### PR TITLE
Remove uses of _tac methods from nondet

### DIFF
--- a/lib/Monads/nondet/Nondet_Det.thy
+++ b/lib/Monads/nondet/Nondet_Det.thy
@@ -51,13 +51,9 @@ lemma det_UN:
 lemma bind_detI[simp, intro!]:
   "\<lbrakk> det f; \<forall>x. det (g x) \<rbrakk> \<Longrightarrow> det (f >>= g)"
   unfolding bind_def det_def
+  apply (erule all_reg[rotated])
   apply clarsimp
-  apply (erule_tac x=s in allE)
-  apply clarsimp
-  apply (erule_tac x="a" in allE)
-  apply (erule_tac x="b" in allE)
-  apply clarsimp
-  done
+  by (metis fst_conv snd_conv)
 
 lemma det_modify[iff]:
   "det (modify f)"

--- a/lib/Monads/nondet/Nondet_Lemmas.thy
+++ b/lib/Monads/nondet/Nondet_Lemmas.thy
@@ -192,8 +192,8 @@ lemma liftE_liftM:
 lemma liftME_liftM:
   "liftME f = liftM (case_sum Inl (Inr \<circ> f))"
   unfolding liftME_def liftM_def bindE_def returnOk_def lift_def
-  apply (rule ext, rename_tac x)
-  apply (rule_tac f="bind x" in arg_cong)
+  apply (rule ext)
+  apply (rule arg_cong[where f="bind m" for m])
   apply (fastforce simp: throwError_def split: sum.splits)
   done
 
@@ -341,10 +341,10 @@ lemma whileLoop_unroll':
 lemma whileLoopE_unroll:
   "whileLoopE C B r = condition (C r) (B r >>=E whileLoopE C B) (returnOk r)"
   unfolding whileLoopE_def
-  apply (rule ext, rename_tac x)
+  apply (rule ext)
   apply (subst whileLoop_unroll)
   apply (clarsimp simp: bindE_def returnOk_def lift_def split: condition_splits)
-  apply (rule_tac f="\<lambda>a. (B r >>= a) x" in arg_cong)
+  apply (rule arg_cong[where f="\<lambda>a. (B r >>= a) x" for x])
   apply (rule ext)+
   apply (clarsimp simp: lift_def split: sum.splits)
   apply (subst whileLoop_unroll)

--- a/lib/Monads/nondet/Nondet_Monad_Equations.thy
+++ b/lib/Monads/nondet/Nondet_Monad_Equations.thy
@@ -177,35 +177,22 @@ lemma gets_the_returns:
   by (simp_all add: returnOk_def throwError_def
                     gets_the_return)
 
-lemma all_rv_choice_fn_eq_pred:
-  "\<lbrakk> \<And>rv. P rv \<Longrightarrow> \<exists>fn. f rv = g fn \<rbrakk> \<Longrightarrow> \<exists>fn. \<forall>rv. P rv \<longrightarrow> f rv = g (fn rv)"
-  apply (rule_tac x="\<lambda>rv. SOME h. f rv = g h" in exI)
-  apply (clarsimp split: if_split)
-  by (meson someI_ex)
-
-lemma all_rv_choice_fn_eq:
-  "\<lbrakk> \<And>rv. \<exists>fn. f rv = g fn \<rbrakk>
-   \<Longrightarrow> \<exists>fn. f = (\<lambda>rv. g (fn rv))"
-  using all_rv_choice_fn_eq_pred[where f=f and g=g and P=\<top>]
-  by (simp add: fun_eq_iff)
-
 lemma gets_the_eq_bind:
-  "\<lbrakk> \<exists>fn. f = gets_the (fn o fn'); \<And>rv. \<exists>fn. g rv = gets_the (fn o fn') \<rbrakk>
+  "\<lbrakk> f = gets_the (fn_f o fn'); \<And>rv. g rv = gets_the (fn_g rv o fn') \<rbrakk>
    \<Longrightarrow> \<exists>fn. (f >>= g) = gets_the (fn o fn')"
-  apply (clarsimp dest!: all_rv_choice_fn_eq)
-  apply (rule_tac x="\<lambda>s. case (fn s) of None \<Rightarrow> None | Some v \<Rightarrow> fna v s" in exI)
+  apply clarsimp
+  apply (rule exI[where x="\<lambda>s. case (fn_f s) of None \<Rightarrow> None | Some v \<Rightarrow> fn_g v s"])
   apply (simp add: gets_the_def bind_assoc exec_gets
                    assert_opt_def fun_eq_iff
             split: option.split)
   done
 
 lemma gets_the_eq_bindE:
-  "\<lbrakk> \<exists>fn. f = gets_the (fn o fn'); \<And>rv. \<exists>fn. g rv = gets_the (fn o fn') \<rbrakk>
+  "\<lbrakk> f = gets_the (fn_f o fn'); \<And>rv. g rv = gets_the (fn_g rv o fn') \<rbrakk>
    \<Longrightarrow> \<exists>fn. (f >>=E g) = gets_the (fn o fn')"
-  apply (simp add: bindE_def)
-  apply (erule gets_the_eq_bind)
+  unfolding bindE_def
+  apply (erule gets_the_eq_bind[where fn_g="\<lambda>rv s. case rv of Inl e \<Rightarrow> Some (Inl e) | Inr v \<Rightarrow> fn_g v s"])
   apply (simp add: lift_def gets_the_returns split: sum.split)
-  apply fastforce
   done
 
 lemma gets_the_fail:
@@ -469,8 +456,8 @@ lemma monad_eq_split:
   shows "(g >>= f) s = (g >>= f') s"
 proof -
   have pre: "\<And>rv s'. \<lbrakk>(rv, s') \<in> fst (g s)\<rbrakk> \<Longrightarrow> f rv s' = f' rv s'"
-    using assms unfolding valid_def
-    by (erule_tac x=s in allE) auto
+    using assms unfolding valid_def apply -
+    by (erule allE[where x=s]) auto
   show ?thesis
     by (simp add: bind_def image_def case_prod_unfold pre)
 qed
@@ -541,16 +528,15 @@ lemma bind_inv_inv_comm:
      empty_fail f; empty_fail g \<rbrakk> \<Longrightarrow>
    do x \<leftarrow> f; y \<leftarrow> g; n x y od = do y \<leftarrow> g; x \<leftarrow> f; n x y od"
   apply (rule ext)
-  apply (rename_tac s)
-  apply (rule_tac s="(do (x, y) \<leftarrow> do x \<leftarrow> f; y \<leftarrow> (\<lambda>_. g s) ; (\<lambda>_. return (x, y) s) od;
-                         n x y od) s" in trans)
+  apply (rule trans[where s="(do (x, y) \<leftarrow> do x \<leftarrow> f; y \<leftarrow> (\<lambda>_. g s) ; (\<lambda>_. return (x, y) s) od;
+                                 n x y od) s" for s])
    apply (simp add: bind_assoc)
    apply (intro bind_apply_cong, simp_all)[1]
     apply (metis in_inv_by_hoareD)
    apply (simp add: return_def bind_def)
    apply (metis in_inv_by_hoareD)
-  apply (rule_tac s="(do (x, y) \<leftarrow> do y \<leftarrow> g; x \<leftarrow> (\<lambda>_. f s) ; (\<lambda>_. return (x, y) s) od;
-                      n x y od) s" in trans[rotated])
+  apply (rule trans[where s="(do (x, y) \<leftarrow> do y \<leftarrow> g; x \<leftarrow> (\<lambda>_. f s) ; (\<lambda>_. return (x, y) s) od;
+                                 n x y od) s" for s, rotated])
    apply (simp add: bind_assoc)
    apply (intro bind_apply_cong, simp_all)[1]
     apply (metis in_inv_by_hoareD)

--- a/lib/Monads/nondet/Nondet_More_VCG.thy
+++ b/lib/Monads/nondet/Nondet_More_VCG.thy
@@ -137,8 +137,8 @@ lemma hoare_split_bind_case_sum:
              "\<And>rv. \<lbrace>S rv\<rbrace> h rv \<lbrace>Q\<rbrace>"
   assumes y: "\<lbrace>P\<rbrace> f \<lbrace>S\<rbrace>,\<lbrace>R\<rbrace>"
   shows      "\<lbrace>P\<rbrace> f >>= case_sum g h \<lbrace>Q\<rbrace>"
-  apply (rule hoare_seq_ext [OF _ y[unfolded validE_def]])
-  apply (case_tac x, simp_all add: x)
+  apply (rule hoare_seq_ext[OF _ y[unfolded validE_def]])
+  apply (wpsimp wp: x split: sum.splits)
   done
 
 lemma hoare_split_bind_case_sumE:
@@ -147,8 +147,8 @@ lemma hoare_split_bind_case_sumE:
   assumes y: "\<lbrace>P\<rbrace> f \<lbrace>S\<rbrace>,\<lbrace>R\<rbrace>"
   shows      "\<lbrace>P\<rbrace> f >>= case_sum g h \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
   apply (unfold validE_def)
-  apply (rule hoare_seq_ext [OF _ y[unfolded validE_def]])
-  apply (case_tac x, simp_all add: x [unfolded validE_def])
+  apply (rule hoare_seq_ext[OF _ y[unfolded validE_def]])
+  apply (wpsimp wp: x[unfolded validE_def] split: sum.splits)
   done
 
 lemma assertE_sp:
@@ -256,12 +256,11 @@ lemma doesn't_grow_proof:
   assumes x: "\<And>x. \<lbrace>\<lambda>s. x \<notin> S s \<and> P s\<rbrace> f \<lbrace>\<lambda>rv s. x \<notin> S s\<rbrace>"
   shows      "\<lbrace>\<lambda>s. card (S s) < n \<and> P s\<rbrace> f \<lbrace>\<lambda>rv s. card (S s) < n\<rbrace>"
   apply (clarsimp simp: valid_def)
-  apply (subgoal_tac "S b \<subseteq> S s")
-   apply (drule card_mono [OF y], simp)
+  apply (erule le_less_trans[rotated])
+  apply (rule card_mono[OF y])
   apply clarsimp
   apply (rule ccontr)
-  apply (subgoal_tac "x \<notin> S b", simp)
-  apply (erule use_valid [OF _ x])
+  apply (drule (2) use_valid[OF _ x, OF _ conjI])
   apply simp
   done
 
@@ -297,13 +296,12 @@ lemma shrinks_proof:
   assumes w: "\<And>s. P s \<Longrightarrow> x \<in> S s"
   shows      "\<lbrace>\<lambda>s. card (S s) \<le> n \<and> P s\<rbrace> f \<lbrace>\<lambda>rv s. card (S s) < n\<rbrace>"
   apply (clarsimp simp: valid_def)
-  apply (subgoal_tac "S b \<subset> S s")
-   apply (drule psubset_card_mono [OF y], simp)
+  apply (erule less_le_trans[rotated])
+  apply (rule psubset_card_mono[OF y])
   apply (rule psubsetI)
    apply clarsimp
    apply (rule ccontr)
-   apply (subgoal_tac "x \<notin> S b", simp)
-   apply (erule use_valid [OF _ x])
+   apply (drule (2) use_valid[OF _ x, OF _ conjI])
    apply simp
   by (metis use_valid w z)
 
@@ -397,13 +395,12 @@ lemma P_bool_lift:
   assumes f: "\<lbrace>\<lambda>s. \<not>Q s\<rbrace> f \<lbrace>\<lambda>r s. \<not>Q s\<rbrace>"
   shows "\<lbrace>\<lambda>s. P (Q s)\<rbrace> f \<lbrace>\<lambda>r s. P (Q s)\<rbrace>"
   apply (clarsimp simp: valid_def)
-  apply (subgoal_tac "Q b = Q s")
-   apply simp
+  apply (rule back_subst[where P=P], assumption)
   apply (rule iffI)
-   apply (rule classical)
-   apply (drule (1) use_valid [OF _ f])
-   apply simp
-  apply (erule (1) use_valid [OF _ t])
+   apply (erule (1) use_valid [OF _ t])
+  apply (rule classical)
+  apply (drule (1) use_valid [OF _ f])
+  apply simp
   done
 
 lemmas fail_inv = hoare_fail_any[where Q="\<lambda>_. P" and P=P for P]
@@ -411,20 +408,15 @@ lemmas fail_inv = hoare_fail_any[where Q="\<lambda>_. P" and P=P for P]
 lemma gets_sp: "\<lbrace>P\<rbrace> gets f \<lbrace>\<lambda>rv. P and (\<lambda>s. f s = rv)\<rbrace>"
   by (wp, simp)
 
-lemma post_by_hoare2:
-  "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>; (r, s') \<in> fst (f s); P s \<rbrakk> \<Longrightarrow> Q r s'"
-  by (rule post_by_hoare, assumption+)
-
 lemma hoare_Ball_helper:
   assumes x: "\<And>x. \<lbrace>P x\<rbrace> f \<lbrace>Q x\<rbrace>"
   assumes y: "\<And>P. \<lbrace>\<lambda>s. P (S s)\<rbrace> f \<lbrace>\<lambda>rv s. P (S s)\<rbrace>"
   shows "\<lbrace>\<lambda>s. \<forall>x \<in> S s. P x s\<rbrace> f \<lbrace>\<lambda>rv s. \<forall>x \<in> S s. Q x rv s\<rbrace>"
   apply (clarsimp simp: valid_def)
-  apply (subgoal_tac "S b = S s")
-   apply (erule post_by_hoare2 [OF x])
-   apply (clarsimp simp: Ball_def)
-  apply (erule_tac P1="\<lambda>x. x = S s" in post_by_hoare2 [OF y])
-  apply (rule refl)
+  apply (drule bspec, erule back_subst[where P="\<lambda>A. x\<in>A" for x])
+   apply (erule post_by_hoare[OF y, rotated])
+   apply (rule refl)
+  apply (erule (1) post_by_hoare[OF x])
   done
 
 lemma handy_prop_divs:
@@ -483,14 +475,14 @@ lemma hoare_in_monad_post:
   assumes x: "\<And>P. \<lbrace>P\<rbrace> f \<lbrace>\<lambda>x. P\<rbrace>"
   shows      "\<lbrace>\<top>\<rbrace> f \<lbrace>\<lambda>rv s. (rv, s) \<in> fst (f s)\<rbrace>"
   apply (clarsimp simp: valid_def)
-  apply (subgoal_tac "s = b", simp)
-  apply (simp add: state_unchanged [OF x])
+  apply (rule back_subst[where P="\<lambda>s. x\<in>fst (f s)" for x], assumption)
+  apply (simp add: state_unchanged[OF x])
   done
 
 lemma list_case_throw_validE_R:
   "\<lbrakk> \<And>y ys. xs = y # ys \<Longrightarrow> \<lbrace>P\<rbrace> f y ys \<lbrace>Q\<rbrace>,- \<rbrakk> \<Longrightarrow>
    \<lbrace>P\<rbrace> case xs of [] \<Rightarrow> throwError e | x # xs \<Rightarrow> f x xs \<lbrace>Q\<rbrace>,-"
-  apply (case_tac xs, simp_all)
+  apply (cases xs, simp_all)
   apply wp
   done
 
@@ -526,13 +518,13 @@ lemma wp_split_const_if:
   assumes x: "\<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>"
   assumes y: "\<lbrace>P'\<rbrace> f \<lbrace>Q'\<rbrace>"
   shows "\<lbrace>\<lambda>s. (G \<longrightarrow> P s) \<and> (\<not> G \<longrightarrow> P' s)\<rbrace> f \<lbrace>\<lambda>rv s. (G \<longrightarrow> Q rv s) \<and> (\<not> G \<longrightarrow> Q' rv s)\<rbrace>"
-  by (case_tac G, simp_all add: x y)
+  by (cases G; simp add: x y)
 
 lemma wp_split_const_if_R:
   assumes x: "\<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,-"
   assumes y: "\<lbrace>P'\<rbrace> f \<lbrace>Q'\<rbrace>,-"
   shows "\<lbrace>\<lambda>s. (G \<longrightarrow> P s) \<and> (\<not> G \<longrightarrow> P' s)\<rbrace> f \<lbrace>\<lambda>rv s. (G \<longrightarrow> Q rv s) \<and> (\<not> G \<longrightarrow> Q' rv s)\<rbrace>,-"
-  by (case_tac G, simp_all add: x y)
+  by (cases G; simp add: x y)
 
 lemma hoare_disj_division:
   "\<lbrakk> P \<or> Q; P \<Longrightarrow> \<lbrace>R\<rbrace> f \<lbrace>S\<rbrace>; Q \<Longrightarrow> \<lbrace>T\<rbrace> f \<lbrace>S\<rbrace> \<rbrakk>
@@ -593,11 +585,12 @@ lemma univ_wp:
 lemma univ_get_wp:
   assumes x: "\<And>P. \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv. P\<rbrace>"
   shows "\<lbrace>\<lambda>s. \<forall>(rv, s') \<in> fst (f s). s = s' \<longrightarrow> Q rv s'\<rbrace> f \<lbrace>Q\<rbrace>"
-  apply (rule hoare_pre_imp [OF _ univ_wp])
+  apply (rule hoare_pre_imp[OF _ univ_wp])
   apply clarsimp
   apply (drule bspec, assumption, simp)
-  apply (subgoal_tac "s = b", simp)
-  apply (simp add: state_unchanged [OF x])
+  apply (drule mp)
+   apply (simp add: state_unchanged[OF x])
+  apply simp
   done
 
 lemma other_hoare_in_monad_post:
@@ -634,10 +627,10 @@ lemma bindE_split_recursive_asm:
   apply (clarsimp simp: validE_def valid_def bindE_def in_bind lift_def)
   apply (erule allE, erule(1) impE)
   apply (drule(1) bspec, simp)
-  apply (case_tac x, simp_all add: in_throwError)
+  apply (clarsimp simp: in_throwError split: sum.splits)
   apply (drule x)
   apply (clarsimp simp: validE_def valid_def)
-  apply (drule(1) bspec, simp)
+  apply (drule(1) bspec, simp split: sum.splits)
   done
 
 lemma validE_R_abstract_rv:
@@ -691,9 +684,8 @@ lemma valid_rv_split:
 lemma hoare_rv_split:
   "\<lbrakk>\<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. rv \<longrightarrow> (Q rv s)\<rbrace>; \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. (\<not>rv) \<longrightarrow> (Q rv s)\<rbrace>\<rbrakk>
    \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>"
-  apply (clarsimp simp: valid_def)
-  apply (case_tac a, fastforce+)
-  done
+  apply (clarsimp simp: valid_def split_def)
+  by (metis (full_types) fst_eqD snd_conv)
 
 lemma combine_validE:
   "\<lbrakk> \<lbrace> P \<rbrace> x \<lbrace> Q \<rbrace>,\<lbrace> E \<rbrace>; \<lbrace> P' \<rbrace> x \<lbrace> Q' \<rbrace>,\<lbrace> E' \<rbrace> \<rbrakk>
@@ -722,23 +714,19 @@ lemma validE_pre_satisfies_post:
 
 lemma hoare_validE_R_conjI:
   "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>, - ; \<lbrace>P\<rbrace> f \<lbrace>Q'\<rbrace>, - \<rbrakk>  \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. Q rv s \<and> Q' rv s\<rbrace>, -"
-  apply (clarsimp simp: Ball_def validE_R_def validE_def valid_def)
-  by (case_tac a; fastforce)
+  by (clarsimp simp: Ball_def validE_R_def validE_def valid_def split: sum.splits)
 
 lemma hoare_validE_E_conjI:
   "\<lbrakk> \<lbrace>P\<rbrace> f -, \<lbrace>Q\<rbrace> ; \<lbrace>P\<rbrace> f -, \<lbrace>Q'\<rbrace> \<rbrakk>  \<Longrightarrow> \<lbrace>P\<rbrace> f -, \<lbrace>\<lambda>rv s. Q rv s \<and> Q' rv s\<rbrace>"
-  apply (clarsimp simp: Ball_def validE_E_def validE_def valid_def)
-  by (case_tac a; fastforce)
+  by (clarsimp simp: Ball_def validE_E_def validE_def valid_def split: sum.splits)
 
 lemma validE_R_post_conjD1:
   "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>r s. Q r s \<and> R r s\<rbrace>,- \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,-"
-  apply (clarsimp simp: validE_R_def validE_def valid_def)
-  by (case_tac a; fastforce)
+  by (fastforce simp: validE_R_def validE_def valid_def split: sum.splits)
 
 lemma validE_R_post_conjD2:
   "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>r s. Q r s \<and> R r s\<rbrace>,- \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>R\<rbrace>,-"
-  apply (clarsimp simp: validE_R_def validE_def valid_def)
-  by (case_tac a; fastforce)
+  by (fastforce simp: validE_R_def validE_def valid_def split: sum.splits)
 
 lemma throw_opt_wp[wp]:
   "\<lbrace>if v = None then E ex else Q (the v)\<rbrace> throw_opt ex v \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"

--- a/lib/Monads/nondet/Nondet_VCG.thy
+++ b/lib/Monads/nondet/Nondet_VCG.thy
@@ -982,7 +982,7 @@ lemmas liftME_E_E_wp[wp_split] = validE_validE_E [OF liftME_wp, simplified, OF v
 lemma assert_opt_wp:
   "\<lbrace>\<lambda>s. x \<noteq> None \<longrightarrow> Q (the x) s\<rbrace> assert_opt x \<lbrace>Q\<rbrace>"
   unfolding assert_opt_def
-  by (case_tac x; wpsimp wp: fail_wp return_wp)
+  by (cases x; wpsimp wp: fail_wp return_wp)
 
 lemma gets_the_wp:
   "\<lbrace>\<lambda>s. (f s \<noteq> None) \<longrightarrow> Q (the (f s)) s\<rbrace> gets_the f \<lbrace>Q\<rbrace>"

--- a/lib/Monads/nondet/Nondet_While_Loop_Rules.thy
+++ b/lib/Monads/nondet/Nondet_While_Loop_Rules.thy
@@ -286,22 +286,35 @@ lemma fst_whileLoop_cond_false:
   using loop_result
   by (rule in_whileLoop_induct, auto)
 
+lemma whileLoop_terminates_results:
+  assumes non_term: "\<And>r. \<lbrace> \<lambda>s. I r s \<and> C r s \<and> \<not> snd (B r s) \<rbrace> B r \<exists>\<lbrace> \<lambda>r' s'. C r' s' \<and> I r' s' \<rbrace>"
+  shows
+    "\<lbrakk>whileLoop_terminates C B r s; (Some (r, s), None) \<notin> whileLoop_results C B; I r s; C r s\<rbrakk>
+     \<Longrightarrow> False"
+proof (induct rule: whileLoop_terminates.induct)
+  case (1 r s)
+  then show ?case
+    apply clarsimp
+    done
+next
+  case (2 r s)
+  then show ?case
+    apply (cut_tac non_term[where r=r])
+    apply (clarsimp simp: exs_valid_def)
+    apply (subst (asm) (2) whileLoop_results.simps)
+    apply clarsimp
+    apply (insert whileLoop_results.simps)
+    apply fast
+    done
+qed
+
 lemma snd_whileLoop:
   assumes init_I: "I r s"
-      and cond_I: "C r s"
-      and non_term: "\<And>r. \<lbrace> \<lambda>s. I r s \<and> C r s \<and> \<not> snd (B r s) \<rbrace> B r \<exists>\<lbrace> \<lambda>r' s'. C r' s' \<and> I r' s' \<rbrace>"
+    and cond_I: "C r s"
+    and non_term: "\<And>r. \<lbrace> \<lambda>s. I r s \<and> C r s \<and> \<not> snd (B r s) \<rbrace> B r \<exists>\<lbrace> \<lambda>r' s'. C r' s' \<and> I r' s' \<rbrace>"
   shows "snd (whileLoop C B r s)"
   apply (clarsimp simp: whileLoop_def)
-  apply (rotate_tac)
-  apply (insert init_I cond_I)
-  apply (induct rule: whileLoop_terminates.induct)
-   apply clarsimp
-  apply (cut_tac r=r in non_term)
-  apply (clarsimp simp: exs_valid_def)
-   apply (subst (asm) (2) whileLoop_results.simps)
-   apply clarsimp
-  apply (insert whileLoop_results.simps)
-  apply fast
+  apply (erule (1) whileLoop_terminates_results[OF non_term _ _ init_I cond_I])
   done
 
 lemma whileLoop_terminates_inv:
@@ -429,11 +442,11 @@ lemma whileLoopE_wp:
   by (rule validE_whileLoopE)
 
 lemma exs_valid_whileLoop:
- assumes init_T: "\<And>s. P s \<Longrightarrow> T r s"
+  assumes init_T: "\<And>s. P s \<Longrightarrow> T r s"
     and iter_I: "\<And>r s0. \<lbrace>\<lambda>s. T r s \<and> C r s \<and> s = s0\<rbrace> B r \<exists>\<lbrace>\<lambda>r' s'. T r' s' \<and> ((r', s'),(r, s0)) \<in> R\<rbrace>"
     and wf_R: "wf R"
     and final_I: "\<And>r s. \<lbrakk> T r s; \<not> C r s  \<rbrakk> \<Longrightarrow> Q r s"
- shows "\<lbrace> P \<rbrace> whileLoop C B r \<exists>\<lbrace> Q \<rbrace>"
+  shows "\<lbrace> P \<rbrace> whileLoop C B r \<exists>\<lbrace> Q \<rbrace>"
 proof (clarsimp simp: exs_valid_def Bex_def)
   fix s
   assume "P s"
@@ -442,17 +455,21 @@ proof (clarsimp simp: exs_valid_def Bex_def)
     fix x
     have "T (fst x) (snd x) \<Longrightarrow> \<exists>r' s'. (r', s') \<in> fst (whileLoop C B (fst x) (snd x)) \<and> T r' s'"
       using wf_R
-      apply induction
-      apply atomize
-      apply (case_tac "C (fst x) (snd x)")
-       apply (subst whileLoop_unroll)
-       apply (clarsimp simp: condition_def bind_def' split: prod.splits)
-       apply (cut_tac ?s0.0=b and r=a in iter_I)
-       apply (clarsimp simp: exs_valid_def)
-       apply blast
-      apply (subst whileLoop_unroll)
-      apply (clarsimp simp: condition_def bind_def' return_def)
-      done
+    proof induct
+      case (less x)
+      then show ?case
+        apply atomize
+        apply (cases "C (fst x) (snd x)")
+         apply (subst whileLoop_unroll)
+         apply (clarsimp simp: condition_def bind_def')
+         apply (cut_tac iter_I[where ?s0.0="snd x" and r="fst x"])
+         apply (clarsimp simp: exs_valid_def)
+         apply blast
+        apply (subst whileLoop_unroll)
+        apply (cases x)
+        apply (clarsimp simp: condition_def bind_def' return_def)
+        done
+    qed
   }
 
   thus "\<exists>r' s'. (r', s') \<in> fst (whileLoop C B r s) \<and> Q r' s'"
@@ -477,8 +494,7 @@ proof -
         apply fact
        apply (rule cond_true, fact)
       apply (clarsimp simp: exs_valid_def)
-      apply (case_tac "fst (B r s) = {}")
-       apply (metis empty_failD [OF body_empty_fail])
+      apply (drule empty_failD3[OF body_empty_fail])
       apply (subst (asm) whileLoop_unroll)
       apply (fastforce simp: condition_def bind_def split_def cond_true)
       done
@@ -498,33 +514,59 @@ lemma empty_fail_whileM[empty_fail_cond, intro!, wp]:
   unfolding whileM_def
   by (wpsimp wp: empty_fail_whileLoop empty_fail_bind)
 
-lemma whileLoop_results_bisim:
+lemma whileLoop_results_bisim_helper:
   assumes base: "(a, b) \<in> whileLoop_results C B"
-  and vars1: "Q = (case a of Some (r, s) \<Rightarrow> Some (rt r, st s) | _ \<Rightarrow> None)"
-  and vars2: "R = (case b of Some (r, s) \<Rightarrow> Some (rt r, st s) | _ \<Rightarrow> None)"
-  and inv_init: "case a of Some (r, s) \<Rightarrow> I r s | _ \<Rightarrow> True"
-  and inv_step: "\<And>r s r' s'. \<lbrakk> I r s; C r s; (r', s') \<in> fst (B r s) \<rbrakk> \<Longrightarrow> I r' s'"
-  and cond_match: "\<And>r s. I r s \<Longrightarrow> C r s = C' (rt r) (st s)"
-  and fail_step: "\<And>r s. \<lbrakk>C r s; snd (B r s); I r s\<rbrakk>
+    and inv_init: "case a of Some (r, s) \<Rightarrow> I r s | _ \<Rightarrow> True"
+    and inv_step: "\<And>r s r' s'. \<lbrakk> I r s; C r s; (r', s') \<in> fst (B r s) \<rbrakk> \<Longrightarrow> I r' s'"
+    and cond_match: "\<And>r s. I r s \<Longrightarrow> C r s = C' (rt r) (st s)"
+    and fail_step: "\<And>r s. \<lbrakk>C r s; snd (B r s); I r s\<rbrakk>
                          \<Longrightarrow> (Some (rt r, st s), None) \<in> whileLoop_results C' B'"
-  and refine: "\<And>r s r' s'. \<lbrakk> I r s; C r s; (r', s') \<in>  fst (B r s) \<rbrakk>
+    and refine: "\<And>r s r' s'. \<lbrakk> I r s; C r s; (r', s') \<in>  fst (B r s) \<rbrakk>
                             \<Longrightarrow> (rt r', st s') \<in> fst (B' (rt r) (st s))"
-  shows "(Q, R) \<in> whileLoop_results C' B'"
-  apply (subst vars1)
-  apply (subst vars2)
-  apply (insert base inv_init)
-  apply (induct rule: whileLoop_results.induct)
+  defines [simp]: "Q x \<equiv> (case x of Some (r, s) \<Rightarrow> Some (rt r, st s) | _ \<Rightarrow> None)"
+    and [simp]: "R y\<equiv> (case y of Some (r, s) \<Rightarrow> Some (rt r, st s) | _ \<Rightarrow> None)"
+  shows "(Q a, R b) \<in> whileLoop_results C' B'"
+  using base inv_init
+proof (induct rule: whileLoop_results.induct)
+  case (1 r s)
+  then show ?case
     apply clarsimp
     apply (subst (asm) cond_match)
      apply (clarsimp simp: option.splits)
     apply (clarsimp simp: option.splits)
-   apply (clarsimp simp: option.splits)
-   apply (metis fail_step)
-  apply (case_tac z)
-   apply (clarsimp simp: option.splits)
-   apply (metis cond_match inv_step refine whileLoop_results.intros(3))
-  apply (clarsimp simp: option.splits)
-  apply (metis cond_match inv_step refine whileLoop_results.intros(3))
+    done
+next
+  case (2 r s)
+  then show ?case
+    apply (clarsimp simp: option.splits)
+    apply (metis fail_step)
+    done
+next
+  case (3 r s r' s' z)
+  then show ?case
+    apply (cases z)
+     apply (clarsimp simp: option.splits)
+     apply (metis cond_match inv_step refine whileLoop_results.intros(3))
+    apply (clarsimp simp: option.splits)
+    apply (metis cond_match inv_step refine whileLoop_results.intros(3))
+    done
+qed
+
+lemma whileLoop_results_bisim:
+  assumes base: "(a, b) \<in> whileLoop_results C B"
+    and vars1: "Q = (case a of Some (r, s) \<Rightarrow> Some (rt r, st s) | _ \<Rightarrow> None)"
+    and vars2: "R = (case b of Some (r, s) \<Rightarrow> Some (rt r, st s) | _ \<Rightarrow> None)"
+    and inv_init: "case a of Some (r, s) \<Rightarrow> I r s | _ \<Rightarrow> True"
+    and inv_step: "\<And>r s r' s'. \<lbrakk> I r s; C r s; (r', s') \<in> fst (B r s) \<rbrakk> \<Longrightarrow> I r' s'"
+    and cond_match: "\<And>r s. I r s \<Longrightarrow> C r s = C' (rt r) (st s)"
+    and fail_step: "\<And>r s. \<lbrakk>C r s; snd (B r s); I r s\<rbrakk>
+                         \<Longrightarrow> (Some (rt r, st s), None) \<in> whileLoop_results C' B'"
+    and refine: "\<And>r s r' s'. \<lbrakk> I r s; C r s; (r', s') \<in>  fst (B r s) \<rbrakk>
+                            \<Longrightarrow> (rt r', st s') \<in> fst (B' (rt r) (st s))"
+  shows "(Q, R) \<in> whileLoop_results C' B'"
+  apply (subst vars1, subst vars2)
+  apply (rule whileLoop_results_bisim_helper)
+       apply (rule assms; assumption?)+
   done
 
 lemma whileLoop_terminates_liftE:
@@ -564,6 +606,10 @@ lemma snd_X_return[simp]:
   "snd ((A >>= (\<lambda>a. return (X a))) s) = snd (A s)"
   by (clarsimp simp: return_def bind_def split_def)
 
+lemma isr_Inr_projr:
+  "\<not> isl a \<Longrightarrow> (a = Inr b) = (b = projr a)"
+  by auto
+
 lemma whileLoopE_liftE:
   "whileLoopE C (\<lambda>r. liftE (B r)) r = liftE (whileLoop C B r)"
   apply (rule ext)
@@ -571,30 +617,33 @@ lemma whileLoopE_liftE:
   apply (rule prod_eqI)
    apply (rule set_eqI, rule iffI)
     apply clarsimp
-    apply (clarsimp simp: in_bind whileLoop_def liftE_def)
-    apply (rule_tac x="b" in exI)
-    apply (rule_tac x="projr a" in exI)
+    apply (clarsimp simp: in_liftE whileLoop_def)
+    \<comment> \<open>The schematic existential is instantiated by 'subst isr_Inr_proj' ... 'rule refl' in two lines\<close>
+    apply (rule exI)
     apply (rule conjI)
-     apply (erule whileLoop_results_bisim[where rt=projr
-                                            and st="\<lambda>x. x"
-                                            and I="\<lambda>r s. case r of Inr x \<Rightarrow> True | _ \<Rightarrow> False"],
-            auto intro: whileLoop_results.intros simp: bind_def return_def lift_def split: sum.splits)[1]
-    apply (drule whileLoop_results_induct_lemma2[where P="\<lambda>(r, s). case r of Inr x \<Rightarrow> True | _ \<Rightarrow> False"])
+     apply (subst isr_Inr_projr)
+      prefer 2
+      apply (rule refl)
+     apply (drule whileLoop_results_induct_lemma2[where P="\<lambda>(r, s). \<not> isl r"])
+         apply (rule refl)
         apply (rule refl)
-       apply (rule refl)
-      apply clarsimp
-     apply (clarsimp simp: return_def bind_def lift_def split: sum.splits)
-    apply (clarsimp simp: return_def bind_def lift_def split: sum.splits)
-   apply (clarsimp simp: in_bind whileLoop_def liftE_def)
+       apply clarsimp
+      apply (clarsimp simp: return_def bind_def lift_def liftE_def split: sum.splits)
+     apply clarsimp
+    apply (erule whileLoop_results_bisim[where rt=projr
+                                           and st="\<lambda>x. x"
+                                           and I="\<lambda>r s. \<not> isl r"],
+           auto intro: whileLoop_results.intros simp: bind_def return_def lift_def liftE_def split: sum.splits)[1]
+   apply (clarsimp simp: in_liftE whileLoop_def)
    apply (erule whileLoop_results_bisim[where rt=Inr and st="\<lambda>x. x" and I="\<lambda>r s. True"],
-          auto intro: whileLoop_results.intros intro!: bexI simp: bind_def return_def lift_def
-               split: sum.splits)[1]
+          auto intro: whileLoop_results.intros intro!: bexI
+               simp: bind_def return_def lift_def liftE_def split: sum.splits)[1]
   apply (rule iffI)
    apply (clarsimp simp: whileLoop_def liftE_def del: notI)
    apply (erule disjE)
     apply (erule whileLoop_results_bisim[where rt=projr
                                            and st="\<lambda>x. x"
-                                           and I="\<lambda>r s. case r of Inr x \<Rightarrow> True | _ \<Rightarrow> False"],
+                                           and I="\<lambda>r s. \<not> isl r"],
            auto intro: whileLoop_results.intros simp: bind_def return_def lift_def split: sum.splits)[1]
    apply (subst (asm) whileLoop_terminates_liftE [symmetric])
    apply (fastforce simp: whileLoop_def liftE_def whileLoop_terminatesE_def)

--- a/lib/Monads/nondet/Nondet_While_Loop_Rules_Completeness.thy
+++ b/lib/Monads/nondet/Nondet_While_Loop_Rules_Completeness.thy
@@ -34,12 +34,14 @@ lemma valid_whileLoop_complete:
     = \<lbrace> P r \<rbrace> whileLoop C B r \<lbrace> Q \<rbrace>"
   apply (rule iffI)
    apply clarsimp
+   apply (rename_tac I)
    apply (rule_tac I=I in valid_whileLoop, auto)[1]
   apply (rule exI [where x="\<lambda>r s. \<lbrace> \<lambda>s'. s' = s \<rbrace> whileLoop C B r \<lbrace> Q \<rbrace>"])
   apply (intro conjI)
     apply (clarsimp simp: valid_def)
    apply (subst (2) valid_def)
    apply clarsimp
+   apply (rename_tac a b)
    apply (subst (asm) (2) whileLoop_unroll)
    apply (case_tac "C a b")
     apply (clarsimp simp: valid_def bind_def' Bex_def condition_def split: if_split_asm)
@@ -66,7 +68,7 @@ proof (rule iffI)
     by auto
 
   thus ?RHS
-    by (rule_tac validNF_whileLoop [where I=I and R=R], auto)
+    by - (rule validNF_whileLoop[where I=I and R=R], auto)
 next
   assume loop: "?RHS"
 
@@ -225,6 +227,10 @@ where
   | "valid_path C B [x] = (\<not> C (fst x) (snd x))"
   | "valid_path C B (x#y#xs) = ((C (fst x) (snd x) \<and> y \<in> fst (B (fst x) (snd x)) \<and> valid_path C B (y#xs)))"
 
+lemma valid_path_not_empty:
+  "valid_path C B xs \<Longrightarrow> xs \<noteq> []"
+  by clarsimp
+
 definition "shortest_path_length C B x Q \<equiv>
         (LEAST n. \<exists>l. valid_path C B l \<and> hd l = x \<and> Q (fst (last l)) (snd (last l)) \<and> length l = n)"
 
@@ -234,8 +240,7 @@ lemma shortest_path_length_same [simp]:
   apply (rule Least_equality)
    apply (rule exI [where x="[a]"])
    apply clarsimp
-  apply (case_tac "y = 0")
-   apply clarsimp
+  apply (rule Suc_leI)
   apply clarsimp
   done
 
@@ -243,9 +248,8 @@ lemma valid_path_simp:
   "valid_path C B l =
         (((\<exists>r s. l = [(r, s)] \<and> \<not> C r s) \<or>
               (\<exists>r s r' s' xs. l = (r, s)#(r', s')#xs \<and> C r s \<and> (r', s') \<in> fst (B r s) \<and> valid_path C B ((r', s')#xs))))"
-  apply (case_tac l)
-   apply clarsimp
-  apply (case_tac list)
+  apply (cases l rule: remdups_adj.cases)
+    apply clarsimp
    apply clarsimp
   apply clarsimp
   done
@@ -260,15 +264,23 @@ proof -
     assume y: "Q r' s'"
     have ?thesis
       using x y
-      apply (induct rule: in_whileLoop_induct)
-       apply (rule_tac x="[(r,s)]" in exI)
-       apply clarsimp
-      apply clarsimp
-      apply (case_tac l)
-       apply clarsimp
-      apply (rule_tac x="(r, s)#l" in exI)
-      apply clarsimp
-      done
+    proof (induct rule: in_whileLoop_induct)
+      case (1 r s)
+      then show ?case
+        apply -
+        apply (rule exI[where x="[(r,s)]"])
+        apply clarsimp
+        done
+    next
+      case (2 r s r' s' r'' s'')
+      then show ?case
+        apply clarsimp
+        apply (frule valid_path_not_empty)
+        apply (rename_tac l)
+        apply (rule_tac x="(r, s)#l" in exI)
+        apply (clarsimp simp: neq_Nil_conv)
+        done
+    qed
   }
 
   thus ?thesis
@@ -297,27 +309,33 @@ lemma shortest_path_is_shortest:
   done
 
 lemma valid_path_implies_exs_valid_whileLoop:
-    "valid_path C B l \<Longrightarrow> \<lbrace> \<lambda>s. s = snd (hd l) \<rbrace> whileLoop C B (fst (hd l)) \<exists>\<lbrace> \<lambda>r s. (r, s) = last l  \<rbrace>"
-  apply (induct l)
-   apply clarsimp
-  apply clarsimp
-  apply rule
-   apply clarsimp
-   apply (subst whileLoop_unroll)
-   apply (clarsimp simp: condition_def bind_def' exs_valid_def return_def)
-  apply clarsimp
-  apply (subst whileLoop_unroll)
-  apply (clarsimp simp: condition_def bind_def' exs_valid_def return_def)
-  apply rule
-   apply (clarsimp split: prod.splits)
-   apply (case_tac l)
+  "valid_path C B l \<Longrightarrow> \<lbrace> \<lambda>s. s = snd (hd l) \<rbrace> whileLoop C B (fst (hd l)) \<exists>\<lbrace> \<lambda>r s. (r, s) = last l  \<rbrace>"
+proof (induct l)
+  case Nil
+  then show ?case
+    by clarsimp
+next
+  case (Cons a l)
+  then show ?case
     apply clarsimp
-   apply (clarsimp split del: if_split)
-   apply (erule bexI [rotated])
-   apply clarsimp
-  apply clarsimp
-  apply (case_tac l, auto)
-  done
+    apply rule
+     apply clarsimp
+     apply (subst whileLoop_unroll)
+     apply (clarsimp simp: condition_def bind_def' exs_valid_def return_def)
+    apply clarsimp
+    apply (subst whileLoop_unroll)
+    apply (clarsimp simp: condition_def bind_def' exs_valid_def return_def)
+    apply rule
+     apply (clarsimp split: prod.splits)
+     apply (cases l)
+      apply clarsimp
+     apply (clarsimp split del: if_split)
+     apply (erule bexI[rotated])
+     apply clarsimp
+    apply clarsimp
+    apply (cases l; clarsimp)
+    done
+qed
 
 lemma shortest_path_gets_shorter:
   "\<lbrakk> \<lbrace> \<lambda>s'. s' = s \<rbrace> whileLoop C B r \<exists>\<lbrace> Q \<rbrace>;
@@ -327,21 +345,22 @@ lemma shortest_path_gets_shorter:
                  \<and> \<lbrace> \<lambda>s. s = s' \<rbrace> whileLoop C B r' \<exists>\<lbrace> Q \<rbrace>"
   apply (drule shortest_path_exists)
   apply clarsimp
-  apply (case_tac l)
+  apply (rename_tac l)
+  apply (case_tac l rule: remdups_adj.cases)
+    apply clarsimp
    apply clarsimp
-  apply (case_tac list)
+  apply (rule bexI[rotated])
    apply clarsimp
-  apply (rule_tac x="aa" in bexI)
-   apply clarify
-   apply (simp only: valid_path.simps, clarify)
-   apply (frule shortest_path_is_shortest [where Q=Q])
-    apply simp
-   apply clarsimp
-   apply (drule valid_path_implies_exs_valid_whileLoop)
-   apply (clarsimp simp: exs_valid_def)
-   apply (erule bexI [rotated])
-   apply (clarsimp split: if_split_asm)
+   apply assumption
+  apply clarify
+  apply (simp only: valid_path.simps, clarify)
+  apply (frule shortest_path_is_shortest [where Q=Q])
+   apply simp
   apply clarsimp
+  apply (drule valid_path_implies_exs_valid_whileLoop)
+  apply (clarsimp simp: exs_valid_def)
+  apply (erule bexI [rotated])
+  apply (clarsimp split: if_split_asm)
   done
 
 lemma exs_valid_whileLoop_complete:


### PR DESCRIPTION
In particular, try to remove as many _tac methods that refer to system-generated variable names as possible. Any remaining uses are explicitly protected by a rename_tac.