### PR TITLE
physBase abstraction

### DIFF
--- a/lib/Word_Lib/Word_Lemmas_Internal.thy
+++ b/lib/Word_Lib/Word_Lemmas_Internal.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2023, Proofcraft Pty Ltd
  * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -717,5 +718,24 @@ lemma mask_alignment_ugliness:
   apply (subst word_plus_and_or_coroll; word_eqI)
    apply (meson linorder_not_le)
   by (auto simp: le_def)
+
+lemma word_and_mask_shift_eq_0:
+  "n \<le> m \<Longrightarrow> x && mask n >> m = 0"
+  by word_eqI
+
+lemma word_mask_and_neg_shift_eq_0:
+  "n < m \<Longrightarrow> - (1 << m) && mask n = 0"
+  by (metis NOT_mask_AND_mask add.inverse_neutral leD less_imp_le mask_AND_NOT_mask mask_eqs(10)
+            shiftl_1 t2n_mask_eq_if)
+
+lemma aligned_mask_plus_bounded:
+  "\<lbrakk> is_aligned x m; m < n; n < LENGTH('a) \<rbrakk> \<Longrightarrow> (x && mask n) + 2^m \<le> 2^n" for x :: "'a::len word"
+  by (metis add_mask_fold and_mask_less' is_aligned_add_step_le is_aligned_after_mask is_aligned_mask
+            leD leI order_less_imp_le t2n_mask_eq_if word_less_sub_1)
+
+lemma aligned_mask_le_mask_minus:
+  "\<lbrakk> is_aligned x m; m \<le> n; n < LENGTH('a)\<rbrakk> \<Longrightarrow> x && mask n \<le> mask n - mask m" for x :: "'a::len word"
+  by (metis and_mask_less' is_aligned_after_mask is_aligned_neg_mask_eq'
+           mask_2pm1 mask_sub neg_mask_mono_le word_less_sub_le)
 
 end

--- a/proof/access-control/ARM/ArchADT_AC.thy
+++ b/proof/access-control/ARM/ArchADT_AC.thy
@@ -101,7 +101,7 @@ lemma ptable_state_objs_to_policy:
                       vspace_cap_rights_to_auth b)" in bexI)
    apply clarsimp
    apply (rule_tac x="(ptrFromPAddr a + (x && mask aa), auth)" in image_eqI)
-    apply (simp add: ptrFromPAddr_def pptrBaseOffset_def pptrBase_def Kernel_Config.physBase_def)
+    apply (simp add: ptrFromPAddr_def)
    apply (simp add: ptr_offset_in_ptr_range)
   apply (simp add: kernel_mappings_kernel_mapping_slots')
   apply (clarsimp simp: graph_of_def)
@@ -165,7 +165,7 @@ lemma get_page_info_state_objs_to_policy:
                       vspace_cap_rights_to_auth r)" in bexI)
    apply clarsimp
    apply (rule_tac x="(ptrFromPAddr base + (x && mask sz), auth)" in image_eqI)
