### PR TITLE
haskell: constrain run_tests to current L4V_ARCH

### DIFF
--- a/spec/haskell/Makefile
+++ b/spec/haskell/Makefile
@@ -31,6 +31,13 @@ GHC_DEV_OPTS=--ghc-options=""
 
 all: build-aarch64 build-riscv build-arm build-arm-hyp-nosmmu build-x64
 
+# build targets by L4V_ARCH:
+ARM: build-arm
+ARM_HYP: build-arm-hyp-nosmmu
+X64: build-x64
+RISCV64: build-riscv
+AARCH64: build-aarch64
+
 sandbox: .stack-work
 
 build-arm: sandbox $(BOOT_FILES)

--- a/spec/tests.xml
+++ b/spec/tests.xml
@@ -39,7 +39,7 @@
 
     <set>
         <!-- Build Haskell kernel code. -->
-        <test name="HaskellKernel" cwd="haskell" cpu-timeout="3600">make</test>
+        <test name="HaskellKernel" cwd="haskell" cpu-timeout="3600">make $L4V_ARCH</test>
     </set>
 
 </testsuite>


### PR DESCRIPTION
Provide L4V_ARCH targets in the Haskell Makefile and constrain run_tests to use only the current L4V_ARCH, to avoid building all architectures in all tests.

A manual invocation of just `make` will still build all architectures for easier checking.