### PR TITLE
ci: Fix broken external workflow

### DIFF
--- a/.github/workflows/external.yml
+++ b/.github/workflows/external.yml
@@ -11,7 +11,7 @@ on:
     - cron: '1 15 1,15 * *'  # 15:01 UTC on 1st and 15th of month
 
 jobs:
-  all:
+  proofs:
     name: Proofs
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
A previous commit added a new job which depended on a job that didn't exist. We rename the `all` job to `proofs` for consistency with other workflows.

Fixes #611.