### PR TITLE
MCS CRefine sorried for RISCV64

### DIFF
--- a/proof/Makefile
+++ b/proof/Makefile
@@ -15,6 +15,11 @@ ifeq "$(L4V_ARCH)" "AARCH64"
   export REFINE_QUICK_AND_DIRTY=1
 endif
 
+# Allow sorry command in RISCV64 CRefine during development:
+ifeq "$(L4V_ARCH)" "RISCV64"
+  export CREFINE_QUICK_AND_DIRTY=1
+endif
+
 #
 # Setup heaps.
 #

--- a/proof/crefine/RISCV64/ArchMove_C.thy
+++ b/proof/crefine/RISCV64/ArchMove_C.thy
@@ -94,7 +94,7 @@ lemma atg_sp':
 (* FIXME: MOVE to EmptyFail *)
 lemma empty_fail_archThreadGet [intro!, wp, simp]:
   "empty_fail (archThreadGet f p)"
-  by (fastforce simp: archThreadGet_def)
+  by (wpsimp simp: archThreadGet_def)
 
 (* FIXME: move to ainvs? *)
 lemma sign_extend_canonical_address:

--- a/proof/crefine/RISCV64/Arch_C.thy
+++ b/proof/crefine/RISCV64/Arch_C.thy
@@ -130,8 +130,7 @@ using [[goals_limit=20]]
   apply (clarsimp simp: cap_lift_page_table_cap cap_to_H_def
                         cap_page_table_cap_lift_def isCap_simps
                         valid_cap'_def get_capSizeBits_CL_def
-                        bit_simps capAligned_def
-                        to_bool_def mask_def page_table_at'_def
+                        bit_simps capAligned_def mask_def page_table_at'_def
                         capRange_def Int_commute asid_bits_def
                         wellformed_mapdata'_def
              simp flip: canonical_bit_def
@@ -2923,7 +2922,7 @@ lemma decodeRISCVMMUInvocation_ccorres:
                           cap_to_H_def[split_simps cap_CL.split]
                           hd_conv_nth length_ineq_not_Nil Kernel_C_defs
                    elim!: ccap_relationE)
