### PR TITLE
github: add num_domains key to artifact upload

### DIFF
--- a/.github/workflows/proof-deploy.yml
+++ b/.github/workflows/proof-deploy.yml
@@ -60,7 +60,7 @@ jobs:
     - name: Upload logs
       uses: actions/upload-artifact@v3
       with:
-        name: logs-${{ matrix.arch }}
+        name: logs-${{ matrix.num_domains }}-${{ matrix.arch }}
         path: logs.tar.xz
 
   deploy:

--- a/.github/workflows/weekly-clean.yml
+++ b/.github/workflows/weekly-clean.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Upload logs
       uses: actions/upload-artifact@v3
       with:
-        name: logs-${{ matrix.arch }}
+        name: logs-${{ matrix.num_domains }}-${{ matrix.arch }}
         path: logs.tar.xz
 
   binary-verification:


### PR DESCRIPTION
If we don't provide the additional name fragment, previous artifacts would be overwritten, which leads to a failure with error message on GitHub.