### PR TITLE
Suppress simplifier warnings in `corres_rewrite`

### DIFF
--- a/lib/Eisbach_Tools/Eisbach_Methods.thy
+++ b/lib/Eisbach_Tools/Eisbach_Methods.thy
@@ -17,6 +17,17 @@ imports
   Local_Method
 begin
 
+section \<open>Warnings\<close>
+
+method_setup not_visible =
+  \<open>Method.text_closure >> (fn m => fn ctxt => fn facts =>
+     let
+       val ctxt' = Context_Position.set_visible false ctxt
+       fun tac st' = method_evaluate m ctxt' facts st'
+     in SIMPLE_METHOD tac facts end)\<close>
+  \<open>set context visibility to false for suppressing warnings in method execution\<close>
+
+
 section \<open>Debugging methods\<close>
 
 method print_concl = (match conclusion in P for P \<Rightarrow> \<open>print_term P\<close>)

--- a/lib/clib/Simpl_Rewrite.thy
+++ b/lib/clib/Simpl_Rewrite.thy
@@ -460,7 +460,7 @@ text \<open>Methods to automate rewriting.\<close>
 
 method do_rewrite uses hom ruleset declares C_simp_simps =
   (rule com_ctxt_focus_rewrite[OF hom], rule ruleset,
-   #break "simpl_rewrite_rewrite", (simp add: C_simp_simps; fail))+
+   #break "simpl_rewrite_rewrite", (not_visible \<open>simp add: C_simp_simps\<close>; fail))+
 
 method rewrite_pre uses hom declares C_simp_pre C_simp_simps =
   (do_rewrite hom: hom ruleset: C_simp_pre)


### PR DESCRIPTION
- add a method for setting context visibility to `false` for Eisabach methods
- use it in `simpl_rewrite` to suppress simplifier warnings in `ccorres_rewrite`

This should make `ccorres_rewrite` quite about `Collect_const` being in the simpset or not. 