### PR TITLE
AArch64 cleanup

### DIFF
--- a/lib/Eisbach_Tools/Eisbach_Methods.thy
+++ b/lib/Eisbach_Tools/Eisbach_Methods.thy
@@ -17,7 +17,6 @@ imports
   Local_Method
 begin
 
-
 section \<open>Debugging methods\<close>
 
 method print_concl = (match conclusion in P for P \<Rightarrow> \<open>print_term P\<close>)
@@ -352,6 +351,11 @@ end
 
 section \<open>Utility methods\<close>
 
+subsection \<open>Instantiations\<close>
+
+text \<open>These do not admit goal parameters in "x", so erule_tac is still sometimes necessary\<close>
+method spec for x :: "_ :: type" = (erule allE[of _ x])
+method bspec for x :: "_ :: type" = (erule ballE[of _ _ x])
 
 subsection \<open>Finding a goal based on successful application of a method\<close>
 

--- a/lib/Lib.thy
+++ b/lib/Lib.thy
@@ -2318,6 +2318,10 @@ lemma bspec_split:
   "\<lbrakk> \<forall>(a, b) \<in> S. P a b; (a, b) \<in> S \<rbrakk> \<Longrightarrow> P a b"
   by fastforce
 
+lemma all_eq_trans:
+  "\<lbrakk> \<forall>x. P x = Q x; \<forall>x. Q x = R x \<rbrakk> \<Longrightarrow> \<forall>x. P x = R x"
+  by simp
+
 lemma set_zip_same:
   "set (zip xs xs) = Id \<inter> (set xs \<times> set xs)"
   by (induct xs) auto
@@ -2523,6 +2527,10 @@ lemmas if_option = if_option_None_eq if_option_Some if_option_Some2
 lemma not_in_ran_None_upd:
   "x \<notin> ran m \<Longrightarrow> x \<notin> ran (m(y := None))"
   by (auto simp: ran_def split: if_split)
+
+lemma ranD:
+  "v \<in> ran f \<Longrightarrow> \<exists>x. f x = Some v"
+  by (auto simp: ran_def)
 
 text \<open>Prevent clarsimp and others from creating Some from not None by folding this and unfolding
   again when safe.\<close>

--- a/lib/Monad_Lists.thy
+++ b/lib/Monad_Lists.thy
@@ -515,10 +515,7 @@ proof (induct xs)
 next
   case (Cons y ys)
   have PQ_inv: "\<And>x. x \<in> set ys \<Longrightarrow> \<lbrace>P and Q y\<rbrace> f x \<lbrace>\<lambda>_. P and Q y\<rbrace>"
-    apply (simp add: pred_conj_def)
-    apply (rule hoare_pre)
-     apply (wp Cons|simp)+
-    done
+    by (wpsimp wp: Cons)
   show ?case
     apply (simp add: mapM_Cons)
     apply wp
@@ -530,6 +527,17 @@ next
      apply (wp Cons|simp)+
     done
 qed
