### PR TITLE
Remove hoare_vcg_precond_imp from wp_comb

### DIFF
--- a/proof/access-control/ARM/ArchFinalise_AC.thy
+++ b/proof/access-control/ARM/ArchFinalise_AC.thy
@@ -107,7 +107,7 @@ lemma finalise_cap_fst_ret[Finalise_AC_assms]:
   "\<lbrace>\<lambda>_. P NullCap \<and> (\<forall>a b c. P (Zombie a b c))\<rbrace>
    finalise_cap cap is_final
    \<lbrace>\<lambda>rv _. P (fst rv)\<rbrace>"
-  including no_pre
+  including classic_wp_pre
   apply (cases cap, simp_all add: arch_finalise_cap_def split del: if_split)
   apply (wp | simp add: comp_def split del: if_split | fastforce)+
   apply (rule hoare_pre)

--- a/proof/access-control/ARM/ArchRetype_AC.thy
+++ b/proof/access-control/ARM/ArchRetype_AC.thy
@@ -98,7 +98,7 @@ lemma copy_global_mappings_integrity:
        \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (rule hoare_gen_asm)
   apply (simp add: copy_global_mappings_def)
-  apply (wp mapM_x_wp[OF _ subset_refl] store_pde_respects)
+  apply (wp mapM_x_wp[OF _ subset_refl] store_pde_respects)+
     apply (drule subsetD[OF copy_global_mappings_index_subset])
     apply (fastforce simp: pd_shifting')
    apply wpsimp+
@@ -329,8 +329,7 @@ lemma dmo_freeMemory_respects[Retype_AC_assms]:
   apply wp
   apply clarsimp
   apply (erule use_valid)
-   apply (wp mol_respects mapM_x_wp' storeWord_integrity_autarch)
-   apply simp
+   apply (wpsimp wp: mol_respects mapM_x_wp' storeWord_integrity_autarch)
    apply (clarsimp simp: word_size_def word_bits_def word_size_bits_def
                          upto_enum_step_shift_red[where us=2, simplified])
    apply (erule bspec)

--- a/proof/access-control/DomainSepInv.thy
+++ b/proof/access-control/DomainSepInv.thy
@@ -452,7 +452,7 @@ lemma finalise_cap_domain_sep_inv_cap:
   "\<lbrace>\<lambda>s. domain_sep_inv_cap irqs cap\<rbrace>
    finalise_cap cap b
    \<lbrace>\<lambda>rv s :: det_ext state. domain_sep_inv_cap irqs (fst rv)\<rbrace>"
-  including no_pre
+  including classic_wp_pre
   apply (case_tac cap)
              apply (wp | simp add: o_def split del: if_split  split: cap.splits
                        | fastforce split: if_splits simp: domain_sep_inv_cap_def)+
@@ -784,7 +784,7 @@ lemma invoke_control_domain_sep_inv:
   "\<lbrace>domain_sep_inv irqs st and irq_control_inv_valid i\<rbrace>
     invoke_irq_control i
    \<lbrace>\<lambda>_ s. domain_sep_inv irqs (st :: 'state_ext state) (s :: det_ext state)\<rbrace>"
-  including no_pre
+  including classic_wp_pre
   apply (case_tac i)
    apply (case_tac irqs)
     apply (wp cap_insert_domain_sep_inv' | simp )+

--- a/proof/access-control/Finalise_AC.thy
+++ b/proof/access-control/Finalise_AC.thy
@@ -700,7 +700,7 @@ lemma finalise_cap_auth':
   "\<lbrace>pas_refined aag and K (pas_cap_cur_auth aag cap)\<rbrace>
    finalise_cap cap final
    \<lbrace>\<lambda>rv _. pas_cap_cur_auth aag (fst rv)\<rbrace>"
-  including no_pre
+  including classic_wp_pre
   apply (rule hoare_gen_asm)
   apply (cases cap, simp_all split del: if_split)
              apply (wp | simp add: comp_def hoare_post_taut[where P = \<top>] split del: if_split

--- a/proof/access-control/Ipc_AC.thy
+++ b/proof/access-control/Ipc_AC.thy
@@ -1781,7 +1781,7 @@ lemma cap_insert_ext_integrity_in_ipc_autarch:
    apply (clarsimp simp: integrity_tcb_in_ipc_def integrity_def
                          tcb_states_of_state_def get_tcb_def
               split del: if_split cong: if_cong)
-   including no_pre
+   including classic_wp_pre
    apply wp
    apply (rule hoare_vcg_conj_lift)
     apply (simp add: list_integ_def del: split_paired_All)
@@ -2655,7 +2655,7 @@ lemma empty_slot_respects_in_ipc_autarch:
   unfolding empty_slot_def post_cap_deletion_def
   apply simp
   apply (wp add: set_cap_respects_in_ipc_autarch set_original_respects_in_ipc_autarch)
-       apply (wp empty_slot_extended_list_integ_lift_in_ipc empty_slot_list_integrity')
+       apply (wpsimp wp: empty_slot_extended_list_integ_lift_in_ipc empty_slot_list_integrity')
           apply simp
          apply wp+
       apply (wp set_cdt_empty_slot_respects_in_ipc_autarch)

--- a/proof/access-control/RISCV64/ArchFinalise_AC.thy
+++ b/proof/access-control/RISCV64/ArchFinalise_AC.thy
@@ -280,7 +280,7 @@ lemma finalise_cap_fst_ret[Finalise_AC_assms]:
   "\<lbrace>\<lambda>_. P NullCap \<and> (\<forall>a b c. P (Zombie a b c))\<rbrace>
    finalise_cap cap is_final
    \<lbrace>\<lambda>rv _. P (fst rv)\<rbrace>"
-  including no_pre
+  including classic_wp_pre
   apply (cases cap, simp_all add: arch_finalise_cap_def split del: if_split)
   apply (wp | simp add: comp_def split del: if_split | fastforce)+
   apply (rule hoare_pre)

--- a/proof/access-control/RISCV64/ArchRetype_AC.thy
+++ b/proof/access-control/RISCV64/ArchRetype_AC.thy
@@ -292,8 +292,7 @@ lemma dmo_freeMemory_respects[Retype_AC_assms]:
   apply wp
   apply clarsimp
   apply (erule use_valid)
-   apply (wp mol_respects mapM_x_wp' storeWord_integrity_autarch)
-   apply simp
+   apply (wpsimp wp: mol_respects mapM_x_wp' storeWord_integrity_autarch)
    apply (clarsimp simp: word_size_def word_size_bits_def word_bits_def
                          upto_enum_step_shift_red[where us=3, simplified])
    apply (erule bspec)

--- a/proof/access-control/Retype_AC.thy
+++ b/proof/access-control/Retype_AC.thy
@@ -497,7 +497,7 @@ lemma retype_region_ext_pas_refined:
   "\<lbrace>pas_refined aag and pas_cur_domain aag and K (\<forall>x\<in> set xs. is_subject aag x)\<rbrace>
    retype_region_ext xs ty
    \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
-  including no_pre
+  including classic_wp_pre
   apply (subst and_assoc[symmetric])
   apply (wp retype_region_ext_extended.pas_refined_tcb_domain_map_wellformed')
   apply (simp add: retype_region_ext_def, wp)

--- a/proof/crefine/AARCH64/Fastpath_Equiv.thy
+++ b/proof/crefine/AARCH64/Fastpath_Equiv.thy
@@ -755,8 +755,7 @@ lemma fastpath_callKernel_SysCall_corres:
                               apply ((wp assert_inv threadSet_pred_tcb_at_state cteInsert_obj_at'_not_queued | wps)+)[1]
                              apply ((wp assert_inv threadSet_pred_tcb_at_state cteInsert_obj_at'_not_queued | wps)+)[1]
                             apply ((wp assert_inv threadSet_pred_tcb_at_state cteInsert_obj_at'_not_queued | wps)+)[1]
-                            apply (wp fastpathBestSwitchCandidate_lift[where f="threadSet f t" for f t])
-                             apply simp
+                            apply (wpsimp wp: fastpathBestSwitchCandidate_lift[where f="threadSet f t" for f t])
                             apply ((wp assert_inv threadSet_pred_tcb_at_state
                                        cteInsert_obj_at'_not_queued
                                     | wps)+)[1]
@@ -1494,7 +1493,7 @@ lemma fastpath_callKernel_SysReplyRecv_corres:
      (invs' and ct_in_state' ((=) Running) and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread)
          and cnode_caps_gsCNodes')
      (callKernel (SyscallEvent SysReplyRecv)) (fastpaths SysReplyRecv)"
-  including no_pre
+  including classic_wp_pre
   supply if_cong[cong] option.case_cong[cong]
   supply if_split[split del]
   supply user_getreg_inv[wp] (* FIXME *)

--- a/proof/crefine/ARM/Fastpath_Equiv.thy
+++ b/proof/crefine/ARM/Fastpath_Equiv.thy
@@ -661,8 +661,7 @@ lemma fastpath_callKernel_SysCall_corres:
                               apply ((wp assert_inv threadSet_pred_tcb_at_state cteInsert_obj_at'_not_queued | wps)+)[1]
                              apply ((wp assert_inv threadSet_pred_tcb_at_state cteInsert_obj_at'_not_queued | wps)+)[1]
                             apply ((wp assert_inv threadSet_pred_tcb_at_state cteInsert_obj_at'_not_queued | wps)+)[1]
-                            apply (wp fastpathBestSwitchCandidate_lift[where f="threadSet f t" for f t])
-                             apply simp
+                            apply (wpsimp wp: fastpathBestSwitchCandidate_lift[where f="threadSet f t" for f t])
                             apply ((wp assert_inv threadSet_pred_tcb_at_state
                                        cteInsert_obj_at'_not_queued
                                     | wps)+)[1]
@@ -1364,7 +1363,7 @@ lemma fastpath_callKernel_SysReplyRecv_corres:
      (invs' and ct_in_state' ((=) Running) and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread)
          and cnode_caps_gsCNodes')
      (callKernel (SyscallEvent SysReplyRecv)) (fastpaths SysReplyRecv)"
-  including no_pre
+  including classic_wp_pre
   supply if_cong[cong] option.case_cong[cong]
   supply if_split[split del]
   supply user_getreg_inv[wp] (* FIXME *)

--- a/proof/crefine/ARM_HYP/Fastpath_Equiv.thy
+++ b/proof/crefine/ARM_HYP/Fastpath_Equiv.thy
@@ -661,8 +661,7 @@ lemma fastpath_callKernel_SysCall_corres:
                               apply ((wp assert_inv threadSet_pred_tcb_at_state cteInsert_obj_at'_not_queued | wps)+)[1]
                              apply ((wp assert_inv threadSet_pred_tcb_at_state cteInsert_obj_at'_not_queued | wps)+)[1]
                             apply ((wp assert_inv threadSet_pred_tcb_at_state cteInsert_obj_at'_not_queued | wps)+)[1]
-                            apply (wp fastpathBestSwitchCandidate_lift[where f="threadSet f t" for f t])
-                             apply simp
+                            apply (wpsimp wp: fastpathBestSwitchCandidate_lift[where f="threadSet f t" for f t])
                             apply ((wp assert_inv threadSet_pred_tcb_at_state
                                        cteInsert_obj_at'_not_queued
                                     | wps)+)[1]
@@ -1367,7 +1366,7 @@ lemma fastpath_callKernel_SysReplyRecv_corres:
      (invs' and ct_in_state' ((=) Running) and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread)
          and cnode_caps_gsCNodes')
      (callKernel (SyscallEvent SysReplyRecv)) (fastpaths SysReplyRecv)"
-  including no_pre
+  including classic_wp_pre
   supply if_cong[cong] option.case_cong[cong]
   supply if_split[split del]
   supply user_getreg_inv[wp] (* FIXME *)

--- a/proof/crefine/Move_C.thy
+++ b/proof/crefine/Move_C.thy
@@ -988,7 +988,7 @@ lemma empty_fail_getIdleThread [simp,intro!]:
 
 lemma setTCB_cur:
   "\<lbrace>cur_tcb'\<rbrace> setObject t (v::tcb) \<lbrace>\<lambda>_. cur_tcb'\<rbrace>"
-  including no_pre
+  including classic_wp_pre
   apply (wp cur_tcb_lift)
   apply (simp add: setObject_def split_def updateObject_default_def)
   apply wp

--- a/proof/drefine/CNode_DR.thy
+++ b/proof/drefine/CNode_DR.thy
@@ -244,8 +244,7 @@ lemma insert_cap_sibling_corres:
            cte_wp_at_caps_of_state has_parent_cte_at is_physical_def
            dest!:is_untyped_cap_eqD)
          apply fastforce
-        apply (wp get_cap_wp set_cap_idle | simp)+
-   apply clarsimp
+        apply (wpsimp wp: get_cap_wp set_cap_idle)+
    apply (clarsimp simp: not_idle_thread_def)
    apply (clarsimp simp: caps_of_state_transform_opt_cap cte_wp_at_caps_of_state
      transform_cap_def)

--- a/proof/drefine/Finalise_DR.thy
+++ b/proof/drefine/Finalise_DR.thy
@@ -486,7 +486,7 @@ lemma dcorres_deleting_irq_handler:
   apply (rule corres_split[OF dcorres_get_irq_slot])
     apply (simp, rule delete_cap_simple_corres,simp)
     apply (rule hoare_vcg_precond_imp [where Q="invs and valid_etcbs"])
-    including no_pre
+    including classic_wp_pre
     apply (wpsimp simp:get_irq_slot_def)+
     apply (rule irq_node_image_not_idle)
     apply (simp add:invs_def valid_state_def)+
@@ -2503,6 +2503,7 @@ lemma dcorres_delete_asid:
               apply (wp | clarsimp)+
          apply simp
         apply (wp | clarsimp)+
+       apply (rule hoare_pre, wp, clarsimp)
       apply (rule hoare_pre, wp)
       apply simp
      apply (wp | clarsimp)+

--- a/proof/drefine/Ipc_DR.thy
+++ b/proof/drefine/Ipc_DR.thy
@@ -702,7 +702,7 @@ lemma tcb_sched_action_tcb_at_not_idle[wp]:
 
 lemma valid_idle_cancel_all_ipc:
   "\<lbrace>valid_idle and valid_state :: det_state \<Rightarrow> bool\<rbrace> IpcCancel_A.cancel_all_ipc word1 \<lbrace>\<lambda>a. valid_idle\<rbrace>"
-  including no_pre
+  including classic_wp_pre
   apply (simp add:cancel_all_ipc_def)
   apply (wp|wpc|simp)+
       apply (rename_tac queue list)
@@ -757,7 +757,7 @@ lemma valid_idle_cancel_all_ipc:
 
 lemma valid_idle_cancel_all_signals:
   "\<lbrace>valid_idle and valid_state :: det_state \<Rightarrow> bool\<rbrace> IpcCancel_A.cancel_all_signals word1 \<lbrace>\<lambda>a. valid_idle\<rbrace>"
-  including no_pre
+  including classic_wp_pre
   apply (simp add:cancel_all_signals_def)
   apply (wp|wpc|simp)+
      apply (rename_tac list)
@@ -1285,10 +1285,9 @@ next
         apply (rule dcorres_set_extra_badge,simp)
        apply (rule Cons.hyps, rule refl, rule refl, simp)
       apply wp[1]
-     apply (simp add: store_word_offs_def set_extra_badge_def
-     not_idle_thread_def ipc_frame_wp_at_def
-     split_def)
-     apply (wp evalMonad_lookup_ipc_buffer_wp)
+     apply (simp add: store_word_offs_def set_extra_badge_def not_idle_thread_def
+                      ipc_frame_wp_at_def split_def)
+     apply (wpsimp wp: evalMonad_lookup_ipc_buffer_wp)
          apply (erule cte_wp_at_weakenE)
          apply (simp add:ipc_buffer_wp_at_def)+
         apply wp

--- a/proof/drefine/Schedule_DR.thy
+++ b/proof/drefine/Schedule_DR.thy
@@ -81,7 +81,7 @@ lemma change_current_domain_and_switch_to_idle_thread_dcorres:
                     Schedule_D.switch_to_thread None
                  od)
                 switch_to_idle_thread"
-  including no_pre
+  including classic_wp_pre
   apply (clarsimp simp: Schedule_D.switch_to_thread_def switch_to_idle_thread_def)
   apply (rule dcorres_symb_exec_r)
     apply (rule corres_guard_imp)

--- a/proof/infoflow/ADT_IF.thy
+++ b/proof/infoflow/ADT_IF.thy
@@ -1665,7 +1665,7 @@ lemma schedule_if_globals_equiv_scheduler[wp]:
    \<lbrace>\<lambda>_. globals_equiv_scheduler st\<rbrace>"
   apply (simp add: schedule_if_def)
   apply wp
-    apply (wp globals_equiv_scheduler_inv'[where P="invs"] activate_thread_globals_equiv)
+    apply (wpsimp wp: globals_equiv_scheduler_inv'[where P="invs"] activate_thread_globals_equiv)
     apply (simp add: invs_arch_state invs_valid_idle)
    apply (wp | simp)+
   done
@@ -2618,8 +2618,7 @@ lemma perform_invocation_irq_state_inv:
                       invoke_tcb_irq_state_inv invoke_cnode_irq_state_inv[simplified validE_R_def]
                    | clarsimp | simp add: invoke_domain_def)+\<close>)?)
    apply wp
-    apply (wp irq_state_inv_triv' invoke_irq_control_irq_masks)
-    apply clarsimp
+    apply (wpsimp wp: irq_state_inv_triv' invoke_irq_control_irq_masks)
     apply assumption
    apply auto[1]
   apply wp

--- a/proof/infoflow/ARM/ArchRetype_IF.thy
+++ b/proof/infoflow/ARM/ArchRetype_IF.thy
@@ -278,7 +278,7 @@ lemma copy_global_mappings_globals_equiv:
   "\<lbrace>globals_equiv s and (\<lambda>s. x \<noteq> arm_global_pd (arch_state s) \<and> is_aligned x pd_bits)\<rbrace>
    copy_global_mappings x
    \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
-  unfolding copy_global_mappings_def including no_pre
+  unfolding copy_global_mappings_def including classic_wp_pre
   apply simp
   apply wp
    apply (rule_tac Q="\<lambda>_. globals_equiv s and (\<lambda>s. x \<noteq> arm_global_pd (arch_state s) \<and>

--- a/proof/infoflow/ARM/ArchScheduler_IF.thy
+++ b/proof/infoflow/ARM/ArchScheduler_IF.thy
@@ -186,7 +186,7 @@ lemma globals_equiv_scheduler_inv'[Scheduler_IF_assms]:
 
 lemma clearExMonitor_globals_equiv_scheduler[wp]:
   "do_machine_op clearExMonitor \<lbrace>globals_equiv_scheduler sta\<rbrace>"
-  unfolding clearExMonitor_def including no_pre
+  unfolding clearExMonitor_def including classic_wp_pre
   apply (wp dmo_no_mem_globals_equiv_scheduler)
    apply simp
   apply (simp add: simpler_modify_def valid_def)

--- a/proof/infoflow/Decode_IF.thy
+++ b/proof/infoflow/Decode_IF.thy
@@ -110,8 +110,8 @@ lemma slot_cap_long_running_delete_reads_respects_f:
          apply (fastforce simp: long_running_delete_def is_final_cap_def gets_bind_ign intro: return_ev)+
       apply (wp is_final_cap_reads_respects[where st=st])[1]
      apply (fastforce simp: long_running_delete_def is_final_cap_def gets_bind_ign intro: return_ev)+
-    apply (wp reads_respects_f[OF get_cap_rev, where Q="\<top>" and st=st], blast)
-   apply (wp get_cap_wp | simp)+
+    apply (wpsimp wp: reads_respects_f[OF get_cap_rev, where Q="\<top>" and st=st])
+   apply (wp get_cap_wp)
   apply (fastforce intro!: cte_wp_valid_cap aag_has_auth_to_obj_refs_of_owned_cap simp: is_zombie_def
                      dest: silc_inv_not_subject)
   done
@@ -227,14 +227,14 @@ lemma decode_tcb_invocation_reads_respects_f:
   apply (simp add: unlessE_def[symmetric] unlessE_whenE split del: if_split
              cong: gen_invocation_labels.case_cong)
   apply (rule equiv_valid_guard_imp)
-   apply (wp (once) requiv_cur_thread_eq range_check_ev respects_f[OF derive_cap_rev]
-                    derive_cap_inv slot_cap_long_running_delete_reads_respects_f[where st=st]
-                    respects_f[OF check_valid_ipc_buffer_rev] check_valid_ipc_buffer_inv
-                    respects_f[OF decode_set_priority_rev] respects_f[OF decode_set_mcpriority_rev]
-                    respects_f[OF decode_set_sched_params_rev]
-                    respects_f[OF get_simple_ko_reads_respects]
-                    respects_f[OF get_bound_notification_reads_respects']
-          | wp (once) whenE_throwError_wp
+   apply (wp requiv_cur_thread_eq range_check_ev respects_f[OF derive_cap_rev]
+             derive_cap_inv slot_cap_long_running_delete_reads_respects_f[where st=st]
+             respects_f[OF check_valid_ipc_buffer_rev] check_valid_ipc_buffer_inv
+             respects_f[OF decode_set_priority_rev] respects_f[OF decode_set_mcpriority_rev]
+             respects_f[OF decode_set_sched_params_rev]
+             respects_f[OF get_simple_ko_reads_respects]
+             respects_f[OF get_bound_notification_reads_respects']
+             whenE_throwError_wp
           | wp (once) hoare_drop_imps
           | wpc
           | simp add: if_apply_def2 split del: if_split add: o_def split_def)+

--- a/proof/infoflow/FinalCaps.thy
+++ b/proof/infoflow/FinalCaps.thy
@@ -1441,7 +1441,7 @@ lemma finalise_cap_ret_is_subject:
    finalise_cap cap is_final
    \<lbrace>\<lambda>rv _ :: det_state. case (fst rv) of Zombie ptr bits n \<Rightarrow> is_subject aag (obj_ref_of (fst rv))
                                                        | _ \<Rightarrow> True\<rbrace>"
-  including no_pre
+  including classic_wp_pre
   apply (case_tac cap, simp_all add: is_zombie_def)
              apply (wp | simp add: comp_def | rule impI | rule conjI)+
   apply (fastforce simp: valid_def dest: arch_finalise_cap_ret)
@@ -2400,7 +2400,7 @@ lemma transfer_caps_silc_inv:
   apply (simp add: transfer_caps_def)
   apply (wpc | wp)+
     apply (rule_tac P = "\<forall>x \<in> set dest_slots. is_subject aag (fst x)" in hoare_gen_asm)
-    apply (wp transfer_caps_loop_pres_dest cap_insert_silc_inv)
+    apply (wpsimp wp: transfer_caps_loop_pres_dest cap_insert_silc_inv)
      apply (fastforce simp: silc_inv_def)
     apply (wp get_receive_slots_authorised hoare_vcg_all_lift hoare_vcg_imp_lift | simp)+
   apply (fastforce elim: cte_wp_at_weakenE)

--- a/proof/infoflow/Finalise_IF.thy
+++ b/proof/infoflow/Finalise_IF.thy
@@ -570,10 +570,10 @@ lemma tcb_sched_action_reads_respects:
    apply (force intro: domtcbs simp: get_etcb_def)
   apply (simp add: equiv_valid_def2 ethread_get_def)
   apply (rule equiv_valid_rv_bind)
-    apply (wp equiv_valid_rv_trivial', simp)
+    apply (wpsimp wp: equiv_valid_rv_trivial')
    apply (rule equiv_valid_2_bind)
       prefer 2
-      apply (wp equiv_valid_rv_trivial, simp)
+      apply (wpsimp wp: equiv_valid_rv_trivial)
      apply (rule equiv_valid_2_bind)
         apply (rule_tac P=\<top> and P'=\<top> and L="{pasObjectAbs aag t}" and L'="{pasObjectAbs aag t}"
                      in ev2_invisible[OF domains_distinct])

--- a/proof/infoflow/Ipc_IF.thy
+++ b/proof/infoflow/Ipc_IF.thy
@@ -601,6 +601,9 @@ lemma send_signal_reads_respects:
                         set_thread_state_runnable_equiv_but_for_labels get_simple_ko_wp
                         gts_wp update_waiting_ntfn_equiv_but_for_labels
                         blocked_cancel_ipc_nosts_equiv_but_for_labels
+            \<comment> \<open>FIXME: The following line is working around the fact that wp (once) doesn't invoke
+                      wp_pre. If that is changed then it could be removed.\<close>
+            | wp_pre0
             | wpc
             | wps)+
     apply (elim conjE)
@@ -1717,7 +1720,7 @@ lemma copy_mrs_globals_equiv:
   "\<lbrace>globals_equiv s and valid_arch_state and (\<lambda>s. receiver \<noteq> idle_thread s)\<rbrace>
    copy_mrs sender sbuf receiver rbuf n
    \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
-  unfolding copy_mrs_def including no_pre
+  unfolding copy_mrs_def including classic_wp_pre
   apply (wp | wpc)+
     apply (rule_tac Q="\<lambda>_. globals_equiv s" in hoare_strengthen_post)
      apply (wp mapM_wp' | wpc)+

--- a/proof/infoflow/Noninterference.thy
+++ b/proof/infoflow/Noninterference.thy
@@ -381,8 +381,7 @@ lemma kernel_entry_if_globals_equiv_scheduler:
                                and (\<lambda>s. ct_idle s \<longrightarrow> tc = idle_context s)\<rbrace>
    kernel_entry_if e tc
    \<lbrace>\<lambda>_. globals_equiv_scheduler st\<rbrace>"
-  apply (wp globals_equiv_scheduler_inv' kernel_entry_if_globals_equiv)
-   apply (clarsimp)
+  apply (wpsimp wp: globals_equiv_scheduler_inv' kernel_entry_if_globals_equiv)
    apply assumption
   apply clarsimp
   done
@@ -2090,10 +2089,10 @@ lemma tcb_sched_action_reads_respects_g':
    apply (force intro: domtcbs simp: get_etcb_def)
   apply (simp add: equiv_valid_def2 ethread_get_def)
   apply (rule equiv_valid_rv_bind)
-    apply (wp equiv_valid_rv_trivial', simp)
+    apply (wpsimp wp: equiv_valid_rv_trivial')
    apply (rule equiv_valid_2_bind)
       prefer 2
-      apply (wp equiv_valid_rv_trivial, simp)
+      apply (wpsimp wp: equiv_valid_rv_trivial)
      apply (rule equiv_valid_2_bind)
         apply (rule_tac P="\<top>" and P'="\<top>" and L="{pasObjectAbs aag thread}" and
                                               L'="{pasObjectAbs aag thread}" in ev2_invisible')

--- a/proof/infoflow/RISCV64/ArchArch_IF.thy
+++ b/proof/infoflow/RISCV64/ArchArch_IF.thy
@@ -464,7 +464,7 @@ lemma copy_global_mappings_valid_arch_state:
                      and (\<lambda>s. x \<notin> global_refs s \<and> is_aligned x pt_bits)\<rbrace>
    copy_global_mappings x
    \<lbrace>\<lambda>_. valid_arch_state\<rbrace>"
-  unfolding copy_global_mappings_def including no_pre
+  unfolding copy_global_mappings_def including classic_wp_pre
   apply simp
   apply wp
    apply (rule_tac Q="\<lambda>_. valid_arch_state and valid_global_vspace_mappings and pspace_aligned

--- a/proof/infoflow/RISCV64/ArchRetype_IF.thy
+++ b/proof/infoflow/RISCV64/ArchRetype_IF.thy
@@ -232,7 +232,7 @@ lemma copy_global_mappings_globals_equiv:
   "\<lbrace>globals_equiv s and (\<lambda>s. x \<noteq> riscv_global_pt (arch_state s) \<and> is_aligned x pt_bits)\<rbrace>
    copy_global_mappings x
    \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
-  unfolding copy_global_mappings_def including no_pre
+  unfolding copy_global_mappings_def including classic_wp_pre
   apply simp
   apply wp
    apply (rule_tac Q="\<lambda>_. globals_equiv s and (\<lambda>s. x \<noteq> riscv_global_pt (arch_state s) \<and>

--- a/proof/infoflow/RISCV64/ArchScheduler_IF.thy
+++ b/proof/infoflow/RISCV64/ArchScheduler_IF.thy
@@ -184,8 +184,7 @@ lemma arch_switch_to_thread_globals_equiv_scheduler[Scheduler_IF_assms]:
    arch_switch_to_thread thread
    \<lbrace>\<lambda>_. globals_equiv_scheduler sta\<rbrace>"
   unfolding arch_switch_to_thread_def storeWord_def
-  by (wpsimp wp: dmo_wp modify_wp thread_get_wp'
-      | wp (once) globals_equiv_scheduler_inv'[where P="\<top>"])+
+  by (wpsimp wp: dmo_wp modify_wp thread_get_wp' globals_equiv_scheduler_inv'[where P="\<top>"])
 
 crunches arch_activate_idle_thread
   for silc_dom_equiv[Scheduler_IF_assms, wp]: "silc_dom_equiv aag st"

--- a/proof/infoflow/Scheduler_IF.thy
+++ b/proof/infoflow/Scheduler_IF.thy
@@ -2397,7 +2397,9 @@ lemma context_update_cur_thread_snippit_cur_domain:
      (\<lambda>s. reads_scheduler_cur_domain aag l s \<and> invs s \<and> silc_inv aag st s \<and>
           (ct_idle s \<longrightarrow> uc = idle_context s) \<and> guarded_pas_domain aag s)
      (gets cur_thread >>= thread_set (tcb_arch_update (arch_tcb_context_set uc)))"
-  apply wp
+  \<comment> \<open>FIXME: maybe should make an equiv_valid_pre?\<close>
+  apply (rule equiv_valid_guard_imp)
+   apply wp
   apply (clarsimp simp: cur_thread_idle silc_inv_not_cur_thread del: notI)
   done
 

--- a/proof/infoflow/Syscall_IF.thy
+++ b/proof/infoflow/Syscall_IF.thy
@@ -187,8 +187,8 @@ proof (induct rule: cap_revoke.induct[where ?a1.0=s])
               apply (frule aag_can_read_self)
               apply (simp add: equiv_for_def split del: if_split)+
           apply (wp drop_spec_ev2_inv[OF liftE_ev2] gets_evrv | simp)+
-     apply (wp drop_spec_ev2_inv[OF liftE_ev2] gets_evrv
-               reads_respects_f[OF get_cap_rev, where st=st and Q=\<top>,simplified equiv_valid_def2])
+     apply (wpsimp wp: drop_spec_ev2_inv[OF liftE_ev2] gets_evrv
+                       reads_respects_f[OF get_cap_rev, where st=st and Q=\<top>,simplified equiv_valid_def2])
      apply clarsimp+
     apply (frule all_children_subjectReads[simplified comp_def])
     apply clarsimp

--- a/proof/infoflow/Tcb_IF.thy
+++ b/proof/infoflow/Tcb_IF.thy
@@ -140,8 +140,7 @@ next
      apply (rule split_spec_bindE)
       apply (rule split_spec_bindE[rotated])
        apply (rule "4.hyps", assumption+)
-      apply (wp set_cap_P set_cap_Q get_cap_wp | simp)
-      apply simp
+      apply (wpsimp wp: set_cap_P set_cap_Q get_cap_wp)
      apply simp
      apply wp
     apply (clarsimp simp add: zombie_is_cap_toE)
@@ -203,11 +202,10 @@ lemma rec_del_globals_equiv:
   "\<lbrace>\<lambda>s. invs s \<and> globals_equiv st s \<and> emptyable (slot_rdcall call) s \<and> valid_rec_del_call call s\<rbrace>
    rec_del call
    \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
-  apply (wp finalise_cap_globals_equiv
-            rec_del_preservation2[where Q="valid_arch_state"
-                                    and R="\<lambda>cap s. invs s \<and> valid_cap cap s
-                                                 \<and> (\<forall>p. cap = ThreadCap p \<longrightarrow> p \<noteq> idle_thread s)"])
-             apply simp
+  apply (wpsimp wp: finalise_cap_globals_equiv
+                    rec_del_preservation2[where Q="valid_arch_state"
+                                            and R="\<lambda>cap s. invs s \<and> valid_cap cap s
+                                                      \<and> (\<forall>p. cap = ThreadCap p \<longrightarrow> p \<noteq> idle_thread s)"])
             apply (wp set_cap_globals_equiv'')
             apply simp
            apply (wp empty_slot_globals_equiv)+
@@ -308,10 +306,9 @@ lemma invoke_tcb_globals_equiv:
        apply (rule_tac Q="\<lambda>_. valid_arch_state and globals_equiv st and
                               (\<lambda>s. word1 \<noteq> idle_thread s) and (\<lambda>s. word2 \<noteq> idle_thread s)"
                     in hoare_strengthen_post)
-        apply ((wp mapM_x_wp' as_user_globals_equiv invoke_tcb_NotificationControl_globals_equiv
-                | simp
-                | intro conjI impI
-                | clarsimp simp: no_cap_to_idle_thread)+)[6]
+        apply (wpsimp wp: mapM_x_wp' as_user_globals_equiv invoke_tcb_NotificationControl_globals_equiv
+                          weak_if_wp')+
+   apply (intro conjI impI; clarsimp simp: no_cap_to_idle_thread)+
   apply (simp del: invoke_tcb.simps tcb_inv_wf.simps)
   apply (wp invoke_tcb_thread_preservation cap_delete_globals_equiv
             cap_insert_globals_equiv'' thread_set_globals_equiv set_mcpriority_globals_equiv
@@ -494,7 +491,7 @@ lemma invoke_tcb_reads_respects_f:
                         and tcb_inv_wf ti and is_subject aag \<circ> cur_thread
                         and K (authorised_tcb_inv aag ti \<and> authorised_tcb_inv_extra aag ti))
        (invoke_tcb ti)"
-  including no_pre
+  including classic_wp_pre
   apply (case_tac ti)
          \<comment> \<open>WriteRegisters\<close>
          apply (strengthen invs_mdb

--- a/proof/invariant-abstract/ARM/ArchVSpaceEntries_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchVSpaceEntries_AI.thy
@@ -455,11 +455,10 @@ lemma mapM_x_copy_pde_updates:
   done
 
 lemma copy_global_mappings_valid_pdpt_objs[wp]:
-  notes hoare_pre [wp_pre del]
-  shows
   "\<lbrace>valid_pdpt_objs and valid_arch_state and pspace_aligned
             and K (is_aligned p pd_bits)\<rbrace>
        copy_global_mappings p \<lbrace>\<lambda>rv. valid_pdpt_objs\<rbrace>"
+  including classic_wp_pre
   apply (rule hoare_gen_asm)
   apply (simp add: copy_global_mappings_def)
   apply wp

--- a/proof/invariant-abstract/ARM_HYP/ArchVSpaceEntries_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchVSpaceEntries_AI.thy
@@ -439,7 +439,7 @@ lemma mapM_x_copy_pde_updates:
          ucast (f x && mask pd_bits >> 3)) ` set xs then pd y else pd' y)))) \<rparr>))\<rbrace>
      mapM_x (\<lambda>x. get_pde (p + f x) >>= store_pde (p' + f x)) xs
    \<lbrace>\<lambda>_. Q\<rbrace>"
-  including no_pre
+  including classic_wp_pre
   apply (induct xs)
    apply (simp add: mapM_x_Nil)
    apply wp

--- a/proof/invariant-abstract/DetSchedAux_AI.thy
+++ b/proof/invariant-abstract/DetSchedAux_AI.thy
@@ -313,15 +313,12 @@ lemma invoke_untyped_valid_sched:
   "\<lbrace>invs and valid_untyped_inv ui and ct_active and valid_sched and valid_idle \<rbrace>
      invoke_untyped ui
    \<lbrace> \<lambda>_ . valid_sched \<rbrace>"
-  including no_pre
   apply (rule hoare_pre)
    apply (rule_tac I="invs and valid_untyped_inv ui and ct_active"
-     in valid_sched_tcb_state_preservation)
-          apply (wp invoke_untyped_st_tcb_at)
-          apply simp
-         apply (wp invoke_untyped_etcb_at)+
-    apply (rule hoare_post_impErr, rule hoare_pre, rule invoke_untyp_invs,
-        simp_all add: invs_valid_idle)[1]
+                in valid_sched_tcb_state_preservation)
+          apply (wpsimp wp: invoke_untyped_st_tcb_at invoke_untyped_etcb_at)+
+     apply (rule hoare_post_impErr, rule invoke_untyp_invs; simp add: invs_valid_idle)
+    apply simp
    apply (rule_tac f="\<lambda>s. P (scheduler_action s)" in hoare_lift_Pf)
     apply (rule_tac f="\<lambda>s. x (ready_queues s)" in hoare_lift_Pf)
      apply wp+

--- a/proof/invariant-abstract/Syscall_AI.thy
+++ b/proof/invariant-abstract/Syscall_AI.thy
@@ -1146,7 +1146,7 @@ lemma hy_inv: "(\<And>s f. P (trans_state f s) = P s) \<Longrightarrow> \<lbrace
   apply (wp | simp)+
   done
 
-declare hoare_seq_ext[wp] hoare_vcg_precond_imp [wp_comb]
+declare hoare_seq_ext[wp]
 
 lemma ct_active_simple [elim!]:
   "ct_active s \<Longrightarrow> st_tcb_at simple (cur_thread s) s"

--- a/proof/refine/AARCH64/Finalise_R.thy
+++ b/proof/refine/AARCH64/Finalise_R.thy
@@ -3393,7 +3393,7 @@ lemma cancelAllIPC_mapM_x_valid_objs':
                  tcbSchedEnqueue t
                od) q
    \<lbrace>\<lambda>_. valid_objs'\<rbrace>"
-  apply (wp mapM_x_wp' sts_valid_objs')
+  apply (wpsimp wp: mapM_x_wp' sts_valid_objs')
    apply (clarsimp simp: valid_tcb_state'_def)+
   done
 

--- a/proof/refine/AARCH64/IpcCancel_R.thy
+++ b/proof/refine/AARCH64/IpcCancel_R.thy
@@ -1106,7 +1106,7 @@ lemma sts_weak_sch_act_wf[wp]:
         \<and> (ksSchedulerAction s = SwitchToThread t \<longrightarrow> runnable' st)\<rbrace>
    setThreadState st t
    \<lbrace>\<lambda>_ s. weak_sch_act_wf (ksSchedulerAction s) s\<rbrace>"
-  including no_pre
+  including classic_wp_pre
   apply (simp add: setThreadState_def)
   apply (wp rescheduleRequired_weak_sch_act_wf)
   apply (rule_tac Q="\<lambda>_ s. weak_sch_act_wf (ksSchedulerAction s) s" in hoare_post_imp, simp)
@@ -1595,7 +1595,7 @@ lemma rescheduleRequired_oa_queued:
   apply (simp add: rescheduleRequired_def sch_act_simple_def)
   apply (rule_tac B="\<lambda>rv s. (rv = ResumeCurrentThread \<or> rv = ChooseNewThread)
                        \<and> ?OAQ t' p s" in hoare_seq_ext)
-   including no_pre
+   including classic_wp_pre
    apply (wp | clarsimp)+
    apply (case_tac x)
      apply (wp | clarsimp)+
@@ -1671,7 +1671,7 @@ lemma sts_valid_queues_partial:
                            pred_tcb_at'_def obj_at'_def inQ_def)
    apply (rule hoare_vcg_all_lift)+
     apply (rule hoare_convert_imp)
-     including no_pre
+     including classic_wp_pre
      apply (wp sts_ksQ setThreadState_oa_queued hoare_impI sts_pred_tcb_neq'
             | clarsimp)+
   apply (rule_tac Q="\<lambda>s. \<forall>d p. ?DISTINCT d p s \<and> sch_act_simple s" in hoare_pre_imp)

--- a/proof/refine/AARCH64/Ipc_R.thy
+++ b/proof/refine/AARCH64/Ipc_R.thy
@@ -714,8 +714,7 @@ lemma transferCapsToSlots_mdb[wp]:
           \<and> transferCaps_srcs caps s\<rbrace>
     transferCapsToSlots ep buffer n caps slots mi
    \<lbrace>\<lambda>rv. valid_mdb'\<rbrace>"
-  apply (wp transferCapsToSlots_presM[where drv=True and vo=True and emx=True and pad=True])
-    apply clarsimp
+  apply (wpsimp wp: transferCapsToSlots_presM[where drv=True and vo=True and emx=True and pad=True])
     apply (frule valid_capAligned)
     apply (clarsimp simp: cte_wp_at_ctes_of is_derived'_def badge_derived'_def)
    apply wp
@@ -864,7 +863,7 @@ lemma transferCapsToSlots_irq_handlers[wp]:
          and transferCaps_srcs caps\<rbrace>
      transferCapsToSlots ep buffer n caps slots mi
   \<lbrace>\<lambda>rv. valid_irq_handlers'\<rbrace>"
-  apply (wp transferCapsToSlots_presM[where vo=True and emx=False and drv=True and pad=False])
+  apply (wpsimp wp: transferCapsToSlots_presM[where vo=True and emx=False and drv=True and pad=False])
      apply (clarsimp simp: is_derived'_def cte_wp_at_ctes_of badge_derived'_def)
      apply (erule(2) valid_irq_handlers_ctes_ofD)
     apply wp
@@ -961,8 +960,8 @@ lemma tcts_zero_ranges[wp]:
           \<and> transferCaps_srcs caps s\<rbrace>
     transferCapsToSlots ep buffer n caps slots mi
   \<lbrace>\<lambda>rv. untyped_ranges_zero'\<rbrace>"
-  apply (wp transferCapsToSlots_presM[where emx=True and vo=True
-      and drv=True and pad=True])
+  apply (wpsimp wp: transferCapsToSlots_presM[where emx=True and vo=True
+                                                and drv=True and pad=True])
     apply (clarsimp simp: cte_wp_at_ctes_of)
    apply (simp add: cteCaps_of_def)
    apply (rule hoare_pre, wp untyped_ranges_zero_lift)
@@ -1182,7 +1181,7 @@ lemmas copyMRs_typ_at_lifts[wp] = typ_at_lifts [OF copyMRs_typ_at']
 
 lemma copy_mrs_invs'[wp]:
   "\<lbrace> invs' and tcb_at' s and tcb_at' r \<rbrace> copyMRs s sb r rb n \<lbrace>\<lambda>rv. invs' \<rbrace>"
-  including no_pre
+  including classic_wp_pre
   apply (simp add: copyMRs_def)
   apply (wp dmo_invs' no_irq_mapM no_irq_storeWord|
          simp add: split_def)

--- a/proof/refine/AARCH64/Retype_R.thy
+++ b/proof/refine/AARCH64/Retype_R.thy
@@ -3431,11 +3431,11 @@ lemma createObjects_orig_cte_wp_at2':
               \<not> (case_option False (P' \<circ> getF) (projectKO_opt val)))
       \<and> pspace_no_overlap' ptr sz s\<rbrace>
   createObjects' ptr n val gbits \<lbrace>\<lambda>r s. P (cte_wp_at' P' p s)\<rbrace>"
+  including classic_wp_pre
   apply (simp add: cte_wp_at'_obj_at')
   apply (rule handy_prop_divs)
    apply (wp createObjects_orig_obj_at2'[where sz = sz], simp)
   apply (simp add: tcb_cte_cases_def cteSizeBits_def)
-  including no_pre
   apply (wp handy_prop_divs createObjects_orig_obj_at2'[where sz = sz]
              | simp add: o_def cong: option.case_cong)+
   done
@@ -3456,7 +3456,7 @@ lemma createNewCaps_cte_wp_at2:
       \<and> pspace_no_overlap' ptr sz s\<rbrace>
      createNewCaps ty ptr n objsz dev
    \<lbrace>\<lambda>rv s. P (cte_wp_at' P' p s)\<rbrace>"
-  including no_pre
+  including classic_wp_pre
   apply (simp add: createNewCaps_def createObjects_def AARCH64_H.toAPIType_def
            split del: if_split)
   apply (case_tac ty; simp add: createNewCaps_def createObjects_def Arch_createNewCaps_def
@@ -4143,7 +4143,7 @@ lemma createNewCaps_idle'[wp]:
          apply (rename_tac apiobject_type)
          apply (case_tac apiobject_type, simp_all split del: if_split)[1]
              apply (wp, simp)
-           including no_pre
+           including classic_wp_pre
            apply (wp mapM_x_wp'
                      createObjects_idle'
                      threadSet_idle'
@@ -4263,8 +4263,7 @@ lemma createNewCaps_valid_queues:
      createNewCaps ty ptr n us d
    \<lbrace>\<lambda>rv. valid_queues\<rbrace>"
   apply (rule hoare_gen_asm)
-  apply (wp valid_queues_lift_asm createNewCaps_obj_at2[where sz=sz])
-       apply (clarsimp simp: projectKO_opts_defs)
+  apply (wpsimp wp: valid_queues_lift_asm createNewCaps_obj_at2[where sz=sz])
        apply (simp add: inQ_def)
       apply (wp createNewCaps_pred_tcb_at'[where sz=sz] | simp)+
   done
@@ -4719,8 +4718,8 @@ lemma createObjects_queues:
         pspace_no_overlap' ptr sz s \<and> range_cover ptr sz (objBitsKO val + gbits) n \<and> n \<noteq> 0\<rbrace>
   createObjects ptr n val gbits
   \<lbrace>\<lambda>rv. valid_queues\<rbrace>"
-  apply (wp valid_queues_lift_asm [unfolded pred_conj_def, OF createObjects_orig_obj_at3]
-            createObjects_pred_tcb_at' [unfolded pred_conj_def])
+  apply (wpsimp wp: valid_queues_lift_asm [unfolded pred_conj_def, OF createObjects_orig_obj_at3]
+                    createObjects_pred_tcb_at' [unfolded pred_conj_def])
       apply fastforce
      apply wp+
   apply fastforce

--- a/proof/refine/AARCH64/Schedule_R.thy
+++ b/proof/refine/AARCH64/Schedule_R.thy
@@ -1224,8 +1224,7 @@ lemma dmo_cap_to'[wp]:
 lemma sct_cap_to'[wp]:
   "\<lbrace>ex_nonz_cap_to' p\<rbrace> setCurThread t \<lbrace>\<lambda>rv. ex_nonz_cap_to' p\<rbrace>"
   apply (simp add: setCurThread_def)
-  apply (wp ex_nonz_cap_to_pres')
-   apply (clarsimp elim!: cte_wp_at'_pspaceI)+
+  apply (wpsimp wp: ex_nonz_cap_to_pres')
   done
 
 lemma setVCPU_cap_to'[wp]:
@@ -2252,7 +2251,7 @@ proof -
       apply (rename_tac l1)
       apply (case_tac "l1 = 0")
        (* switch to idle thread *)
-       apply (simp, wp (once) switchToIdleThread_invs_no_cicd', simp)
+       apply (simp, wp switchToIdleThread_invs_no_cicd', simp)
       (* we have a thread to switch to *)
       apply (clarsimp simp: bitmap_fun_defs)
       apply (wp assert_inv)

--- a/proof/refine/AARCH64/TcbAcc_R.thy
+++ b/proof/refine/AARCH64/TcbAcc_R.thy
@@ -2386,7 +2386,7 @@ lemma threadSet_queued_sch_act_wf[wp]:
   "\<lbrace>\<lambda>s. sch_act_wf (ksSchedulerAction s) s\<rbrace>
     threadSet (tcbQueued_update f) t
    \<lbrace>\<lambda>_ s. sch_act_wf (ksSchedulerAction s) s\<rbrace>"
-  including no_pre
+  including classic_wp_pre
   apply (simp add: sch_act_wf_cases
               split: scheduler_action.split)
   apply (wp hoare_vcg_conj_lift)
@@ -2907,7 +2907,7 @@ lemma rescheduleRequired_valid_bitmapQ_sch_act_simple:
   "\<lbrace> valid_bitmapQ and sch_act_simple\<rbrace>
     rescheduleRequired
    \<lbrace>\<lambda>_. valid_bitmapQ \<rbrace>"
-  including no_pre
+  including classic_wp_pre
   apply (simp add: rescheduleRequired_def sch_act_simple_def)
   apply (rule_tac B="\<lambda>rv s. valid_bitmapQ s \<and>
                             (rv = ResumeCurrentThread \<or> rv = ChooseNewThread)" in hoare_seq_ext)
@@ -2920,7 +2920,7 @@ lemma rescheduleRequired_bitmapQ_no_L1_orphans_sch_act_simple:
   "\<lbrace> bitmapQ_no_L1_orphans and sch_act_simple\<rbrace>
     rescheduleRequired
    \<lbrace>\<lambda>_. bitmapQ_no_L1_orphans \<rbrace>"
-  including no_pre
+  including classic_wp_pre
   apply (simp add: rescheduleRequired_def sch_act_simple_def)
   apply (rule_tac B="\<lambda>rv s. bitmapQ_no_L1_orphans s \<and>
                             (rv = ResumeCurrentThread \<or> rv = ChooseNewThread)" in hoare_seq_ext)
@@ -2933,7 +2933,7 @@ lemma rescheduleRequired_bitmapQ_no_L2_orphans_sch_act_simple:
   "\<lbrace> bitmapQ_no_L2_orphans and sch_act_simple\<rbrace>
     rescheduleRequired
    \<lbrace>\<lambda>_. bitmapQ_no_L2_orphans \<rbrace>"
-  including no_pre
+  including classic_wp_pre
   apply (simp add: rescheduleRequired_def sch_act_simple_def)
   apply (rule_tac B="\<lambda>rv s. bitmapQ_no_L2_orphans s \<and>
                             (rv = ResumeCurrentThread \<or> rv = ChooseNewThread)" in hoare_seq_ext)

--- a/proof/refine/AARCH64/Tcb_R.thy
+++ b/proof/refine/AARCH64/Tcb_R.thy
@@ -1565,7 +1565,7 @@ proof -
                                emptyable_def
                    | wpc | strengthen tcb_cap_always_valid_strg
                                       use_no_cap_to_obj_asid_strg
-                   | wp (once) add: sch_act_simple_lift hoare_drop_imps del: cteInsert_invs
+                   | wp add: sch_act_simple_lift hoare_drop_imps del: cteInsert_invs
                    | (erule exE, clarsimp simp: word_bits_def))+
      apply (clarsimp simp: tcb_at_cte_at_0 tcb_at_cte_at_1[simplified] tcb_at_st_tcb_at[symmetric]
                            tcb_cap_valid_def is_cnode_or_valid_arch_def invs_valid_objs emptyable_def
@@ -2700,7 +2700,7 @@ crunches getThreadBufferSlot, setPriority, setMCPriority
 lemma inv_tcb_IRQInactive:
   "\<lbrace>valid_irq_states'\<rbrace> invokeTCB tcb_inv
   -, \<lbrace>\<lambda>rv s. intStateIRQTable (ksInterruptState s) rv \<noteq> irqstate.IRQInactive\<rbrace>"
-  including no_pre
+  including classic_wp_pre
   apply (simp add: invokeTCB_def)
   apply (rule hoare_pre)
    apply (wpc |

--- a/proof/refine/AARCH64/orphanage/Orphanage.thy
+++ b/proof/refine/AARCH64/orphanage/Orphanage.thy
@@ -789,7 +789,7 @@ lemma chooseThread_no_orphans [wp]:
     apply (rename_tac l1)
     apply (case_tac "l1 = 0")
      (* switch to idle thread *)
-     apply (simp, wp (once), simp)
+     apply (simp, wp, simp)
     (* we have a thread to switch to *)
     apply (clarsimp simp: bitmap_fun_defs)
     apply (wp assert_inv ThreadDecls_H_switchToThread_no_orphans)
@@ -1814,7 +1814,7 @@ lemma cancelBadgedSends_no_orphans [wp]:
    \<lbrace> \<lambda>rv s. no_orphans s \<rbrace>"
   unfolding cancelBadgedSends_def
   by (wpsimp wp: filterM_preserved tcbSchedEnqueue_almost_no_orphans gts_wp' sts_st_tcb'
-                 hoare_drop_imps)
+      | wp (once) hoare_drop_imps)+
 
 crunch no_orphans [wp]: handleFaultReply "no_orphans"
 

--- a/proof/refine/ARM/Finalise_R.thy
+++ b/proof/refine/ARM/Finalise_R.thy
@@ -2992,7 +2992,7 @@ lemma cancelAllIPC_mapM_x_valid_objs':
                  tcbSchedEnqueue t
                od) q
    \<lbrace>\<lambda>_. valid_objs'\<rbrace>"
-  apply (wp mapM_x_wp' sts_valid_objs')
+  apply (wpsimp wp: mapM_x_wp' sts_valid_objs')
    apply (clarsimp simp: valid_tcb_state'_def)+
   done
 

--- a/proof/refine/ARM/IpcCancel_R.thy
+++ b/proof/refine/ARM/IpcCancel_R.thy
@@ -1164,7 +1164,7 @@ lemma sts_weak_sch_act_wf[wp]:
         \<and> (ksSchedulerAction s = SwitchToThread t \<longrightarrow> runnable' st)\<rbrace>
    setThreadState st t
    \<lbrace>\<lambda>_ s. weak_sch_act_wf (ksSchedulerAction s) s\<rbrace>"
-  including no_pre
+  including classic_wp_pre
   apply (simp add: setThreadState_def)
   apply (wp rescheduleRequired_weak_sch_act_wf)
   apply (rule_tac Q="\<lambda>_ s. weak_sch_act_wf (ksSchedulerAction s) s" in hoare_post_imp, simp)
@@ -1483,7 +1483,7 @@ lemma rescheduleRequired_oa_queued:
   apply (simp add: rescheduleRequired_def sch_act_simple_def)
   apply (rule_tac B="\<lambda>rv s. (rv = ResumeCurrentThread \<or> rv = ChooseNewThread)
                        \<and> ?OAQ t' p s" in hoare_seq_ext)
-   including no_pre
+   including classic_wp_pre
    apply (wp | clarsimp)+
    apply (case_tac x)
      apply (wp | clarsimp)+
@@ -1546,7 +1546,7 @@ lemma sts_valid_queues_partial:
                            pred_tcb_at'_def obj_at'_def inQ_def)
    apply (rule hoare_vcg_all_lift)+
     apply (rule hoare_convert_imp)
-     including no_pre
+     including classic_wp_pre
      apply (wp sts_ksQ setThreadState_oa_queued hoare_impI sts_pred_tcb_neq'
             | clarsimp)+
   apply (rule_tac Q="\<lambda>s. \<forall>d p. ?DISTINCT d p s \<and> sch_act_simple s" in hoare_pre_imp)

--- a/proof/refine/ARM/Ipc_R.thy
+++ b/proof/refine/ARM/Ipc_R.thy
@@ -706,8 +706,7 @@ lemma transferCapsToSlots_mdb[wp]:
           \<and> transferCaps_srcs caps s\<rbrace>
     transferCapsToSlots ep buffer n caps slots mi
    \<lbrace>\<lambda>rv. valid_mdb'\<rbrace>"
-  apply (wp transferCapsToSlots_presM[where drv=True and vo=True and emx=True and pad=True])
-    apply clarsimp
+  apply (wpsimp wp: transferCapsToSlots_presM[where drv=True and vo=True and emx=True and pad=True])
     apply (frule valid_capAligned)
     apply (clarsimp simp: cte_wp_at_ctes_of is_derived'_def badge_derived'_def)
    apply wp
@@ -852,7 +851,7 @@ lemma transferCapsToSlots_irq_handlers[wp]:
          and transferCaps_srcs caps\<rbrace>
      transferCapsToSlots ep buffer n caps slots mi
   \<lbrace>\<lambda>rv. valid_irq_handlers'\<rbrace>"
-  apply (wp transferCapsToSlots_presM[where vo=True and emx=False and drv=True and pad=False])
+  apply (wpsimp wp: transferCapsToSlots_presM[where vo=True and emx=False and drv=True and pad=False])
      apply (clarsimp simp: is_derived'_def cte_wp_at_ctes_of badge_derived'_def)
      apply (erule(2) valid_irq_handlers_ctes_ofD)
     apply wp
@@ -955,8 +954,8 @@ lemma tcts_zero_ranges[wp]:
           \<and> transferCaps_srcs caps s\<rbrace>
     transferCapsToSlots ep buffer n caps slots mi
   \<lbrace>\<lambda>rv. untyped_ranges_zero'\<rbrace>"
-  apply (wp transferCapsToSlots_presM[where emx=True and vo=True
-      and drv=True and pad=True])
+  apply (wpsimp wp: transferCapsToSlots_presM[where emx=True and vo=True
+                                                and drv=True and pad=True])
     apply (clarsimp simp: cte_wp_at_ctes_of)
    apply (simp add: cteCaps_of_def)
    apply (rule hoare_pre, wp untyped_ranges_zero_lift)
@@ -1138,7 +1137,7 @@ lemmas copyMRs_typ_at_lifts[wp] = typ_at_lifts [OF copyMRs_typ_at']
 
 lemma copy_mrs_invs'[wp]:
   "\<lbrace> invs' and tcb_at' s and tcb_at' r \<rbrace> copyMRs s sb r rb n \<lbrace>\<lambda>rv. invs' \<rbrace>"
-  including no_pre
+  including classic_wp_pre
   apply (simp add: copyMRs_def)
   apply (wp dmo_invs' no_irq_mapM no_irq_storeWord|
          simp add: split_def)
@@ -2945,7 +2944,7 @@ lemma sai_invs'[wp]:
   "\<lbrace>invs' and ex_nonz_cap_to' ntfnptr\<rbrace>
      sendSignal ntfnptr badge \<lbrace>\<lambda>y. invs'\<rbrace>"
   unfolding sendSignal_def
-  including no_pre
+  including classic_wp_pre
   apply (rule hoare_seq_ext[OF _ get_ntfn_sp'])
   apply (case_tac "ntfnObj nTFN", simp_all)
     prefer 3

--- a/proof/refine/ARM/Retype_R.thy
+++ b/proof/refine/ARM/Retype_R.thy
@@ -3438,7 +3438,7 @@ lemma createObjects_orig_cte_wp_at2':
   apply (rule handy_prop_divs)
    apply (wp createObjects_orig_obj_at2'[where sz = sz], simp)
   apply (simp add: tcb_cte_cases_def)
-  including no_pre
+  including classic_wp_pre
   apply (wp handy_prop_divs createObjects_orig_obj_at2'[where sz = sz]
              | simp add: o_def cong: option.case_cong)+
   done
@@ -3459,7 +3459,7 @@ lemma createNewCaps_cte_wp_at2:
       \<and> pspace_no_overlap' ptr sz s\<rbrace>
      createNewCaps ty ptr n objsz dev
    \<lbrace>\<lambda>rv s. P (cte_wp_at' P' p s)\<rbrace>"
-  including no_pre
+  including classic_wp_pre
   apply (simp add: createNewCaps_def createObjects_def ARM_H.toAPIType_def
            split del: if_split)
   apply (case_tac ty; simp add: createNewCaps_def createObjects_def Arch_createNewCaps_def
@@ -4111,7 +4111,7 @@ lemma createNewCaps_idle'[wp]:
          apply (rename_tac apiobject_type)
          apply (case_tac apiobject_type, simp_all split del: if_split)[1]
              apply (wp, simp)
-           including no_pre
+           including classic_wp_pre
            apply (wp mapM_x_wp'
                      createObjects_idle'
                      threadSet_idle'
@@ -4353,12 +4353,12 @@ lemma createNewCaps_valid_queues:
        and K (range_cover ptr sz (APIType_capBits ty us) n \<and> n \<noteq> 0)\<rbrace>
      createNewCaps ty ptr n us d
    \<lbrace>\<lambda>rv. valid_queues\<rbrace>"
-apply (rule hoare_gen_asm)
-apply (wp valid_queues_lift_asm createNewCaps_obj_at2[where sz=sz])
-apply (clarsimp simp: projectKO_opts_defs)
-apply (simp add: inQ_def)
-apply (wp createNewCaps_pred_tcb_at'[where sz=sz] | simp)+
-done
+  apply (rule hoare_gen_asm)
+  apply (wpsimp wp: valid_queues_lift_asm createNewCaps_obj_at2[where sz=sz])
+       apply (clarsimp simp: projectKO_opts_defs)
+       apply (simp add: inQ_def)
+      apply (wpsimp wp: createNewCaps_pred_tcb_at'[where sz=sz])+
+  done
 
 lemma mapM_x_threadSet_valid_pspace:
   "\<lbrace>valid_pspace' and K (curdom \<le> maxDomain)\<rbrace>
@@ -4814,8 +4814,8 @@ lemma createObjects_queues:
         pspace_no_overlap' ptr sz s \<and> range_cover ptr sz (objBitsKO val + gbits) n \<and> n \<noteq> 0\<rbrace>
   createObjects ptr n val gbits
   \<lbrace>\<lambda>rv. valid_queues\<rbrace>"
-  apply (wp valid_queues_lift_asm [unfolded pred_conj_def, OF createObjects_orig_obj_at3]
-            createObjects_pred_tcb_at' [unfolded pred_conj_def])
+  apply (wpsimp wp: valid_queues_lift_asm [unfolded pred_conj_def, OF createObjects_orig_obj_at3]
+                    createObjects_pred_tcb_at' [unfolded pred_conj_def])
       apply fastforce
      apply wp+
   apply fastforce

--- a/proof/refine/ARM/Schedule_R.thy
+++ b/proof/refine/ARM/Schedule_R.thy
@@ -1101,8 +1101,7 @@ lemma dmo_cap_to'[wp]:
 lemma sct_cap_to'[wp]:
   "\<lbrace>ex_nonz_cap_to' p\<rbrace> setCurThread t \<lbrace>\<lambda>rv. ex_nonz_cap_to' p\<rbrace>"
   apply (simp add: setCurThread_def)
-  apply (wp ex_nonz_cap_to_pres')
-   apply (clarsimp elim!: cte_wp_at'_pspaceI)+
+  apply (wpsimp wp: ex_nonz_cap_to_pres')
   done
 
 
@@ -2107,7 +2106,7 @@ proof -
       apply (rename_tac l1)
       apply (case_tac "l1 = 0")
        (* switch to idle thread *)
-       apply (simp, wp (once) switchToIdleThread_invs_no_cicd', simp)
+       apply (simp, wp switchToIdleThread_invs_no_cicd', simp)
       (* we have a thread to switch to *)
       apply (clarsimp simp: bitmap_fun_defs)
       apply (wp assert_inv)

--- a/proof/refine/ARM/TcbAcc_R.thy
+++ b/proof/refine/ARM/TcbAcc_R.thy
@@ -2311,7 +2311,7 @@ lemma threadSet_queued_sch_act_wf[wp]:
   "\<lbrace>\<lambda>s. sch_act_wf (ksSchedulerAction s) s\<rbrace>
     threadSet (tcbQueued_update f) t
    \<lbrace>\<lambda>_ s. sch_act_wf (ksSchedulerAction s) s\<rbrace>"
-  including no_pre
+  including classic_wp_pre
   apply (simp add: sch_act_wf_cases
               split: scheduler_action.split)
   apply (wp hoare_vcg_conj_lift)
@@ -2827,7 +2827,7 @@ lemma rescheduleRequired_valid_bitmapQ_sch_act_simple:
   "\<lbrace> valid_bitmapQ and sch_act_simple\<rbrace>
     rescheduleRequired
    \<lbrace>\<lambda>_. valid_bitmapQ \<rbrace>"
-  including no_pre
+  including classic_wp_pre
   apply (simp add: rescheduleRequired_def sch_act_simple_def)
   apply (rule_tac B="\<lambda>rv s. valid_bitmapQ s \<and>
                             (rv = ResumeCurrentThread \<or> rv = ChooseNewThread)" in hoare_seq_ext)
@@ -2840,7 +2840,7 @@ lemma rescheduleRequired_bitmapQ_no_L1_orphans_sch_act_simple:
   "\<lbrace> bitmapQ_no_L1_orphans and sch_act_simple\<rbrace>
     rescheduleRequired
    \<lbrace>\<lambda>_. bitmapQ_no_L1_orphans \<rbrace>"
-  including no_pre
+  including classic_wp_pre
   apply (simp add: rescheduleRequired_def sch_act_simple_def)
   apply (rule_tac B="\<lambda>rv s. bitmapQ_no_L1_orphans s \<and>
                             (rv = ResumeCurrentThread \<or> rv = ChooseNewThread)" in hoare_seq_ext)
@@ -2853,7 +2853,7 @@ lemma rescheduleRequired_bitmapQ_no_L2_orphans_sch_act_simple:
   "\<lbrace> bitmapQ_no_L2_orphans and sch_act_simple\<rbrace>
     rescheduleRequired
    \<lbrace>\<lambda>_. bitmapQ_no_L2_orphans \<rbrace>"
-  including no_pre
+  including classic_wp_pre
   apply (simp add: rescheduleRequired_def sch_act_simple_def)
   apply (rule_tac B="\<lambda>rv s. bitmapQ_no_L2_orphans s \<and>
                             (rv = ResumeCurrentThread \<or> rv = ChooseNewThread)" in hoare_seq_ext)

--- a/proof/refine/ARM/Tcb_R.thy
+++ b/proof/refine/ARM/Tcb_R.thy
@@ -1644,7 +1644,7 @@ proof -
                                emptyable_def
                    | wpc | strengthen tcb_cap_always_valid_strg
                                       use_no_cap_to_obj_asid_strg
-                   | wp (once) add: sch_act_simple_lift hoare_drop_imps del: cteInsert_invs
+                   | wp add: sch_act_simple_lift hoare_drop_imps del: cteInsert_invs
                    | (erule exE, clarsimp simp: word_bits_def))+
      (* the last two subgoals *)
      apply (clarsimp simp: tcb_at_cte_at_0 tcb_at_cte_at_1[simplified] tcb_at_st_tcb_at[symmetric]
@@ -2750,7 +2750,7 @@ crunches getThreadBufferSlot, setPriority, setMCPriority
 lemma inv_tcb_IRQInactive:
   "\<lbrace>valid_irq_states'\<rbrace> invokeTCB tcb_inv
   -, \<lbrace>\<lambda>rv s. intStateIRQTable (ksInterruptState s) rv \<noteq> irqstate.IRQInactive\<rbrace>"
-  including no_pre
+  including classic_wp_pre
   apply (simp add: invokeTCB_def)
   apply (rule hoare_pre)
    apply (wpc |

--- a/proof/refine/ARM/VSpace_R.thy
+++ b/proof/refine/ARM/VSpace_R.thy
@@ -881,13 +881,9 @@ lemma deleteASID_corres:
        apply (simp add: vs_refs_def)
        apply (rule image_eqI[rotated], erule graph_ofI)
        apply (simp add: mask_asid_low_bits_ucast_ucast)
-      apply wp
-      apply (simp add: o_def)
-      apply (wp getASID_wp)
-      apply clarsimp
-      apply assumption
-     apply wp+
-   apply clarsimp
+      \<comment> \<open>rewrite assumption so that the goal can refer to the C variable instead of the abstract's.\<close>
+      apply (drule Some_to_the)
+      apply (wpsimp wp: getASID_wp)+
    apply (clarsimp simp: valid_arch_state_def valid_asid_table_def
                   dest!: invs_arch_state)
    apply blast

--- a/proof/refine/ARM/orphanage/Orphanage.thy
+++ b/proof/refine/ARM/orphanage/Orphanage.thy
@@ -804,7 +804,7 @@ lemma chooseThread_no_orphans [wp]:
     apply (rename_tac l1)
     apply (case_tac "l1 = 0")
      (* switch to idle thread *)
-     apply (simp, wp (once), simp)
+     apply (simp, wp, simp)
     (* we have a thread to switch to *)
     apply (clarsimp simp: bitmap_fun_defs)
     apply (wp assert_inv ThreadDecls_H_switchToThread_no_orphans)
@@ -1883,10 +1883,8 @@ lemma cancelBadgedSends_no_orphans [wp]:
    cancelBadgedSends epptr badge
    \<lbrace> \<lambda>rv s. no_orphans s \<rbrace>"
   unfolding cancelBadgedSends_def
-  apply (rule hoare_pre)
-   apply (wp hoare_drop_imps | wpc | clarsimp)+
-      apply (wp filterM_preserved tcbSchedEnqueue_almost_no_orphans gts_wp'
-                sts_st_tcb' hoare_drop_imps | clarsimp)+
+  apply (wpsimp wp: filterM_preserved tcbSchedEnqueue_almost_no_orphans gts_wp' sts_st_tcb'
+         | wp (once) hoare_drop_imps)+
   done
 
 crunch no_orphans [wp]: invalidateTLBByASID "no_orphans"

--- a/proof/refine/ARM_HYP/Finalise_R.thy
+++ b/proof/refine/ARM_HYP/Finalise_R.thy
@@ -2745,7 +2745,7 @@ lemma arch_finaliseCap_removeable[wp]:
      Arch.finaliseCap cap final
    \<lbrace>\<lambda>rv s. isNullCap (fst rv) \<and> removeable' slot s (ArchObjectCap cap) \<and> isNullCap (snd rv)\<rbrace>"
   unfolding ARM_HYP_H.finaliseCap_def
-  including no_pre
+  including classic_wp_pre
   apply (case_tac cap; clarsimp)
        apply ((wpsimp simp: removeable'_def isCap_simps
                 | rule conjI)+)[5]
@@ -3419,7 +3419,7 @@ lemma cancelAllIPC_mapM_x_valid_objs':
                  tcbSchedEnqueue t
                od) q
    \<lbrace>\<lambda>_. valid_objs'\<rbrace>"
-  apply (wp mapM_x_wp' sts_valid_objs')
+  apply (wpsimp wp: mapM_x_wp' sts_valid_objs')
    apply (clarsimp simp: valid_tcb_state'_def)+
   done
 

--- a/proof/refine/ARM_HYP/IpcCancel_R.thy
+++ b/proof/refine/ARM_HYP/IpcCancel_R.thy
@@ -1173,7 +1173,7 @@ lemma sts_weak_sch_act_wf[wp]:
         \<and> (ksSchedulerAction s = SwitchToThread t \<longrightarrow> runnable' st)\<rbrace>
    setThreadState st t
    \<lbrace>\<lambda>_ s. weak_sch_act_wf (ksSchedulerAction s) s\<rbrace>"
-  including no_pre
+  including classic_wp_pre
   apply (simp add: setThreadState_def)
   apply (wp rescheduleRequired_weak_sch_act_wf)
   apply (rule_tac Q="\<lambda>_ s. weak_sch_act_wf (ksSchedulerAction s) s" in hoare_post_imp, simp)
@@ -1637,7 +1637,7 @@ lemma rescheduleRequired_oa_queued:
   apply (simp add: rescheduleRequired_def sch_act_simple_def)
   apply (rule_tac B="\<lambda>rv s. (rv = ResumeCurrentThread \<or> rv = ChooseNewThread)
                        \<and> ?OAQ t' p s" in hoare_seq_ext)
-   including no_pre
+   including classic_wp_pre
    apply (wp | clarsimp)+
    apply (case_tac x)
      apply (wp | clarsimp)+
@@ -1713,7 +1713,7 @@ lemma sts_valid_queues_partial:
                            pred_tcb_at'_def obj_at'_def inQ_def)
    apply (rule hoare_vcg_all_lift)+
     apply (rule hoare_convert_imp)
-     including no_pre
+     including classic_wp_pre
      apply (wp sts_ksQ setThreadState_oa_queued hoare_impI sts_pred_tcb_neq'
             | clarsimp)+
   apply (rule_tac Q="\<lambda>s. \<forall>d p. ?DISTINCT d p s \<and> sch_act_simple s" in hoare_pre_imp)

--- a/proof/refine/ARM_HYP/Ipc_R.thy
+++ b/proof/refine/ARM_HYP/Ipc_R.thy
@@ -717,8 +717,7 @@ lemma transferCapsToSlots_mdb[wp]:
           \<and> transferCaps_srcs caps s\<rbrace>
     transferCapsToSlots ep buffer n caps slots mi
    \<lbrace>\<lambda>rv. valid_mdb'\<rbrace>"
-  apply (wp transferCapsToSlots_presM[where drv=True and vo=True and emx=True and pad=True])
-    apply clarsimp
+  apply (wpsimp wp: transferCapsToSlots_presM[where drv=True and vo=True and emx=True and pad=True])
     apply (frule valid_capAligned)
     apply (clarsimp simp: cte_wp_at_ctes_of is_derived'_def badge_derived'_def)
    apply wp
@@ -871,7 +870,7 @@ lemma transferCapsToSlots_irq_handlers[wp]:
          and transferCaps_srcs caps\<rbrace>
      transferCapsToSlots ep buffer n caps slots mi
   \<lbrace>\<lambda>rv. valid_irq_handlers'\<rbrace>"
-  apply (wp transferCapsToSlots_presM[where vo=True and emx=False and drv=True and pad=False])
+  apply (wpsimp wp: transferCapsToSlots_presM[where vo=True and emx=False and drv=True and pad=False])
      apply (clarsimp simp: is_derived'_def cte_wp_at_ctes_of badge_derived'_def)
      apply (erule(2) valid_irq_handlers_ctes_ofD)
     apply wp
@@ -974,8 +973,8 @@ lemma tcts_zero_ranges[wp]:
           \<and> transferCaps_srcs caps s\<rbrace>
     transferCapsToSlots ep buffer n caps slots mi
   \<lbrace>\<lambda>rv. untyped_ranges_zero'\<rbrace>"
-  apply (wp transferCapsToSlots_presM[where emx=True and vo=True
-      and drv=True and pad=True])
+  apply (wpsimp wp: transferCapsToSlots_presM[where emx=True and vo=True
+                                                and drv=True and pad=True])
     apply (clarsimp simp: cte_wp_at_ctes_of)
    apply (simp add: cteCaps_of_def)
    apply (rule hoare_pre, wp untyped_ranges_zero_lift)
@@ -1194,7 +1193,7 @@ lemmas copyMRs_typ_at_lifts[wp] = typ_at_lifts [OF copyMRs_typ_at']
 
 lemma copy_mrs_invs'[wp]:
   "\<lbrace> invs' and tcb_at' s and tcb_at' r \<rbrace> copyMRs s sb r rb n \<lbrace>\<lambda>rv. invs' \<rbrace>"
-  including no_pre
+  including classic_wp_pre
   apply (simp add: copyMRs_def)
   apply (wp dmo_invs' no_irq_mapM no_irq_storeWord|
          simp add: split_def)

--- a/proof/refine/ARM_HYP/Retype_R.thy
+++ b/proof/refine/ARM_HYP/Retype_R.thy
@@ -3425,7 +3425,7 @@ lemma createObjects_orig_cte_wp_at2':
   apply (rule handy_prop_divs)
    apply (wp createObjects_orig_obj_at2'[where sz = sz], simp)
   apply (simp add: tcb_cte_cases_def)
-  including no_pre
+  including classic_wp_pre
   apply (wp handy_prop_divs createObjects_orig_obj_at2'[where sz = sz]
              | simp add: o_def cong: option.case_cong)+
   done
@@ -3446,7 +3446,7 @@ lemma createNewCaps_cte_wp_at2:
       \<and> pspace_no_overlap' ptr sz s\<rbrace>
      createNewCaps ty ptr n objsz dev
    \<lbrace>\<lambda>rv s. P (cte_wp_at' P' p s)\<rbrace>"
-  including no_pre
+  including classic_wp_pre
   apply (simp add: createNewCaps_def createObjects_def ARM_HYP_H.toAPIType_def
            split del: if_split)
   apply (case_tac ty; simp add: createNewCaps_def createObjects_def Arch_createNewCaps_def
@@ -4182,7 +4182,7 @@ lemma createNewCaps_idle'[wp]:
          apply (rename_tac apiobject_type)
          apply (case_tac apiobject_type, simp_all split del: if_split)[1]
              apply (wp, simp)
-           including no_pre
+           including classic_wp_pre
            apply (wp mapM_x_wp'
                      createObjects_idle'
                      threadSet_idle'
@@ -4378,12 +4378,12 @@ lemma createNewCaps_valid_queues:
        and K (range_cover ptr sz (APIType_capBits ty us) n \<and> n \<noteq> 0)\<rbrace>
      createNewCaps ty ptr n us d
    \<lbrace>\<lambda>rv. valid_queues\<rbrace>"
-apply (rule hoare_gen_asm)
-apply (wp valid_queues_lift_asm createNewCaps_obj_at2[where sz=sz])
-apply (clarsimp simp: projectKO_opts_defs)
-apply (simp add: inQ_def)
-apply (wp createNewCaps_pred_tcb_at'[where sz=sz] | simp)+
-done
+  apply (rule hoare_gen_asm)
+  apply (wpsimp wp: valid_queues_lift_asm createNewCaps_obj_at2[where sz=sz])
+       apply (clarsimp simp: projectKO_opts_defs)
+       apply (simp add: inQ_def)
+      apply (wpsimp wp: createNewCaps_pred_tcb_at'[where sz=sz])+
+  done
 
 lemma mapM_x_threadSet_valid_pspace:
   "\<lbrace>valid_pspace' and K (curdom \<le> maxDomain)\<rbrace>
@@ -4865,8 +4865,8 @@ lemma createObjects_queues:
         pspace_no_overlap' ptr sz s \<and> range_cover ptr sz (objBitsKO val + gbits) n \<and> n \<noteq> 0\<rbrace>
   createObjects ptr n val gbits
   \<lbrace>\<lambda>rv. valid_queues\<rbrace>"
-  apply (wp valid_queues_lift_asm [unfolded pred_conj_def, OF createObjects_orig_obj_at3]
-            createObjects_pred_tcb_at' [unfolded pred_conj_def])
+  apply (wpsimp wp: valid_queues_lift_asm [unfolded pred_conj_def, OF createObjects_orig_obj_at3]
+                    createObjects_pred_tcb_at' [unfolded pred_conj_def])
       apply fastforce
      apply wp+
   apply fastforce

--- a/proof/refine/ARM_HYP/Schedule_R.thy
+++ b/proof/refine/ARM_HYP/Schedule_R.thy
@@ -1189,8 +1189,7 @@ lemma dmo_cap_to'[wp]:
 lemma sct_cap_to'[wp]:
   "\<lbrace>ex_nonz_cap_to' p\<rbrace> setCurThread t \<lbrace>\<lambda>rv. ex_nonz_cap_to' p\<rbrace>"
   apply (simp add: setCurThread_def)
-  apply (wp ex_nonz_cap_to_pres')
-   apply (clarsimp elim!: cte_wp_at'_pspaceI)+
+  apply (wpsimp wp: ex_nonz_cap_to_pres')
   done
 
 lemma setVCPU_cap_to'[wp]:
@@ -2233,7 +2232,7 @@ proof -
       apply (rename_tac l1)
       apply (case_tac "l1 = 0")
        (* switch to idle thread *)
-       apply (simp, wp (once) switchToIdleThread_invs_no_cicd', simp)
+       apply (simp, wp switchToIdleThread_invs_no_cicd', simp)
       (* we have a thread to switch to *)
       apply (clarsimp simp: bitmap_fun_defs)
       apply (wp assert_inv)

--- a/proof/refine/ARM_HYP/TcbAcc_R.thy
+++ b/proof/refine/ARM_HYP/TcbAcc_R.thy
@@ -2390,7 +2390,7 @@ lemma threadSet_queued_sch_act_wf[wp]:
   "\<lbrace>\<lambda>s. sch_act_wf (ksSchedulerAction s) s\<rbrace>
     threadSet (tcbQueued_update f) t
    \<lbrace>\<lambda>_ s. sch_act_wf (ksSchedulerAction s) s\<rbrace>"
-  including no_pre
+  including classic_wp_pre
   apply (simp add: sch_act_wf_cases
               split: scheduler_action.split)
   apply (wp hoare_vcg_conj_lift)
@@ -2911,7 +2911,7 @@ lemma rescheduleRequired_valid_bitmapQ_sch_act_simple:
   "\<lbrace> valid_bitmapQ and sch_act_simple\<rbrace>
     rescheduleRequired
    \<lbrace>\<lambda>_. valid_bitmapQ \<rbrace>"
-  including no_pre
+  including classic_wp_pre
   apply (simp add: rescheduleRequired_def sch_act_simple_def)
   apply (rule_tac B="\<lambda>rv s. valid_bitmapQ s \<and>
                             (rv = ResumeCurrentThread \<or> rv = ChooseNewThread)" in hoare_seq_ext)
@@ -2924,7 +2924,7 @@ lemma rescheduleRequired_bitmapQ_no_L1_orphans_sch_act_simple:
   "\<lbrace> bitmapQ_no_L1_orphans and sch_act_simple\<rbrace>
     rescheduleRequired
    \<lbrace>\<lambda>_. bitmapQ_no_L1_orphans \<rbrace>"
-  including no_pre
+  including classic_wp_pre
   apply (simp add: rescheduleRequired_def sch_act_simple_def)
   apply (rule_tac B="\<lambda>rv s. bitmapQ_no_L1_orphans s \<and>
                             (rv = ResumeCurrentThread \<or> rv = ChooseNewThread)" in hoare_seq_ext)
@@ -2937,7 +2937,7 @@ lemma rescheduleRequired_bitmapQ_no_L2_orphans_sch_act_simple:
   "\<lbrace> bitmapQ_no_L2_orphans and sch_act_simple\<rbrace>
     rescheduleRequired
    \<lbrace>\<lambda>_. bitmapQ_no_L2_orphans \<rbrace>"
-  including no_pre
+  including classic_wp_pre
   apply (simp add: rescheduleRequired_def sch_act_simple_def)
   apply (rule_tac B="\<lambda>rv s. bitmapQ_no_L2_orphans s \<and>
                             (rv = ResumeCurrentThread \<or> rv = ChooseNewThread)" in hoare_seq_ext)

--- a/proof/refine/ARM_HYP/Tcb_R.thy
+++ b/proof/refine/ARM_HYP/Tcb_R.thy
@@ -1619,7 +1619,7 @@ proof -
                                emptyable_def
                    | wpc | strengthen tcb_cap_always_valid_strg
                                       use_no_cap_to_obj_asid_strg
-                   | wp (once) add: sch_act_simple_lift hoare_drop_imps del: cteInsert_invs
+                   | wp add: sch_act_simple_lift hoare_drop_imps del: cteInsert_invs
                    | (erule exE, clarsimp simp: word_bits_def))+
      (* the last two subgoals *)
      apply (clarsimp simp: tcb_at_cte_at_0 tcb_at_cte_at_1[simplified] tcb_at_st_tcb_at[symmetric]
@@ -2779,7 +2779,7 @@ crunches getThreadBufferSlot, setPriority, setMCPriority
 lemma inv_tcb_IRQInactive:
   "\<lbrace>valid_irq_states'\<rbrace> invokeTCB tcb_inv
   -, \<lbrace>\<lambda>rv s. intStateIRQTable (ksInterruptState s) rv \<noteq> irqstate.IRQInactive\<rbrace>"
-  including no_pre
+  including classic_wp_pre
   apply (simp add: invokeTCB_def)
   apply (rule hoare_pre)
    apply (wpc |

--- a/proof/refine/ARM_HYP/VSpace_R.thy
+++ b/proof/refine/ARM_HYP/VSpace_R.thy
@@ -1424,13 +1424,9 @@ lemma deleteASID_corres:
        apply (simp add: vs_refs_def)
        apply (rule image_eqI[rotated], erule graph_ofI)
        apply (simp add: mask_asid_low_bits_ucast_ucast)
-      apply wp
-      apply (simp add: o_def)
-      apply (wp getASID_wp)
-      apply clarsimp
-      apply assumption
-     apply wp+
-   apply clarsimp
+      \<comment> \<open>rewrite assumption so that the goal can refer to the C variable instead of the abstract's.\<close>
+      apply (drule Some_to_the)
+      apply (wpsimp wp: getASID_wp)+
    apply (clarsimp simp: valid_arch_state_def valid_asid_table_def
                   dest!: invs_arch_state)
    apply blast

--- a/proof/refine/RISCV64/Finalise_R.thy
+++ b/proof/refine/RISCV64/Finalise_R.thy
@@ -3017,7 +3017,7 @@ lemma cancelAllIPC_mapM_x_valid_objs':
                  tcbSchedEnqueue t
                od) q
    \<lbrace>\<lambda>_. valid_objs'\<rbrace>"
-  apply (wp mapM_x_wp' sts_valid_objs')
+  apply (wpsimp wp: mapM_x_wp' sts_valid_objs')
    apply (clarsimp simp: valid_tcb_state'_def)+
   done
 

--- a/proof/refine/RISCV64/IpcCancel_R.thy
+++ b/proof/refine/RISCV64/IpcCancel_R.thy
@@ -1110,7 +1110,7 @@ lemma sts_weak_sch_act_wf[wp]:
         \<and> (ksSchedulerAction s = SwitchToThread t \<longrightarrow> runnable' st)\<rbrace>
    setThreadState st t
    \<lbrace>\<lambda>_ s. weak_sch_act_wf (ksSchedulerAction s) s\<rbrace>"
-  including no_pre
+  including classic_wp_pre
   apply (simp add: setThreadState_def)
   apply (wp rescheduleRequired_weak_sch_act_wf)
   apply (rule_tac Q="\<lambda>_ s. weak_sch_act_wf (ksSchedulerAction s) s" in hoare_post_imp, simp)
@@ -1447,7 +1447,7 @@ lemma rescheduleRequired_oa_queued:
   apply (simp add: rescheduleRequired_def sch_act_simple_def)
   apply (rule_tac B="\<lambda>rv s. (rv = ResumeCurrentThread \<or> rv = ChooseNewThread)
                        \<and> ?OAQ t' p s" in hoare_seq_ext)
-   including no_pre
+   including classic_wp_pre
    apply (wp | clarsimp)+
    apply (case_tac x)
      apply (wp | clarsimp)+
@@ -1523,7 +1523,7 @@ lemma sts_valid_queues_partial:
                            pred_tcb_at'_def obj_at'_def inQ_def)
    apply (rule hoare_vcg_all_lift)+
     apply (rule hoare_convert_imp)
-     including no_pre
+     including classic_wp_pre
      apply (wp sts_ksQ setThreadState_oa_queued hoare_impI sts_pred_tcb_neq'
             | clarsimp)+
   apply (rule_tac Q="\<lambda>s. \<forall>d p. ?DISTINCT d p s \<and> sch_act_simple s" in hoare_pre_imp)

--- a/proof/refine/RISCV64/Ipc_R.thy
+++ b/proof/refine/RISCV64/Ipc_R.thy
@@ -713,8 +713,7 @@ lemma transferCapsToSlots_mdb[wp]:
           \<and> transferCaps_srcs caps s\<rbrace>
     transferCapsToSlots ep buffer n caps slots mi
    \<lbrace>\<lambda>rv. valid_mdb'\<rbrace>"
-  apply (wp transferCapsToSlots_presM[where drv=True and vo=True and emx=True and pad=True])
-    apply clarsimp
+  apply (wpsimp wp: transferCapsToSlots_presM[where drv=True and vo=True and emx=True and pad=True])
     apply (frule valid_capAligned)
     apply (clarsimp simp: cte_wp_at_ctes_of is_derived'_def badge_derived'_def)
    apply wp
@@ -861,7 +860,7 @@ lemma transferCapsToSlots_irq_handlers[wp]:
          and transferCaps_srcs caps\<rbrace>
      transferCapsToSlots ep buffer n caps slots mi
   \<lbrace>\<lambda>rv. valid_irq_handlers'\<rbrace>"
-  apply (wp transferCapsToSlots_presM[where vo=True and emx=False and drv=True and pad=False])
+  apply (wpsimp wp: transferCapsToSlots_presM[where vo=True and emx=False and drv=True and pad=False])
      apply (clarsimp simp: is_derived'_def cte_wp_at_ctes_of badge_derived'_def)
      apply (erule(2) valid_irq_handlers_ctes_ofD)
     apply wp
@@ -958,8 +957,8 @@ lemma tcts_zero_ranges[wp]:
           \<and> transferCaps_srcs caps s\<rbrace>
     transferCapsToSlots ep buffer n caps slots mi
   \<lbrace>\<lambda>rv. untyped_ranges_zero'\<rbrace>"
-  apply (wp transferCapsToSlots_presM[where emx=True and vo=True
-      and drv=True and pad=True])
+  apply (wpsimp wp: transferCapsToSlots_presM[where emx=True and vo=True
+                                                and drv=True and pad=True])
     apply (clarsimp simp: cte_wp_at_ctes_of)
    apply (simp add: cteCaps_of_def)
    apply (rule hoare_pre, wp untyped_ranges_zero_lift)
@@ -1179,7 +1178,7 @@ lemmas copyMRs_typ_at_lifts[wp] = typ_at_lifts [OF copyMRs_typ_at']
 
 lemma copy_mrs_invs'[wp]:
   "\<lbrace> invs' and tcb_at' s and tcb_at' r \<rbrace> copyMRs s sb r rb n \<lbrace>\<lambda>rv. invs' \<rbrace>"
-  including no_pre
+  including classic_wp_pre
   apply (simp add: copyMRs_def)
   apply (wp dmo_invs' no_irq_mapM no_irq_storeWord|
          simp add: split_def)

--- a/proof/refine/RISCV64/Retype_R.thy
+++ b/proof/refine/RISCV64/Retype_R.thy
@@ -3373,11 +3373,11 @@ lemma createObjects_orig_cte_wp_at2':
               \<not> (case_option False (P' \<circ> getF) (projectKO_opt val)))
       \<and> pspace_no_overlap' ptr sz s\<rbrace>
   createObjects' ptr n val gbits \<lbrace>\<lambda>r s. P (cte_wp_at' P' p s)\<rbrace>"
+  including classic_wp_pre
   apply (simp add: cte_wp_at'_obj_at')
   apply (rule handy_prop_divs)
    apply (wp createObjects_orig_obj_at2'[where sz = sz], simp)
   apply (simp add: tcb_cte_cases_def cteSizeBits_def)
-  including no_pre
   apply (wp handy_prop_divs createObjects_orig_obj_at2'[where sz = sz]
              | simp add: o_def cong: option.case_cong)+
   done
@@ -3398,7 +3398,7 @@ lemma createNewCaps_cte_wp_at2:
       \<and> pspace_no_overlap' ptr sz s\<rbrace>
      createNewCaps ty ptr n objsz dev
    \<lbrace>\<lambda>rv s. P (cte_wp_at' P' p s)\<rbrace>"
-  including no_pre
+  including classic_wp_pre
   apply (simp add: createNewCaps_def createObjects_def RISCV64_H.toAPIType_def
            split del: if_split)
   apply (case_tac ty; simp add: createNewCaps_def createObjects_def Arch_createNewCaps_def
@@ -4055,7 +4055,7 @@ lemma createNewCaps_idle'[wp]:
          apply (rename_tac apiobject_type)
          apply (case_tac apiobject_type, simp_all split del: if_split)[1]
              apply (wp, simp)
-           including no_pre
+           including classic_wp_pre
            apply (wp mapM_x_wp'
                      createObjects_idle'
                      threadSet_idle'
@@ -4191,8 +4191,7 @@ lemma createNewCaps_valid_queues:
      createNewCaps ty ptr n us d
    \<lbrace>\<lambda>rv. valid_queues\<rbrace>"
   apply (rule hoare_gen_asm)
-  apply (wp valid_queues_lift_asm createNewCaps_obj_at2[where sz=sz])
-       apply (clarsimp simp: projectKO_opts_defs)
+  apply (wpsimp wp: valid_queues_lift_asm createNewCaps_obj_at2[where sz=sz])
        apply (simp add: inQ_def)
       apply (wp createNewCaps_pred_tcb_at'[where sz=sz] | simp)+
   done
@@ -4661,8 +4660,8 @@ lemma createObjects_queues:
         pspace_no_overlap' ptr sz s \<and> range_cover ptr sz (objBitsKO val + gbits) n \<and> n \<noteq> 0\<rbrace>
   createObjects ptr n val gbits
   \<lbrace>\<lambda>rv. valid_queues\<rbrace>"
-  apply (wp valid_queues_lift_asm [unfolded pred_conj_def, OF createObjects_orig_obj_at3]
-            createObjects_pred_tcb_at' [unfolded pred_conj_def])
+  apply (wpsimp wp: valid_queues_lift_asm [unfolded pred_conj_def, OF createObjects_orig_obj_at3]
+                    createObjects_pred_tcb_at' [unfolded pred_conj_def])
       apply fastforce
      apply wp+
   apply fastforce

--- a/proof/refine/RISCV64/Schedule_R.thy
+++ b/proof/refine/RISCV64/Schedule_R.thy
@@ -1079,8 +1079,7 @@ lemma dmo_cap_to'[wp]:
 lemma sct_cap_to'[wp]:
   "\<lbrace>ex_nonz_cap_to' p\<rbrace> setCurThread t \<lbrace>\<lambda>rv. ex_nonz_cap_to' p\<rbrace>"
   apply (simp add: setCurThread_def)
-  apply (wp ex_nonz_cap_to_pres')
-   apply (clarsimp elim!: cte_wp_at'_pspaceI)+
+  apply (wpsimp wp: ex_nonz_cap_to_pres')
   done
 
 
@@ -2095,7 +2094,7 @@ proof -
       apply (rename_tac l1)
       apply (case_tac "l1 = 0")
        (* switch to idle thread *)
-       apply (simp, wp (once) switchToIdleThread_invs_no_cicd', simp)
+       apply (simp, wp switchToIdleThread_invs_no_cicd', simp)
       (* we have a thread to switch to *)
       apply (clarsimp simp: bitmap_fun_defs)
       apply (wp assert_inv)

--- a/proof/refine/RISCV64/TcbAcc_R.thy
+++ b/proof/refine/RISCV64/TcbAcc_R.thy
@@ -2358,7 +2358,7 @@ lemma threadSet_queued_sch_act_wf[wp]:
   "\<lbrace>\<lambda>s. sch_act_wf (ksSchedulerAction s) s\<rbrace>
     threadSet (tcbQueued_update f) t
    \<lbrace>\<lambda>_ s. sch_act_wf (ksSchedulerAction s) s\<rbrace>"
-  including no_pre
+  including classic_wp_pre
   apply (simp add: sch_act_wf_cases
               split: scheduler_action.split)
   apply (wp hoare_vcg_conj_lift)
@@ -2879,7 +2879,7 @@ lemma rescheduleRequired_valid_bitmapQ_sch_act_simple:
   "\<lbrace> valid_bitmapQ and sch_act_simple\<rbrace>
     rescheduleRequired
    \<lbrace>\<lambda>_. valid_bitmapQ \<rbrace>"
-  including no_pre
+  including classic_wp_pre
   apply (simp add: rescheduleRequired_def sch_act_simple_def)
   apply (rule_tac B="\<lambda>rv s. valid_bitmapQ s \<and>
                             (rv = ResumeCurrentThread \<or> rv = ChooseNewThread)" in hoare_seq_ext)
@@ -2892,7 +2892,7 @@ lemma rescheduleRequired_bitmapQ_no_L1_orphans_sch_act_simple:
   "\<lbrace> bitmapQ_no_L1_orphans and sch_act_simple\<rbrace>
     rescheduleRequired
    \<lbrace>\<lambda>_. bitmapQ_no_L1_orphans \<rbrace>"
-  including no_pre
+  including classic_wp_pre
   apply (simp add: rescheduleRequired_def sch_act_simple_def)
   apply (rule_tac B="\<lambda>rv s. bitmapQ_no_L1_orphans s \<and>
                             (rv = ResumeCurrentThread \<or> rv = ChooseNewThread)" in hoare_seq_ext)
@@ -2905,7 +2905,7 @@ lemma rescheduleRequired_bitmapQ_no_L2_orphans_sch_act_simple:
   "\<lbrace> bitmapQ_no_L2_orphans and sch_act_simple\<rbrace>
     rescheduleRequired
    \<lbrace>\<lambda>_. bitmapQ_no_L2_orphans \<rbrace>"
-  including no_pre
+  including classic_wp_pre
   apply (simp add: rescheduleRequired_def sch_act_simple_def)
   apply (rule_tac B="\<lambda>rv s. bitmapQ_no_L2_orphans s \<and>
                             (rv = ResumeCurrentThread \<or> rv = ChooseNewThread)" in hoare_seq_ext)

--- a/proof/refine/RISCV64/Tcb_R.thy
+++ b/proof/refine/RISCV64/Tcb_R.thy
@@ -1557,7 +1557,7 @@ proof -
                                emptyable_def
                    | wpc | strengthen tcb_cap_always_valid_strg
                                       use_no_cap_to_obj_asid_strg
-                   | wp (once) add: sch_act_simple_lift hoare_drop_imps del: cteInsert_invs
+                   | wp add: sch_act_simple_lift hoare_drop_imps del: cteInsert_invs
                    | (erule exE, clarsimp simp: word_bits_def))+
      apply (clarsimp simp: tcb_at_cte_at_0 tcb_at_cte_at_1[simplified] tcb_at_st_tcb_at[symmetric]
                            tcb_cap_valid_def is_cnode_or_valid_arch_def invs_valid_objs emptyable_def
@@ -2703,7 +2703,7 @@ crunches getThreadBufferSlot, setPriority, setMCPriority
 lemma inv_tcb_IRQInactive:
   "\<lbrace>valid_irq_states'\<rbrace> invokeTCB tcb_inv
   -, \<lbrace>\<lambda>rv s. intStateIRQTable (ksInterruptState s) rv \<noteq> irqstate.IRQInactive\<rbrace>"
-  including no_pre
+  including classic_wp_pre
   apply (simp add: invokeTCB_def)
   apply (rule hoare_pre)
    apply (wpc |

--- a/proof/refine/RISCV64/orphanage/Orphanage.thy
+++ b/proof/refine/RISCV64/orphanage/Orphanage.thy
@@ -792,7 +792,7 @@ lemma chooseThread_no_orphans [wp]:
     apply (rename_tac l1)
     apply (case_tac "l1 = 0")
      (* switch to idle thread *)
-     apply (simp, wp (once), simp)
+     apply (simp, wp, simp)
     (* we have a thread to switch to *)
     apply (clarsimp simp: bitmap_fun_defs)
     apply (wp assert_inv ThreadDecls_H_switchToThread_no_orphans)
@@ -1855,10 +1855,8 @@ lemma cancelBadgedSends_no_orphans [wp]:
    cancelBadgedSends epptr badge
    \<lbrace> \<lambda>rv s. no_orphans s \<rbrace>"
   unfolding cancelBadgedSends_def
-  apply (rule hoare_pre)
-   apply (wp hoare_drop_imps | wpc | clarsimp)+
-      apply (wp filterM_preserved tcbSchedEnqueue_almost_no_orphans gts_wp'
-                sts_st_tcb' hoare_drop_imps | clarsimp)+
+  apply (wpsimp wp: filterM_preserved tcbSchedEnqueue_almost_no_orphans gts_wp' sts_st_tcb'
+         | wp (once) hoare_drop_imps)+
   done
 
 crunch no_orphans [wp]: handleFaultReply "no_orphans"

--- a/proof/refine/X64/Finalise_R.thy
+++ b/proof/refine/X64/Finalise_R.thy
@@ -3189,7 +3189,7 @@ lemma cancelAllIPC_mapM_x_valid_objs':
                  tcbSchedEnqueue t
                od) q
    \<lbrace>\<lambda>_. valid_objs'\<rbrace>"
-  apply (wp mapM_x_wp' sts_valid_objs')
+  apply (wpsimp wp: mapM_x_wp' sts_valid_objs')
    apply (clarsimp simp: valid_tcb_state'_def)+
   done
 

--- a/proof/refine/X64/IpcCancel_R.thy
+++ b/proof/refine/X64/IpcCancel_R.thy
@@ -1157,7 +1157,7 @@ lemma sts_weak_sch_act_wf[wp]:
         \<and> (ksSchedulerAction s = SwitchToThread t \<longrightarrow> runnable' st)\<rbrace>
    setThreadState st t
    \<lbrace>\<lambda>_ s. weak_sch_act_wf (ksSchedulerAction s) s\<rbrace>"
-  including no_pre
+  including classic_wp_pre
   apply (simp add: setThreadState_def)
   apply (wp rescheduleRequired_weak_sch_act_wf)
   apply (rule_tac Q="\<lambda>_ s. weak_sch_act_wf (ksSchedulerAction s) s" in hoare_post_imp, simp)
@@ -1513,7 +1513,7 @@ lemma rescheduleRequired_oa_queued:
   apply (simp add: rescheduleRequired_def sch_act_simple_def)
   apply (rule_tac B="\<lambda>rv s. (rv = ResumeCurrentThread \<or> rv = ChooseNewThread)
                        \<and> ?OAQ t' p s" in hoare_seq_ext)
-   including no_pre
+   including classic_wp_pre
    apply (wp | clarsimp)+
    apply (case_tac x)
      apply (wp | clarsimp)+
@@ -1589,7 +1589,7 @@ lemma sts_valid_queues_partial:
                            pred_tcb_at'_def obj_at'_def inQ_def)
    apply (rule hoare_vcg_all_lift)+
     apply (rule hoare_convert_imp)
-     including no_pre
+     including classic_wp_pre
      apply (wp sts_ksQ setThreadState_oa_queued hoare_impI sts_pred_tcb_neq'
             | clarsimp)+
   apply (rule_tac Q="\<lambda>s. \<forall>d p. ?DISTINCT d p s \<and> sch_act_simple s" in hoare_pre_imp)

--- a/proof/refine/X64/Ipc_R.thy
+++ b/proof/refine/X64/Ipc_R.thy
@@ -713,8 +713,7 @@ lemma transferCapsToSlots_mdb[wp]:
           \<and> transferCaps_srcs caps s\<rbrace>
     transferCapsToSlots ep buffer n caps slots mi
    \<lbrace>\<lambda>rv. valid_mdb'\<rbrace>"
-  apply (wp transferCapsToSlots_presM[where drv=True and vo=True and emx=True and pad=True])
-    apply clarsimp
+  apply (wpsimp wp: transferCapsToSlots_presM[where drv=True and vo=True and emx=True and pad=True])
     apply (frule valid_capAligned)
     apply (clarsimp simp: cte_wp_at_ctes_of is_derived'_def badge_derived'_def)
    apply wp
@@ -860,7 +859,7 @@ lemma transferCapsToSlots_irq_handlers[wp]:
          and transferCaps_srcs caps\<rbrace>
      transferCapsToSlots ep buffer n caps slots mi
   \<lbrace>\<lambda>rv. valid_irq_handlers'\<rbrace>"
-  apply (wp transferCapsToSlots_presM[where vo=True and emx=False and drv=True and pad=False])
+  apply (wpsimp wp: transferCapsToSlots_presM[where vo=True and emx=False and drv=True and pad=False])
      apply (clarsimp simp: is_derived'_def cte_wp_at_ctes_of badge_derived'_def)
      apply (erule(2) valid_irq_handlers_ctes_ofD)
     apply wp
@@ -893,7 +892,7 @@ lemma transferCapsToSlots_ioports'[wp]:
          and transferCaps_srcs caps\<rbrace>
      transferCapsToSlots ep buffer n caps slots mi
   \<lbrace>\<lambda>rv. valid_ioports'\<rbrace>"
-  apply (wp transferCapsToSlots_presM[where vo=True and emx=False and drv=True and pad=False])
+  apply (wpsimp wp: transferCapsToSlots_presM[where vo=True and emx=False and drv=True and pad=False])
      apply (clarsimp simp: valid_ioports'_derivedD)
     apply wp
   apply (clarsimp simp:cte_wp_at_ctes_of | intro ballI conjI)+
@@ -989,8 +988,8 @@ lemma tcts_zero_ranges[wp]:
           \<and> transferCaps_srcs caps s\<rbrace>
     transferCapsToSlots ep buffer n caps slots mi
   \<lbrace>\<lambda>rv. untyped_ranges_zero'\<rbrace>"
-  apply (wp transferCapsToSlots_presM[where emx=True and vo=True
-      and drv=True and pad=True])
+  apply (wpsimp wp: transferCapsToSlots_presM[where emx=True and vo=True
+                                                and drv=True and pad=True])
     apply (clarsimp simp: cte_wp_at_ctes_of)
    apply (simp add: cteCaps_of_def)
    apply (rule hoare_pre, wp untyped_ranges_zero_lift)
@@ -1228,7 +1227,7 @@ lemmas copyMRs_typ_at_lifts[wp] = typ_at_lifts [OF copyMRs_typ_at']
 
 lemma copy_mrs_invs'[wp]:
   "\<lbrace> invs' and tcb_at' s and tcb_at' r \<rbrace> copyMRs s sb r rb n \<lbrace>\<lambda>rv. invs' \<rbrace>"
-  including no_pre
+  including classic_wp_pre
   apply (simp add: copyMRs_def)
   apply (wp dmo_invs' no_irq_mapM no_irq_storeWord|
          simp add: split_def)

--- a/proof/refine/X64/Retype_R.thy
+++ b/proof/refine/X64/Retype_R.thy
@@ -3519,7 +3519,7 @@ lemma createObjects_orig_cte_wp_at2':
   apply (rule handy_prop_divs)
    apply (wp createObjects_orig_obj_at2'[where sz = sz], simp)
   apply (simp add: tcb_cte_cases_def)
-  including no_pre
+  including classic_wp_pre
   apply (wp handy_prop_divs createObjects_orig_obj_at2'[where sz = sz]
              | simp add: o_def cong: option.case_cong)+
   done
@@ -3540,7 +3540,7 @@ lemma createNewCaps_cte_wp_at2:
       \<and> pspace_no_overlap' ptr sz s\<rbrace>
      createNewCaps ty ptr n objsz dev
    \<lbrace>\<lambda>rv s. P (cte_wp_at' P' p s)\<rbrace>"
-  including no_pre
+  including classic_wp_pre
   apply (simp add: createNewCaps_def createObjects_def X64_H.toAPIType_def
            split del: if_split)
   apply (case_tac ty; simp add: createNewCaps_def createObjects_def Arch_createNewCaps_def
@@ -4225,7 +4225,7 @@ lemma createNewCaps_idle'[wp]:
          apply (rename_tac apiobject_type)
          apply (case_tac apiobject_type, simp_all split del: if_split)[1]
              apply (wp, simp)
-           including no_pre
+           including classic_wp_pre
            apply (wp mapM_x_wp'
                      createObjects_idle'
                      threadSet_idle'
@@ -4390,12 +4390,12 @@ lemma createNewCaps_valid_queues:
        and K (range_cover ptr sz (APIType_capBits ty us) n \<and> n \<noteq> 0)\<rbrace>
      createNewCaps ty ptr n us d
    \<lbrace>\<lambda>rv. valid_queues\<rbrace>"
-apply (rule hoare_gen_asm)
-apply (wp valid_queues_lift_asm createNewCaps_obj_at2[where sz=sz])
-apply (clarsimp simp: projectKO_opts_defs)
-apply (simp add: inQ_def)
-apply (wp createNewCaps_pred_tcb_at'[where sz=sz] | simp)+
-done
+  apply (rule hoare_gen_asm)
+  apply (wpsimp wp: valid_queues_lift_asm createNewCaps_obj_at2[where sz=sz])
+       apply (clarsimp simp: projectKO_opts_defs)
+       apply (simp add: inQ_def)
+      apply (wpsimp wp: createNewCaps_pred_tcb_at'[where sz=sz])+
+  done
 
 lemma mapM_x_threadSet_valid_pspace:
   "\<lbrace>valid_pspace' and K (curdom \<le> maxDomain)\<rbrace>
@@ -4866,8 +4866,8 @@ lemma createObjects_queues:
         pspace_no_overlap' ptr sz s \<and> range_cover ptr sz (objBitsKO val + gbits) n \<and> n \<noteq> 0\<rbrace>
   createObjects ptr n val gbits
   \<lbrace>\<lambda>rv. valid_queues\<rbrace>"
-  apply (wp valid_queues_lift_asm [unfolded pred_conj_def, OF createObjects_orig_obj_at3]
-            createObjects_pred_tcb_at' [unfolded pred_conj_def])
+  apply (wpsimp wp: valid_queues_lift_asm [unfolded pred_conj_def, OF createObjects_orig_obj_at3]
+                    createObjects_pred_tcb_at' [unfolded pred_conj_def])
       apply fastforce
      apply wp+
   apply fastforce

--- a/proof/refine/X64/Schedule_R.thy
+++ b/proof/refine/X64/Schedule_R.thy
@@ -1078,8 +1078,7 @@ lemma dmo_cap_to'[wp]:
 lemma sct_cap_to'[wp]:
   "\<lbrace>ex_nonz_cap_to' p\<rbrace> setCurThread t \<lbrace>\<lambda>rv. ex_nonz_cap_to' p\<rbrace>"
   apply (simp add: setCurThread_def)
-  apply (wp ex_nonz_cap_to_pres')
-   apply (clarsimp elim!: cte_wp_at'_pspaceI)+
+  apply (wpsimp wp: ex_nonz_cap_to_pres')
   done
 
 
@@ -2098,7 +2097,7 @@ proof -
       apply (rename_tac l1)
       apply (case_tac "l1 = 0")
        (* switch to idle thread *)
-       apply (simp, wp (once) switchToIdleThread_invs_no_cicd', simp)
+       apply (simp, wp switchToIdleThread_invs_no_cicd', simp)
       (* we have a thread to switch to *)
       apply (clarsimp simp: bitmap_fun_defs)
       apply (wp assert_inv)

--- a/proof/refine/X64/TcbAcc_R.thy
+++ b/proof/refine/X64/TcbAcc_R.thy
@@ -2345,7 +2345,7 @@ lemma threadSet_queued_sch_act_wf[wp]:
   "\<lbrace>\<lambda>s. sch_act_wf (ksSchedulerAction s) s\<rbrace>
     threadSet (tcbQueued_update f) t
    \<lbrace>\<lambda>_ s. sch_act_wf (ksSchedulerAction s) s\<rbrace>"
-  including no_pre
+  including classic_wp_pre
   apply (simp add: sch_act_wf_cases
               split: scheduler_action.split)
   apply (wp hoare_vcg_conj_lift)
@@ -2866,7 +2866,7 @@ lemma rescheduleRequired_valid_bitmapQ_sch_act_simple:
   "\<lbrace> valid_bitmapQ and sch_act_simple\<rbrace>
     rescheduleRequired
    \<lbrace>\<lambda>_. valid_bitmapQ \<rbrace>"
-  including no_pre
+  including classic_wp_pre
   apply (simp add: rescheduleRequired_def sch_act_simple_def)
   apply (rule_tac B="\<lambda>rv s. valid_bitmapQ s \<and>
                             (rv = ResumeCurrentThread \<or> rv = ChooseNewThread)" in hoare_seq_ext)
@@ -2879,7 +2879,7 @@ lemma rescheduleRequired_bitmapQ_no_L1_orphans_sch_act_simple:
   "\<lbrace> bitmapQ_no_L1_orphans and sch_act_simple\<rbrace>
     rescheduleRequired
    \<lbrace>\<lambda>_. bitmapQ_no_L1_orphans \<rbrace>"
-  including no_pre
+  including classic_wp_pre
   apply (simp add: rescheduleRequired_def sch_act_simple_def)
   apply (rule_tac B="\<lambda>rv s. bitmapQ_no_L1_orphans s \<and>
                             (rv = ResumeCurrentThread \<or> rv = ChooseNewThread)" in hoare_seq_ext)
@@ -2892,7 +2892,7 @@ lemma rescheduleRequired_bitmapQ_no_L2_orphans_sch_act_simple:
   "\<lbrace> bitmapQ_no_L2_orphans and sch_act_simple\<rbrace>
     rescheduleRequired
    \<lbrace>\<lambda>_. bitmapQ_no_L2_orphans \<rbrace>"
-  including no_pre
+  including classic_wp_pre
   apply (simp add: rescheduleRequired_def sch_act_simple_def)
   apply (rule_tac B="\<lambda>rv s. bitmapQ_no_L2_orphans s \<and>
                             (rv = ResumeCurrentThread \<or> rv = ChooseNewThread)" in hoare_seq_ext)

--- a/proof/refine/X64/Tcb_R.thy
+++ b/proof/refine/X64/Tcb_R.thy
@@ -1584,7 +1584,7 @@ proof -
                                emptyable_def
                    | wpc | strengthen tcb_cap_always_valid_strg
                                       use_no_cap_to_obj_asid_strg
-                   | wp (once) add: sch_act_simple_lift hoare_drop_imps del: cteInsert_invs
+                   | wp add: sch_act_simple_lift hoare_drop_imps del: cteInsert_invs
                    | (erule exE, clarsimp simp: word_bits_def))+
      (* the last two subgoals *)
      apply (clarsimp simp: tcb_at_cte_at_0 tcb_at_cte_at_1[simplified] tcb_at_st_tcb_at[symmetric]
@@ -2735,7 +2735,7 @@ crunches getThreadBufferSlot, setPriority, setMCPriority
 lemma inv_tcb_IRQInactive:
   "\<lbrace>valid_irq_states'\<rbrace> invokeTCB tcb_inv
   -, \<lbrace>\<lambda>rv s. intStateIRQTable (ksInterruptState s) rv \<noteq> irqstate.IRQInactive\<rbrace>"
-  including no_pre
+  including classic_wp_pre
   apply (simp add: invokeTCB_def)
   apply (rule hoare_pre)
    apply (wpc |

--- a/proof/refine/X64/VSpace_R.thy
+++ b/proof/refine/X64/VSpace_R.thy
@@ -347,13 +347,9 @@ lemma deleteASID_corres [corres]:
        apply (simp add: vs_refs_def)
        apply (rule image_eqI[rotated], erule graph_ofI)
        apply (simp add: mask_asid_low_bits_ucast_ucast)
-      apply wp
-      apply (simp add: o_def)
-      apply (wp getASID_wp)
-      apply clarsimp
-      apply assumption
-     apply wp+
-   apply clarsimp
+      \<comment> \<open>rewrite assumption so that the goal can refer to the C variable instead of the abstract's.\<close>
+      apply (drule Some_to_the)
+      apply (wpsimp wp: getASID_wp)+
    apply (clarsimp simp: valid_arch_state_def valid_asid_table_def
                   dest!: invs_arch_state)
    apply blast


### PR DESCRIPTION
This being a `wp_comb` rule is a leftover from before `wp_pre` was implemented and it is being removed because in some cases it can cause unintended schematics to appear in the assumptions. See https://github.com/seL4/l4v/issues/729 for more discussion of this being a problem.

This commit also updates all of the proofs that accidentally depended on it being a wp_comb rule. In many cases this involved `including classic_wp_pre`, which locally returns the wp attributes to a state similar to what it was when the proofs were first written. Other cases required small rewrites, often involving using `wpsimp` instead of `wp`, and removing some uses of `wp (once)`.