### PR TITLE
arm+arm-hyp spec+proofs: use UserContext datatype like other arches

### DIFF
--- a/proof/access-control/ARM/ArchAccess.thy
+++ b/proof/access-control/ARM/ArchAccess.thy
@@ -210,10 +210,10 @@ lemma integrity_asids_kh_update:
 
 subsection \<open>Misc definitions\<close>
 
-definition ctxt_IP_update where
-  "ctxt_IP_update ctxt \<equiv> ctxt(NextIP := ctxt FaultIP)"
+definition ctxt_IP_update :: "user_context \<Rightarrow> user_context" where
+  "ctxt_IP_update ctxt \<equiv> UserContext ((user_regs ctxt)(NextIP := user_regs ctxt FaultIP))"
 
-abbreviation arch_IP_update where
+abbreviation arch_IP_update :: "arch_tcb \<Rightarrow> arch_tcb" where
   "arch_IP_update arch \<equiv> arch_tcb_context_set (ctxt_IP_update (arch_tcb_context_get arch)) arch"
 
 definition asid_pool_integrity ::
@@ -261,7 +261,6 @@ requalify_consts
   state_vrefs
   state_asids_to_policy_arch
   integrity_asids
-  ctxt_IP_update
   arch_IP_update
   arch_cap_auth_conferred
   arch_integrity_obj_atomic

--- a/proof/access-control/ARM/ArchIpc_AC.thy
+++ b/proof/access-control/ARM/ArchIpc_AC.thy
@@ -123,7 +123,8 @@ lemma set_mrs_respects_in_ipc[Ipc_AC_assms]:
    apply simp
    apply wp+
   apply (clarsimp simp: arch_tcb_set_registers_def)
-  by (rule update_tcb_context_in_ipc [unfolded fun_upd_def]; fastforce)
+  by (rule update_tcb_context_in_ipc [unfolded fun_upd_def]
+      ; fastforce simp: arch_tcb_context_set_def)
 
 lemma lookup_ipc_buffer_ptr_range_in_ipc[Ipc_AC_assms]:
   "\<lbrace>valid_objs and integrity_tcb_in_ipc aag X thread epptr tst st\<rbrace>

--- a/proof/crefine/ARM/ADT_C.thy
+++ b/proof/crefine/ARM/ADT_C.thy
@@ -116,26 +116,24 @@ end
 definition
   "register_to_H \<equiv> inv register_from_H"
 
+context state_rel begin
+
 definition
   to_user_context_C :: "user_context \<Rightarrow> user_context_C"
 where
-  "to_user_context_C uc \<equiv> user_context_C (FCP (\<lambda>r. uc (register_to_H (of_nat r))))"
-
-context kernel_m begin
-
-lemma ccontext_rel_to_C:
-  "ccontext_relation uc (to_user_context_C uc)"
-  apply (clarsimp simp: ccontext_relation_def to_user_context_C_def)
-  apply (rule arg_cong [where f=uc])
-  apply (simp add: register_to_H_def inv_def)
-  done
-
-end
+  "to_user_context_C uc \<equiv>
+    user_context_C (ARRAY r. user_regs uc (register_to_H (of_nat r)))"
 
 definition
   from_user_context_C :: "user_context_C \<Rightarrow> user_context"
 where
-  "from_user_context_C uc \<equiv> \<lambda>r. index (registers_C uc) (unat (register_from_H r))"
+  "from_user_context_C uc \<equiv>
+     UserContext (\<lambda>r. (registers_C uc).[unat (register_from_H r)])"
+
+lemma (in kernel_m) ccontext_rel_to_C:
+  "ccontext_relation uc (to_user_context_C uc)"
+  unfolding ccontext_relation_def to_user_context_C_def cregs_relation_def
+  by (clarsimp simp: register_to_H_def inv_def)
 
 definition
   getContext_C :: "tcb_C ptr \<Rightarrow> cstate \<Rightarrow> user_context"
@@ -145,7 +143,12 @@ where
 
 lemma from_user_context_C:
   "ccontext_relation uc uc' \<Longrightarrow> from_user_context_C uc' = uc"
-  by (auto simp: ccontext_relation_def from_user_context_C_def)
+  unfolding ccontext_relation_def cregs_relation_def
+  apply (cases uc)
+  apply (auto simp: from_user_context_C_def)
+  done
+
+end
 
 context kernel_m begin
 
@@ -711,9 +714,16 @@ lemma cpspace_cte_relation_unique:
 lemma inj_tcb_ptr_to_ctcb_ptr: "inj tcb_ptr_to_ctcb_ptr"
   by (simp add: inj_on_def tcb_ptr_to_ctcb_ptr_def)
 
+lemma cregs_relation_imp_eq:
+  "cregs_relation f x \<Longrightarrow> cregs_relation g x \<Longrightarrow> f=g"
+  by (auto simp: cregs_relation_def)
+
 lemma ccontext_relation_imp_eq:
   "ccontext_relation f x \<Longrightarrow> ccontext_relation g x \<Longrightarrow> f=g"
-  by (rule ext) (simp add: ccontext_relation_def)
+  unfolding ccontext_relation_def
+  apply (cases f, cases g)
+  apply (auto dest: cregs_relation_imp_eq)
+  done
 
 lemma carch_tcb_relation_imp_eq:
   "carch_tcb_relation f x \<Longrightarrow> carch_tcb_relation g x \<Longrightarrow> f = g"

--- a/proof/crefine/ARM/ArchMove_C.thy
+++ b/proof/crefine/ARM/ArchMove_C.thy
@@ -218,7 +218,9 @@ proof -
 qed
 
 lemma user_getreg_rv:
-  "\<lbrace>obj_at' (\<lambda>tcb. P ((atcbContextGet o tcbArch) tcb r)) t\<rbrace> asUser t (getRegister r) \<lbrace>\<lambda>rv s. P rv\<rbrace>"
+  "\<lbrace>obj_at' (\<lambda>tcb. P ((user_regs \<circ> atcbContextGet \<circ> tcbArch) tcb r)) t\<rbrace>
+   asUser t (getRegister r)
+   \<lbrace>\<lambda>rv s. P rv\<rbrace>"
   apply (simp add: asUser_def split_def)
   apply (wp threadGet_wp)
   apply (clarsimp simp: obj_at'_def projectKOs getRegister_def in_monad atcbContextGet_def)

--- a/proof/crefine/ARM/CLevityCatch.thy
+++ b/proof/crefine/ARM/CLevityCatch.thy
@@ -62,7 +62,7 @@ declare empty_fail_doMachineOp [simp]
 lemma asUser_get_registers:
   "\<lbrace>tcb_at' target\<rbrace>
      asUser target (mapM getRegister xs)
-   \<lbrace>\<lambda>rv s. obj_at' (\<lambda>tcb. map ((atcbContextGet o tcbArch) tcb) xs = rv) target s\<rbrace>"
+   \<lbrace>\<lambda>rv s. obj_at' (\<lambda>tcb. map ((user_regs \<circ> atcbContextGet \<circ> tcbArch) tcb) xs = rv) target s\<rbrace>"
   apply (induct xs)
    apply (simp add: mapM_empty asUser_return)
    apply wp

--- a/proof/crefine/ARM/Fastpath_C.thy
+++ b/proof/crefine/ARM/Fastpath_C.thy
@@ -1565,7 +1565,7 @@ lemma ctes_of_Some_cte_wp_at:
   by (clarsimp simp: cte_wp_at_ctes_of)
 
 lemma user_getreg_wp:
-  "\<lbrace>\<lambda>s. tcb_at' t s \<and> (\<forall>rv. obj_at' (\<lambda>tcb. (atcbContextGet o tcbArch) tcb r = rv) t s \<longrightarrow> Q rv s)\<rbrace>
+  "\<lbrace>\<lambda>s. tcb_at' t s \<and> (\<forall>rv. obj_at' (\<lambda>tcb. (user_regs o atcbContextGet o tcbArch) tcb r = rv) t s \<longrightarrow> Q rv s)\<rbrace>
       asUser t (getRegister r) \<lbrace>Q\<rbrace>"
   apply (rule_tac Q="\<lambda>rv s. \<exists>rv'. rv' = rv \<and> Q rv' s" in hoare_post_imp)
    apply simp
@@ -1689,8 +1689,8 @@ lemma fastpath_call_ccorres:
   notes hoare_TrueI[simp]
   shows "ccorres dc xfdc
      (\<lambda>s. invs' s \<and> ct_in_state' ((=) Running) s
-                  \<and> obj_at' (\<lambda>tcb. (atcbContextGet o tcbArch) tcb ARM_H.capRegister = cptr
-                                 \<and>  (atcbContextGet o tcbArch) tcb ARM_H.msgInfoRegister = msginfo)
+                  \<and> obj_at' (\<lambda>tcb. (user_regs o atcbContextGet o tcbArch) tcb ARM_H.capRegister = cptr
+                                 \<and>  (user_regs o atcbContextGet o tcbArch) tcb ARM_H.msgInfoRegister = msginfo)
                         (ksCurThread s) s)
      (UNIV \<inter> {s. cptr_' s = cptr} \<inter> {s. msgInfo_' s = msginfo}) []
      (fastpaths SysCall) (Call fastpath_call_'proc)"
@@ -2499,8 +2499,8 @@ lemma fastpath_reply_recv_ccorres:
   notes hoare_TrueI[simp]
   shows "ccorres dc xfdc
        (\<lambda>s. invs' s \<and> ct_in_state' ((=) Running) s
-               \<and> obj_at' (\<lambda>tcb.  (atcbContextGet o tcbArch) tcb capRegister = cptr
-                              \<and>  (atcbContextGet o tcbArch) tcb msgInfoRegister = msginfo)
+               \<and> obj_at' (\<lambda>tcb.  (user_regs o atcbContextGet o tcbArch) tcb capRegister = cptr
+                              \<and>  (user_regs o atcbContextGet o tcbArch) tcb msgInfoRegister = msginfo)
                      (ksCurThread s) s)
        (UNIV \<inter> {s. cptr_' s = cptr} \<inter> {s. msgInfo_' s = msginfo}) []
        (fastpaths SysReplyRecv) (Call fastpath_reply_recv_'proc)"

--- a/proof/crefine/ARM/Fastpath_Equiv.thy
+++ b/proof/crefine/ARM/Fastpath_Equiv.thy
@@ -244,7 +244,7 @@ lemma ctes_of_Some_cte_wp_at:
   by (clarsimp simp: cte_wp_at_ctes_of)
 
 lemma user_getreg_wp:
-  "\<lbrace>\<lambda>s. tcb_at' t s \<and> (\<forall>rv. obj_at' (\<lambda>tcb. (atcbContextGet o tcbArch) tcb r = rv) t s \<longrightarrow> Q rv s)\<rbrace>
+  "\<lbrace>\<lambda>s. tcb_at' t s \<and> (\<forall>rv. obj_at' (\<lambda>tcb. (user_regs o atcbContextGet o tcbArch) tcb r = rv) t s \<longrightarrow> Q rv s)\<rbrace>
       asUser t (getRegister r) \<lbrace>Q\<rbrace>"
   apply (rule_tac Q="\<lambda>rv s. \<exists>rv'. rv' = rv \<and> Q rv' s" in hoare_post_imp)
    apply simp
@@ -733,12 +733,12 @@ lemma fastpath_callKernel_SysCall_corres:
                      apply (rule monadic_rewrite_weaken_flags[where F=False and E=True], simp)
                      apply (rule isolate_thread_actions_rewrite_bind
                                  fastpath_isolate_rewrites fastpath_isolatables
-                                 bool.simps setRegister_simple
+                                 bool.simps setRegister_simple_modify_registers
+                                 zipWithM_setRegister_simple_modify_registers
                                  setVMRoot_isolatable[THEN thread_actions_isolatableD] setVMRoot_isolatable
                                  doMachineOp_isolatable[THEN thread_actions_isolatableD] doMachineOp_isolatable
                                  kernelExitAssertions_isolatable[THEN thread_actions_isolatableD]
                                  kernelExitAssertions_isolatable
-                                 zipWithM_setRegister_simple
                                  thread_actions_isolatable_bind
                               | assumption
                               | wp assert_inv)+
@@ -1645,8 +1645,8 @@ lemma fastpath_callKernel_SysReplyRecv_corres:
                       apply (rule monadic_rewrite_weaken_flags[where F=False and E=True], simp)
                       apply (rule isolate_thread_actions_rewrite_bind
                                   fastpath_isolate_rewrites fastpath_isolatables
-                                  bool.simps setRegister_simple
-                                  zipWithM_setRegister_simple
+                                  bool.simps setRegister_simple_modify_registers
+                                  zipWithM_setRegister_simple_modify_registers
                                   thread_actions_isolatable_bind
                                   thread_actions_isolatableD[OF setCTE_isolatable]
                                   setCTE_isolatable

--- a/proof/crefine/ARM/Ipc_C.thy
+++ b/proof/crefine/ARM/Ipc_C.thy
@@ -1289,7 +1289,7 @@ lemma exceptionMessage_length_aux :
 lemma copyMRsFault_ccorres_exception:
   "ccorres dc xfdc
            (valid_pspace'
-             and obj_at' (\<lambda>tcb. map (atcbContext (tcbArch tcb)) ARM_H.exceptionMessage = msg) sender
+             and obj_at' (\<lambda>tcb. map (user_regs (atcbContext (tcbArch tcb))) ARM_H.exceptionMessage = msg) sender
              and K (length msg = 3)
              and K (recvBuffer \<noteq> Some 0)
              and K (sender \<noteq> receiver))
@@ -1311,7 +1311,7 @@ lemma copyMRsFault_ccorres_exception:
                                          for as bs, simplified] bind_assoc)
    apply (rule ccorres_rhs_assoc2, rule ccorres_split_nothrow_novcg)
 