-    apply (simp add: ptrFromPAddr_def pptrBaseOffset_def pptrBase_def Kernel_Config.physBase_def)
+    apply (simp add: ptrFromPAddr_def)
    apply (simp add: ptr_offset_in_ptr_range)
   apply (clarsimp simp: get_page_info_def get_pd_entry_def get_pt_info_def
                         get_pt_entry_def get_arch_obj_def pte_ref_def graph_of_def

--- a/proof/crefine/ARM/ArchMove_C.thy
+++ b/proof/crefine/ARM/ArchMove_C.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2023, Proofcraft Pty Ltd
  * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
  * Copyright 2014, General Dynamics C4 Systems
  *
@@ -234,6 +235,22 @@ crunches insertNewCap, Arch_createNewCaps, threadSet, Arch.createObject, setThre
   (wp: crunch_wps setObject_ksPSpace_only
    simp: unless_def updateObject_default_def crunch_simps
    ignore_del: preemptionPoint)
+
+lemma addrFromPPtr_mask[simplified ARM.pageBitsForSize_simps]:
+  "n \<le> pageBitsForSize ARMSuperSection
+   \<Longrightarrow> addrFromPPtr ptr && mask n = ptr && mask n"
+  apply (simp add: addrFromPPtr_def)
+  apply (prop_tac "pptrBaseOffset AND mask n = 0")
+   apply (rule mask_zero[OF is_aligned_weaken[OF pptrBaseOffset_aligned]], simp)
+  apply (simp flip: mask_eqs(8))
+  done
+
+(* this could be done as
+   lemmas addrFromPPtr_mask_5 = addrFromPPtr_mask[where n=5, simplified]
+   but that wouldn't give a sanity check of the n \<le> ... assumption  disappearing *)
+lemma addrFromPPtr_mask_5:
+  "addrFromPPtr ptr && mask 5 = ptr && mask 5"
+  by (rule addrFromPPtr_mask[where n=5, simplified])
 
 end
 

--- a/proof/crefine/ARM/Invoke_C.thy
+++ b/proof/crefine/ARM/Invoke_C.thy
@@ -1514,15 +1514,6 @@ lemma pspace_no_overlap_underlying_zero_update:
   apply blast
   done
 
-lemma addrFromPPtr_mask:
-  "n \<le> 28
-    \<Longrightarrow> addrFromPPtr ptr && mask n = ptr && mask n"
-  apply (simp add: addrFromPPtr_def pptrBaseOffset_def pptrBase_def
-                   Kernel_Config.physBase_def)
-  apply word_bitwise
-  apply simp
-  done
-
 lemma clearMemory_untyped_ccorres:
   "ccorres dc xfdc ((\<lambda>s. invs' s
               \<and> (\<exists>cap. cte_wp_at' (\<lambda>cte. cteCap cte = cap) ut_slot s

--- a/proof/crefine/ARM_HYP/ArchMove_C.thy
+++ b/proof/crefine/ARM_HYP/ArchMove_C.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2023, Proofcraft Pty Ltd
  * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
  * Copyright 2014, General Dynamics C4 Systems
  *
@@ -633,6 +634,17 @@ crunches insertNewCap, Arch_createNewCaps, threadSet, Arch.createObject, setThre
   (wp: crunch_wps setObject_ksPSpace_only
    simp: unless_def updateObject_default_def crunch_simps
    ignore_del: preemptionPoint)
+
+(* this could be done as
+   lemmas addrFromPPtr_mask_6 = addrFromPPtr_mask[where n=6, simplified]
+   but that wouldn't give a sanity check of the n \<le> ... assumption  disappearing *)
+lemma addrFromPPtr_mask_6:
+  "addrFromPPtr ptr && mask 6 = ptr && mask 6"
+  by (rule addrFromPPtr_mask[where n=6, simplified])
+
+lemma ptrFromPAddr_mask_6:
+  "ptrFromPAddr ps && mask 6 = ps && mask 6"
+  by (rule ptrFromPAddr_mask[where n=6, simplified])
 
 end
 

--- a/proof/crefine/ARM_HYP/Invoke_C.thy
+++ b/proof/crefine/ARM_HYP/Invoke_C.thy
@@ -1672,15 +1672,6 @@ lemma pspace_no_overlap_underlying_zero_update:
   apply blast
   done
 
-lemma addrFromPPtr_mask:
-  "n \<le> 28
-    \<Longrightarrow> addrFromPPtr ptr && mask n = ptr && mask n"
-  apply (simp add: addrFromPPtr_def pptrBaseOffset_def pptrBase_def
-                   Kernel_Config.physBase_def)
-  apply word_bitwise
-  apply simp
-  done
-
 lemma clearMemory_untyped_ccorres:
   "ccorres dc xfdc ((\<lambda>s. invs' s
               \<and> (\<exists>cap. cte_wp_at' (\<lambda>cte. cteCap cte = cap) ut_slot s

--- a/proof/crefine/ARM_HYP/VSpace_C.thy
+++ b/proof/crefine/ARM_HYP/VSpace_C.thy
@@ -2681,11 +2681,6 @@ lemma ccorres_seq_IF_False:
   "ccorres_underlying sr \<Gamma> r xf arrel axf G G' hs a (IF False THEN x ELSE y FI ;; c) = ccorres_underlying sr \<Gamma> r xf arrel axf G G' hs a (y ;; c)"
   by simp
 
-lemma ptrFromPAddr_mask6_simp[simp]:
-  "ptrFromPAddr ps && mask 6 = ps && mask 6"
-  unfolding ptrFromPAddr_def pptrBaseOffset_def pptrBase_def Kernel_Config.physBase_def
-  by (subst add.commute, subst mask_add_aligned ; simp add: is_aligned_def)
-
 lemma doFlush_ccorres:
   "ccorres dc xfdc (\<lambda>s. vs \<le> ve \<and> ps \<le> ps + (ve - vs) \<and> vs && mask 6 = ps && mask 6
         \<comment> \<open>ahyp version translates ps into kernel virtual before flushing\<close>
@@ -2741,6 +2736,7 @@ lemma doFlush_ccorres:
                         Kernel_C.ARMPageInvalidate_Data_def Kernel_C.ARMPDInvalidate_Data_def
                         Kernel_C.ARMPageCleanInvalidate_Data_def Kernel_C.ARMPDCleanInvalidate_Data_def
                         Kernel_C.ARMPageUnify_Instruction_def Kernel_C.ARMPDUnify_Instruction_def
+                        ptrFromPAddr_mask_6
                   dest: ghost_assertion_size_logic[rotated]
                  split: ARM_HYP_H.flush_type.splits)
   done

--- a/proof/crefine/RISCV64/VSpace_C.thy
+++ b/proof/crefine/RISCV64/VSpace_C.thy
@@ -868,7 +868,7 @@ lemma addrFromKPPtr_spec:
    \<lbrace>\<acute>ret__unsigned_long = addrFromKPPtr (ptr_val (pptr_' s))\<rbrace>"
   apply vcg
   apply (simp add: addrFromKPPtr_def kernelELFBaseOffset_def
-                   kernelELFBase_def kernelELFPAddrBase_def mask_def)
+                   kernelELFBase_def kernelELFPAddrBase_def mask_def pptrTop_def)
   done
 
 lemma isValidVTableRoot_def2:

--- a/proof/infoflow/RISCV64/Example_Valid_State.thy
+++ b/proof/infoflow/RISCV64/Example_Valid_State.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2023, Proofcraft Pty Ltd
  * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -8,6 +9,7 @@ theory Example_Valid_State
 imports
   "ArchNoninterference"
   "Lib.Distinct_Cmd"
+  "AInvs.KernelInit_AI"
 begin
 
 section \<open>Example\<close>
@@ -218,7 +220,8 @@ definition "High_cnode_ptr = pptr_base + 0x18000"
 definition "Silc_cnode_ptr = pptr_base + 0x20000"
 definition "irq_cnode_ptr = pptr_base + 0x28000"
 
-definition "shared_page_ptr = pptr_base + 0x200000"
+definition "shared_page_ptr_virt = pptr_base + 0x200000"
+definition "shared_page_ptr_phys = addrFromPPtr shared_page_ptr_virt"
 
 definition "timer_irq \<equiv> 10" (* not sure exactly how this fits in *)
 
@@ -236,15 +239,15 @@ lemmas s0_ptr_defs =
   ntfn_ptr_def irq_cnode_ptr_def Low_pd_ptr_def High_pd_ptr_def Low_pt_ptr_def High_pt_ptr_def
   Low_tcb_ptr_def High_tcb_ptr_def idle_tcb_ptr_def timer_irq_def Low_prio_def High_prio_def
   Low_time_slice_def Low_domain_def High_domain_def init_irq_node_ptr_def riscv_global_pt_ptr_def
-  pptr_base_def pptrBase_def canonical_bit_def shared_page_ptr_def
+  pptr_base_def pptrBase_def canonical_bit_def shared_page_ptr_virt_def
 
 (* Distinctness proof of kernel pointers. *)
 
 distinct ptrs_distinct[simp]:
   Low_tcb_ptr High_tcb_ptr idle_tcb_ptr ntfn_ptr
-  Low_pt_ptr High_pt_ptr shared_page_ptr Low_pd_ptr High_pd_ptr
+  Low_pt_ptr High_pt_ptr shared_page_ptr_virt Low_pd_ptr High_pd_ptr
   Low_cnode_ptr High_cnode_ptr Low_pool_ptr High_pool_ptr
-  Silc_cnode_ptr irq_cnode_ptr riscv_global_pt_ptr shared_page_ptr
+  Silc_cnode_ptr irq_cnode_ptr riscv_global_pt_ptr
   by (auto simp: s0_ptr_defs)
 
 
@@ -384,7 +387,7 @@ definition Low_caps :: cnode_contents where
       (the_nat_to_bl_10 4)
         \<mapsto> ArchObjectCap (ASIDPoolCap Low_pool_ptr Low_asid),
       (the_nat_to_bl_10 5)
-        \<mapsto> ArchObjectCap (FrameCap shared_page_ptr vm_read_write RISCVLargePage False (Some (Low_asid,0))),
+        \<mapsto> ArchObjectCap (FrameCap shared_page_ptr_virt vm_read_write RISCVLargePage False (Some (Low_asid,0))),
       (the_nat_to_bl_10 6)
         \<mapsto> ArchObjectCap (PageTableCap Low_pt_ptr (Some (Low_asid,0))),
       (the_nat_to_bl_10 318)
@@ -413,7 +416,7 @@ lemma Low_caps_ran:
       ArchObjectCap (PageTableCap Low_pd_ptr (Some (Low_asid,0))),
       ArchObjectCap (PageTableCap Low_pt_ptr (Some (Low_asid,0))),
       ArchObjectCap (ASIDPoolCap Low_pool_ptr Low_asid),
-      ArchObjectCap (FrameCap shared_page_ptr vm_read_write RISCVLargePage False (Some (Low_asid,0))),
+      ArchObjectCap (FrameCap shared_page_ptr_virt vm_read_write RISCVLargePage False (Some (Low_asid,0))),
       NotificationCap ntfn_ptr 0 {AllowSend},
       NullCap}"
   apply (rule equalityI)
@@ -438,7 +441,7 @@ definition High_caps :: cnode_contents where
         (the_nat_to_bl_10 4)
           \<mapsto> ArchObjectCap (ASIDPoolCap High_pool_ptr High_asid),
         (the_nat_to_bl_10 5)
-          \<mapsto> ArchObjectCap (FrameCap shared_page_ptr vm_read_only RISCVLargePage False (Some (High_asid,0))),
+          \<mapsto> ArchObjectCap (FrameCap shared_page_ptr_virt vm_read_only RISCVLargePage False (Some (High_asid,0))),
         (the_nat_to_bl_10 6)
           \<mapsto> ArchObjectCap (PageTableCap High_pt_ptr (Some (High_asid,0))),
         (the_nat_to_bl_10 318)
@@ -454,7 +457,7 @@ lemma High_caps_ran:
       ArchObjectCap (PageTableCap High_pd_ptr (Some (High_asid,0))),
       ArchObjectCap (PageTableCap High_pt_ptr (Some (High_asid,0))),
       ArchObjectCap (ASIDPoolCap High_pool_ptr High_asid),
-      ArchObjectCap (FrameCap shared_page_ptr vm_read_only RISCVLargePage False (Some (High_asid,0))),
+      ArchObjectCap (FrameCap shared_page_ptr_virt vm_read_only RISCVLargePage False (Some (High_asid,0))),
       NotificationCap ntfn_ptr 0 {AllowRecv},
       NullCap}"
   apply (rule equalityI)
@@ -473,7 +476,7 @@ definition Silc_caps :: cnode_contents where
        ((the_nat_to_bl_10 2)
           \<mapsto> CNodeCap Silc_cnode_ptr 10 (the_nat_to_bl_10 2),
         (the_nat_to_bl_10 5)
-          \<mapsto> ArchObjectCap (FrameCap shared_page_ptr vm_read_only RISCVLargePage False (Some (Silc_asid,0))),
+          \<mapsto> ArchObjectCap (FrameCap shared_page_ptr_virt vm_read_only RISCVLargePage False (Some (Silc_asid,0))),
         (the_nat_to_bl_10 318)
           \<mapsto> NotificationCap ntfn_ptr 0 {AllowSend} )"
 
@@ -483,7 +486,7 @@ definition Silc_cnode :: kernel_object where
 lemma Silc_caps_ran:
   "ran Silc_caps =
      {CNodeCap Silc_cnode_ptr 10 (the_nat_to_bl_10 2),
-      ArchObjectCap (FrameCap shared_page_ptr vm_read_only RISCVLargePage False (Some (Silc_asid,0))),
+      ArchObjectCap (FrameCap shared_page_ptr_virt vm_read_only RISCVLargePage False (Some (Silc_asid,0))),
       NotificationCap ntfn_ptr 0 {AllowSend},
       NullCap}"
   apply (rule equalityI)
@@ -514,7 +517,7 @@ abbreviation ppn_from_addr :: "paddr \<Rightarrow> pte_ppn" where
 abbreviation Low_pt' :: pt where
   "Low_pt' \<equiv>
      (\<lambda>_. InvalidPTE)
-       (0 := PagePTE (ppn_from_addr (addrFromPPtr shared_page_ptr)) {} vm_read_write)"
+       (0 := PagePTE (ppn_from_addr shared_page_ptr_phys) {} vm_read_write)"
 
 definition Low_pt :: kernel_object where
   "Low_pt \<equiv> ArchObj (PageTable Low_pt')"
@@ -533,7 +536,7 @@ text \<open>High's VSpace (PageDirectory)\<close>
 abbreviation High_pt' :: pt where
   "High_pt' \<equiv>
      (\<lambda>_. InvalidPTE)
-       (0 := PagePTE (ppn_from_addr (addrFromPPtr shared_page_ptr)) {} vm_read_only)"
+       (0 := PagePTE (ppn_from_addr shared_page_ptr_phys) {} vm_read_only)"
 
 definition High_pt :: kernel_object where
   "High_pt \<equiv> ArchObj (PageTable High_pt')"
@@ -643,7 +646,7 @@ definition kh0 :: kheap where
           Low_tcb_ptr    \<mapsto> Low_tcb,
           High_tcb_ptr   \<mapsto> High_tcb,
           idle_tcb_ptr   \<mapsto> idle_tcb,
-          shared_page_ptr \<mapsto> shared_page,
+          shared_page_ptr_virt \<mapsto> shared_page,
           riscv_global_pt_ptr \<mapsto> init_global_pt)"
 
 lemma irq_node_offs_min:
@@ -725,7 +728,7 @@ lemma irq_node_offs_range_distinct[simp]:
   "High_tcb_ptr \<notin> irq_node_offs_range"
   "idle_tcb_ptr \<notin> irq_node_offs_range"
   "riscv_global_pt_ptr \<notin> irq_node_offs_range"
-  "shared_page_ptr \<notin> irq_node_offs_range"
+  "shared_page_ptr_virt \<notin> irq_node_offs_range"
   by(simp add:irq_node_offs_range_def s0_ptr_defs)+
 
 lemma irq_node_offs_distinct[simp]:
@@ -744,11 +747,11 @@ lemma irq_node_offs_distinct[simp]:
   "init_irq_node_ptr + (ucast (irq:: irq) << 5) \<noteq> High_tcb_ptr"
   "init_irq_node_ptr + (ucast (irq:: irq) << 5) \<noteq> idle_tcb_ptr"
   "init_irq_node_ptr + (ucast (irq:: irq) << 5) \<noteq> riscv_global_pt_ptr"
-  "init_irq_node_ptr + (ucast (irq:: irq) << 5) \<noteq> shared_page_ptr"
+  "init_irq_node_ptr + (ucast (irq:: irq) << 5) \<noteq> shared_page_ptr_virt"
   by (simp add:not_inD[symmetric, OF _ irq_node_offs_in_range])+
 
 lemma kh0_dom:
-  "dom kh0 = {shared_page_ptr, riscv_global_pt_ptr, idle_tcb_ptr, High_tcb_ptr, Low_tcb_ptr,
+  "dom kh0 = {shared_page_ptr_virt, riscv_global_pt_ptr, idle_tcb_ptr, High_tcb_ptr, Low_tcb_ptr,
               High_pt_ptr, Low_pt_ptr, High_pd_ptr, Low_pd_ptr, irq_cnode_ptr, ntfn_ptr,
               Silc_cnode_ptr, High_pool_ptr, Low_pool_ptr, High_cnode_ptr, Low_cnode_ptr}
            \<union> irq_node_offs_range"
@@ -764,7 +767,7 @@ lemmas kh0_SomeD' = set_mp[OF equalityD1[OF kh0_dom[simplified dom_def]], OF Col
 
 lemma kh0_SomeD:
   "kh0 x = Some y \<Longrightarrow>
-        x = shared_page_ptr \<and> y = shared_page \<or>
+        x = shared_page_ptr_virt \<and> y = shared_page \<or>
         x = riscv_global_pt_ptr \<and> y = init_global_pt \<or>
         x = idle_tcb_ptr \<and> y = idle_tcb \<or>
         x = High_tcb_ptr \<and> y = High_tcb \<or>
@@ -839,7 +842,7 @@ definition s0_internal :: "det_ext state" where
 
 lemma kh_s0_def:
   "(kheap s0_internal x = Some y) = (
-        x = shared_page_ptr \<and> y = shared_page \<or>
+        x = shared_page_ptr_virt \<and> y = shared_page \<or>
         x = riscv_global_pt_ptr \<and> y = init_global_pt \<or>
         x = idle_tcb_ptr \<and> y = idle_tcb \<or>
         x = High_tcb_ptr \<and> y = High_tcb \<or>
@@ -866,7 +869,7 @@ subsubsection \<open>Defining the policy graph\<close>
 definition Sys1AgentMap :: "(auth_graph_label subject_label) agent_map" where
   "Sys1AgentMap \<equiv>
    \<comment> \<open>set the range of the shared_page to Low, default everything else to IRQ0\<close>
-   (\<lambda>p. if shared_page_ptr \<le> p \<and> p < shared_page_ptr + 0x200000
+   (\<lambda>p. if p \<in> ptr_range shared_page_ptr_virt (pageBitsForSize RISCVLargePage)
         then partition_label Low
         else partition_label IRQ0)
    (Low_cnode_ptr := partition_label Low,
@@ -899,11 +902,11 @@ lemma Sys1AgentMap_simps:
   "Sys1AgentMap Low_tcb_ptr = partition_label Low"
   "Sys1AgentMap High_tcb_ptr = partition_label High"
   "Sys1AgentMap idle_tcb_ptr = partition_label Low"
-  "\<And>p. \<lbrakk> shared_page_ptr \<le> p; p < shared_page_ptr + 0x200000 \<rbrakk>
+  "\<And>p. p \<in> ptr_range shared_page_ptr_virt (pageBitsForSize RISCVLargePage)
          \<Longrightarrow> Sys1AgentMap p = partition_label Low"
   unfolding Sys1AgentMap_def
   apply simp_all
-  by (auto simp: ptrFromPAddr_def pptrBaseOffset_def paddrBase_def s0_ptr_defs)
+  by (auto simp: s0_ptr_defs ptr_range_def)
 
 definition Sys1ASIDMap :: "(auth_graph_label subject_label) agent_asid_map" where
   "Sys1ASIDMap \<equiv>
@@ -950,17 +953,17 @@ lemma s0_caps_of_state :
          ((Low_cnode_ptr,(the_nat_to_bl_10 3)), ArchObjectCap (PageTableCap Low_pd_ptr (Some (Low_asid,0)))),
          ((Low_cnode_ptr,(the_nat_to_bl_10 6)), ArchObjectCap (PageTableCap Low_pt_ptr (Some (Low_asid,0)))),
          ((Low_cnode_ptr,(the_nat_to_bl_10 4)), ArchObjectCap (ASIDPoolCap Low_pool_ptr Low_asid)),
-         ((Low_cnode_ptr,(the_nat_to_bl_10 5)), ArchObjectCap (FrameCap shared_page_ptr vm_read_write RISCVLargePage False (Some (Low_asid, 0)))),
+         ((Low_cnode_ptr,(the_nat_to_bl_10 5)), ArchObjectCap (FrameCap shared_page_ptr_virt vm_read_write RISCVLargePage False (Some (Low_asid, 0)))),
          ((Low_cnode_ptr,(the_nat_to_bl_10 318)), NotificationCap ntfn_ptr 0 {AllowSend}),
          ((High_cnode_ptr,(the_nat_to_bl_10 1)), ThreadCap High_tcb_ptr),
          ((High_cnode_ptr,(the_nat_to_bl_10 2)), CNodeCap High_cnode_ptr 10 (the_nat_to_bl_10 2)),
          ((High_cnode_ptr,(the_nat_to_bl_10 3)), ArchObjectCap (PageTableCap High_pd_ptr (Some (High_asid,0)))),
          ((High_cnode_ptr,(the_nat_to_bl_10 6)), ArchObjectCap (PageTableCap High_pt_ptr (Some (High_asid,0)))),
          ((High_cnode_ptr,(the_nat_to_bl_10 4)), ArchObjectCap (ASIDPoolCap High_pool_ptr High_asid)),
-         ((High_cnode_ptr,(the_nat_to_bl_10 5)), ArchObjectCap (FrameCap shared_page_ptr vm_read_only RISCVLargePage False (Some (High_asid, 0)))),
+         ((High_cnode_ptr,(the_nat_to_bl_10 5)), ArchObjectCap (FrameCap shared_page_ptr_virt vm_read_only RISCVLargePage False (Some (High_asid, 0)))),
          ((High_cnode_ptr,(the_nat_to_bl_10 318)), NotificationCap  ntfn_ptr 0 {AllowRecv}) ,
          ((Silc_cnode_ptr,(the_nat_to_bl_10 2)), CNodeCap Silc_cnode_ptr 10 (the_nat_to_bl_10 2)),
-         ((Silc_cnode_ptr,(the_nat_to_bl_10 5)), ArchObjectCap (FrameCap shared_page_ptr vm_read_only RISCVLargePage False (Some (Silc_asid, 0)))),
+         ((Silc_cnode_ptr,(the_nat_to_bl_10 5)), ArchObjectCap (FrameCap shared_page_ptr_virt vm_read_only RISCVLargePage False (Some (Silc_asid, 0)))),
          ((Silc_cnode_ptr,(the_nat_to_bl_10 318)), NotificationCap ntfn_ptr 0 {AllowSend}),
          ((Low_tcb_ptr,(tcb_cnode_index 0)), CNodeCap Low_cnode_ptr 10 (the_nat_to_bl_10 2)),
          ((Low_tcb_ptr,(tcb_cnode_index 1)), ArchObjectCap (PageTableCap Low_pd_ptr (Some (Low_asid,0)))),
@@ -1068,7 +1071,7 @@ lemma High_pd_is_aligned[simp]:
   by (clarsimp simp: s0_ptr_defs pt_bits_def table_size_def ptTranslationBits_def pte_bits_def word_size_bits_def is_aligned_def)
 
 lemma shared_page_ptr_is_aligned[simp]:
-  "is_aligned shared_page_ptr pt_bits"
+  "is_aligned shared_page_ptr_virt pt_bits"
   by (clarsimp simp: s0_ptr_defs pt_bits_def table_size_def ptTranslationBits_def pte_bits_def word_size_bits_def is_aligned_def)
 
 lemma vs_lookup_s0_SomeD:
@@ -1099,13 +1102,18 @@ lemma vs_lookup_s0_SomeD:
                      pool_for_asid_s0 asid_pools_of_s0 vspace_for_pool_def
               split: if_splits)+
 
+lemma pt_bits_left_max_minus_1_pageBitsForSize:
+  "pt_bits_left (max_pt_level - 1) = pageBitsForSize RISCVLargePage"
+  apply (clarsimp simp: pt_bits_left_def max_pt_level_def2)
+  done
+
 lemma Sys1_pas_refined:
   "pas_refined Sys1PAS s0_internal"
   apply (clarsimp simp: pas_refined_def)
   apply (intro conjI)
        apply (simp add: Sys1_pas_wellformed)
       apply (clarsimp simp: irq_map_wellformed_aux_def s0_internal_def Sys1AgentMap_def Sys1PAS_def)
-      apply (clarsimp simp: s0_ptr_defs ptrFromPAddr_def pptrBaseOffset_def paddrBase_def)
+      apply (clarsimp simp: s0_ptr_defs ptr_range_def)
       apply word_bitwise
      apply (clarsimp simp: tcb_domain_map_wellformed_aux_def minBound_word High_domain_def Low_domain_def
                            Sys1PAS_def Sys1AgentMap_def default_domain_def)
@@ -1116,8 +1124,6 @@ lemma Sys1_pas_refined:
           apply (elim disjE; clarsimp simp: Sys1AgentMap_simps cap_auth_conferred_def ptr_range_def
                                             arch_cap_auth_conferred_def vspace_cap_rights_to_auth_def
                                             vm_read_write_def vm_read_only_def cap_rights_to_auth_def)
-            apply ((fastforce dest: Sys1AgentMap_simps(15) elim: le_less_trans
-                              simp: pt_bits_left_def bit_simps max_pt_level_def2 s0_ptr_defs)+)[3]
          apply (drule s0_caps_of_state, clarsimp)
          apply (elim disjE, simp_all)[1]
         apply (clarsimp simp: state_refs_of_def thread_st_auth_def tcb_states_of_state_s0
@@ -1128,16 +1134,11 @@ lemma Sys1_pas_refined:
     apply (clarsimp simp: state_vrefs_def)
     apply (drule vs_lookup_s0_SomeD)
     apply (elim disjE; clarsimp)
-         apply ((clarsimp simp: aobjs_of_Some s0_internal_def kh0_obj_def opt_map_def
-                                vs_refs_aux_def Sys1AgentMap_def Sys1AuthGraph_def
-                                graph_of_def pte_ref2_def ptrFromPAddr_addr_from_ppn'
-                         dest!: kh0_SomeD split: option.splits if_splits)+)[4]
-     apply ((clarsimp simp: aobjs_of_Some s0_internal_def kh0_obj_def opt_map_def vs_refs_aux_def
-                            vm_read_only_def vspace_cap_rights_to_auth_def ptr_range_def pte_ref2_def
-                            Sys1AuthGraph_def Sys1AgentMap_simps graph_of_def ptrFromPAddr_addr_from_ppn'
-                     dest!: kh0_SomeD split: option.splits if_splits,
-             fastforce dest: Sys1AgentMap_simps(15) elim: le_less_trans
-                       simp: pt_bits_left_def bit_simps max_pt_level_def2 s0_ptr_defs)+)[2]
+         apply ((clarsimp simp: s0_internal_def kh0_obj_def opt_map_def vs_refs_aux_def
+                                vm_read_only_def vspace_cap_rights_to_auth_def pte_ref2_def
+                                Sys1AuthGraph_def Sys1AgentMap_simps graph_of_def ptrFromPAddr_addr_from_ppn'
+                                shared_page_ptr_phys_def pt_bits_left_max_minus_1_pageBitsForSize
+                         dest!: kh0_SomeD split: option.splits if_splits)+)[6]
    apply (rule subsetI, clarsimp)
    apply (erule state_asids_to_policy_aux.cases)
      apply (drule s0_caps_of_state, clarsimp)
@@ -1180,8 +1181,8 @@ lemma Sys1_pas_wellformed_noninterference:
   done
 
 lemma Sys1AgentMap_shared_page_ptr:
-  "Sys1AgentMap shared_page_ptr = partition_label Low"
-  by (clarsimp simp: Sys1AgentMap_def s0_ptr_defs)
+  "Sys1AgentMap shared_page_ptr_virt = partition_label Low"
+  by (clarsimp simp: Sys1AgentMap_def s0_ptr_defs ptr_range_def bit_simps)
 
 lemma silc_inv_s0:
   "silc_inv Sys1PAS s0_internal s0_internal"
@@ -1276,9 +1277,9 @@ lemma valid_caps_s0[simp]:
   "s0_internal \<turnstile> ArchObjectCap (PageTableCap High_pd_ptr (Some (High_asid,0)))"
   "s0_internal \<turnstile> ArchObjectCap (PageTableCap Low_pt_ptr (Some (Low_asid,0)))"
   "s0_internal \<turnstile> ArchObjectCap (PageTableCap High_pt_ptr (Some (High_asid,0)))"
-  "s0_internal \<turnstile> ArchObjectCap (FrameCap shared_page_ptr vm_read_write RISCVLargePage False (Some (Low_asid,0)))"
-  "s0_internal \<turnstile> ArchObjectCap (FrameCap shared_page_ptr vm_read_only RISCVLargePage False (Some (High_asid,0)))"
-  "s0_internal \<turnstile> ArchObjectCap (FrameCap shared_page_ptr vm_read_only RISCVLargePage False (Some (Silc_asid,0)))"
+  "s0_internal \<turnstile> ArchObjectCap (FrameCap shared_page_ptr_virt vm_read_write RISCVLargePage False (Some (Low_asid,0)))"
+  "s0_internal \<turnstile> ArchObjectCap (FrameCap shared_page_ptr_virt vm_read_only RISCVLargePage False (Some (High_asid,0)))"
+  "s0_internal \<turnstile> ArchObjectCap (FrameCap shared_page_ptr_virt vm_read_only RISCVLargePage False (Some (Silc_asid,0)))"
   "s0_internal \<turnstile> NotificationCap ntfn_ptr 0 {AllowWrite}"
   "s0_internal \<turnstile> NotificationCap ntfn_ptr 0 {AllowRead}"
   "s0_internal \<turnstile> ReplyCap Low_tcb_ptr True {AllowGrant,AllowWrite}"
@@ -1305,7 +1306,7 @@ lemma valid_obj_s0[simp]:
   "valid_obj High_tcb_ptr        High_tcb       s0_internal"
   "valid_obj idle_tcb_ptr        idle_tcb       s0_internal"
   "valid_obj riscv_global_pt_ptr init_global_pt s0_internal"
-  "valid_obj shared_page_ptr shared_page s0_internal"
+  "valid_obj shared_page_ptr_virt shared_page s0_internal"
                  apply (simp_all add: valid_obj_def kh0_obj_def)
               apply (simp add: valid_cs_def Low_caps_ran High_caps_ran Silc_caps_ran
                                valid_cs_size_def word_bits_def cte_level_bits_def)+
@@ -1469,10 +1470,6 @@ lemma valid_reply_masters_s0[simp]:
   apply (force dest: s0_caps_of_state simp: cte_wp_at_caps_of_state is_master_reply_cap_to_def)
   done
 
-lemma riscv_global_pt_is_aligned:
-  "is_aligned riscv_global_pt_ptr pt_bits"
-  by (clarsimp simp: is_aligned_def bit_simps s0_ptr_defs)
-
 lemma valid_global_refs_s0[simp]:
   "valid_global_refs s0_internal"
   apply (clarsimp simp: valid_global_refs_def valid_refs_def cte_wp_at_caps_of_state)
@@ -1487,42 +1484,13 @@ lemma valid_arch_state_s0[simp]:
   "valid_arch_state s0_internal"
   apply (clarsimp simp: valid_arch_state_def s0_internal_def arch_state0_def)
   apply (intro conjI)
-     apply (auto simp: valid_asid_table_def kh0_def kh0_obj_def opt_map_def split: option.splits)[1]
-    apply (clarsimp simp: valid_uses_def)
-    apply (intro conjI; clarsimp)
-          apply (fastforce simp: init_vspace_uses_def canonical_user_canonical
-                           dest: dual_order.strict_trans1[OF _ pptr_base_kernel_elf_base]
-                                 above_pptr_base_canonical less_imp_le)
-         apply (fastforce dest: canonical_user_below_pptr_base
-                          simp: init_vspace_uses_def split: if_splits)
-        apply (fastforce elim: dual_order.strict_trans[rotated] split: if_splits
-                         simp: init_vspace_uses_def pptr_base_def pptrBase_def
-                               canonical_bit_def kernel_elf_base_def kernelELFBase_def
-                               kernelELFPAddrBase_def Kernel_Config.physBase_def mask_def)
-       apply (fastforce dest: dual_order.strict_trans1[where a=kernel_elf_base, rotated]
-                              dual_order.strict_trans1[OF _ pptr_base_kernel_elf_base]
-                              canonical_user_below_pptr_base
-                        simp: init_vspace_uses_def pptr_base_def pptrBase_def
-                              canonical_bit_def kernel_elf_base_def kernelELFBase_def
-                              kernelELFPAddrBase_def Kernel_Config.physBase_def mask_def
-                       split: if_splits)
-      apply (fastforce dest: dual_order.strict_trans2 canonical_user_below_pptr_base
-                       simp: init_vspace_uses_def pptr_base_def pptrBase_def canonical_bit_def
-                             kdev_base_def kdevBase_def kernel_elf_base_def kernelELFBase_def
-                             kernelELFPAddrBase_def Kernel_Config.physBase_def mask_def
-                      split: if_splits)
-     apply (fastforce dest: dual_order.strict_trans1[where a=kernel_elf_base, rotated]
-                            canonical_user_below_pptr_base
-                      simp: user_window_def user_region_def init_vspace_uses_def pptr_base_def
-                            pptrBase_def canonical_bit_def kernel_elf_base_def kernelELFBase_def
-                            kernelELFPAddrBase_def Kernel_Config.physBase_def mask_def
-                     split: if_splits)+
+    apply (auto simp: valid_asid_table_def kh0_def kh0_obj_def opt_map_def split: option.splits)[1]
    apply (fastforce simp: valid_global_arch_objs_def obj_at_def kh0_def a_type_def
                          init_global_pt_def max_pt_level_not_asid_pool_level[symmetric])
   apply (clarsimp simp: valid_global_tables_def pt_walk.simps obind_def)
   apply (fastforce dest: pt_walk_max_level
-                   simp: obind_def opt_map_def riscv_global_pt_is_aligned asid_pool_level_eq
-                         geq_max_pt_level pte_of_def kh0_def kh0_obj_def pte_rights_of_def
+                   simp: obind_def opt_map_def asid_pool_level_eq geq_max_pt_level pte_of_def kh0_def
+                         kh0_obj_def pte_rights_of_def
                   split: if_splits)
   done
 
@@ -1570,7 +1538,8 @@ lemma valid_arch_objs_s0[simp]:
   apply (clarsimp simp: valid_vspace_objs_def obj_at_def)
   apply (drule vs_lookup_s0_SomeD)
   apply (auto simp: aobjs_of_Some kh_s0_def kh0_obj_def data_at_def obj_at_def
-                    ptrFromPAddr_addr_from_ppn' vmpage_size_of_level_def max_pt_level_def2)
+                    ptrFromPAddr_addr_from_ppn' vmpage_size_of_level_def max_pt_level_def2
+                    shared_page_ptr_phys_def)
   done
 
 lemma valid_vs_lookup_s0_internal:
@@ -1623,7 +1592,7 @@ lemma valid_vs_lookup_s0_internal:
      apply (clarsimp simp: vref_for_level_def mask_def pt_simps user_region_simps bit_simps s0_ptr_defs)
      apply (word_bitwise, fastforce)
     apply (clarsimp simp: kh0_obj_def mask_def pt_simps user_region_simps bit_simps s0_ptr_defs)
-    apply (rule FalseE, word_bitwise, fastforce)
+    apply (rule FalseE, word_bitwise, fastforce simp: elf_index_value)
    \<comment> \<open>Low asid\<close>
    apply (rule conjI, clarsimp simp: Low_asid_def asid_low_bits_def)
    apply (rule_tac x=Low_cnode_ptr in exI)
@@ -1638,7 +1607,7 @@ lemma valid_vs_lookup_s0_internal:
     apply (clarsimp simp: vref_for_level_def mask_def pt_simps user_region_simps bit_simps s0_ptr_defs)
     apply (word_bitwise, fastforce)
    apply (clarsimp simp: kh0_obj_def mask_def pt_simps user_region_simps bit_simps s0_ptr_defs)
-   apply (rule FalseE, word_bitwise, fastforce)
+   apply (rule FalseE, word_bitwise, fastforce simp: elf_index_value)
   \<comment> \<open>bot level < max pt level\<close>
   apply (clarsimp simp: pool_for_asid_s0 vspace_for_pool_def asid_pools_of_s0
                  dest!: asid_high_low split: if_splits)
@@ -1652,7 +1621,8 @@ lemma valid_vs_lookup_s0_internal:
                       Some (max_pt_level - 1, High_pt_ptr)")
       apply (clarsimp simp: pt_walk.simps)
       apply (clarsimp simp: ptes_of_def pts_of_s0 in_omonad split: if_splits)
-     apply (clarsimp simp: ptes_of_def pts_of_s0 ptrFromPAddr_addr_from_ppn' split: if_splits)
+     apply (clarsimp simp: ptes_of_def pts_of_s0 shared_page_ptr_phys_def ptrFromPAddr_addr_from_ppn'
+                    split: if_splits)
      apply (rule_tac x=High_cnode_ptr in exI)
      apply (rule_tac x="the_nat_to_bl_10 5" in exI)
      apply (rule exI, intro conjI)
@@ -1672,7 +1642,8 @@ lemma valid_vs_lookup_s0_internal:
                      Some (max_pt_level - 1, Low_pt_ptr)")
      apply (clarsimp simp: pt_walk.simps)
      apply (clarsimp simp: ptes_of_def pts_of_s0 in_omonad split: if_splits)
-    apply (clarsimp simp: ptes_of_def pts_of_s0 ptrFromPAddr_addr_from_ppn' split: if_splits)
+    apply (clarsimp simp: ptes_of_def pts_of_s0 shared_page_ptr_phys_def ptrFromPAddr_addr_from_ppn'
+                   split: if_splits)
     apply (rule_tac x=Low_cnode_ptr in exI)
     apply (rule_tac x="the_nat_to_bl_10 5" in exI)
     apply (rule exI, intro conjI)
@@ -1684,10 +1655,10 @@ lemma valid_vs_lookup_s0_internal:
    \<comment> \<open>No lookups to other ptes\<close>
    apply (clarsimp simp: in_omonad ptes_of_def pts_of_s0  split: if_splits)
    apply (clarsimp simp: kh0_obj_def mask_def pt_simps user_region_simps bit_simps s0_ptr_defs)
-   apply (rule FalseE, word_bitwise, fastforce)
+   apply (rule FalseE, word_bitwise, fastforce simp: elf_index_value)
   apply (clarsimp simp: in_omonad ptes_of_def pts_of_s0  split: if_splits)
   apply (clarsimp simp: kh0_obj_def mask_def pt_simps user_region_simps bit_simps s0_ptr_defs)
-  apply (rule FalseE, word_bitwise, fastforce)
+  apply (rule FalseE, word_bitwise, fastforce simp: elf_index_value)
   done
 
 lemma valid_arch_caps_s0[simp]:
@@ -1756,7 +1727,7 @@ lemma equal_kernel_mappings_s0[simp]:
                    dest!: kh0_SomeD split: if_splits option.splits)
   apply (clarsimp simp: pts_of_s0)
   apply (clarsimp simp: s0_internal_def riscv_global_pt_def arch_state0_def kh0_obj_def
-                        kernel_mapping_slots_def s0_ptr_defs misc)+
+                        kernel_mapping_slots_def s0_ptr_defs misc elf_index_value)+
   done
 
 lemma valid_asid_map_s0[simp]:
@@ -1764,7 +1735,7 @@ lemma valid_asid_map_s0[simp]:
   by (clarsimp simp: valid_asid_map_def s0_internal_def arch_state0_def)
 
 lemma valid_global_pd_mappings_s0_helper:
-  "\<lbrakk> pptr_base \<le> vref; vref < pptr_base + 0x40000000 \<rbrakk>
+  "\<lbrakk> pptr_base \<le> vref; vref < pptr_base + (1 << kernel_window_bits) \<rbrakk>
      \<Longrightarrow> \<exists>a b. pt_lookup_target 0 riscv_global_pt_ptr vref (ptes_of s0_internal) = Some (a, b) \<and>
                is_aligned b (pt_bits_left a) \<and>
                addrFromPPtr b + (vref && mask (pt_bits_left a)) = addrFromPPtr vref"
@@ -1775,32 +1746,40 @@ lemma valid_global_pd_mappings_s0_helper:
                    Some (max_pt_level, pt_slot_offset max_pt_level riscv_global_pt_ptr vref)")
    apply (clarsimp simp: pt_lookup_slot_from_level_def pt_walk.simps)
    apply (fastforce simp: ptes_of_def in_omonad s0_internal_def kh0_def init_global_pt_def
-                          global_pte_def riscv_global_pt_is_aligned is_aligned_pt_slot_offset_pte)
+                          global_pte_def is_aligned_pt_slot_offset_pte)
   apply (clarsimp simp: pt_lookup_slot_from_level_def pt_walk.simps)
   apply (rule conjI; clarsimp dest!: pt_walk_max_level simp: max_pt_level_def2 split: if_splits)
   apply (rule conjI; clarsimp)
-   apply (clarsimp simp: ptes_of_def pts_of_s0 riscv_global_pt_is_aligned global_pte_def
+   apply (clarsimp simp: ptes_of_def pts_of_s0 global_pte_def kernel_window_bits_def
                          table_index_offset_pt_bits_left is_aligned_pt_slot_offset_pte
                   split: if_splits)
     apply (clarsimp simp: misc s0_ptr_defs)
     apply (word_bitwise, fastforce)
    apply (clarsimp simp: misc s0_ptr_defs kernel_mapping_slots_def)
    apply (word_bitwise, fastforce)
-  apply (clarsimp simp: ptes_of_def pts_of_s0 riscv_global_pt_is_aligned
-                        is_aligned_pt_slot_offset_pte global_pte_def
+  apply (clarsimp simp: ptes_of_def pts_of_s0 is_aligned_pt_slot_offset_pte global_pte_def
                  split: if_splits)
    apply (clarsimp simp: addr_from_ppn_def ptrFromPAddr_def addrFromPPtr_def bit_simps
                          mask_def s0_ptr_defs pt_bits_left_def max_pt_level_def2
-                         pptrBaseOffset_def paddrBase_def is_aligned_def)
+                         pptrBaseOffset_def paddrBase_def is_aligned_def kernel_window_bits_def)
    apply (word_bitwise, fastforce)
   apply (clarsimp simp: addr_from_ppn_def ptrFromPAddr_def addrFromPPtr_def bit_simps is_aligned_def
                         s0_ptr_defs pt_bits_left_def max_pt_level_def2 kernel_mapping_slots_def
-                        mask_def pt_slot_offset_def pt_index_def pptrBaseOffset_def paddrBase_def)
+                        mask_def pt_slot_offset_def pt_index_def pptrBaseOffset_def paddrBase_def
+                        toplevel_bits_value elf_index_value kernel_window_bits_def)
   apply (word_bitwise, fastforce)
   done
 
+lemma ptes_of_elf_window:
+  "\<lbrakk>kernel_elf_base \<le> vref; vref < kernel_elf_base + 2 ^ pageBits\<rbrakk>
+   \<Longrightarrow> ptes_of s0_internal (pt_slot_offset max_pt_level riscv_global_pt_ptr vref)
+       = Some (global_pte elf_index)"
+  unfolding ptes_of_def pts_of_s0
+  apply (clarsimp simp: obind_def elf_window_4k is_aligned_pt_slot_offset_pte)
+  done
+
 lemma valid_global_pd_mappings_s0_helper':
-  "\<lbrakk> kernel_elf_base \<le> vref; vref < kernel_elf_base + 0x100000 \<rbrakk>
+  "\<lbrakk> kernel_elf_base \<le> vref; vref < kernel_elf_base + (1 << pageBits) \<rbrakk>
      \<Longrightarrow> \<exists>a b. pt_lookup_target 0 riscv_global_pt_ptr vref (ptes_of s0_internal) = Some (a, b) \<and>
                is_aligned b (pt_bits_left a) \<and>
                addrFromPPtr b + (vref && mask (pt_bits_left a)) = addrFromKPPtr vref"
@@ -1811,39 +1790,21 @@ lemma valid_global_pd_mappings_s0_helper':
                    Some (max_pt_level, pt_slot_offset max_pt_level riscv_global_pt_ptr vref)")
    apply (clarsimp simp: pt_lookup_slot_from_level_def pt_walk.simps)
    apply (fastforce simp: ptes_of_def in_omonad s0_internal_def kh0_def init_global_pt_def
-                          global_pte_def riscv_global_pt_is_aligned is_aligned_pt_slot_offset_pte)
-  apply (clarsimp simp: pt_lookup_slot_from_level_def pt_walk.simps)
-  apply (rule conjI; clarsimp dest!: pt_walk_max_level simp: max_pt_level_def2 split: if_splits)
+                          global_pte_def is_aligned_pt_slot_offset_pte)
   apply (rule conjI; clarsimp)
-   apply (clarsimp simp: ptes_of_def pts_of_s0 riscv_global_pt_is_aligned global_pte_def
-                         table_index_offset_pt_bits_left is_aligned_pt_slot_offset_pte
-                  split: if_splits)
-    apply (clarsimp simp: misc kernel_elf_base_def kernelELFBase_def kernelELFPAddrBase_def
-                          Kernel_Config.physBase_def)
-    apply (word_bitwise, fastforce)
-   apply (clarsimp simp: misc s0_ptr_defs kernel_mapping_slots_def
-                         kernel_elf_base_def kernelELFBase_def kernelELFPAddrBase_def
-                         Kernel_Config.physBase_def)
-   apply (word_bitwise, fastforce)
-  apply (clarsimp simp: ptes_of_def pts_of_s0 riscv_global_pt_is_aligned
-                        is_aligned_pt_slot_offset_pte global_pte_def
-                 split: if_splits)
-   apply (clarsimp simp: addr_from_ppn_def bit_simps s0_ptr_defs pt_bits_left_def mask_def
-                         pt_slot_offset_def pt_index_def kernel_elf_base_def kernelELFBase_def
-                         kernelELFPAddrBase_def Kernel_Config.physBase_def)
-   apply (word_bitwise, fastforce)
-  apply (clarsimp simp: addr_from_ppn_def ptrFromPAddr_def addrFromKPPtr_def bit_simps
-                        is_aligned_def s0_ptr_defs pt_bits_left_def mask_def pptrBaseOffset_def
-                        paddrBase_def kernel_elf_base_def kernelELFBase_def
-                        kernelELFBaseOffset_def kernelELFPAddrBase_def Kernel_Config.physBase_def)
-  apply (word_bitwise, fastforce)
+  apply (rule conjI; clarsimp)
+   apply (clarsimp simp: pt_lookup_slot_from_level_def pt_walk.simps)
+  apply (rule conjI; clarsimp)
+   apply (clarsimp simp: ptes_of_elf_window global_pte_def split: if_splits)
+  apply (clarsimp simp: ptes_of_elf_window global_pte_def elf_index_value)
+  apply (clarsimp simp: is_aligned_ptrFromPAddr_kernelELFPAddrBase kernelELFPAddrBase_addrFromKPPtr)
   done
 
 lemma valid_global_pd_mappings_s0[simp]:
   "valid_global_vspace_mappings s0_internal"
   unfolding valid_global_vspace_mappings_def Let_def
   apply (intro conjI)
-    apply (simp add: s0_internal_def arch_state0_def riscv_global_pt_def riscv_global_pt_is_aligned)
+    apply (simp add: s0_internal_def arch_state0_def riscv_global_pt_def)
    apply (fastforce simp: s0_internal_def arch_state0_def in_omonad kernel_window_def
                           init_vspace_uses_def translate_address_def riscv_global_pt_def
                    dest!: valid_global_pd_mappings_s0_helper split: if_splits)
@@ -1856,10 +1817,10 @@ lemma pspace_in_kernel_window_s0[simp]:
   "pspace_in_kernel_window s0_internal"
   apply (clarsimp simp: pspace_in_kernel_window_def kernel_window_def
                         init_vspace_uses_def s0_internal_def arch_state0_def)
-  apply (subgoal_tac "x \<in> {pptr_base..<pptr_base + (1 << 30)}"; clarsimp)
+  apply (subgoal_tac "x \<in> {pptr_base..<pptr_base + (1 << kernel_window_bits)}"; clarsimp)
   apply (drule kh0_SomeD)
-  by (clarsimp simp: s0_ptr_defs kh0_obj_def cte_level_bits_def
-                     table_size pageBits_def ptTranslationBits_def
+  by (clarsimp simp: s0_ptr_defs kh0_obj_def cte_level_bits_def table_size pageBits_def
+                     ptTranslationBits_def kernel_window_bits_def
               dest!: irq_node_offs_range_correct
       | erule disjE dual_order.strict_trans2[rotated] dual_order.trans
       | rule conjI | word_bitwise)+
@@ -1874,8 +1835,9 @@ lemma cap_refs_in_kernel_window_s0[simp]:
   apply (erule swap, clarsimp)
   apply (drule s0_caps_of_state)
   apply (clarsimp simp: kernel_window_def init_vspace_uses_def s0_internal_def arch_state0_def)
-  apply (subgoal_tac "x \<in> {pptr_base..<pptr_base + (1 << 30)}"; clarsimp)
+  apply (subgoal_tac "x \<in> {pptr_base..<pptr_base + (1 << kernel_window_bits)}"; clarsimp)
   by (clarsimp simp: s0_ptr_defs kh0_obj_def table_size pageBits_def ptTranslationBits_def
+                     kernel_window_bits_def
               dest!: irq_node_offs_range_correct
       | erule disjE dual_order.strict_trans2[rotated] dual_order.trans
       | rule conjI | word_bitwise)+

--- a/proof/infoflow/refine/ARM/Example_Valid_StateH.thy
+++ b/proof/infoflow/refine/ARM/Example_Valid_StateH.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2023, Proofcraft Pty Ltd
  * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -126,7 +127,7 @@ definition
   Low_pt'H :: "word8 \<Rightarrow> ARM_H.pte "
 where
   "Low_pt'H \<equiv> (\<lambda>_. ARM_H.InvalidPTE)
-            (0 := ARM_H.SmallPagePTE shared_page_ptr (PageCacheable \<in> {}) (Global \<in> {}) (XNever \<in> {}) (vmrights_map vm_read_write))"
+            (0 := ARM_H.SmallPagePTE shared_page_ptr_phys (PageCacheable \<in> {}) (Global \<in> {}) (XNever \<in> {}) (vmrights_map vm_read_write))"
 
 definition
   Low_ptH :: "word32 \<Rightarrow> word32 \<Rightarrow> Structures_H.kernel_object option"
@@ -173,7 +174,7 @@ definition
 where
   "High_pt'H \<equiv>
     (\<lambda>_. ARM_H.InvalidPTE)
-     (0 := ARM_H.SmallPagePTE shared_page_ptr (PageCacheable \<in> {}) (Global \<in> {}) (XNever \<in> {})
+     (0 := ARM_H.SmallPagePTE shared_page_ptr_phys (PageCacheable \<in> {}) (Global \<in> {}) (XNever \<in> {})
                       (vmrights_map vm_read_only))"
 
 
@@ -2186,28 +2187,24 @@ lemma s0H_valid_objs':
                              valid_cte'_def
                       split: if_split_asm)
       apply (clarsimp simp: valid_obj'_def global_pdH'_def valid_mapping'_def s0_ptr_defs
-                            is_aligned_def ARM.addrFromPPtr_def ARM.ptrFromPAddr_def
-                            pptrBaseOffset_def ARM.pptrBase_def Kernel_Config.physBase_def
-                            pptrBase_def
                      split: if_split_asm)
-     apply (clarsimp simp: valid_obj'_def High_pdH_def High_pd'H_def valid_pde'_def pteBits_def
-                           valid_mapping'_def s0_ptr_defs is_aligned_def ARM.addrFromPPtr_def
-                           ARM.pptrBase_def ARM.ptrFromPAddr_def ptBits_def
-                           pageBits_def pptrBaseOffset_def pptrBase_def Kernel_Config.physBase_def
+      apply (rule is_aligned_addrFromPPtr_n; clarsimp simp: is_aligned_def)
+     apply (clarsimp simp: valid_obj'_def High_pdH_def High_pd'H_def valid_mapping'_def s0_ptr_defs
+                           ptBits_def pteBits_def
                     split: if_split_asm)
-    apply (clarsimp simp: valid_obj'_def Low_pdH_def Low_pd'H_def valid_pde'_def valid_mapping'_def
-                          s0_ptr_defs is_aligned_def ARM.addrFromPPtr_def pteBits_def
-                          ARM.ptrFromPAddr_def ptBits_def pageBits_def
-                          pptrBaseOffset_def pptrBase_def Kernel_Config.physBase_def
+     apply (intro conjI impI; rule is_aligned_addrFromPPtr_n; clarsimp simp: is_aligned_def)
+    apply (clarsimp simp: valid_obj'_def Low_pdH_def Low_pd'H_def valid_mapping'_def s0_ptr_defs
+                          ptBits_def pteBits_def
                    split: if_split_asm)
+    apply (intro conjI impI; rule is_aligned_addrFromPPtr_n; clarsimp simp: is_aligned_def)
    apply (clarsimp simp: valid_obj'_def High_ptH_def High_pt'H_def valid_mapping'_def s0_ptr_defs
-                         is_aligned_def ARM.addrFromPPtr_def ARM.ptrFromPAddr_def ARM.pptrBase_def
-                         pptrBaseOffset_def pptrBase_def Kernel_Config.physBase_def
+                         ptBits_def pteBits_def shared_page_ptr_phys_def
                   split: if_split_asm)
+   apply (rule is_aligned_addrFromPPtr_n; clarsimp simp: is_aligned_def)
   apply (clarsimp simp: valid_obj'_def Low_ptH_def Low_pt'H_def valid_mapping'_def s0_ptr_defs
-                        is_aligned_def ARM.addrFromPPtr_def ARM.ptrFromPAddr_def
-                        pptrBaseOffset_def pptrBase_def Kernel_Config.physBase_def
+                        ptBits_def pteBits_def shared_page_ptr_phys_def
                  split: if_split_asm)
+  apply (rule is_aligned_addrFromPPtr_n; clarsimp simp: is_aligned_def)
   done
 
 lemmas the_nat_to_bl_simps =

--- a/proof/invariant-abstract/AARCH64/ArchInvariants_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchInvariants_AI.thy
@@ -1494,10 +1494,9 @@ lemma canonical_user_ge0[intro!,simp]:
   "0 < canonical_user"
   by (simp add: canonical_user_def mask_def ipa_size_def)
 
-lemma pptr_base_kernel_elf_base: (* FIXME MK: candidate for Kernel_Config_Lemmas *)
+lemma pptr_base_kernel_elf_base:
   "pptr_base < kernel_elf_base"
-  by (simp add: pptr_base_def pptrBase_def canonical_bit_def kernel_elf_base_def kernelELFBase_def
-                kernelELFPAddrBase_def Kernel_Config.physBase_def mask_def)
+  by (simp add: pptr_base_def kernel_elf_base_def pptrBase_kernelELFBase)
 
 lemma pptrTop_le_ipa_size:
   "pptrTop \<le> mask ipa_size"

--- a/proof/invariant-abstract/AARCH64/ArchKernelInit_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchKernelInit_AI.thy
@@ -248,15 +248,6 @@ lemma idle_thread_in_kernel_window_init_arch_state[simp]:
   apply (rule conjI; unat_arith)
   done
 
-lemma irq_node_pptr_base_kernel_elf_base:
-  "\<lbrakk>x \<le> pptr_base + (m + (mask cte_level_bits + 0x3000)); m \<le> mask (size irq) << cte_level_bits \<rbrakk>
-   \<Longrightarrow> \<not> kernel_elf_base \<le> x" for irq::irq
-  apply (simp add: word_size cte_level_bits_def mask_def pptr_base_def pptrBase_def
-                   Kernel_Config.physBase_def kernel_elf_base_def kernelELFBase_def canonical_bit_def
-                   not_le)
-  apply unat_arith
-  done
-
 lemma irq_node_in_kernel_window_init_arch_state':
   "\<lbrakk> init_irq_node_ptr + m \<le> x; x \<le> init_irq_node_ptr + m + mask cte_level_bits;
      m \<le> mask (size (irq::irq)) << cte_level_bits\<rbrakk>

--- a/proof/invariant-abstract/ARM/ArchAInvsPre.thy
+++ b/proof/invariant-abstract/ARM/ArchAInvsPre.thy
@@ -98,15 +98,6 @@ lemma get_pd_of_thread_reachable:
           split: Structures_A.kernel_object.splits if_split_asm option.splits
                  cap.splits arch_cap.splits)
 
-lemma is_aligned_ptrFromPAddrD:
-"\<lbrakk>is_aligned (ptrFromPAddr b) a; a \<le> 24\<rbrakk> \<Longrightarrow> is_aligned b a"
-  apply (clarsimp simp: ptrFromPAddr_def pptrBaseOffset_def pptrBase_def Kernel_Config.physBase_def)
-  apply (erule is_aligned_addD2)
-  apply (rule is_aligned_weaken[where x = 24])
-   apply (simp add: is_aligned_def)
-  apply simp
-  done
-
 lemma obj_bits_data_at:
   "data_at sz (ptrFromPAddr b) s
   \<Longrightarrow> obj_bits (the (kheap s (ptrFromPAddr b))) = pageBitsForSize sz"
@@ -185,10 +176,6 @@ lemma device_frame_in_device_region:
   \<Longrightarrow> device_state (machine_state s) p \<noteq> None"
   by (auto simp add: pspace_respects_device_region_def dom_def device_mem_def)
 
-lemma is_aligned_pptrBaseOffset:
-"is_aligned pptrBaseOffset (pageBitsForSize sz)"
-  by (case_tac sz, simp_all add: pptrBaseOffset_def
-                   pptrBase_def Kernel_Config.physBase_def is_aligned_def)[1]
 
 global_naming Arch
 named_theorems AInvsPre_asms

--- a/proof/invariant-abstract/ARM/ArchAcc_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchAcc_AI.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2023, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -2327,13 +2328,16 @@ lemma shiftr_20_less:
   by (simp add: word_less_nat_alt word_le_nat_alt shiftr_20_unat_ucast)+
 
 
+lemma kernel_base_aligned_pageBits:
+  "is_aligned kernel_base pageBits"
+  by (simp add: is_aligned_def kernel_base_def pageBits_def)
+
 lemma kernel_base_ge_observation:
   "(kernel_base \<le> x) = (x && ~~ mask 29 = kernel_base)"
   apply (subst mask_in_range)
    apply (simp add: kernel_base_def is_aligned_def)
   apply (simp add: kernel_base_def)
   done
-
 
 lemma kernel_base_less_observation:
   "(x < kernel_base) = (x && ~~ mask 29 \<noteq> kernel_base)"
@@ -2542,39 +2546,6 @@ lemma create_mapping_entries_valid_slots [wp]:
   apply (subst add.commute)
   apply (fastforce intro!: aligned_add_aligned is_aligned_shiftl_self)
   done
-
-lemma is_aligned_addrFromPPtr_n:
-  "\<lbrakk> is_aligned p n; n \<le> 28 \<rbrakk> \<Longrightarrow> is_aligned (Platform.ARM.addrFromPPtr p) n"
-  apply (simp add: Platform.ARM.addrFromPPtr_def)
-  apply (erule aligned_sub_aligned, simp_all)
-  apply (simp add: pptrBaseOffset_def Kernel_Config.physBase_def
-                   pptrBase_def pageBits_def)
-  apply (erule is_aligned_weaken[rotated])
-  apply (simp add: is_aligned_def)
-  done
-
-lemma is_aligned_addrFromPPtr:
-  "is_aligned p pageBits \<Longrightarrow> is_aligned (Platform.ARM.addrFromPPtr p) pageBits"
-  by (simp add: is_aligned_addrFromPPtr_n pageBits_def)
-
-lemma is_aligned_ptrFromPAddr_n:
-  "\<lbrakk>is_aligned x sz; sz\<le> 28\<rbrakk>
-  \<Longrightarrow> is_aligned (ptrFromPAddr x) sz"
-  apply (simp add:ptrFromPAddr_def pptrBaseOffset_def
-    pptrBase_def Kernel_Config.physBase_def)
-  apply (erule aligned_add_aligned)
-   apply (erule is_aligned_weaken[rotated])
-   apply (simp add:is_aligned_def)
-  apply (simp add:word_bits_def)
-  done
-
-lemma is_aligned_ptrFromPAddr:
-  "is_aligned p pageBits \<Longrightarrow> is_aligned (ptrFromPAddr p) pageBits"
-  by (simp add: is_aligned_ptrFromPAddr_n pageBits_def)
-
-lemma pbfs_le_28[simp]:
-  "pageBitsForSize sz \<le> 28"
-  by (cases sz; simp)
 
 lemma store_pde_lookup_pd:
   "\<lbrace>\<exists>\<rhd> pd and page_directory_at pd and valid_vspace_objs

--- a/proof/invariant-abstract/ARM/ArchArch_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchArch_AI.thy
@@ -1256,7 +1256,6 @@ lemma aligned_sum_less_kernel_base:
    apply (case_tac sz,simp_all add:kernel_base_def is_aligned_def)+
   done
 
-
 lemma arch_decode_inv_wf[wp]:
   "\<lbrace>invs and valid_cap (cap.ArchObjectCap arch_cap) and
     cte_wp_at ((=) (cap.ArchObjectCap arch_cap)) slot and
@@ -1373,7 +1372,7 @@ lemma arch_decode_inv_wf[wp]:
                               linorder_not_le aligned_sum_less_kernel_base
                         elim: is_aligned_weaken split: vmpage_size.split
                        split: if_splits
-                      intro!: is_aligned_addrFromPPtr is_aligned_addrFromPPtr_n
+                      intro!: is_aligned_addrFromPPtr_n
                               pbfs_atleast_pageBits)[2]
     apply (cases "invocation_type label = ArchInvocationLabel ARMPageUnmap")
      apply simp

--- a/proof/invariant-abstract/ARM/ArchKernelInit_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchKernelInit_AI.thy
@@ -358,9 +358,8 @@ lemma invs_A:
    apply (clarsimp simp: valid_global_objs_def state_defs)
    apply (clarsimp simp: valid_ao_at_def obj_at_def empty_table_def pde_ref_def
                          valid_pde_mappings_def valid_vso_at_def)
-   apply (simp add: kernel_base_def kernel_mapping_slots_def
-                    Platform.ARM.addrFromPPtr_def pptrBaseOffset_def
-                    pptrBase_def Kernel_Config.physBase_def pageBits_def is_aligned_def)
+   apply (simp add: kernel_mapping_slots_def kernel_base_def)
+   apply (rule is_aligned_addrFromPPtr_n; simp add: pageBits_def is_aligned_def)
   apply (rule conjI)
    apply (simp add: valid_kernel_mappings_def state_defs
                          valid_kernel_mappings_if_pd_def pde_ref_def

--- a/proof/invariant-abstract/ARM_HYP/ArchAInvsPre.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchAInvsPre.thy
@@ -19,15 +19,6 @@ lemma get_pd_of_thread_reachable:
           split: Structures_A.kernel_object.splits if_split_asm option.splits
                  cap.splits arch_cap.splits)
 
-lemma is_aligned_ptrFromPAddrD:
-"\<lbrakk>is_aligned (ptrFromPAddr b) a; a \<le> 25\<rbrakk> \<Longrightarrow> is_aligned b a"
-  apply (clarsimp simp: ptrFromPAddr_def pptrBaseOffset_def pptrBase_def Kernel_Config.physBase_def)
-  apply (erule is_aligned_addD2)
-  apply (rule is_aligned_weaken[where x = 25])
-   apply (simp add: is_aligned_def)
-  apply simp
-  done
-
 lemma obj_bits_data_at:
   "data_at sz (ptrFromPAddr b) s
   \<Longrightarrow> obj_bits (the (kheap s (ptrFromPAddr b))) = pageBitsForSize sz"
@@ -105,10 +96,6 @@ lemma device_frame_in_device_region:
   \<Longrightarrow> device_state (machine_state s) p \<noteq> None"
   by (auto simp add: pspace_respects_device_region_def dom_def device_mem_def)
 
-lemma is_aligned_pptrBaseOffset:
-"is_aligned pptrBaseOffset (pageBitsForSize sz)"
-  by (case_tac sz, simp_all add: pptrBaseOffset_def
-                   pptrBase_def Kernel_Config.physBase_def is_aligned_def)[1]
 
 global_naming Arch
 named_theorems AInvsPre_asms

--- a/proof/invariant-abstract/ARM_HYP/ArchAcc_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchAcc_AI.thy
@@ -2548,39 +2548,6 @@ lemma create_mapping_entries_valid_slots [wp]: (* ARMHYP *)
   apply (fastforce intro!: aligned_add_aligned is_aligned_shiftl_self)
   done
 
-lemma is_aligned_addrFromPPtr_n:
-  "\<lbrakk> is_aligned p n; n \<le> 28 \<rbrakk> \<Longrightarrow> is_aligned (Platform.ARM_HYP.addrFromPPtr p) n"
-  apply (simp add: Platform.ARM_HYP.addrFromPPtr_def)
-  apply (erule aligned_sub_aligned, simp_all)
-  apply (simp add: pptrBaseOffset_def Kernel_Config.physBase_def
-                   pptrBase_def pageBits_def)
-  apply (erule is_aligned_weaken[rotated])
-  apply (simp add: is_aligned_def)
-  done
-
-lemma is_aligned_addrFromPPtr:
-  "is_aligned p pageBits \<Longrightarrow> is_aligned (Platform.ARM_HYP.addrFromPPtr p) pageBits"
-  by (simp add: is_aligned_addrFromPPtr_n pageBits_def)
-
-lemma is_aligned_ptrFromPAddr_n:
-  "\<lbrakk>is_aligned x sz; sz\<le> 28\<rbrakk>
-  \<Longrightarrow> is_aligned (ptrFromPAddr x) sz"
-  apply (simp add:ptrFromPAddr_def pptrBaseOffset_def
-    pptrBase_def Kernel_Config.physBase_def)
-  apply (erule aligned_add_aligned)
-   apply (erule is_aligned_weaken[rotated])
-   apply (simp add:is_aligned_def)
-  apply (simp add:word_bits_def)
-  done
-
-lemma is_aligned_ptrFromPAddr:
-  "is_aligned p pageBits \<Longrightarrow> is_aligned (ptrFromPAddr p) pageBits"
-  by (simp add: is_aligned_ptrFromPAddr_n pageBits_def)
-
-lemma pbfs_le_28[simp]:
-  "pageBitsForSize sz \<le> 28"
-  by (cases sz; simp)
-
 lemma store_pde_lookup_pd: (* ARMHYP *)
   "\<lbrace>\<exists>\<rhd> pd and page_directory_at pd and valid_vspace_objs
      and (\<lambda>s. valid_asid_table (arm_asid_table (arch_state s)) s)\<rbrace>

--- a/proof/invariant-abstract/ARM_HYP/ArchInvariants_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchInvariants_AI.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2023, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -2574,6 +2575,74 @@ qed
 
 lemmas pte_ref_pages_simps[simp] = pte_ref_pages_def[split_simps pte.split]
 lemmas pde_ref_pages_simps[simp] = pde_ref_pages_def[split_simps pde.split]
+
+(* sanity check Arch_Kernel_Config_Lemmas version and shadow original name *)
+lemma physBase_aligned[simplified pageBitsForSize_simps]:
+  "is_aligned physBase (pageBitsForSize ARMSuperSection)"
+  by simp (rule physBase_aligned)
+
+lemma pptrBase_aligned[simplified pageBitsForSize_simps]:
+  "is_aligned pptrBase (pageBitsForSize ARMSuperSection)"
+  by (simp add: is_aligned_def pptrBase_def)
+
+lemma pptrBaseOffset_aligned[simplified pageBitsForSize_simps]:
+  "is_aligned pptrBaseOffset (pageBitsForSize ARMSuperSection)"
+  by (auto simp: pptrBaseOffset_def physBase_aligned pptrBase_aligned
+           elim: is_aligned_weaken intro: aligned_sub_aligned)
+
+lemma pageBitsForSize_limit[simplified pageBitsForSize_simps, simp]:
+  "pageBitsForSize sz \<le> pageBitsForSize ARMSuperSection"
+  by (cases sz; simp)
+
+lemma is_aligned_pptrBaseOffset[simplified pageBitsForSize_simps]:
+  "is_aligned pptrBaseOffset (pageBitsForSize sz)"
+  by (cases sz; clarsimp intro!: is_aligned_weaken[OF pptrBaseOffset_aligned])
+
+lemma is_aligned_addrFromPPtr_n[simplified pageBitsForSize_simps]:
+  "\<lbrakk> is_aligned p n; n \<le> (pageBitsForSize ARMSuperSection) \<rbrakk>
+   \<Longrightarrow> is_aligned (Platform.ARM_HYP.addrFromPPtr p) n"
+  by (auto simp: addrFromPPtr_def
+           elim!: aligned_sub_aligned
+           intro: is_aligned_weaken pptrBaseOffset_aligned)
+
+lemma is_aligned_addrFromPPtr:
+  "is_aligned p pageBits \<Longrightarrow> is_aligned (Platform.ARM_HYP.addrFromPPtr p) pageBits"
+  by (simp add: is_aligned_addrFromPPtr_n pageBits_def)
+
+lemma is_aligned_ptrFromPAddr_n[simplified pageBitsForSize_simps]:
+  "\<lbrakk> is_aligned p n; n \<le> (pageBitsForSize ARMSuperSection)\<rbrakk>
+   \<Longrightarrow> is_aligned (ptrFromPAddr p) n"
+  by (auto simp: ptrFromPAddr_def
+           elim!: aligned_add_aligned
+           intro: is_aligned_weaken pptrBaseOffset_aligned)
+
+lemma is_aligned_ptrFromPAddr:
+  "is_aligned p pageBits \<Longrightarrow> is_aligned (ptrFromPAddr p) pageBits"
+  by (simp add: is_aligned_ptrFromPAddr_n pageBits_def)
+
+lemma is_aligned_ptrFromPAddrD[simplified pageBitsForSize_simps]:
+  "\<lbrakk> is_aligned (ptrFromPAddr b) a; a \<le> (pageBitsForSize ARMSuperSection)\<rbrakk>
+   \<Longrightarrow> is_aligned b a"
+  by (simp add: ptrFromPAddr_def)
+     (erule is_aligned_addD2, erule is_aligned_weaken[OF pptrBaseOffset_aligned])
+
+lemma addrFromPPtr_mask[simplified ARM_HYP.pageBitsForSize_simps]:
+  "n \<le> pageBitsForSize ARMSuperSection
+   \<Longrightarrow> addrFromPPtr ptr && mask n = ptr && mask n"
+  apply (simp add: addrFromPPtr_def)
+  apply (prop_tac "pptrBaseOffset AND mask n = 0")
+   apply (rule mask_zero[OF is_aligned_weaken[OF pptrBaseOffset_aligned]], simp)
+  apply (simp flip: mask_eqs(8))
+  done
+
+lemma ptrFromPAddr_mask[simplified ARM_HYP.pageBitsForSize_simps]:
+  "n \<le> pageBitsForSize ARMSuperSection
+   \<Longrightarrow> ptrFromPAddr ptr && mask n = ptr && mask n"
+  apply (simp add: ptrFromPAddr_def)
+  apply (prop_tac "pptrBaseOffset AND mask n = 0")
+   apply (rule mask_zero[OF is_aligned_weaken[OF pptrBaseOffset_aligned]], simp)
+  apply (simp flip: mask_eqs(7))
+  done
 
 end
 

--- a/proof/invariant-abstract/RISCV64/ArchInvariants_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchInvariants_AI.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2023, Proofcraft Pty Ltd
  * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -1280,10 +1281,55 @@ lemma canonical_user_pptr_base:
   "canonical_user < pptr_base"
   by (simp add: canonical_user_def pptr_base_def pptrBase_def canonical_bit_def mask_def)
 
-lemma pptr_base_kernel_elf_base: (* FIXME MK: candidate for Kernel_Config_Lemmas *)
+(* Shadow lemmas from Arch_Kernel_Config_Lemmas and fold definitions to avoid magic numbers.
+   Written out to make sure the folding has succeeded: *)
+
+lemma is_page_aligned_physBase:
+  "is_aligned physBase pageBits"
+  by (rule is_page_aligned_physBase[folded pageBits_def])
+
+lemma kernel_window_sufficient:
+  "pptrBase + (1 << kernel_window_bits) \<le> kernelELFBase"
+  by (rule kernel_window_sufficient[folded kernel_window_bits_def])
+
+lemma kernel_elf_window_at_least_page:
+  "kernelELFBase + 2 ^ pageBits \<le> kdevBase"
+  by (rule kernel_elf_window_at_least_page[folded pageBits_def])
+
+lemma kernelELFBase_no_overflow:
+  "kernelELFBase < kernelELFBase + 2 ^ pageBits"
+  by (rule kernelELFBase_no_overflow[folded pageBits_def])
+
+(* end shadowing of Arch_Kernel_Config_Lemmas *)
+
+lemma is_page_aligned_kernelELFPAddrBase:
+  "is_aligned kernelELFPAddrBase pageBits"
+  unfolding kernelELFPAddrBase_def
+  by (fastforce intro!: is_aligned_add is_page_aligned_physBase
+                simp: kernelELFPAddrBase_def pageBits_def is_aligned_def)
+
+lemma pptr_base_kernel_elf_base:
   "pptr_base < kernel_elf_base"
-  by (simp add: pptr_base_def pptrBase_def canonical_bit_def kernel_elf_base_def kernelELFBase_def
-                kernelELFPAddrBase_def Kernel_Config.physBase_def mask_def)
+  by (simp add: pptr_base_def kernel_elf_base_def pptrBase_kernelELFBase)
+
+lemma pptr_base_kdev_base:
+  "pptr_base < kdev_base"
+  by (simp add: pptr_base_def pptrBase_def kdev_base_def kdevBase_def canonical_bit_def)
+
+lemma is_page_aligned_pptrTop:
+  "is_aligned pptrTop pageBits"
+  by (simp add: pptrTop_def pageBits_def is_aligned_def)
+
+lemma is_page_aligned_kernel_elf_base:
+  "is_aligned kernel_elf_base pageBits"
+  unfolding kernel_elf_base_def kernelELFBase_def
+  by (simp add: is_aligned_add is_page_aligned_pptrTop is_aligned_andI1
+                is_page_aligned_kernelELFPAddrBase)
+
+lemma canonical_user_kernel_elf_base:
+  "canonical_user < kernel_elf_base"
+  using canonical_user_pptr_base pptr_base_kernel_elf_base
+  by simp
 
 lemma above_pptr_base_canonical:
   "pptr_base \<le> p \<Longrightarrow> canonical_address p"

--- a/proof/invariant-abstract/RISCV64/ArchKernelInit_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchKernelInit_AI.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2023, Proofcraft Pty Ltd
  * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -208,11 +209,33 @@ lemma pt_walk_init_A_st[simp]:
                    is_aligned_pt_slot_offset_pte global_pte_def)
   done
 
+(* Since the bottom 30 bits don't matter for 1GB pages, kernelELFPAddrBase and physBase don't have
+   any influence on the index in the page table, i.e. the virtual address kernel_elf_base is always
+   within the same 1GB page. *)
+lemma elf_index_value:
+  "elf_index = 0x1FE"
+proof -
+  have mask_0: "\<And>n m x. n < m \<Longrightarrow> - (1 << m) && x && mask n = 0"
+    by (metis and.commute and_zero_eq word_mask_and_neg_shift_eq_0 word_bw_assocs(1))
+  have "pt_index max_pt_level kernel_elf_base = 0x1FE"
+    unfolding pt_index_def pt_bits_left_def level_defs bit_simps kernel_elf_base_def
+              kernelELFBase_def pptrTop_def
+    apply (subst word_plus_and_or_coroll)
+     apply (subst mask_0; simp)
+    apply (simp add: word_and_mask_shift_eq_0 shiftr_over_or_dist)
+    apply (simp add: mask_def)
+    done
+  then show ?thesis
+    unfolding elf_index_def
+    by (simp add: bit_simps ucast_ucast_mask)
+qed
+
 lemma table_index_riscv_global_pt_ptr:
   "table_index (pt_slot_offset max_pt_level riscv_global_pt_ptr vref) =
-  ucast ((vref >> ptTranslationBits * 2 + pageBits) && mask ptTranslationBits)"
+  ucast ((vref >> toplevel_bits) && mask ptTranslationBits)"
   apply (simp add: pt_slot_offset_def pt_index_def pt_bits_left_def bit_simps level_defs
-                   riscv_global_pt_ptr_def pptr_base_def pptrBase_def canonical_bit_def)
+                   riscv_global_pt_ptr_def pptr_base_def pptrBase_def canonical_bit_def
+                   toplevel_bits_def)
   apply (subst word_plus_and_or_coroll)
    apply word_bitwise
    apply simp
