### PR TITLE
Cong rules for ccorres_underlying

### DIFF
--- a/lib/clib/CCorresLemmas.thy
+++ b/lib/clib/CCorresLemmas.thy
@@ -630,6 +630,13 @@ lemma ccorres_liftE:
   by (fastforce split: xstate.splits
                 simp: liftE_def ccorres_underlying_def bind_def' return_def unif_rrel_def)
 
+lemma ccorres_liftE':
+  fixes \<Gamma>
+  assumes cc: "ccorresG sr \<Gamma> (r \<circ> Inr) xf P P' hs a c"
+  shows   "ccorresG sr \<Gamma> r xf P P' hs (liftE a) c"
+  using cc
+  by (auto intro!: ccorres_liftE cong: ccorres_context_cong)
+
 lemma ccorres_if_bind:
   "ccorres_underlying sr Gamm r xf arrel axf G G' hs (if a then (b >>= f) else (c >>= f)) d
   \<Longrightarrow> ccorres_underlying sr Gamm r xf arrel axf G G' hs ((if a then b else c) >>= f) d"
@@ -871,9 +878,9 @@ proof -
   qed
   thus ?thesis using lxs j pn
     apply (auto simp: init_xs_def word_less_nat_alt neq_Nil_conv unat_word_ariths unat_of_nat push_mods
-                simp del: unsigned_of_nat
                 elim!: ccorres_guard_imp2
-                dest!: spec[where x=Nil])
+                dest!: spec[where x=Nil]
+                cong: ccorres_all_cong)
     done
 qed
 
@@ -1150,5 +1157,24 @@ proof -
 qed
 
 lemmas ccorres_While' = ccorres_While[where C'=UNIV, simplified]
+
+
+\<comment> \<open>simp rules for rewriting common patterns in the return relations\<close>
+lemma ccorres_dc_o_simp[simp]:
+  "ccorres_underlying srel \<Gamma> (dc \<circ> f) xf ar axf P Q hs m c
+   = ccorres_underlying srel \<Gamma> dc xf ar axf P Q hs m c"
+  "ccorres_underlying srel \<Gamma> r xf (dc \<circ> f) axf P Q hs m c
+   = ccorres_underlying srel \<Gamma> r xf dc axf P Q hs m c"
+  by (simp cong: ccorres_all_cong)+
+
+lemma ccorres_inl_rrel_inl_rrel[simp]:
+  "ccorres_underlying srel \<Gamma> r xf (inl_rrel (inl_rrel ar)) axf P Q hs m c
+   = ccorres_underlying srel \<Gamma> r xf (inl_rrel ar) axf P Q hs m c"
+  by (simp add: inl_rrel_inl_rrel cong: ccorres_all_cong)+
+
+lemma ccorres_inr_rrel_Inr[simp]:
+  "ccorres_underlying srel \<Gamma> (inr_rrel r \<circ> Inr) xf ar axf P Q hs m c
+   = ccorres_underlying srel \<Gamma> r xf ar axf P Q hs m c"
+  by (simp cong: ccorres_context_cong)+
 
 end

--- a/lib/clib/Corres_UL_C.thy
+++ b/lib/clib/Corres_UL_C.thy
@@ -1719,4 +1719,110 @@ lemma ccorres_grab_asm:
    ccorres_underlying sr G rr xf ar ax (P and K Q) P' hs f g"
   by (fastforce simp: ccorres_underlying_def)
 
+
+\<comment> \<open> An experimental cong rule for rewriting everywhere reasonable, with full context.
+    Can cause problems when there are schematic variables or when one of the return relations
+    takes a pair as a parameter. \<close>
+lemma ccorres_context_cong_helper':
+  assumes c: "ccorres_underlying sr \<Gamma> r xf ar axf P Q hs a c"
+  assumes "\<And>s. P s = P' s"
+  \<comment> \<open>Don't use membership equality when rewriting Q, as the LHS can be simplified into something
+     that is unable to unify with the RHS.
+  assumes "\<And>s s'. \<lbrakk> (s,s') \<in> sr; P' s \<rbrakk> \<Longrightarrow> s' \<in> Q = (s' \<in> Q')"\<close>
+  assumes "\<And>s s'. \<lbrakk> (s, s') \<in> sr; P' s \<rbrakk> \<Longrightarrow> Q = Q'"
+  assumes "hs = hs'"
+  assumes "\<And>s s'. \<lbrakk> (s, s') \<in> sr; P' s; s' \<in> Q' \<rbrakk> \<Longrightarrow> a s = a' s"
+  assumes "\<And>s s' s''. \<lbrakk> (s, s') \<in> sr; P' s; s' \<in> Q' \<rbrakk>  \<Longrightarrow> semantic_equiv \<Gamma> s' s'' c c'"
+  assumes "\<And>s s' t'.
+             \<lbrakk> (s, s') \<in> sr; P' s; s' \<in> Q'; \<Gamma> \<turnstile>\<^sub>h \<langle>c' # hs', s'\<rangle> \<Rightarrow> (size hs', Normal t') \<rbrakk> \<Longrightarrow>
+             xf t' = xf' t'"
+  assumes "\<And>x s t s' t'.
+             \<lbrakk> (s, s') \<in> sr; P' s; s' \<in> Q'; (t, t') \<in> sr; (x, t) \<in> fst (a' s);
+               \<Gamma> \<turnstile>\<^sub>h \<langle>c' # hs', s'\<rangle> \<Rightarrow> (size hs', Normal t') \<rbrakk> \<Longrightarrow>
+             r x (xf' t') = r' x (xf' t')"
+  assumes "\<And>s s' t' n.
+             \<lbrakk> (s, s') \<in> sr; P' s; s' \<in> Q'; n \<noteq> size hs'; \<Gamma> \<turnstile>\<^sub>h \<langle>c' # hs', s'\<rangle> \<Rightarrow> (n, Normal t') \<rbrakk> \<Longrightarrow>
+             axf t' = axf' t'"
+  assumes "\<And>x s t s' t' n.
+             \<lbrakk> (s, s') \<in> sr; P' s; s' \<in> Q'; (t, t') \<in> sr; (x, t) \<in> fst (a' s); n \<noteq> size hs';
+               \<Gamma> \<turnstile>\<^sub>h \<langle>c' # hs', s'\<rangle> \<Rightarrow> (n, Normal t') \<rbrakk> \<Longrightarrow>
+             ar x (axf' t') = ar' x (axf' t')"
+  shows   "ccorres_underlying sr \<Gamma> r' xf' ar' axf' P' Q' hs' a' c'"
+  using c
+  apply -
+  apply (rule ccorresI')
+  apply (erule (1) ccorresE)
+      apply (force simp: assms)
+     apply (force simp: assms)
+    apply (force simp: assms)
+   apply (clarsimp simp: assms)
+   apply (erule exec_handlers_semantic_equivD2)
+   apply (force simp: assms)
+  apply (fastforce simp: unif_rrel_def assms)
+  done
+
+lemma ccorres_context_cong_helper:
+  assumes "\<And>s. P s = P' s"
+  assumes "\<And>s s'. \<lbrakk> (s, s') \<in> sr; P' s \<rbrakk> \<Longrightarrow> Q = Q'"
+  assumes "hs = hs'"
+  assumes "\<And>s s'. \<lbrakk> (s, s') \<in> sr; P' s; s' \<in> Q' \<rbrakk> \<Longrightarrow> a s = a' s"
+  assumes "\<And>s s' s''. \<lbrakk> (s, s') \<in> sr; P' s; s' \<in> Q' \<rbrakk>  \<Longrightarrow> semantic_equiv \<Gamma> s' s'' c c'"
+  assumes "\<And>s s' t'.
+             \<lbrakk> (s, s') \<in> sr; P' s; s' \<in> Q'; \<Gamma> \<turnstile>\<^sub>h \<langle>c' # hs', s'\<rangle> \<Rightarrow> (size hs', Normal t') \<rbrakk> \<Longrightarrow>
+             xf t' = xf' t'"
+  assumes "\<And>x s t s' t'.
+             \<lbrakk> (s, s') \<in> sr; P' s; s' \<in> Q'; (t, t') \<in> sr; (x, t) \<in> fst (a' s);
+               \<Gamma> \<turnstile>\<^sub>h \<langle>c' # hs', s'\<rangle> \<Rightarrow> (size hs', Normal t') \<rbrakk> \<Longrightarrow>
+             r x (xf' t') = r' x (xf' t')"
+  assumes "\<And>s s' t' n.
+             \<lbrakk> (s, s') \<in> sr; P' s; s' \<in> Q'; n \<noteq> size hs'; \<Gamma> \<turnstile>\<^sub>h \<langle>c' # hs', s'\<rangle> \<Rightarrow> (n, Normal t') \<rbrakk> \<Longrightarrow>
+             axf t' = axf' t'"
+  assumes "\<And>x s t s' t' n.
+             \<lbrakk> (s, s') \<in> sr; P' s; s' \<in> Q'; (t, t') \<in> sr; (x, t) \<in> fst (a' s); n \<noteq> size hs';
+               \<Gamma> \<turnstile>\<^sub>h \<langle>c' # hs', s'\<rangle> \<Rightarrow> (n, Normal t') \<rbrakk> \<Longrightarrow>
+             ar x (axf' t') = ar' x (axf' t')"
+  shows   "ccorres_underlying sr \<Gamma> r xf ar axf P Q hs a c
+           = ccorres_underlying sr \<Gamma> r' xf' ar' axf' P' Q' hs' a' c'"
+  using assms
+  apply -
+  apply rule
+   apply (erule ccorres_context_cong_helper'; assumption)
+  apply (erule ccorres_context_cong_helper')
+  by (fastforce simp: semantic_equiv_sym exec_handlers_semantic_equiv[where a=c and b=c'])+
+
+lemmas ccorres_context_cong = ccorres_context_cong_helper[OF _ _ _ _ semantic_equivI]
+
+\<comment> \<open> Only rewrite guards, the handler stack and function bodies, with context.
+    This is often more useful, as we generally want the return relations and extraction
+    functions to be stable while working with a ccorres_underlying statement. \<close>
+lemma ccorres_context_weak_cong:
+  assumes "\<And>s. P s = P' s"
+  assumes "\<And>s s'. \<lbrakk> (s, s') \<in> sr; P' s \<rbrakk> \<Longrightarrow> Q = Q'"
+  assumes "\<And>s s'. \<lbrakk> (s, s') \<in> sr; P' s; s' \<in> Q' \<rbrakk> \<Longrightarrow> a s = a' s"
+  assumes "\<And>s s' s''. \<lbrakk> (s, s') \<in> sr; P' s; s' \<in> Q' \<rbrakk>  \<Longrightarrow> \<Gamma>\<turnstile> \<langle>c,Normal s'\<rangle> \<Rightarrow> s'' = \<Gamma>\<turnstile> \<langle>c',Normal s'\<rangle> \<Rightarrow> s''"
+  shows   "ccorres_underlying sr \<Gamma> r xf ar axf P Q hs a c
+           = ccorres_underlying sr \<Gamma> r xf ar axf P' Q' hs a' c'"
+  by (clarsimp simp: assms cong: ccorres_context_cong)
+
+\<comment> \<open> Even more restrictive: only rewrite the abstract monad. \<close>
+lemma ccorres_abstract_cong:
+  "\<lbrakk> \<And>s s'. \<lbrakk> (s, s') \<in> sr; P s ; s' \<in> P' \<rbrakk> \<Longrightarrow> a s = b s \<rbrakk> \<Longrightarrow>
+   ccorres_underlying sr G r xf ar axf P P' hs a c
+   = ccorres_underlying sr G r xf ar axf P P' hs b c"
+  by (clarsimp cong: ccorres_context_weak_cong)
+
+\<comment> \<open> Rewrite almost everywhere, without context. This should behave the same as with normal
+    term rewriting with no cong rule, except it will not rewrite the state relation or function
+    environment. \<close>
+lemma ccorres_all_cong:
+  "\<lbrakk> r=r'; xf=xf'; ar=ar'; axf=axf'; P=P'; Q=Q'; hs=hs'; m=m'; c=c' \<rbrakk> \<Longrightarrow>
+   ccorres_underlying srel \<Gamma> r xf ar axf P Q hs m c
+   = ccorres_underlying srel \<Gamma> r' xf' ar' axf' P' Q' hs' m' c'"
+  by (simp cong: ccorres_context_cong)
+
+\<comment> \<open> Only rewrite guards, the handler stack and function bodies, without context.
+    We make this the default behaviour, so that the the return relations and extraction
+    functions are stable under simplification. \<close>
+lemmas ccorres_weak_cong = ccorres_all_cong[OF refl refl refl refl, cong]
+
 end

--- a/proof/crefine/ARM/Arch_C.thy
+++ b/proof/crefine/ARM/Arch_C.thy
@@ -50,7 +50,7 @@ lemma performPageTableInvocationUnmap_ccorres:
         apply (ctac add: unmapPageTable_ccorres)
           apply csymbr
           apply (simp add: storePTE_def swp_def)
-          apply (ctac add: clearMemory_PT_setObject_PTE_ccorres[unfolded dc_def])
+          apply (ctac add: clearMemory_PT_setObject_PTE_ccorres)
          apply wp
         apply (simp del: Collect_const)
         apply (vcg exspec=unmapPageTable_modifies)
@@ -532,10 +532,10 @@ shows
                          pageBits_def
                    split: if_split)
   apply (clarsimp simp: ARMSmallPageBits_def word_sle_def is_aligned_mask[symmetric]
-                        ghost_assertion_data_get_gs_clear_region[unfolded o_def])
+                        ghost_assertion_data_get_gs_clear_region)
   apply (subst ghost_assertion_size_logic_flex[unfolded o_def, rotated])
      apply assumption
-    apply (simp add: ghost_assertion_data_get_gs_clear_region[unfolded o_def])
+    apply (simp add: ghost_assertion_data_get_gs_clear_region)
    apply (drule valid_global_refsD_with_objSize, clarsimp)+
    apply (clarsimp simp: isCap_simps dest!: ccte_relation_ccap_relation)
   apply (cut_tac ptr=frame and bits=12
@@ -1133,8 +1133,7 @@ lemma createSafeMappingEntries_PDE_ccorres:
                         vm_attribs_relation_def
                         superSectionPDEOffsets_def pdeBits_def
                         from_bool_mask_simp[unfolded mask_def, simplified]
-                        ptr_range_to_list_def upto_enum_step_def
-                        o_def upto_enum_word
+                        ptr_range_to_list_def upto_enum_step_def upto_enum_word
                   cong: if_cong)
   apply (frule(1) page_directory_at_rf_sr, clarsimp)
   apply (frule array_ptr_valid_array_assertionD[OF h_t_valid_clift])
@@ -1889,8 +1888,6 @@ lemma setMRs_single:
 (* usually when we call setMR directly, we mean to only set a single message register
    which will fit in actual registers *)
 lemma setMR_as_setRegister_ccorres:
-  notes dc_simp[simp del]
-  shows
   "ccorres (\<lambda>rv rv'. rv' = of_nat offset + 1) ret__unsigned_'
       (tcb_at' thread and K (TCB_H.msgRegisters ! offset = reg \<and> offset < length msgRegisters))
       (UNIV \<inter> \<lbrace>\<acute>reg = val\<rbrace>
@@ -1907,7 +1904,7 @@ lemma setMR_as_setRegister_ccorres:
    apply (ctac add: setRegister_ccorres)
      apply (rule ccorres_from_vcg_throws[where P'=UNIV and P=\<top>])
      apply (rule allI, rule conseqPre, vcg)
-     apply (clarsimp simp: dc_def return_def)
+     apply (clarsimp simp: return_def)
     apply (rule hoare_post_taut[of \<top>])
    apply (vcg exspec=setRegister_modifies)
   apply (clarsimp simp: length_msgRegisters n_msgRegisters_def not_le conj_commute)
@@ -1917,7 +1914,7 @@ lemma setMR_as_setRegister_ccorres:
   done
 
 lemma performPageGetAddress_ccorres:
-  notes Collect_const[simp del] dc_simp[simp del]
+  notes Collect_const[simp del]
   shows
   "ccorres ((intr_and_se_rel \<circ> Inr) \<currency> dc) (liftxf errstate id (K ()) ret__unsigned_long_')
       (invs' and (\<lambda>s. ksCurThread s = thread) and ct_in_state' ((=) Restart))
@@ -1943,7 +1940,7 @@ lemma performPageGetAddress_ccorres:
        apply (rule ccorres_from_vcg_throws[where P=\<top> and P'=UNIV])
        apply clarsimp
        apply (rule conseqPre, vcg)
-       apply (clarsimp simp: return_def dc_simp)
+       apply (clarsimp simp: return_def)
       apply (rule hoare_post_taut[of \<top>])
      apply (rule ccorres_rhs_assoc)+
      apply (clarsimp simp: replyOnRestart_def liftE_def bind_assoc)
@@ -1966,7 +1963,7 @@ lemma performPageGetAddress_ccorres:
                  apply (rule ccorres_inst[where P=\<top> and P'=UNIV])
                  apply (rule ccorres_from_vcg_throws[where P=\<top> and P'=UNIV])
                  apply (rule allI, rule conseqPre, vcg)
-                 apply (clarsimp simp: return_def dc_def)
+                 apply (clarsimp simp: return_def)
                 apply (rule hoare_post_taut[of \<top>])
                apply (vcg exspec=setThreadState_modifies)
               apply wpsimp
@@ -1979,10 +1976,10 @@ lemma performPageGetAddress_ccorres:
                                Kernel_C.msgInfoRegister_def Kernel_C.R1_def)
          apply (vcg exspec=setMR_modifies)
         apply wpsimp
-       apply (clarsimp simp: dc_def)
+       apply clarsimp
        apply (vcg exspec=setRegister_modifies)
       apply wpsimp
-     apply (clarsimp simp: dc_def ThreadState_Running_def)
+     apply (clarsimp simp: ThreadState_Running_def)
      apply (vcg exspec=lookupIPCBuffer_modifies)
     apply clarsimp
     apply vcg
@@ -2173,12 +2170,12 @@ where
 
 lemma resolve_ret_rel_None[simp]:
   "resolve_ret_rel None y = (valid_C y = scast false)"
-  by (clarsimp simp: resolve_ret_rel_def o_def to_option_def to_bool_def split: if_splits)
+  by (clarsimp simp: resolve_ret_rel_def to_option_def to_bool_def split: if_splits)
 
 lemma resolve_ret_rel_Some:
   "\<lbrakk>valid_C y = scast true;  frameSize_C y = framesize_from_H (fst x); snd x = frameBase_C y\<rbrakk>
    \<Longrightarrow> resolve_ret_rel (Some x) y"
-  by (clarsimp simp: resolve_ret_rel_def o_def to_option_def)
+  by (clarsimp simp: resolve_ret_rel_def to_option_def)
 
 lemma resolveVAddr_ccorres:
   "ccorres resolve_ret_rel ret__struct_resolve_ret_C_'
@@ -2605,7 +2602,7 @@ lemma decodeARMFrameInvocation_ccorres:
             apply csymbr
             apply (simp add: ARM.pptrBase_def hd_conv_nth length_ineq_not_Nil)
             apply ccorres_rewrite
-            apply (rule syscall_error_throwError_ccorres_n[unfolded id_def dc_def])
+            apply (rule syscall_error_throwError_ccorres_n)
             apply (simp add: syscall_error_to_H_cases)
            (* Doesn't throw case *)
            apply (drule_tac s="Some y" in sym,
@@ -2632,7 +2629,6 @@ lemma decodeARMFrameInvocation_ccorres:
                         simp add: ARM.pptrBase_def ARM.pptrBase_def
                                   hd_conv_nth length_ineq_not_Nil,
                         ccorres_rewrite)
-                 apply (fold dc_def)
                  apply (rule ccorres_return_Skip, clarsimp)
                apply (subgoal_tac "cap_get_tag cap = SCAST(32 signed \<rightarrow> 32) cap_frame_cap
                                    \<or> cap_get_tag cap = SCAST(32 signed \<rightarrow> 32) cap_small_frame_cap",

--- a/proof/crefine/ARM/CSpace_All.thy
+++ b/proof/crefine/ARM/CSpace_All.thy
@@ -25,9 +25,9 @@ abbreviation
 
 (* FIXME: move *)
 lemma ccorres_return_into_rel:
-  "ccorres (\<lambda>rv rv'. r (f rv) rv') xf G G' hs a c
+  "ccorres (r \<circ> f) xf G G' hs a c
   \<Longrightarrow> ccorres r xf G G' hs (a >>= (\<lambda>rv. return (f rv))) c"
-  by (simp add: liftM_def[symmetric] o_def)
+  by (simp add: liftM_def[symmetric])
 
 lemma lookupCap_ccorres':
   "ccorres (lookup_failure_rel \<currency> ccap_relation) lookupCap_xf

--- a/proof/crefine/ARM/CSpace_C.thy
+++ b/proof/crefine/ARM/CSpace_C.thy
@@ -892,7 +892,7 @@ lemma setUntypedCapAsFull_ccorres [corres]:
     apply (rule ccorres_move_c_guard_cte)
     apply (rule ccorres_Guard)
     apply (rule ccorres_call)
-       apply (rule update_freeIndex [unfolded dc_def])
+       apply (rule update_freeIndex)
       apply simp
      apply simp
     apply simp
@@ -918,14 +918,14 @@ lemma setUntypedCapAsFull_ccorres [corres]:
       apply csymbr
       apply (clarsimp simp: cap_get_tag_to_H cap_get_tag_UntypedCap split: if_split_asm)
       apply (rule ccorres_cond_false)
-      apply (rule ccorres_return_Skip [unfolded dc_def])
+      apply (rule ccorres_return_Skip)
      apply (clarsimp simp: cap_get_tag_isCap[symmetric] cap_get_tag_UntypedCap split: if_split_asm)
      apply (rule ccorres_cond_false)
-     apply (rule ccorres_return_Skip [unfolded dc_def])
-    apply (rule ccorres_return_Skip [unfolded dc_def])
+     apply (rule ccorres_return_Skip)
+    apply (rule ccorres_return_Skip)
    apply clarsimp
    apply (rule ccorres_cond_false)
-   apply (rule ccorres_return_Skip [unfolded dc_def])
+   apply (rule ccorres_return_Skip)
   apply (clarsimp simp: cap_get_tag_isCap[symmetric] cap_get_tag_UntypedCap)
   apply (frule(1) cte_wp_at_valid_objs_valid_cap')
   apply (clarsimp simp: untypedBits_defs)
@@ -1031,19 +1031,17 @@ lemma cteInsert_ccorres:
                   apply csymbr
                   apply simp
                   apply (rule ccorres_move_c_guard_cte)
-                  apply (simp add:dc_def[symmetric])
                   apply (ctac ccorres:ccorres_updateMDB_set_mdbPrev)
-                 apply (simp add:dc_def[symmetric])
                  apply (ctac ccorres: ccorres_updateMDB_skip)
                 apply (wp static_imp_wp)+
-              apply (clarsimp simp: Collect_const_mem dc_def split del: if_split)
+              apply (clarsimp simp: Collect_const_mem split del: if_split)
               apply vcg
              apply (wp static_imp_wp)
-            apply (clarsimp simp: Collect_const_mem dc_def split del: if_split)
+            apply (clarsimp simp: Collect_const_mem split del: if_split)
             apply vcg
            apply (clarsimp simp:cmdb_node_relation_mdbNext)
            apply (wp setUntypedCapAsFull_cte_at_wp static_imp_wp)
-          apply (clarsimp simp: Collect_const_mem dc_def split del: if_split)
+          apply (clarsimp simp: Collect_const_mem split del: if_split)
           apply (vcg exspec=setUntypedCapAsFull_modifies)
          apply wp
         apply vcg
@@ -1214,7 +1212,7 @@ lemma cteMove_ccorres:
    apply (intro conjI, simp+)
    apply (erule (2) is_aligned_3_prev)
    apply (erule (2) is_aligned_3_next)
-  apply (clarsimp simp: dc_def split del: if_split)
+  apply (clarsimp split del: if_split)
   apply (simp add: ccap_relation_NullCap_iff)
   apply (clarsimp simp: cmdbnode_relation_def mdb_node_to_H_def nullMDBNode_def)
   done
@@ -1956,7 +1954,6 @@ lemma postCapDeletion_ccorres:
     apply (rule ccorres_symb_exec_r)
       apply (rule_tac xf'=irq_' in ccorres_abstract, ceqv)
       apply (rule_tac P="rv' = ucast (capIRQ cap)" in ccorres_gen_asm2)
-      apply (fold dc_def)
       apply (frule cap_get_tag_to_H, solves \<open>clarsimp simp: cap_get_tag_isCap_unfolded_H_cap\<close>)
       apply (clarsimp simp: cap_irq_handler_cap_lift)
       apply (ctac(no_vcg) add: deletedIRQHandler_ccorres)
@@ -1967,9 +1964,9 @@ lemma postCapDeletion_ccorres:
    apply (clarsimp simp: cap_get_tag_isCap)
    apply (rule ccorres_Cond_rhs)
     apply (wpc; clarsimp simp: isCap_simps)
-    apply (ctac(no_vcg) add: Arch_postCapDeletion_ccorres[unfolded dc_def])
+    apply (ctac(no_vcg) add: Arch_postCapDeletion_ccorres)
    apply (simp add: not_irq_or_arch_cap_case)
-   apply (rule ccorres_return_Skip[unfolded dc_def])+
+   apply (rule ccorres_return_Skip)
   apply clarsimp
   apply (rule conjI, clarsimp simp: isCap_simps  Kernel_C.maxIRQ_def)
    apply (frule cap_get_tag_isCap_unfolded_H_cap(5))
@@ -2018,7 +2015,7 @@ lemma emptySlot_ccorres:
 
     \<comment> \<open>*** proof for the 'else' branch (return () and SKIP) ***\<close>
      prefer 2
-     apply (ctac add: ccorres_return_Skip[unfolded dc_def])
+     apply (ctac add: ccorres_return_Skip)
 
     \<comment> \<open>*** proof for the 'then' branch ***\<close>
 
@@ -2063,7 +2060,7 @@ lemma emptySlot_ccorres:
 
                   \<comment> \<open>the post_cap_deletion case\<close>
 
-                  apply (ctac(no_vcg) add: postCapDeletion_ccorres [unfolded dc_def])
+                  apply (ctac(no_vcg) add: postCapDeletion_ccorres)
 
                 \<comment> \<open>Haskell pre/post for y \<leftarrow> updateMDB slot (\<lambda>a. nullMDBNode);\<close>
                  apply wp
@@ -2136,7 +2133,7 @@ lemma capSwapForDelete_ccorres:
    apply (simp add:when_def)
    apply (rule ccorres_if_cond_throws2 [where Q = \<top> and Q' = \<top>])
       apply (case_tac "slot1=slot2", simp+)
-     apply (rule ccorres_return_void_C [simplified dc_def])
+     apply (rule ccorres_return_void_C)
 
   \<comment> \<open>***Main goal***\<close>
   \<comment> \<open>--- ccorres goal with 2 affectations (cap1 and cap2) on both on Haskell and C\<close>
@@ -2145,7 +2142,7 @@ lemma capSwapForDelete_ccorres:
     apply (rule ccorres_pre_getCTE)+
     apply (rule ccorres_move_c_guard_cte, rule ccorres_symb_exec_r)+
   \<comment> \<open>***Main goal***\<close>
-        apply (ctac (no_vcg) add: cteSwap_ccorres [unfolded dc_def] )
+        apply (ctac (no_vcg) add: cteSwap_ccorres)
        \<comment> \<open>C Hoare triple for \<acute>cap2 :== \<dots>\<close>
        apply vcg
        \<comment> \<open>C existential Hoare triple for \<acute>cap2 :== \<dots>\<close>

--- a/proof/crefine/ARM/Delete_C.thy
+++ b/proof/crefine/ARM/Delete_C.thy
@@ -804,7 +804,7 @@ lemma finaliseSlot_ccorres:
                                       ccorres_seq_skip)
                     apply (rule rsubst[where P="ccorres r xf' P P' hs a" for r xf' P P' hs a])
                     apply (rule hyps[folded reduceZombie_def[unfolded cteDelete_def finaliseSlot_def],
-                                         unfolded split_def, unfolded K_def],
+                                     unfolded split_def],
                            (simp add: in_monad)+)
                     apply (simp add: from_bool_0)
                    apply simp
@@ -950,26 +950,23 @@ lemma cteRevoke_ccorres1:
          apply (rule ccorres_drop_cutMon_bindE)
          apply (rule ccorres_rhs_assoc)+
          apply (ctac(no_vcg) add: cteDelete_ccorres)
-           apply (simp del: Collect_const add: Collect_False ccorres_cond_iffs
-                                               dc_def[symmetric])
+           apply (simp del: Collect_const add: Collect_False ccorres_cond_iffs)
            apply (rule ccorres_cutMon, simp only: cutMon_walk_bindE)
            apply (rule ccorres_drop_cutMon_bindE)
            apply (ctac(no_vcg) add: preemptionPoint_ccorres)
-             apply (simp del: Collect_const add: Collect_False ccorres_cond_iffs
-                                                 dc_def[symmetric])
+             apply (simp del: Collect_const add: Collect_False ccorres_cond_iffs)
              apply (rule ccorres_cutMon)
              apply (rule rsubst[where P="ccorres r xf' P P' hs a" for r xf' P P' hs a])
-              apply (rule hyps[unfolded K_def],
-                     (fastforce simp: in_monad)+)[1]
+              apply (rule hyps; fastforce simp: in_monad)
              apply simp
             apply (simp, rule ccorres_split_throws)
-             apply (rule ccorres_return_C_errorE, simp+)[1]
+             apply (rule ccorres_return_C_errorE; simp)
             apply vcg
            apply (wp preemptionPoint_invR)
             apply simp
            apply simp
           apply (simp, rule ccorres_split_throws)
-           apply (rule ccorres_return_C_errorE, simp+)[1]
+           apply (rule ccorres_return_C_errorE; simp)
           apply vcg
          apply (wp cteDelete_invs' cteDelete_sch_act_simple)
         apply (rule ccorres_cond_false)

--- a/proof/crefine/ARM/Fastpath_C.thy
+++ b/proof/crefine/ARM/Fastpath_C.thy
@@ -732,8 +732,7 @@ lemma switchToThread_fp_ccorres:
         apply (simp add: storeWordUser_def bind_assoc case_option_If2
                          split_def
                     del: Collect_const)
-        apply (simp only: dmo_clearExMonitor_setCurThread_swap
-                             dc_def[symmetric])
+        apply (simp only: dmo_clearExMonitor_setCurThread_swap)
         apply (rule ccorres_split_nothrow_novcg_dc)
            apply (rule ccorres_from_vcg[where P=\<top> and P'=UNIV])
            apply (rule allI, rule conseqPre, vcg)
@@ -985,10 +984,7 @@ lemma ccorres_call_hSkip:
   apply -
   apply (rule ccorres_call_hSkip')
        apply (erule ccorres_guard_imp)
-        apply simp
-       apply clarsimp
-      apply (simp_all add: ggl xfdc_def)
-  apply (clarsimp simp: igl)
+        apply (clarsimp simp: ggl igl xfdc_def)+
   done
 
 lemma bind_case_sum_rethrow:
@@ -1777,7 +1773,6 @@ proof -
        apply (rule ccorres_Cond_rhs_Seq)
           apply (rule ccorres_alternative2)
           apply (rule ccorres_split_throws)
-           apply (fold dc_def)[1]
            apply (rule ccorres_call_hSkip)
              apply (rule slowpath_ccorres)
             apply simp
@@ -1812,7 +1807,7 @@ proof -
           apply (rule ccorres_cond_true_seq)
           apply (rule ccorres_split_throws)
            apply (rule ccorres_call_hSkip)
-             apply (erule disjE; simp flip: dc_def; rule slowpath_ccorres)
+             apply (erule disjE; simp; rule slowpath_ccorres)
             apply simp
            apply simp
           apply (vcg exspec=slowpath_noreturn_spec)
@@ -1827,7 +1822,6 @@ proof -
          apply (rule ccorres_Cond_rhs_Seq)
           apply simp
           apply (rule ccorres_split_throws)
-           apply (fold dc_def)[1]
            apply (rule ccorres_call_hSkip)
              apply (rule slowpath_ccorres, simp+)
           apply (vcg exspec=slowpath_noreturn_spec)
@@ -1864,7 +1858,6 @@ proof -
            apply (rule ccorres_Cond_rhs_Seq)
             apply simp
             apply (rule ccorres_split_throws)
-             apply (fold dc_def)[1]
              apply (rule ccorres_call_hSkip)
                apply (rule slowpath_ccorres, simp+)
             apply (vcg exspec=slowpath_noreturn_spec)
@@ -1887,7 +1880,6 @@ proof -
              apply (rule ccorres_Cond_rhs_Seq)
               apply simp
               apply (rule ccorres_split_throws)
-               apply (fold dc_def)[1]
                apply (rule ccorres_call_hSkip)
                  apply (rule slowpath_ccorres, simp+)
               apply (vcg exspec=slowpath_noreturn_spec)
@@ -1945,29 +1937,25 @@ proof -
                         apply (simp add: ctcb_relation_unat_tcbPriority_C
                                           word_less_nat_alt linorder_not_le)
                         apply ceqv
-                       apply (simp add: Collect_const_mem from_bool_eq_if from_bool_eq_if' from_bool_0 if_1_0_0 ccorres_IF_True del: Collect_const)
-                       apply (simp add: if_1_0_0 ccap_relation_ep_helpers from_bool_0 word_le_not_less
-                                    del: Collect_const cong: call_ignore_cong)
+                       apply (simp add: from_bool_eq_if from_bool_eq_if' from_bool_0 ccorres_IF_True del: Collect_const)
 
                        apply (rule ccorres_Cond_rhs)
-                        apply (simp add: bindE_assoc del: Collect_const)
                         apply (rule ccorres_Guard_Seq)
                         apply (rule ccorres_add_return2)
                         apply (ctac add: isHighestPrio_ccorres)
-                        apply (simp add: Collect_const_mem from_bool_eq_if from_bool_eq_if' from_bool_0 if_1_0_0 ccorres_IF_True del: Collect_const)
+                        apply (simp add: from_bool_eq_if from_bool_eq_if' from_bool_0 ccorres_IF_True del: Collect_const)
                         apply (clarsimp simp: to_bool_def)
                         apply (rule_tac P=\<top> and P'=UNIV in ccorres_from_vcg)
                         apply clarsimp
                         apply (rule conseqPre, vcg)
-                        apply (clarsimp simp: from_bool_eq_if from_bool_eq_if' from_bool_0 if_1_0_0)
+                        apply (clarsimp simp: from_bool_eq_if' word_le_not_less from_bool_0)
                         apply (clarsimp simp: return_def)
                         apply (rule wp_post_taut)
                         apply (vcg exspec=isHighestPrio_modifies)
-                       apply (simp add: Collect_const_mem from_bool_eq_if from_bool_eq_if' from_bool_0 if_1_0_0 ccorres_IF_True del: Collect_const)
                        apply (rule_tac P=\<top> and P'="{s. ret__int_' s = 0}" in ccorres_from_vcg)
                        apply (clarsimp simp: isHighestPrio_def' simpler_gets_def)
                        apply (rule conseqPre, vcg)
-                       apply clarsimp
+                       apply (clarsimp simp: from_bool_0)
                       apply clarsimp
                       apply vcg
                      apply (simp add: Collect_const_mem from_bool_eq_if from_bool_eq_if' from_bool_0 if_1_0_0 ccorres_IF_True del: Collect_const)
@@ -1981,7 +1969,6 @@ proof -
                    apply (rule ccorres_Cond_rhs_Seq)
                     apply (simp add: bindE_assoc from_bool_0 catch_throwError del: Collect_const)
                     apply (rule ccorres_split_throws)
-                     apply (fold dc_def)[1]
                      apply (rule ccorres_call_hSkip)
                        apply (rule slowpath_ccorres, simp+)
                     apply (vcg exspec=slowpath_noreturn_spec)
@@ -2000,7 +1987,6 @@ proof -
                apply (rule ccorres_Cond_rhs_Seq)
                 apply simp
                 apply (rule ccorres_split_throws)
-                 apply (fold dc_def)[1]
                  apply (rule ccorres_call_hSkip)
                    apply (rule slowpath_ccorres, simp+)
                 apply (vcg exspec=slowpath_noreturn_spec)
@@ -2015,7 +2001,6 @@ proof -
                   apply (rule ccorres_Cond_rhs_Seq)
                    apply (simp add: pde_stored_asid_def asid_map_pd_to_hwasids_def)
                    apply (rule ccorres_split_throws)
-                    apply (fold dc_def)[1]
                     apply (rule ccorres_call_hSkip)
                       apply (rule slowpath_ccorres, simp+)
                    apply (vcg exspec=slowpath_noreturn_spec)
@@ -2044,7 +2029,6 @@ proof -
                     apply (rule ccorres_seq_cond_raise[THEN iffD2])
                     apply (rule_tac R=\<top> in ccorres_cond2', blast)
                      apply (rule ccorres_split_throws)
-                      apply (fold dc_def)[1]
                       apply (rule ccorres_call_hSkip)
                         apply (rule slowpath_ccorres, simp+)
                      apply (vcg exspec=slowpath_noreturn_spec)
@@ -2100,7 +2084,7 @@ proof -
                                       ccorres_move_array_assertion_tcb_ctes
                                       ccorres_move_c_guard_tcb_ctes)+
                           apply csymbr
-                          apply (simp add: cteInsert_def bind_assoc dc_def[symmetric]
+                          apply (simp add: cteInsert_def bind_assoc
                                       del: Collect_const cong: call_ignore_cong)
                           apply (rule ccorres_pre_getCTE2, rename_tac curThreadReplyCTE)
                           apply (simp only: getThreadState_def)
@@ -2223,7 +2207,6 @@ proof -
                                        apply csymbr
                                        apply csymbr
                                        apply (rule ccorres_call_hSkip)
-                                         apply (fold dc_def)[1]
                                          apply (rule fastpath_restore_ccorres)
                                         apply simp
                                        apply simp
@@ -2608,7 +2591,6 @@ lemma fastpath_reply_recv_ccorres:
        apply (rule ccorres_Cond_rhs_Seq)
         apply (rule ccorres_alternative2)
         apply (rule ccorres_split_throws)
-         apply (fold dc_def)[1]
          apply (rule ccorres_call_hSkip)
            apply (rule slowpath_ccorres)
           apply simp
@@ -2642,7 +2624,7 @@ lemma fastpath_reply_recv_ccorres:
           apply (rule ccorres_cond_true_seq)
           apply (rule ccorres_split_throws)
            apply (rule ccorres_call_hSkip)
-             apply (erule disjE; simp flip: dc_def; rule slowpath_ccorres)
+             apply (erule disjE; simp; rule slowpath_ccorres)
             apply simp
            apply simp
           apply (vcg exspec=slowpath_noreturn_spec)
@@ -2657,7 +2639,6 @@ lemma fastpath_reply_recv_ccorres:
          apply (rule ccorres_Cond_rhs_Seq)
           apply simp
           apply (rule ccorres_split_throws)
-           apply (fold dc_def)[1]
            apply (rule ccorres_call_hSkip)
              apply (rule slowpath_ccorres)
             apply simp
@@ -2682,7 +2663,6 @@ lemma fastpath_reply_recv_ccorres:
              apply (rule ccorres_Cond_rhs_Seq)
             apply (rule ccorres_split_throws)
              apply simp
-             apply (fold dc_def)[1]
              apply (rule ccorres_call_hSkip)
                apply (rule slowpath_ccorres, simp+)
             apply (vcg exspec=slowpath_noreturn_spec)
@@ -2712,7 +2692,6 @@ lemma fastpath_reply_recv_ccorres:
                apply (rule ccorres_Cond_rhs_Seq)
                 apply (simp del: Collect_const not_None_eq)
                 apply (rule ccorres_split_throws)
-                 apply (fold dc_def)[1]
                  apply (rule ccorres_call_hSkip)
                    apply (rule slowpath_ccorres, simp+)
                 apply (vcg exspec=slowpath_noreturn_spec)
@@ -2746,7 +2725,6 @@ lemma fastpath_reply_recv_ccorres:
              apply (rule ccorres_Cond_rhs_Seq)
               apply (simp cong: conj_cong)
                 apply (rule ccorres_split_throws)
-                 apply (fold dc_def)[1]
                  apply (rule ccorres_call_hSkip)
                    apply (rule slowpath_ccorres, simp+)
                 apply (vcg exspec=slowpath_noreturn_spec)
@@ -2766,7 +2744,6 @@ lemma fastpath_reply_recv_ccorres:
                  apply (rule ccorres_Cond_rhs_Seq)
                   apply (simp del: Collect_const not_None_eq)
                   apply (rule ccorres_split_throws)
-                   apply (fold dc_def)[1]
                    apply (rule ccorres_call_hSkip)
                      apply (rule slowpath_ccorres, simp+)
                   apply (vcg exspec=slowpath_noreturn_spec)
@@ -2788,7 +2765,6 @@ lemma fastpath_reply_recv_ccorres:
 
                     apply simp
                     apply (rule ccorres_split_throws)
-                     apply (fold dc_def)[1]
                      apply (rule ccorres_call_hSkip)
                        apply (rule slowpath_ccorres, simp+)
                     apply (vcg exspec=slowpath_noreturn_spec)
@@ -2820,7 +2796,6 @@ lemma fastpath_reply_recv_ccorres:
                       apply (rule ccorres_cond2'[where R=\<top>], blast)
 
                       apply (rule ccorres_split_throws)
-                      apply (fold dc_def)[1]
                       apply (rule ccorres_call_hSkip)
                       apply (rule slowpath_ccorres, simp+)
                       apply (vcg exspec=slowpath_noreturn_spec)
@@ -2835,7 +2810,6 @@ lemma fastpath_reply_recv_ccorres:
                       apply (rule ccorres_Cond_rhs_Seq)
                        apply (simp add: pde_stored_asid_def asid_map_pd_to_hwasids_def)
                        apply (rule ccorres_split_throws)
-                        apply (fold dc_def)[1]
                         apply (rule ccorres_call_hSkip)
                           apply (rule slowpath_ccorres, simp+)
                        apply (vcg exspec=slowpath_noreturn_spec)
@@ -2866,7 +2840,6 @@ lemma fastpath_reply_recv_ccorres:
 
                      apply simp
                      apply (rule ccorres_split_throws)
-                      apply (fold dc_def)[1]
                       apply (rule ccorres_call_hSkip)
                         apply (rule slowpath_ccorres, simp+)
                      apply (vcg exspec=slowpath_noreturn_spec)
@@ -2906,7 +2879,7 @@ lemma fastpath_reply_recv_ccorres:
                        apply ceqv
                       apply (rule ccorres_rhs_assoc2, rule ccorres_rhs_assoc2)
                       apply (rule_tac xf'=xfdc and r'=dc in ccorres_split_nothrow)
-                          apply (rule fastpath_enqueue_ccorres[unfolded o_def,simplified])
+                          apply (rule fastpath_enqueue_ccorres[simplified])
                           apply simp
                          apply ceqv
                         apply (simp add: liftM_def del: Collect_const cong: call_ignore_cong)
@@ -2995,7 +2968,6 @@ lemma fastpath_reply_recv_ccorres:
                                      apply csymbr
                                      apply csymbr
                                      apply (rule ccorres_call_hSkip)
-                                       apply (fold dc_def)[1]
                                        apply (rule fastpath_restore_ccorres)
                                       apply simp
                                      apply simp
@@ -3020,7 +2992,7 @@ lemma fastpath_reply_recv_ccorres:
                              apply (wp setCTE_cte_wp_at_other)
                             apply (simp del: Collect_const)
                             apply vcg
-                           apply (simp add: o_def)
+                           apply simp
                            apply (wp | simp
                                       | wp (once) updateMDB_weak_cte_wp_at
                                       | wp (once) updateMDB_cte_wp_at_other)+

--- a/proof/crefine/ARM/Fastpath_Equiv.thy
+++ b/proof/crefine/ARM/Fastpath_Equiv.thy
@@ -963,7 +963,7 @@ lemma tcbSchedDequeue_rewrite_not_queued:
   apply (monadic_rewrite_l monadic_rewrite_if_l_False \<open>wp threadGet_const\<close>)
    apply (monadic_rewrite_symb_exec_l, rule monadic_rewrite_refl)
    apply wp+
-  apply (clarsimp simp: o_def obj_at'_def)
+  apply clarsimp
   done
 
 lemma schedule_known_rewrite:
@@ -1396,8 +1396,7 @@ lemma fastpath_callKernel_SysReplyRecv_corres:
                         capFaultOnFailure_def rethrowFailure_injection
                         injection_handler_catch bind_bindE_assoc
                         getThreadCallerSlot_def bind_assoc
-                        getSlotCap_def
-                        case_bool_If o_def
+                        getSlotCap_def case_bool_If
                         isRight_def[where x="Inr v" for v]
                         isRight_def[where x="Inl v" for v]
                   cong: if_cong)

--- a/proof/crefine/ARM/Finalise_C.thy
+++ b/proof/crefine/ARM/Finalise_C.thy
@@ -200,8 +200,7 @@ proof (induct ts)
     apply (rule iffD1 [OF ccorres_expand_while_iff])
     apply (rule ccorres_tmp_lift2[where G'=UNIV and G''="\<lambda>x. UNIV", simplified])
      apply ceqv
-    apply (simp add: ccorres_cond_iffs mapM_x_def sequence_x_def
-                     dc_def[symmetric])
+    apply (simp add: ccorres_cond_iffs mapM_x_def sequence_x_def)
     apply (rule ccorres_guard_imp2, rule ccorres_return_Skip)
     apply simp
     done
@@ -210,7 +209,7 @@ next
   show ?case
     apply (rule iffD1 [OF ccorres_expand_while_iff])
     apply (simp del: Collect_const
-                add: dc_def[symmetric] mapM_x_Cons)
+                add: mapM_x_Cons)
     apply (rule ccorres_guard_imp2)
      apply (rule_tac xf'=thread_' in ccorres_abstract)
       apply ceqv
@@ -324,7 +323,7 @@ lemma cancelAllIPC_ccorres:
              subgoal by (simp add: cendpoint_relation_def endpoint_state_defs)
             subgoal by simp
            apply (rule ceqv_refl)
-          apply (simp only: ccorres_seq_skip dc_def[symmetric])
+          apply (simp only: ccorres_seq_skip)
           apply (rule ccorres_split_nothrow_novcg)
               apply (rule cancel_all_ccorres_helper)
              apply ceqv
@@ -341,12 +340,10 @@ lemma cancelAllIPC_ccorres:
          apply (wp set_ep_valid_objs' hoare_vcg_const_Ball_lift
                    weak_sch_act_wf_lift_linear)
         apply vcg
-       apply (simp add: ccorres_cond_iffs dc_def[symmetric])
+       apply (simp add: ccorres_cond_iffs)
        apply (rule ccorres_return_Skip)
       apply (rename_tac list)
-      apply (simp add: endpoint_state_defs
-                       Collect_False Collect_True
-                       ccorres_cond_iffs dc_def[symmetric]
+      apply (simp add: endpoint_state_defs Collect_False Collect_True ccorres_cond_iffs
                   del: Collect_const)
       apply (rule ccorres_rhs_assoc)+
       apply csymbr
@@ -374,7 +371,7 @@ lemma cancelAllIPC_ccorres:
            subgoal by (simp add: cendpoint_relation_def endpoint_state_defs)
           subgoal by simp
          apply (rule ceqv_refl)
-        apply (simp only: ccorres_seq_skip dc_def[symmetric])
+        apply (simp only: ccorres_seq_skip)
         apply (rule ccorres_split_nothrow_novcg)
             apply (rule cancel_all_ccorres_helper)
            apply ceqv
@@ -422,15 +419,12 @@ lemma cancelAllSignals_ccorres:
      apply (rule_tac A="invs' and ko_at' rv ntfnptr"
                   in ccorres_guard_imp2[where A'=UNIV])
       apply wpc
-        apply (simp add: notification_state_defs ccorres_cond_iffs
-                         dc_def[symmetric])
+        apply (simp add: notification_state_defs ccorres_cond_iffs)
         apply (rule ccorres_return_Skip)
-       apply (simp add: notification_state_defs ccorres_cond_iffs
-                        dc_def[symmetric])
+       apply (simp add: notification_state_defs ccorres_cond_iffs)
        apply (rule ccorres_return_Skip)
       apply (rename_tac list)
-      apply (simp add: notification_state_defs ccorres_cond_iffs
-                       dc_def[symmetric] Collect_True
+      apply (simp add: notification_state_defs ccorres_cond_iffs Collect_True
                   del: Collect_const)
       apply (rule ccorres_rhs_assoc)+
       apply csymbr
@@ -456,7 +450,7 @@ lemma cancelAllSignals_ccorres:
            subgoal by (simp add: cnotification_relation_def notification_state_defs Let_def)
           subgoal by simp
          apply (rule ceqv_refl)
-        apply (simp only: ccorres_seq_skip dc_def[symmetric])
+        apply (simp only: ccorres_seq_skip)
         apply (rule ccorres_split_nothrow_novcg)
             apply (rule cancel_all_ccorres_helper)
            apply ceqv
@@ -680,7 +674,7 @@ lemma doUnbindNotification_ccorres:
       apply (rule ccorres_move_c_guard_tcb)
       apply (simp add: setBoundNotification_def)
       apply (rule_tac P'="\<top>" and P="\<top>"
-                   in threadSet_ccorres_lemma3[unfolded dc_def])
+                   in threadSet_ccorres_lemma3)
        apply vcg
       apply simp
       apply (erule(1) rf_sr_tcb_update_no_queue2)
@@ -730,7 +724,7 @@ lemma doUnbindNotification_ccorres':
       apply (rule ccorres_move_c_guard_tcb)
       apply (simp add: setBoundNotification_def)
       apply (rule_tac P'="\<top>" and P="\<top>"
-                   in threadSet_ccorres_lemma3[unfolded dc_def])
+                   in threadSet_ccorres_lemma3)
        apply vcg
       apply simp
       apply (erule(1) rf_sr_tcb_update_no_queue2)
@@ -765,9 +759,9 @@ lemma unbindNotification_ccorres:
      apply simp
      apply wpc
       apply (rule ccorres_cond_false)
-      apply (rule ccorres_return_Skip[unfolded dc_def])
+      apply (rule ccorres_return_Skip)
      apply (rule ccorres_cond_true)
-     apply (ctac (no_vcg) add: doUnbindNotification_ccorres[unfolded dc_def, simplified])
+     apply (ctac (no_vcg) add: doUnbindNotification_ccorres[simplified])
     apply (wp gbn_wp')
    apply vcg
   apply (clarsimp simp: option_to_ptr_def option_to_0_def pred_tcb_at'_def
@@ -987,7 +981,6 @@ lemma invalidateASIDEntry_ccorres:
         apply (rule order_le_less_trans, rule word_and_le1)
         apply (simp add: mask_def)
        apply (rule ccorres_return_Skip)
-      apply (fold dc_def)
       apply (ctac add: invalidateASID_ccorres)
      apply wp
     apply (simp add: guard_is_UNIV_def)
@@ -1020,8 +1013,7 @@ lemma deleteASIDPool_ccorres:
   apply (rule ccorres_gen_asm)
   apply (cinit lift: asid_base_' pool_' simp: whileAnno_def)
    apply (rule ccorres_assert)
-   apply (clarsimp simp: liftM_def dc_def[symmetric] fun_upd_def[symmetric]
-                         when_def
+   apply (clarsimp simp: liftM_def fun_upd_def[symmetric] when_def
                simp del: Collect_const)
    apply (rule ccorres_Guard)+
    apply (rule ccorres_pre_gets_armKSASIDTable_ksArchState)
@@ -1168,14 +1160,12 @@ lemma deleteASID_ccorres:
       apply ceqv
      apply csymbr
      apply wpc
-      apply (simp add: ccorres_cond_iffs dc_def[symmetric]
-                       Collect_False
+      apply (simp add: ccorres_cond_iffs Collect_False
                   del: Collect_const
                  cong: call_ignore_cong)
       apply (rule ccorres_cond_false)
       apply (rule ccorres_return_Skip)
-     apply (simp add: dc_def[symmetric] when_def
-                      Collect_True liftM_def
+     apply (simp add: when_def Collect_True liftM_def
                 cong: conj_cong call_ignore_cong
                  del: Collect_const)
      apply (rule ccorres_pre_getObject_asidpool)
@@ -1356,7 +1346,7 @@ lemma unmapPageTable_ccorres:
    apply (ctac(no_vcg) add: pageTableMapped_ccorres)
     apply wpc
      apply (simp add: option_to_ptr_def option_to_0_def ccorres_cond_iffs)
-     apply (rule ccorres_return_Skip[unfolded dc_def])
+     apply (rule ccorres_return_Skip)
     apply (simp add: option_to_ptr_def option_to_0_def ccorres_cond_iffs)
     apply (rule ccorres_rhs_assoc)+
     apply csymbr
@@ -1366,7 +1356,6 @@ lemma unmapPageTable_ccorres:
     apply (rule ccorres_split_nothrow_novcg_dc)
        apply (rule storePDE_Basic_ccorres)
        apply (simp add: cpde_relation_def Let_def pde_lift_pde_invalid)
-      apply (fold dc_def)
       apply csymbr
       apply (ctac add: cleanByVA_PoU_ccorres)
         apply (ctac(no_vcg) add:flushTable_ccorres)
@@ -1412,7 +1401,7 @@ method return_NullCap_pair_ccorres =
           (rule allI, rule conseqPre, vcg), (clarsimp simp: return_def ccap_relation_NullCap_iff)\<close>
 
 lemma Arch_finaliseCap_ccorres:
-  notes dc_simp[simp del] Collect_const[simp del]
+  notes Collect_const[simp del]
   shows
   "ccorres (\<lambda>rv rv'. ccap_relation (fst rv) (remainder_C rv') \<and>
                      ccap_relation (snd rv) (finaliseCap_ret_C.cleanupInfo_C rv'))
@@ -1878,7 +1867,7 @@ lemma cteDeleteOne_ccorres:
           erule_tac t="ret__unsigned = scast cap_null_cap"
                 and s="cteCap cte = NullCap"
                  in ssubst)
-   apply (clarsimp simp only: when_def unless_def dc_def[symmetric])
+   apply (clarsimp simp only: when_def unless_def)
    apply (rule ccorres_cond2[where R=\<top>])
      apply (clarsimp simp: Collect_const_mem)
     apply (rule ccorres_rhs_assoc)+
@@ -1889,12 +1878,12 @@ lemma cteDeleteOne_ccorres:
       apply (ctac(no_vcg) add: isFinalCapability_ccorres[where slot=slot])
        apply (rule_tac A="invs'  and cte_wp_at' ((=) cte) slot"
                      in ccorres_guard_imp2[where A'=UNIV])
-        apply (simp add: split_def dc_def[symmetric]
+        apply (simp add: split_def
                     del: Collect_const)
         apply (rule ccorres_move_c_guard_cte)
         apply (ctac(no_vcg) add: finaliseCap_True_standin_ccorres)
          apply (rule ccorres_assert)
-         apply (simp add: dc_def[symmetric])
+         apply simp
          apply csymbr
          apply (ctac add: emptySlot_ccorres)
         apply (simp add: pred_conj_def finaliseCapTrue_standin_simple_def)
@@ -1930,7 +1919,7 @@ lemma deletingIRQHandler_ccorres:
                    (UNIV \<inter> {s. irq_opt_relation (Some irq) (irq_' s)}) []
    (deletingIRQHandler irq) (Call deletingIRQHandler_'proc)"
   apply (cinit lift: irq_' cong: call_ignore_cong)
-   apply (clarsimp simp: irq_opt_relation_def ptr_add_assertion_def dc_def[symmetric]
+   apply (clarsimp simp: irq_opt_relation_def ptr_add_assertion_def
                    cong: call_ignore_cong )
    apply (rule_tac r'="\<lambda>rv rv'. rv' = Ptr rv" and xf'="slot_'" in ccorres_split_nothrow)
        apply (rule ccorres_Guard_intStateIRQNode_array_Ptr)
@@ -2171,18 +2160,18 @@ lemma finaliseCap_ccorres:
     apply (rule ccorres_fail)
    apply (rule ccorres_add_return, rule ccorres_split_nothrow_novcg[where r'=dc and xf'=xfdc])
        apply (rule ccorres_Cond_rhs)
-        apply (simp add: ccorres_cond_iffs dc_def[symmetric])
+        apply (simp add: ccorres_cond_iffs)
         apply (rule ccorres_return_Skip)
        apply (rule ccorres_Cond_rhs)
-        apply (simp add: ccorres_cond_iffs dc_def[symmetric])
+        apply (simp add: ccorres_cond_iffs)
         apply (rule ccorres_return_Skip)
        apply (rule ccorres_Cond_rhs)
         apply (rule ccorres_inst[where P=\<top> and P'=UNIV])
         apply simp
        apply (rule ccorres_Cond_rhs)
-        apply (simp add: ccorres_cond_iffs dc_def[symmetric])
+        apply (simp add: ccorres_cond_iffs)
         apply (rule ccorres_return_Skip)
-       apply (simp add: ccorres_cond_iffs dc_def[symmetric])
+       apply (simp add: ccorres_cond_iffs)
        apply (rule ccorres_return_Skip)
       apply (rule ceqv_refl)
      apply (rule ccorres_from_vcg_throws[where P=\<top> and P'=UNIV])

--- a/proof/crefine/ARM/Finalise_C.thy
+++ b/proof/crefine/ARM/Finalise_C.thy
@@ -400,11 +400,6 @@ lemma cancelAllIPC_ccorres:
   apply clarsimp
   done
 
-lemma empty_fail_getNotification:
-  "empty_fail (getNotification ep)"
-  unfolding getNotification_def
-  by (auto intro: empty_fail_getObject)
-
 lemma cancelAllSignals_ccorres:
   "ccorres dc xfdc
    (invs') (UNIV \<inter> {s. ntfnPtr_' s = Ptr ntfnptr}) []
@@ -1786,12 +1781,6 @@ lemma Arch_finaliseCap_ccorres:
                     split: if_split_asm)
    apply (frule cap_get_tag_isCap_unfolded_H_cap, simp)
   done
-
-lemma ccte_relation_ccap_relation:
-  "ccte_relation cte cte' \<Longrightarrow> ccap_relation (cteCap cte) (cte_C.cap_C cte')"
-  by (clarsimp simp: ccte_relation_def ccap_relation_def
-                     cte_to_H_def map_option_Some_eq2
-                     c_valid_cte_def)
 
 lemma isFinalCapability_ccorres:
   "ccorres ((=) \<circ> from_bool) ret__unsigned_long_'

--- a/proof/crefine/ARM/Interrupt_C.thy
+++ b/proof/crefine/ARM/Interrupt_C.thy
@@ -74,11 +74,11 @@ proof -
      apply (rule ccorres_symb_exec_r)
        apply (ctac(no_vcg) add: cteDeleteOne_ccorres[where w="-1"])
         apply (rule ccorres_call)
-           apply (rule cteInsert_ccorres[simplified dc_def])
+           apply (rule cteInsert_ccorres)
           apply (simp add: pred_conj_def)+
-       apply (strengthen ntfn_badge_derived_enough_strg[unfolded o_def]
+       apply (strengthen ntfn_badge_derived_enough_strg
                          invs_mdb_strengthen' valid_objs_invs'_strg)
-       apply (wp cteDeleteOne_other_cap[unfolded o_def])[1]
+       apply (wp cteDeleteOne_other_cap[unfolded o_def])
       apply vcg
      apply (rule conseqPre, vcg, clarsimp simp: rf_sr_def
         gs_set_assn_Delete_cstate_relation[unfolded o_def])
@@ -108,7 +108,7 @@ lemma invokeIRQHandler_ClearIRQHandler_ccorres:
    apply simp
    apply (ctac(no_vcg) add: getIRQSlot_ccorres[simplified])
      apply (rule ccorres_symb_exec_r)
-       apply (ctac add: cteDeleteOne_ccorres[where w="-1",simplified dc_def])
+       apply (ctac add: cteDeleteOne_ccorres[where w="-1"])
       apply vcg
      apply (rule conseqPre, vcg,
             clarsimp simp: rf_sr_def gs_set_assn_Delete_cstate_relation[unfolded o_def])

--- a/proof/crefine/ARM/Invoke_C.thy
+++ b/proof/crefine/ARM/Invoke_C.thy
@@ -68,7 +68,7 @@ lemma setDomain_ccorres:
          apply (rule_tac R="\<lambda>s. rv = ksCurThread s"
                     in ccorres_cond2)
            apply (clarsimp simp: rf_sr_ksCurThread)
-          apply (ctac add: rescheduleRequired_ccorres[unfolded dc_def])
+          apply (ctac add: rescheduleRequired_ccorres)
          apply (rule ccorres_return_Skip')
         apply simp
         apply (wp hoare_drop_imps weak_sch_act_wf_lift_linear)
@@ -78,8 +78,9 @@ lemma setDomain_ccorres:
      apply (rule_tac Q="\<lambda>_. all_invs_but_sch_extra and tcb_at' t and sch_act_simple
                         and (\<lambda>s. rv = ksCurThread s)" in hoare_strengthen_post)
       apply (wp threadSet_all_invs_but_sch_extra)
-     apply (clarsimp simp:valid_pspace_valid_objs' st_tcb_at_def[symmetric]
-       sch_act_simple_def st_tcb_at'_def o_def weak_sch_act_wf_def split:if_splits)
+     apply (clarsimp simp: valid_pspace_valid_objs' st_tcb_at_def[symmetric]
+                           sch_act_simple_def st_tcb_at'_def weak_sch_act_wf_def
+                    split: if_splits)
     apply (simp add: guard_is_UNIV_def)
    apply (rule_tac Q="\<lambda>_. invs' and tcb_at' t and sch_act_simple
       and (\<lambda>s. rv = ksCurThread s \<and> (\<forall>p. t \<notin> set (ksReadyQueues s p)))" in hoare_strengthen_post)
@@ -388,7 +389,7 @@ lemma invokeCNodeRotate_ccorres:
      apply clarsimp
      apply (simp add: return_def)
     apply wp
-   apply (simp add: guard_is_UNIV_def dc_def xfdc_def)
+   apply (simp add: guard_is_UNIV_def)
   apply (clarsimp simp: valid_pspace'_def)
   apply (rule conjI, clarsimp)
   apply (clarsimp simp:cte_wp_at_ctes_of)
@@ -618,9 +619,7 @@ lemma decodeCNodeInvocation_ccorres:
                        del: Collect_const cong: call_ignore_cong)
            apply (rule ccorres_split_throws)
             apply (rule ccorres_rhs_assoc | csymbr)+
-            apply (simp add: invocationCatch_use_injection_handler
-                                  [symmetric, unfolded o_def]
-                             if_1_0_0 dc_def[symmetric]
+            apply (simp add: invocationCatch_use_injection_handler[symmetric, unfolded o_def]
                         del: Collect_const cong: call_ignore_cong)
             apply (rule ccorres_Cond_rhs_Seq)
              apply (simp add:if_P del: Collect_const)
@@ -703,8 +702,7 @@ lemma decodeCNodeInvocation_ccorres:
                          apply (simp add: Collect_const[symmetric] del: Collect_const)
                          apply (rule ccorres_rhs_assoc)+
                          apply (rule ccorres_Cond_rhs_Seq)
-                          apply (simp add: injection_handler_throwError dc_def[symmetric]
-                                           if_P)
+                          apply (simp add: injection_handler_throwError if_P)
                           apply (rule syscall_error_throwError_ccorres_n)
                           apply (simp add: syscall_error_to_H_cases)
                          apply (simp add: list_case_helper injection_handler_returnOk
@@ -731,8 +729,7 @@ lemma decodeCNodeInvocation_ccorres:
                                apply csymbr
                                apply (simp add: cap_get_tag_NullCap del: Collect_const)
                                apply (rule ccorres_Cond_rhs_Seq)
-                                apply (simp add: injection_handler_throwError whenE_def
-                                                 dc_def[symmetric])
+                                apply (simp add: injection_handler_throwError whenE_def)
                                 apply (rule syscall_error_throwError_ccorres_n)
                                 apply (simp add: syscall_error_to_H_cases)
                                apply (simp add: whenE_def injection_handler_returnOk
@@ -808,8 +805,7 @@ lemma decodeCNodeInvocation_ccorres:
                                    apply (simp add: cap_get_tag_NullCap del: Collect_const)
                                    apply (rule ccorres_Cond_rhs_Seq)
                                     apply (simp add: whenE_def injection_handler_returnOk
-                                                     invocationCatch_def injection_handler_throwError
-                                                     dc_def[symmetric])
+                                                     invocationCatch_def injection_handler_throwError)
                                     apply (rule syscall_error_throwError_ccorres_n)
                                     apply (simp add: syscall_error_to_H_cases)
                                    apply (simp add: whenE_def injection_handler_returnOk
@@ -888,7 +884,7 @@ lemma decodeCNodeInvocation_ccorres:
                          apply (simp add: flip: Collect_const
                                     cong: call_ignore_cong)
                          apply (rule ccorres_Cond_rhs_Seq)
-                          apply (simp add: injection_handler_throwError dc_def[symmetric] if_P)
+                          apply (simp add: injection_handler_throwError if_P)
                           apply (rule syscall_error_throwError_ccorres_n)
                           apply (simp add: syscall_error_to_H_cases)
                          apply (simp add: if_not_P del: Collect_const)
@@ -907,8 +903,7 @@ lemma decodeCNodeInvocation_ccorres:
                              apply csymbr
                              apply (simp add: cap_get_tag_isCap del: Collect_const)
                              apply (rule ccorres_Cond_rhs_Seq)
-                              apply (simp add: whenE_def injection_handler_throwError
-                                               dc_def[symmetric] numeral_eqs)
+                              apply (simp add: whenE_def injection_handler_throwError numeral_eqs)
                               apply (rule syscall_error_throwError_ccorres_n)
                               apply (simp add: syscall_error_to_H_cases)
                              apply (simp add: whenE_def injection_handler_returnOk
@@ -1007,13 +1002,11 @@ lemma decodeCNodeInvocation_ccorres:
           apply (simp del: Collect_const)
           apply (rule ccorres_Cond_rhs_Seq)
            apply (simp add: injection_handler_returnOk bindE_assoc
-                            injection_bindE[OF refl refl] split_def
-                            dc_def[symmetric])
+                            injection_bindE[OF refl refl] split_def)
            apply (rule ccorres_split_throws)
             apply (rule ccorres_rhs_assoc)+
             apply (ctac add: ccorres_injection_handler_csum1 [OF ensureEmptySlot_ccorres])
-               apply (simp add: ccorres_invocationCatch_Inr performInvocation_def
-                                dc_def[symmetric] bindE_assoc)
+               apply (simp add: ccorres_invocationCatch_Inr performInvocation_def bindE_assoc)
                apply (ctac add: setThreadState_ccorres)
                  apply (ctac(no_vcg) add: invokeCNodeSaveCaller_ccorres)
                    apply (rule ccorres_alternative2)
@@ -1022,7 +1015,7 @@ lemma decodeCNodeInvocation_ccorres:
                  apply (wp sts_valid_pspace_hangers)+
                apply (simp add: Collect_const_mem)
                apply (vcg exspec=setThreadState_modifies)
-              apply (simp add: dc_def[symmetric])
+              apply simp
               apply (rule ccorres_split_throws)
                apply (rule ccorres_return_C_errorE, simp+)[1]
               apply vcg
@@ -1052,8 +1045,7 @@ lemma decodeCNodeInvocation_ccorres:
                                in ccorres_gen_asm2)
                 apply (simp del: Collect_const)
                 apply (rule ccorres_Cond_rhs_Seq)
-                 apply (simp add: unlessE_def whenE_def injection_handler_throwError
-                                  dc_def[symmetric] from_bool_0)
+                 apply (simp add: unlessE_def whenE_def injection_handler_throwError from_bool_0)
                  apply (rule syscall_error_throwError_ccorres_n)
                  apply (simp add: syscall_error_to_H_cases)
                 apply (simp add: unlessE_def whenE_def injection_handler_returnOk
@@ -1097,12 +1089,10 @@ lemma decodeCNodeInvocation_ccorres:
             apply (simp add: throwError_def return_def exception_defs
                              syscall_error_rel_def syscall_error_to_H_cases)
             apply clarsimp
-           apply (simp add: invocationCatch_use_injection_handler
-                                  [symmetric, unfolded o_def]
+           apply (simp add: invocationCatch_use_injection_handler[symmetric, unfolded o_def]
                        del: Collect_const)
            apply csymbr
            apply (simp add: interpret_excaps_test_null excaps_map_def
-                            if_1_0_0 dc_def[symmetric]
                        del: Collect_const)
            apply (rule ccorres_Cond_rhs_Seq)
             apply (simp add: throwError_bind invocationCatch_def)
@@ -1162,8 +1152,7 @@ lemma decodeCNodeInvocation_ccorres:
                                            del: Collect_const)
                                apply csymbr
                                apply (rule ccorres_Cond_rhs_Seq)
-                                apply (simp add: whenE_def injection_handler_throwError
-                                                 dc_def[symmetric])
+                                apply (simp add: whenE_def injection_handler_throwError)
                                 apply (rule syscall_error_throwError_ccorres_n)
                                 apply (simp add: syscall_error_to_H_cases)
                                apply (simp add: whenE_def[where P=False] injection_handler_returnOk
@@ -1225,8 +1214,7 @@ lemma decodeCNodeInvocation_ccorres:
                                         apply csymbr
                                         apply (simp add: cap_get_tag_NullCap del: Collect_const)
                                         apply (rule ccorres_Cond_rhs_Seq)
-                                         apply (simp add: whenE_def injection_handler_throwError
-                                                          dc_def[symmetric])
+                                         apply (simp add: whenE_def injection_handler_throwError)
                                          apply (rule syscall_error_throwError_ccorres_n)
                                          apply (simp add: syscall_error_to_H_cases)
                                         apply (simp add: whenE_def[where P=False] injection_handler_returnOk
@@ -1234,8 +1222,7 @@ lemma decodeCNodeInvocation_ccorres:
                                         apply csymbr
                                         apply (simp add: cap_get_tag_NullCap del: Collect_const)
                                         apply (rule ccorres_Cond_rhs_Seq)
-                                         apply (simp add: whenE_def injection_handler_throwError
-                                                          dc_def[symmetric])
+                                         apply (simp add: whenE_def injection_handler_throwError)
                                          apply (rule syscall_error_throwError_ccorres_n)
                                          apply (simp add: syscall_error_to_H_cases)
                                         apply (simp add: whenE_def injection_handler_returnOk
@@ -1556,7 +1543,7 @@ lemma clearMemory_untyped_ccorres:
       apply (clarsimp simp: rf_sr_def cstate_relation_def Let_def
                             carch_state_relation_def cmachine_state_relation_def)
      apply csymbr
-     apply (ctac add: cleanCacheRange_RAM_ccorres[unfolded dc_def])
+     apply (ctac add: cleanCacheRange_RAM_ccorres)
     apply wp
    apply (simp add: guard_is_UNIV_def unat_of_nat
                     word_bits_def capAligned_def word_of_nat_less)
@@ -1761,8 +1748,7 @@ lemma resetUntypedCap_ccorres:
      apply (rule ccorres_Guard_Seq[where S=UNIV])?
      apply (rule ccorres_rhs_assoc2)
      apply (rule ccorres_split_nothrow)
-         apply (rule_tac idx="capFreeIndex (cteCap cte)"
-           in deleteObjects_ccorres[where p=slot, unfolded o_def])
+         apply (rule_tac idx="capFreeIndex (cteCap cte)" in deleteObjects_ccorres[where p=slot])
         apply ceqv
        apply clarsimp
        apply (simp only: ccorres_seq_cond_raise)
@@ -2648,7 +2634,6 @@ lemma Arch_isFrameType_spec:
   apply (auto simp: object_type_from_H_def )
   done
 
-
 lemma decodeUntypedInvocation_ccorres_helper:
   notes TripleSuc[simp] untypedBits_defs[simp]
   notes valid_untyped_inv_wcap'.simps[simp del] tl_drop_1[simp]
@@ -2826,8 +2811,8 @@ lemma decodeUntypedInvocation_ccorres_helper:
                      apply (ctac add: ccorres_injection_handler_csum1
                                        [OF lookupTargetSlot_ccorres, unfolded lookupTargetSlot_def])
                         apply (simp add: injection_liftE[OF refl])
-                        apply (simp add: liftE_liftM o_def split_def withoutFailure_def
-                                         hd_drop_conv_nth2 numeral_eqs[symmetric])
+                        apply (simp add: liftE_liftM o_def split_def hd_drop_conv_nth2
+                                   cong: ccorres_all_cong)
                         apply (rule ccorres_nohs)
                         apply (rule ccorres_getSlotCap_cte_at)
                         apply (rule ccorres_move_c_guard_cte)
@@ -2939,8 +2924,8 @@ lemma decodeUntypedInvocation_ccorres_helper:
                                apply (simp add: ccorres_cond_iffs returnOk_def)
                                apply (rule ccorres_return_Skip')
                               apply (rule ccorres_Guard_Seq ccorres_rhs_assoc)+
-                              apply (simp add: ccorres_cond_iffs inl_rrel_inl_rrel)
-                              apply (rule ccorres_return_C_errorE_inl_rrel, simp+)[1]
+                              apply (simp add: ccorres_cond_iffs)
+                              apply (rule ccorres_return_C_errorE_inl_rrel; simp)
                              apply wp
                             apply (simp add: all_ex_eq_helper)
                             apply (vcg exspec=ensureEmptySlot_modifies)
@@ -3035,8 +3020,7 @@ lemma decodeUntypedInvocation_ccorres_helper:
                                                        performInvocation_def liftE_bindE bind_assoc)
                              apply (ctac add: setThreadState_ccorres)
                                apply (rule ccorres_trim_returnE, (simp (no_asm))+)
-                               apply (simp (no_asm) add: o_def dc_def[symmetric] bindE_assoc
-                                                         id_def[symmetric] bind_bindE_assoc)
+                               apply (simp (no_asm) add: bindE_assoc bind_bindE_assoc)
                                apply (rule ccorres_seq_skip'[THEN iffD1])
                                apply (ctac(no_vcg) add: invokeUntyped_Retype_ccorres[where start = "args!4"])
                                  apply (rule ccorres_alternative2)
@@ -3081,7 +3065,7 @@ lemma decodeUntypedInvocation_ccorres_helper:
                        apply (rule conseqPre,vcg,clarsimp)
                       apply vcg
                      apply (rule ccorres_guard_imp[where Q =\<top> and Q' = UNIV,rotated], assumption+)
-                     apply (simp add: o_def)
+                     apply simp
                     apply simp
                     apply (rule checkFreeIndex_wp)
                    apply (clarsimp simp: ccap_relation_untyped_CL_simps shiftL_nat cap_get_tag_isCap
@@ -3146,7 +3130,7 @@ lemma decodeUntypedInvocation_ccorres_helper:
                    apply (rule validE_R_validE)
                    apply (wp injection_wp_E[OF refl])
                   apply clarsimp
-                 apply (simp add: ccHoarePost_def xfdc_def)
+                 apply (simp add: ccHoarePost_def)
                  apply (simp only: whileAnno_def[where I=UNIV and V=UNIV, symmetric])
                  apply (rule_tac V=UNIV in HoarePartial.reannotateWhileNoGuard)
                  apply (vcg exspec=ensureEmptySlot_modifies)
@@ -3273,7 +3257,7 @@ shows
   apply (rule ccorres_guard_imp2)
    apply (rule monadic_rewrite_ccorres_assemble)
     apply (rule_tac isBlocking=isBlocking and isCall=isCall and buffer=buffer
-                in decodeUntypedInvocation_ccorres_helper[unfolded K_def])
+                in decodeUntypedInvocation_ccorres_helper)
     apply assumption
    apply (rule monadic_rewrite_trans[rotated])
     apply (rule monadic_rewrite_bind_head)

--- a/proof/crefine/ARM/IpcCancel_C.thy
+++ b/proof/crefine/ARM/IpcCancel_C.thy
@@ -912,7 +912,6 @@ proof -
           apply (rule ccorres_split_nothrow_novcg_dc)
              prefer 2
              apply (rule ccorres_move_c_guard_tcb)
-             apply (simp only: dc_def[symmetric])
              apply ctac
             prefer 2
             apply (wp, clarsimp, wp+)
@@ -1033,7 +1032,7 @@ proof -
        apply simp
        apply (wp threadGet_wp)
       apply vcg
-     apply (rule ccorres_return_Skip[unfolded dc_def])
+     apply (rule ccorres_return_Skip)
     apply simp
     apply (wp threadGet_wp)
    apply vcg
@@ -1273,7 +1272,6 @@ proof -
           apply (rule ccorres_split_nothrow_novcg_dc)
              prefer 2
              apply (rule ccorres_move_c_guard_tcb)
-             apply (simp only: dc_def[symmetric])
              apply ctac
             prefer 2
             apply (wp, clarsimp, wp+)
@@ -1542,7 +1540,7 @@ proof -
        apply simp
        apply (wp threadGet_wp)
       apply vcg
-     apply (rule ccorres_return_Skip[unfolded dc_def])
+     apply (rule ccorres_return_Skip)
     apply simp
     apply (wp threadGet_wp)
    apply vcg
@@ -1674,7 +1672,6 @@ proof -
           apply (rule ccorres_split_nothrow_novcg_dc)
              prefer 2
              apply (rule ccorres_move_c_guard_tcb)
-             apply (simp only: dc_def[symmetric])
              apply ctac
             prefer 2
             apply (wp, clarsimp, wp+)
@@ -1779,7 +1776,7 @@ proof -
        apply simp
        apply (wp threadGet_wp)
       apply vcg
-     apply (rule ccorres_return_Skip[unfolded dc_def])
+     apply (rule ccorres_return_Skip)
     apply simp
     apply (wp threadGet_wp)
    apply vcg
@@ -2129,11 +2126,6 @@ lemma getCurDomain_maxDom_ccorres_dom_':
                         rf_sr_ksCurDomain)
   done
 
-lemma rf_sr_cscheduler_action_relation:
-  "(s, s') \<in> rf_sr
-   \<Longrightarrow> cscheduler_action_relation (ksSchedulerAction s) (ksSchedulerAction_' (globals s'))"
-  by (clarsimp simp: rf_sr_def cstate_relation_def Let_def)
-
 lemma threadGet_get_obj_at'_has_domain:
   "\<lbrace> tcb_at' t \<rbrace> threadGet tcbDomain t \<lbrace>\<lambda>rv. obj_at' (\<lambda>tcb. rv = tcbDomain tcb) t\<rbrace>"
   by (wp threadGet_obj_at') (simp add: obj_at'_def)
@@ -2150,7 +2142,6 @@ lemma possibleSwitchTo_ccorres:
      (Call possibleSwitchTo_'proc)"
   supply if_split [split del]
   supply Collect_const [simp del]
-  supply dc_simp [simp del]
   supply prio_and_dom_limit_helpers[simp]
   (* FIXME: these should likely be in simpset for CRefine, or even in general *)
   supply from_bool_eq_if[simp] from_bool_eq_if'[simp] from_bool_0[simp]
@@ -2175,7 +2166,7 @@ lemma possibleSwitchTo_ccorres:
       apply (ctac add: tcbSchedEnqueue_ccorres)
      apply (rule_tac R="\<lambda>s. sact = ksSchedulerAction s \<and> weak_sch_act_wf (ksSchedulerAction s) s"
                      in ccorres_cond)
-       apply (fastforce dest!: rf_sr_cscheduler_action_relation pred_tcb_at' tcb_at_not_NULL
+       apply (fastforce dest!: rf_sr_sched_action_relation pred_tcb_at' tcb_at_not_NULL
                         simp: cscheduler_action_relation_def weak_sch_act_wf_def
                         split: scheduler_action.splits)
       apply (ctac add: rescheduleRequired_ccorres)
@@ -2763,7 +2754,7 @@ lemma cancelIPC_ccorres_helper:
   apply (rule allI)
   apply (rule conseqPre)
    apply vcg
-  apply (clarsimp split del: if_split simp del: comp_def)
+  apply (clarsimp split del: if_split)
   apply (frule (2) ep_blocked_in_queueD)
   apply (frule (1) ko_at_valid_ep' [OF _ invs_valid_objs'])
   apply (elim conjE)
@@ -2781,7 +2772,7 @@ lemma cancelIPC_ccorres_helper:
        apply assumption+
    apply (drule (2) ep_to_ep_queue)
    apply (simp add: tcb_queue_relation'_def)
-  apply (clarsimp simp: typ_heap_simps cong: imp_cong split del: if_split simp del: comp_def)
+  apply (clarsimp simp: typ_heap_simps cong: imp_cong split del: if_split)
   apply (frule null_ep_queue [simplified comp_def] null_ep_queue)
   apply (intro impI conjI allI)
    \<comment> \<open>empty case\<close>
@@ -2922,7 +2913,6 @@ lemma cancelIPC_ccorres1:
      apply wpc
             \<comment> \<open>BlockedOnReceive\<close>
             apply (simp add: word_sle_def "StrictC'_thread_state_defs" ccorres_cond_iffs cong: call_ignore_cong)
-            apply (fold dc_def)
             apply (rule ccorres_rhs_assoc)+
             apply csymbr
             apply csymbr
@@ -2951,7 +2941,6 @@ lemma cancelIPC_ccorres1:
            apply (simp add: "StrictC'_thread_state_defs" ccorres_cond_iffs
                             Collect_False Collect_True word_sle_def
                       cong: call_ignore_cong del: Collect_const)
-           apply (fold dc_def)
            apply (rule ccorres_rhs_assoc)+
            apply csymbr
            apply csymbr
@@ -2991,14 +2980,12 @@ lemma cancelIPC_ccorres1:
                 apply (rule ccorres_Cond_rhs)
                  apply (simp add: nullPointer_def when_def)
                  apply (rule ccorres_symb_exec_l[OF _ _ _ empty_fail_stateAssert])
-                   apply (simp only: dc_def[symmetric])
                    apply (rule ccorres_symb_exec_r)
                      apply (ctac add: cteDeleteOne_ccorres[where w1="scast cap_reply_cap"])
                     apply vcg
                    apply (rule conseqPre, vcg, clarsimp simp: rf_sr_def
                        gs_set_assn_Delete_cstate_relation[unfolded o_def])
                   apply (wp | simp)+
-                apply (simp add: when_def nullPointer_def dc_def[symmetric])
                 apply (rule ccorres_return_Skip)
                apply (simp add: guard_is_UNIV_def ghost_assertion_data_get_def
                                 ghost_assertion_data_set_def cap_tag_defs)
@@ -3011,7 +2998,8 @@ lemma cancelIPC_ccorres1:
            apply (clarsimp simp add: guard_is_UNIV_def tcbReplySlot_def
                         Kernel_C.tcbReply_def tcbCNodeEntries_def)
           \<comment> \<open>BlockedOnNotification\<close>
-          apply (simp add: word_sle_def "StrictC'_thread_state_defs" ccorres_cond_iffs dc_def [symmetric] cong: call_ignore_cong)
+          apply (simp add: word_sle_def "StrictC'_thread_state_defs" ccorres_cond_iffs
+                     cong: call_ignore_cong)
           apply (rule ccorres_symb_exec_r)
             apply (ctac (no_vcg))
            apply clarsimp
@@ -3020,10 +3008,12 @@ lemma cancelIPC_ccorres1:
           apply (rule conseqPre, vcg)
           apply clarsimp
          \<comment> \<open>Running, Inactive, and Idle\<close>
-         apply (simp add: word_sle_def "StrictC'_thread_state_defs" ccorres_cond_iffs dc_def [symmetric] cong: call_ignore_cong,
+         apply (simp add: word_sle_def "StrictC'_thread_state_defs" ccorres_cond_iffs
+                    cong: call_ignore_cong,
                 rule ccorres_return_Skip)+
       \<comment> \<open>BlockedOnSend\<close>
-      apply (simp add: word_sle_def "StrictC'_thread_state_defs" ccorres_cond_iffs dc_def [symmetric] cong: call_ignore_cong)
+      apply (simp add: word_sle_def "StrictC'_thread_state_defs" ccorres_cond_iffs
+                 cong: call_ignore_cong)
       \<comment> \<open>clag\<close>
       apply (rule ccorres_rhs_assoc)+
       apply csymbr
@@ -3049,7 +3039,8 @@ lemma cancelIPC_ccorres1:
       apply (rule conseqPre, vcg)
       apply clarsimp
   \<comment> \<open>Restart\<close>
-     apply (simp add: word_sle_def "StrictC'_thread_state_defs" ccorres_cond_iffs dc_def [symmetric] cong: call_ignore_cong,
+     apply (simp add: word_sle_def "StrictC'_thread_state_defs" ccorres_cond_iffs
+                cong: call_ignore_cong,
             rule ccorres_return_Skip)
     \<comment> \<open>Post wp proofs\<close>
     apply vcg

--- a/proof/crefine/ARM/Ipc_C.thy
+++ b/proof/crefine/ARM/Ipc_C.thy
@@ -1428,61 +1428,62 @@ proof -
       apply ceqv
      apply (rule ccorres_Cond_rhs)
       apply (simp del: Collect_const)
-      apply (rule ccorres_rel_imp[where r = "\<lambda>rv rv'. True", simplified])
-      apply (rule_tac F="\<lambda>_. obj_at' (\<lambda>tcb. map ((atcbContext o tcbArch) tcb) ARM_H.syscallMessage = msg)
-                                       sender and valid_pspace'
-                                       and (case recvBuffer of Some x \<Rightarrow> valid_ipc_buffer_ptr' x | None \<Rightarrow> \<top>)"
-                           in ccorres_mapM_x_while'[where i="unat n_msgRegisters"])
-          apply (clarsimp simp: setMR_def n_msgRegisters_def length_msgRegisters
-                                          option_to_0_def liftM_def[symmetric]
-                                   split: option.split_asm)
-          apply (rule ccorres_guard_imp2)
-          apply (rule_tac t=sender and r="ARM_H.syscallMessage ! (n + unat n_msgRegisters)"
-                                   in ccorres_add_getRegister)
-          apply (ctac(no_vcg))
-           apply (rule_tac P="\<lambda>s. rv = msg ! (n + unat n_msgRegisters)"
-                           in ccorres_cross_over_guard)
-           apply (rule ccorres_move_array_assertion_ipc_buffer
-                 | (rule ccorres_flip_Guard, rule ccorres_move_array_assertion_ipc_buffer))+
-           apply (simp add: storeWordUser_def)
-           apply (rule ccorres_pre_stateAssert)
-           apply (ctac add: storeWord_ccorres[unfolded fun_app_def])
-          apply (simp add: pred_conj_def)
-          apply (wp user_getreg_rv)
-         apply (clarsimp simp: n_syscallMessage_def n_msgRegisters_def
-                               syscallMessage_ccorres msgRegisters_ccorres
-                               unat_add_lem[THEN iffD1] unat_of_nat32
-                               word_bits_def word_size_def)
-         apply (simp only:field_simps imp_ex imp_conjL)
-         apply (clarsimp simp: pointerInUserData_c_guard obj_at'_def
-                               pointerInUserData_h_t_valid
-                               atcbContextGet_def
-                               projectKOs objBits_simps word_less_nat_alt
-                               unat_add_lem[THEN iffD1] unat_of_nat)
-         apply (clarsimp simp: pointerInUserData_h_t_valid rf_sr_def
-                               MessageID_Syscall_def
-                               msg_align_bits valid_ipc_buffer_ptr'_def)
-         apply (erule aligned_add_aligned)
-          apply (rule aligned_add_aligned[where n=2])
-            apply (simp add: is_aligned_def)
-           apply (rule is_aligned_mult_triv2 [where n=2, simplified])
-           apply (simp)+
-         apply (simp add: n_msgRegisters_def)
-        apply (vcg exspec=getRegister_modifies)
-        apply simp
-       apply (simp add: setMR_def n_msgRegisters_def length_msgRegisters)
-       apply (rule hoare_pre)
-        apply (wp hoare_case_option_wp | wpc)+
-       apply clarsimp
-      apply (simp add: n_msgRegisters_def word_bits_def)
-     apply (simp add: n_msgRegisters_def)
+      apply (rule ccorres_rel_imp)
+       apply (rule_tac F="\<lambda>_. obj_at' (\<lambda>tcb. map ((atcbContext o tcbArch) tcb) ARM_H.syscallMessage = msg)
+                                        sender and valid_pspace'
+                                        and (case recvBuffer of Some x \<Rightarrow> valid_ipc_buffer_ptr' x | None \<Rightarrow> \<top>)"
+                            in ccorres_mapM_x_while'[where i="unat n_msgRegisters"])
+           apply (clarsimp simp: setMR_def n_msgRegisters_def length_msgRegisters
+                                           option_to_0_def liftM_def[symmetric]
+                                    split: option.split_asm)
+           apply (rule ccorres_guard_imp2)
+            apply (rule_tac t=sender and r="ARM_H.syscallMessage ! (n + unat n_msgRegisters)"
+                                     in ccorres_add_getRegister)
+            apply (ctac(no_vcg))
+             apply (rule_tac P="\<lambda>s. rv = msg ! (n + unat n_msgRegisters)"
+                             in ccorres_cross_over_guard)
+             apply (rule ccorres_move_array_assertion_ipc_buffer
+                   | (rule ccorres_flip_Guard, rule ccorres_move_array_assertion_ipc_buffer))+
+             apply (simp add: storeWordUser_def)
+             apply (rule ccorres_pre_stateAssert)
+             apply (ctac add: storeWord_ccorres[unfolded fun_app_def])
+            apply (simp add: pred_conj_def)
+            apply (wp user_getreg_rv)
+           apply (clarsimp simp: n_syscallMessage_def n_msgRegisters_def
+                                 syscallMessage_ccorres msgRegisters_ccorres
+                                 unat_add_lem[THEN iffD1] unat_of_nat32
+                                 word_bits_def word_size_def)
+           apply (simp only:field_simps imp_ex imp_conjL)
+           apply (clarsimp simp: pointerInUserData_c_guard obj_at'_def
+                                 pointerInUserData_h_t_valid
+                                 atcbContextGet_def
+                                 projectKOs objBits_simps word_less_nat_alt
+                                 unat_add_lem[THEN iffD1] unat_of_nat)
+           apply (clarsimp simp: pointerInUserData_h_t_valid rf_sr_def
+                                 MessageID_Syscall_def
+                                 msg_align_bits valid_ipc_buffer_ptr'_def)
+           apply (erule aligned_add_aligned)
+            apply (rule aligned_add_aligned[where n=2])
+              apply (simp add: is_aligned_def)
+             apply (rule is_aligned_mult_triv2 [where n=2, simplified])
+            apply (simp)+
+          apply (simp add: n_msgRegisters_def)
+         apply (vcg exspec=getRegister_modifies)
+         apply simp
+        apply (simp add: setMR_def n_msgRegisters_def length_msgRegisters)
+        apply (rule hoare_pre)
+         apply (wp hoare_case_option_wp | wpc)+
+        apply clarsimp
+       apply (simp add: n_msgRegisters_def word_bits_def)
+      apply (simp add: n_msgRegisters_def)
+     apply simp
      apply (frule (1) option_to_0_imp)
      apply (subst drop_zip)
      apply (subst drop_n)
      apply (clarsimp simp:  n_msgRegisters_def numeral_eqs
                             mapM_cong[OF msg_aux, simplified numeral_eqs])
      apply (subst mapM_x_return_gen[where w2="()"])
-     apply (rule ccorres_return_Skip[simplified dc_def])
+     apply (rule ccorres_return_Skip)
     apply (clarsimp)
     apply (rule hoare_impI)
     apply (rule mapM_x_wp_inv)
@@ -1866,7 +1867,7 @@ lemma doFaultTransfer_ccorres [corres]:
       apply ceqv
      apply csymbr
      apply (ctac (no_vcg, c_lines 2) add: setMessageInfo_ccorres)
-       apply (ctac add: setRegister_ccorres[unfolded dc_def])
+       apply (ctac add: setRegister_ccorres)
       apply wp
      apply (simp add: badgeRegister_def ARM.badgeRegister_def
                       Kernel_C.badgeRegister_def "StrictC'_register_defs")
@@ -1905,7 +1906,7 @@ lemma unifyFailure_ccorres:
   assumes corr_ac: "ccorres (f \<currency> r) xf P P' hs a c"
   shows "ccorres ((\<lambda>_. dc) \<currency> r) xf P P' hs (unifyFailure a) c"
   using corr_ac
-  apply (simp add: unifyFailure_def rethrowFailure_def const_def o_def
+  apply (simp add: unifyFailure_def rethrowFailure_def const_def
                    handleE'_def throwError_def)
   apply (clarsimp simp: ccorres_underlying_def bind_def split_def return_def
                   split: xstate.splits sum.splits)
@@ -2890,10 +2891,11 @@ lemma ccorres_sequenceE_while':
              Basic (\<lambda>s. i_'_update (\<lambda>_. i_' s + 1) s)))"
   apply (rule ccorres_guard_imp2)
    apply (rule ccorres_symb_exec_r)
-     apply (rule ccorres_sequenceE_while_gen'[where i=0, simplified, where xf_update=i_'_update],
-            (assumption | simp)+)
-       apply (simp add: word_bits_def)
-      apply simp+
+     apply (rule ccorres_rel_imp2)
+       apply (rule ccorres_sequenceE_while_gen'[where i=0, simplified, where xf_update=i_'_update],
+              (assumption | simp)+)
+         apply (simp add: word_bits_def)
+        apply simp+
     apply vcg
    apply (rule conseqPre, vcg)
    apply clarsimp
@@ -3128,7 +3130,7 @@ proof -
     apply (cinit lift: sender_' receiver_' sendBuffer_' receiveBuffer_'
                        canGrant_' badge_' endpoint_'
                  cong: call_ignore_cong)
-     apply (clarsimp cong: call_ignore_cong simp del: dc_simp)
+     apply (clarsimp cong: call_ignore_cong)
      apply (ctac(c_lines 2, no_vcg) add: getMessageInfo_ccorres')
        apply (rule_tac xf'="\<lambda>s. current_extra_caps_' (globals s)"
                    and r'="\<lambda>c c'. interpret_excaps c' = excaps_map c"
@@ -3227,7 +3229,6 @@ lemma replyFromKernel_error_ccorres [corres]:
          apply ((rule ccorres_Guard_Seq)+)?
          apply csymbr
          apply (rule ccorres_abstract_cleanup)
-         apply (fold dc_def)[1]
          apply (rule setMessageInfo_ccorres)
         apply wp
        apply (simp add: Collect_const_mem)
@@ -3296,12 +3297,10 @@ lemma doIPCTransfer_ccorres [corres]:
            apply simp_all[3]
         apply ceqv
        apply csymbr
-       apply (fold dc_def)[1]
        apply ctac
       apply (wp lookupIPCBuffer_not_Some_0 lookupIPCBuffer_aligned)
      apply (clarsimp simp: seL4_Fault_NullFault_def ccorres_cond_iffs
                            fault_to_fault_tag_nonzero)
-     apply (fold dc_def)[1]
      apply ctac
     apply (clarsimp simp: guard_is_UNIV_def option_to_ptr_def split: option.splits)
    apply (rule_tac Q="\<lambda>rv. valid_pspace' and cur_tcb' and tcb_at' sender
@@ -3407,7 +3406,7 @@ proof -
                         n_msgRegisters_def
                         of_nat_less_iff)
        apply ccorres_rewrite
-       apply (rule ccorres_return_Skip[simplified dc_def])
+       apply (rule ccorres_return_Skip)
       apply (wp mapM_wp')
      apply clarsimp+
      apply (clarsimp simp: guard_is_UNIV_def message_info_to_H_def
@@ -3561,7 +3560,6 @@ lemma copyMRsFaultReply_ccorres_syscall:
                  apply (subst aligned_add_aligned, assumption)
                    apply (rule is_aligned_mult_triv2[where n=2, simplified])
                   apply (simp add: msg_align_bits)
-                 apply (simp add: of_nat_unat[simplified comp_def])
                  apply (simp only: n_msgRegisters_def)
                  apply (clarsimp simp: n_syscallMessage_def n_msgRegisters_def
                                        word_unat.Rep_inverse[of "scast _ :: 'a word"]
@@ -3599,8 +3597,8 @@ lemma copyMRsFaultReply_ccorres_syscall:
             apply simp
         apply (subst option.split[symmetric,where P=id, simplified])
         apply (rule valid_drop_case)
-        apply (wp hoare_drop_imps hoare_vcg_all_lift lookupIPCBuffer_aligned[simplified K_def]
-                  lookupIPCBuffer_not_Some_0[simplified K_def])
+        apply (wp hoare_drop_imps hoare_vcg_all_lift lookupIPCBuffer_aligned[simplified]
+                  lookupIPCBuffer_not_Some_0[simplified])
        apply (simp add: length_syscallMessage
                         length_msgRegisters
                         n_syscallMessage_def
@@ -3612,7 +3610,7 @@ lemma copyMRsFaultReply_ccorres_syscall:
        apply (rule ccorres_guard_imp)
          apply (rule ccorres_symb_exec_l)
             apply (case_tac rva; clarsimp)
-             apply (rule ccorres_return_Skip[simplified dc_def])+
+             apply (rule ccorres_return_Skip)+
                 apply (wp mapM_x_wp_inv user_getreg_inv'
                        | clarsimp simp: zipWithM_x_mapM_x split: prod.split)+
      apply (cases  "4 < len")
@@ -3703,7 +3701,7 @@ lemma handleFaultReply_ccorres [corres]:
   apply (unfold K_def, rule ccorres_gen_asm)
   apply (rule monadic_rewrite_ccorres_assemble_nodrop[OF _ handleFaultReply',rotated], simp)
   apply (cinit lift: sender_' receiver_' simp: whileAnno_def)
-   apply (clarsimp simp del: dc_simp)
+   apply clarsimp
    apply (ctac(c_lines 2) add: getMessageInfo_ccorres')
      apply (rename_tac tag tag')
      apply csymbr
@@ -3749,7 +3747,7 @@ lemma handleFaultReply_ccorres [corres]:
                          split del: if_split)
             apply (subst take_min_len[symmetric,where n="unat (msgLength _)"])
             apply (subst take_min_len[symmetric,where n="unat (msgLength _)"])
-            apply (fold bind_assoc id_def)
+            apply (fold bind_assoc)
             apply (ctac add: copyMRsFaultReply_ccorres_syscall[simplified bind_assoc[symmetric]])
               apply (ctac add: ccorres_return_C)
              apply wp
@@ -3964,7 +3962,6 @@ proof -
     apply csymbr
     apply wpc
      apply (clarsimp simp: ccorres_cond_iffs split del: if_split)
-     apply (fold dc_def)[1]
      apply (rule ccorres_rhs_assoc)+
      apply (ctac(no_vcg))
       apply (rule ccorres_symb_exec_r)
@@ -3988,7 +3985,6 @@ proof -
                           fault_to_fault_tag_nonzero
                split del: if_split)
     apply (rule ccorres_rhs_assoc)+
-    apply (fold dc_def)[1]
     apply (rule ccorres_symb_exec_r)
       apply (ctac (no_vcg) add: cteDeleteOne_ccorres[where w="scast cap_reply_cap"])
        apply (rule_tac A'=UNIV in stronger_ccorres_guard_imp)
@@ -4018,7 +4014,6 @@ proof -
                apply (simp only: K_bind_def)
                apply (ctac add: possibleSwitchTo_ccorres)
               apply (wp sts_running_valid_queues setThreadState_st_tcb | simp)+
-            apply (fold dc_def)[1]
              apply (ctac add: setThreadState_ccorres_valid_queues'_simple)
              apply wp
             apply ((wp threadSet_valid_queues threadSet_sch_act threadSet_valid_queues' static_imp_wp
@@ -4090,8 +4085,7 @@ lemma setupCallerCap_ccorres [corres]:
   apply (frule_tac p=sender in is_aligned_tcb_ptr_to_ctcb_ptr)
   apply (cinit lift: sender_' receiver_' canGrant_')
    apply (clarsimp simp: word_sle_def
-                         tcb_cnode_index_defs[THEN ptr_add_assertion_positive[OF ptr_add_assertion_positive_helper]]
-                         , fold dc_def)[1]
+                         tcb_cnode_index_defs[THEN ptr_add_assertion_positive[OF ptr_add_assertion_positive_helper]])
    apply ccorres_remove_UNIV_guard
    apply (ctac(no_vcg))
     apply (rule ccorres_move_array_assertion_tcb_ctes)
@@ -4112,7 +4106,7 @@ lemma setupCallerCap_ccorres [corres]:
         apply (rule ccorres_move_c_guard_cte)
         apply (ctac(no_vcg))
          apply (rule ccorres_assert)
-         apply (simp only: ccorres_seq_skip dc_def[symmetric])
+         apply (simp only: ccorres_seq_skip)
          apply csymbr
          apply (ctac add: cteInsert_ccorres)
         apply simp
@@ -4167,7 +4161,7 @@ lemma sendIPC_dequeue_ccorres_helper:
   apply (rule ccorres_from_vcg)
   apply (rule allI)
   apply (rule conseqPre, vcg)
-  apply (clarsimp split del: if_split simp del: comp_def)
+  apply (clarsimp split del: if_split)
   apply (frule ep_blocked_in_queueD [OF pred_tcb'_weakenE])
      apply simp
     apply assumption+
@@ -4188,7 +4182,7 @@ lemma sendIPC_dequeue_ccorres_helper:
     apply (drule (2) ep_to_ep_queue)
     apply (simp add: tcb_queue_relation'_def)
    apply (clarsimp simp: typ_heap_simps cendpoint_relation_def Let_def
-              cong: imp_cong split del: if_split simp del: comp_def)
+                   cong: imp_cong split del: if_split)
   apply (intro conjI impI allI)
      apply (fastforce simp: h_t_valid_clift)
     apply (fastforce simp: h_t_valid_clift)
@@ -4541,7 +4535,7 @@ lemma sendIPC_enqueue_ccorres_helper:
   apply (rule ccorres_gen_asm)
   apply (rule ccorres_from_vcg)
   apply (rule allI, rule conseqPre, vcg)
-  apply (clarsimp split del: if_split simp del: comp_def)
+  apply (clarsimp split del: if_split)
   apply (frule cmap_relation_ep)
   apply (erule (1) cmap_relation_ko_atE)
   apply (rule conjI)
@@ -4738,12 +4732,9 @@ lemma sendIPC_ccorres [corres]:
               apply (clarsimp simp: disj_imp[symmetric] split del: if_split)
               apply (wpc ; clarsimp)
                apply ccorres_rewrite
-               apply (fold dc_def)[1]
                apply (ctac add: setupCallerCap_ccorres)
               apply ccorres_rewrite
-              apply (fold dc_def)[1]
               apply (ctac add: setThreadState_ccorres)
-             apply (fold dc_def)[1]
              apply (rule ccorres_return_Skip)
             apply (wpsimp wp: hoare_drop_imps hoare_vcg_all_lift possibleSwitchTo_sch_act_not
                               possibleSwitchTo_sch_act_not sts_st_tcb'
@@ -4940,7 +4931,7 @@ lemma receiveIPC_enqueue_ccorres_helper:
   apply (rule ccorres_gen_asm)
   apply (rule ccorres_from_vcg)
   apply (rule allI, rule conseqPre, vcg)
-  apply (clarsimp split del: if_split simp del: comp_def)
+  apply (clarsimp split del: if_split)
   apply (frule cmap_relation_ep)
   apply (erule (1) cmap_relation_ko_atE)
   apply (rule conjI)
@@ -5066,7 +5057,7 @@ lemma receiveIPC_dequeue_ccorres_helper:
   apply (rule ccorres_from_vcg)
   apply (rule allI)
   apply (rule conseqPre, vcg)
-  apply (clarsimp split del: if_split simp del: comp_def)
+  apply (clarsimp split del: if_split)
   apply (frule ep_blocked_in_queueD [OF pred_tcb'_weakenE])
      apply simp
     apply assumption+
@@ -5087,7 +5078,7 @@ lemma receiveIPC_dequeue_ccorres_helper:
     apply (drule (2) ep_to_ep_queue)
     apply (simp add: tcb_queue_relation'_def)
    apply (clarsimp simp: typ_heap_simps cendpoint_relation_def Let_def
-              cong: imp_cong split del: if_split simp del: comp_def)
+                   cong: imp_cong split del: if_split)
   apply (intro conjI impI allI)
      apply (fastforce simp: h_t_valid_clift)
     apply (fastforce simp: h_t_valid_clift)
@@ -5236,7 +5227,7 @@ lemma completeSignal_ccorres:
         apply (erule(1) cmap_relation_ko_atE[OF cmap_relation_ntfn])
         apply (clarsimp simp: cnotification_relation_def Let_def typ_heap_simps)
        apply ceqv
-      apply (fold dc_def, ctac(no_vcg))
+      apply (ctac(no_vcg))
        apply (rule_tac P="invs' and ko_at' ntfn ntfnptr" and P'=UNIV in ccorres_from_vcg)
        apply (rule allI, rule conseqPre, vcg)
        apply (clarsimp)
@@ -5350,7 +5341,7 @@ lemma receiveIPC_ccorres [corres]:
          apply ceqv
         apply (rule ccorres_cond[where R=\<top>])
           apply (simp add: Collect_const_mem)
-         apply (ctac add: completeSignal_ccorres[unfolded dc_def])
+         apply (ctac add: completeSignal_ccorres)
         apply (rule_tac xf'=ret__unsigned_'
                     and val="case ep of IdleEP \<Rightarrow> scast EPState_Idle
                             | RecvEP _ \<Rightarrow> scast EPState_Recv
@@ -5380,20 +5371,18 @@ lemma receiveIPC_ccorres [corres]:
              apply (rule ccorres_rhs_assoc2)
              apply (rule ccorres_rhs_assoc2)
              apply (rule ccorres_split_nothrow_novcg)
-                 apply (simp split del: if_split)
                  apply (rule receiveIPC_block_ccorres_helper[unfolded ptr_val_def, simplified])
                 apply ceqv
                apply simp
                apply (rename_tac list NOo)
-               apply (rule_tac ep="RecvEP list"
-                               in receiveIPC_enqueue_ccorres_helper[simplified, unfolded dc_def])
+               apply (rule_tac ep="RecvEP list" in receiveIPC_enqueue_ccorres_helper[simplified])
               apply (simp add: valid_ep'_def)
               apply (wp sts_st_tcb')
              apply (rename_tac list)
              apply (clarsimp simp: obj_at'_def ko_wp_at'_def projectKOs)
              apply (clarsimp simp: guard_is_UNIV_def)
             apply simp
-             apply (ctac add: doNBRecvFailedTransfer_ccorres[unfolded dc_def])
+             apply (ctac add: doNBRecvFailedTransfer_ccorres)
            \<comment> \<open>IdleEP case\<close>
            apply (rule ccorres_cond_true)
            apply csymbr
@@ -5405,18 +5394,16 @@ lemma receiveIPC_ccorres [corres]:
             apply (rule ccorres_rhs_assoc2)
             apply (rule ccorres_rhs_assoc2)
             apply (rule ccorres_split_nothrow_novcg)
-                apply (simp split del: if_split)
                 apply (rule receiveIPC_block_ccorres_helper[unfolded ptr_val_def, simplified])
                apply ceqv
               apply simp
-              apply (rule_tac ep=IdleEP
-                        in receiveIPC_enqueue_ccorres_helper[simplified, unfolded dc_def])
+              apply (rule_tac ep=IdleEP in receiveIPC_enqueue_ccorres_helper[simplified])
              apply (simp add: valid_ep'_def)
              apply (wp sts_st_tcb')
             apply (clarsimp simp: obj_at'_def ko_wp_at'_def projectKOs)
             apply (clarsimp simp: guard_is_UNIV_def)
            apply simp
-            apply (ctac add: doNBRecvFailedTransfer_ccorres[unfolded dc_def])
+            apply (ctac add: doNBRecvFailedTransfer_ccorres)
           \<comment> \<open>SendEP case\<close>
           apply (thin_tac "isBlockinga = from_bool P" for P)
           apply (rule ccorres_cond_false)
@@ -5494,8 +5481,6 @@ lemma receiveIPC_ccorres [corres]:
                                   split: Structures_H.thread_state.splits)
                   apply ceqv
 
-                 apply (fold dc_def)
-                 supply dc_simp[simp del]
                  apply (clarsimp simp:  from_bool_0 disj_imp[symmetric] simp del: Collect_const)
                  apply wpc
                   (* blocking ipc call *)
@@ -5574,12 +5559,12 @@ lemma receiveIPC_ccorres [corres]:
             apply (clarsimp simp:st_tcb_at_refs_of_rev')
             apply (erule_tac x=x and P="\<lambda>x. st_tcb_at' P x s" for P in ballE)
              apply (drule_tac t=x in valid_queues_not_runnable'_not_ksQ)
-              apply (clarsimp simp: st_tcb_at'_def obj_at'_def o_def)
+              apply (clarsimp simp: st_tcb_at'_def obj_at'_def)
              apply (subgoal_tac "sch_act_not x s")
               prefer 2
               apply (frule invs_sch_act_wf')
               apply (clarsimp simp:sch_act_wf_def)
-              apply (clarsimp simp: st_tcb_at'_def obj_at'_def o_def)
+              apply (clarsimp simp: st_tcb_at'_def obj_at'_def)
              apply (clarsimp simp: obj_at'_def st_tcb_at'_def
                                    projectKOs isBlockedOnSend_def
                              split: list.split | rule conjI)+
@@ -5607,11 +5592,10 @@ lemma sendSignal_dequeue_ccorres_helper:
          IF head_C \<acute>ntfn_queue = Ptr 0 THEN
              CALL notification_ptr_set_state(Ptr ntfn,scast NtfnState_Idle)
          FI)"
-
   apply (rule ccorres_from_vcg)
   apply (rule allI)
   apply (rule conseqPre, vcg)
-  apply (clarsimp split del: if_split simp del: comp_def)
+  apply (clarsimp split del: if_split)
   apply (frule (2) ntfn_blocked_in_queueD)
   apply (frule (1) ko_at_valid_ntfn' [OF _ invs_valid_objs'])
   apply (elim conjE)
@@ -5631,7 +5615,7 @@ lemma sendSignal_dequeue_ccorres_helper:
     apply (drule ntfn_to_ep_queue, (simp add: isWaitingNtfn_def)+)
     apply (simp add: tcb_queue_relation'_def)
    apply (clarsimp simp: typ_heap_simps cnotification_relation_def Let_def
-              cong: imp_cong split del: if_split simp del: comp_def)
+                   cong: imp_cong split del: if_split)
   apply (intro conjI impI allI)
      apply (fastforce simp: h_t_valid_clift)
     apply (fastforce simp: h_t_valid_clift)
@@ -5805,7 +5789,7 @@ lemma sendSignal_ccorres [corres]:
        apply wpc
         apply (simp add: option_to_ctcb_ptr_def split del: if_split)
         apply (rule ccorres_cond_false)
-        apply (ctac add: ntfn_set_active_ccorres[unfolded dc_def])
+        apply (ctac add: ntfn_set_active_ccorres)
        apply (rule ccorres_cond_true)
        apply (rule getThreadState_ccorres_foo)
        apply (rule ccorres_Guard_Seq)
@@ -5820,7 +5804,7 @@ lemma sendSignal_ccorres [corres]:
         apply (ctac(no_vcg) add: cancelIPC_ccorres1[OF cteDeleteOne_ccorres])
          apply (ctac(no_vcg) add: setThreadState_ccorres)
           apply (ctac(no_vcg) add: setRegister_ccorres)
-           apply (ctac add: possibleSwitchTo_ccorres[unfolded dc_def])
+           apply (ctac add: possibleSwitchTo_ccorres)
           apply (wp sts_running_valid_queues sts_st_tcb_at'_cases
                  | simp add: option_to_ctcb_ptr_def split del: if_split)+
         apply (rule_tac Q="\<lambda>_. tcb_at' (the (ntfnBoundTCB ntfn)) and invs'"
@@ -5828,7 +5812,7 @@ lemma sendSignal_ccorres [corres]:
          apply auto[1]
         apply wp
        apply simp
-       apply (ctac add: ntfn_set_active_ccorres[unfolded dc_def])
+       apply (ctac add: ntfn_set_active_ccorres)
       apply (clarsimp simp: guard_is_UNIV_def option_to_ctcb_ptr_def
                             ARM_H.badgeRegister_def Kernel_C.badgeRegister_def
                             ARM.badgeRegister_def Kernel_C.R0_def
@@ -5884,7 +5868,7 @@ lemma sendSignal_ccorres [corres]:
        apply ceqv
       apply (simp only: K_bind_def)
       apply (ctac (no_vcg))
-       apply (simp, fold dc_def)
+       apply simp
        apply (ctac (no_vcg))
         apply (ctac add: possibleSwitchTo_ccorres)
        apply (simp)
@@ -6034,7 +6018,7 @@ lemma receiveSignal_enqueue_ccorres_helper:
   apply (rule ccorres_gen_asm)
   apply (rule ccorres_from_vcg)
   apply (rule allI, rule conseqPre, vcg)
-  apply (clarsimp split del: if_split simp del: comp_def)
+  apply (clarsimp split del: if_split)
   apply (frule cmap_relation_ntfn)
   apply (erule (1) cmap_relation_ko_atE)
   apply (rule conjI)
@@ -6192,11 +6176,10 @@ lemma receiveSignal_ccorres [corres]:
         apply (rule ccorres_rhs_assoc2)
         apply (rule ccorres_rhs_assoc2)
         apply (rule ccorres_split_nothrow_novcg)
-            apply (simp)
             apply (rule receiveSignal_block_ccorres_helper[simplified])
            apply ceqv
           apply (simp only: K_bind_def)
-          apply (rule receiveSignal_enqueue_ccorres_helper[unfolded dc_def, simplified])
+          apply (rule receiveSignal_enqueue_ccorres_helper[simplified])
          apply (simp add: valid_ntfn'_def)
          apply (wp sts_st_tcb')
          apply (rule_tac Q="\<lambda>rv. ko_wp_at' (\<lambda>x. projectKO_opt x = Some ntfn
@@ -6207,7 +6190,7 @@ lemma receiveSignal_ccorres [corres]:
          apply wp
         apply (clarsimp simp: guard_is_UNIV_def)
        apply simp
-       apply (ctac add: doNBRecvFailedTransfer_ccorres[unfolded dc_def])
+       apply (ctac add: doNBRecvFailedTransfer_ccorres)
       \<comment> \<open>ActiveNtfn case\<close>
       apply (rename_tac badge)
       apply (rule ccorres_cond_false)
@@ -6263,8 +6246,7 @@ lemma receiveSignal_ccorres [corres]:
           apply (rule receiveSignal_block_ccorres_helper[simplified])
          apply ceqv
         apply (simp only: K_bind_def)
-        apply (rule_tac ntfn="ntfn"
-                           in receiveSignal_enqueue_ccorres_helper[unfolded dc_def, simplified])
+        apply (rule_tac ntfn="ntfn" in receiveSignal_enqueue_ccorres_helper[simplified])
        apply (simp add: valid_ntfn'_def)
        apply (wp sts_st_tcb')
        apply (rule_tac Q="\<lambda>rv. ko_wp_at' (\<lambda>x. projectKO_opt x = Some ntfn
@@ -6276,7 +6258,7 @@ lemma receiveSignal_ccorres [corres]:
        apply wp
       apply (clarsimp simp: guard_is_UNIV_def)
      apply simp
-     apply (ctac add: doNBRecvFailedTransfer_ccorres[unfolded dc_def])
+     apply (ctac add: doNBRecvFailedTransfer_ccorres)
     apply (clarsimp simp: guard_is_UNIV_def NtfnState_Active_def
                           NtfnState_Waiting_def NtfnState_Idle_def)
    apply (clarsimp simp: guard_is_UNIV_def)

--- a/proof/crefine/ARM/IsolatedThreadAction.thy
+++ b/proof/crefine/ARM/IsolatedThreadAction.thy
@@ -443,7 +443,7 @@ lemma modify_isolatable:
                    liftM_def bind_assoc)
   apply (clarsimp simp: monadic_rewrite_def exec_gets
                    getSchedulerAction_def)
-  apply (simp add: simpler_modify_def o_def)
+  apply (simp add: simpler_modify_def)
   apply (subst swap)
    apply (simp add: obj_at_partial_overwrite_If)
   apply (simp add: ksPSpace_update_partial_id o_def)
@@ -1094,8 +1094,7 @@ lemma setCTE_isolatable:
    apply (erule notE[rotated], erule (3) tcb_ctes_clear[rotated])
   apply (simp add: select_f_returns select_f_asserts split: if_split)
   apply (intro conjI impI)
-    apply (clarsimp simp: simpler_modify_def fun_eq_iff
-                          partial_overwrite_fun_upd2 o_def
+    apply (clarsimp simp: simpler_modify_def fun_eq_iff partial_overwrite_fun_upd2
                   intro!: kernel_state.fold_congs[OF refl refl])
     apply (clarsimp simp: obj_at'_def projectKOs objBits_simps)
     apply (erule notE[rotated], rule tcb_ctes_clear[rotated 2], assumption+)

--- a/proof/crefine/ARM/Machine_C.thy
+++ b/proof/crefine/ARM/Machine_C.thy
@@ -413,13 +413,13 @@ lemma cleanCacheRange_PoC_ccorres:
    apply (clarsimp simp: cleanCacheRange_PoC_def word_sle_def whileAnno_def)
    apply (ccorres_remove_UNIV_guard)
    apply csymbr
-   apply (rule cacheRangeOp_ccorres[simplified dc_def])
+   apply (rule cacheRangeOp_ccorres)
      apply (rule empty_fail_cleanByVA)
     apply clarsimp
   apply (cinitlift index_')
     apply (rule ccorres_guard_imp2)
      apply csymbr
-     apply (ctac add: cleanByVA_ccorres[unfolded dc_def])
+     apply (ctac add: cleanByVA_ccorres)
     apply (clarsimp simp: lineStart_def cacheLineBits_def shiftr_shiftl1
                           mask_out_sub_mask)
     apply (drule_tac s="w1 && mask 5" in sym, simp add: cache_range_lineIndex_helper)
@@ -460,8 +460,8 @@ lemma cleanInvalidateCacheRange_RAM_ccorres:
              apply (drule_tac s="w1 && mask 5" in sym, simp add: cache_range_lineIndex_helper)
             apply (vcg exspec=cleanInvalByVA_modifies)
            apply (rule ceqv_refl)
-          apply (ctac (no_vcg) add: dsb_ccorres[simplified dc_def])
-       apply (wp | clarsimp simp: guard_is_UNIVI o_def)+
+          apply (ctac (no_vcg) add: dsb_ccorres)
+       apply (wp | clarsimp simp: guard_is_UNIVI)+
   apply (frule(1) ghost_assertion_size_logic)
   apply (clarsimp simp: o_def)
   done
@@ -484,7 +484,7 @@ lemma cleanCacheRange_RAM_ccorres:
         in ccorres_cross_over_guard)
      apply (rule ccorres_Guard_Seq)
      apply (rule ccorres_basic_srnoop2, simp)
-     apply (ctac (no_vcg) add: cleanL2Range_ccorres[unfolded dc_def])
+     apply (ctac (no_vcg) add: cleanL2Range_ccorres)
     apply wp+
   apply clarsimp
   apply (auto dest: ghost_assertion_size_logic simp: o_def)
@@ -505,13 +505,13 @@ lemma cleanCacheRange_PoU_ccorres:
    apply (rule ccorres_basic_srnoop2, simp)
    apply (simp add: cleanCacheRange_PoU_def)
    apply csymbr
-   apply (rule cacheRangeOp_ccorres[simplified dc_def])
+   apply (rule cacheRangeOp_ccorres)
      apply (rule empty_fail_cleanByVA_PoU)
     apply clarsimp
     apply (cinitlift index_')
     apply (rule ccorres_guard_imp2)
      apply csymbr
-     apply (ctac add: cleanByVA_PoU_ccorres[unfolded dc_def])
+     apply (ctac add: cleanByVA_PoU_ccorres)
     apply (clarsimp simp: lineStart_def cacheLineBits_def shiftr_shiftl1
                           mask_out_sub_mask)
     apply (drule_tac s="w1 && mask 5" in sym, simp add: cache_range_lineIndex_helper)
@@ -544,14 +544,14 @@ lemma invalidateCacheRange_RAM_ccorres:
        apply (rule ccorres_cond[where R=\<top>])
          apply (clarsimp simp: lineStart_def cacheLineBits_def)
         apply (rule ccorres_call[OF cleanCacheRange_RAM_ccorres, where xf'=xfdc], (clarsimp)+)
-       apply (rule ccorres_return_Skip[unfolded dc_def])
+       apply (rule ccorres_return_Skip)
       apply ceqv
      apply (rule ccorres_split_nothrow_novcg)
          apply (rule ccorres_cond[where R=\<top>])
            apply (clarsimp simp: lineStart_def cacheLineBits_def)
           apply csymbr
           apply (rule ccorres_call[OF cleanCacheRange_RAM_ccorres, where xf'=xfdc], (clarsimp)+)
-         apply (rule ccorres_return_Skip[unfolded dc_def])
+         apply (rule ccorres_return_Skip)
         apply ceqv
        apply (rule_tac P="\<lambda>s. unat (w2 - w1) \<le> gsMaxObjectSize s"
           in ccorres_cross_over_guard)
@@ -574,7 +574,7 @@ lemma invalidateCacheRange_RAM_ccorres:
               apply (drule_tac s="w1 && mask 5" in sym, simp add: cache_range_lineIndex_helper)
              apply (vcg exspec=invalidateByVA_modifies)
             apply ceqv
-           apply (ctac add: dsb_ccorres[unfolded dc_def])
+           apply (ctac add: dsb_ccorres)
           apply wp
          apply (simp add: guard_is_UNIV_def)
         apply wp
@@ -602,13 +602,13 @@ lemma invalidateCacheRange_I_ccorres:
    apply (ccorres_remove_UNIV_guard)
    apply (simp add: invalidateCacheRange_I_def)
    apply csymbr
-   apply (rule cacheRangeOp_ccorres[simplified dc_def])
+   apply (rule cacheRangeOp_ccorres)
      apply (rule empty_fail_invalidateByVA_I)
     apply clarsimp
     apply (cinitlift index_')
     apply (rule ccorres_guard_imp2)
      apply csymbr
-     apply (ctac add: invalidateByVA_I_ccorres[unfolded dc_def])
+     apply (ctac add: invalidateByVA_I_ccorres)
     apply (clarsimp simp: lineStart_def cacheLineBits_def shiftr_shiftl1
                           mask_out_sub_mask)
     apply (drule_tac s="w1 && mask 5" in sym, simp add: cache_range_lineIndex_helper)
@@ -628,13 +628,13 @@ lemma branchFlushRange_ccorres:
    apply (ccorres_remove_UNIV_guard)
    apply (simp add: branchFlushRange_def)
    apply csymbr
-   apply (rule cacheRangeOp_ccorres[simplified dc_def])
+   apply (rule cacheRangeOp_ccorres)
      apply (rule empty_fail_branchFlush)
     apply clarsimp
     apply (cinitlift index_')
     apply (rule ccorres_guard_imp2)
      apply csymbr
-     apply (ctac add: branchFlush_ccorres[unfolded dc_def])
+     apply (ctac add: branchFlush_ccorres)
     apply (clarsimp simp: lineStart_def cacheLineBits_def shiftr_shiftl1
                           mask_out_sub_mask)
     apply (drule_tac s="w1 && mask 5" in sym, simp add: cache_range_lineIndex_helper)

--- a/proof/crefine/ARM/Recycle_C.thy
+++ b/proof/crefine/ARM/Recycle_C.thy
@@ -304,8 +304,8 @@ lemma invalidateTLBByASID_ccorres:
     apply (simp add: case_option_If2 del: Collect_const)
     apply (rule ccorres_if_cond_throws2[where Q=\<top> and Q'=\<top>])
        apply (clarsimp simp: pde_stored_asid_def to_bool_def split: if_split)
-      apply (rule ccorres_return_void_C[unfolded dc_def])
-     apply (simp add: dc_def[symmetric])
+      apply (rule ccorres_return_void_C)
+     apply simp
      apply csymbr
      apply (ctac add: invalidateTranslationASID_ccorres)
     apply vcg
@@ -594,13 +594,13 @@ lemma cancelBadgedSends_ccorres:
                      split: Structures_H.endpoint.split_asm)
      apply ceqv
     apply wpc
-      apply (simp add: dc_def[symmetric] ccorres_cond_iffs)
+      apply (simp add: ccorres_cond_iffs)
       apply (rule ccorres_return_Skip)
-     apply (simp add: dc_def[symmetric] ccorres_cond_iffs)
+     apply (simp add: ccorres_cond_iffs)
      apply (rule ccorres_return_Skip)
     apply (rename_tac list)
     apply (simp add: Collect_True Collect_False endpoint_state_defs
-                     ccorres_cond_iffs dc_def[symmetric]
+                     ccorres_cond_iffs
                 del: Collect_const cong: call_ignore_cong)
     apply (rule ccorres_rhs_assoc)+
     apply (csymbr, csymbr)
@@ -684,7 +684,7 @@ lemma cancelBadgedSends_ccorres:
                 subgoal by (simp add: tcb_queue_relation'_def EPState_Send_def mask_def)
                subgoal by (auto split: if_split)
               subgoal by simp
-             apply (ctac add: rescheduleRequired_ccorres[unfolded dc_def])
+             apply (ctac add: rescheduleRequired_ccorres)
             apply (rule hoare_pre, wp weak_sch_act_wf_lift_linear set_ep_valid_objs')
             apply (clarsimp simp: weak_sch_act_wf_def sch_act_wf_def)
             apply (fastforce simp: valid_ep'_def pred_tcb_at' split: list.splits)
@@ -694,7 +694,7 @@ lemma cancelBadgedSends_ccorres:
           apply (rule iffD1 [OF ccorres_expand_while_iff_Seq])
           apply (rule ccorres_init_tmp_lift2, ceqv)
           apply (rule ccorres_guard_imp2)
-           apply (simp add: bind_assoc dc_def[symmetric]
+           apply (simp add: bind_assoc
                        del: Collect_const)
            apply (rule ccorres_cond_true)
            apply (rule ccorres_rhs_assoc)+
@@ -721,7 +721,7 @@ lemma cancelBadgedSends_ccorres:
             apply ceqv
            apply (rule_tac P="ret__unsigned=blockingIPCBadge rva" in ccorres_gen_asm2)
            apply (rule ccorres_if_bind, rule ccorres_if_lhs)
-            apply (simp add: bind_assoc dc_def[symmetric])
+            apply (simp add: bind_assoc)
             apply (rule ccorres_rhs_assoc)+
             apply (ctac add: setThreadState_ccorres)
               apply (ctac add: tcbSchedEnqueue_ccorres)
@@ -772,8 +772,8 @@ lemma cancelBadgedSends_ccorres:
                     apply (drule_tac x=p in spec)
                     subgoal by fastforce
                    apply (rule conjI)
-                    apply (erule cready_queues_relation_not_queue_ptrs,
-                           auto dest: null_ep_schedD[unfolded o_def] simp: o_def)[1]
+                    apply (erule cready_queues_relation_not_queue_ptrs;
+                           fastforce dest: null_ep_schedD[unfolded o_def] simp: o_def)
                    apply (simp add: carch_state_relation_def
                                     cmachine_state_relation_def
                                     h_t_valid_clift_Some_iff)
@@ -791,9 +791,9 @@ lemma cancelBadgedSends_ccorres:
              apply (wp hoare_vcg_const_Ball_lift sts_st_tcb_at'_cases
                        sts_sch_act sts_valid_queues setThreadState_oa_queued)
             apply (vcg exspec=setThreadState_cslift_spec)
-           apply (simp add: ccorres_cond_iffs dc_def[symmetric])
+           apply (simp add: ccorres_cond_iffs)
            apply (rule ccorres_symb_exec_r2)
-             apply (drule_tac x="x @ [a]" in spec, simp add: dc_def[symmetric])
+             apply (drule_tac x="x @ [a]" in spec, simp)
             apply vcg
            apply (vcg spec=modifies)
           apply (thin_tac "\<forall>x. P x" for P)

--- a/proof/crefine/ARM/Refine_C.thy
+++ b/proof/crefine/ARM/Refine_C.thy
@@ -633,9 +633,9 @@ lemma callKernel_withFastpath_corres_C:
    apply (rule ccorres_rhs_assoc)+
    apply (rule ccorres_symb_exec_r)+
        apply (rule ccorres_Cond_rhs)
-        apply (simp add: dc_def[symmetric])
+        apply simp
         apply (ctac add: ccorres_get_registers[OF fastpath_call_ccorres_callKernel])
-       apply (simp add: dc_def[symmetric])
+       apply simp
        apply (ctac add: ccorres_get_registers[OF fastpath_reply_recv_ccorres_callKernel])
       apply vcg
      apply (rule conseqPre, vcg, clarsimp)
@@ -713,12 +713,12 @@ lemma entry_corres_C:
          apply (rule setTCBContext_C_corres, rule ccontext_rel_to_C, simp)
         apply simp
         apply (rule corres_split)
-           apply (rule corres_cases[where R=fp], simp_all add: dc_def[symmetric])[1]
-            apply (rule callKernel_withFastpath_corres_C, simp)
-           apply (rule callKernel_corres_C[unfolded dc_def], simp)
+           apply (rule corres_cases[where R=fp]; simp)
+            apply (rule callKernel_withFastpath_corres_C)
+           apply (rule callKernel_corres_C)
           apply (rule corres_split[where P=\<top> and P'=\<top> and r'="\<lambda>t t'. t' = tcb_ptr_to_ctcb_ptr t"])
              apply (clarsimp simp: rf_sr_def cstate_relation_def Let_def)
-            apply (rule getContext_corres[unfolded o_def], simp)
+            apply (rule getContext_corres, simp)
            apply (wp threadSet_all_invs_triv' callKernel_cur)+
    apply (clarsimp simp: all_invs'_def invs'_def cur_tcb'_def valid_state'_def)
   apply simp
@@ -915,7 +915,7 @@ lemma do_user_op_corres_C:
                apply (clarsimp simp: rf_sr_def cstate_relation_def Let_def
                                cpspace_relation_def)
                apply (drule(1) device_mem_C_relation[symmetric])
-               apply (simp add: comp_def)
+               apply simp
               apply (rule_tac P=valid_state' and P'=\<top> and r'="(=)" in corres_split)
                  apply (clarsimp simp: cstate_relation_def rf_sr_def
                    Let_def cmachine_state_relation_def)

--- a/proof/crefine/ARM/Retype_C.thy
+++ b/proof/crefine/ARM/Retype_C.thy
@@ -816,7 +816,7 @@ lemma ptr_add_to_new_cap_addrs:
   shows "(CTypesDefs.ptr_add (Ptr ptr :: 'a :: mem_type ptr) \<circ> of_nat) ` {k. k < n}
    = Ptr ` set (new_cap_addrs n ptr ko)"
   unfolding new_cap_addrs_def
-  apply (simp add: comp_def image_image shiftl_t2n size_of_m field_simps)
+  apply (simp add: image_image shiftl_t2n size_of_m field_simps)
   apply (clarsimp simp: atLeastLessThan_def lessThan_def)
   done
 
@@ -3859,12 +3859,10 @@ lemma ccorres_placeNewObject_endpoint:
      apply (clarsimp simp: new_cap_addrs_def)
      apply (cut_tac createObjects_ccorres_ep [where ptr=regionBase and n="1" and sz="objBitsKO (KOEndpoint makeObject)"])
      apply (erule_tac x=\<sigma> in allE, erule_tac x=x in allE)
-     apply (clarsimp elim!:is_aligned_weaken simp: objBitsKO_def word_bits_def)+
-     apply (clarsimp simp: split_def Let_def
-         Fun.comp_def rf_sr_def new_cap_addrs_def
-         region_actually_is_bytes ptr_retyps_gen_def
-         objBits_simps
-         elim!: rsubst[where P="cstate_relation s'" for s'])
+     apply (clarsimp elim!: is_aligned_weaken simp: objBitsKO_def word_bits_def)+
+     apply (clarsimp simp: split_def Let_def rf_sr_def new_cap_addrs_def
+                           region_actually_is_bytes ptr_retyps_gen_def objBits_simps
+                    elim!: rsubst[where P="cstate_relation s'" for s'])
     apply (clarsimp simp: word_bits_conv)
    apply (clarsimp simp: range_cover.aligned objBits_simps)
   apply (clarsimp simp: no_fail_def)
@@ -4947,7 +4945,7 @@ proof -
              apply (simp add: obj_at'_real_def)
              apply (wp placeNewObject_ko_wp_at')
             apply vcg
-           apply (clarsimp simp: dc_def)
+           apply clarsimp
            apply vcg
           apply (clarsimp simp: CPSR_def)
           apply (rule conseqPre, vcg, clarsimp)
@@ -6775,7 +6773,7 @@ shows  "ccorres dc xfdc
            apply (rule_tac P="rv' = of_nat n" in ccorres_gen_asm2, simp)
            apply (rule ccorres_rhs_assoc)+
            apply (rule ccorres_add_return)
-           apply (simp only: dc_def[symmetric] hrs_htd_update)
+           apply (simp only: hrs_htd_update)
            apply ((rule ccorres_Guard_Seq[where S=UNIV])+)?
            apply (rule ccorres_split_nothrow,
                 rule_tac S="{ptr .. ptr + of_nat (length destSlots) * 2^ (getObjectSize newType userSize) - 1}"
@@ -7129,9 +7127,9 @@ shows  "ccorres dc xfdc
   apply (frule(1) range_cover_gsMaxObjectSize, fastforce, assumption)
   apply (clarsimp simp: cte_wp_at_ctes_of)
   apply (drule(1) ghost_assertion_size_logic)+
-  apply (simp add: o_def)
-  apply (case_tac newType,simp_all add:object_type_from_H_def Kernel_C_defs
-             nAPIObjects_def APIType_capBits_def o_def split:apiobject_type.splits)[1]
+  apply (case_tac newType,
+         simp_all add: object_type_from_H_def Kernel_C_defs nAPIObjects_def APIType_capBits_def o_def
+                split: apiobject_type.splits)[1]
           subgoal by (simp add:unat_eq_def word_unat.Rep_inverse' word_less_nat_alt)
          subgoal by (clarsimp simp: objBits_simps', unat_arith)
         apply (fold_subgoals (prefix))[3]

--- a/proof/crefine/ARM/SR_lemmas_C.thy
+++ b/proof/crefine/ARM/SR_lemmas_C.thy
@@ -636,7 +636,6 @@ proof (rule cor_map_relI [OF map_option_eq_dom_eq])
 
   hence "tcb_no_ctes_proj tcb = tcb_no_ctes_proj tcb'" using om
     apply -
-    apply (simp add: o_def)
     apply (drule fun_cong [where x = x])
     apply simp
     done

--- a/proof/crefine/ARM/Schedule_C.thy
+++ b/proof/crefine/ARM/Schedule_C.thy
@@ -58,7 +58,6 @@ lemma Arch_switchToThread_ccorres:
    apply (ctac (no_vcg) add: setVMRoot_ccorres)
     apply (simp (no_asm) del: Collect_const)
     apply (rule_tac A'=UNIV in ccorres_guard_imp2)
-     apply (fold dc_def)[1]
      apply (ctac add: clearExMonitor_ccorres)
     apply clarsimp
    apply wp
@@ -167,14 +166,14 @@ lemma ceqv_remove_tail_Guard_Skip:
   done
 
 lemma switchToThread_ccorres':
-  "ccorres (\<lambda>_ _. True) xfdc
+  "ccorres dc xfdc
            (all_invs_but_ct_idle_or_in_cur_domain' and tcb_at' t)
            (UNIV \<inter> \<lbrace>\<acute>thread = tcb_ptr_to_ctcb_ptr t\<rbrace>)
            hs
            (switchToThread t)
            (Call switchToThread_'proc)"
   apply (rule ccorres_guard_imp2)
-      apply (ctac (no_vcg) add: switchToThread_ccorres[simplified dc_def])
+      apply (ctac (no_vcg) add: switchToThread_ccorres)
      apply auto
   done
 
@@ -266,14 +265,14 @@ proof -
     apply (intro conjI impI)
        apply (fastforce dest: bitmapQ_from_bitmap_lookup simp: valid_bitmapQ_bitmapQ_simp)
       apply (fastforce dest: lookupBitmapPriority_obj_at'
-                       simp: pred_conj_def comp_def obj_at'_def st_tcb_at'_def)
+                       simp: pred_conj_def obj_at'_def st_tcb_at'_def)
      apply (fastforce dest: bitmapQ_from_bitmap_lookup simp: valid_bitmapQ_bitmapQ_simp)
-    apply (clarsimp simp: pred_conj_def comp_def obj_at'_def st_tcb_at'_def)
+    apply (clarsimp simp: pred_conj_def obj_at'_def st_tcb_at'_def)
     apply (clarsimp simp: not_less le_maxDomain_eq_less_numDomains)
     apply (prop_tac "ksCurDomain s = 0")
      using unsigned_eq_0_iff apply force
     apply (cut_tac s=s in lookupBitmapPriority_obj_at'; simp?)
-    apply (clarsimp simp: pred_conj_def comp_def obj_at'_def st_tcb_at'_def)
+    apply (clarsimp simp: pred_conj_def obj_at'_def st_tcb_at'_def)
     done
 qed
 
@@ -349,7 +348,6 @@ lemma isHighestPrio_ccorres:
            (isHighestPrio d p)
            (Call isHighestPrio_'proc)"
   supply Collect_const [simp del]
-  supply dc_simp [simp del]
   supply prio_and_dom_limit_helpers[simp]
   supply Collect_const_mem [simp]
   (* FIXME: these should likely be in simpset for CRefine, or even in general *)
@@ -391,7 +389,6 @@ lemma isHighestPrio_ccorres:
 lemma schedule_ccorres:
   "ccorres dc xfdc invs' UNIV [] schedule (Call schedule_'proc)"
   supply Collect_const [simp del]
-  supply dc_simp [simp del]
   supply prio_and_dom_limit_helpers[simp]
   supply Collect_const_mem [simp]
   (* FIXME: these should likely be in simpset for CRefine, or even in general *)
@@ -405,7 +402,7 @@ lemma schedule_ccorres:
      apply (rule ccorres_cond_false_seq)
      apply simp
      apply (rule_tac P=\<top> and P'="{s. ksSchedulerAction_' (globals s) = NULL }" in ccorres_from_vcg)
-     apply (clarsimp simp: dc_def return_def split: prod.splits)
+     apply (clarsimp simp: return_def split: prod.splits)
      apply (rule conseqPre, vcg, clarsimp)
     (* toplevel case: action is choose new thread *)
     apply (rule ccorres_cond_true_seq)
@@ -422,7 +419,7 @@ lemma schedule_ccorres:
          apply (ctac add: tcbSchedEnqueue_ccorres)
          apply (rule ccorres_from_vcg[where P=\<top> and P'=UNIV])
          apply (clarsimp, rule conseqPre, vcg)
-         apply (clarsimp simp: dc_def return_def)
+         apply (clarsimp simp: return_def)
         apply (rule ccorres_cond_true_seq)
         (* isolate haskell part before setting thread action *)
         apply (simp add: scheduleChooseNewThread_def)
@@ -450,7 +447,7 @@ lemma schedule_ccorres:
         apply (ctac add: tcbSchedEnqueue_ccorres)
         apply (rule ccorres_from_vcg[where P=\<top> and P'=UNIV])
         apply (clarsimp, rule conseqPre, vcg)
-        apply (clarsimp simp: dc_def return_def)
+        apply (clarsimp simp: return_def)
        apply (rule ccorres_cond_false_seq)
 
        apply (rule_tac xf'=was_runnable_' in ccorres_abstract, ceqv)
@@ -470,7 +467,7 @@ lemma schedule_ccorres:
          apply (rule ccorres_rhs_assoc2)
          apply (rule ccorres_rhs_assoc2)
          apply (rule_tac r'="\<lambda>rv rv'. rv = to_bool rv'" and xf'=fastfail_' in ccorres_split_nothrow)
-             apply (clarsimp simp: scheduleSwitchThreadFastfail_def dc_simp)
+             apply (clarsimp simp: scheduleSwitchThreadFastfail_def)
              apply (rule ccorres_cond_seq2[THEN iffD1])
              apply (rule_tac xf'=ret__int_' and val="from_bool (curThread = it)"
                       and R="\<lambda>s. it = ksIdleThread s \<and> curThread = ksCurThread s" and R'=UNIV
@@ -507,11 +504,10 @@ lemma schedule_ccorres:
                 apply (rule ccorres_move_c_guard_tcb)
                 apply (rule ccorres_add_return2)
                 apply (ctac add: isHighestPrio_ccorres, clarsimp)
-                  apply (clarsimp simp: to_bool_def)
                   apply (rule ccorres_inst[where P=\<top> and P'=UNIV])
                   apply (rule ccorres_return)
                   apply (rule conseqPre, vcg)
-                  apply clarsimp
+                  apply (clarsimp simp: to_bool_def)
                  apply (rule wp_post_taut)
                 apply (vcg exspec=isHighestPrio_modifies)
                apply (rule_tac P=\<top> and P'="{s. ret__int_' s = 0}" in ccorres_from_vcg)
@@ -611,13 +607,12 @@ lemma schedule_ccorres:
        apply (clarsimp simp: invs'_bitmapQ_no_L1_orphans invs_ksCurDomain_maxDomain')
        apply (fastforce dest: invs_sch_act_wf')
 
-      apply (wp | clarsimp simp: dc_def)+
+      apply wpsimp+
      apply (vcg exspec=tcbSchedEnqueue_modifies)
     apply wp
    apply vcg
 
-  apply (clarsimp simp: tcb_at_invs' rf_sr_ksCurThread if_apply_def2 invs_queues invs_valid_objs'
-                         dc_def)+
+  apply (clarsimp simp: tcb_at_invs' rf_sr_ksCurThread if_apply_def2 invs_queues invs_valid_objs')
   apply (frule invs_sch_act_wf')
   apply (frule tcb_at_invs')
   apply (rule conjI)
@@ -688,7 +683,7 @@ lemma timerTick_ccorres:
    apply (ctac add: get_tsType_ccorres2 [where f="\<lambda>s. ksCurThread_' (globals s)"])
      apply (rule ccorres_split_nothrow_novcg)
          apply wpc
-                apply (simp add: "StrictC'_thread_state_defs", rule ccorres_cond_false, rule ccorres_return_Skip[unfolded dc_def])+
+                apply (simp add: "StrictC'_thread_state_defs", rule ccorres_cond_false, rule ccorres_return_Skip)+
              (* thread_state.Running *)
              apply simp
              apply (rule ccorres_cond_true)
@@ -710,17 +705,17 @@ lemma timerTick_ccorres:
               apply (rule_tac P="cur_tcb'" and P'=\<top> in ccorres_move_c_guards(8))
                apply (clarsimp simp: cur_tcb'_def)
                apply (fastforce simp: rf_sr_def cstate_relation_def Let_def typ_heap_simps dest: tcb_at_h_t_valid)
-              apply (ctac add: threadSet_timeSlice_ccorres[unfolded dc_def])
+              apply (ctac add: threadSet_timeSlice_ccorres)
              apply (rule ccorres_rhs_assoc)+
              apply (ctac)
                apply simp
                apply (ctac (no_vcg) add: tcbSchedAppend_ccorres)
-                apply (ctac add: rescheduleRequired_ccorres[unfolded dc_def])
+                apply (ctac add: rescheduleRequired_ccorres)
                apply (wp weak_sch_act_wf_lift_linear threadSet_valid_queues
                          threadSet_pred_tcb_at_state tcbSchedAppend_valid_objs' threadSet_valid_objs' threadSet_tcbDomain_triv
                     | clarsimp simp: st_tcb_at'_def o_def split: if_splits)+
              apply (vcg exspec=tcbSchedDequeue_modifies)
-        apply (simp add: "StrictC'_thread_state_defs", rule ccorres_cond_false, rule ccorres_return_Skip[unfolded dc_def])+
+        apply (simp add: "StrictC'_thread_state_defs", rule ccorres_cond_false, rule ccorres_return_Skip)+
         apply ceqv
        apply (clarsimp simp: decDomainTime_def numDomains_sge_1_simp)
        apply (rule ccorres_when[where R=\<top>])
@@ -732,7 +727,6 @@ lemma timerTick_ccorres:
            apply (clarsimp simp: rf_sr_def cstate_relation_def Let_def
                                  carch_state_relation_def cmachine_state_relation_def)
           apply ceqv
-         apply (fold dc_def)
          apply (rule ccorres_pre_getDomainTime)
          apply (rename_tac rva rv'a rvb)
          apply (rule_tac P'="{s. ksDomainTime_' (globals s) = rvb}" in ccorres_inst, simp)
@@ -740,13 +734,13 @@ lemma timerTick_ccorres:
           apply clarsimp
           apply (rule ccorres_guard_imp2)
            apply (rule ccorres_cond_true)
-           apply (ctac add: rescheduleRequired_ccorres[unfolded dc_def])
+           apply (ctac add: rescheduleRequired_ccorres)
           apply clarsimp
           apply assumption
          apply clarsimp
          apply (rule ccorres_guard_imp2)
           apply (rule ccorres_cond_false)
-          apply (rule ccorres_return_Skip[unfolded dc_def])
+          apply (rule ccorres_return_Skip)
          apply clarsimp
         apply wp
        apply (clarsimp simp: guard_is_UNIV_def)

--- a/proof/crefine/ARM/SyscallArgs_C.thy
+++ b/proof/crefine/ARM/SyscallArgs_C.thy
@@ -289,7 +289,7 @@ lemma ccorres_invocationCatch_Inr:
            if reply = [] then liftE (replyOnRestart thread [] isCall) \<sqinter> returnOk ()
                          else liftE (replyOnRestart thread reply isCall)
        odE od) c"
-  apply (simp add: invocationCatch_def liftE_bindE o_xo_injector)
+  apply (simp add: invocationCatch_def liftE_bindE o_xo_injector cong: ccorres_all_cong)
   apply (subst ccorres_liftM_simp[symmetric])
   apply (simp add: liftM_def bind_assoc bindE_def)
   apply (rule_tac f="\<lambda>f. ccorres rvr xs P P' hs f c" for rvr xs in arg_cong)

--- a/proof/crefine/ARM/Syscall_C.thy
+++ b/proof/crefine/ARM/Syscall_C.thy
@@ -264,22 +264,22 @@ lemma decodeInvocation_ccorres:
    apply (rule ccorres_Cond_rhs)
     apply (simp add: if_to_top_of_bind)
     apply (rule ccorres_trim_returnE, simp+)
-    apply (simp add: liftME_invocationCatch o_def)
+    apply (simp add: liftME_invocationCatch)
     apply (rule ccorres_call, rule decodeTCBInvocation_ccorres)
        apply assumption
       apply (simp+)[3]
    apply (rule ccorres_Cond_rhs)
     apply (rule ccorres_trim_returnE, simp+)
-    apply (simp add: liftME_invocationCatch o_def)
+    apply (simp add: liftME_invocationCatch)
     apply (rule ccorres_call,
-           erule decodeDomainInvocation_ccorres[unfolded o_def],
+           erule decodeDomainInvocation_ccorres,
            simp+)[1]
    apply (rule ccorres_Cond_rhs)
     apply (simp add: if_to_top_of_bind)
     apply (rule ccorres_trim_returnE, simp+)
-    apply (simp add: liftME_invocationCatch o_def)
+    apply (simp add: liftME_invocationCatch)
     apply (rule ccorres_call,
-           erule decodeCNodeInvocation_ccorres[unfolded o_def],
+           erule decodeCNodeInvocation_ccorres,
            simp+)[1]
    apply (rule ccorres_Cond_rhs)
     apply simp
@@ -695,7 +695,7 @@ lemma handleFault_ccorres:
          apply (rule ccorres_return_Skip')
         apply clarsimp
         apply (rule ccorres_cond_univ)
-        apply (ctac (no_vcg) add: handleDoubleFault_ccorres [unfolded dc_def])
+        apply (ctac (no_vcg) add: handleDoubleFault_ccorres)
        apply (simp add: sendFaultIPC_def)
        apply wp
          apply ((wp hoare_vcg_all_lift_R hoare_drop_impE_R |wpc |simp add: throw_def)+)[1]
@@ -1046,7 +1046,7 @@ lemma handleReply_ccorres:
                  apply (rule ccorres_cond_true)
                  apply simp
                  apply (rule ccorres_return_void_catchbrk)
-                 apply (rule ccorres_return_void_C[unfolded dc_def])
+                 apply (rule ccorres_return_void_C)
                 apply (vcg exspec=doReplyTransfer_modifies)
                apply (rule ccorres_fail)+
           apply (wpc, simp_all)
@@ -1064,7 +1064,6 @@ lemma handleReply_ccorres:
            apply (csymbr, csymbr, csymbr)
            apply simp
            apply (rule ccorres_assert2)
-           apply (fold dc_def)
            apply (rule ccorres_add_return2)
            apply (ctac (no_vcg))
             apply (rule ccorres_return_void_catchbrk)
@@ -1186,7 +1185,7 @@ lemma handleRecv_ccorres:
                apply (rule ccorres_add_return2)
                apply (rule ccorres_split_nothrow_call[where xf'=xfdc and d'="\<lambda>_. break_C"
                                                       and Q="\<lambda>_ _. True" and Q'="\<lambda>_ _. UNIV"])
-                      apply (ctac add: handleFault_ccorres[unfolded dc_def])
+                      apply (ctac add: handleFault_ccorres)
                      apply simp+
                   apply ceqv
                  apply (rule ccorres_break_return)
@@ -1205,7 +1204,7 @@ lemma handleRecv_ccorres:
           apply (simp add: liftE_bind)
           apply (ctac)
             apply (rule_tac P="\<lambda>s. ksCurThread s = rv" in ccorres_cross_over_guard)
-            apply (ctac add: receiveIPC_ccorres[unfolded dc_def])
+            apply (ctac add: receiveIPC_ccorres)
 
            apply (wp deleteCallerCap_ksQ_ct' hoare_vcg_all_lift)
           apply (rule conseqPost[where Q'=UNIV and A'="{}"], vcg exspec=deleteCallerCap_modifies)
@@ -1253,7 +1252,7 @@ lemma handleRecv_ccorres:
                   apply (rule ccorres_add_return2)
                   apply (rule ccorres_split_nothrow_call[where xf'=xfdc and d'="\<lambda>_. break_C"
                                                and Q="\<lambda>_ _. True" and Q'="\<lambda>_ _. UNIV"])
-                         apply (ctac add: handleFault_ccorres[unfolded dc_def])
+                         apply (ctac add: handleFault_ccorres)
                         apply simp+
                      apply ceqv
                     apply (rule ccorres_break_return)
@@ -1270,7 +1269,7 @@ lemma handleRecv_ccorres:
               apply (clarsimp simp: rf_sr_upd_safe)
 
              apply (simp add: liftE_bind)
-             apply (ctac  add: receiveSignal_ccorres[unfolded dc_def])
+             apply (ctac  add: receiveSignal_ccorres)
             apply clarsimp
             apply (vcg exspec=handleFault_modifies)
            apply (rule ccorres_cond_true_seq)
@@ -1283,7 +1282,7 @@ lemma handleRecv_ccorres:
               apply (rule ccorres_cross_over_guard[where P=\<top>])
               apply (rule ccorres_symb_exec_r)
                 apply (rule ccorres_add_return2)
-                apply (ctac add: handleFault_ccorres[unfolded dc_def])
+                apply (ctac add: handleFault_ccorres)
                   apply (rule ccorres_break_return[where P=\<top> and P'=UNIV])
                    apply simp+
                  apply wp
@@ -1304,7 +1303,7 @@ lemma handleRecv_ccorres:
         apply (rule ccorres_symb_exec_r)
           apply (rule ccorres_cross_over_guard[where P=\<top>])
           apply (rule ccorres_symb_exec_r)
-            apply (ctac add: handleFault_ccorres[unfolded dc_def])
+            apply (ctac add: handleFault_ccorres)
            apply vcg
           apply (rule conseqPre, vcg)
           apply (clarsimp simp: rf_sr_upd_safe)
@@ -1317,9 +1316,9 @@ lemma handleRecv_ccorres:
        apply (rule ccorres_rhs_assoc)+
        apply (rule ccorres_cross_over_guard[where P=\<top>])
        apply (rule ccorres_symb_exec_r)
-         apply (ctac add: handleFault_ccorres[unfolded dc_def])
+         apply (ctac add: handleFault_ccorres)
            apply (rule ccorres_split_throws)
-            apply (rule ccorres_return_void_C [unfolded dc_def])
+            apply (rule ccorres_return_void_C)
            apply vcg
           apply wp
          apply (vcg exspec=handleFault_modifies)
@@ -1531,11 +1530,11 @@ lemma handleInterrupt_ccorres:
     apply (subst doMachineOp_bind)
       apply (rule maskInterrupt_empty_fail)
      apply (rule ackInterrupt_empty_fail)
-    apply (ctac add: maskInterrupt_ccorres[unfolded dc_def])
+    apply (ctac add: maskInterrupt_ccorres)
       apply (subst bind_return_unit[where f="doMachineOp (ackInterrupt irq)"])
-      apply (ctac add: ackInterrupt_ccorres[unfolded dc_def])
+      apply (ctac add: ackInterrupt_ccorres)
         apply (rule ccorres_split_throws)
-         apply (rule ccorres_return_void_C[unfolded dc_def])
+         apply (rule ccorres_return_void_C)
         apply vcg
        apply wp
       apply (vcg exspec=ackInterrupt_modifies)
@@ -1573,7 +1572,7 @@ lemma handleInterrupt_ccorres:
          apply (ctac (no_vcg) add: sendSignal_ccorres)
           apply (simp add: maskIrqSignal_def)
           apply (ctac (no_vcg) add: maskInterrupt_ccorres)
-           apply (ctac add: ackInterrupt_ccorres [unfolded dc_def])
+           apply (ctac add: ackInterrupt_ccorres)
           apply wp+
         apply (simp del: Collect_const)
         apply (rule ccorres_cond_true_seq)
@@ -1582,7 +1581,7 @@ lemma handleInterrupt_ccorres:
         apply (rule ccorres_cond_false_seq)
         apply (simp add: maskIrqSignal_def)
         apply (ctac (no_vcg) add: maskInterrupt_ccorres)
-         apply (ctac add: ackInterrupt_ccorres [unfolded dc_def])
+         apply (ctac add: ackInterrupt_ccorres)
         apply wp
        apply (rule_tac P=\<top> and P'="{s. ret__int_' s = 0 \<and> cap_get_tag cap \<noteq> scast cap_notification_cap}" in ccorres_inst)
        apply (clarsimp simp: isCap_simps simp del: Collect_const)
@@ -1594,7 +1593,7 @@ lemma handleInterrupt_ccorres:
                         rule ccorres_cond_false_seq, simp,
                         rule ccorres_cond_false_seq, simp,
                         ctac (no_vcg) add: maskInterrupt_ccorres,
-                        ctac (no_vcg) add: ackInterrupt_ccorres [unfolded dc_def],
+                        ctac (no_vcg) add: ackInterrupt_ccorres,
                         wp, simp)+)
       apply (wp getSlotCap_wp)
      apply simp
@@ -1603,7 +1602,6 @@ lemma handleInterrupt_ccorres:
     apply (rule ccorres_move_const_guards)+
     apply (rule ccorres_cond_false_seq)
     apply (rule ccorres_cond_true_seq)
-    apply (fold dc_def)[1]
     apply (rule ccorres_rhs_assoc)+
     apply (ctac (no_vcg) add: timerTick_ccorres)
      apply (ctac (no_vcg) add: resetTimer_ccorres)
@@ -1615,7 +1613,7 @@ lemma handleInterrupt_ccorres:
    apply (rule ccorres_cond_false_seq)
    apply (rule ccorres_cond_true_seq)
    apply (ctac add: ccorres_handleReserveIRQ)
-     apply (ctac (no_vcg) add: ackInterrupt_ccorres [unfolded dc_def])
+     apply (ctac (no_vcg) add: ackInterrupt_ccorres)
     apply wp
    apply vcg
   apply (simp add: sint_ucast_eq_uint is_down uint_up_ucast is_up)

--- a/proof/crefine/ARM/Tcb_C.thy
+++ b/proof/crefine/ARM/Tcb_C.thy
@@ -374,8 +374,8 @@ lemma setPriority_ccorres:
         apply (rule ccorres_pre_getCurThread)
         apply (rule_tac R = "\<lambda>s. rv = ksCurThread s" in ccorres_cond2)
           apply (clarsimp simp: rf_sr_ksCurThread)
-         apply (ctac add: rescheduleRequired_ccorres[unfolded dc_def])
-        apply (ctac add: possibleSwitchTo_ccorres[unfolded dc_def])
+         apply (ctac add: rescheduleRequired_ccorres)
+        apply (ctac add: possibleSwitchTo_ccorres)
        apply (rule ccorres_return_Skip')
       apply (wp isRunnable_wp)
      apply (wpsimp wp: hoare_drop_imps threadSet_valid_queues threadSet_valid_objs'
@@ -551,7 +551,7 @@ lemma invokeTCB_ThreadControl_ccorres:
            apply (rule ccorres_move_array_assertion_tcb_ctes ccorres_Guard_Seq)+
            apply csymbr
            apply (simp add: liftE_bindE[symmetric] bindE_assoc getThreadBufferSlot_def
-                            locateSlot_conv o_def
+                            locateSlot_conv
                        del: Collect_const)
            apply (simp add: liftE_bindE del: Collect_const)
            apply (ctac(no_vcg) add: cteDelete_ccorres)
@@ -597,7 +597,7 @@ lemma invokeTCB_ThreadControl_ccorres:
                                            and Q'=UNIV in ccorres_rewrite_cond_sr)
                             apply (clarsimp simp: Collect_const_mem rf_sr_ksCurThread)
                            apply (rule ccorres_Cond_rhs; clarsimp)
-                            apply (ctac (no_vcg) add: rescheduleRequired_ccorres[unfolded dc_def])
+                            apply (ctac (no_vcg) add: rescheduleRequired_ccorres)
                            apply (rule ccorres_return_Skip')
                           apply (rule ccorres_split_nothrow_novcg_dc)
                              apply (rule ccorres_cond2[where R=\<top>], simp add: Collect_const_mem)
@@ -635,7 +635,7 @@ lemma invokeTCB_ThreadControl_ccorres:
                                       and Q'=UNIV in ccorres_rewrite_cond_sr)
                        apply (clarsimp simp: Collect_const_mem rf_sr_ksCurThread)
                       apply (rule ccorres_Cond_rhs; clarsimp)
-                       apply (ctac (no_vcg) add: rescheduleRequired_ccorres[unfolded dc_def])
+                       apply (ctac (no_vcg) add: rescheduleRequired_ccorres)
                       apply (rule ccorres_return_Skip')
                      apply (rule ccorres_split_nothrow_novcg_dc)
                         apply (rule ccorres_cond2[where R=\<top>], simp add: Collect_const_mem)
@@ -662,7 +662,7 @@ lemma invokeTCB_ThreadControl_ccorres:
                                     and Q'=UNIV in ccorres_rewrite_cond_sr)
                      apply (clarsimp simp: Collect_const_mem rf_sr_ksCurThread)
                     apply (rule ccorres_Cond_rhs; clarsimp)
-                     apply (ctac(no_vcg) add: rescheduleRequired_ccorres[unfolded dc_def])
+                     apply (ctac(no_vcg) add: rescheduleRequired_ccorres)
                     apply (rule ccorres_return_Skip')
                    apply (rule ccorres_split_nothrow_novcg_dc)
                       apply(rule ccorres_cond2[where R=\<top>], simp add: Collect_const_mem)
@@ -688,7 +688,7 @@ lemma invokeTCB_ThreadControl_ccorres:
                                   and Q'=UNIV in ccorres_rewrite_cond_sr)
                    apply (clarsimp simp: Collect_const_mem rf_sr_ksCurThread)
                   apply (rule ccorres_Cond_rhs; clarsimp)
-                   apply (ctac(no_vcg) add: rescheduleRequired_ccorres[unfolded dc_def])
+                   apply (ctac(no_vcg) add: rescheduleRequired_ccorres)
                   apply (rule ccorres_return_Skip')
                  apply (rule ccorres_split_nothrow_novcg_dc)
                     apply (rule ccorres_cond2[where R=\<top>], simp add: Collect_const_mem)
@@ -778,7 +778,6 @@ lemma invokeTCB_ThreadControl_ccorres:
          apply csymbr
          apply (ctac(no_vcg) add: cteDelete_ccorres)
            apply (simp add: liftE_bindE Collect_False ccorres_cond_iffs
-                            dc_def
                        del: Collect_const)
            apply ((rule ccorres_split_nothrow_novcg_dc[rotated], assumption) | rule ccorres_rhs_assoc2)+
              apply (simp add: conj_comms pred_conj_def)
@@ -800,8 +799,7 @@ lemma invokeTCB_ThreadControl_ccorres:
              apply (rule checkCapAt_ccorres2)
                 apply ceqv
                apply csymbr
-               apply (simp add: Collect_True assertDerived_def bind_assoc
-                                ccorres_cond_iffs dc_def[symmetric]
+               apply (simp add: Collect_True assertDerived_def bind_assoc ccorres_cond_iffs
                            del: Collect_const)
                apply (rule ccorres_symb_exec_l)
                   apply (ctac add: cteInsert_ccorres)
@@ -809,13 +807,13 @@ lemma invokeTCB_ThreadControl_ccorres:
               apply csymbr
               apply (simp add: Collect_False ccorres_cond_iffs
                           del: Collect_const)
-              apply (rule ccorres_return_Skip[unfolded dc_def])
+              apply (rule ccorres_return_Skip)
              apply (fastforce simp: guard_is_UNIV_def Kernel_C.tcbVTable_def tcbVTableSlot_def
                                     cte_level_bits_def size_of_def)
             apply csymbr
             apply (simp add: Collect_False del: Collect_const)
             apply (rule ccorres_cond_false)
-            apply (rule ccorres_return_Skip[unfolded dc_def])
+            apply (rule ccorres_return_Skip)
            apply (clarsimp simp: guard_is_UNIV_def ccap_relation_def cap_thread_cap_lift cap_to_H_def)
           apply simp
           apply (rule ccorres_split_throws, rule ccorres_return_C_errorE, simp+)
@@ -839,7 +837,6 @@ lemma invokeTCB_ThreadControl_ccorres:
         apply csymbr
         apply (ctac(no_vcg) add: cteDelete_ccorres)
           apply (simp add: liftE_bindE Collect_False ccorres_cond_iffs
-                           dc_def
                       del: Collect_const)
           apply ((rule ccorres_split_nothrow_novcg_dc[rotated], assumption)
                   | rule ccorres_rhs_assoc2)+
@@ -865,8 +862,7 @@ lemma invokeTCB_ThreadControl_ccorres:
             apply (rule checkCapAt_ccorres2)
                apply ceqv
               apply csymbr
-              apply (simp add: Collect_True assertDerived_def bind_assoc
-                               ccorres_cond_iffs dc_def[symmetric]
+              apply (simp add: Collect_True assertDerived_def bind_assoc ccorres_cond_iffs
                           del: Collect_const)
               apply (rule ccorres_symb_exec_l)
                  apply (ctac add: cteInsert_ccorres)
@@ -874,14 +870,14 @@ lemma invokeTCB_ThreadControl_ccorres:
              apply csymbr
              apply (simp add: Collect_False ccorres_cond_iffs
                          del: Collect_const)
-             apply (rule ccorres_return_Skip[unfolded dc_def])
+             apply (rule ccorres_return_Skip)
             apply (clarsimp simp: guard_is_UNIV_def Collect_const_mem
                                   Kernel_C.tcbCTable_def tcbCTableSlot_def
                                   cte_level_bits_def size_of_def option_to_0_def)
            apply csymbr
            apply (simp add: Collect_False del: Collect_const)
            apply (rule ccorres_cond_false)
-           apply (rule ccorres_return_Skip[unfolded dc_def])
+           apply (rule ccorres_return_Skip)
           apply (clarsimp simp: guard_is_UNIV_def ccap_relation_def cap_thread_cap_lift cap_to_H_def)
          apply simp
          apply (rule ccorres_split_throws, rule ccorres_return_C_errorE, simp+)
@@ -930,7 +926,7 @@ lemma setupReplyMaster_ccorres:
   apply (cinit lift: thread_')
    apply (rule ccorres_move_array_assertion_tcb_ctes ccorres_Guard_Seq)+
    apply ctac
-     apply (simp del: Collect_const add: dc_def[symmetric])
+     apply (simp del: Collect_const)
      apply (rule ccorres_pre_getCTE)
      apply (rule ccorres_move_c_guard_cte)
      apply (rule_tac F="\<lambda>rv'. (rv' = scast cap_null_cap) = (cteCap oldCTE = NullCap)"
@@ -1547,10 +1543,10 @@ lemma invokeTCB_WriteRegisters_ccorres[where S=UNIV]:
                  apply (rule ccorres_split_nothrow_novcg)
                      apply (rule ccorres_when[where R=\<top>])
                       apply (simp add: from_bool_0 Collect_const_mem)
-                     apply (rule_tac xf'="\<lambda>_. 0" in ccorres_call)
-                      apply (rule restart_ccorres)
+                     apply (rule_tac xf'=Corres_C.xfdc in ccorres_call)
+                        apply (rule restart_ccorres)
+                       apply simp
                       apply simp
-                      apply (simp add: xfdc_def)
                      apply simp
                     apply (rule ceqv_refl)
                    apply (rule ccorres_split_nothrow_novcg_dc)
@@ -1727,6 +1723,7 @@ shows
                 apply (rule ccorres_rhs_assoc)+
                 apply csymbr
                 apply (ctac add: lookupIPCBuffer_ccorres)
+                  apply (rename_tac state destIPCBuffer ipcBuffer)
                   apply (ctac add: setRegister_ccorres)
                     apply (rule ccorres_stateAssert)
                     apply (rule ccorres_rhs_assoc2)
@@ -1787,15 +1784,15 @@ shows
                        apply (rule bind_apply_cong[OF _ refl])
                        apply (rule_tac n1="min (unat n_frameRegisters - unat n_msgRegisters) (unat n)"
                                    in fun_cong [OF mapM_x_split_append])
-                      apply (rule_tac P="rva \<noteq> Some 0" in ccorres_gen_asm)
-                      apply (subgoal_tac "(ipcBuffer = NULL) = (rva = None)")
+                      apply (rule_tac P="destIPCBuffer \<noteq> Some 0" in ccorres_gen_asm)
+                      apply (subgoal_tac "(ipcBuffer = NULL) = (destIPCBuffer = None)")
                        prefer 2
                        apply (clarsimp simp: option_to_ptr_def option_to_0_def
                                       split: option.split_asm)
                       apply (simp add: bind_assoc del: Collect_const)
                       apply (rule_tac xf'=i_' and r'="\<lambda>_ rv. unat rv = min (unat n_frameRegisters)
                                                                       (min (unat n)
-                                                                           (case rva of None \<Rightarrow> unat n_msgRegisters
+                                                                           (case destIPCBuffer of None \<Rightarrow> unat n_msgRegisters
                                                                               | _ \<Rightarrow> unat n_frameRegisters))"
                                  in ccorres_split_nothrow_novcg)
                           apply (rule ccorres_Cond_rhs)
@@ -1803,7 +1800,7 @@ shows
                                   rule_tac F="\<lambda>m s. obj_at' (\<lambda>tcb. map ((atcbContextGet o tcbArch) tcb) (genericTake n
                                                       (ARM_H.frameRegisters @ ARM_H.gpRegisters))
                                                                = reply) target s
-                                                 \<and> valid_ipc_buffer_ptr' (the rva) s
+                                                 \<and> valid_ipc_buffer_ptr' (the destIPCBuffer) s
                                                  \<and> valid_pspace' s"
                                        and i="unat n_msgRegisters"
                                     in ccorres_mapM_x_while')
@@ -1913,11 +1910,10 @@ shows
                             apply (rename_tac i_c, rule_tac P="i_c = 0" in ccorres_gen_asm2)
                             apply (simp add: drop_zip del: Collect_const)
                             apply (rule ccorres_Cond_rhs)
-                             apply (simp del: Collect_const)
                              apply (rule_tac F="\<lambda>m s. obj_at' (\<lambda>tcb. map ((atcbContextGet o tcbArch) tcb) (genericTake n
                                                        (ARM_H.frameRegisters @ ARM_H.gpRegisters))
                                                                 = reply) target s
-                                                  \<and> valid_ipc_buffer_ptr' (the rva) s \<and> valid_pspace' s"
+                                                  \<and> valid_ipc_buffer_ptr' (the destIPCBuffer) s \<and> valid_pspace' s"
                                         and i="0" in ccorres_mapM_x_while')
                                  apply (clarsimp simp: less_diff_conv drop_zip)
                                  apply (rule ccorres_guard_imp2)
@@ -1988,11 +1984,11 @@ shows
                              apply (simp add: min_less_iff_disj less_imp_diff_less)
                             apply (simp add: drop_zip n_gpRegisters_def)
                             apply (elim disjE impCE)
-                             apply (clarsimp simp: mapM_x_Nil)
+                             apply (clarsimp simp: mapM_x_Nil cong: ccorres_all_cong)
                              apply (rule ccorres_return_Skip')
-                            apply (simp add: linorder_not_less word_le_nat_alt
-                                             drop_zip mapM_x_Nil n_frameRegisters_def
-                                             min.absorb1 n_msgRegisters_def)
+                            apply (simp add: linorder_not_less word_le_nat_alt drop_zip
+                                             mapM_x_Nil n_frameRegisters_def n_msgRegisters_def
+                                       cong: ccorres_all_cong)
                             apply (rule ccorres_guard_imp2, rule ccorres_return_Skip')
                             apply simp
                            apply ceqv
@@ -2292,7 +2288,7 @@ lemma decodeWriteRegisters_ccorres:
          apply (simp add: performInvocation_def)
          apply (ctac(no_vcg) add: invokeTCB_WriteRegisters_ccorres
                                     [where args=args and someNum="unat (args ! 1)"])
-           apply (simp add: dc_def[symmetric] o_def)
+           apply simp
            apply (rule ccorres_alternative2, rule ccorres_return_CE, simp+)
           apply (rule ccorres_return_C_errorE, simp+)[1]
          apply wp[1]
@@ -2313,7 +2309,7 @@ lemma decodeWriteRegisters_ccorres:
                         numeral_eqs
                   simp del: unsigned_numeral)
   apply (frule arg_cong[where f="\<lambda>x. unat (of_nat x :: word32)"],
-         simp(no_asm_use) only: word_unat.Rep_inverse o_def,
+         simp(no_asm_use) only: word_unat.Rep_inverse,
          simp)
   apply (rule conjI)
    apply clarsimp
@@ -3150,7 +3146,6 @@ lemma decodeSetMCPriority_ccorres:
             >>= invocationCatch thread isBlocking isCall InvokeTCB)
      (Call decodeSetMCPriority_'proc)"
   supply Collect_const[simp del]
-  supply dc_simp[simp del]
   apply (cinit' lift: cap_' length___unsigned_long_' current_extra_caps_' buffer_' simp: decodeSetMCPriority_def)
    apply (simp cong: StateSpace.state.fold_congs globals.fold_congs)
    apply (rule ccorres_rhs_assoc2)
@@ -3218,8 +3213,7 @@ lemma decodeSetMCPriority_ccorres:
              apply csymbr
              apply csymbr
              apply (ctac (no_vcg) add: invokeTCB_ThreadControl_ccorres)
-               (* HACK: delete rules from the simpset to avoid the RVRs getting out of sync *)
-               apply (clarsimp simp del: intr_and_se_rel_simps comp_apply dc_simp)
+               apply clarsimp
                apply (rule ccorres_alternative2)
                apply (rule ccorres_return_CE; simp)
               apply (rule ccorres_return_C_errorE; simp)
@@ -3284,7 +3278,7 @@ lemma decodeSetPriority_ccorres:
      (decodeSetPriority args cp extraCaps
             >>= invocationCatch thread isBlocking isCall InvokeTCB)
      (Call decodeSetPriority_'proc)"
-  supply Collect_const[simp del] dc_simp[simp del]
+  supply Collect_const[simp del]
   apply (cinit' lift: cap_' length___unsigned_long_' current_extra_caps_' buffer_' simp: decodeSetPriority_def)
      apply (simp cong: StateSpace.state.fold_congs globals.fold_congs)
    apply (rule ccorres_rhs_assoc2)
@@ -3352,8 +3346,7 @@ lemma decodeSetPriority_ccorres:
              apply csymbr
              apply csymbr
              apply (ctac (no_vcg) add: invokeTCB_ThreadControl_ccorres)
-               (* HACK: delete rules from the simpset to avoid the RVRs getting out of sync *)
-               apply (clarsimp simp del: intr_and_se_rel_simps comp_apply dc_simp)
+               apply clarsimp
                apply (rule ccorres_alternative2)
                apply (rule ccorres_return_CE; simp)
               apply (rule ccorres_return_C_errorE; simp)
@@ -3431,7 +3424,7 @@ lemma decodeSetSchedParams_ccorres:
      (decodeSetSchedParams args cp extraCaps
             >>= invocationCatch thread isBlocking isCall InvokeTCB)
      (Call decodeSetSchedParams_'proc)"
-  supply Collect_const[simp del] dc_simp[simp del]
+  supply Collect_const[simp del]
   apply (cinit' lift: cap_' length___unsigned_long_' current_extra_caps_' buffer_' simp: decodeSetSchedParams_def)
    apply (simp cong: StateSpace.state.fold_congs globals.fold_congs)
    apply (rule ccorres_rhs_assoc2)
@@ -3498,8 +3491,7 @@ lemma decodeSetSchedParams_ccorres:
                   apply csymbr
                   apply csymbr
                   apply (ctac (no_vcg) add: invokeTCB_ThreadControl_ccorres)
-                    (* HACK: delete rules from the simpset to avoid the RVRs getting out of sync *)
-                    apply (clarsimp simp del: intr_and_se_rel_simps comp_apply dc_simp)
+                    apply clarsimp
                     apply (rule ccorres_alternative2)
                     apply (rule ccorres_return_CE; simp)
                    apply (rule ccorres_return_C_errorE; simp)
@@ -3754,7 +3746,7 @@ lemma bindNotification_ccorres:
        apply ceqv
       apply (rule ccorres_move_c_guard_tcb)
       apply (simp add: setBoundNotification_def)
-      apply (rule_tac P'=\<top> and P=\<top> in threadSet_ccorres_lemma3[unfolded dc_def])
+      apply (rule_tac P'=\<top> and P=\<top> in threadSet_ccorres_lemma3)
        apply vcg
       apply simp
       apply (erule (1) rf_sr_tcb_update_no_queue2,
@@ -4212,7 +4204,7 @@ lemma decodeSetSpace_ccorres:
                       apply (simp add: Collect_False del: Collect_const)
                       apply csymbr
                       apply csymbr
-                      apply (simp add: cnode_cap_case_if cap_get_tag_isCap dc_def[symmetric]
+                      apply (simp add: cnode_cap_case_if cap_get_tag_isCap
                                   del: Collect_const)
                       apply (rule ccorres_Cond_rhs_Seq)
                        apply (simp add: injection_handler_throwError
@@ -4356,7 +4348,7 @@ lemma invokeTCB_SetTLSBase_ccorres:
   apply (cinit lift: thread_' tls_base_')
    apply (simp add: liftE_def bind_assoc
                del: Collect_const)
-   apply (ctac add: setRegister_ccorres[simplified dc_def])
+   apply (ctac add: setRegister_ccorres)
      apply (rule ccorres_pre_getCurThread)
      apply (rename_tac cur_thr)
      apply (rule ccorres_split_nothrow_novcg_dc)

--- a/proof/crefine/ARM/VSpace_C.thy
+++ b/proof/crefine/ARM/VSpace_C.thy
@@ -1018,7 +1018,7 @@ lemma flushSpace_ccorres:
      apply (rule_tac Q=\<top> and Q'=\<top> in ccorres_if_cond_throws2)
         apply (clarsimp simp: Collect_const_mem pde_stored_asid_def)
         apply (simp add: if_split_eq1 to_bool_def)
-       apply (rule ccorres_return_void_C [unfolded dc_def])
+       apply (rule ccorres_return_void_C)
       apply csymbr
       apply (clarsimp simp: pde_stored_asid_def)
       apply (case_tac "to_bool (stored_asid_valid_CL (pde_pde_invalid_lift stored_hw_asid___struct_pde_C))")
@@ -1030,7 +1030,7 @@ lemma flushSpace_ccorres:
        apply clarsimp
       apply clarsimp
       apply (rule ccorres_call,
-             rule invalidateTranslationASID_ccorres [simplified dc_def xfdc_def],
+             rule invalidateTranslationASID_ccorres,
              simp+)[1]
      apply vcg
     apply wp+
@@ -1325,7 +1325,6 @@ lemma armv_contextSwitch_ccorres:
   apply (cinit lift: cap_pd_' asid_')
    apply simp
    apply (ctac(no_vcg) add: getHWASID_ccorres)
-    apply (fold dc_def)
     apply (ctac (no_vcg)add: armv_contextSwitch_HWASID_ccorres)
    apply wp
   apply clarsimp
@@ -1357,7 +1356,7 @@ lemma setVMRoot_ccorres:
       apply (simp add: cap_case_isPageDirectoryCap cong: if_cong)
       apply (rule ccorres_cond_true_seq)
       apply (rule ccorres_rhs_assoc)
-      apply (simp add: throwError_def catch_def dc_def[symmetric])
+      apply (simp add: throwError_def catch_def)
       apply (rule ccorres_rhs_assoc)+
       apply (rule ccorres_h_t_valid_armKSGlobalPD)
       apply csymbr
@@ -1385,7 +1384,7 @@ lemma setVMRoot_ccorres:
       apply (rule ccorres_add_return2)
       apply (ctac (no_vcg) add: setCurrentPD_ccorres)
        apply (rule ccorres_split_throws)
-        apply (rule ccorres_return_void_C [unfolded dc_def])
+        apply (rule ccorres_return_void_C)
        apply vcg
       apply wp
      apply (simp add: cap_case_isPageDirectoryCap)
@@ -1417,11 +1416,11 @@ lemma setVMRoot_ccorres:
          apply (rule ccorres_add_return2)
          apply (ctac(no_vcg) add: setCurrentPD_ccorres)
           apply (rule ccorres_split_throws)
-           apply (rule ccorres_return_void_C[unfolded dc_def])
+           apply (rule ccorres_return_void_C)
           apply vcg
          apply wp
         apply (simp add: whenE_def returnOk_def)
-        apply (ctac (no_vcg) add: armv_contextSwitch_ccorres[unfolded dc_def])
+        apply (ctac (no_vcg) add: armv_contextSwitch_ccorres)
        apply (simp add: checkPDNotInASIDMap_def checkPDASIDMapMembership_def)
        apply (rule ccorres_stateAssert)
        apply (rule ccorres_rhs_assoc)+
@@ -1431,7 +1430,7 @@ lemma setVMRoot_ccorres:
        apply (rule ccorres_add_return2)
        apply (ctac(no_vcg) add: setCurrentPD_ccorres)
         apply (rule ccorres_split_throws)
-         apply (rule ccorres_return_void_C[unfolded dc_def])
+         apply (rule ccorres_return_void_C)
         apply vcg
        apply wp
       apply simp
@@ -1597,7 +1596,6 @@ lemma doFlush_ccorres:
                       empty_fail_invalidateCacheRange_I empty_fail_branchFlushRange empty_fail_isb
                       doMachineOp_bind)
      apply (rule ccorres_rhs_assoc)+
-     apply (fold dc_def)
      apply (ctac (no_vcg) add: cleanCacheRange_PoU_ccorres)
       apply (ctac (no_vcg) add: dsb_ccorres)
        apply (ctac (no_vcg) add: invalidateCacheRange_I_ccorres)
@@ -1606,13 +1604,13 @@ lemma doFlush_ccorres:
         apply wp+
     apply simp
    apply (clarsimp simp: Collect_const_mem)
-  apply (auto simp: flushtype_relation_def o_def
-                        Kernel_C.ARMPageClean_Data_def Kernel_C.ARMPDClean_Data_def
-                        Kernel_C.ARMPageInvalidate_Data_def Kernel_C.ARMPDInvalidate_Data_def
-                        Kernel_C.ARMPageCleanInvalidate_Data_def Kernel_C.ARMPDCleanInvalidate_Data_def
-                        Kernel_C.ARMPageUnify_Instruction_def Kernel_C.ARMPDUnify_Instruction_def
-                  dest: ghost_assertion_size_logic[rotated]
-                 split: ARM_H.flush_type.splits)
+  apply (auto simp: flushtype_relation_def
+                    Kernel_C.ARMPageClean_Data_def Kernel_C.ARMPDClean_Data_def
+                    Kernel_C.ARMPageInvalidate_Data_def Kernel_C.ARMPDInvalidate_Data_def
+                    Kernel_C.ARMPageCleanInvalidate_Data_def Kernel_C.ARMPDCleanInvalidate_Data_def
+                    Kernel_C.ARMPageUnify_Instruction_def Kernel_C.ARMPDUnify_Instruction_def
+              dest: ghost_assertion_size_logic[rotated]
+             split: ARM_H.flush_type.splits)
   done
 end
 
@@ -1654,7 +1652,7 @@ lemma performPageFlush_ccorres:
       apply (rule ccorres_return_Skip)
      apply (rule ccorres_from_vcg_throws[where P=\<top> and P'=UNIV])
      apply (rule allI, rule conseqPre, vcg)
-     apply (clarsimp simp: return_def dc_def)
+     apply (clarsimp simp: return_def)
     apply wpsimp
    apply (simp add: guard_is_UNIV_def)
   apply (clarsimp simp: order_less_imp_le)
@@ -1683,12 +1681,12 @@ lemma setRegister_ccorres:
        (asUser thread (setRegister reg val))
        (Call setRegister_'proc)"
   apply (cinit' lift: thread_' reg_' w_')
-   apply (simp add: asUser_def dc_def[symmetric] split_def split del: if_split)
+   apply (simp add: asUser_def split_def)
    apply (rule ccorres_pre_threadGet)
    apply (rule ccorres_Guard)
    apply (simp add: setRegister_def simpler_modify_def exec_select_f_singleton)
    apply (rule_tac P="\<lambda>tcb. (atcbContextGet o tcbArch) tcb = rv"
-                in threadSet_ccorres_lemma2 [unfolded dc_def])
+                in threadSet_ccorres_lemma2)
     apply vcg
    apply (clarsimp simp: setRegister_def HaskellLib_H.runState_def
                          simpler_modify_def typ_heap_simps)
@@ -1837,7 +1835,6 @@ lemma flushPage_ccorres:
        apply (rule ccorres_cond2[where R=\<top>])
          apply (simp add: from_bool_0 Collect_const_mem)
         apply (rule ccorres_pre_getCurThread)
-        apply (fold dc_def)
         apply (ctac add: setVMRoot_ccorres)
        apply (rule ccorres_return_Skip)
       apply (wp | simp add: cur_tcb'_def[symmetric])+
@@ -2094,8 +2091,7 @@ lemma unmapPage_ccorres:
       (unmapPage sz asid vptr pptr) (Call unmapPage_'proc)"
   apply (rule ccorres_gen_asm)
   apply (cinit lift: page_size_' asid_' vptr_' pptr_')
-   apply (simp add: ignoreFailure_liftM ptr_add_assertion_positive
-                    Collect_True
+   apply (simp add: ignoreFailure_liftM ptr_add_assertion_positive Collect_True
                del: Collect_const)
    apply ccorres_remove_UNIV_guard
    apply csymbr
@@ -2107,16 +2103,16 @@ lemma unmapPage_ccorres:
       apply (rule ccorres_splitE_novcg[where r'=dc and xf'=xfdc])
           \<comment> \<open>ARMSmallPage\<close>
           apply (rule ccorres_Cond_rhs)
-           apply (simp add: gen_framesize_to_H_def dc_def[symmetric])
+           apply (simp add: gen_framesize_to_H_def)
            apply (rule ccorres_rhs_assoc)+
            apply csymbr
            apply (ctac add: lookupPTSlot_ccorres)
               apply (rename_tac pt_slot pt_slot')
-              apply (simp add: dc_def[symmetric])
+              apply simp
               apply (rule ccorres_rhs_assoc2, rule ccorres_rhs_assoc2,
                   rule ccorres_rhs_assoc2)
               apply (rule ccorres_splitE_novcg)
-                  apply (simp only: inl_rrel_inl_rrel)
+                  apply simp
                   apply (rule checkMappingPPtr_pte_ccorres)
                   apply (rule conseqPre, vcg)
                   apply (clarsimp simp: typ_heap_simps')
@@ -2125,7 +2121,7 @@ lemma unmapPage_ccorres:
                                 pte_pte_small_lift_def pte_pte_invalid_def
                          split: if_split_asm pte.split_asm)
                  apply (rule ceqv_refl)
-                apply (simp add: liftE_liftM Collect_const[symmetric] dc_def[symmetric]
+                apply (simp add: liftE_liftM Collect_const[symmetric]
                          del: Collect_const)
                 apply (rule ccorres_handlers_weaken2)
                 apply csymbr
@@ -2133,8 +2129,7 @@ lemma unmapPage_ccorres:
                    apply (rule storePTE_Basic_ccorres)
                    apply (simp add: cpte_relation_def Let_def)
                   apply csymbr
-                  apply simp
-                  apply (ctac add: cleanByVA_PoU_ccorres[unfolded dc_def])
+                  apply (ctac add: cleanByVA_PoU_ccorres)
                  apply wp
                 apply (simp add: guard_is_UNIV_def)
                apply wp
@@ -2148,18 +2143,17 @@ lemma unmapPage_ccorres:
            apply (vcg exspec=lookupPTSlot_modifies)
           \<comment> \<open>ARMLargePage\<close>
           apply (rule ccorres_Cond_rhs)
-           apply (simp add: gen_framesize_to_H_def dc_def[symmetric]
+           apply (simp add: gen_framesize_to_H_def
                             largePagePTEOffsets_def pteBits_def)
            apply (rule ccorres_rhs_assoc)+
            apply csymbr
            apply csymbr
            apply (ctac add: lookupPTSlot_ccorres)
               apply (rename_tac ptSlot lookupPTSlot_ret)
-              apply (simp add: Collect_False dc_def[symmetric] del: Collect_const)
+              apply (simp add: Collect_False del: Collect_const)
               apply (rule ccorres_rhs_assoc2, rule ccorres_rhs_assoc2,
                   rule ccorres_rhs_assoc2)
-              apply (rule ccorres_splitE_novcg, simp only: inl_rrel_inl_rrel,
-                     rule checkMappingPPtr_pte_ccorres)
+              apply (rule ccorres_splitE_novcg, simp, rule checkMappingPPtr_pte_ccorres)
                   apply (rule conseqPre, vcg)
                   apply (clarsimp simp: typ_heap_simps')
                   subgoal by (simp add: cpte_relation_def Let_def pte_lift_def
@@ -2167,7 +2161,7 @@ lemma unmapPage_ccorres:
                                     pte_pte_large_lift_def pte_pte_invalid_def
                              split: if_split_asm pte.split_asm)
                  apply (rule ceqv_refl)
-                apply (simp add: liftE_liftM dc_def[symmetric]
+                apply (simp add: liftE_liftM
                              mapM_discarded whileAnno_def ARMLargePageBits_def ARMSmallPageBits_def
                              Collect_False word_sle_def
                         del: Collect_const)
@@ -2198,7 +2192,7 @@ lemma unmapPage_ccorres:
                   apply csymbr
                   apply (rule ccorres_move_c_guard_pte ccorres_move_array_assertion_pte_16)+
                   apply (rule ccorres_add_return2,
-                    ctac(no_vcg) add: cleanCacheRange_PoU_ccorres[unfolded dc_def])
+                    ctac(no_vcg) add: cleanCacheRange_PoU_ccorres)
                    apply (rule ccorres_move_array_assertion_pte_16, rule ccorres_return_Skip')
                   apply wp
                  apply (rule_tac P="is_aligned ptSlot 6" in hoare_gen_asm)
@@ -2239,33 +2233,32 @@ lemma unmapPage_ccorres:
           \<comment> \<open>ARMSection\<close>
           apply (rule ccorres_Cond_rhs)
            apply (rule ccorres_rhs_assoc)+
-           apply (csymbr, csymbr)
-           apply (simp add: gen_framesize_to_H_def dc_def[symmetric]
-                            liftE_liftM
+           \<comment> \<open>FIXME: The second csymbr rewrites the return relation of the goal.
+                      If this was avoided then folding the dc_def could be removed\<close>
+           apply (csymbr, csymbr, fold dc_def)
+           apply (simp add: gen_framesize_to_H_def liftE_liftM
                        del: Collect_const)
            apply (simp split: if_split, rule conjI[rotated], rule impI,
                   rule ccorres_empty, rule impI)
            apply (rule ccorres_rhs_assoc2, rule ccorres_rhs_assoc2,
                   rule ccorres_rhs_assoc2, rule ccorres_rhs_assoc2,
                   rule ccorres_rhs_assoc2)
-           apply (rule ccorres_splitE_novcg, simp only: inl_rrel_inl_rrel,
-                  rule checkMappingPPtr_pde_ccorres)
+           apply (rule ccorres_splitE_novcg, simp, rule checkMappingPPtr_pde_ccorres)
                apply (rule conseqPre, vcg)
                apply (clarsimp simp: typ_heap_simps')
                subgoal by (simp add: pde_pde_section_lift_def cpde_relation_def pde_lift_def
                                      Let_def pde_tag_defs isSectionPDE_def
                               split: pde.split_asm if_split_asm)
               apply (rule ceqv_refl)
-             apply (simp add: Collect_False dc_def[symmetric]
-                      del: Collect_const)
-             apply (rule ccorres_handlers_weaken2, simp)
+             apply (simp add: Collect_False del: Collect_const)
+             apply (rule ccorres_handlers_weaken2)
              apply csymbr
              apply (rule ccorres_split_nothrow_novcg_dc)
                 apply (rule storePDE_Basic_ccorres)
                 apply (simp add: cpde_relation_def Let_def
                               pde_lift_pde_invalid)
                apply csymbr
-               apply (ctac add: cleanByVA_PoU_ccorres[unfolded dc_def])
+               apply (ctac add: cleanByVA_PoU_ccorres)
               apply wp
              apply (clarsimp simp: guard_is_UNIV_def)
             apply simp
@@ -2274,21 +2267,22 @@ lemma unmapPage_ccorres:
           \<comment> \<open>ARMSuperSection\<close>
           apply (rule ccorres_Cond_rhs)
            apply (rule ccorres_rhs_assoc)+
+           \<comment> \<open>FIXME: The third csymbr rewrites the return relation of the goal.
+                      If this was avoided then folding the dc_def could be removed\<close>
            apply csymbr
            apply csymbr
            apply csymbr
+           apply (fold dc_def)
            apply (case_tac "pd = pde_Ptr (lookup_pd_slot pdPtr vptr)")
             prefer 2
             apply (simp, rule ccorres_empty)
-           apply (simp add: gen_framesize_to_H_def dc_def[symmetric]
-                         liftE_liftM mapM_discarded whileAnno_def
-                         superSectionPDEOffsets_def pdeBits_def
-                    del: Collect_const)
+           apply (simp add: gen_framesize_to_H_def liftE_liftM mapM_discarded whileAnno_def
+                            superSectionPDEOffsets_def pdeBits_def
+                       del: Collect_const)
            apply (rule ccorres_rhs_assoc2, rule ccorres_rhs_assoc2,
                rule ccorres_rhs_assoc2, rule ccorres_rhs_assoc2,
                rule ccorres_rhs_assoc2)
-           apply (rule ccorres_splitE_novcg, simp only: inl_rrel_inl_rrel,
-                       rule checkMappingPPtr_pde_ccorres)
+           apply (rule ccorres_splitE_novcg, simp, rule checkMappingPPtr_pde_ccorres)
                apply (rule conseqPre, vcg)
                apply (clarsimp simp: typ_heap_simps')
                subgoal by (simp add: cpde_relation_def Let_def pde_lift_def
@@ -2332,7 +2326,7 @@ lemma unmapPage_ccorres:
                apply csymbr
                apply (rule ccorres_move_c_guard_pde ccorres_move_array_assertion_pde_16)+
                apply (rule ccorres_add_return2)
-               apply (ctac(no_vcg) add: cleanCacheRange_PoU_ccorres[unfolded dc_def])
+               apply (ctac(no_vcg) add: cleanCacheRange_PoU_ccorres)
                 apply (rule ccorres_move_array_assertion_pde_16, rule ccorres_return_Skip')
                apply wp
               apply (rule_tac P="is_aligned pdPtr pdBits" in hoare_gen_asm)
@@ -2369,14 +2363,14 @@ lemma unmapPage_ccorres:
           apply (rule ccorres_empty[where P=\<top>])
          apply ceqv
         apply (simp add: liftE_liftM)
-        apply (ctac add: flushPage_ccorres[unfolded dc_def])
+        apply (ctac add: flushPage_ccorres)
        apply ((wp lookupPTSlot_inv mapM_storePTE_invs[unfolded swp_def]
                  mapM_storePDE_invs[unfolded swp_def]
               | wpc | simp)+)[1]
       apply (simp add: guard_is_UNIV_def)
      apply (simp add: throwError_def)
      apply (rule ccorres_split_throws)
-      apply (rule ccorres_return_void_C[unfolded dc_def])
+      apply (rule ccorres_return_void_C)
      apply vcg
     apply (simp add: lookup_pd_slot_def Let_def)
     apply (wp hoare_vcg_const_imp_lift_R)
@@ -2965,7 +2959,7 @@ lemma performASIDPoolInvocation_ccorres:
         apply (wp getASID_wp)
         apply simp
        apply wp
-       apply (simp add: o_def inv_def)
+       apply (simp add: inv_def)
        apply (wp getASID_wp)
       apply simp
       apply (rule empty_fail_getObject)
@@ -3020,14 +3014,14 @@ lemma flushTable_ccorres:
        apply (rule_tac R=\<top> in ccorres_cond2)
          apply (clarsimp simp: from_bool_0 Collect_const_mem)
         apply (rule ccorres_pre_getCurThread)
-        apply (ctac (no_vcg) add: setVMRoot_ccorres [unfolded dc_def])
-       apply (rule ccorres_return_Skip[unfolded dc_def])
+        apply (ctac (no_vcg) add: setVMRoot_ccorres)
+       apply (rule ccorres_return_Skip)
       apply (wp static_imp_wp)
        apply clarsimp
        apply (rule_tac Q="\<lambda>_ s. invs' s \<and> cur_tcb' s" in hoare_post_imp)
         apply (simp add: invs'_invs_no_cicd cur_tcb'_def)
        apply (wp mapM_x_wp_inv getPTE_wp | wpc)+
-     apply (rule ccorres_return_Skip[unfolded dc_def])
+     apply (rule ccorres_return_Skip)
     apply wp
    apply clarsimp
    apply (strengthen invs_valid_pde_mappings')

--- a/proof/crefine/ARM_HYP/CSpace_All.thy
+++ b/proof/crefine/ARM_HYP/CSpace_All.thy
@@ -25,9 +25,9 @@ abbreviation
 
 (* FIXME: move *)
 lemma ccorres_return_into_rel:
-  "ccorres (\<lambda>rv rv'. r (f rv) rv') xf G G' hs a c
+  "ccorres (r \<circ> f) xf G G' hs a c
   \<Longrightarrow> ccorres r xf G G' hs (a >>= (\<lambda>rv. return (f rv))) c"
-  by (simp add: liftM_def[symmetric] o_def)
+  by (simp add: liftM_def[symmetric])
 
 lemma lookupCap_ccorres':
   "ccorres (lookup_failure_rel \<currency> ccap_relation) lookupCap_xf

--- a/proof/crefine/ARM_HYP/CSpace_C.thy
+++ b/proof/crefine/ARM_HYP/CSpace_C.thy
@@ -919,7 +919,7 @@ lemma setUntypedCapAsFull_ccorres [corres]:
     apply (rule ccorres_move_c_guard_cte)
     apply (rule ccorres_Guard)
     apply (rule ccorres_call)
-       apply (rule update_freeIndex [unfolded dc_def])
+       apply (rule update_freeIndex)
       apply simp
      apply simp
     apply simp
@@ -945,14 +945,14 @@ lemma setUntypedCapAsFull_ccorres [corres]:
       apply csymbr
       apply (clarsimp simp: cap_get_tag_to_H cap_get_tag_UntypedCap split: if_split_asm)
       apply (rule ccorres_cond_false)
-      apply (rule ccorres_return_Skip [unfolded dc_def])
+      apply (rule ccorres_return_Skip)
      apply (clarsimp simp: cap_get_tag_isCap[symmetric] cap_get_tag_UntypedCap split: if_split_asm)
      apply (rule ccorres_cond_false)
-     apply (rule ccorres_return_Skip [unfolded dc_def])
-    apply (rule ccorres_return_Skip [unfolded dc_def])
+     apply (rule ccorres_return_Skip)
+    apply (rule ccorres_return_Skip)
    apply clarsimp
    apply (rule ccorres_cond_false)
-   apply (rule ccorres_return_Skip [unfolded dc_def])
+   apply (rule ccorres_return_Skip)
   apply (clarsimp simp: cap_get_tag_isCap[symmetric] cap_get_tag_UntypedCap)
   apply (frule(1) cte_wp_at_valid_objs_valid_cap')
   apply (clarsimp simp: untypedBits_defs)
@@ -1071,19 +1071,17 @@ lemma cteInsert_ccorres:
                   apply csymbr
                   apply simp
                   apply (rule ccorres_move_c_guard_cte)
-                  apply (simp add:dc_def[symmetric])
                   apply (ctac ccorres:ccorres_updateMDB_set_mdbPrev)
-                 apply (simp add:dc_def[symmetric])
                  apply (ctac ccorres: ccorres_updateMDB_skip)
                 apply (wp static_imp_wp)+
-              apply (clarsimp simp: Collect_const_mem dc_def split del: if_split)
+              apply (clarsimp simp: Collect_const_mem split del: if_split)
               apply vcg
              apply (wp static_imp_wp)
-            apply (clarsimp simp: Collect_const_mem dc_def split del: if_split)
+            apply (clarsimp simp: Collect_const_mem split del: if_split)
             apply vcg
            apply (clarsimp simp:cmdb_node_relation_mdbNext)
            apply (wp setUntypedCapAsFull_cte_at_wp static_imp_wp)
-          apply (clarsimp simp: Collect_const_mem dc_def split del: if_split)
+          apply (clarsimp simp: Collect_const_mem split del: if_split)
           apply (vcg exspec=setUntypedCapAsFull_modifies)
          apply wp
         apply vcg
@@ -1254,7 +1252,7 @@ lemma cteMove_ccorres:
    apply (intro conjI, simp+)
    apply (erule (2) is_aligned_3_prev)
    apply (erule (2) is_aligned_3_next)
-  apply (clarsimp simp: dc_def split del: if_split)
+  apply (clarsimp split del: if_split)
   apply (simp add: ccap_relation_NullCap_iff)
   apply (clarsimp simp: cmdbnode_relation_def mdb_node_to_H_def nullMDBNode_def)
   done
@@ -1398,7 +1396,6 @@ lemma cteMove_ccorres_verbose:
   \<comment> \<open>***--------------------------***\<close>
   \<comment> \<open>***C generalised precondition***\<close>
   \<comment> \<open>***--------------------------***\<close>
-  apply (unfold dc_def)
   apply (clarsimp simp: ccap_relation_NullCap_iff split del: if_split)
   \<comment> \<open>cmdbnode_relation nullMDBNode va\<close>
   apply (simp add: cmdbnode_relation_def)
@@ -2377,7 +2374,6 @@ lemma postCapDeletion_ccorres:
     apply (rule ccorres_symb_exec_r)
       apply (rule_tac xf'=irq_' in ccorres_abstract, ceqv)
       apply (rule_tac P="rv' = ucast (capIRQ cap)" in ccorres_gen_asm2)
-      apply (fold dc_def)
       apply (frule cap_get_tag_to_H, solves \<open>clarsimp simp: cap_get_tag_isCap_unfolded_H_cap\<close>)
       apply (clarsimp simp: cap_irq_handler_cap_lift)
       apply (ctac(no_vcg) add: deletedIRQHandler_ccorres)
@@ -2388,9 +2384,9 @@ lemma postCapDeletion_ccorres:
    apply (clarsimp simp: cap_get_tag_isCap)
    apply (rule ccorres_Cond_rhs)
     apply (wpc; clarsimp simp: isCap_simps)
-    apply (ctac(no_vcg) add: Arch_postCapDeletion_ccorres[unfolded dc_def])
+    apply (ctac(no_vcg) add: Arch_postCapDeletion_ccorres)
    apply (simp add: not_irq_or_arch_cap_case)
-   apply (rule ccorres_return_Skip[unfolded dc_def])+
+   apply (rule ccorres_return_Skip)
   apply clarsimp
   apply (rule conjI, clarsimp simp: isCap_simps  Kernel_C.maxIRQ_def)
    apply (frule cap_get_tag_isCap_unfolded_H_cap(5))
@@ -2439,7 +2435,7 @@ lemma emptySlot_ccorres:
 
     \<comment> \<open>*** proof for the 'else' branch (return () and SKIP) ***\<close>
      prefer 2
-     apply (ctac add: ccorres_return_Skip[unfolded dc_def])
+     apply (ctac add: ccorres_return_Skip)
 
     \<comment> \<open>*** proof for the 'then' branch ***\<close>
 
@@ -2484,7 +2480,7 @@ lemma emptySlot_ccorres:
 
                   \<comment> \<open>the post_cap_deletion case\<close>
 
-                  apply (ctac(no_vcg) add: postCapDeletion_ccorres [unfolded dc_def])
+                  apply (ctac(no_vcg) add: postCapDeletion_ccorres)
 
                 \<comment> \<open>Haskell pre/post for y \<leftarrow> updateMDB slot (\<lambda>a. nullMDBNode);\<close>
                  apply wp
@@ -2557,7 +2553,7 @@ lemma capSwapForDelete_ccorres:
    apply (simp add:when_def)
    apply (rule ccorres_if_cond_throws2 [where Q = \<top> and Q' = \<top>])
       apply (case_tac "slot1=slot2", simp+)
-     apply (rule ccorres_return_void_C [simplified dc_def])
+     apply (rule ccorres_return_void_C)
 
   \<comment> \<open>***Main goal***\<close>
   \<comment> \<open>--- ccorres goal with 2 affectations (cap1 and cap2) on both on Haskell and C\<close>
@@ -2566,7 +2562,7 @@ lemma capSwapForDelete_ccorres:
     apply (rule ccorres_pre_getCTE)+
     apply (rule ccorres_move_c_guard_cte, rule ccorres_symb_exec_r)+
   \<comment> \<open>***Main goal***\<close>
-        apply (ctac (no_vcg) add: cteSwap_ccorres [unfolded dc_def] )
+        apply (ctac (no_vcg) add: cteSwap_ccorres)
        \<comment> \<open>C Hoare triple for \<acute>cap2 :== \<dots>\<close>
        apply vcg
        \<comment> \<open>C existential Hoare triple for \<acute>cap2 :== \<dots>\<close>

--- a/proof/crefine/ARM_HYP/Delete_C.thy
+++ b/proof/crefine/ARM_HYP/Delete_C.thy
@@ -845,7 +845,7 @@ lemma finaliseSlot_ccorres:
                                       ccorres_seq_skip)
                     apply (rule rsubst[where P="ccorres r xf' P P' hs a" for r xf' P P' hs a])
                     apply (rule hyps[folded reduceZombie_def[unfolded cteDelete_def finaliseSlot_def],
-                                         unfolded split_def, unfolded K_def],
+                                     unfolded split_def],
                            (simp add: in_monad)+)
                     apply (simp add: from_bool_0)
                    apply simp
@@ -991,26 +991,23 @@ lemma cteRevoke_ccorres1:
          apply (rule ccorres_drop_cutMon_bindE)
          apply (rule ccorres_rhs_assoc)+
          apply (ctac(no_vcg) add: cteDelete_ccorres)
-           apply (simp del: Collect_const add: Collect_False ccorres_cond_iffs
-                                               dc_def[symmetric])
+           apply (simp del: Collect_const add: Collect_False ccorres_cond_iffs)
            apply (rule ccorres_cutMon, simp only: cutMon_walk_bindE)
            apply (rule ccorres_drop_cutMon_bindE)
            apply (ctac(no_vcg) add: preemptionPoint_ccorres)
-             apply (simp del: Collect_const add: Collect_False ccorres_cond_iffs
-                                                 dc_def[symmetric])
+             apply (simp del: Collect_const add: Collect_False ccorres_cond_iffs)
              apply (rule ccorres_cutMon)
              apply (rule rsubst[where P="ccorres r xf' P P' hs a" for r xf' P P' hs a])
-              apply (rule hyps[unfolded K_def],
-                     (fastforce simp: in_monad)+)[1]
+              apply (rule hyps; fastforce simp: in_monad)
              apply simp
             apply (simp, rule ccorres_split_throws)
-             apply (rule ccorres_return_C_errorE, simp+)[1]
+             apply (rule ccorres_return_C_errorE; simp)
             apply vcg
            apply (wp preemptionPoint_invR)
             apply simp
            apply simp
           apply (simp, rule ccorres_split_throws)
-           apply (rule ccorres_return_C_errorE, simp+)[1]
+           apply (rule ccorres_return_C_errorE; simp)
           apply vcg
          apply (wp cteDelete_invs' cteDelete_sch_act_simple)
         apply (rule ccorres_cond_false)

--- a/proof/crefine/ARM_HYP/Fastpath_C.thy
+++ b/proof/crefine/ARM_HYP/Fastpath_C.thy
@@ -769,7 +769,7 @@ lemma switchToThread_fp_ccorres:
              ceqv, rename_tac "hw_asid_ret")
         apply (ctac(no_vcg) add: armv_contextSwitch_HWASID_ccorres)
          apply (simp add: storeWordUser_def bind_assoc case_option_If2 split_def del: Collect_const)
-         apply (simp only: dmo_clearExMonitor_setCurThread_swap dc_def[symmetric])
+         apply (simp only: dmo_clearExMonitor_setCurThread_swap)
          apply (rule ccorres_split_nothrow_novcg_dc)
             apply (rule ccorres_from_vcg[where P=\<top> and P'=UNIV])
             apply (rule allI, rule conseqPre, vcg)
@@ -1029,10 +1029,7 @@ lemma ccorres_call_hSkip:
   apply -
   apply (rule ccorres_call_hSkip')
        apply (erule ccorres_guard_imp)
-        apply simp
-       apply clarsimp
-      apply (simp_all add: ggl xfdc_def)
-  apply (clarsimp simp: igl)
+        apply (clarsimp simp: ggl igl xfdc_def)+
   done
 
 lemma bind_case_sum_rethrow:
@@ -1821,7 +1818,6 @@ proof -
        apply (rule ccorres_Cond_rhs_Seq)
           apply (rule ccorres_alternative2)
           apply (rule ccorres_split_throws)
-           apply (fold dc_def)[1]
            apply (rule ccorres_call_hSkip)
              apply (rule slowpath_ccorres)
             apply simp
@@ -1856,7 +1852,7 @@ proof -
           apply (rule ccorres_cond_true_seq)
           apply (rule ccorres_split_throws)
            apply (rule ccorres_call_hSkip)
-             apply (erule disjE; simp flip: dc_def; rule slowpath_ccorres)
+             apply (erule disjE; simp; rule slowpath_ccorres)
             apply simp
            apply simp
           apply (vcg exspec=slowpath_noreturn_spec)
@@ -1871,7 +1867,6 @@ proof -
          apply (rule ccorres_Cond_rhs_Seq)
           apply simp
           apply (rule ccorres_split_throws)
-           apply (fold dc_def)[1]
            apply (rule ccorres_call_hSkip)
              apply (rule slowpath_ccorres, simp+)
           apply (vcg exspec=slowpath_noreturn_spec)
@@ -1908,7 +1903,6 @@ proof -
            apply (rule ccorres_Cond_rhs_Seq)
             apply simp
             apply (rule ccorres_split_throws)
-             apply (fold dc_def)[1]
              apply (rule ccorres_call_hSkip)
                apply (rule slowpath_ccorres, simp+)
             apply (vcg exspec=slowpath_noreturn_spec)
@@ -1931,7 +1925,6 @@ proof -
              apply (rule ccorres_Cond_rhs_Seq)
               apply simp
               apply (rule ccorres_split_throws)
-               apply (fold dc_def)[1]
                apply (rule ccorres_call_hSkip)
                  apply (rule slowpath_ccorres, simp+)
               apply (vcg exspec=slowpath_noreturn_spec)
@@ -1989,29 +1982,25 @@ proof -
                         apply (simp add: ctcb_relation_unat_tcbPriority_C
                                           word_less_nat_alt linorder_not_le)
                         apply ceqv
-                       apply (simp add: Collect_const_mem from_bool_eq_if from_bool_eq_if' from_bool_0 if_1_0_0 ccorres_IF_True del: Collect_const)
-                       apply (simp add: if_1_0_0 ccap_relation_ep_helpers from_bool_0 word_le_not_less
-                                    del: Collect_const cong: call_ignore_cong)
+                       apply (simp add: from_bool_eq_if from_bool_eq_if' from_bool_0 ccorres_IF_True del: Collect_const)
 
                        apply (rule ccorres_Cond_rhs)
-                        apply (simp add: bindE_assoc del: Collect_const)
                         apply (rule ccorres_Guard_Seq)
                         apply (rule ccorres_add_return2)
                         apply (ctac add: isHighestPrio_ccorres)
-                        apply (simp add: Collect_const_mem from_bool_eq_if from_bool_eq_if' from_bool_0 if_1_0_0 ccorres_IF_True del: Collect_const)
+                        apply (simp add: from_bool_eq_if from_bool_eq_if' from_bool_0 ccorres_IF_True del: Collect_const)
                         apply (clarsimp simp: to_bool_def)
                         apply (rule_tac P=\<top> and P'=UNIV in ccorres_from_vcg)
                         apply clarsimp
                         apply (rule conseqPre, vcg)
-                        apply (clarsimp simp: from_bool_eq_if from_bool_eq_if' from_bool_0 if_1_0_0)
+                        apply (clarsimp simp: from_bool_eq_if' word_le_not_less from_bool_0)
                         apply (clarsimp simp: return_def)
                         apply (rule wp_post_taut)
                         apply (vcg exspec=isHighestPrio_modifies)
-                       apply (simp add: Collect_const_mem from_bool_eq_if from_bool_eq_if' from_bool_0 if_1_0_0 ccorres_IF_True del: Collect_const)
                        apply (rule_tac P=\<top> and P'="{s. ret__int_' s = 0}" in ccorres_from_vcg)
                        apply (clarsimp simp: isHighestPrio_def' simpler_gets_def)
                        apply (rule conseqPre, vcg)
-                       apply clarsimp
+                       apply (clarsimp simp: from_bool_0)
                       apply clarsimp
                       apply vcg
                      apply (simp add: Collect_const_mem from_bool_eq_if from_bool_eq_if' from_bool_0 if_1_0_0 ccorres_IF_True del: Collect_const)
@@ -2025,7 +2014,6 @@ proof -
                    apply (rule ccorres_Cond_rhs_Seq)
                     apply (simp add: bindE_assoc from_bool_0 catch_throwError del: Collect_const)
                     apply (rule ccorres_split_throws)
-                     apply (fold dc_def)[1]
                      apply (rule ccorres_call_hSkip)
                        apply (rule slowpath_ccorres, simp+)
                     apply (vcg exspec=slowpath_noreturn_spec)
@@ -2044,7 +2032,6 @@ proof -
                apply (rule ccorres_Cond_rhs_Seq)
                 apply simp
                 apply (rule ccorres_split_throws)
-                 apply (fold dc_def)[1]
                  apply (rule ccorres_call_hSkip)
                    apply (rule slowpath_ccorres, simp+)
                 apply (vcg exspec=slowpath_noreturn_spec)
@@ -2059,7 +2046,6 @@ proof -
                   apply (rule ccorres_Cond_rhs_Seq)
                    apply (simp add: pde_stored_asid_def asid_map_pd_to_hwasids_def)
                    apply (rule ccorres_split_throws)
-                    apply (fold dc_def)[1]
                     apply (rule ccorres_call_hSkip)
                       apply (rule slowpath_ccorres, simp+)
                    apply (vcg exspec=slowpath_noreturn_spec)
@@ -2088,7 +2074,6 @@ proof -
                     apply (rule ccorres_seq_cond_raise[THEN iffD2])
                     apply (rule_tac R=\<top> in ccorres_cond2', blast)
                      apply (rule ccorres_split_throws)
-                      apply (fold dc_def)[1]
                       apply (rule ccorres_call_hSkip)
                         apply (rule slowpath_ccorres, simp+)
                      apply (vcg exspec=slowpath_noreturn_spec)
@@ -2144,7 +2129,7 @@ proof -
                                       ccorres_move_array_assertion_tcb_ctes
                                       ccorres_move_c_guard_tcb_ctes)+
                           apply csymbr
-                          apply (simp add: cteInsert_def bind_assoc dc_def[symmetric]
+                          apply (simp add: cteInsert_def bind_assoc
                                       del: Collect_const cong: call_ignore_cong)
                           apply (rule ccorres_pre_getCTE2, rename_tac curThreadReplyCTE)
                           apply (simp only: getThreadState_def)
@@ -2267,7 +2252,6 @@ proof -
                                        apply csymbr
                                        apply csymbr
                                        apply (rule ccorres_call_hSkip)
-                                         apply (fold dc_def)[1]
                                          apply (rule fastpath_restore_ccorres)
                                         apply simp
                                        apply simp
@@ -2294,7 +2278,7 @@ proof -
                                apply (wp updateMDB_weak_cte_wp_at)
                               apply simp
                               apply (vcg exspec=mdb_node_ptr_mset_mdbNext_mdbRevocable_mdbFirstBadged_modifies)
-                             apply (simp add: o_def)
+                             apply simp
                              apply (wp | simp
                                         | wp (once) updateMDB_weak_cte_wp_at
                                         | wp (once) updateMDB_cte_wp_at_other)+
@@ -2650,7 +2634,6 @@ lemma fastpath_reply_recv_ccorres:
        apply (rule ccorres_Cond_rhs_Seq)
         apply (rule ccorres_alternative2)
         apply (rule ccorres_split_throws)
-         apply (fold dc_def)[1]
          apply (rule ccorres_call_hSkip)
            apply (rule slowpath_ccorres)
           apply simp
@@ -2684,7 +2667,7 @@ lemma fastpath_reply_recv_ccorres:
           apply (rule ccorres_cond_true_seq)
           apply (rule ccorres_split_throws)
            apply (rule ccorres_call_hSkip)
-             apply (erule disjE; simp flip: dc_def; rule slowpath_ccorres)
+             apply (erule disjE; simp; rule slowpath_ccorres)
             apply simp
            apply simp
           apply (vcg exspec=slowpath_noreturn_spec)
@@ -2699,7 +2682,6 @@ lemma fastpath_reply_recv_ccorres:
          apply (rule ccorres_Cond_rhs_Seq)
           apply simp
           apply (rule ccorres_split_throws)
-           apply (fold dc_def)[1]
            apply (rule ccorres_call_hSkip)
              apply (rule slowpath_ccorres)
             apply simp
@@ -2724,7 +2706,6 @@ lemma fastpath_reply_recv_ccorres:
              apply (rule ccorres_Cond_rhs_Seq)
             apply (rule ccorres_split_throws)
              apply simp
-             apply (fold dc_def)[1]
              apply (rule ccorres_call_hSkip)
                apply (rule slowpath_ccorres, simp+)
             apply (vcg exspec=slowpath_noreturn_spec)
@@ -2754,7 +2735,6 @@ lemma fastpath_reply_recv_ccorres:
                apply (rule ccorres_Cond_rhs_Seq)
                 apply (simp del: Collect_const not_None_eq)
                 apply (rule ccorres_split_throws)
-                 apply (fold dc_def)[1]
                  apply (rule ccorres_call_hSkip)
                    apply (rule slowpath_ccorres, simp+)
                 apply (vcg exspec=slowpath_noreturn_spec)
@@ -2770,7 +2750,7 @@ lemma fastpath_reply_recv_ccorres:
                            and val="tcb_ptr_to_ctcb_ptr curThread"
                            in ccorres_abstract_known)
                 apply (rule Seq_weak_ceqv, rule Basic_ceqv)
-                apply (rule rewrite_xfI, clarsimp simp only: o_def)
+                apply (rule rewrite_xfI)
                 apply (rule refl)
                apply csymbr
                apply (rule ccorres_move_c_guard_cte)
@@ -2788,7 +2768,6 @@ lemma fastpath_reply_recv_ccorres:
              apply (rule ccorres_Cond_rhs_Seq)
               apply (simp cong: conj_cong)
                 apply (rule ccorres_split_throws)
-                 apply (fold dc_def)[1]
                  apply (rule ccorres_call_hSkip)
                    apply (rule slowpath_ccorres, simp+)
                 apply (vcg exspec=slowpath_noreturn_spec)
@@ -2808,7 +2787,6 @@ lemma fastpath_reply_recv_ccorres:
                  apply (rule ccorres_Cond_rhs_Seq)
                   apply (simp del: Collect_const not_None_eq)
                   apply (rule ccorres_split_throws)
-                   apply (fold dc_def)[1]
                    apply (rule ccorres_call_hSkip)
                      apply (rule slowpath_ccorres, simp+)
                   apply (vcg exspec=slowpath_noreturn_spec)
@@ -2830,7 +2808,6 @@ lemma fastpath_reply_recv_ccorres:
 
                     apply simp
                     apply (rule ccorres_split_throws)
-                     apply (fold dc_def)[1]
                      apply (rule ccorres_call_hSkip)
                        apply (rule slowpath_ccorres, simp+)
                     apply (vcg exspec=slowpath_noreturn_spec)
@@ -2862,7 +2839,6 @@ lemma fastpath_reply_recv_ccorres:
                       apply (rule ccorres_cond2'[where R=\<top>], blast)
 
                       apply (rule ccorres_split_throws)
-                      apply (fold dc_def)[1]
                       apply (rule ccorres_call_hSkip)
                       apply (rule slowpath_ccorres, simp+)
                       apply (vcg exspec=slowpath_noreturn_spec)
@@ -2877,7 +2853,6 @@ lemma fastpath_reply_recv_ccorres:
                       apply (rule ccorres_Cond_rhs_Seq)
                        apply (simp add: pde_stored_asid_def asid_map_pd_to_hwasids_def)
                        apply (rule ccorres_split_throws)
-                        apply (fold dc_def)[1]
                         apply (rule ccorres_call_hSkip)
                           apply (rule slowpath_ccorres, simp+)
                        apply (vcg exspec=slowpath_noreturn_spec)
@@ -2908,7 +2883,6 @@ lemma fastpath_reply_recv_ccorres:
 
                      apply simp
                      apply (rule ccorres_split_throws)
-                      apply (fold dc_def)[1]
                       apply (rule ccorres_call_hSkip)
                         apply (rule slowpath_ccorres, simp+)
                      apply (vcg exspec=slowpath_noreturn_spec)
@@ -2948,7 +2922,7 @@ lemma fastpath_reply_recv_ccorres:
                        apply ceqv
                       apply (rule ccorres_rhs_assoc2, rule ccorres_rhs_assoc2)
                       apply (rule_tac xf'=xfdc and r'=dc in ccorres_split_nothrow)
-                          apply (rule fastpath_enqueue_ccorres[unfolded o_def,simplified])
+                          apply (rule fastpath_enqueue_ccorres[simplified])
                           apply simp
                          apply ceqv
                         apply (simp add: liftM_def del: Collect_const cong: call_ignore_cong)
@@ -3037,7 +3011,6 @@ lemma fastpath_reply_recv_ccorres:
                                      apply csymbr
                                      apply csymbr
                                      apply (rule ccorres_call_hSkip)
-                                       apply (fold dc_def)[1]
                                        apply (rule fastpath_restore_ccorres)
                                       apply simp
                                      apply simp
@@ -3062,7 +3035,7 @@ lemma fastpath_reply_recv_ccorres:
                              apply (wp setCTE_cte_wp_at_other)
                             apply (simp del: Collect_const)
                             apply vcg
-                           apply (simp add: o_def)
+                           apply simp
                            apply (wp | simp
                                       | wp (once) updateMDB_weak_cte_wp_at
                                       | wp (once) updateMDB_cte_wp_at_other)+

--- a/proof/crefine/ARM_HYP/Fastpath_Equiv.thy
+++ b/proof/crefine/ARM_HYP/Fastpath_Equiv.thy
@@ -966,7 +966,7 @@ lemma tcbSchedDequeue_rewrite_not_queued:
   apply (monadic_rewrite_l monadic_rewrite_if_l_False \<open>wp threadGet_const\<close>)
    apply (monadic_rewrite_symb_exec_l, rule monadic_rewrite_refl)
    apply wp+
-  apply (clarsimp simp: o_def obj_at'_def)
+  apply clarsimp
   done
 
 lemma schedule_known_rewrite:
@@ -1399,8 +1399,7 @@ lemma fastpath_callKernel_SysReplyRecv_corres:
                         capFaultOnFailure_def rethrowFailure_injection
                         injection_handler_catch bind_bindE_assoc
                         getThreadCallerSlot_def bind_assoc
-                        getSlotCap_def
-                        case_bool_If o_def
+                        getSlotCap_def case_bool_If
                         isRight_def[where x="Inr v" for v]
                         isRight_def[where x="Inl v" for v]
                   cong: if_cong)

--- a/proof/crefine/ARM_HYP/Finalise_C.thy
+++ b/proof/crefine/ARM_HYP/Finalise_C.thy
@@ -200,8 +200,7 @@ proof (induct ts)
     apply (rule iffD1 [OF ccorres_expand_while_iff])
     apply (rule ccorres_tmp_lift2[where G'=UNIV and G''="\<lambda>x. UNIV", simplified])
      apply ceqv
-    apply (simp add: ccorres_cond_iffs mapM_x_def sequence_x_def
-                     dc_def[symmetric])
+    apply (simp add: ccorres_cond_iffs mapM_x_def sequence_x_def)
     apply (rule ccorres_guard_imp2, rule ccorres_return_Skip)
     apply simp
     done
@@ -210,7 +209,7 @@ next
   show ?case
     apply (rule iffD1 [OF ccorres_expand_while_iff])
     apply (simp del: Collect_const
-                add: dc_def[symmetric] mapM_x_Cons)
+                add: mapM_x_Cons)
     apply (rule ccorres_guard_imp2)
      apply (rule_tac xf'=thread_' in ccorres_abstract)
       apply ceqv
@@ -324,7 +323,7 @@ lemma cancelAllIPC_ccorres:
              subgoal by (simp add: cendpoint_relation_def endpoint_state_defs)
             subgoal by simp
            apply (rule ceqv_refl)
-          apply (simp only: ccorres_seq_skip dc_def[symmetric])
+          apply (simp only: ccorres_seq_skip)
           apply (rule ccorres_split_nothrow_novcg)
               apply (rule cancel_all_ccorres_helper)
              apply ceqv
@@ -341,12 +340,10 @@ lemma cancelAllIPC_ccorres:
          apply (wp set_ep_valid_objs' hoare_vcg_const_Ball_lift
                    weak_sch_act_wf_lift_linear)
         apply vcg
-       apply (simp add: ccorres_cond_iffs dc_def[symmetric])
+       apply (simp add: ccorres_cond_iffs)
        apply (rule ccorres_return_Skip)
       apply (rename_tac list)
-      apply (simp add: endpoint_state_defs
-                       Collect_False Collect_True
-                       ccorres_cond_iffs dc_def[symmetric]
+      apply (simp add: endpoint_state_defs Collect_False Collect_True ccorres_cond_iffs
                   del: Collect_const)
       apply (rule ccorres_rhs_assoc)+
       apply csymbr
@@ -374,7 +371,7 @@ lemma cancelAllIPC_ccorres:
            subgoal by (simp add: cendpoint_relation_def endpoint_state_defs)
           subgoal by simp
          apply (rule ceqv_refl)
-        apply (simp only: ccorres_seq_skip dc_def[symmetric])
+        apply (simp only: ccorres_seq_skip)
         apply (rule ccorres_split_nothrow_novcg)
             apply (rule cancel_all_ccorres_helper)
            apply ceqv
@@ -422,15 +419,12 @@ lemma cancelAllSignals_ccorres:
      apply (rule_tac A="invs' and ko_at' rv ntfnptr"
                   in ccorres_guard_imp2[where A'=UNIV])
       apply wpc
-        apply (simp add: notification_state_defs ccorres_cond_iffs
-                         dc_def[symmetric])
+        apply (simp add: notification_state_defs ccorres_cond_iffs)
         apply (rule ccorres_return_Skip)
-       apply (simp add: notification_state_defs ccorres_cond_iffs
-                        dc_def[symmetric])
+       apply (simp add: notification_state_defs ccorres_cond_iffs)
        apply (rule ccorres_return_Skip)
       apply (rename_tac list)
-      apply (simp add: notification_state_defs ccorres_cond_iffs
-                       dc_def[symmetric] Collect_True
+      apply (simp add: notification_state_defs ccorres_cond_iffs Collect_True
                   del: Collect_const)
       apply (rule ccorres_rhs_assoc)+
       apply csymbr
@@ -456,7 +450,7 @@ lemma cancelAllSignals_ccorres:
            subgoal by (simp add: cnotification_relation_def notification_state_defs Let_def)
           subgoal by simp
          apply (rule ceqv_refl)
-        apply (simp only: ccorres_seq_skip dc_def[symmetric])
+        apply (simp only: ccorres_seq_skip)
         apply (rule ccorres_split_nothrow_novcg)
             apply (rule cancel_all_ccorres_helper)
            apply ceqv
@@ -714,7 +708,7 @@ lemma doUnbindNotification_ccorres:
       apply (rule ccorres_move_c_guard_tcb)
       apply (simp add: setBoundNotification_def)
       apply (rule_tac P'="\<top>" and P="\<top>"
-                   in threadSet_ccorres_lemma3[unfolded dc_def])
+                   in threadSet_ccorres_lemma3)
        apply vcg
       apply simp
       apply (erule(1) rf_sr_tcb_update_no_queue2)
@@ -764,7 +758,7 @@ lemma doUnbindNotification_ccorres':
       apply (rule ccorres_move_c_guard_tcb)
       apply (simp add: setBoundNotification_def)
       apply (rule_tac P'="\<top>" and P="\<top>"
-                   in threadSet_ccorres_lemma3[unfolded dc_def])
+                   in threadSet_ccorres_lemma3)
        apply vcg
       apply simp
       apply (erule(1) rf_sr_tcb_update_no_queue2)
@@ -799,9 +793,9 @@ lemma unbindNotification_ccorres:
      apply simp
      apply wpc
       apply (rule ccorres_cond_false)
-      apply (rule ccorres_return_Skip[unfolded dc_def])
+      apply (rule ccorres_return_Skip)
      apply (rule ccorres_cond_true)
-     apply (ctac (no_vcg) add: doUnbindNotification_ccorres[unfolded dc_def, simplified])
+     apply (ctac (no_vcg) add: doUnbindNotification_ccorres[simplified])
     apply (wp gbn_wp')
    apply vcg
   apply (clarsimp simp: option_to_ptr_def option_to_0_def pred_tcb_at'_def
@@ -1021,7 +1015,6 @@ lemma invalidateASIDEntry_ccorres:
         apply (rule order_le_less_trans, rule word_and_le1)
         apply (simp add: mask_def)
        apply (rule ccorres_return_Skip)
-      apply (fold dc_def)
       apply (ctac add: invalidateASID_ccorres)
      apply wp
     apply (simp add: guard_is_UNIV_def)
@@ -1054,8 +1047,7 @@ lemma deleteASIDPool_ccorres:
   apply (rule ccorres_gen_asm)
   apply (cinit lift: asid_base_' pool_' simp: whileAnno_def)
    apply (rule ccorres_assert)
-   apply (clarsimp simp: liftM_def dc_def[symmetric] fun_upd_def[symmetric]
-                         when_def
+   apply (clarsimp simp: liftM_def fun_upd_def[symmetric] when_def
                simp del: Collect_const)
    apply (rule ccorres_Guard)+
    apply (rule ccorres_pre_gets_armKSASIDTable_ksArchState)
@@ -1202,14 +1194,12 @@ lemma deleteASID_ccorres:
       apply ceqv
      apply csymbr
      apply wpc
-      apply (simp add: ccorres_cond_iffs dc_def[symmetric]
-                       Collect_False
+      apply (simp add: ccorres_cond_iffs Collect_False
                   del: Collect_const
                  cong: call_ignore_cong)
       apply (rule ccorres_cond_false)
       apply (rule ccorres_return_Skip)
-     apply (simp add: dc_def[symmetric] when_def
-                      Collect_True liftM_def
+     apply (simp add: when_def Collect_True liftM_def
                 cong: conj_cong call_ignore_cong
                  del: Collect_const)
      apply (rule ccorres_pre_getObject_asidpool)
@@ -1429,7 +1419,7 @@ lemma unmapPageTable_ccorres:
    apply (ctac(no_vcg) add: pageTableMapped_ccorres)
     apply wpc
      apply (simp add: option_to_ptr_def option_to_0_def ccorres_cond_iffs)
-     apply (rule ccorres_return_Skip[unfolded dc_def])
+     apply (rule ccorres_return_Skip)
     apply (simp add: option_to_ptr_def option_to_0_def ccorres_cond_iffs)
     apply (rule ccorres_rhs_assoc)+
     apply csymbr
@@ -1439,7 +1429,6 @@ lemma unmapPageTable_ccorres:
     apply (rule ccorres_split_nothrow_novcg_dc)
        apply (rule storePDE_Basic_ccorres)
        apply (simp add: cpde_relation_def Let_def pde_lift_pde_invalid)
-      apply (fold dc_def)
       apply csymbr
       apply (ctac add: cleanByVA_PoU_ccorres)
         apply (ctac(no_vcg) add:flushTable_ccorres)
@@ -1572,7 +1561,7 @@ lemma cteDeleteOne_ccorres:
           erule_tac t="ret__unsigned = scast cap_null_cap"
                 and s="cteCap cte = NullCap"
                  in ssubst)
-   apply (clarsimp simp only: when_def unless_def dc_def[symmetric])
+   apply (clarsimp simp only: when_def unless_def)
    apply (rule ccorres_cond2[where R=\<top>])
      apply (clarsimp simp: Collect_const_mem)
     apply (rule ccorres_rhs_assoc)+
@@ -1583,12 +1572,11 @@ lemma cteDeleteOne_ccorres:
       apply (ctac(no_vcg) add: isFinalCapability_ccorres[where slot=slot])
        apply (rule_tac A="invs'  and cte_wp_at' ((=) cte) slot"
                      in ccorres_guard_imp2[where A'=UNIV])
-        apply (simp add: split_def dc_def[symmetric]
-                    del: Collect_const)
+        apply (simp add: split_def del: Collect_const)
         apply (rule ccorres_move_c_guard_cte)
         apply (ctac(no_vcg) add: finaliseCap_True_standin_ccorres)
          apply (rule ccorres_assert)
-         apply (simp add: dc_def[symmetric])
+         apply simp
          apply csymbr
          apply (ctac add: emptySlot_ccorres)
         apply (simp add: pred_conj_def finaliseCapTrue_standin_simple_def)
@@ -1625,7 +1613,7 @@ lemma deletingIRQHandler_ccorres:
                    (UNIV \<inter> {s. irq_opt_relation (Some irq) (irq_' s)}) []
    (deletingIRQHandler irq) (Call deletingIRQHandler_'proc)"
   apply (cinit lift: irq_' cong: call_ignore_cong)
-   apply (clarsimp simp: irq_opt_relation_def ptr_add_assertion_def dc_def[symmetric]
+   apply (clarsimp simp: irq_opt_relation_def ptr_add_assertion_def
                    cong: call_ignore_cong )
    apply (rule_tac r'="\<lambda>rv rv'. rv' = Ptr rv"
                 and xf'="slot_'" in ccorres_split_nothrow)
@@ -1908,7 +1896,6 @@ lemma vcpuInvalidateActive_ccorres:
   "ccorres dc xfdc invs' UNIV hs
            vcpuInvalidateActive
            (Call vcpu_invalidate_active_'proc)"
-  supply dc_simp[simp del]
   apply cinit
    apply (rule ccorres_pre_getCurVCPU)
         apply (subst modify_armHSCurVCPU_when_split)
@@ -1982,7 +1969,6 @@ lemma dissociateVCPUTCB_ccorres:
      (UNIV \<inter> {s. tcb_' s = tcb_ptr_to_ctcb_ptr tptr }
        \<inter> {s. vcpu_' s = vcpu_Ptr vcpuptr }) hs
      (dissociateVCPUTCB vcpuptr tptr) (Call dissociateVCPUTCB_'proc)"
-  supply dc_simp[simp del]
   apply (cinit lift: tcb_' vcpu_')
    apply (rule ccorres_pre_archThreadGet, rename_tac tcbVCPU)
   apply (rule ccorres_pre_getObject_vcpu, rename_tac vcpu)
@@ -2089,7 +2075,6 @@ lemma associateVCPUTCB_ccorres:
      (UNIV \<inter> {s. tcb_' s = tcb_ptr_to_ctcb_ptr tptr }
            \<inter> {s. vcpu_' s = vcpu_Ptr vcpuptr }) hs
      (associateVCPUTCB vcpuptr tptr) (Call associateVCPUTCB_'proc)"
-  supply dc_simp[simp del]
   apply (cinit lift: tcb_' vcpu_')
   apply (rule ccorres_move_c_guard_tcb)
    apply (rule ccorres_pre_archThreadGet, rename_tac tcbVCPU)
@@ -2186,7 +2171,6 @@ lemma vcpuFinalise_ccorres:
   "ccorres dc xfdc (invs' and vcpu_at' vcpuptr)
       ({s. vcpu_' s = Ptr vcpuptr}) []
       (vcpuFinalise vcpuptr) (Call vcpu_finalise_'proc)"
-  supply dc_simp[simp del]
   apply (cinit lift: vcpu_')
    apply (rule ccorres_move_c_guard_vcpu)
    apply (rule ccorres_pre_getObject_vcpu, rename_tac vcpu)
@@ -2239,7 +2223,7 @@ method return_NullCap_pair_ccorres =
           (rule allI, rule conseqPre, vcg), (clarsimp simp: return_def ccap_relation_NullCap_iff)\<close>
 
 lemma Arch_finaliseCap_ccorres:
-  notes dc_simp[simp del] Collect_const[simp del]
+  notes Collect_const[simp del]
   shows
   "ccorres (\<lambda>rv rv'. ccap_relation (fst rv) (remainder_C rv') \<and>
                      ccap_relation (snd rv) (finaliseCap_ret_C.cleanupInfo_C rv'))
@@ -2634,7 +2618,6 @@ lemma prepareThreadDelete_ccorres:
      (invs' and tcb_at' thread)
      (UNIV \<inter> {s. thread_' s = tcb_ptr_to_ctcb_ptr thread}) hs
    (prepareThreadDelete thread) (Call Arch_prepareThreadDelete_'proc)"
-  supply dc_simp[simp del]
   apply (cinit lift: thread_', rename_tac cthread)
    apply (rule ccorres_move_c_guard_tcb)
    apply (rule ccorres_pre_archThreadGet, rename_tac vcpuopt)
@@ -2810,18 +2793,18 @@ lemma finaliseCap_ccorres:
     apply (rule ccorres_fail)
    apply (rule ccorres_add_return, rule ccorres_split_nothrow_novcg[where r'=dc and xf'=xfdc])
        apply (rule ccorres_Cond_rhs)
-        apply (simp add: ccorres_cond_iffs dc_def[symmetric])
+        apply (simp add: ccorres_cond_iffs)
         apply (rule ccorres_return_Skip)
        apply (rule ccorres_Cond_rhs)
-        apply (simp add: ccorres_cond_iffs dc_def[symmetric])
+        apply (simp add: ccorres_cond_iffs)
         apply (rule ccorres_return_Skip)
        apply (rule ccorres_Cond_rhs)
         apply (rule ccorres_inst[where P=\<top> and P'=UNIV])
         apply simp
        apply (rule ccorres_Cond_rhs)
-        apply (simp add: ccorres_cond_iffs dc_def[symmetric])
+        apply (simp add: ccorres_cond_iffs)
         apply (rule ccorres_return_Skip)
-       apply (simp add: ccorres_cond_iffs dc_def[symmetric])
+       apply (simp add: ccorres_cond_iffs)
        apply (rule ccorres_return_Skip)
       apply (rule ceqv_refl)
      apply (rule ccorres_from_vcg_throws[where P=\<top> and P'=UNIV])
@@ -2884,7 +2867,6 @@ lemma Arch_checkIRQ_ccorres:
                     length_ineq_not_Nil hd_conv_nth cast_simps
                del: Collect_const cong: call_ignore_cong)
    apply (rule ccorres_Cond_rhs_Seq)
-    apply (simp add: throwError_bind)
     apply (rule ccorres_from_vcg_split_throws[where P=\<top> and P'=UNIV])
      apply vcg
     apply (rule conseqPre, vcg)

--- a/proof/crefine/ARM_HYP/Finalise_C.thy
+++ b/proof/crefine/ARM_HYP/Finalise_C.thy
@@ -400,11 +400,6 @@ lemma cancelAllIPC_ccorres:
   apply clarsimp
   done
 
-lemma empty_fail_getNotification:
-  "empty_fail (getNotification ep)"
-  unfolding getNotification_def
-  by (auto intro: empty_fail_getObject)
-
 lemma cancelAllSignals_ccorres:
   "ccorres dc xfdc
    (invs') (UNIV \<inter> {s. ntfnPtr_' s = Ptr ntfnptr}) []
@@ -1480,12 +1475,6 @@ lemma no_0_pd_at'[elim!]:
   apply (clarsimp simp: page_directory_at'_def)
   apply (drule spec[where x=0], clarsimp)
   done
-
-lemma ccte_relation_ccap_relation:
-  "ccte_relation cte cte' \<Longrightarrow> ccap_relation (cteCap cte) (cte_C.cap_C cte')"
-  by (clarsimp simp: ccte_relation_def ccap_relation_def
-                     cte_to_H_def map_option_Some_eq2
-                     c_valid_cte_def)
 
 lemma isFinalCapability_ccorres:
   "ccorres ((=) \<circ> from_bool) ret__unsigned_long_'

--- a/proof/crefine/ARM_HYP/Interrupt_C.thy
+++ b/proof/crefine/ARM_HYP/Interrupt_C.thy
@@ -75,12 +75,12 @@ proof -
      apply (rule ccorres_symb_exec_r)
        apply (ctac(no_vcg) add: cteDeleteOne_ccorres[where w="-1"])
         apply (rule ccorres_call)
-        apply (rule cteInsert_ccorres[simplified dc_def])
+        apply (rule cteInsert_ccorres)
           apply simp
          apply simp
         apply simp
        apply (simp add: pred_conj_def)
-       apply (strengthen ntfn_badge_derived_enough_strg[unfolded o_def]
+       apply (strengthen ntfn_badge_derived_enough_strg
                          invs_mdb_strengthen' valid_objs_invs'_strg)
        apply (wp cteDeleteOne_other_cap[unfolded o_def])[1]
       apply vcg
@@ -112,7 +112,7 @@ lemma invokeIRQHandler_ClearIRQHandler_ccorres:
    apply simp
    apply (ctac(no_vcg) add: getIRQSlot_ccorres[simplified])
      apply (rule ccorres_symb_exec_r)
-       apply (ctac add: cteDeleteOne_ccorres[where w="-1",simplified dc_def])
+       apply (ctac add: cteDeleteOne_ccorres[where w="-1"])
       apply vcg
      apply (rule conseqPre, vcg,
             clarsimp simp: rf_sr_def gs_set_assn_Delete_cstate_relation[unfolded o_def])

--- a/proof/crefine/ARM_HYP/Invoke_C.thy
+++ b/proof/crefine/ARM_HYP/Invoke_C.thy
@@ -68,7 +68,7 @@ lemma setDomain_ccorres:
          apply (rule_tac R="\<lambda>s. rv = ksCurThread s"
                     in ccorres_cond2)
            apply (clarsimp simp: rf_sr_ksCurThread)
-          apply (ctac add: rescheduleRequired_ccorres[unfolded dc_def])
+          apply (ctac add: rescheduleRequired_ccorres)
          apply (rule ccorres_return_Skip')
         apply simp
         apply (wp hoare_drop_imps weak_sch_act_wf_lift_linear)
@@ -78,8 +78,9 @@ lemma setDomain_ccorres:
      apply (rule_tac Q="\<lambda>_. all_invs_but_sch_extra and tcb_at' t and sch_act_simple
                         and (\<lambda>s. rv = ksCurThread s)" in hoare_strengthen_post)
       apply (wp threadSet_all_invs_but_sch_extra)
-     apply (clarsimp simp:valid_pspace_valid_objs' st_tcb_at_def[symmetric]
-       sch_act_simple_def st_tcb_at'_def o_def weak_sch_act_wf_def split:if_splits)
+     apply (clarsimp simp: valid_pspace_valid_objs' st_tcb_at_def[symmetric]
+                           sch_act_simple_def st_tcb_at'_def weak_sch_act_wf_def
+                    split: if_splits)
     apply (simp add: guard_is_UNIV_def)
    apply (rule_tac Q="\<lambda>_. invs' and tcb_at' t and sch_act_simple
       and (\<lambda>s. rv = ksCurThread s \<and> (\<forall>p. t \<notin> set (ksReadyQueues s p)))" in hoare_strengthen_post)
@@ -388,7 +389,7 @@ lemma invokeCNodeRotate_ccorres:
      apply clarsimp
      apply (simp add: return_def)
     apply wp
-   apply (simp add: guard_is_UNIV_def dc_def xfdc_def)
+   apply (simp add: guard_is_UNIV_def)
   apply (clarsimp simp: valid_pspace'_def)
   apply (rule conjI, clarsimp)
   apply (clarsimp simp:cte_wp_at_ctes_of)
@@ -638,7 +639,6 @@ lemma decodeCNodeInvocation_ccorres:
            apply (rule ccorres_split_throws)
             apply (rule ccorres_rhs_assoc | csymbr)+
             apply (simp add: invocationCatch_use_injection_handler[symmetric, unfolded o_def]
-                             dc_def[symmetric]
                         del: Collect_const cong: call_ignore_cong)
             apply (rule ccorres_Cond_rhs_Seq)
              apply (simp add:if_P del: Collect_const)
@@ -720,8 +720,7 @@ lemma decodeCNodeInvocation_ccorres:
                          apply (simp add: Collect_const[symmetric] del: Collect_const)
                          apply (rule ccorres_rhs_assoc)+
                          apply (rule ccorres_Cond_rhs_Seq)
-                          apply (simp add: injection_handler_throwError dc_def[symmetric]
-                                           if_P)
+                          apply (simp add: injection_handler_throwError if_P)
                           apply (rule syscall_error_throwError_ccorres_n)
                           apply (simp add: syscall_error_to_H_cases)
                          apply (simp add: list_case_helper injection_handler_returnOk
@@ -748,8 +747,7 @@ lemma decodeCNodeInvocation_ccorres:
                                apply csymbr
                                apply (simp add: cap_get_tag_NullCap del: Collect_const)
                                apply (rule ccorres_Cond_rhs_Seq)
-                                apply (simp add: injection_handler_throwError whenE_def
-                                                 dc_def[symmetric])
+                                apply (simp add: injection_handler_throwError whenE_def)
                                 apply (rule syscall_error_throwError_ccorres_n)
                                 apply (simp add: syscall_error_to_H_cases)
                                apply (simp add: whenE_def injection_handler_returnOk
@@ -825,8 +823,7 @@ lemma decodeCNodeInvocation_ccorres:
                                    apply (simp add: cap_get_tag_NullCap del: Collect_const)
                                    apply (rule ccorres_Cond_rhs_Seq)
                                     apply (simp add: whenE_def injection_handler_returnOk
-                                                     invocationCatch_def injection_handler_throwError
-                                                     dc_def[symmetric])
+                                                     invocationCatch_def injection_handler_throwError)
                                     apply (rule syscall_error_throwError_ccorres_n)
                                     apply (simp add: syscall_error_to_H_cases)
                                    apply (simp add: whenE_def injection_handler_returnOk
@@ -905,7 +902,7 @@ lemma decodeCNodeInvocation_ccorres:
                          apply (simp add: flip: Collect_const
                                     cong: call_ignore_cong)
                          apply (rule ccorres_Cond_rhs_Seq)
-                          apply (simp add: injection_handler_throwError dc_def[symmetric] if_P)
+                          apply (simp add: injection_handler_throwError if_P)
                           apply (rule syscall_error_throwError_ccorres_n)
                           apply (simp add: syscall_error_to_H_cases)
                          apply (simp add: if_not_P del: Collect_const)
@@ -924,8 +921,7 @@ lemma decodeCNodeInvocation_ccorres:
                              apply csymbr
                              apply (simp add: cap_get_tag_isCap del: Collect_const)
                              apply (rule ccorres_Cond_rhs_Seq)
-                              apply (simp add: whenE_def injection_handler_throwError
-                                               dc_def[symmetric] numeral_eqs)
+                              apply (simp add: whenE_def injection_handler_throwError numeral_eqs)
                               apply (rule syscall_error_throwError_ccorres_n)
                               apply (simp add: syscall_error_to_H_cases)
                              apply (simp add: whenE_def injection_handler_returnOk
@@ -1024,13 +1020,11 @@ lemma decodeCNodeInvocation_ccorres:
           apply (simp del: Collect_const)
           apply (rule ccorres_Cond_rhs_Seq)
            apply (simp add: injection_handler_returnOk bindE_assoc
-                            injection_bindE[OF refl refl] split_def
-                            dc_def[symmetric])
+                            injection_bindE[OF refl refl] split_def)
            apply (rule ccorres_split_throws)
             apply (rule ccorres_rhs_assoc)+
             apply (ctac add: ccorres_injection_handler_csum1 [OF ensureEmptySlot_ccorres])
-               apply (simp add: ccorres_invocationCatch_Inr performInvocation_def
-                                dc_def[symmetric] bindE_assoc)
+               apply (simp add: ccorres_invocationCatch_Inr performInvocation_def bindE_assoc)
                apply (ctac add: setThreadState_ccorres)
                  apply (ctac(no_vcg) add: invokeCNodeSaveCaller_ccorres)
                    apply (rule ccorres_alternative2)
@@ -1039,7 +1033,7 @@ lemma decodeCNodeInvocation_ccorres:
                  apply (wp sts_valid_pspace_hangers)+
                apply (simp add: Collect_const_mem)
                apply (vcg exspec=setThreadState_modifies)
-              apply (simp add: dc_def[symmetric])
+              apply simp
               apply (rule ccorres_split_throws)
                apply (rule ccorres_return_C_errorE, simp+)[1]
               apply vcg
@@ -1069,8 +1063,7 @@ lemma decodeCNodeInvocation_ccorres:
                                in ccorres_gen_asm2)
                 apply (simp del: Collect_const)
                 apply (rule ccorres_Cond_rhs_Seq)
-                 apply (simp add: unlessE_def whenE_def injection_handler_throwError
-                                  dc_def[symmetric] from_bool_0)
+                 apply (simp add: unlessE_def whenE_def injection_handler_throwError from_bool_0)
                  apply (rule syscall_error_throwError_ccorres_n)
                  apply (simp add: syscall_error_to_H_cases)
                 apply (simp add: unlessE_def whenE_def injection_handler_returnOk
@@ -1114,12 +1107,10 @@ lemma decodeCNodeInvocation_ccorres:
             apply (simp add: throwError_def return_def exception_defs
                              syscall_error_rel_def syscall_error_to_H_cases)
             apply clarsimp
-           apply (simp add: invocationCatch_use_injection_handler
-                                  [symmetric, unfolded o_def]
+           apply (simp add: invocationCatch_use_injection_handler[symmetric, unfolded o_def]
                        del: Collect_const)
            apply csymbr
            apply (simp add: interpret_excaps_test_null excaps_map_def
-                            if_1_0_0 dc_def[symmetric]
                        del: Collect_const)
            apply (rule ccorres_Cond_rhs_Seq)
             apply (simp add: throwError_bind invocationCatch_def)
@@ -1179,8 +1170,7 @@ lemma decodeCNodeInvocation_ccorres:
                                            del: Collect_const)
                                apply csymbr
                                apply (rule ccorres_Cond_rhs_Seq)
-                                apply (simp add: whenE_def injection_handler_throwError
-                                                 dc_def[symmetric])
+                                apply (simp add: whenE_def injection_handler_throwError)
                                 apply (rule syscall_error_throwError_ccorres_n)
                                 apply (simp add: syscall_error_to_H_cases)
                                apply (simp add: whenE_def[where P=False] injection_handler_returnOk
@@ -1242,8 +1232,7 @@ lemma decodeCNodeInvocation_ccorres:
                                         apply csymbr
                                         apply (simp add: cap_get_tag_NullCap del: Collect_const)
                                         apply (rule ccorres_Cond_rhs_Seq)
-                                         apply (simp add: whenE_def injection_handler_throwError
-                                                          dc_def[symmetric])
+                                         apply (simp add: whenE_def injection_handler_throwError)
                                          apply (rule syscall_error_throwError_ccorres_n)
                                          apply (simp add: syscall_error_to_H_cases)
                                         apply (simp add: whenE_def[where P=False] injection_handler_returnOk
@@ -1251,8 +1240,7 @@ lemma decodeCNodeInvocation_ccorres:
                                         apply csymbr
                                         apply (simp add: cap_get_tag_NullCap del: Collect_const)
                                         apply (rule ccorres_Cond_rhs_Seq)
-                                         apply (simp add: whenE_def injection_handler_throwError
-                                                          dc_def[symmetric])
+                                         apply (simp add: whenE_def injection_handler_throwError)
                                          apply (rule syscall_error_throwError_ccorres_n)
                                          apply (simp add: syscall_error_to_H_cases)
                                         apply (simp add: whenE_def injection_handler_returnOk
@@ -1473,7 +1461,7 @@ lemma seL4_MessageInfo_lift_def2:
 
 lemma globals_update_id:
   "globals_update (t_hrs_'_update (hrs_htd_update id)) x = x"
-   by (simp add:id_def hrs_htd_update_def)
+   by (simp add: hrs_htd_update_def)
 
 lemma getObjectSize_spec:
   "\<forall>s. \<Gamma>\<turnstile>\<lbrace>s. \<acute>t \<le> of_nat (length (enum::object_type list) - 1)\<rbrace> Call getObjectSize_'proc
@@ -1530,7 +1518,7 @@ shows
  "\<lbrakk>ctes_of (s::kernel_state) (ptr_val p) = Some cte; is_aligned ptr bits; bits < word_bits;
   {ptr..ptr + 2 ^ bits - 1} \<inter> {ptr_val p..ptr_val p + mask cteSizeBits} = {}; ((clift hp) :: (cte_C ptr \<rightharpoonup> cte_C)) p = Some to\<rbrakk> \<Longrightarrow>
   (clift (hrs_htd_update (typ_clear_region ptr bits) hp) :: (cte_C ptr \<rightharpoonup> cte_C)) p = Some to"
-   apply (clarsimp simp:lift_t_def lift_typ_heap_def Fun.comp_def restrict_map_def split:if_splits)
+   apply (clarsimp simp:lift_t_def lift_typ_heap_def restrict_map_def split:if_splits)
    apply (intro conjI impI)
    apply (case_tac hp)
     apply (clarsimp simp:typ_clear_region_def hrs_htd_update_def)
@@ -1715,7 +1703,7 @@ lemma clearMemory_untyped_ccorres:
       apply (clarsimp simp: rf_sr_def cstate_relation_def Let_def
                             carch_state_relation_def cmachine_state_relation_def)
      apply csymbr
-     apply (ctac add: cleanCacheRange_RAM_ccorres[unfolded dc_def])
+     apply (ctac add: cleanCacheRange_RAM_ccorres)
     apply wp
    apply (simp add: guard_is_UNIV_def unat_of_nat
                     word_bits_def capAligned_def word_of_nat_less)
@@ -1920,8 +1908,7 @@ lemma resetUntypedCap_ccorres:
      apply (rule ccorres_Guard_Seq[where S=UNIV])?
      apply (rule ccorres_rhs_assoc2)
      apply (rule ccorres_split_nothrow)
-         apply (rule_tac idx="capFreeIndex (cteCap cte)"
-           in deleteObjects_ccorres[where p=slot, unfolded o_def])
+         apply (rule_tac idx="capFreeIndex (cteCap cte)" in deleteObjects_ccorres[where p=slot])
         apply ceqv
        apply clarsimp
        apply (simp only: ccorres_seq_cond_raise)
@@ -2852,7 +2839,6 @@ lemma Arch_isFrameType_spec:
   apply (auto simp: object_type_from_H_def )
   done
 
-
 lemma decodeUntypedInvocation_ccorres_helper:
   notes TripleSuc[simp] untypedBits_defs[simp]
   notes valid_untyped_inv_wcap'.simps[simp del] tl_drop_1[simp]
@@ -3031,8 +3017,8 @@ lemma decodeUntypedInvocation_ccorres_helper:
                      apply (ctac add: ccorres_injection_handler_csum1
                                        [OF lookupTargetSlot_ccorres, unfolded lookupTargetSlot_def])
                         apply (simp add: injection_liftE[OF refl])
-                        apply (simp add: liftE_liftM o_def split_def withoutFailure_def
-                                         hd_drop_conv_nth2 numeral_eqs[symmetric])
+                        apply (simp add: liftE_liftM split_def hd_drop_conv_nth2
+                                   cong: ccorres_all_cong)
                         apply (rule ccorres_nohs)
                         apply (rule ccorres_getSlotCap_cte_at)
                         apply (rule ccorres_move_c_guard_cte)
@@ -3144,8 +3130,8 @@ lemma decodeUntypedInvocation_ccorres_helper:
                                apply (simp add: ccorres_cond_iffs returnOk_def)
                                apply (rule ccorres_return_Skip')
                               apply (rule ccorres_Guard_Seq ccorres_rhs_assoc)+
-                              apply (simp add: ccorres_cond_iffs inl_rrel_inl_rrel)
-                              apply (rule ccorres_return_C_errorE_inl_rrel, simp+)[1]
+                              apply (simp add: ccorres_cond_iffs)
+                              apply (rule ccorres_return_C_errorE_inl_rrel; simp)
                              apply wp
                             apply (simp add: all_ex_eq_helper)
                             apply (vcg exspec=ensureEmptySlot_modifies)
@@ -3242,8 +3228,7 @@ lemma decodeUntypedInvocation_ccorres_helper:
                                                        performInvocation_def liftE_bindE bind_assoc)
                              apply (ctac add: setThreadState_ccorres)
                                apply (rule ccorres_trim_returnE, (simp (no_asm))+)
-                               apply (simp (no_asm) add: o_def dc_def[symmetric] bindE_assoc
-                                                         id_def[symmetric] bind_bindE_assoc)
+                               apply (simp (no_asm) add: bindE_assoc bind_bindE_assoc)
                                apply (rule ccorres_seq_skip'[THEN iffD1])
                                apply (ctac(no_vcg) add: invokeUntyped_Retype_ccorres[where start = "args!4"])
                                  apply (rule ccorres_alternative2)
@@ -3291,7 +3276,7 @@ lemma decodeUntypedInvocation_ccorres_helper:
                        apply (rule conseqPre,vcg,clarsimp)
                       apply vcg
                      apply (rule ccorres_guard_imp[where Q =\<top> and Q' = UNIV,rotated], assumption+)
-                     apply (simp add: o_def)
+                     apply simp
                     apply simp
                     apply (rule checkFreeIndex_wp)
                    apply (clarsimp simp: ccap_relation_untyped_CL_simps shiftL_nat cap_get_tag_isCap
@@ -3356,7 +3341,7 @@ lemma decodeUntypedInvocation_ccorres_helper:
                    apply (rule validE_R_validE)
                    apply (wp injection_wp_E[OF refl])
                   apply clarsimp
-                 apply (simp add: ccHoarePost_def xfdc_def)
+                 apply (simp add: ccHoarePost_def)
                  apply (simp only: whileAnno_def[where I=UNIV and V=UNIV, symmetric])
                  apply (rule_tac V=UNIV in HoarePartial.reannotateWhileNoGuard)
                  apply (vcg exspec=ensureEmptySlot_modifies)
@@ -3484,7 +3469,7 @@ shows
   apply (rule ccorres_guard_imp2)
    apply (rule monadic_rewrite_ccorres_assemble)
     apply (rule_tac isBlocking=isBlocking and isCall=isCall and buffer=buffer
-                in decodeUntypedInvocation_ccorres_helper[unfolded K_def])
+                in decodeUntypedInvocation_ccorres_helper)
     apply assumption
    apply (rule monadic_rewrite_trans[rotated])
     apply (rule monadic_rewrite_bind_head)

--- a/proof/crefine/ARM_HYP/IpcCancel_C.thy
+++ b/proof/crefine/ARM_HYP/IpcCancel_C.thy
@@ -1043,7 +1043,6 @@ proof -
           apply (rule ccorres_split_nothrow_novcg_dc)
              prefer 2
              apply (rule ccorres_move_c_guard_tcb)
-             apply (simp only: dc_def[symmetric])
              apply ctac
             prefer 2
             apply (wp, clarsimp, wp+)
@@ -1166,7 +1165,7 @@ proof -
        apply simp
        apply (wp threadGet_wp)
       apply vcg
-     apply (rule ccorres_return_Skip[unfolded dc_def])
+     apply (rule ccorres_return_Skip)
     apply simp
     apply (wp threadGet_wp)
    apply vcg
@@ -1406,7 +1405,6 @@ proof -
           apply (rule ccorres_split_nothrow_novcg_dc)
              prefer 2
              apply (rule ccorres_move_c_guard_tcb)
-             apply (simp only: dc_def[symmetric])
              apply ctac
             prefer 2
             apply (wp, clarsimp, wp+)
@@ -1679,7 +1677,7 @@ proof -
        apply simp
        apply (wp threadGet_wp)
       apply vcg
-     apply (rule ccorres_return_Skip[unfolded dc_def])
+     apply (rule ccorres_return_Skip)
     apply simp
     apply (wp threadGet_wp)
    apply vcg
@@ -1811,7 +1809,6 @@ proof -
           apply (rule ccorres_split_nothrow_novcg_dc)
              prefer 2
              apply (rule ccorres_move_c_guard_tcb)
-             apply (simp only: dc_def[symmetric])
              apply ctac
             prefer 2
             apply (wp, clarsimp, wp+)
@@ -1919,7 +1916,7 @@ proof -
        apply simp
        apply (wp threadGet_wp)
       apply vcg
-     apply (rule ccorres_return_Skip[unfolded dc_def])
+     apply (rule ccorres_return_Skip)
     apply simp
     apply (wp threadGet_wp)
    apply vcg
@@ -2309,11 +2306,6 @@ lemma getCurDomain_maxDom_ccorres_dom_':
                         rf_sr_ksCurDomain)
   done
 
-lemma rf_sr_cscheduler_action_relation:
-  "(s, s') \<in> rf_sr
-   \<Longrightarrow> cscheduler_action_relation (ksSchedulerAction s) (ksSchedulerAction_' (globals s'))"
-  by (clarsimp simp: rf_sr_def cstate_relation_def Let_def)
-
 lemma threadGet_get_obj_at'_has_domain:
   "\<lbrace> tcb_at' t \<rbrace> threadGet tcbDomain t \<lbrace>\<lambda>rv. obj_at' (\<lambda>tcb. rv = tcbDomain tcb) t\<rbrace>"
   by (wp threadGet_obj_at') (simp add: obj_at'_def)
@@ -2330,7 +2322,6 @@ lemma possibleSwitchTo_ccorres:
      (Call possibleSwitchTo_'proc)"
   supply if_split [split del] if_cong[cong]
   supply Collect_const [simp del]
-  supply dc_simp [simp del]
   supply prio_and_dom_limit_helpers[simp]
   (* FIXME: these should likely be in simpset for CRefine, or even in general *)
   supply from_bool_eq_if[simp] from_bool_eq_if'[simp] from_bool_0[simp] if_1_0_0[simp]
@@ -2355,7 +2346,7 @@ lemma possibleSwitchTo_ccorres:
       apply (ctac add: tcbSchedEnqueue_ccorres)
      apply (rule_tac R="\<lambda>s. sact = ksSchedulerAction s \<and> weak_sch_act_wf (ksSchedulerAction s) s"
                      in ccorres_cond)
-       apply (fastforce dest!: rf_sr_cscheduler_action_relation pred_tcb_at' tcb_at_not_NULL
+       apply (fastforce dest!: rf_sr_sched_action_relation pred_tcb_at' tcb_at_not_NULL
                         simp: cscheduler_action_relation_def weak_sch_act_wf_def
                         split: scheduler_action.splits)
       apply (ctac add: rescheduleRequired_ccorres)
@@ -2944,7 +2935,7 @@ lemma cancelIPC_ccorres_helper:
   apply (rule allI)
   apply (rule conseqPre)
    apply vcg
-  apply (clarsimp split del: if_split simp del: comp_def)
+  apply (clarsimp split del: if_split)
   apply (frule (2) ep_blocked_in_queueD)
   apply (frule (1) ko_at_valid_ep' [OF _ invs_valid_objs'])
   apply (elim conjE)
@@ -2962,7 +2953,7 @@ lemma cancelIPC_ccorres_helper:
        apply assumption+
    apply (drule (2) ep_to_ep_queue)
    apply (simp add: tcb_queue_relation'_def)
-  apply (clarsimp simp: typ_heap_simps cong: imp_cong split del: if_split simp del: comp_def)
+  apply (clarsimp simp: typ_heap_simps cong: imp_cong split del: if_split)
   apply (frule null_ep_queue [simplified comp_def] null_ep_queue)
   apply (intro impI conjI allI)
    \<comment> \<open>empty case\<close>
@@ -3103,7 +3094,6 @@ lemma cancelIPC_ccorres1:
      apply wpc
             \<comment> \<open>BlockedOnReceive\<close>
             apply (simp add: word_sle_def "StrictC'_thread_state_defs" ccorres_cond_iffs cong: call_ignore_cong)
-            apply (fold dc_def)
             apply (rule ccorres_rhs_assoc)+
             apply csymbr
             apply csymbr
@@ -3132,7 +3122,6 @@ lemma cancelIPC_ccorres1:
            apply (simp add: "StrictC'_thread_state_defs" ccorres_cond_iffs
                             Collect_False Collect_True word_sle_def
                       cong: call_ignore_cong del: Collect_const)
-           apply (fold dc_def)
            apply (rule ccorres_rhs_assoc)+
            apply csymbr
            apply csymbr
@@ -3172,14 +3161,12 @@ lemma cancelIPC_ccorres1:
                 apply (rule ccorres_Cond_rhs)
                  apply (simp add: nullPointer_def when_def)
                  apply (rule ccorres_symb_exec_l[OF _ _ _ empty_fail_stateAssert])
-                   apply (simp only: dc_def[symmetric])
                    apply (rule ccorres_symb_exec_r)
                      apply (ctac add: cteDeleteOne_ccorres[where w1="scast cap_reply_cap"])
                     apply vcg
                    apply (rule conseqPre, vcg, clarsimp simp: rf_sr_def
                        gs_set_assn_Delete_cstate_relation[unfolded o_def])
                   apply (wp | simp)+
-                apply (simp add: when_def nullPointer_def dc_def[symmetric])
                 apply (rule ccorres_return_Skip)
                apply (simp add: guard_is_UNIV_def ghost_assertion_data_get_def
                                 ghost_assertion_data_set_def cap_tag_defs)
@@ -3192,7 +3179,8 @@ lemma cancelIPC_ccorres1:
            apply (clarsimp simp add: guard_is_UNIV_def tcbReplySlot_def
                         Kernel_C.tcbReply_def tcbCNodeEntries_def)
           \<comment> \<open>BlockedOnNotification\<close>
-          apply (simp add: word_sle_def "StrictC'_thread_state_defs" ccorres_cond_iffs dc_def [symmetric] cong: call_ignore_cong)
+          apply (simp add: word_sle_def "StrictC'_thread_state_defs" ccorres_cond_iffs
+                     cong: call_ignore_cong)
           apply (rule ccorres_symb_exec_r)
             apply (ctac (no_vcg))
            apply clarsimp
@@ -3201,10 +3189,12 @@ lemma cancelIPC_ccorres1:
           apply (rule conseqPre, vcg)
           apply clarsimp
          \<comment> \<open>Running, Inactive, and Idle\<close>
-         apply (simp add: word_sle_def "StrictC'_thread_state_defs" ccorres_cond_iffs dc_def [symmetric] cong: call_ignore_cong,
+         apply (simp add: word_sle_def "StrictC'_thread_state_defs" ccorres_cond_iffs
+                    cong: call_ignore_cong,
                 rule ccorres_return_Skip)+
       \<comment> \<open>BlockedOnSend\<close>
-      apply (simp add: word_sle_def "StrictC'_thread_state_defs" ccorres_cond_iffs dc_def [symmetric] cong: call_ignore_cong)
+      apply (simp add: word_sle_def "StrictC'_thread_state_defs" ccorres_cond_iffs
+                 cong: call_ignore_cong)
       \<comment> \<open>clag\<close>
       apply (rule ccorres_rhs_assoc)+
       apply csymbr
@@ -3230,7 +3220,8 @@ lemma cancelIPC_ccorres1:
       apply (rule conseqPre, vcg)
       apply clarsimp
   \<comment> \<open>Restart\<close>
-     apply (simp add: word_sle_def "StrictC'_thread_state_defs" ccorres_cond_iffs dc_def [symmetric] cong: call_ignore_cong,
+     apply (simp add: word_sle_def "StrictC'_thread_state_defs" ccorres_cond_iffs
+                cong: call_ignore_cong,
             rule ccorres_return_Skip)
     \<comment> \<open>Post wp proofs\<close>
     apply vcg

--- a/proof/crefine/ARM_HYP/Ipc_C.thy
+++ b/proof/crefine/ARM_HYP/Ipc_C.thy
@@ -799,7 +799,7 @@ begin
 
 (* FIXME: move *)
 lemma ccorres_merge_return:
-  "ccorres (\<lambda>a c. r (f a) c) xf P P' hs H C \<Longrightarrow>
+  "ccorres (r \<circ> f) xf P P' hs H C \<Longrightarrow>
    ccorres r xf P P' hs (do x \<leftarrow> H; return (f x) od) C"
   by (rule ccorres_return_into_rel)
 
@@ -1665,53 +1665,54 @@ proof -
       apply ceqv
      apply (rule ccorres_Cond_rhs)
       apply (simp del: Collect_const)
-      apply (rule ccorres_rel_imp[where r = "\<lambda>rv rv'. True", simplified])
-      apply (rule_tac F="\<lambda>_. obj_at' (\<lambda>tcb. map ((atcbContext o tcbArch) tcb) ARM_HYP_H.syscallMessage = msg)
-                                       sender and valid_pspace'
-                                       and (case recvBuffer of Some x \<Rightarrow> valid_ipc_buffer_ptr' x | None \<Rightarrow> \<top>)"
-                           in ccorres_mapM_x_while'[where i="unat n_msgRegisters"])
-          apply (clarsimp simp: setMR_def n_msgRegisters_def length_msgRegisters
-                                          option_to_0_def liftM_def[symmetric]
-                                   split: option.split_asm)
-          apply (rule ccorres_guard_imp2)
-          apply (rule_tac t=sender and r="ARM_HYP_H.syscallMessage ! (n + unat n_msgRegisters)"
-                                   in ccorres_add_getRegister)
-          apply (ctac(no_vcg))
-           apply (rule_tac P="\<lambda>s. rv = msg ! (n + unat n_msgRegisters)"
-                           in ccorres_cross_over_guard)
-           apply (rule ccorres_move_array_assertion_ipc_buffer
-                 | (rule ccorres_flip_Guard, rule ccorres_move_array_assertion_ipc_buffer))+
-           apply (simp add: storeWordUser_def)
-           apply (rule ccorres_pre_stateAssert)
-           apply (ctac add: storeWord_ccorres[unfolded fun_app_def])
-          apply (simp add: pred_conj_def)
-          apply (wp user_getreg_rv)
-         apply (clarsimp simp: n_syscallMessage_def n_msgRegisters_def
-                               syscallMessage_ccorres msgRegisters_ccorres
-                               unat_add_lem[THEN iffD1] unat_of_nat32
-                               word_bits_def word_size_def)
-         apply (simp only:field_simps imp_ex imp_conjL)
-         apply (clarsimp simp: pointerInUserData_c_guard obj_at'_def
-                               pointerInUserData_h_t_valid
-                               atcbContextGet_def
-                               projectKOs objBits_simps word_less_nat_alt
-                               unat_add_lem[THEN iffD1] unat_of_nat)
-         apply (clarsimp simp: pointerInUserData_h_t_valid rf_sr_def
-                               MessageID_Syscall_def
-                               msg_align_bits valid_ipc_buffer_ptr'_def)
-         apply (erule aligned_add_aligned)
-          apply (rule aligned_add_aligned[where n=2])
-            apply (simp add: is_aligned_def)
-           apply (rule is_aligned_mult_triv2 [where n=2, simplified])
-           apply (simp add: wb_gt_2)+
-         apply (simp add: n_msgRegisters_def)
-        apply (vcg exspec=getRegister_modifies)
-        apply simp
-       apply (simp add: setMR_def n_msgRegisters_def length_msgRegisters)
-       apply (rule hoare_pre)
-        apply (wp hoare_case_option_wp | wpc)+
-       apply clarsimp
-      apply (simp add: n_msgRegisters_def word_bits_def)
+      apply (rule ccorres_rel_imp)
+       apply (rule_tac F="\<lambda>_. obj_at' (\<lambda>tcb. map ((atcbContext o tcbArch) tcb) ARM_HYP_H.syscallMessage = msg)
+                                        sender and valid_pspace'
+                                        and (case recvBuffer of Some x \<Rightarrow> valid_ipc_buffer_ptr' x | None \<Rightarrow> \<top>)"
+                            in ccorres_mapM_x_while'[where i="unat n_msgRegisters"])
+           apply (clarsimp simp: setMR_def n_msgRegisters_def length_msgRegisters
+                                           option_to_0_def liftM_def[symmetric]
+                                    split: option.split_asm)
+           apply (rule ccorres_guard_imp2)
+            apply (rule_tac t=sender and r="ARM_HYP_H.syscallMessage ! (n + unat n_msgRegisters)"
+                                     in ccorres_add_getRegister)
+            apply (ctac(no_vcg))
+             apply (rule_tac P="\<lambda>s. rv = msg ! (n + unat n_msgRegisters)"
+                             in ccorres_cross_over_guard)
+             apply (rule ccorres_move_array_assertion_ipc_buffer
+                   | (rule ccorres_flip_Guard, rule ccorres_move_array_assertion_ipc_buffer))+
+             apply (simp add: storeWordUser_def)
+             apply (rule ccorres_pre_stateAssert)
+             apply (ctac add: storeWord_ccorres[unfolded fun_app_def])
+            apply (simp add: pred_conj_def)
+            apply (wp user_getreg_rv)
+           apply (clarsimp simp: n_syscallMessage_def n_msgRegisters_def
+                                 syscallMessage_ccorres msgRegisters_ccorres
+                                 unat_add_lem[THEN iffD1] unat_of_nat32
+                                 word_bits_def word_size_def)
+           apply (simp only:field_simps imp_ex imp_conjL)
+           apply (clarsimp simp: pointerInUserData_c_guard obj_at'_def
+                                 pointerInUserData_h_t_valid
+                                 atcbContextGet_def
+                                 projectKOs objBits_simps word_less_nat_alt
+                                 unat_add_lem[THEN iffD1] unat_of_nat)
+           apply (clarsimp simp: pointerInUserData_h_t_valid rf_sr_def
+                                 MessageID_Syscall_def
+                                 msg_align_bits valid_ipc_buffer_ptr'_def)
+           apply (erule aligned_add_aligned)
+            apply (rule aligned_add_aligned[where n=2])
+              apply (simp add: is_aligned_def)
+             apply (rule is_aligned_mult_triv2 [where n=2, simplified])
+            apply (simp add: wb_gt_2)+
+          apply (simp add: n_msgRegisters_def)
+         apply (vcg exspec=getRegister_modifies)
+         apply simp
+        apply (simp add: setMR_def n_msgRegisters_def length_msgRegisters)
+        apply (rule hoare_pre)
+         apply (wp hoare_case_option_wp | wpc)+
+        apply clarsimp
+       apply (simp add: n_msgRegisters_def word_bits_def)
+      apply simp
      apply (simp add: n_msgRegisters_def)
      apply (frule (1) option_to_0_imp)
      apply (subst drop_zip)
@@ -1719,7 +1720,7 @@ proof -
      apply (clarsimp simp:  n_msgRegisters_def numeral_eqs
                             mapM_cong[OF msg_aux, simplified numeral_eqs])
      apply (subst mapM_x_return_gen[where w2="()"])
-     apply (rule ccorres_return_Skip[simplified dc_def])
+     apply (rule ccorres_return_Skip)
     apply (clarsimp)
     apply (rule hoare_impI)
     apply (rule mapM_x_wp_inv)
@@ -2282,7 +2283,7 @@ lemma doFaultTransfer_ccorres [corres]:
       apply ceqv
      apply csymbr
      apply (ctac (no_vcg, c_lines 2) add: setMessageInfo_ccorres)
-       apply (ctac add: setRegister_ccorres[unfolded dc_def])
+       apply (ctac add: setRegister_ccorres)
       apply wp
      apply (simp add: badgeRegister_def ARM_HYP.badgeRegister_def
                       "StrictC'_register_defs")
@@ -2320,7 +2321,7 @@ lemma unifyFailure_ccorres:
   assumes corr_ac: "ccorres (f \<currency> r) xf P P' hs a c"
   shows "ccorres ((\<lambda>_. dc) \<currency> r) xf P P' hs (unifyFailure a) c"
   using corr_ac
-  apply (simp add: unifyFailure_def rethrowFailure_def const_def o_def
+  apply (simp add: unifyFailure_def rethrowFailure_def const_def
                    handleE'_def throwError_def)
   apply (clarsimp simp: ccorres_underlying_def bind_def split_def return_def
                   split: xstate.splits sum.splits)
@@ -3357,10 +3358,11 @@ lemma ccorres_sequenceE_while':
              Basic (\<lambda>s. i_'_update (\<lambda>_. i_' s + 1) s)))"
   apply (rule ccorres_guard_imp2)
    apply (rule ccorres_symb_exec_r)
-     apply (rule ccorres_sequenceE_while_gen'[where i=0, simplified, where xf_update=i_'_update],
-            (assumption | simp)+)
-       apply (simp add: word_bits_def)
-      apply simp+
+     apply (rule ccorres_rel_imp2)
+       apply (rule ccorres_sequenceE_while_gen'[where i=0, simplified, where xf_update=i_'_update],
+              (assumption | simp)+)
+         apply (simp add: word_bits_def)
+        apply simp+
     apply vcg
    apply (rule conseqPre, vcg)
    apply clarsimp
@@ -3594,7 +3596,7 @@ proof -
     apply (cinit lift: sender_' receiver_' sendBuffer_' receiveBuffer_'
                        canGrant_' badge_' endpoint_'
                  cong: call_ignore_cong)
-     apply (clarsimp cong: call_ignore_cong simp del: dc_simp)
+     apply (clarsimp cong: call_ignore_cong)
      apply (ctac(c_lines 2, no_vcg) add: getMessageInfo_ccorres')
        apply (rule_tac xf'="\<lambda>s. current_extra_caps_' (globals s)"
                    and r'="\<lambda>c c'. interpret_excaps c' = excaps_map c"
@@ -3703,7 +3705,6 @@ lemma replyFromKernel_error_ccorres [corres]:
          apply ((rule ccorres_Guard_Seq)+)?
          apply csymbr
          apply (rule ccorres_abstract_cleanup)
-         apply (fold dc_def)[1]
          apply (rule setMessageInfo_ccorres)
         apply wp
        apply (simp add: Collect_const_mem)
@@ -3772,12 +3773,10 @@ lemma doIPCTransfer_ccorres [corres]:
            apply simp_all[3]
         apply ceqv
        apply csymbr
-       apply (fold dc_def)[1]
        apply ctac
       apply (wp lookupIPCBuffer_not_Some_0 lookupIPCBuffer_aligned)
      apply (clarsimp simp: seL4_Fault_NullFault_def ccorres_cond_iffs
                            fault_to_fault_tag_nonzero)
-     apply (fold dc_def)[1]
      apply ctac
     apply (clarsimp simp: guard_is_UNIV_def option_to_ptr_def split: option.splits)
    apply (rule_tac Q="\<lambda>rv. valid_pspace' and cur_tcb' and tcb_at' sender
@@ -3904,7 +3903,7 @@ apply (ctac(no_vcg) add: Arch_getSanitiseRegisterInfo_ccorres)
                         n_msgRegisters_def
                         of_nat_less_iff)
        apply ccorres_rewrite
-       apply (rule ccorres_return_Skip[simplified dc_def])
+       apply (rule ccorres_return_Skip)
       apply (wp mapM_wp')
      apply clarsimp+
      apply (clarsimp simp: guard_is_UNIV_def message_info_to_H_def
@@ -4059,7 +4058,6 @@ apply (ctac(no_vcg) add: Arch_getSanitiseRegisterInfo_ccorres)
                  apply (subst aligned_add_aligned, assumption)
                    apply (rule is_aligned_mult_triv2[where n=2, simplified])
                   apply (simp add: msg_align_bits)
-                 apply (simp add: of_nat_unat[simplified comp_def])
                  apply (simp only: n_msgRegisters_def)
                  apply (clarsimp simp: n_syscallMessage_def n_msgRegisters_def
                                        word_unat.Rep_inverse[of "scast _ :: 'a word"]
@@ -4098,8 +4096,8 @@ apply (ctac(no_vcg) add: Arch_getSanitiseRegisterInfo_ccorres)
             apply simp
         apply (subst option.split[symmetric,where P=id, simplified])
         apply (rule valid_drop_case)
-        apply (wp hoare_drop_imps hoare_vcg_all_lift lookupIPCBuffer_aligned[simplified K_def]
-                  lookupIPCBuffer_not_Some_0[simplified K_def])
+        apply (wp hoare_drop_imps hoare_vcg_all_lift lookupIPCBuffer_aligned[simplified]
+                  lookupIPCBuffer_not_Some_0[simplified])
        apply (simp add: length_syscallMessage
                         length_msgRegisters
                         n_syscallMessage_def
@@ -4111,7 +4109,7 @@ apply (ctac(no_vcg) add: Arch_getSanitiseRegisterInfo_ccorres)
        apply (rule ccorres_guard_imp)
          apply (rule ccorres_symb_exec_l)
             apply (case_tac rva ; clarsimp)
-             apply (rule ccorres_return_Skip[simplified dc_def])+
+             apply (rule ccorres_return_Skip)+
                 apply (wp mapM_x_wp_inv user_getreg_inv'
                        | clarsimp simp: zipWithM_x_mapM_x split: prod.split)+
      apply (cases  "4 < len")
@@ -4232,7 +4230,7 @@ lemma handleFaultReply_ccorres [corres]:
   apply (unfold K_def, rule ccorres_gen_asm)
   apply (rule monadic_rewrite_ccorres_assemble_nodrop[OF _ handleFaultReply',rotated], simp)
   apply (cinit lift: sender_' receiver_' simp: whileAnno_def)
-   apply (clarsimp simp del: dc_simp)
+   apply clarsimp
    apply (ctac(c_lines 2) add: getMessageInfo_ccorres')
      apply (rename_tac tag tag')
      apply csymbr
@@ -4278,7 +4276,7 @@ lemma handleFaultReply_ccorres [corres]:
                          split del: if_split)
             apply (subst take_min_len[symmetric,where n="unat (msgLength _)"])
             apply (subst take_min_len[symmetric,where n="unat (msgLength _)"])
-            apply (fold bind_assoc id_def)
+            apply (fold bind_assoc)
             apply (ctac add: copyMRsFaultReply_ccorres_syscall[simplified bind_assoc[symmetric]])
               apply (ctac add: ccorres_return_C)
              apply wp
@@ -4493,7 +4491,6 @@ proof -
     apply csymbr
     apply wpc
      apply (clarsimp simp: ccorres_cond_iffs)
-     apply (fold dc_def)[1]
      apply (rule ccorres_rhs_assoc)+
      apply (ctac(no_vcg))
       apply (rule ccorres_symb_exec_r)
@@ -4517,7 +4514,6 @@ proof -
                           fault_to_fault_tag_nonzero
                split del: if_split)
     apply (rule ccorres_rhs_assoc)+
-    apply (fold dc_def)[1]
     apply (rule ccorres_symb_exec_r)
       apply (ctac (no_vcg) add: cteDeleteOne_ccorres[where w="scast cap_reply_cap"])
        apply (rule_tac A'=UNIV in stronger_ccorres_guard_imp)
@@ -4547,7 +4543,6 @@ proof -
                apply (simp only: K_bind_def)
                apply (ctac add: possibleSwitchTo_ccorres)
               apply (wp sts_running_valid_queues setThreadState_st_tcb | simp)+
-            apply (fold dc_def)[1]
              apply (ctac add: setThreadState_ccorres_valid_queues'_simple)
              apply wp
             apply ((wp threadSet_valid_queues threadSet_sch_act threadSet_valid_queues' static_imp_wp
@@ -4619,8 +4614,7 @@ lemma setupCallerCap_ccorres [corres]:
   apply (frule_tac p=sender in is_aligned_tcb_ptr_to_ctcb_ptr)
   apply (cinit lift: sender_' receiver_' canGrant_')
    apply (clarsimp simp: word_sle_def
-                         tcb_cnode_index_defs[THEN ptr_add_assertion_positive[OF ptr_add_assertion_positive_helper]]
-                         , fold dc_def)[1]
+                         tcb_cnode_index_defs[THEN ptr_add_assertion_positive[OF ptr_add_assertion_positive_helper]])
    apply ccorres_remove_UNIV_guard
    apply (ctac(no_vcg))
     apply (rule ccorres_move_array_assertion_tcb_ctes)
@@ -4641,7 +4635,7 @@ lemma setupCallerCap_ccorres [corres]:
         apply (rule ccorres_move_c_guard_cte)
         apply (ctac(no_vcg))
          apply (rule ccorres_assert)
-         apply (simp only: ccorres_seq_skip dc_def[symmetric])
+         apply (simp only: ccorres_seq_skip)
          apply csymbr
          apply (ctac add: cteInsert_ccorres)
         apply simp
@@ -4695,7 +4689,7 @@ lemma sendIPC_dequeue_ccorres_helper:
   apply (rule ccorres_from_vcg)
   apply (rule allI)
   apply (rule conseqPre, vcg)
-  apply (clarsimp split del: if_split simp del: comp_def)
+  apply (clarsimp split del: if_split)
   apply (frule ep_blocked_in_queueD [OF pred_tcb'_weakenE])
      apply simp
     apply assumption+
@@ -4716,7 +4710,7 @@ lemma sendIPC_dequeue_ccorres_helper:
     apply (drule (2) ep_to_ep_queue)
     apply (simp add: tcb_queue_relation'_def)
    apply (clarsimp simp: typ_heap_simps cendpoint_relation_def Let_def
-              cong: imp_cong split del: if_split simp del: comp_def)
+                   cong: imp_cong split del: if_split)
   apply (intro conjI impI allI)
      apply (fastforce simp: h_t_valid_clift)
     apply (fastforce simp: h_t_valid_clift)
@@ -5068,7 +5062,7 @@ lemma sendIPC_enqueue_ccorres_helper:
   apply (rule ccorres_gen_asm)
   apply (rule ccorres_from_vcg)
   apply (rule allI, rule conseqPre, vcg)
-  apply (clarsimp split del: if_split simp del: comp_def)
+  apply (clarsimp split del: if_split)
   apply (frule cmap_relation_ep)
   apply (erule (1) cmap_relation_ko_atE)
   apply (rule conjI)
@@ -5265,12 +5259,9 @@ lemma sendIPC_ccorres [corres]:
               apply (clarsimp simp: disj_imp[symmetric] split del: if_split)
               apply (wpc ; clarsimp)
                apply ccorres_rewrite
-               apply (fold dc_def)[1]
                apply (ctac add: setupCallerCap_ccorres)
               apply ccorres_rewrite
-              apply (fold dc_def)[1]
               apply (ctac add: setThreadState_ccorres)
-             apply (fold dc_def)[1]
              apply (rule ccorres_return_Skip)
             apply (wpsimp wp: hoare_drop_imps hoare_vcg_all_lift possibleSwitchTo_sch_act_not
                               possibleSwitchTo_sch_act_not sts_st_tcb'
@@ -5466,7 +5457,7 @@ lemma receiveIPC_enqueue_ccorres_helper:
   apply (rule ccorres_gen_asm)
   apply (rule ccorres_from_vcg)
   apply (rule allI, rule conseqPre, vcg)
-  apply (clarsimp split del: if_split simp del: comp_def)
+  apply (clarsimp split del: if_split)
   apply (frule cmap_relation_ep)
   apply (erule (1) cmap_relation_ko_atE)
   apply (rule conjI)
@@ -5592,7 +5583,7 @@ lemma receiveIPC_dequeue_ccorres_helper:
   apply (rule ccorres_from_vcg)
   apply (rule allI)
   apply (rule conseqPre, vcg)
-  apply (clarsimp split del: if_split simp del: comp_def)
+  apply (clarsimp split del: if_split)
   apply (frule ep_blocked_in_queueD [OF pred_tcb'_weakenE])
      apply simp
     apply assumption+
@@ -5613,7 +5604,7 @@ lemma receiveIPC_dequeue_ccorres_helper:
     apply (drule (2) ep_to_ep_queue)
     apply (simp add: tcb_queue_relation'_def)
    apply (clarsimp simp: typ_heap_simps cendpoint_relation_def Let_def
-              cong: imp_cong split del: if_split simp del: comp_def)
+                   cong: imp_cong split del: if_split)
   apply (intro conjI impI allI)
      apply (fastforce simp: h_t_valid_clift)
     apply (fastforce simp: h_t_valid_clift)
@@ -5761,7 +5752,7 @@ lemma completeSignal_ccorres:
         apply (erule(1) cmap_relation_ko_atE[OF cmap_relation_ntfn])
         apply (clarsimp simp: cnotification_relation_def Let_def typ_heap_simps)
        apply ceqv
-      apply (fold dc_def, ctac(no_vcg))
+      apply (ctac(no_vcg))
        apply (rule_tac P="invs' and ko_at' ntfn ntfnptr" and P'=UNIV in ccorres_from_vcg)
        apply (rule allI, rule conseqPre, vcg)
        apply (clarsimp)
@@ -5875,7 +5866,7 @@ lemma receiveIPC_ccorres [corres]:
          apply ceqv
         apply (rule ccorres_cond[where R=\<top>])
           apply (simp add: Collect_const_mem)
-         apply (ctac add: completeSignal_ccorres[unfolded dc_def])
+         apply (ctac add: completeSignal_ccorres)
         apply (rule_tac xf'=ret__unsigned_'
                     and val="case ep of IdleEP \<Rightarrow> scast EPState_Idle
                             | RecvEP _ \<Rightarrow> scast EPState_Recv
@@ -5905,20 +5896,18 @@ lemma receiveIPC_ccorres [corres]:
              apply (rule ccorres_rhs_assoc2)
              apply (rule ccorres_rhs_assoc2)
              apply (rule ccorres_split_nothrow_novcg)
-                 apply (simp split del: if_split)
                  apply (rule receiveIPC_block_ccorres_helper[unfolded ptr_val_def, simplified])
                 apply ceqv
                apply simp
                apply (rename_tac list NOo)
-               apply (rule_tac ep="RecvEP list"
-                               in receiveIPC_enqueue_ccorres_helper[simplified, unfolded dc_def])
+               apply (rule_tac ep="RecvEP list" in receiveIPC_enqueue_ccorres_helper[simplified])
               apply (simp add: valid_ep'_def)
               apply (wp sts_st_tcb')
              apply (rename_tac list)
              apply (clarsimp simp: obj_at'_def ko_wp_at'_def projectKOs)
              apply (clarsimp simp: guard_is_UNIV_def)
             apply simp
-             apply (ctac add: doNBRecvFailedTransfer_ccorres[unfolded dc_def])
+             apply (ctac add: doNBRecvFailedTransfer_ccorres)
            \<comment> \<open>IdleEP case\<close>
            apply (rule ccorres_cond_true)
            apply csymbr
@@ -5930,18 +5919,16 @@ lemma receiveIPC_ccorres [corres]:
             apply (rule ccorres_rhs_assoc2)
             apply (rule ccorres_rhs_assoc2)
             apply (rule ccorres_split_nothrow_novcg)
-                apply (simp split del: if_split)
                 apply (rule receiveIPC_block_ccorres_helper[unfolded ptr_val_def, simplified])
                apply ceqv
               apply simp
-              apply (rule_tac ep=IdleEP
-                        in receiveIPC_enqueue_ccorres_helper[simplified, unfolded dc_def])
+              apply (rule_tac ep=IdleEP in receiveIPC_enqueue_ccorres_helper[simplified])
              apply (simp add: valid_ep'_def)
              apply (wp sts_st_tcb')
             apply (clarsimp simp: obj_at'_def ko_wp_at'_def projectKOs)
             apply (clarsimp simp: guard_is_UNIV_def)
            apply simp
-            apply (ctac add: doNBRecvFailedTransfer_ccorres[unfolded dc_def])
+            apply (ctac add: doNBRecvFailedTransfer_ccorres)
            \<comment> \<open>SendEP case\<close>
           apply (thin_tac "isBlockinga = from_bool P" for P)
           apply (rule ccorres_cond_false)
@@ -6019,8 +6006,6 @@ lemma receiveIPC_ccorres [corres]:
                                   split: Structures_H.thread_state.splits)
                   apply ceqv
 
-                 apply (fold dc_def)
-                 supply dc_simp[simp del]
                  apply (clarsimp simp:  from_bool_0 disj_imp[symmetric] simp del: Collect_const)
                  apply wpc
                   (* blocking ipc call *)
@@ -6099,12 +6084,12 @@ lemma receiveIPC_ccorres [corres]:
             apply (clarsimp simp:st_tcb_at_refs_of_rev')
             apply (erule_tac x=x and P="\<lambda>x. st_tcb_at' P x s" for P in ballE)
              apply (drule_tac t=x in valid_queues_not_runnable'_not_ksQ)
-              apply (clarsimp simp: st_tcb_at'_def obj_at'_def o_def)
+              apply (clarsimp simp: st_tcb_at'_def obj_at'_def)
              apply (subgoal_tac "sch_act_not x s")
               prefer 2
               apply (frule invs_sch_act_wf')
               apply (clarsimp simp:sch_act_wf_def)
-              apply (clarsimp simp: st_tcb_at'_def obj_at'_def o_def)
+              apply (clarsimp simp: st_tcb_at'_def obj_at'_def)
              apply (clarsimp simp: obj_at'_def st_tcb_at'_def
                                    projectKOs isBlockedOnSend_def
                              split: list.split | rule conjI)+
@@ -6132,11 +6117,10 @@ lemma sendSignal_dequeue_ccorres_helper:
          IF head_C \<acute>ntfn_queue = Ptr 0 THEN
              CALL notification_ptr_set_state(Ptr ntfn,scast NtfnState_Idle)
          FI)"
-
   apply (rule ccorres_from_vcg)
   apply (rule allI)
   apply (rule conseqPre, vcg)
-  apply (clarsimp split del: if_split simp del: comp_def)
+  apply (clarsimp split del: if_split)
   apply (frule (2) ntfn_blocked_in_queueD)
   apply (frule (1) ko_at_valid_ntfn' [OF _ invs_valid_objs'])
   apply (elim conjE)
@@ -6156,7 +6140,7 @@ lemma sendSignal_dequeue_ccorres_helper:
     apply (drule ntfn_to_ep_queue, (simp add: isWaitingNtfn_def)+)
     apply (simp add: tcb_queue_relation'_def)
    apply (clarsimp simp: typ_heap_simps cnotification_relation_def Let_def
-              cong: imp_cong split del: if_split simp del: comp_def)
+                   cong: imp_cong split del: if_split)
   apply (intro conjI impI allI)
      apply (fastforce simp: h_t_valid_clift)
     apply (fastforce simp: h_t_valid_clift)
@@ -6333,7 +6317,7 @@ lemma sendSignal_ccorres [corres]:
        apply wpc
         apply (simp add: option_to_ctcb_ptr_def split del: if_split)
         apply (rule ccorres_cond_false)
-        apply (ctac add: ntfn_set_active_ccorres[unfolded dc_def])
+        apply (ctac add: ntfn_set_active_ccorres)
        apply (rule ccorres_cond_true)
        apply (rule getThreadState_ccorres_foo)
        apply (rule ccorres_Guard_Seq)
@@ -6348,7 +6332,7 @@ lemma sendSignal_ccorres [corres]:
         apply (ctac(no_vcg) add: cancelIPC_ccorres1[OF cteDeleteOne_ccorres])
          apply (ctac(no_vcg) add: setThreadState_ccorres)
           apply (ctac(no_vcg) add: setRegister_ccorres)
-           apply (ctac add: possibleSwitchTo_ccorres[unfolded dc_def])
+           apply (ctac add: possibleSwitchTo_ccorres)
           apply (wp sts_running_valid_queues sts_st_tcb_at'_cases
                  | simp add: option_to_ctcb_ptr_def split del: if_split)+
         apply (rule_tac Q="\<lambda>_. tcb_at' (the (ntfnBoundTCB ntfn)) and invs'"
@@ -6356,7 +6340,7 @@ lemma sendSignal_ccorres [corres]:
          apply auto[1]
         apply wp
        apply simp
-       apply (ctac add: ntfn_set_active_ccorres[unfolded dc_def])
+       apply (ctac add: ntfn_set_active_ccorres)
       apply (clarsimp simp: guard_is_UNIV_def option_to_ctcb_ptr_def
                             ARM_HYP_H.badgeRegister_def Kernel_C.badgeRegister_def
                             ARM_HYP.badgeRegister_def Kernel_C.R0_def
@@ -6412,7 +6396,7 @@ lemma sendSignal_ccorres [corres]:
        apply ceqv
       apply (simp only: K_bind_def)
       apply (ctac (no_vcg))
-       apply (simp, fold dc_def)
+       apply simp
        apply (ctac (no_vcg))
         apply (ctac add: possibleSwitchTo_ccorres)
        apply (simp)
@@ -6563,7 +6547,7 @@ lemma receiveSignal_enqueue_ccorres_helper:
   apply (rule ccorres_gen_asm)
   apply (rule ccorres_from_vcg)
   apply (rule allI, rule conseqPre, vcg)
-  apply (clarsimp split del: if_split simp del: comp_def)
+  apply (clarsimp split del: if_split)
   apply (frule cmap_relation_ntfn)
   apply (erule (1) cmap_relation_ko_atE)
   apply (rule conjI)
@@ -6721,11 +6705,10 @@ lemma receiveSignal_ccorres [corres]:
         apply (rule ccorres_rhs_assoc2)
         apply (rule ccorres_rhs_assoc2)
         apply (rule ccorres_split_nothrow_novcg)
-            apply (simp)
             apply (rule receiveSignal_block_ccorres_helper[simplified])
            apply ceqv
           apply (simp only: K_bind_def)
-          apply (rule receiveSignal_enqueue_ccorres_helper[unfolded dc_def, simplified])
+          apply (rule receiveSignal_enqueue_ccorres_helper[simplified])
          apply (simp add: valid_ntfn'_def)
          apply (wp sts_st_tcb')
          apply (rule_tac Q="\<lambda>rv. ko_wp_at' (\<lambda>x. projectKO_opt x = Some ntfn
@@ -6736,7 +6719,7 @@ lemma receiveSignal_ccorres [corres]:
          apply wp
         apply (clarsimp simp: guard_is_UNIV_def)
        apply simp
-       apply (ctac add: doNBRecvFailedTransfer_ccorres[unfolded dc_def])
+       apply (ctac add: doNBRecvFailedTransfer_ccorres)
       \<comment> \<open>ActiveNtfn case\<close>
       apply (rename_tac badge)
       apply (rule ccorres_cond_false)
@@ -6792,8 +6775,7 @@ lemma receiveSignal_ccorres [corres]:
           apply (rule receiveSignal_block_ccorres_helper[simplified])
          apply ceqv
         apply (simp only: K_bind_def)
-        apply (rule_tac ntfn="ntfn"
-                           in receiveSignal_enqueue_ccorres_helper[unfolded dc_def, simplified])
+        apply (rule_tac ntfn="ntfn" in receiveSignal_enqueue_ccorres_helper[simplified])
        apply (simp add: valid_ntfn'_def)
        apply (wp sts_st_tcb')
        apply (rule_tac Q="\<lambda>rv. ko_wp_at' (\<lambda>x. projectKO_opt x = Some ntfn
@@ -6805,7 +6787,7 @@ lemma receiveSignal_ccorres [corres]:
        apply wp
       apply (clarsimp simp: guard_is_UNIV_def)
      apply simp
-     apply (ctac add: doNBRecvFailedTransfer_ccorres[unfolded dc_def])
+     apply (ctac add: doNBRecvFailedTransfer_ccorres)
     apply (clarsimp simp: guard_is_UNIV_def NtfnState_Active_def
                           NtfnState_Waiting_def NtfnState_Idle_def)
    apply (clarsimp simp: guard_is_UNIV_def)

--- a/proof/crefine/ARM_HYP/IsolatedThreadAction.thy
+++ b/proof/crefine/ARM_HYP/IsolatedThreadAction.thy
@@ -412,7 +412,7 @@ lemma modify_isolatable:
                    liftM_def bind_assoc)
   apply (clarsimp simp: monadic_rewrite_def exec_gets
                    getSchedulerAction_def)
-  apply (simp add: simpler_modify_def o_def)
+  apply (simp add: simpler_modify_def)
   apply (subst swap)
    apply (simp add: obj_at_partial_overwrite_If)
   apply (simp add: ksPSpace_update_partial_id o_def)
@@ -646,7 +646,7 @@ lemma setVCPU_isolatable:
   apply (subst setObject_assert_modify;
          simp add: projectKOs objBits_simps archObjSize_def vcpuBits_def vcpu_bits_def pageBits_def)+
   apply (clarsimp simp: select_f_asserts assert_def obj_at_partial_overwrite_id2 split: if_splits)
-  apply (clarsimp simp: select_f_def simpler_modify_def bind_def o_def)
+  apply (clarsimp simp: select_f_def simpler_modify_def bind_def)
   apply (case_tac s)
   apply simp
   apply (rule ext)
@@ -1382,8 +1382,7 @@ lemma setCTE_isolatable:
    apply (erule notE[rotated], erule (3) tcb_ctes_clear[rotated])
   apply (simp add: select_f_returns select_f_asserts split: if_split)
   apply (intro conjI impI)
-    apply (clarsimp simp: simpler_modify_def fun_eq_iff
-                          partial_overwrite_fun_upd2 o_def
+    apply (clarsimp simp: simpler_modify_def fun_eq_iff partial_overwrite_fun_upd2
                   intro!: kernel_state.fold_congs[OF refl refl])
     apply (clarsimp simp: obj_at'_def projectKOs objBits_simps)
     apply (erule notE[rotated], rule tcb_ctes_clear[rotated 2], assumption+)

--- a/proof/crefine/ARM_HYP/Machine_C.thy
+++ b/proof/crefine/ARM_HYP/Machine_C.thy
@@ -560,13 +560,13 @@ lemma cleanCacheRange_PoC_ccorres:
   apply (cinit' lift: start_' end_' pstart_')
    apply (clarsimp simp: cleanCacheRange_PoC_def word_sle_def whileAnno_def)
    apply csymbr
-   apply (rule cacheRangeOp_ccorres[simplified dc_def])
+   apply (rule cacheRangeOp_ccorres)
      apply (rule empty_fail_cleanByVA)
     apply clarsimp
   apply (cinitlift index_')
     apply (rule ccorres_guard_imp2)
      apply csymbr
-     apply (ctac add: cleanByVA_ccorres[unfolded dc_def])
+     apply (ctac add: cleanByVA_ccorres)
     apply (clarsimp simp: lineStart_def cacheLineBits_def shiftr_shiftl1
                           mask_out_sub_mask)
     apply (drule_tac s="w1 && mask 6" in sym, simp add: cache_range_lineIndex_helper)
@@ -606,8 +606,8 @@ lemma cleanInvalidateCacheRange_RAM_ccorres:
              apply (drule_tac s="w1 && mask 6" in sym, simp add: cache_range_lineIndex_helper)
             apply (vcg exspec=cleanInvalByVA_modifies)
            apply (rule ceqv_refl)
-          apply (ctac (no_vcg) add: dsb_ccorres[simplified dc_def])
-       apply (wp | clarsimp simp: guard_is_UNIVI o_def)+
+          apply (ctac (no_vcg) add: dsb_ccorres)
+       apply (wp | clarsimp simp: guard_is_UNIVI)+
   apply (frule(1) ghost_assertion_size_logic)
   apply (clarsimp simp: o_def)
   done
@@ -630,7 +630,7 @@ lemma cleanCacheRange_RAM_ccorres:
         in ccorres_cross_over_guard)
      apply (rule ccorres_Guard_Seq)
      apply (rule ccorres_basic_srnoop2, simp)
-     apply (ctac (no_vcg) add: cleanL2Range_ccorres[unfolded dc_def])
+     apply (ctac (no_vcg) add: cleanL2Range_ccorres)
     apply wp+
   apply clarsimp
   apply (auto dest: ghost_assertion_size_logic simp: o_def)
@@ -650,13 +650,13 @@ lemma cleanCacheRange_PoU_ccorres:
    apply (rule ccorres_basic_srnoop2, simp)
    apply (simp add: cleanCacheRange_PoU_def)
    apply csymbr
-   apply (rule cacheRangeOp_ccorres[simplified dc_def])
+   apply (rule cacheRangeOp_ccorres)
      apply (rule empty_fail_cleanByVA_PoU)
     apply clarsimp
     apply (cinitlift index_')
     apply (rule ccorres_guard_imp2)
      apply csymbr
-     apply (ctac add: cleanByVA_PoU_ccorres[unfolded dc_def])
+     apply (ctac add: cleanByVA_PoU_ccorres)
     apply (clarsimp simp: lineStart_def cacheLineBits_def shiftr_shiftl1
                           mask_out_sub_mask)
     apply (drule_tac s="w1 && mask 6" in sym, simp add: cache_range_lineIndex_helper)
@@ -688,14 +688,14 @@ lemma invalidateCacheRange_RAM_ccorres:
        apply (rule ccorres_cond[where R=\<top>])
          apply (clarsimp simp: lineStart_def cacheLineBits_def)
         apply (rule ccorres_call[OF cleanCacheRange_RAM_ccorres, where xf'=xfdc], (clarsimp)+)
-       apply (rule ccorres_return_Skip[unfolded dc_def])
+       apply (rule ccorres_return_Skip)
       apply ceqv
      apply (rule ccorres_split_nothrow_novcg)
          apply (rule ccorres_cond[where R=\<top>])
            apply (clarsimp simp: lineStart_def cacheLineBits_def)
           apply csymbr
           apply (rule ccorres_call[OF cleanCacheRange_RAM_ccorres, where xf'=xfdc], (clarsimp)+)
-         apply (rule ccorres_return_Skip[unfolded dc_def])
+         apply (rule ccorres_return_Skip)
         apply ceqv
        apply (rule_tac P="\<lambda>s. unat (w2 - w1) \<le> gsMaxObjectSize s"
           in ccorres_cross_over_guard)
@@ -718,7 +718,7 @@ lemma invalidateCacheRange_RAM_ccorres:
               apply (drule_tac s="w1 && mask 6" in sym, simp add: cache_range_lineIndex_helper)
              apply (vcg exspec=invalidateByVA_modifies)
             apply ceqv
-           apply (ctac add: dsb_ccorres[unfolded dc_def])
+           apply (ctac add: dsb_ccorres)
           apply wp
          apply (simp add: guard_is_UNIV_def)
         apply wp
@@ -758,13 +758,13 @@ lemma branchFlushRange_ccorres:
    apply (clarsimp simp: word_sle_def whileAnno_def)
    apply (simp add: branchFlushRange_def)
    apply csymbr
-   apply (rule cacheRangeOp_ccorres[simplified dc_def])
+   apply (rule cacheRangeOp_ccorres)
      apply (rule empty_fail_branchFlush)
     apply clarsimp
     apply (cinitlift index_')
     apply (rule ccorres_guard_imp2)
      apply csymbr
-     apply (ctac add: branchFlush_ccorres[unfolded dc_def])
+     apply (ctac add: branchFlush_ccorres)
     apply (clarsimp simp: lineStart_def cacheLineBits_def shiftr_shiftl1
                           mask_out_sub_mask)
     apply (drule_tac s="w1 && mask 6" in sym, simp add: cache_range_lineIndex_helper)

--- a/proof/crefine/ARM_HYP/Recycle_C.thy
+++ b/proof/crefine/ARM_HYP/Recycle_C.thy
@@ -366,7 +366,7 @@ lemma clearMemory_PageCap_ccorres:
        subgoal by (simp add: pageBits_def ko_at_projectKO_opt[OF user_data_at_ko])
       subgoal by simp
      apply csymbr
-     apply (ctac add: cleanCacheRange_RAM_ccorres[unfolded dc_def])
+     apply (ctac add: cleanCacheRange_RAM_ccorres)
     apply wp
    apply (simp add: guard_is_UNIV_def unat_of_nat
                     word_bits_def capAligned_def word_of_nat_less)
@@ -530,8 +530,8 @@ lemma invalidateTLBByASID_ccorres:
     apply (simp add: case_option_If2 del: Collect_const)
     apply (rule ccorres_if_cond_throws2[where Q=\<top> and Q'=\<top>])
        apply (clarsimp simp: pde_stored_asid_def to_bool_def split: if_split)
-      apply (rule ccorres_return_void_C[unfolded dc_def])
-     apply (simp add: dc_def[symmetric])
+      apply (rule ccorres_return_void_C)
+     apply simp
      apply csymbr
      apply (ctac add: invalidateTranslationASID_ccorres)
     apply vcg
@@ -933,13 +933,13 @@ lemma cancelBadgedSends_ccorres:
                      split: Structures_H.endpoint.split_asm)
      apply ceqv
     apply wpc
-      apply (simp add: dc_def[symmetric] ccorres_cond_iffs)
+      apply (simp add: ccorres_cond_iffs)
       apply (rule ccorres_return_Skip)
-     apply (simp add: dc_def[symmetric] ccorres_cond_iffs)
+     apply (simp add: ccorres_cond_iffs)
      apply (rule ccorres_return_Skip)
     apply (rename_tac list)
     apply (simp add: Collect_True Collect_False endpoint_state_defs
-                     ccorres_cond_iffs dc_def[symmetric]
+                     ccorres_cond_iffs
                 del: Collect_const cong: call_ignore_cong)
     apply (rule ccorres_rhs_assoc)+
     apply (csymbr, csymbr)
@@ -1023,7 +1023,7 @@ lemma cancelBadgedSends_ccorres:
                 subgoal by (simp add: tcb_queue_relation'_def EPState_Send_def mask_def)
                subgoal by (auto split: if_split)
               subgoal by simp
-             apply (ctac add: rescheduleRequired_ccorres[unfolded dc_def])
+             apply (ctac add: rescheduleRequired_ccorres)
             apply (rule hoare_pre, wp weak_sch_act_wf_lift_linear set_ep_valid_objs')
             apply (clarsimp simp: weak_sch_act_wf_def sch_act_wf_def)
             apply (fastforce simp: valid_ep'_def pred_tcb_at' split: list.splits)
@@ -1033,7 +1033,7 @@ lemma cancelBadgedSends_ccorres:
           apply (rule iffD1 [OF ccorres_expand_while_iff_Seq])
           apply (rule ccorres_init_tmp_lift2, ceqv)
           apply (rule ccorres_guard_imp2)
-           apply (simp add: bind_assoc dc_def[symmetric]
+           apply (simp add: bind_assoc
                        del: Collect_const)
            apply (rule ccorres_cond_true)
            apply (rule ccorres_rhs_assoc)+
@@ -1060,7 +1060,7 @@ lemma cancelBadgedSends_ccorres:
             apply ceqv
            apply (rule_tac P="ret__unsigned=blockingIPCBadge rva" in ccorres_gen_asm2)
            apply (rule ccorres_if_bind, rule ccorres_if_lhs)
-            apply (simp add: bind_assoc dc_def[symmetric])
+            apply (simp add: bind_assoc)
             apply (rule ccorres_rhs_assoc)+
             apply (ctac add: setThreadState_ccorres)
               apply (ctac add: tcbSchedEnqueue_ccorres)
@@ -1112,8 +1112,8 @@ lemma cancelBadgedSends_ccorres:
                     apply (drule_tac x=p in spec)
                     subgoal by fastforce
                    apply (rule conjI)
-                    apply (erule cready_queues_relation_not_queue_ptrs,
-                           auto dest: null_ep_schedD[unfolded o_def] simp: o_def)[1]
+                    apply (erule cready_queues_relation_not_queue_ptrs;
+                           fastforce dest: null_ep_schedD[unfolded o_def] simp: o_def)
                    apply (simp add: carch_state_relation_def
                                     cmachine_state_relation_def
                                     h_t_valid_clift_Some_iff)
@@ -1131,9 +1131,9 @@ lemma cancelBadgedSends_ccorres:
              apply (wp hoare_vcg_const_Ball_lift sts_st_tcb_at'_cases
                        sts_sch_act sts_valid_queues setThreadState_oa_queued)
             apply (vcg exspec=setThreadState_cslift_spec)
-           apply (simp add: ccorres_cond_iffs dc_def[symmetric])
+           apply (simp add: ccorres_cond_iffs)
            apply (rule ccorres_symb_exec_r2)
-             apply (drule_tac x="x @ [a]" in spec, simp add: dc_def[symmetric])
+             apply (drule_tac x="x @ [a]" in spec, simp)
             apply vcg
            apply (vcg spec=modifies)
           apply (thin_tac "\<forall>x. P x" for P)

--- a/proof/crefine/ARM_HYP/Refine_C.thy
+++ b/proof/crefine/ARM_HYP/Refine_C.thy
@@ -525,7 +525,7 @@ lemma handleVCPUFault_ccorres:
         apply (ctac (no_vcg) add: schedule_ccorres)
          apply (rule ccorres_stateAssert_after)
          apply (rule ccorres_guard_imp)
-           apply (ctac (no_vcg) add: activateThread_ccorres[simplified dc_def])
+           apply (ctac (no_vcg) add: activateThread_ccorres)
           apply (clarsimp, assumption)
          apply assumption
         apply (wp schedule_sch_act_wf schedule_invs'|strengthen invs_queues invs_valid_objs')+
@@ -642,9 +642,9 @@ lemma callKernel_withFastpath_corres_C:
    apply (rule ccorres_rhs_assoc)+
    apply (rule ccorres_symb_exec_r)+
        apply (rule ccorres_Cond_rhs)
-        apply (simp add: dc_def[symmetric])
+        apply simp
         apply (ctac add: ccorres_get_registers[OF fastpath_call_ccorres_callKernel])
-       apply (simp add: dc_def[symmetric])
+       apply simp
        apply (ctac add: ccorres_get_registers[OF fastpath_reply_recv_ccorres_callKernel])
       apply vcg
      apply (rule conseqPre, vcg, clarsimp)
@@ -729,9 +729,9 @@ lemma entry_corres_C:
           apply (simp add: ccontext_rel_to_C)
          apply simp
         apply (rule corres_split)
-           apply (rule corres_cases[where R=fp], simp_all add: dc_def[symmetric])[1]
-            apply (rule callKernel_withFastpath_corres_C, simp)
-           apply (rule callKernel_corres_C[unfolded dc_def], simp)
+           apply (rule corres_cases[where R=fp]; simp)
+            apply (rule callKernel_withFastpath_corres_C)
+           apply (rule callKernel_corres_C)
           apply (rule corres_split[where P=\<top> and P'=\<top> and r'="\<lambda>t t'. t' = tcb_ptr_to_ctcb_ptr t"])
              apply (clarsimp simp: rf_sr_def cstate_relation_def Let_def)
             apply (rule getContext_corres, simp)
@@ -931,7 +931,7 @@ lemma do_user_op_corres_C:
                apply (clarsimp simp: rf_sr_def cstate_relation_def Let_def
                                cpspace_relation_def)
                apply (drule(1) device_mem_C_relation[symmetric])
-               apply (simp add: comp_def)
+               apply simp
               apply (rule_tac P=valid_state' and P'=\<top> and r'="(=)" in corres_split)
                  apply (clarsimp simp: cstate_relation_def rf_sr_def
                    Let_def cmachine_state_relation_def)

--- a/proof/crefine/ARM_HYP/SR_lemmas_C.thy
+++ b/proof/crefine/ARM_HYP/SR_lemmas_C.thy
@@ -676,7 +676,6 @@ proof (rule cor_map_relI [OF map_option_eq_dom_eq])
 
   hence "tcb_no_ctes_proj tcb = tcb_no_ctes_proj tcb'" using om
     apply -
-    apply (simp add: o_def)
     apply (drule fun_cong [where x = x])
     apply simp
     done

--- a/proof/crefine/ARM_HYP/Schedule_C.thy
+++ b/proof/crefine/ARM_HYP/Schedule_C.thy
@@ -79,7 +79,6 @@ lemma Arch_switchToThread_ccorres:
         apply (ctac (no_vcg) add: setVMRoot_ccorres)
          apply (simp (no_asm) del: Collect_const)
          apply (rule_tac A'=UNIV in ccorres_guard_imp2)
-          apply (fold dc_def)[1]
           apply (ctac add: clearExMonitor_ccorres)
          apply wpsimp+
       apply (vcg exspec=vcpu_switch_modifies)
@@ -217,14 +216,14 @@ lemmas ccorres_remove_tail_Guard_Skip
     = ccorres_abstract[where xf'="\<lambda>_. ()", OF ceqv_remove_tail_Guard_Skip]
 
 lemma switchToThread_ccorres':
-  "ccorres (\<lambda>_ _. True) xfdc
+  "ccorres dc xfdc
            (all_invs_but_ct_idle_or_in_cur_domain' and tcb_at' t)
            (UNIV \<inter> \<lbrace>\<acute>thread = tcb_ptr_to_ctcb_ptr t\<rbrace>)
            hs
            (switchToThread t)
            (Call switchToThread_'proc)"
   apply (rule ccorres_guard_imp2)
-      apply (ctac (no_vcg) add: switchToThread_ccorres[simplified dc_def])
+      apply (ctac (no_vcg) add: switchToThread_ccorres)
      apply auto
   done
 
@@ -316,14 +315,14 @@ proof -
     apply (intro conjI impI)
        apply (fastforce dest: bitmapQ_from_bitmap_lookup simp: valid_bitmapQ_bitmapQ_simp)
       apply (fastforce dest: lookupBitmapPriority_obj_at'
-                       simp: pred_conj_def comp_def obj_at'_def st_tcb_at'_def)
+                       simp: pred_conj_def obj_at'_def st_tcb_at'_def)
      apply (fastforce dest: bitmapQ_from_bitmap_lookup simp: valid_bitmapQ_bitmapQ_simp)
-    apply (clarsimp simp: pred_conj_def comp_def obj_at'_def st_tcb_at'_def)
+    apply (clarsimp simp: pred_conj_def obj_at'_def st_tcb_at'_def)
     apply (clarsimp simp: not_less le_maxDomain_eq_less_numDomains)
     apply (prop_tac "ksCurDomain s = 0")
      using unsigned_eq_0_iff apply force
     apply (cut_tac s=s in lookupBitmapPriority_obj_at'; simp?)
-    apply (clarsimp simp: pred_conj_def comp_def obj_at'_def st_tcb_at'_def)
+    apply (clarsimp simp: pred_conj_def obj_at'_def st_tcb_at'_def)
     done
 qed
 
@@ -404,7 +403,6 @@ lemma isHighestPrio_ccorres:
            (isHighestPrio d p)
            (Call isHighestPrio_'proc)"
   supply Collect_const [simp del]
-  supply dc_simp [simp del]
   supply prio_and_dom_limit_helpers[simp]
   supply Collect_const_mem [simp]
   (* FIXME: these should likely be in simpset for CRefine, or even in general *)
@@ -445,7 +443,6 @@ lemma isHighestPrio_ccorres:
 lemma schedule_ccorres:
   "ccorres dc xfdc invs' UNIV [] schedule (Call schedule_'proc)"
   supply Collect_const [simp del]
-  supply dc_simp [simp del]
   supply prio_and_dom_limit_helpers[simp]
   supply Collect_const_mem [simp]
   (* FIXME: these should likely be in simpset for CRefine, or even in general *)
@@ -459,7 +456,7 @@ lemma schedule_ccorres:
      apply (rule ccorres_cond_false_seq)
      apply simp
      apply (rule_tac P=\<top> and P'="{s. ksSchedulerAction_' (globals s) = NULL }" in ccorres_from_vcg)
-     apply (clarsimp simp: dc_def return_def split: prod.splits)
+     apply (clarsimp simp: return_def split: prod.splits)
      apply (rule conseqPre, vcg, clarsimp)
     (* toplevel case: action is choose new thread *)
     apply (rule ccorres_cond_true_seq)
@@ -476,7 +473,7 @@ lemma schedule_ccorres:
          apply (ctac add: tcbSchedEnqueue_ccorres)
          apply (rule ccorres_from_vcg[where P=\<top> and P'=UNIV])
          apply (clarsimp, rule conseqPre, vcg)
-         apply (clarsimp simp: dc_def return_def)
+         apply (clarsimp simp: return_def)
         apply (rule ccorres_cond_true_seq)
         (* isolate haskell part before setting thread action *)
         apply (simp add: scheduleChooseNewThread_def)
@@ -504,7 +501,7 @@ lemma schedule_ccorres:
         apply (ctac add: tcbSchedEnqueue_ccorres)
         apply (rule ccorres_from_vcg[where P=\<top> and P'=UNIV])
         apply (clarsimp, rule conseqPre, vcg)
-        apply (clarsimp simp: dc_def return_def)
+        apply (clarsimp simp: return_def)
        apply (rule ccorres_cond_false_seq)
 
        apply (rule_tac xf'=was_runnable_' in ccorres_abstract, ceqv)
@@ -524,7 +521,7 @@ lemma schedule_ccorres:
          apply (rule ccorres_rhs_assoc2)
          apply (rule ccorres_rhs_assoc2)
          apply (rule_tac r'="\<lambda>rv rv'. rv = to_bool rv'" and xf'=fastfail_' in ccorres_split_nothrow)
-             apply (clarsimp simp: scheduleSwitchThreadFastfail_def dc_simp)
+             apply (clarsimp simp: scheduleSwitchThreadFastfail_def)
              apply (rule ccorres_cond_seq2[THEN iffD1])
              apply (rule_tac xf'=ret__int_' and val="from_bool (curThread = it)"
                       and R="\<lambda>s. it = ksIdleThread s \<and> curThread = ksCurThread s" and R'=UNIV
@@ -561,11 +558,10 @@ lemma schedule_ccorres:
                 apply (rule ccorres_move_c_guard_tcb)
                 apply (rule ccorres_add_return2)
                 apply (ctac add: isHighestPrio_ccorres, clarsimp)
-                  apply (clarsimp simp: to_bool_def)
                   apply (rule ccorres_inst[where P=\<top> and P'=UNIV])
                   apply (rule ccorres_return)
                   apply (rule conseqPre, vcg)
-                  apply clarsimp
+                  apply (clarsimp simp: to_bool_def)
                  apply (rule wp_post_taut)
                 apply (vcg exspec=isHighestPrio_modifies)
                apply (rule_tac P=\<top> and P'="{s. ret__int_' s = 0}" in ccorres_from_vcg)
@@ -665,13 +661,12 @@ lemma schedule_ccorres:
        apply (clarsimp simp: invs'_bitmapQ_no_L1_orphans invs_ksCurDomain_maxDomain')
        apply (fastforce dest: invs_sch_act_wf')
 
-      apply (wp | clarsimp simp: dc_def)+
+      apply wpsimp+
      apply (vcg exspec=tcbSchedEnqueue_modifies)
     apply wp
    apply vcg
 
-  apply (clarsimp simp: tcb_at_invs' rf_sr_ksCurThread if_apply_def2 invs_queues invs_valid_objs'
-                         dc_def)+
+  apply (clarsimp simp: tcb_at_invs' rf_sr_ksCurThread if_apply_def2 invs_queues invs_valid_objs')
   apply (frule invs_sch_act_wf')
   apply (frule tcb_at_invs')
   apply (rule conjI)
@@ -742,7 +737,7 @@ lemma timerTick_ccorres:
    apply (ctac add: get_tsType_ccorres2 [where f="\<lambda>s. ksCurThread_' (globals s)"])
      apply (rule ccorres_split_nothrow_novcg)
          apply wpc
-                apply (simp add: "StrictC'_thread_state_defs", rule ccorres_cond_false, rule ccorres_return_Skip[unfolded dc_def])+
+                apply (simp add: "StrictC'_thread_state_defs", rule ccorres_cond_false, rule ccorres_return_Skip)+
              (* thread_state.Running *)
              apply simp
              apply (rule ccorres_cond_true)
@@ -764,17 +759,17 @@ lemma timerTick_ccorres:
               apply (rule_tac P="cur_tcb'" and P'=\<top> in ccorres_move_c_guards(8))
                apply (clarsimp simp: cur_tcb'_def)
                apply (fastforce simp: rf_sr_def cstate_relation_def Let_def typ_heap_simps dest: tcb_at_h_t_valid)
-              apply (ctac add: threadSet_timeSlice_ccorres[unfolded dc_def])
+              apply (ctac add: threadSet_timeSlice_ccorres)
              apply (rule ccorres_rhs_assoc)+
              apply (ctac)
                apply simp
                apply (ctac (no_vcg) add: tcbSchedAppend_ccorres)
-                apply (ctac add: rescheduleRequired_ccorres[unfolded dc_def])
+                apply (ctac add: rescheduleRequired_ccorres)
                apply (wp weak_sch_act_wf_lift_linear threadSet_valid_queues
                          threadSet_pred_tcb_at_state tcbSchedAppend_valid_objs' threadSet_valid_objs' threadSet_tcbDomain_triv
                     | clarsimp simp: st_tcb_at'_def o_def split: if_splits)+
              apply (vcg exspec=tcbSchedDequeue_modifies)
-        apply (simp add: "StrictC'_thread_state_defs", rule ccorres_cond_false, rule ccorres_return_Skip[unfolded dc_def])+
+        apply (simp add: "StrictC'_thread_state_defs", rule ccorres_cond_false, rule ccorres_return_Skip)+
         apply ceqv
        apply (clarsimp simp: decDomainTime_def numDomains_sge_1_simp)
        apply (rule ccorres_when[where R=\<top>])
@@ -786,7 +781,6 @@ lemma timerTick_ccorres:
            apply (clarsimp simp: rf_sr_def cstate_relation_def Let_def
                                  carch_state_relation_def cmachine_state_relation_def)
           apply ceqv
-         apply (fold dc_def)
          apply (rule ccorres_pre_getDomainTime)
          apply (rename_tac rva rv'a rvb)
          apply (rule_tac P'="{s. ksDomainTime_' (globals s) = rvb}" in ccorres_inst, simp)
@@ -794,13 +788,13 @@ lemma timerTick_ccorres:
           apply clarsimp
           apply (rule ccorres_guard_imp2)
            apply (rule ccorres_cond_true)
-           apply (ctac add: rescheduleRequired_ccorres[unfolded dc_def])
+           apply (ctac add: rescheduleRequired_ccorres)
           apply clarsimp
           apply assumption
          apply clarsimp
          apply (rule ccorres_guard_imp2)
           apply (rule ccorres_cond_false)
-          apply (rule ccorres_return_Skip[unfolded dc_def])
+          apply (rule ccorres_return_Skip)
          apply clarsimp
         apply wp
        apply (clarsimp simp: guard_is_UNIV_def)

--- a/proof/crefine/ARM_HYP/SyscallArgs_C.thy
+++ b/proof/crefine/ARM_HYP/SyscallArgs_C.thy
@@ -289,7 +289,7 @@ lemma ccorres_invocationCatch_Inr:
            if reply = [] then liftE (replyOnRestart thread [] isCall) \<sqinter> returnOk ()
                          else liftE (replyOnRestart thread reply isCall)
        odE od) c"
-  apply (simp add: invocationCatch_def liftE_bindE o_xo_injector)
+  apply (simp add: invocationCatch_def liftE_bindE o_xo_injector cong: ccorres_all_cong)
   apply (subst ccorres_liftM_simp[symmetric])
   apply (simp add: liftM_def bind_assoc bindE_def)
   apply (rule_tac f="\<lambda>f. ccorres rvr xs P P' hs f c" for rvr xs in arg_cong)

--- a/proof/crefine/ARM_HYP/Syscall_C.thy
+++ b/proof/crefine/ARM_HYP/Syscall_C.thy
@@ -270,22 +270,22 @@ lemma decodeInvocation_ccorres:
    apply (rule ccorres_Cond_rhs)
     apply (simp add: if_to_top_of_bind)
     apply (rule ccorres_trim_returnE, simp+)
-    apply (simp add: liftME_invocationCatch o_def)
+    apply (simp add: liftME_invocationCatch)
     apply (rule ccorres_call, rule decodeTCBInvocation_ccorres)
        apply assumption
       apply (simp+)[3]
    apply (rule ccorres_Cond_rhs)
     apply (rule ccorres_trim_returnE, simp+)
-    apply (simp add: liftME_invocationCatch o_def)
+    apply (simp add: liftME_invocationCatch)
     apply (rule ccorres_call,
-           erule decodeDomainInvocation_ccorres[unfolded o_def],
+           erule decodeDomainInvocation_ccorres,
            simp+)[1]
    apply (rule ccorres_Cond_rhs)
     apply (simp add: if_to_top_of_bind)
     apply (rule ccorres_trim_returnE, simp+)
-    apply (simp add: liftME_invocationCatch o_def)
+    apply (simp add: liftME_invocationCatch)
     apply (rule ccorres_call,
-           erule decodeCNodeInvocation_ccorres[unfolded o_def],
+           erule decodeCNodeInvocation_ccorres,
            simp+)[1]
    apply (rule ccorres_Cond_rhs)
     apply simp
@@ -755,7 +755,7 @@ lemma handleFault_ccorres:
          apply (rule ccorres_return_Skip')
         apply clarsimp
         apply (rule ccorres_cond_univ)
-        apply (ctac (no_vcg) add: handleDoubleFault_ccorres [unfolded dc_def])
+        apply (ctac (no_vcg) add: handleDoubleFault_ccorres)
        apply (simp add: sendFaultIPC_def)
        apply wp
          apply ((wp hoare_vcg_all_lift_R hoare_drop_impE_R |wpc |simp add: throw_def)+)[1]
@@ -1118,7 +1118,7 @@ lemma handleReply_ccorres:
                  apply (rule ccorres_cond_true)
                  apply simp
                  apply (rule ccorres_return_void_catchbrk)
-                 apply (rule ccorres_return_void_C[unfolded dc_def])
+                 apply (rule ccorres_return_void_C)
                 apply (vcg exspec=doReplyTransfer_modifies)
                apply (rule ccorres_fail)+
           apply (wpc, simp_all)
@@ -1136,7 +1136,6 @@ lemma handleReply_ccorres:
            apply (csymbr, csymbr, csymbr)
            apply simp
            apply (rule ccorres_assert2)
-           apply (fold dc_def)
            apply (rule ccorres_add_return2)
            apply (ctac (no_vcg))
             apply (rule ccorres_return_void_catchbrk)
@@ -1298,7 +1297,7 @@ lemma handleRecv_ccorres:
                apply (rule ccorres_add_return2)
                apply (rule ccorres_split_nothrow_call[where xf'=xfdc and d'="\<lambda>_. break_C"
                                                       and Q="\<lambda>_ _. True" and Q'="\<lambda>_ _. UNIV"])
-                      apply (ctac add: handleFault_ccorres[unfolded dc_def])
+                      apply (ctac add: handleFault_ccorres)
                      apply simp+
                   apply ceqv
                  apply (rule ccorres_break_return)
@@ -1317,7 +1316,7 @@ lemma handleRecv_ccorres:
           apply (simp add: liftE_bind)
           apply (ctac)
             apply (rule_tac P="\<lambda>s. ksCurThread s = rv" in ccorres_cross_over_guard)
-            apply (ctac add: receiveIPC_ccorres[unfolded dc_def])
+            apply (ctac add: receiveIPC_ccorres)
 
            apply (wp deleteCallerCap_ksQ_ct' hoare_vcg_all_lift)
           apply (rule conseqPost[where Q'=UNIV and A'="{}"], vcg exspec=deleteCallerCap_modifies)
@@ -1365,7 +1364,7 @@ lemma handleRecv_ccorres:
                   apply (rule ccorres_add_return2)
                   apply (rule ccorres_split_nothrow_call[where xf'=xfdc and d'="\<lambda>_. break_C"
                                                and Q="\<lambda>_ _. True" and Q'="\<lambda>_ _. UNIV"])
-                         apply (ctac add: handleFault_ccorres[unfolded dc_def])
+                         apply (ctac add: handleFault_ccorres)
                         apply simp+
                      apply ceqv
                     apply (rule ccorres_break_return)
@@ -1382,7 +1381,7 @@ lemma handleRecv_ccorres:
               apply (clarsimp simp: rf_sr_upd_safe)
 
              apply (simp add: liftE_bind)
-             apply (ctac  add: receiveSignal_ccorres[unfolded dc_def])
+             apply (ctac  add: receiveSignal_ccorres)
             apply clarsimp
             apply (vcg exspec=handleFault_modifies)
            apply (rule ccorres_cond_true_seq)
@@ -1395,7 +1394,7 @@ lemma handleRecv_ccorres:
               apply (rule ccorres_cross_over_guard[where P=\<top>])
               apply (rule ccorres_symb_exec_r)
                 apply (rule ccorres_add_return2)
-                apply (ctac add: handleFault_ccorres[unfolded dc_def])
+                apply (ctac add: handleFault_ccorres)
                   apply (rule ccorres_break_return[where P=\<top> and P'=UNIV])
                    apply simp+
                  apply wp
@@ -1416,7 +1415,7 @@ lemma handleRecv_ccorres:
         apply (rule ccorres_symb_exec_r)
           apply (rule ccorres_cross_over_guard[where P=\<top>])
           apply (rule ccorres_symb_exec_r)
-            apply (ctac add: handleFault_ccorres[unfolded dc_def])
+            apply (ctac add: handleFault_ccorres)
            apply vcg
           apply (rule conseqPre, vcg)
           apply (clarsimp simp: rf_sr_upd_safe)
@@ -1429,9 +1428,9 @@ lemma handleRecv_ccorres:
        apply (rule ccorres_rhs_assoc)+
        apply (rule ccorres_cross_over_guard[where P=\<top>])
        apply (rule ccorres_symb_exec_r)
-         apply (ctac add: handleFault_ccorres[unfolded dc_def])
+         apply (ctac add: handleFault_ccorres)
            apply (rule ccorres_split_throws)
-            apply (rule ccorres_return_void_C [unfolded dc_def])
+            apply (rule ccorres_return_void_C)
            apply vcg
           apply wp
          apply (vcg exspec=handleFault_modifies)
@@ -1689,7 +1688,7 @@ lemma virq_virq_active_set_virqEOIIRQEN_spec':
        \<lbrace> \<acute>ret__struct_virq_C = virq_C (ARRAY _. virqSetEOIIRQEN (virq_to_H \<^bsup>s\<^esup>virq) \<^bsup>s\<^esup>v32) \<rbrace>"
   apply (hoare_rule HoarePartial.ProcNoRec1) (* force vcg to unfold non-recursive procedure *)
   apply vcg
-  apply (clarsimp simp: virq_to_H_def ARM_A.virqSetEOIIRQEN_def o_def)
+  apply (clarsimp simp: virq_to_H_def ARM_A.virqSetEOIIRQEN_def)
   apply (case_tac virq)
   apply clarsimp
   apply (rule array_ext)
@@ -1702,7 +1701,7 @@ lemma virq_virq_invalid_set_virqEOIIRQEN_spec':
        \<lbrace> \<acute>ret__struct_virq_C = virq_C (ARRAY _. virqSetEOIIRQEN (virq_to_H \<^bsup>s\<^esup>virq) \<^bsup>s\<^esup>v32) \<rbrace>"
   apply (hoare_rule HoarePartial.ProcNoRec1) (* force vcg to unfold non-recursive procedure *)
   apply vcg
-  apply (clarsimp simp: virq_to_H_def ARM_A.virqSetEOIIRQEN_def o_def)
+  apply (clarsimp simp: virq_to_H_def ARM_A.virqSetEOIIRQEN_def)
   apply (case_tac virq)
   apply clarsimp
   apply (rule array_ext)
@@ -1715,7 +1714,7 @@ lemma virq_virq_pending_set_virqEOIIRQEN_spec':
        \<lbrace> \<acute>ret__struct_virq_C = virq_C (ARRAY _. virqSetEOIIRQEN (virq_to_H \<^bsup>s\<^esup>virq) \<^bsup>s\<^esup>v32) \<rbrace>"
   apply (hoare_rule HoarePartial.ProcNoRec1) (* force vcg to unfold non-recursive procedure *)
   apply vcg
-  apply (clarsimp simp: virq_to_H_def ARM_A.virqSetEOIIRQEN_def o_def)
+  apply (clarsimp simp: virq_to_H_def ARM_A.virqSetEOIIRQEN_def)
   apply (case_tac virq)
   apply clarsimp
   apply (rule array_ext)
@@ -1794,8 +1793,8 @@ definition
 where
   "eisr_calc eisr0 eisr1 \<equiv> if eisr0 \<noteq> 0 then word_ctz eisr0 else word_ctz eisr1 + 32"
 
-lemma  ccorres_vgicMaintenance:
-  notes dc_simp[simp del] Collect_const[simp del]
+lemma ccorres_vgicMaintenance:
+  notes Collect_const[simp del]
   notes scast_specific_plus32[simp] scast_specific_plus32_signed[simp]
   notes virq_virq_active_set_virqEOIIRQEN_spec = virq_virq_active_set_virqEOIIRQEN_spec'
   notes virq_virq_invalid_set_virqEOIIRQEN_spec = virq_virq_invalid_set_virqEOIIRQEN_spec'
@@ -2067,7 +2066,7 @@ proof -
        apply wpsimp
       apply wpsimp
      apply wpsimp
-    apply (clarsimp simp: cur_vcpu_relation_def dc_def eisr_calc_def split: option.splits)
+    apply (clarsimp simp: cur_vcpu_relation_def eisr_calc_def split: option.splits)
     done
 qed
 
@@ -2132,8 +2131,8 @@ lemma vcpuUpdate_vppi_masked_ccorres_armHSCurVCPU:
   apply (clarsimp dest!: rf_sr_ksArchState_armHSCurVCPU simp: cur_vcpu_relation_def split: option.splits)
   done
 
-lemma  ccorres_VPPIEvent:
-  notes dc_simp[simp del] Collect_const[simp del]
+lemma ccorres_VPPIEvent:
+  notes Collect_const[simp del]
   notes scast_specific_plus32[simp] scast_specific_plus32_signed[simp]
   shows
   "ccorres dc xfdc
@@ -2224,7 +2223,6 @@ lemma ccorres_handleReservedIRQ:
                      (\<forall>p. ksCurThread s \<notin> set (ksReadyQueues s p))))
     (UNIV \<inter> {s. irq_' s = ucast irq}) hs
     (handleReservedIRQ irq) (Call handleReservedIRQ_'proc)"
-  supply dc_simp[simp del]
   supply Collect_const[simp del]
   apply (cinit lift: irq_')
    apply (clarsimp simp: ucast_up_ucast is_up)
@@ -2275,11 +2273,11 @@ lemma handleInterrupt_ccorres:
     apply (subst doMachineOp_bind)
       apply (rule maskInterrupt_empty_fail)
      apply (rule ackInterrupt_empty_fail)
-    apply (ctac add: maskInterrupt_ccorres[unfolded dc_def])
+    apply (ctac add: maskInterrupt_ccorres)
       apply (subst bind_return_unit[where f="doMachineOp (ackInterrupt irq)"])
-      apply (ctac add: ackInterrupt_ccorres[unfolded dc_def])
+      apply (ctac add: ackInterrupt_ccorres)
         apply (rule ccorres_split_throws)
-         apply (rule ccorres_return_void_C[unfolded dc_def])
+         apply (rule ccorres_return_void_C)
         apply vcg
        apply wp
       apply (vcg exspec=ackInterrupt_modifies)
@@ -2317,7 +2315,7 @@ lemma handleInterrupt_ccorres:
          apply (ctac (no_vcg) add: sendSignal_ccorres)
           apply (simp add: maskIrqSignal_def)
           apply (ctac (no_vcg) add: maskInterrupt_ccorres)
-           apply (ctac add: ackInterrupt_ccorres [unfolded dc_def])
+           apply (ctac add: ackInterrupt_ccorres)
           apply wp+
         apply (simp del: Collect_const)
         apply (rule ccorres_cond_true_seq)
@@ -2326,7 +2324,7 @@ lemma handleInterrupt_ccorres:
         apply (rule ccorres_cond_false_seq)
         apply (simp add: maskIrqSignal_def)
         apply (ctac (no_vcg) add: maskInterrupt_ccorres)
-         apply (ctac add: ackInterrupt_ccorres [unfolded dc_def])
+         apply (ctac add: ackInterrupt_ccorres)
         apply wp
        apply (rule_tac P=\<top> and P'="{s. ret__int_' s = 0 \<and> cap_get_tag cap \<noteq> scast cap_notification_cap}" in ccorres_inst)
        apply (clarsimp simp: isCap_simps simp del: Collect_const)
@@ -2338,7 +2336,7 @@ lemma handleInterrupt_ccorres:
                         rule ccorres_cond_false_seq, simp,
                         rule ccorres_cond_false_seq, simp,
                         ctac (no_vcg) add: maskInterrupt_ccorres,
-                        ctac (no_vcg) add: ackInterrupt_ccorres [unfolded dc_def],
+                        ctac (no_vcg) add: ackInterrupt_ccorres,
                         wp, simp)+)
       apply (wp getSlotCap_wp)
      apply simp
@@ -2347,7 +2345,6 @@ lemma handleInterrupt_ccorres:
     apply (rule ccorres_move_const_guards)+
     apply (rule ccorres_cond_false_seq)
     apply (rule ccorres_cond_true_seq)
-    apply (fold dc_def)[1]
     apply (rule ccorres_rhs_assoc)+
     apply (ctac (no_vcg) add: timerTick_ccorres)
      apply (ctac (no_vcg) add: resetTimer_ccorres)
@@ -2359,7 +2356,7 @@ lemma handleInterrupt_ccorres:
    apply (rule ccorres_cond_false_seq)
    apply (rule ccorres_cond_true_seq)
    apply (ctac add: ccorres_handleReservedIRQ)
-     apply (ctac (no_vcg) add: ackInterrupt_ccorres [unfolded dc_def])
+     apply (ctac (no_vcg) add: ackInterrupt_ccorres)
     apply wp
    apply (vcg exspec=handleReservedIRQ_modifies)
   apply (simp add: sint_ucast_eq_uint is_down uint_up_ucast is_up)

--- a/proof/crefine/ARM_HYP/Tcb_C.thy
+++ b/proof/crefine/ARM_HYP/Tcb_C.thy
@@ -412,8 +412,8 @@ lemma setPriority_ccorres:
         apply (rule ccorres_pre_getCurThread)
         apply (rule_tac R = "\<lambda>s. rv = ksCurThread s" in ccorres_cond2)
           apply (clarsimp simp: rf_sr_ksCurThread)
-         apply (ctac add: rescheduleRequired_ccorres[unfolded dc_def])
-        apply (ctac add: possibleSwitchTo_ccorres[unfolded dc_def])
+         apply (ctac add: rescheduleRequired_ccorres)
+        apply (ctac add: possibleSwitchTo_ccorres)
        apply (rule ccorres_return_Skip')
       apply (wp isRunnable_wp)
      apply (wpsimp wp: hoare_drop_imps threadSet_valid_queues threadSet_valid_objs'
@@ -612,7 +612,7 @@ lemma invokeTCB_ThreadControl_ccorres:
            apply (rule ccorres_move_array_assertion_tcb_ctes ccorres_Guard_Seq)+
            apply csymbr
            apply (simp add: liftE_bindE[symmetric] bindE_assoc getThreadBufferSlot_def
-                            locateSlot_conv o_def
+                            locateSlot_conv
                        del: Collect_const)
            apply (simp add: liftE_bindE del: Collect_const)
            apply (ctac(no_vcg) add: cteDelete_ccorres)
@@ -658,7 +658,7 @@ lemma invokeTCB_ThreadControl_ccorres:
                                            and Q'=UNIV in ccorres_rewrite_cond_sr)
                             apply (clarsimp simp: Collect_const_mem rf_sr_ksCurThread)
                            apply (rule ccorres_Cond_rhs; clarsimp)
-                            apply (ctac (no_vcg) add: rescheduleRequired_ccorres[unfolded dc_def])
+                            apply (ctac (no_vcg) add: rescheduleRequired_ccorres)
                            apply (rule ccorres_return_Skip')
                           apply (rule ccorres_split_nothrow_novcg_dc)
                              apply (rule ccorres_cond2[where R=\<top>], simp add: Collect_const_mem)
@@ -696,7 +696,7 @@ lemma invokeTCB_ThreadControl_ccorres:
                                       and Q'=UNIV in ccorres_rewrite_cond_sr)
                        apply (clarsimp simp: Collect_const_mem rf_sr_ksCurThread)
                       apply (rule ccorres_Cond_rhs; clarsimp)
-                       apply (ctac (no_vcg) add: rescheduleRequired_ccorres[unfolded dc_def])
+                       apply (ctac (no_vcg) add: rescheduleRequired_ccorres)
                       apply (rule ccorres_return_Skip')
                      apply (rule ccorres_split_nothrow_novcg_dc)
                         apply (trace_schematic_insts \<open>rule ccorres_cond2[where R=\<top>], simp add: Collect_const_mem\<close>)
@@ -723,7 +723,7 @@ lemma invokeTCB_ThreadControl_ccorres:
                                     and Q'=UNIV in ccorres_rewrite_cond_sr)
                      apply (clarsimp simp: Collect_const_mem rf_sr_ksCurThread)
                     apply (rule ccorres_Cond_rhs; clarsimp)
-                     apply (ctac(no_vcg) add: rescheduleRequired_ccorres[unfolded dc_def])
+                     apply (ctac(no_vcg) add: rescheduleRequired_ccorres)
                     apply (rule ccorres_return_Skip')
                    apply (rule ccorres_split_nothrow_novcg_dc)
                       apply(rule ccorres_cond2[where R=\<top>], simp add: Collect_const_mem)
@@ -749,7 +749,7 @@ lemma invokeTCB_ThreadControl_ccorres:
                                   and Q'=UNIV in ccorres_rewrite_cond_sr)
                    apply (clarsimp simp: Collect_const_mem rf_sr_ksCurThread)
                   apply (rule ccorres_Cond_rhs; clarsimp)
-                   apply (ctac(no_vcg) add: rescheduleRequired_ccorres[unfolded dc_def])
+                   apply (ctac(no_vcg) add: rescheduleRequired_ccorres)
                   apply (rule ccorres_return_Skip')
                  apply (rule ccorres_split_nothrow_novcg_dc)
                     apply (rule ccorres_cond2[where R=\<top>], simp add: Collect_const_mem)
@@ -839,11 +839,10 @@ lemma invokeTCB_ThreadControl_ccorres:
          apply csymbr
          apply (ctac(no_vcg) add: cteDelete_ccorres)
            apply (simp add: liftE_bindE Collect_False ccorres_cond_iffs
-                            dc_def
                        del: Collect_const)
            apply ((rule ccorres_split_nothrow_novcg_dc[rotated], assumption) | rule ccorres_rhs_assoc2)+
              apply (simp add: conj_comms pred_conj_def)
-             apply (simp add: o_def cong: conj_cong option.case_cong)
+             apply (simp cong: conj_cong option.case_cong)
              apply (wp checked_insert_tcb_invs' hoare_case_option_wp
                        checkCap_inv [where P="tcb_at' p0" for p0]
                        checkCap_inv [where P="cte_at' p0" for p0]
@@ -861,8 +860,7 @@ lemma invokeTCB_ThreadControl_ccorres:
              apply (rule checkCapAt_ccorres2)
                 apply ceqv
                apply csymbr
-               apply (simp add: Collect_True assertDerived_def bind_assoc
-                                ccorres_cond_iffs dc_def[symmetric]
+               apply (simp add: Collect_True assertDerived_def bind_assoc ccorres_cond_iffs
                            del: Collect_const)
                apply (rule ccorres_symb_exec_l)
                   apply (ctac add: cteInsert_ccorres)
@@ -870,13 +868,13 @@ lemma invokeTCB_ThreadControl_ccorres:
               apply csymbr
               apply (simp add: Collect_False ccorres_cond_iffs
                           del: Collect_const)
-              apply (rule ccorres_return_Skip[unfolded dc_def])
+              apply (rule ccorres_return_Skip)
              apply (fastforce simp: guard_is_UNIV_def Kernel_C.tcbVTable_def tcbVTableSlot_def
                                     cte_level_bits_def size_of_def)
             apply csymbr
             apply (simp add: Collect_False del: Collect_const)
             apply (rule ccorres_cond_false)
-            apply (rule ccorres_return_Skip[unfolded dc_def])
+            apply (rule ccorres_return_Skip)
            apply (clarsimp simp: guard_is_UNIV_def ccap_relation_def cap_thread_cap_lift cap_to_H_def)
           apply simp
           apply (rule ccorres_split_throws, rule ccorres_return_C_errorE, simp+)
@@ -900,12 +898,11 @@ lemma invokeTCB_ThreadControl_ccorres:
         apply csymbr
         apply (ctac(no_vcg) add: cteDelete_ccorres)
           apply (simp add: liftE_bindE Collect_False ccorres_cond_iffs
-                           dc_def
                       del: Collect_const)
           apply ((rule ccorres_split_nothrow_novcg_dc[rotated], assumption)
                   | rule ccorres_rhs_assoc2)+
             apply (simp add: conj_comms pred_conj_def)
-            apply (simp add: o_def cong: conj_cong option.case_cong)
+            apply (simp cong: conj_cong option.case_cong)
             apply (wp checked_insert_tcb_invs' hoare_case_option_wp
                       checkCap_inv [where P="tcb_at' p0" for p0]
                       checkCap_inv [where P="cte_at' p0" for p0]
@@ -926,8 +923,7 @@ lemma invokeTCB_ThreadControl_ccorres:
             apply (rule checkCapAt_ccorres2)
                apply ceqv
               apply csymbr
-              apply (simp add: Collect_True assertDerived_def bind_assoc
-                               ccorres_cond_iffs dc_def[symmetric]
+              apply (simp add: Collect_True assertDerived_def bind_assoc ccorres_cond_iffs
                           del: Collect_const)
               apply (rule ccorres_symb_exec_l)
                  apply (ctac add: cteInsert_ccorres)
@@ -935,14 +931,14 @@ lemma invokeTCB_ThreadControl_ccorres:
              apply csymbr
              apply (simp add: Collect_False ccorres_cond_iffs
                          del: Collect_const)
-             apply (rule ccorres_return_Skip[unfolded dc_def])
+             apply (rule ccorres_return_Skip)
             apply (clarsimp simp: guard_is_UNIV_def Collect_const_mem
                                   Kernel_C.tcbCTable_def tcbCTableSlot_def
                                   cte_level_bits_def size_of_def option_to_0_def)
            apply csymbr
            apply (simp add: Collect_False del: Collect_const)
            apply (rule ccorres_cond_false)
-           apply (rule ccorres_return_Skip[unfolded dc_def])
+           apply (rule ccorres_return_Skip)
           apply (clarsimp simp: guard_is_UNIV_def ccap_relation_def cap_thread_cap_lift cap_to_H_def)
          apply simp
          apply (rule ccorres_split_throws, rule ccorres_return_C_errorE, simp+)
@@ -991,7 +987,7 @@ lemma setupReplyMaster_ccorres:
   apply (cinit lift: thread_')
    apply (rule ccorres_move_array_assertion_tcb_ctes ccorres_Guard_Seq)+
    apply ctac
-     apply (simp del: Collect_const add: dc_def[symmetric])
+     apply (simp del: Collect_const)
      apply (rule ccorres_pre_getCTE)
      apply (rule ccorres_move_c_guard_cte)
      apply (rule_tac F="\<lambda>rv'. (rv' = scast cap_null_cap) = (cteCap oldCTE = NullCap)"
@@ -1621,10 +1617,10 @@ lemma invokeTCB_WriteRegisters_ccorres[where S=UNIV]:
                  apply (rule ccorres_split_nothrow_novcg)
                      apply (rule ccorres_when[where R=\<top>])
                       apply (simp add: from_bool_0 Collect_const_mem)
-                     apply (rule_tac xf'="\<lambda>_. 0" in ccorres_call)
-                      apply (rule restart_ccorres)
+                     apply (rule_tac xf'=Corres_C.xfdc in ccorres_call)
+                        apply (rule restart_ccorres)
+                       apply simp
                       apply simp
-                      apply (simp add: xfdc_def)
                      apply simp
                     apply (rule ceqv_refl)
                    apply (rule ccorres_split_nothrow_novcg_dc)
@@ -1808,6 +1804,7 @@ shows
                 apply (rule ccorres_rhs_assoc)+
                 apply csymbr
                 apply (ctac add: lookupIPCBuffer_ccorres)
+                  apply (rename_tac state destIPCBuffer ipcBuffer)
                   apply (ctac add: setRegister_ccorres)
                     apply (rule ccorres_stateAssert)
                     apply (rule ccorres_rhs_assoc2)
@@ -1868,15 +1865,15 @@ shows
                        apply (rule bind_apply_cong[OF _ refl])
                        apply (rule_tac n1="min (unat n_frameRegisters - unat n_msgRegisters) (unat n)"
                                    in fun_cong [OF mapM_x_split_append])
-                      apply (rule_tac P="rva \<noteq> Some 0" in ccorres_gen_asm)
-                      apply (subgoal_tac "(ipcBuffer = NULL) = (rva = None)")
+                      apply (rule_tac P="destIPCBuffer \<noteq> Some 0" in ccorres_gen_asm)
+                      apply (subgoal_tac "(ipcBuffer = NULL) = (destIPCBuffer = None)")
                        prefer 2
                        apply (clarsimp simp: option_to_ptr_def option_to_0_def
                                       split: option.split_asm)
                       apply (simp add: bind_assoc del: Collect_const)
                       apply (rule_tac xf'=i_' and r'="\<lambda>_ rv. unat rv = min (unat n_frameRegisters)
                                                                       (min (unat n)
-                                                                           (case rva of None \<Rightarrow> unat n_msgRegisters
+                                                                           (case destIPCBuffer of None \<Rightarrow> unat n_msgRegisters
                                                                               | _ \<Rightarrow> unat n_frameRegisters))"
                                  in ccorres_split_nothrow_novcg)
                           apply (rule ccorres_Cond_rhs)
@@ -1884,7 +1881,7 @@ shows
                                   rule_tac F="\<lambda>m s. obj_at' (\<lambda>tcb. map ((atcbContextGet o tcbArch) tcb) (genericTake n
                                                       (ARM_HYP_H.frameRegisters @ ARM_HYP_H.gpRegisters))
                                                                = reply) target s
-                                                 \<and> valid_ipc_buffer_ptr' (the rva) s
+                                                 \<and> valid_ipc_buffer_ptr' (the destIPCBuffer) s
                                                  \<and> valid_pspace' s"
                                        and i="unat n_msgRegisters"
                                     in ccorres_mapM_x_while')
@@ -1993,11 +1990,10 @@ shows
                             apply (rename_tac i_c, rule_tac P="i_c = 0" in ccorres_gen_asm2)
                             apply (simp add: drop_zip del: Collect_const)
                             apply (rule ccorres_Cond_rhs)
-                             apply (simp del: Collect_const)
                              apply (rule_tac F="\<lambda>m s. obj_at' (\<lambda>tcb. map ((atcbContextGet o tcbArch) tcb) (genericTake n
                                                        (ARM_HYP_H.frameRegisters @ ARM_HYP_H.gpRegisters))
                                                                 = reply) target s
-                                                  \<and> valid_ipc_buffer_ptr' (the rva) s \<and> valid_pspace' s"
+                                                  \<and> valid_ipc_buffer_ptr' (the destIPCBuffer) s \<and> valid_pspace' s"
                                         and i="0" in ccorres_mapM_x_while')
                                  apply (clarsimp simp: less_diff_conv drop_zip)
                                  apply (rule ccorres_guard_imp2)
@@ -2068,11 +2064,11 @@ shows
                              apply (simp add: min_less_iff_disj less_imp_diff_less)
                             apply (simp add: drop_zip n_gpRegisters_def)
                             apply (elim disjE impCE)
-                             apply (clarsimp simp: mapM_x_Nil)
+                             apply (clarsimp simp: mapM_x_Nil cong: ccorres_all_cong)
                              apply (rule ccorres_return_Skip')
-                            apply (simp add: linorder_not_less word_le_nat_alt
-                                             drop_zip mapM_x_Nil n_frameRegisters_def
-                                             min.absorb1 n_msgRegisters_def)
+                            apply (simp add: linorder_not_less word_le_nat_alt drop_zip
+                                             mapM_x_Nil n_frameRegisters_def n_msgRegisters_def
+                                       cong: ccorres_all_cong)
                             apply (rule ccorres_guard_imp2, rule ccorres_return_Skip')
                             apply simp
                            apply ceqv
@@ -2363,7 +2359,7 @@ lemma decodeWriteRegisters_ccorres:
          apply (simp add: performInvocation_def)
          apply (ctac(no_vcg) add: invokeTCB_WriteRegisters_ccorres
                                     [where args=args and someNum="unat (args ! 1)"])
-           apply (simp add: dc_def[symmetric] o_def)
+           apply simp
            apply (rule ccorres_alternative2, rule ccorres_return_CE, simp+)
           apply (rule ccorres_return_C_errorE, simp+)[1]
          apply wp[1]
@@ -2384,7 +2380,7 @@ lemma decodeWriteRegisters_ccorres:
                         numeral_eqs
                   simp del: unsigned_numeral)
   apply (frule arg_cong[where f="\<lambda>x. unat (of_nat x :: word32)"],
-         simp(no_asm_use) only: word_unat.Rep_inverse o_def,
+         simp(no_asm_use) only: word_unat.Rep_inverse,
          simp)
   apply (rule conjI)
    apply clarsimp
@@ -3244,7 +3240,6 @@ lemma decodeSetMCPriority_ccorres:
             >>= invocationCatch thread isBlocking isCall InvokeTCB)
      (Call decodeSetMCPriority_'proc)"
   supply Collect_const[simp del]
-  supply dc_simp[simp del]
   apply (cinit' lift: cap_' length___unsigned_long_' current_extra_caps_' buffer_' simp: decodeSetMCPriority_def)
    apply (simp cong: StateSpace.state.fold_congs globals.fold_congs)
    apply (rule ccorres_rhs_assoc2)
@@ -3312,8 +3307,7 @@ lemma decodeSetMCPriority_ccorres:
              apply csymbr
              apply csymbr
              apply (ctac (no_vcg) add: invokeTCB_ThreadControl_ccorres)
-               (* HACK: delete rules from the simpset to avoid the RVRs getting out of sync *)
-               apply (clarsimp simp del: intr_and_se_rel_simps comp_apply dc_simp)
+               apply clarsimp
                apply (rule ccorres_alternative2)
                apply (rule ccorres_return_CE; simp)
               apply (rule ccorres_return_C_errorE; simp)
@@ -3378,7 +3372,7 @@ lemma decodeSetPriority_ccorres:
      (decodeSetPriority args cp extraCaps
             >>= invocationCatch thread isBlocking isCall InvokeTCB)
      (Call decodeSetPriority_'proc)"
-  supply Collect_const[simp del] dc_simp[simp del]
+  supply Collect_const[simp del]
   apply (cinit' lift: cap_' length___unsigned_long_' current_extra_caps_' buffer_' simp: decodeSetPriority_def)
      apply (simp cong: StateSpace.state.fold_congs globals.fold_congs)
    apply (rule ccorres_rhs_assoc2)
@@ -3446,8 +3440,7 @@ lemma decodeSetPriority_ccorres:
              apply csymbr
              apply csymbr
              apply (ctac (no_vcg) add: invokeTCB_ThreadControl_ccorres)
-               (* HACK: delete rules from the simpset to avoid the RVRs getting out of sync *)
-               apply (clarsimp simp del: intr_and_se_rel_simps comp_apply dc_simp)
+               apply clarsimp
                apply (rule ccorres_alternative2)
                apply (rule ccorres_return_CE; simp)
               apply (rule ccorres_return_C_errorE; simp)
@@ -3518,7 +3511,7 @@ lemma decodeSetSchedParams_ccorres:
      (decodeSetSchedParams args cp extraCaps
             >>= invocationCatch thread isBlocking isCall InvokeTCB)
      (Call decodeSetSchedParams_'proc)"
-  supply Collect_const[simp del] dc_simp[simp del]
+  supply Collect_const[simp del]
   apply (cinit' lift: cap_' length___unsigned_long_' current_extra_caps_' buffer_' simp: decodeSetSchedParams_def)
    apply (simp cong: StateSpace.state.fold_congs globals.fold_congs)
    apply (rule ccorres_rhs_assoc2)
@@ -3585,8 +3578,7 @@ lemma decodeSetSchedParams_ccorres:
                   apply csymbr
                   apply csymbr
                   apply (ctac (no_vcg) add: invokeTCB_ThreadControl_ccorres)
-                    (* HACK: delete rules from the simpset to avoid the RVRs getting out of sync *)
-                    apply (clarsimp simp del: intr_and_se_rel_simps comp_apply dc_simp)
+                    apply clarsimp
                     apply (rule ccorres_alternative2)
                     apply (rule ccorres_return_CE; simp)
                    apply (rule ccorres_return_C_errorE; simp)
@@ -3841,7 +3833,7 @@ lemma bindNotification_ccorres:
        apply ceqv
       apply (rule ccorres_move_c_guard_tcb)
       apply (simp add: setBoundNotification_def)
-      apply (rule_tac P'=\<top> and P=\<top> in threadSet_ccorres_lemma3[unfolded dc_def])
+      apply (rule_tac P'=\<top> and P=\<top> in threadSet_ccorres_lemma3)
        apply vcg
       apply simp
       apply (erule (1) rf_sr_tcb_update_no_queue2,
@@ -4303,7 +4295,7 @@ lemma decodeSetSpace_ccorres:
                       apply (simp add: Collect_False del: Collect_const)
                       apply csymbr
                       apply csymbr
-                      apply (simp add: cnode_cap_case_if cap_get_tag_isCap dc_def[symmetric]
+                      apply (simp add: cnode_cap_case_if cap_get_tag_isCap
                                   del: Collect_const)
                       apply (rule ccorres_Cond_rhs_Seq)
                        apply (simp add: injection_handler_throwError
@@ -4447,7 +4439,7 @@ lemma invokeTCB_SetTLSBase_ccorres:
   apply (cinit lift: thread_' tls_base_')
    apply (simp add: liftE_def bind_assoc
                del: Collect_const)
-   apply (ctac add: setRegister_ccorres[simplified dc_def])
+   apply (ctac add: setRegister_ccorres)
      apply (rule ccorres_pre_getCurThread)
      apply (rename_tac cur_thr)
      apply (rule ccorres_split_nothrow_novcg_dc)

--- a/proof/crefine/ARM_HYP/VSpace_C.thy
+++ b/proof/crefine/ARM_HYP/VSpace_C.thy
@@ -1095,7 +1095,7 @@ lemma flushSpace_ccorres:
      apply (rule_tac Q=\<top> and Q'=\<top> in ccorres_if_cond_throws2)
         apply (clarsimp simp: Collect_const_mem pde_stored_asid_def)
         apply (simp add: if_split_eq1 to_bool_def)
-       apply (rule ccorres_return_void_C [unfolded dc_def])
+       apply (rule ccorres_return_void_C)
       apply csymbr
       apply (clarsimp simp: pde_stored_asid_def)
       apply (case_tac "to_bool (stored_asid_valid_CL (pde_pde_invalid_lift stored_hw_asid___struct_pde_C))")
@@ -1107,7 +1107,7 @@ lemma flushSpace_ccorres:
        apply clarsimp
       apply clarsimp
       apply (rule ccorres_call,
-             rule invalidateTranslationASID_ccorres [simplified dc_def xfdc_def],
+             rule invalidateTranslationASID_ccorres,
              simp+)[1]
      apply vcg
     apply wp+
@@ -1405,7 +1405,6 @@ lemma armv_contextSwitch_ccorres:
   apply (cinit lift: cap_pd_' asid_')
    apply simp
    apply (ctac(no_vcg) add: getHWASID_ccorres)
-    apply (fold dc_def)
     apply (ctac (no_vcg)add: armv_contextSwitch_HWASID_ccorres)
    apply wp
   apply clarsimp
@@ -1651,7 +1650,7 @@ lemma vcpu_write_reg_ccorres:
              \<inter> \<lbrace> \<acute>value = v \<rbrace>) hs
      (vcpuWriteReg vcpuptr reg v)
      (Call vcpu_write_reg_'proc)"
-  supply Collect_const[simp del] dc_simp[simp del]
+  supply Collect_const[simp del]
   apply (cinit lift: vcpu_' reg_' value_')
    apply (rule ccorres_assert)
    apply clarsimp
@@ -1666,12 +1665,13 @@ lemma vcpu_write_reg_ccorres:
 lemma vcpu_save_reg_ccorres:
   "ccorres dc xfdc (vcpu_at' vcpuptr) (UNIV \<inter> \<lbrace>unat \<acute>reg = fromEnum r\<rbrace> \<inter> \<lbrace> \<acute>vcpu = vcpu_Ptr vcpuptr \<rbrace>) hs
      (vcpuSaveReg vcpuptr r) (Call vcpu_save_reg_'proc)"
-  supply dc_simp[simp del] Collect_const[simp del]
+  supply Collect_const[simp del]
   apply (cinit lift: reg_' vcpu_')
    apply (rule ccorres_assert2)
    apply (rule ccorres_cond_false_seq, simp)
    apply (ctac add: vcpu_hw_read_reg_ccorres)
-     apply (rule ccorres_move_const_guard ccorres_move_c_guard_vcpu, simp del: fun_upd_apply)+
+     apply (rule ccorres_move_const_guard ccorres_move_c_guard_vcpu)+
+     apply (simp del: fun_upd_apply)
      apply (ctac add: vcpuUpdate_vcpuRegs_ccorres)
     apply wpsimp
    apply (vcg exspec=vcpu_hw_read_reg_modifies)
@@ -1683,11 +1683,11 @@ lemma vcpu_restore_reg_ccorres:
   "ccorres dc xfdc
      (vcpu_at' vcpuptr) (UNIV \<inter> \<lbrace>unat \<acute>reg = fromEnum r\<rbrace> \<inter> \<lbrace> \<acute>vcpu = vcpu_Ptr vcpuptr \<rbrace>) hs
      (vcpuRestoreReg vcpuptr r) (Call vcpu_restore_reg_'proc)"
-  supply dc_simp[simp del] Collect_const[simp del]
+  supply Collect_const[simp del]
   apply (cinit lift: reg_' vcpu_')
    apply (rule ccorres_assert2)
    apply (rule ccorres_cond_false_seq, simp)
-   apply (rule ccorres_move_const_guard ccorres_move_c_guard_vcpu, simp)+
+   apply (rule ccorres_move_const_guard ccorres_move_c_guard_vcpu)+
    apply (rule ccorres_pre_getObject_vcpu, rename_tac vcpu)
    apply (ctac add: vcpu_hw_write_reg_ccorres)
   apply (frule maxBound_is_bound')
@@ -1733,7 +1733,6 @@ lemma vcpu_restore_reg_range_ccorres:
   apply (rule ccorres_grab_asm)
   apply (cinit lift: start_' end_' vcpu_' simp: whileAnno_def)
    apply csymbr
-   apply (clarsimp, fold dc_def)
    apply (rule ccorres_dc_from_rrel)
    (* supplying these as dest/intro/simp to proof tactics has no desired effect *)
    using maxBound_is_bound[of start, simplified fromEnum_maxBound_vcpureg_def]
@@ -1770,7 +1769,6 @@ lemma vcpu_save_reg_range_ccorres:
   apply (rule ccorres_grab_asm)
   apply (cinit lift: start_' end_' vcpu_' simp: whileAnno_def)
    apply csymbr
-   apply (clarsimp, fold dc_def)
    apply (rule ccorres_dc_from_rrel)
    (* supplying these as dest/intro/simp to proof tactics has no desired effect *)
    using maxBound_is_bound[of start, simplified fromEnum_maxBound_vcpureg_def]
@@ -1912,7 +1910,6 @@ lemma restore_virt_timer_ccorres:
                    apply (rule ccorres_call)
                       apply (rule_tac P="obj_at' (\<lambda>vcpu'. vcpuVPPIMasked vcpu' vppievent_irq.VPPIEventIRQ_VTimer
                                                            = vcpuVPPIMasked vcpu vppievent_irq.VPPIEventIRQ_VTimer) vcpuptr" in ccorres_cross_over_guard)
-                      apply (fold dc_def)
                       apply (rule maskInterrupt_ccorres, simp)
                     apply simp
                    apply simp
@@ -1994,7 +1991,6 @@ lemma save_virt_timer_ccorres:
           apply (ctac (no_vcg) add: vcpu_write_reg_ccorres)
            apply (ctac (no_vcg) add: read_cntpct_ccorres)
             apply clarsimp
-            apply (fold dc_def)
             apply (rule vcpuUpdate_vTimer_pcount_ccorres)
            apply wpsimp+
   apply (simp add: vcpureg_eq_use_types[where reg=VCPURegCNTV_CVALhigh, simplified, symmetric]
@@ -2049,10 +2045,9 @@ lemma vcpu_disable_ccorres:
        apply (ctac (no_vcg) add: isb_ccorres)
         apply (ctac (no_vcg) add: setSCTLR_ccorres)
          apply (ctac (no_vcg) add: setHCR_ccorres)
-          apply (ctac (no_vcg) add: isb_ccorres[unfolded dc_def])
+          apply (ctac (no_vcg) add: isb_ccorres)
            apply (wpc; ccorres_rewrite)
-            apply (rule ccorres_return_Skip[simplified dc_def])
-           apply (fold dc_def)
+            apply (rule ccorres_return_Skip)
            apply (rename_tac vcpu_ptr)
            apply (rule_tac P="the v \<noteq> 0" in ccorres_gen_asm)
            apply ccorres_rewrite
@@ -2080,9 +2075,9 @@ lemma vcpu_enable_ccorres:
     apply (ctac (no_vcg) add: setHCR_ccorres)
      apply (ctac  (no_vcg) add: isb_ccorres)
       apply (rule_tac P="ko_at' vcpu v" in ccorres_cross_over_guard)
-      apply (ctac pre: ccorres_move_c_guard_vcpu add: set_gic_vcpu_ctrl_hcr_ccorres[unfolded dc_def])
+      apply (ctac pre: ccorres_move_c_guard_vcpu add: set_gic_vcpu_ctrl_hcr_ccorres)
         apply wpsimp+
-        apply (fold dc_def, ctac (no_vcg) add: restore_virt_timer_ccorres)
+        apply (ctac (no_vcg) add: restore_virt_timer_ccorres)
        apply simp
        apply wpsimp
       apply (vcg exspec=set_gic_vcpu_ctrl_hcr_modifies)
@@ -2126,7 +2121,7 @@ lemma ccorres_abstract_known:
   done
 
 lemma vcpu_restore_ccorres:
-  notes upt_Suc[simp del] dc_simp[simp del] Collect_const[simp del]
+  notes upt_Suc[simp del] Collect_const[simp del]
   shows
   "ccorres dc xfdc
        (pspace_aligned' and pspace_distinct' and valid_objs' and no_0_obj' and valid_arch_state'
@@ -2164,7 +2159,7 @@ lemma vcpu_restore_ccorres:
                  apply (rule_tac P="n \<le> 63" in ccorres_gen_asm)
                  apply (rule ccorres_move_c_guard_vcpu)
                  apply (ctac (no_vcg) add: set_gic_vcpu_ctrl_lr_ccorres)
-                apply (clarsimp simp: virq_to_H_def ko_at_vcpu_at'D dc_def upt_Suc)
+                apply (clarsimp simp: virq_to_H_def ko_at_vcpu_at'D upt_Suc)
                 apply (rule conjI[rotated])
   subgoal (* FIXME extract into separate lemma *)
     by (fastforce simp: word_less_nat_alt unat_of_nat_eq elim: order_less_le_trans)
@@ -2182,7 +2177,7 @@ lemma vcpu_restore_ccorres:
            apply wpsimp
           apply (vcg exspec=vcpu_restore_reg_range_modifies)
          apply (wpsimp wp: crunch_wps)
-        apply (wpsimp simp: guard_is_UNIV_def dc_def upt_Suc ko_at_vcpu_at'D  wp: mapM_x_wp_inv
+        apply (wpsimp simp: guard_is_UNIV_def upt_Suc ko_at_vcpu_at'D  wp: mapM_x_wp_inv
                | rule UNIV_I
                | wp hoare_vcg_imp_lift hoare_vcg_all_lift hoare_vcg_disj_lift)+
         apply (fastforce simp: fromEnum_def enum_vcpureg seL4_VCPUReg_SPSRfiq_def)
@@ -2259,7 +2254,7 @@ lemma vgicUpdateLR_ccorres:
   done
 
 lemma vcpu_save_ccorres:
-  notes dc_simp[simp del] Collect_const[simp del]
+  notes Collect_const[simp del]
   shows
   "ccorres dc xfdc
       (pspace_aligned' and pspace_distinct' and valid_objs' and no_0_obj' and valid_arch_state'
@@ -2325,7 +2320,7 @@ lemma vcpu_save_ccorres:
                  apply ceqv
                 apply (ctac (no_vcg) add: armv_vcpu_save_ccorres)
                apply (wpsimp simp: guard_is_UNIV_def wp: mapM_x_wp_inv)+
-  apply (simp add: invs_no_cicd'_def valid_arch_state'_def max_armKSGICVCPUNumListRegs_def dc_def)
+  apply (simp add: invs_no_cicd'_def valid_arch_state'_def max_armKSGICVCPUNumListRegs_def)
   done
 
 lemma vcpu_switch_ccorres_None:
@@ -2342,7 +2337,7 @@ lemma vcpu_switch_ccorres_None:
    apply wpc
     (* v = None & CurVCPU = None *)
     apply (rule ccorres_cond_false)
-    apply (rule ccorres_return_Skip[unfolded dc_def])
+    apply (rule ccorres_return_Skip)
    (* v = None & CurVCPU \<noteq> None *)
    apply ccorres_rewrite
    apply wpc
@@ -2352,7 +2347,7 @@ lemma vcpu_switch_ccorres_None:
    apply (rule_tac R="\<lambda>s. armHSCurVCPU (ksArchState s) = Some (ccurv, cactive)" in ccorres_cond)
      apply (clarsimp simp: cur_vcpu_relation_def dest!: rf_sr_ksArchState_armHSCurVCPU)
     apply (ctac add: vcpu_disable_ccorres)
-      apply (rule_tac v=x2 in armHSCurVCPU_update_active_ccorres[simplified dc_def])
+      apply (rule_tac v=x2 in armHSCurVCPU_update_active_ccorres)
        apply simp
       apply simp
      apply wp
@@ -2360,7 +2355,7 @@ lemma vcpu_switch_ccorres_None:
      apply assumption
     apply clarsimp
     apply (vcg exspec=vcpu_disable_modifies)
-   apply (rule ccorres_return_Skip[unfolded dc_def])
+   apply (rule ccorres_return_Skip)
   apply (clarsimp, rule conjI)
    apply (fastforce dest: invs_cicd_arch_state' simp: valid_arch_state'_def vcpu_at_is_vcpu' ko_wp_at'_def split: option.splits)
   by (auto dest!: rf_sr_ksArchState_armHSCurVCPU simp: cur_vcpu_relation_def)+
@@ -2384,7 +2379,7 @@ lemma vcpu_switch_ccorres_Some:
     apply (rule ccorres_cond_false_seq)
     apply ccorres_rewrite
     apply (ctac add: vcpu_restore_ccorres)
-      apply (rule_tac curv="Some (v, True)" in armHSCurVCPU_update_ccorres[unfolded dc_def])
+      apply (rule_tac curv="Some (v, True)" in armHSCurVCPU_update_ccorres)
      apply wp
     apply clarsimp
     apply (vcg exspec=vcpu_restore_modifies)
@@ -2401,7 +2396,7 @@ lemma vcpu_switch_ccorres_Some:
     apply (rule ccorres_cond_true_seq)
     apply (ctac add: vcpu_save_ccorres)
       apply (ctac add: vcpu_restore_ccorres)
-        apply (rule_tac curv="Some (v, True)" in armHSCurVCPU_update_ccorres[unfolded dc_def])
+        apply (rule_tac curv="Some (v, True)" in armHSCurVCPU_update_ccorres)
        apply wp
       apply clarsimp
       apply (vcg exspec=vcpu_restore_modifies)
@@ -2419,13 +2414,13 @@ lemma vcpu_switch_ccorres_Some:
     apply (rule ccorres_rhs_assoc)
     apply (ctac (no_vcg) add: isb_ccorres)
      apply (ctac (no_vcg) add: vcpu_enable_ccorres)
-      apply (rule_tac v="(v, cactive)" in armHSCurVCPU_update_active_ccorres[simplified dc_def])
+      apply (rule_tac v="(v, cactive)" in armHSCurVCPU_update_active_ccorres)
        apply simp
       apply simp
      apply wp
     apply (wpsimp wp: hoare_vcg_conj_lift vcpuSave_invs_no_cicd' vcpuSave_typ_at')
    (* ccactive =true *)
-   apply (rule ccorres_return_Skip[unfolded dc_def])
+   apply (rule ccorres_return_Skip)
   (* last goal *)
   apply simp
   apply (rule conjI
@@ -2466,7 +2461,7 @@ lemma setVMRoot_ccorres:
       apply (simp add: cap_case_isPageDirectoryCap cong: if_cong)
       apply (rule ccorres_cond_true_seq)
       apply (rule ccorres_rhs_assoc)
-      apply (simp add: throwError_def catch_def dc_def[symmetric])
+      apply (simp add: throwError_def catch_def)
       apply (rule ccorres_rhs_assoc)+
       apply (rule ccorres_h_t_valid_armUSGlobalPD)
       apply csymbr
@@ -2494,7 +2489,7 @@ lemma setVMRoot_ccorres:
       apply (rule ccorres_add_return2)
       apply (ctac (no_vcg) add: setCurrentPD_ccorres)
        apply (rule ccorres_split_throws)
-        apply (rule ccorres_return_void_C [unfolded dc_def])
+        apply (rule ccorres_return_void_C)
        apply vcg
       apply wp
      apply (simp add: cap_case_isPageDirectoryCap)
@@ -2525,11 +2520,11 @@ lemma setVMRoot_ccorres:
          apply (rule ccorres_add_return2)
          apply (ctac(no_vcg) add: setCurrentPD_ccorres)
           apply (rule ccorres_split_throws)
-           apply (rule ccorres_return_void_C[unfolded dc_def])
+           apply (rule ccorres_return_void_C)
           apply vcg
          apply wp
         apply (simp add: whenE_def returnOk_def)
-        apply (ctac (no_vcg) add: armv_contextSwitch_ccorres[unfolded dc_def])
+        apply (ctac (no_vcg) add: armv_contextSwitch_ccorres)
             apply (rename_tac tcb)
          apply simp
         apply clarsimp
@@ -2542,7 +2537,7 @@ lemma setVMRoot_ccorres:
        apply (rule ccorres_add_return2)
        apply (ctac(no_vcg) add: setCurrentPD_ccorres)
         apply (rule ccorres_split_throws)
-         apply (rule ccorres_return_void_C[unfolded dc_def])
+         apply (rule ccorres_return_void_C)
         apply vcg
        apply wp
       apply simp
@@ -2701,7 +2696,7 @@ lemma doFlush_ccorres:
    apply (rule_tac xf'=invLabel___int_' in ccorres_abstract, ceqv, rename_tac invlabel)
    apply (rule_tac P="flushtype_relation t invlabel" in ccorres_gen_asm2)
    apply (simp only: dmo_flushtype_case Let_def)
-   apply (wpc ; simp add: dc_def[symmetric])
+   apply (wpc ; simp)
       apply (rule ccorres_cond_true)
       apply (ctac (no_vcg) add: cleanCacheRange_RAM_ccorres)
      apply (rule ccorres_cond_false)
@@ -2719,7 +2714,6 @@ lemma doFlush_ccorres:
                     empty_fail_invalidateCacheRange_I empty_fail_branchFlushRange empty_fail_isb
                     doMachineOp_bind empty_fail_cond)
    apply (rule ccorres_rhs_assoc)+
-   apply (fold dc_def)
    apply (ctac (no_vcg) add: cleanCacheRange_PoU_ccorres)
     apply (ctac (no_vcg) add: dsb_ccorres)
      apply (ctac (no_vcg) add: invalidateCacheRange_I_ccorres)
@@ -2777,7 +2771,7 @@ lemma performPageFlush_ccorres:
       apply (rule ccorres_return_Skip)
      apply (rule ccorres_from_vcg_throws[where P=\<top> and P'=UNIV])
      apply (rule allI, rule conseqPre, vcg)
-     apply (clarsimp simp: return_def dc_def)
+     apply (clarsimp simp: return_def)
     apply wpsimp
    apply (simp add: guard_is_UNIV_def)
   apply (clarsimp simp: order_less_imp_le)
@@ -2806,12 +2800,12 @@ lemma setRegister_ccorres:
        (asUser thread (setRegister reg val))
        (Call setRegister_'proc)"
   apply (cinit' lift: thread_' reg_' w_')
-   apply (simp add: asUser_def dc_def[symmetric] split_def split del: if_split)
+   apply (simp add: asUser_def split_def)
    apply (rule ccorres_pre_threadGet)
    apply (rule ccorres_Guard)
    apply (simp add: setRegister_def simpler_modify_def exec_select_f_singleton)
    apply (rule_tac P="\<lambda>tcb. (atcbContextGet o tcbArch) tcb = rv"
-                in threadSet_ccorres_lemma2 [unfolded dc_def])
+                in threadSet_ccorres_lemma2)
     apply vcg
    apply (clarsimp simp: setRegister_def HaskellLib_H.runState_def
                          simpler_modify_def typ_heap_simps)
@@ -2842,8 +2836,6 @@ lemma msgRegisters_ccorres:
 (* usually when we call setMR directly, we mean to only set a registers, which will
    fit in actual registers *)
 lemma setMR_as_setRegister_ccorres:
-  notes dc_simp[simp del]
-  shows
   "ccorres (\<lambda>rv rv'. rv' = of_nat offset + 1) ret__unsigned_'
       (tcb_at' thread and K (TCB_H.msgRegisters ! offset = reg \<and> offset < length msgRegisters))
       (UNIV \<inter> \<lbrace>\<acute>reg = val\<rbrace>
@@ -2860,7 +2852,7 @@ lemma setMR_as_setRegister_ccorres:
    apply (ctac add: setRegister_ccorres)
      apply (rule ccorres_from_vcg_throws[where P'=UNIV and P=\<top>])
      apply (rule allI, rule conseqPre, vcg)
-     apply (clarsimp simp: dc_def return_def)
+     apply (clarsimp simp: return_def)
     apply (rule hoare_post_taut[of \<top>])
    apply (vcg exspec=setRegister_modifies)
   apply (clarsimp simp: n_msgRegisters_def length_of_msgRegisters not_le conj_commute)
@@ -3004,7 +2996,6 @@ lemma flushPage_ccorres:
        apply (rule ccorres_cond2[where R=\<top>])
          apply (simp add: from_bool_0 Collect_const_mem)
         apply (rule ccorres_pre_getCurThread)
-        apply (fold dc_def)
         apply (ctac add: setVMRoot_ccorres)
        apply (rule ccorres_return_Skip)
       apply (wp | simp add: cur_tcb'_def[symmetric])+
@@ -3267,8 +3258,7 @@ lemma unmapPage_ccorres:
       (unmapPage sz asid vptr pptr) (Call unmapPage_'proc)"
   apply (rule ccorres_gen_asm)
   apply (cinit lift: page_size_' asid_' vptr_' pptr_')
-   apply (simp add: ignoreFailure_liftM ptr_add_assertion_positive
-                    Collect_True
+   apply (simp add: ignoreFailure_liftM ptr_add_assertion_positive Collect_True
                del: Collect_const)
    apply ccorres_remove_UNIV_guard
    apply csymbr
@@ -3280,12 +3270,12 @@ lemma unmapPage_ccorres:
       apply (rule ccorres_splitE_novcg[where r'=dc and xf'=xfdc])
           \<comment> \<open>ARMSmallPage\<close>
           apply (rule ccorres_Cond_rhs)
-           apply (simp add: gen_framesize_to_H_def dc_def[symmetric])
+           apply (simp add: gen_framesize_to_H_def)
            apply (rule ccorres_rhs_assoc)+
            apply csymbr
            apply (ctac add: lookupPTSlot_ccorres)
               apply (rename_tac pt_slot pt_slot')
-              apply (simp add: dc_def[symmetric])
+              apply simp
               apply (rule ccorres_rhs_assoc2, rule ccorres_rhs_assoc2,
                   rule ccorres_rhs_assoc2, rule ccorres_rhs_assoc2,
                   rule ccorres_rhs_assoc2)
@@ -3300,7 +3290,7 @@ lemma unmapPage_ccorres:
                          split: if_split_asm pte.split_asm)
                  apply (rule ceqv_refl)
                 apply (simp add: unfold_checkMapping_return liftE_liftM
-                              Collect_const[symmetric] dc_def[symmetric]
+                              Collect_const[symmetric]
                          del: Collect_const)
                 apply (rule ccorres_handlers_weaken2)
                 apply csymbr
@@ -3308,8 +3298,7 @@ lemma unmapPage_ccorres:
                    apply (rule storePTE_Basic_ccorres)
                    apply (simp add: cpte_relation_def Let_def)
                   apply csymbr
-                  apply simp
-                  apply (ctac add: cleanByVA_PoU_ccorres[unfolded dc_def])
+                  apply (ctac add: cleanByVA_PoU_ccorres)
                  apply wp
                 apply (simp add: guard_is_UNIV_def)
                apply wp
@@ -3323,18 +3312,17 @@ lemma unmapPage_ccorres:
            apply (vcg exspec=lookupPTSlot_modifies)
           \<comment> \<open>ARMLargePage\<close>
           apply (rule ccorres_Cond_rhs)
-           apply (simp add: gen_framesize_to_H_def dc_def[symmetric])
+           apply (simp add: gen_framesize_to_H_def)
            apply (rule ccorres_rhs_assoc)+
            apply csymbr
            apply csymbr
            apply (ctac add: lookupPTSlot_ccorres)
               apply (rename_tac ptSlot lookupPTSlot_ret)
-              apply (simp add: Collect_False dc_def[symmetric] del: Collect_const)
+              apply (simp add: Collect_False del: Collect_const)
               apply (rule ccorres_rhs_assoc2, rule ccorres_rhs_assoc2,
                   rule ccorres_rhs_assoc2, rule ccorres_rhs_assoc2,
                   rule ccorres_rhs_assoc2)
-              apply (rule ccorres_splitE_novcg, simp only: inl_rrel_inl_rrel,
-                     rule checkMappingPPtr_pte_ccorres)
+              apply (rule ccorres_splitE_novcg, simp, rule checkMappingPPtr_pte_ccorres)
                   apply (rule conseqPre, vcg)
                   apply (clarsimp simp: typ_heap_simps')
                   subgoal by (simp add: cpte_relation_def Let_def pte_lift_def
@@ -3342,7 +3330,7 @@ lemma unmapPage_ccorres:
                                     pte_pte_small_lift_def
                              split: if_split_asm pte.split_asm)
                  apply (rule ceqv_refl)
-                apply (simp add: liftE_liftM dc_def[symmetric]
+                apply (simp add: liftE_liftM
                              mapM_discarded whileAnno_def ARMLargePageBits_def ARMSmallPageBits_def
                              Collect_False unfold_checkMapping_return word_sle_def
                         del: Collect_const)
@@ -3376,7 +3364,7 @@ lemma unmapPage_ccorres:
                   apply csymbr
                   apply (rule ccorres_move_c_guard_pte ccorres_move_array_assertion_pte_16)+
                   apply (rule ccorres_add_return2,
-                    ctac(no_vcg) add: cleanCacheRange_PoU_ccorres[unfolded dc_def])
+                    ctac(no_vcg) add: cleanCacheRange_PoU_ccorres)
                    apply (rule ccorres_move_array_assertion_pte_16, rule ccorres_return_Skip')
                   apply wp
                  apply (rule_tac P="is_aligned ptSlot 7" in hoare_gen_asm)
@@ -3418,16 +3406,17 @@ lemma unmapPage_ccorres:
           \<comment> \<open>ARMSection\<close>
           apply (rule ccorres_Cond_rhs)
            apply (rule ccorres_rhs_assoc)+
-           apply (csymbr, csymbr)
-           apply (simp add: gen_framesize_to_H_def dc_def[symmetric]
-                            liftE_liftM
+           \<comment> \<open>FIXME: The second csymbr rewrites the return relation of the goal.
+                      If this was avoided then folding the dc_def could be removed\<close>
+           apply (csymbr, csymbr, fold dc_def)
+           apply (simp add: gen_framesize_to_H_def liftE_liftM
                        del: Collect_const)
            apply (simp split: if_split, rule conjI[rotated], rule impI,
                   rule ccorres_empty, rule impI)
            apply (rule ccorres_rhs_assoc2, rule ccorres_rhs_assoc2,
                   rule ccorres_rhs_assoc2, rule ccorres_rhs_assoc2,
                   rule ccorres_rhs_assoc2)
-           apply (rule ccorres_splitE_novcg, simp only: inl_rrel_inl_rrel,
+           apply (rule ccorres_splitE_novcg, simp,
                   rule checkMappingPPtr_pde_ccorres)
                apply (rule conseqPre, vcg)
                apply (clarsimp simp: typ_heap_simps')
@@ -3435,16 +3424,16 @@ lemma unmapPage_ccorres:
                                      Let_def pde_tag_defs isSectionPDE_def
                               split: pde.split_asm if_split_asm)
               apply (rule ceqv_refl)
-             apply (simp add: unfold_checkMapping_return Collect_False dc_def[symmetric]
-                      del: Collect_const)
-             apply (rule ccorres_handlers_weaken2, simp)
+             apply (simp add: unfold_checkMapping_return Collect_False
+                         del: Collect_const)
+             apply (rule ccorres_handlers_weaken2)
              apply csymbr
              apply (rule ccorres_split_nothrow_novcg_dc)
                 apply (rule storePDE_Basic_ccorres)
                 apply (simp add: cpde_relation_def Let_def
                               pde_lift_pde_invalid)
                apply csymbr
-               apply (ctac add: cleanByVA_PoU_ccorres[unfolded dc_def])
+               apply (ctac add: cleanByVA_PoU_ccorres)
               apply wp
              apply (clarsimp simp: guard_is_UNIV_def)
             apply simp
@@ -3453,14 +3442,16 @@ lemma unmapPage_ccorres:
           \<comment> \<open>ARMSuperSection\<close>
           apply (rule ccorres_Cond_rhs)
            apply (rule ccorres_rhs_assoc)+
+           \<comment> \<open>FIXME: The third csymbr rewrites the return relation of the goal.
+                      If this was avoided then folding the dc_def could be removed\<close>
            apply csymbr
            apply csymbr
            apply csymbr
+           apply (fold dc_def)
            apply (case_tac "pd = pde_Ptr (lookup_pd_slot pdPtr vptr)")
             prefer 2
             apply (simp, rule ccorres_empty)
-           apply (simp add: gen_framesize_to_H_def dc_def[symmetric]
-                         liftE_liftM mapM_discarded whileAnno_def
+           apply (simp add: gen_framesize_to_H_def liftE_liftM mapM_discarded whileAnno_def
                     del: Collect_const)
            apply (rule ccorres_rhs_assoc2, rule ccorres_rhs_assoc2,
                rule ccorres_rhs_assoc2, rule ccorres_rhs_assoc2,
@@ -3510,7 +3501,7 @@ lemma unmapPage_ccorres:
                apply csymbr
                apply (rule ccorres_move_c_guard_pde ccorres_move_array_assertion_pde_16)+
                apply (rule ccorres_add_return2)
-               apply (ctac(no_vcg) add: cleanCacheRange_PoU_ccorres[unfolded dc_def])
+               apply (ctac(no_vcg) add: cleanCacheRange_PoU_ccorres)
                 apply (rule ccorres_move_array_assertion_pde_16, rule ccorres_return_Skip')
                apply wp
               apply (rule_tac P="is_aligned pdPtr pdBits" in hoare_gen_asm)
@@ -3548,14 +3539,14 @@ lemma unmapPage_ccorres:
           apply (rule ccorres_empty[where P=\<top>])
          apply ceqv
         apply (simp add: liftE_liftM)
-        apply (ctac add: flushPage_ccorres[unfolded dc_def])
+        apply (ctac add: flushPage_ccorres)
        apply ((wp lookupPTSlot_inv mapM_storePTE_invs[unfolded swp_def]
                  mapM_storePDE_invs[unfolded swp_def]
               | wpc | simp)+)[1]
       apply (simp add: guard_is_UNIV_def)
      apply (simp add: throwError_def)
      apply (rule ccorres_split_throws)
-      apply (rule ccorres_return_void_C[unfolded dc_def])
+      apply (rule ccorres_return_void_C)
      apply vcg
     apply (simp add: lookup_pd_slot_def Let_def table_bits_defs)
     apply (wp hoare_vcg_const_imp_lift_R findPDForASID_valid_offset'[simplified table_bits_defs]
@@ -4135,7 +4126,7 @@ lemma performASIDPoolInvocation_ccorres:
         apply (wp getASID_wp)
         apply simp
        apply wp
-       apply (simp add: o_def inv_def)
+       apply (simp add: inv_def)
        apply (wp getASID_wp)
       apply simp
       apply (rule empty_fail_getObject)
@@ -4196,14 +4187,14 @@ lemma flushTable_ccorres:
        apply (rule_tac R=\<top> in ccorres_cond2)
          apply (clarsimp simp: from_bool_0 Collect_const_mem)
         apply (rule ccorres_pre_getCurThread)
-        apply (ctac (no_vcg) add: setVMRoot_ccorres [unfolded dc_def])
-       apply (rule ccorres_return_Skip[unfolded dc_def])
+        apply (ctac (no_vcg) add: setVMRoot_ccorres)
+       apply (rule ccorres_return_Skip)
       apply (wp static_imp_wp)
        apply clarsimp
        apply (rule_tac Q="\<lambda>_ s. invs' s \<and> cur_tcb' s" in hoare_post_imp)
         apply (simp add: invs'_invs_no_cicd cur_tcb'_def)
        apply (wp mapM_x_wp_inv getPTE_wp | wpc)+
-     apply (rule ccorres_return_Skip[unfolded dc_def])
+     apply (rule ccorres_return_Skip)
     apply wp
    apply clarsimp
    apply (strengthen invs_valid_pde_mappings')

--- a/proof/crefine/RISCV64/Arch_C.thy
+++ b/proof/crefine/RISCV64/Arch_C.thy
@@ -73,7 +73,7 @@ using [[goals_limit=20]]
         apply (ctac add: unmapPageTable_ccorres)
           apply (simp add: storePTE_def' swp_def)
           apply clarsimp
-          apply(simp only: dc_def[symmetric] bit_simps_corres[symmetric])
+          apply(simp only: bit_simps_corres[symmetric])
           apply (ctac add: clearMemory_setObject_PTE_ccorres[simplified objBits_InvalidPTE_pte_bits])
          apply wp
         apply (simp del: Collect_const)
@@ -963,7 +963,7 @@ lemma decodeRISCVPageTableInvocation_ccorres:
          apply (solves \<open>clarsimp simp: asidInvalid_def isCap_simps
                                        ccap_relation_PageTableCap_IsMapped\<close>)
         apply (simp add: throwError_bind invocationCatch_def)
-        apply (rule syscall_error_throwError_ccorres_n[simplified id_def dc_def])
+        apply (rule syscall_error_throwError_ccorres_n)
         apply (simp add: syscall_error_to_H_cases)
        apply csymbr
        apply csymbr
@@ -976,7 +976,7 @@ lemma decodeRISCVPageTableInvocation_ccorres:
         apply (fold not_None_def) (* avoid expanding capPTMappedAddress  *)
         apply clarsimp
         apply (simp add: throwError_bind invocationCatch_def)
-        apply (rule syscall_error_throwError_ccorres_n[simplified id_def dc_def])
+        apply (rule syscall_error_throwError_ccorres_n)
         apply (simp add: syscall_error_to_H_cases)
        apply (simp add: lookupError_injection invocationCatch_use_injection_handler
                         injection_bindE[OF refl refl] injection_handler_If bindE_assoc
@@ -988,7 +988,7 @@ lemma decodeRISCVPageTableInvocation_ccorres:
           apply (rule ccorres_if_cond_throws[rotated -1, where Q=\<top> and Q'=\<top>])
              apply vcg
             apply (solves\<open>clarsimp simp: asidInvalid_def isCap_simps ccap_relation_PageTableCap_BasePtr\<close>)
-           apply (rule syscall_error_throwError_ccorres_n[simplified id_def dc_def])
+           apply (rule syscall_error_throwError_ccorres_n)
            apply (simp add: syscall_error_to_H_cases)
           apply (clarsimp simp: bindE_assoc)
           apply (ctac pre: ccorres_liftE_Seq add: lookupPTSlot_ccorres)
@@ -1018,7 +1018,7 @@ lemma decodeRISCVPageTableInvocation_ccorres:
              apply (rule ccorres_if_cond_throws[rotated -1, where Q=\<top> and Q'=\<top>])
                 apply vcg
                apply (solves clarsimp)
-              apply (rule syscall_error_throwError_ccorres_n[simplified id_def dc_def])
+              apply (rule syscall_error_throwError_ccorres_n)
               apply (simp add: syscall_error_to_H_cases)
              (* checks are done, move on to doing the mapping *)
              apply (clarsimp simp: injection_handler_returnOk)
@@ -1321,7 +1321,7 @@ lemma performPageInvocationMapPTE_ccorres:
   done
 
 lemma performPageGetAddress_ccorres:
-  notes Collect_const[simp del] dc_simp[simp del]
+  notes Collect_const[simp del]
   shows
   "ccorres ((intr_and_se_rel \<circ> Inr) \<currency> dc) (liftxf errstate id (K ()) ret__unsigned_long_')
       (invs' and (\<lambda>s. ksCurThread s = thread) and ct_in_state' ((=) Restart))
@@ -1347,7 +1347,7 @@ lemma performPageGetAddress_ccorres:
        apply (rule ccorres_from_vcg_throws[where P=\<top> and P'=UNIV])
        apply clarsimp
        apply (rule conseqPre, vcg)
-       apply (clarsimp simp: return_def dc_simp)
+       apply (clarsimp simp: return_def)
       apply (rule hoare_post_taut[of \<top>])
      apply (rule ccorres_rhs_assoc)+
      apply (clarsimp simp: replyOnRestart_def liftE_def bind_assoc)
@@ -1370,7 +1370,7 @@ lemma performPageGetAddress_ccorres:
                  apply (rule ccorres_inst[where P=\<top> and P'=UNIV])
                  apply (rule ccorres_from_vcg_throws[where P=\<top> and P'=UNIV])
                  apply (rule allI, rule conseqPre, vcg)
-                 apply (clarsimp simp: return_def dc_def)
+                 apply (clarsimp simp: return_def)
                 apply (rule hoare_post_taut[of \<top>])
                apply (vcg exspec=setThreadState_modifies)
               apply wpsimp
@@ -1383,10 +1383,10 @@ lemma performPageGetAddress_ccorres:
                                Kernel_C.msgInfoRegister_def Kernel_C.a1_def)
          apply (vcg exspec=setMR_modifies)
         apply wpsimp
-       apply (clarsimp simp: dc_def)
+       apply clarsimp
        apply (vcg exspec=setRegister_modifies)
       apply wpsimp
-     apply (clarsimp simp: dc_def ThreadState_Running_def)
+     apply (clarsimp simp: ThreadState_Running_def)
      apply (vcg exspec=lookupIPCBuffer_modifies)
     apply clarsimp
     apply vcg
@@ -1775,7 +1775,7 @@ lemma decodeRISCVFrameInvocation_ccorres:
              apply (solves \<open>clarsimp simp: asidInvalid_def isCap_simps
                                        ccap_relation_PageTableCap_IsMapped\<close>)
             apply (simp add: throwError_bind invocationCatch_def)
-            apply (rule syscall_error_throwError_ccorres_n[simplified id_def dc_def])
+            apply (rule syscall_error_throwError_ccorres_n)
             apply (simp add: syscall_error_to_H_cases)
            apply csymbr
            apply csymbr
@@ -1792,7 +1792,7 @@ lemma decodeRISCVFrameInvocation_ccorres:
               apply (rule ccorres_if_cond_throws[rotated -1, where Q=\<top> and Q'=\<top>])
                  apply vcg
                 apply (solves\<open>clarsimp simp: asidInvalid_def isCap_simps ccap_relation_PageTableCap_BasePtr\<close>)
-               apply (rule syscall_error_throwError_ccorres_n[simplified id_def dc_def])
+               apply (rule syscall_error_throwError_ccorres_n)
                apply (simp add: syscall_error_to_H_cases)
               apply (clarsimp simp: bindE_assoc)
               (* check vaddr is valid *)
@@ -1804,7 +1804,7 @@ lemma decodeRISCVFrameInvocation_ccorres:
               apply (rule ccorres_if_cond_throws[rotated -1, where Q=\<top> and Q'=\<top>])
                  apply vcg
                 apply (solves \<open>clarsimp simp: pptrUserTop_def' p_assoc_help\<close>)
-               apply (rule syscall_error_throwError_ccorres_n[simplified id_def dc_def])
+               apply (rule syscall_error_throwError_ccorres_n)
                apply (simp add: syscall_error_to_H_cases)
               (* check vaddr alignment *)
               apply (clarsimp simp: checkVPAlignment_def unlessE_def injection_handler_If
@@ -1815,7 +1815,7 @@ lemma decodeRISCVFrameInvocation_ccorres:
               apply (rule ccorres_if_cond_throws2[rotated -1, where Q=\<top> and Q'=\<top>])
                  apply vcg
                 apply (solves \<open>clarsimp simp: vmsz_aligned_def from_bool_0 is_aligned_mask\<close>)
-               apply (rule syscall_error_throwError_ccorres_n[simplified id_def dc_def])
+               apply (rule syscall_error_throwError_ccorres_n)
                apply (simp add: syscall_error_to_H_cases)
 
               (* lookup pt slot *)
@@ -1827,7 +1827,6 @@ lemma decodeRISCVFrameInvocation_ccorres:
                 apply (rename_tac ptSlot ptSlot_ret)
                 apply wpfix
                 apply (rule_tac P="unat (ptBitsLeft_C ptSlot_ret) < 64" in ccorres_gen_asm)
-                apply (fold dc_def id_def)
                 apply (rule ccorres_if_lhs[rotated])
                  (* throwing a lookup fault, branch condition on C side is true *)
                  apply (prop_tac "ptBitsLeft_C ptSlot_ret
@@ -1888,7 +1887,7 @@ lemma decodeRISCVFrameInvocation_ccorres:
                   apply (rule ccorres_if_cond_throws2[rotated -1, where Q=\<top> and Q'=\<top>])
                      apply vcg
                     apply (solves clarsimp)
-                   apply (rule syscall_error_throwError_ccorres_n[simplified id_def dc_def])
+                   apply (rule syscall_error_throwError_ccorres_n)
                    apply (simp add: syscall_error_to_H_cases)
 
                   (* checks handled, perform frame map *)
@@ -1955,7 +1954,7 @@ lemma decodeRISCVFrameInvocation_ccorres:
                   apply (clarsimp simp: isCap_simps not_None_def ccap_relation_FrameCap_MappedAddress
                                         ccap_relation_PageTableCap_MappedASID
                                         ccap_relation_FrameCap_MappedASID)
-                 apply (rule syscall_error_throwError_ccorres_n[simplified id_def dc_def])
+                 apply (rule syscall_error_throwError_ccorres_n)
                  apply (simp add: syscall_error_to_H_cases)
                 (* ensure mapped address of frame matches *)
                 apply csymbr
@@ -1964,7 +1963,7 @@ lemma decodeRISCVFrameInvocation_ccorres:
                 apply (rule ccorres_if_cond_throws[rotated -1, where Q=\<top> and Q'=\<top>])
                    apply vcg
                   apply (solves clarsimp)
-                 apply (rule syscall_error_throwError_ccorres_n[simplified id_def dc_def])
+                 apply (rule syscall_error_throwError_ccorres_n)
                  apply (simp add: syscall_error_to_H_cases)
 
                 (* ensure lookupPTSlot returned a slot with a PTE *)
@@ -1987,7 +1986,7 @@ lemma decodeRISCVFrameInvocation_ccorres:
                   apply (rule ccorres_if_cond_throws2[rotated -1, where Q=\<top> and Q'=\<top>])
                      apply vcg
                     apply (solves clarsimp)
-                   apply (rule syscall_error_throwError_ccorres_n[simplified id_def dc_def])
+                   apply (rule syscall_error_throwError_ccorres_n)
                    apply (simp add: syscall_error_to_H_cases)
 
                   (* checks handled, perform frame remap *)
@@ -2179,7 +2178,6 @@ lemma decodeRISCVFrameInvocation_ccorres:
     apply (prop_tac "(addrFromPPtr p >> 12) AND mask 44 = (addrFromPPtr p >> 12)")
     subgoal
       apply (frule cte_wp_at'_frame_at', fastforce)
-      apply (clarsimp simp: comp_def)
       apply (prop_tac "canonical_address p")
        apply (erule canonical_address_frame_at', fastforce)
       apply (prop_tac "p \<in> kernel_mappings")
@@ -2845,7 +2843,7 @@ lemma decodeRISCVMMUInvocation_ccorres:
    (* Can't reach *)
    apply (rule ccorres_inst[where P=\<top> and P'=UNIV])
    apply (cases cp; simp add: isCap_simps)
-  apply (clarsimp simp: o_def)
+  apply clarsimp
   apply (rule conjI) (* PTCap *)
    apply (clarsimp simp: cte_wp_at_ctes_of)
    apply (drule_tac t="cteCap cte" in sym)

--- a/proof/crefine/RISCV64/CSpace_All.thy
+++ b/proof/crefine/RISCV64/CSpace_All.thy
@@ -25,9 +25,9 @@ abbreviation
 
 (* FIXME: move *)
 lemma ccorres_return_into_rel:
-  "ccorres (\<lambda>rv rv'. r (f rv) rv') xf G G' hs a c
+  "ccorres (r \<circ> f) xf G G' hs a c
   \<Longrightarrow> ccorres r xf G G' hs (a >>= (\<lambda>rv. return (f rv))) c"
-  by (simp add: liftM_def[symmetric] o_def)
+  by (simp add: liftM_def[symmetric])
 
 lemma lookupCap_ccorres':
   "ccorres (lookup_failure_rel \<currency> ccap_relation) lookupCap_xf

--- a/proof/crefine/RISCV64/CSpace_C.thy
+++ b/proof/crefine/RISCV64/CSpace_C.thy
@@ -868,7 +868,7 @@ lemma setUntypedCapAsFull_ccorres [corres]:
     apply (rule ccorres_move_c_guard_cte)
     apply (rule ccorres_Guard)
     apply (rule ccorres_call)
-       apply (rule update_freeIndex [unfolded dc_def])
+       apply (rule update_freeIndex)
       apply simp
      apply simp
     apply simp
@@ -894,14 +894,14 @@ lemma setUntypedCapAsFull_ccorres [corres]:
       apply csymbr
       apply (clarsimp simp: cap_get_tag_to_H cap_get_tag_UntypedCap split: if_split_asm)
       apply (rule ccorres_cond_false)
-      apply (rule ccorres_return_Skip [unfolded dc_def])
+      apply (rule ccorres_return_Skip)
      apply (clarsimp simp: cap_get_tag_isCap[symmetric] cap_get_tag_UntypedCap split: if_split_asm)
      apply (rule ccorres_cond_false)
-     apply (rule ccorres_return_Skip [unfolded dc_def])
-    apply (rule ccorres_return_Skip [unfolded dc_def])
+     apply (rule ccorres_return_Skip)
+    apply (rule ccorres_return_Skip)
    apply clarsimp
    apply (rule ccorres_cond_false)
-   apply (rule ccorres_return_Skip [unfolded dc_def])
+   apply (rule ccorres_return_Skip)
   apply (clarsimp simp: cap_get_tag_isCap[symmetric] cap_get_tag_UntypedCap)
   apply (frule(1) cte_wp_at_valid_objs_valid_cap')
   apply (clarsimp simp: untypedBits_defs)
@@ -1017,19 +1017,17 @@ lemma cteInsert_ccorres:
                   apply csymbr
                   apply simp
                   apply (rule ccorres_move_c_guard_cte)
-                  apply (simp add:dc_def[symmetric])
                   apply (ctac ccorres:ccorres_updateMDB_set_mdbPrev)
-                 apply (simp add:dc_def[symmetric])
                  apply (ctac ccorres: ccorres_updateMDB_skip)
                 apply (wp static_imp_wp)+
-              apply (clarsimp simp: Collect_const_mem dc_def split del: if_split)
+              apply (clarsimp simp: Collect_const_mem split del: if_split)
               apply vcg
              apply (wp static_imp_wp)
-            apply (clarsimp simp: Collect_const_mem dc_def split del: if_split)
+            apply (clarsimp simp: Collect_const_mem split del: if_split)
             apply vcg
            apply (clarsimp simp:cmdb_node_relation_mdbNext)
            apply (wp setUntypedCapAsFull_cte_at_wp static_imp_wp)
-          apply (clarsimp simp: Collect_const_mem dc_def split del: if_split)
+          apply (clarsimp simp: Collect_const_mem split del: if_split)
           apply (vcg exspec=setUntypedCapAsFull_modifies)
          apply wp
         apply vcg
@@ -2211,7 +2209,6 @@ lemma postCapDeletion_ccorres:
     apply (rule ccorres_symb_exec_r)
       apply (rule_tac xf'=irq_' in ccorres_abstract, ceqv)
       apply (rule_tac P="rv' = ucast (capIRQ cap)" in ccorres_gen_asm2)
-      apply (fold dc_def)
       apply (frule cap_get_tag_to_H, solves \<open>clarsimp simp: cap_get_tag_isCap_unfolded_H_cap\<close>)
       apply (clarsimp simp: cap_irq_handler_cap_lift)
       apply (ctac(no_vcg) add: deletedIRQHandler_ccorres)
@@ -2222,9 +2219,9 @@ lemma postCapDeletion_ccorres:
    apply (clarsimp simp: cap_get_tag_isCap)
    apply (rule ccorres_Cond_rhs)
     apply (wpc; clarsimp simp: isCap_simps)
-    apply (ctac(no_vcg) add: Arch_postCapDeletion_ccorres[unfolded dc_def])
+    apply (ctac(no_vcg) add: Arch_postCapDeletion_ccorres)
    apply (simp add: not_irq_or_arch_cap_case)
-   apply (rule ccorres_return_Skip[unfolded dc_def])+
+   apply (rule ccorres_return_Skip)
   apply clarsimp
   apply (rule conjI, clarsimp simp: isCap_simps  Kernel_C.maxIRQ_def)
    apply (frule cap_get_tag_isCap_unfolded_H_cap(5))
@@ -2273,7 +2270,7 @@ lemma emptySlot_ccorres:
 
     \<comment> \<open>*** proof for the 'else' branch (return () and SKIP) ***\<close>
      prefer 2
-     apply (ctac add: ccorres_return_Skip[unfolded dc_def])
+     apply (ctac add: ccorres_return_Skip)
 
     \<comment> \<open>*** proof for the 'then' branch ***\<close>
 
@@ -2318,7 +2315,7 @@ lemma emptySlot_ccorres:
 
                   \<comment> \<open>the post_cap_deletion case\<close>
 
-                  apply (ctac(no_vcg) add: postCapDeletion_ccorres [unfolded dc_def])
+                  apply (ctac(no_vcg) add: postCapDeletion_ccorres)
 
                 \<comment> \<open>Haskell pre/post for y \<leftarrow> updateMDB slot (\<lambda>a. nullMDBNode);\<close>
                  apply wp
@@ -2392,7 +2389,7 @@ lemma capSwapForDelete_ccorres:
    apply (simp add:when_def)
    apply (rule ccorres_if_cond_throws2 [where Q = \<top> and Q' = \<top>])
       apply (case_tac "slot1=slot2", simp+)
-     apply (rule ccorres_return_void_C [simplified dc_def])
+     apply (rule ccorres_return_void_C)
 
   \<comment> \<open>***Main goal***\<close>
   \<comment> \<open>--- ccorres goal with 2 affectations (cap1 and cap2) on both on Haskell and C\<close>
@@ -2401,7 +2398,7 @@ lemma capSwapForDelete_ccorres:
     apply (rule ccorres_pre_getCTE)+
     apply (rule ccorres_move_c_guard_cte, rule ccorres_symb_exec_r)+
   \<comment> \<open>***Main goal***\<close>
-        apply (ctac (no_vcg) add: cteSwap_ccorres [unfolded dc_def] )
+        apply (ctac (no_vcg) add: cteSwap_ccorres)
        \<comment> \<open>C Hoare triple for \<acute>cap2 :== \<dots>\<close>
        apply vcg
        \<comment> \<open>C existential Hoare triple for \<acute>cap2 :== \<dots>\<close>

--- a/proof/crefine/RISCV64/Delete_C.thy
+++ b/proof/crefine/RISCV64/Delete_C.thy
@@ -856,7 +856,7 @@ lemma finaliseSlot_ccorres:
                                       ccorres_seq_skip)
                     apply (rule rsubst[where P="ccorres r xf' P P' hs a" for r xf' P P' hs a])
                     apply (rule hyps[folded reduceZombie_def[unfolded cteDelete_def finaliseSlot_def],
-                                         unfolded split_def, unfolded K_def],
+                                     unfolded split_def],
                            (simp add: in_monad)+)
                     apply (simp add: from_bool_0)
                    apply simp
@@ -1001,26 +1001,23 @@ lemma cteRevoke_ccorres1:
          apply (rule ccorres_drop_cutMon_bindE)
          apply (rule ccorres_rhs_assoc)+
          apply (ctac(no_vcg) add: cteDelete_ccorres)
-           apply (simp del: Collect_const add: Collect_False ccorres_cond_iffs
-                                               dc_def[symmetric])
+           apply (simp del: Collect_const add: Collect_False ccorres_cond_iffs)
            apply (rule ccorres_cutMon, simp only: cutMon_walk_bindE)
            apply (rule ccorres_drop_cutMon_bindE)
            apply (ctac(no_vcg) add: preemptionPoint_ccorres)
-             apply (simp del: Collect_const add: Collect_False ccorres_cond_iffs
-                                                 dc_def[symmetric])
+             apply (simp del: Collect_const add: Collect_False ccorres_cond_iffs)
              apply (rule ccorres_cutMon)
              apply (rule rsubst[where P="ccorres r xf' P P' hs a" for r xf' P P' hs a])
-              apply (rule hyps[unfolded K_def],
-                     (fastforce simp: in_monad)+)[1]
+              apply (rule hyps; fastforce simp: in_monad)
              apply simp
             apply (simp, rule ccorres_split_throws)
-             apply (rule ccorres_return_C_errorE, simp+)[1]
+             apply (rule ccorres_return_C_errorE; simp)
             apply vcg
            apply (wp preemptionPoint_invR)
             apply simp
            apply simp
           apply (simp, rule ccorres_split_throws)
-           apply (rule ccorres_return_C_errorE, simp+)[1]
+           apply (rule ccorres_return_C_errorE; simp)
           apply vcg
          apply (wp cteDelete_invs' cteDelete_sch_act_simple)
         apply (rule ccorres_cond_false)

--- a/proof/crefine/RISCV64/Finalise_C.thy
+++ b/proof/crefine/RISCV64/Finalise_C.thy
@@ -219,8 +219,7 @@ proof (induct ts)
     apply (rule iffD1 [OF ccorres_expand_while_iff])
     apply (rule ccorres_tmp_lift2[where G'=UNIV and G''="\<lambda>x. UNIV", simplified])
      apply ceqv
-    apply (simp add: ccorres_cond_iffs mapM_x_def sequence_x_def
-                     dc_def[symmetric])
+    apply (simp add: ccorres_cond_iffs mapM_x_def sequence_x_def)
     apply (rule ccorres_guard_imp2, rule ccorres_return_Skip)
     apply simp
     done
@@ -229,7 +228,7 @@ next
   show ?case
     apply (rule iffD1 [OF ccorres_expand_while_iff])
     apply (simp del: Collect_const
-                add: dc_def[symmetric] mapM_x_Cons)
+                add: mapM_x_Cons)
     apply (rule ccorres_guard_imp2)
      apply (rule_tac xf'=thread_' in ccorres_abstract)
       apply ceqv
@@ -344,7 +343,7 @@ lemma cancelAllIPC_ccorres:
              subgoal by (simp add: cendpoint_relation_def endpoint_state_defs)
             subgoal by simp
            apply (rule ceqv_refl)
-          apply (simp only: ccorres_seq_skip dc_def[symmetric])
+          apply (simp only: ccorres_seq_skip)
           apply (rule ccorres_split_nothrow_novcg)
               apply (rule cancel_all_ccorres_helper)
              apply ceqv
@@ -361,12 +360,10 @@ lemma cancelAllIPC_ccorres:
          apply (wp set_ep_valid_objs' hoare_vcg_const_Ball_lift
                    weak_sch_act_wf_lift_linear)
         apply vcg
-       apply (simp add: ccorres_cond_iffs dc_def[symmetric])
+       apply (simp add: ccorres_cond_iffs)
        apply (rule ccorres_return_Skip)
       apply (rename_tac list)
-      apply (simp add: endpoint_state_defs
-                       Collect_False Collect_True
-                       ccorres_cond_iffs dc_def[symmetric]
+      apply (simp add: endpoint_state_defs Collect_False Collect_True ccorres_cond_iffs
                   del: Collect_const)
       apply (rule ccorres_rhs_assoc)+
       apply csymbr
@@ -395,7 +392,7 @@ lemma cancelAllIPC_ccorres:
            subgoal by (simp add: cendpoint_relation_def endpoint_state_defs)
           subgoal by simp
          apply (rule ceqv_refl)
-        apply (simp only: ccorres_seq_skip dc_def[symmetric])
+        apply (simp only: ccorres_seq_skip)
         apply (rule ccorres_split_nothrow_novcg)
             apply (rule cancel_all_ccorres_helper)
            apply ceqv
@@ -443,15 +440,12 @@ lemma cancelAllSignals_ccorres:
      apply (rule_tac A="invs' and ko_at' rv ntfnptr"
                   in ccorres_guard_imp2[where A'=UNIV])
       apply wpc
-        apply (simp add: notification_state_defs ccorres_cond_iffs
-                         dc_def[symmetric])
+        apply (simp add: notification_state_defs ccorres_cond_iffs)
         apply (rule ccorres_return_Skip)
-       apply (simp add: notification_state_defs ccorres_cond_iffs
-                        dc_def[symmetric])
+       apply (simp add: notification_state_defs ccorres_cond_iffs)
        apply (rule ccorres_return_Skip)
       apply (rename_tac list)
-      apply (simp add: notification_state_defs ccorres_cond_iffs
-                       dc_def[symmetric] Collect_True
+      apply (simp add: notification_state_defs ccorres_cond_iffs Collect_True
                   del: Collect_const)
       apply (rule ccorres_rhs_assoc)+
       apply csymbr
@@ -478,7 +472,7 @@ lemma cancelAllSignals_ccorres:
            subgoal by (simp add: cnotification_relation_def notification_state_defs Let_def)
           subgoal by simp
          apply (rule ceqv_refl)
-        apply (simp only: ccorres_seq_skip dc_def[symmetric])
+        apply (simp only: ccorres_seq_skip)
         apply (rule ccorres_split_nothrow_novcg)
             apply (rule cancel_all_ccorres_helper)
            apply ceqv
@@ -735,7 +729,7 @@ lemma doUnbindNotification_ccorres:
       apply (rule ccorres_move_c_guard_tcb)
       apply (simp add: setBoundNotification_def)
       apply (rule_tac P'="\<top>" and P="\<top>"
-                   in threadSet_ccorres_lemma3[unfolded dc_def])
+                   in threadSet_ccorres_lemma3)
        apply vcg
       apply simp
       apply (erule(1) rf_sr_tcb_update_no_queue2)
@@ -785,7 +779,7 @@ lemma doUnbindNotification_ccorres':
       apply (rule ccorres_move_c_guard_tcb)
       apply (simp add: setBoundNotification_def)
       apply (rule_tac P'="\<top>" and P="\<top>"
-                   in threadSet_ccorres_lemma3[unfolded dc_def])
+                   in threadSet_ccorres_lemma3)
        apply vcg
       apply simp
       apply (erule(1) rf_sr_tcb_update_no_queue2)
@@ -819,9 +813,9 @@ lemma unbindNotification_ccorres:
      apply simp
      apply wpc
       apply (rule ccorres_cond_false)
-      apply (rule ccorres_return_Skip[unfolded dc_def])
+      apply (rule ccorres_return_Skip)
      apply (rule ccorres_cond_true)
-     apply (ctac (no_vcg) add: doUnbindNotification_ccorres[unfolded dc_def, simplified])
+     apply (ctac (no_vcg) add: doUnbindNotification_ccorres[simplified])
     apply (wp gbn_wp')
    apply vcg
   apply (clarsimp simp: option_to_ptr_def option_to_0_def pred_tcb_at'_def
@@ -1027,7 +1021,7 @@ lemma deleteASIDPool_ccorres:
   apply (rule ccorres_gen_asm)
   apply (cinit lift: asid_base_' pool_' simp: whileAnno_def)
    apply (rule ccorres_assert)
-   apply (clarsimp simp: liftM_def dc_def[symmetric] when_def)
+   apply (clarsimp simp: liftM_def when_def)
    apply (rule ccorres_Guard)+
    apply (rule ccorres_pre_gets_riscvKSASIDTable_ksArchState)
    apply (rule_tac R="\<lambda>s. rv = riscvKSASIDTable (ksArchState s)" in ccorres_cond2)
@@ -1084,7 +1078,7 @@ lemma deleteASID_ccorres:
       apply (rule ccorres_from_vcg[where P="\<top>" and P'=UNIV])
       apply (rule allI, rule conseqPre, vcg)
       apply (simp add: return_def)
-     apply (clarsimp simp: dc_def[symmetric] when_def liftM_def
+     apply (clarsimp simp: when_def liftM_def
                      cong: conj_cong call_ignore_cong)
      apply (rename_tac asidTable ap)
      apply csymbr
@@ -1354,7 +1348,6 @@ next
           apply (rule ccorres_checkPTAt)
           apply (rule ccorres_symb_exec_r2)
             apply (rule ccorres_symb_exec_r2)
-              apply (fold dc_def)[1]
               apply (rule Suc.hyps[unfolded whileAnno_def])
              using level apply simp
              apply vcg
@@ -1539,7 +1532,7 @@ lemma cteDeleteOne_ccorres:
           erule_tac t="ret__unsigned_longlong = scast cap_null_cap"
                 and s="cteCap cte = NullCap"
                  in ssubst)
-   apply (clarsimp simp only: when_def unless_def dc_def[symmetric])
+   apply (clarsimp simp only: when_def unless_def)
    apply (rule ccorres_cond2[where R=\<top>])
      apply (clarsimp simp: Collect_const_mem)
     apply (rule ccorres_rhs_assoc)+
@@ -1550,12 +1543,12 @@ lemma cteDeleteOne_ccorres:
       apply (ctac(no_vcg) add: isFinalCapability_ccorres[where slot=slot])
        apply (rule_tac A="invs'  and cte_wp_at' ((=) cte) slot"
                      in ccorres_guard_imp2[where A'=UNIV])
-        apply (simp add: split_def dc_def[symmetric]
+        apply (simp add: split_def
                     del: Collect_const)
         apply (rule ccorres_move_c_guard_cte)
         apply (ctac(no_vcg) add: finaliseCap_True_standin_ccorres)
          apply (rule ccorres_assert)
-         apply (simp add: dc_def[symmetric])
+         apply simp
          apply csymbr
          apply (ctac add: emptySlot_ccorres)
         apply (simp add: pred_conj_def finaliseCapTrue_standin_simple_def)
@@ -1591,7 +1584,7 @@ lemma deletingIRQHandler_ccorres:
                    ({s. irq_opt_relation (Some irq) (irq_' s)}) []
    (deletingIRQHandler irq) (Call deletingIRQHandler_'proc)"
   apply (cinit lift: irq_' cong: call_ignore_cong)
-   apply (clarsimp simp: irq_opt_relation_def ptr_add_assertion_def dc_def[symmetric]
+   apply (clarsimp simp: irq_opt_relation_def ptr_add_assertion_def
                    cong: call_ignore_cong )
    apply (rule_tac r'="\<lambda>rv rv'. rv' = Ptr rv"
                 and xf'="slot_'" in ccorres_split_nothrow)
@@ -1748,7 +1741,7 @@ lemma ccap_relation_capFMappedASID_CL_0:
   done
 
 lemma Arch_finaliseCap_ccorres:
-  notes dc_simp[simp del] Collect_const[simp del] if_weak_cong[cong]
+  notes Collect_const[simp del] if_weak_cong[cong]
   shows
   "ccorres (\<lambda>rv rv'. ccap_relation (fst rv) (remainder_C rv') \<and>
                      ccap_relation (snd rv) (finaliseCap_ret_C.cleanupInfo_C rv'))
@@ -1961,7 +1954,6 @@ lemma prepareThreadDelete_ccorres:
      (invs' and tcb_at' thread)
      (UNIV \<inter> {s. thread_' s = tcb_ptr_to_ctcb_ptr thread}) hs
    (prepareThreadDelete thread) (Call Arch_prepareThreadDelete_'proc)"
-  supply dc_simp[simp del]
   apply (cinit lift: thread_', rename_tac cthread)
    apply (rule ccorres_return_Skip)
   apply fastforce
@@ -2116,18 +2108,18 @@ lemma finaliseCap_ccorres:
     apply (rule ccorres_fail)
    apply (rule ccorres_add_return, rule ccorres_split_nothrow_novcg[where r'=dc and xf'=xfdc])
        apply (rule ccorres_Cond_rhs)
-        apply (simp add: ccorres_cond_iffs dc_def[symmetric])
+        apply (simp add: ccorres_cond_iffs)
         apply (rule ccorres_return_Skip)
        apply (rule ccorres_Cond_rhs)
-        apply (simp add: ccorres_cond_iffs dc_def[symmetric])
+        apply (simp add: ccorres_cond_iffs)
         apply (rule ccorres_return_Skip)
        apply (rule ccorres_Cond_rhs)
         apply (rule ccorres_inst[where P=\<top> and P'=UNIV])
         apply simp
        apply (rule ccorres_Cond_rhs)
-        apply (simp add: ccorres_cond_iffs dc_def[symmetric])
+        apply (simp add: ccorres_cond_iffs)
         apply (rule ccorres_return_Skip)
-       apply (simp add: ccorres_cond_iffs dc_def[symmetric])
+       apply (simp add: ccorres_cond_iffs)
        apply (rule ccorres_return_Skip)
       apply (rule ceqv_refl)
      apply (rule ccorres_from_vcg_throws[where P=\<top> and P'=UNIV])

--- a/proof/crefine/RISCV64/Finalise_C.thy
+++ b/proof/crefine/RISCV64/Finalise_C.thy
@@ -421,11 +421,6 @@ lemma cancelAllIPC_ccorres:
   apply clarsimp
   done
 
-lemma empty_fail_getNotification:
-  "empty_fail (getNotification ep)"
-  unfolding getNotification_def
-  by (auto intro: empty_fail_getObject)
-
 lemma cancelAllSignals_ccorres:
   "ccorres dc xfdc
    (invs') (UNIV \<inter> {s. ntfnPtr_' s = Ptr ntfnptr}) []
@@ -1447,12 +1442,6 @@ lemma no_0_page_table_at'[elim!]:
   apply (clarsimp simp: page_table_at'_def)
   apply (drule spec[where x=0], clarsimp simp: bit_simps)
   done
-
-lemma ccte_relation_ccap_relation:
-  "ccte_relation cte cte' \<Longrightarrow> ccap_relation (cteCap cte) (cte_C.cap_C cte')"
-  by (clarsimp simp: ccte_relation_def ccap_relation_def
-                     cte_to_H_def map_option_Some_eq2
-                     c_valid_cte_def)
 
 lemma isFinalCapability_ccorres:
   "ccorres ((=) \<circ> from_bool) ret__unsigned_long_'

--- a/proof/crefine/RISCV64/Interrupt_C.thy
+++ b/proof/crefine/RISCV64/Interrupt_C.thy
@@ -75,7 +75,7 @@ proof -
      apply (rule ccorres_symb_exec_r)
        apply (ctac(no_vcg) add: cteDeleteOne_ccorres[where w="-1"])
         apply (rule ccorres_call)
-           apply (rule cteInsert_ccorres[simplified dc_def])
+           apply (rule cteInsert_ccorres)
           apply simp
          apply simp
         apply simp
@@ -112,7 +112,7 @@ lemma invokeIRQHandler_ClearIRQHandler_ccorres:
    apply (simp add: ucast_up_ucast is_up)
    apply (ctac(no_vcg) add: getIRQSlot_ccorres[simplified])
      apply (rule ccorres_symb_exec_r)
-       apply (ctac add: cteDeleteOne_ccorres[where w="-1",simplified dc_def])
+       apply (ctac add: cteDeleteOne_ccorres[where w="-1"])
       apply vcg
      apply (rule conseqPre, vcg, clarsimp simp: rf_sr_def
         gs_set_assn_Delete_cstate_relation[unfolded o_def])
@@ -345,7 +345,7 @@ lemma invokeIRQControl_ccorres:
       (performIRQControl (Invocations_H.irqcontrol_invocation.IssueIRQHandler irq slot parent))
       (Call invokeIRQControl_'proc)"
   by (clarsimp simp: performIRQControl_def liftE_def bind_assoc
-               intro!: invokeIRQControl_expanded_ccorres[simplified liftE_def K_def, simplified])
+               intro!: invokeIRQControl_expanded_ccorres[simplified liftE_def, simplified])
 
 lemma isIRQActive_ccorres:
   "ccorres (\<lambda>rv rv'. rv' = from_bool rv) ret__unsigned_long_'
@@ -625,7 +625,7 @@ lemma Arch_decodeIRQControlInvocation_ccorres:
     apply (vcg exspec=getSyscallArg_modifies)
    apply ccorres_rewrite
    apply (auto split: invocation_label.split arch_invocation_label.split
-               intro: syscall_error_throwError_ccorres_n[simplified throwError_def o_def dc_def id_def]
+               intro: syscall_error_throwError_ccorres_n[simplified throwError_def o_def]
                simp: throwError_def invocationCatch_def syscall_error_to_H_cases invocation_eq_use_types)[1]
   apply clarsimp
   apply (clarsimp simp: interpret_excaps_test_null excaps_map_def

--- a/proof/crefine/RISCV64/Invoke_C.thy
+++ b/proof/crefine/RISCV64/Invoke_C.thy
@@ -69,7 +69,7 @@ lemma setDomain_ccorres:
          apply (rule_tac R="\<lambda>s. rv = ksCurThread s"
                     in ccorres_cond2)
            apply (clarsimp simp: rf_sr_ksCurThread)
-          apply (ctac add: rescheduleRequired_ccorres[unfolded dc_def])
+          apply (ctac add: rescheduleRequired_ccorres)
          apply (rule ccorres_return_Skip')
         apply simp
         apply (wp hoare_drop_imps weak_sch_act_wf_lift_linear)
@@ -79,8 +79,9 @@ lemma setDomain_ccorres:
      apply (rule_tac Q="\<lambda>_. all_invs_but_sch_extra and tcb_at' t and sch_act_simple
                         and (\<lambda>s. rv = ksCurThread s)" in hoare_strengthen_post)
       apply (wp threadSet_all_invs_but_sch_extra)
-     apply (clarsimp simp:valid_pspace_valid_objs' st_tcb_at_def[symmetric]
-       sch_act_simple_def st_tcb_at'_def o_def weak_sch_act_wf_def split:if_splits)
+     apply (clarsimp simp: valid_pspace_valid_objs' st_tcb_at_def[symmetric]
+                           sch_act_simple_def st_tcb_at'_def weak_sch_act_wf_def
+                    split: if_splits)
     apply (simp add: guard_is_UNIV_def)
    apply (rule_tac Q="\<lambda>_. invs' and tcb_at' t and sch_act_simple
       and (\<lambda>s. rv = ksCurThread s \<and> (\<forall>p. t \<notin> set (ksReadyQueues s p)))" in hoare_strengthen_post)
@@ -382,7 +383,7 @@ lemma invokeCNodeRotate_ccorres:
      apply clarsimp
      apply (simp add: return_def)
     apply wp
-   apply (simp add: guard_is_UNIV_def dc_def xfdc_def)
+   apply (simp add: guard_is_UNIV_def)
   apply (clarsimp simp: valid_pspace'_def)
   apply (rule conjI, clarsimp)
   apply (clarsimp simp:cte_wp_at_ctes_of)
@@ -628,9 +629,7 @@ lemma decodeCNodeInvocation_ccorres:
                        del: Collect_const cong: call_ignore_cong)
            apply (rule ccorres_split_throws)
             apply (rule ccorres_rhs_assoc | csymbr)+
-            apply (simp add: invocationCatch_use_injection_handler
-                                  [symmetric, unfolded o_def]
-                             if_1_0_0 dc_def[symmetric]
+            apply (simp add: invocationCatch_use_injection_handler[symmetric, unfolded o_def]
                         del: Collect_const cong: call_ignore_cong)
             apply (rule ccorres_Cond_rhs_Seq)
              apply (simp add:if_P del: Collect_const)
@@ -713,8 +712,7 @@ lemma decodeCNodeInvocation_ccorres:
                          apply (simp add: Collect_const[symmetric] del: Collect_const)
                          apply (rule ccorres_rhs_assoc)+
                          apply (rule ccorres_Cond_rhs_Seq)
-                          apply (simp add: injection_handler_throwError dc_def[symmetric]
-                                           if_P)
+                          apply (simp add: injection_handler_throwError if_P)
                           apply (rule syscall_error_throwError_ccorres_n)
                           apply (simp add: syscall_error_to_H_cases)
                          apply (simp add: list_case_helper injection_handler_returnOk
@@ -741,8 +739,7 @@ lemma decodeCNodeInvocation_ccorres:
                                apply csymbr
                                apply (simp add: cap_get_tag_NullCap del: Collect_const)
                                apply (rule ccorres_Cond_rhs_Seq)
-                                apply (simp add: injection_handler_throwError whenE_def
-                                                 dc_def[symmetric])
+                                apply (simp add: injection_handler_throwError whenE_def)
                                 apply (rule syscall_error_throwError_ccorres_n)
                                 apply (simp add: syscall_error_to_H_cases)
                                apply (simp add: whenE_def injection_handler_returnOk
@@ -818,8 +815,7 @@ lemma decodeCNodeInvocation_ccorres:
                                    apply (simp add: cap_get_tag_NullCap del: Collect_const)
                                    apply (rule ccorres_Cond_rhs_Seq)
                                     apply (simp add: whenE_def injection_handler_returnOk
-                                                     invocationCatch_def injection_handler_throwError
-                                                     dc_def[symmetric])
+                                                     invocationCatch_def injection_handler_throwError)
                                     apply (rule syscall_error_throwError_ccorres_n)
                                     apply (simp add: syscall_error_to_H_cases)
                                    apply (simp add: whenE_def injection_handler_returnOk
@@ -898,7 +894,7 @@ lemma decodeCNodeInvocation_ccorres:
                          apply (simp add: flip: Collect_const
                                     cong: call_ignore_cong)
                          apply (rule ccorres_Cond_rhs_Seq)
-                          apply (simp add: injection_handler_throwError dc_def[symmetric] if_P)
+                          apply (simp add: injection_handler_throwError if_P)
                           apply (rule syscall_error_throwError_ccorres_n)
                           apply (simp add: syscall_error_to_H_cases)
                          apply (simp add: if_not_P del: Collect_const)
@@ -917,8 +913,7 @@ lemma decodeCNodeInvocation_ccorres:
                              apply csymbr
                              apply (simp add: cap_get_tag_isCap del: Collect_const)
                              apply (rule ccorres_Cond_rhs_Seq)
-                              apply (simp add: whenE_def injection_handler_throwError
-                                               dc_def[symmetric] numeral_eqs)
+                              apply (simp add: whenE_def injection_handler_throwError numeral_eqs)
                               apply (rule syscall_error_throwError_ccorres_n)
                               apply (simp add: syscall_error_to_H_cases)
                              apply (simp add: whenE_def injection_handler_returnOk
@@ -1017,13 +1012,11 @@ lemma decodeCNodeInvocation_ccorres:
           apply (simp del: Collect_const)
           apply (rule ccorres_Cond_rhs_Seq)
            apply (simp add: injection_handler_returnOk bindE_assoc
-                            injection_bindE[OF refl refl] split_def
-                            dc_def[symmetric])
+                            injection_bindE[OF refl refl] split_def)
            apply (rule ccorres_split_throws)
             apply (rule ccorres_rhs_assoc)+
             apply (ctac add: ccorres_injection_handler_csum1 [OF ensureEmptySlot_ccorres])
-               apply (simp add: ccorres_invocationCatch_Inr performInvocation_def
-                                dc_def[symmetric] bindE_assoc)
+               apply (simp add: ccorres_invocationCatch_Inr performInvocation_def bindE_assoc)
                apply (ctac add: setThreadState_ccorres)
                  apply (ctac(no_vcg) add: invokeCNodeSaveCaller_ccorres)
                    apply (rule ccorres_alternative2)
@@ -1032,7 +1025,7 @@ lemma decodeCNodeInvocation_ccorres:
                  apply (wp sts_valid_pspace_hangers)+
                apply (simp add: Collect_const_mem)
                apply (vcg exspec=setThreadState_modifies)
-              apply (simp add: dc_def[symmetric])
+              apply simp
               apply (rule ccorres_split_throws)
                apply (rule ccorres_return_C_errorE, simp+)[1]
               apply vcg
@@ -1062,8 +1055,7 @@ lemma decodeCNodeInvocation_ccorres:
                                in ccorres_gen_asm2)
                 apply (simp del: Collect_const)
                 apply (rule ccorres_Cond_rhs_Seq)
-                 apply (simp add: unlessE_def whenE_def injection_handler_throwError
-                                  dc_def[symmetric] from_bool_0)
+                 apply (simp add: unlessE_def whenE_def injection_handler_throwError from_bool_0)
                  apply (rule syscall_error_throwError_ccorres_n)
                  apply (simp add: syscall_error_to_H_cases)
                 apply (simp add: unlessE_def whenE_def injection_handler_returnOk
@@ -1107,12 +1099,10 @@ lemma decodeCNodeInvocation_ccorres:
             apply (simp add: throwError_def return_def exception_defs
                              syscall_error_rel_def syscall_error_to_H_cases)
             apply clarsimp
-           apply (simp add: invocationCatch_use_injection_handler
-                                  [symmetric, unfolded o_def]
+           apply (simp add: invocationCatch_use_injection_handler[symmetric, unfolded o_def]
                        del: Collect_const)
            apply csymbr
            apply (simp add: interpret_excaps_test_null excaps_map_def
-                            if_1_0_0 dc_def[symmetric]
                        del: Collect_const)
            apply (rule ccorres_Cond_rhs_Seq)
             apply (simp add: throwError_bind invocationCatch_def)
@@ -1172,8 +1162,7 @@ lemma decodeCNodeInvocation_ccorres:
                                            del: Collect_const)
                                apply csymbr
                                apply (rule ccorres_Cond_rhs_Seq)
-                                apply (simp add: whenE_def injection_handler_throwError
-                                                 dc_def[symmetric])
+                                apply (simp add: whenE_def injection_handler_throwError)
                                 apply (rule syscall_error_throwError_ccorres_n)
                                 apply (simp add: syscall_error_to_H_cases)
                                apply (simp add: whenE_def[where P=False] injection_handler_returnOk
@@ -1235,8 +1224,7 @@ lemma decodeCNodeInvocation_ccorres:
                                         apply csymbr
                                         apply (simp add: cap_get_tag_NullCap del: Collect_const)
                                         apply (rule ccorres_Cond_rhs_Seq)
-                                         apply (simp add: whenE_def injection_handler_throwError
-                                                          dc_def[symmetric])
+                                         apply (simp add: whenE_def injection_handler_throwError)
                                          apply (rule syscall_error_throwError_ccorres_n)
                                          apply (simp add: syscall_error_to_H_cases)
                                         apply (simp add: whenE_def[where P=False] injection_handler_returnOk
@@ -1244,8 +1232,7 @@ lemma decodeCNodeInvocation_ccorres:
                                         apply csymbr
                                         apply (simp add: cap_get_tag_NullCap del: Collect_const)
                                         apply (rule ccorres_Cond_rhs_Seq)
-                                         apply (simp add: whenE_def injection_handler_throwError
-                                                          dc_def[symmetric])
+                                         apply (simp add: whenE_def injection_handler_throwError)
                                          apply (rule syscall_error_throwError_ccorres_n)
                                          apply (simp add: syscall_error_to_H_cases)
                                         apply (simp add: whenE_def injection_handler_returnOk
@@ -1466,7 +1453,7 @@ lemma seL4_MessageInfo_lift_def2:
 
 lemma globals_update_id:
   "globals_update (t_hrs_'_update (hrs_htd_update id)) x = x"
-   by (simp add:id_def hrs_htd_update_def)
+   by (simp add: hrs_htd_update_def)
 
 lemma getObjectSize_spec:
   "\<forall>s. \<Gamma>\<turnstile>\<lbrace>s. \<acute>t \<le> of_nat (length (enum::object_type list) - 1)\<rbrace> Call getObjectSize_'proc
@@ -1521,7 +1508,7 @@ shows
  "\<lbrakk>ctes_of (s::kernel_state) (ptr_val p) = Some cte; is_aligned ptr bits; bits < word_bits;
   {ptr..ptr + 2 ^ bits - 1} \<inter> {ptr_val p..ptr_val p + mask cteSizeBits} = {}; ((clift hp) :: (cte_C ptr \<rightharpoonup> cte_C)) p = Some to\<rbrakk> \<Longrightarrow>
   (clift (hrs_htd_update (typ_clear_region ptr bits) hp) :: (cte_C ptr \<rightharpoonup> cte_C)) p = Some to"
-   apply (clarsimp simp:lift_t_def lift_typ_heap_def Fun.comp_def restrict_map_def split:if_splits)
+   apply (clarsimp simp:lift_t_def lift_typ_heap_def restrict_map_def split:if_splits)
    apply (intro conjI impI)
    apply (case_tac hp)
     apply (clarsimp simp:typ_clear_region_def hrs_htd_update_def)
@@ -1829,8 +1816,7 @@ lemma resetUntypedCap_ccorres:
      apply (rule ccorres_Guard_Seq[where S=UNIV])?
      apply (rule ccorres_rhs_assoc2)
      apply (rule ccorres_split_nothrow)
-         apply (rule_tac idx="capFreeIndex (cteCap cte)"
-           in deleteObjects_ccorres[where p=slot, unfolded o_def])
+         apply (rule_tac idx="capFreeIndex (cteCap cte)" in deleteObjects_ccorres[where p=slot])
         apply ceqv
        apply clarsimp
        apply (simp only: ccorres_seq_cond_raise)
@@ -2978,8 +2964,8 @@ lemma decodeUntypedInvocation_ccorres_helper:
                                         [OF lookupTargetSlot_ccorres,
                                             unfolded lookupTargetSlot_def])
                         apply (simp add: injection_liftE[OF refl])
-                        apply (simp add: liftE_liftM o_def split_def withoutFailure_def
-                                         hd_drop_conv_nth2 numeral_eqs[symmetric])
+                        apply (simp add: liftE_liftM split_def hd_drop_conv_nth2
+                                   cong: ccorres_all_cong)
                         apply (rule ccorres_nohs)
                         apply (rule ccorres_getSlotCap_cte_at)
                         apply (rule ccorres_move_c_guard_cte)
@@ -3202,8 +3188,7 @@ lemma decodeUntypedInvocation_ccorres_helper:
                                                        performInvocation_def liftE_bindE bind_assoc)
                              apply (ctac add: setThreadState_ccorres)
                                apply (rule ccorres_trim_returnE, (simp (no_asm))+)
-                               apply (simp (no_asm) add: o_def dc_def[symmetric] bindE_assoc
-                                                         id_def[symmetric] bind_bindE_assoc)
+                               apply (simp (no_asm) add: bindE_assoc bind_bindE_assoc)
                                apply (rule ccorres_seq_skip'[THEN iffD1])
                                apply (ctac(no_vcg) add: invokeUntyped_Retype_ccorres[where start = "args!4"])
                                  apply (rule ccorres_alternative2)
@@ -3252,7 +3237,7 @@ lemma decodeUntypedInvocation_ccorres_helper:
                       apply vcg
                      apply (rule ccorres_guard_imp
                          [where Q =\<top> and Q' = UNIV,rotated],assumption+)
-                     apply (simp add: o_def)
+                     apply simp
                     apply (simp add: liftE_validE)
                     apply (rule checkFreeIndex_wp)
                    apply (clarsimp simp: ccap_relation_untyped_CL_simps shiftL_nat cap_get_tag_isCap
@@ -3319,7 +3304,7 @@ lemma decodeUntypedInvocation_ccorres_helper:
                    apply (rule validE_R_validE)
                    apply (wp injection_wp_E[OF refl])
                   apply clarsimp
-                 apply (simp add: ccHoarePost_def xfdc_def)
+                 apply (simp add: ccHoarePost_def)
                  apply (simp only: whileAnno_def[where I=UNIV and V=UNIV, symmetric])
                  apply (rule_tac V=UNIV
                                 in HoarePartial.reannotateWhileNoGuard)
@@ -3449,7 +3434,7 @@ shows
   apply (rule ccorres_guard_imp2)
    apply (rule monadic_rewrite_ccorres_assemble)
     apply (rule_tac isBlocking=isBlocking and isCall=isCall and buffer=buffer
-                in decodeUntypedInvocation_ccorres_helper[unfolded K_def])
+                in decodeUntypedInvocation_ccorres_helper)
     apply assumption
    apply (rule monadic_rewrite_trans[rotated])
     apply (rule monadic_rewrite_bind_head)

--- a/proof/crefine/RISCV64/IpcCancel_C.thy
+++ b/proof/crefine/RISCV64/IpcCancel_C.thy
@@ -211,7 +211,7 @@ lemma cancelSignal_ccorres_helper:
    apply (drule (2) ntfn_to_ep_queue)
    apply (simp add: tcb_queue_relation'_def)
   apply (clarsimp simp: typ_heap_simps cong: imp_cong split del: if_split)
-  apply (frule null_ep_queue [simplified Fun.comp_def])
+  apply (frule null_ep_queue [simplified comp_def])
   apply (intro impI conjI allI)
    \<comment> \<open>empty case\<close>
    apply clarsimp
@@ -1039,7 +1039,7 @@ proof -
             apply (rule ccorres_split_nothrow_novcg_dc)
                prefer 2
                apply (rule ccorres_move_c_guard_tcb)
-               apply (simp only: dc_def[symmetric])
+               apply simp
                apply ctac
               prefer 2
               apply (wp, clarsimp, wp+)
@@ -1160,7 +1160,7 @@ proof -
          apply simp
          apply (wp threadGet_wp)
         apply vcg
-       apply (rule ccorres_return_Skip[unfolded dc_def])
+       apply (rule ccorres_return_Skip)
       apply simp
       apply (wp threadGet_wp)
      apply vcg
@@ -1397,7 +1397,6 @@ proof -
           apply (rule ccorres_split_nothrow_novcg_dc)
              prefer 2
              apply (rule ccorres_move_c_guard_tcb)
-             apply (simp only: dc_def[symmetric])
              apply ctac
             prefer 2
             apply (wp, clarsimp, wp+)
@@ -1670,7 +1669,7 @@ proof -
        apply simp
        apply (wp threadGet_wp)
       apply vcg
-     apply (rule ccorres_return_Skip[unfolded dc_def])
+     apply (rule ccorres_return_Skip)
     apply simp
     apply (wp threadGet_wp)
    apply vcg
@@ -1802,7 +1801,6 @@ proof -
           apply (rule ccorres_split_nothrow_novcg_dc)
              prefer 2
              apply (rule ccorres_move_c_guard_tcb)
-             apply (simp only: dc_def[symmetric])
              apply ctac
             prefer 2
             apply (wp, clarsimp, wp+)
@@ -1908,7 +1906,7 @@ proof -
        apply simp
        apply (wp threadGet_wp)
       apply vcg
-     apply (rule ccorres_return_Skip[unfolded dc_def])
+     apply (rule ccorres_return_Skip)
     apply simp
     apply (wp threadGet_wp)
    apply vcg
@@ -2266,11 +2264,6 @@ lemma getCurDomain_maxDom_ccorres_dom_':
                         rf_sr_ksCurDomain)
   done
 
-lemma rf_sr_cscheduler_action_relation:
-  "(s, s') \<in> rf_sr
-   \<Longrightarrow> cscheduler_action_relation (ksSchedulerAction s) (ksSchedulerAction_' (globals s'))"
-  by (clarsimp simp: rf_sr_def cstate_relation_def Let_def)
-
 lemma threadGet_get_obj_at'_has_domain:
   "\<lbrace> tcb_at' t \<rbrace> threadGet tcbDomain t \<lbrace>\<lambda>rv. obj_at' (\<lambda>tcb. rv = tcbDomain tcb) t\<rbrace>"
   by (wp threadGet_obj_at') (simp add: obj_at'_def)
@@ -2287,7 +2280,6 @@ lemma possibleSwitchTo_ccorres:
      (Call possibleSwitchTo_'proc)"
   supply if_split [split del]
   supply Collect_const [simp del]
-  supply dc_simp [simp del]
   supply prio_and_dom_limit_helpers[simp]
   (* FIXME: these should likely be in simpset for CRefine, or even in general *)
   supply from_bool_eq_if[simp] from_bool_eq_if'[simp] from_bool_0[simp]
@@ -2312,7 +2304,7 @@ lemma possibleSwitchTo_ccorres:
       apply (ctac add: tcbSchedEnqueue_ccorres)
      apply (rule_tac R="\<lambda>s. sact = ksSchedulerAction s \<and> weak_sch_act_wf (ksSchedulerAction s) s"
                      in ccorres_cond)
-       apply (fastforce dest!: rf_sr_cscheduler_action_relation pred_tcb_at' tcb_at_not_NULL
+       apply (fastforce dest!: rf_sr_sched_action_relation pred_tcb_at' tcb_at_not_NULL
                         simp: cscheduler_action_relation_def weak_sch_act_wf_def
                         split: scheduler_action.splits)
       apply (ctac add: rescheduleRequired_ccorres)
@@ -2901,7 +2893,7 @@ lemma cancelIPC_ccorres_helper:
   apply (rule allI)
   apply (rule conseqPre)
    apply vcg
-  apply (clarsimp split del: if_split simp del: comp_def)
+  apply (clarsimp split del: if_split)
   apply (frule (2) ep_blocked_in_queueD)
   apply (frule (1) ko_at_valid_ep' [OF _ invs_valid_objs'])
   apply (elim conjE)
@@ -2919,7 +2911,7 @@ lemma cancelIPC_ccorres_helper:
        apply assumption+
    apply (drule (2) ep_to_ep_queue)
    apply (simp add: tcb_queue_relation'_def)
-  apply (clarsimp simp: typ_heap_simps cong: imp_cong split del: if_split simp del: comp_def)
+  apply (clarsimp simp: typ_heap_simps cong: imp_cong split del: if_split)
   apply (frule null_ep_queue [simplified comp_def] null_ep_queue)
   apply (intro impI conjI allI)
    \<comment> \<open>empty case\<close>
@@ -3073,7 +3065,6 @@ lemma cancelIPC_ccorres1:
      apply wpc
             \<comment> \<open>BlockedOnReceive\<close>
             apply (simp add: word_sle_def "StrictC'_thread_state_defs" ccorres_cond_iffs cong: call_ignore_cong)
-            apply (fold dc_def)
             apply (rule ccorres_rhs_assoc)+
             apply csymbr
             apply csymbr
@@ -3102,11 +3093,9 @@ lemma cancelIPC_ccorres1:
            apply (simp add: "StrictC'_thread_state_defs" ccorres_cond_iffs
                             Collect_False Collect_True word_sle_def
                       cong: call_ignore_cong del: Collect_const)
-           apply (fold dc_def)
            apply (rule ccorres_rhs_assoc)+
            apply csymbr
            apply csymbr
-           apply (unfold comp_def)[1]
            apply csymbr
            apply (rule ccorres_move_c_guard_tcb)+
            apply (rule ccorres_split_nothrow_novcg)
@@ -3142,14 +3131,12 @@ lemma cancelIPC_ccorres1:
                 apply (rule ccorres_Cond_rhs)
                  apply (simp add: nullPointer_def when_def)
                  apply (rule ccorres_symb_exec_l[OF _ _ _ empty_fail_stateAssert])
-                   apply (simp only: dc_def[symmetric])
                    apply (rule ccorres_symb_exec_r)
                      apply (ctac add: cteDeleteOne_ccorres[where w1="scast cap_reply_cap"])
                     apply vcg
                    apply (rule conseqPre, vcg, clarsimp simp: rf_sr_def
                        gs_set_assn_Delete_cstate_relation[unfolded o_def])
                   apply (wp | simp)+
-                apply (simp add: when_def nullPointer_def dc_def[symmetric])
                 apply (rule ccorres_return_Skip)
                apply (simp add: guard_is_UNIV_def ghost_assertion_data_get_def
                                 ghost_assertion_data_set_def cap_tag_defs)
@@ -3162,7 +3149,8 @@ lemma cancelIPC_ccorres1:
            apply (clarsimp simp add: guard_is_UNIV_def tcbReplySlot_def
                         Kernel_C.tcbReply_def tcbCNodeEntries_def)
           \<comment> \<open>BlockedOnNotification\<close>
-          apply (simp add: word_sle_def "StrictC'_thread_state_defs" ccorres_cond_iffs dc_def [symmetric] cong: call_ignore_cong)
+          apply (simp add: word_sle_def "StrictC'_thread_state_defs" ccorres_cond_iffs
+                     cong: call_ignore_cong)
           apply (rule ccorres_symb_exec_r)
             apply (ctac (no_vcg))
            apply clarsimp
@@ -3171,10 +3159,12 @@ lemma cancelIPC_ccorres1:
           apply (rule conseqPre, vcg)
           apply clarsimp
          \<comment> \<open>Running, Inactive, and Idle\<close>
-         apply (simp add: word_sle_def "StrictC'_thread_state_defs" ccorres_cond_iffs dc_def [symmetric] cong: call_ignore_cong,
+         apply (simp add: word_sle_def "StrictC'_thread_state_defs" ccorres_cond_iffs
+                    cong: call_ignore_cong,
                 rule ccorres_return_Skip)+
       \<comment> \<open>BlockedOnSend\<close>
-      apply (simp add: word_sle_def "StrictC'_thread_state_defs" ccorres_cond_iffs dc_def [symmetric] cong: call_ignore_cong)
+      apply (simp add: word_sle_def "StrictC'_thread_state_defs" ccorres_cond_iffs
+                 cong: call_ignore_cong)
       \<comment> \<open>clag\<close>
       apply (rule ccorres_rhs_assoc)+
       apply csymbr
@@ -3200,7 +3190,8 @@ lemma cancelIPC_ccorres1:
       apply (rule conseqPre, vcg)
       apply clarsimp
   \<comment> \<open>Restart\<close>
-     apply (simp add: word_sle_def "StrictC'_thread_state_defs" ccorres_cond_iffs dc_def [symmetric] cong: call_ignore_cong,
+     apply (simp add: word_sle_def "StrictC'_thread_state_defs" ccorres_cond_iffs
+                cong: call_ignore_cong,
             rule ccorres_return_Skip)
     \<comment> \<open>Post wp proofs\<close>
     apply vcg

--- a/proof/crefine/RISCV64/IsolatedThreadAction.thy
+++ b/proof/crefine/RISCV64/IsolatedThreadAction.thy
@@ -460,7 +460,7 @@ lemma modify_isolatable:
                    liftM_def bind_assoc)
   apply (clarsimp simp: monadic_rewrite_def exec_gets
                    getSchedulerAction_def)
-  apply (simp add: simpler_modify_def o_def)
+  apply (simp add: simpler_modify_def)
   apply (subst swap)
    apply (simp add: obj_at_partial_overwrite_If)
   apply (simp add: ksPSpace_update_partial_id o_def)
@@ -1148,8 +1148,7 @@ lemma setCTE_isolatable:
    apply (erule notE[rotated], erule (3) tcb_ctes_clear[rotated])
   apply (simp add: select_f_returns select_f_asserts split: if_split)
   apply (intro conjI impI)
-    apply (clarsimp simp: simpler_modify_def fun_eq_iff
-                          partial_overwrite_fun_upd2 o_def
+    apply (clarsimp simp: simpler_modify_def fun_eq_iff partial_overwrite_fun_upd2
                   intro!: kernel_state.fold_congs[OF refl refl])
     apply (clarsimp simp: obj_at'_def projectKOs objBits_simps)
     apply (erule notE[rotated], rule tcb_ctes_clear[rotated 2], assumption+)

--- a/proof/crefine/RISCV64/Recycle_C.thy
+++ b/proof/crefine/RISCV64/Recycle_C.thy
@@ -818,13 +818,13 @@ lemma cancelBadgedSends_ccorres:
                      split: Structures_H.endpoint.split_asm)
      apply ceqv
     apply wpc
-      apply (simp add: dc_def[symmetric] ccorres_cond_iffs)
+      apply (simp add: ccorres_cond_iffs)
       apply (rule ccorres_return_Skip)
-     apply (simp add: dc_def[symmetric] ccorres_cond_iffs)
+     apply (simp add: ccorres_cond_iffs)
      apply (rule ccorres_return_Skip)
     apply (rename_tac list)
     apply (simp add: Collect_True Collect_False endpoint_state_defs
-                     ccorres_cond_iffs dc_def[symmetric]
+                     ccorres_cond_iffs
                 del: Collect_const cong: call_ignore_cong)
     apply (rule ccorres_rhs_assoc)+
     apply (csymbr, csymbr)
@@ -909,7 +909,7 @@ lemma cancelBadgedSends_ccorres:
                 subgoal by (simp add: mask_def canonical_bit_def)
                subgoal by (auto split: if_split)
               subgoal by simp
-             apply (ctac add: rescheduleRequired_ccorres[unfolded dc_def])
+             apply (ctac add: rescheduleRequired_ccorres)
             apply (rule hoare_pre, wp weak_sch_act_wf_lift_linear set_ep_valid_objs')
             apply (clarsimp simp: weak_sch_act_wf_def sch_act_wf_def)
             apply (fastforce simp: valid_ep'_def pred_tcb_at' split: list.splits)
@@ -919,7 +919,7 @@ lemma cancelBadgedSends_ccorres:
           apply (rule iffD1 [OF ccorres_expand_while_iff_Seq])
           apply (rule ccorres_init_tmp_lift2, ceqv)
           apply (rule ccorres_guard_imp2)
-           apply (simp add: bind_assoc dc_def[symmetric]
+           apply (simp add: bind_assoc
                        del: Collect_const)
            apply (rule ccorres_cond_true)
            apply (rule ccorres_rhs_assoc)+
@@ -946,7 +946,7 @@ lemma cancelBadgedSends_ccorres:
             apply ceqv
            apply (rule_tac P="ret__unsigned_longlong=blockingIPCBadge rva" in ccorres_gen_asm2)
            apply (rule ccorres_if_bind, rule ccorres_if_lhs)
-            apply (simp add: bind_assoc dc_def[symmetric])
+            apply (simp add: bind_assoc)
             apply (rule ccorres_rhs_assoc)+
             apply (ctac add: setThreadState_ccorres)
               apply (ctac add: tcbSchedEnqueue_ccorres)
@@ -1015,9 +1015,9 @@ lemma cancelBadgedSends_ccorres:
              apply (wp hoare_vcg_const_Ball_lift sts_st_tcb_at'_cases
                        sts_sch_act sts_valid_queues setThreadState_oa_queued)
             apply (vcg exspec=setThreadState_cslift_spec)
-           apply (simp add: ccorres_cond_iffs dc_def[symmetric])
+           apply (simp add: ccorres_cond_iffs)
            apply (rule ccorres_symb_exec_r2)
-             apply (drule_tac x="x @ [a]" in spec, simp add: dc_def[symmetric])
+             apply (drule_tac x="x @ [a]" in spec, simp)
             apply vcg
            apply (vcg spec=modifies)
           apply (thin_tac "\<forall>x. P x" for P)

--- a/proof/crefine/RISCV64/Refine_C.thy
+++ b/proof/crefine/RISCV64/Refine_C.thy
@@ -608,9 +608,9 @@ lemma callKernel_withFastpath_corres_C:
    apply (rule ccorres_rhs_assoc)+
    apply (rule ccorres_symb_exec_r)+
        apply (rule ccorres_Cond_rhs)
-        apply (simp add: dc_def[symmetric])
+        apply simp
         apply (ctac add: ccorres_get_registers[OF fastpath_call_ccorres_callKernel])
-       apply (simp add: dc_def[symmetric])
+       apply simp
        apply (ctac add: ccorres_get_registers[OF fastpath_reply_recv_ccorres_callKernel])
       apply vcg
      apply (rule conseqPre, vcg, clarsimp)
@@ -694,13 +694,13 @@ lemma entry_corres_C:
          apply simp
         apply (rule corres_split)
 (* FIXME: fastpath
-           apply (rule corres_cases[where R=fp], simp_all add: dc_def[symmetric])[1]
-            apply (rule callKernel_withFastpath_corres_C, simp)
+           apply (rule corres_cases[where R=fp]; simp)
+            apply (rule callKernel_withFastpath_corres_C)
 *)
-           apply (rule callKernel_corres_C[unfolded dc_def], simp)
+           apply (rule callKernel_corres_C)
           apply (rule corres_split[where P=\<top> and P'=\<top> and r'="\<lambda>t t'. t' = tcb_ptr_to_ctcb_ptr t"])
              apply (clarsimp simp: rf_sr_def cstate_relation_def Let_def)
-            apply (rule getContext_corres[unfolded o_def], simp)
+            apply (rule getContext_corres, simp)
            apply (wp threadSet_all_invs_triv' callKernel_cur)+
    apply (clarsimp simp: all_invs'_def invs'_def cur_tcb'_def valid_state'_def)
   apply simp
@@ -897,7 +897,7 @@ lemma do_user_op_corres_C:
                apply (clarsimp simp: rf_sr_def cstate_relation_def Let_def
                                cpspace_relation_def)
                apply (drule(1) device_mem_C_relation[symmetric])
-               apply (simp add: comp_def)
+               apply simp
               apply (rule_tac P=valid_state' and P'=\<top> and r'="(=)" in corres_split)
                  apply (clarsimp simp: cstate_relation_def rf_sr_def
                    Let_def cmachine_state_relation_def)

--- a/proof/crefine/RISCV64/Retype_C.thy
+++ b/proof/crefine/RISCV64/Retype_C.thy
@@ -1097,7 +1097,7 @@ lemma ptr_add_to_new_cap_addrs:
   shows "(CTypesDefs.ptr_add (Ptr ptr :: 'a :: mem_type ptr) \<circ> of_nat) ` {k. k < n}
    = Ptr ` set (new_cap_addrs n ptr ko)"
   unfolding new_cap_addrs_def
-  apply (simp add: comp_def image_image shiftl_t2n size_of_m field_simps)
+  apply (simp add: image_image shiftl_t2n size_of_m field_simps)
   apply (clarsimp simp: atLeastLessThan_def lessThan_def)
   done
 
@@ -3091,8 +3091,7 @@ proof -
       apply (simp add: hrs_mem_def, subst rep0)
       apply (simp only: take_replicate, simp add: cte_C_size objBits_simps')
      apply (simp add: cte_C_size objBits_simps')
-    apply (simp add: fun_eq_iff o_def
-              split: if_split)
+    apply (simp add: fun_eq_iff split: if_split)
     apply (simp add: hrs_comm packed_heap_update_collapse
                      typ_heap_simps)
     apply (subst clift_heap_update_same_td_name', simp_all,
@@ -3768,7 +3767,7 @@ lemma mapM_x_storeWord_step:
   apply (subst if_not_P)
    apply (subst not_less)
    apply (erule is_aligned_no_overflow)
-   apply (simp add: mapM_x_map comp_def upto_enum_word del: upt.simps)
+   apply (simp add: mapM_x_map upto_enum_word del: upt.simps)
    apply (subst div_power_helper_64 [OF sz2, simplified])
     apply assumption
    apply (simp add: word_bits_def unat_minus_one del: upt.simps)
@@ -4342,12 +4341,10 @@ lemma ccorres_placeNewObject_endpoint:
      apply (clarsimp simp: new_cap_addrs_def)
      apply (cut_tac createObjects_ccorres_ep [where ptr=regionBase and n="1" and sz="objBitsKO (KOEndpoint makeObject)"])
      apply (erule_tac x=\<sigma> in allE, erule_tac x=x in allE)
-     apply (clarsimp elim!:is_aligned_weaken simp: objBitsKO_def word_bits_def)+
-     apply (clarsimp simp: split_def Let_def
-         Fun.comp_def rf_sr_def new_cap_addrs_def
-         region_actually_is_bytes ptr_retyps_gen_def
-         objBits_simps
-         elim!: rsubst[where P="cstate_relation s'" for s'])
+     apply (clarsimp elim!: is_aligned_weaken simp: objBitsKO_def word_bits_def)+
+     apply (clarsimp simp: split_def Let_def rf_sr_def new_cap_addrs_def
+                           region_actually_is_bytes ptr_retyps_gen_def objBits_simps
+                    elim!: rsubst[where P="cstate_relation s'" for s'])
     apply (clarsimp simp: word_bits_conv)
    apply (clarsimp simp: range_cover.aligned objBits_simps)
   apply (clarsimp simp: no_fail_def)
@@ -4380,12 +4377,10 @@ lemma ccorres_placeNewObject_notification:
      apply (clarsimp simp: new_cap_addrs_def)
      apply (cut_tac createObjects_ccorres_ntfn [where ptr=regionBase and n="1" and sz="objBitsKO (KONotification makeObject)"])
      apply (erule_tac x=\<sigma> in allE, erule_tac x=x in allE)
-     apply (clarsimp elim!:is_aligned_weaken simp: objBitsKO_def word_bits_def)+
-     apply (clarsimp simp: split_def Let_def
-         Fun.comp_def rf_sr_def new_cap_addrs_def
-         region_actually_is_bytes ptr_retyps_gen_def
-         objBits_simps'
-         elim!: rsubst[where P="cstate_relation s'" for s'])
+     apply (clarsimp elim!: is_aligned_weaken simp: objBitsKO_def word_bits_def)+
+     apply (clarsimp simp: split_def Let_def rf_sr_def new_cap_addrs_def
+                           region_actually_is_bytes ptr_retyps_gen_def objBits_simps'
+                    elim!: rsubst[where P="cstate_relation s'" for s'])
     apply (clarsimp simp: word_bits_conv)
    apply (clarsimp simp: range_cover.aligned objBits_simps)
   apply (clarsimp simp: no_fail_def)
@@ -4444,11 +4439,10 @@ lemma ccorres_placeNewObject_captable:
       apply (clarsimp simp: split_def new_cap_addrs_def)
       apply (cut_tac createObjects_ccorres_cte [where ptr=regionBase and n="2 ^ unat userSize" and sz="unat userSize + objBitsKO (KOCTE makeObject)"])
       apply (erule_tac x=\<sigma> in allE, erule_tac x=x in allE)
-      apply (clarsimp elim!:is_aligned_weaken simp: objBitsKO_def word_bits_def cteSizeBits_def)+
-      apply (clarsimp simp: split_def objBitsKO_def
-          Fun.comp_def rf_sr_def split_def Let_def cteSizeBits_def
-          new_cap_addrs_def field_simps power_add ptr_retyps_gen_def
-                   elim!: rsubst[where P="cstate_relation s'" for s'])
+      apply (clarsimp elim!: is_aligned_weaken simp: objBitsKO_def word_bits_def cteSizeBits_def)+
+      apply (clarsimp simp: split_def objBitsKO_def rf_sr_def split_def Let_def cteSizeBits_def
+                            new_cap_addrs_def field_simps power_add ptr_retyps_gen_def
+                     elim!: rsubst[where P="cstate_relation s'" for s'])
      apply (clarsimp simp: word_bits_conv range_cover_def)
     apply (clarsimp simp: objBitsKO_def objBits_simps' range_cover.aligned)
    apply (clarsimp simp: no_fail_def)
@@ -4505,8 +4499,8 @@ lemma Arch_initContext_spec':
   apply (rule allI, rule conseqPre)
    apply (rule hoarep.Catch[rotated], vcg)
    apply (rule conseqPost[where A'="{}" and Q'=Q and Q=Q for Q, simplified])
-   apply ((vcg ,
-           clarsimp simp: hrs_mem_update_compose h_val_id packed_heap_update_collapse o_def
+   apply ((vcg,
+           clarsimp simp: hrs_mem_update_compose h_val_id packed_heap_update_collapse
                           array_updates_rev_app))+
   apply (auto simp: h_val_heap_same_hrs_mem_update_typ_disj[OF h_t_valid_c_guard_field _ tag_disj_via_td_name]
                     export_tag_adjust_ti typ_uinfo_t_def array_updates_rev
@@ -4554,7 +4548,6 @@ proof -
     apply (rule ptr_retyp_h_t_valid)
     apply simp
    apply (rule tcb_ptr_orth_cte_ptrs')
-  apply (simp add: o_def)
   apply (intro conjI allI impI)
      apply (clarsimp simp: rf_sr_def cstate_relation_def Let_def
                            kernel_data_refs_domain_eq_rotate)
@@ -4611,11 +4604,11 @@ lemma placeNewObject_pte:
       apply (clarsimp simp: split_def new_cap_addrs_def)
       apply (cut_tac s=\<sigma> in createObjects_ccorres_pte [where ptr=regionBase and sz=pageBits])
       apply (erule_tac x=\<sigma> in allE, erule_tac x=x in allE)
-      apply (clarsimp elim!:is_aligned_weaken simp: objBitsKO_def word_bits_def)+
+      apply (clarsimp elim!: is_aligned_weaken simp: objBitsKO_def word_bits_def)+
       apply (clarsimp simp: split_def objBitsKO_def archObjSize_def
-          Fun.comp_def rf_sr_def split_def Let_def ptr_retyps_gen_def
-          new_cap_addrs_def field_simps power_add
-          cong: globals.unfold_congs)
+                            rf_sr_def split_def Let_def ptr_retyps_gen_def
+                            new_cap_addrs_def field_simps power_add
+                      cong: globals.unfold_congs)
       apply (simp add: Int_ac bit_simps)
      apply (clarsimp simp: word_bits_conv range_cover_def archObjSize_def bit_simps)
     apply (clarsimp simp: objBitsKO_def range_cover.aligned archObjSize_def bit_simps)
@@ -5341,7 +5334,7 @@ proof -
              apply (simp add: obj_at'_real_def)
              apply (wp placeNewObject_ko_wp_at')
             apply (vcg exspec=Arch_initContext_modifies)
-           apply (clarsimp simp: dc_def)
+           apply clarsimp
            apply vcg
           apply (rule conseqPre, vcg, clarsimp)
          apply (clarsimp simp: createObject_hs_preconds_def
@@ -5519,7 +5512,7 @@ lemma ccorres_guard_impR:
 lemma typ_clear_region_dom:
  "dom (clift (hrs_htd_update (typ_clear_region ptr bits) hp) :: 'b :: mem_type typ_heap)
   \<subseteq>  dom ((clift hp) :: 'b :: mem_type typ_heap)"
-   apply (clarsimp simp:lift_t_def lift_typ_heap_def Fun.comp_def)
+   apply (clarsimp simp:lift_t_def lift_typ_heap_def comp_def)
    apply (clarsimp simp:lift_state_def)
    apply (case_tac hp)
    apply (clarsimp simp:)
@@ -7275,7 +7268,7 @@ shows  "ccorres dc xfdc
            apply (rule_tac P="rv' = of_nat n" in ccorres_gen_asm2, simp)
            apply (rule ccorres_rhs_assoc)+
            apply (rule ccorres_add_return)
-           apply (simp only: dc_def[symmetric] hrs_htd_update)
+           apply (simp only: hrs_htd_update)
            apply ((rule ccorres_Guard_Seq[where S=UNIV])+)?
            apply (rule ccorres_split_nothrow,
                 rule_tac S="{ptr .. ptr + of_nat (length destSlots) * 2^ (getObjectSize newType userSize) - 1}"
@@ -7634,7 +7627,7 @@ shows  "ccorres dc xfdc
   apply (simp add: o_def)
   apply (case_tac newType,
          simp_all add: object_type_from_H_def Kernel_C_defs
-                       nAPIObjects_def APIType_capBits_def o_def split:apiobject_type.splits)[1]
+                       nAPIObjects_def APIType_capBits_def split:apiobject_type.splits)[1]
          subgoal by (simp add:unat_eq_def word_unat.Rep_inverse' word_less_nat_alt)
         subgoal by (clarsimp simp:objBits_simps', unat_arith)
        apply (fold_subgoals (prefix))[3]

--- a/proof/crefine/RISCV64/SR_lemmas_C.thy
+++ b/proof/crefine/RISCV64/SR_lemmas_C.thy
@@ -645,7 +645,6 @@ proof (rule cor_map_relI [OF map_option_eq_dom_eq])
 
   hence "tcb_no_ctes_proj tcb = tcb_no_ctes_proj tcb'" using om
     apply -
-    apply (simp add: o_def)
     apply (drule fun_cong [where x = x])
     apply simp
     done

--- a/proof/crefine/RISCV64/Schedule_C.thy
+++ b/proof/crefine/RISCV64/Schedule_C.thy
@@ -186,14 +186,14 @@ lemmas ccorres_remove_tail_Guard_Skip
     = ccorres_abstract[where xf'="\<lambda>_. ()", OF ceqv_remove_tail_Guard_Skip]
 
 lemma switchToThread_ccorres':
-  "ccorres (\<lambda>_ _. True) xfdc
+  "ccorres dc xfdc
            (all_invs_but_ct_idle_or_in_cur_domain' and tcb_at' t)
            (UNIV \<inter> \<lbrace>\<acute>thread = tcb_ptr_to_ctcb_ptr t\<rbrace>)
            hs
            (switchToThread t)
            (Call switchToThread_'proc)"
   apply (rule ccorres_guard_imp2)
-      apply (ctac (no_vcg) add: switchToThread_ccorres[simplified dc_def])
+      apply (ctac (no_vcg) add: switchToThread_ccorres)
      apply auto
   done
 
@@ -287,14 +287,14 @@ proof -
     apply (intro conjI impI)
        apply (fastforce dest: bitmapQ_from_bitmap_lookup simp: valid_bitmapQ_bitmapQ_simp)
       apply (fastforce dest: lookupBitmapPriority_obj_at'
-                       simp: pred_conj_def comp_def obj_at'_def st_tcb_at'_def)
+                       simp: pred_conj_def obj_at'_def st_tcb_at'_def)
      apply (fastforce dest: bitmapQ_from_bitmap_lookup simp: valid_bitmapQ_bitmapQ_simp)
-    apply (clarsimp simp: pred_conj_def comp_def obj_at'_def st_tcb_at'_def)
+    apply (clarsimp simp: pred_conj_def obj_at'_def st_tcb_at'_def)
     apply (clarsimp simp: not_less le_maxDomain_eq_less_numDomains)
     apply (prop_tac "ksCurDomain s = 0")
      using unsigned_eq_0_iff apply force
     apply (cut_tac s=s in lookupBitmapPriority_obj_at'; simp?)
-    apply (clarsimp simp: pred_conj_def comp_def obj_at'_def st_tcb_at'_def)
+    apply (clarsimp simp: pred_conj_def obj_at'_def st_tcb_at'_def)
     done
 qed
 
@@ -375,7 +375,6 @@ lemma isHighestPrio_ccorres:
            (isHighestPrio d p)
            (Call isHighestPrio_'proc)"
   supply Collect_const [simp del]
-  supply dc_simp [simp del]
   supply prio_and_dom_limit_helpers[simp]
   supply Collect_const_mem [simp]
   (* FIXME: these should likely be in simpset for CRefine, or even in general *)
@@ -416,7 +415,6 @@ lemma isHighestPrio_ccorres:
 lemma schedule_ccorres:
   "ccorres dc xfdc invs' UNIV [] schedule (Call schedule_'proc)"
   supply Collect_const [simp del]
-  supply dc_simp [simp del]
   supply prio_and_dom_limit_helpers[simp]
   supply Collect_const_mem [simp]
   (* FIXME: these should likely be in simpset for CRefine, or even in general *)
@@ -430,7 +428,7 @@ lemma schedule_ccorres:
      apply (rule ccorres_cond_false_seq)
      apply simp
      apply (rule_tac P=\<top> and P'="{s. ksSchedulerAction_' (globals s) = NULL }" in ccorres_from_vcg)
-     apply (clarsimp simp: dc_def return_def split: prod.splits)
+     apply (clarsimp simp: return_def split: prod.splits)
      apply (rule conseqPre, vcg, clarsimp)
     (* toplevel case: action is choose new thread *)
     apply (rule ccorres_cond_true_seq)
@@ -447,7 +445,7 @@ lemma schedule_ccorres:
          apply (ctac add: tcbSchedEnqueue_ccorres)
          apply (rule ccorres_from_vcg[where P=\<top> and P'=UNIV])
          apply (clarsimp, rule conseqPre, vcg)
-         apply (clarsimp simp: dc_def return_def)
+         apply (clarsimp simp: return_def)
         apply (rule ccorres_cond_true_seq)
         (* isolate haskell part before setting thread action *)
         apply (simp add: scheduleChooseNewThread_def)
@@ -475,7 +473,7 @@ lemma schedule_ccorres:
         apply (ctac add: tcbSchedEnqueue_ccorres)
         apply (rule ccorres_from_vcg[where P=\<top> and P'=UNIV])
         apply (clarsimp, rule conseqPre, vcg)
-        apply (clarsimp simp: dc_def return_def)
+        apply (clarsimp simp: return_def)
        apply (rule ccorres_cond_false_seq)
 
        apply (rule_tac xf'=was_runnable_' in ccorres_abstract, ceqv)
@@ -495,7 +493,7 @@ lemma schedule_ccorres:
          apply (rule ccorres_rhs_assoc2)
          apply (rule ccorres_rhs_assoc2)
          apply (rule_tac r'="\<lambda>rv rv'. rv = to_bool rv'" and xf'=fastfail_' in ccorres_split_nothrow)
-             apply (clarsimp simp: scheduleSwitchThreadFastfail_def dc_simp)
+             apply (clarsimp simp: scheduleSwitchThreadFastfail_def)
              apply (rule ccorres_cond_seq2[THEN iffD1])
              apply (rule_tac xf'=ret__int_' and val="from_bool (curThread = it)"
                       and R="\<lambda>s. it = ksIdleThread s \<and> curThread = ksCurThread s" and R'=UNIV
@@ -532,11 +530,10 @@ lemma schedule_ccorres:
                 apply (rule ccorres_move_c_guard_tcb)
                 apply (rule ccorres_add_return2)
                 apply (ctac add: isHighestPrio_ccorres, clarsimp)
-                  apply (clarsimp simp: to_bool_def)
                   apply (rule ccorres_inst[where P=\<top> and P'=UNIV])
                   apply (rule ccorres_return)
                   apply (rule conseqPre, vcg)
-                  apply clarsimp
+                  apply (clarsimp simp: to_bool_def)
                  apply (rule wp_post_taut)
                 apply (vcg exspec=isHighestPrio_modifies)
                apply (rule_tac P=\<top> and P'="{s. ret__int_' s = 0}" in ccorres_from_vcg)
@@ -636,13 +633,12 @@ lemma schedule_ccorres:
        apply (clarsimp simp: invs'_bitmapQ_no_L1_orphans invs_ksCurDomain_maxDomain')
        apply (fastforce dest: invs_sch_act_wf')
 
-      apply (wp | clarsimp simp: dc_def)+
+      apply wpsimp+
      apply (vcg exspec=tcbSchedEnqueue_modifies)
     apply wp
    apply vcg
 
-  apply (clarsimp simp: tcb_at_invs' rf_sr_ksCurThread if_apply_def2 invs_queues invs_valid_objs'
-                         dc_def)+
+  apply (clarsimp simp: tcb_at_invs' rf_sr_ksCurThread if_apply_def2 invs_queues invs_valid_objs')
   apply (frule invs_sch_act_wf')
   apply (frule tcb_at_invs')
   apply (rule conjI)
@@ -714,7 +710,7 @@ lemma timerTick_ccorres:
    apply (ctac add: get_tsType_ccorres2 [where f="\<lambda>s. ksCurThread_' (globals s)"])
      apply (rule ccorres_split_nothrow_novcg)
          apply wpc
-                apply (simp add: "StrictC'_thread_state_defs", rule ccorres_cond_false, rule ccorres_return_Skip[unfolded dc_def])+
+                apply (simp add: "StrictC'_thread_state_defs", rule ccorres_cond_false, rule ccorres_return_Skip)+
              (* thread_state.Running *)
              apply simp
              apply (rule ccorres_cond_true)
@@ -736,17 +732,17 @@ lemma timerTick_ccorres:
               apply (rule_tac P="cur_tcb'" and P'=\<top> in ccorres_move_c_guards(8))
                apply (clarsimp simp: cur_tcb'_def)
                apply (fastforce simp: rf_sr_def cstate_relation_def Let_def typ_heap_simps dest: tcb_at_h_t_valid)
-              apply (ctac add: threadSet_timeSlice_ccorres[unfolded dc_def])
+              apply (ctac add: threadSet_timeSlice_ccorres)
              apply (rule ccorres_rhs_assoc)+
              apply (ctac)
                apply simp
                apply (ctac (no_vcg) add: tcbSchedAppend_ccorres)
-                apply (ctac add: rescheduleRequired_ccorres[unfolded dc_def])
+                apply (ctac add: rescheduleRequired_ccorres)
                apply (wp weak_sch_act_wf_lift_linear threadSet_valid_queues
                          threadSet_pred_tcb_at_state tcbSchedAppend_valid_objs' threadSet_valid_objs' threadSet_tcbDomain_triv
                     | clarsimp simp: st_tcb_at'_def o_def split: if_splits)+
              apply (vcg exspec=tcbSchedDequeue_modifies)
-        apply (simp add: "StrictC'_thread_state_defs", rule ccorres_cond_false, rule ccorres_return_Skip[unfolded dc_def])+
+        apply (simp add: "StrictC'_thread_state_defs", rule ccorres_cond_false, rule ccorres_return_Skip)+
         apply ceqv
        apply (clarsimp simp: decDomainTime_def numDomains_sge_1_simp)
        apply (rule ccorres_when[where R=\<top>])
@@ -758,7 +754,6 @@ lemma timerTick_ccorres:
            apply (clarsimp simp: rf_sr_def cstate_relation_def Let_def
                                  carch_state_relation_def cmachine_state_relation_def)
           apply ceqv
-         apply (fold dc_def)
          apply (rule ccorres_pre_getDomainTime)
          apply (rename_tac rva rv'a rvb)
          apply (rule_tac P'="{s. ksDomainTime_' (globals s) = rvb}" in ccorres_inst, simp)
@@ -766,13 +761,13 @@ lemma timerTick_ccorres:
           apply clarsimp
           apply (rule ccorres_guard_imp2)
            apply (rule ccorres_cond_true)
-           apply (ctac add: rescheduleRequired_ccorres[unfolded dc_def])
+           apply (ctac add: rescheduleRequired_ccorres)
           apply clarsimp
           apply assumption
          apply clarsimp
          apply (rule ccorres_guard_imp2)
           apply (rule ccorres_cond_false)
-          apply (rule ccorres_return_Skip[unfolded dc_def])
+          apply (rule ccorres_return_Skip)
          apply clarsimp
         apply wp
        apply (clarsimp simp: guard_is_UNIV_def)

--- a/proof/crefine/RISCV64/SyscallArgs_C.thy
+++ b/proof/crefine/RISCV64/SyscallArgs_C.thy
@@ -290,7 +290,7 @@ lemma ccorres_invocationCatch_Inr:
            if reply = [] then liftE (replyOnRestart thread [] isCall) \<sqinter> returnOk ()
                          else liftE (replyOnRestart thread reply isCall)
        odE od) c"
-  apply (simp add: invocationCatch_def liftE_bindE o_xo_injector)
+  apply (simp add: invocationCatch_def liftE_bindE o_xo_injector cong: ccorres_all_cong)
   apply (subst ccorres_liftM_simp[symmetric])
   apply (simp add: liftM_def bind_assoc bindE_def)
   apply (rule_tac f="\<lambda>f. ccorres rvr xs P P' hs f c" for rvr xs in arg_cong)

--- a/proof/crefine/RISCV64/Syscall_C.thy
+++ b/proof/crefine/RISCV64/Syscall_C.thy
@@ -270,22 +270,22 @@ lemma decodeInvocation_ccorres:
    apply (rule ccorres_Cond_rhs)
     apply (simp add: if_to_top_of_bind)
     apply (rule ccorres_trim_returnE, simp+)
-    apply (simp add: liftME_invocationCatch o_def)
+    apply (simp add: liftME_invocationCatch)
     apply (rule ccorres_call, rule decodeTCBInvocation_ccorres)
        apply assumption
       apply (simp+)[3]
    apply (rule ccorres_Cond_rhs)
     apply (rule ccorres_trim_returnE, simp+)
-    apply (simp add: liftME_invocationCatch o_def)
+    apply (simp add: liftME_invocationCatch)
     apply (rule ccorres_call,
-           erule decodeDomainInvocation_ccorres[unfolded o_def],
+           erule decodeDomainInvocation_ccorres,
            simp+)[1]
    apply (rule ccorres_Cond_rhs)
     apply (simp add: if_to_top_of_bind)
     apply (rule ccorres_trim_returnE, simp+)
-    apply (simp add: liftME_invocationCatch o_def)
+    apply (simp add: liftME_invocationCatch)
     apply (rule ccorres_call,
-           erule decodeCNodeInvocation_ccorres[unfolded o_def],
+           erule decodeCNodeInvocation_ccorres,
            simp+)[1]
    apply (rule ccorres_Cond_rhs)
     apply simp
@@ -720,7 +720,7 @@ lemma handleFault_ccorres:
          apply (rule ccorres_return_Skip')
         apply clarsimp
         apply (rule ccorres_cond_univ)
-        apply (ctac (no_vcg) add: handleDoubleFault_ccorres [unfolded dc_def])
+        apply (ctac (no_vcg) add: handleDoubleFault_ccorres)
        apply (simp add: sendFaultIPC_def)
        apply wp
          apply ((wp hoare_vcg_all_lift_R hoare_drop_impE_R |wpc |simp add: throw_def)+)[1]
@@ -1059,7 +1059,7 @@ lemma handleReply_ccorres:
                  apply (rule ccorres_cond_true)
                  apply simp
                  apply (rule ccorres_return_void_catchbrk)
-                 apply (rule ccorres_return_void_C[unfolded dc_def])
+                 apply (rule ccorres_return_void_C)
                 apply (vcg exspec=doReplyTransfer_modifies)
                apply (rule ccorres_fail)+
           apply (wpc, simp_all)
@@ -1077,7 +1077,6 @@ lemma handleReply_ccorres:
            apply (csymbr, csymbr, csymbr)
            apply simp
            apply (rule ccorres_assert2)
-           apply (fold dc_def)
            apply (rule ccorres_add_return2)
            apply (ctac (no_vcg))
             apply (rule ccorres_return_void_catchbrk)
@@ -1238,7 +1237,7 @@ lemma handleRecv_ccorres:
                apply (rule ccorres_add_return2)
                apply (rule ccorres_split_nothrow_call[where xf'=xfdc and d'="\<lambda>_. break_C"
                                                       and Q="\<lambda>_ _. True" and Q'="\<lambda>_ _. UNIV"])
-                      apply (ctac add: handleFault_ccorres[unfolded dc_def])
+                      apply (ctac add: handleFault_ccorres)
                      apply simp+
                   apply ceqv
                  apply (rule ccorres_break_return)
@@ -1257,7 +1256,7 @@ lemma handleRecv_ccorres:
           apply (simp add: liftE_bind)
           apply (ctac)
             apply (rule_tac P="\<lambda>s. ksCurThread s = rv" in ccorres_cross_over_guard)
-            apply (ctac add: receiveIPC_ccorres[unfolded dc_def])
+            apply (ctac add: receiveIPC_ccorres)
 
            apply (wp deleteCallerCap_ksQ_ct' hoare_vcg_all_lift)
           apply (rule conseqPost[where Q'=UNIV and A'="{}"], vcg exspec=deleteCallerCap_modifies)
@@ -1305,7 +1304,7 @@ lemma handleRecv_ccorres:
                   apply (rule ccorres_add_return2)
                   apply (rule ccorres_split_nothrow_call[where xf'=xfdc and d'="\<lambda>_. break_C"
                                                and Q="\<lambda>_ _. True" and Q'="\<lambda>_ _. UNIV"])
-                         apply (ctac add: handleFault_ccorres[unfolded dc_def])
+                         apply (ctac add: handleFault_ccorres)
                         apply simp+
                      apply ceqv
                     apply (rule ccorres_break_return)
@@ -1322,7 +1321,7 @@ lemma handleRecv_ccorres:
               apply (clarsimp simp: rf_sr_upd_safe)
 
              apply (simp add: liftE_bind)
-             apply (ctac  add: receiveSignal_ccorres[unfolded dc_def])
+             apply (ctac  add: receiveSignal_ccorres)
             apply clarsimp
             apply (vcg exspec=handleFault_modifies)
            apply (rule ccorres_cond_true_seq)
@@ -1335,7 +1334,7 @@ lemma handleRecv_ccorres:
               apply (rule ccorres_cross_over_guard[where P=\<top>])
               apply (rule ccorres_symb_exec_r)
                 apply (rule ccorres_add_return2)
-                apply (ctac add: handleFault_ccorres[unfolded dc_def])
+                apply (ctac add: handleFault_ccorres)
                   apply (rule ccorres_break_return[where P=\<top> and P'=UNIV])
                    apply simp+
                  apply wp
@@ -1356,7 +1355,7 @@ lemma handleRecv_ccorres:
         apply (rule ccorres_symb_exec_r)
           apply (rule ccorres_cross_over_guard[where P=\<top>])
           apply (rule ccorres_symb_exec_r)
-            apply (ctac add: handleFault_ccorres[unfolded dc_def])
+            apply (ctac add: handleFault_ccorres)
            apply vcg
           apply (rule conseqPre, vcg)
           apply (clarsimp simp: rf_sr_upd_safe)
@@ -1369,9 +1368,9 @@ lemma handleRecv_ccorres:
        apply (rule ccorres_rhs_assoc)+
        apply (rule ccorres_cross_over_guard[where P=\<top>])
        apply (rule ccorres_symb_exec_r)
-         apply (ctac add: handleFault_ccorres[unfolded dc_def])
+         apply (ctac add: handleFault_ccorres)
            apply (rule ccorres_split_throws)
-            apply (rule ccorres_return_void_C [unfolded dc_def])
+            apply (rule ccorres_return_void_C)
            apply vcg
           apply wp
          apply (vcg exspec=handleFault_modifies)
@@ -1588,7 +1587,6 @@ lemma ccorres_handleReservedIRQ:
                      (\<forall>p. ksCurThread s \<notin> set (ksReadyQueues s p))))
     (UNIV \<inter> {s. irq_' s = ucast irq}) hs
     (handleReservedIRQ irq) (Call handleReservedIRQ_'proc)"
-  supply dc_simp[simp del]
   apply (cinit lift: irq_')
    apply (rule ccorres_return_Skip)
   apply clarsimp
@@ -1611,11 +1609,11 @@ lemma handleInterrupt_ccorres:
     apply (subst doMachineOp_bind)
       apply (rule maskInterrupt_empty_fail)
      apply (rule ackInterrupt_empty_fail)
-    apply (ctac add: maskInterrupt_ccorres[unfolded dc_def])
+    apply (ctac add: maskInterrupt_ccorres)
       apply (subst bind_return_unit[where f="doMachineOp (ackInterrupt irq)"])
-      apply (ctac add: ackInterrupt_ccorres[unfolded dc_def])
+      apply (ctac add: ackInterrupt_ccorres)
         apply (rule ccorres_split_throws)
-         apply (rule ccorres_return_void_C[unfolded dc_def])
+         apply (rule ccorres_return_void_C)
         apply vcg
        apply wp
       apply (vcg exspec=ackInterrupt_modifies)
@@ -1654,7 +1652,7 @@ lemma handleInterrupt_ccorres:
          apply csymbr
          apply (ctac (no_vcg) add: sendSignal_ccorres)
           apply (simp add: maskIrqSignal_def)
-          apply (ctac add: ackInterrupt_ccorres [unfolded dc_def])
+          apply (ctac add: ackInterrupt_ccorres)
           apply wp+
         apply (simp del: Collect_const)
         apply (rule ccorres_cond_true_seq)
@@ -1662,7 +1660,7 @@ lemma handleInterrupt_ccorres:
         apply csymbr+
         apply (rule ccorres_cond_false_seq)
         apply (simp add: maskIrqSignal_def)
-        apply (ctac add: ackInterrupt_ccorres [unfolded dc_def])
+        apply (ctac add: ackInterrupt_ccorres)
        apply (rule_tac P=\<top> and P'="{s. ret__int_' s = 0 \<and> cap_get_tag cap \<noteq> scast cap_notification_cap}" in ccorres_inst)
        apply (clarsimp simp: isCap_simps simp del: Collect_const)
        apply (case_tac rva, simp_all del: Collect_const)[1]
@@ -1672,7 +1670,7 @@ lemma handleInterrupt_ccorres:
                         rule ccorres_guard_imp2,
                         rule ccorres_cond_false_seq, simp,
                         rule ccorres_cond_false_seq, simp,
-                        ctac (no_vcg) add: ackInterrupt_ccorres [unfolded dc_def],
+                        ctac (no_vcg) add: ackInterrupt_ccorres,
                         clarsimp)+
       apply (wpsimp wp: getSlotCap_wp simp: maskIrqSignal_def)
      apply simp
@@ -1681,7 +1679,6 @@ lemma handleInterrupt_ccorres:
     apply (rule ccorres_move_const_guards)+
     apply (rule ccorres_cond_false_seq)
     apply (rule ccorres_cond_true_seq)
-    apply (fold dc_def)[1]
     apply (rule ccorres_rhs_assoc)+
     apply (ctac (no_vcg) add: timerTick_ccorres)
      apply (ctac (no_vcg) add: resetTimer_ccorres)
@@ -1693,7 +1690,7 @@ lemma handleInterrupt_ccorres:
    apply (rule ccorres_cond_false_seq)
    apply (rule ccorres_cond_true_seq)
    apply (ctac add: ccorres_handleReservedIRQ)
-     apply (ctac (no_vcg) add: ackInterrupt_ccorres [unfolded dc_def])
+     apply (ctac (no_vcg) add: ackInterrupt_ccorres)
     apply wp
    apply (vcg exspec=handleReservedIRQ_modifies)
   apply (simp add: sint_ucast_eq_uint is_down uint_up_ucast is_up )

--- a/proof/crefine/RISCV64/Tcb_C.thy
+++ b/proof/crefine/RISCV64/Tcb_C.thy
@@ -419,8 +419,8 @@ lemma setPriority_ccorres:
         apply (rule ccorres_pre_getCurThread)
         apply (rule_tac R = "\<lambda>s. rv = ksCurThread s" in ccorres_cond2)
           apply (clarsimp simp: rf_sr_ksCurThread)
-         apply (ctac add: rescheduleRequired_ccorres[unfolded dc_def])
-        apply (ctac add: possibleSwitchTo_ccorres[unfolded dc_def])
+         apply (ctac add: rescheduleRequired_ccorres)
+        apply (ctac add: possibleSwitchTo_ccorres)
        apply (rule ccorres_return_Skip')
       apply (wp isRunnable_wp)
      apply (wpsimp wp: hoare_drop_imps threadSet_valid_queues threadSet_valid_objs'
@@ -626,7 +626,7 @@ lemma invokeTCB_ThreadControl_ccorres:
            apply (rule ccorres_move_array_assertion_tcb_ctes ccorres_Guard_Seq)+
            apply csymbr
            apply (simp add: liftE_bindE[symmetric] bindE_assoc getThreadBufferSlot_def
-                            locateSlot_conv o_def
+                            locateSlot_conv
                        del: Collect_const)
            apply (simp add: liftE_bindE del: Collect_const)
            apply (ctac(no_vcg) add: cteDelete_ccorres)
@@ -672,7 +672,7 @@ lemma invokeTCB_ThreadControl_ccorres:
                                            and Q'=UNIV in ccorres_rewrite_cond_sr)
                             apply (clarsimp simp: Collect_const_mem rf_sr_ksCurThread)
                            apply (rule ccorres_Cond_rhs; clarsimp)
-                            apply (ctac (no_vcg) add: rescheduleRequired_ccorres[unfolded dc_def])
+                            apply (ctac (no_vcg) add: rescheduleRequired_ccorres)
                            apply (rule ccorres_return_Skip')
                           apply (rule ccorres_split_nothrow_novcg_dc)
                              apply (rule ccorres_cond2[where R=\<top>], simp add: Collect_const_mem)
@@ -710,7 +710,7 @@ lemma invokeTCB_ThreadControl_ccorres:
                                       and Q'=UNIV in ccorres_rewrite_cond_sr)
                        apply (clarsimp simp: Collect_const_mem rf_sr_ksCurThread)
                       apply (rule ccorres_Cond_rhs; clarsimp)
-                       apply (ctac (no_vcg) add: rescheduleRequired_ccorres[unfolded dc_def])
+                       apply (ctac (no_vcg) add: rescheduleRequired_ccorres)
                       apply (rule ccorres_return_Skip')
                      apply (rule ccorres_split_nothrow_novcg_dc)
                         apply (rule ccorres_cond2[where R=\<top>], simp add: Collect_const_mem)
@@ -739,7 +739,7 @@ lemma invokeTCB_ThreadControl_ccorres:
                                     and Q'=UNIV in ccorres_rewrite_cond_sr)
                      apply (clarsimp simp: Collect_const_mem rf_sr_ksCurThread)
                     apply (rule ccorres_Cond_rhs; clarsimp)
-                     apply (ctac(no_vcg) add: rescheduleRequired_ccorres[unfolded dc_def])
+                     apply (ctac(no_vcg) add: rescheduleRequired_ccorres)
                     apply (rule ccorres_return_Skip')
                    apply (rule ccorres_split_nothrow_novcg_dc)
                       apply (rule ccorres_cond2[where R=\<top>], simp add: Collect_const_mem)
@@ -767,7 +767,7 @@ lemma invokeTCB_ThreadControl_ccorres:
                                   and Q'=UNIV in ccorres_rewrite_cond_sr)
                    apply (clarsimp simp: Collect_const_mem rf_sr_ksCurThread)
                   apply (rule ccorres_Cond_rhs; clarsimp)
-                   apply (ctac(no_vcg) add: rescheduleRequired_ccorres[unfolded dc_def])
+                   apply (ctac(no_vcg) add: rescheduleRequired_ccorres)
                   apply (rule ccorres_return_Skip')
                  apply (rule ccorres_split_nothrow_novcg_dc)
                     apply (rule ccorres_cond2[where R=\<top>], simp add: Collect_const_mem)
@@ -855,11 +855,10 @@ lemma invokeTCB_ThreadControl_ccorres:
          apply csymbr
          apply (ctac(no_vcg) add: cteDelete_ccorres)
            apply (simp add: liftE_bindE Collect_False ccorres_cond_iffs
-                            dc_def
                        del: Collect_const)
            apply ((rule ccorres_split_nothrow_novcg_dc[rotated], assumption) | rule ccorres_rhs_assoc2)+
              apply (simp add: conj_comms pred_conj_def)
-             apply (simp add: o_def cong: conj_cong option.case_cong)
+             apply (simp cong: conj_cong option.case_cong)
              apply (wp checked_insert_tcb_invs' hoare_case_option_wp
                        checkCap_inv [where P="tcb_at' p0" for p0]
                        checkCap_inv [where P="cte_at' p0" for p0]
@@ -878,8 +877,7 @@ lemma invokeTCB_ThreadControl_ccorres:
              apply (rule checkCapAt_ccorres2)
                 apply ceqv
                apply csymbr
-               apply (simp add: Collect_True assertDerived_def bind_assoc
-                                ccorres_cond_iffs dc_def[symmetric]
+               apply (simp add: Collect_True assertDerived_def bind_assoc ccorres_cond_iffs
                            del: Collect_const)
                apply (rule ccorres_symb_exec_l)
                   apply (ctac add: cteInsert_ccorres)
@@ -887,7 +885,7 @@ lemma invokeTCB_ThreadControl_ccorres:
               apply csymbr
               apply (simp add: Collect_False ccorres_cond_iffs
                           del: Collect_const)
-              apply (rule ccorres_return_Skip[unfolded dc_def])
+              apply (rule ccorres_return_Skip)
              apply (clarsimp simp: guard_is_UNIV_def Collect_const_mem
                                    tcbVTable_def tcbVTableSlot_def Kernel_C.tcbVTable_def
                                    cte_level_bits_def size_of_def option_to_0_def objBits_defs mask_def)
@@ -895,7 +893,7 @@ lemma invokeTCB_ThreadControl_ccorres:
             apply (simp add: Collect_False
                         del: Collect_const)
             apply (rule ccorres_cond_false)
-            apply (rule ccorres_return_Skip[unfolded dc_def])
+            apply (rule ccorres_return_Skip)
            apply (clarsimp simp: guard_is_UNIV_def ccap_relation_def cap_thread_cap_lift
                                  cap_to_H_def Collect_const_mem
                                  canonical_address_bitfield_extract_tcb
@@ -922,12 +920,11 @@ lemma invokeTCB_ThreadControl_ccorres:
         apply csymbr
         apply (ctac(no_vcg) add: cteDelete_ccorres)
           apply (simp add: liftE_bindE Collect_False ccorres_cond_iffs
-                           dc_def
                       del: Collect_const)
           apply ((rule ccorres_split_nothrow_novcg_dc[rotated], assumption)
                   | rule ccorres_rhs_assoc2)+
             apply (simp add: conj_comms pred_conj_def)
-            apply (simp add: o_def cong: conj_cong option.case_cong)
+            apply (simp cong: conj_cong option.case_cong)
             apply (wp checked_insert_tcb_invs' hoare_case_option_wp
                       checkCap_inv [where P="tcb_at' p0" for p0]
                       checkCap_inv [where P="cte_at' p0" for p0]
@@ -949,8 +946,7 @@ lemma invokeTCB_ThreadControl_ccorres:
             apply (rule checkCapAt_ccorres2)
                apply ceqv
               apply csymbr
-              apply (simp add: Collect_True assertDerived_def bind_assoc
-                               ccorres_cond_iffs dc_def[symmetric]
+              apply (simp add: Collect_True assertDerived_def bind_assoc ccorres_cond_iffs
                           del: Collect_const)
               apply (rule ccorres_symb_exec_l)
                  apply (ctac add: cteInsert_ccorres)
@@ -958,7 +954,7 @@ lemma invokeTCB_ThreadControl_ccorres:
              apply csymbr
              apply (simp add: Collect_False ccorres_cond_iffs
                          del: Collect_const)
-             apply (rule ccorres_return_Skip[unfolded dc_def])
+             apply (rule ccorres_return_Skip)
             apply (clarsimp simp: guard_is_UNIV_def Collect_const_mem
                                   Kernel_C.tcbCTable_def tcbCTableSlot_def
                                   cte_level_bits_def size_of_def option_to_0_def mask_def objBits_defs)
@@ -966,7 +962,7 @@ lemma invokeTCB_ThreadControl_ccorres:
            apply (simp add: Collect_False
                        del: Collect_const)
            apply (rule ccorres_cond_false)
-           apply (rule ccorres_return_Skip[unfolded dc_def])
+           apply (rule ccorres_return_Skip)
           apply (clarsimp simp: guard_is_UNIV_def ccap_relation_def cap_thread_cap_lift
                                 cap_to_H_def Collect_const_mem
                                 canonical_address_bitfield_extract_tcb
@@ -1019,7 +1015,7 @@ lemma setupReplyMaster_ccorres:
   apply (cinit lift: thread_')
    apply (rule ccorres_move_array_assertion_tcb_ctes ccorres_Guard_Seq)+
    apply ctac
-     apply (simp del: Collect_const add: dc_def[symmetric])
+     apply (simp del: Collect_const)
      apply (rule ccorres_pre_getCTE)
      apply (rule ccorres_move_c_guard_cte)
      apply (rule_tac F="\<lambda>rv'. (rv' = scast cap_null_cap) = (cteCap oldCTE = NullCap)"
@@ -1156,7 +1152,7 @@ lemma postModifyRegisters_ccorres:
     apply (simp add: if_distrib[where f="asUser t" for t] asUser_return)
     apply (rule ccorres_add_return2)
     apply (rule ccorres_stateAssert)
-    apply (rule ccorres_return_Skip'[unfolded dc_def])
+    apply (rule ccorres_return_Skip')
    by simp+
 
 lemma invokeTCB_CopyRegisters_ccorres:
@@ -1650,10 +1646,10 @@ lemma invokeTCB_WriteRegisters_ccorres[where S=UNIV]:
                  apply (rule ccorres_split_nothrow_novcg)
                      apply (rule ccorres_when[where R=\<top>])
                       apply (simp add: from_bool_0 Collect_const_mem)
-                     apply (rule_tac xf'="\<lambda>_. 0" in ccorres_call)
-                      apply (rule restart_ccorres)
+                     apply (rule_tac xf'=Corres_C.xfdc in ccorres_call)
+                        apply (rule restart_ccorres)
+                       apply simp
                       apply simp
-                      apply (simp add: xfdc_def)
                      apply simp
                     apply (rule ceqv_refl)
                    apply (rule ccorres_split_nothrow_novcg_dc)
@@ -1837,6 +1833,7 @@ shows
                 apply (rule ccorres_rhs_assoc)+
                 apply csymbr
                 apply (ctac add: lookupIPCBuffer_ccorres)
+                  apply (rename_tac state destIPCBuffer ipcBuffer)
                   apply (ctac add: setRegister_ccorres)
                     apply (rule ccorres_stateAssert)
                     apply (rule ccorres_rhs_assoc2)
@@ -1896,15 +1893,15 @@ shows
                        apply (rule bind_apply_cong[OF _ refl])
                        apply (rule_tac n1="min (unat n_frameRegisters - unat n_msgRegisters) (unat n)"
                                    in fun_cong [OF mapM_x_split_append])
-                      apply (rule_tac P="rva \<noteq> Some 0" in ccorres_gen_asm)
-                      apply (subgoal_tac "(ipcBuffer = NULL) = (rva = None)")
+                      apply (rule_tac P="destIPCBuffer \<noteq> Some 0" in ccorres_gen_asm)
+                      apply (subgoal_tac "(ipcBuffer = NULL) = (destIPCBuffer = None)")
                        prefer 2
                        apply (clarsimp simp: option_to_ptr_def option_to_0_def
                                       split: option.split_asm)
                       apply (simp add: bind_assoc del: Collect_const)
                       apply (rule_tac xf'=i_' and r'="\<lambda>_ rv. unat rv = min (unat n_frameRegisters)
                                                                       (min (unat n)
-                                                                           (case rva of None \<Rightarrow> unat n_msgRegisters
+                                                                           (case destIPCBuffer of None \<Rightarrow> unat n_msgRegisters
                                                                               | _ \<Rightarrow> unat n_frameRegisters))"
                                  in ccorres_split_nothrow_novcg)
                           apply (rule ccorres_Cond_rhs)
@@ -1912,7 +1909,7 @@ shows
                                   rule_tac F="\<lambda>m s. obj_at' (\<lambda>tcb. map ((user_regs o atcbContextGet o tcbArch) tcb) (genericTake n
                                                       (RISCV64_H.frameRegisters @ RISCV64_H.gpRegisters))
                                                                = reply) target s
-                                                 \<and> valid_ipc_buffer_ptr' (the rva) s
+                                                 \<and> valid_ipc_buffer_ptr' (the destIPCBuffer) s
                                                  \<and> valid_pspace' s"
                                        and i="unat n_msgRegisters"
                                     in ccorres_mapM_x_while')
@@ -2021,11 +2018,10 @@ shows
                             apply (rename_tac i_c, rule_tac P="i_c = 0" in ccorres_gen_asm2)
                             apply (simp add: drop_zip del: Collect_const)
                             apply (rule ccorres_Cond_rhs)
-                             apply (simp del: Collect_const)
                              apply (rule_tac F="\<lambda>m s. obj_at' (\<lambda>tcb. map ((user_regs o atcbContextGet o tcbArch) tcb) (genericTake n
                                                        (RISCV64_H.frameRegisters @ RISCV64_H.gpRegisters))
                                                                 = reply) target s
-                                                  \<and> valid_ipc_buffer_ptr' (the rva) s \<and> valid_pspace' s"
+                                                  \<and> valid_ipc_buffer_ptr' (the destIPCBuffer) s \<and> valid_pspace' s"
                                         and i="0" in ccorres_mapM_x_while')
                                  apply (clarsimp simp: less_diff_conv drop_zip)
                                  apply (rule ccorres_guard_imp2)
@@ -2098,11 +2094,11 @@ shows
                              apply (simp add: min_less_iff_disj less_imp_diff_less)
                             apply (simp add: drop_zip n_gpRegisters_def)
                             apply (elim disjE impCE)
-                             apply (clarsimp simp: mapM_x_Nil)
+                             apply (clarsimp simp: mapM_x_Nil cong: ccorres_all_cong)
                              apply (rule ccorres_return_Skip')
-                            apply (simp add: linorder_not_less word_le_nat_alt
-                                             drop_zip mapM_x_Nil n_frameRegisters_def
-                                             min.absorb1 n_msgRegisters_def)
+                            apply (simp add: linorder_not_less word_le_nat_alt drop_zip
+                                             mapM_x_Nil n_frameRegisters_def n_msgRegisters_def
+                                       cong: ccorres_all_cong)
                             apply (rule ccorres_guard_imp2, rule ccorres_return_Skip')
                             apply simp
                            apply ceqv
@@ -2192,7 +2188,7 @@ shows
      apply (vcg exspec=suspend_modifies)
     apply vcg
    apply (rule conseqPre, vcg, clarsimp)
-  apply (clarsimp simp: rf_sr_ksCurThread ct_in_state'_def dc_def
+  apply (clarsimp simp: rf_sr_ksCurThread ct_in_state'_def
                  split: if_split)
   done
 
@@ -2394,7 +2390,7 @@ lemma decodeWriteRegisters_ccorres:
          apply (simp add: performInvocation_def)
          apply (ctac(no_vcg) add: invokeTCB_WriteRegisters_ccorres
                                     [where args=args and someNum="unat (args ! 1)"])
-           apply (simp add: dc_def[symmetric] o_def)
+           apply simp
            apply (rule ccorres_alternative2, rule ccorres_return_CE, simp+)
           apply (rule ccorres_return_C_errorE, simp+)[1]
          apply wp[1]
@@ -2414,7 +2410,7 @@ lemma decodeWriteRegisters_ccorres:
                         WriteRegisters_resume_def word_sle_def word_sless_def
                         numeral_eqs)
   apply (frule arg_cong[where f="\<lambda>x. unat (of_nat x :: machine_word)"],
-         simp(no_asm_use) only: word_unat.Rep_inverse o_def,
+         simp(no_asm_use) only: word_unat.Rep_inverse,
          simp)
   apply (rule conjI)
    apply clarsimp
@@ -3213,7 +3209,6 @@ lemma decodeSetMCPriority_ccorres:
             >>= invocationCatch thread isBlocking isCall InvokeTCB)
      (Call decodeSetMCPriority_'proc)"
   supply Collect_const[simp del]
-  supply dc_simp[simp del]
   apply (cinit' lift: cap_' length___unsigned_long_' current_extra_caps_' buffer_' simp: decodeSetMCPriority_def)
    apply (simp cong: StateSpace.state.fold_congs globals.fold_congs)
    apply (rule ccorres_rhs_assoc2)
@@ -3281,8 +3276,7 @@ lemma decodeSetMCPriority_ccorres:
              apply csymbr
              apply csymbr
              apply (ctac (no_vcg) add: invokeTCB_ThreadControl_ccorres)
-               (* HACK: delete rules from the simpset to avoid the RVRs getting out of sync *)
-               apply (clarsimp simp del: intr_and_se_rel_simps comp_apply dc_simp)
+               apply clarsimp
                apply (rule ccorres_alternative2)
                apply (rule ccorres_return_CE; simp)
               apply (rule ccorres_return_C_errorE; simp)
@@ -3347,7 +3341,7 @@ lemma decodeSetPriority_ccorres:
      (decodeSetPriority args cp extraCaps
             >>= invocationCatch thread isBlocking isCall InvokeTCB)
      (Call decodeSetPriority_'proc)"
-  supply Collect_const[simp del] dc_simp[simp del]
+  supply Collect_const[simp del]
   apply (cinit' lift: cap_' length___unsigned_long_' current_extra_caps_' buffer_' simp: decodeSetPriority_def)
      apply (simp cong: StateSpace.state.fold_congs globals.fold_congs)
    apply (rule ccorres_rhs_assoc2)
@@ -3415,8 +3409,7 @@ lemma decodeSetPriority_ccorres:
              apply csymbr
              apply csymbr
              apply (ctac (no_vcg) add: invokeTCB_ThreadControl_ccorres)
-               (* HACK: delete rules from the simpset to avoid the RVRs getting out of sync *)
-               apply (clarsimp simp del: intr_and_se_rel_simps comp_apply dc_simp)
+               apply clarsimp
                apply (rule ccorres_alternative2)
                apply (rule ccorres_return_CE; simp)
               apply (rule ccorres_return_C_errorE; simp)
@@ -3494,7 +3487,7 @@ lemma decodeSetSchedParams_ccorres:
      (decodeSetSchedParams args cp extraCaps
             >>= invocationCatch thread isBlocking isCall InvokeTCB)
      (Call decodeSetSchedParams_'proc)"
-  supply Collect_const[simp del] dc_simp[simp del]
+  supply Collect_const[simp del]
   apply (cinit' lift: cap_' length___unsigned_long_' current_extra_caps_' buffer_' simp: decodeSetSchedParams_def)
    apply (simp cong: StateSpace.state.fold_congs globals.fold_congs)
    apply (rule ccorres_rhs_assoc2)
@@ -3581,8 +3574,7 @@ lemma decodeSetSchedParams_ccorres:
                   apply csymbr
                   apply csymbr
                   apply (ctac (no_vcg) add: invokeTCB_ThreadControl_ccorres)
-                    (* HACK: delete rules from the simpset to avoid the RVRs getting out of sync *)
-                    apply (clarsimp simp del: intr_and_se_rel_simps comp_apply dc_simp)
+                    apply clarsimp
                     apply (rule ccorres_alternative2)
                     apply (rule ccorres_return_CE; simp)
                    apply (rule ccorres_return_C_errorE; simp)
@@ -3848,7 +3840,7 @@ lemma bindNotification_ccorres:
        apply ceqv
       apply (rule ccorres_move_c_guard_tcb)
       apply (simp add: setBoundNotification_def)
-      apply (rule_tac P'=\<top> and P=\<top> in threadSet_ccorres_lemma3[unfolded dc_def])
+      apply (rule_tac P'=\<top> and P=\<top> in threadSet_ccorres_lemma3)
        apply vcg
       apply simp
       apply (erule (1) rf_sr_tcb_update_no_queue2,
@@ -4311,7 +4303,7 @@ lemma decodeSetSpace_ccorres:
                       apply (simp add: Collect_False del: Collect_const)
                       apply csymbr
                       apply csymbr
-                      apply (simp add: cnode_cap_case_if cap_get_tag_isCap dc_def[symmetric]
+                      apply (simp add: cnode_cap_case_if cap_get_tag_isCap
                                   del: Collect_const)
                       apply (rule ccorres_Cond_rhs_Seq)
                        apply (simp add: injection_handler_throwError
@@ -4457,7 +4449,7 @@ lemma invokeTCB_SetTLSBase_ccorres:
   apply (cinit lift: thread_' tls_base_')
    apply (simp add: liftE_def bind_assoc
                del: Collect_const)
-   apply (ctac add: setRegister_ccorres[simplified dc_def])
+   apply (ctac add: setRegister_ccorres)
      apply (rule ccorres_pre_getCurThread)
      apply (rename_tac cur_thr)
      apply (rule ccorres_split_nothrow_novcg_dc)

--- a/proof/crefine/RISCV64/VSpace_C.thy
+++ b/proof/crefine/RISCV64/VSpace_C.thy
@@ -902,7 +902,6 @@ lemma setVMRoot_ccorres:
       apply ccorres_rewrite
       apply (subst bind_return_unit)
       apply (ctac (no_vcg) add: setVSpaceRoot_ccorres)
-       apply (simp flip: dc_def)
        apply (rule ccorres_return_void_C)
       apply (rule hoare_post_taut[where P=\<top>])
      apply (simp add: catch_def bindE_bind_linearise bind_assoc liftE_def)
@@ -925,7 +924,7 @@ lemma setVMRoot_ccorres:
                      in ccorres_gen_asm2)
         apply simp
         apply (rule ccorres_Cond_rhs_Seq)
-         apply (simp add: whenE_def throwError_def dc_def[symmetric], ccorres_rewrite)
+         apply (simp add: whenE_def throwError_def, ccorres_rewrite)
          apply (rule ccorres_rhs_assoc)
          apply (rule ccorres_h_t_valid_riscvKSGlobalPT)
          apply csymbr
@@ -934,10 +933,10 @@ lemma setVMRoot_ccorres:
          apply (ctac (no_vcg) add: setVSpaceRoot_ccorres)
           apply (rule ccorres_return_void_C)
          apply (rule hoare_post_taut[where P=\<top>])
-        apply (simp add: whenE_def returnOk_def flip: dc_def)
+        apply (simp add: whenE_def returnOk_def)
         apply (csymbr)
         apply (ctac (no_vcg) add: setVSpaceRoot_ccorres)
-       apply (rule ccorres_cond_true_seq, simp add: dc_def[symmetric], ccorres_rewrite)
+       apply (rule ccorres_cond_true_seq, simp, ccorres_rewrite)
        apply (rule ccorres_rhs_assoc)
        apply (rule ccorres_h_t_valid_riscvKSGlobalPT)
        apply csymbr
@@ -1004,12 +1003,12 @@ lemma setRegister_ccorres:
        (asUser thread (setRegister reg val))
        (Call setRegister_'proc)"
   apply (cinit' lift: thread_' reg_' w_')
-   apply (simp add: asUser_def dc_def[symmetric] split_def split del: if_split)
+   apply (simp add: asUser_def split_def)
    apply (rule ccorres_pre_threadGet)
    apply (rule ccorres_Guard)
    apply (simp add: setRegister_def simpler_modify_def exec_select_f_singleton)
    apply (rule_tac P="\<lambda>tcb. (atcbContextGet o tcbArch) tcb = rv"
-                in threadSet_ccorres_lemma2 [unfolded dc_def])
+                in threadSet_ccorres_lemma2)
     apply vcg
    apply (clarsimp simp: setRegister_def HaskellLib_H.runState_def
                          simpler_modify_def typ_heap_simps)
@@ -1040,8 +1039,6 @@ lemma msgRegisters_ccorres:
 (* usually when we call setMR directly, we mean to only set a registers, which will
    fit in actual registers *)
 lemma setMR_as_setRegister_ccorres:
-  notes dc_simp[simp del]
-  shows
   "ccorres (\<lambda>rv rv'. rv' = of_nat offset + 1) ret__unsigned_'
       (tcb_at' thread and K (TCB_H.msgRegisters ! offset = reg \<and> offset < length msgRegisters))
       (UNIV \<inter> \<lbrace>\<acute>reg___unsigned_long = val\<rbrace>
@@ -1058,7 +1055,7 @@ lemma setMR_as_setRegister_ccorres:
    apply (ctac add: setRegister_ccorres)
      apply (rule ccorres_from_vcg_throws[where P'=UNIV and P=\<top>])
      apply (rule allI, rule conseqPre, vcg)
-     apply (clarsimp simp: dc_def return_def)
+     apply (clarsimp simp: return_def)
     apply (rule hoare_post_taut[of \<top>])
    apply (vcg exspec=setRegister_modifies)
   apply (clarsimp simp: n_msgRegisters_def length_of_msgRegisters not_le conj_commute)
@@ -1245,7 +1242,6 @@ lemma unmapPage_ccorres:
   apply (rule ccorres_gen_asm)
   apply (cinit lift: page_size_' asid___unsigned_long_' vptr_' pptr___unsigned_long_')
    apply (simp add: ignoreFailure_liftM)
-   apply (fold dc_def)
    apply (ctac add: findVSpaceForASID_ccorres)
       apply (rename_tac vspace find_ret)
       apply (rule ccorres_liftE_Seq)
@@ -1255,9 +1251,9 @@ lemma unmapPage_ccorres:
         apply (simp (no_asm) add: split_def del: Collect_const)
         apply (rule ccorres_split_unless_throwError_cond[where Q=\<top> and Q'=\<top>])
            apply (clarsimp simp: of_nat_pageBitsForSize split: if_split)
-          apply (simp add: throwError_def flip: dc_def)
+          apply (simp add: throwError_def)
           apply (rule ccorres_return_void_C)
-         apply (simp add: dc_def[symmetric])
+         apply simp
          apply (rule ccorres_rhs_assoc2, rule ccorres_rhs_assoc2,
                 rule ccorres_rhs_assoc2, rule ccorres_rhs_assoc2)
          apply (subst bindE_assoc[symmetric])
@@ -1270,11 +1266,10 @@ lemma unmapPage_ccorres:
                             split: if_split_asm pte.split_asm)
             apply (rule ceqv_refl)
            apply (simp add: unfold_checkMapping_return liftE_bindE
-                            Collect_const[symmetric] dc_def[symmetric]
                        del: Collect_const)
            apply csymbr
            apply (rule ccorres_split_nothrow_novcg)
-               apply (simp add: dc_def[symmetric] ptr_add_assertion_def split_def)
+               apply (simp add: ptr_add_assertion_def split_def)
                apply ccorres_rewrite
                apply (rule storePTE_Basic_ccorres)
                apply (simp add: cpte_relation_def Let_def)
@@ -1293,7 +1288,7 @@ lemma unmapPage_ccorres:
        apply wpsimp
       apply (vcg exspec=lookupPTSlot_modifies)
      apply ccorres_rewrite
-     apply (simp add: throwError_def flip: dc_def)
+     apply (simp add: throwError_def)
      apply (rule ccorres_return_void_C)
     apply wp
    apply (vcg exspec=findVSpaceForASID_modifies)
@@ -1373,7 +1368,7 @@ lemma performPageInvocationUnmap_ccorres:
           apply simp
          apply simp
         apply simp
-       apply (simp add: asidInvalid_def flip: dc_def)
+       apply (simp add: asidInvalid_def)
        apply (rule ccorres_return_Skip)
       apply ceqv
      apply (simp add: liftM_def)
@@ -1665,7 +1660,7 @@ proof -
   show ?thesis
     apply (cinit lift: newLvl1pt_' simp: ptIndex_maxPTLevel_pptrBase ptTranslationBits_def)
      apply (rule ccorres_pre_gets_riscvKSGlobalPT_ksArchState, rename_tac globalPT)
-     apply (rule ccorres_rel_imp[where r=dc, OF _ dc_simp])
+     apply (rule ccorres_rel_imp[where r=dc, simplified])
      apply (clarsimp simp: whileAnno_def objBits_simps bit_simps RISCV64.pptrBase_def mask_def)
      apply (rule ccorres_h_t_valid_riscvKSGlobalPT)
      apply csymbr

--- a/proof/crefine/X64/Arch_C.thy
+++ b/proof/crefine/X64/Arch_C.thy
@@ -75,7 +75,7 @@ lemma performPageTableInvocationUnmap_ccorres:
           apply csymbr
           apply (simp add: storePTE_def' swp_def)
           apply clarsimp
-          apply(simp only: dc_def[symmetric] bit_simps_corres[symmetric])
+          apply (simp only: bit_simps_corres[symmetric])
           apply (ctac add: clearMemory_setObject_PTE_ccorres)
          apply wp
         apply (simp del: Collect_const)
@@ -217,7 +217,7 @@ lemma performPageDirectoryInvocationUnmap_ccorres:
           apply csymbr
           apply (simp add: storePDE_def' swp_def)
           apply clarsimp
-          apply(simp only: dc_def[symmetric] bit_simps_corres[symmetric])
+          apply (simp only: bit_simps_corres[symmetric])
           apply (ctac add: clearMemory_setObject_PDE_ccorres)
          apply wp
         apply (simp del: Collect_const)
@@ -359,7 +359,7 @@ lemma performPDPTInvocationUnmap_ccorres:
           apply csymbr
           apply (simp add: storePDPTE_def' swp_def)
           apply clarsimp
-          apply(simp only: dc_def[symmetric] bit_simps_corres[symmetric])
+          apply (simp only: bit_simps_corres[symmetric])
           apply (ctac add: clearMemory_setObject_PDPTE_ccorres)
          apply wp
         apply (simp del: Collect_const)
@@ -887,7 +887,7 @@ shows
                          pageBits_def
                    split: if_split)
   apply (clarsimp simp: X64SmallPageBits_def word_sle_def is_aligned_mask[symmetric]
-                        ghost_assertion_data_get_gs_clear_region[unfolded o_def])
+                        ghost_assertion_data_get_gs_clear_region)
   apply (subst ghost_assertion_size_logic_flex[unfolded o_def, rotated])
      apply assumption
     apply (simp add: ghost_assertion_data_get_gs_clear_region[unfolded o_def])
@@ -1121,10 +1121,10 @@ lemma decodeX64PageTableInvocation_ccorres:
                              isPML4Cap (capCap (fst (extraCaps ! 0)))"
                           in ccorres_cases)
            apply (clarsimp simp: hd_conv_nth throwError_bind invocationCatch_def cong: if_cong)
-           apply (rule syscall_error_throwError_ccorres_n[simplified dc_def id_def o_def])
+           apply (rule syscall_error_throwError_ccorres_n)
            apply (simp add: syscall_error_to_H_cases)
           apply (clarsimp simp: hd_conv_nth throwError_bind invocationCatch_def cong: if_cong)
-          apply (rule syscall_error_throwError_ccorres_n[simplified dc_def id_def o_def])
+          apply (rule syscall_error_throwError_ccorres_n)
           apply (simp add: syscall_error_to_H_cases)
          apply (simp add: hd_conv_nth)
          apply csymbr
@@ -1789,7 +1789,7 @@ lemma performPageInvocationMapPDPTE_ccorres:
   done
 
 lemma performPageGetAddress_ccorres:
-  notes Collect_const[simp del] dc_simp[simp del]
+  notes Collect_const[simp del]
   shows
   "ccorres ((intr_and_se_rel \<circ> Inr) \<currency> dc) (liftxf errstate id (K ()) ret__unsigned_long_')
       (invs' and (\<lambda>s. ksCurThread s = thread) and ct_in_state' ((=) Restart))
@@ -1815,7 +1815,7 @@ lemma performPageGetAddress_ccorres:
        apply (rule ccorres_from_vcg_throws[where P=\<top> and P'=UNIV])
        apply clarsimp
        apply (rule conseqPre, vcg)
-       apply (clarsimp simp: return_def dc_simp)
+       apply (clarsimp simp: return_def)
       apply (rule hoare_post_taut[of \<top>])
      apply (rule ccorres_rhs_assoc)+
      apply (clarsimp simp: replyOnRestart_def liftE_def bind_assoc)
@@ -1838,7 +1838,7 @@ lemma performPageGetAddress_ccorres:
                  apply (rule ccorres_inst[where P=\<top> and P'=UNIV])
                  apply (rule ccorres_from_vcg_throws[where P=\<top> and P'=UNIV])
                  apply (rule allI, rule conseqPre, vcg)
-                 apply (clarsimp simp: return_def dc_def)
+                 apply (clarsimp simp: return_def)
                 apply (rule hoare_post_taut[of \<top>])
                apply (vcg exspec=setThreadState_modifies)
               apply wpsimp
@@ -1851,10 +1851,10 @@ lemma performPageGetAddress_ccorres:
                                Kernel_C.msgInfoRegister_def)
          apply (vcg exspec=setMR_modifies)
         apply wpsimp
-       apply (clarsimp simp: dc_def)
+       apply clarsimp
        apply (vcg exspec=setRegister_modifies)
       apply wpsimp
-     apply (clarsimp simp: dc_def ThreadState_Running_def)
+     apply (clarsimp simp: ThreadState_Running_def)
      apply (vcg exspec=lookupIPCBuffer_modifies)
     apply clarsimp
     apply vcg
@@ -2218,7 +2218,7 @@ lemma decodeX86ModeMapPage_ccorres:
                     (Inr (invocation.InvokePage (PageMap (ArchObjectCap cap) slot x pml4)))
              odE)
             (Call decodeX86ModeMapPage_'proc)"
-  supply if_cong[cong] tl_drop_1[simp] Collect_const[simp del] dc_simp[simp del]
+  supply if_cong[cong] tl_drop_1[simp] Collect_const[simp del]
   apply (simp add: K_def)
   apply (rule ccorres_gen_asm)
   apply (cinit' lift: label___unsigned_long_' page_size_' vroot_' cap_' paddr_' vm_rights_' vm_attr_'
@@ -2249,7 +2249,7 @@ lemma decodeX86ModeMapPage_ccorres:
    apply (vcg exspec=createSafeMappingEntries_PDPTE_modifies)
   by (clarsimp simp: invs_valid_objs' tcb_at_invs' vmsz_aligned_addrFromPPtr' invs_queues
                      valid_tcb_state'_def invs_sch_act_wf' ThreadState_Restart_def rf_sr_ksCurThread
-                     arch_invocation_label_defs mask_def isCap_simps dc_def)
+                     arch_invocation_label_defs mask_def isCap_simps)
 
 lemma valid_cap'_PageCap_kernel_mappings:
   "\<lbrakk>pspace_in_kernel_mappings' s; isPageCap cap; valid_cap' (ArchObjectCap cap) s\<rbrakk>
@@ -2559,7 +2559,7 @@ lemma decodeX64FrameInvocation_ccorres:
                apply (rule ccorres_Cond_rhs_Seq)
                 apply (clarsimp simp: maptype_from_H_def throwError_bind invocationCatch_def
                                split: vmmap_type.split_asm)
-                apply (rule syscall_error_throwError_ccorres_n[simplified id_def o_def dc_def])
+                apply (rule syscall_error_throwError_ccorres_n)
                 apply (clarsimp simp: syscall_error_to_H_cases)
                (* throw on mismatched vaddr *)
                apply simp
@@ -2571,7 +2571,6 @@ lemma decodeX64FrameInvocation_ccorres:
                               split: vmmap_type.split_asm)
                 apply (clarsimp simp: X86_MappingNone_def X86_MappingVSpace_def)
                apply ccorres_rewrite
-               apply (fold dc_def id_def)
                apply (rule syscall_error_throwError_ccorres_n)
                apply (simp add: syscall_error_to_H_cases)
               (* frame cap not mapped, check mapping *)
@@ -2590,7 +2589,7 @@ lemma decodeX64FrameInvocation_ccorres:
               apply csymbr
               apply (simp add: user_vtop_def X64.pptrUserTop_def hd_conv_nth length_ineq_not_Nil)
               apply ccorres_rewrite
-              apply (rule syscall_error_throwError_ccorres_n[unfolded id_def dc_def])
+              apply (rule syscall_error_throwError_ccorres_n)
               apply (simp add: syscall_error_to_H_cases)
              (* Doesn't throw case *)
              apply (drule_tac s="Some y" in sym,
@@ -2626,7 +2625,6 @@ lemma decodeX64FrameInvocation_ccorres:
                    apply (simp add: word_less_nat_alt user_vtop_def X64.pptrUserTop_def hd_conv_nth
                                     length_ineq_not_Nil)
                    apply (ccorres_rewrite)
-                   apply (fold dc_def)
                    apply (rule ccorres_return_Skip)
                   apply clarsimp
                  apply (clarsimp simp: asidInvalid_def)
@@ -2652,7 +2650,7 @@ lemma decodeX64FrameInvocation_ccorres:
                     apply (clarsimp simp: cap_lift_pml4_cap cap_to_H_def get_capPtr_CL_def
                                           cap_pml4_cap_lift_def
                                    elim!: ccap_relationE split: if_split)
-                   apply (rule syscall_error_throwError_ccorres_n[simplified id_def o_def dc_def])
+                   apply (rule syscall_error_throwError_ccorres_n)
                    apply (simp add: syscall_error_to_H_cases)
                   apply csymbr
                   apply (rule ccorres_symb_exec_r)
@@ -2666,7 +2664,7 @@ lemma decodeX64FrameInvocation_ccorres:
                       apply (clarsimp simp: framesize_from_to_H user_vtop_def X64.pptrUserTop_def)
                      apply (simp add: injection_handler_throwError throwError_bind
                                       invocationCatch_def)
-                     apply (rule syscall_error_throwError_ccorres_n[simplified id_def o_def dc_def])
+                     apply (rule syscall_error_throwError_ccorres_n)
                      apply (simp add: syscall_error_to_H_cases)
                     apply csymbr
                     apply csymbr
@@ -3140,10 +3138,10 @@ lemma decodeX64PageDirectoryInvocation_ccorres:
                              isPML4Cap (capCap (fst (extraCaps ! 0)))"
                           in ccorres_cases)
            apply (clarsimp simp: hd_conv_nth throwError_bind invocationCatch_def from_bool_0 cong: if_cong)
-           apply (rule syscall_error_throwError_ccorres_n[simplified dc_def id_def o_def])
+           apply (rule syscall_error_throwError_ccorres_n)
            apply (simp add: syscall_error_to_H_cases)
           apply (clarsimp simp: hd_conv_nth throwError_bind invocationCatch_def from_bool_0 cong: if_cong)
-          apply (rule syscall_error_throwError_ccorres_n[simplified dc_def id_def o_def])
+          apply (rule syscall_error_throwError_ccorres_n)
           apply (simp add: syscall_error_to_H_cases)
          apply (simp add: hd_conv_nth)
          apply csymbr
@@ -3509,7 +3507,7 @@ lemma decodeX64PDPTInvocation_ccorres:
               >>= invocationCatch thread isBlocking isCall InvokeArchObject)
        (Call decodeX64PDPTInvocation_'proc)"
      (is "_ \<Longrightarrow> _ \<Longrightarrow> ccorres _ _ ?pre ?cpre _ _ _")
-  supply Collect_const[simp del] if_cong[cong] dc_simp[simp del]
+  supply Collect_const[simp del] if_cong[cong]
          from_bool_eq_if[simp] from_bool_eq_if'[simp] from_bool_0[simp] ccorres_IF_True[simp]
   apply (clarsimp simp only: isCap_simps)
   apply (cinit' lift: label___unsigned_long_' length___unsigned_long_' cte_' current_extra_caps_' cap_' buffer_'
@@ -3614,15 +3612,14 @@ lemma decodeX64PDPTInvocation_ccorres:
          apply clarsimp
          apply (rule ccorres_Cond_rhs_Seq)
           apply ccorres_rewrite
-          apply clarsimp
           apply (rule_tac P="isArchObjectCap (fst (extraCaps ! 0)) \<and>
                              isPML4Cap (capCap (fst (extraCaps ! 0)))"
                           in ccorres_cases)
            apply (clarsimp simp: hd_conv_nth throwError_bind invocationCatch_def cong: if_cong)
-           apply (rule syscall_error_throwError_ccorres_n[simplified id_def o_def])
+           apply (rule syscall_error_throwError_ccorres_n)
            apply (simp add: syscall_error_to_H_cases)
           apply (clarsimp simp: hd_conv_nth throwError_bind invocationCatch_def cong: if_cong)
-          apply (rule syscall_error_throwError_ccorres_n[simplified id_def o_def])
+          apply (rule syscall_error_throwError_ccorres_n)
           apply (simp add: syscall_error_to_H_cases)
          apply (simp add: hd_conv_nth)
          apply csymbr
@@ -3752,8 +3749,7 @@ lemma decodeX64PDPTInvocation_ccorres:
                     simp: neq_Nil_conv valid_cap_simps' isCap_simps
                           get_capMappedASID_CL_def cap_pml4_cap_lift cap_to_H_simps
                     split: if_split_asm)
-  apply (clarsimp simp: dc_simp neq_Nil_conv[where xs=extraCaps]
-                        excaps_in_mem_def slotcap_in_mem_def
+  apply (clarsimp simp: neq_Nil_conv[where xs=extraCaps] excaps_in_mem_def slotcap_in_mem_def
                  dest!: sym[where s="ArchObjectCap cp" for cp])
   apply (clarsimp simp: word_less_nat_alt hd_conv_nth dest!: length_ineq_not_Nil)
   apply (rule conjI, fastforce simp: mask_def)
@@ -3888,7 +3884,7 @@ lemma decodeX64MMUInvocation_ccorres:
                              throwError_bind invocationCatch_def
                       split: invocation_label.split arch_invocation_label.split)
      apply ccorres_rewrite
-     apply (rule syscall_error_throwError_ccorres_n[simplified id_def o_def])
+     apply (rule syscall_error_throwError_ccorres_n)
      apply (fastforce simp: syscall_error_to_H_cases)
     (* X64ASIDControlMakePool *)
     apply (clarsimp simp: decodeX64MMUInvocation_def decodeX64ASIDControlInvocation_def isCap_simps)
@@ -3899,7 +3895,7 @@ lemma decodeX64MMUInvocation_ccorres:
      apply (rule ccorres_cond_true_seq | simp)+
      apply (simp add: throwError_bind invocationCatch_def)
      apply ccorres_rewrite
-     apply (rule syscall_error_throwError_ccorres_n[simplified id_def o_def])
+     apply (rule syscall_error_throwError_ccorres_n)
      apply (fastforce simp: syscall_error_to_H_cases)
     apply (simp add: interpret_excaps_test_null excaps_map_def)
     apply csymbr
@@ -3908,14 +3904,14 @@ lemma decodeX64MMUInvocation_ccorres:
      apply (rule ccorres_cond_true_seq | simp)+
      apply (simp add: throwError_bind invocationCatch_def)
      apply ccorres_rewrite
-     apply (rule syscall_error_throwError_ccorres_n[simplified id_def o_def])
+     apply (rule syscall_error_throwError_ccorres_n)
      apply (fastforce simp: syscall_error_to_H_cases)
     apply csymbr
     apply (simp add: interpret_excaps_test_null[OF Suc_leI])
     apply (rule ccorres_Cond_rhs_Seq)
      apply (simp add: length_ineq_not_Nil throwError_bind invocationCatch_def)
      apply ccorres_rewrite
-     apply (rule syscall_error_throwError_ccorres_n[simplified id_def o_def])
+     apply (rule syscall_error_throwError_ccorres_n)
      apply (simp add: syscall_error_to_H_cases)
     apply (subgoal_tac "1 < length extraCaps")
      prefer 2
@@ -4020,7 +4016,7 @@ lemma decodeX64MMUInvocation_ccorres:
                 apply (clarsimp split: list.split)
                 apply (fastforce dest!: filter_eq_ConsD)
                apply (simp add: throwError_bind invocationCatch_def)
-               apply (rule syscall_error_throwError_ccorres_n[simplified id_def o_def])
+               apply (rule syscall_error_throwError_ccorres_n)
                apply (fastforce simp: syscall_error_to_H_cases)
               apply (rule ccorres_Guard_Seq)+
               apply (simp add: invocationCatch_use_injection_handler
@@ -4045,7 +4041,7 @@ lemma decodeX64MMUInvocation_ccorres:
                   apply (clarsimp simp:  to_bool_if cond_throw_whenE bindE_assoc)
                   apply (rule ccorres_split_when_throwError_cond[where Q = \<top> and Q' = \<top>])
                      apply fastforce
-                    apply (rule syscall_error_throwError_ccorres_n[simplified id_def])
+                    apply (rule syscall_error_throwError_ccorres_n)
                     apply (clarsimp simp: syscall_error_rel_def shiftL_nat syscall_error_to_H_cases)
                    prefer 2
                    apply vcg
@@ -4163,7 +4159,7 @@ lemma decodeX64MMUInvocation_ccorres:
      apply ccorres_rewrite
      apply (clarsimp simp: isCap_simps decodeX64ASIDPoolInvocation_def
                            throwError_bind invocationCatch_def)
-     apply (rule syscall_error_throwError_ccorres_n[simplified dc_def id_def o_def])
+     apply (rule syscall_error_throwError_ccorres_n)
      apply (fastforce simp: syscall_error_to_H_cases)
     apply (clarsimp simp: isCap_simps decodeX64ASIDPoolInvocation_def split: list.split)
     apply csymbr
@@ -4388,7 +4384,7 @@ lemma decodeX64MMUInvocation_ccorres:
     apply (rule_tac t=b and s="snd (extraCaps ! 0)" in subst, fastforce)
     apply vcg
    (* Mode stuff *)
-   apply (rule ccorres_trim_returnE; simp)
+   apply (rule ccorres_trim_returnE; simp?)
    apply (rule ccorres_call,
           rule decodeX64ModeMMUInvocation_ccorres;
           simp)
@@ -4574,7 +4570,7 @@ lemma setMessageInfo_ksCurThread_ccorres:
   done
 
 lemma invokeX86PortIn8_ccorres:
-  notes Collect_const[simp del] dc_simp[simp del]
+  notes Collect_const[simp del]
   shows
   "ccorres ((intr_and_se_rel \<circ> Inr) \<currency> dc) (liftxf errstate id (K ()) ret__unsigned_long_')
        (valid_objs' and valid_queues and ct_in_state' ((=) Restart) and
@@ -4608,7 +4604,7 @@ lemma invokeX86PortIn8_ccorres:
          apply (rule ccorres_from_vcg_throws[where P=\<top> and P'=UNIV])
          apply clarsimp
          apply (rule conseqPre, vcg)
-         apply (clarsimp simp: return_def dc_simp)
+         apply (clarsimp simp: return_def)
         apply (rule hoare_post_taut[of \<top>])
        apply (rule ccorres_rhs_assoc)+
        apply (clarsimp simp: replyOnRestart_def liftE_def bind_assoc)
@@ -4631,7 +4627,7 @@ lemma invokeX86PortIn8_ccorres:
                    apply (rule ccorres_inst[where P=\<top> and P'=UNIV])
                    apply (rule ccorres_from_vcg_throws[where P=\<top> and P'=UNIV])
                    apply (rule allI, rule conseqPre, vcg)
-                   apply (clarsimp simp: return_def dc_def)
+                   apply (clarsimp simp: return_def)
                   apply (rule hoare_post_taut[of \<top>])
                  apply (vcg exspec=setThreadState_modifies)
                 apply wpsimp
@@ -4644,10 +4640,10 @@ lemma invokeX86PortIn8_ccorres:
                                  Kernel_C.msgInfoRegister_def)
            apply (vcg exspec=setMR_modifies)
           apply wpsimp
-         apply (clarsimp simp: dc_def)
+         apply clarsimp
          apply (vcg exspec=setRegister_modifies)
         apply wpsimp
-       apply (clarsimp simp: dc_def ThreadState_Running_def)
+       apply (clarsimp simp: ThreadState_Running_def)
        apply (vcg exspec=lookupIPCBuffer_modifies)
       apply (wpsimp wp: hoare_vcg_imp_lift hoare_vcg_all_lift)
      apply (vcg exspec=in8_modifies)
@@ -4662,7 +4658,7 @@ lemma invokeX86PortIn8_ccorres:
                                            simplified, symmetric])
 
 lemma invokeX86PortIn16_ccorres:
-  notes Collect_const[simp del] dc_simp[simp del]
+  notes Collect_const[simp del]
   shows
   "ccorres ((intr_and_se_rel \<circ> Inr) \<currency> dc) (liftxf errstate id (K ()) ret__unsigned_long_')
        (valid_objs' and valid_queues and ct_in_state' ((=) Restart) and
@@ -4696,7 +4692,7 @@ lemma invokeX86PortIn16_ccorres:
          apply (rule ccorres_from_vcg_throws[where P=\<top> and P'=UNIV])
          apply clarsimp
          apply (rule conseqPre, vcg)
-         apply (clarsimp simp: return_def dc_simp)
+         apply (clarsimp simp: return_def)
         apply (rule hoare_post_taut[of \<top>])
        apply (rule ccorres_rhs_assoc)+
        apply (clarsimp simp: replyOnRestart_def liftE_def bind_assoc)
@@ -4719,7 +4715,7 @@ lemma invokeX86PortIn16_ccorres:
                    apply (rule ccorres_inst[where P=\<top> and P'=UNIV])
                    apply (rule ccorres_from_vcg_throws[where P=\<top> and P'=UNIV])
                    apply (rule allI, rule conseqPre, vcg)
-                   apply (clarsimp simp: return_def dc_def)
+                   apply (clarsimp simp: return_def)
                   apply (rule hoare_post_taut[of \<top>])
                  apply (vcg exspec=setThreadState_modifies)
                 apply wpsimp
@@ -4732,10 +4728,10 @@ lemma invokeX86PortIn16_ccorres:
                                  Kernel_C.msgInfoRegister_def)
            apply (vcg exspec=setMR_modifies)
           apply wpsimp
-         apply (clarsimp simp: dc_def)
+         apply clarsimp
          apply (vcg exspec=setRegister_modifies)
         apply wpsimp
-       apply (clarsimp simp: dc_def ThreadState_Running_def)
+       apply (clarsimp simp: ThreadState_Running_def)
        apply (vcg exspec=lookupIPCBuffer_modifies)
       apply (wpsimp wp: hoare_vcg_imp_lift hoare_vcg_all_lift)
      apply (vcg exspec=in16_modifies)
@@ -4750,7 +4746,7 @@ lemma invokeX86PortIn16_ccorres:
                                            simplified, symmetric])
 
 lemma invokeX86PortIn32_ccorres:
-  notes Collect_const[simp del] dc_simp[simp del]
+  notes Collect_const[simp del]
   shows
   "ccorres ((intr_and_se_rel \<circ> Inr) \<currency> dc) (liftxf errstate id (K ()) ret__unsigned_long_')
        (valid_objs' and valid_queues and ct_in_state' ((=) Restart) and
@@ -4782,7 +4778,7 @@ lemma invokeX86PortIn32_ccorres:
          apply (rule ccorres_from_vcg_throws[where P=\<top> and P'=UNIV])
          apply clarsimp
          apply (rule conseqPre, vcg)
-         apply (clarsimp simp: return_def dc_simp)
+         apply (clarsimp simp: return_def)
         apply (rule hoare_post_taut[of \<top>])
        apply (rule ccorres_rhs_assoc)+
        apply (clarsimp simp: replyOnRestart_def liftE_def bind_assoc)
@@ -4805,7 +4801,7 @@ lemma invokeX86PortIn32_ccorres:
                    apply (rule ccorres_inst[where P=\<top> and P'=UNIV])
                    apply (rule ccorres_from_vcg_throws[where P=\<top> and P'=UNIV])
                    apply (rule allI, rule conseqPre, vcg)
-                   apply (clarsimp simp: return_def dc_def)
+                   apply (clarsimp simp: return_def)
                   apply (rule hoare_post_taut[of \<top>])
                  apply (vcg exspec=setThreadState_modifies)
                 apply wpsimp
@@ -4818,10 +4814,10 @@ lemma invokeX86PortIn32_ccorres:
                                  Kernel_C.msgInfoRegister_def)
            apply (vcg exspec=setMR_modifies)
           apply wpsimp
-         apply (clarsimp simp: dc_def)
+         apply clarsimp
          apply (vcg exspec=setRegister_modifies)
         apply wpsimp
-       apply (clarsimp simp: dc_def ThreadState_Running_def)
+       apply (clarsimp simp: ThreadState_Running_def)
        apply (vcg exspec=lookupIPCBuffer_modifies)
       apply (wpsimp wp: hoare_vcg_imp_lift hoare_vcg_all_lift)
      apply (vcg exspec=in32_modifies)
@@ -4836,7 +4832,7 @@ lemma invokeX86PortIn32_ccorres:
                                            simplified, symmetric])
 
 lemma invokeX86PortOut8_ccorres:
-  notes Collect_const[simp del] dc_simp[simp del]
+  notes Collect_const[simp del]
   shows
   "ccorres (cintr \<currency> (\<lambda>rv rv'. rv = [])) (liftxf errstate id (K ()) ret__unsigned_long_')
        invs'
@@ -4855,7 +4851,7 @@ lemma invokeX86PortOut8_ccorres:
   done
 
 lemma invokeX86PortOut16_ccorres:
-  notes Collect_const[simp del] dc_simp[simp del]
+  notes Collect_const[simp del]
   shows
   "ccorres (cintr \<currency> (\<lambda>rv rv'. rv = [])) (liftxf errstate id (K ()) ret__unsigned_long_')
        invs'
@@ -4874,7 +4870,7 @@ lemma invokeX86PortOut16_ccorres:
   done
 
 lemma invokeX86PortOut32_ccorres:
-  notes Collect_const[simp del] dc_simp[simp del]
+  notes Collect_const[simp del]
   shows
   "ccorres (cintr \<currency> (\<lambda>rv rv'. rv = [])) (liftxf errstate id (K ()) ret__unsigned_long_')
        invs'
@@ -5340,7 +5336,7 @@ proof -
                 apply (rule ccorres_equals_throwError)
                  apply (fastforce simp: whenE_def throwError_bind invocationCatch_def)
                 apply ccorres_rewrite
-                apply (rule syscall_error_throwError_ccorres_n[simplified dc_def id_def o_def])
+                apply (rule syscall_error_throwError_ccorres_n)
                 apply (clarsimp simp: syscall_error_to_H_cases)
                apply (clarsimp simp: ucast_drop_big_mask)
                apply (clarsimp simp: invocationCatch_use_injection_handler injection_bindE[OF refl refl]
@@ -5352,7 +5348,7 @@ proof -
                 apply (rule ccorres_Cond_rhs_Seq)
                  apply (clarsimp simp: from_bool_0 injection_handler_throwError)
                  apply ccorres_rewrite
-                 apply (rule syscall_error_throwError_ccorres_n[simplified dc_def id_def o_def])
+                 apply (rule syscall_error_throwError_ccorres_n)
                  apply (clarsimp simp: syscall_error_to_H_cases)
                 apply (clarsimp simp: from_bool_neq_0 injection_handler_returnOk)
                 apply (ctac add: ccorres_injection_handler_csum1
@@ -5365,8 +5361,7 @@ proof -
                       apply ccorres_rewrite
                       apply (rule_tac P="\<lambda>s. thread = ksCurThread s" in ccorres_cross_over_guard)
                       apply (ctac add: setThreadState_ccorres)
-                        apply (ctac(no_vcg) add: invokeX86PortControl_ccorres
-                                                   [simplified dc_def o_def id_def])
+                        apply (ctac(no_vcg) add: invokeX86PortControl_ccorres)
                         apply clarsimp
                         apply (rule ccorres_alternative2)
                         apply (rule ccorres_return_CE, simp+)[1]
@@ -5422,7 +5417,7 @@ proof -
      apply (clarsimp simp: interpret_excaps_eq rf_sr_ksCurThread ThreadState_Restart_def mask_def)
      apply (clarsimp simp: rf_sr_def cstate_relation_def Let_def)
     apply clarsimp
-    apply (rule conjI, clarsimp simp: sysargs_rel_to_n o_def dest!: unat_length_4_helper)
+    apply (rule conjI, clarsimp simp: sysargs_rel_to_n dest!: unat_length_4_helper)
     apply (clarsimp simp: o_def)
     done
 qed

--- a/proof/crefine/X64/CSpace_All.thy
+++ b/proof/crefine/X64/CSpace_All.thy
@@ -25,9 +25,9 @@ abbreviation
 
 (* FIXME: move *)
 lemma ccorres_return_into_rel:
-  "ccorres (\<lambda>rv rv'. r (f rv) rv') xf G G' hs a c
+  "ccorres (r \<circ> f) xf G G' hs a c
   \<Longrightarrow> ccorres r xf G G' hs (a >>= (\<lambda>rv. return (f rv))) c"
-  by (simp add: liftM_def[symmetric] o_def)
+  by (simp add: liftM_def[symmetric])
 
 lemma lookupCap_ccorres':
   "ccorres (lookup_failure_rel \<currency> ccap_relation) lookupCap_xf

--- a/proof/crefine/X64/CSpace_C.thy
+++ b/proof/crefine/X64/CSpace_C.thy
@@ -894,7 +894,7 @@ lemma setUntypedCapAsFull_ccorres [corres]:
     apply (rule ccorres_move_c_guard_cte)
     apply (rule ccorres_Guard)
     apply (rule ccorres_call)
-       apply (rule update_freeIndex [unfolded dc_def])
+       apply (rule update_freeIndex)
       apply simp
      apply simp
     apply simp
@@ -920,14 +920,14 @@ lemma setUntypedCapAsFull_ccorres [corres]:
       apply csymbr
       apply (clarsimp simp: cap_get_tag_to_H cap_get_tag_UntypedCap split: if_split_asm)
       apply (rule ccorres_cond_false)
-      apply (rule ccorres_return_Skip [unfolded dc_def])
+      apply (rule ccorres_return_Skip)
      apply (clarsimp simp: cap_get_tag_isCap[symmetric] cap_get_tag_UntypedCap split: if_split_asm)
      apply (rule ccorres_cond_false)
-     apply (rule ccorres_return_Skip [unfolded dc_def])
-    apply (rule ccorres_return_Skip [unfolded dc_def])
+     apply (rule ccorres_return_Skip)
+    apply (rule ccorres_return_Skip)
    apply clarsimp
    apply (rule ccorres_cond_false)
-   apply (rule ccorres_return_Skip [unfolded dc_def])
+   apply (rule ccorres_return_Skip)
   apply (clarsimp simp: cap_get_tag_isCap[symmetric] cap_get_tag_UntypedCap)
   apply (frule(1) cte_wp_at_valid_objs_valid_cap')
   apply (clarsimp simp: untypedBits_defs)
@@ -1043,19 +1043,17 @@ lemma cteInsert_ccorres:
                   apply csymbr
                   apply simp
                   apply (rule ccorres_move_c_guard_cte)
-                  apply (simp add:dc_def[symmetric])
                   apply (ctac ccorres:ccorres_updateMDB_set_mdbPrev)
-                 apply (simp add:dc_def[symmetric])
                  apply (ctac ccorres: ccorres_updateMDB_skip)
                 apply (wp static_imp_wp)+
-              apply (clarsimp simp: Collect_const_mem dc_def split del: if_split)
+              apply (clarsimp simp: Collect_const_mem split del: if_split)
               apply vcg
              apply (wp static_imp_wp)
-            apply (clarsimp simp: Collect_const_mem dc_def split del: if_split)
+            apply (clarsimp simp: Collect_const_mem split del: if_split)
             apply vcg
            apply (clarsimp simp:cmdb_node_relation_mdbNext)
            apply (wp setUntypedCapAsFull_cte_at_wp static_imp_wp)
-          apply (clarsimp simp: Collect_const_mem dc_def split del: if_split)
+          apply (clarsimp simp: Collect_const_mem split del: if_split)
           apply (vcg exspec=setUntypedCapAsFull_modifies)
          apply wp
         apply vcg
@@ -2438,8 +2436,8 @@ lemma Arch_postCapDeletion_ccorres:
    prefer 3 (* IOPort case *)
    apply (rule ccorres_rhs_assoc)+
    apply csymbr+
-   apply (ctac add: freeIOPortRange_ccorres[simplified dc_def])
-   apply (rule ccorres_return_Skip[simplified dc_def])+
+   apply (ctac add: freeIOPortRange_ccorres)
+   apply (rule ccorres_return_Skip)+
   apply (clarsimp simp: arch_cleanup_info_wf'_def split: arch_capability.splits)
   apply (frule cap_get_tag_isCap_unfolded_H_cap)
   by (clarsimp simp: ccap_relation_def cap_io_port_cap_lift cap_to_H_def)
@@ -2464,7 +2462,6 @@ lemma postCapDeletion_ccorres:
     apply (rule ccorres_symb_exec_r)
       apply (rule_tac xf'=irq_' in ccorres_abstract, ceqv)
       apply (rule_tac P="rv' = ucast (capIRQ cap)" in ccorres_gen_asm2)
-      apply (fold dc_def)
       apply (frule cap_get_tag_to_H, solves \<open>clarsimp simp: cap_get_tag_isCap_unfolded_H_cap\<close>)
       apply (clarsimp simp: cap_irq_handler_cap_lift)
       apply (ctac(no_vcg) add: deletedIRQHandler_ccorres)
@@ -2475,9 +2472,9 @@ lemma postCapDeletion_ccorres:
    apply (clarsimp simp: cap_get_tag_isCap)
    apply (rule ccorres_Cond_rhs)
     apply (wpc; clarsimp simp: isCap_simps)
-    apply (ctac(no_vcg) add: Arch_postCapDeletion_ccorres[unfolded dc_def])
+    apply (ctac(no_vcg) add: Arch_postCapDeletion_ccorres)
    apply (simp add: not_irq_or_arch_cap_case)
-   apply (rule ccorres_return_Skip[unfolded dc_def])+
+   apply (rule ccorres_return_Skip)
   apply clarsimp
   apply (rule conjI, clarsimp simp: isCap_simps  Kernel_C.maxIRQ_def)
    apply (frule cap_get_tag_isCap_unfolded_H_cap(5))
@@ -2527,7 +2524,7 @@ lemma emptySlot_ccorres:
 
     \<comment> \<open>*** proof for the 'else' branch (return () and SKIP) ***\<close>
      prefer 2
-     apply (ctac add: ccorres_return_Skip[unfolded dc_def])
+     apply (ctac add: ccorres_return_Skip)
 
     \<comment> \<open>*** proof for the 'then' branch ***\<close>
 
@@ -2572,7 +2569,7 @@ lemma emptySlot_ccorres:
 
                   \<comment> \<open>the post_cap_deletion case\<close>
 
-                  apply (ctac(no_vcg) add: postCapDeletion_ccorres [unfolded dc_def])
+                  apply (ctac(no_vcg) add: postCapDeletion_ccorres)
 
                 \<comment> \<open>Haskell pre/post for y \<leftarrow> updateMDB slot (\<lambda>a. nullMDBNode);\<close>
                  apply wp
@@ -2646,7 +2643,7 @@ lemma capSwapForDelete_ccorres:
    apply (simp add:when_def)
    apply (rule ccorres_if_cond_throws2 [where Q = \<top> and Q' = \<top>])
       apply (case_tac "slot1=slot2", simp+)
-     apply (rule ccorres_return_void_C [simplified dc_def])
+     apply (rule ccorres_return_void_C)
 
   \<comment> \<open>***Main goal***\<close>
   \<comment> \<open>--- ccorres goal with 2 affectations (cap1 and cap2) on both on Haskell and C\<close>
@@ -2655,7 +2652,7 @@ lemma capSwapForDelete_ccorres:
     apply (rule ccorres_pre_getCTE)+
     apply (rule ccorres_move_c_guard_cte, rule ccorres_symb_exec_r)+
   \<comment> \<open>***Main goal***\<close>
-        apply (ctac (no_vcg) add: cteSwap_ccorres [unfolded dc_def] )
+        apply (ctac (no_vcg) add: cteSwap_ccorres)
        \<comment> \<open>C Hoare triple for \<acute>cap2 :== \<dots>\<close>
        apply vcg
        \<comment> \<open>C existential Hoare triple for \<acute>cap2 :== \<dots>\<close>

--- a/proof/crefine/X64/Delete_C.thy
+++ b/proof/crefine/X64/Delete_C.thy
@@ -856,7 +856,7 @@ lemma finaliseSlot_ccorres:
                                       ccorres_seq_skip)
                     apply (rule rsubst[where P="ccorres r xf' P P' hs a" for r xf' P P' hs a])
                     apply (rule hyps[folded reduceZombie_def[unfolded cteDelete_def finaliseSlot_def],
-                                         unfolded split_def, unfolded K_def],
+                                     unfolded split_def],
                            (simp add: in_monad)+)
                     apply (simp add: from_bool_0)
                    apply simp
@@ -1007,26 +1007,23 @@ lemma cteRevoke_ccorres1:
          apply (rule ccorres_drop_cutMon_bindE)
          apply (rule ccorres_rhs_assoc)+
          apply (ctac(no_vcg) add: cteDelete_ccorres)
-           apply (simp del: Collect_const add: Collect_False ccorres_cond_iffs
-                                               dc_def[symmetric])
+           apply (simp del: Collect_const add: Collect_False ccorres_cond_iffs)
            apply (rule ccorres_cutMon, simp only: cutMon_walk_bindE)
            apply (rule ccorres_drop_cutMon_bindE)
            apply (ctac(no_vcg) add: preemptionPoint_ccorres)
-             apply (simp del: Collect_const add: Collect_False ccorres_cond_iffs
-                                                 dc_def[symmetric])
+             apply (simp del: Collect_const add: Collect_False ccorres_cond_iffs)
              apply (rule ccorres_cutMon)
              apply (rule rsubst[where P="ccorres r xf' P P' hs a" for r xf' P P' hs a])
-              apply (rule hyps[unfolded K_def],
-                     (fastforce simp: in_monad)+)[1]
+              apply (rule hyps; fastforce simp: in_monad)
              apply simp
             apply (simp, rule ccorres_split_throws)
-             apply (rule ccorres_return_C_errorE, simp+)[1]
+             apply (rule ccorres_return_C_errorE; simp)
             apply vcg
            apply (wp preemptionPoint_invR)
             apply simp
            apply simp
           apply (simp, rule ccorres_split_throws)
-           apply (rule ccorres_return_C_errorE, simp+)[1]
+           apply (rule ccorres_return_C_errorE; simp)
           apply vcg
          apply (wp cteDelete_invs' cteDelete_sch_act_simple)
         apply (rule ccorres_cond_false)

--- a/proof/crefine/X64/Finalise_C.thy
+++ b/proof/crefine/X64/Finalise_C.thy
@@ -201,8 +201,7 @@ proof (induct ts)
     apply (rule iffD1 [OF ccorres_expand_while_iff])
     apply (rule ccorres_tmp_lift2[where G'=UNIV and G''="\<lambda>x. UNIV", simplified])
      apply ceqv
-    apply (simp add: ccorres_cond_iffs mapM_x_def sequence_x_def
-                     dc_def[symmetric])
+    apply (simp add: ccorres_cond_iffs mapM_x_def sequence_x_def)
     apply (rule ccorres_guard_imp2, rule ccorres_return_Skip)
     apply simp
     done
@@ -211,7 +210,7 @@ next
   show ?case
     apply (rule iffD1 [OF ccorres_expand_while_iff])
     apply (simp del: Collect_const
-                add: dc_def[symmetric] mapM_x_Cons)
+                add: mapM_x_Cons)
     apply (rule ccorres_guard_imp2)
      apply (rule_tac xf'=thread_' in ccorres_abstract)
       apply ceqv
@@ -327,7 +326,7 @@ lemma cancelAllIPC_ccorres:
              subgoal by (simp add: cendpoint_relation_def endpoint_state_defs)
             subgoal by simp
            apply (rule ceqv_refl)
-          apply (simp only: ccorres_seq_skip dc_def[symmetric])
+          apply (simp only: ccorres_seq_skip)
           apply (rule ccorres_split_nothrow_novcg)
               apply (rule cancel_all_ccorres_helper)
              apply ceqv
@@ -344,12 +343,10 @@ lemma cancelAllIPC_ccorres:
          apply (wp set_ep_valid_objs' hoare_vcg_const_Ball_lift
                    weak_sch_act_wf_lift_linear)
         apply vcg
-       apply (simp add: ccorres_cond_iffs dc_def[symmetric])
+       apply (simp add: ccorres_cond_iffs)
        apply (rule ccorres_return_Skip)
       apply (rename_tac list)
-      apply (simp add: endpoint_state_defs
-                       Collect_False Collect_True
-                       ccorres_cond_iffs dc_def[symmetric]
+      apply (simp add: endpoint_state_defs Collect_False Collect_True ccorres_cond_iffs
                   del: Collect_const)
       apply (rule ccorres_rhs_assoc)+
       apply csymbr
@@ -379,7 +376,7 @@ lemma cancelAllIPC_ccorres:
            subgoal by (simp add: cendpoint_relation_def endpoint_state_defs)
           subgoal by simp
          apply (rule ceqv_refl)
-        apply (simp only: ccorres_seq_skip dc_def[symmetric])
+        apply (simp only: ccorres_seq_skip)
         apply (rule ccorres_split_nothrow_novcg)
             apply (rule cancel_all_ccorres_helper)
            apply ceqv
@@ -427,15 +424,12 @@ lemma cancelAllSignals_ccorres:
      apply (rule_tac A="invs' and ko_at' rv ntfnptr"
                   in ccorres_guard_imp2[where A'=UNIV])
       apply wpc
-        apply (simp add: notification_state_defs ccorres_cond_iffs
-                         dc_def[symmetric])
+        apply (simp add: notification_state_defs ccorres_cond_iffs)
         apply (rule ccorres_return_Skip)
-       apply (simp add: notification_state_defs ccorres_cond_iffs
-                        dc_def[symmetric])
+       apply (simp add: notification_state_defs ccorres_cond_iffs)
        apply (rule ccorres_return_Skip)
       apply (rename_tac list)
-      apply (simp add: notification_state_defs ccorres_cond_iffs
-                       dc_def[symmetric] Collect_True
+      apply (simp add: notification_state_defs ccorres_cond_iffs Collect_True
                   del: Collect_const)
       apply (rule ccorres_rhs_assoc)+
       apply csymbr
@@ -463,7 +457,7 @@ lemma cancelAllSignals_ccorres:
            subgoal by (simp add: cnotification_relation_def notification_state_defs Let_def)
           subgoal by simp
          apply (rule ceqv_refl)
-        apply (simp only: ccorres_seq_skip dc_def[symmetric])
+        apply (simp only: ccorres_seq_skip)
         apply (rule ccorres_split_nothrow_novcg)
             apply (rule cancel_all_ccorres_helper)
            apply ceqv
@@ -722,7 +716,7 @@ lemma doUnbindNotification_ccorres:
       apply (rule ccorres_move_c_guard_tcb)
       apply (simp add: setBoundNotification_def)
       apply (rule_tac P'="\<top>" and P="\<top>"
-                   in threadSet_ccorres_lemma3[unfolded dc_def])
+                   in threadSet_ccorres_lemma3)
        apply vcg
       apply simp
       apply (erule(1) rf_sr_tcb_update_no_queue2)
@@ -774,7 +768,7 @@ lemma doUnbindNotification_ccorres':
       apply (rule ccorres_move_c_guard_tcb)
       apply (simp add: setBoundNotification_def)
       apply (rule_tac P'="\<top>" and P="\<top>"
-                   in threadSet_ccorres_lemma3[unfolded dc_def])
+                   in threadSet_ccorres_lemma3)
        apply vcg
       apply simp
       apply (erule(1) rf_sr_tcb_update_no_queue2)
@@ -809,9 +803,9 @@ lemma unbindNotification_ccorres:
      apply simp
      apply wpc
       apply (rule ccorres_cond_false)
-      apply (rule ccorres_return_Skip[unfolded dc_def])
+      apply (rule ccorres_return_Skip)
      apply (rule ccorres_cond_true)
-     apply (ctac (no_vcg) add: doUnbindNotification_ccorres[unfolded dc_def, simplified])
+     apply (ctac (no_vcg) add: doUnbindNotification_ccorres[simplified])
     apply (wp gbn_wp')
    apply vcg
   apply (clarsimp simp: option_to_ptr_def option_to_0_def pred_tcb_at'_def
@@ -1024,8 +1018,7 @@ lemma deleteASIDPool_ccorres:
   apply (rule ccorres_gen_asm)
   apply (cinit lift: asid_base_' pool_' simp: whileAnno_def)
    apply (rule ccorres_assert)
-   apply (clarsimp simp: liftM_def dc_def[symmetric] fun_upd_def[symmetric]
-                         when_def
+   apply (clarsimp simp: liftM_def fun_upd_def[symmetric] when_def
                simp del: Collect_const)
    apply (rule ccorres_Guard)+
    apply (rule ccorres_pre_gets_x86KSASIDTable_ksArchState)
@@ -1187,12 +1180,10 @@ lemma deleteASID_ccorres:
        apply (simp add: asid_high_bits_def)
       apply ceqv
      apply wpc
-      apply (simp add: ccorres_cond_iffs dc_def[symmetric]
-                       Collect_False
+      apply (simp add: ccorres_cond_iffs Collect_False
                  cong: call_ignore_cong)
       apply (rule ccorres_return_Skip)
-     apply (clarsimp simp: dc_def[symmetric] when_def
-                           liftM_def
+     apply (clarsimp simp: when_def liftM_def
                      cong: conj_cong call_ignore_cong)
      apply ccorres_rewrite
      apply (rule ccorres_rhs_assoc)+
@@ -1458,16 +1449,16 @@ lemma unmapPageTable_ccorres:
            apply (simp add: from_bool_0)
            apply ccorres_rewrite
            apply (clarsimp simp: throwError_def)
-           apply (rule ccorres_return_void_C[simplified dc_def])
+           apply (rule ccorres_return_void_C)
           apply (simp add: from_bool_0)
-          apply (rule ccorres_liftE[simplified dc_def])
+          apply (rule ccorres_liftE', simp)
           apply (ctac add: flushTable_ccorres)
             apply (csymbr, rename_tac invalidPDE)
             apply (rule ccorres_split_nothrow_novcg_dc)
                apply (rule storePDE_Basic_ccorres)
                apply (simp add: cpde_relation_def Let_def)
               apply (csymbr, rename_tac root)
-              apply (ctac add: invalidatePageStructureCacheASID_ccorres[simplified dc_def])
+              apply (ctac add: invalidatePageStructureCacheASID_ccorres)
              apply wp
             apply (clarsimp simp add: guard_is_UNIV_def)
            apply wp
@@ -1475,14 +1466,14 @@ lemma unmapPageTable_ccorres:
           apply (vcg exspec=flushTable_modifies)
          apply (clarsimp simp: guard_is_UNIV_def)
         apply (simp,ccorres_rewrite,simp add:throwError_def)
-        apply (rule ccorres_return_void_C[simplified dc_def])
+        apply (rule ccorres_return_void_C)
        apply (clarsimp,wp)
        apply (rule_tac Q'="\<lambda>_ s. invs' s \<and> page_table_at' ptPtr s" in hoare_post_imp_R)
         apply wp
        apply clarsimp
       apply (vcg exspec=lookupPDSlot_modifies)
      apply (simp,ccorres_rewrite,simp add:throwError_def)
-     apply (rule ccorres_return_void_C[simplified dc_def])
+     apply (rule ccorres_return_void_C)
     apply wp
    apply vcg
   apply (auto simp add: asid_wf_def mask_def)
@@ -1600,7 +1591,7 @@ lemma cteDeleteOne_ccorres:
           erule_tac t="ret__unsigned_longlong = scast cap_null_cap"
                 and s="cteCap cte = NullCap"
                  in ssubst)
-   apply (clarsimp simp only: when_def unless_def dc_def[symmetric])
+   apply (clarsimp simp only: when_def unless_def)
    apply (rule ccorres_cond2[where R=\<top>])
      apply (clarsimp simp: Collect_const_mem)
     apply (rule ccorres_rhs_assoc)+
@@ -1611,12 +1602,11 @@ lemma cteDeleteOne_ccorres:
       apply (ctac(no_vcg) add: isFinalCapability_ccorres[where slot=slot])
        apply (rule_tac A="invs'  and cte_wp_at' ((=) cte) slot"
                      in ccorres_guard_imp2[where A'=UNIV])
-        apply (simp add: split_def dc_def[symmetric]
-                    del: Collect_const)
+        apply (simp add: split_def del: Collect_const)
         apply (rule ccorres_move_c_guard_cte)
         apply (ctac(no_vcg) add: finaliseCap_True_standin_ccorres)
          apply (rule ccorres_assert)
-         apply (simp add: dc_def[symmetric])
+         apply simp
          apply csymbr
          apply (ctac add: emptySlot_ccorres)
         apply (simp add: pred_conj_def finaliseCapTrue_standin_simple_def)
@@ -1652,7 +1642,7 @@ lemma deletingIRQHandler_ccorres:
                    (UNIV \<inter> {s. irq_opt_relation (Some irq) (irq_' s)}) []
    (deletingIRQHandler irq) (Call deletingIRQHandler_'proc)"
   apply (cinit lift: irq_' cong: call_ignore_cong)
-   apply (clarsimp simp: irq_opt_relation_def ptr_add_assertion_def dc_def[symmetric]
+   apply (clarsimp simp: irq_opt_relation_def ptr_add_assertion_def
                    cong: call_ignore_cong )
    apply (rule_tac r'="\<lambda>rv rv'. rv' = Ptr rv"
                 and xf'="slot_'" in ccorres_split_nothrow)
@@ -1869,16 +1859,16 @@ lemma unmapPageDirectory_ccorres:
            apply (simp add: from_bool_0)
            apply ccorres_rewrite
            apply (clarsimp simp: throwError_def)
-           apply (rule ccorres_return_void_C[simplified dc_def])
+           apply (rule ccorres_return_void_C)
           apply (simp add: from_bool_0)
-          apply (rule ccorres_liftE[simplified dc_def])
+          apply (rule ccorres_liftE', simp)
           apply (ctac add: flushPD_ccorres)
             apply (csymbr, rename_tac invalidPDPTE)
             apply (rule ccorres_split_nothrow_novcg_dc)
                apply (rule storePDPTE_Basic_ccorres)
                apply (simp add: cpdpte_relation_def Let_def)
               apply (csymbr, rename_tac root)
-              apply (ctac add: invalidatePageStructureCacheASID_ccorres[simplified dc_def])
+              apply (ctac add: invalidatePageStructureCacheASID_ccorres)
              apply wp
             apply (clarsimp simp add: guard_is_UNIV_def)
            apply wp
@@ -1886,11 +1876,11 @@ lemma unmapPageDirectory_ccorres:
           apply (vcg exspec=flushPD_modifies)
          apply (clarsimp simp: guard_is_UNIV_def)
         apply (simp,ccorres_rewrite,simp add:throwError_def)
-        apply (rule ccorres_return_void_C[simplified dc_def])
+        apply (rule ccorres_return_void_C)
        apply wpsimp
       apply (vcg exspec=lookupPDPTSlot_modifies)
      apply (simp,ccorres_rewrite,simp add:throwError_def)
-     apply (rule ccorres_return_void_C[simplified dc_def])
+     apply (rule ccorres_return_void_C)
     apply wp
    apply vcg
   apply (auto simp add: asid_wf_def mask_def)
@@ -1931,7 +1921,7 @@ lemma unmapPDPointerTable_ccorres:
         apply ccorres_rewrite
         apply (clarsimp simp: from_bool_0 isPDPointerTablePML4E_def split: pml4e.splits;
                clarsimp simp: throwError_def;
-               rule ccorres_return_void_C[simplified dc_def])
+               rule ccorres_return_void_C)
        apply (clarsimp simp: isPDPointerTablePML4E_def liftE_def bind_assoc split: pml4e.split_asm)
        apply (ctac add: flushPDPT_ccorres)
          apply csymbr
@@ -1939,7 +1929,7 @@ lemma unmapPDPointerTable_ccorres:
          apply (rule ccorres_split_nothrow_novcg_dc)
             apply (rule storePML4E_Basic_ccorres')
             apply (fastforce simp: cpml4e_relation_def)
-           apply (rule ccorres_return_Skip[simplified dc_def])
+           apply (rule ccorres_return_Skip)
           apply wp
          apply (fastforce simp: guard_is_UNIV_def)
         apply wp
@@ -1947,7 +1937,7 @@ lemma unmapPDPointerTable_ccorres:
       apply vcg
      apply ccorres_rewrite
      apply (clarsimp simp: throwError_def)
-     apply (rule ccorres_return_void_C[simplified dc_def])
+     apply (rule ccorres_return_void_C)
     apply (wpsimp wp: hoare_drop_imps)
    apply (vcg exspec=findVSpaceForASID_modifies)
   apply (auto simp: invs_arch_state' invs_no_0_obj' asid_wf_def mask_def typ_heap_simps
@@ -2169,7 +2159,7 @@ lemma Mode_finaliseCap_ccorres_page_cap:
                dest!: x_less_2_0_1)
 
 lemma Arch_finaliseCap_ccorres:
-  notes dc_simp[simp del] Collect_const[simp del]
+  notes Collect_const[simp del]
   shows
   "ccorres (\<lambda>rv rv'. ccap_relation (fst rv) (remainder_C rv') \<and>
                      ccap_relation (snd rv) (finaliseCap_ret_C.cleanupInfo_C rv'))
@@ -2395,7 +2385,7 @@ lemma fpuThreadDelete_ccorres:
      (invs' and tcb_at' thread)
      (UNIV \<inter> {s. thread_' s = tcb_ptr_to_ctcb_ptr thread}) hs
    (fpuThreadDelete thread) (Call fpuThreadDelete_'proc)"
-  supply Collect_const[simp del] dc_simp[simp del]
+  supply Collect_const[simp del]
   apply (cinit lift: thread_')
    apply clarsimp
    apply (ctac (no_vcg) add: nativeThreadUsingFPU_ccorres)
@@ -2412,7 +2402,6 @@ lemma prepareThreadDelete_ccorres:
      (invs' and tcb_at' thread)
      (UNIV \<inter> {s. thread_' s = tcb_ptr_to_ctcb_ptr thread}) hs
    (prepareThreadDelete thread) (Call Arch_prepareThreadDelete_'proc)"
-  supply dc_simp[simp del]
   apply (cinit lift: thread_', rename_tac cthread)
    apply (ctac add: fpuThreadDelete_ccorres)
   apply fastforce
@@ -2567,18 +2556,18 @@ lemma finaliseCap_ccorres:
     apply (rule ccorres_fail)
    apply (rule ccorres_add_return, rule ccorres_split_nothrow_novcg[where r'=dc and xf'=xfdc])
        apply (rule ccorres_Cond_rhs)
-        apply (simp add: ccorres_cond_iffs dc_def[symmetric])
+        apply (simp add: ccorres_cond_iffs)
         apply (rule ccorres_return_Skip)
        apply (rule ccorres_Cond_rhs)
-        apply (simp add: ccorres_cond_iffs dc_def[symmetric])
+        apply (simp add: ccorres_cond_iffs)
         apply (rule ccorres_return_Skip)
        apply (rule ccorres_Cond_rhs)
         apply (rule ccorres_inst[where P=\<top> and P'=UNIV])
         apply simp
        apply (rule ccorres_Cond_rhs)
-        apply (simp add: ccorres_cond_iffs dc_def[symmetric])
+        apply (simp add: ccorres_cond_iffs)
         apply (rule ccorres_return_Skip)
-       apply (simp add: ccorres_cond_iffs dc_def[symmetric])
+       apply (simp add: ccorres_cond_iffs)
        apply (rule ccorres_return_Skip)
       apply (rule ceqv_refl)
      apply (rule ccorres_from_vcg_throws[where P=\<top> and P'=UNIV])

--- a/proof/crefine/X64/Finalise_C.thy
+++ b/proof/crefine/X64/Finalise_C.thy
@@ -405,11 +405,6 @@ lemma cancelAllIPC_ccorres:
   apply clarsimp
   done
 
-lemma empty_fail_getNotification:
-  "empty_fail (getNotification ep)"
-  unfolding getNotification_def
-  by (auto intro: empty_fail_getObject)
-
 lemma cancelAllSignals_ccorres:
   "ccorres dc xfdc
    (invs') (UNIV \<inter> {s. ntfnPtr_' s = Ptr ntfnptr}) []
@@ -1508,12 +1503,6 @@ lemma no_0_pml4_at'[elim!]:
   apply (clarsimp simp: page_map_l4_at'_def)
   apply (drule spec[where x=0], clarsimp simp: bit_simps)
   done
-
-lemma ccte_relation_ccap_relation:
-  "ccte_relation cte cte' \<Longrightarrow> ccap_relation (cteCap cte) (cte_C.cap_C cte')"
-  by (clarsimp simp: ccte_relation_def ccap_relation_def
-                     cte_to_H_def map_option_Some_eq2
-                     c_valid_cte_def)
 
 lemma isFinalCapability_ccorres:
   "ccorres ((=) \<circ> from_bool) ret__unsigned_long_'

--- a/proof/crefine/X64/Interrupt_C.thy
+++ b/proof/crefine/X64/Interrupt_C.thy
@@ -75,7 +75,7 @@ proof -
      apply (rule ccorres_symb_exec_r)
        apply (ctac(no_vcg) add: cteDeleteOne_ccorres[where w="-1"])
         apply (rule ccorres_call)
-           apply (rule cteInsert_ccorres[simplified dc_def])
+           apply (rule cteInsert_ccorres)
           apply simp
          apply simp
         apply simp
@@ -112,7 +112,7 @@ lemma invokeIRQHandler_ClearIRQHandler_ccorres:
    apply (simp add: ucast_up_ucast is_up)
    apply (ctac(no_vcg) add: getIRQSlot_ccorres[simplified])
      apply (rule ccorres_symb_exec_r)
-       apply (ctac add: cteDeleteOne_ccorres[where w="-1",simplified dc_def])
+       apply (ctac add: cteDeleteOne_ccorres[where w="-1"])
       apply vcg
      apply (rule conseqPre, vcg, clarsimp simp: rf_sr_def
         gs_set_assn_Delete_cstate_relation[unfolded o_def])
@@ -349,7 +349,7 @@ lemma invokeIRQControl_ccorres:
       (performIRQControl (IssueIRQHandler irq slot parent))
       (Call invokeIRQControl_'proc)"
   by (clarsimp simp: performIRQControl_def liftE_def bind_assoc
-               intro!: invokeIRQControl_expanded_ccorres[simplified liftE_def K_def, simplified])
+               intro!: invokeIRQControl_expanded_ccorres[simplified liftE_def, simplified])
 
 lemma isIRQActive_ccorres:
   "ccorres (\<lambda>rv rv'. rv' = from_bool rv) ret__unsigned_long_'
@@ -719,7 +719,7 @@ from assms show ?thesis
    apply (rule ccorres_Cond_rhs_Seq)
     apply ccorres_rewrite
     apply (auto split: invocation_label.split arch_invocation_label.split
-                intro: syscall_error_throwError_ccorres_n[simplified throwError_def o_def dc_def id_def]
+                intro: syscall_error_throwError_ccorres_n[simplified throwError_def o_def]
                 simp: throwError_def invocationCatch_def syscall_error_to_H_cases invocation_eq_use_types)[1]
    apply clarsimp
    apply (rule ccorres_rhs_assoc2)
@@ -739,13 +739,13 @@ from assms show ?thesis
       apply (erule ccorres_disj_division;
              clarsimp split: invocation_label.split simp: invocation_eq_use_types)
        apply (auto split: list.split
-                   intro: syscall_error_throwError_ccorres_n[simplified throwError_def o_def dc_def id_def]
+                   intro: syscall_error_throwError_ccorres_n[simplified throwError_def o_def]
                    simp: throwError_def invocationCatch_def syscall_error_to_H_cases)[2]
      (* Insufficient extra caps *)
      apply (erule ccorres_disj_division;
             clarsimp split: invocation_label.split simp: invocation_eq_use_types)
       apply (auto split: list.split
-                  intro: syscall_error_throwError_ccorres_n[simplified throwError_def o_def dc_def id_def]
+                  intro: syscall_error_throwError_ccorres_n[simplified throwError_def o_def]
                   simp: throwError_def invocationCatch_def syscall_error_to_H_cases)[2]
     (* Arguments OK *)
     apply ccorres_rewrite
@@ -772,7 +772,7 @@ from assms show ?thesis
                                   word_sless_alt is_down sint_ucast_eq_uint word_le_not_less
                                   invocationCatch_use_injection_handler injection_handler_throwError
                                   syscall_error_to_H_cases
-                            intro: syscall_error_throwError_ccorres_n[simplified id_def dc_def]) |
+                            intro: syscall_error_throwError_ccorres_n) |
                        ccorres_rewrite)+)[2]
             apply (erule ccorres_disj_division; clarsimp simp: invocation_eq_use_types)
              (* X64IRQIssueIRQHandlerIOAPIC *)
@@ -792,7 +792,7 @@ from assms show ?thesis
                apply (simp add: injection_handler_whenE injection_handler_throwError)
                apply (rule ccorres_split_when_throwError_cond[where Q=\<top> and Q'=\<top>])
                   apply clarsimp
-                 apply (rule syscall_error_throwError_ccorres_n[simplified id_def dc_def])
+                 apply (rule syscall_error_throwError_ccorres_n)
                  apply (fastforce simp: syscall_error_to_H_cases)
                 apply csymbr
                 apply (ctac add: ccorres_injection_handler_csum1
@@ -828,8 +828,7 @@ from assms show ?thesis
                                              where g="\<lambda>_. injection_handler P Q >>=E R" for P Q R])
                             apply (clarsimp simp: injection_handler_returnOk)
                             apply (simp only: bindE_K_bind)
-                            apply (ctac add: ioapic_decode_map_pin_to_vector_ccorres
-                                               [simplified o_def id_def dc_def K_def])
+                            apply (ctac add: ioapic_decode_map_pin_to_vector_ccorres[simplified o_def])
                                apply ccorres_rewrite
                                apply (simp add: ccorres_invocationCatch_Inr performInvocation_def
                                                 returnOk_bind liftE_bindE bindE_assoc
@@ -895,7 +894,7 @@ from assms show ?thesis
               apply (simp add: injection_handler_whenE injection_handler_throwError)
               apply (rule ccorres_split_when_throwError_cond[where Q=\<top> and Q'=\<top>])
                  apply clarsimp
-                apply (rule syscall_error_throwError_ccorres_n[simplified id_def dc_def])
+                apply (rule syscall_error_throwError_ccorres_n)
                 apply (fastforce simp: syscall_error_to_H_cases)
                apply csymbr
                apply (ctac add: ccorres_injection_handler_csum1
@@ -931,7 +930,7 @@ from assms show ?thesis
                            (* Handle the conditional checks on PCI bus/dev/func *)
                            apply ((rule_tac Q=\<top> and Q'=\<top> in ccorres_split_when_throwError_cond,
                                    fastforce,
-                                   rule syscall_error_throwError_ccorres_n[simplified id_def dc_def],
+                                   rule syscall_error_throwError_ccorres_n,
                                    fastforce simp: syscall_error_to_H_cases)+)[3]
                               apply ccorres_rewrite
                               apply csymbr

--- a/proof/crefine/X64/Invoke_C.thy
+++ b/proof/crefine/X64/Invoke_C.thy
@@ -68,7 +68,7 @@ lemma setDomain_ccorres:
          apply (rule_tac R="\<lambda>s. rv = ksCurThread s"
                     in ccorres_cond2)
            apply (clarsimp simp: rf_sr_ksCurThread)
-          apply (ctac add: rescheduleRequired_ccorres[unfolded dc_def])
+          apply (ctac add: rescheduleRequired_ccorres)
          apply (rule ccorres_return_Skip')
         apply simp
         apply (wp hoare_drop_imps weak_sch_act_wf_lift_linear)
@@ -78,8 +78,9 @@ lemma setDomain_ccorres:
      apply (rule_tac Q="\<lambda>_. all_invs_but_sch_extra and tcb_at' t and sch_act_simple
                         and (\<lambda>s. rv = ksCurThread s)" in hoare_strengthen_post)
       apply (wp threadSet_all_invs_but_sch_extra)
-     apply (clarsimp simp:valid_pspace_valid_objs' st_tcb_at_def[symmetric]
-       sch_act_simple_def st_tcb_at'_def o_def weak_sch_act_wf_def split:if_splits)
+     apply (clarsimp simp: valid_pspace_valid_objs' st_tcb_at_def[symmetric]
+                           sch_act_simple_def st_tcb_at'_def weak_sch_act_wf_def
+                    split: if_splits)
     apply (simp add: guard_is_UNIV_def)
    apply (rule_tac Q="\<lambda>_. invs' and tcb_at' t and sch_act_simple
       and (\<lambda>s. rv = ksCurThread s \<and> (\<forall>p. t \<notin> set (ksReadyQueues s p)))" in hoare_strengthen_post)
@@ -381,7 +382,7 @@ lemma invokeCNodeRotate_ccorres:
      apply clarsimp
      apply (simp add: return_def)
     apply wp
-   apply (simp add: guard_is_UNIV_def dc_def xfdc_def)
+   apply (simp add: guard_is_UNIV_def)
   apply (clarsimp simp: valid_pspace'_def)
   apply (rule conjI, clarsimp)
   apply (clarsimp simp:cte_wp_at_ctes_of)
@@ -626,9 +627,7 @@ lemma decodeCNodeInvocation_ccorres:
                        del: Collect_const cong: call_ignore_cong)
            apply (rule ccorres_split_throws)
             apply (rule ccorres_rhs_assoc | csymbr)+
-            apply (simp add: invocationCatch_use_injection_handler
-                                  [symmetric, unfolded o_def]
-                             if_1_0_0 dc_def[symmetric]
+            apply (simp add: invocationCatch_use_injection_handler[symmetric, unfolded o_def]
                         del: Collect_const cong: call_ignore_cong)
             apply (rule ccorres_Cond_rhs_Seq)
              apply (simp add:if_P del: Collect_const)
@@ -711,8 +710,7 @@ lemma decodeCNodeInvocation_ccorres:
                          apply (simp add: Collect_const[symmetric] del: Collect_const)
                          apply (rule ccorres_rhs_assoc)+
                          apply (rule ccorres_Cond_rhs_Seq)
-                          apply (simp add: injection_handler_throwError dc_def[symmetric]
-                                           if_P)
+                          apply (simp add: injection_handler_throwError if_P)
                           apply (rule syscall_error_throwError_ccorres_n)
                           apply (simp add: syscall_error_to_H_cases)
                          apply (simp add: list_case_helper injection_handler_returnOk
@@ -739,8 +737,7 @@ lemma decodeCNodeInvocation_ccorres:
                                apply csymbr
                                apply (simp add: cap_get_tag_NullCap del: Collect_const)
                                apply (rule ccorres_Cond_rhs_Seq)
-                                apply (simp add: injection_handler_throwError whenE_def
-                                                 dc_def[symmetric])
+                                apply (simp add: injection_handler_throwError whenE_def)
                                 apply (rule syscall_error_throwError_ccorres_n)
                                 apply (simp add: syscall_error_to_H_cases)
                                apply (simp add: whenE_def injection_handler_returnOk
@@ -816,8 +813,7 @@ lemma decodeCNodeInvocation_ccorres:
                                    apply (simp add: cap_get_tag_NullCap del: Collect_const)
                                    apply (rule ccorres_Cond_rhs_Seq)
                                     apply (simp add: whenE_def injection_handler_returnOk
-                                                     invocationCatch_def injection_handler_throwError
-                                                     dc_def[symmetric])
+                                                     invocationCatch_def injection_handler_throwError)
                                     apply (rule syscall_error_throwError_ccorres_n)
                                     apply (simp add: syscall_error_to_H_cases)
                                    apply (simp add: whenE_def injection_handler_returnOk
@@ -896,7 +892,7 @@ lemma decodeCNodeInvocation_ccorres:
                          apply (simp add: flip: Collect_const
                                     cong: call_ignore_cong)
                          apply (rule ccorres_Cond_rhs_Seq)
-                          apply (simp add: injection_handler_throwError dc_def[symmetric] if_P)
+                          apply (simp add: injection_handler_throwError if_P)
                           apply (rule syscall_error_throwError_ccorres_n)
                           apply (simp add: syscall_error_to_H_cases)
                          apply (simp add: if_not_P del: Collect_const)
@@ -915,8 +911,7 @@ lemma decodeCNodeInvocation_ccorres:
                              apply csymbr
                              apply (simp add: cap_get_tag_isCap del: Collect_const)
                              apply (rule ccorres_Cond_rhs_Seq)
-                              apply (simp add: whenE_def injection_handler_throwError
-                                               dc_def[symmetric] numeral_eqs)
+                              apply (simp add: whenE_def injection_handler_throwError numeral_eqs)
                               apply (rule syscall_error_throwError_ccorres_n)
                               apply (simp add: syscall_error_to_H_cases)
                              apply (simp add: whenE_def injection_handler_returnOk
@@ -1015,13 +1010,11 @@ lemma decodeCNodeInvocation_ccorres:
           apply (simp del: Collect_const)
           apply (rule ccorres_Cond_rhs_Seq)
            apply (simp add: injection_handler_returnOk bindE_assoc
-                            injection_bindE[OF refl refl] split_def
-                            dc_def[symmetric])
+                            injection_bindE[OF refl refl] split_def)
            apply (rule ccorres_split_throws)
             apply (rule ccorres_rhs_assoc)+
             apply (ctac add: ccorres_injection_handler_csum1 [OF ensureEmptySlot_ccorres])
-               apply (simp add: ccorres_invocationCatch_Inr performInvocation_def
-                                dc_def[symmetric] bindE_assoc)
+               apply (simp add: ccorres_invocationCatch_Inr performInvocation_def bindE_assoc)
                apply (ctac add: setThreadState_ccorres)
                  apply (ctac(no_vcg) add: invokeCNodeSaveCaller_ccorres)
                    apply (rule ccorres_alternative2)
@@ -1030,7 +1023,7 @@ lemma decodeCNodeInvocation_ccorres:
                  apply (wp sts_valid_pspace_hangers)+
                apply (simp add: Collect_const_mem)
                apply (vcg exspec=setThreadState_modifies)
-              apply (simp add: dc_def[symmetric])
+              apply simp
               apply (rule ccorres_split_throws)
                apply (rule ccorres_return_C_errorE, simp+)[1]
               apply vcg
@@ -1060,8 +1053,7 @@ lemma decodeCNodeInvocation_ccorres:
                                in ccorres_gen_asm2)
                 apply (simp del: Collect_const)
                 apply (rule ccorres_Cond_rhs_Seq)
-                 apply (simp add: unlessE_def whenE_def injection_handler_throwError
-                                  dc_def[symmetric] from_bool_0)
+                 apply (simp add: unlessE_def whenE_def injection_handler_throwError from_bool_0)
                  apply (rule syscall_error_throwError_ccorres_n)
                  apply (simp add: syscall_error_to_H_cases)
                 apply (simp add: unlessE_def whenE_def injection_handler_returnOk
@@ -1105,12 +1097,10 @@ lemma decodeCNodeInvocation_ccorres:
             apply (simp add: throwError_def return_def exception_defs
                              syscall_error_rel_def syscall_error_to_H_cases)
             apply clarsimp
-           apply (simp add: invocationCatch_use_injection_handler
-                                  [symmetric, unfolded o_def]
+           apply (simp add: invocationCatch_use_injection_handler[symmetric, unfolded o_def]
                        del: Collect_const)
            apply csymbr
            apply (simp add: interpret_excaps_test_null excaps_map_def
-                            if_1_0_0 dc_def[symmetric]
                        del: Collect_const)
            apply (rule ccorres_Cond_rhs_Seq)
             apply (simp add: throwError_bind invocationCatch_def)
@@ -1170,8 +1160,7 @@ lemma decodeCNodeInvocation_ccorres:
                                            del: Collect_const)
                                apply csymbr
                                apply (rule ccorres_Cond_rhs_Seq)
-                                apply (simp add: whenE_def injection_handler_throwError
-                                                 dc_def[symmetric])
+                                apply (simp add: whenE_def injection_handler_throwError)
                                 apply (rule syscall_error_throwError_ccorres_n)
                                 apply (simp add: syscall_error_to_H_cases)
                                apply (simp add: whenE_def[where P=False] injection_handler_returnOk
@@ -1233,8 +1222,7 @@ lemma decodeCNodeInvocation_ccorres:
                                         apply csymbr
                                         apply (simp add: cap_get_tag_NullCap del: Collect_const)
                                         apply (rule ccorres_Cond_rhs_Seq)
-                                         apply (simp add: whenE_def injection_handler_throwError
-                                                          dc_def[symmetric])
+                                         apply (simp add: whenE_def injection_handler_throwError)
                                          apply (rule syscall_error_throwError_ccorres_n)
                                          apply (simp add: syscall_error_to_H_cases)
                                         apply (simp add: whenE_def[where P=False] injection_handler_returnOk
@@ -1242,8 +1230,7 @@ lemma decodeCNodeInvocation_ccorres:
                                         apply csymbr
                                         apply (simp add: cap_get_tag_NullCap del: Collect_const)
                                         apply (rule ccorres_Cond_rhs_Seq)
-                                         apply (simp add: whenE_def injection_handler_throwError
-                                                          dc_def[symmetric])
+                                         apply (simp add: whenE_def injection_handler_throwError)
                                          apply (rule syscall_error_throwError_ccorres_n)
                                          apply (simp add: syscall_error_to_H_cases)
                                         apply (simp add: whenE_def injection_handler_returnOk
@@ -1464,7 +1451,7 @@ lemma seL4_MessageInfo_lift_def2:
 
 lemma globals_update_id:
   "globals_update (t_hrs_'_update (hrs_htd_update id)) x = x"
-   by (simp add:id_def hrs_htd_update_def)
+   by (simp add: hrs_htd_update_def)
 
 lemma getObjectSize_spec:
   "\<forall>s. \<Gamma>\<turnstile>\<lbrace>s. \<acute>t \<le> of_nat (length (enum::object_type list) - 1)\<rbrace> Call getObjectSize_'proc
@@ -1521,7 +1508,7 @@ shows
  "\<lbrakk>ctes_of (s::kernel_state) (ptr_val p) = Some cte; is_aligned ptr bits; bits < word_bits;
   {ptr..ptr + 2 ^ bits - 1} \<inter> {ptr_val p..ptr_val p + mask cteSizeBits} = {}; ((clift hp) :: (cte_C ptr \<rightharpoonup> cte_C)) p = Some to\<rbrakk> \<Longrightarrow>
   (clift (hrs_htd_update (typ_clear_region ptr bits) hp) :: (cte_C ptr \<rightharpoonup> cte_C)) p = Some to"
-   apply (clarsimp simp:lift_t_def lift_typ_heap_def Fun.comp_def restrict_map_def split:if_splits)
+   apply (clarsimp simp:lift_t_def lift_typ_heap_def restrict_map_def split:if_splits)
    apply (intro conjI impI)
    apply (case_tac hp)
     apply (clarsimp simp:typ_clear_region_def hrs_htd_update_def)
@@ -1850,8 +1837,7 @@ lemma resetUntypedCap_ccorres:
      apply (rule ccorres_Guard_Seq[where S=UNIV])?
      apply (rule ccorres_rhs_assoc2)
      apply (rule ccorres_split_nothrow)
-         apply (rule_tac idx="capFreeIndex (cteCap cte)"
-           in deleteObjects_ccorres[where p=slot, unfolded o_def])
+         apply (rule_tac idx="capFreeIndex (cteCap cte)" in deleteObjects_ccorres[where p=slot])
         apply ceqv
        apply clarsimp
        apply (simp only: ccorres_seq_cond_raise)
@@ -2825,7 +2811,6 @@ lemma Arch_isFrameType_spec:
   apply (auto simp: object_type_from_H_def )
   done
 
-
 lemma decodeUntypedInvocation_ccorres_helper:
   notes TripleSuc[simp]
   notes valid_untyped_inv_wcap'.simps[simp del] tl_drop_1[simp]
@@ -3005,8 +2990,8 @@ lemma decodeUntypedInvocation_ccorres_helper:
                                         [OF lookupTargetSlot_ccorres,
                                             unfolded lookupTargetSlot_def])
                         apply (simp add: injection_liftE[OF refl])
-                        apply (simp add: liftE_liftM o_def split_def withoutFailure_def
-                                         hd_drop_conv_nth2 numeral_eqs[symmetric])
+                        apply (simp add: liftE_liftM split_def hd_drop_conv_nth2
+                                   cong: ccorres_all_cong)
                         apply (rule ccorres_nohs)
                         apply (rule ccorres_getSlotCap_cte_at)
                         apply (rule ccorres_move_c_guard_cte)
@@ -3229,8 +3214,7 @@ lemma decodeUntypedInvocation_ccorres_helper:
                                                        performInvocation_def liftE_bindE bind_assoc)
                              apply (ctac add: setThreadState_ccorres)
                                apply (rule ccorres_trim_returnE, (simp (no_asm))+)
-                               apply (simp (no_asm) add: o_def dc_def[symmetric] bindE_assoc
-                                                         id_def[symmetric] bind_bindE_assoc)
+                               apply (simp (no_asm) add: bindE_assoc bind_bindE_assoc)
                                apply (rule ccorres_seq_skip'[THEN iffD1])
                                apply (ctac(no_vcg) add: invokeUntyped_Retype_ccorres[where start = "args!4"])
                                  apply (rule ccorres_alternative2)
@@ -3279,7 +3263,7 @@ lemma decodeUntypedInvocation_ccorres_helper:
                       apply vcg
                      apply (rule ccorres_guard_imp
                          [where Q =\<top> and Q' = UNIV,rotated],assumption+)
-                     apply (simp add: o_def)
+                     apply simp
                     apply (simp add: liftE_validE)
                     apply (rule checkFreeIndex_wp)
                    apply (clarsimp simp: ccap_relation_untyped_CL_simps shiftL_nat cap_get_tag_isCap
@@ -3346,7 +3330,7 @@ lemma decodeUntypedInvocation_ccorres_helper:
                    apply (rule validE_R_validE)
                    apply (wp injection_wp_E[OF refl])
                   apply clarsimp
-                 apply (simp add: ccHoarePost_def xfdc_def)
+                 apply (simp add: ccHoarePost_def)
                  apply (simp only: whileAnno_def[where I=UNIV and V=UNIV, symmetric])
                  apply (rule_tac V=UNIV
                                 in HoarePartial.reannotateWhileNoGuard)
@@ -3476,7 +3460,7 @@ shows
   apply (rule ccorres_guard_imp2)
    apply (rule monadic_rewrite_ccorres_assemble)
     apply (rule_tac isBlocking=isBlocking and isCall=isCall and buffer=buffer
-                in decodeUntypedInvocation_ccorres_helper[unfolded K_def])
+                in decodeUntypedInvocation_ccorres_helper)
     apply assumption
    apply (rule monadic_rewrite_trans[rotated])
     apply (rule monadic_rewrite_bind_head)

--- a/proof/crefine/X64/IpcCancel_C.thy
+++ b/proof/crefine/X64/IpcCancel_C.thy
@@ -220,7 +220,7 @@ lemma cancelSignal_ccorres_helper:
    apply (drule (2) ntfn_to_ep_queue)
    apply (simp add: tcb_queue_relation'_def)
   apply (clarsimp simp: typ_heap_simps cong: imp_cong split del: if_split)
-  apply (frule null_ep_queue [simplified Fun.comp_def])
+  apply (frule null_ep_queue [simplified comp_def])
   apply (intro impI conjI allI)
    \<comment> \<open>empty case\<close>
    apply clarsimp
@@ -1054,7 +1054,7 @@ proof -
             apply (rule ccorres_split_nothrow_novcg_dc)
                prefer 2
                apply (rule ccorres_move_c_guard_tcb)
-               apply (simp only: dc_def[symmetric])
+               apply simp
                apply ctac
               prefer 2
               apply (wp, clarsimp, wp+)
@@ -1176,7 +1176,7 @@ proof -
          apply simp
          apply (wp threadGet_wp)
         apply vcg
-       apply (rule ccorres_return_Skip[unfolded dc_def])
+       apply (rule ccorres_return_Skip)
       apply simp
       apply (wp threadGet_wp)
      apply vcg
@@ -1413,7 +1413,6 @@ proof -
           apply (rule ccorres_split_nothrow_novcg_dc)
              prefer 2
              apply (rule ccorres_move_c_guard_tcb)
-             apply (simp only: dc_def[symmetric])
              apply ctac
             prefer 2
             apply (wp, clarsimp, wp+)
@@ -1689,7 +1688,7 @@ proof -
        apply simp
        apply (wp threadGet_wp)
       apply vcg
-     apply (rule ccorres_return_Skip[unfolded dc_def])
+     apply (rule ccorres_return_Skip)
     apply simp
     apply (wp threadGet_wp)
    apply vcg
@@ -1821,7 +1820,6 @@ proof -
           apply (rule ccorres_split_nothrow_novcg_dc)
              prefer 2
              apply (rule ccorres_move_c_guard_tcb)
-             apply (simp only: dc_def[symmetric])
              apply ctac
             prefer 2
             apply (wp, clarsimp, wp+)
@@ -1927,7 +1925,7 @@ proof -
        apply simp
        apply (wp threadGet_wp)
       apply vcg
-     apply (rule ccorres_return_Skip[unfolded dc_def])
+     apply (rule ccorres_return_Skip)
     apply simp
     apply (wp threadGet_wp)
    apply vcg
@@ -2320,11 +2318,6 @@ lemma getCurDomain_maxDom_ccorres_dom_':
                         rf_sr_ksCurDomain)
   done
 
-lemma rf_sr_cscheduler_action_relation:
-  "(s, s') \<in> rf_sr
-   \<Longrightarrow> cscheduler_action_relation (ksSchedulerAction s) (ksSchedulerAction_' (globals s'))"
-  by (clarsimp simp: rf_sr_def cstate_relation_def Let_def)
-
 lemma threadGet_get_obj_at'_has_domain:
   "\<lbrace> tcb_at' t \<rbrace> threadGet tcbDomain t \<lbrace>\<lambda>rv. obj_at' (\<lambda>tcb. rv = tcbDomain tcb) t\<rbrace>"
   by (wp threadGet_obj_at') (simp add: obj_at'_def)
@@ -2341,7 +2334,6 @@ lemma possibleSwitchTo_ccorres:
      (Call possibleSwitchTo_'proc)"
   supply if_split [split del]
   supply Collect_const [simp del]
-  supply dc_simp [simp del]
   supply prio_and_dom_limit_helpers[simp]
   (* FIXME: these should likely be in simpset for CRefine, or even in general *)
   supply from_bool_eq_if[simp] from_bool_eq_if'[simp] from_bool_0[simp]
@@ -2366,7 +2358,7 @@ lemma possibleSwitchTo_ccorres:
       apply (ctac add: tcbSchedEnqueue_ccorres)
      apply (rule_tac R="\<lambda>s. sact = ksSchedulerAction s \<and> weak_sch_act_wf (ksSchedulerAction s) s"
                      in ccorres_cond)
-       apply (fastforce dest!: rf_sr_cscheduler_action_relation pred_tcb_at' tcb_at_not_NULL
+       apply (fastforce dest!: rf_sr_sched_action_relation pred_tcb_at' tcb_at_not_NULL
                         simp: cscheduler_action_relation_def weak_sch_act_wf_def
                         split: scheduler_action.splits)
       apply (ctac add: rescheduleRequired_ccorres)
@@ -2955,7 +2947,7 @@ lemma cancelIPC_ccorres_helper:
   apply (rule allI)
   apply (rule conseqPre)
    apply vcg
-  apply (clarsimp split del: if_split simp del: comp_def)
+  apply (clarsimp split del: if_split)
   apply (frule (2) ep_blocked_in_queueD)
   apply (frule (1) ko_at_valid_ep' [OF _ invs_valid_objs'])
   apply (elim conjE)
@@ -2973,7 +2965,7 @@ lemma cancelIPC_ccorres_helper:
        apply assumption+
    apply (drule (2) ep_to_ep_queue)
    apply (simp add: tcb_queue_relation'_def)
-  apply (clarsimp simp: typ_heap_simps cong: imp_cong split del: if_split simp del: comp_def)
+  apply (clarsimp simp: typ_heap_simps cong: imp_cong split del: if_split)
   apply (frule null_ep_queue [simplified comp_def] null_ep_queue)
   apply (intro impI conjI allI)
    \<comment> \<open>empty case\<close>
@@ -3129,7 +3121,6 @@ lemma cancelIPC_ccorres1:
      apply wpc
             \<comment> \<open>BlockedOnReceive\<close>
             apply (simp add: word_sle_def "StrictC'_thread_state_defs" ccorres_cond_iffs cong: call_ignore_cong)
-            apply (fold dc_def)
             apply (rule ccorres_rhs_assoc)+
             apply csymbr
             apply csymbr
@@ -3158,7 +3149,6 @@ lemma cancelIPC_ccorres1:
            apply (simp add: "StrictC'_thread_state_defs" ccorres_cond_iffs
                             Collect_False Collect_True word_sle_def
                       cong: call_ignore_cong del: Collect_const)
-           apply (fold dc_def)
            apply (rule ccorres_rhs_assoc)+
            apply csymbr
            apply csymbr
@@ -3198,14 +3188,12 @@ lemma cancelIPC_ccorres1:
                 apply (rule ccorres_Cond_rhs)
                  apply (simp add: nullPointer_def when_def)
                  apply (rule ccorres_symb_exec_l[OF _ _ _ empty_fail_stateAssert])
-                   apply (simp only: dc_def[symmetric])
                    apply (rule ccorres_symb_exec_r)
                      apply (ctac add: cteDeleteOne_ccorres[where w1="scast cap_reply_cap"])
                     apply vcg
                    apply (rule conseqPre, vcg, clarsimp simp: rf_sr_def
                        gs_set_assn_Delete_cstate_relation[unfolded o_def])
                   apply (wp | simp)+
-                apply (simp add: when_def nullPointer_def dc_def[symmetric])
                 apply (rule ccorres_return_Skip)
                apply (simp add: guard_is_UNIV_def ghost_assertion_data_get_def
                                 ghost_assertion_data_set_def cap_tag_defs)
@@ -3218,7 +3206,8 @@ lemma cancelIPC_ccorres1:
            apply (clarsimp simp add: guard_is_UNIV_def tcbReplySlot_def
                         Kernel_C.tcbReply_def tcbCNodeEntries_def)
           \<comment> \<open>BlockedOnNotification\<close>
-          apply (simp add: word_sle_def "StrictC'_thread_state_defs" ccorres_cond_iffs dc_def [symmetric] cong: call_ignore_cong)
+          apply (simp add: word_sle_def "StrictC'_thread_state_defs" ccorres_cond_iffs
+                     cong: call_ignore_cong)
           apply (rule ccorres_symb_exec_r)
             apply (ctac (no_vcg))
            apply clarsimp
@@ -3227,10 +3216,12 @@ lemma cancelIPC_ccorres1:
           apply (rule conseqPre, vcg)
           apply clarsimp
          \<comment> \<open>Running, Inactive, and Idle\<close>
-         apply (simp add: word_sle_def "StrictC'_thread_state_defs" ccorres_cond_iffs dc_def [symmetric] cong: call_ignore_cong,
+         apply (simp add: word_sle_def "StrictC'_thread_state_defs" ccorres_cond_iffs
+                    cong: call_ignore_cong,
                 rule ccorres_return_Skip)+
       \<comment> \<open>BlockedOnSend\<close>
-      apply (simp add: word_sle_def "StrictC'_thread_state_defs" ccorres_cond_iffs dc_def [symmetric] cong: call_ignore_cong)
+      apply (simp add: word_sle_def "StrictC'_thread_state_defs" ccorres_cond_iffs
+                 cong: call_ignore_cong)
       \<comment> \<open>clag\<close>
       apply (rule ccorres_rhs_assoc)+
       apply csymbr
@@ -3256,7 +3247,8 @@ lemma cancelIPC_ccorres1:
       apply (rule conseqPre, vcg)
       apply clarsimp
   \<comment> \<open>Restart\<close>
-     apply (simp add: word_sle_def "StrictC'_thread_state_defs" ccorres_cond_iffs dc_def [symmetric] cong: call_ignore_cong,
+     apply (simp add: word_sle_def "StrictC'_thread_state_defs" ccorres_cond_iffs
+                cong: call_ignore_cong,
             rule ccorres_return_Skip)
     \<comment> \<open>Post wp proofs\<close>
     apply vcg

--- a/proof/crefine/X64/Ipc_C.thy
+++ b/proof/crefine/X64/Ipc_C.thy
@@ -724,7 +724,7 @@ begin
 
 (* FIXME: move *)
 lemma ccorres_merge_return:
-  "ccorres (\<lambda>a c. r (f a) c) xf P P' hs H C \<Longrightarrow>
+  "ccorres (r \<circ> f) xf P P' hs H C \<Longrightarrow>
    ccorres r xf P P' hs (do x \<leftarrow> H; return (f x) od) C"
   by (rule ccorres_return_into_rel)
 
@@ -1597,53 +1597,54 @@ proof -
       apply ceqv
      apply (rule ccorres_Cond_rhs)
       apply (simp del: Collect_const)
-      apply (rule ccorres_rel_imp[where r = "\<lambda>rv rv'. True", simplified])
-      apply (rule_tac F="\<lambda>_. obj_at' (\<lambda>tcb. map ((user_regs o atcbContext o tcbArch) tcb) X64_H.syscallMessage = msg)
-                                       sender and valid_pspace'
-                                       and (case recvBuffer of Some x \<Rightarrow> valid_ipc_buffer_ptr' x | None \<Rightarrow> \<top>)"
-                           in ccorres_mapM_x_while'[where i="unat n_msgRegisters"])
-          apply (clarsimp simp: setMR_def n_msgRegisters_def length_msgRegisters
-                                          option_to_0_def liftM_def[symmetric]
-                                   split: option.split_asm)
-          apply (rule ccorres_guard_imp2)
-          apply (rule_tac t=sender and r="X64_H.syscallMessage ! (n + unat n_msgRegisters)"
-                                   in ccorres_add_getRegister)
-          apply (ctac(no_vcg))
-           apply (rule_tac P="\<lambda>s. rv = msg ! (n + unat n_msgRegisters)"
-                           in ccorres_cross_over_guard)
-           apply (rule ccorres_move_array_assertion_ipc_buffer
-                 | (rule ccorres_flip_Guard, rule ccorres_move_array_assertion_ipc_buffer))+
-           apply (simp add: storeWordUser_def)
-           apply (rule ccorres_pre_stateAssert)
-           apply (ctac add: storeWord_ccorres[unfolded fun_app_def])
-          apply (simp add: pred_conj_def)
-          apply (wp user_getreg_rv)
-         apply (clarsimp simp: n_syscallMessage_def n_msgRegisters_def
-                               syscallMessage_ccorres msgRegisters_ccorres
-                               unat_add_lem[THEN iffD1] unat_of_nat64
-                               word_bits_def word_size_def)
-         apply (simp only:field_simps imp_ex imp_conjL)
-         apply (clarsimp simp: pointerInUserData_c_guard obj_at'_def
-                               pointerInUserData_h_t_valid
-                               atcbContextGet_def
-                               projectKOs objBits_simps word_less_nat_alt
-                               unat_add_lem[THEN iffD1] unat_of_nat)
-         apply (clarsimp simp: pointerInUserData_h_t_valid rf_sr_def
-                               MessageID_Syscall_def
-                               msg_align_bits valid_ipc_buffer_ptr'_def)
-         apply (erule aligned_add_aligned)
-          apply (rule aligned_add_aligned[where n=3])
-            apply (simp add: is_aligned_def)
-           apply (rule is_aligned_mult_triv2 [where n=3, simplified])
-           apply (simp add: wb_gt_2)+
-         apply (simp add: n_msgRegisters_def)
-        apply (vcg exspec=getRegister_modifies)
-        apply simp
-       apply (simp add: setMR_def n_msgRegisters_def length_msgRegisters)
-       apply (rule hoare_pre)
-        apply (wp hoare_case_option_wp | wpc)+
-       apply clarsimp
-      apply (simp add: n_msgRegisters_def word_bits_def)
+      apply (rule ccorres_rel_imp)
+       apply (rule_tac F="\<lambda>_. obj_at' (\<lambda>tcb. map ((user_regs o atcbContext o tcbArch) tcb) X64_H.syscallMessage = msg)
+                                        sender and valid_pspace'
+                                        and (case recvBuffer of Some x \<Rightarrow> valid_ipc_buffer_ptr' x | None \<Rightarrow> \<top>)"
+                            in ccorres_mapM_x_while'[where i="unat n_msgRegisters"])
+           apply (clarsimp simp: setMR_def n_msgRegisters_def length_msgRegisters
+                                           option_to_0_def liftM_def[symmetric]
+                                    split: option.split_asm)
+           apply (rule ccorres_guard_imp2)
+            apply (rule_tac t=sender and r="X64_H.syscallMessage ! (n + unat n_msgRegisters)"
+                                     in ccorres_add_getRegister)
+            apply (ctac(no_vcg))
+             apply (rule_tac P="\<lambda>s. rv = msg ! (n + unat n_msgRegisters)"
+                             in ccorres_cross_over_guard)
+             apply (rule ccorres_move_array_assertion_ipc_buffer
+                   | (rule ccorres_flip_Guard, rule ccorres_move_array_assertion_ipc_buffer))+
+             apply (simp add: storeWordUser_def)
+             apply (rule ccorres_pre_stateAssert)
+             apply (ctac add: storeWord_ccorres[unfolded fun_app_def])
+            apply (simp add: pred_conj_def)
+            apply (wp user_getreg_rv)
+           apply (clarsimp simp: n_syscallMessage_def n_msgRegisters_def
+                                 syscallMessage_ccorres msgRegisters_ccorres
+                                 unat_add_lem[THEN iffD1] unat_of_nat64
+                                 word_bits_def word_size_def)
+           apply (simp only:field_simps imp_ex imp_conjL)
+           apply (clarsimp simp: pointerInUserData_c_guard obj_at'_def
+                                 pointerInUserData_h_t_valid
+                                 atcbContextGet_def
+                                 projectKOs objBits_simps word_less_nat_alt
+                                 unat_add_lem[THEN iffD1] unat_of_nat)
+           apply (clarsimp simp: pointerInUserData_h_t_valid rf_sr_def
+                                 MessageID_Syscall_def
+                                 msg_align_bits valid_ipc_buffer_ptr'_def)
+           apply (erule aligned_add_aligned)
+            apply (rule aligned_add_aligned[where n=3])
+              apply (simp add: is_aligned_def)
+             apply (rule is_aligned_mult_triv2 [where n=3, simplified])
+            apply (simp add: wb_gt_2)+
+          apply (simp add: n_msgRegisters_def)
+         apply (vcg exspec=getRegister_modifies)
+         apply simp
+        apply (simp add: setMR_def n_msgRegisters_def length_msgRegisters)
+        apply (rule hoare_pre)
+         apply (wp hoare_case_option_wp | wpc)+
+        apply clarsimp
+       apply (simp add: n_msgRegisters_def word_bits_def)
+      apply simp
      apply (simp add: n_msgRegisters_def)
      apply (frule (1) option_to_0_imp)
      apply (subst drop_zip)
@@ -1651,7 +1652,7 @@ proof -
      apply (clarsimp simp:  n_msgRegisters_def numeral_eqs
                             mapM_cong[OF msg_aux, simplified numeral_eqs])
      apply (subst mapM_x_return_gen[where w2="()"])
-     apply (rule ccorres_return_Skip[simplified dc_def])
+     apply (rule ccorres_return_Skip)
     apply (clarsimp)
     apply (rule hoare_impI)
     apply (wp mapM_x_wp_inv setMR_atcbContext_obj_at[simplified atcbContextGet_def, simplified]
@@ -2043,7 +2044,7 @@ lemma doFaultTransfer_ccorres [corres]:
       apply ceqv
      apply csymbr
      apply (ctac (no_vcg, c_lines 2) add: setMessageInfo_ccorres)
-       apply (ctac add: setRegister_ccorres[unfolded dc_def])
+       apply (ctac add: setRegister_ccorres)
       apply wp
      apply (simp add: badgeRegister_def X64.badgeRegister_def X64.capRegister_def
                       Kernel_C.badgeRegister_def "StrictC'_register_defs")
@@ -2081,7 +2082,7 @@ lemma unifyFailure_ccorres:
   assumes corr_ac: "ccorres (f \<currency> r) xf P P' hs a c"
   shows "ccorres ((\<lambda>_. dc) \<currency> r) xf P P' hs (unifyFailure a) c"
   using corr_ac
-  apply (simp add: unifyFailure_def rethrowFailure_def const_def o_def
+  apply (simp add: unifyFailure_def rethrowFailure_def const_def
                    handleE'_def throwError_def)
   apply (clarsimp simp: ccorres_underlying_def bind_def split_def return_def
                   split: xstate.splits sum.splits)
@@ -3123,10 +3124,11 @@ lemma ccorres_sequenceE_while':
              Basic (\<lambda>s. i_'_update (\<lambda>_. i_' s + 1) s)))"
   apply (rule ccorres_guard_imp2)
    apply (rule ccorres_symb_exec_r)
-     apply (rule ccorres_sequenceE_while_gen'[where i=0, simplified, where xf_update=i_'_update],
-            (assumption | simp)+)
-       apply (simp add: word_bits_def)
-      apply simp+
+     apply (rule ccorres_rel_imp2)
+       apply (rule ccorres_sequenceE_while_gen'[where i=0, simplified, where xf_update=i_'_update],
+              (assumption | simp)+)
+         apply (simp add: word_bits_def)
+        apply simp+
     apply vcg
    apply (rule conseqPre, vcg)
    apply clarsimp
@@ -3359,7 +3361,7 @@ proof -
     apply (cinit lift: sender_' receiver_' sendBuffer_' receiveBuffer_'
                        canGrant_' badge_' endpoint_'
                  cong: call_ignore_cong)
-     apply (clarsimp cong: call_ignore_cong simp del: dc_simp)
+     apply (clarsimp cong: call_ignore_cong)
      apply (ctac(c_lines 2, no_vcg) add: getMessageInfo_ccorres')
        apply (rule_tac xf'="\<lambda>s. current_extra_caps_' (globals s)"
                    and r'="\<lambda>c c'. interpret_excaps c' = excaps_map c"
@@ -3468,7 +3470,6 @@ lemma replyFromKernel_error_ccorres [corres]:
          apply ((rule ccorres_Guard_Seq)+)?
          apply csymbr
          apply (rule ccorres_abstract_cleanup)
-         apply (fold dc_def)[1]
          apply (rule setMessageInfo_ccorres)
         apply wp
        apply (simp add: Collect_const_mem)
@@ -3537,12 +3538,10 @@ lemma doIPCTransfer_ccorres [corres]:
            apply simp_all[3]
         apply ceqv
        apply csymbr
-       apply (fold dc_def)[1]
        apply ctac
       apply (wp lookupIPCBuffer_not_Some_0 lookupIPCBuffer_aligned)
      apply (clarsimp simp: seL4_Fault_NullFault_def ccorres_cond_iffs
                            fault_to_fault_tag_nonzero)
-     apply (fold dc_def)[1]
      apply ctac
     apply (clarsimp simp: guard_is_UNIV_def option_to_ptr_def split: option.splits)
    apply (rule_tac Q="\<lambda>rv. valid_pspace' and cur_tcb' and tcb_at' sender
@@ -3657,7 +3656,7 @@ proof -
                         n_msgRegisters_def
                         of_nat_less_iff)
        apply ccorres_rewrite
-       apply (rule ccorres_return_Skip[simplified dc_def])
+       apply (rule ccorres_return_Skip)
       apply (wp mapM_wp')
      apply clarsimp+
      apply (clarsimp simp: guard_is_UNIV_def message_info_to_H_def
@@ -3813,7 +3812,6 @@ lemma copyMRsFaultReply_ccorres_syscall:
                  apply (subst aligned_add_aligned, assumption)
                    apply (rule is_aligned_mult_triv2[where n=3, simplified])
                   apply (simp add: msg_align_bits)
-                 apply (simp add: of_nat_unat[simplified comp_def])
                  apply (simp only: n_msgRegisters_def)
                  apply (clarsimp simp: n_syscallMessage_def n_msgRegisters_def
                                        word_unat.Rep_inverse[of "scast _ :: 'a word"]
@@ -3852,8 +3850,8 @@ lemma copyMRsFaultReply_ccorres_syscall:
             apply simp
         apply (subst option.split[symmetric,where P=id, simplified])
         apply (rule valid_drop_case)
-        apply (wp hoare_drop_imps hoare_vcg_all_lift lookupIPCBuffer_aligned[simplified K_def]
-                  lookupIPCBuffer_not_Some_0[simplified K_def])
+        apply (wp hoare_drop_imps hoare_vcg_all_lift lookupIPCBuffer_aligned[simplified]
+                  lookupIPCBuffer_not_Some_0[simplified])
        apply (simp add: length_syscallMessage
                         length_msgRegisters
                         n_syscallMessage_def
@@ -3865,7 +3863,7 @@ lemma copyMRsFaultReply_ccorres_syscall:
        apply (rule ccorres_guard_imp)
          apply (rule ccorres_symb_exec_l)
             apply (case_tac rva ; clarsimp)
-             apply (rule ccorres_return_Skip[simplified dc_def])+
+             apply (rule ccorres_return_Skip)+
                 apply (wp mapM_x_wp_inv user_getreg_inv'
                        | clarsimp simp: zipWithM_x_mapM_x split: prod.split)+
      apply (cases  "4 < len")
@@ -3955,7 +3953,7 @@ lemma handleFaultReply_ccorres [corres]:
   apply (unfold K_def, rule ccorres_gen_asm)
   apply (rule monadic_rewrite_ccorres_assemble_nodrop[OF _ handleFaultReply',rotated], simp)
   apply (cinit lift: sender_' receiver_' simp: whileAnno_def)
-   apply (clarsimp simp del: dc_simp)
+   apply clarsimp
    apply (ctac(c_lines 2) add: getMessageInfo_ccorres')
      apply (rename_tac tag tag')
      apply csymbr
@@ -4001,7 +3999,7 @@ lemma handleFaultReply_ccorres [corres]:
                          split del: if_split)
             apply (subst take_min_len[symmetric,where n="unat (msgLength _)"])
             apply (subst take_min_len[symmetric,where n="unat (msgLength _)"])
-            apply (fold bind_assoc id_def)
+            apply (fold bind_assoc)
             apply (ctac add: copyMRsFaultReply_ccorres_syscall[simplified bind_assoc[symmetric]])
               apply (ctac add: ccorres_return_C)
              apply wp
@@ -4217,7 +4215,6 @@ proof -
     apply csymbr
     apply wpc
      apply (clarsimp simp: ccorres_cond_iffs split del: if_split)
-     apply (fold dc_def)[1]
      apply (rule ccorres_rhs_assoc)+
      apply (ctac(no_vcg))
       apply (rule ccorres_symb_exec_r)
@@ -4241,7 +4238,6 @@ proof -
                           fault_to_fault_tag_nonzero
                split del: if_split)
     apply (rule ccorres_rhs_assoc)+
-    apply (fold dc_def)[1]
     apply (rule ccorres_symb_exec_r)
       apply (ctac (no_vcg) add: cteDeleteOne_ccorres[where w="scast cap_reply_cap"])
        apply (rule_tac A'=UNIV in stronger_ccorres_guard_imp)
@@ -4271,7 +4267,6 @@ proof -
                apply (simp only: K_bind_def)
                apply (ctac add: possibleSwitchTo_ccorres)
               apply (wp sts_running_valid_queues setThreadState_st_tcb | simp)+
-            apply (fold dc_def)[1]
              apply (ctac add: setThreadState_ccorres_valid_queues'_simple)
              apply wp
             apply ((wp threadSet_valid_queues threadSet_sch_act threadSet_valid_queues' static_imp_wp
@@ -4343,8 +4338,7 @@ lemma setupCallerCap_ccorres [corres]:
   apply (frule_tac p=sender in is_aligned_tcb_ptr_to_ctcb_ptr)
   apply (cinit lift: sender_' receiver_' canGrant_')
    apply (clarsimp simp: word_sle_def
-                         tcb_cnode_index_defs[THEN ptr_add_assertion_positive[OF ptr_add_assertion_positive_helper]]
-                         , fold dc_def)[1]
+                         tcb_cnode_index_defs[THEN ptr_add_assertion_positive[OF ptr_add_assertion_positive_helper]])
    apply ccorres_remove_UNIV_guard
    apply (ctac(no_vcg))
     apply (rule ccorres_move_array_assertion_tcb_ctes)
@@ -4365,7 +4359,7 @@ lemma setupCallerCap_ccorres [corres]:
         apply (rule ccorres_move_c_guard_cte)
         apply (ctac(no_vcg))
          apply (rule ccorres_assert)
-         apply (simp only: ccorres_seq_skip dc_def[symmetric])
+         apply (simp only: ccorres_seq_skip)
          apply csymbr
          apply (ctac add: cteInsert_ccorres)
         apply simp
@@ -4420,7 +4414,7 @@ lemma sendIPC_dequeue_ccorres_helper:
   apply (rule ccorres_from_vcg)
   apply (rule allI)
   apply (rule conseqPre, vcg)
-  apply (clarsimp split del: if_split simp del: comp_def)
+  apply (clarsimp split del: if_split)
   apply (frule ep_blocked_in_queueD [OF pred_tcb'_weakenE])
      apply simp
     apply assumption+
@@ -4441,7 +4435,7 @@ lemma sendIPC_dequeue_ccorres_helper:
     apply (drule (2) ep_to_ep_queue)
     apply (simp add: tcb_queue_relation'_def)
    apply (clarsimp simp: typ_heap_simps cendpoint_relation_def Let_def
-              cong: imp_cong split del: if_split simp del: comp_def)
+                   cong: imp_cong split del: if_split)
   apply (intro conjI impI allI)
       apply (fastforce simp: h_t_valid_clift)
      apply (fastforce simp: h_t_valid_clift)
@@ -4810,7 +4804,7 @@ lemma sendIPC_enqueue_ccorres_helper:
   apply (rule ccorres_gen_asm)
   apply (rule ccorres_from_vcg)
   apply (rule allI, rule conseqPre, vcg)
-  apply (clarsimp split del: if_split simp del: comp_def)
+  apply (clarsimp split del: if_split)
   apply (frule cmap_relation_ep)
   apply (erule (1) cmap_relation_ko_atE)
   apply (rule conjI)
@@ -5029,12 +5023,9 @@ lemma sendIPC_ccorres [corres]:
               apply (clarsimp simp: disj_imp[symmetric] split del: if_split)
               apply (wpc ; clarsimp)
                apply ccorres_rewrite
-               apply (fold dc_def)[1]
                apply (ctac add: setupCallerCap_ccorres)
               apply ccorres_rewrite
-              apply (fold dc_def)[1]
               apply (ctac add: setThreadState_ccorres)
-             apply (fold dc_def)[1]
              apply (rule ccorres_return_Skip)
             apply (wpsimp wp: hoare_drop_imps hoare_vcg_all_lift possibleSwitchTo_sch_act_not
                               possibleSwitchTo_sch_act_not sts_st_tcb'
@@ -5234,7 +5225,7 @@ lemma receiveIPC_enqueue_ccorres_helper:
   apply (rule ccorres_gen_asm)
   apply (rule ccorres_from_vcg)
   apply (rule allI, rule conseqPre, vcg)
-  apply (clarsimp split del: if_split simp del: comp_def)
+  apply (clarsimp split del: if_split)
   apply (frule cmap_relation_ep)
   apply (erule (1) cmap_relation_ko_atE)
   apply (rule conjI)
@@ -5382,7 +5373,7 @@ lemma receiveIPC_dequeue_ccorres_helper:
   apply (rule ccorres_from_vcg)
   apply (rule allI)
   apply (rule conseqPre, vcg)
-  apply (clarsimp split del: if_split simp del: comp_def)
+  apply (clarsimp split del: if_split)
   apply (frule ep_blocked_in_queueD [OF pred_tcb'_weakenE])
      apply simp
     apply assumption+
@@ -5403,7 +5394,7 @@ lemma receiveIPC_dequeue_ccorres_helper:
     apply (drule (2) ep_to_ep_queue)
     apply (simp add: tcb_queue_relation'_def)
    apply (clarsimp simp: typ_heap_simps cendpoint_relation_def Let_def
-              cong: imp_cong split del: if_split simp del: comp_def)
+                   cong: imp_cong split del: if_split)
   apply (intro conjI impI allI)
       apply (fastforce simp: h_t_valid_clift)
      apply (fastforce simp: h_t_valid_clift)
@@ -5558,7 +5549,7 @@ lemma completeSignal_ccorres:
         apply (erule(1) cmap_relation_ko_atE[OF cmap_relation_ntfn])
         apply (clarsimp simp: cnotification_relation_def Let_def typ_heap_simps)
        apply ceqv
-      apply (fold dc_def, ctac(no_vcg))
+      apply (ctac(no_vcg))
        apply (rule_tac P="invs' and ko_at' ntfn ntfnptr" and P'=UNIV in ccorres_from_vcg)
        apply (rule allI, rule conseqPre, vcg)
        apply (clarsimp)
@@ -5674,7 +5665,7 @@ lemma receiveIPC_ccorres [corres]:
          apply ceqv
         apply (rule ccorres_cond[where R=\<top>])
           apply (simp add: Collect_const_mem)
-         apply (ctac add: completeSignal_ccorres[unfolded dc_def])
+         apply (ctac add: completeSignal_ccorres)
         apply (rule_tac xf'=ret__unsigned_longlong_'
                     and val="case ep of IdleEP \<Rightarrow> scast EPState_Idle
                             | RecvEP _ \<Rightarrow> scast EPState_Recv
@@ -5704,20 +5695,18 @@ lemma receiveIPC_ccorres [corres]:
              apply (rule ccorres_rhs_assoc2)
              apply (rule ccorres_rhs_assoc2)
              apply (rule ccorres_split_nothrow_novcg)
-                 apply (simp split del: if_split)
                  apply (rule receiveIPC_block_ccorres_helper[unfolded ptr_val_def, simplified])
                 apply ceqv
                apply simp
                apply (rename_tac list NOo)
-               apply (rule_tac ep="RecvEP list"
-                               in receiveIPC_enqueue_ccorres_helper[simplified, unfolded dc_def])
+               apply (rule_tac ep="RecvEP list" in receiveIPC_enqueue_ccorres_helper[simplified])
               apply (simp add: valid_ep'_def)
               apply (wp sts_st_tcb')
              apply (rename_tac list)
              apply (clarsimp simp: obj_at'_def ko_wp_at'_def projectKOs)
              apply (clarsimp simp: guard_is_UNIV_def)
             apply simp
-             apply (ctac add: doNBRecvFailedTransfer_ccorres[unfolded dc_def])
+             apply (ctac add: doNBRecvFailedTransfer_ccorres)
            \<comment> \<open>IdleEP case\<close>
            apply (rule ccorres_cond_true)
            apply csymbr
@@ -5729,18 +5718,16 @@ lemma receiveIPC_ccorres [corres]:
             apply (rule ccorres_rhs_assoc2)
             apply (rule ccorres_rhs_assoc2)
             apply (rule ccorres_split_nothrow_novcg)
-                apply (simp split del: if_split)
                 apply (rule receiveIPC_block_ccorres_helper[unfolded ptr_val_def, simplified])
                apply ceqv
               apply simp
-              apply (rule_tac ep=IdleEP
-                        in receiveIPC_enqueue_ccorres_helper[simplified, unfolded dc_def])
+              apply (rule_tac ep=IdleEP in receiveIPC_enqueue_ccorres_helper[simplified])
              apply (simp add: valid_ep'_def)
              apply (wp sts_st_tcb')
             apply (clarsimp simp: obj_at'_def ko_wp_at'_def projectKOs)
             apply (clarsimp simp: guard_is_UNIV_def)
            apply simp
-            apply (ctac add: doNBRecvFailedTransfer_ccorres[unfolded dc_def])
+            apply (ctac add: doNBRecvFailedTransfer_ccorres)
            \<comment> \<open>SendEP case\<close>
           apply (thin_tac "isBlockinga = from_bool P" for P)
           apply (rule ccorres_cond_false)
@@ -5818,8 +5805,6 @@ lemma receiveIPC_ccorres [corres]:
                                   split: Structures_H.thread_state.splits)
                   apply ceqv
 
-                 apply (fold dc_def)
-                 supply dc_simp[simp del]
                  apply (clarsimp simp:  from_bool_0 disj_imp[symmetric] simp del: Collect_const)
                  apply wpc
                   (* blocking ipc call *)
@@ -5899,12 +5884,12 @@ lemma receiveIPC_ccorres [corres]:
            apply (clarsimp simp:st_tcb_at_refs_of_rev')
            apply (erule_tac x=x and P="\<lambda>x. st_tcb_at' P x s" for P in ballE)
             apply (drule_tac t=x in valid_queues_not_runnable'_not_ksQ)
-             apply (clarsimp simp: st_tcb_at'_def obj_at'_def o_def)
+             apply (clarsimp simp: st_tcb_at'_def obj_at'_def)
             apply (subgoal_tac "sch_act_not x s")
              prefer 2
              apply (frule invs_sch_act_wf')
              apply (clarsimp simp:sch_act_wf_def)
-             apply (clarsimp simp: st_tcb_at'_def obj_at'_def o_def)
+             apply (clarsimp simp: st_tcb_at'_def obj_at'_def)
             apply (clarsimp simp: obj_at'_def st_tcb_at'_def
                                   projectKOs isBlockedOnSend_def
                             split: list.split | rule conjI)+
@@ -5932,11 +5917,10 @@ lemma sendSignal_dequeue_ccorres_helper:
          IF head_C \<acute>ntfn_queue = Ptr 0 THEN
              CALL notification_ptr_set_state(Ptr ntfn,scast NtfnState_Idle)
          FI)"
-
   apply (rule ccorres_from_vcg)
   apply (rule allI)
   apply (rule conseqPre, vcg)
-  apply (clarsimp split del: if_split simp del: comp_def)
+  apply (clarsimp split del: if_split)
   apply (frule (2) ntfn_blocked_in_queueD)
   apply (frule (1) ko_at_valid_ntfn' [OF _ invs_valid_objs'])
   apply (elim conjE)
@@ -5956,7 +5940,7 @@ lemma sendSignal_dequeue_ccorres_helper:
     apply (drule ntfn_to_ep_queue, (simp add: isWaitingNtfn_def)+)
     apply (simp add: tcb_queue_relation'_def)
    apply (clarsimp simp: typ_heap_simps cnotification_relation_def Let_def
-              cong: imp_cong split del: if_split simp del: comp_def)
+                   cong: imp_cong split del: if_split)
   apply (intro conjI impI allI)
      apply (fastforce simp: h_t_valid_clift)
     apply (fastforce simp: h_t_valid_clift)
@@ -6144,7 +6128,7 @@ lemma sendSignal_ccorres [corres]:
        apply wpc
         apply (simp add: option_to_ctcb_ptr_def split del: if_split)
         apply (rule ccorres_cond_false)
-        apply (ctac add: ntfn_set_active_ccorres[unfolded dc_def])
+        apply (ctac add: ntfn_set_active_ccorres)
        apply (rule ccorres_cond_true)
        apply (rule getThreadState_ccorres_foo)
        apply (rule ccorres_Guard_Seq)
@@ -6159,7 +6143,7 @@ lemma sendSignal_ccorres [corres]:
         apply (ctac(no_vcg) add: cancelIPC_ccorres1[OF cteDeleteOne_ccorres])
          apply (ctac(no_vcg) add: setThreadState_ccorres)
           apply (ctac(no_vcg) add: setRegister_ccorres)
-           apply (ctac add: possibleSwitchTo_ccorres[unfolded dc_def])
+           apply (ctac add: possibleSwitchTo_ccorres)
           apply (wp sts_running_valid_queues sts_st_tcb_at'_cases
                  | simp add: option_to_ctcb_ptr_def split del: if_split)+
         apply (rule_tac Q="\<lambda>_. tcb_at' (the (ntfnBoundTCB ntfn)) and invs'"
@@ -6167,7 +6151,7 @@ lemma sendSignal_ccorres [corres]:
          apply auto[1]
         apply wp
        apply simp
-       apply (ctac add: ntfn_set_active_ccorres[unfolded dc_def])
+       apply (ctac add: ntfn_set_active_ccorres)
       apply (clarsimp simp: guard_is_UNIV_def option_to_ctcb_ptr_def
                             X64_H.badgeRegister_def Kernel_C.badgeRegister_def
                             X64.badgeRegister_def X64.capRegister_def
@@ -6226,7 +6210,7 @@ lemma sendSignal_ccorres [corres]:
        apply ceqv
       apply (simp only: K_bind_def)
       apply (ctac (no_vcg))
-       apply (simp, fold dc_def)
+       apply simp
        apply (ctac (no_vcg))
         apply (ctac add: possibleSwitchTo_ccorres)
        apply (simp)
@@ -6376,7 +6360,7 @@ lemma receiveSignal_enqueue_ccorres_helper:
   apply (rule ccorres_gen_asm)
   apply (rule ccorres_from_vcg)
   apply (rule allI, rule conseqPre, vcg)
-  apply (clarsimp split del: if_split simp del: comp_def)
+  apply (clarsimp split del: if_split)
   apply (frule cmap_relation_ntfn)
   apply (erule (1) cmap_relation_ko_atE)
   apply (rule conjI)
@@ -6564,11 +6548,10 @@ lemma receiveSignal_ccorres [corres]:
         apply (rule ccorres_rhs_assoc2)
         apply (rule ccorres_rhs_assoc2)
         apply (rule ccorres_split_nothrow_novcg)
-            apply (simp)
             apply (rule receiveSignal_block_ccorres_helper[simplified])
            apply ceqv
           apply (simp only: K_bind_def)
-          apply (rule receiveSignal_enqueue_ccorres_helper[unfolded dc_def, simplified])
+          apply (rule receiveSignal_enqueue_ccorres_helper[simplified])
          apply (simp add: valid_ntfn'_def)
          apply (wp sts_st_tcb')
          apply (rule_tac Q="\<lambda>rv. ko_wp_at' (\<lambda>x. projectKO_opt x = Some ntfn
@@ -6579,7 +6562,7 @@ lemma receiveSignal_ccorres [corres]:
          apply wp
         apply (clarsimp simp: guard_is_UNIV_def)
        apply simp
-       apply (ctac add: doNBRecvFailedTransfer_ccorres[unfolded dc_def])
+       apply (ctac add: doNBRecvFailedTransfer_ccorres)
       \<comment> \<open>ActiveNtfn case\<close>
       apply (rename_tac badge)
       apply (rule ccorres_cond_false)
@@ -6636,8 +6619,7 @@ lemma receiveSignal_ccorres [corres]:
           apply (rule receiveSignal_block_ccorres_helper[simplified])
          apply ceqv
         apply (simp only: K_bind_def)
-        apply (rule_tac ntfn="ntfn"
-                           in receiveSignal_enqueue_ccorres_helper[unfolded dc_def, simplified])
+        apply (rule_tac ntfn="ntfn" in receiveSignal_enqueue_ccorres_helper[simplified])
        apply (simp add: valid_ntfn'_def)
        apply (wp sts_st_tcb')
        apply (rule_tac Q="\<lambda>rv. ko_wp_at' (\<lambda>x. projectKO_opt x = Some ntfn
@@ -6649,7 +6631,7 @@ lemma receiveSignal_ccorres [corres]:
        apply wp
       apply (clarsimp simp: guard_is_UNIV_def)
      apply simp
-     apply (ctac add: doNBRecvFailedTransfer_ccorres[unfolded dc_def])
+     apply (ctac add: doNBRecvFailedTransfer_ccorres)
     apply (clarsimp simp: guard_is_UNIV_def NtfnState_Active_def
                           NtfnState_Waiting_def NtfnState_Idle_def)
    apply (clarsimp simp: guard_is_UNIV_def)

--- a/proof/crefine/X64/IsolatedThreadAction.thy
+++ b/proof/crefine/X64/IsolatedThreadAction.thy
@@ -461,7 +461,7 @@ lemma modify_isolatable:
                    liftM_def bind_assoc)
   apply (clarsimp simp: monadic_rewrite_def exec_gets
                    getSchedulerAction_def)
-  apply (simp add: simpler_modify_def o_def)
+  apply (simp add: simpler_modify_def)
   apply (subst swap)
    apply (simp add: obj_at_partial_overwrite_If)
   apply (simp add: ksPSpace_update_partial_id o_def)
@@ -1159,8 +1159,7 @@ lemma setCTE_isolatable:
    apply (erule notE[rotated], erule (3) tcb_ctes_clear[rotated])
   apply (simp add: select_f_returns select_f_asserts split: if_split)
   apply (intro conjI impI)
-    apply (clarsimp simp: simpler_modify_def fun_eq_iff
-                          partial_overwrite_fun_upd2 o_def
+    apply (clarsimp simp: simpler_modify_def fun_eq_iff partial_overwrite_fun_upd2
                   intro!: kernel_state.fold_congs[OF refl refl])
     apply (clarsimp simp: obj_at'_def projectKOs objBits_simps)
     apply (erule notE[rotated], rule tcb_ctes_clear[rotated 2], assumption+)

--- a/proof/crefine/X64/Recycle_C.thy
+++ b/proof/crefine/X64/Recycle_C.thy
@@ -914,13 +914,13 @@ lemma cancelBadgedSends_ccorres:
                      split: Structures_H.endpoint.split_asm)
      apply ceqv
     apply wpc
-      apply (simp add: dc_def[symmetric] ccorres_cond_iffs)
+      apply (simp add: ccorres_cond_iffs)
       apply (rule ccorres_return_Skip)
-     apply (simp add: dc_def[symmetric] ccorres_cond_iffs)
+     apply (simp add: ccorres_cond_iffs)
      apply (rule ccorres_return_Skip)
     apply (rename_tac list)
     apply (simp add: Collect_True Collect_False endpoint_state_defs
-                     ccorres_cond_iffs dc_def[symmetric]
+                     ccorres_cond_iffs
                 del: Collect_const cong: call_ignore_cong)
     apply (rule ccorres_rhs_assoc)+
     apply (csymbr, csymbr)
@@ -1008,7 +1008,7 @@ lemma cancelBadgedSends_ccorres:
                 subgoal by (simp add: mask_def)
                subgoal by (auto split: if_split)
               subgoal by simp
-             apply (ctac add: rescheduleRequired_ccorres[unfolded dc_def])
+             apply (ctac add: rescheduleRequired_ccorres)
             apply (rule hoare_pre, wp weak_sch_act_wf_lift_linear set_ep_valid_objs')
             apply (clarsimp simp: weak_sch_act_wf_def sch_act_wf_def)
             apply (fastforce simp: valid_ep'_def pred_tcb_at' split: list.splits)
@@ -1018,7 +1018,7 @@ lemma cancelBadgedSends_ccorres:
           apply (rule iffD1 [OF ccorres_expand_while_iff_Seq])
           apply (rule ccorres_init_tmp_lift2, ceqv)
           apply (rule ccorres_guard_imp2)
-           apply (simp add: bind_assoc dc_def[symmetric]
+           apply (simp add: bind_assoc
                        del: Collect_const)
            apply (rule ccorres_cond_true)
            apply (rule ccorres_rhs_assoc)+
@@ -1045,7 +1045,7 @@ lemma cancelBadgedSends_ccorres:
             apply ceqv
            apply (rule_tac P="ret__unsigned_longlong=blockingIPCBadge rva" in ccorres_gen_asm2)
            apply (rule ccorres_if_bind, rule ccorres_if_lhs)
-            apply (simp add: bind_assoc dc_def[symmetric])
+            apply (simp add: bind_assoc)
             apply (rule ccorres_rhs_assoc)+
             apply (ctac add: setThreadState_ccorres)
               apply (ctac add: tcbSchedEnqueue_ccorres)
@@ -1115,9 +1115,9 @@ lemma cancelBadgedSends_ccorres:
              apply (wp hoare_vcg_const_Ball_lift sts_st_tcb_at'_cases
                        sts_sch_act sts_valid_queues setThreadState_oa_queued)
             apply (vcg exspec=setThreadState_cslift_spec)
-           apply (simp add: ccorres_cond_iffs dc_def[symmetric])
+           apply (simp add: ccorres_cond_iffs)
            apply (rule ccorres_symb_exec_r2)
-             apply (drule_tac x="x @ [a]" in spec, simp add: dc_def[symmetric])
+             apply (drule_tac x="x @ [a]" in spec, simp)
             apply vcg
            apply (vcg spec=modifies)
           apply (thin_tac "\<forall>x. P x" for P)

--- a/proof/crefine/X64/Refine_C.thy
+++ b/proof/crefine/X64/Refine_C.thy
@@ -611,9 +611,9 @@ lemma callKernel_withFastpath_corres_C:
    apply (rule ccorres_rhs_assoc)+
    apply (rule ccorres_symb_exec_r)+
        apply (rule ccorres_Cond_rhs)
-        apply (simp add: dc_def[symmetric])
+        apply simp
         apply (ctac add: ccorres_get_registers[OF fastpath_call_ccorres_callKernel])
-       apply (simp add: dc_def[symmetric])
+       apply simp
        apply (ctac add: ccorres_get_registers[OF fastpath_reply_recv_ccorres_callKernel])
       apply vcg
      apply (rule conseqPre, vcg, clarsimp)
@@ -694,13 +694,13 @@ lemma entry_corres_C:
          apply simp
         apply (rule corres_split)
 (* FIXME: fastpath
-           apply (rule corres_cases[where R=fp], simp_all add: dc_def[symmetric])[1]
-            apply (rule callKernel_withFastpath_corres_C, simp)
+           apply (rule corres_cases[where R=fp]; simp)
+            apply (rule callKernel_withFastpath_corres_C)
 *)
-           apply (rule callKernel_corres_C[unfolded dc_def], simp)
+           apply (rule callKernel_corres_C)
           apply (rule corres_split[where P=\<top> and P'=\<top> and r'="\<lambda>t t'. t' = tcb_ptr_to_ctcb_ptr t"])
              apply (clarsimp simp: rf_sr_def cstate_relation_def Let_def)
-            apply (rule getContext_corres[unfolded o_def], simp)
+            apply (rule getContext_corres, simp)
            apply (wp threadSet_all_invs_triv' callKernel_cur)+
    apply (clarsimp simp: all_invs'_def invs'_def cur_tcb'_def valid_state'_def)
   apply simp
@@ -897,7 +897,7 @@ lemma do_user_op_corres_C:
                apply (clarsimp simp: rf_sr_def cstate_relation_def Let_def
                                cpspace_relation_def)
                apply (drule(1) device_mem_C_relation[symmetric])
-               apply (simp add: comp_def)
+               apply simp
               apply (rule_tac P=valid_state' and P'=\<top> and r'="(=)" in corres_split)
                  apply (clarsimp simp: cstate_relation_def rf_sr_def
                    Let_def cmachine_state_relation_def)

--- a/proof/crefine/X64/Retype_C.thy
+++ b/proof/crefine/X64/Retype_C.thy
@@ -1097,7 +1097,7 @@ lemma ptr_add_to_new_cap_addrs:
   shows "(CTypesDefs.ptr_add (Ptr ptr :: 'a :: mem_type ptr) \<circ> of_nat) ` {k. k < n}
    = Ptr ` set (new_cap_addrs n ptr ko)"
   unfolding new_cap_addrs_def
-  apply (simp add: comp_def image_image shiftl_t2n size_of_m field_simps)
+  apply (simp add: image_image shiftl_t2n size_of_m field_simps)
   apply (clarsimp simp: atLeastLessThan_def lessThan_def)
   done
 
@@ -3676,8 +3676,7 @@ proof -
       apply (simp add: hrs_mem_def, subst rep0)
       apply (simp only: take_replicate, simp add: cte_C_size objBits_simps')
      apply (simp add: cte_C_size objBits_simps')
-    apply (simp add: fun_eq_iff o_def
-              split: if_split)
+    apply (simp add: fun_eq_iff split: if_split)
     apply (simp add: hrs_comm packed_heap_update_collapse
                      typ_heap_simps)
     apply (subst clift_heap_update_same_td_name', simp_all,
@@ -4370,7 +4369,7 @@ lemma mapM_x_storeWord_step:
   apply (subst if_not_P)
    apply (subst not_less)
    apply (erule is_aligned_no_overflow)
-   apply (simp add: mapM_x_map comp_def upto_enum_word del: upt.simps)
+   apply (simp add: mapM_x_map upto_enum_word del: upt.simps)
    apply (subst div_power_helper_64 [OF sz2, simplified])
     apply assumption
    apply (simp add: word_bits_def unat_minus_one del: upt.simps)
@@ -4800,7 +4799,7 @@ lemma copyGlobalMappings_ccorres:
   apply (cinit lift: new_vspace_' simp:)
    apply csymbr
    apply (rule ccorres_pre_gets_x64KSSKIMPML4_ksArchState, rename_tac skimPM)
-   apply (rule ccorres_rel_imp[where r=dc, OF _ dc_simp])
+   apply (rule ccorres_rel_imp[where r=dc, simplified])
    apply (clarsimp simp: whileAnno_def objBits_simps archObjSize_def
                          getPML4Index_def bit_simps X64.pptrBase_def mask_def)
     apply csymbr
@@ -4993,12 +4992,10 @@ lemma ccorres_placeNewObject_endpoint:
      apply (clarsimp simp: new_cap_addrs_def)
      apply (cut_tac createObjects_ccorres_ep [where ptr=regionBase and n="1" and sz="objBitsKO (KOEndpoint makeObject)"])
      apply (erule_tac x=\<sigma> in allE, erule_tac x=x in allE)
-     apply (clarsimp elim!:is_aligned_weaken simp: objBitsKO_def word_bits_def)+
-     apply (clarsimp simp: split_def Let_def
-         Fun.comp_def rf_sr_def new_cap_addrs_def
-         region_actually_is_bytes ptr_retyps_gen_def
-         objBits_simps
-         elim!: rsubst[where P="cstate_relation s'" for s'])
+     apply (clarsimp elim!: is_aligned_weaken simp: objBitsKO_def word_bits_def)+
+     apply (clarsimp simp: split_def Let_def rf_sr_def new_cap_addrs_def
+                           region_actually_is_bytes ptr_retyps_gen_def objBits_simps
+                    elim!: rsubst[where P="cstate_relation s'" for s'])
     apply (clarsimp simp: word_bits_conv)
    apply (clarsimp simp: range_cover.aligned objBits_simps)
   apply (clarsimp simp: no_fail_def)
@@ -5031,12 +5028,10 @@ lemma ccorres_placeNewObject_notification:
      apply (clarsimp simp: new_cap_addrs_def)
      apply (cut_tac createObjects_ccorres_ntfn [where ptr=regionBase and n="1" and sz="objBitsKO (KONotification makeObject)"])
      apply (erule_tac x=\<sigma> in allE, erule_tac x=x in allE)
-     apply (clarsimp elim!:is_aligned_weaken simp: objBitsKO_def word_bits_def)+
-     apply (clarsimp simp: split_def Let_def
-         Fun.comp_def rf_sr_def new_cap_addrs_def
-         region_actually_is_bytes ptr_retyps_gen_def
-         objBits_simps'
-         elim!: rsubst[where P="cstate_relation s'" for s'])
+     apply (clarsimp elim!: is_aligned_weaken simp: objBitsKO_def word_bits_def)+
+     apply (clarsimp simp: split_def Let_def rf_sr_def new_cap_addrs_def
+                           region_actually_is_bytes ptr_retyps_gen_def objBits_simps'
+                    elim!: rsubst[where P="cstate_relation s'" for s'])
     apply (clarsimp simp: word_bits_conv)
    apply (clarsimp simp: range_cover.aligned objBits_simps)
   apply (clarsimp simp: no_fail_def)
@@ -5096,11 +5091,10 @@ lemma ccorres_placeNewObject_captable:
       apply (clarsimp simp: split_def new_cap_addrs_def)
       apply (cut_tac createObjects_ccorres_cte [where ptr=regionBase and n="2 ^ unat userSize" and sz="unat userSize + objBitsKO (KOCTE makeObject)"])
       apply (erule_tac x=\<sigma> in allE, erule_tac x=x in allE)
-      apply (clarsimp elim!:is_aligned_weaken simp: objBitsKO_def word_bits_def cteSizeBits_def)+
-      apply (clarsimp simp: split_def objBitsKO_def
-          Fun.comp_def rf_sr_def split_def Let_def cteSizeBits_def
-          new_cap_addrs_def field_simps power_add ptr_retyps_gen_def
-                   elim!: rsubst[where P="cstate_relation s'" for s'])
+      apply (clarsimp elim!: is_aligned_weaken simp: objBitsKO_def word_bits_def cteSizeBits_def)+
+      apply (clarsimp simp: split_def objBitsKO_def rf_sr_def split_def Let_def cteSizeBits_def
+                            new_cap_addrs_def field_simps power_add ptr_retyps_gen_def
+                     elim!: rsubst[where P="cstate_relation s'" for s'])
      apply (clarsimp simp: word_bits_conv range_cover_def)
     apply (clarsimp simp: objBitsKO_def objBits_simps' range_cover.aligned)
    apply (clarsimp simp: no_fail_def)
@@ -5308,11 +5302,11 @@ lemma placeNewObject_pte:
       apply (clarsimp simp: split_def new_cap_addrs_def)
       apply (cut_tac s=\<sigma> in createObjects_ccorres_pte [where ptr=regionBase and sz=pageBits])
       apply (erule_tac x=\<sigma> in allE, erule_tac x=x in allE)
-      apply (clarsimp elim!:is_aligned_weaken simp: objBitsKO_def word_bits_def)+
+      apply (clarsimp elim!: is_aligned_weaken simp: objBitsKO_def word_bits_def)+
       apply (clarsimp simp: split_def objBitsKO_def archObjSize_def
-          Fun.comp_def rf_sr_def split_def Let_def ptr_retyps_gen_def
-          new_cap_addrs_def field_simps power_add
-          cong: globals.unfold_congs)
+                            rf_sr_def split_def Let_def ptr_retyps_gen_def
+                            new_cap_addrs_def field_simps power_add
+                      cong: globals.unfold_congs)
       apply (simp add: Int_ac bit_simps)
      apply (clarsimp simp: word_bits_conv range_cover_def archObjSize_def bit_simps)
     apply (clarsimp simp: objBitsKO_def range_cover.aligned archObjSize_def bit_simps)
@@ -6308,7 +6302,7 @@ proof -
              apply (simp add: obj_at'_real_def)
              apply (wp placeNewObject_ko_wp_at')
             apply (vcg exspec=Arch_initContext_modifies)
-           apply (clarsimp simp: dc_def)
+           apply clarsimp
            apply vcg
           apply (rule conseqPre, vcg, clarsimp)
          apply (clarsimp simp: createObject_hs_preconds_def
@@ -6488,7 +6482,7 @@ lemma ccorres_guard_impR:
 lemma typ_clear_region_dom:
  "dom (clift (hrs_htd_update (typ_clear_region ptr bits) hp) :: 'b :: mem_type typ_heap)
   \<subseteq>  dom ((clift hp) :: 'b :: mem_type typ_heap)"
-   apply (clarsimp simp:lift_t_def lift_typ_heap_def Fun.comp_def)
+   apply (clarsimp simp:lift_t_def lift_typ_heap_def comp_def)
    apply (clarsimp simp:lift_state_def)
    apply (case_tac hp)
    apply (clarsimp simp:)
@@ -8412,7 +8406,7 @@ shows  "ccorres dc xfdc
            apply (rule_tac P="rv' = of_nat n" in ccorres_gen_asm2, simp)
            apply (rule ccorres_rhs_assoc)+
            apply (rule ccorres_add_return)
-           apply (simp only: dc_def[symmetric] hrs_htd_update)
+           apply (simp only: hrs_htd_update)
            apply ((rule ccorres_Guard_Seq[where S=UNIV])+)?
            apply (rule ccorres_split_nothrow,
                 rule_tac S="{ptr .. ptr + of_nat (length destSlots) * 2^ (getObjectSize newType userSize) - 1}"
@@ -8771,7 +8765,7 @@ shows  "ccorres dc xfdc
   apply (simp add: o_def)
   apply (case_tac newType,
          simp_all add: object_type_from_H_def Kernel_C_defs
-                       nAPIObjects_def APIType_capBits_def o_def split:apiobject_type.splits)[1]
+                       nAPIObjects_def APIType_capBits_def split:apiobject_type.splits)[1]
          subgoal by (simp add:unat_eq_def word_unat.Rep_inverse' word_less_nat_alt)
         subgoal by (clarsimp simp:objBits_simps', unat_arith)
        apply (fold_subgoals (prefix))[3]

--- a/proof/crefine/X64/SR_lemmas_C.thy
+++ b/proof/crefine/X64/SR_lemmas_C.thy
@@ -672,7 +672,6 @@ proof (rule cor_map_relI [OF map_option_eq_dom_eq])
 
   hence "tcb_no_ctes_proj tcb = tcb_no_ctes_proj tcb'" using om
     apply -
-    apply (simp add: o_def)
     apply (drule fun_cong [where x = x])
     apply simp
     done

--- a/proof/crefine/X64/Schedule_C.thy
+++ b/proof/crefine/X64/Schedule_C.thy
@@ -182,14 +182,14 @@ lemmas ccorres_remove_tail_Guard_Skip
     = ccorres_abstract[where xf'="\<lambda>_. ()", OF ceqv_remove_tail_Guard_Skip]
 
 lemma switchToThread_ccorres':
-  "ccorres (\<lambda>_ _. True) xfdc
+  "ccorres dc xfdc
            (all_invs_but_ct_idle_or_in_cur_domain' and tcb_at' t)
            (UNIV \<inter> \<lbrace>\<acute>thread = tcb_ptr_to_ctcb_ptr t\<rbrace>)
            hs
            (switchToThread t)
            (Call switchToThread_'proc)"
   apply (rule ccorres_guard_imp2)
-      apply (ctac (no_vcg) add: switchToThread_ccorres[simplified dc_def])
+      apply (ctac (no_vcg) add: switchToThread_ccorres)
      apply auto
   done
 
@@ -283,14 +283,14 @@ proof -
     apply (intro conjI impI)
        apply (fastforce dest: bitmapQ_from_bitmap_lookup simp: valid_bitmapQ_bitmapQ_simp)
       apply (fastforce dest: lookupBitmapPriority_obj_at'
-                       simp: pred_conj_def comp_def obj_at'_def st_tcb_at'_def)
+                       simp: pred_conj_def obj_at'_def st_tcb_at'_def)
      apply (fastforce dest: bitmapQ_from_bitmap_lookup simp: valid_bitmapQ_bitmapQ_simp)
-    apply (clarsimp simp: pred_conj_def comp_def obj_at'_def st_tcb_at'_def)
+    apply (clarsimp simp: pred_conj_def obj_at'_def st_tcb_at'_def)
     apply (clarsimp simp: not_less le_maxDomain_eq_less_numDomains)
     apply (prop_tac "ksCurDomain s = 0")
      using unsigned_eq_0_iff apply force
     apply (cut_tac s=s in lookupBitmapPriority_obj_at'; simp?)
-    apply (clarsimp simp: pred_conj_def comp_def obj_at'_def st_tcb_at'_def)
+    apply (clarsimp simp: pred_conj_def obj_at'_def st_tcb_at'_def)
     done
 qed
 
@@ -371,7 +371,6 @@ lemma isHighestPrio_ccorres:
            (isHighestPrio d p)
            (Call isHighestPrio_'proc)"
   supply Collect_const [simp del]
-  supply dc_simp [simp del]
   supply prio_and_dom_limit_helpers[simp]
   supply Collect_const_mem [simp]
   (* FIXME: these should likely be in simpset for CRefine, or even in general *)
@@ -412,7 +411,6 @@ lemma isHighestPrio_ccorres:
 lemma schedule_ccorres:
   "ccorres dc xfdc invs' UNIV [] schedule (Call schedule_'proc)"
   supply Collect_const [simp del]
-  supply dc_simp [simp del]
   supply prio_and_dom_limit_helpers[simp]
   supply Collect_const_mem [simp]
   (* FIXME: these should likely be in simpset for CRefine, or even in general *)
@@ -426,7 +424,7 @@ lemma schedule_ccorres:
      apply (rule ccorres_cond_false_seq)
      apply simp
      apply (rule_tac P=\<top> and P'="{s. ksSchedulerAction_' (globals s) = NULL }" in ccorres_from_vcg)
-     apply (clarsimp simp: dc_def return_def split: prod.splits)
+     apply (clarsimp simp: return_def split: prod.splits)
      apply (rule conseqPre, vcg, clarsimp)
     (* toplevel case: action is choose new thread *)
     apply (rule ccorres_cond_true_seq)
@@ -443,7 +441,7 @@ lemma schedule_ccorres:
          apply (ctac add: tcbSchedEnqueue_ccorres)
          apply (rule ccorres_from_vcg[where P=\<top> and P'=UNIV])
          apply (clarsimp, rule conseqPre, vcg)
-         apply (clarsimp simp: dc_def return_def)
+         apply (clarsimp simp: return_def)
         apply (rule ccorres_cond_true_seq)
         (* isolate haskell part before setting thread action *)
         apply (simp add: scheduleChooseNewThread_def)
@@ -471,7 +469,7 @@ lemma schedule_ccorres:
         apply (ctac add: tcbSchedEnqueue_ccorres)
         apply (rule ccorres_from_vcg[where P=\<top> and P'=UNIV])
         apply (clarsimp, rule conseqPre, vcg)
-        apply (clarsimp simp: dc_def return_def)
+        apply (clarsimp simp: return_def)
        apply (rule ccorres_cond_false_seq)
 
        apply (rule_tac xf'=was_runnable_' in ccorres_abstract, ceqv)
@@ -491,7 +489,7 @@ lemma schedule_ccorres:
          apply (rule ccorres_rhs_assoc2)
          apply (rule ccorres_rhs_assoc2)
          apply (rule_tac r'="\<lambda>rv rv'. rv = to_bool rv'" and xf'=fastfail_' in ccorres_split_nothrow)
-             apply (clarsimp simp: scheduleSwitchThreadFastfail_def dc_simp)
+             apply (clarsimp simp: scheduleSwitchThreadFastfail_def)
              apply (rule ccorres_cond_seq2[THEN iffD1])
              apply (rule_tac xf'=ret__int_' and val="from_bool (curThread = it)"
                       and R="\<lambda>s. it = ksIdleThread s \<and> curThread = ksCurThread s" and R'=UNIV
@@ -528,11 +526,10 @@ lemma schedule_ccorres:
                 apply (rule ccorres_move_c_guard_tcb)
                 apply (rule ccorres_add_return2)
                 apply (ctac add: isHighestPrio_ccorres, clarsimp)
-                  apply (clarsimp simp: to_bool_def)
                   apply (rule ccorres_inst[where P=\<top> and P'=UNIV])
                   apply (rule ccorres_return)
                   apply (rule conseqPre, vcg)
-                  apply clarsimp
+                  apply (clarsimp simp: to_bool_def)
                  apply (rule wp_post_taut)
                 apply (vcg exspec=isHighestPrio_modifies)
                apply (rule_tac P=\<top> and P'="{s. ret__int_' s = 0}" in ccorres_from_vcg)
@@ -632,13 +629,12 @@ lemma schedule_ccorres:
        apply (clarsimp simp: invs'_bitmapQ_no_L1_orphans invs_ksCurDomain_maxDomain')
        apply (fastforce dest: invs_sch_act_wf')
 
-      apply (wp | clarsimp simp: dc_def)+
+      apply wpsimp+
      apply (vcg exspec=tcbSchedEnqueue_modifies)
     apply wp
    apply vcg
 
-  apply (clarsimp simp: tcb_at_invs' rf_sr_ksCurThread if_apply_def2 invs_queues invs_valid_objs'
-                         dc_def)+
+  apply (clarsimp simp: tcb_at_invs' rf_sr_ksCurThread if_apply_def2 invs_queues invs_valid_objs')
   apply (frule invs_sch_act_wf')
   apply (frule tcb_at_invs')
   apply (rule conjI)
@@ -710,7 +706,7 @@ lemma timerTick_ccorres:
    apply (ctac add: get_tsType_ccorres2 [where f="\<lambda>s. ksCurThread_' (globals s)"])
      apply (rule ccorres_split_nothrow_novcg)
          apply wpc
-                apply (simp add: "StrictC'_thread_state_defs", rule ccorres_cond_false, rule ccorres_return_Skip[unfolded dc_def])+
+                apply (simp add: "StrictC'_thread_state_defs", rule ccorres_cond_false, rule ccorres_return_Skip)+
              (* thread_state.Running *)
              apply simp
              apply (rule ccorres_cond_true)
@@ -732,17 +728,17 @@ lemma timerTick_ccorres:
               apply (rule_tac P="cur_tcb'" and P'=\<top> in ccorres_move_c_guards(8))
                apply (clarsimp simp: cur_tcb'_def)
                apply (fastforce simp: rf_sr_def cstate_relation_def Let_def typ_heap_simps dest: tcb_at_h_t_valid)
-              apply (ctac add: threadSet_timeSlice_ccorres[unfolded dc_def])
+              apply (ctac add: threadSet_timeSlice_ccorres)
              apply (rule ccorres_rhs_assoc)+
              apply (ctac)
                apply simp
                apply (ctac (no_vcg) add: tcbSchedAppend_ccorres)
-                apply (ctac add: rescheduleRequired_ccorres[unfolded dc_def])
+                apply (ctac add: rescheduleRequired_ccorres)
                apply (wp weak_sch_act_wf_lift_linear threadSet_valid_queues
                          threadSet_pred_tcb_at_state tcbSchedAppend_valid_objs' threadSet_valid_objs' threadSet_tcbDomain_triv
                     | clarsimp simp: st_tcb_at'_def o_def split: if_splits)+
              apply (vcg exspec=tcbSchedDequeue_modifies)
-        apply (simp add: "StrictC'_thread_state_defs", rule ccorres_cond_false, rule ccorres_return_Skip[unfolded dc_def])+
+        apply (simp add: "StrictC'_thread_state_defs", rule ccorres_cond_false, rule ccorres_return_Skip)+
         apply ceqv
        apply (clarsimp simp: decDomainTime_def numDomains_sge_1_simp)
        apply (rule ccorres_when[where R=\<top>])
@@ -754,7 +750,6 @@ lemma timerTick_ccorres:
            apply (clarsimp simp: rf_sr_def cstate_relation_def Let_def
                                  carch_state_relation_def cmachine_state_relation_def)
           apply ceqv
-         apply (fold dc_def)
          apply (rule ccorres_pre_getDomainTime)
          apply (rename_tac rva rv'a rvb)
          apply (rule_tac P'="{s. ksDomainTime_' (globals s) = rvb}" in ccorres_inst, simp)
@@ -762,13 +757,13 @@ lemma timerTick_ccorres:
           apply clarsimp
           apply (rule ccorres_guard_imp2)
            apply (rule ccorres_cond_true)
-           apply (ctac add: rescheduleRequired_ccorres[unfolded dc_def])
+           apply (ctac add: rescheduleRequired_ccorres)
           apply clarsimp
           apply assumption
          apply clarsimp
          apply (rule ccorres_guard_imp2)
           apply (rule ccorres_cond_false)
-          apply (rule ccorres_return_Skip[unfolded dc_def])
+          apply (rule ccorres_return_Skip)
          apply clarsimp
         apply wp
        apply (clarsimp simp: guard_is_UNIV_def)

--- a/proof/crefine/X64/SyscallArgs_C.thy
+++ b/proof/crefine/X64/SyscallArgs_C.thy
@@ -289,7 +289,7 @@ lemma ccorres_invocationCatch_Inr:
            if reply = [] then liftE (replyOnRestart thread [] isCall) \<sqinter> returnOk ()
                          else liftE (replyOnRestart thread reply isCall)
        odE od) c"
-  apply (simp add: invocationCatch_def liftE_bindE o_xo_injector)
+  apply (simp add: invocationCatch_def liftE_bindE o_xo_injector cong: ccorres_all_cong)
   apply (subst ccorres_liftM_simp[symmetric])
   apply (simp add: liftM_def bind_assoc bindE_def)
   apply (rule_tac f="\<lambda>f. ccorres rvr xs P P' hs f c" for rvr xs in arg_cong)

--- a/proof/crefine/X64/Syscall_C.thy
+++ b/proof/crefine/X64/Syscall_C.thy
@@ -268,22 +268,22 @@ lemma decodeInvocation_ccorres:
    apply (rule ccorres_Cond_rhs)
     apply (simp add: if_to_top_of_bind)
     apply (rule ccorres_trim_returnE, simp+)
-    apply (simp add: liftME_invocationCatch o_def)
+    apply (simp add: liftME_invocationCatch)
     apply (rule ccorres_call, rule decodeTCBInvocation_ccorres)
        apply assumption
       apply (simp+)[3]
    apply (rule ccorres_Cond_rhs)
     apply (rule ccorres_trim_returnE, simp+)
-    apply (simp add: liftME_invocationCatch o_def)
+    apply (simp add: liftME_invocationCatch)
     apply (rule ccorres_call,
-           erule decodeDomainInvocation_ccorres[unfolded o_def],
+           erule decodeDomainInvocation_ccorres,
            simp+)[1]
    apply (rule ccorres_Cond_rhs)
     apply (simp add: if_to_top_of_bind)
     apply (rule ccorres_trim_returnE, simp+)
-    apply (simp add: liftME_invocationCatch o_def)
+    apply (simp add: liftME_invocationCatch)
     apply (rule ccorres_call,
-           erule decodeCNodeInvocation_ccorres[unfolded o_def],
+           erule decodeCNodeInvocation_ccorres,
            simp+)[1]
    apply (rule ccorres_Cond_rhs)
     apply simp
@@ -717,7 +717,7 @@ lemma handleFault_ccorres:
          apply (rule ccorres_return_Skip')
         apply clarsimp
         apply (rule ccorres_cond_univ)
-        apply (ctac (no_vcg) add: handleDoubleFault_ccorres [unfolded dc_def])
+        apply (ctac (no_vcg) add: handleDoubleFault_ccorres)
        apply (simp add: sendFaultIPC_def)
        apply wp
          apply ((wp hoare_vcg_all_lift_R hoare_drop_impE_R |wpc |simp add: throw_def)+)[1]
@@ -1057,7 +1057,7 @@ lemma handleReply_ccorres:
                  apply (rule ccorres_cond_true)
                  apply simp
                  apply (rule ccorres_return_void_catchbrk)
-                 apply (rule ccorres_return_void_C[unfolded dc_def])
+                 apply (rule ccorres_return_void_C)
                 apply (vcg exspec=doReplyTransfer_modifies)
                apply (rule ccorres_fail)+
           apply (wpc, simp_all)
@@ -1075,7 +1075,6 @@ lemma handleReply_ccorres:
            apply (csymbr, csymbr, csymbr)
            apply simp
            apply (rule ccorres_assert2)
-           apply (fold dc_def)
            apply (rule ccorres_add_return2)
            apply (ctac (no_vcg))
             apply (rule ccorres_return_void_catchbrk)
@@ -1236,7 +1235,7 @@ lemma handleRecv_ccorres:
                apply (rule ccorres_add_return2)
                apply (rule ccorres_split_nothrow_call[where xf'=xfdc and d'="\<lambda>_. break_C"
                                                       and Q="\<lambda>_ _. True" and Q'="\<lambda>_ _. UNIV"])
-                      apply (ctac add: handleFault_ccorres[unfolded dc_def])
+                      apply (ctac add: handleFault_ccorres)
                      apply simp+
                   apply ceqv
                  apply (rule ccorres_break_return)
@@ -1255,7 +1254,7 @@ lemma handleRecv_ccorres:
           apply (simp add: liftE_bind)
           apply (ctac)
             apply (rule_tac P="\<lambda>s. ksCurThread s = rv" in ccorres_cross_over_guard)
-            apply (ctac add: receiveIPC_ccorres[unfolded dc_def])
+            apply (ctac add: receiveIPC_ccorres)
 
            apply (wp deleteCallerCap_ksQ_ct' hoare_vcg_all_lift)
           apply (rule conseqPost[where Q'=UNIV and A'="{}"], vcg exspec=deleteCallerCap_modifies)
@@ -1303,7 +1302,7 @@ lemma handleRecv_ccorres:
                   apply (rule ccorres_add_return2)
                   apply (rule ccorres_split_nothrow_call[where xf'=xfdc and d'="\<lambda>_. break_C"
                                                and Q="\<lambda>_ _. True" and Q'="\<lambda>_ _. UNIV"])
-                         apply (ctac add: handleFault_ccorres[unfolded dc_def])
+                         apply (ctac add: handleFault_ccorres)
                         apply simp+
                      apply ceqv
                     apply (rule ccorres_break_return)
@@ -1320,7 +1319,7 @@ lemma handleRecv_ccorres:
               apply (clarsimp simp: rf_sr_upd_safe)
 
              apply (simp add: liftE_bind)
-             apply (ctac  add: receiveSignal_ccorres[unfolded dc_def])
+             apply (ctac  add: receiveSignal_ccorres)
             apply clarsimp
             apply (vcg exspec=handleFault_modifies)
            apply (rule ccorres_cond_true_seq)
@@ -1333,7 +1332,7 @@ lemma handleRecv_ccorres:
               apply (rule ccorres_cross_over_guard[where P=\<top>])
               apply (rule ccorres_symb_exec_r)
                 apply (rule ccorres_add_return2)
-                apply (ctac add: handleFault_ccorres[unfolded dc_def])
+                apply (ctac add: handleFault_ccorres)
                   apply (rule ccorres_break_return[where P=\<top> and P'=UNIV])
                    apply simp+
                  apply wp
@@ -1354,7 +1353,7 @@ lemma handleRecv_ccorres:
         apply (rule ccorres_symb_exec_r)
           apply (rule ccorres_cross_over_guard[where P=\<top>])
           apply (rule ccorres_symb_exec_r)
-            apply (ctac add: handleFault_ccorres[unfolded dc_def])
+            apply (ctac add: handleFault_ccorres)
            apply vcg
           apply (rule conseqPre, vcg)
           apply (clarsimp simp: rf_sr_upd_safe)
@@ -1367,9 +1366,9 @@ lemma handleRecv_ccorres:
        apply (rule ccorres_rhs_assoc)+
        apply (rule ccorres_cross_over_guard[where P=\<top>])
        apply (rule ccorres_symb_exec_r)
-         apply (ctac add: handleFault_ccorres[unfolded dc_def])
+         apply (ctac add: handleFault_ccorres)
            apply (rule ccorres_split_throws)
-            apply (rule ccorres_return_void_C [unfolded dc_def])
+            apply (rule ccorres_return_void_C)
            apply vcg
           apply wp
          apply (vcg exspec=handleFault_modifies)
@@ -1596,7 +1595,6 @@ lemma ccorres_handleReservedIRQ:
                      (\<forall>p. ksCurThread s \<notin> set (ksReadyQueues s p))))
     (UNIV \<inter> {s. irq_' s = ucast irq}) hs
     (handleReservedIRQ irq) (Call handleReservedIRQ_'proc)"
-  supply dc_simp[simp del]
   apply (cinit lift: irq_')
    apply (rule ccorres_return_Skip)
   apply clarsimp
@@ -1619,11 +1617,11 @@ lemma handleInterrupt_ccorres:
     apply (subst doMachineOp_bind)
       apply (rule maskInterrupt_empty_fail)
      apply (rule ackInterrupt_empty_fail)
-    apply (ctac add: maskInterrupt_ccorres[unfolded dc_def])
+    apply (ctac add: maskInterrupt_ccorres)
       apply (subst bind_return_unit[where f="doMachineOp (ackInterrupt irq)"])
-      apply (ctac add: ackInterrupt_ccorres[unfolded dc_def])
+      apply (ctac add: ackInterrupt_ccorres)
         apply (rule ccorres_split_throws)
-         apply (rule ccorres_return_void_C[unfolded dc_def])
+         apply (rule ccorres_return_void_C)
         apply vcg
        apply wp
       apply (vcg exspec=ackInterrupt_modifies)
@@ -1663,7 +1661,7 @@ lemma handleInterrupt_ccorres:
          apply (ctac (no_vcg) add: sendSignal_ccorres)
           apply (simp add: maskIrqSignal_def)
           apply (ctac (no_vcg) add: maskInterrupt_ccorres)
-           apply (ctac add: ackInterrupt_ccorres [unfolded dc_def])
+           apply (ctac add: ackInterrupt_ccorres)
           apply wp+
         apply (simp del: Collect_const)
         apply (rule ccorres_cond_true_seq)
@@ -1672,7 +1670,7 @@ lemma handleInterrupt_ccorres:
         apply (rule ccorres_cond_false_seq)
         apply (simp add: maskIrqSignal_def)
         apply (ctac (no_vcg) add: maskInterrupt_ccorres)
-         apply (ctac add: ackInterrupt_ccorres [unfolded dc_def])
+         apply (ctac add: ackInterrupt_ccorres)
         apply wp
        apply (rule_tac P=\<top> and P'="{s. ret__int_' s = 0 \<and> cap_get_tag cap \<noteq> scast cap_notification_cap}" in ccorres_inst)
        apply (clarsimp simp: isCap_simps simp del: Collect_const)
@@ -1684,7 +1682,7 @@ lemma handleInterrupt_ccorres:
                         rule ccorres_cond_false_seq, simp,
                         rule ccorres_cond_false_seq, simp,
                         ctac (no_vcg) add: maskInterrupt_ccorres,
-                        ctac (no_vcg) add: ackInterrupt_ccorres [unfolded dc_def],
+                        ctac (no_vcg) add: ackInterrupt_ccorres,
                         wp, simp)+)
       apply (wp getSlotCap_wp)
      apply simp
@@ -1693,7 +1691,6 @@ lemma handleInterrupt_ccorres:
     apply (rule ccorres_move_const_guards)+
     apply (rule ccorres_cond_false_seq)
     apply (rule ccorres_cond_true_seq)
-    apply (fold dc_def)[1]
     apply (rule ccorres_rhs_assoc)+
     apply (ctac (no_vcg) add: timerTick_ccorres)
      apply (ctac (no_vcg) add: resetTimer_ccorres)
@@ -1705,7 +1702,7 @@ lemma handleInterrupt_ccorres:
    apply (rule ccorres_cond_false_seq)
    apply (rule ccorres_cond_true_seq)
    apply (ctac add: ccorres_handleReservedIRQ)
-     apply (ctac (no_vcg) add: ackInterrupt_ccorres [unfolded dc_def])
+     apply (ctac (no_vcg) add: ackInterrupt_ccorres)
     apply wp
    apply (vcg exspec=handleReservedIRQ_modifies)
   apply (simp add: sint_ucast_eq_uint is_down uint_up_ucast is_up )

--- a/proof/crefine/X64/TcbQueue_C.thy
+++ b/proof/crefine/X64/TcbQueue_C.thy
@@ -1383,7 +1383,7 @@ lemma user_fpu_state_C_in_tcb_C_offset:
   "(typ_uinfo_t TYPE(user_fpu_state_C), n) \<in> td_set (typ_uinfo_t TYPE(tcb_C)) 0 \<Longrightarrow> n = 0"
   \<comment> \<open>Examine the fields of tcb_C.\<close>
   apply (simp add: typ_uinfo_t_def tcb_C_typ_info_unfold td_set_export_uinfo_eq td_set_adjust_ti_eq
-                   image_comp image_Un apfst_comp o_def[where f=export_uinfo]
+                   image_comp image_Un apfst_comp
               del: export_uinfo_typdesc_simp)
   apply (elim disjE)
   apply (all \<open>drule td_set_image_field_lookup[rotated]; clarsimp\<close>)

--- a/proof/crefine/X64/Tcb_C.thy
+++ b/proof/crefine/X64/Tcb_C.thy
@@ -412,8 +412,8 @@ lemma setPriority_ccorres:
         apply (rule ccorres_pre_getCurThread)
         apply (rule_tac R = "\<lambda>s. rv = ksCurThread s" in ccorres_cond2)
           apply (clarsimp simp: rf_sr_ksCurThread)
-         apply (ctac add: rescheduleRequired_ccorres[unfolded dc_def])
-        apply (ctac add: possibleSwitchTo_ccorres[unfolded dc_def])
+         apply (ctac add: rescheduleRequired_ccorres)
+        apply (ctac add: possibleSwitchTo_ccorres)
        apply (rule ccorres_return_Skip')
       apply (wp isRunnable_wp)
      apply (wpsimp wp: hoare_drop_imps threadSet_valid_queues threadSet_valid_objs'
@@ -619,7 +619,7 @@ lemma invokeTCB_ThreadControl_ccorres:
            apply (rule ccorres_move_array_assertion_tcb_ctes ccorres_Guard_Seq)+
            apply csymbr
            apply (simp add: liftE_bindE[symmetric] bindE_assoc getThreadBufferSlot_def
-                            locateSlot_conv o_def
+                            locateSlot_conv
                        del: Collect_const)
            apply (simp add: liftE_bindE del: Collect_const)
            apply (ctac(no_vcg) add: cteDelete_ccorres)
@@ -665,7 +665,7 @@ lemma invokeTCB_ThreadControl_ccorres:
                                            and Q'=UNIV in ccorres_rewrite_cond_sr)
                             apply (clarsimp simp: Collect_const_mem rf_sr_ksCurThread)
                            apply (rule ccorres_Cond_rhs; clarsimp)
-                            apply (ctac (no_vcg) add: rescheduleRequired_ccorres[unfolded dc_def])
+                            apply (ctac (no_vcg) add: rescheduleRequired_ccorres)
                            apply (rule ccorres_return_Skip')
                           apply (rule ccorres_split_nothrow_novcg_dc)
                              apply (rule ccorres_cond2[where R=\<top>], simp add: Collect_const_mem)
@@ -703,7 +703,7 @@ lemma invokeTCB_ThreadControl_ccorres:
                                       and Q'=UNIV in ccorres_rewrite_cond_sr)
                        apply (clarsimp simp: Collect_const_mem rf_sr_ksCurThread)
                       apply (rule ccorres_Cond_rhs; clarsimp)
-                       apply (ctac (no_vcg) add: rescheduleRequired_ccorres[unfolded dc_def])
+                       apply (ctac (no_vcg) add: rescheduleRequired_ccorres)
                       apply (rule ccorres_return_Skip')
                      apply (rule ccorres_split_nothrow_novcg_dc)
                         apply (rule ccorres_cond2[where R=\<top>], simp add: Collect_const_mem)
@@ -732,7 +732,7 @@ lemma invokeTCB_ThreadControl_ccorres:
                                     and Q'=UNIV in ccorres_rewrite_cond_sr)
                      apply (clarsimp simp: Collect_const_mem rf_sr_ksCurThread)
                     apply (rule ccorres_Cond_rhs; clarsimp)
-                     apply (ctac(no_vcg) add: rescheduleRequired_ccorres[unfolded dc_def])
+                     apply (ctac(no_vcg) add: rescheduleRequired_ccorres)
                     apply (rule ccorres_return_Skip')
                    apply (rule ccorres_split_nothrow_novcg_dc)
                       apply (rule ccorres_cond2[where R=\<top>], simp add: Collect_const_mem)
@@ -759,7 +759,7 @@ lemma invokeTCB_ThreadControl_ccorres:
                                   and Q'=UNIV in ccorres_rewrite_cond_sr)
                    apply (clarsimp simp: Collect_const_mem rf_sr_ksCurThread)
                   apply (rule ccorres_Cond_rhs; clarsimp)
-                   apply (ctac(no_vcg) add: rescheduleRequired_ccorres[unfolded dc_def])
+                   apply (ctac(no_vcg) add: rescheduleRequired_ccorres)
                   apply (rule ccorres_return_Skip')
                  apply (rule ccorres_split_nothrow_novcg_dc)
                     apply (rule ccorres_cond2[where R=\<top>], simp add: Collect_const_mem)
@@ -847,11 +847,10 @@ lemma invokeTCB_ThreadControl_ccorres:
          apply csymbr
          apply (ctac(no_vcg) add: cteDelete_ccorres)
            apply (simp add: liftE_bindE Collect_False ccorres_cond_iffs
-                            dc_def
                        del: Collect_const)
            apply ((rule ccorres_split_nothrow_novcg_dc[rotated], assumption) | rule ccorres_rhs_assoc2)+
              apply (simp add: conj_comms pred_conj_def)
-             apply (simp add: o_def cong: conj_cong option.case_cong)
+             apply (simp cong: conj_cong option.case_cong)
              apply (wp checked_insert_tcb_invs' hoare_case_option_wp
                        checkCap_inv [where P="tcb_at' p0" for p0]
                        checkCap_inv [where P="cte_at' p0" for p0]
@@ -869,8 +868,7 @@ lemma invokeTCB_ThreadControl_ccorres:
              apply (rule checkCapAt_ccorres2)
                 apply ceqv
                apply csymbr
-               apply (simp add: Collect_True assertDerived_def bind_assoc
-                                ccorres_cond_iffs dc_def[symmetric]
+               apply (simp add: Collect_True assertDerived_def bind_assoc ccorres_cond_iffs
                            del: Collect_const)
                apply (rule ccorres_symb_exec_l)
                   apply (ctac add: cteInsert_ccorres)
@@ -878,14 +876,14 @@ lemma invokeTCB_ThreadControl_ccorres:
               apply csymbr
               apply (simp add: Collect_False ccorres_cond_iffs
                           del: Collect_const)
-              apply (rule ccorres_return_Skip[unfolded dc_def])
+              apply (rule ccorres_return_Skip)
              apply (clarsimp simp: guard_is_UNIV_def Collect_const_mem
                                    tcbVTable_def tcbVTableSlot_def Kernel_C.tcbVTable_def
                                    cte_level_bits_def size_of_def option_to_0_def objBits_defs mask_def)
             apply csymbr
             apply (simp add: Collect_False del: Collect_const)
             apply (rule ccorres_cond_false)
-            apply (rule ccorres_return_Skip[unfolded dc_def])
+            apply (rule ccorres_return_Skip)
            apply (clarsimp simp: guard_is_UNIV_def ccap_relation_def cap_thread_cap_lift
                                  cap_to_H_def Collect_const_mem canonical_address_bitfield_extract_tcb)
           apply simp
@@ -910,12 +908,11 @@ lemma invokeTCB_ThreadControl_ccorres:
         apply csymbr
         apply (ctac(no_vcg) add: cteDelete_ccorres)
           apply (simp add: liftE_bindE Collect_False ccorres_cond_iffs
-                           dc_def
                       del: Collect_const)
           apply ((rule ccorres_split_nothrow_novcg_dc[rotated], assumption)
                   | rule ccorres_rhs_assoc2)+
             apply (simp add: conj_comms pred_conj_def)
-            apply (simp add: o_def cong: conj_cong option.case_cong)
+            apply (simp cong: conj_cong option.case_cong)
             apply (wp checked_insert_tcb_invs' hoare_case_option_wp
                       checkCap_inv [where P="tcb_at' p0" for p0]
                       checkCap_inv [where P="cte_at' p0" for p0]
@@ -936,8 +933,7 @@ lemma invokeTCB_ThreadControl_ccorres:
             apply (rule checkCapAt_ccorres2)
                apply ceqv
               apply csymbr
-              apply (simp add: Collect_True assertDerived_def bind_assoc
-                               ccorres_cond_iffs dc_def[symmetric]
+              apply (simp add: Collect_True assertDerived_def bind_assoc ccorres_cond_iffs
                           del: Collect_const)
               apply (rule ccorres_symb_exec_l)
                  apply (ctac add: cteInsert_ccorres)
@@ -945,14 +941,14 @@ lemma invokeTCB_ThreadControl_ccorres:
              apply csymbr
              apply (simp add: Collect_False ccorres_cond_iffs
                          del: Collect_const)
-             apply (rule ccorres_return_Skip[unfolded dc_def])
+             apply (rule ccorres_return_Skip)
             apply (clarsimp simp: guard_is_UNIV_def Collect_const_mem
                                   Kernel_C.tcbCTable_def tcbCTableSlot_def if_1_0_0
                                   cte_level_bits_def size_of_def option_to_0_def mask_def objBits_defs)
            apply csymbr
            apply (simp add: Collect_False del: Collect_const)
            apply (rule ccorres_cond_false)
-           apply (rule ccorres_return_Skip[unfolded dc_def])
+           apply (rule ccorres_return_Skip)
           apply (clarsimp simp: guard_is_UNIV_def ccap_relation_def cap_thread_cap_lift
                                 cap_to_H_def Collect_const_mem canonical_address_bitfield_extract_tcb)
          apply simp
@@ -1002,7 +998,7 @@ lemma setupReplyMaster_ccorres:
   apply (cinit lift: thread_')
    apply (rule ccorres_move_array_assertion_tcb_ctes ccorres_Guard_Seq)+
    apply ctac
-     apply (simp del: Collect_const add: dc_def[symmetric])
+     apply (simp del: Collect_const)
      apply (rule ccorres_pre_getCTE)
      apply (rule ccorres_move_c_guard_cte)
      apply (rule_tac F="\<lambda>rv'. (rv' = scast cap_null_cap) = (cteCap oldCTE = NullCap)"
@@ -1148,10 +1144,10 @@ lemma postModifyRegisters_ccorres:
     apply (simp add: if_distrib[where f="asUser t" for t] asUser_return)
     apply (rule_tac R="\<lambda>s. ct = ksCurThread s" in ccorres_cond2)
       apply (clarsimp simp: rf_sr_ksCurThread)
-     apply (ctac add: setRegister_ccorres[unfolded dc_def])
+     apply (ctac add: setRegister_ccorres)
     apply (rule ccorres_add_return2)
     apply (rule ccorres_stateAssert)
-    apply (rule ccorres_return_Skip'[unfolded dc_def])
+    apply (rule ccorres_return_Skip')
    by simp+
 
 lemma invokeTCB_CopyRegisters_ccorres:
@@ -1640,10 +1636,10 @@ lemma invokeTCB_WriteRegisters_ccorres[where S=UNIV]:
                  apply (rule ccorres_split_nothrow_novcg)
                      apply (rule ccorres_when[where R=\<top>])
                       apply (simp add: from_bool_0 Collect_const_mem)
-                     apply (rule_tac xf'="\<lambda>_. 0" in ccorres_call)
-                      apply (rule restart_ccorres)
+                     apply (rule_tac xf'=Corres_C.xfdc in ccorres_call)
+                        apply (rule restart_ccorres)
+                       apply simp
                       apply simp
-                      apply (simp add: xfdc_def)
                      apply simp
                     apply (rule ceqv_refl)
                    apply (rule ccorres_split_nothrow_novcg_dc)
@@ -1827,6 +1823,7 @@ shows
                 apply (rule ccorres_rhs_assoc)+
                 apply csymbr
                 apply (ctac add: lookupIPCBuffer_ccorres)
+                  apply (rename_tac state destIPCBuffer ipcBuffer)
                   apply (ctac add: setRegister_ccorres)
                     apply (rule ccorres_stateAssert)
                     apply (rule ccorres_rhs_assoc2)
@@ -1886,15 +1883,15 @@ shows
                        apply (rule bind_apply_cong[OF _ refl])
                        apply (rule_tac n1="min (unat n_frameRegisters - unat n_msgRegisters) (unat n)"
                                    in fun_cong [OF mapM_x_split_append])
-                      apply (rule_tac P="rva \<noteq> Some 0" in ccorres_gen_asm)
-                      apply (subgoal_tac "(ipcBuffer = NULL) = (rva = None)")
+                      apply (rule_tac P="destIPCBuffer \<noteq> Some 0" in ccorres_gen_asm)
+                      apply (subgoal_tac "(ipcBuffer = NULL) = (destIPCBuffer = None)")
                        prefer 2
                        apply (clarsimp simp: option_to_ptr_def option_to_0_def
                                       split: option.split_asm)
                       apply (simp add: bind_assoc del: Collect_const)
                       apply (rule_tac xf'=i_' and r'="\<lambda>_ rv. unat rv = min (unat n_frameRegisters)
                                                                       (min (unat n)
-                                                                           (case rva of None \<Rightarrow> unat n_msgRegisters
+                                                                           (case destIPCBuffer of None \<Rightarrow> unat n_msgRegisters
                                                                               | _ \<Rightarrow> unat n_frameRegisters))"
                                  in ccorres_split_nothrow_novcg)
                           apply (rule ccorres_Cond_rhs)
@@ -1902,7 +1899,7 @@ shows
                                   rule_tac F="\<lambda>m s. obj_at' (\<lambda>tcb. map ((user_regs o atcbContextGet o tcbArch) tcb) (genericTake n
                                                       (X64_H.frameRegisters @ X64_H.gpRegisters))
                                                                = reply) target s
-                                                 \<and> valid_ipc_buffer_ptr' (the rva) s
+                                                 \<and> valid_ipc_buffer_ptr' (the destIPCBuffer) s
                                                  \<and> valid_pspace' s"
                                        and i="unat n_msgRegisters"
                                     in ccorres_mapM_x_while')
@@ -2011,11 +2008,10 @@ shows
                             apply (rename_tac i_c, rule_tac P="i_c = 0" in ccorres_gen_asm2)
                             apply (simp add: drop_zip del: Collect_const)
                             apply (rule ccorres_Cond_rhs)
-                             apply (simp del: Collect_const)
                              apply (rule_tac F="\<lambda>m s. obj_at' (\<lambda>tcb. map ((user_regs o atcbContextGet o tcbArch) tcb) (genericTake n
                                                        (X64_H.frameRegisters @ X64_H.gpRegisters))
                                                                 = reply) target s
-                                                  \<and> valid_ipc_buffer_ptr' (the rva) s \<and> valid_pspace' s"
+                                                  \<and> valid_ipc_buffer_ptr' (the destIPCBuffer) s \<and> valid_pspace' s"
                                         and i="0" in ccorres_mapM_x_while')
                                  apply (clarsimp simp: less_diff_conv drop_zip)
                                  apply (rule ccorres_guard_imp2)
@@ -2088,11 +2084,11 @@ shows
                              apply (simp add: min_less_iff_disj less_imp_diff_less)
                             apply (simp add: drop_zip n_gpRegisters_def)
                             apply (elim disjE impCE)
-                             apply (clarsimp simp: mapM_x_Nil)
+                             apply (clarsimp simp: mapM_x_Nil cong: ccorres_all_cong)
                              apply (rule ccorres_return_Skip')
-                            apply (simp add: linorder_not_less word_le_nat_alt
-                                             drop_zip mapM_x_Nil n_frameRegisters_def
-                                             min.absorb1 n_msgRegisters_def)
+                            apply (simp add: linorder_not_less word_le_nat_alt drop_zip
+                                             mapM_x_Nil n_frameRegisters_def n_msgRegisters_def
+                                       cong: ccorres_all_cong)
                             apply (rule ccorres_guard_imp2, rule ccorres_return_Skip')
                             apply simp
                            apply ceqv
@@ -2182,7 +2178,7 @@ shows
      apply (vcg exspec=suspend_modifies)
     apply vcg
    apply (rule conseqPre, vcg, clarsimp)
-  apply (clarsimp simp: rf_sr_ksCurThread ct_in_state'_def dc_def
+  apply (clarsimp simp: rf_sr_ksCurThread ct_in_state'_def
                  split: if_split)
   done
 
@@ -2384,7 +2380,7 @@ lemma decodeWriteRegisters_ccorres:
          apply (simp add: performInvocation_def)
          apply (ctac(no_vcg) add: invokeTCB_WriteRegisters_ccorres
                                     [where args=args and someNum="unat (args ! 1)"])
-           apply (simp add: dc_def[symmetric] o_def)
+           apply simp
            apply (rule ccorres_alternative2, rule ccorres_return_CE, simp+)
           apply (rule ccorres_return_C_errorE, simp+)[1]
          apply wp[1]
@@ -2404,7 +2400,7 @@ lemma decodeWriteRegisters_ccorres:
                         WriteRegisters_resume_def word_sle_def word_sless_def
                         numeral_eqs)
   apply (frule arg_cong[where f="\<lambda>x. unat (of_nat x :: machine_word)"],
-         simp(no_asm_use) only: word_unat.Rep_inverse o_def,
+         simp(no_asm_use) only: word_unat.Rep_inverse,
          simp)
   apply (rule conjI)
    apply clarsimp
@@ -3202,7 +3198,6 @@ lemma decodeSetMCPriority_ccorres:
             >>= invocationCatch thread isBlocking isCall InvokeTCB)
      (Call decodeSetMCPriority_'proc)"
   supply Collect_const[simp del]
-  supply dc_simp[simp del]
   apply (cinit' lift: cap_' length___unsigned_long_' current_extra_caps_' buffer_' simp: decodeSetMCPriority_def)
    apply (simp cong: StateSpace.state.fold_congs globals.fold_congs)
    apply (rule ccorres_rhs_assoc2)
@@ -3270,8 +3265,7 @@ lemma decodeSetMCPriority_ccorres:
              apply csymbr
              apply csymbr
              apply (ctac (no_vcg) add: invokeTCB_ThreadControl_ccorres)
-               (* HACK: delete rules from the simpset to avoid the RVRs getting out of sync *)
-               apply (clarsimp simp del: intr_and_se_rel_simps comp_apply dc_simp)
+               apply clarsimp
                apply (rule ccorres_alternative2)
                apply (rule ccorres_return_CE; simp)
               apply (rule ccorres_return_C_errorE; simp)
@@ -3336,7 +3330,7 @@ lemma decodeSetPriority_ccorres:
      (decodeSetPriority args cp extraCaps
             >>= invocationCatch thread isBlocking isCall InvokeTCB)
      (Call decodeSetPriority_'proc)"
-  supply Collect_const[simp del] dc_simp[simp del]
+  supply Collect_const[simp del]
   apply (cinit' lift: cap_' length___unsigned_long_' current_extra_caps_' buffer_' simp: decodeSetPriority_def)
      apply (simp cong: StateSpace.state.fold_congs globals.fold_congs)
    apply (rule ccorres_rhs_assoc2)
@@ -3404,8 +3398,7 @@ lemma decodeSetPriority_ccorres:
              apply csymbr
              apply csymbr
              apply (ctac (no_vcg) add: invokeTCB_ThreadControl_ccorres)
-               (* HACK: delete rules from the simpset to avoid the RVRs getting out of sync *)
-               apply (clarsimp simp del: intr_and_se_rel_simps comp_apply dc_simp)
+               apply clarsimp
                apply (rule ccorres_alternative2)
                apply (rule ccorres_return_CE; simp)
               apply (rule ccorres_return_C_errorE; simp)
@@ -3483,7 +3476,7 @@ lemma decodeSetSchedParams_ccorres:
      (decodeSetSchedParams args cp extraCaps
             >>= invocationCatch thread isBlocking isCall InvokeTCB)
      (Call decodeSetSchedParams_'proc)"
-  supply Collect_const[simp del] dc_simp[simp del]
+  supply Collect_const[simp del]
   apply (cinit' lift: cap_' length___unsigned_long_' current_extra_caps_' buffer_' simp: decodeSetSchedParams_def)
    apply (simp cong: StateSpace.state.fold_congs globals.fold_congs)
    apply (rule ccorres_rhs_assoc2)
@@ -3570,8 +3563,7 @@ lemma decodeSetSchedParams_ccorres:
                   apply csymbr
                   apply csymbr
                   apply (ctac (no_vcg) add: invokeTCB_ThreadControl_ccorres)
-                    (* HACK: delete rules from the simpset to avoid the RVRs getting out of sync *)
-                    apply (clarsimp simp del: intr_and_se_rel_simps comp_apply dc_simp)
+                    apply clarsimp
                     apply (rule ccorres_alternative2)
                     apply (rule ccorres_return_CE; simp)
                    apply (rule ccorres_return_C_errorE; simp)
@@ -3837,7 +3829,7 @@ lemma bindNotification_ccorres:
        apply ceqv
       apply (rule ccorres_move_c_guard_tcb)
       apply (simp add: setBoundNotification_def)
-      apply (rule_tac P'=\<top> and P=\<top> in threadSet_ccorres_lemma3[unfolded dc_def])
+      apply (rule_tac P'=\<top> and P=\<top> in threadSet_ccorres_lemma3)
        apply vcg
       apply simp
       apply (erule (1) rf_sr_tcb_update_no_queue2,
@@ -4300,7 +4292,7 @@ lemma decodeSetSpace_ccorres:
                       apply (simp add: Collect_False del: Collect_const)
                       apply csymbr
                       apply csymbr
-                      apply (simp add: cnode_cap_case_if cap_get_tag_isCap dc_def[symmetric]
+                      apply (simp add: cnode_cap_case_if cap_get_tag_isCap
                                   del: Collect_const)
                       apply (rule ccorres_Cond_rhs_Seq)
                        apply (simp add: injection_handler_throwError
@@ -4446,7 +4438,7 @@ lemma invokeTCB_SetTLSBase_ccorres:
   apply (cinit lift: thread_' tls_base_')
    apply (simp add: liftE_def bind_assoc
                del: Collect_const)
-   apply (ctac add: setRegister_ccorres[simplified dc_def])
+   apply (ctac add: setRegister_ccorres)
      apply (rule ccorres_pre_getCurThread)
      apply (rename_tac cur_thr)
      apply (rule ccorres_split_nothrow_novcg_dc)

--- a/proof/crefine/X64/VSpace_C.thy
+++ b/proof/crefine/X64/VSpace_C.thy
@@ -1190,7 +1190,7 @@ lemma setVMRoot_ccorres:
      apply csymbr
      apply (simp add: cap_get_tag_isCap_ArchObject2)
      apply (rule ccorres_Cond_rhs_Seq)
-      apply (simp add: throwError_def catch_def dc_def[symmetric])
+      apply (simp add: throwError_def catch_def)
       apply (rule ccorres_cond_true_seq, ccorres_rewrite)
       apply (rule ccorres_rhs_assoc)
       apply (rule ccorres_h_t_valid_x64KSSKIMPML4)
@@ -1206,9 +1206,9 @@ lemma setVMRoot_ccorres:
      apply (rule_tac P="to_bool (capPML4IsMapped_CL (cap_pml4_cap_lift vRootCap'))
                               = (capPML4MappedASID (capCap vRootCap) \<noteq> None)"
                   in ccorres_gen_asm2)
-     apply (clarsimp simp: to_bool_def dc_def[symmetric])
+     apply (clarsimp simp: to_bool_def)
      apply (rule ccorres_Cond_rhs_Seq)
-      apply (simp add: throwError_def catch_def dc_def[symmetric], ccorres_rewrite)
+      apply (simp add: throwError_def catch_def, ccorres_rewrite)
       apply (rule ccorres_rhs_assoc)
       apply (rule ccorres_h_t_valid_x64KSSKIMPML4)
       apply csymbr
@@ -1232,7 +1232,7 @@ lemma setVMRoot_ccorres:
                      in ccorres_gen_asm2)
         apply simp
         apply (rule ccorres_Cond_rhs_Seq)
-         apply (simp add: whenE_def throwError_def dc_def[symmetric], ccorres_rewrite)
+         apply (simp add: whenE_def throwError_def, ccorres_rewrite)
          apply (rule ccorres_rhs_assoc)
          apply (rule ccorres_h_t_valid_x64KSSKIMPML4)
          apply csymbr
@@ -1245,7 +1245,7 @@ lemma setVMRoot_ccorres:
         apply (csymbr, rename_tac base_addr)
         apply (rule ccorres_symb_exec_r)
           apply (ctac add: getCurrentUserCR3_ccorres, rename_tac currentCR3 currentCR3')
-            apply (rule ccorres_if_bind, rule ccorres_if_lhs; simp add: dc_def[symmetric])
+            apply (rule ccorres_if_bind, rule ccorres_if_lhs; simp)
              apply (rule ccorres_cond_true)
              apply (ctac add: setCurrentUserCR3_ccorres)
             apply (rule ccorres_cond_false)
@@ -1254,7 +1254,7 @@ lemma setVMRoot_ccorres:
           apply vcg
          apply vcg
         apply (rule conseqPre, vcg, clarsimp)
-       apply (rule ccorres_cond_true_seq, simp add: dc_def[symmetric], ccorres_rewrite)
+       apply (rule ccorres_cond_true_seq, simp, ccorres_rewrite)
        apply (rule ccorres_rhs_assoc)
        apply (rule ccorres_h_t_valid_x64KSSKIMPML4)
        apply csymbr
@@ -1329,12 +1329,12 @@ lemma setRegister_ccorres:
        (asUser thread (setRegister reg val))
        (Call setRegister_'proc)"
   apply (cinit' lift: thread_' reg_' w_')
-   apply (simp add: asUser_def dc_def[symmetric] split_def split del: if_split)
+   apply (simp add: asUser_def split_def)
    apply (rule ccorres_pre_threadGet)
    apply (rule ccorres_Guard)
    apply (simp add: setRegister_def simpler_modify_def exec_select_f_singleton)
    apply (rule_tac P="\<lambda>tcb. (atcbContextGet o tcbArch) tcb = rv"
-                in threadSet_ccorres_lemma2 [unfolded dc_def])
+                in threadSet_ccorres_lemma2)
     apply vcg
    apply (clarsimp simp: setRegister_def HaskellLib_H.runState_def
                          simpler_modify_def typ_heap_simps)
@@ -1365,8 +1365,6 @@ lemma msgRegisters_ccorres:
 (* usually when we call setMR directly, we mean to only set a registers, which will
    fit in actual registers *)
 lemma setMR_as_setRegister_ccorres:
-  notes dc_simp[simp del]
-  shows
   "ccorres (\<lambda>rv rv'. rv' = of_nat offset + 1) ret__unsigned_'
       (tcb_at' thread and K (TCB_H.msgRegisters ! offset = reg \<and> offset < length msgRegisters))
       (UNIV \<inter> \<lbrace>\<acute>reg___unsigned_long = val\<rbrace>
@@ -1383,7 +1381,7 @@ lemma setMR_as_setRegister_ccorres:
    apply (ctac add: setRegister_ccorres)
      apply (rule ccorres_from_vcg_throws[where P'=UNIV and P=\<top>])
      apply (rule allI, rule conseqPre, vcg)
-     apply (clarsimp simp: dc_def return_def)
+     apply (clarsimp simp: return_def)
     apply (rule hoare_post_taut[of \<top>])
    apply (vcg exspec=setRegister_modifies)
   apply (clarsimp simp: n_msgRegisters_def length_of_msgRegisters not_le conj_commute)
@@ -1696,14 +1694,15 @@ lemma modeUnmapPage_ccorres:
              rule ccorres_rhs_assoc2, rule ccorres_rhs_assoc2)
       apply (simp only: bindE_assoc[symmetric])
       apply (rule ccorres_splitE_novcg)
-          apply (clarsimp simp: inl_rrel_def)
-          apply (rule checkMappingPPtr_pdpte_ccorres[simplified inl_rrel_def])
-          apply (rule conseqPre, vcg)
-          apply (clarsimp simp: typ_heap_simps')
-          apply (intro conjI impI)
-              apply (auto simp: pdpte_pdpte_1g_lift_def pdpte_lift_def cpdpte_relation_def
-                                isHugePagePDPTE_def pdpteFrame_def
-                         split: if_split_asm pdpte.split_asm pdpte.split)[5]
+          apply (rule ccorres_rel_imp2)
+            apply (rule checkMappingPPtr_pdpte_ccorres)
+            apply (rule conseqPre, vcg)
+            apply (clarsimp simp: typ_heap_simps')
+            apply (auto simp: pdpte_pdpte_1g_lift_def pdpte_lift_def cpdpte_relation_def
+                              isHugePagePDPTE_def pdpteFrame_def
+                       split: if_split_asm pdpte.split_asm pdpte.split)[1]
+           apply fastforce
+          apply (fastforce simp: inl_rrel_def split: sum.splits)
          apply ceqv
         apply csymbr
         apply (rule ccorres_add_returnOk)
@@ -1750,11 +1749,11 @@ lemma unmapPage_ccorres:
       apply (rule ccorres_splitE_novcg[where r'=dc and xf'=xfdc])
           \<comment> \<open>X64SmallPage\<close>
           apply (rule ccorres_Cond_rhs)
-           apply (simp add: framesize_to_H_def dc_def[symmetric])
+           apply (simp add: framesize_to_H_def)
            apply (rule ccorres_rhs_assoc)+
            apply (ctac add: lookupPTSlot_ccorres)
               apply (rename_tac pt_slot pt_slot')
-              apply (simp add: dc_def[symmetric])
+              apply simp
               apply (rule ccorres_rhs_assoc2, rule ccorres_rhs_assoc2,
                      rule ccorres_rhs_assoc2)
               apply (simp only: bindE_assoc[symmetric])
@@ -1768,11 +1767,9 @@ lemma unmapPage_ccorres:
                                  split: if_split_asm pte.split_asm)
                  apply (rule ceqv_refl)
                 apply (simp add: unfold_checkMapping_return liftE_liftM
-                                 Collect_const[symmetric] dc_def[symmetric]
                             del: Collect_const)
                 apply (rule ccorres_handlers_weaken2)
                 apply csymbr
-                apply (simp add: dc_def[symmetric])
                 apply (rule storePTE_Basic_ccorres)
                 apply (simp add: cpte_relation_def Let_def)
                apply wp
@@ -1786,12 +1783,11 @@ lemma unmapPage_ccorres:
            apply (vcg exspec=lookupPTSlot_modifies)
           \<comment> \<open>X64LargePage\<close>
           apply (rule ccorres_Cond_rhs)
-           apply (simp add: framesize_to_H_def dc_def[symmetric]
-                       del: Collect_const)
+           apply (simp add: framesize_to_H_def del: Collect_const)
            apply (rule ccorres_rhs_assoc)+
            apply (ctac add: lookupPDSlot_ccorres)
               apply (rename_tac pd_slot pd_slot')
-              apply (simp add: dc_def[symmetric])
+              apply simp
               apply csymbr
               apply (rule ccorres_rhs_assoc2, rule ccorres_rhs_assoc2,
                      rule ccorres_rhs_assoc2, rule ccorres_rhs_assoc2)
@@ -1806,11 +1802,9 @@ lemma unmapPage_ccorres:
                                  split: if_split_asm pde.split_asm)
                  apply (rule ceqv_refl)
                 apply (simp add: unfold_checkMapping_return liftE_liftM
-                                 Collect_const[symmetric] dc_def[symmetric]
                             del: Collect_const)
                 apply (rule ccorres_handlers_weaken2)
                 apply csymbr
-                apply (simp add: dc_def[symmetric])
                 apply (rule storePDE_Basic_ccorres)
                 apply (simp add: cpde_relation_def Let_def)
                apply wp
@@ -1823,7 +1817,7 @@ lemma unmapPage_ccorres:
            apply simp
            apply (vcg exspec=lookupPDSlot_modifies)
           \<comment> \<open>X64HugePage\<close>
-          apply (simp add: framesize_to_H_def dc_def[symmetric])
+          apply (simp add: framesize_to_H_def)
           apply (rule ccorres_add_return2)
           apply (ctac add: modeUnmapPage_ccorres)
             apply (rule ccorres_from_vcg_might_throw[where P="\<top>" and P'=UNIV])
@@ -1838,13 +1832,13 @@ lemma unmapPage_ccorres:
         apply clarsimp
         apply ccorres_rewrite
         apply (clarsimp simp: liftE_liftM)
-        apply (ctac add: invalidateTranslationSingleASID_ccorres[simplified dc_def])
+        apply (ctac add: invalidateTranslationSingleASID_ccorres)
        apply clarsimp
       apply clarsimp
       apply (clarsimp simp: guard_is_UNIV_def conj_comms tcb_cnode_index_defs)
      apply (simp add: throwError_def)
      apply (rule ccorres_split_throws)
-      apply (rule ccorres_return_void_C[unfolded dc_def])
+      apply (rule ccorres_return_void_C)
      apply vcg
     apply wpsimp
    apply (simp add: Collect_const_mem)
@@ -2064,7 +2058,7 @@ lemma performPageInvocationUnmap_ccorres:
      apply (rule ccorres_rhs_assoc)
      apply (drule_tac s=cap in sym, simp) (* schematic ugliness *)
      apply ccorres_rewrite
-     apply (ctac add: performPageInvocationUnmap_ccorres'[simplified K_def, simplified])
+     apply (ctac add: performPageInvocationUnmap_ccorres')
        apply (rule_tac P=\<top> and P'=UNIV in ccorres_from_vcg_throws)
        apply (rule allI, rule conseqPre, vcg)
        apply (clarsimp simp: return_def)
@@ -2420,7 +2414,7 @@ lemma performASIDPoolInvocation_ccorres:
            apply (rule conseqPre, vcg)
            apply clarsimp
           apply (wpsimp wp: liftM_wp)
-         apply (wpsimp wp: getASID_wp simp: o_def inv_def)
+         apply (wpsimp wp: getASID_wp simp: inv_def)
         apply (clarsimp simp: empty_fail_getObject)
        apply (wpsimp wp: udpateCap_asidpool' hoare_vcg_all_lift hoare_vcg_imp_lift')
       apply vcg

--- a/proof/crefine/lib/AutoCorres_C.thy
+++ b/proof/crefine/lib/AutoCorres_C.thy
@@ -296,8 +296,8 @@ lemma ccorres_to_corres_with_termination:
     "\<And>s s'. \<lbrakk> cstate_relation s (globals s'); P s; \<not> snd (dspec_f s); G s' \<rbrakk> \<Longrightarrow>
              \<Gamma> \<turnstile> Call f_'proc \<down> Normal s'"
   shows "corres_underlying {(s, s'). cstate_relation s s'} True True R P Q dspec_f ac_f"
-  using ccorres ret pre unfolding ac_def ccorres_to_corres_pre_def
-  apply (clarsimp simp: corres_underlying_def ccorres_underlying_def rf_sr_def)
+  using ccorres ret pre unfolding ac_def ccorres_to_corres_pre_def rf_sr_def
+  apply (clarsimp simp: corres_underlying_def ccorres_underlying_def)
   apply (rule conjI)
    apply (fastforce simp: unif_rrel_def intro: EHOther dest: in_AC_call_simpl)
   apply (clarsimp simp: AC_call_L1_def L2_call_L1_def L1_call_simpl_def)
@@ -334,8 +334,8 @@ lemma ccorres_to_corres_no_termination:
   assumes pre: "\<And>s'. G s' \<Longrightarrow> ccorres_to_corres_pre Q \<top> Q' s'"
   assumes ret: "\<And>r s'. R r (ret_xf s') \<longleftrightarrow> R' r (ret_xf' s')"
   shows "corres_underlying {(s, s'). cstate_relation s s'} True True R P Q dspec_f ac_f"
-  using ccorres ret pre unfolding ac_def ccorres_to_corres_pre_def
-  apply (clarsimp simp: ac_def corres_underlying_def ccorres_underlying_def rf_sr_def)
+  using ccorres ret pre unfolding ac_def ccorres_to_corres_pre_def rf_sr_def
+  apply (clarsimp simp: ac_def corres_underlying_def ccorres_underlying_def)
   apply (rule conjI)
    apply (fastforce simp: unif_rrel_def intro: EHOther dest: in_AC_call_simpl)
   apply (clarsimp simp: AC_call_L1_def L2_call_L1_def L1_call_simpl_def)

--- a/proof/crefine/lib/Ctac.thy
+++ b/proof/crefine/lib/Ctac.thy
@@ -1755,7 +1755,7 @@ next
     apply (simp add: simpl_sequence_Cons sequenceE_Cons)
     apply (rule ccorres_guard_imp2)
      apply (rule ccorres_splitE)
-         apply (simp add: inl_rrel_inl_rrel)
+         apply simp
          apply (rule Cons.prems(1)[where zs=Nil, simplified])
         apply (rule ceqv_refl)
        apply (simp add: liftME_def[symmetric] liftME_liftM)
@@ -1809,7 +1809,7 @@ lemma mapME_x_simpl_sequence_fun_related:
         clarsimp elim!: inl_inrE)
   apply (erule_tac x="length zs" in meta_allE
        | erule_tac x="xs ! length zs" in meta_allE)+
-  apply (simp add: dc_def)
+  apply (simp add: dc_def cong: ccorres_all_cong)
   done
 
 lemmas mapME_x_simpl_sequence_same


### PR DESCRIPTION
This demonstrates the required changes after adding new cong rules for `ccorres_underlying`, in particular one that does not rewrite the return relations and extraction functions.

In general, I would say that this helps with all of the easy cases due to having more stable return relations that are easier to unify with. However, there are some cases that are now more complicated due to needing to choose a different cong rule.