-   apply (clarsimp simp: to_bool_def unat_eq_of_nat objBits_simps pageBits_def case_bool_If
+   apply (clarsimp simp: unat_eq_of_nat objBits_simps pageBits_def case_bool_If
                   split: if_splits)
   apply (clarsimp simp: asid_low_bits_word_bits isCap_simps neq_Nil_conv
                         excaps_map_def excaps_in_mem_def

--- a/proof/crefine/RISCV64/Finalise_C.thy
+++ b/proof/crefine/RISCV64/Finalise_C.thy
@@ -1990,12 +1990,6 @@ lemma schedContext_unbindNtfn_ccorres:
     (schedContextUnbindNtfn scPtr) (Call schedContext_unbindNtfn_'proc)"
 sorry (* FIXME RT: schedContext_unbindNtfn_ccorres *)
 
-lemma reply_remove_ccorres:
-  "ccorres dc xfdc
-    (invs' and sc_at' scPtr) (\<lbrace>\<acute>reply = Ptr replyPtr\<rbrace> \<inter> \<lbrace>\<acute>tcb = tcb_ptr_to_ctcb_ptr tcbPtr\<rbrace>) []
-    (replyRemove replyPtr tcbPtr) (Call reply_remove_'proc)"
-sorry (* FIXME RT: reply_remove_ccorres *)
-
 lemma schedContext_unbindTCB_ccorres:
   "ccorres dc xfdc
     (invs' and sc_at' scPtr) (\<lbrace>\<acute>sc = Ptr scPtr\<rbrace> \<inter> \<lbrace>\<acute>tcb = tcb_ptr_to_ctcb_ptr tcbPtr\<rbrace>) []

--- a/proof/crefine/RISCV64/Invoke_C.thy
+++ b/proof/crefine/RISCV64/Invoke_C.thy
@@ -77,14 +77,14 @@ lemma setDomain_ccorres:
       apply simp
       apply wp
      apply (rule_tac Q="\<lambda>_. invs' and tcb_at' t and sch_act_simple
-                        and (\<lambda>s. rv = ksCurThread s)
+                        and (\<lambda>s. curThread = ksCurThread s)
                         and (\<lambda>s. \<forall>d p. distinct (ksReadyQueues s (d, p)))"
                   in hoare_strengthen_post)
        apply wp
       apply (fastforce simp: valid_pspace_valid_objs' weak_sch_act_wf_def
                       split: if_splits)
      apply (rule_tac Q="\<lambda>_. invs' and tcb_at' t and sch_act_simple
-                            and (\<lambda>s. rv = ksCurThread s \<and> (\<forall>p. t \<notin> set (ksReadyQueues s p)))
+                            and (\<lambda>s. curThread = ksCurThread s \<and> (\<forall>p. t \<notin> set (ksReadyQueues s p)))
                             and (\<lambda>s. \<forall>d p. distinct (ksReadyQueues s (d, p)))"
                   in hoare_strengthen_post)
       apply (wpsimp wp: threadSet_tcbDomain_update_invs')
@@ -2893,6 +2893,7 @@ lemma decodeUntypedInvocation_ccorres_helper:
                                   fromEnum_object_type_to_H
                                   object_type_from_H_def minSchedContextBits_def
                                   fromAPIType_def RISCV64_H.fromAPIType_def)
+sorry (* decodeUntypedInvocation_ccorres_helper: needs minSchedContextBits update
                 apply (rule syscall_error_throwError_ccorres_n)
                 apply (simp add: syscall_error_to_H_cases)
                apply (rule_tac xf'="nodeCap_'"
@@ -3365,7 +3366,7 @@ lemma decodeUntypedInvocation_ccorres_helper:
                          capCNodeRadix_CL_less_64s rf_sr_ksCurThread not_le
                   elim!: inl_inrE)
   apply (clarsimp simp: enum_object_type enum_apiobject_type word_le_nat_alt seL4_ObjectTypeCount_def)
-  done
+  done *)
 
 lemma decodeUntypedInvocation_ccorres:
 notes TripleSuc[simp]

--- a/proof/crefine/RISCV64/Invoke_C.thy
+++ b/proof/crefine/RISCV64/Invoke_C.thy
@@ -2527,7 +2527,7 @@ lemma mapME_ensureEmptySlot':
   \<lbrace>\<lambda>rva s. P s \<and> (\<forall>slot \<in> set slots. (\<exists>cte. cteCap cte = capability.NullCap \<and> ctes_of s (f slot) = Some cte))\<rbrace>, -"
   including no_pre
   apply (induct slots arbitrary: P)
-   apply wpsimp
+   apply (wpsimp wp: mapME_wp')
   apply (rename_tac a slots P)
   apply (simp add: mapME_def sequenceE_def Let_def)
   apply (rule_tac Q="\<lambda>rv. P and (\<lambda>s. \<exists>cte. cteCap cte = capability.NullCap \<and> ctes_of s (f a) = Some cte)" in validE_R_sp)

--- a/proof/crefine/RISCV64/IpcCancel_C.thy
+++ b/proof/crefine/RISCV64/IpcCancel_C.thy
@@ -1,7 +1,7 @@
 (*
  * Copyright 2023, Proofcraft Pty Ltd
- * Copyright 2014, General Dynamics C4 Systems
  * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only
  *)
@@ -2745,7 +2745,7 @@ lemma cpspace_relation_ep_update_an_ep:
   and     psp: "pspace_aligned' s" "pspace_distinct' s" "pspace_bounded' s"
   and  others: "\<And>epptr' ep'. \<lbrakk> ko_at' ep' epptr' s; epptr' \<noteq> epptr; ep' \<noteq> IdleEP \<rbrakk>
                                  \<Longrightarrow> set (epQueue ep') \<inter> (ctcb_ptr_to_tcb_ptr ` S) = {}"
-  shows "cmap_relation (map_to_eps (ksPSpace s(epptr \<mapsto> KOEndpoint ep')))
+  shows "cmap_relation (map_to_eps ((ksPSpace s)(epptr \<mapsto> KOEndpoint ep')))
            ((cslift t)(Ptr epptr \<mapsto> endpoint)) Ptr (cendpoint_relation mp')"
   using cp koat psp rel unfolding cmap_relation_def
   apply -
@@ -3037,6 +3037,20 @@ lemma reply_unlink_ccorres:
     (\<lbrace>\<acute>tcb = tcb_ptr_to_ctcb_ptr tcbPtr\<rbrace> \<inter> \<lbrace>\<acute>reply = Ptr replyPtr\<rbrace>) []
     (replyUnlink tcbPtr replyPtr) (Call reply_unlink_'proc)"
 sorry (* FIXME RT: reply_unlink_ccorres *)
+
+lemma reply_pop_ccorres:
+  "ccorres dc xfdc
+    (invs' and tcb_at' tcbPtr and reply_at' replyPtr)
+    (\<lbrace>\<acute>reply = Ptr replyPtr\<rbrace> \<inter> \<lbrace>\<acute>tcb = tcb_ptr_to_ctcb_ptr tcbPtr\<rbrace>) []
+    (replyPop replyPtr tcbPtr) (Call reply_pop_'proc)"
+sorry (* FIXME RT: reply_pop_ccorres *)
+
+lemma reply_remove_ccorres:
+  "ccorres dc xfdc
+    (invs' and tcb_at' tcbPtr and reply_at' replyPtr)
+    (\<lbrace>\<acute>reply = Ptr replyPtr\<rbrace> \<inter> \<lbrace>\<acute>tcb = tcb_ptr_to_ctcb_ptr tcbPtr\<rbrace>) []
+    (replyRemove replyPtr tcbPtr) (Call reply_remove_'proc)"
+sorry (* FIXME RT: reply_remove_ccorres *)
 
 lemma cancelIPC_ccorres1:
   assumes cteDeleteOne_ccorres:

--- a/proof/crefine/RISCV64/Ipc_C.thy
+++ b/proof/crefine/RISCV64/Ipc_C.thy
@@ -3304,7 +3304,7 @@ proof -
    apply (rename_tac word1 word2 word3 word4)
    apply (simp del: Collect_const)
    apply wpc
-    apply (simp add: option_to_ptr_def option_to_0_def)
+    apply (simp add: option_to_ptr_def option_to_0_def mapME_Nil)
     apply (rule ccorres_rhs_assoc2, rule ccorres_split_throws)
      apply (rule ccorres_from_vcg_throws[where P=\<top> and P'=UNIV])
      apply (rule allI, rule conseqPre, vcg)
@@ -4178,7 +4178,7 @@ lemma handleFaultReply_ccorres [corres]:
      apply clarsimp
      apply vcg_step
      apply (clarsimp simp: n_exceptionMessage_def n_syscallMessage_def
-                           message_info_to_H_def scast_def
+                           message_info_to_H_def to_bool_def scast_def
                            length_exceptionMessage length_syscallMessage
                            min_def word_less_nat_alt
                            guard_is_UNIV_def seL4_Faults seL4_Arch_Faults
@@ -5053,7 +5053,7 @@ lemma sendIPC_ccorres [corres]:
            \<inter> \<lbrace>\<acute>thread = tcb_ptr_to_ctcb_ptr thread\<rbrace>
            \<inter> \<lbrace>\<acute>epptr = Ptr epptr\<rbrace>
            \<inter> \<lbrace>badge && mask 64 = badge\<rbrace>) hs
-     (sendIPC blocking do_call badge canGrant canDonate canGrantReply thread epptr)
+     (sendIPC blocking do_call badge canGrant canGrantReply canDonate thread epptr)
      (Call sendIPC_'proc)"
   unfolding K_def
   apply (rule ccorres_gen_asm2)
@@ -5615,6 +5615,12 @@ lemma schedContext_bindTCB_ccorres:
      \<top> (\<lbrace>\<acute>tcb = tcb_ptr_to_ctcb_ptr tcbPtr\<rbrace> \<inter> \<lbrace>\<acute>sc = Ptr scPtr\<rbrace>) []
      (schedContextBindTCB scPtr tcbPtr) (Call schedContext_bindTCB_'proc)"
 sorry (* FIXME RT: schedContext_bindTCB_ccorres *)
+
+lemma schedContext_bindNtfn_ccorres:
+  "ccorres dc xfdc
+     \<top> (\<lbrace>\<acute>tcb = tcb_ptr_to_ctcb_ptr tcbPtr\<rbrace> \<inter> \<lbrace>\<acute>sc = Ptr scPtr\<rbrace>) []
+     (schedContextBindNtfn scPtr tcbPtr) (Call schedContext_bindNtfn_'proc)"
+sorry (* FIXME RT: schedContext_bindNtfn_ccorres *)
 
 lemma completeSignal_ccorres:
   notes if_split[split del]
@@ -6259,7 +6265,7 @@ lemma sendSignal_ccorres [corres]:
        apply csymbr
        apply (rule ccorres_abstract_cleanup)
        apply (rule_tac P="(ret__unsigned_longlong = scast ThreadState_BlockedOnReceive)
-                 = receiveBlocked rva" in ccorres_gen_asm2)
+                 = receiveBlocked rv" in ccorres_gen_asm2)
        apply (rule ccorres_cond[where R=\<top>])
          apply (simp add: Collect_const_mem)
         apply (rule ccorres_rhs_assoc)+
@@ -6507,7 +6513,6 @@ lemma receiveSignal_enqueue_ccorres_helper:
   subgoal sorry (* FIXME RT: sym_refs argument *)
   apply (subgoal_tac "ko_at' (NTFN (WaitingNtfn queue) (ntfnBoundTCB ntfn) (ntfnSc ntfn)) ntfnptr (\<sigma>\<lparr>ksPSpace :=
                              (ksPSpace \<sigma>)(ntfnptr \<mapsto> KONotification (NTFN (WaitingNtfn queue) (ntfnBoundTCB ntfn) (ntfnSc ntfn)))\<rparr>)")
-                             (ksPSpace \<sigma>)(ntfnptr \<mapsto> KONotification (NTFN (WaitingNtfn queue) (ntfnBoundTCB ntfn)))\<rparr>)")
    prefer 2
    apply (clarsimp simp: obj_at'_def projectKOs objBitsKO_def ps_clear_upd)
   apply (intro conjI impI allI)

--- a/proof/crefine/RISCV64/IsolatedThreadAction.thy
+++ b/proof/crefine/RISCV64/IsolatedThreadAction.thy
@@ -720,7 +720,7 @@ lemma lookupExtraCaps_simple_rewrite:
   "msgExtraCaps mi = 0 \<Longrightarrow>
       (lookupExtraCaps thread rcvBuf mi = returnOk [])"
   by (cases mi, simp add: lookupExtraCaps_def getExtraCPtrs_def
-                          liftE_bindE upto_enum_step_def mapM_Nil
+                          liftE_bindE upto_enum_step_def mapM_Nil mapME_Nil
                    split: option.split)
 
 lemma lookupIPC_inv: "\<lbrace>P\<rbrace> lookupIPCBuffer f t \<lbrace>\<lambda>rv. P\<rbrace>"

--- a/proof/crefine/RISCV64/Recycle_C.thy
+++ b/proof/crefine/RISCV64/Recycle_C.thy
@@ -1113,7 +1113,7 @@ lemma coerce_memset_to_heap_update:
                           (NULL)
                           (seL4_Fault_C (FCP (\<lambda>x. 0)))
                           (lookup_fault_C (FCP (\<lambda>x. 0)))
-                            0 0 0 NULL NULL 0 NULL NULL NULL NULL NULL)"
+                            0 0 0 NULL NULL 0 NULL NULL NULL NULL)"
   apply (intro ext, simp add: heap_update_def)
   apply (rule_tac f="\<lambda>xs. heap_update_list x xs a b" for a b in arg_cong)
   apply (simp add: to_bytes_def size_of_def typ_info_simps tcb_C_tag_def)

--- a/proof/crefine/RISCV64/Refine_C.thy
+++ b/proof/crefine/RISCV64/Refine_C.thy
@@ -30,12 +30,24 @@ begin
 
 declare liftE_handle [simp]
 
+crunches setConsumedTime
+  for sch_act_wf[wp]: "\<lambda>s. sch_act_wf (ksSchedulerAction s) s"
+  (wp: crunch_wps)
+
+lemma commitTime_sch_act_wf[wp]:
+  "commitTime \<lbrace>\<lambda>s. sch_act_wf (ksSchedulerAction s) s\<rbrace>"
+  unfolding commitTime_def
+  by (wpsimp wp: isRoundRobin_wp split: if_splits)
+
+crunches setNextInterrupt, switchSchedContext
+  for sch_act_wf[wp]: "\<lambda>s. sch_act_wf (ksSchedulerAction s) s"
+  (wp: crunch_wps)
+
 lemma schedule_sch_act_wf:
-  "\<lbrace>invs'\<rbrace> schedule \<lbrace>\<lambda>_ s. sch_act_wf (ksSchedulerAction s) s\<rbrace>"
-apply (rule hoare_post_imp)
- apply (erule invs_sch_act_wf')
-apply (rule schedule_invs')
-done
+  "\<lbrace>\<lambda>s. invs' s \<and> sch_act_wf (ksSchedulerAction s) s\<rbrace>
+   schedule
+   \<lbrace>\<lambda>_ s. sch_act_wf (ksSchedulerAction s) s\<rbrace>"
+sorry (* FIXME RT: schedule_sch_act_wf. Move above Hoare triples to Refine *)
 
 lemma ucast_8_32_neq:
   "x \<noteq> 0xFF \<Longrightarrow> UCAST(8 \<rightarrow> 32 signed) x \<noteq> 0xFF"
@@ -51,6 +63,7 @@ proof -
   apply (cinit')
    apply (simp add: callKernel_def handleEvent_def minus_one_norm)
    apply (simp add: liftE_bind bind_assoc)
+sorry (* FIXME RT: handleInterruptEntry_ccorres
     apply (ctac (no_vcg) add: getActiveIRQ_ccorres)
     apply (rule ccorres_Guard_Seq)?
     apply wpc
@@ -82,7 +95,7 @@ proof -
     apply (clarsimp simp: non_kernel_IRQs_def)
    apply (wp getActiveIRQ_le_maxIRQ getActiveIRQ_neq_Some0x3FF | simp)+
   apply (clarsimp simp: invs'_def valid_state'_def)
-  done
+  done *)
 qed
 
 lemma handleUnknownSyscall_ccorres:
@@ -95,6 +108,7 @@ lemma handleUnknownSyscall_ccorres:
    apply (simp add: callKernel_def handleEvent_def)
    apply (simp add: liftE_bind bind_assoc)
    apply (rule ccorres_symb_exec_r)
+sorry (* FIXME RT: handleUnknownSyscall_ccorres
      apply (rule ccorres_pre_getCurThread)
      apply (ctac (no_vcg) add: handleFault_ccorres)
       apply (ctac (no_vcg) add: schedule_ccorres)
@@ -120,7 +134,7 @@ lemma handleUnknownSyscall_ccorres:
   apply (frule st_tcb_idle'[rotated])
    apply (erule invs_valid_idle')
   apply (clarsimp simp: cfault_rel_def seL4_Fault_UnknownSyscall_lift is_cap_fault_def)
-  done
+  done *)
 
 lemma handleVMFaultEvent_ccorres:
   "ccorres dc xfdc
@@ -131,6 +145,7 @@ lemma handleVMFaultEvent_ccorres:
   apply (cinit' lift:vm_faultType_')
    apply (simp add: callKernel_def handleEvent_def)
    apply (simp add: liftE_bind bind_assoc)
+sorry (* FIXME RT: handleVMFaultEvent_ccorres
    apply (rule ccorres_pre_getCurThread)
    apply (simp add: catch_def)
    apply (rule ccorres_rhs_assoc2)
@@ -169,7 +184,7 @@ lemma handleVMFaultEvent_ccorres:
   apply (auto simp: ct_in_state'_def cfault_rel_def is_cap_fault_def ct_not_ksQ
               elim: pred_tcb'_weakenE st_tcb_ex_cap''
               dest: st_tcb_at_idle_thread' rf_sr_ksCurThread)
-  done
+  done *)
 
 lemma handleUserLevelFault_ccorres:
   "ccorres dc xfdc
@@ -181,6 +196,7 @@ lemma handleUserLevelFault_ccorres:
    apply (simp add: callKernel_def handleEvent_def)
    apply (simp add: liftE_bind bind_assoc)
    apply (rule ccorres_symb_exec_r)
+sorry (* FIXME RT: handleUserLevelFault_ccorres
      apply (rule ccorres_pre_getCurThread)
      apply (ctac (no_vcg) add: handleFault_ccorres)
       apply (ctac (no_vcg) add: schedule_ccorres)
@@ -210,15 +226,15 @@ lemma handleUserLevelFault_ccorres:
    apply simp
   apply (clarsimp simp: cfault_rel_def seL4_Fault_UserException_lift)
   apply (simp add: is_cap_fault_def)
-  done
+  done *)
 
 lemmas syscall_defs =
   Kernel_C.SysSend_def Kernel_C.SysNBSend_def
   Kernel_C.SysCall_def Kernel_C.SysRecv_def Kernel_C.SysNBRecv_def
-  Kernel_C.SysReply_def Kernel_C.SysReplyRecv_def Kernel_C.SysYield_def
+  Kernel_C.SysReplyRecv_def Kernel_C.SysYield_def
 
 lemma ct_active_not_idle'_strengthen:
-  "invs' s \<and> ct_active' s \<longrightarrow> ksCurThread s \<noteq> ksIdleThread s"
+  "valid_idle' s \<and> ct_active' s \<longrightarrow> ksCurThread s \<noteq> ksIdleThread s"
   by clarsimp
 
 
@@ -231,6 +247,7 @@ lemma handleSyscall_ccorres:
            (callKernel (SyscallEvent sysc)) (Call handleSyscall_'proc)"
   supply if_cong[cong] option.case_cong[cong]
   apply (cinit' lift: syscall_')
+sorry (* FIXME RT: handleSyscall_ccorres
    apply (simp add: callKernel_def handleEvent_def minus_one_norm)
    apply (simp add: handleE_def handleE'_def)
    apply (rule ccorres_split_nothrow_novcg)
@@ -427,7 +444,7 @@ lemma handleSyscall_ccorres:
                         isReply_def ct_not_ksQ irqInvalid_def Kernel_C.irqInvalid_def)
   apply (auto simp: syscall_from_H_def Kernel_C.SysSend_def
               split: option.split_asm)
-  done
+  done *)
 
 lemma ccorres_corres_u:
   "\<lbrakk> ccorres dc xfdc P (Collect P') [] H C; no_fail P H \<rbrakk> \<Longrightarrow>
@@ -476,8 +493,8 @@ lemma ccorres_corres_u_xf:
 definition
   "all_invs' e \<equiv> \<lambda>s'. \<exists>s :: det_state.
     (s,s') \<in> state_relation \<and>
-    (einvs s \<and> (e \<noteq> Interrupt \<longrightarrow> ct_running s) \<and> (ct_running s \<or> ct_idle s) \<and>
-      scheduler_action s = resume_cur_thread \<and> domain_time s \<noteq> 0 \<and> valid_domain_list s) \<and>
+    (mcs_invs s \<and> (e \<noteq> Interrupt \<longrightarrow> ct_running s) \<and> (ct_running s \<or> ct_idle s)
+     \<and> domain_time s \<noteq> 0) \<and>
     (invs' s' \<and>
       (e \<noteq> Interrupt \<longrightarrow> ct_running' s') \<and> (ct_running' s' \<or> ct_idle' s') \<and>
       ksSchedulerAction s' = ResumeCurrentThread  \<and> ksDomainTime s' \<noteq> 0)"
@@ -503,6 +520,7 @@ lemma handleHypervisorEvent_ccorres:
   apply (rule ccorres_guard_imp)
     apply (rule ccorres_symb_exec_l)
        apply (cases t; simp add: handleHypervisorFault_def)
+sorry (* FIXME RT: handleHypervisorEvent_ccorres
        apply (ctac (no_vcg) add: schedule_ccorres)
         apply (rule ccorres_stateAssert_after)
         apply (rule ccorres_guard_imp[where A="A and P" and Q=A for A P])
@@ -512,7 +530,7 @@ lemma handleHypervisorEvent_ccorres:
        apply (wp schedule_sch_act_wf schedule_invs'
               | strengthen invs_queues_imp invs_valid_objs_strengthen)+
     apply clarsimp+
-  done
+  done *)
 
 lemma callKernel_corres_C:
   "corres_underlying rf_sr False True dc
@@ -638,6 +656,7 @@ lemma threadSet_all_invs_triv':
                          atcbContextSet_def arch_tcb_relation_def)
        apply (simp add: tcb_cap_cases_def)
       apply (simp add: tcb_cte_cases_def cteSizeBits_def)
+sorry (* FIXME RT: threadSet_all_invs_triv'
      apply (simp add: exst_same_def)
     apply (wp thread_set_invs_trivial thread_set_ct_running thread_set_not_state_valid_sched
               threadSet_invs_trivial threadSet_ct_running' hoare_weak_lift_imp
@@ -652,7 +671,7 @@ lemma threadSet_all_invs_triv':
    apply (clarsimp simp: invs_def)
   apply (clarsimp simp: invs_psp_aligned invs_distinct)
   apply (clarsimp simp: invs_def cur_tcb_def cur_tcb'_def state_relation_def)
-  done
+  done *)
 
 lemma getContext_corres:
   "t' = tcb_ptr_to_ctcb_ptr t \<Longrightarrow>
@@ -676,9 +695,10 @@ lemma callKernel_cur:
   "\<lbrace>all_invs' e\<rbrace> callKernel e \<lbrace>\<lambda>rv s. tcb_at' (ksCurThread s) s\<rbrace>"
   apply (rule hoare_chain)
     apply (rule ckernel_invs)
+sorry (* FIXME RT: callKernel_cur. Possibly cross cur_tcb and use an assertion?
    apply (clarsimp simp: all_invs'_def sch_act_simple_def)
   apply clarsimp
-  done
+  done *)
 
 lemma entry_corres_C:
   "fp = False \<Longrightarrow> \<comment> \<open>FIXME: fastpath\<close>
@@ -703,9 +723,10 @@ lemma entry_corres_C:
              apply (clarsimp simp: rf_sr_def cstate_relation_def Let_def)
             apply (rule getContext_corres, simp)
            apply (wp threadSet_all_invs_triv' callKernel_cur)+
-   apply (clarsimp simp: all_invs'_def invs'_def cur_tcb'_def valid_state'_def)
+   apply (clarsimp simp: all_invs'_def invs'_def cur_tcb'_def)
+sorry (* FIXME RT: entry_corres_C
   apply simp
-  done
+  done *)
 
 lemma entry_refinement_C:
   "\<lbrakk>all_invs' e s; (s, t) \<in> rf_sr; fp = False \<comment> \<open>FIXME: fastpath\<close> \<rbrakk>
@@ -757,7 +778,7 @@ context kernel_m
 begin
 
 lemma user_memory_update_corres_C_helper:
-      "\<lbrakk>(a, b) \<in> rf_sr; pspace_aligned' a; pspace_distinct' a;
+      "\<lbrakk>(a, b) \<in> rf_sr; pspace_aligned' a; pspace_distinct' a; pspace_bounded' a;
         dom um \<subseteq> dom (user_mem' a)\<rbrakk>
        \<Longrightarrow> (ksMachineState_update
             (underlying_memory_update
@@ -781,13 +802,13 @@ apply (frule_tac ptr=x and b="the (um x)" in storeByteUser_rf_sr_upd)
    apply simp
   apply simp
  apply (thin_tac "(x,y) : rf_sr" for x y)+
- apply (fastforce simp add: pointerInUserData_def dom_user_mem')
+ apply (fastforce simp add: pointerInUserData_def dom_user_mem')+
 apply (simp add: o_def hrs_mem_update_def)
 done
 
 lemma user_memory_update_corres_C:
   "corres_underlying rf_sr False nf (%_ _. True)
-     (\<lambda>s. pspace_aligned' s \<and> pspace_distinct' s \<and> dom um \<subseteq> dom (user_mem' s))
+     (\<lambda>s. pspace_aligned' s \<and> pspace_distinct' s \<and> pspace_bounded' s \<and> dom um \<subseteq> dom (user_mem' s))
      \<top>
      (doMachineOp (user_memory_update um)) (setUserMem_C um)"
   supply if_cong[cong] option.case_cong[cong]
@@ -878,10 +899,10 @@ lemma do_user_op_corres_C:
     apply (rule_tac P=\<top> and P'=\<top> and r'="(=)" in corres_split)
        apply (clarsimp simp: simpler_gets_def getCurThread_def
                 corres_underlying_def rf_sr_def cstate_relation_def Let_def)
-      apply (rule_tac P=valid_state' and P'=\<top> and r'="(=)" in corres_split)
+      apply (rule_tac P=invs' and P'=\<top> and r'="(=)" in corres_split)
          apply (clarsimp simp: cstate_to_A_def absKState_def
                                rf_sr_def cstate_to_H_correct ptable_lift_def)
-        apply (rule_tac P=valid_state' and P'=\<top> and r'="(=)" in corres_split)
+        apply (rule_tac P=invs' and P'=\<top> and r'="(=)" in corres_split)
            apply (clarsimp simp: cstate_to_A_def absKState_def
                                  rf_sr_def cstate_to_H_correct ptable_rights_def)
           apply (rule_tac P=pspace_distinct' and P'=\<top> and r'="(=)"
@@ -899,7 +920,7 @@ lemma do_user_op_corres_C:
                                cpspace_relation_def)
                apply (drule(1) device_mem_C_relation[symmetric])
                apply simp
-              apply (rule_tac P=valid_state' and P'=\<top> and r'="(=)" in corres_split)
+              apply (rule_tac P=invs' and P'=\<top> and r'="(=)" in corres_split)
                  apply (clarsimp simp: cstate_relation_def rf_sr_def
                    Let_def cmachine_state_relation_def)
                 apply (rule_tac P=\<top> and P'=\<top> and r'="(=)" in corres_split)
@@ -920,13 +941,13 @@ lemma do_user_op_corres_C:
                                          where R="\<top>\<top>" and R'="\<top>\<top>"])
                         apply (wp | simp)+
    apply (intro conjI allI ballI impI)
-     apply ((clarsimp simp add: invs'_def valid_state'_def valid_pspace'_def)+)[5]
+     apply ((clarsimp simp add: invs'_def valid_pspace'_def)+)[5]
     apply (clarsimp simp:  ex_abs_def restrict_map_def
                   split: if_splits)
     apply (drule ptable_rights_imp_UserData[rotated -1])
      apply fastforce+
-    apply (clarsimp simp: invs'_def valid_state'_def user_mem'_def device_mem'_def
-                   split: if_splits)
+    apply (clarsimp simp: invs'_def valid_pspace'_def user_mem'_def device_mem'_def
+                   split: if_splits)+
     apply (drule_tac c = x in subsetD[where B = "dom S" for S])
      apply (simp add:dom_def)
     apply fastforce
@@ -997,6 +1018,7 @@ lemma refinement2_both:
    apply (clarsimp simp: full_invs'_def)
    apply (frule use_valid, rule kernelEntry_invs',
           simp add: sch_act_simple_def)
+sorry (* FIXME RT: refinement2_both
     apply (fastforce simp: ct_running'_C)
     apply (clarsimp simp: full_invs_def full_invs'_def all_invs'_def)
    apply fastforce
@@ -1016,7 +1038,7 @@ lemma refinement2_both:
   apply (clarsimp simp: check_active_irq_C_def check_active_irq_H_def)
   apply (rule rev_mp, rule check_active_irq_corres_C)
   apply (fastforce simp: corres_underlying_def full_invs'_def ex_abs_def)
-  done
+  done *)
 
 theorem refinement2:
   "ADT_C uop \<sqsubseteq> ADT_H uop"

--- a/proof/crefine/RISCV64/Retype_C.thy
+++ b/proof/crefine/RISCV64/Retype_C.thy
@@ -3311,8 +3311,7 @@ proof -
        tcbIPCBuffer_C := 0,
        tcbSchedNext_C := tcb_Ptr 0, tcbSchedPrev_C := tcb_Ptr 0,
        tcbEPNext_C := tcb_Ptr 0, tcbEPPrev_C := tcb_Ptr 0,
-       tcbBoundNotification_C := ntfn_Ptr 0,
-       tcbReply_C := reply_Ptr 0\<rparr>"
+       tcbBoundNotification_C := ntfn_Ptr 0\<rparr>"
   have fbtcb: "from_bytes (replicate (size_of TYPE(tcb_C)) 0) = ?tcb"
     apply (simp add: from_bytes_def)
     apply (simp add: typ_info_simps tcb_C_tag_def)

--- a/proof/crefine/RISCV64/SchedContext_C.thy
+++ b/proof/crefine/RISCV64/SchedContext_C.thy
@@ -1,0 +1,88 @@
+(*
+ * Copyright 2022, Proofcraft Pty Ltd
+ * Copyright 2022, UNSW (ABN 57 195 873 197)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory SchedContext_C
+imports Schedule_C
+begin
+
+context kernel_m begin
+
+lemma refill_new_ccorres:
+  "ccorres dc xfdc
+     invs'
+     (\<lbrace>\<acute>sc = Ptr scPtr\<rbrace>
+      \<inter> \<lbrace>\<acute>max_refills = of_nat maxRefills\<rbrace>
+      \<inter> \<lbrace>\<acute>budget = budget\<rbrace>
+      \<inter> \<lbrace>\<acute>period = period\<rbrace>) []
+     (refillNew scPtr maxRefills budget period) (Call refill_new_'proc)"
+sorry (* FIXME RT: refill_new_ccorres *)
+
+lemma refill_update_ccorres:
+  "ccorres dc xfdc
+     invs'
+     (\<lbrace>\<acute>sc = Ptr scPtr\<rbrace>
+      \<inter> \<lbrace>\<acute>new_period = newPeriod\<rbrace>
+      \<inter> \<lbrace>\<acute>new_budget = newBudget\<rbrace>
+      \<inter> \<lbrace>\<acute>new_max_refills = of_nat newMaxRefills\<rbrace>) []
+     (refillUpdate scPtr newPeriod newBudget newMaxRefills) (Call refill_update_'proc)"
+sorry (* FIXME RT: refill_update_ccorres *)
+
+lemma decodeSchedContext_UnbindObject_ccorres:
+  "ccorres dc xfdc
+     invs' \<lbrace>\<acute>sc = Ptr scPtr\<rbrace> []
+     (decodeSchedContext_UnbindObject scPtr excaps) (Call decodeSchedContext_UnbindObject_'proc)"
+sorry (* FIXME RT: decodeSchedContext_UnbindObject_ccorres *)
+
+lemma decodeSchedContext_Bind_ccorres:
+  "ccorres dc xfdc
+     invs' \<lbrace>\<acute>sc = Ptr scPtr\<rbrace> []
+     (decodeSchedContext_Bind scPtr excaps) (Call decodeSchedContext_Bind_'proc)"
+sorry (* FIXME RT: decodeSchedContext_Bind_ccorres *)
+
+lemma setConsumed_ccorres:
+  "ccorres dc xfdc
+     invs' \<lbrace>\<acute>sc = Ptr scPtr\<rbrace> []
+     (setConsumed scPtr buffer) (Call setConsumed_'proc)"
+sorry (* FIXME RT: setConsumed_ccorres *)
+
+lemma decodeSchedContext_YieldTo_ccorres:
+  "ccorres dc xfdc
+     invs' \<lbrace>\<acute>sc = Ptr scPtr\<rbrace> []
+     (decodeSchedContext_YieldTo scPtr buffer) (Call decodeSchedContext_YieldTo_'proc)"
+sorry (* FIXME RT: decodeSchedContext_YieldTo_ccorres *)
+
+lemma decodeSchedContextInvocation_ccorres:
+  "ccorres dc xfdc
+     invs' \<lbrace>\<acute>sc = Ptr scPtr\<rbrace> []
+     (decodeSchedContextInvocation label scPtr excaps buffer)
+     (Call decodeSchedContextInvocation_'proc)"
+sorry (* FIXME RT: decodeSchedContextInvocation_ccorres *)
+
+lemma schedContext_updateConsumed_ccorres:
+  "ccorres dc xfdc
+     invs' \<lbrace>\<acute>sc = Ptr scPtr\<rbrace> []
+     (schedContextUpdateConsumed scPtr)
+     (Call schedContext_updateConsumed_'proc)"
+sorry (* FIXME RT: schedContext_updateConsumed_ccorres *)
+
+lemma schedContext_cancelYieldTo_ccorres:
+  "ccorres dc xfdc
+     invs' \<lbrace>\<acute>tcb = tcb_ptr_to_ctcb_ptr tptr\<rbrace> []
+     (schedContextCancelYieldTo tptr)
+     (Call schedContext_cancelYieldTo_'proc)"
+sorry (* FIXME RT: schedContext_cancelYieldTo_ccorres *)
+
+lemma invokeSchedControl_ConfigureFlags_ccorres:
+  "ccorres dc xfdc
+     invs' UNIV []
+     (invokeSchedControlConfigureFlags iv)
+     (Call invokeSchedControl_ConfigureFlags_'proc)"
+sorry (* FIXME RT: invokeSchedControl_ConfigureFlags_ccorres *)
+
+end
+
+end

--- a/proof/crefine/RISCV64/StateRelation_C.thy
+++ b/proof/crefine/RISCV64/StateRelation_C.thy
@@ -139,6 +139,8 @@ where
   "cmachine_state_relation s s' \<equiv>
   irq_masks s = irq_masks (phantom_machine_state_' s') \<and>
   irq_state s = irq_state (phantom_machine_state_' s') \<and>
+  time_state s = time_state (phantom_machine_state_' s') \<and>
+  last_machine_time s = last_machine_time (phantom_machine_state_' s') \<and>
   device_state s = device_state (phantom_machine_state_' s') \<and>
   \<comment> \<open>exclusive_state s = exclusive_state (phantom_machine_state_' s') \<and>\<close> \<comment> \<open>FIXME: this is needed for infoflow so we'll leave it commented\<close>
   machine_state_rest s = machine_state_rest (phantom_machine_state_' s')"

--- a/run_tests
+++ b/run_tests
@@ -82,13 +82,11 @@ EXCLUDE["RISCV64"]=[
     "RefineOrphanage",
     "SimplExportAndRefine",
     "AsmRefine",
-    "CRefine",
     "ASepSpec",
     "Bisim",
     "SepTactics",
     "TakeGrant",
     "Sep_Algebra",
-    "CBaseRefine",
     "LibTest"
 ]
 


### PR DESCRIPTION
This sorries the last files in the CRefine session, thereby completing the setup of the proof infrastructure for MCS CRefine. 

In addition, this enables testing of the CRefine session via our continuous integration setup.