### PR TITLE
lib FIXME cleanup

### DIFF
--- a/lib/FP_Eval.thy
+++ b/lib/FP_Eval.thy
@@ -6,7 +6,7 @@
 
 theory FP_Eval
 imports
-  HOL.HOL (* FIXME lib: remove *)
+  Main
   ML_Utils.TermPatternAntiquote
 begin
 

--- a/lib/Lib.thy
+++ b/lib/Lib.thy
@@ -1472,6 +1472,10 @@ lemma list_case_If:
   "(case xs of [] \<Rightarrow> P | _ \<Rightarrow> Q) = (if xs = [] then P else Q)"
   by (rule list.case_eq_if)
 
+lemma lifted_if_collapse:
+  "(if P then \<top> else f) = (\<lambda>s. \<not>P \<longrightarrow> f s)"
+  by auto
+
 lemma remove1_Nil_in_set:
   "\<lbrakk> remove1 x xs = []; xs \<noteq> [] \<rbrakk> \<Longrightarrow> x \<in> set xs"
   by (induct xs) (auto split: if_split_asm)

--- a/lib/Monad_Lists.thy
+++ b/lib/Monad_Lists.thy
@@ -208,7 +208,7 @@ lemma zipWithM_One:
   "zipWithM f (x#xs) [a] = (do z \<leftarrow> f x a; return [z] od)"
   by (simp add: zipWithM_def zipWith_def sequence_def)
 
-lemma zipWithM_x_Nil:
+lemma zipWithM_x_Nil[simp]:
   "zipWithM_x f xs [] = return ()"
   by (simp add: zipWithM_x_def zipWith_def sequence_x_def)
 
@@ -332,8 +332,6 @@ lemma mapM_map_simp:
    apply (simp add: mapM_def sequence_def)
   apply (simp add: mapM_Cons)
   done
-
-lemmas zipWithM_x_Nil2 = zipWithM_x_Nil (* FIXME lib: eliminate, make the original [simp] *)
 
 lemma filterM_voodoo:
   "\<forall>ys. P ys (do zs \<leftarrow> filterM m xs; return (ys @ zs) od)

--- a/lib/Monads/Monad_Equations.thy
+++ b/lib/Monads/Monad_Equations.thy
@@ -273,11 +273,9 @@ lemma maybe_fail_bind_fail:
   by (clarsimp simp: bind_def fail_def return_def
                      unless_def when_def)+
 
-lemma select_singleton:(* FIXME lib: [simp]? *)
+lemma select_singleton[simp]:
   "select {x} = return x"
   by (fastforce simp add: fun_eq_iff select_def return_def)
-
-lemmas select_singleton_is_return = select_singleton (* FIXME lib: eliminate *)
 
 lemma return_modify:
   "return () = modify id"

--- a/lib/Monads/Monad_Lib.thy
+++ b/lib/Monads/Monad_Lib.thy
@@ -46,7 +46,7 @@ definition
   zipWith :: "('a \<Rightarrow> 'b \<Rightarrow> 'c) \<Rightarrow> 'a list \<Rightarrow> 'b list \<Rightarrow> 'c list" where
   "zipWith f xs ys \<equiv> map (case_prod f) (zip xs ys)"
 
-lemma zipWith_Nil2 :
+lemma zipWith_Nil[simp]:
   "zipWith f xs [] = []"
   unfolding zipWith_def by simp
 

--- a/lib/Monads/More_NonDetMonadVCG.thy
+++ b/lib/Monads/More_NonDetMonadVCG.thy
@@ -427,8 +427,6 @@ lemma hoare_Ball_helper:
   done
 
 lemmas hoare_gets_post = hoare_gets_sp (* FIXME lib: eliminate *)
-lemmas hoare_return_post = return_sp (* FIXME lib: eliminate, rename original *)
-
 
 lemma handy_prop_divs:
   assumes x: "\<And>P. \<lbrace>\<lambda>s. P (Q s) \<and> S s\<rbrace> f \<lbrace>\<lambda>rv s. P (Q' rv s)\<rbrace>"

--- a/lib/Monads/More_NonDetMonadVCG.thy
+++ b/lib/Monads/More_NonDetMonadVCG.thy
@@ -465,9 +465,7 @@ lemma hoare_set_preserved:
   apply assumption
   done
 
-lemmas hoare_ex_wp = hoare_vcg_ex_lift (* FIXME lib: eliminate *)
-
-lemma hoare_ex_pre: (* safe, unlike hoare_ex_wp *)
+lemma hoare_ex_pre: (* safe, unlike hoare_vcg_ex_lift *)
   "(\<And>x. \<lbrace>P x\<rbrace> f \<lbrace>Q\<rbrace>) \<Longrightarrow> \<lbrace>\<lambda>s. \<exists>x. P x s\<rbrace> f \<lbrace>Q\<rbrace>"
   by (fastforce simp: valid_def)
 

--- a/lib/Monads/More_NonDetMonadVCG.thy
+++ b/lib/Monads/More_NonDetMonadVCG.thy
@@ -426,8 +426,6 @@ lemma hoare_Ball_helper:
   apply (rule refl)
   done
 
-lemmas hoare_gets_post = hoare_gets_sp (* FIXME lib: eliminate *)
-
 lemma handy_prop_divs:
   assumes x: "\<And>P. \<lbrace>\<lambda>s. P (Q s) \<and> S s\<rbrace> f \<lbrace>\<lambda>rv s. P (Q' rv s)\<rbrace>"
              "\<And>P. \<lbrace>\<lambda>s. P (R s) \<and> S s\<rbrace> f \<lbrace>\<lambda>rv s. P (R' rv s)\<rbrace>"

--- a/lib/Monads/More_NonDetMonadVCG.thy
+++ b/lib/Monads/More_NonDetMonadVCG.thy
@@ -295,8 +295,6 @@ lemma shrinks_proof:
    apply simp
   by (metis use_valid w z)
 
-lemmas unlessE_wp = hoare_unlessE_wp (* FIXME lib: eliminate *)
-
 lemma use_validE_R:
   "\<lbrakk> (Inr r, s') \<in> fst (f s); \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,-; P s \<rbrakk> \<Longrightarrow> Q r s'"
   unfolding validE_R_def validE_def

--- a/lib/Monads/NonDetMonadVCG.thy
+++ b/lib/Monads/NonDetMonadVCG.thy
@@ -1696,27 +1696,27 @@ lemma hoare_list_case:
   apply simp
   done
 
-lemma hoare_when_wp [wp_split]:
+lemma when_wp[wp_split]:
  "\<lbrakk> P \<Longrightarrow> \<lbrace>Q\<rbrace> f \<lbrace>R\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>if P then Q else R ()\<rbrace> when P f \<lbrace>R\<rbrace>"
   by (clarsimp simp: when_def valid_def return_def)
 
-lemma hoare_unless_wp[wp_split]:
+lemma unless_wp[wp_split]:
   "(\<not>P \<Longrightarrow> \<lbrace>Q\<rbrace> f \<lbrace>R\<rbrace>) \<Longrightarrow> \<lbrace>if P then R () else Q\<rbrace> unless P f \<lbrace>R\<rbrace>"
   unfolding unless_def by wp auto
 
-lemma hoare_whenE_wp:
+lemma whenE_wp:
   "(P \<Longrightarrow> \<lbrace>Q\<rbrace> f \<lbrace>R\<rbrace>, \<lbrace>E\<rbrace>) \<Longrightarrow> \<lbrace>if P then Q else R ()\<rbrace> whenE P f \<lbrace>R\<rbrace>, \<lbrace>E\<rbrace>"
   unfolding whenE_def by clarsimp wp
 
-lemmas hoare_whenE_wps[wp_split]
-    = hoare_whenE_wp hoare_whenE_wp[THEN validE_validE_R] hoare_whenE_wp[THEN validE_validE_E]
+lemmas whenE_wps[wp_split]
+    = whenE_wp whenE_wp[THEN validE_validE_R] whenE_wp[THEN validE_validE_E]
 
-lemma hoare_unlessE_wp:
+lemma unlessE_wp:
   "(\<not> P \<Longrightarrow> \<lbrace>Q\<rbrace> f \<lbrace>R\<rbrace>, \<lbrace>E\<rbrace>) \<Longrightarrow> \<lbrace>if P then R () else Q\<rbrace> unlessE P f \<lbrace>R\<rbrace>, \<lbrace>E\<rbrace>"
   unfolding unlessE_def by wp auto
 
-lemmas hoare_unlessE_wps[wp_split]
-    = hoare_unlessE_wp hoare_unlessE_wp[THEN validE_validE_R] hoare_unlessE_wp[THEN validE_validE_E]
+lemmas unlessE_wps[wp_split]
+    = unlessE_wp unlessE_wp[THEN validE_validE_R] unlessE_wp[THEN validE_validE_E]
 
 lemma hoare_use_eq:
   assumes x: "\<And>P. \<lbrace>\<lambda>s. P (f s)\<rbrace> m \<lbrace>\<lambda>rv s. P (f s)\<rbrace>"

--- a/lib/Monads/TraceMonadVCG.thy
+++ b/lib/Monads/TraceMonadVCG.thy
@@ -978,7 +978,7 @@ lemma hoare_gen_asm:
   "(P \<Longrightarrow> \<lbrace>P'\<rbrace> f \<lbrace>Q\<rbrace>) \<Longrightarrow> \<lbrace>P' and K P\<rbrace> f \<lbrace>Q\<rbrace>"
   by (fastforce simp add: valid_def)
 
-lemma hoare_when_wp [wp]:
+lemma when_wp [wp]:
  "\<lbrakk> P \<Longrightarrow> \<lbrace>Q\<rbrace> f \<lbrace>R\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>if P then Q else R ()\<rbrace> when P f \<lbrace>R\<rbrace>"
   by (clarsimp simp: when_def valid_def return_def mres_def)
 
@@ -1922,7 +1922,7 @@ lemma hoare_add_post:
   apply simp
   done
 
-lemma hoare_whenE_wp:
+lemma whenE_wp:
   "(P \<Longrightarrow> \<lbrace>Q\<rbrace> f \<lbrace>R\<rbrace>, \<lbrace>E\<rbrace>) \<Longrightarrow> \<lbrace>if P then Q else R ()\<rbrace> whenE P f \<lbrace>R\<rbrace>, \<lbrace>E\<rbrace>"
   unfolding whenE_def by clarsimp wp
 
@@ -1942,7 +1942,7 @@ lemma hoare_list_case:
   apply simp
   done
 
-lemma hoare_unless_wp:
+lemma unless_wp:
   "(\<not>P \<Longrightarrow> \<lbrace>Q\<rbrace> f \<lbrace>R\<rbrace>) \<Longrightarrow> \<lbrace>if P then R () else Q\<rbrace> unless P f \<lbrace>R\<rbrace>"
   unfolding unless_def by wp auto
 

--- a/lib/NonDetMonadLemmaBucket.thy
+++ b/lib/NonDetMonadLemmaBucket.thy
@@ -51,8 +51,6 @@ lemma lifted_if_collapse: (* FIXME lib: move to Lib *)
   "(if P then \<top> else f) = (\<lambda>s. \<not>P \<longrightarrow> f s)"
   by auto
 
-lemmas list_case_return2 = list_case_return (* FIXME lib: eliminate *)
-
 (* We use isLeft, because isLeft=isl is the primitive concept; isRight=\<not>isl matches on isl. *)
 lemma valid_isLeft_theRight_split:
   "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. Q False rv s\<rbrace>,\<lbrace>\<lambda>e s. \<forall>v. Q True v s\<rbrace> \<Longrightarrow>

--- a/lib/NonDetMonadLemmaBucket.thy
+++ b/lib/NonDetMonadLemmaBucket.thy
@@ -42,14 +42,10 @@ lemma return_bindE:
   "isRight v \<Longrightarrow> return v >>=E f = f (theRight v)"
   by (cases v; clarsimp simp: return_returnOk)
 