@@ -220,10 +243,14 @@ lemma table_index_riscv_global_pt_ptr:
   apply (clarsimp simp: word_size)
   done
 
-lemma kernel_window_1G:
-  "\<lbrakk> pptr_base \<le> vref; vref < pptr_base + (1 << 30) \<rbrakk> \<Longrightarrow>
+schematic_goal toplevel_bits_value:
+  "toplevel_bits = ?v"
+  by (simp add: toplevel_bits_def level_defs bit_simps pt_bits_left_def)
+
+lemma kernel_window_bits_table_index:
+  "\<lbrakk> pptr_base \<le> vref; vref < pptr_base + (1 << kernel_window_bits) \<rbrakk> \<Longrightarrow>
     table_index (pt_slot_offset max_pt_level riscv_global_pt_ptr vref) = 0x100"
-  apply (simp add: table_index_riscv_global_pt_ptr)
+  apply (simp add: table_index_riscv_global_pt_ptr toplevel_bits_value kernel_window_bits_def)
   apply (simp add: bit_simps pptr_base_def pptrBase_def neg_mask_le_high_bits word_size flip: NOT_mask)
   apply (subst (asm) mask_def)
   apply (simp add: canonical_bit_def)
@@ -237,81 +264,143 @@ lemma kernel_mapping_slots_0x100[simp]:
                 pptrBase_def canonical_bit_def)
 
 lemma translate_address_kernel_window:
