### PR TITLE
Word_Lib improvements

### DIFF
--- a/lib/Word_Lib/Bitwise.thy
+++ b/lib/Word_Lib/Bitwise.thy
@@ -502,6 +502,6 @@ end
 
 method_setup word_bitwise =
   \<open>Scan.succeed (fn ctxt => Method.SIMPLE_METHOD (Word_Bitwise_Tac.tac ctxt 1))\<close>
-  "decomposer for word equalities and inequalities into bit propositions"
+  "decomposer for word equalities and inequalities into bit propositions on concrete word lengths"
 
 end

--- a/lib/Word_Lib/Bitwise_Signed.thy
+++ b/lib/Word_Lib/Bitwise_Signed.thy
@@ -25,6 +25,6 @@ in
 
 method_setup word_bitwise_signed =
   \<open>Scan.succeed (fn ctxt => Method.SIMPLE_METHOD (bw_tac_signed ctxt 1))\<close>
-  "decomposer for word equalities and inequalities into bit propositions"
+  "decomposer for word equalities and inequalities into bit propositions on concrete word lengths"
 
 end

--- a/lib/Word_Lib/Boolean_Inequalities.thy
+++ b/lib/Word_Lib/Boolean_Inequalities.thy
@@ -1,0 +1,139 @@
+(*
+ * Copyright 2023, Proofcraft Pty Ltd
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ *)
+
+theory Boolean_Inequalities
+  imports Word_EqI
+begin
+
+section \<open>All inequalities between binary Boolean operations on @{typ "'a word"}\<close>
+
+text \<open>
+  Enumerates all binary functions resulting from Boolean operations on @{typ "'a word"}
+  and derives all inequalities of the form @{term "f x y \<le> g x y"} between them.
+  We leave out the trivial @{term "0 \<le> g x y"}, @{term "f x y \<le> -1"}, and
+  @{term "f x y \<le> f x y"}, because these are already readily available to the simplifier and
+  other methods.
+
+  This leaves 36 inequalities. Some of these are subsumed by each other, but we generate
+  the full list to avoid too much manual processing.
+
+  All inequalities produced here are in simp normal form.\<close>
+
+context
+  includes bit_operations_syntax
+begin
+
+(* The following are all 16 binary Boolean operations (on bool):
+   all_bool_funs \<equiv> [
+     \<lambda>x y. False,
+     \<lambda>x y. x \<and> y,
+     \<lambda>x y. x \<and> \<not>y,
+     \<lambda>x y. x,
+     \<lambda>x y. \<not>x \<and> y,
+     \<lambda>x y. y,
+     \<lambda>x y. x \<noteq> y,
+     \<lambda>x y. x \<or> y,
+     \<lambda>x y. \<not>(x \<or> y),
+     \<lambda>x y. x = y,
+     \<lambda>x y. \<not>y,
+     \<lambda>x y. x \<or> \<not>y,
+     \<lambda>x y. \<not>x,
+     \<lambda>x y. \<not>x \<or> y,
+     \<lambda>x y. \<not>(x \<and> y),
+     \<lambda>x y. True
+   ]
+
+  We can define the same for word operations:
+*)
+definition all_bool_word_funs :: "('a::len word \<Rightarrow> 'a word \<Rightarrow> 'a word) list" where
+  "all_bool_word_funs \<equiv> [
+     \<lambda>x y. 0,
+     \<lambda>x y. x AND y,
+     \<lambda>x y. x AND NOT y,
+     \<lambda>x y. x,
+     \<lambda>x y. NOT x AND y,
+     \<lambda>x y. y,
+     \<lambda>x y. x XOR y,
+     \<lambda>x y. x OR y,
+     \<lambda>x y. NOT (x OR y),
+     \<lambda>x y. NOT (x XOR y),
+     \<lambda>x y. NOT y,
+     \<lambda>x y. x OR NOT y,
+     \<lambda>x y. NOT x,
+     \<lambda>x y. NOT x OR y,
+     \<lambda>x y. NOT (x AND y),
+     \<lambda>x y. -1
+   ]"
+
+
+text \<open>
+  The inequalities on @{typ "'a word"} follow directly from implications on propositional
+  Boolean logic, which @{method simp} can solve automatically. This means, we can simply
+  enumerate all combinations, reduce from @{typ "'a word"} to @{typ bool}, and attempt to
+  solve by @{method simp} to get the complete list.\<close>
+local_setup \<open>
+let
+  (* derived from Numeral.mk_num, but returns a term, not syntax. *)
+  fun mk_num n =
+    if n > 0 then
+      (case Integer.quot_rem n 2 of
+        (0, 1) => \<^const>\<open>Num.One\<close>
+      | (n, 0) => \<^const>\<open>Num.Bit0\<close> $ mk_num n
+      | (n, 1) => \<^const>\<open>Num.Bit1\<close> $ mk_num n)
+    else raise Match
+
+  (* derived from Numeral.mk_number, but returns a term, not syntax. *)
+  fun mk_number n =
+    if n = 0 then \<^term>\<open>0::nat\<close>
+    else if n = 1 then \<^term>\<open>1::nat\<close>
+    else \<^term>\<open>numeral::num \<Rightarrow> nat\<close> $ mk_num n;
+
+  (* generic form of the goal statement *)
+  val goal = @{term "\<lambda>n m. (all_bool_word_funs!n) x y \<le> (all_bool_word_funs!m) x y"}
+  (* instance of the goal statement for a pair (i,j) of Boolean functions *)
+  fun stmt (i,j) = HOLogic.Trueprop $ (goal $ mk_number i $ mk_number j)
+
+  (* attempt to prove an inequality between functions i and j *)
+  fun le_thm ctxt (i,j) = Goal.prove ctxt ["x", "y"] [] (stmt (i,j)) (fn _ =>
+    (asm_full_simp_tac (ctxt addsimps [@{thm all_bool_word_funs_def}])
+     THEN_ALL_NEW resolve_tac ctxt @{thms word_leI}
+     THEN_ALL_NEW asm_full_simp_tac (ctxt addsimps @{thms word_eqI_simps bit_simps})) 1)
+
+  (* generate all combinations for (i,j), collect successful inequality theorems,
+     unfold all_bool_word_funs, and put into simp normal form. We leave out 0 (bottom)
+     and 15 (top), as well as reflexive thms to remove trivial lemmas from the list.*)
+  fun thms ctxt =
+    map_product (fn x => fn y => (x,y)) (1 upto 14) (1 upto 14)
+    |> filter (fn (x,y) => x <> y)
+    |> map_filter (try (le_thm ctxt))
+    |> map (Simplifier.simplify ctxt o Local_Defs.unfold ctxt @{thms all_bool_word_funs_def})
+in
+  fn ctxt =>
+    Local_Theory.notes [((Binding.name "word_bool_le_funs", []), [(thms ctxt, [])])] ctxt |> #2
+end
+\<close>
+
+(* Sanity checks: *)
+lemma
+  "x AND y \<le> x" for x :: "'a::len word"
+  by (rule word_bool_le_funs(1))
+
+lemma
+  "NOT x \<le> NOT x OR NOT y" for x :: "'a::len word"
+  by (rule word_bool_le_funs(36))
+
+lemma
+  "x XOR y \<le> NOT x OR NOT y" for x :: "'a::len word"
+  by (rule word_bool_le_funs)
+
+(* Example use when the goal is not in simp normal form: *)
+lemma word_xor_le_nand:
+  "x XOR y \<le> NOT (x AND y)" for x :: "'a::len word"
+  by (clarsimp simp: word_bool_le_funs)
+
+end
+
+end

