### PR TITLE
Enlarge the prefix_refinement rule set

### DIFF
--- a/lib/Monads/trace/Trace_Empty_Fail.thy
+++ b/lib/Monads/trace/Trace_Empty_Fail.thy
@@ -55,6 +55,10 @@ lemma empty_failD3:
   "\<lbrakk> empty_fail f; \<not> failed (f s) \<rbrakk> \<Longrightarrow> mres (f s) \<noteq> {}"
   by (drule(1) empty_failD2, clarsimp)
 
+lemma empty_fail_not_empty:
+  "empty_fail f \<Longrightarrow> \<forall>s. f s \<noteq> {}"
+  by (auto simp: empty_fail_def mres_def)
+
 lemma empty_fail_bindD1:
   "empty_fail (a >>= b) \<Longrightarrow> empty_fail a"
   unfolding empty_fail_def bind_def

--- a/lib/Monads/trace/Trace_Monad.thy
+++ b/lib/Monads/trace/Trace_Monad.thy
@@ -805,6 +805,12 @@ definition Await :: "('s \<Rightarrow> bool) \<Rightarrow> ('s,unit) tmonad" whe
 
 section "Parallel combinator"
 
+text \<open>
+  Programs combined with @{text parallel} should begin with an
+  @{const env_steps} and end with @{const interference} to be wellformed.
+  This ensures that there are at least enough enough environment steps in
+  each program for their traces to be able to be matched up; without it
+  the composed program would be trivially empty.\<close>
 definition parallel :: "('s,'a) tmonad \<Rightarrow> ('s,'a) tmonad \<Rightarrow> ('s,'a) tmonad" where
   "parallel f g = (\<lambda>s. {(xs, rv). \<exists>f_steps. length f_steps = length xs
     \<and> (map (\<lambda>(f_step, (id, s)). (if f_step then id else Env, s)) (zip f_steps xs), rv) \<in> f s

--- a/lib/concurrency/Atomicity_Lib.thy
+++ b/lib/concurrency/Atomicity_Lib.thy
@@ -31,7 +31,7 @@ lemmas prefix_refinement_env_steps_Await =
 
 lemma pfx_refn_interferences:
   "env_stable AR R sr iosr (\<lambda>_. True)
-   \<Longrightarrow> prefix_refinement sr iosr iosr \<top>\<top> \<top>\<top> \<top>\<top> AR R interferences interferences"
+   \<Longrightarrow> prefix_refinement sr iosr iosr \<top>\<top> AR R \<top>\<top> \<top>\<top> interferences interferences"
   apply (rule prefix_refinement_repeat)
     apply (erule prefix_refinement_interference)
    apply wp+
@@ -84,8 +84,8 @@ lemmas repeat_one_triv_refinement =
                                    OF repeat_none_triv_refinement]
 
 schematic_goal prefix_refinement_interferences_split:
-  "prefix_refinement sr isr osr rvr P Q AR R ?aprog cprog
-   \<Longrightarrow> prefix_refinement sr isr osr rvr P Q AR R
+  "prefix_refinement sr isr osr rvr AR R P Q ?aprog cprog
+   \<Longrightarrow> prefix_refinement sr isr osr rvr AR R P Q
                          (do y <- interferences; aprog od) cprog"
   apply (rule prefix_refinement_triv_refinement_abs)
    apply (rule  triv_refinement_mono_bind)
@@ -357,8 +357,8 @@ lemma is_matching_fragment_list_all2:
 lemma pfx_refinement_use_rel_tr_refinement:
   "\<lbrakk>rel_tr_refinement tr_r Q R False g g';
     \<forall>s t t'. tr_r t t' \<longrightarrow> sr s t = sr s t';
-    prefix_refinement sr isr osr rvr P Q' AR R f g'\<rbrakk>
-   \<Longrightarrow> prefix_refinement sr isr osr rvr P (\<lambda>s0. Q and Q' s0) AR R f g"
+    prefix_refinement sr isr osr rvr AR R P Q' f g'\<rbrakk>
+   \<Longrightarrow> prefix_refinement sr isr osr rvr AR R P (\<lambda>s0. Q and Q' s0) f g"
   apply (subst prefix_refinement_def, clarsimp)
   apply (drule(3) rel_tr_refinementD, simp)
   apply clarsimp
@@ -372,8 +372,8 @@ lemma pfx_refinement_use_rel_tr_refinement:
 
 lemma pfx_refinement_use_rel_tr_refinement_equivp:
   "\<lbrakk>rel_tr_refinement sr Q R False g g'; equivp sr;
-    prefix_refinement sr isr osr rvr P Q' AR R f g'\<rbrakk>
-   \<Longrightarrow> prefix_refinement sr isr osr rvr P (\<lambda>s0. Q and Q' s0) AR R f g"
+    prefix_refinement sr isr osr rvr AR R P Q' f g'\<rbrakk>
+   \<Longrightarrow> prefix_refinement sr isr osr rvr AR R P (\<lambda>s0. Q and Q' s0) f g"
   apply (erule pfx_refinement_use_rel_tr_refinement, simp_all)
   apply (metis equivpE sympD transpD)
   done
@@ -812,8 +812,8 @@ lemma adjust_tr_relation_equivp:
 lemma prefix_refinement_i_modify_split:
   "\<lbrakk>adjust_tr_relation tr_r sr; \<forall>s t. isr s t \<longrightarrow> P s \<longrightarrow> Q t \<longrightarrow> intsr (f s) (g t);
     \<forall>s. tr_r s (g s); \<forall>s t. R s t \<longrightarrow> R (g s) (g t); not_env_steps_first b;
-    prefix_refinement sr intsr osr rvr' P' Q' AR R d (do x \<leftarrow> interferences; b od)\<rbrakk>
-   \<Longrightarrow> prefix_refinement sr isr osr rvr' (\<lambda>s0 s. P s \<and> P' s0 (f s)) (\<lambda>s0 s. Q s \<and> Q' s0 (g s)) AR R
+    prefix_refinement sr intsr osr rvr' AR R P' Q' d (do x \<leftarrow> interferences; b od)\<rbrakk>
+   \<Longrightarrow> prefix_refinement sr isr osr rvr' AR R (\<lambda>s0 s. P s \<and> P' s0 (f s)) (\<lambda>s0 s. Q s \<and> Q' s0 (g s))
          (do z \<leftarrow> modify f; d od)
          (do x \<leftarrow> interferences; y \<leftarrow> modify g; b od)"
   apply (clarsimp simp: adjust_tr_relation_def)

--- a/lib/concurrency/Atomicity_Lib.thy
+++ b/lib/concurrency/Atomicity_Lib.thy
@@ -31,7 +31,7 @@ lemmas prefix_refinement_env_steps_Await =
 
 lemma pfx_refn_interferences:
   "env_stable AR R sr iosr (\<lambda>_. True)
-   \<Longrightarrow> prefix_refinement sr iosr iosr \<top>\<top> AR R \<top>\<top> \<top>\<top> interferences interferences"
+   \<Longrightarrow> prefix_refinement sr iosr iosr dc AR R \<top>\<top> \<top>\<top> interferences interferences"
   apply (rule prefix_refinement_repeat)
     apply (erule prefix_refinement_interference)
    apply wp+
@@ -64,14 +64,12 @@ lemma repeat_pre_triv_refinement[simplified]:
   apply (simp add: repeat_def select_early)
   apply (rule triv_refinement_select_concrete_All; clarsimp)
   apply (rule_tac x="Suc x" in triv_refinement_select_abstract_x; simp)
-  apply (rule triv_refinement_refl)
   done
 
 lemma repeat_none_triv_refinement:
   "triv_refinement (repeat f) (return ())"
   apply (simp add: repeat_def)
   apply (rule_tac x="0" in triv_refinement_select_abstract_x; simp)
-  apply (rule triv_refinement_refl)
   done
 
 lemmas repeat_triv_refinement_consume_1 =
@@ -466,7 +464,6 @@ lemma rel_tr_refinement_bind_right_general:
   apply (simp add: rely_cond_append list_all2_same reflpD[where R=sr] rel_prod_sel)
   done
 
-lemmas validI_triv' = rg_weaken_pre[OF validI_triv, simplified]
 lemmas rel_tr_refinement_bind_right =
   rel_tr_refinement_bind_right_general[where C'=False, simplified]
 
@@ -810,7 +807,7 @@ lemma adjust_tr_relation_equivp:
   done
 
 lemma prefix_refinement_i_modify_split:
-  "\<lbrakk>adjust_tr_relation tr_r sr; \<forall>s t. isr s t \<longrightarrow> P s \<longrightarrow> Q t \<longrightarrow> intsr (f s) (g t);
+  "\<lbrakk>adjust_tr_relation tr_r sr; \<And>s t. \<lbrakk>isr s t; P s; Q t\<rbrakk> \<Longrightarrow> intsr (f s) (g t);
     \<forall>s. tr_r s (g s); \<forall>s t. R s t \<longrightarrow> R (g s) (g t); not_env_steps_first b;
     prefix_refinement sr intsr osr rvr' AR R P' Q' d (do x \<leftarrow> interferences; b od)\<rbrakk>
    \<Longrightarrow> prefix_refinement sr isr osr rvr' AR R (\<lambda>s0 s. P s \<and> P' s0 (f s)) (\<lambda>s0 s. Q s \<and> Q' s0 (g s))

--- a/lib/concurrency/Atomicity_Lib.thy
+++ b/lib/concurrency/Atomicity_Lib.thy
@@ -4,18 +4,17 @@
  * SPDX-License-Identifier: BSD-2-Clause
  *)
 theory Atomicity_Lib
-
-imports
-  Prefix_Refinement
-  Monads.Trace_Det
+  imports
+    Prefix_Refinement
+    Monads.Trace_Det
 begin
 
-text \<open>This library introduces a number of proofs about the question of
-atomicity refinement, particularly in combination with the existing
-prefix refinement notion. It introduces an additional notion of refinement
-which left-composes with prefix refinement and can be used to rearrange
-operations around interference points.
-\<close>
+text \<open>
+  This library introduces a number of proofs about the question of
+  atomicity refinement, particularly in combination with the existing
+  prefix refinement notion. It introduces an additional notion of refinement
+  which left-composes with prefix refinement and can be used to rearrange
+  operations around interference points.\<close>
 
 abbreviation
   "interferences \<equiv> repeat interference"
@@ -27,28 +26,25 @@ lemma triv_refinement_Await_env_steps:
   apply simp
   done
 
-lemmas prefix_refinement_env_steps_Await
-    = prefix_refinement_triv_refinement_conc[OF
-        prefix_refinement_env_steps triv_refinement_Await_env_steps]
+lemmas prefix_refinement_env_steps_Await =
+  prefix_refinement_triv_refinement_conc[OF prefix_refinement_env_steps triv_refinement_Await_env_steps]
 
 lemma pfx_refn_interferences:
-  " env_stable AR R sr iosr (\<lambda>t. True)
-    \<Longrightarrow> prefix_refinement sr iosr iosr (\<top>\<top>) (\<top>\<top>) (\<top>\<top>) AR R interferences interferences"
+  "env_stable AR R sr iosr (\<lambda>_. True)
+   \<Longrightarrow> prefix_refinement sr iosr iosr \<top>\<top> \<top>\<top> \<top>\<top> AR R interferences interferences"
   apply (rule prefix_refinement_repeat)
     apply (erule prefix_refinement_interference)
    apply wp+
   done
 
 lemma repeat_n_validI:
-  "\<lbrace>I\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_. I\<rbrace>
-    \<Longrightarrow> \<lbrace>I\<rbrace>,\<lbrace>R\<rbrace> repeat_n n f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_. I\<rbrace>"
+  "\<lbrace>I\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_. I\<rbrace> \<Longrightarrow> \<lbrace>I\<rbrace>,\<lbrace>R\<rbrace> repeat_n n f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_. I\<rbrace>"
   apply (induct n)
    apply wpsimp+
   done
 
 lemma repeat_validI:
-  "\<lbrace>I\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_. I\<rbrace>
-    \<Longrightarrow> \<lbrace>I\<rbrace>,\<lbrace>R\<rbrace> repeat f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_. I\<rbrace>"
+  "\<lbrace>I\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_. I\<rbrace> \<Longrightarrow> \<lbrace>I\<rbrace>,\<lbrace>R\<rbrace> repeat f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_. I\<rbrace>"
   apply (simp add: repeat_def)
   apply (wpsimp wp: repeat_n_validI)
   done
@@ -78,19 +74,19 @@ lemma repeat_none_triv_refinement:
   apply (rule triv_refinement_refl)
   done
 
-lemmas repeat_triv_refinement_consume_1
-    = triv_refinement_trans[OF triv_refinement_mono_bind(1),
-        OF repeat_pre_triv_refinement, simplified bind_assoc,
-        OF triv_refinement_mono_bind(2), simplified]
+lemmas repeat_triv_refinement_consume_1 =
+  triv_refinement_trans[OF triv_refinement_mono_bind(1),
+                        OF repeat_pre_triv_refinement, simplified bind_assoc,
+                        OF triv_refinement_mono_bind(2), simplified]
 
-lemmas repeat_one_triv_refinement
-    = repeat_triv_refinement_consume_1[where b=return and d=return,
-        simplified, OF repeat_none_triv_refinement]
+lemmas repeat_one_triv_refinement =
+  repeat_triv_refinement_consume_1[where b=return and d=return, simplified,
+                                   OF repeat_none_triv_refinement]
 
 schematic_goal prefix_refinement_interferences_split:
   "prefix_refinement sr isr osr rvr P Q AR R ?aprog cprog
-    \<Longrightarrow> prefix_refinement sr isr osr rvr P Q AR R
-                          (do y <- interferences; aprog od) cprog"
+   \<Longrightarrow> prefix_refinement sr isr osr rvr P Q AR R
+                         (do y <- interferences; aprog od) cprog"
   apply (rule prefix_refinement_triv_refinement_abs)
    apply (rule  triv_refinement_mono_bind)
    apply (rule triv_refinement_trans)
@@ -99,21 +95,18 @@ schematic_goal prefix_refinement_interferences_split:
   apply (simp add: bind_assoc)
   done
 
-text \<open>Suppressing interference points. The constant below discards
-the self actions within a trace and filters out traces in which the
-environment acts. This reduces both env_steps and interference to
-noops.
-\<close>
+text \<open>
+  Suppressing interference points. The constant below discards
+  the self actions within a trace and filters out traces in which the
+  environment acts. This reduces both env_steps and interference to
+  noops.\<close>
 
-definition
-  detrace :: "('s, 'a) tmonad \<Rightarrow> ('s, 'a) tmonad"
-where
-  "detrace f = (\<lambda>s. (\<lambda>(tr, res). ([], res))
-     ` (f s \<inter> ({tr. Env \<notin> fst ` set tr} \<times> {res. res \<noteq> Incomplete})))"
+definition detrace :: "('s, 'a) tmonad \<Rightarrow> ('s, 'a) tmonad" where
+  "detrace f =
+     (\<lambda>s. (\<lambda>(tr, res). ([], res)) ` (f s \<inter> ({tr. Env \<notin> fst ` set tr} \<times> {res. res \<noteq> Incomplete})))"
 
 lemma detrace_UN:
-  "detrace (\<lambda>s. \<Union>x \<in> S s. f x s)
-    = (\<lambda>s. \<Union>x \<in> S s. detrace (f x) s)"
+  "detrace (\<lambda>s. \<Union>x \<in> S s. f x s) = (\<lambda>s. \<Union>x \<in> S s. detrace (f x) s)"
   apply (simp add: detrace_def)
   apply (rule ext; fastforce)
   done
@@ -151,13 +144,13 @@ lemma detrace_select[simp]:
   by (rule ext, auto simp add: select_def detrace_def image_image)
 
 lemma detrace_put_trace_elem:
-  "detrace (put_trace_elem (tmid, s)) = (if tmid = Env
-    then (\<lambda>_. {}) else return ())"
+  "detrace (put_trace_elem (tmid, s)) =
+   (if tmid = Env then (\<lambda>_. {}) else return ())"
   by (simp add: put_trace_elem_def detrace_def return_def)
 
 lemma detrace_put_trace:
-  "detrace (put_trace xs) = (if Env \<in> fst ` set xs
-    then (\<lambda>_. {}) else return ())"
+  "detrace (put_trace xs) =
+   (if Env \<in> fst ` set xs then (\<lambda>_. {}) else return ())"
   apply (induct xs; simp)
   apply (clarsimp simp: detrace_bind detrace_put_trace_elem)
   apply (simp add: bind_def)
@@ -198,21 +191,18 @@ lemma detrace_interference:
   apply (simp add: bind_def get_def)
   done
 
-text \<open>Decomposition of environment and program actions by strict
-separation, possibly relevant for ``recovering'' atomicity.\<close>
+text \<open>
+  Decomposition of environment and program actions by strict separation, possibly relevant for
+  ``recovering'' atomicity.\<close>
 
 lemma equivp_compare_f:
   "equivp (\<lambda>x y. f x = f y)"
   by (simp add: equivp_def fun_eq_iff, metis)
 
-definition
-  fst_split_eq :: "('s \<Rightarrow> ('e \<times> 'p)) \<Rightarrow> ('s \<Rightarrow> 's \<Rightarrow> bool)"
-where
+definition fst_split_eq :: "('s \<Rightarrow> ('e \<times> 'p)) \<Rightarrow> ('s \<Rightarrow> 's \<Rightarrow> bool)" where
   "fst_split_eq f = (\<lambda>s s'. fst (f s) = fst (f s'))"
 
-definition
-  snd_split_eq :: "('s \<Rightarrow> ('e \<times> 'p)) \<Rightarrow> ('s \<Rightarrow> 's \<Rightarrow> bool)"
-where
+definition snd_split_eq :: "('s \<Rightarrow> ('e \<times> 'p)) \<Rightarrow> ('s \<Rightarrow> 's \<Rightarrow> bool)" where
   "snd_split_eq f = (\<lambda>s s'. snd (f s) = snd (f s'))"
 
 lemma equivp_split_eqs:
@@ -220,18 +210,17 @@ lemma equivp_split_eqs:
   "equivp (snd_split_eq f)"
   by (simp_all add: fst_split_eq_def snd_split_eq_def equivp_compare_f)
 
-text \<open>One way of defining the "diamond" pattern in which two state
-changes commute. Depends on a way of splitting the state into domains,
-in which state changes can be observed to impact only certain domains.
-This can define a unique way of reordering operations that impact
-disjoint sets of domains.\<close>
+text \<open>
+  One way of defining the "diamond" pattern in which two state
+  changes commute. Depends on a way of splitting the state into domains,
+  in which state changes can be observed to impact only certain domains.
+  This can define a unique way of reordering operations that impact
+  disjoint sets of domains.\<close>
 
 type_synonym
   ('s, 'd) domain_split = "'s \<Rightarrow> 'd \<Rightarrow> 's"
 
-definition
-  dom_s_match :: "('s, 'd) domain_split \<Rightarrow> 'd set \<Rightarrow> 's \<Rightarrow> 's \<Rightarrow> bool"
-where
+definition dom_s_match :: "('s, 'd) domain_split \<Rightarrow> 'd set \<Rightarrow> 's \<Rightarrow> 's \<Rightarrow> bool" where
   "dom_s_match ds D s s' = (\<forall>d \<in> D. ds s' d = ds s d)"
 
 lemma dom_s_match_refl:
@@ -246,15 +235,12 @@ lemma dom_s_match_equivp:
   done
 
 lemma dom_s_match_mono:
-  "dom_s_match ds D s s' \<Longrightarrow> D' \<subseteq> D
-    \<Longrightarrow> dom_s_match ds D' s s'"
+  "\<lbrakk>dom_s_match ds D s s'; D' \<subseteq> D\<rbrakk> \<Longrightarrow> dom_s_match ds D' s s'"
   by (auto simp add: dom_s_match_def)
 
-definition
-  diamond :: "('s, 'd) domain_split \<Rightarrow> 's \<Rightarrow> 's \<Rightarrow> 's \<Rightarrow> 's \<Rightarrow> bool"
-where
-  "diamond ds s sa sb sab = (\<forall>d. (ds sab d = ds sa d \<and> ds sb d = ds s d)
-        \<or> (ds sab d = ds sb d \<and> ds sa d = ds s d))"
+definition diamond :: "('s, 'd) domain_split \<Rightarrow> 's \<Rightarrow> 's \<Rightarrow> 's \<Rightarrow> 's \<Rightarrow> bool" where
+  "diamond ds s sa sb sab =
+     (\<forall>d. (ds sab d = ds sa d \<and> ds sb d = ds s d) \<or> (ds sab d = ds sb d \<and> ds sa d = ds s d))"
 
 lemma diamond_flips:
   "diamond ds s sa sb sab \<Longrightarrow> diamond ds sb sab s sa"
@@ -265,35 +251,28 @@ lemma diamond_diag_flip:
   "diamond ds s sa sb sab \<Longrightarrow> diamond ds s sb sa sab"
   by (simp add: diamond_def, metis)
 
-definition
-  domains_complete :: "('s, 'd) domain_split \<Rightarrow> bool"
-where
+definition domains_complete :: "('s, 'd) domain_split \<Rightarrow> bool" where
   "domains_complete ds = (\<forall>s s'. (\<forall>d. ds s d = ds s' d) \<longrightarrow> s = s')"
 
 lemmas domains_completeD = domains_complete_def[THEN iffD1, rule_format]
 
 lemma diamond_unique:
-  "domains_complete ds \<Longrightarrow> diamond ds s sa sb sab
-    \<Longrightarrow> diamond ds s sa sb sab' \<Longrightarrow> sab = sab'"
+  "\<lbrakk>domains_complete ds; diamond ds s sa sb sab; diamond ds s sa sb sab'\<rbrakk> \<Longrightarrow> sab = sab'"
   apply (erule domains_completeD)
   apply (simp add: diamond_def)
   apply metis
   done
 
 lemma diamond_uniques_other:
-  "domains_complete ds \<Longrightarrow> diamond ds s sa sb sab
-    \<Longrightarrow> diamond ds s sa sb' sab \<Longrightarrow> sb = sb'"
-  "domains_complete ds \<Longrightarrow> diamond ds s sa sb sab
-    \<Longrightarrow> diamond ds s sa' sb sab \<Longrightarrow> sa = sa'"
-  "domains_complete ds \<Longrightarrow> diamond ds s sa sb sab
-    \<Longrightarrow> diamond ds s' sa sb sab \<Longrightarrow> s = s'"
+  "\<lbrakk>domains_complete ds; diamond ds s sa sb sab; diamond ds s sa sb' sab\<rbrakk> \<Longrightarrow> sb = sb'"
+  "\<lbrakk>domains_complete ds; diamond ds s sa sb sab; diamond ds s sa' sb sab\<rbrakk> \<Longrightarrow> sa = sa'"
+  "\<lbrakk>domains_complete ds; diamond ds s sa sb sab; diamond ds s' sa sb sab\<rbrakk> \<Longrightarrow> s = s'"
   by (metis diamond_unique diamond_flips)+
 
 lemmas diamond_uniques = diamond_unique diamond_uniques_other
 
 lemma dom_s_match_diamond:
-  "dom_s_match ds D s sa \<Longrightarrow> diamond ds s sa sb sab
-    \<Longrightarrow> dom_s_match ds D sb sab"
+  "\<lbrakk>dom_s_match ds D s sa; diamond ds s sa sb sab\<rbrakk> \<Longrightarrow> dom_s_match ds D sb sab"
   apply (simp add: dom_s_match_def diamond_def)
   apply metis
   done
@@ -307,28 +286,26 @@ lemma diamond_trans_eq:
   by (simp add: fun_eq_iff, metis diamond_trans diamond_flips)
 
 text \<open>
-A notion of refinement by traces related under a state relation. Simpler
-than @{term prefix_refinement}, and left-composes with
-@{term prefix_refinement}.
+  A notion of refinement by traces related under a state relation. Simpler
+  than @{term prefix_refinement}, and left-composes with
+  @{term prefix_refinement}.
 
-We'll use this notion to show how the concrete side of a @{term prefix_refinement}
-hypothesis can be reordered to better match its specification, in particular
-how interference points can be moved.
-\<close>
+  We'll use this notion to show how the concrete side of a @{term prefix_refinement}
+  hypothesis can be reordered to better match its specification, in particular
+  how interference points can be moved.\<close>
 
-definition
-  rel_tr_refinement :: "('s \<Rightarrow> 's \<Rightarrow> bool) \<Rightarrow> ('s \<Rightarrow> bool) \<Rightarrow> 's rg_pred
-    \<Rightarrow> bool \<Rightarrow> ('s, 'a) tmonad \<Rightarrow> ('s, 'a) tmonad \<Rightarrow>  bool"
-where
-  "rel_tr_refinement sr P R commit f g = (\<forall>tr res s s0. P s
-    \<longrightarrow> (tr, res) \<in> f s \<longrightarrow> rely_cond R s0 tr \<longrightarrow> (commit \<longrightarrow> s0 = s)
-    \<longrightarrow> (\<exists>tr'. (tr', res) \<in> g s \<and> rely_cond R s0 tr'
-                \<and> list_all2 (rel_prod (=) sr) tr tr'))"
+definition rel_tr_refinement ::
+  "('s \<Rightarrow> 's \<Rightarrow> bool) \<Rightarrow> ('s \<Rightarrow> bool) \<Rightarrow> 's rg_pred \<Rightarrow> bool \<Rightarrow> ('s, 'a) tmonad \<Rightarrow> ('s, 'a) tmonad \<Rightarrow> bool"
+  where
+  "rel_tr_refinement sr P R commit f g =
+     (\<forall>tr res s s0. P s
+        \<longrightarrow> (tr, res) \<in> f s \<longrightarrow> rely_cond R s0 tr \<longrightarrow> (commit \<longrightarrow> s0 = s)
+        \<longrightarrow> (\<exists>tr'. (tr', res) \<in> g s \<and> rely_cond R s0 tr'
+                   \<and> list_all2 (rel_prod (=) sr) tr tr'))"
 
 lemma rely_cond_equiv_s:
-  "rely_cond R s0 tr
-    \<Longrightarrow> (\<And>s. tr \<noteq> [] \<Longrightarrow> last tr = (Env, s) \<Longrightarrow> R s0 s \<Longrightarrow> R s0' s)
-    \<Longrightarrow> rely_cond R s0' tr"
+  "\<lbrakk>rely_cond R s0 tr; \<And>s. tr \<noteq> [] \<Longrightarrow> last tr = (Env, s) \<Longrightarrow> R s0 s \<Longrightarrow> R s0' s\<rbrakk>
+   \<Longrightarrow> rely_cond R s0' tr"
   apply (cases tr rule: rev_cases)
    apply simp
   apply (clarsimp simp: rely_cond_append rely_cond_def[where tr="Cons x xs" for x xs])
@@ -337,23 +314,19 @@ lemma rely_cond_equiv_s:
 lemmas rel_tr_refinementD = rel_tr_refinement_def[THEN iffD1, rule_format]
 
 lemma rel_tr_refinement_refl:
-  "reflp sr
-    \<Longrightarrow> rel_tr_refinement sr P R C f f"
+  "reflp sr \<Longrightarrow> rel_tr_refinement sr P R C f f"
   apply (clarsimp simp: rel_tr_refinement_def)
   apply (intro exI, rule conjI, assumption)
   apply (simp add: list_all2_same rel_prod_sel reflpD)
   done
 
 lemma rel_tr_refinement_drop_C:
-  "rel_tr_refinement sr P R False f g
-    \<Longrightarrow> rel_tr_refinement sr P R C f g"
+  "rel_tr_refinement sr P R False f g \<Longrightarrow> rel_tr_refinement sr P R C f g"
   by (clarsimp simp: rel_tr_refinement_def)
 
 lemma rel_tr_refinement_trans:
-  "transp sr
-    \<Longrightarrow> rel_tr_refinement sr P R C f g
-    \<Longrightarrow> rel_tr_refinement sr P R C g h
-    \<Longrightarrow> rel_tr_refinement sr P R C f h"
+  "\<lbrakk>transp sr; rel_tr_refinement sr P R C f g; rel_tr_refinement sr P R C g h\<rbrakk>
+   \<Longrightarrow> rel_tr_refinement sr P R C f h"
   apply (subst rel_tr_refinement_def, clarsimp)
   apply (drule(3) rel_tr_refinementD, clarsimp+)
   apply (drule(3) rel_tr_refinementD, clarsimp+)
@@ -365,7 +338,7 @@ lemma rel_tr_refinement_trans:
 
 lemma list_all2_matching_tr_pfx:
   "list_all2 (rel_prod (=) (\<lambda>cs cs'. \<forall>as. sr as cs = sr as cs')) tr tr'
-    \<Longrightarrow> matching_tr_pfx sr atr tr = matching_tr_pfx sr atr tr'"
+   \<Longrightarrow> matching_tr_pfx sr atr tr = matching_tr_pfx sr atr tr'"
   apply (simp add: matching_tr_pfx_def list_all2_lengthD matching_tr_def)
   apply (intro conj_cong; simp?)
   apply (clarsimp simp: list_all2_conv_all_nth rel_prod_sel split_def)
@@ -373,19 +346,19 @@ lemma list_all2_matching_tr_pfx:
   done
 
 lemma is_matching_fragment_list_all2:
-  "is_matching_fragment sr osr rvr tr' res s0 R s f
-    \<Longrightarrow> list_all2 (rel_prod (=) (\<lambda>cs cs'. \<forall>as. sr as cs = sr as cs')) tr tr'
-    \<Longrightarrow> is_matching_fragment sr osr rvr tr res s0 R s f"
+  "\<lbrakk>is_matching_fragment sr osr rvr tr' res s0 R s f;
+    list_all2 (rel_prod (=) (\<lambda>cs cs'. \<forall>as. sr as cs = sr as cs')) tr tr'\<rbrakk>
+   \<Longrightarrow> is_matching_fragment sr osr rvr tr res s0 R s f"
   apply (clarsimp simp: is_matching_fragment_def)
   apply (subst(asm) list_all2_is_me[symmetric], assumption, simp)
   apply (simp add: list_all2_matching_tr_pfx list_all2_lengthD)
   done
 
 lemma pfx_refinement_use_rel_tr_refinement:
-  "rel_tr_refinement tr_r Q R False g g'
-    \<Longrightarrow> \<forall>s t t'. tr_r t t' \<longrightarrow> sr s t = sr s t'
-    \<Longrightarrow> prefix_refinement sr isr osr rvr P Q' AR R f g'
-    \<Longrightarrow> prefix_refinement sr isr osr rvr P (\<lambda>s0. Q and Q' s0) AR R f g"
+  "\<lbrakk>rel_tr_refinement tr_r Q R False g g';
+    \<forall>s t t'. tr_r t t' \<longrightarrow> sr s t = sr s t';
+    prefix_refinement sr isr osr rvr P Q' AR R f g'\<rbrakk>
+   \<Longrightarrow> prefix_refinement sr isr osr rvr P (\<lambda>s0. Q and Q' s0) AR R f g"
   apply (subst prefix_refinement_def, clarsimp)
   apply (drule(3) rel_tr_refinementD, simp)
   apply clarsimp
@@ -398,25 +371,21 @@ lemma pfx_refinement_use_rel_tr_refinement:
   done
 
 lemma pfx_refinement_use_rel_tr_refinement_equivp:
-  "rel_tr_refinement sr Q R False g g'
-    \<Longrightarrow> equivp sr
-    \<Longrightarrow> prefix_refinement sr isr osr rvr P Q' AR R f g'
-    \<Longrightarrow> prefix_refinement sr isr osr rvr P (\<lambda>s0. Q and Q' s0) AR R f g"
+  "\<lbrakk>rel_tr_refinement sr Q R False g g'; equivp sr;
+    prefix_refinement sr isr osr rvr P Q' AR R f g'\<rbrakk>
+   \<Longrightarrow> prefix_refinement sr isr osr rvr P (\<lambda>s0. Q and Q' s0) AR R f g"
   apply (erule pfx_refinement_use_rel_tr_refinement, simp_all)
   apply (metis equivpE sympD transpD)
   done
 
-definition
-  not_env_steps_first :: "('s, 'a) tmonad \<Rightarrow> bool"
-where
+definition not_env_steps_first :: "('s, 'a) tmonad \<Rightarrow> bool" where
   "not_env_steps_first f = (\<forall>tr res s. (tr, res) \<in> f s \<longrightarrow> tr \<noteq> [] \<longrightarrow> fst (last tr) = Me)"
 
 lemmas not_env_steps_firstD = not_env_steps_first_def[THEN iffD1, rule_format]
 
 lemma not_env_steps_first_bind:
-  "not_env_steps_first f
-    \<Longrightarrow> \<forall>x. not_env_steps_first (g x)
-    \<Longrightarrow> not_env_steps_first (do x \<leftarrow> f; g x od)"
+  "\<lbrakk>not_env_steps_first f; \<forall>x. not_env_steps_first (g x)\<rbrakk>
+   \<Longrightarrow> not_env_steps_first (do x \<leftarrow> f; g x od)"
   apply (subst not_env_steps_first_def, clarsimp)
   apply (erule elem_bindE)
    apply (simp add: not_env_steps_firstD)
@@ -426,7 +395,7 @@ lemma not_env_steps_first_bind:
 
 lemma not_env_steps_first_no_trace:
   "no_trace f \<Longrightarrow> not_env_steps_first f"
-  by (fastforce simp add: not_env_steps_first_def dest: no_trace_emp)
+  by (fastforce simp: not_env_steps_first_def dest: no_trace_emp)
 
 lemma not_env_steps_first_interference:
   "not_env_steps_first interference"
@@ -443,18 +412,17 @@ lemma not_env_steps_first_repeat_n:
 
 lemma not_env_steps_first_repeat:
   "not_env_steps_first f \<Longrightarrow> not_env_steps_first (repeat f)"
-  by (simp add: repeat_def not_env_steps_first_bind
-                   not_env_steps_first_repeat_n not_env_steps_first_simple)
+  by (simp add: repeat_def not_env_steps_first_bind not_env_steps_first_repeat_n
+                not_env_steps_first_simple)
 
-lemmas not_env_steps_first_all = not_env_steps_first_interference
-    not_env_steps_first_bind[rule_format] not_env_steps_first_repeat_n
-    not_env_steps_first_repeat not_env_steps_first_simple
+lemmas not_env_steps_first_all =
+  not_env_steps_first_interference not_env_steps_first_bind[rule_format]
+  not_env_steps_first_repeat_n not_env_steps_first_repeat not_env_steps_first_simple
 
 lemma rel_tr_refinement_bind_left_general:
-  "reflp sr
-    \<Longrightarrow> (\<forall>x. not_env_steps_first (h x)) \<or> (\<forall>s s' t. sr s s' \<longrightarrow> R s t = R s' t)
-    \<Longrightarrow> rel_tr_refinement sr P R C f g
-    \<Longrightarrow> rel_tr_refinement sr P R C (f >>= (\<lambda>x. h x)) (g >>= h)"
+  "\<lbrakk>reflp sr; (\<forall>x. not_env_steps_first (h x)) \<or> (\<forall>s s' t. sr s s' \<longrightarrow> R s t = R s' t);
+    rel_tr_refinement sr P R C f g\<rbrakk>
+   \<Longrightarrow> rel_tr_refinement sr P R C (f >>= (\<lambda>x. h x)) (g >>= h)"
   apply (subst rel_tr_refinement_def, clarsimp)
   apply (erule elem_bindE)
    apply (drule(3) rel_tr_refinementD, simp)
@@ -467,8 +435,7 @@ lemma rel_tr_refinement_bind_left_general:
   apply (simp add: image_def)
   apply (strengthen bexI[mk_strg I _ E] | simp)+
   apply (simp add: list_all2_append rely_cond_append
-                   list_all2_same reflpD[where R=sr] rel_prod_sel
-        split del: if_split)
+                   list_all2_same reflpD[where R=sr] rel_prod_sel)
   apply (erule rely_cond_equiv_s)
   apply (erule disjE)
    apply (drule spec, drule(2) not_env_steps_firstD)
@@ -477,15 +444,12 @@ lemma rel_tr_refinement_bind_left_general:
                  split: if_split_asm)
   done
 
-lemmas rel_tr_refinement_bind_left
-    = rel_tr_refinement_bind_left_general[OF _ disjI1]
+lemmas rel_tr_refinement_bind_left = rel_tr_refinement_bind_left_general[OF _ disjI1]
 
 lemma rel_tr_refinement_bind_right_general:
-  "reflp sr
-    \<Longrightarrow> \<forall>x. rel_tr_refinement sr Q R C' (g x) (h x)
-    \<Longrightarrow> \<lbrace>\<lambda>s0 s. (C \<longrightarrow> s0 = s) \<and> P s\<rbrace>,\<lbrace>R\<rbrace> f
-        \<lbrace>\<lambda>_ _. True\<rbrace>,\<lbrace>\<lambda>_ s0 s. (C' \<longrightarrow> s0 = s) \<and> Q s\<rbrace>
-    \<Longrightarrow> rel_tr_refinement sr P R C (f >>= (\<lambda>x. g x)) (f >>= h)"
+  "\<lbrakk>reflp sr; \<forall>x. rel_tr_refinement sr Q R C' (g x) (h x);
+    \<lbrace>\<lambda>s0 s. (C \<longrightarrow> s0 = s) \<and> P s\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>\<lambda>_ _. True\<rbrace>,\<lbrace>\<lambda>_ s0 s. (C' \<longrightarrow> s0 = s) \<and> Q s\<rbrace>\<rbrakk>
+   \<Longrightarrow> rel_tr_refinement sr P R C (f >>= (\<lambda>x. g x)) (f >>= h)"
   apply (subst rel_tr_refinement_def, clarsimp)
   apply (erule elem_bindE)
    apply (clarsimp simp: bind_def)
@@ -494,28 +458,26 @@ lemma rel_tr_refinement_bind_right_general:
   apply (clarsimp simp: rely_cond_append)
   apply (drule validI_D, erule(1) conjI, assumption+, clarsimp)
   apply (drule spec, drule(3) rel_tr_refinementD,
-    simp add: hd_append hd_map split: if_split_asm)
+         simp add: hd_append hd_map split: if_split_asm)
   apply (clarsimp simp: bind_def)
   apply (simp add: image_def)
   apply (strengthen bexI[mk_strg I _ E] | simp)+
   apply (simp add: list_all2_append list_all2_lengthD)
-  apply (simp add: rely_cond_append list_all2_same reflpD[where R=sr] rel_prod_sel
-        split del: if_split)
+  apply (simp add: rely_cond_append list_all2_same reflpD[where R=sr] rel_prod_sel)
   done
 
 lemmas validI_triv' = rg_weaken_pre[OF validI_triv, simplified]
-lemmas rel_tr_refinement_bind_right
-    = rel_tr_refinement_bind_right_general[where C'=False, simplified]
+lemmas rel_tr_refinement_bind_right =
+  rel_tr_refinement_bind_right_general[where C'=False, simplified]
 
 lemma rel_tr_refinement_comm_repeat_n[simplified K_bind_def]:
-  "equivp sr
-    \<Longrightarrow> rel_tr_refinement sr P R C (do f; g od) (do x \<leftarrow> g; f; return x od)
-    \<Longrightarrow> not_env_steps_first f \<or> (\<forall>s s' t. sr s s' \<longrightarrow> R s t = R s' t)
-    \<Longrightarrow> \<lbrace>\<lambda>s0 s. (C \<longrightarrow> s0 = s) \<and> P s\<rbrace>,\<lbrace>R\<rbrace> f
-        \<lbrace>\<lambda>_ _. True\<rbrace>,\<lbrace>\<lambda>_ s0 s. (C \<longrightarrow> s0 = s) \<and> P s\<rbrace>
-    \<Longrightarrow> rel_tr_refinement sr P R C
-        (do repeat_n n f; g od)
-        (do x \<leftarrow> g; repeat_n n f; return x od)"
+  "\<lbrakk>equivp sr;
+    rel_tr_refinement sr P R C (do f; g od) (do x \<leftarrow> g; f; return x od);
+    not_env_steps_first f \<or> (\<forall>s s' t. sr s s' \<longrightarrow> R s t = R s' t);
+    \<lbrace>\<lambda>s0 s. (C \<longrightarrow> s0 = s) \<and> P s\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>\<lambda>_ _. True\<rbrace>,\<lbrace>\<lambda>_ s0 s. (C \<longrightarrow> s0 = s) \<and> P s\<rbrace>\<rbrakk>
+   \<Longrightarrow> rel_tr_refinement sr P R C
+         (do repeat_n n f; g od)
+         (do x \<leftarrow> g; repeat_n n f; return x od)"
   apply (induct n)
    apply simp
    apply (rule rel_tr_refinement_refl)
@@ -528,21 +490,20 @@ lemma rel_tr_refinement_comm_repeat_n[simplified K_bind_def]:
     apply assumption
    apply (wpsimp wp: repeat_n_validI)
   apply (drule_tac h="\<lambda>x. do f; return x od"
-      in rel_tr_refinement_bind_left_general[rotated 2])
+           in rel_tr_refinement_bind_left_general[rotated 2])
     apply (metis equivpE)
    apply (auto intro!: not_env_steps_first_all)[1]
   apply (simp add: bind_assoc)
   done
 
 lemma rel_tr_refinement_comm_repeat[simplified K_bind_def]:
-  "equivp sr
-    \<Longrightarrow> rel_tr_refinement sr P R C (do f; g od) (do x \<leftarrow> g; f; return x od)
-    \<Longrightarrow> not_env_steps_first f \<or> (\<forall>s s' t. sr s s' \<longrightarrow> R s t = R s' t)
-    \<Longrightarrow> \<lbrace>\<lambda>s0 s. (C \<longrightarrow> s0 = s) \<and> P s\<rbrace>,\<lbrace>R\<rbrace> f
-        \<lbrace>\<lambda>_ _. True\<rbrace>,\<lbrace>\<lambda>_ s0 s. (C \<longrightarrow> s0 = s) \<and> P s\<rbrace>
-    \<Longrightarrow> rel_tr_refinement sr P R C
-        (do repeat f; g od)
-        (do x \<leftarrow> g; repeat f; return x od)"
+  "\<lbrakk>equivp sr;
+    rel_tr_refinement sr P R C (do f; g od) (do x \<leftarrow> g; f; return x od);
+    not_env_steps_first f \<or> (\<forall>s s' t. sr s s' \<longrightarrow> R s t = R s' t);
+    \<lbrace>\<lambda>s0 s. (C \<longrightarrow> s0 = s) \<and> P s\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>\<lambda>_ _. True\<rbrace>,\<lbrace>\<lambda>_ s0 s. (C \<longrightarrow> s0 = s) \<and> P s\<rbrace>\<rbrakk>
+   \<Longrightarrow> rel_tr_refinement sr P R C
+         (do repeat f; g od)
+         (do x \<leftarrow> g; repeat f; return x od)"
   apply (simp add: repeat_def select_early bind_assoc)
   apply (rule rel_tr_refinement_bind_right_general[rule_format])
     apply (metis equivpE)
@@ -551,14 +512,13 @@ lemma rel_tr_refinement_comm_repeat[simplified K_bind_def]:
   done
 
 lemma rel_tr_refinement_rev_comm_repeat_n[simplified K_bind_def]:
-  "equivp sr
-    \<Longrightarrow> rel_tr_refinement sr P R C (do x \<leftarrow> g; f; return x od) (do f; g od)
-    \<Longrightarrow> not_env_steps_first f \<or> (\<forall>s s' t. sr s s' \<longrightarrow> R s t = R s' t)
-    \<Longrightarrow> \<lbrace>\<lambda>s0 s. (C \<longrightarrow> s0 = s) \<and> P s\<rbrace>,\<lbrace>R\<rbrace> f
-        \<lbrace>\<lambda>_ _. True\<rbrace>,\<lbrace>\<lambda>_ s0 s. (C \<longrightarrow> s0 = s) \<and> P s\<rbrace>
-    \<Longrightarrow> rel_tr_refinement sr P R C
-        (do x \<leftarrow> g; repeat_n n f; return x od)
-        (do repeat_n n f; g od)"
+  "\<lbrakk>equivp sr;
+    rel_tr_refinement sr P R C (do x \<leftarrow> g; f; return x od) (do f; g od);
+    not_env_steps_first f \<or> (\<forall>s s' t. sr s s' \<longrightarrow> R s t = R s' t);
+    \<lbrace>\<lambda>s0 s. (C \<longrightarrow> s0 = s) \<and> P s\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>\<lambda>_ _. True\<rbrace>,\<lbrace>\<lambda>_ s0 s. (C \<longrightarrow> s0 = s) \<and> P s\<rbrace>\<rbrakk>
+   \<Longrightarrow> rel_tr_refinement sr P R C
+         (do x \<leftarrow> g; repeat_n n f; return x od)
+         (do repeat_n n f; g od)"
   apply (induct n)
    apply simp
    apply (rule rel_tr_refinement_refl)
@@ -572,21 +532,20 @@ lemma rel_tr_refinement_rev_comm_repeat_n[simplified K_bind_def]:
     apply assumption
    apply (wpsimp wp: repeat_n_validI)
   apply (drule_tac h="\<lambda>x. do f; return x od"
-      in rel_tr_refinement_bind_left_general[rotated 2])
+           in rel_tr_refinement_bind_left_general[rotated 2])
     apply (metis equivpE)
    apply (auto intro!: not_env_steps_first_all)[1]
   apply (simp add: bind_assoc)
   done
 
 lemma rel_tr_refinement_rev_comm_repeat[simplified K_bind_def]:
-  "equivp sr
-    \<Longrightarrow> rel_tr_refinement sr P R C (do x \<leftarrow> g; f; return x od) (do f; g od)
-    \<Longrightarrow> not_env_steps_first f \<or> (\<forall>s s' t. sr s s' \<longrightarrow> R s t = R s' t)
-    \<Longrightarrow> \<lbrace>\<lambda>s0 s. (C \<longrightarrow> s0 = s) \<and> P s\<rbrace>,\<lbrace>R\<rbrace> f
-        \<lbrace>\<lambda>_ _. True\<rbrace>,\<lbrace>\<lambda>_ s0 s. (C \<longrightarrow> s0 = s) \<and> P s\<rbrace>
-    \<Longrightarrow> rel_tr_refinement sr P R C
-        (do x \<leftarrow> g; repeat f; return x od)
-        (do repeat f; g od)"
+  "\<lbrakk>equivp sr;
+    rel_tr_refinement sr P R C (do x \<leftarrow> g; f; return x od) (do f; g od);
+    not_env_steps_first f \<or> (\<forall>s s' t. sr s s' \<longrightarrow> R s t = R s' t);
+    \<lbrace>\<lambda>s0 s. (C \<longrightarrow> s0 = s) \<and> P s\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>\<lambda>_ _. True\<rbrace>,\<lbrace>\<lambda>_ s0 s. (C \<longrightarrow> s0 = s) \<and> P s\<rbrace>\<rbrakk>
+   \<Longrightarrow> rel_tr_refinement sr P R C
+         (do x \<leftarrow> g; repeat f; return x od)
+         (do repeat f; g od)"
   apply (simp add: repeat_def select_early bind_assoc)
   apply (rule rel_tr_refinement_bind_right_general[rule_format])
     apply (metis equivpE)
@@ -599,16 +558,18 @@ lemma alternative_distrib_lhs_bind:
   by (simp add: bind_def alternative_def)
 
 lemma shuttle_modify_commit_step[simplified K_bind_def]:
-  "\<forall>s. sr s (f s) \<Longrightarrow> rel_tr_refinement sr P R C
-    (do x \<leftarrow> commit_step; modify f od) (do x \<leftarrow> modify f; commit_step od)"
+  "\<forall>s. sr s (f s)
+   \<Longrightarrow> rel_tr_refinement sr P R C
+         (do x \<leftarrow> commit_step; modify f od) (do x \<leftarrow> modify f; commit_step od)"
   apply (simp add: rel_tr_refinement_def commit_step_def
                    put_trace_elem_def bind_def get_def return_def modify_def put_def)
   apply (simp add: rely_cond_def)
   done
 
 lemma shuttle_gets_commit_step[simplified K_bind_def]:
-  "reflp sr \<Longrightarrow> rel_tr_refinement sr P R C
-    (do x \<leftarrow> commit_step; gets f od) (do x \<leftarrow> gets f; commit_step; return x od)"
+  "reflp sr
+   \<Longrightarrow> rel_tr_refinement sr P R C
+         (do x \<leftarrow> commit_step; gets f od) (do x \<leftarrow> gets f; commit_step; return x od)"
   apply (simp add: rel_tr_refinement_def commit_step_def
                    put_trace_elem_def bind_def get_def return_def gets_def)
   apply (simp add: rely_cond_def reflpD)
@@ -619,9 +580,9 @@ lemma shuttle_modify_interference[simplified K_bind_def]:
     and P_stable: "\<forall>s t. P s \<longrightarrow> R s t \<longrightarrow> P t"
     and R: "\<forall>s0 s. P s0 \<longrightarrow> R s0 s \<longrightarrow> R (f s0) (f s)"
   shows
-  "rel_tr_refinement sr P R C
-        (do interference; modify f od)
-        (do modify f; interference od)"
+    "rel_tr_refinement sr P R C
+       (do interference; modify f od)
+       (do modify f; interference od)"
 proof -
   have list_all2_map:
     "\<And>xs. list_all2 (rel_prod (=) sr) xs (map (apsnd f) xs)"
@@ -642,8 +603,7 @@ proof -
     apply (clarsimp simp: rel_tr_refinement_def)
     apply (clarsimp simp: bind_def commit_step_def get_def return_def
                           put_trace_elem_def modify_def put_def
-                          interference_def env_steps_def select_def
-                          )
+                          interference_def env_steps_def select_def)
     apply (erule disjE; clarsimp)
     apply (simp add: put_trace_eq_drop)
     apply (clarsimp; split if_split_asm)
@@ -676,24 +636,23 @@ lemma rshuttle_modify_interference[simplified K_bind_def]:
     and P_stable: "\<forall>s t. P s \<longrightarrow> R s t \<longrightarrow> P t"
     and R: "\<forall>s0 s. R (f s0) s \<longrightarrow> P s0 \<longrightarrow> (\<exists>s_pre. s = f s_pre \<and> R s0 s_pre)"
   shows
-  "rel_tr_refinement sr P R C
-        (do modify f; interference od)
-        (do interference; modify f od)"
+    "rel_tr_refinement sr P R C
+       (do modify f; interference od)
+       (do interference; modify f od)"
 proof -
-  have last_st_tr: "\<And>s ss. last_st_tr (map (Pair Env \<circ> f) ss) (f s)
-        = f (last_st_tr (map (Pair Env) ss) s)"
+  have last_st_tr:
+    "\<And>s ss. last_st_tr (map (Pair Env \<circ> f) ss) (f s) = f (last_st_tr (map (Pair Env) ss) s)"
     by (simp add: last_st_tr_def hd_append hd_map)
   { fix s ss s'
-  have rely_cond_P_stable[rule_format]:
-    "P s \<longrightarrow> rely_cond R s (map (Pair Env) ss)
-           \<longrightarrow> s' \<in> set (ss @ [s]) \<longrightarrow> P s'"
-    apply (induct ss arbitrary: s' rule: list.induct)
-     apply simp
-    apply clarsimp
-    apply (clarsimp simp: rely_cond_Cons_eq P_stable)
-    apply (erule P_stable[rule_format, rotated])
-    apply (case_tac x2; simp add: last_st_tr_in_set)
-    done
+    have rely_cond_P_stable[rule_format]:
+      "P s \<longrightarrow> rely_cond R s (map (Pair Env) ss) \<longrightarrow> s' \<in> set (ss @ [s]) \<longrightarrow> P s'"
+      apply (induct ss arbitrary: s' rule: list.induct)
+       apply simp
+      apply clarsimp
+      apply (clarsimp simp: rely_cond_Cons_eq P_stable)
+      apply (erule P_stable[rule_format, rotated])
+      apply (case_tac x2; simp add: last_st_tr_in_set)
+      done
   } note rely_cond_P_stable = this
   have rely_cond_ex:
     "\<And>s ss. rely_cond R (f s) (map (Pair Env) ss) \<longrightarrow> P s
@@ -710,8 +669,7 @@ proof -
     apply (clarsimp simp: rel_tr_refinement_def)
     apply (clarsimp simp: bind_def commit_step_def get_def return_def
                           put_trace_elem_def modify_def put_def
-                          interference_def env_steps_def select_def
-                          )
+                          interference_def env_steps_def select_def)
     apply (erule disjE; clarsimp)
     apply (clarsimp simp: put_trace_eq_drop)
     apply (split if_split_asm)
@@ -739,9 +697,9 @@ proof -
 qed
 
 lemma shuttle_gets_env_step[simplified K_bind_def]:
-  "reflp sr \<Longrightarrow> \<forall>s t. P s \<longrightarrow> R s t \<longrightarrow> f s = f t
-    \<Longrightarrow> rel_tr_refinement sr P R True
-        (do x \<leftarrow> env_step; gets f od) (do x \<leftarrow> gets f; env_step; return x od)"
+  "\<lbrakk>reflp sr; \<forall>s t. P s \<longrightarrow> R s t \<longrightarrow> f s = f t\<rbrakk>
+   \<Longrightarrow> rel_tr_refinement sr P R True
+         (do x \<leftarrow> env_step; gets f od) (do x \<leftarrow> gets f; env_step; return x od)"
   apply (simp add: rel_tr_refinement_def env_step_def select_def
                    put_trace_elem_def bind_def get_def return_def gets_def put_def)
   apply (clarsimp simp: rely_cond_def reflpD)
@@ -755,11 +713,10 @@ lemma env_step_twp[wp]:
   done
 
 lemma shuttle_modify_interferences[simplified K_bind_def]:
-  "equivp sr \<Longrightarrow> \<forall>s. sr s (f s) \<Longrightarrow> \<forall>s t. P s \<longrightarrow> R s t \<longrightarrow> R (f s) (f t)
-    \<Longrightarrow> not_env_steps_first g
-    \<Longrightarrow> \<forall>s t. P s \<longrightarrow> R\<^sup>*\<^sup>* s t \<longrightarrow> P t
-    \<Longrightarrow> rel_tr_refinement sr P R C
-        (do x \<leftarrow> interferences; modify f; g od) (do x \<leftarrow> modify f; interferences; g od)"
+  "\<lbrakk>equivp sr; \<forall>s. sr s (f s); \<forall>s t. P s \<longrightarrow> R s t \<longrightarrow> R (f s) (f t);
+    not_env_steps_first g; \<forall>s t. P s \<longrightarrow> R\<^sup>*\<^sup>* s t \<longrightarrow> P t\<rbrakk>
+   \<Longrightarrow> rel_tr_refinement sr P R C
+         (do x \<leftarrow> interferences; modify f; g od) (do x \<leftarrow> modify f; interferences; g od)"
   apply (simp only: bind_assoc[symmetric])
   apply (rule rel_tr_refinement_bind_left_general)
     apply (metis equivpE)
@@ -772,17 +729,16 @@ lemma shuttle_modify_interferences[simplified K_bind_def]:
   apply wpsimp
   done
 
-lemmas shuttle_modify_interferences_flat
-    = shuttle_modify_interferences[where g="return ()", simplified]
+lemmas shuttle_modify_interferences_flat =
+  shuttle_modify_interferences[where g="return ()", simplified]
 
 lemma rshuttle_modify_interferences[simplified K_bind_def]:
-  "equivp sr \<Longrightarrow> \<forall>s. sr (f s) s
-    \<Longrightarrow> \<forall>s0 s. R (f s0) s \<longrightarrow> P s0 \<longrightarrow> (\<exists>s_pre. s = f s_pre \<and> R s0 s_pre)
-    \<Longrightarrow> not_env_steps_first g
-    \<Longrightarrow> \<forall>s t. P s \<longrightarrow> R\<^sup>*\<^sup>* s t \<longrightarrow> P t
-    \<Longrightarrow> rel_tr_refinement sr P R C
-        (do x \<leftarrow> modify f; interferences; g od)
-        (do x \<leftarrow> interferences; modify f; g od)"
+  "\<lbrakk>equivp sr; \<forall>s. sr (f s) s;
+    \<forall>s0 s. R (f s0) s \<longrightarrow> P s0 \<longrightarrow> (\<exists>s_pre. s = f s_pre \<and> R s0 s_pre);
+    not_env_steps_first g; \<forall>s t. P s \<longrightarrow> R\<^sup>*\<^sup>* s t \<longrightarrow> P t\<rbrakk>
+   \<Longrightarrow> rel_tr_refinement sr P R C
+         (do x \<leftarrow> modify f; interferences; g od)
+         (do x \<leftarrow> interferences; modify f; g od)"
   apply (simp only: bind_assoc[symmetric])
   apply (rule rel_tr_refinement_bind_left_general)
     apply (metis equivpE)
@@ -796,11 +752,10 @@ lemma rshuttle_modify_interferences[simplified K_bind_def]:
   done
 
 lemma shuttle_gets_interference[simplified K_bind_def]:
-  "equivp sr \<Longrightarrow> \<forall>s t. P s \<longrightarrow> R s t \<longrightarrow> f s = f t
-    \<Longrightarrow> (\<forall>s s' t. sr s s' \<longrightarrow> R s t = R s' t)
-    \<Longrightarrow> \<forall>s t. P s \<longrightarrow> R\<^sup>*\<^sup>* s t \<longrightarrow> P t
-    \<Longrightarrow> rel_tr_refinement sr P R C
-        (do x \<leftarrow> interference; gets f od) (do x \<leftarrow> gets f; interference; return x od)"
+  "\<lbrakk>equivp sr; \<forall>s t. P s \<longrightarrow> R s t \<longrightarrow> f s = f t;
+    \<forall>s s' t. sr s s' \<longrightarrow> R s t = R s' t; \<forall>s t. P s \<longrightarrow> R\<^sup>*\<^sup>* s t \<longrightarrow> P t\<rbrakk>
+   \<Longrightarrow> rel_tr_refinement sr P R C
+         (do x \<leftarrow> interference; gets f od) (do x \<leftarrow> gets f; interference; return x od)"
   apply (simp add: interference_def bind_assoc env_steps_repeat)
   apply (rule rel_tr_refinement_trans)
     apply (metis equivpE)
@@ -816,19 +771,18 @@ lemma shuttle_gets_interference[simplified K_bind_def]:
     apply (clarsimp simp: r_into_rtranclp)
    apply (simp add: commit_step_def, wp put_trace_elem_twp)
    apply (simp add: drop_Cons' guar_cond_def)
-  apply (rule shuttle_gets_commit_step[THEN
-    rel_tr_refinement_bind_left_general[rotated -1], simplified bind_assoc return_bind])
+  apply (rule shuttle_gets_commit_step[THEN rel_tr_refinement_bind_left_general[rotated -1],
+                                       simplified bind_assoc return_bind])
     apply (metis equivpE)
    apply (metis equivpE)
   apply simp
   done
 
 lemma shuttle_gets_interferences[simplified K_bind_def]:
-  "equivp sr \<Longrightarrow> \<forall>s t. P s \<longrightarrow> R s t \<longrightarrow> f s = f t
-    \<Longrightarrow> (\<forall>s s' t. sr s s' \<longrightarrow> R s t = R s' t)
-    \<Longrightarrow> \<forall>s t. P s \<longrightarrow> R\<^sup>*\<^sup>* s t \<longrightarrow> P t
-    \<Longrightarrow> rel_tr_refinement sr P R C
-        (do interferences; x \<leftarrow> gets f; g x od) (do x \<leftarrow> gets f; interferences; g x od)"
+  "\<lbrakk>equivp sr; \<forall>s t. P s \<longrightarrow> R s t \<longrightarrow> f s = f t;
+    \<forall>s s' t. sr s s' \<longrightarrow> R s t = R s' t; \<forall>s t. P s \<longrightarrow> R\<^sup>*\<^sup>* s t \<longrightarrow> P t\<rbrakk>
+   \<Longrightarrow> rel_tr_refinement sr P R C
+         (do interferences; x \<leftarrow> gets f; g x od) (do x \<leftarrow> gets f; interferences; g x od)"
   apply (rule rel_tr_refinement_trans)
     apply (metis equivpE)
    apply (simp only: bind_assoc[symmetric] K_bind_def)
@@ -844,32 +798,24 @@ lemma shuttle_gets_interferences[simplified K_bind_def]:
   apply (metis equivpE)
   done
 
-lemmas shuttle_gets_interferences_flat
-    = shuttle_gets_interferences[where g = return, simplified]
+lemmas shuttle_gets_interferences_flat = shuttle_gets_interferences[where g = return, simplified]
 
-definition
-  adjust_tr_relation :: "('t \<Rightarrow> 't \<Rightarrow> bool) \<Rightarrow> ('s \<Rightarrow> 't \<Rightarrow> bool) \<Rightarrow> bool"
-where
+definition adjust_tr_relation :: "('t \<Rightarrow> 't \<Rightarrow> bool) \<Rightarrow> ('s \<Rightarrow> 't \<Rightarrow> bool) \<Rightarrow> bool" where
   "adjust_tr_relation tr_r sr = (equivp tr_r \<and> (\<forall>s t t'. tr_r t t' \<longrightarrow> sr s t = sr s t'))"
 
 lemma adjust_tr_relation_equivp:
-  "equivp sr
-    \<Longrightarrow> adjust_tr_relation sr sr"
+  "equivp sr \<Longrightarrow> adjust_tr_relation sr sr"
   apply (simp add: adjust_tr_relation_def)
   apply (metis equivpE sympD transpD)
   done
 
 lemma prefix_refinement_i_modify_split:
-  "adjust_tr_relation tr_r sr
-    \<Longrightarrow> \<forall>s t. isr s t \<longrightarrow> P s \<longrightarrow> Q t \<longrightarrow> intsr (f s) (g t)
-    \<Longrightarrow> \<forall>s. tr_r s (g s)
-    \<Longrightarrow> \<forall>s t. R s t \<longrightarrow> R (g s) (g t)
-    \<Longrightarrow> not_env_steps_first b
-    \<Longrightarrow> prefix_refinement sr intsr osr rvr' P' Q' AR R
-        d (do x \<leftarrow> interferences; b od)
-    \<Longrightarrow> prefix_refinement sr isr osr rvr' (\<lambda>s0 s. P s \<and> P' s0 (f s)) (\<lambda>s0 s. Q s \<and> Q' s0 (g s)) AR R
-        (do z \<leftarrow> modify f; d od)
-        (do x \<leftarrow> interferences; y \<leftarrow> modify g; b od)"
+  "\<lbrakk>adjust_tr_relation tr_r sr; \<forall>s t. isr s t \<longrightarrow> P s \<longrightarrow> Q t \<longrightarrow> intsr (f s) (g t);
+    \<forall>s. tr_r s (g s); \<forall>s t. R s t \<longrightarrow> R (g s) (g t); not_env_steps_first b;
+    prefix_refinement sr intsr osr rvr' P' Q' AR R d (do x \<leftarrow> interferences; b od)\<rbrakk>
+   \<Longrightarrow> prefix_refinement sr isr osr rvr' (\<lambda>s0 s. P s \<and> P' s0 (f s)) (\<lambda>s0 s. Q s \<and> Q' s0 (g s)) AR R
+         (do z \<leftarrow> modify f; d od)
+         (do x \<leftarrow> interferences; y \<leftarrow> modify g; b od)"
   apply (clarsimp simp: adjust_tr_relation_def)
   apply (rule prefix_refinement_weaken_pre)
     apply (rule pfx_refinement_use_rel_tr_refinement[where tr_r=tr_r and Q=\<top>])

--- a/lib/concurrency/Prefix_Refinement.thy
+++ b/lib/concurrency/Prefix_Refinement.thy
@@ -12,90 +12,75 @@ begin
 section \<open>Definition of prefix fragment refinement.\<close>
 
 text \<open>
-This is a notion of refinement/simulation making use of prefix closure.
-For a concrete program to refine an abstract program, then for every
-trace of the concrete program there must exist a well-formed fragment
-of the abstract program that matches (according to the simulation
-relation) but which leaves enough decisions available to the abstract
-environment to permit parallel composition.
-\<close>
+  This is a notion of refinement/simulation making use of prefix closure.
+  For a concrete program to refine an abstract program, then for every
+  trace of the concrete program there must exist a well-formed fragment
+  of the abstract program that matches (according to the simulation
+  relation) but which leaves enough decisions available to the abstract
+  environment to permit parallel composition.\<close>
 
 text \<open>
-Fragments must be self-closed, or enabled. Certain incomplete traces
-must be possible to extend by a program step.
-\<close>
-definition
-  self_closed :: "((tmid \<times> 's) list \<Rightarrow> bool) \<Rightarrow> 's \<Rightarrow> ('s, 'a) tmonad \<Rightarrow> bool"
-where
-  "self_closed cond s f = (\<forall>xs. (xs, Incomplete) \<in> f s
-    \<longrightarrow> cond xs \<longrightarrow> (\<exists>s'. (Me, s') # xs \<in> fst ` f s))"
+  Fragments must be self-closed, or enabled. Certain incomplete traces
+  must be possible to extend by a program step.\<close>
+definition self_closed :: "((tmid \<times> 's) list \<Rightarrow> bool) \<Rightarrow> 's \<Rightarrow> ('s, 'a) tmonad \<Rightarrow> bool" where
+  "self_closed cond s f =
+     (\<forall>xs. (xs, Incomplete) \<in> f s \<longrightarrow> cond xs \<longrightarrow> (\<exists>s'. (Me, s') # xs \<in> fst ` f s))"
 
 lemmas self_closedD = self_closed_def[THEN iffD1, rule_format]
 
 text \<open>
-Fragments must be environment-closed. Certain incomplete traces
-must be possible to extend by any environment step that is
-compatible with some condition.
-\<close>
-definition
-  env_closed :: "((tmid \<times> 's) list \<Rightarrow> 's \<Rightarrow> bool) \<Rightarrow> 's \<Rightarrow> ('s, 'a) tmonad \<Rightarrow> bool"
-where
-  "env_closed cond s f = (\<forall>xs s'. (xs, Incomplete) \<in> f s
-    \<longrightarrow> cond xs s' \<longrightarrow> ((Env, s') # xs) \<in> fst ` f s)"
+  Fragments must be environment-closed. Certain incomplete traces
+  must be possible to extend by any environment step that is
+  compatible with some condition.\<close>
+definition env_closed :: "((tmid \<times> 's) list \<Rightarrow> 's \<Rightarrow> bool) \<Rightarrow> 's \<Rightarrow> ('s, 'a) tmonad \<Rightarrow> bool" where
+  "env_closed cond s f =
+     (\<forall>xs s'. (xs, Incomplete) \<in> f s \<longrightarrow> cond xs s' \<longrightarrow> ((Env, s') # xs) \<in> fst ` f s)"
 
 lemmas env_closedD = env_closed_def[THEN iffD1, rule_format]
 
 lemma env_closed_strengthen_cond:
-  "env_closed P s f
-    \<Longrightarrow> (\<forall>xs s. Q xs s \<longrightarrow> P xs s)
-    \<Longrightarrow> env_closed Q s f"
+  "\<lbrakk>env_closed P s f; \<forall>xs s. Q xs s \<longrightarrow> P xs s\<rbrakk> \<Longrightarrow> env_closed Q s f"
   by (simp add: env_closed_def)
 
-text \<open>
-Two traces match according to some state relation if they match at every step.
-\<close>
-definition
-  matching_tr :: "('s \<Rightarrow> 't \<Rightarrow> bool) \<Rightarrow> (tmid \<times> 's) list \<Rightarrow> (tmid \<times> 't) list \<Rightarrow> bool"
-where
+text \<open>Two traces match according to some state relation if they match at every step.\<close>
+definition matching_tr :: "('s \<Rightarrow> 't \<Rightarrow> bool) \<Rightarrow> (tmid \<times> 's) list \<Rightarrow> (tmid \<times> 't) list \<Rightarrow> bool" where
   "matching_tr sr = list_all2 (\<lambda>(aid, as) (cid, cs). aid = cid \<and> sr as cs)"
 
-definition
-  matching_tr_pfx :: "('s \<Rightarrow> 't \<Rightarrow> bool) \<Rightarrow> (tmid \<times> 's) list \<Rightarrow> (tmid \<times> 't) list \<Rightarrow> bool"
-where
-  "matching_tr_pfx sr atr ctr = (length atr \<le> length ctr
-    \<and> matching_tr sr (rev atr) (take (length atr) (rev ctr)))"
+definition matching_tr_pfx ::
+  "('s \<Rightarrow> 't \<Rightarrow> bool) \<Rightarrow> (tmid \<times> 's) list \<Rightarrow> (tmid \<times> 't) list \<Rightarrow> bool"
+  where
+  "matching_tr_pfx sr atr ctr =
+     (length atr \<le> length ctr \<and> matching_tr sr (rev atr) (take (length atr) (rev ctr)))"
 
 abbreviation
   "matching_tr_tmids_pfx \<equiv> matching_tr_pfx (\<lambda>_ _. True)"
 
-abbreviation(input)
+abbreviation (input)
   "matching_self_cond ctr \<equiv> (\<lambda>xs. length xs < length ctr \<and> fst (rev ctr ! length xs) = Me)"
 
-abbreviation(input)
-  "matching_env_cond sr ctr s0 R \<equiv> (\<lambda>xs s. matching_tr_pfx sr ((Env, s) # xs) ctr
-                \<and> rely_cond R s0 ((Env, s) # xs))"
+abbreviation (input)
+  "matching_env_cond sr ctr s0 R \<equiv>
+     (\<lambda>xs s. matching_tr_pfx sr ((Env, s) # xs) ctr \<and> rely_cond R s0 ((Env, s) # xs))"
 
 text \<open>
-The collection of properties a fragment must have to match some concrete
-trace. It must be prefix, self and environment closed, nonempty, and all
-outcomes must be matching. The outcomes (trace and result) must match
-the rely condition, the concrete trace (or a prefix), and must either be
-a matching result or @{term Incomplete} if a prefix.
-\<close>
-definition
-  is_matching_fragment :: "('s \<Rightarrow> 't \<Rightarrow> bool) \<Rightarrow> ('s \<Rightarrow> 't \<Rightarrow> bool)
-        \<Rightarrow> ('a \<Rightarrow> 'b \<Rightarrow> bool) \<Rightarrow> (tmid \<times> 't) list \<Rightarrow> ('t, 'b) tmres
-        \<Rightarrow> 's \<Rightarrow> ('s \<Rightarrow> 's \<Rightarrow> bool) \<Rightarrow> 's \<Rightarrow> ('s, 'a) tmonad \<Rightarrow> bool"
-where
+  The collection of properties a fragment must have to match some concrete
+  trace. It must be prefix, self and environment closed, nonempty, and all
+  outcomes must be matching. The outcomes (trace and result) must match
+  the rely condition, the concrete trace (or a prefix), and must either be
+  a matching result or @{term Incomplete} if a prefix.\<close>
+definition is_matching_fragment ::
+  "('s \<Rightarrow> 't \<Rightarrow> bool) \<Rightarrow> ('s \<Rightarrow> 't \<Rightarrow> bool) \<Rightarrow> ('a \<Rightarrow> 'b \<Rightarrow> bool) \<Rightarrow> (tmid \<times> 't) list \<Rightarrow>
+   ('t, 'b) tmres \<Rightarrow> 's \<Rightarrow> ('s \<Rightarrow> 's \<Rightarrow> bool) \<Rightarrow> 's \<Rightarrow> ('s, 'a) tmonad \<Rightarrow> bool"
+  where
   "is_matching_fragment sr osr rvr ctr cres s0 R s f
-    = ((prefix_closed f
-        \<and> self_closed (matching_self_cond ctr) s f
-        \<and> env_closed (matching_env_cond sr ctr s0 R) s f)
-        \<and> (f s \<noteq> {})
+     = ((prefix_closed f
+         \<and> self_closed (matching_self_cond ctr) s f
+         \<and> env_closed (matching_env_cond sr ctr s0 R) s f)
+        \<and> f s \<noteq> {}
         \<and> (\<forall>(tr, res) \<in> f s. rely_cond R s0 tr
-            \<and> matching_tr_pfx sr tr ctr
-            \<and> (length tr < length ctr \<longrightarrow> res = Incomplete)
-            \<and> (length tr = length ctr \<longrightarrow> rel_tmres osr rvr res cres)))"
+             \<and> matching_tr_pfx sr tr ctr
+             \<and> (length tr < length ctr \<longrightarrow> res = Incomplete)
+             \<and> (length tr = length ctr \<longrightarrow> rel_tmres osr rvr res cres)))"
 
 lemmas is_matching_fragmentD = is_matching_fragment_def[THEN iffD1, rule_format]
 
@@ -106,25 +91,24 @@ lemmas is_matching_fragment_env_closed = is_matching_fragment_wf[THEN conjunct2,
 lemmas is_matching_fragment_defD
     = is_matching_fragmentD[THEN conjunct2, THEN conjunct1, rule_format]
 lemmas is_matching_fragment_trD
-    = is_matching_fragmentD[THEN conjunct2, THEN conjunct2,
-        rule_format, where x="(tr, res)" for tr res, simplified, rule_format]
+    = is_matching_fragmentD[THEN conjunct2, THEN conjunct2, rule_format,
+                            where x="(tr, res)" for tr res, simplified, rule_format]
 
 text \<open>
-Prefix fragment refinement. Given the initial conditions, every concrete outcome
-(trace and result) must have a matching fragment which is a simple refinement of
-the abstract program.
-\<close>
-definition
-  prefix_refinement :: "('s \<Rightarrow> 't \<Rightarrow> bool) \<Rightarrow> ('s \<Rightarrow> 't \<Rightarrow> bool) \<Rightarrow> ('s \<Rightarrow> 't \<Rightarrow> bool)
-    \<Rightarrow> ('a \<Rightarrow> 'b \<Rightarrow> bool) \<Rightarrow> ('s \<Rightarrow> 's \<Rightarrow> bool) \<Rightarrow> ('t \<Rightarrow> 't \<Rightarrow> bool)
-    \<Rightarrow> ('s \<Rightarrow> 's \<Rightarrow> bool) \<Rightarrow> ('t \<Rightarrow> 't \<Rightarrow> bool)
-    \<Rightarrow> ('s, 'a) tmonad \<Rightarrow> ('t, 'b) tmonad \<Rightarrow> bool"
-where
+  Prefix fragment refinement. Given the initial conditions, every concrete outcome
+  (trace and result) must have a matching fragment which is a simple refinement of
+  the abstract program.\<close>
+definition prefix_refinement ::
+  "('s \<Rightarrow> 't \<Rightarrow> bool) \<Rightarrow> ('s \<Rightarrow> 't \<Rightarrow> bool) \<Rightarrow> ('s \<Rightarrow> 't \<Rightarrow> bool) \<Rightarrow> ('a \<Rightarrow> 'b \<Rightarrow> bool) \<Rightarrow>
+   ('s \<Rightarrow> 's \<Rightarrow> bool) \<Rightarrow> ('t \<Rightarrow> 't \<Rightarrow> bool) \<Rightarrow> ('s \<Rightarrow> 's \<Rightarrow> bool) \<Rightarrow> ('t \<Rightarrow> 't \<Rightarrow> bool) \<Rightarrow>
+   ('s, 'a) tmonad \<Rightarrow> ('t, 'b) tmonad \<Rightarrow> bool"
+  where
   "prefix_refinement sr isr osr rvr P Q AR R aprog cprog
     = (\<forall>s s0 t0 t. isr s t \<longrightarrow> P s0 s \<longrightarrow> sr s0 t0 \<longrightarrow> Q t0 t
-    \<longrightarrow> (\<forall>(ctr, cres) \<in> cprog t.
-        rely_cond R t0 ctr \<longrightarrow> (\<exists>f. is_matching_fragment sr osr rvr ctr cres s0 AR s f
-            \<and> triv_refinement aprog f)))"
+         \<longrightarrow> (\<forall>(ctr, cres) \<in> cprog t.
+                rely_cond R t0 ctr \<longrightarrow>
+                  (\<exists>f. is_matching_fragment sr osr rvr ctr cres s0 AR s f
+                       \<and> triv_refinement aprog f)))"
 
 abbreviation
   "pfx_refn sr rvr P \<equiv> prefix_refinement sr sr sr rvr P"
@@ -137,7 +121,7 @@ lemmas pfx_refnD2 = pfx_refnD[THEN split_iffD1[where a=tr and b=res for tr res],
 lemma matching_tr_pfx_aCons:
   "matching_tr_pfx sr ((tmid, s) # atr) ctr
     = (\<exists>s'. length atr < length ctr \<and> rev ctr ! length atr = (tmid, s')
-        \<and> sr s s' \<and> matching_tr_pfx sr atr ctr)"
+            \<and> sr s s' \<and> matching_tr_pfx sr atr ctr)"
   apply (simp add: matching_tr_pfx_def matching_tr_def Suc_le_eq
                    list_all2_conv_all_nth less_Suc_eq all_conj_distrib)
   apply (simp add: nth_append prod_eq_iff)
@@ -145,8 +129,8 @@ lemma matching_tr_pfx_aCons:
   done
 
 lemma rely_cond_hd:
-  "rely_cond R s0 xs \<Longrightarrow> xs \<noteq> []
-    \<Longrightarrow> fst (hd xs) = Env \<longrightarrow> R (last_st_tr (tl xs) s0) (snd (hd xs))"
+  "\<lbrakk>rely_cond R s0 xs; xs \<noteq> []\<rbrakk>
+   \<Longrightarrow> fst (hd xs) = Env \<longrightarrow> R (last_st_tr (tl xs) s0) (snd (hd xs))"
   by (clarsimp simp: rely_cond_def neq_Nil_conv trace_steps_append
               split: if_split_asm)
 
@@ -155,25 +139,23 @@ lemma diff_Suc_eq_if:
   by auto
 
 lemma rely_cond_nth:
-  "rely_cond R s0 tr \<Longrightarrow> n < length tr
-    \<Longrightarrow> fst (rev tr ! n) = Env \<longrightarrow> R ((if n = 0 then s0 else snd (rev tr ! (n - 1)))) (snd (rev tr ! n))"
+  "\<lbrakk>rely_cond R s0 tr; n < length tr\<rbrakk>
+   \<Longrightarrow> fst (rev tr ! n) = Env \<longrightarrow> R ((if n = 0 then s0 else snd (rev tr ! (n - 1)))) (snd (rev tr ! n))"
   by (simp add: rely_cond_def trace_steps_rev_drop_nth[where n=0, simplified])
 
 lemma is_matching_fragment_Nil:
-  "is_matching_fragment sr osr rvr ctr cres s0 R s f
-    \<Longrightarrow> [] \<in> fst ` f s"
+  "is_matching_fragment sr osr rvr ctr cres s0 R s f \<Longrightarrow> [] \<in> fst ` f s"
   apply (clarsimp simp: is_matching_fragment_def)
   apply (clarsimp simp only: set_eq_iff empty_iff simp_thms not_all)
   apply (drule(1) prefix_closed_drop[where tr=tr and n="length tr" for tr])
-  apply (clarsimp simp add: in_fst_snd_image)
+  apply (clarsimp simp: in_fst_snd_image)
   done
 
 section \<open>Implications\<close>
 text \<open>
-The notions of matching fragment and prefix refinement we have defined
-allow us to prove the existence of a matching trace in the abstract
-program.
-\<close>
+  The notions of matching fragment and prefix refinement we have defined
+  allow us to prove the existence of a matching trace in the abstract
+  program.\<close>
 theorem matching_fragment_matching_tr:
   assumes match: "is_matching_fragment sr osr rvr ctr cres s0 R' s f"
   and rely: "rely_cond R t0 ctr"
@@ -256,11 +238,9 @@ corollary matching_fragment_matching_tr_trivR:
   assumes match: "is_matching_fragment sr osr rvr ctr cres s0 R s f"
   and sr: "(\<forall>s t t'. sr s t \<longrightarrow> (\<exists>s'. sr s' t' \<and> R s s'))"
   and srx: "sr s0 t0"
-  shows "\<exists>(atr, ares) \<in> f s. matching_tr sr atr ctr
-                    \<and> rel_tmres osr rvr ares cres"
-  using matching_fragment_matching_tr[where R="\<lambda>_ _. True",
-        OF match _ srx]
-  by (auto simp add: rely_cond_def sr)
+  shows "\<exists>(atr, ares) \<in> f s. matching_tr sr atr ctr \<and> rel_tmres osr rvr ares cres"
+  using matching_fragment_matching_tr[where R="\<lambda>_ _. True", OF match _ srx]
+  by (auto simp: rely_cond_def sr)
 
 theorem prefix_refinement_rely_cond_trD:
   assumes preds: "prefix_refinement sr isr osr rvr P Q R' R aprog cprog"
@@ -285,50 +265,41 @@ lemma rely_cond_True:
   by (simp add: rely_cond_def fun_eq_iff)
 
 section \<open>Compositionality.\<close>
-text \<open>The crucial rules for proving prefix refinement
-of parallel and sequential compositions.\<close>
+text \<open>The crucial rules for proving prefix refinement of parallel and sequential compositions.\<close>
 
 lemma ball_set_zip_conv_nth:
-  "(\<forall>x \<in> set (zip ys zs). P x)
-    = (\<forall>n. n < length ys \<longrightarrow> n < length zs \<longrightarrow> P (ys ! n, zs ! n))"
-  by (auto simp add: Ball_def in_set_zip)
+  "(\<forall>x \<in> set (zip ys zs). P x) = (\<forall>n. n < length ys \<longrightarrow> n < length zs \<longrightarrow> P (ys ! n, zs ! n))"
+  by (auto simp: Ball_def in_set_zip)
 
-definition
-  par_tr_fin_principle :: "('s, unit) tmonad \<Rightarrow> bool"
-where
+definition par_tr_fin_principle :: "('s, unit) tmonad \<Rightarrow> bool" where
   "par_tr_fin_principle f = (\<forall>s tr s'. (tr, Result ((), s')) \<in> f s \<longrightarrow> s' = last_st_tr tr s \<and> tr \<noteq> [])"
 
 lemmas par_tr_fin_principleD = par_tr_fin_principle_def[THEN iffD1, rule_format]
 
 lemma tr_in_parallel:
   "(tr, res) \<in> parallel f g s
-    \<Longrightarrow> \<exists>f_tr g_tr. (f_tr, res) \<in> f s \<and> (g_tr, res) \<in> g s
-        \<and> (tr, res) \<in> parallel (K {(f_tr, res)}) (K {(g_tr, res)}) s"
+   \<Longrightarrow> \<exists>f_tr g_tr. (f_tr, res) \<in> f s \<and> (g_tr, res) \<in> g s
+         \<and> (tr, res) \<in> parallel (K {(f_tr, res)}) (K {(g_tr, res)}) s"
   apply (clarsimp simp: parallel_def)
   apply fastforce
   done
 
 lemma matching_env_closedD:
-  "(tr, res) \<in> f s
-    \<Longrightarrow> is_matching_fragment sr osr rvr ctr cres s0 R s f
-    \<Longrightarrow> length tr < length ctr
-    \<Longrightarrow> fst (rev ctr ! length tr) = Env
-    \<Longrightarrow> sr s' (snd (rev ctr ! length tr))
-    \<Longrightarrow> R (last_st_tr tr s0) s'
-    \<Longrightarrow> (Env, s') # tr \<in> fst ` f s"
+  "\<lbrakk>(tr, res) \<in> f s; is_matching_fragment sr osr rvr ctr cres s0 R s f;
+    length tr < length ctr; fst (rev ctr ! length tr) = Env;
+    sr s' (snd (rev ctr ! length tr)); R (last_st_tr tr s0) s'\<rbrakk>
+   \<Longrightarrow> (Env, s') # tr \<in> fst ` f s"
   apply (frule(1) is_matching_fragment_trD, clarsimp)
   apply (erule(1) env_closedD[OF is_matching_fragment_env_closed])
   apply (clarsimp simp: matching_tr_pfx_aCons rely_cond_Cons_eq prod_eq_iff)
   done
 
 lemma par_tr_fin_fragment:
-  "par_tr_fin_principle f
-    \<Longrightarrow> (tr, res) \<in> f s
-    \<Longrightarrow> is_matching_fragment sr osr rvr ctr cres s0 R s f
-    \<Longrightarrow> res = (case (length ctr - length tr, cres)
-          of (0, Failed) \<Rightarrow> Failed
-           | (0, Result _) \<Rightarrow> Result ((), last_st_tr tr s)
-           | _ \<Rightarrow> Incomplete)"
+  "\<lbrakk>par_tr_fin_principle f; (tr, res) \<in> f s; is_matching_fragment sr osr rvr ctr cres s0 R s f\<rbrakk>
+   \<Longrightarrow> res = (case (length ctr - length tr, cres) of
+                  (0, Failed) \<Rightarrow> Failed
+                | (0, Result _) \<Rightarrow> Result ((), last_st_tr tr s)
+                | _ \<Rightarrow> Incomplete)"
   apply (frule(1) is_matching_fragment_trD)
   apply (cases "length tr < length ctr")
    apply (clarsimp split: nat.split)
@@ -339,15 +310,14 @@ lemma par_tr_fin_fragment:
   done
 
 lemma par_tr_fragment_in_parallel:
-  "par_tr_fin_principle f
-    \<Longrightarrow> par_tr_fin_principle g
-    \<Longrightarrow> is_matching_fragment sr osr rvr ctr1 cres s0 R s f
-    \<Longrightarrow> is_matching_fragment sr osr' rvr ctr2 cres s0 R' s g
-    \<Longrightarrow> length ctr1 = length ctr2
-    \<Longrightarrow> \<exists>f_steps res'. length f_steps = length tr
-        \<and> (map (\<lambda>(f_step, (id, s)). (if f_step then id else Env, s)) (zip f_steps tr), res) \<in> f s
-        \<and> (map (\<lambda>(f_step, (id, s)). (if f_step then Env else id, s)) (zip f_steps tr), res') \<in> g s
-    \<Longrightarrow> (tr, res) \<in> parallel f g s"
+  "\<lbrakk>par_tr_fin_principle f; par_tr_fin_principle g;
+    is_matching_fragment sr osr rvr ctr1 cres s0 R s f;
+    is_matching_fragment sr osr' rvr ctr2 cres s0 R' s g;
+    length ctr1 = length ctr2;
+    \<exists>f_steps res'. length f_steps = length tr
+      \<and> (map (\<lambda>(f_step, (id, s)). (if f_step then id else Env, s)) (zip f_steps tr), res) \<in> f s
+      \<and> (map (\<lambda>(f_step, (id, s)). (if f_step then Env else id, s)) (zip f_steps tr), res') \<in> g s\<rbrakk>
+   \<Longrightarrow> (tr, res) \<in> parallel f g s"
   apply (clarsimp simp: parallel_def)
   apply (rule_tac x=f_steps in exI, clarsimp)
   apply (drule(2) par_tr_fin_fragment)+
@@ -357,75 +327,68 @@ lemma par_tr_fragment_in_parallel:
   done
 
 lemma par_tr_fragment_parallel_def:
-  "par_tr_fin_principle f
-    \<Longrightarrow> par_tr_fin_principle g
-    \<Longrightarrow> is_matching_fragment sr osr rvr ctr1 cres s0 R s f
-    \<Longrightarrow> is_matching_fragment sr osr' rvr ctr2 cres s0 R' s g
-    \<Longrightarrow> length ctr1 = length ctr2
-    \<Longrightarrow> parallel f g s = {(tr, res). \<exists>f_steps res'. length f_steps = length tr
-        \<and> (map (\<lambda>(f_step, (id, s)). (if f_step then id else Env, s)) (zip f_steps tr), res) \<in> f s
-        \<and> (map (\<lambda>(f_step, (id, s)). (if f_step then Env else id, s)) (zip f_steps tr), res') \<in> g s}"
+  "\<lbrakk>par_tr_fin_principle f; par_tr_fin_principle g;
+    is_matching_fragment sr osr rvr ctr1 cres s0 R s f;
+    is_matching_fragment sr osr' rvr ctr2 cres s0 R' s g;
+    length ctr1 = length ctr2\<rbrakk>
+   \<Longrightarrow> parallel f g s = {(tr, res). \<exists>f_steps res'. length f_steps = length tr
+       \<and> (map (\<lambda>(f_step, (id, s)). (if f_step then id else Env, s)) (zip f_steps tr), res) \<in> f s
+       \<and> (map (\<lambda>(f_step, (id, s)). (if f_step then Env else id, s)) (zip f_steps tr), res') \<in> g s}"
   apply (rule equalityI; clarsimp)
    apply (auto simp: parallel_def)[1]
   apply (erule(4) par_tr_fragment_in_parallel)
   apply blast
   done
 
-lemmas list_all2_rev_nthD
-    = list_all2_nthD[OF list_all2_rev[THEN iffD2], simplified]
+lemmas list_all2_rev_nthD = list_all2_nthD[OF list_all2_rev[THEN iffD2], simplified]
 
-definition
-  forward_enabled :: "'s rg_pred \<Rightarrow> bool"
-where
+definition forward_enabled :: "'s rg_pred \<Rightarrow> bool" where
   "forward_enabled P = (\<forall>s_pre. \<exists>s. P s_pre s)"
 
 lemmas forward_enabledD = forward_enabled_def[THEN iffD1, rule_format]
 
 lemma forward_enabled_mono:
-  "P \<le> Q \<Longrightarrow> forward_enabled P \<Longrightarrow> forward_enabled Q"
+  "\<lbrakk>P \<le> Q; forward_enabled P\<rbrakk> \<Longrightarrow> forward_enabled Q"
   by (fastforce simp: forward_enabled_def le_fun_def)
 
 lemma forward_enabled_reflp:
   "reflp P \<Longrightarrow> forward_enabled P"
-  by (auto simp add: reflp_def forward_enabled_def)
+  by (auto simp: reflp_def forward_enabled_def)
 
 lemma par_tr_fin_principle_triv_refinement:
-  "par_tr_fin_principle aprog
-    \<Longrightarrow> triv_refinement aprog cprog
-    \<Longrightarrow> par_tr_fin_principle cprog"
+  "\<lbrakk>par_tr_fin_principle aprog; triv_refinement aprog cprog\<rbrakk>
+   \<Longrightarrow> par_tr_fin_principle cprog"
   by (fastforce simp: par_tr_fin_principle_def triv_refinement_def)
 
 lemma matching_tr_pfx_parallel_zip:
-  "matching_tr_pfx sr a_pfx a_tr
-    \<Longrightarrow> matching_tr_pfx sr b_pfx b_tr
-    \<Longrightarrow> length a_pfx = length b_pfx
-    \<Longrightarrow> list_all2 (\<lambda>y z. (fst y = Env \<or> fst z = Env) \<and> snd y = snd z) a_tr b_tr
-    \<Longrightarrow> matching_tr_pfx sr (map parallel_mrg (zip a_pfx b_pfx)) (map parallel_mrg (zip a_tr b_tr))"
+  "\<lbrakk>matching_tr_pfx sr a_pfx a_tr; matching_tr_pfx sr b_pfx b_tr;
+    length a_pfx = length b_pfx;
+    list_all2 (\<lambda>y z. (fst y = Env \<or> fst z = Env) \<and> snd y = snd z) a_tr b_tr\<rbrakk>
+   \<Longrightarrow> matching_tr_pfx sr (map parallel_mrg (zip a_pfx b_pfx)) (map parallel_mrg (zip a_tr b_tr))"
   apply (clarsimp simp: matching_tr_pfx_def matching_tr_def list_all2_lengthD)
   apply (clarsimp simp: list_all2_conv_all_nth)
   apply (clarsimp simp: rev_map split_def zip_rev[symmetric])
   done
 
 lemma drop_sub_Suc_is_Cons:
-  "n = length xs \<Longrightarrow> m < length xs \<Longrightarrow> drop (n - Suc m) xs = (rev xs ! m) # drop (n - m) xs"
+  "\<lbrakk>n = length xs; m < length xs\<rbrakk> \<Longrightarrow> drop (n - Suc m) xs = (rev xs ! m) # drop (n - m) xs"
   apply (rule nth_equalityI; clarsimp)
-  apply (clarsimp simp add: nth_Cons' rev_nth)
+  apply (clarsimp simp: nth_Cons' rev_nth)
   done
 
 lemma le_sub_eq_0:
   "((x :: nat) \<le> x - y) = (x = 0 \<or> y = 0)"
   by arith
 
-lemmas rely_cond_append_split
-    = rely_cond_append[where xs="take n xs" and ys="drop n xs" for n xs, simplified]
-lemmas guar_cond_append_split
-    = guar_cond_append[where xs="take n xs" and ys="drop n xs" for n xs, simplified]
+lemmas rely_cond_append_split =
+  rely_cond_append[where xs="take n xs" and ys="drop n xs" for n xs, simplified]
+lemmas guar_cond_append_split =
+  guar_cond_append[where xs="take n xs" and ys="drop n xs" for n xs, simplified]
 
 lemma validI_drop_next_G:
-  "\<lbrakk> \<lbrace>P\<rbrace>, \<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>, \<lbrace>Q\<rbrace>; P s0 s; (tr, res) \<in> f s;
-        rely_cond R s0 (drop (n - m) tr); n = length tr; m < length tr \<rbrakk>
-    \<Longrightarrow> fst (rev tr ! m) \<noteq> Env
-        \<longrightarrow> G (last_st_tr (rev (take m (rev tr))) s0) (snd (rev tr ! m))"
+  "\<lbrakk>\<lbrace>P\<rbrace>, \<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>, \<lbrace>Q\<rbrace>; P s0 s; (tr, res) \<in> f s; rely_cond R s0 (drop (n - m) tr);
+    n = length tr; m < length tr\<rbrakk>
+   \<Longrightarrow> fst (rev tr ! m) \<noteq> Env \<longrightarrow> G (last_st_tr (rev (take m (rev tr))) s0) (snd (rev tr ! m))"
   apply clarify
   apply (drule(2) validI_GD_drop[where n="n - Suc m"])
    apply (simp add: drop_sub_Suc_is_Cons)
@@ -446,18 +409,17 @@ lemma tr_in_parallel_validI:
   by (clarsimp simp: rel trs predicate2I)
 
 lemma env_closed_parallel_fragment:
-  "is_matching_fragment sr osr rvr ctr1 cres1 s0 (E or Gg) s f
-    \<Longrightarrow> is_matching_fragment sr osr' rvr ctr2 cres2 s0 (E or Gf) s g
-    \<Longrightarrow> par_tr_fin_principle f
-    \<Longrightarrow> par_tr_fin_principle g
-    \<Longrightarrow> cres1 = cres2 \<Longrightarrow> length ctr1 = length ctr2
-    \<Longrightarrow> \<forall>s xs. Q xs s \<longrightarrow> (sr s (snd (rev ctr1 ! length xs)))
-        \<and> (sr s (snd (rev ctr2 ! length xs)))
-        \<and> length xs < length ctr2
-        \<and> fst (rev ctr1 ! length xs) = Env
-        \<and> fst (rev ctr2 ! length xs) = Env
-        \<and> E (last_st_tr xs s0) s
-    \<Longrightarrow> env_closed Q s (parallel f g)"
+  "\<lbrakk>is_matching_fragment sr osr rvr ctr1 cres1 s0 (E or Gg) s f;
+    is_matching_fragment sr osr' rvr ctr2 cres2 s0 (E or Gf) s g;
+    par_tr_fin_principle f; par_tr_fin_principle g;
+    cres1 = cres2; length ctr1 = length ctr2;
+    \<forall>s xs. Q xs s \<longrightarrow> (sr s (snd (rev ctr1 ! length xs)))
+      \<and> (sr s (snd (rev ctr2 ! length xs)))
+      \<and> length xs < length ctr2
+      \<and> fst (rev ctr1 ! length xs) = Env
+      \<and> fst (rev ctr2 ! length xs) = Env
+      \<and> E (last_st_tr xs s0) s\<rbrakk>
+   \<Longrightarrow> env_closed Q s (parallel f g)"
   apply (subst env_closed_def, clarsimp)
   apply (frule is_matching_fragment_prefix_closed[where f=f])
   apply (frule is_matching_fragment_prefix_closed[where f=g])
@@ -472,10 +434,10 @@ lemma env_closed_parallel_fragment:
   apply (drule spec2, drule(1) mp[where P="Q xs s" for xs s])
   apply clarsimp
   apply (drule_tac s'=s' in env_closedD[where f=f, OF is_matching_fragment_env_closed, rotated];
-    simp?)
+         simp?)
    apply (simp add: matching_tr_pfx_aCons rely_cond_Cons_eq last_st_tr_map_zip prod_eq_iff)
   apply (drule_tac s'=s' in env_closedD[where f=g, OF is_matching_fragment_env_closed, rotated];
-    simp?)
+         simp?)
    apply (simp add: matching_tr_pfx_aCons rely_cond_Cons_eq last_st_tr_map_zip prod_eq_iff)
   apply clarsimp
   apply blast
@@ -484,18 +446,15 @@ lemma env_closed_parallel_fragment:
 lemma self_closed_parallel_fragment:
   notes if_split[split del]
   shows
-  "is_matching_fragment sr osr rvr ctr1 cres1 s0 (E or Gg) s f
-    \<Longrightarrow> is_matching_fragment sr osr' rvr ctr2 cres2 s0 (E or Gf) s g
-    \<Longrightarrow> par_tr_fin_principle f
-    \<Longrightarrow> par_tr_fin_principle g
-    \<Longrightarrow> list_all2 (\<lambda>y z. (fst y = Env \<or> fst z = Env) \<and> snd y = snd z) ctr1 ctr2
-    \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>E or Gg\<rbrace> f \<lbrace>Gf\<rbrace>,\<lbrace>\<lambda>_ _ _. True\<rbrace>
-    \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>E or Gf\<rbrace> g \<lbrace>Gg\<rbrace>,\<lbrace>\<lambda>_ _ _. True\<rbrace>
-    \<Longrightarrow> P s0 s
-    \<Longrightarrow> cres1 = cres2
-    \<Longrightarrow> Q = (\<lambda>xs. length xs < length ctr1 \<and> (fst (rev ctr1 ! length xs) \<noteq> Env
-            \<or> fst (rev ctr2 ! length xs) \<noteq> Env))
-    \<Longrightarrow> self_closed Q s (parallel f g)"
+  "\<lbrakk>is_matching_fragment sr osr rvr ctr1 cres1 s0 (E or Gg) s f;
+    is_matching_fragment sr osr' rvr ctr2 cres2 s0 (E or Gf) s g;
+    par_tr_fin_principle f; par_tr_fin_principle g;
+    list_all2 (\<lambda>y z. (fst y = Env \<or> fst z = Env) \<and> snd y = snd z) ctr1 ctr2;
+    \<lbrace>P\<rbrace>,\<lbrace>E or Gg\<rbrace> f \<lbrace>Gf\<rbrace>,\<lbrace>\<lambda>_ _ _. True\<rbrace>; \<lbrace>P\<rbrace>,\<lbrace>E or Gf\<rbrace> g \<lbrace>Gg\<rbrace>,\<lbrace>\<lambda>_ _ _. True\<rbrace>;
+    P s0 s; cres1 = cres2;
+    Q = (\<lambda>xs. length xs < length ctr1 \<and> (fst (rev ctr1 ! length xs) \<noteq> Env
+              \<or> fst (rev ctr2 ! length xs) \<noteq> Env))\<rbrakk>
+   \<Longrightarrow> self_closed Q s (parallel f g)"
   apply (subst self_closed_def, clarsimp)
   apply (subst(asm) parallel_def, clarsimp)
   apply (frule list_all2_lengthD[symmetric])
@@ -506,7 +465,7 @@ lemma self_closed_parallel_fragment:
   apply (frule(1) list_all2_rev_nthD, clarsimp)
   apply (case_tac "fst (rev ctr1 ! length xs) = Env"; simp)
    apply (frule is_matching_fragment_self_closed[where f=g],
-     drule(1) self_closedD, simp add: eq_Me_neq_Env)
+          drule(1) self_closedD, simp add: eq_Me_neq_Env)
    apply (thin_tac "v \<in> g s" for v s)
    apply clarsimp
    apply (frule(1) is_matching_fragment_trD[where f=g])
@@ -519,7 +478,7 @@ lemma self_closed_parallel_fragment:
    apply (blast intro: in_fst_snd_image)
   (* pretty much identical proof for symmetric case. sad. *)
   apply (frule is_matching_fragment_self_closed[where f=f],
-    drule(1) self_closedD, simp add: eq_Me_neq_Env)
+         drule(1) self_closedD, simp add: eq_Me_neq_Env)
   apply (thin_tac "v \<in> f s" for v s)
   apply clarsimp
   apply (frule(1) is_matching_fragment_trD[where f=f])
@@ -533,10 +492,9 @@ lemma self_closed_parallel_fragment:
   done
 
 lemma is_matching_fragment_validI_disj:
-  "is_matching_fragment sr osr rvr b_tr bd_res s0 R s f
-    \<Longrightarrow> triv_refinement g f
-    \<Longrightarrow> G = \<top>\<top> \<or> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> g \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_ _ _. True\<rbrace>
-    \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_ _ _. True\<rbrace>"
+  "\<lbrakk>is_matching_fragment sr osr rvr b_tr bd_res s0 R s f; triv_refinement g f;
+    G = \<top>\<top> \<or> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> g \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_ _ _. True\<rbrace>\<rbrakk>
+   \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_ _ _. True\<rbrace>"
   apply (frule is_matching_fragment_prefix_closed)
   apply (erule disjE)
    apply (simp add: validI_def guar_cond_def)
@@ -557,9 +515,9 @@ lemma rely_self_closed:
   done
 
 lemma rely_env_closed:
-  "env_closed P s f
-    \<Longrightarrow> (\<forall>xs s. P' xs s \<longrightarrow> rely_cond R s0 xs \<longrightarrow> P xs s \<and> R (last_st_tr xs s0) s)
-    \<Longrightarrow> env_closed P' s (rely f R s0)"
+  "\<lbrakk>env_closed P s f;
+    (\<forall>xs s. P' xs s \<longrightarrow> rely_cond R s0 xs \<longrightarrow> P xs s \<and> R (last_st_tr xs s0) s)\<rbrakk>
+   \<Longrightarrow> env_closed P' s (rely f R s0)"
   apply (subst env_closed_def, clarsimp simp: rely_def)
   apply (drule_tac s'=s' in env_closedD, assumption)
    apply simp
@@ -568,16 +526,13 @@ lemma rely_env_closed:
   done
 
 theorem prefix_refinement_parallel:
-  "prefix_refinement sr isr osr rvr P Q (AE or Gc) (E or Gd) a b
-    \<Longrightarrow> prefix_refinement sr isr osr rvr P Q (AE or Ga) (E or Gb) c d
-    \<Longrightarrow> par_tr_fin_principle a
-    \<Longrightarrow> par_tr_fin_principle c
-    \<Longrightarrow> \<lbrace>Q\<rbrace>,\<lbrace>E or Gd\<rbrace> b \<lbrace>Gb\<rbrace>,\<lbrace>\<lambda>_ _ _. True\<rbrace>
-    \<Longrightarrow> \<lbrace>Q\<rbrace>,\<lbrace>E or Gb\<rbrace> d \<lbrace>Gd\<rbrace>,\<lbrace>\<lambda>_ _ _. True\<rbrace>
-    \<Longrightarrow> (Ga = \<top>\<top> \<and> Gc = \<top>\<top>)
-        \<or> (\<lbrace>P\<rbrace>,\<lbrace>AE or Gc\<rbrace> a \<lbrace>Ga\<rbrace>,\<lbrace>\<lambda>_ _ _. True\<rbrace>
-            \<and> \<lbrace>P\<rbrace>,\<lbrace>AE or Ga\<rbrace> c \<lbrace>Gc\<rbrace>,\<lbrace>\<lambda>_ _ _. True\<rbrace>)
-    \<Longrightarrow> prefix_refinement sr isr osr rvr P Q AE E (parallel a c) (parallel b d)"
+  "\<lbrakk>prefix_refinement sr isr osr rvr P Q (AE or Gc) (E or Gd) a b;
+    prefix_refinement sr isr osr rvr P Q (AE or Ga) (E or Gb) c d;
+    par_tr_fin_principle a; par_tr_fin_principle c;
+    \<lbrace>Q\<rbrace>,\<lbrace>E or Gd\<rbrace> b \<lbrace>Gb\<rbrace>,\<lbrace>\<lambda>_ _ _. True\<rbrace>; \<lbrace>Q\<rbrace>,\<lbrace>E or Gb\<rbrace> d \<lbrace>Gd\<rbrace>,\<lbrace>\<lambda>_ _ _. True\<rbrace>;
+    (Ga = \<top>\<top> \<and> Gc = \<top>\<top>)
+    \<or> (\<lbrace>P\<rbrace>,\<lbrace>AE or Gc\<rbrace> a \<lbrace>Ga\<rbrace>,\<lbrace>\<lambda>_ _ _. True\<rbrace> \<and> \<lbrace>P\<rbrace>,\<lbrace>AE or Ga\<rbrace> c \<lbrace>Gc\<rbrace>,\<lbrace>\<lambda>_ _ _. True\<rbrace>)\<rbrakk>
+   \<Longrightarrow> prefix_refinement sr isr osr rvr P Q AE E (parallel a c) (parallel b d)"
   apply (subst prefix_refinement_def, clarsimp)
   apply (drule tr_in_parallel, clarify)
   apply (frule(6) tr_in_parallel_validI)
@@ -594,9 +549,9 @@ theorem prefix_refinement_parallel:
   apply (frule(1) is_matching_fragment_validI_disj[where g=a and G=Ga], blast)
   apply (frule(1) is_matching_fragment_validI_disj[where g=c and G=Gc], blast)
   apply (intro conjI prefix_closed_parallel prefix_closed_rely rely_self_closed,
-    simp_all add: is_matching_fragment_prefix_closed)
+         simp_all add: is_matching_fragment_prefix_closed)
      apply (rule self_closed_parallel_fragment,
-        (assumption | erule par_tr_fin_principle_triv_refinement[rotated])+)
+            (assumption | erule par_tr_fin_principle_triv_refinement[rotated])+)
       apply simp
      apply (frule list_all2_lengthD)
      apply (simp add: list_all2_lengthD eq_Me_neq_Env rev_nth split_def fun_eq_iff
@@ -604,7 +559,7 @@ theorem prefix_refinement_parallel:
     apply (rule rely_env_closed[where P=P and P'=P for P, rotated])
      apply (simp add: rely_cond_Cons_eq)
     apply (rule env_closed_parallel_fragment,
-        (assumption | erule par_tr_fin_principle_triv_refinement[rotated])+)
+           (assumption | erule par_tr_fin_principle_triv_refinement[rotated])+)
       apply simp
      apply (simp add: list_all2_lengthD)
     apply (clarsimp simp: matching_tr_pfx_aCons rev_map split_def
@@ -630,29 +585,26 @@ lemma validI_triv':
 lemmas validI_triv = validI_triv'[where P="\<top>\<top>"]
 
 lemmas prefix_refinement_parallel_ART
-    = prefix_refinement_parallel[OF _ _ _ _ _ _ disjI1[OF conjI, OF refl refl]]
+  = prefix_refinement_parallel[OF _ _ _ _ _ _ disjI1[OF conjI, OF refl refl]]
 lemmas prefix_refinement_parallel_triv
-    = prefix_refinement_parallel_ART[OF _ _ _ _ validI_triv' validI_triv']
+  = prefix_refinement_parallel_ART[OF _ _ _ _ validI_triv' validI_triv']
 lemmas prefix_refinement_parallel'
-    = prefix_refinement_parallel[OF _ _ _ _ _ _ disjI2[OF conjI]]
+  = prefix_refinement_parallel[OF _ _ _ _ _ _ disjI2[OF conjI]]
 
 lemma pfx_trace_set_allD:
-  "\<forall>n. \<forall>v\<in>set (take n xs). P n v \<Longrightarrow> v \<in> set (take n xs)
-    \<Longrightarrow> P n v"
+  "\<lbrakk>\<forall>n. \<forall>v\<in>set (take n xs). P n v; v \<in> set (take n xs)\<rbrakk> \<Longrightarrow> P n v"
   by simp
 
 lemma prefix_closed_UNION:
-   "(\<forall>s' x. x \<in> S s' \<longrightarrow> prefix_closed (f x))
-    \<Longrightarrow> prefix_closed (\<lambda>s. \<Union>x \<in> S s. f x s)"
+  "\<lbrakk>\<forall>s' x. x \<in> S s' \<longrightarrow> prefix_closed (f x)\<rbrakk> \<Longrightarrow> prefix_closed (\<lambda>s. \<Union>x \<in> S s. f x s)"
   apply (simp add: prefix_closed_def)
   apply (blast intro: in_fst_snd_image)
   done
 
 lemma is_matching_fragment_UNION:
-  "(\<forall>x. x \<in> S s \<longrightarrow> is_matching_fragment sr osr rvr ctr cres s0 R s (f x))
-    \<Longrightarrow> (\<forall>s' x. x \<in> S s' \<longrightarrow> prefix_closed (f x))
-    \<Longrightarrow> S s \<noteq> {}
-    \<Longrightarrow> is_matching_fragment sr osr rvr ctr cres s0 R s (\<lambda>s. \<Union>x \<in> S s. f x s)"
+  "\<lbrakk>\<forall>x. x \<in> S s \<longrightarrow> is_matching_fragment sr osr rvr ctr cres s0 R s (f x);
+    \<forall>s' x. x \<in> S s' \<longrightarrow> prefix_closed (f x); S s \<noteq> {}\<rbrakk>
+   \<Longrightarrow> is_matching_fragment sr osr rvr ctr cres s0 R s (\<lambda>s. \<Union>x \<in> S s. f x s)"
   apply (clarsimp simp: is_matching_fragment_def prefix_closed_UNION)
   apply (intro conjI impI)
    apply (clarsimp simp: self_closed_def split_def in_fst_snd_image_eq)
@@ -661,22 +613,23 @@ lemma is_matching_fragment_UNION:
   apply blast
   done
 
-definition
-  mbind :: "('s, 'a) tmonad \<Rightarrow> ('s \<Rightarrow> 'a \<Rightarrow> ('s, 'b) tmonad) \<Rightarrow>
-           's \<Rightarrow> ('s, 'b) tmonad"
+definition mbind ::
+  "('s, 'a) tmonad \<Rightarrow> ('s \<Rightarrow> 'a \<Rightarrow> ('s, 'b) tmonad) \<Rightarrow> 's \<Rightarrow> ('s, 'b) tmonad"
   where
-  "mbind f g s0 \<equiv> \<lambda>s. \<Union>(xs, r) \<in> (f s). case r of Failed \<Rightarrow> {(xs, Failed)}
-    | Incomplete \<Rightarrow> {(xs, Incomplete)}
-    | Result (rv, s) \<Rightarrow> fst_upd (\<lambda>ys. ys @ xs) ` g (last_st_tr xs s0) rv s"
+  "mbind f g s0 \<equiv> \<lambda>s. \<Union>(xs, r) \<in> (f s).
+     case r of
+         Failed \<Rightarrow> {(xs, Failed)}
+       | Incomplete \<Rightarrow> {(xs, Incomplete)}
+       | Result (rv, s) \<Rightarrow> fst_upd (\<lambda>ys. ys @ xs) ` g (last_st_tr xs s0) rv s"
 
 lemma self_closed_mbind:
-  "is_matching_fragment sr osr rvr ctr cres s0 R s f
-    \<Longrightarrow> (\<forall>tr x s'. (tr, Result (x, s')) \<in> f s
-        \<longrightarrow> self_closed (\<lambda>xs. length xs < length ctr' \<and> fst (rev ctr' ! length xs) = Me) s'
-            (g (last_st_tr tr s0) x) \<and> [] \<in> fst ` g (last_st_tr tr s0) x s')
-    \<Longrightarrow> Q = matching_self_cond (ctr' @ ctr)
-    \<Longrightarrow> cres = Incomplete \<longrightarrow> ctr' = []
-    \<Longrightarrow> self_closed Q s (mbind f g s0)"
+  "\<lbrakk>is_matching_fragment sr osr rvr ctr cres s0 R s f;
+    \<forall>tr x s'. (tr, Result (x, s')) \<in> f s
+      \<longrightarrow> self_closed (\<lambda>xs. length xs < length ctr' \<and> fst (rev ctr' ! length xs) = Me) s'
+                      (g (last_st_tr tr s0) x)
+          \<and> [] \<in> fst ` g (last_st_tr tr s0) x s';
+    Q = matching_self_cond (ctr' @ ctr); cres = Incomplete \<longrightarrow> ctr' = []\<rbrakk>
+   \<Longrightarrow> self_closed Q s (mbind f g s0)"
   apply (frule is_matching_fragment_self_closed)
   apply (subst self_closed_def, clarsimp simp: mbind_def)
   apply (rename_tac tr res)
@@ -706,14 +659,12 @@ lemma matching_tr_pfx_rhs_is_extend:
   fixes ys ys'
   defines "N == length ys' - length ys"
   shows
-  "matching_tr_pfx sr xs ys
-    \<Longrightarrow> length xs \<le> length ys \<longrightarrow> drop N ys' = ys
-    \<Longrightarrow> matching_tr_pfx sr xs ys'"
+    "\<lbrakk>matching_tr_pfx sr xs ys; length xs \<le> length ys \<longrightarrow> drop N ys' = ys\<rbrakk>
+     \<Longrightarrow> matching_tr_pfx sr xs ys'"
   apply (clarsimp simp: matching_tr_pfx_def)
   apply (rule context_conjI)
    apply simp
-  apply (simp add: matching_tr_def list_all2_conv_all_nth
-                   min_def)
+  apply (simp add: matching_tr_def list_all2_conv_all_nth min_def)
   apply (clarsimp simp: rev_nth)
   done
 
@@ -721,24 +672,21 @@ lemma matching_tr_pfx_rhs_is_drop:
   fixes ys ys'
   defines "N == length ys - length ys'"
   shows
-  "matching_tr_pfx sr xs ys
-    \<Longrightarrow> drop N ys = ys'
-    \<Longrightarrow> length xs \<le> length ys'
-    \<Longrightarrow> matching_tr_pfx sr xs ys'"
+    "\<lbrakk>matching_tr_pfx sr xs ys; drop N ys = ys'; length xs \<le> length ys'\<rbrakk>
+     \<Longrightarrow> matching_tr_pfx sr xs ys'"
   apply (clarsimp simp: matching_tr_pfx_def)
-  apply (simp add: matching_tr_def list_all2_conv_all_nth
-                   min_def)
+  apply (simp add: matching_tr_def list_all2_conv_all_nth min_def)
   apply (clarsimp simp: rev_nth)
   done
 
 lemma env_closed_mbind:
-  "is_matching_fragment sr osr rvr ctr' cres s0 R s f
-    \<Longrightarrow> \<forall>tr x s'. (tr, Result (x, s')) \<in> f s
-        \<longrightarrow> env_closed (matching_env_cond sr ctr'' (last_st_tr tr s0) R) s' (g (last_st_tr tr s0) x)
-            \<and> [] \<in> fst ` g (last_st_tr tr s0) x s'
-    \<Longrightarrow> (if cres \<in> {Incomplete, Failed} then ctr = ctr' else ctr = ctr'' @ ctr')
-    \<Longrightarrow> Q = matching_env_cond sr ctr s0 R
-    \<Longrightarrow> env_closed Q s (mbind f g s0)"
+  "\<lbrakk>is_matching_fragment sr osr rvr ctr' cres s0 R s f;
+    \<forall>tr x s'. (tr, Result (x, s')) \<in> f s
+      \<longrightarrow> env_closed (matching_env_cond sr ctr'' (last_st_tr tr s0) R) s' (g (last_st_tr tr s0) x)
+          \<and> [] \<in> fst ` g (last_st_tr tr s0) x s';
+    if cres \<in> {Incomplete, Failed} then ctr = ctr' else ctr = ctr'' @ ctr';
+    Q = matching_env_cond sr ctr s0 R\<rbrakk>
+   \<Longrightarrow> env_closed Q s (mbind f g s0)"
   apply (simp add: if_bool_eq_conj)
   apply (subst env_closed_def, clarsimp simp: mbind_def)
   apply (strengthen in_fst_snd_image, simp)
@@ -773,12 +721,11 @@ lemma env_closed_mbind:
   done
 
 lemma prefix_closed_mbind:
-  "prefix_closed f
-    \<Longrightarrow> \<forall>tr x s' s. (tr, Result (x, s')) \<in> f s \<longrightarrow> prefix_closed (g (last_st_tr tr s0) x)
+  "\<lbrakk>prefix_closed f; \<forall>tr x s' s. (tr, Result (x, s')) \<in> f s \<longrightarrow> prefix_closed (g (last_st_tr tr s0) x)\<rbrakk>
    \<Longrightarrow> prefix_closed (mbind f g s0)"
   apply (subst prefix_closed_def, clarsimp simp: mbind_def)
   apply (split tmres.split_asm; clarsimp;
-        (drule(1) prefix_closedD, fastforce elim: rev_bexI)?)
+         (drule(1) prefix_closedD, fastforce elim: rev_bexI)?)
   apply (simp add: Cons_eq_append_conv, safe)
    apply (drule(1) prefix_closedD)
    apply (fastforce elim: rev_bexI)
@@ -789,26 +736,25 @@ lemma prefix_closed_mbind:
   done
 
 lemma is_matching_fragment_mbind:
-  "is_matching_fragment sr intsr rvr ctr cres s0 R s f_a
-    \<Longrightarrow> \<forall>tr x s'. (tr, Result (x, s')) \<in> f_a s
-        \<longrightarrow> is_matching_fragment sr osr rvr' ctr' cres' (last_st_tr tr s0) R s' (f_b (last_st_tr tr s0) x)
-    \<Longrightarrow> \<forall>s0' x. prefix_closed (f_b s0' x)
-    \<Longrightarrow> ctr'' = ctr' @ ctr
-    \<Longrightarrow> cres'' = (case cres of Failed \<Rightarrow> Failed | Incomplete \<Rightarrow> Incomplete | _ \<Rightarrow> cres')
-    \<Longrightarrow> (cres = Incomplete \<or> cres = Failed) \<longrightarrow> ctr' = []
-    \<Longrightarrow> is_matching_fragment sr osr rvr' ctr'' cres'' s0 R s
-        (mbind f_a f_b s0)"
+  "\<lbrakk>is_matching_fragment sr intsr rvr ctr cres s0 R s f_a;
+    \<forall>tr x s'. (tr, Result (x, s')) \<in> f_a s
+      \<longrightarrow> is_matching_fragment sr osr rvr' ctr' cres' (last_st_tr tr s0) R s' (f_b (last_st_tr tr s0) x);
+    \<forall>s0' x. prefix_closed (f_b s0' x);
+    ctr'' = ctr' @ ctr;
+    cres'' = (case cres of Failed \<Rightarrow> Failed | Incomplete \<Rightarrow> Incomplete | _ \<Rightarrow> cres');
+    (cres = Incomplete \<or> cres = Failed) \<longrightarrow> ctr' = []\<rbrakk>
+   \<Longrightarrow> is_matching_fragment sr osr rvr' ctr'' cres'' s0 R s (mbind f_a f_b s0)"
   apply (subst is_matching_fragment_def, clarsimp)
   apply (strengthen env_closed_mbind[where ctr''=ctr', mk_strg I E]
                     prefix_closed_mbind
                     self_closed_mbind[where ctr'="ctr'", mk_strg I E])
   apply (simp add: conj_comms if_bool_eq_conj mres_def split del: if_split)
   apply (intro conjI allI impI; clarsimp?;
-    (blast intro: is_matching_fragment_prefix_closed
-                  is_matching_fragment_env_closed
-                  is_matching_fragment_Nil
-                  is_matching_fragment_self_closed
-            dest: post_by_hoare)?)
+         (blast intro: is_matching_fragment_prefix_closed
+                       is_matching_fragment_env_closed
+                       is_matching_fragment_Nil
+                       is_matching_fragment_self_closed
+                 dest: post_by_hoare)?)
    apply (clarsimp simp: mbind_def)
    apply (frule_tac s=s in is_matching_fragment_defD)
    apply (drule ex_in_conv[THEN iffD2], clarsimp)
@@ -826,16 +772,18 @@ lemma is_matching_fragment_mbind:
   done
 
 lemma is_matching_fragment_mbind_union:
-  "is_matching_fragment sr intsr rvr ctr cres s0 R s f_a
-    \<Longrightarrow> ctr'' = ctr' @ ctr
-    \<Longrightarrow> cres'' = (case cres of Failed \<Rightarrow> Failed | Incomplete \<Rightarrow> Incomplete | _ \<Rightarrow> cres')
-    \<Longrightarrow> cres = Incomplete \<or> cres = Failed \<longrightarrow> ctr' = []
-    \<Longrightarrow> \<forall>tr x s'. (tr, Result (x, s')) \<in> f_a s
+  "\<lbrakk>is_matching_fragment sr intsr rvr ctr cres s0 R s f_a;
+    ctr'' = ctr' @ ctr;
+    cres'' = (case cres of Failed \<Rightarrow> Failed | Incomplete \<Rightarrow> Incomplete | _ \<Rightarrow> cres');
+    cres = Incomplete \<or> cres = Failed \<longrightarrow> ctr' = [];
+    \<forall>tr x s'. (tr, Result (x, s')) \<in> f_a s
         \<longrightarrow> (\<exists>f. is_matching_fragment sr osr rvr' ctr' cres' (last_st_tr tr s0) R s' f
-                \<and> triv_refinement (aprog x) f)
-    \<Longrightarrow> is_matching_fragment sr osr rvr' ctr'' cres'' s0 R s
-        (mbind f_a (\<lambda>s0' rv s. \<Union>f \<in> {f. is_matching_fragment sr osr rvr' ctr' cres' s0' R s f
-                    \<and> triv_refinement (aprog rv) f}. f s) s0)"
+                \<and> triv_refinement (aprog x) f)\<rbrakk>
+   \<Longrightarrow> is_matching_fragment sr osr rvr' ctr'' cres'' s0 R s
+         (mbind f_a
+            (\<lambda>s0' rv s. \<Union>f \<in> {f. is_matching_fragment sr osr rvr' ctr' cres' s0' R s f
+                                  \<and> triv_refinement (aprog rv) f}. f s)
+            s0)"
   apply (rule is_matching_fragment_mbind; assumption?)
    apply clarsimp
    apply (rule is_matching_fragment_UNION)
@@ -848,9 +796,8 @@ lemma is_matching_fragment_mbind_union:
   done
 
 lemma is_matching_fragment_mresD:
-  "is_matching_fragment sr osr rvr ctr cres s0 R s f
-    \<Longrightarrow> (x, s') \<in> mres (f s)
-    \<Longrightarrow> \<exists>y s''. cres = Result (y, s'') \<and> osr s' s'' \<and> rvr x y"
+  "\<lbrakk>is_matching_fragment sr osr rvr ctr cres s0 R s f; (x, s') \<in> mres (f s)\<rbrakk>
+   \<Longrightarrow> \<exists>y s''. cres = Result (y, s'') \<and> osr s' s'' \<and> rvr x y"
   apply (clarsimp simp: mres_def)
   apply (frule(1) is_matching_fragment_trD)
   apply (clarsimp simp: matching_tr_pfx_def)
@@ -858,28 +805,22 @@ lemma is_matching_fragment_mresD:
   done
 
 lemma matching_tr_pfx_sr_hd_append:
-  "matching_tr_pfx sr tr tr'
-    \<Longrightarrow> sr s0 t0
-    \<Longrightarrow> length tr \<ge> length tr'
-    \<Longrightarrow> sr (hd (map snd tr @ [s0])) (hd (map snd tr' @ [t0]))"
+  "\<lbrakk>matching_tr_pfx sr tr tr'; sr s0 t0; length tr \<ge> length tr'\<rbrakk>
+   \<Longrightarrow> sr (hd (map snd tr @ [s0])) (hd (map snd tr' @ [t0]))"
   apply (clarsimp simp: matching_tr_pfx_def matching_tr_def)
   apply (erule list.rel_cases; clarsimp)
   done
 
 lemma matching_tr_pfx_last_st_tr:
-  "matching_tr_pfx sr tr tr'
-    \<Longrightarrow> sr s0 t0
-    \<Longrightarrow> length tr \<ge> length tr'
-    \<Longrightarrow> sr (last_st_tr tr s0) (last_st_tr tr' t0)"
+  "\<lbrakk>matching_tr_pfx sr tr tr'; sr s0 t0; length tr \<ge> length tr'\<rbrakk>
+   \<Longrightarrow> sr (last_st_tr tr s0) (last_st_tr tr' t0)"
   apply (clarsimp simp: matching_tr_pfx_def matching_tr_def)
   apply (erule list.rel_cases; clarsimp)
   done
 
 lemma validI_relyT_mresD:
-  "\<lbrace>P'\<rbrace>,\<lbrace>\<top>\<top>\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>P''\<rbrace>
-    \<Longrightarrow> (rv, s') \<in> mres (f s)
-    \<Longrightarrow> P' s0 s
-    \<Longrightarrow> \<exists>s0'. P'' rv s0' s'"
+  "\<lbrakk>\<lbrace>P'\<rbrace>,\<lbrace>\<top>\<top>\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>P''\<rbrace>; (rv, s') \<in> mres (f s); P' s0 s\<rbrakk>
+   \<Longrightarrow> \<exists>s0'. P'' rv s0' s'"
   apply (clarsimp simp: mres_def)
   apply (drule(2) validI_rvD)
    apply (simp add: rely_cond_def)
@@ -887,11 +828,11 @@ lemma validI_relyT_mresD:
   done
 
 theorem prefix_refinement_bind_general[rule_format]:
-  "prefix_refinement sr isr intsr rvr P Q AR R a c
-    \<Longrightarrow> (\<forall>x y. rvr x y \<longrightarrow> prefix_refinement sr intsr osr rvr' (P'' x) (Q'' y) AR R (b x) (d y))
-    \<Longrightarrow> \<lbrace>P'\<rbrace>,\<lbrace>AR\<rbrace> a \<lbrace>\<top>\<top>\<rbrace>,\<lbrace>P''\<rbrace> \<or> \<lbrace>\<lambda>s. \<exists>s0. P' s0 s\<rbrace> a \<lbrace>\<lambda>rv s. \<forall>s0. P'' rv s0 s\<rbrace>
-    \<Longrightarrow> \<lbrace>Q'\<rbrace>,\<lbrace>R\<rbrace> c \<lbrace>\<top>\<top>\<rbrace>,\<lbrace>Q''\<rbrace>
-    \<Longrightarrow> prefix_refinement sr isr osr rvr' (P and P') (Q and Q') AR R (a >>= b) (c >>= d)"
+  "\<lbrakk>prefix_refinement sr isr intsr rvr P Q AR R a c;
+    \<forall>x y. rvr x y \<longrightarrow> prefix_refinement sr intsr osr rvr' (P'' x) (Q'' y) AR R (b x) (d y);
+    \<lbrace>P'\<rbrace>,\<lbrace>AR\<rbrace> a \<lbrace>\<top>\<top>\<rbrace>,\<lbrace>P''\<rbrace> \<or> \<lbrace>\<lambda>s. \<exists>s0. P' s0 s\<rbrace> a \<lbrace>\<lambda>rv s. \<forall>s0. P'' rv s0 s\<rbrace>;
+    \<lbrace>Q'\<rbrace>,\<lbrace>R\<rbrace> c \<lbrace>\<top>\<top>\<rbrace>,\<lbrace>Q''\<rbrace>\<rbrakk>
+   \<Longrightarrow> prefix_refinement sr isr osr rvr' (P and P') (Q and Q') AR R (a >>= b) (c >>= d)"
   apply (subst prefix_refinement_def, clarsimp simp: bind_def)
   apply (rename_tac c_tr c_res cd_tr cd_res)
   apply (drule(5) prefix_refinementD, simp)
@@ -902,7 +843,8 @@ theorem prefix_refinement_bind_general[rule_format]:
   apply (case_tac "c_res = Incomplete \<or> c_res = Failed")
    apply (intro exI conjI)
     apply (rule_tac ctr'=Nil and cres'=Failed and f_b="\<lambda>_ _ _. {}"
-        in is_matching_fragment_mbind, assumption, simp_all add: prefix_closed_def)[1]
+             in is_matching_fragment_mbind,
+           assumption, simp_all add: prefix_closed_def)[1]
       apply clarsimp
       apply (frule is_matching_fragment_mresD, erule in_mres)
       apply clarsimp
@@ -915,20 +857,20 @@ theorem prefix_refinement_bind_general[rule_format]:
   apply (frule(2) validI_rvD, simp add: rely_cond_append)
   apply (intro exI conjI)
    apply (rule is_matching_fragment_mbind_union[where aprog="b"],
-      assumption, simp_all)[1]
+          assumption, simp_all)[1]
    apply clarsimp
    apply (frule is_matching_fragment_mresD, erule in_mres)
    apply (clarsimp simp: mres_def)
    apply (frule(1) is_matching_fragment_trD)
    apply clarsimp
    apply (rule prefix_refinementD[where x="(a, b)" for a b, simplified, rule_format],
-      blast, simp_all)[1]
+          blast, simp_all)[1]
      prefer 2
      apply (erule(1) matching_tr_pfx_last_st_tr)
      apply simp
     apply (erule disjE)
      apply (drule(1) validI_rvD[OF validI_triv_refinement],
-         erule is_matching_fragment_prefix_closed, assumption+)
+            erule is_matching_fragment_prefix_closed, assumption+)
     apply (drule(2) use_valid[OF in_mres valid_triv_refinement], blast, simp)
    apply (clarsimp simp: rely_cond_append hd_append hd_map cong: if_cong)
   apply (clarsimp simp: triv_refinement_def mbind_def)
@@ -940,22 +882,21 @@ theorem prefix_refinement_bind_general[rule_format]:
 
 section \<open>Using prefix refinement.\<close>
 text \<open>
-Using prefix refinement to map the validI Hoare quadruple
-(precond/rely/guarantee/postcond). Proofs of quadruples for
-abstract programs imply related quadruples for concrete
-programs.
-\<close>
+  Using prefix refinement to map the validI Hoare quadruple
+  (precond/rely/guarantee/postcond). Proofs of quadruples for
+  abstract programs imply related quadruples for concrete
+  programs.\<close>
 
 lemma list_all2_all_trace_steps:
   assumes P: "\<forall>x\<in>trace_steps (rev tr) s0. P x"
   and lR': "list_all2 (\<lambda>(aid, as) (cid, cs). aid = cid \<and> R' as cs) tr' tr"
   and R': "R' s0' s0"
   and Q: "\<forall>idn as1 as2 cs1 cs2. R' as1 cs1 \<longrightarrow> R' as2 cs2
-    \<longrightarrow> P (idn, cs1, cs2) \<longrightarrow> Q (idn, as1, as2)"
+            \<longrightarrow> P (idn, cs1, cs2) \<longrightarrow> Q (idn, as1, as2)"
   shows "\<forall>x\<in>trace_steps (rev tr') s0'. Q x"
 proof -
   note lR'' = lR'[simplified trans[OF list_all2_rev[symmetric] list_all2_conv_all_nth],
-    simplified split_def, THEN conjunct2, rule_format]
+                  simplified split_def, THEN conjunct2, rule_format]
   note len[simp] = lR'[THEN list_all2_lengthD]
   show ?thesis
     using P R'
@@ -968,18 +909,18 @@ proof -
 qed
 
 theorem prefix_refinement_validI:
-  "prefix_refinement sr isr osr rvr prP' prP R' R f g
-    \<Longrightarrow> \<lbrace>P'\<rbrace>,\<lbrace>R'\<rbrace>
-        f \<lbrace>\<lambda>s0 s. \<forall>cs0 cs. sr s0 cs0 \<and> sr s cs \<longrightarrow> G cs0 cs\<rbrace>,\<lbrace>\<lambda>rv
-                s0 s. \<forall>rv' cs0 cs. sr s0 cs0 \<and> osr s cs \<and> rvr rv rv' \<longrightarrow> Q rv' cs0 cs\<rbrace>
-    \<Longrightarrow> \<forall>t0 t. P t0 t \<longrightarrow> (\<exists>s0 s. P' s0 s \<and> prP' s0 s \<and> prP t0 t \<and> isr s t \<and> sr s0 t0)
-    \<Longrightarrow> \<forall>s0 t0 t. sr s0 t0 \<and> R t0 t \<longrightarrow> (\<exists>s. R' s0 s \<and> sr s t)
-    \<Longrightarrow> prefix_closed g
+  "\<lbrakk>prefix_refinement sr isr osr rvr prP' prP R' R f g;
+    \<lbrace>P'\<rbrace>,\<lbrace>R'\<rbrace>
+    f
+    \<lbrace>\<lambda>s0 s. \<forall>cs0 cs. sr s0 cs0 \<and> sr s cs \<longrightarrow> G cs0 cs\<rbrace>,
+    \<lbrace>\<lambda>rv s0 s. \<forall>rv' cs0 cs. sr s0 cs0 \<and> osr s cs \<and> rvr rv rv' \<longrightarrow> Q rv' cs0 cs\<rbrace>;
+    \<forall>t0 t. P t0 t \<longrightarrow> (\<exists>s0 s. P' s0 s \<and> prP' s0 s \<and> prP t0 t \<and> isr s t \<and> sr s0 t0);
+    \<forall>s0 t0 t. sr s0 t0 \<and> R t0 t \<longrightarrow> (\<exists>s. R' s0 s \<and> sr s t); prefix_closed g\<rbrakk>
     \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> g \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
   apply (subst validI_def, clarsimp simp: rely_def)
   apply (drule spec2, drule(1) mp, clarsimp)
   apply (drule(6) prefix_refinement_rely_cond_trD[where R'=R', simplified])
-    apply blast
+   apply blast
   apply clarsimp
   apply (rule conjI)
    apply (frule(3) validI_GD)
@@ -998,30 +939,27 @@ theorem prefix_refinement_validI:
 lemmas prefix_refinement_validI' = prefix_refinement_validI[OF _ rg_strengthen_guar, OF _ rg_strengthen_post]
 
 section \<open>Building blocks.\<close>
-text \<open>
-Prefix refinement rules for various basic constructs.
-\<close>
+text \<open>Prefix refinement rules for various basic constructs.\<close>
 
 lemma prefix_refinement_weaken_pre:
-  "prefix_refinement sr isr osr rvr P' Q' AR R f g
-    \<Longrightarrow> \<forall>s s0. P s0 s \<longrightarrow> P' s0 s
-    \<Longrightarrow> (\<forall>s t s0 t0. isr s t \<longrightarrow> sr s0 t0 \<longrightarrow> P s0 s \<longrightarrow> Q t0 t \<longrightarrow> Q' t0 t)
-    \<Longrightarrow> prefix_refinement sr isr osr rvr P Q AR R f g"
+  "\<lbrakk>prefix_refinement sr isr osr rvr P' Q' AR R f g; \<forall>s s0. P s0 s \<longrightarrow> P' s0 s;
+    \<forall>s t s0 t0. isr s t \<longrightarrow> sr s0 t0 \<longrightarrow> P s0 s \<longrightarrow> Q t0 t \<longrightarrow> Q' t0 t\<rbrakk>
+   \<Longrightarrow> prefix_refinement sr isr osr rvr P Q AR R f g"
  by (fastforce simp: prefix_refinement_def)
 
 lemma prefix_refinement_name_pre:
-  "(\<And>s s0 t t0. isr s t \<Longrightarrow> sr s0 t0 \<Longrightarrow> P s0 s \<Longrightarrow> Q t0 t
-    \<Longrightarrow> prefix_refinement sr isr osr rvr (\<lambda>s0' s'. s0' = s0 \<and> s' = s) (\<lambda>t0' t'. t0' = t0 \<and> t' = t) AR R f g)
-    \<Longrightarrow> prefix_refinement sr isr osr rvr P Q AR R f g"
+  "\<lbrakk>\<And>s s0 t t0. \<lbrakk>isr s t; sr s0 t0; P s0 s; Q t0 t\<rbrakk>
+    \<Longrightarrow> prefix_refinement sr isr osr rvr (\<lambda>s0' s'. s0' = s0 \<and> s' = s) (\<lambda>t0' t'. t0' = t0 \<and> t' = t) AR R f g\<rbrakk>
+   \<Longrightarrow> prefix_refinement sr isr osr rvr P Q AR R f g"
   by (fastforce simp: prefix_refinement_def)
 
 lemma prefix_refinement_bind_v[rule_format]:
-  "prefix_refinement sr isr intsr rvr P Q AR R a c
-    \<Longrightarrow> (\<forall>x y. rvr x y \<longrightarrow> prefix_refinement sr intsr osr rvr' (\<lambda>s0. P'' x) (Q'' y) AR R (b x) (d y))
-    \<Longrightarrow> \<lbrace>P'\<rbrace> a \<lbrace>P''\<rbrace> \<Longrightarrow> \<lbrace>Q'\<rbrace>,\<lbrace>R\<rbrace> c \<lbrace>\<top>\<top>\<rbrace>,\<lbrace>Q''\<rbrace>
-    \<Longrightarrow> prefix_refinement sr isr osr rvr' (\<lambda>s0. P s0 and P') (Q and Q') AR R (a >>= b) (c >>= d)"
+  "\<lbrakk>prefix_refinement sr isr intsr rvr P Q AR R a c;
+    \<forall>x y. rvr x y \<longrightarrow> prefix_refinement sr intsr osr rvr' (\<lambda>s0. P'' x) (Q'' y) AR R (b x) (d y);
+    \<lbrace>P'\<rbrace> a \<lbrace>P''\<rbrace>; \<lbrace>Q'\<rbrace>,\<lbrace>R\<rbrace> c \<lbrace>\<top>\<top>\<rbrace>,\<lbrace>Q''\<rbrace>\<rbrakk>
+   \<Longrightarrow> prefix_refinement sr isr osr rvr' (\<lambda>s0. P s0 and P') (Q and Q') AR R (a >>= b) (c >>= d)"
   apply (rule prefix_refinement_weaken_pre,
-    rule prefix_refinement_bind_general[where P'="\<lambda>_. P'"])
+         rule prefix_refinement_bind_general[where P'="\<lambda>_. P'"])
        apply assumption
       apply (elim allE, erule(1) mp)
      apply (rule disjI2)
@@ -1031,51 +969,47 @@ lemma prefix_refinement_bind_v[rule_format]:
   apply clarsimp
   done
 
-lemmas prefix_refinement_bind
-    = prefix_refinement_bind_general[OF _ _ disjI1]
+lemmas prefix_refinement_bind = prefix_refinement_bind_general[OF _ _ disjI1]
 
 lemma default_prefix_refinement_ex:
   "is_matching_fragment sr osr rvr ctr cres s0 R s
-            (\<lambda>s. aprog s \<inter> ({tr'. length tr' \<le> length ctr} \<times> UNIV))
-    \<Longrightarrow> \<exists>f. is_matching_fragment sr osr rvr ctr cres s0 R s f
-            \<and> triv_refinement aprog f"
+     (\<lambda>s. aprog s \<inter> ({tr'. length tr' \<le> length ctr} \<times> UNIV))
+   \<Longrightarrow> \<exists>f. is_matching_fragment sr osr rvr ctr cres s0 R s f \<and> triv_refinement aprog f"
   apply (intro exI conjI, assumption)
   apply (simp add: triv_refinement_def)
   done
 
 lemma default_prefix_refinement_ex_match_iosr_R:
   "is_matching_fragment sr osr rvr ctr cres s0 R s
-            (rely (\<lambda>s. aprog s \<inter> ({tr'. matching_tr_pfx iosr tr' ctr} \<times> UNIV)) R s0)
-    \<Longrightarrow> \<exists>f. is_matching_fragment sr osr rvr ctr cres s0 R s f
-            \<and> triv_refinement aprog f"
+     (rely (\<lambda>s. aprog s \<inter> ({tr'. matching_tr_pfx iosr tr' ctr} \<times> UNIV)) R s0)
+   \<Longrightarrow> \<exists>f. is_matching_fragment sr osr rvr ctr cres s0 R s f \<and> triv_refinement aprog f"
   apply (intro exI conjI, assumption)
   apply (clarsimp simp add: triv_refinement_def rely_def)
   done
 
 lemma is_matching_fragment_no_trace:
   "is_matching_fragment sr osr rvr [] cres s0 R s (\<lambda>s. {([], ares s)})
-    = rel_tmres osr rvr (ares s) cres"
+   = rel_tmres osr rvr (ares s) cres"
   by (simp add: is_matching_fragment_def prefix_closed_def
                 self_closed_def env_closed_def
                 matching_tr_pfx_def matching_tr_def)
 
 lemma prefix_refinement_return_imp:
-  "(\<forall>s s0 t0 t. P s0 s \<and> Q t0 t \<and> isr s t \<longrightarrow> rvr rv rv' \<and> osr s t)
-    \<Longrightarrow> prefix_refinement sr isr osr rvr P Q AR R (return rv) (return rv')"
+  "\<lbrakk>\<forall>s s0 t0 t. P s0 s \<and> Q t0 t \<and> isr s t \<longrightarrow> rvr rv rv' \<and> osr s t\<rbrakk>
+   \<Longrightarrow> prefix_refinement sr isr osr rvr P Q AR R (return rv) (return rv')"
   apply (clarsimp simp: prefix_refinement_def)
   apply (rule default_prefix_refinement_ex)
   apply (auto simp add: return_def is_matching_fragment_no_trace)
   done
 
-abbreviation(input)
+abbreviation (input)
   "dc2 \<equiv> (\<lambda>_ _. True)"
 
 abbreviation
   "pfx_refnT sr rvr \<equiv> pfx_refn sr rvr (\<lambda>_ _. True) dc2"
 
 lemma pfx_refn_return:
-  "rvr rv rv'
-    \<Longrightarrow> pfx_refnT sr rvr AR R (return rv) (return rv')"
+  "rvr rv rv' \<Longrightarrow> pfx_refnT sr rvr AR R (return rv) (return rv')"
   by (rule prefix_refinement_return_imp, simp)
 
 lemma prefix_refinement_get:
@@ -1093,8 +1027,8 @@ lemma prefix_refinement_put:
   done
 
 lemma prefix_refinement_select:
-  "(\<forall>x \<in> T. \<exists>y \<in> S. rvr y x)
-    \<Longrightarrow> prefix_refinement sr iosr iosr rvr dc2 dc2 AR R (select S) (select T)"
+  "\<lbrakk>\<forall>x \<in> T. \<exists>y \<in> S. rvr y x\<rbrakk>
+   \<Longrightarrow> prefix_refinement sr iosr iosr rvr dc2 dc2 AR R (select S) (select T)"
   apply (clarsimp simp: prefix_refinement_def select_def)
   apply (drule(1) bspec, clarsimp)
   apply (rule_tac x="return y" in exI)
@@ -1107,32 +1041,25 @@ lemma Int_insert_left2:
   "(insert a B \<inter> C) = ((if a \<in> C then {a} else {}) \<union> (B \<inter> C))"
   by auto
 
-definition
-  rely_stable :: "('t \<Rightarrow> 't \<Rightarrow> bool) \<Rightarrow> ('s \<Rightarrow> 't \<Rightarrow> bool) \<Rightarrow> ('t \<Rightarrow> bool) \<Rightarrow> bool"
-where
+definition rely_stable :: "('t \<Rightarrow> 't \<Rightarrow> bool) \<Rightarrow> ('s \<Rightarrow> 't \<Rightarrow> bool) \<Rightarrow> ('t \<Rightarrow> bool) \<Rightarrow> bool" where
   "rely_stable R sr Q = (\<forall>s t t'. Q t \<and> sr s t \<and> R t t' \<longrightarrow> Q t' \<and> (\<exists>s'. sr s' t'))"
 
 lemmas rely_stableD = rely_stable_def[THEN iffD1, simplified imp_conjL, rule_format]
 
-definition
-  env_rely_stable_iosr :: "'s rg_pred \<Rightarrow> 't rg_pred
-    \<Rightarrow> ('s \<Rightarrow> 't \<Rightarrow> bool) \<Rightarrow> ('s \<Rightarrow> 't \<Rightarrow> bool) \<Rightarrow> ('t \<Rightarrow> bool) \<Rightarrow> bool"
-where
-  "env_rely_stable_iosr AR R sr iosr Q
-    = (\<forall>s0 t0 s t. Q t0 \<longrightarrow> iosr s0 t0 \<longrightarrow> R t0 t \<longrightarrow> AR s0 s \<longrightarrow> sr s t \<longrightarrow> iosr s t)"
+definition env_rely_stable_iosr ::
+  "'s rg_pred \<Rightarrow> 't rg_pred \<Rightarrow> ('s \<Rightarrow> 't \<Rightarrow> bool) \<Rightarrow> ('s \<Rightarrow> 't \<Rightarrow> bool) \<Rightarrow> ('t \<Rightarrow> bool) \<Rightarrow> bool"
+  where
+  "env_rely_stable_iosr AR R sr iosr Q =
+     (\<forall>s0 t0 s t. Q t0 \<longrightarrow> iosr s0 t0 \<longrightarrow> R t0 t \<longrightarrow> AR s0 s \<longrightarrow> sr s t \<longrightarrow> iosr s t)"
 
 lemmas env_rely_stable_iosrD = env_rely_stable_iosr_def[THEN iffD1, rule_format]
 
-definition
-  env_stable :: "'s rg_pred \<Rightarrow> 't rg_pred
-    \<Rightarrow> ('s \<Rightarrow> 't \<Rightarrow> bool) \<Rightarrow> ('s \<Rightarrow> 't \<Rightarrow> bool) \<Rightarrow> ('t \<Rightarrow> bool) \<Rightarrow> bool"
-where
-  "env_stable AR R sr iosr Q = (rely_stable R sr Q
-    \<and> env_rely_stable_iosr AR R sr iosr Q \<and> iosr \<le> sr)"
+definition env_stable ::
+  "'s rg_pred \<Rightarrow> 't rg_pred \<Rightarrow> ('s \<Rightarrow> 't \<Rightarrow> bool) \<Rightarrow> ('s \<Rightarrow> 't \<Rightarrow> bool) \<Rightarrow> ('t \<Rightarrow> bool) \<Rightarrow> bool"
+  where
+  "env_stable AR R sr iosr Q = (rely_stable R sr Q \<and> env_rely_stable_iosr AR R sr iosr Q \<and> iosr \<le> sr)"
 
-definition
-  abs_rely_stable :: "('s \<Rightarrow> 's \<Rightarrow> bool) \<Rightarrow> ('s \<Rightarrow> bool) \<Rightarrow> bool"
-where
+definition abs_rely_stable :: "('s \<Rightarrow> 's \<Rightarrow> bool) \<Rightarrow> ('s \<Rightarrow> bool) \<Rightarrow> bool" where
   "abs_rely_stable R P = (\<forall>s s'. P s \<and> R s s' \<longrightarrow> P s')"
 
 lemmas abs_rely_stableD = abs_rely_stable_def[THEN iffD1, simplified imp_conjL, rule_format]
@@ -1142,10 +1069,7 @@ lemma abs_rely_stableT:
   by (simp add: abs_rely_stable_def)
 
 lemma rely_stable_rtranclp:
-  "rely_stable R sr Q
-    \<Longrightarrow> sr s t \<Longrightarrow> Q t
-    \<Longrightarrow> rtranclp R t t'
-    \<Longrightarrow> Q t'"
+  "\<lbrakk>rely_stable R sr Q; sr s t; Q t; rtranclp R t t'\<rbrakk> \<Longrightarrow> Q t'"
   apply (rotate_tac 3, induct arbitrary: s rule: converse_rtranclp_induct)
    apply simp
   apply (clarsimp simp: rely_stable_def)
@@ -1153,9 +1077,7 @@ lemma rely_stable_rtranclp:
   done
 
 lemma abs_rely_stable_rtranclp:
-  "abs_rely_stable R P
-    \<Longrightarrow> P s \<Longrightarrow> rtranclp R s s'
-    \<Longrightarrow> P s'"
+  "\<lbrakk>abs_rely_stable R P; P s; rtranclp R s s'\<rbrakk> \<Longrightarrow> P s'"
   apply (rotate_tac 2, induct rule: converse_rtranclp_induct)
    apply simp
   apply (clarsimp simp: abs_rely_stable_def)
@@ -1164,7 +1086,7 @@ lemma abs_rely_stable_rtranclp:
 lemma prefix_refinement_env_step:
   assumes env_stable: "env_stable AR R sr iosr Q"
   shows "prefix_refinement sr iosr iosr dc2 (\<lambda>s0 s. s0 = s) (\<lambda>t0 t. t0 = t \<and> Q t0)
-    AR R env_step env_step"
+           AR R env_step env_step"
 proof -
   have P: "\<And>S. {xs. length xs = Suc 0} = (\<lambda>x. [x]) ` UNIV"
     apply (safe, simp_all)
@@ -1186,9 +1108,9 @@ proof -
     apply (simp only: UN_extend_simps Int_insert_left2)
     apply (simp add: is_matching_fragment_def UN_If_distrib)
     apply (intro conjI allI impI;
-        simp add: prefix_closed_def in_fst_snd_image_eq self_closed_def
-                  matching_tr_pfx_def matching_tr_def
-                  env_closed_def)
+           simp add: prefix_closed_def in_fst_snd_image_eq self_closed_def
+                     matching_tr_pfx_def matching_tr_def
+                     env_closed_def)
      apply (metis env_rely_stable_iosrD[OF est])
     apply clarsimp
     apply (auto dest: rely_stableD[OF st] predicate2D[OF sr])[1]
@@ -1196,10 +1118,9 @@ proof -
 qed
 
 lemma prefix_refinement_repeat_n:
-  "prefix_refinement sr iosr iosr (\<lambda>_ _. True) P Q AR R f g
-    \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>AR\<rbrace> f \<lbrace>\<top>\<top>\<rbrace>,\<lbrace>\<lambda>_. P\<rbrace>
-    \<Longrightarrow> \<lbrace>\<lambda>t0 t. Q t0 t \<and> (\<exists>s0 s. sr s0 t0 \<and> iosr s t)\<rbrace>,\<lbrace>R\<rbrace> g \<lbrace>\<top>\<top>\<rbrace>,\<lbrace>\<lambda>_. Q\<rbrace>
-    \<Longrightarrow> prefix_refinement sr iosr iosr (\<lambda>_ _. True) P Q AR R (repeat_n n f) (repeat_n n g)"
+  "\<lbrakk>prefix_refinement sr iosr iosr (\<lambda>_ _. True) P Q AR R f g; \<lbrace>P\<rbrace>,\<lbrace>AR\<rbrace> f \<lbrace>\<top>\<top>\<rbrace>,\<lbrace>\<lambda>_. P\<rbrace>;
+    \<lbrace>\<lambda>t0 t. Q t0 t \<and> (\<exists>s0 s. sr s0 t0 \<and> iosr s t)\<rbrace>,\<lbrace>R\<rbrace> g \<lbrace>\<top>\<top>\<rbrace>,\<lbrace>\<lambda>_. Q\<rbrace>\<rbrakk>
+   \<Longrightarrow> prefix_refinement sr iosr iosr (\<lambda>_ _. True) P Q AR R (repeat_n n f) (repeat_n n g)"
   apply (induct n)
    apply (simp add: prefix_refinement_return_imp)
   apply (rule prefix_refinement_weaken_pre)
@@ -1212,7 +1133,7 @@ lemma prefix_refinement_repeat_n:
 lemma prefix_refinement_env_n_steps:
   assumes env_stable: "env_stable AR R sr iosr Q"
   shows "prefix_refinement sr iosr iosr (\<lambda>_ _. True)
-        (=) (\<lambda>t0 t. t0 = t \<and> Q t0) AR R (env_n_steps n) (env_n_steps n)"
+           (=) (\<lambda>t0 t. t0 = t \<and> Q t0) AR R (env_n_steps n) (env_n_steps n)"
   apply (rule prefix_refinement_repeat_n)
     apply (rule prefix_refinement_env_step[OF env_stable])
    apply (simp add: env_step_def)
@@ -1229,10 +1150,9 @@ lemma prefix_refinement_env_n_steps:
   done
 
 lemma prefix_refinement_repeat:
-  "prefix_refinement sr iosr iosr (\<lambda>_ _. True) P Q AR R f g
-    \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>AR\<rbrace> f \<lbrace>\<top>\<top>\<rbrace>,\<lbrace>\<lambda>_. P\<rbrace>
-    \<Longrightarrow> \<lbrace>\<lambda>t0 t. Q t0 t \<and> (\<exists>s0 s. sr s0 t0 \<and> iosr s t)\<rbrace>,\<lbrace>R\<rbrace> g \<lbrace>\<top>\<top>\<rbrace>,\<lbrace>\<lambda>_. Q\<rbrace>
-    \<Longrightarrow> prefix_refinement sr iosr iosr (\<lambda>_ _. True) P Q AR R (repeat f) (repeat g)"
+  "\<lbrakk>prefix_refinement sr iosr iosr (\<lambda>_ _. True) P Q AR R f g; \<lbrace>P\<rbrace>,\<lbrace>AR\<rbrace> f \<lbrace>\<top>\<top>\<rbrace>,\<lbrace>\<lambda>_. P\<rbrace>;
+    \<lbrace>\<lambda>t0 t. Q t0 t \<and> (\<exists>s0 s. sr s0 t0 \<and> iosr s t)\<rbrace>,\<lbrace>R\<rbrace> g \<lbrace>\<top>\<top>\<rbrace>,\<lbrace>\<lambda>_. Q\<rbrace>\<rbrakk>
+   \<Longrightarrow> prefix_refinement sr iosr iosr (\<lambda>_ _. True) P Q AR R (repeat f) (repeat g)"
   apply (simp add: repeat_def)
   apply (rule prefix_refinement_weaken_pre)
     apply (rule prefix_refinement_bind, rule prefix_refinement_select[where rvr="(=)"])
@@ -1248,8 +1168,7 @@ lemma prefix_refinement_repeat:
 
 lemma prefix_refinement_env_steps:
   "env_stable AR R sr iosr Q
-    \<Longrightarrow> prefix_refinement sr iosr iosr (\<lambda>_ _. True)
-        (=) (\<lambda>t0 t. t0 = t \<and> Q t0) AR R env_steps env_steps"
+   \<Longrightarrow> prefix_refinement sr iosr iosr (\<lambda>_ _. True) (=) (\<lambda>t0 t. t0 = t \<and> Q t0) AR R env_steps env_steps"
   apply (simp add: env_steps_repeat)
   apply (rule prefix_refinement_repeat)
     apply (erule prefix_refinement_env_step)
@@ -1266,7 +1185,7 @@ lemma prefix_refinement_env_steps:
 
 lemma prefix_refinement_commit_step:
   "\<forall>s t. isr s t \<longrightarrow> sr s t \<and> osr s t
-    \<Longrightarrow> prefix_refinement sr isr osr (\<lambda>_ _. True) (\<top>\<top>) (\<top>\<top>) AR R commit_step commit_step"
+   \<Longrightarrow> prefix_refinement sr isr osr (\<lambda>_ _. True) (\<top>\<top>) (\<top>\<top>) AR R commit_step commit_step"
   apply (clarsimp simp: prefix_refinement_def)
   apply (rule default_prefix_refinement_ex)
   apply (simp add: commit_step_def bind_def get_def return_def put_trace_elem_def)
@@ -1278,9 +1197,8 @@ lemma prefix_refinement_commit_step:
   done
 
 lemma prefix_refinement_weaken_srs:
-  "prefix_refinement sr isr osr r P Q AR R f g
-    \<Longrightarrow> isr' \<le> isr \<Longrightarrow> osr \<le> osr' \<Longrightarrow> sr \<le> sr
-    \<Longrightarrow> prefix_refinement sr isr' osr' r P Q AR R f g"
+  "\<lbrakk>prefix_refinement sr isr osr r P Q AR R f g; isr' \<le> isr; osr \<le> osr'; sr \<le> sr\<rbrakk>
+   \<Longrightarrow> prefix_refinement sr isr' osr' r P Q AR R f g"
   apply (subst prefix_refinement_def, clarsimp)
   apply (drule(1) predicate2D)
   apply (drule(5) prefix_refinementD)
@@ -1294,7 +1212,7 @@ lemma prefix_refinement_weaken_srs:
 
 lemma prefix_refinement_interference:
   "env_stable AR R sr iosr Q
-    \<Longrightarrow> prefix_refinement sr iosr iosr (\<lambda>_ _. True) \<top>\<top> (\<lambda>t0 t. Q t) AR R interference interference"
+   \<Longrightarrow> prefix_refinement sr iosr iosr (\<lambda>_ _. True) \<top>\<top> (\<lambda>t0 t. Q t) AR R interference interference"
   apply (simp add: interference_def)
   apply (rule prefix_refinement_weaken_pre)
     apply (rule prefix_refinement_bind[where intsr=iosr])
@@ -1313,26 +1231,24 @@ lemma mapM_x_Cons:
   "mapM_x f (x # xs) = do f x; mapM_x f xs od"
   by (simp add: mapM_x_def sequence_x_def)
 
-lemmas prefix_refinement_bind_sr = prefix_refinement_bind[where sr=sr
-    and intsr=sr for sr]
-lemmas prefix_refinement_bind_isr = prefix_refinement_bind[where isr=isr
-    and intsr=isr for isr]
-lemmas pfx_refn_bind = prefix_refinement_bind_v[where sr=sr
-    and isr=sr and osr=sr and intsr=sr for sr]
-lemmas pfx_refn_bindT
-    = pfx_refn_bind[where P'="\<top>" and Q'="\<lambda>_ _. True", OF _ _ hoare_post_taut validI_triv,
-        simplified pred_conj_def, simplified]
+lemmas prefix_refinement_bind_sr = prefix_refinement_bind[where sr=sr and intsr=sr for sr]
+lemmas prefix_refinement_bind_isr = prefix_refinement_bind[where isr=isr and intsr=isr for isr]
+lemmas pfx_refn_bind =
+  prefix_refinement_bind_v[where sr=sr and isr=sr and osr=sr and intsr=sr for sr]
+lemmas pfx_refn_bindT =
+  pfx_refn_bind[where P'="\<top>" and Q'="\<lambda>_ _. True", OF _ _ hoare_post_taut validI_triv,
+                simplified pred_conj_def, simplified]
 
 lemma prefix_refinement_assume_pre:
-  "(P \<Longrightarrow> prefix_refinement sr isr osr rvr P' Q' AR R f g)
-    \<Longrightarrow> prefix_refinement sr isr osr rvr (P' and (\<lambda>_ _. P)) Q' AR R f g"
-  "(P \<Longrightarrow> prefix_refinement sr isr osr rvr P' Q' AR R f g)
-    \<Longrightarrow> prefix_refinement sr isr osr rvr P' (Q' and (\<lambda>_ _. P)) AR R f g"
+  "\<lbrakk>P \<Longrightarrow> prefix_refinement sr isr osr rvr P' Q' AR R f g\<rbrakk>
+   \<Longrightarrow> prefix_refinement sr isr osr rvr (P' and (\<lambda>_ _. P)) Q' AR R f g"
+  "\<lbrakk>P \<Longrightarrow> prefix_refinement sr isr osr rvr P' Q' AR R f g\<rbrakk>
+   \<Longrightarrow> prefix_refinement sr isr osr rvr P' (Q' and (\<lambda>_ _. P)) AR R f g"
   by (auto simp: prefix_refinement_def)
 
 lemma prefix_refinement_modify:
   "\<forall>s t. isr s t \<longrightarrow> P s \<longrightarrow> Q t \<longrightarrow> osr (f s) (g t)
-    \<Longrightarrow> prefix_refinement sr isr osr (\<lambda>_ _. True) (\<lambda>_. P) (\<lambda>_. Q) AR R (modify f) (modify g)"
+   \<Longrightarrow> prefix_refinement sr isr osr (\<lambda>_ _. True) (\<lambda>_. P) (\<lambda>_. Q) AR R (modify f) (modify g)"
   apply (simp add: modify_def)
   apply (rule prefix_refinement_weaken_pre)
     apply (rule prefix_refinement_bind[where intsr=isr, OF prefix_refinement_get])
@@ -1353,7 +1269,7 @@ lemmas prefix_refinement_get_pre =
 
 lemma prefix_refinement_gets:
   "\<forall>s t. iosr s t \<and> P s \<and> Q t \<longrightarrow> rvr (f s) (f' t)
-    \<Longrightarrow> prefix_refinement sr iosr iosr rvr (\<lambda>_. P) (\<lambda>_. Q) AR R (gets f) (gets f')"
+   \<Longrightarrow> prefix_refinement sr iosr iosr rvr (\<lambda>_. P) (\<lambda>_. Q) AR R (gets f) (gets f')"
   apply (simp add: gets_def)
   apply (rule prefix_refinement_get_pre)
   apply (rule prefix_refinement_return_imp)
@@ -1379,8 +1295,7 @@ lemma par_tr_fin_bind:
   done
 
 lemma par_tr_fin_add_env_n_steps:
-  "par_tr_fin_principle f
-    \<Longrightarrow> par_tr_fin_principle (do x \<leftarrow> f; env_n_steps n od)"
+  "par_tr_fin_principle f \<Longrightarrow> par_tr_fin_principle (do x \<leftarrow> f; env_n_steps n od)"
 proof (induct n)
   case 0
   then show ?case by simp
@@ -1416,33 +1331,31 @@ lemma par_tr_fin_interference:
   done
 
 lemma prefix_refinement_triv_refinement_abs:
-  "triv_refinement f f'
-    \<Longrightarrow> prefix_refinement sr isr osr rvr P Q AR R f' g
-    \<Longrightarrow> prefix_refinement sr isr osr rvr P Q AR R f g"
+  "\<lbrakk>triv_refinement f f'; prefix_refinement sr isr osr rvr P Q AR R f' g\<rbrakk>
+   \<Longrightarrow> prefix_refinement sr isr osr rvr P Q AR R f g"
   apply (clarsimp simp: prefix_refinement_def)
   apply (strengthen triv_refinement_trans[mk_strg I E])
   apply fastforce
   done
 
 lemma prefix_refinement_triv_refinement_conc:
-  "prefix_refinement sr isr osr rvr P Q AR R f g'
-    \<Longrightarrow> triv_refinement g' g
-    \<Longrightarrow> prefix_refinement sr isr osr rvr P Q AR R f g"
+  "\<lbrakk>prefix_refinement sr isr osr rvr P Q AR R f g'; triv_refinement g' g\<rbrakk>
+   \<Longrightarrow> prefix_refinement sr isr osr rvr P Q AR R f g"
   apply (clarsimp simp: prefix_refinement_def triv_refinement_def)
   apply blast
   done
 
-lemmas prefix_refinement_triv_pre
-    = Pure.asm_rl[where psi="prefix_refinement sr isr osr rvr
-        (\<lambda>_ _. True) (\<lambda>_ _. True) AR R f g"] for sr isr osr rvr AR R f g
+lemmas prefix_refinement_triv_pre =
+  Pure.asm_rl[where psi="prefix_refinement sr isr osr rvr
+                           (\<lambda>_ _. True) (\<lambda>_ _. True) AR R f g"] for sr isr osr rvr AR R f g
 
 lemma prefix_refinement_mapM:
-  "list_all2 xyr xs ys
-    \<Longrightarrow> (\<forall>x y. x \<in> set xs \<longrightarrow> y \<in> set ys \<longrightarrow> xyr x y
-        \<longrightarrow> prefix_refinement sr intsr intsr rvr P Q AR R (f x) (g y))
-    \<Longrightarrow> (\<forall>x. x \<in> set xs \<longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>AR\<rbrace> f x \<lbrace>\<lambda>_ _. True\<rbrace>,\<lbrace>\<lambda>_. P\<rbrace>)
-    \<Longrightarrow> (\<forall>y. y \<in> set ys \<longrightarrow> \<lbrace>Q\<rbrace>,\<lbrace>R\<rbrace> g y \<lbrace>\<lambda>_ _. True\<rbrace>,\<lbrace>\<lambda>_. Q\<rbrace>)
-    \<Longrightarrow> prefix_refinement sr intsr intsr (list_all2 rvr) P Q AR R (mapM f xs) (mapM g ys)"
+  "\<lbrakk>list_all2 xyr xs ys;
+    \<forall>x y. x \<in> set xs \<longrightarrow> y \<in> set ys \<longrightarrow> xyr x y
+          \<longrightarrow> prefix_refinement sr intsr intsr rvr P Q AR R (f x) (g y);
+    \<forall>x. x \<in> set xs \<longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>AR\<rbrace> f x \<lbrace>\<lambda>_ _. True\<rbrace>,\<lbrace>\<lambda>_. P\<rbrace>;
+    \<forall>y. y \<in> set ys \<longrightarrow> \<lbrace>Q\<rbrace>,\<lbrace>R\<rbrace> g y \<lbrace>\<lambda>_ _. True\<rbrace>,\<lbrace>\<lambda>_. Q\<rbrace>\<rbrakk>
+   \<Longrightarrow> prefix_refinement sr intsr intsr (list_all2 rvr) P Q AR R (mapM f xs) (mapM g ys)"
   apply (induct xs ys rule: list_all2_induct)
    apply (simp add: mapM_def sequence_def prefix_refinement_return_imp)
   apply (clarsimp simp add: mapM_Cons all_conj_distrib imp_conjR)
@@ -1453,13 +1366,12 @@ lemma prefix_refinement_mapM:
        apply (wp validI_triv)+
       apply (blast intro: validI_prefix_closed)
      apply (wp validI_triv | simp add: pred_conj_def
-        | blast dest: validI_prefix_closed)+
+            | blast dest: validI_prefix_closed)+
   done
 
 lemma prefix_refinement_weaken_rel:
-  "prefix_refinement sr isr osr r P Q AR R f g
-    \<Longrightarrow> \<forall>rv rv'. r rv rv' \<longrightarrow> r' rv rv'
-    \<Longrightarrow> prefix_refinement sr isr osr r' P Q AR R f g"
+  "\<lbrakk>prefix_refinement sr isr osr r P Q AR R f g; \<forall>rv rv'. r rv rv' \<longrightarrow> r' rv rv'\<rbrakk>
+   \<Longrightarrow> prefix_refinement sr isr osr r' P Q AR R f g"
   apply (subst prefix_refinement_def, clarsimp)
   apply (drule(5) prefix_refinementD, clarsimp)
   apply (rule exI, rule conjI[rotated], assumption)
@@ -1473,9 +1385,8 @@ lemma rely_cond_mono:
   by (simp add: le_fun_def rely_cond_def split_def)
 
 lemma is_matching_fragment_add_rely:
-  "is_matching_fragment sr osr r ctr cres s0 AR s f
-    \<Longrightarrow> AR' \<le> AR
-    \<Longrightarrow> is_matching_fragment sr osr r ctr cres s0 AR' s (rely f AR' s0)"
+  "\<lbrakk>is_matching_fragment sr osr r ctr cres s0 AR s f; AR' \<le> AR\<rbrakk>
+   \<Longrightarrow> is_matching_fragment sr osr r ctr cres s0 AR' s (rely f AR' s0)"
   apply (frule is_matching_fragment_Nil)
   apply (clarsimp simp: is_matching_fragment_def prefix_closed_rely
                         rely_self_closed)
@@ -1488,9 +1399,8 @@ lemma is_matching_fragment_add_rely:
   done
 
 lemma prefix_refinement_weaken_rely:
-  "prefix_refinement sr isr osr r P Q AR R f g
-    \<Longrightarrow> R' \<le> R \<Longrightarrow> AR' \<le> AR
-    \<Longrightarrow> prefix_refinement sr isr osr r P Q AR' R' f g"
+  "\<lbrakk>prefix_refinement sr isr osr r P Q AR R f g; R' \<le> R; AR' \<le> AR\<rbrakk>
+   \<Longrightarrow> prefix_refinement sr isr osr r P Q AR' R' f g"
   apply (subst prefix_refinement_def, clarsimp)
   apply (drule(3) prefix_refinementD, assumption+)
   apply (clarsimp simp: rely_cond_def split_def le_fun_def)
@@ -1499,8 +1409,9 @@ lemma prefix_refinement_weaken_rely:
   apply (auto simp add: triv_refinement_def rely_def)
   done
 
-text \<open>Using prefix refinement as an in-place calculus, permitting
-multiple applications at the same level.\<close>
+text \<open>
+  Using prefix refinement as an in-place calculus, permitting multiple applications at the
+  same level.\<close>
 
 lemmas trivial = imp_refl[rule_format]
 
@@ -1520,10 +1431,8 @@ lemma matching_tr_symp:
   done
 
 lemma list_all2_is_me:
-  "list_all2 P tr tr'
-    \<Longrightarrow> \<forall>x y. P x y \<longrightarrow> fst x = fst y
-    \<Longrightarrow> (n < length tr \<and> fst (rev tr ! n) = Me)
-        = (n < length tr' \<and> fst (rev tr' ! n) = Me)"
+  "\<lbrakk>list_all2 P tr tr'; \<forall>x y. P x y \<longrightarrow> fst x = fst y\<rbrakk>
+   \<Longrightarrow> (n < length tr \<and> fst (rev tr ! n) = Me) = (n < length tr' \<and> fst (rev tr' ! n) = Me)"
   apply (rule conj_cong, simp add: list_all2_lengthD)
   apply (frule list_all2_rev_nthD, simp add: list_all2_lengthD)
   apply (cases "rev tr ! n", cases "rev tr' ! n", auto)
@@ -1550,11 +1459,9 @@ proof -
     apply (simp add: matching_tr_pfx_def assms)
     apply (rule conj_cong; simp?)
     apply (strengthen iffI)
-    apply (metis matching_tr transpD[OF matching_tr_transp]
-                 sympD[OF matching_tr_symp])
+    apply (metis matching_tr transpD[OF matching_tr_transp] sympD[OF matching_tr_symp])
     done
-  note is_me = matching_tr1[unfolded matching_tr_def, simplified,
-    THEN list_all2_is_me, symmetric]
+  note is_me = matching_tr1[unfolded matching_tr_def, simplified, THEN list_all2_is_me, symmetric]
   show ?thesis using assms
     apply (clarsimp simp: is_matching_fragment_def matching is_me)
     apply (drule(1) bspec)+
@@ -1566,10 +1473,8 @@ proof -
 qed
 
 lemma matching_tr_rely_cond:
-  "matching_tr sr (rev tr) (rev tr')
-    \<Longrightarrow> rely_cond R s0 tr
-    \<Longrightarrow> sr s0 t0
-    \<Longrightarrow> rely_cond (\<lambda>t0 t. \<exists>s0 s. sr s0 t0 \<and> sr s t \<and> R s0 s) t0 tr'"
+  "\<lbrakk>matching_tr sr (rev tr) (rev tr'); rely_cond R s0 tr; sr s0 t0\<rbrakk>
+   \<Longrightarrow> rely_cond (\<lambda>t0 t. \<exists>s0 s. sr s0 t0 \<and> sr s t \<and> R s0 s) t0 tr'"
   apply (simp add: matching_tr_def)
   apply (induct arbitrary: s0 t0 rule: list_all2_induct)
    apply simp
@@ -1581,21 +1486,23 @@ lemma matching_tr_rely_cond:
   done
 
 lemma prefix_refinement_in_place_trans:
-  "prefix_refinement sr isr osr (=) P (\<lambda>_ _. True) AR (\<lambda>t0 t. \<exists>s0 s. sr s0 t0 \<and> sr s t \<and> R s0 s) f g
-    \<Longrightarrow> prefix_refinement sr isr osr (=) (\<lambda>_ _. True) Q AR R g h
-    \<Longrightarrow> equivp sr \<Longrightarrow> equivp osr \<Longrightarrow> equivp isr
-    \<Longrightarrow> (\<forall>s t t'. sr s t \<longrightarrow> R t t' \<longrightarrow> (\<exists>s'. sr s' t' \<and> AR s s'))
-    \<Longrightarrow> prefix_refinement sr isr osr (=) P Q AR R f h"
+  "\<lbrakk>prefix_refinement sr isr osr (=) P (\<lambda>_ _. True) AR (\<lambda>t0 t. \<exists>s0 s. sr s0 t0 \<and> sr s t \<and> R s0 s) f g;
+    prefix_refinement sr isr osr (=) (\<lambda>_ _. True) Q AR R g h;
+    equivp sr; equivp osr; equivp isr;
+    \<forall>s t t'. sr s t \<longrightarrow> R t t' \<longrightarrow> (\<exists>s'. sr s' t' \<and> AR s s')\<rbrakk>
+   \<Longrightarrow> prefix_refinement sr isr osr (=) P Q AR R f h"
   apply (subst prefix_refinement_def, clarsimp)
   apply (drule_tac s=t and t=t and ?t0.0=t0 and cprog=h in pfx_refnD;
-      assumption?)
+         assumption?)
     apply (metis equivp_reflp_symp_transp reflpD)
    apply metis
   apply clarsimp
   apply (rename_tac h_tr h_res frag_g)
   apply (rule_tac x="\<lambda>s. \<Union>(tr, res) \<in> frag_g t \<inter> ({tr. length tr = length h_tr} \<times> UNIV).
-    \<Union>frag_f \<in> {frag_f. is_matching_fragment sr osr (=) tr res s0 AR s frag_f
-                \<and> triv_refinement f frag_f}. frag_f s" in exI)
+                           \<Union>frag_f \<in> {frag_f. is_matching_fragment sr osr (=) tr res s0 AR s frag_f
+                                               \<and> triv_refinement f frag_f}.
+                             frag_f s"
+               in exI)
   apply (rule conjI)
    apply (rule is_matching_fragment_UNION)
      apply clarsimp
@@ -1623,24 +1530,22 @@ lemma prefix_refinement_in_place_trans:
   done
 
 lemma prefix_refinement_Await:
-  "env_stable AR R sr iosr Q
-    \<Longrightarrow> abs_rely_stable AR P
-    \<Longrightarrow> \<forall>s t. P s \<longrightarrow> Q t \<longrightarrow> iosr s t \<longrightarrow> G' t \<longrightarrow> G s
-    \<Longrightarrow> (\<exists>s. G' s) \<longrightarrow> (\<exists>s. G s)
-    \<Longrightarrow> prefix_refinement sr iosr iosr (\<lambda>_ _. True) (\<lambda>s0 s. s0 = s \<and> P s)
-                (\<lambda>t0 t. t0 = t \<and> Q t) AR R
-            (Await G) (Await G')"
+  "\<lbrakk>env_stable AR R sr iosr Q; abs_rely_stable AR P;
+    \<forall>s t. P s \<longrightarrow> Q t \<longrightarrow> iosr s t \<longrightarrow> G' t \<longrightarrow> G s;
+    (\<exists>s. G' s) \<longrightarrow> (\<exists>s. G s)\<rbrakk>
+   \<Longrightarrow> prefix_refinement sr iosr iosr (\<lambda>_ _. True) (\<lambda>s0 s. s0 = s \<and> P s) (\<lambda>t0 t. t0 = t \<and> Q t) AR R
+                         (Await G) (Await G')"
    apply (simp add: Await_redef)
    apply (rule prefix_refinement_weaken_pre)
      apply (rule prefix_refinement_bind[where intsr=iosr]
-             prefix_refinement_select[where rvr="\<lambda>s s'. G s = G' s'"]
-             prefix_refinement_env_steps
-         | simp add: if_split[where P="\<lambda>S. x \<in> S" for x] split del: if_split
-         | (rule prefix_refinement_get, rename_tac s s',
-            rule_tac P="P s" in prefix_refinement_assume_pre(1),
-            rule_tac P="Q s'" in prefix_refinement_assume_pre(2))
-         |  (rule prefix_refinement_select[where rvr=dc2])
-         | wp)+
+                 prefix_refinement_select[where rvr="\<lambda>s s'. G s = G' s'"]
+                 prefix_refinement_env_steps
+            | simp add: if_split[where P="\<lambda>S. x \<in> S" for x] split del: if_split
+            | (rule prefix_refinement_get, rename_tac s s',
+               rule_tac P="P s" in prefix_refinement_assume_pre(1),
+               rule_tac P="Q s'" in prefix_refinement_assume_pre(2))
+            | (rule prefix_refinement_select[where rvr=dc2])
+            | wp)+
    apply clarsimp
    apply (erule(2) abs_rely_stable_rtranclp)
   apply (clarsimp simp: env_stable_def)

--- a/lib/concurrency/Triv_Refinement.thy
+++ b/lib/concurrency/Triv_Refinement.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2024, Proofcraft Pty Ltd
  * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -15,6 +16,12 @@ text \<open>
 definition triv_refinement :: "('s,'a) tmonad \<Rightarrow> ('s,'a) tmonad \<Rightarrow> bool" where
   "triv_refinement aprog cprog = (\<forall>s. cprog s \<subseteq> aprog s)"
 
+lemmas triv_refinement_elemD = triv_refinement_def[THEN iffD1, rule_format, THEN subsetD]
+
+lemma triv_refinement_trans:
+  "\<lbrakk>triv_refinement f g; triv_refinement g h\<rbrakk> \<Longrightarrow> triv_refinement f h"
+  by (auto simp add: triv_refinement_def)
+
 lemma triv_refinement_mono_bind:
   "triv_refinement a c \<Longrightarrow> triv_refinement (a >>= b) (c >>= b)"
   "\<lbrakk>\<forall>x. triv_refinement (b x) (d x)\<rbrakk> \<Longrightarrow> triv_refinement (a >>= b) (a >>= d)"
@@ -24,10 +31,6 @@ lemma triv_refinement_mono_bind:
   apply (intro Un_mono allI order_refl UN_mono image_mono)
   apply simp
   done
-
-lemma triv_refinement_trans:
-  "\<lbrakk>triv_refinement f g; triv_refinement g h\<rbrakk> \<Longrightarrow> triv_refinement f h"
-  by (auto simp add: triv_refinement_def)
 
 lemma triv_refinement_bind:
   "\<lbrakk>triv_refinement a c; \<forall>x. triv_refinement (b x) (d x)\<rbrakk>
@@ -79,17 +82,7 @@ lemma rely_rely_triv_refinement:
   "\<lbrakk>\<And>s0 s. R s0 s \<Longrightarrow> R' s0 s\<rbrakk> \<Longrightarrow> triv_refinement (rely f R' s0) (rely (rely f R s0) R' s0)"
   by (clarsimp simp: triv_refinement_def rely_def parallel_def)
 
-lemma validI_triv_refinement:
-  "\<lbrakk>triv_refinement f g; \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>; prefix_closed g\<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> g \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
-  unfolding rely_def triv_refinement_def validI_def
-  by fastforce
-
-lemma valid_triv_refinement:
-  "\<lbrakk>triv_refinement f g; \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>\<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> g \<lbrace>Q\<rbrace>"
-  unfolding rely_def triv_refinement_def valid_def mres_def
-  by (fastforce elim: image_eqI[rotated])
-
-lemma triv_refinement_refl:
+lemma triv_refinement_refl[simp]:
   "triv_refinement f f"
   by (simp add: triv_refinement_def)
 
@@ -101,6 +94,23 @@ lemma triv_refinement_select_abstract_x:
   "\<lbrakk>x \<in> S; triv_refinement (aprog x) cprog\<rbrakk> \<Longrightarrow> triv_refinement (select S >>= aprog) cprog"
   by (auto simp: triv_refinement_def bind_def select_def)
 
-lemmas triv_refinement_elemD = triv_refinement_def[THEN iffD1, rule_format, THEN subsetD]
+lemma triv_refinement_alternative1:
+  "triv_refinement (a \<sqinter> b) a"
+  by (clarsimp simp: triv_refinement_def alternative_def)
+
+lemma triv_refinement_alternative2:
+  "triv_refinement (a \<sqinter> b) b"
+  by (clarsimp simp: triv_refinement_def alternative_def)
+
+
+lemma validI_triv_refinement:
+  "\<lbrakk>triv_refinement f g; \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>; prefix_closed g\<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> g \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+  unfolding rely_def triv_refinement_def validI_def
+  by fastforce
+
+lemma valid_triv_refinement:
+  "\<lbrakk>triv_refinement f g; \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>\<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> g \<lbrace>Q\<rbrace>"
+  unfolding rely_def triv_refinement_def valid_def mres_def
+  by (fastforce elim: image_eqI[rotated])
 
 end

--- a/lib/concurrency/Triv_Refinement.thy
+++ b/lib/concurrency/Triv_Refinement.thy
@@ -4,23 +4,20 @@
  * SPDX-License-Identifier: BSD-2-Clause
  *)
 theory Triv_Refinement
-
-imports
-  "Monads.Trace_More_RG"
-  "Monads.Trace_Strengthen_Setup"
-
+  imports
+    "Monads.Trace_More_RG"
+    "Monads.Trace_Strengthen_Setup"
 begin
 
-text \<open>This is a simple (almost trivial) definition of refinement,
-which simply resolves nondeterminism to a smaller set of options.\<close>
-definition
-  triv_refinement :: "('s,'a) tmonad \<Rightarrow> ('s,'a) tmonad \<Rightarrow> bool"
-where
+text \<open>
+  This is a simple (almost trivial) definition of refinement, which simply resolves nondeterminism
+  to a smaller set of options.\<close>
+definition triv_refinement :: "('s,'a) tmonad \<Rightarrow> ('s,'a) tmonad \<Rightarrow> bool" where
   "triv_refinement aprog cprog = (\<forall>s. cprog s \<subseteq> aprog s)"
 
 lemma triv_refinement_mono_bind:
   "triv_refinement a c \<Longrightarrow> triv_refinement (a >>= b) (c >>= b)"
-  "(\<forall>x. triv_refinement (b x) (d x)) \<Longrightarrow> triv_refinement (a >>= b) (a >>= d)"
+  "\<lbrakk>\<forall>x. triv_refinement (b x) (d x)\<rbrakk> \<Longrightarrow> triv_refinement (a >>= b) (a >>= d)"
    apply (simp add: triv_refinement_def bind_def)
    apply (intro allI UN_mono; simp)
   apply (simp only: triv_refinement_def bind_def' split_def)
@@ -29,14 +26,12 @@ lemma triv_refinement_mono_bind:
   done
 
 lemma triv_refinement_trans:
-  "triv_refinement f g \<Longrightarrow> triv_refinement g h
-    \<Longrightarrow> triv_refinement f h"
+  "\<lbrakk>triv_refinement f g; triv_refinement g h\<rbrakk> \<Longrightarrow> triv_refinement f h"
   by (auto simp add: triv_refinement_def)
 
 lemma triv_refinement_bind:
-  "triv_refinement a c
-    \<Longrightarrow> (\<forall>x. triv_refinement (b x) (d x))
-    \<Longrightarrow> triv_refinement (bind a b) (bind c d)"
+  "\<lbrakk>triv_refinement a c; \<forall>x. triv_refinement (b x) (d x)\<rbrakk>
+   \<Longrightarrow> triv_refinement (bind a b) (bind c d)"
   by (metis triv_refinement_mono_bind triv_refinement_trans)
 
 lemma triv_refinement_mono_parallel:
@@ -52,11 +47,10 @@ lemma triv_refinement_mono_parallel':
   done
 
 lemma triv_refinement_parallel:
-  "triv_refinement a b
-    \<Longrightarrow> triv_refinement c d
-    \<Longrightarrow> triv_refinement (parallel a c) (parallel b d)"
+  "\<lbrakk>triv_refinement a b; triv_refinement c d\<rbrakk>
+   \<Longrightarrow> triv_refinement (parallel a c) (parallel b d)"
   by (metis triv_refinement_mono_parallel triv_refinement_mono_parallel'
-    triv_refinement_trans)
+            triv_refinement_trans)
 
 lemma select_subset:
   "(select S s \<subseteq> select S' s') = (S \<subseteq> S' \<and> (S \<noteq> {} \<longrightarrow> s = s'))"
@@ -71,34 +65,27 @@ lemma triv_refinement_select_eq:
   by (simp add: triv_refinement_def select_subset)
 
 lemma triv_refinement_rely:
-  "(\<And>s0 s. R' s0 s \<Longrightarrow> R s0 s) \<Longrightarrow>
-   triv_refinement (rely f R s0) (rely f R' s0)"
+  "\<lbrakk>\<And>s0 s. R' s0 s \<Longrightarrow> R s0 s\<rbrakk>
+   \<Longrightarrow> triv_refinement (rely f R s0) (rely f R' s0)"
   unfolding rely_def triv_refinement_def rely_cond_def
   by auto
 
 lemma triv_refinement_rely2:
-  "triv_refinement f g \<Longrightarrow>
-   triv_refinement (rely f R s0) (rely g R s0)"
+  "triv_refinement f g \<Longrightarrow> triv_refinement (rely f R s0) (rely g R s0)"
   unfolding rely_def triv_refinement_def rely_cond_def
   by auto
 
 lemma rely_rely_triv_refinement:
- "(\<And>s0 s. R s0 s \<Longrightarrow> R' s0 s) \<Longrightarrow>
- triv_refinement (rely f R' s0) (rely (rely f R s0) R' s0)"
+  "\<lbrakk>\<And>s0 s. R s0 s \<Longrightarrow> R' s0 s\<rbrakk> \<Longrightarrow> triv_refinement (rely f R' s0) (rely (rely f R s0) R' s0)"
   by (clarsimp simp: triv_refinement_def rely_def parallel_def)
 
 lemma validI_triv_refinement:
-  "triv_refinement f g
-    \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>
-    \<Longrightarrow> prefix_closed g
-    \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> g \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+  "\<lbrakk>triv_refinement f g; \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>; prefix_closed g\<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> g \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
   unfolding rely_def triv_refinement_def validI_def
   by fastforce
 
 lemma valid_triv_refinement:
-  "triv_refinement f g
-    \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>
-    \<Longrightarrow> \<lbrace>P\<rbrace> g \<lbrace>Q\<rbrace>"
+  "\<lbrakk>triv_refinement f g; \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>\<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> g \<lbrace>Q\<rbrace>"
   unfolding rely_def triv_refinement_def valid_def mres_def
   by (fastforce elim: image_eqI[rotated])
 
@@ -107,16 +94,13 @@ lemma triv_refinement_refl:
   by (simp add: triv_refinement_def)
 
 lemma triv_refinement_select_concrete_All:
-  "\<forall>x \<in> S. triv_refinement aprog (cprog x)
-    \<Longrightarrow> triv_refinement aprog (select S >>= cprog)"
-  by (auto simp add: triv_refinement_def bind_def select_def)
+  "\<forall>x \<in> S. triv_refinement aprog (cprog x) \<Longrightarrow> triv_refinement aprog (select S >>= cprog)"
+  by (auto simp: triv_refinement_def bind_def select_def)
 
 lemma triv_refinement_select_abstract_x:
-  "x \<in> S \<Longrightarrow> triv_refinement (aprog x) cprog
-    \<Longrightarrow> triv_refinement (select S >>= aprog) cprog"
-  by (auto simp add: triv_refinement_def bind_def select_def)
+  "\<lbrakk>x \<in> S; triv_refinement (aprog x) cprog\<rbrakk> \<Longrightarrow> triv_refinement (select S >>= aprog) cprog"
+  by (auto simp: triv_refinement_def bind_def select_def)
 
-lemmas triv_refinement_elemD
-    = triv_refinement_def[THEN iffD1, rule_format, THEN subsetD]
+lemmas triv_refinement_elemD = triv_refinement_def[THEN iffD1, rule_format, THEN subsetD]
 
 end

--- a/lib/concurrency/examples/Peterson_Atomicity.thy
+++ b/lib/concurrency/examples/Peterson_Atomicity.thy
@@ -15,8 +15,7 @@ text \<open>
 
 datatype ident = A | B
 
-primrec other_ident
-where
+primrec other_ident where
     "other_ident A = B"
   | "other_ident B = A"
 
@@ -34,7 +33,7 @@ lemma neq_A_B[simp]:
 lemma forall_ident_eq:
   "(\<forall>ident. P ident) = (P A \<and> P B)"
   using ident.nchotomy
-  by metis
+  by (metis (full_types))
 
 lemma other_other_ident_simps[simp]:
   "other_ident (other_ident x) = x"
@@ -43,14 +42,13 @@ lemma other_other_ident_simps[simp]:
   by (simp_all split: other_ident_split add: eq_commute)
 
 text \<open>
-The state of the algorithm. The variables A/B are condensed into
-an ab_v variable, so we can parametrise by thread A/B. The priority
-variable is t_v, and the critical section cs has two variable to
-operate on, cs1_v and cs2_v.
+  The state of the algorithm. The variables A/B are condensed into
+  an ab_v variable, so we can parametrise by thread A/B. The priority
+  variable is t_v, and the critical section cs has two variable to
+  operate on, cs1_v and cs2_v.
 
-Labels are needed to track where we're up to for the preconditions,
-relies and guarantees.
-\<close>
+  Labels are needed to track where we're up to for the preconditions,
+  relies and guarantees.\<close>
 
 datatype label = Awaiting | Critical | Exited
 
@@ -67,136 +65,107 @@ locale mx_locale =
     and csI :: "'b \<Rightarrow> bool"
 begin
 
-definition
-  set_ab :: "ident \<Rightarrow> bool \<Rightarrow> ('a, 'b) p_state \<Rightarrow> ('a, 'b) p_state"
-where
+definition set_ab :: "ident \<Rightarrow> bool \<Rightarrow> ('a, 'b) p_state \<Rightarrow> ('a, 'b) p_state" where
   "set_ab ident trying s = (s \<lparr> ab_v := (ab_v s) (ident := trying) \<rparr>)"
 
-definition
-  set_label :: "ident \<Rightarrow> label \<Rightarrow> ('a, 'b) p_state \<Rightarrow> ('a, 'b) p_state"
-where
+definition set_label :: "ident \<Rightarrow> label \<Rightarrow> ('a, 'b) p_state \<Rightarrow> ('a, 'b) p_state" where
   "set_label ident label s = (s \<lparr> ab_label := (ab_label s) (ident := label) \<rparr>)"
 
-definition
-  locked :: "ident \<Rightarrow> ('a, 'b) p_state \<Rightarrow> bool"
-where
+definition locked :: "ident \<Rightarrow> ('a, 'b) p_state \<Rightarrow> bool" where
   "locked ident s = (ab_v s (other_ident ident) \<longrightarrow> t_v s = ident)"
 
-definition
-  acquire_lock :: "ident \<Rightarrow> (('a, 'b) p_state, unit) tmonad"
-where
+definition acquire_lock :: "ident \<Rightarrow> (('a, 'b) p_state, unit) tmonad" where
   "acquire_lock ident = do
-    interference;
-    modify (set_ab ident True);
-    modify (\<lambda>s. s \<lparr> t_v := other_ident ident \<rparr>);
-    modify (set_label ident Awaiting);
-    interference;
-    Await (locked ident);
-    modify (set_label ident Critical)
+     interference;
+     modify (set_ab ident True);
+     modify (\<lambda>s. s \<lparr> t_v := other_ident ident \<rparr>);
+     modify (set_label ident Awaiting);
+     interference;
+     Await (locked ident);
+     modify (set_label ident Critical)
    od"
 
-definition
-  release_lock :: "ident \<Rightarrow> (('a, 'b) p_state, unit) tmonad"
-where
+definition release_lock :: "ident \<Rightarrow> (('a, 'b) p_state, unit) tmonad" where
   "release_lock ident = do
-    modify (set_ab ident False);
-    modify (set_label ident Exited);
-    interference;
-    return ()
+     modify (set_ab ident False);
+     modify (set_label ident Exited);
+     interference;
+     return ()
    od"
 
-definition
-  abs_critical_section :: "(('a, 'b) p_state, unit) tmonad"
-where
+definition abs_critical_section :: "(('a, 'b) p_state, unit) tmonad" where
   "abs_critical_section = do
-    interferences;
-    modify (\<lambda>s. s \<lparr> cs1_v := cs1 (cs2_v s) \<rparr>);
-    cs2;
-    interference
-  od"
+     interferences;
+     modify (\<lambda>s. s \<lparr> cs1_v := cs1 (cs2_v s) \<rparr>);
+     cs2;
+     interference
+   od"
 
-definition
-  abs_peterson_proc ::
-    "ident \<Rightarrow> (('a, 'b) p_state, unit) tmonad"
-where
+definition abs_peterson_proc :: "ident \<Rightarrow> (('a, 'b) p_state, unit) tmonad" where
   "abs_peterson_proc ident = do
-    acquire_lock ident;
-    abs_critical_section;
-    release_lock ident
-  od"
+     acquire_lock ident;
+     abs_critical_section;
+     release_lock ident
+   od"
 
-definition
-  critical_section :: "(('a, 'b) p_state, unit) tmonad"
-where
+definition critical_section :: "(('a, 'b) p_state, unit) tmonad" where
   "critical_section = do
-    interference;
-    modify (\<lambda>s. s \<lparr> cs1_v := cs1 (cs2_v s) \<rparr>);
-    interference;
-    cs2;
-    interference
-  od"
+     interference;
+     modify (\<lambda>s. s \<lparr> cs1_v := cs1 (cs2_v s) \<rparr>);
+     interference;
+     cs2;
+     interference
+   od"
 
-definition
-  peterson_proc :: "ident \<Rightarrow> (('a, 'b) p_state, unit) tmonad"
-where
+definition peterson_proc :: "ident \<Rightarrow> (('a, 'b) p_state, unit) tmonad" where
   "peterson_proc ident = do
-    acquire_lock ident;
-    critical_section;
-    release_lock ident
-  od"
+     acquire_lock ident;
+     critical_section;
+     release_lock ident
+   od"
 
 abbreviation "critical label \<equiv> label = Critical"
 
-text \<open>The required invariant. We can't both be in the critical section.
-Whenever neither of us is in the critical section, its invariant holds.\<close>
-definition
-  req_peterson_inv :: "('a, 'b) p_state \<Rightarrow> bool"
-where
-  "req_peterson_inv s = (\<not> (critical (ab_label s A) \<and> critical (ab_label s B))
-    \<and> (critical (ab_label s A) \<or> critical (ab_label s B) \<or> csI (cs2_v s)))"
+text \<open>
+  The required invariant. We can't both be in the critical section.
+  Whenever neither of us is in the critical section, its invariant holds.\<close>
+definition req_peterson_inv :: "('a, 'b) p_state \<Rightarrow> bool" where
+  "req_peterson_inv s =
+     (\<not> (critical (ab_label s A) \<and> critical (ab_label s B))
+      \<and> (critical (ab_label s A) \<or> critical (ab_label s B) \<or> csI (cs2_v s)))"
 
-text \<open>The key invariant. We can't both be enabled, where that means
-either we're in the critical section or waiting to enter with priority.
-\<close>
-abbreviation(input)
-  enabled :: "ident \<Rightarrow> ('a, 'b) p_state \<Rightarrow> bool"
-where
-  "enabled ident s \<equiv> (critical (ab_label s ident)
-    \<or> (ab_label s ident = Awaiting \<and> t_v s = ident))"
+text \<open>
+  The key invariant. We can't both be enabled, where that means
+  either we're in the critical section or waiting to enter with priority.\<close>
+abbreviation (input) enabled :: "ident \<Rightarrow> ('a, 'b) p_state \<Rightarrow> bool" where
+  "enabled ident s \<equiv>
+     critical (ab_label s ident) \<or> ab_label s ident = Awaiting \<and> t_v s = ident"
 
-definition
-  key_peterson_inv :: "('a, 'b) p_state \<Rightarrow> bool"
-where
+definition key_peterson_inv :: "('a, 'b) p_state \<Rightarrow> bool" where
   "key_peterson_inv s = (\<not> (enabled A s \<and> enabled B s))"
 
 text \<open>Some trivia about labels and variables.\<close>
-definition
-  local_peterson_inv :: "('a, 'b) p_state \<Rightarrow> bool"
-where
-  "local_peterson_inv s
-    = (\<forall>ident. ab_label s ident \<noteq> Exited \<longrightarrow> ab_v s ident)"
+definition local_peterson_inv :: "('a, 'b) p_state \<Rightarrow> bool" where
+  "local_peterson_inv s = (\<forall>ident. ab_label s ident \<noteq> Exited \<longrightarrow> ab_v s ident)"
 
 definition
-  "invs s = (req_peterson_inv s
-    \<and> key_peterson_inv s \<and> local_peterson_inv s)"
+  "invs s = (req_peterson_inv s \<and> key_peterson_inv s \<and> local_peterson_inv s)"
 
 lemmas invs_defs = req_peterson_inv_def key_peterson_inv_def local_peterson_inv_def
 
-definition
-  peterson_rel :: "ident \<Rightarrow> ('a, 'b) p_state \<Rightarrow> ('a, 'b) p_state \<Rightarrow> bool"
-where
-  "peterson_rel ident s_prior s = (\<comment> \<open>assume invs\<close> invs s_prior \<longrightarrow>
+definition peterson_rel :: "ident \<Rightarrow> ('a, 'b) p_state \<Rightarrow> ('a, 'b) p_state \<Rightarrow> bool" where
+  "peterson_rel ident s_prior s =
+     (\<comment> \<open>assume invs\<close> invs s_prior \<longrightarrow>
             \<comment> \<open>invariants are preserved\<close>
         (invs s
             \<comment> \<open>I won't adjust your variables\<close>
-        \<and> (ab_v s (other_ident ident) = ab_v s_prior (other_ident ident))
-        \<and> (ab_label s (other_ident ident) = ab_label s_prior (other_ident ident))
+         \<and> (ab_v s (other_ident ident) = ab_v s_prior (other_ident ident))
+         \<and> (ab_label s (other_ident ident) = ab_label s_prior (other_ident ident))
             \<comment> \<open>I will only ever give you priority\<close>
-        \<and> (t_v s_prior = other_ident ident \<longrightarrow> t_v s = other_ident ident)
+         \<and> (t_v s_prior = other_ident ident \<longrightarrow> t_v s = other_ident ident)
             \<comment> \<open>If you're in the critical section, I won't change cs2_v and cs1_v\<close>
-        \<and> (critical (ab_label s_prior (other_ident ident))
-                \<longrightarrow> cs2_v s = cs2_v s_prior \<and> cs1_v s = cs1_v s_prior)
-  ))"
+         \<and> (critical (ab_label s_prior (other_ident ident))
+              \<longrightarrow> cs2_v s = cs2_v s_prior \<and> cs1_v s = cs1_v s_prior)))"
 
 lemma peterson_rel_rtranclp[simp]:
   "rtranclp (peterson_rel ident) = (peterson_rel ident)"
@@ -213,57 +182,56 @@ lemma reflp_peterson_rel[simp]:
 declare reflp_peterson_rel[THEN reflpD, simp]
 
 lemma peterson_rel_imp_assume_invs:
-  "invs x \<Longrightarrow> (peterson_rel ident x y \<and> invs x \<and> invs y \<longrightarrow> P x y)
-    \<Longrightarrow> (peterson_rel ident x y \<longrightarrow> P x y)"
+  "\<lbrakk>invs x; peterson_rel ident x y \<and> invs x \<and> invs y \<longrightarrow> P x y\<rbrakk>
+   \<Longrightarrow> peterson_rel ident x y \<longrightarrow> P x y"
   by (simp add: peterson_rel_def)
 
 end
 
 text \<open>
-We assume validity for the underspecified critical section code represented by
-@{text cs2}.
+  We assume validity for the underspecified critical section code represented by
+  @{text cs2}.
 
-We also assume some basic sanity properties about the structure of @{text cs2}.
-\<close>
+  We also assume some basic sanity properties about the structure of @{text cs2}.\<close>
 locale mx_locale_wp = mx_locale cs1 cs2 csI for cs1 :: "'b \<Rightarrow> 'a" and cs2 and csI +
   assumes
     cs_wp: "\<forall>s c. I s \<and> lockf s \<longrightarrow> I s \<and> lockf (s \<lparr> cs2_v := c \<rparr>)
       \<Longrightarrow>
-      \<lbrace> \<lambda>s0' s'. csI (cs2_v s') \<and> s0' = s0 \<and> s' = s \<and> I s \<and> lockf s
-                 \<and> cs1_v s' = cs1 (cs2_v s') \<rbrace>,
-      \<lbrace> \<lambda>s0 s. I s0 \<and> lockf s0 \<longrightarrow> cs2_v s = cs2_v s0 \<and> I s \<and> lockf s
-                                    \<and> cs1_v s = cs1_v s0 \<rbrace>
-        cs2
-      \<lbrace> \<lambda>s0 s. I s0 \<longrightarrow> (\<exists>c. s = s0 \<lparr> cs2_v := c \<rparr>) \<and> I s \<and> lockf s \<rbrace>,
-      \<lbrace> \<lambda>_ s0' s'. \<exists>c. csI c \<and> s' = s \<lparr> cs2_v := c \<rparr>
-                       \<and> (\<exists>c'. s0' = s0 \<or> s0' = s \<lparr> cs2_v := c' \<rparr>)
-                       \<and> I s' \<and> lockf s' \<rbrace>"
+      \<lbrace>\<lambda>s0' s'. csI (cs2_v s') \<and> s0' = s0 \<and> s' = s \<and> I s \<and> lockf s
+                \<and> cs1_v s' = cs1 (cs2_v s')\<rbrace>,
+      \<lbrace>\<lambda>s0 s. I s0 \<and> lockf s0 \<longrightarrow> cs2_v s = cs2_v s0 \<and> I s \<and> lockf s \<and> cs1_v s = cs1_v s0\<rbrace>
+      cs2
+      \<lbrace>\<lambda>s0 s. I s0 \<longrightarrow> (\<exists>c. s = s0 \<lparr> cs2_v := c \<rparr>) \<and> I s \<and> lockf s\<rbrace>,
+      \<lbrace>\<lambda>_ s0' s'. \<exists>c. csI c \<and> s' = s \<lparr> cs2_v := c \<rparr>
+                      \<and> (\<exists>c'. s0' = s0 \<or> s0' = s \<lparr> cs2_v := c' \<rparr>)
+                      \<and> I s' \<and> lockf s'\<rbrace>"
     and cs_closed: "prefix_closed cs2"
     and cs_not_env_steps_first: "not_env_steps_first cs2"
 begin
 
-method_setup rev_drule = \<open>
-  Attrib.thms >> curry (fn (thms, ctxt)
-    => SIMPLE_METHOD (dresolve_tac ctxt thms 1 #> Seq.list_of #> rev #> Seq.of_list))
-\<close>
+method_setup rev_drule =
+  \<open>Attrib.thms >>
+   curry (fn (thms, ctxt) =>
+     SIMPLE_METHOD (dresolve_tac ctxt thms 1 #> Seq.list_of #> rev #> Seq.of_list))\<close>
 
 lemma cs2_wp_apply_peterson[wp]:
- "\<lbrace> (\<lambda>s0 s. csI (cs2_v s)
-      \<and> invs s0 \<and> invs s \<and> critical (ab_label s ident)
-      \<and> cs1_v s = cs1 (cs2_v s)
-      \<and> (\<forall>s0' c' c. csI c \<longrightarrow> (\<exists>c'. s0' = s0 \<or> s0' = s \<lparr> cs2_v := c' \<rparr>)
-              \<longrightarrow>  Q () s0' (s \<lparr> cs2_v := c\<rparr>))) \<rbrace>,
-  \<lbrace> peterson_rel (other_ident ident) \<rbrace>
-    cs2
-  \<lbrace> peterson_rel ident \<rbrace>,
-  \<lbrace> Q \<rbrace>"
+ "\<lbrace>\<lambda>s0 s. csI (cs2_v s)
+     \<and> invs s0 \<and> invs s \<and> critical (ab_label s ident)
+     \<and> cs1_v s = cs1 (cs2_v s)
+     \<and> (\<forall>s0' c' c. csI c \<longrightarrow> (\<exists>c'. s0' = s0 \<or> s0' = s \<lparr> cs2_v := c' \<rparr>)
+          \<longrightarrow>  Q () s0' (s \<lparr> cs2_v := c\<rparr>))\<rbrace>,
+  \<lbrace>peterson_rel (other_ident ident)\<rbrace>
+  cs2
+  \<lbrace>peterson_rel ident\<rbrace>,
+  \<lbrace>Q\<rbrace>"
   apply (rule validI_name_pre[OF cs_closed], clarsimp simp del: imp_disjL)
   apply (rule rg_weaken_pre)
    apply (rule validI_well_behaved[OF cs_closed])
      apply (rule rg_strengthen_post)
       apply (rule_tac s=s and ?s0.0=s0
-         and lockf="\<lambda>s. critical (ab_label s ident)"
-         and I="invs" in cs_wp)
+                  and lockf="\<lambda>s. critical (ab_label s ident)"
+                  and I="invs"
+                   in cs_wp)
       apply (clarsimp simp: invs_defs invs_def)
      apply (clarsimp simp del: imp_disjL)
     apply (simp only: imp_conjL[symmetric])
@@ -276,101 +244,85 @@ lemma cs2_wp_apply_peterson[wp]:
   done
 
 lemma release_lock_mutual_excl:
-  "\<lbrace> \<lambda>s0 s. peterson_rel ident s0 s \<and> invs s
-            \<and> ab_label s ident = Critical \<and> csI (cs2_v s) \<rbrace>,
-   \<lbrace> peterson_rel (other_ident ident) \<rbrace>
-     release_lock ident
-   \<lbrace> peterson_rel ident \<rbrace>,
-   \<lbrace> \<lambda>rv s0 s. peterson_rel ident s0 s \<and> invs s
-               \<and> ab_label s ident = Exited \<rbrace>"
+  "\<lbrace>\<lambda>s0 s. peterson_rel ident s0 s \<and> invs s \<and> ab_label s ident = Critical \<and> csI (cs2_v s)\<rbrace>,
+   \<lbrace>peterson_rel (other_ident ident)\<rbrace>
+   release_lock ident
+   \<lbrace>peterson_rel ident\<rbrace>,
+   \<lbrace>\<lambda>rv s0 s. peterson_rel ident s0 s \<and> invs s \<and> ab_label s ident = Exited\<rbrace>"
   apply (simp add: release_lock_def)
   apply wpsimp
   apply (strengthen peterson_rel_imp_assume_invs | simp)+
   apply (cases ident)
-  apply (safe, simp_all)
-  by ((clarsimp simp: peterson_rel_def set_label_def
-                      set_ab_def invs_defs
-    | rule invs_def[THEN iffD2] conjI
-    | rev_drule invs_def[THEN iffD1])+)
+   apply (safe, simp_all)
+  by (clarsimp simp: peterson_rel_def set_label_def set_ab_def invs_defs
+      | rule invs_def[THEN iffD2] conjI
+      | rev_drule invs_def[THEN iffD1])+
 
 lemma abs_critical_section_mutual_excl:
-  "\<lbrace> \<lambda>s0 s. peterson_rel ident s0 s \<and> invs s \<and> invs s0
-            \<and> ab_label s ident = Critical \<and> csI (cs2_v s) \<rbrace>,
-   \<lbrace> peterson_rel (other_ident ident) \<rbrace>
-     abs_critical_section
-   \<lbrace> peterson_rel ident \<rbrace>,
-   \<lbrace> \<lambda>rv s0 s. peterson_rel ident s0 s \<and> invs s
-               \<and> ab_label s ident = Critical \<and> csI (cs2_v s) \<rbrace>"
+  "\<lbrace>\<lambda>s0 s. peterson_rel ident s0 s \<and> invs s \<and> invs s0 \<and> ab_label s ident = Critical \<and> csI (cs2_v s)\<rbrace>,
+   \<lbrace>peterson_rel (other_ident ident)\<rbrace>
+   abs_critical_section
+   \<lbrace>peterson_rel ident\<rbrace>,
+   \<lbrace>\<lambda>rv s0 s. peterson_rel ident s0 s \<and> invs s \<and> ab_label s ident = Critical \<and> csI (cs2_v s)\<rbrace>"
   apply (simp add: abs_critical_section_def)
   apply wpsimp
   apply (strengthen peterson_rel_imp_assume_invs | simp)+
   apply (cases ident)
-  apply (safe, simp_all)
-  by ((clarsimp simp: peterson_rel_def invs_defs
-    | rule invs_def[THEN iffD2] conjI
-    | rev_drule invs_def[THEN iffD1])+)
+   apply (safe, simp_all)
+  by (clarsimp simp: peterson_rel_def invs_defs
+      | rule invs_def[THEN iffD2] conjI
+      | rev_drule invs_def[THEN iffD1])+
 
 lemma acquire_lock_mutual_excl:
-  "\<lbrace> \<lambda>s0 s. peterson_rel ident s0 s \<and> invs s
-            \<and> ab_label s ident = Exited \<rbrace>,
-   \<lbrace> peterson_rel (other_ident ident) \<rbrace>
-     acquire_lock ident
-   \<lbrace> peterson_rel ident \<rbrace>,
-   \<lbrace> \<lambda>rv s0 s. peterson_rel ident s0 s \<and> invs s \<and> invs s0
-               \<and> ab_label s ident = Critical \<and> csI (cs2_v s) \<rbrace>"
+  "\<lbrace>\<lambda>s0 s. peterson_rel ident s0 s \<and> invs s \<and> ab_label s ident = Exited\<rbrace>,
+   \<lbrace>peterson_rel (other_ident ident)\<rbrace>
+   acquire_lock ident
+   \<lbrace>peterson_rel ident\<rbrace>,
+   \<lbrace>\<lambda>rv s0 s. peterson_rel ident s0 s \<and> invs s \<and> invs s0
+              \<and> ab_label s ident = Critical \<and> csI (cs2_v s)\<rbrace>"
   apply (simp add: acquire_lock_def)
   apply (wpsimp wp: Await_sync_twp)
   apply (strengthen peterson_rel_imp_assume_invs | simp)+
   apply (cases ident)
-  apply (safe, simp_all)
-  by ((clarsimp simp: peterson_rel_def set_label_def set_ab_def
-                      locked_def invs_defs
-    | rule invs_def[THEN iffD2] conjI
-    | rev_drule invs_def[THEN iffD1])+)
+   apply (safe, simp_all)
+  by (clarsimp simp: peterson_rel_def set_label_def set_ab_def locked_def invs_defs
+      | rule invs_def[THEN iffD2] conjI
+      | rev_drule invs_def[THEN iffD1])+
 
 theorem abs_peterson_proc_mutual_excl:
-  "\<lbrace> \<lambda>s0 s. peterson_rel ident s0 s \<and> invs s
-            \<and> ab_label s ident = Exited \<rbrace>,
-   \<lbrace> peterson_rel (other_ident ident) \<rbrace>
-     abs_peterson_proc ident
-   \<lbrace> peterson_rel ident \<rbrace>,
-   \<lbrace> \<lambda>rv s0 s. peterson_rel ident s0 s \<and> invs s
-               \<and> ab_label s ident = Exited \<rbrace>"
+  "\<lbrace>\<lambda>s0 s. peterson_rel ident s0 s \<and> invs s \<and> ab_label s ident = Exited\<rbrace>,
+   \<lbrace>peterson_rel (other_ident ident)\<rbrace>
+   abs_peterson_proc ident
+   \<lbrace>peterson_rel ident\<rbrace>,
+   \<lbrace>\<lambda>rv s0 s. peterson_rel ident s0 s \<and> invs s \<and> ab_label s ident = Exited\<rbrace>"
   apply (simp add: abs_peterson_proc_def bind_assoc)
   apply (wpsimp wp: release_lock_mutual_excl acquire_lock_mutual_excl
                     abs_critical_section_mutual_excl)
   done
 
-definition
-  peterson_sr :: "(('a, 'b) p_state \<Rightarrow> ('a, 'b) p_state  \<Rightarrow> bool)"
-where
+definition peterson_sr :: "(('a, 'b) p_state \<Rightarrow> ('a, 'b) p_state  \<Rightarrow> bool)" where
   "peterson_sr sa sc \<equiv>
-    t_v sa = t_v sc \<and> ab_v sa = ab_v sc
-    \<and> ab_label sa = ab_label sc \<and> cs2_v sa = cs2_v sc"
+     t_v sa = t_v sc \<and> ab_v sa = ab_v sc \<and> ab_label sa = ab_label sc \<and> cs2_v sa = cs2_v sc"
 
-definition
-  peterson_sr' :: "(('a, 'b) p_state \<Rightarrow> ('a, 'b) p_state  \<Rightarrow> bool)"
-where
+definition peterson_sr' :: "(('a, 'b) p_state \<Rightarrow> ('a, 'b) p_state  \<Rightarrow> bool)" where
   "peterson_sr' sa sc \<equiv> sa = sc \<lparr> cs1_v := cs1_v sa \<rparr>"
 
-definition
-  peterson_sr_cs1 :: "(('a, 'b) p_state \<Rightarrow> ('a, 'b) p_state  \<Rightarrow> bool)"
-where
+definition peterson_sr_cs1 :: "(('a, 'b) p_state \<Rightarrow> ('a, 'b) p_state  \<Rightarrow> bool)" where
   "peterson_sr_cs1 sa sc \<equiv> peterson_sr sa sc \<and> cs1_v sa = cs1_v sc"
 
 end
+
 text \<open>
-Finally we assume that we can prove refinement for @{text cs2}, although this
-may depend on being in a state where @{term cs1_v} has been correctly
-initialised.
-\<close>
+  Finally we assume that we can prove refinement for @{text cs2}, although this
+  may depend on being in a state where @{term cs1_v} has been correctly
+  initialised.\<close>
 locale mx_locale_refine = mx_locale_wp cs1 cs2 csI for cs1 :: "'b \<Rightarrow> 'a" and cs2 and csI +
   assumes
     cs_refine:
-          "prefix_refinement peterson_sr peterson_sr_cs1 peterson_sr \<top>\<top>
-                             (\<lambda>_ s. cs1_v s = cs1 (cs2_v s)) \<top>\<top>
-                             (peterson_rel (other_ident ident)) (peterson_rel (other_ident ident))
-                             cs2 cs2"
+    "prefix_refinement peterson_sr peterson_sr_cs1 peterson_sr \<top>\<top>
+                       (\<lambda>_ s. cs1_v s = cs1 (cs2_v s)) \<top>\<top>
+                       (peterson_rel (other_ident ident)) (peterson_rel (other_ident ident))
+                       cs2 cs2"
 begin
 
 lemma
@@ -378,7 +330,7 @@ lemma
   by (auto simp: p_state.splits peterson_sr_def peterson_sr'_def intro!: ext)
 
 lemma peterson_sr_set_ab[simp]:
- "peterson_sr s t \<Longrightarrow> peterson_sr (set_ab ident v s) (set_ab ident v t)"
+  "peterson_sr s t \<Longrightarrow> peterson_sr (set_ab ident v s) (set_ab ident v t)"
   by (simp add: peterson_sr_def set_ab_def)
 
 lemma env_stable_peterson_sr:
@@ -396,10 +348,11 @@ lemma peterson_sr_equivp[simp]:
   "equivp peterson_sr"
   by (auto simp: peterson_sr_def intro!: sympI equivpI transpI)
 
-lemma peterson_sr_cs1_invs: "peterson_sr_cs1 s t \<Longrightarrow> invs s = invs t"
-   apply (auto simp: peterson_sr_def peterson_sr_cs1_def invs_def
-                     req_peterson_inv_def key_peterson_inv_def
-                     local_peterson_inv_def)[1]
+lemma peterson_sr_cs1_invs:
+  "peterson_sr_cs1 s t \<Longrightarrow> invs s = invs t"
+  apply (auto simp: peterson_sr_def peterson_sr_cs1_def invs_def
+                    req_peterson_inv_def key_peterson_inv_def
+                    local_peterson_inv_def)[1]
   done
 
 lemma env_stable_peterson_sr_cs1:
@@ -420,30 +373,30 @@ lemmas prefix_refinement_interference_peterson_cs1 =
   prefix_refinement_interference[OF env_stable_peterson_sr_cs1]
 
 lemmas prefix_refinement_bind_2left_2right
-      = prefix_refinement_bind[where a="bind a a'" and c="bind c c'" for a a' c c', simplified bind_assoc]
+  = prefix_refinement_bind[where a="bind a a'" and c="bind c c'" for a a' c c', simplified bind_assoc]
 lemmas rel_tr_refinement_bind_left_general_2left_2right
-       = rel_tr_refinement_bind_left_general[where f="bind f f'" and g="bind g g'" for f f' g g', simplified bind_assoc]
+  = rel_tr_refinement_bind_left_general[where f="bind f f'" and g="bind g g'" for f f' g g',
+                                        simplified bind_assoc]
 
 lemma peterson_rel_imp_invs:
-  "peterson_rel ident x y \<Longrightarrow> invs x \<Longrightarrow> invs y"
+  "\<lbrakk>peterson_rel ident x y; invs x\<rbrakk> \<Longrightarrow> invs y"
   by (simp add: peterson_rel_def)
 
 lemma peterson_rel_imp_label:
-  "peterson_rel (other_ident ident) x y \<Longrightarrow> invs x
+  "\<lbrakk>peterson_rel (other_ident ident) x y; invs x\<rbrakk>
    \<Longrightarrow> ab_label x ident = ab_label y ident"
   by (simp add: peterson_rel_def)
 
 lemma peterson_rel_set_label:
-  "peterson_rel (other_ident ident) (set_label ident label s) s'
-   \<Longrightarrow> invs (set_label ident label s)
+  "\<lbrakk>peterson_rel (other_ident ident) (set_label ident label s) s'; invs (set_label ident label s)\<rbrakk>
    \<Longrightarrow> ab_label s' ident = label"
   by (simp add: peterson_rel_def set_label_def)
 
 lemma acquire_lock_refinement:
   "prefix_refinement peterson_sr peterson_sr peterson_sr \<top>\<top>
-    \<top>\<top> \<top>\<top>
-    (peterson_rel (other_ident ident)) (peterson_rel (other_ident ident))
-    (acquire_lock ident) (acquire_lock ident)"
+     \<top>\<top> \<top>\<top>
+     (peterson_rel (other_ident ident)) (peterson_rel (other_ident ident))
+     (acquire_lock ident) (acquire_lock ident)"
   apply (unfold acquire_lock_def)
   apply (rule prefix_refinement_weaken_pre)
     apply (rule prefix_refinement_bind_sr)
@@ -464,11 +417,11 @@ lemma acquire_lock_refinement:
   done
 
 lemma peterson_sr_invs[simp]:
-  "peterson_sr as cs \<Longrightarrow> invs as \<Longrightarrow> invs cs"
+  "\<lbrakk>peterson_sr as cs; invs as\<rbrakk> \<Longrightarrow> invs cs"
   by (simp add: peterson_sr_def invs_def invs_defs)
 
 lemma peterson_sr_invs_sym:
-  "peterson_sr as cs \<Longrightarrow> invs cs \<Longrightarrow> invs as"
+  "\<lbrakk>peterson_sr as cs; invs cs\<rbrakk> \<Longrightarrow> invs as"
   by (simp add: peterson_sr_def invs_def invs_defs)
 
 lemma peterson_sr_ab_label:
@@ -477,9 +430,9 @@ lemma peterson_sr_ab_label:
 
 lemma critical_section_refinement:
   "prefix_refinement peterson_sr peterson_sr peterson_sr \<top>\<top>
-    (\<lambda>_ s. invs s \<and> ab_label s ident = Critical) \<top>\<top>
-    (peterson_rel (other_ident ident)) (peterson_rel (other_ident ident))
-    abs_critical_section critical_section"
+     (\<lambda>_ s. invs s \<and> ab_label s ident = Critical) \<top>\<top>
+     (peterson_rel (other_ident ident)) (peterson_rel (other_ident ident))
+     abs_critical_section critical_section"
   apply (simp add: abs_critical_section_def critical_section_def)
   apply (rule prefix_refinement_weaken_pre)
     apply (rule prefix_refinement_interferences_split)
@@ -518,9 +471,9 @@ lemma critical_section_refinement:
 
 lemma release_lock_refinement:
   "prefix_refinement peterson_sr peterson_sr peterson_sr \<top>\<top>
-    \<top>\<top> \<top>\<top>
-    (peterson_rel (other_ident ident)) (peterson_rel (other_ident ident))
-    (release_lock ident) (release_lock ident)"
+     \<top>\<top> \<top>\<top>
+     (peterson_rel (other_ident ident)) (peterson_rel (other_ident ident))
+     (release_lock ident) (release_lock ident)"
   apply (unfold release_lock_def)
   apply (rule prefix_refinement_weaken_pre)
     apply (simp add: modify_modify_bind)
@@ -542,21 +495,21 @@ lemma abs_critical_section_prefix_closed[simp]:
            simp: cs_closed abs_critical_section_def)
 
 lemma peterson_rel_trans:
- "peterson_rel ident x y \<Longrightarrow> peterson_rel ident y z \<Longrightarrow>
-  peterson_rel ident x z"
- by (clarsimp simp: peterson_rel_def)
+  "\<lbrakk>peterson_rel ident x y; peterson_rel ident y z\<rbrakk>
+   \<Longrightarrow> peterson_rel ident x z"
+  by (clarsimp simp: peterson_rel_def)
 
 lemma invs_set_label_Critical:
-  "invs s \<Longrightarrow> locked ident s \<Longrightarrow> ab_label s ident = Awaiting
+  "\<lbrakk>invs s; locked ident s; ab_label s ident = Awaiting\<rbrakk>
    \<Longrightarrow> invs (set_label ident Critical s)"
   by (auto simp: invs_def invs_defs set_label_def locked_def)
 
 lemma acquire_lock_wp:
-  "\<lbrace> \<lambda>s0 s. invs s \<and> ab_label s ident = Exited \<rbrace>,
-   \<lbrace> peterson_rel (other_ident ident) \<rbrace>
-     acquire_lock ident
-   \<lbrace> \<top>\<top> \<rbrace>,
-   \<lbrace> \<lambda>rv s0 s. invs s \<and> ab_label s ident = Critical \<rbrace>"
+  "\<lbrace>\<lambda>s0 s. invs s \<and> ab_label s ident = Exited\<rbrace>,
+   \<lbrace>peterson_rel (other_ident ident)\<rbrace>
+   acquire_lock ident
+   \<lbrace>\<top>\<top>\<rbrace>,
+   \<lbrace>\<lambda>rv s0 s. invs s \<and> ab_label s ident = Critical\<rbrace>"
   apply (simp add: acquire_lock_def)
   apply (wpsimp wp: Await_sync_twp)
   apply (subst (asm) peterson_rel_imp_label, assumption+)
@@ -580,14 +533,14 @@ lemma acquire_lock_prefix_closed[simp]:
 
 theorem peterson_proc_refinement:
   "prefix_refinement peterson_sr peterson_sr peterson_sr \<top>\<top>
-    (\<lambda>_ s. invs s \<and> ab_label s ident = Exited)
-    (\<lambda>_ s. invs s \<and> ab_label s ident = Exited)
-    (peterson_rel (other_ident ident)) (peterson_rel (other_ident ident))
-    (abs_peterson_proc ident)
-    (peterson_proc ident)"
- apply (simp add: abs_peterson_proc_def peterson_proc_def)
-   apply (rule prefix_refinement_weaken_pre)
-   apply (rule prefix_refinement_bind_sr)
+     (\<lambda>_ s. invs s \<and> ab_label s ident = Exited)
+     (\<lambda>_ s. invs s \<and> ab_label s ident = Exited)
+     (peterson_rel (other_ident ident)) (peterson_rel (other_ident ident))
+     (abs_peterson_proc ident)
+     (peterson_proc ident)"
+  apply (simp add: abs_peterson_proc_def peterson_proc_def)
+  apply (rule prefix_refinement_weaken_pre)
+    apply (rule prefix_refinement_bind_sr)
        apply (rule acquire_lock_refinement)
       apply (rule prefix_refinement_bind_sr)
          apply (rule critical_section_refinement)
@@ -596,28 +549,25 @@ theorem peterson_proc_refinement:
                      simp: pred_conj_def)+
   done
 
-definition
-  peterson_rel2 :: "ident \<Rightarrow> ('a, 'b) p_state \<Rightarrow> ('a, 'b) p_state \<Rightarrow> bool"
-where
-  "peterson_rel2 ident s_prior s = (\<comment> \<open>assume invs\<close> invs s_prior \<longrightarrow>
-            \<comment> \<open>If you're in the critical section, I won't change cs1_v\<close>
-        (critical (ab_label s_prior (other_ident ident))
-                \<longrightarrow> cs1_v s = cs1_v s_prior))"
+definition peterson_rel2 :: "ident \<Rightarrow> ('a, 'b) p_state \<Rightarrow> ('a, 'b) p_state \<Rightarrow> bool" where
+  "peterson_rel2 ident s_prior s =
+     (\<comment> \<open>assume invs\<close> invs s_prior \<longrightarrow>
+        \<comment> \<open>If you're in the critical section, I won't change cs1_v\<close>
+        (critical (ab_label s_prior (other_ident ident)) \<longrightarrow> cs1_v s = cs1_v s_prior))"
 
-definition
-  peterson_rel3 :: "ident \<Rightarrow> ('a, 'b) p_state \<Rightarrow> ('a, 'b) p_state \<Rightarrow> bool"
-where
-  "peterson_rel3 ident s_prior s = (\<comment> \<open>assume invs\<close> invs s_prior \<longrightarrow>
-            \<comment> \<open>invariants are preserved\<close>
+definition peterson_rel3 :: "ident \<Rightarrow> ('a, 'b) p_state \<Rightarrow> ('a, 'b) p_state \<Rightarrow> bool" where
+  "peterson_rel3 ident s_prior s =
+     (\<comment> \<open>assume invs\<close> invs s_prior \<longrightarrow>
+         \<comment> \<open>invariants are preserved\<close>
         (invs s
             \<comment> \<open>I won't adjust your variables\<close>
-        \<and> (ab_v s (other_ident ident) = ab_v s_prior (other_ident ident))
-        \<and> (ab_label s (other_ident ident) = ab_label s_prior (other_ident ident))
+         \<and> (ab_v s (other_ident ident) = ab_v s_prior (other_ident ident))
+         \<and> (ab_label s (other_ident ident) = ab_label s_prior (other_ident ident))
             \<comment> \<open>I will only ever give you priority\<close>
-        \<and> (t_v s_prior = other_ident ident \<longrightarrow> t_v s = other_ident ident)
+         \<and> (t_v s_prior = other_ident ident \<longrightarrow> t_v s = other_ident ident)
             \<comment> \<open>If you're in the critical section, I won't change cs2_v\<close>
-        \<and> (critical (ab_label s_prior (other_ident ident))
-                \<longrightarrow> cs2_v s = cs2_v s_prior)))"
+         \<and> (critical (ab_label s_prior (other_ident ident))
+              \<longrightarrow> cs2_v s = cs2_v s_prior)))"
 
 lemma peterson_rel_helpers:
   "peterson_rel2 ident s0 s \<and> peterson_rel3 ident s0 s
@@ -629,8 +579,8 @@ lemma peterson_rel_peterson_rel2:
   by (clarsimp simp: peterson_rel_def peterson_rel2_def)
 
 lemma peterson_sr_peterson_rel3:
-  "peterson_sr as0 cs0 \<Longrightarrow> peterson_sr as cs
-   \<Longrightarrow> peterson_rel ident as0 as \<Longrightarrow> peterson_rel3 ident cs0 cs"
+  "\<lbrakk>peterson_sr as0 cs0; peterson_sr as cs; peterson_rel ident as0 as\<rbrakk>
+   \<Longrightarrow> peterson_rel3 ident cs0 cs"
   apply (clarsimp simp: peterson_rel_def peterson_rel3_def invs_def
                         invs_defs peterson_sr_ab_label)
   apply (clarsimp simp: peterson_sr_def)
@@ -642,13 +592,11 @@ lemma peterson_proc_prefix_closed[simp]:
            simp: cs_closed peterson_proc_def acquire_lock_def release_lock_def)
 
 lemma peterson_proc_mutual_excl_helper:
-  "\<lbrace> \<lambda>s0 s. peterson_rel ident s0 s \<and> invs s
-            \<and> ab_label s ident = Exited \<rbrace>,
-   \<lbrace> peterson_rel (other_ident ident) \<rbrace>
-     peterson_proc ident
-   \<lbrace> peterson_rel3 ident \<rbrace>,
-   \<lbrace> \<lambda>rv s0 s. peterson_rel3 ident s0 s \<and> invs s
-               \<and> ab_label s ident = Exited \<rbrace>"
+  "\<lbrace>\<lambda>s0 s. peterson_rel ident s0 s \<and> invs s \<and> ab_label s ident = Exited\<rbrace>,
+   \<lbrace>peterson_rel (other_ident ident)\<rbrace>
+   peterson_proc ident
+   \<lbrace>peterson_rel3 ident\<rbrace>,
+   \<lbrace>\<lambda>rv s0 s. peterson_rel3 ident s0 s \<and> invs s \<and> ab_label s ident = Exited\<rbrace>"
   apply (rule prefix_refinement_validI')
         apply (rule peterson_proc_refinement)
        apply (rule abs_peterson_proc_mutual_excl)
@@ -665,13 +613,11 @@ lemma peterson_proc_mutual_excl_helper:
   done
 
 lemma peterson_proc_mutual_excl_helper':
-  "\<lbrace> \<lambda>s0 s. peterson_rel ident s0 s \<and> invs s
-            \<and> ab_label s ident = Exited \<rbrace>,
-   \<lbrace> peterson_rel (other_ident ident) \<rbrace>
-     peterson_proc ident
-   \<lbrace> peterson_rel2 ident \<rbrace>,
-   \<lbrace> \<lambda>rv s0 s. peterson_rel2 ident s0 s \<and> invs s
-               \<and> ab_label s ident = Exited \<rbrace>"
+  "\<lbrace>\<lambda>s0 s. peterson_rel ident s0 s \<and> invs s \<and> ab_label s ident = Exited\<rbrace>,
+   \<lbrace>peterson_rel (other_ident ident)\<rbrace>
+   peterson_proc ident
+   \<lbrace>peterson_rel2 ident\<rbrace>,
+   \<lbrace>\<lambda>rv s0 s. peterson_rel2 ident s0 s \<and> invs s \<and> ab_label s ident = Exited\<rbrace>"
   apply (simp add: peterson_proc_def acquire_lock_def release_lock_def
                    critical_section_def)
   apply (wp Await_sync_twp | simp add: split_def
@@ -679,34 +625,32 @@ lemma peterson_proc_mutual_excl_helper':
   apply (clarsimp simp: imp_conjL)
   apply (strengthen peterson_rel_imp_assume_invs | simp)+
   apply (cases ident)
-  apply (safe, simp_all)
-  by ((clarsimp simp: peterson_rel_def peterson_rel2_def forall_ident_eq
-                      set_label_def set_ab_def locked_def invs_defs cs_closed
-    | rule invs_def[THEN iffD2] conjI
-    | rev_drule invs_def[THEN iffD1])+)
+   apply (safe, simp_all)
+  by (clarsimp simp: peterson_rel_def peterson_rel2_def forall_ident_eq
+                     set_label_def set_ab_def locked_def invs_defs cs_closed
+      | rule invs_def[THEN iffD2] conjI
+      | rev_drule invs_def[THEN iffD1])+
 
 lemma peterson_proc_mutual_excl:
-  "\<lbrace> \<lambda>s0 s. peterson_rel ident s0 s \<and> invs s
-            \<and> ab_label s ident = Exited \<rbrace>,
-   \<lbrace> peterson_rel (other_ident ident) \<rbrace>
-     peterson_proc ident
-   \<lbrace> peterson_rel ident \<rbrace>,
-   \<lbrace> \<lambda>rv s0 s. peterson_rel ident s0 s \<and> invs s
-               \<and> ab_label s ident = Exited \<rbrace>"
+  "\<lbrace>\<lambda>s0 s. peterson_rel ident s0 s \<and> invs s \<and> ab_label s ident = Exited\<rbrace>,
+   \<lbrace>peterson_rel (other_ident ident)\<rbrace>
+   peterson_proc ident
+   \<lbrace>peterson_rel ident\<rbrace>,
+   \<lbrace>\<lambda>rv s0 s. peterson_rel ident s0 s \<and> invs s \<and> ab_label s ident = Exited\<rbrace>"
   apply (rule rg_strengthen_guar, rule rg_strengthen_post, rule validI_guar_post_conj_lift)
      apply (rule peterson_proc_mutual_excl_helper)
     apply (rule peterson_proc_mutual_excl_helper')
    apply (clarsimp simp: peterson_rel_helpers)+
   done
 
-definition "abs_peterson_proc_system \<equiv>
+definition
+  "abs_peterson_proc_system \<equiv>
      parallel (do repeat (abs_peterson_proc A); interference od)
               (do repeat (abs_peterson_proc B); interference od)"
 
 lemma validI_repeat_interference:
-  "\<lbrace>P\<rbrace>, \<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>, \<lbrace>\<lambda>_. P\<rbrace>
-   \<Longrightarrow> \<forall>s0 s. P s0 s \<longrightarrow> (\<forall>s'. R\<^sup>*\<^sup>* s s' \<longrightarrow> Q () s' s') \<and> G s0 s
-   \<Longrightarrow> \<lbrace>P\<rbrace>, \<lbrace>R\<rbrace> do repeat f; interference od \<lbrace>G\<rbrace>, \<lbrace>Q\<rbrace>"
+  "\<lbrakk>\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_. P\<rbrace>; \<forall>s0 s. P s0 s \<longrightarrow> (\<forall>s'. R\<^sup>*\<^sup>* s s' \<longrightarrow> Q () s' s') \<and> G s0 s\<rbrakk>
+   \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> do repeat f; interference od \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
   apply (rule bind_twp)
    apply simp
    apply (rule interference_twp)
@@ -716,11 +660,11 @@ lemma validI_repeat_interference:
   done
 
 lemma abs_peterson_proc_system_mutual_excl:
-  "\<lbrace> \<lambda>s0 s. s0 = s \<and> invs s \<and> ab_label s = (\<lambda>_. Exited) \<rbrace>,
-   \<lbrace> \<lambda>s0 s. s0 = s \<rbrace>
-     abs_peterson_proc_system
-   \<lbrace> \<lambda>s0 s. invs s0 \<longrightarrow> invs s \<rbrace>,
-   \<lbrace> \<lambda>rv s0 s. invs s \<rbrace>"
+  "\<lbrace>\<lambda>s0 s. s0 = s \<and> invs s \<and> ab_label s = (\<lambda>_. Exited)\<rbrace>,
+   \<lbrace>\<lambda>s0 s. s0 = s\<rbrace>
+   abs_peterson_proc_system
+   \<lbrace>\<lambda>s0 s. invs s0 \<longrightarrow> invs s\<rbrace>,
+   \<lbrace>\<lambda>rv s0 s. invs s\<rbrace>"
   apply (rule rg_weaken_pre, rule rg_strengthen_post)
     apply (unfold abs_peterson_proc_system_def)
     apply (rule rg_validI[where Qf="\<lambda>_ _. invs" and Qg="\<lambda>_ _. invs"])
@@ -729,10 +673,11 @@ lemma abs_peterson_proc_system_mutual_excl:
           apply (rule validI_repeat_interference[OF abs_peterson_proc_mutual_excl])
           apply (clarsimp simp: peterson_rel_imp_invs)
          apply (simp add: reflp_ge_eq)+
-  apply (clarsimp simp: peterson_rel_def)+
+       apply (clarsimp simp: peterson_rel_def)+
   done
 
-definition "peterson_proc_system \<equiv>
+definition
+  "peterson_proc_system \<equiv>
      parallel (do repeat (peterson_proc A); interference od)
               (do repeat (peterson_proc B); interference od)"
 
@@ -743,15 +688,15 @@ lemma abs_peterson_proc_prefix_closed[simp]:
 
 lemma peterson_repeat_refinement:
   "prefix_refinement peterson_sr peterson_sr peterson_sr \<top>\<top>
-    (\<lambda>s0 s. peterson_rel ident s0 s \<and> invs s \<and> ab_label s ident = Exited)
-    (\<lambda>s0 s. peterson_rel ident s0 s \<and> invs s \<and> ab_label s ident = Exited)
-    (peterson_rel (other_ident ident)) (peterson_rel (other_ident ident))
-    (do repeat (abs_peterson_proc ident);
-        interference
-     od)
-    (do repeat (peterson_proc ident);
-        interference
-     od)"
+     (\<lambda>s0 s. peterson_rel ident s0 s \<and> invs s \<and> ab_label s ident = Exited)
+     (\<lambda>s0 s. peterson_rel ident s0 s \<and> invs s \<and> ab_label s ident = Exited)
+     (peterson_rel (other_ident ident)) (peterson_rel (other_ident ident))
+     (do repeat (abs_peterson_proc ident);
+         interference
+      od)
+     (do repeat (peterson_proc ident);
+         interference
+      od)"
   apply (rule prefix_refinement_weaken_pre)
     apply (rule prefix_refinement_bind_sr)
        apply (rule prefix_refinement_repeat[rotated])
@@ -767,10 +712,10 @@ lemma peterson_repeat_refinement:
 
 theorem peterson_proc_system_refinement:
   "prefix_refinement peterson_sr peterson_sr peterson_sr \<top>\<top>
-    (\<lambda>s0 s. s0 = s \<and> invs s \<and> ab_label s = (\<lambda>_. Exited))
-    (\<lambda>t0 t. t0 = t \<and> invs t \<and> ab_label t = (\<lambda>_. Exited))
-    (\<lambda>s0 s. s0 = s) (\<lambda>t0 t. t0 = t)
-    abs_peterson_proc_system peterson_proc_system"
+     (\<lambda>s0 s. s0 = s \<and> invs s \<and> ab_label s = (\<lambda>_. Exited))
+     (\<lambda>t0 t. t0 = t \<and> invs t \<and> ab_label t = (\<lambda>_. Exited))
+     (\<lambda>s0 s. s0 = s) (\<lambda>t0 t. t0 = t)
+     abs_peterson_proc_system peterson_proc_system"
   apply (unfold abs_peterson_proc_system_def peterson_proc_system_def)
   apply (rule prefix_refinement_parallel')
          apply (rule prefix_refinement_weaken_rely, rule prefix_refinement_weaken_pre)
@@ -795,7 +740,7 @@ theorem peterson_proc_system_refinement:
       apply (rule validI_repeat_interference; simp)
        apply (rule peterson_proc_mutual_excl)
       apply (simp+)[3]
-  apply (rule rg_weaken_pre, rule rg_weaken_rely)
+   apply (rule rg_weaken_pre, rule rg_weaken_rely)
      apply (rule validI_repeat_interference; simp)
       apply (rule abs_peterson_proc_mutual_excl)
      apply (simp+)[3]
@@ -811,11 +756,11 @@ lemma peterson_proc_system_prefix_closed[simp]:
              simp: cs_closed peterson_proc_system_def)
 
 theorem peterson_proc_system_mutual_excl:
-  "\<lbrace> \<lambda>s0 s. s0 = s \<and> invs s \<and> ab_label s = (\<lambda>_. Exited) \<rbrace>,
-   \<lbrace> \<lambda>s0 s. s0 = s \<rbrace>
-     peterson_proc_system
-   \<lbrace> \<lambda>s0 s. invs s0 \<longrightarrow> invs s \<rbrace>,
-   \<lbrace> \<lambda>rv s0 s. invs s \<rbrace>"
+  "\<lbrace>\<lambda>s0 s. s0 = s \<and> invs s \<and> ab_label s = (\<lambda>_. Exited)\<rbrace>,
+   \<lbrace>\<lambda>s0 s. s0 = s\<rbrace>
+   peterson_proc_system
+   \<lbrace>\<lambda>s0 s. invs s0 \<longrightarrow> invs s\<rbrace>,
+   \<lbrace>\<lambda>rv s0 s. invs s\<rbrace>"
   apply (rule prefix_refinement_validI')
         apply (rule peterson_proc_system_refinement)
        apply (rule abs_peterson_proc_system_mutual_excl)

--- a/lib/concurrency/examples/Peterson_Atomicity.thy
+++ b/lib/concurrency/examples/Peterson_Atomicity.thy
@@ -320,8 +320,8 @@ locale mx_locale_refine = mx_locale_wp cs1 cs2 csI for cs1 :: "'b \<Rightarrow> 
   assumes
     cs_refine:
     "prefix_refinement peterson_sr peterson_sr_cs1 peterson_sr \<top>\<top>
-                       (\<lambda>_ s. cs1_v s = cs1 (cs2_v s)) \<top>\<top>
                        (peterson_rel (other_ident ident)) (peterson_rel (other_ident ident))
+                       (\<lambda>_ s. cs1_v s = cs1 (cs2_v s)) \<top>\<top>
                        cs2 cs2"
 begin
 
@@ -394,8 +394,8 @@ lemma peterson_rel_set_label:
 
 lemma acquire_lock_refinement:
   "prefix_refinement peterson_sr peterson_sr peterson_sr \<top>\<top>
-     \<top>\<top> \<top>\<top>
      (peterson_rel (other_ident ident)) (peterson_rel (other_ident ident))
+     \<top>\<top> \<top>\<top>
      (acquire_lock ident) (acquire_lock ident)"
   apply (unfold acquire_lock_def)
   apply (rule prefix_refinement_weaken_pre)
@@ -430,8 +430,8 @@ lemma peterson_sr_ab_label:
 
 lemma critical_section_refinement:
   "prefix_refinement peterson_sr peterson_sr peterson_sr \<top>\<top>
-     (\<lambda>_ s. invs s \<and> ab_label s ident = Critical) \<top>\<top>
      (peterson_rel (other_ident ident)) (peterson_rel (other_ident ident))
+     (\<lambda>_ s. invs s \<and> ab_label s ident = Critical) \<top>\<top>
      abs_critical_section critical_section"
   apply (simp add: abs_critical_section_def critical_section_def)
   apply (rule prefix_refinement_weaken_pre)
@@ -471,8 +471,8 @@ lemma critical_section_refinement:
 
 lemma release_lock_refinement:
   "prefix_refinement peterson_sr peterson_sr peterson_sr \<top>\<top>
-     \<top>\<top> \<top>\<top>
      (peterson_rel (other_ident ident)) (peterson_rel (other_ident ident))
+     \<top>\<top> \<top>\<top>
      (release_lock ident) (release_lock ident)"
   apply (unfold release_lock_def)
   apply (rule prefix_refinement_weaken_pre)
@@ -533,9 +533,9 @@ lemma acquire_lock_prefix_closed[simp]:
 
 theorem peterson_proc_refinement:
   "prefix_refinement peterson_sr peterson_sr peterson_sr \<top>\<top>
-     (\<lambda>_ s. invs s \<and> ab_label s ident = Exited)
-     (\<lambda>_ s. invs s \<and> ab_label s ident = Exited)
      (peterson_rel (other_ident ident)) (peterson_rel (other_ident ident))
+     (\<lambda>_ s. invs s \<and> ab_label s ident = Exited)
+     (\<lambda>_ s. invs s \<and> ab_label s ident = Exited)
      (abs_peterson_proc ident)
      (peterson_proc ident)"
   apply (simp add: abs_peterson_proc_def peterson_proc_def)
@@ -688,9 +688,9 @@ lemma abs_peterson_proc_prefix_closed[simp]:
 
 lemma peterson_repeat_refinement:
   "prefix_refinement peterson_sr peterson_sr peterson_sr \<top>\<top>
-     (\<lambda>s0 s. peterson_rel ident s0 s \<and> invs s \<and> ab_label s ident = Exited)
-     (\<lambda>s0 s. peterson_rel ident s0 s \<and> invs s \<and> ab_label s ident = Exited)
      (peterson_rel (other_ident ident)) (peterson_rel (other_ident ident))
+     (\<lambda>s0 s. peterson_rel ident s0 s \<and> invs s \<and> ab_label s ident = Exited)
+     (\<lambda>s0 s. peterson_rel ident s0 s \<and> invs s \<and> ab_label s ident = Exited)
      (do repeat (abs_peterson_proc ident);
          interference
       od)
@@ -712,9 +712,9 @@ lemma peterson_repeat_refinement:
 
 theorem peterson_proc_system_refinement:
   "prefix_refinement peterson_sr peterson_sr peterson_sr \<top>\<top>
+     (\<lambda>s0 s. s0 = s) (\<lambda>t0 t. t0 = t)
      (\<lambda>s0 s. s0 = s \<and> invs s \<and> ab_label s = (\<lambda>_. Exited))
      (\<lambda>t0 t. t0 = t \<and> invs t \<and> ab_label t = (\<lambda>_. Exited))
-     (\<lambda>s0 s. s0 = s) (\<lambda>t0 t. t0 = t)
      abs_peterson_proc_system peterson_proc_system"
   apply (unfold abs_peterson_proc_system_def peterson_proc_system_def)
   apply (rule prefix_refinement_parallel')

--- a/lib/concurrency/examples/Plus2_Prefix.thy
+++ b/lib/concurrency/examples/Plus2_Prefix.thy
@@ -113,11 +113,11 @@ lemma env_stable:
   done
 
 abbreviation (input)
-  "p_refn rvr P Q AR R \<equiv>
-     prefix_refinement (\<lambda>s t. t = mainv s) (\<lambda>s t. t = mainv s) (\<lambda>s t. t = mainv s) rvr P Q AR R"
+  "p_refn rvr AR R P Q \<equiv>
+     prefix_refinement (\<lambda>s t. t = mainv s) (\<lambda>s t. t = mainv s) (\<lambda>s t. t = mainv s) rvr AR R P Q"
 
 theorem pfx_refn_plus2_x:
-  "p_refn (\<top>\<top>) (=) (\<top>\<top>) AR R (plus2_x tid) plus2"
+  "p_refn (\<top>\<top>) AR R (=) (\<top>\<top>) (plus2_x tid) plus2"
   apply (simp add: plus2_x_def plus2_def)
   apply (rule prefix_refinement_weaken_pre)
     apply (rule pfx_refn_bind prefix_refinement_interference
@@ -215,11 +215,11 @@ lemma bipred_disj_top_eq:
   by auto
 
 lemma fold_parallel_pfx_refn_induct:
-  "\<lbrakk>list_all2 (prefix_refinement sr sr sr (\<lambda>_ _. True) P Q (\<top>\<top>) (\<top>\<top>)) xs ys;
-    prefix_refinement sr sr sr (\<lambda>_ _. True) P Q (\<top>\<top>) (\<top>\<top>) x y;
+  "\<lbrakk>list_all2 (prefix_refinement sr sr sr (\<lambda>_ _. True) (\<top>\<top>) (\<top>\<top>) P Q) xs ys;
+    prefix_refinement sr sr sr (\<lambda>_ _. True) (\<top>\<top>) (\<top>\<top>) P Q x y;
     \<forall>x \<in> set (x # xs). par_tr_fin_principle x;
     \<forall>y \<in> set (y # ys). prefix_closed y\<rbrakk>
-   \<Longrightarrow> prefix_refinement sr sr sr (\<lambda>_ _. True) P Q (\<top>\<top>) (\<top>\<top>)
+   \<Longrightarrow> prefix_refinement sr sr sr (\<lambda>_ _. True) (\<top>\<top>) (\<top>\<top>) P Q
          (fold parallel (rev xs) x) (fold parallel (rev ys) y)"
   apply (induct rule: list_all2_induct; simp)
   apply (rule prefix_refinement_parallel_triv[simplified bipred_disj_top_eq]; simp?)

--- a/lib/concurrency/examples/Plus2_Prefix.thy
+++ b/lib/concurrency/examples/Plus2_Prefix.thy
@@ -24,7 +24,13 @@ text \<open>
 
   We address the issue with a ghost variable which records the number
   of increments by each thread. We use prefix refinement to relate the
-  program with ghost variable to the initial program.\<close>
+  program with ghost variable to the initial program.
+
+  Note that the programs defined here begin with an @{const env_steps}
+  and ends with @{const interference}. This is required so that they
+  can be combined with @{const parallel}; without these steps the
+  traces would not be able to be matched up and the composed program
+  would be trivially empty.\<close>
 
 definition
   "plus2 \<equiv> do


### PR DESCRIPTION
This roughly follows the structure and naming conventions of the `corres_underlying` rule set, as in `Corres.thy` and `ExtraCorres.thy`.