### PR TITLE
github: add manual triggers for testing

### DIFF
--- a/.github/workflows/external.yml
+++ b/.github/workflows/external.yml
@@ -9,6 +9,8 @@ name: External
 on:
   schedule:
     - cron: '1 15 1,15 * *'  # 15:01 UTC on 1st and 15th of month
+  # for testing:
+  workflow_dispatch:
 
 jobs:
   proofs:

--- a/.github/workflows/proof-deploy.yml
+++ b/.github/workflows/proof-deploy.yml
@@ -13,6 +13,8 @@ on:
   repository_dispatch:
     types:
       - manifest-update
+  # for testing:
+  workflow_dispatch:
 
 jobs:
   code:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -12,6 +12,8 @@ on:
       - rt
       - aarch64
   pull_request:
+  # for testing:
+  workflow_dispatch:
 
 jobs:
   check:

--- a/.github/workflows/weekly-clean.yml
+++ b/.github/workflows/weekly-clean.yml
@@ -7,6 +7,8 @@ name: Weekly Clean
 on:
   schedule:
     - cron: '1 15 * * 6'  # 15:01 UTC every Sat = 1:01 am Syd every Sun
+  # for testing:
+  workflow_dispatch:
 
 jobs:
   proofs:


### PR DESCRIPTION
The worklow_dispatch trigger adds a button in the GitHub UI that lets one trigger the workflow manually. Useful for testing the workflows.