### PR TITLE
updates for 2023 C-Parser and AutoCorres releases

### DIFF
--- a/tools/autocorres/tools/release.py
+++ b/tools/autocorres/tools/release.py
@@ -200,9 +200,10 @@ with TempDir(cleanup=(not args.no_cleanup)) as base_dir:
         shutil.copyfile(f_src, f_dest)
 
     # Copy various other files.
-    shutil.copyfile(
-        os.path.join(args.repository, 'lib', 'Word_Lib', 'ROOT'),
-        os.path.join(target_dir, 'lib', 'Word_Lib', 'ROOT'))
+    for session in ['Basics', 'Eisbach_Tools', 'ML_Utils', 'Monads', 'Word_Lib']:
+        shutil.copyfile(
+            os.path.join(args.repository, 'lib', session, 'ROOT'),
+            os.path.join(target_dir, 'lib', session, 'ROOT'))
     shutil.copyfile(
         os.path.join(release_files_dir, "ROOT.release"),
         os.path.join(target_dir, "autocorres", "ROOT"))
@@ -222,36 +223,10 @@ with TempDir(cleanup=(not args.no_cleanup)) as base_dir:
         os.path.join(args.repository, "LICENSES"),
         os.path.join(target_dir, "LICENSES"))
 
-    # Extract dependent sessions in lib. FIXME: rather kludgy
-    print('Extracting sessions from lib/ROOT...')
-
     # Set up ROOT for the tests dir, for the thydeps tool
     subprocess.check_call(
         ['make', 'tests/ROOT'],
         cwd=os.path.join(args.repository, 'tools', 'autocorres'))
-
-    lib_sessions = ['Lib', 'CLib']
-    lib_ROOT = os.path.join(args.repository, 'lib', 'ROOT')
-    with open(lib_ROOT, 'r') as lib_root:
-        data = lib_root.read()
-        # Split out session specs. Assume ROOT file has standard indentation.
-        chunks = data.split('\nsession ')
-        # This will have the license header, etc.
-        header = chunks[0]
-        # Remaining sections. Try to remove comments
-        sessions = ['session ' + re.sub(r'\(\*.*?\*\)', '', x, flags=re.DOTALL)
-                    for x in chunks[1:]]
-
-        new_root = header
-        wanted_specs = {}
-        for wanted in lib_sessions:
-            spec = [spec for spec in sessions if spec.startswith('session %s ' % wanted)]
-            if len(spec) != 1:
-                print('error: %s session not found in %r' % (wanted, lib_ROOT))
-            new_root += '\n' + spec[0]
-
-        with open(os.path.join(target_dir, 'lib', 'ROOT'), 'w') as root_f:
-            root_f.write(new_root)
 
     # For the examples, generate ".thy" files where appropriate, and also
     # generate an "All.thy" which contains all the examples.

--- a/tools/autocorres/tools/release_files/AUTOCORRES_FILES
+++ b/tools/autocorres/tools/release_files/AUTOCORRES_FILES
@@ -33,6 +33,7 @@ exception_rewrite.ML:
     Proof frameworks and code to rewrite monadic specifications to
     avoid using exceptions where possible.
 
+NatBitwise.thy:
 WordAbstract.thy:
 word_abstract.ML:
     Word abstraction framework and theorems.

--- a/tools/autocorres/tools/release_files/CONTRIBUTORS
+++ b/tools/autocorres/tools/release_files/CONTRIBUTORS
@@ -1,19 +1,21 @@
-Core Development Team
----------------------
+Core Developers
+---------------
 
     David Greenaway (inactive)
 
-    Japheth Lim <Japheth.Lim@data61.csiro.au>
+    Japheth Lim (inactive)
+
+    Gerwin Klein (maintenance)
 
 Contributions
 -------------
 
-    Lars Noschinski <noschinl@in.tum.de>
+    Lars Noschinski
 
         "owhile" definitions and related rules, as well as many other
         contributions to the proof libraries.
 
-    Matthew Brecknell <Matthew.Brecknell@data61.csiro.au>
+    Matthew Brecknell (inactive)
 
         Maintenance; integration with seL4's C refinement framework.
 

--- a/tools/autocorres/tools/release_files/ChangeLog
+++ b/tools/autocorres/tools/release_files/ChangeLog
@@ -1,51 +1,55 @@
+AutoCorres Change Log
+=====================
+
 AutoCorres 1.10 (3 Nov 2023)
---------------
+----------------------------
 
-	* Isabelle2023 edition of both AutoCorres and the C parser.
+        * Isabelle2023 edition of both AutoCorres and the C parser.
 