-  "\<lbrakk> pptr_base \<le> vref; vref < pptr_base + (1 << 30) \<rbrakk>\<Longrightarrow>
+  "\<lbrakk> pptr_base \<le> vref; vref < pptr_base + (1 << kernel_window_bits) \<rbrakk>\<Longrightarrow>
    translate_address riscv_global_pt_ptr vref (ptes_of init_A_st) = Some (addrFromPPtr vref)"
   apply (clarsimp simp: translate_address_def in_omonad pt_lookup_target_def
                         pt_lookup_slot_from_level_def)
   apply (simp add: ptes_of_init_A_st_global[THEN fun_cong] init_global_pt_def global_pte_def pte_ref_def)
-  apply (simp add: kernel_window_1G is_aligned_pt_slot_offset_pte)
+  apply (simp add: kernel_window_bits_table_index is_aligned_pt_slot_offset_pte)
   apply (simp add: bit_simps addr_from_ppn_def shiftl_shiftl)
   apply (simp add: ptrFromPAddr_def addrFromPPtr_def)
   apply (simp add: pptrBaseOffset_def paddrBase_def)
-  apply (simp add: pt_bits_left_def bit_simps level_defs)
+  apply (simp add: pt_bits_left_def bit_simps level_defs elf_index_value toplevel_bits_def)
   apply (rule conjI)
    apply (rule is_aligned_add)
     apply (simp add: mask_def)
    apply (simp add: pptrBase_def canonical_bit_def is_aligned_def)
