### PR TITLE
crefine: remove unused lemmas; resolve AARCH64 FIXMEs

### DIFF
--- a/proof/crefine/AARCH64/ADT_C.thy
+++ b/proof/crefine/AARCH64/ADT_C.thy
@@ -161,17 +161,6 @@ where
   "getContext_C thread \<equiv>
    \<lambda>s. from_user_context_C (tcbContext_C (the (clift (t_hrs_' (globals s)) (Ptr &(thread\<rightarrow>[''tcbArch_C''])))))"
 
-(* FIXME AARCH64 move, this is very specific and rather ugly, is it possible to generalise? *)
-lemma size_64_less_64:
-  "size (r::64) < (64::nat)"
-  apply (induct r rule: bit0.plus_induct, simp)
-  apply (frule bit0.Suc_size)
-  apply (case_tac "x = 64 - 1"; clarsimp)
-  apply (prop_tac "size x \<noteq> size (64 - 1 :: 64)")
-   apply (subst bit0.size_inj, simp)
-  apply simp
-  done
-
 lemma from_user_context_C:
   "ccontext_relation uc uc' \<Longrightarrow> from_user_context_C uc' = uc"
   unfolding ccontext_relation_def cregs_relation_def
@@ -751,7 +740,7 @@ lemma fpu_relation_imp_eq:
   apply clarsimp
   apply (rule ext, rename_tac z)
   apply (drule_tac x="size z" in spec)+
-  apply (simp add: state_rel.size_64_less_64)
+  apply (simp add: size_64_less_64)
   done
 
 lemma ccontext_relation_imp_eq:
@@ -944,9 +933,6 @@ lemma option_to_ctcb_ptr_inj:
   apply (erule is_aligned_no_overflow_0; simp)
   done
 
-(* FIXME AARCH64 this is bad news, we need the alignment constraints to use option_to_ctcb_ptr_inj,
-   and we used to be able to say that if there's a non-null tcb pointer in a vcpu, then it's aligned,
-   but on AARCH64 we don't have anything like that in vcpu validity, so we are stuck *)
 lemma cpspace_vcpu_relation_unique:
   assumes "cpspace_vcpu_relation ah ch" "cpspace_vcpu_relation ah' ch"
   assumes "\<forall>x \<in> ran (map_to_vcpus ah). is_aligned_opt (vcpuTCBPtr x) tcbBlockSizeBits"
@@ -1064,19 +1050,6 @@ lemma cpspace_asidpool_relation_unique:
    apply (clarsimp simp: non_dom_eval_eq)
   apply force
   done
-(* FIXME AARCH64 old proof for reference, remove if not needed after rest of ADT_H is fixed
-   apply clarsimp
-   apply (case_tac "i \<le> mask asid_low_bits", simp)
-    apply (drule sym[where s="option_to_ptr _"], simp)
-    apply (simp add: option_to_ptr_def option_to_0_def ran_def split: option.splits)
-   apply clarsimp
-   apply (drule_tac c=i in contra_subsetD, simp)+
-   apply (clarsimp simp: non_dom_eval_eq)
-  apply clarsimp
-  apply (rule ccontr)
-  apply clarsimp
-  apply blast
-  done *)
 
 lemma cpspace_user_data_relation_unique:
   "\<lbrakk>cmap_relation (heap_to_user_data ah bh) (clift ch) Ptr cuser_user_data_relation;
@@ -1307,12 +1280,6 @@ lemma ksPSpace_eq_imp_valid_tcb'_eq:
                  ksPSpace_eq_imp_typ_at'_eq[OF ksPSpace]
                  valid_tcb'_def valid_tcb_state'_def valid_bound_ntfn'_def valid_arch_tcb'_def
           split: thread_state.splits option.splits)
-
-(* FIXME AARCH64 we don't have valid_vcpu' on AARCH64
-lemma ksPSpace_eq_imp_valid_vcpu'_eq:
-  assumes ksPSpace: "ksPSpace s' = ksPSpace s"
-  shows "valid_vcpu' vcpu s' = valid_vcpu' vcpu s"
-  by (auto simp: valid_vcpu'_def ksPSpace_eq_imp_typ_at'_eq[OF ksPSpace] split: option.splits) *)
 
 lemma ksPSpace_eq_imp_valid_objs'_eq:
   assumes ksPSpace: "ksPSpace s' = ksPSpace s"

--- a/proof/crefine/AARCH64/ArchMove_C.thy
+++ b/proof/crefine/AARCH64/ArchMove_C.thy
@@ -55,6 +55,17 @@ lemma ucast_le_ucast_6_64:
   "(ucast x \<le> (ucast y :: word64)) = (x \<le> (y :: 6 word))"
   by (simp add: ucast_le_ucast)
 
+(* FIXME AARCH64: this is very specific and rather ugly, is it possible to generalise? *)
+lemma size_64_less_64:
+  "size (r::64) < (64::nat)"
+  apply (induct r rule: bit0.plus_induct, simp)
+  apply (frule bit0.Suc_size)
+  apply (case_tac "x = 64 - 1"; clarsimp)
+  apply (prop_tac "size x \<noteq> size (64 - 1 :: 64)")
+   apply (subst bit0.size_inj, simp)
+  apply simp
+  done
+
 definition
   user_word_at :: "machine_word \<Rightarrow> machine_word \<Rightarrow> kernel_state \<Rightarrow> bool"
 where
@@ -461,9 +472,6 @@ crunch sch_act_wf'[wp]: readVCPUReg "\<lambda>s. P (sch_act_wf (ksSchedulerActio
 crunch ko_at'[wp]: readVCPUReg "\<lambda>s. P (ko_at' a p s)"
 
 crunch obj_at'[wp]: readVCPUReg "\<lambda>s. P (obj_at' a p s)"
-
-(* FIXME AARCH64 this might not be needed, but currently proved version doesn't have the P
-crunch pred_tcb_at'[wp]: readVCPUReg "\<lambda>s. P (pred_tcb_at' a b p s)"  *)
 
 crunch ksCurThread[wp]: readVCPUReg "\<lambda>s. P (ksCurThread s)"
 

--- a/proof/crefine/AARCH64/CSpace_C.thy
+++ b/proof/crefine/AARCH64/CSpace_C.thy
@@ -1902,8 +1902,7 @@ lemma clearUntypedFreeIndex_noop_ccorres:
   apply simp
   done
 
-(* FIXME AARCH64 move *)
-lemma mask_shiftl_le_mask:
+lemma mask_shiftl_le_mask: (* FIXME AARCH64 move to Word_Lib *)
   "mask n << m \<le> (mask (n+m) :: 'a::len word)"
   by (subst add.commute)
      (rule leq_high_bits_shiftr_low_bits_leq_bits, simp)

--- a/proof/crefine/AARCH64/Finalise_C.thy
+++ b/proof/crefine/AARCH64/Finalise_C.thy
@@ -1118,7 +1118,7 @@ lemma deleteASIDPool_ccorres:
              apply (rule ccorres_move_c_guard_ap)
              apply (rule_tac ccorres_symb_exec_r2)
                apply csymbr
-               apply (rule ccorres_guard_imp) (* FIXME AARCH64: csymbr messes up C precond *)
+               apply (rule ccorres_guard_imp)
                  apply (rule_tac R="\<lambda>_. True" and
                                  R'="\<lbrace>(inv asidpool.ASIDPool poolKO (of_nat n) \<noteq> None) \<longleftrightarrow>
                                       (asid_map_get_tag \<acute>asid_map = scast asid_map_asid_map_vspace)\<rbrace> \<inter>
@@ -1131,7 +1131,6 @@ lemma deleteASIDPool_ccorres:
                  apply (rule ccorres_return_Skip)
                 apply clarsimp
                 apply assumption
-               (* FIXME AARCH64: repairing broken csymbr C precond matching *)
                apply (clarsimp split: if_split simp: upto_enum_word simp del: upt.simps)
                apply (drule CollectD, assumption)
               apply clarsimp
@@ -1905,9 +1904,6 @@ lemma Zombie_new_spec:
   apply (simp add: word_add_less_mono1[where k=1 and j="0x3F", simplified])
   done
 
-(* FIXME AARCH64 move? retire? revisit *)
-lemmas upcast_ucast_id = More_Word.ucast_up_inj
-
 lemma ccap_relation_IRQHandler_mask:
   "\<lbrakk> ccap_relation acap ccap; isIRQHandlerCap acap \<rbrakk>
     \<Longrightarrow> capIRQ_CL (cap_irq_handler_cap_lift ccap) && mask 9
@@ -2618,7 +2614,7 @@ lemma Arch_finaliseCap_ccorres:
                        F="\<lambda>asid'. asid' = asid" and
                        R=\<top> and
                        R'=UNIV
-                       in ccorres_symb_exec_r_abstract_UNIV) (* FIXME AARCH64: csymbr fails *)
+                       in ccorres_symb_exec_r_abstract_UNIV)
           apply vcg
           apply (clarsimp simp: ccap_relation_def map_option_Some_eq2 dest!: cap_to_H_VSCap)
           apply (clarsimp simp: cap_vspace_cap_lift_def cap_vspace_cap_lift)
@@ -2655,7 +2651,7 @@ lemma Arch_finaliseCap_ccorres:
                       F="\<lambda>asid'. asid' = asid" and
                       R=\<top> and
                       R'=UNIV
-                      in ccorres_symb_exec_r_abstract_UNIV) (* FIXME AARCH64: csymbr fails *)
+                      in ccorres_symb_exec_r_abstract_UNIV)
          apply vcg
          apply (clarsimp simp: ccap_relation_def map_option_Some_eq2 dest!: cap_to_H_PTCap)
          apply (clarsimp simp: cap_page_table_cap_lift_def cap_page_table_cap_lift)

