### PR TITLE
make C build dependent on L4V_PLAT

### DIFF
--- a/spec/ROOT
+++ b/spec/ROOT
@@ -81,8 +81,8 @@ session ExecSpec in "design" = Word_Lib +
 
 session CSpec in "cspec" = CKernel +
   directories
-    "c/build/$L4V_ARCH/generated/arch/object"
-    "c/build/$L4V_ARCH/generated/sel4"
+    "c/build/$L4V_ARCH_$L4V_PLAT/generated/arch/object"
+    "c/build/$L4V_ARCH_$L4V_PLAT/generated/sel4"
   theories [condition = "SORRY_MODIFIES_PROOFS", quick_and_dirty]
     "Substitute"
   theories [condition = "SORRY_BITFIELD_PROOFS", quick_and_dirty]

--- a/spec/cspec/AARCH64/Kernel_C.thy
+++ b/spec/cspec/AARCH64/Kernel_C.thy
@@ -12,7 +12,7 @@ imports
 begin
 
 external_file
-  "../c/build/$L4V_ARCH/kernel_all.c_pp"
+  "../c/build/$L4V_ARCH_$L4V_PLAT/kernel_all.c_pp"
 
 context begin interpretation Arch .
 
@@ -108,7 +108,7 @@ lemmas ctcb_offset_defs = ctcb_offset_def ctcb_size_bits_def
 
 cond_sorry_modifies_proofs SORRY_MODIFIES_PROOFS
 
-install_C_file "../c/build/$L4V_ARCH/kernel_all.c_pp"
+install_C_file "../c/build/$L4V_ARCH_$L4V_PLAT/kernel_all.c_pp"
   [machinety=machine_state, ghostty=cghost_state]
 
 text \<open>Hide unqualified names conflicting with Kernel_Config names. Force use of Kernel_C prefix

--- a/spec/cspec/ARM/Kernel_C.thy
+++ b/spec/cspec/ARM/Kernel_C.thy
@@ -12,7 +12,7 @@ imports
 begin
 
 external_file
-  "../c/build/$L4V_ARCH/kernel_all.c_pp"
+  "../c/build/$L4V_ARCH_$L4V_PLAT/kernel_all.c_pp"
 
 context begin interpretation Arch .
 
@@ -90,7 +90,7 @@ lemmas ctcb_offset_defs = ctcb_offset_def ctcb_size_bits_def
 
 cond_sorry_modifies_proofs SORRY_MODIFIES_PROOFS
 
-install_C_file "../c/build/$L4V_ARCH/kernel_all.c_pp"
+install_C_file "../c/build/$L4V_ARCH_$L4V_PLAT/kernel_all.c_pp"
   [machinety=machine_state, ghostty=cghost_state]
 
 text \<open>Hide unqualified names conflicting with Kernel_Config names. Force use of Kernel_C prefix

--- a/spec/cspec/ARM_HYP/Kernel_C.thy
+++ b/spec/cspec/ARM_HYP/Kernel_C.thy
@@ -12,7 +12,7 @@ imports
 begin
 
 external_file
-  "../c/build/$L4V_ARCH/kernel_all.c_pp"
+  "../c/build/$L4V_ARCH_$L4V_PLAT/kernel_all.c_pp"
 
 context begin interpretation Arch .
 
@@ -90,7 +90,7 @@ lemmas ctcb_offset_defs = ctcb_offset_def ctcb_size_bits_def
 
 cond_sorry_modifies_proofs SORRY_MODIFIES_PROOFS
 
-install_C_file "../c/build/$L4V_ARCH/kernel_all.c_pp"
+install_C_file "../c/build/$L4V_ARCH_$L4V_PLAT/kernel_all.c_pp"
   [machinety=machine_state, ghostty=cghost_state]
 
 text \<open>Hide unqualified names conflicting with Kernel_Config names. Force use of Kernel_C prefix

