### PR TITLE
More progress on completing the trace monad rule set

### DIFF
--- a/lib/Monads/nondet/Nondet_No_Fail.thy
+++ b/lib/Monads/nondet/Nondet_No_Fail.thy
@@ -54,14 +54,30 @@ lemma no_failD:
   "\<lbrakk> no_fail P m; P s \<rbrakk> \<Longrightarrow> \<not>(snd (m s))"
   by (simp add: no_fail_def)
 
+lemma no_fail_return[simp, wp]:
+  "no_fail \<top> (return x)"
+  by (simp add: return_def no_fail_def)
+
+lemma no_fail_bind[wp]:
+  "\<lbrakk> \<And>rv. no_fail (R rv) (g rv); \<lbrace>Q\<rbrace> f \<lbrace>R\<rbrace>; no_fail P f \<rbrakk> \<Longrightarrow> no_fail (P and Q) (f >>= (\<lambda>rv. g rv))"
+  unfolding no_fail_def bind_def
+  using post_by_hoare by fastforce
+
+lemma no_fail_get[simp, wp]:
+  "no_fail \<top> get"
+  by (simp add: get_def no_fail_def)
+
+lemma no_fail_put[simp, wp]:
+  "no_fail \<top> (put s)"
+  by (simp add: put_def no_fail_def)
+
 lemma no_fail_modify[wp,simp]:
   "no_fail \<top> (modify f)"
-  by (simp add: no_fail_def modify_def get_def put_def bind_def)
+  by (wpsimp simp: modify_def)
 
 lemma no_fail_gets_simp[simp]:
   "no_fail P (gets f)"
-  unfolding no_fail_def gets_def get_def return_def bind_def
-  by simp
+  by (wpsimp simp: gets_def)
 
 lemma no_fail_gets[wp]:
   "no_fail \<top> (gets f)"
@@ -74,18 +90,6 @@ lemma no_fail_select[simp]:
 lemma no_fail_alt[wp]:
   "\<lbrakk> no_fail P f; no_fail Q g \<rbrakk> \<Longrightarrow> no_fail (P and Q) (f \<sqinter> g)"
   by (simp add: no_fail_def alternative_def)
-
-lemma no_fail_return[simp, wp]:
-  "no_fail \<top> (return x)"
-  by (simp add: return_def no_fail_def)
-
-lemma no_fail_get[simp, wp]:
-  "no_fail \<top> get"
-  by (simp add: get_def no_fail_def)
-
-lemma no_fail_put[simp, wp]:
-  "no_fail \<top> (put s)"
-  by (simp add: put_def no_fail_def)
 
 lemma no_fail_when[wp]:
   "(P \<Longrightarrow> no_fail Q f) \<Longrightarrow> no_fail (if P then Q else \<top>) (when P f)"
@@ -128,11 +132,6 @@ lemma no_fail_undefined[simp, wp]:
 lemma no_fail_returnOK[simp, wp]:
   "no_fail \<top> (returnOk x)"
   by (simp add: returnOk_def)
-
-lemma no_fail_bind[wp]:
-  "\<lbrakk> \<And>rv. no_fail (R rv) (g rv); \<lbrace>Q\<rbrace> f \<lbrace>R\<rbrace>; no_fail P f \<rbrakk> \<Longrightarrow> no_fail (P and Q) (f >>= (\<lambda>rv. g rv))"
-  unfolding no_fail_def bind_def
-  using post_by_hoare by fastforce
 
 lemma no_fail_assume_pre:
   "(\<And>s. P s \<Longrightarrow> no_fail P f) \<Longrightarrow> no_fail P f"

--- a/lib/Monads/nondet/Nondet_No_Fail.thy
+++ b/lib/Monads/nondet/Nondet_No_Fail.thy
@@ -83,7 +83,7 @@ lemma no_fail_gets[wp]:
   "no_fail \<top> (gets f)"
   by simp
 
-lemma no_fail_select[simp]:
+lemma no_fail_select[wp,simp]:
   "no_fail \<top> (select S)"
   by (simp add: no_fail_def select_def)
 
@@ -219,7 +219,7 @@ lemma no_fail_state_assert[wp]:
   unfolding state_assert_def
   by wpsimp
 
-lemma no_fail_condition:
+lemma no_fail_condition[wp]:
   "\<lbrakk>no_fail Q A; no_fail R B\<rbrakk> \<Longrightarrow> no_fail (\<lambda>s. (C s \<longrightarrow> Q s) \<and> (\<not> C s \<longrightarrow> R s)) (condition C A B)"
   unfolding condition_def no_fail_def
   by clarsimp
@@ -230,6 +230,6 @@ lemma no_fail_ex_lift:
 
 lemma no_fail_grab_asm:
   "(G \<Longrightarrow> no_fail P f) \<Longrightarrow> no_fail (\<lambda>s. G \<and> P s) f"
-  by (cases G, simp+)
+  by (cases G; clarsimp)
 
 end

--- a/lib/Monads/nondet/Nondet_Total.thy
+++ b/lib/Monads/nondet/Nondet_Total.thy
@@ -202,7 +202,7 @@ lemma validNF_gets[wp]:
 lemma validNF_condition[wp]:
   "\<lbrakk> \<lbrace> Q \<rbrace> A \<lbrace>P\<rbrace>!; \<lbrace> R \<rbrace> B \<lbrace>P\<rbrace>!\<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s. if C s then Q s else R s\<rbrace> condition C A B \<lbrace>P\<rbrace>!"
   by (erule validNFE)+
-     (rule validNF; wpsimp wp: no_fail_condition)
+     (rule validNF; wpsimp)
 
 lemma validNF_assert[wp]:
   "\<lbrace> (\<lambda>s. P) and (R ()) \<rbrace> assert P \<lbrace> R \<rbrace>!"
@@ -344,7 +344,7 @@ lemma validE_NF_handleE[wp]:
 lemma validE_NF_condition[wp]:
   "\<lbrakk> \<lbrace> Q \<rbrace> A \<lbrace>P\<rbrace>,\<lbrace> E \<rbrace>!; \<lbrace> R \<rbrace> B \<lbrace>P\<rbrace>,\<lbrace> E \<rbrace>! \<rbrakk> \<Longrightarrow>
    \<lbrace>\<lambda>s. if C s then Q s else R s\<rbrace> condition C A B \<lbrace>P\<rbrace>,\<lbrace> E \<rbrace>!"
-  by (erule validE_NFE)+ (wpsimp wp: no_fail_condition validE_NF)
+  by (erule validE_NFE)+ (wpsimp wp: validE_NF)
 
 lemma hoare_assume_preNF:
   "(\<And>s. P s \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>!) \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>!"

--- a/lib/Monads/trace/Trace_Empty_Fail.thy
+++ b/lib/Monads/trace/Trace_Empty_Fail.thy
@@ -18,7 +18,7 @@ text \<open>
   following property: if they return an empty set of completed results, there exists a trace
   corresponding to a failed result.\<close>
 definition empty_fail :: "('s,'a) tmonad \<Rightarrow> bool" where
-  "empty_fail m \<equiv> \<forall>s. mres (m s) = {} \<longrightarrow> Failed \<in> snd ` (m s)"
+  "empty_fail m \<equiv> \<forall>s. mres (m s) = {} \<longrightarrow> failed (m s)"
 
 text \<open>Useful in forcing otherwise unknown executions to have the @{const empty_fail} property.\<close>
 definition mk_ef ::
@@ -38,28 +38,28 @@ wpc_setup "\<lambda>m. empty_fail m" wpc_helper_empty_fail_final
 subsection \<open>@{const empty_fail} intro/dest rules\<close>
 
 lemma empty_failI:
-  "(\<And>s. mres (m s) = {} \<Longrightarrow> Failed \<in> snd ` (m s)) \<Longrightarrow> empty_fail m"
+  "(\<And>s. mres (m s) = {} \<Longrightarrow> failed (m s)) \<Longrightarrow> empty_fail m"
   by (simp add: empty_fail_def)
 
 lemma empty_failD:
-  "\<lbrakk> empty_fail m; mres (m s) = {} \<rbrakk> \<Longrightarrow> Failed \<in> snd ` (m s)"
+  "\<lbrakk> empty_fail m; mres (m s) = {} \<rbrakk> \<Longrightarrow> failed (m s)"
   by (simp add: empty_fail_def)
 
 lemma empty_fail_not_snd:
-  "\<lbrakk> Failed \<notin> snd ` (m s); empty_fail m \<rbrakk> \<Longrightarrow> \<exists>v. v \<in> mres (m s)"
+  "\<lbrakk> \<not> failed (m s); empty_fail m \<rbrakk> \<Longrightarrow> \<exists>v. v \<in> mres (m s)"
   by (fastforce simp: empty_fail_def)
 
 lemmas empty_failD2 = empty_fail_not_snd[rotated]
 
 lemma empty_failD3:
-  "\<lbrakk> empty_fail f; Failed \<notin> snd ` (f s) \<rbrakk> \<Longrightarrow> mres (f s) \<noteq> {}"
+  "\<lbrakk> empty_fail f; \<not> failed (f s) \<rbrakk> \<Longrightarrow> mres (f s) \<noteq> {}"
   by (drule(1) empty_failD2, clarsimp)
 
 lemma empty_fail_bindD1:
   "empty_fail (a >>= b) \<Longrightarrow> empty_fail a"
   unfolding empty_fail_def bind_def
   apply (erule all_reg[rotated])
-  by (force simp: split_def mres_def vimage_def split: tmres.splits)
+  by (force simp: split_def mres_def vimage_def failed_def split: tmres.splits)
 
 
 subsection \<open>Wellformed monads\<close>
@@ -116,14 +116,14 @@ lemma mres_bind_empty:
   apply fastforce
   done
 
-lemma bind_FailedI1:
-  "Failed \<in> snd ` f s \<Longrightarrow> Failed \<in> snd ` (f >>= g) s"
-  by (force simp: bind_def vimage_def)
+lemma bind_failedI1:
+  "failed (f s) \<Longrightarrow> failed ((f >>= g) s)"
+  by (force simp: bind_def vimage_def failed_def)
 