-       apply (rule_tac F="K $ obj_at' (\<lambda>tcb. map ((atcbContext o tcbArch) tcb) ARM_H.exceptionMessage = msg) sender"
+       apply (rule_tac F="K $ obj_at' (\<lambda>tcb. map ((user_regs o atcbContext o tcbArch) tcb) ARM_H.exceptionMessage = msg) sender"
                      in ccorres_mapM_x_while)
            apply (clarsimp simp: n_msgRegisters_def)
            apply (rule ccorres_guard_imp2)
@@ -1357,7 +1357,7 @@ lemma mapM_cong: "\<lbrakk> \<forall>x. elem x xs \<longrightarrow> f x = g x \<
 lemma copyMRsFault_ccorres_syscall:
   "ccorres dc xfdc
            (valid_pspace'
-             and obj_at' (\<lambda>tcb. map (atcbContext (tcbArch tcb)) ARM_H.syscallMessage = msg) sender
+             and obj_at' (\<lambda>tcb. map (user_regs (atcbContext (tcbArch tcb))) ARM_H.syscallMessage = msg) sender
              and (case recvBuffer of Some x \<Rightarrow> valid_ipc_buffer_ptr' x | None \<Rightarrow> \<top>)
              and K (length msg = 12)
              and K (recvBuffer \<noteq> Some 0)
@@ -1396,7 +1396,7 @@ proof -
                                          and ys="drop (unat n_msgRegisters) (zip as bs)"
                                          for as bs, simplified] bind_assoc)
    apply (rule ccorres_rhs_assoc2, rule ccorres_split_nothrow_novcg)
-       apply (rule_tac F="K $ obj_at' (\<lambda>tcb. map ((atcbContext o tcbArch) tcb) ARM_H.syscallMessage = msg) sender"
+       apply (rule_tac F="K $ obj_at' (\<lambda>tcb. map ((user_regs o atcbContext o tcbArch) tcb) ARM_H.syscallMessage = msg) sender"
                      in ccorres_mapM_x_while)
            apply (clarsimp simp: n_msgRegisters_def)
            apply (rule ccorres_guard_imp2)
@@ -1425,7 +1425,7 @@ proof -
      apply (rule ccorres_Cond_rhs)
       apply (simp del: Collect_const)
       apply (rule ccorres_rel_imp)
-       apply (rule_tac F="\<lambda>_. obj_at' (\<lambda>tcb. map ((atcbContext o tcbArch) tcb) ARM_H.syscallMessage = msg)
+       apply (rule_tac F="\<lambda>_. obj_at' (\<lambda>tcb. map ((user_regs o atcbContext o tcbArch) tcb) ARM_H.syscallMessage = msg)
                                         sender and valid_pspace'
                                         and (case recvBuffer of Some x \<Rightarrow> valid_ipc_buffer_ptr' x | None \<Rightarrow> \<top>)"
                             in ccorres_mapM_x_while'[where i="unat n_msgRegisters"])

--- a/proof/crefine/ARM/IsolatedThreadAction.thy
+++ b/proof/crefine/ARM/IsolatedThreadAction.thy
@@ -9,6 +9,8 @@ theory IsolatedThreadAction
 imports ArchMove_C
 begin
 
+context begin interpretation Arch . (*FIXME: arch_split*)
+
 datatype tcb_state_regs =
   TCBStateRegs (tsrState : thread_state) (tsrContext : "MachineTypes.register \<Rightarrow> machine_word")
 
@@ -16,13 +18,16 @@ definition
   get_tcb_state_regs :: "kernel_object option \<Rightarrow> tcb_state_regs"
 where
  "get_tcb_state_regs oko \<equiv> case oko of
-    Some (KOTCB tcb) \<Rightarrow> TCBStateRegs (tcbState tcb) ((atcbContextGet o tcbArch) tcb)"
+    Some (KOTCB tcb) \<Rightarrow> TCBStateRegs (tcbState tcb) ((user_regs o atcbContextGet o tcbArch) tcb)"
 
 definition
   put_tcb_state_regs_tcb :: "tcb_state_regs \<Rightarrow> tcb \<Rightarrow> tcb"
 where
  "put_tcb_state_regs_tcb tsr tcb \<equiv> case tsr of
-     TCBStateRegs st regs \<Rightarrow> tcb \<lparr> tcbState := st, tcbArch := atcbContextSet regs (tcbArch tcb) \<rparr>"
+     TCBStateRegs st regs \<Rightarrow>
+        tcb \<lparr> tcbState := st,
+              tcbArch := atcbContextSet (UserContext regs)
+                         (tcbArch tcb) \<rparr>"
 
 definition
   put_tcb_state_regs :: "tcb_state_regs \<Rightarrow> kernel_object option \<Rightarrow> kernel_object option"
@@ -103,8 +108,6 @@ lemmas setEndpoint_obj_at_tcb' = setEndpoint_obj_at'_tcb
 
 lemmas setNotification_tcb = set_ntfn_tcb_obj_at'
 
-context begin interpretation Arch . (*FIXME: arch_split*)
-
 lemma setObject_modify:
   fixes v :: "'a :: pspace_storable" shows
   "\<lbrakk> obj_at' (P :: 'a \<Rightarrow> bool) p s; updateObject v = updateObject_default v;
@@ -136,8 +139,6 @@ lemma getObject_return:
   apply (simp add: magnitudeCheck_assert in_monad)
   done
 
-end
-
 lemmas getObject_return_tcb
     = getObject_return[OF meta_eq_to_obj_eq, OF loadObject_tcb,
                        unfolded objBits_simps', simplified]
@@ -156,13 +157,13 @@ lemma partial_overwrite_fun_upd:
 
 lemma get_tcb_state_regs_ko_at':
   "ko_at' ko p s \<Longrightarrow> get_tcb_state_regs (ksPSpace s p)
-       = TCBStateRegs (tcbState ko) ((atcbContextGet o tcbArch) ko)"
+       = TCBStateRegs (tcbState ko) ((user_regs o atcbContextGet o tcbArch) ko)"
   by (clarsimp simp: obj_at'_def projectKOs get_tcb_state_regs_def)
 
 lemma put_tcb_state_regs_ko_at':
   "ko_at' ko p s \<Longrightarrow> put_tcb_state_regs tsr (ksPSpace s p)
        = Some (KOTCB (ko \<lparr> tcbState := tsrState tsr
-                         , tcbArch := atcbContextSet (tsrContext tsr) (tcbArch ko)\<rparr>))"
+                         , tcbArch := atcbContextSet (UserContext (tsrContext tsr)) (tcbArch ko)\<rparr>))"
   by (clarsimp simp: obj_at'_def projectKOs put_tcb_state_regs_def
                      put_tcb_state_regs_tcb_def
               split: tcb_state_regs.split)
@@ -193,7 +194,7 @@ lemma ksPSpace_update_partial_id:
   done
 
 lemma isolate_thread_actions_asUser:
-  "\<lbrakk> idx t' = t; inj idx; f = (\<lambda>s. ({(v, g s)}, False)) \<rbrakk> \<Longrightarrow>
+  "\<lbrakk> idx t' = t; inj idx; f = (\<lambda>s. ({(v, modify_registers g s)}, False)) \<rbrakk> \<Longrightarrow>
    monadic_rewrite False True (\<lambda>s. \<forall>x. tcb_at' (idx x) s)
       (asUser t f)
       (isolate_thread_actions idx (return v)
@@ -214,17 +215,30 @@ lemma isolate_thread_actions_asUser:
   apply (clarsimp simp: partial_overwrite_get_tcb_state_regs
                         put_tcb_state_regs_ko_at')
   apply (case_tac ko, simp)
+  apply (rename_tac uc)
+  apply (case_tac uc, simp add: modify_registers_def atcbContextGet_def atcbContextSet_def)
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+lemma getRegister_simple:
+  "getRegister r = (\<lambda>con. ({(user_regs con r, con)}, False))"
+  by (simp add: getRegister_def simpler_gets_def)
+
+lemma mapM_getRegister_simple:
+  "mapM getRegister rs = (\<lambda>con. ({(map (user_regs con) rs, con)}, False))"
+  apply (induct rs)
+   apply (simp add: mapM_Nil return_def)
+  apply (simp add: mapM_Cons getRegister_def simpler_gets_def
+                   bind_def return_def)
+  done
 
 lemma setRegister_simple:
-  "setRegister r v = (\<lambda>con. ({((), con (r := v))}, False))"
+  "setRegister r v = (\<lambda>con. ({((), UserContext ((user_regs con)(r := v)))}, False))"
   by (simp add: setRegister_def simpler_modify_def)
 
 lemma zipWithM_setRegister_simple:
   "zipWithM_x setRegister rs vs
-      = (\<lambda>con. ({((), foldl (\<lambda>con (r, v). con (r := v)) con (zip rs vs))}, False))"
+      = (\<lambda>con. ({((),
+                  UserContext (foldl (\<lambda>regs (r, v). ((regs)(r := v))) (user_regs con) (zip rs vs)))}, False))"
   supply if_split[split del]
   apply (simp add: zipWithM_x_mapM_x)
   apply (induct ("zip rs vs"))
@@ -232,6 +246,18 @@ lemma zipWithM_setRegister_simple:
   apply (clarsimp simp add: mapM_x_Cons bind_def setRegister_def
                             simpler_modify_def fun_upd_def[symmetric])
   done
+
+(* this variant used in fastpath rewrite proof *)
+lemma setRegister_simple_modify_registers:
+  "setRegister r v = (\<lambda>con. ({((), modify_registers (\<lambda>f. f(r := v)) con)}, False))"
+  by (simp add: modify_registers_def setRegister_simple)
+
+(* this variant used in fastpath rewrite proof *)
+lemma zipWithM_setRegister_simple_modify_registers:
+  "zipWithM_x setRegister rs vs
+   = (\<lambda>con. ({((), modify_registers (\<lambda>regs. foldl (\<lambda>f (r,v). f(r := v)) regs (zip rs vs)) con)},
+              False))"
+  by (simp add: modify_registers_def zipWithM_setRegister_simple)
 
 lemma dom_partial_overwrite:
   "\<forall>x. tcb_at' (idx x) s \<Longrightarrow> dom (partial_overwrite idx tsrs (ksPSpace s))
@@ -718,7 +744,7 @@ lemma doIPCTransfer_simple_rewrite:
                \<and> msgLength (messageInfoFromWord msgInfo)
                       \<le> of_nat (length msgRegisters))
       and obj_at' (\<lambda>tcb. tcbFault tcb = None
-               \<and> (atcbContextGet o tcbArch) tcb msgInfoRegister = msgInfo) sender)
+               \<and> (user_regs o atcbContextGet o tcbArch) tcb msgInfoRegister = msgInfo) sender)
    (doIPCTransfer sender ep badge grant rcvr)
    (do rv \<leftarrow> mapM_x (\<lambda>r. do v \<leftarrow> asUser sender (getRegister r);
                              asUser rcvr (setRegister r v)
@@ -883,17 +909,6 @@ lemma activateThread_simple_rewrite:
 
 end
 
-lemma setCTE_obj_at_prio[wp]:
-  "\<lbrace>obj_at' (\<lambda>tcb. P (tcbPriority tcb)) t\<rbrace> setCTE p v \<lbrace>\<lambda>rv. obj_at' (\<lambda>tcb. P (tcbPriority tcb)) t\<rbrace>"
-  unfolding setCTE_def
-  by (rule setObject_cte_obj_at_tcb', simp+)
-
-crunch obj_at_prio[wp]: cteInsert "obj_at' (\<lambda>tcb. P (tcbPriority tcb)) t"
-  (wp: crunch_wps)
-
-crunch ctes_of[wp]: asUser "\<lambda>s. P (ctes_of s)"
-  (wp: crunch_wps)
-
 lemma tcbSchedEnqueue_tcbPriority[wp]:
   "\<lbrace>obj_at' (\<lambda>tcb. P (tcbPriority tcb)) t\<rbrace>
      tcbSchedEnqueue t'
@@ -1022,8 +1037,7 @@ lemma setCTE_assert_modify:
      apply (subst updateObject_cte_tcb)
       apply (fastforce simp add: subtract_mask)
      apply (simp add: assert_opt_def alignCheck_assert bind_assoc
-                      magnitudeCheck_assert
-                      is_aligned_neg_mask2 objBits_def)
+                      magnitudeCheck_assert objBits_def)
      apply (rule ps_clear_lookupAround2, assumption+)
        apply (rule word_and_le2)
       apply (simp add: objBits_simps mask_def field_simps)
@@ -1059,13 +1073,17 @@ lemma partial_overwrite_fun_upd2:
                 else y)"
   by (simp add: fun_eq_iff partial_overwrite_def split: if_split)
 
+lemma atcbContextSetSetGet_eq[simp]:
+  "atcbContextSet (UserContext (user_regs (atcbContextGet t))) t = t"
+  by (cases t, simp add: atcbContextSet_def atcbContextGet_def)
+
 lemma setCTE_isolatable:
   "thread_actions_isolatable idx (setCTE p v)"
   supply if_split[split del]
   apply (simp add: setCTE_assert_modify)
   apply (clarsimp simp: thread_actions_isolatable_def
                         monadic_rewrite_def fun_eq_iff
-                        liftM_def exec_gets
+                        liftM_def
                         isolate_thread_actions_def
                         bind_assoc exec_gets getSchedulerAction_def
                         bind_select_f_bind[symmetric]
@@ -1341,6 +1359,7 @@ lemma copy_register_isolate:
   apply (case_tac obj, case_tac obja)
   apply (simp add: projectKO_opt_tcb put_tcb_state_regs_def
                    put_tcb_state_regs_tcb_def get_tcb_state_regs_def
+                   atcbContextGet_def
              cong: if_cong)
   apply (auto simp: fun_eq_iff split: if_split)
   done
@@ -1459,7 +1478,8 @@ lemmas fastpath_isolatables
       thread_actions_isolatable_returns
 
 lemmas fastpath_isolate_rewrites
-    = isolate_thread_actions_threadSet_tcbState isolate_thread_actions_asUser
+    = isolate_thread_actions_threadSet_tcbState
+      isolate_thread_actions_asUser
       copy_registers_isolate setSchedulerAction_isolate
       fastpath_isolatables[THEN thread_actions_isolatableD]
 

--- a/proof/crefine/ARM/Refine_C.thy
+++ b/proof/crefine/ARM/Refine_C.thy
@@ -593,8 +593,8 @@ lemma ccorres_add_gets:
 lemma ccorres_get_registers:
   "\<lbrakk> \<And>cptr msgInfo. ccorres dc xfdc
      ((\<lambda>s. P s \<and> Q s \<and>
-           obj_at' (\<lambda>tcb. (atcbContextGet o tcbArch) tcb ARM_H.capRegister = cptr
-                      \<and>   (atcbContextGet o tcbArch) tcb ARM_H.msgInfoRegister = msgInfo)
+           obj_at' (\<lambda>tcb. (user_regs o atcbContextGet o tcbArch) tcb ARM_H.capRegister = cptr
+                      \<and>   (user_regs o atcbContextGet o tcbArch) tcb ARM_H.msgInfoRegister = msgInfo)
              (ksCurThread s) s) and R)
      (UNIV \<inter> \<lbrace>\<acute>cptr = cptr\<rbrace> \<inter> \<lbrace>\<acute>msgInfo = msgInfo\<rbrace>) [] m c \<rbrakk>
       \<Longrightarrow>
@@ -607,15 +607,15 @@ lemma ccorres_get_registers:
   apply (rule ccorres_assume_pre)
   apply (clarsimp simp: ct_in_state'_def st_tcb_at'_def)
   apply (drule obj_at_ko_at', clarsimp)
-  apply (erule_tac x="(atcbContextGet o tcbArch) ko ARM_H.capRegister" in meta_allE)
-  apply (erule_tac x="(atcbContextGet o tcbArch) ko ARM_H.msgInfoRegister" in meta_allE)
+  apply (erule_tac x="(user_regs o atcbContextGet o tcbArch) ko ARM_H.capRegister" in meta_allE)
+  apply (erule_tac x="(user_regs o atcbContextGet o tcbArch) ko ARM_H.msgInfoRegister" in meta_allE)
   apply (erule ccorres_guard_imp2)
   apply (clarsimp simp: rf_sr_ksCurThread)
   apply (drule(1) obj_at_cslift_tcb, clarsimp simp: obj_at'_def projectKOs)
   apply (clarsimp simp: ctcb_relation_def ccontext_relation_def
                         ARM_H.msgInfoRegister_def ARM_H.capRegister_def
                         ARM.msgInfoRegister_def ARM.capRegister_def
-                        carch_tcb_relation_def
+                        carch_tcb_relation_def cregs_relation_def
                         "StrictC'_register_defs")
   done
 

--- a/proof/crefine/ARM/Retype_C.thy
+++ b/proof/crefine/ARM/Retype_C.thy
@@ -2910,19 +2910,22 @@ proof -
     unfolding ctcb_relation_def makeObject_tcb
     apply (simp add: fbtcb minBound_word)
     apply (intro conjI)
-         apply (simp add: cthread_state_relation_def thread_state_lift_def
-                          eval_nat_numeral ThreadState_Inactive_def)
-        apply (clarsimp simp: ccontext_relation_def carch_tcb_relation_def
-                              newArchTCB_def atcbContextGet_def)
-        apply (case_tac r; simp add: C_register_defs index_foldr_update
-                                     atcbContext_def newArchTCB_def newContext_def
-                                     initContext_def)
-       apply (simp add: thread_state_lift_def index_foldr_update atcbContextGet_def)
-      apply (simp add: Kernel_Config.timeSlice_def)
-     apply (simp add: cfault_rel_def seL4_Fault_lift_def seL4_Fault_get_tag_def Let_def
-                      lookup_fault_lift_def lookup_fault_get_tag_def lookup_fault_invalid_root_def
-                      index_foldr_update seL4_Fault_NullFault_def option_to_ptr_def option_to_0_def
-               split: if_split)+
+          apply (simp add: cthread_state_relation_def thread_state_lift_def
+                           eval_nat_numeral ThreadState_Inactive_def)
+         apply (clarsimp simp: ccontext_relation_def carch_tcb_relation_def)
+         (* C regs relation *)
+         apply (clarsimp simp: cregs_relation_def)
+         subgoal for r
+           by (case_tac r;
+               simp add: "StrictC'_register_defs" eval_nat_numeral atcbContext_def atcbContextGet_def
+                         newArchTCB_def newContext_def initContext_def take_bit_Suc
+                    del: unsigned_numeral)
+        apply (simp add: thread_state_lift_def index_foldr_update atcbContextGet_def)
+       apply (simp add: Kernel_Config.timeSlice_def)
+      apply (simp add: cfault_rel_def seL4_Fault_lift_def seL4_Fault_get_tag_def Let_def
+                       lookup_fault_lift_def lookup_fault_get_tag_def lookup_fault_invalid_root_def
+                       index_foldr_update seL4_Fault_NullFault_def option_to_ptr_def option_to_0_def
+                split: if_split)+
     apply (simp add: option_to_ctcb_ptr_def)
     done
 

--- a/proof/crefine/ARM/StateRelation_C.thy
+++ b/proof/crefine/ARM/StateRelation_C.thy
@@ -236,9 +236,14 @@ fun
   | "register_from_H ARM.FaultIP = scast Kernel_C.FaultIP"
 
 definition
-  ccontext_relation :: "(MachineTypes.register \<Rightarrow> word32) \<Rightarrow> user_context_C \<Rightarrow> bool"
+  cregs_relation :: "(MachineTypes.register \<Rightarrow> machine_word) \<Rightarrow> machine_word[registers_count] \<Rightarrow> bool"
 where
-  "ccontext_relation regs uc \<equiv>  \<forall>r. regs r = index (registers_C uc) (unat (register_from_H r))"
+  "cregs_relation Hregs Cregs \<equiv>  \<forall>r. Hregs r = Cregs.[unat (register_from_H r)]"
+
+definition
+  ccontext_relation :: "user_context \<Rightarrow> user_context_C \<Rightarrow> bool"
+where
+  "ccontext_relation uc_H uc_C \<equiv> cregs_relation (user_regs uc_H) (registers_C uc_C)"
 
 primrec
   cthread_state_relation_lifted :: "Structures_H.thread_state \<Rightarrow>

--- a/proof/crefine/ARM/SyscallArgs_C.thy
+++ b/proof/crefine/ARM/SyscallArgs_C.thy
@@ -630,7 +630,8 @@ lemma asUser_const_rv:
 lemma getMRs_tcbContext:
   "\<lbrace>\<lambda>s. n < unat n_msgRegisters \<and> n < unat (msgLength info) \<and> thread = ksCurThread s \<and> cur_tcb' s\<rbrace>
   getMRs thread buffer info
-  \<lbrace>\<lambda>rv s. obj_at' (\<lambda>tcb. atcbContextGet (tcbArch tcb) (ARM_H.msgRegisters ! n) = rv ! n) (ksCurThread s) s\<rbrace>"
+  \<lbrace>\<lambda>rv s. obj_at' (\<lambda>tcb. user_regs (atcbContextGet (tcbArch tcb)) (ARM_H.msgRegisters ! n) = rv ! n)
+                  (ksCurThread s) s\<rbrace>"
   apply (rule hoare_assume_pre)
   apply (elim conjE)
   apply (thin_tac "thread = t" for t)
@@ -1186,7 +1187,10 @@ lemma getSyscallArg_ccorres_foo:
      apply (simp add: word_less_nat_alt split: if_split)
     apply (rule ccorres_add_return2)
     apply (rule ccorres_symb_exec_l)
-       apply (rule_tac P="\<lambda>s. n < unat (scast n_msgRegisters :: word32) \<and> obj_at' (\<lambda>tcb. atcbContextGet (tcbArch tcb) (ARM_H.msgRegisters!n) = x!n) (ksCurThread s) s"
+       apply (rule_tac P="\<lambda>s. n < unat (scast n_msgRegisters :: word32)
+                              \<and> obj_at' (\<lambda>tcb. user_regs (atcbContextGet (tcbArch tcb))
+                                                         (ARM_H.msgRegisters!n) = x!n)
+                                        (ksCurThread s) s"
                    and P' = UNIV
          in ccorres_from_vcg_split_throws)
         apply vcg
@@ -1197,7 +1201,7 @@ lemma getSyscallArg_ccorres_foo:
        apply (clarsimp simp: typ_heap_simps')
        apply (clarsimp simp: ctcb_relation_def ccontext_relation_def
                              msgRegisters_ccorres atcbContextGet_def
-                             carch_tcb_relation_def)
+                             carch_tcb_relation_def cregs_relation_def)
        apply (subst (asm) msgRegisters_ccorres)
         apply (clarsimp simp: n_msgRegisters_def)
        apply (simp add: n_msgRegisters_def word_less_nat_alt)

--- a/proof/crefine/ARM/TcbAcc_C.thy
+++ b/proof/crefine/ARM/TcbAcc_C.thy
@@ -94,13 +94,14 @@ lemma getRegister_ccorres [corres]:
        apply (drule (1) obj_at_cslift_tcb)
        apply (clarsimp simp: typ_heap_simps register_from_H_less)
        apply (clarsimp simp: getRegister_def typ_heap_simps)
-       apply (rule_tac x = "((atcbContextGet o tcbArch) ko reg, \<sigma>)" in bexI [rotated])
+       apply (rule_tac x = "((user_regs o atcbContextGet o tcbArch) ko reg, \<sigma>)" in bexI[rotated])
         apply (simp add: in_monad' asUser_def select_f_def split_def)
         apply (subst arg_cong2 [where f = "(\<in>)"])
           defer
           apply (rule refl)
          apply (erule threadSet_eq)
-        apply (clarsimp simp: ctcb_relation_def ccontext_relation_def carch_tcb_relation_def)
+        apply (clarsimp simp: ctcb_relation_def ccontext_relation_def cregs_relation_def
+                              carch_tcb_relation_def)
        apply (wp threadGet_obj_at2)+
    apply simp
   apply simp

--- a/proof/crefine/ARM/Tcb_C.thy
+++ b/proof/crefine/ARM/Tcb_C.thy
@@ -1723,7 +1723,7 @@ shows
                                = min (unat n) (unat n_frameRegisters + unat n_gpRegisters)"
                                 in ccorres_gen_asm)
                     apply (rule ccorres_split_nothrow_novcg)
-                        apply (rule_tac F="\<lambda>m s. obj_at' (\<lambda>tcb. map ((atcbContextGet o tcbArch) tcb) (genericTake n
+                        apply (rule_tac F="\<lambda>m s. obj_at' (\<lambda>tcb. map ((user_regs o atcbContextGet o tcbArch) tcb) (genericTake n
                                                      (ARM_H.frameRegisters @ ARM_H.gpRegisters))
                                                               = reply) target s"
                                    in ccorres_mapM_x_while)
@@ -1789,7 +1789,7 @@ shows
                                  in ccorres_split_nothrow_novcg)
                           apply (rule ccorres_Cond_rhs)
                            apply (rule ccorres_rel_imp,
-                                  rule_tac F="\<lambda>m s. obj_at' (\<lambda>tcb. map ((atcbContextGet o tcbArch) tcb) (genericTake n
+                                  rule_tac F="\<lambda>m s. obj_at' (\<lambda>tcb. map ((user_regs o atcbContextGet o tcbArch) tcb) (genericTake n
                                                       (ARM_H.frameRegisters @ ARM_H.gpRegisters))
                                                                = reply) target s
                                                  \<and> valid_ipc_buffer_ptr' (the destIPCBuffer) s
@@ -1902,7 +1902,7 @@ shows
                             apply (rename_tac i_c, rule_tac P="i_c = 0" in ccorres_gen_asm2)
                             apply (simp add: drop_zip del: Collect_const)
                             apply (rule ccorres_Cond_rhs)
-                             apply (rule_tac F="\<lambda>m s. obj_at' (\<lambda>tcb. map ((atcbContextGet o tcbArch) tcb) (genericTake n
+                             apply (rule_tac F="\<lambda>m s. obj_at' (\<lambda>tcb. map ((user_regs o atcbContextGet o tcbArch) tcb) (genericTake n
                                                        (ARM_H.frameRegisters @ ARM_H.gpRegisters))
                                                                 = reply) target s
                                                   \<and> valid_ipc_buffer_ptr' (the destIPCBuffer) s \<and> valid_pspace' s"

--- a/proof/crefine/ARM/VSpace_C.thy
+++ b/proof/crefine/ARM/VSpace_C.thy
@@ -1701,7 +1701,7 @@ lemma setRegister_ccorres:
     apply (rule ball_tcb_cte_casesI, simp+)
    apply (clarsimp simp: ctcb_relation_def ccontext_relation_def
                          atcbContextSet_def atcbContextGet_def
-                         carch_tcb_relation_def
+                         carch_tcb_relation_def cregs_relation_def
                   split: if_split)
   apply (clarsimp simp: Collect_const_mem
                         register_from_H_less)

--- a/proof/crefine/ARM/Wellformed_C.thy
+++ b/proof/crefine/ARM/Wellformed_C.thy
@@ -39,6 +39,9 @@ abbreviation
 abbreviation
   pd_Ptr :: "32 word \<Rightarrow> (pde_C[4096]) ptr" where "pd_Ptr == Ptr"
 
+type_synonym registers_count = 20
+type_synonym registers_array = "machine_word[registers_count]"
+
 lemma halt_spec:
   "Gamma \<turnstile> {} Call halt_'proc {}"
   apply (rule hoare_complete)

--- a/proof/crefine/ARM_HYP/ArchMove_C.thy
+++ b/proof/crefine/ARM_HYP/ArchMove_C.thy
@@ -615,7 +615,9 @@ proof -
 qed
 
 lemma user_getreg_rv:
-  "\<lbrace>obj_at' (\<lambda>tcb. P ((atcbContextGet o tcbArch) tcb r)) t\<rbrace> asUser t (getRegister r) \<lbrace>\<lambda>rv s. P rv\<rbrace>"
+  "\<lbrace>obj_at' (\<lambda>tcb. P ((user_regs \<circ> atcbContextGet \<circ> tcbArch) tcb r)) t\<rbrace>
+   asUser t (getRegister r)
+   \<lbrace>\<lambda>rv s. P rv\<rbrace>"
   apply (simp add: asUser_def split_def)
   apply (wp threadGet_wp)
   apply (clarsimp simp: obj_at'_def projectKOs getRegister_def in_monad atcbContextGet_def)

--- a/proof/crefine/ARM_HYP/CLevityCatch.thy
+++ b/proof/crefine/ARM_HYP/CLevityCatch.thy
@@ -85,7 +85,7 @@ lemma empty_fail_unifyFailure [intro!, simp]:
 lemma asUser_get_registers:
   "\<lbrace>tcb_at' target\<rbrace>
      asUser target (mapM getRegister xs)
-   \<lbrace>\<lambda>rv s. obj_at' (\<lambda>tcb. map ((atcbContextGet o tcbArch) tcb) xs = rv) target s\<rbrace>"
+   \<lbrace>\<lambda>rv s. obj_at' (\<lambda>tcb. map ((user_regs \<circ> atcbContextGet \<circ> tcbArch) tcb) xs = rv) target s\<rbrace>"
   apply (induct xs)
    apply (simp add: mapM_empty asUser_return)
    apply wp

--- a/proof/crefine/ARM_HYP/Fastpath_C.thy
+++ b/proof/crefine/ARM_HYP/Fastpath_C.thy
@@ -1611,7 +1611,7 @@ lemma ctes_of_Some_cte_wp_at:
   by (clarsimp simp: cte_wp_at_ctes_of)
 
 lemma user_getreg_wp:
-  "\<lbrace>\<lambda>s. tcb_at' t s \<and> (\<forall>rv. obj_at' (\<lambda>tcb. (atcbContextGet o tcbArch) tcb r = rv) t s \<longrightarrow> Q rv s)\<rbrace>
+  "\<lbrace>\<lambda>s. tcb_at' t s \<and> (\<forall>rv. obj_at' (\<lambda>tcb. (user_regs o atcbContextGet o tcbArch) tcb r = rv) t s \<longrightarrow> Q rv s)\<rbrace>
       asUser t (getRegister r) \<lbrace>Q\<rbrace>"
   apply (rule_tac Q="\<lambda>rv s. \<exists>rv'. rv' = rv \<and> Q rv' s" in hoare_post_imp)
    apply simp
@@ -1735,8 +1735,8 @@ lemma fastpath_call_ccorres:
   notes hoare_TrueI[simp] if_cong[cong] option.case_cong[cong]
   shows "ccorres dc xfdc
      (\<lambda>s. invs' s \<and> ct_in_state' ((=) Running) s
-                  \<and> obj_at' (\<lambda>tcb. (atcbContextGet o tcbArch) tcb ARM_HYP_H.capRegister = cptr
-                                 \<and>  (atcbContextGet o tcbArch) tcb ARM_HYP_H.msgInfoRegister = msginfo)
+                  \<and> obj_at' (\<lambda>tcb. (user_regs o atcbContextGet o tcbArch) tcb ARM_HYP_H.capRegister = cptr
+                                 \<and>  (user_regs o atcbContextGet o tcbArch) tcb ARM_HYP_H.msgInfoRegister = msginfo)
                         (ksCurThread s) s)
      (UNIV \<inter> {s. cptr_' s = cptr} \<inter> {s. msgInfo_' s = msginfo}) []
      (fastpaths SysCall) (Call fastpath_call_'proc)"
@@ -2543,8 +2543,8 @@ lemma fastpath_reply_recv_ccorres:
   notes hoare_TrueI[simp]
   shows "ccorres dc xfdc
        (\<lambda>s. invs' s \<and> ct_in_state' ((=) Running) s
-               \<and> obj_at' (\<lambda>tcb.  (atcbContextGet o tcbArch) tcb capRegister = cptr
-                              \<and>  (atcbContextGet o tcbArch) tcb msgInfoRegister = msginfo)
+               \<and> obj_at' (\<lambda>tcb.  (user_regs o atcbContextGet o tcbArch) tcb capRegister = cptr
+                              \<and>  (user_regs o atcbContextGet o tcbArch) tcb msgInfoRegister = msginfo)
                      (ksCurThread s) s)
        (UNIV \<inter> {s. cptr_' s = cptr} \<inter> {s. msgInfo_' s = msginfo}) []
        (fastpaths SysReplyRecv) (Call fastpath_reply_recv_'proc)"

--- a/proof/crefine/ARM_HYP/Fastpath_Equiv.thy
+++ b/proof/crefine/ARM_HYP/Fastpath_Equiv.thy
@@ -244,7 +244,7 @@ lemma ctes_of_Some_cte_wp_at:
   by (clarsimp simp: cte_wp_at_ctes_of)
 
 lemma user_getreg_wp:
-  "\<lbrace>\<lambda>s. tcb_at' t s \<and> (\<forall>rv. obj_at' (\<lambda>tcb. (atcbContextGet o tcbArch) tcb r = rv) t s \<longrightarrow> Q rv s)\<rbrace>
+  "\<lbrace>\<lambda>s. tcb_at' t s \<and> (\<forall>rv. obj_at' (\<lambda>tcb. (user_regs o atcbContextGet o tcbArch) tcb r = rv) t s \<longrightarrow> Q rv s)\<rbrace>
       asUser t (getRegister r) \<lbrace>Q\<rbrace>"
   apply (rule_tac Q="\<lambda>rv s. \<exists>rv'. rv' = rv \<and> Q rv' s" in hoare_post_imp)
    apply simp
@@ -733,7 +733,8 @@ lemma fastpath_callKernel_SysCall_corres:
                      apply (rule monadic_rewrite_weaken_flags[where F=False and E=True], simp)
                      apply (rule isolate_thread_actions_rewrite_bind
                                  fastpath_isolate_rewrites fastpath_isolatables
-                                 bool.simps setRegister_simple
+                                 bool.simps setRegister_simple_modify_registers
+                                 zipWithM_setRegister_simple_modify_registers
                                  threadGet_vcpu_isolatable[THEN thread_actions_isolatableD, simplified o_def]
                                  threadGet_vcpu_isolatable[simplified o_def]
                                  vcpuSwitch_isolatable[THEN thread_actions_isolatableD] vcpuSwitch_isolatable
@@ -741,7 +742,6 @@ lemma fastpath_callKernel_SysCall_corres:
                                  doMachineOp_isolatable[THEN thread_actions_isolatableD] doMachineOp_isolatable
                                  kernelExitAssertions_isolatable[THEN thread_actions_isolatableD]
                                  kernelExitAssertions_isolatable
-                                 zipWithM_setRegister_simple
                                  thread_actions_isolatable_bind
                               | assumption
                               | wp assert_inv)+
@@ -1648,8 +1648,8 @@ lemma fastpath_callKernel_SysReplyRecv_corres:
                       apply (rule monadic_rewrite_weaken_flags[where F=False and E=True], simp)
                       apply (rule isolate_thread_actions_rewrite_bind
                                   fastpath_isolate_rewrites fastpath_isolatables
-                                  bool.simps setRegister_simple
-                                  zipWithM_setRegister_simple
+                                  bool.simps setRegister_simple_modify_registers
+                                  zipWithM_setRegister_simple_modify_registers
                                   thread_actions_isolatable_bind
                                   thread_actions_isolatableD[OF setCTE_isolatable]
                                   setCTE_isolatable

--- a/proof/crefine/ARM_HYP/Ipc_C.thy
+++ b/proof/crefine/ARM_HYP/Ipc_C.thy
@@ -1525,7 +1525,7 @@ lemma exceptionMessage_length_aux :
 lemma copyMRsFault_ccorres_exception:
   "ccorres dc xfdc
            (valid_pspace'
-             and obj_at' (\<lambda>tcb. map (atcbContext (tcbArch tcb)) ARM_HYP_H.exceptionMessage = msg) sender
+             and obj_at' (\<lambda>tcb. map (user_regs (atcbContext (tcbArch tcb))) ARM_HYP_H.exceptionMessage = msg) sender
              and K (length msg = 3)
              and K (recvBuffer \<noteq> Some 0)
              and K (sender \<noteq> receiver))
@@ -1547,7 +1547,7 @@ lemma copyMRsFault_ccorres_exception:
                                          for as bs, simplified] bind_assoc)
    apply (rule ccorres_rhs_assoc2, rule ccorres_split_nothrow_novcg)
 
