### PR TITLE
cspec: adjust Kernel_Config generation

### DIFF
--- a/spec/cspec/c/gen-config-thy.py
+++ b/spec/cspec/c/gen-config-thy.py
@@ -193,7 +193,7 @@ def parse_gen_config(gen_config_file: str) -> Dict[str, str]:
     """
     Parse gen_config.h and return a dictionary of the values.
     """
-    end_comment_re = re.compile(r'  /\*.*\*/')
+    end_comment_re = re.compile(r'/\*.*\*/')
 
     config = {}
     with open(gen_config_file, 'r') as f:

--- a/spec/cspec/c/kernel.mk
+++ b/spec/cspec/c/kernel.mk
@@ -128,4 +128,5 @@ ${KERNEL_CONFIG_ROOT}/.cmake_done: ${KERNEL_DEPS} gen-config-thy.py
 		-DCMAKE_TOOLCHAIN_FILE=${CSPEC_DIR}/c/no-compiler.cmake \
 		${KERNEL_CMAKE_EXTRA_OPTIONS} \
 		-G Ninja ${SOURCE_ROOT}
+	cd ${KERNEL_CONFIG_ROOT} && ninja gen_config/kernel/gen_config.json
 	touch ${KERNEL_CONFIG_ROOT}/.cmake_done


### PR DESCRIPTION
seL4/seL4#975 slightly changed how the config headers are generated. They now need a (short) `ninja` build step and they produce less spaces in the header file.

This PR adjusts for that, but does not read the generated json file yet, which should be more robust in the future than parsing the C header.