-lemma bind_FailedI2:
-  "\<lbrakk>\<forall>res\<in>mres (f s). Failed \<in> snd ` (g (fst res) (snd res)); mres (f s) \<noteq> {}\<rbrakk>
-   \<Longrightarrow> Failed \<in> snd ` (f >>= g) s"
-  by (force simp: bind_def mres_def image_def split_def)
+lemma bind_failedI2:
+  "\<lbrakk>\<forall>res\<in>mres (f s). failed (g (fst res) (snd res)); mres (f s) \<noteq> {}\<rbrakk>
+   \<Longrightarrow> failed ((f >>= g) s)"
+  by (force simp: bind_def mres_def image_def split_def failed_def)
 
 lemma empty_fail_bind[empty_fail_cond]:
   "\<lbrakk> empty_fail a; \<And>x. empty_fail (b x) \<rbrakk> \<Longrightarrow> empty_fail (a >>= b)"
@@ -131,8 +131,8 @@ lemma empty_fail_bind[empty_fail_cond]:
   apply clarsimp
   apply (drule mres_bind_empty)
   apply (erule context_disjE)
-   apply (fastforce intro: bind_FailedI1)
-  apply (fastforce intro!: bind_FailedI2)
+   apply (fastforce intro: bind_failedI1)
+  apply (fastforce intro!: bind_failedI2)
   done
 
 lemma empty_fail_return[empty_fail_term]:
@@ -189,7 +189,7 @@ lemma empty_fail_assert_opt[empty_fail_term]:
 
 lemma empty_fail_mk_ef[empty_fail_term]:
   "empty_fail (mk_ef o m)"
-  by (simp add: empty_fail_def mk_ef_def)
+  by (simp add: empty_fail_def mk_ef_def failed_def)
 
 lemma empty_fail_gets_the[empty_fail_term]:
   "empty_fail (gets_the f)"
@@ -224,7 +224,7 @@ lemma empty_fail_guard[empty_fail_term]:
 
 lemma empty_fail_spec[empty_fail_term]:
   "empty_fail (state_select F)"
-  by (clarsimp simp: state_select_def empty_fail_def default_elem_def mres_def image_def)
+  by (clarsimp simp: state_select_def empty_fail_def default_elem_def mres_def image_def failed_def)
 
 lemma empty_fail_when[empty_fail_cond]:
   "(P \<Longrightarrow> empty_fail x) \<Longrightarrow> empty_fail (when P x)"

--- a/lib/Monads/trace/Trace_Empty_Fail.thy
+++ b/lib/Monads/trace/Trace_Empty_Fail.thy
@@ -333,6 +333,31 @@ lemma empty_fail_notM[empty_fail_cond]:
   "empty_fail A \<Longrightarrow> empty_fail (notM A)"
   by (simp add: notM_def empty_fail_term empty_fail_cond)
 
+lemma empty_fail_put_trace_elem[empty_fail_term]:
+  "empty_fail (put_trace_elem x)"
+  by (clarsimp simp: put_trace_elem_def empty_fail_def mres_def vimage_def)
+
+lemma empty_fail_put_trace[empty_fail_term]:
+  "empty_fail (put_trace xs)"
+  apply (induct xs)
+   apply (clarsimp simp: empty_fail_term)
+  apply (clarsimp simp: empty_fail_term empty_fail_cond)
+  done
+
+lemma empty_fail_interference[empty_fail_term]:
+  "empty_fail interference"
+  by (simp add: interference_def commit_step_def env_steps_def empty_fail_term empty_fail_cond)
+
+lemma last_st_tr_not_empty:
+  "P s \<Longrightarrow> \<exists>xs. P (last_st_tr (map (Pair Env) xs) s')"
+  apply (rule exI[where x="[s]"])
+  apply (auto simp: last_st_tr_def)
+  done
+
+lemma empty_fail_Await[empty_fail_term]:
+  "\<exists>s. c s \<Longrightarrow> empty_fail (Await c)"
+  by (clarsimp simp: Await_def last_st_tr_not_empty empty_fail_term empty_fail_cond)
+
 (* not everything [simp] by default, because side conditions can slow down simp a lot *)
 lemmas empty_fail[wp, intro!] = empty_fail_term empty_fail_cond
 lemmas [simp] = empty_fail_term

--- a/lib/Monads/trace/Trace_Monad.thy
+++ b/lib/Monads/trace/Trace_Monad.thy
@@ -44,7 +44,6 @@ text \<open>
   pair of result and state when the computation did not fail.\<close>
 type_synonym ('s, 'a) tmonad = "'s \<Rightarrow> ((tmid \<times> 's) list \<times> ('s, 'a) tmres) set"
 
-
 text \<open>
   Print the type @{typ "('s,'a) tmonad"} instead of its unwieldy expansion.
   Needs an AST translation in code, because it needs to check that the state variable
@@ -67,6 +66,17 @@ print_ast_translation \<open>
 text \<open>Returns monad results, ignoring failures and traces.\<close>
 definition mres :: "((tmid \<times> 's) list \<times> ('s, 'a) tmres) set \<Rightarrow> ('a \<times> 's) set" where
   "mres r = Result -` (snd ` r)"
+
+text \<open>True if the monad has a computation resulting in Failed.\<close>
+definition failed :: "((tmid \<times> 's) list \<times> ('s, 'a) tmres) set \<Rightarrow> bool" where
+  "failed r \<equiv> Failed \<in> snd ` r"
+
+lemma failed_simps[simp]:
+  "failed {(x, y)} = (y = Failed)"
+  "failed (r \<union> r') = (failed r \<or> failed r')"
+  "\<not> failed {}"
+  by (auto simp: failed_def)
+
 
 text \<open>
   The definition of fundamental monad functions @{text return} and

--- a/lib/Monads/trace/Trace_No_Fail.thy
+++ b/lib/Monads/trace/Trace_No_Fail.thy
@@ -227,4 +227,12 @@ lemma no_fail_condition:
   unfolding condition_def no_fail_def
   by clarsimp
 
+lemma no_fail_ex_lift:
+  "(\<And>x. no_fail (P x) f) \<Longrightarrow> no_fail (\<lambda>s. \<exists>x. P x s) f"
+  by (fastforce simp: no_fail_def)
+
+lemma no_fail_grab_asm:
+  "(G \<Longrightarrow> no_fail P f) \<Longrightarrow> no_fail (\<lambda>s. G \<and> P s) f"
+  by (cases G, simp+)
+
 end

--- a/lib/Monads/trace/Trace_No_Fail.thy
+++ b/lib/Monads/trace/Trace_No_Fail.thy
@@ -22,7 +22,7 @@ text \<open>
   state that satisfies the precondition it returns a @{term Failed} result.
 \<close>
 definition no_fail :: "('s \<Rightarrow> bool) \<Rightarrow> ('s,'a) tmonad \<Rightarrow> bool" where
-  "no_fail P m \<equiv> \<forall>s. P s \<longrightarrow> Failed \<notin> snd ` (m s)"
+  "no_fail P m \<equiv> \<forall>s. P s \<longrightarrow> \<not> failed (m s)"
 
 
 subsection \<open>@{method wpc} setup\<close>
@@ -51,7 +51,7 @@ bundle classic_wp_pre =
 subsection \<open>Lemmas\<close>
 
 lemma no_failD:
-  "\<lbrakk> no_fail P m; P s \<rbrakk> \<Longrightarrow> Failed \<notin> snd ` m s"
+  "\<lbrakk> no_fail P m; P s \<rbrakk> \<Longrightarrow> \<not> failed (m s)"
   by (simp add: no_fail_def)
 
 lemma no_fail_return[simp, wp]:
@@ -61,7 +61,7 @@ lemma no_fail_return[simp, wp]:
 lemma no_fail_bind[wp]:
   "\<lbrakk> no_fail P f; \<And>x. no_fail (R x) (g x); \<lbrace>Q\<rbrace> f \<lbrace>R\<rbrace> \<rbrakk> \<Longrightarrow> no_fail (P and Q) (f >>= (\<lambda>rv. g rv))"
   apply (simp add: no_fail_def bind_def' image_Un image_image
-                   in_image_constant)
+                   in_image_constant failed_def)
   apply (intro allI conjI impI)
    apply (fastforce simp: image_def)
   apply clarsimp
@@ -91,7 +91,7 @@ lemma no_fail_gets[wp]:
 
 lemma no_fail_select[wp,simp]:
   "no_fail \<top> (select S)"
-  by (simp add: no_fail_def select_def image_def)
+  by (simp add: no_fail_def select_def image_def failed_def)
 
 lemma no_fail_alt[wp]:
   "\<lbrakk> no_fail P f; no_fail Q g \<rbrakk> \<Longrightarrow> no_fail (P and Q) (f \<sqinter> g)"

--- a/lib/Monads/trace/Trace_No_Fail.thy
+++ b/lib/Monads/trace/Trace_No_Fail.thy
@@ -89,7 +89,7 @@ lemma no_fail_gets[wp]:
   "no_fail \<top> (gets f)"
   by simp
 
-lemma no_fail_select[simp]:
+lemma no_fail_select[wp,simp]:
   "no_fail \<top> (select S)"
   by (simp add: no_fail_def select_def image_def)
 
@@ -222,7 +222,7 @@ lemma no_fail_state_assert[wp]:
   unfolding state_assert_def
   by wpsimp
 
-lemma no_fail_condition:
+lemma no_fail_condition[wp]:
   "\<lbrakk>no_fail Q A; no_fail R B\<rbrakk> \<Longrightarrow> no_fail (\<lambda>s. (C s \<longrightarrow> Q s) \<and> (\<not> C s \<longrightarrow> R s)) (condition C A B)"
   unfolding condition_def no_fail_def
   by clarsimp
@@ -233,6 +233,6 @@ lemma no_fail_ex_lift:
 
 lemma no_fail_grab_asm:
   "(G \<Longrightarrow> no_fail P f) \<Longrightarrow> no_fail (\<lambda>s. G \<and> P s) f"
-  by (cases G, simp+)
+  by (cases G; clarsimp)
 
 end

--- a/lib/Monads/trace/Trace_No_Fail.thy
+++ b/lib/Monads/trace/Trace_No_Fail.thy
@@ -235,4 +235,28 @@ lemma no_fail_grab_asm:
   "(G \<Longrightarrow> no_fail P f) \<Longrightarrow> no_fail (\<lambda>s. G \<and> P s) f"
   by (cases G; clarsimp)
 
+lemma no_fail_put_trace_elem[wp]:
+  "no_fail \<top> (put_trace_elem x)"
+  by (clarsimp simp: put_trace_elem_def no_fail_def failed_def)
+
+lemma no_fail_put_trace[wp]:
+  "no_fail \<top> (put_trace xs)"
+  by (induct xs; wpsimp)
+
+lemma no_fail_interference[wp]:
+  "no_fail \<top> interference"
+  by (wpsimp simp: interference_def commit_step_def env_steps_def)
+
+lemma no_fail_Await[wp]:
+  "\<exists>s. c s \<Longrightarrow> no_fail \<top> (Await c)"
+  by (wpsimp simp: Await_def)
+
+lemma parallel_failed:
+  "failed (parallel f g s) \<Longrightarrow> failed (f s) \<and> failed (g s)"
+  by (auto simp: parallel_def2 failed_def image_def intro!: bexI)
+
+lemma no_fail_parallel[wp]:
+  "\<lbrakk> no_fail P f \<or> no_fail Q g \<rbrakk> \<Longrightarrow> no_fail (P and Q) (parallel f g)"
+  by (auto simp: no_fail_def dest!: parallel_failed)
+
 end

--- a/lib/Monads/trace/Trace_No_Fail.thy
+++ b/lib/Monads/trace/Trace_No_Fail.thy
@@ -54,14 +54,36 @@ lemma no_failD:
   "\<lbrakk> no_fail P m; P s \<rbrakk> \<Longrightarrow> Failed \<notin> snd ` m s"
   by (simp add: no_fail_def)
 
+lemma no_fail_return[simp, wp]:
+  "no_fail \<top> (return x)"
+  by (simp add: return_def no_fail_def)
+
+lemma no_fail_bind[wp]:
+  "\<lbrakk> no_fail P f; \<And>x. no_fail (R x) (g x); \<lbrace>Q\<rbrace> f \<lbrace>R\<rbrace> \<rbrakk> \<Longrightarrow> no_fail (P and Q) (f >>= (\<lambda>rv. g rv))"
+  apply (simp add: no_fail_def bind_def' image_Un image_image
+                   in_image_constant)
+  apply (intro allI conjI impI)
+   apply (fastforce simp: image_def)
+  apply clarsimp
+  apply (drule(1) post_by_hoare, erule in_mres)
+  apply (fastforce simp: image_def)
+  done
+
+lemma no_fail_get[simp, wp]:
+  "no_fail \<top> get"
+  by (simp add: get_def no_fail_def)
+
+lemma no_fail_put[simp, wp]:
+  "no_fail \<top> (put s)"
+  by (simp add: put_def no_fail_def)
+
 lemma no_fail_modify[wp,simp]:
   "no_fail \<top> (modify f)"
-  by (simp add: no_fail_def modify_def get_def put_def bind_def)
+  by (wpsimp simp: modify_def)
 
 lemma no_fail_gets_simp[simp]:
   "no_fail P (gets f)"
-  unfolding no_fail_def gets_def get_def return_def bind_def
-  by simp
+  by (wpsimp simp: gets_def)
 
 lemma no_fail_gets[wp]:
   "no_fail \<top> (gets f)"
@@ -74,18 +96,6 @@ lemma no_fail_select[simp]:
 lemma no_fail_alt[wp]:
   "\<lbrakk> no_fail P f; no_fail Q g \<rbrakk> \<Longrightarrow> no_fail (P and Q) (f \<sqinter> g)"
   by (auto simp: no_fail_def alternative_def)
-
-lemma no_fail_return[simp, wp]:
-  "no_fail \<top> (return x)"
-  by (simp add: return_def no_fail_def)
-
-lemma no_fail_get[simp, wp]:
-  "no_fail \<top> get"
-  by (simp add: get_def no_fail_def)
-
-lemma no_fail_put[simp, wp]:
-  "no_fail \<top> (put s)"
-  by (simp add: put_def no_fail_def)
 
 lemma no_fail_when[wp]:
   "(P \<Longrightarrow> no_fail Q f) \<Longrightarrow> no_fail (if P then Q else \<top>) (when P f)"
@@ -128,17 +138,6 @@ lemma no_fail_undefined[simp, wp]:
 lemma no_fail_returnOK[simp, wp]:
   "no_fail \<top> (returnOk x)"
   by (simp add: returnOk_def)
-
-lemma no_fail_bind[wp]:
-  "\<lbrakk> no_fail P f; \<And>x. no_fail (R x) (g x); \<lbrace>Q\<rbrace> f \<lbrace>R\<rbrace> \<rbrakk> \<Longrightarrow> no_fail (P and Q) (f >>= (\<lambda>rv. g rv))"
-  apply (simp add: no_fail_def bind_def' image_Un image_image
-                   in_image_constant)
-  apply (intro allI conjI impI)
-   apply (fastforce simp: image_def)
-  apply clarsimp
-  apply (drule(1) post_by_hoare, erule in_mres)
-  apply (fastforce simp: image_def)
-  done
 
 lemma no_fail_assume_pre:
   "(\<And>s. P s \<Longrightarrow> no_fail P f) \<Longrightarrow> no_fail P f"

