### PR TITLE
Enlarge the trace monad rule set for RG logic

### DIFF
--- a/lib/Crunch_Instances_Trace.thy
+++ b/lib/Crunch_Instances_Trace.thy
@@ -8,7 +8,7 @@ theory Crunch_Instances_Trace
 imports
   Crunch
   Monads.Trace_No_Fail
-  Monads.Trace_RG
+  Monads.Trace_More_RG
 begin
 
 lemmas [crunch_param_rules] = Let_def return_bind returnOk_bindE

--- a/lib/Monads/Fun_Pred_Syntax.thy
+++ b/lib/Monads/Fun_Pred_Syntax.thy
@@ -187,6 +187,13 @@ lemma bipred_disj_op_eq[simp]:
 lemma bipred_le_true[simp]: "R \<le> \<top>\<top>"
   by clarsimp
 
+lemma bipred_and_or_True[simp]:
+  "(P or \<top>\<top>) = \<top>\<top>"
+  "(\<top>\<top> or P) = \<top>\<top>"
+  "(P and \<top>\<top>) = P"
+  "(\<top>\<top> and P) = P"
+  by auto
+
 
 section \<open>Examples\<close>
 

--- a/lib/Monads/Monad_Lib.thy
+++ b/lib/Monads/Monad_Lib.thy
@@ -73,4 +73,8 @@ lemma context_disjE:
   "\<lbrakk>P \<or> Q; P \<Longrightarrow> R; \<lbrakk>\<not>P; Q\<rbrakk> \<Longrightarrow> R\<rbrakk> \<Longrightarrow> R"
   by auto
 
+lemma subst2:
+  "\<lbrakk>s = t; u = v; P s u\<rbrakk> \<Longrightarrow> P t v"
+  by clarsimp
+
 end

--- a/lib/Monads/ROOT
+++ b/lib/Monads/ROOT
@@ -50,6 +50,7 @@ session Monads (lib) = HOL +
     Trace_Strengthen_Setup
     Trace_Monad_Equations
     Trace_RG
+    Trace_More_RG
     Trace_In_Monad
     Trace_More_VCG
     Trace_No_Fail

--- a/lib/Monads/trace/Trace_Empty_Fail.thy
+++ b/lib/Monads/trace/Trace_Empty_Fail.thy
@@ -344,9 +344,13 @@ lemma empty_fail_put_trace[empty_fail_term]:
   apply (clarsimp simp: empty_fail_term empty_fail_cond)
   done
 
+lemma empty_fail_env_steps[empty_fail_term]:
+  "empty_fail env_steps"
+  by (simp add: env_steps_def empty_fail_term empty_fail_cond)
+
 lemma empty_fail_interference[empty_fail_term]:
   "empty_fail interference"
-  by (simp add: interference_def commit_step_def env_steps_def empty_fail_term empty_fail_cond)
+  by (simp add: interference_def commit_step_def empty_fail_term empty_fail_cond)
 
 lemma last_st_tr_not_empty:
   "P s \<Longrightarrow> \<exists>xs. P (last_st_tr (map (Pair Env) xs) s')"

--- a/lib/Monads/trace/Trace_Monad.thy
+++ b/lib/Monads/trace/Trace_Monad.thy
@@ -499,6 +499,12 @@ text \<open>
 definition last_st_tr :: "(tmid * 's) list \<Rightarrow> 's \<Rightarrow> 's" where
   "last_st_tr tr s0 \<equiv> hd (map snd tr @ [s0])"
 
+lemma last_st_tr_simps[simp]:
+  "last_st_tr [] s = s"
+  "last_st_tr (x # xs) s = snd x"
+  "last_st_tr (tr @ tr') s = last_st_tr tr (last_st_tr tr' s)"
+  by (simp add: last_st_tr_def hd_append)+
+
 text \<open>Nondeterministically add all possible environment events to the trace.\<close>
 definition env_steps :: "('s,unit) tmonad" where
   "env_steps \<equiv>

