### PR TITLE
aarch64 crefine: update to match other arches

### DIFF
--- a/proof/crefine/AARCH64/VSpace_C.thy
+++ b/proof/crefine/AARCH64/VSpace_C.thy
@@ -335,7 +335,7 @@ lemma corres_symb_exec_unknown_r:
   assumes "\<And>rv. corres_underlying sr nf nf' r P P' a (c rv)"
   shows "corres_underlying sr nf nf' r P P' a (unknown >>= c)"
   apply (simp add: unknown_def)
-  apply (rule corres_symb_exec_r[OF assms]; wp select_inv no_fail_select)
+  apply (rule corres_symb_exec_r[OF assms]; wp select_inv)
   done
 
 lemma isPageTablePTE_def2:


### PR DESCRIPTION
This was a change made in https://github.com/seL4/l4v/commit/146eaa10fc2b3a41d26617b60571eb274535234e, as part of https://github.com/seL4/l4v/pull/696.