+
+lemma mapM_set_inv:
+  assumes "\<And>x. x \<in> set xs \<Longrightarrow> \<lbrace>P\<rbrace> f x \<lbrace>\<lambda>_. P\<rbrace>"
+  assumes "\<And>x. x \<in> set xs \<Longrightarrow> \<lbrace>P\<rbrace> f x \<lbrace>\<lambda>_. Q x\<rbrace>"
+  assumes "\<And>x y. \<lbrakk> x \<in> set xs; y \<in> set xs \<rbrakk> \<Longrightarrow> \<lbrace>P and Q y\<rbrace> f x \<lbrace>\<lambda>_. Q y\<rbrace>"
+  shows "\<lbrace>P\<rbrace> mapM f xs \<lbrace>\<lambda>_ s. P s \<and> (\<forall>x \<in> set xs. Q x s)\<rbrace>"
+  apply (rule hoare_weaken_pre, rule hoare_vcg_conj_lift)
+    apply (rule mapM_wp', erule assms)
+   apply (rule mapM_set; rule assms; assumption)
+  apply simp
+  done
 
 lemma mapM_x_wp:
   assumes x: "\<And>x. x \<in> S \<Longrightarrow> \<lbrace>P\<rbrace> f x \<lbrace>\<lambda>rv. P\<rbrace>"

--- a/lib/Monads/NonDetMonadVCG.thy
+++ b/lib/Monads/NonDetMonadVCG.thy
@@ -1338,7 +1338,11 @@ lemma hoare_weak_lift_imp:
 lemma hoare_vcg_weaken_imp:
   "\<lbrakk> \<And>rv s. Q rv s \<Longrightarrow> Q' rv s ; \<lbrace> P \<rbrace> f \<lbrace>\<lambda>rv s. Q' rv s \<longrightarrow> R rv s\<rbrace> \<rbrakk>
    \<Longrightarrow> \<lbrace> P \<rbrace> f \<lbrace>\<lambda>rv s. Q rv s \<longrightarrow> R rv s\<rbrace>"
-  by (clarsimp simp: valid_def split_def)
+  by (rule hoare_weaken_imp)
+
+lemma hoare_pre_cases:
+  "\<lbrakk> \<lbrace>\<lambda>s. R s \<and> P s\<rbrace> f \<lbrace>Q\<rbrace>; \<lbrace>\<lambda>s. \<not>R s \<and> P' s\<rbrace> f \<lbrace>Q\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P and P'\<rbrace> f \<lbrace>Q\<rbrace>"
+  unfolding valid_def by fastforce
 
 lemma hoare_vcg_ex_lift:
   "\<lbrakk> \<And>x. \<lbrace>P x\<rbrace> f \<lbrace>Q x\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s. \<exists>x. P x s\<rbrace> f \<lbrace>\<lambda>rv s. \<exists>x. Q x rv s\<rbrace>"
@@ -1393,8 +1397,7 @@ lemma hoare_vcg_R_conj:
 
 lemma valid_validE:
   "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv. Q\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv. Q\<rbrace>,\<lbrace>\<lambda>rv. Q\<rbrace>"
-  apply (simp add: validE_def)
-  done
+  by (rule hoare_post_imp_dc)
 
 lemma valid_validE2:
   "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>_. Q'\<rbrace>; \<And>s. Q' s \<Longrightarrow> Q s; \<And>s. Q' s \<Longrightarrow> E s \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>_. Q\<rbrace>,\<lbrace>\<lambda>_. E\<rbrace>"

--- a/lib/Monads/OptionMonad.thy
+++ b/lib/Monads/OptionMonad.thy
@@ -157,42 +157,39 @@ definition map_set :: "('a \<Rightarrow> 'b set option) \<Rightarrow> 'a \<Right
 
 (* opt_pred *)
 
-abbreviation
-  opt_pred :: "('a \<Rightarrow> bool) \<Rightarrow> ('b \<Rightarrow> 'a option) \<Rightarrow> ('b \<Rightarrow> bool)" (infixl "|<" 55) where
+definition opt_pred :: "('a \<Rightarrow> bool) \<Rightarrow> ('b \<Rightarrow> 'a option) \<Rightarrow> ('b \<Rightarrow> bool)" (infixl "|<" 55) where
   "P |< proj \<equiv> (\<lambda>x. case_option False P (proj x))"
 
 lemma opt_pred_conj:
   "((P1 |< hp) p \<and> (P2 |< hp) p) = (((P1 and P2) |< hp) p)"
-  by (fastforce simp: pred_conj_def split: option.splits)
+  by (fastforce simp: pred_conj_def opt_pred_def split: option.splits)
 
 lemma opt_pred_disj:
   "((P1 |< hp) p \<or> (P2 |< hp) p) = (((P1 or P2) |< hp) p)"
-  by (fastforce simp: pred_disj_def split: option.splits)
-
-lemma opt_predD:
-  "(P |< proj) x \<Longrightarrow> \<exists>y. proj x = Some y \<and> P y"
-  by (clarsimp split: option.splits)
-
-lemma opt_predE:
-  "\<lbrakk>(P |< proj) x; \<And>y. \<lbrakk>proj x = Some y; P y\<rbrakk> \<Longrightarrow> R\<rbrakk> \<Longrightarrow> R"
-  by (clarsimp split: option.splits)
+  by (fastforce simp: pred_disj_def opt_pred_def split: option.splits)
 
 lemma in_opt_pred:
   "(P |< f) p = (\<exists>v. f p = Some v \<and> P v)"
-  by (auto dest: opt_predD)
+  by (auto simp: opt_pred_def split: option.splits)
+
+lemmas opt_predD = in_opt_pred[THEN iffD1]
+
+lemma opt_predE:
+  "\<lbrakk>(P |< proj) x; \<And>y. \<lbrakk>proj x = Some y; P y\<rbrakk> \<Longrightarrow> R\<rbrakk> \<Longrightarrow> R"
+  by (blast dest: opt_predD)
 
 lemma opt_pred_unfold_map:
   "(P |< (f |> g)) = ((P |< g) |< f)"
-  by (fastforce simp: opt_map_def split: option.splits)
+  by (fastforce simp: opt_map_def in_opt_pred split: option.splits)
 
 lemma opt_pred_unfold_proj:
   "(P |< (f ||> g))=  (P o g |< f)"
-  by (clarsimp simp: opt_map_def split: option.splits)
+  by (clarsimp simp: opt_map_def opt_pred_def split: option.splits)
 
 (* This rule is useful when fun_upd_apply is not in the simp set: *)
 lemma opt_pred_proj_upd_eq[simp]:
   "(P |< proj (p \<mapsto> v)) p = P v"
-  by simp
+  by (simp add: in_opt_pred)
 
 
 (* obind, etc. *)

--- a/lib/Monads/OptionMonad.thy
+++ b/lib/Monads/OptionMonad.thy
@@ -189,6 +189,12 @@ lemma opt_pred_unfold_proj:
   "(P |< (f ||> g))=  (P o g |< f)"
   by (clarsimp simp: opt_map_def split: option.splits)
 
+(* This rule is useful when fun_upd_apply is not in the simp set: *)
+lemma opt_pred_proj_upd_eq[simp]:
+  "(P |< proj (p \<mapsto> v)) p = P v"
+  by simp
+
+
 (* obind, etc. *)
 
 definition

--- a/lib/Word_Lib/Word_Lemmas_Internal.thy
+++ b/lib/Word_Lib/Word_Lemmas_Internal.thy
@@ -658,6 +658,17 @@ lemmas shiftl_t2n' = shiftl_eq_mult[where x="w::'a::len word" for w]
 
 (* candidates for moving to AFP Word_Lib: *)
 
+lemma word_mask_shift_eqI:
+  "\<lbrakk> x && mask n = y && mask n; x >> n = y >> n \<rbrakk> \<Longrightarrow> x = y"
+  apply (subst mask_or_not_mask[of x n, symmetric])
+  apply (subst mask_or_not_mask[of y n, symmetric])
+  apply (rule arg_cong2[where f="(OR)"]; blast intro: shiftr_eq_neg_mask_eq)
+  done
+
+lemma mask_shiftr_mask_eq:
+  "m \<le> m' + n \<Longrightarrow> (w && mask m >> n) && mask m' = w && mask m >> n" for w :: "'a::len word"
+  by word_eqI_solve
+
 lemma mask_split_aligned:
   assumes len: "m \<le> a + len_of TYPE('a)"
   assumes align: "is_aligned p a"

--- a/proof/invariant-abstract/AARCH64/ArchAInvsPre.thy
+++ b/proof/invariant-abstract/AARCH64/ArchAInvsPre.thy
@@ -42,27 +42,6 @@ lemma data_at_aligned:
   "\<lbrakk> data_at sz p s; pspace_aligned s\<rbrakk> \<Longrightarrow> is_aligned p (pageBitsForSize sz)"
   unfolding data_at_def by (auto simp: obj_at_def dest: pspace_alignedD)
 
-lemma is_aligned_pptrBaseOffset_pt_bits_left:
-  "level \<le> max_pt_level \<Longrightarrow> is_aligned pptrBaseOffset (pt_bits_left level)"
-  apply (drule pt_bits_left_le_max_pt_level)
-  apply (fastforce elim: is_aligned_weaken[rotated]
-                   simp: pptrBaseOffset_def pptrBase_def paddrBase_def
-                         is_aligned_def pt_bits_left_bound_def bit_simps
-                   split: if_split_asm)
-  done
-
-lemma is_aligned_ptrFromPAddr_n_eq:
-  "level \<le> max_pt_level \<Longrightarrow>
-   is_aligned (ptrFromPAddr x) (pt_bits_left level) = is_aligned x (pt_bits_left level)"
-  apply (rule iffI)
-   apply (simp add: ptrFromPAddr_def)
-   apply (erule is_aligned_addD2)
-   apply (erule is_aligned_pptrBaseOffset_pt_bits_left)
-  apply (erule is_aligned_ptrFromPAddr_n)
-  apply (drule pt_bits_left_le_max_pt_level)
-  apply (clarsimp simp: pt_bits_left_bound_def bit_simps split: if_split_asm)
-  done
-
 lemma some_get_page_info_umapsD:
   "\<lbrakk>get_page_info (aobjs_of s) pt_ref vptr = Some (b, a, attr, r);
     \<exists>\<rhd> (max_pt_level, pt_ref) s; vptr \<in> user_region; valid_vspace_objs s; pspace_aligned s;

--- a/proof/invariant-abstract/AARCH64/ArchAcc_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchAcc_AI.thy
@@ -278,9 +278,9 @@ lemma pt_walk_loop_last_level_ptpte_helper_induct:
                     ptes
             = Some (level' - 1, pptr_from_pte pte)")
    apply (drule meta_spec, drule meta_spec, drule meta_spec, drule (1) meta_mp, drule meta_mp)
-    apply (simp add: bit1.minus_one_leq_less)  (* FIXME AARCH64: bit1 *)
+    apply (simp add: vm_level.minus_one_leq_less)
    apply (drule meta_mp)
-    apply (simp add: bit1.minus_one_leq_less bit1.neq_0_conv pt_walk_max_level) (* FIXME AARCH64: bit1 *)
+    apply (simp add: vm_level.minus_one_leq_less vm_level.neq_0_conv pt_walk_max_level)
    apply (clarsimp simp: pptr_from_pte_aligned_pt_bits)
    apply (subst pt_walk.simps)
    apply (clarsimp simp: in_omonad)
@@ -297,7 +297,7 @@ lemma pt_walk_loop_last_level_ptpte_helper_induct:
       apply (drule_tac level'="level'+1" in  vref_for_level_eq_mono)
        apply (fastforce intro: vref_for_level_pt_index_idem)
       apply (fastforce intro: vref_for_level_pt_index_idem)
-     apply (erule bit1.plus_one_leq)
+     apply (erule vm_level.plus_one_leq)
     apply simp
    apply (rule conjI, blast)
    apply (drule_tac level'="level'+1" in  vref_for_level_eq_mono
@@ -306,7 +306,7 @@ lemma pt_walk_loop_last_level_ptpte_helper_induct:
   apply (rule_tac pt_walk_split_Some[where level'="level" and level="level - 1" for level,
                                      THEN iffD2])
     apply (fastforce dest!: vm_level_not_less_zero intro: less_imp_le)
-   apply (meson bit1.leq_minus1_less bit1.not_less_zero_bit0 le_less less_linear less_trans)
+   apply (meson vm_level.leq_minus1_less vm_level.not_less_zero_bit0 le_less less_linear less_trans)
   apply (subgoal_tac
            "pt_walk (level - 1) level' (pptr_from_pte pte)
                     (vref_for_level vref (level' + 1) || (pt_index level vref << pt_bits_left level'))
@@ -314,7 +314,7 @@ lemma pt_walk_loop_last_level_ptpte_helper_induct:
    prefer 2
    apply (rule pt_walk_vref_for_level_eq)
     apply (subst vref_for_level_pt_index_idem, simp+)
-   apply (meson bit1.leq_minus1_less bit1.not_less_zero_bit0 le_less less_linear less_trans)
+   apply (meson vm_level.leq_minus1_less vm_level.not_less_zero_bit0 le_less less_linear less_trans)
   apply clarsimp
   apply (subst pt_walk.simps)
   apply clarsimp
@@ -2342,7 +2342,7 @@ lemma pt_walk_below_pt_upd_idem:
    apply (rename_tac level'')
    apply (prop_tac "level'' < level'")
     apply (drule pt_walk_max_level)
-    apply (simp add: vm_level_leq_minus1_less)
+    apply (simp add: vm_level.leq_minus1_less)
    apply (prop_tac "pt_walk level' level'' (table_base level' p) vref (ptes_of s) =
                       Some (level'', table_base level' p)")
     apply (subst pt_walk.simps)

--- a/proof/invariant-abstract/AARCH64/ArchAcc_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchAcc_AI.thy
@@ -2234,11 +2234,6 @@ lemma pt_index_table_index_slot_offset_eq:
   using table_base_index_eq pt_slot_offset_def
   by force
 
-(* FIXME AARCH64: move *)
-lemma mask_shiftr_mask_eq:
-  "m \<le> m' + n \<Longrightarrow> (w && mask m >> n) && mask m' = w && mask m >> n" for w :: "'a::len word"
-  by word_eqI_solve
-
 (* If you start with a lookup from asid down to level, and you split off a walk at level', then an
    update at level' does not affect the extended pt_walk from level'-1 down to level. *)
 (* FIXME: we should do the same on RISCV64 *)

--- a/proof/invariant-abstract/AARCH64/ArchAcc_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchAcc_AI.thy
@@ -206,17 +206,6 @@ lemma unique_vs_lookup_table:
   apply (drule table_cap_ref_vs_cap_ref; simp)
   done
 
-(* FIXME AARCH64: move *)
-lemma level_type_less_max_pt_level:
-  "level < max_pt_level \<Longrightarrow> level_type level = NormalPT_T"
-  by (clarsimp simp: level_type_def)
-
-(* FIXME AARCH64: move *)
-(* Depending on config, ptTranslationBits NormalPT_T might be equal to ptTranslationBits VSRootPT_T *)
-lemma ptTranslationBits_NormalPT_T_leq:
-  "ptTranslationBits NormalPT_T \<le> ptTranslationBits VSRootPT_T"
-  by (simp add: bit_simps)
-
 lemma vref_for_level_pt_index_idem:
   assumes "level' \<le> max_pt_level" and "level'' \<le> level'" and "level < max_pt_level"
   shows "vref_for_level
@@ -1493,24 +1482,6 @@ lemma kernel_regionsI:
   "p \<in> kernel_device_window s \<Longrightarrow> p \<in> kernel_regions s"
   unfolding kernel_regions_def
   by auto
-
-(* FIXME AARCH64: probably remove
-lemma user_region_canonical_pptr_base:
-  "\<lbrakk> p \<notin> user_region; canonical_address p \<rbrakk> \<Longrightarrow> pptr_base \<le> p"
-  using canonical_below_pptr_base_canonical_user word_le_not_less
-  by (auto simp add: user_region_def not_le) *)
-
-(* FIXME AARCH64: probably remove
-lemma kernel_regions_pptr_base:
-  "\<lbrakk> p \<in> kernel_regions s; valid_uses s \<rbrakk> \<Longrightarrow> pptr_base \<le> p"
-  apply (rule user_region_canonical_pptr_base)
-   apply (simp add: valid_uses_def window_defs)
-   apply (erule_tac x=p in allE)
-   apply auto[1]
-  apply (simp add: valid_uses_def window_defs)
-  apply (erule_tac x=p in allE)
-  apply auto[1]
-  done *)
 
 lemma set_pt_valid_global_vspace_mappings[wp]:
   "\<lbrace>\<top>\<rbrace> set_pt p pt \<lbrace>\<lambda>_. valid_global_vspace_mappings\<rbrace>"

--- a/proof/invariant-abstract/AARCH64/ArchArch_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchArch_AI.thy
@@ -1173,11 +1173,6 @@ lemma arch_thread_set_vcpus_of[wp]:
   apply (clarsimp simp: obj_at_def opt_map_def)
   done
 
-(* FIXME AARCH64: move *)
-lemma opt_pred_proj_upd_eq[simp]:
-  "(P |< proj (p \<mapsto> v)) p = P v"
-  by simp
-
 lemma associate_vcpu_tcb_valid_arch_state[wp]:
   "associate_vcpu_tcb vcpu tcb \<lbrace>valid_arch_state\<rbrace>"
   supply fun_upd_apply[simp del]

--- a/proof/invariant-abstract/AARCH64/ArchArch_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchArch_AI.thy
@@ -1447,13 +1447,13 @@ lemma pts_of_level_type_unique:
 
 lemma pageBitsForSize_max_page_level:
   "pt_bits_left level = pageBitsForSize vmpage_size \<Longrightarrow> level \<le> max_page_level"
-  using bit1.size_inj[where x=level and y=max_page_level, unfolded level_defs, simplified]
+  using vm_level.size_inj[where x=level and y=max_page_level, unfolded level_defs, simplified]
   by (simp add: pageBitsForSize_def pt_bits_left_def ptTranslationBits_def level_defs
            split: vmpage_size.splits if_split_asm)
 
 lemma pageBitsForSize_level_0_eq:
   "pt_bits_left level = pageBitsForSize vmpage_size \<Longrightarrow> (vmpage_size = ARMSmallPage) = (level = 0)"
-  using bit1.size_inj[where x=level and y=max_page_level, unfolded level_defs, simplified]
+  using vm_level.size_inj[where x=level and y=max_page_level, unfolded level_defs, simplified]
   by (simp add: pageBitsForSize_def pt_bits_left_def ptTranslationBits_def
            split: vmpage_size.splits if_split_asm)
 

--- a/proof/invariant-abstract/AARCH64/ArchArch_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchArch_AI.thy
@@ -1540,16 +1540,10 @@ lemma neg_mask_user_region:
   apply simp
   done
 
-(* FIXME AARCH64: move to Kernel_Config_Lemmas *)
-(* ptr is expected to be a kernel-virtual pointer/obj_ref *)
-lemma ucast_ucast_ppn:
-  "(ucast (ucast ptr::ppn)::machine_word) = ptr && mask (ipa_size - pageBits)" for ptr::machine_word
-  by (simp add: ucast_ucast_mask bit_simps Kernel_Config.config_ARM_PA_SIZE_BITS_40_def)
-
 lemma ptrFromPAddr_addr_from_ppn:
   "\<lbrakk> is_aligned pt_ptr pageBits; pptr_base \<le> pt_ptr; pt_ptr < pptrTop \<rbrakk> \<Longrightarrow>
    ptrFromPAddr (paddr_from_ppn (ppn_from_pptr pt_ptr)) = pt_ptr"
-  apply (simp add: paddr_from_ppn_def ppn_from_pptr_def ucast_ucast_ppn)
+  apply (simp add: paddr_from_ppn_def ppn_from_pptr_def ucast_ucast_ppn ppn_len_def')
   apply (frule is_aligned_addrFromPPtr)
   apply (simp add: nat_minus_add_max aligned_shiftr_mask_shiftl addrFromPPtr_mask_ipa
                    mask_len_id[where 'a=machine_word_len, simplified])

--- a/proof/invariant-abstract/AARCH64/ArchArch_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchArch_AI.thy
@@ -1413,37 +1413,17 @@ lemma check_vspace_root_wp[wp]:
   unfolding check_vspace_root_def
   by wpsimp
 
-(* FIXME AARCH64: move ArchInvariants *)
-lemma user_vtop_leq_canonical_user:
-  "user_vtop \<le> canonical_user"
-  by (simp add: user_vtop_def pptrUserTop_def canonical_user_def mask_def ipa_size_def)
-
-(* FIXME AARCH64: move ArchInvariants *)
-lemma user_vtop_canonical_user:
-  "vref < user_vtop \<Longrightarrow> vref \<le> canonical_user"
-  using user_vtop_leq_canonical_user by simp
-
 lemma pt_asid_pool_no_overlap:
   "\<lbrakk> kheap s (table_base (level_type level) pte_ptr) = Some (ArchObj (PageTable pt));
      kheap s (table_base (level_type asid_pool_level) pte_ptr) = Some (ArchObj (ASIDPool pool));
      pspace_distinct s; pt_type pt = level_type level \<rbrakk>
    \<Longrightarrow> False"
   apply (simp add: level_type_def split: if_split_asm)
-   apply (cases "table_base VSRootPT_T pte_ptr = table_base NormalPT_T pte_ptr", simp)
-   apply (drule (3) pspace_distinctD)
-   apply (clarsimp simp: is_aligned_no_overflow_mask)
-   apply (metis and_neg_mask_plus_mask_mono pt_bits_NormalPT_T pt_bits_def word_and_le)
-  apply (simp add: level_defs split: if_split_asm)
+  apply (cases "table_base VSRootPT_T pte_ptr = table_base NormalPT_T pte_ptr", simp)
+  apply (drule (3) pspace_distinctD)
+  apply (clarsimp simp: is_aligned_no_overflow_mask)
+  apply (metis and_neg_mask_plus_mask_mono pt_bits_NormalPT_T pt_bits_def word_and_le)
   done
-
-(* FIXME AARCH64: move close to pts_of_type_unique *)
-lemma pts_of_level_type_unique:
-  "\<lbrakk> pts_of s (table_base (level_type level) pte_ptr) = Some pt;
-     pts_of s (table_base (level_type level') pte_ptr) = Some pt';
-     pt_type pt = level_type level; pt_type pt' = level_type level';
-     pspace_distinct s \<rbrakk>
-   \<Longrightarrow> level_type level' = level_type level"
-  by (metis pts_of_type_unique)
 
 lemma pageBitsForSize_max_page_level:
   "pt_bits_left level = pageBitsForSize vmpage_size \<Longrightarrow> level \<le> max_page_level"
@@ -1456,11 +1436,6 @@ lemma pageBitsForSize_level_0_eq:
   using vm_level.size_inj[where x=level and y=max_page_level, unfolded level_defs, simplified]
   by (simp add: pageBitsForSize_def pt_bits_left_def ptTranslationBits_def
            split: vmpage_size.splits if_split_asm)
-
-(* FIXME AARCH64: move, intergrate with max_pt_level_not_asid_pool_level *)
-lemma asid_pool_level_not_max_pt_level[simp]:
-  "asid_pool_level \<noteq> max_pt_level"
-  by (simp add: level_defs)
 
 lemma decode_fr_inv_map_wf[wp]:
   assumes "arch_cap = FrameCap p rights vmpage_size dev option"
@@ -1575,25 +1550,6 @@ lemma neg_mask_user_region:
 lemma ucast_ucast_ppn:
   "(ucast (ucast ptr::ppn)::machine_word) = ptr && mask (ipa_size - pageBits)" for ptr::machine_word
   by (simp add: ucast_ucast_mask bit_simps Kernel_Config.config_ARM_PA_SIZE_BITS_40_def)
-
-(* FIXME AARCH64: move *)
-lemma pptrTop_le_ipa_size:
-  "pptrTop \<le> mask ipa_size"
-  by (simp add: bit_simps pptrTop_def mask_def)
-
-(* FIXME AARCH64: move *)
-lemma addrFromPPtr_mask_ipa:
-  "\<lbrakk> pptr_base \<le> pt_ptr; pt_ptr < pptrTop \<rbrakk>
-   \<Longrightarrow> addrFromPPtr pt_ptr && mask ipa_size = addrFromPPtr pt_ptr"
-  using pptrTop_le_ipa_size
-  by (simp add: and_mask_eq_iff_le_mask addrFromPPtr_def pptr_base_def pptrBaseOffset_def
-                paddrBase_def word_le_imp_diff_le)
-
-
-(* FIXME AARCH64: move *)
-lemma pageBits_less_ipa_size[simp]:
-  "pageBits < ipa_size"
-  by (simp add: bit_simps)
 
 lemma ptrFromPAddr_addr_from_ppn:
   "\<lbrakk> is_aligned pt_ptr pageBits; pptr_base \<le> pt_ptr; pt_ptr < pptrTop \<rbrakk> \<Longrightarrow>

--- a/proof/invariant-abstract/AARCH64/ArchArch_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchArch_AI.thy
@@ -1050,7 +1050,7 @@ lemma set_vcpu_valid_arch_Some[wp]:
   apply (rule conjI)
    apply (clarsimp simp: vmid_inv_def asid_pools_of_vcpu_None_upd_idem)
   apply (rule conjI)
-   apply (clarsimp simp: cur_vcpu_2_def obj_at_def is_vcpu_def hyp_live_def arch_live_def
+   apply (clarsimp simp: cur_vcpu_2_def obj_at_def is_vcpu_def hyp_live_def arch_live_def in_opt_pred
                    split: option.splits)
   apply (clarsimp simp: valid_global_arch_objs_def obj_at_def)
   done

--- a/proof/invariant-abstract/AARCH64/ArchBCorres_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchBCorres_AI.thy
@@ -8,61 +8,8 @@
 theory ArchBCorres_AI
 imports
   BCorres_AI
+  ArchBitSetup_AI
 begin
-
-(* This context block finds all lemmas with names *.bit1.* or *.bit0.* depending on the size
-   of vm_level, and locally re-declares them under the prefix vm_level.* so that their name
-   is available generically without reference to whether vm_level is even or odd *)
-context begin global_naming vm_level
-
-local_setup \<open>
-  let
-    (* From find_theorems.ML *)
-    fun all_facts_of lthy =
-      let
-        val ctxt = Local_Theory.target_of lthy;
-        val thy = Proof_Context.theory_of ctxt;
-        val transfer = Global_Theory.transfer_theories thy;
-        val global_facts = Global_Theory.facts_of thy;
-      in
-       (Facts.dest_all (Context.Proof ctxt) false [] global_facts)
-       |> maps Facts.selections
-       |> map (apsnd transfer)
-      end;
-
-    (* We will not be referencing lemma collections, only single names *)
-    fun is_single (Facts.Named (_, NONE)) = true
-      | is_single _ = false
-
-    fun name_of (Facts.Named ((name, _), _)) = name
-      | name_of _ = raise ERROR "name_of: no name"
-
-    (* Add a single theorem with name to the local theory *)
-    fun add_thm (name, thm) lthy =
-       Local_Theory.notes [((Binding.name name, []), [([thm], [])])] lthy |> #2
-
-    (* Add a list of theorems with names to the local theory *)
-    fun add_thms lthy xs = fold add_thm xs lthy
-
-    (* The top-level constructor name of the vm_level numeral type tells us whether to match
-       on bit0 or bit1 *)
-    val bit_name = dest_Type @{typ AARCH64_A.vm_level} |> fst |> Long_Name.base_name
-
-    (* Check whether an exploded long name does have a bit0/bit1 name *)
-    fun matches_bit_name names = member (op =) names bit_name
-
-    fun redeclare_short_names lthy =
-      all_facts_of lthy
-      |> filter (matches_bit_name o Long_Name.explode o Facts.ref_name o fst)
-      |> filter (is_single o fst)
-      |> map (fn (thm_ref, thm) => (name_of thm_ref |> Long_Name.base_name, thm))
-      |> add_thms lthy
-  in
-    redeclare_short_names
-  end
-\<close>
-
-end
 
 context Arch begin global_naming AARCH64
 

--- a/proof/invariant-abstract/AARCH64/ArchBitSetup_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchBitSetup_AI.thy
@@ -1,0 +1,66 @@
+(*
+ * Copyright 2023, Proofcraft Pty Ltd
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory ArchBitSetup_AI
+imports
+  Include_AI
+begin
+
+(* This context block finds all lemmas with names *.bit1.* or *.bit0.* depending on the size
+   of vm_level, and locally re-declares them under the prefix vm_level.* so that their name
+   is available generically without reference to whether vm_level is even or odd *)
+context begin global_naming vm_level
+
+local_setup \<open>
+  let
+    (* From find_theorems.ML *)
+    fun all_facts_of lthy =
+      let
+        val ctxt = Local_Theory.target_of lthy;
+        val thy = Proof_Context.theory_of ctxt;
+        val transfer = Global_Theory.transfer_theories thy;
+        val global_facts = Global_Theory.facts_of thy;
+      in
+       (Facts.dest_all (Context.Proof ctxt) false [] global_facts)
+       |> maps Facts.selections
+       |> map (apsnd transfer)
+      end;
+
+    (* We will not be referencing lemma collections, only single names *)
+    fun is_single (Facts.Named (_, NONE)) = true
+      | is_single _ = false
+
+    fun name_of (Facts.Named ((name, _), _)) = name
+      | name_of _ = raise ERROR "name_of: no name"
+
+    (* Add a single theorem with name to the local theory *)
+    fun add_thm (name, thm) lthy =
+       Local_Theory.notes [((Binding.name name, []), [([thm], [])])] lthy |> #2
+
+    (* Add a list of theorems with names to the local theory *)
+    fun add_thms lthy xs = fold add_thm xs lthy
+
+    (* The top-level constructor name of the vm_level numeral type tells us whether to match
+       on bit0 or bit1 *)
+    val bit_name = dest_Type @{typ AARCH64_A.vm_level} |> fst |> Long_Name.base_name
+
+    (* Check whether an exploded long name does have a bit0/bit1 name *)
+    fun matches_bit_name names = member (op =) names bit_name
+
+    fun redeclare_short_names lthy =
+      all_facts_of lthy
+      |> filter (matches_bit_name o Long_Name.explode o Facts.ref_name o fst)
+      |> filter (is_single o fst)
+      |> map (fn (thm_ref, thm) => (name_of thm_ref |> Long_Name.base_name, thm))
+      |> add_thms lthy
+  in
+    redeclare_short_names
+  end
+\<close>
+
+end
+
+end

--- a/proof/invariant-abstract/AARCH64/ArchCSpaceInvPre_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchCSpaceInvPre_AI.thy
@@ -180,7 +180,7 @@ lemma set_cap_valid_table_caps:
   apply (wp hoare_vcg_all_lift
             hoare_vcg_disj_lift hoare_convert_imp[OF set_cap_caps_of_state]
             hoare_use_eq[OF set_cap_arch set_cap_obj_at_impossible])
-  apply (fastforce simp: cap_asid_def the_arch_cap_def split: if_split_asm) (* FIXME AARCH64: the_arch_cap has duplicate definition *)
+  apply (fastforce simp: cap_asid_def split: if_split_asm)
   done
 
 lemma cap_asid_vs_cap_ref_None:

--- a/proof/invariant-abstract/AARCH64/ArchCSpacePre_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchCSpacePre_AI.thy
@@ -151,13 +151,6 @@ lemma arch_derived_is_device:
               split: if_split_asm cap.splits arch_cap.splits)+
   done
 
-(* FIXME AARCH64: use vcpus_of instead *)
-lemma set_cap_no_vcpu[wp]:
-  "\<lbrace>obj_at (is_vcpu and P) p\<rbrace> set_cap cap cref \<lbrace>\<lambda>_. obj_at (is_vcpu and P) p\<rbrace>"
-  unfolding set_cap_def2 split_def
-  by (wpsimp wp: set_object_wp get_object_wp get_cap_wp)
-     (auto simp: obj_at_def is_vcpu_def)
-
 lemma valid_arch_mdb_simple:
   "\<lbrakk> valid_arch_mdb (is_original_cap s) (caps_of_state s);
      is_simple_cap cap; caps_of_state s src = Some capa\<rbrakk> \<Longrightarrow>

--- a/proof/invariant-abstract/AARCH64/ArchDetSchedAux_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchDetSchedAux_AI.thy
@@ -15,106 +15,88 @@ named_theorems DetSchedAux_AI_assms
 
 crunches init_arch_objects
   for exst[wp]: "\<lambda>s. P (exst s)"
-  and ct[wp]: "\<lambda>s. P (cur_thread s)"
   and valid_etcbs[wp, DetSchedAux_AI_assms]: valid_etcbs
-  (wp: crunch_wps unless_wp valid_etcbs_lift)
+  and valid_queues[wp]: valid_queues
+  and valid_sched_action[wp]: valid_sched_action
+  and valid_sched[wp]: valid_sched
 
-crunch ct[wp, DetSchedAux_AI_assms]: invoke_untyped "\<lambda>s. P (cur_thread s)"
-  (wp: crunch_wps dxo_wp_weak preemption_point_inv mapME_x_inv_wp
-   simp: crunch_simps do_machine_op_def detype_def mapM_x_defsym unless_def
-   ignore: freeMemory retype_region_ext)
-crunch ready_queues[wp, DetSchedAux_AI_assms]: invoke_untyped "\<lambda>s. P (ready_queues s)"
+(* already proved earlier *)
+declare invoke_untyped_cur_thread[DetSchedAux_AI_assms]
+
+crunches invoke_untyped
+  for ready_queues[wp, DetSchedAux_AI_assms]: "\<lambda>s. P (ready_queues s)"
+  and scheduler_action[wp, DetSchedAux_AI_assms]: "\<lambda>s. P (scheduler_action s)"
+  and cur_domain[wp, DetSchedAux_AI_assms]: "\<lambda>s. P (cur_domain s)"
   (wp: crunch_wps mapME_x_inv_wp preemption_point_inv'
-   simp: detype_def detype_ext_def crunch_simps
-          wrap_ext_det_ext_ext_def mapM_x_defsym
-   ignore: freeMemory)
-crunch scheduler_action[wp, DetSchedAux_AI_assms]: invoke_untyped "\<lambda>s. P (scheduler_action s)"
-  (wp: crunch_wps mapME_x_inv_wp preemption_point_inv'
-   simp: detype_def detype_ext_def crunch_simps
-         wrap_ext_det_ext_ext_def mapM_x_defsym
-   ignore: freeMemory)
-crunch cur_domain[wp, DetSchedAux_AI_assms]: invoke_untyped "\<lambda>s. P (cur_domain s)"
-  (wp: crunch_wps mapME_x_inv_wp preemption_point_inv'
-   simp: detype_def detype_ext_def crunch_simps
-         wrap_ext_det_ext_ext_def mapM_x_defsym
-   ignore: freeMemory)
-crunch idle_thread[wp, DetSchedAux_AI_assms]: invoke_untyped "\<lambda>s. P (idle_thread s)"
+   simp: detype_def detype_ext_def crunch_simps wrap_ext_det_ext_ext_def mapM_x_defsym)
+
+crunches invoke_untyped
+  for idle_thread[wp, DetSchedAux_AI_assms]: "\<lambda>s. P (idle_thread s)"
   (wp: crunch_wps mapME_x_inv_wp preemption_point_inv dxo_wp_weak
-   simp: detype_def detype_ext_def crunch_simps
-         wrap_ext_det_ext_ext_def mapM_x_defsym
-   ignore: freeMemory retype_region_ext)
+   simp: detype_def detype_ext_def crunch_simps wrap_ext_det_ext_ext_def mapM_x_defsym
+   ignore: retype_region_ext)
 
 lemma tcb_sched_action_valid_idle_etcb:
-  "\<lbrace>valid_idle_etcb\<rbrace>
-     tcb_sched_action foo thread
-   \<lbrace>\<lambda>_. valid_idle_etcb\<rbrace>"
-  apply (rule valid_idle_etcb_lift)
-  apply (simp add: tcb_sched_action_def set_tcb_queue_def)
-  apply (wp | simp)+
-  done
+  "tcb_sched_action foo thread \<lbrace>valid_idle_etcb\<rbrace>"
+  by (rule valid_idle_etcb_lift)
+     (wpsimp simp: tcb_sched_action_def set_tcb_queue_def)
 
-crunch ekheap[wp]: do_machine_op "\<lambda>s. P (ekheap s)"
+crunches do_machine_op
+  for ekheap[wp]: "\<lambda>s. P (ekheap s)"
 
 lemma delete_objects_etcb_at[wp, DetSchedAux_AI_assms]:
-  "\<lbrace>\<lambda>s::det_ext state. etcb_at P t s\<rbrace> delete_objects a b \<lbrace>\<lambda>r s. etcb_at P t s\<rbrace>"
-  apply (simp add: delete_objects_def)
-  apply (simp add: detype_def detype_ext_def wrap_ext_det_ext_ext_def etcb_at_def|wp)+
-  done
+  "delete_objects a b \<lbrace>etcb_at P t\<rbrace>"
+  unfolding delete_objects_def detype_def detype_ext_def
+  by (wpsimp simp: wrap_ext_det_ext_ext_def etcb_at_def)
 
-crunch etcb_at[wp]: reset_untyped_cap "etcb_at P t"
-  (wp: preemption_point_inv' mapME_x_inv_wp crunch_wps
-    simp: unless_def)
-
-crunch valid_etcbs[wp]: reset_untyped_cap "valid_etcbs"
+crunches reset_untyped_cap
+  for etcb_at[wp]: "etcb_at P t"
+  and valid_etcbs[wp]: "valid_etcbs"
   (wp: preemption_point_inv' mapME_x_inv_wp crunch_wps
     simp: unless_def)
 
 lemma invoke_untyped_etcb_at [DetSchedAux_AI_assms]:
-  "\<lbrace>(\<lambda>s :: det_ext state. etcb_at P t s) and valid_etcbs\<rbrace> invoke_untyped ui \<lbrace>\<lambda>r s. st_tcb_at (Not o inactive) t s \<longrightarrow> etcb_at P t s\<rbrace>"
+  "\<lbrace>etcb_at P t and valid_etcbs\<rbrace>
+   invoke_untyped ui
+   \<lbrace>\<lambda>r s. st_tcb_at (Not o inactive) t s \<longrightarrow> etcb_at P t s\<rbrace>"
   apply (cases ui)
-  apply (simp add: mapM_x_def[symmetric] invoke_untyped_def whenE_def
-           split del: if_split)
-  apply (wp retype_region_etcb_at mapM_x_wp'
-            create_cap_no_pred_tcb_at typ_at_pred_tcb_at_lift
-            hoare_convert_imp[OF create_cap_no_pred_tcb_at]
-            hoare_convert_imp[OF _ init_arch_objects_exst]
-      | simp
-      | (wp (once) hoare_drop_impE_E))+
+  apply (simp add: mapM_x_def[symmetric] invoke_untyped_def)
+  apply (wpsimp wp: retype_region_etcb_at mapM_x_wp'
+                    create_cap_no_pred_tcb_at typ_at_pred_tcb_at_lift
+                    hoare_convert_imp[OF create_cap_no_pred_tcb_at]
+                    hoare_convert_imp[OF _ init_arch_objects_exst]
+                    hoare_drop_impE_E)
   done
 
 
-crunch valid_blocked[wp, DetSchedAux_AI_assms]: init_arch_objects valid_blocked
+crunches init_arch_objects
+  for valid_blocked[wp, DetSchedAux_AI_assms]: valid_blocked
   (wp: valid_blocked_lift set_cap_typ_at)
 
-lemma perform_asid_control_etcb_at:"\<lbrace>(\<lambda>s. etcb_at P t s) and valid_etcbs\<rbrace>
-          perform_asid_control_invocation aci
-          \<lbrace>\<lambda>r s. st_tcb_at (Not \<circ> inactive) t s \<longrightarrow> etcb_at P t s\<rbrace>"
+lemma perform_asid_control_etcb_at:
+  "\<lbrace>etcb_at P t and valid_etcbs\<rbrace>
+   perform_asid_control_invocation aci
+   \<lbrace>\<lambda>r s. st_tcb_at (Not \<circ> inactive) t s \<longrightarrow> etcb_at P t s\<rbrace>"
   apply (simp add: perform_asid_control_invocation_def)
-  apply (rule hoare_pre)
-   apply (wp | wpc | simp)+
+  apply wpsimp
        apply (wp hoare_imp_lift_something typ_at_pred_tcb_at_lift)[1]
       apply (rule hoare_drop_imps)
       apply (wp retype_region_etcb_at)+
   apply simp
   done
 
-crunch ct[wp]: perform_asid_control_invocation "\<lambda>s. P (cur_thread s)"
-
-crunch idle_thread[wp]: perform_asid_control_invocation "\<lambda>s. P (idle_thread s)"
-
-crunch valid_etcbs[wp]: perform_asid_control_invocation valid_etcbs (wp: static_imp_wp)
-
-crunch valid_blocked[wp]: perform_asid_control_invocation valid_blocked (wp: static_imp_wp)
-
-crunch schedact[wp]: perform_asid_control_invocation "\<lambda>s :: det_ext state. P (scheduler_action s)" (wp: crunch_wps simp: detype_def detype_ext_def wrap_ext_det_ext_ext_def cap_insert_ext_def ignore: freeMemory)
-
-crunch rqueues[wp]: perform_asid_control_invocation "\<lambda>s :: det_ext state. P (ready_queues s)" (wp: crunch_wps simp: detype_def detype_ext_def wrap_ext_det_ext_ext_def cap_insert_ext_def ignore: freeMemory)
-
-crunch cur_domain[wp]: perform_asid_control_invocation "\<lambda>s :: det_ext state. P (cur_domain s)" (wp: crunch_wps simp: detype_def detype_ext_def wrap_ext_det_ext_ext_def cap_insert_ext_def ignore: freeMemory)
+crunches perform_asid_control_invocation
+  for idle_thread[wp]: "\<lambda>s. P (idle_thread s)"
+  and valid_etcbs[wp]: valid_etcbs
+  and valid_blocked[wp]: valid_blocked
+  and schedact[wp]: "\<lambda>s. P (scheduler_action s)"
+  and ready_queues[wp]: "\<lambda>s. P (ready_queues s)"
+  and cur_domain[wp]: "\<lambda>s. P (cur_domain s)"
+  (wp: static_imp_wp)
 
 lemma perform_asid_control_invocation_valid_sched:
   "\<lbrace>ct_active and invs and valid_aci aci and valid_sched and valid_idle\<rbrace>
-     perform_asid_control_invocation aci
+   perform_asid_control_invocation aci
    \<lbrace>\<lambda>_. valid_sched\<rbrace>"
   apply (rule hoare_pre)
    apply (rule_tac I="invs and ct_active and valid_aci aci" in valid_sched_tcb_state_preservation)
@@ -130,31 +112,21 @@ lemma perform_asid_control_invocation_valid_sched:
   apply simp
   done
 
-crunch valid_queues[wp]: init_arch_objects valid_queues (wp: valid_queues_lift)
-
-crunch valid_sched_action[wp]: init_arch_objects valid_sched_action (wp: valid_sched_action_lift)
-
-crunch valid_sched[wp]: init_arch_objects valid_sched (wp: valid_sched_lift)
-
-(* FIXME AARCH64 issue with crunch ordering, ArchVCPU_AI gets there first rather than some crunch
-   that does this declaration *)
-declare invoke_untyped_cur_thread[DetSchedAux_AI_assms]
-
 end
 
 lemmas tcb_sched_action_valid_idle_etcb
     = AARCH64.tcb_sched_action_valid_idle_etcb
 
 global_interpretation DetSchedAux_AI_det_ext?: DetSchedAux_AI_det_ext
-  proof goal_cases
+proof goal_cases
   interpret Arch .
   case 1 show ?case by (unfold_locales; (fact DetSchedAux_AI_assms)?)
-  qed
+qed
 
 global_interpretation DetSchedAux_AI?: DetSchedAux_AI
-  proof goal_cases
+proof goal_cases
   interpret Arch .
   case 1 show ?case by (unfold_locales; (fact DetSchedAux_AI_assms)?)
-  qed
+qed
 
 end

--- a/proof/invariant-abstract/AARCH64/ArchDetSchedSchedule_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchDetSchedSchedule_AI.thy
@@ -62,11 +62,6 @@ lemma vcpu_switch_weak_valid_sched_action[wp]:
   "\<lbrace>weak_valid_sched_action\<rbrace> vcpu_switch v \<lbrace>\<lambda>_. weak_valid_sched_action\<rbrace>"
   by (rule weak_valid_sched_action_lift; wp)
 
-lemma set_asid_pool_pred_tcb_atP[wp]: (* FIXME AARCH64: replace set_asid_pool_pred_tcb_at in ArchAcc *)
-  "set_asid_pool ptr val \<lbrace>\<lambda>s. P (pred_tcb_at proj Q t s)\<rbrace>"
-  unfolding set_asid_pool_def set_object_def
-  by (wpsimp wp: get_object_wp simp: pred_tcb_at_def obj_at_def)
-
 crunch pred_tcb_atP[wp]: set_vm_root "\<lambda>s. P (pred_tcb_at proj Q t s)"
   (wp: crunch_wps simp: crunch_simps)
 

--- a/proof/invariant-abstract/AARCH64/ArchDetype_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchDetype_AI.thy
@@ -315,11 +315,6 @@ lemma vcpu_tcbs_of_detype[simp]:
   "(vcpu_tcbs_of (detype S s) p = Some aobj) = (p \<notin> S \<and> vcpu_tcbs_of s p = Some aobj)"
   by (simp add: in_omonad detype_def)
 
-(* FIXME AARCH64: move above obj_at_vcpu_hyp_live_of *)
-lemma obj_at_vcpu_hyp_live_of_s:
-  "obj_at (is_vcpu and hyp_live) p s = vcpu_hyp_live_of s p"
-  by (rule arg_cong[OF obj_at_vcpu_hyp_live_of, where f="\<lambda>x. x s"])
-
 lemma cur_vcpu_detype:
   "cur_vcpu (detype (untyped_range cap) s)"
   using valid_arch_state

--- a/proof/invariant-abstract/AARCH64/ArchDetype_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchDetype_AI.thy
@@ -318,12 +318,9 @@ lemma vcpu_tcbs_of_detype[simp]:
 lemma cur_vcpu_detype:
   "cur_vcpu (detype (untyped_range cap) s)"
   using valid_arch_state
-  apply (clarsimp simp: valid_arch_state_def cur_vcpu_def)
-  (* FIXME AARCH64: work around <| being an abbreviation for option_case *)
-  apply (case_tac "arm_current_vcpu (arch_state s)"; simp)
-  apply clarsimp
+  apply (clarsimp simp: valid_arch_state_def cur_vcpu_def split: option.splits)
   apply (frule obj_at_vcpu_hyp_live_of_s[THEN iffD2])
-  apply (clarsimp elim!: live_okE simp: hyp_live_strg split: option.splits)
+  apply (clarsimp elim!: live_okE simp: hyp_live_strg in_opt_pred split: option.splits)
   done
 
 lemma valid_global_arch_objs:

--- a/proof/invariant-abstract/AARCH64/ArchFinalise_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchFinalise_AI.thy
@@ -60,18 +60,6 @@ lemma invs_arm_asid_table_unmap:
                    valid_asid_pool_caps_def equal_kernel_mappings_asid_table_unmap)
   done
 
-(* FIXME AARCH64: move next to mapM_set *)
-lemma mapM_set_inv:
-  assumes "\<And>x. x \<in> set xs \<Longrightarrow> \<lbrace>P\<rbrace> f x \<lbrace>\<lambda>_. P\<rbrace>"
-  assumes "\<And>x. x \<in> set xs \<Longrightarrow> \<lbrace>P\<rbrace> f x \<lbrace>\<lambda>_. Q x\<rbrace>"
-  assumes "\<And>x y. \<lbrakk> x \<in> set xs; y \<in> set xs \<rbrakk> \<Longrightarrow> \<lbrace>P and Q y\<rbrace> f x \<lbrace>\<lambda>_. Q y\<rbrace>"
-  shows "\<lbrace>P\<rbrace> mapM f xs \<lbrace>\<lambda>_ s. P s \<and> (\<forall>x \<in> set xs. Q x s)\<rbrace>"
-  apply (rule hoare_weaken_pre, rule hoare_vcg_conj_lift)
-    apply (rule mapM_wp', erule assms)
-   apply (rule mapM_set; rule assms; assumption)
-  apply simp
-  done
-
 lemma asid_low_bits_of_add:
   "\<lbrakk> is_aligned base asid_low_bits; offset \<le> mask asid_low_bits \<rbrakk> \<Longrightarrow>
    asid_low_bits_of (base + offset) = ucast offset"
@@ -1229,11 +1217,6 @@ lemma vs_lookup_target_clear_asid_strg:
   by (clarsimp simp: vs_lookup_target_def vs_lookup_slot_def vs_lookup_table_def pool_for_asid_def
                      obind_def)
 
-(* FIXME AARCH64: move *)
-lemma None_Some_strg:
-  "x = None \<Longrightarrow> x \<noteq> Some y"
-  by simp
-
 lemma delete_asid_pool_not_target[wp]:
   "\<lbrace>asid_pool_at ptr and valid_vspace_objs and valid_asid_table and pspace_aligned\<rbrace>
    delete_asid_pool asid ptr
@@ -1305,11 +1288,6 @@ lemma delete_asid_no_vs_lookup_target_vspace:
                         vspace_for_asid_def vspace_for_pool_def entry_for_asid_def obind_None_eq
                   split: if_split_asm)
   done
-
-(* FIXME AARCH64: move *)
-lemma hoare_pre_cases:
-  "\<lbrakk> \<lbrace>\<lambda>s. R s \<and> P s\<rbrace> f \<lbrace>Q\<rbrace>; \<lbrace>\<lambda>s. \<not>R s \<and> P' s\<rbrace> f \<lbrace>Q\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P and P'\<rbrace> f \<lbrace>Q\<rbrace>"
-  unfolding valid_def by fastforce
 
 lemma delete_asid_no_vs_lookup_target_no_vspace:
   "\<lbrace>\<lambda>s. vspace_for_asid asid s \<noteq> Some pt \<and> 0 < asid \<and> vref \<in> user_region \<and> vspace_pt_at pt s \<and>

--- a/proof/invariant-abstract/AARCH64/ArchFinalise_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchFinalise_AI.thy
@@ -1016,7 +1016,7 @@ lemma set_vcpu_None_valid_arch[wp]:
   apply (wpsimp wp: set_vcpu_wp)
   apply (clarsimp simp: valid_arch_state_def valid_global_arch_objs_def pts_of_vcpu_None_upd_idem
                         asid_pools_of_vcpu_None_upd_idem vmid_inv_def pt_at_eq_set_vcpu)
-  apply (clarsimp simp add: cur_vcpu_def fun_upd_apply split: option.splits)
+  apply (clarsimp simp add: cur_vcpu_def fun_upd_apply in_opt_pred split: option.splits)
   done
 
 lemma dissociate_vcpu_valid_arch[wp]:

--- a/proof/invariant-abstract/AARCH64/ArchFinalise_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchFinalise_AI.thy
@@ -1012,17 +1012,6 @@ lemma vcpu_disable_valid_machine_state[wp]:
              simp: isb_def setHCR_def setSCTLR_def set_gic_vcpu_ctrl_hcr_def getSCTLR_def
                    get_gic_vcpu_ctrl_hcr_def dsb_def writeVCPUHardwareReg_def maskInterrupt_def)
 
-(* FIXME AARCH64: move to ArchVSpace_AI above valid_irq_node_arch_state_update *)
-lemma arm_asid_table_current_vcpu_update[simp]:
-  "arm_asid_table ((arm_current_vcpu_update v) (arch_state s)) = arm_asid_table (arch_state s)"
-  by clarsimp
-
-(* FIXME AARCH64: move to ArchVSpace_AI above valid_irq_node_arch_state_update *)
-lemma vmid_inv_current_vcpu_update[simp]:
-  "vmid_inv (s\<lparr>arch_state := arm_current_vcpu_update Map.empty (arch_state s)\<rparr>) =
-   vmid_inv s"
-  by (clarsimp simp: vmid_inv_def)
-
 lemma valid_arch_state_vcpu_update_str:
   "valid_arch_state s \<Longrightarrow> valid_arch_state (s\<lparr>arch_state := arm_current_vcpu_update Map.empty (arch_state s)\<rparr>)"
   unfolding valid_arch_state_def

--- a/proof/invariant-abstract/AARCH64/ArchFinalise_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchFinalise_AI.thy
@@ -1644,10 +1644,6 @@ crunch pred_tcb_at[wp]:
 crunch pred_tcb_at[wp_unsafe]: arch_finalise_cap "pred_tcb_at proj P t"
   (simp: crunch_simps wp: crunch_wps)
 
-(* FIXME AARCH64
-crunch empty[wp]: find_free_hw_asid, store_hw_asid, load_hw_asid, set_vm_root_for_flush, page_table_mapped, invalidate_tlb_by_asid
-  "\<lambda>s. P (obj_at (empty_table {}) word s)" *)
-
 lemma set_vcpu_empty[wp]:
   "\<lbrace>\<lambda>s. P (obj_at (empty_table {}) word s)\<rbrace> set_vcpu p v \<lbrace>\<lambda>_ s. P (obj_at (empty_table {}) word s)\<rbrace>"
   apply (rule set_vcpu.vsobj_at)

--- a/proof/invariant-abstract/AARCH64/ArchInterrupt_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchInterrupt_AI.thy
@@ -19,7 +19,7 @@ primrec arch_irq_control_inv_valid_real ::
       cte_wp_at ((=) cap.IRQControlCap) src_slot and
       ex_cte_cap_wp_to is_cnode_cap dest_slot and
       real_cte_at dest_slot and
-      K (irq \<le> maxIRQ))" (*FIXME AARCH64 check this is gone: \<and> irq \<noteq> irqInvalid))" *)
+      K (irq \<le> maxIRQ))"
 
 defs arch_irq_control_inv_valid_def:
   "arch_irq_control_inv_valid \<equiv> arch_irq_control_inv_valid_real"
@@ -49,12 +49,7 @@ lemma decode_irq_control_valid [Interrupt_AI_asms]:
   apply (clarsimp simp: linorder_not_less word_le_nat_alt unat_ucast maxIRQ_def)
   apply (cases caps; clarsimp simp: cte_wp_at_eq_simp)
   apply (intro conjI impI; clarsimp)
-  done (* FIXME AARCH64 this felt too easy, old proof went:
-  apply (drule ucast_ucast_mask_eq)
-   apply (subst and_mask_eq_iff_le_mask)
-   apply (simp add: mask_def word_le_nat_alt)
-  apply fast
-  done *)
+  done
 
 lemma get_irq_slot_different_ARCH[Interrupt_AI_asms]:
   "\<lbrace>\<lambda>s. valid_global_refs s \<and> ex_cte_cap_wp_to is_cnode_cap ptr s\<rbrace>

--- a/proof/invariant-abstract/AARCH64/ArchInvariants_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchInvariants_AI.thy
@@ -2395,6 +2395,10 @@ lemma pt_slot_offset_pt_range:
   for level::vm_level
   by (clarsimp simp: ptes_of_Some)
 
+lemma ucast_ucast_ppn:
+  "ucast (ucast ptr::ppn) = ptr && mask ppn_len" for ptr::obj_ref
+  by (simp add: ucast_ucast_mask ppn_len_def)
+
 lemma pte_base_addr_PageTablePTE[simp]:
   "pte_base_addr (PageTablePTE ppn) = paddr_from_ppn ppn"
   by (simp add: pte_base_addr_def)

--- a/proof/invariant-abstract/AARCH64/ArchInvariants_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchInvariants_AI.thy
@@ -804,12 +804,12 @@ lemma max_pt_level_gt0[simp]:
 lemma max_pt_level_enum:
   "level \<le> max_pt_level \<Longrightarrow> if config_ARM_PA_SIZE_BITS_40 then level \<in> {0,1,2} else level \<in> {0,1,2,3}"
   unfolding level_defs Kernel_Config.config_ARM_PA_SIZE_BITS_40_def
-  by (cases level rule: vm_level_of_nat_cases) (case_tac m; simp; rename_tac m)+
+  by (cases level rule: vm_level.of_nat_cases) (case_tac m; simp; rename_tac m)+
 
 lemma max_page_level_enum:
   "level \<le> max_page_level \<Longrightarrow> level \<in> {0,1,2}"
   unfolding level_defs
-  by (cases level rule: vm_level_of_nat_cases) (case_tac m; simp; rename_tac m)+
+  by (cases level rule: vm_level.of_nat_cases) (case_tac m; simp; rename_tac m)+
 
 lemma asid_pool_level_size:
   "size asid_pool_level = (if config_ARM_PA_SIZE_BITS_40 then 3 else 4)"
@@ -827,7 +827,7 @@ lemma asid_pool_level_not_0[simp]:
 lemma vm_level_not_less_zero:
   fixes level :: vm_level
   shows "level \<noteq> 0 \<Longrightarrow> level > 0"
-  using vm_level_not_less_zero_bit0 neqE by blast
+  using vm_level.not_less_zero_bit0 neqE by blast
 
 lemma asid_pool_level_neq[simp]:
   "(x \<noteq> asid_pool_level) = (x \<le> max_pt_level)"
@@ -836,7 +836,7 @@ proof
   hence "x < asid_pool_level"
     unfolding asid_pool_level_def by simp
   thus "x \<le> max_pt_level"
-    by (simp add: max_pt_level_def vm_level_leq_minus1_less)
+    by (simp add: max_pt_level_def vm_level.leq_minus1_less)
 next
   note maxBound_minus_one_bit[simp del]
   assume "x \<le> max_pt_level"
@@ -892,7 +892,7 @@ lemma max_pt_level_plus_one:
 
 lemma max_pt_level_less_Suc[iff]:
   "(level < level + 1) = (level \<le> max_pt_level)"
-  apply (simp add: vm_level_no_overflow_eq_max_bound max_pt_level_def flip: asid_pool_level_minus)
+  apply (simp add: vm_level.no_overflow_eq_max_bound max_pt_level_def flip: asid_pool_level_minus)
   by (metis asid_pool_level_max asid_pool_level_neq max_pt_level_def antisym_conv2)
 
 lemma size_level1[simp]:
@@ -900,7 +900,7 @@ lemma size_level1[simp]:
 proof
   assume "size level = Suc 0"
   hence "size level = size (1::vm_level)" by simp
-  thus "level = 1" by (subst (asm) vm_level_size_inj)
+  thus "level = 1" by (subst (asm) vm_level.size_inj)
 qed auto
 
 lemma minus_one_max_pt_level[simp]:
@@ -917,7 +917,7 @@ lemma max_inc_pt_level[simp]:
 
 lemma vm_level_le_plus_1_mono:
   "\<lbrakk>level' \<le> level; level \<le> max_pt_level \<rbrakk> \<Longrightarrow> level' + 1 \<le> level + 1"
-  by (simp add: vm_level_plus_one_leq le_less_trans)
+  by (simp add: vm_level.plus_one_leq le_less_trans)
 
 lemma vm_level_less_plus_1_mono:
   "\<lbrakk> level' < level; level \<le> max_pt_level \<rbrakk> \<Longrightarrow> level' + 1 < level + 1"
@@ -925,7 +925,7 @@ lemma vm_level_less_plus_1_mono:
 
 lemma level_minus_one_max_pt_level[iff]:
   "(level - 1 \<le> max_pt_level) = (0 < level)"
-  by (metis max_pt_level_less_Suc vm_level_not_less_zero_bit0 vm_level_pred diff_add_cancel
+  by (metis max_pt_level_less_Suc vm_level.not_less_zero_bit0 vm_level.pred diff_add_cancel
            not_less_iff_gr_or_eq)
 
 (* Sometimes you need type nat directly in the goal, not vm_level *)
@@ -1506,8 +1506,8 @@ lemma pt_walk_max_level:
   apply (clarsimp simp: in_omonad split: if_split_asm)
   apply (erule disjE; clarsimp)
   apply (drule meta_spec, drule (1) meta_mp)
-  apply (drule vm_level_zero_least)
-  using vm_level_pred less_trans not_less by blast
+  apply (drule vm_level.zero_least)
+  using vm_level.pred less_trans not_less by blast
 
 lemma pt_walk_min_level:
   "pt_walk top_level bot_level pt_ptr vptr ptes = Some (level, p)
@@ -1519,7 +1519,7 @@ lemma pt_walk_min_level:
   apply (clarsimp simp: in_omonad split: if_split_asm)
   apply (erule disjE; clarsimp)
   apply (drule meta_spec, drule (1) meta_mp)
-  apply (auto simp: min_def split: if_split_asm dest: vm_level_minus1_leq)
+  apply (auto simp: min_def split: if_split_asm dest: vm_level.minus1_leq)
   done
 
 lemma pt_walk_top:
@@ -1642,9 +1642,9 @@ lemma pt_walk_vref_for_level_eq:
    apply (simp add: pt_walk.simps)
   apply (subst pt_walk.simps)
   apply (subst (2) pt_walk.simps)
-  apply (simp add: Let_def vm_level_leq_minus1_less)
+  apply (simp add: Let_def vm_level.leq_minus1_less)
   apply (drule_tac level'=top_level in vref_for_level_eq_mono)
-   apply (simp add: vm_level_plus_one_leq)
+   apply (simp add: vm_level.plus_one_leq)
   apply (drule_tac pt=pt in vref_for_level_pt_slot_offset)
   apply (clarsimp simp: obind_def split: option.splits)
   done
@@ -1659,7 +1659,7 @@ lemma pt_walk_vref_for_level1:
   "\<lbrakk> level \<le> bot_level; bot_level \<le> top_level; top_level \<le> max_pt_level \<rbrakk> \<Longrightarrow>
    pt_walk top_level bot_level pt (vref_for_level vref (level+1)) =
    pt_walk top_level bot_level pt vref"
-  by (meson max_pt_level_less_Suc vm_level_plus_one_leq leD leI order.trans vref_for_level_idem
+  by (meson max_pt_level_less_Suc vm_level.plus_one_leq leD leI order.trans vref_for_level_idem
             pt_walk_vref_for_level_eq)
 
 lemma vs_lookup_vref_for_level1:
@@ -1784,7 +1784,7 @@ lemma pt_walk_level:
   apply (clarsimp simp: in_omonad split: if_split_asm)
   apply (erule disjE; clarsimp)
   apply (drule meta_spec, drule (1) meta_mp)
-  by (fastforce simp: vm_level_leq_minus1_less dest: pt_walk_max_level)
+  by (fastforce simp: vm_level.leq_minus1_less dest: pt_walk_max_level)
 
 lemma vs_lookup_level:
   "vs_lookup_table bot_level asid vref s = Some (level, p) \<Longrightarrow>
@@ -1912,7 +1912,7 @@ lemma pt_slot_offset_vref:
   apply (prop_tac "size level \<le> size max_pt_level", simp)
   apply (simp add: size_max_pt_level split: if_split_asm)
    apply (erule_tac x="(9 + (9 * size level + n))" in allE,
-          (erule impE; clarsimp), simp flip: vm_level_size_less)+
+          (erule impE; clarsimp), simp flip: vm_level.size_less)+
   done
 
 lemma pt_slot_offset_vref_for_level_eq:
@@ -2078,7 +2078,7 @@ lemma pt_walk_split:
    apply (fastforce simp: obind_assoc intro: opt_bind_cong)
   apply (subgoal_tac "level' < top_level -1")
    apply (fastforce simp: obind_assoc intro: opt_bind_cong)
-  apply (meson vm_level_minus1_leq not_le less_le)
+  apply (meson vm_level.minus1_leq not_le less_le)
   done
 
 lemma pt_walk_split_short:
@@ -2098,7 +2098,7 @@ lemma pt_walk_split_short:
   apply (subgoal_tac "level' < top_level -1")
    apply (clarsimp simp: obind_assoc)
    apply (fastforce simp: obind_def pt_walk.simps intro!: opt_bind_cong)
-  apply (meson vm_level_minus1_leq not_le less_le)
+  apply (meson vm_level.minus1_leq not_le less_le)
   done
 
 lemma pt_walk_split_Some:
@@ -2155,7 +2155,7 @@ lemma vs_lookup_table_split_last_Some:
   apply (clarsimp simp: vs_lookup_table_def in_omonad asid_pool_level_eq
                          vm_level_less_max_pt_level)
   apply (subst (asm) pt_walk_split_Some[where level'="level+1"])
-    apply (clarsimp simp add: less_imp_le vm_level_plus_one_leq)+
+    apply (clarsimp simp add: less_imp_le vm_level.plus_one_leq)+
   apply (subst (asm) (2) pt_walk.simps)
   apply (clarsimp simp: in_omonad split: if_splits)
   done
@@ -2301,7 +2301,7 @@ lemma valid_vspace_objs_strongD:
         pt_type pt = level_type level"
   supply valid_vspace_obj.simps[simp del]
   apply (drule vs_lookup_level)
-  apply (induct level arbitrary: pt_ptr rule: vm_level_from_top_induct[where y="max_pt_level"])
+  apply (induct level arbitrary: pt_ptr rule: vm_level.from_top_induct[where y="max_pt_level"])
    apply simp
    apply (drule (3) vs_lookup_max_pt_valid, simp)
   apply (rename_tac level pt_ptr)
@@ -2610,7 +2610,7 @@ lemma vref_for_level_idx_canonical_user:
    apply (frule bit_imp_possible_bit)
    apply simp
    apply (drule xt1(11), simp)
-   apply (subst (asm) vm_level_size_less[symmetric])
+   apply (subst (asm) vm_level.size_less[symmetric])
    apply (simp add: size_max_pt_level)
   apply (cases "level = max_pt_level")
    apply (clarsimp simp: bit_simps pt_bits_left_def size_max_pt_level asid_pool_level_eq word_size)
@@ -2622,7 +2622,7 @@ lemma vref_for_level_idx_canonical_user:
   apply (simp add: bit_simps pt_bits_left_def size_max_pt_level asid_pool_level_eq word_size)
   apply (frule bit_imp_possible_bit)
   apply (drule xt1(11), simp)
-  apply (subst (asm) vm_level_size_less[symmetric])
+  apply (subst (asm) vm_level.size_less[symmetric])
   apply (simp add: size_max_pt_level)
   done
 
@@ -2729,7 +2729,7 @@ lemma pt_bits_left_inj[simp]:
   apply (intro iffI; clarsimp?)
   apply (clarsimp simp: pt_bits_left_def bit_simps
                  split: if_splits)
-     by (metis vm_level_size_less_eq diff_is_0_eq' mult_zero_right right_diff_distrib' sum_imp_diff
+     by (metis vm_level.size_less_eq diff_is_0_eq' mult_zero_right right_diff_distrib' sum_imp_diff
                zero_neq_numeral)+
 
 lemma pt_walk_stopped:

--- a/proof/invariant-abstract/AARCH64/ArchInvariants_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchInvariants_AI.thy
@@ -1342,7 +1342,6 @@ lemma hyp_sym_refs_obj_atD:
   "\<lbrakk> obj_at P p s; sym_refs (state_hyp_refs_of s) \<rbrakk>
    \<Longrightarrow> \<exists>ko. P ko \<and> state_hyp_refs_of s p = hyp_refs_of ko \<and>
            (\<forall>(x, tp)\<in>hyp_refs_of ko. obj_at (\<lambda>ko. (p, symreftype tp) \<in> hyp_refs_of ko) x s)"
-  supply hyp_refs_of_simps[simp del]
   apply (drule obj_at_state_hyp_refs_ofD)
   apply (erule exEI, clarsimp)
   apply (drule sym, simp)

--- a/proof/invariant-abstract/AARCH64/ArchKHeap_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchKHeap_AI.thy
@@ -492,15 +492,11 @@ definition level_of_slot :: "asid \<Rightarrow> vspace_ref \<Rightarrow> obj_ref
   "level_of_slot asid vref p s \<equiv>
      GREATEST level. vs_lookup_slot level asid vref s = Some (level, p)"
 
-(* FIXME AARCH64: move *)
-lemmas vm_level_GreatestI = bit1.GreatestI
-lemmas vm_level_Greatest_le = bit1.Greatest_le
-
 lemma level_of_slotI:
   "\<lbrakk> vs_lookup_slot level' asid vref s = Some (level', p); level < level'\<rbrakk>
    \<Longrightarrow> vs_lookup_slot (level_of_slot asid vref p s) asid vref s = Some (level_of_slot asid vref p s, p)
        \<and> level < level_of_slot asid vref p s"
-  by (auto simp: level_of_slot_def dest: vm_level_GreatestI vm_level_Greatest_le)
+  by (auto simp: level_of_slot_def dest: vm_level.GreatestI vm_level.Greatest_le)
 
 lemma pool_for_asid_no_pt:
   "\<lbrakk> pool_for_asid asid s = Some p; pts_of s p = Some pte; valid_asid_table s; pspace_aligned s \<rbrakk>
@@ -574,9 +570,6 @@ lemma vs_lookup_slot_level_type:
    \<Longrightarrow> level_type level = pt_t"
   by (fastforce simp: ptes_of_Some intro!: pts_of_type_unique dest: valid_vspace_objs_strong_slotD)
 
-(* FIXME AARCH64: move *)
-lemmas vm_level_from_top_full_induct = bit1.from_top_full_induct
-
 (* Removing a page table pte entry at p will cause lookups to stop at higher levels than requested.
    If performing a shallower lookup than the one requested results in p, then any deeper lookup
    in the updated state will return a higher level result along the original path. *)
@@ -590,7 +583,7 @@ lemma vs_lookup_non_PageTablePTE:
      (if \<exists>level'. vs_lookup_slot level' asid vref s = Some (level', p) \<and> level < level'
       then vs_lookup_table (level_of_slot asid vref p s) asid vref s
       else vs_lookup_table level asid vref s)"
-  apply (induct level rule: vm_level_from_top_full_induct[where y=max_pt_level])
+  apply (induct level rule: vm_level.from_top_full_induct[where y=max_pt_level])
    apply (clarsimp simp: geq_max_pt_level)
    apply (erule disjE; clarsimp)
     apply (rule conjI; clarsimp)
@@ -616,10 +609,10 @@ lemma vs_lookup_non_PageTablePTE:
   subgoal for x old_pte
     apply (subst vs_lookup_split[where level'="x+1"])
       apply (simp add: less_imp_le)
-     apply (simp add: vm_level_plus_one_leq)
+     apply (simp add: vm_level.plus_one_leq)
     apply (subst (2) vs_lookup_split[where level'="x+1"])
       apply (simp add: less_imp_le)
-     apply (simp add: vm_level_plus_one_leq)
+     apply (simp add: vm_level.plus_one_leq)
     apply (erule_tac x="x+1" in allE)
     apply (simp add: less_imp_le)
     apply (simp  split: if_split_asm)

--- a/proof/invariant-abstract/AARCH64/ArchKHeap_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchKHeap_AI.thy
@@ -561,6 +561,14 @@ lemma pts_of_type_unique:
                 simp: in_omonad is_aligned_no_overflow_mask and_neg_mask_plus_mask_mono pt_bits_def
                       word_and_le)
 
+lemma pts_of_level_type_unique:
+  "\<lbrakk> pts_of s (table_base (level_type level) pte_ptr) = Some pt;
+     pts_of s (table_base (level_type level') pte_ptr) = Some pt';
+     pt_type pt = level_type level; pt_type pt' = level_type level';
+     pspace_distinct s \<rbrakk>
+   \<Longrightarrow> level_type level' = level_type level"
+  by (metis pts_of_type_unique)
+
 (* If we look up a slot for some level, and we know there is a pte for type pt_t at that slot,
    then it must agree with the level type of the lookup. *)
 lemma vs_lookup_slot_level_type:

--- a/proof/invariant-abstract/AARCH64/ArchKernelInit_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchKernelInit_AI.thy
@@ -191,31 +191,6 @@ lemma pt_walk_init_A_st[simp]:
                    is_aligned_pt_slot_offset_pte[where pt_t=VSRootPT_T])
   done
 
-(* FIXME AARCH64: statement -- this depends on PA_40 config; potentially not needed
-lemma table_index_arm_global_pt_ptr:
-  "table_index VSRootPT_T (pt_slot_offset max_pt_level arm_global_pt_ptr vref) =
-  (vref >> (ptTranslationBits NormalPT_T) * 2 + pageBits) && mask (ptTranslationBits NormalPT_T)"
-  apply (simp add: pt_slot_offset_def pt_index_def pt_bits_left_def  level_defs
-                   arm_global_pt_ptr_def pptr_base_def pptrBase_def canonical_bit_def)
-  apply (subst word_plus_and_or_coroll)
-   apply word_bitwise
-   apply simp
-  apply word_bitwise
-  apply (clarsimp simp: word_size)
-  done *)
-
-lemma kernel_window_1G:
-  "\<lbrakk> pptr_base \<le> vref; vref < pptr_base + (1 << 30) \<rbrakk> \<Longrightarrow>
-    table_index VSRootPT_T (pt_slot_offset max_pt_level arm_global_pt_ptr vref) = 0x100"
-  oops (* FIXME AARCH64 -- this depends on PA_40 config; potentially not needed
-  apply (simp add: table_index_arm_global_pt_ptr)
-  apply (simp add: bit_simps pptr_base_def pptrBase_def neg_mask_le_high_bits word_size flip: NOT_mask)
-  apply (subst (asm) mask_def)
-  apply (simp add: canonical_bit_def)
-  apply word_bitwise
-  apply (clarsimp simp: word_size)
-  done  *)
-
 lemma kernel_window_init_st:
   "kernel_window init_A_st = { pptr_base ..< pptr_base + (1 << 30) }"
   by (auto simp: state_defs kernel_window_def)

--- a/proof/invariant-abstract/AARCH64/ArchLevityCatch_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchLevityCatch_AI.thy
@@ -30,7 +30,7 @@ lemma ptrFormPAddr_addFromPPtr[simp]:
 
 lemma asid_high_bits_of_add_ucast:
   "is_aligned w asid_low_bits \<Longrightarrow>
-  asid_high_bits_of (ucast (x::9 word) + w) = asid_high_bits_of w"
+  asid_high_bits_of (ucast (x::asid_low_index) + w) = asid_high_bits_of w"
   apply (rule word_eqI)
   apply (simp add: word_size asid_high_bits_of_def nth_ucast nth_shiftr is_aligned_nth)
   apply (subst word_plus_and_or_coroll)

--- a/proof/invariant-abstract/AARCH64/ArchVCPU_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchVCPU_AI.thy
@@ -11,7 +11,7 @@ begin
 
 context Arch begin global_naming AARCH64 (*FIXME: arch_split*)
 
-(* FIXME AARCH64: move to ArchInvariants_AI and use there *)
+(* This is similar to cur_vcpu_2, but not close enough to reuse. *)
 definition active_cur_vcpu_of :: "'z state \<Rightarrow> obj_ref option" where
   "active_cur_vcpu_of s \<equiv> case arm_current_vcpu (arch_state s) of Some (vr, True) \<Rightarrow> Some vr
                                                                  | _  \<Rightarrow> None"

--- a/proof/invariant-abstract/AARCH64/ArchVSpace_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchVSpace_AI.thy
@@ -1330,12 +1330,12 @@ next
      apply simp
      apply (erule mp)
      apply (subst pt_walk.simps)
-     apply (simp add: in_omonad vm_level_leq_minus1_less)
+     apply (simp add: in_omonad vm_level.leq_minus1_less)
     apply (subst (asm) (3) pt_walk.simps)
     apply (case_tac "level = top_level - 1"; clarsimp)
     apply (subgoal_tac "level < top_level - 1", fastforce)
-    apply (frule vm_level_zero_least)
-    apply (subst (asm) vm_level_leq_minus1_less[symmetric], assumption)
+    apply (frule vm_level.zero_least)
+    apply (subst (asm) vm_level.leq_minus1_less[symmetric], assumption)
     apply simp
     done
 qed
@@ -1486,7 +1486,7 @@ lemma store_pte_invalid_vs_lookup_target_unmap:
     (* PageTablePTE: level' would have to be asid_pool_level, contradiction *)
     apply (drule (1) vs_lookup_table_step; simp?)
       apply (rule ccontr)
-      apply (clarsimp simp flip: bit1.neq_0_conv simp: is_PageTablePTE_def)
+      apply (clarsimp simp flip: vm_level.neq_0_conv simp: is_PageTablePTE_def)
      apply (fastforce simp: pte_ref_Some_cases)
     apply (drule (1) no_loop_vs_lookup_table; simp?)
    (* PagePTE *)
@@ -1613,7 +1613,7 @@ lemma unmap_page_table_not_target:
    apply (clarsimp simp: data_at_def obj_at_def)
   apply (clarsimp simp: vs_lookup_slot_def split: if_split_asm)
   apply (drule (4) vs_lookup_table_step, simp)
-  apply (prop_tac "level - 1 < max_pt_level", erule (1) bit1.minus_one_leq_less) (* FIXME AARCH64: bit1 *)
+  apply (prop_tac "level - 1 < max_pt_level", erule (1) vm_level.minus_one_leq_less)
   apply fastforce
   done
 

--- a/proof/invariant-abstract/AARCH64/ArchVSpace_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchVSpace_AI.thy
@@ -142,14 +142,6 @@ lemma vs_lookup_target_clear_asid_table:
   apply blast
   done
 
-(* FIXME AARCH64: move to Word_Lib *)
-lemma word_mask_shift_eqI:
-  "\<lbrakk> x && mask n = y && mask n; x >> n = y >> n \<rbrakk> \<Longrightarrow> x = y"
-  apply (subst mask_or_not_mask[of x n, symmetric])
-  apply (subst mask_or_not_mask[of y n, symmetric])
-  apply (rule arg_cong2[where f="(OR)"]; blast intro: shiftr_eq_neg_mask_eq)
-  done
-
 lemma vmid_for_asid_unmap_pool:
   "\<forall>asid_low. vmid_for_asid_2 (asid_of asid_high asid_low) table pools = None \<Longrightarrow>
    vmid_for_asid_2 asid (table(asid_high := None)) pools = vmid_for_asid_2 asid table pools"
@@ -332,9 +324,6 @@ lemma hyp_live_vcpu_vtimer_idem[simp]:
 lemma vcpu_update_vtimer_hyp_live[wp]:
   "vcpu_update vcpu_ptr (vcpu_vtimer_update f) \<lbrace> obj_at hyp_live p \<rbrace>"
   by (wpsimp wp: vcpu_update_obj_at simp: obj_at_def in_omonad)
-
-crunches do_machine_op (* FIXME AARCH64: move to KHeap crunches *)
-  for kheap[wp]: "\<lambda>s. P (kheap s)"
 
 crunches vcpu_save_reg, vcpu_write_reg
   for vcpu_hyp_live[wp]: "\<lambda>s. P (vcpu_hyp_live_of s)"

--- a/proof/invariant-abstract/AARCH64/ArchVSpace_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchVSpace_AI.thy
@@ -277,7 +277,7 @@ lemma set_vcpu_valid_arch_state_hyp_live:
   apply (wpsimp wp: set_vcpu_wp simp: valid_arch_state_def)
   apply (clarsimp simp: asid_pools_of_vcpu_None_upd_idem vmid_inv_def)
   apply (rule conjI)
-   apply (clarsimp simp: cur_vcpu_2_def hyp_live_vcpu_tcb split: option.splits)
+   apply (clarsimp simp: cur_vcpu_2_def hyp_live_vcpu_tcb in_opt_pred split: option.splits)
   apply (clarsimp simp: valid_global_arch_objs_def obj_at_def pts_of_vcpu_None_upd_idem)
   done
 
@@ -2769,7 +2769,7 @@ lemma set_vcpu_valid_arch_eq_hyp:
   apply (clarsimp simp: vmid_inv_set_vcpu asid_pools_of_vcpu_None_upd_idem pts_of_vcpu_None_upd_idem
                         valid_global_arch_objs_def pt_at_eq_set_vcpu)
   apply (clarsimp simp: cur_vcpu_def split: option.splits)
-  by (auto simp: obj_at_def  vcpu_tcb_refs_def opt_map_def split: option.splits)
+  by (auto simp: obj_at_def  vcpu_tcb_refs_def opt_map_def in_opt_pred split: option.splits)
 
 lemma set_vcpu_invs_eq_hyp:
   "\<lbrace>obj_at (\<lambda>ko'. hyp_refs_of ko' = hyp_refs_of (ArchObj (VCPU v))) p

--- a/proof/invariant-abstract/AARCH64/Machine_AI.thy
+++ b/proof/invariant-abstract/AARCH64/Machine_AI.thy
@@ -291,7 +291,6 @@ crunch_ignore (valid, empty_fail, no_fail)
    grep -oE "(\w+_impl)|(get\w+)" MachineOps.thy|sort|uniq|sed "s/_impl//;s/$/,/;s/^/  /"
    with the following manual interventions:
    - remove false positives: get_def, gets_def, getFPUState, getRegister, getRestartPC
-   - add readVCPUHardwareReg (which uses non-standard "Val" instead of "_val" (FIXME AARCH64))
    - add read_cntpct
    - remove final comma
    - getActiveIRQ does not preserve no_irq *)

--- a/proof/invariant-abstract/AARCH64/Machine_AI.thy
+++ b/proof/invariant-abstract/AARCH64/Machine_AI.thy
@@ -410,6 +410,10 @@ lemma dmo_getActiveIRQ_non_kernel[wp]:
   apply clarsimp
   done
 
+lemma dmo_gets_inv[wp]:
+  "do_machine_op (gets f) \<lbrace>P\<rbrace>"
+  unfolding do_machine_op_def by (wpsimp simp: simpler_gets_def)
+
 end
 
 context begin interpretation Arch .

--- a/proof/invariant-abstract/AARCH64/Machine_AI.thy
+++ b/proof/invariant-abstract/AARCH64/Machine_AI.thy
@@ -292,6 +292,7 @@ crunch_ignore (valid, empty_fail, no_fail)
    with the following manual interventions:
    - remove false positives: get_def, gets_def, getFPUState, getRegister, getRestartPC
    - add readVCPUHardwareReg (which uses non-standard "Val" instead of "_val" (FIXME AARCH64))
+   - add read_cntpct
    - remove final comma
    - getActiveIRQ does not preserve no_irq *)
 crunches
@@ -345,7 +346,6 @@ crunches
   switchFpuOwner,
   readVCPUHardwareReg,
   writeVCPUHardwareReg,
-  (* FIXME AARCH64: machine ops missed by the grep above: *)
   read_cntpct
   for (no_fail) no_fail[intro!, wp, simp]
   and (empty_fail) empty_fail[intro!, wp, simp]

--- a/proof/invariant-abstract/ARM/ArchAcc_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchAcc_AI.thy
@@ -344,13 +344,13 @@ lemma pde_at_aligned_vptr:
                  split: kernel_object.split_asm
                         arch_kernel_obj.split_asm if_split_asm
                  cong: kernel_object.case_cong)
-  apply (prove "is_aligned x 2")
+  apply (prop_tac "is_aligned x 2")
   subgoal
     apply (clarsimp simp: upto_enum_step_def word_shift_by_2)
     by (rule is_aligned_shiftl_self)
   apply (simp add: aligned_add_aligned word_bits_conv
                    is_aligned_shiftl_self)+
-  apply (prove "pd = (x + (pd + (vptr >> 20 << 2)) && ~~ mask pd_bits)")
+  apply (prop_tac "pd = (x + (pd + (vptr >> 20 << 2)) && ~~ mask pd_bits)")
   subgoal
     supply bit_simps[simp del]
     apply (subst mask_lower_twice[symmetric, where n=6])
@@ -547,7 +547,7 @@ lemma lookup_pt_slot_ptes_aligned_valid:
   apply (frule (2) valid_vspace_objsD)
   apply (clarsimp simp: )
   subgoal for s _ _ x
-    apply (prove "page_table_at (ptrFromPAddr x) s")
+    apply (prop_tac "page_table_at (ptrFromPAddr x) s")
     subgoal
       apply (bspec "(ucast (pd + (vptr >> 20 << 2) && mask pd_bits >> 2))";clarsimp)
       apply (frule kernel_mapping_slots_empty_pdeI)
@@ -667,7 +667,7 @@ lemma create_mapping_entries_valid [wp]:
    apply (clarsimp simp add: valid_mapping_entries_def)
    apply wp
   apply (simp add: lookup_pd_slot_def Let_def)
-  apply (prove "is_aligned pd 14")
+  apply (prop_tac "is_aligned pd 14")
    apply (clarsimp simp: obj_at_def add.commute invs_def valid_state_def valid_pspace_def pspace_aligned_def)
    apply (drule bspec, blast)
    apply (clarsimp simp: a_type_def split: kernel_object.splits arch_kernel_obj.splits if_split_asm)
@@ -1244,14 +1244,14 @@ lemma set_pt_valid_vspace_objs[wp]:
   apply (clarsimp simp: valid_vspace_objs_def)
   subgoal for s opt pa rs ao
     apply (spec pa)
-    apply (prove "(\<exists>\<rhd> pa) s")
+    apply (prop_tac "(\<exists>\<rhd> pa) s")
      apply (rule exI[where x=rs])
      apply (erule vs_lookupE)
      apply clarsimp
      apply (erule vs_lookupI)
      apply (erule rtrancl.induct, simp)
      subgoal for \<dots> b c
-       apply (prove "(b \<rhd>1 c) s")
+       apply (prop_tac "(b \<rhd>1 c) s")
        apply (thin_tac "_ : rtrancl _")+
        apply (clarsimp simp add: vs_lookup1_def obj_at_def vs_refs_def
                             split: if_split_asm)
@@ -2096,8 +2096,8 @@ lemma lookup_pt_slot_looks_up [wp]:
   apply (clarsimp simp: vs_lookup1_def lookup_pd_slot_def Let_def pd_shifting pd_shifting_dual)
   apply (rule exI, rule conjI, assumption)
   subgoal for s _ x
-    apply (prove "ptrFromPAddr x + ((vptr >> 12) && 0xFF << 2) && ~~ mask pt_bits = ptrFromPAddr x")
-     apply (prove "is_aligned (ptrFromPAddr x) 10")
+    apply (prop_tac "ptrFromPAddr x + ((vptr >> 12) && 0xFF << 2) && ~~ mask pt_bits = ptrFromPAddr x")
+     apply (prop_tac "is_aligned (ptrFromPAddr x) 10")
       apply (drule (2) valid_vspace_objsD)
       apply clarsimp
       apply (erule_tac x="ucast (vptr >> 20 << 2 >> 2)" in ballE)

--- a/proof/invariant-abstract/ARM_HYP/ArchAcc_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchAcc_AI.thy
@@ -376,13 +376,13 @@ lemma pde_at_aligned_vptr:  (* ARMHYP *) (* 0x3C \<rightarrow> 0x78?, 24 \<right
                  split: kernel_object.split_asm
                         arch_kernel_obj.split_asm if_split_asm
                  cong: kernel_object.case_cong)
-  apply (prove "is_aligned x 3")
+  apply (prop_tac "is_aligned x 3")
   subgoal
     apply (clarsimp simp: upto_enum_step_def word_shift_by_n[of _ 3, simplified])
     by (rule is_aligned_shiftl_self)
   apply (simp add: vspace_bits_defs aligned_add_aligned word_bits_conv
                    is_aligned_shiftl_self)+
-  apply (prove "pd = (x + (pd + (vptr >> pageBits + pt_bits - pte_bits << pde_bits)) && ~~ mask pd_bits)")
+  apply (prop_tac "pd = (x + (pd + (vptr >> pageBits + pt_bits - pte_bits << pde_bits)) && ~~ mask pd_bits)")
   subgoal
     apply (subst mask_lower_twice[symmetric, where n=7])
      apply (simp add: pd_bits_def pageBits_def)
@@ -561,7 +561,7 @@ lemma lookup_pt_slot_ptes_aligned_valid: (* ARMHYP *)
   apply (frule (2) valid_vspace_objsD)
   apply clarsimp
   subgoal for s _ _ x
-    apply (prove "page_table_at (ptrFromPAddr x) s")
+    apply (prop_tac "page_table_at (ptrFromPAddr x) s")
     subgoal
       by (spec "(ucast (pd + (vptr >> (pageBits + pt_bits - pte_bits) << pde_bits) && mask pd_bits >> pde_bits))";clarsimp)
     apply (rule conjI)
@@ -702,7 +702,7 @@ lemma create_mapping_entries_valid [wp]:
    apply (erule (1) page_directory_pde_at_lookupI)
    apply (wpsimp simp: valid_mapping_entries_def superSectionPDE_offsets_def vspace_bits_defs
                        lookup_pd_slot_def)
-  apply (prove "is_aligned pd 14")
+  apply (prop_tac "is_aligned pd 14")
    apply (clarsimp simp: obj_at_def add.commute invs_def valid_state_def valid_pspace_def pspace_aligned_def)
    apply (drule bspec, blast)
    apply (clarsimp simp: a_type_def vspace_bits_defs split: kernel_object.splits arch_kernel_obj.splits if_split_asm)
@@ -1340,14 +1340,14 @@ lemma set_pt_valid_vspace_objs[wp]:
   apply (clarsimp simp: valid_vspace_objs_def)
   subgoal for s opt pa rs ao
     apply (spec pa)
-    apply (prove "(\<exists>\<rhd> pa) s")
+    apply (prop_tac "(\<exists>\<rhd> pa) s")
      apply (rule exI[where x=rs])
      apply (erule vs_lookupE)
      apply clarsimp
      apply (erule vs_lookupI)
      apply (erule rtrancl.induct, simp)
      subgoal for \<dots> b c
-       apply (prove "(b \<rhd>1 c) s")
+       apply (prop_tac "(b \<rhd>1 c) s")
        apply (thin_tac "_ : rtrancl _")+
        apply (clarsimp simp add: vs_lookup1_def obj_at_def vs_refs_def
                             split: if_split_asm)
@@ -2212,8 +2212,8 @@ lemma lookup_pt_slot_looks_up [wp]: (* ARMHYP *)
   apply (clarsimp simp: vs_lookup1_def lookup_pd_slot_def Let_def pd_shifting pd_shifting_dual)
   apply (rule exI, rule conjI, assumption)
   subgoal for s _ x
-    apply (prove "ptrFromPAddr x + ((vptr >> 12) && 0x1FF << 3) && ~~ mask pt_bits = ptrFromPAddr x")
-     apply (prove "is_aligned (ptrFromPAddr x) 12")
+    apply (prop_tac "ptrFromPAddr x + ((vptr >> 12) && 0x1FF << 3) && ~~ mask pt_bits = ptrFromPAddr x")
+     apply (prop_tac "is_aligned (ptrFromPAddr x) 12")
       apply (drule (2) valid_vspace_objsD)
       apply clarsimp
       apply (erule_tac x="ucast (vptr >> pageBits + pt_bits - pte_bits << pde_bits >> pde_bits)" in allE)

--- a/proof/invariant-abstract/KHeap_AI.thy
+++ b/proof/invariant-abstract/KHeap_AI.thy
@@ -997,6 +997,7 @@ crunches do_machine_op
   and valid_global_refs[wp]: valid_global_refs
   and valid_irq_node[wp]: valid_irq_node
   and irq_states[wp]: "\<lambda>s. P (interrupt_states s)"
+  and kheap[wp]: "\<lambda>s. P (kheap s)"
   (simp: cur_tcb_def zombies_final_pspaceI state_refs_of_pspaceI ex_nonz_cap_to_def ct_in_state_def
    wp: crunch_wps valid_arch_state_lift vs_lookup_vspace_obj_at_lift)
 

--- a/proof/invariant-abstract/LevityCatch_AI.thy
+++ b/proof/invariant-abstract/LevityCatch_AI.thy
@@ -50,6 +50,10 @@ declare select_singleton[simp]
 
 crunch_ignore (add: do_extended_op)
 
+lemma None_Some_strg:
+  "x = None \<Longrightarrow> x \<noteq> Some y"
+  by simp
+
 (* Weakest precondition lemmas that need ASpec concepts: *)
 
 lemma const_on_failure_wp:

--- a/proof/invariant-abstract/LevityCatch_AI.thy
+++ b/proof/invariant-abstract/LevityCatch_AI.thy
@@ -23,7 +23,6 @@ end
 
 method spec for x :: "_ :: type" = (erule allE[of _ x])
 method bspec for x :: "_ :: type" = (erule ballE[of _ _ x])
-method prove for x :: "prop" = (rule revcut_rl[of "PROP x"])
 
 lemmas aobj_ref_arch_cap_simps[simp] = aobj_ref_arch_cap
 

--- a/proof/invariant-abstract/LevityCatch_AI.thy
+++ b/proof/invariant-abstract/LevityCatch_AI.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2022, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -8,6 +9,9 @@ theory LevityCatch_AI
 imports
   ArchLevityCatch_AI
 begin
+
+(* FIXME: eliminate mapM_UNIV_wp, use mapM_wp' directly *)
+lemmas mapM_UNIV_wp = mapM_wp'
 
 context begin interpretation Arch .
 
@@ -19,33 +23,20 @@ requalify_facts
 
 end
 
-(*FIXME: Move or remove *)
-
-method spec for x :: "_ :: type" = (erule allE[of _ x])
-method bspec for x :: "_ :: type" = (erule ballE[of _ _ x])
-
 lemmas aobj_ref_arch_cap_simps[simp] = aobj_ref_arch_cap
 
-lemma detype_arch_state :
+lemma detype_arch_state:
   "arch_state (detype S s) = arch_state s"
   by (simp add: detype_def)
 
 lemma obj_ref_elemD:
   "r \<in> obj_refs cap \<Longrightarrow> obj_refs cap = {r}"
-  by (cases cap, simp_all)
-
-lemma const_on_failure_wp :
-  "\<lbrace>P\<rbrace> m \<lbrace>Q\<rbrace>, \<lbrace>\<lambda>rv. Q n\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace> const_on_failure n m \<lbrace>Q\<rbrace>"
-  apply (simp add: const_on_failure_def)
-  apply wp
-  done
+  by (cases cap; simp)
 
 lemma get_cap_id:
   "(v, s') \<in> fst (get_cap p s) \<Longrightarrow> (s' = s)"
-  by (clarsimp simp: get_cap_def get_object_def in_monad
-                     split_def
-              split: Structures_A.kernel_object.splits)
-
+  by (clarsimp simp: get_cap_def get_object_def in_monad split_def
+              split: kernel_object.splits)
 
 lemmas cap_irq_opt_simps[simp] =
   cap_irq_opt_def [split_simps cap.split sum.split]
@@ -53,81 +44,31 @@ lemmas cap_irq_opt_simps[simp] =
 lemmas cap_irqs_simps[simp] =
     cap_irqs_def [unfolded cap_irq_opt_def, split_simps cap.split sum.split, simplified option.simps]
 
-
-lemma all_eq_trans: "\<lbrakk> \<forall>x. P x = Q x; \<forall>x. Q x = R x \<rbrakk> \<Longrightarrow> \<forall>x. P x = R x"
-  by simp
-
-
 declare liftE_wp[wp]
 declare case_sum_True[simp]
 declare select_singleton[simp]
 
-crunch_ignore (add: cap_swap_ext
-              cap_move_ext cap_insert_ext empty_slot_ext create_cap_ext
-              do_extended_op)
+crunch_ignore (add: do_extended_op)
 
-lemma select_ext_weak_wp[wp]: "\<lbrace>\<lambda>s. \<forall>x\<in>S. Q x s\<rbrace> select_ext a S \<lbrace>Q\<rbrace>"
-  apply (simp add: select_ext_def)
-  apply (wp select_wp)
-  apply simp
-  done
+(* Weakest precondition lemmas that need ASpec concepts: *)
 
-lemma select_ext_wp[wp]:"\<lbrace>\<lambda>s. a s \<in> S \<longrightarrow> Q (a s) s\<rbrace> select_ext a S \<lbrace>Q\<rbrace>"
-  apply (simp add: select_ext_def unwrap_ext_det_ext_ext_def)
-  apply (wp select_wp)
-  apply (simp add: unwrap_ext_det_ext_ext_def select_switch_det_ext_ext_def)
-  done
+lemma const_on_failure_wp:
+  "\<lbrace>P\<rbrace> m \<lbrace>Q\<rbrace>, \<lbrace>\<lambda>rv. Q n\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace> const_on_failure n m \<lbrace>Q\<rbrace>"
+  by (wpsimp simp: const_on_failure_def)
 
-(* FIXME: move *)
-lemmas mapM_UNIV_wp = mapM_wp[where S="UNIV", simplified]
+(* Weaker wp rule for arguments "a" which do not take type det_ext state.
+   The stronger rule below will take precendence, because it is declared [wp]
+   later than this one. This rule here will fire when the stronger one does not
+   apply because of a looser type than det_ext state. The looser type tends to
+   happen in goals that are stated by crunch. *)
+lemma select_ext_weak_wp[wp]:
+  "\<lbrace>\<lambda>s. \<forall>x\<in>S. Q x s\<rbrace> select_ext a S \<lbrace>Q\<rbrace>"
+  by (wpsimp simp: select_ext_def wp: select_wp)
 
-lemmas word_simps =
-  word_size word_ops_nth_size nth_ucast nth_shiftr nth_shiftl
-
-lemma mask_split_aligned:
-  assumes len: "m \<le> a + len_of TYPE('a)"
-  assumes align: "is_aligned p a"
-  shows "(p && ~~ mask m) + (ucast ((ucast (p && mask m >> a))::'a::len word) << a) = p"
-  apply (insert align[simplified is_aligned_nth])
-  apply (subst word_plus_and_or_coroll; rule word_eqI; clarsimp simp: word_simps)
-  apply (rule iffI)
-   apply (erule disjE; clarsimp)
-  apply (case_tac "n < m"; case_tac "n < a")
-  using len by auto
-
-lemma mask_split_aligned_neg:
-  fixes x :: "'a::len word"
-  fixes p :: "'b::len word"
-  assumes len: "a + len_of TYPE('a) \<le> len_of TYPE('b)"
-               "m = a + len_of TYPE('a)"
-  assumes x: "x \<noteq> ucast (p && mask m >> a)"
-  shows "(p && ~~ mask m) + (ucast x << a) = p \<Longrightarrow> False"
-  apply (subst (asm) word_plus_and_or_coroll)
-   apply (clarsimp simp: word_simps bang_eq)
-   apply (metis bit_imp_le_length diff_add_inverse le_add1 len(2) less_diff_iff)
-  apply (insert x)
-  apply (erule notE)
-  apply word_eqI
-  subgoal for n
-    using len
-    apply (clarsimp)
-    apply (spec "n + a")
-    by (clarsimp simp: add.commute)
-  done
-
-lemma mask_alignment_ugliness:
-  "\<lbrakk> x \<noteq> x + z && ~~ mask m;
-     is_aligned (x + z && ~~ mask m) m;
-     is_aligned x m;
-     \<forall>n \<ge> m. \<not>z !! n\<rbrakk>
-  \<Longrightarrow> False"
-  apply (erule notE)
-  apply (subst word_plus_and_or_coroll; word_eqI)
-   apply (meson linorder_not_le)
-  by (auto simp: le_def)
-
-lemma ranD:
-  "v \<in> ran f \<Longrightarrow> \<exists>x. f x = Some v"
-  by (auto simp: ran_def)
+(* The "real" wp rule for select_ext, requires det_ext state: *)
+lemma select_ext_wp[wp]:
+  "\<lbrace>\<lambda>s. a s \<in> S \<longrightarrow> Q (a s) s\<rbrace> select_ext a S \<lbrace>Q\<rbrace>"
+  unfolding select_ext_def unwrap_ext_det_ext_ext_def
+  by (wpsimp simp: select_switch_det_ext_ext_def wp: select_wp)
 
 end

--- a/proof/refine/ARM/CSpace1_R.thy
+++ b/proof/refine/ARM/CSpace1_R.thy
@@ -609,7 +609,7 @@ proof (induct a arbitrary: c' cref' bits rule: resolve_address_bits'.induct)
                             simp: locateSlot_conv)
         apply (simp add: drop_postfix_eq)
         apply clarsimp
-        apply (prove "is_aligned ptr (cte_level_bits + cbits) \<and> cbits \<le> word_bits - cte_level_bits")
+        apply (prop_tac "is_aligned ptr (cte_level_bits + cbits) \<and> cbits \<le> word_bits - cte_level_bits")
         apply (erule valid_CNodeCapE; fastforce simp: cte_level_bits_def)
         subgoal premises prems for s s' x
           apply (insert prems)
@@ -622,8 +622,8 @@ proof (induct a arbitrary: c' cref' bits rule: resolve_address_bits'.induct)
             apply (subst \<open>to_bl _ = _\<close>[symmetric])
             apply (drule postfix_dropD)
             apply clarsimp
-            apply (prove "32 + (cbits + length guard) - length cref =
-                         (cbits + length guard) + (32 - length cref)")
+            apply (prop_tac "32 + (cbits + length guard) - length cref =
+                             (cbits + length guard) + (32 - length cref)")
              apply (drule len_drop_lemma, simp, arith)
             apply simp
             apply (subst drop_drop [symmetric])

--- a/proof/refine/ARM_HYP/CSpace1_R.thy
+++ b/proof/refine/ARM_HYP/CSpace1_R.thy
@@ -612,7 +612,7 @@ proof (induct a arbitrary: c' cref' bits rule: resolve_address_bits'.induct)
                             simp: locateSlot_conv)
         apply (simp add: drop_postfix_eq)
         apply clarsimp
-        apply (prove "is_aligned ptr (4 + cbits) \<and> cbits \<le> word_bits - cte_level_bits")
+        apply (prop_tac "is_aligned ptr (4 + cbits) \<and> cbits \<le> word_bits - cte_level_bits")
         apply (erule valid_CNodeCapE; fastforce simp: cte_level_bits_def)
         subgoal premises prems for s s' x
           apply (insert prems)
@@ -625,8 +625,8 @@ proof (induct a arbitrary: c' cref' bits rule: resolve_address_bits'.induct)
             apply (subst \<open>to_bl _ = _\<close>[symmetric])
             apply (drule postfix_dropD)
             apply clarsimp
-            apply (prove "32 + (cbits + length guard) - length cref =
-                         (cbits + length guard) + (32 - length cref)")
+            apply (prop_tac "32 + (cbits + length guard) - length cref =
+                             (cbits + length guard) + (32 - length cref)")
              apply (drule len_drop_lemma, simp, arith)
             apply simp
             apply (subst drop_drop [symmetric])

--- a/spec/abstract/AARCH64/ArchInvocation_A.thy
+++ b/spec/abstract/AARCH64/ArchInvocation_A.thy
@@ -13,9 +13,6 @@ begin
 
 context Arch begin global_naming AARCH64_A
 
-(* FIXME AARCH64: import flush_type directly from Haskell *)
-datatype flush_type = Clean | Invalidate | CleanInvalidate | Unify
-
 text \<open>
   These datatypes encode the arguments to the various possible AARCH64-specific system calls.
   Selectors are defined for various fields for convenience elsewhere.

--- a/spec/abstract/AARCH64/ArchVSpaceAcc_A.thy
+++ b/spec/abstract/AARCH64/ArchVSpaceAcc_A.thy
@@ -96,6 +96,7 @@ type_synonym ptes_of = "pt_type \<Rightarrow> obj_ref \<rightharpoonup> pte"
 locale_abbrev ptes_of :: "'z::state_ext state \<Rightarrow> ptes_of" where
   "ptes_of s pt_t p \<equiv> level_pte_of pt_t p (pts_of s)"
 
+lemmas ptes_of_def = level_pte_of_def
 
 text \<open>The following function takes a pointer to a PTE in kernel memory and returns the PTE.\<close>
 locale_abbrev get_pte :: "pt_type \<Rightarrow> obj_ref \<Rightarrow> (pte,'z::state_ext) s_monad" where

--- a/spec/abstract/AARCH64/Arch_Structs_A.thy
+++ b/spec/abstract/AARCH64/Arch_Structs_A.thy
@@ -88,6 +88,11 @@ text \<open>
 value_type ppn_len = "ipa_size - pageBits"
 type_synonym ppn = "ppn_len word"
 
+text \<open>This lemma encodes @{typ ppn_len} value above as a term, so we can use it generically:\<close>
+lemma ppn_len_def':
+  "ppn_len = ipa_size - pageBits"
+  by (simp add: ppn_len_def pageBits_def ipa_size_def Kernel_Config.config_ARM_PA_SIZE_BITS_40_def)
+
 datatype pte =
     InvalidPTE
   | PagePTE

--- a/spec/abstract/Structures_A.thy
+++ b/spec/abstract/Structures_A.thy
@@ -139,10 +139,6 @@ definition
   case cap of
     CNodeCap oref bits guard \<Rightarrow> (oref, bits, guard)"
 
-definition
-  the_arch_cap :: "cap \<Rightarrow> arch_cap" where
-  "the_arch_cap cap \<equiv> case cap of ArchObjectCap a \<Rightarrow> a"
-
 primrec (nonexhaustive)
   cap_ep_badge :: "cap \<Rightarrow> badge"
 where

--- a/spec/design/skel/AARCH64/ArchRetypeDecls_H.thy
+++ b/spec/design/skel/AARCH64/ArchRetypeDecls_H.thy
@@ -21,7 +21,7 @@ context Arch begin global_naming AARCH64_H
 #INCLUDE_HASKELL_PREPARSE SEL4/Object/Structures/AARCH64.hs
 
 #INCLUDE_HASKELL SEL4/API/Invocation/AARCH64.hs CONTEXT AARCH64_H decls_only \
-  NOT Invocation IRQControlInvocation isVSpaceFlushLabel isPageFlushLabel
+  NOT Invocation IRQControlInvocation isVSpaceFlushLabel isPageFlushLabel FlushType
 
 #INCLUDE_HASKELL SEL4/API/Invocation/AARCH64.hs CONTEXT AARCH64_H decls_only ONLY Invocation IRQControlInvocation
 

--- a/spec/design/skel/AARCH64/Arch_Structs_B.thy
+++ b/spec/design/skel/AARCH64/Arch_Structs_B.thy
@@ -17,6 +17,8 @@ context Arch begin global_naming AARCH64_H
 
 #INCLUDE_HASKELL SEL4/Model/StateData/AARCH64.hs CONTEXT AARCH64_H ONLY ArmVSpaceRegionUse
 
+#INCLUDE_HASKELL SEL4/API/Invocation/AARCH64.hs CONTEXT AARCH64_H ONLY FlushType
+
 end
 
 end

--- a/spec/haskell/src/SEL4/Object/VCPU/AARCH64.hs
+++ b/spec/haskell/src/SEL4/Object/VCPU/AARCH64.hs
@@ -96,6 +96,8 @@ associateVCPUTCB vcpuPtr tcbPtr = do
         _ -> return ()
     archThreadSet (\atcb -> atcb { atcbVCPUPtr = Just vcpuPtr }) tcbPtr
     setObject vcpuPtr $ vcpu { vcpuTCBPtr = Just tcbPtr }
+    ct <- getCurThread
+    when (tcbPtr == ct) $ vcpuSwitch (Just vcpuPtr)
     return []
 
 {- VCPU: Update functions -}

--- a/spec/machine/AARCH64/MachineOps.thy
+++ b/spec/machine/AARCH64/MachineOps.thy
@@ -342,9 +342,9 @@ definition read_cntpct :: "64 word machine_monad" where
 
 subsection "Hypervisor Banked Registers"
 
-consts' vcpuHardwareRegVal :: "vcpureg \<Rightarrow> machine_state \<Rightarrow> machine_word"
+consts' vcpuHardwareReg_val :: "vcpureg \<Rightarrow> machine_state \<Rightarrow> machine_word"
 definition readVCPUHardwareReg :: "vcpureg \<Rightarrow> machine_word machine_monad" where
-  "readVCPUHardwareReg reg \<equiv> gets (vcpuHardwareRegVal reg)"
+  "readVCPUHardwareReg reg \<equiv> gets (vcpuHardwareReg_val reg)"
 
 consts' writeVCPUHardwareReg_impl :: "vcpureg \<Rightarrow> machine_word \<Rightarrow> unit machine_rest_monad"
 definition writeVCPUHardwareReg :: "vcpureg \<Rightarrow> machine_word \<Rightarrow> unit machine_monad" where

--- a/spec/machine/ARM_HYP/MachineOps.thy
+++ b/spec/machine/ARM_HYP/MachineOps.thy
@@ -705,11 +705,11 @@ where
 subsection "Hypervisor Banked Registers"
 
 consts'
-  vcpuHardwareRegVal :: "vcpureg \<Rightarrow> machine_state \<Rightarrow> machine_word"
+  vcpuHardwareReg_val :: "vcpureg \<Rightarrow> machine_state \<Rightarrow> machine_word"
 definition
   readVCPUHardwareReg :: "vcpureg \<Rightarrow> machine_word machine_monad"
 where
-  "readVCPUHardwareReg reg \<equiv> gets (vcpuHardwareRegVal reg)"
+  "readVCPUHardwareReg reg \<equiv> gets (vcpuHardwareReg_val reg)"
 
 consts'
   writeVCPUHardwareReg_impl :: "vcpureg \<Rightarrow> machine_word \<Rightarrow> unit machine_rest_monad"


### PR DESCRIPTION
Cleans up FIXMEs introduced in the AArch64 AInvs verification.

Reduces FIXME count from 73 to 4 in AInvs.