### PR TITLE
lib: split out WP_Pre.pre_tac for wp_pre

### DIFF
--- a/lib/Corres_Method.thy
+++ b/lib/Corres_Method.thy
@@ -169,7 +169,7 @@ method corresK_pre =
       ((succeeds \<open>rule corresK_my_falseF\<close>, rule corresK_weaken_states) |
        rule corresK_weaken)))
 
-method corres_pre = (corres_raw_pre | corresK_pre)?
+method corres_pre' = (corres_raw_pre | corresK_pre)?
 
 lemma corresK_weakenK:
   "corres_underlyingK sr nf nf' F' r P P' f f' \<Longrightarrow> (F \<Longrightarrow> F') \<Longrightarrow> corres_underlyingK sr nf nf' F r P P' f f'"
@@ -662,7 +662,7 @@ method corres_once declares corres_splits corres corresK corresc_simp =
   (no_schematic_concl,
    (corres_alternate |
      (corres_fold_dc?,
-     (corres_pre,
+     (corres_pre',
       #break "corres",
       ( (check_corresK, determ \<open>rule corresK\<close>)
       | corres_apply
@@ -679,7 +679,7 @@ text \<open>Unconditionally try applying split rules. Useful for determining why
  in a given proof.\<close>
 
 method corres_unsafe_split declares corres_splits corres corresK corresc_simp =
-  ((rule corres_splits | corres_pre | corres_once)+)[1]
+  ((rule corres_splits | corres_pre' | corres_once)+)[1]
 
 end
 
@@ -873,7 +873,7 @@ text \<open>
 
 method corres_search uses search
   declares corres corres_symb_exec_ls corres_symb_exec_rs =
-  (corres_pre,
+  (corres_pre',
    use search[corres del] search[corresK del] search[corres_splits del] in
      \<open>use in \<open>corres_search_frame \<open>corres_search search: search\<close> search: search\<close>\<close>)[1]
 

--- a/lib/MonadicRewrite.thy
+++ b/lib/MonadicRewrite.thy
@@ -40,7 +40,7 @@ lemma monadic_rewrite_impossible:
   "monadic_rewrite F E \<bottom> f g"
   by (clarsimp simp: monadic_rewrite_def)
 
-lemma monadic_rewrite_guard_imp[wp_pre]:
+lemma monadic_rewrite_guard_imp:
   "\<lbrakk> monadic_rewrite F E Q f g; \<And>s. P s \<Longrightarrow> Q s \<rbrakk> \<Longrightarrow> monadic_rewrite F E P f g"
   by (auto simp add: monadic_rewrite_def)
 
@@ -720,6 +720,10 @@ wpc_setup "\<lambda>m. monadic_rewrite F E Q' (m >>=E c) m'" wpc_helper_monadic_
 
 text \<open>Tactics\<close>
 
+named_theorems monadic_rewrite_pre
+declare monadic_rewrite_guard_imp[monadic_rewrite_pre]
+method monadic_rewrite_pre = (WP_Pre.pre_tac monadic_rewrite_pre)?
+
 method monadic_rewrite_step =
   determ \<open>rule monadic_rewrite_bind_tail monadic_rewrite_bindE_tail\<close>
 
@@ -757,14 +761,14 @@ method monadic_rewrite_single_pass methods start step action finalise =
 
 (* Step over LHS until action applies, then finalise. *)
 method monadic_rewrite_l_method methods action finalise =
-  monadic_rewrite_single_pass \<open>wp_pre, rule monadic_rewrite_trans\<close>
+  monadic_rewrite_single_pass \<open>monadic_rewrite_pre, rule monadic_rewrite_trans\<close>
                               monadic_rewrite_step
                               action
                               finalise
 
 (* Step over RHS until action applies, then finalise. *)
 method monadic_rewrite_r_method methods action finalise =
-  monadic_rewrite_single_pass \<open>wp_pre, rule monadic_rewrite_trans[rotated]\<close>
+  monadic_rewrite_single_pass \<open>monadic_rewrite_pre, rule monadic_rewrite_trans[rotated]\<close>
                               monadic_rewrite_step
                               action
                               finalise
@@ -784,7 +788,7 @@ method monadic_rewrite_symb_exec_resolutions methods m =
    conditions should be solvable by wpsimp, but the _m versions allow specifying a method or
    wpsimp options. *)
 method monadic_rewrite_symb_exec methods r m =
-  (wp_pre, no_name_eta, r; (monadic_rewrite_symb_exec_resolutions m)?)
+  (monadic_rewrite_pre, no_name_eta, r; (monadic_rewrite_symb_exec_resolutions m)?)
 
 ML \<open>
 structure Monadic_Rewrite = struct

--- a/lib/Monads/wp/WP-method.ML
+++ b/lib/Monads/wp/WP-method.ML
@@ -287,7 +287,9 @@ let
   val trace' = trace orelse Config.get ctxt WP_Pre.wp_trace
   val used_thms_ref = Unsynchronized.ref [] : (string * string * term) list Unsynchronized.ref
   val rules = get_rules ctxt extras
-  val wp_pre_tac = TRY (WP_Pre.tac trace' used_thms_ref ctxt 1)
+  val wp_pre_tac = TRY (WP_Pre.pre_tac trace' ctxt
+                                       (Named_Theorems.get ctxt \<^named_theorems>\<open>wp_pre\<close>)
+                                       used_thms_ref 1)
   val wp_fix_tac = TRY (WPFix.both_tac ctxt 1)
   val cleanup_tac = TRY (REPEAT
                       (resolve_tac ctxt [@{thm TrueI}, @{thm conj_TrueI}, @{thm conj_TrueI2}] 1

--- a/proof/crefine/ARM/Ctac_lemmas_C.thy
+++ b/proof/crefine/ARM/Ctac_lemmas_C.thy
@@ -23,7 +23,7 @@ lemma c_guard_abs_cte:
   apply (simp add: typ_heap_simps')
   done
 
-lemmas ccorres_move_c_guard_cte [corres_pre] = ccorres_move_c_guards  [OF c_guard_abs_cte]
+lemmas ccorres_move_c_guard_cte [ccorres_pre] = ccorres_move_c_guards  [OF c_guard_abs_cte]
 
 lemma c_guard_abs_tcb:
   fixes p :: "tcb_C ptr"
@@ -33,7 +33,7 @@ lemma c_guard_abs_tcb:
   apply simp
   done
 
-lemmas ccorres_move_c_guard_tcb [corres_pre] = ccorres_move_c_guards [OF c_guard_abs_tcb]
+lemmas ccorres_move_c_guard_tcb [ccorres_pre] = ccorres_move_c_guards [OF c_guard_abs_tcb]
 
 lemma cte_array_relation_array_assertion:
   "gsCNodes s p = Some n \<Longrightarrow> cte_array_relation s cstate
@@ -96,7 +96,7 @@ lemma array_assertion_abs_tcb_ctes_add':
 lemmas array_assertion_abs_tcb_ctes_add
   = array_assertion_abs_tcb_ctes_add'[simplified objBits_defs mask_def, simplified]
 
-lemmas ccorres_move_array_assertion_tcb_ctes [corres_pre]
+lemmas ccorres_move_array_assertion_tcb_ctes [ccorres_pre]
     = ccorres_move_array_assertions [OF array_assertion_abs_tcb_ctes(1)]
       ccorres_move_array_assertions [OF array_assertion_abs_tcb_ctes(2)]
       ccorres_move_Guard_Seq[OF array_assertion_abs_tcb_ctes_add]
@@ -119,7 +119,7 @@ lemma c_guard_abs_tcb_ctes':
   done
 
 lemmas c_guard_abs_tcb_ctes = c_guard_abs_tcb_ctes'[simplified objBits_defs mask_def, simplified]
-lemmas ccorres_move_c_guard_tcb_ctes [corres_pre] = ccorres_move_c_guards [OF c_guard_abs_tcb_ctes]
+lemmas ccorres_move_c_guard_tcb_ctes [ccorres_pre] = ccorres_move_c_guards [OF c_guard_abs_tcb_ctes]
 
 lemma c_guard_abs_pte:
   "\<forall>s s'. (s, s') \<in> rf_sr \<and> pte_at' (ptr_val p) s \<and> True

--- a/proof/crefine/ARM/Fastpath_C.thy
+++ b/proof/crefine/ARM/Fastpath_C.thy
@@ -2503,7 +2503,7 @@ lemmas array_assertion_abs_tcb_ctes_add
     = array_assertion_abs_tcb_ctes_add[where
           tcb="\<lambda>s. Ptr (tcb' s)" for tcb', simplified]
 
-lemmas ccorres_move_array_assertion_tcb_ctes [corres_pre]
+lemmas ccorres_move_array_assertion_tcb_ctes [ccorres_pre]
     = ccorres_move_array_assertions [OF array_assertion_abs_tcb_ctes(1)[where
           tcb="\<lambda>s. Ptr (tcb' s)" for tcb', simplified]]
       ccorres_move_array_assertions [OF array_assertion_abs_tcb_ctes(2)]

--- a/proof/crefine/ARM/IpcCancel_C.thy
+++ b/proof/crefine/ARM/IpcCancel_C.thy
@@ -2505,7 +2505,7 @@ lemma cmap_relation_ep:
   by (simp add: Let_def)
 
 (* FIXME: MOVE *)
-lemma ccorres_pre_getEndpoint [corres_pre]:
+lemma ccorres_pre_getEndpoint [ccorres_pre]:
   assumes cc: "\<And>rv. ccorres r xf (P rv) (P' rv) hs (f rv) c"
   shows   "ccorres r xf
            (ep_at' p and (\<lambda>s. \<forall>ep. ko_at' ep p s \<longrightarrow> P ep s))

--- a/proof/crefine/ARM/Syscall_C.thy
+++ b/proof/crefine/ARM/Syscall_C.thy
@@ -1554,7 +1554,7 @@ lemma handleInterrupt_ccorres:
      apply (rule getIRQSlot_ccorres3)
      apply (rule ccorres_getSlotCap_cte_at)
      apply (rule_tac P="cte_at' rv" in ccorres_cross_over_guard)
-     supply ccorres_move_array_assertion_tcb_ctes [corres_pre del]
+     supply ccorres_move_array_assertion_tcb_ctes [ccorres_pre del]
      apply ctac
        apply csymbr
        apply csymbr

--- a/proof/crefine/ARM_HYP/Ctac_lemmas_C.thy
+++ b/proof/crefine/ARM_HYP/Ctac_lemmas_C.thy
@@ -23,7 +23,7 @@ lemma c_guard_abs_cte:
   apply (simp add: typ_heap_simps')
   done
 
-lemmas ccorres_move_c_guard_cte [corres_pre] = ccorres_move_c_guards  [OF c_guard_abs_cte]
+lemmas ccorres_move_c_guard_cte [ccorres_pre] = ccorres_move_c_guards  [OF c_guard_abs_cte]
 
 lemma c_guard_abs_tcb:
   fixes p :: "tcb_C ptr"
@@ -33,7 +33,7 @@ lemma c_guard_abs_tcb:
   apply simp
   done
 
-lemmas ccorres_move_c_guard_tcb [corres_pre] = ccorres_move_c_guards [OF c_guard_abs_tcb]
+lemmas ccorres_move_c_guard_tcb [ccorres_pre] = ccorres_move_c_guards [OF c_guard_abs_tcb]
 
 lemma cte_array_relation_array_assertion:
   "gsCNodes s p = Some n \<Longrightarrow> cte_array_relation s cstate
@@ -96,7 +96,7 @@ lemma array_assertion_abs_tcb_ctes_add':
 lemmas array_assertion_abs_tcb_ctes_add
   = array_assertion_abs_tcb_ctes_add'[simplified objBits_defs mask_def, simplified]
 
-lemmas ccorres_move_array_assertion_tcb_ctes [corres_pre]
+lemmas ccorres_move_array_assertion_tcb_ctes [ccorres_pre]
     = ccorres_move_array_assertions [OF array_assertion_abs_tcb_ctes(1)]
       ccorres_move_array_assertions [OF array_assertion_abs_tcb_ctes(2)]
       ccorres_move_Guard_Seq[OF array_assertion_abs_tcb_ctes_add]
@@ -119,7 +119,7 @@ lemma c_guard_abs_tcb_ctes':
   done
 
 lemmas c_guard_abs_tcb_ctes = c_guard_abs_tcb_ctes'[simplified objBits_defs mask_def, simplified]
-lemmas ccorres_move_c_guard_tcb_ctes [corres_pre] = ccorres_move_c_guards [OF c_guard_abs_tcb_ctes]
+lemmas ccorres_move_c_guard_tcb_ctes [ccorres_pre] = ccorres_move_c_guards [OF c_guard_abs_tcb_ctes]
 
 lemma c_guard_abs_pte:
   "\<forall>s s'. (s, s') \<in> rf_sr \<and> pte_at' (ptr_val p) s \<and> True

--- a/proof/crefine/ARM_HYP/Fastpath_C.thy
+++ b/proof/crefine/ARM_HYP/Fastpath_C.thy
@@ -2545,7 +2545,7 @@ lemmas array_assertion_abs_tcb_ctes_add
     = array_assertion_abs_tcb_ctes_add[where
           tcb="\<lambda>s. Ptr (tcb' s)" for tcb', simplified]
 
-lemmas ccorres_move_array_assertion_tcb_ctes [corres_pre]
+lemmas ccorres_move_array_assertion_tcb_ctes [ccorres_pre]
     = ccorres_move_array_assertions [OF array_assertion_abs_tcb_ctes(1)[where
           tcb="\<lambda>s. Ptr (tcb' s)" for tcb', simplified]]
       ccorres_move_array_assertions [OF array_assertion_abs_tcb_ctes(2)]

--- a/proof/crefine/ARM_HYP/IpcCancel_C.thy
+++ b/proof/crefine/ARM_HYP/IpcCancel_C.thy
@@ -2685,7 +2685,7 @@ lemma cmap_relation_ep:
   by (simp add: Let_def)
 
 (* FIXME: MOVE *)
-lemma ccorres_pre_getEndpoint [corres_pre]:
+lemma ccorres_pre_getEndpoint [ccorres_pre]:
   assumes cc: "\<And>rv. ccorres r xf (P rv) (P' rv) hs (f rv) c"
   shows   "ccorres r xf
            (ep_at' p and (\<lambda>s. \<forall>ep. ko_at' ep p s \<longrightarrow> P ep s))

--- a/proof/crefine/ARM_HYP/Retype_C.thy
+++ b/proof/crefine/ARM_HYP/Retype_C.thy
@@ -5312,7 +5312,7 @@ lemma monadic_rewrite_setObject_vcpu_as_init:
   supply fun_upd_apply[simp del]
   apply simp
   apply (rule monadic_rewrite_gen_asm)
-  apply wp_pre
+  apply monadic_rewrite_pre
    apply (simp add: vcpuWriteReg_def vgicUpdate_def bind_assoc)
     apply (clarsimp simp: vcpuUpdate_def bind_assoc)
     (* explicitly state the vcpu we are setting for each setObject *)

--- a/proof/crefine/ARM_HYP/Syscall_C.thy
+++ b/proof/crefine/ARM_HYP/Syscall_C.thy
@@ -2298,7 +2298,7 @@ lemma handleInterrupt_ccorres:
      apply (rule getIRQSlot_ccorres3)
      apply (rule ccorres_getSlotCap_cte_at)
      apply (rule_tac P="cte_at' rv" in ccorres_cross_over_guard)
-     supply ccorres_move_array_assertion_tcb_ctes [corres_pre del]
+     supply ccorres_move_array_assertion_tcb_ctes [ccorres_pre del]
      apply ctac
        apply csymbr
        apply csymbr

--- a/proof/crefine/RISCV64/CSpaceAcc_C.thy
+++ b/proof/crefine/RISCV64/CSpaceAcc_C.thy
@@ -270,7 +270,7 @@ lemma array_assertion_abs_cnode_ctes:
   apply (metis array_assertion_shrink_right)
   done
 
-lemmas ccorres_move_array_assertion_cnode_ctes [corres_pre]
+lemmas ccorres_move_array_assertion_cnode_ctes [ccorres_pre]
     = ccorres_move_Guard_Seq [OF array_assertion_abs_cnode_ctes]
       ccorres_move_Guard [OF array_assertion_abs_cnode_ctes]
 

--- a/proof/crefine/RISCV64/Ctac_lemmas_C.thy
+++ b/proof/crefine/RISCV64/Ctac_lemmas_C.thy
@@ -23,7 +23,7 @@ lemma c_guard_abs_cte:
   apply (simp add: typ_heap_simps')
   done
 
-lemmas ccorres_move_c_guard_cte [corres_pre] = ccorres_move_c_guards  [OF c_guard_abs_cte]
+lemmas ccorres_move_c_guard_cte [ccorres_pre] = ccorres_move_c_guards  [OF c_guard_abs_cte]
 
 lemma c_guard_abs_tcb:
   fixes p :: "tcb_C ptr"
@@ -33,7 +33,7 @@ lemma c_guard_abs_tcb:
   apply simp
   done
 
-lemmas ccorres_move_c_guard_tcb [corres_pre] = ccorres_move_c_guards [OF c_guard_abs_tcb]
+lemmas ccorres_move_c_guard_tcb [ccorres_pre] = ccorres_move_c_guards [OF c_guard_abs_tcb]
 
 lemma cte_array_relation_array_assertion:
   "gsCNodes s p = Some n \<Longrightarrow> cte_array_relation s cstate
@@ -96,7 +96,7 @@ lemma array_assertion_abs_tcb_ctes_add':
 lemmas array_assertion_abs_tcb_ctes_add
   = array_assertion_abs_tcb_ctes_add'[simplified objBits_defs mask_def, simplified]
 
-lemmas ccorres_move_array_assertion_tcb_ctes [corres_pre]
+lemmas ccorres_move_array_assertion_tcb_ctes [ccorres_pre]
     = ccorres_move_array_assertions [OF array_assertion_abs_tcb_ctes(1)]
       ccorres_move_array_assertions [OF array_assertion_abs_tcb_ctes(2)]
       ccorres_move_Guard_Seq[OF array_assertion_abs_tcb_ctes_add]
@@ -119,7 +119,7 @@ lemma c_guard_abs_tcb_ctes':
   done
 
 lemmas c_guard_abs_tcb_ctes = c_guard_abs_tcb_ctes'[simplified objBits_defs mask_def, simplified]
-lemmas ccorres_move_c_guard_tcb_ctes [corres_pre] = ccorres_move_c_guards  [OF c_guard_abs_tcb_ctes]
+lemmas ccorres_move_c_guard_tcb_ctes [ccorres_pre] = ccorres_move_c_guards  [OF c_guard_abs_tcb_ctes]
 
 lemma c_guard_abs_pte:
   "\<forall>s s'. (s, s') \<in> rf_sr \<and> pte_at' (ptr_val p) s \<and> True

--- a/proof/crefine/RISCV64/IpcCancel_C.thy
+++ b/proof/crefine/RISCV64/IpcCancel_C.thy
@@ -2636,7 +2636,7 @@ lemma cancelSignal_ccorres [corres]:
          | drule_tac x=thread in bspec)+
 
 (* FIXME: MOVE *)
-lemma ccorres_pre_getEndpoint [corres_pre]:
+lemma ccorres_pre_getEndpoint [ccorres_pre]:
   assumes cc: "\<And>rv. ccorres r xf (P rv) (P' rv) hs (f rv) c"
   shows   "ccorres r xf
            (ep_at' p and (\<lambda>s. \<forall>ep. ko_at' ep p s \<longrightarrow> P ep s))

--- a/proof/crefine/X64/CSpaceAcc_C.thy
+++ b/proof/crefine/X64/CSpaceAcc_C.thy
@@ -274,7 +274,7 @@ lemma array_assertion_abs_cnode_ctes:
   apply (metis array_assertion_shrink_right)
   done
 
-lemmas ccorres_move_array_assertion_cnode_ctes [corres_pre]
+lemmas ccorres_move_array_assertion_cnode_ctes [ccorres_pre]
     = ccorres_move_Guard_Seq [OF array_assertion_abs_cnode_ctes]
       ccorres_move_Guard [OF array_assertion_abs_cnode_ctes]
 

--- a/proof/crefine/X64/Ctac_lemmas_C.thy
+++ b/proof/crefine/X64/Ctac_lemmas_C.thy
@@ -23,7 +23,7 @@ lemma c_guard_abs_cte:
   apply (simp add: typ_heap_simps')
   done
 
-lemmas ccorres_move_c_guard_cte [corres_pre] = ccorres_move_c_guards  [OF c_guard_abs_cte]
+lemmas ccorres_move_c_guard_cte [ccorres_pre] = ccorres_move_c_guards  [OF c_guard_abs_cte]
 
 lemma c_guard_abs_tcb:
   fixes p :: "tcb_C ptr"
@@ -33,7 +33,7 @@ lemma c_guard_abs_tcb:
   apply simp
   done
 
-lemmas ccorres_move_c_guard_tcb [corres_pre] = ccorres_move_c_guards [OF c_guard_abs_tcb]
+lemmas ccorres_move_c_guard_tcb [ccorres_pre] = ccorres_move_c_guards [OF c_guard_abs_tcb]
 
 lemma cte_array_relation_array_assertion:
   "gsCNodes s p = Some n \<Longrightarrow> cte_array_relation s cstate
@@ -96,7 +96,7 @@ lemma array_assertion_abs_tcb_ctes_add':
 lemmas array_assertion_abs_tcb_ctes_add
   = array_assertion_abs_tcb_ctes_add'[simplified objBits_defs mask_def, simplified]
 
-lemmas ccorres_move_array_assertion_tcb_ctes [corres_pre]
+lemmas ccorres_move_array_assertion_tcb_ctes [ccorres_pre]
     = ccorres_move_array_assertions [OF array_assertion_abs_tcb_ctes(1)]
       ccorres_move_array_assertions [OF array_assertion_abs_tcb_ctes(2)]
       ccorres_move_Guard_Seq[OF array_assertion_abs_tcb_ctes_add]
@@ -119,7 +119,7 @@ lemma c_guard_abs_tcb_ctes':
   done
 
 lemmas c_guard_abs_tcb_ctes = c_guard_abs_tcb_ctes'[simplified objBits_defs mask_def, simplified]
-lemmas ccorres_move_c_guard_tcb_ctes [corres_pre] = ccorres_move_c_guards  [OF c_guard_abs_tcb_ctes]
+lemmas ccorres_move_c_guard_tcb_ctes [ccorres_pre] = ccorres_move_c_guards  [OF c_guard_abs_tcb_ctes]
 
 lemma c_guard_abs_pte:
   "\<forall>s s'. (s, s') \<in> rf_sr \<and> pte_at' (ptr_val p) s \<and> True

--- a/proof/crefine/X64/IpcCancel_C.thy
+++ b/proof/crefine/X64/IpcCancel_C.thy
@@ -2690,7 +2690,7 @@ lemma cancelSignal_ccorres [corres]:
          | drule_tac x=thread in bspec)+
 
 (* FIXME: MOVE *)
-lemma ccorres_pre_getEndpoint [corres_pre]:
+lemma ccorres_pre_getEndpoint [ccorres_pre]:
   assumes cc: "\<And>rv. ccorres r xf (P rv) (P' rv) hs (f rv) c"
   shows   "ccorres r xf
            (ep_at' p and (\<lambda>s. \<forall>ep. ko_at' ep p s \<longrightarrow> P ep s))

--- a/proof/crefine/lib/Ctac.thy
+++ b/proof/crefine/lib/Ctac.thy
@@ -1876,8 +1876,8 @@ begin
 
 (* Set up ctac proof sets.  These are tried in reverse order (further down is tried first) *)
 
-declare ccorres_Guard [corres_pre]
-declare ccorres_Guard_Seq [corres_pre]
+declare ccorres_Guard [ccorres_pre]
+declare ccorres_Guard_Seq [ccorres_pre]
 
 lemma c_guard_field_abs:
   fixes p :: "'a :: mem_type ptr"

--- a/proof/crefine/lib/ctac-method.ML
+++ b/proof/crefine/lib/ctac-method.ML
@@ -123,7 +123,7 @@ fun ceqv_simpl_seq ctxt = Config.get ctxt (fst ceqv_simpl_sequence_pair)
 val setup =
   Attrib.setup @{binding "corres"} (Attrib.add_del ctac_add ctac_del)
     "correspondence rules"
-  #> Attrib.setup @{binding "corres_pre"}
+  #> Attrib.setup @{binding "ccorres_pre"}
     (Attrib.add_del ctac_pre_add ctac_pre_del)
     "correspondence preprocessing rules"
   #> Attrib.setup @{binding "corres_post"}

--- a/proof/refine/AARCH64/ArchAcc_R.thy
+++ b/proof/refine/AARCH64/ArchAcc_R.thy
@@ -988,9 +988,6 @@ lemma gets_oapply_liftM_rewrite:
   by (simp add: liftM_def simpler_gets_def bind_def gets_map_def assert_opt_def return_def
            split: option.splits)
 
-(* FIXME AARCH64: move *)
-declare corres_guard_imp[wp_pre]
-
 lemma gets_return_gets_eq:
   "gets f >>= (\<lambda>g. return (h g)) = gets (\<lambda>s. h (f s))"
   by (simp add: simpler_gets_def bind_def return_def)
@@ -999,7 +996,7 @@ lemma getPoolPtr_corres:
   "corres (=) (K (0 < asid)) \<top> (gets (pool_for_asid asid)) (getPoolPtr (ucast asid))"
   unfolding pool_for_asid_def getPoolPtr_def asidRange_def
   apply simp
-  apply wp_pre
+  apply corres_pre
     apply (rule corres_assert_gen_asm)
     apply (rule corres_assert_gen_asm)
     apply (rule corres_trivial)


### PR DESCRIPTION
Factor out pre_tac such that we can have separate theorem sets and methods for wp_pre, monadic_rewrite_pre, corres_pre, and potentially others in the future.

Leave everything in wp_pre that we expect to use wp or wp_simp on, in particular also no_fail.

Implements a tiny part of #634 