### PR TITLE
If cpp_path is relative, make it relative to the current theory.

### DIFF
--- a/tools/c-parser/isar_install.ML
+++ b/tools/c-parser/isar_install.ML
@@ -145,7 +145,9 @@ fun get_Csyntax thy s = let
   val cpp_option =
       case Config.get_global thy cpp_path of
           "" => NONE
-        | s => SOME s
+        | s => SOME (if Path.is_absolute (Path.explode s) 
+                     then s 
+                     else Path.implode (Path.append (Resources.master_directory thy) (Path.explode s)))
   val cpp_error_count = Config.get_global thy report_cpp_errors
   val (ast0, _) =
       StrictCParser.parse

--- a/tools/c-parser/isar_install.ML
+++ b/tools/c-parser/isar_install.ML
@@ -145,8 +145,8 @@ fun get_Csyntax thy s = let
   val cpp_option =
       case Config.get_global thy cpp_path of
           "" => NONE
-        | s => SOME (if Path.is_absolute (Path.explode s) 
-                     then s 
+        | s => SOME (if Path.is_absolute (Path.explode s)
+                     then s
                      else Path.implode (Path.append (Resources.master_directory thy) (Path.explode s)))
   val cpp_error_count = Config.get_global thy report_cpp_errors
   val (ast0, _) =


### PR DESCRIPTION
If the path configures as "cpp_path" is not an absolute path, convert it to an absolute path by prepending the directory in which the "install_C_file" is used.  This makes it easier to share the same configuration across a team using different operating systems. 