### PR TITLE
crefine: add no_name_eta to tactics

### DIFF
--- a/lib/clib/CCorres_Rewrite.thy
+++ b/lib/clib/CCorres_Rewrite.thy
@@ -17,7 +17,7 @@ lemma ccorres_com_eq_hom:
            elim: ccorres_semantic_equivD2)
 
 method ccorres_rewrite declares C_simp C_simp_pre C_simp_simps C_simp_throws
-  = simpl_rewrite hom: ccorres_com_eq_hom
+  = (simpl_rewrite hom: ccorres_com_eq_hom, no_name_eta)
 
 lemma hoarep_com_eq_hom:
   "com_eq_hom \<Gamma> (\<lambda>c. hoarep \<Gamma> {} F P c Q A)"

--- a/proof/crefine/ARM/Arch_C.thy
+++ b/proof/crefine/ARM/Arch_C.thy
@@ -397,7 +397,9 @@ shows
       apply (rule ccorres_rhs_assoc2)
       apply (rule ccorres_abstract_cleanup)
       apply (rule ccorres_symb_exec_l)
-        apply (rule_tac P = "rva = (capability.UntypedCap isdev frame pageBits idx)" in ccorres_gen_asm)
+        apply (rename_tac pcap)
+        apply (rule_tac P = "pcap = (capability.UntypedCap isdev frame pageBits idx)"
+                 in ccorres_gen_asm)
         apply (simp add: hrs_htd_update del:fun_upd_apply)
         apply (rule ccorres_split_nothrow)
 
