### PR TITLE
github: use correct secret

### DIFF
--- a/.github/workflows/proof-deploy.yml
+++ b/.github/workflows/proof-deploy.yml
@@ -93,7 +93,7 @@ jobs:
         fetch-depth: 0
         # needed to trigger push actions on the -rebased branch
         # (implict GITHUB_TOKEN does not trigger further push actions).
-        token: ${{ secrets.CI_SSH }}
+        token: ${{ secrets.PRIV_REPO_TOKEN }}
     - name: Rebase
       run: |
         cd l4v-${{ matrix.branch }}


### PR DESCRIPTION
Apologies, #647 needs a small update -- the name of the provided secret token was wrong.