--- a/lib/Monads/trace/Trace_No_Throw.thy
+++ b/lib/Monads/trace/Trace_No_Throw.thy
@@ -99,4 +99,17 @@ lemma no_throw_Inr:
   "\<lbrakk> x \<in> mres (A s); no_throw P A; P s \<rbrakk> \<Longrightarrow> \<exists>y. fst x = Inr y"
   by (fastforce simp: no_throw_def' split: sum.splits)
 
+lemma mres_parallel:
+  "x \<in> mres (parallel f g s) \<Longrightarrow> x \<in> mres (f s) \<and> x \<in> mres (g s)"
+  unfolding parallel_def2 mres_def
+  apply (clarsimp simp: image_def)
+  apply (auto intro!: bexI)
+  done
+
+lemma no_throw_parallel:
+  "\<lbrakk> no_throw P f \<or> no_throw Q g \<rbrakk> \<Longrightarrow> no_throw (P and Q) (parallel f g)"
+  unfolding no_throw_def'
+  apply (auto dest!: mres_parallel)
+  done
+
 end

--- a/lib/Monads/trace/Trace_No_Trace.thy
+++ b/lib/Monads/trace/Trace_No_Trace.thy
@@ -44,21 +44,17 @@ lemma no_trace_is_triple[wp_trip]:
 
 subsection \<open>Rules\<close>
 
-lemma no_trace_prim:
-  "no_trace get"
-  "no_trace (put s)"
-  "no_trace (modify f)"
-  "no_trace (return v)"
-  "no_trace fail"
-  "no_trace (returnOk v)"
-  by (simp_all add: no_trace_def get_def put_def modify_def bind_def
-                    return_def select_def fail_def returnOk_def)
+(*
+  Collect generic no_trace lemmas here:
+   - naming convention is no_trace_NAME.
+   - add lemmas with assumptions to [no_trace_cond] set
+   - add lemmas without assumption to [no_trace_terminal] set
+*)
 
-lemma no_trace_select:
-  "no_trace (select S)"
-  by (clarsimp simp add: no_trace_def select_def)
+named_theorems no_trace_cond
+named_theorems no_trace_terminal
 
-lemma no_trace_bind:
+lemma no_trace_bind[wp_split]:
   "\<lbrakk>no_trace f; \<forall>rv. no_trace (g rv)\<rbrakk>
    \<Longrightarrow> no_trace (do rv \<leftarrow> f; g rv od)"
   apply (subst no_trace_def)
@@ -66,39 +62,72 @@ lemma no_trace_bind:
          fastforce dest: no_traceD)
   done
 
-lemma no_trace_extra:
-  "no_trace (gets f)"
-  "no_trace (assert P)"
-  "no_trace (assert_opt Q)"
-  by (simp_all add: gets_def assert_def assert_opt_def no_trace_bind no_trace_prim
-             split: option.split)
+lemma no_trace_get[no_trace_terminal]:
+  "no_trace get"
+  by (simp add: no_trace_def get_def)
 
-lemma no_trace_alt:
+lemma no_trace_put[no_trace_terminal]:
+  "no_trace (put s)"
+  by (simp add: no_trace_def put_def)
+
+lemma no_trace_modify[no_trace_terminal]:
+  "no_trace (modify f)"
+  by (wpsimp simp: modify_def wp: no_trace_terminal)
+
+lemma no_trace_return[no_trace_terminal]:
+  "no_trace (return v)"
+  by (simp add: no_trace_def return_def)
+
+lemma no_trace_fail[no_trace_terminal]:
+  "no_trace fail"
+  by (simp add: no_trace_def fail_def)
+
+lemma no_trace_returnOk[no_trace_terminal]:
+  "no_trace (returnOk v)"
+  by (simp add: returnOk_def no_trace_terminal)
+
+lemma no_trace_select[no_trace_terminal]:
+  "no_trace (select S)"
+  by (clarsimp simp add: no_trace_def select_def)
+
+lemma no_trace_gets[no_trace_terminal]:
+  "no_trace (gets f)"
+  by (wpsimp simp: gets_def wp: no_trace_terminal)
+
+lemma no_trace_assert[no_trace_terminal]:
+  "no_trace (assert P)"
+  by (simp add: assert_def no_trace_terminal)
+
+lemma no_trace_case_option[no_trace_cond]:
+  assumes f: "no_trace f"
+  assumes g: "\<And>x. no_trace (g x)"
+  shows "no_trace (case_option f g x)"
+  by (clarsimp simp: f g split: option.split)
+
+lemma no_trace_assert_opt[no_trace_terminal]:
+  "no_trace (assert_opt Q)"
+  by (simp add: assert_opt_def no_trace_terminal no_trace_cond)
+
+lemma no_trace_alt[no_trace_cond]:
   "\<lbrakk> no_trace f; no_trace g \<rbrakk> \<Longrightarrow> no_trace (f \<sqinter> g)"
   apply (subst no_trace_def)
   apply (clarsimp simp add: alternative_def;
          fastforce dest: no_traceD)
   done
 
-lemma no_trace_when:
+lemma no_trace_when[no_trace_cond]:
   "\<lbrakk>P \<Longrightarrow> no_trace f\<rbrakk> \<Longrightarrow> no_trace (when P f)"
-  by (simp add: when_def no_trace_prim)
+  by (simp add: when_def no_trace_terminal)
 
-lemma no_trace_unless:
+lemma no_trace_unless[no_trace_cond]:
   "\<lbrakk>\<not>P \<Longrightarrow> no_trace f\<rbrakk> \<Longrightarrow> no_trace (unless P f)"
-  by (simp add: unless_def when_def no_trace_prim)
+  by (simp add: unless_def when_def no_trace_terminal)
 
-lemma no_trace_case_option:
-  assumes f: "no_trace f"
-  assumes g: "\<And>x. no_trace (g x)"
-  shows "no_trace (case_option f g x)"
-  by (clarsimp simp: f g split: option.split)
-
-lemma no_trace_if:
+lemma no_trace_if[no_trace_cond]:
   "\<lbrakk> P \<Longrightarrow> no_trace f; \<not>P \<Longrightarrow> no_trace g \<rbrakk> \<Longrightarrow> no_trace (if P then f else g)"
   by simp
 
-lemma no_trace_apply:
+lemma no_trace_apply[no_trace_cond]:
   "no_trace (f (g x)) \<Longrightarrow> no_trace (f $ g x)"
   by simp
 
@@ -119,74 +148,73 @@ lemma no_trace_liftM_eq[simp]:
      apply (auto split: tmres.splits)
   done
 
-lemma no_trace_liftM:
+lemma no_trace_liftM[no_trace_cond]:
   "no_trace m \<Longrightarrow> no_trace (liftM f m)"
   by simp
 
-lemma no_trace_assertE:
+lemma no_trace_assertE[no_trace_terminal]:
   "no_trace (assertE P)"
-  by (simp add: assertE_def no_trace_prim)
+  by (simp add: assertE_def no_trace_terminal)
 
-lemma no_trace_whenE:
+lemma no_trace_whenE[no_trace_cond]:
   "\<lbrakk> G \<Longrightarrow> no_trace f \<rbrakk> \<Longrightarrow> no_trace (whenE G f)"
-  by (simp add: whenE_def no_trace_prim)
+  by (simp add: whenE_def no_trace_terminal)
 
-lemma no_trace_unlessE:
+lemma no_trace_unlessE[no_trace_cond]:
   "\<lbrakk> \<not> G \<Longrightarrow> no_trace f \<rbrakk> \<Longrightarrow> no_trace (unlessE G f)"
-  by (simp add: unlessE_def no_trace_prim)
+  by (simp add: unlessE_def no_trace_terminal)
 
-lemma no_trace_throwError:
+lemma no_trace_throwError[no_trace_terminal]:
   "no_trace (throwError e)"
-  by (simp add: throwError_def no_trace_prim)
+  by (simp add: throwError_def no_trace_terminal)
 
-lemma no_trace_throw_opt:
+lemma no_trace_throw_opt[no_trace_terminal]:
   "no_trace (throw_opt ex x)"
   unfolding throw_opt_def
-  by (fastforce intro: no_trace_prim no_trace_throwError split: option.splits)
+  by (simp add: no_trace_terminal no_trace_cond)
 
-lemma no_trace_liftE:
+lemma no_trace_liftE[no_trace_cond]:
   "no_trace f \<Longrightarrow> no_trace (liftE f)"
-  unfolding liftE_def by (wpsimp wp: no_trace_bind no_trace_prim)
+  unfolding liftE_def by (wpsimp wp: no_trace_terminal)
 
-lemma no_trace_gets_the:
+lemma no_trace_gets_the[no_trace_terminal]:
   "no_trace (gets_the f)"
   unfolding gets_the_def
-  by (wpsimp wp: no_trace_bind no_trace_extra)
+  by (wpsimp wp: no_trace_terminal)
 
-lemma no_trace_lift:
-  "(\<And>y. x = Inr y \<Longrightarrow> no_trace (f y)) \<Longrightarrow> no_trace (lift f x)"
+lemma no_trace_lift[no_trace_cond]:
+  "\<lbrakk>\<And>y. x = Inr y \<Longrightarrow> no_trace (f y)\<rbrakk> \<Longrightarrow> no_trace (lift f x)"
   unfolding lift_def
-  by (wpsimp wp: no_trace_throwError split: sum.splits)
+  by (wpsimp wp: no_trace_terminal split: sum.splits)
 
-lemma no_trace_bindE:
-  "\<lbrakk> no_trace f; \<And>rv. no_trace (g rv)\<rbrakk>
-     \<Longrightarrow> no_trace (f >>=E g)"
+lemma no_trace_bindE[wp_split]:
+  "\<lbrakk> no_trace f; \<And>rv. no_trace (g rv)\<rbrakk> \<Longrightarrow> no_trace (f >>=E g)"
   unfolding bindE_def
-  by (wpsimp wp: no_trace_bind no_trace_lift)
+  by (wpsimp wp: no_trace_cond)
 
-lemma no_trace_gets_map:
+lemma no_trace_gets_map[no_trace_terminal]:
   "no_trace (gets_map f p)"
-  unfolding gets_map_def by (wpsimp wp: no_trace_bind no_trace_extra)
+  unfolding gets_map_def by (wpsimp wp: no_trace_terminal)
 
-lemma no_trace_state_assert:
+lemma no_trace_state_assert[no_trace_terminal]:
   "no_trace (state_assert P)"
   unfolding state_assert_def
-  by (wpsimp wp: no_trace_bind no_trace_prim no_trace_extra)
+  by (wpsimp wp: no_trace_terminal)
 
-lemma no_trace_condition:
+lemma no_trace_condition[no_trace_cond]:
   "\<lbrakk>no_trace A; no_trace B\<rbrakk> \<Longrightarrow> no_trace (condition C A B)"
   unfolding condition_def no_trace_def
   apply clarsimp
   apply fastforce
   done
 
-lemma no_trace_mapM:
+lemma no_trace_mapM[no_trace_cond]:
   assumes m: "\<And>x. x \<in> set xs \<Longrightarrow> no_trace (m x)"
   shows "no_trace (mapM m xs)"
   using m
 proof (induct xs)
   case Nil
-  thus ?case by (simp add: mapM_def sequence_def no_trace_prim)
+  thus ?case by (simp add: mapM_def sequence_def no_trace_terminal)
 next
   case Cons
   have P: "\<And>m x xs. mapM m (x # xs) = (do y \<leftarrow> m x; ys \<leftarrow> (mapM m xs); return (y # ys) od)"
@@ -194,149 +222,140 @@ next
   from Cons
   show ?case
     apply (simp add: P)
-    apply (wpsimp wp: no_trace_bind no_trace_prim)
+    apply (wpsimp wp: no_trace_terminal)
     done
 qed
 
-lemma no_trace_catch:
+lemma no_trace_catch[no_trace_cond]:
   "\<lbrakk> no_trace f; \<And>x. no_trace (g x) \<rbrakk> \<Longrightarrow> no_trace (catch f g)"
   unfolding catch_def
-  by (wpsimp wp: no_trace_bind no_trace_prim split: sum.split)
+  by (wpsimp wp: no_trace_terminal split: sum.split)
 
-lemma no_trace_state_select:
+lemma no_trace_state_select[no_trace_terminal]:
   "no_trace (state_select F)"
   unfolding state_select_def2
-  by (wpsimp wp: no_trace_bind no_trace_prim no_trace_extra no_trace_select)
+  by (wpsimp wp: no_trace_terminal)
 
-lemma no_trace_liftME:
+lemma no_trace_liftME[no_trace_cond]:
   "no_trace m \<Longrightarrow> no_trace (liftME f m)"
   unfolding liftME_def
-  by (wpsimp wp: no_trace_bindE no_trace_prim)
+  by (wpsimp wp: no_trace_terminal)
 
-lemma no_trace_handle':
+lemma no_trace_handle'[no_trace_cond]:
   "\<lbrakk>no_trace f; \<And>e. no_trace (handler e)\<rbrakk> \<Longrightarrow> no_trace (f <handle2> handler)"
   unfolding handleE'_def
-  by (wpsimp wp: no_trace_bind no_trace_prim split: sum.split)
+  by (wpsimp wp: no_trace_terminal split: sum.split)
 
-lemma no_trace_handleE:
+lemma no_trace_handleE[no_trace_cond]:
   "\<lbrakk> no_trace L; \<And>r. no_trace (R r) \<rbrakk> \<Longrightarrow> no_trace (L <handle> R)"
   unfolding handleE_def