@@ -1466,13 +1468,13 @@ lemma pdeCheckIfMapped_ccorres:
     (Call pdeCheckIfMapped_'proc)"
   apply (cinit lift: pde___ptr_to_struct_pde_C_')
    apply (rule ccorres_pre_getObject_pde)
-   apply (rule_tac P'="{s. \<exists>pde'. cslift s (pde_Ptr slot) = Some pde' \<and> cpde_relation rv pde'}"
+   apply (rule_tac P'="{s. \<exists>pde'. cslift s (pde_Ptr slot) = Some pde' \<and> cpde_relation pd pde'}"
      in ccorres_from_vcg_throws[where P="\<lambda>s. True"])
    apply simp_all
   apply clarsimp
   apply (rule conseqPre, vcg)
   apply (clarsimp simp: typ_heap_simps' return_def)
-  apply (case_tac rv, simp_all add: cpde_relation_invalid isInvalidPDE_def
+  apply (case_tac pd, simp_all add: cpde_relation_invalid isInvalidPDE_def
                              split: if_split)
   done
 
@@ -1793,7 +1795,7 @@ lemma performPageInvocationMapPDE_ccorres:
              apply (clarsimp simp: pde_range_relation_def ptr_range_to_list_def)
             apply vcg
             apply simp
-           apply (wp valid_pde_slots_lift2)
+           apply (wpsimp wp: valid_pde_slots_lift2)
           apply clarsimp
           apply (clarsimp simp: pde_range_relation_def ptr_range_to_list_def)
           apply (rule order_less_le_trans)

--- a/proof/crefine/ARM/CSpace_C.thy
+++ b/proof/crefine/ARM/CSpace_C.thy
@@ -770,7 +770,7 @@ lemma update_freeIndex':
       supply if_cong[cong]
       apply (cinit lift: cap_ptr_' v32_')
        apply (rule ccorres_pre_getCTE)
-       apply (rule_tac P="\<lambda>s. ctes_of s srcSlot = Some rv \<and> (\<exists>i. cteCap rv = UntypedCap d p sz i)"
+       apply (rule_tac P="\<lambda>s. ctes_of s srcSlot = Some cte \<and> (\<exists>i. cteCap cte = UntypedCap d p sz i)"
                 in ccorres_from_vcg[where P' = UNIV])
        apply (rule allI)
        apply (rule conseqPre)
@@ -2055,8 +2055,7 @@ lemma emptySlot_ccorres:
             apply csymbr
             apply (rule ccorres_move_c_guard_cte)
                 \<comment> \<open>--- instruction y \<leftarrow> updateMDB slot (\<lambda>a. nullMDBNode);\<close>
-                apply (ctac (no_vcg)
-                  add: ccorres_updateMDB_const [unfolded const_def])
+                apply (ctac (no_vcg) add: ccorres_updateMDB_const)
 
                   \<comment> \<open>the post_cap_deletion case\<close>
 
@@ -2132,7 +2131,7 @@ lemma capSwapForDelete_ccorres:
   \<comment> \<open>--- instruction: when (slot1 \<noteq> slot2) \<dots> / IF Ptr slot1 = Ptr slot2 THEN \<dots>\<close>
    apply (simp add:when_def)
    apply (rule ccorres_if_cond_throws2 [where Q = \<top> and Q' = \<top>])
-      apply (case_tac "slot1=slot2", simp+)
+      apply (case_tac "slot1=slot2"; simp)
      apply (rule ccorres_return_void_C)
 
   \<comment> \<open>***Main goal***\<close>

--- a/proof/crefine/ARM/Finalise_C.thy
+++ b/proof/crefine/ARM/Finalise_C.thy
@@ -277,10 +277,10 @@ lemma cancelAllIPC_ccorres:
   apply (cinit lift: epptr_')
    apply (rule ccorres_symb_exec_l [OF _ getEndpoint_inv _ empty_fail_getEndpoint])
     apply (rule_tac xf'=ret__unsigned_'
-                and val="case rv of IdleEP \<Rightarrow> scast EPState_Idle
+                and val="case ep of IdleEP \<Rightarrow> scast EPState_Idle
                             | RecvEP _ \<Rightarrow> scast EPState_Recv | SendEP _ \<Rightarrow> scast EPState_Send"
-                and R="ko_at' rv epptr"
-                 in ccorres_symb_exec_r_known_rv_UNIV[where R'=UNIV])
+                and R="ko_at' ep epptr"
+             in ccorres_symb_exec_r_known_rv_UNIV[where R'=UNIV])
        apply vcg
        apply clarsimp
        apply (erule cmap_relationE1 [OF cmap_relation_ep])
@@ -289,8 +289,8 @@ lemma cancelAllIPC_ccorres:
        apply (simp add: cendpoint_relation_def Let_def
                  split: endpoint.split_asm)
       apply ceqv
-     apply (rule_tac A="invs' and ko_at' rv epptr"
-                  in ccorres_guard_imp2[where A'=UNIV])
+     apply (rule_tac A="invs' and ko_at' ep epptr"
+              in ccorres_guard_imp2[where A'=UNIV])
       apply wpc
         apply (rename_tac list)
         apply (simp add: endpoint_state_defs
@@ -404,10 +404,10 @@ lemma cancelAllSignals_ccorres:
   apply (cinit lift: ntfnPtr_')
    apply (rule ccorres_symb_exec_l [OF _ get_ntfn_inv' _ empty_fail_getNotification])
     apply (rule_tac xf'=ret__unsigned_'
-                and val="case ntfnObj rv of IdleNtfn \<Rightarrow> scast NtfnState_Idle
+                and val="case ntfnObj ntfn of IdleNtfn \<Rightarrow> scast NtfnState_Idle
                             | ActiveNtfn _ \<Rightarrow> scast NtfnState_Active | WaitingNtfn _ \<Rightarrow> scast NtfnState_Waiting"
-                and R="ko_at' rv ntfnptr"
-                 in ccorres_symb_exec_r_known_rv_UNIV[where R'=UNIV])
+                and R="ko_at' ntfn ntfnptr"
+             in ccorres_symb_exec_r_known_rv_UNIV[where R'=UNIV])
        apply vcg
        apply clarsimp
        apply (erule cmap_relationE1 [OF cmap_relation_ntfn])
@@ -416,8 +416,8 @@ lemma cancelAllSignals_ccorres:
        apply (simp add: cnotification_relation_def Let_def
                  split: ntfn.split_asm)
       apply ceqv
-     apply (rule_tac A="invs' and ko_at' rv ntfnptr"
-                  in ccorres_guard_imp2[where A'=UNIV])
+     apply (rule_tac A="invs' and ko_at' ntfn ntfnptr"
+              in ccorres_guard_imp2[where A'=UNIV])
       apply wpc
         apply (simp add: notification_state_defs ccorres_cond_iffs)
         apply (rule ccorres_return_Skip)
@@ -432,8 +432,8 @@ lemma cancelAllSignals_ccorres:
       apply csymbr
       apply (rule ccorres_rhs_assoc2, rule ccorres_rhs_assoc2)
       apply (rule_tac r'=dc and xf'=xfdc in ccorres_split_nothrow)
-          apply (rule_tac P="ko_at' rv ntfnptr and invs'"
-                    in ccorres_from_vcg[where P'=UNIV])
+          apply (rule_tac P="ko_at' ntfn ntfnptr and invs'"
+                   in ccorres_from_vcg[where P'=UNIV])
           apply (rule allI, rule conseqPre, vcg)
           apply clarsimp
           apply (rule_tac x=ntfnptr in cmap_relationE1 [OF cmap_relation_ntfn], assumption)
@@ -643,8 +643,8 @@ lemma doUnbindNotification_ccorres:
    (Call doUnbindNotification_'proc)"
   apply (cinit' lift: ntfnPtr_' tcbptr_')
    apply (rule ccorres_symb_exec_l [OF _ get_ntfn_inv' _ empty_fail_getNotification])
-    apply (rule_tac P="invs' and ko_at' rv ntfnptr" and P'=UNIV
-                in ccorres_split_nothrow_novcg)
+    apply (rule_tac P="invs' and ko_at' ntfn ntfnptr" and P'=UNIV
+             in ccorres_split_nothrow_novcg)
         apply (rule ccorres_from_vcg[where rrel=dc and xf=xfdc])
         apply (rule allI, rule conseqPre, vcg)
         apply (clarsimp simp: option_to_ptr_def option_to_0_def)
@@ -663,7 +663,7 @@ lemma doUnbindNotification_ccorres:
               apply (rule cpspace_relation_ntfn_update_ntfn, assumption+)
                apply (clarsimp simp: cnotification_relation_def Let_def
                                      mask_def [where n=2] NtfnState_Waiting_def)
-               apply (case_tac "ntfnObj rv", ((simp add: option_to_ctcb_ptr_def)+)[4])
+               apply (case_tac "ntfnObj ntfn", ((simp add: option_to_ctcb_ptr_def)+)[4])
              subgoal by (simp add: carch_state_relation_def typ_heap_simps')
             subgoal by (simp add: cmachine_state_relation_def)
            subgoal by (simp add: h_t_valid_clift_Some_iff)
@@ -778,13 +778,13 @@ lemma unbindMaybeNotification_ccorres:
   apply (cinit lift: ntfnPtr_')
    apply (rule ccorres_symb_exec_l [OF _ get_ntfn_inv' _ empty_fail_getNotification])
     apply (rule ccorres_rhs_assoc2)
-    apply (rule_tac P="ntfnBoundTCB rv \<noteq> None \<longrightarrow>
-                             option_to_ctcb_ptr (ntfnBoundTCB rv) \<noteq> NULL"
-                     in ccorres_gen_asm)
+    apply (rule_tac P="ntfnBoundTCB ntfn \<noteq> None \<longrightarrow>
+                         option_to_ctcb_ptr (ntfnBoundTCB ntfn) \<noteq> NULL"
+             in ccorres_gen_asm)
     apply (rule_tac xf'=boundTCB_'
-                           and val="option_to_ctcb_ptr (ntfnBoundTCB rv)"
-                           and R="ko_at' rv ntfnptr and valid_bound_tcb' (ntfnBoundTCB rv)"
-                            in ccorres_symb_exec_r_known_rv_UNIV[where R'=UNIV])
+                and val="option_to_ctcb_ptr (ntfnBoundTCB ntfn)"
+                and R="ko_at' ntfn ntfnptr and valid_bound_tcb' (ntfnBoundTCB ntfn)"
+             in ccorres_symb_exec_r_known_rv_UNIV[where R'=UNIV])
        apply vcg
        apply clarsimp
        apply (erule cmap_relationE1[OF cmap_relation_ntfn])

--- a/proof/crefine/ARM/Invoke_C.thy
+++ b/proof/crefine/ARM/Invoke_C.thy
@@ -65,7 +65,7 @@ lemma setDomain_ccorres:
            apply (ctac add: tcbSchedEnqueue_ccorres)
           apply (rule ccorres_return_Skip)
          apply (simp add: when_def)
-         apply (rule_tac R="\<lambda>s. rv = ksCurThread s"
+         apply (rule_tac R="\<lambda>s. curThread = ksCurThread s"
                     in ccorres_cond2)
            apply (clarsimp simp: rf_sr_ksCurThread)
           apply (ctac add: rescheduleRequired_ccorres)
@@ -76,14 +76,16 @@ lemma setDomain_ccorres:
       apply simp
       apply wp
      apply (rule_tac Q="\<lambda>_. all_invs_but_sch_extra and tcb_at' t and sch_act_simple
-                        and (\<lambda>s. rv = ksCurThread s)" in hoare_strengthen_post)
+                            and (\<lambda>s. curThread = ksCurThread s)"
+              in hoare_strengthen_post)
       apply (wp threadSet_all_invs_but_sch_extra)
      apply (clarsimp simp: valid_pspace_valid_objs' st_tcb_at_def[symmetric]
                            sch_act_simple_def st_tcb_at'_def weak_sch_act_wf_def
                     split: if_splits)
     apply (simp add: guard_is_UNIV_def)
    apply (rule_tac Q="\<lambda>_. invs' and tcb_at' t and sch_act_simple
-      and (\<lambda>s. rv = ksCurThread s \<and> (\<forall>p. t \<notin> set (ksReadyQueues s p)))" in hoare_strengthen_post)
+                          and (\<lambda>s. curThread = ksCurThread s \<and> (\<forall>p. t \<notin> set (ksReadyQueues s p)))"
+            in hoare_strengthen_post)
     apply (wp weak_sch_act_wf_lift_linear tcbSchedDequeue_not_queued
               tcbSchedDequeue_not_in_queue hoare_vcg_imp_lift hoare_vcg_all_lift)
    apply (clarsimp simp: invs'_def valid_pspace'_def valid_state'_def)
@@ -619,7 +621,7 @@ lemma decodeCNodeInvocation_ccorres:
                        del: Collect_const cong: call_ignore_cong)
            apply (rule ccorres_split_throws)
             apply (rule ccorres_rhs_assoc | csymbr)+
-            apply (simp add: invocationCatch_use_injection_handler[symmetric, unfolded o_def]
+            apply (simp add: invocationCatch_use_injection_handler[symmetric]
                         del: Collect_const cong: call_ignore_cong)
             apply (rule ccorres_Cond_rhs_Seq)
              apply (simp add:if_P del: Collect_const)
@@ -1089,7 +1091,7 @@ lemma decodeCNodeInvocation_ccorres:
             apply (simp add: throwError_def return_def exception_defs
                              syscall_error_rel_def syscall_error_to_H_cases)
             apply clarsimp
-           apply (simp add: invocationCatch_use_injection_handler[symmetric, unfolded o_def]
+           apply (simp add: invocationCatch_use_injection_handler[symmetric]
                        del: Collect_const)
            apply csymbr
            apply (simp add: interpret_excaps_test_null excaps_map_def

--- a/proof/crefine/ARM/Ipc_C.thy
+++ b/proof/crefine/ARM/Ipc_C.thy
@@ -2951,9 +2951,10 @@ proof -
                    del: Collect_const)
        apply csymbr
        apply (rename_tac "lngth")
-       apply (simp add: mi_from_H_def mapME_def del: Collect_const cong: bind_apply_cong)
+       apply (unfold mapME_def)[1]
+       apply (simp add: mi_from_H_def del: Collect_const)
        apply (rule ccorres_symb_exec_l)
-          apply (rule_tac P="length rv = unat word2" in ccorres_gen_asm)
+          apply (rule_tac P="length xs = unat word2" in ccorres_gen_asm)
           apply csymbr
           apply (rule ccorres_rhs_assoc2)
           apply (rule ccorres_add_returnOk2,
@@ -2963,7 +2964,7 @@ proof -
                         and   Q="UNIV"
                         and   F="\<lambda>n s. valid_pspace' s \<and> tcb_at' thread s \<and>
                                        (case buffer of Some x \<Rightarrow> valid_ipc_buffer_ptr' x | _ \<Rightarrow> \<top>) s \<and>
-                                        (\<forall>m < length rv. user_word_at (rv ! m)
+                                        (\<forall>m < length xs. user_word_at (xs ! m)
                                                       (x2 + (of_nat m + (msgMaxLength + 2)) * 4) s)"
                            in ccorres_sequenceE_while')
                    apply (simp add: split_def)
@@ -2973,7 +2974,7 @@ proof -
                       apply (rule_tac xf'=cptr_' in ccorres_abstract, ceqv)
                       apply (ctac add: capFaultOnFailure_ccorres
                                 [OF lookupSlotForThread_ccorres'])
-                         apply (rule_tac P="is_aligned rva 4" in ccorres_gen_asm)
+                         apply (rule_tac P="is_aligned rv 4" in ccorres_gen_asm)
                          apply (simp add: ccorres_cond_iffs liftE_bindE)
                          apply (rule ccorres_symb_exec_l [OF _ _ _ empty_fail_getSlotCap])
                            apply (rule_tac P'="UNIV \<inter> {s. excaps_map ys
@@ -2994,7 +2995,7 @@ proof -
                         apply (clarsimp simp: ccorres_cond_iffs)
                         apply (rule_tac  P= \<top>
                                  and P'="{x. errstate x= lu_ret___struct_lookupSlot_raw_ret_C \<and>
-                                             rv' = (rv ! length ys)}"
+                                             rv' = (xs ! length ys)}"
                                    in ccorres_from_vcg_throws)
                         apply (rule allI, rule conseqPre, vcg)
                         apply (clarsimp simp: throwError_def return_def)
@@ -3035,7 +3036,7 @@ proof -
              apply ceqv
             apply (simp del: Collect_const)
             apply (rule_tac P'="{s. snd rv'=?curr s}"
-                        and P="\<lambda>s. length rva = length rv \<and> (\<forall>x \<in> set rva. snd x \<noteq> 0)"
+                        and P="\<lambda>s. length rv = length xs \<and> (\<forall>x \<in> set rv. snd x \<noteq> 0)"
                         in ccorres_from_vcg_throws)
             apply (rule allI, rule conseqPre, vcg)
             apply (clarsimp simp: returnOk_def return_def
@@ -3357,7 +3358,7 @@ proof -
      apply (rule ccorres_rhs_assoc2)
      apply (simp add: MessageID_Exception_def)
      apply ccorres_rewrite
-     apply (subst bind_return_unit)
+     apply (rule ccorres_add_return2)
      apply (rule ccorres_split_nothrow_novcg)
          apply (rule ccorres_zipWithM_x_while)
              apply clarsimp

--- a/proof/crefine/ARM/Recycle_C.thy
+++ b/proof/crefine/ARM/Recycle_C.thy
@@ -583,8 +583,8 @@ lemma cancelBadgedSends_ccorres:
               cong: list.case_cong Structures_H.endpoint.case_cong call_ignore_cong
                del: Collect_const)
    apply (rule ccorres_pre_getEndpoint)
-   apply (rule_tac R="ko_at' rv ptr" and xf'="ret__unsigned_'"
-               and val="case rv of RecvEP q \<Rightarrow> scast EPState_Recv | IdleEP \<Rightarrow> scast EPState_Idle
+   apply (rule_tac R="ko_at' ep ptr" and xf'="ret__unsigned_'"
+               and val="case ep of RecvEP q \<Rightarrow> scast EPState_Recv | IdleEP \<Rightarrow> scast EPState_Idle
                                 | SendEP q \<Rightarrow> scast EPState_Send"
                in ccorres_symb_exec_r_known_rv_UNIV[where R'=UNIV])
       apply vcg
@@ -604,12 +604,12 @@ lemma cancelBadgedSends_ccorres:
                 del: Collect_const cong: call_ignore_cong)
     apply (rule ccorres_rhs_assoc)+
     apply (csymbr, csymbr)
-    apply (drule_tac s = rv in sym, simp only:)
-    apply (rule_tac P="ko_at' rv ptr and invs'" in ccorres_cross_over_guard)
+    apply (drule_tac s = ep in sym, simp only:)
+    apply (rule_tac P="ko_at' ep ptr and invs'" in ccorres_cross_over_guard)
     apply (rule ccorres_symb_exec_r)
       apply (rule ccorres_rhs_assoc2, rule ccorres_rhs_assoc2)
       apply (rule ccorres_split_nothrow[where r'=dc and xf'=xfdc, OF _ ceqv_refl])
-         apply (rule_tac P="ko_at' rv ptr"
+         apply (rule_tac P="ko_at' ep ptr"
                     in ccorres_from_vcg[where P'=UNIV])
          apply (rule allI, rule conseqPre, vcg)
          apply clarsimp
@@ -719,7 +719,7 @@ lemma cancelBadgedSends_ccorres:
               subgoal by (simp add: rf_sr_def)
              apply simp
             apply ceqv
-           apply (rule_tac P="ret__unsigned=blockingIPCBadge rva" in ccorres_gen_asm2)
+           apply (rule_tac P="ret__unsigned=blockingIPCBadge rv" in ccorres_gen_asm2)
            apply (rule ccorres_if_bind, rule ccorres_if_lhs)
             apply (simp add: bind_assoc)
             apply (rule ccorres_rhs_assoc)+

--- a/proof/crefine/ARM/Retype_C.thy
+++ b/proof/crefine/ARM/Retype_C.thy
@@ -3638,17 +3638,17 @@ lemma copyGlobalMappings_ccorres:
    apply (rule ccorres_pre_gets_armKSGlobalPD_ksArchState)
    apply csymbr
    apply (rule ccorres_rel_imp)
-    apply (rule_tac F="\<lambda>_ s. rv = armKSGlobalPD (ksArchState s)
-                                \<and> is_aligned rv pdBits \<and> valid_pde_mappings' s
+    apply (rule_tac F="\<lambda>_ s. globalPD = armKSGlobalPD (ksArchState s)
+                                \<and> is_aligned globalPD pdBits \<and> valid_pde_mappings' s
                                 \<and> page_directory_at' pd s
                                 \<and> page_directory_at' (armKSGlobalPD (ksArchState s)) s"
-              and i="0xE00"
-               in ccorres_mapM_x_while')
+                and i="0xE00"
+             in ccorres_mapM_x_while')
         apply (clarsimp simp del: Collect_const)
         apply (rule ccorres_guard_imp2)
          apply (rule ccorres_pre_getObject_pde)
          apply (simp add: storePDE_def del: Collect_const)
-         apply (rule_tac P="\<lambda>s. ko_at' rva (armKSGlobalPD (ksArchState s)
+         apply (rule_tac P="\<lambda>s. ko_at' rv (armKSGlobalPD (ksArchState s)
                                               + ((0xE00 + of_nat n) << 2)) s
                                     \<and> page_directory_at' pd s \<and> valid_pde_mappings' s
                                     \<and> page_directory_at' (armKSGlobalPD (ksArchState s)) s"
@@ -3663,7 +3663,7 @@ lemma copyGlobalMappings_ccorres:
            apply (rule cmap_relationE1[OF rf_sr_cpde_relation],
                   assumption, erule_tac ko=ko' in ko_at_projectKO_opt)
            apply (rule cmap_relationE1[OF rf_sr_cpde_relation],
-                  assumption, erule_tac ko=rva in ko_at_projectKO_opt)
+                  assumption, erule_tac ko=rv in ko_at_projectKO_opt)
            apply (clarsimp simp: typ_heap_simps')
            apply (drule(1) page_directory_at_rf_sr)+
            apply clarsimp

--- a/proof/crefine/ARM/SyscallArgs_C.thy
+++ b/proof/crefine/ARM/SyscallArgs_C.thy
@@ -755,11 +755,13 @@ lemma lookupIPCBuffer_ccorres[corres]:
      apply (rule ccorres_move_array_assertion_tcb_ctes
                  ccorres_move_c_guard_tcb_ctes)+
      apply (ctac (no_vcg))
+       apply (rename_tac bufferCap bufferCap')
        apply csymbr
-       apply (rule_tac b="isArchObjectCap rva \<and> isPageCap (capCap rva)" in ccorres_case_bools')
+       apply (rule_tac b="isArchObjectCap bufferCap \<and> isPageCap (capCap bufferCap)"
+                in ccorres_case_bools')
         apply simp
         apply (rule ccorres_symb_exec_r)
-          apply (rule_tac b="capVPSize (capCap rva) \<noteq> ARMSmallPage" in ccorres_case_bools')
+          apply (rule_tac b="capVPSize (capCap bufferCap) \<noteq> ARMSmallPage" in ccorres_case_bools')
            apply (rule ccorres_cond_true_seq)
            apply (rule ccorres_rhs_assoc)+
            apply csymbr
@@ -767,7 +769,7 @@ lemma lookupIPCBuffer_ccorres[corres]:
            apply (rule ccorres_cond_false_seq)
            apply (simp(no_asm))
            apply csymbr
-           apply (rule_tac b="isDeviceCap rva" in ccorres_case_bools')
+           apply (rule_tac b="isDeviceCap bufferCap" in ccorres_case_bools')
             apply (rule ccorres_cond_true_seq)
             apply (rule ccorres_from_vcg_split_throws[where P=\<top> and P'=UNIV])
              apply vcg
@@ -821,7 +823,7 @@ lemma lookupIPCBuffer_ccorres[corres]:
           apply (rule ccorres_cond_false_seq)
           apply (simp(no_asm))
           apply csymbr
-            apply (rule_tac b="isDeviceCap rva" in ccorres_case_bools')
+            apply (rule_tac b="isDeviceCap bufferCap" in ccorres_case_bools')
              apply (rule ccorres_cond_true_seq)
              apply (rule ccorres_from_vcg_split_throws[where P=\<top> and P'=UNIV])
               apply vcg

--- a/proof/crefine/ARM/Syscall_C.thy
+++ b/proof/crefine/ARM/Syscall_C.thy
@@ -1203,7 +1203,7 @@ lemma handleRecv_ccorres:
 
           apply (simp add: liftE_bind)
           apply (ctac)
-            apply (rule_tac P="\<lambda>s. ksCurThread s = rv" in ccorres_cross_over_guard)
+            apply (rule_tac P="\<lambda>s. ksCurThread s = thread" in ccorres_cross_over_guard)
             apply (ctac add: receiveIPC_ccorres)
 
            apply (wp deleteCallerCap_ksQ_ct' hoare_vcg_all_lift)

--- a/proof/crefine/ARM/Tcb_C.thy
+++ b/proof/crefine/ARM/Tcb_C.thy
@@ -399,7 +399,7 @@ lemma setPriority_ccorres:
   apply (frule (1) valid_objs'_maxDomain[where t=t])
   apply (frule (1) valid_objs'_maxPriority[where t=t])
   apply simp
-done
+  done
 
 lemma setMCPriority_ccorres:
   "ccorres dc xfdc
@@ -1139,10 +1139,10 @@ lemma invokeTCB_CopyRegisters_ccorres:
              apply (simp add: word_bits_def frame_gp_registers_convs n_gpRegisters_def)
             apply simp
            apply (rule ccorres_pre_getCurThread)
+           apply (rename_tac thread)
            apply (ctac add: postModifyRegisters_ccorres[simplified])
              apply (rule ccorres_split_nothrow_novcg_dc)
-                apply (rule_tac R="\<lambda>s. rvd = ksCurThread s"
-                             in ccorres_when)
+                apply (rule_tac R="\<lambda>s. thread = ksCurThread s" in ccorres_when)
                  apply (clarsimp simp: rf_sr_ksCurThread)
                 apply clarsimp
                 apply (ctac (no_vcg) add: rescheduleRequired_ccorres)
@@ -1550,8 +1550,7 @@ lemma invokeTCB_WriteRegisters_ccorres[where S=UNIV]:
                      apply simp
                     apply (rule ceqv_refl)
                    apply (rule ccorres_split_nothrow_novcg_dc)
-                      apply (rule_tac R="\<lambda>s. rv = ksCurThread s"
-                                     in ccorres_when)
+                      apply (rule_tac R="\<lambda>s. self = ksCurThread s" in ccorres_when)
                       apply (clarsimp simp: rf_sr_ksCurThread)
                      apply clarsimp
                      apply (ctac (no_vcg) add: rescheduleRequired_ccorres)
@@ -2020,7 +2019,7 @@ shows
                         apply (clarsimp simp: min_def iffD2 [OF mask_eq_iff_w2p] word_size
                                               word_less_nat_alt
                                       split: if_split_asm dest!: word_unat.Rep_inverse')
-                       apply simp
+                       apply (simp add: pred_conj_def)
                        apply (wp mapM_x_wp' sch_act_wf_lift valid_queues_lift static_imp_wp
                                  tcb_in_cur_domain'_lift)
                       apply (simp add: n_frameRegisters_def n_msgRegisters_def
@@ -2152,7 +2151,8 @@ lemma decodeReadRegisters_ccorres:
        apply (simp add: liftE_bindE bind_assoc)
        apply (rule ccorres_pre_getCurThread)
        apply (rule ccorres_cond_seq)
-       apply (rule_tac R="\<lambda>s. rv = ksCurThread s \<and> isThreadCap cp" and P="\<lambda>s. capTCBPtr cp = rv" in ccorres_cond_both)
+       apply (rule_tac R="\<lambda>s. self = ksCurThread s \<and> isThreadCap cp" and P="\<lambda>s. capTCBPtr cp = self"
+                in ccorres_cond_both)
          apply clarsimp
          apply (frule rf_sr_ksCurThread)
          apply clarsimp
@@ -2163,13 +2163,13 @@ lemma decodeReadRegisters_ccorres:
           apply (drule_tac t="ksCurThread s" in sym)
           apply simp
          apply simp
-        apply (rule_tac P="capTCBPtr cp = rv" in ccorres_gen_asm)
+        apply (rule_tac P="capTCBPtr cp = self" in ccorres_gen_asm)
         apply simp
         apply (simp add: throwError_bind invocationCatch_def
                     cong: StateSpace.state.fold_congs globals.fold_congs)
         apply (rule syscall_error_throwError_ccorres_n)
         apply (simp add: syscall_error_to_H_cases)
-       apply (rule_tac P="capTCBPtr cp \<noteq> rv" in ccorres_gen_asm)
+       apply (rule_tac P="capTCBPtr cp \<noteq> self" in ccorres_gen_asm)
        apply (simp add: returnOk_bind)
        apply (simp add: ccorres_invocationCatch_Inr del: Collect_const)
        apply (ctac add: setThreadState_ccorres)
@@ -2263,7 +2263,8 @@ lemma decodeWriteRegisters_ccorres:
        apply (simp add: liftE_bindE bind_assoc)
        apply (rule ccorres_pre_getCurThread)
        apply (rule ccorres_cond_seq)
-       apply (rule_tac R="\<lambda>s. rv = ksCurThread s \<and> isThreadCap cp" and P="\<lambda>s. capTCBPtr cp = rv" in ccorres_cond_both)
+       apply (rule_tac R="\<lambda>s. self = ksCurThread s \<and> isThreadCap cp" and P="\<lambda>s. capTCBPtr cp = self"
+                in ccorres_cond_both)
          apply clarsimp
          apply (frule rf_sr_ksCurThread)
          apply clarsimp
@@ -2274,13 +2275,13 @@ lemma decodeWriteRegisters_ccorres:
           apply (drule_tac t="ksCurThread s" in sym)
           apply simp
          apply simp
-        apply (rule_tac P="capTCBPtr cp = rv" in ccorres_gen_asm)
+        apply (rule_tac P="capTCBPtr cp = self" in ccorres_gen_asm)
         apply simp
         apply (simp add: throwError_bind invocationCatch_def
                     cong: StateSpace.state.fold_congs globals.fold_congs)
         apply (rule syscall_error_throwError_ccorres_n)
         apply (simp add: syscall_error_to_H_cases)
-       apply (rule_tac P="capTCBPtr cp \<noteq> rv" in ccorres_gen_asm)
+       apply (rule_tac P="capTCBPtr cp \<noteq> self" in ccorres_gen_asm)
        apply (simp add: returnOk_bind)
        apply (simp add: ccorres_invocationCatch_Inr del: Collect_const)
        apply (ctac add: setThreadState_ccorres)
@@ -2566,7 +2567,7 @@ lemma slotCapLongRunningDelete_ccorres:
    apply (simp add: case_Null_If del: Collect_const)
    apply (rule ccorres_pre_getCTE)
    apply (rule ccorres_move_c_guard_cte)
-   apply (rule_tac P="cte_wp_at' ((=) rv) slot"
+   apply (rule_tac P="cte_wp_at' ((=) cte) slot"
                 in ccorres_cross_over_guard)
    apply (rule ccorres_symb_exec_r)
      apply (rule ccorres_if_lhs)
@@ -2587,7 +2588,7 @@ lemma slotCapLongRunningDelete_ccorres:
         apply vcg
        apply (simp del: Collect_const)
        apply (rule ccorres_move_c_guard_cte)
-       apply (rule_tac P="cte_wp_at' ((=) rv) slot"
+       apply (rule_tac P="cte_wp_at' ((=) cte) slot"
                   in  ccorres_from_vcg_throws[where P'=UNIV])
        apply (rule allI, rule conseqPre, vcg)
        apply (clarsimp simp: cte_wp_at_ctes_of return_def)
@@ -3714,7 +3715,7 @@ lemma bindNotification_ccorres:
    (Call bindNotification_'proc)"
   apply (cinit lift: tcb_' ntfnPtr_' simp: bindNotification_def)
    apply (rule ccorres_symb_exec_l [OF _ get_ntfn_inv' _ empty_fail_getNotification])
-    apply (rule_tac P="invs' and ko_at' rv ntfnptr and tcb_at' tcb" and P'=UNIV
+    apply (rule_tac P="invs' and ko_at' ntfn ntfnptr and tcb_at' tcb" and P'=UNIV
                     in ccorres_split_nothrow_novcg)
         apply (rule ccorres_from_vcg[where rrel=dc and xf=xfdc])
         apply (rule allI, rule conseqPre, vcg)
@@ -3734,7 +3735,7 @@ lemma bindNotification_ccorres:
               apply (rule cpspace_relation_ntfn_update_ntfn, assumption+)
                apply (clarsimp simp: cnotification_relation_def Let_def
                                      mask_def [where n=2] NtfnState_Waiting_def)
-               apply (case_tac "ntfnObj rv")
+               apply (case_tac "ntfnObj ntfn")
                  apply (auto simp: option_to_ctcb_ptr_def obj_at'_def objBits_simps projectKOs
                                    bindNTFN_alignment_junk)[4]
              apply (simp add: carch_state_relation_def typ_heap_simps')
@@ -3812,7 +3813,7 @@ lemma decodeUnbindNotification_ccorres:
    apply (rule ccorres_Guard_Seq)
    apply (simp add: liftE_bindE bind_assoc)
    apply (rule ccorres_pre_getBoundNotification)
-   apply (rule_tac P="\<lambda>s. rv \<noteq> Some 0" in ccorres_cross_over_guard)
+   apply (rule_tac P="\<lambda>s. ntfn \<noteq> Some 0" in ccorres_cross_over_guard)
    apply (simp add: bindE_bind_linearise)
    apply wpc
     apply (simp add: bindE_bind_linearise[symmetric]

--- a/proof/crefine/ARM/VSpace_C.thy
+++ b/proof/crefine/ARM/VSpace_C.thy
@@ -171,7 +171,7 @@ lemma loadHWASID_ccorres:
    apply (rule ccorres_symb_exec_l [OF _ _ _ empty_fail_gets])
      apply (rule ccorres_symb_exec_l [OF _ _ _ empty_fail_findPDForASIDAssert])
        apply (rename_tac pd)
-       apply (rule_tac P="\<lambda>s. pd_at_asid' pd asid s \<and> rv = armKSASIDMap (ksArchState s)
+       apply (rule_tac P="\<lambda>s. pd_at_asid' pd asid s \<and> asidMap = armKSASIDMap (ksArchState s)
                                \<and> pd \<notin> ran (option_map snd o armKSASIDMap (ksArchState s)
                                                      |` (- {asid}))
                                \<and> option_map snd (armKSASIDMap (ksArchState s) asid) \<in> {None, Some pd}
@@ -746,7 +746,7 @@ lemma lookupPTSlot_ccorres:
    apply csymbr
    apply csymbr
    apply (rule ccorres_abstract_cleanup)
-   apply (rule_tac P="(ret__unsigned = scast pde_pde_coarse) = (isPageTablePDE rv)"
+   apply (rule_tac P="(ret__unsigned = scast pde_pde_coarse) = (isPageTablePDE pde)"
                in ccorres_gen_asm2)
    apply (rule ccorres_cond2'[where R=\<top>])
      apply (clarsimp simp: Collect_const_mem)
@@ -761,9 +761,10 @@ lemma lookupPTSlot_ccorres:
    apply (simp add: checkPTAt_def bind_liftE_distrib liftE_bindE
                     returnOk_liftE[symmetric])
    apply (rule ccorres_stateAssert)
-   apply (rule_tac P="page_table_at' (ptrFromPAddr (pdeTable rv))
-         and ko_at' rv (lookup_pd_slot pd vptr)
-         and K (isPageTablePDE rv)" and P'=UNIV in ccorres_from_vcg_throws)
+   apply (rule_tac P="page_table_at' (ptrFromPAddr (pdeTable pde))
+                      and ko_at' pde (lookup_pd_slot pd vptr) and K (isPageTablePDE pde)"
+               and P'=UNIV
+            in ccorres_from_vcg_throws)
    apply (rule allI, rule conseqPre, vcg)
    apply (clarsimp simp: returnOk_def return_def Collect_const_mem
                          lookup_pd_slot_def word_sle_def)
@@ -1168,15 +1169,15 @@ lemma findFreeHWASID_ccorres:
         apply (rule_tac xf=hw_asid_offset_' and i=0
                      and xf_update=hw_asid_offset_'_update
                      and r'=dc and xf'=xfdc and Q=UNIV
-                      and F="\<lambda>n s. rv = armKSHWASIDTable (ksArchState s)
-                                   \<and> nextASID = armKSNextASID (ksArchState s)
-                                   \<and> valid_arch_state' s"
+                     and F="\<lambda>n s. hwASIDTable = armKSHWASIDTable (ksArchState s)
+                                  \<and> nextASID = armKSNextASID (ksArchState s)
+                                  \<and> valid_arch_state' s"
                    in ccorres_sequenceE_while_gen')
               apply (rule ccorres_from_vcg_might_throw)
               apply (rule allI, rule conseqPre, vcg)
               apply (clarsimp simp: rf_sr_armKSNextASID)
               apply (subst down_cast_same [symmetric],
-                   simp add: is_down_def target_size_def source_size_def word_size)+
+                     simp add: is_down_def target_size_def source_size_def word_size)+
               apply (simp add: ucast_ucast_mask
                                ucast_ucast_add ucast_and_mask
                                ucast_of_nat_small asidInvalid_def
@@ -1214,7 +1215,7 @@ lemma findFreeHWASID_ccorres:
       apply ceqv
      apply (rule ccorres_assert)
      apply (rule_tac A="\<lambda>s. nextASID = armKSNextASID (ksArchState s)
-                             \<and> rv = armKSHWASIDTable (ksArchState s)
+                             \<and> hwASIDTable = armKSHWASIDTable (ksArchState s)
                              \<and> valid_arch_state' s \<and> valid_pde_mappings' s"
                 in ccorres_guard_imp2[where A'=UNIV])
       apply (simp add: split_def)
@@ -1360,7 +1361,7 @@ lemma setVMRoot_ccorres:
       apply (rule ccorres_rhs_assoc)+
       apply (rule ccorres_h_t_valid_armKSGlobalPD)
       apply csymbr
-      apply (rule ccorres_pre_gets_armKSGlobalPD_ksArchState[unfolded comp_def])
+      apply (rule ccorres_pre_gets_armKSGlobalPD_ksArchState)
       apply (rule ccorres_add_return2)
       apply (ctac (no_vcg) add: setCurrentPD_ccorres)
        apply (rule ccorres_split_throws)
@@ -1380,7 +1381,7 @@ lemma setVMRoot_ccorres:
       apply (rule ccorres_rhs_assoc)+
       apply (rule ccorres_h_t_valid_armKSGlobalPD)
       apply csymbr
-      apply (rule ccorres_pre_gets_armKSGlobalPD_ksArchState[unfolded comp_def])
+      apply (rule ccorres_pre_gets_armKSGlobalPD_ksArchState)
       apply (rule ccorres_add_return2)
       apply (ctac (no_vcg) add: setCurrentPD_ccorres)
        apply (rule ccorres_split_throws)
@@ -1409,7 +1410,7 @@ lemma setVMRoot_ccorres:
          apply (simp add: whenE_def throwError_def
                           checkPDNotInASIDMap_def checkPDASIDMapMembership_def)
          apply (rule ccorres_stateAssert)
-         apply (rule ccorres_pre_gets_armKSGlobalPD_ksArchState[unfolded o_def])
+         apply (rule ccorres_pre_gets_armKSGlobalPD_ksArchState)
          apply (rule ccorres_rhs_assoc)+
          apply (rule ccorres_h_t_valid_armKSGlobalPD)
          apply csymbr
@@ -1424,7 +1425,7 @@ lemma setVMRoot_ccorres:
        apply (simp add: checkPDNotInASIDMap_def checkPDASIDMapMembership_def)
        apply (rule ccorres_stateAssert)
        apply (rule ccorres_rhs_assoc)+
-       apply (rule ccorres_pre_gets_armKSGlobalPD_ksArchState[unfolded o_def])
+       apply (rule ccorres_pre_gets_armKSGlobalPD_ksArchState)
        apply (rule ccorres_h_t_valid_armKSGlobalPD)
        apply csymbr
        apply (rule ccorres_add_return2)
@@ -1476,9 +1477,9 @@ lemma setVMRootForFlush_ccorres:
                  del: Collect_const)
      apply (rule ccorres_if_lhs)
       apply (rule_tac P="(capPDIsMapped_CL (cap_page_directory_cap_lift threadRoot) = 0)
-                             = (capPDMappedASID (capCap rva) = None)
+                             = (capPDMappedASID (capCap rv) = None)
                          \<and> capPDBasePtr_CL (cap_page_directory_cap_lift threadRoot)
-                             = capPDBasePtr (capCap rva)" in ccorres_gen_asm2)
+                             = capPDBasePtr (capCap rv)" in ccorres_gen_asm2)
       apply (rule ccorres_rhs_assoc | csymbr | simp add: Collect_True del: Collect_const)+
       apply (rule ccorres_split_throws)
        apply (rule ccorres_return_C, simp+)
@@ -1685,7 +1686,7 @@ lemma setRegister_ccorres:
    apply (rule ccorres_pre_threadGet)
    apply (rule ccorres_Guard)
    apply (simp add: setRegister_def simpler_modify_def exec_select_f_singleton)
-   apply (rule_tac P="\<lambda>tcb. (atcbContextGet o tcbArch) tcb = rv"
+   apply (rule_tac P="\<lambda>tcb. (atcbContextGet o tcbArch) tcb = uc"
                 in threadSet_ccorres_lemma2)
     apply vcg
    apply (clarsimp simp: setRegister_def HaskellLib_H.runState_def
@@ -2233,9 +2234,7 @@ lemma unmapPage_ccorres:
           \<comment> \<open>ARMSection\<close>
           apply (rule ccorres_Cond_rhs)
            apply (rule ccorres_rhs_assoc)+
-           \<comment> \<open>FIXME: The second csymbr rewrites the return relation of the goal.
-                      If this was avoided then folding the dc_def could be removed\<close>
-           apply (csymbr, csymbr, fold dc_def)
+           apply (csymbr, csymbr)
            apply (simp add: gen_framesize_to_H_def liftE_liftM
                        del: Collect_const)
            apply (simp split: if_split, rule conjI[rotated], rule impI,
@@ -2267,12 +2266,9 @@ lemma unmapPage_ccorres:
           \<comment> \<open>ARMSuperSection\<close>
           apply (rule ccorres_Cond_rhs)
            apply (rule ccorres_rhs_assoc)+
-           \<comment> \<open>FIXME: The third csymbr rewrites the return relation of the goal.
-                      If this was avoided then folding the dc_def could be removed\<close>
            apply csymbr
            apply csymbr
            apply csymbr
-           apply (fold dc_def)
            apply (case_tac "pd = pde_Ptr (lookup_pd_slot pdPtr vptr)")
             prefer 2
             apply (simp, rule ccorres_empty)
@@ -2885,13 +2881,13 @@ lemma performASIDPoolInvocation_ccorres:
          apply (rule ccorres_rhs_assoc2)
          apply (rule_tac ccorres_split_nothrow [where r'=dc and xf'=xfdc])
              apply (simp add: updateCap_def)
-             apply (rule_tac A="cte_wp_at' ((=) rv o cteCap) ctSlot
-                                and K (isPDCap rv \<and> asid \<le> mask asid_bits)"
+             apply (rule_tac A="cte_wp_at' ((=) oldcap o cteCap) ctSlot
+                                and K (isPDCap oldcap \<and> asid \<le> mask asid_bits)"
                          and A'=UNIV in ccorres_guard_imp2)
               apply (rule ccorres_pre_getCTE)
-              apply (rule_tac P="cte_wp_at' ((=) rv o cteCap) ctSlot
-                                 and K (isPDCap rv \<and> asid \<le> mask asid_bits)
-                                 and cte_wp_at' ((=) rva) ctSlot"
+              apply (rule_tac P="cte_wp_at' ((=) oldcap o cteCap) ctSlot
+                                 and K (isPDCap oldcap \<and> asid \<le> mask asid_bits)
+                                 and cte_wp_at' ((=) rv) ctSlot"
                           and P'=UNIV in ccorres_from_vcg)
               apply (rule allI, rule conseqPre, vcg)
               apply (clarsimp simp: cte_wp_at_ctes_of)

--- a/proof/crefine/ARM_HYP/Arch_C.thy
+++ b/proof/crefine/ARM_HYP/Arch_C.thy
@@ -438,7 +438,9 @@ shows
       apply (rule ccorres_rhs_assoc2)
       apply (rule ccorres_abstract_cleanup)
       apply (rule ccorres_symb_exec_l)
-        apply (rule_tac P = "rva = (capability.UntypedCap isdev frame pageBits idx)" in ccorres_gen_asm)
+        apply (rename_tac pcap)
+        apply (rule_tac P = "pcap = (capability.UntypedCap isdev frame pageBits idx)"
+                 in ccorres_gen_asm)
         apply (simp add: hrs_htd_update del:fun_upd_apply)
         apply (rule ccorres_split_nothrow)
 
@@ -1497,13 +1499,13 @@ lemma pdeCheckIfMapped_ccorres:
     (Call pdeCheckIfMapped_'proc)"
   apply (cinit lift: pde___ptr_to_struct_pde_C_')
    apply (rule ccorres_pre_getObject_pde)
-   apply (rule_tac P'="{s. \<exists>pde'. cslift s (pde_Ptr slot) = Some pde' \<and> cpde_relation rv pde'}"
+   apply (rule_tac P'="{s. \<exists>pde'. cslift s (pde_Ptr slot) = Some pde' \<and> cpde_relation pd pde'}"
      in ccorres_from_vcg_throws[where P="\<lambda>s. True"])
    apply simp_all
   apply clarsimp
   apply (rule conseqPre, vcg)
   apply (clarsimp simp: typ_heap_simps' return_def)
-  apply (case_tac rv, simp_all add: cpde_relation_invalid isInvalidPDE_def
+  apply (case_tac pd, simp_all add: cpde_relation_invalid isInvalidPDE_def
                              split: if_split)
   done
 
@@ -2379,9 +2381,9 @@ lemma setVMRootForFlush_ccorres2:
                  del: Collect_const)
      apply (rule ccorres_if_lhs)
       apply (rule_tac P="(capPDIsMapped_CL (cap_page_directory_cap_lift threadRoot) = 0)
-                             = (capPDMappedASID (capCap rva) = None)
+                             = (capPDMappedASID (capCap rv) = None)
                          \<and> capPDBasePtr_CL (cap_page_directory_cap_lift threadRoot)
-                             = capPDBasePtr (capCap rva)" in ccorres_gen_asm2)
+                             = capPDBasePtr (capCap rv)" in ccorres_gen_asm2)
       apply (rule ccorres_rhs_assoc | csymbr | simp add: Collect_True del: Collect_const)+
       apply (rule ccorres_split_throws)
        apply (rule ccorres_return_C, simp+)
@@ -4745,7 +4747,7 @@ lemma decodeVCPUInjectIRQ_ccorres:
                              liftE_liftM[symmetric] liftE_bindE_assoc)
 
        (* symbolically execute the gets on LHS *)
-       apply (rule_tac ccorres_pre_gets_armKSGICVCPUNumListRegs_ksArchState[simplified comp_def],
+       apply (rule_tac ccorres_pre_gets_armKSGICVCPUNumListRegs_ksArchState,
               rename_tac nregs)
 
        (* unfortunately directly looking at \<acute>gic_vcpu_num_list_regs means we need to abstract the IF condition*)

--- a/proof/crefine/ARM_HYP/CSpace_C.thy
+++ b/proof/crefine/ARM_HYP/CSpace_C.thy
@@ -796,7 +796,7 @@ lemma update_freeIndex':
     show ?thesis
       apply (cinit lift: cap_ptr_' v32_')
        apply (rule ccorres_pre_getCTE)
-       apply (rule_tac P="\<lambda>s. ctes_of s srcSlot = Some rv \<and> (\<exists>i. cteCap rv = UntypedCap d p sz i)"
+       apply (rule_tac P="\<lambda>s. ctes_of s srcSlot = Some cte \<and> (\<exists>i. cteCap cte = UntypedCap d p sz i)"
                 in ccorres_from_vcg[where P' = UNIV])
        apply (rule allI)
        apply (rule conseqPre)
@@ -2552,7 +2552,7 @@ lemma capSwapForDelete_ccorres:
   \<comment> \<open>--- instruction: when (slot1 \<noteq> slot2) \<dots> / IF Ptr slot1 = Ptr slot2 THEN \<dots>\<close>
    apply (simp add:when_def)
    apply (rule ccorres_if_cond_throws2 [where Q = \<top> and Q' = \<top>])
-      apply (case_tac "slot1=slot2", simp+)
+      apply (case_tac "slot1=slot2"; simp)
      apply (rule ccorres_return_void_C)
 
   \<comment> \<open>***Main goal***\<close>

--- a/proof/crefine/ARM_HYP/Finalise_C.thy
+++ b/proof/crefine/ARM_HYP/Finalise_C.thy
@@ -277,10 +277,10 @@ lemma cancelAllIPC_ccorres:
   apply (cinit lift: epptr_')
    apply (rule ccorres_symb_exec_l [OF _ getEndpoint_inv _ empty_fail_getEndpoint])
     apply (rule_tac xf'=ret__unsigned_'
-                and val="case rv of IdleEP \<Rightarrow> scast EPState_Idle
+                and val="case ep of IdleEP \<Rightarrow> scast EPState_Idle
                             | RecvEP _ \<Rightarrow> scast EPState_Recv | SendEP _ \<Rightarrow> scast EPState_Send"
-                and R="ko_at' rv epptr"
-                 in ccorres_symb_exec_r_known_rv_UNIV[where R'=UNIV])
+                and R="ko_at' ep epptr"
+             in ccorres_symb_exec_r_known_rv_UNIV[where R'=UNIV])
        apply vcg
        apply clarsimp
        apply (erule cmap_relationE1 [OF cmap_relation_ep])
@@ -289,8 +289,8 @@ lemma cancelAllIPC_ccorres:
        apply (simp add: cendpoint_relation_def Let_def
                  split: endpoint.split_asm)
       apply ceqv
-     apply (rule_tac A="invs' and ko_at' rv epptr"
-                  in ccorres_guard_imp2[where A'=UNIV])
+     apply (rule_tac A="invs' and ko_at' ep epptr"
+              in ccorres_guard_imp2[where A'=UNIV])
       apply wpc
         apply (rename_tac list)
         apply (simp add: endpoint_state_defs
@@ -404,10 +404,10 @@ lemma cancelAllSignals_ccorres:
   apply (cinit lift: ntfnPtr_')
    apply (rule ccorres_symb_exec_l [OF _ get_ntfn_inv' _ empty_fail_getNotification])
     apply (rule_tac xf'=ret__unsigned_'
-                and val="case ntfnObj rv of IdleNtfn \<Rightarrow> scast NtfnState_Idle
+                and val="case ntfnObj ntfn of IdleNtfn \<Rightarrow> scast NtfnState_Idle
                             | ActiveNtfn _ \<Rightarrow> scast NtfnState_Active | WaitingNtfn _ \<Rightarrow> scast NtfnState_Waiting"
-                and R="ko_at' rv ntfnptr"
-                 in ccorres_symb_exec_r_known_rv_UNIV[where R'=UNIV])
+                and R="ko_at' ntfn ntfnptr"
+             in ccorres_symb_exec_r_known_rv_UNIV[where R'=UNIV])
        apply vcg
        apply clarsimp
        apply (erule cmap_relationE1 [OF cmap_relation_ntfn])
@@ -416,8 +416,8 @@ lemma cancelAllSignals_ccorres:
        apply (simp add: cnotification_relation_def Let_def
                  split: ntfn.split_asm)
       apply ceqv
-     apply (rule_tac A="invs' and ko_at' rv ntfnptr"
-                  in ccorres_guard_imp2[where A'=UNIV])
+     apply (rule_tac A="invs' and ko_at' ntfn ntfnptr"
+              in ccorres_guard_imp2[where A'=UNIV])
       apply wpc
         apply (simp add: notification_state_defs ccorres_cond_iffs)
         apply (rule ccorres_return_Skip)
@@ -432,8 +432,8 @@ lemma cancelAllSignals_ccorres:
       apply csymbr
       apply (rule ccorres_rhs_assoc2, rule ccorres_rhs_assoc2)
       apply (rule_tac r'=dc and xf'=xfdc in ccorres_split_nothrow)
-          apply (rule_tac P="ko_at' rv ntfnptr and invs'"
-                    in ccorres_from_vcg[where P'=UNIV])
+          apply (rule_tac P="ko_at' ntfn ntfnptr and invs'"
+                   in ccorres_from_vcg[where P'=UNIV])
           apply (rule allI, rule conseqPre, vcg)
           apply clarsimp
           apply (rule_tac x=ntfnptr in cmap_relationE1 [OF cmap_relation_ntfn], assumption)
@@ -677,8 +677,8 @@ lemma doUnbindNotification_ccorres:
    (Call doUnbindNotification_'proc)"
   apply (cinit' lift: ntfnPtr_' tcbptr_')
    apply (rule ccorres_symb_exec_l [OF _ get_ntfn_inv' _ empty_fail_getNotification])
-    apply (rule_tac P="invs' and ko_at' rv ntfnptr" and P'=UNIV
-                in ccorres_split_nothrow_novcg)
+    apply (rule_tac P="invs' and ko_at' ntfn ntfnptr" and P'=UNIV
+             in ccorres_split_nothrow_novcg)
         apply (rule ccorres_from_vcg[where rrel=dc and xf=xfdc])
         apply (rule allI, rule conseqPre, vcg)
         apply (clarsimp simp: option_to_ptr_def option_to_0_def)
@@ -697,7 +697,7 @@ lemma doUnbindNotification_ccorres:
               apply (rule cpspace_relation_ntfn_update_ntfn, assumption+)
                apply (clarsimp simp: cnotification_relation_def Let_def
                                      mask_def [where n=2] NtfnState_Waiting_def)
-               apply (case_tac "ntfnObj rv", ((simp add: option_to_ctcb_ptr_def)+)[4])
+               apply (case_tac "ntfnObj ntfn", ((simp add: option_to_ctcb_ptr_def)+)[4])
              subgoal by (simp add: carch_state_relation_def typ_heap_simps')
             subgoal by (simp add: cmachine_state_relation_def)
            subgoal by (simp add: h_t_valid_clift_Some_iff)
@@ -812,13 +812,13 @@ lemma unbindMaybeNotification_ccorres:
   apply (cinit lift: ntfnPtr_')
    apply (rule ccorres_symb_exec_l [OF _ get_ntfn_inv' _ empty_fail_getNotification])
     apply (rule ccorres_rhs_assoc2)
-    apply (rule_tac P="ntfnBoundTCB rv \<noteq> None \<longrightarrow>
-                             option_to_ctcb_ptr (ntfnBoundTCB rv) \<noteq> NULL"
-                     in ccorres_gen_asm)
+    apply (rule_tac P="ntfnBoundTCB ntfn \<noteq> None \<longrightarrow>
+                         option_to_ctcb_ptr (ntfnBoundTCB ntfn) \<noteq> NULL"
+             in ccorres_gen_asm)
     apply (rule_tac xf'=boundTCB_'
-                           and val="option_to_ctcb_ptr (ntfnBoundTCB rv)"
-                           and R="ko_at' rv ntfnptr and valid_bound_tcb' (ntfnBoundTCB rv)"
-                            in ccorres_symb_exec_r_known_rv_UNIV[where R'=UNIV])
+                and val="option_to_ctcb_ptr (ntfnBoundTCB ntfn)"
+                and R="ko_at' ntfn ntfnptr and valid_bound_tcb' (ntfnBoundTCB ntfn)"
+             in ccorres_symb_exec_r_known_rv_UNIV[where R'=UNIV])
        apply vcg
        apply clarsimp
        apply (erule cmap_relationE1[OF cmap_relation_ntfn])

--- a/proof/crefine/ARM_HYP/Invoke_C.thy
+++ b/proof/crefine/ARM_HYP/Invoke_C.thy
@@ -65,7 +65,7 @@ lemma setDomain_ccorres:
            apply (ctac add: tcbSchedEnqueue_ccorres)
           apply (rule ccorres_return_Skip)
          apply (simp add: when_def)
-         apply (rule_tac R="\<lambda>s. rv = ksCurThread s"
+         apply (rule_tac R="\<lambda>s. curThread = ksCurThread s"
                     in ccorres_cond2)
            apply (clarsimp simp: rf_sr_ksCurThread)
           apply (ctac add: rescheduleRequired_ccorres)
@@ -76,14 +76,16 @@ lemma setDomain_ccorres:
       apply simp
       apply wp
      apply (rule_tac Q="\<lambda>_. all_invs_but_sch_extra and tcb_at' t and sch_act_simple
-                        and (\<lambda>s. rv = ksCurThread s)" in hoare_strengthen_post)
+                            and (\<lambda>s. curThread = ksCurThread s)"
+              in hoare_strengthen_post)
       apply (wp threadSet_all_invs_but_sch_extra)
      apply (clarsimp simp: valid_pspace_valid_objs' st_tcb_at_def[symmetric]
                            sch_act_simple_def st_tcb_at'_def weak_sch_act_wf_def
                     split: if_splits)
     apply (simp add: guard_is_UNIV_def)
    apply (rule_tac Q="\<lambda>_. invs' and tcb_at' t and sch_act_simple
-      and (\<lambda>s. rv = ksCurThread s \<and> (\<forall>p. t \<notin> set (ksReadyQueues s p)))" in hoare_strengthen_post)
+                          and (\<lambda>s. curThread = ksCurThread s \<and> (\<forall>p. t \<notin> set (ksReadyQueues s p)))"
+            in hoare_strengthen_post)
     apply (wp weak_sch_act_wf_lift_linear tcbSchedDequeue_not_queued
               tcbSchedDequeue_not_in_queue hoare_vcg_imp_lift hoare_vcg_all_lift)
    apply (clarsimp simp: invs'_def valid_pspace'_def valid_state'_def)
@@ -638,7 +640,7 @@ lemma decodeCNodeInvocation_ccorres:
                        del: Collect_const cong: call_ignore_cong)
            apply (rule ccorres_split_throws)
             apply (rule ccorres_rhs_assoc | csymbr)+
-            apply (simp add: invocationCatch_use_injection_handler[symmetric, unfolded o_def]
+            apply (simp add: invocationCatch_use_injection_handler[symmetric]
                         del: Collect_const cong: call_ignore_cong)
             apply (rule ccorres_Cond_rhs_Seq)
              apply (simp add:if_P del: Collect_const)
@@ -1107,7 +1109,7 @@ lemma decodeCNodeInvocation_ccorres:
             apply (simp add: throwError_def return_def exception_defs
                              syscall_error_rel_def syscall_error_to_H_cases)
             apply clarsimp
-           apply (simp add: invocationCatch_use_injection_handler[symmetric, unfolded o_def]
+           apply (simp add: invocationCatch_use_injection_handler[symmetric]
                        del: Collect_const)
            apply csymbr
            apply (simp add: interpret_excaps_test_null excaps_map_def

--- a/proof/crefine/ARM_HYP/Ipc_C.thy
+++ b/proof/crefine/ARM_HYP/Ipc_C.thy
@@ -3416,9 +3416,10 @@ proof -
      apply (rule ccorres_symb_exec_r)
        apply csymbr
        apply (rename_tac "lngth")
-       apply (simp add: mi_from_H_def mapME_def del: Collect_const cong: bind_apply_cong)
+       apply (unfold mapME_def)[1]
+       apply (simp add: mi_from_H_def del: Collect_const)
        apply (rule ccorres_symb_exec_l)
-          apply (rule_tac P="length rv = unat word2" in ccorres_gen_asm)
+          apply (rule_tac P="length xs = unat word2" in ccorres_gen_asm)
           apply csymbr
           apply (rule ccorres_rhs_assoc2)
           apply (rule ccorres_add_returnOk2,
@@ -3428,7 +3429,7 @@ proof -
                         and   Q="UNIV"
                         and   F="\<lambda>n s. valid_pspace' s \<and> tcb_at' thread s \<and>
                                        (case buffer of Some x \<Rightarrow> valid_ipc_buffer_ptr' x | _ \<Rightarrow> \<top>) s \<and>
-                                        (\<forall>m < length rv. user_word_at (rv ! m)
+                                        (\<forall>m < length xs. user_word_at (xs ! m)
                                                       (x2 + (of_nat m + (msgMaxLength + 2)) * 4) s)"
                            in ccorres_sequenceE_while')
                    apply (simp add: split_def)
@@ -3438,7 +3439,7 @@ proof -
                       apply (rule_tac xf'=cptr_' in ccorres_abstract, ceqv)
                       apply (ctac add: capFaultOnFailure_ccorres
                                 [OF lookupSlotForThread_ccorres'])
-                         apply (rule_tac P="is_aligned rva 4" in ccorres_gen_asm)
+                         apply (rule_tac P="is_aligned rv 4" in ccorres_gen_asm)
                          apply (simp add: ccorres_cond_iffs liftE_bindE)
                          apply (rule ccorres_symb_exec_l [OF _ _ _ empty_fail_getSlotCap])
                            apply (rule_tac P'="UNIV \<inter> {s. excaps_map ys
@@ -3459,7 +3460,7 @@ proof -
                         apply (clarsimp simp: ccorres_cond_iffs)
                         apply (rule_tac  P= \<top>
                                  and P'="{x. errstate x= lu_ret___struct_lookupSlot_raw_ret_C \<and>
-                                             rv' = (rv ! length ys)}"
+                                             rv' = (xs ! length ys)}"
                                    in ccorres_from_vcg_throws)
                         apply (rule allI, rule conseqPre, vcg)
                         apply (clarsimp simp: throwError_def return_def)
@@ -3500,8 +3501,7 @@ proof -
              apply ceqv
             apply (simp del: Collect_const)
             apply (rule_tac P'="{s. snd rv'=?curr s}"
-                    and P="\<lambda>s. length rva = length rv
-                                \<and> (\<forall>x \<in> set rva. snd x \<noteq> 0)"
+                        and P="\<lambda>s. length rv = length xs \<and> (\<forall>x \<in> set rv. snd x \<noteq> 0)"
                     in ccorres_from_vcg_throws)
             apply (rule allI, rule conseqPre, vcg)
             apply (clarsimp simp: returnOk_def return_def
@@ -3809,7 +3809,7 @@ lemma Arch_getSanitiseRegisterInfo_ccorres:
   apply (cinit' lift: thread_' simp: getSanitiseRegisterInfo_def2)
    apply (rule ccorres_move_c_guard_tcb)
    apply (rule ccorres_pre_archThreadGet)
-  apply (rule_tac P="\<lambda>s. rv \<noteq> Some 0" in ccorres_cross_over_guard)
+  apply (rule_tac P="\<lambda>s. v \<noteq> Some 0" in ccorres_cross_over_guard)
    apply (rule ccorres_return_C, simp+)
   apply (clarsimp simp: typ_heap_simps ctcb_relation_def carch_tcb_relation_def)
   apply (rule conjI)
@@ -3850,7 +3850,7 @@ apply (ctac(no_vcg) add: Arch_getSanitiseRegisterInfo_ccorres)
      apply (rule ccorres_rhs_assoc2)
      apply (simp add: MessageID_Exception_def)
      apply ccorres_rewrite
-     apply (subst bind_return_unit)
+     apply (rule ccorres_add_return2)
      apply (rule ccorres_split_nothrow_novcg)
          apply (rule ccorres_zipWithM_x_while)
              apply clarsimp

--- a/proof/crefine/ARM_HYP/Recycle_C.thy
+++ b/proof/crefine/ARM_HYP/Recycle_C.thy
@@ -922,8 +922,8 @@ lemma cancelBadgedSends_ccorres:
               cong: list.case_cong Structures_H.endpoint.case_cong call_ignore_cong
                del: Collect_const)
    apply (rule ccorres_pre_getEndpoint)
-   apply (rule_tac R="ko_at' rv ptr" and xf'="ret__unsigned_'"
-               and val="case rv of RecvEP q \<Rightarrow> scast EPState_Recv | IdleEP \<Rightarrow> scast EPState_Idle
+   apply (rule_tac R="ko_at' ep ptr" and xf'="ret__unsigned_'"
+               and val="case ep of RecvEP q \<Rightarrow> scast EPState_Recv | IdleEP \<Rightarrow> scast EPState_Idle
                                 | SendEP q \<Rightarrow> scast EPState_Send"
                in ccorres_symb_exec_r_known_rv_UNIV[where R'=UNIV])
       apply vcg
@@ -943,12 +943,12 @@ lemma cancelBadgedSends_ccorres:
                 del: Collect_const cong: call_ignore_cong)
     apply (rule ccorres_rhs_assoc)+
     apply (csymbr, csymbr)
-    apply (drule_tac s = rv in sym, simp only:)
-    apply (rule_tac P="ko_at' rv ptr and invs'" in ccorres_cross_over_guard)
+    apply (drule_tac s = ep in sym, simp only:)
+    apply (rule_tac P="ko_at' ep ptr and invs'" in ccorres_cross_over_guard)
     apply (rule ccorres_symb_exec_r)
       apply (rule ccorres_rhs_assoc2, rule ccorres_rhs_assoc2)
       apply (rule ccorres_split_nothrow[where r'=dc and xf'=xfdc, OF _ ceqv_refl])
-         apply (rule_tac P="ko_at' rv ptr"
+         apply (rule_tac P="ko_at' ep ptr"
                     in ccorres_from_vcg[where P'=UNIV])
          apply (rule allI, rule conseqPre, vcg)
          apply clarsimp
@@ -1058,7 +1058,7 @@ lemma cancelBadgedSends_ccorres:
               subgoal by (simp add: rf_sr_def)
              apply simp
             apply ceqv
-           apply (rule_tac P="ret__unsigned=blockingIPCBadge rva" in ccorres_gen_asm2)
+           apply (rule_tac P="ret__unsigned=blockingIPCBadge rv" in ccorres_gen_asm2)
            apply (rule ccorres_if_bind, rule ccorres_if_lhs)
             apply (simp add: bind_assoc)
             apply (rule ccorres_rhs_assoc)+

--- a/proof/crefine/ARM_HYP/SyscallArgs_C.thy
+++ b/proof/crefine/ARM_HYP/SyscallArgs_C.thy
@@ -784,11 +784,13 @@ lemma lookupIPCBuffer_ccorres[corres]:
      apply (rule ccorres_move_array_assertion_tcb_ctes
                  ccorres_move_c_guard_tcb_ctes)+
      apply (ctac (no_vcg))
+       apply (rename_tac bufferCap bufferCap')
        apply csymbr
-       apply (rule_tac b="isArchObjectCap rva \<and> isPageCap (capCap rva)" in ccorres_case_bools')
+       apply (rule_tac b="isArchObjectCap bufferCap \<and> isPageCap (capCap bufferCap)"
+                in ccorres_case_bools')
         apply simp
         apply (rule ccorres_symb_exec_r)
-          apply (rule_tac b="capVPSize (capCap rva) \<noteq> ARMSmallPage" in ccorres_case_bools')
+          apply (rule_tac b="capVPSize (capCap bufferCap) \<noteq> ARMSmallPage" in ccorres_case_bools')
            apply (rule ccorres_cond_true_seq)
            apply (rule ccorres_rhs_assoc)+
            apply csymbr
@@ -796,7 +798,7 @@ lemma lookupIPCBuffer_ccorres[corres]:
            apply (rule ccorres_cond_false_seq)
            apply (simp(no_asm))
            apply csymbr
-           apply (rule_tac b="isDeviceCap rva" in ccorres_case_bools')
+           apply (rule_tac b="isDeviceCap bufferCap" in ccorres_case_bools')
             apply (rule ccorres_cond_true_seq)
             apply (rule ccorres_from_vcg_split_throws[where P=\<top> and P'=UNIV])
              apply vcg
@@ -850,7 +852,7 @@ lemma lookupIPCBuffer_ccorres[corres]:
           apply (rule ccorres_cond_false_seq)
           apply (simp(no_asm))
           apply csymbr
-            apply (rule_tac b="isDeviceCap rva" in ccorres_case_bools')
+            apply (rule_tac b="isDeviceCap bufferCap" in ccorres_case_bools')
              apply (rule ccorres_cond_true_seq)
              apply (rule ccorres_from_vcg_split_throws[where P=\<top> and P'=UNIV])
               apply vcg

--- a/proof/crefine/ARM_HYP/Syscall_C.thy
+++ b/proof/crefine/ARM_HYP/Syscall_C.thy
@@ -1315,7 +1315,7 @@ lemma handleRecv_ccorres:
 
           apply (simp add: liftE_bind)
           apply (ctac)
-            apply (rule_tac P="\<lambda>s. ksCurThread s = rv" in ccorres_cross_over_guard)
+            apply (rule_tac P="\<lambda>s. ksCurThread s = thread" in ccorres_cross_over_guard)
             apply (ctac add: receiveIPC_ccorres)
 
            apply (wp deleteCallerCap_ksQ_ct' hoare_vcg_all_lift)

--- a/proof/crefine/ARM_HYP/Tcb_C.thy
+++ b/proof/crefine/ARM_HYP/Tcb_C.thy
@@ -437,7 +437,7 @@ lemma setPriority_ccorres:
   apply (frule (1) valid_objs'_maxDomain[where t=t])
   apply (frule (1) valid_objs'_maxPriority[where t=t])
   apply simp
-done
+  done
 
 lemma setMCPriority_ccorres:
   "ccorres dc xfdc
@@ -1200,10 +1200,10 @@ lemma invokeTCB_CopyRegisters_ccorres:
              apply (simp add: word_bits_def frame_gp_registers_convs n_gpRegisters_def)
             apply simp
            apply (rule ccorres_pre_getCurThread)
+           apply (rename_tac thread)
            apply (ctac add: postModifyRegisters_ccorres[simplified])
              apply (rule ccorres_split_nothrow_novcg_dc)
-                apply (rule_tac R="\<lambda>s. rvd = ksCurThread s"
-                             in ccorres_when)
+                apply (rule_tac R="\<lambda>s. thread = ksCurThread s" in ccorres_when)
                  apply (clarsimp simp: rf_sr_ksCurThread)
                 apply clarsimp
                 apply (ctac (no_vcg) add: rescheduleRequired_ccorres)
@@ -1624,8 +1624,7 @@ lemma invokeTCB_WriteRegisters_ccorres[where S=UNIV]:
                      apply simp
                     apply (rule ceqv_refl)
                    apply (rule ccorres_split_nothrow_novcg_dc)
-                      apply (rule_tac R="\<lambda>s. rv = ksCurThread s"
-                                     in ccorres_when)
+                      apply (rule_tac R="\<lambda>s. self = ksCurThread s" in ccorres_when)
                       apply (clarsimp simp: rf_sr_ksCurThread)
                       apply clarsimp
                       apply (ctac (no_vcg) add: rescheduleRequired_ccorres)
@@ -2100,7 +2099,7 @@ shows
                         apply (clarsimp simp: min_def iffD2 [OF mask_eq_iff_w2p] word_size
                                               word_less_nat_alt
                                       split: if_split_asm dest!: word_unat.Rep_inverse')
-                       apply simp
+                       apply (simp add: pred_conj_def)
                        apply (wp mapM_x_wp' sch_act_wf_lift valid_queues_lift static_imp_wp
                                  tcb_in_cur_domain'_lift)
                       apply (simp add: n_frameRegisters_def n_msgRegisters_def
@@ -2223,7 +2222,8 @@ lemma decodeReadRegisters_ccorres:
        apply (simp add: liftE_bindE bind_assoc)
        apply (rule ccorres_pre_getCurThread)
        apply (rule ccorres_cond_seq)
-       apply (rule_tac R="\<lambda>s. rv = ksCurThread s \<and> isThreadCap cp" and P="\<lambda>s. capTCBPtr cp = rv" in ccorres_cond_both)
+       apply (rule_tac R="\<lambda>s. self = ksCurThread s \<and> isThreadCap cp" and P="\<lambda>s. capTCBPtr cp = self"
+                in ccorres_cond_both)
          apply clarsimp
          apply (frule rf_sr_ksCurThread)
          apply clarsimp
@@ -2234,13 +2234,13 @@ lemma decodeReadRegisters_ccorres:
           apply (drule_tac t="ksCurThread s" in sym)
           apply simp
          apply simp
-        apply (rule_tac P="capTCBPtr cp = rv" in ccorres_gen_asm)
+        apply (rule_tac P="capTCBPtr cp = self" in ccorres_gen_asm)
         apply simp
         apply (simp add: throwError_bind invocationCatch_def
                     cong: StateSpace.state.fold_congs globals.fold_congs)
         apply (rule syscall_error_throwError_ccorres_n)
         apply (simp add: syscall_error_to_H_cases)
-       apply (rule_tac P="capTCBPtr cp \<noteq> rv" in ccorres_gen_asm)
+       apply (rule_tac P="capTCBPtr cp \<noteq> self" in ccorres_gen_asm)
        apply (simp add: returnOk_bind)
        apply (simp add: ccorres_invocationCatch_Inr del: Collect_const)
        apply (ctac add: setThreadState_ccorres)
@@ -2334,7 +2334,8 @@ lemma decodeWriteRegisters_ccorres:
        apply (simp add: liftE_bindE bind_assoc)
        apply (rule ccorres_pre_getCurThread)
        apply (rule ccorres_cond_seq)
-       apply (rule_tac R="\<lambda>s. rv = ksCurThread s \<and> isThreadCap cp" and P="\<lambda>s. capTCBPtr cp = rv" in ccorres_cond_both)
+       apply (rule_tac R="\<lambda>s. self = ksCurThread s \<and> isThreadCap cp" and P="\<lambda>s. capTCBPtr cp = self"
+                in ccorres_cond_both)
          apply clarsimp
          apply (frule rf_sr_ksCurThread)
          apply clarsimp
@@ -2345,13 +2346,13 @@ lemma decodeWriteRegisters_ccorres:
           apply (drule_tac t="ksCurThread s" in sym)
           apply simp
          apply simp
-        apply (rule_tac P="capTCBPtr cp = rv" in ccorres_gen_asm)
+        apply (rule_tac P="capTCBPtr cp = self" in ccorres_gen_asm)
         apply simp
         apply (simp add: throwError_bind invocationCatch_def
                     cong: StateSpace.state.fold_congs globals.fold_congs)
         apply (rule syscall_error_throwError_ccorres_n)
         apply (simp add: syscall_error_to_H_cases)
-       apply (rule_tac P="capTCBPtr cp \<noteq> rv" in ccorres_gen_asm)
+       apply (rule_tac P="capTCBPtr cp \<noteq> self" in ccorres_gen_asm)
        apply (simp add: returnOk_bind)
        apply (simp add: ccorres_invocationCatch_Inr del: Collect_const)
        apply (ctac add: setThreadState_ccorres)
@@ -2660,7 +2661,7 @@ lemma slotCapLongRunningDelete_ccorres:
    apply (simp add: case_Null_If del: Collect_const)
    apply (rule ccorres_pre_getCTE)
    apply (rule ccorres_move_c_guard_cte)
-   apply (rule_tac P="cte_wp_at' ((=) rv) slot"
+   apply (rule_tac P="cte_wp_at' ((=) cte) slot"
                 in ccorres_cross_over_guard)
    apply (rule ccorres_symb_exec_r)
      apply (rule ccorres_if_lhs)
@@ -2681,7 +2682,7 @@ lemma slotCapLongRunningDelete_ccorres:
         apply vcg
        apply (simp del: Collect_const)
        apply (rule ccorres_move_c_guard_cte)
-       apply (rule_tac P="cte_wp_at' ((=) rv) slot"
+       apply (rule_tac P="cte_wp_at' ((=) cte) slot"
                   in  ccorres_from_vcg_throws[where P'=UNIV])
        apply (rule allI, rule conseqPre, vcg)
        apply (clarsimp simp: cte_wp_at_ctes_of return_def)
@@ -3801,7 +3802,7 @@ lemma bindNotification_ccorres:
    (Call bindNotification_'proc)"
   apply (cinit lift: tcb_' ntfnPtr_' simp: bindNotification_def)
    apply (rule ccorres_symb_exec_l [OF _ get_ntfn_inv' _ empty_fail_getNotification])
-    apply (rule_tac P="invs' and ko_at' rv ntfnptr and tcb_at' tcb" and P'=UNIV
+    apply (rule_tac P="invs' and ko_at' ntfn ntfnptr and tcb_at' tcb" and P'=UNIV
                     in ccorres_split_nothrow_novcg)
         apply (rule ccorres_from_vcg[where rrel=dc and xf=xfdc])
         apply (rule allI, rule conseqPre, vcg)
@@ -3821,7 +3822,7 @@ lemma bindNotification_ccorres:
               apply (rule cpspace_relation_ntfn_update_ntfn, assumption+)
                apply (clarsimp simp: cnotification_relation_def Let_def
                                      mask_def [where n=2] NtfnState_Waiting_def)
-               apply (case_tac "ntfnObj rv")
+               apply (case_tac "ntfnObj ntfn")
                  apply (auto simp: option_to_ctcb_ptr_def obj_at'_def objBits_simps projectKOs
                                    bindNTFN_alignment_junk)[4]
              apply (simp add: carch_state_relation_def typ_heap_simps')
@@ -3899,7 +3900,7 @@ lemma decodeUnbindNotification_ccorres:
    apply (rule ccorres_Guard_Seq)
    apply (simp add: liftE_bindE bind_assoc)
    apply (rule ccorres_pre_getBoundNotification)
-   apply (rule_tac P="\<lambda>s. rv \<noteq> Some 0" in ccorres_cross_over_guard)
+   apply (rule_tac P="\<lambda>s. ntfn \<noteq> Some 0" in ccorres_cross_over_guard)
    apply (simp add: bindE_bind_linearise)
    apply wpc
     apply (simp add: bindE_bind_linearise[symmetric]

--- a/proof/crefine/RISCV64/Arch_C.thy
+++ b/proof/crefine/RISCV64/Arch_C.thy
@@ -446,7 +446,7 @@ shows
      apply (rule ccorres_rhs_assoc2)
      apply (rule ccorres_abstract_cleanup)
      apply (rule ccorres_symb_exec_l)
-        apply (rule_tac P = "rva = (capability.UntypedCap isdev frame pageBits idx)" in ccorres_gen_asm)
+        apply (rule_tac P = "rv = (capability.UntypedCap isdev frame pageBits idx)" in ccorres_gen_asm)
         apply (simp add: hrs_htd_update del:fun_upd_apply)
         apply (rule ccorres_split_nothrow)
 

--- a/proof/crefine/RISCV64/CSpace_C.thy
+++ b/proof/crefine/RISCV64/CSpace_C.thy
@@ -746,7 +746,7 @@ lemma update_freeIndex':
     show ?thesis
       apply (cinit lift: cap_ptr_' v64_')
        apply (rule ccorres_pre_getCTE)
-       apply (rule_tac P="\<lambda>s. ctes_of s srcSlot = Some rv \<and> (\<exists>i. cteCap rv = UntypedCap d p sz i)"
+       apply (rule_tac P="\<lambda>s. ctes_of s srcSlot = Some cte \<and> (\<exists>i. cteCap cte = UntypedCap d p sz i)"
                 in ccorres_from_vcg[where P' = UNIV])
        apply (rule allI)
        apply (rule conseqPre)
@@ -2388,7 +2388,7 @@ lemma capSwapForDelete_ccorres:
   \<comment> \<open>--- instruction: when (slot1 \<noteq> slot2) \<dots> / IF Ptr slot1 = Ptr slot2 THEN \<dots>\<close>
    apply (simp add:when_def)
    apply (rule ccorres_if_cond_throws2 [where Q = \<top> and Q' = \<top>])
-      apply (case_tac "slot1=slot2", simp+)
+      apply (case_tac "slot1=slot2"; simp)
      apply (rule ccorres_return_void_C)
 
   \<comment> \<open>***Main goal***\<close>

--- a/proof/crefine/RISCV64/Finalise_C.thy
+++ b/proof/crefine/RISCV64/Finalise_C.thy
@@ -296,10 +296,10 @@ lemma cancelAllIPC_ccorres:
   apply (cinit lift: epptr_')
    apply (rule ccorres_symb_exec_l [OF _ getEndpoint_inv _ empty_fail_getEndpoint])
     apply (rule_tac xf'=ret__unsigned_longlong_'
-                and val="case rv of IdleEP \<Rightarrow> scast EPState_Idle
+                and val="case ep of IdleEP \<Rightarrow> scast EPState_Idle
                             | RecvEP _ \<Rightarrow> scast EPState_Recv | SendEP _ \<Rightarrow> scast EPState_Send"
-                and R="ko_at' rv epptr"
-                 in ccorres_symb_exec_r_known_rv_UNIV[where R'=UNIV])
+                and R="ko_at' ep epptr"
+             in ccorres_symb_exec_r_known_rv_UNIV[where R'=UNIV])
        apply vcg
        apply clarsimp
        apply (erule cmap_relationE1 [OF cmap_relation_ep])
@@ -308,8 +308,8 @@ lemma cancelAllIPC_ccorres:
        apply (simp add: cendpoint_relation_def Let_def
                  split: endpoint.split_asm)
       apply ceqv
-     apply (rule_tac A="invs' and ko_at' rv epptr"
-                  in ccorres_guard_imp2[where A'=UNIV])
+     apply (rule_tac A="invs' and ko_at' ep epptr"
+              in ccorres_guard_imp2[where A'=UNIV])
       apply wpc
         apply (rename_tac list)
         apply (simp add: endpoint_state_defs
@@ -425,10 +425,10 @@ lemma cancelAllSignals_ccorres:
   apply (cinit lift: ntfnPtr_')
    apply (rule ccorres_symb_exec_l [OF _ get_ntfn_inv' _ empty_fail_getNotification])
     apply (rule_tac xf'=ret__unsigned_longlong_'
-                and val="case ntfnObj rv of IdleNtfn \<Rightarrow> scast NtfnState_Idle
+                and val="case ntfnObj ntfn of IdleNtfn \<Rightarrow> scast NtfnState_Idle
                             | ActiveNtfn _ \<Rightarrow> scast NtfnState_Active | WaitingNtfn _ \<Rightarrow> scast NtfnState_Waiting"
-                and R="ko_at' rv ntfnptr"
-                 in ccorres_symb_exec_r_known_rv_UNIV[where R'=UNIV])
+                and R="ko_at' ntfn ntfnptr"
+             in ccorres_symb_exec_r_known_rv_UNIV[where R'=UNIV])
        apply vcg
        apply clarsimp
        apply (erule cmap_relationE1 [OF cmap_relation_ntfn])
@@ -437,8 +437,8 @@ lemma cancelAllSignals_ccorres:
        apply (simp add: cnotification_relation_def Let_def
                  split: ntfn.split_asm)
       apply ceqv
-     apply (rule_tac A="invs' and ko_at' rv ntfnptr"
-                  in ccorres_guard_imp2[where A'=UNIV])
+     apply (rule_tac A="invs' and ko_at' ntfn ntfnptr"
+              in ccorres_guard_imp2[where A'=UNIV])
       apply wpc
         apply (simp add: notification_state_defs ccorres_cond_iffs)
         apply (rule ccorres_return_Skip)
@@ -453,8 +453,8 @@ lemma cancelAllSignals_ccorres:
       apply csymbr
       apply (rule ccorres_rhs_assoc2, rule ccorres_rhs_assoc2)
       apply (rule_tac r'=dc and xf'=xfdc in ccorres_split_nothrow)
-          apply (rule_tac P="ko_at' rv ntfnptr and invs'"
-                    in ccorres_from_vcg[where P'=UNIV])
+          apply (rule_tac P="ko_at' ntfn ntfnptr and invs'"
+                   in ccorres_from_vcg[where P'=UNIV])
           apply (rule allI, rule conseqPre, vcg)
           apply clarsimp
           apply (rule_tac x=ntfnptr in cmap_relationE1 [OF cmap_relation_ntfn], assumption)
@@ -698,8 +698,8 @@ lemma doUnbindNotification_ccorres:
    (Call doUnbindNotification_'proc)"
   apply (cinit' lift: ntfnPtr_' tcbptr_')
    apply (rule ccorres_symb_exec_l [OF _ get_ntfn_inv' _ empty_fail_getNotification])
-    apply (rule_tac P="invs' and ko_at' rv ntfnptr" and P'=UNIV
-                in ccorres_split_nothrow_novcg)
+    apply (rule_tac P="invs' and ko_at' ntfn ntfnptr" and P'=UNIV
+             in ccorres_split_nothrow_novcg)
         apply (rule ccorres_from_vcg[where rrel=dc and xf=xfdc])
         apply (rule allI, rule conseqPre, vcg)
         apply (clarsimp simp: option_to_ptr_def option_to_0_def)
@@ -718,7 +718,7 @@ lemma doUnbindNotification_ccorres:
               apply (rule cpspace_relation_ntfn_update_ntfn, assumption+)
                apply (clarsimp simp: cnotification_relation_def Let_def
                                      mask_def [where n=2] NtfnState_Waiting_def)
-               apply (case_tac "ntfnObj rv", ((simp add: option_to_ctcb_ptr_def)+)[4])
+               apply (case_tac "ntfnObj ntfn", ((simp add: option_to_ctcb_ptr_def)+)[4])
              subgoal by (simp add: carch_state_relation_def)
             subgoal by (simp add: cmachine_state_relation_def)
            subgoal by (simp add: h_t_valid_clift_Some_iff)
@@ -832,13 +832,13 @@ lemma unbindMaybeNotification_ccorres:
   apply (cinit lift: ntfnPtr_')
    apply (rule ccorres_symb_exec_l [OF _ get_ntfn_inv' _ empty_fail_getNotification])
     apply (rule ccorres_rhs_assoc2)
-    apply (rule_tac P="ntfnBoundTCB rv \<noteq> None \<longrightarrow>
-                             option_to_ctcb_ptr (ntfnBoundTCB rv) \<noteq> NULL"
-                     in ccorres_gen_asm)
+    apply (rule_tac P="ntfnBoundTCB ntfn \<noteq> None \<longrightarrow>
+                         option_to_ctcb_ptr (ntfnBoundTCB ntfn) \<noteq> NULL"
+             in ccorres_gen_asm)
     apply (rule_tac xf'=boundTCB_'
-                           and val="option_to_ctcb_ptr (ntfnBoundTCB rv)"
-                           and R="ko_at' rv ntfnptr and valid_bound_tcb' (ntfnBoundTCB rv)"
-                            in ccorres_symb_exec_r_known_rv_UNIV[where R'=UNIV])
+                and val="option_to_ctcb_ptr (ntfnBoundTCB ntfn)"
+                and R="ko_at' ntfn ntfnptr and valid_bound_tcb' (ntfnBoundTCB ntfn)"
+             in ccorres_symb_exec_r_known_rv_UNIV[where R'=UNIV])
        apply vcg
        apply clarsimp
        apply (erule cmap_relationE1[OF cmap_relation_ntfn])

--- a/proof/crefine/RISCV64/Invoke_C.thy
+++ b/proof/crefine/RISCV64/Invoke_C.thy
@@ -66,7 +66,7 @@ lemma setDomain_ccorres:
            apply (ctac add: tcbSchedEnqueue_ccorres)
           apply (rule ccorres_return_Skip)
          apply (simp add: when_def)
-         apply (rule_tac R="\<lambda>s. rv = ksCurThread s"
+         apply (rule_tac R="\<lambda>s. curThread = ksCurThread s"
                     in ccorres_cond2)
            apply (clarsimp simp: rf_sr_ksCurThread)
           apply (ctac add: rescheduleRequired_ccorres)
@@ -77,14 +77,16 @@ lemma setDomain_ccorres:
       apply simp
       apply wp
      apply (rule_tac Q="\<lambda>_. all_invs_but_sch_extra and tcb_at' t and sch_act_simple
-                        and (\<lambda>s. rv = ksCurThread s)" in hoare_strengthen_post)
+                            and (\<lambda>s. curThread = ksCurThread s)"
+              in hoare_strengthen_post)
       apply (wp threadSet_all_invs_but_sch_extra)
      apply (clarsimp simp: valid_pspace_valid_objs' st_tcb_at_def[symmetric]
                            sch_act_simple_def st_tcb_at'_def weak_sch_act_wf_def
                     split: if_splits)
     apply (simp add: guard_is_UNIV_def)
    apply (rule_tac Q="\<lambda>_. invs' and tcb_at' t and sch_act_simple
-      and (\<lambda>s. rv = ksCurThread s \<and> (\<forall>p. t \<notin> set (ksReadyQueues s p)))" in hoare_strengthen_post)
+                          and (\<lambda>s. curThread = ksCurThread s \<and> (\<forall>p. t \<notin> set (ksReadyQueues s p)))"
+            in hoare_strengthen_post)
     apply (wp weak_sch_act_wf_lift_linear tcbSchedDequeue_not_queued
               tcbSchedDequeue_not_in_queue hoare_vcg_imp_lift hoare_vcg_all_lift)
    apply (clarsimp simp: invs'_def valid_pspace'_def valid_state'_def)
@@ -629,7 +631,7 @@ lemma decodeCNodeInvocation_ccorres:
                        del: Collect_const cong: call_ignore_cong)
            apply (rule ccorres_split_throws)
             apply (rule ccorres_rhs_assoc | csymbr)+
-            apply (simp add: invocationCatch_use_injection_handler[symmetric, unfolded o_def]
+            apply (simp add: invocationCatch_use_injection_handler[symmetric]
                         del: Collect_const cong: call_ignore_cong)
             apply (rule ccorres_Cond_rhs_Seq)
              apply (simp add:if_P del: Collect_const)
@@ -1099,7 +1101,7 @@ lemma decodeCNodeInvocation_ccorres:
             apply (simp add: throwError_def return_def exception_defs
                              syscall_error_rel_def syscall_error_to_H_cases)
             apply clarsimp
-           apply (simp add: invocationCatch_use_injection_handler[symmetric, unfolded o_def]
+           apply (simp add: invocationCatch_use_injection_handler[symmetric]
                        del: Collect_const)
            apply csymbr
            apply (simp add: interpret_excaps_test_null excaps_map_def

--- a/proof/crefine/RISCV64/Ipc_C.thy
+++ b/proof/crefine/RISCV64/Ipc_C.thy
@@ -3171,9 +3171,10 @@ proof -
      apply csymbr
      apply csymbr
      apply (rename_tac "lngth")
-     apply (simp add: mi_from_H_def mapME_def del: Collect_const cong: bind_apply_cong)
+     apply (unfold mapME_def)[1]
+     apply (simp add: mi_from_H_def del: Collect_const)
      apply (rule ccorres_symb_exec_l)
-        apply (rule_tac P="length rv = unat word2" in ccorres_gen_asm)
+        apply (rule_tac P="length xs = unat word2" in ccorres_gen_asm)
         apply (rule ccorres_rhs_assoc2)
         apply (rule ccorres_add_returnOk2,
                rule ccorres_splitE_novcg)
@@ -3182,7 +3183,7 @@ proof -
                        and   Q="UNIV"
                        and   F="\<lambda>n s. valid_pspace' s \<and> tcb_at' thread s \<and>
                                       (case buffer of Some x \<Rightarrow> valid_ipc_buffer_ptr' x | _ \<Rightarrow> \<top>) s \<and>
-                                       (\<forall>m < length rv. user_word_at (rv ! m)
+                                       (\<forall>m < length xs. user_word_at (xs ! m)
                                                      (x2 + (of_nat m + (msgMaxLength + 2)) * 8) s)"
                           in ccorres_sequenceE_while')
                   apply (simp add: split_def)
@@ -3192,7 +3193,7 @@ proof -
                      apply (rule_tac xf'=cptr_' in ccorres_abstract, ceqv)
                      apply (ctac add: capFaultOnFailure_ccorres
                                [OF lookupSlotForThread_ccorres'])
-                        apply (rule_tac P="is_aligned rva 5" in ccorres_gen_asm)
+                        apply (rule_tac P="is_aligned rv 5" in ccorres_gen_asm)
                         apply (simp add: ccorres_cond_iffs liftE_bindE)
                         apply (rule ccorres_symb_exec_l [OF _ _ _ empty_fail_getSlotCap])
                           apply (rule_tac P'="UNIV \<inter> {s. excaps_map ys
@@ -3213,7 +3214,7 @@ proof -
                        apply (clarsimp simp: ccorres_cond_iffs)
                        apply (rule_tac  P= \<top>
                                 and P'="{x. errstate x= lu_ret___struct_lookupSlot_raw_ret_C \<and>
-                                            rv' = (rv ! length ys)}"
+                                            rv' = (xs ! length ys)}"
                                   in ccorres_from_vcg_throws)
                        apply (rule allI, rule conseqPre, vcg)
                        apply (clarsimp simp: throwError_def return_def)
@@ -3254,9 +3255,8 @@ proof -
             apply ceqv
            apply (simp del: Collect_const)
            apply (rule_tac P'="{s. snd rv'=?curr s}"
-                   and P="\<lambda>s. length rva = length rv
-                               \<and> (\<forall>x \<in> set rva. snd x \<noteq> 0)"
-                   in ccorres_from_vcg_throws)
+                       and P="\<lambda>s. length rv = length xs \<and> (\<forall>x \<in> set rv. snd x \<noteq> 0)"
+                    in ccorres_from_vcg_throws)
            apply (rule allI, rule conseqPre, vcg)
            apply (clarsimp simp: returnOk_def return_def
                                  seL4_MsgExtraCapBits_def)
@@ -3591,7 +3591,7 @@ proof -
      apply (rule ccorres_rhs_assoc2)
      apply (simp add: MessageID_Exception_def)
      apply ccorres_rewrite
-     apply (subst bind_return_unit)
+     apply (rule ccorres_add_return2)
      apply (rule ccorres_split_nothrow_novcg)
          apply (rule ccorres_zipWithM_x_while)
              apply clarsimp

--- a/proof/crefine/RISCV64/Recycle_C.thy
+++ b/proof/crefine/RISCV64/Recycle_C.thy
@@ -807,8 +807,8 @@ lemma cancelBadgedSends_ccorres:
               cong: list.case_cong Structures_H.endpoint.case_cong call_ignore_cong
                del: Collect_const)
    apply (rule ccorres_pre_getEndpoint)
-   apply (rule_tac R="ko_at' rv ptr" and xf'="ret__unsigned_longlong_'"
-               and val="case rv of RecvEP q \<Rightarrow> scast EPState_Recv | IdleEP \<Rightarrow> scast EPState_Idle
+   apply (rule_tac R="ko_at' ep ptr" and xf'="ret__unsigned_longlong_'"
+               and val="case ep of RecvEP q \<Rightarrow> scast EPState_Recv | IdleEP \<Rightarrow> scast EPState_Idle
                                 | SendEP q \<Rightarrow> scast EPState_Send"
                in ccorres_symb_exec_r_known_rv_UNIV[where R'=UNIV])
       apply vcg
@@ -828,12 +828,12 @@ lemma cancelBadgedSends_ccorres:
                 del: Collect_const cong: call_ignore_cong)
     apply (rule ccorres_rhs_assoc)+
     apply (csymbr, csymbr)
-    apply (drule_tac s = rv in sym, simp only:)
-    apply (rule_tac P="ko_at' rv ptr and invs'" in ccorres_cross_over_guard)
+    apply (drule_tac s = ep in sym, simp only:)
+    apply (rule_tac P="ko_at' ep ptr and invs'" in ccorres_cross_over_guard)
     apply (rule ccorres_symb_exec_r)
       apply (rule ccorres_rhs_assoc2, rule ccorres_rhs_assoc2)
       apply (rule ccorres_split_nothrow[where r'=dc and xf'=xfdc, OF _ ceqv_refl])
-         apply (rule_tac P="ko_at' rv ptr"
+         apply (rule_tac P="ko_at' ep ptr"
                     in ccorres_from_vcg[where P'=UNIV])
          apply (rule allI, rule conseqPre, vcg)
          apply clarsimp
@@ -944,7 +944,7 @@ lemma cancelBadgedSends_ccorres:
               subgoal by (simp add: rf_sr_def)
              apply simp
             apply ceqv
-           apply (rule_tac P="ret__unsigned_longlong=blockingIPCBadge rva" in ccorres_gen_asm2)
+           apply (rule_tac P="ret__unsigned_longlong=blockingIPCBadge rv" in ccorres_gen_asm2)
            apply (rule ccorres_if_bind, rule ccorres_if_lhs)
             apply (simp add: bind_assoc)
             apply (rule ccorres_rhs_assoc)+

--- a/proof/crefine/RISCV64/SyscallArgs_C.thy
+++ b/proof/crefine/RISCV64/SyscallArgs_C.thy
@@ -777,12 +777,12 @@ lemma lookupIPCBuffer_ccorres[corres]:
      apply (rule ccorres_move_array_assertion_tcb_ctes)
      apply (ctac (no_vcg))
        apply csymbr
-       apply (rule_tac b="isArchObjectCap rva \<and> isFrameCap (capCap rva)" in ccorres_case_bools')
+       apply (rule_tac b="isArchObjectCap rv \<and> isFrameCap (capCap rv)" in ccorres_case_bools')
         apply simp
         apply (rule ccorres_cond_false_seq)
         apply (simp(no_asm))
         apply csymbr
-        apply (rule_tac b="isDeviceCap rva" in ccorres_case_bools')
+        apply (rule_tac b="isDeviceCap rv" in ccorres_case_bools')
          apply (rule ccorres_cond_true_seq)
          apply (rule ccorres_from_vcg_split_throws[where P=\<top> and P'=UNIV])
           apply vcg

--- a/proof/crefine/RISCV64/Syscall_C.thy
+++ b/proof/crefine/RISCV64/Syscall_C.thy
@@ -1255,7 +1255,7 @@ lemma handleRecv_ccorres:
 
           apply (simp add: liftE_bind)
           apply (ctac)
-            apply (rule_tac P="\<lambda>s. ksCurThread s = rv" in ccorres_cross_over_guard)
+            apply (rule_tac P="\<lambda>s. ksCurThread s = thread" in ccorres_cross_over_guard)
             apply (ctac add: receiveIPC_ccorres)
 
            apply (wp deleteCallerCap_ksQ_ct' hoare_vcg_all_lift)

--- a/proof/crefine/RISCV64/Tcb_C.thy
+++ b/proof/crefine/RISCV64/Tcb_C.thy
@@ -444,7 +444,7 @@ lemma setPriority_ccorres:
   apply (frule (1) valid_objs'_maxDomain[where t=t])
   apply (frule (1) valid_objs'_maxPriority[where t=t])
   apply simp
-done
+  done
 
 lemma setMCPriority_ccorres:
   "ccorres dc xfdc
@@ -1228,7 +1228,7 @@ lemma invokeTCB_CopyRegisters_ccorres:
            apply (rule ccorres_pre_getCurThread)
            apply (ctac add: postModifyRegisters_ccorres)
              apply (rule ccorres_split_nothrow_novcg_dc)
-                apply (rule_tac R="\<lambda>s. rvd = ksCurThread s"
+                apply (rule_tac R="\<lambda>s. rvc = ksCurThread s"
                            in ccorres_when)
                  apply (clarsimp simp: rf_sr_ksCurThread)
                 apply clarsimp
@@ -1514,7 +1514,7 @@ lemma asUser_getMRs_rel:
   apply (erule getMRs_rel_context, simp)
    apply (clarsimp simp: obj_at'_real_def ko_wp_at'_def projectKOs)
   apply simp
-done
+  done
 
 
 lemma asUser_sysargs_rel:
@@ -1653,7 +1653,7 @@ lemma invokeTCB_WriteRegisters_ccorres[where S=UNIV]:
                      apply simp
                     apply (rule ceqv_refl)
                    apply (rule ccorres_split_nothrow_novcg_dc)
-                      apply (rule_tac R="\<lambda>s. rv = ksCurThread s"
+                      apply (rule_tac R="\<lambda>s. self = ksCurThread s"
                                   in ccorres_when)
                       apply (clarsimp simp: rf_sr_ksCurThread)
                       apply clarsimp
@@ -2130,7 +2130,7 @@ shows
                         apply (clarsimp simp: min_def iffD2 [OF mask_eq_iff_w2p] word_size
                                               word_less_nat_alt
                                       split: if_split_asm dest!: word_unat.Rep_inverse')
-                       apply simp
+                       apply (simp add: pred_conj_def)
                        apply (wp mapM_x_wp' sch_act_wf_lift valid_queues_lift static_imp_wp
                                  tcb_in_cur_domain'_lift)
                       apply (simp add: n_frameRegisters_def n_msgRegisters_def
@@ -2253,7 +2253,8 @@ lemma decodeReadRegisters_ccorres:
        apply (simp add: liftE_bindE bind_assoc)
        apply (rule ccorres_pre_getCurThread)
        apply (rule ccorres_cond_seq)
-       apply (rule_tac R="\<lambda>s. rv = ksCurThread s \<and> isThreadCap cp" and P="\<lambda>s. capTCBPtr cp = rv" in ccorres_cond_both)
+       apply (rule_tac R="\<lambda>s. self = ksCurThread s \<and> isThreadCap cp" and P="\<lambda>s. capTCBPtr cp = self"
+                in ccorres_cond_both)
          apply clarsimp
          apply (frule rf_sr_ksCurThread)
          apply clarsimp
@@ -2264,13 +2265,13 @@ lemma decodeReadRegisters_ccorres:
           apply (drule_tac t="ksCurThread s" in sym)
           apply simp
          apply simp
-        apply (rule_tac P="capTCBPtr cp = rv" in ccorres_gen_asm)
+        apply (rule_tac P="capTCBPtr cp = self" in ccorres_gen_asm)
         apply simp
         apply (simp add: throwError_bind invocationCatch_def
                     cong: StateSpace.state.fold_congs globals.fold_congs)
         apply (rule syscall_error_throwError_ccorres_n)
         apply (simp add: syscall_error_to_H_cases)
-       apply (rule_tac P="capTCBPtr cp \<noteq> rv" in ccorres_gen_asm)
+       apply (rule_tac P="capTCBPtr cp \<noteq> self" in ccorres_gen_asm)
        apply (simp add: returnOk_bind)
        apply (simp add: ccorres_invocationCatch_Inr del: Collect_const)
        apply (ctac add: setThreadState_ccorres)
@@ -2365,7 +2366,8 @@ lemma decodeWriteRegisters_ccorres:
        apply (simp add: liftE_bindE bind_assoc)
        apply (rule ccorres_pre_getCurThread)
        apply (rule ccorres_cond_seq)
-       apply (rule_tac R="\<lambda>s. rv = ksCurThread s \<and> isThreadCap cp" and P="\<lambda>s. capTCBPtr cp = rv" in ccorres_cond_both)
+       apply (rule_tac R="\<lambda>s. self = ksCurThread s \<and> isThreadCap cp" and P="\<lambda>s. capTCBPtr cp = self"
+                in ccorres_cond_both)
          apply clarsimp
          apply (frule rf_sr_ksCurThread)
          apply clarsimp
@@ -2376,13 +2378,13 @@ lemma decodeWriteRegisters_ccorres:
           apply (drule_tac t="ksCurThread s" in sym)
           apply simp
          apply simp
-        apply (rule_tac P="capTCBPtr cp = rv" in ccorres_gen_asm)
+        apply (rule_tac P="capTCBPtr cp = self" in ccorres_gen_asm)
         apply simp
         apply (simp add: throwError_bind invocationCatch_def
                     cong: StateSpace.state.fold_congs globals.fold_congs)
         apply (rule syscall_error_throwError_ccorres_n)
         apply (simp add: syscall_error_to_H_cases)
-       apply (rule_tac P="capTCBPtr cp \<noteq> rv" in ccorres_gen_asm)
+       apply (rule_tac P="capTCBPtr cp \<noteq> self" in ccorres_gen_asm)
        apply (simp add: returnOk_bind)
        apply (simp add: ccorres_invocationCatch_Inr del: Collect_const)
        apply (ctac add: setThreadState_ccorres)
@@ -2626,7 +2628,7 @@ lemma slotCapLongRunningDelete_ccorres:
    apply (simp add: case_Null_If del: Collect_const)
    apply (rule ccorres_pre_getCTE)
    apply (rule ccorres_move_c_guard_cte)
-   apply (rule_tac P="cte_wp_at' ((=) rv) slot"
+   apply (rule_tac P="cte_wp_at' ((=) cte) slot"
                 in ccorres_cross_over_guard)
    apply (rule ccorres_symb_exec_r)
      apply (rule ccorres_if_lhs)
@@ -2647,7 +2649,7 @@ lemma slotCapLongRunningDelete_ccorres:
         apply vcg
        apply (simp del: Collect_const)
        apply (rule ccorres_move_c_guard_cte)
-       apply (rule_tac P="cte_wp_at' ((=) rv) slot"
+       apply (rule_tac P="cte_wp_at' ((=) cte) slot"
                   in  ccorres_from_vcg_throws[where P'=UNIV])
        apply (rule allI, rule conseqPre, vcg)
        apply (clarsimp simp: cte_wp_at_ctes_of return_def)
@@ -3806,7 +3808,7 @@ lemma bindNotification_ccorres:
    (Call bindNotification_'proc)"
   apply (cinit lift: tcb_' ntfnPtr_' simp: bindNotification_def)
    apply (rule ccorres_symb_exec_l [OF _ get_ntfn_inv' _ empty_fail_getNotification])
-    apply (rule_tac P="invs' and ko_at' rv ntfnptr and tcb_at' tcb" and P'=UNIV
+    apply (rule_tac P="invs' and ko_at' ntfn ntfnptr and tcb_at' tcb" and P'=UNIV
                     in ccorres_split_nothrow_novcg)
         apply (rule ccorres_from_vcg[where rrel=dc and xf=xfdc])
         apply (rule allI, rule conseqPre, vcg)
@@ -3826,7 +3828,7 @@ lemma bindNotification_ccorres:
               apply (rule cpspace_relation_ntfn_update_ntfn, assumption+)
                apply (clarsimp simp: cnotification_relation_def Let_def
                                      mask_def [where n=2] NtfnState_Waiting_def)
-               apply (case_tac "ntfnObj rv")
+               apply (case_tac "ntfnObj ntfn")
                  apply ((clarsimp simp: option_to_ctcb_ptr_canonical[OF invs_pspace_canonical']
                                   simp flip: canonical_bit_def)+)[3]
               apply (auto simp: option_to_ctcb_ptr_def objBits_simps'
@@ -3906,7 +3908,7 @@ lemma decodeUnbindNotification_ccorres:
    apply (rule ccorres_Guard_Seq)
    apply (simp add: liftE_bindE bind_assoc)
    apply (rule ccorres_pre_getBoundNotification)
-   apply (rule_tac P="\<lambda>s. rv \<noteq> Some 0" in ccorres_cross_over_guard)
+   apply (rule_tac P="\<lambda>s. ntfn \<noteq> Some 0" in ccorres_cross_over_guard)
    apply (simp add: bindE_bind_linearise)
    apply wpc
     apply (simp add: bindE_bind_linearise[symmetric]

--- a/proof/crefine/RISCV64/VSpace_C.thy
+++ b/proof/crefine/RISCV64/VSpace_C.thy
@@ -895,7 +895,7 @@ lemma setVMRoot_ccorres:
       apply (subst will_throw_and_catch)
        apply (simp split: capability.split arch_capability.split option.split)
        apply (fastforce simp: isCap_simps)
-      apply (rule ccorres_pre_gets_riscvKSGlobalPT_ksArchState[unfolded o_def])
+      apply (rule ccorres_pre_gets_riscvKSGlobalPT_ksArchState)
       apply (rule ccorres_rhs_assoc)+
       apply (rule ccorres_h_t_valid_riscvKSGlobalPT)
       apply csymbr
@@ -928,7 +928,7 @@ lemma setVMRoot_ccorres:
          apply (rule ccorres_rhs_assoc)
          apply (rule ccorres_h_t_valid_riscvKSGlobalPT)
          apply csymbr
-         apply (rule ccorres_pre_gets_riscvKSGlobalPT_ksArchState[unfolded comp_def])
+         apply (rule ccorres_pre_gets_riscvKSGlobalPT_ksArchState)
          apply (rule ccorres_add_return2)
          apply (ctac (no_vcg) add: setVSpaceRoot_ccorres)
           apply (rule ccorres_return_void_C)
@@ -940,7 +940,7 @@ lemma setVMRoot_ccorres:
        apply (rule ccorres_rhs_assoc)
        apply (rule ccorres_h_t_valid_riscvKSGlobalPT)
        apply csymbr
-       apply (rule ccorres_pre_gets_riscvKSGlobalPT_ksArchState[unfolded comp_def])
+       apply (rule ccorres_pre_gets_riscvKSGlobalPT_ksArchState)
        apply (rule ccorres_add_return2)
        apply (ctac (no_vcg) add: setVSpaceRoot_ccorres)
         apply (rule ccorres_return_void_C)
@@ -1007,7 +1007,7 @@ lemma setRegister_ccorres:
    apply (rule ccorres_pre_threadGet)
    apply (rule ccorres_Guard)
    apply (simp add: setRegister_def simpler_modify_def exec_select_f_singleton)
-   apply (rule_tac P="\<lambda>tcb. (atcbContextGet o tcbArch) tcb = rv"
+   apply (rule_tac P="\<lambda>tcb. (atcbContextGet o tcbArch) tcb = uc"
                 in threadSet_ccorres_lemma2)
     apply vcg
    apply (clarsimp simp: setRegister_def HaskellLib_H.runState_def

--- a/proof/crefine/X64/Arch_C.thy
+++ b/proof/crefine/X64/Arch_C.thy
@@ -748,7 +748,9 @@ shows
       apply (rule ccorres_rhs_assoc2)
       apply (rule ccorres_abstract_cleanup)
       apply (rule ccorres_symb_exec_l)
-        apply (rule_tac P = "rva = (capability.UntypedCap isdev frame pageBits idx)" in ccorres_gen_asm)
+        apply (rename_tac pcap)
+        apply (rule_tac P = "pcap = (capability.UntypedCap isdev frame pageBits idx)"
+                 in ccorres_gen_asm)
         apply (simp add: hrs_htd_update del:fun_upd_apply)
         apply (rule ccorres_split_nothrow)
 

--- a/proof/crefine/X64/CSpace_C.thy
+++ b/proof/crefine/X64/CSpace_C.thy
@@ -770,7 +770,7 @@ lemma update_freeIndex':
     show ?thesis
       apply (cinit lift: cap_ptr_' v64_')
        apply (rule ccorres_pre_getCTE)
-       apply (rule_tac P="\<lambda>s. ctes_of s srcSlot = Some rv \<and> (\<exists>i. cteCap rv = UntypedCap d p sz i)"
+       apply (rule_tac P="\<lambda>s. ctes_of s srcSlot = Some cte \<and> (\<exists>i. cteCap cte = UntypedCap d p sz i)"
                 in ccorres_from_vcg[where P' = UNIV])
        apply (rule allI)
        apply (rule conseqPre)
@@ -2642,7 +2642,7 @@ lemma capSwapForDelete_ccorres:
   \<comment> \<open>--- instruction: when (slot1 \<noteq> slot2) \<dots> / IF Ptr slot1 = Ptr slot2 THEN \<dots>\<close>
    apply (simp add:when_def)
    apply (rule ccorres_if_cond_throws2 [where Q = \<top> and Q' = \<top>])
-      apply (case_tac "slot1=slot2", simp+)
+      apply (case_tac "slot1=slot2"; simp)
      apply (rule ccorres_return_void_C)
 
   \<comment> \<open>***Main goal***\<close>

--- a/proof/crefine/X64/Finalise_C.thy
+++ b/proof/crefine/X64/Finalise_C.thy
@@ -278,10 +278,10 @@ lemma cancelAllIPC_ccorres:
   apply (cinit lift: epptr_')
    apply (rule ccorres_symb_exec_l [OF _ getEndpoint_inv _ empty_fail_getEndpoint])
     apply (rule_tac xf'=ret__unsigned_longlong_'
-                and val="case rv of IdleEP \<Rightarrow> scast EPState_Idle
+                and val="case ep of IdleEP \<Rightarrow> scast EPState_Idle
                             | RecvEP _ \<Rightarrow> scast EPState_Recv | SendEP _ \<Rightarrow> scast EPState_Send"
-                and R="ko_at' rv epptr"
-                 in ccorres_symb_exec_r_known_rv_UNIV[where R'=UNIV])
+                and R="ko_at' ep epptr"
+             in ccorres_symb_exec_r_known_rv_UNIV[where R'=UNIV])
        apply vcg
        apply clarsimp
        apply (erule cmap_relationE1 [OF cmap_relation_ep])
@@ -290,8 +290,8 @@ lemma cancelAllIPC_ccorres:
        apply (simp add: cendpoint_relation_def Let_def
                  split: endpoint.split_asm)
       apply ceqv
-     apply (rule_tac A="invs' and ko_at' rv epptr"
-                  in ccorres_guard_imp2[where A'=UNIV])
+     apply (rule_tac A="invs' and ko_at' ep epptr"
+              in ccorres_guard_imp2[where A'=UNIV])
       apply wpc
         apply (rename_tac list)
         apply (simp add: endpoint_state_defs
@@ -409,10 +409,10 @@ lemma cancelAllSignals_ccorres:
   apply (cinit lift: ntfnPtr_')
    apply (rule ccorres_symb_exec_l [OF _ get_ntfn_inv' _ empty_fail_getNotification])
     apply (rule_tac xf'=ret__unsigned_longlong_'
-                and val="case ntfnObj rv of IdleNtfn \<Rightarrow> scast NtfnState_Idle
+                and val="case ntfnObj ntfn of IdleNtfn \<Rightarrow> scast NtfnState_Idle
                             | ActiveNtfn _ \<Rightarrow> scast NtfnState_Active | WaitingNtfn _ \<Rightarrow> scast NtfnState_Waiting"
-                and R="ko_at' rv ntfnptr"
-                 in ccorres_symb_exec_r_known_rv_UNIV[where R'=UNIV])
+                and R="ko_at' ntfn ntfnptr"
+             in ccorres_symb_exec_r_known_rv_UNIV[where R'=UNIV])
        apply vcg
        apply clarsimp
        apply (erule cmap_relationE1 [OF cmap_relation_ntfn])
@@ -421,8 +421,8 @@ lemma cancelAllSignals_ccorres:
        apply (simp add: cnotification_relation_def Let_def
                  split: ntfn.split_asm)
       apply ceqv
-     apply (rule_tac A="invs' and ko_at' rv ntfnptr"
-                  in ccorres_guard_imp2[where A'=UNIV])
+     apply (rule_tac A="invs' and ko_at' ntfn ntfnptr"
+              in ccorres_guard_imp2[where A'=UNIV])
       apply wpc
         apply (simp add: notification_state_defs ccorres_cond_iffs)
         apply (rule ccorres_return_Skip)
@@ -437,8 +437,8 @@ lemma cancelAllSignals_ccorres:
       apply csymbr
       apply (rule ccorres_rhs_assoc2, rule ccorres_rhs_assoc2)
       apply (rule_tac r'=dc and xf'=xfdc in ccorres_split_nothrow)
-          apply (rule_tac P="ko_at' rv ntfnptr and invs'"
-                    in ccorres_from_vcg[where P'=UNIV])
+          apply (rule_tac P="ko_at' ntfn ntfnptr and invs'"
+                   in ccorres_from_vcg[where P'=UNIV])
           apply (rule allI, rule conseqPre, vcg)
           apply clarsimp
           apply (rule_tac x=ntfnptr in cmap_relationE1 [OF cmap_relation_ntfn], assumption)
@@ -683,8 +683,8 @@ lemma doUnbindNotification_ccorres:
    (Call doUnbindNotification_'proc)"
   apply (cinit' lift: ntfnPtr_' tcbptr_')
    apply (rule ccorres_symb_exec_l [OF _ get_ntfn_inv' _ empty_fail_getNotification])
-    apply (rule_tac P="invs' and ko_at' rv ntfnptr" and P'=UNIV
-                in ccorres_split_nothrow_novcg)
+    apply (rule_tac P="invs' and ko_at' ntfn ntfnptr" and P'=UNIV
+             in ccorres_split_nothrow_novcg)
         apply (rule ccorres_from_vcg[where rrel=dc and xf=xfdc])
         apply (rule allI, rule conseqPre, vcg)
         apply (clarsimp simp: option_to_ptr_def option_to_0_def)
@@ -703,7 +703,7 @@ lemma doUnbindNotification_ccorres:
               apply (rule cpspace_relation_ntfn_update_ntfn, assumption+)
                apply (clarsimp simp: cnotification_relation_def Let_def
                                      mask_def [where n=2] NtfnState_Waiting_def)
-               apply (case_tac "ntfnObj rv", ((simp add: option_to_ctcb_ptr_def)+)[4])
+               apply (case_tac "ntfnObj ntfn", ((simp add: option_to_ctcb_ptr_def)+)[4])
              subgoal by (simp add: carch_state_relation_def
                                    global_ioport_bitmap_heap_update_tag_disj_simps
                                    fpu_null_state_heap_update_tag_disj_simps)
@@ -822,13 +822,13 @@ lemma unbindMaybeNotification_ccorres:
   apply (cinit lift: ntfnPtr_')
    apply (rule ccorres_symb_exec_l [OF _ get_ntfn_inv' _ empty_fail_getNotification])
     apply (rule ccorres_rhs_assoc2)
-    apply (rule_tac P="ntfnBoundTCB rv \<noteq> None \<longrightarrow>
-                             option_to_ctcb_ptr (ntfnBoundTCB rv) \<noteq> NULL"
-                     in ccorres_gen_asm)
+    apply (rule_tac P="ntfnBoundTCB ntfn \<noteq> None \<longrightarrow>
+                         option_to_ctcb_ptr (ntfnBoundTCB ntfn) \<noteq> NULL"
+             in ccorres_gen_asm)
     apply (rule_tac xf'=boundTCB_'
-                           and val="option_to_ctcb_ptr (ntfnBoundTCB rv)"
-                           and R="ko_at' rv ntfnptr and valid_bound_tcb' (ntfnBoundTCB rv)"
-                            in ccorres_symb_exec_r_known_rv_UNIV[where R'=UNIV])
+                and val="option_to_ctcb_ptr (ntfnBoundTCB ntfn)"
+                and R="ko_at' ntfn ntfnptr and valid_bound_tcb' (ntfnBoundTCB ntfn)"
+             in ccorres_symb_exec_r_known_rv_UNIV[where R'=UNIV])
        apply vcg
        apply clarsimp
        apply (erule cmap_relationE1[OF cmap_relation_ntfn])

--- a/proof/crefine/X64/Interrupt_C.thy
+++ b/proof/crefine/X64/Interrupt_C.thy
@@ -828,7 +828,7 @@ from assms show ?thesis
                                              where g="\<lambda>_. injection_handler P Q >>=E R" for P Q R])
                             apply (clarsimp simp: injection_handler_returnOk)
                             apply (simp only: bindE_K_bind)
-                            apply (ctac add: ioapic_decode_map_pin_to_vector_ccorres[simplified o_def])
+                            apply (ctac add: ioapic_decode_map_pin_to_vector_ccorres)
                                apply ccorres_rewrite
                                apply (simp add: ccorres_invocationCatch_Inr performInvocation_def
                                                 returnOk_bind liftE_bindE bindE_assoc

--- a/proof/crefine/X64/Invoke_C.thy
+++ b/proof/crefine/X64/Invoke_C.thy
@@ -65,7 +65,7 @@ lemma setDomain_ccorres:
            apply (ctac add: tcbSchedEnqueue_ccorres)
           apply (rule ccorres_return_Skip)
          apply (simp add: when_def)
-         apply (rule_tac R="\<lambda>s. rv = ksCurThread s"
+         apply (rule_tac R="\<lambda>s. curThread = ksCurThread s"
                     in ccorres_cond2)
            apply (clarsimp simp: rf_sr_ksCurThread)
           apply (ctac add: rescheduleRequired_ccorres)
@@ -76,14 +76,16 @@ lemma setDomain_ccorres:
       apply simp
       apply wp
      apply (rule_tac Q="\<lambda>_. all_invs_but_sch_extra and tcb_at' t and sch_act_simple
-                        and (\<lambda>s. rv = ksCurThread s)" in hoare_strengthen_post)
+                            and (\<lambda>s. curThread = ksCurThread s)"
+              in hoare_strengthen_post)
       apply (wp threadSet_all_invs_but_sch_extra)
      apply (clarsimp simp: valid_pspace_valid_objs' st_tcb_at_def[symmetric]
                            sch_act_simple_def st_tcb_at'_def weak_sch_act_wf_def
                     split: if_splits)
     apply (simp add: guard_is_UNIV_def)
    apply (rule_tac Q="\<lambda>_. invs' and tcb_at' t and sch_act_simple
-      and (\<lambda>s. rv = ksCurThread s \<and> (\<forall>p. t \<notin> set (ksReadyQueues s p)))" in hoare_strengthen_post)
+                          and (\<lambda>s. curThread = ksCurThread s \<and> (\<forall>p. t \<notin> set (ksReadyQueues s p)))"
+            in hoare_strengthen_post)
     apply (wp weak_sch_act_wf_lift_linear tcbSchedDequeue_not_queued
               tcbSchedDequeue_not_in_queue hoare_vcg_imp_lift hoare_vcg_all_lift)
    apply (clarsimp simp: invs'_def valid_pspace'_def valid_state'_def)
@@ -627,7 +629,7 @@ lemma decodeCNodeInvocation_ccorres:
                        del: Collect_const cong: call_ignore_cong)
            apply (rule ccorres_split_throws)
             apply (rule ccorres_rhs_assoc | csymbr)+
-            apply (simp add: invocationCatch_use_injection_handler[symmetric, unfolded o_def]
+            apply (simp add: invocationCatch_use_injection_handler[symmetric]
                         del: Collect_const cong: call_ignore_cong)
             apply (rule ccorres_Cond_rhs_Seq)
              apply (simp add:if_P del: Collect_const)
@@ -1097,7 +1099,7 @@ lemma decodeCNodeInvocation_ccorres:
             apply (simp add: throwError_def return_def exception_defs
                              syscall_error_rel_def syscall_error_to_H_cases)
             apply clarsimp
-           apply (simp add: invocationCatch_use_injection_handler[symmetric, unfolded o_def]
+           apply (simp add: invocationCatch_use_injection_handler[symmetric]
                        del: Collect_const)
            apply csymbr
            apply (simp add: interpret_excaps_test_null excaps_map_def

--- a/proof/crefine/X64/Ipc_C.thy
+++ b/proof/crefine/X64/Ipc_C.thy
@@ -3182,9 +3182,10 @@ proof -
      apply csymbr
      apply csymbr
      apply (rename_tac "lngth")
-     apply (simp add: mi_from_H_def mapME_def del: Collect_const cong: bind_apply_cong)
+     apply (unfold mapME_def)[1]
+     apply (simp add: mi_from_H_def del: Collect_const)
      apply (rule ccorres_symb_exec_l)
-        apply (rule_tac P="length rv = unat word2" in ccorres_gen_asm)
+        apply (rule_tac P="length xs = unat word2" in ccorres_gen_asm)
         apply (rule ccorres_rhs_assoc2)
         apply (rule ccorres_add_returnOk2,
                rule ccorres_splitE_novcg)
@@ -3193,7 +3194,7 @@ proof -
                        and   Q="UNIV"
                        and   F="\<lambda>n s. valid_pspace' s \<and> tcb_at' thread s \<and>
                                       (case buffer of Some x \<Rightarrow> valid_ipc_buffer_ptr' x | _ \<Rightarrow> \<top>) s \<and>
-                                       (\<forall>m < length rv. user_word_at (rv ! m)
+                                       (\<forall>m < length xs. user_word_at (xs ! m)
                                                      (x2 + (of_nat m + (msgMaxLength + 2)) * 8) s)"
                           in ccorres_sequenceE_while')
                   apply (simp add: split_def)
@@ -3203,7 +3204,7 @@ proof -
                      apply (rule_tac xf'=cptr_' in ccorres_abstract, ceqv)
                      apply (ctac add: capFaultOnFailure_ccorres
                                [OF lookupSlotForThread_ccorres'])
-                        apply (rule_tac P="is_aligned rva 5" in ccorres_gen_asm)
+                        apply (rule_tac P="is_aligned rv 5" in ccorres_gen_asm)
                         apply (simp add: ccorres_cond_iffs liftE_bindE)
                         apply (rule ccorres_symb_exec_l [OF _ _ _ empty_fail_getSlotCap])
                           apply (rule_tac P'="UNIV \<inter> {s. excaps_map ys
@@ -3224,7 +3225,7 @@ proof -
                        apply (clarsimp simp: ccorres_cond_iffs)
                        apply (rule_tac  P= \<top>
                                 and P'="{x. errstate x= lu_ret___struct_lookupSlot_raw_ret_C \<and>
-                                            rv' = (rv ! length ys)}"
+                                            rv' = (xs ! length ys)}"
                                   in ccorres_from_vcg_throws)
                        apply (rule allI, rule conseqPre, vcg)
                        apply (clarsimp simp: throwError_def return_def)
@@ -3265,9 +3266,8 @@ proof -
             apply ceqv
            apply (simp del: Collect_const)
            apply (rule_tac P'="{s. snd rv'=?curr s}"
-                   and P="\<lambda>s. length rva = length rv
-                               \<and> (\<forall>x \<in> set rva. snd x \<noteq> 0)"
-                   in ccorres_from_vcg_throws)
+                       and P="\<lambda>s. length rv = length xs \<and> (\<forall>x \<in> set rv. snd x \<noteq> 0)"
+                    in ccorres_from_vcg_throws)
            apply (rule allI, rule conseqPre, vcg)
            apply (clarsimp simp: returnOk_def return_def
                                  seL4_MsgExtraCapBits_def)
@@ -3603,7 +3603,7 @@ proof -
      apply (rule ccorres_rhs_assoc2)
      apply (simp add: MessageID_Exception_def)
      apply ccorres_rewrite
-     apply (subst bind_return_unit)
+     apply (rule ccorres_add_return2)
      apply (rule ccorres_split_nothrow_novcg)
          apply (rule ccorres_zipWithM_x_while)
              apply clarsimp

--- a/proof/crefine/X64/Recycle_C.thy
+++ b/proof/crefine/X64/Recycle_C.thy
@@ -903,8 +903,8 @@ lemma cancelBadgedSends_ccorres:
               cong: list.case_cong Structures_H.endpoint.case_cong call_ignore_cong
                del: Collect_const)
    apply (rule ccorres_pre_getEndpoint)
-   apply (rule_tac R="ko_at' rv ptr" and xf'="ret__unsigned_longlong_'"
-               and val="case rv of RecvEP q \<Rightarrow> scast EPState_Recv | IdleEP \<Rightarrow> scast EPState_Idle
+   apply (rule_tac R="ko_at' ep ptr" and xf'="ret__unsigned_longlong_'"
+               and val="case ep of RecvEP q \<Rightarrow> scast EPState_Recv | IdleEP \<Rightarrow> scast EPState_Idle
                                 | SendEP q \<Rightarrow> scast EPState_Send"
                in ccorres_symb_exec_r_known_rv_UNIV[where R'=UNIV])
       apply vcg
@@ -924,12 +924,12 @@ lemma cancelBadgedSends_ccorres:
                 del: Collect_const cong: call_ignore_cong)
     apply (rule ccorres_rhs_assoc)+
     apply (csymbr, csymbr)
-    apply (drule_tac s = rv in sym, simp only:)
-    apply (rule_tac P="ko_at' rv ptr and invs'" in ccorres_cross_over_guard)
+    apply (drule_tac s = ep in sym, simp only:)
+    apply (rule_tac P="ko_at' ep ptr and invs'" in ccorres_cross_over_guard)
     apply (rule ccorres_symb_exec_r)
       apply (rule ccorres_rhs_assoc2, rule ccorres_rhs_assoc2)
       apply (rule ccorres_split_nothrow[where r'=dc and xf'=xfdc, OF _ ceqv_refl])
-         apply (rule_tac P="ko_at' rv ptr"
+         apply (rule_tac P="ko_at' ep ptr"
                     in ccorres_from_vcg[where P'=UNIV])
          apply (rule allI, rule conseqPre, vcg)
          apply clarsimp
@@ -1043,7 +1043,7 @@ lemma cancelBadgedSends_ccorres:
               subgoal by (simp add: rf_sr_def)
              apply simp
             apply ceqv
-           apply (rule_tac P="ret__unsigned_longlong=blockingIPCBadge rva" in ccorres_gen_asm2)
+           apply (rule_tac P="ret__unsigned_longlong=blockingIPCBadge rv" in ccorres_gen_asm2)
            apply (rule ccorres_if_bind, rule ccorres_if_lhs)
             apply (simp add: bind_assoc)
             apply (rule ccorres_rhs_assoc)+

--- a/proof/crefine/X64/SyscallArgs_C.thy
+++ b/proof/crefine/X64/SyscallArgs_C.thy
@@ -783,12 +783,12 @@ lemma lookupIPCBuffer_ccorres[corres]:
      apply (rule ccorres_move_array_assertion_tcb_ctes)
      apply (ctac (no_vcg))
        apply csymbr
-       apply (rule_tac b="isArchObjectCap rva \<and> isPageCap (capCap rva)" in ccorres_case_bools')
+       apply (rule_tac b="isArchObjectCap rv \<and> isPageCap (capCap rv)" in ccorres_case_bools')
         apply simp
         apply (rule ccorres_cond_false_seq)
         apply (simp(no_asm))
         apply csymbr
-        apply (rule_tac b="isDeviceCap rva" in ccorres_case_bools')
+        apply (rule_tac b="isDeviceCap rv" in ccorres_case_bools')
          apply (rule ccorres_cond_true_seq)
          apply (rule ccorres_from_vcg_split_throws[where P=\<top> and P'=UNIV])
           apply vcg

--- a/proof/crefine/X64/Syscall_C.thy
+++ b/proof/crefine/X64/Syscall_C.thy
@@ -1253,7 +1253,7 @@ lemma handleRecv_ccorres:
 
           apply (simp add: liftE_bind)
           apply (ctac)
-            apply (rule_tac P="\<lambda>s. ksCurThread s = rv" in ccorres_cross_over_guard)
+            apply (rule_tac P="\<lambda>s. ksCurThread s = thread" in ccorres_cross_over_guard)
             apply (ctac add: receiveIPC_ccorres)
 
            apply (wp deleteCallerCap_ksQ_ct' hoare_vcg_all_lift)

--- a/proof/crefine/X64/Tcb_C.thy
+++ b/proof/crefine/X64/Tcb_C.thy
@@ -437,7 +437,7 @@ lemma setPriority_ccorres:
   apply (frule (1) valid_objs'_maxDomain[where t=t])
   apply (frule (1) valid_objs'_maxPriority[where t=t])
   apply simp
-done
+  done
 
 lemma setMCPriority_ccorres:
   "ccorres dc xfdc
@@ -1223,7 +1223,7 @@ lemma invokeTCB_CopyRegisters_ccorres:
            apply (rule ccorres_pre_getCurThread)
            apply (ctac add: postModifyRegisters_ccorres)
              apply (rule ccorres_split_nothrow_novcg_dc)
-                apply (rule_tac R="\<lambda>s. rvd = ksCurThread s"
+                apply (rule_tac R="\<lambda>s. rvc = ksCurThread s"
                            in ccorres_when)
                  apply (clarsimp simp: rf_sr_ksCurThread)
                 apply clarsimp
@@ -1504,7 +1504,7 @@ lemma asUser_getMRs_rel:
   apply (erule getMRs_rel_context, simp)
    apply (clarsimp simp: obj_at'_real_def ko_wp_at'_def projectKOs)
   apply simp
-done
+  done
 
 
 lemma asUser_sysargs_rel:
@@ -1643,7 +1643,7 @@ lemma invokeTCB_WriteRegisters_ccorres[where S=UNIV]:
                      apply simp
                     apply (rule ceqv_refl)
                    apply (rule ccorres_split_nothrow_novcg_dc)
-                      apply (rule_tac R="\<lambda>s. rv = ksCurThread s"
+                      apply (rule_tac R="\<lambda>s. self = ksCurThread s"
                                   in ccorres_when)
                       apply (clarsimp simp: rf_sr_ksCurThread)
                       apply clarsimp
@@ -2120,7 +2120,7 @@ shows
                         apply (clarsimp simp: min_def iffD2 [OF mask_eq_iff_w2p] word_size
                                               word_less_nat_alt
                                       split: if_split_asm dest!: word_unat.Rep_inverse')
-                       apply simp
+                       apply (simp add: pred_conj_def)
                        apply (wp mapM_x_wp' sch_act_wf_lift valid_queues_lift static_imp_wp
                                  tcb_in_cur_domain'_lift)
                       apply (simp add: n_frameRegisters_def n_msgRegisters_def
@@ -2243,7 +2243,8 @@ lemma decodeReadRegisters_ccorres:
        apply (simp add: liftE_bindE bind_assoc)
        apply (rule ccorres_pre_getCurThread)
        apply (rule ccorres_cond_seq)
-       apply (rule_tac R="\<lambda>s. rv = ksCurThread s \<and> isThreadCap cp" and P="\<lambda>s. capTCBPtr cp = rv" in ccorres_cond_both)
+       apply (rule_tac R="\<lambda>s. self = ksCurThread s \<and> isThreadCap cp" and P="\<lambda>s. capTCBPtr cp = self"
+                in ccorres_cond_both)
          apply clarsimp
          apply (frule rf_sr_ksCurThread)
          apply clarsimp
@@ -2254,13 +2255,13 @@ lemma decodeReadRegisters_ccorres:
           apply (drule_tac t="ksCurThread s" in sym)
           apply simp
          apply simp
-        apply (rule_tac P="capTCBPtr cp = rv" in ccorres_gen_asm)
+        apply (rule_tac P="capTCBPtr cp = self" in ccorres_gen_asm)
         apply simp
         apply (simp add: throwError_bind invocationCatch_def
                     cong: StateSpace.state.fold_congs globals.fold_congs)
         apply (rule syscall_error_throwError_ccorres_n)
         apply (simp add: syscall_error_to_H_cases)
-       apply (rule_tac P="capTCBPtr cp \<noteq> rv" in ccorres_gen_asm)
+       apply (rule_tac P="capTCBPtr cp \<noteq> self" in ccorres_gen_asm)
        apply (simp add: returnOk_bind)
        apply (simp add: ccorres_invocationCatch_Inr del: Collect_const)
        apply (ctac add: setThreadState_ccorres)
@@ -2355,7 +2356,8 @@ lemma decodeWriteRegisters_ccorres:
        apply (simp add: liftE_bindE bind_assoc)
        apply (rule ccorres_pre_getCurThread)
        apply (rule ccorres_cond_seq)
-       apply (rule_tac R="\<lambda>s. rv = ksCurThread s \<and> isThreadCap cp" and P="\<lambda>s. capTCBPtr cp = rv" in ccorres_cond_both)
+       apply (rule_tac R="\<lambda>s. self = ksCurThread s \<and> isThreadCap cp" and P="\<lambda>s. capTCBPtr cp = self"
+                in ccorres_cond_both)
          apply clarsimp
          apply (frule rf_sr_ksCurThread)
          apply clarsimp
@@ -2366,13 +2368,13 @@ lemma decodeWriteRegisters_ccorres:
           apply (drule_tac t="ksCurThread s" in sym)
           apply simp
          apply simp
-        apply (rule_tac P="capTCBPtr cp = rv" in ccorres_gen_asm)
+        apply (rule_tac P="capTCBPtr cp = self" in ccorres_gen_asm)
         apply simp
         apply (simp add: throwError_bind invocationCatch_def
                     cong: StateSpace.state.fold_congs globals.fold_congs)
         apply (rule syscall_error_throwError_ccorres_n)
         apply (simp add: syscall_error_to_H_cases)
-       apply (rule_tac P="capTCBPtr cp \<noteq> rv" in ccorres_gen_asm)
+       apply (rule_tac P="capTCBPtr cp \<noteq> self" in ccorres_gen_asm)
        apply (simp add: returnOk_bind)
        apply (simp add: ccorres_invocationCatch_Inr del: Collect_const)
        apply (ctac add: setThreadState_ccorres)
@@ -2615,7 +2617,7 @@ lemma slotCapLongRunningDelete_ccorres:
    apply (simp add: case_Null_If del: Collect_const)
    apply (rule ccorres_pre_getCTE)
    apply (rule ccorres_move_c_guard_cte)
-   apply (rule_tac P="cte_wp_at' ((=) rv) slot"
+   apply (rule_tac P="cte_wp_at' ((=) cte) slot"
                 in ccorres_cross_over_guard)
    apply (rule ccorres_symb_exec_r)
      apply (rule ccorres_if_lhs)
@@ -2636,7 +2638,7 @@ lemma slotCapLongRunningDelete_ccorres:
         apply vcg
        apply (simp del: Collect_const)
        apply (rule ccorres_move_c_guard_cte)
-       apply (rule_tac P="cte_wp_at' ((=) rv) slot"
+       apply (rule_tac P="cte_wp_at' ((=) cte) slot"
                   in  ccorres_from_vcg_throws[where P'=UNIV])
        apply (rule allI, rule conseqPre, vcg)
        apply (clarsimp simp: cte_wp_at_ctes_of return_def)
@@ -3795,7 +3797,7 @@ lemma bindNotification_ccorres:
    (Call bindNotification_'proc)"
   apply (cinit lift: tcb_' ntfnPtr_' simp: bindNotification_def)
    apply (rule ccorres_symb_exec_l [OF _ get_ntfn_inv' _ empty_fail_getNotification])
-    apply (rule_tac P="invs' and ko_at' rv ntfnptr and tcb_at' tcb" and P'=UNIV
+    apply (rule_tac P="invs' and ko_at' ntfn ntfnptr and tcb_at' tcb" and P'=UNIV
                     in ccorres_split_nothrow_novcg)
         apply (rule ccorres_from_vcg[where rrel=dc and xf=xfdc])
         apply (rule allI, rule conseqPre, vcg)
@@ -3815,7 +3817,7 @@ lemma bindNotification_ccorres:
               apply (rule cpspace_relation_ntfn_update_ntfn, assumption+)
                apply (clarsimp simp: cnotification_relation_def Let_def
                                      mask_def [where n=2] NtfnState_Waiting_def)
-               apply (case_tac "ntfnObj rv")
+               apply (case_tac "ntfnObj ntfn")
                  apply ((clarsimp simp: option_to_ctcb_ptr_canonical[OF invs_pspace_canonical'])+)[3]
               apply (auto simp: option_to_ctcb_ptr_def objBits_simps'
                                 bindNTFN_alignment_junk)[1]
@@ -3895,7 +3897,7 @@ lemma decodeUnbindNotification_ccorres:
    apply (rule ccorres_Guard_Seq)
    apply (simp add: liftE_bindE bind_assoc)
    apply (rule ccorres_pre_getBoundNotification)
-   apply (rule_tac P="\<lambda>s. rv \<noteq> Some 0" in ccorres_cross_over_guard)
+   apply (rule_tac P="\<lambda>s. ntfn \<noteq> Some 0" in ccorres_cross_over_guard)
    apply (simp add: bindE_bind_linearise)
    apply wpc
     apply (simp add: bindE_bind_linearise[symmetric]

--- a/proof/crefine/X64/VSpace_C.thy
+++ b/proof/crefine/X64/VSpace_C.thy
@@ -654,7 +654,7 @@ lemma lookupPDPTSlot_ccorres':
    apply csymbr
    apply csymbr
    apply (rule ccorres_abstract_cleanup)
-   apply (rule_tac P="(ret__unsigned_longlong = 0) = (rv = X64_H.InvalidPML4E)"
+   apply (rule_tac P="(ret__unsigned_longlong = 0) = (pml4e = X64_H.InvalidPML4E)"
                in ccorres_gen_asm2)
    apply (wpc; ccorres_rewrite)
     apply (rule_tac P=\<top> and P' =UNIV in ccorres_from_vcg_throws)
@@ -666,9 +666,9 @@ lemma lookupPDPTSlot_ccorres':
    apply (thin_tac "_ = PDPointerTablePML4E _ _ _ _ _ _")
    apply (simp add: bind_liftE_distrib liftE_bindE returnOk_liftE[symmetric])
    apply (rule ccorres_stateAssert)
-   apply (rule_tac P="pd_pointer_table_at' (ptrFromPAddr (pml4eTable rv))
-                        and ko_at' rv (lookup_pml4_slot pm vptr)
-                        and K (isPDPointerTablePML4E rv)"
+   apply (rule_tac P="pd_pointer_table_at' (ptrFromPAddr (pml4eTable pml4e))
+                        and ko_at' pml4e (lookup_pml4_slot pm vptr)
+                        and K (isPDPointerTablePML4E pml4e)"
                and P'=UNIV
             in ccorres_from_vcg_throws)
    apply (rule allI, rule conseqPre, vcg)
@@ -1195,7 +1195,7 @@ lemma setVMRoot_ccorres:
       apply (rule ccorres_rhs_assoc)
       apply (rule ccorres_h_t_valid_x64KSSKIMPML4)
       apply csymbr
-      apply (rule ccorres_pre_gets_x64KSSKIMPML4_ksArchState[unfolded comp_def])
+      apply (rule ccorres_pre_gets_x64KSSKIMPML4_ksArchState)
       apply (rule ccorres_add_return2)
       apply (ctac (no_vcg) add: setCurrentUserVSpaceRoot_ccorres)
        apply (rule ccorres_return_void_C)
@@ -1212,7 +1212,7 @@ lemma setVMRoot_ccorres:
       apply (rule ccorres_rhs_assoc)
       apply (rule ccorres_h_t_valid_x64KSSKIMPML4)
       apply csymbr
-      apply (rule ccorres_pre_gets_x64KSSKIMPML4_ksArchState[unfolded comp_def])
+      apply (rule ccorres_pre_gets_x64KSSKIMPML4_ksArchState)
       apply (rule ccorres_add_return2)
       apply (ctac (no_vcg) add: setCurrentUserVSpaceRoot_ccorres)
        apply (rule ccorres_return_void_C)
@@ -1236,7 +1236,7 @@ lemma setVMRoot_ccorres:
          apply (rule ccorres_rhs_assoc)
          apply (rule ccorres_h_t_valid_x64KSSKIMPML4)
          apply csymbr
-         apply (rule ccorres_pre_gets_x64KSSKIMPML4_ksArchState[unfolded comp_def])
+         apply (rule ccorres_pre_gets_x64KSSKIMPML4_ksArchState)
          apply (rule ccorres_add_return2)
          apply (ctac (no_vcg) add: setCurrentUserVSpaceRoot_ccorres)
           apply (rule ccorres_return_void_C)
@@ -1258,7 +1258,7 @@ lemma setVMRoot_ccorres:
        apply (rule ccorres_rhs_assoc)
        apply (rule ccorres_h_t_valid_x64KSSKIMPML4)
        apply csymbr
-       apply (rule ccorres_pre_gets_x64KSSKIMPML4_ksArchState[unfolded comp_def])
+       apply (rule ccorres_pre_gets_x64KSSKIMPML4_ksArchState)
        apply (rule ccorres_add_return2)
        apply (ctac (no_vcg) add: setCurrentUserVSpaceRoot_ccorres)
         apply (rule ccorres_return_void_C)
@@ -1333,7 +1333,7 @@ lemma setRegister_ccorres:
    apply (rule ccorres_pre_threadGet)
    apply (rule ccorres_Guard)
    apply (simp add: setRegister_def simpler_modify_def exec_select_f_singleton)
-   apply (rule_tac P="\<lambda>tcb. (atcbContextGet o tcbArch) tcb = rv"
+   apply (rule_tac P="\<lambda>tcb. (atcbContextGet o tcbArch) tcb = uc"
                 in threadSet_ccorres_lemma2)
     apply vcg
    apply (clarsimp simp: setRegister_def HaskellLib_H.runState_def
@@ -2337,13 +2337,13 @@ lemma performASIDPoolInvocation_ccorres:
       apply (rule ccorres_rhs_assoc2)
       apply (rule_tac ccorres_split_nothrow [where r'=dc and xf'=xfdc])
           apply (simp add: updateCap_def)
-          apply (rule_tac A="cte_wp_at' ((=) rv o cteCap) ctSlot
-                             and K (isPML4Cap' rv \<and> asid \<le> mask asid_bits \<and> asid \<noteq> ucast asidInvalid)"
+          apply (rule_tac A="cte_wp_at' ((=) oldcap o cteCap) ctSlot
+                             and K (isPML4Cap' oldcap \<and> asid \<le> mask asid_bits \<and> asid \<noteq> ucast asidInvalid)"
                       and A'=UNIV in ccorres_guard_imp2)
            apply (rule ccorres_pre_getCTE)
-           apply (rule_tac P="cte_wp_at' ((=) rv o cteCap) ctSlot
-                              and K (isPML4Cap' rv \<and> asid \<le> mask asid_bits \<and> asid \<noteq> ucast asidInvalid)
-                              and cte_wp_at' ((=) rva) ctSlot"
+           apply (rule_tac P="cte_wp_at' ((=) oldcap o cteCap) ctSlot
+                              and K (isPML4Cap' oldcap \<and> asid \<le> mask asid_bits \<and> asid \<noteq> ucast asidInvalid)
+                              and cte_wp_at' ((=) rv) ctSlot"
                        and P'=UNIV in ccorres_from_vcg)
            apply (rule allI, rule conseqPre, vcg)
            apply (clarsimp simp: cte_wp_at_ctes_of)

--- a/proof/crefine/lib/Ctac.thy
+++ b/proof/crefine/lib/Ctac.thy
@@ -2031,6 +2031,7 @@ fun tac ctxt =
         ORELSE (resolve_tac ctxt [@{thm xpresI}] THEN' simp_tac (ctxt |> Splitter.del_split @{thm "if_split"})) 1
     ))
   THEN simp_tac (put_simpset HOL_basic_ss ctxt addsimps @{thms com.case}) 1
+  THEN no_name_eta_tac ctxt
 \<close>
 
 end

--- a/proof/crefine/lib/ctac-method.ML
+++ b/proof/crefine/lib/ctac-method.ML
@@ -1107,7 +1107,9 @@ fun shorten_names mp =
     mp -- Shorten_Names.shorten_names_preserve_new >> MethodExtras.then_all_new
 
 val corres_ctac_tactic = let
-    fun tac upds ctxt = Method.SIMPLE_METHOD' (corres_ctac (apply upds default_ctac_opts) ctxt);
+    fun tac upds ctxt
+      = Method.SIMPLE_METHOD' (corres_ctac (apply upds default_ctac_opts) ctxt
+                               THEN_ALL_NEW (fn _ => no_name_eta_tac ctxt));
 
     val option_args = Args.parens (P.list (Scan.first ctac_options))
     val opt_option_args = Scan.lift (Scan.optional option_args [])
@@ -1133,7 +1135,9 @@ val corres_abstract_args = corres_pre_abstract_args corres_pre_lift_tac_clift;
 val corres_abstract_init_args = corres_pre_abstract_args corres_pre_lift_tac_cinit;
 
 val corres_symb_rhs = let
-    fun tac upds ctxt = Method.SIMPLE_METHOD' (corres_symb_rhs_tac (apply upds default_csymbr_opts) ctxt);
+    fun tac upds ctxt
+      = Method.SIMPLE_METHOD' (corres_symb_rhs_tac (apply upds default_csymbr_opts) ctxt
+                               THEN_ALL_NEW (fn _ => no_name_eta_tac ctxt));
 
     val option_args = Args.parens (P.list (Scan.first csymbr_options))
     val opt_option_args = Scan.lift (Scan.optional option_args [])
@@ -1143,7 +1147,8 @@ in
 end;
 
 val corres_ceqv = let
-    fun tac upds ctxt = Method.SIMPLE_METHOD' (corres_solve_ceqv (#trace (apply upds default_ceqv_opts)) 0 ctxt);
+    fun tac upds ctxt
+      = Method.SIMPLE_METHOD' (corres_solve_ceqv (#trace (apply upds default_ceqv_opts)) 0 ctxt);
 
     val option_args = Args.parens (P.list (Scan.first ceqv_options))
     val opt_option_args = Scan.lift (Scan.optional option_args [])
@@ -1156,7 +1161,8 @@ end;
  * We should be able to get the xfs from the goal ... *)
 fun corres_boilerplate unfold_haskell_p = let
     fun tac (upds, xfs : string list) ctxt
-      = Method.SIMPLE_METHOD' (corres_boilerplate_tac (apply upds default_cinit_opts) unfold_haskell_p xfs ctxt)
+      = Method.SIMPLE_METHOD' (corres_boilerplate_tac (apply upds default_cinit_opts) unfold_haskell_p xfs ctxt
+                               THEN_ALL_NEW (fn _ => no_name_eta_tac ctxt))
 
     val var_lift_args = Args.$$$ liftoptN |-- Args.colon |--
                              Scan.repeat (Scan.unless (Scan.first boilerplate_modifiers) Args.name)


### PR DESCRIPTION
Add `no_name_eta` as a final step in various tactics used by `crefine`, in particular to eta-contract expanded terms. This has partially been superseded by https://github.com/seL4/l4v/pull/646, but still provides improved consistency and better bound variable names.

As potential negatives:
* there will probably be a performance impact. This hasn't been noticeable in interactive sessions but it would be good if we could measure it.
* this isn't perfect consistency, `rule` applications also eta-expand terms when there is unification with higher-order variables.
* a couple of simplification steps in existing proofs made implicit use of terms being eta-expanded. I don't think that this will be a problem for new proofs, it can be fairly easily worked around when encountered and over time could lead to further improvements if we more consistently use eta-contracted forms.