### PR TITLE
simp setup for If and option

### DIFF
--- a/lib/Lib.thy
+++ b/lib/Lib.thy
@@ -2522,7 +2522,25 @@ lemma if_option_None_eq:
   "((if P then Some x else None) = None) = (\<not>P)"
   by simp+
 
-lemmas if_option = if_option_None_eq if_option_Some if_option_Some2
+lemma lhs_sym_eq:
+  "(a = b) = x \<longleftrightarrow> (b = a) = x"
+  by auto
+
+(* if_option is not [simp], because it can add x = y equations to the premises of the goal, which
+   get picked up by the simplifier and may lead to non-termination. *)
+lemmas if_option =
+  if_option_Some
+  if_option_Some[unfolded lhs_sym_eq]
+  if_option_Some2
+  if_option_Some2[unfolded lhs_sym_eq]
+
+(* if_option_eq should be safer, but is still not [simp], because P can be an equation, which can
+   lead to non-termination. *)
+lemmas if_option_eq =
+  if_option_None_eq
+  if_option_None_eq[unfolded lhs_sym_eq]
+  if_option_Some_eq
+  if_option_Some_eq[unfolded lhs_sym_eq]
 
 lemma not_in_ran_None_upd:
   "x \<notin> ran m \<Longrightarrow> x \<notin> ran (m(y := None))"

--- a/proof/invariant-abstract/AARCH64/ArchKHeap_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchKHeap_AI.thy
@@ -9,9 +9,7 @@ theory ArchKHeap_AI
 imports KHeapPre_AI
 begin
 
-(* FIXME AARCH64: if_option is missing all cases for None/Some = if .. *)
-
-declare if_option_Some_eq[simp]
+declare if_option_eq[simp]
 
 context Arch begin global_naming AARCH64
 


### PR DESCRIPTION
Terms of the form "(if P then None else Some _) = None" and all their
combinations can be simplified automatically. For the "Some" variants
we provide a safer form, e.g.:

    ((if P then Some x else None) = Some x) = P

because

    ((if P then Some x else None) = Some y) = (P /\ x = y)

adds an equation to the goal that the simplifier will pick up. That is
often wanted, but sometimes leads to non-termination.

Even the safer form can lead to non-termination if P is an equation, so
none of these are [simp] by default.

- `if_option_eq` is the safer set
- `if_option` is the less safe set that simplifies more

This resolves one of the FIXMEs int he AARCH64 proofs.