-  apply (simp add: pptr_base_def)
+  apply (simp add: pptr_base_def kernel_window_bits_def)
   apply (simp add: pptrBase_def neg_mask_le_high_bits flip: NOT_mask)
   apply (subst word_plus_and_or_coroll; simp add: canonical_bit_def word_size mask_def)
   apply word_bitwise
   apply clarsimp
   done
 
-lemma elf_window_1M:
-  "\<lbrakk> kernel_elf_base \<le> vref; vref < kernel_elf_base + (1 << 20) \<rbrakk> \<Longrightarrow>
-    table_index (pt_slot_offset max_pt_level riscv_global_pt_ptr vref) = 0x1FE"
-  apply (simp add: table_index_riscv_global_pt_ptr)
-  apply (simp add: bit_simps kernel_elf_base_def kernelELFBase_def kernelELFPAddrBase_def
-                   Kernel_Config.physBase_def)
+lemma kernelELF_plus_page:
+  "((kernelELFPAddrBase && mask toplevel_bits) + 2^pageBits) \<le> 2^toplevel_bits"
+  by (fastforce intro: aligned_mask_plus_bounded is_page_aligned_kernelELFPAddrBase
+                simp: toplevel_bits_value bit_simps)
+
+lemma elf_window_4k:
+  "\<lbrakk> kernel_elf_base \<le> vref; vref < kernel_elf_base + (1 << pageBits) \<rbrakk> \<Longrightarrow>
+    table_index (pt_slot_offset max_pt_level riscv_global_pt_ptr vref) = elf_index"
+  using is_page_aligned_kernelELFPAddrBase
+  apply (simp add: table_index_riscv_global_pt_ptr elf_index_value toplevel_bits_value
+                   kernel_elf_base_def kernelELFBase_def)
+  apply (simp add: bit_simps add_ac)
+  apply (drule order_less_le_trans)
+   apply (rule word_plus_mono_right)
+    apply (rule kernelELF_plus_page[unfolded bit_simps toplevel_bits_value, simplified])
+   apply (simp add: pptrTop_def)
+  apply (simp add: bit_simps pptrTop_def mask_def is_aligned_nth)
   apply word_bitwise