-	* Restructured and cleaned up monad libraries. Removed dependencies
+        * Restructured and cleaned up monad libraries. Removed dependencies
           on unrelated l4v libraries.
 
 AutoCorres 1.9 (31 October 2022)
---------------
+--------------------------------
 
-	* Isabelle2021-1 edition of both AutoCorres and the C parser.
+        * Isabelle2021-1 edition of both AutoCorres and the C parser.
 
 AutoCorres 1.8 (31 October 2021)
---------------
+--------------------------------
 
-	* Isabelle2021 edition of both AutoCorres and the C parser.
+        * Isabelle2021 edition of both AutoCorres and the C parser.
 
 AutoCorres 1.7 (2 November 2020)
---------------
+--------------------------------
 
-	* Isabelle2020 edition of both AutoCorres and the C parser.
+        * Isabelle2020 edition of both AutoCorres and the C parser.
 
-	* Slight updates to wp: use "wp (once)" instead of "wp_once"
+        * Slight updates to wp: use "wp (once)" instead of "wp_once"
 
 AutoCorres 1.6.1 (3 October 2019)
-----------------
-	* Correct license for a C parser file. No code changes.
+---------------------------------
+
+        * Correct license for a C parser file. No code changes.
 
 AutoCorres 1.6 (5 September 2019)
---------------
+----------------------------------
 
-	* Isabelle2019 edition of both AutoCorres and the C parser.
+        * Isabelle2019 edition of both AutoCorres and the C parser.
 
-	* Word abstraction has been extended to C bitwise operators.
+        * Word abstraction has been extended to C bitwise operators.
 
 AutoCorres 1.5 (10 September 2018)
---------------
+----------------------------------
 
-	* Isabelle2018 edition of both AutoCorres and the C parser.
+        * Isabelle2018 edition of both AutoCorres and the C parser.
 
 AutoCorres 1.4 (2 March 2018)
---------------
+-----------------------------
 
         * Isabelle2017 edition of both AutoCorres and the C parser.
 
 AutoCorres 1.3 (3 April 2017)
---------------
+-----------------------------
 
         * Isabelle2016-1 edition of both AutoCorres and the C parser.
 
@@ -54,7 +58,7 @@ AutoCorres 1.3 (3 April 2017)
           must be selected using L4V_ARCH environment variable.
 
 AutoCorres 1.2 (31 March 2016)
---------------
+------------------------------
 
         * Isabelle2016 edition of both AutoCorres and the C parser.
 
@@ -67,7 +71,7 @@ AutoCorres 1.2 (31 March 2016)
         * Several minor bug fixes and improvements.
 
 AutoCorres 1.1 (9 Oct 2015)
---------------
+---------------------------
 
         * Isabelle2015 edition of both AutoCorres and the C parser.
 
@@ -85,7 +89,7 @@ AutoCorres 1.1 (9 Oct 2015)
 
 
 AutoCorres 1.0 (16 Dec 2014)
---------------
+----------------------------
 
         * New option “no_opt” to turn off simplifier stages. (Experimental)
 

--- a/tools/autocorres/tools/release_files/ChangeLog
+++ b/tools/autocorres/tools/release_files/ChangeLog
@@ -1,3 +1,11 @@
+AutoCorres 1.10 (3 Nov 2023)
+--------------
+
+	* Isabelle2023 edition of both AutoCorres and the C parser.
+
+	* Restructured and cleaned up monad libraries. Removed dependencies
+          on unrelated l4v libraries.
+
 AutoCorres 1.9 (31 October 2022)
 --------------
 

--- a/tools/autocorres/tools/release_files/README
+++ b/tools/autocorres/tools/release_files/README
@@ -28,7 +28,7 @@ Contents of this README
 Installation
 ------------
 
-AutoCorres is packaged as a theory for Isabelle2021:
+AutoCorres is packaged as a theory for Isabelle2023:
 
     https://isabelle.in.tum.de
 

--- a/tools/autocorres/tools/release_files/ROOT.release
+++ b/tools/autocorres/tools/release_files/ROOT.release
@@ -8,15 +8,14 @@
 session AutoCorres = CParser +
   sessions
     "HOL-Eisbach"
-    Lib
-    CLib
+    Monads
   theories
+    "DataStructures"
     "AutoCorres"
 
 session AutoCorresTest in "tests" = AutoCorres +
   sessions
     "HOL-Number_Theory"
-    AutoCorres
   directories
     "parse-tests"
     "proof-tests"

