### PR TITLE
github: make sure artifact names are unique

### DIFF
--- a/.github/workflows/external.yml
+++ b/.github/workflows/external.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Upload kernel builds
       uses: actions/upload-artifact@v4
       with:
-        name: kernel-builds
+        name: kernel-builds-${{ matrix.arch }}
         path: artifacts/kernel-builds
         if-no-files-found: ignore
     - name: Upload logs

--- a/.github/workflows/proof-deploy.yml
+++ b/.github/workflows/proof-deploy.yml
@@ -54,7 +54,7 @@ jobs:
     - name: Upload kernel builds
       uses: actions/upload-artifact@v4
       with:
-        name: kernel-builds
+        name: kernel-builds-${{ matrix.num_domains }}-${{ matrix.arch }}
         path: artifacts/kernel-builds
         if-no-files-found: ignore
     - name: Upload logs

--- a/.github/workflows/proof.yml
+++ b/.github/workflows/proof.yml
@@ -46,7 +46,7 @@ jobs:
     - name: Upload kernel builds
       uses: actions/upload-artifact@v4
       with:
-        name: kernel-builds
+        name: kernel-builds-${{ matrix.arch }}
         path: artifacts/kernel-builds
         if-no-files-found: ignore
     - name: Upload logs

--- a/.github/workflows/weekly-clean.yml
+++ b/.github/workflows/weekly-clean.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Upload kernel builds
       uses: actions/upload-artifact@v4
       with:
-        name: kernel-builds
+        name: kernel-builds-${{ matrix.num_domains }}-${{ matrix.arch }}
         path: artifacts/kernel-builds
         if-no-files-found: ignore
     - name: Upload logs


### PR DESCRIPTION
Avoid clashes between uploaded artifact names for each workflow. Previously these were just overwritten, but the new GitHub actions error instead.

Fixes #713 