-  apply (clarsimp simp: word_size)
+  apply clarsimp
   done
 
-lemma kernel_mapping_slots_0x1FE[simp]:
-  "0x1FE \<in> kernel_mapping_slots"
+lemma leq_elf_index:
+  "0x100 \<le> elf_index"
+  by (simp add: elf_index_value)
+
+lemma kernel_mapping_slots_elf_index[simp]:
+  "elf_index \<in> kernel_mapping_slots"
   by (simp add: kernel_mapping_slots_def pptr_base_def bit_simps pt_bits_left_def level_defs
-                pptrBase_def canonical_bit_def)
+                pptrBase_def canonical_bit_def leq_elf_index)
+
+lemma rewrite_eq_minus_to_plus_eq:
+  "(x = a - b) = (b + x = a)" for x :: "'a::ring"
+  by auto
+
+lemma merge_kernelELFPAddrBase_masks:
+  "((kernelELFPAddrBase && ~~ mask 30) +
+    (pptrTop + (kernelELFPAddrBase && mask 30) - kernelELFPAddrBase))
+   = pptrTop"
+  by (simp add: mask_out_sub_mask)
+
+lemma is_aligned_ptrFromPAddr_kernelELFPAddrBase:
+  "is_aligned
+     (ptrFromPAddr
+       (addr_from_ppn (ucast (kernelELFPAddrBase && ~~ mask toplevel_bits >> pageBits))))
+     (pt_bits_left max_pt_level)"
+  apply (simp add: addr_from_ppn_def ptrFromPAddr_def addrFromPPtr_def elf_index_value)
+  apply (simp add: pt_bits_left_def bit_simps level_defs ucast_ucast_mask toplevel_bits_value)
+  apply (simp add: pptrBase_def pptrBaseOffset_def paddrBase_def canonical_bit_def)
+  apply (rule is_aligned_add)
+   apply (metis and_not_mask is_aligned_andI1 is_aligned_shiftl_self shiftr_and_eq_shiftl)
+  apply (simp add: is_aligned_def)
+  done
+
+lemma kernelELFPAddrBase_addrFromKPPtr:
+  "\<lbrakk> kernel_elf_base \<le> vref; vref < kernel_elf_base + (1 << pageBits) \<rbrakk>
+   \<Longrightarrow> addr_from_ppn (ucast (kernelELFPAddrBase && ~~ mask toplevel_bits >> pageBits)) +
+       (vref && mask (pt_bits_left max_pt_level))
+       = addrFromKPPtr vref"
+  apply (simp add: addr_from_ppn_def ptrFromPAddr_def addrFromPPtr_def elf_index_value)
+  apply (simp add: pt_bits_left_def bit_simps level_defs ucast_ucast_mask toplevel_bits_value)
+  apply (simp add: addrFromKPPtr_def mask_shiftl_decompose flip: word_and_mask_shiftl)
+  apply (simp add: ac_simps neg_mask_combine)
+  apply (simp add: kernel_elf_base_def kernelELFBaseOffset_def)
+  apply (simp only: kernelELFBase_def)
+  apply (subst rewrite_eq_minus_to_plus_eq)
+  apply (simp add: add_ac merge_kernelELFPAddrBase_masks)
+  apply (subst word_plus_and_or_coroll)
+   apply (simp add: pptrTop_def mask_def)
+   apply word_bitwise
+  apply (subst (asm) word_plus_and_or_coroll)
+   apply (simp add: pptrTop_def mask_def)
+   apply word_bitwise
+  apply (drule order_less_le_trans)
+   apply (rule word_plus_mono_right)
+    apply (rule kernelELF_plus_page[unfolded bit_simps toplevel_bits_value, simplified])
+   apply (simp add: pptrTop_def)
+  apply (simp add: pptrTop_def mask_def)
+  apply word_bitwise
+  apply clarsimp
+  done
 
 lemma translate_address_kernel_elf_window:
