### PR TITLE
cspec: introduce L4V_PLAT

### DIFF
--- a/spec/cspec/c/Makefile
+++ b/spec/cspec/c/Makefile
@@ -29,7 +29,7 @@ CONFIG_THY := ../../machine/${L4V_ARCH}/Kernel_Config.thy
 # called by ../../Makefile
 config: ${CONFIG_THY}
 
-${CONFIG_THY}: ${KERNEL_CONFIG_ROOT}/.cmake_done
+${CONFIG_THY}: ${CONFIG_DONE}
 	./gen-config-thy.py
 
 


### PR DESCRIPTION
L4V_PLAT selects a platform variation within a L4V_ARCH. This mostly affects which seL4 cmake config file is loaded when building config data and the kernel C code. This in turn affects (and will rebuild) ASpec, ExecSpec, and CSpec.

Examples:

    L4V_ARCH=ARM L4V_FEATURES="" L4V_PLAT=""

will load `ARM_verified.cmake`

    L4V_ARCH=ARM L4V_FEATURES="" L4V_PLAT=imx8mm

will load `ARM_imx8mm_verified.cmake`, and

    L4V_ARCH=ARM L4V_FEATURES=MCS L4V_PLAT=imx8mm

will load `ARM_MCS_imx8mm_verified.cmake`.

When `L4V_PLAT` is empty, everything should work as it has so far.

See also https://github.com/seL4/ci-actions/pull/275 and #638 