--- a/proof/crefine/AARCH64/IpcCancel_C.thy
+++ b/proof/crefine/AARCH64/IpcCancel_C.thy
@@ -144,7 +144,7 @@ lemma tcbEPDequeue_spec:
    apply simp
   apply (frule c_guard_clift)
   apply (simp add: typ_heap_simps')
-  apply (intro allI conjI impI) (* FIXME AARCH64 different number of goals, not sure why *)
+  apply (intro allI conjI impI)
                apply (clarsimp simp add: typ_heap_simps h_t_valid_clift_Some_iff)
               apply (clarsimp simp: typ_heap_simps h_t_valid_clift_Some_iff
                               cong: if_weak_cong)

--- a/proof/crefine/AARCH64/Machine_C.thy
+++ b/proof/crefine/AARCH64/Machine_C.thy
@@ -62,7 +62,7 @@ assumes maskInterrupt_ccorres:
            (doMachineOp (maskInterrupt m irq))
            (Call maskInterrupt_'proc)"
 
-(* FIXME AARCH64 this is a simplification until complete FPU handling is added at a future date *)
+(* This is a simplification until complete FPU handling is added at a future date *)
 assumes fpuThreadDelete_ccorres:
   "ccorres dc xfdc (tcb_at' thread) (\<lbrace>\<acute>thread = tcb_ptr_to_ctcb_ptr thread\<rbrace>) hs
      (fpuThreadDelete thread)
@@ -264,14 +264,6 @@ assumes vcpu_hw_write_reg_ccorres:
            \<top> (\<lbrace> unat \<acute>reg_index = fromEnum r \<rbrace> \<inter> \<lbrace> \<acute>reg = v \<rbrace>) hs
            (doMachineOp (writeVCPUHardwareReg r v))
            (Call vcpu_hw_write_reg_'proc)"
-
-(* FIXME AARCH64 these were RISCV64 machine op ccorres assumptions, remove after we have new ones
-assumes hwASIDFlush_ccorres:
-  "ccorres dc xfdc \<top> (\<lbrace>\<acute>asid___unsigned_long = asid\<rbrace>) []
-           (doMachineOp (AARCH64.hwASIDFlush asid))
-           (Call hwASIDFlush_'proc)"
-
-*)
 
 (* The following are fastpath specific assumptions.
    We might want to move them somewhere else. *)

--- a/proof/crefine/AARCH64/Retype_C.thy
+++ b/proof/crefine/AARCH64/Retype_C.thy
@@ -35,14 +35,6 @@ lemma sle_positive: "\<lbrakk> b < 0x8000000000000000; (a :: machine_word) \<le>
   apply (clarsimp simp:word_le_def)
   done
 
-lemma sless_positive: "\<lbrakk> b < 0x8000000000000000; (a :: machine_word) < b \<rbrakk> \<Longrightarrow> a <s b"
-  apply (clarsimp simp: word_sless_def)
-  apply (rule conjI)
-   apply (erule sle_positive)
-   apply simp
-  apply simp
-  done
-
 lemma zero_le_sint: "\<lbrakk> 0 \<le> (a :: machine_word); a < 0x8000000000000000 \<rbrakk> \<Longrightarrow> 0 \<le> sint a"
   apply (subst sint_eq_uint)
    apply (simp add:unat_less_helper)
@@ -51,7 +43,6 @@ lemma zero_le_sint: "\<lbrakk> 0 \<le> (a :: machine_word); a < 0x80000000000000
 
 context begin interpretation Arch . (*FIXME: arch_split*)
 
-(* FIXME AARCH64 we have multiple page table index sizes *)
 lemma map_option_byte_to_word_heap:
   assumes disj: "\<And>(off :: 9 word) x. x<8 \<Longrightarrow> p + ucast off * 8 + x \<notin> S " (*9=page table index*)
   shows "byte_to_word_heap (\<lambda>x. if x \<in> S then 0 else mem x) p
@@ -5844,8 +5835,6 @@ lemma updatePTType_ccorres:
   apply (clarsimp simp: cvariable_array_map_relation_def split: if_splits)
   done
 
-(* FIXME AARCH64 multiple issues in vspace objects, possibly missing ghost state updates, and
-   page table ghost state in state relation *)
 lemma Arch_createObject_ccorres:
   assumes t: "toAPIType newType = None"
   shows "ccorres (\<lambda>a b. ccap_relation (ArchObjectCap a) b) ret__struct_cap_C_'
@@ -5856,7 +5845,6 @@ lemma Arch_createObject_ccorres:
      (Call Arch_createObject_'proc)"
 proof -
   note if_cong[cong]
-  (* FIXME AARCH64 note sign_extend_canonical_address[simp] *)
 
   show ?thesis
     apply (clarsimp simp: createObject_c_preconds_def

--- a/proof/crefine/AARCH64/StateRelation_C.thy
+++ b/proof/crefine/AARCH64/StateRelation_C.thy
@@ -444,7 +444,6 @@ lemma pte_0:
    pte_lift cpte = Some (Pte_pte_invalid)"
   by (simp add: pte_lift_def pte_get_tag_def pte_tag_defs)
 
-(* FIXME AARCH64 review *)
 (* with hypervisor support enabled, use stage-2 translation format for PTE *)
 (* see makeUserPage in C *)
 definition cpte_relation :: "pte \<Rightarrow> pte_C \<Rightarrow> bool" where
@@ -461,8 +460,7 @@ definition cpte_relation :: "pte \<Rightarrow> pte_C \<Rightarrow> bool" where
         then cpte' = Some (Pte_pte_4k_page
                              \<lparr> pte_pte_4k_page_CL.UXN_CL = of_bool xn,
                                page_base_address_CL = baseaddr,
-                               nG_CL = from_bool global, \<comment> \<open>flipped in hyp mode
-                                 (* FIXME AARCH64 check manual for what this really means *)\<close>
+                               nG_CL = from_bool global, \<comment> \<open>flipped in hyp mode\<close>
                                AF_CL = 1,
                                SH_CL = 0,
                                AP_CL = ap_from_vm_rights vmrights,

--- a/proof/crefine/AARCH64/Syscall_C.thy
+++ b/proof/crefine/AARCH64/Syscall_C.thy
@@ -1718,7 +1718,6 @@ lemma word_ctz_upcast_id:
   unfolding word_ctz_def
   by (simp add: ucast_up_app source_size_def target_size_def eq_zero_set_bl)
 
-(* FIXME AARCH64 stated to use machine_word on ARM_HYP, which works there by coincidence *)
 (* folded calculation of eisr used in vgicMaintenance *)
 definition
   eisr_calc :: "32 word \<Rightarrow> 32 word \<Rightarrow> nat"

--- a/proof/crefine/AARCH64/TcbQueue_C.thy
+++ b/proof/crefine/AARCH64/TcbQueue_C.thy
@@ -894,83 +894,6 @@ lemma tcb_queue_relation'_prev_mask:
   shows "ptr_val (getPrev tcb) && ~~ mask bits = ptr_val (getPrev tcb)"
   by (rule tcb_queue_relation_prev_mask [OF tcb_queue_relation'_queue_rel], fact+)
 
-(* FIXME AARCH64 sign-extensions and pspace_canonical' are gone, leaving these in case we end up
-   needing something analogous to demonstrate validity of pointers
-lemma tcb_queue_relation_next_sign:
-  assumes
-    "tcb_queue_relation getNext getPrev mp queue NULL qhead" and
-    valid_ep: "\<forall>t\<in>set queue. tcb_at' t s"
-    "distinct queue"
-    "mp (tcb_ptr_to_ctcb_ptr tcbp) = Some tcb"
-    "tcbp \<in> set queue"  and
-    canon: "pspace_canonical' s"
-  shows "sign_extend canonical_bit (ptr_val (getNext tcb)) = ptr_val (getNext tcb)"
-proof (cases "(getNext tcb) = NULL")
-  case True
-  thus ?thesis by simp
-next
-  case False
-
-  hence "ctcb_ptr_to_tcb_ptr (getNext tcb) \<in> set queue" using assms
-    apply -
-    apply (drule (3) tcb_queueD)
-    apply (clarsimp split: if_split_asm)
-    done
-
-  with valid_ep(1) have tcb: "tcb_at' (ctcb_ptr_to_tcb_ptr (getNext tcb)) s" ..
-  with canon have "canonical_address (ctcb_ptr_to_tcb_ptr (getNext tcb))" by (simp add: obj_at'_is_canonical)
-  moreover
-  have "is_aligned (ctcb_ptr_to_tcb_ptr (getNext tcb)) tcbBlockSizeBits" using tcb by (rule tcb_aligned')
-  ultimately
-  have "canonical_address (ptr_val (getNext tcb))" by (rule canonical_address_ctcb_ptr)
-  thus ?thesis
-    by (simp add: sign_extend_canonical_address[symmetric] canonical_bit_def)
-qed
-
-lemma tcb_queue_relation'_next_sign:
-  "\<lbrakk> tcb_queue_relation' getNext getPrev mp queue qhead qend; \<forall>t\<in>set queue. tcb_at' t s;
-     distinct queue; mp (tcb_ptr_to_ctcb_ptr tcbp) = Some tcb; tcbp \<in> set queue; pspace_canonical' s\<rbrakk>
-\<Longrightarrow> sign_extend canonical_bit (ptr_val (getNext tcb)) = ptr_val (getNext tcb)"
-  by (rule tcb_queue_relation_next_sign [OF tcb_queue_relation'_queue_rel])
-
-lemma tcb_queue_relation_prev_sign:
-  assumes
-    "tcb_queue_relation getNext getPrev mp queue NULL qhead" and
-    valid_ep: "\<forall>t\<in>set queue. tcb_at' t s"
-    "distinct queue"
-    "mp (tcb_ptr_to_ctcb_ptr tcbp) = Some tcb"
-    "tcbp \<in> set queue"  and
-    canon: "pspace_canonical' s"
-  shows "sign_extend canonical_bit (ptr_val (getPrev tcb)) = ptr_val (getPrev tcb)"
-proof (cases "(getPrev tcb) = NULL")
-  case True
-  thus ?thesis by simp
-next
-  case False
-
-  hence "ctcb_ptr_to_tcb_ptr (getPrev tcb) \<in> set queue" using assms
-    apply -
-    apply (drule (3) tcb_queueD)
-    apply (clarsimp split: if_split_asm)
-    done
-
-  with valid_ep(1) have tcb: "tcb_at' (ctcb_ptr_to_tcb_ptr (getPrev tcb)) s" ..
-  with canon have "canonical_address (ctcb_ptr_to_tcb_ptr (getPrev tcb))" by (simp add: obj_at'_is_canonical)
-  moreover
-  have "is_aligned (ctcb_ptr_to_tcb_ptr (getPrev tcb)) tcbBlockSizeBits" using tcb by (rule tcb_aligned')
-  ultimately
-  have "canonical_address (ptr_val (getPrev tcb))" by (rule canonical_address_ctcb_ptr)
-  thus ?thesis
-    by (simp add: sign_extend_canonical_address[symmetric] canonical_bit_def)
-qed
-
-lemma tcb_queue_relation'_prev_sign:
-  "\<lbrakk> tcb_queue_relation' getNext getPrev mp queue qhead qend; \<forall>t\<in>set queue. tcb_at' t s;
-     distinct queue; mp (tcb_ptr_to_ctcb_ptr tcbp) = Some tcb; tcbp \<in> set queue; pspace_canonical' s\<rbrakk>
-\<Longrightarrow> sign_extend canonical_bit (ptr_val (getPrev tcb)) = ptr_val (getPrev tcb)"
-  by (rule tcb_queue_relation_prev_sign [OF tcb_queue_relation'_queue_rel])
-*)
-
 lemma cready_queues_relation_null_queue_ptrs:
   assumes rel: "cready_queues_relation mp cq aq"
   and same: "option_map tcb_null_ep_ptrs \<circ> mp' = option_map tcb_null_ep_ptrs \<circ> mp"
@@ -1476,11 +1399,6 @@ lemma rf_sr_tcb_update_not_in_queue:
    subgoal by simp
   apply (simp add: carch_state_relation_def)
   by (simp add: cmachine_state_relation_def)
-
-(* FIXME AARCH64 unused on all arches, remove: rf_sr_tcb_update_not_in_queue2,
-   rf_sr_tcb_update_not_in_queue *)
-lemmas rf_sr_tcb_update_not_in_queue2
-    = rf_sr_tcb_update_no_queue_helper [OF rf_sr_tcb_update_not_in_queue, simplified]
 
 end
 end

--- a/proof/crefine/AARCH64/Wellformed_C.thy
+++ b/proof/crefine/AARCH64/Wellformed_C.thy
@@ -171,8 +171,6 @@ definition
   Cap_notification_cap aec \<Rightarrow> True
   | _ \<Rightarrow> False"
 
-(* FIXME AARCH64: unclear why there aren't isBlahCap_C functions for arch objects in Wellformed_C *)
-
 definition
   ep_at_C' :: "word64 \<Rightarrow> heap_raw_state \<Rightarrow> bool"
 where
@@ -637,6 +635,11 @@ where
 
 definition cacheLineSize :: nat where
   "cacheLineSize \<equiv> 6"
+
+(* The magic 4 comes out of the bitfield generator -- this applies to all versions of the kernel. *)
+lemma ThreadState_Restart_mask[simp]:
+  "(scast ThreadState_Restart::machine_word) && mask 4 = scast ThreadState_Restart"
+  by (simp add: ThreadState_Restart_def mask_def)
 
 (* generic lemmas with arch-specific consequences *)
 

--- a/proof/crefine/ARM/Arch_C.thy
+++ b/proof/crefine/ARM/Arch_C.thy
@@ -2157,7 +2157,7 @@ lemma pte_get_tag_alt:
   by (auto simp add: pte_lift_def Let_def split: if_split_asm)
 
 definition
-  to_option :: "('a \<Rightarrow> bool) \<Rightarrow> 'a \<Rightarrow> 'a option"
+  to_option :: "('a \<Rightarrow> bool) \<Rightarrow> 'a \<Rightarrow> 'a option" (* FIXME: consider moving to Lib *)
 where
   "to_option f x \<equiv> if f x then Some x else None"
 

--- a/proof/crefine/ARM_HYP/Finalise_C.thy
+++ b/proof/crefine/ARM_HYP/Finalise_C.thy
@@ -1669,8 +1669,6 @@ lemma irq_opt_relation_Some_ucast:
   apply (simp only: unat_arith_simps)
   by (clarsimp simp: word_le_nat_alt Kernel_C.maxIRQ_def)
 
-lemmas upcast_ucast_id = More_Word.ucast_up_inj
-
 lemma irq_opt_relation_Some_ucast':
   "\<lbrakk> x && mask 10 = x; ucast x \<le> (ucast Kernel_C.maxIRQ :: 10 word) \<or> x \<le> (ucast Kernel_C.maxIRQ :: machine_word) \<rbrakk>
     \<Longrightarrow> irq_opt_relation (Some (ucast x)) (ucast x)"

--- a/proof/crefine/ARM_HYP/TcbQueue_C.thy
+++ b/proof/crefine/ARM_HYP/TcbQueue_C.thy
@@ -1199,8 +1199,5 @@ lemma rf_sr_tcb_update_not_in_queue:
                          typ_heap_simps')
   by (simp add: cmachine_state_relation_def)
 
-lemmas rf_sr_tcb_update_not_in_queue2
-    = rf_sr_tcb_update_no_queue_helper [OF rf_sr_tcb_update_not_in_queue, simplified]
-
 end
 end

--- a/proof/crefine/ARM_HYP/VSpace_C.thy
+++ b/proof/crefine/ARM_HYP/VSpace_C.thy
@@ -2669,10 +2669,6 @@ definition
   | ARM_HYP_H.flush_type.CleanInvalidate \<Rightarrow> (label = Kernel_C.ARMPageCleanInvalidate_Data \<or> label = Kernel_C.ARMPDCleanInvalidate_Data)
   | ARM_HYP_H.flush_type.Unify \<Rightarrow> (label = Kernel_C.ARMPageUnify_Instruction \<or> label = Kernel_C.ARMPDUnify_Instruction)"
 
-lemma ccorres_seq_IF_False:
-  "ccorres_underlying sr \<Gamma> r xf arrel axf G G' hs a (IF False THEN x ELSE y FI ;; c) = ccorres_underlying sr \<Gamma> r xf arrel axf G G' hs a (y ;; c)"
-  by simp
-
 lemma doFlush_ccorres:
   "ccorres dc xfdc (\<lambda>s. vs \<le> ve \<and> ps \<le> ps + (ve - vs) \<and> vs && mask 6 = ps && mask 6
         \<comment> \<open>ahyp version translates ps into kernel virtual before flushing\<close>

--- a/proof/crefine/RISCV64/Arch_C.thy
+++ b/proof/crefine/RISCV64/Arch_C.thy
@@ -1402,15 +1402,6 @@ lemma performPageGetAddress_ccorres:
                      pred_tcb_at'_def obj_at'_def ct_in_state'_def)
   done
 
-lemma vaddr_segment_nonsense3_folded:
-  "is_aligned (p :: machine_word) pageBits \<Longrightarrow>
-   (p + ((vaddr >> pageBits) && mask (pt_bits - word_size_bits) << word_size_bits) && ~~ mask pt_bits) = p"
-  apply (rule is_aligned_add_helper[THEN conjunct2])
-   apply (simp add: bit_simps mask_def)+
-  apply (rule shiftl_less_t2n[where m=12 and n=3, simplified, OF and_mask_less'[where n=9, unfolded mask_def, simplified]])
-   apply simp+
-  done
-
 lemma vmsz_aligned_addrFromPPtr':
   "vmsz_aligned (addrFromPPtr p) sz
        = vmsz_aligned p sz"
@@ -1453,18 +1444,6 @@ lemma slotcap_in_mem_valid:
   apply (erule(1) ctes_of_valid')
   done
 
-lemma unat_less_iff64:
-  "\<lbrakk>unat (a::machine_word) = b;c < 2^word_bits\<rbrakk>
-   \<Longrightarrow> (a < of_nat c) = (b < c)"
-  apply (rule iffI)
-    apply (drule unat_less_helper)
-    apply simp
-  apply (simp add:unat64_eq_of_nat)
-  apply (rule of_nat_mono_maybe)
-   apply (simp add:word_bits_def)
-  apply simp
-  done
-
 lemma injection_handler_if_returnOk:
   "injection_handler Inl (if a then b else returnOk c)
   = (if a then (injection_handler Inl b) else returnOk c)"
@@ -1476,11 +1455,6 @@ lemma injection_handler_if_returnOk:
 
 lemma pbfs_less: "pageBitsForSize sz < 31"
   by (case_tac sz,simp_all add: bit_simps)
-
-definition
-  to_option :: "('a \<Rightarrow> bool) \<Rightarrow> 'a \<Rightarrow> 'a option"
-where
-  "to_option f x \<equiv> if f x then Some x else None"
 
 lemma cte_wp_at_eq_gsMaxObjectSize:
   "cte_wp_at' ((=) cap o cteCap) slot s

--- a/proof/crefine/RISCV64/Finalise_C.thy
+++ b/proof/crefine/RISCV64/Finalise_C.thy
@@ -1633,8 +1633,6 @@ lemma Zombie_new_spec:
   apply (simp add: word_add_less_mono1[where k=1 and j="0x3F", simplified])
   done
 
-lemmas upcast_ucast_id = More_Word.ucast_up_inj
-
 lemma irq_opt_relation_Some_ucast:
   "\<lbrakk> x && mask 6 = x; ucast x \<noteq> irqInvalid;
     ucast x \<le> (scast Kernel_C.maxIRQ :: 6 word) \<or> x \<le> (scast Kernel_C.maxIRQ :: machine_word) \<rbrakk>

--- a/proof/crefine/RISCV64/TcbQueue_C.thy
+++ b/proof/crefine/RISCV64/TcbQueue_C.thy
@@ -1474,8 +1474,5 @@ lemma rf_sr_tcb_update_not_in_queue:
   apply (simp add: carch_state_relation_def)
   by (simp add: cmachine_state_relation_def)
 
-lemmas rf_sr_tcb_update_not_in_queue2
-    = rf_sr_tcb_update_no_queue_helper [OF rf_sr_tcb_update_not_in_queue, simplified]
-
 end
 end

--- a/proof/crefine/RISCV64/VSpace_C.thy
+++ b/proof/crefine/RISCV64/VSpace_C.thy
@@ -969,10 +969,6 @@ lemma setVMRoot_ccorres:
               elim!: ccap_relationE
               split: if_split_asm cap_CL.splits)
 
-lemma ccorres_seq_IF_False:
-  "ccorres_underlying sr \<Gamma> r xf arrel axf G G' hs a (IF False THEN x ELSE y FI ;; c) = ccorres_underlying sr \<Gamma> r xf arrel axf G G' hs a (y ;; c)"
-  by simp
-
 (* FIXME x64: needed? *)
 lemma ptrFromPAddr_mask6_simp[simp]:
   "ptrFromPAddr ps && mask 6 = ps && mask 6"

--- a/proof/crefine/X64/Arch_C.thy
+++ b/proof/crefine/X64/Arch_C.thy
@@ -1589,15 +1589,6 @@ lemma pde_align_ptBits:
   apply (simp add: bit_simps)
   done
 
-lemma vaddr_segment_nonsense3_folded:
-  "is_aligned (p :: machine_word) pageBits \<Longrightarrow>
-   (p + ((vaddr >> pageBits) && mask (pt_bits - word_size_bits) << word_size_bits) && ~~ mask pt_bits) = p"
-  apply (rule is_aligned_add_helper[THEN conjunct2])
-   apply (simp add: bit_simps mask_def)+
-  apply (rule shiftl_less_t2n[where m=12 and n=3, simplified, OF and_mask_less'[where n=9, unfolded mask_def, simplified]])
-   apply simp+
-  done
-
 lemma storePDE_Basic_ccorres'':
   "ccorres dc xfdc
      (\<lambda>_. True)
@@ -1913,7 +1904,7 @@ lemma shiftr_asid_low_bits_mask_eq_0:
   apply (rule iffI[rotated])
    apply simp
   apply (rule asid_low_high_bits)
-     apply (rule upcast_ucast_id[where 'b=machine_word_len]; simp add: asid_low_bits_of_mask_eq)
+     apply (rule More_Word.ucast_up_inj[where 'b=machine_word_len]; simp add: asid_low_bits_of_mask_eq)
     apply (simp add: ucast_asid_high_bits_is_shift)
    apply (simp add: asid_wf_def mask_def)
   apply (rule asid_wf_0)
@@ -1924,18 +1915,6 @@ lemma slotcap_in_mem_valid:
             \<Longrightarrow> s \<turnstile>' cap"
   apply (clarsimp simp: slotcap_in_mem_def)
   apply (erule(1) ctes_of_valid')
-  done
-
-lemma unat_less_iff64:
-  "\<lbrakk>unat (a::machine_word) = b;c < 2^word_bits\<rbrakk>
-   \<Longrightarrow> (a < of_nat c) = (b < c)"
-  apply (rule iffI)
-    apply (drule unat_less_helper)
-    apply simp
-  apply (simp add:unat64_eq_of_nat)
-  apply (rule of_nat_mono_maybe)
-   apply (simp add:word_bits_def)
-  apply simp
   done
 
 lemma injection_handler_if_returnOk:
@@ -1949,11 +1928,6 @@ lemma injection_handler_if_returnOk:
 
 lemma pbfs_less: "pageBitsForSize sz < 31"
   by (case_tac sz,simp_all add: bit_simps)
-
-definition
-  to_option :: "('a \<Rightarrow> bool) \<Rightarrow> 'a \<Rightarrow> 'a option"
-where
-  "to_option f x \<equiv> if f x then Some x else None"
 
 lemma cte_wp_at_eq_gsMaxObjectSize:
   "cte_wp_at' ((=) cap o cteCap) slot s

--- a/proof/crefine/X64/Finalise_C.thy
+++ b/proof/crefine/X64/Finalise_C.thy
@@ -1701,8 +1701,6 @@ lemma irq_opt_relation_Some_ucast:
   apply (clarsimp simp: word_le_nat_alt Kernel_C.maxIRQ_def)
   done
 
-lemmas upcast_ucast_id = More_Word.ucast_up_inj
-
 lemma irq_opt_relation_Some_ucast':
   "\<lbrakk> x && mask 8 = x; ucast x \<le> (scast Kernel_C.maxIRQ :: 8 word) \<or> x \<le> (scast Kernel_C.maxIRQ :: machine_word) \<rbrakk>
     \<Longrightarrow> irq_opt_relation (Some (ucast x)) (ucast x)"

--- a/proof/crefine/X64/TcbQueue_C.thy
+++ b/proof/crefine/X64/TcbQueue_C.thy
@@ -1557,8 +1557,5 @@ lemma rf_sr_tcb_update_not_in_queue:
                               global_ioport_bitmap_heap_update_tag_disj_simps obj_at'_def projectKOs)
   by (simp add: cmachine_state_relation_def)
 
-lemmas rf_sr_tcb_update_not_in_queue2
-    = rf_sr_tcb_update_no_queue_helper [OF rf_sr_tcb_update_not_in_queue, simplified]
-
 end
 end

--- a/proof/crefine/X64/VSpace_C.thy
+++ b/proof/crefine/X64/VSpace_C.thy
@@ -1296,10 +1296,6 @@ lemma setVMRoot_ccorres:
   apply (match premises in H: \<open>cr3_C.words_C _.[0] && _ = 0\<close> \<Rightarrow> \<open>insert H; word_bitwise\<close>)
   done
 
-lemma ccorres_seq_IF_False:
-  "ccorres_underlying sr \<Gamma> r xf arrel axf G G' hs a (IF False THEN x ELSE y FI ;; c) = ccorres_underlying sr \<Gamma> r xf arrel axf G G' hs a (y ;; c)"
-  by simp
-
 (* FIXME x64: needed? *)
 lemma ptrFromPAddr_mask6_simp[simp]:
   "ptrFromPAddr ps && mask 6 = ps && mask 6"


### PR DESCRIPTION
First pass resolving obvious FIXMEs in AARCH64 proofs:

- questions that have resolved themselves
- lemmas that are unused (some on all architectures)
- trivial lemma moves
- some FIXME updates for easier grep later