-  by (simp add: no_trace_handle')
+  by (simp add: no_trace_cond)
 
-lemma no_trace_handle_elseE:
+lemma no_trace_handle_elseE[no_trace_cond]:
   "\<lbrakk> no_trace f; \<And>r. no_trace (g r); \<And>r. no_trace (h r) \<rbrakk> \<Longrightarrow> no_trace (f <handle> g <else> h)"
   unfolding handle_elseE_def
-  by (wpsimp wp: no_trace_bind no_trace_prim split: sum.split)
+  by (wpsimp wp: no_trace_terminal split: sum.split)
 
-lemma no_trace_sequence:
+lemma no_trace_sequence[no_trace_cond]:
   "(\<And>m. m \<in> set ms \<Longrightarrow> no_trace m) \<Longrightarrow> no_trace (sequence ms)"
   unfolding sequence_def
-  by (induct ms; wpsimp wp: no_trace_prim no_trace_bind)
+  by (induct ms; wpsimp wp: no_trace_terminal)
 
-lemma no_trace_sequence_x:
+lemma no_trace_sequence_x[no_trace_cond]:
   "(\<And>m. m \<in> set ms \<Longrightarrow> no_trace m) \<Longrightarrow> no_trace (sequence_x ms)"
   unfolding sequence_x_def
-  by (induct ms; wpsimp wp: no_trace_prim no_trace_bind)
+  by (induct ms; wpsimp wp: no_trace_terminal)
 
-lemma no_trace_sequenceE:
+lemma no_trace_sequenceE[no_trace_cond]:
   "(\<And>m. m \<in> set ms \<Longrightarrow> no_trace m) \<Longrightarrow> no_trace (sequenceE ms)"
   unfolding sequenceE_def
-  by (induct ms; wpsimp wp: no_trace_prim no_trace_bindE)
+  by (induct ms; wpsimp wp: no_trace_terminal)
 
-lemma no_trace_sequenceE_x:
+lemma no_trace_sequenceE_x[no_trace_cond]:
   "(\<And>m. m \<in> set ms \<Longrightarrow> no_trace m) \<Longrightarrow> no_trace (sequenceE_x ms)"
   unfolding sequenceE_x_def
-  by (induct ms; wpsimp wp: no_trace_prim no_trace_bindE)
+  by (induct ms; wpsimp wp: no_trace_terminal)
 
-lemma no_trace_mapM_x:
+lemma no_trace_mapM_x[no_trace_cond]:
   "(\<And>m. m \<in> f ` set ms \<Longrightarrow> no_trace m) \<Longrightarrow> no_trace (mapM_x f ms)"
   unfolding mapM_x_def
   by (fastforce intro: no_trace_sequence_x)
 
-lemma no_trace_mapME:
+lemma no_trace_mapME[no_trace_cond]:
   "(\<And>m. m \<in> f ` set xs \<Longrightarrow> no_trace m) \<Longrightarrow> no_trace (mapME f xs)"
   unfolding mapME_def
   by (fastforce intro: no_trace_sequenceE)
 
-lemma no_trace_mapME_x:
+lemma no_trace_mapME_x[no_trace_cond]:
   "(\<And>m'. m' \<in> f ` set xs \<Longrightarrow> no_trace m') \<Longrightarrow> no_trace (mapME_x f xs)"
   unfolding mapME_x_def
   by (fastforce intro: no_trace_sequenceE_x)
 
-lemma no_trace_filterM:
+lemma no_trace_filterM[no_trace_cond]:
   "(\<And>m. m \<in> set ms \<Longrightarrow> no_trace (P m)) \<Longrightarrow> no_trace (filterM P ms)"
-  by (induct ms; wpsimp wp: no_trace_prim no_trace_bind split_del: if_split)
+  by (induct ms; wpsimp wp: no_trace_terminal split_del: if_split)
 
-lemma no_trace_zipWithM_x:
+lemma no_trace_zipWithM_x[no_trace_cond]:
   "(\<And>x y. no_trace (f x y)) \<Longrightarrow> no_trace (zipWithM_x f xs ys)"
   unfolding zipWithM_x_def zipWith_def
   by (fastforce intro: no_trace_sequence_x)
 
-lemma no_trace_zipWithM:
+lemma no_trace_zipWithM[no_trace_cond]:
   "(\<And>x y. no_trace (f x y)) \<Longrightarrow> no_trace (zipWithM f xs ys)"
   unfolding zipWithM_def zipWith_def
   by (fastforce intro: no_trace_sequence)
 
-lemma no_trace_foldM:
+lemma no_trace_foldM[no_trace_cond]:
   "(\<And>x y. no_trace (m x y)) \<Longrightarrow> no_trace (foldM m xs a)"
   unfolding foldM_def
-  by (induct xs; wpsimp wp: no_trace_prim no_trace_bind)
+  by (induct xs; wpsimp wp: no_trace_terminal)
 
-lemma no_trace_foldME:
+lemma no_trace_foldME[no_trace_cond]:
   "(\<And>x y. no_trace (m x y)) \<Longrightarrow> no_trace (foldME m a xs)"
   unfolding foldME_def
-  by (induct xs; wpsimp wp: no_trace_prim no_trace_bindE)
+  by (induct xs; wpsimp wp: no_trace_terminal)
 
-lemma no_trace_maybeM:
+lemma no_trace_maybeM[no_trace_cond]:
   "\<forall>x. no_trace (f x) \<Longrightarrow> no_trace (maybeM f t)"
   unfolding maybeM_def
-  by (fastforce intro: no_trace_prim split: option.splits)
+  by (fastforce intro: no_trace_terminal split: option.splits)
 
-lemma no_trace_notM:
+lemma no_trace_notM[no_trace_cond]:
   "no_trace A \<Longrightarrow> no_trace (notM A)"
   unfolding notM_def
-  by (wpsimp wp: no_trace_bind no_trace_prim)
+  by (wpsimp wp: no_trace_terminal)
 
-lemma no_trace_ifM:
+lemma no_trace_ifM[no_trace_cond]:
   "\<lbrakk> no_trace P; no_trace a; no_trace b \<rbrakk> \<Longrightarrow> no_trace (ifM P a b)"
-  unfolding ifM_def
-  by (wpsimp wp: no_trace_bind)
+  unfolding ifM_def by wpsimp
 
-lemma no_trace_ifME:
+lemma no_trace_ifME[no_trace_cond]:
   "\<lbrakk> no_trace P; no_trace a; no_trace b \<rbrakk> \<Longrightarrow> no_trace (ifME P a b)"
-  unfolding ifME_def
-  by (wpsimp wp: no_trace_bindE)
+  unfolding ifME_def by wpsimp
 
-lemma no_trace_whenM:
+lemma no_trace_whenM[no_trace_cond]:
   "\<lbrakk> no_trace P; no_trace f \<rbrakk> \<Longrightarrow> no_trace (whenM P f)"
   unfolding whenM_def
-  by (wpsimp wp: no_trace_ifM no_trace_prim)
+  by (wpsimp wp: no_trace_terminal no_trace_cond)
 
-lemma no_trace_orM:
+lemma no_trace_orM[no_trace_cond]:
   "\<lbrakk> no_trace A; no_trace B \<rbrakk> \<Longrightarrow> no_trace (orM A B)"
   unfolding orM_def
-  by (wpsimp wp: no_trace_ifM no_trace_prim)
+  by (wpsimp wp: no_trace_terminal no_trace_cond)
 
-lemma no_trace_andM:
+lemma no_trace_andM[no_trace_cond]:
   "\<lbrakk> no_trace A; no_trace B \<rbrakk> \<Longrightarrow> no_trace (andM A B)"
   unfolding andM_def
-  by (wpsimp wp: no_trace_ifM no_trace_prim)
+  by (wpsimp wp: no_trace_terminal no_trace_cond)
 
 \<comment> \<open>While the parallel composition of traceless functions doesn't make much sense, this
    still might be useful to handle trivial goals as part of a proof by contradiction.\<close>
-lemma no_trace_parallel:
+lemma no_trace_parallel[no_trace_cond]:
   "\<lbrakk> no_trace f; no_trace g \<rbrakk> \<Longrightarrow> no_trace (parallel f g)"
   by (fastforce simp: parallel_def2 no_trace_def)
 
-lemmas no_trace_all[wp, iff] =
-  no_trace_prim no_trace_select no_trace_extra no_trace_alt no_trace_when no_trace_unless
-  no_trace_case_option no_trace_if no_trace_apply no_trace_liftM no_trace_assertE no_trace_whenE
-  no_trace_unlessE no_trace_throwError no_trace_throw_opt no_trace_liftE no_trace_gets_the
-  no_trace_bindE no_trace_gets_map no_trace_state_assert no_trace_condition no_trace_mapM
-  no_trace_catch no_trace_state_select no_trace_liftME no_trace_handle' no_trace_handleE
-  no_trace_handle_elseE no_trace_sequence no_trace_sequence_x no_trace_sequenceE no_trace_sequenceE_x
-  no_trace_mapM_x no_trace_mapME no_trace_mapME_x no_trace_filterM no_trace_zipWithM_x
-  no_trace_zipWithM no_trace_foldM no_trace_foldME no_trace_maybeM no_trace_notM no_trace_ifM
-  no_trace_ifME no_trace_whenM no_trace_orM no_trace_andM no_trace_parallel
+(* not everything [simp] by default, because side conditions can slow down simp a lot *)
+lemmas no_trace[wp, intro!] = no_trace_terminal no_trace_cond
+lemmas [simp] = no_trace_terminal
 
 end

--- a/lib/Monads/trace/Trace_No_Trace.thy
+++ b/lib/Monads/trace/Trace_No_Trace.thy
@@ -50,19 +50,20 @@ lemma no_trace_prim:
   "no_trace (modify f)"
   "no_trace (return v)"
   "no_trace fail"
+  "no_trace (returnOk v)"
   by (simp_all add: no_trace_def get_def put_def modify_def bind_def
-                    return_def select_def fail_def)
+                    return_def select_def fail_def returnOk_def)
 
 lemma no_trace_select:
   "no_trace (select S)"
   by (clarsimp simp add: no_trace_def select_def)
 
 lemma no_trace_bind:
-  "no_trace f \<Longrightarrow> \<forall>rv. no_trace (g rv)
-    \<Longrightarrow> no_trace (do rv \<leftarrow> f; g rv od)"
+  "\<lbrakk>no_trace f; \<forall>rv. no_trace (g rv)\<rbrakk>
+   \<Longrightarrow> no_trace (do rv \<leftarrow> f; g rv od)"
   apply (subst no_trace_def)
-  apply (clarsimp simp add: bind_def split: tmres.split_asm;
-    auto dest: no_traceD[rotated])
+  apply (clarsimp simp: bind_def split: tmres.split_asm;
+         fastforce dest: no_traceD)
   done
 
 lemma no_trace_extra:
@@ -72,6 +73,270 @@ lemma no_trace_extra:
   by (simp_all add: gets_def assert_def assert_opt_def no_trace_bind no_trace_prim
              split: option.split)
 
