### PR TITLE
github: auto-rebase platform branches

### DIFF
--- a/.github/workflows/proof-deploy.yml
+++ b/.github/workflows/proof-deploy.yml
@@ -76,3 +76,29 @@ jobs:
       with:
         token: ${{ secrets.PRIV_REPO_TOKEN }}
         tag: "l4v/proof-deploy/${{ github.event_name }}"
+
+  rebase:
+    name: Rebase platform branches
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: [imx8-fpu-ver, exynos5-ver]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ matrix.branch }}
+        path: l4v-${{ matrix.branch }}
+        fetch-depth: 0
+    - name: Rebase
+      run: |
+        cd l4v-${{ matrix.branch }}
+        git config --global user.name "seL4 CI"
+        git config --global user.email "ci@sel4.systems"
+        git rebase origin/master
+        git status
+    - name: Push
+      run: |
+        cd l4v-${{ matrix.branch }}
+        git push -f origin HEAD:${{ matrix.branch }}

--- a/.github/workflows/proof-deploy.yml
+++ b/.github/workflows/proof-deploy.yml
@@ -101,4 +101,4 @@ jobs:
     - name: Push
       run: |
         cd l4v-${{ matrix.branch }}
-        git push -f origin HEAD:${{ matrix.branch }}
+        git push -f origin HEAD:${{ matrix.branch }}-rebased

--- a/.github/workflows/proof.yml
+++ b/.github/workflows/proof.yml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: BSD-2-Clause
 
-name: Proofs
+name: Proof PR
 
 on:
   push:


### PR DESCRIPTION
The action will abort when no clean rebase is possible, and force-push the rebased branch when the rebase over origin/master was clean.

The push will trigger proof runs on the rebased branches.

This required L4V_PLAT etc to be merged first, i.e. everything related to #639  