### PR TITLE
haskell: upgrade to lts-20.25 and ghc 9.2.8

### DIFF
--- a/spec/haskell/SEL4.cabal
+++ b/spec/haskell/SEL4.cabal
@@ -12,13 +12,13 @@ build-type:             Custom
 license:                GPL-2.0-only
 author:                 Philip Derrin et. al., NICTA
 synopsis:               Executable specification for the seL4 Kernel
-tested-with:            GHC == 9.0.2
+tested-with:            GHC == 9.2.8
 homepage:               http://sel4.systems/
 
 custom-setup
   setup-depends:
-    base  == 4.15.*,
-    Cabal == 3.4.1.0
+    base  == 4.16.*,
+    Cabal == 3.6.3.*
 
 Flag FFI
     description:        Include the C language bindings
@@ -47,7 +47,7 @@ Flag ArchAArch64
 Library
     exposed-modules:        SEL4
                             SEL4.Machine.Target
-    build-depends:          mtl==2.2.*, base==4.15.*, array, containers, transformers
+    build-depends:          mtl==2.2.*, base==4.16.*, array, containers, transformers
 
     if flag(FFI)
     -- FFIBindings currently relies on POSIX signal handlers.  This could
@@ -229,6 +229,8 @@ Library
                             -fno-warn-unrecognised-pragmas
                             -fno-warn-unused-binds
                             -fno-warn-unused-imports -fno-warn-unused-matches
+                            -fno-warn-incomplete-record-updates
+                            -fno-warn-incomplete-uni-patterns
 
     cpp-options:
                             -- set via Setup.hs hook

--- a/spec/haskell/stack.yaml
+++ b/spec/haskell/stack.yaml
@@ -7,8 +7,8 @@
 # We use `stack` only to install GHC and cabal-install, not to build the project.
 # The rest of the build works via cabal
 
-# Stackage LTS Haskell 19.12 (ghc-9.0.2)
-resolver: lts-19.12
+# Stackage LTS Haskell 20.25 (ghc-9.2.8)
+resolver: lts-20.25
 
 packages: []
 extra-deps: []


### PR DESCRIPTION
GHC 9.2.8 has better support for Linux/aarch64/v8 for use in Docker.

Like seL4/capdl#50, this is in preparation for upgrading ghc in docker, so we can add multi-architecture (x64/aarch64) docker images. 