-lemma list_case_return: (* FIXME lib: move to Lib *)
+lemma list_case_return: (* not in Lib, because "return" is not in scope there *)
   "(case xs of [] \<Rightarrow> return v | y # ys \<Rightarrow> return (f y ys))
     = return (case xs of [] \<Rightarrow> v | y # ys \<Rightarrow> f y ys)"
   by (simp split: list.split)
-
-lemma lifted_if_collapse: (* FIXME lib: move to Lib *)
-  "(if P then \<top> else f) = (\<lambda>s. \<not>P \<longrightarrow> f s)"
-  by auto
 
 (* We use isLeft, because isLeft=isl is the primitive concept; isRight=\<not>isl matches on isl. *)
 lemma valid_isLeft_theRight_split:

--- a/proof/access-control/ARM/ArchSyscall_AC.thy
+++ b/proof/access-control/ARM/ArchSyscall_AC.thy
@@ -154,7 +154,7 @@ crunch arch_state[Syscall_AC_assms, wp]: init_arch_objects "\<lambda>s. P (arch_
   (wp: crunch_wps)
 
 crunch ct_active [Syscall_AC_assms, wp]: arch_post_cap_deletion "ct_active"
-  (wp: crunch_wps filterM_preserved hoare_unless_wp
+  (wp: crunch_wps filterM_preserved unless_wp
    simp: crunch_simps ignore: do_extended_op)
 
 crunches

--- a/proof/access-control/DomainSepInv.thy
+++ b/proof/access-control/DomainSepInv.thy
@@ -432,7 +432,7 @@ context DomainSepInv_1 begin
 
 crunches cap_delete_one
   for domain_sep_inv[wp]: "\<lambda>s. domain_sep_inv irqs  (st :: 'state_ext state) (s :: det_ext state)"
-  (wp: mapM_x_wp' hoare_unless_wp dxo_wp_weak simp: crunch_simps)
+  (wp: mapM_x_wp' unless_wp dxo_wp_weak simp: crunch_simps)
 
 lemma reply_cancel_ipc_domain_sep_inv[wp]:
   "\<lbrace>domain_sep_inv irqs st\<rbrace>

--- a/proof/access-control/Ipc_AC.thy
+++ b/proof/access-control/Ipc_AC.thy
@@ -37,7 +37,7 @@ lemma send_signal_caps_of_state[wp]:
   done
 
 crunch mdb[wp]: blocked_cancel_ipc, update_waiting_ntfn "\<lambda>s. P (cdt (s :: det_ext state))"
-  (wp: crunch_wps hoare_unless_wp select_wp dxo_wp_weak simp: crunch_simps)
+  (wp: crunch_wps unless_wp select_wp dxo_wp_weak simp: crunch_simps)
 
 lemma cancel_ipc_receive_blocked_mdb:
   "\<lbrace>\<lambda>s :: det_ext state. P (cdt s) \<and> st_tcb_at receive_blocked t s\<rbrace>

--- a/proof/access-control/RISCV64/ArchSyscall_AC.thy
+++ b/proof/access-control/RISCV64/ArchSyscall_AC.thy
@@ -145,7 +145,7 @@ lemma handle_reserved_irq_arch_state[Syscall_AC_assms, wp]:
   unfolding handle_reserved_irq_def by wpsimp
 
 crunch ct_active [Syscall_AC_assms, wp]: arch_post_cap_deletion "ct_active"
-  (wp: crunch_wps filterM_preserved hoare_unless_wp simp: crunch_simps ignore: do_extended_op)
+  (wp: crunch_wps filterM_preserved unless_wp simp: crunch_simps ignore: do_extended_op)
 
 crunches
   arch_post_modify_registers, arch_invoke_irq_control,

--- a/proof/access-control/Retype_AC.thy
+++ b/proof/access-control/Retype_AC.thy
@@ -354,7 +354,7 @@ lemma invoke_untyped_integrity:
              init_arch_objects_integrity retype_region_integrity
              retype_region_ret_is_subject
              set_cap_integrity_autarch hoare_vcg_if_lift
-             hoare_whenE_wp reset_untyped_cap_integrity
+             whenE_wp reset_untyped_cap_integrity
           | clarsimp simp: split_paired_Ball
           | erule in_set_zipE
           | blast)+

--- a/proof/access-control/Syscall_AC.thy
+++ b/proof/access-control/Syscall_AC.thy
@@ -1027,11 +1027,11 @@ lemma cancel_all_ipc_ct_active[wp]:
   done
 
 crunch ct_active[wp]: cap_swap_for_delete "ct_active"
-  (wp: crunch_wps filterM_preserved hoare_unless_wp simp: crunch_simps ignore: do_extended_op)
+  (wp: crunch_wps filterM_preserved unless_wp simp: crunch_simps ignore: do_extended_op)
 
 crunch ct_active[wp]: post_cap_deletion, empty_slot "\<lambda>s :: det_ext state. ct_active s"
   (simp: crunch_simps empty_slot_ext_def ignore: do_extended_op
-     wp: crunch_wps filterM_preserved hoare_unless_wp)
+     wp: crunch_wps filterM_preserved unless_wp)
 
 crunch cur_thread[wp]: cap_swap_for_delete, finalise_cap "\<lambda>s :: det_ext state. P (cur_thread s)"
   (wp: select_wp dxo_wp_weak crunch_wps simp: crunch_simps)

--- a/proof/capDL-api/CNode_DP.thy
+++ b/proof/capDL-api/CNode_DP.thy
@@ -31,7 +31,7 @@ lemma decode_cnode_copy_same_parent_rvu:
   \<lbrace>\<lambda>rv s. Q rv\<rbrace>, -"
   apply (clarsimp simp:user_pointer_at_def Let_def)
   apply (clarsimp simp: decode_cnode_invocation_def split_def split: sum.splits)
-  apply (wp hoare_whenE_wp | simp)+
+  apply (wp whenE_wp | simp)+
         apply (rule validE_validE_R)
         apply (wp derive_cap_invE)+
       apply (rule validE_validE_R)

--- a/proof/capDL-api/Invocation_DP.thy
+++ b/proof/capDL-api/Invocation_DP.thy
@@ -12,7 +12,7 @@ crunch cdl_current_domain[wp]: update_available_range, generate_object_ids, upda
                                mark_tcb_intent_error, corrupt_ipc_buffer, insert_cap_sibling,
                                insert_cap_child, move_cap, invoke_irq_control, invoke_irq_handler
                                                     "\<lambda>s. P (cdl_current_domain s)"
-(wp: crunch_wps select_wp alternative_wp alternativeE_wp hoare_unless_wp simp: split_def corrupt_intents_def)
+(wp: crunch_wps select_wp alternative_wp alternativeE_wp unless_wp simp: split_def corrupt_intents_def)
 
 crunch cdl_irq_node [wp]:  corrupt_ipc_buffer "\<lambda>s. P (cdl_irq_node s)"
 (wp: crunch_wps select_wp simp: corrupt_intents_def)
@@ -371,7 +371,7 @@ lemma handle_event_syscall_no_decode_exception:
       apply (rule liftE_wp_split_r)+
        apply (rule wp_no_exception_seq_r)
         apply (rule liftE_wp_no_exception)
-         apply (rule hoare_whenE_wp)
+         apply (rule whenE_wp)
          apply simp
          apply wp
            apply (rule_tac P = "y = cur_thread" in hoare_gen_asm)
@@ -682,18 +682,18 @@ lemma cdl_cur_thread_detype:
   by (simp add:detype_def)
 
 crunch cdl_current_thread[wp]: reset_untyped_cap "\<lambda>s. P (cdl_current_thread s)"
-  (wp: select_wp alternativeE_wp mapME_x_inv_wp hoare_whenE_wp
+  (wp: select_wp alternativeE_wp mapME_x_inv_wp whenE_wp
     simp: cdl_cur_thread_detype crunch_simps)
 
 lemmas helper = valid_validE_E[OF reset_untyped_cap_cdl_current_thread]
 
 crunch cdl_current_thread[wp]: invoke_untyped "\<lambda>s. P (cdl_current_thread s)"
-(wp:select_wp mapM_x_wp' crunch_wps hoare_unless_wp alternativeE_wp
+(wp:select_wp mapM_x_wp' crunch_wps unless_wp alternativeE_wp
     helper
   simp:cdl_cur_thread_detype crunch_simps)
 
 crunch cdl_current_thread[wp]: move_cap "\<lambda>s. P (cdl_current_thread s)"
-(wp:select_wp mapM_x_wp' crunch_wps hoare_unless_wp
+(wp:select_wp mapM_x_wp' crunch_wps unless_wp
   simp:crunch_simps)
 
 lemma cnode_insert_cap_cdl_current_thread:
@@ -930,7 +930,7 @@ lemma handle_event_syscall_allow_error:
       apply (rule liftE_wp_split_r)+
        apply (rule wp_no_exception_seq_r)
         apply (rule liftE_wp_no_exception)
-         apply (rule hoare_whenE_wp)
+         apply (rule whenE_wp)
          apply (simp)
          apply wp
            apply (rule_tac P = "y = cur_thread" in hoare_gen_asm)

--- a/proof/capDL-api/KHeap_DP.thy
+++ b/proof/capDL-api/KHeap_DP.thy
@@ -441,7 +441,7 @@ lemma lookup_slot_for_cnode_op_wp [wp]:
    apply (clarsimp simp: fault_to_except_def)
    apply (wp)
    apply (clarsimp simp: gets_the_resolve_cap[symmetric])
-   apply (wp gets_the_wpE hoare_whenE_wp)+
+   apply (wp gets_the_wpE whenE_wp)+
   apply (clarsimp split: option.splits sum.splits)
 done
 
@@ -453,7 +453,7 @@ lemma lookup_slot_for_cnode_op_wpE:
   apply (wp)
    apply (clarsimp simp: gets_the_resolve_cap[symmetric])
    apply (clarsimp simp: fault_to_except_def)
-   apply (wp gets_the_wpE hoare_whenE_wp)+
+   apply (wp gets_the_wpE whenE_wp)+
   apply (clarsimp split: option.splits split: sum.splits)
 done
 
@@ -526,7 +526,7 @@ lemma lookup_slot_for_cnode_op_rv':
       lookup_slot_for_cnode_op cnode_cap cap_ptr remaining_size
      \<lbrace>\<lambda>rv s. Q rv s\<rbrace>,-"
   apply (clarsimp simp: lookup_slot_for_cnode_op_def gets_the_resolve_cap[symmetric] split_def fault_to_except_def)
-  apply (wp resolve_cap_rv1 hoare_whenE_wp)
+  apply (wp resolve_cap_rv1 whenE_wp)
   apply (fastforce)
 done
 
@@ -559,7 +559,7 @@ lemma lookup_slot_for_cnode_op_rvu':
       lookup_slot_for_cnode_op cnode_cap cap_ptr remaining_size
      \<lbrace>Q\<rbrace>,\<lbrace>Q'\<rbrace>"
   apply (clarsimp simp: lookup_slot_for_cnode_op_def gets_the_resolve_cap[symmetric] split_def fault_to_except_def)
-  apply (wp resolve_cap_u_nf[where r=r and R=R and cap=cap] hoare_whenE_wp)
+  apply (wp resolve_cap_u_nf[where r=r and R=R and cap=cap] whenE_wp)
   apply (clarsimp simp add:user_pointer_at_def Let_def guard_equal_def
     cap_guard_reset_cap_asid one_lvl_lookup_def)
 done
@@ -580,21 +580,21 @@ lemma derive_cap_rv:
      derive_cap slot cap
  \<lbrace>\<lambda>rv s. P s \<and> ( rv = cap \<or> rv = NullCap )\<rbrace>, \<lbrace>\<lambda>_ _. True\<rbrace>"
   apply (clarsimp simp: derive_cap_def returnOk_def split: cdl_cap.splits,safe)
-                        apply (wp return_rv hoare_whenE_wp alternativeE_wp | clarsimp simp: ensure_no_children_def)+
+                        apply (wp return_rv whenE_wp alternativeE_wp | clarsimp simp: ensure_no_children_def)+
 done
 
 lemma derive_cap_wp [wp]:
 "\<lbrace>P\<rbrace> derive_cap slot cap  \<lbrace>\<lambda>_. P\<rbrace>"
   apply (clarsimp simp: derive_cap_def returnOk_def split: cdl_cap.splits)
   apply (safe)
-    apply ((wp alternative_wp hoare_whenE_wp)|(clarsimp simp: ensure_no_children_def))+
+    apply ((wp alternative_wp whenE_wp)|(clarsimp simp: ensure_no_children_def))+
       done
 
 
 lemma derive_cap_wpE:
 "\<lbrace>P\<rbrace> derive_cap slot cap \<lbrace>\<lambda>_.P\<rbrace>,\<lbrace>\<lambda>_.P\<rbrace>"
   apply (clarsimp simp: derive_cap_def)
-  apply (case_tac cap, (wp hoare_whenE_wp alternative_wp |
+  apply (case_tac cap, (wp whenE_wp alternative_wp |
                         simp add: ensure_no_children_def)+)
   done
 
@@ -616,7 +616,7 @@ lemma decode_cnode_copy_wp: "\<lbrace>P\<rbrace>
      decode_cnode_invocation target target_ref caps (CNodeCopyIntent dest_index dest_depth src_index src_depth rights)
      \<lbrace> \<lambda>_. P \<rbrace>,\<lbrace>\<lambda>_. P\<rbrace>"
   apply (clarsimp simp: decode_cnode_invocation_def split_def)
-  apply (wp hoare_whenE_wp hoare_drop_imps | simp cong: if_cong)+
+  apply (wp whenE_wp hoare_drop_imps | simp cong: if_cong)+
   done
 
 lemma ensure_empty_wp [wp]: "\<lbrace>P\<rbrace> ensure_empty slot \<lbrace>\<lambda>_. P\<rbrace>"
@@ -624,7 +624,7 @@ lemma ensure_empty_wp [wp]: "\<lbrace>P\<rbrace> ensure_empty slot \<lbrace>\<la
 
 lemma ensure_no_children_wp [wp]: "\<lbrace>P\<rbrace> ensure_no_children slot \<lbrace>\<lambda>_. P\<rbrace>"
   apply (clarsimp simp: ensure_no_children_def)
-  apply (wp hoare_whenE_wp)
+  apply (wp whenE_wp)
   apply (clarsimp)
 done
 
@@ -759,7 +759,7 @@ lemma decode_cnode_move_rvu:
 
 
 crunch preserve [wp]:  decode_cnode_invocation "P"
-(wp: derive_cap_wpE unlessE_wp hoare_whenE_wp select_wp hoare_drop_imps simp: if_apply_def2 throw_on_none_def)
+(wp: derive_cap_wpE unlessE_wp whenE_wp select_wp hoare_drop_imps simp: if_apply_def2 throw_on_none_def)
 
 lemma decode_invocation_wp:
   "\<lbrace>P\<rbrace> decode_invocation (CNodeCap x y z sz) ref caps (CNodeIntent intent) \<lbrace>\<lambda>_. P\<rbrace>, -"
@@ -792,7 +792,7 @@ lemma delete_cap_simple_wp:
     delete_cap_simple ptr
   \<lbrace>\<lambda>_. < ptr  \<mapsto>c NullCap \<and>* R>\<rbrace>"
   apply (clarsimp simp: delete_cap_simple_def is_final_cap_def)
-  apply (wp hoare_unless_wp always_empty_wp fast_finalise_cap_non_ep_wp)
+  apply (wp unless_wp always_empty_wp fast_finalise_cap_non_ep_wp)
   apply clarsimp
   apply (frule opt_cap_sep_imp)
   apply (clarsimp, rule conjI)

--- a/proof/capDL-api/Retype_DP.thy
+++ b/proof/capDL-api/Retype_DP.thy
@@ -250,11 +250,11 @@ lemma reset_untyped_cap_wp:
     cdl.lift (uref \<mapsto>c UntypedCap dev obj_range fr \<and>* (\<And>*ptr\<in>tot_free_range. ptr \<mapsto>o Untyped) \<and>* P) s\<rbrace>,-"
   apply (simp add:reset_untyped_cap_def bind_assoc bindE_assoc)
   apply (rule hoare_pre)
-   apply (wp hoare_whenE_wp)
+   apply (wp whenE_wp)
       apply (rule_tac P = "\<exists>fr. cap = UntypedCap dev obj_range fr
           \<and> (\<forall>fr\<in> set x. free_range \<subseteq> fr \<and> fr \<subseteq> obj_range)" in hoare_gen_asmE)
       apply clarsimp
-      apply (wp hoare_whenE_wp mapME_x_wp alternativeE_wp)
+      apply (wp whenE_wp mapME_x_wp alternativeE_wp)
       apply (rule ballI)
        apply (rule hoare_pre)
        apply (wp alternative_wp)
@@ -292,11 +292,11 @@ lemma reset_untyped_cap_wp:
   done
 
 crunch cdl_current_domain[wp]: reset_untyped_cap "\<lambda>s. P (cdl_current_domain s)"
-(wp:select_wp mapM_x_wp' mapME_x_inv_wp alternativeE_wp crunch_wps hoare_unless_wp
+(wp:select_wp mapM_x_wp' mapME_x_inv_wp alternativeE_wp crunch_wps unless_wp
   simp: detype_def crunch_simps)
 
 crunch cdl_current_domain[wp]: invoke_untyped "\<lambda>s. P (cdl_current_domain s)"
-(wp: select_wp mapM_x_wp' mapME_x_inv_wp alternativeE_wp crunch_wps hoare_unless_wp
+(wp: select_wp mapM_x_wp' mapME_x_inv_wp alternativeE_wp crunch_wps unless_wp
   simp: detype_def crunch_simps validE_E_def)
 
 lemma invoke_untyped_wp:
@@ -793,12 +793,12 @@ lemma invoke_untyped_cdt_inc[wp]:
       apply (wp mapM_x_wp[OF _ subset_refl])
        apply (simp add:create_cap_def)
         apply (rule hoare_pre)
-        apply (wp set_parent_other hoare_unless_wp unlessE_wp
+        apply (wp set_parent_other unless_wp unlessE_wp
                | wpc | simp)+
    apply (simp add: reset_untyped_cap_def validE_def sum.case_eq_if)
    apply (rule_tac Q = "\<lambda>r s. cdl_cdt s child = Some parent" in hoare_post_imp)
     apply simp
-   apply (wp hoare_whenE_wp alternativeE_wp mapME_x_inv_wp select_wp | simp)+
+   apply (wp whenE_wp alternativeE_wp mapME_x_inv_wp select_wp | simp)+
   apply (clarsimp simp:detype_def)
   done
 
@@ -960,7 +960,7 @@ lemma invoke_untyped_preempt:
          sep_map_set_conj sep_any_map_o obj_range \<and>* Q) s\<rbrace>"
   apply (simp add: invoke_untyped_def)
   apply (wp unlessE_wp)
-   apply (simp add: reset_untyped_cap_def whenE_liftE | wp hoare_whenE_wp alternative_wp)+
+   apply (simp add: reset_untyped_cap_def whenE_liftE | wp whenE_wp alternative_wp)+
       apply (rule_tac P = "\<exists>a. cap = UntypedCap dev obj_range a" in hoare_gen_asmEx)
       apply (rule hoare_post_impErr[where E = E and F = E for E])
         apply (rule mapME_x_inv_wp[where P = P and E = "\<lambda>r. P" for P])
@@ -1107,7 +1107,7 @@ lemma is_pending_cap_set_available_range[simp]:
 lemma reset_untyped_cap_no_pending[wp]:
   "\<lbrace>no_pending \<rbrace> reset_untyped_cap cref \<lbrace>\<lambda>rv. no_pending\<rbrace>"
   apply (simp add: reset_untyped_cap_def)
-  apply (wp hoare_whenE_wp)
+  apply (wp whenE_wp)
      apply (rule_tac P = "snd cref = tcb_pending_op_slot \<longrightarrow> \<not> is_pending_cap cap" in hoare_gen_asmEx)
      apply (wp mapME_x_inv_wp alternativeE_wp | simp)+
     apply (wp select_wp)+
@@ -1161,7 +1161,7 @@ lemma reset_untyped_cap_not_pending_cap[wp]:
   reset_untyped_cap cref
   \<lbrace>\<lambda>rv s.  (\<exists>cap. opt_cap cref s = Some cap) \<longrightarrow> \<not> is_pending_cap (the (opt_cap cref s))\<rbrace>"
   apply (simp add: reset_untyped_cap_def)
-  apply (wp hoare_whenE_wp)
+  apply (wp whenE_wp)
      apply (rule_tac P = " \<not> is_pending_cap cap" in hoare_gen_asmEx)
      apply (wp mapME_x_inv_wp alternativeE_wp set_cap_opt_cap)+
      apply simp

--- a/proof/capDL-api/TCB_DP.thy
+++ b/proof/capDL-api/TCB_DP.thy
@@ -128,7 +128,7 @@ lemma tcb_update_ipc_buffer_wp:
 \<lbrace>\<lambda>_. <(target_tcb, tcb_ipcbuffer_slot) \<mapsto>c ipc_buffer_cap \<and>* tcb_cap_slot \<mapsto>c (TcbCap target_tcb) \<and>* (ipc_buffer_slot) \<mapsto>c cap \<and>* R>\<rbrace>, \<lbrace>E\<rbrace>"
   apply (clarsimp simp: tcb_update_ipc_buffer_def sep_any_All)
   apply (rule hoare_name_pre_stateE)
-  apply (wp hoare_whenE_wp tcb_update_thread_slot_wp[sep_wand_side_wpE])
+  apply (wp whenE_wp tcb_update_thread_slot_wp[sep_wand_side_wpE])
       apply (clarsimp)
      apply (wp get_cap_rv'[where cap=cap])
     apply (clarsimp)
@@ -148,7 +148,7 @@ lemma tcb_update_ipc_buffer_wp':
 \<lbrace>\<lambda>_. <(target_tcb, tcb_ipcbuffer_slot) \<mapsto>c ipc_buffer_cap \<and>* tcb_cap_slot \<mapsto>c (TcbCap target_tcb) \<and>* (ipc_buffer_slot) \<mapsto>c cap \<and>* R>\<rbrace>, \<lbrace>E\<rbrace>"
   apply (rule hoare_name_pre_stateE)
   apply (clarsimp simp: tcb_update_ipc_buffer_def sep_any_All)
-  apply (wp hoare_whenE_wp tcb_update_thread_slot_wp[sep_wandise] get_cap_rv[where cap=cap])
+  apply (wp whenE_wp tcb_update_thread_slot_wp[sep_wandise] get_cap_rv[where cap=cap])
     apply (rule hoare_allI)
     apply (rule hoare_impI)
     apply (clarsimp)
@@ -172,7 +172,7 @@ lemma tcb_update_vspace_root_wp:
 \<lbrace>\<lambda>_. < (target_tcb, tcb_vspace_slot) \<mapsto>c vrt_cap \<and>* tcb_cap_slot \<mapsto>c (TcbCap target_tcb) \<and>* (vrt_slot) \<mapsto>c cap \<and>* R>\<rbrace>, \<lbrace>E\<rbrace>"
   apply (rule hoare_name_pre_stateE)
   apply (clarsimp simp: tcb_update_vspace_root_def sep_any_All)
-  apply (wp hoare_whenE_wp tcb_update_thread_slot_wp[sep_wand_side_wpE] get_cap_rv)
+  apply (wp whenE_wp tcb_update_thread_slot_wp[sep_wand_side_wpE] get_cap_rv)
     apply (wp get_cap_rv'[where cap=cap])
    apply (clarsimp)
    apply (wp tcb_empty_thread_slot_wpE[sep_wand_wpE])
@@ -188,7 +188,7 @@ lemma tcb_update_vspace_root_wp':
 \<lbrace>\<lambda>_. < (target_tcb, tcb_vspace_slot) \<mapsto>c vrt_cap \<and>* tcb_cap_slot \<mapsto>c (TcbCap target_tcb) \<and>* (vrt_slot) \<mapsto>c cap \<and>* R>\<rbrace>, \<lbrace>E\<rbrace>"
   apply (rule hoare_name_pre_stateE)
   apply (clarsimp simp: tcb_update_vspace_root_def sep_any_All)
-  apply (wp hoare_whenE_wp tcb_update_thread_slot_wp[sep_wand_side_wpE'] get_cap_rv)+
+  apply (wp whenE_wp tcb_update_thread_slot_wp[sep_wand_side_wpE'] get_cap_rv)+
    apply (wp hoare_vcg_conj_liftE1)
     apply (wp tcb_empty_thread_slot_wpE[sep_wand_wpE], (clarsimp simp: sep_conj_assoc | sep_solve) +)
    apply (wp tcb_empty_thread_slot_wpE[sep_wand_wpE], (clarsimp simp: sep_conj_assoc | sep_solve) +)
@@ -218,7 +218,7 @@ lemma tcb_update_cspace_root_wp:
 \<lbrace>\<lambda>_. < (target_tcb, tcb_cspace_slot) \<mapsto>c crt_cap \<and>* tcb_cap_slot \<mapsto>c (TcbCap target_tcb) \<and>* (crt_slot) \<mapsto>c cap \<and>* R>\<rbrace>, \<lbrace>E\<rbrace>"
   apply (rule hoare_name_pre_stateE)
   apply (clarsimp simp: tcb_update_cspace_root_def sep_any_All_side cong:cap_type_bad_cong)
-  apply (wpsimp wp: hoare_whenE_wp tcb_update_thread_slot_wp[sep_wand_side_wpE] get_cap_rv
+  apply (wpsimp wp: whenE_wp tcb_update_thread_slot_wp[sep_wand_side_wpE] get_cap_rv
                     hoare_vcg_conj_liftE1)
     apply (wpsimp wp: tcb_empty_thread_slot_wpE[sep_wand_wpE] simp: sep_conj_assoc)
    apply (wpsimp wp: hoare_vcg_all_lift_R[THEN hoare_vcg_E_elim[rotated]]
@@ -474,7 +474,7 @@ lemma tcb_update_vspace_root_inv:
    tcb_update_vspace_root a b c
  \<lbrace>\<lambda>_ s. P (cdl_current_thread s)\<rbrace>"
   apply (clarsimp simp: tcb_update_vspace_root_def)
-  apply (wp hoare_drop_imps hoare_whenE_wp alternative_wp
+  apply (wp hoare_drop_imps whenE_wp alternative_wp
        | simp add: tcb_update_vspace_root_def tcb_update_thread_slot_def)+
    apply (wp tcb_empty_thread_slot_wp_inv)
   apply auto
@@ -486,7 +486,7 @@ lemma tcb_update_cspace_root_inv:
    tcb_update_cspace_root a b c
  \<lbrace>\<lambda>_ s. P (cdl_current_thread s)\<rbrace>"
   apply (clarsimp simp: tcb_update_cspace_root_def)
-  apply (wp hoare_drop_imps hoare_whenE_wp alternative_wp
+  apply (wp hoare_drop_imps whenE_wp alternative_wp
        | simp add: tcb_update_vspace_root_def tcb_update_thread_slot_def)+
    apply (wp tcb_empty_thread_slot_wp_inv)
   apply auto
@@ -497,7 +497,7 @@ lemma tcb_update_ipc_buffer_inv:
    tcb_update_ipc_buffer a b c
  \<lbrace>\<lambda>_ s. P (cdl_current_thread s)\<rbrace>"
   apply (clarsimp simp: tcb_update_ipc_buffer_def)
-  apply (wp hoare_drop_imps hoare_whenE_wp alternative_wp
+  apply (wp hoare_drop_imps whenE_wp alternative_wp
        | simp add: tcb_update_vspace_root_def tcb_update_thread_slot_def)+
    apply (wp tcb_empty_thread_slot_wp_inv)
   apply auto
@@ -516,7 +516,7 @@ lemma invoke_tcb_ThreadControl_cur_thread:
   \<lbrace>\<lambda>_ s. P  (cdl_current_thread s) \<rbrace>"
   including no_pre
   apply (simp add:invoke_tcb_def comp_def)
-    apply (wp alternative_wp hoare_whenE_wp
+    apply (wp alternative_wp whenE_wp
       tcb_empty_thread_slot_wp_inv
       [where R = "(target_tcb, tcb_vspace_slot) \<mapsto>c -
         \<and>* (target_tcb,tcb_cspace_slot) \<mapsto>c -
@@ -527,7 +527,7 @@ lemma invoke_tcb_ThreadControl_cur_thread:
     apply (clarsimp simp:conj_comms)
     apply (rule hoare_post_impErr[OF valid_validE,rotated],assumption)
      apply (fastforce split:option.splits)
-     apply (wp hoare_drop_imps hoare_whenE_wp alternative_wp
+     apply (wp hoare_drop_imps whenE_wp alternative_wp
        | simp add: tcb_update_vspace_root_def tcb_update_thread_slot_def)+
          apply (rule hoare_post_imp[OF _  insert_cap_child_wp])
         apply (sep_erule_concl refl_imp sep_any_imp, assumption)
@@ -553,7 +553,7 @@ lemma invoke_tcb_ThreadControl_cur_thread:
       apply (wp tcb_empty_thread_slot_wp_inv)
      apply clarsimp
      apply (sep_solve)
-    apply (wp hoare_drop_imps hoare_whenE_wp alternative_wp
+    apply (wp hoare_drop_imps whenE_wp alternative_wp
       | simp add: tcb_update_vspace_root_def tcb_update_thread_slot_def)+
         apply (rule hoare_post_imp[OF _  insert_cap_child_wp])
         apply (sep_select 2)
@@ -590,8 +590,8 @@ lemma invoke_tcb_ThreadControl_cur_thread:
       \<and>* target_tcb \<mapsto>f - \<and>* R> s)
        " in hoare_post_impErr[rotated -1])
      apply assumption
-    apply (wp hoare_whenE_wp |wpc|simp add:tcb_update_cspace_root_def)+
-      apply (wp hoare_drop_imps hoare_whenE_wp alternative_wp
+    apply (wp whenE_wp |wpc|simp add:tcb_update_cspace_root_def)+
+      apply (wp hoare_drop_imps whenE_wp alternative_wp
         | simp add: tcb_update_vspace_root_def tcb_update_thread_slot_def)+
         apply (rule hoare_post_imp[OF _  insert_cap_child_wp])
         apply (sep_schem)
@@ -782,7 +782,7 @@ lemma invoke_tcb_ThreadControl_cdl_current_domain:
   \<rbrace> invoke_tcb (ThreadControl target_tcb tcb_cap_slot faultep croot vroot ipc_buffer)
   \<lbrace>\<lambda>_ s. P  (cdl_current_domain s) \<rbrace>"
   apply (simp add:invoke_tcb_def comp_def)
-    apply (wp alternative_wp hoare_whenE_wp
+    apply (wp alternative_wp whenE_wp
       tcb_empty_thread_slot_wp_inv
       [where R = "(target_tcb, tcb_vspace_slot) \<mapsto>c -
         \<and>* (target_tcb,tcb_cspace_slot) \<mapsto>c -
@@ -793,7 +793,7 @@ lemma invoke_tcb_ThreadControl_cdl_current_domain:
     apply (clarsimp simp:conj_comms)
     apply (rule hoare_post_impErr[OF valid_validE,rotated],assumption)
      apply (fastforce split:option.splits)
-     apply (wp hoare_drop_imps hoare_whenE_wp alternative_wp
+     apply (wp hoare_drop_imps whenE_wp alternative_wp
        | simp add: tcb_update_vspace_root_def tcb_update_thread_slot_def)+
          apply (rule hoare_post_imp[OF _  insert_cap_child_wp])
          apply (sep_schem)
@@ -818,7 +818,7 @@ lemma invoke_tcb_ThreadControl_cdl_current_domain:
        apply (wp tcb_empty_thread_slot_wp_inv)
       apply clarsimp
       apply (sep_solve)
-     apply (wp hoare_drop_imps hoare_whenE_wp alternative_wp
+     apply (wp hoare_drop_imps whenE_wp alternative_wp
       | simp add: tcb_update_vspace_root_def tcb_update_thread_slot_def)+
          apply (rule hoare_post_imp[OF _  insert_cap_child_wp])
          apply (sep_select 2)
@@ -855,8 +855,8 @@ lemma invoke_tcb_ThreadControl_cdl_current_domain:
       \<and>* target_tcb \<mapsto>f - \<and>* R> s)
        " in hoare_post_impErr[rotated -1])
       apply assumption
-     apply (wp hoare_whenE_wp |wpc|simp add:tcb_update_cspace_root_def)+
-       apply (wp hoare_drop_imps hoare_whenE_wp alternative_wp
+     apply (wp whenE_wp |wpc|simp add:tcb_update_cspace_root_def)+
+       apply (wp hoare_drop_imps whenE_wp alternative_wp
         | simp add: tcb_update_vspace_root_def tcb_update_thread_slot_def)+
          apply (rule hoare_post_imp[OF _  insert_cap_child_wp])
          apply (sep_select 2)

--- a/proof/crefine/ARM/ArchMove_C.thy
+++ b/proof/crefine/ARM/ArchMove_C.thy
@@ -65,7 +65,7 @@ lemma setCTE_asidpool':
   "\<lbrace> ko_at' (ASIDPool pool) p \<rbrace> setCTE c p' \<lbrace>\<lambda>_. ko_at' (ASIDPool pool) p\<rbrace>"
   apply (clarsimp simp: setCTE_def)
   apply (simp add: setObject_def split_def)
-  apply (rule hoare_seq_ext [OF _ hoare_gets_post])
+  apply (rule hoare_seq_ext [OF _ hoare_gets_sp])
   apply (clarsimp simp: valid_def in_monad)
   apply (frule updateObject_type)
   apply (clarsimp simp: obj_at'_def projectKOs)

--- a/proof/crefine/ARM/Ipc_C.thy
+++ b/proof/crefine/ARM/Ipc_C.thy
@@ -1204,10 +1204,6 @@ shows
   apply (auto split: if_split)
   done
 
-declare zipWith_Nil2[simp]
-
-declare zipWithM_x_Nil2[simp]
-
 lemma asUser_tcbFault_obj_at:
   "\<lbrace>obj_at' (\<lambda>tcb. P (tcbFault tcb)) t\<rbrace> asUser t' m
    \<lbrace>\<lambda>rv. obj_at' (\<lambda>tcb. P (tcbFault tcb)) t\<rbrace>"

--- a/proof/crefine/ARM/Recycle_C.thy
+++ b/proof/crefine/ARM/Recycle_C.thy
@@ -579,7 +579,7 @@ lemma cancelBadgedSends_ccorres:
               (UNIV \<inter> {s. epptr_' s = Ptr ptr} \<inter> {s. badge_' s = bdg}) []
        (cancelBadgedSends ptr bdg) (Call cancelBadgedSends_'proc)"
   apply (cinit lift: epptr_' badge_' simp: whileAnno_def)
-   apply (simp add: list_case_return2
+   apply (simp add: list_case_return
               cong: list.case_cong Structures_H.endpoint.case_cong call_ignore_cong
                del: Collect_const)
    apply (rule ccorres_pre_getEndpoint)

--- a/proof/crefine/ARM_HYP/ArchMove_C.thy
+++ b/proof/crefine/ARM_HYP/ArchMove_C.thy
@@ -146,7 +146,7 @@ lemma setCTE_asidpool':
   "\<lbrace> ko_at' (ASIDPool pool) p \<rbrace> setCTE c p' \<lbrace>\<lambda>_. ko_at' (ASIDPool pool) p\<rbrace>"
   apply (clarsimp simp: setCTE_def)
   apply (simp add: setObject_def split_def)
-  apply (rule hoare_seq_ext [OF _ hoare_gets_post])
+  apply (rule hoare_seq_ext [OF _ hoare_gets_sp])
   apply (clarsimp simp: valid_def in_monad)
   apply (frule updateObject_type)
   apply (clarsimp simp: obj_at'_def projectKOs)

--- a/proof/crefine/ARM_HYP/Ipc_C.thy
+++ b/proof/crefine/ARM_HYP/Ipc_C.thy
@@ -1421,10 +1421,6 @@ shows
   apply (auto split: if_split)
   done
 
-declare zipWith_Nil2[simp]
-
-declare zipWithM_x_Nil2[simp]
-
 lemma getRestartPC_ccorres [corres]:
   "ccorres (=) ret__unsigned_long_' \<top>
      (UNIV \<inter> \<lbrace>\<acute>thread = tcb_ptr_to_ctcb_ptr thread\<rbrace>) hs

--- a/proof/crefine/ARM_HYP/Recycle_C.thy
+++ b/proof/crefine/ARM_HYP/Recycle_C.thy
@@ -918,7 +918,7 @@ lemma cancelBadgedSends_ccorres:
               (UNIV \<inter> {s. epptr_' s = Ptr ptr} \<inter> {s. badge_' s = bdg}) []
        (cancelBadgedSends ptr bdg) (Call cancelBadgedSends_'proc)"
   apply (cinit lift: epptr_' badge_' simp: whileAnno_def)
-   apply (simp add: list_case_return2
+   apply (simp add: list_case_return
               cong: list.case_cong Structures_H.endpoint.case_cong call_ignore_cong
                del: Collect_const)
    apply (rule ccorres_pre_getEndpoint)

--- a/proof/crefine/RISCV64/Ipc_C.thy
+++ b/proof/crefine/RISCV64/Ipc_C.thy
@@ -1345,10 +1345,6 @@ shows
   apply (auto split: if_split)
   done
 
-declare zipWith_Nil2[simp]
-
-declare zipWithM_x_Nil2[simp]
-
 lemma getRestartPC_ccorres [corres]:
   "ccorres (=) ret__unsigned_long_' \<top>
      (UNIV \<inter> \<lbrace>\<acute>thread = tcb_ptr_to_ctcb_ptr thread\<rbrace>) hs

--- a/proof/crefine/RISCV64/Recycle_C.thy
+++ b/proof/crefine/RISCV64/Recycle_C.thy
@@ -803,7 +803,7 @@ lemma cancelBadgedSends_ccorres:
               (UNIV \<inter> {s. epptr_' s = Ptr ptr} \<inter> {s. badge_' s = bdg}) []
        (cancelBadgedSends ptr bdg) (Call cancelBadgedSends_'proc)"
   apply (cinit lift: epptr_' badge_' simp: whileAnno_def)
-   apply (simp add: list_case_return2
+   apply (simp add: list_case_return
               cong: list.case_cong Structures_H.endpoint.case_cong call_ignore_cong
                del: Collect_const)
    apply (rule ccorres_pre_getEndpoint)

--- a/proof/crefine/RISCV64/VSpace_C.thy
+++ b/proof/crefine/RISCV64/VSpace_C.thy
@@ -1531,7 +1531,7 @@ lemma setCTE_asidpool':
   "\<lbrace> ko_at' (ASIDPool pool) p \<rbrace> setCTE c p' \<lbrace>\<lambda>_. ko_at' (ASIDPool pool) p\<rbrace>"
   apply (clarsimp simp: setCTE_def)
   apply (simp add: setObject_def split_def)
-  apply (rule hoare_seq_ext [OF _ hoare_gets_post])
+  apply (rule hoare_seq_ext [OF _ hoare_gets_sp])
   apply (clarsimp simp: valid_def in_monad)
   apply (frule updateObject_type)
   apply (clarsimp simp: obj_at'_def)

--- a/proof/crefine/X64/ArchMove_C.thy
+++ b/proof/crefine/X64/ArchMove_C.thy
@@ -272,7 +272,7 @@ lemma setCurrentUserCR3_valid_arch_state'[wp]:
 lemma setVMRoot_valid_arch_state':
   "\<lbrace>valid_arch_state'\<rbrace> setVMRoot t \<lbrace>\<lambda>_. valid_arch_state'\<rbrace>"
   apply (simp add: setVMRoot_def getThreadVSpaceRoot_def setCurrentUserVSpaceRoot_def)
-  apply (wp hoare_whenE_wp getCurrentUserCR3_wp findVSpaceForASID_vs_at_wp
+  apply (wp whenE_wp getCurrentUserCR3_wp findVSpaceForASID_vs_at_wp
          | wpcw
          | clarsimp simp: if_apply_def2 asid_wf_0
          | strengthen valid_cr3'_makeCR3)+

--- a/proof/crefine/X64/Ipc_C.thy
+++ b/proof/crefine/X64/Ipc_C.thy
@@ -1353,10 +1353,6 @@ shows
   apply (auto split: if_split)
   done
 
-declare zipWith_Nil2[simp]
-
-declare zipWithM_x_Nil2[simp]
-
 lemma getRestartPC_ccorres [corres]:
   "ccorres (=) ret__unsigned_long_' \<top>
      (UNIV \<inter> \<lbrace>\<acute>thread = tcb_ptr_to_ctcb_ptr thread\<rbrace>) hs

--- a/proof/crefine/X64/Recycle_C.thy
+++ b/proof/crefine/X64/Recycle_C.thy
@@ -899,7 +899,7 @@ lemma cancelBadgedSends_ccorres:
               (UNIV \<inter> {s. epptr_' s = Ptr ptr} \<inter> {s. badge_' s = bdg}) []
        (cancelBadgedSends ptr bdg) (Call cancelBadgedSends_'proc)"
   apply (cinit lift: epptr_' badge_' simp: whileAnno_def)
-   apply (simp add: list_case_return2
+   apply (simp add: list_case_return
               cong: list.case_cong Structures_H.endpoint.case_cong call_ignore_cong
                del: Collect_const)
    apply (rule ccorres_pre_getEndpoint)

--- a/proof/crefine/X64/VSpace_C.thy
+++ b/proof/crefine/X64/VSpace_C.thy
@@ -2231,7 +2231,7 @@ lemma setCTE_asidpool':
   "\<lbrace> ko_at' (ASIDPool pool) p \<rbrace> setCTE c p' \<lbrace>\<lambda>_. ko_at' (ASIDPool pool) p\<rbrace>"
   apply (clarsimp simp: setCTE_def)
   apply (simp add: setObject_def split_def)
-  apply (rule hoare_seq_ext [OF _ hoare_gets_post])
+  apply (rule hoare_seq_ext [OF _ hoare_gets_sp])
   apply (clarsimp simp: valid_def in_monad)
   apply (frule updateObject_type)
   apply (clarsimp simp: obj_at'_def projectKOs)

--- a/proof/crefine/lib/AutoCorres_C.thy
+++ b/proof/crefine/lib/AutoCorres_C.thy
@@ -69,10 +69,10 @@ FIXME: Move this change into AutoCorres itself, or the underlying VCG library.
 
 lemmas [wp del] =
   NonDetMonadEx.validE_whenE
-  NonDetMonadVCG.hoare_whenE_wps
+  NonDetMonadVCG.whenE_wps
 
 lemmas hoare_whenE_wp2 [wp] =
-  NonDetMonadVCG.hoare_whenE_wps[simplified if_apply_def2]
+  NonDetMonadVCG.whenE_wps[simplified if_apply_def2]
 
 section \<open>Rules for proving @{term ccorres_underlying} goals\<close>
 

--- a/proof/drefine/CNode_DR.thy
+++ b/proof/drefine/CNode_DR.thy
@@ -1946,7 +1946,7 @@ context
 notes if_cong[cong]
 begin
 crunch valid_etcbs[wp]: cancel_badged_sends valid_etcbs
-(wp: mapM_x_wp hoare_drop_imps hoare_unless_wp ignore: filterM)
+(wp: mapM_x_wp hoare_drop_imps unless_wp ignore: filterM)
 end
 
 lemma cap_revoke_valid_etcbs[wp]:
@@ -2090,7 +2090,7 @@ lemma decode_cnode_error_corres:
      apply (rule corres_symb_exec_r_dcE, wp)
       apply (rule corres_symb_exec_r_dcE, wp)
        apply (rule corres_symb_exec_r_dcE)
-         apply (rule hoare_pre, wp hoare_whenE_wp)
+         apply (rule hoare_pre, wp whenE_wp)
          apply simp
         apply (rule corres_trivial)
         apply (simp split: gen_invocation_labels.split invocation_label.split list.split)
@@ -2648,7 +2648,7 @@ lemma decode_cnode_corres:
                         apply simp
                        apply (rule dcorres_returnOk)
                        apply (simp add:translate_cnode_invocation_def)
-                      apply (wp get_cap_wp hoare_whenE_wp|clarsimp)+
+                      apply (wp get_cap_wp whenE_wp|clarsimp)+
          apply (rule hoare_post_imp_R[OF validE_validE_R])
          apply (rule hoareE_TrueI[where P = \<top>])
           apply fastforce

--- a/proof/drefine/Finalise_DR.thy
+++ b/proof/drefine/Finalise_DR.thy
@@ -698,7 +698,7 @@ lemma dcorres_set_vm_root:
        apply (wp do_machine_op_wp | clarsimp)+
      apply (rule_tac Q = "\<lambda>_ s. transform s = cs" in hoare_post_imp)
       apply simp
-     apply (wpsimp wp: hoare_whenE_wp do_machine_op_wp [OF allI] hoare_drop_imps find_pd_for_asid_inv
+     apply (wpsimp wp: whenE_wp do_machine_op_wp [OF allI] hoare_drop_imps find_pd_for_asid_inv
                 simp: arm_context_switch_def get_hw_asid_def load_hw_asid_def if_apply_def2)+
   done
 

--- a/proof/drefine/Interrupt_DR.thy
+++ b/proof/drefine/Interrupt_DR.thy
@@ -551,7 +551,7 @@ lemma cap_delete_one_original:
   "slot \<noteq> slot' \<Longrightarrow> \<lbrace>\<lambda>s. is_original_cap s slot\<rbrace> cap_delete_one slot'
             \<lbrace>\<lambda>r s. is_original_cap s slot\<rbrace>"
   apply (clarsimp simp:cap_delete_one_def unless_def)
-  apply (wp hoare_when_wp)
+  apply (wp when_wp)
      apply (clarsimp simp:empty_slot_def)
      apply wp
          apply (clarsimp simp:set_cdt_def)
@@ -570,7 +570,7 @@ lemma cte_wp_at_neq_slot_cap_delete_one:
             \<lbrace>\<lambda>rv. cte_wp_at P slot\<rbrace>"
   supply send_signal_interrupt_states [wp_unsafe del] validNF_prop [wp_unsafe del]
   apply (clarsimp simp:cap_delete_one_def unless_def)
-  apply (wp hoare_when_wp)
+  apply (wp when_wp)
       apply (clarsimp simp:empty_slot_def)
       apply (wp cte_wp_at_neq_slot_set_cap)
            apply clarsimp

--- a/proof/drefine/Tcb_DR.thy
+++ b/proof/drefine/Tcb_DR.thy
@@ -637,7 +637,7 @@ lemma invoke_tcb_corres_write_regs:
             apply simp
            apply wp
           apply (clarsimp simp: when_def)
-          apply (wpsimp wp: hoare_when_wp)+
+          apply (wpsimp wp: when_wp)+
      apply (wp wp_post_taut | simp add:invs_def valid_state_def | fastforce)+
   done
 
@@ -1114,7 +1114,7 @@ lemma dcorres_tcb_update_ipc_buffer:
               apply wp
              apply wp
             apply wpsimp
-           apply (wp hoare_when_wp)+
+           apply (wp when_wp)+
           apply (rule hoare_strengthen_post[OF hoare_TrueI[where P = \<top>]],clarsimp+)
         apply (wp wp_post_taut hoare_drop_imp get_cap_weak_wp)+
       apply (clarsimp simp:conj_comms)
@@ -1207,7 +1207,7 @@ lemma dcorres_tcb_update_vspace_root:
            apply (drule (3) ex_cte_cap_to_not_idle, simp add: not_idle_thread_def)
           apply (rule corres_trivial)
           apply clarsimp
-         apply (wp hoare_when_wp)
+         apply (wp when_wp)
         apply (rule hoare_strengthen_post[OF hoare_TrueI[where P =\<top> ]])
         apply clarsimp
        apply (rule hoare_strengthen_post[OF hoare_TrueI[where P =\<top> ]])
@@ -1294,7 +1294,7 @@ lemma dcorres_tcb_update_cspace_root:
            apply (erule valid_cap_aligned)
           apply (rule corres_trivial)
           apply (clarsimp)
-         apply (wp hoare_when_wp)
+         apply (wp when_wp)
         apply (rule hoare_strengthen_post[OF hoare_TrueI[where P =\<top> ]])
         apply clarsimp
        apply wp+

--- a/proof/drefine/Untyped_DR.thy
+++ b/proof/drefine/Untyped_DR.thy
@@ -1041,7 +1041,7 @@ lemma create_caps_loop_dcorres:
   done
 
 crunch valid_idle[wp]: init_arch_objects "valid_idle"
-  (wp: crunch_wps hoare_unless_wp ignore: clearMemory)
+  (wp: crunch_wps unless_wp ignore: clearMemory)
 
 lemma update_available_range_dcorres:
   "dcorres dc \<top> ( K(\<exists>idx. untyped_cap = transform_cap (cap.UntypedCap dev ptr sz idx)
@@ -1556,7 +1556,7 @@ lemma invoke_untyped_corres:
                                 (Some (cap.UntypedCap dev ptr' sz (if reset then 0 else idx))) and ct_active
                              and (\<lambda>s. reset \<longrightarrow> pspace_no_overlap {ptr' .. ptr' + 2 ^ sz - 1} s)"
                       in hoare_post_impErr)
-        apply (wp hoare_whenE_wp)
+        apply (wp whenE_wp)
         apply (rule validE_validE_R, rule hoare_post_impErr, rule reset_untyped_cap_invs_etc)
          apply (clarsimp simp only: if_True simp_thms ptrs, intro conjI, assumption+)
         apply simp

--- a/proof/infoflow/ADT_IF.thy
+++ b/proof/infoflow/ADT_IF.thy
@@ -2602,7 +2602,7 @@ lemma invoke_untyped_irq_state_inv:
    \<lbrace>\<lambda>_. irq_state_inv st\<rbrace>, \<lbrace>\<lambda>_. irq_state_next st\<rbrace>"
   apply (cases ui, simp add: invoke_untyped_def mapM_x_def[symmetric])
   apply (rule hoare_pre)
-   apply (wp mapM_x_wp' hoare_whenE_wp reset_untyped_cap_irq_state_inv[where irq=irq]
+   apply (wp mapM_x_wp' whenE_wp reset_untyped_cap_irq_state_inv[where irq=irq]
          | rule irq_state_inv_triv | simp)+
   done
 

--- a/proof/infoflow/ARM/ArchArch_IF.thy
+++ b/proof/infoflow/ARM/ArchArch_IF.thy
@@ -62,7 +62,7 @@ crunches set_irq_state, arch_post_cap_deletion, handle_arch_fault_reply
 
 crunch irq_state_of_state[Arch_IF_assms, wp]: arch_switch_to_idle_thread, arch_switch_to_thread
   "\<lambda>s :: det_state. P (irq_state_of_state s)"
-  (wp: dmo_wp modify_wp crunch_wps hoare_whenE_wp
+  (wp: dmo_wp modify_wp crunch_wps whenE_wp
    simp: invalidateLocalTLB_ASID_def setHardwareASID_def set_current_pd_def machine_op_lift_def
          machine_rest_lift_def crunch_simps storeWord_def dsb_def isb_def writeTTBR0_def)
 
@@ -567,7 +567,7 @@ lemma set_vm_root_states_equiv_for[wp]:
   "set_vm_root thread \<lbrace>states_equiv_for P Q R S st\<rbrace>"
   unfolding set_vm_root_def catch_def fun_app_def set_current_pd_def isb_def dsb_def writeTTBR0_def
   by (wpsimp wp: arm_context_switch_states_equiv_for do_machine_op_mol_states_equiv_for
-                 hoare_vcg_all_lift hoare_whenE_wp hoare_drop_imps
+                 hoare_vcg_all_lift whenE_wp hoare_drop_imps
            simp: dmo_bind_valid if_apply_def2)+
 
 lemma set_vm_root_reads_respects:

--- a/proof/infoflow/ARM/ArchDecode_IF.thy
+++ b/proof/infoflow/ARM/ArchDecode_IF.thy
@@ -188,7 +188,7 @@ lemma lookup_pt_slot_no_fail_is_subject:
 
 lemma arch_decode_invocation_reads_respects_f[Decode_IF_assms]:
   notes reads_respects_f_inv' = reads_respects_f_inv[where st=st]
-  notes hoare_whenE_wps[wp_split del]
+  notes whenE_wps[wp_split del]
   shows
     "reads_respects_f aag l
        (silc_inv aag st and invs and pas_refined aag and cte_wp_at ((=) (cap.ArchObjectCap cap)) slot

--- a/proof/infoflow/ARM/ArchRetype_IF.thy
+++ b/proof/infoflow/ARM/ArchRetype_IF.thy
@@ -584,7 +584,7 @@ lemma invoke_untyped_reads_respects_g_wcap[Retype_IF_assms]:
                                and ct_active
                                and (\<lambda>s. reset \<longrightarrow> pspace_no_overlap {ptr .. ptr + 2 ^ sz - 1} s)"
                 in hoare_post_impErr)
-     apply (rule hoare_pre, wp hoare_whenE_wp)
+     apply (rule hoare_pre, wp whenE_wp)
       apply (rule validE_validE_R, rule hoare_post_impErr, rule reset_untyped_cap_invs_etc)
        apply (clarsimp simp only: if_True simp_thms, intro conjI, assumption+)
       apply simp

--- a/proof/infoflow/ARM/ArchSyscall_IF.thy
+++ b/proof/infoflow/ARM/ArchSyscall_IF.thy
@@ -43,7 +43,7 @@ lemma sts_authorised_for_globals_inv[Syscall_IF_assms]:
        apply wpsimp+
     apply (rename_tac page_invocation)
     apply (case_tac page_invocation)
-       apply (simp | wp hoare_ex_wp)+
+       apply (simp | wp hoare_vcg_ex_lift)+
   done
 
 lemma dmo_maskInterrupt_globals_equiv[Syscall_IF_assms, wp]:

--- a/proof/infoflow/Arch_IF.thy
+++ b/proof/infoflow/Arch_IF.thy
@@ -433,7 +433,7 @@ crunch irq_state_of_state[wp]: handle_recv, handle_reply "\<lambda>s. P (irq_sta
 crunch irq_state_of_state[wp]: invoke_irq_handler "\<lambda>s. P (irq_state_of_state s)"
 
 crunch irq_state_of_state[wp]: schedule "\<lambda>s. P (irq_state_of_state s)"
-  (wp: dmo_wp modify_wp crunch_wps hoare_whenE_wp
+  (wp: dmo_wp modify_wp crunch_wps whenE_wp
    simp: machine_op_lift_def machine_rest_lift_def crunch_simps)
 
 crunch irq_state_of_state[wp]: finalise_cap "\<lambda>s. P (irq_state_of_state s)"

--- a/proof/infoflow/FinalCaps.thy
+++ b/proof/infoflow/FinalCaps.thy
@@ -1192,14 +1192,14 @@ lemma cap_delete_one_silc_inv:
    cap_delete_one slot
    \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
   unfolding cap_delete_one_def
-  by (wpsimp wp: hoare_unless_wp empty_slot_silc_inv get_cap_wp)
+  by (wpsimp wp: unless_wp empty_slot_silc_inv get_cap_wp)
 
 lemma cap_delete_one_silc_inv_subject:
   "\<lbrace>silc_inv aag st and K (is_subject aag (fst slot))\<rbrace>
    cap_delete_one slot
    \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
   unfolding cap_delete_one_def
-  apply (wpsimp wp: hoare_unless_wp empty_slot_silc_inv get_cap_wp)
+  apply (wpsimp wp: unless_wp empty_slot_silc_inv get_cap_wp)
   unfolding silc_inv_def
   by simp
 
@@ -1703,7 +1703,7 @@ lemma thread_set_tcb_registers_caps_merge_default_tcb_silc_inv[wp]:
   by (rule thread_set_silc_inv; simp add: tcb_cap_cases_def tcb_registers_caps_merge_def)
 
 crunch silc_inv[wp]: cancel_badged_sends "silc_inv aag st"
-  (  wp: crunch_wps hoare_unless_wp simp: crunch_simps ignore: filterM set_object thread_set
+  (  wp: crunch_wps unless_wp simp: crunch_simps ignore: filterM set_object thread_set
    simp: filterM_mapM)
 
 
@@ -2266,7 +2266,7 @@ lemma cap_delete_one_cte_wp_at_other:
    cap_delete_one irq_slot
    \<lbrace>\<lambda>rv s. cte_wp_at P slot s\<rbrace>"
   unfolding cap_delete_one_def
-  apply (wp hoare_unless_wp empty_slot_cte_wp_elsewhere get_cap_wp | simp)+
+  apply (wp unless_wp empty_slot_cte_wp_elsewhere get_cap_wp | simp)+
   done
 
 

--- a/proof/infoflow/IRQMasks_IF.thy
+++ b/proof/infoflow/IRQMasks_IF.thy
@@ -189,7 +189,7 @@ lemma preemption_point_irq_masks[wp]:
   by (wp preemption_point_inv, simp+)
 
 crunch irq_masks[wp]: cancel_badged_sends "\<lambda>s. P (irq_masks_of_state s)"
-  (wp: crunch_wps dmo_wp no_irq hoare_unless_wp
+  (wp: crunch_wps dmo_wp no_irq unless_wp
    simp: filterM_mapM crunch_simps no_irq_clearMemory
    ignore: filterM)
 

--- a/proof/infoflow/RISCV64/ArchArch_IF.thy
+++ b/proof/infoflow/RISCV64/ArchArch_IF.thy
@@ -61,7 +61,7 @@ crunches set_irq_state, arch_post_cap_deletion, handle_arch_fault_reply
 
 crunch irq_state_of_state[Arch_IF_assms, wp]: arch_switch_to_idle_thread, arch_switch_to_thread
   "\<lambda>s :: det_state. P (irq_state_of_state s)"
-  (wp: dmo_wp modify_wp crunch_wps hoare_whenE_wp
+  (wp: dmo_wp modify_wp crunch_wps whenE_wp
    simp: machine_op_lift_def setVSpaceRoot_def
          machine_rest_lift_def crunch_simps storeWord_def)
 
@@ -243,7 +243,7 @@ lemma set_vm_root_states_equiv_for[wp]:
   "set_vm_root thread \<lbrace>states_equiv_for P Q R S st\<rbrace>"
   unfolding set_vm_root_def catch_def fun_app_def
   by (wpsimp wp: do_machine_op_mol_states_equiv_for
-                 hoare_vcg_all_lift hoare_whenE_wp hoare_drop_imps
+                 hoare_vcg_all_lift whenE_wp hoare_drop_imps
            simp: setVSpaceRoot_def dmo_bind_valid if_apply_def2)+
 
 lemma find_vspace_for_asid_reads_respects:

--- a/proof/infoflow/RISCV64/ArchDecode_IF.thy
+++ b/proof/infoflow/RISCV64/ArchDecode_IF.thy
@@ -97,7 +97,7 @@ lemma pas_cap_cur_auth_ASIDControlCap:
 
 lemma decode_asid_pool_invocation_reads_respects_f:
   notes reads_respects_f_inv' = reads_respects_f_inv[where st=st]
-  notes hoare_whenE_wps[wp_split del]
+  notes whenE_wps[wp_split del]
   shows
     "reads_respects_f aag l
        (silc_inv aag st and invs and pas_refined aag and cte_wp_at ((=) (cap.ArchObjectCap cap)) slot
@@ -128,7 +128,7 @@ lemma decode_asid_pool_invocation_reads_respects_f:
 
 lemma decode_asid_control_invocation_reads_respects_f:
   notes reads_respects_f_inv' = reads_respects_f_inv[where st=st]
-  notes hoare_whenE_wps[wp_split del]
+  notes whenE_wps[wp_split del]
   shows
     "reads_respects_f aag l
        (silc_inv aag st and invs and pas_refined aag and cte_wp_at ((=) (cap.ArchObjectCap cap)) slot
@@ -174,7 +174,7 @@ lemma decode_asid_control_invocation_reads_respects_f:
 
 lemma decode_frame_invocation_reads_respects_f:
   notes reads_respects_f_inv' = reads_respects_f_inv[where st=st]
-  notes hoare_whenE_wps[wp_split del]
+  notes whenE_wps[wp_split del]
   shows
     "reads_respects_f aag l
        (silc_inv aag st and invs and pas_refined aag and cte_wp_at ((=) (cap.ArchObjectCap cap)) slot
@@ -236,7 +236,7 @@ lemma decode_frame_invocation_reads_respects_f:
 
 lemma decode_page_table_invocation_reads_respects_f:
   notes reads_respects_f_inv' = reads_respects_f_inv[where st=st]
-  notes hoare_whenE_wps[wp_split del]
+  notes whenE_wps[wp_split del]
   shows
     "reads_respects_f aag l
        (silc_inv aag st and invs and pas_refined aag and cte_wp_at ((=) (cap.ArchObjectCap cap)) slot
@@ -303,7 +303,7 @@ lemma decode_page_table_invocation_reads_respects_f:
 
 lemma arch_decode_invocation_reads_respects_f[Decode_IF_assms]:
   notes reads_respects_f_inv' = reads_respects_f_inv[where st=st]
-  notes hoare_whenE_wps[wp_split del]
+  notes whenE_wps[wp_split del]
   shows
     "reads_respects_f aag l
        (silc_inv aag st and invs and pas_refined aag and cte_wp_at ((=) (cap.ArchObjectCap cap)) slot

--- a/proof/infoflow/RISCV64/ArchRetype_IF.thy
+++ b/proof/infoflow/RISCV64/ArchRetype_IF.thy
@@ -531,7 +531,7 @@ lemma invoke_untyped_reads_respects_g_wcap[Retype_IF_assms]:
                                and ct_active
                                and (\<lambda>s. reset \<longrightarrow> pspace_no_overlap {ptr .. ptr + 2 ^ sz - 1} s)"
                 in hoare_post_impErr)
-     apply (rule hoare_pre, wp hoare_whenE_wp)
+     apply (rule hoare_pre, wp whenE_wp)
       apply (rule validE_validE_R, rule hoare_post_impErr, rule reset_untyped_cap_invs_etc)
        apply (clarsimp simp only: if_True simp_thms, intro conjI, assumption+)
       apply simp

--- a/proof/infoflow/RISCV64/ArchSyscall_IF.thy
+++ b/proof/infoflow/RISCV64/ArchSyscall_IF.thy
@@ -43,7 +43,7 @@ lemma sts_authorised_for_globals_inv[Syscall_IF_assms]:
       apply wpsimp+
     apply (rename_tac page_invocation)
     apply (case_tac page_invocation)
-      apply (simp | wp hoare_ex_wp)+
+      apply (simp | wp hoare_vcg_ex_lift)+
   done
 
 lemma dmo_maskInterrupt_globals_equiv[Syscall_IF_assms, wp]:

--- a/proof/invariant-abstract/AARCH64/ArchArch_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchArch_AI.thy
@@ -67,7 +67,7 @@ lemma check_vp_wpR [wp]:
   check_vp_alignment sz w \<lbrace>P\<rbrace>, -"
   apply (simp add: check_vp_alignment_def unlessE_whenE cong: vmpage_size.case_cong)
   apply (rule hoare_pre)
-   apply (wp hoare_whenE_wp|wpc)+
+   apply (wp whenE_wp|wpc)+
   apply (simp add: vmsz_aligned_def)
   done
 
@@ -75,7 +75,7 @@ lemma check_vp_wpR [wp]:
 lemma check_vp_inv: "\<lbrace>P\<rbrace> check_vp_alignment sz w \<lbrace>\<lambda>_. P\<rbrace>"
   apply (simp add: check_vp_alignment_def unlessE_whenE cong: vmpage_size.case_cong)
   apply (rule hoare_pre)
-   apply (wp hoare_whenE_wp|wpc)+
+   apply (wp whenE_wp|wpc)+
   apply simp
   done
 

--- a/proof/invariant-abstract/AARCH64/ArchDetSchedAux_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchDetSchedAux_AI.thy
@@ -17,7 +17,7 @@ crunches init_arch_objects
   for exst[wp]: "\<lambda>s. P (exst s)"
   and ct[wp]: "\<lambda>s. P (cur_thread s)"
   and valid_etcbs[wp, DetSchedAux_AI_assms]: valid_etcbs
-  (wp: crunch_wps hoare_unless_wp valid_etcbs_lift)
+  (wp: crunch_wps unless_wp valid_etcbs_lift)
 
 crunch ct[wp, DetSchedAux_AI_assms]: invoke_untyped "\<lambda>s. P (cur_thread s)"
   (wp: crunch_wps dxo_wp_weak preemption_point_inv mapME_x_inv_wp

--- a/proof/invariant-abstract/AARCH64/ArchDetSchedSchedule_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchDetSchedSchedule_AI.thy
@@ -167,7 +167,7 @@ crunch valid_sched [wp, DetSchedSchedule_AI_assms]: arch_switch_to_thread, arch_
   (simp: crunch_simps)
 *)
 crunch exst[wp]: set_vm_root "\<lambda>s. P (exst s)"
-  (wp: crunch_wps hoare_whenE_wp simp: crunch_simps)
+  (wp: crunch_wps whenE_wp simp: crunch_simps)
 
 (* FIXME AARCH64
 crunch ct_in_cur_domain_2 [wp, DetSchedSchedule_AI_assms]: arch_switch_to_thread
@@ -298,13 +298,13 @@ lemma set_asid_pool_valid_sched[wp]:
 
 crunch ct_not_in_q [wp, DetSchedSchedule_AI_assms]:
   arch_finalise_cap, prepare_thread_delete ct_not_in_q
-  (wp: crunch_wps hoare_drop_imps hoare_unless_wp select_inv mapM_wp
+  (wp: crunch_wps hoare_drop_imps unless_wp select_inv mapM_wp
        subset_refl if_fun_split simp: crunch_simps ignore: tcb_sched_action)
 
 (* FIXME AARCH64 VCPU
 crunch valid_etcbs [wp, DetSchedSchedule_AI_assms]:
   arch_finalise_cap, prepare_thread_delete valid_etcbs
-  (wp: hoare_drop_imps hoare_unless_wp select_inv mapM_x_wp mapM_wp subset_refl
+  (wp: hoare_drop_imps unless_wp select_inv mapM_x_wp mapM_wp subset_refl
        if_fun_split simp: crunch_simps ignore: set_object thread_set) *)
 
 crunch simple_sched_action [wp, DetSchedSchedule_AI_assms]:

--- a/proof/invariant-abstract/AARCH64/ArchDeterministic_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchDeterministic_AI.thy
@@ -46,7 +46,7 @@ context Arch begin global_naming AARCH64
 crunch valid_list[wp,Deterministic_AI_assms]: arch_invoke_irq_handler valid_list
 
 crunch valid_list[wp]: invoke_untyped valid_list
-  (wp: crunch_wps preemption_point_inv' hoare_unless_wp mapME_x_wp'
+  (wp: crunch_wps preemption_point_inv' unless_wp mapME_x_wp'
    simp: mapM_x_def_bak crunch_simps)
 
 crunch valid_list[wp]: invoke_irq_control valid_list

--- a/proof/invariant-abstract/AARCH64/ArchVCPU_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchVCPU_AI.thy
@@ -354,7 +354,7 @@ crunches send_ipc, send_fault_ipc, receive_ipc, handle_fault, handle_interrupt, 
 
 crunches init_arch_objects, reset_untyped_cap
   for arch_state[wp]: "\<lambda>s. P (arch_state s)"
-  (wp: crunch_wps preemption_point_inv hoare_unless_wp mapME_x_wp'
+  (wp: crunch_wps preemption_point_inv unless_wp mapME_x_wp'
    simp: crunch_simps)
 
 crunches invoke_untyped

--- a/proof/invariant-abstract/ARM/ArchArch_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchArch_AI.thy
@@ -64,7 +64,7 @@ lemma check_vp_wpR [wp]:
   check_vp_alignment sz w \<lbrace>P\<rbrace>, -"
   apply (simp add: check_vp_alignment_def unlessE_whenE cong: vmpage_size.case_cong)
   apply (rule hoare_pre)
-   apply (wp hoare_whenE_wp|wpc)+
+   apply (wp whenE_wp|wpc)+
   apply (simp add: vmsz_aligned_def)
   done
 
@@ -72,7 +72,7 @@ lemma check_vp_wpR [wp]:
 lemma check_vp_inv: "\<lbrace>P\<rbrace> check_vp_alignment sz w \<lbrace>\<lambda>_. P\<rbrace>"
   apply (simp add: check_vp_alignment_def unlessE_whenE cong: vmpage_size.case_cong)
   apply (rule hoare_pre)
-   apply (wp hoare_whenE_wp|wpc)+
+   apply (wp whenE_wp|wpc)+
   apply simp
   done
 

--- a/proof/invariant-abstract/ARM/ArchDetSchedAux_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchDetSchedAux_AI.thy
@@ -16,7 +16,7 @@ crunches init_arch_objects
   for exst[wp]: "\<lambda>s. P (exst s)"
   and ct[wp]: "\<lambda>s. P (cur_thread s)"
   and valid_etcbs[wp, DetSchedAux_AI_assms]: valid_etcbs
-  (wp: crunch_wps hoare_unless_wp valid_etcbs_lift)
+  (wp: crunch_wps unless_wp valid_etcbs_lift)
 
 crunch ct[wp, DetSchedAux_AI_assms]: invoke_untyped "\<lambda>s. P (cur_thread s)"
   (wp: crunch_wps dxo_wp_weak preemption_point_inv mapME_x_inv_wp

--- a/proof/invariant-abstract/ARM/ArchDetSchedSchedule_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchDetSchedSchedule_AI.thy
@@ -85,7 +85,7 @@ crunch valid_sched [wp, DetSchedSchedule_AI_assms]: arch_switch_to_thread, arch_
   (simp: crunch_simps ignore: clearExMonitor)
 
 crunch exst[wp]: set_vm_root "\<lambda>s. P (exst s)"
-  (wp: crunch_wps hoare_whenE_wp simp: crunch_simps)
+  (wp: crunch_wps whenE_wp simp: crunch_simps)
 
 crunch ct_in_cur_domain_2 [wp, DetSchedSchedule_AI_assms]: arch_switch_to_thread
   "\<lambda>s. ct_in_cur_domain_2 thread (idle_thread s) (scheduler_action s) (cur_domain s) (ekheap s)"
@@ -194,12 +194,12 @@ lemma set_asid_pool_valid_sched[wp]:
 
 crunch ct_not_in_q [wp, DetSchedSchedule_AI_assms]:
   arch_finalise_cap, prepare_thread_delete ct_not_in_q
-  (wp: crunch_wps hoare_drop_imps hoare_unless_wp select_inv mapM_wp
+  (wp: crunch_wps hoare_drop_imps unless_wp select_inv mapM_wp
        subset_refl if_fun_split simp: crunch_simps ignore: tcb_sched_action)
 
 crunch valid_etcbs [wp, DetSchedSchedule_AI_assms]:
   arch_finalise_cap, prepare_thread_delete valid_etcbs
-  (wp: hoare_drop_imps hoare_unless_wp select_inv mapM_x_wp mapM_wp subset_refl
+  (wp: hoare_drop_imps unless_wp select_inv mapM_x_wp mapM_wp subset_refl
        if_fun_split simp: crunch_simps ignore: set_object thread_set)
 
 crunch simple_sched_action [wp, DetSchedSchedule_AI_assms]:

--- a/proof/invariant-abstract/ARM/ArchDeterministic_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchDeterministic_AI.thy
@@ -34,7 +34,7 @@ crunch valid_list[wp]: invalidate_tlb_by_asid valid_list
   (wp: crunch_wps preemption_point_inv' simp: crunch_simps filterM_mapM)
 
 crunch valid_list[wp]: invoke_untyped valid_list
-  (wp: crunch_wps preemption_point_inv' hoare_unless_wp mapME_x_wp'
+  (wp: crunch_wps preemption_point_inv' unless_wp mapME_x_wp'
    simp: mapM_x_def_bak crunch_simps)
 
 crunch valid_list[wp]: invoke_irq_control valid_list

--- a/proof/invariant-abstract/ARM/ArchFinalise_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchFinalise_AI.thy
@@ -694,7 +694,7 @@ lemma flush_table_empty:
     flush_table ac aa b word
    \<lbrace>\<lambda>rv s. obj_at (empty_table (set (arm_global_pts (arch_state s)))) word s\<rbrace>"
   apply (clarsimp simp: flush_table_def set_vm_root_def)
-  apply (wp do_machine_op_obj_at arm_context_switch_empty hoare_whenE_wp
+  apply (wp do_machine_op_obj_at arm_context_switch_empty whenE_wp
     | wpc
     | simp
     | wps)+
@@ -867,10 +867,10 @@ crunch caps_of_state [wp]: arch_finalise_cap "\<lambda>s. P (caps_of_state s)"
    (wp: crunch_wps simp: crunch_simps)
 
 crunch obj_at[wp]: set_vm_root, invalidate_tlb_by_asid "\<lambda>s. P' (obj_at P p s)"
-  (wp: hoare_whenE_wp simp: crunch_simps)
+  (wp: whenE_wp simp: crunch_simps)
 
 crunch arm_global_pts[wp]: set_vm_root, invalidate_asid_entry "\<lambda>s. P' (arm_global_pts (arch_state s))"
-  (wp: hoare_whenE_wp simp: crunch_simps)
+  (wp: whenE_wp simp: crunch_simps)
 
 lemma delete_asid_empty_table_pd:
   "\<lbrace>\<lambda>s. page_directory_at word s

--- a/proof/invariant-abstract/ARM/ArchKHeap_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchKHeap_AI.thy
@@ -456,7 +456,7 @@ lemma valid_global_objs_lift':
   apply (rule hoare_pre)
    apply (rule hoare_use_eq [where f="\<lambda>s. arm_global_pts (arch_state s)", OF pts])
    apply (rule hoare_use_eq [where f="\<lambda>s. arm_global_pd (arch_state s)", OF pd])
-   apply (wp obj ko emp hoare_vcg_const_Ball_lift hoare_ex_wp)
+   apply (wp obj ko emp hoare_vcg_const_Ball_lift hoare_vcg_ex_lift)
   apply (clarsimp simp: second_level_tables_def)
   done
 

--- a/proof/invariant-abstract/ARM/ArchRetype_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchRetype_AI.thy
@@ -58,17 +58,17 @@ declare store_pde_state_hyp_refs_of [wp]
 
 (* These also prove facts about copy_global_mappings *)
 crunch pspace_aligned[wp]: init_arch_objects "pspace_aligned"
-  (ignore: clearMemory wp: crunch_wps hoare_unless_wp)
+  (ignore: clearMemory wp: crunch_wps unless_wp)
 crunch pspace_distinct[wp]: init_arch_objects "pspace_distinct"
-  (ignore: clearMemory wp: crunch_wps hoare_unless_wp)
+  (ignore: clearMemory wp: crunch_wps unless_wp)
 crunch mdb_inv[wp]: init_arch_objects "\<lambda>s. P (cdt s)"
-  (ignore: clearMemory wp: crunch_wps hoare_unless_wp)
+  (ignore: clearMemory wp: crunch_wps unless_wp)
 crunch valid_mdb[wp]: init_arch_objects "valid_mdb"
-  (ignore: clearMemory wp: crunch_wps hoare_unless_wp)
+  (ignore: clearMemory wp: crunch_wps unless_wp)
 crunch cte_wp_at[wp]: init_arch_objects "\<lambda>s. P (cte_wp_at P' p s)"
-  (ignore: clearMemory wp: crunch_wps hoare_unless_wp)
+  (ignore: clearMemory wp: crunch_wps unless_wp)
 crunch typ_at[wp]: init_arch_objects "\<lambda>s. P (typ_at T p s)"
-  (ignore: clearMemory wp: crunch_wps hoare_unless_wp)
+  (ignore: clearMemory wp: crunch_wps unless_wp)
 
 lemma mdb_cte_at_store_pde[wp]:
   "\<lbrace>\<lambda>s. mdb_cte_at (swp (cte_wp_at ((\<noteq>) cap.NullCap)) s) (cdt s)\<rbrace>
@@ -127,14 +127,14 @@ lemma get_pde_wellformed[wp]:
   done
 
 crunch valid_objs[wp]: init_arch_objects "valid_objs"
-  (ignore: clearMemory wp: crunch_wps hoare_unless_wp)
+  (ignore: clearMemory wp: crunch_wps unless_wp)
 
 lemma set_pd_arch_state[wp]:
   "\<lbrace>valid_arch_state\<rbrace> set_pd ptr val \<lbrace>\<lambda>rv. valid_arch_state\<rbrace>"
   by (rule set_pd_valid_arch)
 
 crunch valid_arch_state[wp]: init_arch_objects "valid_arch_state"
-  (ignore: clearMemory set_object wp: crunch_wps hoare_unless_wp)
+  (ignore: clearMemory set_object wp: crunch_wps unless_wp)
 
 lemmas init_arch_objects_valid_cap[wp] = valid_cap_typ [OF init_arch_objects_typ_at]
 

--- a/proof/invariant-abstract/ARM/ArchUntyped_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchUntyped_AI.thy
@@ -531,7 +531,7 @@ lemma init_arch_objects_nonempty_table[Untyped_AI_assms, wp]:
   apply (rule hoare_gen_asm)
   apply (simp add: init_arch_objects_def split del: if_split)
   apply (rule hoare_pre)
-   apply (wp hoare_unless_wp | wpc | simp add: reserve_region_def second_level_tables_def)+
+   apply (wp unless_wp | wpc | simp add: reserve_region_def second_level_tables_def)+
   apply (clarsimp simp: obj_bits_api_def default_arch_object_def pd_bits_def pageBits_def)
   done
 
@@ -562,7 +562,7 @@ lemma set_pd_cte_wp_at_iin[wp]:
 
 crunch cte_wp_at_iin[wp]: init_arch_objects
   "\<lambda>s. P (cte_wp_at (P' (interrupt_irq_node s)) p s)"
-  (ignore: clearMemory wp: crunch_wps hoare_unless_wp)
+  (ignore: clearMemory wp: crunch_wps unless_wp)
 
 lemmas init_arch_objects_ex_cte_cap_wp_to
     = init_arch_objects_excap

--- a/proof/invariant-abstract/ARM/ArchVSpace_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchVSpace_AI.thy
@@ -1637,7 +1637,7 @@ lemma svr_invs [wp]:
   "\<lbrace>invs\<rbrace> set_vm_root t' \<lbrace>\<lambda>_. invs\<rbrace>"
   apply (simp add: set_vm_root_def)
   apply (rule hoare_pre)
-   apply (wp hoare_whenE_wp find_pd_for_asid_inv hoare_vcg_all_lift | wpc | simp add: split_def)+
+   apply (wp whenE_wp find_pd_for_asid_inv hoare_vcg_all_lift | wpc | simp add: split_def)+
     apply (rule_tac Q'="\<lambda>_ s. invs s \<and> x2 \<le> mask asid_bits" in hoare_post_imp_R)
      prefer 2
      apply simp

--- a/proof/invariant-abstract/ARM_HYP/ArchArch_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchArch_AI.thy
@@ -80,7 +80,7 @@ lemma check_vp_wpR [wp]:
   check_vp_alignment sz w \<lbrace>P\<rbrace>, -"
   apply (simp add: check_vp_alignment_def unlessE_whenE cong: vmpage_size.case_cong)
   apply (rule hoare_pre)
-   apply (wp hoare_whenE_wp|wpc)+
+   apply (wp whenE_wp|wpc)+
   apply (simp add: vmsz_aligned_def)
   done
 
@@ -88,7 +88,7 @@ lemma check_vp_wpR [wp]:
 lemma check_vp_inv: "\<lbrace>P\<rbrace> check_vp_alignment sz w \<lbrace>\<lambda>_. P\<rbrace>"
   apply (simp add: check_vp_alignment_def unlessE_whenE cong: vmpage_size.case_cong)
   apply (rule hoare_pre)
-   apply (wp hoare_whenE_wp|wpc)+
+   apply (wp whenE_wp|wpc)+
   apply simp
   done
 

--- a/proof/invariant-abstract/ARM_HYP/ArchDetSchedAux_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchDetSchedAux_AI.thy
@@ -17,7 +17,7 @@ crunches init_arch_objects
   for exst[wp]: "\<lambda>s. P (exst s)"
   and ct[wp]: "\<lambda>s. P (cur_thread s)"
   and valid_etcbs[wp, DetSchedAux_AI_assms]: valid_etcbs
-  (wp: crunch_wps hoare_unless_wp)
+  (wp: crunch_wps unless_wp)
 
 crunch ct[wp, DetSchedAux_AI_assms]: invoke_untyped "\<lambda>s. P (cur_thread s)"
   (wp: crunch_wps dxo_wp_weak preemption_point_inv mapME_x_inv_wp

--- a/proof/invariant-abstract/ARM_HYP/ArchDetSchedSchedule_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchDetSchedSchedule_AI.thy
@@ -289,12 +289,12 @@ lemma arch_thread_set_valid_sched[wp]:
 
 crunch ct_not_in_q [wp, DetSchedSchedule_AI_assms]:
   arch_finalise_cap, prepare_thread_delete ct_not_in_q
-  (wp: crunch_wps hoare_drop_imps hoare_unless_wp select_inv mapM_wp
+  (wp: crunch_wps hoare_drop_imps unless_wp select_inv mapM_wp
        subset_refl if_fun_split simp: crunch_simps ignore: tcb_sched_action)
 
 crunch valid_etcbs [wp, DetSchedSchedule_AI_assms]:
   arch_finalise_cap, prepare_thread_delete valid_etcbs
-  (wp: hoare_drop_imps hoare_unless_wp select_inv mapM_x_wp mapM_wp subset_refl
+  (wp: hoare_drop_imps unless_wp select_inv mapM_x_wp mapM_wp subset_refl
        if_fun_split simp: crunch_simps ignore: set_object thread_set)
 
 crunch simple_sched_action [wp, DetSchedSchedule_AI_assms]:

--- a/proof/invariant-abstract/ARM_HYP/ArchDeterministic_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchDeterministic_AI.thy
@@ -47,7 +47,7 @@ crunch valid_list[wp]: invalidate_tlb_by_asid valid_list
    ignore: without_preemption filterM )
 
 crunch valid_list[wp]: invoke_untyped valid_list
-  (wp: crunch_wps preemption_point_inv' hoare_unless_wp mapME_x_wp'
+  (wp: crunch_wps preemption_point_inv' unless_wp mapME_x_wp'
     simp: mapM_x_def_bak crunch_simps)
 
 crunch valid_list[wp]: invoke_irq_control valid_list

--- a/proof/invariant-abstract/ARM_HYP/ArchFinalise_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchFinalise_AI.thy
@@ -1471,7 +1471,7 @@ lemma flush_table_empty:
     flush_table ac aa b word
    \<lbrace>\<lambda>rv s. obj_at (empty_table {}) word s\<rbrace>"
   apply (clarsimp simp: flush_table_def set_vm_root_def)
-  apply (wp do_machine_op_obj_at arm_context_switch_P_obj_at hoare_whenE_wp hoare_drop_imp
+  apply (wp do_machine_op_obj_at arm_context_switch_P_obj_at whenE_wp hoare_drop_imp
     | wpc
     | simp
     | wps)+
@@ -1654,7 +1654,7 @@ lemma set_vm_root_empty[wp]:
   done
 
 crunch obj_at[wp]: invalidate_tlb_by_asid "\<lambda>s. P' (obj_at P p s)"
-  (wp: hoare_whenE_wp simp: crunch_simps)
+  (wp: whenE_wp simp: crunch_simps)
 
 lemma set_asid_pool_empty[wp]:
   "\<lbrace>obj_at (empty_table {}) word\<rbrace> set_asid_pool x2 pool' \<lbrace>\<lambda>xb. obj_at (empty_table {}) word\<rbrace>"

--- a/proof/invariant-abstract/ARM_HYP/ArchUntyped_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchUntyped_AI.thy
@@ -413,7 +413,7 @@ lemma init_arch_objects_nonempty_table[Untyped_AI_assms, wp]:
   apply (rule hoare_gen_asm)
   apply (simp add: init_arch_objects_def split del: if_split)
   apply (rule hoare_pre)
-   apply (wp hoare_unless_wp | wpc | simp add: reserve_region_def)+
+   apply (wp unless_wp | wpc | simp add: reserve_region_def)+
   apply (clarsimp simp: obj_bits_api_def default_arch_object_def pd_bits_def pageBits_def)
   done
 

--- a/proof/invariant-abstract/ARM_HYP/ArchVCPU_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchVCPU_AI.thy
@@ -338,7 +338,7 @@ crunches send_ipc, send_fault_ipc, receive_ipc, handle_fault, handle_interrupt, 
 
 crunches init_arch_objects, reset_untyped_cap
   for arch_state[wp]: "\<lambda>s. P (arch_state s)"
-  (wp: crunch_wps preemption_point_inv hoare_unless_wp mapME_x_wp'
+  (wp: crunch_wps preemption_point_inv unless_wp mapME_x_wp'
    simp: crunch_simps)
 
 crunches invoke_untyped

--- a/proof/invariant-abstract/ARM_HYP/ArchVSpace_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchVSpace_AI.thy
@@ -1377,7 +1377,7 @@ lemma set_vm_root_valid_arch[wp]:
   "\<lbrace>valid_arch_state and sym_refs o state_hyp_refs_of\<rbrace> set_vm_root pd \<lbrace>\<lambda>_. valid_arch_state\<rbrace>"
   unfolding set_vm_root_def
   apply (wpsimp wp: gets_the_get_tcb_wp get_hw_asid_valid_arch
-                    hoare_vcg_imp_lift hoare_vcg_all_lift hoare_whenE_wp
+                    hoare_vcg_imp_lift hoare_vcg_all_lift whenE_wp
                     hoare_drop_imps get_cap_wp
               simp: if_apply_def2)
   done
@@ -2690,7 +2690,7 @@ lemma dmo_setIRQTrigger_invs[wp]: "\<lbrace>invs\<rbrace> do_machine_op (setIRQT
 lemma svr_invs [wp]:
   "\<lbrace>invs\<rbrace> set_vm_root t' \<lbrace>\<lambda>_. invs\<rbrace>"
   unfolding set_vm_root_def
-  apply (wpsimp wp: gets_the_get_tcb_wp hoare_vcg_all_lift hoare_vcg_imp_lift hoare_whenE_wp
+  apply (wpsimp wp: gets_the_get_tcb_wp hoare_vcg_all_lift hoare_vcg_imp_lift whenE_wp
                     hoare_vcg_disj_lift hoare_drop_imps get_cap_wp
               simp: if_apply_def2)
   apply (thin_tac "cte_wp_at ((=) x) t s" for t)

--- a/proof/invariant-abstract/CSpace_AI.thy
+++ b/proof/invariant-abstract/CSpace_AI.thy
@@ -3514,7 +3514,7 @@ lemma set_untyped_cap_as_full_has_reply_cap:
    set_untyped_cap_as_full src_cap cap src
    \<lbrace>\<lambda>rv s. (has_reply_cap t s)\<rbrace>"
   apply (clarsimp simp:has_reply_cap_def is_reply_cap_to_def)
-  apply (wp hoare_ex_wp)
+  apply (wp hoare_vcg_ex_lift)
    apply (wp set_untyped_cap_as_full_cte_wp_at)
   apply (clarsimp simp:cte_wp_at_caps_of_state)
   apply (rule_tac x = a in exI)

--- a/proof/invariant-abstract/DetSchedDomainTime_AI.thy
+++ b/proof/invariant-abstract/DetSchedDomainTime_AI.thy
@@ -128,7 +128,7 @@ crunch domain_list_inv[wp]:
   "\<lambda>s. P (domain_list s)"
 
 crunch domain_list_inv[wp]: finalise_cap "\<lambda>s. P (domain_list s)"
-  (wp: crunch_wps hoare_unless_wp select_inv simp: crunch_simps)
+  (wp: crunch_wps unless_wp select_inv simp: crunch_simps)
 
 lemma rec_del_domain_list[wp]:
   "\<lbrace>\<lambda>s. P (domain_list s)\<rbrace> rec_del call \<lbrace>\<lambda>rv s. P (domain_list s)\<rbrace>"
@@ -172,7 +172,7 @@ crunch domain_list_inv[wp]: preemption_point "\<lambda>s. P (domain_list s)"
   (wp: OR_choiceE_weak_wp ignore_del: preemption_point)
 
 crunch domain_list_inv[wp]: reset_untyped_cap "\<lambda>s. P (domain_list s)"
-  (wp: crunch_wps hoare_unless_wp mapME_x_inv_wp select_inv
+  (wp: crunch_wps unless_wp mapME_x_inv_wp select_inv
    simp: crunch_simps)
 
 context DetSchedDomainTime_AI begin
@@ -269,7 +269,7 @@ crunch domain_time_inv[wp]:
   "\<lambda>s. P (domain_time s)"
 
 crunch domain_time_inv[wp]: finalise_cap "\<lambda>s. P (domain_time s)"
-  (wp: crunch_wps hoare_drop_imps hoare_unless_wp select_inv mapM_wp
+  (wp: crunch_wps hoare_drop_imps unless_wp select_inv mapM_wp
        subset_refl if_fun_split simp: crunch_simps ignore: tcb_sched_action)
 
 lemma rec_del_domain_time[wp]:
@@ -314,7 +314,7 @@ crunch domain_time_inv[wp]: preemption_point "\<lambda>s. P (domain_time s)"
   (wp: OR_choiceE_weak_wp ignore_del: preemption_point)
 
 crunch domain_time_inv[wp]: reset_untyped_cap "\<lambda>s. P (domain_time s)"
-  (wp: crunch_wps hoare_unless_wp mapME_x_inv_wp select_inv
+  (wp: crunch_wps unless_wp mapME_x_inv_wp select_inv
    simp: crunch_simps)
 
 context DetSchedDomainTime_AI begin

--- a/proof/invariant-abstract/DetSchedSchedule_AI.thy
+++ b/proof/invariant-abstract/DetSchedSchedule_AI.thy
@@ -1359,7 +1359,7 @@ lemma schedule_choose_new_thread_valid_sched:
    schedule_choose_new_thread
    \<lbrace>\<lambda>_. valid_sched \<rbrace>"
   unfolding schedule_choose_new_thread_def
-  apply (wpsimp wp_del: hoare_when_wp
+  apply (wpsimp wp_del: when_wp
                  wp: set_scheduler_action_rct_valid_sched choose_thread_ct_not_queued
                      choose_thread_ct_activatable choose_thread_cur_dom_or_idle
                      hoare_vcg_disj_lift)+
@@ -1380,7 +1380,7 @@ lemma schedule_valid_sched:
                    tcb_sched_enqueue_cur_ct_in_q)
        (* switch_thread candidate *)
        apply (rename_tac candidate)
-       apply (wp del: hoare_when_wp
+       apply (wp del: when_wp
                   add: set_scheduler_action_rct_valid_sched schedule_choose_new_thread_valid_sched)
                 apply (rule hoare_vcg_conj_lift)
                  apply (rule_tac t=candidate in set_scheduler_action_cnt_valid_blocked')
@@ -1416,7 +1416,7 @@ crunches update_restart_pc
 
 
 crunch ct_not_in_q[wp]: finalise_cap ct_not_in_q
-  (wp: crunch_wps hoare_drop_imps hoare_unless_wp select_inv mapM_wp
+  (wp: crunch_wps hoare_drop_imps unless_wp select_inv mapM_wp
        subset_refl if_fun_split simp: crunch_simps ignore: tcb_sched_action)
 
 end
@@ -1516,7 +1516,7 @@ crunches update_restart_pc
 context DetSchedSchedule_AI begin
 
 crunch valid_etcbs[wp]: finalise_cap valid_etcbs
-  (wp: hoare_drop_imps hoare_unless_wp select_inv mapM_x_wp mapM_wp subset_refl
+  (wp: hoare_drop_imps unless_wp select_inv mapM_x_wp mapM_wp subset_refl
        if_fun_split simp: crunch_simps ignore: set_object)
 
 crunch valid_sched[wp]: cap_swap_for_delete, empty_slot, cap_delete_one valid_sched

--- a/proof/invariant-abstract/RISCV64/ArchArch_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchArch_AI.thy
@@ -56,7 +56,7 @@ lemma check_vp_wpR [wp]:
   check_vp_alignment sz w \<lbrace>P\<rbrace>, -"
   apply (simp add: check_vp_alignment_def unlessE_whenE cong: vmpage_size.case_cong)
   apply (rule hoare_pre)
-   apply (wp hoare_whenE_wp|wpc)+
+   apply (wp whenE_wp|wpc)+
   apply (simp add: vmsz_aligned_def)
   done
 
@@ -64,7 +64,7 @@ lemma check_vp_wpR [wp]:
 lemma check_vp_inv: "\<lbrace>P\<rbrace> check_vp_alignment sz w \<lbrace>\<lambda>_. P\<rbrace>"
   apply (simp add: check_vp_alignment_def unlessE_whenE cong: vmpage_size.case_cong)
   apply (rule hoare_pre)
-   apply (wp hoare_whenE_wp|wpc)+
+   apply (wp whenE_wp|wpc)+
   apply simp
   done
 

--- a/proof/invariant-abstract/RISCV64/ArchDetSchedAux_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchDetSchedAux_AI.thy
@@ -16,7 +16,7 @@ crunches init_arch_objects
   for exst[wp]: "\<lambda>s. P (exst s)"
   and ct[wp]: "\<lambda>s. P (cur_thread s)"
   and valid_etcbs[wp, DetSchedAux_AI_assms]: valid_etcbs
-  (wp: crunch_wps hoare_unless_wp valid_etcbs_lift)
+  (wp: crunch_wps unless_wp valid_etcbs_lift)
 
 crunch ct[wp, DetSchedAux_AI_assms]: invoke_untyped "\<lambda>s. P (cur_thread s)"
   (wp: crunch_wps dxo_wp_weak preemption_point_inv mapME_x_inv_wp

--- a/proof/invariant-abstract/RISCV64/ArchDetSchedSchedule_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchDetSchedSchedule_AI.thy
@@ -83,7 +83,7 @@ crunch valid_sched [wp, DetSchedSchedule_AI_assms]: arch_switch_to_thread, arch_
   (simp: crunch_simps)
 
 crunch exst[wp]: set_vm_root "\<lambda>s. P (exst s)"
-  (wp: crunch_wps hoare_whenE_wp simp: crunch_simps)
+  (wp: crunch_wps whenE_wp simp: crunch_simps)
 
 crunch ct_in_cur_domain_2 [wp, DetSchedSchedule_AI_assms]: arch_switch_to_thread
   "\<lambda>s. ct_in_cur_domain_2 thread (idle_thread s) (scheduler_action s) (cur_domain s) (ekheap s)"
@@ -183,12 +183,12 @@ lemma set_asid_pool_valid_sched[wp]:
 
 crunch ct_not_in_q [wp, DetSchedSchedule_AI_assms]:
   arch_finalise_cap, prepare_thread_delete ct_not_in_q
-  (wp: crunch_wps hoare_drop_imps hoare_unless_wp select_inv mapM_wp
+  (wp: crunch_wps hoare_drop_imps unless_wp select_inv mapM_wp
        subset_refl if_fun_split simp: crunch_simps ignore: tcb_sched_action)
 
 crunch valid_etcbs [wp, DetSchedSchedule_AI_assms]:
   arch_finalise_cap, prepare_thread_delete valid_etcbs
-  (wp: hoare_drop_imps hoare_unless_wp select_inv mapM_x_wp mapM_wp subset_refl
+  (wp: hoare_drop_imps unless_wp select_inv mapM_x_wp mapM_wp subset_refl
        if_fun_split simp: crunch_simps ignore: set_object thread_set)
 
 crunch simple_sched_action [wp, DetSchedSchedule_AI_assms]:

--- a/proof/invariant-abstract/RISCV64/ArchDeterministic_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchDeterministic_AI.thy
@@ -31,7 +31,7 @@ context Arch begin global_naming RISCV64
 crunch valid_list[wp,Deterministic_AI_assms]: arch_invoke_irq_handler valid_list
 
 crunch valid_list[wp]: invoke_untyped valid_list
-  (wp: crunch_wps preemption_point_inv' hoare_unless_wp mapME_x_wp'
+  (wp: crunch_wps preemption_point_inv' unless_wp mapME_x_wp'
    simp: mapM_x_def_bak crunch_simps)
 
 crunch valid_list[wp]: invoke_irq_control valid_list

--- a/proof/invariant-abstract/Syscall_AI.thy
+++ b/proof/invariant-abstract/Syscall_AI.thy
@@ -296,7 +296,7 @@ lemma thread_set_cap_to:
   "(\<And>tcb. \<forall>(getF, v)\<in>ran tcb_cap_cases. getF (f tcb) = getF tcb)
   \<Longrightarrow> \<lbrace>ex_nonz_cap_to p\<rbrace> thread_set f tptr \<lbrace>\<lambda>_. ex_nonz_cap_to p\<rbrace>"
   apply (clarsimp simp add: ex_nonz_cap_to_def)
-  apply (wpsimp wp: hoare_ex_wp thread_set_cte_wp_at_trivial
+  apply (wpsimp wp: hoare_vcg_ex_lift thread_set_cte_wp_at_trivial
     | fast)+
   done
 

--- a/proof/invariant-abstract/X64/ArchArch_AI.thy
+++ b/proof/invariant-abstract/X64/ArchArch_AI.thy
@@ -70,7 +70,7 @@ lemma check_vp_wpR [wp]:
   check_vp_alignment sz w \<lbrace>P\<rbrace>, -"
   apply (simp add: check_vp_alignment_def unlessE_whenE cong: vmpage_size.case_cong)
   apply (rule hoare_pre)
-   apply (wp hoare_whenE_wp|wpc)+
+   apply (wp whenE_wp|wpc)+
   apply (simp add: vmsz_aligned_def)
   done
 
@@ -78,7 +78,7 @@ lemma check_vp_wpR [wp]:
 lemma check_vp_inv: "\<lbrace>P\<rbrace> check_vp_alignment sz w \<lbrace>\<lambda>_. P\<rbrace>"
   apply (simp add: check_vp_alignment_def unlessE_whenE cong: vmpage_size.case_cong)
   apply (rule hoare_pre)
-   apply (wp hoare_whenE_wp|wpc)+
+   apply (wp whenE_wp|wpc)+
   apply simp
   done
 

--- a/proof/invariant-abstract/X64/ArchDetSchedAux_AI.thy
+++ b/proof/invariant-abstract/X64/ArchDetSchedAux_AI.thy
@@ -12,8 +12,8 @@ context Arch begin global_naming X64
 
 named_theorems DetSchedAux_AI_assms
 
-crunch exst[wp]: set_object, init_arch_objects "\<lambda>s. P (exst s)" (wp: crunch_wps hoare_unless_wp)
-crunch ct[wp]: init_arch_objects "\<lambda>s. P (cur_thread s)" (wp: crunch_wps hoare_unless_wp)
+crunch exst[wp]: set_object, init_arch_objects "\<lambda>s. P (exst s)" (wp: crunch_wps unless_wp)
+crunch ct[wp]: init_arch_objects "\<lambda>s. P (cur_thread s)" (wp: crunch_wps unless_wp)
 crunch valid_etcbs[wp, DetSchedAux_AI_assms]: init_arch_objects valid_etcbs (wp: valid_etcbs_lift)
 
 crunch ct[wp, DetSchedAux_AI_assms]: invoke_untyped "\<lambda>s. P (cur_thread s)"

--- a/proof/invariant-abstract/X64/ArchDetSchedSchedule_AI.thy
+++ b/proof/invariant-abstract/X64/ArchDetSchedSchedule_AI.thy
@@ -87,7 +87,7 @@ crunch valid_sched [wp, DetSchedSchedule_AI_assms]:
   (simp: crunch_simps ignore: )
 
 crunch exst[wp]: set_vm_root "\<lambda>s. P (exst s)"
-  (wp: crunch_wps hoare_whenE_wp simp: crunch_simps)
+  (wp: crunch_wps whenE_wp simp: crunch_simps)
 
 crunch ct_in_cur_domain_2[wp]: set_vm_root
   "\<lambda>s. ct_in_cur_domain_2 thread (idle_thread s) (scheduler_action s) (cur_domain s) (ekheap s)"
@@ -215,7 +215,7 @@ lemma set_asid_pool_valid_sched[wp]:
   by (wp hoare_drop_imps valid_sched_lift | simp add: set_asid_pool_def)+
 
 crunch ct_not_in_q[wp]: set_object ct_not_in_q
-  (wp: crunch_wps hoare_drop_imps hoare_unless_wp select_inv mapM_wp
+  (wp: crunch_wps hoare_drop_imps unless_wp select_inv mapM_wp
        subset_refl if_fun_split simp: crunch_simps ignore: tcb_sched_action)
 
 lemma flush_table_ct_not_in_q[wp]: "\<lbrace>ct_not_in_q\<rbrace> flush_table a b c d \<lbrace>\<lambda>rv. ct_not_in_q\<rbrace>"
@@ -223,7 +223,7 @@ lemma flush_table_ct_not_in_q[wp]: "\<lbrace>ct_not_in_q\<rbrace> flush_table a 
 
 crunch ct_not_in_q [wp, DetSchedSchedule_AI_assms]:
   arch_finalise_cap, prepare_thread_delete ct_not_in_q
-  (wp: crunch_wps hoare_drop_imps hoare_unless_wp select_inv mapM_wp
+  (wp: crunch_wps hoare_drop_imps unless_wp select_inv mapM_wp
        subset_refl if_fun_split simp: crunch_simps ignore: tcb_sched_action)
 
 lemma flush_table_valid_etcbs[wp]: "\<lbrace>valid_etcbs\<rbrace> flush_table a b c d \<lbrace>\<lambda>rv. valid_etcbs\<rbrace>"
@@ -235,7 +235,7 @@ lemma set_object_valid_etcbs[wp]:
 
 crunch valid_etcbs [wp, DetSchedSchedule_AI_assms]:
   arch_finalise_cap, prepare_thread_delete valid_etcbs
-  (wp: hoare_drop_imps hoare_unless_wp select_inv mapM_x_wp mapM_wp subset_refl
+  (wp: hoare_drop_imps unless_wp select_inv mapM_x_wp mapM_wp subset_refl
        if_fun_split simp: crunch_simps ignore: set_object set_object thread_set)
 
 lemma flush_table_simple_sched_action[wp]: "\<lbrace>simple_sched_action\<rbrace> flush_table a b c d \<lbrace>\<lambda>rv. simple_sched_action\<rbrace>"

--- a/proof/invariant-abstract/X64/ArchDeterministic_AI.thy
+++ b/proof/invariant-abstract/X64/ArchDeterministic_AI.thy
@@ -36,7 +36,7 @@ global_interpretation Deterministic_AI_1?: Deterministic_AI_1
 context Arch begin global_naming X64
 
 crunch valid_list[wp]: invoke_untyped valid_list
-  (wp: crunch_wps preemption_point_inv' hoare_unless_wp mapME_x_wp'
+  (wp: crunch_wps preemption_point_inv' unless_wp mapME_x_wp'
    simp: mapM_x_def_bak crunch_simps)
 
 crunch valid_list[wp]: invoke_irq_control, store_pde, store_pte, store_pdpte, store_pml4e,

--- a/proof/invariant-abstract/X64/ArchFinalise_AI.thy
+++ b/proof/invariant-abstract/X64/ArchFinalise_AI.thy
@@ -522,7 +522,7 @@ lemma suspend_unlive':
 
 crunch obj_at[wp]: fpu_thread_delete
   "\<lambda>s. P' (obj_at P p s)"
-  (wp: hoare_whenE_wp simp: crunch_simps)
+  (wp: whenE_wp simp: crunch_simps)
 
 lemma (* fpu_thread_delete_no_cap_to_obj_ref *)[wp,Finalise_AI_asms]:
   "\<lbrace>no_cap_to_obj_with_diff_ref cap S\<rbrace>
@@ -739,7 +739,7 @@ lemma flush_table_empty:
     flush_table ac aa word b
    \<lbrace>\<lambda>rv s. obj_at (empty_table (set (x64_global_pdpts (arch_state s)))) word s\<rbrace>"
   apply (clarsimp simp: flush_table_def set_vm_root_def)
-  apply (wp do_machine_op_obj_at  hoare_whenE_wp mapM_x_wp'
+  apply (wp do_machine_op_obj_at  whenE_wp mapM_x_wp'
     | wpc
     | simp
     | wps
@@ -1004,11 +1004,11 @@ crunch caps_of_state [wp]: arch_finalise_cap "\<lambda>s. P (caps_of_state s)"
 
 crunch obj_at[wp]: invalidate_page_structure_cache_asid, hw_asid_invalidate
   "\<lambda>s. P' (obj_at P p s)"
-  (wp: hoare_whenE_wp simp: crunch_simps)
+  (wp: whenE_wp simp: crunch_simps)
 
 crunch x64_global_pdpts[wp]: invalidate_page_structure_cache_asid, hw_asid_invalidate
   "\<lambda>s. P' (x64_global_pdpts (arch_state s))"
-  (wp: hoare_whenE_wp simp: crunch_simps)
+  (wp: whenE_wp simp: crunch_simps)
 
 lemma delete_asid_empty_table_pml4:
   "\<lbrace>\<lambda>s. page_map_l4_at word s

--- a/proof/invariant-abstract/X64/ArchKHeap_AI.thy
+++ b/proof/invariant-abstract/X64/ArchKHeap_AI.thy
@@ -398,7 +398,7 @@ lemma valid_global_objs_lift':
    apply (rule hoare_use_eq [where f="\<lambda>s. x64_global_pds (arch_state s)", OF pds])
    apply (rule hoare_use_eq [where f="\<lambda>s. x64_global_pdpts (arch_state s)", OF pdpts])
    apply (rule hoare_use_eq [where f="\<lambda>s. x64_global_pml4 (arch_state s)", OF pml4])
-   apply (wp obj ko emp hoare_vcg_const_Ball_lift hoare_ex_wp)
+   apply (wp obj ko emp hoare_vcg_const_Ball_lift hoare_vcg_ex_lift)
   apply (clarsimp simp: second_level_tables_def)
   done
 

--- a/proof/invariant-abstract/X64/ArchRetype_AI.thy
+++ b/proof/invariant-abstract/X64/ArchRetype_AI.thy
@@ -54,7 +54,7 @@ lemma retype_region_ret_folded [Retype_AI_assms]:
    apply (simp add:retype_addrs_def)
   done
 
-lemmas [wp] =  hoare_unless_wp
+lemmas [wp] =  unless_wp
 
 (* These also prove facts about copy_global_mappings *)
 crunch pspace_aligned[wp]: init_arch_objects "pspace_aligned"

--- a/proof/invariant-abstract/X64/ArchUntyped_AI.thy
+++ b/proof/invariant-abstract/X64/ArchUntyped_AI.thy
@@ -538,7 +538,7 @@ lemma init_arch_objects_nonempty_table[Untyped_AI_assms, wp]:
   apply (rule hoare_gen_asm)
   apply (simp add: init_arch_objects_def split del: if_split)
   apply (rule hoare_pre)
-   apply (wp hoare_unless_wp | wpc | simp add: reserve_region_def second_level_tables_def)+
+   apply (wp unless_wp | wpc | simp add: reserve_region_def second_level_tables_def)+
   apply (clarsimp simp: obj_bits_api_def default_arch_object_def pml4_bits_def pageBits_def)
   done
 
@@ -568,7 +568,7 @@ lemma set_pml4e_cte_wp_at_iin[wp]:
 
 crunch cte_wp_at_iin[wp]: init_arch_objects
   "\<lambda>s. P (cte_wp_at (P' (interrupt_irq_node s)) p s)"
-  (ignore: clearMemory store_pml4e wp: crunch_wps hoare_unless_wp)
+  (ignore: clearMemory store_pml4e wp: crunch_wps unless_wp)
 
 lemmas init_arch_objects_ex_cte_cap_wp_to
     = init_arch_objects_excap

--- a/proof/invariant-abstract/X64/ArchVSpace_AI.thy
+++ b/proof/invariant-abstract/X64/ArchVSpace_AI.thy
@@ -886,7 +886,7 @@ lemma asid_wf_0:
 lemma svr_invs [wp]:
   "\<lbrace>invs\<rbrace> set_vm_root t' \<lbrace>\<lambda>_. invs\<rbrace>"
   apply (simp add: set_vm_root_def)
-  apply (wp hoare_whenE_wp
+  apply (wp whenE_wp
          | wpc
          | simp add: split_def if_apply_def2 cong: conj_cong if_cong
          | strengthen valid_cr3_make_cr3)+

--- a/proof/refine/ARM/Arch_R.thy
+++ b/proof/refine/ARM/Arch_R.thy
@@ -72,7 +72,7 @@ lemma createObject_typ_at':
          pspace_aligned' s \<and> pspace_no_overlap' ptr (objBitsKO ty) s\<rbrace>
    createObjects' ptr (Suc 0) ty 0
    \<lbrace>\<lambda>rv s. typ_at' otype ptr s\<rbrace>"
-  apply (clarsimp simp:createObjects'_def alignError_def split_def | wp hoare_unless_wp | wpc )+
+  apply (clarsimp simp:createObjects'_def alignError_def split_def | wp unless_wp | wpc )+
   apply (clarsimp simp:obj_at'_def ko_wp_at'_def typ_at'_def pspace_distinct'_def)+
   apply (subgoal_tac "ps_clear ptr (objBitsKO ty)
     (s\<lparr>ksPSpace := \<lambda>a. if a = ptr then Some ty else ksPSpace s a\<rparr>)")
@@ -405,7 +405,7 @@ lemma checkVP_wpR [wp]:
   checkVPAlignment sz w \<lbrace>P\<rbrace>, -"
   apply (simp add: checkVPAlignment_def unlessE_whenE cong: vmpage_size.case_cong)
   apply (rule hoare_pre)
-   apply (wp hoare_whenE_wp|wpc)+
+   apply (wp whenE_wp|wpc)+
   apply (simp add: is_aligned_mask vmsz_aligned'_def)
   done
 
@@ -838,11 +838,11 @@ shows
                 apply (simp add: returnOk_liftE[symmetric])
                 apply (rule corres_returnOk)
                 apply (simp add: archinv_relation_def asid_pool_invocation_map_def)
-               apply (rule hoare_pre, wp hoare_whenE_wp)
+               apply (rule hoare_pre, wp whenE_wp)
                apply (clarsimp simp: ucast_fst_hd_assocs)
-               apply (wp hoareE_TrueI hoare_whenE_wp getASID_wp | simp)+
+               apply (wp hoareE_TrueI whenE_wp getASID_wp | simp)+
            apply ((clarsimp simp: p2_low_bits_max | rule TrueI impI)+)[2]
-         apply (wp hoare_whenE_wp getASID_wp)+
+         apply (wp whenE_wp getASID_wp)+
        apply (clarsimp simp: valid_cap_def)
       apply auto[1]
      apply (simp add: isCap_simps split del: if_split)
@@ -916,7 +916,7 @@ shows
                  apply (simp add: ord_le_eq_trans [OF word_n1_ge])
                 apply (wp hoare_drop_imps)+
           apply (simp add: o_def validE_R_def)
-          apply (wp hoare_whenE_wp)+
+          apply (wp whenE_wp)+
       apply fastforce
      apply clarsimp
      apply (simp add: null_def split_def asid_high_bits_def word_le_make_less)
@@ -1033,7 +1033,7 @@ shows
             apply (clarsimp simp: archinv_relation_def page_table_invocation_map_def)
             apply (clarsimp simp: attribs_from_word_def attribsFromWord_def Let_def)
             apply (simp add: shiftr_shiftl1 pageBits_def ptBits_def pdeBits_def pteBits_def)
-           apply (wp hoare_whenE_wp get_master_pde_wp getPDE_wp find_pd_for_asid_inv
+           apply (wp whenE_wp get_master_pde_wp getPDE_wp find_pd_for_asid_inv
                   | wp (once) hoare_drop_imps)+
      apply (fastforce simp: valid_cap_def mask_def
                             invs_vspace_objs[simplified])
@@ -1289,7 +1289,7 @@ lemma tcbSchedEnqueue_vs_entry_align[wp]:
    tcbSchedEnqueue pa
   \<lbrace>\<lambda>rv. ko_wp_at' (\<lambda>ko. P (vs_entry_align ko)) p\<rbrace>"
   apply (clarsimp simp: tcbSchedEnqueue_def setQueue_def)
-  by (wp hoare_unless_wp | simp)+
+  by (wp unless_wp | simp)+
 
 crunch vs_entry_align[wp]:
   setThreadState  "ko_wp_at' (\<lambda>ko. P (vs_entry_align ko)) p"

--- a/proof/refine/ARM/CNodeInv_R.thy
+++ b/proof/refine/ARM/CNodeInv_R.thy
@@ -8775,7 +8775,7 @@ crunch irq_states' [wp]: capSwapForDelete valid_irq_states'
 
 
 crunch irq_states' [wp]: finaliseCap valid_irq_states'
-  (wp: crunch_wps hoare_unless_wp getASID_wp no_irq
+  (wp: crunch_wps unless_wp getASID_wp no_irq
        no_irq_invalidateLocalTLB_ASID no_irq_setHardwareASID
        no_irq_set_current_pd no_irq_invalidateLocalTLB_VAASID
        no_irq_cleanByVA_PoU
@@ -8822,7 +8822,7 @@ lemma cteDelete_IRQInactive:
   "\<lbrace>valid_irq_states'\<rbrace> cteDelete x y
   -, \<lbrace>\<lambda>rv s. intStateIRQTable (ksInterruptState s) rv \<noteq> irqstate.IRQInactive\<rbrace>"
   apply (simp add: cteDelete_def split_def)
-  apply (wp hoare_whenE_wp)
+  apply (wp whenE_wp)
    apply (rule hoare_post_impErr)
      apply (rule validE_E_validE)
      apply (rule finaliseSlot_IRQInactive)
@@ -8835,7 +8835,7 @@ lemma cteDelete_irq_states':
   "\<lbrace>valid_irq_states'\<rbrace> cteDelete x y
   \<lbrace>\<lambda>rv. valid_irq_states'\<rbrace>"
   apply (simp add: cteDelete_def split_def)
-  apply (wp hoare_whenE_wp)
+  apply (wp whenE_wp)
    apply (rule hoare_post_impErr)
      apply (rule hoare_valid_validE)
      apply (rule finaliseSlot_irq_states')
@@ -8859,7 +8859,7 @@ proof (induct rule: cteRevoke.induct)
   case (1 p s')
   show ?case
     apply (subst cteRevoke.simps)
-    apply (wp "1.hyps" unlessE_wp hoare_whenE_wp preemptionPoint_IRQInactive_spec
+    apply (wp "1.hyps" unlessE_wp whenE_wp preemptionPoint_IRQInactive_spec
               cteDelete_IRQInactive cteDelete_irq_states' getCTE_wp')+
     apply clarsimp
     done
@@ -8880,7 +8880,7 @@ lemma inv_cnode_IRQInactive:
   apply (rule hoare_pre)
    apply (wp cteRevoke_IRQInactive finaliseSlot_IRQInactive
              cteDelete_IRQInactive
-             hoare_whenE_wp
+             whenE_wp
            | wpc
            | simp add:  split_def)+
   done

--- a/proof/refine/ARM/CNodeInv_R.thy
+++ b/proof/refine/ARM/CNodeInv_R.thy
@@ -4892,7 +4892,7 @@ lemma cteSwap_valid_pspace'[wp]:
          apply (strengthen imp_consequent, strengthen ctes_of_strng)
          apply ((wp sch_act_wf_lift valid_queues_lift
                     cur_tcb_lift updateCap_no_0  updateCap_ctes_of_wp
-                    hoare_ex_wp updateMDB_cte_wp_at_other getCTE_wp
+                    hoare_vcg_ex_lift updateMDB_cte_wp_at_other getCTE_wp
                   | rule hoare_drop_imps)+)[6]
   apply (clarsimp simp: valid_pspace_no_0[unfolded valid_pspace'_def valid_mdb'_def]
                         cte_wp_at_ctes_of)

--- a/proof/refine/ARM/CSpace_R.thy
+++ b/proof/refine/ARM/CSpace_R.thy
@@ -2936,7 +2936,7 @@ lemma setCTE_irq_states' [wp]:
   apply (wp setObject_ksMachine)
    apply (simp add: updateObject_cte)
    apply (rule hoare_pre)
-    apply (wp hoare_unless_wp|wpc|simp)+
+    apply (wp unless_wp|wpc|simp)+
    apply fastforce
   apply assumption
   done
@@ -3051,7 +3051,7 @@ lemma setCTE_ksMachine[wp]:
   apply (wp setObject_ksMachine)
   apply (clarsimp simp: updateObject_cte
                  split: Structures_H.kernel_object.splits)
-  apply (safe, (wp hoare_unless_wp | simp)+)
+  apply (safe, (wp unless_wp | simp)+)
   done
 
 crunch ksMachine[wp]: cteInsert "\<lambda>s. P (ksMachineState s)"

--- a/proof/refine/ARM/Detype_R.thy
+++ b/proof/refine/ARM/Detype_R.thy
@@ -3331,7 +3331,7 @@ lemma placeNewObject_tcb_at':
          placeNewObject ptr (makeObject::tcb) 0
          \<lbrace>\<lambda>_ s. tcb_at' ptr s \<rbrace>"
   apply (simp add: placeNewObject_def placeNewObject'_def split_def)
-  apply (wp hoare_unless_wp |wpc | simp add:alignError_def)+
+  apply (wp unless_wp |wpc | simp add:alignError_def)+
   by (auto simp: obj_at'_def is_aligned_mask lookupAround2_None1
                     lookupAround2_char1 field_simps objBits_simps
                     projectKO_opt_tcb projectKO_def return_def ps_clear_def
@@ -3787,7 +3787,7 @@ proof -
      apply (drule_tac gbits = us in range_cover_not_zero_shift[rotated])
        apply simp+
      apply (simp add:word_le_sub1)
-    apply (wp haskell_assert_wp hoare_unless_wp | wpc |simp add:alignError_def del:fun_upd_apply)+
+    apply (wp haskell_assert_wp unless_wp | wpc |simp add:alignError_def del:fun_upd_apply)+
     apply (rule conjI)
      apply (rule impI)
      apply (subgoal_tac
@@ -4335,7 +4335,7 @@ lemma createObjects_Cons:
         apply simp
        apply (wp haskell_assert_wp | wpc)+
       apply simp
-     apply (wp hoare_unless_wp |clarsimp)+
+     apply (wp unless_wp |clarsimp)+
   apply (drule range_cover.aligned)
   apply (simp add:is_aligned_mask)
   done
@@ -4577,7 +4577,7 @@ proof -
    apply (drule_tac gbits = us in range_cover_not_zero_shift[rotated])
     apply simp+
    apply (simp add:word_le_sub1)
-   apply (wp haskell_assert_wp hoare_unless_wp |wpc
+   apply (wp haskell_assert_wp unless_wp |wpc
          |simp add:alignError_def del:fun_upd_apply)+
   apply (rule conjI)
    apply (rule impI)
@@ -4639,7 +4639,7 @@ lemma createTCBs_tcb_at':
   \<lbrace>\<lambda>rv s.
   (\<forall>x\<in>set [0.e.of_nat n]. tcb_at' (ptr + x * 2^tcbBlockSizeBits) s)\<rbrace>"
   apply (simp add:createObjects'_def split_def alignError_def)
-  apply (wp hoare_unless_wp |wpc)+
+  apply (wp unless_wp |wpc)+
   apply (subst data_map_insert_def[symmetric])+
   apply clarsimp
   apply (subgoal_tac "(\<forall>x\<le>of_nat n.
@@ -5447,7 +5447,7 @@ lemma createObject_pspace_aligned_distinct':
   createObject ty ptr us d
   \<lbrace>\<lambda>xa s. pspace_aligned' s \<and> pspace_distinct' s\<rbrace>"
   apply (rule hoare_pre)
-  apply (wp placeNewObject_pspace_aligned' hoare_unless_wp
+  apply (wp placeNewObject_pspace_aligned' unless_wp
       placeNewObject_pspace_distinct'
     | simp add:ARM_H.createObject_def
       Retype_H.createObject_def objBits_simps

--- a/proof/refine/ARM/InterruptAcc_R.thy
+++ b/proof/refine/ARM/InterruptAcc_R.thy
@@ -114,7 +114,7 @@ lemma preemptionPoint_inv:
   shows "\<lbrace>P\<rbrace> preemptionPoint \<lbrace>\<lambda>_. P\<rbrace>" using assms
   apply (simp add: preemptionPoint_def setWorkUnits_def getWorkUnits_def modifyWorkUnits_def)
   apply (wpc
-          | wp hoare_whenE_wp hoare_seq_ext [OF _ select_inv] alternative_valid hoare_drop_imps
+          | wp whenE_wp hoare_seq_ext [OF _ select_inv] alternative_valid hoare_drop_imps
           | simp)+
   done
 

--- a/proof/refine/ARM/Interrupt_R.thy
+++ b/proof/refine/ARM/Interrupt_R.thy
@@ -619,7 +619,7 @@ lemma decDomainTime_corres:
 lemma tcbSchedAppend_valid_objs':
   "\<lbrace>valid_objs'\<rbrace>tcbSchedAppend t \<lbrace>\<lambda>r. valid_objs'\<rbrace>"
   apply (simp add:tcbSchedAppend_def)
-  apply (wpsimp wp: hoare_unless_wp threadSet_valid_objs' threadGet_wp)
+  apply (wpsimp wp: unless_wp threadSet_valid_objs' threadGet_wp)
   apply (clarsimp simp add:obj_at'_def typ_at'_def)
   done
 
@@ -782,10 +782,10 @@ lemma threadSet_ksDomainTime[wp]:
   done
 
 crunch ksDomainTime[wp]: rescheduleRequired "\<lambda>s. P (ksDomainTime s)"
-(simp:tcbSchedEnqueue_def wp:hoare_unless_wp)
+(simp:tcbSchedEnqueue_def wp:unless_wp)
 
 crunch ksDomainTime[wp]: tcbSchedAppend "\<lambda>s. P (ksDomainTime s)"
-(simp:tcbSchedEnqueue_def wp:hoare_unless_wp)
+(simp:tcbSchedEnqueue_def wp:unless_wp)
 
 lemma updateTimeSlice_valid_pspace[wp]:
   "\<lbrace>valid_pspace'\<rbrace> threadSet (tcbTimeSlice_update (\<lambda>_. ts')) thread

--- a/proof/refine/ARM/KHeap_R.thy
+++ b/proof/refine/ARM/KHeap_R.thy
@@ -186,7 +186,7 @@ lemma obj_at_setObject1:
    setObject p (v::'a::pspace_storable)
   \<lbrace> \<lambda>rv. obj_at' (\<lambda>x::'a::pspace_storable. True) t \<rbrace>"
   apply (simp add: setObject_def split_def)
-  apply (rule hoare_seq_ext [OF _ hoare_gets_post])
+  apply (rule hoare_seq_ext [OF _ hoare_gets_sp])
   apply (clarsimp simp: valid_def in_monad obj_at'_def
                         projectKOs lookupAround2_char1
                         project_inject
@@ -208,7 +208,7 @@ lemma obj_at_setObject2:
    setObject p (v::'a)
   \<lbrace> \<lambda>rv. obj_at' P t \<rbrace>"
   apply (simp add: setObject_def split_def)
-  apply (rule hoare_seq_ext [OF _ hoare_gets_post])
+  apply (rule hoare_seq_ext [OF _ hoare_gets_sp])
   apply (clarsimp simp: valid_def in_monad)
   apply (frule updateObject_type)
   apply (drule R)

--- a/proof/refine/ARM/LevityCatch.thy
+++ b/proof/refine/ARM/LevityCatch.thy
@@ -39,14 +39,14 @@ lemma alignCheck_assert:
 
 lemma magnitudeCheck_inv:   "\<lbrace>P\<rbrace> magnitudeCheck x y n \<lbrace>\<lambda>rv. P\<rbrace>"
   apply (clarsimp simp add: magnitudeCheck_def split: option.splits)
-  apply (wp hoare_when_wp)
+  apply (wp when_wp)
   apply simp
   done
 
 lemma alignCheck_inv:
   "\<lbrace>P\<rbrace> alignCheck x n \<lbrace>\<lambda>rv. P\<rbrace>"
   apply (simp add: alignCheck_def unless_def alignError_def)
-  apply (wp hoare_when_wp)
+  apply (wp when_wp)
   apply simp
   done
 

--- a/proof/refine/ARM/PageTableDuplicates.thy
+++ b/proof/refine/ARM/PageTableDuplicates.thy
@@ -1045,10 +1045,10 @@ lemma createObject_valid_duplicates'[wp]:
   apply (wpc | wp| simp add: ARM_H.createObject_def split del: if_split)+
          apply (simp add: placeNewObject_def placeNewDataObject_def
                           placeNewObject'_def split_def split del: if_split
-           | wp hoare_unless_wp[where P="d"] hoare_unless_wp[where Q=\<top>]
+           | wp unless_wp[where P="d"] unless_wp[where Q=\<top>]
            | wpc | simp add: alignError_def split del: if_split)+
      apply (rule copyGlobalMappings_valid_duplicates')
-    apply ((wp hoare_unless_wp[where P="d"] hoare_unless_wp[where Q=\<top>] | wpc
+    apply ((wp unless_wp[where P="d"] unless_wp[where Q=\<top>] | wpc
             | simp add: alignError_def placeNewObject_def
                         placeNewObject'_def split_def split del: if_split)+)[2]
   apply (intro conjI impI)
@@ -1167,7 +1167,7 @@ lemma createObject_valid_duplicates'[wp]:
 
 
 crunch arch_inv[wp]: createNewObjects "\<lambda>s. P (armKSGlobalPD (ksArchState s))"
-  (simp: crunch_simps zipWithM_x_mapM wp: crunch_wps hoare_unless_wp)
+  (simp: crunch_simps zipWithM_x_mapM wp: crunch_wps unless_wp)
 
 
 lemma createNewObjects_valid_duplicates'[wp]:
@@ -1320,7 +1320,7 @@ lemma deleteObjects_valid_duplicates'[wp]:
 
 crunch arch_inv[wp]: resetUntypedCap "\<lambda>s. P (ksArchState s)"
   (simp: crunch_simps
-     wp: hoare_drop_imps hoare_unless_wp mapME_x_inv_wp
+     wp: hoare_drop_imps unless_wp mapME_x_inv_wp
          preemptionPoint_inv
    ignore: freeMemory)
 
@@ -1356,7 +1356,7 @@ lemma new_CapTable_bound:
   done
 
 lemma invokeUntyped_valid_duplicates[wp]:
-  notes hoare_whenE_wps[wp_split del] shows
+  notes whenE_wps[wp_split del] shows
   "\<lbrace>invs' and (\<lambda>s. vs_valid_duplicates' (ksPSpace s))
          and valid_untyped_inv' ui and ct_active'\<rbrace>
      invokeUntyped ui
@@ -1373,7 +1373,7 @@ lemma invokeUntyped_valid_duplicates[wp]:
    apply (rule hoare_post_impErr)
      apply (rule combine_validE)
       apply (rule_tac ui=ui in whenE_reset_resetUntypedCap_invs_etc)
-     apply (rule hoare_whenE_wp)
+     apply (rule whenE_wp)
      apply (rule valid_validE)
      apply (rule resetUntypedCap_valid_duplicates')
     defer
@@ -1800,7 +1800,7 @@ lemma invokeCNode_valid_duplicates'[wp]:
       apply (simp add:invs_valid_objs' invs_pspace_aligned')
      apply (clarsimp simp add:invokeCNode_def | wp | intro conjI)+
     apply (rule hoare_pre)
-    apply (wp hoare_unless_wp | wpc | simp)+
+    apply (wp unless_wp | wpc | simp)+
    apply (simp add:invokeCNode_def)
    apply (wp getSlotCap_inv hoare_drop_imp
      |simp add:locateSlot_conv getThreadCallerSlot_def
@@ -1904,7 +1904,7 @@ lemma placeASIDPool_valid_duplicates'[wp]:
   placeNewObject' ptr (KOArch (KOASIDPool makeObject)) 0
   \<lbrace>\<lambda>rv s. vs_valid_duplicates' (ksPSpace s)\<rbrace>"
   apply (simp add:placeNewObject'_def)
-  apply (wp hoare_unless_wp | wpc |
+  apply (wp unless_wp | wpc |
     simp add:alignError_def split_def)+
   apply (subgoal_tac "vs_valid_duplicates' (\<lambda>a. if a = ptr then Some (KOArch (KOASIDPool makeObject)) else ksPSpace s a)")
    apply fastforce
@@ -2127,7 +2127,7 @@ crunch valid_duplicates' [wp]:
 
 crunch valid_duplicates' [wp]:
   tcbSchedAppend "(\<lambda>s. vs_valid_duplicates' (ksPSpace s))"
-  (simp:crunch_simps wp:hoare_unless_wp)
+  (simp:crunch_simps wp:unless_wp)
 
 lemma timerTick_valid_duplicates'[wp]:
   "\<lbrace>\<lambda>s. vs_valid_duplicates' (ksPSpace s)\<rbrace>
@@ -2181,7 +2181,7 @@ crunch valid_duplicates'[wp]:
 
 crunch valid_duplicates'[wp]:
   handleYield "\<lambda>s. vs_valid_duplicates' (ksPSpace s)"
- (ignore: threadGet simp:crunch_simps wp:hoare_unless_wp)
+ (ignore: threadGet simp:crunch_simps wp:unless_wp)
 
 crunch valid_duplicates'[wp]:
   "VSpace_H.handleVMFault", handleHypervisorFault "\<lambda>s. vs_valid_duplicates' (ksPSpace s)"

--- a/proof/refine/ARM/Retype_R.thy
+++ b/proof/refine/ARM/Retype_R.thy
@@ -59,8 +59,6 @@ lemma objBitsKO_bounded2[simp]:
   by (simp add: objBits_simps' word_bits_def pageBits_def archObjSize_def pdeBits_def pteBits_def
            split: Structures_H.kernel_object.split arch_kernel_object.split)
 
-declare select_singleton_is_return[simp]
-
 definition
   APIType_capBits :: "ARM_H.object_type \<Rightarrow> nat \<Rightarrow> nat"
 where

--- a/proof/refine/ARM/Retype_R.thy
+++ b/proof/refine/ARM/Retype_R.thy
@@ -4320,7 +4320,7 @@ lemma createNewCaps_pde_mappings'[wp]:
 lemma createObjects'_irq_states' [wp]:
   "\<lbrace>valid_irq_states'\<rbrace> createObjects' a b c d \<lbrace>\<lambda>_. valid_irq_states'\<rbrace>"
   apply (simp add: createObjects'_def split_def)
-  apply (wp hoare_unless_wp|wpc|simp add: alignError_def)+
+  apply (wp unless_wp|wpc|simp add: alignError_def)+
   apply fastforce
   done
 
@@ -4615,7 +4615,7 @@ lemma createObjects_null_filter':
    createObjects' ptr n val gbits
    \<lbrace>\<lambda>addrs a. P (null_filter' (ctes_of a))\<rbrace>"
    apply (clarsimp simp: createObjects'_def split_def)
-   apply (wp hoare_unless_wp|wpc
+   apply (wp unless_wp|wpc
           | clarsimp simp:haskell_assert_def alignError_def
             split del: if_splits simp del:fun_upd_apply)+
    apply (subst new_cap_addrs_fold')

--- a/proof/refine/ARM/Schedule_R.thy
+++ b/proof/refine/ARM/Schedule_R.thy
@@ -536,7 +536,7 @@ lemma tcbSchedAppend_sch_act_wf[wp]:
   "\<lbrace>\<lambda>s. sch_act_wf (ksSchedulerAction s) s\<rbrace> tcbSchedAppend thread
   \<lbrace>\<lambda>rv s. sch_act_wf (ksSchedulerAction s) s\<rbrace>"
   apply (simp add:tcbSchedAppend_def bitmap_fun_defs)
-  apply (wp hoare_unless_wp setQueue_sch_act threadGet_wp|simp)+
+  apply (wp unless_wp setQueue_sch_act threadGet_wp|simp)+
   apply (fastforce simp:typ_at'_def obj_at'_def)
   done
 

--- a/proof/refine/ARM/Syscall_R.thy
+++ b/proof/refine/ARM/Syscall_R.thy
@@ -855,9 +855,9 @@ lemma valid_irq_node_tcbSchedEnqueue[wp]:
   \<lbrace>\<lambda>rv s'. valid_irq_node' (irq_node' s') s'\<rbrace>"
   apply (rule hoare_pre)
   apply (simp add:valid_irq_node'_def )
-  apply (wp hoare_unless_wp hoare_vcg_all_lift | wps)+
+  apply (wp unless_wp hoare_vcg_all_lift | wps)+
   apply (simp add:tcbSchedEnqueue_def)
-  apply (wp hoare_unless_wp| simp)+
+  apply (wp unless_wp| simp)+
   apply (simp add:valid_irq_node'_def)
   done
 
@@ -971,7 +971,7 @@ lemma setDomain_invs':
   (\<lambda>y. domain \<le> maxDomain))\<rbrace>
   setDomain ptr domain \<lbrace>\<lambda>y. invs'\<rbrace>"
   apply (simp add:setDomain_def )
-  apply (wp add: hoare_when_wp static_imp_wp static_imp_conj_wp rescheduleRequired_all_invs_but_extra
+  apply (wp add: when_wp static_imp_wp static_imp_conj_wp rescheduleRequired_all_invs_but_extra
     tcbSchedEnqueue_valid_action hoare_vcg_if_lift2)
      apply (rule_tac Q = "\<lambda>r s. all_invs_but_sch_extra s \<and> curThread = ksCurThread s
       \<and> (ptr \<noteq> curThread \<longrightarrow> ct_not_inQ s \<and> sch_act_wf (ksSchedulerAction s) s \<and> ct_idle_or_in_cur_domain' s)"

--- a/proof/refine/ARM/TcbAcc_R.thy
+++ b/proof/refine/ARM/TcbAcc_R.thy
@@ -215,7 +215,7 @@ lemma preemptionPoint_irq [wp]:
   "\<lbrace>valid_irq_states'\<rbrace> preemptionPoint -,
    \<lbrace>\<lambda>irq s. intStateIRQTable (ksInterruptState s) irq \<noteq> IRQInactive\<rbrace>"
   apply (simp add: preemptionPoint_def setWorkUnits_def modifyWorkUnits_def getWorkUnits_def)
-  apply (wp hoare_whenE_wp|wpc)+
+  apply (wp whenE_wp|wpc)+
      apply (rule hoare_post_imp)
       prefer 2
      apply (rule doMachineOp_getActiveIRQ_IRQ_active)

--- a/proof/refine/ARM/Tcb_R.thy
+++ b/proof/refine/ARM/Tcb_R.thy
@@ -83,7 +83,7 @@ lemma gts_st_tcb':
   apply (rule hoare_vcg_precond_imp)
    apply (rule hoare_post_imp[where Q="\<lambda>rv s. \<exists>rv'. rv = rv' \<and> st_tcb_at' (\<lambda>st. st = rv') t s"])
     apply simp
-   apply (wp hoare_ex_wp)
+   apply (wp hoare_vcg_ex_lift)
   apply (clarsimp simp add: pred_tcb_at'_def obj_at'_def)
   done
 

--- a/proof/refine/ARM/Untyped_R.thy
+++ b/proof/refine/ARM/Untyped_R.thy
@@ -4017,11 +4017,11 @@ lemma valid_sched_etcbs[elim!]: "valid_sched_2 queues ekh sa cdom kh ct it \<Lon
   by (simp add: valid_sched_def)
 
 crunch ksIdleThread[wp]: deleteObjects "\<lambda>s. P (ksIdleThread s)"
-  (simp: crunch_simps wp: hoare_drop_imps hoare_unless_wp ignore: freeMemory)
+  (simp: crunch_simps wp: hoare_drop_imps unless_wp ignore: freeMemory)
 crunch ksCurDomain[wp]: deleteObjects "\<lambda>s. P (ksCurDomain s)"
-  (simp: crunch_simps wp: hoare_drop_imps hoare_unless_wp ignore: freeMemory)
+  (simp: crunch_simps wp: hoare_drop_imps unless_wp ignore: freeMemory)
 crunch irq_node[wp]: deleteObjects "\<lambda>s. P (irq_node' s)"
-  (simp: crunch_simps wp: hoare_drop_imps hoare_unless_wp ignore: freeMemory)
+  (simp: crunch_simps wp: hoare_drop_imps unless_wp ignore: freeMemory)
 
 lemma deleteObjects_ksCurThread[wp]:
   "\<lbrace>\<lambda>s. P (ksCurThread s)\<rbrace> deleteObjects ptr sz \<lbrace>\<lambda>_ s. P (ksCurThread s)\<rbrace>"
@@ -4576,7 +4576,7 @@ lemma whenE_reset_resetUntypedCap_invs_etc:
       and ct_active'
       and pspace_no_overlap' (if reset then ptr else ptr') sz\<rbrace>, \<lbrace>\<lambda>_. invs'\<rbrace>"
   apply (rule hoare_pre)
-   apply (wp hoare_whenE_wp resetUntypedCap_invs_etc[where idx=idx,
+   apply (wp whenE_wp resetUntypedCap_invs_etc[where idx=idx,
            simplified pred_conj_def conj_assoc]
        | simp)+
   apply (clarsimp simp: cte_wp_at_ctes_of)
@@ -5033,7 +5033,7 @@ lemma sts_valid_untyped_inv':
 
 crunch nosch[wp]: invokeUntyped "\<lambda>s. P (ksSchedulerAction s)"
   (simp: crunch_simps zipWithM_x_mapM
-     wp: crunch_wps hoare_unless_wp mapME_x_inv_wp preemptionPoint_inv)
+     wp: crunch_wps unless_wp mapME_x_inv_wp preemptionPoint_inv)
 
 crunch no_0_obj'[wp]: insertNewCap no_0_obj'
   (wp: crunch_wps)
@@ -5663,7 +5663,7 @@ lemma inv_untyped_IRQInactive:
   -, \<lbrace>\<lambda>rv s. intStateIRQTable (ksInterruptState s) rv \<noteq> irqstate.IRQInactive\<rbrace>"
   apply (simp add: invokeUntyped_def)
   apply (rule hoare_pre)
-   apply (wp hoare_whenE_wp resetUntypedCap_IRQInactive | wpc | simp)+
+   apply (wp whenE_wp resetUntypedCap_IRQInactive | wpc | simp)+
   done
 
 end

--- a/proof/refine/ARM/orphanage/Orphanage.thy
+++ b/proof/refine/ARM/orphanage/Orphanage.thy
@@ -144,7 +144,7 @@ lemma ksQ_all_queued_tcb_ptrs_lift:
   shows "\<lbrace>\<lambda>s. P (t \<in> all_queued_tcb_ptrs s)\<rbrace> f \<lbrace>\<lambda>_ s. P (t \<in> all_queued_tcb_ptrs s)\<rbrace>"
   apply (clarsimp simp: all_queued_tcb_ptrs_def)
   apply (rule_tac P=P in P_bool_lift)
-   apply (wp hoare_ex_wp assms)
+   apply (wp hoare_vcg_ex_lift assms)
   apply (clarsimp)
   apply (wp hoare_vcg_all_lift assms)
   done
@@ -655,7 +655,7 @@ lemma tcbSchedDequeue_all_queued_tcb_ptrs:
   apply (clarsimp simp: tcbSchedDequeue_def all_queued_tcb_ptrs_def)
   apply (rule hoare_pre)
    apply (wp, clarsimp)
-       apply (wp hoare_ex_wp)+
+       apply (wp hoare_vcg_ex_lift)+
      apply (rename_tac d p)
      apply (rule_tac Q="\<lambda>_ s. x \<in> set (ksReadyQueues s (d, p))"
                      in hoare_post_imp, clarsimp)
@@ -744,7 +744,7 @@ lemma findM_on_success:
   apply (induct xs; clarsimp)
   apply wp+
   apply (clarsimp simp: imp_conv_disj Bex_def)
-  apply (wp hoare_vcg_disj_lift hoare_ex_wp | clarsimp | assumption)+
+  apply (wp hoare_vcg_disj_lift hoare_vcg_ex_lift | clarsimp | assumption)+
   done
 
 crunch st_tcb' [wp]: switchToThread "\<lambda>s. P' (st_tcb_at' P t s)"
@@ -767,7 +767,7 @@ lemma tcbSchedDequeue_not_empty:
    \<lbrace> \<lambda>rv s. \<exists>tcb. tcb \<in> set (ksReadyQueues s p) \<and> st_tcb_at' P tcb s \<rbrace>"
   unfolding tcbSchedDequeue_def
   apply wp
-         apply (wp hoare_ex_wp threadSet_pred_tcb_no_state)
+         apply (wp hoare_vcg_ex_lift threadSet_pred_tcb_no_state)
          apply clarsimp
         apply (wp setQueue_deq_not_empty)
        apply clarsimp
@@ -2200,7 +2200,7 @@ lemma performASIDControlInvocation_no_orphans [wp]:
   apply (strengthen invs_pspace_aligned' invs_pspace_distinct' invs_valid_pspace')
   apply (clarsimp simp:conj_comms)
      apply (wp deleteObjects_invs'[where idx = idx and d=False]
-       hoare_ex_wp deleteObjects_cte_wp_at'[where idx = idx and d=False] hoare_vcg_const_imp_lift )
+       hoare_vcg_ex_lift deleteObjects_cte_wp_at'[where idx = idx and d=False] hoare_vcg_const_imp_lift )
   using invs' misc cte exclude no_orphans cover
   apply (clarsimp simp: is_active_thread_state_def makeObject_tcb valid_aci'_def
                         cte_wp_at_ctes_of invs_pspace_aligned' invs_pspace_distinct'

--- a/proof/refine/ARM/orphanage/Orphanage.thy
+++ b/proof/refine/ARM/orphanage/Orphanage.thy
@@ -2096,7 +2096,7 @@ lemma invokeCNode_no_orphans [wp]:
    \<lbrace> \<lambda>rv. no_orphans \<rbrace>"
   unfolding invokeCNode_def
   apply (rule hoare_pre)
-   apply (wp hoare_drop_imps hoare_unless_wp | wpc | clarsimp split del: if_split)+
+   apply (wp hoare_drop_imps unless_wp | wpc | clarsimp split del: if_split)+
   apply (simp add: invs_valid_queues')
   done
 

--- a/proof/refine/ARM_HYP/Arch_R.thy
+++ b/proof/refine/ARM_HYP/Arch_R.thy
@@ -73,7 +73,7 @@ lemma createObject_typ_at':
          pspace_aligned' s \<and> pspace_no_overlap' ptr (objBitsKO ty) s\<rbrace>
    createObjects' ptr (Suc 0) ty 0
    \<lbrace>\<lambda>rv s. typ_at' otype ptr s\<rbrace>"
-  apply (clarsimp simp:createObjects'_def alignError_def split_def | wp hoare_unless_wp | wpc )+
+  apply (clarsimp simp:createObjects'_def alignError_def split_def | wp unless_wp | wpc )+
   apply (clarsimp simp: obj_at'_def ko_wp_at'_def typ_at'_def pspace_distinct'_def)+
   apply (subgoal_tac "ps_clear ptr (objBitsKO ty)
     (s\<lparr>ksPSpace := \<lambda>a. if a = ptr then Some ty else ksPSpace s a\<rparr>)")
@@ -423,7 +423,7 @@ lemma checkVP_wpR [wp]:
   checkVPAlignment sz w \<lbrace>P\<rbrace>, -"
   apply (simp add: checkVPAlignment_def unlessE_whenE cong: vmpage_size.case_cong)
   apply (rule hoare_pre)
-   apply (wp hoare_whenE_wp|wpc)+
+   apply (wp whenE_wp|wpc)+
   apply (simp add: is_aligned_mask vmsz_aligned'_def)
   done
 
@@ -451,7 +451,7 @@ lemma ARMMMU_improve_cases:
   by (cases cap, simp_all add: isCap_simps) (* not sure if this is useful as is *)
 
 lemma decodeVCPUInjectIRQ_inv[wp]: "\<lbrace>P\<rbrace> decodeVCPUInjectIRQ a b \<lbrace>\<lambda>_. P\<rbrace>"
-  by (wpsimp simp: decodeVCPUInjectIRQ_def Let_def wp: hoare_whenE_wp getVCPU_wp | rule conjI)+
+  by (wpsimp simp: decodeVCPUInjectIRQ_def Let_def wp: whenE_wp getVCPU_wp | rule conjI)+
 
 crunch inv [wp]: "ARM_HYP_H.decodeInvocation" "P"
   (wp: crunch_wps mapME_x_inv_wp getASID_wp
@@ -957,11 +957,11 @@ shows
                  apply (simp add: returnOk_liftE[symmetric])
                  apply (rule corres_returnOk)
                  apply (simp add: archinv_relation_def asid_pool_invocation_map_def)
-                apply (rule hoare_pre, wp hoare_whenE_wp)
+                apply (rule hoare_pre, wp whenE_wp)
                 apply (clarsimp simp: ucast_fst_hd_assocs)
-                apply (wp hoareE_TrueI hoare_whenE_wp getASID_wp | simp)+
+                apply (wp hoareE_TrueI whenE_wp getASID_wp | simp)+
             apply ((clarsimp simp: p2_low_bits_max | rule TrueI impI)+)[2]
-          apply (wp hoare_whenE_wp getASID_wp)+
+          apply (wp whenE_wp getASID_wp)+
         apply (clarsimp simp: valid_cap_def)
        apply auto[1]
       apply (simp add: isCap_simps split del: if_split)
@@ -1035,7 +1035,7 @@ shows
                   apply (simp add: ord_le_eq_trans [OF word_n1_ge])
                  apply (wp hoare_drop_imps)+
            apply (simp add: o_def validE_R_def)
-           apply (wp hoare_whenE_wp)+
+           apply (wp whenE_wp)+
        apply fastforce
       apply clarsimp
       apply (simp add: null_def split_def asid_high_bits_def
@@ -1156,7 +1156,7 @@ shows
              apply (rule corres_returnOk)
              apply (clarsimp simp: archinv_relation_def page_table_invocation_map_def)
              apply (simp add: shiftr_shiftl1)
-            apply (wp hoare_whenE_wp get_master_pde_wp getPDE_wp find_pd_for_asid_inv
+            apply (wp whenE_wp get_master_pde_wp getPDE_wp find_pd_for_asid_inv
                    | wp (once) hoare_drop_imps)+
       apply (fastforce simp: valid_cap_def mask_def)
      apply (clarsimp simp: valid_cap'_def)
@@ -1524,7 +1524,7 @@ lemma tcbSchedEnqueue_vs_entry_align[wp]:
    tcbSchedEnqueue pa
   \<lbrace>\<lambda>rv. ko_wp_at' (\<lambda>ko. P (vs_entry_align ko)) p\<rbrace>"
   apply (clarsimp simp: tcbSchedEnqueue_def setQueue_def)
-  by (wp hoare_unless_wp | simp)+
+  by (wp unless_wp | simp)+
 
 crunch vs_entry_align[wp]:
   setThreadState  "ko_wp_at' (\<lambda>ko. P (vs_entry_align ko)) p"

--- a/proof/refine/ARM_HYP/CNodeInv_R.thy
+++ b/proof/refine/ARM_HYP/CNodeInv_R.thy
@@ -4910,7 +4910,7 @@ lemma cteSwap_valid_pspace'[wp]:
          apply (strengthen imp_consequent, strengthen ctes_of_strng)
          apply ((wp sch_act_wf_lift valid_queues_lift
                     cur_tcb_lift updateCap_no_0  updateCap_ctes_of_wp
-                    hoare_ex_wp updateMDB_cte_wp_at_other getCTE_wp
+                    hoare_vcg_ex_lift updateMDB_cte_wp_at_other getCTE_wp
                   | simp add: cte_wp_at_ctes_ofI o_def
                   | rule hoare_drop_imps)+)[6]
   apply (clarsimp simp: valid_pspace_no_0[unfolded valid_pspace'_def valid_mdb'_def]

--- a/proof/refine/ARM_HYP/CNodeInv_R.thy
+++ b/proof/refine/ARM_HYP/CNodeInv_R.thy
@@ -8966,7 +8966,7 @@ crunches
    ignore: saveVirtTimer)
 
 crunch irq_states' [wp]: finaliseCap valid_irq_states'
-  (wp: crunch_wps hoare_unless_wp getASID_wp no_irq
+  (wp: crunch_wps unless_wp getASID_wp no_irq
        no_irq_invalidateLocalTLB_ASID no_irq_setHardwareASID
        no_irq_setCurrentPD no_irq_invalidateLocalTLB_VAASID
        no_irq_cleanByVA_PoU FalseI
@@ -9013,7 +9013,7 @@ lemma cteDelete_IRQInactive:
   "\<lbrace>valid_irq_states'\<rbrace> cteDelete x y
   -, \<lbrace>\<lambda>rv s. intStateIRQTable (ksInterruptState s) rv \<noteq> irqstate.IRQInactive\<rbrace>"
   apply (simp add: cteDelete_def split_def)
-  apply (wp hoare_whenE_wp)
+  apply (wp whenE_wp)
    apply (rule hoare_post_impErr)
      apply (rule validE_E_validE)
      apply (rule finaliseSlot_IRQInactive)
@@ -9026,7 +9026,7 @@ lemma cteDelete_irq_states':
   "\<lbrace>valid_irq_states'\<rbrace> cteDelete x y
   \<lbrace>\<lambda>rv. valid_irq_states'\<rbrace>"
   apply (simp add: cteDelete_def split_def)
-  apply (wp hoare_whenE_wp)
+  apply (wp whenE_wp)
    apply (rule hoare_post_impErr)
      apply (rule hoare_valid_validE)
      apply (rule finaliseSlot_irq_states')
@@ -9050,7 +9050,7 @@ proof (induct rule: cteRevoke.induct)
   case (1 p s')
   show ?case
     apply (subst cteRevoke.simps)
-    apply (wp "1.hyps" unlessE_wp hoare_whenE_wp preemptionPoint_IRQInactive_spec
+    apply (wp "1.hyps" unlessE_wp whenE_wp preemptionPoint_IRQInactive_spec
               cteDelete_IRQInactive cteDelete_irq_states' getCTE_wp')+
     apply clarsimp
     done
@@ -9070,7 +9070,7 @@ lemma inv_cnode_IRQInactive:
   apply (simp add: invokeCNode_def)
   apply (wp hoare_TrueI [where P=\<top>] cteRevoke_IRQInactive finaliseSlot_IRQInactive
              cteDelete_IRQInactive
-             hoare_whenE_wp
+             whenE_wp
            | wpc
            | simp add:  split_def)+
   done

--- a/proof/refine/ARM_HYP/CSpace_R.thy
+++ b/proof/refine/ARM_HYP/CSpace_R.thy
@@ -2964,7 +2964,7 @@ lemma setCTE_irq_states' [wp]:
   apply (wp setObject_ksMachine)
    apply (simp add: updateObject_cte)
    apply (rule hoare_pre)
-    apply (wp hoare_unless_wp|wpc|simp)+
+    apply (wp unless_wp|wpc|simp)+
    apply fastforce
   apply assumption
   done
@@ -3084,7 +3084,7 @@ lemma setCTE_ksMachine[wp]:
   apply (wp setObject_ksMachine)
   apply (clarsimp simp: updateObject_cte
                  split: Structures_H.kernel_object.splits)
-  apply (safe, (wp hoare_unless_wp | simp)+)
+  apply (safe, (wp unless_wp | simp)+)
   done
 
 crunch ksMachine[wp]: cteInsert "\<lambda>s. P (ksMachineState s)"

--- a/proof/refine/ARM_HYP/Detype_R.thy
+++ b/proof/refine/ARM_HYP/Detype_R.thy
@@ -3289,7 +3289,7 @@ lemma placeNewObject_tcb_at':
          placeNewObject ptr (makeObject::tcb) 0
          \<lbrace>\<lambda>_ s. tcb_at' ptr s \<rbrace>"
   apply (simp add: placeNewObject_def placeNewObject'_def split_def)
-  apply (wp hoare_unless_wp |wpc | simp add:alignError_def)+
+  apply (wp unless_wp |wpc | simp add:alignError_def)+
   by (auto simp: obj_at'_def is_aligned_mask lookupAround2_None1
                     lookupAround2_char1 field_simps objBits_simps
                     projectKO_opt_tcb projectKO_def return_def ps_clear_def
@@ -3728,7 +3728,7 @@ proof -
      apply (drule_tac gbits = us in range_cover_not_zero_shift[rotated])
        apply simp+
      apply (simp add:word_le_sub1)
-    apply (wp haskell_assert_wp hoare_unless_wp | wpc
+    apply (wp haskell_assert_wp unless_wp | wpc
         | simp add:alignError_def if_apply_def2 del: fun_upd_apply hoare_fail_any)+
     apply (rule impI)
     apply (subgoal_tac
@@ -4270,7 +4270,7 @@ lemma createObjects_Cons:
         apply simp
        apply (wp haskell_assert_wp | wpc)+
       apply simp
-     apply (wp hoare_unless_wp |clarsimp)+
+     apply (wp unless_wp |clarsimp)+
   apply (drule range_cover.aligned)
   apply (simp add:is_aligned_mask)
   done
@@ -4599,7 +4599,7 @@ proof -
    apply (drule_tac gbits = us in range_cover_not_zero_shift[rotated])
     apply simp+
    apply (simp add:word_le_sub1)
-   apply (wp haskell_assert_wp hoare_unless_wp |wpc
+   apply (wp haskell_assert_wp unless_wp |wpc
          |simp add:alignError_def del:fun_upd_apply)+
   apply (rule conjI)
    apply (rule impI)
@@ -4661,7 +4661,7 @@ lemma createTCBs_tcb_at':
   \<lbrace>\<lambda>rv s.
   (\<forall>x\<in>set [0.e.of_nat n]. tcb_at' (ptr + x * 2^tcbBlockSizeBits) s)\<rbrace>"
   apply (simp add:createObjects'_def split_def alignError_def)
-  apply (wp hoare_unless_wp |wpc)+
+  apply (wp unless_wp |wpc)+
   apply (subst data_map_insert_def[symmetric])+
   apply clarsimp
   apply (subgoal_tac "(\<forall>x\<le>of_nat n.
@@ -5488,7 +5488,7 @@ lemma createObject_pspace_aligned_distinct':
   createObject ty ptr us d
   \<lbrace>\<lambda>xa s. pspace_aligned' s \<and> pspace_distinct' s\<rbrace>"
   apply (rule hoare_pre)
-  apply (wp placeNewObject_pspace_aligned' hoare_unless_wp
+  apply (wp placeNewObject_pspace_aligned' unless_wp
       placeNewObject_pspace_distinct'
     | simp add:ARM_HYP_H.createObject_def
       Retype_H.createObject_def objBits_simps

--- a/proof/refine/ARM_HYP/InterruptAcc_R.thy
+++ b/proof/refine/ARM_HYP/InterruptAcc_R.thy
@@ -119,7 +119,7 @@ lemma preemptionPoint_inv:
   shows "\<lbrace>P\<rbrace> preemptionPoint \<lbrace>\<lambda>_. P\<rbrace>" using assms
   apply (simp add: preemptionPoint_def setWorkUnits_def getWorkUnits_def modifyWorkUnits_def)
   apply (wpc
-          | wp hoare_whenE_wp hoare_seq_ext [OF _ select_inv] alternative_valid hoare_drop_imps
+          | wp whenE_wp hoare_seq_ext [OF _ select_inv] alternative_valid hoare_drop_imps
           | simp)+
   done
 

--- a/proof/refine/ARM_HYP/Interrupt_R.thy
+++ b/proof/refine/ARM_HYP/Interrupt_R.thy
@@ -606,7 +606,7 @@ lemma decDomainTime_corres:
 lemma tcbSchedAppend_valid_objs':
   "\<lbrace>valid_objs'\<rbrace>tcbSchedAppend t \<lbrace>\<lambda>r. valid_objs'\<rbrace>"
   apply (simp add:tcbSchedAppend_def)
-  apply (wpsimp wp: hoare_unless_wp threadSet_valid_objs' threadGet_wp)
+  apply (wpsimp wp: unless_wp threadSet_valid_objs' threadGet_wp)
   apply (clarsimp simp add:obj_at'_def typ_at'_def)
   done
 
@@ -1051,10 +1051,10 @@ lemma threadSet_ksDomainTime[wp]:
   done
 
 crunch ksDomainTime[wp]: rescheduleRequired "\<lambda>s. P (ksDomainTime s)"
-(simp:tcbSchedEnqueue_def wp:hoare_unless_wp)
+(simp:tcbSchedEnqueue_def wp:unless_wp)
 
 crunch ksDomainTime[wp]: tcbSchedAppend "\<lambda>s. P (ksDomainTime s)"
-(simp:tcbSchedEnqueue_def wp:hoare_unless_wp)
+(simp:tcbSchedEnqueue_def wp:unless_wp)
 
 lemma updateTimeSlice_valid_pspace[wp]:
   "\<lbrace>valid_pspace'\<rbrace> threadSet (tcbTimeSlice_update (\<lambda>_. ts')) thread

--- a/proof/refine/ARM_HYP/KHeap_R.thy
+++ b/proof/refine/ARM_HYP/KHeap_R.thy
@@ -254,7 +254,7 @@ lemma obj_at_setObject1:
    setObject p (v::'a::pspace_storable)
   \<lbrace> \<lambda>rv. obj_at' (\<lambda>x::'a::pspace_storable. True) t \<rbrace>"
   apply (simp add: setObject_def split_def)
-  apply (rule hoare_seq_ext [OF _ hoare_gets_post])
+  apply (rule hoare_seq_ext [OF _ hoare_gets_sp])
   apply (clarsimp simp: valid_def in_monad obj_at'_def
                         projectKOs lookupAround2_char1
                         project_inject
@@ -276,7 +276,7 @@ lemma obj_at_setObject2:
    setObject p (v::'a)
   \<lbrace> \<lambda>rv. obj_at' P t \<rbrace>"
   apply (simp add: setObject_def split_def)
-  apply (rule hoare_seq_ext [OF _ hoare_gets_post])
+  apply (rule hoare_seq_ext [OF _ hoare_gets_sp])
   apply (clarsimp simp: valid_def in_monad)
   apply (frule updateObject_type)
   apply (drule R)

--- a/proof/refine/ARM_HYP/LevityCatch.thy
+++ b/proof/refine/ARM_HYP/LevityCatch.thy
@@ -39,14 +39,14 @@ lemma alignCheck_assert:
 
 lemma magnitudeCheck_inv:   "\<lbrace>P\<rbrace> magnitudeCheck x y n \<lbrace>\<lambda>rv. P\<rbrace>"
   apply (clarsimp simp add: magnitudeCheck_def split: option.splits)
-  apply (wp hoare_when_wp)
+  apply (wp when_wp)
   apply simp
   done
 
 lemma alignCheck_inv:
   "\<lbrace>P\<rbrace> alignCheck x n \<lbrace>\<lambda>rv. P\<rbrace>"
   apply (simp add: alignCheck_def unless_def alignError_def)
-  apply (wp hoare_when_wp)
+  apply (wp when_wp)
   apply simp
   done
 

--- a/proof/refine/ARM_HYP/PageTableDuplicates.thy
+++ b/proof/refine/ARM_HYP/PageTableDuplicates.thy
@@ -642,7 +642,7 @@ lemma createObject_valid_duplicates'[wp]:
          apply (simp add: placeNewObject_def placeNewDataObject_def
                           placeNewObject'_def split_def copyGlobalMappings_def
                      split del: if_split
-           | wp hoare_unless_wp[where P="d"] hoare_unless_wp[where Q=\<top>]
+           | wp unless_wp[where P="d"] unless_wp[where Q=\<top>]
            | wpc | simp add: alignError_def split del: if_split)+
   apply (intro conjI impI)
              apply clarsimp+
@@ -874,7 +874,7 @@ lemma deleteObjects_valid_duplicates'[wp]:
 
 crunch arch_inv[wp]: resetUntypedCap "\<lambda>s. P (ksArchState s)"
   (simp: crunch_simps
-     wp: hoare_drop_imps hoare_unless_wp mapME_x_inv_wp
+     wp: hoare_drop_imps unless_wp mapME_x_inv_wp
          preemptionPoint_inv
    ignore: freeMemory)
 
@@ -909,7 +909,7 @@ lemma invokeUntyped_valid_duplicates[wp]:
          and valid_untyped_inv' ui and ct_active'\<rbrace>
      invokeUntyped ui
    \<lbrace>\<lambda>rv s. vs_valid_duplicates' (ksPSpace s) \<rbrace>"
-  supply hoare_whenE_wps[wp_split del]
+  supply whenE_wps[wp_split del]
   apply (simp only: invokeUntyped_def updateCap_def)
   apply (rule hoare_name_pre_state)
   apply (cases ui)
@@ -922,7 +922,7 @@ lemma invokeUntyped_valid_duplicates[wp]:
    apply ((rule validE_validE_R)?, rule hoare_post_impErr)
      apply (rule combine_validE)
       apply (rule_tac ui=ui in whenE_reset_resetUntypedCap_invs_etc)
-     apply (rule hoare_whenE_wp)
+     apply (rule whenE_wp)
      apply (rule valid_validE)
      apply (rule resetUntypedCap_valid_duplicates')
     defer
@@ -1415,7 +1415,7 @@ lemma invokeCNode_valid_duplicates'[wp]:
       apply (simp add:invs_valid_objs' invs_pspace_aligned')
      apply (clarsimp simp add:invokeCNode_def | wp | intro conjI)+
     apply (rule hoare_pre)
-    apply (wp hoare_unless_wp | wpc | simp)+
+    apply (wp unless_wp | wpc | simp)+
    apply (simp add:invokeCNode_def)
    apply (wp getSlotCap_inv hoare_drop_imp
      |simp add:locateSlot_conv getThreadCallerSlot_def
@@ -1847,7 +1847,7 @@ lemma placeASIDPool_valid_duplicates'[wp]:
   placeNewObject' ptr (KOArch (KOASIDPool makeObject)) 0
   \<lbrace>\<lambda>rv s. vs_valid_duplicates' (ksPSpace s)\<rbrace>"
   apply (simp add: placeNewObject'_def)
-  apply (wp hoare_unless_wp | wpc |  simp add:alignError_def split_def)+
+  apply (wp unless_wp | wpc |  simp add:alignError_def split_def)+
   apply (subgoal_tac "vs_valid_duplicates' (\<lambda>a. if a = ptr then Some (KOArch (KOASIDPool makeObject)) else ksPSpace s a)")
    apply fastforce
   apply clarsimp
@@ -2051,7 +2051,7 @@ crunch valid_duplicates' [wp]:
 
 crunch valid_duplicates' [wp]:
   tcbSchedAppend "(\<lambda>s. vs_valid_duplicates' (ksPSpace s))"
-  (simp:crunch_simps wp:hoare_unless_wp)
+  (simp:crunch_simps wp:unless_wp)
 
 lemma timerTick_valid_duplicates'[wp]:
   "\<lbrace>\<lambda>s. vs_valid_duplicates' (ksPSpace s)\<rbrace>
@@ -2114,7 +2114,7 @@ crunch valid_duplicates'[wp]:
 
 crunch valid_duplicates'[wp]:
   handleYield "\<lambda>s. vs_valid_duplicates' (ksPSpace s)"
- (ignore: threadGet simp:crunch_simps wp:hoare_unless_wp)
+ (ignore: threadGet simp:crunch_simps wp:unless_wp)
 
 crunch valid_duplicates'[wp]:
   "VSpace_H.handleVMFault", handleHypervisorFault "\<lambda>s. vs_valid_duplicates' (ksPSpace s)"

--- a/proof/refine/ARM_HYP/Retype_R.thy
+++ b/proof/refine/ARM_HYP/Retype_R.thy
@@ -61,8 +61,6 @@ lemma objBitsKO_bounded2[simp]:
   by (simp add: objBits_simps' word_bits_def vspace_bits_defs vcpu_bits_def archObjSize_def
          split: Structures_H.kernel_object.split arch_kernel_object.split)
 
-declare select_singleton_is_return[simp]
-
 definition
   APIType_capBits :: "ARM_HYP_H.object_type \<Rightarrow> nat \<Rightarrow> nat"
 where

--- a/proof/refine/ARM_HYP/Retype_R.thy
+++ b/proof/refine/ARM_HYP/Retype_R.thy
@@ -4345,7 +4345,7 @@ lemma createNewCaps_pde_mappings'[wp]:
 lemma createObjects'_irq_states' [wp]:
   "\<lbrace>valid_irq_states'\<rbrace> createObjects' a b c d \<lbrace>\<lambda>_. valid_irq_states'\<rbrace>"
   apply (simp add: createObjects'_def split_def)
-  apply (wp hoare_unless_wp|wpc|simp add: alignError_def)+
+  apply (wp unless_wp|wpc|simp add: alignError_def)+
   apply fastforce
   done
 
@@ -4638,7 +4638,7 @@ lemma createObjects_null_filter':
    createObjects' ptr n val gbits
    \<lbrace>\<lambda>addrs a. P (null_filter' (ctes_of a))\<rbrace>"
    apply (clarsimp simp: createObjects'_def split_def)
-   apply (wp hoare_unless_wp|wpc
+   apply (wp unless_wp|wpc
           | clarsimp simp:haskell_assert_def alignError_def
             split del: if_splits simp del:fun_upd_apply)+
    apply (subst new_cap_addrs_fold')

--- a/proof/refine/ARM_HYP/Schedule_R.thy
+++ b/proof/refine/ARM_HYP/Schedule_R.thy
@@ -587,7 +587,7 @@ lemma tcbSchedAppend_sch_act_wf[wp]:
   "\<lbrace>\<lambda>s. sch_act_wf (ksSchedulerAction s) s\<rbrace> tcbSchedAppend thread
   \<lbrace>\<lambda>rv s. sch_act_wf (ksSchedulerAction s) s\<rbrace>"
   apply (simp add:tcbSchedAppend_def bitmap_fun_defs)
-  apply (wp hoare_unless_wp setQueue_sch_act threadGet_wp|simp)+
+  apply (wp unless_wp setQueue_sch_act threadGet_wp|simp)+
   apply (fastforce simp:typ_at'_def obj_at'_def)
   done
 

--- a/proof/refine/ARM_HYP/Syscall_R.thy
+++ b/proof/refine/ARM_HYP/Syscall_R.thy
@@ -868,9 +868,9 @@ lemma valid_irq_node_tcbSchedEnqueue[wp]:
   \<lbrace>\<lambda>rv s'. valid_irq_node' (irq_node' s') s'\<rbrace>"
   apply (rule hoare_pre)
   apply (simp add:valid_irq_node'_def )
-  apply (wp hoare_unless_wp hoare_vcg_all_lift | wps)+
+  apply (wp unless_wp hoare_vcg_all_lift | wps)+
   apply (simp add:tcbSchedEnqueue_def)
-  apply (wp hoare_unless_wp| simp)+
+  apply (wp unless_wp| simp)+
   apply (simp add:valid_irq_node'_def)
   done
 
@@ -987,7 +987,7 @@ lemma setDomain_invs':
   (\<lambda>y. domain \<le> maxDomain))\<rbrace>
   setDomain ptr domain \<lbrace>\<lambda>y. invs'\<rbrace>"
   apply (simp add:setDomain_def )
-  apply (wp add: hoare_when_wp static_imp_wp static_imp_conj_wp rescheduleRequired_all_invs_but_extra
+  apply (wp add: when_wp static_imp_wp static_imp_conj_wp rescheduleRequired_all_invs_but_extra
     tcbSchedEnqueue_valid_action hoare_vcg_if_lift2)
      apply (rule_tac Q = "\<lambda>r s. all_invs_but_sch_extra s \<and> curThread = ksCurThread s
       \<and> (ptr \<noteq> curThread \<longrightarrow> ct_not_inQ s \<and> sch_act_wf (ksSchedulerAction s) s \<and> ct_idle_or_in_cur_domain' s)"

--- a/proof/refine/ARM_HYP/TcbAcc_R.thy
+++ b/proof/refine/ARM_HYP/TcbAcc_R.thy
@@ -229,7 +229,7 @@ lemma preemptionPoint_irq [wp]:
   "\<lbrace>valid_irq_states'\<rbrace> preemptionPoint -,
    \<lbrace>\<lambda>irq s. intStateIRQTable (ksInterruptState s) irq \<noteq> IRQInactive\<rbrace>"
   apply (simp add: preemptionPoint_def setWorkUnits_def modifyWorkUnits_def getWorkUnits_def)
-  apply (wp hoare_whenE_wp|wpc)+
+  apply (wp whenE_wp|wpc)+
      apply (rule hoare_post_imp)
       prefer 2
      apply (rule doMachineOp_getActiveIRQ_IRQ_active)

--- a/proof/refine/ARM_HYP/Tcb_R.thy
+++ b/proof/refine/ARM_HYP/Tcb_R.thy
@@ -83,7 +83,7 @@ lemma gts_st_tcb':
   apply (rule hoare_vcg_precond_imp)
    apply (rule hoare_post_imp[where Q="\<lambda>rv s. \<exists>rv'. rv = rv' \<and> st_tcb_at' (\<lambda>st. st = rv') t s"])
     apply simp
-   apply (wp hoare_ex_wp)
+   apply (wp hoare_vcg_ex_lift)
   apply (clarsimp simp add: pred_tcb_at'_def obj_at'_def)
   done
 

--- a/proof/refine/ARM_HYP/Untyped_R.thy
+++ b/proof/refine/ARM_HYP/Untyped_R.thy
@@ -4066,11 +4066,11 @@ lemma valid_sched_etcbs[elim!]: "valid_sched_2 queues ekh sa cdom kh ct it \<Lon
   by (simp add: valid_sched_def)
 
 crunch ksIdleThread[wp]: deleteObjects "\<lambda>s. P (ksIdleThread s)"
-  (simp: crunch_simps wp: hoare_drop_imps hoare_unless_wp ignore: freeMemory)
+  (simp: crunch_simps wp: hoare_drop_imps unless_wp ignore: freeMemory)
 crunch ksCurDomain[wp]: deleteObjects "\<lambda>s. P (ksCurDomain s)"
-  (simp: crunch_simps wp: hoare_drop_imps hoare_unless_wp ignore: freeMemory)
+  (simp: crunch_simps wp: hoare_drop_imps unless_wp ignore: freeMemory)
 crunch irq_node[wp]: deleteObjects "\<lambda>s. P (irq_node' s)"
-  (simp: crunch_simps wp: hoare_drop_imps hoare_unless_wp ignore: freeMemory)
+  (simp: crunch_simps wp: hoare_drop_imps unless_wp ignore: freeMemory)
 
 lemma deleteObjects_ksCurThread[wp]:
   "\<lbrace>\<lambda>s. P (ksCurThread s)\<rbrace> deleteObjects ptr sz \<lbrace>\<lambda>_ s. P (ksCurThread s)\<rbrace>"
@@ -4625,7 +4625,7 @@ lemma whenE_reset_resetUntypedCap_invs_etc:
       and ct_active'
       and pspace_no_overlap' (if reset then ptr else ptr') sz\<rbrace>, \<lbrace>\<lambda>_. invs'\<rbrace>"
   apply (rule hoare_pre)
-   apply (wp hoare_whenE_wp resetUntypedCap_invs_etc[where idx=idx,
+   apply (wp whenE_wp resetUntypedCap_invs_etc[where idx=idx,
            simplified pred_conj_def conj_assoc]
        | simp)+
   apply (clarsimp simp: cte_wp_at_ctes_of)
@@ -5085,7 +5085,7 @@ lemma sts_valid_untyped_inv':
 
 crunch nosch[wp]: invokeUntyped "\<lambda>s. P (ksSchedulerAction s)"
   (simp: crunch_simps zipWithM_x_mapM
-     wp: crunch_wps hoare_unless_wp mapME_x_inv_wp preemptionPoint_inv)
+     wp: crunch_wps unless_wp mapME_x_inv_wp preemptionPoint_inv)
 
 crunch no_0_obj'[wp]: insertNewCap no_0_obj'
   (wp: crunch_wps)
@@ -5720,7 +5720,7 @@ lemma inv_untyped_IRQInactive:
   -, \<lbrace>\<lambda>rv s. intStateIRQTable (ksInterruptState s) rv \<noteq> irqstate.IRQInactive\<rbrace>"
   apply (simp add: invokeUntyped_def)
   apply (rule hoare_pre)
-   apply (wp hoare_whenE_wp resetUntypedCap_IRQInactive | wpc | simp)+
+   apply (wp whenE_wp resetUntypedCap_IRQInactive | wpc | simp)+
   done
 
 end

--- a/proof/refine/RISCV64/Arch_R.thy
+++ b/proof/refine/RISCV64/Arch_R.thy
@@ -78,7 +78,7 @@ lemma createObject_typ_at':
   supply
     is_aligned_neg_mask_eq[simp del]
     is_aligned_neg_mask_weaken[simp del]
-  apply (clarsimp simp:createObjects'_def alignError_def split_def | wp hoare_unless_wp | wpc )+
+  apply (clarsimp simp:createObjects'_def alignError_def split_def | wp unless_wp | wpc )+
   apply (clarsimp simp:obj_at'_def ko_wp_at'_def typ_at'_def pspace_distinct'_def)+
   apply (subgoal_tac "ps_clear ptr (objBitsKO ty)
     (s\<lparr>ksPSpace := \<lambda>a. if a = ptr then Some ty else ksPSpace s a\<rparr>)")
@@ -403,7 +403,7 @@ lemma checkVP_wpR [wp]:
   checkVPAlignment sz w \<lbrace>P\<rbrace>, -"
   apply (simp add: checkVPAlignment_def unlessE_whenE cong: vmpage_size.case_cong)
   apply (rule hoare_pre)
-   apply (wp hoare_whenE_wp|wpc)+
+   apply (wp whenE_wp|wpc)+
   apply (simp add: is_aligned_mask vmsz_aligned_def)
   done
 
@@ -687,7 +687,7 @@ lemma decodeX64PageTableInvocation_corres:
              apply (rule leq_mask_shift)
              apply (simp add: bit_simps le_mask_high_bits word_size)
             apply ((clarsimp cong: if_cong
-                     | wp hoare_whenE_wp hoare_vcg_all_lift_R getPTE_wp get_pte_wp
+                     | wp whenE_wp hoare_vcg_all_lift_R getPTE_wp get_pte_wp
                      | wp (once) hoare_drop_imps)+)
     apply (clarsimp simp: invs_vspace_objs invs_valid_asid_table invs_psp_aligned invs_distinct)
     apply (clarsimp simp: valid_cap_def wellformed_mapdata_def not_le below_user_vtop_in_user_region)
@@ -813,11 +813,11 @@ shows
                apply (simp add: returnOk_liftE[symmetric])
                apply (rule corres_returnOk)
                apply (simp add: archinv_relation_def asid_pool_invocation_map_def)
-              apply (rule hoare_pre, wp hoare_whenE_wp)
+              apply (rule hoare_pre, wp whenE_wp)
               apply (clarsimp simp: ucast_fst_hd_assocs)
-             apply (wp hoareE_TrueI hoare_whenE_wp getASID_wp | simp)+
+             apply (wp hoareE_TrueI whenE_wp getASID_wp | simp)+
           apply ((clarsimp simp: p2_low_bits_max | rule TrueI impI)+)[2]
-        apply (wp hoare_whenE_wp getASID_wp)+
+        apply (wp whenE_wp getASID_wp)+
       apply (auto simp: valid_cap_def)[1]
      apply auto[1]
     \<comment> \<open>ASIDControlCap\<close>

--- a/proof/refine/RISCV64/CNodeInv_R.thy
+++ b/proof/refine/RISCV64/CNodeInv_R.thy
@@ -8865,7 +8865,7 @@ declare withoutPreemption_lift [wp]
 crunch irq_states' [wp]: capSwapForDelete valid_irq_states'
 
 crunch irq_states' [wp]: finaliseCap valid_irq_states'
-  (wp: crunch_wps hoare_unless_wp getASID_wp no_irq_setVSpaceRoot no_irq_hwASIDFlush
+  (wp: crunch_wps unless_wp getASID_wp no_irq_setVSpaceRoot no_irq_hwASIDFlush
    simp: crunch_simps o_def pteAtIndex_def)
 
 lemma finaliseSlot_IRQInactive':
@@ -8909,7 +8909,7 @@ lemma cteDelete_IRQInactive:
   "\<lbrace>valid_irq_states'\<rbrace> cteDelete x y
   -, \<lbrace>\<lambda>rv s. intStateIRQTable (ksInterruptState s) rv \<noteq> irqstate.IRQInactive\<rbrace>"
   apply (simp add: cteDelete_def split_def)
-  apply (wp hoare_whenE_wp)
+  apply (wp whenE_wp)
    apply (rule hoare_post_impErr)
      apply (rule validE_E_validE)
      apply (rule finaliseSlot_IRQInactive)
@@ -8922,7 +8922,7 @@ lemma cteDelete_irq_states':
   "\<lbrace>valid_irq_states'\<rbrace> cteDelete x y
   \<lbrace>\<lambda>rv. valid_irq_states'\<rbrace>"
   apply (simp add: cteDelete_def split_def)
-  apply (wp hoare_whenE_wp)
+  apply (wp whenE_wp)
    apply (rule hoare_post_impErr)
      apply (rule hoare_valid_validE)
      apply (rule finaliseSlot_irq_states')
@@ -8946,7 +8946,7 @@ proof (induct rule: cteRevoke.induct)
   case (1 p s')
   show ?case
     apply (subst cteRevoke.simps)
-    apply (wp "1.hyps" unlessE_wp hoare_whenE_wp preemptionPoint_IRQInactive_spec
+    apply (wp "1.hyps" unlessE_wp whenE_wp preemptionPoint_IRQInactive_spec
               cteDelete_IRQInactive cteDelete_irq_states' getCTE_wp')+
     apply clarsimp
     done
@@ -8967,7 +8967,7 @@ lemma inv_cnode_IRQInactive:
   apply (rule hoare_pre)
    apply (wp cteRevoke_IRQInactive finaliseSlot_IRQInactive
              cteDelete_IRQInactive
-             hoare_whenE_wp
+             whenE_wp
            | wpc
            | simp add:  split_def)+
   done

--- a/proof/refine/RISCV64/CNodeInv_R.thy
+++ b/proof/refine/RISCV64/CNodeInv_R.thy
@@ -4891,7 +4891,7 @@ lemma cteSwap_valid_pspace'[wp]:
          apply (strengthen imp_consequent, strengthen ctes_of_strng)
          apply ((wp sch_act_wf_lift valid_queues_lift
                     cur_tcb_lift updateCap_no_0  updateCap_ctes_of_wp
-                    hoare_ex_wp getCTE_wp
+                    hoare_vcg_ex_lift getCTE_wp
                   | simp add: cte_wp_at_ctes_ofI o_def
                   | rule hoare_drop_imps)+)[6]
   apply (clarsimp simp: valid_pspace_no_0[unfolded valid_pspace'_def valid_mdb'_def]

--- a/proof/refine/RISCV64/CSpace_R.thy
+++ b/proof/refine/RISCV64/CSpace_R.thy
@@ -2950,7 +2950,7 @@ lemma setCTE_irq_states' [wp]:
   apply (wp setObject_ksMachine)
    apply (simp add: updateObject_cte)
    apply (rule hoare_pre)
-    apply (wp hoare_unless_wp|wpc|simp)+
+    apply (wp unless_wp|wpc|simp)+
    apply fastforce
   apply assumption
   done
@@ -3056,7 +3056,7 @@ lemma setCTE_ksMachine[wp]:
   apply (wp setObject_ksMachine)
   apply (clarsimp simp: updateObject_cte
                  split: Structures_H.kernel_object.splits)
-  apply (safe, (wp hoare_unless_wp | simp)+)
+  apply (safe, (wp unless_wp | simp)+)
   done
 
 crunch ksMachine[wp]: cteInsert "\<lambda>s. P (ksMachineState s)"

--- a/proof/refine/RISCV64/Detype_R.thy
+++ b/proof/refine/RISCV64/Detype_R.thy
@@ -3299,7 +3299,7 @@ proof -
      apply (drule_tac gbits = us in range_cover_not_zero_shift[rotated])
        apply simp+
      apply (simp add:word_le_sub1)
-    apply (wp haskell_assert_wp hoare_unless_wp | wpc
+    apply (wp haskell_assert_wp unless_wp | wpc
         | simp add:alignError_def if_apply_def2 del: fun_upd_apply hoare_fail_any)+
     apply (rule impI)
     apply (subgoal_tac
@@ -3814,7 +3814,7 @@ lemma createObjects_Cons:
         apply simp
        apply (wp haskell_assert_wp | wpc)+
       apply simp
-     apply (wp hoare_unless_wp |clarsimp)+
+     apply (wp unless_wp |clarsimp)+
   apply (drule range_cover.aligned)
   apply (simp add:is_aligned_mask)
   done
@@ -4066,7 +4066,7 @@ proof -
    apply (drule_tac gbits = us in range_cover_not_zero_shift[rotated])
     apply simp+
    apply (simp add:word_le_sub1)
-   apply (wp haskell_assert_wp hoare_unless_wp |wpc
+   apply (wp haskell_assert_wp unless_wp |wpc
          |simp add:alignError_def del:fun_upd_apply)+
   apply (rule conjI)
    apply (rule impI)
@@ -4126,7 +4126,7 @@ lemma createTCBs_tcb_at':
   \<lbrace>\<lambda>rv s.
   (\<forall>x\<in>set [0.e.of_nat n]. tcb_at' (ptr + x * 2^tcbBlockSizeBits) s)\<rbrace>"
   apply (simp add:createObjects'_def split_def alignError_def)
-  apply (wp hoare_unless_wp |wpc)+
+  apply (wp unless_wp |wpc)+
   apply (subst data_map_insert_def[symmetric])+
   apply clarsimp
   apply (subgoal_tac "(\<forall>x\<le>of_nat n.
@@ -4787,7 +4787,7 @@ lemma createObject_pspace_aligned_distinct':
   createObject ty ptr us d
   \<lbrace>\<lambda>xa s. pspace_aligned' s \<and> pspace_distinct' s\<rbrace>"
   apply (rule hoare_pre)
-   apply (wp placeNewObject_pspace_aligned' hoare_unless_wp
+   apply (wp placeNewObject_pspace_aligned' unless_wp
              placeNewObject_pspace_distinct'
           | simp add: RISCV64_H.createObject_def Retype_H.createObject_def objBits_simps
                       curDomain_def placeNewDataObject_def

--- a/proof/refine/RISCV64/Finalise_R.thy
+++ b/proof/refine/RISCV64/Finalise_R.thy
@@ -2750,7 +2750,7 @@ crunch valid_cap'[wp]: prepareThreadDelete "valid_cap' cap"
 crunch invs[wp]: prepareThreadDelete "invs'" (ignore: doMachineOp)
 crunch obj_at'[wp]: prepareThreadDelete
   "\<lambda>s. P' (obj_at' P p s)"
-  (wp: hoare_whenE_wp simp: crunch_simps)
+  (wp: whenE_wp simp: crunch_simps)
 
 end
 

--- a/proof/refine/RISCV64/InterruptAcc_R.thy
+++ b/proof/refine/RISCV64/InterruptAcc_R.thy
@@ -113,7 +113,7 @@ lemma preemptionPoint_inv:
   shows "\<lbrace>P\<rbrace> preemptionPoint \<lbrace>\<lambda>_. P\<rbrace>" using assms
   apply (simp add: preemptionPoint_def setWorkUnits_def getWorkUnits_def modifyWorkUnits_def)
   apply (wpc
-          | wp hoare_whenE_wp hoare_seq_ext [OF _ select_inv] alternative_valid hoare_drop_imps
+          | wp whenE_wp hoare_seq_ext [OF _ select_inv] alternative_valid hoare_drop_imps
           | simp)+
   done
 

--- a/proof/refine/RISCV64/Interrupt_R.thy
+++ b/proof/refine/RISCV64/Interrupt_R.thy
@@ -612,7 +612,7 @@ lemma decDomainTime_corres:
 lemma tcbSchedAppend_valid_objs':
   "\<lbrace>valid_objs'\<rbrace>tcbSchedAppend t \<lbrace>\<lambda>r. valid_objs'\<rbrace>"
   apply (simp add:tcbSchedAppend_def)
-  apply (wpsimp wp: hoare_unless_wp threadSet_valid_objs' threadGet_wp)
+  apply (wpsimp wp: unless_wp threadSet_valid_objs' threadGet_wp)
   apply (clarsimp simp add:obj_at'_def typ_at'_def)
   done
 
@@ -762,10 +762,10 @@ lemma threadSet_ksDomainTime[wp]:
   done
 
 crunch ksDomainTime[wp]: rescheduleRequired "\<lambda>s. P (ksDomainTime s)"
-(simp:tcbSchedEnqueue_def wp:hoare_unless_wp)
+(simp:tcbSchedEnqueue_def wp:unless_wp)
 
 crunch ksDomainTime[wp]: tcbSchedAppend "\<lambda>s. P (ksDomainTime s)"
-(simp:tcbSchedEnqueue_def wp:hoare_unless_wp)
+(simp:tcbSchedEnqueue_def wp:unless_wp)
 
 lemma updateTimeSlice_valid_pspace[wp]:
   "\<lbrace>valid_pspace'\<rbrace> threadSet (tcbTimeSlice_update (\<lambda>_. ts')) thread

--- a/proof/refine/RISCV64/KHeap_R.thy
+++ b/proof/refine/RISCV64/KHeap_R.thy
@@ -183,7 +183,7 @@ lemma obj_at_setObject1:
    setObject p (v::'a::pspace_storable)
   \<lbrace> \<lambda>rv. obj_at' (\<lambda>x::'a::pspace_storable. True) t \<rbrace>"
   apply (simp add: setObject_def split_def)
-  apply (rule hoare_seq_ext [OF _ hoare_gets_post])
+  apply (rule hoare_seq_ext [OF _ hoare_gets_sp])
   apply (clarsimp simp: valid_def in_monad obj_at'_def lookupAround2_char1 project_inject
                  dest!: R)
   apply (subgoal_tac "objBitsKO (injectKO v) = objBitsKO (injectKO obj)")
@@ -203,7 +203,7 @@ lemma obj_at_setObject2:
    setObject p (v::'a)
   \<lbrace> \<lambda>rv. obj_at' P t \<rbrace>"
   apply (simp add: setObject_def split_def)
-  apply (rule hoare_seq_ext [OF _ hoare_gets_post])
+  apply (rule hoare_seq_ext [OF _ hoare_gets_sp])
   apply (clarsimp simp: valid_def in_monad)
   apply (frule updateObject_type)
   apply (drule R)

--- a/proof/refine/RISCV64/PageTableDuplicates.thy
+++ b/proof/refine/RISCV64/PageTableDuplicates.thy
@@ -22,7 +22,7 @@ lemma foldr_data_map_insert[simp]:
 
 crunch arch_inv[wp]: resetUntypedCap "\<lambda>s. P (ksArchState s)"
   (simp: crunch_simps
-     wp: hoare_drop_imps hoare_unless_wp mapME_x_inv_wp
+     wp: hoare_drop_imps unless_wp mapME_x_inv_wp
          preemptionPoint_inv)
 
 lemma mapM_x_mapM_valid:

--- a/proof/refine/RISCV64/Retype_R.thy
+++ b/proof/refine/RISCV64/Retype_R.thy
@@ -4159,7 +4159,7 @@ lemma createNewCaps_irq_handlers':
 lemma createObjects'_irq_states' [wp]:
   "\<lbrace>valid_irq_states'\<rbrace> createObjects' a b c d \<lbrace>\<lambda>_. valid_irq_states'\<rbrace>"
   apply (simp add: createObjects'_def split_def)
-  apply (wp hoare_unless_wp|wpc|simp add: alignError_def)+
+  apply (wp unless_wp|wpc|simp add: alignError_def)+
   apply fastforce
   done
 
@@ -4432,7 +4432,7 @@ lemma createObjects_null_filter':
    createObjects' ptr n val gbits
    \<lbrace>\<lambda>addrs a. P (null_filter' (ctes_of a))\<rbrace>"
    apply (clarsimp simp: createObjects'_def split_def)
-   apply (wp hoare_unless_wp|wpc
+   apply (wp unless_wp|wpc
           | clarsimp simp: alignError_def split del: if_split simp del:fun_upd_apply)+
    apply (subst new_cap_addrs_fold')
      apply (simp add:unat_1_0 unat_gt_0)

--- a/proof/refine/RISCV64/Retype_R.thy
+++ b/proof/refine/RISCV64/Retype_R.thy
@@ -57,8 +57,6 @@ lemma objBitsKO_bounded2[simp]:
   by (simp add: objBits_simps' word_bits_def bit_simps
          split: Structures_H.kernel_object.split arch_kernel_object.split)
 
-declare select_singleton_is_return[simp]
-
 definition
   APIType_capBits :: "RISCV64_H.object_type \<Rightarrow> nat \<Rightarrow> nat"
 where

--- a/proof/refine/RISCV64/Schedule_R.thy
+++ b/proof/refine/RISCV64/Schedule_R.thy
@@ -475,7 +475,7 @@ lemma tcbSchedAppend_sch_act_wf[wp]:
   "\<lbrace>\<lambda>s. sch_act_wf (ksSchedulerAction s) s\<rbrace> tcbSchedAppend thread
   \<lbrace>\<lambda>rv s. sch_act_wf (ksSchedulerAction s) s\<rbrace>"
   apply (simp add:tcbSchedAppend_def bitmap_fun_defs)
-  apply (wp hoare_unless_wp setQueue_sch_act threadGet_wp|simp)+
+  apply (wp unless_wp setQueue_sch_act threadGet_wp|simp)+
   apply (fastforce simp:typ_at'_def obj_at'_def)
   done
 

--- a/proof/refine/RISCV64/Syscall_R.thy
+++ b/proof/refine/RISCV64/Syscall_R.thy
@@ -860,9 +860,9 @@ lemma valid_irq_node_tcbSchedEnqueue[wp]:
   \<lbrace>\<lambda>rv s'. valid_irq_node' (irq_node' s') s'\<rbrace>"
   apply (rule hoare_pre)
   apply (simp add:valid_irq_node'_def )
-  apply (wp hoare_unless_wp hoare_vcg_all_lift | wps)+
+  apply (wp unless_wp hoare_vcg_all_lift | wps)+
   apply (simp add:tcbSchedEnqueue_def)
-  apply (wp hoare_unless_wp| simp)+
+  apply (wp unless_wp| simp)+
   apply (simp add:valid_irq_node'_def)
   done
 
@@ -976,7 +976,7 @@ lemma setDomain_invs':
   (\<lambda>y. domain \<le> maxDomain))\<rbrace>
   setDomain ptr domain \<lbrace>\<lambda>y. invs'\<rbrace>"
   apply (simp add:setDomain_def )
-  apply (wp add: hoare_when_wp static_imp_wp static_imp_conj_wp rescheduleRequired_all_invs_but_extra
+  apply (wp add: when_wp static_imp_wp static_imp_conj_wp rescheduleRequired_all_invs_but_extra
                  tcbSchedEnqueue_valid_action hoare_vcg_if_lift2)
      apply (rule_tac Q = "\<lambda>r s. all_invs_but_sch_extra s \<and> curThread = ksCurThread s
       \<and> (ptr \<noteq> curThread \<longrightarrow> ct_not_inQ s \<and> sch_act_wf (ksSchedulerAction s) s \<and> ct_idle_or_in_cur_domain' s)"

--- a/proof/refine/RISCV64/TcbAcc_R.thy
+++ b/proof/refine/RISCV64/TcbAcc_R.thy
@@ -267,7 +267,7 @@ lemma preemptionPoint_irq [wp]:
   "\<lbrace>valid_irq_states'\<rbrace> preemptionPoint -,
    \<lbrace>\<lambda>irq s. intStateIRQTable (ksInterruptState s) irq \<noteq> IRQInactive\<rbrace>"
   apply (simp add: preemptionPoint_def setWorkUnits_def modifyWorkUnits_def getWorkUnits_def)
-  apply (wp hoare_whenE_wp|wpc)+
+  apply (wp whenE_wp|wpc)+
      apply (rule hoare_post_imp)
       prefer 2
      apply (rule doMachineOp_getActiveIRQ_IRQ_active)

--- a/proof/refine/RISCV64/Tcb_R.thy
+++ b/proof/refine/RISCV64/Tcb_R.thy
@@ -83,7 +83,7 @@ lemma gts_st_tcb':
   apply (rule hoare_vcg_precond_imp)
    apply (rule hoare_post_imp[where Q="\<lambda>rv s. \<exists>rv'. rv = rv' \<and> st_tcb_at' (\<lambda>st. st = rv') t s"])
     apply simp
-   apply (wp hoare_ex_wp)
+   apply (wp hoare_vcg_ex_lift)
   apply (clarsimp simp add: pred_tcb_at'_def obj_at'_def)
   done
 

--- a/proof/refine/RISCV64/Untyped_R.thy
+++ b/proof/refine/RISCV64/Untyped_R.thy
@@ -4052,11 +4052,11 @@ lemma valid_sched_etcbs[elim!]: "valid_sched_2 queues ekh sa cdom kh ct it \<Lon
   by (simp add: valid_sched_def)
 
 crunch ksIdleThread[wp]: deleteObjects "\<lambda>s. P (ksIdleThread s)"
-  (simp: crunch_simps wp: hoare_drop_imps hoare_unless_wp)
+  (simp: crunch_simps wp: hoare_drop_imps unless_wp)
 crunch ksCurDomain[wp]: deleteObjects "\<lambda>s. P (ksCurDomain s)"
-  (simp: crunch_simps wp: hoare_drop_imps hoare_unless_wp)
+  (simp: crunch_simps wp: hoare_drop_imps unless_wp)
 crunch irq_node[wp]: deleteObjects "\<lambda>s. P (irq_node' s)"
-  (simp: crunch_simps wp: hoare_drop_imps hoare_unless_wp)
+  (simp: crunch_simps wp: hoare_drop_imps unless_wp)
 
 lemma deleteObjects_ksCurThread[wp]:
   "\<lbrace>\<lambda>s. P (ksCurThread s)\<rbrace> deleteObjects ptr sz \<lbrace>\<lambda>_ s. P (ksCurThread s)\<rbrace>"
@@ -4598,7 +4598,7 @@ lemma whenE_reset_resetUntypedCap_invs_etc:
       and ct_active'
       and pspace_no_overlap' (if reset then ptr else ptr') sz\<rbrace>, \<lbrace>\<lambda>_. invs'\<rbrace>"
   apply (rule hoare_pre)
-   apply (wp hoare_whenE_wp resetUntypedCap_invs_etc[where idx=idx,
+   apply (wp whenE_wp resetUntypedCap_invs_etc[where idx=idx,
            simplified pred_conj_def conj_assoc]
        | simp)+
   apply (clarsimp simp: cte_wp_at_ctes_of)
@@ -5071,7 +5071,7 @@ lemma sts_valid_untyped_inv':
 
 crunch nosch[wp]: invokeUntyped "\<lambda>s. P (ksSchedulerAction s)"
   (simp: crunch_simps zipWithM_x_mapM
-     wp: crunch_wps hoare_unless_wp mapME_x_inv_wp preemptionPoint_inv)
+     wp: crunch_wps unless_wp mapME_x_inv_wp preemptionPoint_inv)
 
 crunch no_0_obj'[wp]: insertNewCap no_0_obj'
   (wp: crunch_wps)
@@ -5669,7 +5669,7 @@ lemma inv_untyped_IRQInactive:
    invokeUntyped ui
    -, \<lbrace>\<lambda>rv s. intStateIRQTable (ksInterruptState s) rv \<noteq> irqstate.IRQInactive\<rbrace>"
   unfolding invokeUntyped_def
-  by (wpsimp wp: hoare_whenE_wp resetUntypedCap_IRQInactive)
+  by (wpsimp wp: whenE_wp resetUntypedCap_IRQInactive)
 
 end
 end

--- a/proof/refine/RISCV64/VSpace_R.thy
+++ b/proof/refine/RISCV64/VSpace_R.thy
@@ -794,13 +794,13 @@ lemma dmo_setVSpaceRoot_invs_no_cicd'[wp]:
 lemma setVMRoot_invs [wp]:
   "setVMRoot p \<lbrace>invs'\<rbrace>"
   unfolding setVMRoot_def getThreadVSpaceRoot_def
-  by (wpsimp wp: hoare_whenE_wp findVSpaceForASID_vs_at_wp hoare_drop_imps hoare_vcg_ex_lift
+  by (wpsimp wp: whenE_wp findVSpaceForASID_vs_at_wp hoare_drop_imps hoare_vcg_ex_lift
                  hoare_vcg_all_lift)
 
 lemma setVMRoot_invs_no_cicd':
   "\<lbrace>invs_no_cicd'\<rbrace> setVMRoot p \<lbrace>\<lambda>rv. invs_no_cicd'\<rbrace>"
   unfolding setVMRoot_def getThreadVSpaceRoot_def
-  by (wpsimp wp: hoare_whenE_wp findVSpaceForASID_vs_at_wp hoare_drop_imps hoare_vcg_ex_lift
+  by (wpsimp wp: whenE_wp findVSpaceForASID_vs_at_wp hoare_drop_imps hoare_vcg_ex_lift
                  hoare_vcg_all_lift)
 
 crunch nosch [wp]: setVMRoot "\<lambda>s. P (ksSchedulerAction s)"

--- a/proof/refine/RISCV64/orphanage/Orphanage.thy
+++ b/proof/refine/RISCV64/orphanage/Orphanage.thy
@@ -144,7 +144,7 @@ lemma ksQ_all_queued_tcb_ptrs_lift:
   shows "\<lbrace>\<lambda>s. P (t \<in> all_queued_tcb_ptrs s)\<rbrace> f \<lbrace>\<lambda>_ s. P (t \<in> all_queued_tcb_ptrs s)\<rbrace>"
   apply (clarsimp simp: all_queued_tcb_ptrs_def)
   apply (rule_tac P=P in P_bool_lift)
-   apply (wp hoare_ex_wp assms)
+   apply (wp hoare_vcg_ex_lift assms)
   apply (clarsimp)
   apply (wp hoare_vcg_all_lift assms)
   done
@@ -644,7 +644,7 @@ lemma tcbSchedDequeue_all_queued_tcb_ptrs:
   apply (clarsimp simp: tcbSchedDequeue_def all_queued_tcb_ptrs_def)
   apply (rule hoare_pre)
    apply (wp, clarsimp)
-       apply (wp hoare_ex_wp)+
+       apply (wp hoare_vcg_ex_lift)+
      apply (rename_tac d p)
      apply (rule_tac Q="\<lambda>_ s. x \<in> set (ksReadyQueues s (d, p))"
                      in hoare_post_imp, clarsimp)
@@ -733,7 +733,7 @@ lemma findM_on_success:
   apply (induct xs; clarsimp)
   apply wp+
   apply (clarsimp simp: imp_conv_disj Bex_def)
-  apply (wp hoare_vcg_disj_lift hoare_ex_wp | clarsimp | assumption)+
+  apply (wp hoare_vcg_disj_lift hoare_vcg_ex_lift | clarsimp | assumption)+
   done
 
 crunch st_tcb' [wp]: switchToThread "\<lambda>s. P' (st_tcb_at' P t s)"
@@ -755,7 +755,7 @@ lemma tcbSchedDequeue_not_empty:
    \<lbrace> \<lambda>rv s. \<exists>tcb. tcb \<in> set (ksReadyQueues s p) \<and> st_tcb_at' P tcb s \<rbrace>"
   unfolding tcbSchedDequeue_def
   apply wp
-         apply (wp hoare_ex_wp threadSet_pred_tcb_no_state)
+         apply (wp hoare_vcg_ex_lift threadSet_pred_tcb_no_state)
          apply clarsimp
         apply (wp setQueue_deq_not_empty)
        apply clarsimp
@@ -2160,7 +2160,7 @@ lemma performASIDControlInvocation_no_orphans [wp]:
   apply (strengthen invs_pspace_aligned' invs_pspace_distinct' invs_valid_pspace')
   apply (clarsimp simp:conj_comms)
      apply (wp deleteObjects_invs'[where idx = idx and d=False]
-       hoare_ex_wp deleteObjects_cte_wp_at'[where idx = idx and d=False] hoare_vcg_const_imp_lift )
+       hoare_vcg_ex_lift deleteObjects_cte_wp_at'[where idx = idx and d=False] hoare_vcg_const_imp_lift )
   using invs' misc cte exclude no_orphans cover
   apply (clarsimp simp: is_active_thread_state_def makeObject_tcb valid_aci'_def
                         cte_wp_at_ctes_of invs_pspace_aligned' invs_pspace_distinct'

--- a/proof/refine/RISCV64/orphanage/Orphanage.thy
+++ b/proof/refine/RISCV64/orphanage/Orphanage.thy
@@ -2058,7 +2058,7 @@ lemma invokeCNode_no_orphans [wp]:
    \<lbrace> \<lambda>rv. no_orphans \<rbrace>"
   unfolding invokeCNode_def
   apply (rule hoare_pre)
-   apply (wp hoare_drop_imps hoare_unless_wp | wpc | clarsimp split del: if_split)+
+   apply (wp hoare_drop_imps unless_wp | wpc | clarsimp split del: if_split)+
   apply (simp add: invs_valid_queues')
   done
 

--- a/proof/refine/X64/Arch_R.thy
+++ b/proof/refine/X64/Arch_R.thy
@@ -75,7 +75,7 @@ lemma createObject_typ_at':
   supply
     is_aligned_neg_mask_eq[simp del]
     is_aligned_neg_mask_weaken[simp del]
-  apply (clarsimp simp:createObjects'_def alignError_def split_def | wp hoare_unless_wp | wpc )+
+  apply (clarsimp simp:createObjects'_def alignError_def split_def | wp unless_wp | wpc )+
   apply (clarsimp simp:obj_at'_def ko_wp_at'_def typ_at'_def pspace_distinct'_def)+
   apply (subgoal_tac "ps_clear ptr (objBitsKO ty)
     (s\<lparr>ksPSpace := \<lambda>a. if a = ptr then Some ty else ksPSpace s a\<rparr>)")
@@ -453,7 +453,7 @@ lemma checkVP_wpR [wp]:
   "\<lbrace>\<lambda>s. vmsz_aligned w sz \<longrightarrow> P () s\<rbrace>
   checkVPAlignment sz w \<lbrace>P\<rbrace>, -"
   apply (simp add: checkVPAlignment_def)
-  by (wpsimp wp: hoare_whenE_wp simp: is_aligned_mask vmsz_aligned_def)
+  by (wpsimp wp: whenE_wp simp: is_aligned_mask vmsz_aligned_def)
 
 lemma asidHighBits [simp]:
   "asidHighBits = asid_high_bits"
@@ -703,7 +703,7 @@ lemma decodeX64PageTableInvocation_corres:
              apply (clarsimp simp: attribs_from_word_def filter_frame_attrs_def
                                    attribsFromWord_def Let_def)
             apply ((clarsimp cong: if_cong
-                     | wp hoare_whenE_wp hoare_vcg_all_lift_R getPDE_wp get_pde_wp
+                     | wp whenE_wp hoare_vcg_all_lift_R getPDE_wp get_pde_wp
                      | wp (once) hoare_drop_imps)+)[6]
       apply (clarsimp intro!: validE_R_validE)
       apply (rule_tac Q'="\<lambda>rv s.  pspace_aligned s \<and> valid_vspace_objs s \<and> valid_arch_state s \<and>
@@ -794,7 +794,7 @@ lemma decodeX64PageDirectoryInvocation_corres:
              apply (clarsimp simp: attribs_from_word_def filter_frame_attrs_def
                                    attribsFromWord_def Let_def)
             apply ((clarsimp cong: if_cong
-                        | wp hoare_whenE_wp hoare_vcg_all_lift_R getPDPTE_wp get_pdpte_wp
+                        | wp whenE_wp hoare_vcg_all_lift_R getPDPTE_wp get_pdpte_wp
                         | wp (once) hoare_drop_imps)+)[6]
       apply (clarsimp intro!: validE_R_validE)
       apply (rule_tac Q'="\<lambda>rv s.  pspace_aligned s \<and> valid_vspace_objs s \<and> valid_arch_state s \<and>
@@ -882,7 +882,7 @@ lemma decodeX64PDPointerTableInvocation_corres:
              apply (clarsimp simp: attribs_from_word_def filter_frame_attrs_def
                                    attribsFromWord_def Let_def)
             apply ((clarsimp cong: if_cong
-                    | wp hoare_whenE_wp hoare_vcg_all_lift_R getPML4E_wp get_pml4e_wp
+                    | wp whenE_wp hoare_vcg_all_lift_R getPML4E_wp get_pml4e_wp
                     | wp (once) hoare_drop_imps)+)
     apply (fastforce simp: valid_cap_def mask_def intro!: page_map_l4_pml4e_at_lookupI)
    apply (clarsimp simp: valid_cap'_def)
@@ -1161,11 +1161,11 @@ shows
                 apply (simp add: returnOk_liftE[symmetric])
                 apply (rule corres_returnOk)
                 apply (simp add: archinv_relation_def asid_pool_invocation_map_def)
-               apply (rule hoare_pre, wp hoare_whenE_wp)
+               apply (rule hoare_pre, wp whenE_wp)
                apply (clarsimp simp: ucast_fst_hd_assocs)
-              apply (wp hoareE_TrueI hoare_whenE_wp getASID_wp | simp)+
+              apply (wp hoareE_TrueI whenE_wp getASID_wp | simp)+
            apply ((clarsimp simp: p2_low_bits_max | rule TrueI impI)+)[2]
-         apply (wp hoare_whenE_wp getASID_wp)+
+         apply (wp whenE_wp getASID_wp)+
        apply (clarsimp simp: valid_cap_def)
       apply auto[1]
      \<comment> \<open>ASIDControlCap\<close>

--- a/proof/refine/X64/CNodeInv_R.thy
+++ b/proof/refine/X64/CNodeInv_R.thy
@@ -9071,7 +9071,7 @@ declare withoutPreemption_lift [wp]
 crunch irq_states' [wp]: capSwapForDelete valid_irq_states'
 
 crunch irq_states' [wp]: finaliseCap valid_irq_states'
-  (wp: crunch_wps hoare_unless_wp getASID_wp no_irq
+  (wp: crunch_wps unless_wp getASID_wp no_irq
        no_irq_writeCR3 no_irq_invalidateASID
        no_irq_invalidateLocalPageStructureCacheASID
        no_irq_switchFpuOwner no_irq_nativeThreadUsingFPU
@@ -9118,7 +9118,7 @@ lemma cteDelete_IRQInactive:
   "\<lbrace>valid_irq_states'\<rbrace> cteDelete x y
   -, \<lbrace>\<lambda>rv s. intStateIRQTable (ksInterruptState s) rv \<noteq> irqstate.IRQInactive\<rbrace>"
   apply (simp add: cteDelete_def split_def)
-  apply (wp hoare_whenE_wp)
+  apply (wp whenE_wp)
    apply (rule hoare_post_impErr)
      apply (rule validE_E_validE)
      apply (rule finaliseSlot_IRQInactive)
@@ -9131,7 +9131,7 @@ lemma cteDelete_irq_states':
   "\<lbrace>valid_irq_states'\<rbrace> cteDelete x y
   \<lbrace>\<lambda>rv. valid_irq_states'\<rbrace>"
   apply (simp add: cteDelete_def split_def)
-  apply (wp hoare_whenE_wp)
+  apply (wp whenE_wp)
    apply (rule hoare_post_impErr)
      apply (rule hoare_valid_validE)
      apply (rule finaliseSlot_irq_states')
@@ -9155,7 +9155,7 @@ proof (induct rule: cteRevoke.induct)
   case (1 p s')
   show ?case
     apply (subst cteRevoke.simps)
-    apply (wp "1.hyps" unlessE_wp hoare_whenE_wp preemptionPoint_IRQInactive_spec
+    apply (wp "1.hyps" unlessE_wp whenE_wp preemptionPoint_IRQInactive_spec
               cteDelete_IRQInactive cteDelete_irq_states' getCTE_wp')+
     apply clarsimp
     done
@@ -9176,7 +9176,7 @@ lemma inv_cnode_IRQInactive:
   apply (rule hoare_pre)
    apply (wp cteRevoke_IRQInactive finaliseSlot_IRQInactive
              cteDelete_IRQInactive
-             hoare_whenE_wp
+             whenE_wp
            | wpc
            | simp add:  split_def)+
   done

--- a/proof/refine/X64/CNodeInv_R.thy
+++ b/proof/refine/X64/CNodeInv_R.thy
@@ -4936,7 +4936,7 @@ lemma cteSwap_valid_pspace'[wp]:
          apply (strengthen imp_consequent, strengthen ctes_of_strng)
          apply ((wp sch_act_wf_lift valid_queues_lift
                     cur_tcb_lift updateCap_no_0  updateCap_ctes_of_wp
-                    hoare_ex_wp getCTE_wp
+                    hoare_vcg_ex_lift getCTE_wp
                   | simp add: cte_wp_at_ctes_ofI o_def
                   | rule hoare_drop_imps)+)[6]
   apply (clarsimp simp: valid_pspace_no_0[unfolded valid_pspace'_def valid_mdb'_def]

--- a/proof/refine/X64/CSpace_R.thy
+++ b/proof/refine/X64/CSpace_R.thy
@@ -3125,7 +3125,7 @@ lemma setCTE_irq_states' [wp]:
   apply (wp setObject_ksMachine)
    apply (simp add: updateObject_cte)
    apply (rule hoare_pre)
-    apply (wp hoare_unless_wp|wpc|simp)+
+    apply (wp unless_wp|wpc|simp)+
    apply fastforce
   apply assumption
   done
@@ -3237,7 +3237,7 @@ lemma setCTE_ksMachine[wp]:
   apply (wp setObject_ksMachine)
   apply (clarsimp simp: updateObject_cte
                  split: Structures_H.kernel_object.splits)
-  apply (safe, (wp hoare_unless_wp | simp)+)
+  apply (safe, (wp unless_wp | simp)+)
   done
 
 crunch ksMachine[wp]: cteInsert "\<lambda>s. P (ksMachineState s)"

--- a/proof/refine/X64/Detype_R.thy
+++ b/proof/refine/X64/Detype_R.thy
@@ -3553,7 +3553,7 @@ lemma placeNewObject_tcb_at':
          placeNewObject ptr (makeObject::tcb) 0
          \<lbrace>\<lambda>_ s. tcb_at' ptr s \<rbrace>"
   apply (simp add: placeNewObject_def placeNewObject'_def split_def)
-  apply (wp hoare_unless_wp |wpc | simp add:alignError_def)+
+  apply (wp unless_wp |wpc | simp add:alignError_def)+
   by (auto simp: obj_at'_def is_aligned_mask lookupAround2_None1
                     lookupAround2_char1 field_simps objBits_simps
                     projectKO_opt_tcb projectKO_def return_def ps_clear_def
@@ -4001,7 +4001,7 @@ proof -
      apply (drule_tac gbits = us in range_cover_not_zero_shift[rotated])
        apply simp+
      apply (simp add:word_le_sub1)
-    apply (wp haskell_assert_wp hoare_unless_wp | wpc
+    apply (wp haskell_assert_wp unless_wp | wpc
         | simp add:alignError_def if_apply_def2 del: fun_upd_apply hoare_fail_any)+
     apply (rule impI)
     apply (subgoal_tac
@@ -4547,7 +4547,7 @@ lemma createObjects_Cons:
         apply simp
        apply (wp haskell_assert_wp | wpc)+
       apply simp
-     apply (wp hoare_unless_wp |clarsimp)+
+     apply (wp unless_wp |clarsimp)+
   apply (drule range_cover.aligned)
   apply (simp add:is_aligned_mask)
   done
@@ -4831,7 +4831,7 @@ proof -
    apply (drule_tac gbits = us in range_cover_not_zero_shift[rotated])
     apply simp+
    apply (simp add:word_le_sub1)
-   apply (wp haskell_assert_wp hoare_unless_wp |wpc
+   apply (wp haskell_assert_wp unless_wp |wpc
          |simp add:alignError_def del:fun_upd_apply)+
   apply (rule conjI)
    apply (rule impI)
@@ -4893,7 +4893,7 @@ lemma createTCBs_tcb_at':
   \<lbrace>\<lambda>rv s.
   (\<forall>x\<in>set [0.e.of_nat n]. tcb_at' (ptr + x * 2^tcbBlockSizeBits) s)\<rbrace>"
   apply (simp add:createObjects'_def split_def alignError_def)
-  apply (wp hoare_unless_wp |wpc)+
+  apply (wp unless_wp |wpc)+
   apply (subst data_map_insert_def[symmetric])+
   apply clarsimp
   apply (subgoal_tac "(\<forall>x\<le>of_nat n.
@@ -5704,7 +5704,7 @@ lemma createObject_pspace_aligned_distinct':
   createObject ty ptr us d
   \<lbrace>\<lambda>xa s. pspace_aligned' s \<and> pspace_distinct' s\<rbrace>"
   apply (rule hoare_pre)
-  apply (wp placeNewObject_pspace_aligned' hoare_unless_wp
+  apply (wp placeNewObject_pspace_aligned' unless_wp
       placeNewObject_pspace_distinct'
     | simp add:X64_H.createObject_def
       Retype_H.createObject_def objBits_simps

--- a/proof/refine/X64/Finalise_R.thy
+++ b/proof/refine/X64/Finalise_R.thy
@@ -2920,7 +2920,7 @@ crunch valid_cap'[wp]: prepareThreadDelete "valid_cap' cap"
 crunch invs[wp]: prepareThreadDelete "invs'" (ignore: doMachineOp)
 crunch obj_at'[wp]: prepareThreadDelete
   "\<lambda>s. P' (obj_at' P p s)"
-  (wp: hoare_whenE_wp simp: crunch_simps)
+  (wp: whenE_wp simp: crunch_simps)
 
 end
 

--- a/proof/refine/X64/InterruptAcc_R.thy
+++ b/proof/refine/X64/InterruptAcc_R.thy
@@ -112,7 +112,7 @@ lemma preemptionPoint_inv:
   shows "\<lbrace>P\<rbrace> preemptionPoint \<lbrace>\<lambda>_. P\<rbrace>" using assms
   apply (simp add: preemptionPoint_def setWorkUnits_def getWorkUnits_def modifyWorkUnits_def)
   apply (wpc
-          | wp hoare_whenE_wp hoare_seq_ext [OF _ select_inv] alternative_valid hoare_drop_imps
+          | wp whenE_wp hoare_seq_ext [OF _ select_inv] alternative_valid hoare_drop_imps
           | simp)+
   done
 

--- a/proof/refine/X64/Interrupt_R.thy
+++ b/proof/refine/X64/Interrupt_R.thy
@@ -667,7 +667,7 @@ lemma decDomainTime_corres:
 lemma tcbSchedAppend_valid_objs':
   "\<lbrace>valid_objs'\<rbrace>tcbSchedAppend t \<lbrace>\<lambda>r. valid_objs'\<rbrace>"
   apply (simp add:tcbSchedAppend_def)
-  apply (wpsimp wp: hoare_unless_wp threadSet_valid_objs' threadGet_wp)
+  apply (wpsimp wp: unless_wp threadSet_valid_objs' threadGet_wp)
   apply (clarsimp simp add:obj_at'_def typ_at'_def)
   done
 
@@ -829,10 +829,10 @@ lemma threadSet_ksDomainTime[wp]:
   done
 
 crunch ksDomainTime[wp]: rescheduleRequired "\<lambda>s. P (ksDomainTime s)"
-(simp:tcbSchedEnqueue_def wp:hoare_unless_wp)
+(simp:tcbSchedEnqueue_def wp:unless_wp)
 
 crunch ksDomainTime[wp]: tcbSchedAppend "\<lambda>s. P (ksDomainTime s)"
-(simp:tcbSchedEnqueue_def wp:hoare_unless_wp)
+(simp:tcbSchedEnqueue_def wp:unless_wp)
 
 lemma updateTimeSlice_valid_pspace[wp]:
   "\<lbrace>valid_pspace'\<rbrace> threadSet (tcbTimeSlice_update (\<lambda>_. ts')) thread

--- a/proof/refine/X64/KHeap_R.thy
+++ b/proof/refine/X64/KHeap_R.thy
@@ -188,7 +188,7 @@ lemma obj_at_setObject1:
    setObject p (v::'a::pspace_storable)
   \<lbrace> \<lambda>rv. obj_at' (\<lambda>x::'a::pspace_storable. True) t \<rbrace>"
   apply (simp add: setObject_def split_def)
-  apply (rule hoare_seq_ext [OF _ hoare_gets_post])
+  apply (rule hoare_seq_ext [OF _ hoare_gets_sp])
   apply (clarsimp simp: valid_def in_monad obj_at'_def
                         projectKOs lookupAround2_char1
                         project_inject
@@ -210,7 +210,7 @@ lemma obj_at_setObject2:
    setObject p (v::'a)
   \<lbrace> \<lambda>rv. obj_at' P t \<rbrace>"
   apply (simp add: setObject_def split_def)
-  apply (rule hoare_seq_ext [OF _ hoare_gets_post])
+  apply (rule hoare_seq_ext [OF _ hoare_gets_sp])
   apply (clarsimp simp: valid_def in_monad)
   apply (frule updateObject_type)
   apply (drule R)

--- a/proof/refine/X64/LevityCatch.thy
+++ b/proof/refine/X64/LevityCatch.thy
@@ -39,14 +39,14 @@ lemma alignCheck_assert:
 
 lemma magnitudeCheck_inv:   "\<lbrace>P\<rbrace> magnitudeCheck x y n \<lbrace>\<lambda>rv. P\<rbrace>"
   apply (clarsimp simp add: magnitudeCheck_def split: option.splits)
-  apply (wp hoare_when_wp)
+  apply (wp when_wp)
   apply simp
   done
 
 lemma alignCheck_inv:
   "\<lbrace>P\<rbrace> alignCheck x n \<lbrace>\<lambda>rv. P\<rbrace>"
   apply (simp add: alignCheck_def unless_def alignError_def)
-  apply (wp hoare_when_wp)
+  apply (wp when_wp)
   apply simp
   done
 

--- a/proof/refine/X64/PageTableDuplicates.thy
+++ b/proof/refine/X64/PageTableDuplicates.thy
@@ -29,11 +29,11 @@ lemma foldr_data_map_insert[simp]:
   done
 
 crunch arch_inv[wp]: createNewObjects "\<lambda>s. P (x64KSSKIMPML4 (ksArchState s))"
-  (simp: crunch_simps zipWithM_x_mapM wp: crunch_wps hoare_unless_wp)
+  (simp: crunch_simps zipWithM_x_mapM wp: crunch_wps unless_wp)
 
 crunch arch_inv[wp]: resetUntypedCap "\<lambda>s. P (ksArchState s)"
   (simp: crunch_simps
-     wp: hoare_drop_imps hoare_unless_wp mapME_x_inv_wp
+     wp: hoare_drop_imps unless_wp mapME_x_inv_wp
          preemptionPoint_inv
    ignore: freeMemory)
 

--- a/proof/refine/X64/Retype_R.thy
+++ b/proof/refine/X64/Retype_R.thy
@@ -4357,7 +4357,7 @@ lemma createNewCaps_ioports':
 lemma createObjects'_irq_states' [wp]:
   "\<lbrace>valid_irq_states'\<rbrace> createObjects' a b c d \<lbrace>\<lambda>_. valid_irq_states'\<rbrace>"
   apply (simp add: createObjects'_def split_def)
-  apply (wp hoare_unless_wp|wpc|simp add: alignError_def)+
+  apply (wp unless_wp|wpc|simp add: alignError_def)+
   apply fastforce
   done
 
@@ -4636,7 +4636,7 @@ lemma createObjects_null_filter':
    createObjects' ptr n val gbits
    \<lbrace>\<lambda>addrs a. P (null_filter' (ctes_of a))\<rbrace>"
    apply (clarsimp simp: createObjects'_def split_def)
-   apply (wp hoare_unless_wp|wpc
+   apply (wp unless_wp|wpc
           | clarsimp simp:haskell_assert_def alignError_def
             split del: if_splits simp del:fun_upd_apply)+
    apply (subst new_cap_addrs_fold')

--- a/proof/refine/X64/Retype_R.thy
+++ b/proof/refine/X64/Retype_R.thy
@@ -60,8 +60,6 @@ lemma objBitsKO_bounded2[simp]:
   by (simp add: objBits_simps' word_bits_def pageBits_def archObjSize_def
          split: Structures_H.kernel_object.split arch_kernel_object.split)
 
-declare select_singleton_is_return[simp]
-
 definition
   APIType_capBits :: "X64_H.object_type \<Rightarrow> nat \<Rightarrow> nat"
 where

--- a/proof/refine/X64/Schedule_R.thy
+++ b/proof/refine/X64/Schedule_R.thy
@@ -523,7 +523,7 @@ lemma tcbSchedAppend_sch_act_wf[wp]:
   "\<lbrace>\<lambda>s. sch_act_wf (ksSchedulerAction s) s\<rbrace> tcbSchedAppend thread
   \<lbrace>\<lambda>rv s. sch_act_wf (ksSchedulerAction s) s\<rbrace>"
   apply (simp add:tcbSchedAppend_def bitmap_fun_defs)
-  apply (wp hoare_unless_wp setQueue_sch_act threadGet_wp|simp)+
+  apply (wp unless_wp setQueue_sch_act threadGet_wp|simp)+
   apply (fastforce simp:typ_at'_def obj_at'_def)
   done
 

--- a/proof/refine/X64/Syscall_R.thy
+++ b/proof/refine/X64/Syscall_R.thy
@@ -864,9 +864,9 @@ lemma valid_irq_node_tcbSchedEnqueue[wp]:
   \<lbrace>\<lambda>rv s'. valid_irq_node' (irq_node' s') s'\<rbrace>"
   apply (rule hoare_pre)
   apply (simp add:valid_irq_node'_def )
-  apply (wp hoare_unless_wp hoare_vcg_all_lift | wps)+
+  apply (wp unless_wp hoare_vcg_all_lift | wps)+
   apply (simp add:tcbSchedEnqueue_def)
-  apply (wp hoare_unless_wp| simp)+
+  apply (wp unless_wp| simp)+
   apply (simp add:valid_irq_node'_def)
   done
 
@@ -982,7 +982,7 @@ lemma setDomain_invs':
   (\<lambda>y. domain \<le> maxDomain))\<rbrace>
   setDomain ptr domain \<lbrace>\<lambda>y. invs'\<rbrace>"
   apply (simp add:setDomain_def )
-  apply (wp add: hoare_when_wp static_imp_wp static_imp_conj_wp rescheduleRequired_all_invs_but_extra
+  apply (wp add: when_wp static_imp_wp static_imp_conj_wp rescheduleRequired_all_invs_but_extra
     tcbSchedEnqueue_valid_action hoare_vcg_if_lift2)
      apply (rule_tac Q = "\<lambda>r s. all_invs_but_sch_extra s \<and> curThread = ksCurThread s
       \<and> (ptr \<noteq> curThread \<longrightarrow> ct_not_inQ s \<and> sch_act_wf (ksSchedulerAction s) s \<and> ct_idle_or_in_cur_domain' s)"

--- a/proof/refine/X64/TcbAcc_R.thy
+++ b/proof/refine/X64/TcbAcc_R.thy
@@ -244,7 +244,7 @@ lemma preemptionPoint_irq [wp]:
   "\<lbrace>valid_irq_states'\<rbrace> preemptionPoint -,
    \<lbrace>\<lambda>irq s. intStateIRQTable (ksInterruptState s) irq \<noteq> IRQInactive\<rbrace>"
   apply (simp add: preemptionPoint_def setWorkUnits_def modifyWorkUnits_def getWorkUnits_def)
-  apply (wp hoare_whenE_wp|wpc)+
+  apply (wp whenE_wp|wpc)+
      apply (rule hoare_post_imp)
       prefer 2
      apply (rule doMachineOp_getActiveIRQ_IRQ_active)

--- a/proof/refine/X64/Tcb_R.thy
+++ b/proof/refine/X64/Tcb_R.thy
@@ -83,7 +83,7 @@ lemma gts_st_tcb':
   apply (rule hoare_vcg_precond_imp)
    apply (rule hoare_post_imp[where Q="\<lambda>rv s. \<exists>rv'. rv = rv' \<and> st_tcb_at' (\<lambda>st. st = rv') t s"])
     apply simp
-   apply (wp hoare_ex_wp)
+   apply (wp hoare_vcg_ex_lift)
   apply (clarsimp simp add: pred_tcb_at'_def obj_at'_def)
   done
 

--- a/proof/refine/X64/Untyped_R.thy
+++ b/proof/refine/X64/Untyped_R.thy
@@ -4149,11 +4149,11 @@ lemma valid_sched_etcbs[elim!]: "valid_sched_2 queues ekh sa cdom kh ct it \<Lon
   by (simp add: valid_sched_def)
 
 crunch ksIdleThread[wp]: deleteObjects "\<lambda>s. P (ksIdleThread s)"
-  (simp: crunch_simps wp: hoare_drop_imps hoare_unless_wp ignore: freeMemory)
+  (simp: crunch_simps wp: hoare_drop_imps unless_wp ignore: freeMemory)
 crunch ksCurDomain[wp]: deleteObjects "\<lambda>s. P (ksCurDomain s)"
-  (simp: crunch_simps wp: hoare_drop_imps hoare_unless_wp ignore: freeMemory)
+  (simp: crunch_simps wp: hoare_drop_imps unless_wp ignore: freeMemory)
 crunch irq_node[wp]: deleteObjects "\<lambda>s. P (irq_node' s)"
-  (simp: crunch_simps wp: hoare_drop_imps hoare_unless_wp ignore: freeMemory)
+  (simp: crunch_simps wp: hoare_drop_imps unless_wp ignore: freeMemory)
 
 lemma deleteObjects_ksCurThread[wp]:
   "\<lbrace>\<lambda>s. P (ksCurThread s)\<rbrace> deleteObjects ptr sz \<lbrace>\<lambda>_ s. P (ksCurThread s)\<rbrace>"
@@ -4706,7 +4706,7 @@ lemma whenE_reset_resetUntypedCap_invs_etc:
       and ct_active'
       and pspace_no_overlap' (if reset then ptr else ptr') sz\<rbrace>, \<lbrace>\<lambda>_. invs'\<rbrace>"
   apply (rule hoare_pre)
-   apply (wp hoare_whenE_wp resetUntypedCap_invs_etc[where idx=idx,
+   apply (wp whenE_wp resetUntypedCap_invs_etc[where idx=idx,
            simplified pred_conj_def conj_assoc]
        | simp)+
   apply (clarsimp simp: cte_wp_at_ctes_of)
@@ -5176,7 +5176,7 @@ lemma sts_valid_untyped_inv':
 
 crunch nosch[wp]: invokeUntyped "\<lambda>s. P (ksSchedulerAction s)"
   (simp: crunch_simps zipWithM_x_mapM
-     wp: crunch_wps hoare_unless_wp mapME_x_inv_wp preemptionPoint_inv)
+     wp: crunch_wps unless_wp mapME_x_inv_wp preemptionPoint_inv)
 
 crunch no_0_obj'[wp]: insertNewCap no_0_obj'
   (wp: crunch_wps)
@@ -5824,7 +5824,7 @@ lemma inv_untyped_IRQInactive:
   -, \<lbrace>\<lambda>rv s. intStateIRQTable (ksInterruptState s) rv \<noteq> irqstate.IRQInactive\<rbrace>"
   apply (simp add: invokeUntyped_def)
   apply (rule hoare_pre)
-   apply (wp hoare_whenE_wp resetUntypedCap_IRQInactive | wpc | simp)+
+   apply (wp whenE_wp resetUntypedCap_IRQInactive | wpc | simp)+
   done
 
 end

--- a/proof/refine/X64/VSpace_R.thy
+++ b/proof/refine/X64/VSpace_R.thy
@@ -1546,7 +1546,7 @@ lemma getCurrentUserCR3_wp:
 lemma setVMRoot_invs [wp]:
   "\<lbrace>invs'\<rbrace> setVMRoot p \<lbrace>\<lambda>rv. invs'\<rbrace>"
   apply (simp add: setVMRoot_def getThreadVSpaceRoot_def setCurrentUserVSpaceRoot_def)
-  apply (wp hoare_whenE_wp getCurrentUserCR3_wp findVSpaceForASID_vs_at_wp
+  apply (wp whenE_wp getCurrentUserCR3_wp findVSpaceForASID_vs_at_wp
          | wpcw
          | clarsimp simp: if_apply_def2 asid_wf_0
          | strengthen valid_cr3'_makeCR3)+
@@ -1555,7 +1555,7 @@ lemma setVMRoot_invs [wp]:
 lemma setVMRoot_invs_no_cicd':
   "\<lbrace>invs_no_cicd'\<rbrace> setVMRoot p \<lbrace>\<lambda>rv. invs_no_cicd'\<rbrace>"
   apply (simp add: setVMRoot_def getThreadVSpaceRoot_def setCurrentUserVSpaceRoot_def)
-  apply (wp hoare_whenE_wp getCurrentUserCR3_wp findVSpaceForASID_vs_at_wp
+  apply (wp whenE_wp getCurrentUserCR3_wp findVSpaceForASID_vs_at_wp
          | wpcw
          | clarsimp simp: if_apply_def2 asid_wf_0
          | strengthen valid_cr3'_makeCR3)+

--- a/proof/sep-capDL/Helpers_SD.thy
+++ b/proof/sep-capDL/Helpers_SD.thy
@@ -1034,7 +1034,7 @@ lemma derive_cap_wp:
   "\<lbrace> P (derived_cap cap) \<rbrace> derive_cap slot cap \<lbrace>P\<rbrace>, -"
   apply (clarsimp simp: derive_cap_def derived_cap_def)
   apply (clarsimp simp: validE_R_def derive_cap_def split:cdl_cap.splits)
-  apply (safe, (wp alternative_wp alternativeE_wp hoare_whenE_wp |
+  apply (safe, (wp alternative_wp alternativeE_wp whenE_wp |
                 clarsimp simp: ensure_no_children_def)+ )
   done
 

--- a/sys-init/CreateObjects_SI.thy
+++ b/sys-init/CreateObjects_SI.thy
@@ -38,7 +38,7 @@ lemma seL4_Untyped_Retype_has_children_wp:
   \<lbrace>\<lambda>rv s. has_children parent (kernel_state s)\<rbrace>"
   apply (clarsimp simp: has_children_def is_cdt_parent_def)
   apply (subst ex_conj_increase)+
-  apply (rule hoare_ex_wp)+
+  apply (rule hoare_vcg_ex_lift)+
   apply (rule hoare_chain)
     apply (rule seL4_Untyped_Retype_inc_no_preempt
                 [where root_size=si_cnode_size and root_cnode_cap=si_cnode_cap and obj = obj

--- a/sys-init/InitVSpace_SI.thy
+++ b/sys-init/InitVSpace_SI.thy
@@ -887,7 +887,7 @@ lemma set_asid_wp:
   apply (rule valid_si_caps_at_si_cap_at [where obj_id=obj_id], clarsimp+)
   apply (clarsimp simp: si_cap_at_def sep_conj_assoc sep_conj_exists)
   apply (subst ex_conj_increase)+
-  apply (rule hoare_ex_wp)+
+  apply (rule hoare_vcg_ex_lift)+
   apply (rename_tac kobj_id)
   apply (rule hoare_grab_asm)+
   apply wpsimp

--- a/sys-init/Proof_SI.thy
+++ b/sys-init/Proof_SI.thy
@@ -228,14 +228,14 @@ lemma sys_init_explicit:
   apply (insert distinct_card [symmetric, where xs ="[obj\<leftarrow>obj_ids . cnode_or_tcb_at obj spec]"], simp)
   apply (frule distinct_card [symmetric])
   apply (clarsimp simp: init_system_def, wp valid_case_prod')
-            apply (rule hoare_ex_wp, rename_tac t, rule_tac t=t in start_threads_sep [sep_wandise], simp)
-           apply (rule hoare_ex_wp, rename_tac t, rule_tac t=t and
+            apply (rule hoare_vcg_ex_lift, rename_tac t, rule_tac t=t in start_threads_sep [sep_wandise], simp)
+           apply (rule hoare_vcg_ex_lift, rename_tac t, rule_tac t=t and
                                                   free_cptrs="[fstart .e. fend - 1]" in init_cspace_sep [sep_wandise])
-          apply (rule hoare_ex_wp, rename_tac t, rule_tac t=t in init_tcbs_sep [sep_wandise])
-         apply (rule hoare_ex_wp, rename_tac t, rule_tac t=t in init_vspace_sep [sep_wandise])
-        apply (rule hoare_ex_wp, rename_tac t, rule_tac t=t in init_pd_asids_sep [sep_wandise])
-       apply (rule hoare_ex_wp, rename_tac t, rule_tac t=t and dev=False in init_irqs_sep [sep_wandise])
-      apply (rule hoare_ex_wp, rename_tac t, rule_tac t=t and dev=False and
+          apply (rule hoare_vcg_ex_lift, rename_tac t, rule_tac t=t in init_tcbs_sep [sep_wandise])
+         apply (rule hoare_vcg_ex_lift, rename_tac t, rule_tac t=t in init_vspace_sep [sep_wandise])
+        apply (rule hoare_vcg_ex_lift, rename_tac t, rule_tac t=t in init_pd_asids_sep [sep_wandise])
+       apply (rule hoare_vcg_ex_lift, rename_tac t, rule_tac t=t and dev=False in init_irqs_sep [sep_wandise])
+      apply (rule hoare_vcg_ex_lift, rename_tac t, rule_tac t=t and dev=False and
                                              untyped_cptrs = "[ustart .e. uend - 1]" and
                                              free_cptrs_orig = "[fstart .e. fend - 1]" in duplicate_caps_sep [sep_wandise])
      apply (rule create_irq_caps_sep [where dev = False,sep_wandise,

--- a/tools/autocorres/NonDetMonadEx.thy
+++ b/tools/autocorres/NonDetMonadEx.thy
@@ -86,7 +86,7 @@ lemma when_wp_nf [wp]:
            \<Longrightarrow> \<lbrace> if P then Q else R () \<rbrace> when P f \<lbrace> R \<rbrace>!"
   by (monad_eq simp: validNF_def valid_def no_fail_def)
 
-lemmas [wp] = hoare_whenE_wp
+lemmas [wp] = whenE_wp
 
 lemma gets_the_wp_nf [wp]:
   "\<lbrace>\<lambda>s. (f s \<noteq> None) \<and> Q (the (f s)) s\<rbrace> gets_the f \<lbrace>Q\<rbrace>!"


### PR DESCRIPTION
Processing "FIXME lib" issues introduced in the last few PRs.

These are mostly lemma moving, lemma renaming, and removing duplicates.

Some attempts at name consolidation (`unless_wp` instead of `hoare_unless_wp`, to be in line with `return_wp` etc), but only extremely limited, because this is a very deep rabbit hole and too much renaming will probably conflict with the rt branch at some point.