-lemmas no_trace_all[wp, iff] = no_trace_prim no_trace_select no_trace_extra
+lemma no_trace_alt:
+  "\<lbrakk> no_trace f; no_trace g \<rbrakk> \<Longrightarrow> no_trace (f \<sqinter> g)"
+  apply (subst no_trace_def)
+  apply (clarsimp simp add: alternative_def;
+         fastforce dest: no_traceD)
+  done
+
+lemma no_trace_when:
+  "\<lbrakk>P \<Longrightarrow> no_trace f\<rbrakk> \<Longrightarrow> no_trace (when P f)"
+  by (simp add: when_def no_trace_prim)
+
+lemma no_trace_unless:
+  "\<lbrakk>\<not>P \<Longrightarrow> no_trace f\<rbrakk> \<Longrightarrow> no_trace (unless P f)"
+  by (simp add: unless_def when_def no_trace_prim)
+
+lemma no_trace_case_option:
+  assumes f: "no_trace f"
+  assumes g: "\<And>x. no_trace (g x)"
+  shows "no_trace (case_option f g x)"
+  by (clarsimp simp: f g split: option.split)
+
+lemma no_trace_if:
+  "\<lbrakk> P \<Longrightarrow> no_trace f; \<not>P \<Longrightarrow> no_trace g \<rbrakk> \<Longrightarrow> no_trace (if P then f else g)"
+  by simp
+
+lemma no_trace_apply:
+  "no_trace (f (g x)) \<Longrightarrow> no_trace (f $ g x)"
+  by simp
+
+\<comment> \<open>FIXME: make proof nicer\<close>
+lemma no_trace_liftM_eq[simp]:
+  "no_trace (liftM f m) = no_trace m"
+  apply (clarsimp simp: no_trace_def bind_def liftM_def return_def split_def
+                 split: tmres.split_asm)
+  apply safe
+     apply (drule_tac x=tr in spec)
+     apply (drule_tac x="map_tmres id f res" in spec)
+     apply (drule mp)
+      apply (rule exI)
+      apply (erule rev_bexI)
+      apply (clarsimp split: tmres.splits)
+     apply clarsimp
+    apply (drule spec, drule spec, drule mp, rule exI, erule rev_bexI)
+     apply (auto split: tmres.splits)
+  done
+
+lemma no_trace_liftM:
+  "no_trace m \<Longrightarrow> no_trace (liftM f m)"
+  by simp
+
+lemma no_trace_assertE:
+  "no_trace (assertE P)"
+  by (simp add: assertE_def no_trace_prim)
+
+lemma no_trace_whenE:
+  "\<lbrakk> G \<Longrightarrow> no_trace f \<rbrakk> \<Longrightarrow> no_trace (whenE G f)"
+  by (simp add: whenE_def no_trace_prim)
+
+lemma no_trace_unlessE:
+  "\<lbrakk> \<not> G \<Longrightarrow> no_trace f \<rbrakk> \<Longrightarrow> no_trace (unlessE G f)"
+  by (simp add: unlessE_def no_trace_prim)
+
+lemma no_trace_throwError:
+  "no_trace (throwError e)"
+  by (simp add: throwError_def no_trace_prim)
+
+lemma no_trace_throw_opt:
+  "no_trace (throw_opt ex x)"
+  unfolding throw_opt_def
+  by (fastforce intro: no_trace_prim no_trace_throwError split: option.splits)
+
+lemma no_trace_liftE:
+  "no_trace f \<Longrightarrow> no_trace (liftE f)"
+  unfolding liftE_def by (wpsimp wp: no_trace_bind no_trace_prim)
+
+lemma no_trace_gets_the:
+  "no_trace (gets_the f)"
+  unfolding gets_the_def
+  by (wpsimp wp: no_trace_bind no_trace_extra)
+
+lemma no_trace_lift:
+  "(\<And>y. x = Inr y \<Longrightarrow> no_trace (f y)) \<Longrightarrow> no_trace (lift f x)"
+  unfolding lift_def
+  by (wpsimp wp: no_trace_throwError split: sum.splits)
+
+lemma no_trace_bindE:
+  "\<lbrakk> no_trace f; \<And>rv. no_trace (g rv)\<rbrakk>
+     \<Longrightarrow> no_trace (f >>=E g)"
+  unfolding bindE_def
+  by (wpsimp wp: no_trace_bind no_trace_lift)
+
+lemma no_trace_gets_map:
+  "no_trace (gets_map f p)"
+  unfolding gets_map_def by (wpsimp wp: no_trace_bind no_trace_extra)
+
+lemma no_trace_state_assert:
+  "no_trace (state_assert P)"
+  unfolding state_assert_def
+  by (wpsimp wp: no_trace_bind no_trace_prim no_trace_extra)
+
+lemma no_trace_condition:
+  "\<lbrakk>no_trace A; no_trace B\<rbrakk> \<Longrightarrow> no_trace (condition C A B)"
+  unfolding condition_def no_trace_def
+  apply clarsimp
+  apply fastforce
+  done
+
+lemma no_trace_mapM:
+  assumes m: "\<And>x. x \<in> set xs \<Longrightarrow> no_trace (m x)"
+  shows "no_trace (mapM m xs)"
+  using m
+proof (induct xs)
+  case Nil
+  thus ?case by (simp add: mapM_def sequence_def no_trace_prim)
+next
+  case Cons
+  have P: "\<And>m x xs. mapM m (x # xs) = (do y \<leftarrow> m x; ys \<leftarrow> (mapM m xs); return (y # ys) od)"
+    by (simp add: mapM_def sequence_def Let_def)
+  from Cons
+  show ?case
+    apply (simp add: P)
+    apply (wpsimp wp: no_trace_bind no_trace_prim)
+    done
+qed
+
+lemma no_trace_catch:
+  "\<lbrakk> no_trace f; \<And>x. no_trace (g x) \<rbrakk> \<Longrightarrow> no_trace (catch f g)"
+  unfolding catch_def
+  by (wpsimp wp: no_trace_bind no_trace_prim split: sum.split)
+
+lemma no_trace_state_select:
+  "no_trace (state_select F)"
+  unfolding state_select_def2
+  by (wpsimp wp: no_trace_bind no_trace_prim no_trace_extra no_trace_select)
+
+lemma no_trace_liftME:
+  "no_trace m \<Longrightarrow> no_trace (liftME f m)"
+  unfolding liftME_def
+  by (wpsimp wp: no_trace_bindE no_trace_prim)
+
+lemma no_trace_handle':
+  "\<lbrakk>no_trace f; \<And>e. no_trace (handler e)\<rbrakk> \<Longrightarrow> no_trace (f <handle2> handler)"
+  unfolding handleE'_def
+  by (wpsimp wp: no_trace_bind no_trace_prim split: sum.split)
+
+lemma no_trace_handleE:
+  "\<lbrakk> no_trace L; \<And>r. no_trace (R r) \<rbrakk> \<Longrightarrow> no_trace (L <handle> R)"
+  unfolding handleE_def
+  by (simp add: no_trace_handle')
+
+lemma no_trace_handle_elseE:
+  "\<lbrakk> no_trace f; \<And>r. no_trace (g r); \<And>r. no_trace (h r) \<rbrakk> \<Longrightarrow> no_trace (f <handle> g <else> h)"
+  unfolding handle_elseE_def
+  by (wpsimp wp: no_trace_bind no_trace_prim split: sum.split)
+
+lemma no_trace_sequence:
+  "(\<And>m. m \<in> set ms \<Longrightarrow> no_trace m) \<Longrightarrow> no_trace (sequence ms)"
+  unfolding sequence_def
+  by (induct ms; wpsimp wp: no_trace_prim no_trace_bind)
+
+lemma no_trace_sequence_x:
+  "(\<And>m. m \<in> set ms \<Longrightarrow> no_trace m) \<Longrightarrow> no_trace (sequence_x ms)"
+  unfolding sequence_x_def
+  by (induct ms; wpsimp wp: no_trace_prim no_trace_bind)
+
+lemma no_trace_sequenceE:
+  "(\<And>m. m \<in> set ms \<Longrightarrow> no_trace m) \<Longrightarrow> no_trace (sequenceE ms)"
+  unfolding sequenceE_def
+  by (induct ms; wpsimp wp: no_trace_prim no_trace_bindE)
+
+lemma no_trace_sequenceE_x:
+  "(\<And>m. m \<in> set ms \<Longrightarrow> no_trace m) \<Longrightarrow> no_trace (sequenceE_x ms)"
+  unfolding sequenceE_x_def
+  by (induct ms; wpsimp wp: no_trace_prim no_trace_bindE)
+
+lemma no_trace_mapM_x:
+  "(\<And>m. m \<in> f ` set ms \<Longrightarrow> no_trace m) \<Longrightarrow> no_trace (mapM_x f ms)"
+  unfolding mapM_x_def
+  by (fastforce intro: no_trace_sequence_x)
+
+lemma no_trace_mapME:
+  "(\<And>m. m \<in> f ` set xs \<Longrightarrow> no_trace m) \<Longrightarrow> no_trace (mapME f xs)"
+  unfolding mapME_def
+  by (fastforce intro: no_trace_sequenceE)
+
+lemma no_trace_mapME_x:
+  "(\<And>m'. m' \<in> f ` set xs \<Longrightarrow> no_trace m') \<Longrightarrow> no_trace (mapME_x f xs)"
+  unfolding mapME_x_def
+  by (fastforce intro: no_trace_sequenceE_x)
+
+lemma no_trace_filterM:
+  "(\<And>m. m \<in> set ms \<Longrightarrow> no_trace (P m)) \<Longrightarrow> no_trace (filterM P ms)"
+  by (induct ms; wpsimp wp: no_trace_prim no_trace_bind split_del: if_split)
+
+lemma no_trace_zipWithM_x:
+  "(\<And>x y. no_trace (f x y)) \<Longrightarrow> no_trace (zipWithM_x f xs ys)"
+  unfolding zipWithM_x_def zipWith_def
+  by (fastforce intro: no_trace_sequence_x)
+
+lemma no_trace_zipWithM:
+  "(\<And>x y. no_trace (f x y)) \<Longrightarrow> no_trace (zipWithM f xs ys)"
+  unfolding zipWithM_def zipWith_def
+  by (fastforce intro: no_trace_sequence)
+
+lemma no_trace_foldM:
+  "(\<And>x y. no_trace (m x y)) \<Longrightarrow> no_trace (foldM m xs a)"
+  unfolding foldM_def
+  by (induct xs; wpsimp wp: no_trace_prim no_trace_bind)
+
+lemma no_trace_foldME:
+  "(\<And>x y. no_trace (m x y)) \<Longrightarrow> no_trace (foldME m a xs)"
+  unfolding foldME_def
+  by (induct xs; wpsimp wp: no_trace_prim no_trace_bindE)
+
+lemma no_trace_maybeM:
+  "\<forall>x. no_trace (f x) \<Longrightarrow> no_trace (maybeM f t)"
+  unfolding maybeM_def
+  by (fastforce intro: no_trace_prim split: option.splits)
+
+lemma no_trace_notM:
+  "no_trace A \<Longrightarrow> no_trace (notM A)"
+  unfolding notM_def
+  by (wpsimp wp: no_trace_bind no_trace_prim)
+
+lemma no_trace_ifM:
+  "\<lbrakk> no_trace P; no_trace a; no_trace b \<rbrakk> \<Longrightarrow> no_trace (ifM P a b)"
+  unfolding ifM_def
+  by (wpsimp wp: no_trace_bind)
+
+lemma no_trace_ifME:
+  "\<lbrakk> no_trace P; no_trace a; no_trace b \<rbrakk> \<Longrightarrow> no_trace (ifME P a b)"
+  unfolding ifME_def
+  by (wpsimp wp: no_trace_bindE)
+
+lemma no_trace_whenM:
+  "\<lbrakk> no_trace P; no_trace f \<rbrakk> \<Longrightarrow> no_trace (whenM P f)"
+  unfolding whenM_def
+  by (wpsimp wp: no_trace_ifM no_trace_prim)
+
+lemma no_trace_orM:
+  "\<lbrakk> no_trace A; no_trace B \<rbrakk> \<Longrightarrow> no_trace (orM A B)"
+  unfolding orM_def
+  by (wpsimp wp: no_trace_ifM no_trace_prim)
+
+lemma no_trace_andM:
+  "\<lbrakk> no_trace A; no_trace B \<rbrakk> \<Longrightarrow> no_trace (andM A B)"
+  unfolding andM_def
+  by (wpsimp wp: no_trace_ifM no_trace_prim)
+
+\<comment> \<open>While the parallel composition of traceless functions doesn't make much sense, this
+   still might be useful to handle trivial goals as part of a proof by contradiction.\<close>
+lemma no_trace_parallel:
+  "\<lbrakk> no_trace f; no_trace g \<rbrakk> \<Longrightarrow> no_trace (parallel f g)"
+  by (fastforce simp: parallel_def2 no_trace_def)
+
+lemmas no_trace_all[wp, iff] =
+  no_trace_prim no_trace_select no_trace_extra no_trace_alt no_trace_when no_trace_unless
+  no_trace_case_option no_trace_if no_trace_apply no_trace_liftM no_trace_assertE no_trace_whenE
+  no_trace_unlessE no_trace_throwError no_trace_throw_opt no_trace_liftE no_trace_gets_the
+  no_trace_bindE no_trace_gets_map no_trace_state_assert no_trace_condition no_trace_mapM
+  no_trace_catch no_trace_state_select no_trace_liftME no_trace_handle' no_trace_handleE
+  no_trace_handle_elseE no_trace_sequence no_trace_sequence_x no_trace_sequenceE no_trace_sequenceE_x
+  no_trace_mapM_x no_trace_mapME no_trace_mapME_x no_trace_filterM no_trace_zipWithM_x
+  no_trace_zipWithM no_trace_foldM no_trace_foldME no_trace_maybeM no_trace_notM no_trace_ifM
+  no_trace_ifME no_trace_whenM no_trace_orM no_trace_andM no_trace_parallel
 
 end

--- a/lib/Monads/trace/Trace_Prefix_Closed.thy
+++ b/lib/Monads/trace/Trace_Prefix_Closed.thy
@@ -1,0 +1,101 @@
+(*
+ * Copyright 2023, Proofcraft Pty Ltd
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ *)
+
+theory Trace_Prefix_Closed
+  imports
+    Trace_No_Trace
+    Trace_Monad_Equations
+    WPSimp
+begin
+
+subsection "Prefix Closed"
+
+definition prefix_closed :: "('s, 'a) tmonad \<Rightarrow> bool" where
+  "prefix_closed f = (\<forall>s. \<forall>x xs. (x # xs) \<in> fst ` f s \<longrightarrow> (xs, Incomplete) \<in> f s)"
+
+lemmas prefix_closedD1 = prefix_closed_def[THEN iffD1, rule_format]
+
+lemma in_fst_snd_image_eq:
+  "x \<in> fst ` S = (\<exists>y. (x, y) \<in> S)"
+  "y \<in> snd ` S = (\<exists>x. (x, y) \<in> S)"
+  by (auto elim: image_eqI[rotated])
+
+lemma in_fst_snd_image:
+  "(x, y) \<in> S \<Longrightarrow> x \<in> fst ` S"
+  "(x, y) \<in> S \<Longrightarrow> y \<in> snd ` S"
+  by (auto simp: in_fst_snd_image_eq)
+
+lemmas prefix_closedD = prefix_closedD1[OF _ in_fst_snd_image(1)]
+
+lemma no_trace_prefix_closed:
+  "no_trace f \<Longrightarrow> prefix_closed f"
+  by (auto simp add: prefix_closed_def dest: no_trace_emp)
+
+
+subsection \<open>Rules\<close>
+
+lemma prefix_closed_bind:
+  "\<lbrakk>prefix_closed f; \<forall>x. prefix_closed (g x)\<rbrakk> \<Longrightarrow> prefix_closed (f >>= g)"
+  apply (subst prefix_closed_def, clarsimp simp: bind_def)
+  apply (auto simp: Cons_eq_append_conv split: tmres.split_asm
+             dest!: prefix_closedD[rotated];
+         fastforce elim: rev_bexI)
+  done
+
+lemmas prefix_closed_bind[rule_format, wp_split]
+
+lemma prefix_closed_put_trace_elem[iff]:
+  "prefix_closed (put_trace_elem x)"
+  by (clarsimp simp: prefix_closed_def put_trace_elem_def)
+
+lemma prefix_closed_return[iff]:
+  "prefix_closed (return x)"
+  by (simp add: prefix_closed_def return_def)
+
+lemma prefix_closed_put_trace[iff]:
+  "prefix_closed (put_trace tr)"
+  by (induct tr; clarsimp simp: prefix_closed_bind)
+
+lemma prefix_closed_select[iff]:
+  "prefix_closed (select S)"
+  by (simp add: prefix_closed_def select_def image_def)
+
+lemma prefix_closed_mapM[rule_format, wp_split]:
+  "(\<forall>x \<in> set xs. prefix_closed (f x)) \<Longrightarrow> prefix_closed (mapM f xs)"
+  apply (induct xs)
+   apply (simp add: mapM_def sequence_def)
+  apply (clarsimp simp: mapM_Cons)
+  apply (intro prefix_closed_bind allI; clarsimp)
+  done
+
+lemmas modify_prefix_closed[simp] = no_trace_prefix_closed[OF no_trace_all(3)]
+
+lemmas await_prefix_closed[simp] = Await_sync_twp[THEN validI_prefix_closed]
+
+lemma repeat_n_prefix_closed[intro!]:
+  "prefix_closed f \<Longrightarrow> prefix_closed (repeat_n n f)"
+  apply (induct n; simp)
+  apply (auto intro: prefix_closed_bind)
+  done
+
+lemma repeat_prefix_closed[intro!]:
+  "prefix_closed f \<Longrightarrow> prefix_closed (repeat f)"
+  apply (simp add: repeat_def)
+  apply (rule prefix_closed_bind; clarsimp)
+  done
+
+lemma parallel_prefix_closed[wp_split]:
+  "\<lbrakk>prefix_closed f; prefix_closed g\<rbrakk>
+   \<Longrightarrow> prefix_closed (parallel f g)"
+  apply (subst prefix_closed_def, clarsimp simp: parallel_def)
+  apply (subst (asm) zip.zip_Cons)
+  apply (clarsimp split: list.splits)
+  apply (drule(1) prefix_closedD)+
+  apply fastforce
+  done
+
+end

--- a/lib/Monads/trace/Trace_Prefix_Closed.thy
+++ b/lib/Monads/trace/Trace_Prefix_Closed.thy
@@ -9,7 +9,7 @@ theory Trace_Prefix_Closed
   imports
     Trace_No_Trace
     Trace_Monad_Equations
-    WPSimp
+    Eisbach_Tools.Rule_By_Method
 begin
 
 subsection "Prefix Closed"
@@ -36,59 +36,247 @@ lemma no_trace_prefix_closed:
   by (auto simp add: prefix_closed_def dest: no_trace_emp)
 
 
+subsection \<open>Set up for @{method wp}\<close>
+
+lemma prefix_closed_is_triple[wp_trip]:
+  "prefix_closed f = triple_judgement \<top> f (\<lambda>() f. id prefix_closed f)"
+  by (simp add: triple_judgement_def split: unit.split)
+
+
 subsection \<open>Rules\<close>
 
-lemma prefix_closed_bind:
-  "\<lbrakk>prefix_closed f; \<forall>x. prefix_closed (g x)\<rbrakk> \<Longrightarrow> prefix_closed (f >>= g)"
+(*
+  Collect generic prefix_closed lemmas here:
+   - naming convention is prefix_closed_NAME.
+   - add lemmas with assumptions to [prefix_closed_cond] set
+   - add lemmas without assumption to [prefix_closed_terminal] set
+*)
+
+named_theorems prefix_closed_terminal
+named_theorems prefix_closed_cond
+
+lemmas [prefix_closed_terminal] = no_trace_terminal[THEN no_trace_prefix_closed]
+
+lemma prefix_closed_bind[wp_split]:
+  "\<lbrakk>prefix_closed f; \<And>x. prefix_closed (g x)\<rbrakk> \<Longrightarrow> prefix_closed (f >>= g)"
   apply (subst prefix_closed_def, clarsimp simp: bind_def)
-  apply (auto simp: Cons_eq_append_conv split: tmres.split_asm
-             dest!: prefix_closedD[rotated];
-         fastforce elim: rev_bexI)
+  apply (auto 4 4 simp: Cons_eq_append_conv split: tmres.split_asm
+                 dest!: prefix_closedD[rotated] elim: rev_bexI)
   done
 
-lemmas prefix_closed_bind[rule_format, wp_split]
+lemma prefix_closed_case_option[prefix_closed_cond]:
+  assumes f: "prefix_closed f"
+  assumes g: "\<And>x. prefix_closed (g x)"
+  shows "prefix_closed (case_option f g x)"
+  by (clarsimp simp: f g split: option.split)
 
-lemma prefix_closed_put_trace_elem[iff]:
+lemma prefix_closed_alt[prefix_closed_cond]:
+  "\<lbrakk> prefix_closed f; prefix_closed g \<rbrakk> \<Longrightarrow> prefix_closed (f \<sqinter> g)"
+  apply (subst prefix_closed_def)
+  apply (clarsimp simp add: alternative_def;
+         fastforce dest: prefix_closedD)
+  done
+
+lemma prefix_closed_when[prefix_closed_cond]:
+  "\<lbrakk>P \<Longrightarrow> prefix_closed f\<rbrakk> \<Longrightarrow> prefix_closed (when P f)"
+  by (simp add: when_def prefix_closed_terminal)
+
+lemma prefix_closed_unless[prefix_closed_cond]:
+  "\<lbrakk>\<not>P \<Longrightarrow> prefix_closed f\<rbrakk> \<Longrightarrow> prefix_closed (unless P f)"
+  by (simp add: unless_def when_def prefix_closed_terminal)
+
+lemma prefix_closed_if[prefix_closed_cond]:
+  "\<lbrakk> P \<Longrightarrow> prefix_closed f; \<not>P \<Longrightarrow> prefix_closed g \<rbrakk> \<Longrightarrow> prefix_closed (if P then f else g)"
+  by simp
+
+lemma prefix_closed_apply[prefix_closed_cond]:
+  "prefix_closed (f (g x)) \<Longrightarrow> prefix_closed (f $ g x)"
+  by simp
+
+lemma prefix_closed_liftM[prefix_closed_cond]:
+  "prefix_closed m \<Longrightarrow> prefix_closed (liftM f m)"
+  by (wpsimp simp: liftM_def wp: prefix_closed_terminal)
+
+lemma prefix_closed_whenE[prefix_closed_cond]:
+  "\<lbrakk> G \<Longrightarrow> prefix_closed f \<rbrakk> \<Longrightarrow> prefix_closed (whenE G f)"
+  by (simp add: whenE_def prefix_closed_terminal)
+
+lemma prefix_closed_unlessE[prefix_closed_cond]:
+  "\<lbrakk> \<not> G \<Longrightarrow> prefix_closed f \<rbrakk> \<Longrightarrow> prefix_closed (unlessE G f)"
+  by (simp add: unlessE_def prefix_closed_terminal)
+
+lemma prefix_closed_liftE[prefix_closed_cond]:
+  "prefix_closed f \<Longrightarrow> prefix_closed (liftE f)"
+  unfolding liftE_def by (wpsimp wp: prefix_closed_terminal)
+
+lemma prefix_closed_lift[prefix_closed_cond]:
+  "\<lbrakk>\<And>y. x = Inr y \<Longrightarrow> prefix_closed (f y)\<rbrakk> \<Longrightarrow> prefix_closed (lift f x)"
+  unfolding lift_def
+  by (wpsimp wp: prefix_closed_terminal split: sum.splits)
+
+lemma prefix_closed_bindE[wp_split]:
+  "\<lbrakk> prefix_closed f; \<And>rv. prefix_closed (g rv)\<rbrakk> \<Longrightarrow> prefix_closed (f >>=E g)"
+  unfolding bindE_def
+  by (wpsimp wp: prefix_closed_cond)
+
+lemma prefix_closed_condition[prefix_closed_cond]:
+  "\<lbrakk>prefix_closed A; prefix_closed B\<rbrakk> \<Longrightarrow> prefix_closed (condition C A B)"
+  unfolding condition_def prefix_closed_def
+  apply clarsimp
+  done
+
+lemma prefix_closed_mapM[prefix_closed_cond]:
+  "\<lbrakk>\<And>x. x \<in> set xs \<Longrightarrow> prefix_closed (f x)\<rbrakk> \<Longrightarrow> prefix_closed (mapM f xs)"
+  apply (induct xs)
+   apply (simp add: mapM_def sequence_def prefix_closed_terminal)
+  apply (clarsimp simp: mapM_Cons)
+  apply (wpsimp wp: prefix_closed_terminal)
+  done
+
+lemma prefix_closed_catch[prefix_closed_cond]:
+  "\<lbrakk> prefix_closed f; \<And>x. prefix_closed (g x) \<rbrakk> \<Longrightarrow> prefix_closed (catch f g)"
+  unfolding catch_def
+  by (wpsimp wp: prefix_closed_terminal split: sum.split)
+
+lemma prefix_closed_liftME[prefix_closed_cond]:
+  "prefix_closed m \<Longrightarrow> prefix_closed (liftME f m)"
+  unfolding liftME_def
+  by (wpsimp wp: prefix_closed_terminal)
+
+lemma prefix_closed_handle'[prefix_closed_cond]:
+  "\<lbrakk>prefix_closed f; \<And>e. prefix_closed (handler e)\<rbrakk> \<Longrightarrow> prefix_closed (f <handle2> handler)"
+  unfolding handleE'_def
+  by (wpsimp wp: prefix_closed_terminal split: sum.split)
+
+lemma prefix_closed_handleE[prefix_closed_cond]:
+  "\<lbrakk> prefix_closed L; \<And>r. prefix_closed (R r) \<rbrakk> \<Longrightarrow> prefix_closed (L <handle> R)"
+  unfolding handleE_def
+  by (simp add: prefix_closed_cond)
+
+lemma prefix_closed_handle_elseE[prefix_closed_cond]:
+  "\<lbrakk> prefix_closed f; \<And>r. prefix_closed (g r); \<And>r. prefix_closed (h r) \<rbrakk> \<Longrightarrow> prefix_closed (f <handle> g <else> h)"
+  unfolding handle_elseE_def
+  by (wpsimp wp: prefix_closed_terminal split: sum.split)
+
+lemma prefix_closed_sequence[prefix_closed_cond]:
+  "(\<And>m. m \<in> set ms \<Longrightarrow> prefix_closed m) \<Longrightarrow> prefix_closed (sequence ms)"
+  unfolding sequence_def
+  by (induct ms; wpsimp wp: prefix_closed_terminal)
+
+lemma prefix_closed_sequence_x[prefix_closed_cond]:
+  "(\<And>m. m \<in> set ms \<Longrightarrow> prefix_closed m) \<Longrightarrow> prefix_closed (sequence_x ms)"
+  unfolding sequence_x_def
+  by (induct ms; wpsimp wp: prefix_closed_terminal)
+
+lemma prefix_closed_sequenceE[prefix_closed_cond]:
+  "(\<And>m. m \<in> set ms \<Longrightarrow> prefix_closed m) \<Longrightarrow> prefix_closed (sequenceE ms)"
+  unfolding sequenceE_def
+  by (induct ms; wpsimp wp: prefix_closed_terminal)
+
+lemma prefix_closed_sequenceE_x[prefix_closed_cond]:
+  "(\<And>m. m \<in> set ms \<Longrightarrow> prefix_closed m) \<Longrightarrow> prefix_closed (sequenceE_x ms)"
+  unfolding sequenceE_x_def
+  by (induct ms; wpsimp wp: prefix_closed_terminal)
+
+lemma prefix_closed_mapM_x[prefix_closed_cond]:
+  "(\<And>m. m \<in> f ` set ms \<Longrightarrow> prefix_closed m) \<Longrightarrow> prefix_closed (mapM_x f ms)"
+  unfolding mapM_x_def
+  by (fastforce intro: prefix_closed_sequence_x)
+
+lemma prefix_closed_mapME[prefix_closed_cond]:
+  "(\<And>m. m \<in> f ` set xs \<Longrightarrow> prefix_closed m) \<Longrightarrow> prefix_closed (mapME f xs)"
+  unfolding mapME_def
+  by (fastforce intro: prefix_closed_sequenceE)
+
+lemma prefix_closed_mapME_x[prefix_closed_cond]:
+  "(\<And>m'. m' \<in> f ` set xs \<Longrightarrow> prefix_closed m') \<Longrightarrow> prefix_closed (mapME_x f xs)"
+  unfolding mapME_x_def
+  by (fastforce intro: prefix_closed_sequenceE_x)
+
+lemma prefix_closed_filterM[prefix_closed_cond]:
+  "(\<And>m. m \<in> set ms \<Longrightarrow> prefix_closed (P m)) \<Longrightarrow> prefix_closed (filterM P ms)"
+  by (induct ms; wpsimp wp: prefix_closed_terminal split_del: if_split)
+
+lemma prefix_closed_zipWithM_x[prefix_closed_cond]:
+  "(\<And>x y. prefix_closed (f x y)) \<Longrightarrow> prefix_closed (zipWithM_x f xs ys)"
+  unfolding zipWithM_x_def zipWith_def
+  by (fastforce intro: prefix_closed_sequence_x)
+
+lemma prefix_closed_zipWithM[prefix_closed_cond]:
+  "(\<And>x y. prefix_closed (f x y)) \<Longrightarrow> prefix_closed (zipWithM f xs ys)"
+  unfolding zipWithM_def zipWith_def
+  by (fastforce intro: prefix_closed_sequence)
+
+lemma prefix_closed_foldM[prefix_closed_cond]:
+  "(\<And>x y. prefix_closed (m x y)) \<Longrightarrow> prefix_closed (foldM m xs a)"
+  unfolding foldM_def
+  by (induct xs; wpsimp wp: prefix_closed_terminal)
+
+lemma prefix_closed_foldME[prefix_closed_cond]:
+  "(\<And>x y. prefix_closed (m x y)) \<Longrightarrow> prefix_closed (foldME m a xs)"
+  unfolding foldME_def
+  by (induct xs; wpsimp wp: prefix_closed_terminal)
+
+lemma prefix_closed_maybeM[prefix_closed_cond]:
+  "\<forall>x. prefix_closed (f x) \<Longrightarrow> prefix_closed (maybeM f t)"
+  unfolding maybeM_def
+  by (fastforce intro: prefix_closed_terminal split: option.splits)
+
+lemma prefix_closed_notM[prefix_closed_cond]:
+  "prefix_closed A \<Longrightarrow> prefix_closed (notM A)"
+  unfolding notM_def
+  by (wpsimp wp: prefix_closed_terminal)
+
+lemma prefix_closed_ifM[prefix_closed_cond]:
+  "\<lbrakk> prefix_closed P; prefix_closed a; prefix_closed b \<rbrakk> \<Longrightarrow> prefix_closed (ifM P a b)"
+  unfolding ifM_def by wpsimp
+
+lemma prefix_closed_ifME[prefix_closed_cond]:
+  "\<lbrakk> prefix_closed P; prefix_closed a; prefix_closed b \<rbrakk> \<Longrightarrow> prefix_closed (ifME P a b)"
+  unfolding ifME_def by wpsimp
+
+lemma prefix_closed_whenM[prefix_closed_cond]:
+  "\<lbrakk> prefix_closed P; prefix_closed f \<rbrakk> \<Longrightarrow> prefix_closed (whenM P f)"
+  unfolding whenM_def
+  by (wpsimp wp: prefix_closed_terminal prefix_closed_cond)
+
+lemma prefix_closed_orM[prefix_closed_cond]:
+  "\<lbrakk> prefix_closed A; prefix_closed B \<rbrakk> \<Longrightarrow> prefix_closed (orM A B)"
+  unfolding orM_def
+  by (wpsimp wp: prefix_closed_terminal prefix_closed_cond)
+
+lemma prefix_closed_andM[prefix_closed_cond]:
+  "\<lbrakk> prefix_closed A; prefix_closed B \<rbrakk> \<Longrightarrow> prefix_closed (andM A B)"
+  unfolding andM_def
+  by (wpsimp wp: prefix_closed_terminal prefix_closed_cond)
+
+lemma prefix_closed_put_trace_elem[prefix_closed_terminal]:
   "prefix_closed (put_trace_elem x)"
   by (clarsimp simp: prefix_closed_def put_trace_elem_def)
 
-lemma prefix_closed_return[iff]:
-  "prefix_closed (return x)"
-  by (simp add: prefix_closed_def return_def)
-
-lemma prefix_closed_put_trace[iff]:
+lemma prefix_closed_put_trace[prefix_closed_terminal]:
   "prefix_closed (put_trace tr)"
-  by (induct tr; clarsimp simp: prefix_closed_bind)
+  by (induct tr; wpsimp wp: prefix_closed_terminal)
 
-lemma prefix_closed_select[iff]:
-  "prefix_closed (select S)"
-  by (simp add: prefix_closed_def select_def image_def)
+lemma prefix_closed_interference[prefix_closed_terminal]:
+  "prefix_closed interference"
+  by (wpsimp simp: interference_def commit_step_def env_steps_def wp: prefix_closed_terminal)
 
-lemma prefix_closed_mapM[rule_format, wp_split]:
-  "(\<forall>x \<in> set xs. prefix_closed (f x)) \<Longrightarrow> prefix_closed (mapM f xs)"
-  apply (induct xs)
-   apply (simp add: mapM_def sequence_def)
-  apply (clarsimp simp: mapM_Cons)
-  apply (intro prefix_closed_bind allI; clarsimp)
-  done
+lemma prefix_closed_await[prefix_closed_terminal]:
+  "prefix_closed (Await c)"
+  by (wpsimp simp: Await_def wp: prefix_closed_terminal)
 
-lemmas modify_prefix_closed[simp] = no_trace_prefix_closed[OF no_trace_all(3)]
-
-lemmas await_prefix_closed[simp] = Await_sync_twp[THEN validI_prefix_closed]
-
-lemma repeat_n_prefix_closed[intro!]:
+lemma prefix_closed_repeat_n[prefix_closed_cond]:
   "prefix_closed f \<Longrightarrow> prefix_closed (repeat_n n f)"
-  apply (induct n; simp)
-  apply (auto intro: prefix_closed_bind)
-  done
+  by (induct n; wpsimp wp: prefix_closed_terminal)
 
-lemma repeat_prefix_closed[intro!]:
+lemma prefix_closed_repeat[prefix_closed_cond]:
   "prefix_closed f \<Longrightarrow> prefix_closed (repeat f)"
   apply (simp add: repeat_def)
-  apply (rule prefix_closed_bind; clarsimp)
+  apply (wpsimp wp: prefix_closed_terminal prefix_closed_cond)
   done
 
-lemma parallel_prefix_closed[wp_split]:
+lemma prefix_closed_parallel[wp_split]:
   "\<lbrakk>prefix_closed f; prefix_closed g\<rbrakk>
    \<Longrightarrow> prefix_closed (parallel f g)"
   apply (subst prefix_closed_def, clarsimp simp: parallel_def)
@@ -97,5 +285,16 @@ lemma parallel_prefix_closed[wp_split]:
   apply (drule(1) prefix_closedD)+
   apply fastforce
   done
+
+context begin
+(* We want to enforce that prefix_closed_terminal only contains lemmas that have no
+   assumptions. The following thm statement should fail if this is not true. *)
+private lemmas check_no_assumptions_internal = iffD1[OF refl, where P="prefix_closed f" for f]
+thm prefix_closed_terminal[atomized, THEN check_no_assumptions_internal]
+end
+
+(* not everything [simp] by default, because side conditions can slow down simp a lot *)
+lemmas prefix_closed[wp, intro!] = prefix_closed_terminal prefix_closed_cond
+lemmas [simp] = prefix_closed_terminal
 
 end

--- a/lib/Monads/trace/Trace_RG.thy
+++ b/lib/Monads/trace/Trace_RG.thy
@@ -415,7 +415,7 @@ lemma rg_validI:
   and compat: "R \<le> Rf" "R \<le> Rg" "Gf \<le> G" "Gg \<le> G" "Gf \<le> Rg" "Gg \<le> Rf"
   shows "\<lbrace>Pf and Pg\<rbrace>,\<lbrace>R\<rbrace> parallel f g \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv. Qf rv and Qg rv\<rbrace>"
   apply (clarsimp simp: validI_def rely_def pred_conj_def
-                        parallel_prefix_closed validI[THEN validI_prefix_closed])
+                        prefix_closed_parallel validI[THEN validI_prefix_closed])
   apply (drule(3) parallel_rely_induct0[OF _ _ _ validI order_refl order_refl compat])
   apply clarsimp
   apply (drule(2) validI[THEN validI_rvD])+