--- a/lib/Monads/trace/Trace_More_RG.thy
+++ b/lib/Monads/trace/Trace_More_RG.thy
@@ -1,0 +1,637 @@
+(*
+ * Copyright 2023, Proofcraft Pty Ltd
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ *)
+
+(* Partial correctness RG logic lemmas over the trace monad. RG quintuples, lifting lemmas, etc.
+   If it doesn't contain a RG quintuple it likely doesn't belong in here. *)
+
+theory Trace_More_RG
+  imports
+    Trace_RG
+begin
+
+lemma rg_take_disjunct:
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. P' rv s0 s \<and> (False \<or> P'' rv s0 s)\<rbrace>
+   \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>P''\<rbrace>"
+  by (erule rg_strengthen_post, simp)
+
+lemma rg_post_add:
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> S \<lbrace>G\<rbrace>,\<lbrace>\<lambda>r s0 s. Q' r s0 s \<and> Q r s0 s\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> S \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+  by (erule rg_strengthen_post, simp)
+
+lemma rg_post_addE:
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_ s0 s. R s0 s \<and> Q s0 s\<rbrace>,\<lbrace>T\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_ s0 s. Q s0 s\<rbrace>,\<lbrace>T\<rbrace>"
+  by (erule rg_strengthen_postE; simp)
+
+lemma rg_pre_add:
+  "(\<forall>s0 s. P s0 s \<longrightarrow> P' s0 s) \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace> \<longleftrightarrow> \<lbrace>P and P'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+  apply (subst iff_conv_conj_imp)
+  by(intro conjI impI; rule rg_weaken_pre, assumption, clarsimp)
+
+lemma rg_pre_addE:
+  "(\<forall>s0 s. P s0 s \<longrightarrow> R s0 s) \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>S\<rbrace> \<longleftrightarrow> \<lbrace>P and R\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>S\<rbrace>"
+  apply (subst iff_conv_conj_imp)
+  by(intro conjI impI; rule rg_weaken_preE, assumption, clarsimp)
+
+lemma rg_name_pre_state:
+  "\<lbrakk> \<And>s0 s. P s0 s \<Longrightarrow> \<lbrace>\<lambda>_. (=) s\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>; prefix_closed f \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+  by (clarsimp simp: validI_def)
+
+lemma rg_name_pre_stateE:
+  "\<lbrakk>\<And>s0 s. P s0 s \<Longrightarrow> \<lbrace>\<lambda>_. (=) s\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>; prefix_closed f\<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
+  by (clarsimp simp: validIE_def2)
+
+lemma rg_vcg_if_lift_strong:
+  "\<lbrakk> \<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>P\<rbrace>; \<lbrace>\<lambda>s0 s. \<not> P' s0 s\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. \<not> P rv s0 s\<rbrace>; \<lbrace>Q'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>; \<lbrace>S'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>S\<rbrace> \<rbrakk> \<Longrightarrow>
+   \<lbrace>\<lambda>s0 s. if P' s0 s then Q' s0 s else S' s0 s\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. if P rv s0 s then Q rv s0 s else S rv s0 s\<rbrace>"
+
+  "\<lbrakk> \<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>P\<rbrace>; \<lbrace>\<lambda>s0 s. \<not> P' s0 s\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. \<not> P rv s0 s\<rbrace>; \<lbrace>Q'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace> Q\<rbrace>; \<lbrace>S'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>S\<rbrace> \<rbrakk> \<Longrightarrow>
+   \<lbrace>\<lambda>s0 s. if P' s0 s then Q' s0 s else S' s0 s\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. (if P rv s0 s then Q rv else S rv) s0 s\<rbrace>"
+  by (wpsimp wp: rg_vcg_imp_lift' | assumption | fastforce)+
+
+lemma rg_vcg_imp_lift_pre_add:
+  "\<lbrakk> \<lbrace>P and Q\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. Q' rv s0 s\<rbrace>; f \<lbrace>R\<rbrace>,\<lbrace>G\<rbrace>,\<lbrace>\<lambda>s0 s. \<not> Q s0 s\<rbrace> \<rbrakk>
+   \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. Q s0 s \<longrightarrow> Q' rv s0 s\<rbrace>"
+  apply (rule rg_weaken_pre)
+   apply (rule rg_vcg_imp_lift')
+    apply fastforce
+   apply fastforce
+  apply clarsimp
+  done
+
+lemma rg_pre_tautI:
+  "\<lbrakk> \<lbrace>A and P\<rbrace>,\<lbrace>R\<rbrace> a \<lbrace>G\<rbrace>,\<lbrace>B\<rbrace>; \<lbrace>A and not P\<rbrace>,\<lbrace>R\<rbrace> a \<lbrace>G\<rbrace>,\<lbrace>B\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>A\<rbrace>,\<lbrace>R\<rbrace> a \<lbrace>G\<rbrace>,\<lbrace>B\<rbrace>"
+  by (fastforce simp: validI_def)
+
+lemma rg_lift_Pf_pre_conj:
+  assumes P: "\<And>x. \<lbrace>\<lambda>s0 s. Q x s0 s\<rbrace>,\<lbrace>R\<rbrace> m \<lbrace>G\<rbrace>,\<lbrace>P x\<rbrace>"
+  assumes f: "\<And>P. \<lbrace>\<lambda>s0 s. P (g s0 s) \<and> P' s0 s\<rbrace>,\<lbrace>R\<rbrace> m \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_ s0 s. P (f s0 s)\<rbrace>"
+  shows "\<lbrace>\<lambda>s0 s. Q (g s0 s) s0 s \<and> P' s0 s\<rbrace>,\<lbrace>R\<rbrace> m \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. P (f s0 s) rv s0 s\<rbrace>"
+  apply (clarsimp simp: validI_def validI_prefix_closed[OF f] guar_by_rg[OF f])
+  apply (rule use_validI[OF _ P], simp)
+  apply (rule use_validI[OF _ f], simp+)
+  done
+
+lemmas rg_lift_Pf4 = rg_lift_Pf_pre_conj[where P'="\<top>\<top>", simplified]
+lemmas rg_lift_Pf3 = rg_lift_Pf4[where f=f and g=f for f]
+lemmas rg_lift_Pf2 = rg_lift_Pf3[where P="\<lambda>f _. P f" for P]
+lemmas rg_lift_Pf = rg_lift_Pf2[where Q=P and P=P for P]
+
+lemmas rg_lift_Pf3_pre_conj = rg_lift_Pf_pre_conj[where f=f and g=f for f]
+lemmas rg_lift_Pf2_pre_conj = rg_lift_Pf3_pre_conj[where P="\<lambda>f _. P f" for P]
+lemmas rg_lift_Pf_pre_conj' = rg_lift_Pf2_pre_conj[where Q=P and P=P for P]
+
+lemma rg_if_r_and:
+  "\<lbrace>P\<rbrace>,\<lbrace>R'\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>r. if R r then Q r else Q' r\<rbrace>
+   = \<lbrace>P\<rbrace>,\<lbrace>R'\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>r s0 s. (R r \<longrightarrow> Q r s0 s) \<and> (\<not>R r \<longrightarrow> Q' r s0 s)\<rbrace>"
+  by (fastforce simp: validI_def)
+
+lemma rg_convert_imp:
+  "\<lbrakk> \<lbrace>\<lambda>s0 s. \<not> P s0 s\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. \<not> Q s0 s\<rbrace>; \<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>S\<rbrace> \<rbrakk>
+   \<Longrightarrow> \<lbrace>\<lambda>s0 s. P s0 s \<longrightarrow> P' s0 s\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. Q s0 s \<longrightarrow> S rv s0 s\<rbrace>"
+  apply (simp only: imp_conv_disj)
+  apply (erule(1) rg_vcg_disj_lift)
+  done
+
+lemma rg_case_option_wpR:
+  "\<lbrakk>\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f None \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>; \<And>x. \<lbrace>P' x\<rbrace>,\<lbrace>R\<rbrace> f (Some x) \<lbrace>G\<rbrace>,\<lbrace>Q' x\<rbrace>,\<lbrace>E\<rbrace>\<rbrakk>
+   \<Longrightarrow> \<lbrace>case_option P P' v\<rbrace>,\<lbrace>R\<rbrace> f v \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv. case v of None \<Rightarrow> Q rv | Some x \<Rightarrow> Q' x rv\<rbrace>,\<lbrace>E\<rbrace>"
+  by (cases v) auto
+
+lemma rg_exI_tuple:
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>(rv,rv') s0 s. Q x rv rv' s0 s\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>(rv,rv') s0 s. \<exists>x. Q x rv rv' s0 s\<rbrace>"
+  by (fastforce simp: validI_def)
+
+lemma rg_ex_all:
+  "(\<forall>x. \<lbrace>P x\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>) = \<lbrace>\<lambda>s0 s. \<exists>x. P x s0 s\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+  apply (rule iffI)
+   apply (fastforce simp: validI_def)+
+  done
+
+lemma rg_imp_eq_substR:
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. rv = x \<longrightarrow> Q x s0 s\<rbrace>,\<lbrace>E\<rbrace>"
+  by (fastforce simp add: validI_def validIE_def split: sum.splits)
+
+lemma rg_split_bind_case_sum:
+  assumes x: "\<And>rv. \<lbrace>E rv\<rbrace>,\<lbrace>R\<rbrace> g rv \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+             "\<And>rv. \<lbrace>S rv\<rbrace>,\<lbrace>R\<rbrace> h rv \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+  assumes y: "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>S\<rbrace>,\<lbrace>E\<rbrace>"
+  shows      "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f >>= case_sum g h \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+  apply (rule bind_twp[OF _ y[unfolded validIE_def]])
+  apply (wpsimp wp: x split: sum.splits)
+  done
+
+lemma rg_split_bind_case_sumE:
+  assumes x: "\<And>rv. \<lbrace>S' rv\<rbrace>,\<lbrace>R\<rbrace> g rv \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
+             "\<And>rv. \<lbrace>S rv\<rbrace>,\<lbrace>R\<rbrace> h rv \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
+  assumes y: "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>S\<rbrace>,\<lbrace>S'\<rbrace>"
+  shows      "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f >>= case_sum g h \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
+  apply (unfold validIE_def)
+  apply (rule bind_twp[OF _ y[unfolded validIE_def]])
+  apply (wpsimp wp: x[unfolded validIE_def] split: sum.splits)
+  done
+
+lemma assertE_tsp:
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> assertE Q \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. Q \<and> P s0 s\<rbrace>,\<lbrace>E\<rbrace>"
+  by (wpsimp wp: assertE_wp)
+
+lemma case_options_weak_twp:
+  "\<lbrakk> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>; \<And>x. \<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> g x \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace> \<rbrakk>
+   \<Longrightarrow> \<lbrace>P and P'\<rbrace>,\<lbrace>R\<rbrace> case opt of None \<Rightarrow> f | Some x \<Rightarrow> g x \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+  apply (cases opt)
+   apply (clarsimp elim!: rg_weaken_pre)
+  apply (rule rg_weaken_pre [where P'=P'])
+   apply simp+
+  done
+
+lemma case_option_twp_None_return:
+  assumes [wp]: "\<And>x. \<lbrace>P' x\<rbrace>,\<lbrace>R\<rbrace> f x \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_. Q\<rbrace>"
+  shows "\<lbrakk>\<And>x s0 s. (Q and P x) s0 s \<Longrightarrow> P' x s0 s \<rbrakk>
+         \<Longrightarrow> \<lbrace>Q and (\<lambda>s0 s. opt \<noteq> None \<longrightarrow> P (the opt) s0 s)\<rbrace>,\<lbrace>R\<rbrace>
+             (case opt of None \<Rightarrow> return () | Some x \<Rightarrow> f x)
+             \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_. Q\<rbrace>"
+  by (cases opt; wpsimp)
+
+lemma case_option_twp_None_returnOk:
+  assumes [wp]: "\<And>x. \<lbrace>P' x\<rbrace>,\<lbrace>R\<rbrace> f x \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_. Q\<rbrace>,\<lbrace>E\<rbrace>"
+  shows "\<lbrakk>\<And>x s0 s. (Q and P x) s0 s \<Longrightarrow> P' x s0 s \<rbrakk>
+         \<Longrightarrow> \<lbrace>Q and (\<lambda>s0 s. opt \<noteq> None \<longrightarrow> P (the opt) s0 s)\<rbrace>,\<lbrace>R\<rbrace>
+             (case opt of None \<Rightarrow> returnOk () | Some x \<Rightarrow> f x)
+             \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_. Q\<rbrace>,\<lbrace>E\<rbrace>"
+  by (cases opt; wpsimp)
+
+lemma list_cases_weak_twp:
+  assumes "\<lbrace>P_A\<rbrace>,\<lbrace>R\<rbrace> a \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+  assumes "\<And>x xs. \<lbrace>P_B\<rbrace>,\<lbrace>R\<rbrace> b x xs \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+  shows
+  "\<lbrace>P_A and P_B\<rbrace>,\<lbrace>R\<rbrace>
+   case ts of
+       [] \<Rightarrow> a
+     | x#xs \<Rightarrow> b x xs
+   \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+  apply (cases ts)
+  apply (simp, rule rg_weaken_pre, rule assms, simp)+
+  done
+
+lemma rg_vcg_if_lift2:
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. (Q rv s0 s \<longrightarrow> X rv s0 s) \<and> (\<not> Q rv s0 s \<longrightarrow> Y rv s0 s)\<rbrace> \<Longrightarrow>
+   \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. if Q rv s0 s then X rv s0 s else Y rv s0 s\<rbrace>"
+
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. (Q' rv \<longrightarrow> X rv s0 s) \<and> (\<not> Q' rv \<longrightarrow> Y rv s0 s)\<rbrace> \<Longrightarrow>
+   \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv. if Q' rv then X rv else Y rv\<rbrace>"
+  by (auto simp: validI_def)
+
+lemma rg_vcg_if_lift_ER: (* Required because of lack of rv in lifting rules *)
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. (Q rv s0 s \<longrightarrow> X rv s0 s) \<and> (\<not> Q rv s0 s \<longrightarrow> Y rv s0 s)\<rbrace>,\<lbrace>E\<rbrace> \<Longrightarrow>
+   \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. if Q rv s0 s then X rv s0 s else Y rv s0 s\<rbrace>,\<lbrace>E\<rbrace>"
+
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. (Q' rv \<longrightarrow> X rv s0 s) \<and> (\<not> Q' rv \<longrightarrow> Y rv s0 s)\<rbrace>,\<lbrace>E\<rbrace> \<Longrightarrow>
+   \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv. if Q' rv then X rv else Y rv\<rbrace>,\<lbrace>E\<rbrace>"
+  by (auto simp: validI_def validIE_def)
+
+lemma rg_list_all_lift:
+  "\<lbrakk>\<And>r. r \<in> set xs \<Longrightarrow> \<lbrace>Q r\<rbrace>,\<lbrace>R\<rbrace> f -,\<lbrace>\<lambda>rv. Q r\<rbrace>; \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<top>\<top>\<top>\<rbrace>\<rbrakk>
+   \<Longrightarrow> \<lbrace>\<lambda>s0 s. list_all (\<lambda>r. Q r s0 s) xs \<and> P s0 s\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. list_all (\<lambda>r. Q r s0 s) xs\<rbrace>"
+  apply (rule validI_split[rotated, simplified pred_conj_def])
+   apply assumption
+  apply (induct xs; simp)
+   apply wpsimp
+  apply (rule rg_vcg_conj_lift; simp)
+  done
+
+lemma assertE_twp:
+  "\<lbrace>\<lambda>s0 s. F \<longrightarrow> Q () s0 s\<rbrace>,\<lbrace>R\<rbrace> assertE F \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
+  apply (rule rg_pre)
+   apply (unfold assertE_def)
+   apply wp
+  apply simp
+  done
+
+(*If there is a use case which requires a specific guarantee then this rule could be extended with
+  an extra assumption and precondition.*)
+lemma rg_doesn't_grow_proof:
+  assumes y: "\<And>s0 s. finite (S s0 s)"
+  assumes x: "\<And>x. \<lbrace>\<lambda>s0 s. x \<notin> S s0 s \<and> P s0 s\<rbrace>,\<lbrace>R\<rbrace> f -,\<lbrace>\<lambda>rv s0 s. x \<notin> S s0 s\<rbrace>"
+  shows      "\<lbrace>\<lambda>s0 s. card (S s0 s) < n \<and> P s0 s\<rbrace>,\<lbrace>R\<rbrace> f -,\<lbrace>\<lambda>rv s0 s. card (S s0 s) < n\<rbrace>"
+  apply (clarsimp simp: validI_def validI_prefix_closed[OF x])
+  apply (erule le_less_trans[rotated])
+  apply (rule card_mono[OF y])
+  apply clarsimp
+  apply (rule ccontr)
+  apply (drule (2) use_validI[OF _ x, OF _ conjI])
+  apply simp
+  done
+
+lemma rg_vcg_propE_R:
+  "prefix_closed f \<Longrightarrow> \<lbrace>\<lambda>s0 s. P\<rbrace>,\<lbrace>R\<rbrace> f -,\<lbrace>\<lambda>rv s0 s. P\<rbrace>,-"
+  by (simp add: validIE_def validI_def split: sum.split)
+
+lemma rg_set_preserved_proof:
+  assumes y: "\<And>x. \<lbrace>\<lambda>s0 s. Q s0 s \<and> x \<in> S s0 s\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. x \<in> S s0 s\<rbrace>"
+  assumes x: "\<And>x. \<lbrace>\<lambda>s0 s. Q s0 s \<and> x \<notin> S s0 s\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. x \<notin> S s0 s\<rbrace>"
+  shows      "\<lbrace>\<lambda>s0 s. Q s0 s \<and> P (S s0 s)\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. P (S s0 s)\<rbrace>"
+  apply (clarsimp simp: validI_def)
+  by (metis (mono_tags, lifting) equalityI validI_prefix_closed post_by_rg guar_by_rg subsetI x y)
+
+(*If there is a use case which requires a specific guarantee then this rule could be extended with
+  an extra assumption and precondition.*)
+lemma rg_set_shrink_proof:
+  assumes x: "\<And>x. \<lbrace>\<lambda>s0 s. x \<notin> S s0 s\<rbrace>,\<lbrace>R\<rbrace> f -,\<lbrace>\<lambda>rv s0 s. x \<notin> S s0 s\<rbrace>"
+  shows
+  "\<lbrace>\<lambda>s0 s. \<forall>S'. S' \<subseteq> S s0 s \<longrightarrow> P S'\<rbrace>,\<lbrace>R\<rbrace>
+   f
+   -,\<lbrace>\<lambda>rv s0 s. P (S s0 s)\<rbrace>"
+  apply (clarsimp simp: validI_def validI_prefix_closed[OF x])
+  apply (drule spec, erule mp)
+  apply (clarsimp simp: subset_iff)
+  apply (rule ccontr)
+  apply (drule(1) use_validI [OF _ x])
+  apply simp
+  done
+
+lemma rg_shrinks_proof:
+  assumes y: "\<And>s0 s. finite (S s0 s)"
+  assumes x: "\<And>x. \<lbrace>\<lambda>s0 s. x \<notin> S s0 s \<and> P s0 s\<rbrace>,\<lbrace>R\<rbrace> f -,\<lbrace>\<lambda>rv s0 s. x \<notin> S s0 s\<rbrace>"
+  assumes z: "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. x \<notin> S s0 s\<rbrace>"
+  assumes w: "\<And>s0 s. P s0 s \<Longrightarrow> x \<in> S s0 s"
+  shows      "\<lbrace>\<lambda>s0 s. card (S s0 s) \<le> n \<and> P s0 s\<rbrace>,\<lbrace>R\<rbrace> f -,\<lbrace>\<lambda>rv s0 s. card (S s0 s) < n\<rbrace>"
+  apply (clarsimp simp: validI_def validI_prefix_closed[OF x])
+  apply (erule less_le_trans[rotated])
+  apply (rule psubset_card_mono[OF y])
+  apply (rule psubsetI)
+   apply clarsimp
+   apply (rule ccontr)
+   apply (drule (2) use_validI[OF _ x, OF _ conjI])
+   apply simp
+  by (metis use_validI w z)
+
+lemma use_validIE_R':
+  "\<lbrakk>(tr, Result (Inr r, s')) \<in> rely f R s0 s; \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>; P s0 s; s0' = last_st_tr tr s0\<rbrakk>
+   \<Longrightarrow> Q r s0' s'"
+  unfolding validIE_def
+  by (frule(3) use_validI', simp)
+
+lemmas use_validIE_R = use_validIE_R'[OF _ _ _ refl]
+
+lemma use_validIE_guar:
+  "\<lbrakk>(tr, res) \<in> rely f R s0 s; \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>; P s0 s\<rbrakk>
+   \<Longrightarrow> guar_cond G s0 tr"
+  unfolding validIE_def
+  by (frule(2) use_validI_guar, simp)
+
+lemma validI_preservation_ex:
+  assumes x: "\<And>x P. \<lbrace>\<lambda>s0 s. P (f s0 s x :: 'b)\<rbrace>,\<lbrace>R\<rbrace> m \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. P (f s0 s x)\<rbrace>"
+  shows      "\<lbrace>\<lambda>s0 s. P (f s0 s :: 'a \<Rightarrow> 'b)\<rbrace>,\<lbrace>R\<rbrace> m \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. P (f s0 s)\<rbrace>"
+  apply (clarsimp simp: validI_def validI_prefix_closed[OF x] guar_by_rg[OF x])
+  apply (erule subst[rotated, where P=P])
+  apply (rule ext)
+  apply (erule use_validI [OF _ x])
+  apply simp
+  done
+
+lemma whenE_invI:
+  assumes a: "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_. P\<rbrace>"
+  shows "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> whenE Q f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_. P\<rbrace>"
+  by (wpsimp wp: a)
+
+lemma ifM_throwError_returnOkI:
+  "\<lbrace>Q\<rbrace>,\<lbrace>R\<rbrace> test \<lbrace>G\<rbrace>,\<lbrace>\<lambda>c s0 s. \<not> c \<longrightarrow> P s0 s\<rbrace>
+   \<Longrightarrow> \<lbrace>Q\<rbrace>,\<lbrace>R\<rbrace> ifM test (throwError e) (returnOk ()) \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_. P\<rbrace>, -"
+  unfolding ifM_def
+  apply (fold liftE_bindE)
+  apply wpsimp
+   apply assumption
+  apply simp
+  done
+
+lemmas state_unchanged_rg = in_inv_by_rgD [THEN sym]
+lemmas last_state_unchanged_rg = last_st_in_inv_by_rgD [THEN sym]
+
+(*FIXME MC: name? move (both this one and validI in More_VCG)*)
+lemma validI_I:
+  assumes px: "prefix_closed S"
+  assumes gc: "\<And>s0 s tr res. \<lbrakk> P s0 s; (tr, res) \<in> (rely S R s0 s)\<rbrakk> \<Longrightarrow> guar_cond G s0 tr"
+  assumes rl: "\<And>s0 s tr r s'. \<lbrakk> P s0 s; (tr, Result (r, s')) \<in> (rely S R s0 s) \<rbrakk> \<Longrightarrow> Q r (last_st_tr tr s0) s'"
+  shows "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> S \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+  unfolding validI_def using px gc rl by safe
+
+lemma opt_return_pres_lift_rg:
+  assumes x: "\<And>v. \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f v \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv. P\<rbrace>"
+  shows      "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> case x of None \<Rightarrow> return () | Some v \<Rightarrow> f v \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv. P\<rbrace>"
+  by (wpsimp wp: x)
+
+lemma rg_weak_lift_imp_conj:
+  "\<lbrakk> \<lbrace>Q\<rbrace>,\<lbrace>R\<rbrace> m -,\<lbrace>Q'\<rbrace>; \<lbrace>R\<rbrace>,\<lbrace>R\<rbrace> m -,\<lbrace>R'\<rbrace>; \<lbrace>S\<rbrace>,\<lbrace>R\<rbrace> m \<lbrace>G\<rbrace>,\<lbrace>\<top>\<top>\<top>\<rbrace> \<rbrakk>
+   \<Longrightarrow> \<lbrace>\<lambda>s0 s. (P \<longrightarrow> Q s0 s) \<and> R s0 s \<and> S s0 s\<rbrace>,\<lbrace>R\<rbrace> m \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. (P \<longrightarrow> Q' rv s0 s) \<and> R' rv s0 s\<rbrace>"
+  apply wp_pre
+  apply (rule rg_vcg_conj_lift)
+   apply (rule rg_weak_lift_imp; assumption)
+   apply (rule validI_split; assumption)
+  apply clarsimp
+  done
+
+lemma rg_eq_P:
+  assumes "\<And>P. \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_. P\<rbrace>"
+  shows "\<lbrace>\<lambda>_. (=) s\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_ _. (=) s\<rbrace>"
+  by (rule assms)
+
+lemma valid_case_option_post_twp:
+  "\<lbrakk>\<And>x. \<lbrace>P x\<rbrace>,\<lbrace>R\<rbrace> f -,\<lbrace>\<lambda>rv. Q x\<rbrace>\<rbrakk> \<Longrightarrow>
+   \<lbrace>\<lambda>s0 s. case ep of Some x \<Rightarrow> P x s0 s | _ \<Rightarrow> True\<rbrace>,\<lbrace>R\<rbrace>
+   f
+   -,\<lbrace>\<lambda>rv s0 s. case ep of Some x \<Rightarrow> Q x s0 s | _ \<Rightarrow> True\<rbrace>"
+  by (cases ep; fastforce simp: rg_TrueI)
+
+lemma P_bool_lift:
+  assumes t: "\<lbrace>Q\<rbrace>,\<lbrace>R\<rbrace> f -,\<lbrace>\<lambda>r. Q\<rbrace>"
+  assumes f: "\<lbrace>\<lambda>s0 s. \<not>Q s0 s\<rbrace>,\<lbrace>R\<rbrace> f -,\<lbrace>\<lambda>r s0 s. \<not>Q s0 s\<rbrace>"
+  shows "\<lbrace>\<lambda>s0 s. P (Q s0 s)\<rbrace>,\<lbrace>R\<rbrace> f -,\<lbrace>\<lambda>r s0 s. P (Q s0 s)\<rbrace>"
+  apply (clarsimp simp: validI_def validI_prefix_closed[OF f])
+  apply (rule back_subst[where P=P], assumption)
+  apply (rule iffI)
+   apply (erule (1) use_validI [OF _ t])
+  apply (rule classical)
+  apply (drule (1) use_validI [OF _ f])
+  apply simp
+  done
+
+lemma gets_sp: "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> gets f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv. P and (\<lambda>s0 s. f s = rv)\<rbrace>"
+  by (wp, simp)
+
+lemma post_by_rg2:
+  "\<lbrakk>\<lbrace>P\<rbrace>, \<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>, \<lbrace>Q\<rbrace>; (tr, Result (rv, s')) \<in> rely f R s0 s; P s0 s\<rbrakk>
+  \<Longrightarrow> Q rv (last_st_tr tr s0) s'"
+  by (rule post_by_rg, assumption+)
+
+lemma rg_Ball_helper:
+  assumes x: "\<And>x. \<lbrace>P x\<rbrace>,\<lbrace>R\<rbrace> f -,\<lbrace>Q x\<rbrace>"
+  assumes y: "\<And>P. \<lbrace>\<lambda>s0 s. P (S s0 s)\<rbrace>,\<lbrace>R\<rbrace> f -,\<lbrace>\<lambda>rv s0 s. P (S s0 s)\<rbrace>"
+  shows "\<lbrace>\<lambda>s0 s. \<forall>x \<in> S s0 s. P x s0 s\<rbrace>,\<lbrace>R\<rbrace> f -,\<lbrace>\<lambda>rv s0 s. \<forall>x \<in> S s0 s. Q x rv s0 s\<rbrace>"
+  apply (clarsimp simp: validI_def validI_prefix_closed[OF x])
+  apply (drule bspec, erule back_subst[where P="\<lambda>A. x\<in>A" for x])
+   apply (erule post_by_rg[OF y, rotated])
+   apply (rule refl)
+  apply (erule (1) post_by_rg[OF x])
+  done
+
+lemma handy_prop_divs_rg:
+  assumes x: "\<And>P. \<lbrace>\<lambda>s0 s. P (Q s0 s) \<and> S s0 s\<rbrace>,\<lbrace>R\<rbrace> f -,\<lbrace>\<lambda>rv s0 s. P (Q' rv s0 s)\<rbrace>"
+             "\<And>P. \<lbrace>\<lambda>s0 s. P (R s0 s) \<and> S s0 s\<rbrace>,\<lbrace>R\<rbrace> f -,\<lbrace>\<lambda>rv s0 s. P (R' rv s0 s)\<rbrace>"
+  shows      "\<lbrace>\<lambda>s0 s. P (Q s0 s \<and> R s0 s) \<and> S s0 s\<rbrace>,\<lbrace>R\<rbrace> f -,\<lbrace>\<lambda>rv s0 s. P (Q' rv s0 s \<and> R' rv s0 s)\<rbrace>"
+             "\<lbrace>\<lambda>s0 s. P (Q s0 s \<or> R s0 s) \<and> S s0 s\<rbrace>,\<lbrace>R\<rbrace> f -,\<lbrace>\<lambda>rv s0 s. P (Q' rv s0 s \<or> R' rv s0 s)\<rbrace>"
+   apply (clarsimp simp: validI_def validI_prefix_closed[OF x(1)]
+                  elim!: subst[rotated, where P=P])
+   apply (rule use_validI [OF _ x(1)], assumption)
+   apply (rule use_validI [OF _ x(2)], assumption)
+   apply simp
+  apply (clarsimp simp: validI_def validI_prefix_closed[OF x(1)]
+                 elim!: subst[rotated, where P=P])
+  apply (rule use_validI [OF _ x(1)], assumption)
+  apply (rule use_validI [OF _ x(2)], assumption)
+  apply simp
+  done
+
+lemma rg_as_subst:
+  "\<lbrakk> \<And>P. \<lbrace>\<lambda>s0 s. P (fn s0 s)\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. P (fn s0 s)\<rbrace>;
+     \<And>v :: 'a. \<lbrace>P v\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q v\<rbrace> \<rbrakk> \<Longrightarrow>
+   \<lbrace>\<lambda>s0 s. P (fn s0 s) s0 s\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. Q (fn s0 s) rv s0 s\<rbrace>"
+  by (rule rg_lift_Pf3)
+
+lemmas rg_vcg_ball_lift = rg_vcg_const_Ball_lift
+
+lemma rg_set_preserved:
+  assumes x: "\<And>x. \<lbrace>fn' x\<rbrace>,\<lbrace>R\<rbrace> m -,\<lbrace>\<lambda>rv. fn x\<rbrace>"
+  shows      "\<lbrace>\<lambda>s0 s. set xs \<subseteq> {x. fn' x s0 s}\<rbrace>,\<lbrace>R\<rbrace> m -,\<lbrace>\<lambda>rv s0 s. set xs \<subseteq> {x. fn x s0 s}\<rbrace>"
+  apply (induct xs)
+   apply (simp add: rg_TrueI validI_prefix_closed[OF x])
+  apply simp
+  apply (rule rg_vcg_conj_lift)
+   apply (rule x)
+  apply assumption
+  done
+
+lemma rg_ex_pre: (* safe, unlike rg_vcg_ex_lift *)
+  "(\<And>x. \<lbrace>P x\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>) \<Longrightarrow> \<lbrace>\<lambda>s0 s. \<exists>x. P x s0 s\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+  by (fastforce simp: validI_def)
+
+lemma rg_ex_pre_conj:
+  "\<lbrakk>\<And>x. \<lbrace>\<lambda>s0 s. P x s0 s \<and> P' s0 s\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>\<rbrakk>
+   \<Longrightarrow> \<lbrace>\<lambda>s0 s. (\<exists>x. P x s0 s) \<and> P' s0 s\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+  by (fastforce simp: validI_def)
+
+lemma rg_conj_lift_inv:
+  "\<lbrakk>\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>; \<lbrace>\<lambda>s0 s. P' s0 s \<and> I s0 s\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv. I\<rbrace>;
+    \<And>s0 s. P s0 s \<Longrightarrow> P' s0 s\<rbrakk>
+   \<Longrightarrow> \<lbrace>\<lambda>s0 s. P s0 s \<and> I s0 s\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. Q rv s0 s \<and> I s0 s\<rbrace>"
+   by (fastforce simp: validI_def)
+
+lemma rg_in_rely_post:
+  assumes x: "\<And>P. \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f -,\<lbrace>\<lambda>x. P\<rbrace>"
+  shows      "\<lbrace>\<top>\<top>\<rbrace>,\<lbrace>R\<rbrace> f -,\<lbrace>\<lambda>rv s0 s. (rv, s) \<in> mres (rely f R s0 s)\<rbrace>"
+  apply (clarsimp simp: validI_def validI_prefix_closed[OF x])
+  apply (rule back_subst[where P="\<lambda>s0. x\<in>mres (rely f R s0 s)" for x s])
+   apply (rule back_subst[where P="\<lambda>s. x\<in>mres (rely f R s0 s)" for x s0])
+   apply (drule in_mres, assumption)
+   apply (simp add: state_unchanged_rg[OF x])
+  apply (simp add: last_state_unchanged_rg[OF x])
+  done
+
+lemma list_case_throw_validIE_R:
+  "\<lbrakk> \<And>y ys. xs = y # ys \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f y ys \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,- \<rbrakk> \<Longrightarrow>
+   \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> case xs of [] \<Rightarrow> throwError e | x # xs \<Rightarrow> f x xs \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,-"
+  apply (cases xs, simp_all)
+  apply wp
+  done
+
+lemma validI_set_take_helper:
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. \<forall>x \<in> set (xs rv s0 s). Q x rv s0 s\<rbrace>
+   \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. \<forall>x \<in> set (take (n rv s0 s) (xs rv s0 s)). Q x rv s0 s\<rbrace>"
+  apply (erule rg_strengthen_post)
+  apply (clarsimp dest!: in_set_takeD)
+  done
+
+lemma whenE_throwError_tsp:
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> whenE Q (throwError e) \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. \<not> Q \<and> P s0 s\<rbrace>, -"
+  apply (simp add: whenE_def)
+  apply (intro conjI impI; wp)
+  done
+
+lemma weaker_rg_ifE:
+  assumes x: "\<lbrace>P \<rbrace>,\<lbrace>R\<rbrace> a \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
+  assumes y: "\<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> b \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
+  shows      "\<lbrace>P and P'\<rbrace>,\<lbrace>R\<rbrace> if test then a else b \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
+  apply (rule rg_weaken_preE)
+   apply (wp x y)
+  apply simp
+  done
+
+lemma twp_split_const_if:
+  assumes x: "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+  assumes y: "\<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q'\<rbrace>"
+  shows "\<lbrace>\<lambda>s0 s. (S \<longrightarrow> P s0 s) \<and> (\<not> S \<longrightarrow> P' s0 s)\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. (S \<longrightarrow> Q rv s0 s) \<and> (\<not> S \<longrightarrow> Q' rv s0 s)\<rbrace>"
+  by (cases S, simp_all add: x y)
+
+lemma twp_split_const_ifE_R:
+  assumes x: "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
+  assumes y: "\<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q'\<rbrace>,\<lbrace>E\<rbrace>"
+  shows "\<lbrace>\<lambda>s0 s. (S \<longrightarrow> P s0 s) \<and> (\<not> S \<longrightarrow> P' s0 s)\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. (S \<longrightarrow> Q rv s0 s) \<and> (\<not> S \<longrightarrow> Q' rv s0 s)\<rbrace>,\<lbrace>E\<rbrace>"
+  by (cases S, simp_all add: x y)
+
+lemma rg_disj_division:
+  "\<lbrakk> P \<or> Q; P \<Longrightarrow> \<lbrace>R\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>S\<rbrace>; Q \<Longrightarrow> \<lbrace>T\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>S\<rbrace> \<rbrakk>
+   \<Longrightarrow> \<lbrace>\<lambda>s0 s. (P \<longrightarrow> R s0 s) \<and> (Q \<longrightarrow> T s0 s)\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>S\<rbrace>"
+  by (fastforce intro: rg_weaken_pre)
+
+lemma rg_grab_asm:
+  "\<lbrakk> P' \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>; \<not> P' \<Longrightarrow> prefix_closed f \<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s0 s. P' \<and> P s0 s\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+  by (cases P'; simp)
+
+lemma rg_grab_asm2:
+  "\<lbrakk>P' \<Longrightarrow> \<lbrace>\<lambda>s0 s. P s0 s \<and> P'' s0 s\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>; \<not> P' \<Longrightarrow> prefix_closed f\<rbrakk>
+   \<Longrightarrow> \<lbrace>\<lambda>s0 s. P s0 s \<and> P' \<and> P'' s0 s\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+  by (fastforce simp: validI_def)
+
+lemma rg_grab_exs:
+  assumes x: "\<And>x. P x \<Longrightarrow> \<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+  assumes y: "prefix_closed f"
+  shows      "\<lbrace>\<lambda>s0 s. \<exists>x. P x \<and> P' s0 s\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+  apply (clarsimp simp: validI_def y use_validI_guar[OF _ x])
+  apply (erule(2) use_validI [OF _ x])
+  done
+
+lemma rg_prop_E:
+  "prefix_closed f \<Longrightarrow> \<lbrace>\<lambda>s0 s. P\<rbrace>,\<lbrace>R\<rbrace> f -,-,\<lbrace>\<lambda>rv s0 s. P\<rbrace>"
+  by wpsimp
+
+lemma rg_walk_assmsE:
+  assumes x: "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv. P\<rbrace>" and y: "\<And>s0 s. P s0 s \<Longrightarrow> Q s0 s" and z: "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> g \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv. Q\<rbrace>"
+  shows      "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> doE x \<leftarrow> f; g odE \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv. Q\<rbrace>"
+  apply (wp z)
+   apply (simp add: validIE_def)
+   apply (rule rg_strengthen_post [OF x])
+   apply (auto simp: y split: sum.splits)
+  done
+
+(*FIXME MC: it is not immediately obvious what the validI equivalent of these rules should be, so I
+          think it is best to leave them until we have a specific use case.
+lemma univ_twp:
+  "prefix_closed f \<Longrightarrow> \<lbrace>\<lambda>s0 s. \<forall>(rv, s') \<in> mres (rely f R s0 s). Q rv s0 s'\<rbrace>,\<lbrace>R\<rbrace> f -,\<lbrace>Q\<rbrace>"
+  by (simp add: validI_def)
+
+lemma univ_get_twp:
+  assumes x: "\<And>P. \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv. P\<rbrace>"
+  shows "\<lbrace>\<lambda>s0 s. \<forall>(rv, s0 s') \<in> mres (f s0 s). s0 s = s0 s' \<longrightarrow> Q rv s0 s'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+  apply (rule rg_pre_imp[OF _ univ_wp])
+  apply clarsimp
+  apply (drule bspec, assumption, simp)
+  apply (drule mp)
+   apply (simp add: state_unchanged[OF x])
+  apply simp
+  done
+
+lemma other_rg_in_monad_post:
+  assumes x: "\<And>P. \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> fn \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv. P\<rbrace>"
+  shows "\<lbrace>\<lambda>s0 s. \<forall>(v, s0 s) \<in> mres (fn s0 s). F v = v\<rbrace>,\<lbrace>R\<rbrace> fn \<lbrace>G\<rbrace>,\<lbrace>\<lambda>v s0 s'. (F v, s0 s') \<in> mres (fn s0 s')\<rbrace>"
+  proof -
+  have P: "\<And>v s0 s. (F v = v) \<and> (v, s0 s) \<in> mres (fn s0 s) \<Longrightarrow> (F v, s0 s) \<in> mres (fn s0 s)"
+    by simp
+  show ?thesis
+  apply (rule rg_post_imp [OF P], assumption)
+  apply (rule rg_pre_imp)
+  defer
+   apply (rule rg_vcg_conj_lift)
+    apply (rule univ_get_wp [OF x])
+   apply (rule rg_in_monad_post [OF x])
+  apply clarsimp
+  apply (drule bspec, assumption, simp)
+  done
+  qed*)
+
+lemma weak_if_twp:
+  "\<lbrakk> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>; \<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q'\<rbrace> \<rbrakk> \<Longrightarrow>
+   \<lbrace>P and P'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>r. if C r then Q r else Q' r\<rbrace>"
+  by (auto simp: validI_def)
+
+lemma weak_if_twp':
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>r. Q r and Q' r\<rbrace> \<Longrightarrow>
+   \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>r. if C r then Q r else Q' r\<rbrace>"
+  by (auto simp: validI_def)
+
+lemma validE_R_abstract_rv:
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. \<forall>rv'. Q rv' s0 s\<rbrace>,\<lbrace>E\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
+  by (erule rg_strengthen_postE; simp)
+
+lemma validIE_cases_validI:
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. Q (Inr rv) s0 s\<rbrace>,\<lbrace>\<lambda>rv s0 s. Q (Inl rv) s0 s\<rbrace>
+   \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+  apply (simp add: validIE_def)
+  apply (erule rg_strengthen_post)
+  apply (simp split: sum.split_asm)
+  done
+
+lemma liftM_pre_rg:
+  assumes rl: "\<lbrace>\<lambda>s0 s. \<not> P s0 s \<rbrace>,\<lbrace>R\<rbrace> a \<lbrace>G\<rbrace>,\<lbrace> \<lambda>_ _ _. False \<rbrace>"
+  shows "\<lbrace>\<lambda>s0 s. \<not> P s0 s \<rbrace>,\<lbrace>R\<rbrace> liftM f a \<lbrace>G\<rbrace>,\<lbrace> \<lambda>_ _ _. False \<rbrace>"
+  unfolding liftM_def
+  apply (rule bind_twp_fwd)
+   apply (rule rl)
+  apply wp
+  done
+
+lemma rg_gen_asm_conj:
+  "\<lbrakk>P \<Longrightarrow> \<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>; \<not> P \<Longrightarrow> prefix_closed f\<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s0 s. P' s0 s \<and> P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+  by (fastforce simp: validI_def)
+
+lemma rg_add_K:
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace> \<Longrightarrow> \<lbrace>\<lambda>s0 s. P s0 s \<and> I\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. Q rv s0 s \<and> I\<rbrace>"
+  by (fastforce simp: validI_def)
+
+lemma valid_rv_lift:
+  "\<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. rv \<longrightarrow> Q rv s0 s\<rbrace> \<Longrightarrow> \<lbrace>\<lambda>s0 s. P \<and> P' s0 s\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. rv \<longrightarrow> P \<and> Q rv s0 s\<rbrace>"
+  by (fastforce simp: validI_def)
+
+lemma valid_rv_split:
+  "\<lbrakk>\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. rv \<longrightarrow> Q s0 s\<rbrace>; \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. \<not>rv \<longrightarrow> Q' s0 s\<rbrace>\<rbrakk>
+   \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. if rv then Q s0 s else Q' s0 s\<rbrace>"
+  by (fastforce simp: validI_def)
+
+lemma rg_rv_split:
+  "\<lbrakk>\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. rv \<longrightarrow> (Q rv s0 s)\<rbrace>; \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. (\<not>rv) \<longrightarrow> (Q rv s0 s)\<rbrace>\<rbrakk>
+   \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+  apply (clarsimp simp: validI_def)
+  by (metis (full_types))
+
+lemma combine_validE:
+  "\<lbrakk> \<lbrace> P \<rbrace>,\<lbrace>R\<rbrace> x \<lbrace>G\<rbrace>,\<lbrace> Q \<rbrace>,\<lbrace> E \<rbrace>; \<lbrace> P' \<rbrace>,\<lbrace>R\<rbrace> x \<lbrace>G\<rbrace>,\<lbrace> Q' \<rbrace>,\<lbrace> E' \<rbrace> \<rbrakk>
+   \<Longrightarrow> \<lbrace> P and P' \<rbrace>,\<lbrace>R\<rbrace> x \<lbrace>G\<rbrace>,\<lbrace> \<lambda>r. Q r and Q' r \<rbrace>,\<lbrace>\<lambda>r. E r and E' r \<rbrace>"
+  apply (clarsimp simp: validIE_def validI_def split: sum.splits)
+  done
+
+lemma validI_case_prod:
+  "\<lbrakk> \<And>x y. validI (P x y) R (f x y) G Q \<rbrakk> \<Longrightarrow> validI (case_prod P v) R (case_prod (\<lambda>x y. f x y) v) G Q"
+  by (simp add: split_def)
+
+lemma validIE_case_prod:
+  "\<lbrakk> \<And>x y. validIE (P x y) R (f x y) G Q E \<rbrakk> \<Longrightarrow> validIE (case_prod P v) R (case_prod (\<lambda>x y. f x y) v) G Q E"
+  by (simp add: split_def)
+
+lemma rg_validIE_E_conjI:
+  "\<lbrakk> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>; \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E'\<rbrace> \<rbrakk>  \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>\<lambda>rv s0 s. E rv s0 s \<and> E' rv s0 s\<rbrace>"
+  by (fastforce simp: validIE_def validI_def split: sum.splits)
+
+lemma validIE_R_post_conjD1:
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>r s0 s. Q r s0 s \<and> Q' r s0 s\<rbrace>,\<lbrace>E\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
+  by (fastforce simp: validIE_def validI_def split: sum.splits)
+
+lemma validIE_R_post_conjD2:
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>r s0 s. Q r s0 s \<and> Q' r s0 s\<rbrace>,\<lbrace>E\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q'\<rbrace>,\<lbrace>E\<rbrace>"
+  by (fastforce simp: validIE_def validI_def split: sum.splits)
+
+lemma rg_name_pre_state2:
+  "(\<And>s. \<lbrace>\<lambda>s0' s'. P s0' s' \<and> (s' = s)\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>) \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+  by (auto simp: validI_def)
+
+end

--- a/lib/Monads/trace/Trace_More_VCG.thy
+++ b/lib/Monads/trace/Trace_More_VCG.thy
@@ -25,7 +25,7 @@ lemma hoare_post_add:
 
 lemma hoare_post_addE:
   "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>_ s. R s \<and> Q s\<rbrace>, \<lbrace>T\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>_ s. Q s\<rbrace>, \<lbrace>T\<rbrace>"
-  by (erule hoare_post_impErr'; simp)
+  by (erule hoare_post_impErr; simp)
 
 lemma hoare_pre_add:
   "(\<forall>s. P s \<longrightarrow> R s) \<Longrightarrow> (\<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace> \<longleftrightarrow> \<lbrace>P and R\<rbrace> f \<lbrace>Q\<rbrace>)"

--- a/lib/Monads/trace/Trace_No_Trace.thy
+++ b/lib/Monads/trace/Trace_No_Trace.thy
@@ -134,8 +134,7 @@ lemma no_trace_apply[no_trace_cond]:
 \<comment> \<open>FIXME: make proof nicer\<close>
 lemma no_trace_liftM_eq[simp]:
   "no_trace (liftM f m) = no_trace m"
-  apply (clarsimp simp: no_trace_def bind_def liftM_def return_def split_def
-                 split: tmres.split_asm)
+  apply (clarsimp simp: no_trace_def bind_def liftM_def return_def)
   apply safe
      apply (drule_tac x=tr in spec)
      apply (drule_tac x="map_tmres id f res" in spec)

--- a/lib/Monads/trace/Trace_Prefix_Closed.thy
+++ b/lib/Monads/trace/Trace_Prefix_Closed.thy
@@ -93,9 +93,22 @@ lemma prefix_closed_apply[prefix_closed_cond]:
   "prefix_closed (f (g x)) \<Longrightarrow> prefix_closed (f $ g x)"
   by simp
 
+\<comment> \<open>FIXME: make proof nicer\<close>
+lemma prefix_closed_liftM_eq[simp]:
+  "prefix_closed (liftM f m) = prefix_closed m"
+  apply (clarsimp simp: prefix_closed_def bind_def' liftM_def return_def image_def)
+  apply (rule iff_allI)+
+  apply safe
+     apply clarsimp
+     apply (drule_tac x="((a, b) # xs, map_tmres id f ba)" in bspec)
+      apply clarsimp
+      apply (case_tac ba; clarsimp)
+      apply (auto split: tmres.splits)
+  done
+
 lemma prefix_closed_liftM[prefix_closed_cond]:
   "prefix_closed m \<Longrightarrow> prefix_closed (liftM f m)"
-  by (wpsimp simp: liftM_def wp: prefix_closed_terminal)
+  by simp
 
 lemma prefix_closed_whenE[prefix_closed_cond]:
   "\<lbrakk> G \<Longrightarrow> prefix_closed f \<rbrakk> \<Longrightarrow> prefix_closed (whenE G f)"
@@ -258,9 +271,13 @@ lemma prefix_closed_put_trace[prefix_closed_terminal]:
   "prefix_closed (put_trace tr)"
   by (induct tr; wpsimp wp: prefix_closed_terminal)
 
+lemma prefix_closed_env_steps[prefix_closed_terminal]:
+  "prefix_closed env_steps"
+  by (wpsimp simp: env_steps_def wp: prefix_closed_terminal)
+
 lemma prefix_closed_interference[prefix_closed_terminal]:
   "prefix_closed interference"
-  by (wpsimp simp: interference_def commit_step_def env_steps_def wp: prefix_closed_terminal)
+  by (wpsimp simp: interference_def commit_step_def wp: prefix_closed_terminal)
 
 lemma prefix_closed_await[prefix_closed_terminal]:
   "prefix_closed (Await c)"

--- a/lib/Monads/trace/Trace_Prefix_Closed.thy
+++ b/lib/Monads/trace/Trace_Prefix_Closed.thy
@@ -14,6 +14,9 @@ begin
 
 subsection "Prefix Closed"
 
+text \<open>
+  A monad is @{text prefix_closed} if for all traces that it returns, it also returns all incomplete traces
+  leading up to it.\<close>
 definition prefix_closed :: "('s, 'a) tmonad \<Rightarrow> bool" where
   "prefix_closed f = (\<forall>s. \<forall>x xs. (x # xs) \<in> fst ` f s \<longrightarrow> (xs, Incomplete) \<in> f s)"
 

--- a/lib/Monads/trace/Trace_RG.thy
+++ b/lib/Monads/trace/Trace_RG.thy
@@ -7,7 +7,7 @@
 
 theory Trace_RG
   imports
-    Trace_VCG
+    Trace_More_VCG
     Trace_Monad_Equations
     Trace_Prefix_Closed
 begin
@@ -85,6 +85,11 @@ lemma rg_empty_conds[simp]:
   "guar_cond G s0s []"
   by (simp_all add: rely_cond_def guar_cond_def)
 
+lemma rg_conds_True[simp]:
+  "rely_cond \<top>\<top> = \<top>\<top>"
+  "guar_cond \<top>\<top> = \<top>\<top>"
+  by (clarsimp simp: rely_cond_def guar_cond_def fun_eq_iff)+
+
 text \<open>
   @{text "rely f R s0s"} constructs a new function from @{text f}, where the environment
   steps are constrained by @{text R} and @{text s0s} was the initial state before the first
@@ -101,30 +106,76 @@ definition validI ::
          \<longrightarrow> guar_cond G s0 tr
            \<and> (\<forall>rv s'. res = Result (rv, s') \<longrightarrow> Q rv (last_st_tr tr s0) s'))"
 
-(*
-text \<open>Validity for exception monad with interferences. Not as easy to phrase
- as we need to \<close>
-definition validIE :: "('s, 'a + 'b) tmonad \<Rightarrow>
-             's rg_pred \<Rightarrow>
-             's rg_pred \<Rightarrow> 's rg_pred \<Rightarrow>
-             ('b \<Rightarrow> 's rg_pred) \<Rightarrow>
-             ('a \<Rightarrow> 's rg_pred) \<Rightarrow> bool"
- ("_ //PRE _//RELY _//GUAR _//POST _//EXC _" [59,0,0,0,0,0] 60) where
-  "validIE f P R G Q E \<equiv> f SAT [P,R,G,\<lambda>v. case v of Inr r \<Rightarrow> Q r | Inl e \<Rightarrow> E e]"
+text \<open>
+  We often reason about invariant predicates. The following provides shorthand syntax
+  that avoids repeating potentially long predicates.\<close>
+abbreviation (input) invariantI ::
+  "('s,'a) tmonad \<Rightarrow> 's rg_pred \<Rightarrow> 's rg_pred \<Rightarrow> ('s \<Rightarrow> 's \<Rightarrow> bool) \<Rightarrow> bool"
+  ("_/ \<lbrace>_\<rbrace>,/ \<lbrace>_\<rbrace>,/ \<lbrace>_\<rbrace>" [59,0] 60) where
+  "invariantI f R G P \<equiv> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_. P\<rbrace>"
 
-abbreviation (input)
-  validIEsat :: "('s, 'a + 'b) tmonad \<Rightarrow>
-             's rg_pred \<Rightarrow>
-             's rg_pred \<Rightarrow> 's rg_pred \<Rightarrow>
-             ('b \<Rightarrow> 's rg_pred) \<Rightarrow>
-             ('a \<Rightarrow> 's rg_pred) \<Rightarrow> bool"
-  ("_ //SAT [_, _, _, _, _]" [59,0,0,0,0,0] 60)
-  where
-  "validIEsat f P R G Q E \<equiv> validIE f P R G Q E"
- *)
+text \<open> Validity for exception monad with interferences, built on @{term validI}. \<close>
+definition validIE ::
+  "('s \<Rightarrow> 's \<Rightarrow> bool) \<Rightarrow> 's rg_pred \<Rightarrow> ('s, 'a + 'b) tmonad \<Rightarrow> 's rg_pred \<Rightarrow> ('b \<Rightarrow> 's \<Rightarrow> 's \<Rightarrow> bool) \<Rightarrow>
+   ('a \<Rightarrow> 's \<Rightarrow> 's \<Rightarrow> bool) \<Rightarrow> bool"
+  ("(\<lbrace>_\<rbrace>,/ \<lbrace>_\<rbrace>)/ _ /(\<lbrace>_\<rbrace>,/ \<lbrace>_\<rbrace>,/ \<lbrace>_\<rbrace>)") where
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace> \<equiv> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace> \<lambda>v s0 s. case v of Inr r \<Rightarrow> Q r s0 s | Inl e \<Rightarrow> E e s0 s \<rbrace>"
+
+lemma validIE_def2:
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace> \<equiv>
+     prefix_closed f
+     \<and> (\<forall>s0 s tr res. P s0 s \<and> (tr, res) \<in> (rely f R s0 s)
+         \<longrightarrow> guar_cond G s0 tr
+           \<and> (\<forall>rv s'. res = Result (rv, s')
+                \<longrightarrow> (case rv of Inr b \<Rightarrow> Q b (last_st_tr tr s0) s' | Inl a \<Rightarrow> E a (last_st_tr tr s0) s')))"
+  by (unfold validI_def validIE_def)
+
+text \<open>
+  The following two abbreviations are convenient to separate reasoning for exceptional and
+  normal case.\<close>
+abbreviation validIE_R ::
+  "('s \<Rightarrow> 's \<Rightarrow> bool) \<Rightarrow> 's rg_pred \<Rightarrow> ('s, 'a + 'b) tmonad \<Rightarrow> 's rg_pred \<Rightarrow> ('b \<Rightarrow> 's \<Rightarrow> 's \<Rightarrow> bool) \<Rightarrow>
+   bool"
+  ("(\<lbrace>_\<rbrace>,/ \<lbrace>_\<rbrace>)/ _ /(\<lbrace>_\<rbrace>,/ \<lbrace>_\<rbrace>,/ -)") where
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,- \<equiv> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>\<lambda>_ _ _. True\<rbrace>"
+
+abbreviation validIE_E ::
+  "('s \<Rightarrow> 's \<Rightarrow> bool) \<Rightarrow> 's rg_pred \<Rightarrow> ('s, 'a + 'b) tmonad \<Rightarrow> 's rg_pred \<Rightarrow> ('a \<Rightarrow> 's \<Rightarrow> 's \<Rightarrow> bool) \<Rightarrow>
+    bool"
+  ("(\<lbrace>_\<rbrace>,/ \<lbrace>_\<rbrace>)/ _ /(\<lbrace>_\<rbrace>,/ -,/ \<lbrace>_\<rbrace>)") where
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,-,\<lbrace>E\<rbrace> \<equiv> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_ _ _. True\<rbrace>,\<lbrace>E\<rbrace>"
+
+text \<open>
+  The following abbreviations are convenient to separate reasoning about postconditions and the
+  guarantee condition.\<close>
+abbreviation validI_no_guarantee ::
+  "('s \<Rightarrow> 's \<Rightarrow> bool) \<Rightarrow> 's rg_pred \<Rightarrow> ('s,'a) tmonad \<Rightarrow> ('a \<Rightarrow> 's \<Rightarrow> 's \<Rightarrow> bool) \<Rightarrow> bool"
+  ("(\<lbrace>_\<rbrace>,/ \<lbrace>_\<rbrace>)/ _ /(-,/ \<lbrace>_\<rbrace>)") where
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f -,\<lbrace>Q\<rbrace> \<equiv> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>\<lambda>_ _. True\<rbrace>,\<lbrace>Q\<rbrace>"
+
+abbreviation (input) invariantI_no_guarantee ::
+  "('s,'a) tmonad \<Rightarrow> 's rg_pred \<Rightarrow> ('s \<Rightarrow> 's \<Rightarrow> bool) \<Rightarrow> bool"
+  ("_/ \<lbrace>_\<rbrace>,/ -,/ \<lbrace>_\<rbrace>" [59,0] 60) where
+  "f \<lbrace>R\<rbrace>, -, \<lbrace>P\<rbrace> \<equiv> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>\<lambda>_ _. True\<rbrace>,\<lbrace>\<lambda>_. P\<rbrace>"
+
+abbreviation validIE_no_guarantee ::
+  "('s \<Rightarrow> 's \<Rightarrow> bool) \<Rightarrow> 's rg_pred \<Rightarrow> ('s, 'a + 'b) tmonad \<Rightarrow> ('b \<Rightarrow> 's \<Rightarrow> 's \<Rightarrow> bool) \<Rightarrow>
+   ('a \<Rightarrow> 's \<Rightarrow> 's \<Rightarrow> bool) \<Rightarrow> bool"
+  ("(\<lbrace>_\<rbrace>,/ \<lbrace>_\<rbrace>)/ _ /(-,/ \<lbrace>_\<rbrace>,/ \<lbrace>_\<rbrace>)") where
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f -,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace> \<equiv> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>\<lambda>_ _. True\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
+
+abbreviation validIE_R_no_guarantee ::
+  "('s \<Rightarrow> 's \<Rightarrow> bool) \<Rightarrow> 's rg_pred \<Rightarrow> ('s, 'a + 'b) tmonad \<Rightarrow> ('b \<Rightarrow> 's \<Rightarrow> 's \<Rightarrow> bool) \<Rightarrow> bool"
+  ("(\<lbrace>_\<rbrace>,/ \<lbrace>_\<rbrace>)/ _ /(-,/ \<lbrace>_\<rbrace>,/ -)") where
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f -,\<lbrace>Q\<rbrace>,- \<equiv> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>\<lambda>_ _. True\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>\<lambda>_ _ _. True\<rbrace>"
+
+abbreviation validIE_E_no_guarantee ::
+  "('s \<Rightarrow> 's \<Rightarrow> bool) \<Rightarrow> 's rg_pred \<Rightarrow> ('s, 'a + 'b) tmonad \<Rightarrow> ('a \<Rightarrow> 's \<Rightarrow> 's \<Rightarrow> bool) \<Rightarrow> bool"
+  ("(\<lbrace>_\<rbrace>,/ \<lbrace>_\<rbrace>)/ _ /(-,/ -,/ \<lbrace>_\<rbrace>)") where
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f -,-,\<lbrace>E\<rbrace> \<equiv> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>\<lambda>_ _. True\<rbrace>,\<lbrace>\<lambda>_ _ _. True\<rbrace>,\<lbrace>E\<rbrace>"
 
 lemma in_rely:
-  "\<lbrakk> (tr, res) \<in> f s; rely_cond R s0s tr \<rbrakk> \<Longrightarrow> (tr, res) \<in> rely f R s0s s"
+  "\<lbrakk>(tr, res) \<in> f s; rely_cond R s0s tr\<rbrakk> \<Longrightarrow> (tr, res) \<in> rely f R s0s s"
   by (simp add: rely_def)
 
 lemmas validI_D =
@@ -137,48 +188,67 @@ lemmas validI_prefix_closed_T =
   validI_prefix_closed[where P="\<lambda>_ _. False" and R="\<lambda>_ _. False" and G="\<lambda>_ _. True"
                          and Q="\<lambda>_ _ _. True"]
 
+declare validI_prefix_closed[elim!]
 
-section \<open>Lemmas\<close>
 
-lemma validI_weaken_pre:
+section \<open>Pre Lemmas\<close>
+
+lemma rg_weaken_pre:
   "\<lbrakk>\<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>; \<And>s0 s. P s0 s \<Longrightarrow> P' s0 s\<rbrakk>
    \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
   by (simp add: validI_def, blast)
+
+lemmas rg_pre_imp = rg_weaken_pre[rotated]
+
+lemma rg_weaken_preE:
+  "\<lbrakk>\<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>; \<And>s0 s. P s0 s \<Longrightarrow> P' s0 s\<rbrakk>
+   \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
+  by (simp add: validIE_def rg_weaken_pre)
 
 lemma rely_weaken:
   "\<lbrakk>\<forall>s0 s. R s0 s \<longrightarrow> R' s0 s; (tr, res) \<in> rely f R s s0\<rbrakk>
    \<Longrightarrow> (tr, res) \<in> rely f R' s s0"
   by (simp add: rely_def rely_cond_def, blast)
 
-lemma validI_weaken_rely:
-  "\<lbrakk>\<lbrace>P\<rbrace>,\<lbrace>R'\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>; \<forall>s0 s. R s0 s \<longrightarrow> R' s0 s\<rbrakk>
+lemma rg_weaken_rely:
+  "\<lbrakk>\<lbrace>P\<rbrace>,\<lbrace>R'\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>; \<And>s0 s. R s0 s \<Longrightarrow> R' s0 s\<rbrakk>
    \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
   apply (simp add: validI_def)
   by (metis rely_weaken)
 
-lemmas validI_pre[wp_pre] =
-  validI_weaken_pre
-  validI_weaken_rely
+lemma rg_weaken_relyE:
+  "\<lbrakk>\<lbrace>P\<rbrace>,\<lbrace>R'\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>; \<And>s0 s. R s0 s \<Longrightarrow> R' s0 s\<rbrakk>
+   \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
+  by (simp add: validIE_def rg_weaken_rely)
 
-lemma validI_strengthen_post:
-  "\<lbrakk>\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q'\<rbrace>; \<forall>v s0 s. Q' v s0 s \<longrightarrow> Q v s0 s\<rbrakk>
+lemma rg_weaken_pre_rely:
+  "\<lbrakk>\<lbrace>P'\<rbrace>,\<lbrace>R'\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>; \<And>s0 s. R s0 s \<Longrightarrow> R' s0 s; \<And>s0 s. P s0 s \<Longrightarrow> P' s0 s\<rbrakk>
    \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
-  by (simp add: validI_def)
+  by (rule rg_weaken_pre, rule rg_weaken_rely; assumption)
 
-lemma validI_strengthen_guar:
-  "\<lbrakk>\<lbrace>P\<rbrace>, \<lbrace>R\<rbrace> f \<lbrace>G'\<rbrace>, \<lbrace>Q\<rbrace>; \<forall>s0 s. G' s0 s \<longrightarrow> G s0 s\<rbrakk>
-   \<Longrightarrow> \<lbrace>P\<rbrace>, \<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>, \<lbrace>Q\<rbrace>"
-  by (force simp: validI_def guar_cond_def)
+lemma rg_weaken_pre_relyE:
+  "\<lbrakk>\<lbrace>P'\<rbrace>,\<lbrace>R'\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>; \<And>s0 s. R s0 s \<Longrightarrow> R' s0 s; \<And>s0 s. P s0 s \<Longrightarrow> P' s0 s\<rbrakk>
+   \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
+  by (simp add: validIE_def rg_weaken_pre_rely)
+
+lemmas rg_pre[wp_pre] =
+  rg_weaken_pre
+  rg_weaken_preE
 
 
 subsection \<open>Setting up the precondition case splitter.\<close>
 
 (* FIXME: this needs adjustment, case_prod Q is unlikely to unify *)
 lemma wpc_helper_validI:
-  "(\<lbrace>Q\<rbrace>,\<lbrace>R\<rbrace> g \<lbrace>G\<rbrace>,\<lbrace>S\<rbrace>) \<Longrightarrow> wpc_helper (P, P', P'') (case_prod Q, Q', Q'') (\<lbrace>curry P\<rbrace>,\<lbrace>R\<rbrace> g \<lbrace>G\<rbrace>,\<lbrace>S\<rbrace>)"
-  by (clarsimp simp: wpc_helper_def elim!: validI_weaken_pre)
+  "\<lbrace>Q\<rbrace>,\<lbrace>R\<rbrace> g \<lbrace>G\<rbrace>,\<lbrace>S\<rbrace> \<Longrightarrow> wpc_helper (P, P', P'') (case_prod Q, Q', Q'') (\<lbrace>curry P\<rbrace>,\<lbrace>R\<rbrace> g \<lbrace>G\<rbrace>,\<lbrace>S\<rbrace>)"
+  by (clarsimp simp: wpc_helper_def elim!: rg_pre)
+
+lemma wpc_helper_validIE:
+  "\<lbrace>Q\<rbrace>,\<lbrace>R\<rbrace> g \<lbrace>G\<rbrace>,\<lbrace>S\<rbrace>,\<lbrace>E\<rbrace> \<Longrightarrow> wpc_helper (P, P', P'') (case_prod Q, Q', Q'') (\<lbrace>curry P\<rbrace>,\<lbrace>R\<rbrace> g \<lbrace>G\<rbrace>,\<lbrace>S\<rbrace>,\<lbrace>E\<rbrace>)"
+  by (clarsimp simp: wpc_helper_def elim!: rg_pre)
 
 wpc_setup "\<lambda>m. \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> m \<lbrace>G\<rbrace>,\<lbrace>S\<rbrace>" wpc_helper_validI
+wpc_setup "\<lambda>m. \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> m \<lbrace>G\<rbrace>,\<lbrace>S\<rbrace>,\<lbrace>E\<rbrace>" wpc_helper_validIE
 
 
 subsection \<open>RG Logic Rules\<close>
@@ -196,18 +266,6 @@ lemma guar_cond_append:
   "guar_cond G s (xs @ ys) = (guar_cond G s ys \<and> guar_cond G (last_st_tr ys s) xs)"
   by (simp add: guar_cond_def trace_steps_append ball_Un conj_comms)
 
-lemma last_st_tr_append[simp]:
-  "last_st_tr (tr @ tr') s = last_st_tr tr (last_st_tr tr' s)"
-  by (simp add: last_st_tr_def hd_append)
-
-lemma last_st_tr_Nil[simp]:
-  "last_st_tr [] s = s"
-  by (simp add: last_st_tr_def)
-
-lemma last_st_tr_Cons[simp]:
-  "last_st_tr (x # xs) s = snd x"
-  by (simp add: last_st_tr_def)
-
 lemma no_trace_last_st_tr:
   "\<lbrakk>no_trace f; (tr, res) \<in> f s\<rbrakk> \<Longrightarrow> last_st_tr tr s0 = s0"
   by (fastforce simp: no_trace_def)
@@ -216,9 +274,33 @@ lemma no_trace_rely_cond:
   "\<lbrakk>no_trace f; (tr, res) \<in> f s\<rbrakk> \<Longrightarrow> rely_cond R s0 tr"
   by (fastforce simp: no_trace_def rely_cond_def)
 
+lemma validI_valid_no_trace_eq:
+  "no_trace f \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace> = (\<forall>s0. \<lbrace>P s0\<rbrace> f \<lbrace>\<lambda>v. Q v s0\<rbrace>)"
+  apply (rule iffI)
+   apply (fastforce simp: rely_def validI_def valid_def mres_def
+                    dest: no_trace_emp)
+  apply (clarsimp simp: rely_def validI_def valid_def mres_def no_trace_prefix_closed)
+  apply (fastforce simp: eq_snd_iff dest: no_trace_emp)
+  done
+
+lemma validIE_validE_no_trace_eq:
+  "no_trace f \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace> = (\<forall>s0. \<lbrace>P s0\<rbrace> f \<lbrace>\<lambda>v. Q v s0\<rbrace>,\<lbrace>\<lambda>v. E v s0\<rbrace>)"
+  unfolding validIE_def validE_def
+  apply (clarsimp simp: validI_valid_no_trace_eq)
+  done
+
+(*FIXME MC: name*)
+lemma validI_split:
+  "\<lbrakk>\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f -,\<lbrace>Q\<rbrace>; \<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<top>\<top>\<top>\<rbrace>\<rbrakk> \<Longrightarrow> \<lbrace>P and P'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+  by (auto simp: validI_def)
+
+lemma validIE_split:
+  "\<lbrakk>\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f -,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>; \<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<top>\<top>\<top>\<rbrace>,\<lbrace>\<top>\<top>\<top>\<rbrace>\<rbrakk> \<Longrightarrow> \<lbrace>P and P'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
+  by (auto simp: validIE_def validI_split)
+
 lemma bind_twp[wp_split]:
-  "\<lbrakk> \<And>r. \<lbrace>Q' r\<rbrace>,\<lbrace>R\<rbrace> g r \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>; \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q'\<rbrace> \<rbrakk>
-   \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f >>= (\<lambda>r. g r) \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+  "\<lbrakk>\<And>r. \<lbrace>Q' r\<rbrace>,\<lbrace>R\<rbrace> g r \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>; \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q'\<rbrace>\<rbrakk>
+   \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f >>= (\<lambda>rv. g rv) \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
   apply (subst validI_def, rule conjI)
    apply (blast intro: prefix_closed_bind validI_prefix_closed)
   apply (clarsimp simp: bind_def rely_def)
@@ -228,6 +310,134 @@ lemma bind_twp[wp_split]:
   apply (drule meta_spec, frule(2) validI_D)
    apply (clarsimp simp: rely_cond_append split: if_split_asm)
   apply (clarsimp simp: guar_cond_append)
+  done
+
+lemma bindE_twp[wp_split]:
+  "\<lbrakk>\<And>r. \<lbrace>Q' r\<rbrace>,\<lbrace>R\<rbrace> g r \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>; \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q'\<rbrace>,\<lbrace>E\<rbrace>\<rbrakk>
+   \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f >>=E (\<lambda>r. g r) \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
+  apply (simp add: bindE_def validIE_def)
+  apply (erule bind_twp[rotated])
+  apply (clarsimp simp: lift_def throwError_def split: sum.splits)
+  apply (subst validI_valid_no_trace_eq)
+   apply wpsimp+
+  done
+
+lemmas bind_twp_fwd = bind_twp[rotated]
+lemmas bindE_twp_fwd = bindE_twp[rotated]
+
+lemma rg_TrueI:
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f -,\<lbrace>\<lambda>_ _. \<top>\<rbrace> = prefix_closed f"
+  by (simp add: validI_def)
+
+lemma rgE_TrueI:
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f -,\<lbrace>\<lambda>_ _. \<top>\<rbrace>,\<lbrace>\<lambda>_ _. \<top>\<rbrace> = prefix_closed f"
+  by (simp add: validIE_def rg_TrueI)
+
+lemmas twp_post_taut = rg_TrueI[where P="\<top>\<top>", THEN iffD2]
+lemmas twp_post_tautE = rgE_TrueI[where P="\<top>\<top>", THEN iffD2]
+lemmas [elim!] = twp_post_taut twp_post_tautE
+
+lemma rg_post_conj[intro]:
+  "\<lbrakk>\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>; \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q'\<rbrace>\<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q and Q'\<rbrace>"
+  by (fastforce simp: validI_def)
+
+lemma rg_pre_disj[intro]:
+  "\<lbrakk>\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>; \<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>\<rbrakk> \<Longrightarrow> \<lbrace>P or P'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+  by (fastforce simp: validI_def pred_disj_def)
+
+lemma rg_conj:
+  "\<lbrakk>\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>; \<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q'\<rbrace>\<rbrakk> \<Longrightarrow> \<lbrace>P and P'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q and Q'\<rbrace>"
+  unfolding validI_def by auto
+
+lemma rg_pre_cont[simp]:
+  "\<lbrace>\<bottom>\<bottom>\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace> = prefix_closed f"
+  by (simp add: validI_def)
+
+lemma rg_FalseE[simp]:
+  "\<lbrace>\<bottom>\<bottom>\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace> = prefix_closed f"
+  by (simp add: validI_def validIE_def)
+
+lemma rg_post_imp:
+  "\<lbrakk>\<And>v s0 s. Q' v s0 s \<Longrightarrow> Q v s0 s; \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q'\<rbrace>\<rbrakk>
+   \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+  by (simp add: validI_def)
+
+lemma rg_post_impE:
+  "\<lbrakk>\<And>v s0 s. Q' v s0 s \<Longrightarrow> Q v s0 s; \<And>v s0 s. E' v s0 s \<Longrightarrow> E v s0 s; \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q'\<rbrace>,\<lbrace>E'\<rbrace>\<rbrakk>
+   \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
+  by (clarsimp simp: validIE_def2 split: sum.splits)
+
+lemma rg_post_imp_dc:
+  "\<lbrakk>\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> a \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_. Q'\<rbrace>; \<And>s0 s. Q' s0 s \<Longrightarrow> Q s0 s\<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> a \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_. Q\<rbrace>,\<lbrace>\<lambda>_. Q\<rbrace>"
+  by (fastforce simp: validIE_def validI_def split: sum.splits)
+
+lemma rg_post_imp_dc2:
+  "\<lbrakk>\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> a \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_. Q'\<rbrace>; \<And>s0 s. Q' s0 s \<Longrightarrow> Q s0 s\<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> a \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_. Q\<rbrace>,-"
+  by (fastforce simp: validIE_def validI_def split: sum.splits)
+
+lemma rg_post_imp_dc2E:
+  "\<lbrakk>\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> a \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_. Q'\<rbrace>; \<And>s0 s. Q' s0 s \<Longrightarrow> Q s0 s\<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> a \<lbrace>G\<rbrace>,-,\<lbrace>\<lambda>_. Q\<rbrace>"
+  by (fastforce simp: validIE_def validI_def split: sum.splits)
+
+lemma rg_guar_imp:
+  "\<lbrakk>\<And>s0 s. G' s0 s \<Longrightarrow> G s0 s; \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G'\<rbrace>,\<lbrace>Q\<rbrace>\<rbrakk>
+   \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+  by (force simp: validI_def guar_cond_def)
+
+lemma rg_guar_impE:
+  "\<lbrakk>\<And>s0 s. G' s0 s \<Longrightarrow> G s0 s; \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G'\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>\<rbrakk>
+   \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
+  by (clarsimp simp: validIE_def elim!: rg_guar_imp)
+
+lemmas rg_strengthen_post = rg_post_imp[rotated]
+lemmas rg_strengthen_postE = rg_post_impE[rotated 2]
+lemmas rg_strengthen_guar = rg_guar_imp[rotated]
+lemmas rg_strengthen_guarE = rg_guar_impE[rotated]
+
+lemma rg_conjD1:
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0. Q rv s0 and Q' rv s0\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv. Q rv\<rbrace>"
+  unfolding validI_def by auto
+
+lemma rg_conjD2:
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0. Q rv s0 and Q' rv s0\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv. Q' rv\<rbrace>"
+  unfolding validI_def by auto
+
+lemma rg_post_disjI1:
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv. Q rv\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0. Q rv s0 or Q' rv s0\<rbrace>"
+  unfolding validI_def by auto
+
+lemma rg_post_disjI2:
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv. Q' rv\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0. Q rv s0 or Q' rv s0\<rbrace>"
+  unfolding validI_def by auto
+
+lemma use_validI':
+  "\<lbrakk>(tr, Result (rv, s')) \<in> rely f R s0 s; \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>; P s0 s; s0' = last_st_tr tr s0\<rbrakk>
+   \<Longrightarrow> Q rv s0' s'"
+  unfolding validI_def by auto
+
+lemmas use_validI = use_validI'[OF _ _ _ refl]
+
+lemmas post_by_rg = use_validI[rotated]
+
+lemma use_validI_guar:
+  "\<lbrakk>(tr, res) \<in> rely f R s0 s; \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>; P s0 s\<rbrakk>
+   \<Longrightarrow> guar_cond G s0 tr"
+  unfolding validI_def by auto
+
+lemmas guar_by_rg = use_validI_guar[rotated]
+
+lemma in_inv_by_rgD:
+  "\<lbrakk>\<And>P. f \<lbrace>R\<rbrace>,-,\<lbrace>P\<rbrace>; (tr, Result (rv, s')) \<in> rely f R s0 s\<rbrakk> \<Longrightarrow> s' = s"
+  unfolding validI_def
+  apply (drule meta_spec[where x="\<lambda>_. (=) s"])
+  apply blast
+  done
+
+lemma last_st_in_inv_by_rgD:
+  "\<lbrakk>\<And>P. f \<lbrace>R\<rbrace>,-,\<lbrace>P\<rbrace>; (tr, Result (rv, s')) \<in> rely f R s0 s\<rbrakk> \<Longrightarrow> last_st_tr tr s0 = s0"
+  unfolding validI_def
+  apply (drule meta_spec[where x="\<lambda>s0' _. s0' = s0"])
+  apply blast
   done
 
 lemma trace_steps_rev_drop_nth:
@@ -253,8 +463,8 @@ next
 qed
 
 lemma validI_GD_drop:
-  "\<lbrakk> \<lbrace>P\<rbrace>, \<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>, \<lbrace>Q\<rbrace>; P s0 s; (tr, res) \<in> f s;
-     rely_cond R s0 (drop n tr) \<rbrakk>
+  "\<lbrakk>\<lbrace>P\<rbrace>, \<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>, \<lbrace>Q\<rbrace>; P s0 s; (tr, res) \<in> f s;
+     rely_cond R s0 (drop n tr)\<rbrakk>
    \<Longrightarrow> guar_cond G s0 (drop n tr)"
   apply (drule prefix_closed_drop[where n=n], erule validI_prefix_closed)
   apply (auto dest: validI_GD)
@@ -425,7 +635,9 @@ lemma rg_validI:
 lemma rely_prim[simp]:
   "rely (\<lambda>s. insert (v s) (f s)) R s0 = (\<lambda>s. {x. x = v s \<and> rely_cond R s0 (fst x)} \<union> (rely f R s0 s))"
   "rely (\<lambda>s. {}) R s0 = (\<lambda>_. {})"
-  by (auto simp: rely_def prod_eq_iff)
+  "rely (\<lambda>s. (f s) \<union> (g s)) R s0 = (\<lambda>s. (rely f R s0 s) \<union> (rely g R s0 s))"
+  "rely (\<lambda>s. if C s then f s else g s) R s0 = (\<lambda>s. if C s then rely f R s0 s else rely g R s0 s)"
+  by (auto simp: rely_def prod_eq_iff split: if_splits)
 
 lemma put_trace_eq_drop:
   "put_trace xs s
@@ -471,38 +683,653 @@ lemma rely_cond_rtranclp:
   done
 
 
-subsection \<open>Setting up the @{method wp} method\<close>
+subsection \<open>Misc\<close>
 
-(* Attempt to define triple_judgement to use valid_validI_wp as wp_comb rule.
-   It doesn't work. It seems that wp_comb rules cannot take more than 1 assumption *)
-lemma validI_is_triple[wp_trip]:
-  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>
-   = triple_judgement (\<lambda>(s0, s). prefix_closed f \<longrightarrow> P s0 s) f
-                      (\<lambda>(s0,s) f. prefix_closed f \<and> (\<forall>tr res. (tr, res) \<in> rely f R s0 s
-                          \<longrightarrow> guar_cond G s0 tr
-                              \<and> (\<forall>rv s'. res = Result (rv, s') \<longrightarrow> Q rv (last_st_tr tr s0) s')))"
-  apply (simp add: triple_judgement_def validI_def )
-  apply (cases "prefix_closed f"; fastforce)
+lemma rg_gen_asm:
+  "\<lbrakk>P \<Longrightarrow> \<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>; \<not> P \<Longrightarrow> prefix_closed f\<rbrakk> \<Longrightarrow> \<lbrace>P' and (\<lambda>_ _. P)\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+  by (auto simp: validI_def)
+
+lemmas rg_gen_asm_single = rg_gen_asm[where P'="\<top>\<top>", simplified pred_conj_def simp_thms]
+
+lemma rg_gen_asm_lk:
+  "\<lbrakk>P \<Longrightarrow> \<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>; \<not> P \<Longrightarrow> prefix_closed f\<rbrakk> \<Longrightarrow> \<lbrace>(\<lambda>_ _. P) and P'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+  by (auto simp: validI_def)
+
+\<comment> \<open>Useful for forward reasoning, when P is known.
+    The first version allows weakening the precondition.\<close>
+lemma rg_gen_asm_spec':
+  "\<lbrakk>\<And>s0 s. P s0 s \<Longrightarrow> S \<and> P' s0 s; S \<Longrightarrow> \<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>; \<not> S \<Longrightarrow> prefix_closed f\<rbrakk>
+   \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+  by (auto 6 2 simp: validI_def)
+
+lemma rg_gen_asm_spec:
+  "\<lbrakk>\<And>s0 s. P s0 s \<Longrightarrow> S; S \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>; \<not> S \<Longrightarrow> prefix_closed f\<rbrakk>
+   \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+  by (rule rg_gen_asm_spec'[where S=S and P'=P]) simp
+
+lemma rg_conjI:
+  "\<lbrakk>\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>; \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q'\<rbrace>\<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. Q rv s0 s \<and> Q' rv s0 s\<rbrace>"
+  unfolding validI_def by auto
+
+lemma rg_disjI1:
+  "\<lbrakk>\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>\<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. Q rv s0 s \<or> Q' rv s0 s\<rbrace>"
+  unfolding validI_def by blast
+
+lemma rg_disjI2:
+  "\<lbrakk>\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q'\<rbrace>\<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. Q rv s0 s \<or> Q' rv s0 s\<rbrace>"
+  unfolding validI_def by blast
+
+lemma rg_assume_pre:
+  "\<lbrakk>\<And>s0 s. P s0 s \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>; prefix_closed f\<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+  by (auto simp: validI_def)
+
+lemma rg_assume_preE:
+  "\<lbrakk>\<And>s0 s. P s0 s \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>; prefix_closed f\<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
+  by (auto simp: validI_def validIE_def)
+
+lemma rg_allI:
+  "(\<And>x. \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q x\<rbrace>) \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. \<forall>x. Q x rv s0 s\<rbrace>"
+  by (simp add: validI_def)
+
+lemma validE_allI:
+  "(\<And>x. \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>r s. Q x r s\<rbrace>,\<lbrace>E\<rbrace>) \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. \<forall>x. Q x rv s0 s\<rbrace>,\<lbrace>E\<rbrace>"
+  by (fastforce simp: validI_def validIE_def split: sum.splits)
+
+lemma rg_exI:
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q x\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. \<exists>x. Q x rv s0 s\<rbrace>"
+  by (simp add: validI_def) blast
+
+lemma rg_impI:
+  "P' \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f -,\<lbrace>Q\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f -,\<lbrace>\<lambda>rv s0 s. P' \<longrightarrow> Q rv s0 s\<rbrace>"
+  by (simp add: validI_def)
+
+lemma validIE_impI:
+  "\<lbrakk>\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_ _ _. True\<rbrace>,\<lbrace>E\<rbrace>; P' \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>\<rbrakk> \<Longrightarrow>
+   \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. P' \<longrightarrow> Q rv s0 s\<rbrace>,\<lbrace>E\<rbrace>"
+  by (fastforce simp: validIE_def validI_def split: sum.splits)
+
+lemma rg_case_option_wp:
+  "\<lbrakk>\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f None \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>; \<And>x. \<lbrace>P' x\<rbrace>,\<lbrace>R\<rbrace> f (Some x) \<lbrace>G\<rbrace>,\<lbrace>Q' x\<rbrace>\<rbrakk>
+   \<Longrightarrow> \<lbrace>case_option P P' v\<rbrace>,\<lbrace>R\<rbrace> f v \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv. case v of None \<Rightarrow> Q rv | Some x \<Rightarrow> Q' x rv\<rbrace>"
+  by (cases v) auto
+
+lemma rg_case_option_wp2:
+  "\<lbrakk>\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f None \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>; \<And>x. \<lbrace>P' x\<rbrace>,\<lbrace>R\<rbrace> f (Some x) \<lbrace>G\<rbrace>,\<lbrace>Q' x\<rbrace>\<rbrakk>
+   \<Longrightarrow> \<lbrace>case_option P P' v\<rbrace>,\<lbrace>R\<rbrace> f v \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. case v of None \<Rightarrow> Q rv s0 s | Some x \<Rightarrow> Q' x rv s0 s\<rbrace>"
+  by (cases v) auto
+
+(* Might be useful for forward reasoning, when P is known. *)
+lemma rg_when_cases:
+  "\<lbrakk>\<And>s0 s. \<lbrakk>\<not>B; P s0 s\<rbrakk> \<Longrightarrow> Q s0 s; B \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_. Q\<rbrace>\<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> when B f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_. Q\<rbrace>"
+  by (cases B; simp add: validI_def prefix_closed_def return_def)
+
+lemma rg_vcg_prop:
+  "prefix_closed f \<Longrightarrow> \<lbrace>\<lambda>s0 s. P\<rbrace>,\<lbrace>R\<rbrace> f -,\<lbrace>\<lambda>rv s0 s. P\<rbrace>"
+  by (simp add: validI_def)
+
+
+subsection \<open>@{const validI} and @{const validIE}, @{const validIE_R}, @{const validIE_E}\<close>
+
+lemma validI_validIE:
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_. Q\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_. Q\<rbrace>,\<lbrace>\<lambda>_. Q\<rbrace>"
+  by (rule rg_post_imp_dc)
+
+lemma validI_validIE2:
+  "\<lbrakk>\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_. Q'\<rbrace>; \<And>s0 s. Q' s0 s \<Longrightarrow> Q s0 s; \<And>s0 s. Q' s0 s \<Longrightarrow> E s0 s\<rbrakk>
+   \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_. Q\<rbrace>, \<lbrace>\<lambda>_. E\<rbrace>"
+  unfolding validI_def validIE_def
+  by (clarsimp split: sum.splits)
+
+lemma validIE_validI:
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_. Q\<rbrace>,\<lbrace>\<lambda>_. Q\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_. Q\<rbrace>"
+  unfolding validIE_def
+  by fastforce
+
+lemma validI_validIE_R:
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_. Q\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_. Q\<rbrace>,-"
+  by (rule rg_post_imp_dc2)
+
+lemma validI_validIE_E:
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_. Q\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,-,\<lbrace>\<lambda>_. Q\<rbrace>"
+  by (rule rg_post_imp_dc2E)
+
+lemma validIE_eq_validI:
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv. Q\<rbrace>,\<lbrace>\<lambda>rv. Q\<rbrace> = \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv. Q\<rbrace>"
+  by (simp add: validIE_def)
+
+
+subsection \<open>@{const liftM}\<close>
+
+(*FIXME: make proof nicer*)
+lemma rg_liftM_subst:
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> liftM f m \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace> = \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> m \<lbrace>G\<rbrace>,\<lbrace>Q \<circ> f\<rbrace>"
+  apply (clarsimp simp: validI_def)
+  apply (rule conj_cong, clarsimp)
+  apply (rule iff_allI)+
+  apply (clarsimp simp: liftM_def bind_def' return_def image_def)
+  apply safe
+     apply (drule_tac x="map_tmres id f res" in spec)
+     apply (case_tac res; clarsimp)
+       apply (auto simp: rely_def split: tmres.splits)[3]
+   apply (drule_tac x="map_tmres id f (Result (rv, s'))" in spec)
+  apply (auto simp: rely_def split: tmres.splits)
   done
 
-lemma validI_valid_no_trace_eq:
-  "no_trace f \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace> = (\<forall>s0. \<lbrace>P s0\<rbrace> f \<lbrace>\<lambda>v. Q v s0\<rbrace>)"
-  apply (rule iffI)
-   apply (fastforce simp: rely_def validI_def valid_def mres_def
-                    dest: no_trace_emp)
-  apply (clarsimp simp: rely_def validI_def valid_def mres_def no_trace_prefix_closed)
-  apply (fastforce simp: eq_snd_iff dest: no_trace_emp)
+lemma rg_liftME_subst:
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> liftME f m \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>, \<lbrace>E\<rbrace> = \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> m \<lbrace>G\<rbrace>,\<lbrace>Q \<circ> f\<rbrace>,\<lbrace>E\<rbrace>"
+  unfolding validIE_def liftME_liftM rg_liftM_subst o_def
+  by (fastforce intro!: arg_cong[where f="validI P R m G"] split: sum.splits)
+
+lemma liftE_validIE[simp]:
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> liftE f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace> = \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+  by (simp add: liftE_liftM validIE_def rg_liftM_subst o_def)
+
+
+subsection \<open>Operator lifting/splitting\<close>
+
+lemma rg_vcg_if_split:
+  "\<lbrakk>P \<Longrightarrow> \<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>; \<not>P \<Longrightarrow> \<lbrace>P''\<rbrace>,\<lbrace>R\<rbrace> g \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>\<rbrakk>
+   \<Longrightarrow> \<lbrace>\<lambda>s0 s. (P \<longrightarrow> P' s0 s) \<and> (\<not>P \<longrightarrow> P'' s0 s)\<rbrace>,\<lbrace>R\<rbrace> if P then f else g \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+  by simp
+
+lemma rg_vcg_if_splitE:
+  "\<lbrakk>P \<Longrightarrow> \<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>; \<not>P \<Longrightarrow> \<lbrace>P''\<rbrace>,\<lbrace>R\<rbrace> g \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>\<rbrakk>
+   \<Longrightarrow> \<lbrace>\<lambda>s0 s. (P \<longrightarrow> P' s0 s) \<and> (\<not>P \<longrightarrow> P'' s0 s)\<rbrace>,\<lbrace>R\<rbrace> if P then f else g \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
+  by simp
+
+lemma rg_vcg_split_case_option:
+  "\<lbrakk>\<And>x. x = None \<Longrightarrow> \<lbrace>P x\<rbrace>,\<lbrace>R\<rbrace> f x \<lbrace>G\<rbrace>,\<lbrace>Q x\<rbrace>; \<And>x y. x = Some y \<Longrightarrow> \<lbrace>P' x y\<rbrace>,\<lbrace>R\<rbrace> g x y \<lbrace>G\<rbrace>,\<lbrace>Q x\<rbrace>\<rbrakk>
+   \<Longrightarrow> \<lbrace>\<lambda>s0 s. (x = None \<longrightarrow> P x s0 s) \<and> (\<forall>y. x = Some y \<longrightarrow> P' x y s0 s)\<rbrace>,\<lbrace>R\<rbrace>
+       case x of None \<Rightarrow> f x | Some y \<Rightarrow> g x y
+       \<lbrace>G\<rbrace>,\<lbrace>Q x\<rbrace>"
+  by (cases x; simp)
+
+lemma rg_vcg_split_case_optionE:
+  "\<lbrakk>\<And>x. x = None \<Longrightarrow> \<lbrace>P x\<rbrace>,\<lbrace>R\<rbrace> f x \<lbrace>G\<rbrace>,\<lbrace>Q x\<rbrace>,\<lbrace>E x\<rbrace>; \<And>x y. x = Some y \<Longrightarrow> \<lbrace>P' x y\<rbrace>,\<lbrace>R\<rbrace> g x y \<lbrace>G\<rbrace>,\<lbrace>Q x\<rbrace>,\<lbrace>E x\<rbrace>\<rbrakk>
+   \<Longrightarrow> \<lbrace>\<lambda>s0 s. (x = None \<longrightarrow> P x s0 s) \<and> (\<forall>y. x = Some y \<longrightarrow> P' x y s0 s)\<rbrace>,\<lbrace>R\<rbrace>
+       case x of None \<Rightarrow> f x | Some y \<Rightarrow> g x y
+       \<lbrace>G\<rbrace>,\<lbrace>Q x\<rbrace>,\<lbrace>E x\<rbrace>"
+  by (cases x; simp)
+
+lemma rg_vcg_split_case_sum:
+  "\<lbrakk>\<And>x a. x = Inl a \<Longrightarrow> \<lbrace>P x a\<rbrace>,\<lbrace>R\<rbrace> f x a \<lbrace>G\<rbrace>,\<lbrace>Q x\<rbrace>; \<And>x b. x = Inr b \<Longrightarrow> \<lbrace>P' x b\<rbrace>,\<lbrace>R\<rbrace> g x b \<lbrace>G\<rbrace>,\<lbrace>Q x\<rbrace>\<rbrakk>
+   \<Longrightarrow> \<lbrace>\<lambda>s0 s. (\<forall>a. x = Inl a \<longrightarrow> P x a s0 s) \<and> (\<forall>b. x = Inr b \<longrightarrow> P' x b s0 s)\<rbrace>,\<lbrace>R\<rbrace>
+       case x of Inl a \<Rightarrow> f x a | Inr b \<Rightarrow> g x b
+       \<lbrace>G\<rbrace>, \<lbrace>Q x\<rbrace>"
+  by (cases x; simp)
+
+lemma bind_twp_nobind:
+  "\<lbrakk>\<lbrace>B\<rbrace>,\<lbrace>R\<rbrace> g \<lbrace>G\<rbrace>,\<lbrace>C\<rbrace>; \<lbrace>A\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_. B\<rbrace>\<rbrakk> \<Longrightarrow> \<lbrace>A\<rbrace>,\<lbrace>R\<rbrace> do f; g od \<lbrace>G\<rbrace>,\<lbrace>C\<rbrace>"
+  by (erule bind_twp_fwd) clarsimp
+
+lemma bindE_twp_nobind:
+  "\<lbrakk>\<lbrace>B\<rbrace>,\<lbrace>R\<rbrace> g \<lbrace>G\<rbrace>,\<lbrace>C\<rbrace>, \<lbrace>E\<rbrace>; \<lbrace>A\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_. B\<rbrace>, \<lbrace>E\<rbrace>\<rbrakk> \<Longrightarrow> \<lbrace>A\<rbrace>,\<lbrace>R\<rbrace> doE f; g odE \<lbrace>G\<rbrace>,\<lbrace>C\<rbrace>, \<lbrace>E\<rbrace>"
+  by (erule bindE_twp_fwd) clarsimp
+
+lemmas bind_twp_skip = bind_twp[where Q=Q and Q'=Q for Q]
+
+lemma rg_chain:
+  "\<lbrakk>\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>; \<And>s0 s. P' s0 s \<Longrightarrow> P s0 s; \<And>rv s0 s. Q rv s0 s \<Longrightarrow> S rv s0 s\<rbrakk>
+   \<Longrightarrow> \<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>S\<rbrace>"
+  by (wp_pre, rule rg_post_imp)
+
+lemma validIE_weaken: (* FIXME lib: eliminate in favour of rg_chainE *)
+  "\<lbrakk>\<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> A \<lbrace>G\<rbrace>,\<lbrace>Q'\<rbrace>,\<lbrace>E'\<rbrace>; \<And>s0 s. P s0 s \<Longrightarrow> P' s0 s; \<And>rv s0 s. Q' rv s0 s \<Longrightarrow> Q rv s0 s;
+    \<And>rv s0 s. E' rv s0 s \<Longrightarrow> E rv s0 s\<rbrakk>
+   \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> A \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
+  by wp_pre (rule rg_post_impE)
+
+lemmas rg_chainE = validIE_weaken
+
+lemma rg_vcg_conj_lift:
+  "\<lbrakk>\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>; \<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q'\<rbrace>\<rbrakk>
+   \<Longrightarrow> \<lbrace>\<lambda>s0 s. P s0 s \<and> P' s0 s\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. Q rv s0 s \<and> Q' rv s0 s\<rbrace>"
+  unfolding validI_def
+  by fastforce
+
+\<comment> \<open>A variant which works nicely with subgoals that do not contain schematics\<close>
+lemmas rg_vcg_conj_lift_pre_fix = rg_vcg_conj_lift[where P=P and P'=P for P, simplified]
+
+lemma rg_vcg_conj_liftE1:
+  "\<lbrakk>\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,-; \<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q'\<rbrace>,\<lbrace>E\<rbrace>\<rbrakk>
+   \<Longrightarrow> \<lbrace>P and P'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. Q rv s0 s \<and> Q' rv s0 s\<rbrace>,\<lbrace>E\<rbrace>"
+  unfolding validI_def validIE_def
+  by (fastforce simp: split_def split: sum.splits)
+
+lemma rg_vcg_conj_liftE2:
+  "\<lbrakk>\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,-,\<lbrace>E\<rbrace>; \<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q'\<rbrace>,\<lbrace>E'\<rbrace>\<rbrakk>
+   \<Longrightarrow> \<lbrace>\<lambda>s0 s. P s0 s \<and> P' s0 s\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q'\<rbrace>,\<lbrace>\<lambda>rv s0 s. E rv s0 s \<and> E' rv s0 s\<rbrace>"
+  unfolding validIE_def
+  by (rule rg_post_imp[OF _ rg_vcg_conj_lift]; simp split: sum.splits)
+
+lemma rg_vcg_conj_liftE_weaker:
+  assumes "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
+  assumes "\<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q'\<rbrace>,\<lbrace>E\<rbrace>"
+  shows "\<lbrace>\<lambda>s0 s. P s0 s \<and> P' s0 s\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. Q rv s0 s \<and> Q' rv s0 s\<rbrace>,\<lbrace>E\<rbrace>"
+  apply (rule rg_pre)
+    apply (fastforce intro: assms rg_vcg_conj_liftE1 validE_validE_R rg_post_impE)
+   apply simp+
   done
 
-lemma valid_validI_wp[wp_comb]:
+lemma rg_vcg_disj_lift:
+  "\<lbrakk>\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>; \<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q'\<rbrace>\<rbrakk>
+   \<Longrightarrow> \<lbrace>\<lambda>s0 s. P s0 s \<or> P' s0 s\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. Q rv s0 s \<or> Q' rv s0 s\<rbrace>"
+  unfolding validI_def
+  by fastforce
+
+lemma rg_vcg_disj_lift_R:
+  assumes x: "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,-"
+  assumes y: "\<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q'\<rbrace>,-"
+  shows      "\<lbrace>\<lambda>s0 s. P s0 s \<or> P' s0 s\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. Q rv s0 s \<or> Q' rv s0 s\<rbrace>,-"
+  using assms
+  by (fastforce simp: validIE_def validI_def split: sum.splits)
+
+lemma rg_vcg_const_Ball_lift:
+  "\<lbrakk>\<And>x. x \<in> S \<Longrightarrow> \<lbrace>P x\<rbrace>,\<lbrace>R\<rbrace> f -,\<lbrace>Q x\<rbrace>; \<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<top>\<top>\<top>\<rbrace>\<rbrakk>
+   \<Longrightarrow> \<lbrace>\<lambda>s0 s. (\<forall>x\<in>S. P x s0 s) \<and> P' s0 s\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. \<forall>x\<in>S. Q x rv s0 s\<rbrace>"
+  by (fastforce simp: validI_def)
+
+lemma rg_vcg_const_Ball_liftE:
+  "\<lbrakk>\<And>x. x \<in> S \<Longrightarrow> \<lbrace>P x\<rbrace>,\<lbrace>R\<rbrace> f -,\<lbrace>Q x\<rbrace>,\<lbrace>E\<rbrace>; \<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,-, \<lbrace>E\<rbrace>\<rbrakk>
+   \<Longrightarrow> \<lbrace>\<lambda>s0 s. (\<forall>x\<in>S. P x s0 s) \<and> P' s0 s\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. \<forall>x\<in>S. Q x rv s0 s\<rbrace>,\<lbrace>E\<rbrace>"
+  by (fastforce simp: validIE_def validI_def split: sum.splits)
+
+lemmas rg_vcg_const_Ball_liftE_R = rg_vcg_const_Ball_liftE[where E="\<top>\<top>\<top>", simplified validIE_eq_validI]
+
+lemma rg_vcg_const_Ball_liftE_E:
+ "\<lbrakk>\<And>x. x \<in> S \<Longrightarrow> \<lbrace>P x\<rbrace>,\<lbrace>R\<rbrace> f -,-,\<lbrace>E x\<rbrace>; \<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<top>\<top>\<top>\<rbrace>\<rbrakk>
+  \<Longrightarrow> \<lbrace>\<lambda>s0 s.(\<forall>x\<in>S. P x s0 s) \<and> P' s0 s\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,-,\<lbrace>\<lambda>rv s0 s. \<forall>x \<in> S. E x rv s0 s\<rbrace>"
+  unfolding validIE_def
+  by (rule rg_strengthen_post)
+     (fastforce intro!: rg_vcg_const_Ball_lift split: sum.splits)+
+
+lemmas rg_vcg_const_Ball_lift_T = rg_vcg_const_Ball_lift[where G="\<top>\<top>" and P'="\<top>\<top>", simplified]
+lemmas rg_vcg_const_Ball_liftE_R_T = rg_vcg_const_Ball_liftE_R[where G="\<top>\<top>" and P'="\<top>\<top>", simplified]
+lemmas rg_vcg_const_Ball_liftE_E_T = rg_vcg_const_Ball_liftE_E[where G="\<top>\<top>" and P'="\<top>\<top>", simplified]
+
+lemma rg_vcg_all_lift:
+  "\<lbrakk>\<And>x. \<lbrace>P x\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q x\<rbrace>\<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s0 s. \<forall>x. P x s0 s\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. \<forall>x. Q x rv s0 s\<rbrace>"
+  by (fastforce simp: validI_def)
+
+lemma rg_vcg_all_liftE_R:
+  "\<lbrakk>\<And>x. \<lbrace>P x\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q x\<rbrace>,\<lbrace>E\<rbrace>\<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s0 s. \<forall>x. P x s0 s\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. \<forall>x. Q x rv s0 s\<rbrace>,\<lbrace>E\<rbrace>"
+  by (fastforce simp: validIE_def validI_def split: sum.splits)
+
+lemma rg_vcg_all_liftE_E:
+  "\<lbrakk>\<And>x. \<lbrace>P x\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E x\<rbrace>\<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s0 s. \<forall>x. P x s0 s\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>\<lambda>rv s0 s. \<forall>x. E x rv s0 s\<rbrace>"
+  by (fastforce simp: validIE_def validI_def split: sum.splits)
+
+lemma rg_vcg_imp_lift:
+  "\<lbrakk>\<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. \<not> P rv s0 s\<rbrace>; \<lbrace>Q'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>\<rbrakk>
+   \<Longrightarrow> \<lbrace>\<lambda>s0 s. P' s0 s \<or> Q' s0 s\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. P rv s0 s \<longrightarrow> Q rv s0 s\<rbrace>"
+  by (simp only: imp_conv_disj) (rule rg_vcg_disj_lift)
+
+lemma rg_vcg_imp_lift':
+  "\<lbrakk>\<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. \<not> P rv s0 s\<rbrace>; \<lbrace>Q'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>\<rbrakk>
+   \<Longrightarrow> \<lbrace>\<lambda>s0 s. \<not> P' s0 s \<longrightarrow> Q' s0 s\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. P rv s0 s \<longrightarrow> Q rv s0 s\<rbrace>"
+  by (wpsimp wp: rg_vcg_imp_lift)
+
+lemma rg_vcg_imp_liftE:
+  "\<lbrakk>\<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. \<not> P rv s0 s\<rbrace>,\<lbrace>E\<rbrace>; \<lbrace>Q'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>\<rbrakk>
+   \<Longrightarrow> \<lbrace>\<lambda>s0 s. P' s0 s \<or> Q' s0 s\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. P rv s0 s \<longrightarrow> Q rv s0 s\<rbrace>,\<lbrace>E\<rbrace>"
+  by (fastforce simp: validIE_def validI_def split: sum.splits)
+
+lemma rg_vcg_imp_liftE':
+  "\<lbrakk>\<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. \<not> P rv s0 s\<rbrace>,\<lbrace>E\<rbrace>; \<lbrace>Q'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>\<rbrakk>
+   \<Longrightarrow> \<lbrace>\<lambda>s0 s. \<not> P' s0 s \<longrightarrow> Q' s0 s\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. P rv s0 s \<longrightarrow> Q rv s0 s\<rbrace>,\<lbrace>E\<rbrace>"
+  by (wpsimp wp: rg_vcg_imp_liftE)
+
+lemma rg_vcg_imp_liftE_E:
+  "\<lbrakk>\<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>\<lambda>rv s0 s. \<not> P rv s0 s\<rbrace>; \<lbrace>Q'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>\<rbrakk>
+   \<Longrightarrow> \<lbrace>\<lambda>s0 s. P' s0 s \<or> Q' s0 s\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>\<lambda>rv s0 s. P rv s0 s \<longrightarrow> E rv s0 s\<rbrace>"
+  by (auto simp add: validI_def validIE_def split: sum.splits)
+
+lemma rg_vcg_imp_liftE_E':
+  "\<lbrakk>\<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>\<lambda>rv s0 s. \<not> P rv s0 s\<rbrace>; \<lbrace>Q'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>\<rbrakk>
+   \<Longrightarrow> \<lbrace>\<lambda>s0 s. \<not> P' s0 s \<longrightarrow> Q' s0 s\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>\<lambda>rv s0 s. P rv s0 s \<longrightarrow> E rv s0 s\<rbrace>"
+  by (wpsimp wp: rg_vcg_imp_liftE_E)
+
+lemma rg_vcg_imp_conj_lift[wp_comb]:
+  "\<lbrakk>\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. Q rv s0 s \<longrightarrow> Q' rv s0 s\<rbrace>; \<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. (Q rv s0 s \<longrightarrow> Q'' rv s0 s) \<and> Q''' rv s0 s\<rbrace>\<rbrakk>
+   \<Longrightarrow> \<lbrace>P and P'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. (Q rv s0 s \<longrightarrow> Q' rv s0 s \<and> Q'' rv s0 s) \<and> Q''' rv s0 s\<rbrace>"
+  by (auto simp: validI_def)
+
+lemmas rg_vcg_imp_conj_lift'[wp_unsafe] = rg_vcg_imp_conj_lift[where Q'''="\<top>\<top>\<top>", simplified]
+
+lemma rg_absorb_imp:
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. Q rv s0 s \<and> Q' rv s0 s\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. Q rv s0 s \<longrightarrow> Q' rv s0 s\<rbrace>"
+  by (erule rg_post_imp[rotated], blast)
+
+lemma rg_weaken_imp:
+  "\<lbrakk>\<And>rv s0 s. Q rv s0 s \<Longrightarrow> Q' rv s0 s ;  \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. Q' rv s0 s \<longrightarrow> S rv s0 s\<rbrace>\<rbrakk>
+   \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. Q rv s0 s \<longrightarrow> S rv s0 s\<rbrace>"
+  by (clarsimp simp: validI_def split_def)
+
+lemma rg_vcg_const_imp_lift:
+  "\<lbrakk>P \<Longrightarrow> \<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> f -,\<lbrace>Q\<rbrace>; \<lbrace>P''\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<top>\<top>\<top>\<rbrace>\<rbrakk>
+   \<Longrightarrow> \<lbrace>\<lambda>s0 s. (P \<longrightarrow> P' s0 s) \<and> P'' s0 s\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. P \<longrightarrow> Q rv s0 s\<rbrace>"
+  apply (cases P; simp)
+  apply wp_pre
+    apply (rule validI_split; assumption)
+   apply clarsimp+
+  done
+
+lemma rg_vcg_const_imp_liftE_E:
+  "\<lbrakk>P \<Longrightarrow> \<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> f -,-,\<lbrace>E\<rbrace>; \<lbrace>P''\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<top>\<top>\<top>\<rbrace>\<rbrakk>
+   \<Longrightarrow> \<lbrace>\<lambda>s0 s. (P \<longrightarrow> P' s0 s) \<and> P'' s0 s\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,-,\<lbrace>\<lambda>rv s0 s. P \<longrightarrow> E rv s0 s\<rbrace>"
+  unfolding validIE_def
+  by (rule rg_strengthen_post)
+     (fastforce intro!: rg_vcg_const_imp_lift split: sum.splits)+
+
+lemma rg_vcg_const_imp_liftE_R:
+  "\<lbrakk>P \<Longrightarrow> \<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> f -,\<lbrace>Q\<rbrace>,-; \<lbrace>P''\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<top>\<top>\<top>\<rbrace>\<rbrakk>
+   \<Longrightarrow> \<lbrace>\<lambda>s0 s. (P \<longrightarrow> P' s0 s) \<and> P'' s0 s\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. P \<longrightarrow> Q rv s0 s\<rbrace>,-"
+  unfolding validIE_def
+  by (rule rg_strengthen_post)
+     (fastforce intro!: rg_vcg_const_imp_lift split: sum.splits)+
+
+(*FIXME MC: not clear whether we want these _T variants, and if we do whether they should be in the
+          wp set along with the above rules*)
+lemmas rg_vcg_const_imp_lift_T = rg_vcg_const_imp_lift[where G="\<top>\<top>" and P''="\<top>\<top>", simplified]
+lemmas rg_vcg_const_imp_liftE_E_T = rg_vcg_const_imp_liftE_E[where G="\<top>\<top>" and P''="\<top>\<top>", simplified]
+lemmas rg_vcg_const_imp_liftE_R_T = rg_vcg_const_imp_liftE_R[where G="\<top>\<top>" and P''="\<top>\<top>", simplified]
+
+lemma rg_weak_lift_imp:
+  "\<lbrakk>\<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> f -,\<lbrace>Q\<rbrace>; \<lbrace>P''\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<top>\<top>\<top>\<rbrace>\<rbrakk>
+   \<Longrightarrow> \<lbrace>\<lambda>s0 s. (P \<longrightarrow> P' s0 s) \<and> P'' s0 s\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. P \<longrightarrow> Q rv s0 s\<rbrace>"
+  by (auto simp: validI_def split_def)
+
+lemma rg_weak_lift_impE:
+  "\<lbrakk>\<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> f -,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>; \<lbrace>P''\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<top>\<top>\<top>\<rbrace>\<rbrakk>
+   \<Longrightarrow> \<lbrace>\<lambda>s0 s. (P \<longrightarrow> P' s0 s) \<and> P'' s0 s\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. P \<longrightarrow> Q rv s0 s\<rbrace>,\<lbrace>\<lambda>rv s0 s. P \<longrightarrow> E rv s0 s\<rbrace>"
+  unfolding validIE_def
+  by (rule rg_strengthen_post)
+     (fastforce intro!: rg_weak_lift_imp split: sum.splits)+
+
+lemma rg_weak_lift_impE_R:
+  "\<lbrakk>\<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> f -,\<lbrace>Q\<rbrace>,-; \<lbrace>P''\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<top>\<top>\<top>\<rbrace>\<rbrakk>
+   \<Longrightarrow> \<lbrace>\<lambda>s0 s. (P \<longrightarrow> P' s0 s) \<and> P'' s0 s\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. P \<longrightarrow> Q rv s0 s\<rbrace>,-"
+  unfolding validIE_def
+  by (rule rg_strengthen_post)
+     (fastforce intro!: rg_weak_lift_imp split: sum.splits)+
+
+lemmas rg_weak_lift_imp_T = rg_weak_lift_imp[where G="\<top>\<top>" and P''="\<top>\<top>", simplified]
+lemmas rg_weak_lift_impE_T = rg_weak_lift_impE[where G="\<top>\<top>" and P''="\<top>\<top>", simplified]
+lemmas rg_weak_lift_impE_R_T = rg_weak_lift_impE_R[where G="\<top>\<top>" and P''="\<top>\<top>", simplified]
+
+lemma rg_vcg_ex_lift:
+  "\<lbrakk>\<And>x. \<lbrace>P x\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q x\<rbrace>\<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s0 s. \<exists>x. P x s0 s\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. \<exists>x. Q x rv s0 s\<rbrace>"
+  by (clarsimp simp: validI_def, blast)
+
+lemma rg_vcg_ex_liftE:
+  "\<lbrakk>\<And>x. \<lbrace>P x\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q x\<rbrace>,\<lbrace>E\<rbrace>\<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s0 s. \<exists>x. P x s0 s\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. \<exists>x. Q x rv s0 s\<rbrace>,\<lbrace>E\<rbrace>"
+  by (fastforce simp: validIE_def validI_def split: sum.splits)
+
+lemma rg_vcg_ex_liftE_E:
+  "\<lbrakk>\<And>x. \<lbrace>P x\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,-,\<lbrace>E x\<rbrace>\<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s0 s. \<exists>x. P x s0 s\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,-,\<lbrace>\<lambda>rv s0 s. \<exists>x. E x rv s0 s\<rbrace>"
+  by (fastforce simp: validIE_def validI_def split: sum.splits)
+
+lemma rg_vcg_ex_lift_R1:
+  "\<lbrakk>\<And>x. \<lbrace>P x\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,-\<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s0 s. \<exists>x. P x s0 s\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,-"
+  by (fastforce simp: validI_def validIE_def split: sum.splits)
+
+lemma rg_liftP_ext:
+  assumes "\<And>P x. m \<lbrace>R\<rbrace>,\<lbrace>G\<rbrace>,\<lbrace>\<lambda>s0 s. P s0 (f s x)\<rbrace>"
+  shows "m \<lbrace>R\<rbrace>,\<lbrace>G\<rbrace>,\<lbrace>\<lambda>s0 s. P s0 (f s)\<rbrace>"
+  unfolding validI_def
+  apply (rule conjI, rule validI_prefix_closed[OF assms])
+  apply clarsimp
+  apply (rule conjI, clarsimp simp: rely_def, erule (2) validI_GD[OF assms])
+  apply clarsimp
+  apply (erule subst2[rotated 2, where P=P])
+   apply (drule use_validI, rule assms, rule refl)
+   apply simp
+  apply (rule ext)
+  apply (drule use_validI, rule assms, rule refl)
+  apply simp
+  done
+
+(* for instantiations *)
+lemma rg_triv:    "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace>f\<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace>f\<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>" .
+lemma rg_trivE:   "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>" .
+lemma rg_trivE_R: "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,- \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,-" .
+lemma rg_trivR_R: "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,-,\<lbrace>E\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,-,\<lbrace>E\<rbrace>" .
+
+lemma rg_vcg_E_elim:
+  "\<lbrakk>\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,-,\<lbrace>E\<rbrace>; \<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,-\<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s0 s. P s0 s \<and> P' s0 s\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
+  by (rule rg_strengthen_postE[OF rg_vcg_conj_liftE2]) simp+
+
+lemma rg_strengthen_post_R:
+  "\<lbrakk> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q'\<rbrace>,-; \<And>rv s0 s. Q' rv s0 s \<Longrightarrow> Q rv s0 s \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,-"
+  by (erule rg_post_impE)
+
+lemma rg_strengthen_post_E:
+  "\<lbrakk> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,-,\<lbrace>Q'\<rbrace>; \<And>rv s0 s. Q' rv s0 s \<Longrightarrow> Q rv s0 s \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,-,\<lbrace>Q\<rbrace>"
+  by (rule rg_post_impE)
+
+lemma rg_post_comb_imp_conj:
+  "\<lbrakk>\<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>; \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q'\<rbrace>; \<And>s0 s. P s0 s \<Longrightarrow> P' s0 s\<rbrakk>
+   \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. Q rv s0 s \<and> Q' rv s0 s\<rbrace>"
+  by (wpsimp wp: rg_vcg_conj_lift)
+
+lemma rg_vcg_if_lift:
+  "\<lbrace>R\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. (P \<longrightarrow> X rv s0 s) \<and> (\<not>P \<longrightarrow> Y rv s0 s)\<rbrace> \<Longrightarrow>
+   \<lbrace>R\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. if P then X rv s0 s else Y rv s0 s\<rbrace>"
+
+  "\<lbrace>R\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. (P \<longrightarrow> X rv s0 s) \<and> (\<not>P \<longrightarrow> Y rv s0 s)\<rbrace> \<Longrightarrow>
+   \<lbrace>R\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv. if P then X rv else Y rv\<rbrace>"
+  by (auto simp: validI_def split_def)
+
+lemma rg_vcg_split_lift[wp]:
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f x y \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> case (x, y) of (a, b) \<Rightarrow> f a b \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+  by simp
+
+named_theorems rg_vcg_op_lift
+lemmas [rg_vcg_op_lift] =
+  rg_vcg_const_imp_lift
+  rg_vcg_const_imp_liftE_E
+  rg_vcg_const_imp_liftE_R
+  (* leaving out rg_vcg_conj_lift*, because that is built into wp *)
+  rg_vcg_disj_lift
+  rg_vcg_disj_lift_R
+  rg_vcg_ex_lift
+  rg_vcg_ex_liftE
+  rg_vcg_ex_liftE_E
+  rg_vcg_all_lift
+  rg_vcg_all_liftE_R
+  rg_vcg_all_liftE_E
+  rg_vcg_const_Ball_lift
+  rg_vcg_const_Ball_liftE
+  rg_vcg_const_Ball_liftE_R
+  rg_vcg_const_Ball_liftE_E
+  rg_vcg_split_lift
+  rg_vcg_if_lift
+  rg_vcg_imp_lift'
+  rg_vcg_imp_liftE'
+  rg_vcg_imp_liftE_E'
+
+
+subsection \<open>Weakest Precondition Rules\<close>
+
+lemma valid_validI_wp:
   "\<lbrakk>no_trace f; \<And>s0. \<lbrace>P s0\<rbrace> f \<lbrace>\<lambda>v. Q v s0 \<rbrace>\<rbrakk>
    \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
   by (clarsimp simp: validI_valid_no_trace_eq)
 
+lemma validE_validIE_wp:
+  "\<lbrakk>no_trace f; \<And>s0. \<lbrace>P s0\<rbrace> f \<lbrace>\<lambda>v. Q v s0 \<rbrace>,\<lbrace>\<lambda>v. E v s0\<rbrace>\<rbrakk>
+   \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
+  by (clarsimp simp: validIE_validE_no_trace_eq)
 
+lemmas valid_validI_lifts[wp] = no_trace_terminal[THEN valid_validI_wp]
+
+lemmas validE_validIE_lifts[wp] =
+  no_trace_fail[THEN validE_validIE_wp] no_trace_returnOk[THEN validE_validIE_wp]
+  no_trace_assertE[THEN validE_validIE_wp] no_trace_throwError[THEN validE_validIE_wp]
+  no_trace_throw_opt[THEN validE_validIE_wp]
+
+lemma liftE_twp:
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> liftE f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
+  by simp
+
+lemma catch_twp:
+  "\<lbrakk> \<And>x. \<lbrace>E x\<rbrace>,\<lbrace>R\<rbrace> handler x \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>; \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace> \<rbrakk>
+   \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> catch f handler \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+  unfolding validI_def validIE_def
+  apply (rule conjI, clarsimp)
+  unfolding catch_def return_def rely_def bind_def
+  apply (fastforce simp: rely_cond_append guar_cond_append
+                 split: sum.splits tmres.splits)
+  done
+
+lemma handleE'_twp:
+  "\<lbrakk> \<And>x. \<lbrace>F x\<rbrace>,\<lbrace>R\<rbrace> handler x \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>; \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>F\<rbrace> \<rbrakk>
+   \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f <handle2> handler \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
+  unfolding validI_def validIE_def
+  apply (rule conjI, clarsimp)
+  unfolding handleE'_def return_def rely_def bind_def
+  apply (fastforce simp: rely_cond_append guar_cond_append
+                 split: sum.splits tmres.splits)
+  done
+
+lemma handleE_twp:
+  assumes x: "\<And>x. \<lbrace>F x\<rbrace>,\<lbrace>R\<rbrace> handler x \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
+  assumes y: "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>F\<rbrace>"
+  shows      "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f <handle> handler \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
+  by (simp add: handleE_def handleE'_twp[OF x y])
+
+lemma liftM_twp:
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> m \<lbrace>G\<rbrace>,\<lbrace>Q \<circ> f\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> liftM f m \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+  by (simp add: rg_liftM_subst)
+
+lemma liftME_twp:
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> m \<lbrace>G\<rbrace>,\<lbrace>Q \<circ> f\<rbrace>,\<lbrace>E\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> liftME f m \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
+  by (simp add: rg_liftME_subst)
+
+lemma list_cases_twp:
+  assumes a: "\<lbrace>P_A\<rbrace>,\<lbrace>R\<rbrace> a \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+  assumes b: "\<And>x xs. ts = x#xs \<Longrightarrow> \<lbrace>P_B x xs\<rbrace>,\<lbrace>R\<rbrace> b x xs \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+  shows "\<lbrace>case_list P_A P_B ts\<rbrace>,\<lbrace>R\<rbrace> case ts of [] \<Rightarrow> a | x # xs \<Rightarrow> b x xs \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+  by (cases ts, auto simp: a b)
+
+lemma rg_vcg_handle_elseE:
+  "\<lbrakk> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q'\<rbrace>,\<lbrace>E'\<rbrace>; \<And>e. \<lbrace>E' e\<rbrace>,\<lbrace>R\<rbrace> g e \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>; \<And>x. \<lbrace>Q' x\<rbrace>,\<lbrace>R\<rbrace> h x \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace> \<rbrakk>
+   \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f <handle> g <else> h \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
+  unfolding handle_elseE_def validIE_def
+  by (wpsimp wp: bind_twp_fwd | assumption | rule conjI)+
+
+lemma alternative_twp:
+  assumes x: "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+  assumes y: "\<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> f' \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+  shows      "\<lbrace>P and P'\<rbrace>,\<lbrace>R\<rbrace> f \<sqinter> f' \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+  unfolding validI_def
+  apply (rule conjI, fastforce simp: validI_prefix_closed[OF x] validI_prefix_closed[OF y])
+  by (fastforce simp: alternative_def post_by_rg[OF x] post_by_rg[OF y] guar_by_rg[OF x] guar_by_rg[OF y])
+
+lemma alternativeE_twp:
+  assumes "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
+  assumes "\<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> f' \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
+  shows   "\<lbrace>P and P'\<rbrace>,\<lbrace>R\<rbrace> f \<sqinter> f' \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
+  unfolding validIE_def
+  by (wpsimp wp: assms alternative_twp | fold validIE_def)+
+
+lemma condition_twp:
+  "\<lbrakk> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> A \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>; \<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> B \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace> \<rbrakk>
+   \<Longrightarrow> \<lbrace>\<lambda>s0 s. if C s then P s0 s else P' s0 s\<rbrace>,\<lbrace>R\<rbrace> condition C A B \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+  by (auto simp: condition_def validI_def prefix_closed_def)
+
+lemma conditionE_twp:
+  "\<lbrakk> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> A \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>; \<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> B \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace> \<rbrakk>
+   \<Longrightarrow> \<lbrace>\<lambda>s0 s. if C s then P s0 s else P' s0 s\<rbrace>,\<lbrace>R\<rbrace> condition C A B \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
+  by (clarsimp simp: validIE_def condition_twp)
+
+lemma when_twp[wp_split]:
+  "\<lbrakk> P \<Longrightarrow> \<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>if P then P' else Q ()\<rbrace>,\<lbrace>R\<rbrace> when P f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+  unfolding when_def by wpsimp
+
+lemma unless_twp[wp_split]:
+  "(\<not>P \<Longrightarrow> \<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>) \<Longrightarrow> \<lbrace>if P then Q () else P'\<rbrace>,\<lbrace>R\<rbrace> unless P f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+  unfolding unless_def by wpsimp (simp split: if_splits)+
+
+lemma whenE_twp:
+  "(P \<Longrightarrow> \<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>) \<Longrightarrow> \<lbrace>if P then P' else Q ()\<rbrace>,\<lbrace>R\<rbrace> whenE P f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
+  unfolding whenE_def by wpsimp
+
+lemma unlessE_twp:
+  "(\<not> P \<Longrightarrow> \<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>) \<Longrightarrow> \<lbrace>if P then Q () else P'\<rbrace>,\<lbrace>R\<rbrace> unlessE P f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
+  unfolding unlessE_def by wpsimp
+
+lemma maybeM_twp:
+  "(\<And>x. y = Some x \<Longrightarrow> \<lbrace>P x\<rbrace>,\<lbrace>R\<rbrace> m x \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>) \<Longrightarrow>
+   \<lbrace>\<lambda>s0 s. (\<forall>x. y = Some x \<longrightarrow> P x s0 s) \<and> (y = None \<longrightarrow> Q () s0 s)\<rbrace>,\<lbrace>R\<rbrace> maybeM m y \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+  unfolding maybeM_def by wpsimp (simp split: if_splits)+
+
+lemma notM_twp:
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> m \<lbrace>G\<rbrace>,\<lbrace>\<lambda>c. Q (\<not> c)\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> notM m \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+  unfolding notM_def by wpsimp
+
+lemma ifM_twp:
+  assumes [wp]: "\<lbrace>Q\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>S\<rbrace>" "\<lbrace>Q'\<rbrace>,\<lbrace>R\<rbrace> g \<lbrace>G\<rbrace>,\<lbrace>S\<rbrace>"
+  assumes [wp]: "\<lbrace>A\<rbrace>,\<lbrace>R\<rbrace> P \<lbrace>G\<rbrace>,\<lbrace>\<lambda>c s0 s. c \<longrightarrow> Q s0 s\<rbrace>" "\<lbrace>B\<rbrace>,\<lbrace>R\<rbrace> P \<lbrace>G\<rbrace>,\<lbrace>\<lambda>c s0 s. \<not>c \<longrightarrow> Q' s0 s\<rbrace>"
+  shows "\<lbrace>A and B\<rbrace>,\<lbrace>R\<rbrace> ifM P f g \<lbrace>G\<rbrace>,\<lbrace>S\<rbrace>"
+  unfolding ifM_def
+  by (wpsimp wp: rg_vcg_if_split rg_vcg_conj_lift)
+
+lemma andM_twp:
+  assumes [wp]: "\<lbrace>Q'\<rbrace>,\<lbrace>R\<rbrace> B \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+  assumes [wp]: "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> A \<lbrace>G\<rbrace>,\<lbrace>\<lambda>c s0 s. c \<longrightarrow> Q' s0 s\<rbrace>" "\<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> A \<lbrace>G\<rbrace>,\<lbrace>\<lambda>c s0 s. \<not> c \<longrightarrow> Q False s0 s\<rbrace>"
+  shows "\<lbrace>P and P'\<rbrace>,\<lbrace>R\<rbrace> andM A B \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+  unfolding andM_def by (wpsimp wp: ifM_twp)
+
+lemma orM_twp:
+  assumes [wp]: "\<lbrace>Q'\<rbrace>,\<lbrace>R\<rbrace> B \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+  assumes [wp]: "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> A \<lbrace>G\<rbrace>,\<lbrace>\<lambda>c s0 s. c \<longrightarrow> Q True s0 s\<rbrace>" "\<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> A \<lbrace>G\<rbrace>,\<lbrace>\<lambda>c s0 s. \<not> c \<longrightarrow> Q' s0 s\<rbrace>"
+  shows "\<lbrace>P and P'\<rbrace>,\<lbrace>R\<rbrace> orM A B \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+  unfolding orM_def by (wp ifM_twp)
+
+lemma whenM_twp:
+  assumes [wp]: "\<lbrace>Q\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>S\<rbrace>"
+  assumes [wp]: "\<lbrace>A\<rbrace>,\<lbrace>R\<rbrace> P \<lbrace>G\<rbrace>,\<lbrace>\<lambda>c s0 s. c \<longrightarrow> Q s0 s\<rbrace>" "\<lbrace>B\<rbrace>,\<lbrace>R\<rbrace> P \<lbrace>G\<rbrace>,\<lbrace>\<lambda>c s0 s. \<not>c \<longrightarrow> S () s0 s\<rbrace>"
+  shows "\<lbrace>A and B\<rbrace>,\<lbrace>R\<rbrace> whenM P f \<lbrace>G\<rbrace>,\<lbrace>S\<rbrace>"
+  unfolding whenM_def by (wp ifM_twp)
+
+lemma rg_K_bind[wp_split]:
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> K_bind f x \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+  by simp
+
+lemma validE_K_bind[wp_split]:
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> x \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>, \<lbrace>E\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> K_bind x f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
+  by simp
+
+lemma rg_fun_app_twp:
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f' x \<lbrace>G\<rbrace>,\<lbrace>Q'\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f' $ x \<lbrace>G\<rbrace>,\<lbrace>Q'\<rbrace>"
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f x \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f $ x \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
+  by simp+
+
+lemma case_option_twp:
+  "\<lbrakk> \<And>x. \<lbrace>P x\<rbrace>,\<lbrace>R\<rbrace> m x \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>; \<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> m' \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace> \<rbrakk>\<Longrightarrow>
+   \<lbrace>\<lambda>s0 s. (x = None \<longrightarrow> P' s0 s) \<and> (x \<noteq> None \<longrightarrow> P (the x) s0 s)\<rbrace>,\<lbrace>R\<rbrace> case_option m' m x \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+  by (cases x; simp)
+
+lemma case_option_twpE:
+  "\<lbrakk> \<And>x. \<lbrace>P x\<rbrace>,\<lbrace>R\<rbrace> m x \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>; \<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> m' \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace> \<rbrakk> \<Longrightarrow>
+   \<lbrace>\<lambda>s0 s. (x = None \<longrightarrow> P' s0 s) \<and> (x \<noteq> None \<longrightarrow> P (the x) s0 s)\<rbrace>,\<lbrace>R\<rbrace> case_option m' m x \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
+  by (cases x; simp)
+
+(* FIXME: make wp *)
+lemma whenE_throwError_twp:
+  "\<lbrace>\<lambda>s0 s. \<not>P \<longrightarrow> Q s0 s\<rbrace>,\<lbrace>R\<rbrace> whenE P (throwError e) \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_. Q\<rbrace>,-"
+  by (simp add: whenE_def returnOk_def throwError_def return_def validIE_def validI_def prefix_closed_def)
+
+(*FIXME MC: not used, worth updating for validI or just delete?
+lemma select_throwError_twp:
+  "\<lbrace>\<lambda>s0 s. \<forall>x\<in>S. Q x s0 s\<rbrace>,\<lbrace>R\<rbrace> select S >>= throwError \<lbrace>G\<rbrace>,-,\<lbrace>Q\<rbrace>"
+  by (simp add: bind_def throwError_def return_def select_def validIE_def validI_def prefix_closed_def)*)
+
+(*FIXME MC: explore adding a rely_preserves definition for the first part of this precondition*)
 lemma env_steps_twp[wp]:
   "\<lbrace>\<lambda>s0 s. (\<forall>s'. R\<^sup>*\<^sup>* s0 s' \<longrightarrow> Q () s' s') \<and> Q () s0 s\<rbrace>,\<lbrace>R\<rbrace> env_steps \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
-  apply (simp add: interference_def env_steps_def)
+  apply (simp add: env_steps_def)
   apply wp
   apply (clarsimp simp: guar_cond_def trace_steps_rev_drop_nth rev_nth)
   apply (drule rely_cond_rtranclp)
@@ -530,6 +1357,329 @@ lemma Await_sync_twp:
   apply (drule rely_cond_rtranclp)
   apply (simp add: o_def)
   done
+
+
+subsection \<open>Setting up the @{method wp} method\<close>
+
+(* Attempt to define triple_judgement to use valid_validI_wp as wp_comb rule.
+   It doesn't work. It seems that wp_comb rules cannot take more than 1 assumption *)
+lemma validI_is_triple:
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>
+   = triple_judgement (\<lambda>(s0,s). prefix_closed f \<longrightarrow> P s0 s) f
+                      (\<lambda>(s0,s) f. prefix_closed f \<and> (\<forall>tr res. (tr, res) \<in> rely f R s0 s
+                          \<longrightarrow> guar_cond G s0 tr
+                              \<and> (\<forall>rv s'. res = Result (rv, s') \<longrightarrow> Q rv (last_st_tr tr s0) s')))"
+  apply (simp add: triple_judgement_def validI_def )
+  apply (cases "prefix_closed f"; fastforce)
+  done
+
+lemma validIE_is_triple:
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>
+   = triple_judgement (\<lambda>(s0,s). prefix_closed f \<longrightarrow> P s0 s) f
+                      (\<lambda>(s0,s) f. prefix_closed f \<and> (\<forall>tr res. (tr, res) \<in> rely f R s0 s
+                          \<longrightarrow> guar_cond G s0 tr
+                              \<and> (\<forall>rv s'. res = Result (rv, s')
+                                   \<longrightarrow> (case rv of Inr b \<Rightarrow> Q b (last_st_tr tr s0) s'
+                                                 | Inl a \<Rightarrow> E a (last_st_tr tr s0) s'))))"
+  by (fastforce simp: validIE_def2 triple_judgement_def)
+
+lemmas rg_wp_combs = rg_vcg_conj_lift
+
+lemmas rg_wp_combsE =
+  rg_vcg_conj_liftE1
+  rg_vcg_conj_liftE2
+  rg_vcg_E_elim
+
+lemmas rg_wp_state_combsE =
+  validI_validIE_R
+  rg_vcg_conj_liftE1[OF validI_validIE_R]
+  rg_vcg_E_elim[OF validI_validIE_E]
+  rg_vcg_conj_liftE2[OF validI_validIE_E]
+
+lemmas rg_classic_wp_combs = rg_post_comb_imp_conj rg_weaken_pre rg_wp_combs
+lemmas rg_classic_wp_combsE = rg_weaken_preE rg_wp_combsE
+
+lemmas rg_classic_wp_state_combsE =
+  rg_weaken_preE[OF validI_validIE]
+  rg_wp_state_combsE
+
+lemmas all_rg_classic_wp_combs =
+  rg_classic_wp_state_combsE
+  rg_classic_wp_combsE
+  rg_classic_wp_combs
+
+lemmas rg_wp_splits[wp_split] =
+  bind_twp bindE_twp handleE'_twp handleE_twp
+  catch_twp rg_vcg_if_split rg_vcg_if_splitE
+  liftM_twp liftME_twp whenE_twp unlessE_twp
+  validIE_validI
+
+lemmas [wp_comb] = rg_wp_state_combsE rg_wp_combsE rg_wp_combs
+
+(* rules towards the bottom will be matched first *)
+lemmas [wp] = rg_vcg_prop
+              twp_post_taut
+              twp_post_tautE
+              rg_fun_app_twp
+              liftE_twp
+              alternative_twp
+              alternativeE_twp
+              condition_twp
+              conditionE_twp
+              maybeM_twp notM_twp ifM_twp andM_twp orM_twp whenM_twp
+
+lemmas [wp_trip] = validI_is_triple validIE_is_triple
+
+
+subsection \<open>Simplifications on conjunction\<close>
+
+lemma rg_post_eq:
+  "\<lbrakk> Q = Q'; \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q'\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+  by simp
+
+lemma rg_post_eqE1:
+  "\<lbrakk> Q = Q'; \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q'\<rbrace>,\<lbrace>E\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
+  by simp
+
+lemma rg_post_eqE2:
+  "\<lbrakk> E = E'; \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E'\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
+  by simp
+
+lemma pred_conj_apply_elim':
+  "(\<lambda>rv. Q rv and Q' rv) = (\<lambda>rv s0 s. Q rv s0 s \<and> Q' rv s0 s)"
+  by (simp add: pred_conj_def)
+
+lemma pred_conj_conj_elim':
+  "(\<lambda>rv s0 s. (Q rv and Q' rv) s0 s \<and> Q'' rv s0 s) = (\<lambda>rv s0 s. Q rv s0 s \<and> Q' rv s0 s \<and> Q'' rv s0 s)"
+  by simp
+
+lemma conj_assoc_apply':
+  "(\<lambda>rv s0 s. (Q rv s0 s \<and> Q' rv s0 s) \<and> Q'' rv s0 s) = (\<lambda>rv s0 s. Q rv s0 s \<and> Q' rv s0 s \<and> Q'' rv s0 s)"
+  by simp
+
+lemma all_elim':
+  "(\<lambda>rv s0 s. \<forall>x. P rv s0 s) = P"
+  by simp
+
+lemma all_conj_elim':
+  "(\<lambda>rv s0 s. (\<forall>x. P rv s0 s) \<and> Q rv s0 s) = (\<lambda>rv s0 s. P rv s0 s \<and> Q rv s0 s)"
+  by simp
+
+lemmas rg_vcg_rhs_simps =
+  pred_conj_apply_elim' pred_conj_conj_elim' conj_assoc_apply' all_elim' all_conj_elim'
+
+lemma if_apply_reductI:
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> If P' (f x) (g x) \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> If P' f g x \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+  by (cases P'; simp)
+
+lemma if_apply_reductIE:
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> If P' (f x) (g x) \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> If P' f g x \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
+  by (cases P'; simp)
+
+lemmas rg_wp_simps[wp_split] =
+  rg_vcg_rhs_simps[THEN rg_post_eq] rg_vcg_rhs_simps[THEN rg_post_eqE1]
+  rg_vcg_rhs_simps[THEN rg_post_eqE2]
+  if_apply_reductI if_apply_reductIE TrueI
+
+schematic_goal rg_if_apply_test:
+  "\<lbrace>?Q\<rbrace>,\<lbrace>R\<rbrace> (if A then returnOk else K fail) x \<lbrace>G\<rbrace>,\<lbrace>P\<rbrace>,\<lbrace>E\<rbrace>"
+  by wpsimp
+
+lemma rg_elim_pred_conj:
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. Q rv s0 s \<and> Q' rv s0 s\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv. Q rv and Q' rv\<rbrace>"
+  by (unfold pred_conj_def)
+
+lemma rg_elim_pred_conjE1:
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. Q rv s0 s \<and> Q' rv s0 s\<rbrace>,\<lbrace>E\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv. Q rv and Q' rv\<rbrace>,\<lbrace>E\<rbrace>"
+  by (unfold pred_conj_def)
+
+lemma rg_elim_pred_conjE2:
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>\<lambda>rv s0 s. E rv s0 s \<and> E' rv s0 s\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>\<lambda>rv. E rv and E' rv\<rbrace>"
+  by (unfold pred_conj_def)
+
+lemmas rg_wp_pred_conj_elims =
+  rg_elim_pred_conj rg_elim_pred_conjE1 rg_elim_pred_conjE2
+
+
+subsection \<open>Bundles\<close>
+
+bundle no_rg_pre = rg_pre [wp_pre del]
+
+bundle classic_twp_pre = rg_pre [wp_pre del]
+    all_rg_classic_wp_combs[wp_comb del] all_rg_classic_wp_combs[wp_comb]
+
+
+text \<open>Miscellaneous lemmas on rg quintuples\<close>
+
+lemma rg_pre_cases:
+  "\<lbrakk> \<lbrace>\<lambda>s0 s. C s0 s \<and> P s0 s\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>; \<lbrace>\<lambda>s0 s. \<not>C s0 s \<and> P' s0 s\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace> \<rbrakk>
+   \<Longrightarrow> \<lbrace>P and P'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+  unfolding validI_def by fastforce
+
+lemma rg_vcg_mp:
+  "\<lbrakk> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>; \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>r s0 s. Q r s0 s \<longrightarrow> Q' r s0 s\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q'\<rbrace>"
+  by (auto simp: validI_def)
+
+(* note about this precond stuff: rules get a chance to bind directly
+   before any of their combined forms. As a result, these precondition
+   implication rules are only used when needed. *)
+lemma rg_add_post:
+  "\<lbrakk> \<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q'\<rbrace>; \<And>s0 s. P s0 s \<Longrightarrow> P' s0 s; \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. Q' rv s0 s \<longrightarrow> Q rv s0 s\<rbrace> \<rbrakk>
+   \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+  unfolding validI_def by fastforce
+
+lemma rg_gen_asmE:
+  "\<lbrakk>P \<Longrightarrow> \<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>; \<not> P \<Longrightarrow> prefix_closed f\<rbrakk>
+   \<Longrightarrow> \<lbrace>P' and (\<lambda>_ _. P)\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
+  by (simp add: validIE_def validI_def) blast
+
+lemma rg_list_case:
+  "\<lbrakk> \<lbrace>P1\<rbrace>,\<lbrace>R\<rbrace> f f1 \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>; \<And>y ys. xs = y#ys \<Longrightarrow> \<lbrace>P2 y ys\<rbrace>,\<lbrace>R\<rbrace> f (f2 y ys) \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace> \<rbrakk> \<Longrightarrow>
+   \<lbrace>case xs of [] \<Rightarrow> P1 | y#ys \<Rightarrow> P2 y ys\<rbrace>,\<lbrace>R\<rbrace> f (case xs of [] \<Rightarrow> f1 | y#ys \<Rightarrow> f2 y ys) \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+  by (cases xs; simp)
+
+lemma rg_use_eq:
+  assumes "\<And>P. \<lbrace>\<lambda>s0 s. P (f s)\<rbrace>,\<lbrace>R\<rbrace> m \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_ s0 s. P (f s)\<rbrace>"
+  assumes "\<And>f. \<lbrace>\<lambda>s0 s. P f s0 s\<rbrace>,\<lbrace>R\<rbrace> m \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_ s0 s. Q f s0 s\<rbrace>"
+  shows "\<lbrace>\<lambda>s0 s. P (f s) s0 s\<rbrace>,\<lbrace>R\<rbrace> m \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_ s0 s. Q (f s) s0 s \<rbrace>"
+  apply (rule rg_post_imp[where Q'="\<lambda>_ s0 s. \<exists>y. y = f s \<and> Q y s0 s"], simp)
+  apply (wpsimp wp: rg_vcg_ex_lift assms)
+  done
+
+lemma rg_validE_pred_conj:
+  "\<lbrakk> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>; \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q'\<rbrace>,\<lbrace>E\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q and Q'\<rbrace>,\<lbrace>E\<rbrace>"
+  unfolding validI_def validIE_def
+  by (simp split: sum.splits)
+
+lemma rg_validE_conj:
+  "\<lbrakk> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>; \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q'\<rbrace>,\<lbrace>E\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. Q rv s0 s \<and> Q' rv s0 s\<rbrace>,\<lbrace>E\<rbrace>"
+  unfolding validI_def validIE_def
+  by (simp split: sum.splits)
+
+lemma rg_drop_imp:
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. Q' rv s0 s \<longrightarrow> Q rv s0 s\<rbrace>"
+  by (auto simp: validI_def)
+
+lemma rg_drop_impE:
+  "\<lbrakk>\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>r. Q\<rbrace>, \<lbrace>E\<rbrace>\<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. Q' rv s0 s \<longrightarrow> Q s0 s\<rbrace>, \<lbrace>E\<rbrace>"
+  by (simp add: validIE_weaken)
+
+lemma rg_drop_impE_E:
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>, \<lbrace>\<lambda>rv s0 s. E' rv s0 s \<longrightarrow> E rv s0 s\<rbrace>"
+  by (auto simp: validIE_def validI_def split: sum.splits)
+
+lemmas rg_drop_imps = rg_drop_imp rg_drop_impE rg_drop_impE_E
+
+(*This is unsafe, but can be very useful when supplied as a comb rule.*)
+lemma rg_drop_imp_conj[wp_unsafe]:
+  "\<lbrakk> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q'\<rbrace>; \<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. (Q rv s0 s \<longrightarrow> Q'' rv s0 s) \<and> Q''' rv s0 s\<rbrace> \<rbrakk> \<Longrightarrow>
+   \<lbrace>P and P'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. (Q rv s0 s \<longrightarrow> Q' rv s0 s \<and> Q'' rv s0 s) \<and> Q''' rv s0 s\<rbrace>"
+  by (auto simp: validI_def)
+
+lemmas rg_drop_imp_conj'[wp_unsafe] = rg_drop_imp_conj[where Q'''="\<top>\<top>\<top>", simplified]
+
+lemma rg_vcg_set_pred_lift:
+  assumes "\<And>P x. m \<lbrace>R\<rbrace>,\<lbrace>G\<rbrace>,\<lbrace> \<lambda>s0 s. P (f x s0 s) \<rbrace>"
+  shows "m \<lbrace>R\<rbrace>,\<lbrace>G\<rbrace>,\<lbrace> \<lambda>s0 s. P {x. f x s0 s} \<rbrace>"
+  using assms[where P="\<lambda>x . x"] assms[where P=Not]
+  by (fastforce simp: validI_def elim!: subst[rotated, where P=P])
+
+(*If there is a use case which requires a specific guarantee then this rule could be extended with
+  an extra assumption and precondition.*)
+lemma rg_vcg_set_pred_lift_mono:
+  assumes f: "\<And>x. m \<lbrace>R\<rbrace>,-,\<lbrace> f x \<rbrace>"
+  assumes mono: "\<And>A B. A \<subseteq> B \<Longrightarrow> P A \<Longrightarrow> P B"
+  shows "m \<lbrace>R\<rbrace>,-,\<lbrace> \<lambda>s0 s. P {x. f x s0 s} \<rbrace>"
+  by (fastforce simp: validI_def validI_prefix_closed[OF f] elim!: mono[rotated]
+                dest: use_validI[OF _ f])
+
+text \<open>If a function contains an @{term assert}, or equivalent, then it might be
+      possible to strengthen the precondition of an already-proven rg quintuple
+      @{text pos}, by additionally proving a side condition @{text neg}, that
+      violating some condition causes failure. The stronger rg quintuple produced
+      by this theorem allows the precondition to assume that the condition is
+      satisfied.\<close>
+lemma rg_strengthen_pre_via_assert_forward:
+  assumes pos: "\<lbrace> P \<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace> Q \<rbrace>"
+  assumes rel: "\<And>s0 s. S s0 s \<longrightarrow> P s0 s \<or> N s0 s"
+  assumes neg: "\<lbrace> N \<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace> \<bottom>\<bottom>\<bottom> \<rbrace>"
+  shows "\<lbrace> S \<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace> Q \<rbrace>"
+  apply (rule rg_weaken_pre)
+   apply (rule rg_strengthen_post)
+    apply (rule rg_vcg_disj_lift[OF pos neg])
+   by (auto simp: rel)
+
+text \<open>Like @{thm rg_strengthen_pre_via_assert_forward}, strengthen a precondition
+      by proving a side condition that the negation of that condition would cause
+      failure. This version is intended for backward reasoning. Apply it to a goal to
+      obtain a stronger precondition after proving the side condition.\<close>
+lemma rg_strengthen_pre_via_assert_backward:
+  assumes neg: "\<lbrace> \<lambda>s0 s. \<not> E s0 s \<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace> \<bottom>\<bottom>\<bottom> \<rbrace>"
+  assumes pos: "\<lbrace> P and E \<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace> Q \<rbrace>"
+  shows "\<lbrace> P \<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace> Q \<rbrace>"
+  by (rule rg_strengthen_pre_via_assert_forward[OF pos _ neg], simp)
+
+
+subsection \<open>Strongest postcondition rules\<close>
+
+lemma get_tsp:
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> get \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. s = rv \<and> P s0 s\<rbrace>"
+  by (simp add: get_def validI_def prefix_closed_def)
+
+lemma put_tsp:
+  "\<lbrace>\<top>\<top>\<rbrace>,\<lbrace>R\<rbrace> put a \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_ s0 s. s = a\<rbrace>"
+  by (simp add: put_def validI_def prefix_closed_def)
+
+lemma return_tsp:
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> return a \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. rv = a \<and> P s0 s\<rbrace>"
+  by (simp add:return_def validI_def prefix_closed_def)
+
+lemma rg_return_tsp: (* FIXME lib: eliminate *)
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> return x \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv. P and (\<lambda>_ _. rv = x)\<rbrace>"
+  by (simp add: validI_def return_def prefix_closed_def)
+
+lemma assert_tsp:
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> assert Q \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_ s0 s. P s0 s \<and> Q\<rbrace>"
+  by (simp add: assert_def fail_def return_def validI_def prefix_closed_def)
+
+lemma rg_gets_tsp:
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> gets f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. rv = f s \<and> P s0 s\<rbrace>"
+  by (simp add: validI_def simpler_gets_def prefix_closed_def)
+
+lemma rg_returnOk_tsp:
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> returnOk x \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. rv = x \<and> P s0 s\<rbrace>, \<lbrace>Q\<rbrace>"
+  by (simp add: validI_def validIE_def returnOk_def return_def prefix_closed_def)
+
+\<comment> \<open>For forward reasoning in RG proofs, these lemmas allow us to step over the
+    left-hand-side of monadic bind, while keeping the same precondition.\<close>
+
+named_theorems forward_inv_step_rules
+
+lemmas rg_forward_inv_step_nobind[forward_inv_step_rules] =
+  bind_twp_nobind[where B=A and A=A for A, rotated]
+
+lemmas bind_twp_fwd_skip[forward_inv_step_rules] =
+  bind_twp_fwd[where Q'="\<lambda>_. P" and P=P for P]
+
+lemmas rg_forward_inv_step_nobindE_valid[forward_inv_step_rules] =
+  bindE_twp_nobind[where B=A and A=A and E="\<lambda>_. C" and C="\<lambda>_. C" for A C,
+                        simplified validIE_eq_validI, rotated]
+
+lemmas rg_forward_inv_step_valid[forward_inv_step_rules] =
+  bindE_twp_fwd[where Q'="\<lambda>_. P" and P=P and E="\<lambda>_. Q" and Q="\<lambda>_. Q" for P Q,
+                 simplified validIE_eq_validI]
+
+lemmas rg_forward_inv_step_nobindE[forward_inv_step_rules] =
+  bindE_twp_nobind[where B=A and A=A for A, rotated]
+
+lemmas bindE_twp_fwd_skip[forward_inv_step_rules] =
+  bindE_twp_fwd[where Q'="\<lambda>_. P" and P=P for P]
+
+method forward_inv_step uses wp simp =
+  rule forward_inv_step_rules, solves \<open>wpsimp wp: wp simp: simp\<close>
+
+
+subsection \<open>FIXME MC: look at these lemmas and work out where they should go / what this section should be called\<close>
 
 lemma mres_union:
   "mres (a \<union> b) = mres a \<union> mres b"
@@ -665,21 +1815,13 @@ lemma validI_guar_post_conj_lift:
   apply (auto simp: guar_cond_def)
   done
 
-lemma rely_cond_True[simp]:
-  "rely_cond \<top>\<top> s0 tr = True"
-  by (clarsimp simp: rely_cond_def)
-
-lemma guar_cond_True[simp]:
-  "guar_cond \<top>\<top> s0 tr = True"
-  by (clarsimp simp: guar_cond_def)
-
 lemma validI_valid_wp:
-  "\<lbrakk>\<lbrace>P\<rbrace>,\<lbrace>\<top>\<top>\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv _ s. Q rv s\<rbrace>\<rbrakk>
+  "\<lbrakk>\<lbrace>P\<rbrace>,\<lbrace>\<top>\<top>\<rbrace> f -,\<lbrace>\<lambda>rv _ s. Q rv s\<rbrace>\<rbrakk>
    \<Longrightarrow> \<lbrace>P s0\<rbrace> f \<lbrace>Q\<rbrace>"
   by (auto simp: rely_def validI_def valid_def mres_def)
 
 lemma validI_triv_valid_eq:
-  "prefix_closed f \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>\<top>\<top>\<rbrace> f \<lbrace>\<top>\<top>\<rbrace>,\<lbrace>\<lambda>rv _ s. Q rv s\<rbrace> = (\<forall>s0. \<lbrace>\<lambda>s. P s0 s\<rbrace> f \<lbrace>Q\<rbrace>)"
+  "prefix_closed f \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>\<top>\<top>\<rbrace> f -,\<lbrace>\<lambda>rv _ s. Q rv s\<rbrace> = (\<forall>s0. \<lbrace>\<lambda>s. P s0 s\<rbrace> f \<lbrace>Q\<rbrace>)"
   by (fastforce simp: rely_def validI_def valid_def mres_def image_def)
 
 end

--- a/lib/Monads/trace/Trace_Strengthen_Setup.thy
+++ b/lib/Monads/trace/Trace_Strengthen_Setup.thy
@@ -39,7 +39,7 @@ lemma strengthen_validE_E_cong[strg]:
 lemma strengthen_validI[strg]:
   "\<lbrakk>\<And>r s0 s. st F (\<longrightarrow>) (Q r s0 s) (Q' r s0 s)\<rbrakk>
    \<Longrightarrow> st F (\<longrightarrow>) (\<lbrace>P\<rbrace>,\<lbrace>G\<rbrace> f \<lbrace>R\<rbrace>,\<lbrace>Q\<rbrace>) (\<lbrace>P\<rbrace>,\<lbrace>G\<rbrace> f \<lbrace>R\<rbrace>,\<lbrace>Q'\<rbrace>)"
-  by (cases F, auto elim: validI_strengthen_post)
+  by (cases F, auto elim: rg_strengthen_post)
 
 lemma wpfix_strengthen_hoare:
   "\<lbrakk>\<And>s. st (\<not> F) (\<longrightarrow>) (P s) (P' s); \<And>r s. st F (\<longrightarrow>) (Q r s) (Q' r s)\<rbrakk>

--- a/lib/concurrency/Atomicity_Lib.thy
+++ b/lib/concurrency/Atomicity_Lib.thy
@@ -36,10 +36,7 @@ lemma pfx_refn_interferences:
     \<Longrightarrow> prefix_refinement sr iosr iosr (\<top>\<top>) (\<top>\<top>) (\<top>\<top>) AR R interferences interferences"
   apply (rule prefix_refinement_repeat)
     apply (erule prefix_refinement_interference)
-   apply wp
-   apply simp
-  apply wp
-  apply simp
+   apply wp+
   done
 
 lemma repeat_n_validI:
@@ -59,7 +56,7 @@ lemma repeat_validI:
 lemma interferences_twp[wp]:
   "\<lbrace>\<lambda>s0 s. (\<forall>s'. R\<^sup>*\<^sup>* s s' \<longrightarrow> Q () s' s') \<and> G s0 s \<and> reflp G \<and> Q () s0 s\<rbrace>,\<lbrace>R\<rbrace> interferences \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
   (is "\<lbrace>?P\<rbrace>,\<lbrace>R\<rbrace> ?f \<lbrace>G\<rbrace>,\<lbrace>?Q\<rbrace>")
-  apply (rule validI_strengthen_post, rule repeat_validI)
+  apply (rule rg_strengthen_post, rule repeat_validI)
    apply wp
    apply (clarsimp simp: reflpD[where R=G])
    apply (metis rtranclp_trans)
@@ -506,7 +503,7 @@ lemma rel_tr_refinement_bind_right_general:
         split del: if_split)
   done
 
-lemmas validI_triv' = validI_weaken_pre[OF validI_triv, simplified]
+lemmas validI_triv' = rg_weaken_pre[OF validI_triv, simplified]
 lemmas rel_tr_refinement_bind_right
     = rel_tr_refinement_bind_right_general[where C'=False, simplified]
 
@@ -529,8 +526,7 @@ lemma rel_tr_refinement_comm_repeat_n[simplified K_bind_def]:
    apply (rule rel_tr_refinement_bind_right_general[rule_format])
      apply (metis equivpE)
     apply assumption
-   apply (rule validI_weaken_pre, wp repeat_n_validI)
-   apply simp
+   apply (wpsimp wp: repeat_n_validI)
   apply (drule_tac h="\<lambda>x. do f; return x od"
       in rel_tr_refinement_bind_left_general[rotated 2])
     apply (metis equivpE)
@@ -551,7 +547,7 @@ lemma rel_tr_refinement_comm_repeat[simplified K_bind_def]:
   apply (rule rel_tr_refinement_bind_right_general[rule_format])
     apply (metis equivpE)
    apply (erule(1) rel_tr_refinement_comm_repeat_n, simp+)
-  apply (rule validI_weaken_pre, wp, simp)
+  apply wpsimp
   done
 
 lemma rel_tr_refinement_rev_comm_repeat_n[simplified K_bind_def]:
@@ -574,8 +570,7 @@ lemma rel_tr_refinement_rev_comm_repeat_n[simplified K_bind_def]:
    apply (rule rel_tr_refinement_bind_right_general[rule_format])
      apply (metis equivpE)
     apply assumption
-   apply (rule validI_weaken_pre, wp repeat_n_validI)
-   apply simp
+   apply (wpsimp wp: repeat_n_validI)
   apply (drule_tac h="\<lambda>x. do f; return x od"
       in rel_tr_refinement_bind_left_general[rotated 2])
     apply (metis equivpE)
@@ -596,7 +591,7 @@ lemma rel_tr_refinement_rev_comm_repeat[simplified K_bind_def]:
   apply (rule rel_tr_refinement_bind_right_general[rule_format])
     apply (metis equivpE)
    apply (erule(1) rel_tr_refinement_rev_comm_repeat_n, simp+)
-  apply (rule validI_weaken_pre, wp, simp)
+  apply wpsimp
   done
 
 lemma alternative_distrib_lhs_bind:
@@ -755,8 +750,7 @@ lemma shuttle_gets_env_step[simplified K_bind_def]:
 lemma env_step_twp[wp]:
   "\<lbrace>\<lambda>s0 s. (\<forall>s'. R s0 s' \<longrightarrow> Q () s' s')\<rbrace>,\<lbrace>R\<rbrace> env_step \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
   apply (simp add: env_step_def)
-  apply (rule validI_weaken_pre)
-   apply (wp put_trace_elem_twp)
+  apply (wp put_trace_elem_twp)
   apply (clarsimp simp: rely_cond_def drop_Cons' guar_cond_def)
   done
 
@@ -775,7 +769,7 @@ lemma shuttle_modify_interferences[simplified K_bind_def]:
      apply assumption
     apply (rule shuttle_modify_interference, (simp add: r_into_rtranclp)+)
    apply (simp add: not_env_steps_first_interference)
-  apply (rule validI_weaken_pre, wp, simp)
+  apply wpsimp
   done
 
 lemmas shuttle_modify_interferences_flat
@@ -798,8 +792,7 @@ lemma rshuttle_modify_interferences[simplified K_bind_def]:
      apply assumption
     apply (rule rshuttle_modify_interference, (simp add: r_into_rtranclp)+)
    apply (simp add: not_env_steps_first_interference)
-  apply (rule validI_weaken_pre, wp)
-  apply simp
+  apply wpsimp
   done
 
 lemma shuttle_gets_interference[simplified K_bind_def]:
@@ -819,9 +812,9 @@ lemma shuttle_gets_interference[simplified K_bind_def]:
        apply (metis equivpE)
       apply simp
      apply simp
-    apply (rule validI_weaken_pre, wp)
+    apply wpsimp
     apply (clarsimp simp: r_into_rtranclp)
-   apply (simp add: commit_step_def, rule validI_weaken_pre, wp put_trace_elem_twp)
+   apply (simp add: commit_step_def, wp put_trace_elem_twp)
    apply (simp add: drop_Cons' guar_cond_def)
   apply (rule shuttle_gets_commit_step[THEN
     rel_tr_refinement_bind_left_general[rotated -1], simplified bind_assoc return_bind])
@@ -844,8 +837,7 @@ lemma shuttle_gets_interferences[simplified K_bind_def]:
     apply simp
    apply (rule rel_tr_refinement_comm_repeat, assumption)
      apply (rule shuttle_gets_interference; simp)
-     apply simp
-    apply (rule validI_weaken_pre, wp, simp)
+    apply simp
    apply wpsimp
   apply (simp add: bind_assoc)
   apply (rule rel_tr_refinement_refl)

--- a/lib/concurrency/Prefix_Refinement.thy
+++ b/lib/concurrency/Prefix_Refinement.thy
@@ -995,7 +995,7 @@ theorem prefix_refinement_validI:
   apply (case_tac tr; clarsimp simp: list_all2_Cons2 matching_tr_def)
   done
 
-lemmas prefix_refinement_validI' = prefix_refinement_validI[OF _ validI_strengthen_guar, OF _ validI_strengthen_post]
+lemmas prefix_refinement_validI' = prefix_refinement_validI[OF _ rg_strengthen_guar, OF _ rg_strengthen_post]
 
 section \<open>Building blocks.\<close>
 text \<open>
@@ -1239,7 +1239,7 @@ lemma prefix_refinement_repeat:
        apply simp
       apply simp
       apply (rule prefix_refinement_repeat_n, assumption+)
-      apply (rule validI_weaken_pre, assumption, simp)
+      apply (rule rg_weaken_pre, assumption, simp)
      apply wp
     apply wp
    apply clarsimp

--- a/lib/concurrency/Triv_Refinement.thy
+++ b/lib/concurrency/Triv_Refinement.thy
@@ -6,7 +6,7 @@
 theory Triv_Refinement
 
 imports
-  "Monads.Trace_RG"
+  "Monads.Trace_More_RG"
   "Monads.Trace_Strengthen_Setup"
 
 begin

--- a/lib/concurrency/examples/Peterson_Atomicity.thy
+++ b/lib/concurrency/examples/Peterson_Atomicity.thy
@@ -258,9 +258,9 @@ lemma cs2_wp_apply_peterson[wp]:
   \<lbrace> peterson_rel ident \<rbrace>,
   \<lbrace> Q \<rbrace>"
   apply (rule validI_name_pre[OF cs_closed], clarsimp simp del: imp_disjL)
-  apply (rule validI_weaken_pre)
+  apply (rule rg_weaken_pre)
    apply (rule validI_well_behaved[OF cs_closed])
-     apply (rule validI_strengthen_post)
+     apply (rule rg_strengthen_post)
       apply (rule_tac s=s and ?s0.0=s0
          and lockf="\<lambda>s. critical (ab_label s ident)"
          and I="invs" in cs_wp)
@@ -284,8 +284,7 @@ lemma release_lock_mutual_excl:
    \<lbrace> \<lambda>rv s0 s. peterson_rel ident s0 s \<and> invs s
                \<and> ab_label s ident = Exited \<rbrace>"
   apply (simp add: release_lock_def)
-  apply (rule validI_weaken_pre)
-   apply wpsimp+
+  apply wpsimp
   apply (strengthen peterson_rel_imp_assume_invs | simp)+
   apply (cases ident)
   apply (safe, simp_all)
@@ -303,8 +302,7 @@ lemma abs_critical_section_mutual_excl:
    \<lbrace> \<lambda>rv s0 s. peterson_rel ident s0 s \<and> invs s
                \<and> ab_label s ident = Critical \<and> csI (cs2_v s) \<rbrace>"
   apply (simp add: abs_critical_section_def)
-  apply (rule validI_weaken_pre)
-   apply wpsimp+
+  apply wpsimp
   apply (strengthen peterson_rel_imp_assume_invs | simp)+
   apply (cases ident)
   apply (safe, simp_all)
@@ -321,8 +319,7 @@ lemma acquire_lock_mutual_excl:
    \<lbrace> \<lambda>rv s0 s. peterson_rel ident s0 s \<and> invs s \<and> invs s0
                \<and> ab_label s ident = Critical \<and> csI (cs2_v s) \<rbrace>"
   apply (simp add: acquire_lock_def)
-  apply (rule validI_weaken_pre)
-   apply (wpsimp wp: Await_sync_twp)+
+  apply (wpsimp wp: Await_sync_twp)
   apply (strengthen peterson_rel_imp_assume_invs | simp)+
   apply (cases ident)
   apply (safe, simp_all)
@@ -340,9 +337,8 @@ theorem abs_peterson_proc_mutual_excl:
    \<lbrace> \<lambda>rv s0 s. peterson_rel ident s0 s \<and> invs s
                \<and> ab_label s ident = Exited \<rbrace>"
   apply (simp add: abs_peterson_proc_def bind_assoc)
-  apply (rule validI_weaken_pre)
-   apply (wpsimp wp: release_lock_mutual_excl acquire_lock_mutual_excl
-                     abs_critical_section_mutual_excl)+
+  apply (wpsimp wp: release_lock_mutual_excl acquire_lock_mutual_excl
+                    abs_critical_section_mutual_excl)
   done
 
 definition
@@ -562,8 +558,7 @@ lemma acquire_lock_wp:
    \<lbrace> \<top>\<top> \<rbrace>,
    \<lbrace> \<lambda>rv s0 s. invs s \<and> ab_label s ident = Critical \<rbrace>"
   apply (simp add: acquire_lock_def)
-  apply (rule validI_weaken_pre)
-   apply (wpsimp wp: Await_sync_twp)+
+  apply (wpsimp wp: Await_sync_twp)
   apply (subst (asm) peterson_rel_imp_label, assumption+)
   apply (drule(1) peterson_rel_imp_invs)
   apply (drule(1) peterson_rel_trans)
@@ -630,7 +625,7 @@ lemma peterson_rel_helpers:
   by (clarsimp simp: peterson_rel_def peterson_rel2_def peterson_rel3_def)
 
 lemma peterson_rel_peterson_rel2:
-  "peterson_rel ident s0 s \<longrightarrow> peterson_rel2 ident s0 s"
+  "peterson_rel ident s0 s \<Longrightarrow> peterson_rel2 ident s0 s"
   by (clarsimp simp: peterson_rel_def peterson_rel2_def)
 
 lemma peterson_sr_peterson_rel3:
@@ -679,9 +674,8 @@ lemma peterson_proc_mutual_excl_helper':
                \<and> ab_label s ident = Exited \<rbrace>"
   apply (simp add: peterson_proc_def acquire_lock_def release_lock_def
                    critical_section_def)
-  apply (rule validI_weaken_pre)
-   apply (wp Await_sync_twp | simp add: split_def
-          | rule validI_strengthen_guar[OF _ allI[OF allI[OF peterson_rel_peterson_rel2]]])+
+  apply (wp Await_sync_twp | simp add: split_def
+         | rule rg_strengthen_guar[OF _ peterson_rel_peterson_rel2])+
   apply (clarsimp simp: imp_conjL)
   apply (strengthen peterson_rel_imp_assume_invs | simp)+
   apply (cases ident)
@@ -699,7 +693,7 @@ lemma peterson_proc_mutual_excl:
    \<lbrace> peterson_rel ident \<rbrace>,
    \<lbrace> \<lambda>rv s0 s. peterson_rel ident s0 s \<and> invs s
                \<and> ab_label s ident = Exited \<rbrace>"
-  apply (rule validI_strengthen_guar, rule validI_strengthen_post, rule validI_guar_post_conj_lift)
+  apply (rule rg_strengthen_guar, rule rg_strengthen_post, rule validI_guar_post_conj_lift)
      apply (rule peterson_proc_mutual_excl_helper)
     apply (rule peterson_proc_mutual_excl_helper')
    apply (clarsimp simp: peterson_rel_helpers)+
@@ -716,7 +710,7 @@ lemma validI_repeat_interference:
   apply (rule bind_twp)
    apply simp
    apply (rule interference_twp)
-  apply (rule validI_strengthen_post)
+  apply (rule rg_strengthen_post)
    apply (rule repeat_validI, assumption)
   apply simp
   done
@@ -727,7 +721,7 @@ lemma abs_peterson_proc_system_mutual_excl:
      abs_peterson_proc_system
    \<lbrace> \<lambda>s0 s. invs s0 \<longrightarrow> invs s \<rbrace>,
    \<lbrace> \<lambda>rv s0 s. invs s \<rbrace>"
-  apply (rule validI_weaken_pre, rule validI_strengthen_post)
+  apply (rule rg_weaken_pre, rule rg_strengthen_post)
     apply (unfold abs_peterson_proc_system_def)
     apply (rule rg_validI[where Qf="\<lambda>_ _. invs" and Qg="\<lambda>_ _. invs"])
            apply (rule validI_repeat_interference[OF abs_peterson_proc_mutual_excl])
@@ -761,9 +755,9 @@ lemma peterson_repeat_refinement:
   apply (rule prefix_refinement_weaken_pre)
     apply (rule prefix_refinement_bind_sr)
        apply (rule prefix_refinement_repeat[rotated])
-         apply (rule abs_peterson_proc_mutual_excl[THEN validI_strengthen_guar])
+         apply (rule abs_peterson_proc_mutual_excl[THEN rg_strengthen_guar])
          apply simp
-        apply (rule peterson_proc_mutual_excl[THEN validI_strengthen_guar, THEN validI_weaken_pre])
+        apply (rule peterson_proc_mutual_excl[THEN rg_strengthen_guar, THEN rg_weaken_pre])
          apply simp+
        apply (rule peterson_proc_refinement[THEN prefix_refinement_weaken_pre])
         apply simp+
@@ -793,19 +787,19 @@ theorem peterson_proc_system_refinement:
         apply (rule eq_refl, rule bipred_disj_op_eq, simp)
        apply (clarsimp intro!: par_tr_fin_bind par_tr_fin_interference)
       apply (clarsimp intro!: par_tr_fin_bind par_tr_fin_interference)
-     apply (rule validI_weaken_pre, rule validI_weaken_rely)
+     apply (rule rg_weaken_pre, rule rg_weaken_rely)
        apply (rule validI_repeat_interference; simp)
         apply (rule peterson_proc_mutual_excl)
        apply (simp+)[3]
-    apply (rule validI_weaken_pre, rule validI_weaken_rely)
+    apply (rule rg_weaken_pre, rule rg_weaken_rely)
       apply (rule validI_repeat_interference; simp)
        apply (rule peterson_proc_mutual_excl)
       apply (simp+)[3]
-  apply (rule validI_weaken_pre, rule validI_weaken_rely)
+  apply (rule rg_weaken_pre, rule rg_weaken_rely)
      apply (rule validI_repeat_interference; simp)
       apply (rule abs_peterson_proc_mutual_excl)
      apply (simp+)[3]
-  apply (rule validI_weaken_pre, rule validI_weaken_rely)
+  apply (rule rg_weaken_pre, rule rg_weaken_rely)
     apply (rule validI_repeat_interference; simp)
      apply (rule abs_peterson_proc_mutual_excl)
     apply (simp+)[3]

--- a/lib/concurrency/examples/Plus2_Prefix.thy
+++ b/lib/concurrency/examples/Plus2_Prefix.thy
@@ -79,17 +79,15 @@ theorem plus2_x_property:
   "\<lbrace>\<lambda>s0 s. plus2_inv tids s \<and> threadv s tid = 0 \<and> s = s0 \<and> tid \<in> tids \<and> finite tids\<rbrace>,\<lbrace>plus2_rel tids {tid}\<rbrace>
     plus2_x tid \<lbrace>plus2_rel tids (- {tid})\<rbrace>,\<lbrace>\<lambda>_ _ s. plus2_inv tids s \<and> threadv s tid = 2\<rbrace>"
   apply (simp add: plus2_x_def)
-  apply (rule validI_weaken_pre)
-   apply wp
-  apply clarsimp
+  apply wpsimp
   apply (clarsimp simp: plus2_rel_def point_update_def)
   done
 
 corollary plus2_x_parallel:
   "\<lbrace>\<lambda>s0 s. mainv s = 0 \<and> (\<forall>tid \<in> {1, 2}. threadv s tid = 0) \<and> s = s0\<rbrace>,\<lbrace>\<lambda>a b. a = b\<rbrace>
     parallel (plus2_x 1) (plus2_x 2) \<lbrace>\<lambda>s0 s. True\<rbrace>,\<lbrace>\<lambda>_ s0 s. mainv s = 4\<rbrace>"
-  apply (rule validI_weaken_pre)
-   apply (rule validI_strengthen_post)
+  apply (rule rg_weaken_pre)
+   apply (rule rg_strengthen_post)
     apply ((rule rg_validI plus2_x_property[where tids="{1, 2}"])+; simp add: plus2_rel_def le_fun_def)
    apply (clarsimp simp: plus2_inv_def)
   apply (clarsimp simp add: plus2_inv_def)
@@ -114,10 +112,8 @@ theorem pfx_refn_plus2_x:
   apply (simp add: plus2_x_def plus2_def)
   apply (rule prefix_refinement_weaken_pre)
     apply (rule pfx_refn_bind prefix_refinement_interference
-         prefix_refinement_env_steps allI
-         pfx_refn_modifyT env_stable
-       | simp
-       | wp)+
+                prefix_refinement_env_steps pfx_refn_modifyT env_stable
+           | wpsimp)+
   done
 
 lemma par_tr_fin_plus2_x:
@@ -127,8 +123,7 @@ lemma par_tr_fin_plus2_x:
 lemma prefix_closed_plus2:
   "prefix_closed plus2"
   apply (simp add: plus2_def)
-  apply (rule validI_prefix_closed_T, rule validI_weaken_pre, wp)
-  apply simp
+  apply (rule validI_prefix_closed_T, wpsimp)
   done
 
 theorem plus2_parallel:
@@ -140,7 +135,7 @@ theorem plus2_parallel:
        apply (rule pfx_refn_plus2_x[where tid=1])
       apply (rule pfx_refn_plus2_x[where tid=2])
      apply clarsimp
-     apply (rule validI_strengthen_post)
+     apply (rule rg_strengthen_post)
       apply (rule plus2_x_parallel[simplified])
      apply clarsimp
     apply (clarsimp simp: plus2_xstate.splits)
@@ -164,10 +159,10 @@ lemma plus2_x_n_parallel_induct:
   apply (case_tac n)
    apply (simp only: lessThan_Suc)
    apply simp
-   apply (rule validI_weaken_pre, rule plus2_x_property)
+   apply (wp plus2_x_property)
    apply clarsimp
   apply (clarsimp split del: if_split)
-  apply (rule validI_weaken_pre, rule validI_strengthen_post,
+  apply (rule rg_weaken_pre, rule rg_strengthen_post,
     rule rg_validI, rule plus2_x_property[where tids="{..< N}"],
     assumption, (clarsimp simp: plus2_rel_def)+)
    apply (auto dest: less_Suc_eq[THEN iffD1])[1]
@@ -178,8 +173,8 @@ theorem plus2_x_n_parallel:
   "n > 0 \<Longrightarrow>
   \<lbrace>\<lambda>s0 s. mainv s = 0 \<and> (\<forall>i < n. threadv s i = 0) \<and> s = s0\<rbrace>,\<lbrace>plus2_rel {..< n} {..< n}\<rbrace>
     fold parallel (map plus2_x [1 ..< n]) (plus2_x 0) \<lbrace>\<lambda>s0 s. True\<rbrace>,\<lbrace>\<lambda>_ _ s. mainv s = (n * 2)\<rbrace>"
-  apply (rule validI_weaken_pre, rule validI_strengthen_post,
-      rule validI_strengthen_guar, erule plus2_x_n_parallel_induct)
+  apply (rule rg_weaken_pre, rule rg_strengthen_post,
+      rule rg_strengthen_guar, erule plus2_x_n_parallel_induct)
      apply simp
     apply simp
    apply (clarsimp simp: plus2_inv_def)
@@ -240,7 +235,7 @@ theorem plus2_n_parallel:
        apply (simp add: le_fun_def)
       apply (simp add: le_fun_def)
      apply simp
-     apply (rule validI_strengthen_post, rule plus2_x_n_parallel[simplified], simp)
+     apply (rule rg_strengthen_post, rule plus2_x_n_parallel[simplified], simp)
      apply clarsimp
     apply (clarsimp simp: plus2_xstate.splits exI[where x="\<lambda>_. 0"])
    apply clarsimp


### PR DESCRIPTION
This generally follows the structure and naming conventions of the existing rule set for Hoare logic, in `Trace_VCG.thy` and `Trace_More_VCG.thy` (and the very similar ruleset and files in the nondet directory).

I took the opportunity to make some changes as I went along. In particular:
* `validIE_R` and `validIE_L` are abbreviations instead of definitions.
* some lemmas were relocated to better follow the structure of the file and to improve reuse.
* some lemmas were renamed in an attempt to be more consistent.

It would be good to propagate the last two back to the Hoare versions, to keep things consistent and allow us to update the rest of the proofs now. The first one might not be worth it however, as it would require too many other changes to work.

Lemmas for lifting over combinators in the guarantee have been left out for now as it is unclear if they would be useful. They shouldn't be too hard to add if we come across a use case.