--- a/spec/cspec/RISCV64/Kernel_C.thy
+++ b/spec/cspec/RISCV64/Kernel_C.thy
@@ -12,7 +12,7 @@ imports
 begin
 
 external_file
-  "../c/build/$L4V_ARCH/kernel_all.c_pp"
+  "../c/build/$L4V_ARCH_$L4V_PLAT/kernel_all.c_pp"
 
 context begin interpretation Arch .
 
@@ -87,7 +87,7 @@ lemmas ctcb_offset_defs = ctcb_offset_def ctcb_size_bits_def
 
 cond_sorry_modifies_proofs SORRY_MODIFIES_PROOFS
 
-install_C_file "../c/build/$L4V_ARCH/kernel_all.c_pp"
+install_C_file "../c/build/$L4V_ARCH_$L4V_PLAT/kernel_all.c_pp"
   [machinety=machine_state, ghostty=cghost_state]
 
 text \<open>Hide unqualified names conflicting with Kernel_Config names. Force use of Kernel_C prefix

--- a/spec/cspec/X64/Kernel_C.thy
+++ b/spec/cspec/X64/Kernel_C.thy
@@ -12,7 +12,7 @@ imports
 begin
 
 external_file
-  "../c/build/$L4V_ARCH/kernel_all.c_pp"
+  "../c/build/$L4V_ARCH_$L4V_PLAT/kernel_all.c_pp"
 
 context begin interpretation Arch .
 
@@ -90,7 +90,7 @@ lemmas ctcb_offset_defs = ctcb_offset_def ctcb_size_bits_def
 
 cond_sorry_modifies_proofs SORRY_MODIFIES_PROOFS
 
-install_C_file "../c/build/$L4V_ARCH/kernel_all.c_pp"
+install_C_file "../c/build/$L4V_ARCH_$L4V_PLAT/kernel_all.c_pp"
   [machinety=machine_state, ghostty=cghost_state]
 
 text \<open>Hide unqualified names conflicting with Kernel_Config names. Force use of Kernel_C prefix

--- a/spec/cspec/c/Makefile
+++ b/spec/cspec/c/Makefile
@@ -4,11 +4,13 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-# For kernel builds (CSpec and binary verificaiton):
-KERNEL_BUILD_ROOT := build/${L4V_ARCH}
+# For kernel builds (CSpec and binary verificaiton).
+# We will get e.g. "ARM_" for empty L4V_PLAT, but that is preferrable to messing
+# with the corresponding external_file and install_C_file commands in Isabelle.
+KERNEL_BUILD_ROOT := build/${L4V_ARCH}_${L4V_PLAT}
 
 # For building configuration headers only (not used in CSpec):
-KERNEL_CONFIG_ROOT := config-build/${L4V_ARCH}
+KERNEL_CONFIG_ROOT := config-build/${L4V_ARCH}_${L4V_PLAT}
 
 # Death to recursively-expanded variables.
 KERNEL_CMAKE_EXTRA_OPTIONS := ${KERNEL_CMAKE_EXTRA_OPTIONS}

--- a/spec/cspec/mk_umm_types.py
+++ b/spec/cspec/mk_umm_types.py
@@ -52,7 +52,7 @@ theory UmmTypesFile
 begin
 declare [[allow_underscore_idents = true]]
 external_file "%(input)s"
-setup \<open> IsarInstall.gen_umm_types_file "%(input)s" "%(output)s" \<close>
+setup \\<open> IsarInstall.gen_umm_types_file "%(input)s" "%(output)s" \\<close>
 end
 """
 


### PR DESCRIPTION
The Makefile currently does not correctly track changes to L4V_PLAT, because that is an env variable and not a file.

By appending `_$L4V_PLAT` to the build directory, we make such changes visible in the file system, which means `make` will track things correctly again.

Using a plain `${L4V_ARCH}_${L4V_PLAT}` path will give us a trailing `_` when `L4V_PLAT` is empty, but this is only in generated build directories we usually don't look at, and it avoids making the `external_file` and `install_C_file` commands in Isabelle more complex.