### PR TITLE
aarch64 ainvs: remove unused physBase lemmas

### DIFF
--- a/proof/invariant-abstract/AARCH64/ArchInvariants_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchInvariants_AI.thy
@@ -1494,10 +1494,6 @@ lemma canonical_user_ge0[intro!,simp]:
   "0 < canonical_user"
   by (simp add: canonical_user_def mask_def ipa_size_def)
 
-lemma pptr_base_kernel_elf_base:
-  "pptr_base < kernel_elf_base"
-  by (simp add: pptr_base_def kernel_elf_base_def pptrBase_kernelELFBase)
-
 lemma pptrTop_le_ipa_size:
   "pptrTop \<le> mask ipa_size"
   by (simp add: bit_simps pptrTop_def mask_def)

--- a/spec/machine/AARCH64/Arch_Kernel_Config_Lemmas.thy
+++ b/spec/machine/AARCH64/Arch_Kernel_Config_Lemmas.thy
@@ -14,10 +14,7 @@ begin
 
 context Arch begin global_naming AARCH64
 
-lemma pptrBase_kernelELFBase:
-  "pptrBase < kernelELFBase"
-  by (simp add: pptrBase_def canonical_bit_def kernelELFBase_def kernelELFPAddrBase_def pptrTop_def
-                Kernel_Config.physBase_def mask_def)
+(* Currently no restrictions required *)
 
 end
 end


### PR DESCRIPTION
The condition `pptrBase < kernelELFBase` is not required on AArch64 in hyp mode and was left over from the initial RISC-V setup.

Since this check does fail for some platforms (where physBase = 0 and consequently pptrBase = kernelELFBase) we remove it here.

(Failing platforms discovered in seL4/seL4#1001)