### PR TITLE
cspec: provide mechanism for adding dts overlays

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 /spec/cspec/c/build
 /spec/cspec/c/config-build
 /spec/cspec/c/export
+/spec/cspec/c/overlays/*/overlay.dts
 
 /spec/haskell/stack.yaml.lock
 /spec/haskell/doc/**/*.aux

--- a/spec/cspec/README.md
+++ b/spec/cspec/README.md
@@ -52,6 +52,9 @@ indicating the architecture-specific definitions and proofs to use. The default
 architecture is `ARM` and will be selected if none is provided. See
 `l4v/spec/cspec/c/Makefile` for seL4 configuration details.
 
+The build process has an option for providing a device tree overlay file if
+desired, which can customise the memory regions available to the kernel. See
+the [README](c/overlays/README.md) file in `c/overlays/` for more details.
 
 Remarks
 -------

--- a/spec/cspec/c/overlays/AARCH64/default-overlay.dts
+++ b/spec/cspec/c/overlays/AARCH64/default-overlay.dts
@@ -1,0 +1,6 @@
+/*
+ * Copyright 2023, Proofcraft Pty Ltd
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+/* Empty overlay file that will be used if no custom `overlay.dts` exists. */

--- a/spec/cspec/c/overlays/ARM/default-overlay.dts
+++ b/spec/cspec/c/overlays/ARM/default-overlay.dts
@@ -1,0 +1,6 @@
+/*
+ * Copyright 2023, Proofcraft Pty Ltd
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+/* Empty overlay file that will be used if no custom `overlay.dts` exists. */

--- a/spec/cspec/c/overlays/ARM_HYP/default-overlay.dts
+++ b/spec/cspec/c/overlays/ARM_HYP/default-overlay.dts
@@ -1,0 +1,6 @@
+/*
+ * Copyright 2023, Proofcraft Pty Ltd
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+/* Empty overlay file that will be used if no custom `overlay.dts` exists. */

--- a/spec/cspec/c/overlays/README.md
+++ b/spec/cspec/c/overlays/README.md
@@ -1,0 +1,22 @@
+<!--
+     Copyright 2024, Proofcraft Pty Ltd
+
+     SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
+# DTS Overlays
+
+This directory contains device tree overlay files that can be used to override
+default platform parameters such as available memory regions.
+
+The default files in the repository are all empty.
+
+To provide an override, place a file `overlay.dts` into the respective
+architecture directory, e.g. `ARM/overlay.dts`.
+
+The l4v build system will pick up this overlay file when it generates the
+kernel configuration data and preprocessed kernel code. It will rebuild proof
+sessions according to their dependencies.
+
+The `X64` build does not support overlays, and therefore does not provide a
+default.

--- a/spec/cspec/c/overlays/RISCV64/default-overlay.dts
+++ b/spec/cspec/c/overlays/RISCV64/default-overlay.dts
@@ -1,0 +1,6 @@
+/*
+ * Copyright 2023, Proofcraft Pty Ltd
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+/* Empty overlay file that will be used if no custom `overlay.dts` exists. */


### PR DESCRIPTION
Add mechanism for adding overlay.dts files to the l4v build for all architectures apart from X64 (which does not use dts files).

For example, place a file `overlays/ARM/overlay.dts` into the tree and the build will pick it up as custom overlay file with the correct proof session dependencies.

If no file is provided, an empty default overlay file is used.

This mechanism is useful for a multi-kernel setup that uses overlays to restrict the available memory regions per CPU node.