### PR TITLE
aarch64 cspec+crefine: pt_type ghost state + table array sizes

### DIFF
--- a/spec/abstract/AARCH64/Arch_Structs_A.thy
+++ b/spec/abstract/AARCH64/Arch_Structs_A.thy
@@ -113,48 +113,7 @@ definition pte_base_addr :: "pte \<Rightarrow> paddr" where
 definition ppn_from_pptr :: "obj_ref \<Rightarrow> ppn" where
   "ppn_from_pptr p = ucast (addrFromPPtr p >> pageBits)"
 
-definition vs_index_bits :: nat where
-  "vs_index_bits \<equiv> if config_ARM_PA_SIZE_BITS_40 then 10 else (9::nat)"
-
-lemma vs_index_bits_ge0[simp, intro!]: "0 < vs_index_bits"
-  by (simp add: vs_index_bits_def)
-
-(* A dependent-ish type in Isabelle. We use typedef here instead of value_type so that we can
-   retain a symbolic value (vs_index_bits) for the size of the type instead of getting a plain
-   number such as 9 or 10. *)
-typedef vs_index_len = "{n :: nat. n < vs_index_bits}" by auto
-
-end
-
-instantiation AARCH64_A.vs_index_len :: len0
-begin
-  interpretation Arch .
-  definition len_of_vs_index_len: "len_of (x::vs_index_len itself) \<equiv> CARD(vs_index_len)"
-  instance ..
-end
-
-instantiation AARCH64_A.vs_index_len :: len
-begin
-  interpretation Arch .
-  instance
-  proof
-   show "0 < LENGTH(vs_index_len)"
-     by (simp add: len_of_vs_index_len type_definition.card[OF type_definition_vs_index_len])
-  qed
-end
-
-context Arch begin global_naming AARCH64_A
-
-type_synonym vs_index = "vs_index_len word"
-
-type_synonym pt_index_len = 9
-type_synonym pt_index = "pt_index_len word"
-
-text \<open>Sanity check:\<close>
-lemma length_vs_index_len[simp]:
-  "LENGTH(vs_index_len) = vs_index_bits"
-  by (simp add: len_of_vs_index_len type_definition.card[OF type_definition_vs_index_len])
-
+(* Sanity check for page table type sizes -- ptTranslationBits not yet available at definition site *)
 lemma vs_index_ptTranslationBits:
   "ptTranslationBits VSRootPT_T = LENGTH(vs_index_len)"
   by (simp add: ptTranslationBits_def vs_index_bits_def)

--- a/spec/machine/AARCH64/Platform.thy
+++ b/spec/machine/AARCH64/Platform.thy
@@ -101,5 +101,64 @@ definition irqVTimerEvent :: irq where
 definition pageColourBits :: nat where
   "pageColourBits \<equiv> undefined" \<comment> \<open>not implemented on this platform\<close>
 
+
+section \<open>Page table sizes\<close>
+
+definition vs_index_bits :: nat where
+  "vs_index_bits \<equiv> if config_ARM_PA_SIZE_BITS_40 then 10 else (9::nat)"
+
 end
+
+(* Need to declare code equation outside Arch locale *)
+declare AARCH64.vs_index_bits_def[code]
+
+context Arch begin global_naming AARCH64
+
+lemma vs_index_bits_ge0[simp, intro!]: "0 < vs_index_bits"
+  by (simp add: vs_index_bits_def)
+
+(* A dependent-ish type in Isabelle. We use typedef here instead of value_type so that we can
+   retain a symbolic value (vs_index_bits) for the size of the type instead of getting a plain
+   number such as 9 or 10. *)
+typedef vs_index_len = "{n :: nat. n < vs_index_bits}" by auto
+
+end
+
+instantiation AARCH64.vs_index_len :: len0
+begin
+  interpretation Arch .
+  definition len_of_vs_index_len: "len_of (x::vs_index_len itself) \<equiv> CARD(vs_index_len)"
+  instance ..
+end
+
+instantiation AARCH64.vs_index_len :: len
+begin
+  interpretation Arch .
+  instance
+  proof
+   show "0 < LENGTH(vs_index_len)"
+     by (simp add: len_of_vs_index_len type_definition.card[OF type_definition_vs_index_len])
+  qed
+end
+
+context Arch begin global_naming AARCH64
+
+type_synonym vs_index = "vs_index_len word"
+
+type_synonym pt_index_len = 9
+type_synonym pt_index = "pt_index_len word"
+
+text \<open>Sanity check:\<close>
+lemma length_vs_index_len[simp]:
+  "LENGTH(vs_index_len) = vs_index_bits"
+  by (simp add: len_of_vs_index_len type_definition.card[OF type_definition_vs_index_len])
+
+
+section \<open>C array sizes corresponding to page table sizes\<close>
+
+value_type pt_array_len = "(2::nat) ^ LENGTH(pt_index_len)"
+value_type vs_array_len = "(2::nat) ^ vs_index_bits"
+
+end
+
 end


### PR DESCRIPTION
- add ghost state corresponding to gsPTTypes in Haskell and ASpec
- add ghost type comments
- style update for old definitions since we need to touch most of these
- define vs/pt_array_len for use in C annotations
- make NormalPT_T/VSRootPT_T names available for use in C annotations

Currently the vs/pt_array_len declarations introduce a dependency of CSpec on ASpec. We could remove that if we moved the definitions of pt_index_len and vs_index_bits higher, so that they become visible in ExecSpec.

This PR is required for merging seL4/seL4#1156