--- a/tools/autocorres/tools/release_files/ROOTS.base_dir
+++ b/tools/autocorres/tools/release_files/ROOTS.base_dir
@@ -1,4 +1,7 @@
-lib
+lib/Basics
+lib/Eisbach_Tools
+lib/ML_Utils
+lib/Monads
 lib/Word_Lib
 c-parser
 autocorres

--- a/tools/c-parser/INSTALL.md
+++ b/tools/c-parser/INSTALL.md
@@ -9,7 +9,7 @@
 NB: These instructions apply to the stand-alone release of the C parser.
 If this is in an L4.verified checkout, see the top-level README.md instead.
 
-This code requires Isabelle2021 and the MLton SML compiler.
+This code requires Isabelle2023 and the MLton SML compiler.
 
 The C parser supports multiple target architectures:
 

--- a/tools/c-parser/RELEASES.md
+++ b/tools/c-parser/RELEASES.md
@@ -156,3 +156,9 @@
       ##<decl_type>: <name>
 
   e.g. `##Function: ctzl`
+
+## 1.20
+
+- Builds with Isabelle2023
+- Rearranged library session structure and included more libraries for heap
+  reasoning in the release. See e.g. files TypHeapLib.thy and LemmaBucket_C.thy

--- a/tools/c-parser/mkrelease
+++ b/tools/c-parser/mkrelease
@@ -110,25 +110,15 @@ done
 
 # other misc files
 cp -v lib/Word_Lib/ROOT "$outputdir/src/lib/Word_Lib/"
+cp -v lib/Basics/ROOT "$outputdir/src/lib/Basics/"
+cp -v lib/ML_Utils/ROOT "$outputdir/src/lib/ML_Utils/"
 
 echo "Creating ROOTS file"
 cat >"$outputdir/src/ROOTS" <<EOF
 lib/Word_Lib
-lib
+lib/Basics
+lib/ML_Utils
 c-parser
-EOF
-
-echo "Adding ROOT file for Lib session"
-cat > "$outputdir/src/lib/ROOT" <<EOF
-(*
- * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
- *
- * SPDX-License-Identifier: BSD-2-Clause
- *)
-
-session Lib = HOL +
-  directories "ml-helpers"
-  theories "ML_Utils"
 EOF
 
 echo "Rearranging directories"

--- a/tools/c-parser/mkrelease
+++ b/tools/c-parser/mkrelease
@@ -32,7 +32,8 @@ die ()
 if [ $# -ne 1 ]
 then
     echo "Usage:" >&2
-    die "  $0 tag" >&2
+    echo "  $0 <c-parser-tag-version>"
+    die "e.g.  $0 1.20" >&2
 fi
 
 # Get the directory that this script is running in.

--- a/tools/c-parser/mkrelease
+++ b/tools/c-parser/mkrelease
@@ -183,7 +183,6 @@ sed '
 ' < standalone-parser/Makefile > "$outputdir/src/c-parser/standalone-parser/Makefile"
 popd > /dev/null
 
-
 echo "Making PDF of ctranslation file."
 cd "$outputdir/src/c-parser/doc"
 make ctranslation.pdf > /dev/null
@@ -191,22 +190,6 @@ make ctranslation.pdf > /dev/null
 mv ctranslation.pdf "$outputdir/doc"
 
 popd > /dev/null
-
-lookforlicense=$(find "$outputdir" \! -name '*.lex.sml' \! -name '*.grm.sml' \! -type d -exec grep -q @LICENSE \{\} \; -print)
-if [ -n "$lookforlicense" ]
-then
-    die "### @LICENSE detected in file(s) $lookforlicense"
-else
-    echo "No @LICENSEs remain unexpanded - good."
-fi
-
-lookformichaeln=$(find "$outputdir" \! -name RELEASES.md \! -type d -exec grep -q /michaeln \{\} \; -print)
-if [ -n "$lookformichaeln" ]
-then
-    die "### /michaeln detected in file(s) $lookformichaeln"
-else
-    echo "No occurrences of \"/michaeln\" - good."
-fi
 
 echo -n "Compressing into $stem.tar.gz: "
 mv "$tmpdir/c-parser" "$tmpdir/$stem"


### PR DESCRIPTION
The library restructure means a few things need to be updated in the release scripts for the C parser and AutoCorres. Overall this simplified both scripts, so it looks like this is at least a small win.

Summary:
- update change logs, bump versions
- update release scripts for new library structure
- update ROOT/ROOTS files in the releases
- update AutoCorres CONTRIBUTORS file