-       apply (rule_tac F="K $ obj_at' (\<lambda>tcb. map ((atcbContext o tcbArch) tcb) ARM_HYP_H.exceptionMessage = msg) sender"
+       apply (rule_tac F="K $ obj_at' (\<lambda>tcb. map ((user_regs o atcbContext o tcbArch) tcb) ARM_HYP_H.exceptionMessage = msg) sender"
                      in ccorres_mapM_x_while)
            apply (clarsimp simp: n_msgRegisters_def)
            apply (rule ccorres_guard_imp2)
@@ -1593,7 +1593,7 @@ lemma mapM_cong: "\<lbrakk> \<forall>x. elem x xs \<longrightarrow> f x = g x \<
 lemma copyMRsFault_ccorres_syscall:
   "ccorres dc xfdc
            (valid_pspace'
-             and obj_at' (\<lambda>tcb. map (atcbContext (tcbArch tcb)) ARM_HYP_H.syscallMessage = msg) sender
+             and obj_at' (\<lambda>tcb. map (user_regs (atcbContext (tcbArch tcb))) ARM_HYP_H.syscallMessage = msg) sender
              and (case recvBuffer of Some x \<Rightarrow> valid_ipc_buffer_ptr' x | None \<Rightarrow> \<top>)
              and K (length msg = 12)
              and K (recvBuffer \<noteq> Some 0)
@@ -1632,7 +1632,7 @@ proof -
                                          and ys="drop (unat n_msgRegisters) (zip as bs)"
                                          for as bs, simplified] bind_assoc)
    apply (rule ccorres_rhs_assoc2, rule ccorres_split_nothrow_novcg)
-       apply (rule_tac F="K $ obj_at' (\<lambda>tcb. map ((atcbContext o tcbArch) tcb) ARM_HYP_H.syscallMessage = msg) sender"
+       apply (rule_tac F="K $ obj_at' (\<lambda>tcb. map ((user_regs o atcbContext o tcbArch) tcb) ARM_HYP_H.syscallMessage = msg) sender"
                      in ccorres_mapM_x_while)
            apply (clarsimp simp: n_msgRegisters_def)
            apply (rule ccorres_guard_imp2)
@@ -1661,7 +1661,7 @@ proof -
      apply (rule ccorres_Cond_rhs)
       apply (simp del: Collect_const)
       apply (rule ccorres_rel_imp)
-       apply (rule_tac F="\<lambda>_. obj_at' (\<lambda>tcb. map ((atcbContext o tcbArch) tcb) ARM_HYP_H.syscallMessage = msg)
+       apply (rule_tac F="\<lambda>_. obj_at' (\<lambda>tcb. map ((user_regs o atcbContext o tcbArch) tcb) ARM_HYP_H.syscallMessage = msg)
                                         sender and valid_pspace'
                                         and (case recvBuffer of Some x \<Rightarrow> valid_ipc_buffer_ptr' x | None \<Rightarrow> \<top>)"
                             in ccorres_mapM_x_while'[where i="unat n_msgRegisters"])

--- a/proof/crefine/ARM_HYP/IsolatedThreadAction.thy
+++ b/proof/crefine/ARM_HYP/IsolatedThreadAction.thy
@@ -9,6 +9,8 @@ theory IsolatedThreadAction
 imports ArchMove_C
 begin
 
+context begin interpretation Arch . (*FIXME: arch_split*)
+
 datatype tcb_state_regs =
   TCBStateRegs (tsrState : thread_state) (tsrContext : "MachineTypes.register \<Rightarrow> machine_word")
 
@@ -16,13 +18,16 @@ definition
   get_tcb_state_regs :: "kernel_object option \<Rightarrow> tcb_state_regs"
 where
  "get_tcb_state_regs oko \<equiv> case oko of
-    Some (KOTCB tcb) \<Rightarrow> TCBStateRegs (tcbState tcb) ((atcbContextGet o tcbArch) tcb)"
+    Some (KOTCB tcb) \<Rightarrow> TCBStateRegs (tcbState tcb) ((user_regs o atcbContextGet o tcbArch) tcb)"
 
 definition
   put_tcb_state_regs_tcb :: "tcb_state_regs \<Rightarrow> tcb \<Rightarrow> tcb"
 where
  "put_tcb_state_regs_tcb tsr tcb \<equiv> case tsr of
-     TCBStateRegs st regs \<Rightarrow> tcb \<lparr> tcbState := st, tcbArch := atcbContextSet regs (tcbArch tcb) \<rparr>"
+     TCBStateRegs st regs \<Rightarrow>
+        tcb \<lparr> tcbState := st,
+              tcbArch := atcbContextSet (UserContext regs)
+                         (tcbArch tcb) \<rparr>"
 
 definition
   put_tcb_state_regs :: "tcb_state_regs \<Rightarrow> kernel_object option \<Rightarrow> kernel_object option"
@@ -101,8 +106,6 @@ lemmas setEndpoint_obj_at_tcb' = setEndpoint_obj_at'_tcb
 
 lemmas setNotification_tcb = set_ntfn_tcb_obj_at'
 
-context begin interpretation Arch . (*FIXME: arch_split*)
-
 lemma setObject_modify:
   fixes v :: "'a :: pspace_storable" shows
   "\<lbrakk> obj_at' (P :: 'a \<Rightarrow> bool) p s; updateObject v = updateObject_default v;
@@ -134,8 +137,6 @@ lemma getObject_return:
   apply (simp add: magnitudeCheck_assert in_monad)
   done
 
-end
-
 lemmas getObject_return_tcb
     = getObject_return[OF meta_eq_to_obj_eq, OF loadObject_tcb,
                        unfolded objBits_simps', simplified]
@@ -154,13 +155,13 @@ lemma partial_overwrite_fun_upd:
 
 lemma get_tcb_state_regs_ko_at':
   "ko_at' ko p s \<Longrightarrow> get_tcb_state_regs (ksPSpace s p)
-       = TCBStateRegs (tcbState ko) ((atcbContextGet o tcbArch) ko)"
+       = TCBStateRegs (tcbState ko) ((user_regs o atcbContextGet o tcbArch) ko)"
   by (clarsimp simp: obj_at'_def projectKOs get_tcb_state_regs_def)
 
 lemma put_tcb_state_regs_ko_at':
   "ko_at' ko p s \<Longrightarrow> put_tcb_state_regs tsr (ksPSpace s p)
        = Some (KOTCB (ko \<lparr> tcbState := tsrState tsr
-                         , tcbArch := atcbContextSet (tsrContext tsr) (tcbArch ko)\<rparr>))"
+                         , tcbArch := atcbContextSet (UserContext (tsrContext tsr)) (tcbArch ko)\<rparr>))"
   by (clarsimp simp: obj_at'_def projectKOs put_tcb_state_regs_def
                      put_tcb_state_regs_tcb_def
               split: tcb_state_regs.split)
@@ -191,7 +192,7 @@ lemma ksPSpace_update_partial_id:
   done
 
 lemma isolate_thread_actions_asUser:
-  "\<lbrakk> idx t' = t; inj idx; f = (\<lambda>s. ({(v, g s)}, False)) \<rbrakk> \<Longrightarrow>
+  "\<lbrakk> idx t' = t; inj idx; f = (\<lambda>s. ({(v, modify_registers g s)}, False)) \<rbrakk> \<Longrightarrow>
    monadic_rewrite False True (\<lambda>s. \<forall>x. tcb_at' (idx x) s)
       (asUser t f)
       (isolate_thread_actions idx (return v)
@@ -212,16 +213,16 @@ lemma isolate_thread_actions_asUser:
   apply (clarsimp simp: partial_overwrite_get_tcb_state_regs
                         put_tcb_state_regs_ko_at')
   apply (case_tac ko, simp)
+  apply (rename_tac uc)
+  apply (case_tac uc, simp add: modify_registers_def atcbContextGet_def atcbContextSet_def)
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
-
 lemma getRegister_simple:
-  "getRegister r = (\<lambda>con. ({(con r, con)}, False))"
+  "getRegister r = (\<lambda>con. ({(user_regs con r, con)}, False))"
   by (simp add: getRegister_def simpler_gets_def)
 
 lemma mapM_getRegister_simple:
-  "mapM getRegister rs = (\<lambda>con. ({(map con rs, con)}, False))"
+  "mapM getRegister rs = (\<lambda>con. ({(map (user_regs con) rs, con)}, False))"
   apply (induct rs)
    apply (simp add: mapM_Nil return_def)
   apply (simp add: mapM_Cons getRegister_def simpler_gets_def
@@ -229,18 +230,31 @@ lemma mapM_getRegister_simple:
   done
 
 lemma setRegister_simple:
-  "setRegister r v = (\<lambda>con. ({((), con (r := v))}, False))"
+  "setRegister r v = (\<lambda>con. ({((), UserContext ((user_regs con)(r := v)))}, False))"
   by (simp add: setRegister_def simpler_modify_def)
 
 lemma zipWithM_setRegister_simple:
   "zipWithM_x setRegister rs vs
-      = (\<lambda>con. ({((), foldl (\<lambda>con (r, v). con (r := v)) con (zip rs vs))}, False))"
+      = (\<lambda>con. ({((),
+                  UserContext (foldl (\<lambda>regs (r, v). ((regs)(r := v))) (user_regs con) (zip rs vs)))}, False))"
   apply (simp add: zipWithM_x_mapM_x)
   apply (induct ("zip rs vs"))
    apply (simp add: mapM_x_Nil return_def)
   apply (clarsimp simp add: mapM_x_Cons bind_def setRegister_def
                             simpler_modify_def fun_upd_def[symmetric])
   done
+
+(* this variant used in fastpath rewrite proof *)
+lemma setRegister_simple_modify_registers:
+  "setRegister r v = (\<lambda>con. ({((), modify_registers (\<lambda>f. f(r := v)) con)}, False))"
+  by (simp add: modify_registers_def setRegister_simple)
+
+(* this variant used in fastpath rewrite proof *)
+lemma zipWithM_setRegister_simple_modify_registers:
+  "zipWithM_x setRegister rs vs
+   = (\<lambda>con. ({((), modify_registers (\<lambda>regs. foldl (\<lambda>f (r,v). f(r := v)) regs (zip rs vs)) con)},
+              False))"
+  by (simp add: modify_registers_def zipWithM_setRegister_simple)
 
 lemma dom_partial_overwrite:
   "\<forall>x. tcb_at' (idx x) s \<Longrightarrow> dom (partial_overwrite idx tsrs (ksPSpace s))
@@ -957,7 +971,7 @@ lemma doIPCTransfer_simple_rewrite:
                \<and> msgLength (messageInfoFromWord msgInfo)
                       \<le> of_nat (length msgRegisters))
       and obj_at' (\<lambda>tcb. tcbFault tcb = None
-               \<and> (atcbContextGet o tcbArch) tcb msgInfoRegister = msgInfo) sender)
+               \<and> (user_regs o atcbContextGet o tcbArch) tcb msgInfoRegister = msgInfo) sender)
    (doIPCTransfer sender ep badge grant rcvr)
    (do rv \<leftarrow> mapM_x (\<lambda>r. do v \<leftarrow> asUser sender (getRegister r);
                              asUser rcvr (setRegister r v)
@@ -1177,17 +1191,6 @@ lemma activateThread_simple_rewrite:
 
 end
 
-lemma setCTE_obj_at_prio[wp]:
-  "\<lbrace>obj_at' (\<lambda>tcb. P (tcbPriority tcb)) t\<rbrace> setCTE p v \<lbrace>\<lambda>rv. obj_at' (\<lambda>tcb. P (tcbPriority tcb)) t\<rbrace>"
-  unfolding setCTE_def
-  by (rule setObject_cte_obj_at_tcb', simp+)
-
-crunch obj_at_prio[wp]: cteInsert "obj_at' (\<lambda>tcb. P (tcbPriority tcb)) t"
-  (wp: crunch_wps)
-
-crunch ctes_of[wp]: asUser "\<lambda>s. P (ctes_of s)"
-  (wp: crunch_wps)
-
 lemma tcbSchedEnqueue_tcbPriority[wp]:
   "\<lbrace>obj_at' (\<lambda>tcb. P (tcbPriority tcb)) t\<rbrace>
      tcbSchedEnqueue t'
@@ -1310,8 +1313,7 @@ lemma setCTE_assert_modify:
      apply (subst updateObject_cte_tcb)
       apply (fastforce simp add: subtract_mask)
      apply (simp add: assert_opt_def alignCheck_assert bind_assoc
-                      magnitudeCheck_assert
-                      is_aligned_neg_mask2 objBits_def)
+                      magnitudeCheck_assert objBits_def)
      apply (rule ps_clear_lookupAround2, assumption+)
        apply (rule word_and_le2)
       apply (simp add: objBits_simps mask_def field_simps)
@@ -1347,13 +1349,17 @@ lemma partial_overwrite_fun_upd2:
                 else y)"
   by (simp add: fun_eq_iff partial_overwrite_def split: if_split)
 
+lemma atcbContextSetSetGet_eq[simp]:
+  "atcbContextSet (UserContext (user_regs (atcbContextGet t))) t = t"
+  by (cases t, simp add: atcbContextSet_def atcbContextGet_def)
+
 lemma setCTE_isolatable:
   "thread_actions_isolatable idx (setCTE p v)"
   supply if_split[split del]
   apply (simp add: setCTE_assert_modify)
   apply (clarsimp simp: thread_actions_isolatable_def
                         monadic_rewrite_def fun_eq_iff
-                        liftM_def exec_gets
+                        liftM_def
                         isolate_thread_actions_def
                         bind_assoc exec_gets getSchedulerAction_def
                         bind_select_f_bind[symmetric]
@@ -1658,6 +1664,7 @@ lemma copy_register_isolate:
   apply (case_tac obj, case_tac obja)
   apply (simp add: projectKO_opt_tcb put_tcb_state_regs_def
                    put_tcb_state_regs_tcb_def get_tcb_state_regs_def
+                   atcbContextGet_def
              cong: if_cong)
   apply (auto simp: fun_eq_iff split: if_split)
   done
@@ -1776,7 +1783,8 @@ lemmas fastpath_isolatables
       thread_actions_isolatable_returns
 
 lemmas fastpath_isolate_rewrites
-    = isolate_thread_actions_threadSet_tcbState isolate_thread_actions_asUser
+    = isolate_thread_actions_threadSet_tcbState
+      isolate_thread_actions_asUser
       copy_registers_isolate setSchedulerAction_isolate
       fastpath_isolatables[THEN thread_actions_isolatableD]
 

--- a/proof/crefine/ARM_HYP/Refine_C.thy
+++ b/proof/crefine/ARM_HYP/Refine_C.thy
@@ -602,8 +602,8 @@ lemma ccorres_add_gets:
 lemma ccorres_get_registers:
   "\<lbrakk> \<And>cptr msgInfo. ccorres dc xfdc
      ((\<lambda>s. P s \<and> Q s \<and>
-           obj_at' (\<lambda>tcb. (atcbContextGet o tcbArch) tcb ARM_HYP_H.capRegister = cptr
-                      \<and>   (atcbContextGet o tcbArch) tcb ARM_HYP_H.msgInfoRegister = msgInfo)
+           obj_at' (\<lambda>tcb. (user_regs o atcbContextGet o tcbArch) tcb ARM_HYP_H.capRegister = cptr
+                      \<and>   (user_regs o atcbContextGet o tcbArch) tcb ARM_HYP_H.msgInfoRegister = msgInfo)
              (ksCurThread s) s) and R)
      (UNIV \<inter> \<lbrace>\<acute>cptr = cptr\<rbrace> \<inter> \<lbrace>\<acute>msgInfo = msgInfo\<rbrace>) [] m c \<rbrakk>
       \<Longrightarrow>
@@ -616,15 +616,15 @@ lemma ccorres_get_registers:
   apply (rule ccorres_assume_pre)
   apply (clarsimp simp: ct_in_state'_def st_tcb_at'_def)
   apply (drule obj_at_ko_at', clarsimp)
-  apply (erule_tac x="(atcbContextGet o tcbArch) ko ARM_HYP_H.capRegister" in meta_allE)
-  apply (erule_tac x="(atcbContextGet o tcbArch) ko ARM_HYP_H.msgInfoRegister" in meta_allE)
+  apply (erule_tac x="(user_regs o atcbContextGet o tcbArch) ko ARM_HYP_H.capRegister" in meta_allE)
+  apply (erule_tac x="(user_regs o atcbContextGet o tcbArch) ko ARM_HYP_H.msgInfoRegister" in meta_allE)
   apply (erule ccorres_guard_imp2)
   apply (clarsimp simp: rf_sr_ksCurThread)
   apply (drule(1) obj_at_cslift_tcb, clarsimp simp: obj_at'_def projectKOs)
   apply (clarsimp simp: ctcb_relation_def ccontext_relation_def
                         ARM_HYP_H.msgInfoRegister_def ARM_HYP_H.capRegister_def
                         ARM_HYP.msgInfoRegister_def ARM_HYP.capRegister_def
-                        carch_tcb_relation_def
+                        carch_tcb_relation_def cregs_relation_def
                         "StrictC'_register_defs")
   done
 

--- a/proof/crefine/ARM_HYP/Retype_C.thy
+++ b/proof/crefine/ARM_HYP/Retype_C.thy
@@ -2961,14 +2961,9 @@ lemma update_ti_t_array_rep_word0:
   done
 
 lemma newContext_def2:
-  "newContext \<equiv> (\<lambda>x. if x = register.CPSR then 0x150 else 0)"
-proof -
-  have "newContext = (\<lambda>x. if x = register.CPSR then 0x150 else 0)"
-    apply (simp add: newContext_def initContext_def)
-    apply (auto intro: ext)
-    done
-  thus "newContext \<equiv> (\<lambda>x. if x = register.CPSR then 0x150 else 0)" by simp
-qed
+  "newContext \<equiv> UserContext (\<lambda>x. if x = register.CPSR then 0x150 else 0)"
+  by (rule newContext_def[simplified initContext_def, simplified,
+                          simplified fun_upd_def])
 
 lemma tcb_queue_update_other:
   "\<lbrakk> ctcb_ptr_to_tcb_ptr p \<notin> set tcbs \<rbrakk> \<Longrightarrow>
@@ -3419,15 +3414,15 @@ proof -
     supply unsigned_numeral[simp del]
     apply (simp add: fbtcb minBound_word)
     apply (intro conjI)
-        apply (simp add: cthread_state_relation_def thread_state_lift_def
-                         eval_nat_numeral ThreadState_defs)
-       apply (clarsimp simp: ccontext_relation_def newContext_def2 carch_tcb_relation_def
-                             newArchTCB_def)
+         apply (simp add: cthread_state_relation_def thread_state_lift_def
+                          eval_nat_numeral ThreadState_defs)
+        apply (clarsimp simp: ccontext_relation_def newContext_def2 carch_tcb_relation_def
+                              newArchTCB_def cregs_relation_def)
        apply (case_tac r,
               simp_all add: "StrictC'_register_defs" eval_nat_numeral
                             atcbContext_def newArchTCB_def newContext_def
                             initContext_def)[1] \<comment> \<open>takes ages\<close>
-                         apply (simp add: thread_state_lift_def eval_nat_numeral atcbContextGet_def)+
+                           apply (simp add: thread_state_lift_def eval_nat_numeral atcbContextGet_def)+
      apply (simp add: Kernel_Config.timeSlice_def)
     apply (simp add: cfault_rel_def seL4_Fault_lift_def seL4_Fault_get_tag_def Let_def
                      lookup_fault_lift_def lookup_fault_get_tag_def lookup_fault_invalid_root_def

--- a/proof/crefine/ARM_HYP/StateRelation_C.thy
+++ b/proof/crefine/ARM_HYP/StateRelation_C.thy
@@ -250,9 +250,14 @@ fun
   | "register_from_H ARM_HYP.FaultIP = scast Kernel_C.FaultIP"
 
 definition
-  ccontext_relation :: "(MachineTypes.register \<Rightarrow> word32) \<Rightarrow> user_context_C \<Rightarrow> bool"
+  cregs_relation :: "(MachineTypes.register \<Rightarrow> machine_word) \<Rightarrow> machine_word[registers_count] \<Rightarrow> bool"
 where
-  "ccontext_relation regs uc \<equiv>  \<forall>r. regs r = index (registers_C uc) (unat (register_from_H r))"
+  "cregs_relation Hregs Cregs \<equiv>  \<forall>r. Hregs r = Cregs.[unat (register_from_H r)]"
+
+definition
+  ccontext_relation :: "user_context \<Rightarrow> user_context_C \<Rightarrow> bool"
+where
+  "ccontext_relation uc_H uc_C \<equiv> cregs_relation (user_regs uc_H) (registers_C uc_C)"
 
 primrec
   cthread_state_relation_lifted :: "Structures_H.thread_state \<Rightarrow>

--- a/proof/crefine/ARM_HYP/SyscallArgs_C.thy
+++ b/proof/crefine/ARM_HYP/SyscallArgs_C.thy
@@ -654,7 +654,7 @@ lemma asUser_const_rv:
 lemma getMRs_tcbContext:
   "\<lbrace>\<lambda>s. n < unat n_msgRegisters \<and> n < unat (msgLength info) \<and> thread = ksCurThread s \<and> cur_tcb' s\<rbrace>
   getMRs thread buffer info
-  \<lbrace>\<lambda>rv s. obj_at' (\<lambda>tcb. atcbContextGet (tcbArch tcb) (ARM_HYP_H.msgRegisters ! n) = rv ! n) (ksCurThread s) s\<rbrace>"
+  \<lbrace>\<lambda>rv s. obj_at' (\<lambda>tcb. user_regs (atcbContextGet (tcbArch tcb)) (ARM_HYP_H.msgRegisters ! n) = rv ! n) (ksCurThread s) s\<rbrace>"
   apply (rule hoare_assume_pre)
   apply (elim conjE)
   apply (thin_tac "thread = t" for t)
@@ -1220,7 +1220,10 @@ lemma getSyscallArg_ccorres_foo:
      apply (simp add: word_less_nat_alt split: if_split)
     apply (rule ccorres_add_return2)
     apply (rule ccorres_symb_exec_l)
-       apply (rule_tac P="\<lambda>s. n < unat (scast n_msgRegisters :: word32) \<and> obj_at' (\<lambda>tcb. atcbContextGet (tcbArch tcb) (ARM_HYP_H.msgRegisters!n) = x!n) (ksCurThread s) s"
+       apply (rule_tac P="\<lambda>s. n < unat (scast n_msgRegisters :: word32)
+                              \<and> obj_at' (\<lambda>tcb. user_regs (atcbContextGet (tcbArch tcb))
+                                                         (ARM_HYP_H.msgRegisters!n) = x!n)
+                                        (ksCurThread s) s"
                    and P' = UNIV
          in ccorres_from_vcg_split_throws)
         apply vcg
@@ -1231,7 +1234,7 @@ lemma getSyscallArg_ccorres_foo:
        apply (clarsimp simp: typ_heap_simps' msgRegisters_scast)
        apply (clarsimp simp: ctcb_relation_def ccontext_relation_def
                              msgRegisters_ccorres atcbContextGet_def
-                             carch_tcb_relation_def)
+                             carch_tcb_relation_def cregs_relation_def)
        apply (subst (asm) msgRegisters_ccorres)
         apply (clarsimp simp: n_msgRegisters_def)
        apply (simp add: n_msgRegisters_def word_less_nat_alt)

--- a/proof/crefine/ARM_HYP/TcbAcc_C.thy
+++ b/proof/crefine/ARM_HYP/TcbAcc_C.thy
@@ -144,13 +144,14 @@ lemma getRegister_ccorres [corres]:
        apply (drule (1) obj_at_cslift_tcb)
        apply (clarsimp simp: typ_heap_simps register_from_H_less register_from_H_sless)
        apply (clarsimp simp: getRegister_def typ_heap_simps)
-       apply (rule_tac x = "((atcbContextGet o tcbArch) ko reg, \<sigma>)" in bexI [rotated])
+       apply (rule_tac x = "((user_regs o atcbContextGet o tcbArch) ko reg, \<sigma>)" in bexI[rotated])
         apply (simp add: in_monad' asUser_def select_f_def split_def)
         apply (subst arg_cong2 [where f = "(\<in>)"])
           defer
           apply (rule refl)
          apply (erule threadSet_eq)
-        apply (clarsimp simp: ctcb_relation_def ccontext_relation_def carch_tcb_relation_def)
+        apply (clarsimp simp: ctcb_relation_def ccontext_relation_def cregs_relation_def
+                              carch_tcb_relation_def)
        apply (wp threadGet_obj_at2)+
    apply simp
   apply simp

--- a/proof/crefine/ARM_HYP/Tcb_C.thy
+++ b/proof/crefine/ARM_HYP/Tcb_C.thy
@@ -1495,11 +1495,11 @@ lemma threadSet_same:
   by (wpsimp wp: setObject_tcb_strongest getObject_tcb_wp) fastforce
 
 lemma asUser_setRegister_ko_at':
-  "\<lbrace>obj_at' (\<lambda>tcb'. tcb = tcbArch_update (\<lambda>_. atcbContextSet ((atcbContextGet (tcbArch tcb'))(r := v)) (tcbArch tcb')) tcb') dst\<rbrace>
+  "\<lbrace>obj_at' (\<lambda>tcb'. tcb = tcbArch_update (\<lambda>_. atcbContextSet (modify_registers (\<lambda>regs. regs(r := v)) (atcbContextGet (tcbArch tcb'))) (tcbArch tcb')) tcb') dst\<rbrace>
   asUser dst (setRegister r v) \<lbrace>\<lambda>rv. ko_at' (tcb::tcb) dst\<rbrace>"
   unfolding asUser_def
   apply (wpsimp wp: threadSet_same threadGet_wp)
-  apply (clarsimp simp: setRegister_def simpler_modify_def obj_at'_def)
+  apply (clarsimp simp: setRegister_def simpler_modify_def obj_at'_def modify_registers_def)
   done
 
 lemma invokeTCB_WriteRegisters_ccorres[where S=UNIV]:
@@ -1804,7 +1804,7 @@ shows
                                = min (unat n) (unat n_frameRegisters + unat n_gpRegisters)"
                                 in ccorres_gen_asm)
                     apply (rule ccorres_split_nothrow_novcg)
-                        apply (rule_tac F="\<lambda>m s. obj_at' (\<lambda>tcb. map ((atcbContextGet o tcbArch) tcb) (genericTake n
+                        apply (rule_tac F="\<lambda>m s. obj_at' (\<lambda>tcb. map ((user_regs o atcbContextGet o tcbArch) tcb) (genericTake n
                                                      (ARM_HYP_H.frameRegisters @ ARM_HYP_H.gpRegisters))
                                                               = reply) target s"
                                    in ccorres_mapM_x_while)
@@ -1870,7 +1870,7 @@ shows
                                  in ccorres_split_nothrow_novcg)
                           apply (rule ccorres_Cond_rhs)
                            apply (rule ccorres_rel_imp,
-                                  rule_tac F="\<lambda>m s. obj_at' (\<lambda>tcb. map ((atcbContextGet o tcbArch) tcb) (genericTake n
+                                  rule_tac F="\<lambda>m s. obj_at' (\<lambda>tcb. map ((user_regs o atcbContextGet o tcbArch) tcb) (genericTake n
                                                       (ARM_HYP_H.frameRegisters @ ARM_HYP_H.gpRegisters))
                                                                = reply) target s
                                                  \<and> valid_ipc_buffer_ptr' (the destIPCBuffer) s
@@ -1982,7 +1982,7 @@ shows
                             apply (rename_tac i_c, rule_tac P="i_c = 0" in ccorres_gen_asm2)
                             apply (simp add: drop_zip del: Collect_const)
                             apply (rule ccorres_Cond_rhs)
-                             apply (rule_tac F="\<lambda>m s. obj_at' (\<lambda>tcb. map ((atcbContextGet o tcbArch) tcb) (genericTake n
+                             apply (rule_tac F="\<lambda>m s. obj_at' (\<lambda>tcb. map ((user_regs o atcbContextGet o tcbArch) tcb) (genericTake n
                                                        (ARM_HYP_H.frameRegisters @ ARM_HYP_H.gpRegisters))
                                                                 = reply) target s
                                                   \<and> valid_ipc_buffer_ptr' (the destIPCBuffer) s \<and> valid_pspace' s"

--- a/proof/crefine/ARM_HYP/VSpace_C.thy
+++ b/proof/crefine/ARM_HYP/VSpace_C.thy
@@ -2816,7 +2816,7 @@ lemma setRegister_ccorres:
     apply (rule ball_tcb_cte_casesI, simp+)
    apply (clarsimp simp: ctcb_relation_def ccontext_relation_def
                          atcbContextSet_def atcbContextGet_def
-                         carch_tcb_relation_def
+                         carch_tcb_relation_def cregs_relation_def
                   split: if_split)
   apply (clarsimp simp: Collect_const_mem register_from_H_sless
                         register_from_H_less)

--- a/proof/crefine/ARM_HYP/Wellformed_C.thy
+++ b/proof/crefine/ARM_HYP/Wellformed_C.thy
@@ -59,6 +59,9 @@ abbreviation
 abbreviation
   word_Ptr :: "addr \<Rightarrow> machine_word ptr" where "word_Ptr \<equiv> Ptr"
 
+type_synonym registers_count = 20
+type_synonym registers_array = "machine_word[registers_count]"
+
 lemma halt_spec:
   "Gamma \<turnstile> {} Call halt_'proc {}"
   apply (rule hoare_complete)

--- a/proof/drefine/Intent_DR.thy
+++ b/proof/drefine/Intent_DR.thy
@@ -302,16 +302,16 @@ lemma dcorres_set_object_tcb:
   apply (clarsimp simp: option_map_def restrict_map_def map_add_def)
   done
 
-lemma set_cxt_none_det_intent_corres:
+lemma set_cxt_none_det_intent_corres':
   "\<lbrakk>kheap s' y = Some (TCB obj'); ekheap s' y \<noteq> None;  valid_idle s';not_idle_thread y s'\<rbrakk>
          \<Longrightarrow> dcorres dc ((=) (transform s')) ((=) s')
              (corrupt_tcb_intent y)
-             (KHeap_A.set_object y (TCB (tcb_arch_update (arch_tcb_context_set cxt) obj')))"
+             (KHeap_A.set_object y (TCB (tcb_arch_update f obj')))"
   apply (clarsimp simp:bind_assoc corrupt_tcb_intent_def get_thread_def gets_def gets_the_def)
   apply (rule corres_guard_imp)
     apply (rule_tac P="(=)(transform s')" and Q="(=) s'"
-       and x="transform_full_intent (machine_state (update_kheap ((kheap s')(y\<mapsto>(TCB (tcb_arch_update (arch_tcb_context_set cxt) obj')))) s'))
-       y (tcb_arch_update (arch_tcb_context_set cxt) obj')"
+       and x="transform_full_intent (machine_state (update_kheap ((kheap s')(y\<mapsto>(TCB (tcb_arch_update f obj')))) s'))
+       y (tcb_arch_update f obj')"
        in select_pick_corres)
     apply (clarsimp simp:update_thread_def get_object_def
        gets_the_def gets_def bind_assoc)
@@ -329,6 +329,13 @@ lemma set_cxt_none_det_intent_corres:
    apply clarsimp
   apply clarsimp
 done
+
+lemma set_cxt_none_det_intent_corres:
+  "\<lbrakk>kheap s' y = Some (TCB obj'); ekheap s' y \<noteq> None;  valid_idle s';not_idle_thread y s'\<rbrakk>
+         \<Longrightarrow> dcorres dc ((=) (transform s')) ((=) s')
+             (corrupt_tcb_intent y)
+             (KHeap_A.set_object y (TCB (tcb_arch_update (arch_tcb_context_set cxt) obj')))"
+  by (rule set_cxt_none_det_intent_corres')
 
 lemma set_message_info_corres:
   "dcorres dc \<top> (valid_idle and not_idle_thread y and valid_etcbs) (corrupt_tcb_intent y)
@@ -425,13 +432,16 @@ lemma set_registers_corres:
   done
 
 lemma set_mrs_corres_no_recv_buffer:
-  "dcorres dc \<top> (valid_idle and not_idle_thread y and valid_etcbs) (corrupt_tcb_intent y) (set_mrs y None msg)"
-  apply (clarsimp simp:set_mrs_def get_thread_def arch_tcb_update_aux3 arch_tcb_set_registers_def)
+  "dcorres dc \<top> (valid_idle and not_idle_thread y and valid_etcbs)
+     (corrupt_tcb_intent y) (set_mrs y None msg)"
+  unfolding set_mrs_def
+  apply (subst arch_tcb_update_aux3)
+  apply simp
   apply (rule dcorres_absorb_gets_the, clarsimp)
   apply (drule(1) valid_etcbs_get_tcb_get_etcb)
   apply (rule corres_dummy_return_l)
   apply (rule corres_split_forwards' [where Q'="%x. \<top>" and Q="%x. \<top>"])
-     apply (rule set_cxt_none_det_intent_corres)
+     apply (rule set_cxt_none_det_intent_corres')
         apply (simp add:get_tcb_def get_etcb_def
                   split:option.splits Structures_A.kernel_object.splits
                | wp)+
@@ -1064,7 +1074,7 @@ done
 
 lemma get_tcb_mrs_wp:
   "\<lbrace>(=) sa and ko_at (TCB obj) thread and K_bind (evalMonad (lookup_ipc_buffer False thread) sa = Some (op_buf))\<rbrace>
-    get_mrs thread (op_buf) (data_to_message_info (arch_tcb_context_get (tcb_arch obj) msg_info_register))
+    get_mrs thread (op_buf) (data_to_message_info (arch_tcb_get_registers (tcb_arch obj) msg_info_register))
             \<lbrace>\<lambda>rv s. rv = get_tcb_mrs (machine_state sa) obj\<rbrace>"
   apply (case_tac op_buf)
     apply (clarsimp simp:get_mrs_def thread_get_def gets_the_def)
@@ -1072,8 +1082,10 @@ lemma get_tcb_mrs_wp:
     apply (clarsimp simp:get_tcb_mrs_def Let_def)
     apply (clarsimp simp:Suc_leI[OF msg_registers_lt_msg_max_length] split del:if_split)
     apply (clarsimp simp:get_tcb_message_info_def get_ipc_buffer_words_empty)
-    apply (clarsimp dest!:get_tcb_SomeD simp:obj_at_def arch_tcb_get_registers_def)
-  apply (clarsimp simp:get_mrs_def thread_get_def gets_the_def arch_tcb_get_registers_def)
+    apply (clarsimp dest!:get_tcb_SomeD
+                    simp:obj_at_def arch_tcb_get_registers_def arch_tcb_context_get_def)
+  apply (clarsimp simp:get_mrs_def thread_get_def gets_the_def arch_tcb_get_registers_def
+                       arch_tcb_context_get_def)
   apply (clarsimp simp:Suc_leI[OF msg_registers_lt_msg_max_length] split del:if_split)
   apply (wp|wpc)+
   apply (rule_tac P = "tcb = obj" in hoare_gen_asm)
@@ -1083,7 +1095,7 @@ lemma get_tcb_mrs_wp:
       (get_ipc_buffer_words (machine_state sa) obj ([Suc (length msg_registers)..<msg_max_length] @ [msg_max_length]))"
       in hoare_strengthen_post)
     apply (rule get_ipc_buffer_words[where thread=thread ])
-    apply simp
+    apply (simp add: arch_tcb_context_get_def)
   apply wp
   apply (fastforce simp:get_tcb_SomeD obj_at_def)
 done
@@ -1617,14 +1629,15 @@ lemma select_f_store_word:
 
 lemma select_f_get_register:
   "(as_user thread (getRegister register)) =
-    (do tcb\<leftarrow>gets_the (get_tcb thread);return (arch_tcb_context_get (tcb_arch tcb) register) od)"
+    (do tcb\<leftarrow>gets_the (get_tcb thread);return (arch_tcb_get_registers (tcb_arch tcb) register) od)"
   apply (simp add: assert_opt_def as_user_def set_object_def get_object_def gets_the_def
                    a_type_def assert_def put_def select_f_def getRegister_def gets_def get_def
                    return_def bind_def)
   apply (rule ext)
   apply (case_tac "get_tcb thread s")
    apply (clarsimp simp: fail_def return_def)+
-  apply (clarsimp simp: get_tcb_def split: option.splits Structures_A.kernel_object.splits)
+  apply (clarsimp simp: get_tcb_def arch_tcb_get_registers_def arch_tcb_context_get_def
+                  split: option.splits Structures_A.kernel_object.splits)
   done
 
 lemma select_f_evalMonad:
@@ -1889,7 +1902,7 @@ lemma ex_cte_cap_wp_to_not_idle:
 
 lemma pspace_aligned_set_cxt_mrs[wp]:
   "\<lbrace>ko_at (TCB tcb) thread and pspace_aligned\<rbrace>
-     KHeap_A.set_object thread (TCB (tcb_arch_update (arch_tcb_context_set t) tcb))
+     KHeap_A.set_object thread (TCB (tcb_arch_update (tcb_context_update f) tcb))
    \<lbrace>\<lambda>rv. pspace_aligned\<rbrace>"
   apply (wp set_object_aligned)
   apply (clarsimp simp:obj_at_def)
@@ -1897,7 +1910,7 @@ lemma pspace_aligned_set_cxt_mrs[wp]:
 
 lemma pspace_distinct_set_cxt_mrs[wp]:
   "\<lbrace>ko_at (TCB tcb) thread and pspace_distinct\<rbrace>
-     KHeap_A.set_object thread (TCB (tcb_arch_update (arch_tcb_context_set t) tcb))
+     KHeap_A.set_object thread (TCB (tcb_arch_update (tcb_context_update f) tcb))
    \<lbrace>\<lambda>rv. pspace_distinct\<rbrace>"
   apply (wp set_object_distinct)
   apply (clarsimp simp:obj_at_def)
@@ -1906,7 +1919,7 @@ lemma pspace_distinct_set_cxt_mrs[wp]:
 
 lemma valid_objs_set_cxt_mrs[wp]:
   "\<lbrace>ko_at (TCB tcb) thread and valid_objs\<rbrace>
-     KHeap_A.set_object thread (TCB (tcb_arch_update (arch_tcb_context_set t) tcb))
+     KHeap_A.set_object thread (TCB (tcb_arch_update (tcb_context_update f) tcb))
    \<lbrace>\<lambda>rv. valid_objs\<rbrace>"
   apply (wp set_object_valid_objs)
   apply (clarsimp simp:obj_at_def)
@@ -1922,14 +1935,14 @@ lemma valid_objs_set_cxt_mrs[wp]:
 
 lemma ipc_frame_set_cxt_mrs[wp]:
   "\<lbrace>ko_at (TCB tcb) thread and ipc_frame_wp_at P a\<rbrace>
-     KHeap_A.set_object thread (TCB (tcb_arch_update (arch_tcb_context_set t) tcb))
+     KHeap_A.set_object thread (TCB (tcb_arch_update (tcb_context_update f) tcb))
    \<lbrace>\<lambda>rv. ipc_frame_wp_at P a\<rbrace>"
   by (clarsimp simp: KHeap_A.set_object_def get_object_def get_def put_def bind_def valid_def
                        return_def obj_at_def ipc_frame_wp_at_def in_monad)
 
 lemma ipc_buffer_set_cxt_mrs[wp]:
   "\<lbrace>ko_at (TCB tcb) thread and ipc_buffer_wp_at P a\<rbrace>
-     KHeap_A.set_object thread (TCB (tcb_arch_update (arch_tcb_context_set t) tcb))
+     KHeap_A.set_object thread (TCB (tcb_arch_update (tcb_context_update f) tcb))
    \<lbrace>\<lambda>rv. ipc_buffer_wp_at P a\<rbrace>"
   by (clarsimp simp: KHeap_A.set_object_def get_object_def get_def put_def bind_def valid_def
                        return_def obj_at_def ipc_buffer_wp_at_def in_monad)
@@ -1955,7 +1968,7 @@ lemma set_mrs_corres:
   apply (rule corres_guard_imp)
     apply (rule corres_split [where r'=dc])
        apply (clarsimp, drule(1) valid_etcbs_get_tcb_get_etcb)
-       apply (rule_tac s'=s' in set_cxt_none_det_intent_corres; clarsimp)
+       apply (rule_tac s'=s' in set_cxt_none_det_intent_corres'; clarsimp)
         apply (clarsimp dest!: get_tcb_SomeD)
        apply (clarsimp dest!: get_etcb_SomeD)
       apply (rule corres_dummy_return_l)
@@ -1968,13 +1981,13 @@ lemma set_mrs_corres:
        apply wp+
     apply (wp set_object_valid_etcbs)
    apply (simp del:upt.simps)
-  apply (auto dest!:get_tcb_SomeD simp:obj_at_def ipc_frame_wp_at_def)
+  apply (auto dest!:get_tcb_SomeD simp:obj_at_def ipc_frame_wp_at_def arch_tcb_get_registers_def)
   done
 
 lemma set_registers_ipc_frame_ptr_at[wp]:
   "\<lbrace>ipc_frame_wp_at buf y\<rbrace>as_user thread (setRegister r rv) \<lbrace>%x. ipc_frame_wp_at buf y\<rbrace>"
   apply (clarsimp simp: as_user_def select_f_def
-                        arch_tcb_update_aux3
+                        arch_tcb_update_aux3 arch_tcb_context_set_def
                         setRegister_def simpler_modify_def)
   apply wp
      apply clarsimp
@@ -1990,7 +2003,7 @@ lemma set_registers_ipc_buffer_ptr_at[wp]:
   apply (clarsimp simp: as_user_def
                         select_f_def
                         setRegister_def
-                        arch_tcb_update_aux3
+                        arch_tcb_update_aux3 arch_tcb_context_set_def
                         simpler_modify_def)
   apply wp
     apply clarsimp

--- a/proof/drefine/Ipc_DR.thy
+++ b/proof/drefine/Ipc_DR.thy
@@ -1011,7 +1011,7 @@ lemma evalMonad_mapM:
 
 lemma evalMonad_get_extra_cptrs:
   "\<lbrakk>evalMonad (lookup_ipc_buffer False thread) s = Some (Some buf);get_tcb thread s = Some tcb;
-    (evalMonad (Ipc_A.get_extra_cptrs (Some buf) (data_to_message_info (arch_tcb_context_get (tcb_arch tcb) msg_info_register))) s) = Some a
+    (evalMonad (Ipc_A.get_extra_cptrs (Some buf) (data_to_message_info (arch_tcb_get_registers (tcb_arch tcb) msg_info_register))) s) = Some a
     \<rbrakk>
   \<Longrightarrow> a = (map (to_bl) (cdl_intent_extras $ transform_full_intent (machine_state s) thread tcb))"
   including no_pre
@@ -1036,7 +1036,7 @@ lemma evalMonad_get_extra_cptrs:
     apply (rule weak_det_spec_mapM[OF weak_det_spec_loadWord])
    apply (rule empty_when_fail_mapM)
    apply (clarsimp simp:empty_when_fail_loadWord weak_det_spec_loadWord)
-  apply (clarsimp simp:get_tcb_message_info_def)
+  apply (clarsimp simp:get_tcb_message_info_def arch_tcb_context_get_def arch_tcb_get_registers_def)
   done
 
 lemma dcorres_symb_exec_r_evalMonad:
@@ -1645,10 +1645,10 @@ lemma dcorres_lookup_extra_caps:
      \<top> ((=) s)
      (Endpoint_D.lookup_extra_caps thread
                                    (cdl_intent_extras (transform_full_intent (machine_state s) thread t)))
-     (Ipc_A.lookup_extra_caps thread buffer (data_to_message_info (arch_tcb_context_get (tcb_arch t) msg_info_register)))"
+     (Ipc_A.lookup_extra_caps thread buffer (data_to_message_info (arch_tcb_get_registers (tcb_arch t) msg_info_register)))"
   apply (clarsimp simp:lookup_extra_caps_def liftE_bindE Endpoint_D.lookup_extra_caps_def)
   apply (rule corres_symb_exec_r)
-     apply (rule_tac F = "evalMonad (get_extra_cptrs buffer (data_to_message_info (arch_tcb_context_get (tcb_arch t) msg_info_register))) s = Some rv"
+     apply (rule_tac F = "evalMonad (get_extra_cptrs buffer (data_to_message_info (arch_tcb_get_registers (tcb_arch t) msg_info_register))) s = Some rv"
                      in corres_gen_asm2)
      apply (rule corres_mapME[where S = "{(x,y). x = of_bl y \<and> length y = word_bits}"])
            prefer 3
@@ -1701,7 +1701,7 @@ lemma dcorres_copy_mrs':
     and valid_idle and not_idle_thread thread and not_idle_thread recv and tcb_at recv
     and valid_objs and pspace_aligned and pspace_distinct and valid_etcbs)
     (corrupt_ipc_buffer recv in_receive)
-    (copy_mrs send rva recv rv (mi_length (data_to_message_info (arch_tcb_context_get (tcb_arch tcb) msg_info_register))))"
+    (copy_mrs send rva recv rv (mi_length (data_to_message_info (arch_tcb_get_registers (tcb_arch tcb) msg_info_register))))"
   apply (rule dcorres_expand_pfx)
   apply (clarsimp simp:corrupt_ipc_buffer_def)
   apply (case_tac rv)
@@ -1858,7 +1858,7 @@ done
 
 lemma ipc_buffer_wp_at_copy_mrs[wp]:
   "\<lbrace>ipc_buffer_wp_at buf t \<rbrace>
-     copy_mrs send rva recv rv (mi_length (data_to_message_info (arch_tcb_context_get (tcb_arch obj') msg_info_register)))
+     copy_mrs send rva recv rv (mi_length (data_to_message_info (arch_tcb_get_registers (tcb_arch obj') msg_info_register)))
    \<lbrace>\<lambda>r. ipc_buffer_wp_at buf t\<rbrace>"
   unfolding copy_mrs_def
   apply (wp|wpc)+

--- a/proof/drefine/Schedule_DR.thy
+++ b/proof/drefine/Schedule_DR.thy
@@ -593,7 +593,8 @@ lemma schedule_dcorres:
  * tcb context of a thread does affect the state translation to capDL
  *)
 lemma get_tcb_message_info_nextPC [simp]:
-  "get_tcb_message_info (tcb_arch_update (tcb_context_update (\<lambda>ctx. ctx(NextIP := pc))) tcb) =
+  "get_tcb_message_info (tcb_arch_update (tcb_context_update
+                                            (\<lambda>ctx. UserContext ((user_regs ctx)(NextIP := pc)))) tcb) =
    get_tcb_message_info tcb"
   by (simp add: get_tcb_message_info_def
                 arch_tcb_context_get_def
@@ -601,24 +602,29 @@ lemma get_tcb_message_info_nextPC [simp]:
                 ARM.msgInfoRegister_def)
 
 lemma map_msg_registers_nextPC [simp]:
-  "map ((tcb_context tcb)(NextIP := pc)) msg_registers =
-   map (tcb_context tcb) msg_registers"
+  "map ((user_regs (tcb_context tcb))(NextIP := pc)) msg_registers =
+   map (user_regs (tcb_context tcb)) msg_registers"
   by (simp add: msg_registers_def ARM.msgRegisters_def
                 upto_enum_red fromEnum_def toEnum_def enum_register)
 
 lemma get_ipc_buffer_words_nextPC [simp]:
-  "get_ipc_buffer_words m (tcb_arch_update (tcb_context_update (\<lambda>ctx. ctx(NextIP := pc))) tcb) =
+  "get_ipc_buffer_words m (tcb_arch_update (tcb_context_update
+                                            (\<lambda>ctx. UserContext ((user_regs ctx)(NextIP := pc)))) tcb) =
    get_ipc_buffer_words m tcb"
   by (rule ext) (simp add: get_ipc_buffer_words_def)
 
 lemma get_tcb_mrs_nextPC [simp]:
-  "get_tcb_mrs m (tcb_arch_update (tcb_context_update (\<lambda>ctx. ctx(NextIP := pc))) tcb) =
+  "get_tcb_mrs m (tcb_arch_update (tcb_context_update
+                                            (\<lambda>ctx. UserContext ((user_regs ctx)(NextIP := pc)))) tcb) =
    get_tcb_mrs m tcb"
   by (simp add: get_tcb_mrs_def Let_def arch_tcb_context_get_def)
 
 lemma transform_tcb_NextIP:
-  "transform_tcb m t (tcb_arch_update (tcb_context_update (\<lambda>ctx. ctx(NextIP:= pc))) tcb)
+  "transform_tcb m t (tcb_arch_update (tcb_context_update
+                                            (\<lambda>ctx. UserContext ((user_regs ctx)(NextIP := pc)))) tcb)
   = transform_tcb m t tcb"
+  apply (rule ext)
+  apply (simp add: transform_tcb_def transform_full_intent_def Let_def)
   by (auto simp add: transform_tcb_def transform_full_intent_def Let_def
                      cap_register_def ARM.capRegister_def
                      arch_tcb_context_get_def)

--- a/proof/drefine/StateTranslationProofs_DR.thy
+++ b/proof/drefine/StateTranslationProofs_DR.thy
@@ -54,10 +54,12 @@ abbreviation
 "update_kheap kh s \<equiv> kheap_update (\<lambda>_. kh) s"
 
 abbreviation
-"tcb_set_mi tcb msg \<equiv> tcb \<lparr>tcb_context := (tcb_context tcb)(msg_info_register := msg)\<rparr>"
+"tcb_set_mi tcb msg \<equiv>
+  tcb \<lparr>tcb_context := modify_registers (\<lambda>rs. rs(msg_info_register := msg)) (tcb_context tcb)\<rparr>"
 
 abbreviation
-"update_tcb_cxt_badge msg tcb\<equiv> tcb \<lparr>tcb_context := (tcb_context tcb)(badge_register := msg)\<rparr>"
+"update_tcb_cxt_badge msg tcb\<equiv>
+  tcb \<lparr>tcb_context := modify_registers (\<lambda>rs. rs(badge_register := msg)) (tcb_context tcb)\<rparr>"
 
 abbreviation
 "update_tcb_state state tcb \<equiv> tcb \<lparr>tcb_state := state\<rparr>"

--- a/proof/drefine/StateTranslation_D.thy
+++ b/proof/drefine/StateTranslation_D.thy
@@ -755,7 +755,8 @@ where
 definition
   get_tcb_message_info :: "tcb \<Rightarrow> Structures_A.message_info"
 where
-  "get_tcb_message_info t \<equiv> data_to_message_info ((arch_tcb_context_get (tcb_arch t)) msg_info_register)"
+  "get_tcb_message_info t \<equiv>
+     data_to_message_info ((user_regs (arch_tcb_context_get (tcb_arch t))) msg_info_register)"
 
 definition
   get_tcb_mrs :: "machine_state \<Rightarrow> tcb \<Rightarrow> word32 list"
@@ -763,7 +764,7 @@ where
   "get_tcb_mrs ms tcb \<equiv>
     let
       info = get_tcb_message_info tcb;
-      cpu_mrs = map (arch_tcb_context_get (tcb_arch tcb)) msg_registers;
+      cpu_mrs = map (user_regs (arch_tcb_context_get (tcb_arch tcb))) msg_registers;
       mem_mrs = get_ipc_buffer_words ms tcb [length msg_registers + 1 ..< Suc msg_max_length]
     in
       (take (unat (mi_length info)) (cpu_mrs @ mem_mrs))"
@@ -782,7 +783,7 @@ where
                      (invocation_type (mi_label mi))
                      (get_tcb_mrs ms tcb)),
     cdl_intent_error = guess_error (mi_label mi),
-    cdl_intent_cap = arch_tcb_context_get (tcb_arch tcb) cap_register,
+    cdl_intent_cap = user_regs (arch_tcb_context_get (tcb_arch tcb)) cap_register,
     cdl_intent_extras = get_ipc_buffer_words ms tcb [buffer_cptr_index ..< buffer_cptr_index + (unat (mi_extra_caps mi))],
     cdl_intent_recv_slot = case (get_ipc_buffer_words ms tcb [offset ..< offset + 3]) of
                                 [croot, index, depth] \<Rightarrow> Some (croot, index, unat depth)

--- a/proof/invariant-abstract/ARM/ArchInvariants_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchInvariants_AI.thy
@@ -48,7 +48,7 @@ lemma iarch_tcb_context_set[simp]:
 lemma iarch_tcb_set_registers[simp]:
   "arch_tcb_to_iarch_tcb (arch_tcb_set_registers regs arch_tcb)
      = arch_tcb_to_iarch_tcb arch_tcb"
-  by (simp add: arch_tcb_set_registers_def)
+  by (simp add: arch_tcb_to_iarch_tcb_def)
 
 (* These simplifications allows us to keep many arch-specific proofs unchanged. *)
 

--- a/proof/invariant-abstract/ARM_HYP/ArchInvariants_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchInvariants_AI.thy
@@ -48,7 +48,7 @@ lemma iarch_tcb_context_set[simp]:
 lemma iarch_tcb_set_registers[simp]:
   "arch_tcb_to_iarch_tcb (arch_tcb_set_registers regs arch_tcb)
      = arch_tcb_to_iarch_tcb arch_tcb"
-  by (simp add: arch_tcb_set_registers_def)
+  by (simp add: arch_tcb_to_iarch_tcb_def arch_tcb_set_registers_def)
 
 lemmas vspace_bits_defs = pd_bits_def pde_bits_def pt_bits_def pte_bits_def pageBits_def
 

--- a/proof/refine/ARM/CNodeInv_R.thy
+++ b/proof/refine/ARM/CNodeInv_R.thy
@@ -5241,6 +5241,11 @@ lemma invalid_Thread_CNode:
   apply (clarsimp simp: obj_at'_def projectKOs)
   done
 
+(* FIXME MOVE *)
+lemma all_Not_False[simp]:
+  "All Not = False"
+  by blast
+
 lemma Final_notUntyped_capRange_disjoint:
   "\<lbrakk> isFinal cap sl (cteCaps_of s); cteCaps_of s sl' = Some cap';
       sl \<noteq> sl'; capUntypedPtr cap = capUntypedPtr cap'; capBits cap = capBits cap';
@@ -5256,21 +5261,11 @@ lemma Final_notUntyped_capRange_disjoint:
    apply (clarsimp simp: valid_cap'_def
                          obj_at'_def projectKOs objBits_simps'
                          typ_at'_def ko_wp_at'_def
+                         page_table_at'_def page_directory_at'_def
+                         sameObjectAs_def3 isCap_simps
                   split: capability.split_asm zombie_type.split_asm
-                         arch_capability.split_asm
-                  dest!: spec[where x=0])
-     apply (clarsimp simp: sameObjectAs_def3 isCap_simps)
-    apply (simp add: isCap_simps)
-   apply (simp add: isCap_simps)
-  apply (clarsimp simp: valid_cap'_def
-                        obj_at'_def projectKOs objBits_simps
-                        typ_at'_def ko_wp_at'_def
-                        page_table_at'_def page_directory_at'_def
-                 split: capability.split_asm zombie_type.split_asm
-                        arch_capability.split_asm
-                 dest!: spec[where x=0])
-    apply fastforce+
-  apply (clarsimp simp: isCap_simps sameObjectAs_def3)
+                         arch_capability.split_asm option.split_asm
+                  dest!: spec[where x=0])+
   done
 
 lemma capBits_capUntyped_capRange:

--- a/proof/refine/ARM/KHeap_R.thy
+++ b/proof/refine/ARM/KHeap_R.thy
@@ -678,8 +678,8 @@ lemma cte_wp_at_ctes_of:
    apply (simp add: field_simps)
   apply (clarsimp split: if_split_asm del: disjCI)
    apply (simp add: ps_clear_def3 field_simps)
-  apply (rule disjI2, rule exI[where x="p - (p && ~~ mask 9)"])
-  apply (clarsimp simp: ps_clear_def3[where na=9] is_aligned_mask
+  apply (rule disjI2, rule exI[where x="p - (p && ~~ mask tcb_bits)"])
+  apply (clarsimp simp: ps_clear_def3[where na=tcb_bits] is_aligned_mask
                         word_bw_assocs field_simps)
   done
 

--- a/proof/refine/ARM_HYP/CNodeInv_R.thy
+++ b/proof/refine/ARM_HYP/CNodeInv_R.thy
@@ -5265,6 +5265,11 @@ lemma invalid_Thread_CNode:
   apply (clarsimp simp: obj_at'_def projectKOs)
   done
 
+(* FIXME MOVE *)
+lemma all_Not_False[simp]:
+  "All Not = False"
+  by blast
+
 lemma Final_notUntyped_capRange_disjoint:
   "\<lbrakk> isFinal cap sl (cteCaps_of s); cteCaps_of s sl' = Some cap';
       sl \<noteq> sl'; capUntypedPtr cap = capUntypedPtr cap'; capBits cap = capBits cap';
@@ -5280,21 +5285,11 @@ lemma Final_notUntyped_capRange_disjoint:
    apply (clarsimp simp: valid_cap'_def
                          obj_at'_def projectKOs objBits_simps'
                          typ_at'_def ko_wp_at'_def
+                         page_table_at'_def page_directory_at'_def
+                         sameObjectAs_def3 isCap_simps
                   split: capability.split_asm zombie_type.split_asm
-                         arch_capability.split_asm
-                  dest!: spec[where x=0])
-     apply (clarsimp simp: sameObjectAs_def3 isCap_simps)
-    apply (simp add: isCap_simps)
-   apply (simp add: isCap_simps)
-  apply (clarsimp simp: valid_cap'_def
-                        obj_at'_def projectKOs objBits_simps
-                        typ_at'_def ko_wp_at'_def
-                        page_table_at'_def page_directory_at'_def
-                 split: capability.split_asm zombie_type.split_asm
-                        arch_capability.split_asm
-                 dest!: spec[where x=0])
-    apply fastforce+
-  apply (clarsimp simp: isCap_simps sameObjectAs_def3)
+                         arch_capability.split_asm option.split_asm
+                  dest!: spec[where x=0])+
   done
 
 lemma capBits_capUntyped_capRange:

--- a/proof/refine/ARM_HYP/KHeap_R.thy
+++ b/proof/refine/ARM_HYP/KHeap_R.thy
@@ -762,8 +762,8 @@ lemma cte_wp_at_ctes_of:
    apply (simp add: field_simps)
   apply (clarsimp split: if_split_asm del: disjCI)
    apply (simp add: ps_clear_def3 field_simps)
-  apply (rule disjI2, rule exI[where x="p - (p && ~~ mask 9)"])
-  apply (clarsimp simp: ps_clear_def3[where na=9] is_aligned_mask
+  apply (rule disjI2, rule exI[where x="p - (p && ~~ mask tcb_bits)"])
+  apply (clarsimp simp: ps_clear_def3[where na=tcb_bits] is_aligned_mask
                         word_bw_assocs field_simps)
   done
 

--- a/proof/refine/ARM_HYP/TcbAcc_R.thy
+++ b/proof/refine/ARM_HYP/TcbAcc_R.thy
@@ -4160,6 +4160,18 @@ lemmas msgRegisters_unfold
          unfolded fromEnum_def enum_register, simplified,
          unfolded toEnum_def enum_register, simplified]
 
+lemma thread_get_registers:
+  "thread_get (arch_tcb_get_registers \<circ> tcb_arch) t = as_user t (gets user_regs)"
+  apply (simp add: thread_get_def as_user_def arch_tcb_get_registers_def
+                   arch_tcb_context_get_def arch_tcb_context_set_def)
+  apply (rule bind_cong [OF refl])
+  apply (clarsimp simp: gets_the_member)
+  apply (simp add: get_def the_run_state_def set_object_def get_object_def
+                   put_def bind_def return_def gets_def)
+  apply (drule get_tcb_SomeD)
+  apply (clarsimp simp: map_upd_triv select_f_def image_def return_def)
+  done
+
 lemma getMRs_corres:
   "corres (=) (tcb_at t and pspace_aligned and pspace_distinct)
               (case_option \<top> valid_ipc_buffer_ptr' buf)
@@ -4171,8 +4183,7 @@ lemma getMRs_corres:
              (tcb_at t and pspace_aligned and pspace_distinct) \<top>
              (thread_get (arch_tcb_get_registers o tcb_arch) t)
              (asUser t (mapM getRegister ARM_HYP_H.msgRegisters))"
-    unfolding arch_tcb_get_registers_def
-    apply (subst thread_get_as_user)
+    apply (subst thread_get_registers)
     apply (rule asUser_corres')
     apply (subst mapM_gets)
      apply (simp add: getRegister_def)
@@ -4251,6 +4262,28 @@ lemma storeWordUser_valid_ipc_buffer_ptr' [wp]:
   unfolding valid_ipc_buffer_ptr'_def2
   by (wp hoare_vcg_all_lift storeWordUser_typ_at')
 
+lemma thread_set_as_user_registers:
+  "thread_set (\<lambda>tcb. tcb \<lparr> tcb_arch := arch_tcb_set_registers (f (arch_tcb_get_registers (tcb_arch tcb)))
+                          (tcb_arch tcb) \<rparr>) t
+    = as_user t (modify (modify_registers f))"
+proof -
+  have P: "\<And>f. det (modify f)"
+    by (simp add: modify_def)
+  thus ?thesis
+    apply (simp add: as_user_def P thread_set_def)
+    apply (clarsimp simp: select_f_def simpler_modify_def bind_def image_def modify_registers_def
+                          arch_tcb_set_registers_def arch_tcb_get_registers_def
+                          arch_tcb_context_set_def arch_tcb_context_get_def)
+    done
+qed
+
+lemma UserContext_fold:
+  "UserContext (foldl (\<lambda>s (x, y). s(x := y)) (user_regs s) xs) =
+   foldl (\<lambda>s (r, v). UserContext ((user_regs s)(r := v))) s xs"
+  apply (induct xs arbitrary: s; simp)
+  apply (clarsimp split: prod.splits)
+  by (metis user_context.sel(1))
+
 lemma setMRs_corres:
   assumes m: "mrs' = mrs"
   shows
@@ -4258,7 +4291,8 @@ lemma setMRs_corres:
               (case_option \<top> valid_ipc_buffer_ptr' buf)
               (set_mrs t buf mrs) (setMRs t buf mrs')"
 proof -
-  have setRegister_def2: "setRegister = (\<lambda>r v. modify (\<lambda>s. s ( r := v )))"
+  have setRegister_def2:
+    "setRegister = (\<lambda>r v.  modify (\<lambda>s. UserContext ((user_regs s)(r := v))))"
     by ((rule ext)+, simp add: setRegister_def)
 
   have S: "\<And>xs ys n m. m - n \<ge> length xs \<Longrightarrow> (zip xs (drop n (take m ys))) = zip xs (drop n ys)"
@@ -4272,24 +4306,23 @@ proof -
 
   show ?thesis using m
     unfolding setMRs_def set_mrs_def
-    apply (clarsimp simp: arch_tcb_set_registers_def arch_tcb_get_registers_def cong: option.case_cong split del: if_split)
+    apply (clarsimp cong: option.case_cong split del: if_split)
     apply (subst bind_assoc[symmetric])
     apply (fold thread_set_def[simplified])
-    apply (subst thread_set_as_user[where f="\<lambda>context. \<lambda>reg.
-                      if reg \<in> set (take (length mrs) msg_registers)
-                      then mrs ! (the_index msg_registers reg) else context reg",simplified])
+    apply (subst thread_set_as_user_registers)
     apply (cases buf)
-     apply (clarsimp simp: msgRegisters_unfold setRegister_def2 zipWithM_x_Nil zipWithM_x_modify
+     apply (clarsimp simp: msgRegisters_unfold setRegister_def2 zipWithM_x_modify
                            take_min_len zip_take_triv2 min.commute)
      apply (rule corres_guard_imp)
        apply (rule corres_split_nor[OF asUser_corres'])
           apply (rule corres_modify')
-           apply (fastforce simp: fold_fun_upd[symmetric] msgRegisters_unfold
+           apply (fastforce simp: fold_fun_upd[symmetric] msgRegisters_unfold UserContext_fold
+                                  modify_registers_def
                             cong: if_cong simp del: the_index.simps)
           apply ((wp |simp)+)[6]
     \<comment> \<open>buf = Some a\<close>
     using if_split[split del]
-    apply (clarsimp simp: msgRegisters_unfold setRegister_def2 zipWithM_x_Nil zipWithM_x_modify
+    apply (clarsimp simp: msgRegisters_unfold setRegister_def2 zipWithM_x_modify
                           take_min_len zip_take_triv2 min.commute
                           msgMaxLength_def msgLengthBits_def)
     apply (simp add: msg_max_length_def)
@@ -4297,9 +4330,10 @@ proof -
       apply (rule corres_split_nor[OF asUser_corres'])
          apply (rule corres_modify')
           apply (simp only: msgRegisters_unfold cong: if_cong)
-          apply (fastforce simp: fold_fun_upd[symmetric])
+          apply (fastforce simp: fold_fun_upd[symmetric] msgRegisters_unfold UserContext_fold
+                                  modify_registers_def)
          apply clarsimp
-         apply (rule corres_split_nor)
+        apply (rule corres_split_nor)
            apply (rule_tac S="{((x, y), (x', y')). y = y' \<and> x' = (a + (of_nat x * 4)) \<and> x < unat max_ipc_words}"
                         in zipWithM_x_corres)
                apply (fastforce intro: storeWordUser_corres)

--- a/spec/abstract/ARM/ArchRetype_A.thy
+++ b/spec/abstract/ARM/ArchRetype_A.thy
@@ -38,7 +38,7 @@ where
 
 definition
   empty_context :: user_context where
-  "empty_context \<equiv> \<lambda>_. 0"
+  "empty_context \<equiv> UserContext (\<lambda>_. 0)"
 
 definition init_arch_tcb :: arch_tcb where
   "init_arch_tcb \<equiv> \<lparr> tcb_context = empty_context \<rparr>"

--- a/spec/abstract/ARM/Arch_Structs_A.thy
+++ b/spec/abstract/ARM/Arch_Structs_A.thy
@@ -300,7 +300,9 @@ definition
   "default_arch_tcb \<equiv> \<lparr>
       tcb_context    = new_context\<rparr>"
 
-text \<open>accesors for @{text "tcb_context"} inside @{text "arch_tcb"}\<close>
+text \<open>
+  Accessors for @{text "tcb_context"} inside @{text "arch_tcb"}. These are later used to
+  implement @{text as_user}, i.e.\ need to be compatible with @{text user_monad}.\<close>
 definition
   arch_tcb_context_set :: "user_context \<Rightarrow> arch_tcb \<Rightarrow> arch_tcb"
 where
@@ -311,15 +313,20 @@ definition
 where
   "arch_tcb_context_get a_tcb \<equiv> tcb_context a_tcb"
 
+(* FIXME: the following means that we break the set/getRegister abstraction
+          and should move some of this into the machine interface (same as X64) *)
+text \<open>
+  Accessors for the user register part of the @{text "arch_tcb"}.
+  (Because @{typ "register \<Rightarrow> machine_word"} might not be equal to @{typ user_context}).\<close>
 definition
   arch_tcb_set_registers :: "(register \<Rightarrow> machine_word) \<Rightarrow> arch_tcb \<Rightarrow> arch_tcb"
 where
-  "arch_tcb_set_registers \<equiv> arch_tcb_context_set"
+  "arch_tcb_set_registers regs a_tcb \<equiv> a_tcb \<lparr> tcb_context := UserContext regs \<rparr>"
 
 definition
   arch_tcb_get_registers :: "arch_tcb \<Rightarrow> register \<Rightarrow> machine_word"
 where
-  "arch_tcb_get_registers \<equiv> arch_tcb_context_get"
+  "arch_tcb_get_registers a_tcb \<equiv> user_regs (tcb_context a_tcb)"
 
 end
 

--- a/spec/abstract/ARM/Machine_A.thy
+++ b/spec/abstract/ARM/Machine_A.thy
@@ -13,7 +13,7 @@ chapter "ARM Machine Instantiation"
 
 theory Machine_A
 imports
-  "ExecSpec.MachineTypes"
+  "ExecSpec.MachineOps"
 begin
 
 context Arch begin global_naming ARM_A
@@ -107,11 +107,9 @@ definition
   msg_label_bits :: nat where
   [simp]: "msg_label_bits \<equiv> 20"
 
-type_synonym user_context = "register \<Rightarrow> data"
-
 definition
   new_context :: "user_context" where
-  "new_context \<equiv> (\<lambda>r. 0) (CPSR := 0x150)"
+  "new_context \<equiv> UserContext ((\<lambda>r. 0) (CPSR := 0x150))"
 
 text \<open>The lowest virtual address in the kernel window. The kernel reserves the
 virtual addresses from here up in every virtual address space.\<close>

--- a/spec/abstract/ARM_HYP/ArchRetype_A.thy
+++ b/spec/abstract/ARM_HYP/ArchRetype_A.thy
@@ -38,7 +38,7 @@ where
 
 definition
   empty_context :: user_context where
-  "empty_context \<equiv> \<lambda>_. 0"
+  "empty_context \<equiv> UserContext (\<lambda>_. 0)"
 
 definition init_arch_tcb :: arch_tcb where
   "init_arch_tcb \<equiv> \<lparr> tcb_context = empty_context, tcb_vcpu = None \<rparr>"

--- a/spec/abstract/ARM_HYP/Arch_Structs_A.thy
+++ b/spec/abstract/ARM_HYP/Arch_Structs_A.thy
@@ -398,7 +398,9 @@ definition
       tcb_context    = new_context,
       tcb_vcpu       = None \<rparr>"
 
-text \<open>accesors for @{text "tcb_context"} inside @{text "arch_tcb"}\<close>
+text \<open>
+  Accessors for @{text "tcb_context"} inside @{text "arch_tcb"}. These are later used to
+  implement @{text as_user}, i.e.\ need to be compatible with @{text user_monad}.\<close>
 definition
   arch_tcb_context_set :: "user_context \<Rightarrow> arch_tcb \<Rightarrow> arch_tcb"
 where
@@ -409,15 +411,20 @@ definition
 where
   "arch_tcb_context_get a_tcb \<equiv> tcb_context a_tcb"
 
+(* FIXME: the following means that we break the set/getRegister abstraction
+          and should move some of this into the machine interface (same as X64) *)
+text \<open>
+  Accessors for the user register part of the @{text "arch_tcb"}.
+  (Because @{typ "register \<Rightarrow> machine_word"} might not be equal to @{typ user_context}).\<close>
 definition
   arch_tcb_set_registers :: "(register \<Rightarrow> machine_word) \<Rightarrow> arch_tcb \<Rightarrow> arch_tcb"
 where
-  "arch_tcb_set_registers \<equiv> arch_tcb_context_set"
+  "arch_tcb_set_registers regs a_tcb \<equiv> a_tcb \<lparr> tcb_context := UserContext regs \<rparr>"
 
 definition
   arch_tcb_get_registers :: "arch_tcb \<Rightarrow> register \<Rightarrow> machine_word"
 where
-  "arch_tcb_get_registers \<equiv> arch_tcb_context_get"
+  "arch_tcb_get_registers a_tcb \<equiv> user_regs (tcb_context a_tcb)"
 
 end
 

--- a/spec/abstract/ARM_HYP/Machine_A.thy
+++ b/spec/abstract/ARM_HYP/Machine_A.thy
@@ -13,7 +13,7 @@ chapter "ARM Machine Instantiation"
 
 theory Machine_A
 imports
-  "ExecSpec.MachineTypes"
+  "ExecSpec.MachineOps"
 begin
 
 context Arch begin global_naming ARM_A
@@ -107,11 +107,9 @@ definition
   msg_label_bits :: nat where
   [simp]: "msg_label_bits \<equiv> 20"
 
-type_synonym user_context = "register \<Rightarrow> data"
-
 definition
   new_context :: "user_context" where
-  "new_context \<equiv> (\<lambda>r. 0) (CPSR := 0x150)"
+  "new_context \<equiv> UserContext ((\<lambda>r. 0) (CPSR := 0x150))"
 
 text \<open>The lowest virtual address in the kernel window. The kernel reserves the
 virtual addresses from here up in every virtual address space.\<close>

--- a/spec/design/skel/ARM/RegisterSet_H.thy
+++ b/spec/design/skel/ARM/RegisterSet_H.thy
@@ -9,14 +9,14 @@ chapter "Register Set"
 theory RegisterSet_H
 imports
   "Lib.HaskellLib_H"
-  MachineTypes
+  MachineOps
 begin
 context Arch begin global_naming ARM_H
 
 definition
-  newContext :: "register => machine_word"
+  newContext :: "user_context"
 where
- "newContext \<equiv> (K 0) aLU initContext"
+ "newContext \<equiv> UserContext ((K 0) aLU initContext)"
 
 end
 end

--- a/spec/design/skel/ARM_HYP/RegisterSet_H.thy
+++ b/spec/design/skel/ARM_HYP/RegisterSet_H.thy
@@ -9,14 +9,14 @@ chapter "Register Set"
 theory RegisterSet_H
 imports
   "Lib.HaskellLib_H"
-  MachineTypes
+  MachineOps
 begin
 context Arch begin global_naming ARM_HYP_H
 
 definition
-  newContext :: "register => machine_word"
+  newContext :: "user_context"
 where
- "newContext \<equiv> (K 0) aLU initContext"
+ "newContext \<equiv> UserContext ((K 0) aLU initContext)"
 
 end
 end

--- a/spec/machine/ARM/MachineOps.thy
+++ b/spec/machine/ARM/MachineOps.thy
@@ -495,19 +495,20 @@ definition
 
 section "User Monad"
 
-type_synonym user_context = "register \<Rightarrow> machine_word"
+type_synonym user_regs = "register \<Rightarrow> machine_word"
+
+datatype user_context = UserContext (user_regs : user_regs)
 
 type_synonym 'a user_monad = "(user_context, 'a) nondet_monad"
 
-definition
-  getRegister :: "register \<Rightarrow> machine_word user_monad"
-where
-  "getRegister r \<equiv> gets (\<lambda>uc. uc r)"
+definition getRegister :: "register \<Rightarrow> machine_word user_monad" where
+  "getRegister r \<equiv> gets (\<lambda>s. user_regs s r)"
 
-definition
-  setRegister :: "register \<Rightarrow> machine_word \<Rightarrow> unit user_monad"
-where
-  "setRegister r v \<equiv> modify (\<lambda>uc. uc (r := v))"
+definition modify_registers :: "(user_regs \<Rightarrow> user_regs) \<Rightarrow> user_context \<Rightarrow> user_context" where
+  "modify_registers f uc \<equiv> UserContext (f (user_regs uc))"
+
+definition setRegister :: "register \<Rightarrow> machine_word \<Rightarrow> unit user_monad" where
+  "setRegister r v \<equiv> modify (\<lambda>s. UserContext ((user_regs s) (r := v)))"
 
 definition
   "getRestartPC \<equiv> getRegister FaultIP"

--- a/spec/machine/ARM_HYP/MachineOps.thy
+++ b/spec/machine/ARM_HYP/MachineOps.thy
@@ -720,19 +720,20 @@ where
 
 section "User Monad"
 
-type_synonym user_context = "register \<Rightarrow> machine_word"
+type_synonym user_regs = "register \<Rightarrow> machine_word"
+
+datatype user_context = UserContext (user_regs : user_regs)
 
 type_synonym 'a user_monad = "(user_context, 'a) nondet_monad"
 
-definition
-  getRegister :: "register \<Rightarrow> machine_word user_monad"
-where
-  "getRegister r \<equiv> gets (\<lambda>uc. uc r)"
+definition getRegister :: "register \<Rightarrow> machine_word user_monad" where
+  "getRegister r \<equiv> gets (\<lambda>s. user_regs s r)"
 
-definition
-  setRegister :: "register \<Rightarrow> machine_word \<Rightarrow> unit user_monad"
-where
-  "setRegister r v \<equiv> modify (\<lambda>uc. uc (r := v))"
+definition modify_registers :: "(user_regs \<Rightarrow> user_regs) \<Rightarrow> user_context \<Rightarrow> user_context" where
+  "modify_registers f uc \<equiv> UserContext (f (user_regs uc))"
+
+definition setRegister :: "register \<Rightarrow> machine_word \<Rightarrow> unit user_monad" where
+  "setRegister r v \<equiv> modify (\<lambda>s. UserContext ((user_regs s) (r := v)))"
 
 definition
   "getRestartPC \<equiv> getRegister FaultIP"


### PR DESCRIPTION
This reduces the diff to other architectures and FPU versions by having a UserContext datatype that contains the register state, instead of assuming the context is only the state of the registers.

Some of this touches old proofs and fitting in with style is wonky. Thoughts welcome.
This will break the FPU Arm platform port proofs, but once fixed the diff will be smaller.
Will squash commits to the above commit message (and same header as this PR) once people are ok with the changes.