### PR TITLE
READMEs: use run_tests consistently in READMEs

### DIFF
--- a/proof/access-control/README.md
+++ b/proof/access-control/README.md
@@ -24,9 +24,9 @@ top of the [Abstract Spec Invariant Proof](../invariant-abstract/).
 Building
 --------
 
-To build from the `l4v/` directory, run:
+To build for the ARM architecture from the `l4v/` directory, run:
 
-    ./isabelle/bin/isabelle build -d . -v -b Access
+    L4V_ARCH=ARM ./run_tests Access
 
 
 Important Theories
@@ -35,4 +35,3 @@ Important Theories
 The top-level theory where these two properties are proved for the
 kernel is [`Syscall_AC`](Syscall_AC.thy); the bottom-level theory where
 the properties are defined is [`Access`](Access.thy).
-

--- a/proof/bisim/README.md
+++ b/proof/bisim/README.md
@@ -14,9 +14,9 @@ kernel that has no other system calls than signalling notifications.
 Building
 --------
 
-To build from the `l4v/` directory, run:
+To build for the ARM architecture from the `l4v/` directory, run:
 
-    ./isabelle/bin/isabelle build -d . -v -b Bisim
+    L4V_ARCH=ARM ./run_tests Bisim
 
 Important Theories
 ------------------

--- a/proof/capDL-api/README.md
+++ b/proof/capDL-api/README.md
@@ -24,13 +24,12 @@ and Andrew Boyton's PhD thesis.
 Building
 --------
 
-To build from the `l4v/` directory, run:
+To build for the ARM architecture from the `l4v/` directory, run:
 
-    ./isabelle/bin/isabelle build -d . -v -b DSpecProofs
+    L4V_ARCH=ARM ./run_tests DSpecProofs
 
 Important Theories
 ------------------
 
 The top-level theory is [`API_DP`](API_DP.thy). The seL4 API and kernel
 model are located in [`Kernel_DP`](Kernel_DP.thy).
-

--- a/proof/crefine/README.md
+++ b/proof/crefine/README.md
@@ -30,13 +30,9 @@ The approach used for the proof is described in the TPHOLS '09
 Building
 --------
 
-To build from the `l4v/proof` directory, run:
+To build for the ARM architecture from the `l4v/` directory, run:
 
-    make CRefine
-
-If you wish to build for a specific architecture other than the default, set
-your `L4V_ARCH` environment variable accordingly, as documented for the [C code
-translation](../../spec/cspec/README.md).
+    L4V_ARCH=ARM ./run_tests CRefine
 
 Important Theories
 ------------------

--- a/proof/drefine/README.md
+++ b/proof/drefine/README.md
@@ -19,9 +19,9 @@ specification][capDL]. It is described as part of an ICFEM '13
 Building
 --------
 
-To build from the `l4v/` directory, run:
+To build for the ARM architecture from the `l4v/` directory, run:
 
-    ./isabelle/bin/isabelle build -d . -v -b DRefine
+    L4V_ARCH=ARM ./run_tests DRefine
 
 Important Theories
 ------------------

--- a/proof/infoflow/README.md
+++ b/proof/infoflow/README.md
@@ -24,9 +24,9 @@ the [C Refinement Proof](../crefine/).
 Building
 --------
 
-To build from the `l4v/` directory, run:
+To build for the ARM architecture from the `l4v/` directory, run:
 
-    ./isabelle/bin/isabelle build -d . -v -b InfoFlow
+    L4V_ARCH=ARM ./run_tests InfoFlow
 
 Important Theories
 ------------------
@@ -42,4 +42,3 @@ specification is [`InfoFlow`](InfoFlow.thy). Confidentiality is
 a relational property and the theory [`EquivValid`](../../lib/EquivValid.thy)
 defines these generically for the nondeterministic state monad of the
 abstract specification.
-

--- a/proof/invariant-abstract/README.md
+++ b/proof/invariant-abstract/README.md
@@ -17,9 +17,9 @@ described in a TPHOLS '08 [paper][1].
 Building
 --------
 
-To build from the `l4v/` directory, run:
+To build for the ARM architecture from the `l4v/` directory, run:
 
-    ./isabelle/bin/isabelle build -d . -v -b AInvs
+    L4V_ARCH=ARM ./run_tests AInvs
 
 Important Theories
 ------------------

--- a/proof/refine/README.md
+++ b/proof/refine/README.md
@@ -20,12 +20,9 @@ Proof](../invariant-abstract/). It is described in the TPHOLS '08
 Building
 --------
 
-Make sure that the `L4V_ARCH` environment variable is set to the desired
-target architecture. If in doubt, use `L4V_ARCH=ARM`.
+To build for the ARM architecture from the `l4v/` directory, run:
 
-To build from the `l4v/` directory, run:
-
-    ./isabelle/bin/isabelle build -d . -v -b Refine
+    L4V_ARCH=ARM ./run_tests Refine
 
 Important Theories
 ------------------

--- a/proof/sep-capDL/README.md
+++ b/proof/sep-capDL/README.md
@@ -30,9 +30,9 @@ and Andrew Boyton's PhD thesis.
 Building
 --------
 
-To build from the `l4v/` directory, run:
+To build for the ARM architecture from the `l4v/` directory, run:
 