-  "\<lbrakk> kernel_elf_base \<le> vref; vref < kernel_elf_base + (1 << 20) \<rbrakk> \<Longrightarrow>
+  "\<lbrakk> kernel_elf_base \<le> vref; vref < kernel_elf_base + (1 << pageBits) \<rbrakk> \<Longrightarrow>
    translate_address riscv_global_pt_ptr vref (ptes_of init_A_st) = Some (addrFromKPPtr vref)"
   apply (clarsimp simp: translate_address_def in_omonad pt_lookup_target_def
                         pt_lookup_slot_from_level_def)
   apply (simp add: ptes_of_init_A_st_global[THEN fun_cong] init_global_pt_def global_pte_def pte_ref_def)
-  apply (simp add: elf_window_1M is_aligned_pt_slot_offset_pte)
-  apply (simp add: bit_simps addr_from_ppn_def shiftl_shiftl)
-  apply (simp add: ptrFromPAddr_def addrFromPPtr_def)
-  apply (simp add: addrFromKPPtr_def kernelELFBaseOffset_def kernelELFPAddrBase_def kernelELFBase_def
-                   Kernel_Config.physBase_def mask_def)
-  apply (simp add: pt_bits_left_def bit_simps level_defs)
-  apply (rule conjI)
-   apply (simp add: pptrBase_def pptrBaseOffset_def paddrBase_def canonical_bit_def is_aligned_def)
-  apply (simp add: kernel_elf_base_def kernelELFBase_def kernelELFPAddrBase_def Kernel_Config.physBase_def)
-  apply (subst word_plus_and_or_coroll)
-   apply (simp add: canonical_bit_def word_size mask_def)
-   apply word_bitwise
-  apply (simp add: canonical_bit_def word_size mask_def)
-  apply word_bitwise
-  apply clarsimp
+  apply (simp add: elf_window_4k is_aligned_pt_slot_offset_pte elf_index_value)
+  apply (clarsimp simp: is_aligned_ptrFromPAddr_kernelELFPAddrBase kernelELFPAddrBase_addrFromKPPtr)
   done
 
 lemma kernel_window_init_st:
-  "kernel_window init_A_st = { pptr_base ..< pptr_base + (1 << 30) }"
-  by (auto simp: state_defs kernel_window_def)
+  "kernel_window init_A_st = { pptr_base ..< pptr_base + (1 << kernel_window_bits) }"
+  by (auto simp: state_defs kernel_window_def toplevel_bits_def bit_simps)
+
+lemma abs_kernel_window_sufficient:
+  "pptr_base + (1 << kernel_window_bits) \<le> kernel_elf_base"
+  unfolding pptr_base_def kernel_elf_base_def
+  using kernel_window_sufficient
+  by simp
+
+lemma abs_kernel_elf_window_at_least_page:
+  "kernel_elf_base + 2 ^ pageBits \<le> kdev_base"
+  unfolding kernel_elf_base_def kdev_base_def
+  using kernel_elf_window_at_least_page
+  by simp
+
+lemma kernel_elf_base_no_overflow:
+  "kernel_elf_base < kernel_elf_base + 2 ^ pageBits"
+  unfolding kernel_elf_base_def
+  by (rule kernelELFBase_no_overflow)
 
 lemma kernel_elf_window_init_st:
-  "kernel_elf_window init_A_st = { kernel_elf_base ..< kernel_elf_base + (1 << 20) }"
-  apply (clarsimp simp: state_defs kernel_elf_window_def kernel_elf_base_def kernelELFBase_def
-                        pptr_base_def pptrBase_def canonical_bit_def kernelELFPAddrBase_def
-                        Kernel_Config.physBase_def)
-  apply (rule set_eqI, clarsimp)
-  apply (rule iffI)
-   apply auto[1]
-  apply clarsimp
-  apply word_bitwise
-  apply clarsimp
-  done
+  "kernel_elf_window init_A_st = { kernel_elf_base ..< kernel_elf_base + (1 << pageBits) }"
+  using abs_kernel_window_sufficient
+  by (force simp: state_defs kernel_elf_window_def)
 
 lemma valid_global_vspace_mappings_init_A_st[simp]:
   "valid_global_vspace_mappings init_A_st"
@@ -322,29 +411,22 @@ lemma valid_global_vspace_mappings_init_A_st[simp]:
 lemma valid_uses_init_A_st[simp]: "valid_uses_2 init_vspace_uses"
 proof -
   note canonical_bit_def[simp]
-  have [simp]: "pptr_base < pptr_base + 0x40000000"
-    by (simp add: pptr_base_def pptrBase_def)
+  have [simplified, simp]: "pptr_base < pptr_base + (1 << kernel_window_bits)"
+    by (simp add: pptr_base_def pptrBase_def kernel_window_bits_def)
   have [simp]: "p \<le> canonical_user \<Longrightarrow> \<not> pptr_base \<le> p" for p
     by (rule notI, drule (1) order_trans)
        (simp add: canonical_user_def mask_def pptr_base_def pptrBase_def)
   have [simp]: "p \<le> canonical_user \<Longrightarrow> \<not> kernel_elf_base \<le> p" for p
-    by (rule notI, drule (1) order_trans)
-       (simp add: canonical_user_def mask_def kernel_elf_base_def kernelELFBase_def
-                  kernelELFPAddrBase_def Kernel_Config.physBase_def)
+    using canonical_user_kernel_elf_base by simp
   have [simp]: "p \<le> canonical_user \<Longrightarrow> \<not> kdev_base \<le> p" for p
     by (rule notI, drule (1) order_trans)
        (simp add: canonical_user_def mask_def kdev_base_def kdevBase_def)
-  have [simp]: "kernel_elf_base \<le> p \<Longrightarrow> \<not> p < pptr_base + 0x40000000" for p
-    by (rule notI, drule (1) order_le_less_trans)
-       (simp add: kernel_elf_base_def kernelELFBase_def pptr_base_def pptrBase_def
-                  kernelELFPAddrBase_def Kernel_Config.physBase_def mask_def)
-  have [simp]: "kdev_base \<le> p \<Longrightarrow> \<not> p < kernel_elf_base + 0x100000" for p
-    by (rule notI, drule (1) order_le_less_trans)
-       (simp add: kernel_elf_base_def kernelELFBase_def kdev_base_def kdevBase_def pptrBase_def
-                  kernelELFPAddrBase_def Kernel_Config.physBase_def mask_def)
-  have "pptr_base + 0x40000000 < kernel_elf_base + 0x100000"
-    by (simp add: kernel_elf_base_def kernelELFBase_def pptr_base_def pptrBase_def
-                  kernelELFPAddrBase_def Kernel_Config.physBase_def mask_def)
+  have [simplified, simp]: "kernel_elf_base \<le> p \<Longrightarrow> \<not> p < pptr_base + (1 << kernel_window_bits)" for p
+    using abs_kernel_window_sufficient by simp
+  have [simp]: "kdev_base \<le> p \<Longrightarrow> \<not> p < kernel_elf_base + 2 ^ pageBits" for p
+    using abs_kernel_elf_window_at_least_page by simp
+  have "pptr_base + (1 << kernel_window_bits) < kernel_elf_base + 2 ^ pageBits"
+    using abs_kernel_window_sufficient kernel_elf_base_no_overflow by simp
   thus ?thesis
     using canonical_user_pptr_base pptr_base_kernel_elf_base
     unfolding valid_uses_2_def init_vspace_uses_def window_defs
@@ -381,25 +463,42 @@ lemma valid_vspace_objs_init_A_st[simp]:
 lemma global_pt_kernel_window_init_arch_state[simp]:
   "obj_addrs init_global_pt riscv_global_pt_ptr \<subseteq>
      kernel_window_2 (riscv_kernel_vspace init_arch_state)"
-  apply (clarsimp simp: state_defs pptr_base_num bit_simps kernel_window_def kernel_elf_base_def)
+  apply (clarsimp simp: state_defs pptr_base_num bit_simps kernel_window_def kernel_elf_base_def
+                        kernel_window_bits_def)
   apply (rule conjI; unat_arith)
   done
 
 lemma idle_thread_in_kernel_window_init_arch_state[simp]:
   "{idle_thread_ptr..0x3FF + idle_thread_ptr} \<subseteq>
      kernel_window_2 (riscv_kernel_vspace init_arch_state)"
-  apply (clarsimp simp: state_defs pptr_base_num bit_simps kernel_window_def kernel_elf_base_def)
+  apply (clarsimp simp: state_defs pptr_base_num bit_simps kernel_window_def kernel_elf_base_def
+                        kernel_window_bits_def)
   apply (rule conjI; unat_arith)
   done
 
+lemma pptr_base_kernel_window_no_overflow:
+  "pptr_base \<le> pptr_base + (1 << kernel_window_bits)"
+  by (simp add: pptr_base_def pptrBase_def canonical_bit_def kernel_window_bits_def)
+
 lemma irq_node_pptr_base_kernel_elf_base:
-  "\<lbrakk>x \<le> pptr_base + (m + (mask cte_level_bits + 0x3000)); m \<le> mask (size irq) << cte_level_bits \<rbrakk>
-   \<Longrightarrow> \<not> kernel_elf_base \<le> x" for irq::irq
-  apply (simp add: word_size cte_level_bits_def mask_def pptr_base_def pptrBase_def
-                   kernel_elf_base_def kernelELFBase_def canonical_bit_def not_le
-                   kernelELFPAddrBase_def Kernel_Config.physBase_def)
-  apply unat_arith
-  done
+  fixes irq::irq
+  assumes "x \<le> pptr_base + (m + (mask cte_level_bits + 0x3000))"
+  assumes "m \<le> mask (size irq) << cte_level_bits"
+  shows "\<not> kernel_elf_base \<le> x"
+proof -
+  have less:
+    "\<And>m x. \<lbrakk> m \<le> x; x < 1 << kernel_window_bits \<rbrakk> \<Longrightarrow> pptr_base + m < kernel_elf_base"
+    using order_le_less_trans word_plus_strict_mono_right pptr_base_kernel_elf_base
+          pptr_base_kernel_window_no_overflow abs_kernel_window_sufficient
+    by fastforce
+  from assms show ?thesis
+    apply (simp add: not_le)
+    apply (erule order_le_less_trans)
+    apply (rule less[where x="mask cte_level_bits + 0x3000 + mask (size irq) << cte_level_bits"];
+           simp add: word_size cte_level_bits_def mask_def kernel_window_bits_def)
+    apply unat_arith
+    done
+qed
 
 lemma irq_node_in_kernel_window_init_arch_state':
   "\<lbrakk> init_irq_node_ptr + m \<le> x; x \<le> init_irq_node_ptr + m + mask cte_level_bits;
@@ -418,9 +517,10 @@ lemma irq_node_in_kernel_window_init_arch_state':
     apply (simp add: pptr_base_num canonical_bit_def is_aligned_def)
    apply (simp add: pptr_base_num cte_level_bits_def canonical_bit_def mask_def word_size)
    apply unat_arith
-  apply (simp add: kernel_elf_base_def kernelELFBase_def cte_level_bits_def canonical_bit_def
-                   mask_def init_irq_node_ptr_def pptr_base_num word_size kernelELFPAddrBase_def
-                   Kernel_Config.physBase_def)
+  apply clarsimp
+  apply (thin_tac "kernel_elf_base \<le> x \<longrightarrow> P" for x P)
+  apply (simp add: cte_level_bits_def canonical_bit_def mask_def init_irq_node_ptr_def
+                   pptr_base_num word_size kernel_window_bits_def)
   apply unat_arith
   apply clarsimp
   done

