### PR TITLE
Update to Isabelle2024

### DIFF
--- a/lib/Defs.thy
+++ b/lib/Defs.thy
@@ -15,4 +15,3 @@ begin
 ML_file "defs.ML"
 
 end
-

--- a/lib/Eisbach_Tools/Apply_Debug.thy
+++ b/lib/Eisbach_Tools/Apply_Debug.thy
@@ -685,7 +685,7 @@ in
        let
         val (ctxt,thm) = get_state st;
 
-        val r = case Exn.interruptible_capture (fn st =>
+        val r = case Exn.result (fn st =>
         let val _ = Seq.pull (break ctxt NONE thm) in
         (case (Seq.pull o Proof.apply m) st
           of (SOME (Seq.Result st', _)) => RESULT (get_state st')

--- a/lib/Eval_Bool.thy
+++ b/lib/Eval_Bool.thy
@@ -47,12 +47,12 @@ val eval_nat = eval (mk_constname_tab [@{term "Suc 0"}, @{term "Suc 1"},
 val eval_int = eval (mk_constname_tab [@{term "0 :: int"}, @{term "1 :: int"},
     @{term "18 :: int"}, @{term "(-9) :: int"}])
 
-val eval_bool_simproc = Simplifier.make_simproc @{context} "eval_bool"
-  { lhss = [@{term "b :: bool"}], proc = K eval_bool }
-val eval_nat_simproc = Simplifier.make_simproc @{context} "eval_nat"
-  { lhss = [@{term "n :: nat"}], proc = K eval_nat }
-val eval_int_simproc = Simplifier.make_simproc @{context} "eval_int"
-  { lhss = [@{term "i :: int"}], proc = K eval_int }
+val eval_bool_simproc = Simplifier.make_simproc @{context}
+  { name = "eval_bool", lhss = [@{term "b :: bool"}], proc = K eval_bool, identifier = [] }
+val eval_nat_simproc = Simplifier.make_simproc @{context}
+  { name = "eval_nat", lhss = [@{term "n :: nat"}], proc = K eval_nat, identifier = [] }
+val eval_int_simproc = Simplifier.make_simproc @{context}
+  { name = "eval_int", lhss = [@{term "i :: int"}], proc = K eval_int, identifier = [] }
 
 end
 \<close>

--- a/lib/Hoare_Sep_Tactics/Hoare_Sep_Tactics.thy
+++ b/lib/Hoare_Sep_Tactics/Hoare_Sep_Tactics.thy
@@ -344,8 +344,7 @@ done
 
 
 ML \<open>
-   fun J f x = f x
-               handle _ => x   (* FIXME! exceptions *)
+   fun J f x = \<^try>\<open>f x catch _ => x\<close>
 
    fun sep_wp thms ctxt  =
    let

--- a/lib/Match_Abbreviation.thy
+++ b/lib/Match_Abbreviation.thy
@@ -138,12 +138,12 @@ fun do_adjust ctxt ((("select", []), [p]), fixes) t = let
   | do_adjust _ args _ = error ("do_adjust: unexpected: " ^ @{make_string} args)
 
 fun unvarify_types_same ty = ty
-  |> Term_Subst.map_atypsT_same
+  |> Term.map_atyps_same
     (fn TVar ((a, i), S) => TFree (a ^ "_var_" ^ string_of_int i, S)
       | _ => raise Same.SAME)
 
 fun unvarify_types tm = tm
-  |> Same.commit (Term_Subst.map_types_same unvarify_types_same)
+  |> Same.commit (Term.map_types_same unvarify_types_same)
 
 fun match_abbreviation mode name init adjusts int ctxt = let
     val init_term = init ctxt

--- a/lib/Qualify.thy
+++ b/lib/Qualify.thy
@@ -64,8 +64,8 @@ fun get_new_consts old_thy consts =
     val space = #const_space (Consts.dest consts);
 
     val consts =
-      filter (fn nm => not (can (Consts.the_const (Sign.consts_of old_thy)) nm) andalso
-                       can (Consts.the_const consts) nm) new_consts
+      filter (fn nm => not (can (Consts.the_const_type (Sign.consts_of old_thy)) nm) andalso
+                       can (Consts.the_const_type consts) nm) new_consts
       |> map (fn nm => `(make_bind space old_thy) nm);
 
   in consts end;

--- a/lib/Repeat_Attribute.thy
+++ b/lib/Repeat_Attribute.thy
@@ -19,10 +19,7 @@ fun apply_attributes attrs thm ctxt =
   in if Thm.eq_thm (thm, thm')
      then (SOME ctxt', SOME thm)
      else
-       apply_attributes attrs thm' ctxt'
-       handle e =>
-         (if Exn.is_interrupt e then Exn.reraise e else ();
-          (SOME ctxt', SOME thm'))
+       \<^try>\<open>apply_attributes attrs thm' ctxt' catch _ => (SOME ctxt', SOME thm')\<close>
   end
 
 fun repeat_attribute_cmd attr_srcs (ctxt, thm) =

--- a/lib/SimpStrategy.thy
+++ b/lib/SimpStrategy.thy
@@ -90,15 +90,16 @@ fun simp_strategy_True_conv ct = case Thm.term_of ct of
 fun new_simp_strategy thy (name : term) ss rewr_True =
 let
   val ctxt = Proof_Context.init_global thy;
-  val ss = Simplifier.make_simproc ctxt ("simp_strategy_" ^ fst (dest_Const name))
-    {lhss = [@{term simp_strategy} $ name $ @{term x}],
+  val ss = Simplifier.make_simproc ctxt
+    {name = "simp_strategy_" ^ fst (dest_Const name),
+     lhss = [@{term simp_strategy} $ name $ @{term x}],
      proc = (fn _ => fn ctxt' => fn ct =>
         ct
         |> (Conv.arg_conv (Simplifier.rewrite (put_simpset ss ctxt'))
           then_conv (if rewr_True then simp_strategy_True_conv
                       else Conv.all_conv))
-        |> (fn c => if Thm.is_reflexive c then NONE else SOME c))
-     }
+        |> (fn c => if Thm.is_reflexive c then NONE else SOME c)),
+     identifier = []}
 in
   ss
 end

--- a/lib/Try_Attribute.thy
+++ b/lib/Try_Attribute.thy
@@ -19,12 +19,11 @@ fun try_attribute_cmd (warn, attr_srcs) (ctxt, thm) =
   let
     val attrs = map (attribute_generic ctxt) attr_srcs
     val (th', context') =
-      fold (uncurry o Thm.apply_attribute) attrs (thm, ctxt)
-      handle e =>
-        (if Exn.is_interrupt e then Exn.reraise e
-         else if warn then warning ("TRY: ignoring exception: " ^ (@{make_string} e))
-         else ();
-        (thm, ctxt))
+      \<^try>\<open>
+         fold (uncurry o Thm.apply_attribute) attrs (thm, ctxt)
+       catch e =>
+         (if warn then warning ("TRY: ignoring exception: " ^ (@{make_string} e)) else ();
+          (thm, ctxt))\<close>
   in (SOME context', SOME th') end
 
 in

--- a/lib/Word_Lib/Bitwise.thy
+++ b/lib/Word_Lib/Bitwise.thy
@@ -400,9 +400,7 @@ fun upt_conv ctxt ct =
       end
   | _ => NONE;
 
-val expand_upt_simproc =
-  Simplifier.make_simproc \<^context> "expand_upt"
-   {lhss = [\<^term>\<open>upt x y\<close>], proc = K upt_conv};
+val expand_upt_simproc = \<^simproc_setup>\<open>passive expand_upt ("upt x y") = \<open>K upt_conv\<close>\<close>;
 
 fun word_len_simproc_fn ctxt ct =
   (case Thm.term_of ct of
@@ -420,8 +418,7 @@ fun word_len_simproc_fn ctxt ct =
   | _ => NONE);
 
 val word_len_simproc =
-  Simplifier.make_simproc \<^context> "word_len"
-   {lhss = [\<^term>\<open>len_of x\<close>], proc = K word_len_simproc_fn};
+  \<^simproc_setup>\<open>passive word_len ("len_of x") = \<open>K word_len_simproc_fn\<close>\<close>;
 
 (* convert 5 or nat 5 to Suc 4 when n_sucs = 1, Suc (Suc 4) when n_sucs = 2,
    or just 5 (discarding nat) when n_sucs = 0 *)
@@ -448,9 +445,11 @@ fun nat_get_Suc_simproc_fn n_sucs ctxt ct =
   end handle TERM _ => NONE;
 
 fun nat_get_Suc_simproc n_sucs ts =
-  Simplifier.make_simproc \<^context> "nat_get_Suc"
-   {lhss = map (fn t => t $ \<^term>\<open>n :: nat\<close>) ts,
-    proc = K (nat_get_Suc_simproc_fn n_sucs)};
+  Simplifier.make_simproc \<^context>
+   {name = "nat_get_Suc",
+    lhss = map (fn t => t $ \<^term>\<open>n :: nat\<close>) ts,
+    proc = K (nat_get_Suc_simproc_fn n_sucs),
+    identifier = []};
 
 val no_split_ss =
   simpset_of (put_simpset HOL_ss \<^context>

--- a/lib/Word_Lib/Guide.thy
+++ b/lib/Word_Lib/Guide.thy
@@ -64,7 +64,7 @@ text \<open>
 
       \<^item> Equality rule: @{thm [display, mode=iff] bit_eq_iff [where ?'a = int, no_vars]}
 
-      \<^item> Induction rule: @{thm [display, mode=iff] bits_induct [where ?'a = int, no_vars]}
+      \<^item> Induction rule: @{thm [display, mode=iff] bit_induct [where ?'a = int, no_vars]}
 
     \<^item> Characteristic properties @{prop [source] \<open>bit (f x) n \<longleftrightarrow> P x n\<close>}
       are available in fact collection \<^text>\<open>bit_simps\<close>.

--- a/lib/Word_Lib/More_Word.thy
+++ b/lib/Word_Lib/More_Word.thy
@@ -826,7 +826,7 @@ lemma word_2p_mult_inc:
   assumes x: "2 * 2 ^ n < (2::'a::len word) * 2 ^ m"
   assumes suc_n: "Suc n < LENGTH('a::len)"
   shows "2^n < (2::'a::len word)^m"
-  by (smt suc_n le_less_trans lessI nat_less_le nat_mult_less_cancel_disj p2_gt_0
+  by (smt (verit) suc_n le_less_trans lessI nat_less_le nat_mult_less_cancel_disj p2_gt_0
           power_Suc power_Suc unat_power_lower word_less_nat_alt x)
 
 lemma power_overflow:
@@ -1198,7 +1198,7 @@ lemma unat_Suc2:
 
 lemma word_div_1:
   "(n :: 'a :: len word) div 1 = n"
-  by (fact bits_div_by_1)
+  by (fact div_by_1)
 
 lemma word_minus_one_le:
   "-1 \<le> (x :: 'a :: len word) = (x = -1)"
@@ -2094,7 +2094,7 @@ lemma degenerate_word:"LENGTH('a) = 1 \<Longrightarrow> (x::('a::len) word) = 0 
   by (metis One_nat_def less_irrefl_nat sint_1_cases)
 
 lemma div_by_0_word: "(x::'a::len word) div 0 = 0"
-  by (fact bits_div_by_0)
+  by (fact div_by_0)
 
 lemma div_less_dividend_word:"\<lbrakk>x \<noteq> 0; n \<noteq> 1\<rbrakk> \<Longrightarrow> (x::('a::len) word) div n < x"
   apply (cases \<open>n = 0\<close>)
@@ -2232,8 +2232,7 @@ lemma word_ops_nth:
 lemma word_power_nonzero:
   "\<lbrakk> (x :: 'a::len word) < 2 ^ (LENGTH('a) - n); n < LENGTH('a); x \<noteq> 0 \<rbrakk>
   \<Longrightarrow> x * 2 ^ n \<noteq> 0"
-  by (metis Word.word_div_mult bits_div_0 len_gt_0 len_of_finite_2_def nat_mult_power_less_eq
-    p2_gt_0 unat_mono unat_power_lower word_gt_a_gt_0)
+  by (metis gr0I mult.commute not_less_eq p2_gt_0 power_0 word_less_1 word_power_less_diff zero_less_diff)
 
 lemma less_1_helper:
   "n \<le> m \<Longrightarrow> (n - 1 :: int) < m"
@@ -2411,7 +2410,7 @@ lemma eq_ucast_ucast_eq:
 lemma le_ucast_ucast_le:
   "x \<le> ucast y \<Longrightarrow> ucast x \<le> y"
   for x :: "'a::len word" and y :: "'b::len word"
-  by (smt le_unat_uoi linorder_not_less order_less_imp_le ucast_nat_def unat_arith_simps(1))
+  by (smt (verit) le_unat_uoi linorder_not_less order_less_imp_le ucast_nat_def unat_arith_simps(1))
 
 lemma less_ucast_ucast_less:
   "LENGTH('b) \<le> LENGTH('a) \<Longrightarrow> x < ucast y \<Longrightarrow> ucast x < y"

--- a/lib/Word_Lib/More_Word_Operations.thy
+++ b/lib/Word_Lib/More_Word_Operations.thy
@@ -805,7 +805,7 @@ lemma neg_mask_in_mask_range:
     apply (subst word_plus_and_or_coroll, word_eqI_solve)
     apply (metis bit.disj_ac(2) bit.disj_conj_distrib2 le_word_or2 word_and_max word_or_not)
    apply clarsimp
-   apply (smt add.right_neutral eq_iff is_aligned_neg_mask_eq mask_out_add_aligned neg_mask_mono_le
+   apply (smt (verit) add.right_neutral eq_iff is_aligned_neg_mask_eq mask_out_add_aligned neg_mask_mono_le
               word_and_not)
   apply (simp add: power_overflow mask_eq_decr_exp)
   done

--- a/lib/Word_Lib/Reversed_Bit_Lists.thy
+++ b/lib/Word_Lib/Reversed_Bit_Lists.thy
@@ -844,7 +844,6 @@ next
   obtain b k where \<open>bin = of_bool b + 2 * k\<close>
     using bin_exhaust by blast
   moreover have \<open>(2 * k - 1) div 2 = k - 1\<close>
-    using even_succ_div_2 [of \<open>2 * (k - 1)\<close>]
     by simp
   ultimately show ?case
     using Suc [of \<open>bin div 2\<close>]
@@ -2212,7 +2211,7 @@ text\<open>Like @{thm shiftr_bl}\<close>
 lemma sshiftr_bl: "x >>> n \<equiv> of_bl (replicate n (msb x) @ take (LENGTH('a) - n) (to_bl x))"
   for x :: "'a::len word"
   unfolding word_msb_alt
-  by (smt (z3) length_to_bl_eq sshiftr_bl_of word_bl.Rep_inverse)
+  by (smt (verit) length_to_bl_eq sshiftr_bl_of word_bl.Rep_inverse)
 
 end
 

--- a/lib/Word_Lib/Signed_Division_Word.thy
+++ b/lib/Word_Lib/Signed_Division_Word.thy
@@ -189,8 +189,8 @@ lemma sdiv_word_max:
 proof (cases \<open>sint a = 0 \<or> sint b = 0 \<or> sgn (sint a) \<noteq> sgn (sint b)\<close>)
   case True then show ?thesis
     apply (auto simp add: sgn_if not_less signed_divide_int_def split: if_splits)
-     apply (smt (z3) pos_imp_zdiv_neg_iff zero_le_power)
-    apply (smt (z3) not_exp_less_eq_0_int pos_imp_zdiv_neg_iff)
+     apply (smt (verit) pos_imp_zdiv_neg_iff zero_le_power)
+    apply (smt (verit) not_exp_less_eq_0_int pos_imp_zdiv_neg_iff)
     done
 next
   case False

--- a/lib/Word_Lib/Singleton_Bit_Shifts.thy
+++ b/lib/Word_Lib/Singleton_Bit_Shifts.thy
@@ -11,31 +11,40 @@ theory Singleton_Bit_Shifts
 begin
 
 definition shiftl1 :: \<open>'a::len word \<Rightarrow> 'a word\<close>
-  where \<open>shiftl1 = push_bit 1\<close>
+  where shiftl1_eq_double: \<open>shiftl1 = times 2\<close>
 
 lemma bit_shiftl1_iff [bit_simps]:
   \<open>bit (shiftl1 w) n \<longleftrightarrow> 0 < n \<and> n < LENGTH('a) \<and> bit w (n - 1)\<close>
   for w :: \<open>'a::len word\<close>
-  by (simp only: shiftl1_def bit_push_bit_iff) auto
+  by (auto simp add: shiftl1_eq_double bit_simps)
 
 definition shiftr1 :: \<open>'a::len word \<Rightarrow> 'a word\<close>
-  where \<open>shiftr1 = drop_bit 1\<close>
+  where shiftr1_eq_half: \<open>shiftr1 w = w div 2\<close>
 
 lemma bit_shiftr1_iff [bit_simps]:
   \<open>bit (shiftr1 w) n \<longleftrightarrow> bit w (Suc n)\<close>
   for w :: \<open>'a::len word\<close>
-  by (simp add: shiftr1_def bit_drop_bit_eq)
+  by (simp add: shiftr1_eq_half bit_Suc)
 
 definition sshiftr1 :: \<open>'a::len word \<Rightarrow> 'a word\<close>
-  where \<open>sshiftr1 \<equiv> signed_drop_bit 1\<close>
+  where sshiftr1_def: \<open>sshiftr1 = signed_drop_bit 1\<close>
 
 lemma bit_sshiftr1_iff [bit_simps]:
   \<open>bit (sshiftr1 w) n \<longleftrightarrow> bit w (if n = LENGTH('a) - 1 then LENGTH('a) - 1 else Suc n)\<close>
   for w :: \<open>'a::len word\<close>
-  by (auto simp add: sshiftr1_def bit_signed_drop_bit_iff)
+  by (auto simp add: sshiftr1_def bit_simps)
 
-lemma shiftr1_1: "shiftr1 (1::'a::len word) = 0"
-  by (simp add: shiftr1_def)
+lemma shiftl1_def:
+  \<open>shiftl1 = push_bit 1\<close>
+  by (rule ext, rule bit_word_eqI) (simp add: bit_simps mult.commute [of _ 2])
+
+lemma shiftr1_def:
+  \<open>shiftr1 = drop_bit 1\<close>
+  by (rule ext, rule bit_word_eqI) (simp add: bit_simps)
+
+lemma shiftr1_1:
+  \<open>shiftr1 (1::'a::len word) = 0\<close>
+  by (rule bit_word_eqI) (simp add: bit_simps)
 
 lemma sshiftr1_eq:
   \<open>sshiftr1 w = word_of_int (sint w div 2)\<close>
@@ -50,105 +59,108 @@ lemma shiftr1_eq:
   by (rule bit_word_eqI) (simp add: bit_simps flip: bit_Suc)
 
 lemma shiftl1_rev:
-  "shiftl1 w = word_reverse (shiftr1 (word_reverse w))"
+  \<open>shiftl1 w = word_reverse (shiftr1 (word_reverse w))\<close>
   by (rule bit_word_eqI) (auto simp add: bit_simps Suc_diff_Suc simp flip: bit_Suc)
 
 lemma shiftl1_p:
-  "shiftl1 w = w + w"
-  for w :: "'a::len word"
-  by (simp add: shiftl1_def)
+  \<open>shiftl1 w = w + w\<close>
+  by (rule bit_word_eqI) (simp add: bit_simps)
 
 lemma shiftr1_bintr:
-  "(shiftr1 (numeral w) :: 'a::len word) =
-    word_of_int (take_bit LENGTH('a) (numeral w) div 2)"
-  by (rule bit_word_eqI) (simp add: bit_simps bit_numeral_iff [where ?'a = int] flip: bit_Suc)
+  \<open>(shiftr1 (numeral w) :: 'a::len word) =
+    word_of_int (take_bit LENGTH('a) (numeral w) div 2)\<close>
+  apply (rule bit_word_eqI)
+  apply (simp add: bit_simps flip: bit_Suc)
+  done
 
 lemma sshiftr1_sbintr:
-  "(sshiftr1 (numeral w) :: 'a::len word) =
-    word_of_int (signed_take_bit (LENGTH('a) - 1) (numeral w) div 2)"
-  apply (cases \<open>LENGTH('a)\<close>)
-  apply simp_all
+  \<open>(sshiftr1 (numeral w) :: 'a::len word) =
+    word_of_int (signed_take_bit (LENGTH('a) - 1) (numeral w) div 2)\<close>
   apply (rule bit_word_eqI)
-  apply (auto simp add: bit_simps min_def simp flip: bit_Suc elim: le_SucE)
+  apply (simp add: bit_simps flip: bit_Suc)
+  apply transfer
+  apply auto
   done
 
 lemma shiftl1_wi:
-  "shiftl1 (word_of_int w) = word_of_int (2 * w)"
-  by (rule bit_word_eqI) (auto simp add: bit_simps)
+  \<open>shiftl1 (word_of_int w) = word_of_int (2 * w)\<close>
+  by (rule bit_word_eqI) (simp add: bit_simps)
 
 lemma shiftl1_numeral:
-  "shiftl1 (numeral w) = numeral (Num.Bit0 w)"
-  unfolding word_numeral_alt shiftl1_wi by simp
+  \<open>shiftl1 (numeral w) = numeral (Num.Bit0 w)\<close>
+  by (rule bit_word_eqI) (auto simp add: bit_simps bit_numeral_Bit0_iff)
 
 lemma shiftl1_neg_numeral:
-  "shiftl1 (- numeral w) = - numeral (Num.Bit0 w)"
-  unfolding word_neg_numeral_alt shiftl1_wi by simp
+  \<open>shiftl1 (- numeral w) = - numeral (Num.Bit0 w)\<close>
+  by (simp add: shiftl1_eq_double)
 
 lemma shiftl1_0:
-  "shiftl1 0 = 0"
-  by (simp add: shiftl1_def)
+  \<open>shiftl1 0 = 0\<close>
+  by (rule bit_word_eqI) (simp add: bit_simps)
 
 lemma shiftl1_def_u:
-  "shiftl1 w = word_of_int (2 * uint w)"
-  by (fact shiftl1_eq)
+  \<open>shiftl1 w = word_of_int (2 * uint w)\<close>
+  by (rule bit_word_eqI) (simp add: bit_simps)
 
 lemma shiftl1_def_s:
-  "shiftl1 w = word_of_int (2 * sint w)"
-  by (simp add: shiftl1_def)
+  \<open>shiftl1 w = word_of_int (2 * sint w)\<close>
+  by (rule bit_word_eqI) (simp add: bit_simps)
 
 lemma shiftr1_0:
-  "shiftr1 0 = 0"
-  by (simp add: shiftr1_def)
+  \<open>shiftr1 0 = 0\<close>
+  by (rule bit_word_eqI) (simp add: bit_simps)
 
 lemma sshiftr1_0:
-  "sshiftr1 0 = 0"
-  by (simp add: sshiftr1_def)
+  \<open>sshiftr1 0 = 0\<close>
+  by (rule bit_word_eqI) (simp add: bit_simps)
 
 lemma sshiftr1_n1:
-  "sshiftr1 (- 1) = - 1"
-  by (simp add: sshiftr1_def)
+  \<open>sshiftr1 (- 1) = - 1\<close>
+  by (rule bit_word_eqI) (auto simp add: bit_simps)
 
 lemma uint_shiftr1:
-  "uint (shiftr1 w) = uint w div 2"
+  \<open>uint (shiftr1 w) = uint w div 2\<close>
   by (rule bit_eqI) (simp add: bit_simps flip: bit_Suc)
 
 lemma shiftr1_div_2:
-  "uint (shiftr1 w) = uint w div 2"
+  \<open>uint (shiftr1 w) = uint w div 2\<close>
   by (fact uint_shiftr1)
 
 lemma sshiftr1_div_2:
-  "sint (sshiftr1 w) = sint w div 2"
-  by (rule bit_eqI) (auto simp add: bit_simps ac_simps min_def simp flip: bit_Suc elim: le_SucE)
+  \<open>sint (sshiftr1 w) = sint w div 2\<close>
+  by (rule bit_eqI) (auto simp add: bit_simps simp flip: bit_Suc)
 
 lemma nth_shiftl1:
-  "bit (shiftl1 w) n \<longleftrightarrow> n < size w \<and> n > 0 \<and> bit w (n - 1)"
+  \<open>bit (shiftl1 w) n \<longleftrightarrow> n < size w \<and> n > 0 \<and> bit w (n - 1)\<close>
   by (auto simp add: word_size bit_simps)
 
 lemma nth_shiftr1:
-  "bit (shiftr1 w) n = bit w (Suc n)"
+  \<open>bit (shiftr1 w) n = bit w (Suc n)\<close>
   by (fact bit_shiftr1_iff)
 
-lemma nth_sshiftr1: "bit (sshiftr1 w) n = (if n = size w - 1 then bit w n else bit w (Suc n))"
+lemma nth_sshiftr1:
+  \<open>bit (sshiftr1 w) n = (if n = size w - 1 then bit w n else bit w (Suc n))\<close>
   by (auto simp add: word_size bit_simps)
 
 lemma shiftl_power:
-  "(shiftl1 ^^ x) (y::'a::len word) = 2 ^ x * y"
-  by (induction x) (simp_all add: shiftl1_def)
+  \<open>(shiftl1 ^^ x) (y::'a::len word) = 2 ^ x * y\<close>
+  by (simp add: shiftl1_eq_double funpow_double_eq_push_bit push_bit_eq_mult)
 
 lemma le_shiftr1:
   \<open>shiftr1 u \<le> shiftr1 v\<close> if \<open>u \<le> v\<close>
-  using that by (simp add: word_le_nat_alt unat_div div_le_mono shiftr1_def drop_bit_Suc)
+  using that by (simp add: shiftr1_eq_half word_less_eq_imp_half_less_eq)
 
 lemma le_shiftr1':
-  "\<lbrakk> shiftr1 u \<le> shiftr1 v ; shiftr1 u \<noteq> shiftr1 v \<rbrakk> \<Longrightarrow> u \<le> v"
-  by (meson dual_order.antisym le_cases le_shiftr1)
+  \<open>u \<le> v\<close> if \<open>shiftr1 u \<le> shiftr1 v\<close> \<open>shiftr1 u \<noteq> shiftr1 v\<close>
+  by (rule word_half_less_imp_less_eq) (use that in \<open>simp add: shiftr1_eq_half\<close>)
 
 lemma sshiftr_eq_funpow_sshiftr1:
   \<open>w >>> n = (sshiftr1 ^^ n) w\<close>
-  apply (rule sym)
-  apply (simp add: sshiftr1_def sshiftr_def)
-  apply (induction n)
-   apply simp_all
-  done
+proof -
+  have \<open>sshiftr1 ^^ n = (signed_drop_bit n :: 'a word \<Rightarrow> _)\<close>
+    by (induction n) (simp_all add: sshiftr1_def)
+  then show ?thesis
+    by (simp add: sshiftr_def)
+qed
 
 end

--- a/lib/Word_Lib/Word_Lemmas.thy
+++ b/lib/Word_Lib/Word_Lemmas.thy
@@ -1346,7 +1346,7 @@ lemma word_two_power_neg_ineq:
 
 lemma unat_shiftl_absorb:
   "\<lbrakk> x \<le> 2 ^ p; p + k < LENGTH('a) \<rbrakk> \<Longrightarrow> unat (x :: 'a :: len word) * 2 ^ k = unat (x * 2 ^ k)"
-  by (smt add_diff_cancel_right' add_lessD1 le_add2 le_less_trans mult.commute nat_le_power_trans
+  by (smt (verit) add_diff_cancel_right' add_lessD1 le_add2 le_less_trans mult.commute nat_le_power_trans
           unat_lt2p unat_mult_lem unat_power_lower word_le_nat_alt)
 
 lemma word_plus_mono_right_split:
@@ -1512,7 +1512,7 @@ lemma sint_eq_uint_2pl:
 lemma pow_sub_less:
   "\<lbrakk> a + b \<le> LENGTH('a); unat (x :: 'a :: len word) = 2 ^ a \<rbrakk>
    \<Longrightarrow> unat (x * 2 ^ b - 1) < 2 ^ (a + b)"
-  by (smt (z3) eq_or_less_helperD le_add2 le_eq_less_or_eq le_trans power_add unat_mult_lem unat_pow_le_intro unat_power_lower word_eq_unatI)
+  by (smt (verit) eq_or_less_helperD le_add2 le_eq_less_or_eq le_trans power_add unat_mult_lem unat_pow_le_intro unat_power_lower word_eq_unatI)
 
 lemma sle_le_2pl:
   "\<lbrakk> (b :: 'a :: len word) < 2 ^ (LENGTH('a) - 1); a \<le> b \<rbrakk> \<Longrightarrow> a <=s b"
@@ -1545,8 +1545,8 @@ context
 begin
 
 private lemma sbintrunc_uint_ucast:
-  "Suc n = LENGTH('b::len) \<Longrightarrow> signed_take_bit n (uint (ucast w :: 'b word)) = signed_take_bit n (uint w)"
-  by word_eqI
+  \<open>signed_take_bit n (uint (ucast w :: 'b word)) = signed_take_bit n (uint w)\<close> if \<open>Suc n = LENGTH('b::len)\<close>
+  by (rule bit_eqI) (use that in \<open>auto simp add: bit_simps\<close>)
 
 private lemma test_bit_sbintrunc:
   assumes "i < LENGTH('a)"

--- a/lib/crunch-cmd.ML
+++ b/lib/crunch-cmd.ML
@@ -71,8 +71,6 @@ fun funkysplit [_,b,c] = [b,c]
 
 fun real_base_name name = name |> Long_Name.explode |> funkysplit |> Long_Name.implode (*Handles locales properly-ish*)
 
-fun handle_int exn func = if Exn.is_interrupt exn then Exn.reraise exn else func
-
 val Thm : (Facts.ref * Token.src list) -> ((Facts.ref * Token.src list), xstring) sum = Inl
 val Constant : xstring -> ((Facts.ref * Token.src list), xstring) sum = Inr
 val thms = lefts
@@ -235,6 +233,7 @@ fun simps_of n = n ^ simps_sfx;
 fun num_args t = length (binder_types t) - 1;
 
 fun real_const_from_name const nmspce ctxt =
+  \<^try>\<open>
     let
       val qual::locale::nm::nil = Long_Name.explode const;
       val SOME some_nmspce = nmspce;
@@ -243,7 +242,7 @@ fun real_const_from_name const nmspce ctxt =
      in
        nm
      end
-     handle exn => handle_int exn const;
+  catch _ => const\<close>;
 
 
 fun get_monad ctxt f xs = if is_Const f then
@@ -389,12 +388,14 @@ fun eq_cname (Const (s, _)) (Const (t, _)) = (s = t)
   | eq_cname _ _ = false
 
 fun resolve_abbreviated ctxt abbrev =
-  let
+  \<^try>\<open>
+    let
       val (abbrevn,_) = dest_Const abbrev
       val origin = (head_of (snd ((Consts.the_abbreviation o Proof_Context.consts_of) ctxt abbrevn)));
       val (originn,_) = dest_Const origin;
       val (_::_::_::nil) = Long_Name.explode originn;
-    in origin end handle exn => handle_int exn abbrev
+    in origin end
+  catch _ => abbrev\<close>;
 
 fun map_consts f =
       let
@@ -442,10 +443,14 @@ fun induct_inst ctxt const goal nmspce =
        then error ("Unfold rule generated for " ^ const ^ " does not apply")
        else (ms', induct_inst_simplified) end
 
-fun unfold_data ctxt constn goal nmspce NONE = (
-    induct_inst ctxt constn goal nmspce handle exn => handle_int exn
-    unfold ctxt constn goal nmspce handle exn => handle_int exn
-    error ("unfold_data: couldn't find defn or induct rule for " ^ constn))
+fun unfold_data ctxt constn goal nmspce NONE =
+    \<^try>\<open>
+      induct_inst ctxt constn goal nmspce
+    catch _ =>
+      \<^try>\<open>
+        unfold ctxt constn goal nmspce
+      catch _ =>
+        error ("unfold_data: couldn't find defn or induct rule for " ^ constn)\<close>\<close>
   | unfold_data ctxt constn goal _ (SOME thm) =
     let
       val trivial_rule = Thm.trivial goal
@@ -755,8 +760,8 @@ fun crunch cfg pre extra stack const' thms =
     let
       val _ = "crunching constant: " ^ Proof_Context.markup_const ctxt const |> writeln;
       val const_term = read_const ctxt const;
-      val goal = make_goal const_term const pre extra ctxt
-                 handle exn => handle_int exn (raise WrongType);
+      val goal =
+        \<^try>\<open>make_goal const_term const pre extra ctxt catch _ => raise WrongType\<close>;
       val _ = debug_trace_bl
         [K (Pretty.str "goal: "), fn () => Syntax.pretty_term ctxt goal]
     in (* first check: has this constant already been done or supplied? *)
@@ -832,15 +837,17 @@ fun crunch cfg pre extra stack const' thms =
 fun get_locale_origins full_const_names ctxt =
   let
     fun get_locale_origin abbrev =
-      let
-        (*Check if the given const is an abbreviation*)
-        val (origin,_) = dest_Const (head_of (snd ((Consts.the_abbreviation o Proof_Context.consts_of) ctxt abbrev)));
-        (*Check that the origin can be broken into 3 parts (i.e. it is from a locale) *)
-        val [_,_,_] = Long_Name.explode origin;
-        (*Remember the theory for the abbreviation*)
+      \<^try>\<open>
+        let
+          (*Check if the given const is an abbreviation*)
+          val (origin,_) = dest_Const (head_of (snd ((Consts.the_abbreviation o Proof_Context.consts_of) ctxt abbrev)));
+          (*Check that the origin can be broken into 3 parts (i.e. it is from a locale) *)
+          val [_,_,_] = Long_Name.explode origin;
+          (*Remember the theory for the abbreviation*)
 
-        val [qual,nm] = Long_Name.explode abbrev
-      in SOME qual end handle exn => handle_int exn NONE
+          val [qual,nm] = Long_Name.explode abbrev
+        in SOME qual end
+      catch _ => NONE\<close>
   in fold (curry (fn (abbrev,qual) => case (get_locale_origin abbrev) of
                                         SOME q => SOME q
                                       | NONE => NONE)) full_const_names NONE

--- a/lib/defs.ML
+++ b/lib/defs.ML
@@ -4,6 +4,16 @@
  * SPDX-License-Identifier: BSD-2-Clause
  *)
 
+(* This is a slightly modified and simplified version of the old Isabelle "defs" command.
+   It still uses Global_Theory.add_def as "defs" did.
+
+   The modifications are:
+     - "overloading" and "unchecked" are removed
+     - no attributes for the definition theorem
+     - only one equation per "defs" command
+     - deprecation warning removed
+*)
+
 signature OLD_DEFS=
 sig
 end
@@ -15,18 +25,7 @@ fun read ctxt (b, str) =
   Syntax.read_prop ctxt str handle ERROR msg =>
     cat_error msg ("The error(s) above occurred in definition " ^ Binding.print b);
 
-fun add_defs ctxt ((unchecked, overloaded), args) thy =
- (legacy_feature "Old 'defs' command -- use 'definition' (with 'overloading') instead";
-  thy |>
-    (if unchecked then Global_Theory.add_defs_unchecked else Global_Theory.add_defs)
-      overloaded
-      (map (fn ((b, ax), srcs) => ((b, read ctxt (b, ax)), map (Attrib.attribute_cmd ctxt) srcs)) args));
-
-val opt_unchecked_overloaded =
-  Scan.optional (@{keyword "("} |-- Parse.!!!
-    (((@{keyword "unchecked"} >> K true) --
-        Scan.optional (@{keyword "overloaded"} >> K true) false ||
-      @{keyword "overloaded"} >> K (false, true)) --| @{keyword ")"})) (false, false);
+fun add_def ctxt (b, str) thy = Global_Theory.add_def (b, read ctxt (b, str)) thy
 
 fun syntax_alias global_alias local_alias b name =
   Local_Theory.declaration {syntax = true, pos = Position.none, pervasive = true} (fn phi =>
@@ -39,18 +38,14 @@ val const_alias = syntax_alias Sign.const_alias Proof_Context.const_alias;
 
 val _ =
   Outer_Syntax.command @{command_keyword defs} "define constants"
-    (Parse.opt_target -- (opt_unchecked_overloaded --
-      Scan.repeat1 (Parse_Spec.thm_name ":" -- Parse.prop >> (fn ((x, y), z) => ((x, z), y))))
-      >> (fn (target, (b, args)) => Toplevel.local_theory NONE target (fn lthy =>
+    (Parse.opt_target -- (Parse.binding -- (Parse.$$$ ":" |-- Parse.prop))
+      >> (fn (target, (b, str)) => Toplevel.local_theory NONE target (fn lthy =>
           let
-               val args' = map (fn ((b, def), x) => ((Binding.suffix_name "__internal__" b, def), x)) args
-               val (thms, lthy') = Local_Theory.background_theory_result (add_defs lthy (b, args')) lthy;
-               val lthy'' = fold2 (fn ((b, _), _) => fn thm =>
-                  fn lthy =>
-                    let val (_, lthy') = Local_Theory.note ((b,[]), [thm]) lthy
-                    in lthy' end) args thms lthy';
-               val lthy''' = Local_Theory.raw_theory (fold (fn thm =>
-                    Global_Theory.hide_fact true (Thm.derivation_name thm)) thms) lthy''
+               val b' = Binding.suffix_name "__internal__" b
+               val (thm, lthy') = Local_Theory.background_theory_result (add_def lthy (b', str)) lthy;
+               val (_, lthy'') = Local_Theory.note ((b,[]), [thm]) lthy'
+               val lthy''' = Local_Theory.raw_theory
+                               (Global_Theory.hide_fact true (Thm.derivation_name thm)) lthy''
           in lthy''' end)));
 
 

--- a/proof/crefine/Move_C.thy
+++ b/proof/crefine/Move_C.thy
@@ -286,8 +286,8 @@ lemma word_minus_1_shiftr:
   apply (clarsimp simp: and_mask_dvd low_bits_zero)
   apply (subst mod_pos_pos_trivial)
     apply (simp add: word_le_def)
-    apply (metis mult_zero_left neq_zero div_positive_int linorder_not_le uint_2p_alt word_div_lt_eq_0
-                 word_less_def zless2p)
+    apply (metis (mono_tags) More_Word.word_div_mult assms(2) div_of_0_id p2_gt_0 uint_2p_alt uint_div
+                             unsigned_eq_0_iff word_less_div word_less_iff_unsigned)
    apply (metis shiftr_div_2n uint_1 uint_sub_lt2p)
   apply fastforce
   done

--- a/proof/crefine/lib/CToCRefine.thy
+++ b/proof/crefine/lib/CToCRefine.thy
@@ -28,14 +28,16 @@ ML \<open>
 fun mk_meta_eq_safe t = mk_meta_eq t
   handle THM _ => t;
 
-val unfold_bodies = Simplifier.make_simproc @{context} "unfold constants named *_body"
-  {lhss = [@{term "v"}],
-   proc= fn _ =>
-  (fn ctxt => (fn t => case head_of (Thm.term_of t) of
-    Const (s, _) => if String.isSuffix "_body" s
-       then try (Global_Theory.get_thm (Proof_Context.theory_of ctxt) #> mk_meta_eq_safe) (suffix "_def" s)
-       else NONE
-   | _ => NONE))}
+val unfold_bodies = Simplifier.make_simproc @{context}
+  {name = "unfold constants named *_body",
+   lhss = [@{term "v"}],
+   proc = fn _ =>
+     (fn ctxt => (fn t => case head_of (Thm.term_of t) of
+       Const (s, _) => if String.isSuffix "_body" s
+          then try (Global_Theory.get_thm (Proof_Context.theory_of ctxt) #> mk_meta_eq_safe) (suffix "_def" s)
+          else NONE
+      | _ => NONE)),
+   identifier = []}
 \<close>
 
 theorem spec_refine:

--- a/spec/design/skel/CSpace_H.thy
+++ b/spec/design/skel/CSpace_H.thy
@@ -29,7 +29,8 @@ termination
   done
 
 defs
-  resolveAddressBits_decl_def [simp]:
+  resolveAddressBits_decl_def:
   "CSpaceDecls_H.resolveAddressBits \<equiv> resolveAddressBits"
+declare resolveAddressBits_decl_def[simp]
 
 end

--- a/tools/asmrefine/ProveGraphRefine.thy
+++ b/tools/asmrefine/ProveGraphRefine.thy
@@ -355,9 +355,11 @@ fun fold_of_nat_eq_Ifs ctxt tm = let
   in thm end
 
 val fold_of_nat_eq_Ifs_simproc = Simplifier.make_simproc
-  (Proof_Context.init_global @{theory}) "fold_of_nat_eq_Ifs"
-  { lhss = [@{term "If (x = 0) y z"}]
+  (Proof_Context.init_global @{theory})
+  { name = "fold_of_nat_eq_Ifs"
+  , lhss = [@{term "If (x = 0) y z"}]
   , proc = fn _ => fn ctxt => try (fold_of_nat_eq_Ifs ctxt) o Thm.term_of
+  , identifier = []
   }
 
 fun unfold_assertion_data_get_set_conv ctxt tm = let
@@ -369,9 +371,11 @@ fun unfold_assertion_data_get_set_conv ctxt tm = let
   in Simplifier.rewrite (ctxt addsimps defs) (Thm.cterm_of ctxt tm) end
 
 val unfold_assertion_data_get_set = Simplifier.make_simproc
-  (Proof_Context.init_global @{theory}) "unfold_assertion_data_get"
-  { lhss = [@{term "ghost_assertion_data_get k acc s"}, @{term "ghost_assertion_data_set k v upd"}]
+  (Proof_Context.init_global @{theory})
+  { name = "unfold_assertion_data_get"
+  , lhss = [@{term "ghost_assertion_data_get k acc s"}, @{term "ghost_assertion_data_set k v upd"}]
   , proc = fn _ => fn ctxt => SOME o (unfold_assertion_data_get_set_conv ctxt) o Thm.term_of
+  , identifier = []
   }
 
 \<close>

--- a/tools/autocorres/WordAbstract.thy
+++ b/tools/autocorres/WordAbstract.thy
@@ -249,8 +249,7 @@ lemma sint_bitwise_abstract_binops:
 lemma abstract_val_signed_bitNOT:
   "abstract_val P x sint (x' :: 'a::len signed word) \<Longrightarrow>
    abstract_val P (NOT x) sint (NOT x')"
-  by (fastforce intro: int_eq_test_bitI
-                simp: nth_sint bin_nth_ops word_nth_neq test_bit_def'[symmetric] test_bit_wi[where 'a="'a signed"])
+  by (fastforce intro: int_eq_test_bitI simp: min_less_iff_disj)
 
 lemma abstract_val_signed_unary_minus:
   "\<lbrakk> abstract_val P r sint r' \<rbrakk> \<Longrightarrow>

--- a/tools/autocorres/autocorres_trace.ML
+++ b/tools/autocorres/autocorres_trace.ML
@@ -171,25 +171,28 @@ fun my_unify_fact_tac ctxt subproof n state =
   case my_typ_match stateterm proofterm of
      NONE => Seq.empty
    | SOME typinsts =>
+     \<^try>\<open>
      (case Thm.instantiate (TVars.make (map (fn (v, t) => (v, ctyp_of' t)) (Utils.nubBy fst typinsts)), Vars.empty) state of
        state' =>
         let val stateterm' = nth (Thm.prems_of state') (n-1) in
         case my_match stateterm' proofterm of
            NONE => Seq.empty
          | SOME substs =>
+            \<^try>\<open>
              let val substs' = Utils.nubBy #1 substs
                                |> map (fn (var, args, t') => (var, my_lambda args t'))
                                |> map (fn (v, t) => (v, cterm_of' t))
              in
-             case Thm.instantiate (TVars.empty, Vars.make substs') state of state' =>
-               (case Proof_Context.fact_tac ctxt [Variable.gen_all ctxt subproof] 1 state' |> Seq.pull of
-                   NONE => Seq.empty
-                 | r => Seq.make (fn () => r))
-             handle _ => Seq.empty
+             \<^try>\<open>
+               case Thm.instantiate (TVars.empty, Vars.make substs') state of state' =>
+                 (case Proof_Context.fact_tac ctxt [Variable.gen_all ctxt subproof] 1 state' |> Seq.pull of
+                     NONE => Seq.empty
+                   | r => Seq.make (fn () => r))
+             catch _ => Seq.empty\<close>
              end
-       handle _ => Seq.empty
+            catch _ => Seq.empty\<close>
       end)
-      handle _ => Seq.empty
+      catch _ => Seq.empty\<close>
   end
   end
 

--- a/tools/autocorres/utils.ML
+++ b/tools/autocorres/utils.ML
@@ -950,8 +950,9 @@ fun solved_tac thm =
 
 (* Convenience function for making simprocs. *)
 fun mk_simproc' ctxt (name : string, pats : string list, proc : Proof.context -> cterm -> thm option) = let
-  in Simplifier.make_simproc ctxt name
-       {lhss = map (Proof_Context.read_term_pattern ctxt) pats,
+  in Simplifier.make_simproc ctxt
+       {name=name, identifier=[],
+        lhss = map (Proof_Context.read_term_pattern ctxt) pats,
         proc = K proc} end
 
 (* Get named_theorems in reverse order. We use this for translation rulesets

--- a/tools/c-parser/UMM_Proofs.ML
+++ b/tools/c-parser/UMM_Proofs.ML
@@ -406,28 +406,28 @@ fun umm_struct_calculation ((recname, flds), st, thy) = let
       Const(@{const_name "typ_name_itself"}, mk_itself_type recty -->
           typ_name_ty) $ Free("x", mk_itself_type recty)
   val typnameitself_rhs = mk_string recname
-  val typnameitself_triple =
-      ((Binding.name (recname ^ "_typ_name_itself"),
-        mk_defeqn(typnameitself_lhs, typnameitself_rhs)),
-       [Simplifier.simp_add])
+  val typnameitself_tuple =
+      (Binding.name (recname ^ "_typ_name_itself"),
+       mk_defeqn(typnameitself_lhs, typnameitself_rhs))
 
   (* the typ_tag definition *)
   val typtag_lhs = mk_typ_info_tm recty $ Free("x", mk_itself_type recty)
   val typtag_rhs = tag_tm
-  val typtag_triple =
-      ((Binding.name (recname ^ "_typ_tag"),
-        mk_defeqn(typtag_lhs, typtag_rhs)),
-       [])
+  val typtag_tuple =
+      (Binding.name (recname ^ "_typ_tag"),
+       mk_defeqn(typtag_lhs, typtag_rhs))
 
   val typ_info_TYPE = mk_typ_info_of recty
 
   (* make the definitions *)
   val (typnameitself_thm, typtag_thm, thy) =
-      case Global_Theory.add_defs true
-                                  [typnameitself_triple, typtag_triple] thy
+      case fold_map Global_Theory.add_def_overloaded
+                                  [typnameitself_tuple, typtag_tuple] thy
        of
           ([x,y], thy) => (x,y,thy)
         | _ => raise Fail "UMM_Proofs: Bind error"
+  val (_, thy) =
+      Global_Theory.note_thms "" ((Binding.empty, []), [([typnameitself_thm], [Simplifier.simp_add])]) thy
   val thy = add_data_thms [("typ_name_itself", [typnameitself_thm])] thy
 
   val _ = phase "MEMTYPE"

--- a/tools/c-parser/heapstatetype.ML
+++ b/tools/c-parser/heapstatetype.ML
@@ -58,10 +58,9 @@ fun hst_prove_globals fullrecname thy = let
        ("hst_htd_update",hst_htd_update_lhs_t,hst_htd_update_rhs_t)]
   val defs = map (fn (n,l,r) =>
                      ((Binding.name (n ^ NameGeneration.global_rcd_name),
-                       mk_defeqn(l recty', r hrs recty')),
-                      []))
+                       mk_defeqn(l recty', r hrs recty'))))
                  triples
-  val (hst_thms, thy) = Global_Theory.add_defs true defs thy
+  val (hst_thms, thy) = fold_map Global_Theory.add_def_overloaded defs thy
   val thy' = thy |> Context.theory_map (Simplifier.map_ss (fn ss => ss addsimps hst_thms))
   val hst_instance_t =
       Logic.mk_of_class(recty, "SepFrame.heap_state_type")

--- a/tools/c-parser/standalone-parser/Makefile
+++ b/tools/c-parser/standalone-parser/Makefile
@@ -53,7 +53,8 @@ include $(STP_PFX)/../Makefile
 STP_CLEAN_TARGETS := $(STPARSERS) $(TOKENIZERS) $(STP_PFX)/c-parser.o $(STP_PFX)/table.ML
 
 $(STP_PFX)/table.ML: $(ISABELLE_HOME)/src/Pure/General/table.ML
-	sed -e '/ML.pretty-printing/,/final.declarations/d' < $< > $@
+	sed -e '/\(\* cache \*\)/,/final.declarations/d' < $< | \
+	sed -e "s/^  val unsynchronized_cache:.*a/  (* removed unsynchronized_cache *)/" > $@
 
 $(ARCH_DIRS):
 	mkdir -p $@

--- a/tools/c-parser/standalone-parser/Makefile
+++ b/tools/c-parser/standalone-parser/Makefile
@@ -52,7 +52,7 @@ include $(STP_PFX)/../Makefile
 
 STP_CLEAN_TARGETS := $(STPARSERS) $(TOKENIZERS) $(STP_PFX)/c-parser.o $(STP_PFX)/table.ML
 
-$(STP_PFX)/table.ML: $(ISABELLE_HOME)/src/Pure/General/table.ML
+$(STP_PFX)/table.ML: $(ISABELLE_HOME)/src/Pure/General/table.ML $(STP_PFX)/Makefile
 	sed -e '/\(\* cache \*\)/,/final.declarations/d' < $< | \
 	sed -e "s/^  val unsynchronized_cache:.*a/  (* removed unsynchronized_cache *)/" > $@
 

--- a/tools/c-parser/umm_heap/ArrayAssertion.thy
+++ b/tools/c-parser/umm_heap/ArrayAssertion.thy
@@ -204,7 +204,7 @@ next
     apply (simp add: o_def)
     apply (subst Suc.hyps)
      apply arith
-    apply (metis mod_geq)
+    apply (simp add: mod_if)
     done
 qed
 


### PR DESCRIPTION
Updates all proofs and ML code to Isabelle2024.

The changes are very minor this time, and apart from one or two cases only involve ML code. The main ML differences are that:
* the simproc setup has changed slightly
* it is now an error to catch all exceptions and instead we use the new `\<^try>` antiquotation
* the underlying ML for the old-style `defs` command was downgraded, which meant that `defs` had to be correspondingly downgraded as well.

Nicely, initial testing did show some fairly significant performance improvements, particularly to the CPU time.
```
Isabelle2023:
  N = 22
  Average ARM CRefine: (00:28:45 real, 03:16:57 cpu, 22.11GB)
  Standard Deviation: (00:01:25 real, 00:16:05 cpu, 0.38GB)
Isabelle2024:
  N = 22
  Average ARM CRefine: (00:24:16 real, 02:22:21 cpu, 22.12GB)
  Standard Deviation: (00:00:29 real, 00:02:49 cpu, 0.40GB)
```