### PR TITLE
cspec: Allow kernel build export from older l4v

### DIFF
--- a/spec/cspec/c/overlays/AARCH64/default-overlay.dts
+++ b/spec/cspec/c/overlays/AARCH64/default-overlay.dts
@@ -1,6 +1,0 @@
-/*
- * Copyright 2023, Proofcraft Pty Ltd
- * SPDX-License-Identifier: GPL-2.0-only
- */
-
-/* Empty overlay file that will be used if no custom `overlay.dts` exists. */

--- a/spec/cspec/c/overlays/ARM/default-overlay.dts
+++ b/spec/cspec/c/overlays/ARM/default-overlay.dts
@@ -1,6 +1,0 @@
-/*
- * Copyright 2023, Proofcraft Pty Ltd
- * SPDX-License-Identifier: GPL-2.0-only
- */
-
-/* Empty overlay file that will be used if no custom `overlay.dts` exists. */

--- a/spec/cspec/c/overlays/ARM_HYP/default-overlay.dts
+++ b/spec/cspec/c/overlays/ARM_HYP/default-overlay.dts
@@ -1,6 +1,0 @@
-/*
- * Copyright 2023, Proofcraft Pty Ltd
- * SPDX-License-Identifier: GPL-2.0-only
- */
-
-/* Empty overlay file that will be used if no custom `overlay.dts` exists. */

--- a/spec/cspec/c/overlays/README.md
+++ b/spec/cspec/c/overlays/README.md
@@ -6,10 +6,10 @@
 
 # DTS Overlays
 
-This directory contains device tree overlay files that can be used to override
-default platform parameters such as available memory regions.
+This directory can be used to supply custom device tree overlay files that
+override default platform parameters such as available memory regions.
 
-The default files in the repository are all empty.
+Without a custom overlay, the seL4 kernel build will use an empty overlay file.
 
 To provide an override, place a file `overlay.dts` into the respective
 architecture directory, e.g. `ARM/overlay.dts`.
@@ -18,5 +18,5 @@ The l4v build system will pick up this overlay file when it generates the
 kernel configuration data and preprocessed kernel code. It will rebuild proof
 sessions according to their dependencies.
 
-The `X64` build does not support overlays, and therefore does not provide a
-default.
+The `X64` build does not support overlays, so an overlay in an `X64`
+subdirectory will be ignored.

--- a/spec/cspec/c/overlays/RISCV64/default-overlay.dts
+++ b/spec/cspec/c/overlays/RISCV64/default-overlay.dts
@@ -1,6 +1,0 @@
-/*
- * Copyright 2023, Proofcraft Pty Ltd
- * SPDX-License-Identifier: GPL-2.0-only
- */
-
-/* Empty overlay file that will be used if no custom `overlay.dts` exists. */


### PR DESCRIPTION
In `export-kernel-builds.py`, we allow using two different l4 checkouts:
- one in which to look for l4v kernel build artifacts, and
- one to provide the kernel build and export machinery.

This is occasionally useful for binary verification (BV), since it allows us to obtain kernel build artifacts in the format expected by BV, from older l4v versions that lack the export machinery.

Additionally, in the l4v kernel build (`kernel.mk`), we change the way device tree overlays are handled, to avoid the need to create files in the l4v checkout providing the build export machinery. This makes it possible to build using read-only l4v checkouts.