### PR TITLE
github: use explicit token to enable push triggers

### DIFF
--- a/.github/workflows/proof-deploy.yml
+++ b/.github/workflows/proof-deploy.yml
@@ -91,6 +91,9 @@ jobs:
         ref: ${{ matrix.branch }}
         path: l4v-${{ matrix.branch }}
         fetch-depth: 0
+        # needed to trigger push actions on the -rebased branch
+        # (implict GITHUB_TOKEN does not trigger further push actions).
+        token: ${{ secrets.CI_SSH }}
     - name: Rebase
       run: |
         cd l4v-${{ matrix.branch }}


### PR DESCRIPTION
The implicit GITHUB_TOKEN does not trigger further push actions in the same repo, but in this case we do want the push action to happen on the `-rebased` branches, so we use an explicit auth token instead.