### PR TITLE
a simpler corres method

### DIFF
--- a/lib/Corres_Method.thy
+++ b/lib/Corres_Method.thy
@@ -1,0 +1,215 @@
+(*
+ * Copyright 2023, Proofcraft Pty Ltd
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ *)
+
+theory Corres_Method
+imports Corres_Cases ExtraCorres
+begin
+
+(* A proof method for automating simple steps in corres proofs.
+
+   While the method might solve some corres proofs completely, the purpose is to make simple
+   things more automatic, remove boilerplate, and to leave a proof state in which the user can make
+   more progress. The goal is not to provide full automation or deeper search.
+
+   The main idea is to repeatedly try to apply terminal [corres] rules after splitting off the head
+   of a bind/bindE statement on both sides of a corres goal. The method provides options for less
+   safe rules such as moving asserts to guards etc when the user knows that this is safe to do in
+   a particular instance.
+
+   See description at corres' method below for all parameters and options.
+*)
+
+section \<open>Goal predicates\<close>
+
+(* Succeed if the conclusion is a corres goal and also not purely schematic *)
+method is_corres = succeeds \<open>rule corres_inst\<close>, fails \<open>rule TrueI\<close>
+
+lemma no_fail_triv: "no_fail P f \<Longrightarrow> no_fail P f" .
+lemmas hoare_trivs = hoare_triv hoare_trivE hoare_trivE_R hoare_trivR_R no_fail_triv
+
+(* Succeed if the conclusion is a wp/no_fail goal and also not purely schematic*)
+method is_wp = succeeds \<open>rule hoare_trivs\<close>, fails \<open>rule TrueI\<close>
+
+lemmas hoare_post_False = hoare_pre_cont[where P="\<lambda>_. \<bottom>"]
+lemmas hoareE_post_False = hoare_FalseE[where Q="\<lambda>_. \<bottom>" and E="\<lambda>_. \<bottom>"]
+
+(* Succeed if the conclusion has a schematic post condition (assuming a wp goal). *)
+method is_hoare_schematic_post =
+  (* If the post condition matches both \<top> and \<bottom>, it must be schematic *)
+  succeeds \<open>wp_pre, rule hoare_post_False hoareE_post_False\<close>,
+  succeeds \<open>wp_pre, rule wp_post_taut wp_post_tautE\<close>
+
+section \<open>Main corres method\<close>
+
+named_theorems corres_splits
+method corres_split declares corres_splits = no_name_eta, rule corres_splits
+
+(* This method is called on non-corres, non-wp side conditions after a corres rule has been
+   applied. At that point, there should be no schematic variables in those side condition goals.
+   Despite that, we are still careful with simp etc here, in case the user does provide a corres
+   rule that generates a schematic in those side condition goals. *)
+method corres_cleanup methods m uses simp simp_del split split_del cong intro =
+    m
+  | assumption
+  | rule refl TrueI
+  | clarsimp simp del: corres_no_simp simp_del simp: simp split: split split del: split_del
+             cong: cong intro!: intro
+  (* enables passing in conjI for terminal goals: *)
+  | (rule intro;
+     corres_cleanup m simp: simp simp_del: simp_del split: split split_del: split_del
+                      cong: cong intro: intro)
+
+(* Apply a single corres rule and attempt to solve non-corres and non-wp side conditions.
+   We don't expect any wp side conditions, but check anyway for safety. If the rule is declared
+   as terminal rule, all side conditions must be solved and no corres or wp side conditions are
+   allowed. If the rule is declared as a regular corres rule, unsolved side conditions as well as
+   corres and wp side conditions will be left over unchanged. *)
+method corres_rule
+  methods m uses simp simp_del split split_del cong intro declares corres corres_term =
+  determ \<open>solves \<open>((rule corres_term | corres_rrel_pre, rule corres_term);
+                   solves \<open>corres_cleanup m simp: simp simp_del: simp_del split: split
+                                            split_del: split_del cong: cong\<close>)\<close>
+          | (rule corres | corres_rrel_pre, rule corres);
+            ((fails \<open>is_corres\<close>, fails \<open>is_wp\<close>,
+              solves \<open>corres_cleanup m simp: simp simp_del: simp_del split: split
+                                       split_del: split_del cong: cong\<close>)?)\<close>
+
+(* For normalisation of corres terms, e.g. liftE *)
+named_theorems corres_simp
+
+(* The main method:
+
+   After preliminaries such as wpfix and corres_pre, repeatedly try to either solve the goal
+   outright or split off the head from a bind/bindE statement and apply a corres rule (only
+   split when a corres rule applies). If none of these works, try a corres rule from the "fallback"
+   argument. (These are for things like moving asserts to a guard, which we only want to do if no
+   other corres rule applies).
+
+   Attempt to solve side conditions with the corres_cleanup method. The cleanup method uses the
+   simp and term_simp arguments.
+
+   Attempt simp on the head corres goal without rewriting guards or return relation when
+   none of these make progress (to process things such as liftM). Does not use the term_simp
+   argument.
+
+   Attempt clarsimp on the head side condition and final implications. Does not use the term_simp
+   argument.
+
+   Attempt wpsimp+ when the head goal is a wp goal (usually present when all corres goals have been
+   solved). Fail if we somehow ended up with a schematic post condition despite all safety measures.
+*)
+method corres'
+  methods m
+  uses simp term_simp simp_del split split_del cong intro wp wp_del fallback
+  declares corres corres_term corres_splits =
+  (((* debug breakpoint *)
+    #break "corres",
+    (* introduce schematic guards if they don't exist *)
+    corres_pre0
+    (* fix up schematic guards if they contain constructor parameters *)
+    | wpfix
+    (* apply a single corres rule if possible *)
+    | corres_rule m simp: term_simp simp simp_del: simp_del split_del: split_del split: split
+                    cong: cong corres: corres corres_term: corres_term
+    (* only split if we can apply a single corres rule afterwards *)
+    | corres_split corres_splits: corres_splits,
+      corres_rule m simp: simp term_simp simp_del: simp_del split_del: split_del split: split
+                    cong: cong corres: corres corres_term: corres_term
+    (* apply potentially unsafe fallback rules if any are provided *)
+    | corres_rule m simp: simp term_simp simp_del: simp_del split_del: split_del split: split
+                    cong: cong corres: fallback
+    (* simplify head corres goal, e.g. for things like liftM unfolding if the user provides such
+       a rule as "simp". Not clarsimp, because clarsimp will still perform hypsubst on assumptions
+       and might through that rewrite guards *)
+    | succeeds \<open>is_corres\<close>,
+      simp (no_asm_use) cong: corres_weaker_cong cong split: split split del: if_split split_del
+                        add: simp corres_simp del: corres_no_simp simp_del
+    (* simplify any remaining side condition head goal (non-corres, non-wp). This is either a side
+       condition that was not solved by corres_cleanup, or it is one of the two terminal implication
+       goals. It is very likely that the method will stop after this and not have solved the goal,
+       but it also very likely that the first thing we want to do for such a goal is clarsimp. That
+       means, overall we might solve a few more goals, and not be detrimental to interactive proof
+       either. *)
+    | fails \<open>is_corres\<close>, fails \<open>is_wp\<close>,
+      clarsimp cong: cong simp del: simp_del simp: simp split del: if_split split_del split: split
+               intro!: intro
+    (* if (and only if) we get to the state where all corres goals and side conditions are solved,
+       attempt to solve all wp goals that were generated in order. We are not using then_all_new_fwd
+       here, because we should only start solving wp goals once *all* corres goals are solved --
+       otherwise the goal will still have schematic post conditions. Fail if there is a
+       free schematic postcondition despite all these measures.
+       *)
+    | succeeds \<open>is_wp\<close>, fails \<open>is_hoare_schematic_post\<close>,
+      (wpsimp wp: wp wp_del: wp_del simp: simp simp_del: simp_del split: split split_del: split_del
+              cong: cong)+
+   )+)[1]
+
+(* Instance of the corres' method with default cleanup tactic. We provide "fail" as default to let
+   the other cleanup tactis run. "succeed" would stop without progress (useful for debugging). *)
+method corres
+  uses simp term_simp simp_del split split_del cong intro wp wp_del fallback
+  declares corres corres_term corres_splits =
+  corres' \<open>fail\<close> simp: simp term_simp: term_simp simp_del: simp_del split: split
+                 split_del: split_del cong: cong intro: intro wp: wp wp_del: wp_del
+                 fallback: fallback
+                 corres: corres corres_term: corres_term corres_splits: corres_splits
+
+
+section \<open>Corres rule setup\<close>
+
+lemmas [corres_splits] =
+  corres_split
+  corres_splitEE
+
+lemmas corres_split_liftE_bindE [corres_splits] =
+  corres_splitEE[OF corres_liftE_rel_sum[THEN iffD2], simplified]
+
+(* corres_term are rules that are safe when all side conditions can be solved immediately -- they
+   might have guards like \<top> that are too weak in general, but if the goal can be solved with
+   that weak guard, the rule is safe. This enables us to solve trivial cases without adding
+   unsafe rules to the [corres] set. *)
+lemmas [corres_term] =
+  corres_return_eq_same corres_gets_trivial select_corres_eq
+  corres_underlying_assert_assert
+
+lemmas corres_returnOk_eq_same[corres_term] = corres_returnOkTT[of "(=)"]
+lemmas corres_throwError_eq_same[corres_term] = corres_throwErrorTT[of "(=)"]
+
+lemma corres_get_trivial[corres_term]:
+  "corres_underlying sr nf nf' (\<lambda>s s'. (s,s') \<in> sr) \<top> \<top> get get"
+  by simp
+
+lemmas corres_underlying_stateAssert_stateAssert_trivial[corres_term] =
+  corres_underlying_stateAssert_stateAssert[where P=\<top> and P'=\<top>, simplified]
+
+lemma corres_modify_tivial[corres_term]:
+  "(\<And>s s'. (s, s') \<in> sr \<Longrightarrow> (f s, g s') \<in> sr) \<Longrightarrow>
+   corres_underlying sr nf nf' dc \<top> \<top> (modify f) (modify g)"
+  by (simp add: corres_modify)
+
+(* Regular corres rules are rules where we expect side conditions to be solvable once the rule
+   matches, but those side conditions might be too hard for automation, so they must be safe to
+   leave over for later manual proof. *)
+lemmas [corres] =
+  corres_underlying_fail_fail
+  corres_fail
+  corres_assert
+  whenE_throwError_corres (* match this before corres_whenE *)
+  corres_whenE
+  corres_when
+
+  (* not in corres_split, because head is usually not solvable by single rule: *)
+  corres_split_handle
+  corres_split_catch
+  corres_if2
+
+(* Transform corres terms when no other rules match: *)
+lemmas [corres_simp] =
+  liftE_bindE
+  unless_when
+  unlessE_whenE
+
+end

--- a/lib/Corres_UL.thy
+++ b/lib/Corres_UL.thy
@@ -72,14 +72,6 @@ lemma corres_underlying_serial:
   apply auto
   done
 
-(* FIXME: duplicated with HOL.iff_allI *)
-lemma All_eqI:
-  assumes ass: "\<And>x. A x = B x"
-  shows "(\<forall>x. A x) = (\<forall>x. B x)"
-  apply (subst ass)
-  apply (rule refl)
-  done
-
 lemma corres_singleton:
  "corres_underlying sr nf nf' r P P' (\<lambda>s. ({(R s, S s)},x)) (\<lambda>s. ({(R' s, S' s)},False))
   = (\<forall>s s'. P s \<and> P' s' \<and> (s, s') \<in> sr \<and> (nf \<longrightarrow> \<not> x)
@@ -104,12 +96,8 @@ lemma corres_return[simp, corres_no_simp]:
   by (simp add: return_def corres_singleton)
 
 lemma corres_get[simp, corres_no_simp]:
- "corres_underlying sr nf nf' r P P' get get =
-  (\<forall> s s'. (s, s') \<in> sr \<and> P s \<and> P' s' \<longrightarrow> r s s')"
-  apply (simp add: get_def corres_singleton)
-  apply (rule All_eqI)+
-  apply safe
-  done
+ "corres_underlying sr nf nf' r P P' get get = (\<forall> s s'. (s, s') \<in> sr \<and> P s \<and> P' s' \<longrightarrow> r s s')"
+  by (fastforce simp: get_def corres_singleton)
 
 lemma corres_gets[simp, corres_no_simp]:
  "corres_underlying sr nf nf' r P P' (gets a) (gets b) =
@@ -484,30 +472,19 @@ lemma corres_if3:
 
 text \<open>Some equivalences about liftM and other useful simps\<close>
 
-lemma snd_liftM [simp]:
-  "snd (liftM t f s) = snd (f s)"
-  by (auto simp: liftM_def bind_def return_def)
-
 lemma corres_liftM_simp[simp]:
-  "(corres_underlying sr nf nf' r P P' (liftM t f) g)
-    = (corres_underlying sr nf nf' (r \<circ> t) P P' f g)"
-  apply (simp add: corres_underlying_def
-           handy_liftM_lemma Ball_def Bex_def)
-  apply (rule All_eqI)+
-  apply blast
-  done
+  "corres_underlying sr nf nf' r P P' (liftM t f) g =
+   corres_underlying sr nf nf' (r \<circ> t) P P' f g"
+  by (fastforce simp add: corres_underlying_def in_liftM)
 
 lemma corres_liftM2_simp[simp]:
- "corres_underlying sr nf nf' r P P' f (liftM t g) =
-  corres_underlying sr nf nf' (\<lambda>x. r x \<circ> t) P P' f g"
-  apply (simp add: corres_underlying_def
-           handy_liftM_lemma Ball_def)
-  apply (rule All_eqI)+
-  apply blast
-  done
+  "corres_underlying sr nf nf' r P P' f (liftM t g) =
+   corres_underlying sr nf nf' (\<lambda>x. r x \<circ> t) P P' f g"
+  by (fastforce simp add: corres_underlying_def in_liftM)
 
 lemma corres_liftE_rel_sum[simp]:
- "corres_underlying sr nf nf' (f \<oplus> r) P P' (liftE m) (liftE m') = corres_underlying sr nf nf' r P P' m m'"
+ "corres_underlying sr nf nf' (f \<oplus> r) P P' (liftE m) (liftE m') =
+  corres_underlying sr nf nf' r P P' m m'"
   by (simp add: liftE_liftM o_def)
 
 text \<open>Support for proving correspondence to noop with hoare triples\<close>

--- a/lib/ExtraCorres.thy
+++ b/lib/ExtraCorres.thy
@@ -8,6 +8,15 @@ theory ExtraCorres
 imports Corres_UL
 begin
 
+(* FIXME: the S in this rule is mainly to make the induction work, we don't actually need it in
+   application. This means, this form should be hidden and the main form should be resolving the
+   last assumption with order_refl. *)
+
+(* The lemma looks weaker than in it could be -- the guards P and P' are not allowed to depend on
+   list elements. This is fine, because P/P' are a loop invariants that need to be supplied
+   manually anyway, and we want these to be true for all loop iterations. An instance such as
+   "\<lambda>s. \<forall>x \<in> set xs. P x s" is possible and covers the cases the (not really) stronger formulation
+   would cover. *)
 lemma corres_mapM:
   assumes x: "r [] []"
   assumes y: "\<And>x xs y ys. \<lbrakk> r xs ys; r' x y \<rbrakk> \<Longrightarrow> r (x # xs) (y # ys)"
@@ -69,6 +78,7 @@ next
     done
 qed
 
+(* FIXME: see comment for mapM rule. Same applies for lemma strength *)
 lemma corres_mapM_x:
   assumes x: "\<And>x y. (x, y) \<in> S \<Longrightarrow> corres_underlying sr nf nf' dc P P' (f x) (f' y)"
   assumes y: "\<And>x y. (x, y) \<in> S \<Longrightarrow> \<lbrace>P\<rbrace> f x \<lbrace>\<lambda>rv. P\<rbrace>"
@@ -83,6 +93,7 @@ lemma corres_mapM_x:
            apply (simp | wp)+
   done
 
+(* FIXME: see comment for mapM rule. Same applies for lemma strength *)
 lemma corres_mapME:
   assumes x: "r [] []"
   assumes y: "\<And>x xs y ys. \<lbrakk> r xs ys; r' x y \<rbrakk> \<Longrightarrow> r (x # xs) (y # ys)"

--- a/lib/Monads/In_Monad.thy
+++ b/lib/Monads/In_Monad.thy
@@ -106,8 +106,6 @@ lemma in_liftM:
   "((r, s') \<in> fst (liftM t f s)) = (\<exists>r'. (r', s') \<in> fst (f s) \<and> r = t r')"
   by (simp add: liftM_def return_def bind_def Bex_def)
 
-lemmas handy_liftM_lemma = in_liftM (* FIXME lib: eliminate *)
-
 lemma in_bindE:
   "(rv, s') \<in> fst ((f >>=E (\<lambda>rv'. g rv')) s) =
    ((\<exists>ex. rv = Inl ex \<and> (Inl ex, s') \<in> fst (f s)) \<or>

--- a/lib/Monads/MonadEq_Lemmas.thy
+++ b/lib/Monads/MonadEq_Lemmas.thy
@@ -151,6 +151,10 @@ lemma snd_handleE[monad_eq]:
   unfolding handleE_def
   by (rule snd_handleE')
 
+lemma snd_liftM[monad_eq, simp]:
+  "snd (liftM t f s) = snd (f s)"
+  by (auto simp: liftM_def bind_def return_def)
+
 declare in_liftE[monad_eq]
 
 lemma snd_liftE[monad_eq]:

--- a/lib/Monads/TraceMonadVCG.thy
+++ b/lib/Monads/TraceMonadVCG.thy
@@ -2006,9 +2006,6 @@ lemma in_liftM:
  "((r, s') \<in> mres (liftM t f s)) = (\<exists>r'. (r', s') \<in> mres (f s) \<and> r = t r')"
   by (simp add: liftM_def in_return in_bind)
 
-(* FIXME: eliminate *)
-lemmas handy_liftM_lemma = in_liftM
-
 lemma hoare_fun_app_wp[wp]:
   "\<lbrace>P\<rbrace> f' x \<lbrace>Q'\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace> f' $ x \<lbrace>Q'\<rbrace>"
   "\<lbrace>P\<rbrace> f x \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace> f $ x \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"

--- a/lib/ROOT
+++ b/lib/ROOT
@@ -34,6 +34,7 @@ session Lib (lib) = Word_Lib +
     Crunch_Instances_Trace
     StateMonad
     Corres_UL
+    Corres_Method
     Find_Names
     LemmaBucket
     Try_Methods

--- a/proof/refine/AARCH64/LevityCatch.thy
+++ b/proof/refine/AARCH64/LevityCatch.thy
@@ -10,6 +10,7 @@ imports
   "Lib.AddUpdSimps"
   "Lib.LemmaBucket"
   "Lib.SimpStrategy"
+  "Lib.Corres_Method"
 begin
 
 no_notation bind_drop (infixl ">>" 60)

--- a/proof/refine/ARM/LevityCatch.thy
+++ b/proof/refine/ARM/LevityCatch.thy
@@ -8,6 +8,7 @@ theory LevityCatch
 imports
   "BaseRefine.Include"
   "Lib.LemmaBucket"
+  "Lib.Corres_Method"
 begin
 
 (* Try again, clagged from Include *)

--- a/proof/refine/ARM_HYP/LevityCatch.thy
+++ b/proof/refine/ARM_HYP/LevityCatch.thy
@@ -8,6 +8,7 @@ theory LevityCatch
 imports
   "BaseRefine.Include"
   "Lib.LemmaBucket"
+  "Lib.Corres_Method"
 begin
 
 (* Try again, clagged from Include *)

--- a/proof/refine/RISCV64/Bits_R.thy
+++ b/proof/refine/RISCV64/Bits_R.thy
@@ -208,6 +208,8 @@ where
   lfr_def[simp]:
  "lfr x y \<equiv> (y = lookup_failure_map x)"
 
+lemmas corres_throwError_lfr[corres_term] = corres_throwErrorTT[of lfr]
+
 text \<open>Correspondence and weakest precondition
         rules for the "on failure" transformers\<close>
 

--- a/proof/refine/RISCV64/LevityCatch.thy
+++ b/proof/refine/RISCV64/LevityCatch.thy
@@ -10,6 +10,7 @@ imports
   "Lib.AddUpdSimps"
   "Lib.LemmaBucket"
   "Lib.SimpStrategy"
+  "Lib.Corres_Method"
 begin
 
 no_notation bind_drop (infixl ">>" 60)

--- a/proof/refine/RISCV64/SubMonad_R.thy
+++ b/proof/refine/RISCV64/SubMonad_R.thy
@@ -27,6 +27,10 @@ lemma corres_machine_op:
    apply (simp_all add: state_relation_def swp_def)
   done
 
+lemmas corres_machine_op_Id = corres_machine_op[OF corres_Id]
+lemmas corres_machine_op_Id_eq[corres_term] = corres_machine_op_Id[where r="(=)"]
+lemmas corres_machine_op_Id_dc[corres_term] = corres_machine_op_Id[where r="dc::unit \<Rightarrow> unit \<Rightarrow> bool"]
+
 lemma doMachineOp_mapM:
   assumes "\<And>x. empty_fail (m x)"
   shows "doMachineOp (mapM m l) = mapM (doMachineOp \<circ> m) l"

--- a/proof/refine/RISCV64/VSpace_R.thy
+++ b/proof/refine/RISCV64/VSpace_R.thy
@@ -44,25 +44,17 @@ lemma asidBits_asid_bits[simp]:
   "asidBits = asid_bits"
   by (simp add: bit_simps' asid_bits_def asidBits_def)
 
-lemma no_fail_read_stval[intro!,simp]:
+lemma no_fail_read_stval[wp, intro!, simp]:
   "no_fail \<top> read_stval"
   by (simp add: read_stval_def)
 
 lemma handleVMFault_corres:
   "corres (fr \<oplus> dc) (tcb_at thread) (tcb_at' thread)
           (handle_vm_fault thread fault) (handleVMFault thread fault)"
-  apply (simp add: RISCV64_H.handleVMFault_def handle_vm_fault_def)
-  apply (rule corres_guard_imp)
-    apply (rule corres_split_eqrE)
-       apply simp
-       apply (rule corres_machine_op[where r="(=)"])
-       apply (rule corres_Id, rule refl, simp)
-       apply (rule no_fail_read_stval)
-      apply (cases fault; simp)
-     apply wpsimp+
-  done
+  unfolding handleVMFault_def handle_vm_fault_def
+  by (corres | corres_cases_both)+
 
-lemma no_fail_setVSpaceRoot[intro!, simp]:
+lemma no_fail_setVSpaceRoot[wp, intro!, simp]:
   "no_fail \<top> (setVSpaceRoot v a)"
   by (simp add: setVSpaceRoot_def)
 
@@ -85,10 +77,7 @@ proof -
             (do globalPT <- gets (riscvKSGlobalPT \<circ> ksArchState);
                 doMachineOp (setVSpaceRoot (addrFromKPPtr globalPT) 0)
              od)" for P Q
-    apply (corresKsimp corres: corres_gets_global_pt corres_machine_op)
-     apply fastforce
-    apply (simp add: addrFromKPPtr_def)
-    done
+    by corres
 
   show ?thesis
   unfolding set_vm_root_def setVMRoot_def catchFailure_def withoutFailure_def throw_def
@@ -132,17 +121,7 @@ proof -
          apply (case_tac acap; clarsimp simp: isCap_simps catch_throwError intro!: global)
          apply (rename_tac m)
          apply (case_tac m; clarsimp simp: isCap_simps catch_throwError intro!: global)
-         apply (rule corres_guard_imp)
-           apply (rule corres_split_catch [where f=lfr and E'="\<lambda>_. \<top>"])
-              apply (rule corres_split_eqrE[OF findVSpaceForASID_corres[OF refl]])
-                apply (rule whenE_throwError_corres; simp add: lookup_failure_map_def)
-                apply (rule corres_machine_op)
-                apply corresKsimp
-                 apply fastforce
-                apply simp
-               apply wpsimp+
-             apply (rule global, assumption)
-            apply wpsimp+
+         apply (corres simp: lookup_failure_map_def)
           apply (frule (1) cte_wp_at_valid_objs_valid_cap)
           apply (clarsimp simp: valid_cap_def mask_def wellformed_mapdata_def)
          apply (wpsimp wp: get_cap_wp simp: getThreadVSpaceRoot_def)+
@@ -151,7 +130,7 @@ proof -
 qed
 
 
-lemma get_asid_pool_corres_inv':
+lemma get_asid_pool_corres_inv'[corres]:
   assumes "p' = p"
   shows "corres (\<lambda>p. (\<lambda>p'. p = p' o ucast) \<circ> inv ASIDPool)
                 (asid_pool_at p and pspace_aligned and pspace_distinct) \<top>
@@ -194,58 +173,27 @@ lemma hwASIDFlush_corres[corres]:
   "corres dc \<top> \<top> (do_machine_op (hwASIDFlush x)) (doMachineOp (hwASIDFlush x))"
   by (corresKsimp corres: corres_machine_op)
 
-lemma deleteASID_corres [corres]:
+lemma deleteASID_corres[corres]:
   assumes "asid' = ucast asid" "pm' = pm"
   shows "corres dc invs no_0_obj'
                 (delete_asid asid pm) (deleteASID asid' pm')"
   unfolding delete_asid_def deleteASID_def using assms
   apply simp
-  apply (rule corres_guard_imp)
-    apply (rule corres_split[OF corres_gets_asid])
-      apply (case_tac "asid_table (asid_high_bits_of asid)", simp)
-      apply clarsimp
-      apply (rule_tac P="\<lambda>s. asid_high_bits_of asid \<in> dom (asidTable o ucast) \<longrightarrow>
-                             asid_pool_at (the ((asidTable o ucast) (asid_high_bits_of asid))) s \<and>
-                             pspace_aligned s \<and> pspace_distinct s" and
-                      P'="\<top>" and
-                      Q="invs and
-                         (\<lambda>s. asid_table s = asidTable \<circ> ucast)" in
-                      corres_split)
-         apply (simp add: dom_def)
-         apply (rule get_asid_pool_corres_inv'[OF refl, unfolded pred_conj_def, simplified])
-        apply (rule corres_when)
-         apply (simp add: mask_asid_low_bits_ucast_ucast asid_low_bits_of_def ucast_ucast_a is_down)
-        apply (rule corres_split[OF hwASIDFlush_corres])
-          apply (rule_tac P="asid_pool_at (the (asidTable (ucast (asid_high_bits_of asid))))
-                             and pspace_aligned and pspace_distinct"
-                      and P'="\<top>"
-                       in corres_split)
-             apply (simp del: fun_upd_apply)
-             apply (rule setObject_ASIDPool_corres)
-             apply (simp add: inv_def mask_asid_low_bits_ucast_ucast)
+  apply (corres simp: liftM_def mask_asid_low_bits_ucast_ucast asid_low_bits_of_def
+                      ucast_ucast_a is_down
+         | corres_cases_both)+
+             (* side condition of setObject_ASIDPool_corres needs manual work *)
              apply (rule ext)
-             apply (clarsimp simp: o_def ucast_ucast_a is_down asid_low_bits_of_def)
+             apply (clarsimp simp: ucast_ucast_a is_down asid_low_bits_of_def
+                                   mask_asid_low_bits_ucast_ucast inv_def)
              apply (word_bitwise, clarsimp)
-            apply (rule corres_split[OF getCurThread_corres])
-              apply simp
-              apply (rule setVMRoot_corres[OF refl])
-             apply wp+
-           apply (thin_tac "x = f o g" for x f g)
-           apply (simp del: fun_upd_apply)
-           apply (fold cur_tcb_def)
+            (* continue rest of corres proof: *)
+            apply (corres corres: getCurThread_corres)
            apply (wp set_asid_pool_vs_lookup_unmap'
-                     set_asid_pool_vspace_objs_unmap_single
-                  | strengthen valid_arch_state_asid_table valid_arch_state_global_arch_objs)+
-       apply (auto simp: obj_at_def a_type_def graph_of_def
-                  split: if_split_asm dest: invs_valid_asid_table)[1]
-      apply (wp getASID_wp)
-      apply clarsimp
-      apply assumption
-     apply wp+
-   apply clarsimp
-   apply (frule invs_valid_asid_table)
-   apply (drule (1) valid_asid_tableD)
-   apply (clarsimp simp: invs_distinct)
+                     set_asid_pool_vspace_objs_unmap_single getASID_wp
+                  | strengthen valid_arch_state_asid_table valid_arch_state_global_arch_objs
+                  | simp flip: cur_tcb_def)+
+   apply (fastforce dest: valid_asid_tableD invs_valid_asid_table)
   apply simp
   done
 
@@ -709,26 +657,15 @@ lemma performASIDPoolInvocation_corres:
   using assms
   apply (clarsimp simp: perform_asid_pool_invocation_def performASIDPoolInvocation_def)
   apply (cases ap, simp add: asid_pool_invocation_map_def)
-  apply (rule corres_guard_imp)
-    apply (rule corres_split[OF getSlotCap_corres[OF refl] _ get_cap_wp getSlotCap_wp])
-    apply (rule corres_assert_gen_asm_l, rule corres_assert_gen_asm_l)
-    apply (rule_tac F="is_pt_cap pt_cap" in corres_gen_asm)
-    apply (rule corres_split[OF updateCap_same_master])
-       apply (clarsimp simp: is_cap_simps update_map_data_def)
-      apply (rule corres_split[OF copy_global_mappings_corres])
-         apply (clarsimp simp: is_cap_simps)
-        apply (unfold store_asid_pool_entry_def)[1]
-        apply (rule corres_split[where r'="\<lambda>pool pool'. pool = pool' \<circ> ucast"])
-           apply (simp cong: corres_weak_cong)
-           apply (rule corres_rel_imp)
-            apply (rule getObject_ASIDPool_corres[OF refl])
-           apply simp
-          apply (simp cong: corres_weak_cong)
-          apply (rule setObject_ASIDPool_corres)
-          apply (rule ext)
-          apply (clarsimp simp: inv_def is_cap_simps ucast_up_inj)
-         apply (wp getASID_wp)+
-       apply (wpsimp wp: set_cap_typ_at hoare_drop_imps|strengthen valid_arch_state_global_arch_objs)+
+  (* The fastforce is needed for the side conditions of setObject_ASIDPool_corres used at the end.
+     Guarded by "match" to not slow down the rest too much. *)
+  apply (corres' \<open>match conclusion in "f' = inv f x \<circ> g" for f' f x g \<Rightarrow>
+                   \<open>fastforce simp: inv_def is_cap_simps ucast_up_inj\<close>\<close>
+                 corres: getSlotCap_corres corres_assert_gen_asm_l updateCap_same_master
+                 simp: update_map_data_def cap.is_ArchObjectCap_def arch_cap.is_PageTableCap_def
+                       liftM_def store_asid_pool_entry_def)
+    apply (wpsimp wp: set_cap_typ_at hoare_drop_imps get_cap_wp
+           | strengthen valid_arch_state_global_arch_objs)+
    apply (clarsimp simp: valid_apinv_def cte_wp_at_caps_of_state is_cap_simps cap_master_cap_simps
                          update_map_data_def in_omonad)
    apply (drule (1) caps_of_state_valid_cap)

--- a/proof/refine/X64/LevityCatch.thy
+++ b/proof/refine/X64/LevityCatch.thy
@@ -8,6 +8,7 @@ theory LevityCatch
 imports
   "BaseRefine.Include"
   "Lib.LemmaBucket"
+  "Lib.Corres_Method"
 begin
 
 (* Try again, clagged from Include *)


### PR DESCRIPTION
This new `corres` method is similar to the `corresK` method and calculus, but much less ambitious. Its main purpose is to automate boilerplate proof steps in corres proofs and is specifically not trying to fully automate such proofs (although some few might be solved).

The idea is that the method will make some progress with obvious steps and leave over a proof state the user can operate on further.

I've tried to put in a lot of comments to document the design and some of the rationale, but there are no examples yet. 

Implements #634  (see there for parts of the design discussion)

This is on top of #653, which renames the old `Corres_Method` to `CorresK_Method`