-        ./isabelle/bin/isabelle build -d . -v -b SepDSpec
+        L4V_ARCH=ARM ./run_tests SepDSpec
 
 
 Important Theories

--- a/spec/abstract/README.md
+++ b/spec/abstract/README.md
@@ -45,14 +45,14 @@ The corresponding Isabelle session is `ASpec`. It is set up to build a
 human-readable PDF document. `Glossary_Doc` contains definitions of common
 seL4 terms.
 
-To build, run in directory `l4v/spec`:
+To build, run in directory `l4v/`:
 
-    make ASpec
+    L4V_ARCH=ARM ./run_test ASpec
 
 Remarks
 -------
 
- * Note that this specification is actually an extensible _family_ of
+ * Note that this specification is actually an extensible *family* of
    specifications, with predefined extension points. These points can
    either be left generic, as for most of the abstract invariant proofs,
    or they can be instantiated to more precise behaviour, such as in

--- a/spec/capDL/README.md
+++ b/spec/capDL/README.md
@@ -44,8 +44,7 @@ tables is uniformly modelled as capabilities.
 Building
 --------
 
-The corresponding Isabelle session is `DSpec`. To build, run in directory
-`l4v/spec`:
+The corresponding Isabelle session is `DSpec`. To build for the ARM
+architecture, run in directory `l4v/`:
 
-    make DSpec
-
+    L4V_ARCH=ARM ./run_tests DSpec

--- a/spec/cspec/README.md
+++ b/spec/cspec/README.md
@@ -34,10 +34,10 @@ Building
 The corresponding Isabelle sessions for this module are `CKernel` and `CSpec`.
 `CSpec` contains `CKernel` plus automated bitfield proofs.
 
-To build the image, run the corresponding session in directory `l4v/spec`,
-e.g.:
+To build the image for the ARM architecture, run the corresponding session in
+directory `l4v/`, e.g.:
 
-    make CSpec
+    L4V_ARCH=ARM ./run_tests CSpec
 
 This will also configure and preprocess the kernel sources.
 

--- a/spec/design/README.md
+++ b/spec/design/README.md
@@ -33,18 +33,19 @@ this level of abstraction.
 Building
 --------
 
-The corresponding Isabelle session is `ExecSpec`. Build in `l4v/spec/` with
+The corresponding Isabelle session is `ExecSpec`. Build in `l4v` for the ARM
+architecture with
 
-    make ExecSpec
+    L4V_ARCH=ARM ./run_tests ExecSpec
 
 
 Remarks
 -------
 
  * for regenerating the design spec from Haskell sources, go to directory
-   `l4v/tools/haskell-translator` and run
+   `l4v/` and run
 
-          ./make_spec.sh
+        ./run_test haskell-translator
 
  * skeleton files that define which parts of which Haskell files get mapped
    to which Isabelle theories are found in the sub directories `skel` and

--- a/spec/sep-abstract/README.md
+++ b/spec/sep-abstract/README.md
@@ -19,9 +19,9 @@ appropriately can be found in the `proof` directory under
 Building
 --------
 
-To build from the `l4v/` directory, run:
+To build from the `l4v/` directory for the ARM architecture, run:
 
-    ./isabelle/bin/isabelle build -d . -v -b ASepSpec
+    L4V_ARCH=ARM ./run_tests ASepSpec
 
 Important Theories
 ------------------

--- a/spec/take-grant/README.md
+++ b/spec/take-grant/README.md
@@ -29,9 +29,10 @@ Overview
 Building
 --------
 
-The corresponding Isabelle session is `TakeGrant`. To build, run in directory `l4v/spec`:
+The corresponding Isabelle session is `TakeGrant`. To build for the ARM
+architecture, run in directory `l4v/`:
 
-    make TakeGrant
+    L4V_ARCH=ARM ./run_tests TakeGrant
 
 
 Remarks

--- a/sys-init/README.md
+++ b/sys-init/README.md
@@ -22,13 +22,13 @@ The system initialiser and the proof are described in the
 Building
 --------
 
-To build from the `l4v/` directory, run:
+To build from the `l4v/` directory for the ARM architecture, run:
 
-    make SysInit
+    L4V_ARCH=ARM ./run_tests SysInit
 
 To build the example capDL specifications, from the `l4v/` directory, run:
 
-    make SysInitExamples
+    L4V_ARCH=ARM ./run_tests SysInitExamples
 
 
 Important Theories

--- a/tools/autocorres/README.md
+++ b/tools/autocorres/README.md
@@ -35,7 +35,7 @@ Contents of this README
 Installation
 ------------
 
-AutoCorres is packaged as a theory for Isabelle2021:
+AutoCorres is packaged as a theory for Isabelle2022:
 
     https://isabelle.in.tum.de
 

--- a/tools/c-parser/Simpl/README.md
+++ b/tools/c-parser/Simpl/README.md
@@ -10,4 +10,4 @@ Simpl
 This directory contains Norbert Schirmer's Simpl language and associated VCG
 tool. The code is covered by an LGPL licence.
 
-See http://afp.sourceforge.net/entries/Simpl.shtml
+See <http://afp.sourceforge.net/entries/Simpl.shtml>


### PR DESCRIPTION
Avoid mixing `isabelle`, `make`, and `run_tests` invocations. Standardise on `run_tests` and mention `L4V_ARCH` each time to indicate that you can and should set `L4V_ARCH`.