### PR TITLE
provide a NUM_DOMAINS test override

### DIFF
--- a/.github/workflows/proof-deploy.yml
+++ b/.github/workflows/proof-deploy.yml
@@ -37,6 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         arch: [ARM, ARM_HYP, AARCH64, RISCV64, X64]
+        num_domains: ['1', '']
     # test only most recent push:
     concurrency: l4v-regression-${{ github.ref }}-${{ strategy.job-index }}
     steps:
@@ -45,6 +46,7 @@ jobs:
       with:
         L4V_ARCH: ${{ matrix.arch }}
         xml: ${{ needs.code.outputs.xml }}
+        NUM_DOMAINS: ${{ matrix.num_domains }}
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/weekly-clean.yml
+++ b/.github/workflows/weekly-clean.yml
@@ -18,11 +18,13 @@ jobs:
       fail-fast: false
       matrix:
         arch: [ARM, ARM_HYP, AARCH64, RISCV64, X64]
+        num_domains: ['1', '7', '']
     steps:
     - name: Proofs
       uses: seL4/ci-actions/aws-proofs@master
       with:
         L4V_ARCH: ${{ matrix.arch }}
+        NUM_DOMAINS: ${{ matrix.num_domains }}
         cache_read: ''  # start with empty cache, but write cache back (default)
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/run_tests
+++ b/run_tests
@@ -122,7 +122,9 @@ returncode = 0
 for arch in archs:
     features = os.environ.get("L4V_FEATURES", "")
     plat = os.environ.get("L4V_PLAT", "")
-    print(f"Testing for L4V_ARCH='{arch}', L4V_FEATURES='{features}', L4V_PLAT='{plat}':")
+    num_domains = os.environ.get("INPUT_NUM_DOMAINS", "")
+    print(f"Testing for L4V_ARCH='{arch}', L4V_FEATURES='{features}', L4V_PLAT='{plat}', "
+          f"INPUT_NUM_DOMAINS='{num_domains}'")
 
     os.environ["L4V_ARCH"] = arch
     # Provide L4V_ARCH_IS_ARM for Corres_Test in lib/ROOT

--- a/spec/cspec/c/kernel.mk
+++ b/spec/cspec/c/kernel.mk
@@ -108,6 +108,10 @@ ${OVERLAY}: ${DEFAULT_OVERLAY}
 	@cp $< $@
 endif
 
+ifdef INPUT_NUM_DOMAINS
+KERNEL_CMAKE_EXTRA_OPTIONS += -DKernelNumDomains=${INPUT_NUM_DOMAINS}
+endif
+
 # Initialize the CMake build. We purge the build directory and start again
 # whenever any of the kernel sources change, so that we can reliably pick up
 # changes to the build config.


### PR DESCRIPTION
Setting the environment variable `INPUT_NUM_DOMAINS` will cause the build to override the `KernelNumDomains` setting in the config file with the provided setting. `INPUT_NUM_DOMAINS` is the name we get from the GitHub workflow input with the name `NUM_DOMAINS`.

The second commit switches the test to the following `NUM_DOMAINS` settings:

- PRs: default as in config file, no matrix
- push to master: with NUM_DOMAINS = 1 and default (= '')
- weekly test: with NUM_DOMAINS = 1, 7, and default

The default is 16 in the current config files. 1 leads to structural code changes is the setting most likely to break. 7 is for checking that the proofs also work with a value that is not a power of 2.

This needs seL4/ci-actions#293 to be merged first.