### PR TITLE
`ADT_C` sorry-free

### DIFF
--- a/proof/crefine/RISCV64/IpcCancel_C.thy
+++ b/proof/crefine/RISCV64/IpcCancel_C.thy
@@ -185,7 +185,6 @@ lemma ntfn_ptr_set_queue_spec:
   apply (clarsimp simp: packed_heap_update_collapse_hrs typ_heap_simps' canonical_bit_def)
   done
 
-
 lemma cancelSignal_ccorres_helper:
   "ccorres dc xfdc (invs' and (\<lambda>s. sym_refs (state_refs_of' s))
                     and st_tcb_at' ((=) (BlockedOnNotification ntfn)) thread and ko_at' ntfn' ntfn)
@@ -238,22 +237,27 @@ lemma cancelSignal_ccorres_helper:
                         typ_heap_simps')
        apply (elim conjE)
        apply (intro conjI)
-            \<comment> \<open>tcb relation\<close>
-             apply (erule ctcb_relation_null_queue_ptrs)
-             apply (clarsimp simp: comp_def)
-            \<comment> \<open>ep relation\<close>
-            apply (erule iffD1 [OF cmap_relation_cong, OF refl refl, rotated -1])
-            apply simp
-            apply (rule cendpoint_relation_ntfn_queue, assumption+)
+             \<comment> \<open>tcb relation\<close>
+              apply (erule ctcb_relation_null_queue_ptrs)
+              apply (clarsimp simp: comp_def)
+             \<comment> \<open>ep relation\<close>
+             apply (erule iffD1 [OF cmap_relation_cong, OF refl refl, rotated -1])
              apply simp
-            apply (erule (1) map_to_ko_atI')
-           \<comment> \<open>ntfn relation\<close>
-           apply (rule cpspace_relation_ntfn_update_ntfn, assumption+)
-            apply (simp add: cnotification_relation_def Let_def NtfnState_Idle_def)
-           apply (simp add: carch_state_relation_def carch_globals_def)
-          subgoal sorry (* FIXME RT: refill_buffer_relation *)
-         \<comment> \<open>queue relation\<close>
-         apply (rule cready_queues_relation_null_queue_ptrs, assumption+)
+             apply (rule cendpoint_relation_ntfn_queue, assumption+)
+              apply simp
+             apply (erule (1) map_to_ko_atI')
+            \<comment> \<open>ntfn relation\<close>
+            apply (rule cpspace_relation_ntfn_update_ntfn, assumption+)
+             apply (simp add: cnotification_relation_def Let_def NtfnState_Idle_def)
+            apply (simp add: carch_state_relation_def carch_globals_def)
+           subgoal sorry (* FIXME RT: refill_buffer_relation *)
+          \<comment> \<open>queue relations\<close>
+          apply (rule cready_queues_relation_null_queue_ptrs, assumption+)
+          apply (clarsimp simp: comp_def)
+         apply (erule iffD2[OF tcb_queue_relation_only_next_prev, rotated -1])
+          apply (rule null_ep_schedD[THEN conjunct1])
+          apply (clarsimp simp: comp_def)
+         apply (rule null_ep_schedD[THEN conjunct2])
          apply (clarsimp simp: comp_def)
         apply (clarsimp simp: carch_state_relation_def carch_globals_def
                               typ_heap_simps' packed_heap_update_collapse_hrs)
@@ -275,34 +279,39 @@ lemma cancelSignal_ccorres_helper:
                        typ_heap_simps')
       apply (elim conjE)
       apply (intro conjI)
-           \<comment> \<open>tcb relation\<close>
-            apply (erule ctcb_relation_null_queue_ptrs)
-            apply (clarsimp simp: comp_def)
-           \<comment> \<open>ep relation\<close>
-           apply (erule iffD1 [OF cmap_relation_cong, OF refl refl, rotated -1])
-           apply simp
-           apply (rule cendpoint_relation_ntfn_queue)
-               apply fastforce
-              apply assumption+
-           apply simp
-           apply (erule (1) map_to_ko_atI')
-          \<comment> \<open>ntfn relation\<close>
-          apply (rule cpspace_relation_ntfn_update_ntfn, assumption+)
-           apply (simp add: cnotification_relation_def Let_def isWaitingNtfn_def
-                     split: ntfn.splits split del: if_split)
-           apply (erule iffD1 [OF tcb_queue_relation'_cong [OF refl _ _ refl], rotated -1])
-            apply (clarsimp simp add: h_t_valid_clift_Some_iff)
-            apply (subst tcb_queue_relation'_next_sign; assumption?)
+             \<comment> \<open>tcb relation\<close>
+             apply (erule ctcb_relation_null_queue_ptrs)
+             apply (clarsimp simp: comp_def)
+            \<comment> \<open>ep relation\<close>
+            apply (erule iffD1 [OF cmap_relation_cong, OF refl refl, rotated -1])
+            apply simp
+            apply (rule cendpoint_relation_ntfn_queue)
+                apply fastforce
+               apply assumption+
+            apply simp
+            apply (erule (1) map_to_ko_atI')
+           \<comment> \<open>ntfn relation\<close>
+           apply (rule cpspace_relation_ntfn_update_ntfn, assumption+)
+            apply (simp add: cnotification_relation_def Let_def isWaitingNtfn_def
+                      split: ntfn.splits split del: if_split)
+            apply (erule iffD1 [OF tcb_queue_relation'_cong [OF refl _ _ refl], rotated -1])
+             apply (clarsimp simp add: h_t_valid_clift_Some_iff)
+             apply (subst tcb_queue_relation'_next_sign; assumption?)
+              apply fastforce
+             apply (simp add: notification_lift_def sign_extend_sign_extend_eq canonical_bit_def)
+            apply (clarsimp simp: h_t_valid_clift_Some_iff notification_lift_def sign_extend_sign_extend_eq)
+            apply (subst tcb_queue_relation'_prev_sign; assumption?)
              apply fastforce
-            apply (simp add: notification_lift_def sign_extend_sign_extend_eq canonical_bit_def)
-           apply (clarsimp simp: h_t_valid_clift_Some_iff notification_lift_def sign_extend_sign_extend_eq)
-           apply (subst tcb_queue_relation'_prev_sign; assumption?)
-            apply fastforce
-           apply (simp add: canonical_bit_def)
-          apply simp
-         \<comment> \<open>queue relation\<close>
-         subgoal sorry (* FIXME RT: refill_buffer_relation *)
-        apply (rule cready_queues_relation_null_queue_ptrs, assumption+)
+            apply (simp add: canonical_bit_def)
+           apply simp
+          \<comment> \<open>queue relations\<close>
+          subgoal sorry (* FIXME RT: refill_buffer_relation *)
+         apply (rule cready_queues_relation_null_queue_ptrs, assumption+)
+         apply (clarsimp simp: comp_def)
+        apply (erule iffD2[OF tcb_queue_relation_only_next_prev, rotated -1])
+         apply (rule null_ep_schedD[THEN conjunct1])
+         apply (clarsimp simp: comp_def)
+        apply (rule null_ep_schedD[THEN conjunct2])
         apply (clarsimp simp: comp_def)
        subgoal by (clarsimp simp: carch_state_relation_def carch_globals_def)
       subgoal by (simp add: cmachine_state_relation_def)
@@ -710,7 +719,8 @@ lemma state_relation_queue_update_helper':
                        \<and> obj_at' (\<lambda>tcb. tcbDomain tcb = qdom) x s)
                    \<or> (tcb_at' x s \<and> (\<forall>d' p'. (d' \<noteq> qdom \<or> p' \<noteq> prio)
                                          \<longrightarrow> x \<notin> set (ksReadyQueues s (d', p'))));
-          S \<noteq> {}; qdom \<le> ucast maxDom; prio \<le> ucast maxPrio \<rbrakk>
+          S \<noteq> {}; qdom \<le> ucast maxDom; prio \<le> ucast maxPrio;
+          set (ksReleaseQueue s) \<inter> S = {} \<rbrakk>
       \<Longrightarrow> (s \<lparr>ksReadyQueues := (ksReadyQueues s)((qdom, prio) := q)\<rparr>, t) \<in> rf_sr"
   apply (subst(asm) disj_imp_rhs)
    apply (subst obj_at'_and[symmetric])
@@ -727,39 +737,47 @@ lemma state_relation_queue_update_helper':
   apply (clarsimp simp: rf_sr_def cstate_relation_def Let_def)
   apply (intro conjI)
       \<comment> \<open>cpspace_relation\<close>
-      apply (erule nonemptyE, drule(1) bspec)
-      apply (clarsimp simp: cpspace_relation_def)
-      apply (drule obj_at_ko_at', clarsimp)
-      apply (rule cmap_relationE1, assumption,
-             erule ko_at_projectKO_opt)
-      apply (frule null_sched_queue)
-      apply (frule null_sched_epD)
-      apply (intro conjI)
-        \<comment> \<open>tcb relation\<close>
-        apply (drule ctcb_relation_null_queue_ptrs,
-               simp_all)[1]
-       \<comment> \<open>endpoint relation\<close>
+       apply (erule nonemptyE, drule(1) bspec)
+       apply (clarsimp simp: cpspace_relation_def)
+       apply (drule obj_at_ko_at', clarsimp)
+       apply (rule cmap_relationE1, assumption,
+              erule ko_at_projectKO_opt)
+       apply (frule null_sched_queue)
+       apply (frule null_sched_epD)
+       apply (intro conjI)
+         \<comment> \<open>tcb relation\<close>
+         apply (drule ctcb_relation_null_queue_ptrs,
+                simp_all)[1]
+        \<comment> \<open>endpoint relation\<close>
+        apply (erule iffD1 [OF cmap_relation_cong, OF refl refl, rotated -1])
+        apply simp
+        apply (erule cendpoint_relation_upd_tcb_no_queues, simp+)
+       \<comment> \<open>ntfn relation\<close>
        apply (erule iffD1 [OF cmap_relation_cong, OF refl refl, rotated -1])
        apply simp
-       apply (erule cendpoint_relation_upd_tcb_no_queues, simp+)
-      \<comment> \<open>ntfn relation\<close>
-      apply (erule iffD1 [OF cmap_relation_cong, OF refl refl, rotated -1])
-      apply simp
-      apply (erule cnotification_relation_upd_tcb_no_queues, simp+)
-     \<comment> \<open>refill_buffer_relation\<close>
-     apply (clarsimp simp: refill_buffer_relation_def typ_heap_simps)
-    \<comment> \<open>ready queues\<close>
-    apply (simp add: cready_queues_relation_def Let_def cready_queues_index_to_C_in_range
-                     seL4_MinPrio_def minDom_def)
-    apply clarsimp
-    apply (frule cready_queues_index_to_C_distinct, assumption+)
-    apply (clarsimp simp: cready_queues_index_to_C_in_range all_conj_distrib)
-    apply (rule iffD1 [OF tcb_queue_relation'_cong[OF refl], rotated -1],
-           drule spec, drule spec, erule mp, simp+)
+       apply (erule cnotification_relation_upd_tcb_no_queues, simp+)
+      \<comment> \<open>refill_buffer_relation\<close>
+      apply (clarsimp simp: refill_buffer_relation_def typ_heap_simps)
+     \<comment> \<open>ready queues\<close>
+     apply (simp add: cready_queues_relation_def Let_def cready_queues_index_to_C_in_range
+                      seL4_MinPrio_def minDom_def)
+     apply clarsimp
+     apply (frule cready_queues_index_to_C_distinct, assumption+)
+     apply (clarsimp simp: cready_queues_index_to_C_in_range all_conj_distrib)
+     apply (rule iffD1 [OF tcb_queue_relation'_cong[OF refl], rotated -1],
+            drule spec, drule spec, erule mp, simp+)
+     apply clarsimp
+     apply (drule_tac x="tcb_ptr_to_ctcb_ptr x" in fun_cong)+
+     apply (clarsimp simp: restrict_map_def
+                    split: if_split_asm)
+    \<comment> \<open>release queue\<close>
+    apply (rule_tac mp'1="lift_t c_guard (f (t_hrs_' (globals s')))"
+                and mp1="lift_t c_guard ((t_hrs_' (globals s')))"
+                 in iffD1[OF tcb_queue_relation_cong];
+           simp?)
     apply clarsimp
     apply (drule_tac x="tcb_ptr_to_ctcb_ptr x" in fun_cong)+
-    apply (clarsimp simp: restrict_map_def
-                   split: if_split_asm)
+    subgoal by (auto simp: restrict_map_def split: if_split_asm)
    by (auto simp: carch_state_relation_def cmachine_state_relation_def)
 
 lemma state_relation_queue_update_helper:
@@ -782,7 +800,8 @@ lemma state_relation_queue_update_helper:
                        \<and> obj_at' (\<lambda>tcb. tcbDomain tcb = qdom) x s)
                    \<or> (tcb_at' x s \<and> (\<forall>d' p'. (d' \<noteq> qdom \<or> p' \<noteq> prio)
                                          \<longrightarrow> x \<notin> set (ksReadyQueues s (d', p'))));
-          S \<noteq> {}; qdom \<le> ucast maxDom; prio \<le> ucast maxPrio \<rbrakk>
+          S \<noteq> {}; qdom \<le> ucast maxDom; prio \<le> ucast maxPrio;
+          set (ksReleaseQueue s) \<inter> S = {} \<rbrakk>
       \<Longrightarrow> (s \<lparr>ksReadyQueues := (ksReadyQueues s)((qdom, prio) := q)\<rparr>, t) \<in> rf_sr"
   apply (subgoal_tac "\<forall>d p. (\<forall>t\<in>set (ksReadyQueues s (d, p)). obj_at' (inQ d p) t s)
                            \<and> distinct (ksReadyQueues s (d, p))")
@@ -993,14 +1012,62 @@ lemma c_invert_assist: "3 - (ucast (p :: priority) >> 6 :: machine_word) < 4"
   using prio_ucast_shiftr_wordRadix_helper'[simplified wordRadix_def]
   by - (rule word_less_imp_diff_less, simp_all)
 
+lemma tcb_queue_relation_prev_next:
+  "\<lbrakk> tcb_queue_relation tn tp' mp queue qprev qhead;
+     tcbp \<in> set queue; distinct (ctcb_ptr_to_tcb_ptr qprev # queue);
+     \<forall>t \<in> set queue. tcb_at' t s; qprev \<noteq> tcb_Ptr 0 \<longrightarrow> mp qprev \<noteq> None;
+     mp (tcb_ptr_to_ctcb_ptr tcbp) = Some tcb \<rbrakk>
+      \<Longrightarrow> (tn tcb \<noteq> tcb_Ptr 0 \<longrightarrow> tn tcb \<in> tcb_ptr_to_ctcb_ptr ` set queue
+                       \<and> mp (tn tcb) \<noteq> None \<and> tn tcb \<noteq> tcb_ptr_to_ctcb_ptr tcbp)
+        \<and> (tp' tcb \<noteq> tcb_Ptr 0 \<longrightarrow> (tp' tcb \<in> tcb_ptr_to_ctcb_ptr ` set queue
+                                         \<or> tp' tcb = qprev)
+                       \<and> mp (tp' tcb) \<noteq> None \<and> tp' tcb \<noteq> tcb_ptr_to_ctcb_ptr tcbp)
+        \<and> (tn tcb \<noteq> tcb_Ptr 0 \<longrightarrow> tn tcb \<noteq> tp' tcb)"
+  apply (induct queue arbitrary: qprev qhead)
+   apply simp
+  apply simp
+  apply (erule disjE)
+   apply clarsimp
+   apply (case_tac "queue")
+    apply clarsimp
+   apply clarsimp
+   apply (rule conjI)
+    apply clarsimp
+   apply clarsimp
+   apply (drule_tac f=ctcb_ptr_to_tcb_ptr in arg_cong[where y="tp' tcb"], simp)
+  apply clarsimp
+  apply fastforce
+  done
+
+lemma tcb_queue_relation_prev_next':
+  "\<lbrakk> tcb_queue_relation' tn tp' mp queue qhead qend; tcbp \<in> set queue; distinct queue;
+       \<forall>t \<in> set queue. tcb_at' t s; mp (tcb_ptr_to_ctcb_ptr tcbp) = Some tcb \<rbrakk>
+      \<Longrightarrow> (tn tcb \<noteq> tcb_Ptr 0 \<longrightarrow> tn tcb \<in> tcb_ptr_to_ctcb_ptr ` set queue
+                       \<and> mp (tn tcb) \<noteq> None \<and> tn tcb \<noteq> tcb_ptr_to_ctcb_ptr tcbp)
+        \<and> (tp' tcb \<noteq> tcb_Ptr 0 \<longrightarrow> tp' tcb \<in> tcb_ptr_to_ctcb_ptr ` set queue
+                       \<and> mp (tp' tcb) \<noteq> None \<and> tp' tcb \<noteq> tcb_ptr_to_ctcb_ptr tcbp)
+        \<and> (tn tcb \<noteq> tcb_Ptr 0 \<longrightarrow> tn tcb \<noteq> tp' tcb)"
+  apply (clarsimp simp: tcb_queue_relation'_def split: if_split_asm)
+  apply (drule(1) tcb_queue_relation_prev_next, simp_all)
+   apply (fastforce dest: tcb_at_not_NULL)
+  apply clarsimp
+  done
+
+(* FIXME RT: move to Refine *)
+definition ready_or_release' :: "kernel_state \<Rightarrow> bool" where
+   "ready_or_release' s \<equiv> \<forall>t. \<not> (\<exists>d p. t \<in> set (ksReadyQueues s (d,p)) \<and> t \<in> set (ksReleaseQueue s))"
+
+(* FIXME RT: move to Refine *)
+lemma ready_or_release'_disjoint_queues:
+  "ready_or_release' s \<Longrightarrow> \<forall>d p. set (ksReadyQueues s (d, p)) \<inter> set (ksReleaseQueue s) = {}"
+  by (fastforce simp: ready_or_release'_def)
+
 lemma tcbSchedEnqueue_ccorres:
   "ccorres dc xfdc
-           (valid_queues and tcb_at' t and valid_objs'
-            and (\<lambda>s. \<forall>d p. distinct (ksReadyQueues s (d, p))))
-           (UNIV \<inter> \<lbrace>\<acute>tcb = tcb_ptr_to_ctcb_ptr t\<rbrace>)
-           hs
-           (tcbSchedEnqueue t)
-           (Call tcbSchedEnqueue_'proc)"
+     (valid_queues and tcb_at' t and valid_objs' and (\<lambda>s. \<forall>d p. distinct (ksReadyQueues s (d, p)))
+      and (\<lambda>s. t \<notin> set (ksReleaseQueue s)) and ready_or_release')
+     \<lbrace>\<acute>tcb = tcb_ptr_to_ctcb_ptr t\<rbrace> hs
+     (tcbSchedEnqueue t) (Call tcbSchedEnqueue_'proc)"
 proof -
   note prio_and_dom_limit_helpers[simp] word_sle_def[simp] maxDom_to_H[simp] maxPrio_to_H[simp]
   note invert_prioToL1Index_c_simp[simp]
@@ -1056,7 +1123,9 @@ proof -
              apply (rule_tac P="\<lambda>s. valid_queues s \<and> (\<forall>p. t \<notin> set (ksReadyQueues s p))
                                   \<and> (\<exists>tcb. ko_at' tcb t s \<and> tcbDomain tcb =rva
                                   \<and> tcbPriority tcb = rvb \<and> valid_tcb' tcb s)
-                                  \<and> (\<forall>d p. distinct (ksReadyQueues s (d, p)))"
+                                  \<and> (\<forall>d p. distinct (ksReadyQueues s (d, p)))
+                                  \<and> t \<notin> set (ksReleaseQueue s)
+                                  \<and> ready_or_release' s"
                          and P'=UNIV in ccorres_from_vcg)
              apply (rule allI, rule conseqPre, vcg)
              apply (clarsimp simp: getQueue_def gets_def get_def setQueue_def modify_def
@@ -1146,24 +1215,31 @@ proof -
               apply (rule tcb_at_not_NULL, erule obj_at'_weakenE, simp)
              apply (frule(2) obj_at_cslift_tcb[OF valid_queues_obj_at'D])
              apply (clarsimp simp: h_val_field_clift' h_t_valid_clift)
-             apply (erule_tac S="{t, v}" for v in state_relation_queue_update_helper,
+             apply (rule_tac S="set (t # ksReadyQueues \<sigma> (tcbDomain tcb, tcbPriority tcb))"
+                          in state_relation_queue_update_helper,
                     (simp | rule globals.equality)+,
                     simp_all add: typ_heap_simps if_Some_helper numPriorities_def
                                   cready_queues_index_to_C_def2 upd_unless_null_def
                              del: fun_upd_restrict_conv
                              cong: if_cong
                              split del: if_split)[1]
-                apply simp
-                apply (rule conjI)
-                 apply clarsimp
-                 apply (drule_tac s="tcb_ptr_to_ctcb_ptr t" in sym, simp)
-                apply (clarsimp simp add: fun_upd_twist)
-               prefer 4
-               apply (simp add: obj_at'_weakenE[OF _ TrueI])
-               apply (rule disjI1, erule (1) valid_queues_obj_at'D)
-              apply clarsimp
-             apply (fastforce simp: tcb_null_sched_ptrs_def)
-            apply (simp add: typ_heap_simps c_guard_clift)
+                  apply simp
+                  apply (rule conjI)
+                   apply clarsimp
+                   apply (drule_tac s="tcb_ptr_to_ctcb_ptr t" in sym, simp)
+                  apply (clarsimp simp add: fun_upd_twist)
+                 prefer 4
+                 apply (simp add: obj_at'_weakenE[OF _ TrueI])
+                 apply (fastforce intro!: valid_queues_obj_at'D)
+                apply (rule ext)
+                apply (clarsimp split: if_splits simp: typ_heap_simps)
+                apply (frule rf_sr_sched_queue_relation)
+                  apply fastforce
+                 apply fastforce
+                apply (meson ctcb_ptr_to_tcb_ptr_imageI)
+               apply (fastforce simp: tcb_null_sched_ptrs_def)
+              apply (simp add: typ_heap_simps c_guard_clift)
+             apply (fastforce simp: ready_or_release'_def)
             apply (simp add: guard_is_UNIV_def)
            apply simp
            apply (wp threadGet_wp)
@@ -1175,56 +1251,16 @@ proof -
       apply simp
       apply (wp threadGet_wp)
      apply vcg
-    apply (fastforce simp: valid_objs'_def obj_at'_def ran_def typ_at'_def valid_obj'_def inQ_def
-                    dest!: valid_queues_obj_at'D)
-  done
+    apply clarsimp
+    apply (frule ready_or_release'_disjoint_queues)
+    by (fastforce simp: valid_objs'_def obj_at'_def ran_def typ_at'_def valid_obj'_def inQ_def
+                 dest!: valid_queues_obj_at'D)
 qed
 
 lemmas tcbSchedDequeue_update
     = tcbDequeue_update[where tn=tcbSchedNext_C and tn_update=tcbSchedNext_C_update
                           and tp'=tcbSchedPrev_C and tp_update=tcbSchedPrev_C_update,
                         simplified]
-
-lemma tcb_queue_relation_prev_next:
-  "\<lbrakk> tcb_queue_relation tn tp' mp queue qprev qhead;
-     tcbp \<in> set queue; distinct (ctcb_ptr_to_tcb_ptr qprev # queue);
-     \<forall>t \<in> set queue. tcb_at' t s; qprev \<noteq> tcb_Ptr 0 \<longrightarrow> mp qprev \<noteq> None;
-     mp (tcb_ptr_to_ctcb_ptr tcbp) = Some tcb \<rbrakk>
-      \<Longrightarrow> (tn tcb \<noteq> tcb_Ptr 0 \<longrightarrow> tn tcb \<in> tcb_ptr_to_ctcb_ptr ` set queue
-                       \<and> mp (tn tcb) \<noteq> None \<and> tn tcb \<noteq> tcb_ptr_to_ctcb_ptr tcbp)
-        \<and> (tp' tcb \<noteq> tcb_Ptr 0 \<longrightarrow> (tp' tcb \<in> tcb_ptr_to_ctcb_ptr ` set queue
-                                         \<or> tp' tcb = qprev)
-                       \<and> mp (tp' tcb) \<noteq> None \<and> tp' tcb \<noteq> tcb_ptr_to_ctcb_ptr tcbp)
-        \<and> (tn tcb \<noteq> tcb_Ptr 0 \<longrightarrow> tn tcb \<noteq> tp' tcb)"
-  apply (induct queue arbitrary: qprev qhead)
-   apply simp
-  apply simp
-  apply (erule disjE)
-   apply clarsimp
-   apply (case_tac "queue")
-    apply clarsimp
-   apply clarsimp
-   apply (rule conjI)
-    apply clarsimp
-   apply clarsimp
-   apply (drule_tac f=ctcb_ptr_to_tcb_ptr in arg_cong[where y="tp' tcb"], simp)
-  apply clarsimp
-  apply fastforce
-  done
-
-lemma tcb_queue_relation_prev_next':
-  "\<lbrakk> tcb_queue_relation' tn tp' mp queue qhead qend; tcbp \<in> set queue; distinct queue;
-       \<forall>t \<in> set queue. tcb_at' t s; mp (tcb_ptr_to_ctcb_ptr tcbp) = Some tcb \<rbrakk>
-      \<Longrightarrow> (tn tcb \<noteq> tcb_Ptr 0 \<longrightarrow> tn tcb \<in> tcb_ptr_to_ctcb_ptr ` set queue
-                       \<and> mp (tn tcb) \<noteq> None \<and> tn tcb \<noteq> tcb_ptr_to_ctcb_ptr tcbp)
-        \<and> (tp' tcb \<noteq> tcb_Ptr 0 \<longrightarrow> tp' tcb \<in> tcb_ptr_to_ctcb_ptr ` set queue
-                       \<and> mp (tp' tcb) \<noteq> None \<and> tp' tcb \<noteq> tcb_ptr_to_ctcb_ptr tcbp)
-        \<and> (tn tcb \<noteq> tcb_Ptr 0 \<longrightarrow> tn tcb \<noteq> tp' tcb)"
-  apply (clarsimp simp: tcb_queue_relation'_def split: if_split_asm)
-  apply (drule(1) tcb_queue_relation_prev_next, simp_all)
-   apply (fastforce dest: tcb_at_not_NULL)
-  apply clarsimp
-  done
 
 (* L1 bitmap only updated if L2 entry bits end up all zero *)
 lemma rf_sr_drop_bitmaps_dequeue_helper_L2:
@@ -1344,7 +1380,7 @@ lemma tcbSchedDequeue_ccorres':
   "ccorres dc xfdc
            ((\<lambda>s. \<forall>d p. (\<forall>t\<in>set (ksReadyQueues s (d, p)). obj_at' (inQ d p) t s)
                      \<and> distinct (ksReadyQueues s (d, p)))
-             and valid_queues' and tcb_at' t and valid_objs')
+             and valid_queues' and tcb_at' t and valid_objs' and ready_or_release')
            (UNIV \<inter> \<lbrace>\<acute>tcb = tcb_ptr_to_ctcb_ptr t\<rbrace>)
            []
            (tcbSchedDequeue t)
@@ -1413,7 +1449,8 @@ proof -
            apply (rule_tac P="(\<lambda>s. \<forall>d p. (\<forall>t\<in>set (ksReadyQueues s (d, p)). obj_at' (inQ d p) t s)
                                          \<and> distinct (ksReadyQueues s (d, p)))
                                 and valid_queues' and obj_at' (inQ rva rvb) t
-                                and (\<lambda>s. rva \<le> maxDomain \<and> rvb \<le> maxPriority)"
+                                and (\<lambda>s. rva \<le> maxDomain \<and> rvb \<le> maxPriority)
+                                and ready_or_release'"
                        and P'=UNIV in ccorres_from_vcg)
            apply (rule allI, rule conseqPre, vcg)
            apply (clarsimp simp: getQueue_def gets_def get_def setQueue_def modify_def
@@ -1519,8 +1556,9 @@ proof -
                                    maxDom_to_H maxPrio_to_H
                              cong: if_cong split del: if_split)[1]
 
-               apply (fastforce simp: tcb_null_sched_ptrs_def typ_heap_simps c_guard_clift
-                                elim: obj_at'_weaken)+
+                 apply (fastforce simp: tcb_null_sched_ptrs_def typ_heap_simps c_guard_clift
+                                  elim: obj_at'_weaken)+
+              apply (fastforce simp: ready_or_release'_def)
              apply (erule_tac S="set (ksReadyQueues \<sigma> (tcbDomain ko, tcbPriority ko))"
                       in state_relation_queue_update_helper',
                     (simp | rule globals.equality)+,
@@ -1529,8 +1567,9 @@ proof -
                                   maxDom_to_H maxPrio_to_H
                             cong: if_cong split del: if_split,
                     simp_all add: typ_heap_simps')[1]
-              subgoal by (fastforce simp: tcb_null_sched_ptrs_def)
-             subgoal by fastforce
+               subgoal by (fastforce simp: tcb_null_sched_ptrs_def)
+              subgoal by fastforce
+             apply (fastforce simp: ready_or_release'_def)
             apply clarsimp
             apply (rule conjI; clarsimp)
              apply (rule conjI)
@@ -1549,10 +1588,11 @@ proof -
                                  cready_queues_index_to_C_def2
                                  maxDom_to_H maxPrio_to_H
                            cong: if_cong split del: if_split)[1]
-               apply (fold_subgoals (prefix))[4]
+               apply (fold_subgoals (prefix))[5]
             subgoal premises prems using prems
               by - (fastforce simp: typ_heap_simps c_guard_clift tcb_null_sched_ptrs_def
-                                    clift_heap_update_same[OF h_t_valid_clift])+
+                                    clift_heap_update_same[OF h_t_valid_clift]
+                                    ready_or_release'_def)+
            apply (rule conjI; clarsimp simp: queue_in_range[simplified maxDom_to_H maxPrio_to_H])
             apply (frule (1) valid_queuesD')
             apply (drule (1) obj_at_cslift_tcb, clarsimp simp: inQ_def)
@@ -1614,8 +1654,7 @@ proof -
            apply (clarsimp simp: h_val_field_clift'
                                  h_t_valid_clift[THEN h_t_valid_field] h_t_valid_clift)
            apply (simp add: invert_prioToL1Index_c_simp)
-           apply (frule_tac s=\<sigma> in tcb_queue_relation_prev_next')
-               apply (fastforce simp add: ksQ_tcb_at')+
+           apply (frule_tac s=\<sigma> in tcb_queue_relation_prev_next'; (fastforce simp: ksQ_tcb_at')?)
            apply (drule_tac s=\<sigma> in tcbSchedDequeue_update, assumption,
                   simp_all add: remove1_filter ksQ_tcb_at')[1]
            apply (clarsimp simp: filter_noteq_op upd_unless_null_def)
@@ -1634,10 +1673,11 @@ proof -
                                   cready_queues_index_to_C_def2
                                   maxDom_to_H maxPrio_to_H
                             cong: if_cong split del: if_split)[1]
-                apply (fastforce simp: tcb_null_sched_ptrs_def)
-               apply (clarsimp simp: typ_heap_simps')
-              apply (fastforce simp: typ_heap_simps)
-             apply (fastforce simp: tcb_null_sched_ptrs_def)
+                 apply (fastforce simp: tcb_null_sched_ptrs_def)
+                apply (clarsimp simp: typ_heap_simps')
+               apply (fastforce simp: typ_heap_simps)
+              apply (fastforce simp: tcb_null_sched_ptrs_def)
+             apply (fastforce simp: ready_or_release'_def)
             apply (erule_tac S="set (ksReadyQueues \<sigma> (tcbDomain ko, tcbPriority ko))"
                      in state_relation_queue_update_helper',
                    (simp | rule globals.equality)+,
@@ -1645,10 +1685,11 @@ proof -
                                  cready_queues_index_to_C_def2
                                  maxDom_to_H maxPrio_to_H
                            cong: if_cong split del: if_split)[1]
-               apply (fold_subgoals (prefix))[4]
+               apply (fold_subgoals (prefix))[5]
             subgoal premises prems using prems
               by - (fastforce simp: typ_heap_simps c_guard_clift tcb_null_sched_ptrs_def
-                                    clift_heap_update_same[OF h_t_valid_clift])+
+                                    clift_heap_update_same[OF h_t_valid_clift]
+                                    ready_or_release'_def)+
            apply (clarsimp)
            apply (rule conjI; clarsimp simp: typ_heap_simps)
             apply (rule conjI)
@@ -1669,9 +1710,10 @@ proof -
                                 cready_queues_index_to_C_def2 typ_heap_simps
                                 maxDom_to_H maxPrio_to_H
                           cong: if_cong split del: if_split)[1]
-            apply (fold_subgoals (prefix))[3]
+            apply (fold_subgoals (prefix))[4]
            subgoal premises prems using prems
-            by (fastforce simp: typ_heap_simps c_guard_clift tcb_null_sched_ptrs_def)+
+            by (fastforce simp: typ_heap_simps c_guard_clift tcb_null_sched_ptrs_def
+                                ready_or_release'_def)+
           apply (simp add: guard_is_UNIV_def)
          apply simp
          apply (wp threadGet_wp)
@@ -1683,14 +1725,16 @@ proof -
     apply simp
     apply (wp threadGet_wp)
    apply vcg
-  by (fastforce simp: valid_objs'_def obj_at'_def ran_def projectKOs typ_at'_def
+  apply clarsimp
+  apply (frule ready_or_release'_disjoint_queues)
+  by (fastforce simp: valid_objs'_def obj_at'_def ran_def typ_at'_def
                       valid_obj'_def valid_tcb'_def inQ_def)
 qed
 
 lemma tcbSchedDequeue_ccorres:
   "ccorres dc xfdc
            (valid_queues and valid_queues' and tcb_at' t and valid_objs'
-            and (\<lambda>s. \<forall>d p. distinct (ksReadyQueues s (d, p))))
+            and (\<lambda>s. \<forall>d p. distinct (ksReadyQueues s (d, p))) and ready_or_release')
            (UNIV \<inter> \<lbrace>\<acute>tcb = tcb_ptr_to_ctcb_ptr t\<rbrace>)
            []
            (tcbSchedDequeue t)
@@ -1754,7 +1798,8 @@ lemma tcb_queue_relation_qend_mems:
 lemma tcbSchedAppend_ccorres:
   "ccorres dc xfdc
            (valid_queues and tcb_at' t and valid_objs'
-            and (\<lambda>s. \<forall>d p. distinct (ksReadyQueues s (d, p))))
+            and (\<lambda>s. \<forall>d p. distinct (ksReadyQueues s (d, p)))
+            and (\<lambda>s. t \<notin> set (ksReleaseQueue s)) and ready_or_release')
            (UNIV \<inter> \<lbrace>\<acute>tcb = tcb_ptr_to_ctcb_ptr t\<rbrace>)
            []
            (tcbSchedAppend t)
@@ -1814,7 +1859,10 @@ proof -
            apply (rule_tac P="\<lambda>s. valid_queues s \<and> (\<forall>p. t \<notin> set (ksReadyQueues s p))
                                   \<and> (\<exists>tcb. ko_at' tcb t s \<and> tcbDomain tcb =rva
                                   \<and> tcbPriority tcb = rvb \<and> valid_tcb' tcb s)
-                                  \<and> (\<forall>d p. distinct (ksReadyQueues s (d, p)))"
+                                  \<and> (\<forall>d p. distinct (ksReadyQueues s (d, p)))
+                                  \<and> t \<notin> set (ksReleaseQueue s)
+                                  \<and> (\<forall>d p. set (ksReadyQueues s (d, p)) \<inter> set (ksReleaseQueue s) = {})
+                                  \<and> ready_or_release' s"
                        and P'=UNIV in ccorres_from_vcg)
            apply (rule allI, rule conseqPre, vcg)
            apply (clarsimp simp: getQueue_def gets_def get_def setQueue_def modify_def
@@ -1891,38 +1939,45 @@ proof -
            apply (clarsimp simp: cready_queues_index_to_C_def2 numPriorities_def)
            apply (frule(2) obj_at_cslift_tcb[OF valid_queues_obj_at'D])
            apply (clarsimp simp: h_val_field_clift' h_t_valid_clift)
-           apply (erule_tac S="{t, v}" for v in state_relation_queue_update_helper,
+           apply (rule_tac S="set (t # ksReadyQueues \<sigma> (tcbDomain tcb, tcbPriority tcb))"
+                        in state_relation_queue_update_helper,
                   (simp | rule globals.equality)+,
                   simp_all add: typ_heap_simps if_Some_helper numPriorities_def
                                 cready_queues_index_to_C_def2 upd_unless_null_def
                            cong: if_cong split del: if_split
                            del: fun_upd_restrict_conv)[1]
-                 apply simp
-                 apply (rule conjI)
-                  apply clarsimp
-                  apply (drule_tac s="tcb_ptr_to_ctcb_ptr t" in sym, simp)
-                 apply (clarsimp simp add: fun_upd_twist)
-                prefer 4
-                apply (simp add: obj_at'_weakenE[OF _ TrueI])
-                apply (rule disjI1, erule valid_queues_obj_at'D)
-                subgoal by simp
-               subgoal by simp
-              subgoal by (fastforce simp: tcb_null_sched_ptrs_def)
-             apply (clarsimp simp: typ_heap_simps')
+                  apply simp
+                  apply (rule conjI)
+                   apply clarsimp
+                   apply (drule_tac s="tcb_ptr_to_ctcb_ptr t" in sym, simp)
+                  apply (clarsimp simp add: fun_upd_twist)
+                 prefer 4
+                 apply (simp add: obj_at'_weakenE[OF _ TrueI])
+                 apply (fastforce intro!: valid_queues_obj_at'D)
+                apply (rule ext)
+                apply (clarsimp split: if_splits simp: typ_heap_simps)
+                apply (frule rf_sr_sched_queue_relation)
+                  apply fastforce
+                 apply fastforce
+                apply (meson ctcb_ptr_to_tcb_ptr_imageI)
+               subgoal by (fastforce simp: tcb_null_sched_ptrs_def)
+              apply (clarsimp simp: typ_heap_simps')
+             apply fast
             apply (simp add: guard_is_UNIV_def)
            apply simp
            apply (wp threadGet_wp)
           apply vcg
          apply simp
-        apply (wp threadGet_wp)
-       apply vcg
-      apply (rule ccorres_return_Skip)
-     apply simp
-     apply (wp threadGet_wp)
-    apply vcg
-   by (fastforce simp: valid_objs'_def obj_at'_def ran_def projectKOs typ_at'_def
-                       valid_obj'_def inQ_def
-                dest!: valid_queues_obj_at'D)
+         apply (wp threadGet_wp)
+        apply vcg
+       apply (rule ccorres_return_Skip)
+      apply simp
+      apply (wp threadGet_wp)
+     apply vcg
+    apply clarsimp
+    apply (frule ready_or_release'_disjoint_queues)
+    by (fastforce simp: valid_objs'_def obj_at'_def ran_def typ_at'_def valid_obj'_def inQ_def
+                 dest!: valid_queues_obj_at'D)
 qed
 
 lemma isStopped_spec:
@@ -2904,23 +2959,28 @@ lemma cancelIPC_ccorres_helper:
        apply (elim conjE)
        apply (intro conjI)
        \<comment> \<open>tcb relation\<close>
-            apply (erule ctcb_relation_null_queue_ptrs)
-            subgoal by (clarsimp simp: comp_def)
-        \<comment> \<open>ep relation\<close>
-           apply (rule cpspace_relation_ep_update_ep, assumption+)
-            subgoal by (simp add: cendpoint_relation_def Let_def EPState_Idle_def)
-           subgoal by simp
-           \<comment> \<open>ntfn relation\<close>
-          apply (erule iffD1 [OF cmap_relation_cong, OF refl refl, rotated -1])
-          apply simp
-          apply (rule cnotification_relation_ep_queue, assumption+)
-           subgoal by simp
-          apply (erule (1) map_to_ko_atI')
-          subgoal sorry (* FIXME RT: refill_buffer_relation *)
-         apply (simp add: heap_to_user_data_def Let_def)
-        \<comment> \<open>queue relation\<close>
-         apply (rule cready_queues_relation_null_queue_ptrs, assumption+)
-         subgoal by (clarsimp simp: comp_def)
+              apply (erule ctcb_relation_null_queue_ptrs)
+              subgoal by (clarsimp simp: comp_def)
+          \<comment> \<open>ep relation\<close>
+             apply (rule cpspace_relation_ep_update_ep, assumption+)
+              subgoal by (simp add: cendpoint_relation_def Let_def EPState_Idle_def)
+             subgoal by simp
+             \<comment> \<open>ntfn relation\<close>
+            apply (erule iffD1 [OF cmap_relation_cong, OF refl refl, rotated -1])
+            apply simp
+            apply (rule cnotification_relation_ep_queue, assumption+)
+             subgoal by simp
+            apply (erule (1) map_to_ko_atI')
+           subgoal sorry (* FIXME RT: refill_buffer_relation *)
+          apply (simp add: heap_to_user_data_def Let_def)
+        \<comment> \<open>queue relations\<close>
+          apply (rule cready_queues_relation_null_queue_ptrs, assumption+)
+          subgoal by (clarsimp simp: comp_def)
+         apply (erule iffD2[OF tcb_queue_relation_only_next_prev, rotated -1])
+          apply (rule null_ep_schedD[THEN conjunct1])
+          apply (clarsimp simp: comp_def)
+         apply (rule null_ep_schedD[THEN conjunct2])
+         apply (clarsimp simp: comp_def)
         subgoal by (clarsimp simp: carch_state_relation_def carch_globals_def
                                    packed_heap_update_collapse_hrs)
        subgoal by (simp add: cmachine_state_relation_def)
@@ -2942,44 +3002,49 @@ lemma cancelIPC_ccorres_helper:
       apply (elim conjE)
       apply (intro conjI)
       \<comment> \<open>tcb relation\<close>
-           apply (erule ctcb_relation_null_queue_ptrs)
-           subgoal by (clarsimp simp: comp_def)
-       \<comment> \<open>ep relation\<close>
-          apply (rule cpspace_relation_ep_update_ep, assumption+)
-           apply (simp add: cendpoint_relation_def Let_def isSendEP_def isRecvEP_def split: endpoint.splits split del: if_split)
-           \<comment> \<open>recv case\<close>
-            apply (subgoal_tac "pspace_canonical' \<sigma>")
-             prefer 2
-             apply fastforce
-            apply (clarsimp
-                     simp: h_t_valid_clift_Some_iff ctcb_offset_defs
-                           tcb_queue_relation'_next_mask tcb_queue_relation'_prev_mask
-                           tcb_queue_relation'_next_sign tcb_queue_relation'_prev_sign
-                     simp flip: canonical_bit_def
-                     cong: tcb_queue_relation'_cong)
-            subgoal by (intro impI conjI; simp)
-           \<comment> \<open>send case\<close>
-            apply (subgoal_tac "pspace_canonical' \<sigma>")
-             prefer 2
-             apply fastforce
-           apply (clarsimp
-                    simp: h_t_valid_clift_Some_iff ctcb_offset_defs
-                          tcb_queue_relation'_next_mask tcb_queue_relation'_prev_mask
-                          tcb_queue_relation'_next_sign tcb_queue_relation'_prev_sign
-                    simp flip: canonical_bit_def
-                    cong: tcb_queue_relation'_cong)
-           subgoal by (intro impI conjI; simp)
-          subgoal by simp
-                \<comment> \<open>ntfn relation\<close>
-         apply (erule iffD1 [OF cmap_relation_cong, OF refl refl, rotated -1])
-         apply simp
-         apply (rule cnotification_relation_ep_queue, assumption+)
-         apply simp
-         apply (erule (1) map_to_ko_atI')
-         subgoal sorry (* FIXME RT: refill_buffer_relation *)
-         \<comment> \<open>queue relation\<close>
-        apply (rule cready_queues_relation_null_queue_ptrs, assumption+)
-        subgoal by (clarsimp simp: comp_def)
+             apply (erule ctcb_relation_null_queue_ptrs)
+             subgoal by (clarsimp simp: comp_def)
+         \<comment> \<open>ep relation\<close>
+            apply (rule cpspace_relation_ep_update_ep, assumption+)
+             apply (simp add: cendpoint_relation_def Let_def isSendEP_def isRecvEP_def split: endpoint.splits split del: if_split)
+             \<comment> \<open>recv case\<close>
+              apply (subgoal_tac "pspace_canonical' \<sigma>")
+               prefer 2
+               apply fastforce
+              apply (clarsimp
+                       simp: h_t_valid_clift_Some_iff ctcb_offset_defs
+                             tcb_queue_relation'_next_mask tcb_queue_relation'_prev_mask
+                             tcb_queue_relation'_next_sign tcb_queue_relation'_prev_sign
+                       simp flip: canonical_bit_def
+                       cong: tcb_queue_relation'_cong)
+              subgoal by (intro impI conjI; simp)
+             \<comment> \<open>send case\<close>
+              apply (subgoal_tac "pspace_canonical' \<sigma>")
+               prefer 2
+               apply fastforce
+             apply (clarsimp
+                      simp: h_t_valid_clift_Some_iff ctcb_offset_defs
+                            tcb_queue_relation'_next_mask tcb_queue_relation'_prev_mask
+                            tcb_queue_relation'_next_sign tcb_queue_relation'_prev_sign
+                      simp flip: canonical_bit_def
+                      cong: tcb_queue_relation'_cong)
+             subgoal by (intro impI conjI; simp)
+            subgoal by simp
+                  \<comment> \<open>ntfn relation\<close>
+           apply (erule iffD1 [OF cmap_relation_cong, OF refl refl, rotated -1])
+           apply simp
+           apply (rule cnotification_relation_ep_queue, assumption+)
+           apply simp
+           apply (erule (1) map_to_ko_atI')
+          subgoal sorry (* FIXME RT: refill_buffer_relation *)
+          \<comment> \<open>queue relations\<close>
+         apply (rule cready_queues_relation_null_queue_ptrs, assumption+)
+         subgoal by (clarsimp simp: comp_def)
+        apply (erule iffD2[OF tcb_queue_relation_only_next_prev, rotated -1])
+          apply (rule null_ep_schedD[THEN conjunct1])
+          apply (clarsimp simp: comp_def)
+        apply (rule null_ep_schedD[THEN conjunct2])
+        apply (clarsimp simp: comp_def)
        subgoal by (clarsimp simp: carch_state_relation_def carch_globals_def
                                   packed_heap_update_collapse_hrs)
       subgoal by (simp add: cmachine_state_relation_def)

--- a/proof/crefine/RISCV64/Ipc_C.thy
+++ b/proof/crefine/RISCV64/Ipc_C.thy
@@ -4534,23 +4534,28 @@ lemma sendIPC_dequeue_ccorres_helper:
                          typ_heap_simps')
         apply (elim conjE)
         apply (intro conjI)
-             \<comment> \<open>tcb relation\<close>
-             apply (erule ctcb_relation_null_queue_ptrs)
-             apply (clarsimp simp: comp_def)
-            \<comment> \<open>ep relation\<close>
-            apply (rule cpspace_relation_ep_update_ep, assumption+)
-             apply (simp add: cendpoint_relation_def Let_def EPState_Idle_def
-                              tcb_queue_relation'_def)
-            apply simp
-           \<comment> \<open>ntfn relation\<close>
-           apply (erule iffD1 [OF cmap_relation_cong, OF refl refl, rotated -1])
-           apply simp
-           apply (rule cnotification_relation_ep_queue, assumption+)
-            apply simp
-           apply (erule (1) map_to_ko_atI')
-           subgoal sorry (* FIXME RT: refill_buffer_relation *)
-          \<comment> \<open>queue relation\<close>
-          apply (rule cready_queues_relation_null_queue_ptrs, assumption+)
+               \<comment> \<open>tcb relation\<close>
+               apply (erule ctcb_relation_null_queue_ptrs)
+               apply (clarsimp simp: comp_def)
+              \<comment> \<open>ep relation\<close>
+              apply (rule cpspace_relation_ep_update_ep, assumption+)
+               apply (simp add: cendpoint_relation_def Let_def EPState_Idle_def
+                                tcb_queue_relation'_def)
+              apply simp
+             \<comment> \<open>ntfn relation\<close>
+             apply (erule iffD1 [OF cmap_relation_cong, OF refl refl, rotated -1])
+             apply simp
+             apply (rule cnotification_relation_ep_queue, assumption+)
+              apply simp
+             apply (erule (1) map_to_ko_atI')
+            subgoal sorry (* FIXME RT: refill_buffer_relation *)
+           \<comment> \<open>queue relations\<close>
+           apply (rule cready_queues_relation_null_queue_ptrs, assumption+)
+           apply (clarsimp simp: comp_def)
+          apply (erule iffD2[OF tcb_queue_relation_only_next_prev, rotated -1])
+           apply (rule null_ep_schedD[THEN conjunct1])
+           apply (clarsimp simp: comp_def)
+          apply (rule null_ep_schedD[THEN conjunct2])
           apply (clarsimp simp: comp_def)
          apply (clarsimp simp: carch_state_relation_def packed_heap_update_collapse_hrs)
         apply (simp add: cmachine_state_relation_def)
@@ -4575,31 +4580,36 @@ lemma sendIPC_dequeue_ccorres_helper:
                         typ_heap_simps')
        apply (elim conjE)
        apply (intro conjI)
-             \<comment> \<open>tcb relation\<close>
-            apply (erule ctcb_relation_null_queue_ptrs)
-            apply (clarsimp simp: comp_def)
-           \<comment> \<open>ep relation\<close>
-           apply (rule cpspace_relation_ep_update_ep, assumption+)
-            apply (clarsimp simp: cendpoint_relation_def Let_def
-                                  isRecvEP_def isSendEP_def
-                                  tcb_queue_relation'_def valid_ep'_def
-                       simp flip: canonical_bit_def
-                           split: endpoint.splits list.splits
-                       split del: if_split)
-            apply (subgoal_tac "tcb_at' (if x22 = [] then x21 else last x22) \<sigma>")
-             apply (erule (1) tcb_and_not_mask_canonical[OF invs_pspace_canonical'])
-             apply (simp add: objBits_simps')
-            apply (clarsimp split: if_split)
-           apply simp
-          \<comment> \<open>ntfn relation\<close>
-          apply (erule iffD1 [OF cmap_relation_cong, OF refl refl, rotated -1])
-          apply simp
-          apply (rule cnotification_relation_ep_queue, assumption+)
-           apply simp
-          apply (erule (1) map_to_ko_atI')
-          subgoal sorry (* FIXME RT: refill_buffer_relation *)
-         \<comment> \<open>queue relation\<close>
-         apply (rule cready_queues_relation_null_queue_ptrs, assumption+)
+               \<comment> \<open>tcb relation\<close>
+              apply (erule ctcb_relation_null_queue_ptrs)
+              apply (clarsimp simp: comp_def)
+             \<comment> \<open>ep relation\<close>
+             apply (rule cpspace_relation_ep_update_ep, assumption+)
+              apply (clarsimp simp: cendpoint_relation_def Let_def
+                                    isRecvEP_def isSendEP_def
+                                    tcb_queue_relation'_def valid_ep'_def
+                         simp flip: canonical_bit_def
+                             split: endpoint.splits list.splits
+                         split del: if_split)
+              apply (subgoal_tac "tcb_at' (if x22 = [] then x21 else last x22) \<sigma>")
+               apply (erule (1) tcb_and_not_mask_canonical[OF invs_pspace_canonical'])
+               apply (simp add: objBits_simps')
+              apply (clarsimp split: if_split)
+             apply simp
+            \<comment> \<open>ntfn relation\<close>
+            apply (erule iffD1 [OF cmap_relation_cong, OF refl refl, rotated -1])
+            apply simp
+            apply (rule cnotification_relation_ep_queue, assumption+)
+             apply simp
+            apply (erule (1) map_to_ko_atI')
+           subgoal sorry (* FIXME RT: refill_buffer_relation *)
+          \<comment> \<open>queue relations\<close>
+          apply (rule cready_queues_relation_null_queue_ptrs, assumption+)
+          apply (clarsimp simp: comp_def)
+         apply (erule iffD2[OF tcb_queue_relation_only_next_prev, rotated -1])
+          apply (rule null_ep_schedD[THEN conjunct1])
+          apply (clarsimp simp: comp_def)
+         apply (rule null_ep_schedD[THEN conjunct2])
          apply (clarsimp simp: comp_def)
         apply (clarsimp simp: carch_state_relation_def packed_heap_update_collapse_hrs)
        apply (simp add: cmachine_state_relation_def)
@@ -4915,34 +4925,39 @@ lemma sendIPC_enqueue_ccorres_helper:
        apply (elim conjE)
        apply (intro conjI)
             \<comment> \<open>tcb relation\<close>
-            apply (erule ctcb_relation_null_queue_ptrs)
-            apply (clarsimp simp: comp_def)
-           \<comment> \<open>ep relation\<close>
-           apply (rule cpspace_relation_ep_update_ep', assumption+)
-            apply (clarsimp simp: cendpoint_relation_def Let_def
-                                  mask_def [where n=3] EPState_Send_def)
-            apply (clarsimp simp: tcb_queue_relation'_def is_aligned_neg_mask)
-            apply (rule conjI, simp add: mask_def)
-            subgoal
-              apply (clarsimp simp: valid_pspace'_def objBits_simps' simp flip: canonical_bit_def)
-              apply (erule (1) tcb_and_not_mask_canonical)
-              by (simp (no_asm) add: tcbBlockSizeBits_def)
-           apply (simp add: isSendEP_def isRecvEP_def)
-          \<comment> \<open>ntfn relation\<close>
-          apply (erule iffD1 [OF cmap_relation_cong, OF refl refl, rotated -1])
-          apply simp
-          apply (rule cnotification_relation_ep_queue, assumption+)
-            apply (simp add: isSendEP_def isRecvEP_def)
-           apply simp
-          apply (frule_tac x=p in map_to_ko_atI, clarsimp, clarsimp)
-            apply fastforce
-           apply (erule(2) map_to_ko_at_updI')
-           apply (simp only:projectKOs injectKO_ep objBits_simps)
-           apply clarsimp
-          apply (clarsimp simp: obj_at'_def projectKOs)
-          subgoal sorry (* FIXME RT: refill_buffer_relation *)
-         \<comment> \<open>queue relation\<close>
-         apply (rule cready_queues_relation_null_queue_ptrs, assumption+)
+              apply (erule ctcb_relation_null_queue_ptrs)
+             apply (clarsimp simp: comp_def)
+             \<comment> \<open>ep relation\<close>
+             apply (rule cpspace_relation_ep_update_ep', assumption+)
+              apply (clarsimp simp: cendpoint_relation_def Let_def
+                                    mask_def [where n=3] EPState_Send_def)
+              apply (clarsimp simp: tcb_queue_relation'_def is_aligned_neg_mask)
+              apply (rule conjI, simp add: mask_def)
+              subgoal
+                apply (clarsimp simp: valid_pspace'_def objBits_simps' simp flip: canonical_bit_def)
+                apply (erule (1) tcb_and_not_mask_canonical)
+                by (simp (no_asm) add: tcbBlockSizeBits_def)
+             apply (simp add: isSendEP_def isRecvEP_def)
+            \<comment> \<open>ntfn relation\<close>
+            apply (erule iffD1 [OF cmap_relation_cong, OF refl refl, rotated -1])
+            apply simp
+            apply (rule cnotification_relation_ep_queue, assumption+)
+              apply (simp add: isSendEP_def isRecvEP_def)
+             apply simp
+            apply (frule_tac x=p in map_to_ko_atI, clarsimp, clarsimp)
+              apply fastforce
+             apply (erule(2) map_to_ko_at_updI')
+             apply (simp only:projectKOs injectKO_ep objBits_simps)
+             apply clarsimp
+            apply (clarsimp simp: obj_at'_def projectKOs)
+           subgoal sorry (* FIXME RT: refill_buffer_relation *)
+          \<comment> \<open>queue relations\<close>
+          apply (rule cready_queues_relation_null_queue_ptrs, assumption+)
+          apply (clarsimp simp: comp_def)
+         apply (erule iffD2[OF tcb_queue_relation_only_next_prev, rotated -1])
+          apply (rule null_ep_schedD[THEN conjunct1])
+          apply (clarsimp simp: comp_def)
+         apply (rule null_ep_schedD[THEN conjunct2])
          apply (clarsimp simp: comp_def)
         apply (clarsimp simp: carch_state_relation_def packed_heap_update_collapse_hrs)
        apply (simp add: cmachine_state_relation_def)
@@ -4960,43 +4975,48 @@ lemma sendIPC_enqueue_ccorres_helper:
                        typ_heap_simps')
       apply (elim conjE)
       apply (intro conjI)
-           \<comment> \<open>tcb relation\<close>
-           apply (erule ctcb_relation_null_queue_ptrs)
-           apply (clarsimp simp: comp_def)
-          \<comment> \<open>ep relation\<close>
-          apply (rule cpspace_relation_ep_update_ep', assumption+)
-           apply (clarsimp simp: cendpoint_relation_def Let_def
-                                 mask_def [where n=3] EPState_Send_def
-                          split: if_split)
-           subgoal
-             apply (clarsimp simp: tcb_queue_relation'_def is_aligned_neg_mask
-                                 valid_ep'_def
-                           dest: tcb_queue_relation_next_not_NULL)
-             apply (rule conjI, clarsimp)
-              apply (rule conjI, fastforce simp: mask_def)
-              apply (clarsimp simp: valid_pspace'_def objBits_simps' simp flip: canonical_bit_def)
-              apply (erule (1) tcb_and_not_mask_canonical)
-              apply (simp (no_asm) add: tcbBlockSizeBits_def)
-             apply (clarsimp simp: valid_pspace'_def objBits_simps' simp flip: canonical_bit_def)
-             apply (rule conjI, solves \<open>simp (no_asm) add: mask_def\<close>)
-             apply (erule (1) tcb_and_not_mask_canonical)
-             apply (simp (no_asm) add: tcbBlockSizeBits_def)
-             done
-          apply (simp add: isSendEP_def isRecvEP_def)
-         \<comment> \<open>ntfn relation\<close>
-         apply (erule iffD1 [OF cmap_relation_cong, OF refl refl, rotated -1])
-         apply simp
-         apply (rule cnotification_relation_ep_queue, assumption+)
-           apply (simp add: isSendEP_def isRecvEP_def)
-          apply simp
-         apply (frule_tac x=p in map_to_ko_atI, clarsimp, clarsimp)
-           apply fastforce
-          apply (erule(2) map_to_ko_at_updI')
-          apply (clarsimp simp: objBitsKO_def)
-         apply (clarsimp simp: obj_at'_def)
-         subgoal sorry (* FIXME RT: refill_buffer_relation *)
-        \<comment> \<open>queue relation\<close>
-        apply (rule cready_queues_relation_null_queue_ptrs, assumption+)
+             \<comment> \<open>tcb relation\<close>
+             apply (erule ctcb_relation_null_queue_ptrs)
+             apply (clarsimp simp: comp_def)
+            \<comment> \<open>ep relation\<close>
+            apply (rule cpspace_relation_ep_update_ep', assumption+)
+             apply (clarsimp simp: cendpoint_relation_def Let_def
+                                   mask_def [where n=3] EPState_Send_def
+                            split: if_split)
+             subgoal
+               apply (clarsimp simp: tcb_queue_relation'_def is_aligned_neg_mask
+                                     valid_ep'_def
+                               dest: tcb_queue_relation_next_not_NULL)
+               apply (rule conjI, clarsimp)
+                apply (rule conjI, fastforce simp: mask_def)
+                apply (clarsimp simp: valid_pspace'_def objBits_simps' simp flip: canonical_bit_def)
+                apply (erule (1) tcb_and_not_mask_canonical)
+                apply (simp (no_asm) add: tcbBlockSizeBits_def)
+               apply (clarsimp simp: valid_pspace'_def objBits_simps' simp flip: canonical_bit_def)
+               apply (rule conjI, solves \<open>simp (no_asm) add: mask_def\<close>)
+               apply (erule (1) tcb_and_not_mask_canonical)
+               apply (simp (no_asm) add: tcbBlockSizeBits_def)
+               done
+            apply (simp add: isSendEP_def isRecvEP_def)
+           \<comment> \<open>ntfn relation\<close>
+           apply (erule iffD1 [OF cmap_relation_cong, OF refl refl, rotated -1])
+           apply simp
+           apply (rule cnotification_relation_ep_queue, assumption+)
+             apply (simp add: isSendEP_def isRecvEP_def)
+            apply simp
+           apply (frule_tac x=p in map_to_ko_atI, clarsimp, clarsimp)
+             apply fastforce
+            apply (erule(2) map_to_ko_at_updI')
+            apply (clarsimp simp: objBitsKO_def)
+           apply (clarsimp simp: obj_at'_def)
+          subgoal sorry (* FIXME RT: refill_buffer_relation *)
+         \<comment> \<open>queue relations\<close>
+         apply (rule cready_queues_relation_null_queue_ptrs, assumption+)
+         apply (clarsimp simp: comp_def)
+        apply (erule iffD2[OF tcb_queue_relation_only_next_prev, rotated -1])
+         apply (rule null_ep_schedD[THEN conjunct1])
+         apply (clarsimp simp: comp_def)
+        apply (rule null_ep_schedD[THEN conjunct2])
         apply (clarsimp simp: comp_def)
        apply (clarsimp simp: carch_state_relation_def packed_heap_update_collapse_hrs)
       apply (simp add: cmachine_state_relation_def)
@@ -5403,8 +5423,13 @@ lemma receiveIPC_enqueue_ccorres_helper:
            apply (clarsimp simp: objBitsKO_def)
           apply (clarsimp simp: obj_at'_def)
           subgoal sorry (* FIXME RT: refill_buffer_relation *)
-         \<comment> \<open>queue relation\<close>
-         apply (rule cready_queues_relation_null_queue_ptrs, assumption+)
+          \<comment> \<open>queue relations\<close>
+          apply (rule cready_queues_relation_null_queue_ptrs, assumption+)
+          apply (clarsimp simp: comp_def)
+         apply (erule iffD2[OF tcb_queue_relation_only_next_prev, rotated -1])
+          apply (rule null_ep_schedD[THEN conjunct1])
+          apply (clarsimp simp: comp_def)
+         apply (rule null_ep_schedD[THEN conjunct2])
          apply (clarsimp simp: comp_def)
         apply (clarsimp simp: carch_state_relation_def packed_heap_update_collapse_hrs)
        apply (simp add: cmachine_state_relation_def)
@@ -5422,35 +5447,40 @@ lemma receiveIPC_enqueue_ccorres_helper:
                        typ_heap_simps')
       apply (elim conjE)
       apply (intro conjI)
-           \<comment> \<open>tcb relation\<close>
-           apply (erule ctcb_relation_null_queue_ptrs)
-           apply (clarsimp simp: comp_def)
-          \<comment> \<open>ep relation\<close>
-          apply (rule cpspace_relation_ep_update_ep', assumption+)
-           apply (clarsimp simp: cendpoint_relation_def Let_def
-                                 mask_def [where n=3] EPState_Recv_def)
-           apply (clarsimp simp: tcb_queue_relation'_def is_aligned_neg_mask
-                           simp flip: canonical_bit_def)
-           subgoal
-             apply (rule conjI, solves\<open>simp (no_asm) add: mask_def\<close>)
-             apply (clarsimp simp: valid_pspace'_def)
-             apply (erule (1) tcb_and_not_mask_canonical, simp (no_asm) add: tcbBlockSizeBits_def)
-             done
-          apply (simp add: isSendEP_def isRecvEP_def)
-         \<comment> \<open>ntfn relation\<close>
-         apply (erule iffD1 [OF cmap_relation_cong, OF refl refl, rotated -1])
-         apply simp
-         apply (rule cnotification_relation_ep_queue, assumption+)
-           apply (simp add: isSendEP_def isRecvEP_def)
-          apply simp
-         apply (frule_tac x=p in map_to_ko_atI, clarsimp, clarsimp)
-          apply fastforce
-         apply (erule(2) map_to_ko_at_updI')
-          apply (clarsimp simp: objBitsKO_def)
-         apply (clarsimp simp: obj_at'_def)
-         subgoal sorry (* FIXME RT: refill_buffer_relation *)
-        \<comment> \<open>queue relation\<close>
-        apply (rule cready_queues_relation_null_queue_ptrs, assumption+)
+             \<comment> \<open>tcb relation\<close>
+             apply (erule ctcb_relation_null_queue_ptrs)
+             apply (clarsimp simp: comp_def)
+            \<comment> \<open>ep relation\<close>
+            apply (rule cpspace_relation_ep_update_ep', assumption+)
+             apply (clarsimp simp: cendpoint_relation_def Let_def
+                                   mask_def [where n=3] EPState_Recv_def)
+             apply (clarsimp simp: tcb_queue_relation'_def is_aligned_neg_mask
+                             simp flip: canonical_bit_def)
+             subgoal
+               apply (rule conjI, solves\<open>simp (no_asm) add: mask_def\<close>)
+               apply (clarsimp simp: valid_pspace'_def)
+               apply (erule (1) tcb_and_not_mask_canonical, simp (no_asm) add: tcbBlockSizeBits_def)
+               done
+            apply (simp add: isSendEP_def isRecvEP_def)
+           \<comment> \<open>ntfn relation\<close>
+           apply (erule iffD1 [OF cmap_relation_cong, OF refl refl, rotated -1])
+           apply simp
+           apply (rule cnotification_relation_ep_queue, assumption+)
+             apply (simp add: isSendEP_def isRecvEP_def)
+            apply simp
+           apply (frule_tac x=p in map_to_ko_atI, clarsimp, clarsimp)
+            apply fastforce
+           apply (erule(2) map_to_ko_at_updI')
+            apply (clarsimp simp: objBitsKO_def)
+           apply (clarsimp simp: obj_at'_def)
+          subgoal sorry (* FIXME RT: refill_buffer_relation *)
+         \<comment> \<open>queue relations\<close>
+         apply (rule cready_queues_relation_null_queue_ptrs, assumption+)
+         apply (clarsimp simp: comp_def)
+        apply (erule iffD2[OF tcb_queue_relation_only_next_prev, rotated -1])
+         apply (rule null_ep_schedD[THEN conjunct1])
+         apply (clarsimp simp: comp_def)
+        apply (rule null_ep_schedD[THEN conjunct2])
         apply (clarsimp simp: comp_def)
        apply (clarsimp simp: carch_state_relation_def packed_heap_update_collapse_hrs)
       apply (simp add: cmachine_state_relation_def)
@@ -5521,23 +5551,28 @@ lemma receiveIPC_dequeue_ccorres_helper:
                          typ_heap_simps')
         apply (elim conjE)
         apply (intro conjI)
-             \<comment> \<open>tcb relation\<close>
-             apply (erule ctcb_relation_null_queue_ptrs)
-             apply (clarsimp simp: comp_def)
-            \<comment> \<open>ep relation\<close>
-            apply (rule cpspace_relation_ep_update_ep, assumption+)
-             apply (simp add: cendpoint_relation_def Let_def EPState_Idle_def
-                              tcb_queue_relation'_def)
-            apply simp
-           \<comment> \<open>ntfn relation\<close>
-           apply (erule iffD1 [OF cmap_relation_cong, OF refl refl, rotated -1])
-           apply simp
-           apply (rule cnotification_relation_ep_queue, assumption+)
-           apply simp
-          apply (erule (1) map_to_ko_atI')
-           subgoal sorry (* FIXME RT: refill_buffer_relation *)
-          \<comment> \<open>queue relation\<close>
-          apply (rule cready_queues_relation_null_queue_ptrs, assumption+)
+               \<comment> \<open>tcb relation\<close>
+               apply (erule ctcb_relation_null_queue_ptrs)
+               apply (clarsimp simp: comp_def)
+              \<comment> \<open>ep relation\<close>
+              apply (rule cpspace_relation_ep_update_ep, assumption+)
+               apply (simp add: cendpoint_relation_def Let_def EPState_Idle_def
+                                tcb_queue_relation'_def)
+              apply simp
+             \<comment> \<open>ntfn relation\<close>
+             apply (erule iffD1 [OF cmap_relation_cong, OF refl refl, rotated -1])
+             apply simp
+             apply (rule cnotification_relation_ep_queue, assumption+)
+              apply simp
+             apply (erule (1) map_to_ko_atI')
+            subgoal sorry (* FIXME RT: refill_buffer_relation *)
+           \<comment> \<open>queue relations\<close>
+           apply (rule cready_queues_relation_null_queue_ptrs, assumption+)
+           apply (clarsimp simp: comp_def)
+          apply (erule iffD2[OF tcb_queue_relation_only_next_prev, rotated -1])
+           apply (rule null_ep_schedD[THEN conjunct1])
+           apply (clarsimp simp: comp_def)
+          apply (rule null_ep_schedD[THEN conjunct2])
           apply (clarsimp simp: comp_def)
          apply (clarsimp simp: carch_state_relation_def packed_heap_update_collapse_hrs)
         apply (simp add: cmachine_state_relation_def)
@@ -5562,31 +5597,36 @@ lemma receiveIPC_dequeue_ccorres_helper:
                         typ_heap_simps')
        apply (elim conjE)
        apply (intro conjI)
-            \<comment> \<open>tcb relation\<close>
-            apply (erule ctcb_relation_null_queue_ptrs)
-            apply (clarsimp simp: comp_def)
-           \<comment> \<open>ep relation\<close>
-           apply (rule cpspace_relation_ep_update_ep, assumption+)
-            apply (clarsimp simp: cendpoint_relation_def Let_def
-                                  isRecvEP_def isSendEP_def
-                                  tcb_queue_relation'_def valid_ep'_def
-                       simp flip: canonical_bit_def
-                           split: endpoint.splits list.splits
-                       split del: if_split)
-            apply (subgoal_tac "tcb_at' (if x22 = [] then x21 else last x22) \<sigma>")
-             apply (erule (1) tcb_and_not_mask_canonical[OF invs_pspace_canonical'])
-             apply (clarsimp simp: objBits_simps')
-            apply (clarsimp split: if_split)
-           apply simp
-          \<comment> \<open>ntfn relation\<close>
-          apply (erule iffD1 [OF cmap_relation_cong, OF refl refl, rotated -1])
-          apply simp
-          apply (rule cnotification_relation_ep_queue, assumption+)
-           apply simp
-          apply (erule (1) map_to_ko_atI')
-          subgoal sorry (* FIXME RT: refill_buffer_relation *)
-         \<comment> \<open>queue relation\<close>
-         apply (rule cready_queues_relation_null_queue_ptrs, assumption+)
+              \<comment> \<open>tcb relation\<close>
+              apply (erule ctcb_relation_null_queue_ptrs)
+              apply (clarsimp simp: comp_def)
+             \<comment> \<open>ep relation\<close>
+             apply (rule cpspace_relation_ep_update_ep, assumption+)
+              apply (clarsimp simp: cendpoint_relation_def Let_def
+                                    isRecvEP_def isSendEP_def
+                                    tcb_queue_relation'_def valid_ep'_def
+                         simp flip: canonical_bit_def
+                             split: endpoint.splits list.splits
+                         split del: if_split)
+              apply (subgoal_tac "tcb_at' (if x22 = [] then x21 else last x22) \<sigma>")
+               apply (erule (1) tcb_and_not_mask_canonical[OF invs_pspace_canonical'])
+               apply (clarsimp simp: objBits_simps')
+              apply (clarsimp split: if_split)
+             apply simp
+            \<comment> \<open>ntfn relation\<close>
+            apply (erule iffD1 [OF cmap_relation_cong, OF refl refl, rotated -1])
+            apply simp
+            apply (rule cnotification_relation_ep_queue, assumption+)
+             apply simp
+            apply (erule (1) map_to_ko_atI')
+           subgoal sorry (* FIXME RT: refill_buffer_relation *)
+         \<comment> \<open>queue relations\<close>
+          apply (rule cready_queues_relation_null_queue_ptrs, assumption+)
+          apply (clarsimp simp: comp_def)
+         apply (erule iffD2[OF tcb_queue_relation_only_next_prev, rotated -1])
+          apply (rule null_ep_schedD[THEN conjunct1])
+          apply (clarsimp simp: comp_def)
+         apply (rule null_ep_schedD[THEN conjunct2])
          apply (clarsimp simp: comp_def)
         apply (clarsimp simp: carch_state_relation_def packed_heap_update_collapse_hrs)
        apply (simp add: cmachine_state_relation_def)
@@ -6095,23 +6135,28 @@ lemma sendSignal_dequeue_ccorres_helper:
                          typ_heap_simps')
         apply (elim conjE)
         apply (intro conjI)
-             \<comment> \<open>tcb relation\<close>
-             apply (erule ctcb_relation_null_queue_ptrs)
-             apply (clarsimp simp: comp_def)
-            \<comment> \<open>ep relation\<close>
-            apply (erule iffD1 [OF cmap_relation_cong, OF refl refl, rotated -1])
-            apply simp
-            apply (rule cendpoint_relation_ntfn_queue, assumption+)
-             apply simp+
-            apply (erule (1) map_to_ko_atI')
-           \<comment> \<open>ntfn relation\<close>
-           apply (rule cpspace_relation_ntfn_update_ntfn, assumption+)
-            apply (simp add: cnotification_relation_def Let_def NtfnState_Idle_def
-                             tcb_queue_relation'_def)
-           apply simp
-           subgoal sorry (* FIXME RT: refill_buffer_relation *)
-          \<comment> \<open>queue relation\<close>
-          apply (rule cready_queues_relation_null_queue_ptrs, assumption+)
+               \<comment> \<open>tcb relation\<close>
+               apply (erule ctcb_relation_null_queue_ptrs)
+               apply (clarsimp simp: comp_def)
+              \<comment> \<open>ep relation\<close>
+              apply (erule iffD1 [OF cmap_relation_cong, OF refl refl, rotated -1])
+              apply simp
+              apply (rule cendpoint_relation_ntfn_queue, assumption+)
+               apply simp+
+              apply (erule (1) map_to_ko_atI')
+             \<comment> \<open>ntfn relation\<close>
+             apply (rule cpspace_relation_ntfn_update_ntfn, assumption+)
+              apply (simp add: cnotification_relation_def Let_def NtfnState_Idle_def
+                               tcb_queue_relation'_def)
+             apply simp
+            subgoal sorry (* FIXME RT: refill_buffer_relation *)
+          \<comment> \<open>queue relations\<close>
+           apply (rule cready_queues_relation_null_queue_ptrs, assumption+)
+           apply (clarsimp simp: comp_def)
+          apply (erule iffD2[OF tcb_queue_relation_only_next_prev, rotated -1])
+           apply (rule null_ep_schedD[THEN conjunct1])
+           apply (clarsimp simp: comp_def)
+          apply (rule null_ep_schedD[THEN conjunct2])
           apply (clarsimp simp: comp_def)
          apply (clarsimp simp: carch_state_relation_def packed_heap_update_collapse_hrs)
         apply (simp add: cmachine_state_relation_def)
@@ -6138,33 +6183,38 @@ lemma sendSignal_dequeue_ccorres_helper:
                         typ_heap_simps')
        apply (elim conjE)
        apply (intro conjI)
-            \<comment> \<open>tcb relation\<close>
-            apply (erule ctcb_relation_null_queue_ptrs)
-            apply (clarsimp simp: comp_def)
-           \<comment> \<open>ep relation\<close>
-           apply (erule iffD1 [OF cmap_relation_cong, OF refl refl, rotated -1])
-           apply simp
-           apply (rule cendpoint_relation_ntfn_queue, assumption+)
-            apply simp+
-           apply (erule (1) map_to_ko_atI')
-          \<comment> \<open>ntfn relation\<close>
-          apply (rule cpspace_relation_ntfn_update_ntfn, assumption+)
-           apply (clarsimp simp: cnotification_relation_def Let_def
-                                 isWaitingNtfn_def
-                                 tcb_queue_relation'_def valid_ntfn'_def
-                          split: Structures_H.notification.splits list.splits
-                      split del: if_split)
-           apply (subgoal_tac "tcb_at' (if x22 = [] then x21 else last x22) \<sigma>")
-            apply (rule conjI)
-             subgoal by (erule (1) tcb_ptr_sign_extend_canonical[OF invs_pspace_canonical'])
-            apply (rule context_conjI)
-             subgoal by (erule (1) tcb_ptr_sign_extend_canonical[OF invs_pspace_canonical'])
-            apply clarsimp
-           apply (clarsimp split: if_split)
-          apply simp
-          subgoal sorry (* FIXME RT: refill_buffer_relation *)
-         \<comment> \<open>queue relation\<close>
-         apply (rule cready_queues_relation_null_queue_ptrs, assumption+)
+              \<comment> \<open>tcb relation\<close>
+              apply (erule ctcb_relation_null_queue_ptrs)
+              apply (clarsimp simp: comp_def)
+             \<comment> \<open>ep relation\<close>
+             apply (erule iffD1 [OF cmap_relation_cong, OF refl refl, rotated -1])
+             apply simp
+             apply (rule cendpoint_relation_ntfn_queue, assumption+)
+              apply simp+
+             apply (erule (1) map_to_ko_atI')
+            \<comment> \<open>ntfn relation\<close>
+            apply (rule cpspace_relation_ntfn_update_ntfn, assumption+)
+             apply (clarsimp simp: cnotification_relation_def Let_def
+                                   isWaitingNtfn_def
+                                   tcb_queue_relation'_def valid_ntfn'_def
+                            split: Structures_H.notification.splits list.splits
+                        split del: if_split)
+             apply (subgoal_tac "tcb_at' (if x22 = [] then x21 else last x22) \<sigma>")
+              apply (rule conjI)
+               subgoal by (erule (1) tcb_ptr_sign_extend_canonical[OF invs_pspace_canonical'])
+              apply (rule context_conjI)
+               subgoal by (erule (1) tcb_ptr_sign_extend_canonical[OF invs_pspace_canonical'])
+              apply clarsimp
+             apply (clarsimp split: if_split)
+            apply simp
+           subgoal sorry (* FIXME RT: refill_buffer_relation *)
+          \<comment> \<open>queue relations\<close>
+          apply (rule cready_queues_relation_null_queue_ptrs, assumption+)
+         apply (clarsimp simp: comp_def)
+        apply (erule iffD2[OF tcb_queue_relation_only_next_prev, rotated -1])
+         apply (rule null_ep_schedD[THEN conjunct1])
+          apply (clarsimp simp: comp_def)
+         apply (rule null_ep_schedD[THEN conjunct2])
          apply (clarsimp simp: comp_def)
         apply (clarsimp simp: carch_state_relation_def)
        apply (simp add: cmachine_state_relation_def)
@@ -6529,39 +6579,44 @@ lemma receiveSignal_enqueue_ccorres_helper:
                         typ_heap_simps')
        apply (elim conjE)
        apply (intro conjI)
-            \<comment> \<open>tcb relation\<close>
-            apply (erule ctcb_relation_null_queue_ptrs)
-            apply (clarsimp simp: comp_def)
-           \<comment> \<open>ep relation\<close>
-           apply (erule iffD1 [OF cmap_relation_cong, OF refl refl, rotated -1])
-           apply simp
-           apply (rule cendpoint_relation_ntfn_queue, assumption+)
-             apply (simp add: isWaitingNtfn_def)
-            apply simp
-           apply (frule_tac x=p in map_to_ko_atI, clarsimp, clarsimp)
-            apply fastforce
-           apply (erule(2) map_to_ko_at_updI')
-            apply (clarsimp simp: objBitsKO_def)
-           apply (clarsimp simp: obj_at'_def)
-          \<comment> \<open>ntfn relation\<close>
-          apply (rule cpspace_relation_ntfn_update_ntfn', assumption+)
-            apply (case_tac "ntfn", simp_all)[1]
-           apply (clarsimp simp: cnotification_relation_def Let_def
-                                 mask_def [where n=3] NtfnState_Waiting_def)
-           subgoal
-             apply (clarsimp simp: tcb_queue_relation'_def is_aligned_neg_mask                                valid_ntfn'_def
-                                   dest: tcb_queue_relation_next_not_NULL)
-             apply (rule conjI, fastforce simp: mask_def)
-             apply (rule context_conjI)
-              subgoal by (fastforce simp: valid_pspace'_def objBits_simps'
-                              intro!: tcb_ptr_sign_extend_canonical
-                               dest!: st_tcb_strg'[rule_format])
-             by clarsimp
-          apply (simp add: isWaitingNtfn_def)
-          subgoal sorry (* FIXME RT: refill_buffer_relation *)
-         \<comment> \<open>queue relation\<close>
-         apply (rule cready_queues_relation_null_queue_ptrs, assumption+)
-         subgoal by (clarsimp simp: comp_def)
+              \<comment> \<open>tcb relation\<close>
+              apply (erule ctcb_relation_null_queue_ptrs)
+              apply (clarsimp simp: comp_def)
+             \<comment> \<open>ep relation\<close>
+             apply (erule iffD1 [OF cmap_relation_cong, OF refl refl, rotated -1])
+             apply simp
+             apply (rule cendpoint_relation_ntfn_queue, assumption+)
+               apply (simp add: isWaitingNtfn_def)
+              apply simp
+             apply (frule_tac x=p in map_to_ko_atI, clarsimp, clarsimp)
+              apply fastforce
+             apply (erule(2) map_to_ko_at_updI')
+              apply (clarsimp simp: objBitsKO_def)
+             apply (clarsimp simp: obj_at'_def)
+            \<comment> \<open>ntfn relation\<close>
+            apply (rule cpspace_relation_ntfn_update_ntfn', assumption+)
+              apply (case_tac "ntfn", simp_all)[1]
+             apply (clarsimp simp: cnotification_relation_def Let_def
+                                   mask_def [where n=3] NtfnState_Waiting_def)
+             subgoal
+               apply (clarsimp simp: tcb_queue_relation'_def is_aligned_neg_mask valid_ntfn'_def
+                               dest: tcb_queue_relation_next_not_NULL)
+               apply (rule conjI, fastforce simp: mask_def)
+               apply (rule context_conjI)
+                subgoal by (fastforce simp: valid_pspace'_def objBits_simps'
+                                    intro!: tcb_ptr_sign_extend_canonical
+                                     dest!: st_tcb_strg'[rule_format])
+               by clarsimp
+            apply (simp add: isWaitingNtfn_def)
+           subgoal sorry (* FIXME RT: refill_buffer_relation *)
+          \<comment> \<open>queue relations\<close>
+          apply (rule cready_queues_relation_null_queue_ptrs, assumption+)
+          subgoal by (clarsimp simp: comp_def)
+         apply (erule iffD2[OF tcb_queue_relation_only_next_prev, rotated -1])
+          apply (rule null_ep_schedD[THEN conjunct1])
+          apply (clarsimp simp: comp_def)
+         apply (rule null_ep_schedD[THEN conjunct2])
+         apply (clarsimp simp: comp_def)
         apply (clarsimp simp: carch_state_relation_def packed_heap_update_collapse_hrs)
        apply (simp add: cmachine_state_relation_def)
       apply (simp add: h_t_valid_clift_Some_iff)
@@ -6578,50 +6633,55 @@ lemma receiveSignal_enqueue_ccorres_helper:
                        typ_heap_simps')
       apply (elim conjE)
       apply (intro conjI)
-           \<comment> \<open>tcb relation\<close>
-           apply (erule ctcb_relation_null_queue_ptrs)
-           apply (clarsimp simp: comp_def)
-          \<comment> \<open>ep relation\<close>
-          apply (erule iffD1 [OF cmap_relation_cong, OF refl refl, rotated -1])
-          apply simp
-          apply (rule cendpoint_relation_ntfn_queue, assumption+)
-            apply (simp add: isWaitingNtfn_def)
-           apply simp
-          apply (frule_tac x=p in map_to_ko_atI, clarsimp, clarsimp)
-           apply fastforce
-          apply (erule(2) map_to_ko_at_updI')
-           apply (clarsimp simp: objBitsKO_def)
-          apply (clarsimp simp: obj_at'_def)
-         \<comment> \<open>ntfn relation\<close>
-         apply (rule cpspace_relation_ntfn_update_ntfn', assumption+)
-           apply (case_tac "ntfn", simp_all)[1]
-          apply (clarsimp simp: cnotification_relation_def Let_def
-                                mask_def [where n=3] NtfnState_Waiting_def
-                         split: if_split)
-          subgoal for _ _ ko'
-            apply (clarsimp simp: tcb_queue_relation'_def is_aligned_neg_mask
-                            dest: tcb_queue_relation_next_not_NULL)
-            apply (rule conjI, clarsimp)
-             apply (rule conjI, fastforce simp: mask_def)
-             apply (rule context_conjI)
-              subgoal by (fastforce intro!: tcb_ptr_sign_extend_canonical
-                                     dest!: st_tcb_strg'[rule_format])
-             apply clarsimp
-            apply clarsimp
-            apply (rule conjI, fastforce simp: mask_def)
-            apply (rule conjI)
-             subgoal by (fastforce intro!: tcb_ptr_sign_extend_canonical
-                                    dest!: st_tcb_strg'[rule_format])
-            apply (subgoal_tac "canonical_address (ntfnQueue_head_CL (notification_lift ko'))")
-             apply (clarsimp simp: canonical_address_sign_extended sign_extended_iff_sign_extend)
-            apply (clarsimp simp: notification_lift_def canonical_address_sign_extended
-                                  sign_extended_sign_extend
-                            simp flip: canonical_bit_def)
-            done
-         apply (simp add: isWaitingNtfn_def)
-         subgoal sorry (* FIXME RT: refill_buffer_relation *)
-        \<comment> \<open>queue relation\<close>
-        apply (rule cready_queues_relation_null_queue_ptrs, assumption+)
+             \<comment> \<open>tcb relation\<close>
+             apply (erule ctcb_relation_null_queue_ptrs)
+             apply (clarsimp simp: comp_def)
+            \<comment> \<open>ep relation\<close>
+            apply (erule iffD1 [OF cmap_relation_cong, OF refl refl, rotated -1])
+            apply simp
+            apply (rule cendpoint_relation_ntfn_queue, assumption+)
+              apply (simp add: isWaitingNtfn_def)
+             apply simp
+            apply (frule_tac x=p in map_to_ko_atI, clarsimp, clarsimp)
+             apply fastforce
+            apply (erule(2) map_to_ko_at_updI')
+             apply (clarsimp simp: objBitsKO_def)
+            apply (clarsimp simp: obj_at'_def)
+           \<comment> \<open>ntfn relation\<close>
+           apply (rule cpspace_relation_ntfn_update_ntfn', assumption+)
+             apply (case_tac "ntfn", simp_all)[1]
+            apply (clarsimp simp: cnotification_relation_def Let_def
+                                  mask_def [where n=3] NtfnState_Waiting_def
+                           split: if_split)
+            subgoal for _ _ ko'
+              apply (clarsimp simp: tcb_queue_relation'_def is_aligned_neg_mask
+                              dest: tcb_queue_relation_next_not_NULL)
+              apply (rule conjI, clarsimp)
+               apply (rule conjI, fastforce simp: mask_def)
+               apply (rule context_conjI)
+                subgoal by (fastforce intro!: tcb_ptr_sign_extend_canonical
+                                       dest!: st_tcb_strg'[rule_format])
+               apply clarsimp
+              apply clarsimp
+              apply (rule conjI, fastforce simp: mask_def)
+              apply (rule conjI)
+               subgoal by (fastforce intro!: tcb_ptr_sign_extend_canonical
+                                      dest!: st_tcb_strg'[rule_format])
+              apply (subgoal_tac "canonical_address (ntfnQueue_head_CL (notification_lift ko'))")
+               apply (clarsimp simp: canonical_address_sign_extended sign_extended_iff_sign_extend)
+              apply (clarsimp simp: notification_lift_def canonical_address_sign_extended
+                                    sign_extended_sign_extend
+                              simp flip: canonical_bit_def)
+              done
+           apply (simp add: isWaitingNtfn_def)
+          subgoal sorry (* FIXME RT: refill_buffer_relation *)
+         \<comment> \<open>queue relations\<close>
+         apply (rule cready_queues_relation_null_queue_ptrs, assumption+)
+         apply (clarsimp simp: comp_def)
+        apply (erule iffD2[OF tcb_queue_relation_only_next_prev, rotated -1])
+         apply (rule null_ep_schedD[THEN conjunct1])
+         apply (clarsimp simp: comp_def)
+        apply (rule null_ep_schedD[THEN conjunct2])
         apply (clarsimp simp: comp_def)
        apply (clarsimp simp: carch_state_relation_def packed_heap_update_collapse_hrs)
       apply (simp add: cmachine_state_relation_def)

--- a/proof/crefine/RISCV64/Recycle_C.thy
+++ b/proof/crefine/RISCV64/Recycle_C.thy
@@ -773,16 +773,6 @@ lemma cnotification_relation_q_cong:
   apply (auto intro: iffD1[OF tcb_queue_relation'_cong[OF refl refl refl]])
   done
 
-lemma tcbSchedEnqueue_ep_at:
-  "\<lbrace>obj_at' (P :: endpoint \<Rightarrow> bool) ep\<rbrace>
-      tcbSchedEnqueue t
-   \<lbrace>\<lambda>rv. obj_at' P ep\<rbrace>"
-  including no_pre
-  apply (simp add: tcbSchedEnqueue_def unless_def null_def)
-  apply (wp threadGet_wp, clarsimp, wp+)
-  apply (clarsimp split: if_split, wp)
-  done
-
 lemma ccorres_duplicate_guard:
   "ccorres r xf (P and P) Q hs f f' \<Longrightarrow> ccorres r xf P Q hs f f'"
   by (erule ccorres_guard_imp, auto)

--- a/proof/crefine/RISCV64/Refine_C.thy
+++ b/proof/crefine/RISCV64/Refine_C.thy
@@ -892,17 +892,20 @@ lemma dmo_domain_user_mem'[wp]:
   done
 
 lemma do_user_op_corres_C:
-  "corres_underlying rf_sr False False (=) (invs' and ex_abs einvs) \<top>
-                     (doUserOp f tc) (doUserOp_C f tc)"
+  "corres_underlying rf_sr False False (=)
+     (invs' and (\<lambda>s. sch_act_wf (ksSchedulerAction s) s) and ex_abs einvs) \<top>
+     (doUserOp f tc) (doUserOp_C f tc)"
   apply (simp only: doUserOp_C_def doUserOp_def split_def)
   apply (rule corres_guard_imp)
     apply (rule_tac P=\<top> and P'=\<top> and r'="(=)" in corres_split)
        apply (clarsimp simp: simpler_gets_def getCurThread_def
                 corres_underlying_def rf_sr_def cstate_relation_def Let_def)
-      apply (rule_tac P=invs' and P'=\<top> and r'="(=)" in corres_split)
+      apply (rule_tac P="invs' and (\<lambda>s. sch_act_wf (ksSchedulerAction s) s)"
+                  and P'=\<top> and r'="(=)" in corres_split)
          apply (clarsimp simp: cstate_to_A_def absKState_def
                                rf_sr_def cstate_to_H_correct ptable_lift_def)
-        apply (rule_tac P=invs' and P'=\<top> and r'="(=)" in corres_split)
+        apply (rule_tac P="invs' and (\<lambda>s. sch_act_wf (ksSchedulerAction s) s)"
+                    and P'=\<top> and r'="(=)" in corres_split)
            apply (clarsimp simp: cstate_to_A_def absKState_def
                                  rf_sr_def cstate_to_H_correct ptable_rights_def)
           apply (rule_tac P=pspace_distinct' and P'=\<top> and r'="(=)"
@@ -998,7 +1001,12 @@ lemma refinement2_both:
    apply (drule lift_state_relationD)
    apply (clarsimp simp: cstate_to_A_def)
     apply (subst cstate_to_H_correct)
-     apply (fastforce simp: full_invs'_def invs'_def)
+      apply (fastforce simp: full_invs'_def invs'_def)
+     apply (clarsimp simp: lift_state_relation_def full_invs_def)
+     apply (rule sch_act_wf_cross)
+         apply force
+        subgoal by (clarsimp simp: valid_sched_def)
+       apply fastforce+
     apply (clarsimp simp: rf_sr_def)
    apply (simp add:absKState_def observable_memory_def absExst_def)
    apply (rule MachineTypes.machine_state.equality,simp_all)[1]

--- a/proof/crefine/RISCV64/Retype_C.thy
+++ b/proof/crefine/RISCV64/Retype_C.thy
@@ -3340,8 +3340,7 @@ proof -
       apply (case_tac r; simp add: C_register_defs index_foldr_update
                                    atcbContext_def newArchTCB_def newContext_def
                                    initContext_def)
-      apply clarsimp
-     apply (simp add: thread_state_lift_def index_foldr_update atcbContextGet_def)
+      apply (simp add: thread_state_lift_def index_foldr_update atcbContextGet_def)+
     apply (simp add: cfault_rel_def seL4_Fault_lift_def seL4_Fault_get_tag_def Let_def
                      lookup_fault_lift_def lookup_fault_get_tag_def lookup_fault_invalid_root_def
                      index_foldr_update seL4_Fault_NullFault_def option_to_ptr_def option_to_0_def

--- a/proof/crefine/RISCV64/Retype_C.thy
+++ b/proof/crefine/RISCV64/Retype_C.thy
@@ -5220,7 +5220,11 @@ lemma threadSet_domain_ccorres [corres]:
      subgoal by (simp add: ctcb_relation_def)
     apply assumption
    apply simp
-  apply (erule cready_queues_relation_not_queue_ptrs)
+  apply (rule conjI)
+   apply (erule cready_queues_relation_not_queue_ptrs)
+    apply (rule ext, simp split: if_split)
+   apply (rule ext, simp split: if_split)
+  apply (erule iffD2[OF tcb_queue_relation_only_next_prev, rotated -1])
    apply (rule ext, simp split: if_split)
   apply (rule ext, simp split: if_split)
   done

--- a/proof/crefine/RISCV64/SR_lemmas_C.thy
+++ b/proof/crefine/RISCV64/SR_lemmas_C.thy
@@ -1077,7 +1077,9 @@ lemma cstate_relation_only_t_hrs:
   ksDomScheduleIdx_' s = ksDomScheduleIdx_' t;
   ksCurDomain_' s = ksCurDomain_' t;
   ksDomainTime_' s = ksDomainTime_' t;
-  ksConsumed_' s = ksConsumed_' t
+  ksConsumed_' s = ksConsumed_' t;
+  ksReleaseHead_' s = ksReleaseHead_' t;
+  ksReprogram_' s = ksReprogram_' t
   \<rbrakk>
   \<Longrightarrow> cstate_relation a s = cstate_relation a t"
   unfolding cstate_relation_def
@@ -1104,6 +1106,8 @@ lemma rf_sr_upd:
     "ksCurDomain_' (globals x) = ksCurDomain_' (globals y)"
     "ksDomainTime_' (globals x) = ksDomainTime_' (globals y)"
     "ksConsumed_' (globals x) = ksConsumed_' (globals y)"
+    "ksReleaseHead_' (globals x) = ksReleaseHead_' (globals y)"
+    "ksReprogram_' (globals x) = ksReprogram_' (globals y)"
   shows "((a, x) \<in> rf_sr) = ((a, y) \<in> rf_sr)"
   unfolding rf_sr_def using assms
   by simp (rule cstate_relation_only_t_hrs, auto)
@@ -1129,8 +1133,10 @@ lemma rf_sr_upd_safe[simp]:
     "phantom_machine_state_' (globals (g y)) = phantom_machine_state_' (globals y)"
   and    gs: "ghost'state_' (globals (g y)) = ghost'state_' (globals y)"
   and     wu:  "(ksWorkUnitsCompleted_' (globals (g y))) = (ksWorkUnitsCompleted_' (globals y))"
+  and rlshd: "(ksReleaseHead_' (globals (g y))) = (ksReleaseHead_' (globals y))"
+  and reprog: "(ksReprogram_' (globals (g y))) = (ksReprogram_' (globals y))"
   shows "((a, (g y)) \<in> rf_sr) = ((a, y) \<in> rf_sr)"
-  using rl rq rqL1 rqL2 sa ct ctime csc it isc ist arch wu gs dsi cdom dt cons
+  using rl rq rqL1 rqL2 sa ct ctime csc it isc ist arch wu gs dsi cdom dt cons rlshd reprog
   by - (rule rf_sr_upd)
 
 (* More of a well-formed lemma, but \<dots> *)

--- a/proof/crefine/RISCV64/StateRelation_C.thy
+++ b/proof/crefine/RISCV64/StateRelation_C.thy
@@ -444,7 +444,7 @@ definition refill_buffer_relation ::
 lemma refill_buffer_relation_gs_dom:
   "refill_buffer_relation ah ch gs \<Longrightarrow>
    let abs_sc_hp = map_to_scs ah;
-       lens_hp = gs_refill_buffer_lengths gs
+       lens_hp = gs_sc_size gs
    in dom abs_sc_hp = dom lens_hp"
   by (simp add: refill_buffer_relation_def Let_def)
 
@@ -452,7 +452,7 @@ lemma refill_buffer_relation_crefill_hp_dom:
   "refill_buffer_relation ah ch gs \<Longrightarrow>
    let abs_sc_hp = map_to_scs ah;
        crefill_hp = clift ch;
-       lens_hp = gs_refill_buffer_lengths gs
+       lens_hp = gs_sc_size gs
    in dom crefill_hp
       = (\<Union>p\<in>dom abs_sc_hp. set (map (\<lambda>i. sc_ptr_to_crefill_ptr p +\<^sub>p int i) [0..<the (lens_hp p)]))"
   by (simp add: refill_buffer_relation_def Let_def)
@@ -461,7 +461,7 @@ lemma refill_buffer_relation_crefill_relation:
   "refill_buffer_relation ah ch gs \<Longrightarrow>
    let abs_sc_hp = map_to_scs ah;
        crefill_hp = clift ch;
-       lens_hp = gs_refill_buffer_lengths gs
+       lens_hp = gs_sc_size gs
    in (\<forall>p sc. abs_sc_hp p = Some sc \<longrightarrow>
                dyn_array_list_rel crefill_hp crefill_relation (scRefills sc) (sc_ptr_to_crefill_ptr p)
               \<and> lens_hp p = Some (length (scRefills sc)))"
@@ -829,6 +829,7 @@ where
        cready_queues_relation (clift cheap)
                              (ksReadyQueues_' cstate)
                              (ksReadyQueues astate) \<and>
+       sched_queue_relation (clift cheap) (ksReleaseQueue astate) NULL (ksReleaseHead_' cstate) \<and>
        zero_ranges_are_zero (gsUntypedZeroRanges astate) cheap \<and>
        cbitmap_L1_relation (ksReadyQueuesL1Bitmap_' cstate) (ksReadyQueuesL1Bitmap astate) \<and>
        cbitmap_L2_relation (ksReadyQueuesL2Bitmap_' cstate) (ksReadyQueuesL2Bitmap astate) \<and>
@@ -859,7 +860,8 @@ where
                               Kernel_C.kernel_all_global_addresses.ksDomSchedule \<and>
        ksDomScheduleIdx_' cstate = of_nat (ksDomScheduleIdx astate) \<and>
        ksCurDomain_' cstate = ucast (ksCurDomain astate) \<and>
-       ksDomainTime_' cstate = ksDomainTime astate"
+       ksDomainTime_' cstate = ksDomainTime astate \<and>
+       to_bool (ksReprogram_' cstate) = ksReprogramTimer astate"
 
 end
 

--- a/proof/crefine/RISCV64/TcbQueue_C.thy
+++ b/proof/crefine/RISCV64/TcbQueue_C.thy
@@ -1395,23 +1395,24 @@ lemma rf_sr_tcb_update_no_queue:
   apply (clarsimp simp: map_comp_update projectKO_opt_tcb cvariable_relation_upd_const
                         typ_heap_simps')
   apply (intro conjI)
-        subgoal by (clarsimp simp: cmap_relation_def map_comp_update projectKO_opts_defs inj_eq)
+         subgoal by (clarsimp simp: cmap_relation_def map_comp_update projectKO_opts_defs inj_eq)
+        apply (erule iffD1 [OF cmap_relation_cong, OF refl refl, rotated -1])
+        apply simp
+        apply (rule cendpoint_relation_upd_tcb_no_queues, assumption+)
+         subgoal by fastforce
+        subgoal by fastforce
        apply (erule iffD1 [OF cmap_relation_cong, OF refl refl, rotated -1])
        apply simp
-       apply (rule cendpoint_relation_upd_tcb_no_queues, assumption+)
+       apply (rule cnotification_relation_upd_tcb_no_queues, assumption+)
         subgoal by fastforce
        subgoal by fastforce
-      apply (erule iffD1 [OF cmap_relation_cong, OF refl refl, rotated -1])
-      apply simp
-      apply (rule cnotification_relation_upd_tcb_no_queues, assumption+)
-       subgoal by fastforce
-      subgoal by fastforce
-     subgoal by (clarsimp simp: map_comp_update projectKO_opt_sc typ_heap_simps'
-                                refill_buffer_relation_def)
+      subgoal by (clarsimp simp: map_comp_update projectKO_opt_sc typ_heap_simps'
+                                 refill_buffer_relation_def)
      apply (erule cready_queues_relation_not_queue_ptrs)
       subgoal by fastforce
      subgoal by fastforce
-    subgoal by (clarsimp simp: carch_state_relation_def typ_heap_simps')
+    subgoal by (fastforce elim!: iffD2[OF tcb_queue_relation_only_next_prev, rotated -1])
+   subgoal by (clarsimp simp: carch_state_relation_def typ_heap_simps')
   by (simp add: cmachine_state_relation_def)
 
 lemma rf_sr_tcb_update_no_queue_helper:

--- a/proof/invariant-abstract/ARM/ArchDetSchedAux_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchDetSchedAux_AI.thy
@@ -274,6 +274,14 @@ lemma perform_asid_control_invocation_pred_map_sc_refill_cfgs_of:
   by (wpsimp wp: delete_objects_pred_map_sc_refill_cfgs_of
            comb: hoare_drop_imp)
 
+lemma perform_asid_control_invocation_inactive_implies_zero_budget:
+  "perform_asid_control_invocation aci
+   \<lbrace>\<lambda>s. pred_map inactive_scrc (sc_refill_cfgs_of s) p
+        \<longrightarrow> pred_map (\<lambda>cfg. scrc_budget cfg = 0) (sc_refill_cfgs_of s) p\<rbrace>"
+  unfolding perform_asid_control_invocation_def
+  by (wpsimp wp: delete_objects_pred_map_sc_refill_cfgs_of
+           comb: hoare_drop_imp)
+
 crunches perform_asid_control_invocation
   for valid_machine_time[wp]: "valid_machine_time"
   and cur_sc[wp]: "\<lambda>s. P (cur_sc s)"
@@ -295,6 +303,7 @@ lemma perform_asid_control_invocation_valid_sched:
                                    perform_asid_control_invocation_sc_at_pred_n
                                    perform_asid_control_invocation_valid_idle
                                    perform_asid_control_invocation_pred_map_sc_refill_cfgs_of
+                                   perform_asid_control_invocation_inactive_implies_zero_budget
                                    hoare_vcg_all_lift
                              simp: ipc_queued_thread_state_live live_sc_def)+
   done

--- a/proof/invariant-abstract/RISCV64/ArchDetSchedAux_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchDetSchedAux_AI.thy
@@ -274,6 +274,14 @@ lemma perform_asid_control_invocation_pred_map_sc_refill_cfgs_of:
   by (wpsimp wp: delete_objects_pred_map_sc_refill_cfgs_of
            comb: hoare_drop_imp)
 
+lemma perform_asid_control_invocation_inactive_implies_zero_budget:
+  "perform_asid_control_invocation aci
+   \<lbrace>\<lambda>s. pred_map inactive_scrc (sc_refill_cfgs_of s) p
+        \<longrightarrow> pred_map (\<lambda>cfg. scrc_budget cfg = 0) (sc_refill_cfgs_of s) p\<rbrace>"
+  unfolding perform_asid_control_invocation_def
+  by (wpsimp wp: delete_objects_pred_map_sc_refill_cfgs_of
+           comb: hoare_drop_imp)
+
 crunches perform_asid_control_invocation
   for valid_machine_time[wp]: "valid_machine_time"
   and cur_sc[wp]: "\<lambda>s. P (cur_sc s)"
@@ -295,6 +303,7 @@ lemma perform_asid_control_invocation_valid_sched:
                                    perform_asid_control_invocation_sc_at_pred_n
                                    perform_asid_control_invocation_valid_idle
                                    perform_asid_control_invocation_pred_map_sc_refill_cfgs_of
+                                   perform_asid_control_invocation_inactive_implies_zero_budget
                                    hoare_vcg_all_lift
                              simp: ipc_queued_thread_state_live live_sc_def)+
   done

--- a/proof/refine/ARM/Finalise_R.thy
+++ b/proof/refine/ARM/Finalise_R.thy
@@ -4860,7 +4860,7 @@ lemma schedContextZeroRefillMax_corres:
                         set_refills_def sc_at_sc_obj_at updateSchedContext_def)
   apply (rule corres_underlying_lift_ex1')
   apply (rule corres_guard_imp)
-    apply (subst bind_dummy_ret_val, subst update_sched_context_decompose[symmetric])
+    apply (subst bind_dummy_ret_val, subst update_sched_context_decompose[symmetric])+
     apply (rule_tac n1=n in monadic_rewrite_corres_l[OF update_sched_context_rewrite])
     apply (rule corres_split[OF get_sc_corres])
       apply (rule_tac P="ko_at (kernel_object.SchedContext sc n) scPtr"

--- a/proof/refine/ARM/Refine.thy
+++ b/proof/refine/ARM/Refine.thy
@@ -406,7 +406,7 @@ lemma valid_sched_init[simp]:
                         active_sc_def MIN_REFILLS_def)
   by (auto simp: vs_all_heap_simps active_sc_valid_refills_def cfg_valid_refills_def
                  rr_valid_refills_def MIN_REFILLS_def bounded_release_time_def
-                 default_sched_context_def MAX_PERIOD_def
+                 default_sched_context_def MAX_PERIOD_def active_sc_def
           intro: order_trans[OF mult_left_mono, OF us_to_ticks_helper])
 
 lemma valid_domain_list_init[simp]:

--- a/proof/refine/ARM/SchedContextInv_R.thy
+++ b/proof/refine/ARM/SchedContextInv_R.thy
@@ -860,75 +860,66 @@ lemma refillNew_corres:
                           dest!: state_relation_sc_relation)
          apply (fastforce simp: obj_at_simps is_sc_obj opt_map_red
                          dest!: state_relation_sc_replies_relation_sc)
-        (* budget *)
-        apply (rule corres_split[OF updateSchedContext_corres]; (clarsimp simp: objBits_simps)?)
-            apply (fastforce simp: obj_at_simps is_sc_obj sc_relation_def opt_map_red opt_pred_def
-                            dest!: state_relation_sc_relation)
-           apply (fastforce simp: obj_at_simps is_sc_obj opt_map_red
-                           dest!: state_relation_sc_replies_relation_sc)
-          (* max_refills, sc_refills update *)
-          (* rewrite into one step updateSchedContext corres *)
-          apply (rename_tac ctime)
-          apply (rule_tac P="sc_obj_at n sc_ptr and (\<lambda>s. ctime = cur_time s)"
-                      and P'="sc_at' sc_ptr and (\<lambda>s'. ctime = ksCurTime s')
-                              and (\<lambda>s'. ((\<lambda>sc'. objBits sc' = minSchedContextBits + n) |< scs_of' s') sc_ptr)"
-                 in corres_inst)
-          apply (subst bind_assoc[symmetric])
-          apply (subst update_sched_context_decompose[symmetric, simplified])
-          apply (subst bind_assoc[symmetric])
-          apply (subst bind_assoc[symmetric])
-          apply (subst bind_assoc)
-          apply (rule corres_guard_imp)
-            apply (rule corres_split[OF monadic_rewrite_corres_r
-                                           [OF monadic_rewrite_sym
-                                                   [OF updateSchedContext_decompose_x2[simplified]]]])
-                 apply (clarsimp simp: objBits_simps)+
+         (* budget, max_refills, sc_refills update: rewrite into one step updateSchedContext corres *)
+        apply (rename_tac ctime)
+        apply (rule_tac P="sc_obj_at n sc_ptr and (\<lambda>s. ctime = cur_time s)"
+                    and P'="sc_at' sc_ptr and (\<lambda>s'. ctime = ksCurTime s')
+                            and (\<lambda>s'. ((\<lambda>sc'. objBits sc' = minSchedContextBits + n) |< scs_of' s') sc_ptr)"
+               in corres_inst)
+        apply (subst bind_assoc[symmetric])+
+        apply (subst update_sched_context_decompose[symmetric, simplified])+
+        apply (subst bind_assoc)
+        apply (rule corres_guard_imp)
+          apply (rule corres_split[OF monadic_rewrite_corres_r
+                                       [OF monadic_rewrite_sym
+                                        [OF updateSchedContext_decompose_x2[simplified]]]])
+               apply (clarsimp simp: objBits_simps)+
                (* use setSchedContext_corres *)
-               apply (rule monadic_rewrite_corres_l[OF update_sched_context_rewrite[where n=n]])
-               apply (simp add: updateSchedContext_def)
-               apply (rule corres_split[OF get_sc_corres])
-                 apply (rename_tac sc')
-                 apply (rule_tac P="ko_at (kernel_object.SchedContext sc n) sc_ptr"
-                             and P'="ko_at' sc' sc_ptr
-                                     and (\<lambda>s'. ((\<lambda>sc'. objBits sc' = minSchedContextBits + n) |< scs_of' s') sc_ptr)"
-                        in corres_inst)
-                 apply (rule_tac F="length (scRefills sc') = max_num_refills (min_sched_context_bits + n)"
-                        in corres_req)
-                  apply (clarsimp simp: obj_at_simps scBits_simps opt_map_red opt_pred_def)
-                  using scBits_inverse_sc apply fastforce
-                 apply (rule stronger_corres_guard_imp)
-                   apply (rule_tac sc'="sc'\<lparr> scRefillMax := max_refills,
-                                             scRefillHead := 0,
-                                             scRefillCount := Suc 0,
-                                             scRefills := updateAt 0 (scRefills sc') (\<lambda>r. Refill ctime budget)\<rparr>"
-                          in setSchedContext_corres)
-                    apply (clarsimp simp: sc_relation_def refills_map_def valid_refills_number'_def
-                                          wrap_slice_start_0 max_num_refills_eq_refillAbsoluteMax')
-                    apply (case_tac "scRefills sc'"; simp add: updateAt_def null_def refill_map_def)
-                   apply (clarsimp simp: objBits_simps scBits_simps)
-                  apply simp
-                 apply (fastforce simp: obj_at_simps is_sc_obj opt_map_red
-                                 dest!: sc_replies_relation_prevs_list[OF state_relation_sc_replies_relation])
-                apply (wpsimp wp: getSchedContext_wp')+
-              (* last step : add tail *)
-              apply (rule_tac P="sc_obj_at n sc_ptr and is_active_sc2 sc_ptr"
-                          and P'="sc_at' sc_ptr
-                                  and (\<lambda>s'. ((\<lambda>sc'. objBits sc' = minSchedContextBits + n
-                                             \<and> scRefillHead sc' = 0 \<and> scRefillCount sc' = 1
-                                             \<and> scRefillMax sc' = max_refills) |< scs_of' s') sc_ptr)"
-                     in corres_inst)
-              apply (rule stronger_corres_guard_imp)
-                apply (rule maybeAddEmptyTail_corres[simplified dc_def])
-               apply simp
-              apply (clarsimp simp: obj_at_simps is_sc_obj scBits_simps opt_map_red opt_pred_def
-                                    valid_refills_number'_def)
-              apply (drule (1) pspace_relation_absD[OF _ state_relation_pspace_relation, rotated])
-              using scBits_inverse_sc apply fastforce
-             apply (wpsimp wp: update_sched_context_wp updateSchedContext_wp)+
-           apply (clarsimp simp:  obj_at_def is_sc_obj is_active_sc2_def)
-          apply (clarsimp simp: obj_at_simps fun_upd_def[symmetric] valid_objs'_def ps_clear_upd
-                                opt_map_red opt_pred_def)
-         apply (wpsimp wp: update_sched_context_wp updateSchedContext_wp)+
+             apply (rule monadic_rewrite_corres_l[OF update_sched_context_rewrite[where n=n]])
+             apply (simp add: updateSchedContext_def)
+             apply (rule corres_split[OF get_sc_corres])
+               apply (rename_tac sc')
+               apply (rule_tac P="ko_at (kernel_object.SchedContext sc n) sc_ptr"
+                           and P'="ko_at' sc' sc_ptr
+                                   and (\<lambda>s'. ((\<lambda>sc'. objBits sc' = minSchedContextBits + n) |< scs_of' s') sc_ptr)"
+                            in corres_inst)
+               apply (rule_tac F="length (scRefills sc') = max_num_refills (min_sched_context_bits + n)"
+                            in corres_req)
+                apply (clarsimp simp: obj_at_simps scBits_simps opt_map_red opt_pred_def)
+                using scBits_inverse_sc apply fastforce
+               apply (rule stronger_corres_guard_imp)
+                 apply (rule_tac sc'="sc'\<lparr> scRefillMax := max_refills,
+                                           scRefillHead := 0,
+                                           scRefillCount := Suc 0,
+                                           scRefills := updateAt 0 (scRefills sc') (\<lambda>r. Refill ctime budget)\<rparr>"
+                              in setSchedContext_corres)
+                  apply (clarsimp simp: sc_relation_def refills_map_def valid_refills_number'_def
+                                        wrap_slice_start_0 max_num_refills_eq_refillAbsoluteMax')
+                  apply (case_tac "scRefills sc'"; simp add: updateAt_def null_def refill_map_def)
+                 apply (clarsimp simp: objBits_simps scBits_simps)
+                apply simp
+               apply (fastforce simp: obj_at_simps is_sc_obj opt_map_red
+                               dest!: sc_replies_relation_prevs_list[OF state_relation_sc_replies_relation])
+              apply (wpsimp wp: getSchedContext_wp')+
+            (* last step : add tail *)
+            apply (rule_tac P="sc_obj_at n sc_ptr and is_active_sc2 sc_ptr"
+                        and P'="sc_at' sc_ptr
+                                and (\<lambda>s'. ((\<lambda>sc'. objBits sc' = minSchedContextBits + n
+                                           \<and> scRefillHead sc' = 0 \<and> scRefillCount sc' = 1
+                                           \<and> scRefillMax sc' = max_refills) |< scs_of' s') sc_ptr)"
+                         in corres_inst)
+            apply (rule stronger_corres_guard_imp)
+              apply (rule maybeAddEmptyTail_corres)
+             apply simp
+            apply (clarsimp simp: obj_at_simps is_sc_obj scBits_simps opt_map_red opt_pred_def
+                                  valid_refills_number'_def)
+            apply (drule (1) pspace_relation_absD[OF _ state_relation_pspace_relation, rotated])
+            using scBits_inverse_sc apply fastforce
+           apply (wpsimp wp: update_sched_context_wp updateSchedContext_wp)+
+         apply (clarsimp simp:  obj_at_def is_sc_obj is_active_sc2_def)
+        apply (clarsimp simp: obj_at_simps fun_upd_def[symmetric] valid_objs'_def ps_clear_upd
+                              opt_map_red opt_pred_def)
+       apply (wpsimp wp: update_sched_context_wp updateSchedContext_wp)+
    apply (clarsimp simp:  obj_at_def is_sc_obj is_active_sc2_def)
   apply (clarsimp simp: obj_at_simps fun_upd_def[symmetric] valid_objs'_def ps_clear_upd opt_map_red
                         opt_pred_def)
@@ -943,8 +934,9 @@ lemma refillUpdate_corres:
               (refillUpdate sc_ptr period budget max_refills)"
   (is "_ \<Longrightarrow> _ \<Longrightarrow> corres _ (?pred and _) ?conc _ _")
   supply getSchedContext_wp[wp del] set_sc'.get_wp[wp del] projection_rewrites[simp]
-  apply (rule corres_cross_add_guard[where
-      Q = "sc_at' sc_ptr and (\<lambda>s'. ((\<lambda>sc. objBits sc = minSchedContextBits + n) |< scs_of' s') sc_ptr)"])
+  apply (rule corres_cross_add_guard[where Q = "sc_at' sc_ptr
+                                                and (\<lambda>s'. ((\<lambda>sc. objBits sc = minSchedContextBits + n)
+                                                           |< scs_of' s') sc_ptr)"])
    apply (fastforce dest!: sc_obj_at_cross[OF state_relation_pspace_relation]
                      simp: obj_at'_def projectKOs opt_map_red opt_pred_def)
   apply (rule_tac Q="is_active_sc' sc_ptr" in corres_cross_add_guard)
@@ -957,7 +949,8 @@ lemma refillUpdate_corres:
     apply (subst bind_assoc[where m="update_sched_context _ _", symmetric])
     apply (subst update_sched_context_decompose[symmetric, simplified])
     apply (subst bind_assoc[where m="updateSchedContext _ _", symmetric])
-    apply (subst bind_assoc[where m="do _ \<leftarrow> updateSchedContext _ _; updateSchedContext _ _ od", symmetric])
+    apply (subst bind_assoc[where m="do _ \<leftarrow> updateSchedContext _ _; updateSchedContext _ _ od",
+                            symmetric])
     apply (subst bind_assoc[where m="do _ \<leftarrow> (do _ \<leftarrow> updateSchedContext _ _; updateSchedContext _ _ od);
                                      updateSchedContext _ _ od", symmetric])
     apply (subst bind_assoc[where m="updateSchedContext _ _"])
@@ -965,12 +958,12 @@ lemma refillUpdate_corres:
     apply (subst bind_assoc[where m="updateSchedContext _ _"])
     apply (rule stronger_corres_guard_imp)
       apply (rule corres_split[OF monadic_rewrite_corres_r
-                                     [OF monadic_rewrite_sym
-                                             [OF updateSchedContext_decompose_x3[simplified]]]])
-                                       (* now use setSchedContext_corres *)
+                                   [OF monadic_rewrite_sym
+                                        [OF updateSchedContext_decompose_x3[simplified]]]])
+    (* now use setSchedContext_corres *)
            apply ((clarsimp simp: objBits_simps)+)[2]
          apply (rule corres_inst[where P="?pred and sc_obj_at n sc_ptr" and P'="?conc and sc_at' sc_ptr"])
-         (* one of the sc_obj_at n sc_ptr will be consumed by the next line *)
+    (* one of the sc_obj_at n sc_ptr will be consumed by the next line *)
          apply (rule monadic_rewrite_corres_l[OF update_sched_context_rewrite[where n=n]])
          apply (simp add: updateSchedContext_def)
          apply (rule stronger_corres_guard_imp)
@@ -980,31 +973,46 @@ lemma refillUpdate_corres:
                          and P'="ko_at' sc' sc_ptr
                                  and K (objBits sc' = minSchedContextBits + n
                                             \<and> 0 < scRefillMax sc' \<and> sc_valid_refills' sc')"
-                    in corres_inst)
+                          in corres_inst)
              apply (rule_tac F="0 < scRefillMax sc' \<and> sc_valid_refills' sc'
                                  \<and> length (scRefills sc') = max_num_refills (min_sched_context_bits + n)"
-                     in corres_req)
+                          in corres_req)
               apply clarsimp
               apply (clarsimp simp: obj_at'_def projectKOs objBits_simps scBits_simps)
               using scBits_inverse_sc apply fastforce
              apply (rule stronger_corres_guard_imp)
-               apply (rule setSchedContext_corres)
-                apply (unfold sc_relation_def; elim conjE exE; intro conjI; fastforce?)
-                apply (clarsimp simp: refills_map_def wrap_slice_start_0 hd_map neq_Nil_lengthI
-                                      refill_map_def updateAt_def null_def refillHd_def hd_wrap_slice
-                                      valid_refills_number'_def max_num_refills_eq_refillAbsoluteMax')
-               apply (clarsimp simp: objBits_simps scBits_simps)
-              apply simp
-             apply (clarsimp simp: obj_at_simps scBits_simps is_sc_obj)
-             apply (fastforce elim!: sc_replies_relation_prevs_list[OF state_relation_sc_replies_relation])
-            apply wpsimp
-           apply (wpsimp wp: getSchedContext_wp')
+               apply (rename_tac sc sc')
+               apply (rule_tac P="?pred and ko_at (kernel_object.SchedContext sc n) sc_ptr"
+                           and P'="ko_at' sc' sc_ptr
+                                   and K (objBits sc' = minSchedContextBits + n
+                                          \<and> 0 < scRefillMax sc' \<and> sc_valid_refills' sc')"
+                            in corres_inst)
+               apply (rule_tac F="0 < scRefillMax sc' \<and> sc_valid_refills' sc'
+                                    \<and> length (scRefills sc') = max_num_refills (min_sched_context_bits + n)"
+                            in corres_req)
+                apply clarsimp
+               apply (rule stronger_corres_guard_imp)
+                 apply (rule setSchedContext_corres)
+                  apply (unfold sc_relation_def; elim conjE exE; intro conjI; fastforce?)
+                  apply (clarsimp simp: refills_map_def wrap_slice_start_0 hd_map neq_Nil_lengthI
+                                        refill_map_def updateAt_def null_def refillHd_def hd_wrap_slice
+                                        valid_refills_number'_def max_num_refills_eq_refillAbsoluteMax')
+                 apply (clarsimp simp: objBits_simps scBits_simps)
+                apply simp
+               apply (clarsimp simp: obj_at_simps scBits_simps is_sc_obj)
+               apply (fastforce elim!: sc_replies_relation_prevs_list[OF state_relation_sc_replies_relation])
+              apply wpsimp
+             apply (wpsimp wp: getSchedContext_wp')+
           apply (clarsimp simp: obj_at_def is_sc_obj)
          apply (drule state_relation_sc_relation[where ptr=sc_ptr];
-               (fastforce simp: obj_at_simps is_sc_obj obj_bits_def)?)
+                (fastforce simp: obj_at_simps is_sc_obj obj_bits_def)?)
          apply (clarsimp simp: obj_at_simps is_sc_obj valid_refills_number'_def scBits_simps
                                opt_map_red opt_pred_def valid_refills'_def
                         dest!: scRefills_length)
+        apply ((clarsimp simp: objBits_simps)+)[2]
+        (* sc_budget and sc_period *)
+        apply (subst bind_assoc[where m="update_sched_context _ _", symmetric])
+        apply (subst update_sched_context_decompose[symmetric, simplified])
         (* sc_period *)
         apply (rule corres_split[OF updateSchedContext_corres])
              apply (fastforce dest!: state_relation_sc_relation
@@ -1012,70 +1020,60 @@ lemma refillUpdate_corres:
             apply (fastforce dest!: state_relation_sc_replies_relation_sc
                               simp: obj_at_simps is_sc_obj sc_relation_def opt_map_red)
            apply (simp add: objBits_simps)
-          (* sc_budget *)
-          apply (rule corres_split[OF updateSchedContext_corres])
-               apply (fastforce dest!: state_relation_sc_relation
-                                 simp: obj_at_simps is_sc_obj sc_relation_def opt_map_red opt_pred_def)
-              apply (fastforce dest!: state_relation_sc_replies_relation_sc
-                                simp: obj_at_simps is_sc_obj sc_relation_def opt_map_red)
-             apply (simp add: objBits_simps)
-            (* the rest *)
-            apply (rule_tac P="sc_obj_at n sc_ptr and
+          (* the rest *)
+          apply (rule_tac P="sc_obj_at n sc_ptr and
                               (\<lambda>s. ((\<lambda>sc. sc_refills sc\<noteq> [] \<and> 0 < sc_refill_max sc) |< scs_of s) sc_ptr)"
-                       and P'="sc_at' sc_ptr and
+                      and P'="sc_at' sc_ptr and
                               (\<lambda>s'. ((\<lambda>ko. 1 < scRefillMax ko \<and> scRefillCount ko = 1 \<and> sc_valid_refills' ko)
                                             |< scs_of' s') sc_ptr)"
-                   in corres_inst)
-            apply (simp add: when_def[symmetric] whenM_def ifM_def bind_assoc split del: if_split)
-            apply (rule corres_guard_imp)
-              apply (rule corres_split[OF refillReady_corres]) (* projection version *)
-                (* when-block *)
-                apply (rule corres_split[OF corres_when], simp)
-                   apply (rule corres_split[OF getCurTime_corres])
-                     apply (rule corres_guard_imp)
-                       apply (rule updateRefillHd_corres, simp)
-                       apply (simp add: refill_map_def)
-                      apply (simp+)[2]
-                    apply (wpsimp+)[2]
-                  apply (simp add: liftM_def bind_assoc)
-                  apply (rule corres_split[OF get_sc_corres])
-                    (* if-block *)
-                    apply (rename_tac sc sc')
-                    apply (rule_tac P="ko_at (kernel_object.SchedContext sc n) sc_ptr
-                                       and K (0 < sc_refill_max sc) and K (sc_refills sc \<noteq> [])
-                                        and K (valid_sched_context_size n)"
-                                and P'="ko_at' sc' sc_ptr
-                                        and K (1 < scRefillMax sc' \<and> scRefillCount sc' = 1 \<and> sc_valid_refills' sc')"
-                           in corres_inst)
-                    apply (rule_tac F="refill_hd sc = refill_map (refillHd sc')" in corres_req)
-                     apply (fastforce dest!: refill_hd_relation)
-                    apply (rule corres_guard_imp)
-                      apply (rule corres_if)
-                        apply (clarsimp simp: refill_map_def)
-                       apply (rule corres_split[OF updateRefillHd_corres], simp)
-                          apply (clarsimp simp: refill_map_def)
-                         apply (rule maybeAddEmptyTail_corres)
-                        apply (wpsimp simp: update_refill_hd_rewrite)
-                       apply (wpsimp simp: updateRefillHd_def wp: updateSchedContext_wp)
-                      apply (rule refillAddTail_corres)
+                       in corres_inst)
+          apply (simp add: when_def[symmetric] whenM_def ifM_def bind_assoc split del: if_split)
+          apply (rule corres_guard_imp)
+            apply (rule corres_split[OF refillReady_corres]) (* projection version *)
+              (* when-block *)
+              apply (rule corres_split[OF corres_when], simp)
+                 apply (rule corres_split[OF getCurTime_corres])
+                   apply (rule corres_guard_imp)
+                     apply (rule updateRefillHd_corres, simp)
+                     apply (simp add: refill_map_def)
+                    apply (simp+)[2]
+                  apply (wpsimp+)[2]
+                apply (simp add: liftM_def bind_assoc)
+                apply (rule corres_split[OF get_sc_corres])
+                  (* if-block *)
+                  apply (rename_tac sc sc')
+                  apply (rule_tac P="ko_at (kernel_object.SchedContext sc n) sc_ptr
+                                     and K (0 < sc_refill_max sc) and K (sc_refills sc \<noteq> [])
+                                      and K (valid_sched_context_size n)"
+                              and P'="ko_at' sc' sc_ptr
+                                      and K (1 < scRefillMax sc' \<and> scRefillCount sc' = 1 \<and> sc_valid_refills' sc')"
+                               in corres_inst)
+                  apply (rule_tac F="refill_hd sc = refill_map (refillHd sc')" in corres_req)
+                   apply (fastforce dest!: refill_hd_relation)
+                  apply (rule corres_guard_imp)
+                    apply (rule corres_if)
                       apply (clarsimp simp: refill_map_def)
-                     apply (clarsimp simp: obj_at_def is_sc_obj is_active_sc2_def opt_map_red opt_pred_def)
-                    apply (clarsimp simp: obj_at_simps opt_map_red opt_pred_def is_sc_obj ps_clear_upd
-                                          scBits_simps fun_upd_def[symmetric] valid_refills'_def)
-                   apply wpsimp
-                  apply (wpsimp wp: getSchedContext_wp')
-                 apply (wpsimp simp: update_refill_hd_def wp: update_sched_context_wp)
-                apply (wpsimp simp: updateRefillHd_def objBits_simps
-                                wp: updateSchedContext_wp)
-               apply (wpsimp wp: get_sc_refill_ready_wp)
-              apply (wpsimp wp: refillReady_wp')
-             apply (fastforce simp: obj_at_def is_sc_obj is_active_sc2_def opt_map_red opt_pred_def)
-            apply (fastforce simp: obj_at_simps ps_clear_upd fun_upd_def[symmetric]
-                                   valid_refills'_def opt_map_red opt_pred_def)
-           apply ((wpsimp wp: updateSchedContext_wp update_sched_context_wp simp: objBits_simps)+)[5]
-      apply (rule monadic_rewrite_refine_valid[where P''=\<top>, OF updateSchedContext_decompose_x3, simplified])
-        apply ((clarsimp simp: objBits_simps)+)[2]
-      apply (wpsimp wp: updateSchedContext_wp simp: objBits_simps)
+                     apply (rule corres_split[OF updateRefillHd_corres], simp)
+                      apply (clarsimp simp: refill_map_def)
+                      apply (rule maybeAddEmptyTail_corres[simplified dc_def])
+                      apply (wpsimp simp: update_refill_hd_rewrite)
+                     apply (wpsimp simp: updateRefillHd_def wp: updateSchedContext_wp)
+                    apply (rule refillAddTail_corres[simplified dc_def])
+                    apply (clarsimp simp: refill_map_def)
+                   apply (clarsimp simp: obj_at_def is_sc_obj is_active_sc2_def opt_map_red opt_pred_def)
+                  apply (clarsimp simp: obj_at_simps opt_map_red opt_pred_def is_sc_obj ps_clear_upd
+                                        scBits_simps fun_upd_def[symmetric] valid_refills'_def)
+                 apply wpsimp
+                apply (wpsimp wp: getSchedContext_wp')
+               apply (wpsimp simp: update_refill_hd_def wp: update_sched_context_wp)
+              apply (wpsimp simp: updateRefillHd_def objBits_simps
+                               wp: updateSchedContext_wp)
+             apply (wpsimp wp: get_sc_refill_ready_wp)
+            apply (wpsimp wp: refillReady_wp')
+           apply (fastforce simp: obj_at_def is_sc_obj is_active_sc2_def opt_map_red opt_pred_def)
+          apply (fastforce simp: obj_at_simps ps_clear_upd fun_upd_def[symmetric]
+                                 valid_refills'_def opt_map_red opt_pred_def)
+                     apply ((wpsimp wp: updateSchedContext_wp update_sched_context_wp simp: objBits_simps)+)[5]
      apply (clarsimp simp: obj_at_def is_sc_obj is_active_sc2_def opt_map_red opt_pred_def)
     apply (clarsimp simp: obj_at_simps scBits_simps ps_clear_upd fun_upd_def[symmetric]
                           valid_refills_number'_def is_sc_obj)
@@ -1098,14 +1096,6 @@ lemma refillNew_invs':
   (is "\<lbrace>?P\<rbrace> _ \<lbrace>?Q\<rbrace>")
   apply (clarsimp simp: refillNew_def)
   apply (rule hoare_seq_ext_skip, wpsimp)
-
-  apply (rule hoare_seq_ext_skip)
-   apply (intro hoare_vcg_conj_lift_pre_fix; (solves wpsimp)?)
-    apply (wpsimp wp: updateSchedContext_invs')
-    apply (fastforce dest: invs'_ko_at_valid_sched_context'
-                     simp: valid_sched_context'_def valid_sched_context_size'_def objBits_simps)
-   apply (wpsimp wp: updateSchedContext_wp)
-   apply (clarsimp simp: obj_at_simps ko_wp_at'_def ps_clear_def opt_map_def)
 
   apply (rule hoare_seq_ext_skip)
    apply (intro hoare_vcg_conj_lift_pre_fix; (solves wpsimp)?)
@@ -1175,16 +1165,7 @@ lemma refillUpdate_invs':
    apply (find_goal \<open>match conclusion in "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>_. ex_nonz_cap_to' scPtr\<rbrace>" for P f \<Rightarrow> -\<close>)
    apply (wpsimp wp: updateSchedContext_ex_nonz_cap_to' refillReady_wp
                simp: updateRefillHd_def)
-  apply (rule_tac B="\<lambda>_. invs' and ex_nonz_cap_to' scPtr" in hoare_seq_ext)
-   apply (wpsimp wp: updateSchedContext_invs')
-   apply (fastforce dest: invs'_ko_at_valid_sched_context'
-                    simp: valid_sched_context'_def valid_sched_context_size'_def obj_at_simps)
   apply (simp add: bind_assoc)
-  apply (clarsimp simp: pred_conj_def)
-  apply (intro hoare_vcg_conj_lift_pre_fix)
-   apply (find_goal \<open>match conclusion in "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>_. ex_nonz_cap_to' scPtr\<rbrace>" for P f \<Rightarrow> -\<close>)
-   apply (wpsimp wp: updateSchedContext_ex_nonz_cap_to')
-
   apply (rule hoare_seq_ext_skip)
    apply (intro hoare_vcg_conj_lift_pre_fix; (solves wpsimp)?)
     apply (wpsimp wp: updateSchedContext_invs')

--- a/proof/refine/ARM/Schedule_R.thy
+++ b/proof/refine/ARM/Schedule_R.thy
@@ -4765,7 +4765,7 @@ lemma refillBudgetCheck_corres:
                              sp_valid_refills_def is_active_sc_rewrite[symmetric])
     apply (find_goal \<open>match conclusion in "\<lbrace>P\<rbrace> handle_overrun_loop _ \<lbrace>Q\<rbrace>" for P Q \<Rightarrow> -\<close>)
     apply (clarsimp simp: pred_conj_def)
-    apply (intro hoare_vcg_conj_lift_pre_fix; (solves \<open>wpsimp | handle_overrun_loop_simple\<close>)?)
+    apply (intro hoare_vcg_conj_lift_pre_fix; (solves handle_overrun_loop_simple)?)
       apply wps_conj_solves
      apply (wpsimp wp: handle_overrun_loop_refills_unat_sum_equals_budget)
      apply (fastforce intro: valid_refills_refills_unat_sum_equals_budget

--- a/proof/refine/ARM/StateRelation.thy
+++ b/proof/refine/ARM/StateRelation.thy
@@ -248,7 +248,6 @@ definition sc_relation ::
   "Structures_A.sched_context \<Rightarrow> nat \<Rightarrow> Structures_H.sched_context \<Rightarrow> bool" where
   "sc_relation \<equiv> \<lambda>sc n sc'.
      sc_period sc = scPeriod sc' \<and>
-     sc_budget sc = scBudget sc' \<and>
      sc_consumed sc = scConsumed sc' \<and>
      sc_tcb sc = scTCB sc' \<and>
      sc_ntfn sc = scNtfn sc' \<and>

--- a/proof/refine/RISCV64/ADT_H.thy
+++ b/proof/refine/RISCV64/ADT_H.thy
@@ -277,7 +277,10 @@ definition
 definition scMap :: "(obj_ref \<rightharpoonup> obj_ref) \<Rightarrow> sched_context \<Rightarrow> Structures_A.sched_context" where
   "scMap replyPrevs sc = \<lparr>
      sc_period     = scPeriod sc,
-     sc_budget     = scBudget sc,
+     sc_budget     = if scRefillMax sc > 0
+                     then refills_sum (refills_map (scRefillHead sc) (scRefillCount sc)
+                                                   (scRefillMax sc) (scRefills sc))
+                     else 0,
      sc_consumed   = scConsumed sc,
      sc_tcb        = scTCB sc,
      sc_ntfn       = scNtfn sc,
@@ -460,6 +463,7 @@ lemma absHeap_correct:
   assumes pspace_aligned:  "pspace_aligned s"
   assumes pspace_distinct: "pspace_distinct s"
   assumes valid_objs:      "valid_objs s"
+  assumes valid_refills:   "active_sc_valid_refills s"
   assumes pspace_relation: "pspace_relation (kheap s) (ksPSpace s')"
   assumes ghost_relation:  "ghost_relation (kheap s) (gsUserPages s') (gsCNodes s')"
   assumes replies:         "sc_replies_relation s s'"
@@ -723,6 +727,16 @@ proof -
      apply (rule relatedE, assumption, ko, ako)
      apply (frule scBits_inverse_sc_relation)
      apply (clarsimp simp: sc_relation_def scMap_def mapScSize_def sc_replies_prevs_walk[OF replies])
+     apply (intro conjI impI)
+      apply (prop_tac "valid_refills y s")
+       apply (fastforce intro: valid_refills active_sc_valid_refillsE
+                         simp: vs_all_heap_simps active_sc_def)
+      apply (clarsimp simp: valid_refills_def vs_all_heap_simps rr_valid_refills_def
+                     split: if_splits)
+     apply (insert valid_refills)
+     apply (force simp: active_sc_valid_refills_def valid_refills_def vs_all_heap_simps
+                        active_sc_def
+                 split: if_splits)
 
     apply (erule relatedE, ko, ako)
     apply (clarsimp simp: reply_relation_def replyMap_def)

--- a/proof/refine/RISCV64/Finalise_R.thy
+++ b/proof/refine/RISCV64/Finalise_R.thy
@@ -4784,7 +4784,7 @@ lemma schedContextZeroRefillMax_corres:
                         set_refills_def sc_at_sc_obj_at updateSchedContext_def)
   apply (rule corres_underlying_lift_ex1')
   apply (rule corres_guard_imp)
-    apply (subst bind_dummy_ret_val, subst update_sched_context_decompose[symmetric])
+    apply (subst bind_dummy_ret_val, subst update_sched_context_decompose[symmetric])+
     apply (rule_tac n1=n in monadic_rewrite_corres_l[OF update_sched_context_rewrite])
     apply (rule corres_split[OF get_sc_corres])
       apply (rule_tac P="ko_at (kernel_object.SchedContext sc n) scPtr"

--- a/proof/refine/RISCV64/Refine.thy
+++ b/proof/refine/RISCV64/Refine.thy
@@ -403,7 +403,7 @@ lemma valid_sched_init[simp]:
                         active_sc_def MIN_REFILLS_def)
   by (auto simp: vs_all_heap_simps active_sc_valid_refills_def cfg_valid_refills_def
                  rr_valid_refills_def MIN_REFILLS_def bounded_release_time_def
-                 default_sched_context_def MAX_PERIOD_def
+                 default_sched_context_def MAX_PERIOD_def active_sc_def
           intro: order_trans[OF mult_left_mono, OF us_to_ticks_helper])
 
 lemma valid_domain_list_init[simp]:

--- a/proof/refine/RISCV64/Schedule_R.thy
+++ b/proof/refine/RISCV64/Schedule_R.thy
@@ -4666,7 +4666,7 @@ lemma refillBudgetCheck_corres:
                              sp_valid_refills_def is_active_sc_rewrite[symmetric])
     apply (find_goal \<open>match conclusion in "\<lbrace>P\<rbrace> handle_overrun_loop _ \<lbrace>Q\<rbrace>" for P Q \<Rightarrow> -\<close>)
     apply (clarsimp simp: pred_conj_def)
-    apply (intro hoare_vcg_conj_lift_pre_fix; (solves \<open>wpsimp | handle_overrun_loop_simple\<close>)?)
+    apply (intro hoare_vcg_conj_lift_pre_fix; (solves handle_overrun_loop_simple)?)
       apply wps_conj_solves
      apply (wpsimp wp: handle_overrun_loop_refills_unat_sum_equals_budget)
      apply (fastforce intro: valid_refills_refills_unat_sum_equals_budget

--- a/proof/refine/RISCV64/StateRelation.thy
+++ b/proof/refine/RISCV64/StateRelation.thy
@@ -213,7 +213,6 @@ definition sc_relation ::
   where
   "sc_relation \<equiv> \<lambda>sc n sc'.
      sc_period sc = scPeriod sc' \<and>
-     sc_budget sc = scBudget sc' \<and>
      sc_consumed sc = scConsumed sc' \<and>
      sc_tcb sc = scTCB sc' \<and>
      sc_ntfn sc = scNtfn sc' \<and>

--- a/spec/abstract/SchedContext_A.thy
+++ b/spec/abstract/SchedContext_A.thy
@@ -413,7 +413,8 @@ definition
 where
   "sched_context_zero_refill_max sc_ptr = do
      update_sched_context sc_ptr (sc_refills_update (\<lambda>_. []));
-     update_sched_context sc_ptr (sc_refill_max_update (\<lambda>_. 0))
+     update_sched_context sc_ptr (sc_refill_max_update (\<lambda>_. 0));
+     update_sched_context sc_ptr (sc_budget_update (\<lambda>_. 0))
    od"
 
 text \<open> Unbind TCB from its scheduling context, if there is one bound. \<close>

--- a/spec/design/skel/ObjectInstances_H.thy
+++ b/spec/design/skel/ObjectInstances_H.thy
@@ -255,7 +255,7 @@ definition
 definition
   makeObject_sc:
   "(makeObject :: sched_context) \<equiv>
-     SchedContext 0 0 0 Nothing Nothing Nothing 0 False Nothing 0 0 0 (replicate minRefillLength emptyRefill)"
+     SchedContext 0 0 Nothing Nothing Nothing 0 False Nothing 0 0 0 (replicate minRefillLength emptyRefill)"
 
 definition
   loadObject_sc[simp]:

--- a/spec/haskell/src/SEL4/Object/Instances.lhs
+++ b/spec/haskell/src/SEL4/Object/Instances.lhs
@@ -53,7 +53,7 @@ The following are the instances of "Storable" for the four main types of kernel 
 \subsubsection{SchedContext objects}
 
 > instance PSpaceStorable SchedContext where
->     makeObject = SchedContext 0 0 0 Nothing Nothing Nothing 0 False Nothing 0 0 0 []
+>     makeObject = SchedContext 0 0 Nothing Nothing Nothing 0 False Nothing 0 0 0 []
 >     injectKO   = KOSchedContext
 >     projectKO o = case o of
 >         KOSchedContext e -> return e

--- a/spec/haskell/src/SEL4/Object/SchedContext.lhs
+++ b/spec/haskell/src/SEL4/Object/SchedContext.lhs
@@ -225,7 +225,6 @@ This module uses the C preprocessor to select a target architecture.
 > refillNew scPtr maxRefills budget period = do
 >     curTime <- getCurTime
 >     updateSchedContext scPtr (\sc -> sc { scPeriod = period })
->     updateSchedContext scPtr (\sc -> sc { scBudget = budget })
 >     updateSchedContext scPtr (\sc -> sc { scRefillMax = maxRefills })
 >     updateSchedContext scPtr (\sc -> sc { scRefillHead = 0, scRefillCount = 1 })
 >     setRefillHd scPtr (Refill { rTime = curTime, rAmount = budget })
@@ -247,7 +246,6 @@ This module uses the C preprocessor to select a target architecture.
 >     updateSchedContext scPtr (\sc -> sc { scRefillCount = 1 })
 >     updateSchedContext scPtr (\sc -> sc { scRefillMax = newMaxRefills })
 >     updateSchedContext scPtr (\sc -> sc { scPeriod = newPeriod })
->     updateSchedContext scPtr (\sc -> sc { scBudget = newBudget })
 >     whenM (refillReady scPtr) $ do
 >         curTime <- getCurTime
 >         updateRefillHd scPtr $ \r -> r { rTime = curTime }

--- a/spec/haskell/src/SEL4/Object/Structures.lhs
+++ b/spec/haskell/src/SEL4/Object/Structures.lhs
@@ -204,7 +204,6 @@ list of pointers to waiting threads;
 
 > data SchedContext = SchedContext {
 >     scPeriod :: Ticks,
->     scBudget :: Ticks,
 >     scConsumed :: Ticks,
 >     scTCB :: Maybe (PPtr TCB),
 >     scReply :: Maybe (PPtr Reply),


### PR DESCRIPTION
This removes all the sorries in the file `ADT_C`, thereby significantly increasing our confidence that the state relation is correct. 

This also removes the `budget` field of scheduling contexts in the executable specification (and Haskell kernel). This brings the executable spec closer to the C code and shifts the condition that the budget is always the sum of all refills into the abstract refinement proofs where the corresponding invariants are more easily available.