--- a/lib/Word_Lib/Boolean_Inequalities.thy
+++ b/lib/Word_Lib/Boolean_Inequalities.thy
@@ -132,7 +132,7 @@ lemma
 (* Example use when the goal is not in simp normal form: *)
 lemma word_xor_le_nand:
   "x XOR y \<le> NOT (x AND y)" for x :: "'a::len word"
-  by (clarsimp simp: word_bool_le_funs)
+  by (simp add: word_bool_le_funs)
 
 end
 

--- a/lib/Word_Lib/Many_More.thy
+++ b/lib/Word_Lib/Many_More.thy
@@ -167,17 +167,17 @@ lemma takeWhile_take_has_property_nth:
   "\<lbrakk> n < length (takeWhile P xs) \<rbrakk> \<Longrightarrow> P (xs ! n)"
   by (induct xs arbitrary: n; simp split: if_split_asm) (case_tac n, simp_all)
 
-lemma takeWhile_replicate:
-  "takeWhile f (replicate len x) = (if f x then replicate len x else [])"
-  by (induct_tac len) auto
-
 lemma takeWhile_replicate_empty:
   "\<not> f x \<Longrightarrow> takeWhile f (replicate len x) = []"
-  by (simp add: takeWhile_replicate)
+  by simp
 
 lemma takeWhile_replicate_id:
   "f x \<Longrightarrow> takeWhile f (replicate len x) = replicate len x"
-  by (simp add: takeWhile_replicate)
+  by simp
+
+lemma takeWhile_all:
+  "length (takeWhile P xs) = length xs \<Longrightarrow> \<forall>x \<in> set xs. P x"
+  by (induct xs) (auto split: if_split_asm)
 
 lemma nth_rev: "n < length xs \<Longrightarrow> rev xs ! n = xs ! (length xs - 1 - n)"
   using rev_nth by simp

