### PR TITLE
crefine: simp rules for true and false

### DIFF
--- a/lib/Word_Lib/More_Bit_Ring.thy
+++ b/lib/Word_Lib/More_Bit_Ring.thy
@@ -125,6 +125,11 @@ lemma minus_eq_and_not_minus_xor:
   "x - y = 2 * (x AND NOT y) - (x XOR y)"
   by (metis and.commute minus_diff_eq minus_eq_xor_minus_not_and xor.commute)
 
+lemma and_one_neq_simps[simp]:
+  "x AND 1 \<noteq> 0 \<longleftrightarrow> x AND 1 = 1"
+  "x AND 1 \<noteq> 1 \<longleftrightarrow> x AND 1 = 0"
+  by (clarsimp simp: and_one_eq)+
+
 end
 end
 

--- a/proof/crefine/ARM/Arch_C.thy
+++ b/proof/crefine/ARM/Arch_C.thy
@@ -54,7 +54,7 @@ lemma performPageTableInvocationUnmap_ccorres:
          apply wp
         apply (simp del: Collect_const)
         apply (vcg exspec=unmapPageTable_modifies)
-       apply (simp add: to_bool_def)
+       apply simp
        apply (rule ccorres_return_Skip')
       apply (simp add: cap_get_tag_isCap_ArchObject[symmetric])
       apply (clarsimp simp: cap_lift_page_table_cap cap_to_H_def
@@ -796,7 +796,7 @@ lemma decodeARMPageTableInvocation_ccorres:
             apply vcg
            apply (rule conseqPre, vcg)
            apply (clarsimp simp: throwError_def return_def syscall_error_rel_def
-                                 syscall_error_to_H_cases exception_defs false_def)
+                                 syscall_error_to_H_cases exception_defs)
            apply (erule lookup_failure_rel_fault_lift[rotated])
            apply (simp add: exception_defs)
           apply simp
@@ -889,8 +889,8 @@ lemma checkVPAlignment_spec:
   apply (clarsimp simp: mask_eq_iff_w2p word_size)
   apply (rule conjI)
    apply (simp add: pageBitsForSize_def split: vmpage_size.split)
-  apply (simp add: from_bool_def vmsz_aligned'_def is_aligned_mask
-                   mask_def split: if_split)
+  apply (simp add: vmsz_aligned'_def is_aligned_mask mask_def
+            split: if_split)
   done
 
 definition
@@ -1032,9 +1032,9 @@ lemma createSafeMappingEntries_PDE_ccorres:
     apply (clarsimp simp: pde_get_tag_alt cpde_relation_pde_case
                           pde_tag_defs fst_throwError_returnOk
                           pde_range_relation_def ptr_range_to_list_def
-                          exception_defs isRight_def from_bool_def[where b=True]
+                          exception_defs isRight_def
                           syscall_error_rel_def syscall_error_to_H_cases)
-    apply (clarsimp simp: cpde_relation_def true_def false_def)
+    apply (clarsimp simp: cpde_relation_def)
    apply (rule ccorres_Cond_rhs)
     apply (simp del: Collect_const)
     apply (rule ccorres_rhs_assoc)+
@@ -1074,7 +1074,7 @@ lemma createSafeMappingEntries_PDE_ccorres:
                     apply (rule allI, rule conseqPre, vcg)
                     apply (clarsimp simp: if_1_0_0 return_def typ_heap_simps Let_def)
                     apply (simp add: isPageTablePDE_def isSectionPDE_def
-                                     cpde_relation_pde_case from_bool_def)
+                                     cpde_relation_pde_case)
                     apply (intro impI conjI disjCI2, simp_all add: array_assertion_shrink_right)[1]
                     apply (clarsimp simp: pde_tag_defs  split: if_split bool.split)
                     apply (frule pde_pde_section_size_0_1[simplified pde_tag_defs, simplified], simp)
@@ -1142,7 +1142,7 @@ lemma createSafeMappingEntries_PDE_ccorres:
     ARMSectionBits_def word_0_sle_from_less
     pageBits_def)
   apply (rule conjI)
-   apply (simp add: cpde_relation_def true_def false_def)
+   apply (simp add: cpde_relation_def)
   apply (simp add: upt_def split: if_split)
   done
 
@@ -1274,7 +1274,7 @@ lemma createSafeMappingEntries_PTE_ccorres:
          apply vcg
         apply (rule conseqPre, vcg)
         apply (clarsimp simp: fst_throwError_returnOk syscall_error_to_H_cases
-                              syscall_error_rel_def exception_defs false_def)
+                              syscall_error_rel_def exception_defs)
         apply (erule lookup_failure_rel_fault_lift[rotated])
         apply (simp add: exception_defs)
        apply simp
@@ -1372,7 +1372,7 @@ lemma createSafeMappingEntries_PTE_ccorres:
          apply vcg
         apply (rule conseqPre, vcg)
         apply (clarsimp simp: fst_throwError_returnOk syscall_error_rel_def
-                              syscall_error_to_H_cases exception_defs false_def)
+                              syscall_error_to_H_cases exception_defs)
         apply (erule lookup_failure_rel_fault_lift[rotated])
         apply (simp add: exception_defs)
        apply (wp injection_wp[OF refl])
@@ -1391,7 +1391,7 @@ lemma createSafeMappingEntries_PTE_ccorres:
                         from_bool_mask_simp[unfolded mask_def, simplified])
   apply (clarsimp simp: typ_heap_simps pte_range_relation_def
                         ptr_range_to_list_def upto_enum_word)
-  apply (simp add: cpte_relation_def true_def false_def pte_tag_defs)
+  apply (simp add: cpte_relation_def pte_tag_defs)
   using pte_get_tag_exhaust
   apply (auto simp: vmsz_aligned'_def largePagePTEOffsets_def pteBits_def
                     upt_def upto_enum_def upto_enum_step_def)[1]
@@ -1445,7 +1445,7 @@ lemma pteCheckIfMapped_ccorres:
   apply clarsimp
   apply (rule conseqPre, vcg)
   apply (clarsimp simp: typ_heap_simps' return_def)
-  apply (case_tac rv, simp_all add: to_bool_def isInvalidPTE_def pte_tag_defs pte_pte_invalid_def
+  apply (case_tac rv, simp_all add: isInvalidPTE_def pte_tag_defs pte_pte_invalid_def
                                     cpte_relation_def pte_pte_large_lift_def pte_get_tag_def
                                     pte_lift_def Let_def
                              split: if_split_asm)
@@ -1473,7 +1473,7 @@ lemma pdeCheckIfMapped_ccorres:
   apply clarsimp
   apply (rule conseqPre, vcg)
   apply (clarsimp simp: typ_heap_simps' return_def)
-  apply (case_tac rv, simp_all add: to_bool_def cpde_relation_invalid isInvalidPDE_def
+  apply (case_tac rv, simp_all add: cpde_relation_invalid isInvalidPDE_def
                              split: if_split)
   done
 
@@ -1557,7 +1557,7 @@ lemma performPageInvocationMapPTE_ccorres:
             apply (rule allI, rule conseqPre, vcg)
             apply (clarsimp simp:return_def)
            apply (rule wp_post_taut)
-          apply (simp add: to_bool_def)
+          apply simp
           apply (rule_tac P=\<top> and P'=UNIV in ccorres_from_vcg_throws)
           apply (rule allI, rule conseqPre, vcg)
           apply (clarsimp simp:return_def)
@@ -1818,12 +1818,12 @@ lemma performPageInvocationMapPDE_ccorres:
            apply (rule allI, rule conseqPre, vcg)
            apply (clarsimp simp:return_def)
           apply wp [1]
-         apply (simp add: to_bool_def)
+         apply simp
          apply (rule_tac P=\<top> and P'=UNIV in ccorres_from_vcg_throws)
          apply (rule allI, rule conseqPre, vcg)
          apply (clarsimp simp:return_def)
         apply (wp hoare_vcg_const_imp_lift) [1]
-       apply (clarsimp simp: to_bool_def)
+       apply clarsimp
        apply (rule hoare_strengthen_post)
         apply (rule_tac Q'="\<lambda>rv s. valid_pde_mappings' s
                 \<and> valid_pde_slots'2 mapping s
@@ -2173,12 +2173,12 @@ where
 
 lemma resolve_ret_rel_None[simp]:
   "resolve_ret_rel None y = (valid_C y = scast false)"
-  by (clarsimp simp: resolve_ret_rel_def o_def to_option_def false_def to_bool_def split: if_splits)
+  by (clarsimp simp: resolve_ret_rel_def o_def to_option_def to_bool_def split: if_splits)
 
 lemma resolve_ret_rel_Some:
   "\<lbrakk>valid_C y = scast true;  frameSize_C y = framesize_from_H (fst x); snd x = frameBase_C y\<rbrakk>
    \<Longrightarrow> resolve_ret_rel (Some x) y"
-  by (clarsimp simp: resolve_ret_rel_def o_def to_option_def true_def)
+  by (clarsimp simp: resolve_ret_rel_def o_def to_option_def)
 
 lemma resolveVAddr_ccorres:
   "ccorres resolve_ret_rel ret__struct_resolve_ret_C_'
@@ -2448,7 +2448,7 @@ lemma decodeARMFrameInvocation_ccorres:
         apply vcg
        apply (rule conseqPre, vcg)
        apply (clarsimp simp: throwError_def return_def syscall_error_rel_def
-                             syscall_error_to_H_cases exception_defs false_def)
+                             syscall_error_to_H_cases exception_defs)
        apply (erule lookup_failure_rel_fault_lift[rotated])
        apply (simp add: exception_defs)
       apply (wp injection_wp[OF refl])
@@ -2621,7 +2621,7 @@ lemma decodeARMFrameInvocation_ccorres:
                   apply (prop_tac "generic_frame_cap_get_capFMappedASID_CL (cap_lift cap)
                                    = capPDMappedASID_CL (cap_page_directory_cap_lift rv')")
                    apply (clarsimp simp: cap_lift_page_directory_cap cap_to_H_def
-                                         to_bool_def cap_page_directory_cap_lift_def
+                                         cap_page_directory_cap_lift_def
                                   elim!: ccap_relationE split: if_splits)
                   apply (clarsimp, ccorres_rewrite)
                   apply (csymbr, clarsimp simp: hd_conv_nth length_ineq_not_Nil, ccorres_rewrite)
@@ -2653,7 +2653,7 @@ lemma decodeARMFrameInvocation_ccorres:
                 apply (rule ccorres_if_cond_throws[rotated -1, where Q=\<top> and Q'=\<top>])
                    apply vcg
                   apply (clarsimp simp: cap_lift_page_directory_cap cap_to_H_def
-                                        to_bool_def cap_page_directory_cap_lift_def
+                                        cap_page_directory_cap_lift_def
                                  elim!: ccap_relationE split: if_split)
                  apply (rule syscall_error_throwError_ccorres_n)
                  apply (simp add: syscall_error_to_H_cases)
@@ -2730,7 +2730,7 @@ lemma decodeARMFrameInvocation_ccorres:
                apply (rule_tac P'="{s. find_ret = errstate s}" in ccorres_from_vcg_throws[where P=\<top>])
                apply (rule allI, rule conseqPre, vcg)
                apply (clarsimp simp: fst_throwError_returnOk exception_defs syscall_error_rel_def
-                                     syscall_error_to_H_cases false_def)
+                                     syscall_error_to_H_cases)
                apply (erule lookup_failure_rel_fault_lift[rotated], simp add: exception_defs)
               apply simp
               apply (wp injection_wp[OF refl] | wp (once) hoare_drop_imps)+
@@ -3027,11 +3027,10 @@ lemma decodeARMPageDirectoryInvocation_ccorres:
         apply (simp add:if_to_top_of_bind if_to_top_of_bindE)
         apply (rule ccorres_if_cond_throws[rotated -1,where Q=\<top> and Q'=\<top>])
            apply vcg
-          apply (clarsimp dest!:cap_lift_page_directory_cap
-                    simp : cap_page_directory_cap_lift_def
-                           cap_to_H_def to_bool_def Let_def
-                    elim!: ccap_relationE
-                    split: cap_CL.splits if_splits)
+          apply (clarsimp dest!: cap_lift_page_directory_cap
+                          simp : cap_page_directory_cap_lift_def cap_to_H_def to_bool_def Let_def
+                          elim!: ccap_relationE
+                          split: cap_CL.splits if_splits)
          apply (simp add:injection_handler_throwError)
          apply (rule syscall_error_throwError_ccorres_n)
          apply (simp add:syscall_error_to_H_cases)
@@ -3067,16 +3066,17 @@ lemma decodeARMPageDirectoryInvocation_ccorres:
                 apply simp
                apply simp
               apply ceqv
-             apply (simp add:injection_handler_If
-               injection_handler_returnOk if_to_top_of_bind if_to_top_of_bindE)
+             apply (simp add: injection_handler_If injection_handler_returnOk if_to_top_of_bind
+                              if_to_top_of_bindE)
              apply (rule_tac Q=\<top> and Q'=\<top> in ccorres_if_cond_throws[rotated -1])
                 apply vcg
-               apply (clarsimp simp:resolve_ret_rel_def to_bool_def to_option_def
-                        rel_option_alt_def not_le split:option.splits if_splits)
-              apply (simp add:invocationCatch_def ARM_H.performInvocation_def
-                performInvocation_def performARMMMUInvocation_def)
-              apply (simp add:performPageDirectoryInvocation_def
-                liftE_case_sum liftE_bindE liftE_alternative)
+               apply (clarsimp simp: resolve_ret_rel_def to_bool_def to_option_def
+                                     rel_option_alt_def not_le
+                              split: option.splits if_splits)
+              apply (simp add: invocationCatch_def ARM_H.performInvocation_def
+                               performInvocation_def performARMMMUInvocation_def)
+              apply (simp add: performPageDirectoryInvocation_def
+                               liftE_case_sum liftE_bindE liftE_alternative)
               apply (ctac add: setThreadState_ccorres)
               apply (rule ccorres_alternative2)
               apply (simp add:returnOk_liftE[symmetric])
@@ -3101,7 +3101,7 @@ lemma decodeARMPageDirectoryInvocation_ccorres:
               apply (rule ccorres_from_vcg_throws[where P=\<top> and P'=UNIV])
               apply (rule allI, rule conseqPre, vcg)
               apply (clarsimp simp: throwError_def return_def syscall_error_rel_def exception_defs
-                                    syscall_error_to_H_cases false_def)
+                                    syscall_error_to_H_cases)
               apply (clarsimp simp: page_base_def resolve_ret_rel_def rel_option_alt_def to_option_def
                                     mask_def[unfolded shiftl_1,symmetric]
                               split: option.splits if_splits)
@@ -3157,7 +3157,7 @@ lemma decodeARMPageDirectoryInvocation_ccorres:
             apply vcg
            apply (rule conseqPre, vcg)
            apply (clarsimp simp: throwError_def return_def syscall_error_rel_def
-                                 syscall_error_to_H_cases exception_defs false_def)
+                                 syscall_error_to_H_cases exception_defs)
            apply (erule lookup_failure_rel_fault_lift[rotated])
            apply (simp add: exception_defs)
           apply simp
@@ -3207,67 +3207,65 @@ lemma decodeARMPageDirectoryInvocation_ccorres:
       apply (case_tac st,simp+)
      apply (frule cap_get_tag_isCap_unfolded_H_cap(15))
      apply (clarsimp simp: cap_lift_page_directory_cap hd_conv_nth
-                        cap_lift_page_table_cap typ_heap_simps'
+                           cap_lift_page_table_cap typ_heap_simps'
+                           cap_to_H_def cap_page_directory_cap_lift_def
+                           cap_page_table_cap_lift_def
+                           typ_heap_simps' shiftl_t2n[where n=2] field_simps
+                    elim!: ccap_relationE)
+     apply (intro conjI impI allI)
+      apply (clarsimp simp: ThreadState_Restart_def less_mask_eq rf_sr_ksCurThread
+                            resolve_ret_rel_def framesize_from_to_H framesize_from_H_mask2
+                            to_option_def rel_option_alt_def to_bool_def typ_heap_simps'
+                     split: option.splits if_splits
+             | fastforce simp: mask_def
+             | rule flushtype_relation_triv,simp add:isPageFlush_def isPDFlushLabel_def
+             | rule word_of_nat_less,simp add: pbfs_less)+
+    apply (frule cap_get_tag_isCap_unfolded_H_cap(15))
+    apply (clarsimp simp: cap_lift_page_directory_cap hd_conv_nth
+                          cap_lift_page_table_cap
+                          cap_to_H_def cap_page_directory_cap_lift_def
+                          cap_page_table_cap_lift_def
+                          typ_heap_simps' shiftl_t2n[where n=2] field_simps
+                   elim!: ccap_relationE)
+    apply (intro conjI impI allI)
+     apply (clarsimp simp: ThreadState_Restart_def less_mask_eq rf_sr_ksCurThread
+                           resolve_ret_rel_def framesize_from_to_H framesize_from_H_mask2
+                           to_option_def rel_option_alt_def to_bool_def
+                           typ_heap_simps'
+                    split: option.splits if_splits
+            | fastforce simp: mask_def
+            | rule flushtype_relation_triv, simp add:isPageFlush_def isPDFlushLabel_def
+            | rule word_of_nat_less, simp add: pbfs_less)+
+   apply (frule cap_get_tag_isCap_unfolded_H_cap(15))
+   apply (clarsimp simp: cap_lift_page_directory_cap hd_conv_nth
+                         cap_lift_page_table_cap
+                         cap_to_H_def cap_page_directory_cap_lift_def
+                         to_bool_def cap_page_table_cap_lift_def
+                         typ_heap_simps' shiftl_t2n[where n=2] field_simps
+                  elim!: ccap_relationE)
+   apply (intro conjI impI allI)
+    apply (clarsimp simp: ThreadState_Restart_def less_mask_eq rf_sr_ksCurThread
+                          resolve_ret_rel_def framesize_from_to_H framesize_from_H_mask2
+                          to_option_def rel_option_alt_def typ_heap_simps'
+                   split: option.splits if_splits
+           | fastforce simp: mask_def
+           | rule flushtype_relation_triv, simp add:isPageFlush_def isPDFlushLabel_def
+           | rule word_of_nat_less, simp add: pbfs_less)+ (* slow 20 secs *)
+  apply (frule cap_get_tag_isCap_unfolded_H_cap(15))
+  apply (clarsimp simp: cap_lift_page_directory_cap hd_conv_nth
+                        cap_lift_page_table_cap
                         cap_to_H_def cap_page_directory_cap_lift_def
                         to_bool_def cap_page_table_cap_lift_def
                         typ_heap_simps' shiftl_t2n[where n=2] field_simps
                  elim!: ccap_relationE)
-     apply (intro conjI impI allI)
-      apply (clarsimp simp:ThreadState_Restart_def less_mask_eq rf_sr_ksCurThread
-        resolve_ret_rel_def framesize_from_to_H framesize_from_H_mask2
-        to_option_def rel_option_alt_def to_bool_def typ_heap_simps'
-        split:option.splits if_splits
-      | fastforce simp: mask_def
-      | rule flushtype_relation_triv,simp add:isPageFlush_def isPDFlushLabel_def
-      | rule word_of_nat_less,simp add: pbfs_less)+
-    apply (frule cap_get_tag_isCap_unfolded_H_cap(15))
-    apply (clarsimp simp: cap_lift_page_directory_cap hd_conv_nth
-      cap_lift_page_table_cap
-      cap_to_H_def cap_page_directory_cap_lift_def
-      to_bool_def cap_page_table_cap_lift_def
-      typ_heap_simps' shiftl_t2n[where n=2] field_simps
-      elim!: ccap_relationE)
-    apply (intro conjI impI allI)
-     apply (clarsimp simp:ThreadState_Restart_def less_mask_eq rf_sr_ksCurThread
-        resolve_ret_rel_def framesize_from_to_H framesize_from_H_mask2
-        to_option_def rel_option_alt_def to_bool_def
-        typ_heap_simps'
-        split:option.splits if_splits
-      | fastforce simp: mask_def
-      | rule flushtype_relation_triv,simp add:isPageFlush_def isPDFlushLabel_def
-      | rule word_of_nat_less,simp add: pbfs_less)+
-   apply (frule cap_get_tag_isCap_unfolded_H_cap(15))
-   apply (clarsimp simp: cap_lift_page_directory_cap hd_conv_nth
-     cap_lift_page_table_cap
-     cap_to_H_def cap_page_directory_cap_lift_def
-     to_bool_def cap_page_table_cap_lift_def
-     typ_heap_simps' shiftl_t2n[where n=2] field_simps
-     elim!: ccap_relationE)
-   apply (intro conjI impI allI)
-    apply (clarsimp simp:ThreadState_Restart_def less_mask_eq rf_sr_ksCurThread
-      resolve_ret_rel_def framesize_from_to_H framesize_from_H_mask2
-      to_option_def rel_option_alt_def to_bool_def
-      typ_heap_simps'
-      split:option.splits if_splits
-      | fastforce simp: mask_def
-      | rule flushtype_relation_triv,simp add:isPageFlush_def isPDFlushLabel_def
-      | rule word_of_nat_less,simp add: pbfs_less)+ (* slow 20 secs *)
-  apply (frule cap_get_tag_isCap_unfolded_H_cap(15))
-  apply (clarsimp simp: cap_lift_page_directory_cap hd_conv_nth
-    cap_lift_page_table_cap
-    cap_to_H_def cap_page_directory_cap_lift_def
-    to_bool_def cap_page_table_cap_lift_def
-    typ_heap_simps' shiftl_t2n[where n=2] field_simps
-    elim!: ccap_relationE)
   apply (intro conjI impI allI)
-   by (clarsimp simp:ThreadState_Restart_def less_mask_eq rf_sr_ksCurThread
-     resolve_ret_rel_def framesize_from_to_H framesize_from_H_mask2
-     to_option_def rel_option_alt_def to_bool_def
-     typ_heap_simps'
-     split:option.splits if_splits
-     | fastforce simp: mask_def
-     | rule flushtype_relation_triv,simp add:isPageFlush_def isPDFlushLabel_def
-     | rule word_of_nat_less,simp add: pbfs_less)+
+   by (clarsimp simp: ThreadState_Restart_def less_mask_eq rf_sr_ksCurThread
+                      resolve_ret_rel_def framesize_from_to_H framesize_from_H_mask2
+                      to_option_def rel_option_alt_def typ_heap_simps'
+               split: option.splits if_splits
+       | fastforce simp: mask_def
+       | rule flushtype_relation_triv, simp add:isPageFlush_def isPDFlushLabel_def
+       | rule word_of_nat_less, simp add: pbfs_less)+
 
 lemma Arch_decodeInvocation_ccorres:
   "interpret_excaps extraCaps' = excaps_map extraCaps
@@ -3419,14 +3417,13 @@ lemma Arch_decodeInvocation_ccorres:
                   apply (cut_tac P="\<lambda>y. y < i_' x + 1 = rhs y" for rhs in allI,
                          rule less_x_plus_1)
                    apply (clarsimp simp: asid_high_bits_def)
-                  apply (clarsimp simp: rf_sr_armKSASIDTable from_bool_def
+                  apply (clarsimp simp: rf_sr_armKSASIDTable
                                         asid_high_bits_word_bits
                                         option_to_ptr_def option_to_0_def
                                         order_less_imp_le
                                         linorder_not_less
                                         order_antisym[OF inc_le])
-                  apply (clarsimp simp: true_def false_def
-                                 split: option.split if_split)
+                  apply (clarsimp split: option.split if_split)
                   apply (simp add: asid_high_bits_def word_le_nat_alt
                                    word_less_nat_alt unat_add_lem[THEN iffD1])
                   apply auto[1]
@@ -3446,7 +3443,6 @@ lemma Arch_decodeInvocation_ccorres:
                                       word_sless_def if_1_0_0 from_bool_0
                                       rf_sr_armKSASIDTable[where n=0, simplified])
                 apply (simp add: asid_high_bits_def option_to_ptr_def option_to_0_def
-                                 from_bool_def
                           split: option.split if_split)
                 apply fastforce
                apply ceqv
@@ -3681,7 +3677,7 @@ lemma Arch_decodeInvocation_ccorres:
           apply (rule allI, rule conseqPre, vcg)
           apply (clarsimp simp: throwError_def return_def
                                 syscall_error_rel_def exception_defs
-                                syscall_error_to_H_cases false_def)
+                                syscall_error_to_H_cases)
           apply (simp add: lookup_fault_lift_invalid_root)
          apply csymbr
          apply (rule_tac Q=\<top> and Q'=\<top> in ccorres_if_cond_throws[rotated -1])
@@ -3730,9 +3726,7 @@ lemma Arch_decodeInvocation_ccorres:
                                        = capASIDBase cp")
                 apply (subgoal_tac "\<And>x. (x < (i_' xb + 1))
                                           = (x < i_' xb \<or> x = i_' xb)")
-                 apply (clarsimp simp: inc_le from_bool_def typ_heap_simps
-                                       asid_low_bits_def not_less field_simps
-                                       false_def
+                 apply (clarsimp simp: inc_le typ_heap_simps asid_low_bits_def not_less field_simps
                                 split: if_split bool.splits)
                  apply unat_arith
                 apply (rule iffI)
@@ -3783,11 +3777,10 @@ lemma Arch_decodeInvocation_ccorres:
                                    word_sless_def word_sle_def)
              apply (erule cmap_relationE1[OF rf_sr_cpspace_asidpool_relation],
                     erule ko_at_projectKO_opt)
-             apply (clarsimp simp: typ_heap_simps from_bool_def split: if_split)
+             apply (clarsimp simp: typ_heap_simps split: if_split)
              apply (simp add: cap_get_tag_isCap_ArchObject[symmetric])
              apply (clarsimp simp: cap_lift_asid_pool_cap cap_to_H_def
-                                   cap_asid_pool_cap_lift_def false_def
-                                   ucast_minus ucast_nat_def
+                                   cap_asid_pool_cap_lift_def ucast_minus ucast_nat_def
                             elim!: ccap_relationE)
             apply ceqv
            apply (rule ccorres_Guard_Seq)+
@@ -3910,13 +3903,12 @@ lemma Arch_decodeInvocation_ccorres:
     apply (auto simp: ct_in_state'_def valid_tcb_state'_def
                dest!: st_tcb_at_idle_thread'
                elim!: pred_tcb'_weakenE)[1]
-  apply (clarsimp simp: if_1_0_0 cte_wp_at_ctes_of asidHighBits_handy_convs
+  apply (clarsimp simp: cte_wp_at_ctes_of asidHighBits_handy_convs
                         word_sle_def word_sless_def asidLowBits_handy_convs
                         rf_sr_ksCurThread "StrictC'_thread_state_defs"
                         mask_def[where n=4]
                   cong: if_cong)
-  apply (clarsimp simp: if_1_0_0 to_bool_def ccap_relation_isDeviceCap2
-     objBits_simps archObjSize_def pageBits_def from_bool_def case_bool_If)
+  apply (clarsimp simp: ccap_relation_isDeviceCap2 objBits_simps archObjSize_def pageBits_def)
   apply (rule conjI)
    (* Is Asid Control Cap *)
    apply (clarsimp simp: neq_Nil_conv excaps_in_mem_def excaps_map_def)
@@ -3926,11 +3918,10 @@ lemma Arch_decodeInvocation_ccorres:
                          ccap_rights_relation_def rightsFromWord_wordFromRights)
    apply (clarsimp simp: asid_high_bits_word_bits split: list.split_asm)
     apply (clarsimp simp: cap_untyped_cap_lift_def cap_lift_untyped_cap
-                         cap_to_H_def[split_simps cap_CL.split]
-                         hd_conv_nth length_ineq_not_Nil
-                  elim!: ccap_relationE)
-   apply (clarsimp simp: if_1_0_0 to_bool_def unat_eq_of_nat
-                         objBits_simps archObjSize_def pageBits_def from_bool_def case_bool_If
+                          cap_to_H_def[split_simps cap_CL.split]
+                          hd_conv_nth length_ineq_not_Nil
+                   elim!: ccap_relationE)
+   apply (clarsimp simp: to_bool_def unat_eq_of_nat objBits_simps archObjSize_def pageBits_def
                   split: if_splits)
   apply (clarsimp simp: asid_low_bits_word_bits isCap_simps neq_Nil_conv
                         excaps_map_def excaps_in_mem_def
@@ -3948,8 +3939,7 @@ lemma Arch_decodeInvocation_ccorres:
                   elim!: ccap_relationE split: if_split_asm)
    apply (clarsimp split: list.split)
   apply (clarsimp simp: cap_lift_asid_pool_cap cap_lift_page_directory_cap
-                        cap_to_H_def to_bool_def
-                        cap_page_directory_cap_lift_def
+                        cap_to_H_def cap_page_directory_cap_lift_def
                  elim!: ccap_relationE split: if_split_asm)
   done
 end

--- a/proof/crefine/ARM/Arch_C.thy
+++ b/proof/crefine/ARM/Arch_C.thy
@@ -3939,9 +3939,10 @@ lemma Arch_decodeInvocation_ccorres:
                   elim!: ccap_relationE split: if_split_asm)
    apply (clarsimp split: list.split)
   apply (clarsimp simp: cap_lift_asid_pool_cap cap_lift_page_directory_cap
-                        cap_to_H_def cap_page_directory_cap_lift_def
+                        cap_to_H_def cap_page_directory_cap_lift_def to_bool_def
                  elim!: ccap_relationE split: if_split_asm)
   done
+
 end
 
 end

--- a/proof/crefine/ARM/CLevityCatch.thy
+++ b/proof/crefine/ARM/CLevityCatch.thy
@@ -10,6 +10,7 @@ imports
   ArchMove_C
   "CParser.LemmaBucket_C"
   "Lib.LemmaBucket"
+  Boolean_C
 begin
 
 context begin interpretation Arch . (*FIXME: arch_split*)

--- a/proof/crefine/ARM/CSpace_All.thy
+++ b/proof/crefine/ARM/CSpace_All.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2023, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -248,8 +249,7 @@ lemma lookupSlotForCNodeOp_ccorres':
    apply vcg
 
   \<comment> \<open>last subgoal\<close>
-  apply (clarsimp simp: if_1_0_0  to_bool_def true_def word_size
-                        fromIntegral_def integral_inv)
+  apply (clarsimp simp: word_size fromIntegral_def integral_inv)
   apply (case_tac "cap_get_tag root = scast cap_cnode_cap")
    prefer 2 apply clarsimp
   apply (clarsimp simp: unat_of_nat32 word_sle_def)
@@ -285,7 +285,7 @@ lemma lookupSourceSlot_ccorres':
      apply simp
     apply simp
    apply (ctac add: lookupSlotForCNodeOp_ccorres')
-  apply (clarsimp simp: to_bool_def true_def false_def)
+  apply clarsimp
   done
 
 lemma lookupSourceSlot_ccorres:
@@ -315,7 +315,7 @@ lemma lookupTargetSlot_ccorres':
      apply simp
     apply simp
    apply (ctac add: lookupSlotForCNodeOp_ccorres')
-  apply (clarsimp simp: to_bool_def true_def false_def)
+  apply clarsimp
   done
 
 lemma lookupTargetSlot_ccorres:
@@ -345,7 +345,7 @@ lemma lookupPivotSlot_ccorres:
      apply simp
     apply simp
    apply (ctac add: lookupSlotForCNodeOp_ccorres)
-  apply (clarsimp simp: to_bool_def true_def false_def)
+  apply clarsimp
   done
 
 end

--- a/proof/crefine/ARM/CSpace_C.thy
+++ b/proof/crefine/ARM/CSpace_C.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2023, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -60,7 +61,7 @@ lemma maskVMRights_spec:
   apply clarsimp
   apply (rule conjI)
    apply ((auto simp: vmrights_to_H_def maskVMRights_def vmrights_defs
-                      cap_rights_to_H_def to_bool_def
+                      cap_rights_to_H_def
                split: bool.split
          | simp add: mask_def
          | word_bitwise)+)[1]
@@ -152,10 +153,6 @@ lemma Arch_maskCapRights_ccorres [corres]:
    apply (cases arch_cap)
        by (fastforce simp add: cap_get_tag_isCap isCap_simps  simp del: not_ex simp_thms(44))+
 
-lemma to_bool_mask_to_bool_bf:
-  "to_bool (x && 1) = to_bool_bf (x::word32)"
-  by (simp add: to_bool_bf_def to_bool_def)
-
 lemma to_bool_cap_rights_bf:
   "to_bool (capAllowRead_CL (seL4_CapRights_lift R)) =
    to_bool_bf (capAllowRead_CL (seL4_CapRights_lift R))"
@@ -216,7 +213,7 @@ lemma maskCapRights_ccorres [corres]:
   apply csymbr
   apply (simp add: maskCapRights_cap_cases cap_get_tag_isCap del: Collect_const)
   apply wpc
-              apply (simp add: Collect_const_mem from_bool_def)
+              apply (simp add: Collect_const_mem)
               apply csymbr
               apply (simp add: cap_get_tag_isCap isCap_simps del: Collect_const)
               apply (simp add: ccorres_cond_iffs)
@@ -226,7 +223,7 @@ lemma maskCapRights_ccorres [corres]:
                apply vcg
               apply clarsimp
               apply (simp add: cap_get_tag_isCap isCap_simps return_def)
-             apply (simp add: Collect_const_mem from_bool_def)
+             apply (simp add: Collect_const_mem)
              apply csymbr
              apply (simp add: cap_get_tag_isCap isCap_simps del: Collect_const)
              apply (simp add: ccorres_cond_iffs)
@@ -235,7 +232,7 @@ lemma maskCapRights_ccorres [corres]:
              apply (rule conseqPre)
               apply vcg
              apply (clarsimp simp: return_def)
-            apply (simp add: Collect_const_mem from_bool_def)
+            apply (simp add: Collect_const_mem)
             apply csymbr
             apply (simp add: cap_get_tag_isCap isCap_simps del: Collect_const)
             apply (simp add: ccorres_cond_iffs)
@@ -261,7 +258,7 @@ lemma maskCapRights_ccorres [corres]:
             apply (simp add: ccap_rights_relation_def cap_rights_to_H_def
                              to_bool_ntfn_cap_bf
                              to_bool_mask_to_bool_bf to_bool_cap_rights_bf)
-           apply (simp add: Collect_const_mem from_bool_def)
+           apply (simp add: Collect_const_mem)
            apply csymbr
            apply (simp add: cap_get_tag_isCap isCap_simps ccorres_cond_iffs)
            apply (rule ccorres_from_vcg_throws [where P=\<top> and P'=UNIV])
@@ -269,7 +266,7 @@ lemma maskCapRights_ccorres [corres]:
            apply (rule conseqPre)
             apply vcg
            apply (clarsimp simp: cap_get_tag_isCap isCap_simps return_def)
-          apply (simp add: Collect_const_mem from_bool_def)
+          apply (simp add: Collect_const_mem)
           apply csymbr
           apply (simp add: cap_get_tag_isCap isCap_simps ccorres_cond_iffs)
           apply (rule ccorres_from_vcg_throws [where P=\<top> and P'=UNIV])
@@ -297,7 +294,7 @@ lemma maskCapRights_ccorres [corres]:
           apply (simp add: ccap_rights_relation_def cap_rights_to_H_def
                            to_bool_ep_cap_bf
                            to_bool_mask_to_bool_bf to_bool_cap_rights_bf)
-         apply (simp add: Collect_const_mem from_bool_def)
+         apply (simp add: Collect_const_mem)
          apply csymbr
          apply (simp add: cap_get_tag_isCap isCap_simps del: Collect_const)
          apply (simp add: ccorres_cond_iffs)
@@ -306,7 +303,7 @@ lemma maskCapRights_ccorres [corres]:
          apply (rule conseqPre)
           apply vcg
          apply (clarsimp simp: return_def)
-        apply (simp add: Collect_const_mem from_bool_def)
+        apply (simp add: Collect_const_mem)
         apply csymbr
         apply (simp add: cap_get_tag_isCap isCap_simps ccorres_cond_iffs)
         apply (rule ccorres_from_vcg_throws [where P=\<top> and P'=UNIV])
@@ -314,7 +311,7 @@ lemma maskCapRights_ccorres [corres]:
         apply (rule conseqPre)
          apply vcg
         apply (clarsimp simp: cap_get_tag_isCap isCap_simps return_def)
-       apply (simp add: Collect_const_mem from_bool_def)
+       apply (simp add: Collect_const_mem)
        apply (subst bind_return [symmetric])
        apply (rule ccorres_split_throws)
         apply ctac
@@ -327,7 +324,7 @@ lemma maskCapRights_ccorres [corres]:
          apply wp
         apply vcg
        apply vcg
-      apply (simp add: Collect_const_mem from_bool_def)
+      apply (simp add: Collect_const_mem)
       apply csymbr
       apply (simp add: cap_get_tag_isCap isCap_simps del: Collect_const)
       apply ccorres_rewrite
@@ -347,7 +344,7 @@ lemma maskCapRights_ccorres [corres]:
       apply (simp add: ccap_rights_relation_def cap_rights_to_H_def
                        to_bool_reply_cap_bf
                        to_bool_mask_to_bool_bf[simplified] to_bool_cap_rights_bf)
-     apply (simp add: Collect_const_mem from_bool_def)
+     apply (simp add: Collect_const_mem)
      apply csymbr
      apply (simp add: cap_get_tag_isCap isCap_simps del: Collect_const)
      apply (simp add: ccorres_cond_iffs)
@@ -356,7 +353,7 @@ lemma maskCapRights_ccorres [corres]:
      apply (rule conseqPre)
       apply vcg
      apply (clarsimp simp: return_def)
-    apply (simp add: Collect_const_mem from_bool_def)
+    apply (simp add: Collect_const_mem)
     apply csymbr
     apply (simp add: cap_get_tag_isCap isCap_simps del: Collect_const)
     apply (simp add: ccorres_cond_iffs)
@@ -366,7 +363,7 @@ lemma maskCapRights_ccorres [corres]:
      apply vcg
     apply clarsimp
     apply (simp add: cap_get_tag_isCap isCap_simps return_def)
-   apply (simp add: Collect_const_mem from_bool_def)
+   apply (simp add: Collect_const_mem)
    apply csymbr
    apply (simp add: cap_get_tag_isCap isCap_simps del: Collect_const)
    apply (simp add: ccorres_cond_iffs)
@@ -521,9 +518,9 @@ lemma Arch_isCapRevocable_spec:
         {t. \<forall>c c'.  ccap_relation c (derivedCap_' s) \<and> ccap_relation c' (srcCap_' s)
             \<longrightarrow> ret__unsigned_long_' t = from_bool (Arch.isCapRevocable c c')}"
   apply vcg
-  by (auto simp: false_def from_bool_def)
+  by auto
 
-method revokable'_hammer = solves \<open>(simp add: cap_get_tag_isCap isCap_simps ccorres_cond_iffs from_bool_def true_def false_def,
+method revokable'_hammer = solves \<open>(simp add: cap_get_tag_isCap isCap_simps ccorres_cond_iffs,
                     rule ccorres_guard_imp, rule ccorres_return_C; clarsimp)\<close>
 
 lemma revokable_ccorres:
@@ -550,7 +547,7 @@ lemma revokable_ccorres:
     \<comment> \<open>Uninteresting caps\<close>
               apply revokable'_hammer+
     \<comment> \<open>NotificationCap\<close>
-            apply (simp add: cap_get_tag_isCap isCap_simps ccorres_cond_iffs from_bool_def true_def false_def)
+            apply (simp add: cap_get_tag_isCap isCap_simps ccorres_cond_iffs)
             apply (rule ccorres_guard_imp, (rule ccorres_rhs_assoc)+, csymbr, csymbr)
               apply (rule ccorres_return_C, clarsimp+)
             apply (frule_tac cap'1=srcCap in cap_get_tag_NotificationCap[THEN iffD1])
@@ -559,12 +556,12 @@ lemma revokable_ccorres:
              apply (clarsimp simp: cap_get_tag_isCap isCap_simps)
             apply (fastforce simp: cap_get_tag_isCap isCap_simps)
     \<comment> \<open>IRQHandlerCap\<close>
-           apply (simp add: cap_get_tag_isCap isCap_simps ccorres_cond_iffs from_bool_def true_def false_def)
+           apply (simp add: cap_get_tag_isCap isCap_simps ccorres_cond_iffs)
            apply (rule ccorres_guard_imp, csymbr)
              apply (rule ccorres_return_C, clarsimp+)
            apply (fastforce simp: cap_get_tag_isCap isCap_simps)
     \<comment> \<open>EndpointCap\<close>
-          apply (simp add: cap_get_tag_isCap isCap_simps ccorres_cond_iffs from_bool_def true_def false_def)
+          apply (simp add: cap_get_tag_isCap isCap_simps ccorres_cond_iffs)
           apply (rule ccorres_guard_imp, (rule ccorres_rhs_assoc)+, csymbr, csymbr)
             apply (rule ccorres_return_C, clarsimp+)
           apply (frule_tac cap'1=srcCap in cap_get_tag_EndpointCap[THEN iffD1])
@@ -721,50 +718,6 @@ definition
              else if (cap_get_tag newCap = scast cap_irq_handler_cap)
                   then (if cap_get_tag srcCap = scast cap_irq_control_cap then 1 else 0)
              else if (cap_get_tag newCap = scast cap_untyped_cap) then 1 else 0)"
-
-lemma cteInsert_if_helper:
-  assumes cgt: "rv = cap_get_tag newCap"
-  and     rul: "\<And>s g. (s \<in> Q) = (s\<lparr> ret__unsigned_' := undefined,
-  unsigned_eret_2_':= undefined \<rparr> \<in> Q')"
-  shows "\<Gamma> \<turnstile>\<^bsub>/UNIV\<^esub> {s. (cap_get_tag srcCap = cap_get_tag newCap
-                          \<or> is_simple_cap_tag (cap_get_tag newCap)) \<and>
-            (s\<lparr>newCapIsRevocable_' := cteInsert_newCapIsRevocable_if newCap srcCap\<rparr> \<in> Q)}
-          (IF rv = scast cap_endpoint_cap THEN
-               \<acute>ret__unsigned :== CALL cap_endpoint_cap_get_capEPBadge(newCap);;
-               \<acute>unsigned_eret_2 :== CALL cap_endpoint_cap_get_capEPBadge(srcCap);;
-               \<acute>newCapIsRevocable :== (if \<acute>ret__unsigned \<noteq> \<acute>unsigned_eret_2 then 1 else 0)
-             ELSE
-               IF rv = scast cap_notification_cap THEN
-                 \<acute>ret__unsigned :== CALL cap_notification_cap_get_capNtfnBadge(newCap);;
-                 \<acute>unsigned_eret_2 :== CALL cap_notification_cap_get_capNtfnBadge(srcCap);;
-                 \<acute>newCapIsRevocable :== (if \<acute>ret__unsigned \<noteq> \<acute>unsigned_eret_2 then 1 else 0)
-               ELSE
-                 IF rv = scast cap_irq_handler_cap THEN
-                   \<acute>ret__unsigned :== CALL cap_get_capType(srcCap);;
-                   \<acute>newCapIsRevocable :== (if \<acute>ret__unsigned = scast cap_irq_control_cap then 1 else 0)
-                 ELSE
-                   IF rv = scast cap_untyped_cap THEN
-                     \<acute>newCapIsRevocable :== scast true
-                   ELSE
-                     \<acute>newCapIsRevocable :== scast false
-                   FI
-                 FI
-               FI
-             FI) Q"
-  unfolding cteInsert_newCapIsRevocable_if_def
-  apply (unfold cgt)
-  apply (rule conseqPre)
-  apply vcg
-  apply (clarsimp simp: true_def false_def
-                        is_simple_cap_tag_def
-                  cong: if_cong)
-  apply (simp add: cap_tag_defs)
-  apply (intro allI conjI impI)
-                      apply (clarsimp simp: rul)+
-  done
-
-lemma forget_Q':
-  "(x \<in> Q) = (y \<in> Q) \<Longrightarrow> (x \<in> Q) = (y \<in> Q)" .
 
 (* Useful:
   apply (tactic {* let val _ = reset CtacImpl.trace_ceqv; val _ = reset CtacImpl.trace_ctac in all_tac end; *})
@@ -1263,9 +1216,7 @@ lemma cteMove_ccorres:
    apply (erule (2) is_aligned_3_next)
   apply (clarsimp simp: dc_def split del: if_split)
   apply (simp add: ccap_relation_NullCap_iff)
-  apply (clarsimp simp add: cmdbnode_relation_def
-    mdb_node_to_H_def nullMDBNode_def
-    false_def to_bool_def)
+  apply (clarsimp simp: cmdbnode_relation_def mdb_node_to_H_def nullMDBNode_def)
   done
 
 (************************************************************************)
@@ -1613,8 +1564,8 @@ lemma emptySlot_helper:
                          mdbFirstBadged_CL (cteMDBNode_CL y)")
       prefer 2
       apply (drule cteMDBNode_CL_lift [symmetric])
-      subgoal by (simp add: mdb_node_lift_def mask_def word_bw_assocs)
-     subgoal by (simp add: to_bool_def mask_def)
+      subgoal by (simp add: mdb_node_lift_def word_bw_assocs)
+     subgoal by (simp add: to_bool_def)
    \<comment> \<open>\<dots> \<exists>x\<in>fst \<dots>\<close>
    apply clarsimp
    apply (rule fst_setCTE [OF ctes_of_cte_at], assumption )
@@ -1644,7 +1595,7 @@ lemma emptySlot_helper:
     prefer 2
     apply (drule cteMDBNode_CL_lift [symmetric])
     subgoal by (simp add: mdb_node_lift_def mask_def word_bw_assocs)
-   apply (simp add: to_bool_def mask_def split: if_split)
+   apply (simp add: to_bool_def split: if_split)
 
   \<comment> \<open>trivial case where mdbNext rva = 0\<close>
    apply (simp add:ccorres_cond_empty_iff)
@@ -1743,7 +1694,6 @@ lemma setIRQState_ccorres:
    apply (simp add: empty_fail_def getInterruptState_def simpler_gets_def)
 
   apply clarsimp
-  apply (simp add: from_bool_def)
   apply (cases irqState, simp_all)
   apply (simp add: Kernel_C.IRQSignal_def Kernel_C.IRQInactive_def)
   apply (simp add: Kernel_C.IRQTimer_def Kernel_C.IRQInactive_def)
@@ -2123,7 +2073,7 @@ lemma emptySlot_ccorres:
             \<comment> \<open>Haskell pre/post for y \<leftarrow> updateCap slot capability.NullCap;\<close>
              apply wp
             \<comment> \<open>C       pre/post for y \<leftarrow> updateCap slot capability.NullCap;\<close>
-            apply (simp add: Collect_const_mem cmdbnode_relation_def mdb_node_to_H_def nullMDBNode_def false_def)
+            apply (simp add: Collect_const_mem cmdbnode_relation_def mdb_node_to_H_def nullMDBNode_def)
         \<comment> \<open>Haskell pre/post for the two nested updates\<close>
          apply wp
         \<comment> \<open>C       pre/post for the two nested updates\<close>
@@ -2289,8 +2239,8 @@ lemma Arch_sameRegionAs_spec:
   apply (cases capa; simp add: cap_get_tag_isCap_unfolded_H_cap isCap_simps)
 
   \<comment> \<open>capa is ASIDPoolCap\<close>
-      apply (cases capb; simp add: cap_get_tag_isCap_unfolded_H_cap
-                         isCap_simps cap_tag_defs from_bool_def false_def)
+      apply (cases capb;
+             simp add: cap_get_tag_isCap_unfolded_H_cap isCap_simps cap_tag_defs)
       \<comment> \<open>capb is also ASIDPoolCap\<close>
        apply (frule cap_get_tag_isCap_unfolded_H_cap(13)[where cap'=cap_a])
        apply (frule cap_get_tag_isCap_unfolded_H_cap(13)[where cap'=cap_b])
@@ -2312,8 +2262,8 @@ lemma Arch_sameRegionAs_spec:
       done
 
   \<comment> \<open>capa is ASIDControlCap\<close>
-     apply (cases capb; simp add: cap_get_tag_isCap_unfolded_H_cap
-                        isCap_simps cap_tag_defs from_bool_def false_def true_def)
+     apply (cases capb;
+            simp add: cap_get_tag_isCap_unfolded_H_cap isCap_simps cap_tag_defs)
      \<comment> \<open>capb is PageCap\<close>
      subgoal for \<dots> vmpage_size option
      apply (case_tac "vmpage_size=ARMSmallPage")
@@ -2328,8 +2278,8 @@ lemma Arch_sameRegionAs_spec:
     apply (cases "vmpage_size=ARMSmallPage")
     \<comment> \<open>capa is a small frame\<close>
      apply (frule cap_get_tag_isCap_unfolded_H_cap(16)[where cap' = cap_a], assumption)
-     apply (cases capb; simp add: cap_get_tag_isCap_unfolded_H_cap
-                        isCap_simps cap_tag_defs from_bool_def false_def true_def)
+     apply (cases capb;
+            simp add: cap_get_tag_isCap_unfolded_H_cap isCap_simps cap_tag_defs from_bool_def)
    \<comment> \<open>capb is PageCap\<close>
 
      subgoal for \<dots> vmpage_sizea optiona
@@ -2404,8 +2354,8 @@ lemma Arch_sameRegionAs_spec:
        apply (simp add: cap_frame_cap_lift)
        apply (simp add: c_valid_cap_def cl_valid_cap_def)
 
-    apply (cases capb; simp add: cap_get_tag_isCap_unfolded_H_cap
-                       isCap_simps cap_tag_defs from_bool_def false_def true_def)
+    apply (cases capb;
+           simp add: cap_get_tag_isCap_unfolded_H_cap isCap_simps cap_tag_defs from_bool_def)
     \<comment> \<open>capb is PageCap\<close>
     subgoal for \<dots> vmpage_sizea optiona
 
@@ -2482,8 +2432,8 @@ lemma Arch_sameRegionAs_spec:
    done
 
   \<comment> \<open>capa is PageTableCap\<close>
-   apply (cases capb; simp_all add: cap_get_tag_isCap_unfolded_H_cap
-                      isCap_simps cap_tag_defs from_bool_def false_def true_def)
+   apply (cases capb;
+          simp_all add: cap_get_tag_isCap_unfolded_H_cap isCap_simps cap_tag_defs)
     \<comment> \<open>capb is PageCap\<close>
     subgoal for \<dots> vmpage_size option
     apply (cases "vmpage_size=ARMSmallPage")
@@ -2503,8 +2453,8 @@ lemma Arch_sameRegionAs_spec:
                     capPTBasePtr_CL (cap_page_table_cap_lift cap_b)"; simp)
 
   \<comment> \<open>capa is PageDirectoryCap\<close>
-  apply (cases capb; simp add: cap_get_tag_isCap_unfolded_H_cap
-                      isCap_simps cap_tag_defs from_bool_def false_def true_def)
+  apply (cases capb;
+         simp add: cap_get_tag_isCap_unfolded_H_cap isCap_simps cap_tag_defs)
    \<comment> \<open>capb is PageCap\<close>
    subgoal for \<dots> vmpage_size option
    apply (cases "vmpage_size=ARMSmallPage")
@@ -2848,8 +2798,7 @@ lemma cap_get_capIsPhysical_spec:
                                           cap_lift_asid_control_cap word_sle_def
                                           cap_lift_irq_control_cap cap_lift_null_cap
                                           mask_def objBits_simps cap_lift_domain_cap
-                                          ptr_add_assertion_positive from_bool_def
-                                          true_def false_def
+                                          ptr_add_assertion_positive
                                    dest!: sym [where t = "cap_get_tag cap" for cap]
                                    split: vmpage_size.splits)+
   (* XXX: slow. there should be a rule for this *)
@@ -2943,22 +2892,23 @@ lemma sameRegionAs_spec:
   apply (simp add: sameRegionAs_def isArchCap_tag_def2)
   apply (case_tac capa, simp_all add: cap_get_tag_isCap_unfolded_H_cap isCap_simps)
             \<comment> \<open>capa is a ThreadCap\<close>
-             apply (case_tac capb, simp_all add: cap_get_tag_isCap_unfolded_H_cap
-                          isCap_simps cap_tag_defs from_bool_def false_def)[1]
+             apply (case_tac capb,
+                    simp_all add: cap_get_tag_isCap_unfolded_H_cap isCap_simps cap_tag_defs)[1]
               apply (frule_tac cap'=cap_a in cap_get_tag_isCap_unfolded_H_cap(1))
               apply (frule_tac cap'=cap_b in cap_get_tag_isCap_unfolded_H_cap(1))
               apply (simp add: ccap_relation_def map_option_case)
               apply (simp add: cap_thread_cap_lift)
               apply (simp add: cap_to_H_def)
+              apply (clarsimp simp: from_bool_0 split: if_split)
               apply (clarsimp simp: case_bool_If ctcb_ptr_to_tcb_ptr_def if_distrib
                               cong: if_cong)
              apply (frule_tac cap'=cap_b in cap_get_tag_isArchCap_unfolded_H_cap)
              apply (clarsimp simp: isArchCap_tag_def2)
            \<comment> \<open>capa is a NullCap\<close>
-            apply (simp add: cap_tag_defs from_bool_def false_def)
+            apply (simp add: cap_tag_defs)
           \<comment> \<open>capa is an NotificationCap\<close>
-           apply (case_tac capb, simp_all add: cap_get_tag_isCap_unfolded_H_cap
-                        isCap_simps cap_tag_defs from_bool_def false_def)[1]
+           apply (case_tac capb,
+                  simp_all add: cap_get_tag_isCap_unfolded_H_cap isCap_simps cap_tag_defs)[1]
             apply (frule_tac cap'=cap_a in cap_get_tag_isCap_unfolded_H_cap(3))
             apply (frule_tac cap'=cap_b in cap_get_tag_isCap_unfolded_H_cap(3))
             apply (simp add: ccap_relation_def map_option_case)
@@ -2968,15 +2918,15 @@ lemma sameRegionAs_spec:
            apply (frule_tac cap'=cap_b in cap_get_tag_isArchCap_unfolded_H_cap)
            apply (clarsimp simp: isArchCap_tag_def2)
           \<comment> \<open>capa is an IRQHandlerCap\<close>
-          apply (case_tac capb, simp_all add: cap_get_tag_isCap_unfolded_H_cap
-                      isCap_simps cap_tag_defs from_bool_def false_def)[1]
+          apply (case_tac capb,
+                 simp_all add: cap_get_tag_isCap_unfolded_H_cap isCap_simps cap_tag_defs)[1]
            apply (frule_tac cap'=cap_a in cap_get_tag_isCap_unfolded_H_cap(5))
            apply (frule_tac cap'=cap_b in cap_get_tag_isCap_unfolded_H_cap(5))
            apply (simp add: ccap_relation_def map_option_case)
            apply (simp add: cap_irq_handler_cap_lift)
            apply (simp add: cap_to_H_def)
            apply (clarsimp simp: up_ucast_inj_eq c_valid_cap_def
-                                 cl_valid_cap_def mask_twice
+                                 cl_valid_cap_def mask_twice from_bool_0
                           split: if_split bool.split
                           | intro impI conjI
                           | simp )+
@@ -2986,34 +2936,34 @@ lemma sameRegionAs_spec:
           apply (clarsimp simp: isArchCap_tag_def2)
          \<comment> \<open>capa is an EndpointCap\<close>
          apply (case_tac capb, simp_all add: cap_get_tag_isCap_unfolded_H_cap
-                      isCap_simps cap_tag_defs from_bool_def false_def)[1]
+                                             isCap_simps cap_tag_defs)[1]
           apply (frule_tac cap'=cap_a in cap_get_tag_isCap_unfolded_H_cap(4))
           apply (frule_tac cap'=cap_b in cap_get_tag_isCap_unfolded_H_cap(4))
           apply (simp add: ccap_relation_def map_option_case)
           apply (simp add: cap_endpoint_cap_lift)
           apply (simp add: cap_to_H_def)
-          apply (clarsimp split: if_split)
+          apply (clarsimp simp: from_bool_0 split: if_split)
          apply (frule_tac cap'=cap_b in cap_get_tag_isArchCap_unfolded_H_cap)
          apply (clarsimp simp: isArchCap_tag_def2)
         \<comment> \<open>capa is a DomainCap\<close>
         apply (case_tac capb, simp_all add: cap_get_tag_isCap_unfolded_H_cap
-                     isCap_simps cap_tag_defs from_bool_def false_def true_def)[1]
+                                            isCap_simps cap_tag_defs)[1]
         apply (frule_tac cap'=cap_b in cap_get_tag_isArchCap_unfolded_H_cap)
         apply (fastforce simp: isArchCap_tag_def2 split: if_split)
        \<comment> \<open>capa is a Zombie\<close>
-       apply (simp add: cap_tag_defs from_bool_def false_def)
+       apply (simp add: cap_tag_defs)
       \<comment> \<open>capa is an Arch object cap\<close>
       apply (frule_tac cap'=cap_a in cap_get_tag_isArchCap_unfolded_H_cap)
       apply (clarsimp simp: isArchCap_tag_def2 cap_tag_defs linorder_not_less [THEN sym])
       apply (rule conjI, clarsimp, rule impI)+
       apply (case_tac capb, simp_all add: cap_get_tag_isCap_unfolded_H_cap
-                   isCap_simps cap_tag_defs from_bool_def false_def)[1]
+                                          isCap_simps cap_tag_defs)[1]
       \<comment> \<open>capb is an Arch object cap\<close>
       apply (frule_tac cap'=cap_b in cap_get_tag_isArchCap_unfolded_H_cap)
       apply (fastforce simp: isArchCap_tag_def2 cap_tag_defs linorder_not_less [THEN sym])
      \<comment> \<open>capa is a ReplyCap\<close>
      apply (case_tac capb, simp_all add: cap_get_tag_isCap_unfolded_H_cap
-                  isCap_simps cap_tag_defs from_bool_def false_def)[1]
+                                         isCap_simps cap_tag_defs)[1]
       apply (frule_tac cap'=cap_b in cap_get_tag_isArchCap_unfolded_H_cap)
       apply (clarsimp simp: isArchCap_tag_def2)
      apply (frule_tac cap'=cap_a in cap_get_tag_isCap_unfolded_H_cap(8))
@@ -3021,7 +2971,7 @@ lemma sameRegionAs_spec:
      apply (simp add: ccap_relation_def map_option_case)
      apply (simp add: cap_reply_cap_lift)
      apply (simp add: cap_to_H_def ctcb_ptr_to_tcb_ptr_def)
-     apply (clarsimp split: if_split)
+     apply (clarsimp simp: from_bool_0 split: if_split)
     \<comment> \<open>capa is an UntypedCap\<close>
     apply (frule_tac cap'=cap_a in cap_get_tag_isCap_unfolded_H_cap(9))
     apply (intro conjI)
@@ -3029,8 +2979,7 @@ lemma sameRegionAs_spec:
         apply (rule impI, drule(1) cap_get_tag_to_H)+
         apply (clarsimp simp: capAligned_def word_bits_conv
                               objBits_simps' get_capZombieBits_CL_def
-                              Let_def word_less_nat_alt
-                              less_mask_eq true_def
+                              Let_def word_less_nat_alt less_mask_eq
                        split: if_split_asm)
        apply (subgoal_tac "capBlockSize_CL (cap_untyped_cap_lift cap_a) \<le> 0x1F")
         apply (simp add: word_le_make_less)
@@ -3049,10 +2998,9 @@ lemma sameRegionAs_spec:
                                cap_untyped_cap_lift cap_to_H_def
                                field_simps valid_cap'_def)+)[4]
     apply (rule impI, simp add: from_bool_0 ccap_relation_get_capIsPhysical[symmetric])
-    apply (simp add: from_bool_def false_def)
    \<comment> \<open>capa is a CNodeCap\<close>
    apply (case_tac capb, simp_all add: cap_get_tag_isCap_unfolded_H_cap
-                isCap_simps cap_tag_defs from_bool_def false_def)[1]
+                                       isCap_simps cap_tag_defs)[1]
     apply (frule_tac cap'=cap_b in cap_get_tag_isArchCap_unfolded_H_cap)
     apply (clarsimp simp: isArchCap_tag_def2)
    apply (frule_tac cap'=cap_a in cap_get_tag_isCap_unfolded_H_cap(10))
@@ -3060,10 +3008,9 @@ lemma sameRegionAs_spec:
    apply (simp add: ccap_relation_def map_option_case)
    apply (simp add: cap_cnode_cap_lift)
    apply (simp add: cap_to_H_def)
-   apply (clarsimp split: if_split bool.split)
+   apply (clarsimp simp: from_bool_0 split: if_split bool.split)
   \<comment> \<open>capa is an IRQControlCap\<close>
-  apply (case_tac capb, simp_all add: cap_get_tag_isCap_unfolded_H_cap
-               isCap_simps cap_tag_defs from_bool_def false_def true_def)[1]
+  apply (case_tac capb, simp_all add: cap_get_tag_isCap_unfolded_H_cap isCap_simps cap_tag_defs)[1]
   apply (frule_tac cap'=cap_b in cap_get_tag_isArchCap_unfolded_H_cap)
   apply (fastforce simp: isArchCap_tag_def2 split: if_split)
   done
@@ -3104,23 +3051,21 @@ lemma Arch_sameObjectAs_spec:
              simp_all add: cap_get_tag_isCap_unfolded_H_cap cap_tag_defs)[1]
        apply (rename_tac vmpage_sizea optiona)
        apply (case_tac "vmpage_sizea = ARMSmallPage",
-              simp_all add: cap_get_tag_isCap_unfolded_H_cap cap_tag_defs
-                            false_def from_bool_def)[1]
+              simp_all add: cap_get_tag_isCap_unfolded_H_cap cap_tag_defs)[1]
        apply (frule_tac cap'=cap_a in cap_get_tag_isCap_unfolded_H_cap(16), simp)
        apply (frule_tac cap'=cap_b in cap_get_tag_isCap_unfolded_H_cap(16), simp)
        apply (simp add: ccap_relation_def map_option_case)
        apply (simp add: cap_small_frame_cap_lift)
-       apply (clarsimp simp: cap_to_H_def capAligned_def to_bool_def from_bool_def
+       apply (clarsimp simp: cap_to_H_def capAligned_def to_bool_def
                       split: if_split bool.split
                       dest!: is_aligned_no_overflow)
       apply (case_tac "vmpage_sizea = ARMSmallPage",
-             simp_all add: cap_get_tag_isCap_unfolded_H_cap cap_tag_defs
-                           false_def from_bool_def)[1]
+             simp_all add: cap_get_tag_isCap_unfolded_H_cap cap_tag_defs)[1]
       apply (frule_tac cap'=cap_a in cap_get_tag_isCap_unfolded_H_cap(17), simp)
       apply (frule_tac cap'=cap_b in cap_get_tag_isCap_unfolded_H_cap(17), simp)
       apply (simp add: ccap_relation_def map_option_case)
       apply (simp add: cap_frame_cap_lift)
-      apply (clarsimp simp: cap_to_H_def capAligned_def from_bool_def
+      apply (clarsimp simp: cap_to_H_def capAligned_def
                             c_valid_cap_def cl_valid_cap_def
                             Kernel_C.ARMSmallPage_def
                      split: if_split bool.split vmpage_size.split_asm
@@ -3139,8 +3084,7 @@ lemma sameObjectAs_spec:
   apply vcg
   apply (clarsimp simp: sameObjectAs_def isArchCap_tag_def2)
   apply (case_tac capa, simp_all add: cap_get_tag_isCap_unfolded_H_cap
-                                      isCap_simps cap_tag_defs
-                                      from_bool_def false_def)
+                                      isCap_simps cap_tag_defs)
             apply fastforce+
      \<comment> \<open>capa is an arch cap\<close>
      apply (frule cap_get_tag_isArchCap_unfolded_H_cap)
@@ -3222,7 +3166,7 @@ lemma isMDBParentOf_spec:
      apply (simp add: ccte_relation_def map_option_case)
      apply (simp add: cte_lift_def)
      apply (clarsimp simp: cte_to_H_def mdb_node_to_H_def split: option.split_asm)
-     apply (clarsimp simp: Let_def false_def from_bool_def to_bool_def
+     apply (clarsimp simp: Let_def to_bool_def
                     split: if_split bool.splits)
      apply ((clarsimp simp: typ_heap_simps dest!: lift_t_g)+)[3]
   apply (rule_tac x="cteCap ctea" in exI, rule conjI)
@@ -3241,11 +3185,11 @@ lemma isMDBParentOf_spec:
   apply (rule impI, rule conjI)
    \<comment> \<open>sameRegionAs = 0\<close>
    apply (rule impI)
-   apply (clarsimp simp: from_bool_def false_def
+   apply (clarsimp simp: from_bool_def
                   split: if_split bool.splits)
 
   \<comment> \<open>sameRegionAs \<noteq> 0\<close>
-  apply (clarsimp simp: from_bool_def false_def)
+  apply (clarsimp simp: from_bool_def)
   apply (case_tac "RetypeDecls_H.sameRegionAs (cap_to_H x2b) (cap_to_H x2c)")
    prefer 2 apply clarsimp
   apply (clarsimp cong:bool.case_cong if_cong simp: typ_heap_simps)
@@ -3255,8 +3199,7 @@ lemma isMDBParentOf_spec:
    apply clarsimp
    apply (frule cap_get_tag_EndpointCap)
    apply simp
-   apply (clarsimp simp: to_bool_def isNotificationCap_def isEndpointCap_def true_def) \<comment> \<open>badge of A is not 0 now\<close>
-
+   apply (clarsimp simp: to_bool_def isNotificationCap_def isEndpointCap_def) \<comment> \<open>badge of A is not 0 now\<close>
 
    apply (subgoal_tac "cap_get_tag (cte_C.cap_C cte_b) = scast cap_endpoint_cap") \<comment> \<open>needed also after\<close>
     prefer 2
@@ -3271,8 +3214,7 @@ lemma isMDBParentOf_spec:
    apply clarsimp
    apply (frule cap_get_tag_NotificationCap)
    apply simp
-   apply (clarsimp simp: to_bool_def isNotificationCap_def isEndpointCap_def true_def) \<comment> \<open>badge of A is not 0 now\<close>
-
+   apply (clarsimp simp: to_bool_def isNotificationCap_def isEndpointCap_def) \<comment> \<open>badge of A is not 0 now\<close>
 
    apply (subgoal_tac "cap_get_tag (cte_C.cap_C cte_b) = scast cap_notification_cap") \<comment> \<open>needed also after\<close>
     prefer 2
@@ -3288,11 +3230,9 @@ lemma isMDBParentOf_spec:
   apply clarsimp
   apply (simp add: to_bool_def)
   apply (subgoal_tac "(\<not> (isEndpointCap (cap_to_H x2b))) \<and> ( \<not> (isNotificationCap (cap_to_H x2b)))")
-   apply (clarsimp simp: true_def)
-  apply (rule conjI)
-   apply (clarsimp simp: cap_get_tag_isCap [symmetric])+
-done
-
+   apply clarsimp
+  apply (clarsimp simp: cap_get_tag_isCap[symmetric])
+  done
 
 lemma updateCapData_spec:
   "\<forall>cap. \<Gamma> \<turnstile> \<lbrace> ccap_relation cap \<acute>cap \<and> preserve = to_bool (\<acute>preserve) \<and> newData = \<acute>newData\<rbrace>
@@ -3306,7 +3246,7 @@ lemma updateCapData_spec:
   apply (simp add: updateCapData_def)
 
   apply (case_tac cap, simp_all add: cap_get_tag_isCap_unfolded_H_cap
-                        isCap_simps from_bool_def isArchCap_tag_def2 cap_tag_defs Let_def)
+                                     isCap_simps isArchCap_tag_def2 cap_tag_defs Let_def)
   \<comment> \<open>NotificationCap\<close>
      apply clarsimp
      apply (frule cap_get_tag_isCap_unfolded_H_cap(3))
@@ -3435,7 +3375,6 @@ lemma ensureNoChildren_ccorres:
    apply (rule conjI)
    \<comment> \<open>isMDBParentOf is not zero\<close>
     apply clarsimp
-    apply (simp add: from_bool_def)
     apply (case_tac "isMDBParentOf (cte_to_H y) (cte_to_H ya)", simp_all)[1]
 
     apply (simp add: bind_def)
@@ -3446,7 +3385,6 @@ lemma ensureNoChildren_ccorres:
     apply (simp add: syscall_error_to_H_cases(9))
    \<comment> \<open>isMDBParentOf is zero\<close>
    apply clarsimp
-   apply (simp add: from_bool_def)
    apply (case_tac "isMDBParentOf (cte_to_H y) (cte_to_H ya)", simp_all)[1]
    apply (simp add: bind_def)
    apply (simp add: split_paired_Bex)
@@ -3561,9 +3499,8 @@ lemma Arch_deriveCap_ccorres:
      apply (rule context_conjI)
       apply (simp add: cap_get_tag_isCap_ArchObject)
      apply (clarsimp simp: returnOk_def return_def isCap_simps)
-     subgoal by  (simp add: ccap_relation_def cap_lift_def Let_def
-                            cap_tag_defs cap_to_H_def to_bool_def
-                            cap_small_frame_cap_lift_def asidInvalid_def)
+     subgoal by (simp add: ccap_relation_def cap_lift_def Let_def cap_tag_defs cap_to_H_def
+                           cap_small_frame_cap_lift_def asidInvalid_def)
     apply (clarsimp simp: ccorres_cond_iffs)
     apply (rule ccorres_from_vcg_throws[where P=\<top> and P'=UNIV])
     apply (rule allI, rule conseqPre, vcg)
@@ -3571,8 +3508,7 @@ lemma Arch_deriveCap_ccorres:
     apply (rule context_conjI)
      apply (simp add: cap_get_tag_isCap_ArchObject)
     apply (clarsimp simp: returnOk_def return_def isCap_simps)
-    subgoal by (simp add: ccap_relation_def cap_lift_def Let_def
-                          cap_tag_defs cap_to_H_def to_bool_def
+    subgoal by (simp add: ccap_relation_def cap_lift_def Let_def cap_tag_defs cap_to_H_def
                           cap_frame_cap_lift_def asidInvalid_def c_valid_cap_def cl_valid_cap_def)
    apply (simp add: cap_get_tag_isCap_ArchObject
                     ccorres_cond_iffs)
@@ -3596,7 +3532,7 @@ lemma deriveCap_ccorres':
    apply csymbr
    apply (fold case_bool_If)
    apply wpc
-    apply (clarsimp simp: cap_get_tag_isCap isCap_simps from_bool_def)
+    apply (clarsimp simp: cap_get_tag_isCap isCap_simps)
     apply csymbr
     apply (clarsimp simp: cap_get_tag_isCap)
     apply (rule ccorres_from_vcg_throws [where P=\<top> and P' = UNIV])
@@ -3605,7 +3541,7 @@ lemma deriveCap_ccorres':
      apply vcg
     apply clarsimp
    apply wpc
-    apply (clarsimp simp: isCap_simps cap_get_tag_isCap from_bool_def)
+    apply (clarsimp simp: isCap_simps cap_get_tag_isCap)
     apply csymbr
     apply (clarsimp simp: isCap_simps cap_get_tag_isCap)
     apply (rule ccorres_from_vcg_throws[where P=\<top> and P'=UNIV])
@@ -3613,7 +3549,7 @@ lemma deriveCap_ccorres':
     apply (clarsimp simp: returnOk_def return_def
                           ccap_relation_NullCap_iff)
    apply wpc
-    apply (clarsimp simp: isCap_simps cap_get_tag_isCap from_bool_def)
+    apply (clarsimp simp: isCap_simps cap_get_tag_isCap)
     apply csymbr
     apply (clarsimp simp: isCap_simps cap_get_tag_isCap)
     apply (rule ccorres_rhs_assoc)+
@@ -3638,7 +3574,7 @@ lemma deriveCap_ccorres':
                            errstate_def)
     apply wp
    apply wpc
-    apply (clarsimp simp: isCap_simps cap_get_tag_isCap from_bool_def)
+    apply (clarsimp simp: isCap_simps cap_get_tag_isCap)
     apply csymbr
     apply (clarsimp simp: isCap_simps cap_get_tag_isCap)
     apply (rule ccorres_from_vcg_throws[where P=\<top> and P'=UNIV])
@@ -3670,7 +3606,7 @@ lemma deriveCap_ccorres':
      apply (rule allI, rule conseqPre, vcg)
      apply (clarsimp simp: return_def throwError_def)
     apply wp
-   apply (simp add: cap_get_tag_isCap isArchCap_T_isArchObjectCap from_bool_def)
+   apply (simp add: cap_get_tag_isCap isArchCap_T_isArchObjectCap)
    apply csymbr
    apply (simp add: cap_get_tag_isCap)
    apply (rule ccorres_from_vcg_throws[where P=\<top> and P'=UNIV])
@@ -3680,7 +3616,6 @@ lemma deriveCap_ccorres':
                         Collect_const_mem from_bool_0
                         cap_get_tag_isArchCap_unfolded_H_cap)
   done
-
 
 lemma deriveCap_ccorres:
   "ccorres (syscall_error_rel \<currency> ccap_relation) deriveCap_xf

--- a/proof/crefine/ARM/CSpace_RAB_C.thy
+++ b/proof/crefine/ARM/CSpace_RAB_C.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2023, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -182,7 +183,7 @@ next
        apply (vcg strip_guards=true) \<comment> \<open>takes a while\<close>
        apply clarsimp
       apply simp
-     apply (clarsimp simp: cap_get_tag_isCap to_bool_def)
+     apply (clarsimp simp: cap_get_tag_isCap)
   \<comment> \<open>Main thm\<close>
   proof (induct cap' cptr' guard' rule: resolveAddressBits.induct [case_names ind])
     case (ind cap cptr guard)
@@ -523,8 +524,8 @@ lemma rightsFromWord_spec:
   \<lbrace>seL4_CapRights_lift \<acute>ret__struct_seL4_CapRights_C = cap_rights_from_word_canon \<^bsup>s\<^esup>w \<rbrace>"
   apply vcg
   apply (simp add: seL4_CapRights_lift_def nth_shiftr mask_shift_simps nth_shiftr
-    cap_rights_from_word_canon_def from_bool_def word_and_1 eval_nat_numeral
-    word_sless_def word_sle_def)
+                   cap_rights_from_word_canon_def word_and_1 eval_nat_numeral
+                   word_sless_def word_sle_def)
   done
 
 

--- a/proof/crefine/ARM/Delete_C.thy
+++ b/proof/crefine/ARM/Delete_C.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2023, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -141,7 +142,7 @@ lemma capRemovable_spec:
   supply if_cong[cong]
   apply vcg
   apply (clarsimp simp: cap_get_tag_isCap(1-8)[THEN trans[OF eq_commute]])
-  apply (simp add: capRemovable_def from_bool_def[where b=True] true_def)
+  apply (simp add: capRemovable_def)
   apply (clarsimp simp: ccap_zombie_radix_less4)
   apply (subst eq_commute, subst from_bool_eq_if)
   apply (rule exI, rule conjI, assumption)
@@ -601,7 +602,7 @@ lemma reduceZombie_ccorres1:
       apply (rule ccorres_inst[where P=\<top> and P'=UNIV])
       apply simp
      apply (simp add: guard_is_UNIV_def Collect_const_mem)
-     apply (clarsimp simp: from_bool_def false_def isCap_simps size_of_def cte_level_bits_def)
+     apply (clarsimp simp: isCap_simps size_of_def cte_level_bits_def)
      apply (simp only: word_bits_def unat_of_nat unat_arith_simps, simp)
     apply (simp add: guard_is_UNIV_def)+
   apply (clarsimp simp: cte_wp_at_ctes_of)
@@ -676,8 +677,7 @@ lemma finaliseSlot_ccorres:
         apply (rule ccorres_drop_cutMon)
         apply (rule ccorres_from_vcg_throws[where P=\<top> and P'=UNIV])
         apply (rule allI, rule conseqPre, vcg)
-        apply (clarsimp simp: returnOk_def return_def
-                              from_bool_def true_def ccap_relation_NullCap_iff)
+        apply (clarsimp simp: returnOk_def return_def ccap_relation_NullCap_iff)
        apply (simp add: Collect_True liftE_bindE split_def
                         ccorres_cond_iffs cutMon_walk_bind
                    del: Collect_const cong: call_ignore_cong)
@@ -716,8 +716,7 @@ lemma finaliseSlot_ccorres:
                                       | _ \<Rightarrow> True"
                               in ccorres_from_vcg_throws[where P'=UNIV])
               apply (rule allI, rule conseqPre, vcg)
-              apply (clarsimp simp: returnOk_def return_def
-                                    from_bool_def true_def)
+              apply (clarsimp simp: returnOk_def return_def)
               apply (clarsimp simp: cleanup_info_wf'_def arch_cleanup_info_wf'_def
                              split: if_split capability.splits)
              apply vcg
@@ -754,11 +753,11 @@ lemma finaliseSlot_ccorres:
                   apply (rule allI, rule conseqPre, vcg)
                   apply (clarsimp simp: returnOk_def return_def)
                   apply (drule use_valid [OF _ finaliseCap_cases, OF _ TrueI])
-                  apply (simp add: from_bool_def false_def irq_opt_relation_def true_def
+                  apply (simp add: irq_opt_relation_def
                             split: if_split_asm)
                  apply vcg
                 apply wp
-               apply (simp add: guard_is_UNIV_def true_def)
+               apply (simp add: guard_is_UNIV_def)
               apply wp
              apply (simp add: guard_is_UNIV_def)
             apply (simp only: liftE_bindE cutMon_walk_bind Let_def
@@ -783,7 +782,6 @@ lemma finaliseSlot_ccorres:
                                in ccorres_from_vcg[where P'=UNIV])
                   apply (rule allI, rule conseqPre, vcg)
                   apply (clarsimp simp: return_def)
-                  apply (simp add: from_bool_def false_def)
                   apply fastforce
                  apply ceqv
                 apply (simp only: from_bool_0 simp_thms Collect_False
@@ -853,7 +851,7 @@ lemma finaliseSlot_ccorres:
                       simp: isCap_simps final_matters'_def o_def)
         apply clarsimp
         apply (frule valid_globals_cte_wpD'[rotated], clarsimp)
-        apply (clarsimp simp: cte_wp_at_ctes_of false_def from_bool_def)
+        apply (clarsimp simp: cte_wp_at_ctes_of)
         apply (erule(1) cmap_relationE1 [OF cmap_relation_cte])
         apply (frule valid_global_refsD_with_objSize, clarsimp)
         apply (auto simp: typ_heap_simps dest!: ccte_relation_ccap_relation)[1]
@@ -979,9 +977,8 @@ lemma cteRevoke_ccorres1:
         apply (rule ccorres_from_vcg_throws[where P=\<top> and P'=UNIV])
         apply (rule allI, rule conseqPre, vcg)
         apply (clarsimp simp: returnOk_def return_def)
-       apply (simp add: guard_is_UNIV_def from_bool_def true_def cintr_def
-                        Collect_const_mem exception_defs)
-      apply (simp add: guard_is_UNIV_def from_bool_def true_def)
+       apply (simp add: guard_is_UNIV_def cintr_def Collect_const_mem exception_defs)
+      apply (simp add: guard_is_UNIV_def)
      apply (rule getCTE_wp)
     apply (clarsimp simp: cte_wp_at_ctes_of nullPointer_def)
     apply (drule invs_mdb')

--- a/proof/crefine/ARM/Fastpath_C.thy
+++ b/proof/crefine/ARM/Fastpath_C.thy
@@ -1116,7 +1116,7 @@ lemma isValidVTableRoot_fp_spec:
        {t. ret__unsigned_long_' t = from_bool (isValidVTableRoot_C (pd_cap_' s))}"
   apply vcg
   apply (clarsimp simp: word_sle_def word_sless_def isValidVTableRoot_fp_lemma)
-  apply (simp add: from_bool_def split: if_split)
+  apply (simp split: if_split)
   done
 
 lemma isRecvEP_endpoint_case:
@@ -1526,8 +1526,8 @@ lemma cap_reply_cap_ptr_new_np_updateCap_ccorres:
                    limited_and_simps cap_reply_cap_def
                    limited_and_simps1[OF lshift_limited_and, OF limited_and_from_bool]
                    shiftr_over_or_dist word_bw_assocs mask_def shiftl_shiftr3 word_size)
-  apply (cases m ; clarsimp)
-  apply (cases canGrant ; clarsimp)
+  apply (cases m ; clarsimp simp: true_def)
+  apply (cases canGrant ; clarsimp simp: true_def false_def)
   done
 
 lemma fastpath_copy_mrs_ccorres:
@@ -2871,7 +2871,6 @@ lemma fastpath_reply_recv_ccorres:
                         apply (rule slowpath_ccorres, simp+)
                      apply (vcg exspec=slowpath_noreturn_spec)
                     apply (simp add: pde_stored_asid_def asid_map_pd_to_hwasids_def
-                                     to_bool_def
                                 del: Collect_const cong: call_ignore_cong)
 
                     apply (rule ccorres_rhs_assoc2)
@@ -2895,8 +2894,7 @@ lemma fastpath_reply_recv_ccorres:
                          apply (simp add: cep_relations_drop_fun_upd)
                          apply (erule cmap_relation_updI, erule ko_at_projectKO_opt)
                           apply (simp add: ctcb_relation_def cthread_state_relation_def
-                                           "StrictC'_thread_state_defs" from_bool_0
-                                           to_bool_def if_1_0_0)
+                                           "StrictC'_thread_state_defs")
                           apply (clarsimp simp: ccap_relation_ep_helpers)
                          apply simp
                         apply (rule conjI, erule cready_queues_relation_not_queue_ptrs)

--- a/proof/crefine/ARM/Finalise_C.thy
+++ b/proof/crefine/ARM/Finalise_C.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2023, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -834,7 +835,7 @@ lemma finaliseCap_True_cases_ccorres:
    apply csymbr
    apply (simp add: cap_get_tag_isCap Collect_False del: Collect_const)
    apply (fold case_bool_If)
-   apply (simp add: false_def)
+   apply simp
    apply csymbr
    apply wpc
     apply (simp add: cap_get_tag_isCap ccorres_cond_univ_iff Let_def)
@@ -1202,8 +1203,7 @@ lemma deleteASID_ccorres:
         apply (simp add: asid_low_bits_def Kernel_C.asidLowBits_def
                          mask_def word_and_le1)
         apply (drule sym, simp)
-        apply (simp add: option_to_ptr_def option_to_0_def
-                         from_bool_def inv_ASIDPool
+        apply (simp add: option_to_ptr_def option_to_0_def inv_ASIDPool
                   split: option.split if_split bool.split)
        apply ceqv
       apply (rule ccorres_cond2[where R=\<top>])
@@ -1568,7 +1568,7 @@ lemma Arch_finaliseCap_ccorres:
       apply (frule cap_get_tag_isCap_unfolded_H_cap)
       apply (frule cap_lift_page_directory_cap)
       apply (clarsimp simp: ccap_relation_def cap_to_H_def capAligned_def
-                            to_bool_def cap_page_directory_cap_lift_def
+                            cap_page_directory_cap_lift_def
                             asid_bits_def
                       split: if_split_asm)
      apply simp
@@ -1610,9 +1610,8 @@ lemma Arch_finaliseCap_ccorres:
       apply (frule cap_get_tag_isCap_unfolded_H_cap)
       apply (frule cap_lift_page_table_cap)
       apply (clarsimp simp: ccap_relation_def cap_to_H_def capAligned_def
-                            to_bool_def cap_page_table_cap_lift_def
-                            asid_bits_def
-                      split: if_split_asm)
+                            cap_page_table_cap_lift_def asid_bits_def
+                     split: if_split_asm)
      apply simp
      apply return_NullCap_pair_ccorres
     apply (clarsimp simp: isCap_simps)
@@ -1776,7 +1775,7 @@ lemma Arch_finaliseCap_ccorres:
      apply (frule cap_get_tag_isCap_unfolded_H_cap)
      apply (frule cap_lift_page_directory_cap)
      apply (clarsimp simp: ccap_relation_def cap_to_H_def capAligned_def
-                           to_bool_def cap_page_directory_cap_lift_def
+                           cap_page_directory_cap_lift_def
                            asid_bits_def
                      split: if_split_asm)
     apply (frule cap_get_tag_isCap_unfolded_H_cap)
@@ -1814,7 +1813,7 @@ lemma isFinalCapability_ccorres:
            apply (simp add: mdbPrev_to_H[symmetric])
           apply (rule ccorres_from_vcg[where P=\<top> and P'=UNIV])
           apply (rule allI, rule conseqPre, vcg)
-          apply (simp add: return_def from_bool_def false_def)
+          apply (simp add: return_def)
          apply (rule ccorres_rhs_assoc)+
          apply (rule ccorres_symb_exec_l[OF _ getCTE_inv getCTE_wp empty_fail_getCTE])
          apply (rule_tac P="cte_wp_at' ((=) cte) slot
@@ -1853,10 +1852,9 @@ lemma isFinalCapability_ccorres:
        apply (rule cmap_relationE1 [OF cmap_relation_cte], assumption+,
                   simp?, simp add: typ_heap_simps)+
        apply (drule ccte_relation_ccap_relation)+
-       apply (auto simp: false_def true_def from_bool_def split: bool.splits)[1]
+       apply (auto simp: from_bool_def split: bool.splits)[1]
       apply (wp getCTE_wp')
-     apply (clarsimp simp add: guard_is_UNIV_def Collect_const_mem false_def
-                               from_bool_0 true_def from_bool_def)
+     apply (clarsimp simp add: guard_is_UNIV_def Collect_const_mem)
     apply vcg
    apply (rule conseqPre, vcg)
    apply clarsimp
@@ -1914,13 +1912,12 @@ lemma cteDeleteOne_ccorres:
         apply (strengthen invs_mdb_strengthen' invs_urz)
         apply (wp typ_at_lifts isFinalCapability_inv
             | strengthen invs_valid_objs')+
-       apply (clarsimp simp: from_bool_def true_def irq_opt_relation_def
-                             invs_pspace_aligned' cte_wp_at_ctes_of)
+       apply (clarsimp simp: irq_opt_relation_def invs_pspace_aligned' cte_wp_at_ctes_of)
        apply (erule(1) cmap_relationE1 [OF cmap_relation_cte])
        apply (clarsimp simp: typ_heap_simps ccte_relation_ccap_relation ccap_relation_NullCap_iff)
       apply (wp isFinalCapability_inv)
      apply simp
-    apply (simp del: Collect_const add: false_def)
+    apply (simp del: Collect_const)
    apply (rule ccorres_return_Skip)
   apply (clarsimp simp: Collect_const_mem cte_wp_at_ctes_of)
   apply (erule(1) cmap_relationE1 [OF cmap_relation_cte])
@@ -2081,7 +2078,7 @@ lemma finaliseCap_ccorres:
                del: Collect_const)
    apply (rule ccorres_if_lhs)
     apply (simp, rule ccorres_fail)
-   apply (simp add: from_bool_0 Collect_True Collect_False false_def
+   apply (simp add: from_bool_0 Collect_True Collect_False
                del: Collect_const)
    apply csymbr
    apply (simp add: cap_get_tag_isCap Collect_False Collect_True
@@ -2165,7 +2162,7 @@ lemma finaliseCap_ccorres:
    apply (simp add: isArchCap_T_isArchObjectCap[symmetric]
                del: Collect_const)
    apply (rule ccorres_if_lhs)
-    apply (simp add: Collect_False Collect_True Let_def true_def
+    apply (simp add: Collect_False Collect_True Let_def
                 del: Collect_const)
     apply (rule_tac P="(capIRQ cap) \<le>  ARM.maxIRQ" in ccorres_gen_asm)
     apply (rule ccorres_rhs_assoc)+
@@ -2205,8 +2202,7 @@ lemma finaliseCap_ccorres:
                            irq_opt_relation_def)
     apply wp
    apply (simp add: guard_is_UNIV_def)
-  apply (clarsimp simp: cap_get_tag_isCap word_sle_def Collect_const_mem
-                        false_def from_bool_def)
+  apply (clarsimp simp: cap_get_tag_isCap word_sle_def Collect_const_mem)
   apply (intro impI conjI)
              apply (clarsimp split: bool.splits)
             apply (clarsimp split: bool.splits)
@@ -2222,7 +2218,7 @@ lemma finaliseCap_ccorres:
                       split: option.splits cap_CL.splits if_splits)
      apply clarsimp
      apply (frule cap_get_tag_to_H, erule(1) cap_get_tag_isCap [THEN iffD2])
-     apply (clarsimp simp: isCap_simps from_bool_def false_def)
+     apply (clarsimp simp: isCap_simps)
      apply (clarsimp simp: tcb_cnode_index_defs ptr_add_assertion_def)
     apply clarsimp
     apply (frule cap_get_tag_to_H, erule(1) cap_get_tag_isCap [THEN iffD2])

--- a/proof/crefine/ARM/Interrupt_C.thy
+++ b/proof/crefine/ARM/Interrupt_C.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2023, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -16,7 +17,7 @@ lemma invokeIRQHandler_AckIRQ_ccorres:
      (InterruptDecls_H.invokeIRQHandler (AckIRQ irq)) (Call invokeIRQHandler_AckIRQ_'proc)"
   apply (cinit lift: irq_' simp: Interrupt_H.invokeIRQHandler_def invokeIRQHandler_def)
    apply (ctac add: maskInterrupt_ccorres)
-  apply (simp add: from_bool_def false_def)
+  apply simp
   done
 
 lemma getIRQSlot_ccorres:
@@ -258,12 +259,12 @@ lemma decodeIRQHandlerInvocation_ccorres:
     sysargs_rel_n_def word_less_nat_alt)
   apply (clarsimp simp: cte_wp_at_ctes_of neq_Nil_conv sysargs_rel_def n_msgRegisters_def
                     excaps_map_def excaps_in_mem_def word_less_nat_alt hd_conv_nth
-                    slotcap_in_mem_def valid_tcb_state'_def from_bool_def toBool_def
+                    slotcap_in_mem_def valid_tcb_state'_def
              dest!: interpret_excaps_eq split: bool.splits)
   apply (intro conjI impI allI)
   apply (clarsimp simp: cte_wp_at_ctes_of neq_Nil_conv sysargs_rel_def n_msgRegisters_def
                     excaps_map_def excaps_in_mem_def word_less_nat_alt hd_conv_nth
-                    slotcap_in_mem_def valid_tcb_state'_def from_bool_def toBool_def
+                    slotcap_in_mem_def valid_tcb_state'_def
              dest!: interpret_excaps_eq split: bool.splits)+
      apply (auto dest: st_tcb_at_idle_thread' ctes_of_valid')[4]
     apply (drule ctes_of_valid')
@@ -381,8 +382,7 @@ lemma isIRQActive_ccorres:
                          Let_def cinterrupt_relation_def)
    apply (drule spec, drule(1) mp)
    apply (case_tac "intStateIRQTable (ksInterruptState \<sigma>) irq")
-     apply (simp add: from_bool_def irq_state_defs Kernel_C.maxIRQ_def
-                      word_le_nat_alt)+
+     apply (simp add: irq_state_defs Kernel_C.maxIRQ_def word_le_nat_alt)+
   done
 
 lemma Platform_maxIRQ:
@@ -609,7 +609,7 @@ lemma Arch_decodeIRQControlInvocation_ccorres:
   apply (clarsimp simp: Kernel_C.maxIRQ_def word_le_nat_alt
                         ucast_nat_def ucast_ucast_mask mask_eq_ucast_eq unat_ucast_mask
                         less_mask_eq[unfolded word_less_nat_alt])
-  apply (cases "args ! Suc 0 = 0"; clarsimp simp: true_def false_def)
+  apply (cases "args ! Suc 0 = 0"; clarsimp)
   done
 
 lemma decodeIRQControlInvocation_ccorres:

--- a/proof/crefine/ARM/Invoke_C.thy
+++ b/proof/crefine/ARM/Invoke_C.thy
@@ -64,7 +64,7 @@ lemma setDomain_ccorres:
           apply (rule ccorres_cond2[where R=\<top>], simp add: Collect_const_mem)
            apply (ctac add: tcbSchedEnqueue_ccorres)
           apply (rule ccorres_return_Skip)
-         apply (simp add: when_def to_bool_def)
+         apply (simp add: when_def)
          apply (rule_tac R="\<lambda>s. rv = ksCurThread s"
                     in ccorres_cond2)
            apply (clarsimp simp: rf_sr_ksCurThread)
@@ -228,7 +228,7 @@ lemma invokeCNodeDelete_ccorres:
    apply (rule ccorres_trim_returnE, simp, simp)
    apply (rule ccorres_callE)
        apply (rule cteDelete_ccorres[simplified])
-      apply (simp add: from_bool_def true_def)+
+      apply simp+
 done
 
 
@@ -248,7 +248,7 @@ lemma invokeCNodeRevoke_ccorres:
    apply (rule ccorres_trim_returnE, simp, simp)
    apply (rule ccorres_callE)
        apply (rule cteRevoke_ccorres[simplified])
-      apply (simp add: from_bool_def true_def)+
+      apply simp+
 done
 
 
@@ -537,12 +537,10 @@ lemma hasCancelSendRights_spec:
    apply clarsimp
    apply (drule sym, drule (1) cap_get_tag_to_H)
    apply (clarsimp simp: hasCancelSendRights_def to_bool_def
-                         true_def false_def
                    split: if_split bool.splits)
   apply (rule impI)
   apply (case_tac cap,
-         auto simp: cap_get_tag_isCap_unfolded_H_cap cap_tag_defs
-                     from_bool_def false_def true_def hasCancelSendRights_def
+         auto simp: cap_get_tag_isCap_unfolded_H_cap cap_tag_defs hasCancelSendRights_def
               dest: cap_get_tag_isArchCap_unfolded_H_cap
               split: capability.splits bool.splits)[1]
   done
@@ -739,7 +737,7 @@ lemma decodeCNodeInvocation_ccorres:
                                 apply (simp add: syscall_error_to_H_cases)
                                apply (simp add: whenE_def injection_handler_returnOk
                                                 ccorres_invocationCatch_Inr performInvocation_def
-                                                bindE_assoc false_def)
+                                                bindE_assoc)
                                apply (ctac add: setThreadState_ccorres)
                                  apply (simp add: ccorres_cond_iffs)
                                  apply (ctac(no_vcg) add: invokeCNodeInsert_ccorres)
@@ -815,7 +813,7 @@ lemma decodeCNodeInvocation_ccorres:
                                     apply (rule syscall_error_throwError_ccorres_n)
                                     apply (simp add: syscall_error_to_H_cases)
                                    apply (simp add: whenE_def injection_handler_returnOk
-                                                    ccorres_invocationCatch_Inr false_def
+                                                    ccorres_invocationCatch_Inr
                                                     performInvocation_def bindE_assoc)
                                    apply (ctac add: setThreadState_ccorres)
                                      apply (simp add: ccorres_cond_iffs)
@@ -871,7 +869,7 @@ lemma decodeCNodeInvocation_ccorres:
                                        in ccorres_gen_asm2)
                            apply csymbr
                            apply csymbr
-                           apply (simp add: cap_get_tag_NullCap true_def)
+                           apply (simp add: cap_get_tag_NullCap)
                            apply (ctac add: setThreadState_ccorres)
                              apply (simp add: ccorres_cond_iffs)
                              apply (ctac(no_vcg) add: invokeCNodeMove_ccorres)
@@ -917,7 +915,7 @@ lemma decodeCNodeInvocation_ccorres:
                                               ccorres_invocationCatch_Inr numeral_eqs
                                               performInvocation_def bindE_assoc)
                              apply (ctac add: setThreadState_ccorres)
-                               apply (simp add: true_def ccorres_cond_iffs)
+                               apply (simp add: ccorres_cond_iffs)
                                apply (ctac(no_vcg) add: invokeCNodeMove_ccorres)
                                  apply (rule ccorres_alternative2)
                                  apply (rule ccorres_return_CE, simp+)[1]
@@ -1376,9 +1374,7 @@ lemma decodeCNodeInvocation_ccorres:
                              cl_valid_cte_def c_valid_cap_def
                              map_option_Some_eq2 neq_Nil_conv ccap_relation_def
                              numeral_eqs hasCancelSendRights_not_Null
-                             ccap_relation_NullCap_iff[symmetric]
-                             if_1_0_0 interpret_excaps_test_null
-                             false_def true_def
+                             ccap_relation_NullCap_iff[symmetric] interpret_excaps_test_null
             | clarsimp simp: typ_heap_simps'
             | frule length_ineq_not_Nil)+)
   done
@@ -3103,8 +3099,8 @@ lemma decodeUntypedInvocation_ccorres_helper:
                                           unat_of_nat_APIType_capBits word_size length_ineq_not_Nil
                                           not_less word_le_nat_alt isCap_simps valid_cap_simps')
                     apply (strengthen word_of_nat_less)
-                    apply (clarsimp simp: StrictC'_thread_state_defs mask_def true_def false_def
-                                          from_bool_0 ccap_relation_isDeviceCap2
+                    apply (clarsimp simp: StrictC'_thread_state_defs mask_def
+                                          ccap_relation_isDeviceCap2
                                    split: if_split)
                     apply (intro conjI impI;
                            clarsimp simp: not_less shiftr_eq_0 unat_of_nat_APIType_capBits

--- a/proof/crefine/ARM/IpcCancel_C.thy
+++ b/proof/crefine/ARM/IpcCancel_C.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2023, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -353,9 +354,9 @@ lemma isStopped_ccorres [corres]:
    apply vcg
    apply clarsimp
   apply clarsimp
-  apply (clarsimp simp: to_bool_def true_def false_def typ_heap_simps
-    ctcb_relation_thread_state_to_tsType split: thread_state.splits)
-  apply (simp add: "StrictC'_thread_state_defs")+
+  apply (clarsimp simp: typ_heap_simps ctcb_relation_thread_state_to_tsType
+                 split: thread_state.splits)
+    apply (simp add: "StrictC'_thread_state_defs")+
   done
 
 lemma isRunnable_ccorres [corres]:
@@ -381,10 +382,10 @@ lemma isRunnable_ccorres [corres]:
     apply (vcg)
    apply (clarsimp)
   apply (clarsimp)
-  apply (clarsimp simp: to_bool_def true_def false_def typ_heap_simps
-    ctcb_relation_thread_state_to_tsType split: thread_state.splits)
-  apply (simp add: "StrictC'_thread_state_defs")+
-done
+  apply (clarsimp simp: typ_heap_simps ctcb_relation_thread_state_to_tsType
+                 split: thread_state.splits)
+       apply (simp add: "StrictC'_thread_state_defs")+
+  done
 
 
 
@@ -668,13 +669,6 @@ lemma state_relation_queue_update_helper:
   apply (drule(1) bspec)
   apply (erule obj_at'_weakenE, clarsimp)
   done
-
-(* FIXME: move *)
-lemma from_bool_vals [simp]:
-  "from_bool True = scast true"
-  "from_bool False = scast false"
-  "scast true \<noteq> scast false"
-  by (auto simp add: from_bool_def true_def false_def)
 
 declare fun_upd_restrict_conv[simp del]
 
@@ -1793,10 +1787,6 @@ proof -
                          valid_obj'_def inQ_def
                    dest!: valid_queues_obj_at'D)
 qed
-
-lemma true_eq_from_bool [simp]:
-  "(scast true = from_bool P) = P"
-  by (simp add: true_def from_bool_def split: bool.splits)
 
 lemma isRunnable_spec:
   "\<forall>s. \<Gamma> \<turnstile> ({s} \<inter> {s. cslift s (thread_' s) \<noteq> None}) Call isRunnable_'proc

--- a/proof/crefine/ARM/Ipc_C.thy
+++ b/proof/crefine/ARM/Ipc_C.thy
@@ -1059,7 +1059,7 @@ lemma setMRs_syscall_error_ccorres:
                  | wp hoare_case_option_wp
                  | (simp del: Collect_const, vcg exspec=setMR_modifies)
                )+
-   apply (simp add: msgMaxLength_unfold true_def false_def)
+   apply (simp add: msgMaxLength_unfold)
    apply (clarsimp split:if_split_asm simp:syscall_error_to_H_def map_option_Some_eq2)
    apply (simp add: msgFromLookupFailure_def
                  split: lookup_failure.split
@@ -2633,9 +2633,8 @@ next
                               word_sle_def t2n_mask_eq_if)
             apply (rule conjI)
              apply (clarsimp simp: ccap_rights_relation_def cap_rights_to_H_def
-                                 false_def true_def to_bool_def allRights_def
-                                 excaps_map_def split_def
-                          dest!: drop_n_foo interpret_excaps_eq)
+                                   allRights_def excaps_map_def split_def
+                            dest!: drop_n_foo interpret_excaps_eq)
             apply (clarsimp simp:from_bool_def split:bool.splits)
              apply (case_tac "isEndpointCap (fst x)")
               apply (clarsimp simp: cap_get_tag_EndpointCap ep_cap_not_null cap_get_tag_isCap[symmetric])
@@ -2675,7 +2674,7 @@ next
          apply (rule conseqPre, vcg)
          apply (clarsimp split del: if_split)
         apply (clarsimp split del: if_split
-                       simp add: Collect_const[symmetric] precond_def true_def false_def
+                       simp add: Collect_const[symmetric] precond_def
                        simp del: Collect_const)
         apply (rule HoarePartial.Seq[rotated] HoarePartial.Cond[OF order_refl]
                   HoarePartial.Basic[OF order_refl] HoarePartial.Skip[OF order_refl]
@@ -3001,7 +3000,7 @@ proof -
                         apply (clarsimp simp: cfault_rel2_def)
                         apply (clarsimp simp: cfault_rel_def)
                         apply (simp add: seL4_Fault_CapFault_lift)
-                        apply (clarsimp simp: is_cap_fault_def to_bool_def false_def)
+                        apply (clarsimp simp: is_cap_fault_def)
                        apply wp
                        apply (rule hoare_post_imp_R, rule lsft_real_cte)
                        apply (clarsimp simp: obj_at'_def projectKOs objBits_simps')
@@ -3246,7 +3245,7 @@ lemma replyFromKernel_error_ccorres [corres]:
                    message_info_to_H_def valid_pspace_valid_objs')
   apply (clarsimp simp: msgLengthBits_def msgFromSyscallError_def
                         syscall_error_to_H_def syscall_error_type_defs
-                        mask_def true_def option_to_ptr_def
+                        mask_def option_to_ptr_def
                  split: if_split_asm)
   done
 
@@ -3304,7 +3303,7 @@ lemma doIPCTransfer_ccorres [corres]:
                            fault_to_fault_tag_nonzero)
      apply (fold dc_def)[1]
      apply ctac
-    apply (clarsimp simp: guard_is_UNIV_def false_def option_to_ptr_def split: option.splits)
+    apply (clarsimp simp: guard_is_UNIV_def option_to_ptr_def split: option.splits)
    apply (rule_tac Q="\<lambda>rv. valid_pspace' and cur_tcb' and tcb_at' sender
                        and tcb_at' receiver and K (rv \<noteq> Some 0)
                        and (case_option \<top> valid_ipc_buffer_ptr' rv)
@@ -3313,7 +3312,7 @@ lemma doIPCTransfer_ccorres [corres]:
     apply (auto simp: valid_ipc_buffer_ptr'_def option_to_0_def
                    split: option.splits)[1]
    apply (wp lookupIPCBuffer_not_Some_0 lookupIPCBuffer_aligned)
-  apply (auto simp: to_bool_def true_def)
+  apply auto
   done
 
 lemma length_exceptionMessage:
@@ -3328,7 +3327,6 @@ lemma Arch_getSanitiseRegisterInfo_ccorres:
      (Call Arch_getSanitiseRegisterInfo_'proc)"
   apply (cinit' lift: thread_' simp: getSanitiseRegisterInfo_def)
    apply (rule ccorres_return_C, simp+)
-  apply (clarsimp simp: false_def)
   done
 
 lemma copyMRsFaultReply_ccorres_exception:
@@ -3653,7 +3651,7 @@ lemma handleArchFaultReply_corres:
          apply simp+
       apply (rule ccorres_symb_exec_l)
          apply (ctac add: ccorres_return_C)
-        apply (wp mapM_wp' empty_fail_loadWordUser | clarsimp simp: to_bool_def true_def)+
+        apply (wp mapM_wp' empty_fail_loadWordUser | clarsimp)+
   done
 
 (* MOVE *)
@@ -3794,9 +3792,9 @@ lemma handleFaultReply_ccorres [corres]:
      apply clarsimp
      apply vcg_step
      apply (clarsimp simp: n_exceptionMessage_def n_syscallMessage_def
-                           message_info_to_H_def to_bool_def scast_def
+                           message_info_to_H_def scast_def
                            length_exceptionMessage length_syscallMessage
-                           min_def word_less_nat_alt true_def
+                           min_def word_less_nat_alt
                            guard_is_UNIV_def seL4_Faults seL4_Arch_Faults
                        split: if_split)
     apply (simp add: length_exceptionMessage length_syscallMessage)
@@ -3804,10 +3802,8 @@ lemma handleFaultReply_ccorres [corres]:
    apply clarsimp
    apply (vcg exspec=getRegister_modifies)
   apply (clarsimp simp: n_exceptionMessage_def n_syscallMessage_def
-                        message_info_to_H_def to_bool_def
-                        length_exceptionMessage length_syscallMessage
-                        min_def word_less_nat_alt true_def
-                        obj_at'_def
+                        message_info_to_H_def length_exceptionMessage length_syscallMessage
+                        min_def word_less_nat_alt obj_at'_def
                  split: if_split)
   using arch_fault_to_fault_tag_range
   apply (fastforce simp: seL4_Faults seL4_Arch_Faults)
@@ -4029,7 +4025,7 @@ proof -
                        threadSet_valid_objs' threadSet_weak_sch_act_wf
                          | simp add: valid_tcb_state'_def)+)[1]
            apply (clarsimp simp: guard_is_UNIV_def ThreadState_Restart_def
-                                 ThreadState_Inactive_def mask_def to_bool_def
+                                 ThreadState_Inactive_def mask_def
                                  option_to_ctcb_ptr_def)
 
           apply (rule_tac Q="\<lambda>rv. valid_queues and tcb_at' receiver and valid_queues' and
@@ -4051,8 +4047,7 @@ proof -
     apply (rule conseqPre, vcg)
     apply (simp(no_asm_use) add: gs_set_assn_Delete_cstate_relation[unfolded o_def]
                                  subset_iff rf_sr_def)
-   apply (clarsimp simp: guard_is_UNIV_def to_bool_def true_def
-                         option_to_ptr_def option_to_0_def false_def
+   apply (clarsimp simp: guard_is_UNIV_def option_to_ptr_def option_to_0_def
                          ThreadState_Running_def mask_def
                          ghost_assertion_data_get_def ghost_assertion_data_set_def
                          cap_tag_defs option_to_ctcb_ptr_def
@@ -4124,7 +4119,7 @@ lemma setupCallerCap_ccorres [corres]:
         apply (wp getSlotCap_cte_wp_at)
        apply (clarsimp simp: ccap_relation_def cap_lift_reply_cap
                              cap_to_H_simps cap_reply_cap_lift_def
-                             false_def tcbSlots Kernel_C.tcbCaller_def
+                             tcbSlots Kernel_C.tcbCaller_def
                              size_of_def cte_level_bits_def ctcb_size_bits_def)
         apply (simp add: is_aligned_neg_mask)
        apply (wp getCTE_wp')
@@ -4144,7 +4139,7 @@ lemma setupCallerCap_ccorres [corres]:
      apply (simp add: locateSlot_conv)
      apply wp
     apply (clarsimp simp: ccap_rights_relation_def allRights_def
-                          mask_def true_def cap_rights_to_H_def tcbCallerSlot_def
+                          mask_def cap_rights_to_H_def tcbCallerSlot_def
                           Kernel_C.tcbCaller_def)
    apply simp
    apply wp
@@ -4356,9 +4351,7 @@ lemma sendIPC_block_ccorres_helper:
           (simp add: typ_heap_simps')+)[1]
          apply (simp add: tcb_cte_cases_def)
         apply (simp add: ctcb_relation_def cthread_state_relation_def
-                         ThreadState_BlockedOnSend_def mask_def
-                         from_bool_def to_bool_def)
-        apply (clarsimp split: bool.split)
+                         ThreadState_BlockedOnSend_def mask_def)
        apply ceqv
       apply clarsimp
       apply ctac
@@ -4742,7 +4735,7 @@ lemma sendIPC_ccorres [corres]:
             apply (ctac(no_vcg) add: possibleSwitchTo_ccorres)
              apply (clarsimp split del: if_split)
              apply (wpc ; ccorres_rewrite)
-              apply (clarsimp simp: from_bool_def disj_imp[symmetric] split del: if_split)
+              apply (clarsimp simp: disj_imp[symmetric] split del: if_split)
               apply (wpc ; clarsimp)
                apply ccorres_rewrite
                apply (fold dc_def)[1]
@@ -5506,7 +5499,7 @@ lemma receiveIPC_ccorres [corres]:
                  apply (clarsimp simp:  from_bool_0 disj_imp[symmetric] simp del: Collect_const)
                  apply wpc
                   (* blocking ipc call *)
-                  apply (clarsimp simp: from_bool_def split del: if_split simp del: Collect_const)
+                  apply (clarsimp split del: if_split simp del: Collect_const)
                   apply ccorres_rewrite
                   apply (wpc ; clarsimp ; ccorres_rewrite)
                    apply csymbr
@@ -5555,12 +5548,11 @@ lemma receiveIPC_ccorres [corres]:
              apply (subgoal_tac "state_refs_of' s (capEPPtr cap) = (set list) \<times> {EPRecv}
                                  \<and> thread \<notin> (set list)")
               subgoal by (fastforce simp: obj_at'_def is_aligned_neg_mask objBits_simps'
-                                    projectKOs invs'_def valid_state'_def st_tcb_at'_def
-                                valid_tcb_state'_def ko_wp_at'_def invs_valid_objs'
-                                    isBlockedOnReceive_def projectKO_opt_tcb
-                                    from_bool_def to_bool_def
-                              elim!: delta_sym_refs
-                             split: if_split_asm bool.splits) (*very long*)
+                                          projectKOs invs'_def valid_state'_def st_tcb_at'_def
+                                          valid_tcb_state'_def ko_wp_at'_def invs_valid_objs'
+                                          isBlockedOnReceive_def projectKO_opt_tcb
+                                   elim!: delta_sym_refs
+                                   split: if_split_asm bool.splits) (*very long*)
              apply (frule(1) sym_refs_obj_atD' [OF _ invs_sym'])
              apply (clarsimp simp: st_tcb_at'_def ko_wp_at'_def obj_at'_def projectKOs
                             split: if_split_asm)
@@ -5568,12 +5560,11 @@ lemma receiveIPC_ccorres [corres]:
              apply (case_tac "tcbState obj", simp_all add: tcb_bound_refs'_def)[1]
             apply (subgoal_tac "state_refs_of' s (capEPPtr cap) = {}")
              subgoal by (fastforce simp: obj_at'_def is_aligned_neg_mask objBits_simps'
-                                   projectKOs invs'_def valid_state'_def st_tcb_at'_def
-                               valid_tcb_state'_def ko_wp_at'_def invs_valid_objs'
-                                   isBlockedOnReceive_def projectKO_opt_tcb
-                                   from_bool_def to_bool_def
-                             elim: delta_sym_refs
-                            split: if_split_asm bool.splits) (*very long *)
+                                         projectKOs invs'_def valid_state'_def st_tcb_at'_def
+                                         valid_tcb_state'_def ko_wp_at'_def invs_valid_objs'
+                                         isBlockedOnReceive_def projectKO_opt_tcb
+                                  elim!: delta_sym_refs
+                                  split: if_split_asm bool.splits) (*very long *)
             apply (clarsimp simp: obj_at'_def state_refs_of'_def projectKOs)
            apply (frule(1) sym_refs_ko_atD' [OF _ invs_sym'])
            apply (frule invs_queues)
@@ -5957,8 +5948,7 @@ lemma receiveSignal_block_ccorres_helper:
           (simp add: typ_heap_simps')+)
          apply (simp add: tcb_cte_cases_def)
         apply (simp add: ctcb_relation_def cthread_state_relation_def
-                         ThreadState_BlockedOnNotification_def mask_def
-                         from_bool_def to_bool_def)
+                         ThreadState_BlockedOnNotification_def mask_def)
        apply ceqv
       apply clarsimp
       apply ctac

--- a/proof/crefine/ARM/Retype_C.thy
+++ b/proof/crefine/ARM/Retype_C.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2023, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -2136,9 +2137,9 @@ lemma insertNewCap_ccorres_helper:
    apply (rule conjI)
     apply (erule (2) cmap_relation_updI)
     apply (simp add: ccap_relation_def ccte_relation_def cte_lift_def)
-    subgoal by (simp add: cte_to_H_def map_option_Some_eq2 mdb_node_to_H_def to_bool_mask_to_bool_bf is_aligned_neg_mask
-      c_valid_cte_def true_def
-      split: option.splits)
+    subgoal by (simp add: cte_to_H_def map_option_Some_eq2 mdb_node_to_H_def to_bool_mask_to_bool_bf
+                          is_aligned_neg_mask c_valid_cte_def
+                   split: option.splits)
    subgoal by simp
    apply (erule_tac t = s' in ssubst)
    apply simp
@@ -4708,7 +4709,7 @@ proof -
                 is_aligned_neg_mask_eq vmrights_to_H_def
                 Kernel_C.VMReadWrite_def Kernel_C.VMNoAccess_def
                 Kernel_C.VMKernelOnly_def Kernel_C.VMReadOnly_def)
-     apply (simp add: to_bool_def false_def isFrameType_def)
+     apply (simp add: isFrameType_def)
 
     \<comment> \<open>PageDirectoryObject\<close>
     apply (cinit' lift: t_' regionBase_' userSize_' deviceMemory_')
@@ -4731,7 +4732,7 @@ proof -
             apply simp
            apply simp
           apply wp
-         apply (clarsimp simp: false_def)
+         apply clarsimp
          apply vcg
         apply wp
        apply (clarsimp simp: pageBits_def ccap_relation_def APIType_capBits_def
@@ -4918,8 +4919,7 @@ proof -
            apply simp
           apply (clarsimp simp: ccap_relation_def cap_to_H_def
                                 getObjectSize_def apiGetObjectSize_def
-                                cap_untyped_cap_lift to_bool_eq_0 true_def
-                                aligned_add_aligned
+                                cap_untyped_cap_lift to_bool_eq_0 aligned_add_aligned
                          split: option.splits)
           apply (subst is_aligned_neg_mask_eq [OF is_aligned_weaken])
             apply (erule range_cover.aligned)
@@ -4971,8 +4971,7 @@ proof -
                                region_actually_is_bytes_def APIType_capBits_def)
          apply (frule(1) ghost_assertion_size_logic_no_unat)
          apply (clarsimp simp: ccap_relation_def cap_to_H_def getObjectSize_def
-                               apiGetObjectSize_def cap_thread_cap_lift to_bool_def true_def
-                               aligned_add_aligned
+                               apiGetObjectSize_def cap_thread_cap_lift aligned_add_aligned
                         split: option.splits)
          apply (clarsimp simp: ctcb_ptr_to_tcb_ptr_def ctcb_offset_defs
                                tcb_ptr_to_ctcb_ptr_def
@@ -5009,7 +5008,7 @@ proof -
           apply wp
          apply (clarsimp simp: ccap_relation_def cap_to_H_def getObjectSize_def
                                objBits_simps apiGetObjectSize_def epSizeBits_def
-                               cap_endpoint_cap_lift to_bool_def true_def
+                               cap_endpoint_cap_lift
                         split: option.splits
                         dest!: range_cover.aligned)
         apply (clarsimp simp: createObject_hs_preconds_def isFrameType_def)
@@ -5048,7 +5047,7 @@ proof -
          apply wp
         apply (clarsimp simp: ccap_relation_def cap_to_H_def getObjectSize_def
                               apiGetObjectSize_def ntfnSizeBits_def objBits_simps
-                              cap_notification_cap_lift to_bool_def true_def
+                              cap_notification_cap_lift
                        dest!: range_cover.aligned
                        split: option.splits)
        apply (clarsimp simp: createObject_hs_preconds_def isFrameType_def)
@@ -5107,8 +5106,7 @@ proof -
        apply (simp add: power_add cte_C_size objBits_defs)
       apply (frule range_cover.aligned)
       apply (clarsimp simp: ccap_relation_def cap_to_H_def
-                            cap_cnode_cap_lift to_bool_def true_def
-                            getObjectSize_def
+                            cap_cnode_cap_lift getObjectSize_def
                             apiGetObjectSize_def cteSizeBits_def
                             objBits_simps field_simps is_aligned_power2
                             addr_card_wb is_aligned_weaken[where y=word_size_bits]

--- a/proof/crefine/ARM/Schedule_C.thy
+++ b/proof/crefine/ARM/Schedule_C.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2023, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -383,7 +384,7 @@ lemma isHighestPrio_ccorres:
       apply (rule ccorres_return_C, simp, simp, simp)
      apply (rule wp_post_taut)
     apply (vcg exspec=getHighestPrio_modifies)+
-  apply (clarsimp simp: word_le_nat_alt true_def to_bool_def maxDomain_le_unat_ucast_explicit
+  apply (clarsimp simp: word_le_nat_alt maxDomain_le_unat_ucast_explicit
                   split: if_splits)
   done
 
@@ -480,17 +481,17 @@ lemma schedule_ccorres:
               apply (rule ccorres_cond2'[where R=\<top>], fastforce)
                apply clarsimp
                apply (rule ccorres_return[where R'=UNIV], clarsimp, vcg)
-               apply (rule_tac P="\<lambda>s. obj_at' (\<lambda>tcb. tcbPriority tcb = curPrio) curThread s
-                                      \<and> curThread = ksCurThread s
-                                      \<and> obj_at' (\<lambda>tcb. tcbPriority tcb = targetPrio) candidate s"
-                        and P'=UNIV in ccorres_from_vcg)
-               apply clarsimp
-               apply (rule conseqPre, vcg)
-               apply (clarsimp simp: return_def cur_tcb'_def rf_sr_ksCurThread)
-               apply (drule (1) obj_at_cslift_tcb)+
-               apply (clarsimp simp: typ_heap_simps ctcb_relation_def to_bool_def split: if_split)
-               apply unat_arith
-              apply (wpsimp wp: threadGet_obj_at2)
+              apply (rule_tac P="\<lambda>s. obj_at' (\<lambda>tcb. tcbPriority tcb = curPrio) curThread s
+                                     \<and> curThread = ksCurThread s
+                                     \<and> obj_at' (\<lambda>tcb. tcbPriority tcb = targetPrio) candidate s"
+                       and P'=UNIV in ccorres_from_vcg)
+              apply clarsimp
+              apply (rule conseqPre, vcg)
+              apply (clarsimp simp: return_def cur_tcb'_def rf_sr_ksCurThread)
+              apply (drule (1) obj_at_cslift_tcb)+
+              apply (clarsimp simp: typ_heap_simps ctcb_relation_def split: if_split)
+              apply unat_arith
+              apply clarsimp
              apply vcg
             apply ceqv
            (* fastfail calculation complete *)
@@ -551,10 +552,10 @@ lemma schedule_ccorres:
                       in ccorres_symb_exec_r_known_rv)
                 apply clarsimp
                 apply (rule conseqPre, vcg)
-                apply (clarsimp simp: false_def cur_tcb'_def rf_sr_ksCurThread)
+                apply (clarsimp simp: cur_tcb'_def rf_sr_ksCurThread)
 
                 apply (drule (1) obj_at_cslift_tcb)+
-                apply (clarsimp simp: typ_heap_simps ctcb_relation_def to_bool_def split: if_split)
+                apply (clarsimp simp: typ_heap_simps ctcb_relation_def split: if_split)
                 apply (solves \<open>unat_arith, rule iffI; simp\<close>)
                apply ceqv
               apply clarsimp
@@ -599,9 +600,9 @@ lemma schedule_ccorres:
           apply wp
          apply (clarsimp, vcg exspec=tcbSchedEnqueue_modifies)
         apply (clarsimp, vcg exspec=tcbSchedEnqueue_modifies)
-       apply (clarsimp simp: to_bool_def true_def)
+       apply clarsimp
        apply (strengthen ko_at'_obj_at'_field)
-       apply (clarsimp cong: imp_cong simp: ko_at'_obj_at'_field to_bool_def true_def)
+       apply (clarsimp cong: imp_cong simp: ko_at'_obj_at'_field)
        apply wp
       apply clarsimp
       (* when runnable tcbSchedEnqueue curThread *)
@@ -613,7 +614,6 @@ lemma schedule_ccorres:
       apply (wp | clarsimp simp: dc_def)+
      apply (vcg exspec=tcbSchedEnqueue_modifies)
     apply wp
-   apply (clarsimp simp: to_bool_def false_def)
    apply vcg
 
   apply (clarsimp simp: tcb_at_invs' rf_sr_ksCurThread if_apply_def2 invs_queues invs_valid_objs'
@@ -624,7 +624,7 @@ lemma schedule_ccorres:
    apply (clarsimp dest!: rf_sr_cscheduler_relation simp: cscheduler_action_relation_def)
   apply (rule conjI; clarsimp)
    apply (frule (1) obj_at_cslift_tcb)
-   apply (clarsimp simp: cscheduler_action_relation_def typ_heap_simps max_word_not_0
+   apply (clarsimp simp: cscheduler_action_relation_def typ_heap_simps
                   split: scheduler_action.splits)
   apply (frule (1) obj_at_cslift_tcb)
   apply (clarsimp dest!: rf_sr_cscheduler_relation invs_sch_act_wf'

--- a/proof/crefine/ARM/SyscallArgs_C.thy
+++ b/proof/crefine/ARM/SyscallArgs_C.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2023, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -792,7 +793,7 @@ lemma lookupIPCBuffer_ccorres[corres]:
                apply (frule capFVMRights_range)
                apply (simp add: cap_frame_cap_lift
                                generic_frame_cap_get_capFVMRights_CL_def)
-               apply (clarsimp simp: cap_to_H_def vmrights_to_H_def to_bool_def
+               apply (clarsimp simp: cap_to_H_def vmrights_to_H_def
                                word_le_make_less Kernel_C.VMNoAccess_def
                                Kernel_C.VMReadWrite_def Kernel_C.VMReadOnly_def
                                Kernel_C.VMKernelOnly_def
@@ -847,7 +848,7 @@ lemma lookupIPCBuffer_ccorres[corres]:
                apply (frule capFVMRights_range)
                apply (simp add: cap_frame_cap_lift
                                 generic_frame_cap_get_capFVMRights_CL_def)
-                apply (clarsimp simp: cap_to_H_def vmrights_to_H_def to_bool_def
+                apply (clarsimp simp: cap_to_H_def vmrights_to_H_def
                                       word_le_make_less Kernel_C.VMNoAccess_def
                                       Kernel_C.VMReadWrite_def Kernel_C.VMReadOnly_def
                                       Kernel_C.VMKernelOnly_def

--- a/proof/crefine/ARM/Syscall_C.thy
+++ b/proof/crefine/ARM/Syscall_C.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2023, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -18,9 +19,6 @@ crunch sch_act_wf [wp]: replyFromKernel "\<lambda>s. sch_act_wf (ksSchedulerActi
 end
 
 context kernel_m begin
-
-(* FIXME: should do this from the beginning *)
-declare true_def [simp] false_def [simp]
 
 definition
   one_on_true :: "bool \<Rightarrow> nat"
@@ -629,7 +627,7 @@ lemma sendFaultIPC_ccorres:
              apply (clarsimp simp: cap_get_tag_isCap isEndpointCap_def isCap_simps
                                     ccap_relation_ep_helpers)
             apply (frule cap_get_tag_isCap(4)[symmetric])
-            apply (clarsimp simp: cap_get_tag_EndpointCap to_bool_def)
+            apply (clarsimp simp: cap_get_tag_EndpointCap)
             apply (drule cap_get_tag_isCap(4) [symmetric])
             apply (clarsimp simp: isCap_simps cap_endpoint_cap_lift cap_lift_capEPBadge_mask_eq)
            apply (clarsimp simp: case_bool_If)
@@ -1355,8 +1353,8 @@ lemma handleRecv_ccorres:
   apply (frule tcb_aligned'[OF tcb_at_invs'])
   apply clarsimp
   apply (intro conjI impI allI)
-             apply (clarsimp simp: cfault_rel_def seL4_Fault_CapFault_lift
-                              lookup_fault_missing_capability_lift is_cap_fault_def)+
+           apply (clarsimp simp: cfault_rel_def seL4_Fault_CapFault_lift
+                            lookup_fault_missing_capability_lift is_cap_fault_def)+
          apply (clarsimp simp: cap_get_tag_NotificationCap)
          apply (rule cmap_relationE1[OF cmap_relation_ntfn], assumption, erule ko_at_projectKO_opt)
          apply (clarsimp simp: cnotification_relation_def Let_def)

--- a/proof/crefine/ARM/Tcb_C.thy
+++ b/proof/crefine/ARM/Tcb_C.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2023, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -453,8 +454,8 @@ lemma checkCapAt_ccorres:
      apply assumption
     apply (simp only: when_def if_to_top_of_bind)
     apply (rule ccorres_if_lhs)
-     apply (simp add: from_bool_def true_def)
-    apply (simp add: from_bool_def false_def)
+     apply simp
+    apply simp
    apply (simp add: guard_is_UNIV_def)
   apply (clarsimp simp: cte_wp_at_ctes_of)
   done
@@ -576,13 +577,13 @@ lemma invokeTCB_ThreadControl_ccorres:
                 apply (rule checkCapAt_ccorres)
                    apply ceqv
                   apply csymbr
-                  apply (simp add: true_def Collect_True
+                  apply (simp add: Collect_True
                               del: Collect_const)
                   apply (rule ccorres_rhs_assoc)+
                   apply (rule checkCapAt_ccorres)
                      apply ceqv
                     apply csymbr
-                    apply (simp add: true_def Collect_True
+                    apply (simp add: Collect_True
                                 del: Collect_const)
                     apply (simp add: assertDerived_def bind_assoc del: Collect_const)
                     apply (rule ccorres_symb_exec_l)
@@ -623,12 +624,12 @@ lemma invokeTCB_ThreadControl_ccorres:
                        apply (clarsimp split: if_splits)
                       apply (wp empty_fail_stateAssert hoare_case_option_wp | simp del: Collect_const)+
                    apply csymbr
-                   apply (simp add: false_def Collect_False ccorres_cond_iffs
+                   apply (simp add: Collect_False ccorres_cond_iffs
                                del: Collect_const)
                    apply (rule ccorres_pre_getCurThread)
                    apply (rename_tac curThread)
                    apply (rule ccorres_split_nothrow_novcg_dc)
-                      apply (simp add: when_def to_bool_def)
+                      apply (simp add: when_def)
                       apply (rule_tac C'="{s. target = curThread}"
                                       and Q="\<lambda>s. ksCurThread s = curThread"
                                       and Q'=UNIV in ccorres_rewrite_cond_sr)
@@ -650,12 +651,11 @@ lemma invokeTCB_ThreadControl_ccorres:
                                         tcbBuffer_def size_of_def cte_level_bits_def
                                         tcbIPCBufferSlot_def)
                  apply csymbr
-                 apply (simp add: Collect_False false_def
-                             del: Collect_const)
+                 apply (simp add: Collect_False del: Collect_const)
                  apply (rule ccorres_cond_false_seq, simp)
                  apply (rule ccorres_pre_getCurThread)
                  apply (rename_tac curThread)
-                 apply (simp add: when_def to_bool_def)
+                 apply (simp add: when_def)
                  apply (rule ccorres_split_nothrow_novcg_dc)
                     apply (rule_tac C'="{s. target = curThread}"
                                     and Q="\<lambda>s. ksCurThread s = curThread"
@@ -673,7 +673,7 @@ lemma invokeTCB_ThreadControl_ccorres:
                    apply (clarsimp simp: guard_is_UNIV_def)
                   apply (wp hoare_vcg_if_lift2(1) static_imp_wp, strengthen sch_act_wf_weak; wp)
                  apply (clarsimp simp: guard_is_UNIV_def Collect_const_mem)
-                apply (simp add: guard_is_UNIV_def false_def Collect_const_mem)
+                apply (simp add: guard_is_UNIV_def Collect_const_mem)
                 apply (clarsimp simp: ccap_relation_def cap_thread_cap_lift cap_to_H_def)
                apply simp
                apply (rule ccorres_cond_false_seq, simp)
@@ -681,7 +681,7 @@ lemma invokeTCB_ThreadControl_ccorres:
                apply (simp split: option.split_asm)
                apply (rule ccorres_pre_getCurThread)
                apply (rename_tac curThread)
-               apply (simp add: when_def to_bool_def)
+               apply (simp add: when_def)
                apply (rule ccorres_split_nothrow_novcg_dc)
                   apply (rule_tac C'="{s. target = curThread}"
                                   and Q="\<lambda>s. ksCurThread s = curThread"
@@ -762,7 +762,7 @@ lemma invokeTCB_ThreadControl_ccorres:
          apply (clarsimp simp: inQ_def Collect_const_mem cintr_def
                                exception_defs tcb_cnode_index_defs)
          apply (simp add: tcbBuffer_def tcbIPCBufferSlot_def word_sle_def
-                          cte_level_bits_def from_bool_def true_def size_of_def case_option_If2 )
+                          cte_level_bits_def size_of_def case_option_If2 )
          apply (rule conjI)
           apply (clarsimp simp: case_option_If2 if_n_0_0 objBits_simps' valid_cap'_def
                                 capAligned_def word_bits_conv obj_at'_def projectKOs)
@@ -795,33 +795,28 @@ lemma invokeTCB_ThreadControl_ccorres:
            apply (rule checkCapAt_ccorres2)
               apply ceqv
              apply csymbr
-             apply (simp add: true_def Collect_True
-                         del: Collect_const)
+             apply (simp add: Collect_True del: Collect_const)
              apply (rule ccorres_rhs_assoc)+
              apply (rule checkCapAt_ccorres2)
                 apply ceqv
                apply csymbr
-               apply (simp add: true_def Collect_True
-                                assertDerived_def bind_assoc
+               apply (simp add: Collect_True assertDerived_def bind_assoc
                                 ccorres_cond_iffs dc_def[symmetric]
                            del: Collect_const)
                apply (rule ccorres_symb_exec_l)
                   apply (ctac add: cteInsert_ccorres)
                  apply (wp empty_fail_stateAssert hoare_case_option_wp | simp del: Collect_const)+
               apply csymbr
-              apply (simp add: false_def Collect_False ccorres_cond_iffs
+              apply (simp add: Collect_False ccorres_cond_iffs
                           del: Collect_const)
               apply (rule ccorres_return_Skip[unfolded dc_def])
              apply (fastforce simp: guard_is_UNIV_def Kernel_C.tcbVTable_def tcbVTableSlot_def
                                     cte_level_bits_def size_of_def)
             apply csymbr
-            apply (simp add: false_def Collect_False
-                        del: Collect_const)
+            apply (simp add: Collect_False del: Collect_const)
             apply (rule ccorres_cond_false)
             apply (rule ccorres_return_Skip[unfolded dc_def])
-           apply (clarsimp simp: guard_is_UNIV_def false_def
-                                 ccap_relation_def cap_thread_cap_lift
-                                 cap_to_H_def)
+           apply (clarsimp simp: guard_is_UNIV_def ccap_relation_def cap_thread_cap_lift cap_to_H_def)
           apply simp
           apply (rule ccorres_split_throws, rule ccorres_return_C_errorE, simp+)
           apply vcg
@@ -865,34 +860,29 @@ lemma invokeTCB_ThreadControl_ccorres:
           apply (rule checkCapAt_ccorres2)
              apply ceqv
             apply csymbr
-            apply (simp add: true_def Collect_True
-                        del: Collect_const)
+            apply (simp add: Collect_True del: Collect_const)
             apply (rule ccorres_rhs_assoc)+
             apply (rule checkCapAt_ccorres2)
                apply ceqv
               apply csymbr
-              apply (simp add: true_def Collect_True
-                               assertDerived_def bind_assoc
+              apply (simp add: Collect_True assertDerived_def bind_assoc
                                ccorres_cond_iffs dc_def[symmetric]
                           del: Collect_const)
               apply (rule ccorres_symb_exec_l)
                  apply (ctac add: cteInsert_ccorres)
                 apply (wp empty_fail_stateAssert  hoare_case_option_wp | simp del: Collect_const)+
              apply csymbr
-             apply (simp add: false_def Collect_False ccorres_cond_iffs
+             apply (simp add: Collect_False ccorres_cond_iffs
                          del: Collect_const)
              apply (rule ccorres_return_Skip[unfolded dc_def])
             apply (clarsimp simp: guard_is_UNIV_def Collect_const_mem
                                   Kernel_C.tcbCTable_def tcbCTableSlot_def
                                   cte_level_bits_def size_of_def option_to_0_def)
            apply csymbr
-           apply (simp add: false_def Collect_False
-                       del: Collect_const)
+           apply (simp add: Collect_False del: Collect_const)
            apply (rule ccorres_cond_false)
            apply (rule ccorres_return_Skip[unfolded dc_def])
-          apply (clarsimp simp: guard_is_UNIV_def false_def
-                                ccap_relation_def cap_thread_cap_lift
-                                cap_to_H_def)
+          apply (clarsimp simp: guard_is_UNIV_def ccap_relation_def cap_thread_cap_lift cap_to_H_def)
          apply simp
          apply (rule ccorres_split_throws, rule ccorres_return_C_errorE, simp+)
          apply vcg
@@ -910,7 +900,7 @@ lemma invokeTCB_ThreadControl_ccorres:
                 threadSet_cap_to' static_imp_wp | simp)+
      apply (clarsimp simp: guard_is_UNIV_def tcbCTableSlot_def Kernel_C.tcbCTable_def
                            cte_level_bits_def size_of_def word_sle_def option_to_0_def
-                           true_def from_bool_def cintr_def Collect_const_mem)
+                           cintr_def Collect_const_mem)
     apply (simp add: conj_comms)
     apply (wp hoare_case_option_wp threadSet_invs_trivial
               threadSet_cap_to' static_imp_wp | simp)+
@@ -981,7 +971,7 @@ lemma setupReplyMaster_ccorres:
           apply (subst is_aligned_neg_mask_weaken)
             apply (erule is_aligned_tcb_ptr_to_ctcb_ptr)
            apply (simp add: ctcb_size_bits_def)
-          apply (simp add: true_def mask_def to_bool_def)
+          apply simp
          apply simp
         apply (simp add: cmachine_state_relation_def
                          typ_heap_simps'
@@ -1186,9 +1176,8 @@ lemma invokeTCB_CopyRegisters_ccorres:
      apply (fastforce simp: sch_act_wf_weak)
     apply (wpsimp wp: hoare_drop_imp)+
    apply (clarsimp simp add: guard_is_UNIV_def)
-  apply (clarsimp simp: to_bool_def invs_weak_sch_act_wf invs_valid_objs'
+  apply (clarsimp simp: invs_weak_sch_act_wf invs_valid_objs'
                  split: if_split
-                  cong: if_cong
             | rule conjI)+
      apply (clarsimp dest!: global'_no_ex_cap simp: invs'_def valid_state'_def | rule conjI)+
   done
@@ -1623,7 +1612,7 @@ lemma invokeTCB_Suspend_ccorres:
    apply (ctac(no_vcg) add: suspend_ccorres[OF cteDeleteOne_ccorres])
     apply (rule ccorres_return_CE, simp+)[1]
    apply wp
-  apply (clarsimp simp: from_bool_def true_def)
+  apply clarsimp
   apply (auto simp: invs'_def valid_state'_def global'_no_ex_cap)
   done
 
@@ -1637,7 +1626,7 @@ lemma invokeTCB_Resume_ccorres:
    apply (ctac(no_vcg) add: restart_ccorres)
     apply (rule ccorres_return_CE, simp+)[1]
    apply wp
-  apply (clarsimp simp: from_bool_def true_def)
+  apply clarsimp
   done
 
 lemma Arch_decodeTransfer_spec:
@@ -1734,7 +1723,7 @@ shows
              apply (rule ccorres_symb_exec_l[OF _ _ _ empty_fail_getThreadState])
                apply (rule ccorres_if_lhs[OF _ ccorres_False[where P'=UNIV]])
                apply (rule ccorres_if_lhs)
-                apply (simp add: Collect_True true_def whileAnno_def del: Collect_const)
+                apply (simp add: Collect_True whileAnno_def del: Collect_const)
                 apply (rule ccorres_rhs_assoc)+
                 apply csymbr
                 apply (ctac add: lookupIPCBuffer_ccorres)
@@ -2063,7 +2052,7 @@ shows
                                  ARM.badgeRegister_def
                                  "StrictC'_register_defs")
                 apply (vcg exspec=lookupIPCBuffer_modifies)
-               apply (simp add: false_def)
+               apply simp
                apply (ctac(no_vcg) add: setThreadState_ccorres)
                 apply (rule ccorres_from_vcg_throws[where P=\<top> and P'=UNIV])
                 apply (rule allI, rule conseqPre, vcg)
@@ -2093,7 +2082,7 @@ shows
      apply (vcg exspec=suspend_modifies)
     apply vcg
    apply (rule conseqPre, vcg, clarsimp)
-  apply (clarsimp simp: rf_sr_ksCurThread ct_in_state'_def true_def
+  apply (clarsimp simp: rf_sr_ksCurThread ct_in_state'_def
                  split: if_split)
   done
 
@@ -2224,7 +2213,7 @@ lemma decodeReadRegisters_ccorres:
                      valid_tcb_state'_def
               elim!: pred_tcb'_weakenE
               dest!: st_tcb_at_idle_thread')[1]
-  apply (clarsimp simp: from_bool_def word_and_1 split: if_split)
+  apply (clarsimp simp: word_and_1 split: if_split)
   done
 
 lemma decodeWriteRegisters_ccorres:
@@ -2337,8 +2326,7 @@ lemma decodeWriteRegisters_ccorres:
   apply (rule disjCI2)
   apply (clarsimp simp: genericTake_def linorder_not_less)
   apply (subst hd_conv_nth, clarsimp simp: unat_eq_0)
-  apply (clarsimp simp: from_bool_def word_and_1
-                 split: if_split)
+  apply (clarsimp simp: word_and_1 split: if_split)
   done
 
 lemma excaps_map_Nil: "(excaps_map caps = []) = (caps = [])"
@@ -2406,7 +2394,7 @@ lemma decodeCopyRegisters_ccorres:
           apply (simp add: case_bool_If if_to_top_of_bindE
                            if_to_top_of_bind
                       del: Collect_const cong: if_cong)
-          apply (simp add: to_bool_def returnOk_bind Collect_True
+          apply (simp add: returnOk_bind Collect_True
                            ccorres_invocationCatch_Inr performInvocation_def
                       del: Collect_const)
           apply (ctac add: setThreadState_ccorres)
@@ -2611,7 +2599,7 @@ lemma slotCapLongRunningDelete_ccorres:
        apply (clarsimp simp: typ_heap_simps cap_get_tag_isCap
                              from_bool_0
                       dest!: ccte_relation_ccap_relation)
-       apply (simp add: from_bool_def false_def true_def
+       apply (simp add: from_bool_def
                  split: bool.split)
        apply (auto simp add: longRunningDelete_def isCap_simps
                  split: capability.split)[1]
@@ -2619,13 +2607,12 @@ lemma slotCapLongRunningDelete_ccorres:
       apply (wp hoare_drop_imps isFinalCapability_inv)
      apply (clarsimp simp: Collect_const_mem guard_is_UNIV_def)
      apply (rename_tac rv')
-     apply (case_tac rv'; clarsimp simp: false_def true_def)
+     apply (case_tac rv'; clarsimp simp: false_def)
     apply vcg
    apply (rule conseqPre, vcg, clarsimp)
   apply (clarsimp simp: cte_wp_at_ctes_of)
   apply (erule(1) cmap_relationE1 [OF cmap_relation_cte])
-  apply (clarsimp simp: typ_heap_simps cap_get_tag_isCap
-                        from_bool_def false_def map_comp_Some_iff
+  apply (clarsimp simp: typ_heap_simps cap_get_tag_isCap map_comp_Some_iff
                  dest!: ccte_relation_ccap_relation)
   done
 
@@ -2640,7 +2627,7 @@ lemma isValidVTableRoot_spec:
     {s'. ret__unsigned_long_' s' = from_bool (isValidVTableRoot_C (cap_' s))}"
   apply vcg
   apply (clarsimp simp: isValidVTableRoot_C_def if_1_0_0 from_bool_0)
-  apply (simp add: from_bool_def to_bool_def false_def split: if_split)
+  apply (simp add: to_bool_def split: if_split)
   done
 
 lemma isValidVTableRoot_conv:
@@ -2654,9 +2641,8 @@ lemma isValidVTableRoot_conv:
    apply (case_tac "cap_get_tag cap' = scast cap_page_directory_cap")
     apply (clarsimp split: arch_capability.split simp: isCap_simps)
     apply (clarsimp simp: ccap_relation_def map_option_Some_eq2
-                          cap_page_directory_cap_lift cap_to_H_def
-                          from_bool_def)
-    apply (clarsimp simp: to_bool_def split: if_split)
+                          cap_page_directory_cap_lift cap_to_H_def)
+    apply (clarsimp split: if_split)
    apply (clarsimp simp: cap_get_tag_isCap cap_get_tag_isCap_ArchObject)
    apply (simp split: arch_capability.split_asm add: isCap_simps)
   apply (case_tac "cap_get_tag cap' = scast cap_page_directory_cap")
@@ -2967,7 +2953,7 @@ lemma decodeTCBConfigure_ccorres:
                                           in ccorres_from_vcg[where P=\<top>])
                            apply (rule allI, rule conseqPre, vcg)
                            apply (subgoal_tac "extraCaps \<noteq> []")
-                            apply (clarsimp simp: returnOk_def return_def hd_conv_nth false_def)
+                            apply (clarsimp simp: returnOk_def return_def hd_conv_nth)
                             apply fastforce
                            apply clarsimp
                           apply ceqv
@@ -2994,7 +2980,7 @@ lemma decodeTCBConfigure_ccorres:
                                                 in ccorres_from_vcg[where P=\<top>])
                                 apply (rule allI, rule conseqPre, vcg)
                                 apply (clarsimp simp: returnOk_def return_def
-                                                      hd_drop_conv_nth2 false_def)
+                                                      hd_drop_conv_nth2)
                                 apply fastforce
                                apply ceqv
                               apply (ctac add: ccorres_injection_handler_csum1
@@ -3453,9 +3439,9 @@ lemma decodeSetSchedParams_ccorres:
                    val="from_bool (length args < 2 \<or> length extraCaps = 0)" in
                    ccorres_symb_exec_r_known_rv)
       apply vcg
-      apply (auto simp: interpret_excaps_test_null excaps_map_def from_bool_def unat_eq_0
-                  split: bool.splits)[1]
-       apply (unat_arith+)[2]
+      apply (force simp: interpret_excaps_test_null excaps_map_def from_bool_def unat_eq_0
+                         unat_arith_simps
+                  split: bool.splits if_splits)
      apply ceqv
     apply clarsimp
     apply (wpc,
@@ -3940,7 +3926,7 @@ lemma decodeBindNotification_ccorres:
       apply csymbr
       apply (clarsimp simp add: if_to_top_of_bind to_bool_eq_0[symmetric] simp del: Collect_const)
       apply (rule ccorres_Cond_rhs_Seq)
-       apply (clarsimp simp: to_bool_def throwError_bind invocationCatch_def)
+       apply (clarsimp simp: throwError_bind invocationCatch_def)
        apply (rule ccorres_from_vcg_split_throws[where P=\<top> and P'=UNIV])
         apply vcg
        apply (rule conseqPre, vcg)
@@ -3963,7 +3949,7 @@ lemma decodeBindNotification_ccorres:
          apply (clarsimp simp: typ_heap_simps cnotification_relation_def Let_def
                                valid_ntfn'_def)
          apply (case_tac "ntfnObj ntfn", simp_all add: isWaitingNtfn_def option_to_ctcb_ptr_def
-                             false_def true_def split: option.split_asm if_split,
+                                                split: option.split_asm if_split,
                          auto simp: neq_Nil_conv tcb_queue_relation'_def tcb_at_not_NULL[symmetric]
                                     tcb_at_not_NULL)[1]
         apply ceqv
@@ -4027,8 +4013,8 @@ lemma decodeBindNotification_ccorres:
        apply (rule conseqPre, vcg)
        apply (clarsimp simp: throwError_def return_def syscall_error_rel_def
                              syscall_error_to_H_cases exception_defs)
-      apply (clarsimp simp add: guard_is_UNIV_def isWaitingNtfn_def from_bool_0
-                                ThreadState_Restart_def mask_def true_def
+      apply (clarsimp simp add: guard_is_UNIV_def isWaitingNtfn_def
+                                ThreadState_Restart_def mask_def
                                 rf_sr_ksCurThread capTCBPtr_eq)
      apply (simp add: hd_conv_nth bindE_bind_linearise nTFN_case_If_ptr throwError_bind invocationCatch_def)
      apply (rule ccorres_from_vcg_split_throws[where P=\<top> and P'=UNIV])
@@ -4214,7 +4200,7 @@ lemma decodeSetSpace_ccorres:
                                  in ccorres_from_vcg[where P=\<top>])
                      apply (rule allI, rule conseqPre, vcg)
                      apply (subgoal_tac "extraCaps \<noteq> []")
-                      apply (clarsimp simp: returnOk_def return_def hd_conv_nth false_def)
+                      apply (clarsimp simp: returnOk_def return_def hd_conv_nth)
                       apply fastforce
                      apply clarsimp
                     apply ceqv
@@ -4241,8 +4227,7 @@ lemma decodeSetSpace_ccorres:
                            apply (rule_tac P'="{s. vRootCap = vRootCap_' s}"
                                   in ccorres_from_vcg[where P=\<top>])
                            apply (rule allI, rule conseqPre, vcg)
-                           apply (clarsimp simp: returnOk_def return_def
-                                                 hd_drop_conv_nth2 false_def)
+                           apply (clarsimp simp: returnOk_def return_def hd_drop_conv_nth2)
                            apply fastforce
                           apply ceqv
                          apply (ctac add: ccorres_injection_handler_csum1
@@ -4355,10 +4340,7 @@ lemma decodeSetSpace_ccorres:
                         "StrictC'_thread_state_defs" mask_eq_iff_w2p word_size)
   apply (simp add: word_sle_def cap_get_tag_isCap)
   apply (subgoal_tac "args \<noteq> []")
-   apply (clarsimp simp: hd_conv_nth)
-   apply (drule sym, simp, simp add: true_def from_bool_0)
-   apply (clarsimp simp: objBits_defs)
-   apply fastforce
+   apply (fastforce simp: hd_conv_nth objBits_defs)
   apply clarsimp
   done
 

--- a/proof/crefine/ARM/Wellformed_C.thy
+++ b/proof/crefine/ARM/Wellformed_C.thy
@@ -243,40 +243,6 @@ definition
                    | Some cap \<Rightarrow> Some \<lparr> cap_CL = cap,
                                        cteMDBNode_CL = mdb_node_lift (cteMDBNode_C c) \<rparr>"
 
-(* this is slightly weird, but the bitfield generator
-   masks everything with the expected bit length.
-   So we do that here too. *)
-definition
-  to_bool_bf :: "'a::len word \<Rightarrow> bool" where
-  "to_bool_bf w \<equiv> (w && mask 1) = 1"
-
-lemma to_bool_bf_0 [simp]: "\<not>to_bool_bf 0"
-  by (simp add: to_bool_bf_def)
-
-lemma to_bool_bf_1 [simp]: "to_bool_bf 1"
-  by (simp add: to_bool_bf_def mask_def)
-
-lemma to_bool_bf_and [simp]:
-  "to_bool_bf (a && b) = (to_bool_bf a \<and> to_bool_bf (b::word32))"
-  apply (clarsimp simp: to_bool_bf_def)
-  apply (rule iffI)
-   apply (subst (asm) bang_eq)
-   apply (simp add: word_size)
-   apply (rule conjI)
-    apply (rule word_eqI)
-    apply (auto simp add: word_size)[1]
-   apply (rule word_eqI)
-   apply (auto simp add: word_size)[1]
-  apply clarsimp
-  apply (rule word_eqI)
-  apply (subst (asm) bang_eq)+
-  apply (auto simp add: word_size)[1]
-  done
-
-lemma to_bool_bf_to_bool_mask:
-  "w && mask (Suc 0) = w \<Longrightarrow> to_bool_bf w = to_bool (w::word32)"
-  by (metis One_nat_def mask_eq1_nochoice fold_eq_0_to_bool mask_1 to_bool_bf_0 to_bool_bf_def)
-
 definition
   mdb_node_to_H :: "mdb_node_CL \<Rightarrow> mdbnode"
   where

--- a/proof/crefine/ARM_HYP/Arch_C.thy
+++ b/proof/crefine/ARM_HYP/Arch_C.thy
@@ -4310,7 +4310,7 @@ lemma decodeARMMMUInvocation_ccorres:
                   elim!: ccap_relationE split: if_split_asm)
    apply (clarsimp split: list.split)
   apply (clarsimp simp: cap_lift_asid_pool_cap cap_lift_page_directory_cap
-                        cap_to_H_def cap_page_directory_cap_lift_def
+                        cap_to_H_def cap_page_directory_cap_lift_def to_bool_def
                  elim!: ccap_relationE split: if_split_asm)
   done
 

--- a/proof/crefine/ARM_HYP/Arch_C.thy
+++ b/proof/crefine/ARM_HYP/Arch_C.thy
@@ -76,7 +76,7 @@ lemma performPageTableInvocationUnmap_ccorres:
          apply wp
         apply (simp del: Collect_const)
         apply (vcg exspec=unmapPageTable_modifies)
-       apply (simp add: to_bool_def)
+       apply simp
        apply (rule ccorres_return_Skip')
       apply (simp add: cap_get_tag_isCap_ArchObject[symmetric])
       apply (clarsimp simp: cap_lift_page_table_cap cap_to_H_def
@@ -835,7 +835,7 @@ lemma decodeARMPageTableInvocation_ccorres:
           apply vcg
          apply (rule conseqPre, vcg)
          apply (clarsimp simp: throwError_def return_def syscall_error_rel_def
-                               syscall_error_to_H_cases exception_defs false_def)
+                               syscall_error_to_H_cases exception_defs)
          apply (erule lookup_failure_rel_fault_lift[rotated])
          apply (simp add: exception_defs)
         apply simp
@@ -916,8 +916,8 @@ lemma checkVPAlignment_spec:
   apply (clarsimp simp: mask_eq_iff_w2p word_size)
   apply (rule conjI)
    apply (simp add: pageBitsForSize_def split: vmpage_size.split)
-  apply (simp add: from_bool_def vmsz_aligned'_def is_aligned_mask
-                   mask_def split: if_split)
+  apply (simp add: vmsz_aligned'_def is_aligned_mask mask_def
+            split: if_split)
   done
 
 definition
@@ -1055,9 +1055,9 @@ lemma createSafeMappingEntries_PDE_ccorres:
     apply (clarsimp simp: pde_get_tag_alt cpde_relation_pde_case
                           pde_tag_defs fst_throwError_returnOk
                           pde_range_relation_def ptr_range_to_list_def
-                          exception_defs isRight_def from_bool_def[where b=True]
+                          exception_defs isRight_def
                           syscall_error_rel_def syscall_error_to_H_cases)
-    apply (clarsimp simp: cpde_relation_def true_def false_def)
+    apply (clarsimp simp: cpde_relation_def)
    apply (rule ccorres_Cond_rhs)
     apply (simp del: Collect_const)
     apply (rule ccorres_rhs_assoc)+
@@ -1097,7 +1097,7 @@ lemma createSafeMappingEntries_PDE_ccorres:
                     apply (rule allI, rule conseqPre, vcg)
                     apply (clarsimp simp: if_1_0_0 return_def typ_heap_simps Let_def)
                     apply (simp add: isPageTablePDE_def isSectionPDE_def
-                                     cpde_relation_pde_case from_bool_def)
+                                     cpde_relation_pde_case)
                     apply (intro impI conjI disjCI2, simp_all add: array_assertion_shrink_right)[1]
                     apply (clarsimp simp: pde_tag_defs  split: if_split bool.split)
                     apply (frule pde_pde_section_size_0_1[simplified pde_tag_defs, simplified], simp)
@@ -1162,7 +1162,7 @@ lemma createSafeMappingEntries_PDE_ccorres:
     ARMSectionBits_def word_0_sle_from_less
     table_bits_defs)
   apply (rule conjI)
-   apply (simp add: cpde_relation_def true_def false_def)
+   apply (simp add: cpde_relation_def)
   apply (simp add: superSectionPDEOffsets_def table_bits_defs upto_enum_step_def
                    upto_enum_def comp_def del: upt_Suc split: if_split)
   done
@@ -1267,8 +1267,7 @@ lemma createSafeMappingEntries_PTE_ccorres:
              apply (erule cmap_relationE1[OF rf_sr_cpte_relation], erule ko_at_projectKO_opt)
              apply (clarsimp simp: typ_heap_simps cpte_relation_def Let_def)
              apply (case_tac rva
-                    ; fastforce simp: if_1_0_0 pte_lifts isLargePagePTE_def false_def true_def
-                                     pte_pte_small_lift_def)
+                    ; fastforce simp: pte_lifts isLargePagePTE_def pte_pte_small_lift_def)
             apply ceqv
            apply (clarsimp simp del: Collect_const)
            (* the if/IF condition is now the same on both sides *)
@@ -1295,7 +1294,7 @@ lemma createSafeMappingEntries_PTE_ccorres:
          apply vcg
         apply (rule conseqPre, vcg)
         apply (clarsimp simp: fst_throwError_returnOk syscall_error_to_H_cases
-                              syscall_error_rel_def exception_defs false_def)
+                              syscall_error_rel_def exception_defs)
         apply (erule lookup_failure_rel_fault_lift[rotated])
         apply (simp add: exception_defs)
        apply simp
@@ -1391,7 +1390,7 @@ lemma createSafeMappingEntries_PTE_ccorres:
          apply vcg
         apply (rule conseqPre, vcg)
         apply (clarsimp simp: fst_throwError_returnOk syscall_error_rel_def
-                              syscall_error_to_H_cases exception_defs false_def)
+                              syscall_error_to_H_cases exception_defs)
         apply (erule lookup_failure_rel_fault_lift[rotated])
         apply (simp add: exception_defs)
        apply (wp injection_wp[OF refl])
@@ -1410,8 +1409,7 @@ lemma createSafeMappingEntries_PTE_ccorres:
                         from_bool_mask_simp[unfolded mask_def, simplified])
   apply (clarsimp simp: typ_heap_simps pte_range_relation_def
                         ptr_range_to_list_def upto_enum_word)
-  apply (simp add: cpte_relation_def true_def false_def pte_tag_defs if_1_0_0 table_bits_defs
-                    largePagePTEOffsets_def)
+  apply (simp add: cpte_relation_def pte_tag_defs table_bits_defs largePagePTEOffsets_def)
   apply (auto simp: vmsz_aligned'_def upto_enum_step_def upto_enum_def)[1]
   done
 
@@ -1480,9 +1478,8 @@ lemma pteCheckIfMapped_ccorres:
   apply clarsimp
   apply (rule conseqPre, vcg)
   apply (clarsimp simp: typ_heap_simps' return_def)
-  apply (case_tac rv, simp_all add: to_bool_def isInvalidPTE_def pte_tag_defs pte_pte_invalid_def
-                                    cpte_relation_def pte_get_tag_def
-                                    pte_lift_def Let_def
+  apply (case_tac rv, simp_all add: isInvalidPTE_def pte_tag_defs pte_pte_invalid_def
+                                    cpte_relation_def pte_get_tag_def pte_lift_def Let_def
                              split: if_split_asm)
   done
 
@@ -1508,7 +1505,7 @@ lemma pdeCheckIfMapped_ccorres:
   apply clarsimp
   apply (rule conseqPre, vcg)
   apply (clarsimp simp: typ_heap_simps' return_def)
-  apply (case_tac rv, simp_all add: to_bool_def cpde_relation_invalid isInvalidPDE_def
+  apply (case_tac rv, simp_all add: cpde_relation_invalid isInvalidPDE_def
                              split: if_split)
   done
 
@@ -1702,7 +1699,7 @@ lemma performPageInvocationMapPTE_ccorres:
              apply (rule allI, rule conseqPre, vcg)
              apply (clarsimp simp:return_def)
             apply (rule wp_post_taut)
-           apply (simp add: to_bool_def)
+           apply simp
            apply (rule_tac P=\<top> and P'=UNIV in ccorres_from_vcg_throws)
            apply (rule allI, rule conseqPre, vcg)
            apply (clarsimp simp:return_def)
@@ -2080,7 +2077,7 @@ lemma performPageInvocationMapPDE_ccorres:
              apply (rule allI, rule conseqPre, vcg)
              apply (clarsimp simp:return_def)
             apply (rule wp_post_taut)
-           apply (simp add: to_bool_def)
+           apply simp
            apply (rule_tac P=\<top> and P'=UNIV in ccorres_from_vcg_throws)
            apply (rule allI, rule conseqPre, vcg)
            apply (clarsimp simp:return_def)
@@ -2398,7 +2395,7 @@ lemma setVMRootForFlush_ccorres2:
        apply (ctac (no_vcg) add: armv_contextSwitch_ccorres)
         apply (ctac add: ccorres_return_C)
        apply wp
-      apply (simp add: true_def from_bool_def)
+      apply simp
       apply vcg
      apply (rule conseqPre, vcg)
      apply (simp add: Collect_const_mem)
@@ -2408,14 +2405,12 @@ lemma setVMRootForFlush_ccorres2:
    apply vcg
   apply (clarsimp simp: Collect_const_mem if_1_0_0 word_sle_def
                         ccap_rights_relation_def cap_rights_to_H_def
-                        mask_def[where n="Suc 0"] true_def to_bool_def
-                        allRights_def size_of_def cte_level_bits_def
+                        mask_def[where n="Suc 0"] allRights_def size_of_def cte_level_bits_def
                         tcbVTableSlot_def Kernel_C.tcbVTable_def invs'_invs_no_cicd)
   apply (clarsimp simp: rf_sr_ksCurThread ptr_val_tcb_ptr_mask' [OF tcb_at_invs'])
   apply (frule cte_at_tcb_at_16'[OF tcb_at_invs'], clarsimp simp: cte_wp_at_ctes_of)
   apply (rule cmap_relationE1[OF cmap_relation_cte], assumption+)
-  apply (clarsimp simp: false_def true_def from_bool_def
-                        typ_heap_simps' ptr_add_assertion_positive)
+  apply (clarsimp simp: typ_heap_simps' ptr_add_assertion_positive)
   apply (clarsimp simp: tcb_cnode_index_defs
                         rf_sr_tcb_ctes_array_assertion2[OF _ tcb_at_invs',
                             THEN array_assertion_shrink_right])
@@ -2444,12 +2439,12 @@ where
 
 lemma resolve_ret_rel_None[simp]:
   "resolve_ret_rel None y = (valid_C y = scast false)"
-  by (clarsimp simp: resolve_ret_rel_def o_def to_option_def false_def to_bool_def split: if_splits)
+  by (clarsimp simp: resolve_ret_rel_def o_def to_option_def to_bool_def split: if_splits)
 
 lemma resolve_ret_rel_Some:
   "\<lbrakk>valid_C y = scast true;  frameSize_C y = framesize_from_H (fst x); snd x = frameBase_C y\<rbrakk>
    \<Longrightarrow> resolve_ret_rel (Some x) y"
-  by (clarsimp simp: resolve_ret_rel_def o_def to_option_def true_def)
+  by (clarsimp simp: resolve_ret_rel_def o_def to_option_def)
 
 lemma pte_get_tag_exhaust:
   "pte_get_tag pte = 0 \<or> pte_get_tag pte = 1 \<or>  pte_get_tag pte = 2 \<or>  pte_get_tag pte = 3"
@@ -2540,12 +2535,12 @@ lemma resolveVAddr_ccorres:
         prefer 2
         apply (simp add: mask_def ARMLargePage_def)
        \<comment> \<open>reduce to resolve_ret_rel goals first\<close>
-       apply (clarsimp simp: fst_return pte_get_tag_alt true_def false_def pt_bits_def pte_bits_def
+       apply (clarsimp simp: fst_return pte_get_tag_alt pt_bits_def pte_bits_def
                       split: pte.splits)
        apply (safe ; clarsimp simp: cpte_relation_get_tag_simps c_pages_noteq)
        (* 4 subgoals *)
        apply (fastforce simp: cpte_relation_def pte_pte_small_lift_def pte_lift_def Let_def mask_def
-                              valid_mapping'_def  true_def framesize_from_H_simps page_base_def
+                              valid_mapping'_def framesize_from_H_simps page_base_def
                         split: if_splits intro!: resolve_ret_rel_Some
                         dest!: is_aligned_neg_mask_eq)+
        done
@@ -2562,12 +2557,12 @@ lemma resolveVAddr_ccorres:
    apply clarsimp
    apply (clarsimp simp: isPageTablePDE_def pde_get_tag_alt pde_tag_defs cpde_relation_def
                           fst_return typ_heap_simps framesize_from_H_simps
-                          pde_pde_section_lift_def true_def
+                          pde_pde_section_lift_def
                    intro: resolve_ret_rel_Some
                    split: pde.splits)
      subgoal
        apply (fastforce simp: cpte_relation_def pte_pte_small_lift_def pte_lift_def Let_def mask_def
-                              valid_mapping'_def  true_def framesize_from_H_simps
+                              valid_mapping'_def framesize_from_H_simps
                         split: if_splits intro!: resolve_ret_rel_Some
                         dest!: is_aligned_neg_mask_eq)+
        done
@@ -2576,7 +2571,7 @@ lemma resolveVAddr_ccorres:
        apply (rule conjI)
         apply (clarsimp simp: gen_framesize_to_H_def split: if_splits)
        apply (rule resolve_ret_rel_Some;
-              clarsimp simp: true_def framesize_from_H_simps ARMSuperSection_def)
+              clarsimp simp: framesize_from_H_simps ARMSuperSection_def)
        apply (clarsimp simp: page_base_def gen_framesize_to_H_def ARMSmallPage_def ARMLargePage_def
                              ARMSection_def mask_def)
        done
@@ -2817,7 +2812,7 @@ lemma decodeARMFrameInvocation_ccorres:
         apply vcg
        apply (rule conseqPre, vcg)
        apply (clarsimp simp: throwError_def return_def syscall_error_rel_def
-                             syscall_error_to_H_cases exception_defs false_def)
+                             syscall_error_to_H_cases exception_defs)
        apply (erule lookup_failure_rel_fault_lift[rotated])
        apply (simp add: exception_defs)
       apply (wp injection_wp[OF refl])
@@ -3023,7 +3018,7 @@ lemma decodeARMFrameInvocation_ccorres:
                 apply (rule ccorres_if_cond_throws[rotated -1, where Q=\<top> and Q'=\<top>])
                    apply vcg
                   apply (clarsimp simp: cap_lift_page_directory_cap cap_to_H_def
-                                        to_bool_def cap_page_directory_cap_lift_def
+                                        cap_page_directory_cap_lift_def
                                  elim!: ccap_relationE split: if_split)
                  apply (rule syscall_error_throwError_ccorres_n)
                  apply (simp add: syscall_error_to_H_cases)
@@ -3099,7 +3094,7 @@ lemma decodeARMFrameInvocation_ccorres:
                apply (rule_tac P'="{s. find_ret = errstate s}" in ccorres_from_vcg_throws[where P=\<top>])
                apply (rule allI, rule conseqPre, vcg)
                apply (clarsimp simp: fst_throwError_returnOk exception_defs syscall_error_rel_def
-                                     syscall_error_to_H_cases false_def)
+                                     syscall_error_to_H_cases)
                apply (erule lookup_failure_rel_fault_lift[rotated], simp add: exception_defs)
               apply simp
               apply (wp injection_wp[OF refl] | wp (once) hoare_drop_imps)+
@@ -3375,9 +3370,9 @@ lemma decodeARMPageDirectoryInvocation_ccorres:
       apply (rule ccorres_add_return)
       apply (ctac add: getSyscallArg_ccorres_foo[where args=args and n=1 and buffer=buffer])
         apply (simp add: invocationCatch_use_injection_handler
-                       injection_bindE[OF refl refl] bindE_assoc
-                       injection_handler_returnOk injection_handler_whenE
-                       lookupError_injection)
+                         injection_bindE[OF refl refl] bindE_assoc
+                         injection_handler_returnOk injection_handler_whenE
+                         lookupError_injection)
         apply (simp add:if_to_top_of_bindE)
         apply (rule ccorres_if_cond_throws[rotated -1, where Q=\<top> and Q'=\<top>])
            apply vcg
@@ -3402,11 +3397,11 @@ lemma decodeARMPageDirectoryInvocation_ccorres:
         apply (simp add:if_to_top_of_bind if_to_top_of_bindE)
         apply (rule ccorres_if_cond_throws[rotated -1,where Q=\<top> and Q'=\<top>])
            apply vcg
-          apply (clarsimp dest!:cap_lift_page_directory_cap
-                    simp : cap_page_directory_cap_lift_def
-                           cap_to_H_def to_bool_def Let_def
-                    elim!: ccap_relationE
-                    split: cap_CL.splits if_splits)
+          apply (clarsimp simp: cap_page_directory_cap_lift_def
+                                cap_to_H_def to_bool_def Let_def
+                         dest!: cap_lift_page_directory_cap
+                         elim!: ccap_relationE
+                         split: cap_CL.splits if_splits)
          apply (simp add:injection_handler_throwError)
          apply (rule syscall_error_throwError_ccorres_n)
          apply (simp add:syscall_error_to_H_cases)
@@ -3440,16 +3435,17 @@ lemma decodeARMPageDirectoryInvocation_ccorres:
                 apply simp
                apply simp
               apply ceqv
-             apply (simp add:injection_handler_If
-               injection_handler_returnOk if_to_top_of_bind if_to_top_of_bindE)
+             apply (simp add: injection_handler_If
+                              injection_handler_returnOk if_to_top_of_bind if_to_top_of_bindE)
              apply (rule_tac Q=\<top> and Q'=\<top> in ccorres_if_cond_throws[rotated -1])
                 apply vcg
-               apply (clarsimp simp:resolve_ret_rel_def to_bool_def to_option_def
-                        rel_option_alt_def not_le split:option.splits if_splits)
-              apply (simp add:invocationCatch_def ARM_HYP_H.performInvocation_def
-                performInvocation_def performARMMMUInvocation_def)
-              apply (simp add:performPageDirectoryInvocation_def
-                liftE_case_sum liftE_bindE liftE_alternative)
+               apply (clarsimp simp: resolve_ret_rel_def to_bool_def to_option_def
+                                     rel_option_alt_def not_le
+                              split: option.splits if_splits)
+              apply (simp add: invocationCatch_def ARM_HYP_H.performInvocation_def
+                               performInvocation_def performARMMMUInvocation_def)
+              apply (simp add: performPageDirectoryInvocation_def
+                               liftE_case_sum liftE_bindE liftE_alternative)
               apply (ctac add: setThreadState_ccorres)
                 apply (rule ccorres_alternative2)
                 apply (simp add:returnOk_liftE[symmetric])
@@ -3458,12 +3454,11 @@ lemma decodeARMPageDirectoryInvocation_ccorres:
               apply (vcg exspec=setThreadState_modifies)
              apply csymbr
              apply csymbr
-             apply (simp add:injection_handler_whenE
-               injection_bindE[OF refl refl] bindE_assoc
-               if_to_top_of_bindE injection_handler_throwError
-               injection_handler_returnOk injection_handler_stateAssert_relocate
-               checkValidMappingSize_def
-             )
+             apply (simp add: injection_handler_whenE
+                              injection_bindE[OF refl refl] bindE_assoc
+                              if_to_top_of_bindE injection_handler_throwError
+                              injection_handler_returnOk injection_handler_stateAssert_relocate
+                              checkValidMappingSize_def)
              apply (rule ccorres_stateAssert)
              apply (rule_tac Q=\<top> and Q'=\<top> in ccorres_if_cond_throws[rotated -1])
                 apply vcg
@@ -3474,7 +3469,7 @@ lemma decodeARMPageDirectoryInvocation_ccorres:
               apply (rule ccorres_from_vcg_throws[where P=\<top> and P'=UNIV])
               apply (rule allI, rule conseqPre, vcg)
               apply (clarsimp simp: throwError_def return_def syscall_error_rel_def exception_defs
-                                    syscall_error_to_H_cases false_def)
+                                    syscall_error_to_H_cases)
               apply (clarsimp simp: page_base_def resolve_ret_rel_def rel_option_alt_def to_option_def
                                     mask_def[unfolded shiftl_1,symmetric]
                               split: option.splits if_splits)
@@ -3540,7 +3535,7 @@ lemma decodeARMPageDirectoryInvocation_ccorres:
             apply vcg
            apply (rule conseqPre, vcg)
            apply (clarsimp simp: throwError_def return_def syscall_error_rel_def
-                                 syscall_error_to_H_cases exception_defs false_def)
+                                 syscall_error_to_H_cases exception_defs)
            apply (erule lookup_failure_rel_fault_lift[rotated])
            apply (simp add: exception_defs)
           apply simp
@@ -3558,99 +3553,96 @@ lemma decodeARMPageDirectoryInvocation_ccorres:
     apply (simp add:isPDFlush_fold throwError_invocationCatch)
     apply (rule syscall_error_throwError_ccorres_n)
     apply (clarsimp simp: syscall_error_to_H_cases)
-   apply (clarsimp simp:ex_cte_cap_wp_to'_def invs_arch_state'
-     invs_valid_objs' invs_sch_act_wf' tcb_at_invs')
+   apply (clarsimp simp: ex_cte_cap_wp_to'_def invs_arch_state'
+                         invs_valid_objs' invs_sch_act_wf' tcb_at_invs')
   apply (clarsimp simp: isCap_simps cte_wp_at_ctes_of invs_no_0_obj')
   apply (frule ctes_of_valid', clarsimp)
   apply (drule_tac t="cteCap cte" in sym, simp)
   apply (intro conjI)
          apply (clarsimp simp: sysargs_rel_to_n word_le_nat_alt mask_def
-           linorder_not_less linorder_not_le valid_cap_simps')
+                               linorder_not_less linorder_not_le valid_cap_simps')
          apply (clarsimp dest!:ct_active_runnable')
          apply (simp add:ct_in_state'_def)
          apply (erule pred_tcb'_weakenE)
           apply (case_tac st,simp+)
         apply (clarsimp simp: sysargs_rel_to_n word_le_nat_alt mask_def
-          linorder_not_less linorder_not_le valid_cap_simps')
+                              linorder_not_less linorder_not_le valid_cap_simps')
         apply (clarsimp dest!:ct_active_runnable')
         apply (simp add:ct_in_state'_def)
         apply (erule pred_tcb'_weakenE)
         apply (case_tac st,simp+)
        apply (clarsimp simp: sysargs_rel_to_n word_le_nat_alt mask_def
-         linorder_not_less linorder_not_le valid_cap_simps')
+                             linorder_not_less linorder_not_le valid_cap_simps')
        apply (clarsimp dest!:ct_active_runnable')
        apply (simp add:ct_in_state'_def)
        apply (erule pred_tcb'_weakenE)
        apply (case_tac st,simp+)
       apply (clarsimp simp: sysargs_rel_to_n word_le_nat_alt mask_def
-        linorder_not_less linorder_not_le valid_cap_simps')
+                            linorder_not_less linorder_not_le valid_cap_simps')
       apply (clarsimp dest!:ct_active_runnable')
       apply (simp add:ct_in_state'_def)
       apply (erule pred_tcb'_weakenE)
       apply (case_tac st,simp+)
      apply (frule cap_get_tag_isCap_unfolded_H_cap(15))
      apply (clarsimp simp: cap_lift_page_directory_cap hd_conv_nth
-                        cap_lift_page_table_cap typ_heap_simps'
+                           cap_lift_page_table_cap typ_heap_simps'
+                           cap_to_H_def cap_page_directory_cap_lift_def
+                           to_bool_def cap_page_table_cap_lift_def
+                           typ_heap_simps' shiftl_t2n[where n=2] field_simps
+                    elim!: ccap_relationE)
+     apply (intro conjI impI allI)
+      apply (clarsimp simp: ThreadState_Restart_def less_mask_eq rf_sr_ksCurThread
+                            resolve_ret_rel_def framesize_from_to_H framesize_from_H_mask2
+                            to_option_def rel_option_alt_def to_bool_def typ_heap_simps'
+                     split: option.splits if_splits
+             | fastforce simp: mask_def
+             | rule flushtype_relation_triv, simp add: isPageFlush_def isPDFlushLabel_def
+             | rule word_of_nat_less, simp add: pbfs_less)+
+    apply (frule cap_get_tag_isCap_unfolded_H_cap(15))
+    apply (clarsimp simp: cap_lift_page_directory_cap hd_conv_nth
+                          cap_lift_page_table_cap
+                          cap_to_H_def cap_page_directory_cap_lift_def
+                          cap_page_table_cap_lift_def
+                          typ_heap_simps' shiftl_t2n[where n=2] field_simps
+                   elim!: ccap_relationE)
+    apply (intro conjI impI allI)
+     apply (clarsimp simp: ThreadState_Restart_def less_mask_eq rf_sr_ksCurThread
+                           resolve_ret_rel_def framesize_from_to_H framesize_from_H_mask2
+                           to_option_def rel_option_alt_def to_bool_def typ_heap_simps'
+                    split: option.splits if_splits
+            | fastforce simp: mask_def
+            | rule flushtype_relation_triv, simp add: isPageFlush_def isPDFlushLabel_def
+            | rule word_of_nat_less, simp add: pbfs_less)+
+   apply (frule cap_get_tag_isCap_unfolded_H_cap(15))
+   apply (clarsimp simp: cap_lift_page_directory_cap hd_conv_nth
+                         cap_lift_page_table_cap
+                         cap_to_H_def cap_page_directory_cap_lift_def
+                         cap_page_table_cap_lift_def
+                         typ_heap_simps' shiftl_t2n[where n=2] field_simps
+                  elim!: ccap_relationE)
+   apply (intro conjI impI allI)
+    apply (clarsimp simp: ThreadState_Restart_def less_mask_eq rf_sr_ksCurThread
+                          resolve_ret_rel_def framesize_from_to_H framesize_from_H_mask2
+                          to_option_def rel_option_alt_def to_bool_def typ_heap_simps'
+                   split: option.splits if_splits
+           | fastforce simp: mask_def
+           | rule flushtype_relation_triv, simp add: isPageFlush_def isPDFlushLabel_def
+           | rule word_of_nat_less, simp add: pbfs_less)+ (* slow 20 secs *)
+  apply (frule cap_get_tag_isCap_unfolded_H_cap(15))
+  apply (clarsimp simp: cap_lift_page_directory_cap hd_conv_nth
+                        cap_lift_page_table_cap
                         cap_to_H_def cap_page_directory_cap_lift_def
                         to_bool_def cap_page_table_cap_lift_def
                         typ_heap_simps' shiftl_t2n[where n=2] field_simps
                  elim!: ccap_relationE)
-     apply (intro conjI impI allI)
-      apply (clarsimp simp:ThreadState_Restart_def less_mask_eq rf_sr_ksCurThread
-        resolve_ret_rel_def framesize_from_to_H framesize_from_H_mask2
-        to_option_def rel_option_alt_def to_bool_def typ_heap_simps'
-        split:option.splits if_splits
-      | fastforce simp: mask_def
-      | rule flushtype_relation_triv,simp add:isPageFlush_def isPDFlushLabel_def
-      | rule word_of_nat_less,simp add: pbfs_less)+
-    apply (frule cap_get_tag_isCap_unfolded_H_cap(15))
-    apply (clarsimp simp: cap_lift_page_directory_cap hd_conv_nth
-      cap_lift_page_table_cap
-      cap_to_H_def cap_page_directory_cap_lift_def
-      to_bool_def cap_page_table_cap_lift_def
-      typ_heap_simps' shiftl_t2n[where n=2] field_simps
-      elim!: ccap_relationE)
-    apply (intro conjI impI allI)
-     apply (clarsimp simp:ThreadState_Restart_def less_mask_eq rf_sr_ksCurThread
-        resolve_ret_rel_def framesize_from_to_H framesize_from_H_mask2
-        to_option_def rel_option_alt_def to_bool_def
-        typ_heap_simps'
-        split:option.splits if_splits
-      | fastforce simp: mask_def
-      | rule flushtype_relation_triv,simp add:isPageFlush_def isPDFlushLabel_def
-      | rule word_of_nat_less,simp add: pbfs_less)+
-   apply (frule cap_get_tag_isCap_unfolded_H_cap(15))
-   apply (clarsimp simp: cap_lift_page_directory_cap hd_conv_nth
-     cap_lift_page_table_cap
-     cap_to_H_def cap_page_directory_cap_lift_def
-     to_bool_def cap_page_table_cap_lift_def
-     typ_heap_simps' shiftl_t2n[where n=2] field_simps
-     elim!: ccap_relationE)
-   apply (intro conjI impI allI)
-    apply (clarsimp simp:ThreadState_Restart_def less_mask_eq rf_sr_ksCurThread
-      resolve_ret_rel_def framesize_from_to_H framesize_from_H_mask2
-      to_option_def rel_option_alt_def to_bool_def
-      typ_heap_simps'
-      split:option.splits if_splits
-      | fastforce simp: mask_def
-      | rule flushtype_relation_triv,simp add:isPageFlush_def isPDFlushLabel_def
-      | rule word_of_nat_less,simp add: pbfs_less)+ (* slow 20 secs *)
-  apply (frule cap_get_tag_isCap_unfolded_H_cap(15))
-  apply (clarsimp simp: cap_lift_page_directory_cap hd_conv_nth
-    cap_lift_page_table_cap
-    cap_to_H_def cap_page_directory_cap_lift_def
-    to_bool_def cap_page_table_cap_lift_def
-    typ_heap_simps' shiftl_t2n[where n=2] field_simps
-    elim!: ccap_relationE)
   apply (intro conjI impI allI)
-  by (clarsimp simp:ThreadState_Restart_def less_mask_eq rf_sr_ksCurThread
-     resolve_ret_rel_def framesize_from_to_H framesize_from_H_mask2
-     to_option_def rel_option_alt_def to_bool_def
-     typ_heap_simps'
-     split:option.splits if_splits
-     | fastforce simp: mask_def
-     | rule flushtype_relation_triv,simp add:isPageFlush_def isPDFlushLabel_def
-     | rule word_of_nat_less,simp add: pbfs_less)+
+  by (clarsimp simp: ThreadState_Restart_def less_mask_eq rf_sr_ksCurThread
+                     resolve_ret_rel_def framesize_from_to_H framesize_from_H_mask2
+                     to_option_def rel_option_alt_def typ_heap_simps'
+              split: option.splits if_splits
+      | fastforce simp: mask_def
+      | rule flushtype_relation_triv, simp add: isPageFlush_def isPDFlushLabel_def
+      | rule word_of_nat_less, simp add: pbfs_less)+
 
 lemma decodeARMMMUInvocation_ccorres:
   "\<lbrakk> interpret_excaps extraCaps' = excaps_map extraCaps ; \<not> isVCPUCap cp \<rbrakk>
@@ -3796,14 +3788,13 @@ lemma decodeARMMMUInvocation_ccorres:
                   apply (cut_tac P="\<lambda>y. y < i_' x + 1 = rhs y" for rhs in allI,
                          rule less_x_plus_1)
                    apply (clarsimp simp: asid_high_bits_def)
-                  apply (clarsimp simp: rf_sr_armKSASIDTable from_bool_def
+                  apply (clarsimp simp: rf_sr_armKSASIDTable
                                         asid_high_bits_word_bits
                                         option_to_ptr_def option_to_0_def
                                         order_less_imp_le
                                         linorder_not_less
                                         order_antisym[OF inc_le])
-                  apply (clarsimp simp: true_def false_def
-                                 split: option.split if_split)
+                  apply (clarsimp split: option.split if_split)
                   apply (simp add: asid_high_bits_def word_le_nat_alt
                                    word_less_nat_alt unat_add_lem[THEN iffD1])
                   apply auto[1]
@@ -3823,7 +3814,6 @@ lemma decodeARMMMUInvocation_ccorres:
                                       word_sless_def if_1_0_0 from_bool_0
                                       rf_sr_armKSASIDTable[where n=0, simplified])
                 apply (simp add: asid_high_bits_def option_to_ptr_def option_to_0_def
-                                 from_bool_def
                           split: option.split if_split)
                 apply fastforce
                apply ceqv
@@ -4058,7 +4048,7 @@ lemma decodeARMMMUInvocation_ccorres:
           apply (rule allI, rule conseqPre, vcg)
           apply (clarsimp simp: throwError_def return_def
                                 syscall_error_rel_def exception_defs
-                                syscall_error_to_H_cases false_def)
+                                syscall_error_to_H_cases)
           apply (simp add: lookup_fault_lift_invalid_root)
          apply csymbr
          apply (rule_tac Q=\<top> and Q'=\<top> in ccorres_if_cond_throws[rotated -1])
@@ -4107,9 +4097,7 @@ lemma decodeARMMMUInvocation_ccorres:
                                        = capASIDBase cp")
                 apply (subgoal_tac "\<And>x. (x < (i_' xb + 1))
                                           = (x < i_' xb \<or> x = i_' xb)")
-                 apply (clarsimp simp: inc_le from_bool_def typ_heap_simps
-                                       asid_low_bits_def not_less field_simps
-                                       false_def
+                 apply (clarsimp simp: inc_le typ_heap_simps asid_low_bits_def not_less field_simps
                                 split: if_split bool.splits)
                  apply unat_arith
                 apply (rule iffI)
@@ -4160,11 +4148,10 @@ lemma decodeARMMMUInvocation_ccorres:
                                    word_sless_def word_sle_def)
              apply (erule cmap_relationE1[OF rf_sr_cpspace_asidpool_relation],
                     erule ko_at_projectKO_opt)
-             apply (clarsimp simp: typ_heap_simps from_bool_def split: if_split)
+             apply (clarsimp simp: typ_heap_simps split: if_split)
              apply (simp add: cap_get_tag_isCap_ArchObject[symmetric])
              apply (clarsimp simp: cap_lift_asid_pool_cap cap_to_H_def
-                                   cap_asid_pool_cap_lift_def false_def
-                                   ucast_minus ucast_nat_def
+                                   cap_asid_pool_cap_lift_def ucast_minus ucast_nat_def
                             elim!: ccap_relationE)
             apply ceqv
            apply (rule ccorres_Guard_Seq)+
@@ -4287,13 +4274,12 @@ lemma decodeARMMMUInvocation_ccorres:
     apply (auto simp: ct_in_state'_def valid_tcb_state'_def
                dest!: st_tcb_at_idle_thread'
                elim!: pred_tcb'_weakenE)[1]
-  apply (clarsimp simp: if_1_0_0 cte_wp_at_ctes_of asidHighBits_handy_convs
+  apply (clarsimp simp: cte_wp_at_ctes_of asidHighBits_handy_convs
                         word_sle_def word_sless_def asidLowBits_handy_convs
                         rf_sr_ksCurThread "StrictC'_thread_state_defs"
                         mask_def[where n=4]
                   cong: if_cong)
-  apply (clarsimp simp: if_1_0_0 to_bool_def ccap_relation_isDeviceCap2
-     objBits_simps archObjSize_def pageBits_def from_bool_def case_bool_If)
+  apply (clarsimp simp: ccap_relation_isDeviceCap2 objBits_simps archObjSize_def pageBits_def)
   apply (rule conjI)
    (* Is Asid Control Cap *)
    apply (clarsimp simp: neq_Nil_conv excaps_in_mem_def excaps_map_def)
@@ -4303,11 +4289,10 @@ lemma decodeARMMMUInvocation_ccorres:
                          ccap_rights_relation_def rightsFromWord_wordFromRights)
    apply (clarsimp simp: asid_high_bits_word_bits split: list.split_asm)
     apply (clarsimp simp: cap_untyped_cap_lift_def cap_lift_untyped_cap
-                         cap_to_H_def[split_simps cap_CL.split]
-                         hd_conv_nth length_ineq_not_Nil
-                  elim!: ccap_relationE)
-   apply (clarsimp simp: if_1_0_0 to_bool_def unat_eq_of_nat
-                         objBits_simps archObjSize_def pageBits_def from_bool_def case_bool_If
+                          cap_to_H_def[split_simps cap_CL.split]
+                          hd_conv_nth length_ineq_not_Nil
+                   elim!: ccap_relationE)
+   apply (clarsimp simp: to_bool_def unat_eq_of_nat objBits_simps archObjSize_def pageBits_def
                   split: if_splits)
   apply (clarsimp simp: asid_low_bits_word_bits isCap_simps neq_Nil_conv
                         excaps_map_def excaps_in_mem_def
@@ -4325,8 +4310,7 @@ lemma decodeARMMMUInvocation_ccorres:
                   elim!: ccap_relationE split: if_split_asm)
    apply (clarsimp split: list.split)
   apply (clarsimp simp: cap_lift_asid_pool_cap cap_lift_page_directory_cap
-                        cap_to_H_def to_bool_def
-                        cap_page_directory_cap_lift_def
+                        cap_to_H_def cap_page_directory_cap_lift_def
                  elim!: ccap_relationE split: if_split_asm)
   done
 
@@ -5110,10 +5094,8 @@ lemma invokeVCPUAckVPPI_ccorres:
    apply (simp add: invokeVCPUAckVPPI_def)
    apply (rule ccorres_move_const_guards)
    apply (rule ccorres_move_c_guard_vcpu)
-   apply (simp add: false_def)
    apply (ctac (no_vcg) add: vcpuVPPIMasked_update_ccorres[
-                               where v=False, simplified false_def from_bool_def,
-                               simplified])
+                               where v=False, simplified from_bool_vals])
      apply (rule ccorres_from_vcg_throws[where P=\<top> and P'=UNIV])
      apply (rule allI, rule conseqPre, vcg)
      apply (clarsimp simp: return_def dc_def)

--- a/proof/crefine/ARM_HYP/CLevityCatch.thy
+++ b/proof/crefine/ARM_HYP/CLevityCatch.thy
@@ -10,6 +10,7 @@ imports
   ArchMove_C
   "CParser.LemmaBucket_C"
   "Lib.LemmaBucket"
+  Boolean_C
 begin
 
 context begin interpretation Arch . (*FIXME: arch_split*)

--- a/proof/crefine/ARM_HYP/CSpace_All.thy
+++ b/proof/crefine/ARM_HYP/CSpace_All.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2023, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -248,8 +249,7 @@ lemma lookupSlotForCNodeOp_ccorres':
    apply vcg
 
   \<comment> \<open>last subgoal\<close>
-  apply (clarsimp simp: if_1_0_0  to_bool_def true_def word_size
-                        fromIntegral_def integral_inv)
+  apply (clarsimp simp: word_size fromIntegral_def integral_inv)
   apply (case_tac "cap_get_tag root = scast cap_cnode_cap")
    prefer 2 apply clarsimp
   apply (clarsimp simp: unat_of_nat32 word_sle_def)
@@ -285,7 +285,7 @@ lemma lookupSourceSlot_ccorres':
      apply simp
     apply simp
    apply (ctac add: lookupSlotForCNodeOp_ccorres')
-  apply (clarsimp simp: to_bool_def true_def false_def)
+  apply clarsimp
   done
 
 lemma lookupSourceSlot_ccorres:
@@ -315,7 +315,7 @@ lemma lookupTargetSlot_ccorres':
      apply simp
     apply simp
    apply (ctac add: lookupSlotForCNodeOp_ccorres')
-  apply (clarsimp simp: to_bool_def true_def false_def)
+  apply clarsimp
   done
 
 lemma lookupTargetSlot_ccorres:
@@ -345,7 +345,7 @@ lemma lookupPivotSlot_ccorres:
      apply simp
     apply simp
    apply (ctac add: lookupSlotForCNodeOp_ccorres)
-  apply (clarsimp simp: to_bool_def true_def false_def)
+  apply clarsimp
   done
 
 end

--- a/proof/crefine/ARM_HYP/CSpace_C.thy
+++ b/proof/crefine/ARM_HYP/CSpace_C.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2023, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -60,7 +61,7 @@ lemma maskVMRights_spec:
   apply clarsimp
   apply (rule conjI)
    apply ((auto simp: vmrights_to_H_def maskVMRights_def vmrights_defs
-                      cap_rights_to_H_def to_bool_def
+                      cap_rights_to_H_def
                split: bool.split
          | simp add: mask_def
          | word_bitwise)+)[1]
@@ -152,11 +153,7 @@ lemma Arch_maskCapRights_ccorres [corres]:
    apply (cases arch_cap)
        by (fastforce simp add: cap_get_tag_isCap isCap_simps  simp del: not_ex simp_thms(44))+
 
-(* FIXME: move to Wellformed_C (or move to_bool_bf out of Wellformed_C) *)
-lemma to_bool_mask_to_bool_bf:
-  "to_bool (x && 1) = to_bool_bf (x::word32)"
-  by (simp add: to_bool_bf_def to_bool_def)
-
+(* FIXME: move to Wellformed_C *)
 lemma to_bool_cap_rights_bf:
   "to_bool (capAllowRead_CL (seL4_CapRights_lift R)) =
    to_bool_bf (capAllowRead_CL (seL4_CapRights_lift R))"
@@ -217,7 +214,7 @@ lemma maskCapRights_ccorres [corres]:
   apply csymbr
   apply (simp add: maskCapRights_cap_cases cap_get_tag_isCap del: Collect_const)
   apply wpc
-              apply (simp add: Collect_const_mem from_bool_def)
+              apply (simp add: Collect_const_mem)
               apply csymbr
               apply (simp add: cap_get_tag_isCap isCap_simps del: Collect_const)
               apply (simp add: ccorres_cond_iffs)
@@ -227,7 +224,7 @@ lemma maskCapRights_ccorres [corres]:
                apply vcg
               apply clarsimp
               apply (simp add: cap_get_tag_isCap isCap_simps return_def)
-             apply (simp add: Collect_const_mem from_bool_def)
+             apply (simp add: Collect_const_mem)
              apply csymbr
              apply (simp add: cap_get_tag_isCap isCap_simps del: Collect_const)
              apply (simp add: ccorres_cond_iffs)
@@ -236,7 +233,7 @@ lemma maskCapRights_ccorres [corres]:
              apply (rule conseqPre)
               apply vcg
              apply (clarsimp simp: return_def)
-            apply (simp add: Collect_const_mem from_bool_def)
+            apply (simp add: Collect_const_mem)
             apply csymbr
             apply (simp add: cap_get_tag_isCap isCap_simps del: Collect_const)
             apply (simp add: ccorres_cond_iffs)
@@ -262,7 +259,7 @@ lemma maskCapRights_ccorres [corres]:
             apply (simp add: ccap_rights_relation_def cap_rights_to_H_def
                              to_bool_ntfn_cap_bf
                              to_bool_mask_to_bool_bf to_bool_cap_rights_bf)
-           apply (simp add: Collect_const_mem from_bool_def)
+           apply (simp add: Collect_const_mem)
            apply csymbr
            apply (simp add: cap_get_tag_isCap isCap_simps ccorres_cond_iffs)
            apply (rule ccorres_from_vcg_throws [where P=\<top> and P'=UNIV])
@@ -270,7 +267,7 @@ lemma maskCapRights_ccorres [corres]:
            apply (rule conseqPre)
             apply vcg
            apply (clarsimp simp: cap_get_tag_isCap isCap_simps return_def)
-          apply (simp add: Collect_const_mem from_bool_def)
+          apply (simp add: Collect_const_mem)
           apply csymbr
           apply (simp add: cap_get_tag_isCap isCap_simps ccorres_cond_iffs)
           apply (rule ccorres_from_vcg_throws [where P=\<top> and P'=UNIV])
@@ -298,7 +295,7 @@ lemma maskCapRights_ccorres [corres]:
           apply (simp add: ccap_rights_relation_def cap_rights_to_H_def
                            to_bool_ep_cap_bf
                            to_bool_mask_to_bool_bf to_bool_cap_rights_bf)
-         apply (simp add: Collect_const_mem from_bool_def)
+         apply (simp add: Collect_const_mem)
          apply csymbr
          apply (simp add: cap_get_tag_isCap isCap_simps del: Collect_const)
          apply (simp add: ccorres_cond_iffs)
@@ -307,7 +304,7 @@ lemma maskCapRights_ccorres [corres]:
          apply (rule conseqPre)
           apply vcg
          apply (clarsimp simp: return_def)
-        apply (simp add: Collect_const_mem from_bool_def)
+        apply (simp add: Collect_const_mem)
         apply csymbr
         apply (simp add: cap_get_tag_isCap isCap_simps ccorres_cond_iffs)
         apply (rule ccorres_from_vcg_throws [where P=\<top> and P'=UNIV])
@@ -315,7 +312,7 @@ lemma maskCapRights_ccorres [corres]:
         apply (rule conseqPre)
          apply vcg
         apply (clarsimp simp: cap_get_tag_isCap isCap_simps return_def)
-       apply (simp add: Collect_const_mem from_bool_def)
+       apply (simp add: Collect_const_mem)
        apply (subst bind_return [symmetric])
        apply (rule ccorres_split_throws)
         apply ctac
@@ -328,7 +325,7 @@ lemma maskCapRights_ccorres [corres]:
          apply wp
         apply vcg
        apply vcg
-      apply (simp add: Collect_const_mem from_bool_def)
+      apply (simp add: Collect_const_mem)
       apply csymbr
       apply (simp add: cap_get_tag_isCap isCap_simps del: Collect_const)
       apply ccorres_rewrite
@@ -348,7 +345,7 @@ lemma maskCapRights_ccorres [corres]:
       apply (simp add: ccap_rights_relation_def cap_rights_to_H_def
                        to_bool_reply_cap_bf
                        to_bool_mask_to_bool_bf[simplified] to_bool_cap_rights_bf)
-     apply (simp add: Collect_const_mem from_bool_def)
+     apply (simp add: Collect_const_mem)
      apply csymbr
      apply (simp add: cap_get_tag_isCap isCap_simps del: Collect_const)
      apply (simp add: ccorres_cond_iffs)
@@ -357,7 +354,7 @@ lemma maskCapRights_ccorres [corres]:
      apply (rule conseqPre)
       apply vcg
      apply (clarsimp simp: return_def)
-    apply (simp add: Collect_const_mem from_bool_def)
+    apply (simp add: Collect_const_mem)
     apply csymbr
     apply (simp add: cap_get_tag_isCap isCap_simps del: Collect_const)
     apply (simp add: ccorres_cond_iffs)
@@ -367,7 +364,7 @@ lemma maskCapRights_ccorres [corres]:
      apply vcg
     apply clarsimp
     apply (simp add: cap_get_tag_isCap isCap_simps return_def)
-   apply (simp add: Collect_const_mem from_bool_def)
+   apply (simp add: Collect_const_mem)
    apply csymbr
    apply (simp add: cap_get_tag_isCap isCap_simps del: Collect_const)
    apply (simp add: ccorres_cond_iffs)
@@ -528,9 +525,9 @@ lemma Arch_isCapRevocable_spec:
         {t. \<forall>c c'.  ccap_relation c (derivedCap_' s) \<and> ccap_relation c' (srcCap_' s)
             \<longrightarrow> ret__unsigned_long_' t = from_bool (Arch.isCapRevocable c c')}"
   apply vcg
-  by (auto simp: false_def from_bool_def)
+  by auto
 
-method revokable'_hammer = solves \<open>(simp add: cap_get_tag_isCap isCap_simps ccorres_cond_iffs from_bool_def true_def false_def,
+method revokable'_hammer = solves \<open>(simp add: cap_get_tag_isCap isCap_simps ccorres_cond_iffs,
                     rule ccorres_guard_imp, rule ccorres_return_C; clarsimp)\<close>
 
 lemma revokable_ccorres:
@@ -557,7 +554,7 @@ lemma revokable_ccorres:
     \<comment> \<open>Uninteresting caps\<close>
               apply revokable'_hammer+
     \<comment> \<open>NotificationCap\<close>
-            apply (simp add: cap_get_tag_isCap isCap_simps ccorres_cond_iffs from_bool_def true_def false_def)
+            apply (simp add: cap_get_tag_isCap isCap_simps ccorres_cond_iffs)
             apply (rule ccorres_guard_imp, (rule ccorres_rhs_assoc)+, csymbr, csymbr)
               apply (rule ccorres_return_C, clarsimp+)
             apply (frule_tac cap'1=srcCap in cap_get_tag_NotificationCap[THEN iffD1])
@@ -566,12 +563,12 @@ lemma revokable_ccorres:
              apply (clarsimp simp: cap_get_tag_isCap isCap_simps)
             apply (fastforce simp: cap_get_tag_isCap isCap_simps)
     \<comment> \<open>IRQHandlerCap\<close>
-           apply (simp add: cap_get_tag_isCap isCap_simps ccorres_cond_iffs from_bool_def true_def false_def)
+           apply (simp add: cap_get_tag_isCap isCap_simps ccorres_cond_iffs)
            apply (rule ccorres_guard_imp, csymbr)
              apply (rule ccorres_return_C, clarsimp+)
            apply (fastforce simp: cap_get_tag_isCap isCap_simps)
     \<comment> \<open>EndpointCap\<close>
-          apply (simp add: cap_get_tag_isCap isCap_simps ccorres_cond_iffs from_bool_def true_def false_def)
+          apply (simp add: cap_get_tag_isCap isCap_simps ccorres_cond_iffs)
           apply (rule ccorres_guard_imp, (rule ccorres_rhs_assoc)+, csymbr, csymbr)
             apply (rule ccorres_return_C, clarsimp+)
           apply (frule_tac cap'1=srcCap in cap_get_tag_EndpointCap[THEN iffD1])
@@ -728,52 +725,6 @@ definition
              else if (cap_get_tag newCap = scast cap_irq_handler_cap)
                   then (if cap_get_tag srcCap = scast cap_irq_control_cap then 1 else 0)
              else if (cap_get_tag newCap = scast cap_untyped_cap) then 1 else 0)"
-
-lemma cteInsert_if_helper:
-  assumes cgt: "rv = cap_get_tag newCap"
-  and     rul: "\<And>s g. (s \<in> Q) = (s\<lparr> ret__unsigned_' := undefined,
-  unsigned_eret_2_':= undefined \<rparr> \<in> Q')"
-  shows "\<Gamma> \<turnstile>\<^bsub>/UNIV\<^esub> {s. (cap_get_tag srcCap = cap_get_tag newCap
-                          \<or> is_simple_cap_tag (cap_get_tag newCap)) \<and>
-            (s\<lparr>newCapIsRevocable_' := cteInsert_newCapIsRevocable_if newCap srcCap\<rparr> \<in> Q)}
-          (IF rv = scast cap_endpoint_cap THEN
-               \<acute>ret__unsigned :== CALL cap_endpoint_cap_get_capEPBadge(newCap);;
-               \<acute>unsigned_eret_2 :== CALL cap_endpoint_cap_get_capEPBadge(srcCap);;
-               \<acute>newCapIsRevocable :== (if \<acute>ret__unsigned \<noteq> \<acute>unsigned_eret_2 then 1 else 0)
-             ELSE
-               IF rv = scast cap_notification_cap THEN
-                 \<acute>ret__unsigned :== CALL cap_notification_cap_get_capNtfnBadge(newCap);;
-                 \<acute>unsigned_eret_2 :== CALL cap_notification_cap_get_capNtfnBadge(srcCap);;
-                 \<acute>newCapIsRevocable :== (if \<acute>ret__unsigned \<noteq> \<acute>unsigned_eret_2 then 1 else 0)
-               ELSE
-                 IF rv = scast cap_irq_handler_cap THEN
-                   \<acute>ret__unsigned :== CALL cap_get_capType(srcCap);;
-                   \<acute>newCapIsRevocable :== (if \<acute>ret__unsigned = scast cap_irq_control_cap then 1 else 0)
-                 ELSE
-                   IF rv = scast cap_untyped_cap THEN
-                     \<acute>newCapIsRevocable :== scast true
-                   ELSE
-                     \<acute>newCapIsRevocable :== scast false
-                   FI
-                 FI
-               FI
-             FI) Q"
-  unfolding cteInsert_newCapIsRevocable_if_def
-  apply (unfold cgt)
-  apply (rule conseqPre)
-  apply vcg
-  apply (clarsimp simp: true_def false_def
-                        is_simple_cap_tag_def
-                  cong: if_cong)
-  apply (simp add: cap_tag_defs)
-  apply (intro allI conjI impI)
-                      apply (clarsimp simp: rul)+
-  done
-
-lemma forget_Q':
-  "(x \<in> Q) = (y \<in> Q) \<Longrightarrow> (x \<in> Q) = (y \<in> Q)" .
-
-lemmas cteInsert_if_helper' = cteInsert_if_helper [OF _ forget_Q']
 
 (* Useful:
   apply (tactic {* let val _ = reset CtacImpl.trace_ceqv; val _ = reset CtacImpl.trace_ctac in all_tac end; *})
@@ -1305,9 +1256,7 @@ lemma cteMove_ccorres:
    apply (erule (2) is_aligned_3_next)
   apply (clarsimp simp: dc_def split del: if_split)
   apply (simp add: ccap_relation_NullCap_iff)
-  apply (clarsimp simp add: cmdbnode_relation_def
-    mdb_node_to_H_def nullMDBNode_def
-    false_def to_bool_def)
+  apply (clarsimp simp: cmdbnode_relation_def mdb_node_to_H_def nullMDBNode_def)
   done
 
 lemma cteMove_ccorres_verbose:
@@ -1455,7 +1404,6 @@ lemma cteMove_ccorres_verbose:
   apply (simp add: cmdbnode_relation_def)
   apply (simp add: mdb_node_to_H_def)
   apply (simp add: nullMDBNode_def)
-  apply (simp add: false_def to_bool_def)
   done
 
 (************************************************************************)
@@ -1961,8 +1909,8 @@ lemma emptySlot_helper:
                          mdbFirstBadged_CL (cteMDBNode_CL y)")
       prefer 2
       apply (drule cteMDBNode_CL_lift [symmetric])
-      subgoal by (simp add: mdb_node_lift_def mask_def word_bw_assocs)
-     subgoal by (simp add: to_bool_def mask_def)
+      subgoal by (simp add: mdb_node_lift_def word_bw_assocs)
+     subgoal by (simp add: to_bool_def)
    \<comment> \<open>\<dots> \<exists>x\<in>fst \<dots>\<close>
    apply clarsimp
    apply (rule fst_setCTE [OF ctes_of_cte_at], assumption )
@@ -1993,7 +1941,7 @@ lemma emptySlot_helper:
     prefer 2
     apply (drule cteMDBNode_CL_lift [symmetric])
     subgoal by (simp add: mdb_node_lift_def mask_def word_bw_assocs)
-   apply (simp add: to_bool_def mask_def split: if_split)
+   apply (simp add: to_bool_def split: if_split)
 
   \<comment> \<open>trivial case where mdbNext rva = 0\<close>
    apply (simp add:ccorres_cond_empty_iff)
@@ -2162,7 +2110,6 @@ lemma setIRQState_ccorres:
    apply (simp add: empty_fail_def getInterruptState_def simpler_gets_def)
 
   apply clarsimp
-  apply (simp add: from_bool_def)
   apply (cases irqState, simp_all)
   apply (simp add: Kernel_C.IRQSignal_def Kernel_C.IRQInactive_def)
   apply (simp add: Kernel_C.IRQTimer_def Kernel_C.IRQInactive_def)
@@ -2547,7 +2494,7 @@ lemma emptySlot_ccorres:
             \<comment> \<open>Haskell pre/post for y \<leftarrow> updateCap slot capability.NullCap;\<close>
              apply wp
             \<comment> \<open>C       pre/post for y \<leftarrow> updateCap slot capability.NullCap;\<close>
-            apply (simp add: Collect_const_mem cmdbnode_relation_def mdb_node_to_H_def nullMDBNode_def false_def)
+            apply (simp add: Collect_const_mem cmdbnode_relation_def mdb_node_to_H_def nullMDBNode_def)
         \<comment> \<open>Haskell pre/post for the two nested updates\<close>
          apply wp
         \<comment> \<open>C       pre/post for the two nested updates\<close>
@@ -2741,8 +2688,8 @@ lemma Arch_sameRegionAs_spec:
 
   (* FIXME: add 1 indent, 1 extra VCPU goal appeared *)
   \<comment> \<open>capa is ASIDPoolCap\<close>
-      apply (cases capb; simp add: cap_get_tag_isCap_unfolded_H_cap
-                         isCap_simps cap_tag_defs from_bool_def false_def)
+      apply (cases capb;
+             simp add: cap_get_tag_isCap_unfolded_H_cap isCap_simps cap_tag_defs)
       \<comment> \<open>capb is also ASIDPoolCap\<close>
        apply (frule cap_get_tag_isCap_unfolded_H_cap(13)[where cap'=cap_a])
        apply (frule cap_get_tag_isCap_unfolded_H_cap(13)[where cap'=cap_b])
@@ -2764,8 +2711,8 @@ lemma Arch_sameRegionAs_spec:
       done
 
   \<comment> \<open>capa is ASIDControlCap\<close>
-     apply (cases capb; simp add: cap_get_tag_isCap_unfolded_H_cap
-                        isCap_simps cap_tag_defs from_bool_def false_def true_def)
+     apply (cases capb;
+            simp add: cap_get_tag_isCap_unfolded_H_cap isCap_simps cap_tag_defs)
      \<comment> \<open>capb is PageCap\<close>
      subgoal for \<dots> vmpage_size option
      apply (case_tac "vmpage_size=ARMSmallPage")
@@ -2780,8 +2727,8 @@ lemma Arch_sameRegionAs_spec:
     apply (cases "vmpage_size=ARMSmallPage")
     \<comment> \<open>capa is a small frame\<close>
      apply (frule cap_get_tag_isCap_unfolded_H_cap(16)[where cap' = cap_a], assumption)
-     apply (cases capb; simp add: cap_get_tag_isCap_unfolded_H_cap
-                        isCap_simps cap_tag_defs from_bool_def false_def true_def)
+     apply (cases capb;
+            simp add: cap_get_tag_isCap_unfolded_H_cap isCap_simps cap_tag_defs from_bool_def)
    \<comment> \<open>capb is PageCap\<close>
 
      subgoal for \<dots> vmpage_sizea optiona
@@ -2856,8 +2803,8 @@ lemma Arch_sameRegionAs_spec:
        apply (simp add: cap_frame_cap_lift)
        apply (simp add: c_valid_cap_def cl_valid_cap_def)
 
-    apply (cases capb; simp add: cap_get_tag_isCap_unfolded_H_cap
-                       isCap_simps cap_tag_defs from_bool_def false_def true_def)
+    apply (cases capb;
+           simp add: cap_get_tag_isCap_unfolded_H_cap isCap_simps cap_tag_defs from_bool_def)
     \<comment> \<open>capb is PageCap\<close>
     subgoal for \<dots> vmpage_sizea optiona
 
@@ -2934,8 +2881,8 @@ lemma Arch_sameRegionAs_spec:
    done
 
   \<comment> \<open>capa is PageTableCap\<close>
-   apply (cases capb; simp_all add: cap_get_tag_isCap_unfolded_H_cap
-                      isCap_simps cap_tag_defs from_bool_def false_def true_def)
+   apply (cases capb;
+          simp_all add: cap_get_tag_isCap_unfolded_H_cap isCap_simps cap_tag_defs)
     \<comment> \<open>capb is PageCap\<close>
     subgoal for \<dots> vmpage_size option
     apply (cases "vmpage_size=ARMSmallPage")
@@ -2955,8 +2902,8 @@ lemma Arch_sameRegionAs_spec:
                     capPTBasePtr_CL (cap_page_table_cap_lift cap_b)"; simp)
 
   \<comment> \<open>capa is PageDirectoryCap\<close>
-  apply (cases capb; simp add: cap_get_tag_isCap_unfolded_H_cap
-                      isCap_simps cap_tag_defs from_bool_def false_def true_def)
+  apply (cases capb;
+         simp add: cap_get_tag_isCap_unfolded_H_cap isCap_simps cap_tag_defs)
    \<comment> \<open>capb is PageCap\<close>
    subgoal for \<dots> vmpage_size option
    apply (cases "vmpage_size=ARMSmallPage")
@@ -2976,8 +2923,8 @@ lemma Arch_sameRegionAs_spec:
                    capPDBasePtr_CL (cap_page_directory_cap_lift cap_b)"; simp)
 
   \<comment> \<open>capa is VCPUCap\<close>
-  apply (cases capb; simp add: cap_get_tag_isCap_unfolded_H_cap
-                      isCap_simps cap_tag_defs from_bool_def false_def true_def)
+  apply (cases capb;
+         simp add: cap_get_tag_isCap_unfolded_H_cap isCap_simps cap_tag_defs)
    \<comment> \<open>capb is PageCap\<close>
    subgoal for \<dots> vmpage_size option
    apply (cases "vmpage_size=ARMSmallPage")
@@ -3343,8 +3290,7 @@ lemma cap_get_capIsPhysical_spec:
                                           cap_lift_asid_control_cap word_sle_def
                                           cap_lift_irq_control_cap cap_lift_null_cap
                                           mask_def objBits_simps cap_lift_domain_cap
-                                          ptr_add_assertion_positive from_bool_def
-                                          true_def false_def
+                                          ptr_add_assertion_positive
                                    dest!: sym [where t = "cap_get_tag cap" for cap]
                                    split: vmpage_size.splits)+
   (* XXX: slow. there should be a rule for this *)
@@ -3452,22 +3398,23 @@ lemma sameRegionAs_spec:
   apply (simp add: sameRegionAs_def isArchCap_tag_def2)
   apply (case_tac capa, simp_all add: cap_get_tag_isCap_unfolded_H_cap isCap_simps)
             \<comment> \<open>capa is a ThreadCap\<close>
-             apply (case_tac capb, simp_all add: cap_get_tag_isCap_unfolded_H_cap
-                          isCap_simps cap_tag_defs from_bool_def false_def)[1]
+             apply (case_tac capb,
+                    simp_all add: cap_get_tag_isCap_unfolded_H_cap isCap_simps cap_tag_defs)[1]
               apply (frule_tac cap'=cap_a in cap_get_tag_isCap_unfolded_H_cap(1))
               apply (frule_tac cap'=cap_b in cap_get_tag_isCap_unfolded_H_cap(1))
               apply (simp add: ccap_relation_def map_option_case)
               apply (simp add: cap_thread_cap_lift)
               apply (simp add: cap_to_H_def)
+              apply (clarsimp simp: from_bool_0 split: if_split)
              apply (clarsimp simp: case_bool_If ctcb_ptr_to_tcb_ptr_def if_distrib
                               cong: if_cong)
              apply (frule_tac cap'=cap_b in cap_get_tag_isArchCap_unfolded_H_cap)
              apply (clarsimp simp: isArchCap_tag_def2)
            \<comment> \<open>capa is a NullCap\<close>
-            apply (simp add: cap_tag_defs from_bool_def false_def)
+            apply (simp add: cap_tag_defs)
           \<comment> \<open>capa is an NotificationCap\<close>
-           apply (case_tac capb, simp_all add: cap_get_tag_isCap_unfolded_H_cap
-                        isCap_simps cap_tag_defs from_bool_def false_def)[1]
+           apply (case_tac capb,
+                  simp_all add: cap_get_tag_isCap_unfolded_H_cap isCap_simps cap_tag_defs)[1]
             apply (frule_tac cap'=cap_a in cap_get_tag_isCap_unfolded_H_cap(3))
             apply (frule_tac cap'=cap_b in cap_get_tag_isCap_unfolded_H_cap(3))
             apply (simp add: ccap_relation_def map_option_case)
@@ -3477,15 +3424,15 @@ lemma sameRegionAs_spec:
            apply (frule_tac cap'=cap_b in cap_get_tag_isArchCap_unfolded_H_cap)
            apply (clarsimp simp: isArchCap_tag_def2)
           \<comment> \<open>capa is an IRQHandlerCap\<close>
-          apply (case_tac capb, simp_all add: cap_get_tag_isCap_unfolded_H_cap
-                      isCap_simps cap_tag_defs from_bool_def false_def)[1]
+          apply (case_tac capb,
+                 simp_all add: cap_get_tag_isCap_unfolded_H_cap isCap_simps cap_tag_defs)[1]
            apply (frule_tac cap'=cap_a in cap_get_tag_isCap_unfolded_H_cap(5))
            apply (frule_tac cap'=cap_b in cap_get_tag_isCap_unfolded_H_cap(5))
            apply (simp add: ccap_relation_def map_option_case)
            apply (simp add: cap_irq_handler_cap_lift)
            apply (simp add: cap_to_H_def)
            apply (clarsimp simp: up_ucast_inj_eq c_valid_cap_def
-                                 cl_valid_cap_def mask_twice
+                                 cl_valid_cap_def mask_twice from_bool_0
                           split: if_split bool.split
                           | intro impI conjI
                           | simp )+
@@ -3495,34 +3442,34 @@ lemma sameRegionAs_spec:
           apply (clarsimp simp: isArchCap_tag_def2)
          \<comment> \<open>capa is an EndpointCap\<close>
          apply (case_tac capb, simp_all add: cap_get_tag_isCap_unfolded_H_cap
-                      isCap_simps cap_tag_defs from_bool_def false_def)[1]
+                                             isCap_simps cap_tag_defs)[1]
           apply (frule_tac cap'=cap_a in cap_get_tag_isCap_unfolded_H_cap(4))
           apply (frule_tac cap'=cap_b in cap_get_tag_isCap_unfolded_H_cap(4))
           apply (simp add: ccap_relation_def map_option_case)
           apply (simp add: cap_endpoint_cap_lift)
           apply (simp add: cap_to_H_def)
-          apply (clarsimp split: if_split)
+          apply (clarsimp simp: from_bool_0 split: if_split)
          apply (frule_tac cap'=cap_b in cap_get_tag_isArchCap_unfolded_H_cap)
          apply (clarsimp simp: isArchCap_tag_def2)
         \<comment> \<open>capa is a DomainCap\<close>
         apply (case_tac capb, simp_all add: cap_get_tag_isCap_unfolded_H_cap
-                     isCap_simps cap_tag_defs from_bool_def false_def true_def)[1]
+                                            isCap_simps cap_tag_defs)[1]
         apply (frule_tac cap'=cap_b in cap_get_tag_isArchCap_unfolded_H_cap)
         apply (fastforce simp: isArchCap_tag_def2 split: if_split)
        \<comment> \<open>capa is a Zombie\<close>
-       apply (simp add: cap_tag_defs from_bool_def false_def)
+       apply (simp add: cap_tag_defs)
       \<comment> \<open>capa is an Arch object cap\<close>
       apply (frule_tac cap'=cap_a in cap_get_tag_isArchCap_unfolded_H_cap)
       apply (clarsimp simp: isArchCap_tag_def2 cap_tag_defs linorder_not_less [THEN sym])
       apply (rule conjI, clarsimp, rule impI)+
       apply (case_tac capb, simp_all add: cap_get_tag_isCap_unfolded_H_cap
-                   isCap_simps cap_tag_defs from_bool_def false_def)[1]
+                                          isCap_simps cap_tag_defs)[1]
       \<comment> \<open>capb is an Arch object cap\<close>
       apply (frule_tac cap'=cap_b in cap_get_tag_isArchCap_unfolded_H_cap)
       apply (fastforce simp: isArchCap_tag_def2 cap_tag_defs linorder_not_less [THEN sym])
      \<comment> \<open>capa is a ReplyCap\<close>
      apply (case_tac capb, simp_all add: cap_get_tag_isCap_unfolded_H_cap
-                  isCap_simps cap_tag_defs from_bool_def false_def)[1]
+                                         isCap_simps cap_tag_defs)[1]
       apply (frule_tac cap'=cap_b in cap_get_tag_isArchCap_unfolded_H_cap)
       apply (clarsimp simp: isArchCap_tag_def2)
      apply (frule_tac cap'=cap_a in cap_get_tag_isCap_unfolded_H_cap(8))
@@ -3530,7 +3477,7 @@ lemma sameRegionAs_spec:
      apply (simp add: ccap_relation_def map_option_case)
      apply (simp add: cap_reply_cap_lift)
      apply (simp add: cap_to_H_def ctcb_ptr_to_tcb_ptr_def)
-     apply (clarsimp split: if_split)
+     apply (clarsimp simp: from_bool_0 split: if_split)
     \<comment> \<open>capa is an UntypedCap\<close>
     apply (frule_tac cap'=cap_a in cap_get_tag_isCap_unfolded_H_cap(9))
     apply (intro conjI)
@@ -3538,8 +3485,7 @@ lemma sameRegionAs_spec:
         apply (rule impI, drule(1) cap_get_tag_to_H)+
         apply (clarsimp simp: capAligned_def word_bits_conv
                               objBits_simps' get_capZombieBits_CL_def
-                              Let_def word_less_nat_alt
-                              less_mask_eq true_def
+                              Let_def word_less_nat_alt less_mask_eq
                        split: if_split_asm)
        apply (subgoal_tac "capBlockSize_CL (cap_untyped_cap_lift cap_a) \<le> 0x1F")
         apply (simp add: word_le_make_less)
@@ -3560,10 +3506,9 @@ lemma sameRegionAs_spec:
                                cap_untyped_cap_lift cap_to_H_def
                                field_simps valid_cap'_def)+)[4]
     apply (rule impI, simp add: from_bool_0 ccap_relation_get_capIsPhysical[symmetric])
-    apply (simp add: from_bool_def false_def)
    \<comment> \<open>capa is a CNodeCap\<close>
    apply (case_tac capb, simp_all add: cap_get_tag_isCap_unfolded_H_cap
-                isCap_simps cap_tag_defs from_bool_def false_def)[1]
+                                       isCap_simps cap_tag_defs)[1]
     apply (frule_tac cap'=cap_b in cap_get_tag_isArchCap_unfolded_H_cap)
     apply (clarsimp simp: isArchCap_tag_def2)
    apply (frule_tac cap'=cap_a in cap_get_tag_isCap_unfolded_H_cap(10))
@@ -3571,10 +3516,9 @@ lemma sameRegionAs_spec:
    apply (simp add: ccap_relation_def map_option_case)
    apply (simp add: cap_cnode_cap_lift)
    apply (simp add: cap_to_H_def)
-   apply (clarsimp split: if_split bool.split)
+   apply (clarsimp simp: from_bool_0 split: if_split bool.split)
   \<comment> \<open>capa is an IRQControlCap\<close>
-  apply (case_tac capb, simp_all add: cap_get_tag_isCap_unfolded_H_cap
-               isCap_simps cap_tag_defs from_bool_def false_def true_def)[1]
+  apply (case_tac capb, simp_all add: cap_get_tag_isCap_unfolded_H_cap isCap_simps cap_tag_defs)[1]
   apply (frule_tac cap'=cap_b in cap_get_tag_isArchCap_unfolded_H_cap)
   apply (fastforce simp: isArchCap_tag_def2 split: if_split)
   done
@@ -3624,23 +3568,21 @@ lemma Arch_sameObjectAs_spec:
              simp_all add: cap_get_tag_isCap_unfolded_H_cap cap_tag_defs)[1]
        apply (rename_tac vmpage_sizea optiona)
        apply (case_tac "vmpage_sizea = ARMSmallPage",
-              simp_all add: cap_get_tag_isCap_unfolded_H_cap cap_tag_defs
-                            false_def from_bool_def)[1]
+              simp_all add: cap_get_tag_isCap_unfolded_H_cap cap_tag_defs)[1]
        apply (frule_tac cap'=cap_a in cap_get_tag_isCap_unfolded_H_cap(16), simp)
        apply (frule_tac cap'=cap_b in cap_get_tag_isCap_unfolded_H_cap(16), simp)
        apply (simp add: ccap_relation_def map_option_case)
        apply (simp add: cap_small_frame_cap_lift)
-       apply (clarsimp simp: cap_to_H_def capAligned_def to_bool_def from_bool_def
+       apply (clarsimp simp: cap_to_H_def capAligned_def to_bool_def
                       split: if_split bool.split
                       dest!: is_aligned_no_overflow)
       apply (case_tac "vmpage_sizea = ARMSmallPage",
-             simp_all add: cap_get_tag_isCap_unfolded_H_cap cap_tag_defs
-                           false_def from_bool_def)[1]
+             simp_all add: cap_get_tag_isCap_unfolded_H_cap cap_tag_defs)[1]
       apply (frule_tac cap'=cap_a in cap_get_tag_isCap_unfolded_H_cap(17), simp)
       apply (frule_tac cap'=cap_b in cap_get_tag_isCap_unfolded_H_cap(17), simp)
       apply (simp add: ccap_relation_def map_option_case)
       apply (simp add: cap_frame_cap_lift)
-      apply (clarsimp simp: cap_to_H_def capAligned_def from_bool_def
+      apply (clarsimp simp: cap_to_H_def capAligned_def
                             c_valid_cap_def cl_valid_cap_def
                             Kernel_C.ARMSmallPage_def
                      split: if_split bool.split vmpage_size.split_asm
@@ -3659,8 +3601,7 @@ lemma sameObjectAs_spec:
   apply vcg
   apply (clarsimp simp: sameObjectAs_def isArchCap_tag_def2)
   apply (case_tac capa, simp_all add: cap_get_tag_isCap_unfolded_H_cap
-                                      isCap_simps cap_tag_defs
-                                      from_bool_def false_def)
+                                      isCap_simps cap_tag_defs)
             apply fastforce+
      \<comment> \<open>capa is an arch cap\<close>
      apply (frule cap_get_tag_isArchCap_unfolded_H_cap)
@@ -3741,7 +3682,7 @@ lemma isMDBParentOf_spec:
      apply (simp add: ccte_relation_def map_option_case)
      apply (simp add: cte_lift_def)
      apply (clarsimp simp: cte_to_H_def mdb_node_to_H_def split: option.split_asm)
-     apply (clarsimp simp: Let_def false_def from_bool_def to_bool_def
+     apply (clarsimp simp: Let_def to_bool_def
                     split: if_split bool.splits)
      apply ((clarsimp simp: typ_heap_simps dest!: lift_t_g)+)[3]
   apply (rule_tac x="cteCap ctea" in exI, rule conjI)
@@ -3760,11 +3701,11 @@ lemma isMDBParentOf_spec:
   apply (rule impI, rule conjI)
    \<comment> \<open>sameRegionAs = 0\<close>
    apply (rule impI)
-   apply (clarsimp simp: from_bool_def false_def
+   apply (clarsimp simp: from_bool_def
                   split: if_split bool.splits)
 
   \<comment> \<open>sameRegionAs \<noteq> 0\<close>
-  apply (clarsimp simp: from_bool_def false_def)
+  apply (clarsimp simp: from_bool_def)
   apply (case_tac "RetypeDecls_H.sameRegionAs (cap_to_H x2b) (cap_to_H x2c)")
    prefer 2 apply clarsimp
   apply (clarsimp cong:bool.case_cong if_cong simp: typ_heap_simps)
@@ -3774,8 +3715,7 @@ lemma isMDBParentOf_spec:
    apply clarsimp
    apply (frule cap_get_tag_EndpointCap)
    apply simp
-   apply (clarsimp simp: to_bool_def isNotificationCap_def isEndpointCap_def true_def) \<comment> \<open>badge of A is not 0 now\<close>
-
+   apply (clarsimp simp: to_bool_def isNotificationCap_def isEndpointCap_def) \<comment> \<open>badge of A is not 0 now\<close>
 
    apply (subgoal_tac "cap_get_tag (cte_C.cap_C cte_b) = scast cap_endpoint_cap") \<comment> \<open>needed also after\<close>
     prefer 2
@@ -3790,8 +3730,7 @@ lemma isMDBParentOf_spec:
    apply clarsimp
    apply (frule cap_get_tag_NotificationCap)
    apply simp
-   apply (clarsimp simp: to_bool_def isNotificationCap_def isEndpointCap_def true_def) \<comment> \<open>badge of A is not 0 now\<close>
-
+   apply (clarsimp simp: to_bool_def isNotificationCap_def isEndpointCap_def) \<comment> \<open>badge of A is not 0 now\<close>
 
    apply (subgoal_tac "cap_get_tag (cte_C.cap_C cte_b) = scast cap_notification_cap") \<comment> \<open>needed also after\<close>
     prefer 2
@@ -3807,11 +3746,9 @@ lemma isMDBParentOf_spec:
   apply clarsimp
   apply (simp add: to_bool_def)
   apply (subgoal_tac "(\<not> (isEndpointCap (cap_to_H x2b))) \<and> ( \<not> (isNotificationCap (cap_to_H x2b)))")
-   apply (clarsimp simp: true_def)
-  apply (rule conjI)
-   apply (clarsimp simp: cap_get_tag_isCap [symmetric])+
-done
-
+   apply clarsimp
+  apply (clarsimp simp: cap_get_tag_isCap[symmetric])
+  done
 
 lemma updateCapData_spec:
   "\<forall>cap. \<Gamma> \<turnstile> \<lbrace> ccap_relation cap \<acute>cap \<and> preserve = to_bool (\<acute>preserve) \<and> newData = \<acute>newData\<rbrace>
@@ -3825,7 +3762,7 @@ lemma updateCapData_spec:
   apply (simp add: updateCapData_def)
 
   apply (case_tac cap, simp_all add: cap_get_tag_isCap_unfolded_H_cap
-                        isCap_simps from_bool_def isArchCap_tag_def2 cap_tag_defs Let_def)
+                                     isCap_simps isArchCap_tag_def2 cap_tag_defs Let_def)
   \<comment> \<open>NotificationCap\<close>
      apply clarsimp
      apply (frule cap_get_tag_isCap_unfolded_H_cap(3))
@@ -3954,7 +3891,6 @@ lemma ensureNoChildren_ccorres:
    apply (rule conjI)
    \<comment> \<open>isMDBParentOf is not zero\<close>
     apply clarsimp
-    apply (simp add: from_bool_def)
     apply (case_tac "isMDBParentOf (cte_to_H y) (cte_to_H ya)", simp_all)[1]
 
     apply (simp add: bind_def)
@@ -3965,7 +3901,6 @@ lemma ensureNoChildren_ccorres:
     apply (simp add: syscall_error_to_H_cases(9))
    \<comment> \<open>isMDBParentOf is zero\<close>
    apply clarsimp
-   apply (simp add: from_bool_def)
    apply (case_tac "isMDBParentOf (cte_to_H y) (cte_to_H ya)", simp_all)[1]
    apply (simp add: bind_def)
    apply (simp add: split_paired_Bex)
@@ -4077,9 +4012,8 @@ lemma Arch_deriveCap_ccorres:
      apply (rule context_conjI)
       apply (simp add: cap_get_tag_isCap_ArchObject)
      apply (clarsimp simp: returnOk_def return_def isCap_simps)
-     subgoal by  (simp add: ccap_relation_def cap_lift_def Let_def
-                            cap_tag_defs cap_to_H_def to_bool_def
-                            cap_small_frame_cap_lift_def asidInvalid_def)
+     subgoal by (simp add: ccap_relation_def cap_lift_def Let_def cap_tag_defs cap_to_H_def
+                           cap_small_frame_cap_lift_def asidInvalid_def)
     apply (clarsimp simp: ccorres_cond_iffs)
     apply (rule ccorres_from_vcg_throws[where P=\<top> and P'=UNIV])
     apply (rule allI, rule conseqPre, vcg)
@@ -4087,8 +4021,7 @@ lemma Arch_deriveCap_ccorres:
     apply (rule context_conjI)
      apply (simp add: cap_get_tag_isCap_ArchObject)
     apply (clarsimp simp: returnOk_def return_def isCap_simps)
-    subgoal by (simp add: ccap_relation_def cap_lift_def Let_def
-                          cap_tag_defs cap_to_H_def to_bool_def
+    subgoal by (simp add: ccap_relation_def cap_lift_def Let_def cap_tag_defs cap_to_H_def
                           cap_frame_cap_lift_def asidInvalid_def c_valid_cap_def cl_valid_cap_def)
    apply (simp add: cap_get_tag_isCap_ArchObject
                     ccorres_cond_iffs)
@@ -4112,7 +4045,7 @@ lemma deriveCap_ccorres':
    apply csymbr
    apply (fold case_bool_If)
    apply wpc
-    apply (clarsimp simp: cap_get_tag_isCap isCap_simps from_bool_def)
+    apply (clarsimp simp: cap_get_tag_isCap isCap_simps)
     apply csymbr
     apply (clarsimp simp: cap_get_tag_isCap)
     apply (rule ccorres_from_vcg_throws [where P=\<top> and P' = UNIV])
@@ -4121,7 +4054,7 @@ lemma deriveCap_ccorres':
      apply vcg
     apply clarsimp
    apply wpc
-    apply (clarsimp simp: isCap_simps cap_get_tag_isCap from_bool_def)
+    apply (clarsimp simp: isCap_simps cap_get_tag_isCap)
     apply csymbr
     apply (clarsimp simp: isCap_simps cap_get_tag_isCap)
     apply (rule ccorres_from_vcg_throws[where P=\<top> and P'=UNIV])
@@ -4129,7 +4062,7 @@ lemma deriveCap_ccorres':
     apply (clarsimp simp: returnOk_def return_def
                           ccap_relation_NullCap_iff)
    apply wpc
-    apply (clarsimp simp: isCap_simps cap_get_tag_isCap from_bool_def)
+    apply (clarsimp simp: isCap_simps cap_get_tag_isCap)
     apply csymbr
     apply (clarsimp simp: isCap_simps cap_get_tag_isCap)
     apply (rule ccorres_rhs_assoc)+
@@ -4154,7 +4087,7 @@ lemma deriveCap_ccorres':
                            errstate_def)
     apply wp
    apply wpc
-    apply (clarsimp simp: isCap_simps cap_get_tag_isCap from_bool_def)
+    apply (clarsimp simp: isCap_simps cap_get_tag_isCap)
     apply csymbr
     apply (clarsimp simp: isCap_simps cap_get_tag_isCap)
     apply (rule ccorres_from_vcg_throws[where P=\<top> and P'=UNIV])
@@ -4168,7 +4101,7 @@ lemma deriveCap_ccorres':
      apply vcg
     apply (clarsimp simp: cap_get_tag_isCap
                           liftME_def Let_def isArchCap_T_isArchObjectCap
-                          ccorres_cond_univ_iff from_bool_def)
+                          ccorres_cond_univ_iff)
     apply (rule ccorres_add_returnOk)
     apply (rule ccorres_split_nothrow_call_novcgE
                     [where xf'=ret__struct_deriveCap_ret_C_'])
@@ -4186,7 +4119,7 @@ lemma deriveCap_ccorres':
      apply (rule allI, rule conseqPre, vcg)
      apply (clarsimp simp: return_def throwError_def)
     apply wp
-   apply (simp add: cap_get_tag_isCap isArchCap_T_isArchObjectCap from_bool_def)
+   apply (simp add: cap_get_tag_isCap isArchCap_T_isArchObjectCap)
    apply csymbr
    apply (simp add: cap_get_tag_isCap)
    apply (rule ccorres_from_vcg_throws[where P=\<top> and P'=UNIV])
@@ -4196,7 +4129,6 @@ lemma deriveCap_ccorres':
                         Collect_const_mem from_bool_0
                         cap_get_tag_isArchCap_unfolded_H_cap)
   done
-
 
 lemma deriveCap_ccorres:
   "ccorres (syscall_error_rel \<currency> ccap_relation) deriveCap_xf

--- a/proof/crefine/ARM_HYP/CSpace_RAB_C.thy
+++ b/proof/crefine/ARM_HYP/CSpace_RAB_C.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2023, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -219,7 +220,7 @@ next
        apply (vcg strip_guards=true) \<comment> \<open>takes a while\<close>
        apply clarsimp
       apply simp
-     apply (clarsimp simp: cap_get_tag_isCap to_bool_def)
+     apply (clarsimp simp: cap_get_tag_isCap)
   \<comment> \<open>Main thm\<close>
   proof (induct cap' cptr' guard' rule: resolveAddressBits.induct [case_names ind])
     case (ind cap cptr guard)
@@ -559,8 +560,8 @@ lemma rightsFromWord_spec:
   \<lbrace>seL4_CapRights_lift \<acute>ret__struct_seL4_CapRights_C = cap_rights_from_word_canon \<^bsup>s\<^esup>w \<rbrace>"
   apply vcg
   apply (simp add: seL4_CapRights_lift_def nth_shiftr mask_shift_simps nth_shiftr
-    cap_rights_from_word_canon_def from_bool_def word_and_1 eval_nat_numeral
-    word_sless_def word_sle_def)
+                   cap_rights_from_word_canon_def word_and_1 eval_nat_numeral
+                   word_sless_def word_sle_def)
   done
 
 
@@ -574,12 +575,6 @@ lemma cap_rights_to_H_from_word_canon [simp]:
   apply (simp add: cap_rights_from_word_canon_def)
   apply (simp add: cap_rights_to_H_def)
   done
-
-(* MOVE *)
-lemma to_bool_false [simp]:
-  "to_bool false = False"
-  unfolding to_bool_def false_def
-  by simp
 
 
 lemma tcb_ptr_to_ctcb_ptr_mask [simp]:

--- a/proof/crefine/ARM_HYP/Delete_C.thy
+++ b/proof/crefine/ARM_HYP/Delete_C.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2023, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -141,7 +142,7 @@ lemma capRemovable_spec:
   supply if_cong[cong]
   apply vcg
   apply (clarsimp simp: cap_get_tag_isCap(1-8)[THEN trans[OF eq_commute]])
-  apply (simp add: capRemovable_def from_bool_def[where b=True] true_def)
+  apply (simp add: capRemovable_def)
   apply (clarsimp simp: ccap_zombie_radix_less4)
   apply (subst eq_commute, subst from_bool_eq_if)
   apply (rule exI, rule conjI, assumption)
@@ -635,7 +636,7 @@ lemma reduceZombie_ccorres1:
       apply (rule ccorres_inst[where P=\<top> and P'=UNIV])
       apply simp
      apply (simp add: guard_is_UNIV_def Collect_const_mem)
-     apply (clarsimp simp: from_bool_def false_def isCap_simps size_of_def cte_level_bits_def)
+     apply (clarsimp simp: isCap_simps size_of_def cte_level_bits_def)
      apply (simp only: word_bits_def unat_of_nat unat_arith_simps, simp)
     apply (simp add: guard_is_UNIV_def)+
   apply (clarsimp simp: cte_wp_at_ctes_of)
@@ -717,8 +718,7 @@ lemma finaliseSlot_ccorres:
         apply (rule ccorres_drop_cutMon)
         apply (rule ccorres_from_vcg_throws[where P=\<top> and P'=UNIV])
         apply (rule allI, rule conseqPre, vcg)
-        apply (clarsimp simp: returnOk_def return_def
-                              from_bool_def true_def ccap_relation_NullCap_iff)
+        apply (clarsimp simp: returnOk_def return_def ccap_relation_NullCap_iff)
        apply (simp add: Collect_True liftE_bindE split_def
                         ccorres_cond_iffs cutMon_walk_bind
                    del: Collect_const cong: call_ignore_cong)
@@ -757,8 +757,7 @@ lemma finaliseSlot_ccorres:
                                       | _ \<Rightarrow> True"
                               in ccorres_from_vcg_throws[where P'=UNIV])
               apply (rule allI, rule conseqPre, vcg)
-              apply (clarsimp simp: returnOk_def return_def
-                                    from_bool_def true_def)
+              apply (clarsimp simp: returnOk_def return_def)
               apply (clarsimp simp: cleanup_info_wf'_def arch_cleanup_info_wf'_def
                              split: if_split capability.splits)
              apply vcg
@@ -795,11 +794,11 @@ lemma finaliseSlot_ccorres:
                   apply (rule allI, rule conseqPre, vcg)
                   apply (clarsimp simp: returnOk_def return_def)
                   apply (drule use_valid [OF _ finaliseCap_cases, OF _ TrueI])
-                  apply (simp add: from_bool_def false_def irq_opt_relation_def true_def
+                  apply (simp add: irq_opt_relation_def
                             split: if_split_asm)
                  apply vcg
                 apply wp
-               apply (simp add: guard_is_UNIV_def true_def)
+               apply (simp add: guard_is_UNIV_def)
               apply wp
              apply (simp add: guard_is_UNIV_def)
             apply (simp only: liftE_bindE cutMon_walk_bind Let_def
@@ -824,7 +823,6 @@ lemma finaliseSlot_ccorres:
                                in ccorres_from_vcg[where P'=UNIV])
                   apply (rule allI, rule conseqPre, vcg)
                   apply (clarsimp simp: return_def)
-                  apply (simp add: from_bool_def false_def)
                   apply fastforce
                  apply ceqv
                 apply (simp only: from_bool_0 simp_thms Collect_False
@@ -894,7 +892,7 @@ lemma finaliseSlot_ccorres:
                       simp: isCap_simps final_matters'_def o_def)
         apply clarsimp
         apply (frule valid_globals_cte_wpD'[rotated], clarsimp)
-        apply (clarsimp simp: cte_wp_at_ctes_of false_def from_bool_def)
+        apply (clarsimp simp: cte_wp_at_ctes_of)
         apply (erule(1) cmap_relationE1 [OF cmap_relation_cte])
         apply (frule valid_global_refsD_with_objSize, clarsimp)
         apply (auto simp: typ_heap_simps dest!: ccte_relation_ccap_relation)[1]
@@ -1020,9 +1018,8 @@ lemma cteRevoke_ccorres1:
         apply (rule ccorres_from_vcg_throws[where P=\<top> and P'=UNIV])
         apply (rule allI, rule conseqPre, vcg)
         apply (clarsimp simp: returnOk_def return_def)
-       apply (simp add: guard_is_UNIV_def from_bool_def true_def cintr_def
-                        Collect_const_mem exception_defs)
-      apply (simp add: guard_is_UNIV_def from_bool_def true_def)
+       apply (simp add: guard_is_UNIV_def cintr_def Collect_const_mem exception_defs)
+      apply (simp add: guard_is_UNIV_def)
      apply (rule getCTE_wp)
     apply (clarsimp simp: cte_wp_at_ctes_of nullPointer_def)
     apply (drule invs_mdb')

--- a/proof/crefine/ARM_HYP/Fastpath_C.thy
+++ b/proof/crefine/ARM_HYP/Fastpath_C.thy
@@ -1160,7 +1160,7 @@ lemma isValidVTableRoot_fp_spec:
        {t. ret__unsigned_long_' t = from_bool (isValidVTableRoot_C (pd_cap_' s))}"
   apply vcg
   apply (clarsimp simp: word_sle_def word_sless_def isValidVTableRoot_fp_lemma)
-  apply (simp add: from_bool_def split: if_split)
+  apply (simp split: if_split)
   done
 
 lemma isRecvEP_endpoint_case:
@@ -1570,8 +1570,8 @@ lemma cap_reply_cap_ptr_new_np_updateCap_ccorres:
                    limited_and_simps cap_reply_cap_def
                    limited_and_simps1[OF lshift_limited_and, OF limited_and_from_bool]
                    shiftr_over_or_dist word_bw_assocs mask_def shiftl_shiftr3 word_size)
-  apply (cases m ; clarsimp)
-  apply (cases canGrant ; clarsimp)
+  apply (cases m ; clarsimp simp: true_def)
+  apply (cases canGrant ; clarsimp simp: true_def false_def)
   done
 
 lemma fastpath_copy_mrs_ccorres:
@@ -2913,7 +2913,6 @@ lemma fastpath_reply_recv_ccorres:
                         apply (rule slowpath_ccorres, simp+)
                      apply (vcg exspec=slowpath_noreturn_spec)
                     apply (simp add: pde_stored_asid_def asid_map_pd_to_hwasids_def
-                                     to_bool_def
                                 del: Collect_const cong: call_ignore_cong)
 
                     apply (rule ccorres_rhs_assoc2)
@@ -2937,8 +2936,7 @@ lemma fastpath_reply_recv_ccorres:
                          apply (simp add: cep_relations_drop_fun_upd)
                          apply (erule cmap_relation_updI, erule ko_at_projectKO_opt)
                           apply (simp add: ctcb_relation_def cthread_state_relation_def
-                                           "StrictC'_thread_state_defs" from_bool_0
-                                           to_bool_def if_1_0_0)
+                                           "StrictC'_thread_state_defs")
                           apply (clarsimp simp: ccap_relation_ep_helpers)
                          apply simp
                         apply (rule conjI, erule cready_queues_relation_not_queue_ptrs)

--- a/proof/crefine/ARM_HYP/Finalise_C.thy
+++ b/proof/crefine/ARM_HYP/Finalise_C.thy
@@ -869,7 +869,7 @@ lemma finaliseCap_True_cases_ccorres:
    apply csymbr
    apply (simp add: cap_get_tag_isCap Collect_False del: Collect_const)
    apply (fold case_bool_If)
-   apply (simp add: false_def)
+   apply simp
    apply csymbr
    apply wpc
     apply (simp add: cap_get_tag_isCap ccorres_cond_univ_iff Let_def)
@@ -1237,8 +1237,7 @@ lemma deleteASID_ccorres:
         apply (simp add: asid_low_bits_def Kernel_C.asidLowBits_def
                          mask_def word_and_le1)
         apply (drule sym, simp)
-        apply (simp add: option_to_ptr_def option_to_0_def
-                         from_bool_def inv_ASIDPool
+        apply (simp add: option_to_ptr_def option_to_0_def inv_ASIDPool
                   split: option.split if_split bool.split)
        apply ceqv
       apply (rule ccorres_cond2[where R=\<top>])
@@ -1508,7 +1507,7 @@ lemma isFinalCapability_ccorres:
            apply (simp add: mdbPrev_to_H[symmetric])
           apply (rule ccorres_from_vcg[where P=\<top> and P'=UNIV])
           apply (rule allI, rule conseqPre, vcg)
-          apply (simp add: return_def from_bool_def false_def)
+          apply (simp add: return_def)
          apply (rule ccorres_rhs_assoc)+
          apply (rule ccorres_symb_exec_l[OF _ getCTE_inv getCTE_wp empty_fail_getCTE])
          apply (rule_tac P="cte_wp_at' ((=) cte) slot
@@ -1547,10 +1546,9 @@ lemma isFinalCapability_ccorres:
        apply (rule cmap_relationE1 [OF cmap_relation_cte], assumption+,
                   simp?, simp add: typ_heap_simps)+
        apply (drule ccte_relation_ccap_relation)+
-       apply (auto simp: false_def true_def from_bool_def split: bool.splits)[1]
+       apply (auto simp: from_bool_def split: bool.splits)[1]
       apply (wp getCTE_wp')
-     apply (clarsimp simp add: guard_is_UNIV_def Collect_const_mem false_def
-                               from_bool_0 true_def from_bool_def)
+     apply (clarsimp simp add: guard_is_UNIV_def Collect_const_mem)
     apply vcg
    apply (rule conseqPre, vcg)
    apply clarsimp
@@ -1608,13 +1606,12 @@ lemma cteDeleteOne_ccorres:
         apply (strengthen invs_mdb_strengthen' invs_urz)
         apply (wp typ_at_lifts isFinalCapability_inv
             | strengthen invs_valid_objs')+
-       apply (clarsimp simp: from_bool_def true_def irq_opt_relation_def
-                             invs_pspace_aligned' cte_wp_at_ctes_of)
+       apply (clarsimp simp: irq_opt_relation_def invs_pspace_aligned' cte_wp_at_ctes_of)
        apply (erule(1) cmap_relationE1 [OF cmap_relation_cte])
        apply (clarsimp simp: typ_heap_simps ccte_relation_ccap_relation ccap_relation_NullCap_iff)
       apply (wp isFinalCapability_inv)
      apply simp
-    apply (simp del: Collect_const add: false_def)
+    apply (simp del: Collect_const)
    apply (rule ccorres_return_Skip)
   apply (clarsimp simp: Collect_const_mem cte_wp_at_ctes_of)
   apply (erule(1) cmap_relationE1 [OF cmap_relation_cte])
@@ -1897,11 +1894,11 @@ lemma armHSCurVCPU_update_active_false_ccorres:
   apply (clarsimp simp: modifyArchState_def)
   apply (rule ccorres_from_vcg)
   apply (rule allI, rule conseqPre, vcg)
-  apply (clarsimp simp: bind_def simpler_gets_def from_bool_def simpler_modify_def)
+  apply (clarsimp simp: bind_def simpler_gets_def simpler_modify_def)
   apply (clarsimp simp: rf_sr_def cstate_relation_def Let_def)
-  apply (clarsimp simp: cmachine_state_relation_def from_bool_def)
+  apply (clarsimp simp: cmachine_state_relation_def)
   apply (clarsimp simp: carch_state_relation_def carch_globals_def cur_vcpu_relation_def)
-  apply (case_tac "armHSCurVCPU (ksArchState \<sigma>)"; clarsimp simp: from_bool_def false_def)
+  apply (case_tac "armHSCurVCPU (ksArchState \<sigma>)"; clarsimp)
   done
 
 lemma armHSCurVCPU_update_curv_Null_ccorres:
@@ -1914,8 +1911,8 @@ lemma armHSCurVCPU_update_curv_Null_ccorres:
   apply (clarsimp simp: bind_def simpler_gets_def simpler_modify_def)
   apply (clarsimp simp: rf_sr_def cstate_relation_def Let_def)
   apply (clarsimp simp: carch_state_relation_def carch_globals_def cur_vcpu_relation_def
-                     cmachine_state_relation_def from_bool_def true_def false_def
-               split: bool.split option.splits)
+                        cmachine_state_relation_def
+                 split: bool.split option.splits)
   done
 
 lemma vcpuInvalidateActive_ccorres:
@@ -1935,8 +1932,8 @@ lemma vcpuInvalidateActive_ccorres:
         apply clarsimp
         apply (frule rf_sr_ksArchState_armHSCurVCPU)
         apply (case_tac "\<exists> t. (armHSCurVCPU \<circ> ksArchState) s =  Some t \<and> snd t")
-         apply (clarsimp simp: cur_vcpu_relation_def true_def)
-        apply (clarsimp simp: cur_vcpu_relation_def true_def)
+         apply (clarsimp simp: cur_vcpu_relation_def)
+        apply (clarsimp simp: cur_vcpu_relation_def)
         apply (case_tac "(armHSCurVCPU \<circ> ksArchState) s"; clarsimp)
        apply (rule_tac a=" _ >>= (\<lambda>_. when (hsCurVCPU \<noteq> None \<and> snd (the hsCurVCPU))
                                           (modifyArchState(armHSCurVCPU_update
@@ -1980,7 +1977,7 @@ lemma sanitiseSetRegister_ccorres:
                       UNIV
                       hs
              (asUser tptr (setRegister reg (local.sanitiseRegister False reg val)))
-             (\<acute>unsigned_long_eret_2 :== CALL sanitiseRegister(reg',val',0);;
+             (\<acute>unsigned_long_eret_2 :== CALL sanitiseRegister(reg',val',scast false);;
               CALL setRegister(tcb_ptr_to_ctcb_ptr tptr,reg',\<acute>unsigned_long_eret_2))"
   apply (rule ccorres_guard_imp2)
    apply (rule ccorres_symb_exec_r)
@@ -2034,7 +2031,7 @@ lemma dissociateVCPUTCB_ccorres:
     apply (case_tac "tcbVCPU = Some vcpuptr \<longrightarrow> vcpuTCBPtr vcpu \<noteq> Some tptr")
      apply simp
      apply (rule ccorres_fail')
-    apply (simp add: false_def)
+    apply simp
     apply ccorres_rewrite
     apply (rule ccorres_pre_getCurVCPU)
     apply (rule ccorres_split_nothrow[where r'=dc and xf'=xfdc])
@@ -2406,7 +2403,7 @@ lemma Arch_finaliseCap_ccorres:
       apply (frule cap_get_tag_isCap_unfolded_H_cap)
       apply (frule cap_lift_page_directory_cap)
       apply (clarsimp simp: ccap_relation_def cap_to_H_def capAligned_def
-                            to_bool_def cap_page_directory_cap_lift_def
+                            cap_page_directory_cap_lift_def
                             asid_bits_def
                       split: if_split_asm)
      apply simp
@@ -2449,9 +2446,8 @@ lemma Arch_finaliseCap_ccorres:
       apply (frule cap_get_tag_isCap_unfolded_H_cap)
       apply (frule cap_lift_page_table_cap)
       apply (clarsimp simp: ccap_relation_def cap_to_H_def capAligned_def
-                            to_bool_def cap_page_table_cap_lift_def
-                            asid_bits_def
-                      split: if_split_asm)
+                            cap_page_table_cap_lift_def asid_bits_def
+                     split: if_split_asm)
      apply simp
      apply return_NullCap_pair_ccorres
     apply (clarsimp simp: isCap_simps)
@@ -2625,7 +2621,7 @@ lemma Arch_finaliseCap_ccorres:
      apply (frule cap_get_tag_isCap_unfolded_H_cap)
      apply (frule cap_lift_page_directory_cap)
      apply (clarsimp simp: ccap_relation_def cap_to_H_def capAligned_def
-                           to_bool_def cap_page_directory_cap_lift_def
+                           cap_page_directory_cap_lift_def
                            asid_bits_def
                      split: if_split_asm)
     apply (frule cap_get_tag_isCap_unfolded_H_cap)
@@ -2720,7 +2716,7 @@ lemma finaliseCap_ccorres:
                del: Collect_const)
    apply (rule ccorres_if_lhs)
     apply (simp, rule ccorres_fail)
-   apply (simp add: from_bool_0 Collect_True Collect_False false_def
+   apply (simp add: from_bool_0 Collect_True Collect_False
                del: Collect_const)
    apply csymbr
    apply (simp add: cap_get_tag_isCap Collect_False Collect_True
@@ -2805,7 +2801,7 @@ lemma finaliseCap_ccorres:
    apply (simp add: isArchCap_T_isArchObjectCap[symmetric]
                del: Collect_const)
    apply (rule ccorres_if_lhs)
-    apply (simp add: Collect_False Collect_True Let_def true_def
+    apply (simp add: Collect_False Collect_True Let_def
                 del: Collect_const)
     apply (rule_tac P="(capIRQ cap) \<le>  ARM_HYP.maxIRQ" in ccorres_gen_asm)
     apply (rule ccorres_rhs_assoc)+
@@ -2845,8 +2841,7 @@ lemma finaliseCap_ccorres:
                            irq_opt_relation_def)
     apply wp
    apply (simp add: guard_is_UNIV_def)
-  apply (clarsimp simp: cap_get_tag_isCap word_sle_def Collect_const_mem
-                        false_def from_bool_def)
+  apply (clarsimp simp: cap_get_tag_isCap word_sle_def Collect_const_mem)
   apply (intro impI conjI)
                 apply (clarsimp split: bool.splits)
                apply (clarsimp split: bool.splits)
@@ -2863,7 +2858,7 @@ lemma finaliseCap_ccorres:
                       split: option.splits cap_CL.splits if_splits)
      apply clarsimp
      apply (frule cap_get_tag_to_H, erule(1) cap_get_tag_isCap [THEN iffD2])
-     apply (clarsimp simp: isCap_simps from_bool_def false_def)
+     apply (clarsimp simp: isCap_simps)
      apply (clarsimp simp: tcb_cnode_index_defs ptr_add_assertion_def)
     apply clarsimp
     apply (frule cap_get_tag_to_H, erule(1) cap_get_tag_isCap [THEN iffD2])

--- a/proof/crefine/ARM_HYP/Interrupt_C.thy
+++ b/proof/crefine/ARM_HYP/Interrupt_C.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2023, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -16,7 +17,7 @@ lemma invokeIRQHandler_AckIRQ_ccorres:
      (InterruptDecls_H.invokeIRQHandler (AckIRQ irq)) (Call invokeIRQHandler_AckIRQ_'proc)"
   apply (cinit lift: irq_' simp: Interrupt_H.invokeIRQHandler_def invokeIRQHandler_def)
    apply (ctac add: maskInterrupt_ccorres)
-  apply (simp add: from_bool_def false_def)
+  apply simp
   done
 
 lemma getIRQSlot_ccorres:
@@ -266,12 +267,12 @@ lemma decodeIRQHandlerInvocation_ccorres:
     sysargs_rel_n_def word_less_nat_alt)
   apply (clarsimp simp: cte_wp_at_ctes_of neq_Nil_conv sysargs_rel_def n_msgRegisters_def
                     excaps_map_def excaps_in_mem_def word_less_nat_alt hd_conv_nth
-                    slotcap_in_mem_def valid_tcb_state'_def from_bool_def toBool_def
+                    slotcap_in_mem_def valid_tcb_state'_def
              dest!: interpret_excaps_eq split: bool.splits)
   apply (intro conjI impI allI)
   apply (clarsimp simp: cte_wp_at_ctes_of neq_Nil_conv sysargs_rel_def n_msgRegisters_def
                     excaps_map_def excaps_in_mem_def word_less_nat_alt hd_conv_nth
-                    slotcap_in_mem_def valid_tcb_state'_def from_bool_def toBool_def
+                    slotcap_in_mem_def valid_tcb_state'_def
              dest!: interpret_excaps_eq split: bool.splits)+
      apply (auto dest: st_tcb_at_idle_thread' ctes_of_valid')[4]
     apply (drule ctes_of_valid')
@@ -582,7 +583,7 @@ lemma Arch_decodeIRQControlInvocation_ccorres:
   apply (clarsimp simp: Kernel_C.maxIRQ_def word_le_nat_alt
                         ucast_nat_def ucast_ucast_mask mask_eq_ucast_eq unat_ucast_mask
                         less_mask_eq[unfolded word_less_nat_alt])
-  apply (cases "args ! Suc 0 = 0"; clarsimp simp: true_def false_def)
+  apply (cases "args ! Suc 0 = 0"; clarsimp)
   done
 
 lemma decodeIRQControlInvocation_ccorres:

--- a/proof/crefine/ARM_HYP/Invoke_C.thy
+++ b/proof/crefine/ARM_HYP/Invoke_C.thy
@@ -64,7 +64,7 @@ lemma setDomain_ccorres:
           apply (rule ccorres_cond2[where R=\<top>], simp add: Collect_const_mem)
            apply (ctac add: tcbSchedEnqueue_ccorres)
           apply (rule ccorres_return_Skip)
-         apply (simp add: when_def to_bool_def)
+         apply (simp add: when_def)
          apply (rule_tac R="\<lambda>s. rv = ksCurThread s"
                     in ccorres_cond2)
            apply (clarsimp simp: rf_sr_ksCurThread)
@@ -228,7 +228,7 @@ lemma invokeCNodeDelete_ccorres:
    apply (rule ccorres_trim_returnE, simp, simp)
    apply (rule ccorres_callE)
        apply (rule cteDelete_ccorres[simplified])
-      apply (simp add: from_bool_def true_def)+
+      apply simp+
 done
 
 
@@ -248,7 +248,7 @@ lemma invokeCNodeRevoke_ccorres:
    apply (rule ccorres_trim_returnE, simp, simp)
    apply (rule ccorres_callE)
        apply (rule cteRevoke_ccorres[simplified])
-      apply (simp add: from_bool_def true_def)+
+      apply simp+
 done
 
 
@@ -556,12 +556,10 @@ lemma hasCancelSendRights_spec:
    apply clarsimp
    apply (drule sym, drule (1) cap_get_tag_to_H)
    apply (clarsimp simp: hasCancelSendRights_def to_bool_def
-                         true_def false_def
                    split: if_split bool.splits)
   apply (rule impI)
   apply (case_tac cap,
-         auto simp: cap_get_tag_isCap_unfolded_H_cap cap_tag_defs
-                     from_bool_def false_def true_def hasCancelSendRights_def
+         auto simp: cap_get_tag_isCap_unfolded_H_cap cap_tag_defs hasCancelSendRights_def
               dest: cap_get_tag_isArchCap_unfolded_H_cap
               split: capability.splits bool.splits)[1]
   done
@@ -756,7 +754,7 @@ lemma decodeCNodeInvocation_ccorres:
                                 apply (simp add: syscall_error_to_H_cases)
                                apply (simp add: whenE_def injection_handler_returnOk
                                                 ccorres_invocationCatch_Inr performInvocation_def
-                                                bindE_assoc false_def)
+                                                bindE_assoc)
                                apply (ctac add: setThreadState_ccorres)
                                  apply (simp add: ccorres_cond_iffs)
                                  apply (ctac(no_vcg) add: invokeCNodeInsert_ccorres)
@@ -832,7 +830,7 @@ lemma decodeCNodeInvocation_ccorres:
                                     apply (rule syscall_error_throwError_ccorres_n)
                                     apply (simp add: syscall_error_to_H_cases)
                                    apply (simp add: whenE_def injection_handler_returnOk
-                                                    ccorres_invocationCatch_Inr false_def
+                                                    ccorres_invocationCatch_Inr
                                                     performInvocation_def bindE_assoc)
                                    apply (ctac add: setThreadState_ccorres)
                                      apply (simp add: ccorres_cond_iffs)
@@ -888,7 +886,7 @@ lemma decodeCNodeInvocation_ccorres:
                                        in ccorres_gen_asm2)
                            apply csymbr
                            apply csymbr
-                           apply (simp add: cap_get_tag_NullCap true_def)
+                           apply (simp add: cap_get_tag_NullCap)
                            apply (ctac add: setThreadState_ccorres)
                              apply (simp add: ccorres_cond_iffs)
                              apply (ctac(no_vcg) add: invokeCNodeMove_ccorres)
@@ -934,7 +932,7 @@ lemma decodeCNodeInvocation_ccorres:
                                               ccorres_invocationCatch_Inr numeral_eqs
                                               performInvocation_def bindE_assoc)
                              apply (ctac add: setThreadState_ccorres)
-                               apply (simp add: true_def ccorres_cond_iffs)
+                               apply (simp add: ccorres_cond_iffs)
                                apply (ctac(no_vcg) add: invokeCNodeMove_ccorres)
                                  apply (rule ccorres_alternative2)
                                  apply (rule ccorres_return_CE, simp+)[1]
@@ -1394,8 +1392,7 @@ lemma decodeCNodeInvocation_ccorres:
                              map_option_Some_eq2 neq_Nil_conv ccap_relation_def
                              numeral_eqs hasCancelSendRights_not_Null
                              ccap_relation_NullCap_iff[symmetric]
-                             if_1_0_0 interpret_excaps_test_null
-                             mdbRevocable_CL_cte_to_H false_def true_def
+                             interpret_excaps_test_null mdbRevocable_CL_cte_to_H
             | clarsimp simp: typ_heap_simps'
             | frule length_ineq_not_Nil)+)
   done
@@ -3312,8 +3309,8 @@ lemma decodeUntypedInvocation_ccorres_helper:
                                           unat_of_nat_APIType_capBits word_size length_ineq_not_Nil
                                           not_less word_le_nat_alt isCap_simps valid_cap_simps')
                     apply (strengthen word_of_nat_less)
-                    apply (clarsimp simp: StrictC'_thread_state_defs mask_def true_def false_def
-                                          from_bool_0 ccap_relation_isDeviceCap2
+                    apply (clarsimp simp: StrictC'_thread_state_defs mask_def
+                                          ccap_relation_isDeviceCap2
                                    split: if_split)
                     apply (intro conjI impI;
                            clarsimp simp: not_less shiftr_eq_0 unat_of_nat_APIType_capBits

--- a/proof/crefine/ARM_HYP/IpcCancel_C.thy
+++ b/proof/crefine/ARM_HYP/IpcCancel_C.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2023, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -424,9 +425,9 @@ lemma isStopped_ccorres [corres]:
    apply vcg
    apply clarsimp
   apply clarsimp
-  apply (clarsimp simp: to_bool_def true_def false_def typ_heap_simps
-    ctcb_relation_thread_state_to_tsType split: thread_state.splits)
-  apply (simp add: "StrictC'_thread_state_defs")+
+  apply (clarsimp simp: typ_heap_simps ctcb_relation_thread_state_to_tsType
+                 split: thread_state.splits)
+    apply (simp add: "StrictC'_thread_state_defs")+
   done
 
 lemma isRunnable_ccorres [corres]:
@@ -452,10 +453,10 @@ lemma isRunnable_ccorres [corres]:
     apply (vcg)
    apply (clarsimp)
   apply (clarsimp)
-  apply (clarsimp simp: to_bool_def true_def false_def typ_heap_simps
-    ctcb_relation_thread_state_to_tsType split: thread_state.splits)
-  apply (simp add: "StrictC'_thread_state_defs")+
-done
+  apply (clarsimp simp: typ_heap_simps ctcb_relation_thread_state_to_tsType
+                 split: thread_state.splits)
+       apply (simp add: "StrictC'_thread_state_defs")+
+  done
 
 
 
@@ -784,13 +785,6 @@ lemma state_relation_queue_update_helper:
   apply (drule(1) bspec)
   apply (erule obj_at'_weakenE, clarsimp)
   done
-
-(* FIXME: move *)
-lemma from_bool_vals [simp]:
-  "from_bool True = scast true"
-  "from_bool False = scast false"
-  "scast true \<noteq> scast false"
-  by (auto simp add: from_bool_def true_def false_def)
 
 (* FIXME: move *)
 lemma cmap_relation_no_upd:
@@ -1933,10 +1927,6 @@ proof -
                          valid_obj'_def inQ_def
                    dest!: valid_queues_obj_at'D)
 qed
-
-lemma true_eq_from_bool [simp]:
-  "(scast true = from_bool P) = P"
-  by (simp add: true_def from_bool_def split: bool.splits)
 
 lemma isStopped_spec:
   "\<forall>s. \<Gamma> \<turnstile> ({s} \<inter> {s. cslift s (thread_' s) \<noteq> None}) Call isStopped_'proc

--- a/proof/crefine/ARM_HYP/Ipc_C.thy
+++ b/proof/crefine/ARM_HYP/Ipc_C.thy
@@ -1268,7 +1268,7 @@ lemma setMRs_syscall_error_ccorres:
                  | wp hoare_case_option_wp
                  | (simp del: Collect_const, vcg exspec=setMR_modifies)
                )+
-   apply (simp add: msgMaxLength_unfold true_def false_def)
+   apply (simp add: msgMaxLength_unfold)
    apply (clarsimp split:if_split_asm simp:syscall_error_to_H_def map_option_Some_eq2)
    apply (simp add: msgFromLookupFailure_def
                  split: lookup_failure.split
@@ -3087,9 +3087,8 @@ next
                               word_sle_def t2n_mask_eq_if)
             apply (rule conjI)
              apply (clarsimp simp: ccap_rights_relation_def cap_rights_to_H_def
-                                 false_def true_def to_bool_def allRights_def
-                                 excaps_map_def split_def
-                          dest!: drop_n_foo interpret_excaps_eq)
+                                   allRights_def excaps_map_def split_def
+                            dest!: drop_n_foo interpret_excaps_eq)
             apply (clarsimp simp:from_bool_def split:bool.splits)
              apply (case_tac "isEndpointCap (fst x)")
               apply (clarsimp simp: cap_get_tag_EndpointCap ep_cap_not_null cap_get_tag_isCap[symmetric])
@@ -3129,7 +3128,7 @@ next
          apply (rule conseqPre, vcg)
          apply (clarsimp split del: if_split)
         apply (clarsimp split del: if_split
-                       simp add: Collect_const[symmetric] precond_def true_def false_def
+                       simp add: Collect_const[symmetric] precond_def
                        simp del: Collect_const)
         apply (rule HoarePartial.Seq[rotated] HoarePartial.Cond[OF order_refl]
                   HoarePartial.Basic[OF order_refl] HoarePartial.Skip[OF order_refl]
@@ -3466,7 +3465,7 @@ proof -
                         apply (clarsimp simp: cfault_rel2_def)
                         apply (clarsimp simp: cfault_rel_def)
                         apply (simp add: seL4_Fault_CapFault_lift)
-                        apply (clarsimp simp: is_cap_fault_def to_bool_def false_def)
+                        apply (clarsimp simp: is_cap_fault_def)
                        apply wp
                        apply (rule hoare_post_imp_R, rule lsft_real_cte)
                        apply (clarsimp simp: obj_at'_def projectKOs objBits_simps')
@@ -3722,7 +3721,7 @@ lemma replyFromKernel_error_ccorres [corres]:
                    message_info_to_H_def valid_pspace_valid_objs')
   apply (clarsimp simp: msgLengthBits_def msgFromSyscallError_def
                         syscall_error_to_H_def syscall_error_type_defs
-                        mask_def true_def option_to_ptr_def
+                        mask_def option_to_ptr_def
                  split: if_split_asm)
   done
 
@@ -3780,7 +3779,7 @@ lemma doIPCTransfer_ccorres [corres]:
                            fault_to_fault_tag_nonzero)
      apply (fold dc_def)[1]
      apply ctac
-    apply (clarsimp simp: guard_is_UNIV_def false_def option_to_ptr_def split: option.splits)
+    apply (clarsimp simp: guard_is_UNIV_def option_to_ptr_def split: option.splits)
    apply (rule_tac Q="\<lambda>rv. valid_pspace' and cur_tcb' and tcb_at' sender
                        and tcb_at' receiver and K (rv \<noteq> Some 0)
                        and (case_option \<top> valid_ipc_buffer_ptr' rv)
@@ -3789,7 +3788,7 @@ lemma doIPCTransfer_ccorres [corres]:
     apply (auto simp: valid_ipc_buffer_ptr'_def option_to_0_def
                    split: option.splits)[1]
    apply (wp lookupIPCBuffer_not_Some_0 lookupIPCBuffer_aligned)
-  apply (auto simp: to_bool_def true_def)
+  apply auto
   done
 
 lemma fault_case_absorb_bind:
@@ -3820,7 +3819,7 @@ lemma Arch_getSanitiseRegisterInfo_ccorres:
    apply (clarsimp simp: valid_tcb'_def valid_arch_tcb'_def)
   apply (clarsimp simp: typ_heap_simps)
   apply (case_tac "atcbVCPUPtr (tcbArch tcb) \<noteq> None")
-   apply (clarsimp simp:if_1_0_0 true_def false_def split: if_splits)+
+   apply (clarsimp split: if_splits)+
   done
 
 
@@ -3864,7 +3863,7 @@ apply (ctac(no_vcg) add: Arch_getSanitiseRegisterInfo_ccorres)
                   apply (vcg)
                  apply clarsimp
                  apply (rule conseqPre, vcg)
-                 apply (auto simp: from_bool_def sanitiseRegister_def)[1]
+                 apply (auto simp: sanitiseRegister_def)[1]
                 apply wp
                apply clarsimp
                apply vcg
@@ -4155,7 +4154,7 @@ lemma handleArchFaultReply_corres:
             apply simp+
          apply (rule ccorres_symb_exec_l)
             apply (ctac add: ccorres_return_C)
-           apply (wp mapM_wp' empty_fail_loadWordUser | clarsimp simp: to_bool_def true_def)+
+           apply (wpsimp wp: mapM_wp' empty_fail_loadWordUser)+
      (* VCPUFault *)
      apply (rule ccorres_symb_exec_l)
         apply (rule ccorres_stateAssert)
@@ -4165,7 +4164,7 @@ lemma handleArchFaultReply_corres:
            apply simp+
         apply (rule ccorres_symb_exec_l)
            apply (ctac add: ccorres_return_C)
-          apply (wp mapM_wp' empty_fail_loadWordUser | clarsimp simp: to_bool_def true_def)+
+          apply (wpsimp wp: mapM_wp' empty_fail_loadWordUser)+
     (* VPPIEvent *)
     apply (rule ccorres_symb_exec_l)
        apply (rule ccorres_stateAssert)
@@ -4175,7 +4174,7 @@ lemma handleArchFaultReply_corres:
           apply simp+
        apply (rule ccorres_symb_exec_l)
           apply (ctac add: ccorres_return_C)
-         apply (wp mapM_wp' empty_fail_loadWordUser | clarsimp simp: to_bool_def true_def)+
+         apply (wpsimp wp: mapM_wp' empty_fail_loadWordUser)+
    (* VGICMaintenance *)
    apply (rule ccorres_symb_exec_l)
       apply (rule ccorres_stateAssert)
@@ -4185,7 +4184,7 @@ lemma handleArchFaultReply_corres:
          apply simp+
       apply (rule ccorres_symb_exec_l)
          apply (ctac add: ccorres_return_C)
-        apply (wp mapM_wp' empty_fail_loadWordUser | clarsimp simp: to_bool_def true_def)+
+        apply (wp mapM_wp' empty_fail_loadWordUser | clarsimp)+
   done
 
 (* MOVE *)
@@ -4321,9 +4320,9 @@ lemma handleFaultReply_ccorres [corres]:
      apply clarsimp
      apply vcg_step
      apply (clarsimp simp: n_exceptionMessage_def n_syscallMessage_def
-                           message_info_to_H_def to_bool_def scast_def
+                           message_info_to_H_def scast_def
                            length_exceptionMessage length_syscallMessage
-                           min_def word_less_nat_alt true_def
+                           min_def word_less_nat_alt
                            guard_is_UNIV_def seL4_Faults seL4_Arch_Faults
                        split: if_split)
     apply (simp add: length_exceptionMessage length_syscallMessage)
@@ -4331,10 +4330,8 @@ lemma handleFaultReply_ccorres [corres]:
    apply clarsimp
    apply (vcg exspec=getRegister_modifies)
   apply (clarsimp simp: n_exceptionMessage_def n_syscallMessage_def
-                        message_info_to_H_def to_bool_def
-                        length_exceptionMessage length_syscallMessage
-                        min_def word_less_nat_alt true_def
-                        obj_at'_def
+                        message_info_to_H_def length_exceptionMessage length_syscallMessage
+                        min_def word_less_nat_alt obj_at'_def
                  split: if_split)
   apply (fastforce simp: seL4_Faults seL4_Arch_Faults)
   done
@@ -4557,7 +4554,7 @@ proof -
                        threadSet_valid_objs' threadSet_weak_sch_act_wf
                          | simp add: valid_tcb_state'_def)+)[1]
            apply (clarsimp simp: guard_is_UNIV_def ThreadState_Restart_def
-                                 ThreadState_Inactive_def mask_def to_bool_def
+                                 ThreadState_Inactive_def mask_def
                                  option_to_ctcb_ptr_def)
 
           apply (rule_tac Q="\<lambda>rv. valid_queues and tcb_at' receiver and valid_queues' and
@@ -4579,8 +4576,7 @@ proof -
     apply (rule conseqPre, vcg)
     apply (simp(no_asm_use) add: gs_set_assn_Delete_cstate_relation[unfolded o_def]
                                  subset_iff rf_sr_def)
-   apply (clarsimp simp: guard_is_UNIV_def to_bool_def true_def
-                         option_to_ptr_def option_to_0_def false_def
+   apply (clarsimp simp: guard_is_UNIV_def option_to_ptr_def option_to_0_def
                          ThreadState_Running_def mask_def
                          ghost_assertion_data_get_def ghost_assertion_data_set_def
                          cap_tag_defs option_to_ctcb_ptr_def
@@ -4652,7 +4648,7 @@ lemma setupCallerCap_ccorres [corres]:
         apply (wp getSlotCap_cte_wp_at)
        apply (clarsimp simp: ccap_relation_def cap_lift_reply_cap
                              cap_to_H_simps cap_reply_cap_lift_def
-                             false_def tcbSlots Kernel_C.tcbCaller_def
+                             tcbSlots Kernel_C.tcbCaller_def
                              size_of_def cte_level_bits_def ctcb_size_bits_def)
        apply (wp getCTE_wp')
       apply (simp add: tcbSlots Kernel_C.tcbCaller_def
@@ -4671,7 +4667,7 @@ lemma setupCallerCap_ccorres [corres]:
      apply (simp add: locateSlot_conv)
      apply wp
     apply (clarsimp simp: ccap_rights_relation_def allRights_def
-                          mask_def true_def cap_rights_to_H_def tcbCallerSlot_def
+                          mask_def cap_rights_to_H_def tcbCallerSlot_def
                           Kernel_C.tcbCaller_def)
    apply simp
    apply wp
@@ -4882,9 +4878,7 @@ lemma sendIPC_block_ccorres_helper:
           (simp add: typ_heap_simps')+)[1]
          apply (simp add: tcb_cte_cases_def)
         apply (simp add: ctcb_relation_def cthread_state_relation_def
-                         ThreadState_BlockedOnSend_def mask_def
-                         from_bool_def to_bool_def)
-        apply (clarsimp split: bool.split)
+                         ThreadState_BlockedOnSend_def mask_def)
        apply ceqv
       apply clarsimp
       apply ctac
@@ -5268,7 +5262,7 @@ lemma sendIPC_ccorres [corres]:
             apply (ctac(no_vcg) add: possibleSwitchTo_ccorres)
              apply (clarsimp split del: if_split)
              apply (wpc ; ccorres_rewrite)
-              apply (clarsimp simp: from_bool_def disj_imp[symmetric] split del: if_split)
+              apply (clarsimp simp: disj_imp[symmetric] split del: if_split)
               apply (wpc ; clarsimp)
                apply ccorres_rewrite
                apply (fold dc_def)[1]
@@ -5288,7 +5282,7 @@ lemma sendIPC_ccorres [corres]:
                 | wp (once) hoare_drop_imp
                 | strengthen sch_act_wf_weak)+
        apply (fastforce simp: guard_is_UNIV_def ThreadState_Inactive_def Collect_const_mem
-                               ThreadState_Running_def mask_def from_bool_def
+                               ThreadState_Running_def mask_def
                                option_to_ptr_def option_to_0_def
                         split: bool.split_asm)
 
@@ -6030,7 +6024,7 @@ lemma receiveIPC_ccorres [corres]:
                  apply (clarsimp simp:  from_bool_0 disj_imp[symmetric] simp del: Collect_const)
                  apply wpc
                   (* blocking ipc call *)
-                  apply (clarsimp simp: from_bool_def split del: if_split simp del: Collect_const)
+                  apply (clarsimp split del: if_split simp del: Collect_const)
                   apply ccorres_rewrite
                   apply (wpc ; clarsimp ; ccorres_rewrite)
                    apply csymbr
@@ -6082,7 +6076,6 @@ lemma receiveIPC_ccorres [corres]:
                                           projectKOs invs'_def valid_state'_def st_tcb_at'_def
                                           valid_tcb_state'_def ko_wp_at'_def invs_valid_objs'
                                           isBlockedOnReceive_def projectKO_opt_tcb
-                                          from_bool_def to_bool_def
                                    elim!: delta_sym_refs
                                    split: if_split_asm bool.splits) (*very long*)
              apply (frule(1) sym_refs_obj_atD' [OF _ invs_sym'])
@@ -6095,8 +6088,7 @@ lemma receiveIPC_ccorres [corres]:
                                          projectKOs invs'_def valid_state'_def st_tcb_at'_def
                                          valid_tcb_state'_def ko_wp_at'_def invs_valid_objs'
                                          isBlockedOnReceive_def projectKO_opt_tcb
-                                         from_bool_def to_bool_def
-                                   elim: delta_sym_refs
+                                  elim!: delta_sym_refs
                                   split: if_split_asm bool.splits) (*very long *)
             apply (clarsimp simp: obj_at'_def state_refs_of'_def projectKOs)
            apply (frule(1) sym_refs_ko_atD' [OF _ invs_sym'])
@@ -6484,8 +6476,7 @@ lemma receiveSignal_block_ccorres_helper:
           (simp add: typ_heap_simps')+)
          apply (simp add: tcb_cte_cases_def)
         apply (simp add: ctcb_relation_def cthread_state_relation_def
-                         ThreadState_BlockedOnNotification_def mask_def
-                         from_bool_def to_bool_def)
+                         ThreadState_BlockedOnNotification_def mask_def)
        apply ceqv
       apply clarsimp
       apply ctac

--- a/proof/crefine/ARM_HYP/Retype_C.thy
+++ b/proof/crefine/ARM_HYP/Retype_C.thy
@@ -2503,9 +2503,9 @@ lemma insertNewCap_ccorres_helper:
    apply (rule conjI)
     apply (erule (2) cmap_relation_updI)
     apply (simp add: ccap_relation_def ccte_relation_def cte_lift_def)
-    subgoal by (simp add: cte_to_H_def map_option_Some_eq2 mdb_node_to_H_def to_bool_mask_to_bool_bf is_aligned_neg_mask
-      c_valid_cte_def true_def
-      split: option.splits)
+    subgoal by (simp add: cte_to_H_def map_option_Some_eq2 mdb_node_to_H_def to_bool_mask_to_bool_bf
+                          is_aligned_neg_mask c_valid_cte_def
+                   split: option.splits)
    subgoal by simp
    apply (erule_tac t = s' in ssubst)
    apply (simp cong: lifth_update)
@@ -2814,18 +2814,8 @@ lemma createNewCaps_untyped_if_helper:
              (\<not> gbits \<le> sz) = (s' \<in> \<lbrace>of_nat sz < (of_nat gbits :: word32)\<rbrace>)"
   by (clarsimp simp: not_le unat_of_nat32 word_less_nat_alt lt_word_bits_lt_pow)
 
-lemma true_mask1 [simp]:
-  "true && mask (Suc 0) = true"
-  unfolding true_def
-  by (simp add: bang_eq cong: conj_cong)
-
 (* Levity: added (20090419 09:44:40) *)
 declare shiftl_mask_is_0 [simp]
-
-lemma to_bool_simps [simp]:
-  "to_bool true" "\<not> to_bool false"
-  unfolding true_def false_def to_bool_def
-  by simp_all
 
 lemma heap_list_update':
   "\<lbrakk> n = length v; length v \<le> 2 ^ word_bits \<rbrakk> \<Longrightarrow> heap_list (heap_update_list p v h) n p = v"
@@ -5477,7 +5467,7 @@ proof -
      apply (subst index_fold_update; clarsimp)
     (* vppi array initialisation *)
     apply clarsimp
-    apply (case_tac vppi; clarsimp simp: from_bool_def)
+    apply (case_tac vppi; clarsimp)
     (* only one vppievent_irq constructor, safe to unfold *)
     apply (clarsimp simp: fromEnum_def enum_vppievent_irq)
     done
@@ -5741,48 +5731,47 @@ proof -
     apply (frule range_cover.aligned)
     apply (cut_tac t)
     apply (case_tac newType,
-           simp_all add: toAPIType_def
-               bind_assoc
-               ARMLargePageBits_def)
+           simp_all add: toAPIType_def bind_assoc ARMLargePageBits_def)
          apply (cinit' lift: t_' regionBase_' userSize_' deviceMemory_')
           apply (simp add: object_type_from_H_def Kernel_C_defs)
           apply (simp add: ccorres_cond_univ_iff ccorres_cond_empty_iff
-                      ARMLargePageBits_def ARMSmallPageBits_def
-                      ARMSectionBits_def ARMSuperSectionBits_def asidInvalid_def
-                      sle_positive APIType_capBits_def shiftL_nat objBits_simps
-                      ptBits_def archObjSize_def pageBits_def word_sle_def word_sless_def
-                      fold_eq_0_to_bool)
+                           ARMLargePageBits_def ARMSmallPageBits_def
+                           ARMSectionBits_def ARMSuperSectionBits_def asidInvalid_def
+                           sle_positive APIType_capBits_def shiftL_nat objBits_simps
+                           ptBits_def archObjSize_def pageBits_def word_sle_def word_sless_def
+                           fold_eq_0_to_bool)
           apply (ccorres_remove_UNIV_guard)
           apply (clarsimp simp: hrs_htd_update ptBits_def objBits_simps archObjSize_def
-            ARM_HYP_H.createObject_def pageBits_def
-            cond_second_eq_seq_ccorres modify_gsUserPages_update
-            intro!: ccorres_rhs_assoc)
+                                ARM_HYP_H.createObject_def pageBits_def
+                                cond_second_eq_seq_ccorres modify_gsUserPages_update
+                        intro!: ccorres_rhs_assoc)
           apply ((rule ccorres_return_C | simp | wp | vcg
-            | (rule match_ccorres, ctac add:
-                    placeNewDataObject_ccorres[where us=0 and newType=newType, simplified]
-                    gsUserPages_update_ccorres[folded modify_gsUserPages_update])
-            | (rule match_ccorres, csymbr))+)[1]
+                  | (rule match_ccorres, ctac add:
+                          placeNewDataObject_ccorres[where us=0 and newType=newType, simplified]
+                          gsUserPages_update_ccorres[folded modify_gsUserPages_update])
+                  | (rule match_ccorres, csymbr))+)[1]
          apply (intro conjI)
           apply (clarsimp simp: createObject_hs_preconds_def
                                 APIType_capBits_def pageBits_def)
          apply (clarsimp simp: pageBits_def ccap_relation_def APIType_capBits_def
-                    framesize_to_H_def cap_to_H_simps cap_small_frame_cap_lift
-                    vmrights_to_H_def vm_rights_defs is_aligned_neg_mask_eq, simp add: mask_def)
+                               framesize_to_H_def cap_to_H_simps cap_small_frame_cap_lift
+                               vmrights_to_H_def vm_rights_defs is_aligned_neg_mask_eq,
+                simp add: mask_def)
 
         \<comment> \<open>Page objects: could possibly fix the duplication here\<close>
         apply (cinit' lift: t_' regionBase_' userSize_' deviceMemory_')
          apply (simp add: object_type_from_H_def Kernel_C_defs)
          apply (simp add: ccorres_cond_univ_iff ccorres_cond_empty_iff
-                     ARMLargePageBits_def ARMSmallPageBits_def
-                     ARMSectionBits_def ARMSuperSectionBits_def asidInvalid_def
-                     sle_positive APIType_capBits_def shiftL_nat objBits_simps
-                     ptBits_def archObjSize_def pageBits_def word_sle_def word_sless_def
-                     fold_eq_0_to_bool)
+                          ARMLargePageBits_def ARMSmallPageBits_def
+                          ARMSectionBits_def ARMSuperSectionBits_def asidInvalid_def
+                          sle_positive APIType_capBits_def shiftL_nat objBits_simps
+                          ptBits_def archObjSize_def pageBits_def word_sle_def word_sless_def
+                          fold_eq_0_to_bool)
          apply (ccorres_remove_UNIV_guard)
          apply (clarsimp simp: hrs_htd_update ptBits_def objBits_simps archObjSize_def
-           ARM_HYP_H.createObject_def pageBits_def
-           cond_second_eq_seq_ccorres modify_gsUserPages_update
-           intro!: ccorres_rhs_assoc)
+                               ARM_HYP_H.createObject_def pageBits_def
+                               cond_second_eq_seq_ccorres modify_gsUserPages_update
+                       intro!: ccorres_rhs_assoc)
          apply ((rule ccorres_return_C | simp | wp | vcg
            | (rule match_ccorres, ctac add:
                    placeNewDataObject_ccorres[where us=4 and newType=newType, simplified]
@@ -5792,24 +5781,24 @@ proof -
          apply (clarsimp simp: createObject_hs_preconds_def
                                APIType_capBits_def pageBits_def)
         apply (clarsimp simp: pageBits_def ccap_relation_def APIType_capBits_def
-                   framesize_to_H_def cap_to_H_simps cap_frame_cap_lift
-                   vmrights_to_H_def mask_def vm_rights_defs vm_page_size_defs
-                   cl_valid_cap_def c_valid_cap_def
-                   is_aligned_neg_mask_eq_concrete[THEN sym])
+                              framesize_to_H_def cap_to_H_simps cap_frame_cap_lift
+                              vmrights_to_H_def mask_def vm_rights_defs vm_page_size_defs
+                              cl_valid_cap_def c_valid_cap_def
+                              is_aligned_neg_mask_eq_concrete[THEN sym])
 
        apply (cinit' lift: t_' regionBase_' userSize_' deviceMemory_')
         apply (simp add: object_type_from_H_def Kernel_C_defs)
         apply (simp add: ccorres_cond_univ_iff ccorres_cond_empty_iff
-                    ARMLargePageBits_def ARMSmallPageBits_def
-                    ARMSectionBits_def ARMSuperSectionBits_def asidInvalid_def
-                    sle_positive APIType_capBits_def shiftL_nat objBits_simps
-                    ptBits_def archObjSize_def pageBits_def word_sle_def word_sless_def
-                    fold_eq_0_to_bool)
+                         ARMLargePageBits_def ARMSmallPageBits_def
+                         ARMSectionBits_def ARMSuperSectionBits_def asidInvalid_def
+                         sle_positive APIType_capBits_def shiftL_nat objBits_simps
+                         ptBits_def archObjSize_def pageBits_def word_sle_def word_sless_def
+                         fold_eq_0_to_bool)
         apply (ccorres_remove_UNIV_guard)
         apply (clarsimp simp: hrs_htd_update ptBits_def objBits_simps archObjSize_def
-          ARM_HYP_H.createObject_def pageBits_def
-          cond_second_eq_seq_ccorres modify_gsUserPages_update
-          intro!: ccorres_rhs_assoc)
+                              ARM_HYP_H.createObject_def pageBits_def
+                              cond_second_eq_seq_ccorres modify_gsUserPages_update
+                      intro!: ccorres_rhs_assoc)
         apply ((rule ccorres_return_C | simp | wp | vcg
           | (rule match_ccorres, ctac add:
                   placeNewDataObject_ccorres[where us=9 and newType=newType, simplified]
@@ -5819,19 +5808,19 @@ proof -
         apply (clarsimp simp: createObject_hs_preconds_def
                               APIType_capBits_def pageBits_def)
        apply (clarsimp simp: pageBits_def ccap_relation_def APIType_capBits_def
-                  framesize_to_H_def cap_to_H_simps cap_frame_cap_lift
-                  vmrights_to_H_def mask_def vm_rights_defs vm_page_size_defs
-                  cl_valid_cap_def c_valid_cap_def
-                  is_aligned_neg_mask_eq_concrete[THEN sym])
+                             framesize_to_H_def cap_to_H_simps cap_frame_cap_lift
+                             vmrights_to_H_def mask_def vm_rights_defs vm_page_size_defs
+                             cl_valid_cap_def c_valid_cap_def
+                             is_aligned_neg_mask_eq_concrete[THEN sym])
 
       apply (cinit' lift: t_' regionBase_' userSize_' deviceMemory_')
        apply (simp add: object_type_from_H_def Kernel_C_defs)
        apply (simp add: ccorres_cond_univ_iff ccorres_cond_empty_iff
-                   ARMLargePageBits_def ARMSmallPageBits_def
-                   ARMSectionBits_def ARMSuperSectionBits_def asidInvalid_def
-                   sle_positive APIType_capBits_def shiftL_nat objBits_simps
-                   ptBits_def archObjSize_def pageBits_def word_sle_def word_sless_def
-                   fold_eq_0_to_bool)
+                        ARMLargePageBits_def ARMSmallPageBits_def
+                        ARMSectionBits_def ARMSuperSectionBits_def asidInvalid_def
+                        sle_positive APIType_capBits_def shiftL_nat objBits_simps
+                        ptBits_def archObjSize_def pageBits_def word_sle_def word_sless_def
+                        fold_eq_0_to_bool)
        apply (ccorres_remove_UNIV_guard)
        apply (clarsimp simp: hrs_htd_update ptBits_def objBits_simps archObjSize_def
          ARM_HYP_H.createObject_def pageBits_def
@@ -5846,23 +5835,23 @@ proof -
        apply (clarsimp simp: createObject_hs_preconds_def
                              APIType_capBits_def pageBits_def)
       apply (clarsimp simp: pageBits_def ccap_relation_def APIType_capBits_def
-                 framesize_to_H_def cap_to_H_simps cap_frame_cap_lift
-                 vmrights_to_H_def mask_def vm_rights_defs vm_page_size_defs
-                 cl_valid_cap_def c_valid_cap_def
-                 is_aligned_neg_mask_eq_concrete[THEN sym])
+                            framesize_to_H_def cap_to_H_simps cap_frame_cap_lift
+                            vmrights_to_H_def mask_def vm_rights_defs vm_page_size_defs
+                            cl_valid_cap_def c_valid_cap_def
+                            is_aligned_neg_mask_eq_concrete[THEN sym])
 
      \<comment> \<open>PageTableObject\<close>
      apply (cinit' lift: t_' regionBase_' userSize_' deviceMemory_')
       apply (simp add: object_type_from_H_def Kernel_C_defs)
       apply (simp add: ccorres_cond_univ_iff ccorres_cond_empty_iff
-                  ARMLargePageBits_def ARMSmallPageBits_def
-                  ARMSectionBits_def ARMSuperSectionBits_def asidInvalid_def
-                  sle_positive APIType_capBits_def shiftL_nat objBits_simps
-                  ptBits_def archObjSize_def pageBits_def word_sle_def word_sless_def)
+                       ARMLargePageBits_def ARMSmallPageBits_def
+                       ARMSectionBits_def ARMSuperSectionBits_def asidInvalid_def
+                       sle_positive APIType_capBits_def shiftL_nat objBits_simps
+                       ptBits_def archObjSize_def pageBits_def word_sle_def word_sless_def)
       apply (ccorres_remove_UNIV_guard)
       apply (rule ccorres_rhs_assoc)+
       apply (clarsimp simp: hrs_htd_update ptBits_def objBits_simps archObjSize_def
-        ARM_HYP_H.createObject_def pageBits_def pt_bits_def)
+                            ARM_HYP_H.createObject_def pageBits_def pt_bits_def)
       apply (ctac pre only: add: placeNewObject_pte[simplified])
         apply csymbr
         apply (rule ccorres_return_C)
@@ -5878,11 +5867,11 @@ proof -
                             invs_urz)
      apply clarsimp
      apply (clarsimp simp: pageBits_def ccap_relation_def APIType_capBits_def
-                framesize_to_H_def cap_to_H_simps cap_page_table_cap_lift
-                is_aligned_neg_mask_eq vmrights_to_H_def
-                Kernel_C.VMReadWrite_def Kernel_C.VMNoAccess_def
-                Kernel_C.VMKernelOnly_def Kernel_C.VMReadOnly_def)
-     apply (clarsimp simp: to_bool_def false_def isFrameType_def)
+                           framesize_to_H_def cap_to_H_simps cap_page_table_cap_lift
+                           is_aligned_neg_mask_eq vmrights_to_H_def
+                           Kernel_C.VMReadWrite_def Kernel_C.VMNoAccess_def
+                           Kernel_C.VMKernelOnly_def Kernel_C.VMReadOnly_def)
+     apply (clarsimp simp: isFrameType_def)
      apply (rule sym)
      apply (simp add: is_aligned_neg_mask_eq'[symmetric] is_aligned_weaken)
 
@@ -5890,13 +5879,13 @@ proof -
     apply (cinit' lift: t_' regionBase_' userSize_' deviceMemory_')
      apply (simp add: object_type_from_H_def Kernel_C_defs)
      apply (simp add: ccorres_cond_univ_iff ccorres_cond_empty_iff
-                asidInvalid_def sle_positive APIType_capBits_def shiftL_nat
-                objBits_simps archObjSize_def
-                ptBits_def pageBits_def pdBits_def word_sle_def word_sless_def)
+                      asidInvalid_def sle_positive APIType_capBits_def shiftL_nat
+                      objBits_simps archObjSize_def
+                      ptBits_def pageBits_def pdBits_def word_sle_def word_sless_def)
      apply (ccorres_remove_UNIV_guard)
      apply (rule ccorres_rhs_assoc)+
      apply (clarsimp simp: hrs_htd_update ptBits_def objBits_simps archObjSize_def
-        ARM_HYP_H.createObject_def pageBits_def pdBits_def pd_bits_def)
+                           ARM_HYP_H.createObject_def pageBits_def pdBits_def pd_bits_def)
      apply (ctac pre only: add: placeNewObject_pde[simplified])
        apply (ctac add: copyGlobalMappings_ccorres)
          apply csymbr
@@ -5907,14 +5896,14 @@ proof -
             apply simp
            apply simp
           apply wp
-         apply (clarsimp simp: false_def)
+         apply clarsimp
          apply vcg
         apply wp
        apply (clarsimp simp: pageBits_def ccap_relation_def APIType_capBits_def
-                  framesize_to_H_def cap_to_H_simps cap_page_directory_cap_lift
-                  is_aligned_neg_mask_eq vmrights_to_H_def
-                  Kernel_C.VMReadWrite_def Kernel_C.VMNoAccess_def
-                  Kernel_C.VMKernelOnly_def Kernel_C.VMReadOnly_def)
+                             framesize_to_H_def cap_to_H_simps cap_page_directory_cap_lift
+                             is_aligned_neg_mask_eq vmrights_to_H_def
+                             Kernel_C.VMReadWrite_def Kernel_C.VMNoAccess_def
+                             Kernel_C.VMKernelOnly_def Kernel_C.VMReadOnly_def)
        apply (vcg exspec=copyGlobalMappings_modifies)
       apply (clarsimp simp:placeNewObject_def2)
       apply (wp createObjects'_pde_mappings' createObjects'_page_directory_at_global[where sz=pdBits]
@@ -5922,24 +5911,24 @@ proof -
      apply clarsimp
      apply vcg
     apply (clarsimp simp: invs_pspace_aligned' invs_pspace_distinct'
-               archObjSize_def invs_valid_global' makeObject_pde pdBits_def
-               pageBits_def range_cover.aligned projectKOs APIType_capBits_def
-               object_type_from_H_def objBits_simps
-               invs_valid_objs' isFrameType_def)
+                          archObjSize_def invs_valid_global' makeObject_pde pdBits_def
+                          pageBits_def range_cover.aligned projectKOs APIType_capBits_def
+                          object_type_from_H_def objBits_simps
+                          invs_valid_objs' isFrameType_def)
     apply (frule invs_arch_state')
     apply (frule range_cover.aligned)
     apply (frule is_aligned_addrFromPPtr_n, simp)
     apply (intro conjI, simp_all add: table_bits_defs)[1]
         apply fastforce
        apply ((clarsimp simp: is_aligned_no_overflow'[where n=14, simplified]
-                             field_simps is_aligned_mask[symmetric] mask_AND_less_0)+)[3]
+                              field_simps is_aligned_mask[symmetric] mask_AND_less_0)+)[3]
     \<comment> \<open>VCPU\<close>
     apply (cinit' lift: t_' regionBase_' userSize_' deviceMemory_')
      apply (simp add: object_type_from_H_def Kernel_C_defs)
      apply ccorres_rewrite
      apply (simp add: ccorres_cond_univ_iff ccorres_cond_empty_iff
-                asidInvalid_def sle_positive APIType_capBits_def shiftL_nat
-                objBits_simps archObjSize_def word_sle_def word_sless_def)
+                      asidInvalid_def sle_positive APIType_capBits_def shiftL_nat
+                      objBits_simps archObjSize_def word_sle_def word_sless_def)
      apply (clarsimp simp: hrs_htd_update ptBits_def objBits_simps archObjSize_def
                            ARM_HYP_H.createObject_def pageBits_def pdBits_def)
      apply (rule ccorres_rhs_assoc)+
@@ -5950,8 +5939,8 @@ proof -
       apply wp
      apply (vcg exspec=vcpu_init_modifies)
     apply (clarsimp simp: invs_pspace_aligned' invs_pspace_distinct'
-               invs_valid_global' range_cover.aligned APIType_capBits_def
-               invs_valid_objs' isFrameType_def invs_urz)
+                          invs_valid_global' range_cover.aligned APIType_capBits_def
+                          invs_valid_objs' isFrameType_def invs_urz)
     apply (frule range_cover.aligned)
     apply (clarsimp simp: ccap_relation_def cap_vcpu_cap_lift cap_to_H_def)
     apply (rule sym, rule is_aligned_neg_mask_eq)
@@ -6067,11 +6056,11 @@ proof -
    apply (rule ccorres_cond_seq)
    (* Architecture specific objects. *)
    apply (rule_tac
-           Q="createObject_hs_preconds regionBase newType userSize isdev" and
-           S="createObject_c_preconds1 regionBase newType userSize isdev" and
-           R="createObject_hs_preconds regionBase newType userSize isdev" and
-           T="createObject_c_preconds1 regionBase newType userSize isdev"
-           in ccorres_Cond_rhs)
+            Q="createObject_hs_preconds regionBase newType userSize isdev" and
+            S="createObject_c_preconds1 regionBase newType userSize isdev" and
+            R="createObject_hs_preconds regionBase newType userSize isdev" and
+            T="createObject_c_preconds1 regionBase newType userSize isdev"
+            in ccorres_Cond_rhs)
     apply (subgoal_tac "toAPIType newType = None")
      apply clarsimp
      apply (rule ccorres_rhs_assoc)+
@@ -6088,10 +6077,9 @@ proof -
                            region_actually_is_bytes
                            region_actually_is_bytes_def)
     apply (clarsimp simp: object_type_from_H_def
-      ARM_HYP_H.toAPIType_def Kernel_C_defs toAPIType_def
-      nAPIObjects_def word_sle_def createObject_c_preconds_def
-      word_le_nat_alt split:
-      apiobject_type.splits object_type.splits)
+                          ARM_HYP_H.toAPIType_def Kernel_C_defs toAPIType_def
+                          nAPIObjects_def word_sle_def createObject_c_preconds_def word_le_nat_alt
+                    split: apiobject_type.splits object_type.splits)
    apply (subgoal_tac "\<exists>apiType. newType = APIObjectType apiType")
     apply clarsimp
     apply (rule ccorres_guard_imp)
@@ -6099,24 +6087,24 @@ proof -
 
           (* Untyped *)
           apply (clarsimp simp: Kernel_C_defs object_type_from_H_def
-            toAPIType_def ARM_HYP_H.toAPIType_def nAPIObjects_def
-            word_sle_def intro!: Corres_UL_C.ccorres_cond_empty
-            Corres_UL_C.ccorres_cond_univ ccorres_rhs_assoc)
+                                toAPIType_def ARM_HYP_H.toAPIType_def nAPIObjects_def word_sle_def
+                        intro!: Corres_UL_C.ccorres_cond_empty
+                                Corres_UL_C.ccorres_cond_univ ccorres_rhs_assoc)
           apply (rule_tac
-             A ="createObject_hs_preconds regionBase
-                   (APIObjectType apiobject_type.Untyped)
-                    (unat (userSizea :: word32)) isdev" and
-             A'=UNIV in
-             ccorres_guard_imp)
+                   A ="createObject_hs_preconds regionBase
+                         (APIObjectType apiobject_type.Untyped)
+                          (unat (userSizea :: word32)) isdev" and
+                   A'=UNIV in
+                   ccorres_guard_imp)
             apply (rule ccorres_symb_exec_r)
               apply (rule ccorres_return_C, simp, simp, simp)
              apply vcg
             apply (rule conseqPre, vcg, clarsimp)
            apply simp
           apply (clarsimp simp: ccap_relation_def cap_to_H_def ARM_HYP_H.getObjectSize_def
-                     apiGetObjectSize_def cap_untyped_cap_lift to_bool_eq_0 true_def
-                     aligned_add_aligned
-                   split: option.splits)
+                                apiGetObjectSize_def cap_untyped_cap_lift to_bool_eq_0
+                                aligned_add_aligned
+                         split: option.splits)
           apply (subst is_aligned_neg_mask_eq [OF is_aligned_weaken])
             apply (erule range_cover.aligned)
            apply (clarsimp simp:APIType_capBits_def untypedBits_defs)
@@ -6126,15 +6114,15 @@ proof -
 
          (* TCB *)
          apply (clarsimp simp: Kernel_C_defs object_type_from_H_def
-           toAPIType_def ARM_HYP_H.toAPIType_def nAPIObjects_def
-           word_sle_def intro!: Corres_UL_C.ccorres_cond_empty
-           Corres_UL_C.ccorres_cond_univ ccorres_rhs_assoc)
+                               toAPIType_def ARM_HYP_H.toAPIType_def nAPIObjects_def word_sle_def
+                       intro!: Corres_UL_C.ccorres_cond_empty
+                               Corres_UL_C.ccorres_cond_univ ccorres_rhs_assoc)
          apply (rule_tac
-           A ="createObject_hs_preconds regionBase
-                 (APIObjectType apiobject_type.TCBObject) (unat userSizea) isdev" and
-           A'="createObject_c_preconds1 regionBase
-                 (APIObjectType apiobject_type.TCBObject) (unat userSizea) isdev" in
-            ccorres_guard_imp2)
+                  A ="createObject_hs_preconds regionBase
+                        (APIObjectType apiobject_type.TCBObject) (unat userSizea) isdev" and
+                  A'="createObject_c_preconds1 regionBase
+                        (APIObjectType apiobject_type.TCBObject) (unat userSizea) isdev" in
+                  ccorres_guard_imp2)
           apply (rule ccorres_symb_exec_r)
             apply (ccorres_remove_UNIV_guard)
             apply (simp add: hrs_htd_update)
@@ -6168,11 +6156,10 @@ proof -
                                region_actually_is_bytes_def APIType_capBits_def)
          apply (frule(1) ghost_assertion_size_logic_no_unat)
          apply (clarsimp simp: ccap_relation_def cap_to_H_def
-                    getObjectSize_def ARM_HYP_H.getObjectSize_def
-                    apiGetObjectSize_def Collect_const_mem
-                    cap_thread_cap_lift to_bool_def true_def
-                    aligned_add_aligned
-                  split: option.splits)
+                               getObjectSize_def ARM_HYP_H.getObjectSize_def
+                               apiGetObjectSize_def Collect_const_mem
+                               cap_thread_cap_lift aligned_add_aligned
+                        split: option.splits)
          apply (clarsimp simp: ctcb_ptr_to_tcb_ptr_def ctcb_offset_defs
                                tcb_ptr_to_ctcb_ptr_def
                                invs_valid_objs' invs_urz isFrameType_def)
@@ -6187,17 +6174,16 @@ proof -
 
         (* Endpoint *)
         apply (clarsimp simp: Kernel_C_defs object_type_from_H_def
-          toAPIType_def ARM_HYP_H.toAPIType_def nAPIObjects_def
-          word_sle_def intro!: ccorres_cond_empty ccorres_cond_univ
-          ccorres_rhs_assoc)
+                              toAPIType_def ARM_HYP_H.toAPIType_def nAPIObjects_def word_sle_def
+                      intro!: ccorres_cond_empty ccorres_cond_univ ccorres_rhs_assoc)
         apply (rule_tac
-           A ="createObject_hs_preconds regionBase
-                 (APIObjectType apiobject_type.EndpointObject)
-                 (unat (userSizea :: word32)) isdev" and
-           A'="createObject_c_preconds1 regionBase
-                 (APIObjectType apiobject_type.EndpointObject)
-                 (unat userSizea) isdev" in
-           ccorres_guard_imp2)
+                 A ="createObject_hs_preconds regionBase
+                       (APIObjectType apiobject_type.EndpointObject)
+                       (unat (userSizea :: word32)) isdev" and
+                 A'="createObject_c_preconds1 regionBase
+                       (APIObjectType apiobject_type.EndpointObject)
+                       (unat userSizea) isdev" in
+                 ccorres_guard_imp2)
          apply (ccorres_remove_UNIV_guard)
          apply (simp add: hrs_htd_update)
          apply (ctac (no_vcg) pre only: add: ccorres_placeNewObject_endpoint)
@@ -6207,38 +6193,38 @@ proof -
            apply (rule conseqPre, vcg, clarsimp)
           apply wp
          apply (clarsimp simp: ccap_relation_def cap_to_H_def
-                    getObjectSize_def ARM_HYP_H.getObjectSize_def
-                    objBits_simps apiGetObjectSize_def epSizeBits_def
-                    Collect_const_mem cap_endpoint_cap_lift
-                    to_bool_def true_def
-                  split: option.splits   dest!: range_cover.aligned)
+                               getObjectSize_def ARM_HYP_H.getObjectSize_def
+                               objBits_simps apiGetObjectSize_def epSizeBits_def
+                               Collect_const_mem cap_endpoint_cap_lift
+                        split: option.splits
+                        dest!: range_cover.aligned)
         apply (clarsimp simp: createObject_hs_preconds_def isFrameType_def)
         apply (frule invs_pspace_aligned')
         apply (frule invs_pspace_distinct')
         apply (frule invs_queues)
         apply (frule invs_sym')
         apply (auto simp: getObjectSize_def objBits_simps
-                    ARM_HYP_H.getObjectSize_def apiGetObjectSize_def
-                    epSizeBits_def word_bits_conv
-                  elim!: is_aligned_no_wrap'   intro!: range_cover_simpleI)[1]
+                          ARM_HYP_H.getObjectSize_def apiGetObjectSize_def
+                          epSizeBits_def word_bits_conv
+                   elim!: is_aligned_no_wrap'
+                  intro!: range_cover_simpleI)[1]
 
        (* Notification *)
        apply (clarsimp simp: createObject_c_preconds_def)
        apply (clarsimp simp: getObjectSize_def objBits_simps
-                  ARM_HYP_H.getObjectSize_def apiGetObjectSize_def
-                  epSizeBits_def word_bits_conv word_sle_def word_sless_def)
+                             ARM_HYP_H.getObjectSize_def apiGetObjectSize_def
+                             epSizeBits_def word_bits_conv word_sle_def word_sless_def)
        apply (clarsimp simp: Kernel_C_defs object_type_from_H_def
-         toAPIType_def ARM_HYP_H.toAPIType_def nAPIObjects_def
-         word_sle_def intro!: ccorres_cond_empty ccorres_cond_univ
-         ccorres_rhs_assoc)
+                             toAPIType_def ARM_HYP_H.toAPIType_def nAPIObjects_def word_sle_def
+                     intro!: ccorres_cond_empty ccorres_cond_univ ccorres_rhs_assoc)
        apply (rule_tac
-         A ="createObject_hs_preconds regionBase
-               (APIObjectType apiobject_type.NotificationObject)
-               (unat (userSizea :: word32)) isdev" and
-         A'="createObject_c_preconds1 regionBase
-               (APIObjectType apiobject_type.NotificationObject)
-               (unat userSizea) isdev" in
-         ccorres_guard_imp2)
+                A ="createObject_hs_preconds regionBase
+                      (APIObjectType apiobject_type.NotificationObject)
+                      (unat (userSizea :: word32)) isdev" and
+                A'="createObject_c_preconds1 regionBase
+                      (APIObjectType apiobject_type.NotificationObject)
+                      (unat userSizea) isdev" in
+                ccorres_guard_imp2)
         apply (ccorres_remove_UNIV_guard)
         apply (simp add: hrs_htd_update)
         apply (ctac (no_vcg) pre only: add: ccorres_placeNewObject_notification)
@@ -6248,38 +6234,40 @@ proof -
           apply (rule conseqPre, vcg, clarsimp)
          apply wp
         apply (clarsimp simp: ccap_relation_def cap_to_H_def
-            getObjectSize_def ARM_HYP_H.getObjectSize_def
-            apiGetObjectSize_def ntfnSizeBits_def objBits_simps
-            Collect_const_mem cap_notification_cap_lift to_bool_def true_def
-            dest!: range_cover.aligned split: option.splits)
+                              getObjectSize_def ARM_HYP_H.getObjectSize_def
+                              apiGetObjectSize_def ntfnSizeBits_def objBits_simps
+                              Collect_const_mem cap_notification_cap_lift
+                       dest!: range_cover.aligned
+                       split: option.splits)
        apply (clarsimp simp: createObject_hs_preconds_def isFrameType_def)
        apply (frule invs_pspace_aligned')
        apply (frule invs_pspace_distinct')
        apply (frule invs_queues)
        apply (frule invs_sym')
        apply (auto simp: getObjectSize_def objBits_simps
-                   ARM_HYP_H.getObjectSize_def apiGetObjectSize_def
-                   ntfnSizeBits_def word_bits_conv
-                elim!: is_aligned_no_wrap'  intro!: range_cover_simpleI)[1]
+                         ARM_HYP_H.getObjectSize_def apiGetObjectSize_def
+                         ntfnSizeBits_def word_bits_conv
+                  elim!: is_aligned_no_wrap'
+                 intro!: range_cover_simpleI)[1]
 
       (* CapTable *)
       apply (clarsimp simp: createObject_c_preconds_def)
       apply (clarsimp simp: getObjectSize_def objBits_simps
-                  ARM_HYP_H.getObjectSize_def apiGetObjectSize_def
-                  ntfnSizeBits_def word_bits_conv)
+                            ARM_HYP_H.getObjectSize_def apiGetObjectSize_def
+                            ntfnSizeBits_def word_bits_conv)
       apply (clarsimp simp: Kernel_C_defs object_type_from_H_def
-                 toAPIType_def ARM_HYP_H.toAPIType_def nAPIObjects_def
-                 word_sle_def word_sless_def zero_le_sint_32
-               intro!: ccorres_cond_empty ccorres_cond_univ ccorres_rhs_assoc
-                       ccorres_move_c_guards ccorres_Guard_Seq)
+                            toAPIType_def ARM_HYP_H.toAPIType_def nAPIObjects_def
+                            word_sle_def word_sless_def zero_le_sint_32
+                    intro!: ccorres_cond_empty ccorres_cond_univ ccorres_rhs_assoc
+                            ccorres_move_c_guards ccorres_Guard_Seq)
       apply (rule_tac
-         A ="createObject_hs_preconds regionBase
-               (APIObjectType apiobject_type.CapTableObject)
-               (unat (userSizea :: word32)) isdev" and
-         A'="createObject_c_preconds1 regionBase
-               (APIObjectType apiobject_type.CapTableObject)
-               (unat userSizea) isdev" in
-         ccorres_guard_imp2)
+               A ="createObject_hs_preconds regionBase
+                     (APIObjectType apiobject_type.CapTableObject)
+                     (unat (userSizea :: word32)) isdev" and
+               A'="createObject_c_preconds1 regionBase
+                     (APIObjectType apiobject_type.CapTableObject)
+                     (unat userSizea) isdev" in
+               ccorres_guard_imp2)
        apply (simp add:field_simps hrs_htd_update)
        apply (ccorres_remove_UNIV_guard)
        apply (ctac pre only: add: ccorres_placeNewObject_captable)
@@ -6300,19 +6288,17 @@ proof -
        apply (frule invs_queues)
        apply (frule invs_sym')
        apply (frule(1) ghost_assertion_size_logic_no_unat)
-       apply (clarsimp simp: getObjectSize_def objBits_simps
-                  ARM_HYP_H.getObjectSize_def apiGetObjectSize_def
-                  cteSizeBits_def word_bits_conv add.commute createObject_c_preconds_def
-                  region_actually_is_bytes_def
-                  invs_valid_objs' invs_urz
-                 elim!: is_aligned_no_wrap'
-                dest: word_of_nat_le  intro!: range_coverI)[1]
+       apply (clarsimp simp: objBits_simps ARM_HYP_H.getObjectSize_def apiGetObjectSize_def
+                             cteSizeBits_def word_bits_conv add.commute createObject_c_preconds_def
+                             region_actually_is_bytes_def invs_valid_objs' invs_urz
+                      elim!: is_aligned_no_wrap'
+                       dest: word_of_nat_le)
       apply (clarsimp simp: createObject_hs_preconds_def hrs_htd_update isFrameType_def)
       apply (frule range_cover.strong_times_32[folded addr_card_wb], simp+)
       apply (subst h_t_array_valid_retyp, simp+)
        apply (simp add: power_add cte_C_size objBits_defs)
       apply (frule range_cover.aligned)
-      apply (clarsimp simp: ccap_relation_def cap_to_H_def cap_cnode_cap_lift to_bool_def true_def
+      apply (clarsimp simp: ccap_relation_def cap_to_H_def cap_cnode_cap_lift
                             getObjectSize_def apiGetObjectSize_def objBits_simps' field_simps
                             is_aligned_power2 addr_card_wb is_aligned_weaken[where y=word_size_bits]
                             is_aligned_neg_mask

--- a/proof/crefine/ARM_HYP/Schedule_C.thy
+++ b/proof/crefine/ARM_HYP/Schedule_C.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2023, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -437,7 +438,7 @@ lemma isHighestPrio_ccorres:
       apply (rule ccorres_return_C, simp, simp, simp)
      apply (rule wp_post_taut)
     apply (vcg exspec=getHighestPrio_modifies)+
-  apply (clarsimp simp: word_le_nat_alt true_def to_bool_def maxDomain_le_unat_ucast_explicit
+  apply (clarsimp simp: word_le_nat_alt maxDomain_le_unat_ucast_explicit
                   split: if_splits)
   done
 
@@ -534,17 +535,17 @@ lemma schedule_ccorres:
               apply (rule ccorres_cond2'[where R=\<top>], fastforce)
                apply clarsimp
                apply (rule ccorres_return[where R'=UNIV], clarsimp, vcg)
-               apply (rule_tac P="\<lambda>s. obj_at' (\<lambda>tcb. tcbPriority tcb = curPrio) curThread s
-                                      \<and> curThread = ksCurThread s
-                                      \<and> obj_at' (\<lambda>tcb. tcbPriority tcb = targetPrio) candidate s"
-                        and P'=UNIV in ccorres_from_vcg)
-               apply clarsimp
-               apply (rule conseqPre, vcg)
-               apply (clarsimp simp: return_def cur_tcb'_def rf_sr_ksCurThread)
-               apply (drule (1) obj_at_cslift_tcb)+
-               apply (clarsimp simp: typ_heap_simps ctcb_relation_def to_bool_def split: if_split)
-               apply unat_arith
-              apply (wpsimp wp: threadGet_obj_at2)
+              apply (rule_tac P="\<lambda>s. obj_at' (\<lambda>tcb. tcbPriority tcb = curPrio) curThread s
+                                     \<and> curThread = ksCurThread s
+                                     \<and> obj_at' (\<lambda>tcb. tcbPriority tcb = targetPrio) candidate s"
+                       and P'=UNIV in ccorres_from_vcg)
+              apply clarsimp
+              apply (rule conseqPre, vcg)
+              apply (clarsimp simp: return_def cur_tcb'_def rf_sr_ksCurThread)
+              apply (drule (1) obj_at_cslift_tcb)+
+              apply (clarsimp simp: typ_heap_simps ctcb_relation_def split: if_split)
+              apply unat_arith
+              apply clarsimp
              apply vcg
             apply ceqv
            (* fastfail calculation complete *)
@@ -605,10 +606,10 @@ lemma schedule_ccorres:
                       in ccorres_symb_exec_r_known_rv)
                 apply clarsimp
                 apply (rule conseqPre, vcg)
-                apply (clarsimp simp: false_def cur_tcb'_def rf_sr_ksCurThread)
+                apply (clarsimp simp: cur_tcb'_def rf_sr_ksCurThread)
 
                 apply (drule (1) obj_at_cslift_tcb)+
-                apply (clarsimp simp: typ_heap_simps ctcb_relation_def to_bool_def split: if_split)
+                apply (clarsimp simp: typ_heap_simps ctcb_relation_def split: if_split)
                 apply (solves \<open>unat_arith, rule iffI; simp\<close>)
                apply ceqv
               apply clarsimp
@@ -653,9 +654,9 @@ lemma schedule_ccorres:
           apply wp
          apply (clarsimp, vcg exspec=tcbSchedEnqueue_modifies)
         apply (clarsimp, vcg exspec=tcbSchedEnqueue_modifies)
-       apply (clarsimp simp: to_bool_def true_def)
+       apply clarsimp
        apply (strengthen ko_at'_obj_at'_field)
-       apply (clarsimp cong: imp_cong simp: ko_at'_obj_at'_field to_bool_def true_def)
+       apply (clarsimp cong: imp_cong simp: ko_at'_obj_at'_field)
        apply wp
       apply clarsimp
       (* when runnable tcbSchedEnqueue curThread *)
@@ -667,7 +668,6 @@ lemma schedule_ccorres:
       apply (wp | clarsimp simp: dc_def)+
      apply (vcg exspec=tcbSchedEnqueue_modifies)
     apply wp
-   apply (clarsimp simp: to_bool_def false_def)
    apply vcg
 
   apply (clarsimp simp: tcb_at_invs' rf_sr_ksCurThread if_apply_def2 invs_queues invs_valid_objs'
@@ -678,7 +678,7 @@ lemma schedule_ccorres:
    apply (clarsimp dest!: rf_sr_cscheduler_relation simp: cscheduler_action_relation_def)
   apply (rule conjI; clarsimp)
    apply (frule (1) obj_at_cslift_tcb)
-   apply (clarsimp simp: cscheduler_action_relation_def typ_heap_simps max_word_not_0
+   apply (clarsimp simp: cscheduler_action_relation_def typ_heap_simps
                   split: scheduler_action.splits)
   apply (frule (1) obj_at_cslift_tcb)
   apply (clarsimp dest!: rf_sr_cscheduler_relation invs_sch_act_wf'

--- a/proof/crefine/ARM_HYP/SyscallArgs_C.thy
+++ b/proof/crefine/ARM_HYP/SyscallArgs_C.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2023, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -821,7 +822,7 @@ lemma lookupIPCBuffer_ccorres[corres]:
                apply (frule capFVMRights_range)
                apply (simp add: cap_frame_cap_lift
                                generic_frame_cap_get_capFVMRights_CL_def)
-               apply (clarsimp simp: cap_to_H_def vmrights_to_H_def to_bool_def
+               apply (clarsimp simp: cap_to_H_def vmrights_to_H_def
                                word_le_make_less Kernel_C.VMNoAccess_def
                                Kernel_C.VMReadWrite_def Kernel_C.VMReadOnly_def
                                Kernel_C.VMKernelOnly_def
@@ -876,7 +877,7 @@ lemma lookupIPCBuffer_ccorres[corres]:
                apply (frule capFVMRights_range)
                apply (simp add: cap_frame_cap_lift
                                 generic_frame_cap_get_capFVMRights_CL_def)
-                apply (clarsimp simp: cap_to_H_def vmrights_to_H_def to_bool_def
+                apply (clarsimp simp: cap_to_H_def vmrights_to_H_def
                                       word_le_make_less Kernel_C.VMNoAccess_def
                                       Kernel_C.VMReadWrite_def Kernel_C.VMReadOnly_def
                                       Kernel_C.VMKernelOnly_def

--- a/proof/crefine/ARM_HYP/Syscall_C.thy
+++ b/proof/crefine/ARM_HYP/Syscall_C.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2023, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -18,9 +19,6 @@ crunch sch_act_wf [wp]: replyFromKernel "\<lambda>s. sch_act_wf (ksSchedulerActi
 end
 
 context kernel_m begin
-
-(* FIXME: should do this from the beginning *)
-declare true_def [simp] false_def [simp]
 
 lemma ccorres_If_False:
   "ccorres_underlying sr Gamm r xf arrel axf R R' hs b c
@@ -689,7 +687,7 @@ lemma sendFaultIPC_ccorres:
              apply (clarsimp simp: cap_get_tag_isCap isEndpointCap_def isCap_simps
                                     ccap_relation_ep_helpers)
             apply (frule cap_get_tag_isCap(4)[symmetric])
-            apply (clarsimp simp: cap_get_tag_EndpointCap to_bool_def)
+            apply (clarsimp simp: cap_get_tag_EndpointCap)
             apply (drule cap_get_tag_isCap(4) [symmetric])
             apply (clarsimp simp: isCap_simps cap_endpoint_cap_lift cap_lift_capEPBadge_mask_eq)
            apply (clarsimp simp: case_bool_If)
@@ -1467,8 +1465,8 @@ lemma handleRecv_ccorres:
   apply (frule tcb_aligned'[OF tcb_at_invs'])
   apply clarsimp
   apply (intro conjI impI allI)
-             apply (clarsimp simp: cfault_rel_def seL4_Fault_CapFault_lift
-                              lookup_fault_missing_capability_lift is_cap_fault_def)+
+           apply (clarsimp simp: cfault_rel_def seL4_Fault_CapFault_lift
+                            lookup_fault_missing_capability_lift is_cap_fault_def)+
          apply (clarsimp simp: cap_get_tag_NotificationCap)
          apply (rule cmap_relationE1[OF cmap_relation_ntfn], assumption, erule ko_at_projectKO_opt)
          apply (clarsimp simp: cnotification_relation_def Let_def)

--- a/proof/crefine/ARM_HYP/TcbAcc_C.thy
+++ b/proof/crefine/ARM_HYP/TcbAcc_C.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2023, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -347,10 +348,10 @@ lemma armHSCurVCPU_update_active_ccorres:
   apply (clarsimp simp: modifyArchState_def)
   apply (rule ccorres_from_vcg)
   apply (rule allI, rule conseqPre, vcg)
-  apply (clarsimp simp: bind_def simpler_gets_def from_bool_def simpler_modify_def)
+  apply (clarsimp simp: bind_def simpler_gets_def simpler_modify_def)
   apply (clarsimp simp: rf_sr_def cstate_relation_def Let_def)
   by (clarsimp simp: carch_state_relation_def carch_globals_def cur_vcpu_relation_def
-                     cmachine_state_relation_def from_bool_def
+                     cmachine_state_relation_def
                split: bool.split)
 
 lemma armHSCurVCPU_update_curv_ccorres:
@@ -363,7 +364,7 @@ lemma armHSCurVCPU_update_curv_ccorres:
   apply (clarsimp simp: bind_def simpler_gets_def simpler_modify_def)
   apply (clarsimp simp: rf_sr_def cstate_relation_def Let_def)
   by (clarsimp simp: carch_state_relation_def carch_globals_def cur_vcpu_relation_def
-                     cmachine_state_relation_def from_bool_def true_def false_def
+                     cmachine_state_relation_def
                split: bool.split)
 
 lemma armHSCurVCPU_update_ccorres:
@@ -377,7 +378,7 @@ lemma armHSCurVCPU_update_ccorres:
   apply (clarsimp simp: bind_def simpler_gets_def simpler_modify_def)
   apply (clarsimp simp: rf_sr_def cstate_relation_def Let_def)
   by (clarsimp simp: carch_state_relation_def carch_globals_def cur_vcpu_relation_def
-                     cmachine_state_relation_def from_bool_def true_def false_def
+                     cmachine_state_relation_def
                split: bool.split)
 
 lemmas armHSCurVCPU_update_active_ccorres2 = armHSCurVCPU_update_ccorres[where curv="Some (v, b)" for v b]

--- a/proof/crefine/ARM_HYP/Tcb_C.thy
+++ b/proof/crefine/ARM_HYP/Tcb_C.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2023, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -491,8 +492,8 @@ lemma checkCapAt_ccorres:
      apply assumption
     apply (simp only: when_def if_to_top_of_bind)
     apply (rule ccorres_if_lhs)
-     apply (simp add: from_bool_def true_def)
-    apply (simp add: from_bool_def false_def)
+     apply simp
+    apply simp
    apply (simp add: guard_is_UNIV_def)
   apply (clarsimp simp: cte_wp_at_ctes_of)
   done
@@ -637,13 +638,13 @@ lemma invokeTCB_ThreadControl_ccorres:
                 apply (rule checkCapAt_ccorres)
                    apply ceqv
                   apply csymbr
-                  apply (simp add: true_def Collect_True
+                  apply (simp add: Collect_True
                               del: Collect_const)
                   apply (rule ccorres_rhs_assoc)+
                   apply (rule checkCapAt_ccorres)
                      apply ceqv
                     apply csymbr
-                    apply (simp add: true_def Collect_True
+                    apply (simp add: Collect_True
                                 del: Collect_const)
                     apply (simp add: assertDerived_def bind_assoc del: Collect_const)
                     apply (rule ccorres_symb_exec_l)
@@ -684,12 +685,12 @@ lemma invokeTCB_ThreadControl_ccorres:
                        apply (clarsimp split: if_splits)
                       apply (wp empty_fail_stateAssert hoare_case_option_wp | simp del: Collect_const)+
                    apply csymbr
-                   apply (simp add: false_def Collect_False ccorres_cond_iffs
+                   apply (simp add: Collect_False ccorres_cond_iffs
                                del: Collect_const)
                    apply (rule ccorres_pre_getCurThread)
                    apply (rename_tac curThread)
                    apply (rule ccorres_split_nothrow_novcg_dc)
-                      apply (simp add: when_def to_bool_def)
+                      apply (simp add: when_def)
                       apply (rule_tac C'="{s. target = curThread}"
                                       and Q="\<lambda>s. ksCurThread s = curThread"
                                       and Q'=UNIV in ccorres_rewrite_cond_sr)
@@ -711,12 +712,11 @@ lemma invokeTCB_ThreadControl_ccorres:
                                         tcbBuffer_def size_of_def cte_level_bits_def
                                         tcbIPCBufferSlot_def)
                  apply csymbr
-                 apply (simp add: Collect_False false_def
-                             del: Collect_const)
+                 apply (simp add: Collect_False del: Collect_const)
                  apply (rule ccorres_cond_false_seq, simp)
                  apply (rule ccorres_pre_getCurThread)
                  apply (rename_tac curThread)
-                 apply (simp add: when_def to_bool_def)
+                 apply (simp add: when_def)
                  apply (rule ccorres_split_nothrow_novcg_dc)
                     apply (rule_tac C'="{s. target = curThread}"
                                     and Q="\<lambda>s. ksCurThread s = curThread"
@@ -734,7 +734,7 @@ lemma invokeTCB_ThreadControl_ccorres:
                    apply (clarsimp simp: guard_is_UNIV_def)
                   apply (wp hoare_vcg_if_lift2(1) static_imp_wp, strengthen sch_act_wf_weak; wp)
                  apply (clarsimp simp: guard_is_UNIV_def Collect_const_mem)
-                apply (simp add: guard_is_UNIV_def false_def Collect_const_mem)
+                apply (simp add: guard_is_UNIV_def Collect_const_mem)
                 apply (clarsimp simp: ccap_relation_def cap_thread_cap_lift cap_to_H_def)
                apply simp
                apply (rule ccorres_cond_false_seq, simp)
@@ -742,7 +742,7 @@ lemma invokeTCB_ThreadControl_ccorres:
                apply (simp split: option.split_asm)
                apply (rule ccorres_pre_getCurThread)
                apply (rename_tac curThread)
-               apply (simp add: when_def to_bool_def)
+               apply (simp add: when_def)
                apply (rule ccorres_split_nothrow_novcg_dc)
                   apply (rule_tac C'="{s. target = curThread}"
                                   and Q="\<lambda>s. ksCurThread s = curThread"
@@ -823,7 +823,7 @@ lemma invokeTCB_ThreadControl_ccorres:
          apply (clarsimp simp: inQ_def Collect_const_mem cintr_def
                                exception_defs tcb_cnode_index_defs)
          apply (simp add: tcbBuffer_def tcbIPCBufferSlot_def word_sle_def
-                          cte_level_bits_def from_bool_def true_def size_of_def case_option_If2 )
+                          cte_level_bits_def size_of_def case_option_If2 )
          apply (rule conjI)
           apply (clarsimp simp: case_option_If2 if_n_0_0 objBits_simps' valid_cap'_def
                                 capAligned_def word_bits_conv obj_at'_def projectKOs)
@@ -856,33 +856,28 @@ lemma invokeTCB_ThreadControl_ccorres:
            apply (rule checkCapAt_ccorres2)
               apply ceqv
              apply csymbr
-             apply (simp add: true_def Collect_True
-                         del: Collect_const)
+             apply (simp add: Collect_True del: Collect_const)
              apply (rule ccorres_rhs_assoc)+
              apply (rule checkCapAt_ccorres2)
                 apply ceqv
                apply csymbr
-               apply (simp add: true_def Collect_True
-                                assertDerived_def bind_assoc
+               apply (simp add: Collect_True assertDerived_def bind_assoc
                                 ccorres_cond_iffs dc_def[symmetric]
                            del: Collect_const)
                apply (rule ccorres_symb_exec_l)
                   apply (ctac add: cteInsert_ccorres)
                  apply (wp empty_fail_stateAssert hoare_case_option_wp | simp del: Collect_const)+
               apply csymbr
-              apply (simp add: false_def Collect_False ccorres_cond_iffs
+              apply (simp add: Collect_False ccorres_cond_iffs
                           del: Collect_const)
               apply (rule ccorres_return_Skip[unfolded dc_def])
              apply (fastforce simp: guard_is_UNIV_def Kernel_C.tcbVTable_def tcbVTableSlot_def
                                     cte_level_bits_def size_of_def)
             apply csymbr
-            apply (simp add: false_def Collect_False
-                        del: Collect_const)
+            apply (simp add: Collect_False del: Collect_const)
             apply (rule ccorres_cond_false)
             apply (rule ccorres_return_Skip[unfolded dc_def])
-           apply (clarsimp simp: guard_is_UNIV_def false_def
-                                 ccap_relation_def cap_thread_cap_lift
-                                 cap_to_H_def)
+           apply (clarsimp simp: guard_is_UNIV_def ccap_relation_def cap_thread_cap_lift cap_to_H_def)
           apply simp
           apply (rule ccorres_split_throws, rule ccorres_return_C_errorE, simp+)
           apply vcg
@@ -926,34 +921,29 @@ lemma invokeTCB_ThreadControl_ccorres:
           apply (rule checkCapAt_ccorres2)
              apply ceqv
             apply csymbr
-            apply (simp add: true_def Collect_True
-                        del: Collect_const)
+            apply (simp add: Collect_True del: Collect_const)
             apply (rule ccorres_rhs_assoc)+
             apply (rule checkCapAt_ccorres2)
                apply ceqv
               apply csymbr
-              apply (simp add: true_def Collect_True
-                               assertDerived_def bind_assoc
+              apply (simp add: Collect_True assertDerived_def bind_assoc
                                ccorres_cond_iffs dc_def[symmetric]
                           del: Collect_const)
               apply (rule ccorres_symb_exec_l)
                  apply (ctac add: cteInsert_ccorres)
                 apply (wp empty_fail_stateAssert  hoare_case_option_wp | simp del: Collect_const)+
              apply csymbr
-             apply (simp add: false_def Collect_False ccorres_cond_iffs
+             apply (simp add: Collect_False ccorres_cond_iffs
                          del: Collect_const)
              apply (rule ccorres_return_Skip[unfolded dc_def])
             apply (clarsimp simp: guard_is_UNIV_def Collect_const_mem
                                   Kernel_C.tcbCTable_def tcbCTableSlot_def
                                   cte_level_bits_def size_of_def option_to_0_def)
            apply csymbr
-           apply (simp add: false_def Collect_False
-                       del: Collect_const)
+           apply (simp add: Collect_False del: Collect_const)
            apply (rule ccorres_cond_false)
            apply (rule ccorres_return_Skip[unfolded dc_def])
-          apply (clarsimp simp: guard_is_UNIV_def false_def
-                                ccap_relation_def cap_thread_cap_lift
-                                cap_to_H_def)
+          apply (clarsimp simp: guard_is_UNIV_def ccap_relation_def cap_thread_cap_lift cap_to_H_def)
          apply simp
          apply (rule ccorres_split_throws, rule ccorres_return_C_errorE, simp+)
          apply vcg
@@ -971,7 +961,7 @@ lemma invokeTCB_ThreadControl_ccorres:
                 threadSet_cap_to' static_imp_wp | simp)+
      apply (clarsimp simp: guard_is_UNIV_def tcbCTableSlot_def Kernel_C.tcbCTable_def
                            cte_level_bits_def size_of_def word_sle_def option_to_0_def
-                           true_def from_bool_def cintr_def Collect_const_mem)
+                           cintr_def Collect_const_mem)
     apply (simp add: conj_comms)
     apply (wp hoare_case_option_wp threadSet_invs_trivial
               threadSet_cap_to' static_imp_wp | simp)+
@@ -1042,7 +1032,7 @@ lemma setupReplyMaster_ccorres:
           apply (subst is_aligned_neg_mask_weaken)
             apply (erule is_aligned_tcb_ptr_to_ctcb_ptr)
            apply (simp add: ctcb_size_bits_def)
-          apply (simp add: true_def mask_def to_bool_def)
+          apply simp
          apply simp
         apply (simp add: cmachine_state_relation_def
                          typ_heap_simps'
@@ -1247,9 +1237,8 @@ lemma invokeTCB_CopyRegisters_ccorres:
      apply (fastforce simp: sch_act_wf_weak)
     apply (wpsimp wp: hoare_drop_imp)+
    apply (clarsimp simp add: guard_is_UNIV_def)
-  apply (clarsimp simp: to_bool_def invs_weak_sch_act_wf invs_valid_objs'
+  apply (clarsimp simp: invs_weak_sch_act_wf invs_valid_objs'
                  split: if_split
-                  cong: if_cong
             | rule conjI)+
      apply (clarsimp dest!: global'_no_ex_cap simp: invs'_def valid_state'_def | rule conjI)+
   done
@@ -1698,7 +1687,7 @@ lemma invokeTCB_Suspend_ccorres:
    apply (ctac(no_vcg) add: suspend_ccorres[OF cteDeleteOne_ccorres])
     apply (rule ccorres_return_CE, simp+)[1]
    apply wp
-  apply (clarsimp simp: from_bool_def true_def)
+  apply clarsimp
   apply (auto simp: invs'_def valid_state'_def global'_no_ex_cap)
   done
 
@@ -1712,7 +1701,7 @@ lemma invokeTCB_Resume_ccorres:
    apply (ctac(no_vcg) add: restart_ccorres)
     apply (rule ccorres_return_CE, simp+)[1]
    apply wp
-  apply (clarsimp simp: from_bool_def true_def)
+  apply clarsimp
   done
 
 lemma Arch_decodeTransfer_spec:
@@ -1815,7 +1804,7 @@ shows
              apply (rule ccorres_symb_exec_l[OF _ _ _ empty_fail_getThreadState])
                apply (rule ccorres_if_lhs[OF _ ccorres_False[where P'=UNIV]])
                apply (rule ccorres_if_lhs)
-                apply (simp add: Collect_True true_def whileAnno_def del: Collect_const)
+                apply (simp add: Collect_True whileAnno_def del: Collect_const)
                 apply (rule ccorres_rhs_assoc)+
                 apply csymbr
                 apply (ctac add: lookupIPCBuffer_ccorres)
@@ -2143,7 +2132,7 @@ shows
                                  ARM_HYP.badgeRegister_def
                                  "StrictC'_register_defs")
                 apply (vcg exspec=lookupIPCBuffer_modifies)
-               apply (simp add: false_def)
+               apply simp
                apply (ctac(no_vcg) add: setThreadState_ccorres)
                 apply (rule ccorres_from_vcg_throws[where P=\<top> and P'=UNIV])
                 apply (rule allI, rule conseqPre, vcg)
@@ -2173,7 +2162,7 @@ shows
      apply (vcg exspec=suspend_modifies)
     apply vcg
    apply (rule conseqPre, vcg, clarsimp)
-  apply (clarsimp simp: rf_sr_ksCurThread ct_in_state'_def true_def
+  apply (clarsimp simp: rf_sr_ksCurThread ct_in_state'_def
                  split: if_split)
   done
 
@@ -2295,7 +2284,7 @@ lemma decodeReadRegisters_ccorres:
                      valid_tcb_state'_def
               elim!: pred_tcb'_weakenE
               dest!: st_tcb_at_idle_thread')[1]
-  apply (clarsimp simp: from_bool_def word_and_1 split: if_split)
+  apply (clarsimp simp: word_and_1 split: if_split)
   done
 
 lemma decodeWriteRegisters_ccorres:
@@ -2408,8 +2397,7 @@ lemma decodeWriteRegisters_ccorres:
   apply (rule disjCI2)
   apply (clarsimp simp: genericTake_def linorder_not_less)
   apply (subst hd_conv_nth, clarsimp simp: unat_eq_0)
-  apply (clarsimp simp: from_bool_def word_and_1
-                 split: if_split)
+  apply (clarsimp simp: word_and_1 split: if_split)
   done
 
 lemma excaps_map_Nil: "(excaps_map caps = []) = (caps = [])"
@@ -2478,7 +2466,7 @@ lemma decodeCopyRegisters_ccorres:
           apply (simp add: case_bool_If if_to_top_of_bindE
                            if_to_top_of_bind
                       del: Collect_const cong: if_cong)
-          apply (simp add: to_bool_def returnOk_bind Collect_True
+          apply (simp add: returnOk_bind Collect_True
                            ccorres_invocationCatch_Inr performInvocation_def
                       del: Collect_const)
           apply (ctac add: setThreadState_ccorres)
@@ -2705,7 +2693,7 @@ lemma slotCapLongRunningDelete_ccorres:
        apply (clarsimp simp: typ_heap_simps cap_get_tag_isCap
                              from_bool_0
                       dest!: ccte_relation_ccap_relation)
-       apply (simp add: from_bool_def false_def true_def
+       apply (simp add: from_bool_def
                  split: bool.split)
        apply (auto simp add: longRunningDelete_def isCap_simps
                  split: capability.split)[1]
@@ -2713,13 +2701,12 @@ lemma slotCapLongRunningDelete_ccorres:
       apply (wp hoare_drop_imps isFinalCapability_inv)
      apply (clarsimp simp: Collect_const_mem guard_is_UNIV_def)
      apply (rename_tac rv')
-     apply (case_tac rv'; clarsimp simp: false_def true_def)
+     apply (case_tac rv'; clarsimp simp: false_def)
     apply vcg
    apply (rule conseqPre, vcg, clarsimp)
   apply (clarsimp simp: cte_wp_at_ctes_of)
   apply (erule(1) cmap_relationE1 [OF cmap_relation_cte])
-  apply (clarsimp simp: typ_heap_simps cap_get_tag_isCap
-                        from_bool_def false_def map_comp_Some_iff
+  apply (clarsimp simp: typ_heap_simps cap_get_tag_isCap map_comp_Some_iff
                  dest!: ccte_relation_ccap_relation)
   done
 
@@ -2734,7 +2721,7 @@ lemma isValidVTableRoot_spec:
     {s'. ret__unsigned_long_' s' = from_bool (isValidVTableRoot_C (cap_' s))}"
   apply vcg
   apply (clarsimp simp: isValidVTableRoot_C_def if_1_0_0 from_bool_0)
-  apply (simp add: from_bool_def to_bool_def false_def split: if_split)
+  apply (simp add: to_bool_def split: if_split)
   done
 
 lemma isValidVTableRoot_conv:
@@ -2748,9 +2735,8 @@ lemma isValidVTableRoot_conv:
    apply (case_tac "cap_get_tag cap' = scast cap_page_directory_cap")
     apply (clarsimp split: arch_capability.split simp: isCap_simps)
     apply (clarsimp simp: ccap_relation_def map_option_Some_eq2
-                          cap_page_directory_cap_lift cap_to_H_def
-                          from_bool_def)
-    apply (clarsimp simp: to_bool_def split: if_split)
+                          cap_page_directory_cap_lift cap_to_H_def)
+    apply (clarsimp split: if_split)
    apply (clarsimp simp: cap_get_tag_isCap cap_get_tag_isCap_ArchObject)
    apply (simp split: arch_capability.split_asm add: isCap_simps)
   apply (case_tac "cap_get_tag cap' = scast cap_page_directory_cap")
@@ -3062,7 +3048,7 @@ lemma decodeTCBConfigure_ccorres:
                                           in ccorres_from_vcg[where P=\<top>])
                            apply (rule allI, rule conseqPre, vcg)
                            apply (subgoal_tac "extraCaps \<noteq> []")
-                            apply (clarsimp simp: returnOk_def return_def hd_conv_nth false_def)
+                            apply (clarsimp simp: returnOk_def return_def hd_conv_nth)
                             apply fastforce
                            apply clarsimp
                           apply ceqv
@@ -3089,7 +3075,7 @@ lemma decodeTCBConfigure_ccorres:
                                                 in ccorres_from_vcg[where P=\<top>])
                                 apply (rule allI, rule conseqPre, vcg)
                                 apply (clarsimp simp: returnOk_def return_def
-                                                      hd_drop_conv_nth2 false_def)
+                                                      hd_drop_conv_nth2)
                                 apply fastforce
                                apply ceqv
                               apply (ctac add: ccorres_injection_handler_csum1
@@ -3540,9 +3526,9 @@ lemma decodeSetSchedParams_ccorres:
                    val="from_bool (length args < 2 \<or> length extraCaps = 0)" in
                    ccorres_symb_exec_r_known_rv)
       apply vcg
-      apply (auto simp: interpret_excaps_test_null excaps_map_def from_bool_def unat_eq_0
-                  split: bool.splits)[1]
-       apply (unat_arith+)[2]
+      apply (force simp: interpret_excaps_test_null excaps_map_def from_bool_def unat_eq_0
+                         unat_arith_simps
+                  split: bool.splits if_splits)
      apply ceqv
     apply clarsimp
     apply (wpc,
@@ -4031,7 +4017,7 @@ lemma decodeBindNotification_ccorres:
       apply csymbr
       apply (clarsimp simp add: if_to_top_of_bind to_bool_eq_0[symmetric] simp del: Collect_const)
       apply (rule ccorres_Cond_rhs_Seq)
-       apply (clarsimp simp: to_bool_def throwError_bind invocationCatch_def)
+       apply (clarsimp simp: throwError_bind invocationCatch_def)
        apply (rule ccorres_from_vcg_split_throws[where P=\<top> and P'=UNIV])
         apply vcg
        apply (rule conseqPre, vcg)
@@ -4054,7 +4040,7 @@ lemma decodeBindNotification_ccorres:
          apply (clarsimp simp: typ_heap_simps cnotification_relation_def Let_def
                                valid_ntfn'_def)
          apply (case_tac "ntfnObj ntfn", simp_all add: isWaitingNtfn_def option_to_ctcb_ptr_def
-                             false_def true_def split: option.split_asm if_split,
+                                                split: option.split_asm if_split,
                          auto simp: neq_Nil_conv tcb_queue_relation'_def tcb_at_not_NULL[symmetric]
                                     tcb_at_not_NULL)[1]
         apply ceqv
@@ -4118,8 +4104,8 @@ lemma decodeBindNotification_ccorres:
        apply (rule conseqPre, vcg)
        apply (clarsimp simp: throwError_def return_def syscall_error_rel_def
                              syscall_error_to_H_cases exception_defs)
-      apply (clarsimp simp add: guard_is_UNIV_def isWaitingNtfn_def from_bool_0
-                                ThreadState_Restart_def mask_def true_def
+      apply (clarsimp simp add: guard_is_UNIV_def isWaitingNtfn_def
+                                ThreadState_Restart_def mask_def
                                 rf_sr_ksCurThread capTCBPtr_eq)
      apply (simp add: hd_conv_nth bindE_bind_linearise nTFN_case_If_ptr throwError_bind invocationCatch_def)
      apply (rule ccorres_from_vcg_split_throws[where P=\<top> and P'=UNIV])
@@ -4305,7 +4291,7 @@ lemma decodeSetSpace_ccorres:
                                  in ccorres_from_vcg[where P=\<top>])
                      apply (rule allI, rule conseqPre, vcg)
                      apply (subgoal_tac "extraCaps \<noteq> []")
-                      apply (clarsimp simp: returnOk_def return_def hd_conv_nth false_def)
+                      apply (clarsimp simp: returnOk_def return_def hd_conv_nth)
                       apply fastforce
                      apply clarsimp
                     apply ceqv
@@ -4332,8 +4318,7 @@ lemma decodeSetSpace_ccorres:
                            apply (rule_tac P'="{s. vRootCap = vRootCap_' s}"
                                   in ccorres_from_vcg[where P=\<top>])
                            apply (rule allI, rule conseqPre, vcg)
-                           apply (clarsimp simp: returnOk_def return_def
-                                                 hd_drop_conv_nth2 false_def)
+                           apply (clarsimp simp: returnOk_def return_def hd_drop_conv_nth2)
                            apply fastforce
                           apply ceqv
                          apply (ctac add: ccorres_injection_handler_csum1
@@ -4446,10 +4431,7 @@ lemma decodeSetSpace_ccorres:
                         "StrictC'_thread_state_defs" mask_eq_iff_w2p word_size)
   apply (simp add: word_sle_def cap_get_tag_isCap)
   apply (subgoal_tac "args \<noteq> []")
-   apply (clarsimp simp: hd_conv_nth)
-   apply (drule sym, simp, simp add: true_def from_bool_0)
-   apply (clarsimp simp: objBits_defs)
-   apply fastforce
+   apply (fastforce simp: hd_conv_nth objBits_defs)
   apply clarsimp
   done
 

--- a/proof/crefine/ARM_HYP/Wellformed_C.thy
+++ b/proof/crefine/ARM_HYP/Wellformed_C.thy
@@ -271,63 +271,6 @@ definition
                    | Some cap \<Rightarrow> Some \<lparr> cap_CL = cap,
                                        cteMDBNode_CL = mdb_node_lift (cteMDBNode_C c) \<rparr>"
 
-lemma to_bool_false [simp]: "\<not> to_bool false"
-  by (simp add: to_bool_def false_def)
-
-(* this is slightly weird, but the bitfield generator
-   masks everything with the expected bit length.
-   So we do that here too. *)
-definition
-  to_bool_bf :: "'a::len word \<Rightarrow> bool" where
-  "to_bool_bf w \<equiv> (w && mask 1) = 1"
-
-lemma to_bool_bf_mask1 [simp]:
-  "to_bool_bf (mask (Suc 0))"
-  by (simp add: mask_def to_bool_bf_def)
-
-lemma to_bool_bf_0 [simp]: "\<not>to_bool_bf 0"
-  by (simp add: to_bool_bf_def)
-
-lemma to_bool_bf_1 [simp]: "to_bool_bf 1"
-  by (simp add: to_bool_bf_def mask_def)
-
-lemma to_bool_bf_false [simp]:
-  "\<not>to_bool_bf false"
-  by (simp add: false_def)
-
-lemma to_bool_bf_true [simp]:
-  "to_bool_bf true"
-  by (simp add: true_def)
-
-lemma to_bool_to_bool_bf:
-  "w = false \<or> w = true \<Longrightarrow> to_bool_bf w = to_bool w"
-  by (auto simp: false_def true_def to_bool_def to_bool_bf_def mask_def)
-
-lemma to_bool_bf_mask_1 [simp]:
-  "to_bool_bf (w && mask (Suc 0)) = to_bool_bf w"
-  by (simp add: to_bool_bf_def)
-
-lemma to_bool_bf_and [simp]:
-  "to_bool_bf (a && b) = (to_bool_bf a \<and> to_bool_bf (b::word32))"
-  apply (clarsimp simp: to_bool_bf_def)
-  apply (rule iffI)
-   apply (subst (asm) bang_eq)
-   apply (simp add: word_size)
-   apply (rule conjI)
-    apply (rule word_eqI)
-    apply (auto simp add: word_size)[1]
-   apply (rule word_eqI)
-   apply (auto simp add: word_size)[1]
-  apply clarsimp
-  apply (rule word_eqI)
-  apply (subst (asm) bang_eq)+
-  apply (auto simp add: word_size)[1]
-  done
-
-lemma to_bool_bf_to_bool_mask:
-  "w && mask (Suc 0) = w \<Longrightarrow> to_bool_bf w = to_bool (w::word32)"
-  by (metis One_nat_def mask_eq1_nochoice fold_eq_0_to_bool mask_1 to_bool_bf_0 to_bool_bf_def)
-
 definition
   mdb_node_to_H :: "mdb_node_CL \<Rightarrow> mdbnode"
   where

--- a/proof/crefine/RISCV64/Arch_C.thy
+++ b/proof/crefine/RISCV64/Arch_C.thy
@@ -2227,7 +2227,7 @@ lemma decodeRISCVFrameInvocation_ccorres:
              apply (match conclusion in \<open>cpte_relation _ _\<close> \<Rightarrow>
                       \<open>solves \<open>simp (no_asm) add: cpte_relation_def,
                                clarsimp simp: Let_def makeUserPTE_def attribsFromWord_def
-                                              pageBits_def
+                                              pageBits_def word_and_1
                                         split: pte.splits if_splits\<close>\<close>
                     | match conclusion in \<open>ccap_relation _ _\<close> \<Rightarrow>
                         \<open>solves \<open>simp (no_asm) add: ccap_relation_def,

--- a/proof/crefine/RISCV64/Arch_C.thy
+++ b/proof/crefine/RISCV64/Arch_C.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2023, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
  *
@@ -77,7 +78,7 @@ using [[goals_limit=20]]
          apply wp
         apply (simp del: Collect_const)
         apply (vcg exspec=unmapPageTable_modifies)
-       apply (simp add: to_bool_def)
+       apply simp
        apply (rule ccorres_return_Skip')
       apply (simp add: cap_get_tag_isCap_ArchObject[symmetric])
       apply (clarsimp simp: cap_lift_page_table_cap cap_to_H_def
@@ -1010,9 +1011,7 @@ lemma decodeRISCVPageTableInvocation_ccorres:
                apply (erule cmap_relationE1[OF rf_sr_cpte_relation], erule ko_at_projectKO_opt)
                apply (clarsimp simp: typ_heap_simps from_bool_eq_if)
                apply (simp flip: word_unat.Rep_inject)
-               apply (auto simp: cpte_relation_def Let_def
-                                  pte_lift_def
-                                  from_bool_def case_bool_If
+               apply (auto simp: cpte_relation_def Let_def pte_lift_def case_bool_If
                           split: pte.split_asm if_splits)[1]
               apply ceqv
              apply clarsimp
@@ -1060,10 +1059,10 @@ lemma decodeRISCVPageTableInvocation_ccorres:
          apply (rule conseqPre, vcg)
          apply clarsimp
          apply (clarsimp simp: throwError_def return_def syscall_error_rel_def
-                               syscall_error_to_H_cases exception_defs false_def)
+                               syscall_error_to_H_cases exception_defs)
          apply (erule lookup_failure_rel_fault_lift[rotated])
          apply (clarsimp simp: throwError_def return_def syscall_error_rel_def
-                                syscall_error_to_H_cases exception_defs false_def)
+                                syscall_error_to_H_cases exception_defs)
         apply clarsimp
         apply (wp injection_wp[OF refl] findVSpaceForASID_inv hoare_drop_imps)
        apply clarsimp
@@ -1180,8 +1179,7 @@ lemma checkVPAlignment_spec:
   apply (clarsimp simp: mask_eq_iff_w2p word_size)
   apply (rule conjI)
    apply (simp add: pageBitsForSize_def bit_simps split: vmpage_size.split)
-  apply (simp add: from_bool_def vmsz_aligned_def is_aligned_mask
-                   mask_def split: if_split)
+  apply (simp add: vmsz_aligned_def is_aligned_mask mask_def split: if_split)
   done
 
 definition
@@ -1845,7 +1843,7 @@ lemma decodeRISCVFrameInvocation_ccorres:
                  apply (clarsimp simp: throwError_def return_def bindE_def NonDetMonad.lift_def
                                        exception_defs lookup_fault_lift_invalid_root)
                  apply (clarsimp simp: syscall_error_rel_def exception_defs syscall_error_to_H_def
-                                       syscall_error_type_defs false_def)
+                                       syscall_error_type_defs)
                  apply (simp add: lookup_fault_missing_capability_lift)
                  apply (subst word_le_mask_eq)
                   apply (simp add: mask_def word_le_nat_alt)
@@ -1882,9 +1880,7 @@ lemma decodeRISCVFrameInvocation_ccorres:
                     apply clarsimp
                     apply (erule cmap_relationE1[OF rf_sr_cpte_relation], erule ko_at_projectKO_opt)
                     apply (clarsimp simp: typ_heap_simps from_bool_eq_if from_bool_0)
-                    apply (fastforce simp: cpte_relation_def Let_def
-                                       pte_lift_def
-                                       from_bool_def case_bool_If
+                    apply (fastforce simp: cpte_relation_def Let_def pte_lift_def case_bool_If
                                split: pte.split_asm if_splits)
                    apply ceqv
                   apply clarsimp
@@ -2061,10 +2057,10 @@ lemma decodeRISCVFrameInvocation_ccorres:
              apply (rule conseqPre, vcg)
              apply clarsimp
              apply (clarsimp simp: throwError_def return_def syscall_error_rel_def
-                                   syscall_error_to_H_cases exception_defs false_def)
+                                   syscall_error_to_H_cases exception_defs)
              apply (erule lookup_failure_rel_fault_lift[rotated])
              apply (clarsimp simp: throwError_def return_def syscall_error_rel_def
-                                   syscall_error_to_H_cases exception_defs false_def)
+                                   syscall_error_to_H_cases exception_defs)
             apply clarsimp
             apply (wp injection_wp[OF refl] findVSpaceForASID_inv hoare_drop_imps)
            apply clarsimp
@@ -2442,14 +2438,13 @@ lemma decodeRISCVMMUInvocation_ccorres:
                   apply (cut_tac P="\<lambda>y. y < i_' x + 1 = rhs y" for rhs in allI,
                          rule less_x_plus_1)
                    apply (fastforce simp: asid_high_bits_def)
-                  apply (clarsimp simp: rf_sr_riscvKSASIDTable from_bool_def
+                  apply (clarsimp simp: rf_sr_riscvKSASIDTable
                                         asid_high_bits_word_bits
                                         option_to_ptr_def option_to_0_def
                                         order_less_imp_le
                                         linorder_not_less
                                         order_antisym[OF inc_le])
-                  apply (clarsimp simp: true_def false_def
-                                 split: option.split if_split)
+                  apply (clarsimp split: option.split if_split)
                   apply (auto simp: asid_high_bits_def word_le_nat_alt
                                     word_less_nat_alt unat_add_lem[THEN iffD1]
                                     Kernel_C_defs)[1]
@@ -2468,8 +2463,7 @@ lemma decodeRISCVMMUInvocation_ccorres:
                 apply (clarsimp simp: asidHighBits_handy_convs word_sle_def
                                       word_sless_def from_bool_0
                                       rf_sr_riscvKSASIDTable[where n=0, simplified])
-                apply (simp add: asid_high_bits_def option_to_ptr_def option_to_0_def
-                                 from_bool_def Kernel_C_defs
+                apply (simp add: asid_high_bits_def option_to_ptr_def option_to_0_def Kernel_C_defs
                           split: option.split if_split)
                 apply fastforce
                apply ceqv
@@ -2645,11 +2639,10 @@ lemma decodeRISCVMMUInvocation_ccorres:
        apply (clarsimp simp: excaps_in_mem_def)
        apply (frule (1) slotcap_in_mem_PageTable)
        apply (clarsimp simp: typ_heap_simps' from_bool_0 split: if_split)
-       apply (case_tac a; clarsimp simp: isCap_simps cap_get_tag_isCap_unfolded_H_cap
-                                         cap_tag_defs true_def)
+       apply (case_tac a; clarsimp simp: isCap_simps cap_get_tag_isCap_unfolded_H_cap cap_tag_defs)
        apply (intro conjI impI
               ; solves \<open>clarsimp simp: isCap_simps asidInvalid_def cap_lift_page_table_cap cap_to_H_simps
-                                       true_def c_valid_cap_def cl_valid_cap_def
+                                       c_valid_cap_def cl_valid_cap_def
                                        ccap_relation_PageTableCap_IsMapped\<close>)
       apply ceqv
      apply (rule ccorres_Cond_rhs_Seq)
@@ -2694,8 +2687,7 @@ lemma decodeRISCVMMUInvocation_ccorres:
         apply (rule ccorres_from_vcg_throws[where P=\<top> and P'=UNIV])
         apply (rule allI, rule conseqPre, vcg)
         apply (clarsimp simp: throwError_def return_def
-                              syscall_error_rel_def exception_defs
-                              syscall_error_to_H_cases false_def)
+                              syscall_error_rel_def exception_defs syscall_error_to_H_cases)
         apply (simp add: lookup_fault_lift_invalid_root)
        apply csymbr
        apply (simp add: liftME_def bindE_assoc if_to_top_of_bind)
@@ -2745,9 +2737,7 @@ lemma decodeRISCVMMUInvocation_ccorres:
                                      = capASIDBase cp")
               apply (subgoal_tac "\<And>x. (x < (i_' xb + 1))
                                         = (x < i_' xb \<or> x = i_' xb)")
-               apply (clarsimp simp: inc_le from_bool_def typ_heap_simps
-                                     asid_low_bits_def not_less field_simps
-                                     false_def
+               apply (clarsimp simp: inc_le typ_heap_simps asid_low_bits_def not_less field_simps
                               split: if_split bool.splits)
                apply unat_arith
               apply (rule iffI)
@@ -2797,11 +2787,10 @@ lemma decodeRISCVMMUInvocation_ccorres:
                                  word_sless_def word_sle_def)
            apply (erule cmap_relationE1[OF rf_sr_cpspace_asidpool_relation],
                   erule ko_at_projectKO_opt)
-           apply (clarsimp simp: typ_heap_simps from_bool_def split: if_split)
+           apply (clarsimp simp: typ_heap_simps split: if_split)
            apply (frule cap_get_tag_isCap_unfolded_H_cap)
            apply (clarsimp simp: cap_lift_asid_pool_cap cap_to_H_def
-                                 cap_asid_pool_cap_lift_def false_def
-                                 ucast_minus ucast_nat_def
+                                 cap_asid_pool_cap_lift_def ucast_minus ucast_nat_def
                           elim!: ccap_relationE)
           apply ceqv
          apply (simp add: if_to_top_of_bind)
@@ -2921,21 +2910,19 @@ lemma decodeRISCVMMUInvocation_ccorres:
                         rf_sr_ksCurThread "StrictC'_thread_state_defs"
                         mask_def[where n=4]
                   cong: if_cong)
-  apply (clarsimp simp: to_bool_def ccap_relation_isDeviceCap2 objBits_simps
-                        pageBits_def from_bool_def case_bool_If)
+  apply (clarsimp simp: ccap_relation_isDeviceCap2 objBits_simps pageBits_def case_bool_If)
   apply (rule conjI; clarsimp)
    apply (clarsimp simp: neq_Nil_conv excaps_in_mem_def excaps_map_def)
    apply (frule interpret_excaps_eq[rule_format, where n=0], simp)
    apply (frule interpret_excaps_eq[rule_format, where n=1], simp)
    apply (clarsimp simp: mask_def[where n=4] slotcap_in_mem_def
                          ccap_rights_relation_def rightsFromWord_wordFromRights)
-   apply (clarsimp simp: asid_high_bits_word_bits Kernel_C.asidHighBits_def true_def split: list.split_asm)
+   apply (clarsimp simp: asid_high_bits_word_bits Kernel_C.asidHighBits_def split: list.split_asm)
     apply (clarsimp simp: cap_untyped_cap_lift_def cap_lift_untyped_cap
                           cap_to_H_def[split_simps cap_CL.split]
                           hd_conv_nth length_ineq_not_Nil Kernel_C_defs
                    elim!: ccap_relationE)
-   apply (clarsimp simp: to_bool_def unat_eq_of_nat
-                         objBits_simps pageBits_def from_bool_def case_bool_If
+   apply (clarsimp simp: to_bool_def unat_eq_of_nat objBits_simps pageBits_def case_bool_If
                   split: if_splits)
   apply (clarsimp simp: asid_low_bits_word_bits isCap_simps neq_Nil_conv
                         excaps_map_def excaps_in_mem_def
@@ -2946,22 +2933,20 @@ lemma decodeRISCVMMUInvocation_ccorres:
   apply (frule interpret_excaps_eq[rule_format, where n=0], simp)
   apply (rule conjI)
    apply (clarsimp simp: cap_lift_asid_pool_cap cap_lift_page_table_cap
-                         cap_to_H_def to_bool_def valid_cap'_def
+                         cap_to_H_def valid_cap'_def
                          cap_page_table_cap_lift_def inv_ASIDPool
-                         cap_asid_pool_cap_lift_def mask_def true_def
+                         cap_asid_pool_cap_lift_def mask_def
                          asid_shiftr_low_bits_less[unfolded mask_def asid_bits_def] word_and_le1
                   elim!: ccap_relationE split: if_split_asm asidpool.splits)
    apply (clarsimp split: list.split)
    apply (clarsimp simp: casid_pool_relation_def)
    apply (case_tac asidpool', simp)
   apply (clarsimp simp: cap_lift_asid_pool_cap cap_lift_page_table_cap
-                        cap_to_H_def to_bool_def
-                        cap_page_table_cap_lift_def
+                        cap_to_H_def cap_page_table_cap_lift_def
                  elim!: ccap_relationE split: if_split_asm)
   apply (erule rf_sr_cte_at_validD[rotated])
   apply (fastforce simp: slotcap_in_mem_def2)
   done
-
 
 lemma setMessageInfo_ksCurThread_ccorres:
   "ccorres dc xfdc (tcb_at' thread and (\<lambda>s. ksCurThread s = thread))

--- a/proof/crefine/RISCV64/CLevityCatch.thy
+++ b/proof/crefine/RISCV64/CLevityCatch.thy
@@ -10,6 +10,7 @@ imports
   ArchMove_C
   "CParser.LemmaBucket_C"
   "Lib.LemmaBucket"
+  Boolean_C
 begin
 
 context begin interpretation Arch . (*FIXME: arch_split*)

--- a/proof/crefine/RISCV64/CSpace_All.thy
+++ b/proof/crefine/RISCV64/CSpace_All.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2023, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -253,8 +254,7 @@ lemma lookupSlotForCNodeOp_ccorres':
    apply vcg
 
   \<comment> \<open>last subgoal\<close>
-  apply (clarsimp simp: if_1_0_0  to_bool_def true_def word_size
-                        fromIntegral_def integral_inv)
+  apply (clarsimp simp: word_size fromIntegral_def integral_inv)
   apply (case_tac "cap_get_tag root = scast cap_cnode_cap")
    prefer 2 apply clarsimp
   apply (clarsimp simp: unat_of_nat64 word_sle_def)
@@ -290,7 +290,7 @@ lemma lookupSourceSlot_ccorres':
      apply simp
     apply simp
    apply (ctac add: lookupSlotForCNodeOp_ccorres')
-  apply (clarsimp simp: to_bool_def true_def false_def)
+  apply clarsimp
   done
 
 lemma lookupSourceSlot_ccorres:
@@ -320,7 +320,7 @@ lemma lookupTargetSlot_ccorres':
      apply simp
     apply simp
    apply (ctac add: lookupSlotForCNodeOp_ccorres')
-  apply (clarsimp simp: to_bool_def true_def false_def)
+  apply clarsimp
   done
 
 lemma lookupTargetSlot_ccorres:
@@ -350,7 +350,7 @@ lemma lookupPivotSlot_ccorres:
      apply simp
     apply simp
    apply (ctac add: lookupSlotForCNodeOp_ccorres)
-  apply (clarsimp simp: to_bool_def true_def false_def)
+  apply clarsimp
   done
 
 end

--- a/proof/crefine/RISCV64/CSpace_C.thy
+++ b/proof/crefine/RISCV64/CSpace_C.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2023, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
  *
@@ -111,10 +112,6 @@ lemma Arch_maskCapRights_ccorres [corres]:
    apply (cases arch_cap)
          by (fastforce simp add: cap_get_tag_isCap isCap_simps  simp del: not_ex simp_thms(44))+
 
-lemma to_bool_mask_to_bool_bf:
-  "to_bool (x && 1) = to_bool_bf (x::machine_word)"
-  by (simp add: to_bool_bf_def to_bool_def)
-
 lemma to_bool_cap_rights_bf:
   "to_bool (capAllowRead_CL (seL4_CapRights_lift R)) =
    to_bool_bf (capAllowRead_CL (seL4_CapRights_lift R))"
@@ -175,7 +172,7 @@ lemma maskCapRights_ccorres [corres]:
   apply csymbr
   apply (simp add: maskCapRights_cap_cases cap_get_tag_isCap del: Collect_const)
   apply wpc
-              apply (simp add: Collect_const_mem from_bool_def)
+              apply (simp add: Collect_const_mem)
               apply csymbr
               apply (simp add: cap_get_tag_isCap isCap_simps del: Collect_const)
               apply (simp add: ccorres_cond_iffs)
@@ -185,7 +182,7 @@ lemma maskCapRights_ccorres [corres]:
                apply vcg
               apply clarsimp
               apply (simp add: cap_get_tag_isCap isCap_simps return_def)
-             apply (simp add: Collect_const_mem from_bool_def)
+             apply (simp add: Collect_const_mem)
              apply csymbr
              apply (simp add: cap_get_tag_isCap isCap_simps del: Collect_const)
              apply (simp add: ccorres_cond_iffs)
@@ -194,7 +191,7 @@ lemma maskCapRights_ccorres [corres]:
              apply (rule conseqPre)
               apply vcg
              apply (clarsimp simp: return_def)
-            apply (simp add: Collect_const_mem from_bool_def)
+            apply (simp add: Collect_const_mem)
             apply csymbr
             apply (simp add: cap_get_tag_isCap isCap_simps del: Collect_const)
             apply (simp add: ccorres_cond_iffs)
@@ -220,7 +217,7 @@ lemma maskCapRights_ccorres [corres]:
             apply (simp add: ccap_rights_relation_def cap_rights_to_H_def
                              to_bool_ntfn_cap_bf
                              to_bool_mask_to_bool_bf to_bool_cap_rights_bf)
-           apply (simp add: Collect_const_mem from_bool_def)
+           apply (simp add: Collect_const_mem)
            apply csymbr
            apply (simp add: cap_get_tag_isCap isCap_simps ccorres_cond_iffs)
            apply (rule ccorres_from_vcg_throws [where P=\<top> and P'=UNIV])
@@ -228,7 +225,7 @@ lemma maskCapRights_ccorres [corres]:
            apply (rule conseqPre)
             apply vcg
            apply (clarsimp simp: cap_get_tag_isCap isCap_simps return_def)
-          apply (simp add: Collect_const_mem from_bool_def)
+          apply (simp add: Collect_const_mem)
           apply csymbr
           apply (simp add: cap_get_tag_isCap isCap_simps ccorres_cond_iffs)
           apply (rule ccorres_from_vcg_throws [where P=\<top> and P'=UNIV])
@@ -256,7 +253,7 @@ lemma maskCapRights_ccorres [corres]:
           apply (simp add: ccap_rights_relation_def cap_rights_to_H_def
                            to_bool_ep_cap_bf
                            to_bool_mask_to_bool_bf to_bool_cap_rights_bf)
-         apply (simp add: Collect_const_mem from_bool_def)
+         apply (simp add: Collect_const_mem)
          apply csymbr
          apply (simp add: cap_get_tag_isCap isCap_simps del: Collect_const)
          apply (simp add: ccorres_cond_iffs)
@@ -265,7 +262,7 @@ lemma maskCapRights_ccorres [corres]:
          apply (rule conseqPre)
           apply vcg
          apply (clarsimp simp: return_def)
-        apply (simp add: Collect_const_mem from_bool_def)
+        apply (simp add: Collect_const_mem)
         apply csymbr
         apply (simp add: cap_get_tag_isCap isCap_simps ccorres_cond_iffs)
         apply (rule ccorres_from_vcg_throws [where P=\<top> and P'=UNIV])
@@ -273,7 +270,7 @@ lemma maskCapRights_ccorres [corres]:
         apply (rule conseqPre)
          apply vcg
         apply (clarsimp simp: cap_get_tag_isCap isCap_simps return_def)
-       apply (simp add: Collect_const_mem from_bool_def)
+       apply (simp add: Collect_const_mem)
        apply (subst bind_return [symmetric])
        apply (rule ccorres_split_throws)
         apply ctac
@@ -286,7 +283,7 @@ lemma maskCapRights_ccorres [corres]:
          apply wp
         apply vcg
        apply vcg
-      apply (simp add: Collect_const_mem from_bool_def)
+      apply (simp add: Collect_const_mem)
       apply csymbr
       apply (simp add: cap_get_tag_isCap isCap_simps del: Collect_const)
       apply ccorres_rewrite
@@ -306,7 +303,7 @@ lemma maskCapRights_ccorres [corres]:
       apply (simp add: ccap_rights_relation_def cap_rights_to_H_def
                        to_bool_reply_cap_bf
                        to_bool_mask_to_bool_bf[simplified] to_bool_cap_rights_bf)
-     apply (simp add: Collect_const_mem from_bool_def)
+     apply (simp add: Collect_const_mem)
      apply csymbr
      apply (simp add: cap_get_tag_isCap isCap_simps del: Collect_const)
      apply (simp add: ccorres_cond_iffs)
@@ -315,7 +312,7 @@ lemma maskCapRights_ccorres [corres]:
      apply (rule conseqPre)
       apply vcg
      apply (clarsimp simp: return_def)
-    apply (simp add: Collect_const_mem from_bool_def)
+    apply (simp add: Collect_const_mem)
     apply csymbr
     apply (simp add: cap_get_tag_isCap isCap_simps del: Collect_const)
     apply (simp add: ccorres_cond_iffs)
@@ -325,7 +322,7 @@ lemma maskCapRights_ccorres [corres]:
      apply vcg
     apply clarsimp
     apply (simp add: cap_get_tag_isCap isCap_simps return_def)
-   apply (simp add: Collect_const_mem from_bool_def)
+   apply (simp add: Collect_const_mem)
    apply csymbr
    apply (simp add: cap_get_tag_isCap isCap_simps del: Collect_const)
    apply (simp add: ccorres_cond_iffs)
@@ -482,7 +479,7 @@ lemma Arch_isCapRevocable_spec:
         {t. \<forall>c c'.  ccap_relation c (derivedCap_' s) \<and> ccap_relation c' (srcCap_' s)
             \<longrightarrow> ret__unsigned_long_' t = from_bool (Arch.isCapRevocable c c')}"
   apply vcg
-  by (auto simp: false_def from_bool_def RISCV64_H.isCapRevocable_def
+  by (auto simp: RISCV64_H.isCapRevocable_def
                  cap_get_tag_isCap_unfolded_H_cap cap_tag_defs isCap_simps
                  cap_get_tag_isCap[unfolded, simplified]
           split: capability.splits arch_capability.splits bool.splits)
@@ -492,7 +489,7 @@ lemmas isCapRevocable_simps[simp] = Retype_H.isCapRevocable_def[split_simps capa
 context begin (* revokable_ccorres *)
 
 private method revokable'_hammer = solves \<open>(
-              simp add: cap_get_tag_isCap isCap_simps ccorres_cond_iffs from_bool_def true_def false_def,
+              simp add: cap_get_tag_isCap isCap_simps ccorres_cond_iffs,
               rule ccorres_guard_imp,
               rule ccorres_return_C; clarsimp)\<close>
 
@@ -521,7 +518,7 @@ lemma revokable_ccorres:
     \<comment> \<open>Uninteresting caps\<close>
               apply revokable'_hammer+
     \<comment> \<open>NotificationCap\<close>
-            apply (simp add: cap_get_tag_isCap isCap_simps ccorres_cond_iffs from_bool_def true_def false_def)
+            apply (simp add: cap_get_tag_isCap isCap_simps ccorres_cond_iffs)
             apply (rule ccorres_guard_imp, (rule ccorres_rhs_assoc)+, csymbr, csymbr)
               apply (rule ccorres_return_C, clarsimp+)
             apply (frule_tac cap'1=srcCap in cap_get_tag_NotificationCap[THEN iffD1])
@@ -530,12 +527,12 @@ lemma revokable_ccorres:
              apply (clarsimp simp: cap_get_tag_isCap isCap_simps)
             apply (fastforce simp: cap_get_tag_isCap isCap_simps)
     \<comment> \<open>IRQHandlerCap\<close>
-           apply (simp add: cap_get_tag_isCap isCap_simps ccorres_cond_iffs from_bool_def true_def false_def)
+           apply (simp add: cap_get_tag_isCap isCap_simps ccorres_cond_iffs)
            apply (rule ccorres_guard_imp, csymbr)
              apply (rule ccorres_return_C, clarsimp+)
            apply (fastforce simp: cap_get_tag_isCap isCap_simps)
     \<comment> \<open>EndpointCap\<close>
-          apply (simp add: cap_get_tag_isCap isCap_simps ccorres_cond_iffs from_bool_def true_def false_def)
+          apply (simp add: cap_get_tag_isCap isCap_simps ccorres_cond_iffs)
           apply (rule ccorres_guard_imp, (rule ccorres_rhs_assoc)+, csymbr, csymbr)
             apply (rule ccorres_return_C, clarsimp+)
           apply (frule_tac cap'1=srcCap in cap_get_tag_EndpointCap[THEN iffD1])
@@ -1169,7 +1166,7 @@ lemma cteMove_ccorres:
    apply (clarsimp simp: cte_wp_at_ctes_of cteSizeBits_eq ctes_of_canonical ctes_of_aligned_bits)
    apply assumption
   apply (clarsimp simp: ccap_relation_NullCap_iff cmdbnode_relation_def
-                        mdb_node_to_H_def nullMDBNode_def false_def)
+                        mdb_node_to_H_def nullMDBNode_def)
   done
 
 (************************************************************************)
@@ -1495,8 +1492,8 @@ lemma emptySlot_helper:
                          mdbFirstBadged_CL (cteMDBNode_CL y)")
       prefer 2
       apply (drule cteMDBNode_CL_lift [symmetric])
-      subgoal by (simp add: mdb_node_lift_def mask_def word_bw_assocs)
-     subgoal by (simp add: to_bool_def mask_def)
+      subgoal by (simp add: mdb_node_lift_def word_bw_assocs)
+     subgoal by (simp add: to_bool_def)
    \<comment> \<open>\<dots> \<exists>x\<in>fst \<dots>\<close>
    apply clarsimp
    apply (rule fst_setCTE [OF ctes_of_cte_at], assumption )
@@ -1526,7 +1523,7 @@ lemma emptySlot_helper:
     prefer 2
     apply (drule cteMDBNode_CL_lift [symmetric])
     subgoal by (simp add: mdb_node_lift_def mask_def word_bw_assocs)
-   apply (simp add: to_bool_def mask_def split: if_split)
+   apply (simp add: to_bool_def split: if_split)
 
   \<comment> \<open>trivial case where mdbNext rva = 0\<close>
    apply (simp add:ccorres_cond_empty_iff)
@@ -1677,7 +1674,6 @@ lemma setIRQState_ccorres:
     apply wp
    apply (simp add: empty_fail_def getInterruptState_def simpler_gets_def)
   apply clarsimp
-  apply (simp add: from_bool_def)
   apply (cases irqState, simp_all)
   apply (simp add: Kernel_C.IRQSignal_def Kernel_C.IRQInactive_def)
   apply (simp add: Kernel_C.IRQTimer_def Kernel_C.IRQInactive_def)
@@ -2332,7 +2328,7 @@ lemma emptySlot_ccorres:
             \<comment> \<open>Haskell pre/post for y \<leftarrow> updateCap slot capability.NullCap;\<close>
              apply wp
             \<comment> \<open>C       pre/post for y \<leftarrow> updateCap slot capability.NullCap;\<close>
-            apply (simp add: Collect_const_mem cmdbnode_relation_def mdb_node_to_H_def nullMDBNode_def false_def)
+            apply (simp add: Collect_const_mem cmdbnode_relation_def mdb_node_to_H_def nullMDBNode_def)
         \<comment> \<open>Haskell pre/post for the two nested updates\<close>
          apply wp
         \<comment> \<open>C       pre/post for the two nested updates\<close>
@@ -2487,7 +2483,7 @@ lemma Arch_sameRegionAs_spec:
     apply (cases capa; cases capb;
            frule (1) cap_get_tag[where cap'=cap_a]; (frule cap_lifts[where c=cap_a, THEN iffD1])?;
            frule (1) cap_get_tag[where cap'=cap_b]; (frule cap_lifts[where c=cap_b, THEN iffD1])?;
-           simp add: cap_tag_defs isCap_simps from_bool_def true_def false_def if_0_1_eq;
+           simp add: cap_tag_defs isCap_simps from_bool_def if_0_1_eq;
            clarsimp simp: ccap_relation_def cap_to_H_def c_valid_cap_def cl_valid_cap_def Let_def)
     by (clarsimp simp: cap_frame_cap_lift_def'[simplified cap_tag_defs]
                           framesize_to_H_def pageBitsForSize_def field_simps
@@ -2717,11 +2713,10 @@ lemma cap_get_capIsPhysical_spec:
                                           cap_lift_asid_control_cap word_sle_def
                                           cap_lift_irq_control_cap cap_lift_null_cap
                                           mask_def objBits_simps cap_lift_domain_cap
-                                          ptr_add_assertion_positive from_bool_def
-                                          true_def false_def cap_get_tag_scast
+                                          ptr_add_assertion_positive cap_get_tag_scast
                                    dest!: sym [where t = "ucast (cap_get_tag cap)" for cap]
                                    split: vmpage_size.splits)+
-  by (fastforce dest!: cap_lift_Some_CapD split: option.split cap_CL.split)
+  by (fastforce dest!: cap_lift_Some_CapD split: option.splits cap_CL.splits)
 
 lemma ccap_relation_get_capPtr_not_physical:
   "\<lbrakk> ccap_relation hcap ccap; capClass hcap \<noteq> PhysicalClass \<rbrakk> \<Longrightarrow>
@@ -2800,39 +2795,40 @@ lemma sameRegionAs_spec:
   apply (case_tac capa, simp_all add: cap_get_tag_isCap_unfolded_H_cap isCap_simps)
             \<comment> \<open>capa is a ThreadCap\<close>
              apply (case_tac capb, simp_all add: cap_get_tag_isCap_unfolded_H_cap
-                          isCap_simps cap_tag_defs from_bool_def false_def)[1]
+                                                 isCap_simps cap_tag_defs)[1]
               apply (frule_tac cap'=cap_a in cap_get_tag_isCap_unfolded_H_cap(1))
               apply (frule_tac cap'=cap_b in cap_get_tag_isCap_unfolded_H_cap(1))
               apply (simp add: ccap_relation_def map_option_case)
               apply (simp add: cap_thread_cap_lift)
               apply (simp add: cap_to_H_def)
+              apply (clarsimp simp: from_bool_0 split: if_split)
              apply (clarsimp simp: case_bool_If ctcb_ptr_to_tcb_ptr_def if_distrib
                               cong: if_cong)
              apply (frule_tac cap'=cap_b in cap_get_tag_isArchCap_unfolded_H_cap)
              apply (clarsimp simp: isArchCap_tag_def2)
            \<comment> \<open>capa is a NullCap\<close>
-            apply (simp add: cap_tag_defs from_bool_def false_def)
+            apply (simp add: cap_tag_defs)
           \<comment> \<open>capa is an NotificationCap\<close>
            apply (case_tac capb, simp_all add: cap_get_tag_isCap_unfolded_H_cap
-                        isCap_simps cap_tag_defs from_bool_def false_def)[1]
+                                               isCap_simps cap_tag_defs)[1]
             apply (frule_tac cap'=cap_a in cap_get_tag_isCap_unfolded_H_cap(3))
             apply (frule_tac cap'=cap_b in cap_get_tag_isCap_unfolded_H_cap(3))
             apply (simp add: ccap_relation_def map_option_case)
             apply (simp add: cap_notification_cap_lift)
             apply (simp add: cap_to_H_def)
-            apply (clarsimp split: if_split)
+            apply (clarsimp simp: from_bool_0 split: if_split)
            apply (frule_tac cap'=cap_b in cap_get_tag_isArchCap_unfolded_H_cap)
            apply (clarsimp simp: isArchCap_tag_def2)
           \<comment> \<open>capa is an IRQHandlerCap\<close>
           apply (case_tac capb, simp_all add: cap_get_tag_isCap_unfolded_H_cap
-                      isCap_simps cap_tag_defs from_bool_def false_def)[1]
+                                              isCap_simps cap_tag_defs)[1]
            apply (frule_tac cap'=cap_a in cap_get_tag_isCap_unfolded_H_cap(5))
            apply (frule_tac cap'=cap_b in cap_get_tag_isCap_unfolded_H_cap(5))
            apply (simp add: ccap_relation_def map_option_case)
            apply (simp add: cap_irq_handler_cap_lift)
            apply (simp add: cap_to_H_def)
            apply (clarsimp simp: up_ucast_inj_eq c_valid_cap_def ucast_eq_mask
-                                 cl_valid_cap_def mask_twice
+                                 cl_valid_cap_def mask_twice from_bool_0
                           split: if_split bool.split
                   | intro impI conjI
                   | simp)
@@ -2840,34 +2836,34 @@ lemma sameRegionAs_spec:
           apply (clarsimp simp: isArchCap_tag_def2)
          \<comment> \<open>capa is an EndpointCap\<close>
          apply (case_tac capb, simp_all add: cap_get_tag_isCap_unfolded_H_cap
-                      isCap_simps cap_tag_defs from_bool_def false_def)[1]
+                                             isCap_simps cap_tag_defs)[1]
           apply (frule_tac cap'=cap_a in cap_get_tag_isCap_unfolded_H_cap(4))
           apply (frule_tac cap'=cap_b in cap_get_tag_isCap_unfolded_H_cap(4))
           apply (simp add: ccap_relation_def map_option_case)
           apply (simp add: cap_endpoint_cap_lift)
           apply (simp add: cap_to_H_def)
-          apply (clarsimp split: if_split)
+          apply (clarsimp simp: from_bool_0 split: if_split)
          apply (frule_tac cap'=cap_b in cap_get_tag_isArchCap_unfolded_H_cap)
          apply (clarsimp simp: isArchCap_tag_def2)
         \<comment> \<open>capa is a DomainCap\<close>
         apply (case_tac capb, simp_all add: cap_get_tag_isCap_unfolded_H_cap
-                     isCap_simps cap_tag_defs from_bool_def false_def true_def)[1]
+                                            isCap_simps cap_tag_defs)[1]
         apply (frule_tac cap'=cap_b in cap_get_tag_isArchCap_unfolded_H_cap)
         apply (fastforce simp: isArchCap_tag_def2 split: if_split)
        \<comment> \<open>capa is a Zombie\<close>
-       apply (simp add: cap_tag_defs from_bool_def false_def)
+       apply (simp add: cap_tag_defs)
       \<comment> \<open>capa is an Arch object cap\<close>
       apply (frule_tac cap'=cap_a in cap_get_tag_isArchCap_unfolded_H_cap)
       apply (clarsimp simp: isArchCap_tag_def2 cap_tag_defs linorder_not_less [THEN sym])
       apply (rule conjI, clarsimp, rule impI)+
       apply (case_tac capb, simp_all add: cap_get_tag_isCap_unfolded_H_cap
-                   isCap_simps cap_tag_defs from_bool_def false_def)[1]
+                                          isCap_simps cap_tag_defs)[1]
       \<comment> \<open>capb is an Arch object cap\<close>
       apply (frule_tac cap'=cap_b in cap_get_tag_isArchCap_unfolded_H_cap)
       apply (fastforce simp: isArchCap_tag_def2 cap_tag_defs linorder_not_less [THEN sym])
      \<comment> \<open>capa is a ReplyCap\<close>
      apply (case_tac capb, simp_all add: cap_get_tag_isCap_unfolded_H_cap
-                  isCap_simps cap_tag_defs from_bool_def false_def)[1]
+                                         isCap_simps cap_tag_defs)[1]
       apply (frule_tac cap'=cap_b in cap_get_tag_isArchCap_unfolded_H_cap)
       apply (clarsimp simp: isArchCap_tag_def2)
      apply (frule_tac cap'=cap_a in cap_get_tag_isCap_unfolded_H_cap(8))
@@ -2875,7 +2871,7 @@ lemma sameRegionAs_spec:
      apply (simp add: ccap_relation_def map_option_case)
      apply (simp add: cap_reply_cap_lift)
      apply (simp add: cap_to_H_def ctcb_ptr_to_tcb_ptr_def)
-     apply (clarsimp split: if_split)
+     apply (clarsimp simp: from_bool_0 split: if_split)
     \<comment> \<open>capa is an UntypedCap\<close>
     apply (frule_tac cap'=cap_a in cap_get_tag_isCap_unfolded_H_cap(9))
     apply (intro conjI)
@@ -2883,8 +2879,7 @@ lemma sameRegionAs_spec:
         apply (rule impI, drule(1) cap_get_tag_to_H)+
         apply (clarsimp simp: capAligned_def word_bits_conv
                               objBits_simps' get_capZombieBits_CL_def
-                              Let_def word_less_nat_alt
-                              less_mask_eq true_def
+                              Let_def word_less_nat_alt less_mask_eq
                        split: if_split_asm)
        apply (subgoal_tac "capBlockSize_CL (cap_untyped_cap_lift cap_a) \<le> 0x3F")
         apply (simp add: word_le_make_less)
@@ -2905,10 +2900,9 @@ lemma sameRegionAs_spec:
                                cap_untyped_cap_lift cap_to_H_def
                                field_simps valid_cap'_def)+)[4]
     apply (rule impI, simp add: from_bool_0 ccap_relation_get_capIsPhysical[symmetric])
-    apply (simp add: from_bool_def false_def)
    \<comment> \<open>capa is a CNodeCap\<close>
    apply (case_tac capb, simp_all add: cap_get_tag_isCap_unfolded_H_cap
-                isCap_simps cap_tag_defs from_bool_def false_def)[1]
+                                       isCap_simps cap_tag_defs)[1]
     apply (frule_tac cap'=cap_b in cap_get_tag_isArchCap_unfolded_H_cap)
     apply (clarsimp simp: isArchCap_tag_def2)
    apply (frule_tac cap'=cap_a in cap_get_tag_isCap_unfolded_H_cap(10))
@@ -2916,10 +2910,9 @@ lemma sameRegionAs_spec:
    apply (simp add: ccap_relation_def map_option_case)
    apply (simp add: cap_cnode_cap_lift)
    apply (simp add: cap_to_H_def)
-   apply (clarsimp split: if_split bool.split)
+   apply (clarsimp simp: from_bool_0 split: if_split bool.split)
   \<comment> \<open>capa is an IRQControlCap\<close>
-  apply (case_tac capb, simp_all add: cap_get_tag_isCap_unfolded_H_cap
-               isCap_simps cap_tag_defs from_bool_def false_def true_def)[1]
+  apply (case_tac capb, simp_all add: cap_get_tag_isCap_unfolded_H_cap isCap_simps cap_tag_defs)[1]
   apply (frule_tac cap'=cap_b in cap_get_tag_isArchCap_unfolded_H_cap)
   apply (fastforce simp: isArchCap_tag_def2 split: if_split)
   done
@@ -2954,7 +2947,7 @@ lemma ccap_relation_FrameCap_IsDevice:
   apply (clarsimp simp: ccap_relation_def cap_to_H_def cap_lift_def cap_lift_defs cap_tag_defs
                         Let_def)
   apply (thin_tac _)+
-  by (clarsimp simp: to_bool_def mask_def word_and_1 split: if_splits)
+  by (clarsimp simp: word_and_1 split: if_splits)
 
 lemma ccap_relation_FrameCap_Size:
   "ccap_relation (ArchObjectCap (FrameCap p r s d m)) ccap
@@ -3013,16 +3006,16 @@ lemma Arch_sameObjectAs_spec:
         apply (cases capa)
            apply (all \<open>frule (1) cap_get_tag[where cap'=cap_a]\<close>)
            apply (all \<open>(frule cap_lifts[where c=cap_a, THEN iffD1])?\<close>)
-           apply (all \<open>clarsimp simp: cap_tag_defs isCap_simps from_bool_def true_def false_def if_0_1_eq
-                          split: if_splits\<close>)
+           apply (all \<open>clarsimp simp: cap_tag_defs isCap_simps
+                               split: if_splits\<close>)
            apply (all \<open>fastforce?\<close>)
           (* frames remain. *)
         apply (all \<open>cases capb\<close>)
            apply (all \<open>frule (1) cap_get_tag[where cap'=cap_b]\<close>)
            apply (all \<open>(frule cap_lifts[where c=cap_b, THEN iffD1])?\<close>)
-           apply (all \<open>clarsimp simp: cap_tag_defs isCap_simps from_bool_def true_def false_def if_0_1_eq
-                                 ccap_relation_FrameCap_fields framesize_from_H_eq capAligned_def
-                          split: if_splits\<close>)
+           apply (all \<open>clarsimp simp: cap_tag_defs isCap_simps ccap_relation_FrameCap_fields
+                                      framesize_from_H_eq capAligned_def
+                               split: if_splits\<close>)
         by (all \<open>(fastforce simp: RISCV64_H.sameRegionAs_def isCap_simps is_aligned_no_overflow_mask)?\<close>)
       done
   qed
@@ -3036,8 +3029,7 @@ lemma sameObjectAs_spec:
   apply vcg
   apply (clarsimp simp: sameObjectAs_def isArchCap_tag_def2)
   apply (case_tac capa, simp_all add: cap_get_tag_isCap_unfolded_H_cap
-                                      isCap_simps cap_tag_defs
-                                      from_bool_def false_def)
+                                      isCap_simps cap_tag_defs)
             apply fastforce+
      \<comment> \<open>capa is an arch cap\<close>
      apply (frule cap_get_tag_isArchCap_unfolded_H_cap)
@@ -3118,7 +3110,7 @@ lemma isMDBParentOf_spec:
      apply (simp add: ccte_relation_def map_option_case)
      apply (simp add: cte_lift_def)
      apply (clarsimp simp: cte_to_H_def mdb_node_to_H_def split: option.split_asm)
-     apply (clarsimp simp: Let_def false_def from_bool_def to_bool_def
+     apply (clarsimp simp: Let_def to_bool_def
                     split: if_split bool.splits)
      apply ((clarsimp simp: typ_heap_simps dest!: lift_t_g)+)[3]
   apply (rule_tac x="cteCap ctea" in exI, rule conjI)
@@ -3135,11 +3127,11 @@ lemma isMDBParentOf_spec:
   apply (rule conjI)
    \<comment> \<open>sameRegionAs = 0\<close>
    apply (rule impI)
-   apply (clarsimp simp: from_bool_def false_def
+   apply (clarsimp simp: from_bool_def
                   split: if_split bool.splits)
 
   \<comment> \<open>sameRegionAs \<noteq> 0\<close>
-  apply (clarsimp simp: from_bool_def false_def)
+  apply (clarsimp simp: from_bool_def)
   apply (clarsimp cong:bool.case_cong if_cong simp: typ_heap_simps)
 
   apply (rule conjI)
@@ -3147,8 +3139,7 @@ lemma isMDBParentOf_spec:
    apply clarsimp
    apply (frule cap_get_tag_EndpointCap)
    apply simp
-   apply (clarsimp simp: to_bool_def isNotificationCap_def isEndpointCap_def true_def) \<comment> \<open>badge of A is not 0 now\<close>
-
+   apply (clarsimp simp: to_bool_def isNotificationCap_def isEndpointCap_def) \<comment> \<open>badge of A is not 0 now\<close>
 
    apply (subgoal_tac "cap_get_tag (cte_C.cap_C cte_b) = scast cap_endpoint_cap") \<comment> \<open>needed also after\<close>
     prefer 2
@@ -3163,8 +3154,7 @@ lemma isMDBParentOf_spec:
    apply clarsimp
    apply (frule cap_get_tag_NotificationCap)
    apply simp
-   apply (clarsimp simp: to_bool_def isNotificationCap_def isEndpointCap_def true_def) \<comment> \<open>badge of A is not 0 now\<close>
-
+   apply (clarsimp simp: to_bool_def isNotificationCap_def isEndpointCap_def) \<comment> \<open>badge of A is not 0 now\<close>
 
    apply (subgoal_tac "cap_get_tag (cte_C.cap_C cte_b) = scast cap_notification_cap") \<comment> \<open>needed also after\<close>
     prefer 2
@@ -3180,7 +3170,7 @@ lemma isMDBParentOf_spec:
   apply clarsimp
   apply (simp add: to_bool_def)
   apply (subgoal_tac "(\<not> (isEndpointCap (cap_to_H x2b))) \<and> ( \<not> (isNotificationCap (cap_to_H x2b)))")
-   apply (clarsimp simp: true_def)
+   apply clarsimp
   apply (clarsimp simp: cap_get_tag_isCap [symmetric])
   done
 
@@ -3196,7 +3186,7 @@ lemma updateCapData_spec:
   apply (simp add: updateCapData_def)
 
   apply (case_tac cap, simp_all add: cap_get_tag_isCap_unfolded_H_cap
-                        isCap_simps from_bool_def isArchCap_tag_def2 cap_tag_defs Let_def)
+                                     isCap_simps isArchCap_tag_def2 cap_tag_defs Let_def)
   \<comment> \<open>NotificationCap\<close>
      apply clarsimp
      apply (frule cap_get_tag_isCap_unfolded_H_cap(3))
@@ -3322,7 +3312,6 @@ lemma ensureNoChildren_ccorres:
    apply (rule conjI)
    \<comment> \<open>isMDBParentOf is not zero\<close>
     apply clarsimp
-    apply (simp add: from_bool_def)
     apply (case_tac "isMDBParentOf (cte_to_H y) (cte_to_H ya)", simp_all)[1]
 
     apply (simp add: bind_def)
@@ -3333,7 +3322,6 @@ lemma ensureNoChildren_ccorres:
     apply (simp add: syscall_error_to_H_cases(9))
    \<comment> \<open>isMDBParentOf is zero\<close>
    apply clarsimp
-   apply (simp add: from_bool_def)
    apply (case_tac "isMDBParentOf (cte_to_H y) (cte_to_H ya)", simp_all)[1]
    apply (simp add: bind_def)
    apply (simp add: split_paired_Bex)
@@ -3417,7 +3405,7 @@ lemma deriveCap_ccorres':
    apply csymbr
    apply (fold case_bool_If)
    apply wpc
-    apply (clarsimp simp: cap_get_tag_isCap isCap_simps from_bool_def)
+    apply (clarsimp simp: cap_get_tag_isCap isCap_simps)
     apply csymbr
     apply (clarsimp simp: cap_get_tag_isCap)
     apply (rule ccorres_from_vcg_throws [where P=\<top> and P' = UNIV])
@@ -3426,7 +3414,7 @@ lemma deriveCap_ccorres':
      apply vcg
     apply clarsimp
    apply wpc
-    apply (clarsimp simp: isCap_simps cap_get_tag_isCap from_bool_def)
+    apply (clarsimp simp: isCap_simps cap_get_tag_isCap)
     apply csymbr
     apply (clarsimp simp: isCap_simps cap_get_tag_isCap)
     apply (rule ccorres_from_vcg_throws[where P=\<top> and P'=UNIV])
@@ -3434,7 +3422,7 @@ lemma deriveCap_ccorres':
     apply (clarsimp simp: returnOk_def return_def
                           ccap_relation_NullCap_iff)
    apply wpc
-    apply (clarsimp simp: isCap_simps cap_get_tag_isCap from_bool_def)
+    apply (clarsimp simp: isCap_simps cap_get_tag_isCap)
     apply csymbr
     apply (clarsimp simp: isCap_simps cap_get_tag_isCap)
     apply (rule ccorres_rhs_assoc)+
@@ -3457,7 +3445,7 @@ lemma deriveCap_ccorres':
                            errstate_def)
     apply wp
    apply wpc
-    apply (clarsimp simp: isCap_simps cap_get_tag_isCap from_bool_def)
+    apply (clarsimp simp: isCap_simps cap_get_tag_isCap)
     apply csymbr
     apply (clarsimp simp: isCap_simps cap_get_tag_isCap)
     apply (rule ccorres_from_vcg_throws[where P=\<top> and P'=UNIV])
@@ -3471,7 +3459,7 @@ lemma deriveCap_ccorres':
      apply vcg
     apply (clarsimp simp: cap_get_tag_isCap
                           liftME_def Let_def isArchCap_T_isArchObjectCap
-                          ccorres_cond_univ_iff from_bool_def)
+                          ccorres_cond_univ_iff)
     apply (rule ccorres_add_returnOk)
     apply (rule ccorres_split_nothrow_call_novcgE
                     [where xf'=ret__struct_deriveCap_ret_C_'])
@@ -3489,7 +3477,7 @@ lemma deriveCap_ccorres':
      apply (rule allI, rule conseqPre, vcg)
      apply (clarsimp simp: return_def throwError_def)
     apply wp
-   apply (simp add: cap_get_tag_isCap isArchCap_T_isArchObjectCap from_bool_def)
+   apply (simp add: cap_get_tag_isCap isArchCap_T_isArchObjectCap)
    apply csymbr
    apply (simp add: cap_get_tag_isCap)
    apply (rule ccorres_from_vcg_throws[where P=\<top> and P'=UNIV])
@@ -3499,7 +3487,6 @@ lemma deriveCap_ccorres':
                         Collect_const_mem from_bool_0
                         cap_get_tag_isArchCap_unfolded_H_cap)
   done
-
 
 lemma deriveCap_ccorres:
   "ccorres (syscall_error_rel \<currency> ccap_relation) deriveCap_xf

--- a/proof/crefine/RISCV64/CSpace_RAB_C.thy
+++ b/proof/crefine/RISCV64/CSpace_RAB_C.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2023, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -222,7 +223,7 @@ next
        apply (vcg strip_guards=true) \<comment> \<open>takes a while\<close>
        apply clarsimp
       apply simp
-     apply (clarsimp simp: cap_get_tag_isCap to_bool_def)
+     apply (clarsimp simp: cap_get_tag_isCap)
   \<comment> \<open>Main thm\<close>
   proof (induct cap' cptr' guard' rule: resolveAddressBits.induct [case_names ind])
     case (ind cap cptr guard)
@@ -563,8 +564,8 @@ lemma rightsFromWord_spec:
   \<lbrace>seL4_CapRights_lift \<acute>ret__struct_seL4_CapRights_C = cap_rights_from_word_canon \<^bsup>s\<^esup>w \<rbrace>"
   apply vcg
   apply (simp add: seL4_CapRights_lift_def nth_shiftr mask_shift_simps nth_shiftr
-    cap_rights_from_word_canon_def from_bool_def word_and_1 eval_nat_numeral
-    word_sless_def word_sle_def)
+                   cap_rights_from_word_canon_def word_and_1 eval_nat_numeral
+                   word_sless_def word_sle_def)
   done
 
 
@@ -578,12 +579,6 @@ lemma cap_rights_to_H_from_word_canon [simp]:
   apply (simp add: cap_rights_from_word_canon_def)
   apply (simp add: cap_rights_to_H_def)
   done
-
-(* MOVE *)
-lemma to_bool_false [simp]:
-  "to_bool false = False"
-  unfolding to_bool_def false_def
-  by simp
 
 lemma tcb_ptr_to_ctcb_ptr_mask [simp]:
   assumes tcbat: "tcb_at' thread s"

--- a/proof/crefine/RISCV64/Delete_C.thy
+++ b/proof/crefine/RISCV64/Delete_C.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2023, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -147,7 +148,7 @@ lemma capRemovable_spec:
   supply if_cong[cong]
   apply vcg
   apply (clarsimp simp: cap_get_tag_isCap(1-8)[THEN trans[OF eq_commute]])
-  apply (simp add: capRemovable_def from_bool_def[where b=True] true_def)
+  apply (simp add: capRemovable_def)
   apply (clarsimp simp: ccap_zombie_radix_less4)
   apply (subst eq_commute, subst from_bool_eq_if)
   apply (rule exI, rule conjI, assumption)
@@ -648,7 +649,7 @@ lemma reduceZombie_ccorres1:
       apply (rule ccorres_inst[where P=\<top> and P'=UNIV])
       apply simp
      apply (simp add: guard_is_UNIV_def Collect_const_mem)
-     apply (clarsimp simp: from_bool_def false_def isCap_simps size_of_def cte_level_bits_def)
+     apply (clarsimp simp: isCap_simps size_of_def cte_level_bits_def)
      apply (simp only: word_bits_def unat_of_nat unat_arith_simps, simp)
     apply (simp add: guard_is_UNIV_def)+
   apply (clarsimp simp: cte_wp_at_ctes_of)
@@ -730,8 +731,7 @@ lemma finaliseSlot_ccorres:
         apply (rule ccorres_drop_cutMon)
         apply (rule ccorres_from_vcg_throws[where P=\<top> and P'=UNIV])
         apply (rule allI, rule conseqPre, vcg)
-        apply (clarsimp simp: returnOk_def return_def
-                              from_bool_def true_def ccap_relation_NullCap_iff)
+        apply (clarsimp simp: returnOk_def return_def ccap_relation_NullCap_iff)
        apply (simp add: Collect_True liftE_bindE split_def
                         ccorres_cond_iffs cutMon_walk_bind
                    del: Collect_const cong: call_ignore_cong)
@@ -768,8 +768,7 @@ lemma finaliseSlot_ccorres:
               apply (rule_tac P="\<lambda>s. cleanup_info_wf' (snd rvb)"
                               in ccorres_from_vcg_throws[where P'=UNIV])
               apply (rule allI, rule conseqPre, vcg)
-              apply (clarsimp simp: returnOk_def return_def
-                                    from_bool_def true_def)
+              apply (clarsimp simp: returnOk_def return_def)
               apply (clarsimp simp: cleanup_info_wf'_def arch_cleanup_info_wf'_def
                              split: if_split capability.splits)
              apply vcg
@@ -806,11 +805,11 @@ lemma finaliseSlot_ccorres:
                   apply (rule allI, rule conseqPre, vcg)
                   apply (clarsimp simp: returnOk_def return_def)
                   apply (drule use_valid [OF _ finaliseCap_cases, OF _ TrueI])
-                  apply (simp add: from_bool_def false_def irq_opt_relation_def true_def
+                  apply (simp add: irq_opt_relation_def
                             split: if_split_asm)
                  apply vcg
                 apply wp
-               apply (simp add: guard_is_UNIV_def true_def)
+               apply (simp add: guard_is_UNIV_def)
               apply wp
              apply (simp add: guard_is_UNIV_def)
             apply (simp only: liftE_bindE cutMon_walk_bind Let_def
@@ -835,7 +834,6 @@ lemma finaliseSlot_ccorres:
                                in ccorres_from_vcg[where P'=UNIV])
                   apply (rule allI, rule conseqPre, vcg)
                   apply (clarsimp simp: return_def)
-                  apply (simp add: from_bool_def false_def)
                   apply fastforce
                  apply ceqv
                 apply (simp only: from_bool_0 simp_thms Collect_False
@@ -904,7 +902,7 @@ lemma finaliseSlot_ccorres:
                           simp: isCap_simps final_matters'_def o_def)
         apply clarsimp
         apply (frule valid_globals_cte_wpD'[rotated], clarsimp)
-        apply (clarsimp simp: cte_wp_at_ctes_of false_def from_bool_def)
+        apply (clarsimp simp: cte_wp_at_ctes_of)
         apply (erule(1) cmap_relationE1 [OF cmap_relation_cte])
         apply (frule valid_global_refsD_with_objSize, clarsimp)
         apply (auto simp: typ_heap_simps dest!: ccte_relation_ccap_relation)[1]
@@ -1030,9 +1028,8 @@ lemma cteRevoke_ccorres1:
         apply (rule ccorres_from_vcg_throws[where P=\<top> and P'=UNIV])
         apply (rule allI, rule conseqPre, vcg)
         apply (clarsimp simp: returnOk_def return_def)
-       apply (simp add: guard_is_UNIV_def from_bool_def true_def cintr_def
-                        Collect_const_mem exception_defs)
-      apply (simp add: guard_is_UNIV_def from_bool_def true_def)
+       apply (simp add: guard_is_UNIV_def cintr_def Collect_const_mem exception_defs)
+      apply (simp add: guard_is_UNIV_def)
      apply (rule getCTE_wp)
     apply (clarsimp simp: cte_wp_at_ctes_of nullPointer_def)
     apply (drule invs_mdb')

--- a/proof/crefine/RISCV64/Finalise_C.thy
+++ b/proof/crefine/RISCV64/Finalise_C.thy
@@ -1734,22 +1734,6 @@ lemma cnotification_relation_udpate_arch:
   apply (safe ; case_tac "xa = p" ; clarsimp simp: option_map2_def map_option_case)
   done
 
-lemma sanitiseSetRegister_ccorres:
-  "\<lbrakk> val = val'; reg' = register_from_H reg\<rbrakk> \<Longrightarrow>
-     ccorres dc xfdc (tcb_at' tptr)
-                      UNIV
-                      hs
-             (asUser tptr (setRegister reg (local.sanitiseRegister False reg val)))
-             (\<acute>unsigned_long_eret_2 :== CALL sanitiseRegister(reg',val',0);;
-              CALL setRegister(tcb_ptr_to_ctcb_ptr tptr,reg',\<acute>unsigned_long_eret_2))"
-  apply (rule ccorres_guard_imp2)
-   apply (rule ccorres_symb_exec_r)
-     apply (ctac add: setRegister_ccorres)
-    apply (vcg)
-   apply (rule conseqPre, vcg)
-   apply (fastforce simp: sanitiseRegister_def split: register.splits)
-  by (auto simp: sanitiseRegister_def from_bool_def simp del: Collect_const split: register.splits bool.splits)
-
 lemma case_option_both[simp]:
   "(case f of None \<Rightarrow> P | _ \<Rightarrow> P) = P"
   by (auto split: option.splits)

--- a/proof/crefine/RISCV64/Finalise_C.thy
+++ b/proof/crefine/RISCV64/Finalise_C.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2023, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
  *
@@ -898,7 +899,7 @@ lemma finaliseCap_True_cases_ccorres:
    apply csymbr
    apply (simp add: cap_get_tag_isCap Collect_False del: Collect_const)
    apply (fold case_bool_If)
-   apply (simp add: false_def)
+   apply simp
    apply csymbr
    apply wpc
     apply (simp add: cap_get_tag_isCap ccorres_cond_univ_iff Let_def)
@@ -1108,7 +1109,7 @@ lemma deleteASID_ccorres:
                         simp flip: mask_2pm1
                        split: asidpool.split_asm asid_pool_C.split_asm)
         apply (drule_tac x="asid && mask asid_low_bits" in spec)
-        apply (clarsimp simp: word_and_le1 from_bool_def case_bool_If inv_ASIDPool)
+        apply (clarsimp simp: word_and_le1 case_bool_If inv_ASIDPool)
         apply (fastforce simp: option_to_ptr_def option_to_0_def split: if_splits option.splits)
        apply ceqv
       apply (rule ccorres_cond2[where R=\<top>])
@@ -1473,7 +1474,7 @@ lemma isFinalCapability_ccorres:
            apply (simp add: mdbPrev_to_H[symmetric])
           apply (rule ccorres_from_vcg[where P=\<top> and P'=UNIV])
           apply (rule allI, rule conseqPre, vcg)
-          apply (simp add: return_def from_bool_def false_def)
+          apply (simp add: return_def)
          apply (rule ccorres_rhs_assoc)+
          apply (rule ccorres_symb_exec_l[OF _ getCTE_inv getCTE_wp empty_fail_getCTE])
          apply (rule_tac P="cte_wp_at' ((=) cte) slot
@@ -1512,10 +1513,9 @@ lemma isFinalCapability_ccorres:
        apply (rule cmap_relationE1 [OF cmap_relation_cte], assumption+,
                   simp?, simp add: typ_heap_simps)+
        apply (drule ccte_relation_ccap_relation)+
-       apply (auto simp: false_def true_def from_bool_def split: bool.splits)[1]
+       apply (auto simp: from_bool_def split: bool.splits)[1]
       apply (wp getCTE_wp')
-     apply (clarsimp simp add: guard_is_UNIV_def Collect_const_mem false_def
-                               from_bool_0 true_def from_bool_def)
+     apply (clarsimp simp add: guard_is_UNIV_def Collect_const_mem)
     apply vcg
    apply (rule conseqPre, vcg)
    apply clarsimp
@@ -1573,13 +1573,12 @@ lemma cteDeleteOne_ccorres:
         apply (strengthen invs_mdb_strengthen' invs_urz)
         apply (wp typ_at_lifts isFinalCapability_inv
             | strengthen invs_valid_objs')+
-       apply (clarsimp simp: from_bool_def true_def irq_opt_relation_def
-                             invs_pspace_aligned' cte_wp_at_ctes_of)
+       apply (clarsimp simp: irq_opt_relation_def invs_pspace_aligned' cte_wp_at_ctes_of)
        apply (erule(1) cmap_relationE1 [OF cmap_relation_cte])
        apply (clarsimp simp: typ_heap_simps ccte_relation_ccap_relation ccap_relation_NullCap_iff)
       apply (wp isFinalCapability_inv)
      apply simp
-    apply (simp del: Collect_const add: false_def)
+    apply (simp del: Collect_const)
    apply (rule ccorres_return_Skip)
   apply (clarsimp simp: Collect_const_mem cte_wp_at_ctes_of)
   apply (erule(1) cmap_relationE1 [OF cmap_relation_cte])
@@ -1919,7 +1918,7 @@ lemma Arch_finaliseCap_ccorres:
       apply (rule ccorres_return_C; simp)
      apply (prop_tac "ret__unsigned_longlong \<noteq> 0")
       apply (clarsimp simp: ccap_relation_def map_option_Some_eq2 dest!: cap_to_H_PTCap)
-      apply (simp add: cap_page_table_cap_lift_def to_bool_def split: if_split_asm)
+      apply (simp add: cap_page_table_cap_lift_def split: if_split_asm)
      apply ccorres_rewrite
      apply (rule ccorres_rhs_assoc)+
      apply csymbr
@@ -2023,7 +2022,7 @@ lemma finaliseCap_ccorres:
                del: Collect_const)
    apply (rule ccorres_if_lhs)
     apply (simp, rule ccorres_fail)
-   apply (simp add: from_bool_0 Collect_True Collect_False false_def
+   apply (simp add: from_bool_0 Collect_True Collect_False
                del: Collect_const)
    apply csymbr
    apply (simp add: cap_get_tag_isCap Collect_False Collect_True
@@ -2108,7 +2107,7 @@ lemma finaliseCap_ccorres:
    apply (simp add: isArchCap_T_isArchObjectCap[symmetric]
                del: Collect_const)
    apply (rule ccorres_if_lhs)
-    apply (simp add: Collect_False Collect_True Let_def true_def
+    apply (simp add: Collect_False Collect_True Let_def
                 del: Collect_const)
     apply (rule_tac P="(capIRQ cap) \<le>  RISCV64.maxIRQ" in ccorres_gen_asm)
     apply (rule ccorres_rhs_assoc)+
@@ -2148,8 +2147,7 @@ lemma finaliseCap_ccorres:
                            irq_opt_relation_def)
     apply wp
    apply (simp add: guard_is_UNIV_def)
-  apply (clarsimp simp: cap_get_tag_isCap word_sle_def Collect_const_mem
-                        false_def from_bool_def)
+  apply (clarsimp simp: cap_get_tag_isCap word_sle_def Collect_const_mem)
   apply (intro impI conjI)
                 apply (clarsimp split: bool.splits)
                apply (clarsimp split: bool.splits)
@@ -2166,7 +2164,7 @@ lemma finaliseCap_ccorres:
                     split: option.splits cap_CL.splits if_splits)
       apply clarsimp
       apply (frule cap_get_tag_to_H, erule(1) cap_get_tag_isCap [THEN iffD2])
-      apply (clarsimp simp: isCap_simps from_bool_def false_def)
+      apply (clarsimp simp: isCap_simps)
      apply (clarsimp simp: tcb_cnode_index_defs ptr_add_assertion_def)
     apply clarsimp
     apply (frule cap_get_tag_to_H, erule(1) cap_get_tag_isCap [THEN iffD2])

--- a/proof/crefine/RISCV64/Interrupt_C.thy
+++ b/proof/crefine/RISCV64/Interrupt_C.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2023, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -16,7 +17,7 @@ lemma invokeIRQHandler_AckIRQ_ccorres:
      (InterruptDecls_H.invokeIRQHandler (AckIRQ irq)) (Call invokeIRQHandler_AckIRQ_'proc)"
   apply (cinit lift: irq_' simp: Interrupt_H.invokeIRQHandler_def invokeIRQHandler_def)
    apply (ctac add: plic_complete_claim_ccorres)
-  apply (simp add: from_bool_def false_def)
+  apply simp
   done
 
 lemma getIRQSlot_ccorres:
@@ -266,12 +267,12 @@ lemma decodeIRQHandlerInvocation_ccorres:
                         sysargs_rel_n_def word_less_nat_alt)
   apply (clarsimp simp: cte_wp_at_ctes_of neq_Nil_conv sysargs_rel_def n_msgRegisters_def
                     excaps_map_def excaps_in_mem_def word_less_nat_alt hd_conv_nth
-                    slotcap_in_mem_def valid_tcb_state'_def from_bool_def toBool_def
+                    slotcap_in_mem_def valid_tcb_state'_def
              dest!: interpret_excaps_eq split: bool.splits)
   apply (intro conjI impI allI)
   apply (clarsimp simp: cte_wp_at_ctes_of neq_Nil_conv sysargs_rel_def n_msgRegisters_def
                     excaps_map_def excaps_in_mem_def word_less_nat_alt hd_conv_nth
-                    slotcap_in_mem_def valid_tcb_state'_def from_bool_def toBool_def
+                    slotcap_in_mem_def valid_tcb_state'_def
              dest!: interpret_excaps_eq split: bool.splits)+
      apply (auto dest: st_tcb_at_idle_thread' ctes_of_valid')[4]
     apply (drule ctes_of_valid')
@@ -363,8 +364,7 @@ lemma isIRQActive_ccorres:
                          Let_def cinterrupt_relation_def)
    apply (drule spec, drule(1) mp)
    apply (case_tac "intStateIRQTable (ksInterruptState \<sigma>) irq")
-     apply (simp add: from_bool_def irq_state_defs Kernel_C.maxIRQ_def
-                      word_le_nat_alt)+
+      apply (simp add: irq_state_defs Kernel_C.maxIRQ_def word_le_nat_alt)+
   done
 
 lemma Platform_maxIRQ:
@@ -607,7 +607,7 @@ lemma Arch_decodeIRQControlInvocation_ccorres:
                 apply (simp add: and_mask_eq_iff_le_mask)
                 apply (simp add: mask_def word_le_nat_alt)
                apply (clarsimp simp: numeral_2_eq_2 numeral_3_eq_3 exception_defs
-                                     ThreadState_Restart_def false_def mask_def from_bool_def)
+                                     ThreadState_Restart_def mask_def)
                apply (rule conseqPre, vcg)
                apply (fastforce simp: exception_defs split: if_split)
               apply (rule subset_refl)
@@ -774,7 +774,7 @@ lemma decodeIRQControlInvocation_ccorres:
              apply (rule sym)
              apply (simp add: and_mask_eq_iff_le_mask)
              apply (simp add: mask_def word_le_nat_alt)
-            apply (clarsimp simp: numeral_2_eq_2 exception_defs ThreadState_Restart_def false_def mask_def)
+            apply (clarsimp simp: numeral_2_eq_2 exception_defs ThreadState_Restart_def mask_def)
             apply (rule conseqPre, vcg)
              apply (fastforce simp: exception_defs)
             apply (rule subset_refl)

--- a/proof/crefine/RISCV64/Invoke_C.thy
+++ b/proof/crefine/RISCV64/Invoke_C.thy
@@ -65,7 +65,7 @@ lemma setDomain_ccorres:
           apply (rule ccorres_cond2[where R=\<top>], simp add: Collect_const_mem)
            apply (ctac add: tcbSchedEnqueue_ccorres)
           apply (rule ccorres_return_Skip)
-         apply (simp add: when_def to_bool_def)
+         apply (simp add: when_def)
          apply (rule_tac R="\<lambda>s. rv = ksCurThread s"
                     in ccorres_cond2)
            apply (clarsimp simp: rf_sr_ksCurThread)
@@ -229,7 +229,7 @@ lemma invokeCNodeDelete_ccorres:
    apply (rule ccorres_trim_returnE, simp, simp)
    apply (rule ccorres_callE)
        apply (rule cteDelete_ccorres[simplified])
-      apply (simp add: from_bool_def true_def)+
+      apply simp+
 done
 
 
@@ -249,7 +249,7 @@ lemma invokeCNodeRevoke_ccorres:
    apply (rule ccorres_trim_returnE, simp, simp)
    apply (rule ccorres_callE)
        apply (rule cteRevoke_ccorres[simplified])
-      apply (simp add: from_bool_def true_def)+
+      apply simp+
 done
 
 
@@ -547,12 +547,10 @@ lemma hasCancelSendRights_spec:
    apply clarsimp
    apply (drule sym, drule (1) cap_get_tag_to_H)
    apply (clarsimp simp: hasCancelSendRights_def to_bool_def
-                         true_def false_def
                    split: if_split bool.splits)
   apply (rule impI)
   apply (case_tac cap,
-         auto simp: cap_get_tag_isCap_unfolded_H_cap cap_tag_defs
-                     from_bool_def false_def true_def hasCancelSendRights_def
+         auto simp: cap_get_tag_isCap_unfolded_H_cap cap_tag_defs hasCancelSendRights_def
               dest: cap_get_tag_isArchCap_unfolded_H_cap
               split: capability.splits bool.splits)[1]
   done
@@ -749,7 +747,7 @@ lemma decodeCNodeInvocation_ccorres:
                                 apply (simp add: syscall_error_to_H_cases)
                                apply (simp add: whenE_def injection_handler_returnOk
                                                 ccorres_invocationCatch_Inr performInvocation_def
-                                                bindE_assoc false_def)
+                                                bindE_assoc)
                                apply (ctac add: setThreadState_ccorres)
                                  apply (simp add: ccorres_cond_iffs)
                                  apply (ctac(no_vcg) add: invokeCNodeInsert_ccorres)
@@ -825,7 +823,7 @@ lemma decodeCNodeInvocation_ccorres:
                                     apply (rule syscall_error_throwError_ccorres_n)
                                     apply (simp add: syscall_error_to_H_cases)
                                    apply (simp add: whenE_def injection_handler_returnOk
-                                                    ccorres_invocationCatch_Inr false_def
+                                                    ccorres_invocationCatch_Inr
                                                     performInvocation_def bindE_assoc)
                                    apply (ctac add: setThreadState_ccorres)
                                      apply (simp add: ccorres_cond_iffs)
@@ -881,7 +879,7 @@ lemma decodeCNodeInvocation_ccorres:
                                        in ccorres_gen_asm2)
                            apply csymbr
                            apply csymbr
-                           apply (simp add: cap_get_tag_NullCap true_def)
+                           apply (simp add: cap_get_tag_NullCap)
                            apply (ctac add: setThreadState_ccorres)
                              apply (simp add: ccorres_cond_iffs)
                              apply (ctac(no_vcg) add: invokeCNodeMove_ccorres)
@@ -927,7 +925,7 @@ lemma decodeCNodeInvocation_ccorres:
                                               ccorres_invocationCatch_Inr numeral_eqs
                                               performInvocation_def bindE_assoc)
                              apply (ctac add: setThreadState_ccorres)
-                               apply (simp add: true_def ccorres_cond_iffs)
+                               apply (simp add: ccorres_cond_iffs)
                                apply (ctac(no_vcg) add: invokeCNodeMove_ccorres)
                                  apply (rule ccorres_alternative2)
                                  apply (rule ccorres_return_CE, simp+)[1]
@@ -1387,8 +1385,7 @@ lemma decodeCNodeInvocation_ccorres:
                              map_option_Some_eq2 neq_Nil_conv ccap_relation_def
                              numeral_eqs hasCancelSendRights_not_Null
                              ccap_relation_NullCap_iff[symmetric]
-                             if_1_0_0 interpret_excaps_test_null
-                             mdbRevocable_CL_cte_to_H false_def true_def
+                             interpret_excaps_test_null mdbRevocable_CL_cte_to_H
             | clarsimp simp: typ_heap_simps'
             | frule length_ineq_not_Nil)+)
   done
@@ -3272,8 +3269,8 @@ lemma decodeUntypedInvocation_ccorres_helper:
                                            unat_of_nat_APIType_capBits word_size hd_conv_nth length_ineq_not_Nil
                        not_less word_le_nat_alt isCap_simps valid_cap_simps')
                     apply (strengthen word_of_nat_less)
-                    apply (clarsimp simp: StrictC'_thread_state_defs mask_def true_def false_def
-                                          from_bool_0 ccap_relation_isDeviceCap2
+                    apply (clarsimp simp: StrictC'_thread_state_defs mask_def
+                                          ccap_relation_isDeviceCap2
                                    split: if_split)
                     apply (clarsimp simp: not_less shiftr_overflow maxUntypedSizeBits_def
                                           unat_of_nat_APIType_capBits)

--- a/proof/crefine/RISCV64/IpcCancel_C.thy
+++ b/proof/crefine/RISCV64/IpcCancel_C.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2023, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
  *
@@ -422,9 +423,9 @@ lemma isStopped_ccorres [corres]:
    apply vcg
    apply clarsimp
   apply clarsimp
-  apply (clarsimp simp: to_bool_def true_def false_def typ_heap_simps
-    ctcb_relation_thread_state_to_tsType split: thread_state.splits)
-  apply (simp add: "StrictC'_thread_state_defs")+
+  apply (clarsimp simp: typ_heap_simps ctcb_relation_thread_state_to_tsType
+                 split: thread_state.splits)
+    apply (simp add: "StrictC'_thread_state_defs")+
   done
 
 lemma isRunnable_ccorres [corres]:
@@ -450,10 +451,10 @@ lemma isRunnable_ccorres [corres]:
     apply (vcg)
    apply (clarsimp)
   apply (clarsimp)
-  apply (clarsimp simp: to_bool_def true_def false_def typ_heap_simps
-    ctcb_relation_thread_state_to_tsType split: thread_state.splits)
-  apply (simp add: "StrictC'_thread_state_defs")+
-done
+  apply (clarsimp simp: typ_heap_simps ctcb_relation_thread_state_to_tsType
+                 split: thread_state.splits)
+       apply (simp add: "StrictC'_thread_state_defs")+
+  done
 
 
 
@@ -779,13 +780,6 @@ lemma state_relation_queue_update_helper:
   apply (drule(1) bspec)
   apply (erule obj_at'_weakenE, clarsimp)
   done
-
-(* FIXME: move *)
-lemma from_bool_vals [simp]:
-  "from_bool True = scast true"
-  "from_bool False = scast false"
-  "scast true \<noteq> scast false"
-  by (auto simp add: from_bool_def true_def false_def)
 
 (* FIXME: move *)
 lemma cmap_relation_no_upd:
@@ -1922,10 +1916,6 @@ proof -
                          valid_obj'_def inQ_def
                    dest!: valid_queues_obj_at'D)
 qed
-
-lemma true_eq_from_bool [simp]:
-  "(scast true = from_bool P) = P"
-  by (simp add: true_def from_bool_def split: bool.splits)
 
 lemma isStopped_spec:
   "\<forall>s. \<Gamma> \<turnstile> ({s} \<inter> {s. cslift s (thread_' s) \<noteq> None}) Call isStopped_'proc

--- a/proof/crefine/RISCV64/Ipc_C.thy
+++ b/proof/crefine/RISCV64/Ipc_C.thy
@@ -1195,7 +1195,7 @@ lemma setMRs_syscall_error_ccorres:
                  | wp hoare_case_option_wp
                  | (simp del: Collect_const, vcg exspec=setMR_modifies)
                )+
-   apply (simp add: msgMaxLength_unfold if_1_0_0 true_def false_def)
+   apply (simp add: msgMaxLength_unfold)
    apply (clarsimp split:if_split_asm simp:syscall_error_to_H_def map_option_Some_eq2 ucast_and_mask ucast_nat_def)
    apply (simp add: msgFromLookupFailure_def
                  split: lookup_failure.split
@@ -2845,9 +2845,8 @@ next
                               word_sle_def t2n_mask_eq_if)
             apply (rule conjI)
              apply (clarsimp simp: ccap_rights_relation_def cap_rights_to_H_def
-                                 false_def true_def to_bool_def allRights_def
-                                 excaps_map_def split_def
-                          dest!: drop_n_foo interpret_excaps_eq)
+                                   allRights_def excaps_map_def split_def
+                            dest!: drop_n_foo interpret_excaps_eq)
             apply (clarsimp simp:from_bool_def split:bool.splits)
              apply (case_tac "isEndpointCap (fst x)")
               apply (clarsimp simp: cap_get_tag_EndpointCap ep_cap_not_null cap_get_tag_isCap[symmetric])
@@ -2887,7 +2886,7 @@ next
          apply (rule conseqPre, vcg)
          apply (clarsimp split del: if_split)
         apply (clarsimp split del: if_split
-                       simp add: Collect_const[symmetric] precond_def true_def false_def
+                       simp add: Collect_const[symmetric] precond_def
                        simp del: Collect_const)
         apply (rule HoarePartial.Seq[rotated] HoarePartial.Cond[OF order_refl]
                   HoarePartial.Basic[OF order_refl] HoarePartial.Skip[OF order_refl]
@@ -3221,7 +3220,7 @@ proof -
                        apply (clarsimp simp: cfault_rel2_def)
                        apply (clarsimp simp: cfault_rel_def)
                        apply (simp add: seL4_Fault_CapFault_lift)
-                       apply (clarsimp simp: is_cap_fault_def to_bool_def false_def)
+                       apply (clarsimp simp: is_cap_fault_def)
                       apply wp
                       apply (rule hoare_post_imp_R, rule lsft_real_cte)
                       apply (clarsimp simp: obj_at'_def projectKOs objBits_simps')
@@ -3476,7 +3475,7 @@ lemma replyFromKernel_error_ccorres [corres]:
                    message_info_to_H_def valid_pspace_valid_objs')
   apply (clarsimp simp: msgLengthBits_def msgFromSyscallError_def
                         syscall_error_to_H_def syscall_error_type_defs
-                        mask_def true_def option_to_ptr_def
+                        mask_def option_to_ptr_def
                  split: if_split_asm)
   done
 
@@ -3534,7 +3533,7 @@ lemma doIPCTransfer_ccorres [corres]:
                            fault_to_fault_tag_nonzero)
      apply (fold dc_def)[1]
      apply ctac
-    apply (clarsimp simp: guard_is_UNIV_def false_def option_to_ptr_def split: option.splits)
+    apply (clarsimp simp: guard_is_UNIV_def option_to_ptr_def split: option.splits)
    apply (rule_tac Q="\<lambda>rv. valid_pspace' and cur_tcb' and tcb_at' sender
                        and tcb_at' receiver and K (rv \<noteq> Some 0)
                        and (case_option \<top> valid_ipc_buffer_ptr' rv)
@@ -3543,7 +3542,7 @@ lemma doIPCTransfer_ccorres [corres]:
     apply (auto simp: valid_ipc_buffer_ptr'_def option_to_0_def
                    split: option.splits)[1]
    apply (wp lookupIPCBuffer_not_Some_0 lookupIPCBuffer_aligned)
-  apply (auto simp: to_bool_def true_def)
+  apply auto
   done
 
 lemma fault_case_absorb_bind:
@@ -3564,7 +3563,6 @@ lemma Arch_getSanitiseRegisterInfo_ccorres:
      (Call Arch_getSanitiseRegisterInfo_'proc)"
   apply (cinit' lift: thread_' simp: getSanitiseRegisterInfo_def)
    apply (rule ccorres_return_C, simp+)
-  apply (simp add: false_def)
   done
 
 lemma copyMRsFaultReply_ccorres_exception:
@@ -3607,7 +3605,7 @@ proof -
                   apply (vcg)
                  apply clarsimp
                  apply (rule conseqPre, vcg)
-                 apply (auto simp: from_bool_def sanitiseRegister_def)[1]
+                 apply (auto simp: sanitiseRegister_def)[1]
                 apply wp
                apply clarsimp
                apply vcg
@@ -3898,7 +3896,7 @@ lemma handleArchFaultReply_corres:
          apply simp+
       apply (rule ccorres_symb_exec_l)
          apply (ctac add: ccorres_return_C)
-        apply (wp mapM_wp' empty_fail_loadWordUser | clarsimp simp: to_bool_def true_def)+
+        apply (wp mapM_wp' empty_fail_loadWordUser | clarsimp)+
   done
 
 (* MOVE *)
@@ -4034,9 +4032,9 @@ lemma handleFaultReply_ccorres [corres]:
      apply clarsimp
      apply vcg_step
      apply (clarsimp simp: n_exceptionMessage_def n_syscallMessage_def
-                           message_info_to_H_def to_bool_def scast_def
+                           message_info_to_H_def scast_def
                            length_exceptionMessage length_syscallMessage
-                           min_def word_less_nat_alt true_def
+                           min_def word_less_nat_alt
                            guard_is_UNIV_def seL4_Faults seL4_Arch_Faults
                        split: if_split)
     apply (simp add: length_exceptionMessage length_syscallMessage)
@@ -4044,10 +4042,8 @@ lemma handleFaultReply_ccorres [corres]:
    apply clarsimp
    apply (vcg exspec=getRegister_modifies)
   apply (clarsimp simp: n_exceptionMessage_def n_syscallMessage_def
-                        message_info_to_H_def to_bool_def
-                        length_exceptionMessage length_syscallMessage
-                        min_def word_less_nat_alt true_def
-                        obj_at'_def
+                        message_info_to_H_def length_exceptionMessage length_syscallMessage
+                        min_def word_less_nat_alt obj_at'_def
                  split: if_split)
   apply (fastforce simp: seL4_Faults seL4_Arch_Faults)
   done
@@ -4271,7 +4267,7 @@ proof -
                        threadSet_valid_objs' threadSet_weak_sch_act_wf
                          | simp add: valid_tcb_state'_def)+)[1]
            apply (clarsimp simp: guard_is_UNIV_def ThreadState_Restart_def
-                                 ThreadState_Inactive_def mask_def to_bool_def
+                                 ThreadState_Inactive_def mask_def
                                  option_to_ctcb_ptr_def)
 
           apply (rule_tac Q="\<lambda>rv. valid_queues and tcb_at' receiver and valid_queues' and
@@ -4293,8 +4289,7 @@ proof -
     apply (rule conseqPre, vcg)
     apply (simp(no_asm_use) add: gs_set_assn_Delete_cstate_relation[unfolded o_def]
                                  subset_iff rf_sr_def)
-   apply (clarsimp simp: guard_is_UNIV_def to_bool_def true_def
-                         option_to_ptr_def option_to_0_def false_def
+   apply (clarsimp simp: guard_is_UNIV_def option_to_ptr_def option_to_0_def
                          ThreadState_Running_def mask_def
                          ghost_assertion_data_get_def ghost_assertion_data_set_def
                          cap_tag_defs option_to_ctcb_ptr_def
@@ -4366,7 +4361,7 @@ lemma setupCallerCap_ccorres [corres]:
         apply (wp getSlotCap_cte_wp_at)
        apply (clarsimp simp: ccap_relation_def cap_lift_reply_cap
                              cap_to_H_simps cap_reply_cap_lift_def
-                             false_def tcbSlots Kernel_C.tcbCaller_def
+                             tcbSlots Kernel_C.tcbCaller_def
                              size_of_def cte_level_bits_def)
         apply (simp add: is_aligned_neg_mask)
        apply (wp getCTE_wp')
@@ -4386,7 +4381,7 @@ lemma setupCallerCap_ccorres [corres]:
      apply (simp add: locateSlot_conv)
      apply wp
     apply (clarsimp simp: ccap_rights_relation_def allRights_def
-                          mask_def true_def cap_rights_to_H_def tcbCallerSlot_def
+                          mask_def cap_rights_to_H_def tcbCallerSlot_def
                           Kernel_C.tcbCaller_def)
    apply simp
    apply wp
@@ -4602,8 +4597,7 @@ lemma sendIPC_block_ccorres_helper:
           (simp add: typ_heap_simps')+)[1]
          apply (simp add: tcb_cte_cases_def cteSizeBits_def)
         apply (simp add: ctcb_relation_def cthread_state_relation_def
-                         ThreadState_BlockedOnSend_def mask_def
-                         from_bool_def to_bool_def)
+                         ThreadState_BlockedOnSend_def mask_def)
         apply (clarsimp simp: canonical_address_sign_extended sign_extended_iff_sign_extend
                        split: bool.split)
        apply ceqv
@@ -5007,7 +5001,7 @@ lemma sendIPC_ccorres [corres]:
             apply (ctac(no_vcg) add: possibleSwitchTo_ccorres)
              apply (clarsimp split del: if_split)
              apply (wpc ; ccorres_rewrite)
-              apply (clarsimp simp: from_bool_def disj_imp[symmetric] split del: if_split)
+              apply (clarsimp simp: disj_imp[symmetric] split del: if_split)
               apply (wpc ; clarsimp)
                apply ccorres_rewrite
                apply (fold dc_def)[1]
@@ -5027,7 +5021,7 @@ lemma sendIPC_ccorres [corres]:
                 | wp (once) hoare_drop_imp
                 | strengthen sch_act_wf_weak)+
        apply (fastforce simp: guard_is_UNIV_def ThreadState_Inactive_def Collect_const_mem
-                               ThreadState_Running_def mask_def from_bool_def
+                               ThreadState_Running_def mask_def
                                option_to_ptr_def option_to_0_def
                         split: bool.split_asm)
 
@@ -5794,7 +5788,7 @@ lemma receiveIPC_ccorres [corres]:
                  apply (clarsimp simp:  from_bool_0 disj_imp[symmetric] simp del: Collect_const)
                  apply wpc
                   (* blocking ipc call *)
-                  apply (clarsimp simp: from_bool_def split del: if_split simp del: Collect_const)
+                  apply (clarsimp split del: if_split simp del: Collect_const)
                   apply ccorres_rewrite
                   apply (wpc ; clarsimp ; ccorres_rewrite)
                    apply csymbr
@@ -5846,7 +5840,7 @@ lemma receiveIPC_ccorres [corres]:
                                          projectKOs invs'_def valid_state'_def st_tcb_at'_def
                                          valid_tcb_state'_def ko_wp_at'_def invs_valid_objs'
                                          isBlockedOnReceive_def projectKO_opt_tcb
-                                         from_bool_def to_bool_def objBits_simps'
+                                         objBits_simps'
                                   elim!: delta_sym_refs
                                   split: if_split_asm bool.splits) (*very long*)
             apply (frule(1) sym_refs_obj_atD' [OF _ invs_sym'])
@@ -5859,7 +5853,6 @@ lemma receiveIPC_ccorres [corres]:
                                         projectKOs invs'_def valid_state'_def st_tcb_at'_def
                                         valid_tcb_state'_def ko_wp_at'_def invs_valid_objs'
                                         isBlockedOnReceive_def projectKO_opt_tcb objBits_simps'
-                                        from_bool_def to_bool_def
                                   elim: delta_sym_refs
                                  split: if_split_asm bool.splits) (*very long *)
            apply (clarsimp simp: obj_at'_def state_refs_of'_def projectKOs)
@@ -6254,7 +6247,6 @@ lemma receiveSignal_block_ccorres_helper:
          apply (simp add: tcb_cte_cases_def cteSizeBits_def)
         apply (simp add: ctcb_relation_def cthread_state_relation_def
                          ThreadState_BlockedOnNotification_def mask_def
-                         from_bool_def to_bool_def
                     flip: canonical_bit_def)
         apply (clarsimp simp: canonical_address_sign_extended sign_extended_iff_sign_extend)
        apply ceqv

--- a/proof/crefine/RISCV64/Retype_C.thy
+++ b/proof/crefine/RISCV64/Retype_C.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2023, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -2307,9 +2308,10 @@ lemma insertNewCap_ccorres_helper:
   apply (rule conjI)
    apply (erule (2) cmap_relation_updI)
    apply (simp add: ccap_relation_def ccte_relation_def cte_lift_def)
-    subgoal by (simp add: cte_to_H_def map_option_Some_eq2 mdb_node_to_H_def to_bool_mask_to_bool_bf is_aligned_neg_mask_weaken
-      c_valid_cte_def true_def canonical_address_sign_extended sign_extended_iff_sign_extend cteSizeBits_def
-      split: option.splits flip: canonical_bit_def)
+    subgoal by (simp add: cte_to_H_def map_option_Some_eq2 mdb_node_to_H_def to_bool_mask_to_bool_bf
+                          is_aligned_neg_mask_weaken c_valid_cte_def canonical_address_sign_extended
+                          sign_extended_iff_sign_extend cteSizeBits_def
+                   split: option.splits flip: canonical_bit_def)
    subgoal by simp
   apply (erule_tac t = s' in ssubst)
   apply (simp cong: lifth_update)
@@ -2618,16 +2620,6 @@ lemma createNewCaps_untyped_if_helper:
   "\<forall>s s'. (s, s') \<in> rf_sr \<and> (sz < word_bits \<and> gbits < word_bits) \<and> True  \<longrightarrow>
              (\<not> gbits \<le> sz) = (s' \<in> \<lbrace>of_nat sz < (of_nat gbits :: machine_word)\<rbrace>)"
   by (clarsimp simp: not_le unat_of_nat64 word_less_nat_alt lt_word_bits_lt_pow)
-
-lemma true_mask1 [simp]:
-  "true && mask (Suc 0) = true"
-  unfolding true_def
-  by (simp add: bang_eq cong: conj_cong)
-
-lemma to_bool_simps [simp]:
-  "to_bool true" "\<not> to_bool false"
-  unfolding true_def false_def to_bool_def
-  by simp_all
 
 lemma heap_list_update':
   "\<lbrakk> n = length v; length v \<le> 2 ^ word_bits \<rbrakk> \<Longrightarrow> heap_list (heap_update_list p v h) n p = v"
@@ -5150,8 +5142,7 @@ proof -
     apply clarsimp
     apply (clarsimp simp: pageBits_def ccap_relation_def APIType_capBits_def
                           framesize_to_H_def cap_to_H_simps cap_page_table_cap_lift
-                          vmrights_to_H_def)
-    apply (clarsimp simp: to_bool_def false_def isFrameType_def)
+                          vmrights_to_H_def isFrameType_def)
     done
 qed
 
@@ -5274,11 +5265,11 @@ proof -
    apply (rule ccorres_cond_seq)
    (* Architecture specific objects. *)
    apply (rule_tac
-           Q="createObject_hs_preconds regionBase newType userSize isdev" and
-           S="createObject_c_preconds1 regionBase newType userSize isdev" and
-           R="createObject_hs_preconds regionBase newType userSize isdev" and
-           T="createObject_c_preconds1 regionBase newType userSize isdev"
-           in ccorres_Cond_rhs)
+            Q="createObject_hs_preconds regionBase newType userSize isdev" and
+            S="createObject_c_preconds1 regionBase newType userSize isdev" and
+            R="createObject_hs_preconds regionBase newType userSize isdev" and
+            T="createObject_c_preconds1 regionBase newType userSize isdev"
+            in ccorres_Cond_rhs)
     apply (subgoal_tac "toAPIType newType = None")
      apply clarsimp
      apply (rule ccorres_rhs_assoc)+
@@ -5322,10 +5313,9 @@ proof -
             apply (rule conseqPre, vcg, clarsimp)
            apply simp
           apply (clarsimp simp: ccap_relation_def cap_to_H_def
-                     getObjectSize_def apiGetObjectSize_def
-                     cap_untyped_cap_lift to_bool_eq_0 true_def
-                     aligned_add_aligned sign_extend_canonical_address
-                   split: option.splits)
+                                getObjectSize_def apiGetObjectSize_def cap_untyped_cap_lift
+                                aligned_add_aligned sign_extend_canonical_address
+                         split: option.splits)
           apply (subst word_le_mask_eq, clarsimp simp: mask_def, unat_arith,
                  auto simp: word_bits_conv untypedBits_defs)[1]
 
@@ -5335,11 +5325,11 @@ proof -
                        intro!: Corres_UL_C.ccorres_cond_empty
                                Corres_UL_C.ccorres_cond_univ ccorres_rhs_assoc)
          apply (rule_tac
-           A ="createObject_hs_preconds regionBase
-                 (APIObjectType apiobject_type.TCBObject) (unat userSizea) isdev" and
-           A'="createObject_c_preconds1 regionBase
-                 (APIObjectType apiobject_type.TCBObject) (unat userSizea) isdev" in
-            ccorres_guard_imp2)
+                  A ="createObject_hs_preconds regionBase
+                        (APIObjectType apiobject_type.TCBObject) (unat userSizea) isdev" and
+                  A'="createObject_c_preconds1 regionBase
+                        (APIObjectType apiobject_type.TCBObject) (unat userSizea) isdev" in
+                  ccorres_guard_imp2)
           apply (rule ccorres_symb_exec_r)
             apply (ccorres_remove_UNIV_guard)
             apply (simp add: hrs_htd_update)
@@ -5372,29 +5362,27 @@ proof -
                                region_actually_is_bytes_def APIType_capBits_def)
          apply (frule(1) ghost_assertion_size_logic_no_unat)
          apply (clarsimp simp: ccap_relation_def cap_to_H_def
-                    getObjectSize_def apiGetObjectSize_def
-                    cap_thread_cap_lift to_bool_def true_def
-                    aligned_add_aligned
-                  split: option.splits)
+                               getObjectSize_def apiGetObjectSize_def
+                               cap_thread_cap_lift aligned_add_aligned
+                        split: option.splits)
          apply (frule range_cover.aligned)
          apply (clarsimp simp: ctcb_ptr_to_tcb_ptr_def ctcb_offset_defs
                                tcb_ptr_to_ctcb_ptr_def
                                invs_valid_objs' invs_urz isFrameType_def
-                         simp flip: canonical_bit_def)
+                    simp flip: canonical_bit_def)
 
         (* Endpoint *)
         apply (clarsimp simp: Kernel_C_defs object_type_from_H_def
-          toAPIType_def nAPIObjects_def
-          word_sle_def intro!: ccorres_cond_empty ccorres_cond_univ
-          ccorres_rhs_assoc)
+                              toAPIType_def nAPIObjects_def word_sle_def
+                      intro!: ccorres_cond_empty ccorres_cond_univ ccorres_rhs_assoc)
         apply (rule_tac
-           A ="createObject_hs_preconds regionBase
-                 (APIObjectType apiobject_type.EndpointObject)
-                 (unat (userSizea :: machine_word)) isdev" and
-           A'="createObject_c_preconds1 regionBase
-                 (APIObjectType apiobject_type.EndpointObject)
-                 (unat userSizea) isdev" in
-           ccorres_guard_imp2)
+                 A ="createObject_hs_preconds regionBase
+                       (APIObjectType apiobject_type.EndpointObject)
+                       (unat (userSizea :: machine_word)) isdev" and
+                 A'="createObject_c_preconds1 regionBase
+                       (APIObjectType apiobject_type.EndpointObject)
+                       (unat userSizea) isdev" in
+                 ccorres_guard_imp2)
          apply (simp add: hrs_htd_update)
          apply (ctac (no_vcg) pre only: add: ccorres_placeNewObject_endpoint)
            apply (rule ccorres_symb_exec_r)
@@ -5403,9 +5391,10 @@ proof -
            apply (rule conseqPre, vcg, clarsimp)
           apply wp
          apply (clarsimp simp: ccap_relation_def cap_to_H_def getObjectSize_def
-                    objBits_simps apiGetObjectSize_def epSizeBits_def
-                    cap_endpoint_cap_lift to_bool_def true_def sign_extend_canonical_address
-                  split: option.splits   dest!: range_cover.aligned)
+                               objBits_simps apiGetObjectSize_def epSizeBits_def
+                               cap_endpoint_cap_lift sign_extend_canonical_address
+                        split: option.splits
+                        dest!: range_cover.aligned)
         apply (clarsimp simp: createObject_hs_preconds_def isFrameType_def)
         apply (frule invs_pspace_aligned')
         apply (frule invs_pspace_distinct')
@@ -5413,25 +5402,24 @@ proof -
         apply (frule invs_sym')
         apply (auto simp: getObjectSize_def objBits_simps apiGetObjectSize_def
                           epSizeBits_def word_bits_conv
-                  elim!: is_aligned_no_wrap'   intro!: range_cover_simpleI)[1]
+                   elim!: is_aligned_no_wrap'
+                  intro!: range_cover_simpleI)[1]
 
        (* Notification *)
        apply (clarsimp simp: createObject_c_preconds_def)
-       apply (clarsimp simp: getObjectSize_def objBits_simps
-                  apiGetObjectSize_def
-                  epSizeBits_def word_bits_conv word_sle_def word_sless_def)
+       apply (clarsimp simp: getObjectSize_def objBits_simps apiGetObjectSize_def
+                             epSizeBits_def word_bits_conv word_sle_def word_sless_def)
        apply (clarsimp simp: Kernel_C_defs object_type_from_H_def
-         toAPIType_def nAPIObjects_def
-         word_sle_def intro!: ccorres_cond_empty ccorres_cond_univ
-         ccorres_rhs_assoc)
+                             toAPIType_def nAPIObjects_def word_sle_def
+                     intro!: ccorres_cond_empty ccorres_cond_univ ccorres_rhs_assoc)
        apply (rule_tac
-         A ="createObject_hs_preconds regionBase
-               (APIObjectType apiobject_type.NotificationObject)
-               (unat (userSizea :: machine_word)) isdev" and
-         A'="createObject_c_preconds1 regionBase
-               (APIObjectType apiobject_type.NotificationObject)
-               (unat userSizea) isdev" in
-         ccorres_guard_imp2)
+                A ="createObject_hs_preconds regionBase
+                      (APIObjectType apiobject_type.NotificationObject)
+                      (unat (userSizea :: machine_word)) isdev" and
+                A'="createObject_c_preconds1 regionBase
+                      (APIObjectType apiobject_type.NotificationObject)
+                      (unat userSizea) isdev" in
+                ccorres_guard_imp2)
         apply (simp add: hrs_htd_update)
         apply (ctac (no_vcg) pre only: add: ccorres_placeNewObject_notification)
           apply (rule ccorres_symb_exec_r)
@@ -5440,10 +5428,11 @@ proof -
           apply (rule conseqPre, vcg, clarsimp)
          apply wp
         apply (clarsimp simp: ccap_relation_def cap_to_H_def
-            getObjectSize_def sign_extend_canonical_address
-            apiGetObjectSize_def ntfnSizeBits_def objBits_simps
-            cap_notification_cap_lift to_bool_def true_def
-            dest!: range_cover.aligned split: option.splits)
+                              getObjectSize_def sign_extend_canonical_address
+                              apiGetObjectSize_def ntfnSizeBits_def objBits_simps
+                              cap_notification_cap_lift
+                       dest!: range_cover.aligned
+                       split: option.splits)
        apply (clarsimp simp: createObject_hs_preconds_def isFrameType_def)
        apply (frule invs_pspace_aligned')
        apply (frule invs_pspace_distinct')
@@ -5460,18 +5449,18 @@ proof -
                   apiGetObjectSize_def
                   ntfnSizeBits_def word_bits_conv)
       apply (clarsimp simp: Kernel_C_defs object_type_from_H_def
-                 toAPIType_def nAPIObjects_def
-                 word_sle_def word_sless_def zero_le_sint
-               intro!: ccorres_cond_empty ccorres_cond_univ ccorres_rhs_assoc
-                       ccorres_move_c_guards ccorres_Guard_Seq)
+                            toAPIType_def nAPIObjects_def
+                            word_sle_def word_sless_def zero_le_sint
+                    intro!: ccorres_cond_empty ccorres_cond_univ ccorres_rhs_assoc
+                            ccorres_move_c_guards ccorres_Guard_Seq)
       apply (rule_tac
-         A ="createObject_hs_preconds regionBase
-               (APIObjectType apiobject_type.CapTableObject)
-               (unat (userSizea :: machine_word)) isdev" and
-         A'="createObject_c_preconds1 regionBase
-               (APIObjectType apiobject_type.CapTableObject)
-               (unat userSizea) isdev" in
-         ccorres_guard_imp2)
+               A ="createObject_hs_preconds regionBase
+                     (APIObjectType apiobject_type.CapTableObject)
+                     (unat (userSizea :: machine_word)) isdev" and
+               A'="createObject_c_preconds1 regionBase
+                     (APIObjectType apiobject_type.CapTableObject)
+                     (unat userSizea) isdev" in
+               ccorres_guard_imp2)
        apply (simp add:field_simps hrs_htd_update)
        apply (ctac pre only: add: ccorres_placeNewObject_captable)
          apply (subst gsCNodes_update)
@@ -5502,14 +5491,12 @@ proof -
       apply (frule range_cover.strong_times_64[folded addr_card_wb], simp+)
       apply (subst h_t_array_valid_retyp, simp+)
        apply (simp add: power_add cte_C_size cteSizeBits_def)
-      apply (clarsimp simp: ccap_relation_def cap_to_H_def
-         cap_cnode_cap_lift to_bool_def true_def
-         getObjectSize_def
-         apiGetObjectSize_def cteSizeBits_def
-         objBits_simps field_simps is_aligned_power2
-         addr_card_wb is_aligned_weaken[where y=2]
-         is_aligned_neg_mask_weaken
-        split: option.splits)
+      apply (clarsimp simp: ccap_relation_def cap_to_H_def cap_cnode_cap_lift
+                            getObjectSize_def apiGetObjectSize_def cteSizeBits_def
+                            objBits_simps field_simps is_aligned_power2
+                            addr_card_wb is_aligned_weaken[where y=2]
+                            is_aligned_neg_mask_weaken
+                     split: option.splits)
       apply (rule conjI)
        apply (frule range_cover.aligned)
        apply (simp add: aligned_and is_aligned_weaken sign_extend_canonical_address)

--- a/proof/crefine/RISCV64/Schedule_C.thy
+++ b/proof/crefine/RISCV64/Schedule_C.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2023, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
  *
@@ -408,7 +409,7 @@ lemma isHighestPrio_ccorres:
       apply (rule ccorres_return_C, simp, simp, simp)
      apply (rule wp_post_taut)
     apply (vcg exspec=getHighestPrio_modifies)+
-  apply (clarsimp simp: word_le_nat_alt true_def to_bool_def maxDomain_le_unat_ucast_explicit
+  apply (clarsimp simp: word_le_nat_alt maxDomain_le_unat_ucast_explicit
                   split: if_splits)
   done
 
@@ -505,17 +506,17 @@ lemma schedule_ccorres:
               apply (rule ccorres_cond2'[where R=\<top>], fastforce)
                apply clarsimp
                apply (rule ccorres_return[where R'=UNIV], clarsimp, vcg)
-               apply (rule_tac P="\<lambda>s. obj_at' (\<lambda>tcb. tcbPriority tcb = curPrio) curThread s
-                                      \<and> curThread = ksCurThread s
-                                      \<and> obj_at' (\<lambda>tcb. tcbPriority tcb = targetPrio) candidate s"
-                        and P'=UNIV in ccorres_from_vcg)
-               apply clarsimp
-               apply (rule conseqPre, vcg)
-               apply (clarsimp simp: return_def cur_tcb'_def rf_sr_ksCurThread)
-               apply (drule (1) obj_at_cslift_tcb)+
-               apply (clarsimp simp: typ_heap_simps ctcb_relation_def to_bool_def split: if_split)
-               apply unat_arith
-              apply (wpsimp wp: threadGet_obj_at2)
+              apply (rule_tac P="\<lambda>s. obj_at' (\<lambda>tcb. tcbPriority tcb = curPrio) curThread s
+                                     \<and> curThread = ksCurThread s
+                                     \<and> obj_at' (\<lambda>tcb. tcbPriority tcb = targetPrio) candidate s"
+                       and P'=UNIV in ccorres_from_vcg)
+              apply clarsimp
+              apply (rule conseqPre, vcg)
+              apply (clarsimp simp: return_def cur_tcb'_def rf_sr_ksCurThread)
+              apply (drule (1) obj_at_cslift_tcb)+
+              apply (clarsimp simp: typ_heap_simps ctcb_relation_def split: if_split)
+              apply unat_arith
+              apply clarsimp
              apply vcg
             apply ceqv
            (* fastfail calculation complete *)
@@ -576,10 +577,10 @@ lemma schedule_ccorres:
                       in ccorres_symb_exec_r_known_rv)
                 apply clarsimp
                 apply (rule conseqPre, vcg)
-                apply (clarsimp simp: false_def cur_tcb'_def rf_sr_ksCurThread)
+                apply (clarsimp simp: cur_tcb'_def rf_sr_ksCurThread)
 
                 apply (drule (1) obj_at_cslift_tcb)+
-                apply (clarsimp simp: typ_heap_simps ctcb_relation_def to_bool_def split: if_split)
+                apply (clarsimp simp: typ_heap_simps ctcb_relation_def split: if_split)
                 apply (solves \<open>unat_arith, rule iffI; simp\<close>)
                apply ceqv
               apply clarsimp
@@ -624,9 +625,9 @@ lemma schedule_ccorres:
           apply wp
          apply (clarsimp, vcg exspec=tcbSchedEnqueue_modifies)
         apply (clarsimp, vcg exspec=tcbSchedEnqueue_modifies)
-       apply (clarsimp simp: to_bool_def true_def)
+       apply clarsimp
        apply (strengthen ko_at'_obj_at'_field)
-       apply (clarsimp cong: imp_cong simp: ko_at'_obj_at'_field to_bool_def true_def)
+       apply (clarsimp cong: imp_cong simp: ko_at'_obj_at'_field)
        apply wp
       apply clarsimp
       (* when runnable tcbSchedEnqueue curThread *)
@@ -638,7 +639,6 @@ lemma schedule_ccorres:
       apply (wp | clarsimp simp: dc_def)+
      apply (vcg exspec=tcbSchedEnqueue_modifies)
     apply wp
-   apply (clarsimp simp: to_bool_def false_def)
    apply vcg
 
   apply (clarsimp simp: tcb_at_invs' rf_sr_ksCurThread if_apply_def2 invs_queues invs_valid_objs'
@@ -649,12 +649,12 @@ lemma schedule_ccorres:
    apply (clarsimp dest!: rf_sr_cscheduler_relation simp: cscheduler_action_relation_def)
   apply (rule conjI; clarsimp)
    apply (frule (1) obj_at_cslift_tcb)
-   apply (clarsimp simp: cscheduler_action_relation_def typ_heap_simps max_word_not_0
+   apply (clarsimp simp: cscheduler_action_relation_def typ_heap_simps
                   split: scheduler_action.splits)
   apply (frule (1) obj_at_cslift_tcb)
   apply (clarsimp dest!: rf_sr_cscheduler_relation invs_sch_act_wf'
                   simp: cscheduler_action_relation_def)
-  apply (intro conjI impI allI; clarsimp simp: typ_heap_simps ctcb_relation_def to_bool_def)
+  apply (intro conjI impI allI; clarsimp simp: typ_heap_simps ctcb_relation_def)
      apply (fastforce simp: tcb_at_not_NULL tcb_at_1 dest: pred_tcb_at')+
   done
 

--- a/proof/crefine/RISCV64/SyscallArgs_C.thy
+++ b/proof/crefine/RISCV64/SyscallArgs_C.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2023, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
  *
@@ -804,8 +805,7 @@ lemma lookupIPCBuffer_ccorres[corres]:
            apply (frule cap_get_tag_isCap_unfolded_H_cap(15),simp)
            apply (frule capFVMRights_range)
            apply (simp add: cap_frame_cap_lift)
-           apply (clarsimp simp: cap_to_H_def vmrights_to_H_def to_bool_def
-                                 word_le_make_less
+           apply (clarsimp simp: cap_to_H_def vmrights_to_H_def word_le_make_less
                                  Kernel_C.VMReadWrite_def Kernel_C.VMReadOnly_def
                                  Kernel_C.VMKernelOnly_def
                            dest: word_less_cases)

--- a/proof/crefine/RISCV64/Syscall_C.thy
+++ b/proof/crefine/RISCV64/Syscall_C.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2023, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
  *
@@ -19,9 +20,6 @@ crunch sch_act_wf [wp]: replyFromKernel "\<lambda>s. sch_act_wf (ksSchedulerActi
 end
 
 context kernel_m begin
-
-(* FIXME: should do this from the beginning *)
-declare true_def [simp] false_def [simp]
 
 lemma ccorres_If_False:
   "ccorres_underlying sr Gamm r xf arrel axf R R' hs b c
@@ -662,7 +660,7 @@ lemma sendFaultIPC_ccorres:
              apply (clarsimp simp: cap_get_tag_isCap isEndpointCap_def isCap_simps
                                     ccap_relation_ep_helpers)
             apply (drule cap_get_tag_isCap(4)[symmetric])
-            apply (clarsimp simp: cap_get_tag_EndpointCap to_bool_def)
+            apply (clarsimp simp: cap_get_tag_EndpointCap)
            apply (clarsimp simp: case_bool_If)
            apply (rule_tac P=\<top> and P'=UNIV in ccorres_from_vcg_throws)
            apply clarsimp
@@ -1407,8 +1405,8 @@ lemma handleRecv_ccorres:
   apply (frule tcb_aligned'[OF tcb_at_invs'])
   apply clarsimp
   apply (intro conjI impI allI)
-             apply (clarsimp simp: cfault_rel_def seL4_Fault_CapFault_lift
-                              lookup_fault_missing_capability_lift is_cap_fault_def)+
+           apply (clarsimp simp: cfault_rel_def seL4_Fault_CapFault_lift
+                            lookup_fault_missing_capability_lift is_cap_fault_def)+
          apply (clarsimp simp: cap_get_tag_NotificationCap)
          apply (rule cmap_relationE1[OF cmap_relation_ntfn], assumption, erule ko_at_projectKO_opt)
          apply (clarsimp simp: cnotification_relation_def Let_def)

--- a/proof/crefine/RISCV64/Tcb_C.thy
+++ b/proof/crefine/RISCV64/Tcb_C.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2023, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
  *
@@ -498,8 +499,8 @@ lemma checkCapAt_ccorres:
      apply assumption
     apply (simp only: when_def if_to_top_of_bind)
     apply (rule ccorres_if_lhs)
-     apply (simp add: from_bool_def true_def)
-    apply (simp add: from_bool_def false_def)
+     apply simp
+    apply simp
    apply (simp add: guard_is_UNIV_def)
   apply (clarsimp simp: cte_wp_at_ctes_of)
   done
@@ -651,13 +652,13 @@ lemma invokeTCB_ThreadControl_ccorres:
                 apply (rule checkCapAt_ccorres)
                    apply ceqv
                   apply csymbr
-                  apply (simp add: true_def Collect_True
+                  apply (simp add: Collect_True
                               del: Collect_const)
                   apply (rule ccorres_rhs_assoc)+
                   apply (rule checkCapAt_ccorres)
                      apply ceqv
                     apply csymbr
-                    apply (simp add: true_def Collect_True
+                    apply (simp add: Collect_True
                                 del: Collect_const)
                     apply (simp add: assertDerived_def bind_assoc del: Collect_const)
                     apply (rule ccorres_symb_exec_l)
@@ -698,12 +699,12 @@ lemma invokeTCB_ThreadControl_ccorres:
                        apply (clarsimp split: if_splits)
                       apply (wp empty_fail_stateAssert hoare_case_option_wp | simp del: Collect_const)+
                    apply csymbr
-                   apply (simp add: false_def Collect_False ccorres_cond_iffs
+                   apply (simp add: Collect_False ccorres_cond_iffs
                                del: Collect_const)
                    apply (rule ccorres_pre_getCurThread)
                    apply (rename_tac curThread)
                    apply (rule ccorres_split_nothrow_novcg_dc)
-                      apply (simp add: when_def to_bool_def)
+                      apply (simp add: when_def)
                       apply (rule_tac C'="{s. target = curThread}"
                                       and Q="\<lambda>s. ksCurThread s = curThread"
                                       and Q'=UNIV in ccorres_rewrite_cond_sr)
@@ -726,12 +727,12 @@ lemma invokeTCB_ThreadControl_ccorres:
                                         tcbIPCBufferSlot_def
                                         mask_def objBits_defs)
                  apply csymbr
-                 apply (simp add: if_1_0_0 Collect_False false_def ccorres_cond_iffs
+                 apply (simp add: Collect_False ccorres_cond_iffs
                              del: Collect_const)
                  apply (rule ccorres_cond_false_seq, simp)
                  apply (rule ccorres_pre_getCurThread)
                  apply (rename_tac curThread)
-                 apply (simp add: when_def to_bool_def)
+                 apply (simp add: when_def)
                  apply (rule ccorres_split_nothrow_novcg_dc)
                     apply (rule_tac C'="{s. target = curThread}"
                                     and Q="\<lambda>s. ksCurThread s = curThread"
@@ -749,7 +750,7 @@ lemma invokeTCB_ThreadControl_ccorres:
                    apply (clarsimp simp: guard_is_UNIV_def)
                   apply (wp hoare_vcg_if_lift2(1) static_imp_wp, strengthen sch_act_wf_weak; wp)
                  apply (clarsimp simp : guard_is_UNIV_def Collect_const_mem)
-                apply (simp add: guard_is_UNIV_def if_1_0_0 false_def Collect_const_mem
+                apply (simp add: guard_is_UNIV_def Collect_const_mem
                             flip: canonical_bit_def)
                 apply (clarsimp simp: ccap_relation_def cap_thread_cap_lift cap_to_H_def canonical_address_bitfield_extract_tcb)
                (* \<not> P *)
@@ -759,7 +760,7 @@ lemma invokeTCB_ThreadControl_ccorres:
                apply (simp split: option.split_asm)
                apply (rule ccorres_pre_getCurThread)
                apply (rename_tac curThread)
-               apply (simp add: when_def to_bool_def)
+               apply (simp add: when_def)
                apply (rule ccorres_split_nothrow_novcg_dc)
                   apply (rule_tac C'="{s. target = curThread}"
                                   and Q="\<lambda>s. ksCurThread s = curThread"
@@ -838,7 +839,7 @@ lemma invokeTCB_ThreadControl_ccorres:
          apply (clarsimp simp: inQ_def Collect_const_mem cintr_def
                                exception_defs tcb_cnode_index_defs)
          apply (simp add: tcbBuffer_def tcbIPCBufferSlot_def word_sle_def
-                          cte_level_bits_def from_bool_def true_def size_of_def case_option_If2 )
+                          cte_level_bits_def size_of_def case_option_If2 )
          apply (rule conjI)
           apply (clarsimp simp: objBits_simps' word_bits_conv case_option_If2 if_n_0_0 valid_cap'_def
                                 capAligned_def obj_at'_def projectKOs)
@@ -871,34 +872,32 @@ lemma invokeTCB_ThreadControl_ccorres:
            apply (rule checkCapAt_ccorres2)
               apply ceqv
              apply csymbr
-             apply (simp add: true_def Collect_True
+             apply (simp add: Collect_True
                          del: Collect_const)
              apply (rule ccorres_rhs_assoc)+
              apply (rule checkCapAt_ccorres2)
                 apply ceqv
                apply csymbr
-               apply (simp add: true_def Collect_True
-                                assertDerived_def bind_assoc
+               apply (simp add: Collect_True assertDerived_def bind_assoc
                                 ccorres_cond_iffs dc_def[symmetric]
                            del: Collect_const)
                apply (rule ccorres_symb_exec_l)
                   apply (ctac add: cteInsert_ccorres)
                  apply (wp empty_fail_stateAssert hoare_case_option_wp | simp del: Collect_const)+
               apply csymbr
-              apply (simp add: false_def Collect_False ccorres_cond_iffs
+              apply (simp add: Collect_False ccorres_cond_iffs
                           del: Collect_const)
               apply (rule ccorres_return_Skip[unfolded dc_def])
              apply (clarsimp simp: guard_is_UNIV_def Collect_const_mem
                                    tcbVTable_def tcbVTableSlot_def Kernel_C.tcbVTable_def
                                    cte_level_bits_def size_of_def option_to_0_def objBits_defs mask_def)
             apply csymbr
-            apply (simp add: if_1_0_0 false_def Collect_False
+            apply (simp add: Collect_False
                         del: Collect_const)
             apply (rule ccorres_cond_false)
             apply (rule ccorres_return_Skip[unfolded dc_def])
-           apply (clarsimp simp: guard_is_UNIV_def false_def
-                                 ccap_relation_def cap_thread_cap_lift
-                                 cap_to_H_def if_1_0_0 Collect_const_mem
+           apply (clarsimp simp: guard_is_UNIV_def ccap_relation_def cap_thread_cap_lift
+                                 cap_to_H_def Collect_const_mem
                                  canonical_address_bitfield_extract_tcb
                            simp flip: canonical_bit_def)
           apply simp
@@ -935,8 +934,7 @@ lemma invokeTCB_ThreadControl_ccorres:
                       checkCap_inv [where P="valid_cap' c" for c]
                       checkCap_inv [where P="sch_act_simple"]
                    | simp)+
-           apply (clarsimp simp: guard_is_UNIV_def from_bool_def true_def
-                                 word_sle_def if_1_0_0 Collect_const_mem
+           apply (clarsimp simp: guard_is_UNIV_def word_sle_def Collect_const_mem
                                  option_to_0_def Kernel_C.tcbVTable_def tcbVTableSlot_def
                                  cte_level_bits_def size_of_def cintr_def
                                  tcb_cnode_index_defs objBits_defs mask_def)
@@ -945,34 +943,32 @@ lemma invokeTCB_ThreadControl_ccorres:
           apply (rule checkCapAt_ccorres2)
              apply ceqv
             apply csymbr
-            apply (simp add: true_def Collect_True
+            apply (simp add: Collect_True
                         del: Collect_const)
             apply (rule ccorres_rhs_assoc)+
             apply (rule checkCapAt_ccorres2)
                apply ceqv
               apply csymbr
-              apply (simp add: true_def Collect_True
-                               assertDerived_def bind_assoc
+              apply (simp add: Collect_True assertDerived_def bind_assoc
                                ccorres_cond_iffs dc_def[symmetric]
                           del: Collect_const)
               apply (rule ccorres_symb_exec_l)
                  apply (ctac add: cteInsert_ccorres)
                 apply (wp empty_fail_stateAssert  hoare_case_option_wp | simp del: Collect_const)+
              apply csymbr
-             apply (simp add: false_def Collect_False ccorres_cond_iffs
+             apply (simp add: Collect_False ccorres_cond_iffs
                          del: Collect_const)
              apply (rule ccorres_return_Skip[unfolded dc_def])
             apply (clarsimp simp: guard_is_UNIV_def Collect_const_mem
-                                  Kernel_C.tcbCTable_def tcbCTableSlot_def if_1_0_0
+                                  Kernel_C.tcbCTable_def tcbCTableSlot_def
                                   cte_level_bits_def size_of_def option_to_0_def mask_def objBits_defs)
            apply csymbr
-           apply (simp add: false_def Collect_False
+           apply (simp add: Collect_False
                        del: Collect_const)
            apply (rule ccorres_cond_false)
            apply (rule ccorres_return_Skip[unfolded dc_def])
-          apply (clarsimp simp: guard_is_UNIV_def false_def
-                                ccap_relation_def cap_thread_cap_lift
-                                cap_to_H_def if_1_0_0 Collect_const_mem
+          apply (clarsimp simp: guard_is_UNIV_def ccap_relation_def cap_thread_cap_lift
+                                cap_to_H_def Collect_const_mem
                                 canonical_address_bitfield_extract_tcb
                           simp flip: canonical_bit_def)
          apply simp
@@ -992,7 +988,7 @@ lemma invokeTCB_ThreadControl_ccorres:
                 threadSet_cap_to' static_imp_wp | simp)+
      apply (clarsimp simp: guard_is_UNIV_def tcbCTableSlot_def Kernel_C.tcbCTable_def
                            cte_level_bits_def size_of_def word_sle_def option_to_0_def
-                           true_def from_bool_def cintr_def objBits_defs mask_def)
+                           cintr_def objBits_defs mask_def)
     apply (simp add: conj_comms)
     apply (wp hoare_case_option_wp threadSet_invs_trivial
               threadSet_cap_to' static_imp_wp | simp)+
@@ -1061,7 +1057,6 @@ lemma setupReplyMaster_ccorres:
           apply (simp add: cte_to_H_def cap_to_H_def mdb_node_to_H_def
                            nullMDBNode_def c_valid_cte_def)
           apply (simp add: cap_reply_cap_lift)
-          apply (simp add: true_def mask_def to_bool_def)
          apply simp
         apply (simp add: cmachine_state_relation_def packed_heap_update_collapse_hrs
                          carch_state_relation_def carch_globals_def
@@ -1267,7 +1262,7 @@ lemma invokeTCB_CopyRegisters_ccorres:
      apply (fastforce simp: sch_act_wf_weak)
     apply (wpsimp wp: hoare_drop_imp)+
    apply (clarsimp simp add: guard_is_UNIV_def)
-  apply (clarsimp simp: to_bool_def invs_weak_sch_act_wf invs_valid_objs'
+  apply (clarsimp simp: invs_weak_sch_act_wf invs_valid_objs'
                  split: if_split cong: if_cong | rule conjI)+
      apply (clarsimp dest!: global'_no_ex_cap simp: invs'_def valid_state'_def | rule conjI)+
   done
@@ -1721,7 +1716,7 @@ lemma invokeTCB_Suspend_ccorres:
    apply (ctac(no_vcg) add: suspend_ccorres[OF cteDeleteOne_ccorres])
     apply (rule ccorres_return_CE, simp+)[1]
    apply wp
-  apply (clarsimp simp: from_bool_def true_def)
+  apply clarsimp
   apply (auto simp: invs'_def valid_state'_def global'_no_ex_cap)
   done
 
@@ -1735,7 +1730,7 @@ lemma invokeTCB_Resume_ccorres:
    apply (ctac(no_vcg) add: restart_ccorres)
     apply (rule ccorres_return_CE, simp+)[1]
    apply wp
-  apply (clarsimp simp: from_bool_def true_def)
+  apply clarsimp
   done
 
 lemma Arch_decodeTransfer_spec:
@@ -1838,7 +1833,7 @@ shows
              apply (rule ccorres_symb_exec_l[OF _ _ _ empty_fail_getThreadState])
                apply (rule ccorres_if_lhs[OF _ ccorres_False[where P'=UNIV]])
                apply (rule ccorres_if_lhs)
-                apply (simp add: Collect_True true_def whileAnno_def del: Collect_const)
+                apply (simp add: Collect_True whileAnno_def del: Collect_const)
                 apply (rule ccorres_rhs_assoc)+
                 apply csymbr
                 apply (ctac add: lookupIPCBuffer_ccorres)
@@ -2167,7 +2162,7 @@ shows
                                  RISCV64.badgeRegister_def RISCV64.capRegister_def
                                  "StrictC'_register_defs")
                 apply (vcg exspec=lookupIPCBuffer_modifies)
-               apply (simp add: false_def)
+               apply simp
                apply (ctac(no_vcg) add: setThreadState_ccorres)
                 apply (rule ccorres_from_vcg_throws[where P=\<top> and P'=UNIV])
                 apply (rule allI, rule conseqPre, vcg)
@@ -2197,7 +2192,7 @@ shows
      apply (vcg exspec=suspend_modifies)
     apply vcg
    apply (rule conseqPre, vcg, clarsimp)
-  apply (clarsimp simp: rf_sr_ksCurThread ct_in_state'_def true_def dc_def
+  apply (clarsimp simp: rf_sr_ksCurThread ct_in_state'_def dc_def
                  split: if_split)
   done
 
@@ -2319,7 +2314,7 @@ lemma decodeReadRegisters_ccorres:
                      valid_tcb_state'_def
               elim!: pred_tcb'_weakenE
               dest!: st_tcb_at_idle_thread')[1]
-  apply (clarsimp simp: from_bool_def word_and_1 split: if_split)
+  apply (clarsimp simp: word_and_1 split: if_split)
   done
 
 lemma decodeWriteRegisters_ccorres:
@@ -2432,8 +2427,7 @@ lemma decodeWriteRegisters_ccorres:
   apply (rule disjCI2)
   apply (clarsimp simp: genericTake_def linorder_not_less)
   apply (subst hd_conv_nth, clarsimp simp: unat_eq_0)
-  apply (clarsimp simp: from_bool_def word_and_1
-                 split: if_split)
+  apply (clarsimp simp: word_and_1 split: if_split)
   done
 
 lemma excaps_map_Nil: "(excaps_map caps = []) = (caps = [])"
@@ -2501,7 +2495,7 @@ lemma decodeCopyRegisters_ccorres:
           apply (simp add: case_bool_If if_to_top_of_bindE
                            if_to_top_of_bind
                       del: Collect_const cong: if_cong)
-          apply (simp add: to_bool_def returnOk_bind Collect_True
+          apply (simp add: returnOk_bind Collect_True
                            ccorres_invocationCatch_Inr performInvocation_def
                       del: Collect_const)
           apply (ctac add: setThreadState_ccorres)
@@ -2665,7 +2659,7 @@ lemma slotCapLongRunningDelete_ccorres:
        apply (clarsimp simp: typ_heap_simps cap_get_tag_isCap
                              from_bool_0
                       dest!: ccte_relation_ccap_relation)
-       apply (simp add: from_bool_def false_def true_def
+       apply (simp add: from_bool_def
                  split: bool.split)
        apply (auto simp add: longRunningDelete_def isCap_simps
                  split: capability.split)[1]
@@ -2673,13 +2667,12 @@ lemma slotCapLongRunningDelete_ccorres:
       apply (wp hoare_drop_imps isFinalCapability_inv)
      apply (clarsimp simp: Collect_const_mem guard_is_UNIV_def)
      apply (rename_tac rv')
-     apply (case_tac rv'; clarsimp simp: false_def true_def)
+     apply (case_tac rv'; clarsimp simp: false_def)
     apply vcg
    apply (rule conseqPre, vcg, clarsimp)
   apply (clarsimp simp: cte_wp_at_ctes_of)
   apply (erule(1) cmap_relationE1 [OF cmap_relation_cte])
-  apply (clarsimp simp: typ_heap_simps cap_get_tag_isCap
-                        from_bool_def false_def map_comp_Some_iff
+  apply (clarsimp simp: typ_heap_simps cap_get_tag_isCap map_comp_Some_iff
                  dest!: ccte_relation_ccap_relation)
   done
 
@@ -2694,7 +2687,7 @@ lemma isValidVTableRoot_spec:
     {s'. ret__unsigned_long_' s' = from_bool (isValidVTableRoot_C (cap_' s))}"
   apply vcg
   apply (clarsimp simp: isValidVTableRoot_C_def if_1_0_0 from_bool_0)
-  apply (simp add: from_bool_def to_bool_def false_def split: if_split)
+  apply (simp add: to_bool_def split: if_split)
   done
 
 lemma isValidVTableRoot_conv:
@@ -2708,9 +2701,8 @@ lemma isValidVTableRoot_conv:
    apply (case_tac "cap_get_tag cap' = scast cap_page_table_cap")
     apply (clarsimp split: arch_capability.split simp: isCap_simps)
     apply (clarsimp simp: ccap_relation_def map_option_Some_eq2
-                          cap_page_table_cap_lift cap_to_H_def
-                          from_bool_def)
-    apply (clarsimp simp: to_bool_def split: if_split)
+                          cap_page_table_cap_lift cap_to_H_def)
+    apply (clarsimp split: if_split)
    apply (clarsimp simp: cap_get_tag_isCap cap_get_tag_isCap_ArchObject)
    apply (simp split: arch_capability.split_asm add: isCap_simps)
   apply (case_tac "cap_get_tag cap' = scast cap_page_table_cap")
@@ -3025,7 +3017,7 @@ lemma decodeTCBConfigure_ccorres:
                                           in ccorres_from_vcg[where P=\<top>])
                            apply (rule allI, rule conseqPre, vcg)
                            apply (subgoal_tac "extraCaps \<noteq> []")
-                            apply (clarsimp simp: returnOk_def return_def hd_conv_nth false_def)
+                            apply (clarsimp simp: returnOk_def return_def hd_conv_nth)
                             apply fastforce
                            apply clarsimp
                           apply ceqv
@@ -3052,7 +3044,7 @@ lemma decodeTCBConfigure_ccorres:
                                                 in ccorres_from_vcg[where P=\<top>])
                                 apply (rule allI, rule conseqPre, vcg)
                                 apply (clarsimp simp: returnOk_def return_def
-                                                      hd_drop_conv_nth2 false_def)
+                                                      hd_drop_conv_nth2)
                                 apply fastforce
                                apply ceqv
                               apply (ctac add: ccorres_injection_handler_csum1
@@ -3510,9 +3502,9 @@ lemma decodeSetSchedParams_ccorres:
                    val="from_bool (length args < 2 \<or> length extraCaps = 0)" in
                    ccorres_symb_exec_r_known_rv)
       apply vcg
-      apply (auto simp: interpret_excaps_test_null excaps_map_def from_bool_def unat_eq_0
-                  split: bool.splits)[1]
-       apply (unat_arith+)[2]
+      apply (force simp: interpret_excaps_test_null excaps_map_def from_bool_def unat_eq_0
+                         unat_arith_simps
+                  split: bool.splits if_splits)
      apply ceqv
     apply clarsimp
 (*
@@ -4032,7 +4024,7 @@ lemma decodeBindNotification_ccorres:
       apply csymbr
       apply (clarsimp simp add: if_to_top_of_bind to_bool_eq_0[symmetric] simp del: Collect_const)
       apply (rule ccorres_Cond_rhs_Seq)
-       apply (clarsimp simp: to_bool_def throwError_bind invocationCatch_def)
+       apply (clarsimp simp: throwError_bind invocationCatch_def)
        apply (rule ccorres_from_vcg_split_throws[where P=\<top> and P'=UNIV])
         apply vcg
        apply (rule conseqPre, vcg)
@@ -4055,7 +4047,7 @@ lemma decodeBindNotification_ccorres:
          apply (clarsimp simp: typ_heap_simps cnotification_relation_def Let_def
                                valid_ntfn'_def)
          apply (case_tac "ntfnObj ntfn", simp_all add: isWaitingNtfn_def option_to_ctcb_ptr_def
-                             false_def true_def split: option.split_asm if_split,
+                                                split: option.split_asm if_split,
                          auto simp: neq_Nil_conv tcb_queue_relation'_def tcb_at_not_NULL[symmetric]
                                     tcb_at_not_NULL)[1]
         apply ceqv
@@ -4119,8 +4111,8 @@ lemma decodeBindNotification_ccorres:
        apply (rule conseqPre, vcg)
        apply (clarsimp simp: throwError_def return_def syscall_error_rel_def
                              syscall_error_to_H_cases exception_defs)
-      apply (clarsimp simp add: guard_is_UNIV_def isWaitingNtfn_def from_bool_0
-                                ThreadState_Restart_def mask_def true_def
+      apply (clarsimp simp add: guard_is_UNIV_def isWaitingNtfn_def
+                                ThreadState_Restart_def mask_def
                                 rf_sr_ksCurThread capTCBPtr_eq)
      apply (simp add: hd_conv_nth bindE_bind_linearise nTFN_case_If_ptr throwError_bind invocationCatch_def)
      apply (rule ccorres_from_vcg_split_throws[where P=\<top> and P'=UNIV])
@@ -4307,7 +4299,7 @@ lemma decodeSetSpace_ccorres:
                                  in ccorres_from_vcg[where P=\<top>])
                      apply (rule allI, rule conseqPre, vcg)
                      apply (subgoal_tac "extraCaps \<noteq> []")
-                      apply (clarsimp simp: returnOk_def return_def hd_conv_nth false_def)
+                      apply (clarsimp simp: returnOk_def return_def hd_conv_nth)
                       apply fastforce
                      apply clarsimp
                     apply ceqv
@@ -4334,8 +4326,7 @@ lemma decodeSetSpace_ccorres:
                            apply (rule_tac P'="{s. vRootCap = vRootCap_' s}"
                                   in ccorres_from_vcg[where P=\<top>])
                            apply (rule allI, rule conseqPre, vcg)
-                           apply (clarsimp simp: returnOk_def return_def
-                                                 hd_drop_conv_nth2 false_def)
+                           apply (clarsimp simp: returnOk_def return_def hd_drop_conv_nth2)
                            apply fastforce
                           apply ceqv
                          apply (ctac add: ccorres_injection_handler_csum1
@@ -4449,7 +4440,6 @@ lemma decodeSetSpace_ccorres:
   apply (simp add: word_sle_def cap_get_tag_isCap)
   apply (subgoal_tac "args \<noteq> []")
    apply (clarsimp simp: hd_conv_nth)
-   apply (drule sym, simp, simp add: true_def from_bool_0)
    apply (clarsimp simp: objBits_simps')
    apply fastforce
   apply clarsimp

--- a/proof/crefine/RISCV64/VSpace_C.thy
+++ b/proof/crefine/RISCV64/VSpace_C.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2023, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
  *
@@ -82,7 +83,7 @@ lemma checkVPAlignment_ccorres:
        apply simp
       apply simp
      apply simp
-    apply (simp split: if_split add: to_bool_def)
+    apply (simp split: if_split)
    apply (clarsimp simp: mask_def unlessE_def throwError_def split: if_split)
    apply (rule ccorres_guard_imp)
      apply (rule ccorres_return_C)
@@ -90,7 +91,7 @@ lemma checkVPAlignment_ccorres:
       apply simp
      apply simp
     apply simp
-   apply (simp split: if_split add: to_bool_def)
+   apply (simp split: if_split)
   apply (clarsimp split: if_split)
   apply (simp add: word_less_nat_alt)
   apply (rule order_le_less_trans, rule pageBitsForSize_le)
@@ -253,8 +254,7 @@ lemma handleVMFault_ccorres:
    apply (rule corres_split[OF read_stval_ccorres[ac]])
       apply terminates_trivial
      apply (drule sym, clarsimp)
-     apply (wpc; simp add: vm_fault_type_from_H_def vm_fault_defs_C
-                           true_def false_def bind_assoc)
+     apply (wpc; simp add: vm_fault_type_from_H_def vm_fault_defs_C bind_assoc)
           apply (rule returnVMFault_corres;
                  clarsimp simp: exception_defs mask_twice lift_rv_def mask_def vmFaultTypeFSR_def)+
      apply wpsimp+
@@ -383,7 +383,7 @@ lemma isPTEPageTable_spec':
                         cpte_relation pte cpte \<longrightarrow>
              \<acute>ret__unsigned_long = from_bool (isPageTablePTE pte) \<rbrace>"
   by vcg
-     (auto simp: from_bool_def cpte_relation_def isPageTablePTE_def2 Let_def
+     (auto simp: cpte_relation_def isPageTablePTE_def2 Let_def
                  readable_from_vm_rights_def writable_from_vm_rights_def bit_simps
            split: bool.split if_split pte.splits vmrights.splits)
 
@@ -406,7 +406,7 @@ lemma isPTEPageTable_corres:
   apply (drule rf_sr_cpte_relation)
   apply (drule (1) cmap_relation_ko_atD)
   apply (clarsimp simp: typ_heap_simps)
-  apply (cases pte; simp add: readable_from_vm_rights0 isPageTablePTE_def from_bool_def
+  apply (cases pte; simp add: readable_from_vm_rights0 isPageTablePTE_def
                               cpte_relation_def writable_from_vm_rights_def)
   done
 
@@ -965,11 +965,10 @@ lemma setVMRoot_ccorres:
   apply (clarsimp simp: isCap_simps isValidVTableRoot_def2)
   apply (clarsimp simp: cap_get_tag_isCap_ArchObject2)
   by (clarsimp simp: cap_get_tag_isCap_ArchObject[symmetric]
-                        cap_lift_page_table_cap cap_to_H_def
-                        cap_page_table_cap_lift_def isCap_simps
-                        to_bool_def mask_def isZombieTCB_C_def Let_def
-                 elim!: ccap_relationE
-                 split: if_split_asm cap_CL.splits)
+                     cap_lift_page_table_cap cap_to_H_def
+                     cap_page_table_cap_lift_def isCap_simps isZombieTCB_C_def Let_def
+              elim!: ccap_relationE
+              split: if_split_asm cap_CL.splits)
 
 lemma ccorres_seq_IF_False:
   "ccorres_underlying sr \<Gamma> r xf arrel axf G G' hs a (IF False THEN x ELSE y FI ;; c) = ccorres_underlying sr \<Gamma> r xf arrel axf G G' hs a (y ;; c)"
@@ -1267,7 +1266,7 @@ lemma unmapPage_ccorres:
              apply (rule checkMappingPPtr_pte_ccorres[simplified])
              apply (rule conseqPre, vcg exspec=isPTEPageTable_spec')
              apply (clarsimp simp: cpte_relation_def Let_def pte_lift_def isPagePTE_def
-                                   typ_heap_simps isPageTablePTE_def bit_simps from_bool_def
+                                   typ_heap_simps isPageTablePTE_def bit_simps
                             split: if_split_asm pte.split_asm)
             apply (rule ceqv_refl)
            apply (simp add: unfold_checkMapping_return liftE_bindE

--- a/proof/crefine/RISCV64/Wellformed_C.thy
+++ b/proof/crefine/RISCV64/Wellformed_C.thy
@@ -260,63 +260,6 @@ definition
                    | Some cap \<Rightarrow> Some \<lparr> cap_CL = cap,
                                        cteMDBNode_CL = mdb_node_lift (cteMDBNode_C c) \<rparr>"
 
-lemma to_bool_false [simp]: "\<not> to_bool false"
-  by (simp add: to_bool_def false_def)
-
-(* this is slightly weird, but the bitfield generator
-   masks everything with the expected bit length.
-   So we do that here too. *)
-definition
-  to_bool_bf :: "'a::len word \<Rightarrow> bool" where
-  "to_bool_bf w \<equiv> (w && mask 1) = 1"
-
-lemma to_bool_bf_mask1 [simp]:
-  "to_bool_bf (mask (Suc 0))"
-  by (simp add: mask_def to_bool_bf_def)
-
-lemma to_bool_bf_0 [simp]: "\<not>to_bool_bf 0"
-  by (simp add: to_bool_bf_def)
-
-lemma to_bool_bf_1 [simp]: "to_bool_bf 1"
-  by (simp add: to_bool_bf_def mask_def)
-
-lemma to_bool_bf_false [simp]:
-  "\<not>to_bool_bf false"
-  by (simp add: false_def)
-
-lemma to_bool_bf_true [simp]:
-  "to_bool_bf true"
-  by (simp add: true_def)
-
-lemma to_bool_to_bool_bf:
-  "w = false \<or> w = true \<Longrightarrow> to_bool_bf w = to_bool w"
-  by (auto simp: false_def true_def to_bool_def to_bool_bf_def mask_def)
-
-lemma to_bool_bf_mask_1 [simp]:
-  "to_bool_bf (w && mask (Suc 0)) = to_bool_bf w"
-  by (simp add: to_bool_bf_def)
-
-lemma to_bool_bf_and [simp]:
-  "to_bool_bf (a && b) = (to_bool_bf a \<and> to_bool_bf (b::word64))"
-  apply (clarsimp simp: to_bool_bf_def)
-  apply (rule iffI)
-   apply (subst (asm) bang_eq)
-   apply (simp add: word_size)
-   apply (rule conjI)
-    apply (rule word_eqI)
-    apply (auto simp add: word_size)[1]
-   apply (rule word_eqI)
-   apply (auto simp add: word_size)[1]
-  apply clarsimp
-  apply (rule word_eqI)
-  apply (subst (asm) bang_eq)+
-  apply (auto simp add: word_size)[1]
-  done
-
-lemma to_bool_bf_to_bool_mask:
-  "w && mask (Suc 0) = w \<Longrightarrow> to_bool_bf w = to_bool (w::word64)"
-  by (metis mask_Suc_0 bool_mask mask_1 to_bool_0 to_bool_1 to_bool_bf_def word_gt_0)
-
 definition
   mdb_node_to_H :: "mdb_node_CL \<Rightarrow> mdbnode"
   where

--- a/proof/crefine/X64/Arch_C.thy
+++ b/proof/crefine/X64/Arch_C.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2023, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -79,7 +80,7 @@ lemma performPageTableInvocationUnmap_ccorres:
          apply wp
         apply (simp del: Collect_const)
         apply (vcg exspec=unmapPageTable_modifies)
-       apply (simp add: to_bool_def)
+       apply simp
        apply (rule ccorres_return_Skip')
       apply (simp add: cap_get_tag_isCap_ArchObject[symmetric])
       apply (clarsimp simp: cap_lift_page_table_cap cap_to_H_def
@@ -221,7 +222,7 @@ lemma performPageDirectoryInvocationUnmap_ccorres:
          apply wp
         apply (simp del: Collect_const)
         apply (vcg exspec=unmapPageDirectory_modifies)
-       apply (simp add: to_bool_def)
+       apply simp
        apply (rule ccorres_return_Skip')
       apply (simp add: cap_get_tag_isCap_ArchObject[symmetric])
       apply (clarsimp simp: cap_lift_page_directory_cap cap_to_H_def
@@ -363,7 +364,7 @@ lemma performPDPTInvocationUnmap_ccorres:
          apply wp
         apply (simp del: Collect_const)
         apply (vcg exspec=unmapPDPT_modifies)
-       apply (simp add: to_bool_def)
+       apply simp
        apply (rule ccorres_return_Skip')
       apply (simp add: cap_get_tag_isCap_ArchObject[symmetric])
       apply (clarsimp simp: cap_lift_pdpt_cap cap_to_H_def
@@ -940,8 +941,7 @@ lemma isValidNativeRoot_spec:
          {t. \<forall>cap. ccap_relation cap (cap_' s) \<longrightarrow> ret__unsigned_long_' t = from_bool (isArchObjectCap cap \<and> isPML4Cap (capCap cap) \<and>
                                         capPML4MappedASID (capCap cap) \<noteq> None)}"
   apply (vcg, clarsimp)
-  apply (rule conjI, clarsimp simp: from_bool_def case_bool_If if_1_0_0
-                             split: if_split)
+  apply (rule conjI, clarsimp simp: case_bool_If split: if_split)
    apply (rule conjI; clarsimp simp: cap_pml4_cap_lift)
    apply (erule ccap_relationE, clarsimp simp: cap_to_H_def isCap_simps to_bool_def
                                         split: if_split_asm)
@@ -1176,7 +1176,7 @@ lemma decodeX64PageTableInvocation_ccorres:
                   apply (clarsimp simp: typ_heap_simps from_bool_eq_if)
                   apply (auto simp: cpde_relation_def Let_def pde_pde_pt_lift_def
                                     pde_pde_pt_lift pde_tag_defs pde_pde_large_lift_def
-                                    pde_lift_def from_bool_def case_bool_If
+                                    pde_lift_def case_bool_If
                              split: pde.split_asm if_splits)[1]
                  apply ceqv
                 apply clarsimp
@@ -1215,7 +1215,7 @@ lemma decodeX64PageTableInvocation_ccorres:
                apply vcg
               apply (rule conseqPre, vcg)
               apply (clarsimp simp: throwError_def return_def syscall_error_rel_def
-                                    syscall_error_to_H_cases exception_defs false_def)
+                                    syscall_error_to_H_cases exception_defs)
               apply (erule lookup_failure_rel_fault_lift[rotated])
               apply (clarsimp simp: exception_defs)
              apply clarsimp
@@ -1233,7 +1233,7 @@ lemma decodeX64PageTableInvocation_ccorres:
            apply simp
            apply (rule conseqPre, vcg)
            apply (clarsimp simp: throwError_def return_def syscall_error_rel_def
-                                 syscall_error_to_H_cases exception_defs false_def)
+                                 syscall_error_to_H_cases exception_defs)
            apply (erule lookup_failure_rel_fault_lift[rotated])
            apply (simp add: exception_defs)
           apply simp
@@ -1291,7 +1291,6 @@ lemma decodeX64PageTableInvocation_ccorres:
   apply (clarsimp simp: cap_lift_page_directory_cap hd_conv_nth
                         cap_lift_page_table_cap bit_simps
                         cap_page_directory_cap_lift_def
-                        to_bool_def
                         typ_heap_simps' shiftl_t2n[where n=3] field_simps
                  elim!: ccap_relationE)
   apply (clarsimp simp: neq_Nil_conv[where xs=extraCaps]
@@ -1371,8 +1370,7 @@ lemma checkVPAlignment_spec:
   apply (clarsimp simp: mask_eq_iff_w2p word_size)
   apply (rule conjI)
    apply (simp add: pageBitsForSize_def bit_simps split: vmpage_size.split)
-  apply (simp add: from_bool_def vmsz_aligned_def is_aligned_mask
-                   mask_def split: if_split)
+  apply (simp add: vmsz_aligned_def is_aligned_mask mask_def split: if_split)
   done
 
 definition
@@ -2014,14 +2012,14 @@ lemma createSafeMappingEntries_PTE_ccorres:
      apply (rule_tac P'="{s. lu_ret___struct_lookupPTSlot_ret_C = errstate s}" in ccorres_from_vcg_throws[where P=\<top>])
      apply (rule allI, rule conseqPre, vcg)
      apply (clarsimp simp: fst_throwError_returnOk syscall_error_to_H_cases
-                           syscall_error_rel_def exception_defs false_def)
+                           syscall_error_rel_def exception_defs)
      apply (erule lookup_failure_rel_fault_lift[rotated])
      apply (simp add: exception_defs)
     apply wpsimp
    apply (clarsimp simp: isVMPTE_def)
    apply (vcg exspec=lookupPTSlot_modifies)
   apply clarsimp
-  apply (clarsimp simp: cpte_relation_def Let_def vm_attribs_relation_def from_bool_def)
+  apply (clarsimp simp: cpte_relation_def Let_def vm_attribs_relation_def)
   apply (rule addrFromPPtr_mask_middle_pml4ShiftBits[simplified, simplified bit_simps])
    apply (clarsimp simp: vmsz_aligned_addrFromPPtr' vmsz_aligned_aligned_pageBits[simplified bit_simps])
   apply clarsimp
@@ -2091,8 +2089,8 @@ lemma createSafeMappingEntries_PDE_ccorres:
          apply clarsimp
          apply (erule cmap_relationE1[OF rf_sr_cpde_relation], erule ko_at_projectKO_opt)
          apply (clarsimp simp: typ_heap_simps cpde_relation_def Let_def)
-         apply (case_tac x; fastforce simp: if_1_0_0 pde_lifts isPageTablePDE_def false_def true_def
-                                            pde_pde_pt_lift_def)
+         apply (case_tac x;
+                fastforce simp: pde_lifts isPageTablePDE_def pde_pde_pt_lift_def)
         apply ceqv
        apply (clarsimp simp: pde_case_isPageTablePDE)
        apply (rule ccorres_Cond_rhs_Seq, clarsimp)
@@ -2109,7 +2107,7 @@ lemma createSafeMappingEntries_PDE_ccorres:
      apply (rule_tac P'="{s. lu_ret___struct_lookupPDSlot_ret_C = errstate s}" in ccorres_from_vcg_throws[where P=\<top>])
      apply (rule allI, rule conseqPre, vcg)
      apply (clarsimp simp: fst_throwError_returnOk syscall_error_to_H_cases
-                           syscall_error_rel_def exception_defs false_def)
+                           syscall_error_rel_def exception_defs)
      apply (erule lookup_failure_rel_fault_lift[rotated])
      apply (simp add: exception_defs)
     apply clarsimp
@@ -2120,8 +2118,7 @@ lemma createSafeMappingEntries_PDE_ccorres:
                         is_aligned_addrFromPPtr_pageBitsForSize[where sz=X64LargePage, simplified]
                         vmsz_aligned_def
                   dest!: addrFromPPtr_mask_middle_shiftBits[where sz=X64LargePage, simplified])
-  apply (clarsimp simp: bit_simps cpde_relation_def Let_def true_def false_def
-                        isPageTablePDE_def of_bool_from_bool
+  apply (clarsimp simp: bit_simps cpde_relation_def isPageTablePDE_def
                 split: pde.splits)
   done
 
@@ -2160,8 +2157,8 @@ lemma createSafeMappingEntries_PDPTE_ccorres:
          apply clarsimp
          apply (erule cmap_relationE1[OF rf_sr_cpdpte_relation], erule ko_at_projectKO_opt)
          apply (clarsimp simp: typ_heap_simps cpdpte_relation_def Let_def)
-         apply (case_tac x; fastforce simp: if_1_0_0 pdpte_lifts isPageDirectoryPDPTE_def false_def true_def
-                                            pdpte_pdpte_pd_lift_def)
+         apply (case_tac x;
+                fastforce simp: pdpte_lifts isPageDirectoryPDPTE_def pdpte_pdpte_pd_lift_def)
         apply ceqv
        apply (clarsimp simp: pdpte_case_isPageDirectoryPDPTE)
        apply (rule ccorres_Cond_rhs_Seq, clarsimp)
@@ -2178,7 +2175,7 @@ lemma createSafeMappingEntries_PDPTE_ccorres:
      apply (rule_tac P'="{s. lu_ret___struct_lookupPDPTSlot_ret_C = errstate s}" in ccorres_from_vcg_throws[where P=\<top>])
      apply (rule allI, rule conseqPre, vcg)
      apply (clarsimp simp: fst_throwError_returnOk syscall_error_to_H_cases
-                           syscall_error_rel_def exception_defs false_def)
+                           syscall_error_rel_def exception_defs)
      apply (erule lookup_failure_rel_fault_lift[rotated])
      apply (simp add: exception_defs)
     apply clarsimp
@@ -2189,8 +2186,7 @@ lemma createSafeMappingEntries_PDPTE_ccorres:
                         is_aligned_addrFromPPtr_pageBitsForSize[where sz=X64HugePage, simplified]
                         vmsz_aligned_def
                   dest!: addrFromPPtr_mask_middle_shiftBits[where sz=X64HugePage, simplified])
-  apply (clarsimp simp: bit_simps cpdpte_relation_def Let_def true_def false_def
-                        isPageDirectoryPDPTE_def of_bool_from_bool
+  apply (clarsimp simp: bit_simps cpdpte_relation_def isPageDirectoryPDPTE_def
                 split: pdpte.splits)
   done
 
@@ -2653,7 +2649,7 @@ lemma decodeX64FrameInvocation_ccorres:
                   apply (simp add: Collect_False if_to_top_of_bindE)
                   apply (rule ccorres_if_cond_throws[rotated -1, where Q=\<top> and Q'=\<top>])
                      apply vcg
-                    apply (clarsimp simp: cap_lift_pml4_cap cap_to_H_def get_capPtr_CL_def to_bool_def
+                    apply (clarsimp simp: cap_lift_pml4_cap cap_to_H_def get_capPtr_CL_def
                                           cap_pml4_cap_lift_def
                                    elim!: ccap_relationE split: if_split)
                    apply (rule syscall_error_throwError_ccorres_n[simplified id_def o_def dc_def])
@@ -2762,8 +2758,7 @@ lemma decodeX64FrameInvocation_ccorres:
                   apply vcg
                  apply (rule conseqPre, vcg)
                  apply (clarsimp simp: fst_throwError_returnOk exception_defs
-                                       syscall_error_rel_def syscall_error_to_H_cases
-                                       false_def)
+                                       syscall_error_rel_def syscall_error_to_H_cases)
                  apply (erule lookup_failure_rel_fault_lift[rotated])
                  apply (simp add: exception_defs)
                 apply (simp add: isCap_simps)
@@ -2865,7 +2860,7 @@ lemma decodeX64FrameInvocation_ccorres:
   apply (rename_tac pml4_cap b ys pml4_slot)
   apply (frule ccap_relation_PageCap_MapType)
   apply (erule_tac c="ArchObjectCap (PML4Cap a b)" for a b in ccap_relationE)
-  apply (clarsimp simp: cap_lift_pml4_cap to_bool_def cap_pml4_cap_lift_def framesize_from_to_H
+  apply (clarsimp simp: cap_lift_pml4_cap cap_pml4_cap_lift_def framesize_from_to_H
                            cap_to_H_def[split_simps cap_CL.split]
                            valid_cap'_def user_vtop_def X64.pptrUserTop_def)
   apply (prop_tac "(cap_C.words_C (cte_C.cap_C pml4_slot).[0] >> 58) && 1 \<noteq> 0")
@@ -3198,7 +3193,7 @@ lemma decodeX64PageDirectoryInvocation_ccorres:
                   apply (clarsimp simp: typ_heap_simps from_bool_eq_if)
                   apply (auto simp: cpdpte_relation_def Let_def pdpte_pdpte_pd_lift_def
                                     pdpte_pdpte_pd_lift pdpte_tag_defs pdpte_pdpte_1g_lift_def
-                                    pdpte_lift_def from_bool_def case_bool_If
+                                    pdpte_lift_def case_bool_If
                               split: pdpte.split_asm if_splits)[1]
                  apply ceqv
                 apply clarsimp
@@ -3237,7 +3232,8 @@ lemma decodeX64PageDirectoryInvocation_ccorres:
               apply (rule_tac P'="{s. errstate s = lookup_pd_ret}" in ccorres_from_vcg_split_throws[where P=\<top>])
                apply vcg
               apply (rule conseqPre, vcg)
-              apply (clarsimp simp: throwError_def return_def syscall_error_rel_def syscall_error_to_H_cases exception_defs false_def)
+              apply (clarsimp simp: throwError_def return_def syscall_error_rel_def
+                                    syscall_error_to_H_cases exception_defs)
               apply (erule lookup_failure_rel_fault_lift[rotated])
               apply (clarsimp simp: exception_defs)
              apply clarsimp
@@ -3254,7 +3250,7 @@ lemma decodeX64PageDirectoryInvocation_ccorres:
            apply simp
            apply (rule conseqPre, vcg)
            apply (clarsimp simp: throwError_def return_def syscall_error_rel_def
-                                 syscall_error_to_H_cases exception_defs false_def)
+                                 syscall_error_to_H_cases exception_defs)
            apply (erule lookup_failure_rel_fault_lift[rotated])
            apply (simp add: exception_defs)
           apply simp
@@ -3309,7 +3305,6 @@ lemma decodeX64PageDirectoryInvocation_ccorres:
   apply (clarsimp simp: cap_lift_pdpt_cap hd_conv_nth
                         cap_lift_page_directory_cap bit_simps
                         cap_pdpt_cap_lift_def
-                        to_bool_def
                         typ_heap_simps' shiftl_t2n[where n=3] field_simps
                  elim!: ccap_relationE)
   apply (clarsimp simp: neq_Nil_conv[where xs=extraCaps]
@@ -3704,7 +3699,8 @@ lemma decodeX64PDPTInvocation_ccorres:
            apply (rule_tac P'="{s. errstate s = find_ret}" in ccorres_from_vcg_split_throws[where P=\<top>])
             apply vcg
            apply (rule conseqPre, vcg)
-           apply (clarsimp simp: throwError_def return_def syscall_error_rel_def syscall_error_to_H_cases exception_defs false_def)
+           apply (clarsimp simp: throwError_def return_def syscall_error_rel_def
+                                 syscall_error_to_H_cases exception_defs)
            apply (erule lookup_failure_rel_fault_lift[rotated])
            apply (fastforce simp: exception_defs)
           apply clarsimp
@@ -3986,14 +3982,13 @@ lemma decodeX64MMUInvocation_ccorres:
                   apply (cut_tac P="\<lambda>y. y < i_' x + 1 = rhs y" for rhs in allI,
                          rule less_x_plus_1)
                    apply (fastforce simp: asid_high_bits_def)
-                  apply (clarsimp simp: rf_sr_x86KSASIDTable from_bool_def
+                  apply (clarsimp simp: rf_sr_x86KSASIDTable
                                         asid_high_bits_word_bits
                                         option_to_ptr_def option_to_0_def
                                         order_less_imp_le
                                         linorder_not_less
                                         order_antisym[OF inc_le])
-                  apply (clarsimp simp: true_def false_def
-                                 split: option.split if_split)
+                  apply (clarsimp split: option.split if_split)
                   apply (auto simp: asid_high_bits_def word_le_nat_alt
                                     word_less_nat_alt unat_add_lem[THEN iffD1]
                                     Kernel_C_defs)[1]
@@ -4012,8 +4007,7 @@ lemma decodeX64MMUInvocation_ccorres:
                 apply (clarsimp simp: asidHighBits_handy_convs word_sle_def
                                       word_sless_def from_bool_0
                                       rf_sr_x86KSASIDTable[where n=0, simplified])
-                apply (simp add: asid_high_bits_def option_to_ptr_def option_to_0_def
-                                 from_bool_def Kernel_C_defs
+                apply (simp add: asid_high_bits_def option_to_ptr_def option_to_0_def Kernel_C_defs
                           split: option.split if_split)
                 apply fastforce
                apply ceqv
@@ -4190,7 +4184,7 @@ lemma decodeX64MMUInvocation_ccorres:
        apply (frule (1) slotcap_in_mem_PML4)
        apply (clarsimp simp: typ_heap_simps' from_bool_0 split: if_split)
        apply (fastforce simp: isCap_simps asidInvalid_def cap_lift_pml4_cap cap_to_H_simps
-                              get_capMappedASID_CL_def true_def c_valid_cap_def cl_valid_cap_def
+                              get_capMappedASID_CL_def c_valid_cap_def cl_valid_cap_def
                         elim!: ccap_relationE split: if_splits)
       apply ceqv
      apply (rule ccorres_Cond_rhs_Seq)
@@ -4234,8 +4228,7 @@ lemma decodeX64MMUInvocation_ccorres:
         apply (rule ccorres_from_vcg_throws[where P=\<top> and P'=UNIV])
         apply (rule allI, rule conseqPre, vcg)
         apply (clarsimp simp: throwError_def return_def
-                              syscall_error_rel_def exception_defs
-                              syscall_error_to_H_cases false_def)
+                              syscall_error_rel_def exception_defs syscall_error_to_H_cases)
         apply (simp add: lookup_fault_lift_invalid_root)
        apply csymbr
        apply (simp add: liftME_def bindE_assoc if_to_top_of_bind)
@@ -4285,9 +4278,7 @@ lemma decodeX64MMUInvocation_ccorres:
                                      = capASIDBase cp")
               apply (subgoal_tac "\<And>x. (x < (i_' xb + 1))
                                         = (x < i_' xb \<or> x = i_' xb)")
-               apply (clarsimp simp: inc_le from_bool_def typ_heap_simps
-                                     asid_low_bits_def not_less field_simps
-                                     false_def
+               apply (clarsimp simp: inc_le typ_heap_simps asid_low_bits_def not_less field_simps
                               split: if_split bool.splits)
                apply unat_arith
               apply (rule iffI)
@@ -4341,11 +4332,10 @@ lemma decodeX64MMUInvocation_ccorres:
                                  word_sless_def word_sle_def)
            apply (erule cmap_relationE1[OF rf_sr_cpspace_asidpool_relation],
                   erule ko_at_projectKO_opt)
-           apply (clarsimp simp: typ_heap_simps from_bool_def split: if_split)
+           apply (clarsimp simp: typ_heap_simps split: if_split)
            apply (frule cap_get_tag_isCap_unfolded_H_cap)
            apply (clarsimp simp: cap_lift_asid_pool_cap cap_to_H_def
-                                 cap_asid_pool_cap_lift_def false_def
-                                 ucast_minus ucast_nat_def
+                                 cap_asid_pool_cap_lift_def ucast_minus ucast_nat_def
                           elim!: ccap_relationE)
           apply ceqv
          apply (rule ccorres_Guard_Seq)+
@@ -4471,8 +4461,8 @@ lemma decodeX64MMUInvocation_ccorres:
                         rf_sr_ksCurThread "StrictC'_thread_state_defs"
                         mask_def[where n=4]
                   cong: if_cong)
-  apply (clarsimp simp: to_bool_def ccap_relation_isDeviceCap2 objBits_simps
-                        archObjSize_def pageBits_def from_bool_def case_bool_If)
+  apply (clarsimp simp: ccap_relation_isDeviceCap2 objBits_simps
+                        archObjSize_def pageBits_def case_bool_If)
   apply (rule conjI)
    (* Is Asid Control Cap *)
    apply (clarsimp simp: neq_Nil_conv excaps_in_mem_def excaps_map_def)
@@ -4486,7 +4476,7 @@ lemma decodeX64MMUInvocation_ccorres:
                           hd_conv_nth length_ineq_not_Nil Kernel_C_defs
                    elim!: ccap_relationE)
    apply (clarsimp simp: to_bool_def unat_eq_of_nat
-                         objBits_simps archObjSize_def pageBits_def from_bool_def case_bool_If
+                         objBits_simps archObjSize_def pageBits_def case_bool_If
                   split: if_splits)
   apply (clarsimp simp: asid_low_bits_word_bits isCap_simps neq_Nil_conv
                         excaps_map_def excaps_in_mem_def
@@ -4497,15 +4487,14 @@ lemma decodeX64MMUInvocation_ccorres:
   apply (frule interpret_excaps_eq[rule_format, where n=0], simp)
   apply (rule conjI)
    apply (clarsimp simp: cap_lift_asid_pool_cap cap_lift_page_directory_cap
-                         cap_to_H_def to_bool_def valid_cap'_def
+                         cap_to_H_def valid_cap'_def
                          cap_page_directory_cap_lift_def
                          cap_asid_pool_cap_lift_def mask_def
                          asid_shiftr_low_bits_less[unfolded mask_def asid_bits_def] word_and_le1
                   elim!: ccap_relationE split: if_split_asm)
    apply (clarsimp split: list.split)
   apply (clarsimp simp: cap_lift_asid_pool_cap cap_lift_page_directory_cap
-                        cap_to_H_def to_bool_def
-                        cap_page_directory_cap_lift_def
+                        cap_to_H_def cap_page_directory_cap_lift_def
                  elim!: ccap_relationE split: if_split_asm)
   apply (erule rf_sr_cte_at_validD[rotated])
   apply (fastforce simp: slotcap_in_mem_def2)
@@ -5115,7 +5104,7 @@ lemma isIOPortRangeFree_spec:
                                                 !! unat (port && mask wordRadix))}"])
   apply (simp add: port_array_def)
   apply (rule conseqPre, vcg)
-    apply (all \<open>clarsimp simp: hrs_simps false_def from_bool_0 wordRadix_def is_up is_down
+    apply (all \<open>clarsimp simp: hrs_simps from_bool_0 wordRadix_def is_up is_down
                                unat_ucast_upcast uint_up_ucast sint_ucast_eq_uint up_ucast_inj_eq
                                not_max_word_simps[THEN ucast_increment]
                                ucast_cmp_ucast ucast_cmp_ucast[where 'a=16 and y="0x40", simplified]\<close>)

--- a/proof/crefine/X64/CLevityCatch.thy
+++ b/proof/crefine/X64/CLevityCatch.thy
@@ -10,6 +10,7 @@ imports
   ArchMove_C
   "CParser.LemmaBucket_C"
   "Lib.LemmaBucket"
+  Boolean_C
 begin
 
 context begin interpretation Arch . (*FIXME: arch_split*)

--- a/proof/crefine/X64/CSpace_All.thy
+++ b/proof/crefine/X64/CSpace_All.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2023, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -253,8 +254,7 @@ lemma lookupSlotForCNodeOp_ccorres':
    apply vcg
 
   \<comment> \<open>last subgoal\<close>
-  apply (clarsimp simp: if_1_0_0  to_bool_def true_def word_size
-                        fromIntegral_def integral_inv)
+  apply (clarsimp simp: word_size fromIntegral_def integral_inv)
   apply (case_tac "cap_get_tag root___struct_cap_C = scast cap_cnode_cap")
    prefer 2 apply clarsimp
   apply (clarsimp simp: unat_of_nat64 word_sle_def)
@@ -290,7 +290,7 @@ lemma lookupSourceSlot_ccorres':
      apply simp
     apply simp
    apply (ctac add: lookupSlotForCNodeOp_ccorres')
-  apply (clarsimp simp: to_bool_def true_def false_def)
+  apply clarsimp
   done
 
 lemma lookupSourceSlot_ccorres:
@@ -320,7 +320,7 @@ lemma lookupTargetSlot_ccorres':
      apply simp
     apply simp
    apply (ctac add: lookupSlotForCNodeOp_ccorres')
-  apply (clarsimp simp: to_bool_def true_def false_def)
+  apply clarsimp
   done
 
 lemma lookupTargetSlot_ccorres:
@@ -350,7 +350,7 @@ lemma lookupPivotSlot_ccorres:
      apply simp
     apply simp
    apply (ctac add: lookupSlotForCNodeOp_ccorres)
-  apply (clarsimp simp: to_bool_def true_def false_def)
+  apply clarsimp
   done
 
 end

--- a/proof/crefine/X64/CSpace_C.thy
+++ b/proof/crefine/X64/CSpace_C.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2023, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -127,10 +128,6 @@ lemma Arch_maskCapRights_ccorres [corres]:
    apply (cases arch_cap)
          by (fastforce simp add: cap_get_tag_isCap isCap_simps  simp del: not_ex simp_thms(44))+
 
-lemma to_bool_mask_to_bool_bf:
-  "to_bool (x && 1) = to_bool_bf (x::machine_word)"
-  by (simp add: to_bool_bf_def to_bool_def)
-
 lemma to_bool_cap_rights_bf:
   "to_bool (capAllowRead_CL (seL4_CapRights_lift R)) =
    to_bool_bf (capAllowRead_CL (seL4_CapRights_lift R))"
@@ -191,7 +188,7 @@ lemma maskCapRights_ccorres [corres]:
   apply csymbr
   apply (simp add: maskCapRights_cap_cases cap_get_tag_isCap del: Collect_const)
   apply wpc
-              apply (simp add: Collect_const_mem from_bool_def)
+              apply (simp add: Collect_const_mem)
               apply csymbr
               apply (simp add: cap_get_tag_isCap isCap_simps del: Collect_const)
               apply (simp add: ccorres_cond_iffs)
@@ -201,7 +198,7 @@ lemma maskCapRights_ccorres [corres]:
                apply vcg
               apply clarsimp
               apply (simp add: cap_get_tag_isCap isCap_simps return_def)
-             apply (simp add: Collect_const_mem from_bool_def)
+             apply (simp add: Collect_const_mem)
              apply csymbr
              apply (simp add: cap_get_tag_isCap isCap_simps del: Collect_const)
              apply (simp add: ccorres_cond_iffs)
@@ -210,7 +207,7 @@ lemma maskCapRights_ccorres [corres]:
              apply (rule conseqPre)
               apply vcg
              apply (clarsimp simp: return_def)
-            apply (simp add: Collect_const_mem from_bool_def)
+            apply (simp add: Collect_const_mem)
             apply csymbr
             apply (simp add: cap_get_tag_isCap isCap_simps del: Collect_const)
             apply (simp add: ccorres_cond_iffs)
@@ -236,7 +233,7 @@ lemma maskCapRights_ccorres [corres]:
             apply (simp add: ccap_rights_relation_def cap_rights_to_H_def
                              to_bool_ntfn_cap_bf
                              to_bool_mask_to_bool_bf to_bool_cap_rights_bf)
-           apply (simp add: Collect_const_mem from_bool_def)
+           apply (simp add: Collect_const_mem)
            apply csymbr
            apply (simp add: cap_get_tag_isCap isCap_simps ccorres_cond_iffs)
            apply (rule ccorres_from_vcg_throws [where P=\<top> and P'=UNIV])
@@ -244,7 +241,7 @@ lemma maskCapRights_ccorres [corres]:
            apply (rule conseqPre)
             apply vcg
            apply (clarsimp simp: cap_get_tag_isCap isCap_simps return_def)
-          apply (simp add: Collect_const_mem from_bool_def)
+          apply (simp add: Collect_const_mem)
           apply csymbr
           apply (simp add: cap_get_tag_isCap isCap_simps ccorres_cond_iffs)
           apply (rule ccorres_from_vcg_throws [where P=\<top> and P'=UNIV])
@@ -272,7 +269,7 @@ lemma maskCapRights_ccorres [corres]:
           apply (simp add: ccap_rights_relation_def cap_rights_to_H_def
                            to_bool_ep_cap_bf
                            to_bool_mask_to_bool_bf to_bool_cap_rights_bf)
-         apply (simp add: Collect_const_mem from_bool_def)
+         apply (simp add: Collect_const_mem)
          apply csymbr
          apply (simp add: cap_get_tag_isCap isCap_simps del: Collect_const)
          apply (simp add: ccorres_cond_iffs)
@@ -281,7 +278,7 @@ lemma maskCapRights_ccorres [corres]:
          apply (rule conseqPre)
           apply vcg
          apply (clarsimp simp: return_def)
-        apply (simp add: Collect_const_mem from_bool_def)
+        apply (simp add: Collect_const_mem)
         apply csymbr
         apply (simp add: cap_get_tag_isCap isCap_simps ccorres_cond_iffs)
         apply (rule ccorres_from_vcg_throws [where P=\<top> and P'=UNIV])
@@ -289,7 +286,7 @@ lemma maskCapRights_ccorres [corres]:
         apply (rule conseqPre)
          apply vcg
         apply (clarsimp simp: cap_get_tag_isCap isCap_simps return_def)
-       apply (simp add: Collect_const_mem from_bool_def)
+       apply (simp add: Collect_const_mem)
        apply (subst bind_return [symmetric])
        apply (rule ccorres_split_throws)
         apply ctac
@@ -302,7 +299,7 @@ lemma maskCapRights_ccorres [corres]:
          apply wp
         apply vcg
        apply vcg
-      apply (simp add: Collect_const_mem from_bool_def)
+      apply (simp add: Collect_const_mem)
       apply csymbr
       apply (simp add: cap_get_tag_isCap isCap_simps del: Collect_const)
       apply ccorres_rewrite
@@ -322,7 +319,7 @@ lemma maskCapRights_ccorres [corres]:
       apply (simp add: ccap_rights_relation_def cap_rights_to_H_def
                        to_bool_reply_cap_bf
                        to_bool_mask_to_bool_bf[simplified] to_bool_cap_rights_bf)
-     apply (simp add: Collect_const_mem from_bool_def)
+     apply (simp add: Collect_const_mem)
      apply csymbr
      apply (simp add: cap_get_tag_isCap isCap_simps del: Collect_const)
      apply (simp add: ccorres_cond_iffs)
@@ -331,7 +328,7 @@ lemma maskCapRights_ccorres [corres]:
      apply (rule conseqPre)
       apply vcg
      apply (clarsimp simp: return_def)
-    apply (simp add: Collect_const_mem from_bool_def)
+    apply (simp add: Collect_const_mem)
     apply csymbr
     apply (simp add: cap_get_tag_isCap isCap_simps del: Collect_const)
     apply (simp add: ccorres_cond_iffs)
@@ -341,7 +338,7 @@ lemma maskCapRights_ccorres [corres]:
      apply vcg
     apply clarsimp
     apply (simp add: cap_get_tag_isCap isCap_simps return_def)
-   apply (simp add: Collect_const_mem from_bool_def)
+   apply (simp add: Collect_const_mem)
    apply csymbr
    apply (simp add: cap_get_tag_isCap isCap_simps del: Collect_const)
    apply (simp add: ccorres_cond_iffs)
@@ -502,8 +499,7 @@ lemma Arch_isCapRevocable_spec:
         {t. \<forall>c c'.  ccap_relation c (derivedCap_' s) \<and> ccap_relation c' (srcCap_' s)
             \<longrightarrow> ret__unsigned_long_' t = from_bool (Arch.isCapRevocable c c')}"
   apply vcg
-  by (auto simp: false_def from_bool_def X64_H.isCapRevocable_def
-                 cap_get_tag_isCap_unfolded_H_cap cap_tag_defs isCap_simps
+  by (auto simp: X64_H.isCapRevocable_def cap_get_tag_isCap_unfolded_H_cap cap_tag_defs isCap_simps
                  cap_get_tag_isCap[unfolded cap_io_port_control_cap_def, simplified]
           split: capability.splits arch_capability.splits bool.splits)
 
@@ -512,7 +508,7 @@ lemmas isCapRevocable_simps[simp] = Retype_H.isCapRevocable_def[split_simps capa
 context begin (* revokable_ccorres *)
 
 private method revokable'_hammer = solves \<open>(
-              simp add: cap_get_tag_isCap isCap_simps ccorres_cond_iffs from_bool_def true_def false_def,
+              simp add: cap_get_tag_isCap isCap_simps ccorres_cond_iffs,
               rule ccorres_guard_imp,
               rule ccorres_return_C; clarsimp)\<close>
 
@@ -541,7 +537,7 @@ lemma revokable_ccorres:
     \<comment> \<open>Uninteresting caps\<close>
               apply revokable'_hammer+
     \<comment> \<open>NotificationCap\<close>
-            apply (simp add: cap_get_tag_isCap isCap_simps ccorres_cond_iffs from_bool_def true_def false_def)
+            apply (simp add: cap_get_tag_isCap isCap_simps ccorres_cond_iffs)
             apply (rule ccorres_guard_imp, (rule ccorres_rhs_assoc)+, csymbr, csymbr)
               apply (rule ccorres_return_C, clarsimp+)
             apply (frule_tac cap'1=srcCap in cap_get_tag_NotificationCap[THEN iffD1])
@@ -550,12 +546,12 @@ lemma revokable_ccorres:
              apply (clarsimp simp: cap_get_tag_isCap isCap_simps)
             apply (fastforce simp: cap_get_tag_isCap isCap_simps)
     \<comment> \<open>IRQHandlerCap\<close>
-           apply (simp add: cap_get_tag_isCap isCap_simps ccorres_cond_iffs from_bool_def true_def false_def)
+           apply (simp add: cap_get_tag_isCap isCap_simps ccorres_cond_iffs)
            apply (rule ccorres_guard_imp, csymbr)
              apply (rule ccorres_return_C, clarsimp+)
            apply (fastforce simp: cap_get_tag_isCap isCap_simps)
     \<comment> \<open>EndpointCap\<close>
-          apply (simp add: cap_get_tag_isCap isCap_simps ccorres_cond_iffs from_bool_def true_def false_def)
+          apply (simp add: cap_get_tag_isCap isCap_simps ccorres_cond_iffs)
           apply (rule ccorres_guard_imp, (rule ccorres_rhs_assoc)+, csymbr, csymbr)
             apply (rule ccorres_return_C, clarsimp+)
           apply (frule_tac cap'1=srcCap in cap_get_tag_EndpointCap[THEN iffD1])
@@ -1196,7 +1192,7 @@ lemma cteMove_ccorres:
    apply (clarsimp simp: cte_wp_at_ctes_of cteSizeBits_eq ctes_of_canonical ctes_of_aligned_bits)
    apply assumption
   apply (clarsimp simp: ccap_relation_NullCap_iff cmdbnode_relation_def
-                        mdb_node_to_H_def nullMDBNode_def false_def)
+                        mdb_node_to_H_def nullMDBNode_def)
   done
 
 (************************************************************************)
@@ -1523,8 +1519,8 @@ lemma emptySlot_helper:
                          mdbFirstBadged_CL (cteMDBNode_CL y)")
       prefer 2
       apply (drule cteMDBNode_CL_lift [symmetric])
-      subgoal by (simp add: mdb_node_lift_def mask_def word_bw_assocs)
-     subgoal by (simp add: to_bool_def mask_def)
+      subgoal by (simp add: mdb_node_lift_def word_bw_assocs)
+     subgoal by (simp add: to_bool_def)
    \<comment> \<open>\<dots> \<exists>x\<in>fst \<dots>\<close>
    apply clarsimp
    apply (rule fst_setCTE [OF ctes_of_cte_at], assumption )
@@ -1555,7 +1551,7 @@ lemma emptySlot_helper:
     prefer 2
     apply (drule cteMDBNode_CL_lift [symmetric])
     subgoal by (simp add: mdb_node_lift_def mask_def word_bw_assocs)
-   apply (simp add: to_bool_def mask_def split: if_split)
+   apply (simp add: to_bool_def split: if_split)
 
   \<comment> \<open>trivial case where mdbNext rva = 0\<close>
    apply (simp add:ccorres_cond_empty_iff)
@@ -1718,7 +1714,6 @@ lemma setIRQState_ccorres:
     apply wp
    apply (simp add: empty_fail_def getInterruptState_def simpler_gets_def)
   apply clarsimp
-  apply (simp add: from_bool_def)
   apply (cases irqState, simp_all)
   apply (simp add: Kernel_C.IRQSignal_def Kernel_C.IRQInactive_def)
   apply (simp add: Kernel_C.IRQTimer_def Kernel_C.IRQInactive_def)
@@ -2427,9 +2422,9 @@ lemma freeIOPortRange_ccorres:
   apply (cinit lift: first_port_' last_port_')
    apply (rule ccorres_Guard)
    apply (ctac add: setIOPortMask_ccorres)
-  by (clarsimp simp: false_def rf_sr_def cstate_relation_def Let_def carch_state_relation_def
-                        global_ioport_bitmap_relation_def typ_heap_simps
-                 split: if_splits)
+  by (clarsimp simp: rf_sr_def cstate_relation_def Let_def carch_state_relation_def
+                     global_ioport_bitmap_relation_def typ_heap_simps
+              split: if_splits)
 
 lemma Arch_postCapDeletion_ccorres:
   "ccorres dc xfdc
@@ -2587,7 +2582,7 @@ lemma emptySlot_ccorres:
             \<comment> \<open>Haskell pre/post for y \<leftarrow> updateCap slot capability.NullCap;\<close>
              apply wp
             \<comment> \<open>C       pre/post for y \<leftarrow> updateCap slot capability.NullCap;\<close>
-            apply (simp add: Collect_const_mem cmdbnode_relation_def mdb_node_to_H_def nullMDBNode_def false_def)
+            apply (simp add: Collect_const_mem cmdbnode_relation_def mdb_node_to_H_def nullMDBNode_def)
         \<comment> \<open>Haskell pre/post for the two nested updates\<close>
          apply wp
         \<comment> \<open>C       pre/post for the two nested updates\<close>
@@ -2743,7 +2738,7 @@ lemma Arch_sameRegionAs_spec:
   apply (cases capa; cases capb;
          frule (1) cap_get_tag[where cap'=cap_a]; (frule cap_lifts[where c=cap_a, THEN iffD1])?;
          frule (1) cap_get_tag[where cap'=cap_b]; (frule cap_lifts[where c=cap_b, THEN iffD1])?)
-  apply (simp_all add: cap_tag_defs isCap_simps from_bool_def true_def false_def if_0_1_eq)
+  apply (simp_all add: cap_tag_defs isCap_simps from_bool_def if_0_1_eq)
   apply (all \<open>clarsimp simp: ccap_relation_def cap_to_H_def
                              c_valid_cap_def cl_valid_cap_def Let_def\<close>)
    apply (simp add: cap_io_port_cap_lift_def'[simplified cap_tag_defs] mask_def
@@ -2987,8 +2982,7 @@ lemma cap_get_capIsPhysical_spec:
                                           cap_lift_asid_control_cap word_sle_def
                                           cap_lift_irq_control_cap cap_lift_null_cap
                                           mask_def objBits_simps cap_lift_domain_cap
-                                          ptr_add_assertion_positive from_bool_def
-                                          true_def false_def cap_get_tag_scast
+                                          ptr_add_assertion_positive cap_get_tag_scast
                                    dest!: sym [where t = "ucast (cap_get_tag cap)" for cap]
                                    split: vmpage_size.splits)+
   (* XXX: slow. there should be a rule for this *)
@@ -3072,22 +3066,23 @@ lemma sameRegionAs_spec:
   apply (simp add: sameRegionAs_def isArchCap_tag_def2 ccap_relation_c_valid_cap)
   apply (case_tac capa, simp_all add: cap_get_tag_isCap_unfolded_H_cap isCap_simps)
             \<comment> \<open>capa is a ThreadCap\<close>
-             apply (case_tac capb, simp_all add: cap_get_tag_isCap_unfolded_H_cap
-                          isCap_simps cap_tag_defs from_bool_def false_def)[1]
+             apply (case_tac capb,
+                    simp_all add: cap_get_tag_isCap_unfolded_H_cap isCap_simps cap_tag_defs)[1]
               apply (frule_tac cap'=cap_a in cap_get_tag_isCap_unfolded_H_cap(1))
               apply (frule_tac cap'=cap_b in cap_get_tag_isCap_unfolded_H_cap(1))
               apply (simp add: ccap_relation_def map_option_case)
               apply (simp add: cap_thread_cap_lift)
               apply (simp add: cap_to_H_def)
+              apply (clarsimp simp: from_bool_0 split: if_split)
              apply (clarsimp simp: case_bool_If ctcb_ptr_to_tcb_ptr_def if_distrib
                               cong: if_cong)
              apply (frule_tac cap'=cap_b in cap_get_tag_isArchCap_unfolded_H_cap)
              apply (clarsimp simp: isArchCap_tag_def2)
            \<comment> \<open>capa is a NullCap\<close>
-            apply (simp add: cap_tag_defs from_bool_def false_def)
+            apply (simp add: cap_tag_defs)
           \<comment> \<open>capa is an NotificationCap\<close>
-           apply (case_tac capb, simp_all add: cap_get_tag_isCap_unfolded_H_cap
-                        isCap_simps cap_tag_defs from_bool_def false_def)[1]
+           apply (case_tac capb,
+                  simp_all add: cap_get_tag_isCap_unfolded_H_cap isCap_simps cap_tag_defs)[1]
             apply (frule_tac cap'=cap_a in cap_get_tag_isCap_unfolded_H_cap(3))
             apply (frule_tac cap'=cap_b in cap_get_tag_isCap_unfolded_H_cap(3))
             apply (simp add: ccap_relation_def map_option_case)
@@ -3097,8 +3092,8 @@ lemma sameRegionAs_spec:
            apply (frule_tac cap'=cap_b in cap_get_tag_isArchCap_unfolded_H_cap)
            apply (clarsimp simp: isArchCap_tag_def2)
           \<comment> \<open>capa is an IRQHandlerCap\<close>
-          apply (case_tac capb, simp_all add: cap_get_tag_isCap_unfolded_H_cap
-                      isCap_simps cap_tag_defs from_bool_def false_def)[1]
+          apply (case_tac capb,
+                 simp_all add: cap_get_tag_isCap_unfolded_H_cap isCap_simps cap_tag_defs)[1]
            apply (frule_tac cap'=cap_a in cap_get_tag_isCap_unfolded_H_cap(5))
            apply (frule_tac cap'=cap_b in cap_get_tag_isCap_unfolded_H_cap(5))
            apply (simp add: ccap_relation_def map_option_case)
@@ -3113,34 +3108,34 @@ lemma sameRegionAs_spec:
           apply (clarsimp simp: isArchCap_tag_def2)
          \<comment> \<open>capa is an EndpointCap\<close>
          apply (case_tac capb, simp_all add: cap_get_tag_isCap_unfolded_H_cap
-                      isCap_simps cap_tag_defs from_bool_def false_def)[1]
+                                             isCap_simps cap_tag_defs)[1]
           apply (frule_tac cap'=cap_a in cap_get_tag_isCap_unfolded_H_cap(4))
           apply (frule_tac cap'=cap_b in cap_get_tag_isCap_unfolded_H_cap(4))
           apply (simp add: ccap_relation_def map_option_case)
           apply (simp add: cap_endpoint_cap_lift)
           apply (simp add: cap_to_H_def)
-          apply (clarsimp split: if_split)
+          apply (clarsimp simp: from_bool_0 split: if_split)
          apply (frule_tac cap'=cap_b in cap_get_tag_isArchCap_unfolded_H_cap)
          apply (clarsimp simp: isArchCap_tag_def2)
         \<comment> \<open>capa is a DomainCap\<close>
         apply (case_tac capb, simp_all add: cap_get_tag_isCap_unfolded_H_cap
-                     isCap_simps cap_tag_defs from_bool_def false_def true_def)[1]
+                                            isCap_simps cap_tag_defs)[1]
         apply (frule_tac cap'=cap_b in cap_get_tag_isArchCap_unfolded_H_cap)
         apply (fastforce simp: isArchCap_tag_def2 split: if_split)
        \<comment> \<open>capa is a Zombie\<close>
-       apply (simp add: cap_tag_defs from_bool_def false_def)
+       apply (simp add: cap_tag_defs)
       \<comment> \<open>capa is an Arch object cap\<close>
       apply (frule_tac cap'=cap_a in cap_get_tag_isArchCap_unfolded_H_cap)
       apply (clarsimp simp: isArchCap_tag_def2 cap_tag_defs linorder_not_less [THEN sym])
       apply (rule conjI, clarsimp, rule impI)+
       apply (case_tac capb, simp_all add: cap_get_tag_isCap_unfolded_H_cap
-                   isCap_simps cap_tag_defs from_bool_def false_def)[1]
+                                          isCap_simps cap_tag_defs)[1]
       \<comment> \<open>capb is an Arch object cap\<close>
       apply (frule_tac cap'=cap_b in cap_get_tag_isArchCap_unfolded_H_cap)
       apply (fastforce simp: isArchCap_tag_def2 cap_tag_defs linorder_not_less [THEN sym])
      \<comment> \<open>capa is a ReplyCap\<close>
      apply (case_tac capb, simp_all add: cap_get_tag_isCap_unfolded_H_cap
-                  isCap_simps cap_tag_defs from_bool_def false_def)[1]
+                                         isCap_simps cap_tag_defs)[1]
       apply (frule_tac cap'=cap_b in cap_get_tag_isArchCap_unfolded_H_cap)
       apply (clarsimp simp: isArchCap_tag_def2)
      apply (frule_tac cap'=cap_a in cap_get_tag_isCap_unfolded_H_cap(8))
@@ -3148,7 +3143,7 @@ lemma sameRegionAs_spec:
      apply (simp add: ccap_relation_def map_option_case)
      apply (simp add: cap_reply_cap_lift)
      apply (simp add: cap_to_H_def ctcb_ptr_to_tcb_ptr_def)
-     apply (clarsimp split: if_split)
+     apply (clarsimp simp: from_bool_0 split: if_split)
     \<comment> \<open>capa is an UntypedCap\<close>
     apply (frule_tac cap'=cap_a in cap_get_tag_isCap_unfolded_H_cap(9))
     apply (intro conjI)
@@ -3156,8 +3151,7 @@ lemma sameRegionAs_spec:
         apply (rule impI, drule(1) cap_get_tag_to_H)+
         apply (clarsimp simp: capAligned_def word_bits_conv
                               objBits_simps' get_capZombieBits_CL_def
-                              Let_def word_less_nat_alt
-                              less_mask_eq true_def
+                              Let_def word_less_nat_alt less_mask_eq
                        split: if_split_asm)
        apply (subgoal_tac "capBlockSize_CL (cap_untyped_cap_lift cap_a) \<le> 0x3F")
         apply (simp add: word_le_make_less)
@@ -3178,10 +3172,9 @@ lemma sameRegionAs_spec:
                                cap_untyped_cap_lift cap_to_H_def
                                field_simps valid_cap'_def)+)[4]
     apply (rule impI, simp add: from_bool_0 ccap_relation_get_capIsPhysical[symmetric])
-    apply (simp add: from_bool_def false_def)
    \<comment> \<open>capa is a CNodeCap\<close>
    apply (case_tac capb, simp_all add: cap_get_tag_isCap_unfolded_H_cap
-                isCap_simps cap_tag_defs from_bool_def false_def)[1]
+                                       isCap_simps cap_tag_defs)[1]
     apply (frule_tac cap'=cap_b in cap_get_tag_isArchCap_unfolded_H_cap)
     apply (clarsimp simp: isArchCap_tag_def2)
    apply (frule_tac cap'=cap_a in cap_get_tag_isCap_unfolded_H_cap(10))
@@ -3189,10 +3182,9 @@ lemma sameRegionAs_spec:
    apply (simp add: ccap_relation_def map_option_case)
    apply (simp add: cap_cnode_cap_lift)
    apply (simp add: cap_to_H_def)
-   apply (clarsimp split: if_split bool.split)
+   apply (clarsimp simp: from_bool_0 split: if_split bool.split)
   \<comment> \<open>capa is an IRQControlCap\<close>
-  apply (case_tac capb, simp_all add: cap_get_tag_isCap_unfolded_H_cap
-               isCap_simps cap_tag_defs from_bool_def false_def true_def)[1]
+  apply (case_tac capb, simp_all add: cap_get_tag_isCap_unfolded_H_cap isCap_simps cap_tag_defs)[1]
   apply (frule_tac cap'=cap_b in cap_get_tag_isArchCap_unfolded_H_cap)
   apply (fastforce simp: isArchCap_tag_def2 split: if_split)
   done
@@ -3228,7 +3220,7 @@ lemma ccap_relation_PageCap_IsDevice:
   apply (clarsimp simp: ccap_relation_def cap_to_H_def cap_lift_def cap_lift_defs cap_tag_defs
                         Let_def)
   apply (thin_tac _)+
-  by (clarsimp simp: to_bool_def mask_def word_and_1 split: if_splits)
+  by (clarsimp simp: word_and_1 split: if_splits)
 
 lemma ccap_relation_PageCap_Size:
   "ccap_relation (ArchObjectCap (PageCap p r t s d m)) ccap
@@ -3287,14 +3279,14 @@ lemma Arch_sameObjectAs_spec:
       apply (cases capa)
       apply (all \<open>frule (1) cap_get_tag[where cap'=cap_a]\<close>)
       apply (all \<open>(frule cap_lifts[where c=cap_a, THEN iffD1])?\<close>)
-      apply (all \<open>clarsimp simp: cap_tag_defs isCap_simps from_bool_def true_def false_def if_0_1_eq
+      apply (all \<open>clarsimp simp: cap_tag_defs isCap_simps
                           split: if_splits\<close>)
       apply (all \<open>fastforce?\<close>)
       (* IO ports and frames remain. *)
       apply (all \<open>cases capb\<close>)
       apply (all \<open>frule (1) cap_get_tag[where cap'=cap_b]\<close>)
       apply (all \<open>(frule cap_lifts[where c=cap_b, THEN iffD1])?\<close>)
-      apply (all \<open>clarsimp simp: cap_tag_defs isCap_simps from_bool_def true_def false_def if_0_1_eq
+      apply (all \<open>clarsimp simp: cap_tag_defs isCap_simps
                                  ccap_relation_PageCap_fields framesize_from_H_eq capAligned_def
                           split: if_splits\<close>)
       apply (all \<open>(fastforce simp: X64_H.sameRegionAs_def isCap_simps)?\<close>)
@@ -3311,8 +3303,7 @@ lemma sameObjectAs_spec:
   apply vcg
   apply (clarsimp simp: sameObjectAs_def isArchCap_tag_def2)
   apply (case_tac capa, simp_all add: cap_get_tag_isCap_unfolded_H_cap
-                                      isCap_simps cap_tag_defs
-                                      from_bool_def false_def)
+                                      isCap_simps cap_tag_defs)
             apply fastforce+
      \<comment> \<open>capa is an arch cap\<close>
      apply (frule cap_get_tag_isArchCap_unfolded_H_cap)
@@ -3392,7 +3383,7 @@ lemma isMDBParentOf_spec:
      apply (simp add: ccte_relation_def map_option_case)
      apply (simp add: cte_lift_def)
      apply (clarsimp simp: cte_to_H_def mdb_node_to_H_def split: option.split_asm)
-     apply (clarsimp simp: Let_def false_def from_bool_def to_bool_def
+     apply (clarsimp simp: Let_def to_bool_def
                     split: if_split bool.splits)
      apply ((clarsimp simp: typ_heap_simps dest!: lift_t_g)+)[3]
   apply (rule_tac x="cteCap ctea" in exI, rule conjI)
@@ -3409,11 +3400,11 @@ lemma isMDBParentOf_spec:
   apply (rule conjI)
    \<comment> \<open>sameRegionAs = 0\<close>
    apply (rule impI)
-   apply (clarsimp simp: from_bool_def false_def
+   apply (clarsimp simp: from_bool_def
                   split: if_split bool.splits)
 
   \<comment> \<open>sameRegionAs \<noteq> 0\<close>
-  apply (clarsimp simp: from_bool_def false_def)
+  apply (clarsimp simp: from_bool_def)
   apply (clarsimp cong:bool.case_cong if_cong simp: typ_heap_simps)
 
   apply (rule conjI)
@@ -3421,8 +3412,7 @@ lemma isMDBParentOf_spec:
    apply clarsimp
    apply (frule cap_get_tag_EndpointCap)
    apply simp
-   apply (clarsimp simp: to_bool_def isNotificationCap_def isEndpointCap_def true_def) \<comment> \<open>badge of A is not 0 now\<close>
-
+   apply (clarsimp simp: to_bool_def isNotificationCap_def isEndpointCap_def) \<comment> \<open>badge of A is not 0 now\<close>
 
    apply (subgoal_tac "cap_get_tag (cte_C.cap_C cte_b) = scast cap_endpoint_cap") \<comment> \<open>needed also after\<close>
     prefer 2
@@ -3437,8 +3427,7 @@ lemma isMDBParentOf_spec:
    apply clarsimp
    apply (frule cap_get_tag_NotificationCap)
    apply simp
-   apply (clarsimp simp: to_bool_def isNotificationCap_def isEndpointCap_def true_def) \<comment> \<open>badge of A is not 0 now\<close>
-
+   apply (clarsimp simp: to_bool_def isNotificationCap_def isEndpointCap_def) \<comment> \<open>badge of A is not 0 now\<close>
 
    apply (subgoal_tac "cap_get_tag (cte_C.cap_C cte_b) = scast cap_notification_cap") \<comment> \<open>needed also after\<close>
     prefer 2
@@ -3454,7 +3443,7 @@ lemma isMDBParentOf_spec:
   apply clarsimp
   apply (simp add: to_bool_def)
   apply (subgoal_tac "(\<not> (isEndpointCap (cap_to_H x2b))) \<and> ( \<not> (isNotificationCap (cap_to_H x2b)))")
-   apply (clarsimp simp: true_def)
+   apply clarsimp
   apply (clarsimp simp: cap_get_tag_isCap [symmetric])
   done
 
@@ -3470,7 +3459,7 @@ lemma updateCapData_spec:
   apply (simp add: updateCapData_def)
 
   apply (case_tac cap, simp_all add: cap_get_tag_isCap_unfolded_H_cap
-                        isCap_simps from_bool_def isArchCap_tag_def2 cap_tag_defs Let_def)
+                                     isCap_simps isArchCap_tag_def2 cap_tag_defs Let_def)
   \<comment> \<open>NotificationCap\<close>
      apply clarsimp
      apply (frule cap_get_tag_isCap_unfolded_H_cap(3))
@@ -3597,7 +3586,6 @@ lemma ensureNoChildren_ccorres:
    apply (rule conjI)
    \<comment> \<open>isMDBParentOf is not zero\<close>
     apply clarsimp
-    apply (simp add: from_bool_def)
     apply (case_tac "isMDBParentOf (cte_to_H y) (cte_to_H ya)", simp_all)[1]
 
     apply (simp add: bind_def)
@@ -3608,7 +3596,6 @@ lemma ensureNoChildren_ccorres:
     apply (simp add: syscall_error_to_H_cases(9))
    \<comment> \<open>isMDBParentOf is zero\<close>
    apply clarsimp
-   apply (simp add: from_bool_def)
    apply (case_tac "isMDBParentOf (cte_to_H y) (cte_to_H ya)", simp_all)[1]
    apply (simp add: bind_def)
    apply (simp add: split_paired_Bex)
@@ -3783,7 +3770,7 @@ lemma deriveCap_ccorres':
    apply csymbr
    apply (fold case_bool_If)
    apply wpc
-    apply (clarsimp simp: cap_get_tag_isCap isCap_simps from_bool_def)
+    apply (clarsimp simp: cap_get_tag_isCap isCap_simps)
     apply csymbr
     apply (clarsimp simp: cap_get_tag_isCap)
     apply (rule ccorres_from_vcg_throws [where P=\<top> and P' = UNIV])
@@ -3792,7 +3779,7 @@ lemma deriveCap_ccorres':
      apply vcg
     apply clarsimp
    apply wpc
-    apply (clarsimp simp: isCap_simps cap_get_tag_isCap from_bool_def)
+    apply (clarsimp simp: isCap_simps cap_get_tag_isCap)
     apply csymbr
     apply (clarsimp simp: isCap_simps cap_get_tag_isCap)
     apply (rule ccorres_from_vcg_throws[where P=\<top> and P'=UNIV])
@@ -3800,7 +3787,7 @@ lemma deriveCap_ccorres':
     apply (clarsimp simp: returnOk_def return_def
                           ccap_relation_NullCap_iff)
    apply wpc
-    apply (clarsimp simp: isCap_simps cap_get_tag_isCap from_bool_def)
+    apply (clarsimp simp: isCap_simps cap_get_tag_isCap)
     apply csymbr
     apply (clarsimp simp: isCap_simps cap_get_tag_isCap)
     apply (rule ccorres_rhs_assoc)+
@@ -3823,7 +3810,7 @@ lemma deriveCap_ccorres':
                            errstate_def)
     apply wp
    apply wpc
-    apply (clarsimp simp: isCap_simps cap_get_tag_isCap from_bool_def)
+    apply (clarsimp simp: isCap_simps cap_get_tag_isCap)
     apply csymbr
     apply (clarsimp simp: isCap_simps cap_get_tag_isCap)
     apply (rule ccorres_from_vcg_throws[where P=\<top> and P'=UNIV])
@@ -3837,7 +3824,7 @@ lemma deriveCap_ccorres':
      apply vcg
     apply (clarsimp simp: cap_get_tag_isCap
                           liftME_def Let_def isArchCap_T_isArchObjectCap
-                          ccorres_cond_univ_iff from_bool_def)
+                          ccorres_cond_univ_iff)
     apply (rule ccorres_add_returnOk)
     apply (rule ccorres_split_nothrow_call_novcgE
                     [where xf'=ret__struct_deriveCap_ret_C_'])
@@ -3855,7 +3842,7 @@ lemma deriveCap_ccorres':
      apply (rule allI, rule conseqPre, vcg)
      apply (clarsimp simp: return_def throwError_def)
     apply wp
-   apply (simp add: cap_get_tag_isCap isArchCap_T_isArchObjectCap from_bool_def)
+   apply (simp add: cap_get_tag_isCap isArchCap_T_isArchObjectCap)
    apply csymbr
    apply (simp add: cap_get_tag_isCap)
    apply (rule ccorres_from_vcg_throws[where P=\<top> and P'=UNIV])
@@ -3865,7 +3852,6 @@ lemma deriveCap_ccorres':
                         Collect_const_mem from_bool_0
                         cap_get_tag_isArchCap_unfolded_H_cap)
   done
-
 
 lemma deriveCap_ccorres:
   "ccorres (syscall_error_rel \<currency> ccap_relation) deriveCap_xf

--- a/proof/crefine/X64/CSpace_RAB_C.thy
+++ b/proof/crefine/X64/CSpace_RAB_C.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2023, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -222,7 +223,7 @@ next
        apply (vcg strip_guards=true) \<comment> \<open>takes a while\<close>
        apply clarsimp
       apply simp
-     apply (clarsimp simp: cap_get_tag_isCap to_bool_def)
+     apply (clarsimp simp: cap_get_tag_isCap)
   \<comment> \<open>Main thm\<close>
   proof (induct cap' cptr' guard' rule: resolveAddressBits.induct [case_names ind])
     case (ind cap cptr guard)
@@ -562,8 +563,8 @@ lemma rightsFromWord_spec:
   \<lbrace>seL4_CapRights_lift \<acute>ret__struct_seL4_CapRights_C = cap_rights_from_word_canon \<^bsup>s\<^esup>w \<rbrace>"
   apply vcg
   apply (simp add: seL4_CapRights_lift_def nth_shiftr mask_shift_simps nth_shiftr
-    cap_rights_from_word_canon_def from_bool_def word_and_1 eval_nat_numeral
-    word_sless_def word_sle_def)
+                   cap_rights_from_word_canon_def word_and_1 eval_nat_numeral
+                   word_sless_def word_sle_def)
   done
 
 
@@ -577,12 +578,6 @@ lemma cap_rights_to_H_from_word_canon [simp]:
   apply (simp add: cap_rights_from_word_canon_def)
   apply (simp add: cap_rights_to_H_def)
   done
-
-(* MOVE *)
-lemma to_bool_false [simp]:
-  "to_bool false = False"
-  unfolding to_bool_def false_def
-  by simp
 
 lemma tcb_ptr_to_ctcb_ptr_mask [simp]:
   assumes tcbat: "tcb_at' thread s"

--- a/proof/crefine/X64/Delete_C.thy
+++ b/proof/crefine/X64/Delete_C.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2023, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -147,7 +148,7 @@ lemma capRemovable_spec:
   supply if_cong[cong]
   apply vcg
   apply (clarsimp simp: cap_get_tag_isCap(1-8)[THEN trans[OF eq_commute]])
-  apply (simp add: capRemovable_def from_bool_def[where b=True] true_def)
+  apply (simp add: capRemovable_def)
   apply (clarsimp simp: ccap_zombie_radix_less4)
   apply (subst eq_commute, subst from_bool_eq_if)
   apply (rule exI, rule conjI, assumption)
@@ -648,7 +649,7 @@ lemma reduceZombie_ccorres1:
       apply (rule ccorres_inst[where P=\<top> and P'=UNIV])
       apply simp
      apply (simp add: guard_is_UNIV_def Collect_const_mem)
-     apply (clarsimp simp: from_bool_def false_def isCap_simps size_of_def cte_level_bits_def)
+     apply (clarsimp simp: isCap_simps size_of_def cte_level_bits_def)
      apply (simp only: word_bits_def unat_of_nat unat_arith_simps, simp)
     apply (simp add: guard_is_UNIV_def)+
   apply (clarsimp simp: cte_wp_at_ctes_of)
@@ -730,8 +731,7 @@ lemma finaliseSlot_ccorres:
         apply (rule ccorres_drop_cutMon)
         apply (rule ccorres_from_vcg_throws[where P=\<top> and P'=UNIV])
         apply (rule allI, rule conseqPre, vcg)
-        apply (clarsimp simp: returnOk_def return_def
-                              from_bool_def true_def ccap_relation_NullCap_iff)
+        apply (clarsimp simp: returnOk_def return_def ccap_relation_NullCap_iff)
        apply (simp add: Collect_True liftE_bindE split_def
                         ccorres_cond_iffs cutMon_walk_bind
                    del: Collect_const cong: call_ignore_cong)
@@ -768,8 +768,7 @@ lemma finaliseSlot_ccorres:
               apply (rule_tac P="\<lambda>s. cleanup_info_wf' (snd rvb)"
                               in ccorres_from_vcg_throws[where P'=UNIV])
               apply (rule allI, rule conseqPre, vcg)
-              apply (clarsimp simp: returnOk_def return_def
-                                    from_bool_def true_def)
+              apply (clarsimp simp: returnOk_def return_def)
               apply (clarsimp simp: cleanup_info_wf'_def arch_cleanup_info_wf'_def
                              split: if_split capability.splits)
              apply vcg
@@ -806,11 +805,11 @@ lemma finaliseSlot_ccorres:
                   apply (rule allI, rule conseqPre, vcg)
                   apply (clarsimp simp: returnOk_def return_def)
                   apply (drule use_valid [OF _ finaliseCap_cases, OF _ TrueI])
-                  apply (simp add: from_bool_def false_def irq_opt_relation_def true_def
+                  apply (simp add: irq_opt_relation_def
                             split: if_split_asm)
                  apply vcg
                 apply wp
-               apply (simp add: guard_is_UNIV_def true_def)
+               apply (simp add: guard_is_UNIV_def)
               apply wp
              apply (simp add: guard_is_UNIV_def)
             apply (simp only: liftE_bindE cutMon_walk_bind Let_def
@@ -835,7 +834,6 @@ lemma finaliseSlot_ccorres:
                                in ccorres_from_vcg[where P'=UNIV])
                   apply (rule allI, rule conseqPre, vcg)
                   apply (clarsimp simp: return_def)
-                  apply (simp add: from_bool_def false_def)
                   apply fastforce
                  apply ceqv
                 apply (simp only: from_bool_0 simp_thms Collect_False
@@ -910,7 +908,7 @@ lemma finaliseSlot_ccorres:
                       simp: isCap_simps final_matters'_def o_def)
         apply clarsimp
         apply (frule valid_globals_cte_wpD'[rotated], clarsimp)
-        apply (clarsimp simp: cte_wp_at_ctes_of false_def from_bool_def)
+        apply (clarsimp simp: cte_wp_at_ctes_of)
         apply (erule(1) cmap_relationE1 [OF cmap_relation_cte])
         apply (frule valid_global_refsD_with_objSize, clarsimp)
         apply (auto simp: typ_heap_simps dest!: ccte_relation_ccap_relation)[1]
@@ -1036,9 +1034,8 @@ lemma cteRevoke_ccorres1:
         apply (rule ccorres_from_vcg_throws[where P=\<top> and P'=UNIV])
         apply (rule allI, rule conseqPre, vcg)
         apply (clarsimp simp: returnOk_def return_def)
-       apply (simp add: guard_is_UNIV_def from_bool_def true_def cintr_def
-                        Collect_const_mem exception_defs)
-      apply (simp add: guard_is_UNIV_def from_bool_def true_def)
+       apply (simp add: guard_is_UNIV_def cintr_def Collect_const_mem exception_defs)
+      apply (simp add: guard_is_UNIV_def)
      apply (rule getCTE_wp)
     apply (clarsimp simp: cte_wp_at_ctes_of nullPointer_def)
     apply (drule invs_mdb')

--- a/proof/crefine/X64/Finalise_C.thy
+++ b/proof/crefine/X64/Finalise_C.thy
@@ -1969,10 +1969,9 @@ lemma ccap_relation_PDPT_IsMapped:
   "ccap_relation (ArchObjectCap (PDPointerTableCap x1 x2)) cap \<Longrightarrow>
      capPDPTIsMapped_CL (cap_pdpt_cap_lift cap) = from_bool (\<not> Option.is_none x2)"
   apply (frule cap_get_tag_isCap_unfolded_H_cap)
-  apply (clarsimp simp: ccap_relation_def cap_to_H_def cap_pdpt_cap_lift_def cap_lift_def Let_def
-                        cap_tag_defs to_bool_def true_def
-                  split: if_split)
-  apply word_bitwise
+  apply (clarsimp simp: ccap_relation_def cap_to_H_def cap_pdpt_cap_lift_def cap_lift_def
+                        cap_tag_defs to_bool_def
+                 split: if_split)
   done
 
 lemma ccap_relation_PML4_IsMapped:
@@ -1980,9 +1979,8 @@ lemma ccap_relation_PML4_IsMapped:
      capPML4IsMapped_CL (cap_pml4_cap_lift cap) = from_bool (\<not> Option.is_none x2)"
   apply (frule cap_get_tag_isCap_unfolded_H_cap)
   apply (clarsimp simp: ccap_relation_def cap_to_H_def cap_pml4_cap_lift_def cap_lift_def
-                        cap_tag_defs to_bool_def true_def
-                  split: if_split)
-  apply word_bitwise
+                        cap_tag_defs to_bool_def
+                 split: if_split)
   done
 
 lemma if_case_opt_same_branches:

--- a/proof/crefine/X64/Finalise_C.thy
+++ b/proof/crefine/X64/Finalise_C.thy
@@ -1810,22 +1810,6 @@ lemma cnotification_relation_udpate_arch:
   apply (safe ; case_tac "xa = p" ; clarsimp simp: option_map2_def map_option_case)
   done
 
-lemma sanitiseSetRegister_ccorres:
-  "\<lbrakk> val = val'; reg' = register_from_H reg\<rbrakk> \<Longrightarrow>
-     ccorres dc xfdc (tcb_at' tptr)
-                      UNIV
-                      hs
-             (asUser tptr (setRegister reg (local.sanitiseRegister False reg val)))
-             (\<acute>unsigned_long_eret_2 :== CALL sanitiseRegister(reg',val',0);;
-              CALL setRegister(tcb_ptr_to_ctcb_ptr tptr,reg',\<acute>unsigned_long_eret_2))"
-  apply (rule ccorres_guard_imp2)
-   apply (rule ccorres_symb_exec_r)
-     apply (ctac add: setRegister_ccorres)
-    apply (vcg)
-   apply (rule conseqPre, vcg)
-   apply (fastforce simp: sanitiseRegister_def split: register.splits)
-  by (auto simp: sanitiseRegister_def from_bool_def simp del: Collect_const split: register.splits bool.splits)
-
 lemma case_option_both[simp]:
   "(case f of None \<Rightarrow> P | _ \<Rightarrow> P) = P"
   by (auto split: option.splits)

--- a/proof/crefine/X64/Finalise_C.thy
+++ b/proof/crefine/X64/Finalise_C.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2023, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -878,7 +879,7 @@ lemma finaliseCap_True_cases_ccorres:
    apply csymbr
    apply (simp add: cap_get_tag_isCap Collect_False del: Collect_const)
    apply (fold case_bool_If)
-   apply (simp add: false_def)
+   apply simp
    apply csymbr
    apply wpc
     apply (simp add: cap_get_tag_isCap ccorres_cond_univ_iff Let_def)
@@ -1098,7 +1099,7 @@ lemma deleteASIDPool_ccorres:
                 apply (drule_tac x="of_nat n" in spec)+
                 apply (simp add: asid_low_bits_def word_le_nat_alt)
                 apply (simp add: word_unat.Abs_inverse unats_def)
-                apply (clarsimp simp: asid_map_relation_def false_def asid_map_tag_defs
+                apply (clarsimp simp: asid_map_relation_def asid_map_tag_defs
                                       asid_map_lift_def Let_def
                                split: option.split_asm asid_map_CL.split_asm if_splits)
                apply (rule ccorres_rhs_assoc)+
@@ -1223,7 +1224,7 @@ lemma deleteASID_ccorres:
         apply (simp add: asid_low_bits_def Kernel_C.asidLowBits_def
                          mask_def word_and_le1 asid_map_relation_def)
         apply (rule conjI, fastforce simp: asid_map_lifts from_bool_def case_bool_If inv_ASIDPool)
-        apply (fastforce simp: from_bool_def case_bool_If inv_ASIDPool asid_map_lift_def
+        apply (fastforce simp: case_bool_If inv_ASIDPool asid_map_lift_def
                        split: option.split_asm asid_map_CL.split_asm if_split_asm)
        apply ceqv
       apply (rule ccorres_cond2[where R=\<top>])
@@ -1534,7 +1535,7 @@ lemma isFinalCapability_ccorres:
            apply (simp add: mdbPrev_to_H[symmetric])
           apply (rule ccorres_from_vcg[where P=\<top> and P'=UNIV])
           apply (rule allI, rule conseqPre, vcg)
-          apply (simp add: return_def from_bool_def false_def)
+          apply (simp add: return_def)
          apply (rule ccorres_rhs_assoc)+
          apply (rule ccorres_symb_exec_l[OF _ getCTE_inv getCTE_wp empty_fail_getCTE])
          apply (rule_tac P="cte_wp_at' ((=) cte) slot
@@ -1573,10 +1574,9 @@ lemma isFinalCapability_ccorres:
        apply (rule cmap_relationE1 [OF cmap_relation_cte], assumption+,
                   simp?, simp add: typ_heap_simps)+
        apply (drule ccte_relation_ccap_relation)+
-       apply (auto simp: false_def true_def from_bool_def split: bool.splits)[1]
+       apply (auto simp: from_bool_def split: bool.splits)[1]
       apply (wp getCTE_wp')
-     apply (clarsimp simp add: guard_is_UNIV_def Collect_const_mem false_def
-                               from_bool_0 true_def from_bool_def)
+     apply (clarsimp simp add: guard_is_UNIV_def Collect_const_mem)
     apply vcg
    apply (rule conseqPre, vcg)
    apply clarsimp
@@ -1634,13 +1634,12 @@ lemma cteDeleteOne_ccorres:
         apply (strengthen invs_mdb_strengthen' invs_urz)
         apply (wp typ_at_lifts isFinalCapability_inv
             | strengthen invs_valid_objs')+
-       apply (clarsimp simp: from_bool_def true_def irq_opt_relation_def
-                             invs_pspace_aligned' cte_wp_at_ctes_of)
+       apply (clarsimp simp: irq_opt_relation_def invs_pspace_aligned' cte_wp_at_ctes_of)
        apply (erule(1) cmap_relationE1 [OF cmap_relation_cte])
        apply (clarsimp simp: typ_heap_simps ccte_relation_ccap_relation ccap_relation_NullCap_iff)
       apply (wp isFinalCapability_inv)
      apply simp
-    apply (simp del: Collect_const add: false_def)
+    apply (simp del: Collect_const)
    apply (rule ccorres_return_Skip)
   apply (clarsimp simp: Collect_const_mem cte_wp_at_ctes_of)
   apply (erule(1) cmap_relationE1 [OF cmap_relation_cte])
@@ -1936,7 +1935,7 @@ lemma unmapPDPointerTable_ccorres:
           apply (erule ko_at_projectKO_opt)
          apply (rename_tac pml4e_C)
          apply (fastforce simp: typ_heap_simps cpml4e_relation_def Let_def
-                                isPDPointerTablePML4E_def from_bool_def
+                                isPDPointerTablePML4E_def
                           split: bool.splits if_split pml4e.split_asm)
         apply ceqv
        apply (rule ccorres_Cond_rhs_Seq)
@@ -1971,7 +1970,7 @@ lemma ccap_relation_PDPT_IsMapped:
      capPDPTIsMapped_CL (cap_pdpt_cap_lift cap) = from_bool (\<not> Option.is_none x2)"
   apply (frule cap_get_tag_isCap_unfolded_H_cap)
   apply (clarsimp simp: ccap_relation_def cap_to_H_def cap_pdpt_cap_lift_def cap_lift_def Let_def
-                        cap_tag_defs to_bool_def true_def false_def
+                        cap_tag_defs to_bool_def true_def
                   split: if_split)
   apply word_bitwise
   done
@@ -1980,8 +1979,8 @@ lemma ccap_relation_PML4_IsMapped:
   "ccap_relation (ArchObjectCap (PML4Cap x1 x2)) cap \<Longrightarrow>
      capPML4IsMapped_CL (cap_pml4_cap_lift cap) = from_bool (\<not> Option.is_none x2)"
   apply (frule cap_get_tag_isCap_unfolded_H_cap)
-  apply (clarsimp simp: ccap_relation_def cap_to_H_def cap_pml4_cap_lift_def cap_lift_def Let_def
-                        cap_tag_defs to_bool_def true_def false_def
+  apply (clarsimp simp: ccap_relation_def cap_to_H_def cap_pml4_cap_lift_def cap_lift_def
+                        cap_tag_defs to_bool_def true_def
                   split: if_split)
   apply word_bitwise
   done
@@ -2033,7 +2032,7 @@ lemma Mode_finaliseCap_ccorres_pdpt:
                    R'=UNIV
                    in ccorres_symb_exec_r_known_rv_UNIV)
       apply (vcg exspec=unmapPDPT_modifies)
-      apply (fastforce simp: false_def cap_get_tag_isCap_unfolded_H_cap
+      apply (fastforce simp: cap_get_tag_isCap_unfolded_H_cap
                              ccap_relation_PDPT_IsMapped from_bool_eq_if')
      apply ceqv
     apply (rule ccorres_Cond_rhs_Seq)
@@ -2095,7 +2094,7 @@ lemma Mode_finaliseCap_ccorres_pml4:
                    R'=UNIV
                    in ccorres_symb_exec_r_known_rv_UNIV)
       apply vcg
-      apply (fastforce simp: false_def cap_get_tag_isCap_unfolded_H_cap
+      apply (fastforce simp: cap_get_tag_isCap_unfolded_H_cap
                              ccap_relation_PML4_IsMapped from_bool_eq_if')
      apply ceqv
     apply (rule ccorres_Cond_rhs_Seq)
@@ -2148,7 +2147,7 @@ lemma Mode_finaliseCap_ccorres_page_cap:
                             od)
      (Call Mode_finaliseCap_'proc)"
   supply Collect_const[simp del]
-  apply (cinit' lift: cap_' simp: false_def)
+  apply (cinit' lift: cap_')
    apply csymbr
    apply (clarsimp simp: cap_get_tag_isCap_unfolded_H_cap cap_tag_defs)
    apply ccorres_rewrite
@@ -2236,7 +2235,7 @@ lemma Arch_finaliseCap_ccorres:
           apply (clarsimp simp: return_def)
          apply wp
         apply fastforce
-       apply (fastforce simp: false_def)
+       apply fastforce
       \<comment> \<open>PML4Cap\<close>
       apply (rule ccorres_guard_imp)
         apply (rule ccorres_add_return2)
@@ -2246,7 +2245,7 @@ lemma Arch_finaliseCap_ccorres:
          apply (clarsimp simp: return_def)
         apply wp
        apply fastforce
-      apply (fastforce simp: false_def)
+      apply fastforce
      \<comment> \<open>PageCap\<close>
      apply (clarsimp simp: isCap_simps)
      apply (rule ccorres_guard_imp[where A="?abstract_pre" and A'=UNIV])
@@ -2298,7 +2297,7 @@ lemma Arch_finaliseCap_ccorres:
      apply (frule cap_get_tag_isCap_unfolded_H_cap)
      apply (frule cap_lift_page_directory_cap)
      apply (clarsimp simp: ccap_relation_def cap_to_H_def capAligned_def
-                           to_bool_def cap_page_directory_cap_lift_def
+                           cap_page_directory_cap_lift_def
                            asid_bits_def
                     split: if_split_asm)
     apply simp
@@ -2342,8 +2341,7 @@ lemma Arch_finaliseCap_ccorres:
      apply (frule cap_get_tag_isCap_unfolded_H_cap)
      apply (frule cap_lift_page_table_cap)
      apply (clarsimp simp: ccap_relation_def cap_to_H_def capAligned_def
-                           to_bool_def cap_page_table_cap_lift_def
-                           asid_bits_def
+                           cap_page_table_cap_lift_def asid_bits_def
                     split: if_split_asm)
      apply simp
      apply (rule ccorres_inst[where P=\<top> and P'=UNIV], return_NullCap_pair_ccorres)
@@ -2477,7 +2475,7 @@ lemma finaliseCap_ccorres:
                del: Collect_const)
    apply (rule ccorres_if_lhs)
     apply (simp, rule ccorres_fail)
-   apply (simp add: from_bool_0 Collect_True Collect_False false_def
+   apply (simp add: from_bool_0 Collect_True Collect_False
                del: Collect_const)
    apply csymbr
    apply (simp add: cap_get_tag_isCap Collect_False Collect_True
@@ -2562,7 +2560,7 @@ lemma finaliseCap_ccorres:
    apply (simp add: isArchCap_T_isArchObjectCap[symmetric]
                del: Collect_const)
    apply (rule ccorres_if_lhs)
-    apply (simp add: Collect_False Collect_True Let_def true_def
+    apply (simp add: Collect_False Collect_True Let_def
                 del: Collect_const)
     apply (rule_tac P="(capIRQ cap) \<le>  X64.maxIRQ" in ccorres_gen_asm)
     apply (rule ccorres_rhs_assoc)+
@@ -2602,8 +2600,7 @@ lemma finaliseCap_ccorres:
                            irq_opt_relation_def)
     apply wp
    apply (simp add: guard_is_UNIV_def)
-  apply (clarsimp simp: cap_get_tag_isCap word_sle_def Collect_const_mem
-                        false_def from_bool_def)
+  apply (clarsimp simp: cap_get_tag_isCap word_sle_def Collect_const_mem)
   apply (intro impI conjI)
                 apply (clarsimp split: bool.splits)
                apply (clarsimp split: bool.splits)
@@ -2620,7 +2617,7 @@ lemma finaliseCap_ccorres:
                    split: option.splits cap_CL.splits if_splits)
      apply clarsimp
      apply (frule cap_get_tag_to_H, erule(1) cap_get_tag_isCap [THEN iffD2])
-     apply (clarsimp simp: isCap_simps from_bool_def false_def)
+     apply (clarsimp simp: isCap_simps)
     apply (clarsimp simp: tcb_cnode_index_defs ptr_add_assertion_def)
    apply clarsimp
    apply (frule cap_get_tag_to_H, erule(1) cap_get_tag_isCap [THEN iffD2])

--- a/proof/crefine/X64/Interrupt_C.thy
+++ b/proof/crefine/X64/Interrupt_C.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2023, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -16,7 +17,7 @@ lemma invokeIRQHandler_AckIRQ_ccorres:
      (InterruptDecls_H.invokeIRQHandler (AckIRQ irq)) (Call invokeIRQHandler_AckIRQ_'proc)"
   apply (cinit lift: irq_' simp: Interrupt_H.invokeIRQHandler_def invokeIRQHandler_def)
    apply (ctac add: maskInterrupt_ccorres)
-  apply (simp add: from_bool_def false_def)
+  apply simp
   done
 
 lemma getIRQSlot_ccorres:
@@ -267,12 +268,12 @@ lemma decodeIRQHandlerInvocation_ccorres:
     sysargs_rel_n_def word_less_nat_alt)
   apply (clarsimp simp: cte_wp_at_ctes_of neq_Nil_conv sysargs_rel_def n_msgRegisters_def
                     excaps_map_def excaps_in_mem_def word_less_nat_alt hd_conv_nth
-                    slotcap_in_mem_def valid_tcb_state'_def from_bool_def toBool_def
+                    slotcap_in_mem_def valid_tcb_state'_def
              dest!: interpret_excaps_eq split: bool.splits)
   apply (intro conjI impI allI)
   apply (clarsimp simp: cte_wp_at_ctes_of neq_Nil_conv sysargs_rel_def n_msgRegisters_def
                     excaps_map_def excaps_in_mem_def word_less_nat_alt hd_conv_nth
-                    slotcap_in_mem_def valid_tcb_state'_def from_bool_def toBool_def
+                    slotcap_in_mem_def valid_tcb_state'_def
              dest!: interpret_excaps_eq split: bool.splits)+
      apply (auto dest: st_tcb_at_idle_thread' ctes_of_valid')[4]
     apply (drule ctes_of_valid')
@@ -367,8 +368,7 @@ lemma isIRQActive_ccorres:
                          Let_def cinterrupt_relation_def)
    apply (drule spec, drule(1) mp)
    apply (case_tac "intStateIRQTable (ksInterruptState \<sigma>) irq")
-     apply (simp add: from_bool_def irq_state_defs Kernel_C.maxIRQ_def
-                      word_le_nat_alt)+
+      apply (simp add: irq_state_defs Kernel_C.maxIRQ_def word_le_nat_alt)+
   done
 
 lemma Platform_maxIRQ:
@@ -1002,7 +1002,7 @@ from assms show ?thesis
                       "StrictC'_thread_state_defs" rf_sr_ksCurThread cte_wp_at_ctes_of
                       sysargs_rel_def sysargs_rel_n_def
                       excaps_map_def excaps_in_mem_def slotcap_in_mem_def
-                      valid_tcb_state'_def from_bool_def toBool_def word_less_nat_alt
+                      valid_tcb_state'_def word_less_nat_alt
                       c_irq_const_defs irq64_helper_one irq64_helper_two irq64_helper_three
                       irq64_helper_four irq64_helper_five
                       unat_less_2p_word_bits word_less_alt word_sless_alt is_down sint_ucast_eq_uint

--- a/proof/crefine/X64/Invoke_C.thy
+++ b/proof/crefine/X64/Invoke_C.thy
@@ -64,7 +64,7 @@ lemma setDomain_ccorres:
           apply (rule ccorres_cond2[where R=\<top>], simp add: Collect_const_mem)
            apply (ctac add: tcbSchedEnqueue_ccorres)
           apply (rule ccorres_return_Skip)
-         apply (simp add: when_def to_bool_def)
+         apply (simp add: when_def)
          apply (rule_tac R="\<lambda>s. rv = ksCurThread s"
                     in ccorres_cond2)
            apply (clarsimp simp: rf_sr_ksCurThread)
@@ -228,7 +228,7 @@ lemma invokeCNodeDelete_ccorres:
    apply (rule ccorres_trim_returnE, simp, simp)
    apply (rule ccorres_callE)
        apply (rule cteDelete_ccorres[simplified])
-      apply (simp add: from_bool_def true_def)+
+      apply simp+
 done
 
 
@@ -248,7 +248,7 @@ lemma invokeCNodeRevoke_ccorres:
    apply (rule ccorres_trim_returnE, simp, simp)
    apply (rule ccorres_callE)
        apply (rule cteRevoke_ccorres[simplified])
-      apply (simp add: from_bool_def true_def)+
+      apply simp+
 done
 
 
@@ -546,12 +546,10 @@ lemma hasCancelSendRights_spec:
    apply clarsimp
    apply (drule sym, drule (1) cap_get_tag_to_H)
    apply (clarsimp simp: hasCancelSendRights_def to_bool_def
-                         true_def false_def
                    split: if_split bool.splits)
   apply (rule impI)
   apply (case_tac cap,
-         auto simp: cap_get_tag_isCap_unfolded_H_cap cap_tag_defs
-                     from_bool_def false_def true_def hasCancelSendRights_def
+         auto simp: cap_get_tag_isCap_unfolded_H_cap cap_tag_defs hasCancelSendRights_def
               dest: cap_get_tag_isArchCap_unfolded_H_cap
               split: capability.splits bool.splits)[1]
   done
@@ -747,7 +745,7 @@ lemma decodeCNodeInvocation_ccorres:
                                 apply (simp add: syscall_error_to_H_cases)
                                apply (simp add: whenE_def injection_handler_returnOk
                                                 ccorres_invocationCatch_Inr performInvocation_def
-                                                bindE_assoc false_def)
+                                                bindE_assoc)
                                apply (ctac add: setThreadState_ccorres)
                                  apply (simp add: ccorres_cond_iffs)
                                  apply (ctac(no_vcg) add: invokeCNodeInsert_ccorres)
@@ -823,7 +821,7 @@ lemma decodeCNodeInvocation_ccorres:
                                     apply (rule syscall_error_throwError_ccorres_n)
                                     apply (simp add: syscall_error_to_H_cases)
                                    apply (simp add: whenE_def injection_handler_returnOk
-                                                    ccorres_invocationCatch_Inr false_def
+                                                    ccorres_invocationCatch_Inr
                                                     performInvocation_def bindE_assoc)
                                    apply (ctac add: setThreadState_ccorres)
                                      apply (simp add: ccorres_cond_iffs)
@@ -879,7 +877,7 @@ lemma decodeCNodeInvocation_ccorres:
                                        in ccorres_gen_asm2)
                            apply csymbr
                            apply csymbr
-                           apply (simp add: cap_get_tag_NullCap true_def)
+                           apply (simp add: cap_get_tag_NullCap)
                            apply (ctac add: setThreadState_ccorres)
                              apply (simp add: ccorres_cond_iffs)
                              apply (ctac(no_vcg) add: invokeCNodeMove_ccorres)
@@ -925,7 +923,7 @@ lemma decodeCNodeInvocation_ccorres:
                                               ccorres_invocationCatch_Inr numeral_eqs
                                               performInvocation_def bindE_assoc)
                              apply (ctac add: setThreadState_ccorres)
-                               apply (simp add: true_def ccorres_cond_iffs)
+                               apply (simp add: ccorres_cond_iffs)
                                apply (ctac(no_vcg) add: invokeCNodeMove_ccorres)
                                  apply (rule ccorres_alternative2)
                                  apply (rule ccorres_return_CE, simp+)[1]
@@ -1385,8 +1383,7 @@ lemma decodeCNodeInvocation_ccorres:
                              map_option_Some_eq2 neq_Nil_conv ccap_relation_def
                              numeral_eqs hasCancelSendRights_not_Null
                              ccap_relation_NullCap_iff[symmetric]
-                             if_1_0_0 interpret_excaps_test_null
-                             mdbRevocable_CL_cte_to_H false_def true_def
+                             interpret_excaps_test_null mdbRevocable_CL_cte_to_H
             | clarsimp simp: typ_heap_simps'
             | frule length_ineq_not_Nil)+)
   done
@@ -3299,8 +3296,8 @@ lemma decodeUntypedInvocation_ccorres_helper:
                                            unat_of_nat_APIType_capBits word_size hd_conv_nth length_ineq_not_Nil
                        not_less word_le_nat_alt isCap_simps valid_cap_simps')
                     apply (strengthen word_of_nat_less)
-                    apply (clarsimp simp: StrictC'_thread_state_defs mask_def true_def false_def
-                                          from_bool_0 ccap_relation_isDeviceCap2
+                    apply (clarsimp simp: StrictC'_thread_state_defs mask_def
+                                          ccap_relation_isDeviceCap2
                                    split: if_split)
                     apply (clarsimp simp: not_less shiftr_overflow maxUntypedSizeBits_def
                                           unat_of_nat_APIType_capBits)

--- a/proof/crefine/X64/IpcCancel_C.thy
+++ b/proof/crefine/X64/IpcCancel_C.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2023, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -436,9 +437,9 @@ lemma isStopped_ccorres [corres]:
    apply vcg
    apply clarsimp
   apply clarsimp
-  apply (clarsimp simp: to_bool_def true_def false_def typ_heap_simps
-    ctcb_relation_thread_state_to_tsType split: thread_state.splits)
-  apply (simp add: "StrictC'_thread_state_defs")+
+  apply (clarsimp simp: typ_heap_simps ctcb_relation_thread_state_to_tsType
+                 split: thread_state.splits)
+    apply (simp add: "StrictC'_thread_state_defs")+
   done
 
 lemma isRunnable_ccorres [corres]:
@@ -464,10 +465,10 @@ lemma isRunnable_ccorres [corres]:
     apply (vcg)
    apply (clarsimp)
   apply (clarsimp)
-  apply (clarsimp simp: to_bool_def true_def false_def typ_heap_simps
-    ctcb_relation_thread_state_to_tsType split: thread_state.splits)
-  apply (simp add: "StrictC'_thread_state_defs")+
-done
+  apply (clarsimp simp: typ_heap_simps ctcb_relation_thread_state_to_tsType
+                 split: thread_state.splits)
+       apply (simp add: "StrictC'_thread_state_defs")+
+  done
 
 
 
@@ -794,13 +795,6 @@ lemma state_relation_queue_update_helper:
   apply (drule(1) bspec)
   apply (erule obj_at'_weakenE, clarsimp)
   done
-
-(* FIXME: move *)
-lemma from_bool_vals [simp]:
-  "from_bool True = scast true"
-  "from_bool False = scast false"
-  "scast true \<noteq> scast false"
-  by (auto simp add: from_bool_def true_def false_def)
 
 (* FIXME: move *)
 lemma cmap_relation_no_upd:
@@ -1941,10 +1935,6 @@ proof -
                          valid_obj'_def inQ_def
                    dest!: valid_queues_obj_at'D)
 qed
-
-lemma true_eq_from_bool [simp]:
-  "(scast true = from_bool P) = P"
-  by (simp add: true_def from_bool_def split: bool.splits)
 
 lemma isStopped_spec:
   "\<forall>s. \<Gamma> \<turnstile> ({s} \<inter> {s. cslift s (thread_' s) \<noteq> None}) Call isStopped_'proc

--- a/proof/crefine/X64/Ipc_C.thy
+++ b/proof/crefine/X64/Ipc_C.thy
@@ -1200,7 +1200,7 @@ lemma setMRs_syscall_error_ccorres:
                  | wp hoare_case_option_wp
                  | (simp del: Collect_const, vcg exspec=setMR_modifies)
                )+
-   apply (simp add: msgMaxLength_unfold if_1_0_0 true_def false_def)
+   apply (simp add: msgMaxLength_unfold)
    apply (clarsimp split:if_split_asm simp:syscall_error_to_H_def map_option_Some_eq2 ucast_and_mask ucast_nat_def)
    apply (simp add: msgFromLookupFailure_def
                  split: lookup_failure.split
@@ -2855,9 +2855,8 @@ next
                               word_sle_def t2n_mask_eq_if)
             apply (rule conjI)
              apply (clarsimp simp: ccap_rights_relation_def cap_rights_to_H_def
-                                 false_def true_def to_bool_def allRights_def
-                                 excaps_map_def split_def
-                          dest!: drop_n_foo interpret_excaps_eq)
+                                   allRights_def excaps_map_def split_def
+                            dest!: drop_n_foo interpret_excaps_eq)
             apply (clarsimp simp:from_bool_def split:bool.splits)
              apply (case_tac "isEndpointCap (fst x)")
               apply (clarsimp simp: cap_get_tag_EndpointCap ep_cap_not_null cap_get_tag_isCap[symmetric])
@@ -2897,7 +2896,7 @@ next
          apply (rule conseqPre, vcg)
          apply (clarsimp split del: if_split)
         apply (clarsimp split del: if_split
-                       simp add: Collect_const[symmetric] precond_def true_def false_def
+                       simp add: Collect_const[symmetric] precond_def
                        simp del: Collect_const)
         apply (rule HoarePartial.Seq[rotated] HoarePartial.Cond[OF order_refl]
                   HoarePartial.Basic[OF order_refl] HoarePartial.Skip[OF order_refl]
@@ -3231,7 +3230,7 @@ proof -
                        apply (clarsimp simp: cfault_rel2_def)
                        apply (clarsimp simp: cfault_rel_def)
                        apply (simp add: seL4_Fault_CapFault_lift)
-                       apply (clarsimp simp: is_cap_fault_def to_bool_def false_def)
+                       apply (clarsimp simp: is_cap_fault_def)
                       apply wp
                       apply (rule hoare_post_imp_R, rule lsft_real_cte)
                       apply (clarsimp simp: obj_at'_def projectKOs objBits_simps')
@@ -3487,7 +3486,7 @@ lemma replyFromKernel_error_ccorres [corres]:
                    message_info_to_H_def valid_pspace_valid_objs')
   apply (clarsimp simp: msgLengthBits_def msgFromSyscallError_def
                         syscall_error_to_H_def syscall_error_type_defs
-                        mask_def true_def option_to_ptr_def
+                        mask_def option_to_ptr_def
                  split: if_split_asm)
   done
 
@@ -3545,7 +3544,7 @@ lemma doIPCTransfer_ccorres [corres]:
                            fault_to_fault_tag_nonzero)
      apply (fold dc_def)[1]
      apply ctac
-    apply (clarsimp simp: guard_is_UNIV_def false_def option_to_ptr_def split: option.splits)
+    apply (clarsimp simp: guard_is_UNIV_def option_to_ptr_def split: option.splits)
    apply (rule_tac Q="\<lambda>rv. valid_pspace' and cur_tcb' and tcb_at' sender
                        and tcb_at' receiver and K (rv \<noteq> Some 0)
                        and (case_option \<top> valid_ipc_buffer_ptr' rv)
@@ -3554,7 +3553,7 @@ lemma doIPCTransfer_ccorres [corres]:
     apply (auto simp: valid_ipc_buffer_ptr'_def option_to_0_def
                    split: option.splits)[1]
    apply (wp lookupIPCBuffer_not_Some_0 lookupIPCBuffer_aligned)
-  apply (auto simp: to_bool_def true_def)
+  apply auto
   done
 
 lemma fault_case_absorb_bind:
@@ -3575,7 +3574,6 @@ lemma Arch_getSanitiseRegisterInfo_ccorres:
      (Call Arch_getSanitiseRegisterInfo_'proc)"
   apply (cinit' lift: thread_' simp: getSanitiseRegisterInfo_def)
    apply (rule ccorres_return_C, simp+)
-  apply (simp add: false_def)
   done
 
 lemma copyMRsFaultReply_ccorres_exception:
@@ -3618,7 +3616,7 @@ proof -
                   apply (vcg)
                  apply clarsimp
                  apply (rule conseqPre, vcg)
-                 apply (auto simp: from_bool_def sanitiseRegister_def)[1]
+                 apply (auto simp: sanitiseRegister_def)[1]
                 apply wp
                apply clarsimp
                apply vcg
@@ -3909,7 +3907,7 @@ lemma handleArchFaultReply_corres:
          apply simp+
       apply (rule ccorres_symb_exec_l)
          apply (ctac add: ccorres_return_C)
-        apply (wp mapM_wp' empty_fail_loadWordUser | clarsimp simp: to_bool_def true_def)+
+        apply (wp mapM_wp' empty_fail_loadWordUser | clarsimp)+
   done
 
 (* MOVE *)
@@ -4045,9 +4043,9 @@ lemma handleFaultReply_ccorres [corres]:
      apply clarsimp
      apply vcg_step
      apply (clarsimp simp: n_exceptionMessage_def n_syscallMessage_def
-                           message_info_to_H_def to_bool_def scast_def
+                           message_info_to_H_def scast_def
                            length_exceptionMessage length_syscallMessage
-                           min_def word_less_nat_alt true_def
+                           min_def word_less_nat_alt
                            guard_is_UNIV_def seL4_Faults seL4_Arch_Faults
                        split: if_split)
     apply (simp add: length_exceptionMessage length_syscallMessage)
@@ -4055,10 +4053,8 @@ lemma handleFaultReply_ccorres [corres]:
    apply clarsimp
    apply (vcg exspec=getRegister_modifies)
   apply (clarsimp simp: n_exceptionMessage_def n_syscallMessage_def
-                        message_info_to_H_def to_bool_def
-                        length_exceptionMessage length_syscallMessage
-                        min_def word_less_nat_alt true_def
-                        obj_at'_def
+                        message_info_to_H_def length_exceptionMessage length_syscallMessage
+                        min_def word_less_nat_alt obj_at'_def
                  split: if_split)
   apply (fastforce simp: seL4_Faults seL4_Arch_Faults)
   done
@@ -4282,7 +4278,7 @@ proof -
                        threadSet_valid_objs' threadSet_weak_sch_act_wf
                          | simp add: valid_tcb_state'_def)+)[1]
            apply (clarsimp simp: guard_is_UNIV_def ThreadState_Restart_def
-                                 ThreadState_Inactive_def mask_def to_bool_def
+                                 ThreadState_Inactive_def mask_def
                                  option_to_ctcb_ptr_def)
 
           apply (rule_tac Q="\<lambda>rv. valid_queues and tcb_at' receiver and valid_queues' and
@@ -4304,8 +4300,7 @@ proof -
     apply (rule conseqPre, vcg)
     apply (simp(no_asm_use) add: gs_set_assn_Delete_cstate_relation[unfolded o_def]
                                  subset_iff rf_sr_def)
-   apply (clarsimp simp: guard_is_UNIV_def to_bool_def true_def
-                         option_to_ptr_def option_to_0_def false_def
+   apply (clarsimp simp: guard_is_UNIV_def option_to_ptr_def option_to_0_def
                          ThreadState_Running_def mask_def
                          ghost_assertion_data_get_def ghost_assertion_data_set_def
                          cap_tag_defs option_to_ctcb_ptr_def
@@ -4377,7 +4372,7 @@ lemma setupCallerCap_ccorres [corres]:
         apply (wp getSlotCap_cte_wp_at)
        apply (clarsimp simp: ccap_relation_def cap_lift_reply_cap
                              cap_to_H_simps cap_reply_cap_lift_def
-                             false_def tcbSlots Kernel_C.tcbCaller_def
+                             tcbSlots Kernel_C.tcbCaller_def
                              size_of_def cte_level_bits_def)
         apply (simp add: is_aligned_neg_mask)
        apply (wp getCTE_wp')
@@ -4397,7 +4392,7 @@ lemma setupCallerCap_ccorres [corres]:
      apply (simp add: locateSlot_conv)
      apply wp
     apply (clarsimp simp: ccap_rights_relation_def allRights_def
-                          mask_def true_def cap_rights_to_H_def tcbCallerSlot_def
+                          mask_def cap_rights_to_H_def tcbCallerSlot_def
                           Kernel_C.tcbCaller_def)
    apply simp
    apply wp
@@ -4618,8 +4613,7 @@ lemma sendIPC_block_ccorres_helper:
           (simp add: typ_heap_simps')+)[1]
          apply (simp add: tcb_cte_cases_def)
         apply (simp add: ctcb_relation_def cthread_state_relation_def
-                         ThreadState_BlockedOnSend_def mask_def
-                         from_bool_def to_bool_def)
+                         ThreadState_BlockedOnSend_def mask_def)
         apply (clarsimp simp: canonical_address_sign_extended sign_extended_iff_sign_extend
                        split: bool.split)
        apply ceqv
@@ -5032,7 +5026,7 @@ lemma sendIPC_ccorres [corres]:
             apply (ctac(no_vcg) add: possibleSwitchTo_ccorres)
              apply (clarsimp split del: if_split)
              apply (wpc ; ccorres_rewrite)
-              apply (clarsimp simp: from_bool_def disj_imp[symmetric] split del: if_split)
+              apply (clarsimp simp: disj_imp[symmetric] split del: if_split)
               apply (wpc ; clarsimp)
                apply ccorres_rewrite
                apply (fold dc_def)[1]
@@ -5052,7 +5046,7 @@ lemma sendIPC_ccorres [corres]:
                 | wp (once) hoare_drop_imp
                 | strengthen sch_act_wf_weak)+
        apply (fastforce simp: guard_is_UNIV_def ThreadState_Inactive_def Collect_const_mem
-                               ThreadState_Running_def mask_def from_bool_def
+                               ThreadState_Running_def mask_def
                                option_to_ptr_def option_to_0_def
                         split: bool.split_asm)
 
@@ -5829,7 +5823,7 @@ lemma receiveIPC_ccorres [corres]:
                  apply (clarsimp simp:  from_bool_0 disj_imp[symmetric] simp del: Collect_const)
                  apply wpc
                   (* blocking ipc call *)
-                  apply (clarsimp simp: from_bool_def split del: if_split simp del: Collect_const)
+                  apply (clarsimp split del: if_split simp del: Collect_const)
                   apply ccorres_rewrite
                   apply (wpc ; clarsimp ; ccorres_rewrite)
                    apply csymbr
@@ -5881,7 +5875,7 @@ lemma receiveIPC_ccorres [corres]:
                                          projectKOs invs'_def valid_state'_def st_tcb_at'_def
                                          valid_tcb_state'_def ko_wp_at'_def invs_valid_objs'
                                          isBlockedOnReceive_def projectKO_opt_tcb
-                                         from_bool_def to_bool_def objBits_simps'
+                                         objBits_simps'
                                   elim!: delta_sym_refs
                                   split: if_split_asm bool.splits) (*very long*)
             apply (frule(1) sym_refs_obj_atD' [OF _ invs_sym'])
@@ -5894,7 +5888,6 @@ lemma receiveIPC_ccorres [corres]:
                                         projectKOs invs'_def valid_state'_def st_tcb_at'_def
                                         valid_tcb_state'_def ko_wp_at'_def invs_valid_objs'
                                         isBlockedOnReceive_def projectKO_opt_tcb objBits_simps'
-                                        from_bool_def to_bool_def
                                   elim: delta_sym_refs
                                  split: if_split_asm bool.splits) (*very long *)
            apply (clarsimp simp: obj_at'_def state_refs_of'_def projectKOs)
@@ -6298,8 +6291,7 @@ lemma receiveSignal_block_ccorres_helper:
           (simp add: typ_heap_simps')+)
          apply (simp add: tcb_cte_cases_def)
         apply (simp add: ctcb_relation_def cthread_state_relation_def
-                         ThreadState_BlockedOnNotification_def mask_def
-                         from_bool_def to_bool_def)
+                         ThreadState_BlockedOnNotification_def mask_def)
         apply (clarsimp simp: canonical_address_sign_extended sign_extended_iff_sign_extend)
        apply ceqv
       apply clarsimp

--- a/proof/crefine/X64/Retype_C.thy
+++ b/proof/crefine/X64/Retype_C.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2023, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -2853,9 +2854,10 @@ lemma insertNewCap_ccorres_helper:
   apply (rule conjI)
    apply (erule (2) cmap_relation_updI)
    apply (simp add: ccap_relation_def ccte_relation_def cte_lift_def)
-    subgoal by (simp add: cte_to_H_def map_option_Some_eq2 mdb_node_to_H_def to_bool_mask_to_bool_bf is_aligned_neg_mask_weaken
-      c_valid_cte_def true_def canonical_address_sign_extended sign_extended_iff_sign_extend cteSizeBits_def
-      split: option.splits)
+    subgoal by (simp add: cte_to_H_def map_option_Some_eq2 mdb_node_to_H_def to_bool_mask_to_bool_bf
+                          is_aligned_neg_mask_weaken c_valid_cte_def canonical_address_sign_extended
+                          sign_extended_iff_sign_extend cteSizeBits_def
+                   split: option.splits)
    subgoal by simp
   apply (erule_tac t = s' in ssubst)
   apply (simp cong: lifth_update)
@@ -3168,16 +3170,6 @@ lemma createNewCaps_untyped_if_helper:
   "\<forall>s s'. (s, s') \<in> rf_sr \<and> (sz < word_bits \<and> gbits < word_bits) \<and> True  \<longrightarrow>
              (\<not> gbits \<le> sz) = (s' \<in> \<lbrace>of_nat sz < (of_nat gbits :: machine_word)\<rbrace>)"
   by (clarsimp simp: not_le unat_of_nat64 word_less_nat_alt lt_word_bits_lt_pow)
-
-lemma true_mask1 [simp]:
-  "true && mask (Suc 0) = true"
-  unfolding true_def
-  by (simp add: bang_eq cong: conj_cong)
-
-lemma to_bool_simps [simp]:
-  "to_bool true" "\<not> to_bool false"
-  unfolding true_def false_def to_bool_def
-  by simp_all
 
 lemma heap_list_update':
   "\<lbrakk> n = length v; length v \<le> 2 ^ word_bits \<rbrakk> \<Longrightarrow> heap_list (heap_update_list p v h) n p = v"
@@ -6005,7 +5997,7 @@ proof -
        apply (clarsimp simp: pageBits_def ccap_relation_def APIType_capBits_def
                              framesize_to_H_def cap_to_H_simps cap_page_table_cap_lift
                              vmrights_to_H_def)
-       apply (clarsimp simp: to_bool_def false_def isFrameType_def)
+       apply (clarsimp simp: isFrameType_def)
 
       \<comment> \<open>PageDirectoryObject\<close>
       apply (cinit' lift: t_' regionBase_' userSize_' deviceMemory_')
@@ -6034,7 +6026,7 @@ proof -
       apply (clarsimp simp: ccap_relation_def APIType_capBits_def
                             framesize_to_H_def cap_to_H_simps cap_page_directory_cap_lift
                             vmrights_to_H_def bit_simps)
-      apply (clarsimp simp: to_bool_def false_def isFrameType_def)
+      apply (clarsimp simp: isFrameType_def)
 
      \<comment> \<open>PDPointerTableObject\<close>
      apply (cinit' lift: t_' regionBase_' userSize_' deviceMemory_')
@@ -6062,7 +6054,7 @@ proof -
      apply (clarsimp simp: ccap_relation_def APIType_capBits_def
                            framesize_to_H_def cap_to_H_simps cap_pdpt_cap_lift
                            vmrights_to_H_def bit_simps)
-     apply (clarsimp simp: to_bool_def false_def isFrameType_def)
+     apply (clarsimp simp: isFrameType_def)
 
     \<comment> \<open>PML4Object\<close>
     apply (cinit' lift: t_' regionBase_' userSize_' deviceMemory_')
@@ -6091,10 +6083,9 @@ proof -
                            APIType_capBits_def invs_queues invs_valid_objs' invs_urz bit_simps)
     apply clarsimp
     apply (clarsimp simp: ccap_relation_def APIType_capBits_def
-                           framesize_to_H_def cap_to_H_simps cap_pml4_cap_lift
-                           vmrights_to_H_def bit_simps)
-    apply (clarsimp simp: to_bool_def false_def isFrameType_def
-                          c_valid_cap_def cl_valid_cap_def asidInvalid_def)
+                          framesize_to_H_def cap_to_H_simps cap_pml4_cap_lift
+                          vmrights_to_H_def bit_simps)
+    apply (clarsimp simp: isFrameType_def c_valid_cap_def cl_valid_cap_def asidInvalid_def)
     done
 qed
 
@@ -6241,11 +6232,11 @@ proof -
    apply (rule ccorres_cond_seq)
    (* Architecture specific objects. *)
    apply (rule_tac
-           Q="createObject_hs_preconds regionBase newType userSize isdev" and
-           S="createObject_c_preconds1 regionBase newType userSize isdev" and
-           R="createObject_hs_preconds regionBase newType userSize isdev" and
-           T="createObject_c_preconds1 regionBase newType userSize isdev"
-           in ccorres_Cond_rhs)
+            Q="createObject_hs_preconds regionBase newType userSize isdev" and
+            S="createObject_c_preconds1 regionBase newType userSize isdev" and
+            R="createObject_hs_preconds regionBase newType userSize isdev" and
+            T="createObject_c_preconds1 regionBase newType userSize isdev"
+            in ccorres_Cond_rhs)
     apply (subgoal_tac "toAPIType newType = None")
      apply clarsimp
      apply (rule ccorres_rhs_assoc)+
@@ -6278,21 +6269,20 @@ proof -
                         intro!: Corres_UL_C.ccorres_cond_empty
                                 Corres_UL_C.ccorres_cond_univ ccorres_rhs_assoc)
           apply (rule_tac
-             A ="createObject_hs_preconds regionBase
-                   (APIObjectType apiobject_type.Untyped)
-                    (unat (userSizea :: machine_word)) isdev" and
-             A'=UNIV in
-             ccorres_guard_imp)
+                   A ="createObject_hs_preconds regionBase
+                         (APIObjectType apiobject_type.Untyped)
+                          (unat (userSizea :: machine_word)) isdev" and
+                   A'=UNIV in
+                   ccorres_guard_imp)
             apply (rule ccorres_symb_exec_r)
               apply (rule ccorres_return_C, simp, simp, simp)
              apply vcg
             apply (rule conseqPre, vcg, clarsimp)
            apply simp
           apply (clarsimp simp: ccap_relation_def cap_to_H_def
-                     getObjectSize_def apiGetObjectSize_def
-                     cap_untyped_cap_lift to_bool_eq_0 true_def
-                     aligned_add_aligned sign_extend_canonical_address
-                   split: option.splits)
+                                getObjectSize_def apiGetObjectSize_def cap_untyped_cap_lift
+                                aligned_add_aligned sign_extend_canonical_address
+                         split: option.splits)
           apply (subst word_le_mask_eq, clarsimp simp: mask_def, unat_arith,
                  auto simp: word_bits_conv untypedBits_defs)[1]
 
@@ -6302,11 +6292,11 @@ proof -
                        intro!: Corres_UL_C.ccorres_cond_empty
                                Corres_UL_C.ccorres_cond_univ ccorres_rhs_assoc)
          apply (rule_tac
-           A ="createObject_hs_preconds regionBase
-                 (APIObjectType apiobject_type.TCBObject) (unat userSizea) isdev" and
-           A'="createObject_c_preconds1 regionBase
-                 (APIObjectType apiobject_type.TCBObject) (unat userSizea) isdev" in
-            ccorres_guard_imp2)
+                  A ="createObject_hs_preconds regionBase
+                        (APIObjectType apiobject_type.TCBObject) (unat userSizea) isdev" and
+                  A'="createObject_c_preconds1 regionBase
+                        (APIObjectType apiobject_type.TCBObject) (unat userSizea) isdev" in
+                  ccorres_guard_imp2)
           apply (rule ccorres_symb_exec_r)
             apply (ccorres_remove_UNIV_guard)
             apply (simp add: hrs_htd_update)
@@ -6339,10 +6329,10 @@ proof -
                                region_actually_is_bytes_def APIType_capBits_def)
          apply (frule(1) ghost_assertion_size_logic_no_unat)
          apply (clarsimp simp: ccap_relation_def cap_to_H_def
-                    getObjectSize_def apiGetObjectSize_def
-                    cap_thread_cap_lift to_bool_def true_def
-                    aligned_add_aligned
-                  split: option.splits)
+                               getObjectSize_def apiGetObjectSize_def
+                               cap_thread_cap_lift
+                               aligned_add_aligned
+                        split: option.splits)
          apply (frule range_cover.aligned)
          apply (clarsimp simp: ctcb_ptr_to_tcb_ptr_def ctcb_offset_defs
                                tcb_ptr_to_ctcb_ptr_def
@@ -6350,17 +6340,16 @@ proof -
 
         (* Endpoint *)
         apply (clarsimp simp: Kernel_C_defs object_type_from_H_def
-          toAPIType_def nAPIObjects_def
-          word_sle_def intro!: ccorres_cond_empty ccorres_cond_univ
-          ccorres_rhs_assoc)
+                              toAPIType_def nAPIObjects_def word_sle_def
+                      intro!: ccorres_cond_empty ccorres_cond_univ ccorres_rhs_assoc)
         apply (rule_tac
-           A ="createObject_hs_preconds regionBase
-                 (APIObjectType apiobject_type.EndpointObject)
-                 (unat (userSizea :: machine_word)) isdev" and
-           A'="createObject_c_preconds1 regionBase
-                 (APIObjectType apiobject_type.EndpointObject)
-                 (unat userSizea) isdev" in
-           ccorres_guard_imp2)
+                 A ="createObject_hs_preconds regionBase
+                       (APIObjectType apiobject_type.EndpointObject)
+                       (unat (userSizea :: machine_word)) isdev" and
+                 A'="createObject_c_preconds1 regionBase
+                       (APIObjectType apiobject_type.EndpointObject)
+                       (unat userSizea) isdev" in
+                 ccorres_guard_imp2)
          apply (simp add: hrs_htd_update)
          apply (ctac (no_vcg) pre only: add: ccorres_placeNewObject_endpoint)
            apply (rule ccorres_symb_exec_r)
@@ -6369,9 +6358,10 @@ proof -
            apply (rule conseqPre, vcg, clarsimp)
           apply wp
          apply (clarsimp simp: ccap_relation_def cap_to_H_def getObjectSize_def
-                    objBits_simps apiGetObjectSize_def epSizeBits_def
-                    cap_endpoint_cap_lift to_bool_def true_def sign_extend_canonical_address
-                  split: option.splits   dest!: range_cover.aligned)
+                               objBits_simps apiGetObjectSize_def epSizeBits_def
+                               cap_endpoint_cap_lift sign_extend_canonical_address
+                        split: option.splits
+                        dest!: range_cover.aligned)
         apply (clarsimp simp: createObject_hs_preconds_def isFrameType_def)
         apply (frule invs_pspace_aligned')
         apply (frule invs_pspace_distinct')
@@ -6379,25 +6369,24 @@ proof -
         apply (frule invs_sym')
         apply (auto simp: getObjectSize_def objBits_simps apiGetObjectSize_def
                           epSizeBits_def word_bits_conv
-                  elim!: is_aligned_no_wrap'   intro!: range_cover_simpleI)[1]
+                   elim!: is_aligned_no_wrap'
+                  intro!: range_cover_simpleI)[1]
 
        (* Notification *)
        apply (clarsimp simp: createObject_c_preconds_def)
-       apply (clarsimp simp: getObjectSize_def objBits_simps
-                  apiGetObjectSize_def
-                  epSizeBits_def word_bits_conv word_sle_def word_sless_def)
+       apply (clarsimp simp: getObjectSize_def objBits_simps apiGetObjectSize_def
+                             epSizeBits_def word_bits_conv word_sle_def word_sless_def)
        apply (clarsimp simp: Kernel_C_defs object_type_from_H_def
-         toAPIType_def nAPIObjects_def
-         word_sle_def intro!: ccorres_cond_empty ccorres_cond_univ
-         ccorres_rhs_assoc)
+                             toAPIType_def nAPIObjects_def word_sle_def
+                     intro!: ccorres_cond_empty ccorres_cond_univ ccorres_rhs_assoc)
        apply (rule_tac
-         A ="createObject_hs_preconds regionBase
-               (APIObjectType apiobject_type.NotificationObject)
-               (unat (userSizea :: machine_word)) isdev" and
-         A'="createObject_c_preconds1 regionBase
-               (APIObjectType apiobject_type.NotificationObject)
-               (unat userSizea) isdev" in
-         ccorres_guard_imp2)
+                A ="createObject_hs_preconds regionBase
+                      (APIObjectType apiobject_type.NotificationObject)
+                      (unat (userSizea :: machine_word)) isdev" and
+                A'="createObject_c_preconds1 regionBase
+                      (APIObjectType apiobject_type.NotificationObject)
+                      (unat userSizea) isdev" in
+                ccorres_guard_imp2)
         apply (simp add: hrs_htd_update)
         apply (ctac (no_vcg) pre only: add: ccorres_placeNewObject_notification)
           apply (rule ccorres_symb_exec_r)
@@ -6406,19 +6395,21 @@ proof -
           apply (rule conseqPre, vcg, clarsimp)
          apply wp
         apply (clarsimp simp: ccap_relation_def cap_to_H_def
-            getObjectSize_def sign_extend_canonical_address
-            apiGetObjectSize_def ntfnSizeBits_def objBits_simps
-            cap_notification_cap_lift to_bool_def true_def
-            dest!: range_cover.aligned split: option.splits)
+                              getObjectSize_def sign_extend_canonical_address
+                              apiGetObjectSize_def ntfnSizeBits_def objBits_simps
+                              cap_notification_cap_lift
+                       dest!: range_cover.aligned
+                       split: option.splits)
        apply (clarsimp simp: createObject_hs_preconds_def isFrameType_def)
        apply (frule invs_pspace_aligned')
        apply (frule invs_pspace_distinct')
        apply (frule invs_queues)
        apply (frule invs_sym')
        apply (auto simp: getObjectSize_def objBits_simps
-                   apiGetObjectSize_def
-                   ntfnSizeBits_def word_bits_conv
-                elim!: is_aligned_no_wrap'  intro!: range_cover_simpleI)[1]
+                         apiGetObjectSize_def
+                         ntfnSizeBits_def word_bits_conv
+                  elim!: is_aligned_no_wrap'
+                 intro!: range_cover_simpleI)[1]
 
       (* CapTable *)
       apply (clarsimp simp: createObject_c_preconds_def)
@@ -6426,18 +6417,18 @@ proof -
                   apiGetObjectSize_def
                   ntfnSizeBits_def word_bits_conv)
       apply (clarsimp simp: Kernel_C_defs object_type_from_H_def
-                 toAPIType_def nAPIObjects_def
-                 word_sle_def word_sless_def zero_le_sint
-               intro!: ccorres_cond_empty ccorres_cond_univ ccorres_rhs_assoc
-                       ccorres_move_c_guards ccorres_Guard_Seq)
+                            toAPIType_def nAPIObjects_def
+                            word_sle_def word_sless_def zero_le_sint
+                    intro!: ccorres_cond_empty ccorres_cond_univ ccorres_rhs_assoc
+                            ccorres_move_c_guards ccorres_Guard_Seq)
       apply (rule_tac
-         A ="createObject_hs_preconds regionBase
-               (APIObjectType apiobject_type.CapTableObject)
-               (unat (userSizea :: machine_word)) isdev" and
-         A'="createObject_c_preconds1 regionBase
-               (APIObjectType apiobject_type.CapTableObject)
-               (unat userSizea) isdev" in
-         ccorres_guard_imp2)
+               A ="createObject_hs_preconds regionBase
+                     (APIObjectType apiobject_type.CapTableObject)
+                     (unat (userSizea :: machine_word)) isdev" and
+               A'="createObject_c_preconds1 regionBase
+                     (APIObjectType apiobject_type.CapTableObject)
+                     (unat userSizea) isdev" in
+               ccorres_guard_imp2)
        apply (simp add:field_simps hrs_htd_update)
        apply (ctac pre only: add: ccorres_placeNewObject_captable)
          apply (subst gsCNodes_update)
@@ -6458,24 +6449,23 @@ proof -
        apply (frule invs_sym')
        apply (frule(1) ghost_assertion_size_logic_no_unat)
        apply (clarsimp simp: getObjectSize_def objBits_simps
-                  apiGetObjectSize_def
-                  cteSizeBits_def word_bits_conv add.commute createObject_c_preconds_def
-                  region_actually_is_bytes_def
-                  invs_valid_objs' invs_urz
-                 elim!: is_aligned_no_wrap'
-                dest: word_of_nat_le  intro!: range_coverI)[1]
+                             apiGetObjectSize_def
+                             cteSizeBits_def word_bits_conv add.commute createObject_c_preconds_def
+                             region_actually_is_bytes_def
+                             invs_valid_objs' invs_urz
+                      elim!: is_aligned_no_wrap'
+                       dest: word_of_nat_le
+                     intro!: range_coverI)
       apply (clarsimp simp: createObject_hs_preconds_def hrs_htd_update isFrameType_def)
       apply (frule range_cover.strong_times_64[folded addr_card_wb], simp+)
       apply (subst h_t_array_valid_retyp, simp+)
        apply (simp add: power_add cte_C_size cteSizeBits_def)
-      apply (clarsimp simp: ccap_relation_def cap_to_H_def
-         cap_cnode_cap_lift to_bool_def true_def
-         getObjectSize_def
-         apiGetObjectSize_def cteSizeBits_def
-         objBits_simps field_simps is_aligned_power2
-         addr_card_wb is_aligned_weaken[where y=2]
-         is_aligned_neg_mask_weaken
-        split: option.splits)
+      apply (clarsimp simp: ccap_relation_def cap_to_H_def cap_cnode_cap_lift
+                            getObjectSize_def apiGetObjectSize_def cteSizeBits_def
+                            objBits_simps field_simps is_aligned_power2
+                            addr_card_wb is_aligned_weaken[where y=2]
+                            is_aligned_neg_mask_weaken
+                     split: option.splits)
       apply (rule conjI)
        apply (frule range_cover.aligned)
        apply (simp add: aligned_and is_aligned_weaken sign_extend_canonical_address)

--- a/proof/crefine/X64/Schedule_C.thy
+++ b/proof/crefine/X64/Schedule_C.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2023, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -404,7 +405,7 @@ lemma isHighestPrio_ccorres:
       apply (rule ccorres_return_C, simp, simp, simp)
      apply (rule wp_post_taut)
     apply (vcg exspec=getHighestPrio_modifies)+
-  apply (clarsimp simp: word_le_nat_alt true_def to_bool_def maxDomain_le_unat_ucast_explicit
+  apply (clarsimp simp: word_le_nat_alt maxDomain_le_unat_ucast_explicit
                   split: if_splits)
   done
 
@@ -501,17 +502,17 @@ lemma schedule_ccorres:
               apply (rule ccorres_cond2'[where R=\<top>], fastforce)
                apply clarsimp
                apply (rule ccorres_return[where R'=UNIV], clarsimp, vcg)
-               apply (rule_tac P="\<lambda>s. obj_at' (\<lambda>tcb. tcbPriority tcb = curPrio) curThread s
-                                      \<and> curThread = ksCurThread s
-                                      \<and> obj_at' (\<lambda>tcb. tcbPriority tcb = targetPrio) candidate s"
-                        and P'=UNIV in ccorres_from_vcg)
-               apply clarsimp
-               apply (rule conseqPre, vcg)
-               apply (clarsimp simp: return_def cur_tcb'_def rf_sr_ksCurThread)
-               apply (drule (1) obj_at_cslift_tcb)+
-               apply (clarsimp simp: typ_heap_simps ctcb_relation_def to_bool_def split: if_split)
-               apply unat_arith
-              apply (wpsimp wp: threadGet_obj_at2)
+              apply (rule_tac P="\<lambda>s. obj_at' (\<lambda>tcb. tcbPriority tcb = curPrio) curThread s
+                                     \<and> curThread = ksCurThread s
+                                     \<and> obj_at' (\<lambda>tcb. tcbPriority tcb = targetPrio) candidate s"
+                       and P'=UNIV in ccorres_from_vcg)
+              apply clarsimp
+              apply (rule conseqPre, vcg)
+              apply (clarsimp simp: return_def cur_tcb'_def rf_sr_ksCurThread)
+              apply (drule (1) obj_at_cslift_tcb)+
+              apply (clarsimp simp: typ_heap_simps ctcb_relation_def split: if_split)
+              apply unat_arith
+              apply clarsimp
              apply vcg
             apply ceqv
            (* fastfail calculation complete *)
@@ -572,10 +573,10 @@ lemma schedule_ccorres:
                       in ccorres_symb_exec_r_known_rv)
                 apply clarsimp
                 apply (rule conseqPre, vcg)
-                apply (clarsimp simp: false_def cur_tcb'_def rf_sr_ksCurThread)
+                apply (clarsimp simp: cur_tcb'_def rf_sr_ksCurThread)
 
                 apply (drule (1) obj_at_cslift_tcb)+
-                apply (clarsimp simp: typ_heap_simps ctcb_relation_def to_bool_def split: if_split)
+                apply (clarsimp simp: typ_heap_simps ctcb_relation_def split: if_split)
                 apply (solves \<open>unat_arith, rule iffI; simp\<close>)
                apply ceqv
               apply clarsimp
@@ -620,9 +621,9 @@ lemma schedule_ccorres:
           apply wp
          apply (clarsimp, vcg exspec=tcbSchedEnqueue_modifies)
         apply (clarsimp, vcg exspec=tcbSchedEnqueue_modifies)
-       apply (clarsimp simp: to_bool_def true_def)
+       apply clarsimp
        apply (strengthen ko_at'_obj_at'_field)
-       apply (clarsimp cong: imp_cong simp: ko_at'_obj_at'_field to_bool_def true_def)
+       apply (clarsimp cong: imp_cong simp: ko_at'_obj_at'_field)
        apply wp
       apply clarsimp
       (* when runnable tcbSchedEnqueue curThread *)
@@ -634,7 +635,6 @@ lemma schedule_ccorres:
       apply (wp | clarsimp simp: dc_def)+
      apply (vcg exspec=tcbSchedEnqueue_modifies)
     apply wp
-   apply (clarsimp simp: to_bool_def false_def)
    apply vcg
 
   apply (clarsimp simp: tcb_at_invs' rf_sr_ksCurThread if_apply_def2 invs_queues invs_valid_objs'
@@ -645,7 +645,7 @@ lemma schedule_ccorres:
    apply (clarsimp dest!: rf_sr_cscheduler_relation simp: cscheduler_action_relation_def)
   apply (rule conjI; clarsimp)
    apply (frule (1) obj_at_cslift_tcb)
-   apply (clarsimp simp: cscheduler_action_relation_def typ_heap_simps max_word_not_0
+   apply (clarsimp simp: cscheduler_action_relation_def typ_heap_simps
                   split: scheduler_action.splits)
   apply (frule (1) obj_at_cslift_tcb)
   apply (clarsimp dest!: rf_sr_cscheduler_relation invs_sch_act_wf'

--- a/proof/crefine/X64/SyscallArgs_C.thy
+++ b/proof/crefine/X64/SyscallArgs_C.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2023, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -810,8 +811,7 @@ lemma lookupIPCBuffer_ccorres[corres]:
            apply (frule cap_get_tag_isCap_unfolded_H_cap(18),simp)
            apply (frule capFVMRights_range)
            apply (simp add: cap_frame_cap_lift)
-           apply (clarsimp simp: cap_to_H_def vmrights_to_H_def to_bool_def
-                                 word_le_make_less
+           apply (clarsimp simp: cap_to_H_def vmrights_to_H_def word_le_make_less
                                  Kernel_C.VMReadWrite_def Kernel_C.VMReadOnly_def
                                  Kernel_C.VMKernelOnly_def
                            dest: word_less_cases)

--- a/proof/crefine/X64/Syscall_C.thy
+++ b/proof/crefine/X64/Syscall_C.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2023, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -18,9 +19,6 @@ crunch sch_act_wf [wp]: replyFromKernel "\<lambda>s. sch_act_wf (ksSchedulerActi
 end
 
 context kernel_m begin
-
-(* FIXME: should do this from the beginning *)
-declare true_def [simp] false_def [simp]
 
 lemma ccorres_If_False:
   "ccorres_underlying sr Gamm r xf arrel axf R R' hs b c
@@ -659,7 +657,7 @@ lemma sendFaultIPC_ccorres:
              apply (clarsimp simp: cap_get_tag_isCap isEndpointCap_def isCap_simps
                                     ccap_relation_ep_helpers)
             apply (drule cap_get_tag_isCap(4)[symmetric])
-            apply (clarsimp simp: cap_get_tag_EndpointCap to_bool_def)
+            apply (clarsimp simp: cap_get_tag_EndpointCap)
            apply (clarsimp simp: case_bool_If)
            apply (rule_tac P=\<top> and P'=UNIV in ccorres_from_vcg_throws)
            apply clarsimp
@@ -1405,8 +1403,8 @@ lemma handleRecv_ccorres:
   apply (frule tcb_aligned'[OF tcb_at_invs'])
   apply clarsimp
   apply (intro conjI impI allI)
-             apply (clarsimp simp: cfault_rel_def seL4_Fault_CapFault_lift
-                              lookup_fault_missing_capability_lift is_cap_fault_def)+
+           apply (clarsimp simp: cfault_rel_def seL4_Fault_CapFault_lift
+                            lookup_fault_missing_capability_lift is_cap_fault_def)+
          apply (clarsimp simp: cap_get_tag_NotificationCap)
          apply (rule cmap_relationE1[OF cmap_relation_ntfn], assumption, erule ko_at_projectKO_opt)
          apply (clarsimp simp: cnotification_relation_def Let_def)

--- a/proof/crefine/X64/Tcb_C.thy
+++ b/proof/crefine/X64/Tcb_C.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2023, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -491,8 +492,8 @@ lemma checkCapAt_ccorres:
      apply assumption
     apply (simp only: when_def if_to_top_of_bind)
     apply (rule ccorres_if_lhs)
-     apply (simp add: from_bool_def true_def)
-    apply (simp add: from_bool_def false_def)
+     apply simp
+    apply simp
    apply (simp add: guard_is_UNIV_def)
   apply (clarsimp simp: cte_wp_at_ctes_of)
   done
@@ -644,13 +645,13 @@ lemma invokeTCB_ThreadControl_ccorres:
                 apply (rule checkCapAt_ccorres)
                    apply ceqv
                   apply csymbr
-                  apply (simp add: true_def Collect_True
+                  apply (simp add: Collect_True
                               del: Collect_const)
                   apply (rule ccorres_rhs_assoc)+
                   apply (rule checkCapAt_ccorres)
                      apply ceqv
                     apply csymbr
-                    apply (simp add: true_def Collect_True
+                    apply (simp add: Collect_True
                                 del: Collect_const)
                     apply (simp add: assertDerived_def bind_assoc del: Collect_const)
                     apply (rule ccorres_symb_exec_l)
@@ -691,12 +692,12 @@ lemma invokeTCB_ThreadControl_ccorres:
                        apply (clarsimp split: if_splits)
                       apply (wp empty_fail_stateAssert hoare_case_option_wp | simp del: Collect_const)+
                    apply csymbr
-                   apply (simp add: false_def Collect_False ccorres_cond_iffs
+                   apply (simp add: Collect_False ccorres_cond_iffs
                                del: Collect_const)
                    apply (rule ccorres_pre_getCurThread)
                    apply (rename_tac curThread)
                    apply (rule ccorres_split_nothrow_novcg_dc)
-                      apply (simp add: when_def to_bool_def)
+                      apply (simp add: when_def)
                       apply (rule_tac C'="{s. target = curThread}"
                                       and Q="\<lambda>s. ksCurThread s = curThread"
                                       and Q'=UNIV in ccorres_rewrite_cond_sr)
@@ -719,12 +720,12 @@ lemma invokeTCB_ThreadControl_ccorres:
                                         tcbIPCBufferSlot_def
                                         mask_def objBits_defs)
                  apply csymbr
-                 apply (simp add: if_1_0_0 Collect_False false_def ccorres_cond_iffs
+                 apply (simp add: Collect_False ccorres_cond_iffs
                              del: Collect_const)
                  apply (rule ccorres_cond_false_seq, simp)
                  apply (rule ccorres_pre_getCurThread)
                  apply (rename_tac curThread)
-                 apply (simp add: when_def to_bool_def)
+                 apply (simp add: when_def)
                  apply (rule ccorres_split_nothrow_novcg_dc)
                     apply (rule_tac C'="{s. target = curThread}"
                                     and Q="\<lambda>s. ksCurThread s = curThread"
@@ -742,7 +743,7 @@ lemma invokeTCB_ThreadControl_ccorres:
                    apply (clarsimp simp: guard_is_UNIV_def)
                   apply (wp hoare_vcg_if_lift2(1) static_imp_wp, strengthen sch_act_wf_weak; wp)
                  apply (clarsimp simp : guard_is_UNIV_def Collect_const_mem)
-                apply (simp add: guard_is_UNIV_def if_1_0_0 false_def Collect_const_mem)
+                apply (simp add: guard_is_UNIV_def Collect_const_mem)
                 apply (clarsimp simp: ccap_relation_def cap_thread_cap_lift cap_to_H_def canonical_address_bitfield_extract_tcb)
                (* \<not> P *)
                apply simp
@@ -751,7 +752,7 @@ lemma invokeTCB_ThreadControl_ccorres:
                apply (simp split: option.split_asm)
                apply (rule ccorres_pre_getCurThread)
                apply (rename_tac curThread)
-               apply (simp add: when_def to_bool_def)
+               apply (simp add: when_def)
                apply (rule ccorres_split_nothrow_novcg_dc)
                   apply (rule_tac C'="{s. target = curThread}"
                                   and Q="\<lambda>s. ksCurThread s = curThread"
@@ -830,7 +831,7 @@ lemma invokeTCB_ThreadControl_ccorres:
          apply (clarsimp simp: inQ_def Collect_const_mem cintr_def
                                exception_defs tcb_cnode_index_defs)
          apply (simp add: tcbBuffer_def tcbIPCBufferSlot_def word_sle_def
-                          cte_level_bits_def from_bool_def true_def size_of_def case_option_If2 )
+                          cte_level_bits_def size_of_def case_option_If2 )
          apply (rule conjI)
           apply (clarsimp simp: objBits_simps' word_bits_conv case_option_If2 if_n_0_0 valid_cap'_def
                                 capAligned_def obj_at'_def projectKOs)
@@ -863,34 +864,30 @@ lemma invokeTCB_ThreadControl_ccorres:
            apply (rule checkCapAt_ccorres2)
               apply ceqv
              apply csymbr
-             apply (simp add: true_def Collect_True
-                         del: Collect_const)
+             apply (simp add: Collect_True del: Collect_const)
              apply (rule ccorres_rhs_assoc)+
              apply (rule checkCapAt_ccorres2)
                 apply ceqv
                apply csymbr
-               apply (simp add: true_def Collect_True
-                                assertDerived_def bind_assoc
+               apply (simp add: Collect_True assertDerived_def bind_assoc
                                 ccorres_cond_iffs dc_def[symmetric]
                            del: Collect_const)
                apply (rule ccorres_symb_exec_l)
                   apply (ctac add: cteInsert_ccorres)
                  apply (wp empty_fail_stateAssert hoare_case_option_wp | simp del: Collect_const)+
               apply csymbr
-              apply (simp add: false_def Collect_False ccorres_cond_iffs
+              apply (simp add: Collect_False ccorres_cond_iffs
                           del: Collect_const)
               apply (rule ccorres_return_Skip[unfolded dc_def])
              apply (clarsimp simp: guard_is_UNIV_def Collect_const_mem
                                    tcbVTable_def tcbVTableSlot_def Kernel_C.tcbVTable_def
                                    cte_level_bits_def size_of_def option_to_0_def objBits_defs mask_def)
             apply csymbr
-            apply (simp add: if_1_0_0 false_def Collect_False
-                        del: Collect_const)
+            apply (simp add: Collect_False del: Collect_const)
             apply (rule ccorres_cond_false)
             apply (rule ccorres_return_Skip[unfolded dc_def])
-           apply (clarsimp simp: guard_is_UNIV_def false_def
-                                 ccap_relation_def cap_thread_cap_lift
-                                 cap_to_H_def if_1_0_0 Collect_const_mem canonical_address_bitfield_extract_tcb)
+           apply (clarsimp simp: guard_is_UNIV_def ccap_relation_def cap_thread_cap_lift
+                                 cap_to_H_def Collect_const_mem canonical_address_bitfield_extract_tcb)
           apply simp
           apply (rule ccorres_split_throws, rule ccorres_return_C_errorE, simp+)
           apply vcg
@@ -925,8 +922,7 @@ lemma invokeTCB_ThreadControl_ccorres:
                       checkCap_inv [where P="valid_cap' c" for c]
                       checkCap_inv [where P="sch_act_simple"]
                    | simp)+
-           apply (clarsimp simp: guard_is_UNIV_def from_bool_def true_def
-                                 word_sle_def if_1_0_0 Collect_const_mem
+           apply (clarsimp simp: guard_is_UNIV_def word_sle_def Collect_const_mem
                                  option_to_0_def Kernel_C.tcbVTable_def tcbVTableSlot_def
                                  cte_level_bits_def size_of_def cintr_def
                                  tcb_cnode_index_defs objBits_defs mask_def)
@@ -935,34 +931,30 @@ lemma invokeTCB_ThreadControl_ccorres:
           apply (rule checkCapAt_ccorres2)
              apply ceqv
             apply csymbr
-            apply (simp add: true_def Collect_True
-                        del: Collect_const)
+            apply (simp add: Collect_True del: Collect_const)
             apply (rule ccorres_rhs_assoc)+
             apply (rule checkCapAt_ccorres2)
                apply ceqv
               apply csymbr
-              apply (simp add: true_def Collect_True
-                               assertDerived_def bind_assoc
+              apply (simp add: Collect_True assertDerived_def bind_assoc
                                ccorres_cond_iffs dc_def[symmetric]
                           del: Collect_const)
               apply (rule ccorres_symb_exec_l)
                  apply (ctac add: cteInsert_ccorres)
                 apply (wp empty_fail_stateAssert  hoare_case_option_wp | simp del: Collect_const)+
              apply csymbr
-             apply (simp add: false_def Collect_False ccorres_cond_iffs
+             apply (simp add: Collect_False ccorres_cond_iffs
                          del: Collect_const)
              apply (rule ccorres_return_Skip[unfolded dc_def])
             apply (clarsimp simp: guard_is_UNIV_def Collect_const_mem
                                   Kernel_C.tcbCTable_def tcbCTableSlot_def if_1_0_0
                                   cte_level_bits_def size_of_def option_to_0_def mask_def objBits_defs)
            apply csymbr
-           apply (simp add: false_def Collect_False
-                       del: Collect_const)
+           apply (simp add: Collect_False del: Collect_const)
            apply (rule ccorres_cond_false)
            apply (rule ccorres_return_Skip[unfolded dc_def])
-          apply (clarsimp simp: guard_is_UNIV_def false_def
-                                ccap_relation_def cap_thread_cap_lift
-                                cap_to_H_def if_1_0_0 Collect_const_mem canonical_address_bitfield_extract_tcb)
+          apply (clarsimp simp: guard_is_UNIV_def ccap_relation_def cap_thread_cap_lift
+                                cap_to_H_def Collect_const_mem canonical_address_bitfield_extract_tcb)
          apply simp
          apply (rule ccorres_split_throws, rule ccorres_return_C_errorE, simp+)
          apply vcg
@@ -980,7 +972,7 @@ lemma invokeTCB_ThreadControl_ccorres:
                 threadSet_cap_to' static_imp_wp | simp)+
      apply (clarsimp simp: guard_is_UNIV_def tcbCTableSlot_def Kernel_C.tcbCTable_def
                            cte_level_bits_def size_of_def word_sle_def option_to_0_def
-                           true_def from_bool_def cintr_def objBits_defs mask_def)
+                           cintr_def objBits_defs mask_def)
     apply (simp add: conj_comms)
     apply (wp hoare_case_option_wp threadSet_invs_trivial
               threadSet_cap_to' static_imp_wp | simp)+
@@ -1048,7 +1040,6 @@ lemma setupReplyMaster_ccorres:
           apply (simp add: cte_to_H_def cap_to_H_def mdb_node_to_H_def
                            nullMDBNode_def c_valid_cte_def)
           apply (simp add: cap_reply_cap_lift)
-          apply (simp add: true_def mask_def to_bool_def)
          apply simp
         apply (simp add: cmachine_state_relation_def packed_heap_update_collapse_hrs
                          carch_state_relation_def carch_globals_def
@@ -1266,7 +1257,7 @@ lemma invokeTCB_CopyRegisters_ccorres:
      apply (fastforce simp: sch_act_wf_weak)
     apply (wpsimp wp: hoare_drop_imp)+
    apply (clarsimp simp add: guard_is_UNIV_def)
-  apply (clarsimp simp: to_bool_def invs_weak_sch_act_wf invs_valid_objs'
+  apply (clarsimp simp: invs_weak_sch_act_wf invs_valid_objs'
                  split: if_split cong: if_cong | rule conjI)+
      apply (clarsimp dest!: global'_no_ex_cap simp: invs'_def valid_state'_def | rule conjI)+
   done
@@ -1715,7 +1706,7 @@ lemma invokeTCB_Suspend_ccorres:
    apply (ctac(no_vcg) add: suspend_ccorres[OF cteDeleteOne_ccorres])
     apply (rule ccorres_return_CE, simp+)[1]
    apply wp
-  apply (clarsimp simp: from_bool_def true_def)
+  apply clarsimp
   apply (auto simp: invs'_def valid_state'_def global'_no_ex_cap)
   done
 
@@ -1729,7 +1720,7 @@ lemma invokeTCB_Resume_ccorres:
    apply (ctac(no_vcg) add: restart_ccorres)
     apply (rule ccorres_return_CE, simp+)[1]
    apply wp
-  apply (clarsimp simp: from_bool_def true_def)
+  apply clarsimp
   done
 
 lemma Arch_decodeTransfer_spec:
@@ -1832,7 +1823,7 @@ shows
              apply (rule ccorres_symb_exec_l[OF _ _ _ empty_fail_getThreadState])
                apply (rule ccorres_if_lhs[OF _ ccorres_False[where P'=UNIV]])
                apply (rule ccorres_if_lhs)
-                apply (simp add: Collect_True true_def whileAnno_def del: Collect_const)
+                apply (simp add: Collect_True whileAnno_def del: Collect_const)
                 apply (rule ccorres_rhs_assoc)+
                 apply csymbr
                 apply (ctac add: lookupIPCBuffer_ccorres)
@@ -2161,7 +2152,7 @@ shows
                                  X64.badgeRegister_def X64.capRegister_def
                                  "StrictC'_register_defs")
                 apply (vcg exspec=lookupIPCBuffer_modifies)
-               apply (simp add: false_def)
+               apply simp
                apply (ctac(no_vcg) add: setThreadState_ccorres)
                 apply (rule ccorres_from_vcg_throws[where P=\<top> and P'=UNIV])
                 apply (rule allI, rule conseqPre, vcg)
@@ -2191,7 +2182,7 @@ shows
      apply (vcg exspec=suspend_modifies)
     apply vcg
    apply (rule conseqPre, vcg, clarsimp)
-  apply (clarsimp simp: rf_sr_ksCurThread ct_in_state'_def true_def dc_def
+  apply (clarsimp simp: rf_sr_ksCurThread ct_in_state'_def dc_def
                  split: if_split)
   done
 
@@ -2313,7 +2304,7 @@ lemma decodeReadRegisters_ccorres:
                      valid_tcb_state'_def
               elim!: pred_tcb'_weakenE
               dest!: st_tcb_at_idle_thread')[1]
-  apply (clarsimp simp: from_bool_def word_and_1 split: if_split)
+  apply (clarsimp simp: word_and_1 split: if_split)
   done
 
 lemma decodeWriteRegisters_ccorres:
@@ -2426,8 +2417,7 @@ lemma decodeWriteRegisters_ccorres:
   apply (rule disjCI2)
   apply (clarsimp simp: genericTake_def linorder_not_less)
   apply (subst hd_conv_nth, clarsimp simp: unat_eq_0)
-  apply (clarsimp simp: from_bool_def word_and_1
-                 split: if_split)
+  apply (clarsimp simp: word_and_1 split: if_split)
   done
 
 lemma excaps_map_Nil: "(excaps_map caps = []) = (caps = [])"
@@ -2495,7 +2485,7 @@ lemma decodeCopyRegisters_ccorres:
           apply (simp add: case_bool_If if_to_top_of_bindE
                            if_to_top_of_bind
                       del: Collect_const cong: if_cong)
-          apply (simp add: to_bool_def returnOk_bind Collect_True
+          apply (simp add: returnOk_bind Collect_True
                            ccorres_invocationCatch_Inr performInvocation_def
                       del: Collect_const)
           apply (ctac add: setThreadState_ccorres)
@@ -2658,7 +2648,7 @@ lemma slotCapLongRunningDelete_ccorres:
        apply (clarsimp simp: typ_heap_simps cap_get_tag_isCap
                              from_bool_0
                       dest!: ccte_relation_ccap_relation)
-       apply (simp add: from_bool_def false_def true_def
+       apply (simp add: from_bool_def
                  split: bool.split)
        apply (auto simp add: longRunningDelete_def isCap_simps
                  split: capability.split)[1]
@@ -2666,13 +2656,12 @@ lemma slotCapLongRunningDelete_ccorres:
       apply (wp hoare_drop_imps isFinalCapability_inv)
      apply (clarsimp simp: Collect_const_mem guard_is_UNIV_def)
      apply (rename_tac rv')
-     apply (case_tac rv'; clarsimp simp: false_def true_def)
+     apply (case_tac rv'; clarsimp simp: false_def)
     apply vcg
    apply (rule conseqPre, vcg, clarsimp)
   apply (clarsimp simp: cte_wp_at_ctes_of)
   apply (erule(1) cmap_relationE1 [OF cmap_relation_cte])
-  apply (clarsimp simp: typ_heap_simps cap_get_tag_isCap
-                        from_bool_def false_def map_comp_Some_iff
+  apply (clarsimp simp: typ_heap_simps cap_get_tag_isCap map_comp_Some_iff
                  dest!: ccte_relation_ccap_relation)
   done
 
@@ -2687,7 +2676,7 @@ lemma isValidVTableRoot_spec:
     {s'. ret__unsigned_long_' s' = from_bool (isValidVTableRoot_C (cap_' s))}"
   apply vcg
   apply (clarsimp simp: isValidVTableRoot_C_def if_1_0_0 from_bool_0)
-  apply (simp add: from_bool_def to_bool_def false_def split: if_split)
+  apply (simp add: to_bool_def split: if_split)
   done
 
 lemma isValidVTableRoot_conv:
@@ -2701,9 +2690,8 @@ lemma isValidVTableRoot_conv:
    apply (case_tac "cap_get_tag cap' = scast cap_pml4_cap")
     apply (clarsimp split: arch_capability.split simp: isCap_simps)
     apply (clarsimp simp: ccap_relation_def map_option_Some_eq2
-                          cap_pml4_cap_lift cap_to_H_def
-                          from_bool_def)
-    apply (clarsimp simp: to_bool_def split: if_split)
+                          cap_pml4_cap_lift cap_to_H_def)
+    apply (clarsimp split: if_split)
    apply (clarsimp simp: cap_get_tag_isCap cap_get_tag_isCap_ArchObject)
    apply (simp split: arch_capability.split_asm add: isCap_simps)
   apply (case_tac "cap_get_tag cap' = scast cap_pml4_cap")
@@ -3018,7 +3006,7 @@ lemma decodeTCBConfigure_ccorres:
                                           in ccorres_from_vcg[where P=\<top>])
                            apply (rule allI, rule conseqPre, vcg)
                            apply (subgoal_tac "extraCaps \<noteq> []")
-                            apply (clarsimp simp: returnOk_def return_def hd_conv_nth false_def)
+                            apply (clarsimp simp: returnOk_def return_def hd_conv_nth)
                             apply fastforce
                            apply clarsimp
                           apply ceqv
@@ -3045,7 +3033,7 @@ lemma decodeTCBConfigure_ccorres:
                                                 in ccorres_from_vcg[where P=\<top>])
                                 apply (rule allI, rule conseqPre, vcg)
                                 apply (clarsimp simp: returnOk_def return_def
-                                                      hd_drop_conv_nth2 false_def)
+                                                      hd_drop_conv_nth2)
                                 apply fastforce
                                apply ceqv
                               apply (ctac add: ccorres_injection_handler_csum1
@@ -3503,9 +3491,9 @@ lemma decodeSetSchedParams_ccorres:
                    val="from_bool (length args < 2 \<or> length extraCaps = 0)" in
                    ccorres_symb_exec_r_known_rv)
       apply vcg
-      apply (auto simp: interpret_excaps_test_null excaps_map_def from_bool_def unat_eq_0
-                  split: bool.splits)[1]
-       apply (unat_arith+)[2]
+      apply (force simp: interpret_excaps_test_null excaps_map_def from_bool_def unat_eq_0
+                         unat_arith_simps
+                  split: bool.splits if_splits)
      apply ceqv
     apply clarsimp
 (*
@@ -4025,7 +4013,7 @@ lemma decodeBindNotification_ccorres:
       apply csymbr
       apply (clarsimp simp add: if_to_top_of_bind to_bool_eq_0[symmetric] simp del: Collect_const)
       apply (rule ccorres_Cond_rhs_Seq)
-       apply (clarsimp simp: to_bool_def throwError_bind invocationCatch_def)
+       apply (clarsimp simp: throwError_bind invocationCatch_def)
        apply (rule ccorres_from_vcg_split_throws[where P=\<top> and P'=UNIV])
         apply vcg
        apply (rule conseqPre, vcg)
@@ -4048,7 +4036,7 @@ lemma decodeBindNotification_ccorres:
          apply (clarsimp simp: typ_heap_simps cnotification_relation_def Let_def
                                valid_ntfn'_def)
          apply (case_tac "ntfnObj ntfn", simp_all add: isWaitingNtfn_def option_to_ctcb_ptr_def
-                             false_def true_def split: option.split_asm if_split,
+                                                split: option.split_asm if_split,
                          auto simp: neq_Nil_conv tcb_queue_relation'_def tcb_at_not_NULL[symmetric]
                                     tcb_at_not_NULL)[1]
         apply ceqv
@@ -4112,8 +4100,8 @@ lemma decodeBindNotification_ccorres:
        apply (rule conseqPre, vcg)
        apply (clarsimp simp: throwError_def return_def syscall_error_rel_def
                              syscall_error_to_H_cases exception_defs)
-      apply (clarsimp simp add: guard_is_UNIV_def isWaitingNtfn_def from_bool_0
-                                ThreadState_Restart_def mask_def true_def
+      apply (clarsimp simp add: guard_is_UNIV_def isWaitingNtfn_def
+                                ThreadState_Restart_def mask_def
                                 rf_sr_ksCurThread capTCBPtr_eq)
      apply (simp add: hd_conv_nth bindE_bind_linearise nTFN_case_If_ptr throwError_bind invocationCatch_def)
      apply (rule ccorres_from_vcg_split_throws[where P=\<top> and P'=UNIV])
@@ -4300,7 +4288,7 @@ lemma decodeSetSpace_ccorres:
                                  in ccorres_from_vcg[where P=\<top>])
                      apply (rule allI, rule conseqPre, vcg)
                      apply (subgoal_tac "extraCaps \<noteq> []")
-                      apply (clarsimp simp: returnOk_def return_def hd_conv_nth false_def)
+                      apply (clarsimp simp: returnOk_def return_def hd_conv_nth)
                       apply fastforce
                      apply clarsimp
                     apply ceqv
@@ -4327,8 +4315,7 @@ lemma decodeSetSpace_ccorres:
                            apply (rule_tac P'="{s. vRootCap = vRootCap_' s}"
                                   in ccorres_from_vcg[where P=\<top>])
                            apply (rule allI, rule conseqPre, vcg)
-                           apply (clarsimp simp: returnOk_def return_def
-                                                 hd_drop_conv_nth2 false_def)
+                           apply (clarsimp simp: returnOk_def return_def hd_drop_conv_nth2)
                            apply fastforce
                           apply ceqv
                          apply (ctac add: ccorres_injection_handler_csum1
@@ -4442,7 +4429,6 @@ lemma decodeSetSpace_ccorres:
   apply (simp add: word_sle_def cap_get_tag_isCap)
   apply (subgoal_tac "args \<noteq> []")
    apply (clarsimp simp: hd_conv_nth)
-   apply (drule sym, simp, simp add: true_def from_bool_0)
    apply (clarsimp simp: objBits_simps')
    apply fastforce
   apply clarsimp

--- a/proof/crefine/X64/VSpace_C.thy
+++ b/proof/crefine/X64/VSpace_C.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2023, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -81,7 +82,7 @@ lemma checkVPAlignment_ccorres:
        apply simp
       apply simp
      apply simp
-    apply (simp split: if_split add: to_bool_def)
+    apply (simp split: if_split)
    apply (clarsimp simp: mask_def unlessE_def throwError_def split: if_split)
    apply (rule ccorres_guard_imp)
      apply (rule ccorres_return_C)
@@ -89,7 +90,7 @@ lemma checkVPAlignment_ccorres:
       apply simp
      apply simp
     apply simp
-   apply (simp split: if_split add: to_bool_def)
+   apply (simp split: if_split)
   apply (clarsimp split: if_split)
   apply (simp add: word_less_nat_alt)
   apply (rule order_le_less_trans, rule pageBitsForSize_le)
@@ -288,7 +289,7 @@ lemma handleVMFault_ccorres:
         apply terminates_trivial
        apply (drule sym, clarsimp)
        apply (wpc; simp add: vm_fault_type_from_H_def X86InstructionFault_def X86DataFault_def
-                             true_def false_def bind_assoc)
+                             bind_assoc)
         apply (rule returnVMFault_corres;
                clarsimp simp: exception_defs mask_twice lift_rv_def)+
       apply wpsimp+
@@ -1276,13 +1277,12 @@ lemma setVMRoot_ccorres:
    apply (frule cte_wp_at_valid_objs_valid_cap'; clarsimp simp: invs_cicd_valid_objs')
    apply (clarsimp simp: isCap_simps valid_cap'_def mask_def asid_wf_def)
   apply (clarsimp simp: tcb_cnode_index_defs cte_level_bits_def tcbVTableSlot_def
-                        cte_at_tcb_at_32' to_bool_def)
+                        cte_at_tcb_at_32')
   apply (clarsimp simp: cap_get_tag_isCap_ArchObject2
                  dest!: isCapDs)
   apply (clarsimp simp: cap_get_tag_isCap_ArchObject[symmetric]
                         cap_lift_pml4_cap cap_to_H_def
-                        cap_pml4_cap_lift_def
-                        to_bool_def mask_def
+                        cap_pml4_cap_lift_def mask_def
                         ccr3_relation_defs Let_def
                         cr3_lift_def word_bw_assocs
                  elim!: ccap_relationE
@@ -1828,7 +1828,7 @@ lemma unmapPage_ccorres:
           apply (ctac add: modeUnmapPage_ccorres)
             apply (rule ccorres_from_vcg_might_throw[where P="\<top>" and P'=UNIV])
             apply (rule allI, rule conseqPre, vcg)
-            apply (clarsimp simp: true_def false_def return_def inl_rrel_def split: sum.split_asm)
+            apply (clarsimp simp: return_def inl_rrel_def split: sum.split_asm)
            apply wp
           apply (vcg exspec=modeUnmapPage_modifies)
          apply ceqv
@@ -2382,7 +2382,7 @@ lemma performASIDPoolInvocation_ccorres:
              apply (simp add: cte_to_H_def c_valid_cte_def)
              apply (simp add: cap_pml4_cap_lift)
              apply (simp (no_asm) add: cap_to_H_def)
-             apply (simp add: to_bool_def asid_bits_def le_mask_imp_and_mask word_bits_def)
+             apply (simp add: asid_bits_def le_mask_imp_and_mask word_bits_def)
              apply (clarsimp simp: c_valid_cap_def cl_valid_cap_def)
              apply (erule (1) cap_lift_PML4Cap_Base)
             apply simp

--- a/proof/crefine/X64/Wellformed_C.thy
+++ b/proof/crefine/X64/Wellformed_C.thy
@@ -284,63 +284,6 @@ definition
                    | Some cap \<Rightarrow> Some \<lparr> cap_CL = cap,
                                        cteMDBNode_CL = mdb_node_lift (cteMDBNode_C c) \<rparr>"
 
-lemma to_bool_false [simp]: "\<not> to_bool false"
-  by (simp add: to_bool_def false_def)
-
-(* this is slightly weird, but the bitfield generator
-   masks everything with the expected bit length.
-   So we do that here too. *)
-definition
-  to_bool_bf :: "'a::len word \<Rightarrow> bool" where
-  "to_bool_bf w \<equiv> (w && mask 1) = 1"
-
-lemma to_bool_bf_mask1 [simp]:
-  "to_bool_bf (mask (Suc 0))"
-  by (simp add: mask_def to_bool_bf_def)
-
-lemma to_bool_bf_0 [simp]: "\<not>to_bool_bf 0"
-  by (simp add: to_bool_bf_def)
-
-lemma to_bool_bf_1 [simp]: "to_bool_bf 1"
-  by (simp add: to_bool_bf_def mask_def)
-
-lemma to_bool_bf_false [simp]:
-  "\<not>to_bool_bf false"
-  by (simp add: false_def)
-
-lemma to_bool_bf_true [simp]:
-  "to_bool_bf true"
-  by (simp add: true_def)
-
-lemma to_bool_to_bool_bf:
-  "w = false \<or> w = true \<Longrightarrow> to_bool_bf w = to_bool w"
-  by (auto simp: false_def true_def to_bool_def to_bool_bf_def mask_def)
-
-lemma to_bool_bf_mask_1 [simp]:
-  "to_bool_bf (w && mask (Suc 0)) = to_bool_bf w"
-  by (simp add: to_bool_bf_def)
-
-lemma to_bool_bf_and [simp]:
-  "to_bool_bf (a && b) = (to_bool_bf a \<and> to_bool_bf (b::word64))"
-  apply (clarsimp simp: to_bool_bf_def)
-  apply (rule iffI)
-   apply (subst (asm) bang_eq)
-   apply (simp add: word_size)
-   apply (rule conjI)
-    apply (rule word_eqI)
-    apply (auto simp add: word_size)[1]
-   apply (rule word_eqI)
-   apply (auto simp add: word_size)[1]
-  apply clarsimp
-  apply (rule word_eqI)
-  apply (subst (asm) bang_eq)+
-  apply (auto simp add: word_size)[1]
-  done
-
-lemma to_bool_bf_to_bool_mask:
-  "w && mask (Suc 0) = w \<Longrightarrow> to_bool_bf w = to_bool (w::word64)"
-  by (metis mask_Suc_0 bool_mask mask_1 to_bool_0 to_bool_1 to_bool_bf_def word_gt_0)
-
 definition
   mdb_node_to_H :: "mdb_node_CL \<Rightarrow> mdbnode"
   where

--- a/proof/crefine/lib/Boolean_C.thy
+++ b/proof/crefine/lib/Boolean_C.thy
@@ -1,0 +1,138 @@
+(*
+ * Copyright 2023, Proofcraft Pty Ltd
+ * Copyright 2014, General Dynamics C4 Systems
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+(* Definitions and rules for C boolean constants parsed from the kernel *)
+
+theory Boolean_C
+imports
+  "CSpec.KernelInc_C"
+begin
+
+lemma true_and_1[simp]:
+  "true && 1 = true"
+  "signed true && 1 = signed true"
+  "unsigned true && 1 = unsigned true"
+  by (simp add: true_def)+
+
+lemma to_bool_true[simp]:
+  "to_bool true"
+  "to_bool (signed true)"
+  "to_bool (unsigned true)"
+  by (simp add: to_bool_def true_def)+
+
+lemma true_equals_simps[simp]:
+  "true = 1 \<longleftrightarrow> True"
+  "signed true = 1 \<longleftrightarrow> True"
+  "unsigned true = 1 \<longleftrightarrow> True"
+  "true = 0 \<longleftrightarrow> False"
+  "signed true = 0 \<longleftrightarrow> False"
+  "unsigned true = 0 \<longleftrightarrow> False"
+  by (simp add: true_def)+
+
+lemma true_eq_from_bool[simp]:
+  "(true = from_bool P) = P"
+  "(signed true = from_bool P) = P"
+  "(unsigned true = from_bool P) = P"
+  by (simp add: from_bool_def split: bool.splits)+
+
+lemma false_and_1[simp]:
+  "false && 1 = false"
+  "signed false && 1 = signed false"
+  "unsigned false && 1 = unsigned false"
+  by (simp add: false_def)+
+
+lemma to_bool_false[simp]:
+  "\<not> to_bool false"
+  "\<not> to_bool (signed false)"
+  "\<not> to_bool (unsigned false)"
+  by (simp add: to_bool_def false_def)+
+
+lemma false_equals_simps[simp]:
+  "false = 0 \<longleftrightarrow> True"
+  "signed false = 0 \<longleftrightarrow> True"
+  "unsigned false = 0 \<longleftrightarrow> True"
+  "false = 1 \<longleftrightarrow> False"
+  "signed false = 1 \<longleftrightarrow> False"
+  "unsigned false = 1 \<longleftrightarrow> False"
+  by (simp add: false_def)+
+
+lemma false_eq_from_bool[simp]:
+  "(false = from_bool P) = (\<not> P)"
+  "(signed false = from_bool P) = (\<not> P)"
+  "(unsigned false = from_bool P) = (\<not> P)"
+  by (simp add: from_bool_def split: bool.splits)+
+
+lemma from_bool_vals[simp]:
+  "from_bool True = signed true"
+  "from_bool False = signed false"
+  by (simp add: from_bool_def)+
+
+lemma true_neq_false[simp]:
+  "true \<noteq> false"
+  "signed true \<noteq> signed false"
+  "unsigned true \<noteq> unsigned false"
+  by (simp add: true_def false_def)+
+
+(* The bitfield generator masks everything with the expected bit length, so we do that here too. *)
+definition
+  to_bool_bf :: "'a::len word \<Rightarrow> bool" where
+  "to_bool_bf w \<equiv> (w && mask 1) = 1"
+
+lemma to_bool_bf_mask1[simp]:
+  "to_bool_bf (mask (Suc 0))"
+  by (simp add: mask_def to_bool_bf_def)
+
+lemma to_bool_bf_0[simp]:
+  "\<not>to_bool_bf 0"
+  by (simp add: to_bool_bf_def)
+
+lemma to_bool_bf_1[simp]:
+  "to_bool_bf 1"
+  by (simp add: to_bool_bf_def mask_def)
+
+lemma to_bool_bf_false[simp]:
+  "\<not>to_bool_bf false"
+  by (simp add: false_def)
+
+lemma to_bool_bf_true[simp]:
+  "to_bool_bf true"
+  by (simp add: true_def)
+
+lemma to_bool_to_bool_bf:
+  "w = false \<or> w = true \<Longrightarrow> to_bool_bf w = to_bool w"
+  by (auto simp: false_def true_def to_bool_def to_bool_bf_def mask_def)
+
+lemma to_bool_bf_mask_1[simp]:
+  "to_bool_bf (w && mask (Suc 0)) = to_bool_bf w"
+  by (simp add: to_bool_bf_def)
+
+lemma to_bool_bf_and[simp]:
+  "to_bool_bf (a && b) = (to_bool_bf a \<and> to_bool_bf b)"
+  apply (clarsimp simp: to_bool_bf_def)
+  apply (rule iffI)
+   apply (subst (asm) bang_eq)
+   apply (simp add: word_size)
+   apply (rule conjI)
+    apply (rule word_eqI)
+    apply (auto simp add: word_size)[1]
+   apply (rule word_eqI)
+   apply (auto simp add: word_size)[1]
+  apply clarsimp
+  apply (rule word_eqI)
+  apply (subst (asm) bang_eq)+
+  apply (auto simp add: word_size)[1]
+  done
+
+lemma to_bool_bf_to_bool_mask:
+  "w && mask (Suc 0) = w \<Longrightarrow> to_bool_bf w = to_bool (w::machine_word)"
+  by (metis mask_Suc_0 bool_mask mask_1 to_bool_0 to_bool_1 to_bool_bf_def word_gt_0)
+
+lemma to_bool_mask_to_bool_bf:
+  "to_bool (x && 1) = to_bool_bf (x::machine_word)"
+  by (simp add: to_bool_bf_def to_bool_def)
+
+end


### PR DESCRIPTION
These rules allow the simplifier to solve almost all existing goals that involve the C constants `true` and `false`, without unfolding their definitions.

Apologies for making this PR hard to review, the relevant rules are in `Wellformed_C`. All of the other changes are removing definition unfolds that are now unnecessary, and fixing style and indentation in touched lemmas.

There almost definitely could be similar rules for `to_bool` and `from_bool` that would further improve the automation, but I don't think that that is worth exploring now.