### PR TITLE
cspec: extract physBase from C headers

### DIFF
--- a/proof/crefine/ARM_HYP/SR_lemmas_C.thy
+++ b/proof/crefine/ARM_HYP/SR_lemmas_C.thy
@@ -2438,5 +2438,19 @@ lemma unat_scast_numDomains:
   "unat (SCAST(32 signed \<rightarrow> machine_word_len) Kernel_C.numDomains) = unat Kernel_C.numDomains"
   by (simp add: scast_eq sint_numDomains_to_H unat_numDomains_to_H numDomains_machine_word_safe)
 
+(* FIXME physBase now has two definitions: Kernel_Config.physBase and Platform.ARM_HYP.physBase,
+     the latter should be removed, but sees plenty of use in ARM_HYP *)
+(* doubles as a sanity check of Kernel_Config being correctly loaded from the seL4 build system *)
+lemma physBase_spec:
+  "\<forall>s. \<Gamma>\<turnstile> {s} Call physBase_'proc {t. ret__unsigned_long_' t = Kernel_Config.physBase }"
+  apply (rule allI, rule conseqPre, vcg)
+  apply (simp add: Kernel_Config.physBase_def)
+  done
+
+(* FIXME: this is a temporary fix, only Kernel_Config.physBase should remain in the end *)
+lemma unify_physBase:
+  "Kernel_Config.physBase = Platform.ARM_HYP.physBase"
+  by (simp add: Kernel_Config.physBase_def Platform.ARM_HYP.physBase_def)
+
 end
 end

--- a/proof/crefine/ARM_HYP/VSpace_C.thy
+++ b/proof/crefine/ARM_HYP/VSpace_C.thy
@@ -781,7 +781,8 @@ lemma ptrFromPAddr_spec:
    Call ptrFromPAddr_'proc
    \<lbrace>\<acute>ret__ptr_to_void = Ptr (ptrFromPAddr (paddr_' s))\<rbrace>"
   apply vcg
-  apply (simp add: ptrFromPAddr_def pptrBaseOffset_def pptrBase_def physBase_def)
+  (* FIXME: unify_physBase will be unnecessary once there is only one physBase *)
+  apply (simp add: ptrFromPAddr_def pptrBaseOffset_def pptrBase_def unify_physBase)
   done
 
 lemma addrFromPPtr_spec:
@@ -789,7 +790,8 @@ lemma addrFromPPtr_spec:
    Call addrFromPPtr_'proc
    \<lbrace>\<acute>ret__unsigned_long = addrFromPPtr (ptr_val (pptr_' s))\<rbrace>"
   apply vcg
-  apply (simp add: addrFromPPtr_def pptrBaseOffset_def pptrBase_def physBase_def)
+  (* FIXME: unify_physBase will be unnecessary once there is only one physBase *)
+  apply (simp add: addrFromPPtr_def pptrBaseOffset_def pptrBase_def unify_physBase)
   done
 
 lemma addrFromKPPtr_spec:
@@ -797,8 +799,9 @@ lemma addrFromKPPtr_spec:
    Call addrFromKPPtr_'proc
    \<lbrace>\<acute>ret__unsigned_long = addrFromKPPtr (ptr_val (pptr_' s))\<rbrace>"
   apply vcg
+  (* FIXME: unify_physBase will be unnecessary once there is only one physBase *)
   apply (simp add: addrFromKPPtr_def kernelELFBaseOffset_def kernelELFPAddrBase_def
-                   kernelELFBase_def physBase_def pptrBase_def mask_def)
+                   kernelELFBase_def unify_physBase pptrBase_def mask_def)
   done
 
 abbreviation


### PR DESCRIPTION
Extract the numeric value physBase_raw from the generated header gen_headers/plat/machine/devices_gen.h and provide it as the constant physBase in Kernel_Config.thy.

In C this will later match up with the value returned by physBase().

Test with: seL4/seL4#983

(Test will fail until we have adjusted the proofs for use of `physBase()`)