--- a/lib/Word_Lib/More_Bit_Ring.thy
+++ b/lib/Word_Lib/More_Bit_Ring.thy
@@ -1,0 +1,131 @@
+(*
+ * Copyright 2023, Proofcraft Pty Ltd
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ *)
+
+theory More_Bit_Ring
+  imports Main
+begin
+
+(* Additional equalities on semiring_bit_operations and ring_bit_operations, in particular
+   relationships between Boolean and arithmetic operations. *)
+
+context semiring_bit_operations
+begin
+
+context
+  includes bit_operations_syntax
+begin
+
+lemma disjunctive_add2:
+  "(x AND y) = 0 \<Longrightarrow> x + y = x OR y"
+  by (metis disjunctive_add bit_0_eq bit_and_iff bot_apply bot_bool_def)
+
+end
+end
+
+context ring_bit_operations
+begin
+
+context
+  includes bit_operations_syntax
+begin
+
+lemma not_xor_is_eqv:
+  "NOT (x XOR y) = (x AND y) OR (NOT x AND NOT y)"
+  by (simp add: bit.xor_def bit.disj_conj_distrib or.commute)
+
+lemma not_xor_eq_xor_not:
+  "(NOT x) XOR y = x XOR (NOT y)"
+  by simp
+
+lemma not_minus:
+  "NOT (x - y) = y - x - 1"
+  by (simp add: not_eq_complement)
+
+lemma minus_not_eq_plus_1:
+  "- NOT x = x + 1"
+  by (simp add: minus_eq_not_plus_1)
+
+lemma not_minus_eq_minus_1:
+  "NOT (- x) = x - 1"
+  by (simp add: not_eq_complement)
+
+lemma and_plus_not_and:
+  "(x AND y) + (x AND NOT y) = x"
+  by (metis and.left_commute and.right_neutral bit.conj_cancel_right bit.conj_disj_distrib
+            bit.conj_zero_right bit.disj_cancel_right disjunctive_add2)
+
+lemma or_eq_and_not_plus:
+  "x OR y = (x AND NOT y) + y"
+  by (simp add: and.assoc bit.disj_conj_distrib2 disjunctive_add2)
+
+lemma and_eq_not_or_minus:
+  "x AND y = (NOT x OR y) - NOT x"
+  by (metis and.idem and_eq_not_not_or eq_diff_eq or.commute or.idem or_eq_and_not_plus)
+
+lemma and_not_eq_or_minus:
+  "x AND NOT y = (x OR y) - y"
+  by (simp add: or_eq_and_not_plus)
+
+lemma and_not_eq_minus_and:
+  "x AND NOT y = x - (x AND y)"
+  by (simp add: add.commute eq_diff_eq and_plus_not_and)
+
+lemma or_minus_eq_minus_and:
+  "(x OR y) - y = x - (x AND y)"
+  by (metis and_not_eq_minus_and and_not_eq_or_minus)
+
+lemma plus_eq_and_or:
+  "x + y = (x OR y) + (x AND y)"
+  using add_commute local.add.semigroup_axioms or_eq_and_not_plus semigroup.assoc
+  by (fastforce simp: and_plus_not_and)
+
+lemma xor_eq_or_minus_and:
+  "x XOR y = (x OR y) - (x AND y)"
+  by (metis (no_types) bit.de_Morgan_conj bit.xor_def2 bit_and_iff bit_or_iff disjunctive_diff)
+
+lemma not_xor_eq_and_plus_not_or:
+  "NOT (x XOR y) = (x AND y) + NOT (x OR y)"
+  by (metis (no_types, lifting) not_diff_distrib add.commute bit.de_Morgan_conj bit.xor_def2
+                                bit_and_iff bit_or_iff disjunctive_diff)
+
+lemma not_xor_eq_and_minus_or:
+  "NOT (x XOR y) = (x AND y) - (x OR y) - 1"
+  by (metis not_diff_distrib add.commute minus_diff_eq not_minus_eq_minus_1 not_xor_eq_and_plus_not_or)
+
+lemma plus_eq_xor_plus_carry:
+  "x + y = (x XOR y) + 2 * (x AND y)"
+  by (metis plus_eq_and_or add.commute add.left_commute diff_add_cancel mult_2 xor_eq_or_minus_and)
+
+lemma plus_eq_or_minus_xor:
+  "x + y = 2 * (x OR y) - (x XOR y)"
+  by (metis add_diff_cancel_left' diff_diff_eq2 local.mult_2 plus_eq_and_or xor_eq_or_minus_and)
+
+lemma plus_eq_minus_neg:
+  "x + y = x - NOT y - 1"
+  using add_commute local.not_diff_distrib not_minus
+  by auto
+
+lemma minus_eq_plus_neg:
+  "x - y = x + NOT y + 1"
+  by (simp add: add.semigroup_axioms diff_conv_add_uminus minus_eq_not_plus_1 semigroup.assoc)
+
+lemma minus_eq_and_not_minus_not_and:
+  "x - y = (x AND NOT y) - (NOT x AND y)"
+  by (metis bit.de_Morgan_conj bit.double_compl not_diff_distrib plus_eq_and_or)
+
+lemma minus_eq_xor_minus_not_and:
+  "x - y = (x XOR y) - 2 * (NOT x AND y)"
+  by (metis (no_types) bit.compl_eq_compl_iff bit.xor_compl_left not_diff_distrib
+                       plus_eq_xor_plus_carry)
+
+lemma minus_eq_and_not_minus_xor:
+  "x - y = 2 * (x AND NOT y) - (x XOR y)"
+  by (metis and.commute minus_diff_eq minus_eq_xor_minus_not_and xor.commute)
+
+end
+end
+
+end

--- a/lib/Word_Lib/More_Word.thy
+++ b/lib/Word_Lib/More_Word.thy
@@ -63,7 +63,7 @@ lemma unat_p2: "n < LENGTH('a :: len) \<Longrightarrow> unat (2 ^ n :: 'a word) 
 
 lemma word_div_lt_eq_0:
   "x < y \<Longrightarrow> x div y = 0" for x :: "'a :: len word"
-  by transfer simp
+  by (fact div_word_less)
 
 lemma word_div_eq_1_iff: "n div m = 1 \<longleftrightarrow> n \<ge> m \<and> unat n < 2 * unat (m :: 'a :: len word)"
   apply (simp only: word_arith_nat_defs word_le_nat_alt word_of_nat_eq_iff flip: nat_div_eq_Suc_0_iff)
@@ -93,7 +93,7 @@ lemma p2_eq_0:
 
 lemma p2len:
   \<open>(2 :: 'a word) ^ LENGTH('a::len) = 0\<close>
-  by simp
+  by (fact word_pow_0)
 
 lemma neg_mask_is_div:
   "w AND NOT (mask n) = (w div 2^n) * 2^n"
@@ -157,10 +157,7 @@ lemma less_eq_mask_iff_take_bit_eq_self:
 
 lemma NOT_eq:
   "NOT (x :: 'a :: len word) = - x - 1"
-  apply (cut_tac x = "x" in word_add_not)
-  apply (drule add.commute [THEN trans])
-  apply (drule eq_diff_eq [THEN iffD2])
-  by simp
+  by (fact not_eq_complement)
 
 lemma NOT_mask: "NOT (mask n :: 'a::len word) = - (2 ^ n)"
   by (simp add : NOT_eq mask_2pm1)
@@ -216,16 +213,12 @@ lemma of_int_uint:
 corollary word_plus_and_or_coroll:
   "x AND y = 0 \<Longrightarrow> x + y = x OR y"
   for x y :: \<open>'a::len word\<close>
-  using word_plus_and_or[where x=x and y=y]
-  by simp
+  by (fact disjunctive_add2)
 
 corollary word_plus_and_or_coroll2:
   "(x AND w) + (x AND NOT w) = x"
   for x w :: \<open>'a::len word\<close>
-  apply (subst disjunctive_add)
-   apply (simp add: bit_simps)
-  apply (simp flip: bit.conj_disj_distrib)
-  done
+  by (fact and_plus_not_and)
 
 lemma unat_mask_eq:
   \<open>unat (mask n :: 'a::len word) = mask (min LENGTH('a) n)\<close>