--- a/lib/Monads/trace/Trace_Total.thy
+++ b/lib/Monads/trace/Trace_Total.thy
@@ -25,7 +25,7 @@ definition validNF ::
   "\<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>! \<equiv> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace> \<and> no_fail P f"
 
 lemma validNF_alt_def:
-  "\<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>! = (\<forall>s. P s \<longrightarrow> ((\<forall>(r', s') \<in> mres (f s). Q r' s') \<and> Failed \<notin> snd ` (f s)))"
+  "\<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>! = (\<forall>s. P s \<longrightarrow> ((\<forall>(r', s') \<in> mres (f s). Q r' s') \<and> \<not> failed (f s)))"
   by (auto simp: validNF_def valid_def no_fail_def)
 
 definition validE_NF ::
@@ -88,7 +88,7 @@ lemma validNF_no_fail:
   by (erule validNFE)
 
 lemma validNF_not_failed:
-  "\<lbrakk> \<lbrace> P \<rbrace> f \<lbrace> Q \<rbrace>!; P s \<rbrakk> \<Longrightarrow> Failed \<notin> snd ` (f s)"
+  "\<lbrakk> \<lbrace> P \<rbrace> f \<lbrace> Q \<rbrace>!; P s \<rbrakk> \<Longrightarrow> \<not> failed (f s)"
   by (clarsimp simp: validNF_def no_fail_def)
 
 lemma use_validNF:
@@ -134,7 +134,7 @@ text \<open>
   Set up combination rules for @{method wp}, which also requires a @{text wp_trip} rule for
   @{const validNF}.\<close>
 definition validNF_property :: "('a \<Rightarrow> 's \<Rightarrow> bool) \<Rightarrow> 's \<Rightarrow> ('s,'a) tmonad \<Rightarrow> bool" where
-  "validNF_property Q s b \<equiv> Failed \<notin> snd ` (b s) \<and> (\<forall>(r', s') \<in> mres (b s). Q r' s')"
+  "validNF_property Q s b \<equiv> \<not> failed (b s) \<and> (\<forall>(r', s') \<in> mres (b s). Q r' s')"
 
 lemma validNF_is_triple[wp_trip]:
   "validNF P f Q = triple_judgement P f (validNF_property Q)"
@@ -308,7 +308,7 @@ definition validE_NF_property ::
   "('a \<Rightarrow> 's \<Rightarrow> bool) \<Rightarrow> ('c \<Rightarrow> 's \<Rightarrow> bool) \<Rightarrow> 's \<Rightarrow> ('s, 'c+'a) tmonad \<Rightarrow> bool"
   where
   "validE_NF_property Q E s b \<equiv>
-   Failed \<notin> snd ` (b s) \<and> (\<forall>(r', s') \<in> mres (b s). case r' of Inl x \<Rightarrow> E x s' | Inr x \<Rightarrow> Q x s')"
+   \<not> failed (b s) \<and> (\<forall>(r', s') \<in> mres (b s). case r' of Inl x \<Rightarrow> E x s' | Inr x \<Rightarrow> Q x s')"
 
 lemma validE_NF_is_triple[wp_trip]:
   "validE_NF P f Q E = triple_judgement P f (validE_NF_property Q E)"

--- a/lib/Monads/trace/Trace_Total.thy
+++ b/lib/Monads/trace/Trace_Total.thy
@@ -202,7 +202,7 @@ lemma validNF_gets[wp]:
 lemma validNF_condition[wp]:
   "\<lbrakk> \<lbrace> Q \<rbrace> A \<lbrace>P\<rbrace>!; \<lbrace> R \<rbrace> B \<lbrace>P\<rbrace>!\<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s. if C s then Q s else R s\<rbrace> condition C A B \<lbrace>P\<rbrace>!"
   by (erule validNFE)+
-     (rule validNF; wpsimp wp: no_fail_condition)
+     (rule validNF; wpsimp)
 
 lemma validNF_assert[wp]:
   "\<lbrace> (\<lambda>s. P) and (R ()) \<rbrace> assert P \<lbrace> R \<rbrace>!"
@@ -344,7 +344,7 @@ lemma validE_NF_handleE[wp]:
 lemma validE_NF_condition[wp]:
   "\<lbrakk> \<lbrace> Q \<rbrace> A \<lbrace>P\<rbrace>,\<lbrace> E \<rbrace>!; \<lbrace> R \<rbrace> B \<lbrace>P\<rbrace>,\<lbrace> E \<rbrace>!\<rbrakk> \<Longrightarrow>
    \<lbrace>\<lambda>s. if C s then Q s else R s\<rbrace> condition C A B \<lbrace>P\<rbrace>,\<lbrace> E \<rbrace>!"
-  by (erule validE_NFE)+ (wpsimp wp: no_fail_condition validE_NF)
+  by (erule validE_NFE)+ (wpsimp wp: validE_NF)
 
 lemma hoare_assume_preNF:
   "(\<And>s. P s \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>!) \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>!"

--- a/lib/concurrency/Atomicity_Lib.thy
+++ b/lib/concurrency/Atomicity_Lib.thy
@@ -438,8 +438,7 @@ lemma not_env_steps_first_interference:
   apply (clarsimp simp: not_env_steps_first_def)
   done
 
-lemmas not_env_steps_first_simple
-    = no_trace_all[THEN not_env_steps_first_no_trace]
+lemmas not_env_steps_first_simple = no_trace_terminal[THEN not_env_steps_first_no_trace]
 
 lemma not_env_steps_first_repeat_n:
   "not_env_steps_first f \<Longrightarrow> not_env_steps_first (repeat_n n f)"
@@ -752,8 +751,6 @@ lemma shuttle_gets_env_step[simplified K_bind_def]:
                    put_trace_elem_def bind_def get_def return_def gets_def put_def)
   apply (clarsimp simp: rely_cond_def reflpD)
   done
-
-lemmas prefix_closed_interference[simp] = interference_twp[THEN validI_prefix_closed]
 
 lemma env_step_twp[wp]:
   "\<lbrace>\<lambda>s0 s. (\<forall>s'. R s0 s' \<longrightarrow> Q () s' s')\<rbrace>,\<lbrace>R\<rbrace> env_step \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"

--- a/lib/concurrency/Prefix_Refinement.thy
+++ b/lib/concurrency/Prefix_Refinement.thy
@@ -543,7 +543,7 @@ lemma is_matching_fragment_validI_disj:
   apply (erule(2) validI_triv_refinement)
   done
 
-lemma rely_prefix_closed:
+lemma prefix_closed_rely:
   "prefix_closed f \<Longrightarrow> prefix_closed (rely f R s0)"
   apply (subst prefix_closed_def, clarsimp simp: rely_def rely_cond_Cons_eq)
   apply (erule(1) prefix_closedD)
@@ -593,7 +593,7 @@ theorem prefix_refinement_parallel:
   apply (subst is_matching_fragment_def, clarsimp)
   apply (frule(1) is_matching_fragment_validI_disj[where g=a and G=Ga], blast)
   apply (frule(1) is_matching_fragment_validI_disj[where g=c and G=Gc], blast)
-  apply (intro conjI parallel_prefix_closed rely_prefix_closed rely_self_closed,
+  apply (intro conjI prefix_closed_parallel prefix_closed_rely rely_self_closed,
     simp_all add: is_matching_fragment_prefix_closed)
      apply (rule self_closed_parallel_fragment,
         (assumption | erule par_tr_fin_principle_triv_refinement[rotated])+)
@@ -772,7 +772,7 @@ lemma env_closed_mbind:
   apply (fastforce elim: image_eqI[rotated])
   done
 
-lemma mbind_prefix_closed:
+lemma prefix_closed_mbind:
   "prefix_closed f
     \<Longrightarrow> \<forall>tr x s' s. (tr, Result (x, s')) \<in> f s \<longrightarrow> prefix_closed (g (last_st_tr tr s0) x)
    \<Longrightarrow> prefix_closed (mbind f g s0)"
@@ -800,7 +800,7 @@ lemma is_matching_fragment_mbind:
         (mbind f_a f_b s0)"
   apply (subst is_matching_fragment_def, clarsimp)
   apply (strengthen env_closed_mbind[where ctr''=ctr', mk_strg I E]
-                    mbind_prefix_closed
+                    prefix_closed_mbind
                     self_closed_mbind[where ctr'="ctr'", mk_strg I E])
   apply (simp add: conj_comms if_bool_eq_conj mres_def split del: if_split)
   apply (intro conjI allI impI; clarsimp?;
@@ -1346,10 +1346,10 @@ lemma prefix_refinement_modify:
 
 lemmas pfx_refn_modifyT = prefix_refinement_modify[where P="\<top>" and Q="\<top>"]
 
-lemmas prefix_refinement_get_pre
-    = prefix_refinement_bind[OF prefix_refinement_get _
-        valid_validI_wp[OF _ get_sp] valid_validI_wp[OF _ get_sp],
-    simplified pred_conj_def no_trace_all, simplified]
+lemmas prefix_refinement_get_pre =
+  prefix_refinement_bind[OF prefix_refinement_get _ valid_validI_wp[OF _ get_sp]
+                            valid_validI_wp[OF _ get_sp],
+                         simplified pred_conj_def, simplified]
 
 lemma prefix_refinement_gets:
   "\<forall>s t. iosr s t \<and> P s \<and> Q t \<longrightarrow> rvr (f s) (f' t)
@@ -1477,7 +1477,7 @@ lemma is_matching_fragment_add_rely:
     \<Longrightarrow> AR' \<le> AR
     \<Longrightarrow> is_matching_fragment sr osr r ctr cres s0 AR' s (rely f AR' s0)"
   apply (frule is_matching_fragment_Nil)
-  apply (clarsimp simp: is_matching_fragment_def rely_prefix_closed
+  apply (clarsimp simp: is_matching_fragment_def prefix_closed_rely
                         rely_self_closed)
   apply (intro conjI)
     apply (erule rely_env_closed)

--- a/lib/concurrency/examples/Peterson_Atomicity.thy
+++ b/lib/concurrency/examples/Peterson_Atomicity.thy
@@ -813,7 +813,7 @@ theorem peterson_proc_system_refinement:
 
 lemma peterson_proc_system_prefix_closed[simp]:
   "prefix_closed (peterson_proc_system)"
-  by (auto intro!: prefix_closed_bind parallel_prefix_closed
+  by (auto intro!: prefix_closed_bind prefix_closed_parallel
              simp: cs_closed peterson_proc_system_def)
 
 theorem peterson_proc_system_mutual_excl:

--- a/lib/concurrency/examples/Plus2_Prefix.thy
+++ b/lib/concurrency/examples/Plus2_Prefix.thy
@@ -147,7 +147,7 @@ theorem plus2_parallel:
     apply (strengthen exI[where x="f(1 := x, 2 := y)" for f x y])
     apply simp
    apply clarsimp
-  apply (intro parallel_prefix_closed prefix_closed_plus2)
+  apply (intro prefix_closed_parallel prefix_closed_plus2)
   done
 
 section \<open>Generalising\<close>
@@ -202,7 +202,7 @@ lemma fold_parallel_par_tr_fin_principle[where xs="rev xs" for xs, simplified]:
 lemma fold_parallel_prefix_closed[where xs="rev xs" for xs, simplified]:
   "\<forall>x \<in> insert x (set xs). prefix_closed x
     \<Longrightarrow> prefix_closed (fold parallel (rev xs) x)"
-  by (induct xs, simp_all add: parallel_prefix_closed)
+  by (induct xs, simp_all add: prefix_closed_parallel)
 
 lemma bipred_disj_top_eq:
   "(Rel or (\<lambda>_ _. True)) = (\<lambda>_ _. True)"

--- a/proof/crefine/RISCV64/VSpace_C.thy
+++ b/proof/crefine/RISCV64/VSpace_C.thy
@@ -345,7 +345,7 @@ lemma corres_symb_exec_unknown_r:
   assumes "\<And>rv. corres_underlying sr nf nf' r P P' a (c rv)"
   shows "corres_underlying sr nf nf' r P P' a (unknown >>= c)"
   apply (simp add: unknown_def)
-  apply (rule corres_symb_exec_r[OF assms]; wp select_inv no_fail_select)
+  apply (rule corres_symb_exec_r[OF assms]; wp select_inv)
   done
 
 lemma isPageTablePTE_def2:

--- a/proof/crefine/X64/VSpace_C.thy
+++ b/proof/crefine/X64/VSpace_C.thy
@@ -448,7 +448,7 @@ lemma corres_symb_exec_unknown_r:
   assumes "\<And>rv. corres_underlying sr nf nf' r P P' a (c rv)"
   shows "corres_underlying sr nf nf' r P P' a (unknown >>= c)"
   apply (simp add: unknown_def)
-  apply (rule corres_symb_exec_r[OF assms]; wp select_inv no_fail_select)
+  apply (rule corres_symb_exec_r[OF assms]; wp select_inv)
   done
 
 lemma lookupPML4Slot'_spec:

--- a/proof/crefine/lib/AutoCorres_C.thy
+++ b/proof/crefine/lib/AutoCorres_C.thy
@@ -921,7 +921,7 @@ lemma terminates_spec_no_fail:
       using spec_result_Normal p_spec by simp
     have L1_call_simpl_no_fail:
       "no_fail (\<lambda>s. P s s) (L1_call_simpl check_termination \<Gamma> f_'proc)"
-      apply (wpsimp simp: L1_call_simpl_def wp: no_fail_select)
+      apply (wpsimp simp: L1_call_simpl_def)
       using terminates normal by auto
     have select_f_L1_call_simpl_no_fail:
       "\<And>s. no_fail (\<lambda>_. P s s) (select_f (L1_call_simpl check_termination \<Gamma> f_'proc s))"
@@ -936,7 +936,7 @@ lemma terminates_spec_no_fail:
       apply (clarsimp simp: ac AC_call_L1_def L2_call_L1_def)
       apply (wpsimp wp_del: select_f_wp)
             apply (rule hoare_strengthen_post[OF select_f_L1_call_simpl_rv], fastforce)
-           apply (wpsimp wp: select_f_L1_call_simpl_no_fail no_fail_select)+
+           apply (wpsimp wp: select_f_L1_call_simpl_no_fail)+
       apply (fastforce simp: nf_pre)
       done
   qed

--- a/proof/invariant-abstract/AARCH64/Machine_AI.thy
+++ b/proof/invariant-abstract/AARCH64/Machine_AI.thy
@@ -150,7 +150,7 @@ lemma no_fail_getActiveIRQ[wp]:
   "no_fail \<top> (getActiveIRQ in_kernel)"
   apply (simp add: getActiveIRQ_def)
   apply (rule no_fail_pre)
-   apply (wp no_fail_select)
+   apply wp
   apply simp
   done
 

--- a/proof/invariant-abstract/ARM/Machine_AI.thy
+++ b/proof/invariant-abstract/ARM/Machine_AI.thy
@@ -317,7 +317,7 @@ lemma no_fail_getActiveIRQ[wp]:
   "no_fail \<top> (getActiveIRQ in_kernel)"
   apply (simp add: getActiveIRQ_def)
   apply (rule no_fail_pre)
-   apply (wp no_fail_select)
+   apply wp
   apply simp
   done
 

--- a/proof/invariant-abstract/ARM_HYP/Machine_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/Machine_AI.thy
@@ -326,7 +326,7 @@ lemma no_fail_getActiveIRQ[wp]:
   "no_fail \<top> (getActiveIRQ in_kernel)"
   apply (simp add: getActiveIRQ_def)
   apply (rule no_fail_pre)
-   apply (wp no_fail_select)
+   apply wp
   apply simp
   done
 

--- a/proof/invariant-abstract/RISCV64/Machine_AI.thy
+++ b/proof/invariant-abstract/RISCV64/Machine_AI.thy
@@ -175,7 +175,7 @@ lemma no_fail_getActiveIRQ[wp]:
   "no_fail \<top> (getActiveIRQ in_kernel)"
   apply (simp add: getActiveIRQ_def)
   apply (rule no_fail_pre)
-   apply (wp no_fail_select)
+   apply wp
   apply simp
   done
 

--- a/proof/invariant-abstract/X64/Machine_AI.thy
+++ b/proof/invariant-abstract/X64/Machine_AI.thy
@@ -175,7 +175,7 @@ lemma no_fail_getActiveIRQ[wp]:
   "no_fail \<top> (getActiveIRQ in_kernel)"
   apply (simp add: getActiveIRQ_def)
   apply (rule no_fail_pre)
-   apply (wp no_fail_select)
+   apply wp
   apply simp
   done
 


### PR DESCRIPTION
This extends the rule sets for the various monad properties (`no_trace`, `no_fail`, etc.) to cover all of the monad primitives that we have. It does not touch the RG rule set.