--- a/proof/refine/ARM/Arch_R.thy
+++ b/proof/refine/ARM/Arch_R.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2023, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -1492,17 +1493,6 @@ lemma ensureSafeMapping_valid_slots_duplicated':
   apply (fastforce simp:valid_slots_duplicated'_def)
   done
 
-lemma is_aligned_ptrFromPAddr_aligned:
-  "m \<le> 28 \<Longrightarrow> is_aligned (ptrFromPAddr p) m = is_aligned p m"
-  apply (simp add: ptrFromPAddr_def is_aligned_mask pptrBaseOffset_def pptrBase_def
-                   Kernel_Config.physBase_def)
-  apply (subst add.commute)
-  apply (subst mask_add_aligned)
-   apply (erule is_aligned_weaken[rotated])
-   apply (simp add:is_aligned_def)
-  apply simp
-  done
-
 (* FIXME: this lemma is too specific *)
 lemma lookupPTSlot_aligned:
   "\<lbrace>\<lambda>s. is_aligned vptr 16 \<and> valid_objs' s\<rbrace> lookupPTSlot pd vptr \<lbrace>\<lambda>p s. is_aligned p 6\<rbrace>,-"
@@ -1514,15 +1504,13 @@ lemma lookupPTSlot_aligned:
     split:Structures_H.kernel_object.splits arch_kernel_object.splits)
   apply (simp add:valid_obj'_def lookup_pt_slot_no_fail_def)
   apply (rule aligned_add_aligned)
-    apply (rule is_aligned_ptrFromPAddr_aligned[where m = 6,THEN iffD2])
-     apply simp
-    apply (erule is_aligned_weaken)
-    apply (simp add:ptBits_def pageBits_def)
+    apply (erule is_aligned_ptrFromPAddr_n)
+    apply (simp add: ptBits_def pteBits_def)
    apply (rule is_aligned_shiftl,simp)
    apply (rule is_aligned_andI1)
    apply (rule is_aligned_shiftr)
    apply simp
-  apply simp
+  apply (simp add: ptBits_def)
   done
 
 lemma createMappingEntires_valid_slots_duplicated'[wp]:

--- a/proof/refine/ARM_HYP/Arch_R.thy
+++ b/proof/refine/ARM_HYP/Arch_R.thy
@@ -605,7 +605,7 @@ lemma decodeARMPageFlush_corres:
       apply (rule whenE_throwError_corres, simp)
        apply simp
       apply (rule whenE_throwError_corres, simp)
-       apply (simp add: fromPAddr_def Kernel_Config.physBase_def paddrTop_def add.commute)
+       apply (clarsimp simp: add.commute fromPAddr_def)
       apply (rule corres_trivial)
       apply (rule corres_returnOk)
     apply (clarsimp simp: archinv_relation_def page_invocation_map_def flush_type_map_def)
@@ -1723,17 +1723,6 @@ lemma ensureSafeMapping_valid_slots_duplicated':
   apply (fastforce simp:valid_slots_duplicated'_def)
   done
 
-lemma is_aligned_ptrFromPAddr_aligned:
-  "m \<le> 28 \<Longrightarrow> is_aligned (ptrFromPAddr p) m = is_aligned p m"
-  apply (simp add:ptrFromPAddr_def is_aligned_mask
-    pptrBaseOffset_def pptrBase_def Kernel_Config.physBase_def)
-  apply (subst add.commute)
-  apply (subst mask_add_aligned)
-   apply (erule is_aligned_weaken[rotated])
-   apply (simp add:is_aligned_def)
-  apply simp
-  done
-
 (* FIXME: this lemma is too specific *)
 lemma lookupPTSlot_aligned:
   "\<lbrace>\<lambda>s. is_aligned vptr 16 \<and> valid_objs' s\<rbrace> lookupPTSlot pd vptr \<lbrace>\<lambda>p s. is_aligned p 7\<rbrace>,-"
@@ -1745,15 +1734,13 @@ lemma lookupPTSlot_aligned:
     split:Structures_H.kernel_object.splits arch_kernel_object.splits)
   apply (simp add:valid_obj'_def lookup_pt_slot_no_fail_def)
   apply (rule aligned_add_aligned)
-    apply (rule is_aligned_ptrFromPAddr_aligned[where m = 7,THEN iffD2])
-     apply simp
-    apply (erule is_aligned_weaken)
-    apply (simp add: vspace_bits_defs)
+    apply (erule is_aligned_ptrFromPAddr_n)
+    apply (simp add: pt_bits_def pte_bits_def)
    apply (rule is_aligned_shiftl)
    apply (rule is_aligned_andI1)
    apply (rule is_aligned_shiftr)
    apply (simp add: pte_bits_def pageBits_def pt_bits_def)
-  apply simp
+  apply (simp add: pt_bits_def)
   done
 
 lemma createMappingEntires_valid_slots_duplicated'[wp]:

--- a/spec/abstract/AARCH64/Arch_Structs_A.thy
+++ b/spec/abstract/AARCH64/Arch_Structs_A.thy
@@ -12,7 +12,7 @@ imports
   "ExecSpec.Arch_Structs_B"
   ExceptionTypes_A
   VMRights_A
-  ExecSpec.Kernel_Config_Lemmas
+  ExecSpec.Arch_Kernel_Config_Lemmas
 begin
 
 context begin interpretation Arch .

--- a/spec/abstract/ARM/Arch_Structs_A.thy
+++ b/spec/abstract/ARM/Arch_Structs_A.thy
@@ -15,7 +15,7 @@ imports
   "ExecSpec.Arch_Structs_B"
   ExceptionTypes_A
   VMRights_A
-  ExecSpec.Kernel_Config_Lemmas
+  ExecSpec.Arch_Kernel_Config_Lemmas
 begin
 
 context Arch begin global_naming ARM_A

--- a/spec/abstract/ARM_HYP/Arch_Structs_A.thy
+++ b/spec/abstract/ARM_HYP/Arch_Structs_A.thy
@@ -15,7 +15,7 @@ imports
   "ExecSpec.Arch_Structs_B"
   ExceptionTypes_A
   VMRights_A
-  ExecSpec.Kernel_Config_Lemmas
+  ExecSpec.Arch_Kernel_Config_Lemmas
 begin
 
 context Arch begin global_naming ARM_A

--- a/spec/abstract/RISCV64/Arch_Structs_A.thy
+++ b/spec/abstract/RISCV64/Arch_Structs_A.thy
@@ -11,7 +11,7 @@ imports
   "ExecSpec.Arch_Structs_B"
   ExceptionTypes_A
   VMRights_A
-  ExecSpec.Kernel_Config_Lemmas
+  ExecSpec.Arch_Kernel_Config_Lemmas
 begin
 
 context Arch begin global_naming RISCV64_A

--- a/spec/abstract/X64/Arch_Structs_A.thy
+++ b/spec/abstract/X64/Arch_Structs_A.thy
@@ -11,7 +11,7 @@ imports
   "ExecSpec.Arch_Structs_B"
   ExceptionTypes_A
   VMRights_A
-  ExecSpec.Kernel_Config_Lemmas
+  ExecSpec.Arch_Kernel_Config_Lemmas
 begin
 
 context Arch begin global_naming X64_A

--- a/spec/design/skel/RISCV64/Hardware_H.thy
+++ b/spec/design/skel/RISCV64/Hardware_H.thy
@@ -12,7 +12,7 @@ begin
 
 context Arch begin global_naming RISCV64_H
 
-#INCLUDE_HASKELL SEL4/Machine/Hardware/RISCV64.hs Platform=Platform.RISCV64 CONTEXT RISCV64_H NOT plic_complete_claim getMemoryRegions getDeviceRegions getKernelDevices loadWord storeWord storeWordVM getActiveIRQ ackInterrupt maskInterrupt configureTimer resetTimer debugPrint getRestartPC setNextPC clearMemory clearMemoryVM initMemory freeMemory setHardwareASID wordFromPDE wordFromPTE VMFaultType HypFaultType VMPageSize pageBits pageBitsForSize toPAddr addrFromPPtr ptrFromPAddr sfence physBase paddrBase pptrBase pptrBaseOffset pptrUserTop kernelELFBase kernelELFBaseOffset kernelELFPAddrBase addrFromKPPtr ptTranslationBits vmFaultTypeFSR read_stval setVSpaceRoot hwASIDFlush setIRQTrigger
+#INCLUDE_HASKELL SEL4/Machine/Hardware/RISCV64.hs Platform=Platform.RISCV64 CONTEXT RISCV64_H NOT plic_complete_claim getMemoryRegions getDeviceRegions getKernelDevices loadWord storeWord storeWordVM getActiveIRQ ackInterrupt maskInterrupt configureTimer resetTimer debugPrint getRestartPC setNextPC clearMemory clearMemoryVM initMemory freeMemory setHardwareASID wordFromPDE wordFromPTE VMFaultType HypFaultType VMPageSize pageBits pageBitsForSize toPAddr addrFromPPtr ptrFromPAddr sfence physBase paddrBase pptrBase pptrBaseOffset pptrTop pptrUserTop kernelELFBase kernelELFBaseOffset kernelELFPAddrBase addrFromKPPtr ptTranslationBits vmFaultTypeFSR read_stval setVSpaceRoot hwASIDFlush setIRQTrigger
 
 end
 

--- a/spec/machine/AARCH64/Arch_Kernel_Config_Lemmas.thy
+++ b/spec/machine/AARCH64/Arch_Kernel_Config_Lemmas.thy
@@ -1,0 +1,18 @@
+(*
+ * Copyright 2023, Proofcraft Pty Ltd
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+(* Architecture-specific lemmas constraining Kernel_Config definitions *)
+
+theory Arch_Kernel_Config_Lemmas
+imports
+  Kernel_Config_Lemmas
+  Platform
+begin
+
+context Arch begin global_naming AARCH64
+
+end
+end

--- a/spec/machine/AARCH64/Arch_Kernel_Config_Lemmas.thy
+++ b/spec/machine/AARCH64/Arch_Kernel_Config_Lemmas.thy
@@ -14,5 +14,10 @@ begin
 
 context Arch begin global_naming AARCH64
 
+lemma pptrBase_kernelELFBase:
+  "pptrBase < kernelELFBase"
+  by (simp add: pptrBase_def canonical_bit_def kernelELFBase_def kernelELFPAddrBase_def pptrTop_def
+                Kernel_Config.physBase_def mask_def)
+
 end
 end

--- a/spec/machine/AARCH64/Platform.thy
+++ b/spec/machine/AARCH64/Platform.thy
@@ -12,7 +12,7 @@ imports
   "Word_Lib.WordSetup"
   "Lib.Defs"
   Setup_Locale
-  Kernel_Config_Lemmas
+  Kernel_Config
 begin
 
 context Arch begin global_naming AARCH64

--- a/spec/machine/ARM/Arch_Kernel_Config_Lemmas.thy
+++ b/spec/machine/ARM/Arch_Kernel_Config_Lemmas.thy
@@ -14,5 +14,10 @@ begin
 
 context Arch begin global_naming ARM
 
+(* note: 24 = pageBitsForSize ARMSuperSection, we do not have access to ASpec at this point *)
+lemma physBase_aligned:
+  "is_aligned physBase 24"
+  by (simp add: is_aligned_def Kernel_Config.physBase_def)
+
 end
 end

--- a/spec/machine/ARM/Arch_Kernel_Config_Lemmas.thy
+++ b/spec/machine/ARM/Arch_Kernel_Config_Lemmas.thy
@@ -1,0 +1,18 @@
+(*
+ * Copyright 2023, Proofcraft Pty Ltd
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+(* Architecture-specific lemmas constraining Kernel_Config definitions *)
+
+theory Arch_Kernel_Config_Lemmas
+imports
+  Kernel_Config_Lemmas
+  Platform
+begin
+
+context Arch begin global_naming ARM
+
+end
+end

--- a/spec/machine/ARM/Platform.thy
+++ b/spec/machine/ARM/Platform.thy
@@ -12,7 +12,7 @@ imports
   "Lib.Lib"
   "Word_Lib.WordSetup"
   Setup_Locale
-  Kernel_Config_Lemmas
+  Kernel_Config
 begin
 
 context Arch begin global_naming ARM

--- a/spec/machine/ARM_HYP/Arch_Kernel_Config_Lemmas.thy
+++ b/spec/machine/ARM_HYP/Arch_Kernel_Config_Lemmas.thy
@@ -14,5 +14,10 @@ begin
 
 context Arch begin global_naming ARM_HYP
 
+(* note: 25 = pageBitsForSize ARMSuperSection, we do not have access to ASpec at this point *)
+lemma physBase_aligned:
+  "is_aligned physBase 25"
+  by (simp add: is_aligned_def Kernel_Config.physBase_def)
+
 end
 end

--- a/spec/machine/ARM_HYP/Arch_Kernel_Config_Lemmas.thy
+++ b/spec/machine/ARM_HYP/Arch_Kernel_Config_Lemmas.thy
@@ -1,0 +1,18 @@
+(*
+ * Copyright 2023, Proofcraft Pty Ltd
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+(* Architecture-specific lemmas constraining Kernel_Config definitions *)
+
+theory Arch_Kernel_Config_Lemmas
+imports
+  Kernel_Config_Lemmas
+  Platform
+begin
+
+context Arch begin global_naming ARM_HYP
+
+end
+end

--- a/spec/machine/ARM_HYP/Platform.thy
+++ b/spec/machine/ARM_HYP/Platform.thy
@@ -12,7 +12,7 @@ imports
   "Lib.Lib"
   "Word_Lib.WordSetup"
   Setup_Locale
-  Kernel_Config_Lemmas
+  Kernel_Config
 begin
 
 context Arch begin global_naming ARM_HYP

--- a/spec/machine/Kernel_Config_Lemmas.thy
+++ b/spec/machine/Kernel_Config_Lemmas.thy
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: GPL-2.0-only
  *)
 
+(* Architecture-independent lemmas constraining Kernel_Config definitions *)
+
 theory Kernel_Config_Lemmas
 imports "$L4V_ARCH/Kernel_Config"
 begin

--- a/spec/machine/RISCV64/Arch_Kernel_Config_Lemmas.thy
+++ b/spec/machine/RISCV64/Arch_Kernel_Config_Lemmas.thy
@@ -1,0 +1,18 @@
+(*
+ * Copyright 2023, Proofcraft Pty Ltd
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+(* Architecture-specific lemmas constraining Kernel_Config definitions *)
+
+theory Arch_Kernel_Config_Lemmas
+imports
+  Kernel_Config_Lemmas
+  Platform
+begin
+
+context Arch begin global_naming RISCV64
+
+end
+end

--- a/spec/machine/RISCV64/Arch_Kernel_Config_Lemmas.thy
+++ b/spec/machine/RISCV64/Arch_Kernel_Config_Lemmas.thy
@@ -14,5 +14,33 @@ begin
 
 context Arch begin global_naming RISCV64
 
+lemma pptrBase_kernelELFBase:
+  "pptrBase < kernelELFBase"
+  by (simp add: pptrBase_def canonical_bit_def kernelELFBase_def kernelELFPAddrBase_def pptrTop_def
+                Kernel_Config.physBase_def mask_def)
+
+(* 12 in this lemma and below is pageBits, which is not yet defined in this theory.
+   Definition will be folded and the lemmas shadowed in AInvs. *)
+lemma is_page_aligned_physBase:
+  "is_aligned physBase 12"
+  by (simp add: Kernel_Config.physBase_def is_aligned_def)
+
+(* 22 is kernel_window_bits, defined in Init_A. To be folded in AInvs. *)
+lemma kernel_window_sufficient:
+  "pptrBase + (1 << 22) \<le> kernelELFBase"
+  unfolding pptrBase_def canonical_bit_def kernelELFBase_def kernelELFPAddrBase_def pptrTop_def
+  by (simp add: mask_def Kernel_Config.physBase_def)
+
+lemma kernel_elf_window_at_least_page:
+  "kernelELFBase + 2 ^ 12 \<le> kdevBase"
+  unfolding kernelELFBase_def kernelELFPAddrBase_def kdevBase_def pptrTop_def
+  by (simp add: mask_def Kernel_Config.physBase_def)
+
+(* This doesn't follow from alignment, because we need <, not \<le> *)
+lemma kernelELFBase_no_overflow:
+  "kernelELFBase < kernelELFBase + 2 ^ 12"
+  unfolding kernelELFBase_def kernelELFPAddrBase_def pptrTop_def
+  by (simp add: mask_def Kernel_Config.physBase_def)
+
 end
 end

--- a/spec/machine/RISCV64/Platform.thy
+++ b/spec/machine/RISCV64/Platform.thy
@@ -12,7 +12,7 @@ imports
   "Word_Lib.WordSetup"
   "Lib.Defs"
   Setup_Locale
-  Kernel_Config_Lemmas
+  Kernel_Config
 begin
 
 context Arch begin global_naming RISCV64

--- a/spec/machine/RISCV64/Platform.thy
+++ b/spec/machine/RISCV64/Platform.thy
@@ -109,10 +109,13 @@ definition kernelELFPAddrBase :: machine_word
   where
   "kernelELFPAddrBase = physBase + 0x4000000"
 
+definition pptrTop :: machine_word
+  where
+  "pptrTop \<equiv> - (1 << 31)"
+
 definition kernelELFBase :: machine_word
   where
-  (* note: the - (1 << 31) here is PADDR_TOP in C *)
-  "kernelELFBase = - (1 << 31) + (kernelELFPAddrBase && mask 30)" (* 2^64 - 2 GiB + ... *)
+  "kernelELFBase = pptrTop + (kernelELFPAddrBase && mask 30)" (* 2^64 - 2 GiB + ... *)
 
 definition kernelELFBaseOffset :: machine_word
   where

--- a/spec/machine/X64/Arch_Kernel_Config_Lemmas.thy
+++ b/spec/machine/X64/Arch_Kernel_Config_Lemmas.thy
@@ -1,0 +1,18 @@
+(*
+ * Copyright 2023, Proofcraft Pty Ltd
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+(* Architecture-specific lemmas constraining Kernel_Config definitions *)
+
+theory Arch_Kernel_Config_Lemmas
+imports
+  Kernel_Config_Lemmas
+  Platform
+begin
+
+context Arch begin global_naming X64
+
+end
+end

--- a/spec/machine/X64/Platform.thy
+++ b/spec/machine/X64/Platform.thy
@@ -12,7 +12,7 @@ imports
   "Word_Lib.WordSetup"
   "Lib.Defs"
   Setup_Locale
-  Kernel_Config_Lemmas
+  Kernel_Config
 begin
 
 context Arch begin global_naming X64


### PR DESCRIPTION
Refactor the proofs such that they do not unfold the value of these constants, but
instead only work with characteristic properties. Prove these characteristic properties once
per architecture in a separate theory file. If this file passes, the rest of the proofs are now guaranteed
to work for that architecture.