@@ -626,7 +619,7 @@ lemma word_power_less_1 [simp]:
   done
 
 lemma word_sub_1_le:
-  "x \<noteq> 0 \<Longrightarrow> x - 1 \<le> (x :: ('a :: len) word)"
+  "x \<noteq> 0 \<Longrightarrow> x - 1 \<le> (x :: 'a :: len word)"
   apply (subst no_ulen_sub)
   apply simp
   apply (cases "uint x = 0")
@@ -749,13 +742,13 @@ qed
 lemma mask_out_sub_mask:
   "(x AND NOT (mask n)) = x - (x AND (mask n))"
   for x :: \<open>'a::len word\<close>
-  by (simp add: field_simps word_plus_and_or_coroll2)
+  by (fact and_not_eq_minus_and)
 
 lemma subtract_mask:
   "p - (p AND mask n) = (p AND NOT (mask n))"
   "p - (p AND NOT (mask n)) = (p AND mask n)"
   for p :: \<open>'a::len word\<close>
-  by (simp add: field_simps word_plus_and_or_coroll2)+
+  by (auto simp: and_not_eq_minus_and)
 
 lemma take_bit_word_eq_self_iff:
   \<open>take_bit n w = w \<longleftrightarrow> n \<ge> LENGTH('a) \<or> w < 2 ^ n\<close>
@@ -764,7 +757,7 @@ lemma take_bit_word_eq_self_iff:
   by (transfer fixing: n) auto
 
 lemma word_power_increasing:
-  assumes x: "2 ^ x < (2 ^ y::'a::len word)" "x < LENGTH('a::len)" "y < LENGTH('a::len)"
+  assumes x: "2 ^ x < (2 ^ y::'a::len word)" "x < LENGTH('a)" "y < LENGTH('a)"
   shows "x < y" using x
   using assms by transfer simp
 
@@ -788,18 +781,8 @@ lemma plus_one_helper2:
                 unatSuc)
 
 lemma less_x_plus_1:
-  fixes x :: "'a :: len word" shows
-  "x \<noteq> - 1 \<Longrightarrow> (y < (x + 1)) = (y < x \<or> y = x)"
-  apply (rule iffI)
-   apply (rule disjCI)
-   apply (drule plus_one_helper)
-   apply simp
-  apply (subgoal_tac "x < x + 1")
-   apply (erule disjE, simp_all)
-  apply (rule plus_one_helper2 [OF order_refl])
-  apply (rule notI, drule max_word_wrap)
-  apply simp
-  done
+  "x \<noteq> - 1 \<Longrightarrow> (y < x + 1) = (y < x \<or> y = x)" for x :: "'a::len word"
+  by (meson max_word_wrap plus_one_helper plus_one_helper2 word_le_less_eq)
 
 lemma word_Suc_leq:
   fixes k::"'a::len word" shows "k \<noteq> - 1 \<Longrightarrow> x < k + 1 \<longleftrightarrow> x \<le> k"
@@ -825,10 +808,10 @@ lemma word_atLeastLessThan_Suc_atLeastAtMost_union:
   fixes l::"'a::len word"
   assumes "m \<noteq> - 1" and "l \<le> m" and "m \<le> u"
   shows "{l..m} \<union> {m+1..u} = {l..u}"
-  proof -
+proof -
   from ivl_disj_un_two(8)[OF assms(2) assms(3)] have "{l..u} = {l..m} \<union> {m<..u}" by blast
   with assms show ?thesis by(simp add: word_atLeastAtMost_Suc_greaterThanAtMost)
-  qed
+qed
 
 lemma max_word_less_eq_iff [simp]:
   \<open>- 1 \<le> w \<longleftrightarrow> w = - 1\<close> for w :: \<open>'a::len word\<close>
@@ -1079,17 +1062,12 @@ lemma word_less_sub_1:
   by (fact word_le_minus_one_leq)
 
 lemma word_sub_mono2:
-  "\<lbrakk> a + b \<le> c + d; c \<le> a; b \<le> a + b; d \<le> c + d \<rbrakk>
-    \<Longrightarrow> b \<le> (d :: 'a :: len word)"
-  apply (drule(1) word_sub_mono)
-    apply simp
-   apply simp
-  apply simp
-  done
+  "\<lbrakk> a + b \<le> c + d; c \<le> a; b \<le> a + b; d \<le> c + d \<rbrakk> \<Longrightarrow> b \<le> (d :: 'a :: len word)"
+  by (drule(1) word_sub_mono; simp)
 
 lemma word_not_le:
   "(\<not> x \<le> (y :: 'a :: len word)) = (y < x)"
-  by fastforce
+  by (fact not_le)
 
 lemma word_subset_less:
   "\<lbrakk> {x .. x + r - 1} \<subseteq> {y .. y + s - 1};
@@ -1227,11 +1205,9 @@ lemma word_minus_one_le:
   by (fact word_order.extremum_unique)
 
 lemma up_scast_inj:
-      "\<lbrakk> scast x = (scast y :: 'b :: len word); size x \<le> LENGTH('b) \<rbrakk>
-         \<Longrightarrow> x = y"
+  "\<lbrakk> scast x = (scast y :: 'b :: len word); size x \<le> LENGTH('b) \<rbrakk> \<Longrightarrow> x = y"
   apply transfer
-  apply (cases \<open>LENGTH('a)\<close>)
-  apply simp_all
+  apply (cases \<open>LENGTH('a)\<close>; simp)
   apply (metis order_refl take_bit_signed_take_bit take_bit_tightened)
   done
 
@@ -1246,12 +1222,8 @@ lemma word_le_add:
   by (rule exI [where x = "unat (y - x)"]) simp
 
 lemma word_plus_mcs_4':
-  fixes x :: "'a :: len word"
-  shows "\<lbrakk>x + v \<le> x + w; x \<le> x + v\<rbrakk> \<Longrightarrow> v \<le> w"
-  apply (rule word_plus_mcs_4)
-   apply (simp add: add.commute)
-  apply (simp add: add.commute)
-  done
+  "\<lbrakk>x + v \<le> x + w; x \<le> x + v\<rbrakk> \<Longrightarrow> v \<le> w" for x :: "'a::len word"
+  by (rule word_plus_mcs_4; simp add: add.commute)
 
 lemma unat_eq_1:
   \<open>unat x = Suc 0 \<longleftrightarrow> x = 1\<close>
@@ -1466,11 +1438,12 @@ lemma unat_1_0:
 lemma x_less_2_0_1':
   fixes x :: "'a::len word"
   shows "\<lbrakk>LENGTH('a) \<noteq> 1; x < 2\<rbrakk> \<Longrightarrow> x = 0 \<or> x = 1"
-  apply (cases \<open>2 \<le> LENGTH('a)\<close>)
-  apply simp_all
+  apply (cases \<open>2 \<le> LENGTH('a)\<close>; simp)
   apply transfer
-  apply auto
-  apply (metis add.commute add.right_neutral even_two_times_div_two mod_div_trivial mod_pos_pos_trivial mult.commute mult_zero_left not_less not_take_bit_negative odd_two_times_div_two_succ)
+  apply clarsimp
+  apply (metis add.commute add.right_neutral even_two_times_div_two mod_div_trivial
+               mod_pos_pos_trivial mult.commute mult_zero_left not_less not_take_bit_negative
+               odd_two_times_div_two_succ)
   done
 
 lemmas word_add_le_iff2 = word_add_le_iff [folded no_olen_add_nat]
@@ -1817,7 +1790,7 @@ lemma test_bit_size: "bit w n \<Longrightarrow> n < size w"
   for w :: "'a::len word"
   by transfer simp
 
-lemma word_eq_iff: "x = y \<longleftrightarrow> (\<forall>n<LENGTH('a). bit x n = bit y n)" (is \<open>?P \<longleftrightarrow> ?Q\<close>)
+lemma word_eq_iff: "x = y \<longleftrightarrow> (\<forall>n<LENGTH('a). bit x n = bit y n)"
   for x y :: "'a::len word"
   by transfer (auto simp add: bit_eq_iff bit_take_bit_iff)
 
@@ -2120,8 +2093,8 @@ lemma div_of_0_id[simp]:"(0::('a::len) word) div n = 0"
 lemma degenerate_word:"LENGTH('a) = 1 \<Longrightarrow> (x::('a::len) word) = 0 \<or> x = 1"
   by (metis One_nat_def less_irrefl_nat sint_1_cases)
 
-lemma div_by_0_word:"(x::('a::len) word) div 0 = 0"
-  by (metis div_0 div_by_0 unat_0 word_arith_nat_defs(6) word_div_1)
+lemma div_by_0_word: "(x::'a::len word) div 0 = 0"
+  by (fact bits_div_by_0)
 
 lemma div_less_dividend_word:"\<lbrakk>x \<noteq> 0; n \<noteq> 1\<rbrakk> \<Longrightarrow> (x::('a::len) word) div n < x"
   apply (cases \<open>n = 0\<close>)

--- a/lib/Word_Lib/More_Word.thy
+++ b/lib/Word_Lib/More_Word.thy
@@ -11,6 +11,7 @@ theory More_Word
     "HOL-Library.Word"
     More_Arithmetic
     More_Divides
+    More_Bit_Ring
 begin
 
 context

--- a/lib/Word_Lib/Sgn_Abs.thy
+++ b/lib/Word_Lib/Sgn_Abs.thy
@@ -1,0 +1,131 @@
+(*
+ * Copyright 2023, Proofcraft Pty Ltd
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ *)
+
+theory Sgn_Abs
+  imports Most_significant_bit
+begin
+
+section \<open>@{const sgn} and @{const abs} for @{typ "'a word"}\<close>
+
+subsection \<open>Instances\<close>
+
+text \<open>@{const sgn} on words returns -1, 0, or 1.\<close>
+instantiation word :: (len) sgn
+begin
+
+definition sgn_word :: \<open>'a word \<Rightarrow> 'a word\<close> where
+  \<open>sgn w = (if w = 0 then 0 else if 0 <s w then 1 else -1)\<close>
+
+instance ..
+
+end
+
+
+(* Simplification setup for sgn on numerals *)
+
+lemma word_sgn_0[simp]:
+  "sgn 0 = (0::'a::len word)"
+  by (simp add: sgn_word_def)
+
+lemma word_sgn_1[simp]:
+  "sgn 1 = (1::'a::len word)"
+  by (simp add: sgn_word_def)
+
+lemma word_sgn_max_word[simp]:
+  "sgn (- 1) = (-1::'a::len word)"
+  by (clarsimp simp: sgn_word_def word_sless_alt)
+
+lemmas word_sgn_numeral[simp] = sgn_word_def[where w="numeral w" for w]
+
+
+text \<open>@{const abs} on words is the usual definition.\<close>
+instantiation word :: (len) abs
+begin
+
+definition abs_word :: \<open>'a word \<Rightarrow> 'a word\<close> where
+  \<open>abs w = (if w \<le>s 0 then -w else w)\<close>
+
+instance ..
+
+end
+
+
+(* Simplification setup for abs on numerals *)
+
+lemma word_abs_0[simp]:
+  "\<bar>0\<bar> = (0::'a::len word)"
+  by (simp add: abs_word_def)
+
+lemma word_abs_1[simp]:
+  "\<bar>1\<bar> = (1::'a::len word)"
+  by (simp add: abs_word_def)
+
+lemma word_abs_max_word[simp]:
+  "\<bar>- 1\<bar> = (1::'a::len word)"
+  by (clarsimp simp: abs_word_def word_sle_eq)
+
+lemma word_abs_msb:
+  "\<bar>w\<bar> = (if msb w then -w else w)" for w::"'a::len word"
+  by (simp add: abs_word_def msb_word_iff_sless_0 word_sless_eq)
+
+lemmas word_abs_numeral[simp] = word_abs_msb[where w="numeral w" for w]
+
+
+subsection \<open>Properties\<close>
+
+(* Many of these are from linordered_idom, but need <s instead of < and occasionally
+   an additional assumption on minimum word length, because in "1 word" we have -1 = 1. *)
+
+lemma word_sgn_0_0:
+  "sgn a = 0 \<longleftrightarrow> a = 0" for a::"'a::len word"
+  by (simp add: sgn_word_def)
+
+lemma word_sgn_1_pos:
+  "1 < LENGTH('a) \<Longrightarrow> sgn a = 1 \<longleftrightarrow> 0 <s a" for a::"'a::len word"
+  unfolding sgn_word_def by simp
+
+lemma word_sgn_1_neg:
+  "sgn a = - 1 \<longleftrightarrow> a <s 0"
+  unfolding sgn_word_def
+  using sint_1_cases by force
+
+lemma word_sgn_pos[simp]:
+  "0 <s a \<Longrightarrow> sgn a = 1"
+  by (simp add: sgn_word_def)
+
+lemma word_sgn_neg[simp]:
+  "a <s 0 \<Longrightarrow> sgn a = - 1"
+  by (simp only: word_sgn_1_neg)
+
+lemma word_abs_sgn:
+  "\<bar>k\<bar> = k * sgn k" for k :: "'a::len word"
+  unfolding sgn_word_def abs_word_def
+  by auto
+
+lemma word_sgn_greater[simp]:
+  "0 <s sgn a \<longleftrightarrow> 0 <s a" for a::"'a::len word"
+  by (smt (verit) signed_eq_0_iff sint_1_cases sint_n1 word_sgn_0_0 word_sgn_neg word_sgn_pos
+                  word_sless_alt)
+
+lemma word_sgn_less[simp]:
+  "sgn a <s 0 \<longleftrightarrow> a <s 0" for a::"'a::len word"
+  unfolding sgn_word_def
+  using degenerate_word signed.antisym_conv3 word_sless_alt by force
+
+lemma word_abs_sgn_eq_1[simp]:
+  "a \<noteq> 0 \<Longrightarrow> \<bar>sgn a\<bar> = 1" for a::"'a::len word"
+  unfolding abs_word_def sgn_word_def
+  by (clarsimp simp: word_sle_eq)
+
+lemma word_abs_sgn_eq:
+  "\<bar>sgn a\<bar> = (if a = 0 then 0 else 1)" for a::"'a::len word"
+  by clarsimp
+
+lemma word_sgn_mult_self_eq[simp]:
+  "sgn a * sgn a = of_bool (a \<noteq> 0)" for a::"'a::len word"
+  by (cases "0 <s a"; simp)
+
+end

--- a/lib/Word_Lib/Word_EqI.thy
+++ b/lib/Word_Lib/Word_EqI.thy
@@ -15,8 +15,12 @@ begin
 
 text \<open>
   Some word equalities can be solved by considering the problem bitwise for all
-  @{prop "n < LENGTH('a::len)"}, which is different to running @{text word_bitwise}
-  and expanding into an explicit list of bits.
+  @{prop "n < LENGTH('a::len)"}. This is similar to the existing method @{text word_bitwise}
+  and expanding into an explicit list of bits. The @{text word_bitwise} only works on
+  concrete word lengths, but can treat a wider number of operators (in particular a mix of
+  arithmetic, order, and bit operations). The @{text word_eqI} method below works on words of
+  abstract size (@{typ "'a word"}) and produces smaller, more abstract goals, but does not deal
+  with arithmetic operations.
 \<close>
 
 lemmas le_mask_high_bits_len = le_mask_high_bits[unfolded word_size]
@@ -49,6 +53,8 @@ lemma test_bit_lenD:
   "bit x n \<Longrightarrow> n < LENGTH('a) \<and> bit x n" for x :: "'a :: len word"
   by (fastforce dest: test_bit_size simp: word_size)
 
+\<comment> \<open>Method to reduce goals of the form @{prop "P \<Longrightarrow> x = y"} for words of abstract length to
+    reasoning on bits of the words. Leaves open goal if unsolved.\<close>
 method word_eqI uses simp simp_del split split_del cong flip =
   ((* reduce conclusion to test_bit: *)
    rule word_eqI_rules,
@@ -72,6 +78,8 @@ method word_eqI uses simp simp_del split split_del cong flip =
    (* helps sometimes, rarely: *)
    (simp add: simp test_bit_conj_lt del: simp_del flip: flip split: split split del: split_del cong: cong)?)
 
+\<comment> \<open>Method to reduce goals of the form @{prop "P \<Longrightarrow> x = y"} for words of abstract length to
+    reasoning on bits of the words. Fails if goal unsolved, but tries harder than @{method word_eqI}.\<close>
 method word_eqI_solve uses simp simp_del split split_del cong flip dest =
   solves \<open>word_eqI simp: simp simp_del: simp_del split: split split_del: split_del
                    cong: cong simp flip: flip;

--- a/lib/Word_Lib/Word_Lemmas.thy
+++ b/lib/Word_Lib/Word_Lemmas.thy
@@ -16,6 +16,7 @@ theory Word_Lemmas
     Enumeration_Word
     Aligned
     Bit_Shifts_Infix_Syntax
+    Boolean_Inequalities
     Word_EqI
 begin
 
@@ -24,6 +25,32 @@ lemmas take_bit_Suc_numeral[simp] = take_bit_Suc[where a="numeral w" for w]
 context
   includes bit_operations_syntax
 begin
+
+lemma word_max_le_or:
+  "max x y \<le> x OR y" for x :: "'a::len word"
+  by (simp add: word_bool_le_funs)
+
+lemma word_and_le_min:
+  "x AND y \<le> min x y" for x :: "'a::len word"
+  by (simp add: word_bool_le_funs)
+
+lemma word_not_le_eq:
+  "(NOT x \<le> y) = (NOT y \<le> x)" for x :: "'a::len word"
+  by transfer (auto simp: take_bit_not_eq_mask_diff)
+
+lemma word_not_le_not_eq[simp]:
+  "(NOT y \<le> NOT x) = (x \<le> y)" for x :: "'a::len word"
+  by (subst word_not_le_eq) simp
+
+lemma not_min_eq:
+  "NOT (min x y) = max (NOT x) (NOT y)" for x :: "'a::len word"
+  unfolding min_def max_def
+  by auto
+
+lemma not_max_eq:
+  "NOT (max x y) = min (NOT x) (NOT y)" for x :: "'a::len word"
+  unfolding min_def max_def
+  by auto
 
 lemma ucast_le_ucast_eq:
   fixes x y :: "'a::len word"

--- a/lib/Word_Lib/Word_Lib_Sumo.thy
+++ b/lib/Word_Lib/Word_Lib_Sumo.thy
@@ -34,6 +34,7 @@ imports
   Rsplit
   Signed_Words
   Syntax_Bundles
+  Sgn_Abs
   Typedef_Morphisms
   Type_Syntax
   Word_EqI

--- a/lib/Word_Lib/Word_Lib_Sumo.thy
+++ b/lib/Word_Lib/Word_Lib_Sumo.thy
@@ -134,6 +134,6 @@ lemmas cast_simps = cast_simps ucast_down_bl
 lemma nth_ucast:
   "(ucast (w::'a::len word)::'b::len word) !! n =
    (w !! n \<and> n < min LENGTH('a) LENGTH('b))"
-  by (auto simp add: bit_simps not_le dest: bit_imp_le_length)
+  by (auto simp: not_le dest: bit_imp_le_length)
 
 end

--- a/lib/Word_Lib/Word_Lib_Sumo.thy
+++ b/lib/Word_Lib/Word_Lib_Sumo.thy
@@ -16,7 +16,6 @@ imports
   Bits_Int
   Bitwise_Signed
   Bitwise
-  Boolean_Inequalities
   Enumeration_Word
   Generic_set_bit
   Hex_Words

--- a/lib/Word_Lib/Word_Lib_Sumo.thy
+++ b/lib/Word_Lib/Word_Lib_Sumo.thy
@@ -16,6 +16,7 @@ imports
   Bits_Int
   Bitwise_Signed
   Bitwise
+  Boolean_Inequalities
   Enumeration_Word
   Generic_set_bit
   Hex_Words


### PR DESCRIPTION
- define `sgn` and `abs`
- prove equalities between boolean and arithmetic operations (in rings, so applies to `int` and `word`). Examples include
  ```
  x + y = (x OR y) + (x AND y)
  x + y = (x XOR y) + 2 * (x AND y)
  x - y = (x AND NOT y) - (NOT x AND y)
  x XOR y = (x OR y) - (x AND y)
  x OR y = (x AND NOT y) + y
  ```
  etc. This should be a fairly complete set.
- prove all inequalities between binary boolean functions on words (e.g. `a && b <= a || b` etc)
- add laws about min, max, and NOT 
- some cleanup in `More_Word` (because some of these are now subsumed by ring lemmas) and doc improvements
- a lemma to turn `a < b` into a bitwise expression on abstract word lengths

Provides only additional rules or changes proofs, but should not change the proof context in any destructive way.