### PR TITLE
More monad improvements

### DIFF
--- a/lib/CorresK_Method.thy
+++ b/lib/CorresK_Method.thy
@@ -981,13 +981,13 @@ lemma corres_inst_conj_lift[corresKwp_wp_comb]:
 lemmas [corresKwp_wp_comb] =
   corresKwp_wp_comb_del[# \<open>-\<close> \<open>atomize (full), rule allI, rule corres_inst_eq_imp\<close>]
   valid_validE_R
-  hoare_vcg_R_conj[OF valid_validE_R]
-  hoare_vcg_E_elim[OF valid_validE_E]
-  hoare_vcg_E_conj[OF valid_validE_E]
+  hoare_vcg_conj_liftE_R[OF valid_validE_R]
+  hoare_vcg_conj_elimE[OF valid_validE_E]
+  hoare_vcg_conj_liftE_E[OF valid_validE_E]
   validE_validE_R
-  hoare_vcg_R_conj
-  hoare_vcg_E_elim
-  hoare_vcg_E_conj
+  hoare_vcg_conj_liftE_R
+  hoare_vcg_conj_elimE
+  hoare_vcg_conj_liftE_E
   hoare_vcg_conj_lift
 
 declare hoare_post_comb_imp_conj[corresKwp_wp_comb_del]

--- a/lib/ExtraCorres.thy
+++ b/lib/ExtraCorres.thy
@@ -464,14 +464,14 @@ lemma corres_whileLoop_abs_ret:
    apply (clarsimp simp: validNF_def)
    apply (rule conjI)
     apply (intro hoare_vcg_conj_lift_pre_fix; (solves wpsimp)?)
-      apply (rule_tac Q="\<lambda>s'. \<exists>rv s. (s, s') \<in> srel \<and> rrel rv conc_r
+      apply (rule_tac P'="\<lambda>s'. \<exists>rv s. (s, s') \<in> srel \<and> rrel rv conc_r
                                      \<and> P rv s \<and> (P' conc_r s' \<and> C' conc_r s') \<and> s' = new_s"
                    in hoare_weaken_pre[rotated])
        apply clarsimp
       apply (rule hoare_ex_pre)
       apply (rename_tac abs_r)
       apply (rule hoare_weaken_pre)
-       apply (rule_tac G="rrel abs_r conc_r" in hoare_grab_asm)
+       apply (rule_tac P'="rrel abs_r conc_r" in hoare_grab_asm)
        apply (wpsimp wp: wp_from_corres_u[OF body_corres] body_inv)
        apply (fastforce dest: nf)
       apply (fastforce dest: cond)

--- a/lib/Monad_Lists.thy
+++ b/lib/Monad_Lists.thy
@@ -482,7 +482,7 @@ lemma filterM_subset:
 lemma filterM_all:
   "\<lbrakk> \<And>x y. \<lbrakk> x \<in> set xs; y \<in> set xs \<rbrakk> \<Longrightarrow> \<lbrace>P y\<rbrace> m x \<lbrace>\<lambda>rv. P y\<rbrace> \<rbrakk> \<Longrightarrow>
    \<lbrace>\<lambda>s. \<forall>x \<in> set xs. P x s\<rbrace> filterM m xs \<lbrace>\<lambda>rv s. \<forall>x \<in> set rv. P x s\<rbrace>"
-  apply (rule_tac Q="\<lambda>rv s. set rv \<subseteq> set xs \<and> (\<forall>x \<in> set xs. P x s)"
+  apply (rule_tac Q'="\<lambda>rv s. set rv \<subseteq> set xs \<and> (\<forall>x \<in> set xs. P x s)"
               in hoare_strengthen_post)
    apply (wp filterM_subset hoare_vcg_const_Ball_lift filterM_preserved)
     apply simp+

--- a/lib/Monads/nondet/Nondet_More_VCG.thy
+++ b/lib/Monads/nondet/Nondet_More_VCG.thy
@@ -20,20 +20,20 @@ lemma hoare_take_disjunct:
   by (erule hoare_strengthen_post, simp)
 
 lemma hoare_post_add:
-  "\<lbrace>P\<rbrace> S \<lbrace>\<lambda>r s. R r s \<and> Q r s\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace> S \<lbrace>Q\<rbrace>"
+  "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>r s. Q' r s \<and> Q r s\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>"
   by (erule hoare_strengthen_post, simp)
 
 lemma hoare_post_addE:
-  "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>_ s. R s \<and> Q s\<rbrace>, \<lbrace>T\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>_ s. Q s\<rbrace>, \<lbrace>T\<rbrace>"
+  "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>_ s. Q' s \<and> Q s\<rbrace>,\<lbrace>E\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>_ s. Q s\<rbrace>,\<lbrace>E\<rbrace>"
   by (erule hoare_strengthen_postE; simp)
 
 lemma hoare_pre_add:
-  "(\<forall>s. P s \<longrightarrow> R s) \<Longrightarrow> (\<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace> \<longleftrightarrow> \<lbrace>P and R\<rbrace> f \<lbrace>Q\<rbrace>)"
+  "(\<forall>s. P s \<longrightarrow> P' s) \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace> \<longleftrightarrow> \<lbrace>P and P'\<rbrace> f \<lbrace>Q\<rbrace>"
   apply (subst iff_conv_conj_imp)
   by(intro conjI impI; rule hoare_weaken_pre, assumption, clarsimp)
 
 lemma hoare_pre_addE:
-  "(\<forall>s. P s \<longrightarrow> R s) \<Longrightarrow> (\<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>, \<lbrace>S\<rbrace> \<longleftrightarrow> \<lbrace>P and R\<rbrace> f \<lbrace>Q\<rbrace>, \<lbrace>S\<rbrace>)"
+  "(\<forall>s. P s \<longrightarrow> P' s) \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace> \<longleftrightarrow> \<lbrace>P and P'\<rbrace> f \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
   apply (subst iff_conv_conj_imp)
   by(intro conjI impI; rule hoare_weaken_preE, assumption, clarsimp)
 
@@ -46,15 +46,15 @@ lemma hoare_name_pre_stateE:
   by (clarsimp simp: validE_def2)
 
 lemma hoare_vcg_if_lift_strong:
-  "\<lbrakk> \<lbrace>P'\<rbrace> f \<lbrace>P\<rbrace>; \<lbrace>\<lambda>s. \<not> P' s\<rbrace> f \<lbrace>\<lambda>rv s. \<not> P rv s\<rbrace>; \<lbrace>Q'\<rbrace> f \<lbrace>Q\<rbrace>; \<lbrace>R'\<rbrace> f \<lbrace>R\<rbrace> \<rbrakk> \<Longrightarrow>
-   \<lbrace>\<lambda>s. if P' s then Q' s else R' s\<rbrace> f \<lbrace>\<lambda>rv s. if P rv s then Q rv s else R rv s\<rbrace>"
+  "\<lbrakk> \<lbrace>P'\<rbrace> f \<lbrace>P\<rbrace>; \<lbrace>\<lambda>s. \<not> P' s\<rbrace> f \<lbrace>\<lambda>rv s. \<not> P rv s\<rbrace>; \<lbrace>Q'\<rbrace> f \<lbrace>Q\<rbrace>; \<lbrace>S'\<rbrace> f \<lbrace>S\<rbrace> \<rbrakk> \<Longrightarrow>
+   \<lbrace>\<lambda>s. if P' s then Q' s else S' s\<rbrace> f \<lbrace>\<lambda>rv s. if P rv s then Q rv s else S rv s\<rbrace>"
 
-  "\<lbrakk> \<lbrace>P'\<rbrace> f \<lbrace>P\<rbrace>; \<lbrace>\<lambda>s. \<not> P' s\<rbrace> f \<lbrace>\<lambda>rv s. \<not> P rv s\<rbrace>; \<lbrace>Q'\<rbrace> f \<lbrace> Q\<rbrace>; \<lbrace>R'\<rbrace> f \<lbrace>R\<rbrace> \<rbrakk> \<Longrightarrow>
-   \<lbrace>\<lambda>s. if P' s then Q' s else R' s\<rbrace> f \<lbrace>\<lambda>rv s. (if P rv s then Q rv else R rv) s\<rbrace>"
+  "\<lbrakk> \<lbrace>P'\<rbrace> f \<lbrace>P\<rbrace>; \<lbrace>\<lambda>s. \<not> P' s\<rbrace> f \<lbrace>\<lambda>rv s. \<not> P rv s\<rbrace>; \<lbrace>Q'\<rbrace> f \<lbrace> Q\<rbrace>; \<lbrace>S'\<rbrace> f \<lbrace>S\<rbrace> \<rbrakk> \<Longrightarrow>
+   \<lbrace>\<lambda>s. if P' s then Q' s else S' s\<rbrace> f \<lbrace>\<lambda>rv s. (if P rv s then Q rv else S rv) s\<rbrace>"
   by (wpsimp wp: hoare_vcg_imp_lift' | assumption | fastforce)+
 
 lemma hoare_vcg_imp_lift_pre_add:
-  "\<lbrakk> \<lbrace>P and Q\<rbrace> f \<lbrace>\<lambda>rv s. R rv s\<rbrace>; f \<lbrace>\<lambda>s. \<not> Q s\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. Q s \<longrightarrow> R rv s\<rbrace>"
+  "\<lbrakk> \<lbrace>P and Q\<rbrace> f \<lbrace>\<lambda>rv s. Q' rv s\<rbrace>; f \<lbrace>\<lambda>s. \<not> Q s\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. Q s \<longrightarrow> Q' rv s\<rbrace>"
   apply (rule hoare_weaken_pre)
    apply (rule hoare_vcg_imp_lift')
     apply fastforce
@@ -66,16 +66,17 @@ lemma hoare_pre_tautI:
   "\<lbrakk> \<lbrace>A and P\<rbrace> a \<lbrace>B\<rbrace>; \<lbrace>A and not P\<rbrace> a \<lbrace>B\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>A\<rbrace> a \<lbrace>B\<rbrace>"
   by (fastforce simp: valid_def split_def pred_conj_def pred_neg_def)
 
+\<comment> \<open>FIXME: swap P and Q in these rules?\<close>
 lemma hoare_lift_Pf_pre_conj:
   assumes P: "\<And>x. \<lbrace>\<lambda>s. Q x s\<rbrace> m \<lbrace>P x\<rbrace>"
-  assumes f: "\<And>P. \<lbrace>\<lambda>s. P (g s) \<and> R s\<rbrace> m \<lbrace>\<lambda>_ s. P (f s)\<rbrace>"
-  shows "\<lbrace>\<lambda>s. Q (g s) s \<and> R s\<rbrace> m \<lbrace>\<lambda>rv s. P (f s) rv s\<rbrace>"
+  assumes f: "\<And>P. \<lbrace>\<lambda>s. P (g s) \<and> P' s\<rbrace> m \<lbrace>\<lambda>_ s. P (f s)\<rbrace>"
+  shows "\<lbrace>\<lambda>s. Q (g s) s \<and> P' s\<rbrace> m \<lbrace>\<lambda>rv s. P (f s) rv s\<rbrace>"
   apply (clarsimp simp: valid_def)
   apply (rule use_valid [OF _ P], simp)
   apply (rule use_valid [OF _ f], simp, simp)
   done
 
-lemmas hoare_lift_Pf4 = hoare_lift_Pf_pre_conj[where R=\<top>, simplified]
+lemmas hoare_lift_Pf4 = hoare_lift_Pf_pre_conj[where P'=\<top>, simplified]
 lemmas hoare_lift_Pf3 = hoare_lift_Pf4[where f=f and g=f for f]
 lemmas hoare_lift_Pf2 = hoare_lift_Pf3[where P="\<lambda>f _. P f" for P]
 lemmas hoare_lift_Pf = hoare_lift_Pf2[where Q=P and P=P for P]
@@ -85,13 +86,13 @@ lemmas hoare_lift_Pf2_pre_conj = hoare_lift_Pf3_pre_conj[where P="\<lambda>f _. 
 lemmas hoare_lift_Pf_pre_conj' = hoare_lift_Pf2_pre_conj[where Q=P and P=P for P]
 
 lemma hoare_if_r_and:
-  "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>r. if R r then Q r else Q' r\<rbrace>
-   = \<lbrace>P\<rbrace> f \<lbrace>\<lambda>r s. (R r \<longrightarrow> Q r s) \<and> (\<not>R r \<longrightarrow> Q' r s)\<rbrace>"
+  "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>r. if P' r then Q r else Q' r\<rbrace>
+   = \<lbrace>P\<rbrace> f \<lbrace>\<lambda>r s. (P' r \<longrightarrow> Q r s) \<and> (\<not>P' r \<longrightarrow> Q' r s)\<rbrace>"
   by (fastforce simp: valid_def)
 
 lemma hoare_convert_imp:
-  "\<lbrakk> \<lbrace>\<lambda>s. \<not> P s\<rbrace> f \<lbrace>\<lambda>rv s. \<not> Q s\<rbrace>; \<lbrace>R\<rbrace> f \<lbrace>S\<rbrace> \<rbrakk>
-   \<Longrightarrow> \<lbrace>\<lambda>s. P s \<longrightarrow> R s\<rbrace> f \<lbrace>\<lambda>rv s. Q s \<longrightarrow> S rv s\<rbrace>"
+  "\<lbrakk> \<lbrace>\<lambda>s. \<not> P s\<rbrace> f \<lbrace>\<lambda>rv s. \<not> Q s\<rbrace>; \<lbrace>P'\<rbrace> f \<lbrace>S\<rbrace> \<rbrakk>
+   \<Longrightarrow> \<lbrace>\<lambda>s. P s \<longrightarrow> P' s\<rbrace> f \<lbrace>\<lambda>rv s. Q s \<longrightarrow> S rv s\<rbrace>"
   apply (simp only: imp_conv_disj)
   apply (erule(1) hoare_vcg_disj_lift)
   done
@@ -107,12 +108,6 @@ lemma hoare_case_option_wpR:
   "\<lbrakk>\<lbrace>P\<rbrace> f None \<lbrace>Q\<rbrace>,-; \<And>x. \<lbrace>P' x\<rbrace> f (Some x) \<lbrace>Q' x\<rbrace>,-\<rbrakk>
    \<Longrightarrow> \<lbrace>case_option P P' v\<rbrace> f v \<lbrace>\<lambda>rv. case v of None \<Rightarrow> Q rv | Some x \<Rightarrow> Q' x rv\<rbrace>,-"
   by (cases v) auto
-
-lemma hoare_vcg_conj_liftE_R:
-  "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>P'\<rbrace>,-; \<lbrace>Q\<rbrace> f \<lbrace>Q'\<rbrace>,- \<rbrakk> \<Longrightarrow> \<lbrace>P and Q\<rbrace> f \<lbrace>\<lambda>rv s. P' rv s \<and> Q' rv s\<rbrace>, -"
-  apply (simp add: validE_R_def validE_def valid_def split: sum.splits)
-  apply blast
-  done
 
 lemma K_valid[wp]:
   "\<lbrace>K P\<rbrace> f \<lbrace>\<lambda>_. K P\<rbrace>"
@@ -133,18 +128,18 @@ lemma hoare_imp_eq_substR:
   by (fastforce simp add: valid_def validE_R_def validE_def split: sum.splits)
 
 lemma hoare_split_bind_case_sum:
-  assumes x: "\<And>rv. \<lbrace>R rv\<rbrace> g rv \<lbrace>Q\<rbrace>"
-             "\<And>rv. \<lbrace>S rv\<rbrace> h rv \<lbrace>Q\<rbrace>"
-  assumes y: "\<lbrace>P\<rbrace> f \<lbrace>S\<rbrace>,\<lbrace>R\<rbrace>"
+  assumes x: "\<And>rv. \<lbrace>E rv\<rbrace> g rv \<lbrace>Q\<rbrace>"
+             "\<And>rv. \<lbrace>Q' rv\<rbrace> h rv \<lbrace>Q\<rbrace>"
+  assumes y: "\<lbrace>P\<rbrace> f \<lbrace>Q'\<rbrace>,\<lbrace>E\<rbrace>"
   shows      "\<lbrace>P\<rbrace> f >>= case_sum g h \<lbrace>Q\<rbrace>"
   apply (rule bind_wp[OF _ y[unfolded validE_def]])
   apply (wpsimp wp: x split: sum.splits)
   done
 
 lemma hoare_split_bind_case_sumE:
-  assumes x: "\<And>rv. \<lbrace>R rv\<rbrace> g rv \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
-             "\<And>rv. \<lbrace>S rv\<rbrace> h rv \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
-  assumes y: "\<lbrace>P\<rbrace> f \<lbrace>S\<rbrace>,\<lbrace>R\<rbrace>"
+  assumes x: "\<And>rv. \<lbrace>E' rv\<rbrace> g rv \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
+             "\<And>rv. \<lbrace>Q' rv\<rbrace> h rv \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
+  assumes y: "\<lbrace>P\<rbrace> f \<lbrace>Q'\<rbrace>,\<lbrace>E'\<rbrace>"
   shows      "\<lbrace>P\<rbrace> f >>= case_sum g h \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
   apply (unfold validE_def)
   apply (rule bind_wp[OF _ y[unfolded validE_def]])
@@ -159,6 +154,7 @@ lemma throwErrorE_E [wp]:
   "\<lbrace>Q e\<rbrace> throwError e -, \<lbrace>Q\<rbrace>"
   by (simp add: validE_E_def) wp
 
+\<comment> \<open>FIXME: remove these inv rules?\<close>
 lemma gets_inv [simp]:
   "\<lbrace> P \<rbrace> gets f \<lbrace> \<lambda>r. P \<rbrace>"
   by (simp add: gets_def, wp)
@@ -169,11 +165,13 @@ lemma select_inv:
 
 lemmas return_inv = hoare_return_drop_var
 
-lemma assert_inv: "\<lbrace>P\<rbrace> assert Q \<lbrace>\<lambda>r. P\<rbrace>"
+lemma assert_inv:
+  "\<lbrace>P\<rbrace> assert Q \<lbrace>\<lambda>r. P\<rbrace>"
   unfolding assert_def
   by (cases Q) simp+
 
-lemma assert_opt_inv: "\<lbrace>P\<rbrace> assert_opt Q \<lbrace>\<lambda>r. P\<rbrace>"
+lemma assert_opt_inv:
+  "\<lbrace>P\<rbrace> assert_opt Q \<lbrace>\<lambda>r. P\<rbrace>"
   unfolding assert_opt_def
   by (cases Q) simp+
 
@@ -181,7 +179,7 @@ lemma case_options_weak_wp:
   "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>; \<And>x. \<lbrace>P'\<rbrace> g x \<lbrace>Q\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P and P'\<rbrace> case opt of None \<Rightarrow> f | Some x \<Rightarrow> g x \<lbrace>Q\<rbrace>"
   apply (cases opt)
    apply (clarsimp elim!: hoare_weaken_pre)
-  apply (rule hoare_weaken_pre [where Q=P'])
+  apply (rule hoare_weaken_pre[where P'=P'])
    apply simp+
   done
 
@@ -217,19 +215,19 @@ lemma list_cases_weak_wp:
 lemmas hoare_FalseE_R = hoare_FalseE[where E="\<top>\<top>", folded validE_R_def]
 
 lemma hoare_vcg_if_lift2:
-  "\<lbrace>R\<rbrace> f \<lbrace>\<lambda>rv s. (P rv s \<longrightarrow> X rv s) \<and> (\<not> P rv s \<longrightarrow> Y rv s)\<rbrace> \<Longrightarrow>
-   \<lbrace>R\<rbrace> f \<lbrace>\<lambda>rv s. if P rv s then X rv s else Y rv s\<rbrace>"
+  "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. (Q rv s \<longrightarrow> X rv s) \<and> (\<not> Q rv s \<longrightarrow> Y rv s)\<rbrace> \<Longrightarrow>
+   \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. if Q rv s then X rv s else Y rv s\<rbrace>"
 
-  "\<lbrace>R\<rbrace> f \<lbrace>\<lambda>rv s. (P' rv \<longrightarrow> X rv s) \<and> (\<not> P' rv \<longrightarrow> Y rv s)\<rbrace> \<Longrightarrow>
-   \<lbrace>R\<rbrace> f \<lbrace>\<lambda>rv. if P' rv then X rv else Y rv\<rbrace>"
+  "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. (Q' rv \<longrightarrow> X rv s) \<and> (\<not> Q' rv \<longrightarrow> Y rv s)\<rbrace> \<Longrightarrow>
+   \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv. if Q' rv then X rv else Y rv\<rbrace>"
   by (auto simp: valid_def split_def)
 
 lemma hoare_vcg_if_lift_ER: (* Required because of lack of rv in lifting rules *)
-  "\<lbrace>R\<rbrace> f \<lbrace>\<lambda>rv s. (P rv s \<longrightarrow> X rv s) \<and> (\<not> P rv s \<longrightarrow> Y rv s)\<rbrace>, - \<Longrightarrow>
-   \<lbrace>R\<rbrace> f \<lbrace>\<lambda>rv s. if P rv s then X rv s else Y rv s\<rbrace>, -"
+  "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. (Q rv s \<longrightarrow> X rv s) \<and> (\<not> Q rv s \<longrightarrow> Y rv s)\<rbrace>, - \<Longrightarrow>
+   \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. if Q rv s then X rv s else Y rv s\<rbrace>, -"
 
-  "\<lbrace>R\<rbrace> f \<lbrace>\<lambda>rv s. (P' rv \<longrightarrow> X rv s) \<and> (\<not> P' rv \<longrightarrow> Y rv s)\<rbrace>, - \<Longrightarrow>
-   \<lbrace>R\<rbrace> f \<lbrace>\<lambda>rv. if P' rv then X rv else Y rv\<rbrace>, -"
+  "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. (Q' rv \<longrightarrow> X rv s) \<and> (\<not> Q' rv \<longrightarrow> Y rv s)\<rbrace>, - \<Longrightarrow>
+   \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv. if Q' rv then X rv else Y rv\<rbrace>, -"
   by (auto simp: valid_def validE_R_def validE_def split_def)
 
 lemma hoare_list_all_lift:
@@ -365,8 +363,8 @@ lemma valid_return_unit:
   by (auto simp: valid_def in_bind in_return Ball_def)
 
 lemma hoare_weak_lift_imp_conj:
-  "\<lbrakk> \<lbrace>Q\<rbrace> m \<lbrace>Q'\<rbrace>; \<lbrace>R\<rbrace> m \<lbrace>R'\<rbrace> \<rbrakk>
-   \<Longrightarrow> \<lbrace>\<lambda>s. (P \<longrightarrow> Q s) \<and> R s\<rbrace> m \<lbrace>\<lambda>rv s. (P \<longrightarrow> Q' rv s) \<and> R' rv s\<rbrace>"
+  "\<lbrakk> \<lbrace>P'\<rbrace> m \<lbrace>Q'\<rbrace>; \<lbrace>P''\<rbrace> m \<lbrace>Q''\<rbrace> \<rbrakk>
+   \<Longrightarrow> \<lbrace>\<lambda>s. (P \<longrightarrow> P' s) \<and> P'' s\<rbrace> m \<lbrace>\<lambda>rv s. (P \<longrightarrow> Q' rv s) \<and> Q'' rv s\<rbrace>"
   apply (rule hoare_vcg_conj_lift)
    apply (rule hoare_weak_lift_imp)
    apply assumption+
@@ -378,7 +376,7 @@ lemma hoare_eq_P:
   by (rule assms)
 
 lemma hoare_validE_R_conj:
-  "\<lbrakk>\<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>, -; \<lbrace>P\<rbrace> f \<lbrace>R\<rbrace>, -\<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q and R\<rbrace>, -"
+  "\<lbrakk>\<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>, -; \<lbrace>P\<rbrace> f \<lbrace>Q'\<rbrace>, -\<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q and Q'\<rbrace>, -"
   by (simp add: valid_def validE_def validE_R_def Let_def split_def split: sum.splits)
 
 lemmas throwError_validE_R = throwError_wp [where E="\<top>\<top>", folded validE_R_def]
@@ -421,9 +419,9 @@ lemma hoare_Ball_helper:
 
 lemma handy_prop_divs:
   assumes x: "\<And>P. \<lbrace>\<lambda>s. P (Q s) \<and> S s\<rbrace> f \<lbrace>\<lambda>rv s. P (Q' rv s)\<rbrace>"
-             "\<And>P. \<lbrace>\<lambda>s. P (R s) \<and> S s\<rbrace> f \<lbrace>\<lambda>rv s. P (R' rv s)\<rbrace>"
-  shows      "\<lbrace>\<lambda>s. P (Q s \<and> R s) \<and> S s\<rbrace> f \<lbrace>\<lambda>rv s. P (Q' rv s \<and> R' rv s)\<rbrace>"
-             "\<lbrace>\<lambda>s. P (Q s \<or> R s) \<and> S s\<rbrace> f \<lbrace>\<lambda>rv s. P (Q' rv s \<or> R' rv s)\<rbrace>"
+             "\<And>P. \<lbrace>\<lambda>s. P (T s) \<and> S s\<rbrace> f \<lbrace>\<lambda>rv s. P (T' rv s)\<rbrace>"
+  shows      "\<lbrace>\<lambda>s. P (Q s \<and> T s) \<and> S s\<rbrace> f \<lbrace>\<lambda>rv s. P (Q' rv s \<and> T' rv s)\<rbrace>"
+             "\<lbrace>\<lambda>s. P (Q s \<or> T s) \<and> S s\<rbrace> f \<lbrace>\<lambda>rv s. P (Q' rv s \<or> T' rv s)\<rbrace>"
    apply (clarsimp simp: valid_def
                   elim!: subst[rotated, where P=P])
    apply (rule use_valid [OF _ x(1)], assumption)
@@ -517,36 +515,26 @@ lemma weaker_hoare_ifE:
 lemma wp_split_const_if:
   assumes x: "\<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>"
   assumes y: "\<lbrace>P'\<rbrace> f \<lbrace>Q'\<rbrace>"
-  shows "\<lbrace>\<lambda>s. (G \<longrightarrow> P s) \<and> (\<not> G \<longrightarrow> P' s)\<rbrace> f \<lbrace>\<lambda>rv s. (G \<longrightarrow> Q rv s) \<and> (\<not> G \<longrightarrow> Q' rv s)\<rbrace>"
-  by (cases G; simp add: x y)
+  shows "\<lbrace>\<lambda>s. (S \<longrightarrow> P s) \<and> (\<not> S \<longrightarrow> P' s)\<rbrace> f \<lbrace>\<lambda>rv s. (S \<longrightarrow> Q rv s) \<and> (\<not> S \<longrightarrow> Q' rv s)\<rbrace>"
+  by (cases S; simp add: x y)
 
 lemma wp_split_const_if_R:
   assumes x: "\<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,-"
   assumes y: "\<lbrace>P'\<rbrace> f \<lbrace>Q'\<rbrace>,-"
-  shows "\<lbrace>\<lambda>s. (G \<longrightarrow> P s) \<and> (\<not> G \<longrightarrow> P' s)\<rbrace> f \<lbrace>\<lambda>rv s. (G \<longrightarrow> Q rv s) \<and> (\<not> G \<longrightarrow> Q' rv s)\<rbrace>,-"
-  by (cases G; simp add: x y)
+  shows "\<lbrace>\<lambda>s. (S \<longrightarrow> P s) \<and> (\<not> S \<longrightarrow> P' s)\<rbrace> f \<lbrace>\<lambda>rv s. (S \<longrightarrow> Q rv s) \<and> (\<not> S \<longrightarrow> Q' rv s)\<rbrace>,-"
+  by (cases S; simp add: x y)
 
 lemma hoare_disj_division:
-  "\<lbrakk> P \<or> Q; P \<Longrightarrow> \<lbrace>R\<rbrace> f \<lbrace>S\<rbrace>; Q \<Longrightarrow> \<lbrace>T\<rbrace> f \<lbrace>S\<rbrace> \<rbrakk>
-   \<Longrightarrow> \<lbrace>\<lambda>s. (P \<longrightarrow> R s) \<and> (Q \<longrightarrow> T s)\<rbrace> f \<lbrace>S\<rbrace>"
-  apply safe
-   apply (rule hoare_pre_imp)
-    prefer 2
-    apply simp
-   apply simp
-  apply (rule hoare_pre_imp)
-   prefer 2
-   apply simp
-  apply simp
-  done
+  "\<lbrakk> P \<or> P'; P \<Longrightarrow> \<lbrace>S\<rbrace> f \<lbrace>Q\<rbrace>; P' \<Longrightarrow> \<lbrace>T\<rbrace> f \<lbrace>Q\<rbrace> \<rbrakk>
+   \<Longrightarrow> \<lbrace>\<lambda>s. (P \<longrightarrow> S s) \<and> (P' \<longrightarrow> T s)\<rbrace> f \<lbrace>Q\<rbrace>"
+  by (fastforce intro: hoare_weaken_pre)
 
 lemma hoare_grab_asm:
-  "\<lbrakk> G \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s. G \<and> P s\<rbrace> f \<lbrace>Q\<rbrace>"
-  by (cases G, simp+)
+  "\<lbrakk> P' \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s. P' \<and> P s\<rbrace> f \<lbrace>Q\<rbrace>"
+  by (cases P', simp+)
 
 lemma hoare_grab_asm2:
-  "\<lbrakk>P' \<Longrightarrow> \<lbrace>\<lambda>s. P s \<and> R s\<rbrace> f \<lbrace>Q\<rbrace>\<rbrakk>
-   \<Longrightarrow> \<lbrace>\<lambda>s. P s \<and> P' \<and> R s\<rbrace> f \<lbrace>Q\<rbrace>"
+  "\<lbrakk>P' \<Longrightarrow> \<lbrace>\<lambda>s. P s \<and> P'' s\<rbrace> f \<lbrace>Q\<rbrace>\<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s. P s \<and> P' \<and> P'' s\<rbrace> f \<lbrace>Q\<rbrace>"
   by (fastforce simp: valid_def)
 
 lemma hoare_grab_exs:
@@ -559,15 +547,6 @@ lemma hoare_grab_exs:
 lemma hoare_prop_E: "\<lbrace>\<lambda>rv. P\<rbrace> f -,\<lbrace>\<lambda>rv s. P\<rbrace>"
   unfolding validE_E_def
   by (rule hoare_pre, wp, simp)
-
-lemma hoare_vcg_conj_lift_R:
-  "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,-; \<lbrace>R\<rbrace> f \<lbrace>S\<rbrace>,- \<rbrakk>
-   \<Longrightarrow> \<lbrace>\<lambda>s. P s \<and> R s\<rbrace> f \<lbrace>\<lambda>rv s. Q rv s \<and> S rv s\<rbrace>,-"
-  apply (simp add: validE_R_def validE_def)
-  apply (drule(1) hoare_vcg_conj_lift)
-  apply (erule hoare_strengthen_post)
-  apply (clarsimp split: sum.splits)
-  done
 
 lemma hoare_walk_assmsE:
   assumes x: "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv. P\<rbrace>" and y: "\<And>s. P s \<Longrightarrow> Q s" and z: "\<lbrace>P\<rbrace> g \<lbrace>\<lambda>rv. Q\<rbrace>"
@@ -622,8 +601,8 @@ lemma weak_if_wp':
   by (auto simp add: valid_def split_def)
 
 lemma bindE_split_recursive_asm:
-  assumes x: "\<And>x s'. \<lbrakk> (Inr x, s') \<in> fst (f s) \<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s. B x s \<and> s = s'\<rbrace> g x \<lbrace>C\<rbrace>, \<lbrace>E\<rbrace>"
-  shows      "\<lbrace>A\<rbrace> f \<lbrace>B\<rbrace>, \<lbrace>E\<rbrace> \<Longrightarrow> \<lbrace>\<lambda>st. A st \<and> st = s\<rbrace> f >>=E g \<lbrace>C\<rbrace>, \<lbrace>E\<rbrace>"
+  assumes x: "\<And>x s'. \<lbrakk> (Inr x, s') \<in> fst (f s) \<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s. Q' x s \<and> s = s'\<rbrace> g x \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
+  shows      "\<lbrace>P\<rbrace> f \<lbrace>Q'\<rbrace>, \<lbrace>E\<rbrace> \<Longrightarrow> \<lbrace>\<lambda>st. P st \<and> st = s\<rbrace> f >>=E g \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
   apply (clarsimp simp: validE_def valid_def bindE_def in_bind lift_def)
   apply (erule allE, erule(1) impE)
   apply (drule(1) bspec, simp)
@@ -708,7 +687,7 @@ lemma valid_pre_satisfies_post:
   by (clarsimp simp: valid_def)
 
 lemma validE_pre_satisfies_post:
-  "\<lbrakk> \<And>s r' s'. P s \<Longrightarrow> Q r' s'; \<And>s r' s'. P s \<Longrightarrow> R r' s' \<rbrakk> \<Longrightarrow> \<lbrace> P \<rbrace> m \<lbrace> Q \<rbrace>,\<lbrace> R \<rbrace>"
+  "\<lbrakk> \<And>s r' s'. P s \<Longrightarrow> Q r' s'; \<And>s r' s'. P s \<Longrightarrow> E r' s' \<rbrakk> \<Longrightarrow> \<lbrace> P \<rbrace> m \<lbrace> Q \<rbrace>,\<lbrace> E \<rbrace>"
   by (clarsimp simp: validE_def2 split: sum.splits)
 
 lemma hoare_validE_R_conjI:
@@ -720,11 +699,11 @@ lemma hoare_validE_E_conjI:
   by (clarsimp simp: Ball_def validE_E_def validE_def valid_def split: sum.splits)
 
 lemma validE_R_post_conjD1:
-  "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>r s. Q r s \<and> R r s\<rbrace>,- \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,-"
+  "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>r s. Q r s \<and> Q' r s\<rbrace>,- \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,-"
   by (fastforce simp: validE_R_def validE_def valid_def split: sum.splits)
 
 lemma validE_R_post_conjD2:
-  "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>r s. Q r s \<and> R r s\<rbrace>,- \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>R\<rbrace>,-"
+  "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>r s. Q r s \<and> Q' r s\<rbrace>,- \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q'\<rbrace>,-"
   by (fastforce simp: validE_R_def validE_def valid_def split: sum.splits)
 
 lemma throw_opt_wp[wp]:
@@ -735,10 +714,12 @@ lemma hoare_name_pre_state2:
   "(\<And>s. \<lbrace>P and ((=) s)\<rbrace> f \<lbrace>Q\<rbrace>) \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>"
   by (auto simp: valid_def intro: hoare_name_pre_state)
 
-lemma returnOk_E': "\<lbrace>P\<rbrace> returnOk r -,\<lbrace>E\<rbrace>"
+lemma returnOk_E':
+  "\<lbrace>P\<rbrace> returnOk r -,\<lbrace>E\<rbrace>"
   by wpsimp
 
-lemma throwError_R': "\<lbrace>P\<rbrace> throwError e \<lbrace>Q\<rbrace>,-"
+lemma throwError_R':
+  "\<lbrace>P\<rbrace> throwError e \<lbrace>Q\<rbrace>,-"
   by wpsimp
 
 end

--- a/lib/Monads/nondet/Nondet_More_VCG.thy
+++ b/lib/Monads/nondet/Nondet_More_VCG.thy
@@ -154,7 +154,6 @@ lemma throwErrorE_E [wp]:
   "\<lbrace>Q e\<rbrace> throwError e -, \<lbrace>Q\<rbrace>"
   by (simp add: validE_E_def) wp
 
-\<comment> \<open>FIXME: remove these inv rules?\<close>
 lemma gets_inv [simp]:
   "\<lbrace> P \<rbrace> gets f \<lbrace> \<lambda>r. P \<rbrace>"
   by (simp add: gets_def, wp)
@@ -162,8 +161,6 @@ lemma gets_inv [simp]:
 lemma select_inv:
   "\<lbrace> P \<rbrace> select S \<lbrace> \<lambda>r. P \<rbrace>"
   by wpsimp
-
-lemmas return_inv = hoare_return_drop_var
 
 lemma assert_inv:
   "\<lbrace>P\<rbrace> assert Q \<lbrace>\<lambda>r. P\<rbrace>"

--- a/lib/Monads/nondet/Nondet_VCG.thy
+++ b/lib/Monads/nondet/Nondet_VCG.thy
@@ -91,13 +91,13 @@ lemma validE_make_schematic_post:
 section \<open>Pre Lemmas\<close>
 
 lemma hoare_pre_imp:
-  "\<lbrakk> \<And>s. P s \<Longrightarrow> Q s; \<lbrace>Q\<rbrace> a \<lbrace>R\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> a \<lbrace>R\<rbrace>"
+  "\<lbrakk> \<And>s. P s \<Longrightarrow> P' s; \<lbrace>P'\<rbrace> f \<lbrace>Q\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>"
   by (fastforce simp: valid_def)
 
 lemmas hoare_weaken_pre = hoare_pre_imp[rotated]
 
 lemma hoare_weaken_preE:
-  "\<lbrakk> \<lbrace>Q\<rbrace> f \<lbrace>R\<rbrace>,\<lbrace>E\<rbrace>; \<And>s. P s \<Longrightarrow> Q s \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>R\<rbrace>,\<lbrace>E\<rbrace>"
+  "\<lbrakk> \<lbrace>P'\<rbrace> f \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>; \<And>s. P s \<Longrightarrow> P' s \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
   by (fastforce simp: validE_def2)
 
 lemma hoare_weaken_preE_R:
@@ -202,11 +202,11 @@ lemmas wp_post_tautE_E = hoareE_E_TrueI[where P=\<top>]
 lemmas wp_post_tauts[intro] = wp_post_taut wp_post_tautE wp_post_tautE_R wp_post_tautE_E
 
 lemma hoare_post_conj[intro]:
-  "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>; \<lbrace>P\<rbrace> f \<lbrace>R\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q and R\<rbrace>"
+  "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>; \<lbrace>P\<rbrace> f \<lbrace>Q'\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q and Q'\<rbrace>"
   by (fastforce simp: valid_def)
 
 lemma hoare_pre_disj[intro]:
-  "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>R\<rbrace>; \<lbrace>Q\<rbrace> f \<lbrace>R\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P or Q\<rbrace> f \<lbrace>R\<rbrace>"
+  "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>; \<lbrace>P'\<rbrace> f \<lbrace>Q\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P or P'\<rbrace> f \<lbrace>Q\<rbrace>"
   by (simp add:valid_def pred_disj_def)
 
 lemma hoare_conj:
@@ -218,7 +218,7 @@ lemma hoare_pre_cont[simp]:
   by (simp add:valid_def)
 
 lemma hoare_FalseE[simp]:
-  "\<lbrace>\<bottom>\<rbrace> f \<lbrace>Q\<rbrace>, \<lbrace>E\<rbrace>"
+  "\<lbrace>\<bottom>\<rbrace> f \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
   by (simp add: valid_def validE_def)
 
 \<comment> \<open>FIXME: remove?\<close>
@@ -238,26 +238,25 @@ lemma hoare_modifyE_var:
 
 \<comment> \<open>FIXME: remove?\<close>
 lemma hoare_if:
-  "\<lbrakk> P \<Longrightarrow> \<lbrace>Q\<rbrace> a \<lbrace>R\<rbrace>; \<not> P \<Longrightarrow> \<lbrace>Q\<rbrace> b \<lbrace>R\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>Q\<rbrace> if P then a else b \<lbrace>R\<rbrace>"
+  "\<lbrakk> P' \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>; \<not> P' \<Longrightarrow> \<lbrace>P\<rbrace> g \<lbrace>Q\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> if P' then f else g \<lbrace>Q\<rbrace>"
   by (simp add: valid_def)
 
 \<comment> \<open>FIXME: remove?\<close>
 lemma hoare_pre_subst:
-  "\<lbrakk> A = B; \<lbrace>A\<rbrace> a \<lbrace>C\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>B\<rbrace> a \<lbrace>C\<rbrace>"
+  "\<lbrakk> P = P'; \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P'\<rbrace> f \<lbrace>Q\<rbrace>"
   by (erule subst)
 
 \<comment> \<open>FIXME: remove?\<close>
 lemma hoare_post_subst:
-  "\<lbrakk> B = C; \<lbrace>A\<rbrace> a \<lbrace>B\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>A\<rbrace> a \<lbrace>C\<rbrace>"
+  "\<lbrakk> Q = Q'; \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q'\<rbrace>"
   by (erule subst)
 
-\<comment> \<open>FIXME: change R to Q and Q to Q'\<close>
 lemma hoare_post_imp:
-  "\<lbrakk> \<And>rv s. Q rv s \<Longrightarrow> R rv s; \<lbrace>P\<rbrace> a \<lbrace>Q\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> a \<lbrace>R\<rbrace>"
-  by(fastforce simp:valid_def split_def)
+  "\<lbrakk> \<And>rv s. Q' rv s \<Longrightarrow> Q rv s; \<lbrace>P\<rbrace> f \<lbrace>Q'\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>"
+  by(fastforce simp: valid_def split_def)
 
 lemma hoare_post_impE:
-  "\<lbrakk> \<And>rv s. Q rv s \<Longrightarrow> R rv s; \<And>e s. E e s \<Longrightarrow> F e s; \<lbrace>P\<rbrace> a \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> a \<lbrace>R\<rbrace>,\<lbrace>F\<rbrace>"
+  "\<lbrakk> \<And>rv s. Q' rv s \<Longrightarrow> Q rv s; \<And>e s. E' e s \<Longrightarrow> E e s; \<lbrace>P\<rbrace> f \<lbrace>Q'\<rbrace>,\<lbrace>E'\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
   by(fastforce simp: validE_def2 split: sum.splits)
 
 lemmas hoare_strengthen_post = hoare_post_imp[rotated]
@@ -269,48 +268,48 @@ lemma hoare_strengthen_postE_R:
   by (erule hoare_post_impE)
 
 lemma hoare_strengthen_postE_E:
-  "\<lbrakk> \<lbrace>P\<rbrace> f -,\<lbrace>Q'\<rbrace>; \<And>rv s. Q' rv s \<Longrightarrow> Q rv s \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f -,\<lbrace>Q\<rbrace>"
+  "\<lbrakk> \<lbrace>P\<rbrace> f -,\<lbrace>E'\<rbrace>; \<And>rv s. E' rv s \<Longrightarrow> E rv s \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f -,\<lbrace>E\<rbrace>"
   unfolding validE_E_def
   by (rule hoare_post_impE)
 
 lemma hoare_validE_cases:
-  "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>, \<lbrace>\<lambda>_ _. True\<rbrace>; \<lbrace>P\<rbrace> f \<lbrace>\<lambda>_ _. True\<rbrace>, \<lbrace>R\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>, \<lbrace>R\<rbrace>"
+  "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,\<lbrace>\<lambda>_ _. True\<rbrace>; \<lbrace>P\<rbrace> f \<lbrace>\<lambda>_ _. True\<rbrace>,\<lbrace>E\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
   by (fastforce simp: validE_def valid_def split: sum.splits)
 
-lemma hoare_post_imp_dc:
-  "\<lbrakk>\<lbrace>P\<rbrace> a \<lbrace>\<lambda>_. Q\<rbrace>; \<And>s. Q s \<Longrightarrow> R s\<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> a \<lbrace>\<lambda>_. R\<rbrace>, \<lbrace>\<lambda>_. R\<rbrace>"
+lemma hoare_post_impE_dc:
+  "\<lbrakk>\<lbrace>P\<rbrace> f \<lbrace>\<lambda>_. Q'\<rbrace>; \<And>s. Q' s \<Longrightarrow> Q s\<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>_. Q\<rbrace>, \<lbrace>\<lambda>_. Q\<rbrace>"
   by (fastforce simp: validE_def valid_def split: sum.splits)
 
-lemma hoare_post_imp_dc2:
-  "\<lbrakk>\<lbrace>P\<rbrace> a \<lbrace>\<lambda>_. Q\<rbrace>; \<And>s. Q s \<Longrightarrow> R s\<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> a \<lbrace>\<lambda>_. R\<rbrace>, \<lbrace>\<lambda>_. \<top>\<rbrace>"
+lemma hoare_post_impE_R_dc:
+  "\<lbrakk>\<lbrace>P\<rbrace> f \<lbrace>\<lambda>_. Q'\<rbrace>; \<And>s. Q' s \<Longrightarrow> Q s\<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>_. Q\<rbrace>, \<lbrace>\<lambda>_. \<top>\<rbrace>"
   by (fastforce simp: validE_def valid_def split: sum.splits)
 
-lemma hoare_post_imp_dc2E:
-  "\<lbrakk>\<lbrace>P\<rbrace> a \<lbrace>\<lambda>_. Q\<rbrace>; \<And>s. Q s \<Longrightarrow> R s\<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> a \<lbrace>\<lambda>_. \<top>\<rbrace>, \<lbrace>\<lambda>_. R\<rbrace>"
+lemma hoare_post_impE_E_dc:
+  "\<lbrakk>\<lbrace>P\<rbrace> f \<lbrace>\<lambda>_. Q'\<rbrace>; \<And>s. Q' s \<Longrightarrow> Q s\<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>_. \<top>\<rbrace>, \<lbrace>\<lambda>_. Q\<rbrace>"
   by (fastforce simp: validE_def valid_def split: sum.splits)
 
-lemma hoare_post_imp_dc2_actual:
-  "\<lbrace>P\<rbrace> a \<lbrace>\<lambda>_. R\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace> a \<lbrace>\<lambda>_. R\<rbrace>, \<lbrace>\<lambda>_. \<top>\<rbrace>"
-  by (rule hoare_post_imp_dc2)
+lemma hoare_post_impE_R_dc_actual:
+  "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>_. Q\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>_. Q\<rbrace>, \<lbrace>\<lambda>_. \<top>\<rbrace>"
+  by (rule hoare_post_impE_R_dc)
 
-lemma hoare_post_imp_dc2E_actual:
-  "\<lbrace>P\<rbrace> a \<lbrace>\<lambda>_. R\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace> a \<lbrace>\<lambda>_. \<top>\<rbrace>, \<lbrace>\<lambda>_. R\<rbrace>"
-  by (rule hoare_post_imp_dc2E)
+lemma hoare_post_impE_E_dc_actual:
+  "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>_. Q\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>_. \<top>\<rbrace>, \<lbrace>\<lambda>_. Q\<rbrace>"
+  by (rule hoare_post_impE_E_dc)
 
 lemma hoare_conjD1:
-  "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv. Q rv and R rv\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv. Q rv\<rbrace>"
+  "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv. Q rv and Q' rv\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv. Q rv\<rbrace>"
   unfolding valid_def by auto
 
 lemma hoare_conjD2:
-  "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv. Q rv and R rv\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv. R rv\<rbrace>"
+  "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv. Q rv and Q' rv\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv. Q' rv\<rbrace>"
   unfolding valid_def by auto
 
 lemma hoare_post_disjI1:
-  "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv. Q rv\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv. Q rv or R rv\<rbrace>"
+  "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv. Q rv\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv. Q rv or Q' rv\<rbrace>"
   unfolding valid_def by auto
 
 lemma hoare_post_disjI2:
-  "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv. R rv\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv. Q rv or R rv\<rbrace>"
+  "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv. Q' rv\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv. Q rv or Q' rv\<rbrace>"
   unfolding valid_def by auto
 
 lemma use_valid:
@@ -326,11 +325,11 @@ lemma use_valid_inv:
   using use_valid[where f=f, OF step pres[where N="\<lambda>p. p = P s"]] by simp
 
 lemma use_validE_norm:
-  "\<lbrakk> (Inr r', s') \<in> fst (B s); \<lbrace> P \<rbrace> B \<lbrace> Q \<rbrace>,\<lbrace> E \<rbrace>; P s \<rbrakk> \<Longrightarrow> Q r' s'"
+  "\<lbrakk> (Inr r', s') \<in> fst (f s); \<lbrace> P \<rbrace> f \<lbrace> Q \<rbrace>,\<lbrace> E \<rbrace>; P s \<rbrakk> \<Longrightarrow> Q r' s'"
   unfolding validE_def valid_def by force
 
 lemma use_validE_except:
-  "\<lbrakk> (Inl r', s') \<in> fst (B s); \<lbrace> P \<rbrace> B \<lbrace> Q \<rbrace>,\<lbrace> E \<rbrace>; P s \<rbrakk> \<Longrightarrow> E r' s'"
+  "\<lbrakk> (Inl r', s') \<in> fst (f s); \<lbrace> P \<rbrace> f \<lbrace> Q \<rbrace>,\<lbrace> E \<rbrace>; P s \<rbrakk> \<Longrightarrow> E r' s'"
   unfolding validE_def valid_def by force
 
 lemma in_inv_by_hoareD:
@@ -353,23 +352,23 @@ lemma hoare_gen_asm_lk:
 \<comment> \<open>Useful for forward reasoning, when P is known.
     The first version allows weakening the precondition.\<close>
 lemma hoare_gen_asm_spec':
-  "\<lbrakk> \<And>s. P s \<Longrightarrow> S \<and> R s; S \<Longrightarrow> \<lbrace>R\<rbrace> f \<lbrace>Q\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>"
+  "\<lbrakk> \<And>s. P s \<Longrightarrow> S \<and> P' s; S \<Longrightarrow> \<lbrace>P'\<rbrace> f \<lbrace>Q\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>"
   by (fastforce simp: valid_def)
 
 lemma hoare_gen_asm_spec:
   "\<lbrakk> \<And>s. P s \<Longrightarrow> S; S \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>"
-  by (rule hoare_gen_asm_spec'[where S=S and R=P]) simp
+  by (rule hoare_gen_asm_spec'[where S=S and P'=P]) simp
 
 lemma hoare_conjI:
-  "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>; \<lbrace>P\<rbrace> f \<lbrace>R\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>r s. Q r s \<and> R r s\<rbrace>"
+  "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>; \<lbrace>P\<rbrace> f \<lbrace>Q'\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>r s. Q r s \<and> Q' r s\<rbrace>"
   unfolding valid_def by blast
 
 lemma hoare_disjI1:
-  "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. Q rv s \<or> R rv s \<rbrace>"
+  "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. Q rv s \<or> Q' rv s \<rbrace>"
   unfolding valid_def by blast
 
 lemma hoare_disjI2:
-  "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>R\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. Q rv s \<or> R rv s \<rbrace>"
+  "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>Q'\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. Q rv s \<or> Q' rv s \<rbrace>"
   unfolding valid_def by blast
 
 lemma hoare_assume_pre:
@@ -377,7 +376,7 @@ lemma hoare_assume_pre:
   by (auto simp: valid_def)
 
 lemma hoare_assume_preE:
-  "(\<And>s. P s \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,\<lbrace>R\<rbrace>) \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,\<lbrace>R\<rbrace>"
+  "(\<And>s. P s \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>) \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
   by (auto simp: valid_def validE_def)
 
 lemma hoare_allI:
@@ -393,7 +392,7 @@ lemma hoare_exI:
   by (simp add: valid_def) blast
 
 lemma hoare_impI:
-  "(R \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>) \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. R \<longrightarrow> Q rv s\<rbrace>"
+  "(P' \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>) \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. P' \<longrightarrow> Q rv s\<rbrace>"
   by (simp add: valid_def) blast
 
 lemma validE_impI:
@@ -425,7 +424,7 @@ subsection \<open>@{const valid} and @{const validE}, @{const validE_R}, @{const
 
 lemma valid_validE:
   "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>_. Q\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>_. Q\<rbrace>, \<lbrace>\<lambda>_. Q\<rbrace>"
-  by (rule hoare_post_imp_dc)
+  by (rule hoare_post_impE_dc)
 
 lemma valid_validE2:
   "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>_. Q'\<rbrace>; \<And>s. Q' s \<Longrightarrow> Q s; \<And>s. Q' s \<Longrightarrow> E s \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>_. Q\<rbrace>, \<lbrace>\<lambda>_. E\<rbrace>"
@@ -486,33 +485,33 @@ lemma liftE_validE[simp]:
 subsection \<open>Operator lifting/splitting\<close>
 
 lemma hoare_vcg_if_split:
-  "\<lbrakk> P \<Longrightarrow> \<lbrace>Q\<rbrace> f \<lbrace>S\<rbrace>; \<not>P \<Longrightarrow> \<lbrace>R\<rbrace> g \<lbrace>S\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s. (P \<longrightarrow> Q s) \<and> (\<not>P \<longrightarrow> R s)\<rbrace> if P then f else g \<lbrace>S\<rbrace>"
+  "\<lbrakk> P \<Longrightarrow> \<lbrace>P'\<rbrace> f \<lbrace>Q\<rbrace>; \<not>P \<Longrightarrow> \<lbrace>P''\<rbrace> g \<lbrace>Q\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s. (P \<longrightarrow> P' s) \<and> (\<not>P \<longrightarrow> P'' s)\<rbrace> if P then f else g \<lbrace>Q\<rbrace>"
   by simp
 
 lemma hoare_vcg_if_splitE:
-  "\<lbrakk> P \<Longrightarrow> \<lbrace>Q\<rbrace> f \<lbrace>S\<rbrace>,\<lbrace>E\<rbrace>; \<not>P \<Longrightarrow> \<lbrace>R\<rbrace> g \<lbrace>S\<rbrace>,\<lbrace>E\<rbrace> \<rbrakk> \<Longrightarrow>
-   \<lbrace>\<lambda>s. (P \<longrightarrow> Q s) \<and> (\<not>P \<longrightarrow> R s)\<rbrace> if P then f else g \<lbrace>S\<rbrace>,\<lbrace>E\<rbrace>"
+  "\<lbrakk> P \<Longrightarrow> \<lbrace>P'\<rbrace> f \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>; \<not>P \<Longrightarrow> \<lbrace>P''\<rbrace> g \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace> \<rbrakk> \<Longrightarrow>
+   \<lbrace>\<lambda>s. (P \<longrightarrow> P' s) \<and> (\<not>P \<longrightarrow> P'' s)\<rbrace> if P then f else g \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
   by simp
 
 lemma hoare_vcg_split_case_option:
-  "\<lbrakk> \<And>x. x = None \<Longrightarrow> \<lbrace>P x\<rbrace> f x \<lbrace>R x\<rbrace>; \<And>x y. x = Some y \<Longrightarrow> \<lbrace>Q x y\<rbrace> g x y \<lbrace>R x\<rbrace> \<rbrakk>
-   \<Longrightarrow> \<lbrace>\<lambda>s. (x = None \<longrightarrow> P x s) \<and> (\<forall>y. x = Some y \<longrightarrow> Q x y s)\<rbrace>
+  "\<lbrakk> \<And>x. x = None \<Longrightarrow> \<lbrace>P x\<rbrace> f x \<lbrace>Q x\<rbrace>; \<And>x y. x = Some y \<Longrightarrow> \<lbrace>P' x y\<rbrace> g x y \<lbrace>Q x\<rbrace> \<rbrakk>
+   \<Longrightarrow> \<lbrace>\<lambda>s. (x = None \<longrightarrow> P x s) \<and> (\<forall>y. x = Some y \<longrightarrow> P' x y s)\<rbrace>
        case x of None \<Rightarrow> f x | Some y \<Rightarrow> g x y
-       \<lbrace>R x\<rbrace>"
+       \<lbrace>Q x\<rbrace>"
   by (cases x; simp)
 
 lemma hoare_vcg_split_case_optionE:
-  "\<lbrakk> \<And>x. x = None \<Longrightarrow> \<lbrace>P x\<rbrace> f x \<lbrace>R x\<rbrace>,\<lbrace>E x\<rbrace>; \<And>x y. x = Some y \<Longrightarrow> \<lbrace>Q x y\<rbrace> g x y \<lbrace>R x\<rbrace>,\<lbrace>E x\<rbrace> \<rbrakk>
-   \<Longrightarrow> \<lbrace>\<lambda>s. (x = None \<longrightarrow> P x s) \<and> (\<forall>y. x = Some y \<longrightarrow> Q x y s)\<rbrace>
+  "\<lbrakk> \<And>x. x = None \<Longrightarrow> \<lbrace>P x\<rbrace> f x \<lbrace>Q x\<rbrace>,\<lbrace>E x\<rbrace>; \<And>x y. x = Some y \<Longrightarrow> \<lbrace>P' x y\<rbrace> g x y \<lbrace>Q x\<rbrace>,\<lbrace>E x\<rbrace> \<rbrakk>
+   \<Longrightarrow> \<lbrace>\<lambda>s. (x = None \<longrightarrow> P x s) \<and> (\<forall>y. x = Some y \<longrightarrow> P' x y s)\<rbrace>
        case x of None \<Rightarrow> f x | Some y \<Rightarrow> g x y
-       \<lbrace>R x\<rbrace>, \<lbrace>E x\<rbrace>"
+       \<lbrace>Q x\<rbrace>, \<lbrace>E x\<rbrace>"
   by (cases x; simp)
 
 lemma hoare_vcg_split_case_sum:
-  "\<lbrakk> \<And>x a. x = Inl a \<Longrightarrow> \<lbrace>P x a\<rbrace> f x a \<lbrace>R x\<rbrace>; \<And>x b. x = Inr b \<Longrightarrow> \<lbrace>Q x b\<rbrace> g x b \<lbrace>R x\<rbrace> \<rbrakk>
-   \<Longrightarrow> \<lbrace>\<lambda>s. (\<forall>a. x = Inl a \<longrightarrow> P x a s) \<and> (\<forall>b. x = Inr b \<longrightarrow> Q x b s)\<rbrace>
+  "\<lbrakk> \<And>x a. x = Inl a \<Longrightarrow> \<lbrace>P x a\<rbrace> f x a \<lbrace>Q x\<rbrace>; \<And>x b. x = Inr b \<Longrightarrow> \<lbrace>P' x b\<rbrace> g x b \<lbrace>Q x\<rbrace> \<rbrakk>
+   \<Longrightarrow> \<lbrace>\<lambda>s. (\<forall>a. x = Inl a \<longrightarrow> P x a s) \<and> (\<forall>b. x = Inr b \<longrightarrow> P' x b s)\<rbrace>
        case x of Inl a \<Rightarrow> f x a | Inr b \<Rightarrow> g x b
-       \<lbrace>R x\<rbrace>"
+       \<lbrace>Q x\<rbrace>"
   by (cases x; simp)
 
 lemma bind_wp_nobind:
@@ -526,7 +525,7 @@ lemma bindE_wp_nobind:
 lemmas bind_wp_skip = bind_wp[where Q=Q and Q'=Q for Q]
 
 lemma hoare_chain:
-  "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>; \<And>s. R s \<Longrightarrow> P s; \<And>rv s. Q rv s \<Longrightarrow> S rv s \<rbrakk> \<Longrightarrow> \<lbrace>R\<rbrace> f \<lbrace>S\<rbrace>"
+  "\<lbrakk> \<lbrace>P'\<rbrace> f \<lbrace>Q'\<rbrace>; \<And>s. P s \<Longrightarrow> P' s; \<And>rv s. Q' rv s \<Longrightarrow> Q rv s \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>"
   by (wp_pre, rule hoare_post_imp)
 
 lemma hoare_chainE:
@@ -540,7 +539,7 @@ lemma hoare_vcg_conj_lift:
   by fastforce
 
 \<comment> \<open>A variant which works nicely with subgoals that do not contain schematics\<close>
-lemmas hoare_vcg_conj_lift_pre_fix = hoare_vcg_conj_lift[where P=R and P'=R for R, simplified]
+lemmas hoare_vcg_conj_lift_pre_fix = hoare_vcg_conj_lift[where P=P and P'=P for P, simplified]
 
 lemma hoare_vcg_conj_liftE1:
   "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,-; \<lbrace>P'\<rbrace> f \<lbrace>Q'\<rbrace>,\<lbrace>E\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P and P'\<rbrace> f \<lbrace>\<lambda>rv s. Q rv s \<and> Q' rv s\<rbrace>,\<lbrace>E\<rbrace>"
@@ -581,13 +580,13 @@ lemma hoare_vcg_const_Ball_liftE:
   "\<lbrakk> \<And>x. x \<in> S \<Longrightarrow> \<lbrace>P x\<rbrace> f \<lbrace>Q x\<rbrace>,\<lbrace>E\<rbrace>; \<lbrace>\<lambda>s. True\<rbrace> f \<lbrace>\<lambda>r s. True\<rbrace>, \<lbrace>E\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s. \<forall>x\<in>S. P x s\<rbrace> f \<lbrace>\<lambda>rv s. \<forall>x\<in>S. Q x rv s\<rbrace>,\<lbrace>E\<rbrace>"
   by (fastforce simp: validE_def valid_def split: sum.splits)
 
-lemma hoare_vcg_const_Ball_lift_R:
+lemma hoare_vcg_const_Ball_liftE_R:
  "\<lbrakk> \<And>x. x \<in> S \<Longrightarrow> \<lbrace>P x\<rbrace> f \<lbrace>Q x\<rbrace>,- \<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s. \<forall>x \<in> S. P x s\<rbrace> f \<lbrace>\<lambda>rv s. \<forall>x \<in> S. Q x rv s\<rbrace>,-"
   unfolding validE_R_def validE_def
   by (rule hoare_strengthen_post)
      (fastforce intro!: hoare_vcg_const_Ball_lift split: sum.splits)+
 
-lemma hoare_vcg_const_Ball_lift_E_E:
+lemma hoare_vcg_const_Ball_liftE_E:
  "(\<And>x. x \<in> S \<Longrightarrow> \<lbrace>P x\<rbrace> f -,\<lbrace>Q x\<rbrace>) \<Longrightarrow> \<lbrace>\<lambda>s. \<forall>x \<in> S. P x s\<rbrace> f -,\<lbrace>\<lambda>rv s. \<forall>x \<in> S. Q x rv s\<rbrace>"
   unfolding validE_E_def validE_def valid_def
   by (fastforce split: sum.splits)
@@ -602,11 +601,11 @@ lemma hoare_vcg_all_liftE:
 
 lemma hoare_vcg_all_liftE_R:
   "(\<And>x. \<lbrace>P x\<rbrace> f \<lbrace>Q x\<rbrace>, -) \<Longrightarrow> \<lbrace>\<lambda>s. \<forall>x. P x s\<rbrace> f \<lbrace>\<lambda>rv s. \<forall>x. Q x rv s\<rbrace>, -"
-  by (rule hoare_vcg_const_Ball_lift_R[where S=UNIV, simplified])
+  by (rule hoare_vcg_const_Ball_liftE_R[where S=UNIV, simplified])
 
 lemma hoare_vcg_all_liftE_E:
-  "(\<And>x. \<lbrace>P x\<rbrace> f -, \<lbrace>Q x\<rbrace>) \<Longrightarrow> \<lbrace>\<lambda>s. \<forall>x. P x s\<rbrace> f -,\<lbrace>\<lambda>rv s. \<forall>x. Q x rv s\<rbrace>"
-  by (rule hoare_vcg_const_Ball_lift_E_E[where S=UNIV, simplified])
+  "(\<And>x. \<lbrace>P x\<rbrace> f -, \<lbrace>E x\<rbrace>) \<Longrightarrow> \<lbrace>\<lambda>s. \<forall>x. P x s\<rbrace> f -,\<lbrace>\<lambda>rv s. \<forall>x. E x rv s\<rbrace>"
+  by (rule hoare_vcg_const_Ball_liftE_E[where S=UNIV, simplified])
 
 lemma hoare_vcg_imp_lift:
   "\<lbrakk> \<lbrace>P'\<rbrace> f \<lbrace>\<lambda>rv s. \<not> P rv s\<rbrace>; \<lbrace>Q'\<rbrace> f \<lbrace>Q\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s. P' s \<or> Q' s\<rbrace> f \<lbrace>\<lambda>rv s. P rv s \<longrightarrow> Q rv s\<rbrace>"
@@ -626,11 +625,11 @@ lemma hoare_vcg_imp_liftE':
    \<Longrightarrow> \<lbrace>\<lambda>s. \<not> P' s \<longrightarrow> Q' s\<rbrace> f \<lbrace>\<lambda>rv s. P rv s \<longrightarrow> Q rv s\<rbrace>, \<lbrace>E\<rbrace>"
   by (fastforce simp: validE_def valid_def split: sum.splits)
 
-lemma hoare_vcg_imp_lift_R:
+lemma hoare_vcg_imp_liftE_R:
   "\<lbrakk> \<lbrace>P'\<rbrace> f \<lbrace>\<lambda>rv s. \<not> P rv s\<rbrace>, -; \<lbrace>Q'\<rbrace> f \<lbrace>Q\<rbrace>, - \<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s. P' s \<or> Q' s\<rbrace> f \<lbrace>\<lambda>rv s. P rv s \<longrightarrow> Q rv s\<rbrace>, -"
   by (auto simp add: valid_def validE_R_def validE_def split_def split: sum.splits)
 
-lemma hoare_vcg_imp_lift_R':
+lemma hoare_vcg_imp_liftE_R':
   "\<lbrakk> \<lbrace>P'\<rbrace> f \<lbrace>\<lambda>rv s. \<not> P rv s\<rbrace>, -; \<lbrace>Q'\<rbrace> f \<lbrace>Q\<rbrace>, - \<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s. \<not>P' s \<longrightarrow> Q' s\<rbrace> f \<lbrace>\<lambda>rv s. P rv s \<longrightarrow> Q rv s\<rbrace>, -"
   by (auto simp add: valid_def validE_R_def validE_def split_def split: sum.splits)
 
@@ -652,24 +651,24 @@ lemma hoare_vcg_imp_conj_lift[wp_comb]:
 lemmas hoare_vcg_imp_conj_lift'[wp_unsafe] = hoare_vcg_imp_conj_lift[where Q'''="\<top>\<top>", simplified]
 
 lemma hoare_absorb_imp:
-  "\<lbrace> P \<rbrace> f \<lbrace>\<lambda>rv s. Q rv s \<and> R rv s\<rbrace> \<Longrightarrow> \<lbrace> P \<rbrace> f \<lbrace>\<lambda>rv s. Q rv s \<longrightarrow> R rv s\<rbrace>"
+  "\<lbrace> P \<rbrace> f \<lbrace>\<lambda>rv s. Q rv s \<and> Q' rv s\<rbrace> \<Longrightarrow> \<lbrace> P \<rbrace> f \<lbrace>\<lambda>rv s. Q rv s \<longrightarrow> Q' rv s\<rbrace>"
   by (erule hoare_post_imp[rotated], blast)
 
 lemma hoare_weaken_imp:
-  "\<lbrakk> \<And>rv s. Q rv s \<Longrightarrow> Q' rv s ;  \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. Q' rv s \<longrightarrow> R rv s\<rbrace> \<rbrakk>
-    \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. Q rv s \<longrightarrow> R rv s\<rbrace>"
+  "\<lbrakk> \<And>rv s. Q rv s \<Longrightarrow> Q' rv s ; \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. Q' rv s \<longrightarrow> S rv s\<rbrace> \<rbrakk>
+    \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. Q rv s \<longrightarrow> S rv s\<rbrace>"
   by (clarsimp simp: valid_def split_def)
 
 lemma hoare_vcg_const_imp_lift:
-  "\<lbrakk> P \<Longrightarrow> \<lbrace>Q\<rbrace> m \<lbrace>R\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s. P \<longrightarrow> Q s\<rbrace> m \<lbrace>\<lambda>rv s. P \<longrightarrow> R rv s\<rbrace>"
+  "\<lbrakk> P \<Longrightarrow> \<lbrace>P'\<rbrace> m \<lbrace>Q\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s. P \<longrightarrow> P' s\<rbrace> m \<lbrace>\<lambda>rv s. P \<longrightarrow> Q rv s\<rbrace>"
   by (cases P, simp_all add: hoare_vcg_prop)
 
-lemma hoare_vcg_const_imp_lift_E:
-  "(P \<Longrightarrow> \<lbrace>Q\<rbrace> f -, \<lbrace>R\<rbrace>) \<Longrightarrow> \<lbrace>\<lambda>s. P \<longrightarrow> Q s\<rbrace> f -, \<lbrace>\<lambda>rv s. P \<longrightarrow> R rv s\<rbrace>"
+lemma hoare_vcg_const_imp_liftE_E:
+  "(P \<Longrightarrow> \<lbrace>P'\<rbrace> f -, \<lbrace>E\<rbrace>) \<Longrightarrow> \<lbrace>\<lambda>s. P \<longrightarrow> P' s\<rbrace> f -, \<lbrace>\<lambda>rv s. P \<longrightarrow> E rv s\<rbrace>"
   by (fastforce simp: validE_E_def validE_def valid_def split_def split: sum.splits)
 
-lemma hoare_vcg_const_imp_lift_R:
-  "(P \<Longrightarrow> \<lbrace>Q\<rbrace> m \<lbrace>R\<rbrace>,-) \<Longrightarrow> \<lbrace>\<lambda>s. P \<longrightarrow> Q s\<rbrace> m \<lbrace>\<lambda>rv s. P \<longrightarrow> R rv s\<rbrace>,-"
+lemma hoare_vcg_const_imp_liftE_R:
+  "(P \<Longrightarrow> \<lbrace>P'\<rbrace> m \<lbrace>Q\<rbrace>,-) \<Longrightarrow> \<lbrace>\<lambda>s. P \<longrightarrow> P' s\<rbrace> m \<lbrace>\<lambda>rv s. P \<longrightarrow> Q rv s\<rbrace>,-"
   by (fastforce simp: validE_R_def validE_def valid_def split_def split: sum.splits)
 
 lemma hoare_weak_lift_imp:
@@ -677,11 +676,11 @@ lemma hoare_weak_lift_imp:
   by (auto simp add: valid_def split_def)
 
 lemma hoare_weak_lift_impE:
-  "\<lbrace>Q\<rbrace> m \<lbrace>R\<rbrace>,\<lbrace>E\<rbrace> \<Longrightarrow> \<lbrace>\<lambda>s. P \<longrightarrow> Q s\<rbrace> m \<lbrace>\<lambda>rv s. P \<longrightarrow> R rv s\<rbrace>,\<lbrace>\<lambda>rv s. P \<longrightarrow> E rv s\<rbrace>"
+  "\<lbrace>P'\<rbrace> m \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace> \<Longrightarrow> \<lbrace>\<lambda>s. P \<longrightarrow> P' s\<rbrace> m \<lbrace>\<lambda>rv s. P \<longrightarrow> Q rv s\<rbrace>,\<lbrace>\<lambda>rv s. P \<longrightarrow> E rv s\<rbrace>"
   by (cases P; simp add: validE_def hoare_vcg_prop)
 
-lemma hoare_weak_lift_imp_R:
-  "\<lbrace>Q\<rbrace> m \<lbrace>R\<rbrace>,- \<Longrightarrow> \<lbrace>\<lambda>s. P \<longrightarrow> Q s\<rbrace> m \<lbrace>\<lambda>rv s. P \<longrightarrow> R rv s\<rbrace>,-"
+lemma hoare_weak_lift_impE_R:
+  "\<lbrace>P'\<rbrace> m \<lbrace>Q\<rbrace>,- \<Longrightarrow> \<lbrace>\<lambda>s. P \<longrightarrow> P' s\<rbrace> m \<lbrace>\<lambda>rv s. P \<longrightarrow> Q rv s\<rbrace>,-"
   by (cases P; wpsimp wp: wp_post_tautE_R)
 
 lemma hoare_vcg_ex_lift:
@@ -712,24 +711,30 @@ lemma hoare_liftP_ext:
   done
 
 (* for instantiations *)
-lemma hoare_triv:    "\<lbrace>P\<rbrace>f\<lbrace>Q\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace>f\<lbrace>Q\<rbrace>" .
+lemma hoare_triv:    "\<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>" .
 lemma hoare_trivE:   "\<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>" .
 lemma hoare_trivE_R: "\<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,- \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,-" .
 lemma hoare_trivR_R: "\<lbrace>P\<rbrace> f -,\<lbrace>E\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace> f -,\<lbrace>E\<rbrace>" .
 
-lemma hoare_vcg_E_conj:
+lemma hoare_vcg_conj_liftE_E:
   "\<lbrakk> \<lbrace>P\<rbrace> f -,\<lbrace>E\<rbrace>; \<lbrace>P'\<rbrace> f \<lbrace>Q'\<rbrace>,\<lbrace>E'\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s. P s \<and> P' s\<rbrace> f \<lbrace>Q'\<rbrace>, \<lbrace>\<lambda>rv s. E rv s \<and> E' rv s\<rbrace>"
   unfolding validE_def validE_E_def
   by (rule hoare_post_imp[OF _ hoare_vcg_conj_lift]; simp split: sum.splits)
 
-lemma hoare_vcg_E_elim:
+lemma hoare_vcg_conj_elimE:
   "\<lbrakk> \<lbrace>P\<rbrace> f -,\<lbrace>E\<rbrace>; \<lbrace>P'\<rbrace> f \<lbrace>Q\<rbrace>,- \<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s. P s \<and> P' s\<rbrace> f \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
-  by (rule hoare_strengthen_postE[OF hoare_vcg_E_conj]) (simp add: validE_R_def)+
+  by (rule hoare_strengthen_postE[OF hoare_vcg_conj_liftE_E]) (simp add: validE_R_def)+
 
-lemma hoare_vcg_R_conj:
+lemma hoare_vcg_conj_liftE_R:
   "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,-; \<lbrace>P'\<rbrace> f \<lbrace>Q'\<rbrace>,- \<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s. P s \<and> P' s\<rbrace> f \<lbrace>\<lambda>rv s. Q rv s \<and> Q' rv s\<rbrace>,-"
   unfolding validE_R_def validE_def
   by (rule hoare_post_imp[OF _ hoare_vcg_conj_lift]; simp split: sum.splits)
+
+lemma hoare_vcg_conj_liftE_R':
+  "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,-; \<lbrace>P'\<rbrace> f \<lbrace>Q'\<rbrace>,- \<rbrakk> \<Longrightarrow> \<lbrace>P and P'\<rbrace> f \<lbrace>\<lambda>rv s. Q rv s \<and> Q' rv s\<rbrace>, -"
+  apply (simp add: validE_R_def validE_def valid_def split: sum.splits)
+  apply blast
+  done
 
 lemma hoare_lift_Pf_E_R:
   "\<lbrakk> \<And>x. \<lbrace>P x\<rbrace> m \<lbrace>\<lambda>_. P x\<rbrace>, -; \<And>P. \<lbrace>\<lambda>s. P (f s)\<rbrace> m \<lbrace>\<lambda>_ s. P (f s)\<rbrace>, - \<rbrakk> \<Longrightarrow>
@@ -746,11 +751,11 @@ lemma hoare_post_comb_imp_conj:
   by (wpsimp wp: hoare_vcg_conj_lift)
 
 lemma hoare_vcg_if_lift:
-  "\<lbrace>R\<rbrace> f \<lbrace>\<lambda>rv s. (P \<longrightarrow> X rv s) \<and> (\<not>P \<longrightarrow> Y rv s)\<rbrace> \<Longrightarrow>
-   \<lbrace>R\<rbrace> f \<lbrace>\<lambda>rv s. if P then X rv s else Y rv s\<rbrace>"
+  "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. (P' \<longrightarrow> X rv s) \<and> (\<not>P' \<longrightarrow> Y rv s)\<rbrace> \<Longrightarrow>
+   \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. if P' then X rv s else Y rv s\<rbrace>"
 
-  "\<lbrace>R\<rbrace> f \<lbrace>\<lambda>rv s. (P \<longrightarrow> X rv s) \<and> (\<not>P \<longrightarrow> Y rv s)\<rbrace> \<Longrightarrow>
-   \<lbrace>R\<rbrace> f \<lbrace>\<lambda>rv. if P then X rv else Y rv\<rbrace>"
+  "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. (P' \<longrightarrow> X rv s) \<and> (\<not>P' \<longrightarrow> Y rv s)\<rbrace> \<Longrightarrow>
+   \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv. if P' then X rv else Y rv\<rbrace>"
   by (auto simp: valid_def split_def)
 
 lemma hoare_vcg_split_lift[wp]:
@@ -760,8 +765,8 @@ lemma hoare_vcg_split_lift[wp]:
 named_theorems hoare_vcg_op_lift
 lemmas [hoare_vcg_op_lift] =
   hoare_vcg_const_imp_lift
-  hoare_vcg_const_imp_lift_E
-  hoare_vcg_const_imp_lift_R
+  hoare_vcg_const_imp_liftE_E
+  hoare_vcg_const_imp_liftE_R
   (* leaving out hoare_vcg_conj_lift*, because that is built into wp *)
   hoare_vcg_disj_lift
   hoare_vcg_disj_lift_R
@@ -774,13 +779,13 @@ lemmas [hoare_vcg_op_lift] =
   hoare_vcg_all_liftE_R
   hoare_vcg_const_Ball_lift
   hoare_vcg_const_Ball_liftE
-  hoare_vcg_const_Ball_lift_R
-  hoare_vcg_const_Ball_lift_E_E
+  hoare_vcg_const_Ball_liftE_R
+  hoare_vcg_const_Ball_liftE_E
   hoare_vcg_split_lift
   hoare_vcg_if_lift
   hoare_vcg_imp_lift'
   hoare_vcg_imp_liftE'
-  hoare_vcg_imp_lift_R'
+  hoare_vcg_imp_liftE_R'
   hoare_vcg_imp_liftE_E'
 
 
@@ -867,8 +872,8 @@ lemma list_cases_wp:
   by (cases ts, auto simp: a b)
 
 lemma hoare_vcg_handle_elseE:
-  "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>; \<And>e. \<lbrace>E e\<rbrace> g e \<lbrace>R\<rbrace>,\<lbrace>F\<rbrace>; \<And>x. \<lbrace>Q x\<rbrace> h x \<lbrace>R\<rbrace>,\<lbrace>F\<rbrace> \<rbrakk> \<Longrightarrow>
-   \<lbrace>P\<rbrace> f <handle> g <else> h \<lbrace>R\<rbrace>,\<lbrace>F\<rbrace>"
+  "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>Q'\<rbrace>,\<lbrace>E'\<rbrace>; \<And>e. \<lbrace>E' e\<rbrace> g e \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>; \<And>x. \<lbrace>Q' x\<rbrace> h x \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace> \<rbrakk> \<Longrightarrow>
+   \<lbrace>P\<rbrace> f <handle> g <else> h \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
   unfolding handle_elseE_def validE_def
   by (wpsimp wp: bind_wp_fwd | assumption | rule conjI)+
 
@@ -911,11 +916,11 @@ lemma state_select_wp:
   by (wpsimp wp: put_wp select_wp return_wp get_wp assert_wp)
 
 lemma condition_wp:
-  "\<lbrakk> \<lbrace>Q\<rbrace> A \<lbrace>P\<rbrace>; \<lbrace>R\<rbrace> B \<lbrace>P\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s. if C s then Q s else R s\<rbrace> condition C A B \<lbrace>P\<rbrace>"
+  "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>; \<lbrace>P'\<rbrace> g \<lbrace>Q\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s. if C s then P s else P' s\<rbrace> condition C f g \<lbrace>Q\<rbrace>"
   by (clarsimp simp: condition_def valid_def)
 
 lemma conditionE_wp:
-  "\<lbrakk> \<lbrace>P\<rbrace> A \<lbrace>Q\<rbrace>,\<lbrace>R\<rbrace>; \<lbrace>P'\<rbrace> B \<lbrace>Q\<rbrace>,\<lbrace>R\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s. if C s then P s else P' s\<rbrace> condition C A B \<lbrace>Q\<rbrace>,\<lbrace>R\<rbrace>"
+  "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>; \<lbrace>P'\<rbrace> g \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s. if C s then P s else P' s\<rbrace> condition C f g \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
   by (clarsimp simp: condition_def validE_def valid_def)
 
 lemma state_assert_wp:
@@ -924,19 +929,19 @@ lemma state_assert_wp:
   by (wp bind_wp_fwd get_wp assert_wp)
 
 lemma when_wp[wp_split]:
-  "\<lbrakk> P \<Longrightarrow> \<lbrace>Q\<rbrace> f \<lbrace>R\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>if P then Q else R ()\<rbrace> when P f \<lbrace>R\<rbrace>"
+  "\<lbrakk> P \<Longrightarrow> \<lbrace>P'\<rbrace> f \<lbrace>Q\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>if P then P' else Q ()\<rbrace> when P f \<lbrace>Q\<rbrace>"
   by (clarsimp simp: when_def valid_def return_def)
 
 lemma unless_wp[wp_split]:
-  "(\<not>P \<Longrightarrow> \<lbrace>Q\<rbrace> f \<lbrace>R\<rbrace>) \<Longrightarrow> \<lbrace>if P then R () else Q\<rbrace> unless P f \<lbrace>R\<rbrace>"
+  "(\<not>P \<Longrightarrow> \<lbrace>P'\<rbrace> f \<lbrace>Q\<rbrace>) \<Longrightarrow> \<lbrace>if P then Q () else P'\<rbrace> unless P f \<lbrace>Q\<rbrace>"
   unfolding unless_def by wp auto
 
 lemma whenE_wp:
-  "(P \<Longrightarrow> \<lbrace>Q\<rbrace> f \<lbrace>R\<rbrace>, \<lbrace>E\<rbrace>) \<Longrightarrow> \<lbrace>if P then Q else R ()\<rbrace> whenE P f \<lbrace>R\<rbrace>, \<lbrace>E\<rbrace>"
+  "(P \<Longrightarrow> \<lbrace>P'\<rbrace> f \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>) \<Longrightarrow> \<lbrace>if P then P' else Q ()\<rbrace> whenE P f \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
   unfolding whenE_def by clarsimp (wp returnOk_wp)
 
 lemma unlessE_wp:
-  "(\<not> P \<Longrightarrow> \<lbrace>Q\<rbrace> f \<lbrace>R\<rbrace>, \<lbrace>E\<rbrace>) \<Longrightarrow> \<lbrace>if P then R () else Q\<rbrace> unlessE P f \<lbrace>R\<rbrace>, \<lbrace>E\<rbrace>"
+  "(\<not> P \<Longrightarrow> \<lbrace>P'\<rbrace> f \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>) \<Longrightarrow> \<lbrace>if P then Q () else P'\<rbrace> unlessE P f \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
   unfolding unlessE_def
   by (wpsimp wp: returnOk_wp)
 
@@ -950,8 +955,8 @@ lemma notM_wp:
   unfolding notM_def by (wpsimp wp: return_wp)
 
 lemma ifM_wp:
-  assumes [wp]: "\<lbrace>Q\<rbrace> f \<lbrace>S\<rbrace>" "\<lbrace>R\<rbrace> g \<lbrace>S\<rbrace>"
-  assumes [wp]: "\<lbrace>A\<rbrace> P \<lbrace>\<lambda>c s. c \<longrightarrow> Q s\<rbrace>" "\<lbrace>B\<rbrace> P \<lbrace>\<lambda>c s. \<not>c \<longrightarrow> R s\<rbrace>"
+  assumes [wp]: "\<lbrace>Q\<rbrace> f \<lbrace>S\<rbrace>" "\<lbrace>Q'\<rbrace> g \<lbrace>S\<rbrace>"
+  assumes [wp]: "\<lbrace>A\<rbrace> P \<lbrace>\<lambda>c s. c \<longrightarrow> Q s\<rbrace>" "\<lbrace>B\<rbrace> P \<lbrace>\<lambda>c s. \<not>c \<longrightarrow> Q' s\<rbrace>"
   shows "\<lbrace>A and B\<rbrace> ifM P f g \<lbrace>S\<rbrace>"
   unfolding ifM_def
   by (wpsimp wp: hoare_vcg_if_split hoare_vcg_conj_lift)
@@ -1072,15 +1077,16 @@ lemmas hoare_wp_combs = hoare_vcg_conj_lift
 
 lemmas hoare_wp_combsE =
   validE_validE_R
-  hoare_vcg_R_conj
-  hoare_vcg_E_elim
-  hoare_vcg_E_conj
+  validE_validE_E
+  hoare_vcg_conj_liftE_R
+  hoare_vcg_conj_elimE
+  hoare_vcg_conj_liftE_E
 
 lemmas hoare_wp_state_combsE =
   valid_validE_R
-  hoare_vcg_R_conj[OF valid_validE_R]
-  hoare_vcg_E_elim[OF valid_validE_E]
-  hoare_vcg_E_conj[OF valid_validE_E]
+  hoare_vcg_conj_liftE_R[OF valid_validE_R]
+  hoare_vcg_conj_elimE[OF valid_validE_E]
+  hoare_vcg_conj_liftE_E[OF valid_validE_E]
 
 lemmas hoare_classic_wp_combs = hoare_post_comb_imp_conj hoare_weaken_pre hoare_wp_combs
 lemmas hoare_classic_wp_combsE = hoare_weaken_preE hoare_weaken_preE_R hoare_wp_combsE
@@ -1153,9 +1159,9 @@ lemmas [wp] = wp_post_tauts
 lemmas [wp_trip] = valid_is_triple validE_is_triple validE_E_is_triple validE_R_is_triple
 
 lemmas validE_E_combs[wp_comb] =
-    hoare_vcg_E_conj[where Q'="\<top>\<top>", folded validE_E_def]
+    hoare_vcg_conj_liftE_E[where Q'="\<top>\<top>", folded validE_E_def]
     valid_validE_E
-    hoare_vcg_E_conj[where Q'="\<top>\<top>", folded validE_E_def, OF valid_validE_E]
+    hoare_vcg_conj_liftE_E[where Q'="\<top>\<top>", folded validE_E_def, OF valid_validE_E]
 
 
 subsection \<open>Simplifications on conjunction\<close>
@@ -1252,7 +1258,7 @@ bundle classic_wp_pre = hoare_pre [wp_pre del]
 text \<open>Miscellaneous lemmas on hoare triples\<close>
 
 lemma hoare_pre_cases:
-  "\<lbrakk> \<lbrace>\<lambda>s. R s \<and> P s\<rbrace> f \<lbrace>Q\<rbrace>; \<lbrace>\<lambda>s. \<not>R s \<and> P' s\<rbrace> f \<lbrace>Q\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P and P'\<rbrace> f \<lbrace>Q\<rbrace>"
+  "\<lbrakk> \<lbrace>\<lambda>s. C s \<and> P s\<rbrace> f \<lbrace>Q\<rbrace>; \<lbrace>\<lambda>s. \<not>C s \<and> P' s\<rbrace> f \<lbrace>Q\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P and P'\<rbrace> f \<lbrace>Q\<rbrace>"
   unfolding valid_def by fastforce
 
 lemma hoare_vcg_mp:
@@ -1286,7 +1292,7 @@ lemma hoare_use_eq:
   assumes "\<And>P. \<lbrace>\<lambda>s. P (f s)\<rbrace> m \<lbrace>\<lambda>_ s. P (f s)\<rbrace>"
   assumes "\<And>f. \<lbrace>\<lambda>s. P f s\<rbrace> m \<lbrace>\<lambda>_ s. Q f s\<rbrace>"
   shows "\<lbrace>\<lambda>s. P (f s) s\<rbrace> m \<lbrace>\<lambda>_ s. Q (f s) s \<rbrace>"
-  apply (rule hoare_post_imp[where Q="\<lambda>_ s. \<exists>y. y = f s \<and> Q y s"], simp)
+  apply (rule hoare_post_imp[where Q'="\<lambda>_ s. \<exists>y. y = f s \<and> Q y s"], simp)
   apply (wpsimp wp: hoare_vcg_ex_lift assms)
   done
 
@@ -1299,39 +1305,37 @@ lemma hoare_failE[simp]:
   by wp
 
 lemma hoare_validE_pred_conj:
-  "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>, \<lbrace>E\<rbrace>; \<lbrace>P\<rbrace> f \<lbrace>R\<rbrace>, \<lbrace>E\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q and R\<rbrace>, \<lbrace>E\<rbrace>"
+  "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>; \<lbrace>P\<rbrace> f \<lbrace>Q'\<rbrace>,\<lbrace>E\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q and Q'\<rbrace>,\<lbrace>E\<rbrace>"
   unfolding valid_def validE_def
   by (simp add: split_def split: sum.splits)
 
 lemma hoare_validE_conj:
-  "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>, \<lbrace>E\<rbrace>; \<lbrace>P\<rbrace> f \<lbrace>R\<rbrace>, \<lbrace>E\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. Q rv s \<and> R rv s\<rbrace>, \<lbrace>E\<rbrace>"
+  "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>; \<lbrace>P\<rbrace> f \<lbrace>Q'\<rbrace>,\<lbrace>E\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. Q rv s \<and> Q' rv s\<rbrace>,\<lbrace>E\<rbrace>"
   unfolding valid_def validE_def
   by (simp add: split_def split: sum.splits)
-
-lemmas hoare_valid_validE = valid_validE (* FIXME lib: eliminate one *)
-
-declare validE_validE_E[wp_comb]
 
 lemmas if_validE_E[wp_split] =
   validE_validE_E[OF hoare_vcg_if_splitE[OF validE_E_validE validE_E_validE]]
 
 lemma hoare_drop_imp:
-  "\<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. R rv s \<longrightarrow> Q rv s\<rbrace>"
+  "\<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. Q' rv s \<longrightarrow> Q rv s\<rbrace>"
   by (auto simp: valid_def)
 
 lemma hoare_drop_impE:
-  "\<lbrakk>\<lbrace>P\<rbrace> f \<lbrace>\<lambda>r. Q\<rbrace>, \<lbrace>E\<rbrace>\<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. R rv s \<longrightarrow> Q s\<rbrace>, \<lbrace>E\<rbrace>"
+  "\<lbrakk>\<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>, \<lbrace>E\<rbrace>\<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. Q' rv s \<longrightarrow> Q rv s\<rbrace>, \<lbrace>E\<rbrace>"
   by (simp add: hoare_chainE)
 
 lemma hoare_drop_impE_R:
-  "\<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,- \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. R rv s \<longrightarrow> Q rv s\<rbrace>, -"
+  "\<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,- \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. Q' rv s \<longrightarrow> Q rv s\<rbrace>, -"
   by (auto simp: validE_R_def validE_def valid_def split_def split: sum.splits)
 
+(*Q is used instead of E so that hoare_drop_imps can be instantiated, which requires that all of its
+  thms have the same variables.*)
 lemma hoare_drop_impE_E:
-  "\<lbrace>P\<rbrace> f -,\<lbrace>Q\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace> f -, \<lbrace>\<lambda>rv s. R rv s \<longrightarrow> Q rv s\<rbrace>"
+  "\<lbrace>P\<rbrace> f -,\<lbrace>Q\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace> f -, \<lbrace>\<lambda>rv s. Q' rv s \<longrightarrow> Q rv s\<rbrace>"
   by (auto simp: validE_E_def validE_def valid_def split_def split: sum.splits)
 
-lemmas hoare_drop_imps = hoare_drop_imp hoare_drop_impE_R hoare_drop_impE_E
+lemmas hoare_drop_imps = hoare_drop_imp hoare_drop_impE hoare_drop_impE_R hoare_drop_impE_E
 
 (*This is unsafe, but can be very useful when supplied as a comb rule.*)
 lemma hoare_drop_imp_conj[wp_unsafe]:

--- a/lib/Monads/nondet/Nondet_VCG.thy
+++ b/lib/Monads/nondet/Nondet_VCG.thy
@@ -221,32 +221,22 @@ lemma hoare_FalseE[simp]:
   "\<lbrace>\<bottom>\<rbrace> f \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
   by (simp add: valid_def validE_def)
 
-\<comment> \<open>FIXME: remove?\<close>
-lemma hoare_return_drop_var[iff]:
+lemma return_inv[iff]:
   "\<lbrace>Q\<rbrace> return x \<lbrace>\<lambda>r. Q\<rbrace>"
   by (simp add: valid_def return_def)
 
-\<comment> \<open>FIXME: remove?\<close>
-lemma hoare_gets[intro]:
-  "\<lbrakk> \<And>s. P s \<Longrightarrow> Q (f s) s \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> gets f \<lbrace>Q\<rbrace>"
-  by (simp add:valid_def gets_def get_def bind_def return_def)
-
-\<comment> \<open>FIXME: remove?\<close>
 lemma hoare_modifyE_var:
   "\<lbrakk> \<And>s. P s \<Longrightarrow> Q (f s) \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> modify f \<lbrace>\<lambda>_ s. Q s\<rbrace>"
   by(simp add: valid_def modify_def put_def get_def bind_def)
 
-\<comment> \<open>FIXME: remove?\<close>
 lemma hoare_if:
   "\<lbrakk> P' \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>; \<not> P' \<Longrightarrow> \<lbrace>P\<rbrace> g \<lbrace>Q\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> if P' then f else g \<lbrace>Q\<rbrace>"
   by (simp add: valid_def)
 
-\<comment> \<open>FIXME: remove?\<close>
 lemma hoare_pre_subst:
   "\<lbrakk> P = P'; \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P'\<rbrace> f \<lbrace>Q\<rbrace>"
   by (erule subst)
 
-\<comment> \<open>FIXME: remove?\<close>
 lemma hoare_post_subst:
   "\<lbrakk> Q = Q'; \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q'\<rbrace>"
   by (erule subst)

--- a/lib/Monads/nondet/Nondet_While_Loop_Rules.thy
+++ b/lib/Monads/nondet/Nondet_While_Loop_Rules.thy
@@ -867,6 +867,6 @@ lemma whileM_inv:
   by (fastforce intro: whileM_wp_gen)
 
 lemmas whileM_post_inv
-  = hoare_strengthen_post[where R="\<lambda>_. Q" for Q, OF whileM_inv[where P=C for C], rotated -1]
+  = hoare_strengthen_post[where Q'="\<lambda>_. Q" for Q, OF whileM_inv[where P=C for C], rotated -1]
 
 end

--- a/lib/Monads/trace/Trace_More_RG.thy
+++ b/lib/Monads/trace/Trace_More_RG.thy
@@ -19,11 +19,11 @@ lemma rg_take_disjunct:
   by (erule rg_strengthen_post, simp)
 
 lemma rg_post_add:
-  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> S \<lbrace>G\<rbrace>,\<lbrace>\<lambda>r s0 s. Q' r s0 s \<and> Q r s0 s\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> S \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>r s0 s. Q' r s0 s \<and> Q r s0 s\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
   by (erule rg_strengthen_post, simp)
 
 lemma rg_post_addE:
-  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_ s0 s. R s0 s \<and> Q s0 s\<rbrace>,\<lbrace>T\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_ s0 s. Q s0 s\<rbrace>,\<lbrace>T\<rbrace>"
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_ s0 s. R s0 s \<and> Q s0 s\<rbrace>,\<lbrace>E\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_ s0 s. Q s0 s\<rbrace>,\<lbrace>E\<rbrace>"
   by (erule rg_strengthen_postE; simp)
 
 lemma rg_pre_add:
@@ -32,7 +32,7 @@ lemma rg_pre_add:
   by(intro conjI impI; rule rg_weaken_pre, assumption, clarsimp)
 
 lemma rg_pre_addE:
-  "(\<forall>s0 s. P s0 s \<longrightarrow> R s0 s) \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>S\<rbrace> \<longleftrightarrow> \<lbrace>P and R\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>S\<rbrace>"
+  "(\<forall>s0 s. P s0 s \<longrightarrow> R s0 s) \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace> \<longleftrightarrow> \<lbrace>P and R\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
   apply (subst iff_conv_conj_imp)
   by(intro conjI impI; rule rg_weaken_preE, assumption, clarsimp)
 
@@ -85,8 +85,8 @@ lemmas rg_lift_Pf2_pre_conj = rg_lift_Pf3_pre_conj[where P="\<lambda>f _. P f" f
 lemmas rg_lift_Pf_pre_conj' = rg_lift_Pf2_pre_conj[where Q=P and P=P for P]
 
 lemma rg_if_r_and:
-  "\<lbrace>P\<rbrace>,\<lbrace>R'\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>r. if R r then Q r else Q' r\<rbrace>
-   = \<lbrace>P\<rbrace>,\<lbrace>R'\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>r s0 s. (R r \<longrightarrow> Q r s0 s) \<and> (\<not>R r \<longrightarrow> Q' r s0 s)\<rbrace>"
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>r. if P' r then Q r else Q' r\<rbrace>
+   = \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>r s0 s. (P' r \<longrightarrow> Q r s0 s) \<and> (\<not>P' r \<longrightarrow> Q' r s0 s)\<rbrace>"
   by (fastforce simp: validI_def)
 
 lemma rg_convert_imp:
@@ -117,8 +117,8 @@ lemma rg_imp_eq_substR:
 
 lemma rg_split_bind_case_sum:
   assumes x: "\<And>rv. \<lbrace>E rv\<rbrace>,\<lbrace>R\<rbrace> g rv \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
-             "\<And>rv. \<lbrace>S rv\<rbrace>,\<lbrace>R\<rbrace> h rv \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
-  assumes y: "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>S\<rbrace>,\<lbrace>E\<rbrace>"
+             "\<And>rv. \<lbrace>Q' rv\<rbrace>,\<lbrace>R\<rbrace> h rv \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+  assumes y: "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q'\<rbrace>,\<lbrace>E\<rbrace>"
   shows      "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f >>= case_sum g h \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
   apply (rule bind_twp[OF _ y[unfolded validIE_def]])
   apply (wpsimp wp: x split: sum.splits)
@@ -324,8 +324,8 @@ lemma opt_return_pres_lift_rg:
   by (wpsimp wp: x)
 
 lemma rg_weak_lift_imp_conj:
-  "\<lbrakk> \<lbrace>Q\<rbrace>,\<lbrace>R\<rbrace> m -,\<lbrace>Q'\<rbrace>; \<lbrace>R\<rbrace>,\<lbrace>R\<rbrace> m -,\<lbrace>R'\<rbrace>; \<lbrace>S\<rbrace>,\<lbrace>R\<rbrace> m \<lbrace>G\<rbrace>,\<lbrace>\<top>\<top>\<top>\<rbrace> \<rbrakk>
-   \<Longrightarrow> \<lbrace>\<lambda>s0 s. (P \<longrightarrow> Q s0 s) \<and> R s0 s \<and> S s0 s\<rbrace>,\<lbrace>R\<rbrace> m \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. (P \<longrightarrow> Q' rv s0 s) \<and> R' rv s0 s\<rbrace>"
+  "\<lbrakk> \<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> m -,\<lbrace>Q'\<rbrace>; \<lbrace>P''\<rbrace>,\<lbrace>R\<rbrace> m -,\<lbrace>Q''\<rbrace>; \<lbrace>S\<rbrace>,\<lbrace>R\<rbrace> m \<lbrace>G\<rbrace>,\<lbrace>\<top>\<top>\<top>\<rbrace> \<rbrakk>
+   \<Longrightarrow> \<lbrace>\<lambda>s0 s. (P \<longrightarrow> P' s0 s) \<and> P'' s0 s \<and> S s0 s\<rbrace>,\<lbrace>R\<rbrace> m \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. (P \<longrightarrow> Q' rv s0 s) \<and> Q'' rv s0 s\<rbrace>"
   apply wp_pre
   apply (rule rg_vcg_conj_lift)
    apply (rule rg_weak_lift_imp; assumption)
@@ -379,9 +379,9 @@ lemma rg_Ball_helper:
 
 lemma handy_prop_divs_rg:
   assumes x: "\<And>P. \<lbrace>\<lambda>s0 s. P (Q s0 s) \<and> S s0 s\<rbrace>,\<lbrace>R\<rbrace> f -,\<lbrace>\<lambda>rv s0 s. P (Q' rv s0 s)\<rbrace>"
-             "\<And>P. \<lbrace>\<lambda>s0 s. P (R s0 s) \<and> S s0 s\<rbrace>,\<lbrace>R\<rbrace> f -,\<lbrace>\<lambda>rv s0 s. P (R' rv s0 s)\<rbrace>"
-  shows      "\<lbrace>\<lambda>s0 s. P (Q s0 s \<and> R s0 s) \<and> S s0 s\<rbrace>,\<lbrace>R\<rbrace> f -,\<lbrace>\<lambda>rv s0 s. P (Q' rv s0 s \<and> R' rv s0 s)\<rbrace>"
-             "\<lbrace>\<lambda>s0 s. P (Q s0 s \<or> R s0 s) \<and> S s0 s\<rbrace>,\<lbrace>R\<rbrace> f -,\<lbrace>\<lambda>rv s0 s. P (Q' rv s0 s \<or> R' rv s0 s)\<rbrace>"
+             "\<And>P. \<lbrace>\<lambda>s0 s. P (T s0 s) \<and> S s0 s\<rbrace>,\<lbrace>R\<rbrace> f -,\<lbrace>\<lambda>rv s0 s. P (T' rv s0 s)\<rbrace>"
+  shows      "\<lbrace>\<lambda>s0 s. P (Q s0 s \<and> T s0 s) \<and> S s0 s\<rbrace>,\<lbrace>R\<rbrace> f -,\<lbrace>\<lambda>rv s0 s. P (Q' rv s0 s \<and> T' rv s0 s)\<rbrace>"
+             "\<lbrace>\<lambda>s0 s. P (Q s0 s \<or> T s0 s) \<and> S s0 s\<rbrace>,\<lbrace>R\<rbrace> f -,\<lbrace>\<lambda>rv s0 s. P (Q' rv s0 s \<or> T' rv s0 s)\<rbrace>"
    apply (clarsimp simp: validI_def validI_prefix_closed[OF x(1)]
                   elim!: subst[rotated, where P=P])
    apply (rule use_validI [OF _ x(1)], assumption)
@@ -481,8 +481,8 @@ lemma twp_split_const_ifE_R:
   by (cases S, simp_all add: x y)
 
 lemma rg_disj_division:
-  "\<lbrakk> P \<or> Q; P \<Longrightarrow> \<lbrace>R\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>S\<rbrace>; Q \<Longrightarrow> \<lbrace>T\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>S\<rbrace> \<rbrakk>
-   \<Longrightarrow> \<lbrace>\<lambda>s0 s. (P \<longrightarrow> R s0 s) \<and> (Q \<longrightarrow> T s0 s)\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>S\<rbrace>"
+  "\<lbrakk> P \<or> P'; P \<Longrightarrow> \<lbrace>S\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>; P' \<Longrightarrow> \<lbrace>T\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace> \<rbrakk>
+   \<Longrightarrow> \<lbrace>\<lambda>s0 s. (P \<longrightarrow> S s0 s) \<and> (P' \<longrightarrow> T s0 s)\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
   by (fastforce intro: rg_weaken_pre)
 
 lemma rg_grab_asm:

--- a/lib/Monads/trace/Trace_More_VCG.thy
+++ b/lib/Monads/trace/Trace_More_VCG.thy
@@ -20,20 +20,20 @@ lemma hoare_take_disjunct:
   by (erule hoare_strengthen_post, simp)
 
 lemma hoare_post_add:
-  "\<lbrace>P\<rbrace> S \<lbrace>\<lambda>r s. R r s \<and> Q r s\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace> S \<lbrace>Q\<rbrace>"
+  "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>r s. Q' r s \<and> Q r s\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>"
   by (erule hoare_strengthen_post, simp)
 
 lemma hoare_post_addE:
-  "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>_ s. R s \<and> Q s\<rbrace>, \<lbrace>T\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>_ s. Q s\<rbrace>, \<lbrace>T\<rbrace>"
+  "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>_ s. Q' s \<and> Q s\<rbrace>,\<lbrace>E\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>_ s. Q s\<rbrace>,\<lbrace>E\<rbrace>"
   by (erule hoare_strengthen_postE; simp)
 
 lemma hoare_pre_add:
-  "(\<forall>s. P s \<longrightarrow> R s) \<Longrightarrow> (\<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace> \<longleftrightarrow> \<lbrace>P and R\<rbrace> f \<lbrace>Q\<rbrace>)"
+  "(\<forall>s. P s \<longrightarrow> P' s) \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace> \<longleftrightarrow> \<lbrace>P and P'\<rbrace> f \<lbrace>Q\<rbrace>"
   apply (subst iff_conv_conj_imp)
   by(intro conjI impI; rule hoare_weaken_pre, assumption, clarsimp)
 
 lemma hoare_pre_addE:
-  "(\<forall>s. P s \<longrightarrow> R s) \<Longrightarrow> (\<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>, \<lbrace>S\<rbrace> \<longleftrightarrow> \<lbrace>P and R\<rbrace> f \<lbrace>Q\<rbrace>, \<lbrace>S\<rbrace>)"
+  "(\<forall>s. P s \<longrightarrow> P' s) \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace> \<longleftrightarrow> \<lbrace>P and P'\<rbrace> f \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
   apply (subst iff_conv_conj_imp)
   by(intro conjI impI; rule hoare_weaken_preE, assumption, clarsimp)
 
@@ -46,15 +46,15 @@ lemma hoare_name_pre_stateE:
   by (clarsimp simp: validE_def2)
 
 lemma hoare_vcg_if_lift_strong:
-  "\<lbrakk> \<lbrace>P'\<rbrace> f \<lbrace>P\<rbrace>; \<lbrace>\<lambda>s. \<not> P' s\<rbrace> f \<lbrace>\<lambda>rv s. \<not> P rv s\<rbrace>; \<lbrace>Q'\<rbrace> f \<lbrace>Q\<rbrace>; \<lbrace>R'\<rbrace> f \<lbrace>R\<rbrace> \<rbrakk> \<Longrightarrow>
-   \<lbrace>\<lambda>s. if P' s then Q' s else R' s\<rbrace> f \<lbrace>\<lambda>rv s. if P rv s then Q rv s else R rv s\<rbrace>"
+  "\<lbrakk> \<lbrace>P'\<rbrace> f \<lbrace>P\<rbrace>; \<lbrace>\<lambda>s. \<not> P' s\<rbrace> f \<lbrace>\<lambda>rv s. \<not> P rv s\<rbrace>; \<lbrace>Q'\<rbrace> f \<lbrace>Q\<rbrace>; \<lbrace>S'\<rbrace> f \<lbrace>S\<rbrace> \<rbrakk> \<Longrightarrow>
+   \<lbrace>\<lambda>s. if P' s then Q' s else S' s\<rbrace> f \<lbrace>\<lambda>rv s. if P rv s then Q rv s else S rv s\<rbrace>"
 
-  "\<lbrakk> \<lbrace>P'\<rbrace> f \<lbrace>P\<rbrace>; \<lbrace>\<lambda>s. \<not> P' s\<rbrace> f \<lbrace>\<lambda>rv s. \<not> P rv s\<rbrace>; \<lbrace>Q'\<rbrace> f \<lbrace> Q\<rbrace>; \<lbrace>R'\<rbrace> f \<lbrace>R\<rbrace> \<rbrakk> \<Longrightarrow>
-   \<lbrace>\<lambda>s. if P' s then Q' s else R' s\<rbrace> f \<lbrace>\<lambda>rv s. (if P rv s then Q rv else R rv) s\<rbrace>"
+  "\<lbrakk> \<lbrace>P'\<rbrace> f \<lbrace>P\<rbrace>; \<lbrace>\<lambda>s. \<not> P' s\<rbrace> f \<lbrace>\<lambda>rv s. \<not> P rv s\<rbrace>; \<lbrace>Q'\<rbrace> f \<lbrace> Q\<rbrace>; \<lbrace>S'\<rbrace> f \<lbrace>S\<rbrace> \<rbrakk> \<Longrightarrow>
+   \<lbrace>\<lambda>s. if P' s then Q' s else S' s\<rbrace> f \<lbrace>\<lambda>rv s. (if P rv s then Q rv else S rv) s\<rbrace>"
   by (wpsimp wp: hoare_vcg_imp_lift' | assumption | fastforce)+
 
 lemma hoare_vcg_imp_lift_pre_add:
-  "\<lbrakk> \<lbrace>P and Q\<rbrace> f \<lbrace>\<lambda>rv s. R rv s\<rbrace>; f \<lbrace>\<lambda>s. \<not> Q s\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. Q s \<longrightarrow> R rv s\<rbrace>"
+  "\<lbrakk> \<lbrace>P and Q\<rbrace> f \<lbrace>\<lambda>rv s. Q' rv s\<rbrace>; f \<lbrace>\<lambda>s. \<not> Q s\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. Q s \<longrightarrow> Q' rv s\<rbrace>"
   apply (rule hoare_weaken_pre)
    apply (rule hoare_vcg_imp_lift')
     apply fastforce
@@ -66,16 +66,17 @@ lemma hoare_pre_tautI:
   "\<lbrakk> \<lbrace>A and P\<rbrace> a \<lbrace>B\<rbrace>; \<lbrace>A and not P\<rbrace> a \<lbrace>B\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>A\<rbrace> a \<lbrace>B\<rbrace>"
   by (fastforce simp: valid_def split_def pred_conj_def pred_neg_def)
 
+\<comment> \<open>FIXME: swap P and Q in these rules?\<close>
 lemma hoare_lift_Pf_pre_conj:
   assumes P: "\<And>x. \<lbrace>\<lambda>s. Q x s\<rbrace> m \<lbrace>P x\<rbrace>"
-  assumes f: "\<And>P. \<lbrace>\<lambda>s. P (g s) \<and> R s\<rbrace> m \<lbrace>\<lambda>_ s. P (f s)\<rbrace>"
-  shows "\<lbrace>\<lambda>s. Q (g s) s \<and> R s\<rbrace> m \<lbrace>\<lambda>rv s. P (f s) rv s\<rbrace>"
+  assumes f: "\<And>P. \<lbrace>\<lambda>s. P (g s) \<and> P' s\<rbrace> m \<lbrace>\<lambda>_ s. P (f s)\<rbrace>"
+  shows "\<lbrace>\<lambda>s. Q (g s) s \<and> P' s\<rbrace> m \<lbrace>\<lambda>rv s. P (f s) rv s\<rbrace>"
   apply (clarsimp simp: valid_def)
   apply (rule use_valid [OF _ P], simp)
   apply (rule use_valid [OF _ f], simp, simp)
   done
 
-lemmas hoare_lift_Pf4 = hoare_lift_Pf_pre_conj[where R=\<top>, simplified]
+lemmas hoare_lift_Pf4 = hoare_lift_Pf_pre_conj[where P'=\<top>, simplified]
 lemmas hoare_lift_Pf3 = hoare_lift_Pf4[where f=f and g=f for f]
 lemmas hoare_lift_Pf2 = hoare_lift_Pf3[where P="\<lambda>f _. P f" for P]
 lemmas hoare_lift_Pf = hoare_lift_Pf2[where Q=P and P=P for P]
@@ -85,13 +86,13 @@ lemmas hoare_lift_Pf2_pre_conj = hoare_lift_Pf3_pre_conj[where P="\<lambda>f _. 
 lemmas hoare_lift_Pf_pre_conj' = hoare_lift_Pf2_pre_conj[where Q=P and P=P for P]
 
 lemma hoare_if_r_and:
-  "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>r. if R r then Q r else Q' r\<rbrace>
-   = \<lbrace>P\<rbrace> f \<lbrace>\<lambda>r s. (R r \<longrightarrow> Q r s) \<and> (\<not>R r \<longrightarrow> Q' r s)\<rbrace>"
+  "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>r. if P' r then Q r else Q' r\<rbrace>
+   = \<lbrace>P\<rbrace> f \<lbrace>\<lambda>r s. (P' r \<longrightarrow> Q r s) \<and> (\<not>P' r \<longrightarrow> Q' r s)\<rbrace>"
   by (fastforce simp: valid_def)
 
 lemma hoare_convert_imp:
-  "\<lbrakk> \<lbrace>\<lambda>s. \<not> P s\<rbrace> f \<lbrace>\<lambda>rv s. \<not> Q s\<rbrace>; \<lbrace>R\<rbrace> f \<lbrace>S\<rbrace> \<rbrakk>
-   \<Longrightarrow> \<lbrace>\<lambda>s. P s \<longrightarrow> R s\<rbrace> f \<lbrace>\<lambda>rv s. Q s \<longrightarrow> S rv s\<rbrace>"
+  "\<lbrakk> \<lbrace>\<lambda>s. \<not> P s\<rbrace> f \<lbrace>\<lambda>rv s. \<not> Q s\<rbrace>; \<lbrace>P'\<rbrace> f \<lbrace>S\<rbrace> \<rbrakk>
+   \<Longrightarrow> \<lbrace>\<lambda>s. P s \<longrightarrow> P' s\<rbrace> f \<lbrace>\<lambda>rv s. Q s \<longrightarrow> S rv s\<rbrace>"
   apply (simp only: imp_conv_disj)
   apply (erule(1) hoare_vcg_disj_lift)
   done
@@ -107,12 +108,6 @@ lemma hoare_case_option_wpR:
   "\<lbrakk>\<lbrace>P\<rbrace> f None \<lbrace>Q\<rbrace>,-; \<And>x. \<lbrace>P' x\<rbrace> f (Some x) \<lbrace>Q' x\<rbrace>,-\<rbrakk>
    \<Longrightarrow> \<lbrace>case_option P P' v\<rbrace> f v \<lbrace>\<lambda>rv. case v of None \<Rightarrow> Q rv | Some x \<Rightarrow> Q' x rv\<rbrace>,-"
   by (cases v) auto
-
-lemma hoare_vcg_conj_liftE_R:
-  "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>P'\<rbrace>,-; \<lbrace>Q\<rbrace> f \<lbrace>Q'\<rbrace>,- \<rbrakk> \<Longrightarrow> \<lbrace>P and Q\<rbrace> f \<lbrace>\<lambda>rv s. P' rv s \<and> Q' rv s\<rbrace>, -"
-  apply (simp add: validE_R_def validE_def valid_def split: sum.splits)
-  apply blast
-  done
 
 lemma K_valid[wp]:
   "\<lbrace>K P\<rbrace> f \<lbrace>\<lambda>_. K P\<rbrace>"
@@ -133,18 +128,18 @@ lemma hoare_imp_eq_substR:
   by (fastforce simp add: valid_def validE_R_def validE_def split: sum.splits)
 
 lemma hoare_split_bind_case_sum:
-  assumes x: "\<And>rv. \<lbrace>R rv\<rbrace> g rv \<lbrace>Q\<rbrace>"
-             "\<And>rv. \<lbrace>S rv\<rbrace> h rv \<lbrace>Q\<rbrace>"
-  assumes y: "\<lbrace>P\<rbrace> f \<lbrace>S\<rbrace>,\<lbrace>R\<rbrace>"
+  assumes x: "\<And>rv. \<lbrace>E rv\<rbrace> g rv \<lbrace>Q\<rbrace>"
+             "\<And>rv. \<lbrace>Q' rv\<rbrace> h rv \<lbrace>Q\<rbrace>"
+  assumes y: "\<lbrace>P\<rbrace> f \<lbrace>Q'\<rbrace>,\<lbrace>E\<rbrace>"
   shows      "\<lbrace>P\<rbrace> f >>= case_sum g h \<lbrace>Q\<rbrace>"
   apply (rule bind_wp[OF _ y[unfolded validE_def]])
   apply (wpsimp wp: x split: sum.splits)
   done
 
 lemma hoare_split_bind_case_sumE:
-  assumes x: "\<And>rv. \<lbrace>R rv\<rbrace> g rv \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
-             "\<And>rv. \<lbrace>S rv\<rbrace> h rv \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
-  assumes y: "\<lbrace>P\<rbrace> f \<lbrace>S\<rbrace>,\<lbrace>R\<rbrace>"
+  assumes x: "\<And>rv. \<lbrace>E' rv\<rbrace> g rv \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
+             "\<And>rv. \<lbrace>Q' rv\<rbrace> h rv \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
+  assumes y: "\<lbrace>P\<rbrace> f \<lbrace>Q'\<rbrace>,\<lbrace>E'\<rbrace>"
   shows      "\<lbrace>P\<rbrace> f >>= case_sum g h \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
   apply (unfold validE_def)
   apply (rule bind_wp[OF _ y[unfolded validE_def]])
@@ -159,6 +154,7 @@ lemma throwErrorE_E [wp]:
   "\<lbrace>Q e\<rbrace> throwError e -, \<lbrace>Q\<rbrace>"
   by (simp add: validE_E_def) wp
 
+\<comment> \<open>FIXME: remove these inv rules?\<close>
 lemma gets_inv [simp]:
   "\<lbrace> P \<rbrace> gets f \<lbrace> \<lambda>r. P \<rbrace>"
   by (simp add: gets_def, wp)
@@ -169,11 +165,13 @@ lemma select_inv:
 
 lemmas return_inv = hoare_return_drop_var
 
-lemma assert_inv: "\<lbrace>P\<rbrace> assert Q \<lbrace>\<lambda>r. P\<rbrace>"
+lemma assert_inv:
+  "\<lbrace>P\<rbrace> assert Q \<lbrace>\<lambda>r. P\<rbrace>"
   unfolding assert_def
   by (cases Q) simp+
 
-lemma assert_opt_inv: "\<lbrace>P\<rbrace> assert_opt Q \<lbrace>\<lambda>r. P\<rbrace>"
+lemma assert_opt_inv:
+  "\<lbrace>P\<rbrace> assert_opt Q \<lbrace>\<lambda>r. P\<rbrace>"
   unfolding assert_opt_def
   by (cases Q) simp+
 
@@ -181,7 +179,7 @@ lemma case_options_weak_wp:
   "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>; \<And>x. \<lbrace>P'\<rbrace> g x \<lbrace>Q\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P and P'\<rbrace> case opt of None \<Rightarrow> f | Some x \<Rightarrow> g x \<lbrace>Q\<rbrace>"
   apply (cases opt)
    apply (clarsimp elim!: hoare_weaken_pre)
-  apply (rule hoare_weaken_pre [where Q=P'])
+  apply (rule hoare_weaken_pre[where P'=P'])
    apply simp+
   done
 
@@ -217,19 +215,19 @@ lemma list_cases_weak_wp:
 lemmas hoare_FalseE_R = hoare_FalseE[where E="\<top>\<top>", folded validE_R_def]
 
 lemma hoare_vcg_if_lift2:
-  "\<lbrace>R\<rbrace> f \<lbrace>\<lambda>rv s. (P rv s \<longrightarrow> X rv s) \<and> (\<not> P rv s \<longrightarrow> Y rv s)\<rbrace> \<Longrightarrow>
-   \<lbrace>R\<rbrace> f \<lbrace>\<lambda>rv s. if P rv s then X rv s else Y rv s\<rbrace>"
+  "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. (Q rv s \<longrightarrow> X rv s) \<and> (\<not> Q rv s \<longrightarrow> Y rv s)\<rbrace> \<Longrightarrow>
+   \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. if Q rv s then X rv s else Y rv s\<rbrace>"
 
-  "\<lbrace>R\<rbrace> f \<lbrace>\<lambda>rv s. (P' rv \<longrightarrow> X rv s) \<and> (\<not> P' rv \<longrightarrow> Y rv s)\<rbrace> \<Longrightarrow>
-   \<lbrace>R\<rbrace> f \<lbrace>\<lambda>rv. if P' rv then X rv else Y rv\<rbrace>"
+  "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. (Q' rv \<longrightarrow> X rv s) \<and> (\<not> Q' rv \<longrightarrow> Y rv s)\<rbrace> \<Longrightarrow>
+   \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv. if Q' rv then X rv else Y rv\<rbrace>"
   by (auto simp: valid_def split_def)
 
 lemma hoare_vcg_if_lift_ER: (* Required because of lack of rv in lifting rules *)
-  "\<lbrace>R\<rbrace> f \<lbrace>\<lambda>rv s. (P rv s \<longrightarrow> X rv s) \<and> (\<not> P rv s \<longrightarrow> Y rv s)\<rbrace>, - \<Longrightarrow>
-   \<lbrace>R\<rbrace> f \<lbrace>\<lambda>rv s. if P rv s then X rv s else Y rv s\<rbrace>, -"
+  "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. (Q rv s \<longrightarrow> X rv s) \<and> (\<not> Q rv s \<longrightarrow> Y rv s)\<rbrace>, - \<Longrightarrow>
+   \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. if Q rv s then X rv s else Y rv s\<rbrace>, -"
 
-  "\<lbrace>R\<rbrace> f \<lbrace>\<lambda>rv s. (P' rv \<longrightarrow> X rv s) \<and> (\<not> P' rv \<longrightarrow> Y rv s)\<rbrace>, - \<Longrightarrow>
-   \<lbrace>R\<rbrace> f \<lbrace>\<lambda>rv. if P' rv then X rv else Y rv\<rbrace>, -"
+  "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. (Q' rv \<longrightarrow> X rv s) \<and> (\<not> Q' rv \<longrightarrow> Y rv s)\<rbrace>, - \<Longrightarrow>
+   \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv. if Q' rv then X rv else Y rv\<rbrace>, -"
   by (auto simp: valid_def validE_R_def validE_def split_def)
 
 lemma hoare_list_all_lift:
@@ -361,8 +359,8 @@ lemma valid_return_unit:
   by (auto simp: valid_def in_bind in_return Ball_def)
 
 lemma hoare_weak_lift_imp_conj:
-  "\<lbrakk> \<lbrace>Q\<rbrace> m \<lbrace>Q'\<rbrace>; \<lbrace>R\<rbrace> m \<lbrace>R'\<rbrace> \<rbrakk>
-   \<Longrightarrow> \<lbrace>\<lambda>s. (P \<longrightarrow> Q s) \<and> R s\<rbrace> m \<lbrace>\<lambda>rv s. (P \<longrightarrow> Q' rv s) \<and> R' rv s\<rbrace>"
+  "\<lbrakk> \<lbrace>P'\<rbrace> m \<lbrace>Q'\<rbrace>; \<lbrace>P''\<rbrace> m \<lbrace>Q''\<rbrace> \<rbrakk>
+   \<Longrightarrow> \<lbrace>\<lambda>s. (P \<longrightarrow> P' s) \<and> P'' s\<rbrace> m \<lbrace>\<lambda>rv s. (P \<longrightarrow> Q' rv s) \<and> Q'' rv s\<rbrace>"
   apply (rule hoare_vcg_conj_lift)
    apply (rule hoare_weak_lift_imp)
    apply assumption+
@@ -374,7 +372,7 @@ lemma hoare_eq_P:
   by (rule assms)
 
 lemma hoare_validE_R_conj:
-  "\<lbrakk>\<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>, -; \<lbrace>P\<rbrace> f \<lbrace>R\<rbrace>, -\<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q and R\<rbrace>, -"
+  "\<lbrakk>\<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>, -; \<lbrace>P\<rbrace> f \<lbrace>Q'\<rbrace>, -\<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q and Q'\<rbrace>, -"
   by (simp add: valid_def validE_def validE_R_def Let_def split_def split: sum.splits)
 
 lemmas throwError_validE_R = throwError_wp [where E="\<top>\<top>", folded validE_R_def]
@@ -404,10 +402,6 @@ lemmas fail_inv = hoare_fail_any[where Q="\<lambda>_. P" and P=P for P]
 lemma gets_sp: "\<lbrace>P\<rbrace> gets f \<lbrace>\<lambda>rv. P and (\<lambda>s. f s = rv)\<rbrace>"
   by (wp, simp)
 
-lemma post_by_hoare2:
-  "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>; (r, s') \<in> mres (f s); P s \<rbrakk> \<Longrightarrow> Q r s'"
-  by (rule post_by_hoare, assumption+)
-
 lemma hoare_Ball_helper:
   assumes x: "\<And>x. \<lbrace>P x\<rbrace> f \<lbrace>Q x\<rbrace>"
   assumes y: "\<And>P. \<lbrace>\<lambda>s. P (S s)\<rbrace> f \<lbrace>\<lambda>rv s. P (S s)\<rbrace>"
@@ -421,9 +415,9 @@ lemma hoare_Ball_helper:
 
 lemma handy_prop_divs:
   assumes x: "\<And>P. \<lbrace>\<lambda>s. P (Q s) \<and> S s\<rbrace> f \<lbrace>\<lambda>rv s. P (Q' rv s)\<rbrace>"
-             "\<And>P. \<lbrace>\<lambda>s. P (R s) \<and> S s\<rbrace> f \<lbrace>\<lambda>rv s. P (R' rv s)\<rbrace>"
-  shows      "\<lbrace>\<lambda>s. P (Q s \<and> R s) \<and> S s\<rbrace> f \<lbrace>\<lambda>rv s. P (Q' rv s \<and> R' rv s)\<rbrace>"
-             "\<lbrace>\<lambda>s. P (Q s \<or> R s) \<and> S s\<rbrace> f \<lbrace>\<lambda>rv s. P (Q' rv s \<or> R' rv s)\<rbrace>"
+             "\<And>P. \<lbrace>\<lambda>s. P (T s) \<and> S s\<rbrace> f \<lbrace>\<lambda>rv s. P (T' rv s)\<rbrace>"
+  shows      "\<lbrace>\<lambda>s. P (Q s \<and> T s) \<and> S s\<rbrace> f \<lbrace>\<lambda>rv s. P (Q' rv s \<and> T' rv s)\<rbrace>"
+             "\<lbrace>\<lambda>s. P (Q s \<or> T s) \<and> S s\<rbrace> f \<lbrace>\<lambda>rv s. P (Q' rv s \<or> T' rv s)\<rbrace>"
    apply (clarsimp simp: valid_def
                   elim!: subst[rotated, where P=P])
    apply (rule use_valid [OF _ x(1)], assumption)
@@ -517,36 +511,26 @@ lemma weaker_hoare_ifE:
 lemma wp_split_const_if:
   assumes x: "\<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>"
   assumes y: "\<lbrace>P'\<rbrace> f \<lbrace>Q'\<rbrace>"
-  shows "\<lbrace>\<lambda>s. (G \<longrightarrow> P s) \<and> (\<not> G \<longrightarrow> P' s)\<rbrace> f \<lbrace>\<lambda>rv s. (G \<longrightarrow> Q rv s) \<and> (\<not> G \<longrightarrow> Q' rv s)\<rbrace>"
-  by (cases G, simp_all add: x y)
+  shows "\<lbrace>\<lambda>s. (S \<longrightarrow> P s) \<and> (\<not> S \<longrightarrow> P' s)\<rbrace> f \<lbrace>\<lambda>rv s. (S \<longrightarrow> Q rv s) \<and> (\<not> S \<longrightarrow> Q' rv s)\<rbrace>"
+  by (cases S; simp add: x y)
 
 lemma wp_split_const_if_R:
   assumes x: "\<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,-"
   assumes y: "\<lbrace>P'\<rbrace> f \<lbrace>Q'\<rbrace>,-"
-  shows "\<lbrace>\<lambda>s. (G \<longrightarrow> P s) \<and> (\<not> G \<longrightarrow> P' s)\<rbrace> f \<lbrace>\<lambda>rv s. (G \<longrightarrow> Q rv s) \<and> (\<not> G \<longrightarrow> Q' rv s)\<rbrace>,-"
-  by (cases G, simp_all add: x y)
+  shows "\<lbrace>\<lambda>s. (S \<longrightarrow> P s) \<and> (\<not> S \<longrightarrow> P' s)\<rbrace> f \<lbrace>\<lambda>rv s. (S \<longrightarrow> Q rv s) \<and> (\<not> S \<longrightarrow> Q' rv s)\<rbrace>,-"
+  by (cases S; simp add: x y)
 
 lemma hoare_disj_division:
-  "\<lbrakk> P \<or> Q; P \<Longrightarrow> \<lbrace>R\<rbrace> f \<lbrace>S\<rbrace>; Q \<Longrightarrow> \<lbrace>T\<rbrace> f \<lbrace>S\<rbrace> \<rbrakk>
-   \<Longrightarrow> \<lbrace>\<lambda>s. (P \<longrightarrow> R s) \<and> (Q \<longrightarrow> T s)\<rbrace> f \<lbrace>S\<rbrace>"
-  apply safe
-   apply (rule hoare_pre_imp)
-    prefer 2
-    apply simp
-   apply simp
-  apply (rule hoare_pre_imp)
-   prefer 2
-   apply simp
-  apply simp
-  done
+  "\<lbrakk> P \<or> P'; P \<Longrightarrow> \<lbrace>S\<rbrace> f \<lbrace>Q\<rbrace>; P' \<Longrightarrow> \<lbrace>T\<rbrace> f \<lbrace>Q\<rbrace> \<rbrakk>
+   \<Longrightarrow> \<lbrace>\<lambda>s. (P \<longrightarrow> S s) \<and> (P' \<longrightarrow> T s)\<rbrace> f \<lbrace>Q\<rbrace>"
+  by (fastforce intro: hoare_weaken_pre)
 
 lemma hoare_grab_asm:
-  "\<lbrakk> G \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s. G \<and> P s\<rbrace> f \<lbrace>Q\<rbrace>"
-  by (cases G, simp+)
+  "\<lbrakk> P' \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s. P' \<and> P s\<rbrace> f \<lbrace>Q\<rbrace>"
+  by (cases P', simp+)
 
 lemma hoare_grab_asm2:
-  "\<lbrakk>P' \<Longrightarrow> \<lbrace>\<lambda>s. P s \<and> R s\<rbrace> f \<lbrace>Q\<rbrace>\<rbrakk>
-   \<Longrightarrow> \<lbrace>\<lambda>s. P s \<and> P' \<and> R s\<rbrace> f \<lbrace>Q\<rbrace>"
+  "\<lbrakk>P' \<Longrightarrow> \<lbrace>\<lambda>s. P s \<and> P'' s\<rbrace> f \<lbrace>Q\<rbrace>\<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s. P s \<and> P' \<and> P'' s\<rbrace> f \<lbrace>Q\<rbrace>"
   by (fastforce simp: valid_def)
 
 lemma hoare_grab_exs:
@@ -559,15 +543,6 @@ lemma hoare_grab_exs:
 lemma hoare_prop_E: "\<lbrace>\<lambda>rv. P\<rbrace> f -,\<lbrace>\<lambda>rv s. P\<rbrace>"
   unfolding validE_E_def
   by (rule hoare_pre, wp, simp)
-
-lemma hoare_vcg_conj_lift_R:
-  "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,-; \<lbrace>R\<rbrace> f \<lbrace>S\<rbrace>,- \<rbrakk>
-   \<Longrightarrow> \<lbrace>\<lambda>s. P s \<and> R s\<rbrace> f \<lbrace>\<lambda>rv s. Q rv s \<and> S rv s\<rbrace>,-"
-  apply (simp add: validE_R_def validE_def)
-  apply (drule(1) hoare_vcg_conj_lift)
-  apply (erule hoare_strengthen_post)
-  apply (clarsimp split: sum.splits)
-  done
 
 lemma hoare_walk_assmsE:
   assumes x: "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv. P\<rbrace>" and y: "\<And>s. P s \<Longrightarrow> Q s" and z: "\<lbrace>P\<rbrace> g \<lbrace>\<lambda>rv. Q\<rbrace>"
@@ -622,8 +597,8 @@ lemma weak_if_wp':
   by (auto simp add: valid_def split_def)
 
 lemma bindE_split_recursive_asm:
-  assumes x: "\<And>x s'. \<lbrakk> (Inr x, s') \<in> mres (f s) \<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s. B x s \<and> s = s'\<rbrace> g x \<lbrace>C\<rbrace>, \<lbrace>E\<rbrace>"
-  shows      "\<lbrace>A\<rbrace> f \<lbrace>B\<rbrace>, \<lbrace>E\<rbrace> \<Longrightarrow> \<lbrace>\<lambda>st. A st \<and> st = s\<rbrace> f >>=E g \<lbrace>C\<rbrace>, \<lbrace>E\<rbrace>"
+  assumes x: "\<And>x s'. \<lbrakk> (Inr x, s') \<in> mres (f s) \<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s. Q' x s \<and> s = s'\<rbrace> g x \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
+  shows      "\<lbrace>P\<rbrace> f \<lbrace>Q'\<rbrace>, \<lbrace>E\<rbrace> \<Longrightarrow> \<lbrace>\<lambda>st. P st \<and> st = s\<rbrace> f >>=E g \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
   apply (clarsimp simp: validE_def valid_def bindE_def in_bind lift_def)
   apply (erule allE, erule(1) impE)
   apply (drule(1) bspec, simp)
@@ -708,23 +683,23 @@ lemma valid_pre_satisfies_post:
   by (clarsimp simp: valid_def)
 
 lemma validE_pre_satisfies_post:
-  "\<lbrakk> \<And>s r' s'. P s \<Longrightarrow> Q r' s'; \<And>s r' s'. P s \<Longrightarrow> R r' s' \<rbrakk> \<Longrightarrow> \<lbrace> P \<rbrace> m \<lbrace> Q \<rbrace>,\<lbrace> R \<rbrace>"
+  "\<lbrakk> \<And>s r' s'. P s \<Longrightarrow> Q r' s'; \<And>s r' s'. P s \<Longrightarrow> E r' s' \<rbrakk> \<Longrightarrow> \<lbrace> P \<rbrace> m \<lbrace> Q \<rbrace>,\<lbrace> E \<rbrace>"
   by (clarsimp simp: validE_def2 split: sum.splits)
 
 lemma hoare_validE_R_conjI:
   "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>, - ; \<lbrace>P\<rbrace> f \<lbrace>Q'\<rbrace>, - \<rbrakk>  \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. Q rv s \<and> Q' rv s\<rbrace>, -"
-  by (fastforce simp: Ball_def validE_R_def validE_def valid_def split: sum.splits)
+  by (clarsimp simp: Ball_def validE_R_def validE_def valid_def split: sum.splits)
 
 lemma hoare_validE_E_conjI:
   "\<lbrakk> \<lbrace>P\<rbrace> f -, \<lbrace>Q\<rbrace> ; \<lbrace>P\<rbrace> f -, \<lbrace>Q'\<rbrace> \<rbrakk>  \<Longrightarrow> \<lbrace>P\<rbrace> f -, \<lbrace>\<lambda>rv s. Q rv s \<and> Q' rv s\<rbrace>"
-  by (fastforce simp: Ball_def validE_E_def validE_def valid_def split: sum.splits)
+  by (clarsimp simp: Ball_def validE_E_def validE_def valid_def split: sum.splits)
 
 lemma validE_R_post_conjD1:
-  "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>r s. Q r s \<and> R r s\<rbrace>,- \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,-"
+  "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>r s. Q r s \<and> Q' r s\<rbrace>,- \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,-"
   by (fastforce simp: validE_R_def validE_def valid_def split: sum.splits)
 
 lemma validE_R_post_conjD2:
-  "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>r s. Q r s \<and> R r s\<rbrace>,- \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>R\<rbrace>,-"
+  "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>r s. Q r s \<and> Q' r s\<rbrace>,- \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q'\<rbrace>,-"
   by (fastforce simp: validE_R_def validE_def valid_def split: sum.splits)
 
 lemma throw_opt_wp[wp]:
@@ -735,10 +710,12 @@ lemma hoare_name_pre_state2:
   "(\<And>s. \<lbrace>P and ((=) s)\<rbrace> f \<lbrace>Q\<rbrace>) \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>"
   by (auto simp: valid_def intro: hoare_name_pre_state)
 
-lemma returnOk_E': "\<lbrace>P\<rbrace> returnOk r -,\<lbrace>E\<rbrace>"
+lemma returnOk_E':
+  "\<lbrace>P\<rbrace> returnOk r -,\<lbrace>E\<rbrace>"
   by wpsimp
 
-lemma throwError_R': "\<lbrace>P\<rbrace> throwError e \<lbrace>Q\<rbrace>,-"
+lemma throwError_R':
+  "\<lbrace>P\<rbrace> throwError e \<lbrace>Q\<rbrace>,-"
   by wpsimp
 
 end

--- a/lib/Monads/trace/Trace_More_VCG.thy
+++ b/lib/Monads/trace/Trace_More_VCG.thy
@@ -154,7 +154,6 @@ lemma throwErrorE_E [wp]:
   "\<lbrace>Q e\<rbrace> throwError e -, \<lbrace>Q\<rbrace>"
   by (simp add: validE_E_def) wp
 
-\<comment> \<open>FIXME: remove these inv rules?\<close>
 lemma gets_inv [simp]:
   "\<lbrace> P \<rbrace> gets f \<lbrace> \<lambda>r. P \<rbrace>"
   by (simp add: gets_def, wp)
@@ -162,8 +161,6 @@ lemma gets_inv [simp]:
 lemma select_inv:
   "\<lbrace> P \<rbrace> select S \<lbrace> \<lambda>r. P \<rbrace>"
   by wpsimp
-
-lemmas return_inv = hoare_return_drop_var
 
 lemma assert_inv:
   "\<lbrace>P\<rbrace> assert Q \<lbrace>\<lambda>r. P\<rbrace>"

--- a/lib/Monads/trace/Trace_RG.thy
+++ b/lib/Monads/trace/Trace_RG.thy
@@ -363,8 +363,7 @@ lemma rg_FalseE[simp]:
   by (simp add: validI_def validIE_def)
 
 lemma rg_post_imp:
-  "\<lbrakk>\<And>v s0 s. Q' v s0 s \<Longrightarrow> Q v s0 s; \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q'\<rbrace>\<rbrakk>
-   \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
+  "\<lbrakk>\<And>v s0 s. Q' v s0 s \<Longrightarrow> Q v s0 s; \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q'\<rbrace>\<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
   by (simp add: validI_def)
 
 lemma rg_post_impE:
@@ -375,16 +374,24 @@ lemma rg_post_impE:
 lemmas rg_strengthen_post = rg_post_imp[rotated]
 lemmas rg_strengthen_postE = rg_post_impE[rotated 2]
 
-lemma rg_post_imp_dc:
-  "\<lbrakk>\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> a \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_. Q'\<rbrace>; \<And>s0 s. Q' s0 s \<Longrightarrow> Q s0 s\<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> a \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_. Q\<rbrace>,\<lbrace>\<lambda>_. Q\<rbrace>"
+lemma rg_strengthen_postE_R:
+  "\<lbrakk> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q'\<rbrace>,-; \<And>rv s0 s. Q' rv s0 s \<Longrightarrow> Q rv s0 s \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,-"
+  by (erule rg_post_impE)
+
+lemma rg_strengthen_postE_E:
+  "\<lbrakk> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,-,\<lbrace>E'\<rbrace>; \<And>rv s0 s. E' rv s0 s \<Longrightarrow> E rv s0 s \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,-,\<lbrace>E\<rbrace>"
+  by (rule rg_post_impE)
+
+lemma rg_post_impE_dc:
+  "\<lbrakk>\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_. Q'\<rbrace>; \<And>s0 s. Q' s0 s \<Longrightarrow> Q s0 s\<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_. Q\<rbrace>,\<lbrace>\<lambda>_. Q\<rbrace>"
   by (fastforce simp: validIE_def validI_def split: sum.splits)
 
-lemma rg_post_imp_dc2:
-  "\<lbrakk>\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> a \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_. Q'\<rbrace>; \<And>s0 s. Q' s0 s \<Longrightarrow> Q s0 s\<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> a \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_. Q\<rbrace>,-"
+lemma rg_post_impE_R_dc:
+  "\<lbrakk>\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_. Q'\<rbrace>; \<And>s0 s. Q' s0 s \<Longrightarrow> Q s0 s\<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_. Q\<rbrace>,-"
   by (fastforce simp: validIE_def validI_def split: sum.splits)
 
-lemma rg_post_imp_dc2E:
-  "\<lbrakk>\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> a \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_. Q'\<rbrace>; \<And>s0 s. Q' s0 s \<Longrightarrow> Q s0 s\<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> a \<lbrace>G\<rbrace>,-,\<lbrace>\<lambda>_. Q\<rbrace>"
+lemma rg_post_impE_E_dc:
+  "\<lbrakk>\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_. Q'\<rbrace>; \<And>s0 s. Q' s0 s \<Longrightarrow> Q s0 s\<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,-,\<lbrace>\<lambda>_. Q\<rbrace>"
   by (fastforce simp: validIE_def validI_def split: sum.splits)
 
 lemma rg_guar_imp:
@@ -778,7 +785,7 @@ subsection \<open>@{const validI} and @{const validIE}, @{const validIE_R}, @{co
 
 lemma validI_validIE:
   "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_. Q\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_. Q\<rbrace>,\<lbrace>\<lambda>_. Q\<rbrace>"
-  by (rule rg_post_imp_dc)
+  by (rule rg_post_impE_dc)
 
 lemma validI_validIE2:
   "\<lbrakk>\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_. Q'\<rbrace>; \<And>s0 s. Q' s0 s \<Longrightarrow> Q s0 s; \<And>s0 s. Q' s0 s \<Longrightarrow> E s0 s\<rbrakk>
@@ -793,11 +800,11 @@ lemma validIE_validI:
 
 lemma validI_validIE_R:
   "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_. Q\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_. Q\<rbrace>,-"
-  by (rule rg_post_imp_dc2)
+  by (rule rg_post_impE_R_dc)
 
 lemma validI_validIE_E:
   "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>_. Q\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,-,\<lbrace>\<lambda>_. Q\<rbrace>"
-  by (rule rg_post_imp_dc2E)
+  by (rule rg_post_impE_E_dc)
 
 lemma validIE_eq_validI:
   "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv. Q\<rbrace>,\<lbrace>\<lambda>rv. Q\<rbrace> = \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv. Q\<rbrace>"
@@ -875,8 +882,8 @@ lemma bindE_twp_nobind:
 lemmas bind_twp_skip = bind_twp[where Q=Q and Q'=Q for Q]
 
 lemma rg_chain:
-  "\<lbrakk>\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>; \<And>s0 s. P' s0 s \<Longrightarrow> P s0 s; \<And>rv s0 s. Q rv s0 s \<Longrightarrow> S rv s0 s\<rbrakk>
-   \<Longrightarrow> \<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>S\<rbrace>"
+  "\<lbrakk>\<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q'\<rbrace>; \<And>s0 s. P s0 s \<Longrightarrow> P' s0 s; \<And>rv s0 s. Q' rv s0 s \<Longrightarrow> Q rv s0 s\<rbrakk>
+   \<Longrightarrow> \<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>"
   by (wp_pre, rule rg_post_imp)
 
 lemma rg_chainE:
@@ -1005,7 +1012,7 @@ lemma rg_absorb_imp:
   by (erule rg_post_imp[rotated], blast)
 
 lemma rg_weaken_imp:
-  "\<lbrakk>\<And>rv s0 s. Q rv s0 s \<Longrightarrow> Q' rv s0 s ;  \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. Q' rv s0 s \<longrightarrow> S rv s0 s\<rbrace>\<rbrakk>
+  "\<lbrakk>\<And>rv s0 s. Q rv s0 s \<Longrightarrow> Q' rv s0 s ; \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. Q' rv s0 s \<longrightarrow> S rv s0 s\<rbrace>\<rbrakk>
    \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. Q rv s0 s \<longrightarrow> S rv s0 s\<rbrace>"
   by (clarsimp simp: validI_def split_def)
 
@@ -1099,23 +1106,15 @@ lemma rg_trivE:   "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>
 lemma rg_trivE_R: "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,- \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,-" .
 lemma rg_trivR_R: "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,-,\<lbrace>E\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,-,\<lbrace>E\<rbrace>" .
 
-lemma rg_vcg_E_conj:
+lemma rg_vcg_conj_liftE_E:
   "\<lbrakk>\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,-,\<lbrace>E\<rbrace>; \<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E'\<rbrace>\<rbrakk>
    \<Longrightarrow> \<lbrace>\<lambda>s0 s. P s0 s \<and> P' s0 s\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>\<lambda>rv s0 s. E rv s0 s \<and> E' rv s0 s\<rbrace>"
   unfolding validIE_def
   by (rule rg_post_imp[OF _ rg_vcg_conj_lift]; simp split: sum.splits)
 
-lemma rg_vcg_E_elim:
+lemma rg_vcg_conj_elimE:
   "\<lbrakk>\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,-,\<lbrace>E\<rbrace>; \<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,-\<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s0 s. P s0 s \<and> P' s0 s\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
-  by (rule rg_strengthen_postE[OF rg_vcg_E_conj]) simp+
-
-lemma rg_strengthen_post_R:
-  "\<lbrakk> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q'\<rbrace>,-; \<And>rv s0 s. Q' rv s0 s \<Longrightarrow> Q rv s0 s \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,-"
-  by (erule rg_post_impE)
-
-lemma rg_strengthen_post_E:
-  "\<lbrakk> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,-,\<lbrace>Q'\<rbrace>; \<And>rv s0 s. Q' rv s0 s \<Longrightarrow> Q rv s0 s \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,-,\<lbrace>Q\<rbrace>"
-  by (rule rg_post_impE)
+  by (rule rg_strengthen_postE[OF rg_vcg_conj_liftE_E]) simp+
 
 lemma rg_post_comb_imp_conj:
   "\<lbrakk>\<lbrace>P'\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>; \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q'\<rbrace>; \<And>s0 s. P s0 s \<Longrightarrow> P' s0 s\<rbrakk>
@@ -1123,11 +1122,11 @@ lemma rg_post_comb_imp_conj:
   by (wpsimp wp: rg_vcg_conj_lift)
 
 lemma rg_vcg_if_lift:
-  "\<lbrace>R\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. (P \<longrightarrow> X rv s0 s) \<and> (\<not>P \<longrightarrow> Y rv s0 s)\<rbrace> \<Longrightarrow>
-   \<lbrace>R\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. if P then X rv s0 s else Y rv s0 s\<rbrace>"
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. (P' \<longrightarrow> X rv s0 s) \<and> (\<not>P' \<longrightarrow> Y rv s0 s)\<rbrace> \<Longrightarrow>
+   \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. if P' then X rv s0 s else Y rv s0 s\<rbrace>"
 
-  "\<lbrace>R\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. (P \<longrightarrow> X rv s0 s) \<and> (\<not>P \<longrightarrow> Y rv s0 s)\<rbrace> \<Longrightarrow>
-   \<lbrace>R\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv. if P then X rv else Y rv\<rbrace>"
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. (P' \<longrightarrow> X rv s0 s) \<and> (\<not>P' \<longrightarrow> Y rv s0 s)\<rbrace> \<Longrightarrow>
+   \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv. if P' then X rv else Y rv\<rbrace>"
   by (auto simp: validI_def split_def)
 
 lemma rg_vcg_split_lift[wp]:
@@ -1398,12 +1397,12 @@ lemmas rg_wp_combs = rg_vcg_conj_lift
 lemmas rg_wp_combsE =
   rg_vcg_conj_liftE1
   rg_vcg_conj_liftE2
-  rg_vcg_E_elim
+  rg_vcg_conj_elimE
 
 lemmas rg_wp_state_combsE =
   validI_validIE_R
   rg_vcg_conj_liftE1[OF validI_validIE_R]
-  rg_vcg_E_elim[OF validI_validIE_E]
+  rg_vcg_conj_elimE[OF validI_validIE_E]
   rg_vcg_conj_liftE2[OF validI_validIE_E]
 
 lemmas rg_classic_wp_combs = rg_post_comb_imp_conj rg_weaken_pre rg_wp_combs
@@ -1578,11 +1577,13 @@ lemma rg_drop_imp:
   by (auto simp: validI_def)
 
 lemma rg_drop_impE:
-  "\<lbrakk>\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>r. Q\<rbrace>, \<lbrace>E\<rbrace>\<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. Q' rv s0 s \<longrightarrow> Q s0 s\<rbrace>, \<lbrace>E\<rbrace>"
+  "\<lbrakk>\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>, \<lbrace>E\<rbrace>\<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>\<lambda>rv s0 s. Q' rv s0 s \<longrightarrow> Q rv s0 s\<rbrace>, \<lbrace>E\<rbrace>"
   by (simp add: rg_chainE)
 
+(*Q is used instead of E so that hoare_drop_imps can be instantiated, which requires that all of its
+  thms have the same variables.*)
 lemma rg_drop_impE_E:
-  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q\<rbrace>, \<lbrace>\<lambda>rv s0 s. E' rv s0 s \<longrightarrow> E rv s0 s\<rbrace>"
+  "\<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q''\<rbrace>,\<lbrace>Q\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace>,\<lbrace>R\<rbrace> f \<lbrace>G\<rbrace>,\<lbrace>Q''\<rbrace>, \<lbrace>\<lambda>rv s0 s. Q' rv s0 s \<longrightarrow> Q rv s0 s\<rbrace>"
   by (auto simp: validIE_def validI_def split: sum.splits)
 
 lemmas rg_drop_imps = rg_drop_imp rg_drop_impE rg_drop_impE_E

--- a/lib/Monads/trace/Trace_VCG.thy
+++ b/lib/Monads/trace/Trace_VCG.thy
@@ -87,16 +87,16 @@ lemma validE_make_schematic_post:
 section \<open>Pre Lemmas\<close>
 
 lemma hoare_pre_imp:
-  "\<lbrakk> \<And>s. P s \<Longrightarrow> Q s; \<lbrace>Q\<rbrace> a \<lbrace>R\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> a \<lbrace>R\<rbrace>"
+  "\<lbrakk> \<And>s. P s \<Longrightarrow> P' s; \<lbrace>P'\<rbrace> f \<lbrace>Q\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>"
   by (fastforce simp: valid_def)
 
 lemmas hoare_weaken_pre = hoare_pre_imp[rotated]
 
 lemma hoare_weaken_preE:
-  "\<lbrakk> \<lbrace>Q\<rbrace> f \<lbrace>R\<rbrace>,\<lbrace>E\<rbrace>; \<And>s. P s \<Longrightarrow> Q s \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>R\<rbrace>,\<lbrace>E\<rbrace>"
+  "\<lbrakk> \<lbrace>P'\<rbrace> f \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>; \<And>s. P s \<Longrightarrow> P' s \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
   by (fastforce simp: validE_def2)
 
-lemma hoare_weaken_preE_R: (* FIXME lib: rename to hoare_weaken_preE_R *)
+lemma hoare_weaken_preE_R:
   "\<lbrakk> \<lbrace>P'\<rbrace> f \<lbrace>Q\<rbrace>,-; \<And>s. P s \<Longrightarrow> P' s \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,-"
   unfolding validE_R_def
   by (rule hoare_weaken_preE)
@@ -130,7 +130,6 @@ lemma wpc_helper_validR_R:
   "\<lbrace>Q\<rbrace> f -,\<lbrace>E\<rbrace> \<Longrightarrow> wpc_helper (P, P', P'') (Q, Q', Q'') \<lbrace>P\<rbrace> f -,\<lbrace>E\<rbrace>"
   by (clarsimp simp: wpc_helper_def elim!: hoare_pre)
 
-
 wpc_setup "\<lambda>m. \<lbrace>P\<rbrace> m \<lbrace>Q\<rbrace>" wpc_helper_valid
 wpc_setup "\<lambda>m. \<lbrace>P\<rbrace> m \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>" wpc_helper_validE
 wpc_setup "\<lambda>m. \<lbrace>P\<rbrace> m \<lbrace>Q\<rbrace>,-" wpc_helper_validE_R
@@ -140,21 +139,21 @@ wpc_setup "\<lambda>m. \<lbrace>P\<rbrace> m -,\<lbrace>E\<rbrace>" wpc_helper_v
 subsection "Hoare Logic Rules"
 
 lemma bind_wp[wp_split]:
-  "\<lbrakk> \<And>r. \<lbrace>Q' r\<rbrace> g r \<lbrace>Q\<rbrace>; \<lbrace>P\<rbrace> f \<lbrace>Q'\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f >>= (\<lambda>rv. g rv) \<lbrace>Q\<rbrace>"
+  "\<lbrakk>\<And>rv. \<lbrace>Q' rv\<rbrace> g rv \<lbrace>Q\<rbrace>; \<lbrace>P\<rbrace> f \<lbrace>Q'\<rbrace>\<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f >>= (\<lambda>rv. g rv) \<lbrace>Q\<rbrace>"
   by (fastforce simp: valid_def bind_def' mres_def intro: image_eqI[rotated])
 
 lemma bindE_wp[wp_split]:
-  "\<lbrakk> \<And>r. \<lbrace>Q' r\<rbrace> g r \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>; \<lbrace>P\<rbrace> f \<lbrace>Q'\<rbrace>,\<lbrace>E\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f >>=E (\<lambda>rv. g rv) \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
+  "\<lbrakk>\<And>rv. \<lbrace>Q' rv\<rbrace> g rv \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>; \<lbrace>P\<rbrace> f \<lbrace>Q'\<rbrace>,\<lbrace>E\<rbrace>\<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f >>=E (\<lambda>rv. g rv) \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
   by (fastforce simp: validE_def2 bindE_def bind_def throwError_def return_def lift_def mres_def image_def
                split: sum.splits tmres.splits)
 
 lemma bindE_R_wp:
-  "\<lbrakk>\<And>r. \<lbrace>Q' r\<rbrace> g r \<lbrace>Q\<rbrace>,-; \<lbrace>P\<rbrace> f \<lbrace>Q'\<rbrace>,-\<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f >>=E (\<lambda>rv. g rv) \<lbrace>Q\<rbrace>,-"
+  "\<lbrakk>\<And>rv. \<lbrace>Q' rv\<rbrace> g rv \<lbrace>Q\<rbrace>,-; \<lbrace>P\<rbrace> f \<lbrace>Q'\<rbrace>,-\<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f >>=E (\<lambda>rv. g rv) \<lbrace>Q\<rbrace>,-"
   apply (clarsimp simp: validE_R_def)
   by (wp | assumption)+
 
 lemma bindE_E_wp:
-  "\<lbrakk>\<And>r. \<lbrace>Q' r\<rbrace> g r -,\<lbrace>E\<rbrace>; \<lbrace>P\<rbrace> f \<lbrace>Q'\<rbrace>,\<lbrace>E\<rbrace>\<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f >>=E (\<lambda>rv. g rv) -,\<lbrace>E\<rbrace>"
+  "\<lbrakk>\<And>rv. \<lbrace>Q' rv\<rbrace> g rv -,\<lbrace>E\<rbrace>; \<lbrace>P\<rbrace> f \<lbrace>Q'\<rbrace>,\<lbrace>E\<rbrace>\<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f >>=E (\<lambda>rv. g rv) -,\<lbrace>E\<rbrace>"
   apply (clarsimp simp: validE_E_def)
   by (wp | assumption)+
 
@@ -162,17 +161,17 @@ lemmas bind_wp_fwd = bind_wp[rotated]
 lemmas bindE_wp_fwd = bindE_wp[rotated]
 
 lemma bind_wpE_R:
-  "\<lbrakk>\<And>x. \<lbrace>Q' x\<rbrace> g x \<lbrace>Q\<rbrace>,-; \<lbrace>P\<rbrace> f \<lbrace>Q'\<rbrace>\<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f >>= g \<lbrace>Q\<rbrace>,-"
+  "\<lbrakk>\<And>rv. \<lbrace>Q' rv\<rbrace> g rv \<lbrace>Q\<rbrace>,-; \<lbrace>P\<rbrace> f \<lbrace>Q'\<rbrace>\<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f >>= (\<lambda>rv. g rv) \<lbrace>Q\<rbrace>,-"
   apply (clarsimp simp: validE_R_def validE_def)
   by (wp | assumption)+
 
 lemma bind_wpE_E:
-  "\<lbrakk>\<And>x. \<lbrace>Q' x\<rbrace> g x -,\<lbrace>E\<rbrace>; \<lbrace>P\<rbrace> f \<lbrace>Q'\<rbrace>\<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f >>= g -,\<lbrace>E\<rbrace>"
+  "\<lbrakk>\<And>rv. \<lbrace>Q' rv\<rbrace> g rv -,\<lbrace>E\<rbrace>; \<lbrace>P\<rbrace> f \<lbrace>Q'\<rbrace>\<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f >>= (\<lambda>rv. g rv) -,\<lbrace>E\<rbrace>"
   apply (clarsimp simp: validE_E_def validE_def)
   by (wp | assumption)+
 
 lemma bind_wpE:
-  "\<lbrakk>\<And>x. \<lbrace>Q' x\<rbrace> g x \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>; \<lbrace>P\<rbrace> f \<lbrace>Q'\<rbrace>\<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f >>= g \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
+  "\<lbrakk>\<And>rv. \<lbrace>Q' rv\<rbrace> g rv \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>; \<lbrace>P\<rbrace> f \<lbrace>Q'\<rbrace>\<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f >>= (\<lambda>rv. g rv) \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
   apply (clarsimp simp: validE_def)
   by (wp | assumption)+
 
@@ -199,11 +198,11 @@ lemmas wp_post_tautE_E = hoareE_E_TrueI[where P=\<top>]
 lemmas wp_post_tauts[intro] = wp_post_taut wp_post_tautE wp_post_tautE_R wp_post_tautE_E
 
 lemma hoare_post_conj[intro]:
-  "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>; \<lbrace>P\<rbrace> f \<lbrace>R\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q and R\<rbrace>"
+  "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>; \<lbrace>P\<rbrace> f \<lbrace>Q'\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q and Q'\<rbrace>"
   by (fastforce simp: valid_def)
 
 lemma hoare_pre_disj[intro]:
-  "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>R\<rbrace>; \<lbrace>Q\<rbrace> f \<lbrace>R\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P or Q\<rbrace> f \<lbrace>R\<rbrace>"
+  "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>; \<lbrace>P'\<rbrace> f \<lbrace>Q\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P or P'\<rbrace> f \<lbrace>Q\<rbrace>"
   by (simp add:valid_def pred_disj_def)
 
 lemma hoare_conj:
@@ -215,7 +214,7 @@ lemma hoare_pre_cont[simp]:
   by (simp add:valid_def)
 
 lemma hoare_FalseE[simp]:
-  "\<lbrace>\<bottom>\<rbrace> f \<lbrace>Q\<rbrace>, \<lbrace>E\<rbrace>"
+  "\<lbrace>\<bottom>\<rbrace> f \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
   by (simp add: valid_def validE_def)
 
 lemma hoare_return_drop_var[iff]:
@@ -231,23 +230,23 @@ lemma hoare_modifyE_var:
   by(simp add: valid_def modify_def put_def get_def bind_def mres_def)
 
 lemma hoare_if:
-  "\<lbrakk> P \<Longrightarrow> \<lbrace>Q\<rbrace> a \<lbrace>R\<rbrace>; \<not> P \<Longrightarrow> \<lbrace>Q\<rbrace> b \<lbrace>R\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>Q\<rbrace> if P then a else b \<lbrace>R\<rbrace>"
+  "\<lbrakk> P' \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>; \<not> P' \<Longrightarrow> \<lbrace>P\<rbrace> g \<lbrace>Q\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> if P' then f else g \<lbrace>Q\<rbrace>"
   by (simp add: valid_def)
 
 lemma hoare_pre_subst:
-  "\<lbrakk> A = B; \<lbrace>A\<rbrace> a \<lbrace>C\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>B\<rbrace> a \<lbrace>C\<rbrace>"
+  "\<lbrakk> P = P'; \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P'\<rbrace> f \<lbrace>Q\<rbrace>"
   by (erule subst)
 
 lemma hoare_post_subst:
-  "\<lbrakk> B = C; \<lbrace>A\<rbrace> a \<lbrace>B\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>A\<rbrace> a \<lbrace>C\<rbrace>"
+  "\<lbrakk> Q = Q'; \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q'\<rbrace>"
   by (erule subst)
 
 lemma hoare_post_imp:
-  "\<lbrakk> \<And>rv s. Q rv s \<Longrightarrow> R rv s; \<lbrace>P\<rbrace> a \<lbrace>Q\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> a \<lbrace>R\<rbrace>"
+  "\<lbrakk> \<And>rv s. Q' rv s \<Longrightarrow> Q rv s; \<lbrace>P\<rbrace> f \<lbrace>Q'\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>"
   by(fastforce simp:valid_def split_def)
 
 lemma hoare_post_impE:
-  "\<lbrakk> \<And>rv s. Q rv s \<Longrightarrow> R rv s; \<And>e s. E e s \<Longrightarrow> F e s; \<lbrace>P\<rbrace> a \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> a \<lbrace>R\<rbrace>,\<lbrace>F\<rbrace>"
+  "\<lbrakk> \<And>rv s. Q' rv s \<Longrightarrow> Q rv s; \<And>e s. E' e s \<Longrightarrow> E e s; \<lbrace>P\<rbrace> f \<lbrace>Q'\<rbrace>,\<lbrace>E'\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
   by(fastforce simp: validE_def2 split: sum.splits)
 
 lemmas hoare_strengthen_post = hoare_post_imp[rotated]
@@ -259,48 +258,48 @@ lemma hoare_strengthen_postE_R:
   by (erule hoare_post_impE)
 
 lemma hoare_strengthen_postE_E:
-  "\<lbrakk> \<lbrace>P\<rbrace> f -,\<lbrace>Q'\<rbrace>; \<And>rv s. Q' rv s \<Longrightarrow> Q rv s \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f -,\<lbrace>Q\<rbrace>"
+  "\<lbrakk> \<lbrace>P\<rbrace> f -,\<lbrace>E'\<rbrace>; \<And>rv s. E' rv s \<Longrightarrow> E rv s \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f -,\<lbrace>E\<rbrace>"
   unfolding validE_E_def
   by (rule hoare_post_impE)
 
 lemma hoare_validE_cases:
-  "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>, \<lbrace>\<lambda>_ _. True\<rbrace>; \<lbrace>P\<rbrace> f \<lbrace>\<lambda>_ _. True\<rbrace>, \<lbrace>R\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>, \<lbrace>R\<rbrace>"
+  "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,\<lbrace>\<lambda>_ _. True\<rbrace>; \<lbrace>P\<rbrace> f \<lbrace>\<lambda>_ _. True\<rbrace>,\<lbrace>E\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
   by (fastforce simp: validE_def valid_def split: sum.splits)
 
-lemma hoare_post_imp_dc:
-  "\<lbrakk>\<lbrace>P\<rbrace> a \<lbrace>\<lambda>_. Q\<rbrace>; \<And>s. Q s \<Longrightarrow> R s\<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> a \<lbrace>\<lambda>_. R\<rbrace>, \<lbrace>\<lambda>_. R\<rbrace>"
+lemma hoare_post_impE_dc:
+  "\<lbrakk>\<lbrace>P\<rbrace> f \<lbrace>\<lambda>_. Q'\<rbrace>; \<And>s. Q' s \<Longrightarrow> Q s\<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>_. Q\<rbrace>, \<lbrace>\<lambda>_. Q\<rbrace>"
   by (fastforce simp: validE_def valid_def split: sum.splits)
 
-lemma hoare_post_imp_dc2:
-  "\<lbrakk>\<lbrace>P\<rbrace> a \<lbrace>\<lambda>_. Q\<rbrace>; \<And>s. Q s \<Longrightarrow> R s\<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> a \<lbrace>\<lambda>_. R\<rbrace>, \<lbrace>\<lambda>_. \<top>\<rbrace>"
+lemma hoare_post_impE_R_dc:
+  "\<lbrakk>\<lbrace>P\<rbrace> f \<lbrace>\<lambda>_. Q'\<rbrace>; \<And>s. Q' s \<Longrightarrow> Q s\<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>_. Q\<rbrace>, \<lbrace>\<lambda>_. \<top>\<rbrace>"
   by (fastforce simp: validE_def valid_def split: sum.splits)
 
-lemma hoare_post_imp_dc2E:
-  "\<lbrakk>\<lbrace>P\<rbrace> a \<lbrace>\<lambda>_. Q\<rbrace>; \<And>s. Q s \<Longrightarrow> R s\<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> a \<lbrace>\<lambda>_. \<top>\<rbrace>, \<lbrace>\<lambda>_. R\<rbrace>"
+lemma hoare_post_impE_E_dc:
+  "\<lbrakk>\<lbrace>P\<rbrace> f \<lbrace>\<lambda>_. Q'\<rbrace>; \<And>s. Q' s \<Longrightarrow> Q s\<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>_. \<top>\<rbrace>, \<lbrace>\<lambda>_. Q\<rbrace>"
   by (fastforce simp: validE_def valid_def split: sum.splits)
 
-lemma hoare_post_imp_dc2_actual:
-  "\<lbrace>P\<rbrace> a \<lbrace>\<lambda>_. R\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace> a \<lbrace>\<lambda>_. R\<rbrace>, \<lbrace>\<lambda>_. \<top>\<rbrace>"
-  by (rule hoare_post_imp_dc2)
+lemma hoare_post_impE_R_dc_actual:
+  "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>_. Q\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>_. Q\<rbrace>, \<lbrace>\<lambda>_. \<top>\<rbrace>"
+  by (rule hoare_post_impE_R_dc)
 
-lemma hoare_post_imp_dc2E_actual:
-  "\<lbrace>P\<rbrace> a \<lbrace>\<lambda>_. R\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace> a \<lbrace>\<lambda>_. \<top>\<rbrace>, \<lbrace>\<lambda>_. R\<rbrace>"
-  by (rule hoare_post_imp_dc2E)
+lemma hoare_post_impE_E_dc_actual:
+  "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>_. Q\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>_. \<top>\<rbrace>, \<lbrace>\<lambda>_. Q\<rbrace>"
+  by (rule hoare_post_impE_E_dc)
 
 lemma hoare_conjD1:
-  "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv. Q rv and R rv\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv. Q rv\<rbrace>"
+  "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv. Q rv and Q' rv\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv. Q rv\<rbrace>"
   unfolding valid_def by auto
 
 lemma hoare_conjD2:
-  "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv. Q rv and R rv\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv. R rv\<rbrace>"
+  "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv. Q rv and Q' rv\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv. Q' rv\<rbrace>"
   unfolding valid_def by auto
 
 lemma hoare_post_disjI1:
-  "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv. Q rv\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv. Q rv or R rv\<rbrace>"
+  "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv. Q rv\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv. Q rv or Q' rv\<rbrace>"
   unfolding valid_def by auto
 
 lemma hoare_post_disjI2:
-  "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv. R rv\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv. Q rv or R rv\<rbrace>"
+  "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv. Q' rv\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv. Q rv or Q' rv\<rbrace>"
   unfolding valid_def by auto
 
 lemma use_valid:
@@ -316,11 +315,11 @@ lemma use_valid_inv:
   using use_valid[where f=f, OF step pres[where N="\<lambda>p. p = P s"]] by simp
 
 lemma use_validE_norm:
-  "\<lbrakk> (Inr r', s') \<in> mres (B s); \<lbrace>P\<rbrace> B \<lbrace>Q\<rbrace>,\<lbrace> E \<rbrace>; P s \<rbrakk> \<Longrightarrow> Q r' s'"
+  "\<lbrakk> (Inr r', s') \<in> mres (f s); \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>; P s \<rbrakk> \<Longrightarrow> Q r' s'"
   unfolding validE_def valid_def by force
 
 lemma use_validE_except:
-  "\<lbrakk> (Inl r', s') \<in> mres (B s); \<lbrace>P\<rbrace> B \<lbrace>Q\<rbrace>,\<lbrace> E \<rbrace>; P s \<rbrakk> \<Longrightarrow> E r' s'"
+  "\<lbrakk> (Inl r', s') \<in> mres (f s); \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>; P s \<rbrakk> \<Longrightarrow> E r' s'"
   unfolding validE_def valid_def by force
 
 lemma in_inv_by_hoareD:
@@ -343,23 +342,23 @@ lemma hoare_gen_asm_lk:
 \<comment> \<open>Useful for forward reasoning, when P is known.
     The first version allows weakening the precondition.\<close>
 lemma hoare_gen_asm_spec':
-  "\<lbrakk> \<And>s. P s \<Longrightarrow> S \<and> R s; S \<Longrightarrow> \<lbrace>R\<rbrace> f \<lbrace>Q\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>"
+  "\<lbrakk> \<And>s. P s \<Longrightarrow> S \<and> P' s; S \<Longrightarrow> \<lbrace>P'\<rbrace> f \<lbrace>Q\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>"
   by (fastforce simp: valid_def)
 
 lemma hoare_gen_asm_spec:
   "\<lbrakk> \<And>s. P s \<Longrightarrow> S; S \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>"
-  by (rule hoare_gen_asm_spec'[where S=S and R=P]) simp
+  by (rule hoare_gen_asm_spec'[where S=S and P'=P]) simp
 
 lemma hoare_conjI:
-  "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>; \<lbrace>P\<rbrace> f \<lbrace>R\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>r s. Q r s \<and> R r s\<rbrace>"
+  "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>; \<lbrace>P\<rbrace> f \<lbrace>Q'\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>r s. Q r s \<and> Q' r s\<rbrace>"
   unfolding valid_def by blast
 
 lemma hoare_disjI1:
-  "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. Q rv s \<or> R rv s \<rbrace>"
+  "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. Q rv s \<or> Q' rv s \<rbrace>"
   unfolding valid_def by blast
 
 lemma hoare_disjI2:
-  "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>R\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. Q rv s \<or> R rv s \<rbrace>"
+  "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>Q'\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. Q rv s \<or> Q' rv s \<rbrace>"
   unfolding valid_def by blast
 
 lemma hoare_assume_pre:
@@ -367,7 +366,7 @@ lemma hoare_assume_pre:
   by (auto simp: valid_def)
 
 lemma hoare_assume_preE:
-  "(\<And>s. P s \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,\<lbrace>R\<rbrace>) \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,\<lbrace>R\<rbrace>"
+  "(\<And>s. P s \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>) \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
   by (auto simp: valid_def validE_def)
 
 lemma hoare_allI:
@@ -383,7 +382,7 @@ lemma hoare_exI:
   by (simp add: valid_def) blast
 
 lemma hoare_impI:
-  "(R \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>) \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. R \<longrightarrow> Q rv s\<rbrace>"
+  "(P' \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>) \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. P' \<longrightarrow> Q rv s\<rbrace>"
   by (simp add: valid_def) blast
 
 lemma validE_impI:
@@ -415,7 +414,7 @@ subsection \<open>@{const valid} and @{const validE}, @{const validE_R}, @{const
 
 lemma valid_validE:
   "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>_. Q\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>_. Q\<rbrace>, \<lbrace>\<lambda>_. Q\<rbrace>"
-  by (rule hoare_post_imp_dc)
+  by (rule hoare_post_impE_dc)
 
 lemma valid_validE2:
   "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>_. Q'\<rbrace>; \<And>s. Q' s \<Longrightarrow> Q s; \<And>s. Q' s \<Longrightarrow> E s \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>_. Q\<rbrace>, \<lbrace>\<lambda>_. E\<rbrace>"
@@ -483,33 +482,33 @@ lemma liftE_validE[simp]:
 subsection \<open>Operator lifting/splitting\<close>
 
 lemma hoare_vcg_if_split:
-  "\<lbrakk> P \<Longrightarrow> \<lbrace>Q\<rbrace> f \<lbrace>S\<rbrace>; \<not>P \<Longrightarrow> \<lbrace>R\<rbrace> g \<lbrace>S\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s. (P \<longrightarrow> Q s) \<and> (\<not>P \<longrightarrow> R s)\<rbrace> if P then f else g \<lbrace>S\<rbrace>"
+  "\<lbrakk> P \<Longrightarrow> \<lbrace>P'\<rbrace> f \<lbrace>Q\<rbrace>; \<not>P \<Longrightarrow> \<lbrace>P''\<rbrace> g \<lbrace>Q\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s. (P \<longrightarrow> P' s) \<and> (\<not>P \<longrightarrow> P'' s)\<rbrace> if P then f else g \<lbrace>Q\<rbrace>"
   by simp
 
 lemma hoare_vcg_if_splitE:
-  "\<lbrakk> P \<Longrightarrow> \<lbrace>Q\<rbrace> f \<lbrace>S\<rbrace>,\<lbrace>E\<rbrace>; \<not>P \<Longrightarrow> \<lbrace>R\<rbrace> g \<lbrace>S\<rbrace>,\<lbrace>E\<rbrace> \<rbrakk> \<Longrightarrow>
-   \<lbrace>\<lambda>s. (P \<longrightarrow> Q s) \<and> (\<not>P \<longrightarrow> R s)\<rbrace> if P then f else g \<lbrace>S\<rbrace>,\<lbrace>E\<rbrace>"
+  "\<lbrakk> P \<Longrightarrow> \<lbrace>P'\<rbrace> f \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>; \<not>P \<Longrightarrow> \<lbrace>P''\<rbrace> g \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace> \<rbrakk> \<Longrightarrow>
+   \<lbrace>\<lambda>s. (P \<longrightarrow> P' s) \<and> (\<not>P \<longrightarrow> P'' s)\<rbrace> if P then f else g \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
   by simp
 
 lemma hoare_vcg_split_case_option:
-  "\<lbrakk> \<And>x. x = None \<Longrightarrow> \<lbrace>P x\<rbrace> f x \<lbrace>R x\<rbrace>; \<And>x y. x = Some y \<Longrightarrow> \<lbrace>Q x y\<rbrace> g x y \<lbrace>R x\<rbrace> \<rbrakk>
-   \<Longrightarrow> \<lbrace>\<lambda>s. (x = None \<longrightarrow> P x s) \<and> (\<forall>y. x = Some y \<longrightarrow> Q x y s)\<rbrace>
+  "\<lbrakk> \<And>x. x = None \<Longrightarrow> \<lbrace>P x\<rbrace> f x \<lbrace>Q x\<rbrace>; \<And>x y. x = Some y \<Longrightarrow> \<lbrace>P' x y\<rbrace> g x y \<lbrace>Q x\<rbrace> \<rbrakk>
+   \<Longrightarrow> \<lbrace>\<lambda>s. (x = None \<longrightarrow> P x s) \<and> (\<forall>y. x = Some y \<longrightarrow> P' x y s)\<rbrace>
        case x of None \<Rightarrow> f x | Some y \<Rightarrow> g x y
-       \<lbrace>R x\<rbrace>"
+       \<lbrace>Q x\<rbrace>"
   by (cases x; simp)
 
 lemma hoare_vcg_split_case_optionE:
-  "\<lbrakk> \<And>x. x = None \<Longrightarrow> \<lbrace>P x\<rbrace> f x \<lbrace>R x\<rbrace>,\<lbrace>E x\<rbrace>; \<And>x y. x = Some y \<Longrightarrow> \<lbrace>Q x y\<rbrace> g x y \<lbrace>R x\<rbrace>,\<lbrace>E x\<rbrace> \<rbrakk>
-   \<Longrightarrow> \<lbrace>\<lambda>s. (x = None \<longrightarrow> P x s) \<and> (\<forall>y. x = Some y \<longrightarrow> Q x y s)\<rbrace>
+  "\<lbrakk> \<And>x. x = None \<Longrightarrow> \<lbrace>P x\<rbrace> f x \<lbrace>Q x\<rbrace>,\<lbrace>E x\<rbrace>; \<And>x y. x = Some y \<Longrightarrow> \<lbrace>P' x y\<rbrace> g x y \<lbrace>Q x\<rbrace>,\<lbrace>E x\<rbrace> \<rbrakk>
+   \<Longrightarrow> \<lbrace>\<lambda>s. (x = None \<longrightarrow> P x s) \<and> (\<forall>y. x = Some y \<longrightarrow> P' x y s)\<rbrace>
        case x of None \<Rightarrow> f x | Some y \<Rightarrow> g x y
-       \<lbrace>R x\<rbrace>, \<lbrace>E x\<rbrace>"
+       \<lbrace>Q x\<rbrace>, \<lbrace>E x\<rbrace>"
   by (cases x; simp)
 
 lemma hoare_vcg_split_case_sum:
-  "\<lbrakk> \<And>x a. x = Inl a \<Longrightarrow> \<lbrace>P x a\<rbrace> f x a \<lbrace>R x\<rbrace>; \<And>x b. x = Inr b \<Longrightarrow> \<lbrace>Q x b\<rbrace> g x b \<lbrace>R x\<rbrace> \<rbrakk>
-   \<Longrightarrow> \<lbrace>\<lambda>s. (\<forall>a. x = Inl a \<longrightarrow> P x a s) \<and> (\<forall>b. x = Inr b \<longrightarrow> Q x b s)\<rbrace>
+  "\<lbrakk> \<And>x a. x = Inl a \<Longrightarrow> \<lbrace>P x a\<rbrace> f x a \<lbrace>Q x\<rbrace>; \<And>x b. x = Inr b \<Longrightarrow> \<lbrace>P' x b\<rbrace> g x b \<lbrace>Q x\<rbrace> \<rbrakk>
+   \<Longrightarrow> \<lbrace>\<lambda>s. (\<forall>a. x = Inl a \<longrightarrow> P x a s) \<and> (\<forall>b. x = Inr b \<longrightarrow> P' x b s)\<rbrace>
        case x of Inl a \<Rightarrow> f x a | Inr b \<Rightarrow> g x b
-       \<lbrace>R x\<rbrace>"
+       \<lbrace>Q x\<rbrace>"
   by (cases x; simp)
 
 lemma bind_wp_nobind:
@@ -523,7 +522,7 @@ lemma bindE_wp_nobind:
 lemmas bind_wp_skip = bind_wp[where Q=Q and Q'=Q for Q]
 
 lemma hoare_chain:
-  "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>; \<And>s. R s \<Longrightarrow> P s; \<And>rv s. Q rv s \<Longrightarrow> S rv s \<rbrakk> \<Longrightarrow> \<lbrace>R\<rbrace> f \<lbrace>S\<rbrace>"
+  "\<lbrakk> \<lbrace>P'\<rbrace> f \<lbrace>Q'\<rbrace>; \<And>s. P s \<Longrightarrow> P' s; \<And>rv s. Q' rv s \<Longrightarrow> Q rv s \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>"
   by (wp_pre, rule hoare_post_imp)
 
 lemma hoare_chainE:
@@ -537,7 +536,7 @@ lemma hoare_vcg_conj_lift:
   by fastforce
 
 \<comment> \<open>A variant which works nicely with subgoals that do not contain schematics\<close>
-lemmas hoare_vcg_conj_lift_pre_fix = hoare_vcg_conj_lift[where P=R and P'=R for R, simplified]
+lemmas hoare_vcg_conj_lift_pre_fix = hoare_vcg_conj_lift[where P=P and P'=P for P, simplified]
 
 lemma hoare_vcg_conj_liftE1:
   "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,-; \<lbrace>P'\<rbrace> f \<lbrace>Q'\<rbrace>,\<lbrace>E\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P and P'\<rbrace> f \<lbrace>\<lambda>rv s. Q rv s \<and> Q' rv s\<rbrace>,\<lbrace>E\<rbrace>"
@@ -578,13 +577,13 @@ lemma hoare_vcg_const_Ball_liftE:
   "\<lbrakk> \<And>x. x \<in> S \<Longrightarrow> \<lbrace>P x\<rbrace> f \<lbrace>Q x\<rbrace>,\<lbrace>E\<rbrace>; \<lbrace>\<lambda>s. True\<rbrace> f \<lbrace>\<lambda>r s. True\<rbrace>, \<lbrace>E\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s. \<forall>x\<in>S. P x s\<rbrace> f \<lbrace>\<lambda>rv s. \<forall>x\<in>S. Q x rv s\<rbrace>,\<lbrace>E\<rbrace>"
   by (fastforce simp: validE_def valid_def split: sum.splits)
 
-lemma hoare_vcg_const_Ball_lift_R:
+lemma hoare_vcg_const_Ball_liftE_R:
  "\<lbrakk> \<And>x. x \<in> S \<Longrightarrow> \<lbrace>P x\<rbrace> f \<lbrace>Q x\<rbrace>,- \<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s. \<forall>x \<in> S. P x s\<rbrace> f \<lbrace>\<lambda>rv s. \<forall>x \<in> S. Q x rv s\<rbrace>,-"
   unfolding validE_R_def validE_def
   by (rule hoare_strengthen_post)
      (fastforce intro!: hoare_vcg_const_Ball_lift split: sum.splits)+
 
-lemma hoare_vcg_const_Ball_lift_E_E:
+lemma hoare_vcg_const_Ball_liftE_E:
  "(\<And>x. x \<in> S \<Longrightarrow> \<lbrace>P x\<rbrace> f -,\<lbrace>Q x\<rbrace>) \<Longrightarrow> \<lbrace>\<lambda>s. \<forall>x \<in> S. P x s\<rbrace> f -,\<lbrace>\<lambda>rv s. \<forall>x \<in> S. Q x rv s\<rbrace>"
   unfolding validE_E_def validE_def valid_def
   by (fastforce split: sum.splits)
@@ -599,11 +598,11 @@ lemma hoare_vcg_all_liftE:
 
 lemma hoare_vcg_all_liftE_R:
   "(\<And>x. \<lbrace>P x\<rbrace> f \<lbrace>Q x\<rbrace>, -) \<Longrightarrow> \<lbrace>\<lambda>s. \<forall>x. P x s\<rbrace> f \<lbrace>\<lambda>rv s. \<forall>x. Q x rv s\<rbrace>, -"
-  by (rule hoare_vcg_const_Ball_lift_R[where S=UNIV, simplified])
+  by (rule hoare_vcg_const_Ball_liftE_R[where S=UNIV, simplified])
 
 lemma hoare_vcg_all_liftE_E:
   "(\<And>x. \<lbrace>P x\<rbrace> f -, \<lbrace>Q x\<rbrace>) \<Longrightarrow> \<lbrace>\<lambda>s. \<forall>x. P x s\<rbrace> f -,\<lbrace>\<lambda>rv s. \<forall>x. Q x rv s\<rbrace>"
-  by (rule hoare_vcg_const_Ball_lift_E_E[where S=UNIV, simplified])
+  by (rule hoare_vcg_const_Ball_liftE_E[where S=UNIV, simplified])
 
 lemma hoare_vcg_imp_lift:
   "\<lbrakk> \<lbrace>P'\<rbrace> f \<lbrace>\<lambda>rv s. \<not> P rv s\<rbrace>; \<lbrace>Q'\<rbrace> f \<lbrace>Q\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s. P' s \<or> Q' s\<rbrace> f \<lbrace>\<lambda>rv s. P rv s \<longrightarrow> Q rv s\<rbrace>"
@@ -623,11 +622,11 @@ lemma hoare_vcg_imp_liftE':
    \<Longrightarrow> \<lbrace>\<lambda>s. \<not> P' s \<longrightarrow> Q' s\<rbrace> f \<lbrace>\<lambda>rv s. P rv s \<longrightarrow> Q rv s\<rbrace>, \<lbrace>E\<rbrace>"
   by (fastforce simp: validE_def valid_def split: sum.splits)
 
-lemma hoare_vcg_imp_lift_R:
+lemma hoare_vcg_imp_liftE_R:
   "\<lbrakk> \<lbrace>P'\<rbrace> f \<lbrace>\<lambda>rv s. \<not> P rv s\<rbrace>, -; \<lbrace>Q'\<rbrace> f \<lbrace>Q\<rbrace>, - \<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s. P' s \<or> Q' s\<rbrace> f \<lbrace>\<lambda>rv s. P rv s \<longrightarrow> Q rv s\<rbrace>, -"
   by (auto simp add: valid_def validE_R_def validE_def split_def split: sum.splits)
 
-lemma hoare_vcg_imp_lift_R':
+lemma hoare_vcg_imp_liftE_R':
   "\<lbrakk> \<lbrace>P'\<rbrace> f \<lbrace>\<lambda>rv s. \<not> P rv s\<rbrace>, -; \<lbrace>Q'\<rbrace> f \<lbrace>Q\<rbrace>, - \<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s. \<not>P' s \<longrightarrow> Q' s\<rbrace> f \<lbrace>\<lambda>rv s. P rv s \<longrightarrow> Q rv s\<rbrace>, -"
   by (auto simp add: valid_def validE_R_def validE_def split_def split: sum.splits)
 
@@ -649,24 +648,24 @@ lemma hoare_vcg_imp_conj_lift[wp_comb]:
 lemmas hoare_vcg_imp_conj_lift'[wp_unsafe] = hoare_vcg_imp_conj_lift[where Q'''="\<top>\<top>", simplified]
 
 lemma hoare_absorb_imp:
-  "\<lbrace> P \<rbrace> f \<lbrace>\<lambda>rv s. Q rv s \<and> R rv s\<rbrace> \<Longrightarrow> \<lbrace> P \<rbrace> f \<lbrace>\<lambda>rv s. Q rv s \<longrightarrow> R rv s\<rbrace>"
+  "\<lbrace> P \<rbrace> f \<lbrace>\<lambda>rv s. Q rv s \<and> Q' rv s\<rbrace> \<Longrightarrow> \<lbrace> P \<rbrace> f \<lbrace>\<lambda>rv s. Q rv s \<longrightarrow> Q' rv s\<rbrace>"
   by (erule hoare_post_imp[rotated], blast)
 
 lemma hoare_weaken_imp:
-  "\<lbrakk> \<And>rv s. Q rv s \<Longrightarrow> Q' rv s ;  \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. Q' rv s \<longrightarrow> R rv s\<rbrace> \<rbrakk>
-    \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. Q rv s \<longrightarrow> R rv s\<rbrace>"
+  "\<lbrakk> \<And>rv s. Q rv s \<Longrightarrow> Q' rv s ; \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. Q' rv s \<longrightarrow> S rv s\<rbrace> \<rbrakk>
+    \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. Q rv s \<longrightarrow> S rv s\<rbrace>"
   by (clarsimp simp: valid_def split_def)
 
 lemma hoare_vcg_const_imp_lift:
-  "\<lbrakk> P \<Longrightarrow> \<lbrace>Q\<rbrace> m \<lbrace>R\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s. P \<longrightarrow> Q s\<rbrace> m \<lbrace>\<lambda>rv s. P \<longrightarrow> R rv s\<rbrace>"
+  "\<lbrakk> P \<Longrightarrow> \<lbrace>P'\<rbrace> m \<lbrace>Q\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s. P \<longrightarrow> P' s\<rbrace> m \<lbrace>\<lambda>rv s. P \<longrightarrow> Q rv s\<rbrace>"
   by (cases P, simp_all add: hoare_vcg_prop)
 
-lemma hoare_vcg_const_imp_lift_E:
-  "(P \<Longrightarrow> \<lbrace>Q\<rbrace> f -, \<lbrace>R\<rbrace>) \<Longrightarrow> \<lbrace>\<lambda>s. P \<longrightarrow> Q s\<rbrace> f -, \<lbrace>\<lambda>rv s. P \<longrightarrow> R rv s\<rbrace>"
+lemma hoare_vcg_const_imp_liftE_E:
+  "(P \<Longrightarrow> \<lbrace>P'\<rbrace> f -, \<lbrace>E\<rbrace>) \<Longrightarrow> \<lbrace>\<lambda>s. P \<longrightarrow> P' s\<rbrace> f -, \<lbrace>\<lambda>rv s. P \<longrightarrow> E rv s\<rbrace>"
   by (fastforce simp: validE_E_def validE_def valid_def split_def split: sum.splits)
 
-lemma hoare_vcg_const_imp_lift_R:
-  "(P \<Longrightarrow> \<lbrace>Q\<rbrace> m \<lbrace>R\<rbrace>,-) \<Longrightarrow> \<lbrace>\<lambda>s. P \<longrightarrow> Q s\<rbrace> m \<lbrace>\<lambda>rv s. P \<longrightarrow> R rv s\<rbrace>,-"
+lemma hoare_vcg_const_imp_liftE_R:
+  "(P \<Longrightarrow> \<lbrace>P'\<rbrace> m \<lbrace>Q\<rbrace>,-) \<Longrightarrow> \<lbrace>\<lambda>s. P \<longrightarrow> P' s\<rbrace> m \<lbrace>\<lambda>rv s. P \<longrightarrow> Q rv s\<rbrace>,-"
   by (fastforce simp: validE_R_def validE_def valid_def split_def split: sum.splits)
 
 lemma hoare_weak_lift_imp:
@@ -674,11 +673,11 @@ lemma hoare_weak_lift_imp:
   by (auto simp add: valid_def split_def)
 
 lemma hoare_weak_lift_impE:
-  "\<lbrace>Q\<rbrace> m \<lbrace>R\<rbrace>,\<lbrace>E\<rbrace> \<Longrightarrow> \<lbrace>\<lambda>s. P \<longrightarrow> Q s\<rbrace> m \<lbrace>\<lambda>rv s. P \<longrightarrow> R rv s\<rbrace>,\<lbrace>\<lambda>rv s. P \<longrightarrow> E rv s\<rbrace>"
+  "\<lbrace>P'\<rbrace> m \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace> \<Longrightarrow> \<lbrace>\<lambda>s. P \<longrightarrow> P' s\<rbrace> m \<lbrace>\<lambda>rv s. P \<longrightarrow> Q rv s\<rbrace>,\<lbrace>\<lambda>rv s. P \<longrightarrow> E rv s\<rbrace>"
   by (cases P; simp add: validE_def hoare_vcg_prop)
 
-lemma hoare_weak_lift_imp_R:
-  "\<lbrace>Q\<rbrace> m \<lbrace>R\<rbrace>,- \<Longrightarrow> \<lbrace>\<lambda>s. P \<longrightarrow> Q s\<rbrace> m \<lbrace>\<lambda>rv s. P \<longrightarrow> R rv s\<rbrace>,-"
+lemma hoare_weak_lift_impE_R:
+  "\<lbrace>P'\<rbrace> m \<lbrace>Q\<rbrace>,- \<Longrightarrow> \<lbrace>\<lambda>s. P \<longrightarrow> P' s\<rbrace> m \<lbrace>\<lambda>rv s. P \<longrightarrow> Q rv s\<rbrace>,-"
   by (cases P; wpsimp wp: wp_post_tautE_R)
 
 lemma hoare_vcg_ex_lift:
@@ -709,24 +708,30 @@ lemma hoare_liftP_ext:
   done
 
 (* for instantiations *)
-lemma hoare_triv:    "\<lbrace>P\<rbrace>f\<lbrace>Q\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace>f\<lbrace>Q\<rbrace>" .
+lemma hoare_triv:    "\<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>" .
 lemma hoare_trivE:   "\<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>" .
 lemma hoare_trivE_R: "\<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,- \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,-" .
 lemma hoare_trivR_R: "\<lbrace>P\<rbrace> f -,\<lbrace>E\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace> f -,\<lbrace>E\<rbrace>" .
 
-lemma hoare_vcg_E_conj:
+lemma hoare_vcg_conj_liftE_E:
   "\<lbrakk> \<lbrace>P\<rbrace> f -,\<lbrace>E\<rbrace>; \<lbrace>P'\<rbrace> f \<lbrace>Q'\<rbrace>,\<lbrace>E'\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s. P s \<and> P' s\<rbrace> f \<lbrace>Q'\<rbrace>, \<lbrace>\<lambda>rv s. E rv s \<and> E' rv s\<rbrace>"
   unfolding validE_def validE_E_def
   by (rule hoare_post_imp[OF _ hoare_vcg_conj_lift]; simp split: sum.splits)
 
-lemma hoare_vcg_E_elim:
+lemma hoare_vcg_conj_elimE:
   "\<lbrakk> \<lbrace>P\<rbrace> f -,\<lbrace>E\<rbrace>; \<lbrace>P'\<rbrace> f \<lbrace>Q\<rbrace>,- \<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s. P s \<and> P' s\<rbrace> f \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
-  by (rule hoare_strengthen_postE[OF hoare_vcg_E_conj]) (simp add: validE_R_def)+
+  by (rule hoare_strengthen_postE[OF hoare_vcg_conj_liftE_E]) (simp add: validE_R_def)+
 
-lemma hoare_vcg_R_conj:
+lemma hoare_vcg_conj_liftE_R:
   "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,-; \<lbrace>P'\<rbrace> f \<lbrace>Q'\<rbrace>,- \<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s. P s \<and> P' s\<rbrace> f \<lbrace>\<lambda>rv s. Q rv s \<and> Q' rv s\<rbrace>,-"
   unfolding validE_R_def validE_def
   by (rule hoare_post_imp[OF _ hoare_vcg_conj_lift]; simp split: sum.splits)
+
+lemma hoare_vcg_conj_liftE_R':
+  "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,-; \<lbrace>P'\<rbrace> f \<lbrace>Q'\<rbrace>,- \<rbrakk> \<Longrightarrow> \<lbrace>P and P'\<rbrace> f \<lbrace>\<lambda>rv s. Q rv s \<and> Q' rv s\<rbrace>, -"
+  apply (simp add: validE_R_def validE_def valid_def split: sum.splits)
+  apply blast
+  done
 
 lemma hoare_lift_Pf_E_R:
   "\<lbrakk> \<And>x. \<lbrace>P x\<rbrace> m \<lbrace>\<lambda>_. P x\<rbrace>, -; \<And>P. \<lbrace>\<lambda>s. P (f s)\<rbrace> m \<lbrace>\<lambda>_ s. P (f s)\<rbrace>, - \<rbrakk> \<Longrightarrow>
@@ -743,11 +748,11 @@ lemma hoare_post_comb_imp_conj:
   by (wpsimp wp: hoare_vcg_conj_lift)
 
 lemma hoare_vcg_if_lift:
-  "\<lbrace>R\<rbrace> f \<lbrace>\<lambda>rv s. (P \<longrightarrow> X rv s) \<and> (\<not>P \<longrightarrow> Y rv s)\<rbrace> \<Longrightarrow>
-   \<lbrace>R\<rbrace> f \<lbrace>\<lambda>rv s. if P then X rv s else Y rv s\<rbrace>"
+  "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. (P' \<longrightarrow> X rv s) \<and> (\<not>P' \<longrightarrow> Y rv s)\<rbrace> \<Longrightarrow>
+   \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. if P' then X rv s else Y rv s\<rbrace>"
 
-  "\<lbrace>R\<rbrace> f \<lbrace>\<lambda>rv s. (P \<longrightarrow> X rv s) \<and> (\<not>P \<longrightarrow> Y rv s)\<rbrace> \<Longrightarrow>
-   \<lbrace>R\<rbrace> f \<lbrace>\<lambda>rv. if P then X rv else Y rv\<rbrace>"
+  "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. (P' \<longrightarrow> X rv s) \<and> (\<not>P' \<longrightarrow> Y rv s)\<rbrace> \<Longrightarrow>
+   \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv. if P' then X rv else Y rv\<rbrace>"
   by (auto simp: valid_def split_def)
 
 lemma hoare_vcg_split_lift[wp]:
@@ -757,8 +762,8 @@ lemma hoare_vcg_split_lift[wp]:
 named_theorems hoare_vcg_op_lift
 lemmas [hoare_vcg_op_lift] =
   hoare_vcg_const_imp_lift
-  hoare_vcg_const_imp_lift_E
-  hoare_vcg_const_imp_lift_R
+  hoare_vcg_const_imp_liftE_E
+  hoare_vcg_const_imp_liftE_R
   (* leaving out hoare_vcg_conj_lift*, because that is built into wp *)
   hoare_vcg_disj_lift
   hoare_vcg_disj_lift_R
@@ -771,13 +776,13 @@ lemmas [hoare_vcg_op_lift] =
   hoare_vcg_all_liftE_R
   hoare_vcg_const_Ball_lift
   hoare_vcg_const_Ball_liftE
-  hoare_vcg_const_Ball_lift_R
-  hoare_vcg_const_Ball_lift_E_E
+  hoare_vcg_const_Ball_liftE_R
+  hoare_vcg_const_Ball_liftE_E
   hoare_vcg_split_lift
   hoare_vcg_if_lift
   hoare_vcg_imp_lift'
   hoare_vcg_imp_liftE'
-  hoare_vcg_imp_lift_R'
+  hoare_vcg_imp_liftE_R'
   hoare_vcg_imp_liftE_E'
 
 
@@ -864,8 +869,8 @@ lemma list_cases_wp:
   by (cases ts, auto simp: a b)
 
 lemma hoare_vcg_handle_elseE:
-  "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>; \<And>e. \<lbrace>E e\<rbrace> g e \<lbrace>R\<rbrace>,\<lbrace>F\<rbrace>; \<And>x. \<lbrace>Q x\<rbrace> h x \<lbrace>R\<rbrace>,\<lbrace>F\<rbrace> \<rbrakk> \<Longrightarrow>
-   \<lbrace>P\<rbrace> f <handle> g <else> h \<lbrace>R\<rbrace>,\<lbrace>F\<rbrace>"
+  "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>Q'\<rbrace>,\<lbrace>E'\<rbrace>; \<And>e. \<lbrace>E' e\<rbrace> g e \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>; \<And>x. \<lbrace>Q' x\<rbrace> h x \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace> \<rbrakk> \<Longrightarrow>
+   \<lbrace>P\<rbrace> f <handle> g <else> h \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
   unfolding handle_elseE_def validE_def
   by (wpsimp wp: bind_wp_fwd | assumption | rule conjI)+
 
@@ -904,11 +909,11 @@ lemma state_select_wp:
   by (wpsimp wp: put_wp select_wp return_wp get_wp assert_wp)
 
 lemma condition_wp:
-  "\<lbrakk> \<lbrace>Q\<rbrace> A \<lbrace>P\<rbrace>; \<lbrace>R\<rbrace> B \<lbrace>P\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s. if C s then Q s else R s\<rbrace> condition C A B \<lbrace>P\<rbrace>"
+  "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>; \<lbrace>P'\<rbrace> g \<lbrace>Q\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s. if C s then P s else P' s\<rbrace> condition C f g \<lbrace>Q\<rbrace>"
   by (clarsimp simp: condition_def valid_def)
 
 lemma conditionE_wp:
-  "\<lbrakk> \<lbrace>P\<rbrace> A \<lbrace>Q\<rbrace>,\<lbrace>R\<rbrace>; \<lbrace>P'\<rbrace> B \<lbrace>Q\<rbrace>,\<lbrace>R\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s. if C s then P s else P' s\<rbrace> condition C A B \<lbrace>Q\<rbrace>,\<lbrace>R\<rbrace>"
+  "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>; \<lbrace>P'\<rbrace> g \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s. if C s then P s else P' s\<rbrace> condition C f g \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
   by (clarsimp simp: condition_def validE_def valid_def)
 
 lemma state_assert_wp:
@@ -917,19 +922,19 @@ lemma state_assert_wp:
   by (wp bind_wp_fwd get_wp assert_wp)
 
 lemma when_wp[wp_split]:
-  "\<lbrakk> P \<Longrightarrow> \<lbrace>Q\<rbrace> f \<lbrace>R\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>if P then Q else R ()\<rbrace> when P f \<lbrace>R\<rbrace>"
+  "\<lbrakk> P \<Longrightarrow> \<lbrace>P'\<rbrace> f \<lbrace>Q\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>if P then P' else Q ()\<rbrace> when P f \<lbrace>Q\<rbrace>"
   by (clarsimp simp: when_def valid_def return_def mres_def)
 
 lemma unless_wp[wp_split]:
-  "(\<not>P \<Longrightarrow> \<lbrace>Q\<rbrace> f \<lbrace>R\<rbrace>) \<Longrightarrow> \<lbrace>if P then R () else Q\<rbrace> unless P f \<lbrace>R\<rbrace>"
+  "(\<not>P \<Longrightarrow> \<lbrace>P'\<rbrace> f \<lbrace>Q\<rbrace>) \<Longrightarrow> \<lbrace>if P then Q () else P'\<rbrace> unless P f \<lbrace>Q\<rbrace>"
   unfolding unless_def by wp auto
 
 lemma whenE_wp:
-  "(P \<Longrightarrow> \<lbrace>Q\<rbrace> f \<lbrace>R\<rbrace>, \<lbrace>E\<rbrace>) \<Longrightarrow> \<lbrace>if P then Q else R ()\<rbrace> whenE P f \<lbrace>R\<rbrace>, \<lbrace>E\<rbrace>"
+  "(P \<Longrightarrow> \<lbrace>P'\<rbrace> f \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>) \<Longrightarrow> \<lbrace>if P then P' else Q ()\<rbrace> whenE P f \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
   unfolding whenE_def by clarsimp (wp returnOk_wp)
 
 lemma unlessE_wp:
-  "(\<not> P \<Longrightarrow> \<lbrace>Q\<rbrace> f \<lbrace>R\<rbrace>, \<lbrace>E\<rbrace>) \<Longrightarrow> \<lbrace>if P then R () else Q\<rbrace> unlessE P f \<lbrace>R\<rbrace>, \<lbrace>E\<rbrace>"
+  "(\<not> P \<Longrightarrow> \<lbrace>P'\<rbrace> f \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>) \<Longrightarrow> \<lbrace>if P then Q () else P'\<rbrace> unlessE P f \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
   unfolding unlessE_def
   by (wpsimp wp: returnOk_wp)
 
@@ -943,8 +948,8 @@ lemma notM_wp:
   unfolding notM_def by (wpsimp wp: return_wp)
 
 lemma ifM_wp:
-  assumes [wp]: "\<lbrace>Q\<rbrace> f \<lbrace>S\<rbrace>" "\<lbrace>R\<rbrace> g \<lbrace>S\<rbrace>"
-  assumes [wp]: "\<lbrace>A\<rbrace> P \<lbrace>\<lambda>c s. c \<longrightarrow> Q s\<rbrace>" "\<lbrace>B\<rbrace> P \<lbrace>\<lambda>c s. \<not>c \<longrightarrow> R s\<rbrace>"
+  assumes [wp]: "\<lbrace>Q\<rbrace> f \<lbrace>S\<rbrace>" "\<lbrace>Q'\<rbrace> g \<lbrace>S\<rbrace>"
+  assumes [wp]: "\<lbrace>A\<rbrace> P \<lbrace>\<lambda>c s. c \<longrightarrow> Q s\<rbrace>" "\<lbrace>B\<rbrace> P \<lbrace>\<lambda>c s. \<not>c \<longrightarrow> Q' s\<rbrace>"
   shows "\<lbrace>A and B\<rbrace> ifM P f g \<lbrace>S\<rbrace>"
   unfolding ifM_def
   by (wpsimp wp: hoare_vcg_if_split hoare_vcg_conj_lift)
@@ -1067,15 +1072,16 @@ lemmas hoare_wp_combs = hoare_vcg_conj_lift
 
 lemmas hoare_wp_combsE =
   validE_validE_R
-  hoare_vcg_R_conj
-  hoare_vcg_E_elim
-  hoare_vcg_E_conj
+  validE_validE_E
+  hoare_vcg_conj_liftE_R
+  hoare_vcg_conj_elimE
+  hoare_vcg_conj_liftE_E
 
 lemmas hoare_wp_state_combsE =
   valid_validE_R
-  hoare_vcg_R_conj[OF valid_validE_R]
-  hoare_vcg_E_elim[OF valid_validE_E]
-  hoare_vcg_E_conj[OF valid_validE_E]
+  hoare_vcg_conj_liftE_R[OF valid_validE_R]
+  hoare_vcg_conj_elimE[OF valid_validE_E]
+  hoare_vcg_conj_liftE_E[OF valid_validE_E]
 
 lemmas hoare_classic_wp_combs = hoare_post_comb_imp_conj hoare_weaken_pre hoare_wp_combs
 lemmas hoare_classic_wp_combsE = hoare_weaken_preE hoare_weaken_preE_R hoare_wp_combsE
@@ -1147,9 +1153,9 @@ lemmas [wp] = wp_post_tauts
 lemmas [wp_trip] = valid_is_triple validE_is_triple validE_E_is_triple validE_R_is_triple
 
 lemmas validE_E_combs[wp_comb] =
-    hoare_vcg_E_conj[where Q'="\<top>\<top>", folded validE_E_def]
+    hoare_vcg_conj_liftE_E[where Q'="\<top>\<top>", folded validE_E_def]
     valid_validE_E
-    hoare_vcg_E_conj[where Q'="\<top>\<top>", folded validE_E_def, OF valid_validE_E]
+    hoare_vcg_conj_liftE_E[where Q'="\<top>\<top>", folded validE_E_def, OF valid_validE_E]
 
 
 subsection \<open>Simplifications on conjunction\<close>
@@ -1246,7 +1252,7 @@ bundle classic_wp_pre = hoare_pre [wp_pre del]
 text \<open>Miscellaneous lemmas on hoare triples\<close>
 
 lemma hoare_pre_cases:
-  "\<lbrakk> \<lbrace>\<lambda>s. R s \<and> P s\<rbrace> f \<lbrace>Q\<rbrace>; \<lbrace>\<lambda>s. \<not>R s \<and> P' s\<rbrace> f \<lbrace>Q\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P and P'\<rbrace> f \<lbrace>Q\<rbrace>"
+  "\<lbrakk> \<lbrace>\<lambda>s. C s \<and> P s\<rbrace> f \<lbrace>Q\<rbrace>; \<lbrace>\<lambda>s. \<not>C s \<and> P' s\<rbrace> f \<lbrace>Q\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P and P'\<rbrace> f \<lbrace>Q\<rbrace>"
   unfolding valid_def by fastforce
 
 lemma hoare_vcg_mp:
@@ -1280,7 +1286,7 @@ lemma hoare_use_eq:
   assumes "\<And>P. \<lbrace>\<lambda>s. P (f s)\<rbrace> m \<lbrace>\<lambda>_ s. P (f s)\<rbrace>"
   assumes "\<And>f. \<lbrace>\<lambda>s. P f s\<rbrace> m \<lbrace>\<lambda>_ s. Q f s\<rbrace>"
   shows "\<lbrace>\<lambda>s. P (f s) s\<rbrace> m \<lbrace>\<lambda>_ s. Q (f s) s \<rbrace>"
-  apply (rule hoare_post_imp[where Q="\<lambda>_ s. \<exists>y. y = f s \<and> Q y s"], simp)
+  apply (rule hoare_post_imp[where Q'="\<lambda>_ s. \<exists>y. y = f s \<and> Q y s"], simp)
   apply (wpsimp wp: hoare_vcg_ex_lift assms)
   done
 
@@ -1293,39 +1299,37 @@ lemma hoare_failE[simp]:
   by wp
 
 lemma hoare_validE_pred_conj:
-  "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>, \<lbrace>E\<rbrace>; \<lbrace>P\<rbrace> f \<lbrace>R\<rbrace>, \<lbrace>E\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q and R\<rbrace>, \<lbrace>E\<rbrace>"
+  "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>; \<lbrace>P\<rbrace> f \<lbrace>Q'\<rbrace>,\<lbrace>E\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q and Q'\<rbrace>,\<lbrace>E\<rbrace>"
   unfolding valid_def validE_def
   by (simp add: split_def split: sum.splits)
 
 lemma hoare_validE_conj:
-  "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>, \<lbrace>E\<rbrace>; \<lbrace>P\<rbrace> f \<lbrace>R\<rbrace>, \<lbrace>E\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. Q rv s \<and> R rv s\<rbrace>, \<lbrace>E\<rbrace>"
+  "\<lbrakk> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>; \<lbrace>P\<rbrace> f \<lbrace>Q'\<rbrace>,\<lbrace>E\<rbrace> \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. Q rv s \<and> Q' rv s\<rbrace>,\<lbrace>E\<rbrace>"
   unfolding valid_def validE_def
   by (simp add: split_def split: sum.splits)
-
-lemmas hoare_valid_validE = valid_validE (* FIXME lib: eliminate one *)
-
-declare validE_validE_E[wp_comb]
 
 lemmas if_validE_E[wp_split] =
   validE_validE_E[OF hoare_vcg_if_splitE[OF validE_E_validE validE_E_validE]]
 
 lemma hoare_drop_imp:
-  "\<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. R rv s \<longrightarrow> Q rv s\<rbrace>"
+  "\<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. Q' rv s \<longrightarrow> Q rv s\<rbrace>"
   by (auto simp: valid_def)
 
 lemma hoare_drop_impE:
-  "\<lbrakk>\<lbrace>P\<rbrace> f \<lbrace>\<lambda>r. Q\<rbrace>, \<lbrace>E\<rbrace>\<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. R rv s \<longrightarrow> Q s\<rbrace>, \<lbrace>E\<rbrace>"
+  "\<lbrakk>\<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>, \<lbrace>E\<rbrace>\<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. Q' rv s \<longrightarrow> Q rv s\<rbrace>, \<lbrace>E\<rbrace>"
   by (simp add: hoare_chainE)
 
 lemma hoare_drop_impE_R:
-  "\<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,- \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. R rv s \<longrightarrow> Q rv s\<rbrace>, -"
+  "\<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>,- \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. Q' rv s \<longrightarrow> Q rv s\<rbrace>, -"
   by (auto simp: validE_R_def validE_def valid_def split_def split: sum.splits)
 
+(*Q is used instead of E so that hoare_drop_imps can be instantiated, which requires that all of its
+  thms have the same variables.*)
 lemma hoare_drop_impE_E:
-  "\<lbrace>P\<rbrace> f -,\<lbrace>Q\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace> f -, \<lbrace>\<lambda>rv s. R rv s \<longrightarrow> Q rv s\<rbrace>"
+  "\<lbrace>P\<rbrace> f -,\<lbrace>Q\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace> f -, \<lbrace>\<lambda>rv s. Q' rv s \<longrightarrow> Q rv s\<rbrace>"
   by (auto simp: validE_E_def validE_def valid_def split_def split: sum.splits)
 
-lemmas hoare_drop_imps = hoare_drop_imp hoare_drop_impE_R hoare_drop_impE_E
+lemmas hoare_drop_imps = hoare_drop_imp hoare_drop_impE hoare_drop_impE_R hoare_drop_impE_E
 
 (*This is unsafe, but can be very useful when supplied as a comb rule.*)
 lemma hoare_drop_imp_conj[wp_unsafe]:
@@ -1393,7 +1397,7 @@ lemma hoare_return_sp: (* FIXME lib: eliminate *)
   by (simp add: valid_def return_def mres_def)
 
 lemma assert_sp:
-  "\<lbrace>P\<rbrace> assert Q \<lbrace>\<lambda>_ s. P s \<and> Q \<rbrace>"
+  "\<lbrace>P\<rbrace> assert Q \<lbrace>\<lambda>_ s. P s \<and> Q\<rbrace>"
   by (simp add: assert_def fail_def return_def valid_def mres_def)
 
 lemma hoare_gets_sp:

--- a/lib/Monads/trace/Trace_VCG.thy
+++ b/lib/Monads/trace/Trace_VCG.thy
@@ -217,13 +217,9 @@ lemma hoare_FalseE[simp]:
   "\<lbrace>\<bottom>\<rbrace> f \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"
   by (simp add: valid_def validE_def)
 
-lemma hoare_return_drop_var[iff]:
+lemma return_inv[iff]:
   "\<lbrace>Q\<rbrace> return x \<lbrace>\<lambda>r. Q\<rbrace>"
   by (simp add: valid_def return_def mres_def)
-
-lemma hoare_gets[intro]:
-  "\<lbrakk> \<And>s. P s \<Longrightarrow> Q (f s) s \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> gets f \<lbrace>Q\<rbrace>"
-  by (simp add:valid_def gets_def get_def bind_def return_def mres_def)
 
 lemma hoare_modifyE_var:
   "\<lbrakk> \<And>s. P s \<Longrightarrow> Q (f s) \<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> modify f \<lbrace>\<lambda>_ s. Q s\<rbrace>"

--- a/lib/Monads/wp/WPBang.thy
+++ b/lib/Monads/wp/WPBang.thy
@@ -24,7 +24,7 @@ fun check_has_frees_tac Ps (_ : int) thm = let
   in if null fs then Seq.empty else Seq.single thm end
 
 fun wp_bang wp_safe_rules ctxt = let
-    val wp_safe_rules_conj = ((wp_safe_rules RL @{thms hoare_vcg_conj_lift hoare_vcg_R_conj})
+    val wp_safe_rules_conj = ((wp_safe_rules RL @{thms hoare_vcg_conj_lift hoare_vcg_conj_liftE_R})
         RL @{thms hoare_strengthen_post hoare_strengthen_postE_R hoare_strengthen_postE_E})
       |> map (rotate_prems 1)
   in

--- a/lib/sep_algebra/MonadSep.thy
+++ b/lib/sep_algebra/MonadSep.thy
@@ -134,7 +134,7 @@ lemma foldM_set_sep:
 lemma sep_list_conj_map_singleton_wp:
   "\<lbrakk>x \<in> set xs; \<And>R. \<lbrace><P \<and>* I x \<and>* R>\<rbrace> f \<lbrace>\<lambda>_. <Q \<and>* I x \<and>* R>\<rbrace>\<rbrakk>
   \<Longrightarrow> \<lbrace><P \<and>* \<And>* map I xs \<and>* R>\<rbrace> f \<lbrace>\<lambda>_. <Q \<and>* \<And>* map I xs \<and>* R>\<rbrace>"
-  apply (rule hoare_chain [where P="<P \<and>* I x \<and>* \<And>* map I (remove1 x xs) \<and>* R>" and
+  apply (rule hoare_chain[where P'="<P \<and>* I x \<and>* \<And>* map I (remove1 x xs) \<and>* R>" and
                                  Q="\<lambda>_. <Q \<and>* I x \<and>* \<And>* map I (remove1 x xs) \<and>* R>"])
     apply fastforce
    apply (subst (asm) sep_list_conj_map_remove1, assumption)
@@ -146,7 +146,7 @@ lemma sep_list_conj_map_singleton_wp:
 lemma sep_set_conj_map_singleton_wp:
   "\<lbrakk>finite xs; x \<in> xs; \<And>R. \<lbrace><P \<and>* I x \<and>* R>\<rbrace> f \<lbrace>\<lambda>_. <Q \<and>* I x \<and>* R>\<rbrace>\<rbrakk>
   \<Longrightarrow> \<lbrace><P \<and>* (\<And>* x\<in>xs. I x) \<and>* R>\<rbrace> f \<lbrace>\<lambda>_. <Q \<and>* (\<And>* x\<in>xs. I x) \<and>* R>\<rbrace>"
-  apply (rule hoare_chain [where P="<P \<and>* I x \<and>* (\<And>* x\<in>xs - {x}. I x) \<and>* R>" and
+  apply (rule hoare_chain[where P'="<P \<and>* I x \<and>* (\<And>* x\<in>xs - {x}. I x) \<and>* R>" and
                                  Q="\<lambda>_. <Q \<and>* I x \<and>* (\<And>* x\<in>xs - {x}. I x) \<and>* R>"], assumption)
    apply (subst (asm) sep.prod.remove, assumption+)
    apply sep_solve

--- a/lib/sep_algebra/MonadSep.thy
+++ b/lib/sep_algebra/MonadSep.thy
@@ -135,7 +135,7 @@ lemma sep_list_conj_map_singleton_wp:
   "\<lbrakk>x \<in> set xs; \<And>R. \<lbrace><P \<and>* I x \<and>* R>\<rbrace> f \<lbrace>\<lambda>_. <Q \<and>* I x \<and>* R>\<rbrace>\<rbrakk>
   \<Longrightarrow> \<lbrace><P \<and>* \<And>* map I xs \<and>* R>\<rbrace> f \<lbrace>\<lambda>_. <Q \<and>* \<And>* map I xs \<and>* R>\<rbrace>"
   apply (rule hoare_chain[where P'="<P \<and>* I x \<and>* \<And>* map I (remove1 x xs) \<and>* R>" and
-                                 Q="\<lambda>_. <Q \<and>* I x \<and>* \<And>* map I (remove1 x xs) \<and>* R>"])
+                                Q'="\<lambda>_. <Q \<and>* I x \<and>* \<And>* map I (remove1 x xs) \<and>* R>"])
     apply fastforce
    apply (subst (asm) sep_list_conj_map_remove1, assumption)
    apply (sep_select_asm 3)
@@ -147,7 +147,7 @@ lemma sep_set_conj_map_singleton_wp:
   "\<lbrakk>finite xs; x \<in> xs; \<And>R. \<lbrace><P \<and>* I x \<and>* R>\<rbrace> f \<lbrace>\<lambda>_. <Q \<and>* I x \<and>* R>\<rbrace>\<rbrakk>
   \<Longrightarrow> \<lbrace><P \<and>* (\<And>* x\<in>xs. I x) \<and>* R>\<rbrace> f \<lbrace>\<lambda>_. <Q \<and>* (\<And>* x\<in>xs. I x) \<and>* R>\<rbrace>"
   apply (rule hoare_chain[where P'="<P \<and>* I x \<and>* (\<And>* x\<in>xs - {x}. I x) \<and>* R>" and
-                                 Q="\<lambda>_. <Q \<and>* I x \<and>* (\<And>* x\<in>xs - {x}. I x) \<and>* R>"], assumption)
+                                Q'="\<lambda>_. <Q \<and>* I x \<and>* (\<And>* x\<in>xs - {x}. I x) \<and>* R>"], assumption)
    apply (subst (asm) sep.prod.remove, assumption+)
    apply sep_solve
   apply (subst sep.prod.remove, assumption+)

--- a/proof/access-control/ARM/ArchArch_AC.thy
+++ b/proof/access-control/ARM/ArchArch_AC.thy
@@ -427,7 +427,7 @@ lemma unmap_page_respects:
                       mapM_set''[where f="(\<lambda>a. store_pde a InvalidPDE)"
                                    and I="\<lambda>x s. is_subject aag (x && ~~ mask pd_bits)"
                                    and Q="integrity aag X st"]
-          | wp (once) hoare_drop_imps[where R="\<lambda>rv s. rv"])+
+          | wp (once) hoare_drop_imps[where Q'="\<lambda>rv s. rv"])+
   done
 
 (* FIXME: CLAG *)
@@ -609,7 +609,7 @@ lemma perform_asid_control_invocation_pas_refined [wp]:
    apply (rename_tac frame slot parent base cap)
    apply (case_tac slot, rename_tac slot_ptr slot_idx)
    apply (case_tac parent, rename_tac parent_ptr parent_idx)
-   apply (rule_tac Q="\<lambda>rv s.
+   apply (rule_tac Q'="\<lambda>rv s.
              (\<exists>idx. cte_wp_at ((=) (UntypedCap False frame pageBits idx)) parent s) \<and>
              (\<forall>x\<in>ptr_range frame pageBits. is_subject aag x) \<and>
              pas_refined aag s \<and>
@@ -963,7 +963,7 @@ lemma delete_asid_pool_pas_refined [wp]:
   "delete_asid_pool param_a param_b \<lbrace>pas_refined aag\<rbrace>"
   unfolding delete_asid_pool_def
   apply (wp | wpc | simp)+
-      apply (rule_tac Q = "\<lambda>_ s. pas_refined aag s \<and>
+      apply (rule_tac Q'="\<lambda>_ s. pas_refined aag s \<and>
                                  asid_table = arm_asid_table (arch_state s)" in hoare_post_imp)
        apply clarsimp
        apply (erule pas_refined_clear_asid)

--- a/proof/access-control/ARM/ArchDomainSepInv.thy
+++ b/proof/access-control/ARM/ArchDomainSepInv.thy
@@ -114,7 +114,7 @@ lemma arch_invoke_irq_control_domain_sep_inv[DomainSepInv_assms]:
    \<lbrace>\<lambda>_. domain_sep_inv irqs st\<rbrace>"
   apply (cases ivk)
   apply (wpsimp wp: cap_insert_domain_sep_inv' simp: set_irq_state_def)
-   apply (rule_tac Q="\<lambda>_. domain_sep_inv irqs st and arch_irq_control_inv_valid ivk"
+   apply (rule_tac Q'="\<lambda>_. domain_sep_inv irqs st and arch_irq_control_inv_valid ivk"
                 in hoare_strengthen_post[rotated])
     apply (fastforce simp: domain_sep_inv_def domain_sep_inv_cap_def arch_irq_control_inv_valid_def)
    apply (wpsimp wp: do_machine_op_domain_sep_inv simp: arch_irq_control_inv_valid_def)+

--- a/proof/access-control/ARM/ArchRetype_AC.thy
+++ b/proof/access-control/ARM/ArchRetype_AC.thy
@@ -169,7 +169,7 @@ lemma copy_global_mappings_pas_refined:
   apply wp
     (* Use \<circ> to avoid wp filtering out the global_pd condition here
        TODO: see if we can clean this up *)
-    apply (rule_tac Q="\<lambda>rv s. is_aligned global_pd pd_bits \<and>
+    apply (rule_tac Q'="\<lambda>rv s. is_aligned global_pd pd_bits \<and>
                               (global_pd = (arm_global_pd \<circ> arch_state) s \<and>
                                valid_kernel_mappings s \<and> valid_arch_state s \<and>
                                valid_global_objs s \<and> valid_global_refs s \<and> pas_refined aag s)"
@@ -219,7 +219,7 @@ lemma init_arch_objects_pas_refined[Retype_AC_assms]:
   apply (case_tac aobject_type, simp_all)
         apply ((simp | wp)+)[5]
    apply wp
-    apply (rule_tac Q="\<lambda>rv. pas_refined aag and
+    apply (rule_tac Q'="\<lambda>rv. pas_refined aag and
                             all_invs_but_equal_kernel_mappings_restricted (set refs) and
                             (\<lambda>s. \<forall>x \<in> set refs. x \<notin> global_refs s)" in hoare_strengthen_post)
      apply (wp mapM_x_wp[OF _ subset_refl])

--- a/proof/access-control/ARM/ArchTcb_AC.thy
+++ b/proof/access-control/ARM/ArchTcb_AC.thy
@@ -41,7 +41,7 @@ lemma invoke_tcb_tc_respects_aag[Tcb_AC_assms]:
            strengthen imp_consequent[where Q="x = None" for x], simp cong: conj_cong)
           | strengthen invs_psp_aligned invs_vspace_objs invs_arch_state
           | rule wp_split_const_if wp_split_const_if_R hoare_vcg_all_liftE_R
-                 hoare_vcg_E_elim hoare_vcg_const_imp_lift_R hoare_vcg_R_conj
+                 hoare_vcg_conj_elimE hoare_vcg_const_imp_liftE_R hoare_vcg_conj_liftE_R
           | wp restart_integrity_autarch set_mcpriority_integrity_autarch
                as_user_integrity_autarch thread_set_integrity_autarch
                option_update_thread_integrity_autarch
@@ -54,7 +54,7 @@ lemma invoke_tcb_tc_respects_aag[Tcb_AC_assms]:
                out_invs_trivial case_option_wpE cap_delete_deletes
                cap_delete_valid_cap cap_insert_valid_cap out_cte_at
                cap_insert_cte_at cap_delete_cte_at out_valid_cap out_tcb_valid
-               hoare_vcg_const_imp_lift_R hoare_vcg_all_liftE_R
+               hoare_vcg_const_imp_liftE_R hoare_vcg_all_liftE_R
                thread_set_tcb_ipc_buffer_cap_cleared_invs
                thread_set_invs_trivial[OF ball_tcb_cap_casesI]
                hoare_vcg_all_lift thread_set_valid_cap out_emptyable

--- a/proof/access-control/Access_AC.thy
+++ b/proof/access-control/Access_AC.thy
@@ -1301,7 +1301,7 @@ lemma hoare_gen_asm2:
 lemma hoare_vcg_all_liftE:
   "(\<And>x. \<lbrace>P x\<rbrace> f \<lbrace>Q x\<rbrace>, \<lbrace>Q' x\<rbrace>) \<Longrightarrow> \<lbrace>\<lambda>s. \<forall>x. P x s\<rbrace> f \<lbrace>\<lambda>rv s. \<forall>x. Q x rv s\<rbrace>, \<lbrace>\<lambda>rv s. \<forall>x. Q' x rv s\<rbrace>"
   unfolding validE_def
-  apply (rule hoare_post_imp [where Q = "\<lambda>v s. \<forall>x. case v of Inl e \<Rightarrow> Q' x e s | Inr r \<Rightarrow> Q x r s"])
+  apply (rule hoare_post_imp[where Q'="\<lambda>v s. \<forall>x. case v of Inl e \<Rightarrow> Q' x e s | Inr r \<Rightarrow> Q x r s"])
    apply (clarsimp split: sum.splits)
   apply (erule hoare_vcg_all_lift)
   done

--- a/proof/access-control/CNode_AC.thy
+++ b/proof/access-control/CNode_AC.thy
@@ -246,7 +246,7 @@ lemma decode_cnode_inv_authorised:
   apply (simp add: authorised_cnode_inv_def decode_cnode_invocation_def
                    split_def whenE_def unlessE_def set_eq_iff
              cong: if_cong Invocations_A.cnode_invocation.case_cong split del: if_split)
-  apply (wpsimp wp: hoare_vcg_all_lift hoare_vcg_const_imp_lift_R hoare_vcg_all_liftE_R lsfco_cte_at
+  apply (wpsimp wp: hoare_vcg_all_lift hoare_vcg_const_imp_liftE_R hoare_vcg_all_liftE_R lsfco_cte_at
          | wp (once) get_cap_cur_auth)+
   apply (subgoal_tac "\<forall>n. n < length excaps
                           \<longrightarrow> (is_cnode_cap (excaps ! n)
@@ -866,7 +866,7 @@ lemma empty_slot_integrity_transferable[wp_transferable]:
    apply (simp add: set_cdt_def)
    apply (wp set_original_wp)
        apply (rename_tac cdtv x)
-       apply (rule_tac Q = "\<lambda>_ s'. integrity aag X s s'\<and> cdtv = cdt s \<and>
+       apply (rule_tac Q'="\<lambda>_ s'. integrity aag X s s'\<and> cdtv = cdt s \<and>
                             is_original_cap s = is_original_cap s'"
                        in hoare_post_imp)
         apply (clarsimp simp add: integrity_def)

--- a/proof/access-control/DomainSepInv.thy
+++ b/proof/access-control/DomainSepInv.thy
@@ -878,7 +878,7 @@ lemma send_ipc_domain_sep_inv:
    \<lbrace>\<lambda>_ s. domain_sep_inv irqs (st :: 'state_ext state) (s :: det_ext state)\<rbrace>"
   unfolding send_ipc_def
   apply (wp setup_caller_cap_domain_sep_inv hoare_vcg_if_lift | wpc | simp split del:if_split)+
-        apply (rule_tac Q="\<lambda> r s. domain_sep_inv irqs st s" in hoare_strengthen_post)
+        apply (rule_tac Q'="\<lambda> r s. domain_sep_inv irqs st s" in hoare_strengthen_post)
          apply (wp do_ipc_transfer_domain_sep_inv dxo_wp_weak | wpc | simp)+
      apply (wp (once) hoare_drop_imps)
      apply (wp get_simple_ko_wp)+
@@ -895,7 +895,7 @@ lemma receive_ipc_base_domain_sep_inv:
    \<lbrace>\<lambda>_ s. domain_sep_inv irqs (st :: 'state_ext state) (s :: det_ext state)\<rbrace>"
   apply (clarsimp cong: endpoint.case_cong thread_get_def get_thread_state_def)
   apply (wp setup_caller_cap_domain_sep_inv dxo_wp_weak | wpc | simp split del: if_split)+
-        apply (rule_tac Q="\<lambda> r s. domain_sep_inv irqs st s" in hoare_strengthen_post)
+        apply (rule_tac Q'="\<lambda> r s. domain_sep_inv irqs st s" in hoare_strengthen_post)
          apply (wp do_ipc_transfer_domain_sep_inv hoare_vcg_all_lift | wpc | simp)+
      apply (wpsimp wp: hoare_vcg_imp_lift[OF set_simple_ko_get_tcb, unfolded disj_not1]
                        hoare_vcg_all_lift get_simple_ko_wp
@@ -1052,7 +1052,7 @@ lemma invoke_tcb_domain_sep_inv:
      apply  ((wp | simp)+)[1]
     apply (simp add: split_def cong: option.case_cong)
     apply (wp checked_cap_insert_domain_sep_inv hoare_vcg_all_liftE_R hoare_vcg_all_lift
-              hoare_vcg_const_imp_lift_R cap_delete_domain_sep_inv cap_delete_deletes
+              hoare_vcg_const_imp_liftE_R cap_delete_domain_sep_inv cap_delete_deletes
               dxo_wp_weak cap_delete_valid_cap cap_delete_cte_at hoare_weak_lift_imp
            | wpc | strengthen
            | simp add: option_update_thread_def emptyable_def tcb_cap_cases_def
@@ -1158,7 +1158,7 @@ lemma handle_recv_domain_sep_inv:
   apply (wp hoare_vcg_all_lift lookup_slot_for_thread_cap_fault receive_ipc_domain_sep_inv
             delete_caller_cap_domain_sep_inv get_cap_wp get_simple_ko_wp
          | wpc | simp
-         | (rule_tac Q="\<lambda>rv. invs and (\<lambda>s. cur_thread s = thread)" in hoare_strengthen_post, wp,
+         | (rule_tac Q'="\<lambda>rv. invs and (\<lambda>s. cur_thread s = thread)" in hoare_strengthen_post, wp,
             clarsimp simp: invs_valid_objs invs_sym_refs))+
      apply (rule_tac Q'="\<lambda>r s. domain_sep_inv irqs st s \<and> invs s \<and>
                                tcb_at thread s \<and> thread = cur_thread s" in hoare_strengthen_postE_R)

--- a/proof/access-control/DomainSepInv.thy
+++ b/proof/access-control/DomainSepInv.thy
@@ -1089,13 +1089,15 @@ lemma handle_invocation_domain_sep_inv:
                    split_def liftE_liftM_liftME liftME_def bindE_assoc)
   apply (wp syscall_valid perform_invocation_domain_sep_inv set_thread_state_runnable_valid_sched
          | simp split del: if_split)+
-        apply (rule_tac E="\<lambda>ft. domain_sep_inv irqs st and valid_objs and sym_refs \<circ> state_refs_of
-                                                       and valid_mdb and (\<lambda>y. valid_fault ft)"
-                    and R="Q" and Q=Q for Q in hoare_strengthen_postE)
+        apply (rule_tac E'="\<lambda>ft. domain_sep_inv irqs st and valid_objs and sym_refs \<circ> state_refs_of
+                                                        and valid_mdb and (\<lambda>y. valid_fault ft)"
+                    and Q="Q" and Q'=Q for Q
+                     in hoare_strengthen_postE)
          apply (wp | simp | clarsimp)+
-      apply (rule_tac E="\<lambda>ft. domain_sep_inv irqs st and valid_objs and sym_refs \<circ> state_refs_of and
-                              valid_mdb and (\<lambda>y. valid_fault (CapFault x False ft))"
-                  and R="Q" and Q=Q for Q in hoare_strengthen_postE)
+      apply (rule_tac E'="\<lambda>ft. domain_sep_inv irqs st and valid_objs and sym_refs \<circ> state_refs_of and
+                               valid_mdb and (\<lambda>y. valid_fault (CapFault x False ft))"
+                  and Q="Q" and Q'=Q for Q
+                   in hoare_strengthen_postE)
         apply (wp lcs_ex_cap_to2 | clarsimp)+
   apply (auto intro: st_tcb_ex_cap simp: ct_in_state_def)
   done
@@ -1184,8 +1186,10 @@ lemma handle_event_domain_sep_inv:
        apply (wpsimp wp: handle_send_domain_sep_inv handle_call_domain_sep_inv
                          handle_recv_domain_sep_inv handle_reply_domain_sep_inv hy_inv
               | simp add: invs_valid_objs invs_mdb invs_sym_refs valid_fault_def)+
-     apply (rule_tac E="\<lambda>rv s. domain_sep_inv irqs (st :: 'state_ext state) (s :: det_ext state) \<and>
-                               invs s \<and> valid_fault rv" and R="Q" and Q=Q for Q in hoare_strengthen_postE)
+     apply (rule_tac E'="\<lambda>rv s. domain_sep_inv irqs (st :: 'state_ext state) (s :: det_ext state) \<and>
+                                invs s \<and> valid_fault rv"
+                 and Q="Q" and Q'=Q for Q
+                  in hoare_strengthen_postE)
      apply (wp | simp add: invs_valid_objs invs_mdb invs_sym_refs valid_fault_def | auto)+
   done
 

--- a/proof/access-control/Finalise_AC.thy
+++ b/proof/access-control/Finalise_AC.thy
@@ -283,7 +283,7 @@ lemma cancel_all_ipc_pas_refined[wp]:
    cancel_all_ipc epptr
    \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   apply (clarsimp simp: cancel_all_ipc_def get_ep_queue_def cong: endpoint.case_cong)
-  apply (rule_tac Q="\<lambda>_. pas_refined aag and pspace_aligned
+  apply (rule_tac Q'="\<lambda>_. pas_refined aag and pspace_aligned
                                          and valid_vspace_objs
                                          and valid_arch_state"
                in hoare_strengthen_post)
@@ -296,7 +296,7 @@ lemma cancel_all_signals_pas_refined[wp]:
    cancel_all_signals ntfnptr
    \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   apply (clarsimp simp: cancel_all_signals_def cong: ntfn.case_cong)
-  apply (rule_tac Q="\<lambda>_. pas_refined aag and pspace_aligned
+  apply (rule_tac Q'="\<lambda>_. pas_refined aag and pspace_aligned
                                          and valid_vspace_objs
                                          and valid_arch_state"
                in hoare_strengthen_post)
@@ -352,7 +352,7 @@ lemma reply_cancel_ipc_pas_refined[wp]:
   apply (rule hoare_gen_asm)
   apply (simp add: reply_cancel_ipc_def)
   apply (wp add: wp_transferable del: wp_not_transferable)
-   apply (rule hoare_strengthen_post[where Q="\<lambda>_. invs and tcb_at t and pas_refined aag"])
+   apply (rule hoare_strengthen_post[where Q'="\<lambda>_. invs and tcb_at t and pas_refined aag"])
     apply (wpsimp wp: hoare_wp_combs thread_set_tcb_fault_reset_invs thread_set_pas_refined)+
    apply (frule(1) reply_cap_descends_from_master0)
    apply (fastforce simp: cte_wp_at_caps_of_state intro:it_Reply)
@@ -1167,7 +1167,7 @@ next
                                         simp_thms disj_not1], simp_all)[1]
        apply (simp add: cte_wp_at_caps_of_state)
        apply wp+
-      apply (rule_tac Q = "\<lambda>rv' s. (slot \<noteq> p \<or> exposed \<longrightarrow> cte_wp_at P p s) \<and> P (fst rv')
+      apply (rule_tac Q'="\<lambda>rv' s. (slot \<noteq> p \<or> exposed \<longrightarrow> cte_wp_at P p s) \<and> P (fst rv')
                              \<and> cte_at slot s" in hoare_post_imp)
        apply (clarsimp simp: cte_wp_at_caps_of_state)
       apply (wp hoare_weak_lift_imp set_cap_cte_wp_at' finalise_cap_cte_wp_at_nullinv

--- a/proof/access-control/Interrupt_AC.thy
+++ b/proof/access-control/Interrupt_AC.thy
@@ -84,7 +84,7 @@ lemma invoke_irq_handler_pas_refined:
    apply (wp cap_insert_pas_refined_not_transferable delete_one_caps_of_state
           | strengthen invs_mdb | simp add: cte_wp_at_caps_of_state)+
     apply (rename_tac irq cap slot)
-    apply (rule_tac Q =
+    apply (rule_tac Q'=
             "\<lambda> irq_slot. K(irq_slot \<noteq> slot) and invs and emptyable irq_slot
                      and cte_wp_at can_fast_finalise irq_slot
                      and not cte_wp_at is_transferable_cap slot

--- a/proof/access-control/Ipc_AC.thy
+++ b/proof/access-control/Ipc_AC.thy
@@ -540,7 +540,7 @@ next
          and solve this using derived_cap_is_derived, and then solve the rest
          using derive_cap_is_derived_foo *)
     apply (rule_tac Q'="\<lambda>r s. S r s \<and> Q r s" for S Q in hoare_strengthen_postE_R)
-     apply (rule hoare_vcg_conj_lift_R)
+     apply (rule hoare_vcg_conj_liftE_R)
       apply (rule derive_cap_is_derived)
      prefer 2
      apply clarsimp
@@ -765,7 +765,7 @@ lemma transfer_caps_loop_presM_extended:
           | assumption | simp split del: if_split)+
       apply (rule cap_insert_assume_null)
       apply (wp x hoare_vcg_const_Ball_lift cap_insert_cte_wp_at hoare_weak_lift_imp)+
-    apply (rule hoare_vcg_conj_liftE_R)
+    apply (rule hoare_vcg_conj_liftE_R')
      apply (rule derive_cap_is_derived_foo')
     apply (rule_tac Q' ="\<lambda>cap' s. (vo \<longrightarrow> cap'\<noteq> NullCap \<longrightarrow>
                                    cte_wp_at (is_derived (cdt s) (aa, b) cap') (aa, b) s) \<and>
@@ -773,8 +773,8 @@ lemma transfer_caps_loop_presM_extended:
      prefer 2
      apply clarsimp
      apply assumption
-    apply (rule hoare_vcg_conj_liftE_R)
-     apply (rule hoare_vcg_const_imp_lift_R)
+    apply (rule hoare_vcg_conj_liftE_R')
+     apply (rule hoare_vcg_const_imp_liftE_R)
      apply (rule derive_cap_is_derived)
     apply (wp derive_cap_is_derived_foo')+
   apply (clarsimp simp: cte_wp_at_caps_of_state
@@ -850,7 +850,7 @@ lemma copy_mrs_pas_refined:
    copy_mrs sender sbuf receiver rbuf n
    \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   unfolding copy_mrs_def
-  apply (rule_tac Q="\<lambda>_. pas_refined aag and pspace_aligned
+  apply (rule_tac Q'="\<lambda>_. pas_refined aag and pspace_aligned
                                          and valid_vspace_objs
                                          and valid_arch_state"
                in hoare_strengthen_post[rotated], clarsimp)
@@ -1059,7 +1059,7 @@ lemma send_ipc_pas_refined:
          apply (simp add: hoare_if_r_and split del:if_split)
          apply (wp setup_caller_cap_pas_refined set_thread_state_pas_refined)+
        apply (simp split del:if_split)
-       apply (rule_tac Q="\<lambda>rv. pas_refined aag and pspace_aligned and valid_vspace_objs and
+       apply (rule_tac Q'="\<lambda>rv. pas_refined aag and pspace_aligned and valid_vspace_objs and
                                valid_arch_state and valid_mdb and
                                K (can_grant \<or> can_grant_reply
                                   \<longrightarrow> (reply_can_grant \<longrightarrow> is_subject aag x21) \<and>
@@ -1203,7 +1203,7 @@ lemma receive_ipc_base_pas_refined:
    apply (wp set_thread_state_pas_refined get_simple_ko_wp setup_caller_cap_pas_refined
           | wpc | simp add: thread_get_def do_nbrecv_failed_transfer_def split del: if_split)+
         apply (rename_tac list sss data)
-        apply (rule_tac Q="\<lambda>rv s. pas_refined aag s \<and> pspace_aligned s \<and> valid_vspace_objs s \<and>
+        apply (rule_tac Q'="\<lambda>rv s. pas_refined aag s \<and> pspace_aligned s \<and> valid_vspace_objs s \<and>
                                   valid_arch_state s \<and> valid_mdb s \<and>
                                   (sender_can_grant data \<longrightarrow> is_subject aag (hd list)) \<and>
                                   (sender_can_grant_reply data \<longrightarrow>
@@ -1529,7 +1529,7 @@ lemma receive_ipc_base_integrity:
              sts_receive_Inactive_respects[where ep = epptr]
              as_user_integrity_autarch)
         apply (rename_tac list tcb data)
-        apply (rule_tac Q="\<lambda>rv s. integrity aag X st s
+        apply (rule_tac Q'="\<lambda>rv s. integrity aag X st s
                            \<and> valid_mdb s
                            \<and> is_subject aag receiver
                            \<and> (sender_can_call data \<longrightarrow> AllowGrant \<in> rights
@@ -2080,7 +2080,7 @@ valid_objs and valid_mdb and st_tcb_at can_receive_ipc receiver and
   apply (wpsimp wp: as_user_respects_in_ipc set_message_info_respects_in_ipc copy_mrs_pas_refined
                     copy_mrs_respects_in_ipc transfer_caps_respects_in_ipc get_mi_length
                     lookup_extra_caps_authorised lookup_extra_caps_length hoare_vcg_const_Ball_lift
-                    hoare_vcg_conj_lift_R hoare_vcg_const_imp_lift lec_valid_cap'
+                    hoare_vcg_conj_liftE_R hoare_vcg_const_imp_lift lec_valid_cap'
          | rule hoare_drop_imps)+
   apply (auto simp: null_def intro: st_tcb_at_tcb_at)
   done
@@ -2353,7 +2353,7 @@ lemma send_ipc_integrity_autarch:
    apply (rule hoare_pre)
     apply (wp setup_caller_cap_integrity_autarch set_thread_state_integrity_autarch thread_get_wp'
            | wpc)+
-          apply (rule_tac Q="\<lambda>rv s. integrity aag X st s \<and> (can_grant \<longrightarrow> is_subject aag (hd list))"
+          apply (rule_tac Q'="\<lambda>rv s. integrity aag X st s \<and> (can_grant \<longrightarrow> is_subject aag (hd list))"
                        in hoare_strengthen_post[rotated])
           apply simp+
           apply (wp set_thread_state_integrity_autarch thread_get_wp'
@@ -2368,7 +2368,7 @@ lemma send_ipc_integrity_autarch:
   apply (rule hoare_pre)
    apply (wpc, wp)
    apply (rename_tac list s receiver queue)
-   apply (rule_tac Q="\<lambda>_ s'. integrity aag X st s \<and>
+   apply (rule_tac Q'="\<lambda>_ s'. integrity aag X st s \<and>
                              integrity_tcb_in_ipc aag X receiver epptr TRFinal s s'" in hoare_post_imp)
     apply (fastforce dest!: integrity_tcb_in_ipc_final elim!: integrity_trans)
    apply (wp setup_caller_cap_respects_in_ipc_reply
@@ -2437,11 +2437,11 @@ lemma handle_fault_pas_refined:
    handle_fault thread fault
    \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   apply (wpsimp wp: set_thread_state_pas_refined simp: handle_fault_def handle_double_fault_def)
-    apply (rule hoare_vcg_E_elim)
+    apply (rule hoare_vcg_conj_elimE)
      apply (clarsimp simp: send_fault_ipc_def Let_def)
      apply wp
        apply wpsimp
-      apply (rule hoare_strengthen_postE[where E=E and F=E for E])
+      apply (rule hoare_strengthen_postE[where E'=E and F=E for E])
         apply (rule valid_validE)
         apply (wpsimp wp: send_fault_ipc_pas_refined)+
   apply fastforce
@@ -2478,7 +2478,7 @@ lemma send_fault_ipc_integrity_autarch:
          | wpc | simp add: is_obj_defs)+
   (* 14 subgoals *)
   apply (rename_tac word1 word2 set)
-  apply (rule_tac R="\<lambda>rv s. ep_at word1 s" in hoare_post_add)
+  apply (rule_tac Q'="\<lambda>rv s. ep_at word1 s" in hoare_post_add)
   apply (simp only: obj_at_conj_distrib[symmetric] flip: conj_assoc)
   apply (wp thread_set_obj_at_impossible thread_set_tcb_fault_set_invs
             get_cap_auth_wp[where aag=aag]
@@ -2812,7 +2812,7 @@ lemma do_reply_transfer_respects:
     \<comment> \<open>receiver is not a subject\<close>
     apply (rule use_spec') \<comment> \<open>Name initial state\<close>
     apply (simp add: spec_valid_def) \<comment> \<open>no imp rule?\<close>
-    apply (rule_tac Q="\<lambda>_ s'. integrity aag X st s \<and>
+    apply (rule_tac Q'="\<lambda>_ s'. integrity aag X st s \<and>
                               integrity_tcb_in_ipc aag X receiver _ TRFinal s s'" in hoare_post_imp)
      apply (fastforce dest!: integrity_tcb_in_ipc_final elim!: integrity_trans)
     apply ((wp possible_switch_to_respects_in_ipc_autarch
@@ -2835,7 +2835,7 @@ lemma do_reply_transfer_respects:
     apply (rule use_spec') \<comment> \<open>Name initial state\<close>
     apply (simp add: spec_valid_def) \<comment> \<open>no imp rule?\<close>
     apply wp
-          apply (rule_tac Q="\<lambda>_ s'. integrity aag X st s \<and>
+          apply (rule_tac Q'="\<lambda>_ s'. integrity aag X st s \<and>
                                       integrity_tcb_in_fault_reply aag X receiver TRFFinal s s'"
                        in hoare_post_imp)
            apply (fastforce dest!: integrity_tcb_in_fault_reply_final elim!: integrity_trans)

--- a/proof/access-control/Ipc_AC.thy
+++ b/proof/access-control/Ipc_AC.thy
@@ -2441,7 +2441,7 @@ lemma handle_fault_pas_refined:
      apply (clarsimp simp: send_fault_ipc_def Let_def)
      apply wp
        apply wpsimp
-      apply (rule hoare_strengthen_postE[where E'=E and F=E for E])
+      apply (rule hoare_strengthen_postE[where E'=E and E=E for E])
         apply (rule valid_validE)
         apply (wpsimp wp: send_fault_ipc_pas_refined)+
   apply fastforce

--- a/proof/access-control/RISCV64/ArchArch_AC.thy
+++ b/proof/access-control/RISCV64/ArchArch_AC.thy
@@ -918,7 +918,7 @@ lemma unmap_page_table_respects:
   apply (simp add: unmap_page_table_def sfence_def)
   apply (wpsimp wp: pt_lookup_from_level_is_subject dmo_mol_respects hoare_vcg_conj_liftE_weaker
                     store_pte_respects pt_lookup_from_level_wrp[where Q="\<lambda>_. integrity aag X st"]
-         | wp (once) hoare_drop_imps hoare_vcg_E_elim)+
+         | wp (once) hoare_drop_imps hoare_vcg_conj_elimE)+
   apply (intro conjI; clarsimp)
     apply fastforce
    apply (rule aag_Control_into_owns[rotated], assumption)
@@ -1070,7 +1070,7 @@ lemma perform_pg_inv_map_pas_refined:
     apply (rule hoare_vcg_conj_lift, wpsimp)
     apply wps
     apply (rule state_vrefs_store_NonPageTablePTE_wp)
-   apply (rule_tac Q="\<lambda>_. invs and pas_refined aag and K (\<not> is_PageTablePTE pte)
+   apply (rule_tac Q'="\<lambda>_. invs and pas_refined aag and K (\<not> is_PageTablePTE pte)
                                and authorised_page_inv aag (PageMap cap ct_slot (pte,slot))
                                and same_ref (pte,slot) (ArchObjectCap cap)"
                 in hoare_strengthen_post[rotated])
@@ -1152,7 +1152,7 @@ lemma unmap_page_respects:
                       mapM_set''[where f="(\<lambda>a. store_pte a InvalidPTE)"
                                    and I="\<lambda>x s. is_subject aag (x && ~~ mask pt_bits)"
                                    and Q="integrity aag X st"]
-          | wp (once) hoare_drop_imps[where R="\<lambda>rv s. rv"])+
+          | wp (once) hoare_drop_imps[where Q'="\<lambda>rv s. rv"])+
   apply (clarsimp simp: pt_lookup_slot_def)
   apply (frule pt_lookup_slot_from_level_is_subject)
           apply (fastforce simp: valid_arch_state_asid_table
@@ -1336,7 +1336,7 @@ lemma perform_asid_control_invocation_pas_refined:
    apply (rename_tac frame slot parent base )
    apply (case_tac slot, rename_tac slot_ptr slot_idx)
    apply (case_tac parent, rename_tac parent_ptr parent_idx)
-   apply (rule_tac Q="\<lambda>rv s.
+   apply (rule_tac Q'="\<lambda>rv s.
              (\<exists>idx. cte_wp_at ((=) (UntypedCap False frame pageBits idx)) parent s) \<and>
              (\<forall>x\<in>ptr_range frame pageBits. is_subject aag x) \<and>
              pas_refined aag s \<and> pas_cur_domain aag s \<and>
@@ -1467,7 +1467,7 @@ lemma copy_global_mappings_state_vrefs:
   unfolding copy_global_mappings_def
   apply clarsimp
   apply wp
-    apply (rule_tac Q="\<lambda>_ s. P (state_vrefs s) \<and> pspace_aligned s \<and> valid_vspace_objs s \<and>
+    apply (rule_tac Q'="\<lambda>_ s. P (state_vrefs s) \<and> pspace_aligned s \<and> valid_vspace_objs s \<and>
                              valid_asid_table s \<and> unique_table_refs s \<and> valid_vs_lookup s \<and>
                              valid_objs s \<and> is_aligned pt_ptr pt_bits \<and> is_aligned global_pt pt_bits \<and>
                              (\<forall>level. \<not> \<exists>\<rhd> (level, table_base (pt_ptr)) s) \<and>
@@ -1672,7 +1672,7 @@ lemma copy_global_mappings_vs_lookup_table_noteq:
   unfolding copy_global_mappings_def
   apply clarsimp
   apply wp
-    apply (rule_tac Q="\<lambda>_. pspace_aligned and valid_vspace_objs and valid_asid_table and
+    apply (rule_tac Q'="\<lambda>_. pspace_aligned and valid_vspace_objs and valid_asid_table and
                            unique_table_refs and valid_vs_lookup and valid_objs and
                            (\<lambda>s. vs_lookup_table level asid vref s \<noteq> Some (level, pt_ptr) \<and>
                                 vref \<in> user_region \<and> is_aligned pt_ptr pt_bits \<and>

--- a/proof/access-control/RISCV64/ArchDomainSepInv.thy
+++ b/proof/access-control/RISCV64/ArchDomainSepInv.thy
@@ -106,7 +106,7 @@ lemma arch_invoke_irq_control_domain_sep_inv[DomainSepInv_assms]:
    \<lbrace>\<lambda>_. domain_sep_inv irqs st\<rbrace>"
   apply (cases ivk)
   apply (wpsimp wp: cap_insert_domain_sep_inv' simp: set_irq_state_def)
-   apply (rule_tac Q="\<lambda>_. domain_sep_inv irqs st and arch_irq_control_inv_valid ivk"
+   apply (rule_tac Q'="\<lambda>_. domain_sep_inv irqs st and arch_irq_control_inv_valid ivk"
                 in hoare_strengthen_post[rotated])
     apply (fastforce simp: domain_sep_inv_def domain_sep_inv_cap_def arch_irq_control_inv_valid_def)
    apply (wpsimp wp: do_machine_op_domain_sep_inv simp: arch_irq_control_inv_valid_def)+

--- a/proof/access-control/RISCV64/ArchFinalise_AC.thy
+++ b/proof/access-control/RISCV64/ArchFinalise_AC.thy
@@ -70,7 +70,7 @@ lemma delete_asid_pas_refined[wp]:
   unfolding delete_asid_def
   apply (rule bind_wp)
    apply (wpsimp simp: set_asid_pool_def wp: set_object_wp hoare_vcg_imp_lift' hoare_vcg_all_lift)
-    apply (rule_tac Q="\<lambda>_ s. riscv_asid_table (arch_state s) = asid_table \<and>
+    apply (rule_tac Q'="\<lambda>_ s. riscv_asid_table (arch_state s) = asid_table \<and>
                              ako_at (ASIDPool pool) x2 s \<and> pas_refined aag s"
                  in hoare_strengthen_post[rotated])
      defer

--- a/proof/access-control/RISCV64/ArchTcb_AC.thy
+++ b/proof/access-control/RISCV64/ArchTcb_AC.thy
@@ -41,7 +41,7 @@ lemma invoke_tcb_tc_respects_aag[Tcb_AC_assms]:
           strengthen imp_consequent[where Q="x = None" for x], simp cong: conj_cong)
          | strengthen invs_psp_aligned invs_vspace_objs invs_arch_state
          | rule wp_split_const_if wp_split_const_if_R hoare_vcg_all_liftE_R
-                hoare_vcg_E_elim hoare_vcg_const_imp_lift_R hoare_vcg_R_conj
+                hoare_vcg_conj_elimE hoare_vcg_const_imp_liftE_R hoare_vcg_conj_liftE_R
          | wp restart_integrity_autarch set_mcpriority_integrity_autarch
               as_user_integrity_autarch thread_set_integrity_autarch
               option_update_thread_integrity_autarch
@@ -54,7 +54,7 @@ lemma invoke_tcb_tc_respects_aag[Tcb_AC_assms]:
               out_invs_trivial case_option_wpE cap_delete_deletes
               cap_delete_valid_cap cap_insert_valid_cap out_cte_at
               cap_insert_cte_at cap_delete_cte_at out_valid_cap out_tcb_valid
-              hoare_vcg_const_imp_lift_R hoare_vcg_all_liftE_R
+              hoare_vcg_const_imp_liftE_R hoare_vcg_all_liftE_R
               thread_set_tcb_ipc_buffer_cap_cleared_invs
               thread_set_invs_trivial[OF ball_tcb_cap_casesI]
               hoare_vcg_all_lift thread_set_valid_cap out_emptyable

--- a/proof/access-control/Retype_AC.thy
+++ b/proof/access-control/Retype_AC.thy
@@ -1028,7 +1028,7 @@ lemma reset_untyped_cap_pas_refined[wp]:
    apply (wps | wp set_cap_pas_refined_not_transferable | simp add: unless_def)+
      apply (rule valid_validE)
      apply (rule_tac P="is_untyped_cap cap \<and> pas_cap_cur_auth aag cap" in hoare_gen_asm)
-     apply (rule_tac Q="\<lambda>_. cte_wp_at (\<lambda> c. \<not> is_transferable (Some c)) slot and pas_refined aag and
+     apply (rule_tac Q'="\<lambda>_. cte_wp_at (\<lambda> c. \<not> is_transferable (Some c)) slot and pas_refined aag and
                             pspace_aligned and valid_vspace_objs and valid_arch_state"
                   in hoare_strengthen_post)
       apply (rule validE_valid, rule mapME_x_inv_wp)
@@ -1056,7 +1056,7 @@ lemma invoke_untyped_pas_refined:
    \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   apply (rule hoare_gen_asm)
   apply (rule hoare_pre)
-   apply (rule_tac Q="\<lambda>_. pas_refined aag and pspace_aligned and valid_vspace_objs
+   apply (rule_tac Q'="\<lambda>_. pas_refined aag and pspace_aligned and valid_vspace_objs
                                           and valid_arch_state and pas_cur_domain aag" in hoare_strengthen_post)
    apply (rule invoke_untyped_Q)
         apply (rule hoare_pre, wp create_cap_pas_refined)
@@ -1084,7 +1084,7 @@ lemma invoke_untyped_pas_refined:
        apply blast
       apply (rule hoare_name_pre_state, clarsimp)
       apply (rule hoare_pre, wp retype_region_pas_refined)
-       apply (rule_tac Q="\<lambda>rv. post_retype_invs tp rv and pas_cur_domain aag" in hoare_strengthen_post)
+       apply (rule_tac Q'="\<lambda>rv. post_retype_invs tp rv and pas_cur_domain aag" in hoare_strengthen_post)
         apply (wp retype_region_post_retype_invs_spec)
        apply (clarsimp simp: post_retype_invs_def invs_def valid_state_def valid_pspace_def split: if_splits)
       apply (clarsimp simp: authorised_untyped_inv_def)
@@ -1173,7 +1173,7 @@ lemma decode_untyped_invocation_authorised:
    apply (wp whenE_throwError_wp  hoare_vcg_all_lift mapME_x_inv_wp
           | simp split: untyped_invocation.splits
           | (auto)[1])+
-           apply (rule_tac Q="\<lambda>node_cap s.
+           apply (rule_tac Q'="\<lambda>node_cap s.
                               (is_cnode_cap node_cap \<longrightarrow> is_subject aag (obj_ref_of node_cap)) \<and>
                               is_subject aag (fst slot) \<and> new_type \<noteq> ArchObject ASIDPoolObj \<and>
                               (\<forall>cap. cte_wp_at ((=) cap) slot s

--- a/proof/access-control/Syscall_AC.thy
+++ b/proof/access-control/Syscall_AC.thy
@@ -1155,11 +1155,11 @@ lemma call_kernel_integrity':
   apply (wpsimp wp: activate_thread_respects schedule_integrity_pasMayEditReadyQueues
                     handle_interrupt_integrity dmo_wp handle_interrupt_pas_refined)
     apply (clarsimp simp: if_fun_split)
-    apply (rule_tac Q="\<lambda>rv ms. (rv \<noteq> None \<longrightarrow> the rv \<notin> non_kernel_IRQs) \<and>
-                                R True (domain_sep_inv (pasMaySendIrqs aag) st' s) rv ms"
-                and R="\<lambda>rv ms. R (the rv \<in> non_kernel_IRQs \<longrightarrow> scheduler_act_sane s \<and> ct_not_queued s)
+    apply (rule_tac Q'="\<lambda>rv ms. (rv \<noteq> None \<longrightarrow> the rv \<notin> non_kernel_IRQs) \<and>
+                                Q True (domain_sep_inv (pasMaySendIrqs aag) st' s) rv ms"
+                and Q="\<lambda>rv ms. Q (the rv \<in> non_kernel_IRQs \<longrightarrow> scheduler_act_sane s \<and> ct_not_queued s)
                                  (pasMaySendIrqs aag \<or> interrupt_states s (the rv) \<noteq> IRQSignal) rv ms"
-                for R in hoare_strengthen_post[rotated], fastforce simp: domain_sep_inv_def)
+                for Q in hoare_strengthen_post[rotated], fastforce simp: domain_sep_inv_def)
     apply (wpsimp wp: getActiveIRQ_rv_None hoare_drop_imps getActiveIRQ_inv)
    apply (rule hoare_strengthen_postE,
       rule_tac Q="integrity aag X st and pas_refined aag and einvs and guarded_pas_domain aag

--- a/proof/access-control/Syscall_AC.thy
+++ b/proof/access-control/Syscall_AC.thy
@@ -203,7 +203,7 @@ lemma lcs_reply_owns:
    \<lbrace>\<lambda>rv _. \<forall>ep. (\<exists>m R. fst rv = ReplyCap ep m R \<and> AllowGrant \<in> R) \<longrightarrow> is_subject aag ep\<rbrace>, -"
   apply (rule hoare_strengthen_postE_R)
    apply (rule hoare_pre)
-    apply (rule hoare_vcg_conj_lift_R [where S = "K (pas_refined aag)"])
+    apply (rule hoare_vcg_conj_liftE_R[where Q'="K (pas_refined aag)"])
      apply (rule lookup_cap_and_slot_cur_auth)
     apply (simp | wp lookup_cap_and_slot_inv)+
   apply (force simp: aag_cap_auth_def cap_auth_conferred_def reply_cap_rights_to_auth_def
@@ -283,7 +283,7 @@ lemma handle_invocation_pas_refined:
        | simp add: if_apply_def2 conj_comms split del: if_split)+,
       (wp lookup_extra_caps_auth lookup_extra_caps_authorised decode_invocation_authorised
           lookup_cap_and_slot_authorised lookup_cap_and_slot_cur_auth as_user_pas_refined
-          lookup_cap_and_slot_valid_fault3 hoare_vcg_const_imp_lift_R
+          lookup_cap_and_slot_valid_fault3 hoare_vcg_const_imp_liftE_R
        | simp add: comp_def runnable_eq_active split del: if_split)+,
        fastforce intro: guarded_to_cur_domain if_live_then_nonz_capD
                   simp: ct_in_state_def st_tcb_at_def live_def)+
@@ -317,7 +317,7 @@ lemma handle_invocation_respects:
                    set_thread_state_integrity_autarch
                    lookup_cap_and_slot_cur_auth lookup_cap_and_slot_authorised
                    hoare_vcg_const_imp_lift perform_invocation_pas_refined
-                   set_thread_state_ct_st hoare_vcg_const_imp_lift_R
+                   set_thread_state_ct_st hoare_vcg_const_imp_liftE_R
                    lookup_cap_and_slot_valid_fault3
                 | (rule valid_validE, strengthen invs_vobjs_strgs))+
   by (fastforce intro: st_tcb_ex_cap' guarded_to_cur_domain
@@ -336,7 +336,7 @@ lemma handle_recv_pas_refined:
             lookup_slot_for_thread_authorised lookup_slot_for_thread_cap_fault
             hoare_vcg_all_liftE_R get_simple_ko_wp
          | wpc | simp
-         | (rule_tac Q="\<lambda>rv s. invs s \<and> is_subject aag thread \<and> aag_has_auth_to aag Receive thread"
+         | (rule_tac Q'="\<lambda>rv s. invs s \<and> is_subject aag thread \<and> aag_has_auth_to aag Receive thread"
                   in hoare_strengthen_post,
             wp, clarsimp simp: invs_valid_objs invs_sym_refs))+
      apply (rule_tac Q'="\<lambda>rv s. pas_refined aag s \<and> invs s \<and> tcb_at thread s
@@ -363,7 +363,7 @@ lemma handle_recv_integrity:
             lookup_slot_for_thread_cap_fault get_cap_auth_wp [where aag=aag] get_simple_ko_wp
          | wpc
          | simp
-         | rule_tac Q="\<lambda>rv s. invs s \<and> is_subject aag thread \<and> aag_has_auth_to aag Receive thread"
+         | rule_tac Q'="\<lambda>rv s. invs s \<and> is_subject aag thread \<and> aag_has_auth_to aag Receive thread"
                  in hoare_strengthen_post, wp, clarsimp simp: invs_valid_objs invs_sym_refs)+
      apply (rule_tac Q'="\<lambda>rv s. pas_refined aag s \<and> einvs s \<and> is_subject aag (cur_thread s)
                               \<and> tcb_at thread s \<and> cur_thread s = thread \<and> is_subject aag thread
@@ -705,7 +705,7 @@ lemma handle_event_integrity:
                   handle_reply_valid_sched
                   hoare_vcg_conj_lift hoare_vcg_all_lift hoare_drop_imps
             simp: domain_sep_inv_def
-      | rule dmo_wp hoare_vcg_E_elim
+      | rule dmo_wp hoare_vcg_conj_elimE
       | fastforce
       | (rule hoare_vcg_conj_lift)?, wpsimp wp: getActiveIRQ_inv)+
 

--- a/proof/access-control/Tcb_AC.thy
+++ b/proof/access-control/Tcb_AC.thy
@@ -383,7 +383,7 @@ lemma invoke_tcb_pas_refined:
   apply (rule hoare_gen_asm)
   apply (cases ti, simp_all add: authorised_tcb_inv_def)
         apply (wp ita_wps hoare_drop_imps
-                  hoare_strengthen_post[where Q="\<lambda>_. pas_refined aag and pspace_aligned
+                  hoare_strengthen_post[where Q'="\<lambda>_. pas_refined aag and pspace_aligned
                                                                      and valid_vspace_objs
                                                                      and valid_arch_state",
                                         OF mapM_x_wp']
@@ -440,7 +440,7 @@ lemma decode_set_space_authorised:
   apply (simp cong: list.case_cong split del: if_split)
   apply (clarsimp simp: ball_Un split del: if_split
          | wp (once) derive_cap_obj_refs_auth derive_cap_untyped_range_subset derive_cap_clas
-                     derive_cap_cli hoare_vcg_const_imp_lift_R hoare_vcg_all_liftE_R
+                     derive_cap_cli hoare_vcg_const_imp_liftE_R hoare_vcg_all_liftE_R
                      whenE_throwError_wp slot_long_running_inv)+
   apply (clarsimp simp: not_less all_set_conv_all_nth dest!: P_0_1_spec)
   apply (auto simp: aag_cap_auth_def update_cap_cli

--- a/proof/capDL-api/Arch_DP.thy
+++ b/proof/capDL-api/Arch_DP.thy
@@ -224,7 +224,7 @@ lemma seL4_Page_Table_Map:
          in hoare_gen_asmEx)
         apply (elim conjE exE)
         apply simp
-        apply (rule_tac Q = "\<lambda>iv s. cdl_current_thread s = Some root_tcb_id \<and>
+        apply (rule_tac Q'="\<lambda>iv s. cdl_current_thread s = Some root_tcb_id \<and>
                                     cdl_current_domain s = minBound \<and>
           <(root_tcb_id, tcb_pending_op_slot) \<mapsto>c RunningCap
           \<and>* (root_tcb_id, tcb_cspace_slot) \<mapsto>c cnode_cap
@@ -238,7 +238,7 @@ lemma seL4_Page_Table_Map:
          in hoare_strengthen_postE[rotated -1])
            apply assumption
           apply clarsimp
-         apply (rule hoare_vcg_E_elim)
+         apply (rule hoare_vcg_conj_elimE)
           apply wp
          apply wp
          apply (rule validE_validE_R)
@@ -353,7 +353,7 @@ lemma seL4_Section_Map_wp:
          in hoare_gen_asmEx)
         apply (elim exE)+
         apply simp
-        apply (rule_tac Q = "\<lambda>iv s. cdl_current_thread s = Some root_tcb_id \<and>
+        apply (rule_tac Q'="\<lambda>iv s. cdl_current_thread s = Some root_tcb_id \<and>
                                     cdl_current_domain s = minBound \<and>
           <(root_tcb_id, tcb_pending_op_slot) \<mapsto>c RunningCap
           \<and>* (root_tcb_id, tcb_cspace_slot) \<mapsto>c cnode_cap
@@ -367,7 +367,7 @@ lemma seL4_Section_Map_wp:
           [cdl_lookup_pd_slot pd_ptr vaddr])"
          in hoare_strengthen_postE[rotated -1])
           apply assumption
-         apply (rule hoare_vcg_E_elim)
+         apply (rule hoare_vcg_conj_elimE)
           apply wp
          apply wp
          apply (rule validE_validE_R)
@@ -492,7 +492,7 @@ lemma seL4_Page_Map_wp:
          in hoare_gen_asmEx)
         apply (elim exE)+
         apply simp
-        apply (rule_tac Q = "\<lambda>iv s. cdl_current_thread s = Some root_tcb_id \<and>
+        apply (rule_tac Q'="\<lambda>iv s. cdl_current_thread s = Some root_tcb_id \<and>
                                     cdl_current_domain s = minBound \<and>
           <(root_tcb_id, tcb_pending_op_slot) \<mapsto>c RunningCap
           \<and>* (root_tcb_id, tcb_cspace_slot) \<mapsto>c cnode_cap
@@ -508,7 +508,7 @@ lemma seL4_Page_Map_wp:
              (cnode_id,frame_offset) [ (pt_ptr, unat ((vaddr >> 12) && 0xFF))] )"
          in hoare_strengthen_postE[rotated -1])
           apply assumption
-         apply (rule hoare_vcg_E_elim)
+         apply (rule hoare_vcg_conj_elimE)
           apply wp
          apply wp
          apply (rule validE_validE_R)

--- a/proof/capDL-api/CNode_DP.thy
+++ b/proof/capDL-api/CNode_DP.thy
@@ -189,7 +189,7 @@ lemma seL4_CNode_Mint_sep:
           apply (sep_solve)
          apply sep_solve
         apply (assumption)
-       apply (rule_tac Q = "\<lambda>r. (\<lambda>s. cdl_current_thread s = Some root_tcb_id \<and>
+       apply (rule_tac Q'="\<lambda>r. (\<lambda>s. cdl_current_thread s = Some root_tcb_id \<and>
                 cdl_current_domain s = minBound) and
                 < (root_tcb_id, tcb_pending_op_slot) \<mapsto>c RestartCap \<and>* Q > and
                 K (\<exists>cap''. reset_cap_asid cap'' = reset_cap_asid cap' \<and> iv = InvokeCNode
@@ -354,7 +354,7 @@ lemma seL4_CNode_Mutate_sep:
             apply (sep_solve)
           apply sep_solve
          apply (assumption)
-        apply (rule_tac Q = "\<lambda>r. < (root_tcb_id, tcb_pending_op_slot) \<mapsto>c RestartCap \<and>* Q >
+        apply (rule_tac Q'="\<lambda>r. < (root_tcb_id, tcb_pending_op_slot) \<mapsto>c RestartCap \<and>* Q >
           and (\<lambda>a. cdl_current_thread a = Some root_tcb_id
                  \<and> cdl_current_domain a = minBound) and K(\<exists>dcap.
            reset_cap_asid dcap = reset_cap_asid src_cap \<and>
@@ -513,7 +513,7 @@ lemma seL4_CNode_Move_sep:
            apply (sep_solve)
           apply sep_solve
          apply (assumption)
-        apply (rule_tac Q = "\<lambda>r. < (root_tcb_id, tcb_pending_op_slot) \<mapsto>c RestartCap \<and>* Q>
+        apply (rule_tac Q'="\<lambda>r. < (root_tcb_id, tcb_pending_op_slot) \<mapsto>c RestartCap \<and>* Q>
           and (\<lambda>a. cdl_current_thread a = Some root_tcb_id
                  \<and> cdl_current_domain a = minBound) and K(\<exists>dcap.
            reset_cap_asid dcap = reset_cap_asid src_cap \<and>
@@ -670,7 +670,7 @@ lemma seL4_CNode_Copy_sep:
            apply (sep_solve)
           apply sep_solve
          apply (assumption)
-        apply (rule_tac Q = "\<lambda>r. (\<lambda>s. cdl_current_thread s = Some root_tcb_id
+        apply (rule_tac Q'="\<lambda>r. (\<lambda>s. cdl_current_thread s = Some root_tcb_id
                                     \<and> cdl_current_domain s = minBound) and
           < (root_tcb_id, tcb_pending_op_slot) \<mapsto>c RestartCap \<and>* Q> and
           K (\<exists>cap''. reset_cap_asid cap'' = reset_cap_asid src_cap \<and> iv = InvokeCNode

--- a/proof/capDL-api/Invocation_DP.thy
+++ b/proof/capDL-api/Invocation_DP.thy
@@ -569,7 +569,7 @@ lemma call_kernel_with_intent_no_fault_helper:
   apply wp
         apply (rule_tac P = "thread_ptr = root_tcb_id" in hoare_gen_asm)
         apply (simp add:call_kernel_loop_def)
-        apply (rule_tac Q = "\<lambda>r s. cdl_current_thread s = Some root_tcb_id
+        apply (rule_tac Q'="\<lambda>r s. cdl_current_thread s = Some root_tcb_id
                                \<and> cdl_current_domain s = minBound \<longrightarrow> Q s
                " in hoare_strengthen_post[rotated])
          apply fastforce
@@ -580,7 +580,7 @@ lemma call_kernel_with_intent_no_fault_helper:
             apply (rule hoare_pre_cont)
            apply (wp has_restart_cap_sep_wp[where cap = RunningCap])[1]
           apply wp
-         apply (rule_tac Q = "\<lambda>r s. cdl_current_thread s = Some root_tcb_id
+         apply (rule_tac Q'="\<lambda>r s. cdl_current_thread s = Some root_tcb_id
                               \<and> cdl_current_domain s = minBound \<longrightarrow> (Q s
                               \<and>  <(root_tcb_id, tcb_pending_op_slot) \<mapsto>c RunningCap \<and>* (\<lambda>s. True)> s)"
                 in hoare_strengthen_post)
@@ -1049,7 +1049,7 @@ lemma call_kernel_with_intent_allow_error_helper:
   apply (wp thread_has_error_wp)
         apply (simp add:call_kernel_loop_def)
         apply (rule_tac P = "thread_ptr = root_tcb_id" in hoare_gen_asm)
-        apply (rule_tac Q = "\<lambda>r s. (cdl_current_thread s = Some root_tcb_id
+        apply (rule_tac Q'="\<lambda>r s. (cdl_current_thread s = Some root_tcb_id
                                     \<and> cdl_current_domain s = minBound) \<longrightarrow>
                                        (\<not>tcb_has_error (the (cdl_current_thread s)) s \<longrightarrow> Q s) \<and>
                                        (tcb_has_error (the (cdl_current_thread s)) s \<longrightarrow> Perror s)"

--- a/proof/capDL-api/Invocation_DP.thy
+++ b/proof/capDL-api/Invocation_DP.thy
@@ -870,8 +870,7 @@ lemma tcb_has_error_set_cap:
   \<lbrace>\<lambda>ya s. P (tcb_has_error p s)\<rbrace>"
   apply (rule hoare_name_pre_state)
   apply clarsimp
-  apply (rule_tac Q = "\<lambda>r s'. tcb_has_error p s' = tcb_has_error p s" in
-    hoare_strengthen_post)
+  apply (rule_tac Q'="\<lambda>r s'. tcb_has_error p s' = tcb_has_error p s" in hoare_strengthen_post)
   apply (simp add:set_cap_def
     gets_the_def set_object_def
     split_def)
@@ -1067,7 +1066,7 @@ lemma call_kernel_with_intent_allow_error_helper:
                          hoare_strengthen_post[OF schedule_no_choice_wp])
          apply (clarsimp, assumption)
         apply clarsimp
-        apply (rule_tac Q =
+        apply (rule_tac Q'=
                "\<lambda>r a. (\<not> tcb_has_error root_tcb_id a \<longrightarrow> (Q a
                             \<and> cdl_current_thread a = Some root_tcb_id
                             \<and> cdl_current_domain a = minBound

--- a/proof/capDL-api/Retype_DP.thy
+++ b/proof/capDL-api/Retype_DP.thy
@@ -714,7 +714,6 @@ lemma unify_failure_cdt_lift:
   including no_pre
   apply (wp hoare_drop_imps)
   apply (clarsimp simp:validE_def valid_def)
-  apply (case_tac a,fastforce+)
   done
 
 lemma validE_def2:
@@ -960,7 +959,7 @@ lemma invoke_untyped_preempt:
   apply (wp unlessE_wp)
    apply (simp add: reset_untyped_cap_def whenE_liftE | wp whenE_wp)+
       apply (rule_tac P = "\<exists>a. cap = UntypedCap dev obj_range a" in hoare_gen_asmEx)
-      apply (rule hoare_strengthen_postE[where E'=E and F = E for E])
+      apply (rule hoare_strengthen_postE[where E'=E and E=E for E])
         apply (rule mapME_x_inv_wp[where P = P and E = "\<lambda>r. P" for P])
         apply wp
          apply simp

--- a/proof/capDL-api/Retype_DP.thy
+++ b/proof/capDL-api/Retype_DP.thy
@@ -613,9 +613,9 @@ lemma seL4_Untyped_Retype_sep:
                has_kids 1)"
            in hoare_gen_asmEx)
          apply clarsimp
-         apply (rule hoare_vcg_E_elim[where P = P and P' = P for P,simplified,rotated])
+         apply (rule hoare_vcg_conj_elimE[where P = P and P' = P for P,simplified,rotated])
           apply wp
-          apply (rule hoare_strengthen_postE_R[OF hoare_vcg_conj_lift_R])
+          apply (rule hoare_strengthen_postE_R[OF hoare_vcg_conj_liftE_R])
            apply (rule invoke_untyped_one_has_children)
            apply fastforce
           apply (rule_tac P = "P1 \<and>* P2" for P1 P2 in
@@ -792,7 +792,7 @@ lemma invoke_untyped_cdt_inc[wp]:
         apply (wp set_parent_other unless_wp unlessE_wp
                | wpc | simp)+
    apply (simp add: reset_untyped_cap_def validE_def sum.case_eq_if)
-   apply (rule_tac Q = "\<lambda>r s. cdl_cdt s child = Some parent" in hoare_post_imp)
+   apply (rule_tac Q'="\<lambda>r s. cdl_cdt s child = Some parent" in hoare_post_imp)
     apply simp
    apply (wp whenE_wp mapME_x_inv_wp | simp)+
   apply (clarsimp simp:detype_def)
@@ -960,7 +960,7 @@ lemma invoke_untyped_preempt:
   apply (wp unlessE_wp)
    apply (simp add: reset_untyped_cap_def whenE_liftE | wp whenE_wp)+
       apply (rule_tac P = "\<exists>a. cap = UntypedCap dev obj_range a" in hoare_gen_asmEx)
-      apply (rule hoare_strengthen_postE[where E = E and F = E for E])
+      apply (rule hoare_strengthen_postE[where E'=E and F = E for E])
         apply (rule mapME_x_inv_wp[where P = P and E = "\<lambda>r. P" for P])
         apply wp
          apply simp
@@ -1237,9 +1237,9 @@ lemma seL4_Untyped_Retype_inc_no_preempt:
                has_kids 1)"
            in hoare_gen_asmEx)
          apply clarsimp
-         apply (rule hoare_vcg_E_elim[where P = P and P' = P for P,simplified,rotated])
+         apply (rule hoare_vcg_conj_elimE[where P = P and P' = P for P,simplified,rotated])
           apply wp
-          apply (rule hoare_strengthen_postE_R[OF hoare_vcg_conj_lift_R])
+          apply (rule hoare_strengthen_postE_R[OF hoare_vcg_conj_liftE_R])
            apply (rule valid_validE_R)
            apply (rule invoke_untyped_cdt_inc)
           apply (rule_tac P = "P1 \<and>* P2" for P1 P2 in

--- a/proof/capDL-api/TCB_DP.thy
+++ b/proof/capDL-api/TCB_DP.thy
@@ -220,8 +220,8 @@ lemma tcb_update_cspace_root_wp:
   apply (wpsimp wp: whenE_wp tcb_update_thread_slot_wp[sep_wand_side_wpE] get_cap_rv
                     hoare_vcg_conj_liftE1)
     apply (wpsimp wp: tcb_empty_thread_slot_wpE[sep_wand_wpE] simp: sep_conj_assoc)
-   apply (wpsimp wp: hoare_vcg_all_liftE_R[THEN hoare_vcg_E_elim[rotated]]
-                     hoare_vcg_const_imp_lift_R
+   apply (wpsimp wp: hoare_vcg_all_liftE_R[THEN hoare_vcg_conj_elimE[rotated]]
+                     hoare_vcg_const_imp_liftE_R
                      tcb_empty_thread_slot_wpE[sep_wand_wpE]
           split_del: if_split simp: if_apply_def2)
   apply (clarsimp)
@@ -534,7 +534,7 @@ lemma invoke_tcb_ThreadControl_cur_thread:
          apply (rule hoare_post_imp[OF _  insert_cap_sibling_wp])
        apply (sep_erule_concl refl_imp sep_any_imp)+
        apply (assumption)
-       apply (rule_tac Q = "\<lambda>r s. P (cdl_current_thread s)
+       apply (rule_tac Q'="\<lambda>r s. P (cdl_current_thread s)
          \<and> (<(target_tcb, tcb_vspace_slot) \<mapsto>c -
          \<and>* (target_tcb, tcb_cspace_slot) \<mapsto>c -
          \<and>* (target_tcb, tcb_ipcbuffer_slot) \<mapsto>c NullCap
@@ -542,7 +542,7 @@ lemma invoke_tcb_ThreadControl_cur_thread:
          " in hoare_post_imp)
        apply (clarsimp simp:sep_conj_ac)
        apply wp+
-     apply (rule_tac Q = "\<lambda>r s. P (cdl_current_thread s)
+     apply (rule_tac Q'="\<lambda>r s. P (cdl_current_thread s)
        \<and> (<(target_tcb, tcb_vspace_slot) \<mapsto>c -
        \<and>* (target_tcb,tcb_cspace_slot) \<mapsto>c -
        \<and>* (target_tcb, tcb_ipcbuffer_slot) \<mapsto>c NullCap
@@ -563,7 +563,7 @@ lemma invoke_tcb_ThreadControl_cur_thread:
        apply (sep_select 2)
        apply (drule sep_map_c_any)
        apply assumption
-      apply (rule_tac Q = "\<lambda>r s. P (cdl_current_thread s)
+      apply (rule_tac Q'="\<lambda>r s. P (cdl_current_thread s)
         \<and> (<(target_tcb, tcb_vspace_slot) \<mapsto>c -
         \<and>* (target_tcb,tcb_cspace_slot) \<mapsto>c -
         \<and>* (target_tcb, tcb_ipcbuffer_slot) \<mapsto>c NullCap
@@ -572,7 +572,7 @@ lemma invoke_tcb_ThreadControl_cur_thread:
         " in hoare_post_imp)
        apply (clarsimp simp:sep_conj_ac)
       apply wp+
-     apply (rule_tac Q = "\<lambda>r s. P (cdl_current_thread s)
+     apply (rule_tac Q'="\<lambda>r s. P (cdl_current_thread s)
        \<and> (<(target_tcb, tcb_vspace_slot) \<mapsto>c -
        \<and>* (target_tcb, tcb_cspace_slot) \<mapsto>c -
        \<and>* (target_tcb, tcb_ipcbuffer_slot) \<mapsto>c NullCap
@@ -582,7 +582,7 @@ lemma invoke_tcb_ThreadControl_cur_thread:
      apply (wp tcb_empty_thread_slot_wp_inv)
     apply clarsimp
     apply sep_solve
-    apply (rule_tac Q = "\<lambda>r s. P (cdl_current_thread s)
+    apply (rule_tac Q'="\<lambda>r s. P (cdl_current_thread s)
        \<and> (<(target_tcb, tcb_vspace_slot) \<mapsto>c NullCap
       \<and>* (target_tcb,tcb_cspace_slot) \<mapsto>c -
       \<and>* (target_tcb, tcb_ipcbuffer_slot) \<mapsto>c NullCap
@@ -596,7 +596,7 @@ lemma invoke_tcb_ThreadControl_cur_thread:
         apply (sep_schem)
        apply wp
        apply (rule hoare_post_imp[OF _ insert_cap_sibling_wp], sep_schem)
-      apply (rule_tac Q = "\<lambda>r s. P (cdl_current_thread s)
+      apply (rule_tac Q'="\<lambda>r s. P (cdl_current_thread s)
         \<and> (<(target_tcb, tcb_vspace_slot) \<mapsto>c NullCap
         \<and>* (target_tcb,tcb_cspace_slot) \<mapsto>c -
         \<and>* (target_tcb, tcb_ipcbuffer_slot) \<mapsto>c NullCap
@@ -605,7 +605,7 @@ lemma invoke_tcb_ThreadControl_cur_thread:
        apply (clarsimp simp:sep_conj_ac, sep_solve)
       apply wp+
      apply (rule_tac P = "cap_type (fst x2) \<noteq> Some UntypedType" in hoare_gen_asmEx)
-     apply (rule_tac Q = "\<lambda>r s. P (cdl_current_thread s)
+     apply (rule_tac Q'="\<lambda>r s. P (cdl_current_thread s)
        \<and> (<(target_tcb, tcb_vspace_slot) \<mapsto>c NullCap
        \<and>* (target_tcb, tcb_cspace_slot) \<mapsto>c -
        \<and>* (target_tcb, tcb_ipcbuffer_slot) \<mapsto>c NullCap
@@ -620,7 +620,7 @@ lemma invoke_tcb_ThreadControl_cur_thread:
    apply sep_solve+
   apply (rule hoare_pre)
    apply (wp|wpc|simp)+
-   apply (rule_tac Q = "\<lambda>r s. P (cdl_current_thread s)
+   apply (rule_tac Q'="\<lambda>r s. P (cdl_current_thread s)
           \<and> (<(target_tcb, tcb_vspace_slot) \<mapsto>c NullCap
           \<and>* (target_tcb,tcb_cspace_slot) \<mapsto>c NullCap
           \<and>* (target_tcb, tcb_ipcbuffer_slot) \<mapsto>c NullCap
@@ -799,7 +799,7 @@ lemma invoke_tcb_ThreadControl_cdl_current_domain:
        apply wp
          apply (rule hoare_post_imp[OF _  insert_cap_sibling_wp])
        apply (sep_schem)
-       apply (rule_tac Q = "\<lambda>r s. P (cdl_current_domain s)
+       apply (rule_tac Q'="\<lambda>r s. P (cdl_current_domain s)
          \<and> (<(target_tcb, tcb_vspace_slot) \<mapsto>c -
          \<and>* (target_tcb, tcb_cspace_slot) \<mapsto>c -
          \<and>* (target_tcb, tcb_ipcbuffer_slot) \<mapsto>c NullCap
@@ -807,7 +807,7 @@ lemma invoke_tcb_ThreadControl_cdl_current_domain:
          " in hoare_post_imp)
          apply (clarsimp simp: sep_conj_ac, sep_solve)
         apply wp+
-      apply (rule_tac Q = "\<lambda>r s. P (cdl_current_domain s)
+      apply (rule_tac Q'="\<lambda>r s. P (cdl_current_domain s)
        \<and> (<(target_tcb, tcb_vspace_slot) \<mapsto>c -
        \<and>* (target_tcb,tcb_cspace_slot) \<mapsto>c -
        \<and>* (target_tcb, tcb_ipcbuffer_slot) \<mapsto>c NullCap
@@ -828,7 +828,7 @@ lemma invoke_tcb_ThreadControl_cdl_current_domain:
         apply (sep_select 2)
         apply (drule sep_map_c_any)
         apply assumption
-       apply (rule_tac Q = "\<lambda>r s. P (cdl_current_domain s)
+       apply (rule_tac Q'="\<lambda>r s. P (cdl_current_domain s)
         \<and> (<(target_tcb, tcb_vspace_slot) \<mapsto>c -
         \<and>* (target_tcb,tcb_cspace_slot) \<mapsto>c -
         \<and>* (target_tcb, tcb_ipcbuffer_slot) \<mapsto>c NullCap
@@ -837,7 +837,7 @@ lemma invoke_tcb_ThreadControl_cdl_current_domain:
         " in hoare_post_imp)
         apply (clarsimp simp:sep_conj_ac)
        apply wp+
-     apply (rule_tac Q = "\<lambda>r s. P (cdl_current_domain s)
+     apply (rule_tac Q'="\<lambda>r s. P (cdl_current_domain s)
        \<and> (<(target_tcb, tcb_vspace_slot) \<mapsto>c -
        \<and>* (target_tcb, tcb_cspace_slot) \<mapsto>c -
        \<and>* (target_tcb, tcb_ipcbuffer_slot) \<mapsto>c NullCap
@@ -847,7 +847,7 @@ lemma invoke_tcb_ThreadControl_cdl_current_domain:
       apply (wp tcb_empty_thread_slot_wp_inv)
      apply clarsimp
      apply sep_solve
-    apply (rule_tac Q = "\<lambda>r s. P (cdl_current_domain s)
+    apply (rule_tac Q'="\<lambda>r s. P (cdl_current_domain s)
        \<and> (<(target_tcb, tcb_vspace_slot) \<mapsto>c NullCap
       \<and>* (target_tcb,tcb_cspace_slot) \<mapsto>c -
       \<and>* (target_tcb, tcb_ipcbuffer_slot) \<mapsto>c NullCap
@@ -866,7 +866,7 @@ lemma invoke_tcb_ThreadControl_cdl_current_domain:
         apply (sep_select 2)
         apply (drule sep_map_c_any)
         apply assumption
-       apply (rule_tac Q = "\<lambda>r s. P (cdl_current_domain s)
+       apply (rule_tac Q'="\<lambda>r s. P (cdl_current_domain s)
         \<and> (<(target_tcb, tcb_vspace_slot) \<mapsto>c NullCap
         \<and>* (target_tcb,tcb_cspace_slot) \<mapsto>c -
         \<and>* (target_tcb, tcb_ipcbuffer_slot) \<mapsto>c NullCap
@@ -875,7 +875,7 @@ lemma invoke_tcb_ThreadControl_cdl_current_domain:
         apply (clarsimp simp:sep_conj_ac)
        apply wp+
      apply (rule_tac P = "cap_type (fst x2) \<noteq> Some UntypedType" in hoare_gen_asmEx)
-     apply (rule_tac Q = "\<lambda>r s. P (cdl_current_domain s)
+     apply (rule_tac Q'="\<lambda>r s. P (cdl_current_domain s)
        \<and> (<(target_tcb, tcb_vspace_slot) \<mapsto>c NullCap
        \<and>* (target_tcb, tcb_cspace_slot) \<mapsto>c -
        \<and>* (target_tcb, tcb_ipcbuffer_slot) \<mapsto>c NullCap
@@ -890,7 +890,7 @@ lemma invoke_tcb_ThreadControl_cdl_current_domain:
                  apply sep_solve+
    apply (rule hoare_pre)
     apply (wp|wpc|simp)+
-    apply (rule_tac Q = "\<lambda>r s. P (cdl_current_domain s)
+    apply (rule_tac Q'="\<lambda>r s. P (cdl_current_domain s)
           \<and> (<(target_tcb, tcb_vspace_slot) \<mapsto>c NullCap
           \<and>* (target_tcb,tcb_cspace_slot) \<mapsto>c NullCap
           \<and>* (target_tcb, tcb_ipcbuffer_slot) \<mapsto>c NullCap
@@ -1060,7 +1060,7 @@ shows
             apply (sep_schem)
            apply sep_solve
           apply assumption
-         apply (rule_tac Q = "\<lambda>r s. cdl_current_thread s = Some root_tcb_id \<and>
+         apply (rule_tac Q'="\<lambda>r s. cdl_current_thread s = Some root_tcb_id \<and>
           cdl_current_domain s = minBound \<and>
           (\<exists>cspace_cap' vspace_cap' buffer_frame_cap'.
           iv = (InvokeTcb $
@@ -1082,7 +1082,7 @@ shows
           root_tcb_id \<mapsto>f Tcb cdl_tcb \<and>*
           cap_object cnode_cap \<mapsto>f CNode (empty_cnode root_size) \<and>*
           (root_tcb_id, tcb_cspace_slot) \<mapsto>c cnode_cap \<and>* (cap_object cnode_cap, cnode_cap_slot) \<mapsto>c cnode_cap' \<and>* R> s"
-          in  hoare_strengthen_post)
+          in hoare_strengthen_post)
           apply wp
           apply clarsimp
           apply (rule hoare_strengthen_post[OF set_cap_wp])

--- a/proof/crefine/AARCH64/Arch_C.thy
+++ b/proof/crefine/AARCH64/Arch_C.thy
@@ -588,7 +588,7 @@ shows
       apply clarsimp
       apply (wp getSlotCap_wp)
      apply clarsimp
-    apply (rule_tac Q="\<lambda>_. cte_wp_at' ((=) (UntypedCap isdev frame pageBits idx) o cteCap) parent
+    apply (rule_tac Q'="\<lambda>_. cte_wp_at' ((=) (UntypedCap isdev frame pageBits idx) o cteCap) parent
                           and (\<lambda>s. descendants_range_in' {frame..frame + (2::machine_word) ^ pageBits - (1::machine_word)} parent (ctes_of s))
                           and pspace_no_overlap' frame pageBits
                           and invs'

--- a/proof/crefine/AARCH64/DetWP.thy
+++ b/proof/crefine/AARCH64/DetWP.thy
@@ -120,7 +120,7 @@ lemma det_wp_asUser [wp]:
       apply (drule det_wp_det)
       apply (erule det_wp_select_f)
      apply wp+
-   apply (rule_tac Q="\<lambda>_. tcb_at' t" in hoare_post_imp)
+   apply (rule_tac Q'="\<lambda>_. tcb_at' t" in hoare_post_imp)
     apply simp
    apply wp
   apply simp

--- a/proof/crefine/AARCH64/Fastpath_C.thy
+++ b/proof/crefine/AARCH64/Fastpath_C.thy
@@ -1580,7 +1580,7 @@ lemma user_getreg_wp:
   "\<lbrace>\<lambda>s. tcb_at' t s \<and> (\<forall>rv. obj_at' (\<lambda>tcb. (user_regs \<circ> atcbContextGet \<circ> tcbArch) tcb r = rv) t s
         \<longrightarrow> Q rv s)\<rbrace>
    asUser t (getRegister r) \<lbrace>Q\<rbrace>"
-  apply (rule_tac Q="\<lambda>rv s. \<exists>rv'. rv' = rv \<and> Q rv' s" in hoare_post_imp)
+  apply (rule_tac Q'="\<lambda>rv s. \<exists>rv'. rv' = rv \<and> Q rv' s" in hoare_post_imp)
    apply simp
   apply (rule hoare_pre, wp hoare_vcg_ex_lift user_getreg_rv)
   apply (clarsimp simp: obj_at'_def)
@@ -2468,7 +2468,7 @@ proof -
                                       set_ep_valid_objs' asid_has_vmid_lift
                                       setObject_no_0_obj'[where 'a=endpoint, folded setEndpoint_def]
                                    | strengthen not_obj_at'_strengthen)+
-                             apply (rule_tac Q="\<lambda>_ s. hd (epQueue send_ep) \<noteq> curThread
+                             apply (rule_tac Q'="\<lambda>_ s. hd (epQueue send_ep) \<noteq> curThread
                                                       \<and> pred_tcb_at' itcbState ((=) (tcbState xa)) (hd (epQueue send_ep)) s"
                                           in hoare_post_imp)
                               apply fastforce

--- a/proof/crefine/AARCH64/Fastpath_Equiv.thy
+++ b/proof/crefine/AARCH64/Fastpath_Equiv.thy
@@ -243,7 +243,7 @@ lemma ctes_of_Some_cte_wp_at:
 lemma user_getreg_wp:
   "\<lbrace>\<lambda>s. tcb_at' t s \<and> (\<forall>rv. obj_at' (\<lambda>tcb. (user_regs \<circ> atcbContextGet o tcbArch) tcb r = rv) t s \<longrightarrow> Q rv s)\<rbrace>
       asUser t (getRegister r) \<lbrace>Q\<rbrace>"
-  apply (rule_tac Q="\<lambda>rv s. \<exists>rv'. rv' = rv \<and> Q rv' s" in hoare_post_imp)
+  apply (rule_tac Q'="\<lambda>rv s. \<exists>rv'. rv' = rv \<and> Q rv' s" in hoare_post_imp)
    apply simp
   apply (rule hoare_pre, wp hoare_vcg_ex_lift user_getreg_rv)
   apply (clarsimp simp: obj_at'_def)

--- a/proof/crefine/AARCH64/Finalise_C.thy
+++ b/proof/crefine/AARCH64/Finalise_C.thy
@@ -757,7 +757,7 @@ lemma suspend_ccorres:
         apply ceqv
        apply (ctac(no_vcg) add: setThreadState_ccorres_simple)
         apply (ctac add: tcbSchedDequeue_ccorres)
-       apply (rule_tac Q="\<lambda>_. valid_objs' and tcb_at' thread and pspace_aligned' and pspace_distinct'"
+       apply (rule_tac Q'="\<lambda>_. valid_objs' and tcb_at' thread and pspace_aligned' and pspace_distinct'"
                     in hoare_post_imp)
         apply clarsimp
        apply (wp sts_valid_objs')[1]
@@ -2394,7 +2394,7 @@ lemma associateVCPUTCB_ccorres:
       apply ((wpsimp wp: hoare_vcg_all_lift hoare_drop_imps
               | strengthen invs_valid_objs' invs_arch_state')+)[1]
      apply (vcg exspec=dissociateVCPUTCB_modifies)
-    apply (rule_tac Q="\<lambda>_. invs' and vcpu_at' vcpuptr and tcb_at' tptr" in hoare_post_imp)
+    apply (rule_tac Q'="\<lambda>_. invs' and vcpu_at' vcpuptr and tcb_at' tptr" in hoare_post_imp)
      apply (clarsimp simp: typ_at_tcb' obj_at'_def)
      apply (rename_tac vcpu obj, case_tac vcpu)
      apply (fastforce simp: valid_arch_tcb'_def valid_vcpu'_def objBits_simps)

--- a/proof/crefine/AARCH64/Invoke_C.thy
+++ b/proof/crefine/AARCH64/Invoke_C.thy
@@ -76,7 +76,7 @@ lemma setDomain_ccorres:
        apply (simp add: guard_is_UNIV_def)
       apply simp
       apply wp
-     apply (rule_tac Q="\<lambda>_. all_invs_but_sch_extra and tcb_at' t and sch_act_simple
+     apply (rule_tac Q'="\<lambda>_. all_invs_but_sch_extra and tcb_at' t and sch_act_simple
                             and (\<lambda>s. curThread = ksCurThread s)"
               in hoare_strengthen_post)
       apply (wp threadSet_all_invs_but_sch_extra)
@@ -84,7 +84,7 @@ lemma setDomain_ccorres:
                             sch_act_simple_def st_tcb_at'_def weak_sch_act_wf_def
                      split: if_splits)
     apply (simp add: guard_is_UNIV_def)
-   apply (rule_tac Q="\<lambda>_. invs' and tcb_at' t and sch_act_simple and (\<lambda>s. curThread = ksCurThread s)"
+   apply (rule_tac Q'="\<lambda>_. invs' and tcb_at' t and sch_act_simple and (\<lambda>s. curThread = ksCurThread s)"
             in hoare_strengthen_post)
     apply (wp weak_sch_act_wf_lift_linear tcbSchedDequeue_not_queued
               hoare_vcg_imp_lift hoare_vcg_all_lift)
@@ -762,7 +762,7 @@ lemma decodeCNodeInvocation_ccorres:
                                apply (rule_tac Q'="\<lambda>rv. valid_pspace'
                                                     and valid_cap' rv and valid_objs'
                                                          and tcb_at' thread and (\<lambda>s. sch_act_wf (ksSchedulerAction s) s)"
-                                           in hoare_vcg_R_conj)
+                                           in hoare_vcg_conj_liftE_R)
                                 apply (rule deriveCap_Null_helper[OF deriveCap_derived])
                                apply wp
                               apply (clarsimp simp: cte_wp_at_ctes_of)
@@ -838,7 +838,7 @@ lemma decodeCNodeInvocation_ccorres:
                                    apply (rule_tac Q'="\<lambda>rv. valid_pspace'
                                                         and valid_cap' rv and valid_objs'
                                                              and tcb_at' thread and (\<lambda>s. sch_act_wf (ksSchedulerAction s) s)"
-                                               in hoare_vcg_R_conj)
+                                               in hoare_vcg_conj_liftE_R)
                                     apply (rule deriveCap_Null_helper [OF deriveCap_derived])
                                    apply wp
                                   apply (clarsimp simp: cte_wp_at_ctes_of)
@@ -959,7 +959,7 @@ lemma decodeCNodeInvocation_ccorres:
                       apply (clarsimp simp:valid_updateCapDataI invs_valid_objs' invs_valid_pspace')
                       apply assumption
                      apply (wp hoare_vcg_all_liftE_R injection_wp_E[OF refl]
-                               lsfco_cte_at' hoare_vcg_const_imp_lift_R
+                               lsfco_cte_at' hoare_vcg_const_imp_liftE_R
                            )+
                     apply (simp add: Collect_const_mem word_sle_def word_sless_def
                                      all_ex_eq_helper)
@@ -1336,7 +1336,7 @@ lemma decodeCNodeInvocation_ccorres:
           apply (rule ccorres_return_C_errorE, simp+)[1]
          apply vcg
         apply simp
-        apply (wp injection_wp_E[OF refl] hoare_vcg_const_imp_lift_R
+        apply (wp injection_wp_E[OF refl] hoare_vcg_const_imp_liftE_R
                   hoare_vcg_all_liftE_R lsfco_cte_at' hoare_weak_lift_imp
                 | simp add: hasCancelSendRights_not_Null ctes_of_valid_strengthen
                       cong: conj_cong

--- a/proof/crefine/AARCH64/IpcCancel_C.thy
+++ b/proof/crefine/AARCH64/IpcCancel_C.thy
@@ -2774,7 +2774,7 @@ lemma cancelIPC_ccorres1:
                                 ghost_assertion_data_set_def cap_tag_defs)
               apply (simp add: locateSlot_conv, wp)
              apply vcg
-            apply (rule_tac Q="\<lambda>rv. tcb_at' thread and invs'" in hoare_post_imp)
+            apply (rule_tac Q'="\<lambda>rv. tcb_at' thread and invs'" in hoare_post_imp)
              apply (clarsimp simp: cte_wp_at_ctes_of capHasProperty_def
                                    cap_get_tag_isCap ucast_id)
             apply (wp threadSet_invs_trivial | simp)+

--- a/proof/crefine/AARCH64/Ipc_C.thy
+++ b/proof/crefine/AARCH64/Ipc_C.thy
@@ -1406,7 +1406,7 @@ lemma asUser_atcbContext_obj_at:
 lemma asUser_tcbFault_inv:
   "\<lbrace>\<lambda>s. \<exists>t. ko_at' t p' s \<and> tcbFault t = f\<rbrace> asUser p m
    \<lbrace>\<lambda>rv s. \<exists>t. ko_at' t p' s \<and> tcbFault t = f\<rbrace>"
-  apply (rule_tac Q="\<lambda>rv. obj_at' (\<lambda>t. tcbFault t = f) p'"
+  apply (rule_tac Q'="\<lambda>rv. obj_at' (\<lambda>t. tcbFault t = f) p'"
                in hoare_strengthen_post)
    apply (wp asUser_tcbFault_obj_at)
    apply (clarsimp simp: obj_at'_def)+
@@ -3719,7 +3719,7 @@ lemma doIPCTransfer_ccorres [corres]:
                            fault_to_fault_tag_nonzero)
      apply ctac
     apply (clarsimp simp: guard_is_UNIV_def option_to_ptr_def split: option.splits)
-   apply (rule_tac Q="\<lambda>rv. valid_pspace' and cur_tcb' and tcb_at' sender
+   apply (rule_tac Q'="\<lambda>rv. valid_pspace' and cur_tcb' and tcb_at' sender
                        and tcb_at' receiver and K (rv \<noteq> Some 0)
                        and (case_option \<top> valid_ipc_buffer_ptr' rv)
                        and K (receiver \<noteq> sender \<and> endpoint \<noteq> Some 0)"
@@ -4487,7 +4487,7 @@ lemma doReplyTransfer_ccorres [corres]:
                          | simp add: valid_tcb_state'_def)+)[1]
            apply (clarsimp simp: guard_is_UNIV_def ThreadState_defs mask_def option_to_ctcb_ptr_def)
 
-          apply (rule_tac Q="\<lambda>rv. tcb_at' receiver and
+          apply (rule_tac Q'="\<lambda>rv. tcb_at' receiver and
                                 valid_objs' and sch_act_simple and (\<lambda>s. ksCurDomain s \<le> maxDomain) and
                                 (\<lambda>s. sch_act_wf (ksSchedulerAction s) s) and
                                 pspace_aligned' and pspace_distinct'" in hoare_post_imp)
@@ -4586,7 +4586,7 @@ lemma setupCallerCap_ccorres [corres]:
                        ptr_add_assertion_positive Collect_const_mem
                        tcb_cnode_index_defs)
      apply simp
-     apply (rule_tac Q="\<lambda>rv. valid_pspace' and tcb_at' receiver" in hoare_post_imp)
+     apply (rule_tac Q'="\<lambda>rv. valid_pspace' and tcb_at' receiver" in hoare_post_imp)
       apply (auto simp: cte_wp_at_ctes_of isCap_simps valid_pspace'_def
                         tcbSlots Kernel_C.tcbCaller_def size_of_def
                         cte_level_bits_def)[1]
@@ -6000,7 +6000,7 @@ lemma receiveIPC_ccorres [corres]:
                 apply (fastforce simp: guard_is_UNIV_def ThreadState_defs mask_def
                                        cap_get_tag_isCap ccap_relation_ep_helpers)
                apply (clarsimp simp: valid_tcb_state'_def)
-               apply (rule_tac Q="\<lambda>_. valid_pspace'
+               apply (rule_tac Q'="\<lambda>_. valid_pspace'
                                        and st_tcb_at' ((=) sendState) sender and tcb_at' thread
                                        and (\<lambda>s. sch_act_wf (ksSchedulerAction s) s)
                                        and sch_act_not sender and K (thread \<noteq> sender)
@@ -6008,7 +6008,7 @@ lemma receiveIPC_ccorres [corres]:
                 apply (fastforce simp: valid_pspace_valid_objs' pred_tcb_at'_def sch_act_wf_weak
                                        obj_at'_def)
                apply (wpsimp simp: guard_is_UNIV_def option_to_ptr_def option_to_0_def conj_ac)+
-           apply (rule_tac Q="\<lambda>rv. valid_pspace'
+           apply (rule_tac Q'="\<lambda>rv. valid_pspace'
                                and cur_tcb' and tcb_at' sender and tcb_at' thread
                                and sch_act_not sender and K (thread \<noteq> sender)
                                and ep_at' (capEPPtr cap)
@@ -6302,7 +6302,7 @@ lemma sendSignal_ccorres [corres]:
            apply (ctac add: possibleSwitchTo_ccorres)
           apply (wp sts_valid_objs' sts_st_tcb_at'_cases
                  | simp add: option_to_ctcb_ptr_def split del: if_split)+
-        apply (rule_tac Q="\<lambda>_. tcb_at' (the (ntfnBoundTCB ntfn)) and invs'"
+        apply (rule_tac Q'="\<lambda>_. tcb_at' (the (ntfnBoundTCB ntfn)) and invs'"
                  in hoare_post_imp)
          apply auto[1]
         apply wp
@@ -6691,7 +6691,7 @@ lemma receiveSignal_ccorres [corres]:
           apply (rule receiveSignal_enqueue_ccorres_helper[simplified])
          apply (simp add: valid_ntfn'_def)
          apply (wp sts_st_tcb')
-         apply (rule_tac Q="\<lambda>rv. ko_wp_at' (\<lambda>x. projectKO_opt x = Some ntfn
+         apply (rule_tac Q'="\<lambda>rv. ko_wp_at' (\<lambda>x. projectKO_opt x = Some ntfn
                                \<and> projectKO_opt x = (None::tcb option))
                                   (capNtfnPtr cap)"
                        in hoare_post_imp)
@@ -6758,7 +6758,7 @@ lemma receiveSignal_ccorres [corres]:
         apply (rule_tac ntfn="ntfn" in receiveSignal_enqueue_ccorres_helper[simplified])
        apply (simp add: valid_ntfn'_def)
        apply (wp sts_st_tcb')
-       apply (rule_tac Q="\<lambda>rv. ko_wp_at' (\<lambda>x. projectKO_opt x = Some ntfn
+       apply (rule_tac Q'="\<lambda>rv. ko_wp_at' (\<lambda>x. projectKO_opt x = Some ntfn
                              \<and> projectKO_opt x = (None::tcb option))
                                     (capNtfnPtr cap)
                       and K (thread \<notin> set list)"

--- a/proof/crefine/AARCH64/IsolatedThreadAction.thy
+++ b/proof/crefine/AARCH64/IsolatedThreadAction.thy
@@ -602,7 +602,7 @@ lemma select_f_isolatable:
 lemma doMachineOp_isolatable:
   "thread_actions_isolatable idx (doMachineOp m)"
   apply (simp add: doMachineOp_def split_def)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
                gets_isolatable thread_actions_isolatable_returns
                modify_isolatable select_f_isolatable)
   apply (simp | wp)+
@@ -622,8 +622,8 @@ lemma getASIDPoolEntry_isolatable:
                    case_option_If2 assertE_def liftE_def checkPTAt_def
                    stateAssert_def2 assert_def liftM_def
              cong: if_cong)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
-               thread_actions_isolatable_bindE[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
+               thread_actions_isolatable_bindE[OF _ _ hoare_weaken_pre]
                thread_actions_isolatable_if thread_actions_isolatable_returns
                thread_actions_isolatable_fail
                gets_isolatable getObject_isolatable)
@@ -638,8 +638,8 @@ lemma findVSpaceForASID_isolatable:
                    case_option_If2 assertE_def liftE_def checkPTAt_def
                    stateAssert_def2
              cong: if_cong)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
-               thread_actions_isolatable_bindE[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
+               thread_actions_isolatable_bindE[OF _ _ hoare_weaken_pre]
                thread_actions_isolatable_if thread_actions_isolatable_returns
                thread_actions_isolatable_fail
                gets_isolatable getObject_isolatable getASIDPoolEntry_isolatable
@@ -738,7 +738,7 @@ lemma setASIDPool_isolatable:
 lemma vcpuUpdate_isolatable:
   "thread_actions_isolatable idx (vcpuUpdate p f)"
   apply (clarsimp simp: vcpuUpdate_def)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
                getVCPU_isolatable setVCPU_isolatable
          |wp|assumption|clarsimp)+
   done
@@ -754,7 +754,7 @@ lemma vgicUpdateLR_isolatable:
 lemma vcpuWriteReg_isolatable:
   "thread_actions_isolatable idx (vcpuWriteReg v p val)"
   apply (clarsimp simp: vcpuWriteReg_def)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
                vcpuUpdate_isolatable doMachineOp_isolatable
          | wpsimp)+
   done
@@ -762,7 +762,7 @@ lemma vcpuWriteReg_isolatable:
 lemma vcpuReadReg_isolatable:
   "thread_actions_isolatable idx (vcpuReadReg v p)"
   apply (clarsimp simp: vcpuReadReg_def)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
                vcpuUpdate_isolatable getVCPU_isolatable thread_actions_isolatable_return
          | wpsimp)+
   done
@@ -770,7 +770,7 @@ lemma vcpuReadReg_isolatable:
 lemma vcpuSaveReg_isolatable:
   "thread_actions_isolatable idx (vcpuSaveReg p v)"
   apply (clarsimp simp: vcpuSaveReg_def)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
                vcpuUpdate_isolatable doMachineOp_isolatable
          | wpsimp)+
   done
@@ -778,7 +778,7 @@ lemma vcpuSaveReg_isolatable:
 lemma vcpuRestoreReg_isolatable:
   "thread_actions_isolatable idx (vcpuRestoreReg p v)"
   apply (clarsimp simp: vcpuRestoreReg_def)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
                vcpuUpdate_isolatable doMachineOp_isolatable getVCPU_isolatable
          | wpsimp)+
   done
@@ -787,14 +787,14 @@ lemma thread_actions_isolatable_mapM_x:
   "\<lbrakk> \<And>x. thread_actions_isolatable idx (f x);
      \<And>x t. f x \<lbrace>tcb_at' t\<rbrace> \<rbrakk> \<Longrightarrow> thread_actions_isolatable idx (mapM_x f xs)"
   apply (induct xs; clarsimp simp: mapM_x_Nil mapM_x_Cons thread_actions_isolatable_returns)
-  apply (rule thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]; clarsimp?)
+  apply (rule thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]; clarsimp?)
    apply assumption+
   done
 
 lemma vcpuSaveRegRange_isolatable:
   "thread_actions_isolatable idx (vcpuSaveRegRange p r rt)"
   apply (clarsimp simp: vcpuSaveRegRange_def)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
                vcpuSaveReg_isolatable thread_actions_isolatable_mapM_x
          | wpsimp)+
   done
@@ -802,7 +802,7 @@ lemma vcpuSaveRegRange_isolatable:
 lemma vcpuRestoreRegRange_isolatable:
   "thread_actions_isolatable idx (vcpuRestoreRegRange p r rt)"
   apply (clarsimp simp: vcpuRestoreRegRange_def)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
                vcpuRestoreReg_isolatable thread_actions_isolatable_mapM_x
          | wpsimp)+
   done
@@ -810,7 +810,7 @@ lemma vcpuRestoreRegRange_isolatable:
 lemma saveVirtTimer_isolatable:
   "thread_actions_isolatable idx (saveVirtTimer v)"
   apply (clarsimp simp: saveVirtTimer_def)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
                thread_actions_isolatable_if thread_actions_isolatable_returns
                thread_actions_isolatable_fail
                gets_isolatable doMachineOp_isolatable vcpuSaveReg_isolatable
@@ -821,7 +821,7 @@ lemma saveVirtTimer_isolatable:
 lemma getIRQState_isolatable:
   "thread_actions_isolatable idx (getIRQState irq)"
   apply (clarsimp simp: getIRQState_def liftM_def getInterruptState_def)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
                 thread_actions_isolatable_returns gets_isolatable
          | wpsimp | fastforce)+
   done
@@ -829,7 +829,7 @@ lemma getIRQState_isolatable:
 lemma restoreVirtTimer_isolatable:
   "thread_actions_isolatable idx (restoreVirtTimer v)"
   apply (clarsimp simp: restoreVirtTimer_def when_def isIRQActive_def liftM_bind)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
                thread_actions_isolatable_if thread_actions_isolatable_returns
                thread_actions_isolatable_fail
                gets_isolatable doMachineOp_isolatable vcpuSaveReg_isolatable
@@ -843,7 +843,7 @@ lemma vcpuSave_isolatable:
   supply if_split[split del]
   apply (clarsimp simp: vcpuSave_def armvVCPUSave_def thread_actions_isolatable_fail when_def
                   split: option.splits)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
                thread_actions_isolatable_if thread_actions_isolatable_returns
                thread_actions_isolatable_fail
                gets_isolatable doMachineOp_isolatable vcpuSaveReg_isolatable
@@ -856,7 +856,7 @@ lemma vcpuSave_isolatable:
 lemma vcpuEnable_isolatable:
   "thread_actions_isolatable idx (vcpuEnable v)"
   apply (clarsimp simp: vcpuEnable_def)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
                vcpuRestoreReg_isolatable doMachineOp_isolatable getVCPU_isolatable
                restoreVirtTimer_isolatable
          | wpsimp)+
@@ -865,7 +865,7 @@ lemma vcpuEnable_isolatable:
 lemma vcpuRestore_isolatable:
   "thread_actions_isolatable idx (vcpuRestore v)"
   apply (clarsimp simp: vcpuRestore_def)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
                getVCPU_isolatable gets_isolatable doMachineOp_isolatable vcpuEnable_isolatable
                vcpuRestoreRegRange_isolatable
          | wpsimp)+
@@ -874,7 +874,7 @@ lemma vcpuRestore_isolatable:
 lemma vcpuDisable_isolatable:
   "thread_actions_isolatable idx (vcpuDisable v)"
   apply (clarsimp simp: vcpuDisable_def split: option.splits, intro conjI)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
                doMachineOp_isolatable vcpuEnable_isolatable
                vgicUpdate_isolatable vcpuSaveReg_isolatable saveVirtTimer_isolatable
          | wpsimp)+
@@ -885,16 +885,16 @@ lemma vcpuSwitch_isolatable:
   supply if_cong[cong] option.case_cong[cong]
   apply (clarsimp simp: vcpuSwitch_def when_def split: option.splits)
   apply (safe intro!:
-               thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
-               thread_actions_isolatable_bindE[OF _ _ hoare_pre(1)]
-               thread_actions_isolatable_catch[OF _ _ hoare_pre(1)]
+               thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
+               thread_actions_isolatable_bindE[OF _ _ hoare_weaken_pre]
+               thread_actions_isolatable_catch[OF _ _ hoare_weaken_pre]
                thread_actions_isolatable_if thread_actions_isolatable_returns
                thread_actions_isolatable_fail
                gets_isolatable)
    apply (clarsimp simp: thread_actions_isolatable_returns
                   split: option.splits
          |intro thread_actions_isolatable_if thread_actions_isolatable_returns
-                thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
+                thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
                 vcpuSave_isolatable vcpuRestore_isolatable
                 vcpuDisable_isolatable vcpuEnable_isolatable
                 modifyArchState_isolatable conjI doMachineOp_isolatable
@@ -965,9 +965,9 @@ lemma armContextSwitch_isolatable:
   "thread_actions_isolatable idx (armContextSwitch p asid)"
   supply if_split[split del]
   apply (simp add: armContextSwitch_def getVMID_def loadVMID_def getASIDPoolEntry_def getPoolPtr_def)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
-               thread_actions_isolatable_bindE[OF _ _ hoare_pre(1)]
-               thread_actions_isolatable_catch[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
+               thread_actions_isolatable_bindE[OF _ _ hoare_weaken_pre]
+               thread_actions_isolatable_catch[OF _ _ hoare_weaken_pre]
                thread_actions_isolatable_if thread_actions_isolatable_returns
                thread_actions_isolatable_fail gets_isolatable getASIDPool_isolatable
                setASIDPool_isolatable doMachineOp_isolatable
@@ -988,9 +988,9 @@ lemma setVMRoot_isolatable:
                    whenE_def liftE_def
                    stateAssert_def2
              cong: if_cong)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
-               thread_actions_isolatable_bindE[OF _ _ hoare_pre(1)]
-               thread_actions_isolatable_catch[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
+               thread_actions_isolatable_bindE[OF _ _ hoare_weaken_pre]
+               thread_actions_isolatable_catch[OF _ _ hoare_weaken_pre]
                thread_actions_isolatable_if thread_actions_isolatable_returns
                thread_actions_isolatable_fail
                gets_isolatable getCTE_isolatable
@@ -1325,7 +1325,7 @@ lemma setThreadState_no_sch_change:
   (is "Nondet_VCG.valid ?P ?f ?Q")
   apply (simp add: setThreadState_def setSchedulerAction_def)
   apply (wp hoare_pre_cont[where f=rescheduleRequired])
-  apply (rule_tac Q="\<lambda>_. ?P and st_tcb_at' ((=) st) t" in hoare_post_imp)
+  apply (rule_tac Q'="\<lambda>_. ?P and st_tcb_at' ((=) st) t" in hoare_post_imp)
    apply (clarsimp split: if_split)
    apply (clarsimp simp: obj_at'_def st_tcb_at'_def projectKOs)
   apply (wp threadSet_pred_tcb_at_state)
@@ -1387,7 +1387,7 @@ lemma setEndpoint_isolatable:
    apply (simp add: obj_at_partial_overwrite_id2)
    apply (drule_tac x=x in spec)
    apply (clarsimp simp: obj_at'_def projectKOs select_f_asserts)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
                thread_actions_isolatable_if
                thread_actions_isolatable_return
                thread_actions_isolatable_fail)
@@ -1533,7 +1533,7 @@ lemma cteInsert_isolatable:
   supply if_split[split del] if_cong[cong]
   apply (simp add: cteInsert_def updateCap_def updateMDB_def
                    Let_def setUntypedCapAsFull_def)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
                thread_actions_isolatable_if
                thread_actions_isolatable_returns
                getCTE_isolatable setCTE_isolatable)
@@ -1619,7 +1619,7 @@ lemma switchToThread_isolatable:
   "thread_actions_isolatable idx (Arch.switchToThread t)"
   apply (simp add: switchToThread_def getTCB_threadGet
                    storeWordUser_def stateAssert_def2)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
                gets_isolatable setVMRoot_isolatable
                thread_actions_isolatable_if
                doMachineOp_isolatable
@@ -1640,7 +1640,7 @@ lemma tcbQueued_put_tcb_state_regs_tcb:
 lemma idleThreadNotQueued_isolatable:
   "thread_actions_isolatable idx (stateAssert idleThreadNotQueued [])"
   apply (simp add: stateAssert_def2 stateAssert_def)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
                gets_isolatable
                thread_actions_isolatable_if
                thread_actions_isolatable_returns
@@ -1858,7 +1858,7 @@ lemma updateMDB_isolatable:
   "thread_actions_isolatable idx (updateMDB slot f)"
   apply (simp add: updateMDB_def thread_actions_isolatable_return
             split: if_split)
-  apply (intro impI thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
+  apply (intro impI thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
                getCTE_isolatable setCTE_isolatable,
            (wp | simp)+)
   done
@@ -1880,7 +1880,7 @@ lemma emptySlot_isolatable:
   "thread_actions_isolatable idx (emptySlot slot NullCap)"
   apply (simp add: emptySlot_def updateCap_def case_Null_If Retype_H.postCapDeletion_def
              cong: if_cong)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
                clearUntypedFreeIndex_isolatable
                thread_actions_isolatable_if
                getCTE_isolatable setCTE_isolatable

--- a/proof/crefine/AARCH64/Refine_C.thy
+++ b/proof/crefine/AARCH64/Refine_C.thy
@@ -75,7 +75,7 @@ proof -
       apply (wp schedule_sch_act_wf schedule_invs'
              | strengthen invs_valid_objs_strengthen invs_pspace_aligned' invs_pspace_distinct')+
    apply simp
-   apply (rule_tac Q="\<lambda>rv s. invs' s \<and> (\<forall>x. rv = Some x \<longrightarrow> x \<le> Kernel_Config.maxIRQ) \<and>
+   apply (rule_tac Q'="\<lambda>rv s. invs' s \<and> (\<forall>x. rv = Some x \<longrightarrow> x \<le> Kernel_Config.maxIRQ) \<and>
                              sch_act_not (ksCurThread s) s" in hoare_post_imp)
     apply (solves clarsimp)
    apply (wp getActiveIRQ_le_maxIRQ | simp)+
@@ -363,7 +363,7 @@ lemma handleSyscall_ccorres:
           apply wp[1]
          apply clarsimp
          apply wp
-         apply (rule_tac Q="\<lambda>rv s. ct_in_state' simple' s \<and> sch_act_sane s"
+         apply (rule_tac Q'="\<lambda>rv s. ct_in_state' simple' s \<and> sch_act_sane s"
                               in hoare_post_imp)
           apply (simp add: ct_in_state'_def)
          apply (wp handleReply_sane)
@@ -401,15 +401,15 @@ lemma handleSyscall_ccorres:
           | wpc
           | wp hoare_drop_imp handleReply_sane handleReply_nonz_cap_to_ct schedule_invs'
           | strengthen ct_active_not_idle'_strengthen invs_valid_objs_strengthen)+
-      apply (rule_tac  Q="\<lambda>rv. invs' and ct_active'" in hoare_post_imp, simp)
+      apply (rule_tac Q'="\<lambda>rv. invs' and ct_active'" in hoare_post_imp, simp)
       apply (wp hy_invs')
      apply (clarsimp simp add: liftE_def)
      apply wp
-     apply (rule_tac  Q="\<lambda>rv. invs' and ct_active'" in hoare_post_imp, simp)
+     apply (rule_tac Q'="\<lambda>rv. invs' and ct_active'" in hoare_post_imp, simp)
      apply (wp hy_invs')
     apply (clarsimp simp: liftE_def)
     apply (wp)
-    apply (rule_tac Q="\<lambda>_. invs'" in hoare_post_imp, simp)
+    apply (rule_tac Q'="\<lambda>_. invs'" in hoare_post_imp, simp)
     apply (wp hw_invs')
    apply (simp add: guard_is_UNIV_def)
   apply clarsimp

--- a/proof/crefine/AARCH64/Retype_C.thy
+++ b/proof/crefine/AARCH64/Retype_C.thy
@@ -7337,7 +7337,7 @@ lemma createObject_valid_cap':
   apply (simp add:createObject_def3)
   apply (rule hoare_pre)
   apply wp
-   apply (rule_tac Q = "\<lambda>r s. r \<noteq> [] \<and> Q r s" for Q in hoare_strengthen_post)
+   apply (rule_tac Q'="\<lambda>r s. r \<noteq> [] \<and> Q r s" for Q in hoare_strengthen_post)
    apply (rule hoare_vcg_conj_lift)
      apply (rule hoare_strengthen_post[OF createNewCaps_ret_len])
       apply clarsimp
@@ -7412,7 +7412,7 @@ lemma createObject_caps_overlap_reserved_ret':
   apply (simp add:createObject_def3)
   apply (rule hoare_pre)
   apply wp
-   apply (rule_tac Q = "\<lambda>r s. r \<noteq> [] \<and> Q r s" for Q in hoare_strengthen_post)
+   apply (rule_tac Q'="\<lambda>r s. r \<noteq> [] \<and> Q r s" for Q in hoare_strengthen_post)
    apply (rule hoare_vcg_conj_lift)
      apply (rule hoare_strengthen_post[OF createNewCaps_ret_len])
       apply clarsimp
@@ -7435,7 +7435,7 @@ lemma createObject_descendants_range':
   apply (simp add:createObject_def3)
   apply (rule hoare_pre)
   apply wp
-   apply (rule_tac Q = "\<lambda>r s. r \<noteq> [] \<and> Q r s" for Q in hoare_strengthen_post)
+   apply (rule_tac Q'="\<lambda>r s. r \<noteq> [] \<and> Q r s" for Q in hoare_strengthen_post)
    apply (rule hoare_vcg_conj_lift)
      apply (rule hoare_strengthen_post[OF createNewCaps_ret_len])
       apply clarsimp
@@ -7466,7 +7466,7 @@ lemma createObject_idlethread_range:
   apply (simp add:createObject_def3)
   apply (rule hoare_pre)
   apply wp
-   apply (rule_tac Q = "\<lambda>r s. r \<noteq> [] \<and> Q r s" for Q in hoare_strengthen_post)
+   apply (rule_tac Q'="\<lambda>r s. r \<noteq> [] \<and> Q r s" for Q in hoare_strengthen_post)
    apply (rule hoare_vcg_conj_lift)
      apply (rule hoare_strengthen_post[OF createNewCaps_ret_len])
       apply clarsimp
@@ -7486,7 +7486,7 @@ lemma createObject_IRQHandler:
   apply (simp add:createObject_def3)
   apply (rule hoare_pre)
   apply wp
-   apply (rule_tac Q = "\<lambda>r s. r \<noteq> [] \<and> Q r s" for Q in hoare_strengthen_post)
+   apply (rule_tac Q'="\<lambda>r s. r \<noteq> [] \<and> Q r s" for Q in hoare_strengthen_post)
    apply (rule hoare_vcg_conj_lift)
      apply (rule hoare_strengthen_post[OF createNewCaps_ret_len])
       apply clarsimp
@@ -7504,7 +7504,7 @@ lemma createObject_capClass[wp]:
   apply (simp add:createObject_def3)
   apply (rule hoare_pre)
   apply wp
-   apply (rule_tac Q = "\<lambda>r s. r \<noteq> [] \<and> Q r s" for Q in hoare_strengthen_post)
+   apply (rule_tac Q'="\<lambda>r s. r \<noteq> [] \<and> Q r s" for Q in hoare_strengthen_post)
    apply (rule hoare_vcg_conj_lift)
      apply (rule hoare_strengthen_post[OF createNewCaps_ret_len])
       apply clarsimp
@@ -7551,7 +7551,7 @@ lemma createObject_parent_helper:
     \<rbrace>
     createObject ty ptr us dev
     \<lbrace>\<lambda>rv. cte_wp_at' (\<lambda>cte. isUntypedCap (cteCap cte) \<and> (sameRegionAs (cteCap cte) rv)) p\<rbrace>"
-  apply (rule hoare_post_imp [where Q="\<lambda>rv s. \<exists>cte. cte_wp_at' ((=) cte) p s
+  apply (rule hoare_post_imp[where Q'="\<lambda>rv s. \<exists>cte. cte_wp_at' ((=) cte) p s
                                            \<and> isUntypedCap (cteCap cte) \<and>
                                 sameRegionAs (cteCap cte) rv"])
   apply (clarsimp simp:cte_wp_at_ctes_of)
@@ -8334,7 +8334,7 @@ shows  "ccorres dc xfdc
                  (cnodeptr + (of_nat k * 0x20 + start * 0x20 + of_nat n * 0x20)) s)
               \<and> descendants_range_in' {(of_nat n << APIType_capBits newType userSize) +
                  ptr.. (ptr && ~~ mask sz) + 2 ^ sz  - 1} srcSlot (ctes_of s)"
-              in hoare_pre(1))
+              in hoare_weaken_pre)
              apply wp
             apply (clarsimp simp:createObject_hs_preconds_def conj_comms add.commute[where b=ptr]
                    invs_valid_pspace' invs_pspace_distinct' invs_pspace_aligned'

--- a/proof/crefine/AARCH64/Schedule_C.thy
+++ b/proof/crefine/AARCH64/Schedule_C.thy
@@ -90,7 +90,7 @@ lemma Arch_switchToThread_ccorres:
        apply wpsimp
       apply (vcg exspec=vcpu_switch_modifies)
      apply wpsimp+
-    apply (rule_tac Q="\<lambda>rv s. all_invs_but_ct_idle_or_in_cur_domain' s
+    apply (rule_tac Q'="\<lambda>rv s. all_invs_but_ct_idle_or_in_cur_domain' s
                               \<and> case_option \<top> (ko_wp_at' (is_vcpu' and hyp_live')) (atcbVCPUPtr (tcbArch rv)) s
                               \<and> obj_at' (\<lambda>t::tcb. True) t s" in hoare_strengthen_post[rotated])
      apply (clarsimp simp: vcpu_at_is_vcpu' invs_no_cicd'_def valid_state'_def valid_pspace'_def
@@ -717,7 +717,7 @@ lemma schedule_ccorres:
        apply wp
       apply clarsimp
       (* when runnable tcbSchedEnqueue curThread *)
-      apply (rule_tac Q="\<lambda>rv s. invs' s \<and> ksCurThread s = curThread
+      apply (rule_tac Q'="\<lambda>rv s. invs' s \<and> ksCurThread s = curThread
                                 \<and> ksSchedulerAction s = SwitchToThread candidate" in hoare_post_imp)
        apply (clarsimp simp: invs'_bitmapQ_no_L1_orphans invs_ksCurDomain_maxDomain')
        apply (fastforce dest: invs_sch_act_wf')

--- a/proof/crefine/AARCH64/SyscallArgs_C.thy
+++ b/proof/crefine/AARCH64/SyscallArgs_C.thy
@@ -952,7 +952,7 @@ lemma getMRs_user_word:
                          linorder_not_less [symmetric])
    apply (wp mapM_loadWordUser_user_words_at)
    apply (wp hoare_vcg_all_lift)
-    apply (rule_tac Q="\<lambda>_. \<top>" in hoare_strengthen_post)
+    apply (rule_tac Q'="\<lambda>_. \<top>" in hoare_strengthen_post)
      apply wp
     apply clarsimp
     defer
@@ -1008,7 +1008,7 @@ lemma getMRs_rel:
   apply (rule hoare_pre)
    apply (rule_tac x=mi in hoare_exI)
    apply wp
-   apply (rule_tac Q="\<lambda>rv s. thread = ksCurThread s \<and> fst (getMRs thread buffer mi s) = {(rv,s)}" in hoare_strengthen_post)
+   apply (rule_tac Q'="\<lambda>rv s. thread = ksCurThread s \<and> fst (getMRs thread buffer mi s) = {(rv,s)}" in hoare_strengthen_post)
     apply (wp det_result det_wp_getMRs)
    apply clarsimp
   apply (clarsimp simp: cur_tcb'_def)
@@ -1175,7 +1175,7 @@ lemma getSyscallArg_ccorres_foo:
     apply (clarsimp simp: option_to_ptr_def option_to_0_def)
     apply (rule_tac P="\<lambda>s. valid_ipc_buffer_ptr' (ptr_val (Ptr b)) s \<and> i < msgLength mi \<and>
                            msgLength mi \<le> msgMaxLength \<and> scast n_msgRegisters \<le> i"
-                 in hoare_pre(1))
+                 in hoare_weaken_pre)
      apply (wp getMRs_user_word)
     apply (clarsimp simp: msgMaxLength_def unat_less_helper)
    apply fastforce

--- a/proof/crefine/AARCH64/Syscall_C.thy
+++ b/proof/crefine/AARCH64/Syscall_C.thy
@@ -259,7 +259,7 @@ lemma decodeInvocation_ccorres:
        apply simp
        apply (vcg exspec=performInvocation_Reply_modifies)
       apply (simp add: cur_tcb'_def[symmetric])
-      apply (rule_tac R="\<lambda>rv s. ksCurThread s = thread" in hoare_post_add)
+      apply (rule_tac Q'="\<lambda>rv s. ksCurThread s = thread" in hoare_post_add)
       apply (simp cong: conj_cong)
       apply (strengthen imp_consequent)
       apply (wp sts_invs_minor' sts_st_tcb_at'_cases)
@@ -682,9 +682,9 @@ lemma sendFaultIPC_ccorres:
                  , assumption)
          apply vcg
         apply (clarsimp simp: inQ_def)
-        apply (rule_tac Q="\<lambda>a b. invs' b \<and> st_tcb_at' simple' tptr b
+        apply (rule_tac Q'="\<lambda>a b. invs' b \<and> st_tcb_at' simple' tptr b
                                  \<and> sch_act_not tptr b \<and> valid_cap' a b"
-                 and E="\<lambda> _. \<top>"
+                 and E'="\<lambda> _. \<top>"
                  in hoare_strengthen_postE)
           apply (wp)
          apply (clarsimp simp: isCap_simps)
@@ -884,8 +884,8 @@ lemma handleInvocation_ccorres:
                      apply (rule ccorres_return_C_errorE, simp+)[1]
                     apply vcg
                    apply (simp add: invocationCatch_def o_def)
-                   apply (rule_tac Q="\<lambda>rv'. invs' and tcb_at' rv"
-                               and E="\<lambda>ft. invs' and tcb_at' rv"
+                   apply (rule_tac Q'="\<lambda>rv'. invs' and tcb_at' rv"
+                               and E'="\<lambda>ft. invs' and tcb_at' rv"
                               in hoare_strengthen_postE)
                      apply (wp hoare_split_bind_case_sumE hoare_drop_imps
                                setThreadState_nonqueued_state_update
@@ -2014,7 +2014,7 @@ proof -
 
        (* clean up get_gic_vcpu_ctrl_misr postcondition *)
        apply (wp hoare_vcg_all_lift)
-       apply (rule_tac Q="\<lambda>_ s. ?PRE s \<and> armHSCurVCPU (ksArchState s) = Some (vcpuPtr, active)" in hoare_post_imp)
+       apply (rule_tac Q'="\<lambda>_ s. ?PRE s \<and> armHSCurVCPU (ksArchState s) = Some (vcpuPtr, active)" in hoare_post_imp)
         apply clarsimp
     subgoal for _ _ eisr0 eisr1
       apply (clarsimp simp: invs'_HScurVCPU_vcpu_at' valid_arch_state'_def max_armKSGICVCPUNumListRegs_def dest!: invs_arch_state')

--- a/proof/crefine/AARCH64/Tcb_C.thy
+++ b/proof/crefine/AARCH64/Tcb_C.thy
@@ -428,7 +428,7 @@ lemma setPriority_ccorres:
                  simp: st_tcb_at'_def o_def split: if_splits)
     apply (simp add: guard_is_UNIV_def)
    apply (rule hoare_strengthen_post[
-                 where Q="\<lambda>rv s.
+                 where Q'="\<lambda>rv s.
                           obj_at' (\<lambda>_. True) t s \<and>
                           priority \<le> maxPriority \<and>
                           ksCurDomain s \<le> maxDomain \<and>
@@ -675,7 +675,7 @@ lemma invokeTCB_ThreadControl_ccorres:
                          apply wp
                         apply (clarsimp simp : guard_is_UNIV_def Collect_const_mem)
                        apply (rule hoare_strengthen_post[
-                                    where Q= "\<lambda>rv s.
+                                    where Q'="\<lambda>rv s.
                                               valid_objs' s \<and>
                                               weak_sch_act_wf (ksSchedulerAction s) s \<and>
                                               ((\<exists>a b. priority = Some (a, b)) \<longrightarrow>
@@ -771,7 +771,7 @@ lemma invokeTCB_ThreadControl_ccorres:
                apply (clarsimp simp : guard_is_UNIV_def Collect_const_mem)
               apply (simp cong: conj_cong)
               apply (rule hoare_strengthen_post[
-                            where Q="\<lambda>a b. (valid_objs' b \<and>
+                            where Q'="\<lambda>a b. (valid_objs' b \<and>
                                        sch_act_wf (ksSchedulerAction b) b \<and>
                                        pspace_aligned' b \<and> pspace_distinct' b \<and>
                                        ((\<exists>a b. priority = Some (a, b)) \<longrightarrow>
@@ -816,7 +816,7 @@ lemma invokeTCB_ThreadControl_ccorres:
             apply vcg
            apply (simp add: conj_comms cong: conj_cong)
            apply (strengthen invs_ksCurDomain_maxDomain' invs_pspace_distinct')
-           apply (wp hoare_vcg_const_imp_lift_R cteDelete_invs')
+           apply (wp hoare_vcg_const_imp_liftE_R cteDelete_invs')
           apply simp
           apply (rule ccorres_split_nothrow_novcg_dc)
              apply (rule ccorres_cond2[where R=\<top>], simp add: Collect_const_mem)
@@ -1234,13 +1234,13 @@ lemma invokeTCB_CopyRegisters_ccorres:
           apply (simp add: pred_conj_def guard_is_UNIV_def cong: if_cong
                   | wp mapM_x_wp_inv hoare_drop_imp)+
       apply clarsimp
-      apply (rule_tac Q="\<lambda>rv. invs' and tcb_at' destn" in hoare_strengthen_post[rotated])
+      apply (rule_tac Q'="\<lambda>rv. invs' and tcb_at' destn" in hoare_strengthen_post[rotated])
        apply (fastforce simp: sch_act_wf_weak)
       apply (wpsimp wp: hoare_drop_imp restart_invs')+
      apply (clarsimp simp add: guard_is_UNIV_def)
     apply (wp hoare_drop_imp hoare_vcg_if_lift)+
     apply simp
-    apply (rule_tac Q="\<lambda>rv. invs' and tcb_at' destn" in hoare_strengthen_post[rotated])
+    apply (rule_tac Q'="\<lambda>rv. invs' and tcb_at' destn" in hoare_strengthen_post[rotated])
      apply (fastforce simp: sch_act_wf_weak)
     apply (wpsimp wp: hoare_drop_imp)+
    apply (clarsimp simp add: guard_is_UNIV_def)
@@ -1649,7 +1649,7 @@ lemma invokeTCB_WriteRegisters_ccorres[where S=UNIV]:
                     apply wp
                    apply (simp add: guard_is_UNIV_def)
                   apply (wp hoare_drop_imp)
-                   apply (rule_tac Q="\<lambda>rv. invs' and tcb_at' dst" in hoare_strengthen_post[rotated])
+                   apply (rule_tac Q'="\<lambda>rv. invs' and tcb_at' dst" in hoare_strengthen_post[rotated])
                     apply (fastforce simp: sch_act_wf_weak)
                    apply (wpsimp wp: restart_invs')+
                  apply (clarsimp simp add: guard_is_UNIV_def)
@@ -2165,7 +2165,7 @@ shows
         apply wp
        apply (simp add: Collect_const_mem ThreadState_defs mask_def)
        apply vcg
-      apply (rule_tac Q="\<lambda>rv. invs' and st_tcb_at' ((=) Restart) thread
+      apply (rule_tac Q'="\<lambda>rv. invs' and st_tcb_at' ((=) Restart) thread
                              and tcb_at' target" in hoare_post_imp)
        apply (clarsimp simp: pred_tcb_at')
        apply (auto elim!: pred_tcb'_weakenE)[1]

--- a/proof/crefine/AARCH64/VSpace_C.thy
+++ b/proof/crefine/AARCH64/VSpace_C.thy
@@ -2134,7 +2134,7 @@ lemma performASIDPoolInvocation_ccorres:
            apply wp
           apply simp
           apply vcg
-         apply (rule hoare_strengthen_post[where Q="\<lambda>_. \<top>"], wp)
+         apply (rule hoare_strengthen_post[where Q'="\<lambda>_. \<top>"], wp)
          apply (clarsimp simp: typ_at'_def ko_wp_at'_def obj_at'_def)
        apply simp
        apply vcg
@@ -2741,7 +2741,7 @@ lemma vcpu_enable_ccorres:
        apply wpsimp
       apply (vcg exspec=set_gic_vcpu_ctrl_hcr_modifies)
      apply wpsimp+
-   apply (rule_tac Q="\<lambda>_. vcpu_at' v" in hoare_post_imp, fastforce)
+   apply (rule_tac Q'="\<lambda>_. vcpu_at' v" in hoare_post_imp, fastforce)
    apply wpsimp
   apply (clarsimp simp: typ_heap_simps' Collect_const_mem cvcpu_relation_def
                         cvcpu_regs_relation_def Let_def cvgic_relation_def hcrVCPU_def

--- a/proof/crefine/ARM/Arch_C.thy
+++ b/proof/crefine/ARM/Arch_C.thy
@@ -475,7 +475,7 @@ shows
        apply clarsimp
        apply (wp getSlotCap_wp)
       apply clarsimp
-     apply (rule_tac Q="\<lambda>_. cte_wp_at' ((=) (UntypedCap isdev frame pageBits idx) o cteCap) parent
+     apply (rule_tac Q'="\<lambda>_. cte_wp_at' ((=) (UntypedCap isdev frame pageBits idx) o cteCap) parent
                            and (\<lambda>s. descendants_range_in' {frame..frame + (2::word32) ^ pageBits - (1::word32)} parent (ctes_of s))
                            and pspace_no_overlap' frame pageBits
                            and invs'

--- a/proof/crefine/ARM/DetWP.thy
+++ b/proof/crefine/ARM/DetWP.thy
@@ -120,7 +120,7 @@ lemma det_wp_asUser [wp]:
       apply (drule det_wp_det)
       apply (erule det_wp_select_f)
      apply wp+
-   apply (rule_tac Q="\<lambda>_. tcb_at' t" in hoare_post_imp)
+   apply (rule_tac Q'="\<lambda>_. tcb_at' t" in hoare_post_imp)
     apply simp
    apply wp
   apply simp

--- a/proof/crefine/ARM/Fastpath_C.thy
+++ b/proof/crefine/ARM/Fastpath_C.thy
@@ -1571,7 +1571,7 @@ lemma ctes_of_Some_cte_wp_at:
 lemma user_getreg_wp:
   "\<lbrace>\<lambda>s. tcb_at' t s \<and> (\<forall>rv. obj_at' (\<lambda>tcb. (user_regs o atcbContextGet o tcbArch) tcb r = rv) t s \<longrightarrow> Q rv s)\<rbrace>
       asUser t (getRegister r) \<lbrace>Q\<rbrace>"
-  apply (rule_tac Q="\<lambda>rv s. \<exists>rv'. rv' = rv \<and> Q rv' s" in hoare_post_imp)
+  apply (rule_tac Q'="\<lambda>rv s. \<exists>rv'. rv' = rv \<and> Q rv' s" in hoare_post_imp)
    apply simp
   apply (rule hoare_pre, wp hoare_vcg_ex_lift user_getreg_rv)
   apply (clarsimp simp: obj_at'_def)
@@ -2266,7 +2266,7 @@ proof -
                                set_ep_valid_objs'
                                setObject_no_0_obj'[where 'a=endpoint, folded setEndpoint_def]
                                | strengthen not_obj_at'_strengthen)+
-                      apply (rule_tac Q="\<lambda>_ s. hd (epQueue send_ep) \<noteq> curThread
+                      apply (rule_tac Q'="\<lambda>_ s. hd (epQueue send_ep) \<noteq> curThread
                                               \<and> pred_tcb_at' itcbState ((=) (tcbState xa)) (hd (epQueue send_ep)) s"
                                in hoare_post_imp)
                        apply fastforce

--- a/proof/crefine/ARM/Fastpath_Equiv.thy
+++ b/proof/crefine/ARM/Fastpath_Equiv.thy
@@ -250,7 +250,7 @@ lemma ctes_of_Some_cte_wp_at:
 lemma user_getreg_wp:
   "\<lbrace>\<lambda>s. tcb_at' t s \<and> (\<forall>rv. obj_at' (\<lambda>tcb. (user_regs o atcbContextGet o tcbArch) tcb r = rv) t s \<longrightarrow> Q rv s)\<rbrace>
       asUser t (getRegister r) \<lbrace>Q\<rbrace>"
-  apply (rule_tac Q="\<lambda>rv s. \<exists>rv'. rv' = rv \<and> Q rv' s" in hoare_post_imp)
+  apply (rule_tac Q'="\<lambda>rv s. \<exists>rv'. rv' = rv \<and> Q rv' s" in hoare_post_imp)
    apply simp
   apply (rule hoare_pre, wp hoare_vcg_ex_lift user_getreg_rv)
   apply (clarsimp simp: obj_at'_def)

--- a/proof/crefine/ARM/Finalise_C.thy
+++ b/proof/crefine/ARM/Finalise_C.thy
@@ -720,7 +720,7 @@ lemma suspend_ccorres:
         apply ceqv
        apply (ctac(no_vcg) add: setThreadState_ccorres_simple)
         apply (ctac add: tcbSchedDequeue_ccorres)
-       apply (rule_tac Q="\<lambda>_. valid_objs' and tcb_at' thread and pspace_aligned' and pspace_distinct'"
+       apply (rule_tac Q'="\<lambda>_. valid_objs' and tcb_at' thread and pspace_aligned' and pspace_distinct'"
                     in hoare_post_imp)
         apply clarsimp
        apply (wp sts_valid_objs')[1]
@@ -1519,7 +1519,7 @@ lemma unmapPageTable_ccorres:
      apply wp
     apply (fastforce simp: guard_is_UNIV_def Collect_const_mem Let_def
       shiftl_t2n field_simps lookup_pd_slot_def)
-   apply (rule_tac Q="\<lambda>rv s. (case rv of Some pd \<Rightarrow> page_directory_at' pd s | _ \<Rightarrow> True) \<and> invs' s"
+   apply (rule_tac Q'="\<lambda>rv s. (case rv of Some pd \<Rightarrow> page_directory_at' pd s | _ \<Rightarrow> True) \<and> invs' s"
              in hoare_post_imp)
     apply (clarsimp simp: lookup_pd_slot_def Let_def
                           mask_add_aligned less_pptrBase_valid_pde_offset''

--- a/proof/crefine/ARM/Invoke_C.thy
+++ b/proof/crefine/ARM/Invoke_C.thy
@@ -75,7 +75,7 @@ lemma setDomain_ccorres:
        apply (simp add: guard_is_UNIV_def)
       apply simp
       apply wp
-     apply (rule_tac Q="\<lambda>_. all_invs_but_sch_extra and tcb_at' t and sch_act_simple
+     apply (rule_tac Q'="\<lambda>_. all_invs_but_sch_extra and tcb_at' t and sch_act_simple
                             and (\<lambda>s. curThread = ksCurThread s)"
               in hoare_strengthen_post)
       apply (wp threadSet_all_invs_but_sch_extra)
@@ -83,7 +83,7 @@ lemma setDomain_ccorres:
                             sch_act_simple_def st_tcb_at'_def weak_sch_act_wf_def
                      split: if_splits)
     apply (simp add: guard_is_UNIV_def)
-   apply (rule_tac Q="\<lambda>_. invs' and tcb_at' t and sch_act_simple and (\<lambda>s. curThread = ksCurThread s)"
+   apply (rule_tac Q'="\<lambda>_. invs' and tcb_at' t and sch_act_simple and (\<lambda>s. curThread = ksCurThread s)"
             in hoare_strengthen_post)
     apply (wp weak_sch_act_wf_lift_linear tcbSchedDequeue_not_queued
               hoare_vcg_imp_lift hoare_vcg_all_lift)
@@ -752,7 +752,7 @@ lemma decodeCNodeInvocation_ccorres:
                                apply (rule_tac Q'="\<lambda>rv. valid_pspace'
                                                     and valid_cap' rv and valid_objs'
                                                          and tcb_at' thread and (\<lambda>s. sch_act_wf (ksSchedulerAction s) s)"
-                                           in hoare_vcg_R_conj)
+                                           in hoare_vcg_conj_liftE_R)
                                 apply (rule deriveCap_Null_helper[OF deriveCap_derived])
                                apply wp
                               apply (clarsimp simp: cte_wp_at_ctes_of)
@@ -828,7 +828,7 @@ lemma decodeCNodeInvocation_ccorres:
                                    apply (rule_tac Q'="\<lambda>rv. valid_pspace'
                                                         and valid_cap' rv and valid_objs'
                                                              and tcb_at' thread and (\<lambda>s. sch_act_wf (ksSchedulerAction s) s)"
-                                               in hoare_vcg_R_conj)
+                                               in hoare_vcg_conj_liftE_R)
                                     apply (rule deriveCap_Null_helper [OF deriveCap_derived])
                                    apply wp
                                   apply (clarsimp simp: cte_wp_at_ctes_of)
@@ -949,7 +949,7 @@ lemma decodeCNodeInvocation_ccorres:
                       apply (clarsimp simp:valid_updateCapDataI invs_valid_objs' invs_valid_pspace')
                       apply assumption
                      apply (wp hoare_vcg_all_liftE_R injection_wp_E[OF refl]
-                               lsfco_cte_at' hoare_vcg_const_imp_lift_R
+                               lsfco_cte_at' hoare_vcg_const_imp_liftE_R
                            )+
                     apply (simp add: Collect_const_mem word_sle_def word_sless_def
                                      all_ex_eq_helper)
@@ -1326,7 +1326,7 @@ lemma decodeCNodeInvocation_ccorres:
           apply (rule ccorres_return_C_errorE, simp+)[1]
          apply vcg
         apply simp
-        apply (wp injection_wp_E[OF refl] hoare_vcg_const_imp_lift_R
+        apply (wp injection_wp_E[OF refl] hoare_vcg_const_imp_liftE_R
                   hoare_vcg_all_liftE_R lsfco_cte_at' hoare_weak_lift_imp
                 | simp add: hasCancelSendRights_not_Null ctes_of_valid_strengthen
                       cong: conj_cong

--- a/proof/crefine/ARM/IpcCancel_C.thy
+++ b/proof/crefine/ARM/IpcCancel_C.thy
@@ -2733,7 +2733,7 @@ lemma cancelIPC_ccorres1:
                                 ghost_assertion_data_set_def cap_tag_defs)
               apply (simp add: locateSlot_conv, wp)
              apply vcg
-            apply (rule_tac Q="\<lambda>rv. tcb_at' thread and invs'" in hoare_post_imp)
+            apply (rule_tac Q'="\<lambda>rv. tcb_at' thread and invs'" in hoare_post_imp)
              apply (clarsimp simp: cte_wp_at_ctes_of capHasProperty_def
                                    cap_get_tag_isCap ucast_id)
             apply (wp threadSet_invs_trivial | simp)+

--- a/proof/crefine/ARM/Ipc_C.thy
+++ b/proof/crefine/ARM/Ipc_C.thy
@@ -3305,7 +3305,7 @@ lemma doIPCTransfer_ccorres [corres]:
                            fault_to_fault_tag_nonzero)
      apply ctac
     apply (clarsimp simp: guard_is_UNIV_def option_to_ptr_def split: option.splits)
-   apply (rule_tac Q="\<lambda>rv. valid_pspace' and cur_tcb' and tcb_at' sender
+   apply (rule_tac Q'="\<lambda>rv. valid_pspace' and cur_tcb' and tcb_at' sender
                        and tcb_at' receiver and K (rv \<noteq> Some 0)
                        and (case_option \<top> valid_ipc_buffer_ptr' rv)
                        and K (receiver \<noteq> sender \<and> endpoint \<noteq> Some 0)"
@@ -4020,7 +4020,7 @@ lemma doReplyTransfer_ccorres [corres]:
                          | simp add: valid_tcb_state'_def)+)[1]
            apply (clarsimp simp: guard_is_UNIV_def ThreadState_defs mask_def option_to_ctcb_ptr_def)
 
-          apply (rule_tac Q="\<lambda>rv. tcb_at' receiver and
+          apply (rule_tac Q'="\<lambda>rv. tcb_at' receiver and
                                 valid_objs' and sch_act_simple and (\<lambda>s. ksCurDomain s \<le> maxDomain) and
                                 (\<lambda>s. sch_act_wf (ksSchedulerAction s) s) and
                                 pspace_aligned' and pspace_distinct'" in hoare_post_imp)
@@ -4119,7 +4119,7 @@ lemma setupCallerCap_ccorres [corres]:
                        ptr_add_assertion_positive Collect_const_mem
                        tcb_cnode_index_defs)
      apply simp
-     apply (rule_tac Q="\<lambda>rv. valid_pspace' and tcb_at' receiver" in hoare_post_imp)
+     apply (rule_tac Q'="\<lambda>rv. valid_pspace' and tcb_at' receiver" in hoare_post_imp)
       apply (auto simp: cte_wp_at_ctes_of isCap_simps
                         tcbSlots Kernel_C.tcbCaller_def size_of_def
                         cte_level_bits_def)[1]
@@ -5479,7 +5479,7 @@ lemma receiveIPC_ccorres [corres]:
                 apply (fastforce simp: guard_is_UNIV_def ThreadState_defs mask_def
                                        cap_get_tag_isCap ccap_relation_ep_helpers)
                apply (clarsimp simp: valid_tcb_state'_def)
-               apply (rule_tac Q="\<lambda>_. valid_pspace'
+               apply (rule_tac Q'="\<lambda>_. valid_pspace'
                                        and st_tcb_at' ((=) sendState) sender and tcb_at' thread
                                        and (\<lambda>s. sch_act_wf (ksSchedulerAction s) s)
                                        and sch_act_not sender and K (thread \<noteq> sender)
@@ -5487,7 +5487,7 @@ lemma receiveIPC_ccorres [corres]:
                 apply (fastforce simp: valid_pspace_valid_objs' pred_tcb_at'_def sch_act_wf_weak
                                        obj_at'_def)
                apply (wpsimp simp: guard_is_UNIV_def option_to_ptr_def option_to_0_def conj_ac)+
-           apply (rule_tac Q="\<lambda>rv. valid_pspace'
+           apply (rule_tac Q'="\<lambda>rv. valid_pspace'
                                and cur_tcb' and tcb_at' sender and tcb_at' thread
                                and sch_act_not sender and K (thread \<noteq> sender)
                                and ep_at' (capEPPtr cap)
@@ -5774,7 +5774,7 @@ lemma sendSignal_ccorres [corres]:
            apply (ctac add: possibleSwitchTo_ccorres)
           apply (wp sts_valid_objs' sts_st_tcb_at'_cases
                  | simp add: option_to_ctcb_ptr_def split del: if_split)+
-        apply (rule_tac Q="\<lambda>_. tcb_at' (the (ntfnBoundTCB ntfn)) and invs'"
+        apply (rule_tac Q'="\<lambda>_. tcb_at' (the (ntfnBoundTCB ntfn)) and invs'"
                  in hoare_post_imp)
          apply auto[1]
         apply wp
@@ -6139,7 +6139,7 @@ lemma receiveSignal_ccorres [corres]:
           apply (rule receiveSignal_enqueue_ccorres_helper[simplified])
          apply (simp add: valid_ntfn'_def)
          apply (wp sts_st_tcb')
-         apply (rule_tac Q="\<lambda>rv. ko_wp_at' (\<lambda>x. projectKO_opt x = Some ntfn
+         apply (rule_tac Q'="\<lambda>rv. ko_wp_at' (\<lambda>x. projectKO_opt x = Some ntfn
                                \<and> projectKO_opt x = (None::tcb option))
                                   (capNtfnPtr cap)"
                        in hoare_post_imp)
@@ -6206,7 +6206,7 @@ lemma receiveSignal_ccorres [corres]:
         apply (rule_tac ntfn="ntfn" in receiveSignal_enqueue_ccorres_helper[simplified])
        apply (simp add: valid_ntfn'_def)
        apply (wp sts_st_tcb')
-       apply (rule_tac Q="\<lambda>rv. ko_wp_at' (\<lambda>x. projectKO_opt x = Some ntfn
+       apply (rule_tac Q'="\<lambda>rv. ko_wp_at' (\<lambda>x. projectKO_opt x = Some ntfn
                              \<and> projectKO_opt x = (None::tcb option))
                                     (capNtfnPtr cap)
                       and K (thread \<notin> set list)"

--- a/proof/crefine/ARM/IsolatedThreadAction.thy
+++ b/proof/crefine/ARM/IsolatedThreadAction.thy
@@ -610,7 +610,7 @@ lemma select_f_isolatable:
 lemma doMachineOp_isolatable:
   "thread_actions_isolatable idx (doMachineOp m)"
   apply (simp add: doMachineOp_def split_def)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
                gets_isolatable thread_actions_isolatable_returns
                modify_isolatable select_f_isolatable)
   apply (simp | wp)+
@@ -630,8 +630,8 @@ lemma findPDForASID_isolatable:
                    case_option_If2 assertE_def liftE_def checkPDAt_def
                    stateAssert_def2
              cong: if_cong)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
-               thread_actions_isolatable_bindE[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
+               thread_actions_isolatable_bindE[OF _ _ hoare_weaken_pre]
                thread_actions_isolatable_if thread_actions_isolatable_returns
                thread_actions_isolatable_fail
                gets_isolatable getObject_isolatable)
@@ -652,9 +652,9 @@ lemma getHWASID_isolatable:
                    invalidateHWASIDEntry_def
                    storeHWASID_def
              cong: if_cong)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
-               thread_actions_isolatable_bindE[OF _ _ hoare_pre(1)]
-               thread_actions_isolatable_catch[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
+               thread_actions_isolatable_bindE[OF _ _ hoare_weaken_pre]
+               thread_actions_isolatable_catch[OF _ _ hoare_weaken_pre]
                thread_actions_isolatable_if thread_actions_isolatable_returns
                thread_actions_isolatable_fail
                gets_isolatable modify_isolatable
@@ -673,9 +673,9 @@ lemma setVMRoot_isolatable:
                    checkPDNotInASIDMap_def stateAssert_def2
                    checkPDASIDMapMembership_def armv_contextSwitch_def
              cong: if_cong)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
-               thread_actions_isolatable_bindE[OF _ _ hoare_pre(1)]
-               thread_actions_isolatable_catch[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
+               thread_actions_isolatable_bindE[OF _ _ hoare_weaken_pre]
+               thread_actions_isolatable_catch[OF _ _ hoare_weaken_pre]
                thread_actions_isolatable_if thread_actions_isolatable_returns
                thread_actions_isolatable_fail
                gets_isolatable getCTE_isolatable getHWASID_isolatable
@@ -936,7 +936,7 @@ lemma setThreadState_no_sch_change:
   (is "Nondet_VCG.valid ?P ?f ?Q")
   apply (simp add: setThreadState_def setSchedulerAction_def)
   apply (wp hoare_pre_cont[where f=rescheduleRequired])
-  apply (rule_tac Q="\<lambda>_. ?P and st_tcb_at' ((=) st) t" in hoare_post_imp)
+  apply (rule_tac Q'="\<lambda>_. ?P and st_tcb_at' ((=) st) t" in hoare_post_imp)
    apply (clarsimp split: if_split)
    apply (clarsimp simp: obj_at'_def st_tcb_at'_def projectKOs)
   apply (wp threadSet_pred_tcb_at_state)
@@ -998,7 +998,7 @@ lemma setEndpoint_isolatable:
    apply (simp add: obj_at_partial_overwrite_id2)
    apply (drule_tac x=x in spec)
    apply (clarsimp simp: obj_at'_def projectKOs select_f_asserts)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
                thread_actions_isolatable_if
                thread_actions_isolatable_return
                thread_actions_isolatable_fail)
@@ -1146,7 +1146,7 @@ lemma cteInsert_isolatable:
   supply if_split[split del] if_cong[cong]
   apply (simp add: cteInsert_def updateCap_def updateMDB_def
                    Let_def setUntypedCapAsFull_def)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
                thread_actions_isolatable_if
                thread_actions_isolatable_returns assert_isolatable
                getCTE_isolatable setCTE_isolatable)
@@ -1232,7 +1232,7 @@ lemma threadGet_isolatable:
   "thread_actions_isolatable idx (Arch.switchToThread t)"
   apply (simp add: switchToThread_def
                    storeWordUser_def stateAssert_def2)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
                gets_isolatable setVMRoot_isolatable
                thread_actions_isolatable_if
                doMachineOp_isolatable
@@ -1255,7 +1255,7 @@ lemma tcbQueued_put_tcb_state_regs_tcb:
 lemma idleThreadNotQueued_isolatable:
   "thread_actions_isolatable idx (stateAssert idleThreadNotQueued [])"
   apply (simp add: stateAssert_def2 stateAssert_def)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
                gets_isolatable
                thread_actions_isolatable_if
                thread_actions_isolatable_returns
@@ -1441,7 +1441,7 @@ lemma updateMDB_isolatable:
   "thread_actions_isolatable idx (updateMDB slot f)"
   apply (simp add: updateMDB_def thread_actions_isolatable_return
             split: if_split)
-  apply (intro impI thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
+  apply (intro impI thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
                getCTE_isolatable setCTE_isolatable,
            (wp | simp)+)
   done
@@ -1463,7 +1463,7 @@ lemma emptySlot_isolatable:
   "thread_actions_isolatable idx (emptySlot slot NullCap)"
   apply (simp add: emptySlot_def updateCap_def case_Null_If Retype_H.postCapDeletion_def
              cong: if_cong)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
                clearUntypedFreeIndex_isolatable
                thread_actions_isolatable_if
                getCTE_isolatable setCTE_isolatable

--- a/proof/crefine/ARM/Refine_C.thy
+++ b/proof/crefine/ARM/Refine_C.thy
@@ -84,7 +84,7 @@ proof -
        apply (clarsimp simp: return_def)
       apply (wp schedule_sch_act_wf schedule_invs'
              | strengthen invs_valid_objs_strengthen invs_pspace_aligned' invs_pspace_distinct')+
-   apply (rule_tac Q="\<lambda>rv s. invs' s \<and> (\<forall>x. rv = Some x \<longrightarrow> x \<le> Kernel_Config.maxIRQ)" in hoare_post_imp)
+   apply (rule_tac Q'="\<lambda>rv s. invs' s \<and> (\<forall>x. rv = Some x \<longrightarrow> x \<le> Kernel_Config.maxIRQ)" in hoare_post_imp)
     apply (solves clarsimp)
    apply (wp getActiveIRQ_le_maxIRQ | simp)+
   apply (clarsimp simp: invs'_def valid_state'_def)
@@ -267,12 +267,12 @@ lemma handleSyscall_ccorres:
                   apply wp
                  apply (simp add: guard_is_UNIV_def)
                 apply clarsimp
-                apply (rule_tac Q="\<lambda>rv s. invs' s \<and>
+                apply (rule_tac Q'="\<lambda>rv s. invs' s \<and>
                                           (\<forall>x. rv = Some x \<longrightarrow> x \<le> Kernel_Config.maxIRQ)"
                                 in hoare_post_imp)
                  apply (solves clarsimp)
                 apply (wp getActiveIRQ_le_maxIRQ | simp)+
-               apply (rule_tac Q=" invs' " in hoare_post_imp_dc2E, wp)
+               apply (rule_tac Q'=" invs' " in hoare_post_impE_E_dc, wp)
                apply (simp add: invs'_def valid_state'_def)
               apply clarsimp
               apply (vcg exspec=handleInvocation_modifies)
@@ -301,12 +301,12 @@ lemma handleSyscall_ccorres:
                  apply wp
                 apply (simp add: guard_is_UNIV_def)
                apply clarsimp
-               apply (rule_tac Q="\<lambda>rv s. invs' s \<and>
+               apply (rule_tac Q'="\<lambda>rv s. invs' s \<and>
                                          (\<forall>x. rv = Some x \<longrightarrow> x \<le> Kernel_Config.maxIRQ)"
                                in hoare_post_imp)
                 apply (solves clarsimp)
                apply (wp getActiveIRQ_le_maxIRQ | simp)+
-              apply (rule_tac Q=" invs' " in hoare_post_imp_dc2E, wp)
+              apply (rule_tac Q'=" invs' " in hoare_post_impE_E_dc, wp)
               apply (simp add: invs'_def valid_state'_def)
              apply clarsimp
              apply (vcg exspec=handleInvocation_modifies)
@@ -335,12 +335,12 @@ lemma handleSyscall_ccorres:
                 apply wp
                apply (simp add: guard_is_UNIV_def)
               apply clarsimp
-              apply (rule_tac Q="\<lambda>rv s. invs' s \<and>
+              apply (rule_tac Q'="\<lambda>rv s. invs' s \<and>
                                         (\<forall>x. rv = Some x \<longrightarrow> x \<le> Kernel_Config.maxIRQ)"
                               in hoare_post_imp)
                apply (solves clarsimp)
               apply (wp getActiveIRQ_le_maxIRQ | simp)+
-             apply (rule_tac Q=" invs'" in hoare_post_imp_dc2E, wp)
+             apply (rule_tac Q'=" invs'" in hoare_post_impE_E_dc, wp)
              apply (simp add: invs'_def valid_state'_def)
             apply clarsimp
             apply (vcg exspec=handleInvocation_modifies)
@@ -373,7 +373,7 @@ lemma handleSyscall_ccorres:
           apply wp[1]
          apply clarsimp
          apply wp
-         apply (rule_tac Q="\<lambda>rv s. ct_in_state' simple' s \<and> sch_act_sane s"
+         apply (rule_tac Q'="\<lambda>rv s. ct_in_state' simple' s \<and> sch_act_sane s"
                               in hoare_post_imp)
           apply (simp add: ct_in_state'_def)
          apply (wp handleReply_sane)
@@ -408,15 +408,15 @@ lemma handleSyscall_ccorres:
           | wpc
           | wp hoare_drop_imp handleReply_sane handleReply_nonz_cap_to_ct schedule_invs'
           | strengthen ct_active_not_idle'_strengthen invs_valid_objs_strengthen)+
-      apply (rule_tac  Q="\<lambda>rv. invs' and ct_active'" in hoare_post_imp, simp)
+      apply (rule_tac Q'="\<lambda>rv. invs' and ct_active'" in hoare_post_imp, simp)
       apply (wp hy_invs')
      apply (clarsimp simp add: liftE_def)
      apply wp
-     apply (rule_tac  Q="\<lambda>rv. invs' and ct_active'" in hoare_post_imp, simp)
+     apply (rule_tac Q'="\<lambda>rv. invs' and ct_active'" in hoare_post_imp, simp)
      apply (wp hy_invs')
     apply (clarsimp simp: liftE_def)
     apply (wp)
-    apply (rule_tac Q="\<lambda>_. invs'" in hoare_post_imp, simp)
+    apply (rule_tac Q'="\<lambda>_. invs'" in hoare_post_imp, simp)
     apply (wp hw_invs')
    apply (simp add: guard_is_UNIV_def)
    apply clarsimp

--- a/proof/crefine/ARM/Retype_C.thy
+++ b/proof/crefine/ARM/Retype_C.thy
@@ -5894,7 +5894,7 @@ lemma createObject_valid_cap':
   apply (simp add:createObject_def3)
   apply (rule hoare_pre)
   apply wp
-   apply (rule_tac Q = "\<lambda>r s. r \<noteq> [] \<and> Q r s" for Q in hoare_strengthen_post)
+   apply (rule_tac Q'="\<lambda>r s. r \<noteq> [] \<and> Q r s" for Q in hoare_strengthen_post)
    apply (rule hoare_vcg_conj_lift)
      apply (rule hoare_strengthen_post[OF createNewCaps_ret_len])
       apply clarsimp
@@ -5966,7 +5966,7 @@ lemma createObject_caps_overlap_reserved_ret':
   apply (simp add:createObject_def3)
   apply (rule hoare_pre)
   apply wp
-   apply (rule_tac Q = "\<lambda>r s. r \<noteq> [] \<and> Q r s" for Q in hoare_strengthen_post)
+   apply (rule_tac Q'="\<lambda>r s. r \<noteq> [] \<and> Q r s" for Q in hoare_strengthen_post)
    apply (rule hoare_vcg_conj_lift)
      apply (rule hoare_strengthen_post[OF createNewCaps_ret_len])
       apply clarsimp
@@ -5989,7 +5989,7 @@ lemma createObject_descendants_range':
   apply (simp add:createObject_def3)
   apply (rule hoare_pre)
   apply wp
-   apply (rule_tac Q = "\<lambda>r s. r \<noteq> [] \<and> Q r s" for Q in hoare_strengthen_post)
+   apply (rule_tac Q'="\<lambda>r s. r \<noteq> [] \<and> Q r s" for Q in hoare_strengthen_post)
    apply (rule hoare_vcg_conj_lift)
      apply (rule hoare_strengthen_post[OF createNewCaps_ret_len])
       apply clarsimp
@@ -6020,7 +6020,7 @@ lemma createObject_idlethread_range:
   apply (simp add:createObject_def3)
   apply (rule hoare_pre)
   apply wp
-   apply (rule_tac Q = "\<lambda>r s. r \<noteq> [] \<and> Q r s" for Q in hoare_strengthen_post)
+   apply (rule_tac Q'="\<lambda>r s. r \<noteq> [] \<and> Q r s" for Q in hoare_strengthen_post)
    apply (rule hoare_vcg_conj_lift)
      apply (rule hoare_strengthen_post[OF createNewCaps_ret_len])
       apply clarsimp
@@ -6036,7 +6036,7 @@ lemma createObject_IRQHandler:
   apply (simp add:createObject_def3)
   apply (rule hoare_pre)
   apply wp
-   apply (rule_tac Q = "\<lambda>r s. r \<noteq> [] \<and> Q r s" for Q in hoare_strengthen_post)
+   apply (rule_tac Q'="\<lambda>r s. r \<noteq> [] \<and> Q r s" for Q in hoare_strengthen_post)
    apply (rule hoare_vcg_conj_lift)
      apply (rule hoare_strengthen_post[OF createNewCaps_ret_len])
       apply clarsimp
@@ -6054,7 +6054,7 @@ lemma createObject_capClass[wp]:
   apply (simp add:createObject_def3)
   apply (rule hoare_pre)
   apply wp
-   apply (rule_tac Q = "\<lambda>r s. r \<noteq> [] \<and> Q r s" for Q in hoare_strengthen_post)
+   apply (rule_tac Q'="\<lambda>r s. r \<noteq> [] \<and> Q r s" for Q in hoare_strengthen_post)
    apply (rule hoare_vcg_conj_lift)
      apply (rule hoare_strengthen_post[OF createNewCaps_ret_len])
       apply clarsimp
@@ -6099,7 +6099,7 @@ lemma createObject_parent_helper:
     \<rbrace>
     createObject ty ptr us dev
     \<lbrace>\<lambda>rv. cte_wp_at' (\<lambda>cte. isUntypedCap (cteCap cte) \<and> (sameRegionAs (cteCap cte) rv)) p\<rbrace>"
-  apply (rule hoare_post_imp [where Q="\<lambda>rv s. \<exists>cte. cte_wp_at' ((=) cte) p s
+  apply (rule hoare_post_imp[where Q'="\<lambda>rv s. \<exists>cte. cte_wp_at' ((=) cte) p s
                                            \<and> isUntypedCap (cteCap cte) \<and>
                                 sameRegionAs (cteCap cte) rv"])
   apply (clarsimp simp:cte_wp_at_ctes_of)
@@ -6808,7 +6808,7 @@ shows  "ccorres dc xfdc
                  (cnodeptr + (of_nat k * 0x10 + start * 0x10 + of_nat n * 0x10)) s)
               \<and> descendants_range_in' {(of_nat n << APIType_capBits newType userSize) +
                  ptr.. (ptr && ~~ mask sz) + 2 ^ sz  - 1} srcSlot (ctes_of s)"
-              in hoare_pre(1))
+              in hoare_weaken_pre)
              apply wp
             apply (clarsimp simp:createObject_hs_preconds_def conj_comms
                    invs_valid_pspace' invs_pspace_distinct' invs_pspace_aligned'

--- a/proof/crefine/ARM/Schedule_C.thy
+++ b/proof/crefine/ARM/Schedule_C.thy
@@ -636,7 +636,7 @@ lemma schedule_ccorres:
        apply wp
       apply clarsimp
       (* when runnable tcbSchedEnqueue curThread *)
-      apply (rule_tac Q="\<lambda>rv s. invs' s \<and> ksCurThread s = curThread
+      apply (rule_tac Q'="\<lambda>rv s. invs' s \<and> ksCurThread s = curThread
                                 \<and> ksSchedulerAction s = SwitchToThread candidate" in hoare_post_imp)
        apply (clarsimp simp: invs'_bitmapQ_no_L1_orphans invs_ksCurDomain_maxDomain')
        apply (fastforce dest: invs_sch_act_wf')

--- a/proof/crefine/ARM/SyscallArgs_C.thy
+++ b/proof/crefine/ARM/SyscallArgs_C.thy
@@ -1006,7 +1006,7 @@ lemma getMRs_user_word:
                          linorder_not_less [symmetric])
    apply (wp mapM_loadWordUser_user_words_at)
    apply (wp hoare_vcg_all_lift)
-    apply (rule_tac Q="\<lambda>_. \<top>" in hoare_strengthen_post)
+    apply (rule_tac Q'="\<lambda>_. \<top>" in hoare_strengthen_post)
      apply wp
     apply clarsimp
     defer
@@ -1062,7 +1062,7 @@ lemma getMRs_rel:
   apply (rule hoare_pre)
    apply (rule_tac x=mi in hoare_exI)
    apply wp
-   apply (rule_tac Q="\<lambda>rv s. thread = ksCurThread s \<and> fst (getMRs thread buffer mi s) = {(rv,s)}" in hoare_strengthen_post)
+   apply (rule_tac Q'="\<lambda>rv s. thread = ksCurThread s \<and> fst (getMRs thread buffer mi s) = {(rv,s)}" in hoare_strengthen_post)
     apply (wp det_result det_wp_getMRs)
    apply clarsimp
   apply (clarsimp simp: cur_tcb'_def)
@@ -1230,7 +1230,7 @@ lemma getSyscallArg_ccorres_foo:
     apply (clarsimp simp: option_to_ptr_def option_to_0_def)
     apply (rule_tac P="\<lambda>s. valid_ipc_buffer_ptr' (ptr_val (Ptr b)) s \<and> i < msgLength mi \<and>
                            msgLength mi \<le> msgMaxLength \<and> scast n_msgRegisters \<le> i"
-                 in hoare_pre(1))
+                 in hoare_weaken_pre)
      apply (wp getMRs_user_word)
     apply (clarsimp simp: msgMaxLength_def unat_less_helper)
    apply fastforce

--- a/proof/crefine/ARM/Syscall_C.thy
+++ b/proof/crefine/ARM/Syscall_C.thy
@@ -253,7 +253,7 @@ lemma decodeInvocation_ccorres:
        apply simp
        apply (vcg exspec=performInvocation_Reply_modifies)
       apply (simp add: cur_tcb'_def[symmetric])
-      apply (rule_tac R="\<lambda>rv s. ksCurThread s = thread" in hoare_post_add)
+      apply (rule_tac Q'="\<lambda>rv s. ksCurThread s = thread" in hoare_post_add)
       apply (simp cong: conj_cong)
       apply (strengthen imp_consequent)
       apply (wp sts_invs_minor' sts_st_tcb_at'_cases)
@@ -627,9 +627,9 @@ lemma sendFaultIPC_ccorres:
                  , assumption)
          apply vcg
         apply (clarsimp simp: inQ_def)
-        apply (rule_tac Q="\<lambda>a b. invs' b \<and> st_tcb_at' simple' tptr b
+        apply (rule_tac Q'="\<lambda>a b. invs' b \<and> st_tcb_at' simple' tptr b
                                  \<and> sch_act_not tptr b \<and> valid_cap' a b"
-                 and E="\<lambda> _. \<top>"
+                 and E'="\<lambda> _. \<top>"
                  in hoare_strengthen_postE)
           apply (wp)
          apply (clarsimp simp: isCap_simps)
@@ -847,8 +847,8 @@ lemma handleInvocation_ccorres:
                      apply (rule ccorres_return_C_errorE, simp+)[1]
                     apply vcg
                    apply (simp add: invocationCatch_def o_def)
-                   apply (rule_tac Q="\<lambda>rv'. invs' and tcb_at' rv"
-                               and E="\<lambda>ft. invs' and tcb_at' rv"
+                   apply (rule_tac Q'="\<lambda>rv'. invs' and tcb_at' rv"
+                               and E'="\<lambda>ft. invs' and tcb_at' rv"
                               in hoare_strengthen_postE)
                      apply (wp hoare_split_bind_case_sumE hoare_drop_imps
                                setThreadState_nonqueued_state_update

--- a/proof/crefine/ARM/Tcb_C.thy
+++ b/proof/crefine/ARM/Tcb_C.thy
@@ -384,7 +384,7 @@ lemma setPriority_ccorres:
                  simp: st_tcb_at'_def o_def split: if_splits)
     apply (simp add: guard_is_UNIV_def)
    apply (rule hoare_strengthen_post[
-                 where Q="\<lambda>rv s.
+                 where Q'="\<lambda>rv s.
                           obj_at' (\<lambda>_. True) t s \<and>
                           priority \<le> maxPriority \<and>
                           ksCurDomain s \<le> maxDomain \<and>
@@ -607,7 +607,7 @@ lemma invokeTCB_ThreadControl_ccorres:
                          apply wp
                         apply (clarsimp simp: guard_is_UNIV_def Collect_const_mem)
                        apply (rule hoare_strengthen_post[
-                                    where Q= "\<lambda>rv s.
+                                    where Q'="\<lambda>rv s.
                                               valid_objs' s \<and>
                                               weak_sch_act_wf (ksSchedulerAction s) s \<and>
                                               ((\<exists>a b. priority = Some (a, b)) \<longrightarrow>
@@ -698,7 +698,7 @@ lemma invokeTCB_ThreadControl_ccorres:
                apply (clarsimp simp: guard_is_UNIV_def Collect_const_mem)
               apply (simp cong: conj_cong)
               apply (rule hoare_strengthen_post[
-                            where Q="\<lambda>a b. (valid_objs' b \<and>
+                            where Q'="\<lambda>a b. (valid_objs' b \<and>
                                        sch_act_wf (ksSchedulerAction b) b \<and>
                                        pspace_aligned' b \<and> pspace_distinct' b \<and>
                                        ((\<exists>a b. priority = Some (a, b)) \<longrightarrow>
@@ -745,7 +745,7 @@ lemma invokeTCB_ThreadControl_ccorres:
             apply vcg
            apply (simp add: conj_comms cong: conj_cong)
            apply (strengthen invs_ksCurDomain_maxDomain' invs_pspace_distinct')
-           apply (wp hoare_vcg_const_imp_lift_R cteDelete_invs')
+           apply (wp hoare_vcg_const_imp_liftE_R cteDelete_invs')
           apply simp
           apply (rule ccorres_split_nothrow_novcg_dc)
              apply (rule ccorres_cond2[where R=\<top>], simp add: Collect_const_mem)
@@ -1156,13 +1156,13 @@ lemma invokeTCB_CopyRegisters_ccorres:
             apply (simp add: pred_conj_def guard_is_UNIV_def  cong: if_cong
                       | wp mapM_x_wp_inv hoare_drop_imp)+
            apply clarsimp
-      apply (rule_tac Q="\<lambda>rv. invs' and tcb_at' destn" in hoare_strengthen_post[rotated])
+      apply (rule_tac Q'="\<lambda>rv. invs' and tcb_at' destn" in hoare_strengthen_post[rotated])
        apply (fastforce simp: sch_act_wf_weak)
       apply (wpsimp wp: hoare_drop_imp restart_invs')+
      apply (clarsimp simp add: guard_is_UNIV_def)
     apply (wp hoare_drop_imp hoare_vcg_if_lift)+
     apply simp
-    apply (rule_tac Q="\<lambda>rv. invs' and tcb_at' destn" in hoare_strengthen_post[rotated])
+    apply (rule_tac Q'="\<lambda>rv. invs' and tcb_at' destn" in hoare_strengthen_post[rotated])
      apply (fastforce simp: sch_act_wf_weak)
     apply (wpsimp wp: hoare_drop_imp)+
    apply (clarsimp simp add: guard_is_UNIV_def)
@@ -1553,7 +1553,7 @@ lemma invokeTCB_WriteRegisters_ccorres[where S=UNIV]:
                    apply wp
                   apply (simp add: guard_is_UNIV_def)
                  apply (wp hoare_drop_imp)
-                  apply (rule_tac Q="\<lambda>rv. invs' and tcb_at' dst" in hoare_strengthen_post[rotated])
+                  apply (rule_tac Q'="\<lambda>rv. invs' and tcb_at' dst" in hoare_strengthen_post[rotated])
                    apply (fastforce simp: sch_act_wf_weak)
                   apply (wpsimp wp: restart_invs')+
                 apply (clarsimp simp add: guard_is_UNIV_def)
@@ -2062,7 +2062,7 @@ shows
         apply wp
        apply (simp add: Collect_const_mem ThreadState_defs mask_def)
        apply vcg
-      apply (rule_tac Q="\<lambda>rv. invs' and st_tcb_at' ((=) Restart) thread
+      apply (rule_tac Q'="\<lambda>rv. invs' and st_tcb_at' ((=) Restart) thread
                              and tcb_at' target" in hoare_post_imp)
        apply (clarsimp simp: pred_tcb_at')
        apply (auto elim!: pred_tcb'_weakenE)[1]

--- a/proof/crefine/ARM/VSpace_C.thy
+++ b/proof/crefine/ARM/VSpace_C.thy
@@ -1648,7 +1648,7 @@ lemma performPageFlush_ccorres:
           apply (ctac add: setVMRoot_ccorres)
          apply (rule ccorres_return_Skip)
         apply (simp add: cur_tcb'_def[symmetric])
-        apply (rule_tac Q="\<lambda>_ s. invs' s \<and> cur_tcb' s" in hoare_post_imp)
+        apply (rule_tac Q'="\<lambda>_ s. invs' s \<and> cur_tcb' s" in hoare_post_imp)
          apply (simp add: invs'_invs_no_cicd)
         apply wp+
       apply (rule ccorres_return_Skip)
@@ -1786,7 +1786,7 @@ lemma performPageDirectoryInvocationFlush_ccorres:
        apply wp
       apply (simp add: guard_is_UNIV_def)
      apply (simp add: cur_tcb'_def[symmetric])
-     apply (rule_tac Q="\<lambda>_ s. invs' s \<and> cur_tcb' s" in hoare_post_imp)
+     apply (rule_tac Q'="\<lambda>_ s. invs' s \<and> cur_tcb' s" in hoare_post_imp)
       apply (simp add: invs'_invs_no_cicd)
      apply wp+
    apply (simp)
@@ -1840,7 +1840,7 @@ lemma flushPage_ccorres:
         apply (ctac add: setVMRoot_ccorres)
        apply (rule ccorres_return_Skip)
       apply (wp | simp add: cur_tcb'_def[symmetric])+
-      apply (rule_tac Q="\<lambda>_ s. invs' s \<and> cur_tcb' s" in hoare_post_imp)
+      apply (rule_tac Q'="\<lambda>_ s. invs' s \<and> cur_tcb' s" in hoare_post_imp)
        apply (simp add: invs'_invs_no_cicd)
       apply (wp | simp add: cur_tcb'_def[symmetric])+
      apply (rule ccorres_return_Skip)
@@ -2371,7 +2371,7 @@ lemma unmapPage_ccorres:
       apply (rule ccorres_return_void_C)
      apply vcg
     apply (simp add: lookup_pd_slot_def Let_def)
-    apply (wp hoare_vcg_const_imp_lift_R)
+    apply (wp hoare_vcg_const_imp_liftE_R)
    apply (simp add: Collect_const_mem)
    apply (vcg exspec=findPDForASID_modifies)
   apply (clarsimp simp: invs_arch_state' invs_no_0_obj' invs_valid_objs'
@@ -3016,7 +3016,7 @@ lemma flushTable_ccorres:
        apply (rule ccorres_return_Skip)
       apply (wp hoare_weak_lift_imp)
        apply clarsimp
-       apply (rule_tac Q="\<lambda>_ s. invs' s \<and> cur_tcb' s" in hoare_post_imp)
+       apply (rule_tac Q'="\<lambda>_ s. invs' s \<and> cur_tcb' s" in hoare_post_imp)
         apply (simp add: invs'_invs_no_cicd cur_tcb'_def)
        apply (wp mapM_x_wp_inv getPTE_wp | wpc)+
      apply (rule ccorres_return_Skip)

--- a/proof/crefine/ARM_HYP/Arch_C.thy
+++ b/proof/crefine/ARM_HYP/Arch_C.thy
@@ -517,7 +517,7 @@ shows
        apply clarsimp
        apply (wp getSlotCap_wp)
       apply clarsimp
-     apply (rule_tac Q="\<lambda>_. cte_wp_at' ((=) (UntypedCap isdev frame pageBits idx) o cteCap) parent
+     apply (rule_tac Q'="\<lambda>_. cte_wp_at' ((=) (UntypedCap isdev frame pageBits idx) o cteCap) parent
                            and (\<lambda>s. descendants_range_in' {frame..frame + (2::word32) ^ pageBits - (1::word32)} parent (ctes_of s))
                            and pspace_no_overlap' frame pageBits
                            and invs'

--- a/proof/crefine/ARM_HYP/DetWP.thy
+++ b/proof/crefine/ARM_HYP/DetWP.thy
@@ -120,7 +120,7 @@ lemma det_wp_asUser [wp]:
       apply (drule det_wp_det)
       apply (erule det_wp_select_f)
      apply wp+
-   apply (rule_tac Q="\<lambda>_. tcb_at' t" in hoare_post_imp)
+   apply (rule_tac Q'="\<lambda>_. tcb_at' t" in hoare_post_imp)
     apply simp
    apply wp
   apply simp

--- a/proof/crefine/ARM_HYP/Fastpath_C.thy
+++ b/proof/crefine/ARM_HYP/Fastpath_C.thy
@@ -790,7 +790,7 @@ lemma switchToThread_fp_ccorres:
      apply (rule ccorres_False[where P'=UNIV])
     apply simp
     apply (wp findPDForASID_pd_at_wp)[1]
-   apply (rule_tac Q=
+   apply (rule_tac Q'=
             "\<lambda>r s. \<forall>cte. map_to_ctes (ksPSpace s) (thread + 2 ^ cte_level_bits * tcbVTableSlot) = Some cte \<longrightarrow>
                            pd \<in> ran (\<lambda>a. map_option snd (armKSASIDMap (ksArchState s) a))
                            \<and> page_directory_at' pd s

--- a/proof/crefine/ARM_HYP/Fastpath_C.thy
+++ b/proof/crefine/ARM_HYP/Fastpath_C.thy
@@ -1617,7 +1617,7 @@ lemma ctes_of_Some_cte_wp_at:
 lemma user_getreg_wp:
   "\<lbrace>\<lambda>s. tcb_at' t s \<and> (\<forall>rv. obj_at' (\<lambda>tcb. (user_regs o atcbContextGet o tcbArch) tcb r = rv) t s \<longrightarrow> Q rv s)\<rbrace>
       asUser t (getRegister r) \<lbrace>Q\<rbrace>"
-  apply (rule_tac Q="\<lambda>rv s. \<exists>rv'. rv' = rv \<and> Q rv' s" in hoare_post_imp)
+  apply (rule_tac Q'="\<lambda>rv s. \<exists>rv'. rv' = rv \<and> Q rv' s" in hoare_post_imp)
    apply simp
   apply (rule hoare_pre, wp hoare_vcg_ex_lift user_getreg_rv)
   apply (clarsimp simp: obj_at'_def)
@@ -2309,7 +2309,7 @@ proof -
                                set_ep_valid_objs'
                                setObject_no_0_obj'[where 'a=endpoint, folded setEndpoint_def]
                             | strengthen not_obj_at'_strengthen)+
-                      apply (rule_tac Q="\<lambda>_ s. hd (epQueue send_ep) \<noteq> curThread
+                      apply (rule_tac Q'="\<lambda>_ s. hd (epQueue send_ep) \<noteq> curThread
                                               \<and> pred_tcb_at' itcbState ((=) (tcbState xa)) (hd (epQueue send_ep)) s"
                                in hoare_post_imp)
                        apply fastforce

--- a/proof/crefine/ARM_HYP/Fastpath_Equiv.thy
+++ b/proof/crefine/ARM_HYP/Fastpath_Equiv.thy
@@ -250,7 +250,7 @@ lemma ctes_of_Some_cte_wp_at:
 lemma user_getreg_wp:
   "\<lbrace>\<lambda>s. tcb_at' t s \<and> (\<forall>rv. obj_at' (\<lambda>tcb. (user_regs o atcbContextGet o tcbArch) tcb r = rv) t s \<longrightarrow> Q rv s)\<rbrace>
       asUser t (getRegister r) \<lbrace>Q\<rbrace>"
-  apply (rule_tac Q="\<lambda>rv s. \<exists>rv'. rv' = rv \<and> Q rv' s" in hoare_post_imp)
+  apply (rule_tac Q'="\<lambda>rv s. \<exists>rv'. rv' = rv \<and> Q rv' s" in hoare_post_imp)
    apply simp
   apply (rule hoare_pre, wp hoare_vcg_ex_lift user_getreg_rv)
   apply (clarsimp simp: obj_at'_def)

--- a/proof/crefine/ARM_HYP/Finalise_C.thy
+++ b/proof/crefine/ARM_HYP/Finalise_C.thy
@@ -754,7 +754,7 @@ lemma suspend_ccorres:
         apply ceqv
        apply (ctac(no_vcg) add: setThreadState_ccorres_simple)
         apply (ctac add: tcbSchedDequeue_ccorres)
-       apply (rule_tac Q="\<lambda>_. valid_objs' and tcb_at' thread and pspace_aligned' and pspace_distinct'"
+       apply (rule_tac Q'="\<lambda>_. valid_objs' and tcb_at' thread and pspace_aligned' and pspace_distinct'"
                     in hoare_post_imp)
         apply clarsimp
        apply (wp sts_valid_objs')[1]
@@ -1592,7 +1592,7 @@ lemma unmapPageTable_ccorres:
      apply wp
     apply (fastforce simp: guard_is_UNIV_def Collect_const_mem Let_def
       shiftl_t2n field_simps lookup_pd_slot_def table_bits_defs)
-   apply (rule_tac Q="\<lambda>rv s. (case rv of Some pd \<Rightarrow> page_directory_at' pd s | _ \<Rightarrow> True) \<and> invs' s"
+   apply (rule_tac Q'="\<lambda>rv s. (case rv of Some pd \<Rightarrow> page_directory_at' pd s | _ \<Rightarrow> True) \<and> invs' s"
              in hoare_post_imp)
     apply (clarsimp simp: lookup_pd_slot_def Let_def
                           mask_add_aligned less_pptrBase_valid_pde_offset''
@@ -2259,7 +2259,7 @@ lemma associateVCPUTCB_ccorres:
       apply ((wpsimp wp: hoare_vcg_all_lift hoare_drop_imps
               | strengthen invs_valid_objs' invs_arch_state')+)[1]
      apply (vcg exspec=dissociateVCPUTCB_modifies)
-    apply (rule_tac Q="\<lambda>_. invs' and vcpu_at' vcpuptr and tcb_at' tptr" in hoare_post_imp)
+    apply (rule_tac Q'="\<lambda>_. invs' and vcpu_at' vcpuptr and tcb_at' tptr" in hoare_post_imp)
      apply (clarsimp simp: valid_vcpu'_def typ_at_tcb' obj_at'_def projectKOs)
      apply (rename_tac vcpu obj, case_tac vcpu)
      apply (fastforce simp: valid_arch_tcb'_def)

--- a/proof/crefine/ARM_HYP/Invoke_C.thy
+++ b/proof/crefine/ARM_HYP/Invoke_C.thy
@@ -75,7 +75,7 @@ lemma setDomain_ccorres:
        apply (simp add: guard_is_UNIV_def)
       apply simp
       apply wp
-     apply (rule_tac Q="\<lambda>_. all_invs_but_sch_extra and tcb_at' t and sch_act_simple
+     apply (rule_tac Q'="\<lambda>_. all_invs_but_sch_extra and tcb_at' t and sch_act_simple
                             and (\<lambda>s. curThread = ksCurThread s)"
               in hoare_strengthen_post)
       apply (wp threadSet_all_invs_but_sch_extra)
@@ -83,7 +83,7 @@ lemma setDomain_ccorres:
                             sch_act_simple_def st_tcb_at'_def weak_sch_act_wf_def
                      split: if_splits)
     apply (simp add: guard_is_UNIV_def)
-   apply (rule_tac Q="\<lambda>_. invs' and tcb_at' t and sch_act_simple and (\<lambda>s. curThread = ksCurThread s)"
+   apply (rule_tac Q'="\<lambda>_. invs' and tcb_at' t and sch_act_simple and (\<lambda>s. curThread = ksCurThread s)"
             in hoare_strengthen_post)
     apply (wp weak_sch_act_wf_lift_linear tcbSchedDequeue_not_queued
               hoare_vcg_imp_lift hoare_vcg_all_lift)
@@ -770,7 +770,7 @@ lemma decodeCNodeInvocation_ccorres:
                                apply (rule_tac Q'="\<lambda>rv. valid_pspace'
                                                     and valid_cap' rv and valid_objs'
                                                          and tcb_at' thread and (\<lambda>s. sch_act_wf (ksSchedulerAction s) s)"
-                                           in hoare_vcg_R_conj)
+                                           in hoare_vcg_conj_liftE_R)
                                 apply (rule deriveCap_Null_helper[OF deriveCap_derived])
                                apply wp
                               apply (clarsimp simp: cte_wp_at_ctes_of)
@@ -846,7 +846,7 @@ lemma decodeCNodeInvocation_ccorres:
                                    apply (rule_tac Q'="\<lambda>rv. valid_pspace'
                                                         and valid_cap' rv and valid_objs'
                                                              and tcb_at' thread and (\<lambda>s. sch_act_wf (ksSchedulerAction s) s)"
-                                               in hoare_vcg_R_conj)
+                                               in hoare_vcg_conj_liftE_R)
                                     apply (rule deriveCap_Null_helper [OF deriveCap_derived])
                                    apply wp
                                   apply (clarsimp simp: cte_wp_at_ctes_of)
@@ -967,7 +967,7 @@ lemma decodeCNodeInvocation_ccorres:
                       apply (clarsimp simp:valid_updateCapDataI invs_valid_objs' invs_valid_pspace')
                       apply assumption
                      apply (wp hoare_vcg_all_liftE_R injection_wp_E[OF refl]
-                               lsfco_cte_at' hoare_vcg_const_imp_lift_R
+                               lsfco_cte_at' hoare_vcg_const_imp_liftE_R
                            )+
                     apply (simp add: Collect_const_mem word_sle_def word_sless_def
                                      all_ex_eq_helper)
@@ -1344,7 +1344,7 @@ lemma decodeCNodeInvocation_ccorres:
           apply (rule ccorres_return_C_errorE, simp+)[1]
          apply vcg
         apply simp
-        apply (wp injection_wp_E[OF refl] hoare_vcg_const_imp_lift_R
+        apply (wp injection_wp_E[OF refl] hoare_vcg_const_imp_liftE_R
                   hoare_vcg_all_liftE_R lsfco_cte_at' hoare_weak_lift_imp
                 | simp add: hasCancelSendRights_not_Null ctes_of_valid_strengthen
                       cong: conj_cong

--- a/proof/crefine/ARM_HYP/IpcCancel_C.thy
+++ b/proof/crefine/ARM_HYP/IpcCancel_C.thy
@@ -2804,7 +2804,7 @@ lemma cancelIPC_ccorres1:
                                 ghost_assertion_data_set_def cap_tag_defs)
               apply (simp add: locateSlot_conv, wp)
              apply vcg
-            apply (rule_tac Q="\<lambda>rv. tcb_at' thread and invs'" in hoare_post_imp)
+            apply (rule_tac Q'="\<lambda>rv. tcb_at' thread and invs'" in hoare_post_imp)
              apply (clarsimp simp: cte_wp_at_ctes_of capHasProperty_def
                                    cap_get_tag_isCap ucast_id)
             apply (wp threadSet_invs_trivial | simp)+

--- a/proof/crefine/ARM_HYP/Ipc_C.thy
+++ b/proof/crefine/ARM_HYP/Ipc_C.thy
@@ -1455,7 +1455,7 @@ lemma asUser_atcbContext_obj_at:
 lemma asUser_tcbFault_inv:
   "\<lbrace>\<lambda>s. \<exists>t. ko_at' t p' s \<and> tcbFault t = f\<rbrace> asUser p m
    \<lbrace>\<lambda>rv s. \<exists>t. ko_at' t p' s \<and> tcbFault t = f\<rbrace>"
-  apply (rule_tac Q="\<lambda>rv. obj_at' (\<lambda>t. tcbFault t = f) p'"
+  apply (rule_tac Q'="\<lambda>rv. obj_at' (\<lambda>t. tcbFault t = f) p'"
                in hoare_strengthen_post)
    apply (wp asUser_tcbFault_obj_at)
    apply (clarsimp simp: obj_at'_def)+
@@ -3782,7 +3782,7 @@ lemma doIPCTransfer_ccorres [corres]:
                            fault_to_fault_tag_nonzero)
      apply ctac
     apply (clarsimp simp: guard_is_UNIV_def option_to_ptr_def split: option.splits)
-   apply (rule_tac Q="\<lambda>rv. valid_pspace' and cur_tcb' and tcb_at' sender
+   apply (rule_tac Q'="\<lambda>rv. valid_pspace' and cur_tcb' and tcb_at' sender
                        and tcb_at' receiver and K (rv \<noteq> Some 0)
                        and (case_option \<top> valid_ipc_buffer_ptr' rv)
                        and K (receiver \<noteq> sender \<and> endpoint \<noteq> Some 0)"
@@ -4549,7 +4549,7 @@ lemma doReplyTransfer_ccorres [corres]:
                          | simp add: valid_tcb_state'_def)+)[1]
            apply (clarsimp simp: guard_is_UNIV_def ThreadState_defs mask_def option_to_ctcb_ptr_def)
 
-          apply (rule_tac Q="\<lambda>rv. tcb_at' receiver and
+          apply (rule_tac Q'="\<lambda>rv. tcb_at' receiver and
                                 valid_objs' and sch_act_simple and (\<lambda>s. ksCurDomain s \<le> maxDomain) and
                                 (\<lambda>s. sch_act_wf (ksSchedulerAction s) s) and
                                 pspace_aligned' and pspace_distinct'" in hoare_post_imp)
@@ -4647,7 +4647,7 @@ lemma setupCallerCap_ccorres [corres]:
                        ptr_add_assertion_positive Collect_const_mem
                        tcb_cnode_index_defs)
      apply simp
-     apply (rule_tac Q="\<lambda>rv. valid_pspace' and tcb_at' receiver" in hoare_post_imp)
+     apply (rule_tac Q'="\<lambda>rv. valid_pspace' and tcb_at' receiver" in hoare_post_imp)
       apply (auto simp: cte_wp_at_ctes_of isCap_simps
                         tcbSlots Kernel_C.tcbCaller_def size_of_def
                         cte_level_bits_def)[1]
@@ -6004,7 +6004,7 @@ lemma receiveIPC_ccorres [corres]:
                 apply (fastforce simp: guard_is_UNIV_def ThreadState_defs mask_def
                                        cap_get_tag_isCap ccap_relation_ep_helpers)
                apply (clarsimp simp: valid_tcb_state'_def)
-               apply (rule_tac Q="\<lambda>_. valid_pspace'
+               apply (rule_tac Q'="\<lambda>_. valid_pspace'
                                        and st_tcb_at' ((=) sendState) sender and tcb_at' thread
                                        and (\<lambda>s. sch_act_wf (ksSchedulerAction s) s)
                                        and sch_act_not sender and K (thread \<noteq> sender)
@@ -6012,7 +6012,7 @@ lemma receiveIPC_ccorres [corres]:
                 apply (fastforce simp: valid_pspace_valid_objs' pred_tcb_at'_def sch_act_wf_weak
                                        obj_at'_def)
                apply (wpsimp simp: guard_is_UNIV_def option_to_ptr_def option_to_0_def conj_ac)+
-           apply (rule_tac Q="\<lambda>rv. valid_pspace'
+           apply (rule_tac Q'="\<lambda>rv. valid_pspace'
                                and cur_tcb' and tcb_at' sender and tcb_at' thread
                                and sch_act_not sender and K (thread \<noteq> sender)
                                and ep_at' (capEPPtr cap)
@@ -6302,7 +6302,7 @@ lemma sendSignal_ccorres [corres]:
            apply (ctac add: possibleSwitchTo_ccorres)
           apply (wp sts_valid_objs' sts_st_tcb_at'_cases
                  | simp add: option_to_ctcb_ptr_def split del: if_split)+
-        apply (rule_tac Q="\<lambda>_. tcb_at' (the (ntfnBoundTCB ntfn)) and invs'"
+        apply (rule_tac Q'="\<lambda>_. tcb_at' (the (ntfnBoundTCB ntfn)) and invs'"
                  in hoare_post_imp)
          apply auto[1]
         apply wp
@@ -6668,7 +6668,7 @@ lemma receiveSignal_ccorres [corres]:
           apply (rule receiveSignal_enqueue_ccorres_helper[simplified])
          apply (simp add: valid_ntfn'_def)
          apply (wp sts_st_tcb')
-         apply (rule_tac Q="\<lambda>rv. ko_wp_at' (\<lambda>x. projectKO_opt x = Some ntfn
+         apply (rule_tac Q'="\<lambda>rv. ko_wp_at' (\<lambda>x. projectKO_opt x = Some ntfn
                                \<and> projectKO_opt x = (None::tcb option))
                                   (capNtfnPtr cap)"
                        in hoare_post_imp)
@@ -6735,7 +6735,7 @@ lemma receiveSignal_ccorres [corres]:
         apply (rule_tac ntfn="ntfn" in receiveSignal_enqueue_ccorres_helper[simplified])
        apply (simp add: valid_ntfn'_def)
        apply (wp sts_st_tcb')
-       apply (rule_tac Q="\<lambda>rv. ko_wp_at' (\<lambda>x. projectKO_opt x = Some ntfn
+       apply (rule_tac Q'="\<lambda>rv. ko_wp_at' (\<lambda>x. projectKO_opt x = Some ntfn
                              \<and> projectKO_opt x = (None::tcb option))
                                     (capNtfnPtr cap)
                       and K (thread \<notin> set list)"

--- a/proof/crefine/ARM_HYP/IsolatedThreadAction.thy
+++ b/proof/crefine/ARM_HYP/IsolatedThreadAction.thy
@@ -573,7 +573,7 @@ lemma thread_actions_isolatable_assert[simp]:
 lemma doMachineOp_isolatable:
   "thread_actions_isolatable idx (doMachineOp m)"
   apply (simp add: doMachineOp_def split_def)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
                gets_isolatable thread_actions_isolatable_returns
                modify_isolatable select_f_isolatable)
   apply (simp | wp)+
@@ -593,8 +593,8 @@ lemma findPDForASID_isolatable:
                    case_option_If2 assertE_def liftE_def checkPDAt_def
                    stateAssert_def2
              cong: if_cong)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
-               thread_actions_isolatable_bindE[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
+               thread_actions_isolatable_bindE[OF _ _ hoare_weaken_pre]
                thread_actions_isolatable_if thread_actions_isolatable_returns
                thread_actions_isolatable_fail
                gets_isolatable getObject_isolatable)
@@ -615,9 +615,9 @@ lemma getHWASID_isolatable:
                    invalidateHWASIDEntry_def
                    storeHWASID_def
              cong: if_cong)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
-               thread_actions_isolatable_bindE[OF _ _ hoare_pre(1)]
-               thread_actions_isolatable_catch[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
+               thread_actions_isolatable_bindE[OF _ _ hoare_weaken_pre]
+               thread_actions_isolatable_catch[OF _ _ hoare_weaken_pre]
                thread_actions_isolatable_if thread_actions_isolatable_returns
                thread_actions_isolatable_fail
                gets_isolatable modify_isolatable
@@ -683,7 +683,7 @@ lemma setVCPU_isolatable:
 lemma vcpuUpdate_isolatable:
   "thread_actions_isolatable idx (vcpuUpdate p f)"
   apply (clarsimp simp: vcpuUpdate_def)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
                getVCPU_isolatable setVCPU_isolatable
          |wp|assumption|clarsimp)+
   done
@@ -699,7 +699,7 @@ lemma vgicUpdateLR_isolatable:
 lemma vcpuWriteReg_isolatable:
   "thread_actions_isolatable idx (vcpuWriteReg v p val)"
   apply (clarsimp simp: vcpuWriteReg_def)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
                vcpuUpdate_isolatable doMachineOp_isolatable
          | wpsimp)+
   done
@@ -707,7 +707,7 @@ lemma vcpuWriteReg_isolatable:
 lemma vcpuReadReg_isolatable:
   "thread_actions_isolatable idx (vcpuReadReg v p)"
   apply (clarsimp simp: vcpuReadReg_def)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
                vcpuUpdate_isolatable getVCPU_isolatable thread_actions_isolatable_return
          | wpsimp)+
   done
@@ -715,7 +715,7 @@ lemma vcpuReadReg_isolatable:
 lemma vcpuSaveReg_isolatable:
   "thread_actions_isolatable idx (vcpuSaveReg p v)"
   apply (clarsimp simp: vcpuSaveReg_def)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
                vcpuUpdate_isolatable doMachineOp_isolatable
          |wpsimp)+
   done
@@ -723,7 +723,7 @@ lemma vcpuSaveReg_isolatable:
 lemma vcpuRestoreReg_isolatable:
   "thread_actions_isolatable idx (vcpuRestoreReg p v)"
   apply (clarsimp simp: vcpuRestoreReg_def)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
                vcpuUpdate_isolatable doMachineOp_isolatable getVCPU_isolatable
          |wpsimp)+
   done
@@ -732,14 +732,14 @@ lemma thread_actions_isolatable_mapM_x:
   "\<lbrakk> \<And>x. thread_actions_isolatable idx (f x);
      \<And>x t. f x \<lbrace>tcb_at' t\<rbrace> \<rbrakk> \<Longrightarrow> thread_actions_isolatable idx (mapM_x f xs)"
   apply (induct xs; clarsimp simp: mapM_x_Nil mapM_x_Cons thread_actions_isolatable_returns)
-  apply (rule thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]; clarsimp?)
+  apply (rule thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]; clarsimp?)
    apply assumption+
   done
 
 lemma vcpuSaveRegRange_isolatable:
   "thread_actions_isolatable idx (vcpuSaveRegRange p r rt)"
   apply (clarsimp simp: vcpuSaveRegRange_def)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
                vcpuSaveReg_isolatable thread_actions_isolatable_mapM_x
          | wpsimp)+
   done
@@ -747,7 +747,7 @@ lemma vcpuSaveRegRange_isolatable:
 lemma vcpuRestoreRegRange_isolatable:
   "thread_actions_isolatable idx (vcpuRestoreRegRange p r rt)"
   apply (clarsimp simp: vcpuRestoreRegRange_def)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
                vcpuRestoreReg_isolatable thread_actions_isolatable_mapM_x
          | wpsimp)+
   done
@@ -755,7 +755,7 @@ lemma vcpuRestoreRegRange_isolatable:
 lemma saveVirtTimer_isolatable:
   "thread_actions_isolatable idx (saveVirtTimer v)"
   apply (clarsimp simp: saveVirtTimer_def)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
                thread_actions_isolatable_if thread_actions_isolatable_returns
                thread_actions_isolatable_fail
                gets_isolatable doMachineOp_isolatable vcpuSaveReg_isolatable
@@ -766,7 +766,7 @@ lemma saveVirtTimer_isolatable:
 lemma getIRQState_isolatable:
   "thread_actions_isolatable idx (getIRQState irq)"
   apply (clarsimp simp: getIRQState_def liftM_def getInterruptState_def)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
                 thread_actions_isolatable_returns gets_isolatable
          | wpsimp | fastforce)+
   done
@@ -774,7 +774,7 @@ lemma getIRQState_isolatable:
 lemma restoreVirtTimer_isolatable:
   "thread_actions_isolatable idx (restoreVirtTimer v)"
   apply (clarsimp simp: restoreVirtTimer_def when_def isIRQActive_def liftM_bind)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
                thread_actions_isolatable_if thread_actions_isolatable_returns
                thread_actions_isolatable_fail
                gets_isolatable doMachineOp_isolatable vcpuSaveReg_isolatable
@@ -788,7 +788,7 @@ lemma vcpuSave_isolatable:
   supply if_split[split del]
   apply (clarsimp simp: vcpuSave_def armvVCPUSave_def thread_actions_isolatable_fail when_def
                   split: option.splits)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
                thread_actions_isolatable_if thread_actions_isolatable_returns
                thread_actions_isolatable_fail
                gets_isolatable doMachineOp_isolatable vcpuSaveReg_isolatable
@@ -801,7 +801,7 @@ lemma vcpuSave_isolatable:
 lemma vcpuEnable_isolatable:
   "thread_actions_isolatable idx (vcpuEnable v)"
   apply (clarsimp simp: vcpuEnable_def)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
                vcpuRestoreReg_isolatable doMachineOp_isolatable getVCPU_isolatable
                restoreVirtTimer_isolatable
          | wpsimp)+
@@ -810,7 +810,7 @@ lemma vcpuEnable_isolatable:
 lemma vcpuRestore_isolatable:
   "thread_actions_isolatable idx (vcpuRestore v)"
   apply (clarsimp simp: vcpuRestore_def)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
                getVCPU_isolatable gets_isolatable doMachineOp_isolatable vcpuEnable_isolatable
                vcpuRestoreRegRange_isolatable
          | wpsimp)+
@@ -819,7 +819,7 @@ lemma vcpuRestore_isolatable:
 lemma vcpuDisable_isolatable:
   "thread_actions_isolatable idx (vcpuDisable v)"
   apply (clarsimp simp: vcpuDisable_def split: option.splits, intro conjI)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
                doMachineOp_isolatable vcpuEnable_isolatable
                vgicUpdate_isolatable vcpuSaveReg_isolatable saveVirtTimer_isolatable
          | wpsimp)+
@@ -830,16 +830,16 @@ lemma vcpuSwitch_isolatable:
   supply if_cong[cong] option.case_cong[cong]
   apply (clarsimp simp: vcpuSwitch_def when_def split: option.splits)
   apply (safe intro!:
-               thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
-               thread_actions_isolatable_bindE[OF _ _ hoare_pre(1)]
-               thread_actions_isolatable_catch[OF _ _ hoare_pre(1)]
+               thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
+               thread_actions_isolatable_bindE[OF _ _ hoare_weaken_pre]
+               thread_actions_isolatable_catch[OF _ _ hoare_weaken_pre]
                thread_actions_isolatable_if thread_actions_isolatable_returns
                thread_actions_isolatable_fail
                gets_isolatable)
    apply (clarsimp simp: thread_actions_isolatable_returns
                   split: option.splits
          |intro thread_actions_isolatable_if thread_actions_isolatable_returns
-                thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
+                thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
                 vcpuSave_isolatable vcpuRestore_isolatable
                 vcpuDisable_isolatable vcpuEnable_isolatable
                 modifyArchState_isolatable conjI doMachineOp_isolatable
@@ -901,9 +901,9 @@ lemma setVMRoot_isolatable:
                    checkPDNotInASIDMap_def stateAssert_def2
                    checkPDASIDMapMembership_def armv_contextSwitch_def
              cong: if_cong)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
-               thread_actions_isolatable_bindE[OF _ _ hoare_pre(1)]
-               thread_actions_isolatable_catch[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
+               thread_actions_isolatable_bindE[OF _ _ hoare_weaken_pre]
+               thread_actions_isolatable_catch[OF _ _ hoare_weaken_pre]
                thread_actions_isolatable_if thread_actions_isolatable_returns
                thread_actions_isolatable_fail
                gets_isolatable getCTE_isolatable getHWASID_isolatable
@@ -1211,7 +1211,7 @@ lemma setThreadState_no_sch_change:
   (is "Nondet_VCG.valid ?P ?f ?Q")
   apply (simp add: setThreadState_def setSchedulerAction_def)
   apply (wp hoare_pre_cont[where f=rescheduleRequired])
-  apply (rule_tac Q="\<lambda>_. ?P and st_tcb_at' ((=) st) t" in hoare_post_imp)
+  apply (rule_tac Q'="\<lambda>_. ?P and st_tcb_at' ((=) st) t" in hoare_post_imp)
    apply (clarsimp split: if_split)
    apply (clarsimp simp: obj_at'_def st_tcb_at'_def projectKOs)
   apply (wp threadSet_pred_tcb_at_state)
@@ -1273,7 +1273,7 @@ lemma setEndpoint_isolatable:
    apply (simp add: obj_at_partial_overwrite_id2)
    apply (drule_tac x=x in spec)
    apply (clarsimp simp: obj_at'_def projectKOs select_f_asserts)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
                thread_actions_isolatable_if
                thread_actions_isolatable_return
                thread_actions_isolatable_fail)
@@ -1421,7 +1421,7 @@ lemma cteInsert_isolatable:
   supply if_split[split del] if_cong[cong]
   apply (simp add: cteInsert_def updateCap_def updateMDB_def
                    Let_def setUntypedCapAsFull_def)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
                thread_actions_isolatable_if
                thread_actions_isolatable_returns assert_isolatable
                getCTE_isolatable setCTE_isolatable)
@@ -1507,7 +1507,7 @@ lemma switchToThread_isolatable:
   "thread_actions_isolatable idx (Arch.switchToThread t)"
   apply (simp add: switchToThread_def getTCB_threadGet
                    storeWordUser_def stateAssert_def2)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
                gets_isolatable setVMRoot_isolatable
                thread_actions_isolatable_if
                doMachineOp_isolatable
@@ -1528,7 +1528,7 @@ lemma tcbQueued_put_tcb_state_regs_tcb:
 lemma idleThreadNotQueued_isolatable:
   "thread_actions_isolatable idx (stateAssert idleThreadNotQueued [])"
   apply (simp add: stateAssert_def2 stateAssert_def)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
                gets_isolatable
                thread_actions_isolatable_if
                thread_actions_isolatable_returns
@@ -1745,7 +1745,7 @@ lemma updateMDB_isolatable:
   "thread_actions_isolatable idx (updateMDB slot f)"
   apply (simp add: updateMDB_def thread_actions_isolatable_return
             split: if_split)
-  apply (intro impI thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
+  apply (intro impI thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
                getCTE_isolatable setCTE_isolatable,
            (wp | simp)+)
   done
@@ -1767,7 +1767,7 @@ lemma emptySlot_isolatable:
   "thread_actions_isolatable idx (emptySlot slot NullCap)"
   apply (simp add: emptySlot_def updateCap_def case_Null_If Retype_H.postCapDeletion_def
              cong: if_cong)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
                clearUntypedFreeIndex_isolatable
                thread_actions_isolatable_if
                getCTE_isolatable setCTE_isolatable

--- a/proof/crefine/ARM_HYP/Refine_C.thy
+++ b/proof/crefine/ARM_HYP/Refine_C.thy
@@ -80,7 +80,7 @@ proof -
       apply (wp schedule_sch_act_wf schedule_invs'
              | strengthen invs_valid_objs_strengthen invs_pspace_aligned' invs_pspace_distinct')+
    apply simp
-   apply (rule_tac Q="\<lambda>rv s. invs' s \<and> (\<forall>x. rv = Some x \<longrightarrow> x \<le> Kernel_Config.maxIRQ) \<and>
+   apply (rule_tac Q'="\<lambda>rv s. invs' s \<and> (\<forall>x. rv = Some x \<longrightarrow> x \<le> Kernel_Config.maxIRQ) \<and>
                              sch_act_not (ksCurThread s) s"
                 in hoare_post_imp)
     apply (solves clarsimp)
@@ -370,7 +370,7 @@ lemma handleSyscall_ccorres:
           apply wp[1]
          apply clarsimp
          apply wp
-         apply (rule_tac Q="\<lambda>rv s. ct_in_state' simple' s \<and> sch_act_sane s"
+         apply (rule_tac Q'="\<lambda>rv s. ct_in_state' simple' s \<and> sch_act_sane s"
                               in hoare_post_imp)
           apply (simp add: ct_in_state'_def)
          apply (wp handleReply_sane)
@@ -408,15 +408,15 @@ lemma handleSyscall_ccorres:
           | wpc
           | wp hoare_drop_imp handleReply_sane handleReply_nonz_cap_to_ct schedule_invs'
           | strengthen ct_active_not_idle'_strengthen invs_valid_objs_strengthen)+
-      apply (rule_tac  Q="\<lambda>rv. invs' and ct_active'" in hoare_post_imp, simp)
+      apply (rule_tac Q'="\<lambda>rv. invs' and ct_active'" in hoare_post_imp, simp)
       apply (wp hy_invs')
      apply (clarsimp simp add: liftE_def)
      apply wp
-     apply (rule_tac  Q="\<lambda>rv. invs' and ct_active'" in hoare_post_imp, simp)
+     apply (rule_tac Q'="\<lambda>rv. invs' and ct_active'" in hoare_post_imp, simp)
      apply (wp hy_invs')
     apply (clarsimp simp: liftE_def)
     apply (wp)
-    apply (rule_tac Q="\<lambda>_. invs'" in hoare_post_imp, simp)
+    apply (rule_tac Q'="\<lambda>_. invs'" in hoare_post_imp, simp)
     apply (wp hw_invs')
    apply (simp add: guard_is_UNIV_def)
    apply clarsimp

--- a/proof/crefine/ARM_HYP/Retype_C.thy
+++ b/proof/crefine/ARM_HYP/Retype_C.thy
@@ -7196,7 +7196,7 @@ lemma createObject_valid_cap':
   apply (simp add:createObject_def3)
   apply (rule hoare_pre)
   apply wp
-   apply (rule_tac Q = "\<lambda>r s. r \<noteq> [] \<and> Q r s" for Q in hoare_strengthen_post)
+   apply (rule_tac Q'="\<lambda>r s. r \<noteq> [] \<and> Q r s" for Q in hoare_strengthen_post)
    apply (rule hoare_vcg_conj_lift)
      apply (rule hoare_strengthen_post[OF createNewCaps_ret_len])
       apply clarsimp
@@ -7268,7 +7268,7 @@ lemma createObject_caps_overlap_reserved_ret':
   apply (simp add:createObject_def3)
   apply (rule hoare_pre)
   apply wp
-   apply (rule_tac Q = "\<lambda>r s. r \<noteq> [] \<and> Q r s" for Q in hoare_strengthen_post)
+   apply (rule_tac Q'="\<lambda>r s. r \<noteq> [] \<and> Q r s" for Q in hoare_strengthen_post)
    apply (rule hoare_vcg_conj_lift)
      apply (rule hoare_strengthen_post[OF createNewCaps_ret_len])
       apply clarsimp
@@ -7291,7 +7291,7 @@ lemma createObject_descendants_range':
   apply (simp add:createObject_def3)
   apply (rule hoare_pre)
   apply wp
-   apply (rule_tac Q = "\<lambda>r s. r \<noteq> [] \<and> Q r s" for Q in hoare_strengthen_post)
+   apply (rule_tac Q'="\<lambda>r s. r \<noteq> [] \<and> Q r s" for Q in hoare_strengthen_post)
    apply (rule hoare_vcg_conj_lift)
      apply (rule hoare_strengthen_post[OF createNewCaps_ret_len])
       apply clarsimp
@@ -7322,7 +7322,7 @@ lemma createObject_idlethread_range:
   apply (simp add:createObject_def3)
   apply (rule hoare_pre)
   apply wp
-   apply (rule_tac Q = "\<lambda>r s. r \<noteq> [] \<and> Q r s" for Q in hoare_strengthen_post)
+   apply (rule_tac Q'="\<lambda>r s. r \<noteq> [] \<and> Q r s" for Q in hoare_strengthen_post)
    apply (rule hoare_vcg_conj_lift)
      apply (rule hoare_strengthen_post[OF createNewCaps_ret_len])
       apply clarsimp
@@ -7342,7 +7342,7 @@ lemma createObject_IRQHandler:
   apply (simp add:createObject_def3)
   apply (rule hoare_pre)
   apply wp
-   apply (rule_tac Q = "\<lambda>r s. r \<noteq> [] \<and> Q r s" for Q in hoare_strengthen_post)
+   apply (rule_tac Q'="\<lambda>r s. r \<noteq> [] \<and> Q r s" for Q in hoare_strengthen_post)
    apply (rule hoare_vcg_conj_lift)
      apply (rule hoare_strengthen_post[OF createNewCaps_ret_len])
       apply clarsimp
@@ -7360,7 +7360,7 @@ lemma createObject_capClass[wp]:
   apply (simp add:createObject_def3)
   apply (rule hoare_pre)
   apply wp
-   apply (rule_tac Q = "\<lambda>r s. r \<noteq> [] \<and> Q r s" for Q in hoare_strengthen_post)
+   apply (rule_tac Q'="\<lambda>r s. r \<noteq> [] \<and> Q r s" for Q in hoare_strengthen_post)
    apply (rule hoare_vcg_conj_lift)
      apply (rule hoare_strengthen_post[OF createNewCaps_ret_len])
       apply clarsimp
@@ -7407,7 +7407,7 @@ lemma createObject_parent_helper:
     \<rbrace>
     createObject ty ptr us dev
     \<lbrace>\<lambda>rv. cte_wp_at' (\<lambda>cte. isUntypedCap (cteCap cte) \<and> (sameRegionAs (cteCap cte) rv)) p\<rbrace>"
-  apply (rule hoare_post_imp [where Q="\<lambda>rv s. \<exists>cte. cte_wp_at' ((=) cte) p s
+  apply (rule hoare_post_imp[where Q'="\<lambda>rv s. \<exists>cte. cte_wp_at' ((=) cte) p s
                                            \<and> isUntypedCap (cteCap cte) \<and>
                                 sameRegionAs (cteCap cte) rv"])
   apply (clarsimp simp:cte_wp_at_ctes_of)
@@ -8152,7 +8152,7 @@ shows  "ccorres dc xfdc
                  (cnodeptr + (of_nat k * 0x10 + start * 0x10 + of_nat n * 0x10)) s)
               \<and> descendants_range_in' {(of_nat n << APIType_capBits newType userSize) +
                  ptr.. (ptr && ~~ mask sz) + 2 ^ sz  - 1} srcSlot (ctes_of s)"
-              in hoare_pre(1))
+              in hoare_weaken_pre)
              apply wp
             apply (clarsimp simp:createObject_hs_preconds_def conj_comms
                    invs_valid_pspace' invs_pspace_distinct' invs_pspace_aligned'

--- a/proof/crefine/ARM_HYP/Schedule_C.thy
+++ b/proof/crefine/ARM_HYP/Schedule_C.thy
@@ -70,7 +70,7 @@ lemma Arch_switchToThread_ccorres:
          apply wpsimp+
       apply (vcg exspec=vcpu_switch_modifies)
      apply wpsimp+
-    apply (rule_tac Q="\<lambda>rv s. all_invs_but_ct_idle_or_in_cur_domain' s
+    apply (rule_tac Q'="\<lambda>rv s. all_invs_but_ct_idle_or_in_cur_domain' s
                               \<and> case_option (\<lambda>_. True) (ko_wp_at' (is_vcpu' and hyp_live')) (atcbVCPUPtr (tcbArch rv)) s
                               \<and> obj_at' (\<lambda>t::tcb. True) t s" in hoare_strengthen_post[rotated])
      apply (clarsimp simp: vcpu_at_is_vcpu' elim!: ko_wp_at'_weakenE split: option.splits)
@@ -677,7 +677,7 @@ lemma schedule_ccorres:
        apply wp
       apply clarsimp
       (* when runnable tcbSchedEnqueue curThread *)
-      apply (rule_tac Q="\<lambda>rv s. invs' s \<and> ksCurThread s = curThread
+      apply (rule_tac Q'="\<lambda>rv s. invs' s \<and> ksCurThread s = curThread
                                 \<and> ksSchedulerAction s = SwitchToThread candidate" in hoare_post_imp)
        apply (clarsimp simp: invs'_bitmapQ_no_L1_orphans invs_ksCurDomain_maxDomain')
        apply (fastforce dest: invs_sch_act_wf')

--- a/proof/crefine/ARM_HYP/SyscallArgs_C.thy
+++ b/proof/crefine/ARM_HYP/SyscallArgs_C.thy
@@ -1039,7 +1039,7 @@ lemma getMRs_user_word:
                          linorder_not_less [symmetric])
    apply (wp mapM_loadWordUser_user_words_at)
    apply (wp hoare_vcg_all_lift)
-    apply (rule_tac Q="\<lambda>_. \<top>" in hoare_strengthen_post)
+    apply (rule_tac Q'="\<lambda>_. \<top>" in hoare_strengthen_post)
      apply wp
     apply clarsimp
     defer
@@ -1095,7 +1095,7 @@ lemma getMRs_rel:
   apply (rule hoare_pre)
    apply (rule_tac x=mi in hoare_exI)
    apply wp
-   apply (rule_tac Q="\<lambda>rv s. thread = ksCurThread s \<and> fst (getMRs thread buffer mi s) = {(rv,s)}" in hoare_strengthen_post)
+   apply (rule_tac Q'="\<lambda>rv s. thread = ksCurThread s \<and> fst (getMRs thread buffer mi s) = {(rv,s)}" in hoare_strengthen_post)
     apply (wp det_result det_wp_getMRs)
    apply clarsimp
   apply (clarsimp simp: cur_tcb'_def)
@@ -1263,7 +1263,7 @@ lemma getSyscallArg_ccorres_foo:
     apply (clarsimp simp: option_to_ptr_def option_to_0_def)
     apply (rule_tac P="\<lambda>s. valid_ipc_buffer_ptr' (ptr_val (Ptr b)) s \<and> i < msgLength mi \<and>
                            msgLength mi \<le> msgMaxLength \<and> scast n_msgRegisters \<le> i"
-                 in hoare_pre(1))
+                 in hoare_weaken_pre)
      apply (wp getMRs_user_word)
     apply (clarsimp simp: msgMaxLength_def unat_less_helper)
    apply fastforce

--- a/proof/crefine/ARM_HYP/Syscall_C.thy
+++ b/proof/crefine/ARM_HYP/Syscall_C.thy
@@ -259,7 +259,7 @@ lemma decodeInvocation_ccorres:
        apply simp
        apply (vcg exspec=performInvocation_Reply_modifies)
       apply (simp add: cur_tcb'_def[symmetric])
-      apply (rule_tac R="\<lambda>rv s. ksCurThread s = thread" in hoare_post_add)
+      apply (rule_tac Q'="\<lambda>rv s. ksCurThread s = thread" in hoare_post_add)
       apply (simp cong: conj_cong)
       apply (strengthen imp_consequent)
       apply (wp sts_invs_minor' sts_st_tcb_at'_cases)
@@ -712,9 +712,9 @@ lemma sendFaultIPC_ccorres:
                  , assumption)
          apply vcg
         apply (clarsimp simp: inQ_def)
-        apply (rule_tac Q="\<lambda>a b. invs' b \<and> st_tcb_at' simple' tptr b
+        apply (rule_tac Q'="\<lambda>a b. invs' b \<and> st_tcb_at' simple' tptr b
                                  \<and> sch_act_not tptr b \<and> valid_cap' a b"
-                 and E="\<lambda> _. \<top>"
+                 and E'="\<lambda> _. \<top>"
                  in hoare_strengthen_postE)
           apply (wp)
          apply (clarsimp simp: isCap_simps)
@@ -944,8 +944,8 @@ lemma handleInvocation_ccorres:
                      apply (rule ccorres_return_C_errorE, simp+)[1]
                     apply vcg
                    apply (simp add: invocationCatch_def o_def)
-                   apply (rule_tac Q="\<lambda>rv'. invs' and tcb_at' rv"
-                               and E="\<lambda>ft. invs' and tcb_at' rv"
+                   apply (rule_tac Q'="\<lambda>rv'. invs' and tcb_at' rv"
+                               and E'="\<lambda>ft. invs' and tcb_at' rv"
                               in hoare_strengthen_postE)
                      apply (wp hoare_split_bind_case_sumE hoare_drop_imps
                                setThreadState_nonqueued_state_update
@@ -1997,7 +1997,7 @@ proof -
 
        (* clean up get_gic_vcpu_ctrl_misr postcondition *)
        apply (wp hoare_vcg_all_lift)
-       apply (rule_tac Q="\<lambda>_ s. ?PRE s \<and> armHSCurVCPU (ksArchState s) = Some (vcpuPtr, active)" in hoare_post_imp)
+       apply (rule_tac Q'="\<lambda>_ s. ?PRE s \<and> armHSCurVCPU (ksArchState s) = Some (vcpuPtr, active)" in hoare_post_imp)
         apply clarsimp
         apply (clarsimp simp: invs'_HScurVCPU_vcpu_at' valid_arch_state'_def max_armKSGICVCPUNumListRegs_def dest!: invs_arch_state')
         apply (erule eisr_calc_signed_limits)

--- a/proof/crefine/ARM_HYP/Tcb_C.thy
+++ b/proof/crefine/ARM_HYP/Tcb_C.thy
@@ -422,7 +422,7 @@ lemma setPriority_ccorres:
                  simp: st_tcb_at'_def o_def split: if_splits)
     apply (simp add: guard_is_UNIV_def)
    apply (rule hoare_strengthen_post[
-                 where Q="\<lambda>rv s.
+                 where Q'="\<lambda>rv s.
                           obj_at' (\<lambda>_. True) t s \<and>
                           priority \<le> maxPriority \<and>
                           ksCurDomain s \<le> maxDomain \<and>
@@ -667,8 +667,8 @@ lemma invokeTCB_ThreadControl_ccorres:
                          apply clarsimp
                          apply wp
                         apply (clarsimp simp: guard_is_UNIV_def Collect_const_mem)
-                       apply (rule hoare_strengthen_post [
-                                    where Q= "\<lambda>rv s.
+                       apply (rule hoare_strengthen_post[
+                                    where Q'="\<lambda>rv s.
                                               valid_objs' s \<and>
                                               weak_sch_act_wf (ksSchedulerAction s) s \<and>
                                               ((\<exists>a b. priority = Some (a, b)) \<longrightarrow>
@@ -759,7 +759,7 @@ lemma invokeTCB_ThreadControl_ccorres:
                apply (clarsimp simp: guard_is_UNIV_def Collect_const_mem)
               apply (simp cong: conj_cong)
               apply (rule hoare_strengthen_post[
-                            where Q="\<lambda>a b. (valid_objs' b \<and>
+                            where Q'="\<lambda>a b. (valid_objs' b \<and>
                                        sch_act_wf (ksSchedulerAction b) b \<and>
                                        pspace_aligned' b \<and> pspace_distinct' b \<and>
                                        ((\<exists>a b. priority = Some (a, b)) \<longrightarrow>
@@ -806,7 +806,7 @@ lemma invokeTCB_ThreadControl_ccorres:
             apply vcg
            apply (simp add: conj_comms cong: conj_cong)
            apply (strengthen invs_ksCurDomain_maxDomain' invs_pspace_distinct')
-           apply (wp hoare_vcg_const_imp_lift_R cteDelete_invs')
+           apply (wp hoare_vcg_const_imp_liftE_R cteDelete_invs')
           apply simp
           apply (rule ccorres_split_nothrow_novcg_dc)
              apply (rule ccorres_cond2[where R=\<top>], simp add: Collect_const_mem)
@@ -1217,13 +1217,13 @@ lemma invokeTCB_CopyRegisters_ccorres:
             apply (simp add: pred_conj_def guard_is_UNIV_def  cong: if_cong
                       | wp mapM_x_wp_inv hoare_drop_imp)+
            apply clarsimp
-      apply (rule_tac Q="\<lambda>rv. invs' and tcb_at' destn" in hoare_strengthen_post[rotated])
+      apply (rule_tac Q'="\<lambda>rv. invs' and tcb_at' destn" in hoare_strengthen_post[rotated])
        apply (fastforce simp: sch_act_wf_weak)
       apply (wpsimp wp: hoare_drop_imp restart_invs')+
      apply (clarsimp simp add: guard_is_UNIV_def)
     apply (wp hoare_drop_imp hoare_vcg_if_lift)+
     apply simp
-    apply (rule_tac Q="\<lambda>rv. invs' and tcb_at' destn" in hoare_strengthen_post[rotated])
+    apply (rule_tac Q'="\<lambda>rv. invs' and tcb_at' destn" in hoare_strengthen_post[rotated])
      apply (fastforce simp: sch_act_wf_weak)
     apply (wpsimp wp: hoare_drop_imp)+
    apply (clarsimp simp add: guard_is_UNIV_def)
@@ -1627,7 +1627,7 @@ lemma invokeTCB_WriteRegisters_ccorres[where S=UNIV]:
                     apply wp
                    apply (simp add: guard_is_UNIV_def)
                   apply (wp hoare_drop_imp)
-                   apply (rule_tac Q="\<lambda>rv. invs' and tcb_at' dst" in hoare_strengthen_post[rotated])
+                   apply (rule_tac Q'="\<lambda>rv. invs' and tcb_at' dst" in hoare_strengthen_post[rotated])
                     apply (fastforce simp: sch_act_wf_weak)
                    apply (wpsimp wp: restart_invs')+
                  apply (clarsimp simp add: guard_is_UNIV_def)
@@ -2142,7 +2142,7 @@ shows
         apply wp
        apply (simp add: Collect_const_mem ThreadState_defs mask_def)
        apply vcg
-      apply (rule_tac Q="\<lambda>rv. invs' and st_tcb_at' ((=) Restart) thread
+      apply (rule_tac Q'="\<lambda>rv. invs' and st_tcb_at' ((=) Restart) thread
                              and tcb_at' target" in hoare_post_imp)
        apply (clarsimp simp: pred_tcb_at')
        apply (auto elim!: pred_tcb'_weakenE)[1]

--- a/proof/crefine/ARM_HYP/VSpace_C.thy
+++ b/proof/crefine/ARM_HYP/VSpace_C.thy
@@ -2081,7 +2081,7 @@ lemma vcpu_enable_ccorres:
        apply wpsimp
       apply (vcg exspec=set_gic_vcpu_ctrl_hcr_modifies)
      apply wpsimp+
-   apply (rule_tac Q="\<lambda>_. vcpu_at' v" in hoare_post_imp, fastforce)
+   apply (rule_tac Q'="\<lambda>_. vcpu_at' v" in hoare_post_imp, fastforce)
    apply wpsimp
   apply (clarsimp simp: typ_heap_simps' Collect_const_mem cvcpu_relation_def
                         cvcpu_regs_relation_def Let_def cvgic_relation_def hcrVCPU_def
@@ -2761,7 +2761,7 @@ lemma performPageFlush_ccorres:
           apply (ctac add: setVMRoot_ccorres)
          apply (rule ccorres_return_Skip)
         apply (simp add: cur_tcb'_def[symmetric])
-        apply (rule_tac Q="\<lambda>_ s. invs' s \<and> cur_tcb' s" in hoare_post_imp)
+        apply (rule_tac Q'="\<lambda>_ s. invs' s \<and> cur_tcb' s" in hoare_post_imp)
          apply (simp add: invs'_invs_no_cicd)
         apply wp+
       apply (rule ccorres_return_Skip)
@@ -2941,7 +2941,7 @@ lemma performPageDirectoryInvocationFlush_ccorres:
        apply wp
       apply (simp add: guard_is_UNIV_def)
      apply (simp add: cur_tcb'_def[symmetric])
-     apply (rule_tac Q="\<lambda>_ s. invs' s \<and> cur_tcb' s" in hoare_post_imp)
+     apply (rule_tac Q'="\<lambda>_ s. invs' s \<and> cur_tcb' s" in hoare_post_imp)
       apply (simp add: invs'_invs_no_cicd)
      apply wp+
    apply (simp)
@@ -2995,7 +2995,7 @@ lemma flushPage_ccorres:
         apply (ctac add: setVMRoot_ccorres)
        apply (rule ccorres_return_Skip)
       apply (wp | simp add: cur_tcb'_def[symmetric])+
-      apply (rule_tac Q="\<lambda>_ s. invs' s \<and> cur_tcb' s" in hoare_post_imp)
+      apply (rule_tac Q'="\<lambda>_ s. invs' s \<and> cur_tcb' s" in hoare_post_imp)
        apply (simp add: invs'_invs_no_cicd)
       apply (wp | simp add: cur_tcb'_def[symmetric])+
      apply (rule ccorres_return_Skip)
@@ -3541,7 +3541,7 @@ lemma unmapPage_ccorres:
       apply (rule ccorres_return_void_C)
      apply vcg
     apply (simp add: lookup_pd_slot_def Let_def table_bits_defs)
-    apply (wp hoare_vcg_const_imp_lift_R findPDForASID_valid_offset'[simplified table_bits_defs]
+    apply (wp hoare_vcg_const_imp_liftE_R findPDForASID_valid_offset'[simplified table_bits_defs]
               findPDForASID_aligned[simplified table_bits_defs])
    apply (simp add: Collect_const_mem)
    apply (vcg exspec=findPDForASID_modifies)
@@ -4183,7 +4183,7 @@ lemma flushTable_ccorres:
        apply (rule ccorres_return_Skip)
       apply (wp hoare_weak_lift_imp)
        apply clarsimp
-       apply (rule_tac Q="\<lambda>_ s. invs' s \<and> cur_tcb' s" in hoare_post_imp)
+       apply (rule_tac Q'="\<lambda>_ s. invs' s \<and> cur_tcb' s" in hoare_post_imp)
         apply (simp add: invs'_invs_no_cicd cur_tcb'_def)
        apply (wp mapM_x_wp_inv getPTE_wp | wpc)+
      apply (rule ccorres_return_Skip)

--- a/proof/crefine/Move_C.thy
+++ b/proof/crefine/Move_C.thy
@@ -124,7 +124,7 @@ lemma option_to_0_simps [simp]:
 lemma of_bool_from_bool: "of_bool = from_bool"
   by (rule ext, simp add: from_bool_def split: bool.split)
 
-lemma hoare_vcg_imp_lift_R:
+lemma hoare_vcg_imp_liftE_R:
   "\<lbrakk> \<lbrace>P'\<rbrace> f \<lbrace>\<lambda>rv s. \<not> P rv s\<rbrace>, -; \<lbrace>Q'\<rbrace> f \<lbrace>Q\<rbrace>, - \<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s. P' s \<or> Q' s\<rbrace> f \<lbrace>\<lambda>rv s. P rv s \<longrightarrow> Q rv s\<rbrace>, -"
   by (auto simp add: valid_def validE_R_def validE_def split_def split: sum.splits)
 
@@ -642,7 +642,7 @@ lemma getMessageInfo_le3:
   including no_pre
   apply (simp add: getMessageInfo_def)
   apply wp
-  apply (rule_tac Q="\<lambda>_. \<top>" in hoare_strengthen_post)
+  apply (rule_tac Q'="\<lambda>_. \<top>" in hoare_strengthen_post)
    apply wp
   apply (rename_tac rv s)
   apply (simp add: messageInfoFromWord_def Let_def msgExtraCapBits_def)
@@ -655,7 +655,7 @@ lemma getMessageInfo_msgLength:
   including no_pre
   apply (simp add: getMessageInfo_def)
   apply wp
-  apply (rule_tac Q="\<lambda>_. \<top>" in hoare_strengthen_post)
+  apply (rule_tac Q'="\<lambda>_. \<top>" in hoare_strengthen_post)
    apply wp
   apply (simp add: messageInfoFromWord_def Let_def not_less msgMaxLength_def msgLengthBits_def
             split: if_split)
@@ -993,7 +993,7 @@ lemma cancelIPC_st_tcb_at':
   "\<lbrace>\<lambda>s. t\<noteq>t' \<and> st_tcb_at' P t' s\<rbrace> cancelIPC t \<lbrace>\<lambda>_. st_tcb_at' P t'\<rbrace>"
   apply (simp add: cancelIPC_def Let_def getThreadReplySlot_def locateSlot_conv)
   apply (wp sts_pred_tcb_neq' getEndpoint_wp cteDeleteOne_Reply getCTE_wp' | wpc)+
-          apply (rule hoare_strengthen_post [where Q="\<lambda>_. st_tcb_at' P t'"])
+          apply (rule hoare_strengthen_post[where Q'="\<lambda>_. st_tcb_at' P t'"])
            apply (wp threadSet_st_tcb_at2)
            apply simp
           apply (clarsimp simp: cte_wp_at_ctes_of capHasProperty_def)

--- a/proof/crefine/Move_C.thy
+++ b/proof/crefine/Move_C.thy
@@ -124,10 +124,6 @@ lemma option_to_0_simps [simp]:
 lemma of_bool_from_bool: "of_bool = from_bool"
   by (rule ext, simp add: from_bool_def split: bool.split)
 
-lemma hoare_vcg_imp_liftE_R:
-  "\<lbrakk> \<lbrace>P'\<rbrace> f \<lbrace>\<lambda>rv s. \<not> P rv s\<rbrace>, -; \<lbrace>Q'\<rbrace> f \<lbrace>Q\<rbrace>, - \<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s. P' s \<or> Q' s\<rbrace> f \<lbrace>\<lambda>rv s. P rv s \<longrightarrow> Q rv s\<rbrace>, -"
-  by (auto simp add: valid_def validE_R_def validE_def split_def split: sum.splits)
-
 (* FIXME: move to Lib *)
 lemma length_Suc_0_conv:
   "length x = Suc 0 = (\<exists>y. x = [y])"

--- a/proof/crefine/RISCV64/Arch_C.thy
+++ b/proof/crefine/RISCV64/Arch_C.thy
@@ -521,7 +521,7 @@ shows
       apply clarsimp
       apply (wp getSlotCap_wp)
      apply clarsimp
-    apply (rule_tac Q="\<lambda>_. cte_wp_at' ((=) (UntypedCap isdev frame pageBits idx) o cteCap) parent
+    apply (rule_tac Q'="\<lambda>_. cte_wp_at' ((=) (UntypedCap isdev frame pageBits idx) o cteCap) parent
                           and (\<lambda>s. descendants_range_in' {frame..frame + (2::machine_word) ^ pageBits - (1::machine_word)} parent (ctes_of s))
                           and pspace_no_overlap' frame pageBits
                           and invs'

--- a/proof/crefine/RISCV64/DetWP.thy
+++ b/proof/crefine/RISCV64/DetWP.thy
@@ -120,7 +120,7 @@ lemma det_wp_asUser [wp]:
       apply (drule det_wp_det)
       apply (erule det_wp_select_f)
      apply wp+
-   apply (rule_tac Q="\<lambda>_. tcb_at' t" in hoare_post_imp)
+   apply (rule_tac Q'="\<lambda>_. tcb_at' t" in hoare_post_imp)
     apply simp
    apply wp
   apply simp

--- a/proof/crefine/RISCV64/Finalise_C.thy
+++ b/proof/crefine/RISCV64/Finalise_C.thy
@@ -774,7 +774,7 @@ lemma suspend_ccorres:
         apply ceqv
        apply (ctac(no_vcg) add: setThreadState_ccorres_simple)
         apply (ctac add: tcbSchedDequeue_ccorres)
-       apply (rule_tac Q="\<lambda>_. valid_objs' and tcb_at' thread and pspace_aligned' and pspace_distinct'"
+       apply (rule_tac Q'="\<lambda>_. valid_objs' and tcb_at' thread and pspace_aligned' and pspace_distinct'"
                     in hoare_post_imp)
         apply clarsimp
        apply (wp sts_valid_objs')[1]

--- a/proof/crefine/RISCV64/Invoke_C.thy
+++ b/proof/crefine/RISCV64/Invoke_C.thy
@@ -76,7 +76,7 @@ lemma setDomain_ccorres:
        apply (simp add: guard_is_UNIV_def)
       apply simp
       apply wp
-     apply (rule_tac Q="\<lambda>_. all_invs_but_sch_extra and tcb_at' t and sch_act_simple
+     apply (rule_tac Q'="\<lambda>_. all_invs_but_sch_extra and tcb_at' t and sch_act_simple
                             and (\<lambda>s. curThread = ksCurThread s)"
               in hoare_strengthen_post)
       apply (wp threadSet_all_invs_but_sch_extra)
@@ -84,7 +84,7 @@ lemma setDomain_ccorres:
                             sch_act_simple_def st_tcb_at'_def weak_sch_act_wf_def
                      split: if_splits)
     apply (simp add: guard_is_UNIV_def)
-   apply (rule_tac Q="\<lambda>_. invs' and tcb_at' t and sch_act_simple and (\<lambda>s. curThread = ksCurThread s)"
+   apply (rule_tac Q'="\<lambda>_. invs' and tcb_at' t and sch_act_simple and (\<lambda>s. curThread = ksCurThread s)"
             in hoare_strengthen_post)
     apply (wp weak_sch_act_wf_lift_linear tcbSchedDequeue_not_queued
               hoare_vcg_imp_lift hoare_vcg_all_lift)
@@ -762,7 +762,7 @@ lemma decodeCNodeInvocation_ccorres:
                                apply (rule_tac Q'="\<lambda>rv. valid_pspace'
                                                     and valid_cap' rv and valid_objs'
                                                          and tcb_at' thread and (\<lambda>s. sch_act_wf (ksSchedulerAction s) s)"
-                                           in hoare_vcg_R_conj)
+                                           in hoare_vcg_conj_liftE_R)
                                 apply (rule deriveCap_Null_helper[OF deriveCap_derived])
                                apply wp
                               apply (clarsimp simp: cte_wp_at_ctes_of)
@@ -838,7 +838,7 @@ lemma decodeCNodeInvocation_ccorres:
                                    apply (rule_tac Q'="\<lambda>rv. valid_pspace'
                                                         and valid_cap' rv and valid_objs'
                                                              and tcb_at' thread and (\<lambda>s. sch_act_wf (ksSchedulerAction s) s)"
-                                               in hoare_vcg_R_conj)
+                                               in hoare_vcg_conj_liftE_R)
                                     apply (rule deriveCap_Null_helper [OF deriveCap_derived])
                                    apply wp
                                   apply (clarsimp simp: cte_wp_at_ctes_of)
@@ -959,7 +959,7 @@ lemma decodeCNodeInvocation_ccorres:
                       apply (clarsimp simp:valid_updateCapDataI invs_valid_objs' invs_valid_pspace')
                       apply assumption
                      apply (wp hoare_vcg_all_liftE_R injection_wp_E[OF refl]
-                               lsfco_cte_at' hoare_vcg_const_imp_lift_R
+                               lsfco_cte_at' hoare_vcg_const_imp_liftE_R
                            )+
                     apply (simp add: Collect_const_mem word_sle_def word_sless_def
                                      all_ex_eq_helper)
@@ -1336,7 +1336,7 @@ lemma decodeCNodeInvocation_ccorres:
           apply (rule ccorres_return_C_errorE, simp+)[1]
          apply vcg
         apply simp
-        apply (wp injection_wp_E[OF refl] hoare_vcg_const_imp_lift_R
+        apply (wp injection_wp_E[OF refl] hoare_vcg_const_imp_liftE_R
                   hoare_vcg_all_liftE_R lsfco_cte_at' hoare_weak_lift_imp
                 | simp add: hasCancelSendRights_not_Null ctes_of_valid_strengthen
                       cong: conj_cong

--- a/proof/crefine/RISCV64/IpcCancel_C.thy
+++ b/proof/crefine/RISCV64/IpcCancel_C.thy
@@ -2759,7 +2759,7 @@ lemma cancelIPC_ccorres1:
                                 ghost_assertion_data_set_def cap_tag_defs)
               apply (simp add: locateSlot_conv, wp)
              apply vcg
-            apply (rule_tac Q="\<lambda>rv. tcb_at' thread and invs'" in hoare_post_imp)
+            apply (rule_tac Q'="\<lambda>rv. tcb_at' thread and invs'" in hoare_post_imp)
              apply (clarsimp simp: cte_wp_at_ctes_of capHasProperty_def
                                    cap_get_tag_isCap ucast_id)
             apply (wp threadSet_invs_trivial | simp)+

--- a/proof/crefine/RISCV64/Ipc_C.thy
+++ b/proof/crefine/RISCV64/Ipc_C.thy
@@ -1380,7 +1380,7 @@ lemma asUser_atcbContext_obj_at:
 lemma asUser_tcbFault_inv:
   "\<lbrace>\<lambda>s. \<exists>t. ko_at' t p' s \<and> tcbFault t = f\<rbrace> asUser p m
    \<lbrace>\<lambda>rv s. \<exists>t. ko_at' t p' s \<and> tcbFault t = f\<rbrace>"
-  apply (rule_tac Q="\<lambda>rv. obj_at' (\<lambda>t. tcbFault t = f) p'"
+  apply (rule_tac Q'="\<lambda>rv. obj_at' (\<lambda>t. tcbFault t = f) p'"
                in hoare_strengthen_post)
    apply (wp asUser_tcbFault_obj_at)
    apply (clarsimp simp: obj_at'_def)+
@@ -3533,7 +3533,7 @@ lemma doIPCTransfer_ccorres [corres]:
                            fault_to_fault_tag_nonzero)
      apply ctac
     apply (clarsimp simp: guard_is_UNIV_def option_to_ptr_def split: option.splits)
-   apply (rule_tac Q="\<lambda>rv. valid_pspace' and cur_tcb' and tcb_at' sender
+   apply (rule_tac Q'="\<lambda>rv. valid_pspace' and cur_tcb' and tcb_at' sender
                        and tcb_at' receiver and K (rv \<noteq> Some 0)
                        and (case_option \<top> valid_ipc_buffer_ptr' rv)
                        and K (receiver \<noteq> sender \<and> endpoint \<noteq> Some 0)"
@@ -4259,7 +4259,7 @@ lemma doReplyTransfer_ccorres [corres]:
                          | simp add: valid_tcb_state'_def)+)[1]
            apply (clarsimp simp: guard_is_UNIV_def ThreadState_defs mask_def option_to_ctcb_ptr_def)
 
-          apply (rule_tac Q="\<lambda>rv. tcb_at' receiver and
+          apply (rule_tac Q'="\<lambda>rv. tcb_at' receiver and
                                 valid_objs' and sch_act_simple and (\<lambda>s. ksCurDomain s \<le> maxDomain) and
                                 (\<lambda>s. sch_act_wf (ksSchedulerAction s) s) and
                                 pspace_aligned' and pspace_distinct'" in hoare_post_imp)
@@ -4358,7 +4358,7 @@ lemma setupCallerCap_ccorres [corres]:
                        ptr_add_assertion_positive Collect_const_mem
                        tcb_cnode_index_defs)
      apply simp
-     apply (rule_tac Q="\<lambda>rv. valid_pspace' and tcb_at' receiver" in hoare_post_imp)
+     apply (rule_tac Q'="\<lambda>rv. valid_pspace' and tcb_at' receiver" in hoare_post_imp)
       apply (auto simp: cte_wp_at_ctes_of isCap_simps valid_pspace'_def
                         tcbSlots Kernel_C.tcbCaller_def size_of_def
                         cte_level_bits_def)[1]
@@ -5766,7 +5766,7 @@ lemma receiveIPC_ccorres [corres]:
                 apply (fastforce simp: guard_is_UNIV_def ThreadState_defs mask_def
                                        cap_get_tag_isCap ccap_relation_ep_helpers)
                apply (clarsimp simp: valid_tcb_state'_def)
-               apply (rule_tac Q="\<lambda>_. valid_pspace'
+               apply (rule_tac Q'="\<lambda>_. valid_pspace'
                                        and st_tcb_at' ((=) sendState) sender and tcb_at' thread
                                        and (\<lambda>s. sch_act_wf (ksSchedulerAction s) s)
                                        and sch_act_not sender and K (thread \<noteq> sender)
@@ -5774,7 +5774,7 @@ lemma receiveIPC_ccorres [corres]:
                 apply (fastforce simp: valid_pspace_valid_objs' pred_tcb_at'_def sch_act_wf_weak
                                        obj_at'_def)
                apply (wpsimp simp: guard_is_UNIV_def option_to_ptr_def option_to_0_def conj_ac)+
-           apply (rule_tac Q="\<lambda>rv. valid_pspace'
+           apply (rule_tac Q'="\<lambda>rv. valid_pspace'
                                and cur_tcb' and tcb_at' sender and tcb_at' thread
                                and sch_act_not sender and K (thread \<noteq> sender)
                                and ep_at' (capEPPtr cap)
@@ -6068,7 +6068,7 @@ lemma sendSignal_ccorres [corres]:
            apply (ctac add: possibleSwitchTo_ccorres)
           apply (wp sts_valid_objs' sts_st_tcb_at'_cases
                  | simp add: option_to_ctcb_ptr_def split del: if_split)+
-        apply (rule_tac Q="\<lambda>_. tcb_at' (the (ntfnBoundTCB ntfn)) and invs'"
+        apply (rule_tac Q'="\<lambda>_. tcb_at' (the (ntfnBoundTCB ntfn)) and invs'"
                  in hoare_post_imp)
          apply auto[1]
         apply wp
@@ -6460,7 +6460,7 @@ lemma receiveSignal_ccorres [corres]:
           apply (rule receiveSignal_enqueue_ccorres_helper[simplified])
          apply (simp add: valid_ntfn'_def)
          apply (wp sts_st_tcb')
-         apply (rule_tac Q="\<lambda>rv. ko_wp_at' (\<lambda>x. projectKO_opt x = Some ntfn
+         apply (rule_tac Q'="\<lambda>rv. ko_wp_at' (\<lambda>x. projectKO_opt x = Some ntfn
                                \<and> projectKO_opt x = (None::tcb option))
                                   (capNtfnPtr cap)"
                        in hoare_post_imp)
@@ -6527,7 +6527,7 @@ lemma receiveSignal_ccorres [corres]:
         apply (rule_tac ntfn="ntfn" in receiveSignal_enqueue_ccorres_helper[simplified])
        apply (simp add: valid_ntfn'_def)
        apply (wp sts_st_tcb')
-       apply (rule_tac Q="\<lambda>rv. ko_wp_at' (\<lambda>x. projectKO_opt x = Some ntfn
+       apply (rule_tac Q'="\<lambda>rv. ko_wp_at' (\<lambda>x. projectKO_opt x = Some ntfn
                              \<and> projectKO_opt x = (None::tcb option))
                                     (capNtfnPtr cap)
                       and K (thread \<notin> set list)"

--- a/proof/crefine/RISCV64/IsolatedThreadAction.thy
+++ b/proof/crefine/RISCV64/IsolatedThreadAction.thy
@@ -601,7 +601,7 @@ lemma select_f_isolatable:
 lemma doMachineOp_isolatable:
   "thread_actions_isolatable idx (doMachineOp m)"
   apply (simp add: doMachineOp_def split_def)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
                gets_isolatable thread_actions_isolatable_returns
                modify_isolatable select_f_isolatable)
   apply (simp | wp)+
@@ -621,8 +621,8 @@ lemma findVSpaceForASID_isolatable:
                    case_option_If2 assertE_def liftE_def checkPTAt_def
                    stateAssert_def2
              cong: if_cong)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
-               thread_actions_isolatable_bindE[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
+               thread_actions_isolatable_bindE[OF _ _ hoare_weaken_pre]
                thread_actions_isolatable_if thread_actions_isolatable_returns
                thread_actions_isolatable_fail
                gets_isolatable getObject_isolatable)
@@ -657,7 +657,7 @@ lemma thread_actions_isolatable_mapM_x:
   "\<lbrakk> \<And>x. thread_actions_isolatable idx (f x);
      \<And>x t. f x \<lbrace>tcb_at' t\<rbrace> \<rbrakk> \<Longrightarrow> thread_actions_isolatable idx (mapM_x f xs)"
   apply (induct xs; clarsimp simp: mapM_x_Nil mapM_x_Cons thread_actions_isolatable_returns)
-  apply (rule thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]; clarsimp?)
+  apply (rule thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]; clarsimp?)
    apply assumption+
   done
 
@@ -687,9 +687,9 @@ lemma setVMRoot_isolatable:
                    whenE_def liftE_def
                    stateAssert_def2 assert_def
              cong: if_cong)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
-               thread_actions_isolatable_bindE[OF _ _ hoare_pre(1)]
-               thread_actions_isolatable_catch[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
+               thread_actions_isolatable_bindE[OF _ _ hoare_weaken_pre]
+               thread_actions_isolatable_catch[OF _ _ hoare_weaken_pre]
                thread_actions_isolatable_if thread_actions_isolatable_returns
                thread_actions_isolatable_fail
                gets_isolatable getCTE_isolatable
@@ -970,7 +970,7 @@ lemma setThreadState_no_sch_change:
   (is "Nondet_VCG.valid ?P ?f ?Q")
   apply (simp add: setThreadState_def setSchedulerAction_def)
   apply (wp hoare_pre_cont[where f=rescheduleRequired])
-  apply (rule_tac Q="\<lambda>_. ?P and st_tcb_at' ((=) st) t" in hoare_post_imp)
+  apply (rule_tac Q'="\<lambda>_. ?P and st_tcb_at' ((=) st) t" in hoare_post_imp)
    apply (clarsimp split: if_split)
    apply (clarsimp simp: obj_at'_def st_tcb_at'_def projectKOs)
   apply (wp threadSet_pred_tcb_at_state)
@@ -1032,7 +1032,7 @@ lemma setEndpoint_isolatable:
    apply (simp add: obj_at_partial_overwrite_id2)
    apply (drule_tac x=x in spec)
    apply (clarsimp simp: obj_at'_def projectKOs select_f_asserts)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
                thread_actions_isolatable_if
                thread_actions_isolatable_return
                thread_actions_isolatable_fail)
@@ -1182,7 +1182,7 @@ lemma cteInsert_isolatable:
   supply if_split[split del] if_cong[cong]
   apply (simp add: cteInsert_def updateCap_def updateMDB_def
                    Let_def setUntypedCapAsFull_def)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
                thread_actions_isolatable_if
                thread_actions_isolatable_returns assert_isolatable
                getCTE_isolatable setCTE_isolatable)
@@ -1268,7 +1268,7 @@ lemma threadGet_isolatable:
   "thread_actions_isolatable idx (Arch.switchToThread t)"
   apply (simp add: switchToThread_def
                    storeWordUser_def stateAssert_def2)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
                gets_isolatable setVMRoot_isolatable
                thread_actions_isolatable_if
                doMachineOp_isolatable
@@ -1285,7 +1285,7 @@ lemma tcbQueued_put_tcb_state_regs_tcb:
 lemma idleThreadNotQueued_isolatable:
   "thread_actions_isolatable idx (stateAssert idleThreadNotQueued [])"
   apply (simp add: stateAssert_def2 stateAssert_def)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
                gets_isolatable
                thread_actions_isolatable_if
                thread_actions_isolatable_returns
@@ -1503,7 +1503,7 @@ lemma updateMDB_isolatable:
   "thread_actions_isolatable idx (updateMDB slot f)"
   apply (simp add: updateMDB_def thread_actions_isolatable_return
             split: if_split)
-  apply (intro impI thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
+  apply (intro impI thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
                getCTE_isolatable setCTE_isolatable,
            (wp | simp)+)
   done
@@ -1525,7 +1525,7 @@ lemma emptySlot_isolatable:
   "thread_actions_isolatable idx (emptySlot slot NullCap)"
   apply (simp add: emptySlot_def updateCap_def case_Null_If Retype_H.postCapDeletion_def
              cong: if_cong)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
                clearUntypedFreeIndex_isolatable
                thread_actions_isolatable_if
                getCTE_isolatable setCTE_isolatable

--- a/proof/crefine/RISCV64/Refine_C.thy
+++ b/proof/crefine/RISCV64/Refine_C.thy
@@ -79,7 +79,7 @@ proof -
        apply (clarsimp simp: return_def)
       apply (wp schedule_sch_act_wf schedule_invs'
              | strengthen invs_valid_objs_strengthen invs_pspace_aligned' invs_pspace_distinct')+
-   apply (rule_tac Q="\<lambda>rv s. invs' s \<and> (\<forall>x. rv = Some x \<longrightarrow> x \<le> RISCV64.maxIRQ) \<and> rv \<noteq> Some 0x3FF" in hoare_post_imp)
+   apply (rule_tac Q'="\<lambda>rv s. invs' s \<and> (\<forall>x. rv = Some x \<longrightarrow> x \<le> RISCV64.maxIRQ) \<and> rv \<noteq> Some 0x3FF" in hoare_post_imp)
     apply (clarsimp simp: non_kernel_IRQs_def)
    apply (wp getActiveIRQ_le_maxIRQ getActiveIRQ_neq_Some0x3FF | simp)+
   apply (clarsimp simp: invs'_def valid_state'_def)
@@ -265,12 +265,12 @@ lemma handleSyscall_ccorres:
                   apply wp
                  apply (simp add: guard_is_UNIV_def)
                 apply clarsimp
-                apply (rule_tac Q="\<lambda>rv s. invs' s \<and>
+                apply (rule_tac Q'="\<lambda>rv s. invs' s \<and>
                  (\<forall>x. rv = Some x \<longrightarrow> x \<le> RISCV64.maxIRQ) \<and> rv \<noteq> Some 0x3FF"
                                              in hoare_post_imp)
                  apply (clarsimp simp: non_kernel_IRQs_def)
                 apply (wp getActiveIRQ_le_maxIRQ getActiveIRQ_neq_Some0x3FF | simp)+
-               apply (rule_tac Q=" invs' " in hoare_post_imp_dc2E, wp)
+               apply (rule_tac Q'=" invs' " in hoare_post_impE_E_dc, wp)
                apply (simp add: invs'_def valid_state'_def)
               apply clarsimp
               apply (vcg exspec=handleInvocation_modifies)
@@ -301,12 +301,12 @@ lemma handleSyscall_ccorres:
                  apply wp
                 apply (simp add: guard_is_UNIV_def)
                apply clarsimp
-               apply (rule_tac Q="\<lambda>rv s. invs' s \<and>
+               apply (rule_tac Q'="\<lambda>rv s. invs' s \<and>
                 (\<forall>x. rv = Some x \<longrightarrow> x \<le> RISCV64.maxIRQ) \<and> rv \<noteq> Some 0x3FF"
                                      in hoare_post_imp)
                 apply (clarsimp simp: non_kernel_IRQs_def)
                apply (wp getActiveIRQ_le_maxIRQ getActiveIRQ_neq_Some0x3FF | simp)+
-              apply (rule_tac Q=" invs' " in hoare_post_imp_dc2E, wp)
+              apply (rule_tac Q'=" invs' " in hoare_post_impE_E_dc, wp)
               apply (simp add: invs'_def valid_state'_def)
              apply clarsimp
              apply (vcg exspec=handleInvocation_modifies)
@@ -336,12 +336,12 @@ lemma handleSyscall_ccorres:
                 apply wp
                apply (simp add: guard_is_UNIV_def)
               apply clarsimp
-              apply (rule_tac Q="\<lambda>rv s. invs' s \<and>
+              apply (rule_tac Q'="\<lambda>rv s. invs' s \<and>
                (\<forall>x. rv = Some x \<longrightarrow> x \<le> RISCV64.maxIRQ) \<and> rv \<noteq> Some 0x3FF"
                                         in hoare_post_imp)
                apply (clarsimp simp: non_kernel_IRQs_def)
               apply (wp getActiveIRQ_le_maxIRQ getActiveIRQ_neq_Some0x3FF | simp)+
-             apply (rule_tac Q=" invs' " in hoare_post_imp_dc2E, wp)
+             apply (rule_tac Q'=" invs' " in hoare_post_impE_E_dc, wp)
              apply (simp add: invs'_def valid_state'_def)
             apply clarsimp
             apply (vcg exspec=handleInvocation_modifies)
@@ -374,7 +374,7 @@ lemma handleSyscall_ccorres:
           apply wp[1]
          apply clarsimp
          apply wp
-         apply (rule_tac Q="\<lambda>rv s. ct_in_state' simple' s \<and> sch_act_sane s"
+         apply (rule_tac Q'="\<lambda>rv s. ct_in_state' simple' s \<and> sch_act_sane s"
                               in hoare_post_imp)
           apply (simp add: ct_in_state'_def)
          apply (wp handleReply_sane)
@@ -409,15 +409,15 @@ lemma handleSyscall_ccorres:
           | wpc
           | wp hoare_drop_imp handleReply_sane handleReply_nonz_cap_to_ct schedule_invs'
           | strengthen ct_active_not_idle'_strengthen invs_valid_objs_strengthen)+
-      apply (rule_tac  Q="\<lambda>rv. invs' and ct_active'" in hoare_post_imp, simp)
+      apply (rule_tac Q'="\<lambda>rv. invs' and ct_active'" in hoare_post_imp, simp)
       apply (wp hy_invs')
      apply (clarsimp simp add: liftE_def)
      apply wp
-     apply (rule_tac  Q="\<lambda>rv. invs' and ct_active'" in hoare_post_imp, simp)
+     apply (rule_tac Q'="\<lambda>rv. invs' and ct_active'" in hoare_post_imp, simp)
      apply (wp hy_invs')
     apply (clarsimp simp: liftE_def)
     apply (wp)
-    apply (rule_tac Q="\<lambda>_. invs'" in hoare_post_imp, simp)
+    apply (rule_tac Q'="\<lambda>_. invs'" in hoare_post_imp, simp)
     apply (wp hw_invs')
    apply (simp add: guard_is_UNIV_def)
   apply clarsimp

--- a/proof/crefine/RISCV64/Retype_C.thy
+++ b/proof/crefine/RISCV64/Retype_C.thy
@@ -6302,7 +6302,7 @@ lemma createObject_valid_cap':
   apply (simp add:createObject_def3)
   apply (rule hoare_pre)
   apply wp
-   apply (rule_tac Q = "\<lambda>r s. r \<noteq> [] \<and> Q r s" for Q in hoare_strengthen_post)
+   apply (rule_tac Q'="\<lambda>r s. r \<noteq> [] \<and> Q r s" for Q in hoare_strengthen_post)
    apply (rule hoare_vcg_conj_lift)
      apply (rule hoare_strengthen_post[OF createNewCaps_ret_len])
       apply clarsimp
@@ -6376,7 +6376,7 @@ lemma createObject_caps_overlap_reserved_ret':
   apply (simp add:createObject_def3)
   apply (rule hoare_pre)
   apply wp
-   apply (rule_tac Q = "\<lambda>r s. r \<noteq> [] \<and> Q r s" for Q in hoare_strengthen_post)
+   apply (rule_tac Q'="\<lambda>r s. r \<noteq> [] \<and> Q r s" for Q in hoare_strengthen_post)
    apply (rule hoare_vcg_conj_lift)
      apply (rule hoare_strengthen_post[OF createNewCaps_ret_len])
       apply clarsimp
@@ -6399,7 +6399,7 @@ lemma createObject_descendants_range':
   apply (simp add:createObject_def3)
   apply (rule hoare_pre)
   apply wp
-   apply (rule_tac Q = "\<lambda>r s. r \<noteq> [] \<and> Q r s" for Q in hoare_strengthen_post)
+   apply (rule_tac Q'="\<lambda>r s. r \<noteq> [] \<and> Q r s" for Q in hoare_strengthen_post)
    apply (rule hoare_vcg_conj_lift)
      apply (rule hoare_strengthen_post[OF createNewCaps_ret_len])
       apply clarsimp
@@ -6430,7 +6430,7 @@ lemma createObject_idlethread_range:
   apply (simp add:createObject_def3)
   apply (rule hoare_pre)
   apply wp
-   apply (rule_tac Q = "\<lambda>r s. r \<noteq> [] \<and> Q r s" for Q in hoare_strengthen_post)
+   apply (rule_tac Q'="\<lambda>r s. r \<noteq> [] \<and> Q r s" for Q in hoare_strengthen_post)
    apply (rule hoare_vcg_conj_lift)
      apply (rule hoare_strengthen_post[OF createNewCaps_ret_len])
       apply clarsimp
@@ -6450,7 +6450,7 @@ lemma createObject_IRQHandler:
   apply (simp add:createObject_def3)
   apply (rule hoare_pre)
   apply wp
-   apply (rule_tac Q = "\<lambda>r s. r \<noteq> [] \<and> Q r s" for Q in hoare_strengthen_post)
+   apply (rule_tac Q'="\<lambda>r s. r \<noteq> [] \<and> Q r s" for Q in hoare_strengthen_post)
    apply (rule hoare_vcg_conj_lift)
      apply (rule hoare_strengthen_post[OF createNewCaps_ret_len])
       apply clarsimp
@@ -6468,7 +6468,7 @@ lemma createObject_capClass[wp]:
   apply (simp add:createObject_def3)
   apply (rule hoare_pre)
   apply wp
-   apply (rule_tac Q = "\<lambda>r s. r \<noteq> [] \<and> Q r s" for Q in hoare_strengthen_post)
+   apply (rule_tac Q'="\<lambda>r s. r \<noteq> [] \<and> Q r s" for Q in hoare_strengthen_post)
    apply (rule hoare_vcg_conj_lift)
      apply (rule hoare_strengthen_post[OF createNewCaps_ret_len])
       apply clarsimp
@@ -6515,7 +6515,7 @@ lemma createObject_parent_helper:
     \<rbrace>
     createObject ty ptr us dev
     \<lbrace>\<lambda>rv. cte_wp_at' (\<lambda>cte. isUntypedCap (cteCap cte) \<and> (sameRegionAs (cteCap cte) rv)) p\<rbrace>"
-  apply (rule hoare_post_imp [where Q="\<lambda>rv s. \<exists>cte. cte_wp_at' ((=) cte) p s
+  apply (rule hoare_post_imp[where Q'="\<lambda>rv s. \<exists>cte. cte_wp_at' ((=) cte) p s
                                            \<and> isUntypedCap (cteCap cte) \<and>
                                 sameRegionAs (cteCap cte) rv"])
   apply (clarsimp simp:cte_wp_at_ctes_of)
@@ -7285,7 +7285,7 @@ shows  "ccorres dc xfdc
                  (cnodeptr + (of_nat k * 0x20 + start * 0x20 + of_nat n * 0x20)) s)
               \<and> descendants_range_in' {(of_nat n << APIType_capBits newType userSize) +
                  ptr.. (ptr && ~~ mask sz) + 2 ^ sz  - 1} srcSlot (ctes_of s)"
-              in hoare_pre(1))
+              in hoare_weaken_pre)
              apply wp
             apply (clarsimp simp:createObject_hs_preconds_def conj_comms add.commute[where b=ptr]
                    invs_valid_pspace' invs_pspace_distinct' invs_pspace_aligned'

--- a/proof/crefine/RISCV64/Schedule_C.thy
+++ b/proof/crefine/RISCV64/Schedule_C.thy
@@ -679,7 +679,7 @@ lemma schedule_ccorres:
        apply wp
       apply clarsimp
       (* when runnable tcbSchedEnqueue curThread *)
-      apply (rule_tac Q="\<lambda>rv s. invs' s \<and> ksCurThread s = curThread
+      apply (rule_tac Q'="\<lambda>rv s. invs' s \<and> ksCurThread s = curThread
                                 \<and> ksSchedulerAction s = SwitchToThread candidate" in hoare_post_imp)
        apply (clarsimp simp: invs'_bitmapQ_no_L1_orphans invs_ksCurDomain_maxDomain')
        apply (fastforce dest: invs_sch_act_wf')

--- a/proof/crefine/RISCV64/SyscallArgs_C.thy
+++ b/proof/crefine/RISCV64/SyscallArgs_C.thy
@@ -942,7 +942,7 @@ lemma getMRs_user_word:
                          linorder_not_less [symmetric])
    apply (wp mapM_loadWordUser_user_words_at)
    apply (wp hoare_vcg_all_lift)
-    apply (rule_tac Q="\<lambda>_. \<top>" in hoare_strengthen_post)
+    apply (rule_tac Q'="\<lambda>_. \<top>" in hoare_strengthen_post)
      apply wp
     apply clarsimp
     defer
@@ -998,7 +998,7 @@ lemma getMRs_rel:
   apply (rule hoare_pre)
    apply (rule_tac x=mi in hoare_exI)
    apply wp
-   apply (rule_tac Q="\<lambda>rv s. thread = ksCurThread s \<and> fst (getMRs thread buffer mi s) = {(rv,s)}" in hoare_strengthen_post)
+   apply (rule_tac Q'="\<lambda>rv s. thread = ksCurThread s \<and> fst (getMRs thread buffer mi s) = {(rv,s)}" in hoare_strengthen_post)
     apply (wp det_result det_wp_getMRs)
    apply clarsimp
   apply (clarsimp simp: cur_tcb'_def)
@@ -1164,7 +1164,7 @@ lemma getSyscallArg_ccorres_foo:
     apply (clarsimp simp: option_to_ptr_def option_to_0_def)
     apply (rule_tac P="\<lambda>s. valid_ipc_buffer_ptr' (ptr_val (Ptr b)) s \<and> i < msgLength mi \<and>
                            msgLength mi \<le> msgMaxLength \<and> scast n_msgRegisters \<le> i"
-                 in hoare_pre(1))
+                 in hoare_weaken_pre)
      apply (wp getMRs_user_word)
     apply (clarsimp simp: msgMaxLength_def unat_less_helper)
    apply fastforce

--- a/proof/crefine/RISCV64/Syscall_C.thy
+++ b/proof/crefine/RISCV64/Syscall_C.thy
@@ -259,7 +259,7 @@ lemma decodeInvocation_ccorres:
        apply simp
        apply (vcg exspec=performInvocation_Reply_modifies)
       apply (simp add: cur_tcb'_def[symmetric])
-      apply (rule_tac R="\<lambda>rv s. ksCurThread s = thread" in hoare_post_add)
+      apply (rule_tac Q'="\<lambda>rv s. ksCurThread s = thread" in hoare_post_add)
       apply (simp cong: conj_cong)
       apply (strengthen imp_consequent)
       apply (wp sts_invs_minor' sts_st_tcb_at'_cases)
@@ -683,9 +683,9 @@ lemma sendFaultIPC_ccorres:
                  , assumption)
          apply vcg
         apply (clarsimp simp: inQ_def)
-        apply (rule_tac Q="\<lambda>a b. invs' b \<and> st_tcb_at' simple' tptr b
+        apply (rule_tac Q'="\<lambda>a b. invs' b \<and> st_tcb_at' simple' tptr b
                                  \<and> sch_act_not tptr b \<and> valid_cap' a b"
-                 and E="\<lambda> _. \<top>"
+                 and E'="\<lambda> _. \<top>"
                  in hoare_strengthen_postE)
           apply (wp)
          apply (clarsimp simp: isCap_simps)
@@ -885,8 +885,8 @@ lemma handleInvocation_ccorres:
                      apply (rule ccorres_return_C_errorE, simp+)[1]
                     apply vcg
                    apply (simp add: invocationCatch_def o_def)
-                   apply (rule_tac Q="\<lambda>rv'. invs' and tcb_at' rv"
-                               and E="\<lambda>ft. invs' and tcb_at' rv"
+                   apply (rule_tac Q'="\<lambda>rv'. invs' and tcb_at' rv"
+                               and E'="\<lambda>ft. invs' and tcb_at' rv"
                               in hoare_strengthen_postE)
                      apply (wp hoare_split_bind_case_sumE hoare_drop_imps
                                setThreadState_nonqueued_state_update

--- a/proof/crefine/RISCV64/Tcb_C.thy
+++ b/proof/crefine/RISCV64/Tcb_C.thy
@@ -429,7 +429,7 @@ lemma setPriority_ccorres:
                  simp: st_tcb_at'_def o_def split: if_splits)
     apply (simp add: guard_is_UNIV_def)
    apply (rule hoare_strengthen_post[
-                 where Q="\<lambda>rv s.
+                 where Q'="\<lambda>rv s.
                           obj_at' (\<lambda>_. True) t s \<and>
                           priority \<le> maxPriority \<and>
                           ksCurDomain s \<le> maxDomain \<and>
@@ -682,7 +682,7 @@ lemma invokeTCB_ThreadControl_ccorres:
                          apply wp
                         apply (clarsimp simp : guard_is_UNIV_def Collect_const_mem)
                        apply (rule hoare_strengthen_post[
-                                    where Q= "\<lambda>rv s.
+                                    where Q'="\<lambda>rv s.
                                               valid_objs' s \<and>
                                               weak_sch_act_wf (ksSchedulerAction s) s \<and>
                                               ((\<exists>a b. priority = Some (a, b)) \<longrightarrow>
@@ -777,7 +777,7 @@ lemma invokeTCB_ThreadControl_ccorres:
                apply (clarsimp simp : guard_is_UNIV_def Collect_const_mem)
               apply (simp cong: conj_cong)
               apply (rule hoare_strengthen_post[
-                            where Q="\<lambda>a b. (valid_objs' b \<and>
+                            where Q'="\<lambda>a b. (valid_objs' b \<and>
                                        sch_act_wf (ksSchedulerAction b) b \<and>
                                        pspace_aligned' b \<and> pspace_distinct' b \<and>
                                        ((\<exists>a b. priority = Some (a, b)) \<longrightarrow>
@@ -822,7 +822,7 @@ lemma invokeTCB_ThreadControl_ccorres:
             apply vcg
            apply (simp add: conj_comms cong: conj_cong)
            apply (strengthen invs_ksCurDomain_maxDomain' invs_pspace_distinct')
-           apply (wp hoare_vcg_const_imp_lift_R cteDelete_invs')
+           apply (wp hoare_vcg_const_imp_liftE_R cteDelete_invs')
           apply simp
           apply (rule ccorres_split_nothrow_novcg_dc)
              apply (rule ccorres_cond2[where R=\<top>], simp add: Collect_const_mem)
@@ -1242,13 +1242,13 @@ lemma invokeTCB_CopyRegisters_ccorres:
           apply (simp add: pred_conj_def guard_is_UNIV_def cong: if_cong
                   | wp mapM_x_wp_inv hoare_drop_imp)+
       apply clarsimp
-      apply (rule_tac Q="\<lambda>rv. invs' and tcb_at' destn" in hoare_strengthen_post[rotated])
+      apply (rule_tac Q'="\<lambda>rv. invs' and tcb_at' destn" in hoare_strengthen_post[rotated])
        apply (fastforce simp: sch_act_wf_weak)
       apply (wpsimp wp: hoare_drop_imp restart_invs')+
      apply (clarsimp simp add: guard_is_UNIV_def)
     apply (wp hoare_drop_imp hoare_vcg_if_lift)+
     apply simp
-    apply (rule_tac Q="\<lambda>rv. invs' and tcb_at' destn" in hoare_strengthen_post[rotated])
+    apply (rule_tac Q'="\<lambda>rv. invs' and tcb_at' destn" in hoare_strengthen_post[rotated])
      apply (fastforce simp: sch_act_wf_weak)
     apply (wpsimp wp: hoare_drop_imp)+
    apply (clarsimp simp add: guard_is_UNIV_def)
@@ -1657,7 +1657,7 @@ lemma invokeTCB_WriteRegisters_ccorres[where S=UNIV]:
                     apply wp
                    apply (simp add: guard_is_UNIV_def)
                   apply (wp hoare_drop_imp)
-                   apply (rule_tac Q="\<lambda>rv. invs' and tcb_at' dst" in hoare_strengthen_post[rotated])
+                   apply (rule_tac Q'="\<lambda>rv. invs' and tcb_at' dst" in hoare_strengthen_post[rotated])
                     apply (fastforce simp: sch_act_wf_weak)
                    apply (wpsimp wp: restart_invs')+
                  apply (clarsimp simp add: guard_is_UNIV_def)
@@ -2173,7 +2173,7 @@ shows
         apply wp
        apply (simp add: Collect_const_mem ThreadState_defs mask_def)
        apply vcg
-      apply (rule_tac Q="\<lambda>rv. invs' and st_tcb_at' ((=) Restart) thread
+      apply (rule_tac Q'="\<lambda>rv. invs' and st_tcb_at' ((=) Restart) thread
                              and tcb_at' target" in hoare_post_imp)
        apply (clarsimp simp: pred_tcb_at')
        apply (auto elim!: pred_tcb'_weakenE)[1]

--- a/proof/crefine/RISCV64/VSpace_C.thy
+++ b/proof/crefine/RISCV64/VSpace_C.thy
@@ -1750,7 +1750,7 @@ lemma performASIDPoolInvocation_ccorres:
            apply wp
           apply simp
           apply vcg
-         apply (rule hoare_strengthen_post[where Q="\<lambda>_. \<top>"], wp)
+         apply (rule hoare_strengthen_post[where Q'="\<lambda>_. \<top>"], wp)
          apply (clarsimp simp: typ_at'_def ko_wp_at'_def obj_at'_def)
         apply wp
        apply simp

--- a/proof/crefine/X64/Arch_C.thy
+++ b/proof/crefine/X64/Arch_C.thy
@@ -826,7 +826,7 @@ shows
        apply clarsimp
        apply (wp getSlotCap_wp)
       apply clarsimp
-     apply (rule_tac Q="\<lambda>_. cte_wp_at' ((=) (UntypedCap isdev frame pageBits idx) o cteCap) parent
+     apply (rule_tac Q'="\<lambda>_. cte_wp_at' ((=) (UntypedCap isdev frame pageBits idx) o cteCap) parent
                            and (\<lambda>s. descendants_range_in' {frame..frame + (2::machine_word) ^ pageBits - (1::machine_word)} parent (ctes_of s))
                            and pspace_no_overlap' frame pageBits
                            and invs'
@@ -1243,7 +1243,7 @@ lemma decodeX64PageTableInvocation_ccorres:
          apply simp
          apply (vcg exspec=findVSpaceForASID_modifies)
         apply simp
-        apply (rule_tac Q="\<lambda>a b. invs' b \<and> valid_cap' (fst (extraCaps ! 0)) b \<and> tcb_at' thread b \<and>
+        apply (rule_tac Q'="\<lambda>a b. invs' b \<and> valid_cap' (fst (extraCaps ! 0)) b \<and> tcb_at' thread b \<and>
                                  sch_act_wf (ksSchedulerAction b) b \<and> cte_wp_at' (\<lambda>_. True) slot b"
                                  in hoare_strengthen_post)
          apply wp
@@ -3232,7 +3232,7 @@ lemma decodeX64PageDirectoryInvocation_ccorres:
          apply simp
          apply (vcg exspec=findVSpaceForASID_modifies)
         apply simp
-        apply (rule_tac Q="\<lambda>a b. invs' b \<and> valid_cap' (fst (extraCaps ! 0)) b \<and> tcb_at' thread b \<and>
+        apply (rule_tac Q'="\<lambda>a b. invs' b \<and> valid_cap' (fst (extraCaps ! 0)) b \<and> tcb_at' thread b \<and>
                                  sch_act_wf (ksSchedulerAction b) b \<and> cte_wp_at' (\<lambda>_. True) slot b"
                         in hoare_strengthen_post)
          apply wp
@@ -5362,7 +5362,7 @@ proof -
                 apply (simp add: all_ex_eq_helper)
                 apply (vcg exspec=lookupTargetSlot_modifies)
                apply (wpsimp wp: isIOPortRangeFree_wp)
-              apply (rule_tac Q="\<lambda>rv. invs' and valid_cap' a and st_tcb_at' runnable' thread
+              apply (rule_tac Q'="\<lambda>rv. invs' and valid_cap' a and st_tcb_at' runnable' thread
                                       and sch_act_simple and cte_wp_at' \<top> slot
                                       and (\<lambda>s. thread = ksCurThread s)" in hoare_strengthen_post)
                apply (wpsimp wp: getSlotCap_wp)
@@ -5382,7 +5382,7 @@ proof -
          apply (simp add: all_ex_eq_helper, vcg exspec=getSyscallArg_modifies)
         apply wp
        apply (simp add: all_ex_eq_helper, vcg exspec=getSyscallArg_modifies)
-      apply (rule_tac Q="\<lambda>rv. ?apre" in hoare_strengthen_post)
+      apply (rule_tac Q'="\<lambda>rv. ?apre" in hoare_strengthen_post)
        apply wp
       apply (clarsimp simp: sysargs_rel_to_n excaps_in_mem_def slotcap_in_mem_def cte_wp_at_ctes_of
                       interpret_excaps_eq

--- a/proof/crefine/X64/DetWP.thy
+++ b/proof/crefine/X64/DetWP.thy
@@ -121,7 +121,7 @@ lemma det_wp_asUser [wp]:
       apply (drule det_wp_det)
       apply (erule det_wp_select_f)
      apply wp+
-   apply (rule_tac Q="\<lambda>_. tcb_at' t" in hoare_post_imp)
+   apply (rule_tac Q'="\<lambda>_. tcb_at' t" in hoare_post_imp)
     apply simp
    apply wp
   apply simp

--- a/proof/crefine/X64/Finalise_C.thy
+++ b/proof/crefine/X64/Finalise_C.thy
@@ -759,7 +759,7 @@ lemma suspend_ccorres:
         apply ceqv
        apply (ctac(no_vcg) add: setThreadState_ccorres_simple)
         apply (ctac add: tcbSchedDequeue_ccorres)
-       apply (rule_tac Q="\<lambda>_. valid_objs' and tcb_at' thread and pspace_aligned' and pspace_distinct'"
+       apply (rule_tac Q'="\<lambda>_. valid_objs' and tcb_at' thread and pspace_aligned' and pspace_distinct'"
                     in hoare_post_imp)
         apply clarsimp
        apply (wp sts_valid_objs')[1]

--- a/proof/crefine/X64/Invoke_C.thy
+++ b/proof/crefine/X64/Invoke_C.thy
@@ -75,7 +75,7 @@ lemma setDomain_ccorres:
        apply (simp add: guard_is_UNIV_def)
       apply simp
       apply wp
-     apply (rule_tac Q="\<lambda>_. all_invs_but_sch_extra and tcb_at' t and sch_act_simple
+     apply (rule_tac Q'="\<lambda>_. all_invs_but_sch_extra and tcb_at' t and sch_act_simple
                             and (\<lambda>s. curThread = ksCurThread s)"
               in hoare_strengthen_post)
       apply (wp threadSet_all_invs_but_sch_extra)
@@ -83,7 +83,7 @@ lemma setDomain_ccorres:
                             sch_act_simple_def st_tcb_at'_def weak_sch_act_wf_def
                      split: if_splits)
     apply (simp add: guard_is_UNIV_def)
-   apply (rule_tac Q="\<lambda>_. invs' and tcb_at' t and sch_act_simple and (\<lambda>s. curThread = ksCurThread s)"
+   apply (rule_tac Q'="\<lambda>_. invs' and tcb_at' t and sch_act_simple and (\<lambda>s. curThread = ksCurThread s)"
             in hoare_strengthen_post)
     apply (wp weak_sch_act_wf_lift_linear tcbSchedDequeue_not_queued
               hoare_vcg_imp_lift hoare_vcg_all_lift)
@@ -760,7 +760,7 @@ lemma decodeCNodeInvocation_ccorres:
                                apply (rule_tac Q'="\<lambda>rv. valid_pspace'
                                                     and valid_cap' rv and valid_objs'
                                                          and tcb_at' thread and (\<lambda>s. sch_act_wf (ksSchedulerAction s) s)"
-                                           in hoare_vcg_R_conj)
+                                           in hoare_vcg_conj_liftE_R)
                                 apply (rule deriveCap_Null_helper[OF deriveCap_derived])
                                apply wp
                               apply (clarsimp simp: cte_wp_at_ctes_of)
@@ -836,7 +836,7 @@ lemma decodeCNodeInvocation_ccorres:
                                    apply (rule_tac Q'="\<lambda>rv. valid_pspace'
                                                         and valid_cap' rv and valid_objs'
                                                              and tcb_at' thread and (\<lambda>s. sch_act_wf (ksSchedulerAction s) s)"
-                                               in hoare_vcg_R_conj)
+                                               in hoare_vcg_conj_liftE_R)
                                     apply (rule deriveCap_Null_helper [OF deriveCap_derived])
                                    apply wp
                                   apply (clarsimp simp: cte_wp_at_ctes_of)
@@ -957,7 +957,7 @@ lemma decodeCNodeInvocation_ccorres:
                       apply (clarsimp simp:valid_updateCapDataI invs_valid_objs' invs_valid_pspace')
                       apply assumption
                      apply (wp hoare_vcg_all_liftE_R injection_wp_E[OF refl]
-                               lsfco_cte_at' hoare_vcg_const_imp_lift_R
+                               lsfco_cte_at' hoare_vcg_const_imp_liftE_R
                            )+
                     apply (simp add: Collect_const_mem word_sle_def word_sless_def
                                      all_ex_eq_helper)
@@ -1334,7 +1334,7 @@ lemma decodeCNodeInvocation_ccorres:
           apply (rule ccorres_return_C_errorE, simp+)[1]
          apply vcg
         apply simp
-        apply (wp injection_wp_E[OF refl] hoare_vcg_const_imp_lift_R
+        apply (wp injection_wp_E[OF refl] hoare_vcg_const_imp_liftE_R
                   hoare_vcg_all_liftE_R lsfco_cte_at' hoare_weak_lift_imp
                 | simp add: hasCancelSendRights_not_Null ctes_of_valid_strengthen
                       cong: conj_cong

--- a/proof/crefine/X64/IpcCancel_C.thy
+++ b/proof/crefine/X64/IpcCancel_C.thy
@@ -2816,7 +2816,7 @@ lemma cancelIPC_ccorres1:
                                 ghost_assertion_data_set_def cap_tag_defs)
               apply (simp add: locateSlot_conv, wp)
              apply vcg
-            apply (rule_tac Q="\<lambda>rv. tcb_at' thread and invs'" in hoare_post_imp)
+            apply (rule_tac Q'="\<lambda>rv. tcb_at' thread and invs'" in hoare_post_imp)
              apply (clarsimp simp: cte_wp_at_ctes_of capHasProperty_def
                                    cap_get_tag_isCap ucast_id)
             apply (wp threadSet_invs_trivial | simp)+

--- a/proof/crefine/X64/Ipc_C.thy
+++ b/proof/crefine/X64/Ipc_C.thy
@@ -1383,7 +1383,7 @@ lemma asUser_atcbContext_obj_at:
 lemma asUser_tcbFault_inv:
   "\<lbrace>\<lambda>s. \<exists>t. ko_at' t p' s \<and> tcbFault t = f\<rbrace> asUser p m
    \<lbrace>\<lambda>rv s. \<exists>t. ko_at' t p' s \<and> tcbFault t = f\<rbrace>"
-  apply (rule_tac Q="\<lambda>rv. obj_at' (\<lambda>t. tcbFault t = f) p'"
+  apply (rule_tac Q'="\<lambda>rv. obj_at' (\<lambda>t. tcbFault t = f) p'"
                in hoare_strengthen_post)
    apply (wp asUser_tcbFault_obj_at)
    apply (clarsimp simp: obj_at'_def)+
@@ -3541,7 +3541,7 @@ lemma doIPCTransfer_ccorres [corres]:
                            fault_to_fault_tag_nonzero)
      apply ctac
     apply (clarsimp simp: guard_is_UNIV_def option_to_ptr_def split: option.splits)
-   apply (rule_tac Q="\<lambda>rv. valid_pspace' and cur_tcb' and tcb_at' sender
+   apply (rule_tac Q'="\<lambda>rv. valid_pspace' and cur_tcb' and tcb_at' sender
                        and tcb_at' receiver and K (rv \<noteq> Some 0)
                        and (case_option \<top> valid_ipc_buffer_ptr' rv)
                        and K (receiver \<noteq> sender \<and> endpoint \<noteq> Some 0)"
@@ -4267,7 +4267,7 @@ lemma doReplyTransfer_ccorres [corres]:
                          | simp add: valid_tcb_state'_def)+)[1]
            apply (clarsimp simp: guard_is_UNIV_def ThreadState_defs mask_def option_to_ctcb_ptr_def)
 
-          apply (rule_tac Q="\<lambda>rv. tcb_at' receiver and
+          apply (rule_tac Q'="\<lambda>rv. tcb_at' receiver and
                                 valid_objs' and sch_act_simple and (\<lambda>s. ksCurDomain s \<le> maxDomain) and
                                 (\<lambda>s. sch_act_wf (ksSchedulerAction s) s) and
                                 pspace_aligned' and pspace_distinct'" in hoare_post_imp)
@@ -4366,7 +4366,7 @@ lemma setupCallerCap_ccorres [corres]:
                        ptr_add_assertion_positive Collect_const_mem
                        tcb_cnode_index_defs)
      apply simp
-     apply (rule_tac Q="\<lambda>rv. valid_pspace' and tcb_at' receiver" in hoare_post_imp)
+     apply (rule_tac Q'="\<lambda>rv. valid_pspace' and tcb_at' receiver" in hoare_post_imp)
       apply (auto simp: cte_wp_at_ctes_of isCap_simps valid_pspace'_def
                         tcbSlots Kernel_C.tcbCaller_def size_of_def
                         cte_level_bits_def)[1]
@@ -5785,7 +5785,7 @@ lemma receiveIPC_ccorres [corres]:
                 apply (fastforce simp: guard_is_UNIV_def ThreadState_defs mask_def
                                        cap_get_tag_isCap ccap_relation_ep_helpers)
                apply (clarsimp simp: valid_tcb_state'_def)
-               apply (rule_tac Q="\<lambda>_. valid_pspace'
+               apply (rule_tac Q'="\<lambda>_. valid_pspace'
                                        and st_tcb_at' ((=) sendState) sender and tcb_at' thread
                                        and (\<lambda>s. sch_act_wf (ksSchedulerAction s) s)
                                        and sch_act_not sender and K (thread \<noteq> sender)
@@ -5793,7 +5793,7 @@ lemma receiveIPC_ccorres [corres]:
                 apply (fastforce simp: valid_pspace_valid_objs' pred_tcb_at'_def sch_act_wf_weak
                                        obj_at'_def)
                apply (wpsimp simp: guard_is_UNIV_def option_to_ptr_def option_to_0_def conj_ac)+
-           apply (rule_tac Q="\<lambda>rv. valid_pspace'
+           apply (rule_tac Q'="\<lambda>rv. valid_pspace'
                                and cur_tcb' and tcb_at' sender and tcb_at' thread
                                and sch_act_not sender and K (thread \<noteq> sender)
                                and ep_at' (capEPPtr cap)
@@ -6094,7 +6094,7 @@ lemma sendSignal_ccorres [corres]:
            apply (ctac add: possibleSwitchTo_ccorres)
           apply (wp sts_valid_objs' sts_st_tcb_at'_cases
                  | simp add: option_to_ctcb_ptr_def split del: if_split)+
-        apply (rule_tac Q="\<lambda>_. tcb_at' (the (ntfnBoundTCB ntfn)) and invs'"
+        apply (rule_tac Q'="\<lambda>_. tcb_at' (the (ntfnBoundTCB ntfn)) and invs'"
                  in hoare_post_imp)
          apply auto[1]
         apply wp
@@ -6492,7 +6492,7 @@ lemma receiveSignal_ccorres [corres]:
           apply (rule receiveSignal_enqueue_ccorres_helper[simplified])
          apply (simp add: valid_ntfn'_def)
          apply (wp sts_st_tcb')
-         apply (rule_tac Q="\<lambda>rv. ko_wp_at' (\<lambda>x. projectKO_opt x = Some ntfn
+         apply (rule_tac Q'="\<lambda>rv. ko_wp_at' (\<lambda>x. projectKO_opt x = Some ntfn
                                \<and> projectKO_opt x = (None::tcb option))
                                   (capNtfnPtr cap)"
                        in hoare_post_imp)
@@ -6560,7 +6560,7 @@ lemma receiveSignal_ccorres [corres]:
         apply (rule_tac ntfn="ntfn" in receiveSignal_enqueue_ccorres_helper[simplified])
        apply (simp add: valid_ntfn'_def)
        apply (wp sts_st_tcb')
-       apply (rule_tac Q="\<lambda>rv. ko_wp_at' (\<lambda>x. projectKO_opt x = Some ntfn
+       apply (rule_tac Q'="\<lambda>rv. ko_wp_at' (\<lambda>x. projectKO_opt x = Some ntfn
                              \<and> projectKO_opt x = (None::tcb option))
                                     (capNtfnPtr cap)
                       and K (thread \<notin> set list)"

--- a/proof/crefine/X64/IsolatedThreadAction.thy
+++ b/proof/crefine/X64/IsolatedThreadAction.thy
@@ -602,7 +602,7 @@ lemma select_f_isolatable:
 lemma doMachineOp_isolatable:
   "thread_actions_isolatable idx (doMachineOp m)"
   apply (simp add: doMachineOp_def split_def)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
                gets_isolatable thread_actions_isolatable_returns
                modify_isolatable select_f_isolatable)
   apply (simp | wp)+
@@ -622,8 +622,8 @@ lemma findVSpaceForASID_isolatable:
                    case_option_If2 assertE_def liftE_def checkPML4At_def
                    stateAssert_def2
              cong: if_cong)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
-               thread_actions_isolatable_bindE[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
+               thread_actions_isolatable_bindE[OF _ _ hoare_weaken_pre]
                thread_actions_isolatable_if thread_actions_isolatable_returns
                thread_actions_isolatable_fail
                gets_isolatable getObject_isolatable)
@@ -658,7 +658,7 @@ lemma thread_actions_isolatable_mapM_x:
   "\<lbrakk> \<And>x. thread_actions_isolatable idx (f x);
      \<And>x t. f x \<lbrace>tcb_at' t\<rbrace> \<rbrakk> \<Longrightarrow> thread_actions_isolatable idx (mapM_x f xs)"
   apply (induct xs; clarsimp simp: mapM_x_Nil mapM_x_Cons thread_actions_isolatable_returns)
-  apply (rule thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]; clarsimp?)
+  apply (rule thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]; clarsimp?)
    apply assumption+
   done
 
@@ -674,7 +674,7 @@ lemma setCurrentUserCR3_isolatable:
   "thread_actions_isolatable idx (setCurrentUserCR3 f)"
   apply (clarsimp simp: setCurrentUserCR3_def)
   apply (intro modify_isolatable doMachineOp_isolatable
-               thread_actions_isolatable_bind[OF _ _ hoare_pre(1)])
+               thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre])
     apply wpsimp+
   done
 
@@ -691,9 +691,9 @@ lemma setVMRoot_isolatable:
                    whenE_def liftE_def
                    stateAssert_def2
              cong: if_cong)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
-               thread_actions_isolatable_bindE[OF _ _ hoare_pre(1)]
-               thread_actions_isolatable_catch[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
+               thread_actions_isolatable_bindE[OF _ _ hoare_weaken_pre]
+               thread_actions_isolatable_catch[OF _ _ hoare_weaken_pre]
                thread_actions_isolatable_if thread_actions_isolatable_returns
                thread_actions_isolatable_fail
                getCurrentUserCR3_isolatable setCurrentUserCR3_isolatable
@@ -958,7 +958,7 @@ lemma setThreadState_no_sch_change:
   (is "Nondet_VCG.valid ?P ?f ?Q")
   apply (simp add: setThreadState_def setSchedulerAction_def)
   apply (wp hoare_pre_cont[where f=rescheduleRequired])
-  apply (rule_tac Q="\<lambda>_. ?P and st_tcb_at' ((=) st) t" in hoare_post_imp)
+  apply (rule_tac Q'="\<lambda>_. ?P and st_tcb_at' ((=) st) t" in hoare_post_imp)
    apply (clarsimp split: if_split)
    apply (clarsimp simp: obj_at'_def st_tcb_at'_def projectKOs)
   apply (wp threadSet_pred_tcb_at_state)
@@ -1020,7 +1020,7 @@ lemma setEndpoint_isolatable:
    apply (simp add: obj_at_partial_overwrite_id2)
    apply (drule_tac x=x in spec)
    apply (clarsimp simp: obj_at'_def projectKOs select_f_asserts)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
                thread_actions_isolatable_if
                thread_actions_isolatable_return
                thread_actions_isolatable_fail)
@@ -1172,7 +1172,7 @@ lemma cteInsert_isolatable:
   supply if_split[split del] if_cong[cong]
   apply (simp add: cteInsert_def updateCap_def updateMDB_def
                    Let_def setUntypedCapAsFull_def)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
                thread_actions_isolatable_if
                thread_actions_isolatable_returns assert_isolatable
                getCTE_isolatable setCTE_isolatable)
@@ -1258,7 +1258,7 @@ lemma threadGet_isolatable:
   "thread_actions_isolatable idx (Arch.switchToThread t)"
   apply (simp add: switchToThread_def
                    storeWordUser_def stateAssert_def2)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
                gets_isolatable setVMRoot_isolatable
                thread_actions_isolatable_if
                doMachineOp_isolatable
@@ -1275,7 +1275,7 @@ lemma tcbQueued_put_tcb_state_regs_tcb:
 lemma idleThreadNotQueued_isolatable:
   "thread_actions_isolatable idx (stateAssert idleThreadNotQueued [])"
   apply (simp add: stateAssert_def2 stateAssert_def)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
                gets_isolatable
                thread_actions_isolatable_if
                thread_actions_isolatable_returns
@@ -1493,7 +1493,7 @@ lemma updateMDB_isolatable:
   "thread_actions_isolatable idx (updateMDB slot f)"
   apply (simp add: updateMDB_def thread_actions_isolatable_return
             split: if_split)
-  apply (intro impI thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
+  apply (intro impI thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
                getCTE_isolatable setCTE_isolatable,
            (wp | simp)+)
   done
@@ -1515,7 +1515,7 @@ lemma emptySlot_isolatable:
   "thread_actions_isolatable idx (emptySlot slot NullCap)"
   apply (simp add: emptySlot_def updateCap_def case_Null_If Retype_H.postCapDeletion_def
              cong: if_cong)
-  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_pre(1)]
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
                clearUntypedFreeIndex_isolatable
                thread_actions_isolatable_if
                getCTE_isolatable setCTE_isolatable

--- a/proof/crefine/X64/Refine_C.thy
+++ b/proof/crefine/X64/Refine_C.thy
@@ -79,7 +79,7 @@ proof -
        apply (clarsimp simp: return_def)
       apply (wp schedule_sch_act_wf schedule_invs'
              | strengthen invs_valid_objs_strengthen invs_pspace_aligned' invs_pspace_distinct')+
-   apply (rule_tac Q="\<lambda>rv s. invs' s \<and> (\<forall>x. rv = Some x \<longrightarrow> x \<le> X64.maxIRQ) \<and> rv \<noteq> Some 0x3FF" in hoare_post_imp)
+   apply (rule_tac Q'="\<lambda>rv s. invs' s \<and> (\<forall>x. rv = Some x \<longrightarrow> x \<le> X64.maxIRQ) \<and> rv \<noteq> Some 0x3FF" in hoare_post_imp)
     apply (clarsimp simp: non_kernel_IRQs_def)
    apply (wp getActiveIRQ_le_maxIRQ getActiveIRQ_neq_Some0xFF | simp)+
   apply (clarsimp simp: invs'_def valid_state'_def)
@@ -264,12 +264,12 @@ lemma handleSyscall_ccorres:
                   apply wp
                  apply (simp add: guard_is_UNIV_def)
                 apply clarsimp
-                apply (rule_tac Q="\<lambda>rv s. invs' s \<and>
+                apply (rule_tac Q'="\<lambda>rv s. invs' s \<and>
                  (\<forall>x. rv = Some x \<longrightarrow> x \<le> X64.maxIRQ) \<and> rv \<noteq> Some 0x3FF"
                                              in hoare_post_imp)
                  apply (clarsimp simp: non_kernel_IRQs_def)
                 apply (wp getActiveIRQ_le_maxIRQ getActiveIRQ_neq_Some0xFF | simp)+
-               apply (rule_tac Q=" invs' " in hoare_post_imp_dc2E, wp)
+               apply (rule_tac Q'=" invs' " in hoare_post_impE_E_dc, wp)
                apply (simp add: invs'_def valid_state'_def)
               apply clarsimp
               apply (vcg exspec=handleInvocation_modifies)
@@ -300,12 +300,12 @@ lemma handleSyscall_ccorres:
                  apply wp
                 apply (simp add: guard_is_UNIV_def)
                apply clarsimp
-               apply (rule_tac Q="\<lambda>rv s. invs' s \<and>
+               apply (rule_tac Q'="\<lambda>rv s. invs' s \<and>
                 (\<forall>x. rv = Some x \<longrightarrow> x \<le> X64.maxIRQ) \<and> rv \<noteq> Some 0x3FF"
                                      in hoare_post_imp)
                 apply (clarsimp simp: non_kernel_IRQs_def)
                apply (wp getActiveIRQ_le_maxIRQ getActiveIRQ_neq_Some0xFF | simp)+
-              apply (rule_tac Q=" invs' " in hoare_post_imp_dc2E, wp)
+              apply (rule_tac Q'=" invs' " in hoare_post_impE_E_dc, wp)
               apply (simp add: invs'_def valid_state'_def)
              apply clarsimp
              apply (vcg exspec=handleInvocation_modifies)
@@ -337,12 +337,12 @@ lemma handleSyscall_ccorres:
                 apply wp
                apply (simp add: guard_is_UNIV_def)
               apply clarsimp
-              apply (rule_tac Q="\<lambda>rv s. invs' s \<and>
+              apply (rule_tac Q'="\<lambda>rv s. invs' s \<and>
                (\<forall>x. rv = Some x \<longrightarrow> x \<le> X64.maxIRQ) \<and> rv \<noteq> Some 0x3FF"
                                         in hoare_post_imp)
                apply (clarsimp simp: non_kernel_IRQs_def)
               apply (wp getActiveIRQ_le_maxIRQ getActiveIRQ_neq_Some0xFF | simp)+
-             apply (rule_tac Q=" invs' " in hoare_post_imp_dc2E, wp)
+             apply (rule_tac Q'=" invs' " in hoare_post_impE_E_dc, wp)
              apply (simp add: invs'_def valid_state'_def)
             apply clarsimp
             apply (vcg exspec=handleInvocation_modifies)
@@ -375,7 +375,7 @@ lemma handleSyscall_ccorres:
           apply wp[1]
          apply clarsimp
          apply wp
-         apply (rule_tac Q="\<lambda>rv s. ct_in_state' simple' s \<and> sch_act_sane s"
+         apply (rule_tac Q'="\<lambda>rv s. ct_in_state' simple' s \<and> sch_act_sane s"
                               in hoare_post_imp)
           apply (simp add: ct_in_state'_def)
          apply (wp handleReply_sane)
@@ -410,15 +410,15 @@ lemma handleSyscall_ccorres:
           | wpc
           | wp hoare_drop_imp handleReply_sane handleReply_nonz_cap_to_ct schedule_invs'
           | strengthen ct_active_not_idle'_strengthen invs_valid_objs_strengthen)+
-      apply (rule_tac  Q="\<lambda>rv. invs' and ct_active'" in hoare_post_imp, simp)
+      apply (rule_tac Q'="\<lambda>rv. invs' and ct_active'" in hoare_post_imp, simp)
       apply (wp hy_invs')
      apply (clarsimp simp add: liftE_def)
      apply wp
-     apply (rule_tac  Q="\<lambda>rv. invs' and ct_active'" in hoare_post_imp, simp)
+     apply (rule_tac Q'="\<lambda>rv. invs' and ct_active'" in hoare_post_imp, simp)
      apply (wp hy_invs')
     apply (clarsimp simp: liftE_def)
     apply (wp)
-    apply (rule_tac Q="\<lambda>_. invs'" in hoare_post_imp, simp)
+    apply (rule_tac Q'="\<lambda>_. invs'" in hoare_post_imp, simp)
     apply (wp hw_invs')
    apply (simp add: guard_is_UNIV_def)
   apply clarsimp

--- a/proof/crefine/X64/Retype_C.thy
+++ b/proof/crefine/X64/Retype_C.thy
@@ -7412,7 +7412,7 @@ lemma createObject_valid_cap':
   apply (simp add:createObject_def3)
   apply (rule hoare_pre)
   apply wp
-   apply (rule_tac Q = "\<lambda>r s. r \<noteq> [] \<and> Q r s" for Q in hoare_strengthen_post)
+   apply (rule_tac Q'="\<lambda>r s. r \<noteq> [] \<and> Q r s" for Q in hoare_strengthen_post)
    apply (rule hoare_vcg_conj_lift)
      apply (rule hoare_strengthen_post[OF createNewCaps_ret_len])
       apply clarsimp
@@ -7486,7 +7486,7 @@ lemma createObject_caps_overlap_reserved_ret':
   apply (simp add:createObject_def3)
   apply (rule hoare_pre)
   apply wp
-   apply (rule_tac Q = "\<lambda>r s. r \<noteq> [] \<and> Q r s" for Q in hoare_strengthen_post)
+   apply (rule_tac Q'="\<lambda>r s. r \<noteq> [] \<and> Q r s" for Q in hoare_strengthen_post)
    apply (rule hoare_vcg_conj_lift)
      apply (rule hoare_strengthen_post[OF createNewCaps_ret_len])
       apply clarsimp
@@ -7509,7 +7509,7 @@ lemma createObject_descendants_range':
   apply (simp add:createObject_def3)
   apply (rule hoare_pre)
   apply wp
-   apply (rule_tac Q = "\<lambda>r s. r \<noteq> [] \<and> Q r s" for Q in hoare_strengthen_post)
+   apply (rule_tac Q'="\<lambda>r s. r \<noteq> [] \<and> Q r s" for Q in hoare_strengthen_post)
    apply (rule hoare_vcg_conj_lift)
      apply (rule hoare_strengthen_post[OF createNewCaps_ret_len])
       apply clarsimp
@@ -7540,7 +7540,7 @@ lemma createObject_idlethread_range:
   apply (simp add:createObject_def3)
   apply (rule hoare_pre)
   apply wp
-   apply (rule_tac Q = "\<lambda>r s. r \<noteq> [] \<and> Q r s" for Q in hoare_strengthen_post)
+   apply (rule_tac Q'="\<lambda>r s. r \<noteq> [] \<and> Q r s" for Q in hoare_strengthen_post)
    apply (rule hoare_vcg_conj_lift)
      apply (rule hoare_strengthen_post[OF createNewCaps_ret_len])
       apply clarsimp
@@ -7560,7 +7560,7 @@ lemma createObject_IRQHandler:
   apply (simp add:createObject_def3)
   apply (rule hoare_pre)
   apply wp
-   apply (rule_tac Q = "\<lambda>r s. r \<noteq> [] \<and> Q r s" for Q in hoare_strengthen_post)
+   apply (rule_tac Q'="\<lambda>r s. r \<noteq> [] \<and> Q r s" for Q in hoare_strengthen_post)
    apply (rule hoare_vcg_conj_lift)
      apply (rule hoare_strengthen_post[OF createNewCaps_ret_len])
       apply clarsimp
@@ -7578,7 +7578,7 @@ lemma createObject_capClass[wp]:
   apply (simp add:createObject_def3)
   apply (rule hoare_pre)
   apply wp
-   apply (rule_tac Q = "\<lambda>r s. r \<noteq> [] \<and> Q r s" for Q in hoare_strengthen_post)
+   apply (rule_tac Q'="\<lambda>r s. r \<noteq> [] \<and> Q r s" for Q in hoare_strengthen_post)
    apply (rule hoare_vcg_conj_lift)
      apply (rule hoare_strengthen_post[OF createNewCaps_ret_len])
       apply clarsimp
@@ -7626,7 +7626,7 @@ lemma createObject_parent_helper:
     \<rbrace>
     createObject ty ptr us dev
     \<lbrace>\<lambda>rv. cte_wp_at' (\<lambda>cte. isUntypedCap (cteCap cte) \<and> (sameRegionAs (cteCap cte) rv)) p\<rbrace>"
-  apply (rule hoare_post_imp [where Q="\<lambda>rv s. \<exists>cte. cte_wp_at' ((=) cte) p s
+  apply (rule hoare_post_imp[where Q'="\<lambda>rv s. \<exists>cte. cte_wp_at' ((=) cte) p s
                                            \<and> isUntypedCap (cteCap cte) \<and>
                                 sameRegionAs (cteCap cte) rv"])
   apply (clarsimp simp:cte_wp_at_ctes_of)
@@ -8415,7 +8415,7 @@ shows  "ccorres dc xfdc
                  (cnodeptr + (of_nat k * 0x20 + start * 0x20 + of_nat n * 0x20)) s)
               \<and> descendants_range_in' {(of_nat n << APIType_capBits newType userSize) +
                  ptr.. (ptr && ~~ mask sz) + 2 ^ sz  - 1} srcSlot (ctes_of s)"
-              in hoare_pre(1))
+              in hoare_weaken_pre)
              apply wp
             apply (clarsimp simp:createObject_hs_preconds_def conj_comms add.commute[where b=ptr]
                    invs_valid_pspace' invs_pspace_distinct' invs_pspace_aligned'

--- a/proof/crefine/X64/Schedule_C.thy
+++ b/proof/crefine/X64/Schedule_C.thy
@@ -678,7 +678,7 @@ lemma schedule_ccorres:
        apply wp
       apply clarsimp
       (* when runnable tcbSchedEnqueue curThread *)
-      apply (rule_tac Q="\<lambda>rv s. invs' s \<and> ksCurThread s = curThread
+      apply (rule_tac Q'="\<lambda>rv s. invs' s \<and> ksCurThread s = curThread
                                 \<and> ksSchedulerAction s = SwitchToThread candidate" in hoare_post_imp)
        apply (clarsimp simp: invs'_bitmapQ_no_L1_orphans invs_ksCurDomain_maxDomain')
        apply (fastforce dest: invs_sch_act_wf')

--- a/proof/crefine/X64/SyscallArgs_C.thy
+++ b/proof/crefine/X64/SyscallArgs_C.thy
@@ -948,7 +948,7 @@ lemma getMRs_user_word:
                          linorder_not_less [symmetric])
    apply (wp mapM_loadWordUser_user_words_at)
    apply (wp hoare_vcg_all_lift)
-    apply (rule_tac Q="\<lambda>_. \<top>" in hoare_strengthen_post)
+    apply (rule_tac Q'="\<lambda>_. \<top>" in hoare_strengthen_post)
      apply wp
     apply clarsimp
     defer
@@ -1004,7 +1004,7 @@ lemma getMRs_rel:
   apply (rule hoare_pre)
    apply (rule_tac x=mi in hoare_exI)
    apply wp
-   apply (rule_tac Q="\<lambda>rv s. thread = ksCurThread s \<and> fst (getMRs thread buffer mi s) = {(rv,s)}" in hoare_strengthen_post)
+   apply (rule_tac Q'="\<lambda>rv s. thread = ksCurThread s \<and> fst (getMRs thread buffer mi s) = {(rv,s)}" in hoare_strengthen_post)
     apply (wp det_result det_wp_getMRs)
    apply clarsimp
   apply (clarsimp simp: cur_tcb'_def)
@@ -1170,7 +1170,7 @@ lemma getSyscallArg_ccorres_foo:
     apply (clarsimp simp: option_to_ptr_def option_to_0_def)
     apply (rule_tac P="\<lambda>s. valid_ipc_buffer_ptr' (ptr_val (Ptr b)) s \<and> i < msgLength mi \<and>
                            msgLength mi \<le> msgMaxLength \<and> scast n_msgRegisters \<le> i"
-                 in hoare_pre(1))
+                 in hoare_weaken_pre)
      apply (wp getMRs_user_word)
     apply (clarsimp simp: msgMaxLength_def unat_less_helper)
    apply fastforce

--- a/proof/crefine/X64/Syscall_C.thy
+++ b/proof/crefine/X64/Syscall_C.thy
@@ -257,7 +257,7 @@ lemma decodeInvocation_ccorres:
        apply simp
        apply (vcg exspec=performInvocation_Reply_modifies)
       apply (simp add: cur_tcb'_def[symmetric])
-      apply (rule_tac R="\<lambda>rv s. ksCurThread s = thread" in hoare_post_add)
+      apply (rule_tac Q'="\<lambda>rv s. ksCurThread s = thread" in hoare_post_add)
       apply (simp cong: conj_cong)
       apply (strengthen imp_consequent)
       apply (wp sts_invs_minor' sts_st_tcb_at'_cases)
@@ -680,9 +680,9 @@ lemma sendFaultIPC_ccorres:
                  , assumption)
          apply vcg
         apply (clarsimp simp: inQ_def)
-        apply (rule_tac Q="\<lambda>a b. invs' b \<and> st_tcb_at' simple' tptr b
+        apply (rule_tac Q'="\<lambda>a b. invs' b \<and> st_tcb_at' simple' tptr b
                                  \<and> sch_act_not tptr b \<and> valid_cap' a b"
-                 and E="\<lambda> _. \<top>"
+                 and E'="\<lambda> _. \<top>"
                  in hoare_strengthen_postE)
           apply (wp)
          apply (clarsimp simp: isCap_simps)
@@ -882,8 +882,8 @@ lemma handleInvocation_ccorres:
                      apply (rule ccorres_return_C_errorE, simp+)[1]
                     apply vcg
                    apply (simp add: invocationCatch_def o_def)
-                   apply (rule_tac Q="\<lambda>rv'. invs' and tcb_at' rv"
-                               and E="\<lambda>ft. invs' and tcb_at' rv"
+                   apply (rule_tac Q'="\<lambda>rv'. invs' and tcb_at' rv"
+                               and E'="\<lambda>ft. invs' and tcb_at' rv"
                               in hoare_strengthen_postE)
                      apply (wp hoare_split_bind_case_sumE hoare_drop_imps
                                setThreadState_nonqueued_state_update

--- a/proof/crefine/X64/Tcb_C.thy
+++ b/proof/crefine/X64/Tcb_C.thy
@@ -422,7 +422,7 @@ lemma setPriority_ccorres:
                  simp: st_tcb_at'_def o_def split: if_splits)
     apply (simp add: guard_is_UNIV_def)
    apply (rule hoare_strengthen_post[
-                 where Q="\<lambda>rv s.
+                 where Q'="\<lambda>rv s.
                           obj_at' (\<lambda>_. True) t s \<and>
                           priority \<le> maxPriority \<and>
                           ksCurDomain s \<le> maxDomain \<and>
@@ -675,7 +675,7 @@ lemma invokeTCB_ThreadControl_ccorres:
                          apply wp
                         apply (clarsimp simp : guard_is_UNIV_def Collect_const_mem)
                        apply (rule hoare_strengthen_post[
-                                    where Q= "\<lambda>rv s.
+                                    where Q'="\<lambda>rv s.
                                               valid_objs' s \<and>
                                               weak_sch_act_wf (ksSchedulerAction s) s \<and>
                                               ((\<exists>a b. priority = Some (a, b)) \<longrightarrow>
@@ -769,7 +769,7 @@ lemma invokeTCB_ThreadControl_ccorres:
                apply (clarsimp simp : guard_is_UNIV_def Collect_const_mem)
               apply (simp cong: conj_cong)
               apply (rule hoare_strengthen_post[
-                            where Q="\<lambda>a b. (valid_objs' b \<and>
+                            where Q'="\<lambda>a b. (valid_objs' b \<and>
                                        sch_act_wf (ksSchedulerAction b) b \<and>
                                        pspace_aligned' b \<and> pspace_distinct' b \<and>
                                        ((\<exists>a b. priority = Some (a, b)) \<longrightarrow>
@@ -814,7 +814,7 @@ lemma invokeTCB_ThreadControl_ccorres:
             apply vcg
            apply (simp add: conj_comms cong: conj_cong)
            apply (strengthen invs_ksCurDomain_maxDomain' invs_pspace_distinct')
-           apply (wp hoare_vcg_const_imp_lift_R cteDelete_invs')
+           apply (wp hoare_vcg_const_imp_liftE_R cteDelete_invs')
           apply simp
           apply (rule ccorres_split_nothrow_novcg_dc)
              apply (rule ccorres_cond2[where R=\<top>], simp add: Collect_const_mem)
@@ -1237,13 +1237,13 @@ lemma invokeTCB_CopyRegisters_ccorres:
           apply (simp add: pred_conj_def guard_is_UNIV_def cong: if_cong
                   | wp mapM_x_wp_inv hoare_drop_imp)+
       apply clarsimp
-      apply (rule_tac Q="\<lambda>rv. invs' and tcb_at' destn" in hoare_strengthen_post[rotated])
+      apply (rule_tac Q'="\<lambda>rv. invs' and tcb_at' destn" in hoare_strengthen_post[rotated])
        apply (fastforce simp: sch_act_wf_weak)
       apply (wpsimp wp: hoare_drop_imp restart_invs')+
      apply (clarsimp simp add: guard_is_UNIV_def)
     apply (wp hoare_drop_imp hoare_vcg_if_lift)+
     apply simp
-    apply (rule_tac Q="\<lambda>rv. invs' and tcb_at' destn" in hoare_strengthen_post[rotated])
+    apply (rule_tac Q'="\<lambda>rv. invs' and tcb_at' destn" in hoare_strengthen_post[rotated])
      apply (fastforce simp: sch_act_wf_weak)
     apply (wpsimp wp: hoare_drop_imp)+
    apply (clarsimp simp add: guard_is_UNIV_def)
@@ -1647,7 +1647,7 @@ lemma invokeTCB_WriteRegisters_ccorres[where S=UNIV]:
                     apply wp
                    apply (simp add: guard_is_UNIV_def)
                   apply (wp hoare_drop_imp)
-                   apply (rule_tac Q="\<lambda>rv. invs' and tcb_at' dst" in hoare_strengthen_post[rotated])
+                   apply (rule_tac Q'="\<lambda>rv. invs' and tcb_at' dst" in hoare_strengthen_post[rotated])
                     apply (fastforce simp: sch_act_wf_weak)
                    apply (wpsimp wp: restart_invs')+
                  apply (clarsimp simp add: guard_is_UNIV_def)
@@ -2163,7 +2163,7 @@ shows
         apply wp
        apply (simp add: Collect_const_mem ThreadState_defs mask_def)
        apply vcg
-      apply (rule_tac Q="\<lambda>rv. invs' and st_tcb_at' ((=) Restart) thread
+      apply (rule_tac Q'="\<lambda>rv. invs' and st_tcb_at' ((=) Restart) thread
                              and tcb_at' target" in hoare_post_imp)
        apply (clarsimp simp: pred_tcb_at')
        apply (auto elim!: pred_tcb'_weakenE)[1]

--- a/proof/crefine/lib/Ctac.thy
+++ b/proof/crefine/lib/Ctac.thy
@@ -1770,7 +1770,7 @@ next
         apply assumption
        apply (clarsimp elim!: inl_inrE)
       apply simp
-      apply (rule hoare_vcg_const_imp_lift_R)
+      apply (rule hoare_vcg_const_imp_liftE_R)
       apply (rule hoare_gen_asmE)
       apply (erule Cons.prems(3)[where n=0, simplified])
      apply (rule_tac P="Q \<inter> {s. \<exists>\<sigma>. P \<sigma> \<and> (\<sigma>, s) \<in> sr}"

--- a/proof/drefine/Arch_DR.thy
+++ b/proof/drefine/Arch_DR.thy
@@ -166,7 +166,7 @@ lemma dcorres_lookup_pt_slot:
           apply simp
          apply simp
      apply (simp add: transform_pde_def)+
-    apply (rule hoare_strengthen_post[where Q = "\<lambda>r. valid_pde r and pspace_aligned"] )
+    apply (rule hoare_strengthen_post[where Q'="\<lambda>r. valid_pde r and pspace_aligned"] )
      apply (wp get_pde_valid)
     apply (clarsimp simp:valid_pde_def dest!:pt_aligned
       split:ARM_A.pde.splits)
@@ -184,7 +184,7 @@ lemma lookup_pt_slot_aligned_6':
   apply (simp add:lookup_pt_slot_def)
   apply (wp|wpc)+
    apply clarsimp
-   apply (rule hoare_strengthen_post[where Q = "\<lambda>r. valid_pde r and pspace_aligned"] )
+   apply (rule hoare_strengthen_post[where Q'="\<lambda>r. valid_pde r and pspace_aligned"] )
     apply wp
    apply simp+
    apply (clarsimp simp:valid_pde_def dest!:pt_aligned split:ARM_A.pde.splits)
@@ -1207,7 +1207,7 @@ lemma invoke_page_table_corres:
        apply (wp store_pte_cte_wp_at)
       apply fastforce
      apply wpsimp+
-    apply (rule_tac Q="\<lambda>rv s. invs s \<and> valid_etcbs s \<and> a \<noteq> idle_thread s \<and> cte_wp_at \<top> (a,b) s \<and>
+    apply (rule_tac Q'="\<lambda>rv s. invs s \<and> valid_etcbs s \<and> a \<noteq> idle_thread s \<and> cte_wp_at \<top> (a,b) s \<and>
                               caps_of_state s' = caps_of_state s" in hoare_strengthen_post)
      apply wp
     apply (clarsimp simp:invs_def valid_state_def)
@@ -1235,7 +1235,7 @@ lemma set_vm_root_for_flush_dwp[wp]:
        apply (rule hoare_conjI,rule hoare_drop_imp)
         apply (wp do_machine_op_wp|clarsimp simp:load_hw_asid_def)+
      apply (wpc|wp)+
-    apply (rule_tac Q="\<lambda>rv s. transform s = cs" in hoare_strengthen_post)
+    apply (rule_tac Q'="\<lambda>rv s. transform s = cs" in hoare_strengthen_post)
      apply (wp|clarsimp)+
   done
 
@@ -1548,7 +1548,7 @@ lemma invoke_page_corres:
           apply (clarsimp simp: transform_mapping_def update_map_data_def)
          apply (wp get_cap_cte_wp_at_rv unmap_page_pred_tcb_at |
                 clarsimp simp:valid_idle_def not_idle_thread_def)+
-     apply (rule_tac Q="\<lambda>rv s. valid_etcbs s \<and>
+     apply (rule_tac Q'="\<lambda>rv s. valid_etcbs s \<and>
                                idle_tcb_at (\<lambda>(st, ntfn, arch). idle st \<and> ntfn = None \<and> valid_arch_idle arch)
                                            (idle_thread s) s \<and>
                                a \<noteq> idle_thread s \<and> idle_thread s = idle_thread_ptr \<and> cte_wp_at \<top> (a,b) s \<and>
@@ -1683,7 +1683,7 @@ proof -
                  apply (clarsimp simp: transform_asid_table_def transform_asid_def
                                        fun_upd_def[symmetric] unat_map_upd)
                 apply wp+
-             apply (rule_tac Q="\<lambda>rv s. cte_wp_at (\<lambda>c. \<exists>idx. c = (cap.UntypedCap False frame pageBits idx)) cref s
+             apply (rule_tac Q'="\<lambda>rv s. cte_wp_at (\<lambda>c. \<exists>idx. c = (cap.UntypedCap False frame pageBits idx)) cref s
                                        \<and> asid_pool_at frame s
                                        \<and> cte_wp_at ((=) cap.NullCap) cnode_ref s
                                        \<and> ex_cte_cap_to cnode_ref s \<and> invs s \<and> valid_etcbs s"
@@ -1719,7 +1719,7 @@ proof -
       apply (rule_tac P = "is_aligned frame page_bits \<and> page_bits \<le> word_bits \<and> 2 \<le> page_bits"
                       in hoare_gen_asm)
       apply (simp add: delete_objects_rewrite[unfolded word_size_bits_def] is_aligned_neg_mask_eq)
-      apply (rule_tac Q="\<lambda>_ s.
+      apply (rule_tac Q'="\<lambda>_ s.
              invs s \<and> valid_etcbs s \<and> pspace_no_overlap_range_cover frame pageBits s \<and>
              descendants_range_in (untyped_range (cap.UntypedCap False frame pageBits idx)) cref s \<and>
              cte_wp_at ((=) (cap.UntypedCap False frame pageBits idx)) cref s \<and>

--- a/proof/drefine/CNode_DR.thy
+++ b/proof/drefine/CNode_DR.thy
@@ -222,7 +222,7 @@ lemma insert_cap_sibling_corres:
              | simp add: swp_def cte_wp_at_caps_of_state)+)
          apply (wp set_cap_idle |
             simp add:set_untyped_cap_as_full_def split del: if_split)+
-          apply (rule_tac Q = "\<lambda>r s. cdt s sibling = None
+          apply (rule_tac Q'="\<lambda>r s. cdt s sibling = None
            \<and> \<not> should_be_parent_of src_capa (is_original_cap s sibling) cap (cap_insert_dest_original cap src_capa)
            \<and> mdb_cte_at (swp (cte_wp_at ((\<noteq>) cap.NullCap)) s) (cdt s)"
            in hoare_strengthen_post)
@@ -234,7 +234,7 @@ lemma insert_cap_sibling_corres:
          apply (wp get_cap_wp set_cap_idle hoare_weak_lift_imp
            | simp add:set_untyped_cap_as_full_def
            split del: if_split)+
-         apply (rule_tac Q = "\<lambda>r s. cdt s sibling = None
+         apply (rule_tac Q'="\<lambda>r s. cdt s sibling = None
            \<and> (\<exists>cap. caps_of_state s src = Some cap)
            \<and> \<not> should_be_parent_of src_capa (is_original_cap s src) cap (cap_insert_dest_original cap src_capa)
            \<and> mdb_cte_at (swp (cte_wp_at ((\<noteq>) cap.NullCap)) s) (cdt s)"
@@ -306,7 +306,7 @@ lemma insert_cap_child_corres:
                     | simp add: swp_def cte_wp_at_caps_of_state)+
          apply (wp set_cap_idle |
           simp add:set_untyped_cap_as_full_def split del:if_split)+
-          apply (rule_tac Q = "\<lambda>r s. not_idle_thread (fst child) s
+          apply (rule_tac Q'="\<lambda>r s. not_idle_thread (fst child) s
             \<and> should_be_parent_of src_capa (is_original_cap s child) cap (cap_insert_dest_original cap src_capa)
             \<and> mdb_cte_at (swp (cte_wp_at ((\<noteq>) cap.NullCap)) s) (cdt s)"
            in hoare_strengthen_post)
@@ -315,7 +315,7 @@ lemma insert_cap_child_corres:
           apply fastforce
          apply (wp get_cap_wp set_cap_idle hoare_weak_lift_imp
            | simp split del:if_split add:set_untyped_cap_as_full_def)+
-         apply (rule_tac Q = "\<lambda>r s. not_idle_thread (fst child) s
+         apply (rule_tac Q'="\<lambda>r s. not_idle_thread (fst child) s
            \<and> (\<exists>cap. caps_of_state s src = Some cap)
            \<and> should_be_parent_of src_capa (is_original_cap s src) cap (cap_insert_dest_original cap src_capa)
            \<and> mdb_cte_at (swp (cte_wp_at ((\<noteq>) cap.NullCap)) s) (cdt s)"
@@ -521,7 +521,7 @@ lemma delete_cap_corres:
     apply (rule validE_validE_R)
     apply (simp add:validE_def weak_valid_mdb_def)
     apply (rule hoare_drop_imp)
-    apply (rule_tac Q = "\<lambda>r. invs and not_idle_thread a and valid_etcbs" in hoare_strengthen_post)
+    apply (rule_tac Q'="\<lambda>r. invs and not_idle_thread a and valid_etcbs" in hoare_strengthen_post)
      apply (wp rec_del_invs)
      apply (simp add:not_idle_thread_def validE_def)
      apply wp
@@ -550,7 +550,7 @@ lemma delete_cap_corres':
     apply (rule validE_validE_R)
     apply (simp add:validE_def weak_valid_mdb_def)
     apply (rule hoare_drop_imp)
-    apply (rule_tac Q = "\<lambda>r. invs and not_idle_thread a and valid_etcbs" in hoare_strengthen_post)
+    apply (rule_tac Q'="\<lambda>r. invs and not_idle_thread a and valid_etcbs" in hoare_strengthen_post)
      apply (wp rec_del_invs)
      apply (simp add:not_idle_thread_def validE_def)
      apply wp
@@ -1004,7 +1004,7 @@ lemma dcorres_ep_cancel_badge_sends:
                apply simp+
              apply (clarsimp simp:bind_assoc not_idle_thread_def)
              apply (wp sts_st_tcb_at_neq)
-              apply (rule_tac Q="\<lambda>r a. valid_idle a \<and> idle_thread a = idle_thread s' \<and>
+              apply (rule_tac Q'="\<lambda>r a. valid_idle a \<and> idle_thread a = idle_thread s' \<and>
                 st_tcb_at (\<lambda>ts. \<exists>pl. ts = Structures_A.thread_state.BlockedOnSend epptr pl) y a
                \<and> y \<noteq> idle_thread a \<and> valid_etcbs a" in hoare_strengthen_post)
                apply wp
@@ -1524,7 +1524,7 @@ lemma store_pte_ct:
   apply wp
    apply (simp add:set_pt_def)
    apply wp
-   apply (rule_tac Q = "\<lambda>r s. P (cur_thread s)" in hoare_strengthen_post)
+   apply (rule_tac Q'="\<lambda>r s. P (cur_thread s)" in hoare_strengthen_post)
     apply (wp|clarsimp)+
   done
 
@@ -1535,7 +1535,7 @@ lemma invalidate_tlb_by_asid_dwp:
   apply (wp do_machine_op_wp|wpc)+
    apply clarsimp
    apply (wp)
-  apply (rule_tac Q = "\<lambda>r s. transform s = cs" in  hoare_strengthen_post)
+  apply (rule_tac Q'="\<lambda>r s. transform s = cs" in hoare_strengthen_post)
    apply (simp add:load_hw_asid_def)
    apply (wp|clarsimp)+
   done
@@ -1569,10 +1569,10 @@ lemma copy_global_mappings_dwp:
   "is_aligned word pd_bits\<Longrightarrow> \<lbrace>\<lambda>ps. valid_idle (ps :: det_state) \<and> transform ps = cs\<rbrace> copy_global_mappings word \<lbrace>\<lambda>r s. transform s = cs\<rbrace>"
   apply (simp add:copy_global_mappings_def)
   apply wp
-    apply (rule_tac Q = "\<lambda>r s. valid_idle s \<and> transform s = cs" in hoare_strengthen_post)
+    apply (rule_tac Q'="\<lambda>r s. valid_idle s \<and> transform s = cs" in hoare_strengthen_post)
      apply (rule mapM_x_wp')
      apply wp
-       apply (rule_tac Q="\<lambda>s. valid_idle s \<and> transform s = cs" in hoare_weaken_pre)
+       apply (rule_tac P'="\<lambda>s. valid_idle s \<and> transform s = cs" in hoare_weaken_pre)
         apply (rule dcorres_to_wp)
         apply (rule corres_guard_imp[OF store_pde_set_cap_corres])
           apply (clarsimp simp:kernel_mapping_slots_def)
@@ -1782,7 +1782,7 @@ lemma thread_set_valid_idle:
   apply (simp add: thread_set_def not_idle_thread_def)
   apply (simp add: gets_the_def valid_idle_def)
   apply wp
-  apply (rule_tac Q="not_idle_thread thread and valid_idle" in hoare_weaken_pre)
+  apply (rule_tac P'="not_idle_thread thread and valid_idle" in hoare_weaken_pre)
   apply (clarsimp simp: KHeap_A.set_object_def get_object_def in_monad get_def put_def bind_def obj_at_def
                         return_def valid_def not_idle_thread_def valid_idle_def pred_tcb_at_def)
   apply simp+

--- a/proof/drefine/Finalise_DR.thy
+++ b/proof/drefine/Finalise_DR.thy
@@ -214,10 +214,10 @@ lemma delete_cap_one_shrink_descendants:
         apply (rule_tac P="\<lambda>s. valid_mdb s \<and> cdt s = cdt' \<and> cdt pres = cdt' \<and> slot \<in> CSpaceAcc_A.descendants_of p (cdt s)
                                \<and> mdb_cte_at (swp (cte_wp_at ((\<noteq>) cap.NullCap)) s) (cdt s)"
                      in hoare_weaken_pre)
-         apply (rule_tac Q ="\<lambda>r s. Q r s \<and>  (mdb_cte_at (swp (cte_wp_at ((\<noteq>) cap.NullCap)) s) (cdt s))" for Q in hoare_strengthen_post)
+         apply (rule_tac Q'="\<lambda>r s. Q r s \<and>  (mdb_cte_at (swp (cte_wp_at ((\<noteq>) cap.NullCap)) s) (cdt s))" for Q in hoare_strengthen_post)
           apply (rule hoare_vcg_conj_lift)
            apply (rule delete_cdt_slot_shrink_descendants[where y= "cdt pres" and p = p])
-          apply (rule_tac Q="\<lambda>s. mdb_cte_at (swp (cte_wp_at ((\<noteq>)cap.NullCap)) s ) cdt'" in hoare_weaken_pre)
+          apply (rule_tac P'="\<lambda>s. mdb_cte_at (swp (cte_wp_at ((\<noteq>)cap.NullCap)) s ) cdt'" in hoare_weaken_pre)
            apply (case_tac slot)
            apply (clarsimp simp:set_cdt_def get_def put_def bind_def valid_def mdb_cte_at_def)
           apply (assumption)
@@ -486,7 +486,7 @@ lemma dcorres_deleting_irq_handler:
   apply (rule corres_guard_imp)
   apply (rule corres_split[OF dcorres_get_irq_slot])
     apply (simp, rule delete_cap_simple_corres,simp)
-    apply (rule hoare_weaken_pre [where Q="invs and valid_etcbs"])
+    apply (rule hoare_weaken_pre[where P'="invs and valid_etcbs"])
     including classic_wp_pre
     apply (wpsimp simp:get_irq_slot_def)+
     apply (rule irq_node_image_not_idle)
@@ -697,7 +697,7 @@ lemma dcorres_set_vm_root:
      apply wp+
       apply wpc
        apply (wp do_machine_op_wp | clarsimp)+
-     apply (rule_tac Q = "\<lambda>_ s. transform s = cs" in hoare_post_imp)
+     apply (rule_tac Q'="\<lambda>_ s. transform s = cs" in hoare_post_imp)
       apply simp
      apply (wpsimp wp: whenE_wp do_machine_op_wp [OF allI] hoare_drop_imps find_pd_for_asid_inv
                 simp: arm_context_switch_def get_hw_asid_def load_hw_asid_def if_apply_def2)+
@@ -796,7 +796,7 @@ lemma dcorres_flush_page:
         apply (rule hoare_conjI,rule hoare_drop_imp)
          apply (wp do_machine_op_wp|clarsimp simp:load_hw_asid_def)+
       apply (wpc|wp)+
-     apply (rule_tac Q="\<lambda>rv s. transform s = cs" in hoare_strengthen_post)
+     apply (rule_tac Q'="\<lambda>rv s. transform s = cs" in hoare_strengthen_post)
       apply (wp|clarsimp)+
 done
 
@@ -821,7 +821,7 @@ lemma dcorres_flush_table:
         apply (rule hoare_conjI,rule hoare_drop_imp)
          apply (wp do_machine_op_wp|clarsimp simp:load_hw_asid_def)+
       apply (wpc|wp)+
-     apply (rule_tac Q="\<lambda>rv s. transform s = cs" in hoare_strengthen_post)
+     apply (rule_tac Q'="\<lambda>rv s. transform s = cs" in hoare_strengthen_post)
       apply (wp|clarsimp)+
 done
 
@@ -1403,10 +1403,10 @@ lemma remain_pt_pd_relation:
   apply (subgoal_tac "ptr\<noteq> y")
    apply (simp add: store_pte_def)
    apply wp
-     apply (rule_tac Q = "ko_at (ArchObj (arch_kernel_obj.PageTable rv)) (ptr && ~~ mask pt_bits)
+     apply (rule_tac P'="ko_at (ArchObj (arch_kernel_obj.PageTable rv)) (ptr && ~~ mask pt_bits)
                 and  pt_page_relation (y && ~~ mask pt_bits) pg_id y S" in hoare_weaken_pre)
       apply (clarsimp simp: set_pt_def)
-      apply (rule_tac Q = "ko_at (ArchObj (arch_kernel_obj.PageTable rv)) (ptr && ~~ mask pt_bits)
+      apply (rule_tac P'="ko_at (ArchObj (arch_kernel_obj.PageTable rv)) (ptr && ~~ mask pt_bits)
                    and  pt_page_relation (y && ~~ mask pt_bits) pg_id y S" in hoare_weaken_pre)
        apply (clarsimp simp: valid_def set_object_def get_object_def in_monad)
        apply (drule_tac x= y in bspec,simp)
@@ -1427,10 +1427,10 @@ lemma remain_pd_section_relation:
        \<lbrace>\<lambda>r s. pd_section_relation (y && ~~ mask pd_bits) sid y s\<rbrace>"
   apply (simp add: store_pde_def)
   apply wp
-    apply (rule_tac Q = "ko_at (ArchObj (arch_kernel_obj.PageDirectory rv)) (ptr && ~~ mask pd_bits)
+    apply (rule_tac P'="ko_at (ArchObj (arch_kernel_obj.PageDirectory rv)) (ptr && ~~ mask pd_bits)
                   and pd_section_relation (y && ~~ mask pd_bits) sid y " in hoare_weaken_pre)
      apply (clarsimp simp: set_pd_def)
-     apply (rule_tac Q = "ko_at (ArchObj (arch_kernel_obj.PageDirectory rv)) (ptr && ~~ mask pd_bits)
+     apply (rule_tac P'="ko_at (ArchObj (arch_kernel_obj.PageDirectory rv)) (ptr && ~~ mask pd_bits)
                 and pd_section_relation (y && ~~ mask pd_bits) sid y " in hoare_weaken_pre)
       apply (clarsimp simp: valid_def set_object_def get_object_def in_monad)
       apply (clarsimp simp: pd_section_relation_def dest!: ucast_inj_mask | rule conjI)+
@@ -1449,10 +1449,10 @@ lemma remain_pd_super_section_relation:
        \<lbrace>\<lambda>r s. pd_super_section_relation (y && ~~ mask pd_bits) sid y s\<rbrace>"
   apply (simp add: store_pde_def)
   apply wp
-    apply (rule_tac Q = "ko_at (ArchObj (arch_kernel_obj.PageDirectory rv)) (ptr && ~~ mask pd_bits)
+    apply (rule_tac P'="ko_at (ArchObj (arch_kernel_obj.PageDirectory rv)) (ptr && ~~ mask pd_bits)
                and pd_super_section_relation (y && ~~ mask pd_bits) sid y " in hoare_weaken_pre)
      apply (clarsimp simp: set_pd_def)
-     apply (rule_tac Q = "ko_at (ArchObj (arch_kernel_obj.PageDirectory rv)) (ptr && ~~ mask pd_bits)
+     apply (rule_tac P'="ko_at (ArchObj (arch_kernel_obj.PageDirectory rv)) (ptr && ~~ mask pd_bits)
                and pd_super_section_relation (y && ~~ mask pd_bits) sid y " in hoare_weaken_pre)
       apply (clarsimp simp: valid_def set_object_def get_object_def in_monad)
       apply (clarsimp simp: pd_super_section_relation_def dest!: ucast_inj_mask | rule conjI)+
@@ -2040,7 +2040,7 @@ lemma pd_pt_relation_page_table_mapped_wp:
     apply (simp add:get_pde_def)
     apply wp
    apply (simp add:validE_def)
-   apply (rule hoare_strengthen_post[where Q="\<lambda>rv. page_table_at w"])
+   apply (rule hoare_strengthen_post[where Q'="\<lambda>rv. page_table_at w"])
     apply wp
    apply (clarsimp simp:pd_pt_relation_def obj_at_def)+
  done
@@ -3416,7 +3416,7 @@ proof (induct arbitrary: S rule: rec_del.induct,
       apply (wp cutMon_validE_R_drop rec_del_invs
                  | simp add: not_idle_thread_def
                  | strengthen invs_weak_valid_mdb invs_valid_idle_strg
-                 | rule hoare_vcg_E_elim[rotated])+
+                 | rule hoare_vcg_conj_elimE[rotated])+
 
     done
 next

--- a/proof/drefine/Intent_DR.thy
+++ b/proof/drefine/Intent_DR.thy
@@ -1091,7 +1091,7 @@ lemma get_tcb_mrs_wp:
   apply (rule_tac P = "tcb = obj" in hoare_gen_asm)
    apply (clarsimp simp: get_tcb_mrs_def Let_def get_tcb_message_info_def Suc_leI[OF msg_registers_lt_msg_max_length]
                    split del:if_split)
-    apply (rule_tac Q="\<lambda>buf_mrs s. buf_mrs =
+    apply (rule_tac Q'="\<lambda>buf_mrs s. buf_mrs =
       (get_ipc_buffer_words (machine_state sa) obj ([Suc (length msg_registers)..<msg_max_length] @ [msg_max_length]))"
       in hoare_strengthen_post)
     apply (rule get_ipc_buffer_words[where thread=thread ])

--- a/proof/drefine/Interrupt_DR.thy
+++ b/proof/drefine/Interrupt_DR.thy
@@ -474,7 +474,7 @@ lemma dcorres_invoke_irq_control_body:
    apply (simp add:valid_cap_def cap_aligned_def word_bits_def)
    apply (rule hoare_pre)
     apply (rule hoare_vcg_conj_lift)
-     apply (rule_tac Q = "\<lambda>r s. cte_wp_at ((=) cap.IRQControlCap) (aa,ba) s
+     apply (rule_tac Q'="\<lambda>r s. cte_wp_at ((=) cap.IRQControlCap) (aa,ba) s
                                 \<and> is_original_cap s (aa, ba)" in hoare_strengthen_post)
       apply (wp set_irq_state_cte_wp_at set_irq_state_original)
      apply (simp add:cte_wp_at_def should_be_parent_of_def)
@@ -578,7 +578,7 @@ lemma cte_wp_at_neq_slot_cap_delete_one:
            apply (wp dxo_wp_weak | simp)+
          apply (clarsimp simp:set_cdt_def)
          apply (wp | clarsimp)+
-      apply (rule_tac Q = "\<lambda>r s. cte_wp_at P slot s \<and> cte_at slot' s" in hoare_strengthen_post)
+      apply (rule_tac Q'="\<lambda>r s. cte_wp_at P slot s \<and> cte_at slot' s" in hoare_strengthen_post)
        apply (rule hoare_vcg_conj_lift)
         apply wp
        apply (wp get_cap_cte)

--- a/proof/drefine/Ipc_DR.thy
+++ b/proof/drefine/Ipc_DR.thy
@@ -581,7 +581,7 @@ lemma recv_signal_corres:
        apply (rule corres_dummy_return_l)
        apply (rule corres_split[OF set_register_corres corres_dummy_set_notification])
         apply (wp |clarsimp)+
-     apply (rule_tac Q="\<lambda>r. ko_at (kernel_object.Notification r) word1 and valid_state" in hoare_strengthen_post)
+     apply (rule_tac Q'="\<lambda>r. ko_at (kernel_object.Notification r) word1 and valid_state" in hoare_strengthen_post)
       apply (wp get_simple_ko_ko_at | clarsimp)+
      apply (rule valid_objs_valid_ntfn_simp)
       apply (clarsimp simp:valid_objs_valid_ntfn_simp valid_state_def valid_pspace_def)
@@ -815,7 +815,7 @@ lemma cancel_ipc_valid_idle:
   apply (clarsimp simp: cancel_ipc_def)
   apply (wp not_idle_after_blocked_cancel_ipc not_idle_after_reply_cancel_ipc
             not_idle_thread_cancel_signal | wpc | simp)+
-   apply (rule hoare_strengthen_post[where Q="\<lambda>r. st_tcb_at ((=) r) obj_id'
+   apply (rule hoare_strengthen_post[where Q'="\<lambda>r. st_tcb_at ((=) r) obj_id'
                                                   and not_idle_thread obj_id' and invs"])
     apply (wp gts_sp)
    apply (clarsimp simp: invs_def valid_state_def valid_pspace_def not_idle_thread_def | rule conjI)+
@@ -1207,7 +1207,7 @@ lemma ipc_buffer_wp_at_cap_insert[wp]:
   "\<lbrace>ipc_buffer_wp_at buf t :: det_state \<Rightarrow> bool \<rbrace> cap_insert cap' (slot_ptr, slot_idx) a \<lbrace>\<lambda>r. ipc_buffer_wp_at buf t\<rbrace>"
   apply (simp add:cap_insert_def set_untyped_cap_as_full_def)
   apply (wp|simp split del:if_split)+
-           apply (rule_tac Q = "\<lambda>r. ipc_buffer_wp_at buf t" in hoare_strengthen_post)
+           apply (rule_tac Q'="\<lambda>r. ipc_buffer_wp_at buf t" in hoare_strengthen_post)
             apply wp
            apply (clarsimp simp:ipc_buffer_wp_at_def)
           apply (wp get_cap_inv hoare_drop_imp)+
@@ -1355,7 +1355,7 @@ next
         apply simp
        apply (clarsimp simp:cte_wp_at_caps_of_state)
       apply (subst imp_conjR)
-      apply (rule hoare_vcg_conj_liftE_R)
+      apply (rule hoare_vcg_conj_liftE_R')
        apply (rule derive_cap_is_derived)
       apply (rule derive_cap_is_derived_foo)
      apply wp+
@@ -1870,7 +1870,7 @@ lemma ipc_buffer_wp_at_copy_mrs[wp]:
       prefer 2
       apply fastforce
      apply (clarsimp simp:ipc_buffer_wp_at_def)
-    apply (rule_tac Q="\<lambda>rv. ipc_buffer_wp_at buf t" in hoare_strengthen_post)
+    apply (rule_tac Q'="\<lambda>rv. ipc_buffer_wp_at buf t" in hoare_strengthen_post)
      apply (wp mapM_wp)
      apply fastforce
     apply (clarsimp)
@@ -1936,7 +1936,7 @@ lemma corres_complete_ipc_transfer:
             apply (rule hoare_strengthen_postE_R)
              apply (rule validE_validE_R)
              apply (rule hoare_vcg_conj_liftE1[OF lookup_extra_caps_srcs])
-             apply (rule hoare_post_imp_dc2_actual[OF lookup_extra_caps_inv[where P=valid_objs]])
+             apply (rule hoare_post_impE_R_dc_actual[OF lookup_extra_caps_inv[where P=valid_objs]])
             apply clarsimp
             apply (drule(1) bspec)
             apply (clarsimp simp:cte_wp_at_caps_of_state)
@@ -2236,9 +2236,9 @@ lemma do_reply_transfer_corres:
                    hoare_drop_imps thread_set_cur_thread_idle_thread
                    thread_set_valid_idle
                    | simp add:not_idle_thread_def)+
-    apply (rule_tac Q = "\<lambda>r s. invs s \<and> not_idle_thread recver s \<and> valid_etcbs s
+    apply (rule_tac Q'="\<lambda>r s. invs s \<and> not_idle_thread recver s \<and> valid_etcbs s
         \<and> tcb_at recver s "
-      in  hoare_strengthen_post)
+      in hoare_strengthen_post)
      apply (clarsimp simp:not_idle_thread_def)
      apply (wp cap_delete_one_reply_st_tcb_at)+
     apply (clarsimp simp:not_idle_thread_def invs_valid_idle st_tcb_at_tcb_at)
@@ -2261,7 +2261,7 @@ lemma set_endpoint_valid_irq_node[wp]:
   apply wp
    apply (simp add:set_simple_ko_def)
    apply (wp hoare_vcg_all_lift)
-      apply (rule_tac Q="\<lambda>s. \<forall>irq. cap_table_at 0 (interrupt_irq_node s irq) s \<and> ep_at w s" in hoare_weaken_pre)
+      apply (rule_tac P'="\<lambda>s. \<forall>irq. cap_table_at 0 (interrupt_irq_node s irq) s \<and> ep_at w s" in hoare_weaken_pre)
        apply (clarsimp simp: set_object_def get_object_def in_monad get_def put_def bind_def
                              return_def valid_def obj_at_def)
        apply (drule_tac x = irq in spec)
@@ -2397,7 +2397,7 @@ lemma dcorres_receive_sync:
             apply (rule set_thread_state_corres[unfolded tcb_slots])
            apply wp
           apply (wp hoare_drop_imps gts_st_tcb_at | simp add:not_idle_thread_def)+
-         apply (rule_tac Q="\<lambda>fault. valid_mdb and valid_objs and pspace_aligned
+         apply (rule_tac Q'="\<lambda>fault. valid_mdb and valid_objs and pspace_aligned
            and pspace_distinct and not_idle_thread t and not_idle_thread thread
            and valid_idle and valid_irq_node and (\<lambda>s. cur_thread s \<noteq> idle_thread s)
            and tcb_at t and tcb_at thread
@@ -2651,7 +2651,7 @@ lemma send_sync_ipc_corres:
               apply (rule corres_alternate2)
               apply (rule corres_return_trivial)
              apply wp
-            apply (rule_tac Q="\<lambda>r. valid_mdb and valid_idle and valid_objs
+            apply (rule_tac Q'="\<lambda>r. valid_mdb and valid_idle and valid_objs
                           and not_idle_thread thread and not_idle_thread y and tcb_at thread and tcb_at y
                           and st_tcb_at runnable thread and valid_etcbs"
                           in hoare_strengthen_post[rotated])
@@ -2692,8 +2692,8 @@ lemma not_idle_thread_resolve_address_bits:
   apply (rule validE_R_validE)
   apply (rule_tac hoare_weaken_preE_R)
    apply (rule validE_validE_R)
-   apply (rule_tac Q="\<lambda>r. valid_global_refs and valid_objs and valid_idle and valid_irq_node and ex_cte_cap_to (fst r)"
-    in hoare_strengthen_postE[where E="\<lambda>x y. True"])
+   apply (rule_tac Q'="\<lambda>r. valid_global_refs and valid_objs and valid_idle and valid_irq_node and ex_cte_cap_to (fst r)"
+    in hoare_strengthen_postE[where E'="\<lambda>x y. True"])
      apply (wp rab_cte_cap_to)
     apply clarsimp
     apply (drule ex_cte_cap_to_not_idle, auto simp: not_idle_thread_def)[1]

--- a/proof/drefine/KHeap_DR.thy
+++ b/proof/drefine/KHeap_DR.thy
@@ -1384,10 +1384,10 @@ lemma valid_idle_fast_finalise[wp]:
   apply (case_tac p)
              apply simp_all
      apply (wp,simp add:valid_state_def invs_def)
-    apply (rule hoare_post_imp[where Q="%r. invs"])
+    apply (rule hoare_post_imp[where Q'="%r. invs"])
      apply (clarsimp simp:valid_state_def invs_def,wp cancel_all_ipc_invs)
     apply clarsimp
-   apply (rule hoare_post_imp[where Q="%r. invs"])
+   apply (rule hoare_post_imp[where Q'="%r. invs"])
     apply (clarsimp simp:valid_state_def invs_def,wp unbind_maybe_notification_invs cancel_all_signals_invs)
    apply clarsimp
   apply wp
@@ -1398,10 +1398,10 @@ lemma valid_irq_node_fast_finalise[wp]:
   "\<lbrace>invs\<rbrace> IpcCancel_A.fast_finalise p q \<lbrace>%r. valid_irq_node\<rbrace>"
   apply (case_tac p; simp)
      apply (wp,simp add:valid_state_def invs_def)
-    apply (rule hoare_post_imp[where Q="%r. invs"])
+    apply (rule hoare_post_imp[where Q'="%r. invs"])
       apply (clarsimp simp:valid_state_def invs_def,wp cancel_all_ipc_invs)
       apply clarsimp
-    apply (rule hoare_post_imp[where Q="%r. invs"])
+    apply (rule hoare_post_imp[where Q'="%r. invs"])
       apply (clarsimp simp:valid_state_def invs_def,wp unbind_maybe_notification_invs cancel_all_signals_invs)
       apply clarsimp
   apply wp
@@ -1412,10 +1412,10 @@ lemma invs_mdb_fast_finalise[wp]:
   "\<lbrace>invs\<rbrace> IpcCancel_A.fast_finalise p q \<lbrace>%r. valid_mdb\<rbrace>"
   apply (case_tac p; simp)
      apply (wp,simp add:valid_state_def invs_def)
-    apply (rule hoare_post_imp[where Q="%r. invs"])
+    apply (rule hoare_post_imp[where Q'="%r. invs"])
       apply (clarsimp simp:valid_state_def invs_def,wp cancel_all_ipc_invs)
       apply clarsimp
-    apply (rule hoare_post_imp[where Q="%r. invs"])
+    apply (rule hoare_post_imp[where Q'="%r. invs"])
       apply (clarsimp simp:valid_state_def invs_def,wp unbind_maybe_notification_invs cancel_all_signals_invs)
       apply clarsimp
   apply wp
@@ -2745,7 +2745,7 @@ lemma get_tcb_reply_cap_wp_cte_at:
     "\<lbrace>tcb_at sid and valid_objs and cte_wp_at ((\<noteq>) cap.NullCap) (sid, tcb_cnode_index 2)\<rbrace> CSpaceAcc_A.get_cap (sid, tcb_cnode_index 2)
     \<lbrace>\<lambda>rv. cte_wp_at ((\<noteq>) cap.NullCap) (obj_ref_of rv, tcb_cnode_index 2)\<rbrace>"
   apply (rule hoare_post_imp
-     [where Q="\<lambda>r. cte_wp_at (\<lambda>c. r \<noteq> cap.NullCap) (sid,tcb_cnode_index 2)
+     [where Q'="\<lambda>r. cte_wp_at (\<lambda>c. r \<noteq> cap.NullCap) (sid,tcb_cnode_index 2)
        and tcb_at sid and valid_objs and cte_wp_at ((=) r) (sid,tcb_cnode_index 2)"])
    apply clarsimp
    apply (frule cte_wp_tcb_cap_valid)
@@ -2759,7 +2759,7 @@ lemma get_tcb_reply_cap_wp_master_cap:
   "\<lbrace>tcb_at sid and valid_objs and cte_wp_at ((\<noteq>) cap.NullCap) (sid,tcb_cnode_index 2) \<rbrace> CSpaceAcc_A.get_cap (sid, tcb_cnode_index 2)
     \<lbrace>\<lambda>rv s. (is_master_reply_cap rv)  \<rbrace>"
   apply (rule hoare_post_imp
-     [where Q="\<lambda>r. cte_wp_at (\<lambda>c. r \<noteq> cap.NullCap) (sid,tcb_cnode_index 2)
+     [where Q'="\<lambda>r. cte_wp_at (\<lambda>c. r \<noteq> cap.NullCap) (sid,tcb_cnode_index 2)
        and tcb_at sid and valid_objs and cte_wp_at ((=) r) (sid,tcb_cnode_index 2)"])
    apply clarsimp
    apply (frule cte_wp_tcb_cap_valid)
@@ -2773,7 +2773,7 @@ lemma get_tcb_reply_cap_wp_original_cap:
     "\<lbrace>tcb_at sid and valid_objs and cte_wp_at ((\<noteq>) cap.NullCap) (sid,tcb_cnode_index 2) and valid_mdb \<rbrace> CSpaceAcc_A.get_cap (sid, tcb_cnode_index 2)
     \<lbrace>\<lambda>rv s. is_original_cap s (obj_ref_of rv, tcb_cnode_index 2)\<rbrace>"
   apply (rule hoare_post_imp
-     [where Q="\<lambda>r. cte_wp_at (\<lambda>c. r \<noteq> cap.NullCap) (sid,tcb_cnode_index 2) and valid_mdb
+     [where Q'="\<lambda>r. cte_wp_at (\<lambda>c. r \<noteq> cap.NullCap) (sid,tcb_cnode_index 2) and valid_mdb
        and tcb_at sid and valid_objs and cte_wp_at ((=) r) (sid,tcb_cnode_index 2)"])
    apply (rename_tac rv s)
    apply clarsimp
@@ -2797,7 +2797,7 @@ lemma get_tcb_reply_cap_wp_obj_ref:
     "\<lbrace>tcb_at sid and valid_objs and cte_wp_at ((\<noteq>) cap.NullCap) (sid,tcb_cnode_index 2) \<rbrace> CSpaceAcc_A.get_cap (sid, tcb_cnode_index 2)
     \<lbrace>\<lambda>rv s. (obj_ref_of rv = sid) \<rbrace>"
   apply (rule hoare_post_imp
-     [where Q="\<lambda>r. cte_wp_at (\<lambda>c. r \<noteq> cap.NullCap) (sid,tcb_cnode_index 2)
+     [where Q'="\<lambda>r. cte_wp_at (\<lambda>c. r \<noteq> cap.NullCap) (sid,tcb_cnode_index 2)
        and tcb_at sid and valid_objs and cte_wp_at ((=) r) (sid,tcb_cnode_index 2)"])
    apply clarsimp
    apply (frule cte_wp_tcb_cap_valid)
@@ -2944,7 +2944,7 @@ lemma delete_cap_simple_corres:
            apply (rule always_empty_slot_corres)
           apply simp
          apply wp
-         apply (rule hoare_post_imp [where Q="\<lambda>r. valid_mdb and valid_idle
+         apply (rule hoare_post_imp[where Q'="\<lambda>r. valid_mdb and valid_idle
                       and  not_idle_thread (fst slot) and valid_etcbs"])
           apply (simp add:valid_mdb_def weak_valid_mdb_def)
          apply wp
@@ -2956,7 +2956,7 @@ lemma delete_cap_simple_corres:
 
 lemma cap_delete_one_valid_mdb[wp]:
   "\<lbrace>invs and emptyable slot\<rbrace> cap_delete_one slot \<lbrace>\<lambda>yc. valid_mdb\<rbrace>"
-  apply (rule hoare_post_imp [where Q="%x. invs"])
+  apply (rule hoare_post_imp[where Q'="%x. invs"])
    apply (simp add:invs_def valid_state_def valid_pspace_def)
   apply (rule delete_one_invs)
   done
@@ -3375,9 +3375,9 @@ lemma not_idle_thread_resolve_address_bits:
   apply (rule validE_R_validE)
   apply (rule_tac hoare_weaken_preE_R)
    apply (rule validE_validE_R)
-   apply (rule_tac Q="\<lambda>r. valid_etcbs and valid_global_refs and valid_objs and valid_idle and
+   apply (rule_tac Q'="\<lambda>r. valid_etcbs and valid_global_refs and valid_objs and valid_idle and
                           valid_irq_node and ex_cte_cap_to (fst r)"
-          in hoare_strengthen_postE[where E="\<lambda>x y. True"])
+          in hoare_strengthen_postE[where E'="\<lambda>x y. True"])
      apply (wp rab_cte_cap_to)
     apply (auto intro: ex_cte_cap_wp_to_not_idle)[2]
   apply (clarsimp simp:ex_cte_cap_to_def)

--- a/proof/drefine/Refine_D.thy
+++ b/proof/drefine/Refine_D.thy
@@ -48,7 +48,7 @@ lemma dcorres_call_kernel:
           apply (clarsimp simp: when_def split: option.splits)
           apply (rule handle_interrupt_corres[simplified dc_def])
          apply ((wp | simp)+)[3]
-      apply (rule hoare_post_imp_dc2E, rule handle_event_invs_and_valid_sched)
+      apply (rule hoare_post_impE_E_dc, rule handle_event_invs_and_valid_sched)
       apply (clarsimp simp: invs_def valid_state_def)
       apply (simp add: conj_comms if_apply_def2 non_kernel_IRQs_def
              | wp | strengthen valid_etcbs_sched valid_idle_invs_strg)+

--- a/proof/drefine/Syscall_DR.thy
+++ b/proof/drefine/Syscall_DR.thy
@@ -1645,9 +1645,9 @@ lemma handle_event_corres:
         apply wp[1]
         apply clarsimp
         apply (frule (1) ct_running_not_idle_etc)
-        apply (fastforce simp: st_tcb_at_def obj_at_def generates_pending_def gets_def get_def
-                               valid_fault_def
-                        split: Structures_A.thread_state.splits)+
+        apply (fastforce simp: st_tcb_at_def obj_at_def generates_pending_def valid_fault_def
+                        split: Structures_A.thread_state.splits)
+       apply wpsimp+
      apply (rule corres_symb_exec_r[OF handle_fault_corres])
        apply wp[1]
        apply clarsimp

--- a/proof/drefine/Tcb_DR.thy
+++ b/proof/drefine/Tcb_DR.thy
@@ -568,9 +568,9 @@ lemma restart_corres:
             apply wp
            apply (simp add:not_idle_thread_def)
            apply ((wp|wps)+)[2]
-         apply (rule_tac Q="(=) s' and invs" in  hoare_weaken_pre)
+         apply (rule_tac P'="(=) s' and invs" in hoare_weaken_pre)
           apply (rule hoare_strengthen_post
-             [where Q="\<lambda>r. invs and tcb_at obj_id and not_idle_thread obj_id and valid_etcbs"])
+             [where Q'="\<lambda>r. invs and tcb_at obj_id and not_idle_thread obj_id and valid_etcbs"])
            apply (simp add:not_idle_thread_def)
            apply (wp)
              apply (clarsimp simp:invs_def valid_state_def valid_pspace_def
@@ -701,7 +701,7 @@ lemma not_idle_after_restart [wp]:
    apply (simp add:cancel_ipc_def)
    apply (wp not_idle_after_blocked_cancel_ipc not_idle_after_reply_cancel_ipc
              not_idle_thread_cancel_signal | wpc)+
-   apply (rule hoare_strengthen_post[where Q="\<lambda>r. st_tcb_at ((=) r) obj_id'
+   apply (rule hoare_strengthen_post[where Q'="\<lambda>r. st_tcb_at ((=) r) obj_id'
                                                   and not_idle_thread obj_id' and invs"])
     apply (wp gts_sp)
    apply (clarsimp simp: invs_def valid_state_def valid_pspace_def not_idle_thread_def | rule conjI)+
@@ -788,7 +788,7 @@ lemma cnode_cap_unique_bits:
     CSpaceAcc_A.get_cap (ba, c)
   \<lbrace>\<lambda>rv s. (Structures_A.is_cnode_cap rv \<and> obj_refs rv = obj_refs cap) \<longrightarrow> (bits_of rv = bits_of cap)\<rbrace>"
   apply (rule hoare_pre)
-   apply (rule_tac Q="\<lambda>r s. (\<forall>a b. \<not> cte_wp_at (\<lambda>c. obj_refs c = obj_refs cap \<and>
+   apply (rule_tac Q'="\<lambda>r s. (\<forall>a b. \<not> cte_wp_at (\<lambda>c. obj_refs c = obj_refs cap \<and>
                                                     table_cap_ref c \<noteq> table_cap_ref cap) (a, b) s)
                             \<and> valid_cap cap s \<and> valid_objs s
                             \<and> valid_objs s \<and> cte_wp_at (\<lambda>x. x = r) (ba,c) s"
@@ -1057,8 +1057,8 @@ lemma dcorres_tcb_update_ipc_buffer:
                apply simp
               apply wpsimp+
      apply (rule validE_validE_R)
-     apply (rule_tac Q = "\<lambda>r s. invs s \<and> valid_etcbs s \<and> not_idle_thread obj_id' s  \<and> tcb_at obj_id' s"
-        in hoare_strengthen_postE[where E="\<lambda>x. \<top>"])
+     apply (rule_tac Q'="\<lambda>r s. invs s \<and> valid_etcbs s \<and> not_idle_thread obj_id' s  \<and> tcb_at obj_id' s"
+        in hoare_strengthen_postE[where E'="\<lambda>x. \<top>"])
        apply (simp add:not_idle_thread_def)
        apply (wp cap_delete_cte_at cap_delete_deletes)
       apply (clarsimp simp:invs_def valid_state_def not_idle_thread_def)
@@ -1100,7 +1100,7 @@ lemma dcorres_tcb_update_ipc_buffer:
                apply (rule dcorres_insert_cap_combine)
                apply clarsimp
               apply wp
-             apply (rule_tac Q = "\<lambda>r s. cte_wp_at ((=) cap.NullCap) (obj_id', tcb_cnode_index 4) s
+             apply (rule_tac Q'="\<lambda>r s. cte_wp_at ((=) cap.NullCap) (obj_id', tcb_cnode_index 4) s
                                         \<and> cte_wp_at (\<lambda>_. True) (ab, ba) s
                                         \<and> valid_global_refs s \<and> valid_idle s \<and> valid_irq_node s
                                         \<and> valid_mdb s \<and> valid_objs s\<and> not_idle_thread ab s \<and> valid_etcbs s
@@ -1139,10 +1139,10 @@ lemma dcorres_tcb_update_ipc_buffer:
      apply (simp add: transform_tcb_slot_4)
      apply (rule hoare_strengthen_postE[OF validE_R_validE[OF hoareE_R_TrueI]])
       apply simp+
-    apply (rule_tac Q = "\<lambda>r s. invs s \<and> valid_etcbs s \<and> not_idle_thread (fst a') s \<and> tcb_at obj_id' s
+    apply (rule_tac Q'="\<lambda>r s. invs s \<and> valid_etcbs s \<and> not_idle_thread (fst a') s \<and> tcb_at obj_id' s
       \<and> not_idle_thread obj_id' s \<and> not_idle_thread ab s \<and> cte_wp_at (\<lambda>a. True) (ab,ba) s
       \<and> cte_wp_at (\<lambda>c. c = cap.NullCap) (obj_id', tcb_cnode_index 4) s \<and> is_aligned a msg_align_bits"
-      in hoare_strengthen_postE[where E="\<lambda>x. \<top>"])
+      in hoare_strengthen_postE[where E'="\<lambda>x. \<top>"])
       apply (simp add:not_idle_thread_def)
       apply (wp cap_delete_cte_at cap_delete_deletes cap_delete_valid_cap)
      apply (clarsimp simp:invs_valid_objs invs_mdb invs_valid_idle)
@@ -1207,7 +1207,7 @@ lemma dcorres_tcb_update_vspace_root:
              apply (simp add: transform_cap_def)
             apply wp
            apply (simp add: same_object_as_def)
-           apply (rule_tac Q = "\<lambda>r s. cte_wp_at ((=) cap.NullCap) (obj_id', tcb_cnode_index (Suc 0)) s \<and> cte_wp_at (\<lambda>_. True) (ba, c) s
+           apply (rule_tac Q'="\<lambda>r s. cte_wp_at ((=) cap.NullCap) (obj_id', tcb_cnode_index (Suc 0)) s \<and> cte_wp_at (\<lambda>_. True) (ba, c) s
              \<and>  valid_global_refs s \<and> valid_idle s \<and> valid_irq_node s \<and> valid_mdb s \<and> not_idle_thread ba s \<and> valid_objs s \<and> valid_etcbs s
              \<and> ((is_thread_cap r \<and> obj_ref_of r = obj_id') \<longrightarrow> ex_cte_cap_wp_to (\<lambda>_. True) (obj_id', tcb_cnode_index (Suc 0)) s)"
              in hoare_strengthen_post)
@@ -1224,10 +1224,10 @@ lemma dcorres_tcb_update_vspace_root:
       apply (rule hoare_drop_imp)
       apply (wp | simp)+
     apply (rule validE_validE_R)
-    apply (rule_tac Q = "\<lambda>r s. invs s \<and> valid_etcbs s \<and> not_idle_thread ba s \<and>
+    apply (rule_tac Q'="\<lambda>r s. invs s \<and> valid_etcbs s \<and> not_idle_thread ba s \<and>
                  not_idle_thread (fst a') s \<and> cte_wp_at (\<lambda>_. True) (ba, c) s \<and>
                  cte_wp_at (\<lambda>c. c = cap.NullCap) (obj_id', tcb_cnode_index (Suc 0)) s"
-          in hoare_strengthen_postE[where E="\<lambda>x. \<top>"])
+          in hoare_strengthen_postE[where E'="\<lambda>x. \<top>"])
       apply (simp add: not_idle_thread_def)
       apply (wp cap_delete_cte_at cap_delete_deletes)
      apply (clarsimp simp: invs_def valid_state_def valid_pspace_def)
@@ -1293,7 +1293,7 @@ lemma dcorres_tcb_update_cspace_root:
              apply (rule dcorres_insert_cap_combine[folded alternative_com])
              apply (clarsimp simp:is_cap_simps)
             apply wp
-           apply (rule_tac Q = "\<lambda>r s. cte_wp_at ((=) cap.NullCap) (obj_id', tcb_cnode_index 0) s \<and> cte_wp_at (\<lambda>_. True) (ba, c) s
+           apply (rule_tac Q'="\<lambda>r s. cte_wp_at ((=) cap.NullCap) (obj_id', tcb_cnode_index 0) s \<and> cte_wp_at (\<lambda>_. True) (ba, c) s
              \<and>  valid_global_refs s \<and> valid_idle s \<and> valid_irq_node s \<and> valid_mdb s \<and> not_idle_thread ba s \<and> valid_objs s \<and> valid_etcbs s
              \<and> ((is_thread_cap r \<and> obj_ref_of r = obj_id') \<longrightarrow> ex_cte_cap_wp_to (\<lambda>_. True) (obj_id', tcb_cnode_index 0) s)"
              in hoare_strengthen_post)
@@ -1316,11 +1316,11 @@ lemma dcorres_tcb_update_cspace_root:
      apply clarsimp
      apply wp
     apply (clarsimp simp:conj_comms)
-    apply (rule_tac Q = "\<lambda>r s. invs s \<and> valid_etcbs s \<and> not_idle_thread ba s \<and> valid_cap aaa s \<and>
+    apply (rule_tac Q'="\<lambda>r s. invs s \<and> valid_etcbs s \<and> not_idle_thread ba s \<and> valid_cap aaa s \<and>
                  not_idle_thread (fst a') s \<and> cte_wp_at (\<lambda>_. True) (ba, c) s \<and>
                  cte_wp_at (\<lambda>c. c = cap.NullCap) (obj_id', tcb_cnode_index 0) s \<and>
                  no_cap_to_obj_dr_emp aaa s"
-            in hoare_strengthen_postE[where E = "\<lambda>r. \<top>"])
+            in hoare_strengthen_postE[where E'="\<lambda>r. \<top>"])
       apply (simp add:not_idle_thread_def)
       apply (wp cap_delete_cte_at cap_delete_deletes cap_delete_valid_cap)
      apply (simp add:invs_valid_objs)
@@ -1623,7 +1623,7 @@ lemma dcorres_thread_control:
                   | intro conjI allI impI
                   | clarsimp split: option.split)+
      apply (wp case_option_wpE)+
-    apply (rule_tac Q="\<lambda>_. ?P" in hoare_strengthen_post[rotated])
+    apply (rule_tac Q'="\<lambda>_. ?P" in hoare_strengthen_post[rotated])
      apply (clarsimp simp: is_valid_vtable_root_def is_cnode_or_valid_arch_def
                            is_arch_cap_def not_idle_thread_def emptyable_def
                     split: option.splits)

--- a/proof/drefine/Untyped_DR.thy
+++ b/proof/drefine/Untyped_DR.thy
@@ -1500,7 +1500,7 @@ lemma invoke_untyped_corres:
                     retype_region_obj_at[THEN hoare_vcg_const_imp_lift]
                     retype_region_caps_of[where sza = "\<lambda>_. sz"]
                  | simp add: misc)+
-            apply (rule_tac Q="\<lambda>rv s. cte_wp_at ((\<noteq>) cap.NullCap) cref s
+            apply (rule_tac Q'="\<lambda>rv s. cte_wp_at ((\<noteq>) cap.NullCap) cref s
                                       \<and> post_retype_invs tp rv s
                                       \<and> idle_thread s \<notin> fst ` set slots
                                       \<and> untyped_is_device (transform_cap cap) = dev
@@ -1516,7 +1516,7 @@ lemma invoke_untyped_corres:
                       retype_region_post_retype_invs[where sz = sz]
                       hoare_vcg_const_Ball_lift retype_region_aligned_for_init)+
           apply (clarsimp simp:conj_comms misc cover)
-          apply (rule_tac Q="\<lambda>r s.
+          apply (rule_tac Q'="\<lambda>r s.
                cte_wp_at (\<lambda>cp. \<exists>idx. cp = (cap.UntypedCap dev ptr' sz idx)) cref s \<and>
                invs s \<and> pspace_no_overlap_range_cover ptr sz s \<and> caps_no_overlap ptr sz s \<and>
                region_in_kernel_window {ptr..(ptr && ~~ mask sz) + 2 ^ sz - 1} s \<and>
@@ -1558,8 +1558,8 @@ lemma invoke_untyped_corres:
        apply (wp (once) hoare_drop_imps)
        apply wp
       apply ((rule validE_validE_R)?,
-             rule_tac E="\<top>\<top>" and
-                      Q="\<lambda>_. valid_etcbs and invs and valid_untyped_inv_wcap untyped_invocation
+             rule_tac E'="\<top>\<top>" and
+                      Q'="\<lambda>_. valid_etcbs and invs and valid_untyped_inv_wcap untyped_invocation
                                 (Some (cap.UntypedCap dev ptr' sz (if reset then 0 else idx))) and ct_active
                              and (\<lambda>s. reset \<longrightarrow> pspace_no_overlap {ptr' .. ptr' + 2 ^ sz - 1} s)"
                       in hoare_strengthen_postE)

--- a/proof/infoflow/ADT_IF.thy
+++ b/proof/infoflow/ADT_IF.thy
@@ -1124,7 +1124,7 @@ lemma handle_preemption_if_irq_masks:
    handle_preemption_if tc
    \<lbrace>\<lambda>_ s. P (irq_masks_of_state s)\<rbrace>"
   apply (simp add: handle_preemption_if_def | wp handle_interrupt_irq_masks[where st=st])+
-   apply (rule_tac Q="\<lambda>rv s. P (irq_masks_of_state s) \<and> domain_sep_inv False st s \<and>
+   apply (rule_tac Q'="\<lambda>rv s. P (irq_masks_of_state s) \<and> domain_sep_inv False st s \<and>
                              (\<forall>x. rv = Some x \<longrightarrow> x \<le> maxIRQ)" in hoare_strengthen_post)
   by (wp | simp)+
 
@@ -1607,7 +1607,7 @@ lemma kernel_entry_if_domain_time_sched_action:
   apply (case_tac "e = Interrupt")
    apply (simp add: kernel_entry_if_def)
    apply (wp handle_interrupt_valid_domain_time| wpc | simp)+
-      apply (rule_tac Q="\<lambda>r s. domain_time s > 0" in hoare_strengthen_post)
+      apply (rule_tac Q'="\<lambda>r s. domain_time s > 0" in hoare_strengthen_post)
        apply (wp | simp)+
       apply (wp hoare_false_imp kernel_entry_if_domain_fields | fastforce)+
   done
@@ -1623,7 +1623,7 @@ lemma handle_preemption_if_domain_time_sched_action:
    \<lbrace>\<lambda>_ s. domain_time s = 0 \<longrightarrow> scheduler_action s = choose_new_thread\<rbrace>"
   apply (simp add: handle_preemption_if_def)
   apply (wp handle_interrupt_valid_domain_time| wpc | simp)+
-   apply (rule_tac Q="\<lambda>r s. domain_time s > 0" in hoare_strengthen_post)
+   apply (rule_tac Q'="\<lambda>r s. domain_time s > 0" in hoare_strengthen_post)
     apply wpsimp+
   done
 
@@ -1945,7 +1945,7 @@ lemma handle_preemption_if_valid_sched[wp]:
    handle_preemption_if irq
    \<lbrace>\<lambda>_. valid_sched\<rbrace>"
   apply (wpsimp simp: handle_preemption_if_def cong: if_cong)
-   apply (rule_tac Q="\<lambda>rv. valid_sched and invs and K (rv \<notin> Some ` non_kernel_IRQs)"
+   apply (rule_tac Q'="\<lambda>rv. valid_sched and invs and K (rv \<notin> Some ` non_kernel_IRQs)"
                 in hoare_strengthen_post[rotated])
     apply clarsimp
    apply (wpsimp wp: getActiveIRQ_neq_non_kernel)+
@@ -2049,7 +2049,7 @@ lemma invs_if_Step_ADT_A_if:
        apply simp
       apply simp
       apply (erule use_valid, erule use_valid[OF _ check_active_irq_if_wp])
-       apply (rule_tac Q="\<lambda>a. (invs and ct_running) and
+       apply (rule_tac Q'="\<lambda>a. (invs and ct_running) and
                               (\<lambda>b. valid_vspace_objs_if b \<and> valid_list b \<and> valid_sched b \<and>
                                    only_timer_irq_inv timer_irq s0_internal b \<and>
                                    silc_inv initial_aag s0_internal b \<and>
@@ -2071,7 +2071,7 @@ lemma invs_if_Step_ADT_A_if:
       apply simp
      apply simp
      apply (erule use_valid, erule use_valid[OF _ check_active_irq_if_wp])
-      apply (rule_tac Q="\<lambda>a. (invs and ct_running) and
+      apply (rule_tac Q'="\<lambda>a. (invs and ct_running) and
                              (\<lambda>b. valid_vspace_objs_if b \<and> valid_list b \<and> valid_sched b \<and>
                                   only_timer_irq_inv timer_irq s0_internal b \<and>
                                   silc_inv initial_aag s0_internal b \<and>
@@ -2822,7 +2822,7 @@ lemma schedule_if_irq_measure_if:
 lemma schedule_if_next_irq_state_of_state:
   "(r, b) \<in> fst (schedule_if uc i_s) \<Longrightarrow> next_irq_state_of_state b = next_irq_state_of_state i_s"
   apply (erule use_valid)
-   apply (rule_tac Q="\<lambda>_. irq_state_inv i_s" in hoare_strengthen_post)
+   apply (rule_tac Q'="\<lambda>_. irq_state_inv i_s" in hoare_strengthen_post)
     apply (wp schedule_if_irq_state_inv)
    apply (auto simp: irq_state_inv_def)
   done

--- a/proof/infoflow/ARM/ArchADT_IF.thy
+++ b/proof/infoflow/ARM/ArchADT_IF.thy
@@ -320,7 +320,7 @@ lemma invoke_tcb_irq_state_inv[ADT_IF_assms]:
     apply ((wp irq_state_inv_triv | simp)+)[2]
   (* just ThreadControl left *)
   apply (simp add: split_def cong: option.case_cong)
-  by (wp hoare_vcg_all_liftE_R hoare_vcg_all_lift hoare_vcg_const_imp_lift_R
+  by (wp hoare_vcg_all_liftE_R hoare_vcg_all_lift hoare_vcg_const_imp_liftE_R
          checked_cap_insert_domain_sep_inv cap_delete_deletes
          cap_delete_irq_state_inv[where st=st and sta=sta and irq=irq]
          cap_delete_irq_state_next[where st=st and sta=sta and irq=irq]

--- a/proof/infoflow/ARM/ArchArch_IF.thy
+++ b/proof/infoflow/ARM/ArchArch_IF.thy
@@ -804,9 +804,10 @@ lemma arm_asid_table_update_reads_respects:
    apply (rule modify_ev2)
    apply clarsimp
    apply (drule (1) is_subject_kheap_eq[rotated])
-   apply (auto simp: reads_equiv_def2 affects_equiv_def2 states_equiv_for_def equiv_for_def
-             intro!: equiv_asids_arm_asid_table_update)
-   done
+   apply (fastforce simp: reads_equiv_def2 affects_equiv_def2 states_equiv_for_def equiv_for_def
+                  intro!: equiv_asids_arm_asid_table_update)
+  apply wpsimp
+  done
 
 lemma perform_asid_control_invocation_reads_respects:
   notes K_bind_ev[wp del]

--- a/proof/infoflow/ARM/ArchFinalCaps.thy
+++ b/proof/infoflow/ARM/ArchFinalCaps.thy
@@ -302,7 +302,7 @@ lemma invoke_tcb_silc_inv[FinalCaps_assms]:
   (* slow, ~2 mins *)
   apply (simp only: conj_ac cong: conj_cong imp_cong |
          wp checked_insert_pas_refined checked_cap_insert_silc_inv hoare_vcg_all_liftE_R
-            hoare_vcg_all_lift hoare_vcg_const_imp_lift_R
+            hoare_vcg_all_lift hoare_vcg_const_imp_liftE_R
             cap_delete_silc_inv_not_transferable
             cap_delete_pas_refined' cap_delete_deletes
             cap_delete_valid_cap cap_delete_cte_at

--- a/proof/infoflow/ARM/ArchIRQMasks_IF.thy
+++ b/proof/infoflow/ARM/ArchIRQMasks_IF.thy
@@ -139,16 +139,16 @@ lemma invoke_tcb_irq_masks[IRQMasks_IF_assms]:
        apply (rule hoare_strengthen_postE[OF cap_delete_irq_masks[where P=P]])
         apply blast
        apply blast
-      apply (wpsimp wp: hoare_vcg_all_liftE_R hoare_vcg_const_imp_lift_R hoare_vcg_all_lift hoare_drop_imps
+      apply (wpsimp wp: hoare_vcg_all_liftE_R hoare_vcg_const_imp_liftE_R hoare_vcg_all_lift hoare_drop_imps
                         checked_cap_insert_domain_sep_inv)+
-      apply (rule_tac Q="\<lambda> r s. domain_sep_inv False st s \<and> P (irq_masks_of_state s)"
-                  and E="\<lambda>_ s. P (irq_masks_of_state s)" in hoare_strengthen_postE)
+      apply (rule_tac Q'="\<lambda> r s. domain_sep_inv False st s \<and> P (irq_masks_of_state s)"
+                  and E'="\<lambda>_ s. P (irq_masks_of_state s)" in hoare_strengthen_postE)
         apply (wp hoare_vcg_conj_liftE1 cap_delete_irq_masks)
        apply fastforce
       apply blast
      apply (wpsimp wp: hoare_weak_lift_imp hoare_vcg_all_lift checked_cap_insert_domain_sep_inv)+
-     apply (rule_tac Q="\<lambda> r s. domain_sep_inv False st s \<and> P (irq_masks_of_state s)"
-                 and E="\<lambda>_ s. P (irq_masks_of_state s)" in hoare_strengthen_postE)
+     apply (rule_tac Q'="\<lambda> r s. domain_sep_inv False st s \<and> P (irq_masks_of_state s)"
+                 and E'="\<lambda>_ s. P (irq_masks_of_state s)" in hoare_strengthen_postE)
        apply (wp hoare_vcg_conj_liftE1 cap_delete_irq_masks)
       apply fastforce
      apply blast

--- a/proof/infoflow/ARM/ArchIpc_IF.thy
+++ b/proof/infoflow/ARM/ArchIpc_IF.thy
@@ -382,7 +382,7 @@ lemma set_mrs_equiv_but_for_labels[Ipc_IF_assms]:
   unfolding set_mrs_def
   apply (wp | wpc)+
         apply (subst zipWithM_x_mapM_x)
-        apply (rule_tac Q="\<lambda>_. equiv_but_for_labels aag L st and K (pasObjectAbs aag thread \<in> L  \<and>
+        apply (rule_tac Q'="\<lambda>_. equiv_but_for_labels aag L st and K (pasObjectAbs aag thread \<in> L  \<and>
                                (case buf of (Some buf') \<Rightarrow> is_aligned buf' msg_align_bits \<and>
                                                            (\<forall>x \<in> ptr_range buf' msg_align_bits.
                                                               pasObjectAbs aag x \<in> L)

--- a/proof/infoflow/ARM/ArchNoninterference.thy
+++ b/proof/infoflow/ARM/ArchNoninterference.thy
@@ -82,7 +82,7 @@ lemma do_user_op_if_partitionIntegrity[Noninterference_assms]:
   "\<lbrace>partitionIntegrity aag st and pas_refined aag and invs and is_subject aag \<circ> cur_thread\<rbrace>
    do_user_op_if tc uop
    \<lbrace>\<lambda>_. partitionIntegrity aag st\<rbrace>"
- apply (rule_tac Q="\<lambda>rv s. integrity (aag\<lparr>pasMayActivate := False, pasMayEditReadyQueues := False\<rparr>)
+ apply (rule_tac Q'="\<lambda>rv s. integrity (aag\<lparr>pasMayActivate := False, pasMayEditReadyQueues := False\<rparr>)
                                      (scheduler_affects_globals_frame st) st s \<and>
                            domain_fields_equiv st s \<and> idle_thread s = idle_thread st \<and>
                            globals_equiv_scheduler st s \<and> silc_dom_equiv aag st s"

--- a/proof/infoflow/ARM/ArchRetype_IF.thy
+++ b/proof/infoflow/ARM/ArchRetype_IF.thy
@@ -171,7 +171,7 @@ lemma copy_global_mappings_reads_respects_g:
   apply simp
   apply (rule bind_ev_pre)
      prefer 3
-     apply (rule_tac Q="\<lambda>s. is_subject aag x \<and> x \<noteq> arm_global_pd (arch_state s) \<and>
+     apply (rule_tac P'="\<lambda>s. is_subject aag x \<and> x \<noteq> arm_global_pd (arch_state s) \<and>
                             pspace_aligned s \<and> valid_arch_state s" in hoare_weaken_pre)
       apply (rule gets_sp)
      apply (assumption)
@@ -283,7 +283,7 @@ lemma copy_global_mappings_globals_equiv:
   unfolding copy_global_mappings_def including classic_wp_pre
   apply simp
   apply wp
-   apply (rule_tac Q="\<lambda>_. globals_equiv s and (\<lambda>s. x \<noteq> arm_global_pd (arch_state s) \<and>
+   apply (rule_tac Q'="\<lambda>_. globals_equiv s and (\<lambda>s. x \<noteq> arm_global_pd (arch_state s) \<and>
                                                    is_aligned x pd_bits)" in hoare_strengthen_post)
     apply (wp mapM_x_wp[OF _ subset_refl] store_pde_globals_equiv)
     apply (fastforce dest: subsetD[OF copy_global_mappings_index_subset] simp: pd_shifting')
@@ -301,7 +301,7 @@ lemma init_arch_objects_globals_equiv:
   apply (subst do_machine_op_mapM_x[OF empty_fail_cleanCacheRange_PoU])+
   apply (rule hoare_pre)
    apply (wpc | wp mapM_x_wp[OF dmo_cleanCacheRange_PoU_globals_equiv subset_refl])+
-    apply (rule_tac Q="\<lambda>_. globals_equiv s and (\<lambda> s. arm_global_pd (arch_state s) \<notin> set refs)"
+    apply (rule_tac Q'="\<lambda>_. globals_equiv s and (\<lambda> s. arm_global_pd (arch_state s) \<notin> set refs)"
                  in hoare_strengthen_post)
      apply (wp mapM_x_wp[OF _ subset_refl] copy_global_mappings_globals_equiv
               dmo_cleanCacheRange_PoU_globals_equiv
@@ -542,11 +542,11 @@ lemma invoke_untyped_reads_respects_g_wcap[Retype_IF_assms]:
   apply (simp add: invoke_untyped_def mapM_x_def[symmetric])
   apply (wpsimp wp: mapM_x_ev'' create_cap_reads_respects_g
                     hoare_vcg_ball_lift init_arch_objects_reads_respects_g)+
-           apply (rule_tac Q="\<lambda>_. invs" in hoare_strengthen_post)
+           apply (rule_tac Q'="\<lambda>_. invs" in hoare_strengthen_post)
             apply (wp init_arch_objects_invs_from_restricted)
            apply (fastforce simp: invs_def)
           apply (wp retype_region_reads_respects_g[where sz=sz and slot="slot_of_untyped_inv ui"])
-         apply (rule_tac Q="\<lambda>rvc s. (\<forall>x\<in>set rvc. is_subject aag x) \<and>
+         apply (rule_tac Q'="\<lambda>rvc s. (\<forall>x\<in>set rvc. is_subject aag x) \<and>
                                     (\<forall>x\<in>set rvc. is_aligned x (obj_bits_api apiobject_type nat)) \<and>
                                     ((0::obj_ref) < of_nat (length list)) \<and>
                                     post_retype_invs apiobject_type rvc s \<and>
@@ -582,8 +582,8 @@ lemma invoke_untyped_reads_respects_g_wcap[Retype_IF_assms]:
    apply (rule_tac P="authorised_untyped_inv aag ui \<and>
                       (\<forall>p \<in> ptr_range ptr sz. is_subject aag p)" in hoare_gen_asmE)
    apply (rule validE_validE_R,
-          rule_tac E="\<top>\<top>"
-               and Q="\<lambda>_. invs and valid_untyped_inv_wcap ui (Some (UntypedCap dev ptr sz (If reset 0 idx)))
+          rule_tac E'="\<top>\<top>"
+               and Q'="\<lambda>_. invs and valid_untyped_inv_wcap ui (Some (UntypedCap dev ptr sz (If reset 0 idx)))
                                and ct_active
                                and (\<lambda>s. reset \<longrightarrow> pspace_no_overlap {ptr .. ptr + 2 ^ sz - 1} s)"
                 in hoare_strengthen_postE)
@@ -658,7 +658,7 @@ lemma reset_untyped_cap_globals_equiv:
              preemption_point_inv | simp add: unless_def)+
      apply (rule valid_validE)
      apply (rule_tac P="cap_aligned cap \<and> is_untyped_cap cap" in hoare_gen_asm)
-     apply (rule_tac Q="\<lambda>_ s. valid_global_objs s \<and> valid_arch_state s \<and> globals_equiv st s"
+     apply (rule_tac Q'="\<lambda>_ s. valid_global_objs s \<and> valid_arch_state s \<and> globals_equiv st s"
                   in hoare_strengthen_post)
       apply (rule validE_valid, rule mapME_x_wp')
       apply (rule hoare_pre)

--- a/proof/infoflow/ARM/ArchScheduler_IF.thy
+++ b/proof/infoflow/ARM/ArchScheduler_IF.thy
@@ -178,7 +178,7 @@ lemma globals_equiv_scheduler_inv'[Scheduler_IF_assms]:
   apply (rule use_spec)
   apply (simp add: spec_valid_def)
   apply (erule_tac x="(swap_things sa s)" in allE)
-  apply (rule_tac Q="\<lambda>r st. globals_equiv (swap_things sa s) st" in hoare_strengthen_post)
+  apply (rule_tac Q'="\<lambda>r st. globals_equiv (swap_things sa s) st" in hoare_strengthen_post)
    apply (rule hoare_pre)
     apply assumption
    apply (clarsimp simp: globals_equiv_def swap_things_def globals_equiv_scheduler_def

--- a/proof/infoflow/ARM/ArchTcb_IF.thy
+++ b/proof/infoflow/ARM/ArchTcb_IF.thy
@@ -103,13 +103,13 @@ lemma invoke_tcb_thread_preservation[Tcb_IF_assms]:
    apply wp
         apply ((simp add: conj_comms(1, 2)
                 | rule wp_split_const_if wp_split_const_if_R hoare_vcg_all_liftE_R
-                       hoare_vcg_E_elim hoare_vcg_const_imp_lift_R hoare_vcg_R_conj
+                       hoare_vcg_conj_elimE hoare_vcg_const_imp_liftE_R hoare_vcg_conj_liftE_R
                 | (wp check_cap_inv2[where Q="\<lambda>_. pas_refined aag"]
                       check_cap_inv2[where Q="\<lambda>_ s. t \<noteq> idle_thread s"]
                       out_invs_trivial case_option_wpE cap_delete_deletes
                       cap_delete_valid_cap cap_insert_valid_cap out_cte_at
                       cap_insert_cte_at cap_delete_cte_at out_valid_cap out_tcb_valid
-                      hoare_vcg_const_imp_lift_R hoare_vcg_all_liftE_R
+                      hoare_vcg_const_imp_liftE_R hoare_vcg_all_liftE_R
                       thread_set_tcb_ipc_buffer_cap_cleared_invs
                       thread_set_invs_trivial[OF ball_tcb_cap_casesI]
                       hoare_vcg_all_lift thread_set_valid_cap out_emptyable
@@ -155,7 +155,7 @@ lemma tc_reads_respects_f[Tcb_IF_assms]:
        (invoke_tcb ti)"
   apply (simp add: split_def cong: option.case_cong)
   apply (wpsimp wp: set_priority_reads_respects[THEN reads_respects_f[where  st=st and Q=\<top>]])
-                    apply (wpsimp wp: hoare_vcg_const_imp_lift_R simp: when_def | wpc)+
+                    apply (wpsimp wp: hoare_vcg_const_imp_liftE_R simp: when_def | wpc)+
                     apply (rule conjI)
                      apply ((wpsimp wp: reschedule_required_reads_respects_f)+)[4]
                  apply ((wp reads_respects_f[OF cap_insert_reads_respects, where st=st]
@@ -183,7 +183,7 @@ lemma tc_reads_respects_f[Tcb_IF_assms]:
                            set_mcpriority_only_timer_irq_inv[where st=st' and irq=irq]
                            cap_delete_deletes cap_delete_valid_cap cap_delete_cte_at
                            cap_delete_pas_refined' itr_wps(12) itr_wps(14) cap_insert_cte_at
-                           checked_insert_no_cap_to hoare_vcg_const_imp_lift_R hoare_vcg_conj_lift
+                           checked_insert_no_cap_to hoare_vcg_const_imp_liftE_R hoare_vcg_conj_lift
                            as_user_reads_respects_f thread_set_mdb cap_delete_invs
                       | wpc
                       | simp add: emptyable_def tcb_cap_cases_def tcb_cap_valid_def
@@ -214,7 +214,7 @@ lemma tc_reads_respects_f[Tcb_IF_assms]:
                       set_mcpriority_only_timer_irq_inv[where st=st' and irq=irq]
                       cap_delete_deletes cap_delete_valid_cap cap_delete_cte_at
                       cap_delete_pas_refined' itr_wps(12) itr_wps(14) cap_insert_cte_at
-                      checked_insert_no_cap_to hoare_vcg_const_imp_lift_R
+                      checked_insert_no_cap_to hoare_vcg_const_imp_liftE_R
                       as_user_reads_respects_f cap_delete_invs
                  | wpc
                  | simp add: emptyable_def tcb_cap_cases_def tcb_cap_valid_def when_def st_tcb_at_triv

--- a/proof/infoflow/Decode_IF.thy
+++ b/proof/infoflow/Decode_IF.thy
@@ -51,7 +51,7 @@ lemma expand_len_gr_Suc_0:
   by fastforce
 
 (* FIXME: remove *)
-lemmas hoare_vcg_imp_lift_R = hoare_vcg_const_imp_lift_R
+lemmas hoare_vcg_imp_liftE_R = hoare_vcg_const_imp_liftE_R
 
 lemma decode_cnode_invocation_rev:
   "reads_equiv_valid_inv A (aag :: 'a subject_label PAS)
@@ -61,7 +61,7 @@ lemma decode_cnode_invocation_rev:
   apply (rule equiv_valid_guard_imp)
   apply (simp add: unlessE_whenE)
   apply wp
-  apply (wp if_apply_ev derive_cap_rev whenE_inv hoare_vcg_imp_lift_R
+  apply (wp if_apply_ev derive_cap_rev whenE_inv hoare_vcg_imp_liftE_R
              lookup_slot_for_cnode_op_rev hoare_vcg_all_liftE_R
              lookup_slot_for_cnode_op_authorised ensure_empty_rev get_cap_rev
          | simp add: split_def unlessE_whenE split del: if_split
@@ -201,7 +201,7 @@ lemma decode_untyped_invocation_rev:
          | simp
          | rule validE_R_validE | strengthen aag_can_read_self)+
                   apply (rule hoare_strengthen_post[
-                                  where Q="\<lambda> rv s. (is_cnode_cap rv
+                                  where Q'="\<lambda> rv s. (is_cnode_cap rv
                                                          \<longrightarrow> is_subject aag (obj_ref_of rv))
                                                  \<and> pas_refined aag s"])
                    apply (wp (once) whenE_throwError_wp

--- a/proof/infoflow/FinalCaps.thy
+++ b/proof/infoflow/FinalCaps.thy
@@ -2794,15 +2794,17 @@ lemma handle_invocation_silc_inv:
   apply (wp syscall_valid perform_invocation_silc_inv set_thread_state_runnable_valid_sched
             set_thread_state_pas_refined decode_invocation_authorised
          | simp split del: if_split)+
-       apply (rule_tac E="\<lambda>ft. silc_inv aag st and pas_refined aag and
-                               is_subject aag \<circ> cur_thread and invs and
-                               (\<lambda>_. valid_fault ft \<and> is_subject aag thread)"
-                   and R="Q" and Q=Q for Q in hoare_strengthen_postE)
+       apply (rule_tac E'="\<lambda>ft. silc_inv aag st and pas_refined aag and
+                                is_subject aag \<circ> cur_thread and invs and
+                                (\<lambda>_. valid_fault ft \<and> is_subject aag thread)"
+                   and Q="Q" and Q'=Q for Q
+                    in hoare_strengthen_postE)
          apply (wp lookup_extra_caps_authorised lookup_extra_caps_auth | simp)+
-     apply (rule_tac E="\<lambda>ft. silc_inv aag st and pas_refined aag and
-                             is_subject aag \<circ> cur_thread and invs and
-                             (\<lambda>_. valid_fault (CapFault x False ft) \<and> is_subject aag thread)"
-                 and R="Q" and Q=Q for Q in hoare_strengthen_postE)
+     apply (rule_tac E'="\<lambda>ft. silc_inv aag st and pas_refined aag and
+                              is_subject aag \<circ> cur_thread and invs and
+                              (\<lambda>_. valid_fault (CapFault x False ft) \<and> is_subject aag thread)"
+                 and Q="Q" and Q'=Q for Q
+                  in hoare_strengthen_postE)
         apply (wp lookup_cap_and_slot_authorised lookup_cap_and_slot_cur_auth | simp)+
   apply (auto intro: st_tcb_ex_cap simp: ct_in_state_def runnable_eq_active)
   done

--- a/proof/infoflow/FinalCaps.thy
+++ b/proof/infoflow/FinalCaps.thy
@@ -1983,7 +1983,7 @@ lemma reset_untyped_cap_untyped_cap:
   apply (rule hoare_pre)
    apply (wp set_cap_cte_wp_at | simp add: unless_def)+
      apply (rule valid_validE,
-            rule_tac Q="\<lambda>rv. cte_wp_at (\<lambda>cp. is_untyped_cap cp \<and> is_untyped_cap cap \<and>
+            rule_tac Q'="\<lambda>rv. cte_wp_at (\<lambda>cp. is_untyped_cap cp \<and> is_untyped_cap cap \<and>
                                              untyped_range cp = untyped_range cap \<and>
                                              P True (untyped_range cp)) slot"
                   in hoare_strengthen_post)
@@ -2108,7 +2108,7 @@ lemma reset_untyped_cap_silc_inv:
   apply (simp add: reset_untyped_cap_def cong: if_cong)
   apply (rule validE_valid, rule hoare_pre)
    apply (wp set_cap_silc_inv_simple | simp add: unless_def)+
-     apply (rule valid_validE, rule_tac Q="\<lambda>_. cte_wp_at is_untyped_cap slot and
+     apply (rule valid_validE, rule_tac Q'="\<lambda>_. cte_wp_at is_untyped_cap slot and
                                                silc_inv aag st" in hoare_strengthen_post)
       apply (rule validE_valid, rule mapME_x_inv_wp, rule hoare_pre)
        apply (wp mapME_x_inv_wp preemption_point_inv set_cap_cte_wp_at
@@ -2135,7 +2135,7 @@ lemma invoke_untyped_silc_inv:
    \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
   apply (rule hoare_gen_asm)
   apply (rule hoare_pre)
-   apply (rule_tac Q="\<lambda>_. silc_inv aag st and
+   apply (rule_tac Q'="\<lambda>_. silc_inv aag st and
                           cte_wp_at (\<lambda>cp. is_untyped_cap cp
                                           \<longrightarrow> (\<forall>x \<in> untyped_range cp. is_subject aag x))
                                     (case ui of Retype src_slot _ _ _ _ _ _ _ \<Rightarrow> src_slot)"
@@ -2840,7 +2840,7 @@ lemma handle_recv_silc_inv:
             receive_ipc_silc_inv lookup_slot_for_thread_authorised
             lookup_slot_for_thread_cap_fault get_cap_auth_wp[where aag=aag]
          | wpc | simp
-         | rule_tac Q="\<lambda>rv s. invs s \<and> pas_refined aag s \<and> is_subject aag thread \<and>
+         | rule_tac Q'="\<lambda>rv s. invs s \<and> pas_refined aag s \<and> is_subject aag thread \<and>
                               (pasSubject aag, Receive, pasObjectAbs aag x31) \<in> pasPolicy aag"
                  in hoare_strengthen_post, wp, clarsimp simp: invs_valid_objs invs_sym_refs)+
     apply (rule_tac Q'="\<lambda>r s. silc_inv aag st s \<and> invs s \<and> pas_refined aag s \<and>

--- a/proof/infoflow/Finalise_IF.thy
+++ b/proof/infoflow/Finalise_IF.thy
@@ -643,7 +643,7 @@ lemma cancel_all_ipc_reads_respects:
       | rule subset_refl
       | wp (once) hoare_drop_imps
       | assumption
-      | rule hoare_strengthen_post[where Q="\<lambda>_. pas_refined aag and pspace_aligned
+      | rule hoare_strengthen_post[where Q'="\<lambda>_. pas_refined aag and pspace_aligned
                                                                 and valid_vspace_objs
                                                                 and valid_arch_state", OF mapM_x_wp])+
 
@@ -777,7 +777,7 @@ lemma cancel_all_signals_reads_respects:
       | rule subset_refl
       | wp (once) hoare_drop_imps
       | simp
-      | rule hoare_strengthen_post[where Q="\<lambda>_. pas_refined aag and pspace_aligned
+      | rule hoare_strengthen_post[where Q'="\<lambda>_. pas_refined aag and pspace_aligned
                                                                 and valid_vspace_objs
                                                                 and valid_arch_state", OF mapM_x_wp])+
 
@@ -824,7 +824,7 @@ lemma cap_delete_one_reads_respects_f:
             reads_respects_f[OF fast_finalise_reads_respects, where st=st]
             empty_slot_silc_inv
         | simp | elim conjE)+
-      apply (rule_tac Q="\<lambda>rva s. rva = is_final_cap' rv s \<and>
+      apply (rule_tac Q'="\<lambda>rva s. rva = is_final_cap' rv s \<and>
                                  cte_wp_at ((=) rv) slot s \<and>
                                  silc_inv aag st s \<and>
                                  is_subject aag (fst slot) \<and>
@@ -856,7 +856,7 @@ lemma cap_delete_one_reads_respects_f_transferable:
              reads_respects_f[OF empty_slot_reads_respects, where st=st]
              reads_respects_f[OF fast_finalise_reads_respects, where st=st]
           | simp | elim conjE)+
-      apply (rule_tac Q="\<lambda>rva s. rva = is_final_cap' rv s \<and>
+      apply (rule_tac Q'="\<lambda>rva s. rva = is_final_cap' rv s \<and>
                                  cte_wp_at ((=) rv) slot s \<and>
                                  silc_inv aag st s \<and>
                                  is_transferable_in slot s \<and>
@@ -1001,7 +1001,7 @@ lemma reply_cancel_ipc_reads_respects_f:
             reads_respects_f[OF thread_set_reads_respects, where st=st]
             reads_respects_f[OF gets_descendants_of_revrv[folded equiv_valid_def2]]
          | simp add: when_def split del: if_split | elim conjE)+
-   apply (rule_tac Q="\<lambda> rv s. silc_inv aag st s \<and> invs s \<and> pas_refined aag s
+   apply (rule_tac Q'="\<lambda> rv s. silc_inv aag st s \<and> invs s \<and> pas_refined aag s
                                                 \<and> tcb_at tptr s \<and> is_subject aag tptr"
                 in hoare_strengthen_post)
     apply (wp thread_set_tcb_fault_update_silc_inv hoare_vcg_imp_lift hoare_vcg_ball_lift
@@ -1262,7 +1262,7 @@ next
           apply (clarsimp simp: appropriate_cte_cap_def split: cap.splits)
          apply (clarsimp cong: conj_cong simp: conj_comms)
         apply (wp drop_spec_ev[OF liftE_ev] is_final_cap_reads_respects | simp)+
-       apply (rule_tac Q="\<lambda>rva s. rva = is_final_cap' rv s \<and> cte_wp_at ((=) rv) slot s \<and>
+       apply (rule_tac Q'="\<lambda>rva s. rva = is_final_cap' rv s \<and> cte_wp_at ((=) rv) slot s \<and>
                                   only_timer_irq_inv irq st' s \<and> silc_inv aag st s \<and>
                                   pas_refined aag s \<and> pas_cap_cur_auth aag rv \<and>
                                   invs s \<and> valid_list s \<and> valid_sched s \<and> simple_sched_action s \<and>

--- a/proof/infoflow/IRQMasks_IF.thy
+++ b/proof/infoflow/IRQMasks_IF.thy
@@ -345,7 +345,7 @@ lemma handle_event_irq_masks:
                    | wp (once) hoare_drop_imps)+\<close>)?)
   apply simp
   apply (wp handle_interrupt_irq_masks[where st=st] | wpc | simp)+
-   apply (rule_tac Q="\<lambda>rv s. P (irq_masks_of_state s) \<and> domain_sep_inv False st s \<and>
+   apply (rule_tac Q'="\<lambda>rv s. P (irq_masks_of_state s) \<and> domain_sep_inv False st s \<and>
                              (\<forall>x. rv = Some x \<longrightarrow> x \<le> maxIRQ)" in hoare_strengthen_post)
     apply wpsimp+
   done
@@ -357,7 +357,7 @@ lemma call_kernel_irq_masks:
    \<lbrace>\<lambda>rv s. P (irq_masks_of_state s)\<rbrace>"
   apply (simp add: call_kernel_def)
   apply (wp handle_interrupt_irq_masks[where st=st])+
-    apply (rule_tac Q="\<lambda>rv s. P (irq_masks_of_state s) \<and> domain_sep_inv False st s \<and>
+    apply (rule_tac Q'="\<lambda>rv s. P (irq_masks_of_state s) \<and> domain_sep_inv False st s \<and>
                               (\<forall>x. rv = Some x \<longrightarrow> x \<le> maxIRQ)" in hoare_strengthen_post)
      apply (wp | simp)+
    apply (rule_tac Q="\<lambda>x s. P (irq_masks_of_state s) \<and> domain_sep_inv False st s"

--- a/proof/infoflow/IRQMasks_IF.thy
+++ b/proof/infoflow/IRQMasks_IF.thy
@@ -360,8 +360,8 @@ lemma call_kernel_irq_masks:
     apply (rule_tac Q'="\<lambda>rv s. P (irq_masks_of_state s) \<and> domain_sep_inv False st s \<and>
                               (\<forall>x. rv = Some x \<longrightarrow> x \<le> maxIRQ)" in hoare_strengthen_post)
      apply (wp | simp)+
-   apply (rule_tac Q="\<lambda>x s. P (irq_masks_of_state s) \<and> domain_sep_inv False st s"
-               and F="E" for E in hoare_strengthen_postE)
+   apply (rule_tac Q'="\<lambda>x s. P (irq_masks_of_state s) \<and> domain_sep_inv False st s"
+               and E="E" for E in hoare_strengthen_postE)
      apply (rule valid_validE)
      apply (wp handle_event_irq_masks[where st=st] valid_validE[OF handle_event_domain_sep_inv]
             | simp)+

--- a/proof/infoflow/InfoFlow_IF.thy
+++ b/proof/infoflow/InfoFlow_IF.thy
@@ -957,8 +957,9 @@ lemma do_machine_op_rev:
        apply (clarsimp simp: select_f_def equiv_valid_2_def)
        apply (insert equiv_dmo, clarsimp simp: equiv_valid_def2 equiv_valid_2_def)[1]
        apply blast
-    apply (wp select_f_inv)+
+      apply (wpsimp wp: select_f_inv)+
     apply (fastforce simp: select_f_def dest: state_unchanged[OF mo_inv])+
+  apply wpsimp
   done
 
 end

--- a/proof/infoflow/Ipc_IF.thy
+++ b/proof/infoflow/Ipc_IF.thy
@@ -907,7 +907,7 @@ lemma transfer_caps_loop_reads_respects':
      prefer 2
      apply (clarsimp simp: cte_wp_at_caps_of_state split del: if_split)
      apply (strengthen is_derived_is_transferable[mk_strg I' O], assumption, solves\<open>simp\<close>)
-    apply (rule hoare_vcg_conj_liftE_R)
+    apply (rule hoare_vcg_conj_liftE_R')
      apply (rule derive_cap_is_derived)
     apply (wp derive_cap_is_derived_foo')
    apply wp
@@ -1606,7 +1606,7 @@ lemma do_reply_transfer_reads_respects_f:
          | wp (once) reads_respects_f[where aag=aag and st=st]
          | elim conjE
          | wp (once) hoare_drop_imps)+
-         apply (rule_tac Q="\<lambda> rv s. pas_refined aag s \<and> pas_cur_domain aag s \<and> invs s
+         apply (rule_tac Q'="\<lambda> rv s. pas_refined aag s \<and> pas_cur_domain aag s \<and> invs s
                                  \<and> is_subject aag (cur_thread s)
                                  \<and> silc_inv aag st s"
                      in hoare_strengthen_post[rotated])
@@ -1703,8 +1703,8 @@ next
          apply (rule Cons.hyps)
         apply (simp)
         apply (wp cap_insert_globals_equiv'')
-       apply (rule_tac Q="\<lambda>_. globals_equiv st and valid_arch_state and valid_global_objs"
-                   and E="\<lambda>_. globals_equiv st and valid_arch_state and valid_global_objs"
+       apply (rule_tac Q'="\<lambda>_. globals_equiv st and valid_arch_state and valid_global_objs"
+                   and E'="\<lambda>_. globals_equiv st and valid_arch_state and valid_global_objs"
                     in hoare_strengthen_postE)
          apply (simp add: whenE_def, rule conjI)
           apply (rule impI, wp)+
@@ -1727,12 +1727,12 @@ lemma copy_mrs_globals_equiv:
    \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
   unfolding copy_mrs_def including classic_wp_pre
   apply (wp | wpc)+
-    apply (rule_tac Q="\<lambda>_. globals_equiv s" in hoare_strengthen_post)
+    apply (rule_tac Q'="\<lambda>_. globals_equiv s" in hoare_strengthen_post)
      apply (wp mapM_wp' | wpc)+
       apply (wp store_word_offs_globals_equiv)+
     apply fastforce
    apply simp
-   apply (rule_tac Q="\<lambda>_. globals_equiv s and valid_arch_state and (\<lambda>sa. receiver \<noteq> idle_thread sa)"
+   apply (rule_tac Q'="\<lambda>_. globals_equiv s and valid_arch_state and (\<lambda>sa. receiver \<noteq> idle_thread sa)"
                 in hoare_strengthen_post)
     apply (wp mapM_wp' as_user_globals_equiv)
     apply (simp)
@@ -1803,7 +1803,7 @@ lemma do_ipc_transfer_globals_equiv:
    \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
   unfolding do_ipc_transfer_def
   apply (wp do_normal_transfer_globals_equiv do_fault_transfer_globals_equiv | wpc)+
-    apply (rule_tac Q="\<lambda>_. globals_equiv st and valid_arch_state and valid_global_objs and
+    apply (rule_tac Q'="\<lambda>_. globals_equiv st and valid_arch_state and valid_global_objs and
                            (\<lambda>sa. receiver \<noteq> idle_thread sa) and
                            (\<lambda>sa. (\<forall>rb. recv_buffer = Some rb
                                  \<longrightarrow> auth_ipc_buffers sa receiver = ptr_range rb msg_align_bits) \<and>
@@ -1823,7 +1823,7 @@ lemma send_ipc_globals_equiv:
   unfolding send_ipc_def
   apply (wp set_simple_ko_globals_equiv set_thread_state_globals_equiv
             setup_caller_cap_globals_equiv | wpc)+
-        apply (rule_tac Q="\<lambda>_. globals_equiv st and valid_arch_state and valid_global_objs"
+        apply (rule_tac Q'="\<lambda>_. globals_equiv st and valid_arch_state and valid_global_objs"
                      in hoare_strengthen_post[rotated])
          apply (fastforce)
         apply (wp set_thread_state_globals_equiv dxo_wp_weak | simp)+
@@ -1832,7 +1832,7 @@ lemma send_ipc_globals_equiv:
      apply (clarsimp)
      apply (rule hoare_drop_imps)
      apply (wp set_simple_ko_globals_equiv)+
-   apply (rule_tac Q="\<lambda>ep. ko_at (Endpoint ep) epptr and globals_equiv st and valid_objs and
+   apply (rule_tac Q'="\<lambda>ep. ko_at (Endpoint ep) epptr and globals_equiv st and valid_objs and
                            valid_arch_state and valid_global_refs and pspace_distinct and
                            pspace_aligned and valid_global_objs and
                            (\<lambda>s. sym_refs (state_refs_of s)) and valid_idle"
@@ -1859,7 +1859,7 @@ lemma receive_ipc_globals_equiv:
              setup_caller_cap_globals_equiv dxo_wp_weak as_user_globals_equiv
           | wpc
           | simp split del: if_split)+
-             apply (rule hoare_strengthen_post[where Q= "\<lambda>_. globals_equiv st and valid_arch_state
+             apply (rule hoare_strengthen_post[where Q'="\<lambda>_. globals_equiv st and valid_arch_state
                                                                               and valid_global_objs"])
               apply (wp do_ipc_transfer_globals_equiv as_user_globals_equiv)
              apply clarsimp
@@ -2011,8 +2011,8 @@ lemma handle_fault_globals_equiv:
    \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
   unfolding handle_fault_def
   apply (wp handle_double_fault_globals_equiv)
-    apply (rule_tac Q="\<lambda>_. globals_equiv st and valid_arch_state" and
-                    E="\<lambda>_. globals_equiv st and valid_arch_state" in hoare_strengthen_postE)
+    apply (rule_tac Q'="\<lambda>_. globals_equiv st and valid_arch_state" and
+                    E'="\<lambda>_. globals_equiv st and valid_arch_state" in hoare_strengthen_postE)
       apply (wp send_fault_ipc_globals_equiv | simp)+
   done
 
@@ -2034,7 +2034,7 @@ lemma do_reply_transfer_globals_equiv:
   apply (wp set_thread_state_globals_equiv cap_delete_one_globals_equiv do_ipc_transfer_globals_equiv
             thread_set_globals_equiv handle_fault_reply_globals_equiv dxo_wp_weak
          | wpc | simp split del: if_split)+
-     apply (rule_tac Q="\<lambda>_. globals_equiv st and valid_arch_state and valid_objs and valid_arch_state
+     apply (rule_tac Q'="\<lambda>_. globals_equiv st and valid_arch_state and valid_objs and valid_arch_state
                                              and valid_global_refs and pspace_distinct
                                              and pspace_aligned and valid_global_objs
                                              and (\<lambda>s. receiver \<noteq> idle_thread s) and valid_idle"
@@ -2049,7 +2049,7 @@ lemma handle_reply_globals_equiv:
    \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
   unfolding handle_reply_def
   apply (wp do_reply_transfer_globals_equiv | wpc)+
-    apply (rule_tac Q="\<lambda>_. globals_equiv st and valid_objs and valid_arch_state and valid_global_refs
+    apply (rule_tac Q'="\<lambda>_. globals_equiv st and valid_objs and valid_arch_state and valid_global_refs
                                             and pspace_distinct and pspace_aligned
                                             and valid_global_objs and valid_idle"
                  in hoare_strengthen_post)

--- a/proof/infoflow/Noninterference.thy
+++ b/proof/infoflow/Noninterference.thy
@@ -462,11 +462,11 @@ lemma schedule_cur_domain:
   supply hoare_pre_cont[where f=next_domain, wp add]
          ethread_get_wp[wp del] if_split[split del] if_cong[cong]
   apply (simp add: schedule_def schedule_choose_new_thread_def | wp | wpc)+
-               apply (rule_tac Q="\<lambda>_. ?PRE" in hoare_strengthen_post)
+               apply (rule_tac Q'="\<lambda>_. ?PRE" in hoare_strengthen_post)
                 apply (simp | wp gts_wp | wp (once) hoare_drop_imps)+
-               apply (rule_tac Q="\<lambda>_. ?PRE" in hoare_strengthen_post)
+               apply (rule_tac Q'="\<lambda>_. ?PRE" in hoare_strengthen_post)
                 apply (simp | wp gts_wp | wp (once) hoare_drop_imps)+
-      apply (rule_tac Q="\<lambda>_. ?PRE" in hoare_strengthen_post)
+      apply (rule_tac Q'="\<lambda>_. ?PRE" in hoare_strengthen_post)
        apply (simp | wp gts_wp | wp (once) hoare_drop_imps)+
   apply (clarsimp split: if_split)
   done
@@ -479,11 +479,11 @@ lemma schedule_domain_fields:
   supply hoare_pre_cont[where f=next_domain, wp add]
          ethread_get_wp[wp del] if_split[split del] if_cong[cong]
   apply (simp add: schedule_def schedule_choose_new_thread_def | wp | wpc)+
-               apply (rule_tac Q="\<lambda>_. ?PRE" in hoare_strengthen_post)
+               apply (rule_tac Q'="\<lambda>_. ?PRE" in hoare_strengthen_post)
                 apply (simp | wp gts_wp | wp (once) hoare_drop_imps)+
-               apply (rule_tac Q="\<lambda>_. ?PRE" in hoare_strengthen_post)
+               apply (rule_tac Q'="\<lambda>_. ?PRE" in hoare_strengthen_post)
                 apply (simp | wp gts_wp | wp (once) hoare_drop_imps)+
-      apply (rule_tac Q="\<lambda>_. ?PRE" in hoare_strengthen_post)
+      apply (rule_tac Q'="\<lambda>_. ?PRE" in hoare_strengthen_post)
        apply (simp | wp gts_wp | wp (once) hoare_drop_imps)+
   apply (clarsimp split: if_split)
   done
@@ -495,7 +495,7 @@ lemma schedule_if_partitionIntegrity:
          schedule_if tc
          \<lbrace>\<lambda>_. partitionIntegrity aag st\<rbrace>"
   apply (simp add: schedule_if_def)
-  apply (rule_tac Q="\<lambda>rv s. integrity (aag\<lparr>pasMayActivate := False, pasMayEditReadyQueues := False\<rparr>)
+  apply (rule_tac Q'="\<lambda>rv s. integrity (aag\<lparr>pasMayActivate := False, pasMayEditReadyQueues := False\<rparr>)
                                       (scheduler_affects_globals_frame st) st s \<and>
                             domain_fields_equiv st s \<and> idle_thread s = idle_thread st \<and>
                             globals_equiv_scheduler st s \<and> silc_dom_equiv aag st s"
@@ -503,7 +503,7 @@ lemma schedule_if_partitionIntegrity:
    apply (wpsimp wp: activate_thread_integrity activate_thread_globals_equiv_scheduler
                      silc_dom_equiv_from_silc_inv_valid'[where P="\<top>"] schedule_integrity
                      hoare_vcg_all_lift domain_fields_equiv_lift[where Q="\<top>" and R="\<top>"])
-    apply (rule_tac Q="\<lambda>r s. guarded_pas_domain aag s \<and> pas_cur_domain aag s \<and>
+    apply (rule_tac Q'="\<lambda>r s. guarded_pas_domain aag s \<and> pas_cur_domain aag s \<and>
                              domain_fields_equiv st s \<and> idle_thread s = idle_thread st \<and>
                              globals_equiv_scheduler st s \<and> silc_inv aag st s \<and>
                              silc_dom_equiv aag st s \<and> invs s" in hoare_strengthen_post)
@@ -702,7 +702,7 @@ lemma kernel_entry_if_integrity:
   unfolding kernel_entry_if_def
   apply wp
      apply (rule valid_validE)
-     apply (rule_tac Q="\<lambda>_ s. integrity aag X (st\<lparr>kheap :=
+     apply (rule_tac Q'="\<lambda>_ s. integrity aag X (st\<lparr>kheap :=
                          (kheap st)(cur_thread st \<mapsto> TCB (tcb_arch_update (arch_tcb_context_set tc)
                                                             (the (get_tcb (cur_thread st) st))))\<rparr>) s
                        \<and> is_subject aag (cur_thread s)
@@ -737,7 +737,7 @@ lemma kernel_entry_if_partitionIntegrity:
                     and guarded_pas_domain aag and (\<lambda>s. ev \<noteq> Interrupt \<and> ct_active s) and (=) st\<rbrace>
    kernel_entry_if ev tc
    \<lbrace>\<lambda>_. partitionIntegrity (aag :: 'a subject_label PAS) st\<rbrace>"
-  apply (rule_tac Q="\<lambda>rv s. (\<forall>X. integrity (aag\<lparr>pasMayActivate := False,
+  apply (rule_tac Q'="\<lambda>rv s. (\<forall>X. integrity (aag\<lparr>pasMayActivate := False,
                                                 pasMayEditReadyQueues := False\<rparr>) X st s) \<and>
                             domain_fields_equiv st s \<and> globals_equiv_scheduler st s \<and>
                             idle_thread s = idle_thread st \<and> silc_dom_equiv aag st s"
@@ -2330,7 +2330,7 @@ lemma schedule_if_reads_respects_g:
                   and (\<lambda>s. domain_time s > 0) and pas_refined pas) (schedule_if tc)"
   apply (simp add: schedule_if_def)
   apply (wp schedule_reads_respects_g activate_thread_reads_respects_g)
-   apply (rule_tac Q="\<lambda>rv s. guarded_pas_domain pas s \<and> invs s \<and> pas_cur_domain pas s"
+   apply (rule_tac Q'="\<lambda>rv s. guarded_pas_domain pas s \<and> invs s \<and> pas_cur_domain pas s"
                 in hoare_strengthen_post)
     apply (wp schedule_guarded_pas_domain schedule_cur_domain
            | simp add: guarded_pas_domain_def

--- a/proof/infoflow/RISCV64/ArchADT_IF.thy
+++ b/proof/infoflow/RISCV64/ArchADT_IF.thy
@@ -249,7 +249,7 @@ lemma invoke_tcb_irq_state_inv[ADT_IF_assms]:
     defer
       apply ((wp irq_state_inv_triv | simp)+)[2]
     apply (simp add: split_def cong: option.case_cong)
-  by (wp hoare_vcg_all_liftE_R hoare_vcg_all_lift hoare_vcg_const_imp_lift_R
+  by (wp hoare_vcg_all_liftE_R hoare_vcg_all_lift hoare_vcg_const_imp_liftE_R
          checked_cap_insert_domain_sep_inv cap_delete_deletes
          cap_delete_irq_state_inv[where st=st and sta=sta and irq=irq]
          cap_delete_irq_state_next[where st=st and sta=sta and irq=irq]

--- a/proof/infoflow/RISCV64/ArchArch_IF.thy
+++ b/proof/infoflow/RISCV64/ArchArch_IF.thy
@@ -394,7 +394,7 @@ lemma perform_page_invocation_reads_respects:
              mapM_ev'' store_pte_reads_respects unmap_page_reads_respects  dmo_mol_2_reads_respects
              get_cap_rev set_mrs_reads_respects set_message_info_reads_respects
           | simp add: sfence_def
-          | wpc | wp (once) hoare_drop_imps[where R="\<lambda>r s. r"])+
+          | wpc | wp (once) hoare_drop_imps[where Q'="\<lambda>r s. r"])+
   apply (clarsimp simp: authorised_page_inv_def valid_page_inv_def)
   apply (auto simp: cte_wp_at_caps_of_state authorised_slots_def cap_links_asid_slot_def
                     label_owns_asid_slot_def valid_arch_cap_def wellformed_mapdata_def
@@ -471,7 +471,7 @@ lemma copy_global_mappings_valid_arch_state:
   unfolding copy_global_mappings_def including classic_wp_pre
   apply simp
   apply wp
-   apply (rule_tac Q="\<lambda>_. valid_arch_state and valid_global_vspace_mappings and pspace_aligned
+   apply (rule_tac Q'="\<lambda>_. valid_arch_state and valid_global_vspace_mappings and pspace_aligned
                                            and (\<lambda>s. x \<notin> global_refs s \<and> is_aligned x pt_bits)"
                 in hoare_strengthen_post)
     apply (wp mapM_x_wp[OF _ subset_refl]
@@ -769,7 +769,7 @@ lemma mapM_x_swp_store_pte_globals_equiv:
                     and (\<lambda>s. \<forall>x \<in> set slots. table_base x \<notin> global_refs s)\<rbrace>
    mapM_x (swp store_pte pte) slots
    \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
-  apply (rule_tac Q="\<lambda>_. pspace_aligned and globals_equiv s and valid_arch_state
+  apply (rule_tac Q'="\<lambda>_. pspace_aligned and globals_equiv s and valid_arch_state
                                         and valid_global_vspace_mappings
                                         and (\<lambda>s. \<forall>x \<in> set slots. table_base x \<notin> global_refs s)"
                in hoare_strengthen_post)
@@ -785,7 +785,7 @@ lemma mapM_x_swp_store_pte_valid_ko_at_arch[wp]:
                    and (\<lambda>s. \<forall>x \<in> set slots. table_base x \<notin> global_refs s)\<rbrace>
    mapM_x (swp store_pte A) slots
    \<lbrace>\<lambda>_. valid_arch_state\<rbrace>"
-  apply (rule_tac Q="\<lambda>_. pspace_aligned and valid_arch_state and valid_global_vspace_mappings
+  apply (rule_tac Q'="\<lambda>_. pspace_aligned and valid_arch_state and valid_global_vspace_mappings
                                         and (\<lambda>s. \<forall>x \<in> set slots. table_base x \<notin> global_refs s)"
                in hoare_strengthen_post)
    apply (wp mapM_x_wp' store_pte_valid_arch_state_unreachable
@@ -856,7 +856,7 @@ lemma mapM_swp_store_pte_globals_equiv:
                     and (\<lambda>s. \<forall>x \<in> set slots. table_base x \<notin> global_refs s)\<rbrace>
    mapM (swp store_pte pte) slots
    \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
-  apply (rule_tac Q="\<lambda>_. pspace_aligned and globals_equiv s and valid_arch_state
+  apply (rule_tac Q'="\<lambda>_. pspace_aligned and globals_equiv s and valid_arch_state
                                         and valid_global_vspace_mappings
                                         and (\<lambda>s. \<forall>x \<in> set slots. table_base x \<notin> global_refs s)"
                in hoare_strengthen_post)
@@ -872,7 +872,7 @@ lemma mapM_swp_store_pte_valid_ko_at_arch[wp]:
                     and (\<lambda>s. \<forall>x \<in> set slots. table_base x \<notin> global_refs s)\<rbrace>
    mapM (swp store_pte pte) slots
    \<lbrace>\<lambda>_. valid_arch_state\<rbrace>"
-  apply (rule_tac Q="\<lambda>_. pspace_aligned and globals_equiv s and valid_arch_state
+  apply (rule_tac Q'="\<lambda>_. pspace_aligned and globals_equiv s and valid_arch_state
                                         and valid_global_vspace_mappings
                                         and (\<lambda>s. \<forall>x \<in> set slots. table_base x \<notin> global_refs s)"
                in hoare_strengthen_post)
@@ -939,7 +939,7 @@ lemma set_mrs_globals_equiv:
         apply (simp add: zipWithM_x_mapM_x)
         apply (rule conjI)
          apply (rule impI)
-         apply (rule_tac Q="\<lambda>_. globals_equiv s" in hoare_strengthen_post)
+         apply (rule_tac Q'="\<lambda>_. globals_equiv s" in hoare_strengthen_post)
           apply (wp mapM_x_wp')
           apply (simp add: split_def)
           apply (wp store_word_offs_globals_equiv)
@@ -1059,7 +1059,7 @@ lemma perform_asid_control_invocation_globals_equiv:
    (* factor out the implication -- we know what the relevant components of the
       cap referred to in the cte_wp_at are anyway from valid_aci, so just use
       those directly to simplify the reasoning later on *)
-   apply (rule_tac Q="\<lambda>a b. globals_equiv s b \<and> invs b \<and>
+   apply (rule_tac Q'="\<lambda>a b. globals_equiv s b \<and> invs b \<and>
                              word1 \<noteq> riscv_global_pt (arch_state b) \<and> word1 \<noteq> idle_thread b \<and>
                              (\<exists>idx. cte_wp_at ((=) (UntypedCap False word1 pageBits idx)) cslot_ptr2 b) \<and>
                              descendants_of cslot_ptr2 (cdt b) = {} \<and>

--- a/proof/infoflow/RISCV64/ArchArch_IF.thy
+++ b/proof/infoflow/RISCV64/ArchArch_IF.thy
@@ -425,8 +425,9 @@ lemma riscv_asid_table_update_reads_respects:
    apply (rule modify_ev2)
    apply clarsimp
    apply (drule (1) is_subject_kheap_eq[rotated])
-   apply (auto simp: reads_equiv_def2 affects_equiv_def2 states_equiv_for_def equiv_for_def
-             intro!: equiv_asids_riscv_asid_table_update)
+   apply (fastforce simp: reads_equiv_def2 affects_equiv_def2 states_equiv_for_def equiv_for_def
+                  intro!: equiv_asids_riscv_asid_table_update)
+  apply wpsimp
   done
 
 lemma perform_asid_control_invocation_reads_respects:

--- a/proof/infoflow/RISCV64/ArchFinalCaps.thy
+++ b/proof/infoflow/RISCV64/ArchFinalCaps.thy
@@ -278,7 +278,7 @@ lemma invoke_tcb_silc_inv[FinalCaps_assms]:
          | clarsimp
          | simp only: conj_ac cong: conj_cong imp_cong
          | wp checked_insert_pas_refined checked_cap_insert_silc_inv hoare_vcg_all_liftE_R
-              hoare_vcg_all_lift hoare_vcg_const_imp_lift_R
+              hoare_vcg_all_lift hoare_vcg_const_imp_liftE_R
               cap_delete_silc_inv_not_transferable
               cap_delete_pas_refined' cap_delete_deletes
               cap_delete_valid_cap cap_delete_cte_at

--- a/proof/infoflow/RISCV64/ArchIRQMasks_IF.thy
+++ b/proof/infoflow/RISCV64/ArchIRQMasks_IF.thy
@@ -135,16 +135,16 @@ lemma invoke_tcb_irq_masks[IRQMasks_IF_assms]:
        apply (rule hoare_strengthen_postE[OF cap_delete_irq_masks[where P=P]])
         apply blast
        apply blast
-      apply (wpsimp wp: hoare_vcg_all_liftE_R hoare_vcg_const_imp_lift_R hoare_vcg_all_lift hoare_drop_imps
+      apply (wpsimp wp: hoare_vcg_all_liftE_R hoare_vcg_const_imp_liftE_R hoare_vcg_all_lift hoare_drop_imps
                         checked_cap_insert_domain_sep_inv)+
-      apply (rule_tac Q="\<lambda> r s. domain_sep_inv False st s \<and> P (irq_masks_of_state s)"
-                  and E="\<lambda>_ s. P (irq_masks_of_state s)" in hoare_strengthen_postE)
+      apply (rule_tac Q'="\<lambda> r s. domain_sep_inv False st s \<and> P (irq_masks_of_state s)"
+                  and E'="\<lambda>_ s. P (irq_masks_of_state s)" in hoare_strengthen_postE)
         apply (wp hoare_vcg_conj_liftE1 cap_delete_irq_masks)
        apply fastforce
       apply blast
      apply (wpsimp wp: hoare_weak_lift_imp hoare_vcg_all_lift checked_cap_insert_domain_sep_inv)+
-     apply (rule_tac Q="\<lambda> r s. domain_sep_inv False st s \<and> P (irq_masks_of_state s)"
-                 and E="\<lambda>_ s. P (irq_masks_of_state s)" in hoare_strengthen_postE)
+     apply (rule_tac Q'="\<lambda> r s. domain_sep_inv False st s \<and> P (irq_masks_of_state s)"
+                 and E'="\<lambda>_ s. P (irq_masks_of_state s)" in hoare_strengthen_postE)
        apply (wp hoare_vcg_conj_liftE1 cap_delete_irq_masks)
       apply fastforce
      apply blast

--- a/proof/infoflow/RISCV64/ArchIpc_IF.thy
+++ b/proof/infoflow/RISCV64/ArchIpc_IF.thy
@@ -381,7 +381,7 @@ lemma set_mrs_equiv_but_for_labels[Ipc_IF_assms]:
   unfolding set_mrs_def
   apply (wp | wpc)+
         apply (subst zipWithM_x_mapM_x)
-        apply (rule_tac Q="\<lambda>_. equiv_but_for_labels aag L st and K (pasObjectAbs aag thread \<in> L  \<and>
+        apply (rule_tac Q'="\<lambda>_. equiv_but_for_labels aag L st and K (pasObjectAbs aag thread \<in> L  \<and>
                                (case buf of (Some buf') \<Rightarrow> is_aligned buf' msg_align_bits \<and>
                                                            (\<forall>x \<in> ptr_range buf' msg_align_bits.
                                                               pasObjectAbs aag x \<in> L)

--- a/proof/infoflow/RISCV64/ArchNoninterference.thy
+++ b/proof/infoflow/RISCV64/ArchNoninterference.thy
@@ -66,7 +66,7 @@ lemma do_user_op_if_partitionIntegrity[Noninterference_assms]:
   "\<lbrace>partitionIntegrity aag st and pas_refined aag and invs and is_subject aag \<circ> cur_thread\<rbrace>
    do_user_op_if tc uop
    \<lbrace>\<lambda>_. partitionIntegrity aag st\<rbrace>"
- apply (rule_tac Q="\<lambda>rv s. integrity (aag\<lparr>pasMayActivate := False, pasMayEditReadyQueues := False\<rparr>)
+ apply (rule_tac Q'="\<lambda>rv s. integrity (aag\<lparr>pasMayActivate := False, pasMayEditReadyQueues := False\<rparr>)
                                      (scheduler_affects_globals_frame st) st s \<and>
                            domain_fields_equiv st s \<and> idle_thread s = idle_thread st \<and>
                            globals_equiv_scheduler st s \<and> silc_dom_equiv aag st s"

--- a/proof/infoflow/RISCV64/ArchRetype_IF.thy
+++ b/proof/infoflow/RISCV64/ArchRetype_IF.thy
@@ -154,7 +154,7 @@ lemma copy_global_mappings_reads_respects_g:
   apply clarsimp
   apply (rule bind_ev_pre)
      prefer 3
-     apply (rule_tac Q="\<lambda>s. is_subject aag x \<and> x \<noteq> riscv_global_pt (arch_state s) \<and>
+     apply (rule_tac P'="\<lambda>s. is_subject aag x \<and> x \<noteq> riscv_global_pt (arch_state s) \<and>
                             pspace_aligned s \<and> valid_global_arch_objs s" in hoare_weaken_pre)
       apply (rule gets_sp)
      apply (assumption)
@@ -237,7 +237,7 @@ lemma copy_global_mappings_globals_equiv:
   unfolding copy_global_mappings_def including classic_wp_pre
   apply simp
   apply wp
-   apply (rule_tac Q="\<lambda>_. globals_equiv s and (\<lambda>s. x \<noteq> riscv_global_pt (arch_state s) \<and>
+   apply (rule_tac Q'="\<lambda>_. globals_equiv s and (\<lambda>s. x \<noteq> riscv_global_pt (arch_state s) \<and>
                                                    is_aligned x pt_bits)" in hoare_strengthen_post)
     apply (wp mapM_x_wp[OF _ subset_refl] store_pte_globals_equiv)
     apply (simp only: pt_index_def)
@@ -490,7 +490,7 @@ lemma invoke_untyped_reads_respects_g_wcap[Retype_IF_assms]:
   apply (wpsimp wp: mapM_x_ev'' create_cap_reads_respects_g
                     hoare_vcg_ball_lift init_arch_objects_reads_respects_g)+
           apply (wp retype_region_reads_respects_g[where sz=sz and slot="slot_of_untyped_inv ui"])
-         apply (rule_tac Q="\<lambda>rvc s. (\<forall>x\<in>set rvc. is_subject aag x) \<and>
+         apply (rule_tac Q'="\<lambda>rvc s. (\<forall>x\<in>set rvc. is_subject aag x) \<and>
                                     (\<forall>x\<in>set rvc. is_aligned x (obj_bits_api apiobject_type nat)) \<and>
                                     ((0::obj_ref) < of_nat (length list)) \<and>
                                     post_retype_invs apiobject_type rvc s \<and>
@@ -529,8 +529,8 @@ lemma invoke_untyped_reads_respects_g_wcap[Retype_IF_assms]:
    apply (rule_tac P="authorised_untyped_inv aag ui \<and>
                       (\<forall>p \<in> ptr_range ptr sz. is_subject aag p)" in hoare_gen_asmE)
    apply (rule validE_validE_R,
-          rule_tac E="\<top>\<top>"
-               and Q="\<lambda>_. invs and valid_untyped_inv_wcap ui (Some (UntypedCap dev ptr sz (If reset 0 idx)))
+          rule_tac E'="\<top>\<top>"
+               and Q'="\<lambda>_. invs and valid_untyped_inv_wcap ui (Some (UntypedCap dev ptr sz (If reset 0 idx)))
                                and ct_active
                                and (\<lambda>s. reset \<longrightarrow> pspace_no_overlap {ptr .. ptr + 2 ^ sz - 1} s)"
                 in hoare_strengthen_postE)
@@ -605,7 +605,7 @@ lemma reset_untyped_cap_globals_equiv:
              preemption_point_inv | simp add: unless_def)+
      apply (rule valid_validE)
      apply (rule_tac P="cap_aligned cap \<and> is_untyped_cap cap" in hoare_gen_asm)
-     apply (rule_tac Q="\<lambda>_ s. valid_global_objs s \<and> valid_arch_state s \<and> globals_equiv st s"
+     apply (rule_tac Q'="\<lambda>_ s. valid_global_objs s \<and> valid_arch_state s \<and> globals_equiv st s"
                   in hoare_strengthen_post)
       apply (rule validE_valid, rule mapME_x_wp')
       apply (rule hoare_pre)

--- a/proof/infoflow/RISCV64/ArchScheduler_IF.thy
+++ b/proof/infoflow/RISCV64/ArchScheduler_IF.thy
@@ -173,7 +173,7 @@ lemma globals_equiv_scheduler_inv'[Scheduler_IF_assms]:
   apply (rule use_spec)
   apply (simp add: spec_valid_def)
   apply (erule_tac x="(swap_things sa s)" in allE)
-  apply (rule_tac Q="\<lambda>r st. globals_equiv (swap_things sa s) st" in hoare_strengthen_post)
+  apply (rule_tac Q'="\<lambda>r st. globals_equiv (swap_things sa s) st" in hoare_strengthen_post)
    apply (rule hoare_pre)
     apply assumption
    apply (clarsimp simp: globals_equiv_def swap_things_def globals_equiv_scheduler_def

--- a/proof/infoflow/RISCV64/ArchTcb_IF.thy
+++ b/proof/infoflow/RISCV64/ArchTcb_IF.thy
@@ -105,13 +105,13 @@ lemma invoke_tcb_thread_preservation[Tcb_IF_assms]:
                              tcb_cap_always_valid_strg[where p="tcb_cnode_index (Suc 0)"]
                 | simp add: conj_comms(1, 2)
                 | rule wp_split_const_if wp_split_const_if_R hoare_vcg_all_liftE_R
-                       hoare_vcg_E_elim hoare_vcg_const_imp_lift_R hoare_vcg_R_conj
+                       hoare_vcg_conj_elimE hoare_vcg_const_imp_liftE_R hoare_vcg_conj_liftE_R
                 | (wp check_cap_inv2[where Q="\<lambda>_. pas_refined aag"]
                       check_cap_inv2[where Q="\<lambda>_ s. t \<noteq> idle_thread s"]
                       out_invs_trivial case_option_wpE cap_delete_deletes
                       cap_delete_valid_cap cap_insert_valid_cap out_cte_at
                       cap_insert_cte_at cap_delete_cte_at out_valid_cap out_tcb_valid
-                      hoare_vcg_const_imp_lift_R hoare_vcg_all_liftE_R
+                      hoare_vcg_const_imp_liftE_R hoare_vcg_all_liftE_R
                       thread_set_tcb_ipc_buffer_cap_cleared_invs
                       thread_set_invs_trivial[OF ball_tcb_cap_casesI]
                       hoare_vcg_all_lift thread_set_valid_cap out_emptyable
@@ -151,7 +151,7 @@ lemma tc_reads_respects_f[Tcb_IF_assms]:
        (invoke_tcb ti)"
   apply (simp add: split_def cong: option.case_cong)
   apply (wpsimp wp: set_priority_reads_respects[THEN reads_respects_f[where  st=st and Q=\<top>]])
-                    apply (wpsimp wp: hoare_vcg_const_imp_lift_R simp: when_def | wpc)+
+                    apply (wpsimp wp: hoare_vcg_const_imp_liftE_R simp: when_def | wpc)+
                     apply (rule conjI)
                      apply ((wpsimp wp: reschedule_required_reads_respects_f)+)[4]
                  apply ((wp reads_respects_f[OF cap_insert_reads_respects, where st=st]
@@ -179,7 +179,7 @@ lemma tc_reads_respects_f[Tcb_IF_assms]:
                            set_mcpriority_only_timer_irq_inv[where st=st' and irq=irq]
                            cap_delete_deletes cap_delete_valid_cap cap_delete_cte_at
                            cap_delete_pas_refined' itr_wps(12) itr_wps(14) cap_insert_cte_at
-                           checked_insert_no_cap_to hoare_vcg_const_imp_lift_R hoare_vcg_conj_lift
+                           checked_insert_no_cap_to hoare_vcg_const_imp_liftE_R hoare_vcg_conj_lift
                            as_user_reads_respects_f thread_set_mdb cap_delete_invs
                       | wpc
                       | simp add: emptyable_def tcb_cap_cases_def tcb_cap_valid_def
@@ -210,7 +210,7 @@ lemma tc_reads_respects_f[Tcb_IF_assms]:
                       set_mcpriority_only_timer_irq_inv[where st=st' and irq=irq]
                       cap_delete_deletes cap_delete_valid_cap cap_delete_cte_at
                       cap_delete_pas_refined' itr_wps(12) itr_wps(14) cap_insert_cte_at
-                      checked_insert_no_cap_to hoare_vcg_const_imp_lift_R
+                      checked_insert_no_cap_to hoare_vcg_const_imp_liftE_R
                       as_user_reads_respects_f cap_delete_invs
                  | wpc
                  | simp add: emptyable_def tcb_cap_cases_def tcb_cap_valid_def when_def st_tcb_at_triv

--- a/proof/infoflow/Syscall_IF.thy
+++ b/proof/infoflow/Syscall_IF.thy
@@ -705,10 +705,10 @@ lemma handle_recv_reads_respects_f:
                       simp: aag_cap_auth_def cap_auth_conferred_def cap_rights_to_auth_def)[1]
         apply (wp reads_respects_f[OF handle_fault_reads_respects,where st=st])
        apply (wpsimp wp: get_simple_ko_wp get_cap_wp)+
-        apply (rule_tac Q="\<lambda>r s. silc_inv aag st s \<and> einvs s \<and> pas_refined aag s \<and>
+        apply (rule_tac Q'="\<lambda>r s. silc_inv aag st s \<and> einvs s \<and> pas_refined aag s \<and>
                                  tcb_at rv s \<and> pas_cur_domain aag s \<and> is_subject aag rv \<and>
                                  is_subject aag (cur_thread s) \<and> is_subject aag (fst (fst r))"
-                     and E=E and F=E for E in hoare_strengthen_postE)
+                     and E'=E and E=E for E in hoare_strengthen_postE)
           apply (wp lookup_slot_for_thread_authorised lookup_slot_for_thread_cap_fault)
          apply ((fastforce simp add:valid_fault_def)+)[3]
       apply (wp reads_respects_f[OF as_user_reads_respects,where st=st and Q=\<top>])

--- a/proof/infoflow/Syscall_IF.thy
+++ b/proof/infoflow/Syscall_IF.thy
@@ -723,16 +723,16 @@ lemma handle_recv_globals_equiv:
   unfolding handle_recv_def
   apply (wp handle_fault_globals_equiv get_simple_ko_wp
         | wpc | simp add: Let_def)+
-      apply (rule_tac Q="\<lambda>r s. invs s \<and> globals_equiv st s" and
-                      E = "\<lambda>r s. valid_fault (CapFault (of_bl ep_cptr) True r)"
+      apply (rule_tac Q'="\<lambda>r s. invs s \<and> globals_equiv st s" and
+                      E'="\<lambda>r s. valid_fault (CapFault (of_bl ep_cptr) True r)"
                    in hoare_strengthen_postE)
-        apply (rule hoare_vcg_E_elim)
+        apply (rule hoare_vcg_conj_elimE)
          apply (wp lookup_cap_cap_fault receive_ipc_globals_equiv
                    receive_signal_globals_equiv delete_caller_cap_invs
                    delete_caller_cap_globals_equiv
                 | wpc
                 | simp add: Let_def invs_imps invs_valid_idle valid_fault_def
-                | rule_tac Q="\<lambda>rv s. invs s \<and> thread \<noteq> idle_thread s \<and> globals_equiv st s"
+                | rule_tac Q'="\<lambda>rv s. invs s \<and> thread \<noteq> idle_thread s \<and> globals_equiv st s"
                            in hoare_strengthen_post,
                   wp,
                   clarsimp simp: invs_valid_objs invs_valid_global_objs invs_arch_state invs_distinct)+
@@ -907,11 +907,11 @@ lemma handle_event_reads_respects_f_g:
         apply ((wp reads_respects_f_g'[OF handle_fault_reads_respects_g, where st=st] | simp)+)[1]
        prefer 2
        apply (simp add: validE_E_def)
-       apply (rule_tac E="\<lambda>r s. invs s \<and> is_subject aag rv \<and> is_subject aag (cur_thread s)
+       apply (rule_tac E'="\<lambda>r s. invs s \<and> is_subject aag rv \<and> is_subject aag (cur_thread s)
                               \<and> valid_fault r \<and> pas_refined aag s \<and> pas_cur_domain aag s
                               \<and> silc_inv aag st s \<and> rv \<noteq> idle_thread s"
-                   and Q="\<top>\<top>" in hoare_strengthen_postE)
-         apply (rule hoare_vcg_E_conj)
+                   and Q'="\<top>\<top>" in hoare_strengthen_postE)
+         apply (rule hoare_vcg_conj_liftE_E)
           apply (wp hv_invs handle_vm_fault_silc_inv)+
        apply (simp add: invs_imps invs_mdb invs_valid_idle)+
      apply wp+
@@ -987,8 +987,8 @@ lemma handle_invocation_globals_equiv:
             set_thread_state_globals_equiv hoare_vcg_all_lift
          | simp split del: if_split
          | wp (once) hoare_drop_imps)+
-         apply (rule_tac Q="\<lambda>r. invs and globals_equiv st and (\<lambda>s. thread \<noteq> idle_thread s)"
-                     and E="\<lambda>_. globals_equiv st" in hoare_strengthen_postE)
+         apply (rule_tac Q'="\<lambda>r. invs and globals_equiv st and (\<lambda>s. thread \<noteq> idle_thread s)"
+                     and E'="\<lambda>_. globals_equiv st" in hoare_strengthen_postE)
            apply (wp pinv_invs perform_invocation_globals_equiv
                      requiv_get_tcb_eq' set_thread_state_globals_equiv
                      sts_authorised_for_globals_inv

--- a/proof/infoflow/Tcb_IF.thy
+++ b/proof/infoflow/Tcb_IF.thy
@@ -165,11 +165,11 @@ lemma rec_del_preservation2:
      rec_del call
      \<lbrace>\<lambda>r. P\<rbrace>"
   apply (insert assms)
-  apply (rule_tac Q="\<lambda>s. invs s \<and> P s \<and> Q s
+  apply (rule_tac P'="\<lambda>s. invs s \<and> P s \<and> Q s
                                 \<and> emptyable (slot_rdcall call) s
                                 \<and> valid_rec_del_call call s" in hoare_pre_imp)
    apply simp
-  apply (rule_tac Q="\<lambda>rv s. P s \<and> Q s" in hoare_strengthen_post)
+  apply (rule_tac Q'="\<lambda>rv s. P s \<and> Q s" in hoare_strengthen_post)
    apply (rule validE_valid)
    apply (rule use_spec)
    apply (rule rec_del_preservation2' [where R=R],simp+)
@@ -306,7 +306,7 @@ lemma invoke_tcb_globals_equiv:
                                 | clarsimp simp: no_cap_to_idle_thread)+\<close>)?)
    apply wpsimp
        apply (rename_tac word1 word2 bool1 bool2 bool3 bool4 arch_copy_register_sets)
-       apply (rule_tac Q="\<lambda>_. valid_arch_state and globals_equiv st and
+       apply (rule_tac Q'="\<lambda>_. valid_arch_state and globals_equiv st and
                               (\<lambda>s. word1 \<noteq> idle_thread s) and (\<lambda>s. word2 \<noteq> idle_thread s)"
                     in hoare_strengthen_post)
         apply (wpsimp wp: mapM_x_wp' as_user_globals_equiv invoke_tcb_NotificationControl_globals_equiv
@@ -500,7 +500,7 @@ lemma invoke_tcb_reads_respects_f:
          apply (strengthen invs_mdb
                 | wpsimp wp: when_ev restart_reads_respects_f reschedule_required_reads_respects_f
                              as_user_reads_respects_f restart_silc_inv restart_pas_refined hoare_vcg_if_lift)+
-            apply (rule hoare_strengthen_post[where Q="\<lambda>_ s. \<forall>rv. R rv s" and R=R for R, rotated])
+            apply (rule hoare_strengthen_post[where Q'="\<lambda>_ s. \<forall>rv. R rv s" and R=R for R, rotated])
              apply (rename_tac rv s)
              apply (erule_tac x=rv in allE, assumption)
             apply wpsimp+
@@ -518,7 +518,7 @@ lemma invoke_tcb_reads_respects_f:
                  restart_silc_inv restart_pas_refined
               | simp split del: if_split add: det_setRegister det_setNextPC
               | strengthen invs_mdb
-              | (rule hoare_strengthen_post[where Q="\<lambda>_. silc_inv aag st and pas_refined aag
+              | (rule hoare_strengthen_post[where Q'="\<lambda>_. silc_inv aag st and pas_refined aag
                                                                          and pspace_aligned
                                                                          and valid_vspace_objs
                                                                          and valid_arch_state",

--- a/proof/infoflow/Tcb_IF.thy
+++ b/proof/infoflow/Tcb_IF.thy
@@ -500,7 +500,7 @@ lemma invoke_tcb_reads_respects_f:
          apply (strengthen invs_mdb
                 | wpsimp wp: when_ev restart_reads_respects_f reschedule_required_reads_respects_f
                              as_user_reads_respects_f restart_silc_inv restart_pas_refined hoare_vcg_if_lift)+
-            apply (rule hoare_strengthen_post[where Q'="\<lambda>_ s. \<forall>rv. R rv s" and R=R for R, rotated])
+            apply (rule hoare_strengthen_post[where Q'="\<lambda>_ s. \<forall>rv. Q rv s" and Q=Q for Q, rotated])
              apply (rename_tac rv s)
              apply (erule_tac x=rv in allE, assumption)
             apply wpsimp+

--- a/proof/infoflow/refine/ADT_IF_Refine.thy
+++ b/proof/infoflow/refine/ADT_IF_Refine.thy
@@ -132,7 +132,7 @@ lemma kernel_entry_if_valid_domain_time:
    apply (wp handle_interrupt_valid_domain_time
           | clarsimp | wpc)+
      \<comment> \<open>strengthen post of do_machine_op; we know interrupt occurred\<close>
-     apply (rule_tac Q="\<lambda>_ s. 0 < domain_time s" in hoare_post_imp, fastforce)
+     apply (rule_tac Q'="\<lambda>_ s. 0 < domain_time s" in hoare_post_imp, fastforce)
      apply (wp+, simp)
   done
 
@@ -362,7 +362,7 @@ lemma doUserOp_if_ex_abs[wp]:
    \<lbrace>\<lambda>_. ex_abs (einvs)\<rbrace>"
   apply (rule hoare_pre)
    apply (rule corres_ex_abs_lift'[OF do_user_op_if_corres'])
-   apply (rule_tac Q="\<lambda>a. invs and ct_running and valid_list and valid_sched" in hoare_strengthen_post)
+   apply (rule_tac Q'="\<lambda>a. invs and ct_running and valid_list and valid_sched" in hoare_strengthen_post)
     apply (wp do_user_op_if_invs)
    apply clarsimp
   apply (clarsimp simp: ex_abs_def)
@@ -433,7 +433,7 @@ lemma handle_preemption_if_valid_domain_time:
   unfolding handle_preemption_if_def
   apply (rule hoare_pre)
    apply (wp handle_interrupt_valid_domain_time)
-   apply (rule_tac Q="\<lambda>_ s. 0 < domain_time s" in hoare_post_imp, fastforce)
+   apply (rule_tac Q'="\<lambda>_ s. 0 < domain_time s" in hoare_post_imp, fastforce)
    apply (wp, simp)
   done
 
@@ -772,7 +772,7 @@ lemma abstract_invs:
               apply (rule preserves_lifts |
                      wp check_active_irq_if_wp do_user_op_if_invs
                     | clarsimp simp add: full_invs_if_def)+
-          apply (rule_tac Q="\<lambda>r s'. (invs and ct_running) s' \<and>
+          apply (rule_tac Q'="\<lambda>r s'. (invs and ct_running) s' \<and>
                    valid_list s' \<and>
                    valid_sched s' \<and> scheduler_action s' = resume_cur_thread \<and>
                    valid_domain_list s' \<and>
@@ -782,7 +782,7 @@ lemma abstract_invs:
              apply clarsimp+
          apply (rule preserves_lifts)
          apply (simp add: full_invs_if_def)
-         apply (rule_tac Q="\<lambda>r s'. (invs and ct_running) s' \<and>
+         apply (rule_tac Q'="\<lambda>r s'. (invs and ct_running) s' \<and>
                   valid_list s' \<and>
                    valid_domain_list s' \<and>
                   domain_time s' \<noteq> 0 \<and>

--- a/proof/infoflow/refine/ADT_IF_Refine_C.thy
+++ b/proof/infoflow/refine/ADT_IF_Refine_C.thy
@@ -197,7 +197,7 @@ lemma handleEvent_Interrupt_no_fail: "no_fail (invs' and ex_abs einvs) (handleEv
    apply wp
      apply (rule handleInterrupt_no_fail)
     apply (simp add: crunch_simps)
-    apply (rule_tac Q="\<lambda>r s. ex_abs (einvs) s \<and> invs' s \<and>
+    apply (rule_tac Q'="\<lambda>r s. ex_abs (einvs) s \<and> invs' s \<and>
                              (\<forall>irq. r = Some irq
                                     \<longrightarrow> intStateIRQTable (ksInterruptState s) irq \<noteq> irqstate.IRQInactive)"
                  in hoare_strengthen_post)
@@ -269,7 +269,7 @@ lemma handleEvent_ccorres:
                apply wp[1]
               apply clarsimp
               apply wp
-              apply (rule_tac Q="\<lambda>rv s. ct_in_state' simple' s \<and> sch_act_sane s"
+              apply (rule_tac Q'="\<lambda>rv s. ct_in_state' simple' s \<and> sch_act_sane s"
                     in hoare_post_imp)
                apply (simp add: ct_in_state'_def)
               apply (wp handleReply_sane)
@@ -510,7 +510,7 @@ lemma schedule_if_corres_C:
          apply simp
         apply simp
        apply (rule wp_post_taut)+
-     apply (rule_tac Q="\<lambda>r. ct_in_state' activatable' and invs' and
+     apply (rule_tac Q'="\<lambda>r. ct_in_state' activatable' and invs' and
                             ex_abs (invs and ct_in_state activatable)" in hoare_strengthen_post)
       apply (wp schedule_invs' corres_ex_abs_lift)
        apply (rule schedule_corres)

--- a/proof/infoflow/refine/ARM/ArchADT_IF_Refine_C.thy
+++ b/proof/infoflow/refine/ARM/ArchADT_IF_Refine_C.thy
@@ -38,7 +38,7 @@ proof -
      apply (rule allI, rule conseqPre, vcg)
      apply (clarsimp simp: return_def)
     apply wp
-   apply (rule_tac Q="\<lambda>rv s. invs' s \<and> (\<forall>x. rv = Some x \<longrightarrow> x \<le> maxIRQ)" in hoare_post_imp)
+   apply (rule_tac Q'="\<lambda>rv s. invs' s \<and> (\<forall>x. rv = Some x \<longrightarrow> x \<le> maxIRQ)" in hoare_post_imp)
     apply (solves clarsimp)
    apply (wp getActiveIRQ_le_maxIRQ | simp)+
   apply (clarsimp simp: invs'_def valid_state'_def)

--- a/proof/infoflow/refine/RISCV64/ArchADT_IF_Refine_C.thy
+++ b/proof/infoflow/refine/RISCV64/ArchADT_IF_Refine_C.thy
@@ -38,7 +38,7 @@ proof -
      apply (rule allI, rule conseqPre, vcg)
      apply (clarsimp simp: return_def)
     apply wp
-   apply (rule_tac Q="\<lambda>rv s. invs' s \<and> (\<forall>x. rv = Some x \<longrightarrow> x \<le> maxIRQ)" in hoare_post_imp)
+   apply (rule_tac Q'="\<lambda>rv s. invs' s \<and> (\<forall>x. rv = Some x \<longrightarrow> x \<le> maxIRQ)" in hoare_post_imp)
     apply (clarsimp simp: non_kernel_IRQs_def)
    apply (wp getActiveIRQ_le_maxIRQ | simp)+
   apply (clarsimp simp: invs'_def valid_state'_def)

--- a/proof/invariant-abstract/AARCH64/ArchArch_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchArch_AI.thy
@@ -932,7 +932,7 @@ lemma associate_vcpu_tcb_sym_refs_hyp[wp]:
                              obj_at (\<lambda>ko. hyp_refs_of ko = {} ) t s  \<and>
                              sym_refs (state_hyp_refs_of s)"
                           in hoare_triv)
-      apply (rule_tac Q="\<lambda>rv s. obj_at (\<lambda>ko. hyp_refs_of ko = {} ) vr s \<and>
+      apply (rule_tac Q'="\<lambda>rv s. obj_at (\<lambda>ko. hyp_refs_of ko = {} ) vr s \<and>
                                 obj_at (\<lambda>ko. hyp_refs_of ko = {} ) t s  \<and>
                                 sym_refs (state_hyp_refs_of s)"
                              in hoare_post_imp)
@@ -945,7 +945,7 @@ lemma associate_vcpu_tcb_sym_refs_hyp[wp]:
        apply (wp | wpc | clarsimp)+
       apply (simp add: obj_at_def vcpu_tcb_refs_def)
      apply (wp  get_vcpu_ko | wpc | clarsimp)+
-   apply (rule_tac Q="\<lambda>rv s. (\<exists>t'. obj_at (\<lambda>tcb. tcb = TCB t' \<and> rv = tcb_vcpu (tcb_arch t')) t s) \<and>
+   apply (rule_tac Q'="\<lambda>rv s. (\<exists>t'. obj_at (\<lambda>tcb. tcb = TCB t' \<and> rv = tcb_vcpu (tcb_arch t')) t s) \<and>
                              sym_refs (state_hyp_refs_of s)"
                           in hoare_post_imp)
     apply (clarsimp simp: obj_at_def)
@@ -1137,7 +1137,7 @@ lemma associate_vcpu_tcb_valid_arch_state[wp]:
   supply fun_upd_apply[simp del]
   apply (clarsimp simp: associate_vcpu_tcb_def)
   apply (wpsimp wp: vcpu_switch_valid_arch)
-        apply (rule_tac Q="\<lambda>_ s. valid_arch_state s \<and> vcpu_hyp_live_of s vcpu" in hoare_post_imp)
+        apply (rule_tac Q'="\<lambda>_ s. valid_arch_state s \<and> vcpu_hyp_live_of s vcpu" in hoare_post_imp)
          apply fastforce
         apply wpsimp+
   done

--- a/proof/invariant-abstract/AARCH64/ArchCNodeInv_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchCNodeInv_AI.thy
@@ -714,7 +714,7 @@ next
     apply simp
     apply (rule hoare_pre_spec_validE)
      apply (wp replace_cap_invs | simp add: is_cap_simps)+
-      apply (rule_tac Q="\<lambda>rv s. Q s \<and> invs s \<and> cte_wp_at (\<lambda>cap. cap = rv) slot s
+      apply (rule_tac Q'="\<lambda>rv s. Q s \<and> invs s \<and> cte_wp_at (\<lambda>cap. cap = rv) slot s
                              \<and> cte_wp_at (\<lambda>cap. cap = cap.NullCap
                                         \<or> \<not> False \<and> is_zombie cap
                                             \<and> (ptr, nat_to_cref (zombie_cte_bits bits) n)

--- a/proof/invariant-abstract/AARCH64/ArchDetSchedDomainTime_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchDetSchedDomainTime_AI.thy
@@ -76,7 +76,7 @@ lemma vgic_maintenance_valid_domain_time:
   "\<lbrace>\<lambda>s. 0 < domain_time s\<rbrace>
     vgic_maintenance \<lbrace>\<lambda>y s. domain_time s = 0 \<longrightarrow> scheduler_action s = choose_new_thread\<rbrace>"
   unfolding vgic_maintenance_def
-  apply (rule hoare_strengthen_post [where Q="\<lambda>_ s. 0 < domain_time s"])
+  apply (rule hoare_strengthen_post[where Q'="\<lambda>_ s. 0 < domain_time s"])
    apply (wpsimp wp: handle_fault_domain_time_inv hoare_drop_imps)
   apply clarsimp
   done
@@ -85,7 +85,7 @@ lemma vppi_event_valid_domain_time:
   "\<lbrace>\<lambda>s :: det_ext state. 0 < domain_time s\<rbrace>
     vppi_event irq \<lbrace>\<lambda>y s. domain_time s = 0 \<longrightarrow> scheduler_action s = choose_new_thread\<rbrace>"
   unfolding vppi_event_def
-  apply (rule hoare_strengthen_post [where Q="\<lambda>_ s. 0 < domain_time s"])
+  apply (rule hoare_strengthen_post[where Q'="\<lambda>_ s. 0 < domain_time s"])
    apply (wpsimp wp: handle_fault_domain_time_inv hoare_drop_imps)
   apply clarsimp
   done
@@ -112,7 +112,7 @@ lemma timer_tick_valid_domain_time:
            wp: reschedule_required_valid_domain_time hoare_vcg_const_imp_lift gts_wp
                (* unless we hit dec_domain_time we know ?dtnot0 holds on the state, so clean up the
                   postcondition once we hit thread_set_time_slice *)
-               hoare_post_imp[where Q="\<lambda>_. ?dtnot0" and R="\<lambda>_ s. domain_time s = 0 \<longrightarrow> X s"
+               hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and R="\<lambda>_ s. domain_time s = 0 \<longrightarrow> X s"
                                 and a="thread_set_time_slice t ts" for X t ts]
                hoare_drop_imp[where f="ethread_get t f" for t f])
   apply fastforce
@@ -128,15 +128,15 @@ lemma handle_interrupt_valid_domain_time [DetSchedDomainTime_AI_assms]:
   apply (case_tac "maxIRQ < i", solves \<open>wpsimp wp: hoare_false_imp\<close>)
   apply clarsimp
   apply (wpsimp simp: arch_mask_irq_signal_def)
-        apply (rule hoare_post_imp[where Q="\<lambda>_. ?dtnot0" and a="send_signal p c" for p c], fastforce)
+        apply (rule hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and a="send_signal p c" for p c], fastforce)
         apply wpsimp
-       apply (rule hoare_post_imp[where Q="\<lambda>_. ?dtnot0" and a="get_cap p" for p], fastforce)
+       apply (rule hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and a="get_cap p" for p], fastforce)
        apply (wpsimp wp: timer_tick_valid_domain_time simp: handle_reserved_irq_def)+
-     apply (rule hoare_post_imp[where Q="\<lambda>_. ?dtnot0" and a="vppi_event i" for i], fastforce)
+     apply (rule hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and a="vppi_event i" for i], fastforce)
      apply wpsimp+
-    apply (rule hoare_post_imp[where Q="\<lambda>_. ?dtnot0" and a="vgic_maintenance"], fastforce)
+    apply (rule hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and a="vgic_maintenance"], fastforce)
     apply wpsimp+
-   apply (rule hoare_post_imp[where Q="\<lambda>_. ?dtnot0" and a="get_irq_state i" for i], fastforce)
+   apply (rule hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and a="get_irq_state i" for i], fastforce)
    apply wpsimp+
   done
 

--- a/proof/invariant-abstract/AARCH64/ArchDetSchedDomainTime_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchDetSchedDomainTime_AI.thy
@@ -112,8 +112,8 @@ lemma timer_tick_valid_domain_time:
            wp: reschedule_required_valid_domain_time hoare_vcg_const_imp_lift gts_wp
                (* unless we hit dec_domain_time we know ?dtnot0 holds on the state, so clean up the
                   postcondition once we hit thread_set_time_slice *)
-               hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and R="\<lambda>_ s. domain_time s = 0 \<longrightarrow> X s"
-                                and a="thread_set_time_slice t ts" for X t ts]
+               hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and Q="\<lambda>_ s. domain_time s = 0 \<longrightarrow> X s"
+                                and f="thread_set_time_slice t ts" for X t ts]
                hoare_drop_imp[where f="ethread_get t f" for t f])
   apply fastforce
   done
@@ -128,15 +128,15 @@ lemma handle_interrupt_valid_domain_time [DetSchedDomainTime_AI_assms]:
   apply (case_tac "maxIRQ < i", solves \<open>wpsimp wp: hoare_false_imp\<close>)
   apply clarsimp
   apply (wpsimp simp: arch_mask_irq_signal_def)
-        apply (rule hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and a="send_signal p c" for p c], fastforce)
+        apply (rule hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and f="send_signal p c" for p c], fastforce)
         apply wpsimp
-       apply (rule hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and a="get_cap p" for p], fastforce)
+       apply (rule hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and f="get_cap p" for p], fastforce)
        apply (wpsimp wp: timer_tick_valid_domain_time simp: handle_reserved_irq_def)+
-     apply (rule hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and a="vppi_event i" for i], fastforce)
+     apply (rule hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and f="vppi_event i" for i], fastforce)
      apply wpsimp+
-    apply (rule hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and a="vgic_maintenance"], fastforce)
+    apply (rule hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and f="vgic_maintenance"], fastforce)
     apply wpsimp+
-   apply (rule hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and a="get_irq_state i" for i], fastforce)
+   apply (rule hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and f="get_irq_state i" for i], fastforce)
    apply wpsimp+
   done
 

--- a/proof/invariant-abstract/AARCH64/ArchDetype_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchDetype_AI.thy
@@ -645,7 +645,7 @@ lemma delete_objects_invs[wp]:
   apply (simp add: delete_objects_def)
   apply (simp add: freeMemory_def word_size_def bind_assoc)
    apply (rule hoare_pre)
-   apply (rule_tac G="is_aligned ptr bits \<and> word_size_bits \<le> bits \<and> bits \<le> word_bits"
+   apply (rule_tac P'="is_aligned ptr bits \<and> word_size_bits \<le> bits \<and> bits \<le> word_bits"
                 in hoare_grab_asm)
    apply (simp add: mapM_storeWord_clear_um[unfolded word_size_def]
                     intvl_range_conv[where 'a=machine_word_len, folded word_bits_def])

--- a/proof/invariant-abstract/AARCH64/ArchFinalise_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchFinalise_AI.thy
@@ -115,7 +115,7 @@ lemma delete_asid_pool_invs[wp]:
   apply wpsimp
       apply (strengthen invs_arm_asid_table_unmap)
       apply (rename_tac table pool)
-      apply (rule_tac Q="\<lambda>_ s. (invs s \<and> is_aligned base asid_low_bits \<and> table = asid_table s \<and>
+      apply (rule_tac Q'="\<lambda>_ s. (invs s \<and> is_aligned base asid_low_bits \<and> table = asid_table s \<and>
                                  (\<exists>ap. asid_pools_of s pptr = Some ap \<and>
                                    (\<forall>asid_low. ap asid_low \<noteq> None \<longrightarrow> pool asid_low \<noteq> None))) \<and>
                                (\<forall>x \<in> set [0 .e. mask asid_low_bits].
@@ -782,7 +782,7 @@ lemma dissociate_vcpu_tcb_sym_refs_hyp[wp]:
   "\<lbrace>\<lambda>s. sym_refs (state_hyp_refs_of s)\<rbrace> dissociate_vcpu_tcb vr t \<lbrace>\<lambda>rv s. sym_refs (state_hyp_refs_of s)\<rbrace>"
   apply (simp add: dissociate_vcpu_tcb_def arch_get_sanitise_register_info_def)
   apply (wp arch_thread_set_wp set_vcpu_wp)
-       apply (rule_tac Q="\<lambda>_ s. obj_at (\<lambda>ko. \<exists>tcb. ko = TCB tcb \<and> tcb_vcpu (tcb_arch tcb) = Some vr) t s
+       apply (rule_tac Q'="\<lambda>_ s. obj_at (\<lambda>ko. \<exists>tcb. ko = TCB tcb \<and> tcb_vcpu (tcb_arch tcb) = Some vr) t s
                              \<and> sym_refs (state_hyp_refs_of s)" in hoare_post_imp)
         apply clarsimp
         apply (clarsimp simp: get_tcb_Some_ko_at obj_at_def sym_refs_vcpu_None split: if_splits)
@@ -1127,7 +1127,7 @@ lemma arch_finalise_cap_vcpu:
   notes simps = replaceable_def
                 is_cap_simps vs_cap_ref_def
                 no_cap_to_obj_with_diff_ref_Null o_def
-  notes wps = hoare_drop_imp[where R="%_. is_final_cap' cap" for cap]
+  notes wps = hoare_drop_imp[where Q'="%_. is_final_cap' cap" for cap]
               valid_cap_typ
   shows
   "cap = VCPUCap r \<Longrightarrow> \<lbrace>\<lambda>s. s \<turnstile> cap.ArchObjectCap cap \<and>
@@ -1370,7 +1370,7 @@ lemma arch_finalise_cap_replaceable:
                 is_cap_simps vs_cap_ref_def
                 no_cap_to_obj_with_diff_ref_Null o_def
                 reachable_frame_cap_simps
-  notes wps = hoare_drop_imp[where R="%_. is_final_cap' cap" for cap]
+  notes wps = hoare_drop_imp[where Q'="%_. is_final_cap' cap" for cap]
               valid_cap_typ
               unmap_page_unreachable unmap_page_table_unreachable
               delete_asid_unreachable vcpu_finalise_unlive[simplified o_def]
@@ -1484,7 +1484,7 @@ lemma prepare_thread_delete_unlive0:
 
 lemma prepare_thread_delete_unlive[wp]:
   "\<lbrace>obj_at (Not \<circ> live0) ptr\<rbrace> prepare_thread_delete ptr \<lbrace>\<lambda>rv. obj_at (Not \<circ> live) ptr\<rbrace>"
-  apply (rule_tac Q="\<lambda>rv. obj_at (Not \<circ> live0) ptr and obj_at (Not \<circ> hyp_live) ptr" in hoare_strengthen_post)
+  apply (rule_tac Q'="\<lambda>rv. obj_at (Not \<circ> live0) ptr and obj_at (Not \<circ> hyp_live) ptr" in hoare_strengthen_post)
   apply (wpsimp wp: hoare_vcg_conj_lift prepare_thread_delete_unlive_hyp prepare_thread_delete_unlive0)
    apply (clarsimp simp: obj_at_def)
   apply (clarsimp simp: obj_at_def, case_tac ko, simp_all add: is_tcb_def live_def)

--- a/proof/invariant-abstract/AARCH64/ArchFinalise_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchFinalise_AI.thy
@@ -1324,7 +1324,7 @@ lemma delete_asid_no_vs_lookup_target_no_vspace:
    \<lbrace>\<lambda>rv s. vs_lookup_target level asid vref s \<noteq> Some (level, pt)\<rbrace>"
   unfolding delete_asid_def
   (* We know we are in the case where delete_asid does not do anything *)
-  apply (wpsimp wp: when_wp[where Q="\<lambda>_. False", simplified])
+  apply (wpsimp wp: when_wp[where P'="\<lambda>_. False", simplified])
   apply (rule conjI, fastforce simp: vs_lookup_target_def vs_lookup_slot_def vs_lookup_table_def)
   (* pool_for_asid asid s \<noteq> None *)
   apply clarsimp

--- a/proof/invariant-abstract/AARCH64/ArchInterrupt_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchInterrupt_AI.thy
@@ -146,7 +146,7 @@ lemma invoke_irq_handler_invs'[Interrupt_AI_asms]:
     apply (wp valid_cap_typ [OF cap_delete_one_typ_at])
      apply (strengthen real_cte_tcb_valid)
      apply (wp real_cte_at_typ_valid [OF cap_delete_one_typ_at])
-     apply (rule_tac Q="\<lambda>rv s. is_ntfn_cap cap \<and> invs s
+     apply (rule_tac Q'="\<lambda>rv s. is_ntfn_cap cap \<and> invs s
                               \<and> cte_wp_at (is_derived (cdt s) prod cap) prod s"
                 in hoare_post_imp)
       apply (clarsimp simp: is_cap_simps is_derived_def cte_wp_at_caps_of_state)
@@ -277,7 +277,7 @@ lemma (* handle_interrupt_invs *) [Interrupt_AI_asms]:
      apply (wpsimp wp: dmo_maskInterrupt_invs maskInterrupt_invs_ARCH dmo_ackInterrupt
                       send_signal_interrupt_states simp: arch_mask_irq_signal_def)+
      apply (wp get_cap_wp send_signal_interrupt_states )
-    apply (rule_tac Q="\<lambda>rv. invs and (\<lambda>s. st = interrupt_states s irq)" in hoare_post_imp)
+    apply (rule_tac Q'="\<lambda>rv. invs and (\<lambda>s. st = interrupt_states s irq)" in hoare_post_imp)
      apply (clarsimp simp: ex_nonz_cap_to_def invs_valid_objs)
      apply (intro allI exI, erule cte_wp_at_weakenE)
      apply (clarsimp simp: is_cap_simps)

--- a/proof/invariant-abstract/AARCH64/ArchIpc_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchIpc_AI.thy
@@ -56,8 +56,7 @@ lemma derive_cap_is_derived [Ipc_AI_assms]:
                     | fold validE_R_def
                     | erule cte_wp_at_weakenE
                     | simp split: cap.split_asm)+)[11]
-  including no_pre
-  apply(rule hoare_pre, wp hoare_drop_imps arch_derive_cap_is_derived)
+  apply(wp hoare_drop_imps arch_derive_cap_is_derived)
   apply(clarify, drule cte_wp_at_norm, clarify)
   apply(frule(1) cte_wp_at_valid_objs_valid_cap)
   apply(erule cte_wp_at_weakenE)

--- a/proof/invariant-abstract/AARCH64/ArchIpc_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchIpc_AI.thy
@@ -288,7 +288,7 @@ lemma transfer_caps_tcb_caps:
          | wpc | simp)+
     apply (erule imp)
    apply (wp hoare_vcg_conj_lift hoare_vcg_const_imp_lift hoare_vcg_all_lift)
-    apply (rule_tac Q = "\<lambda>rv s. (\<forall>x\<in>set rv. real_cte_at x s) \<and> cte_wp_at P (t, ref) s \<and> tcb_at t s"
+    apply (rule_tac Q'="\<lambda>rv s. (\<forall>x\<in>set rv. real_cte_at x s) \<and> cte_wp_at P (t, ref) s \<and> tcb_at t s"
                     in hoare_strengthen_post)
      apply (wp get_rs_real_cte_at)
     apply clarsimp
@@ -312,7 +312,7 @@ lemma transfer_caps_non_null_cte_wp_at:
    apply (wp hoare_vcg_ball_lift transfer_caps_loop_cte_wp_at hoare_weak_lift_imp
      | wpc | clarsimp simp:imp)+
    apply (rule hoare_strengthen_post
-            [where Q="\<lambda>rv s'. (cte_wp_at ((\<noteq>) cap.NullCap) ptr) s'
+            [where Q'="\<lambda>rv s'. (cte_wp_at ((\<noteq>) cap.NullCap) ptr) s'
                       \<and> (\<forall>x\<in>set rv. cte_wp_at ((=) cap.NullCap) x s')",
              rotated])
     apply (clarsimp)

--- a/proof/invariant-abstract/AARCH64/ArchSchedule_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchSchedule_AI.thy
@@ -93,7 +93,7 @@ lemma stt_invs [wp,Schedule_AI_asms]:
   apply (simp add: switch_to_thread_def)
   apply wp
      apply (simp add: trans_state_update[symmetric] del: trans_state_update)
-    apply (rule_tac Q="\<lambda>_. invs and tcb_at t'" in hoare_strengthen_post, wp)
+    apply (rule_tac Q'="\<lambda>_. invs and tcb_at t'" in hoare_strengthen_post, wp)
     apply (clarsimp simp: invs_def valid_state_def valid_idle_def
                           valid_irq_node_def valid_machine_state_def)
     apply (fastforce simp: cur_tcb_def obj_at_def

--- a/proof/invariant-abstract/AARCH64/ArchTcb_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchTcb_AI.thy
@@ -242,12 +242,12 @@ lemma tc_invs[Tcb_AI_asms]:
                   strengthen imp_consequent[where Q="x = None" for x], simp cong: conj_cong)
         | rule wp_split_const_if wp_split_const_if_R
                    hoare_vcg_all_liftE_R
-                   hoare_vcg_E_elim hoare_vcg_const_imp_lift_R
-                   hoare_vcg_R_conj
+                   hoare_vcg_conj_elimE hoare_vcg_const_imp_liftE_R
+                   hoare_vcg_conj_liftE_R
         | (wp out_invs_trivial case_option_wpE cap_delete_deletes
              cap_delete_valid_cap cap_insert_valid_cap out_cte_at
              cap_insert_cte_at cap_delete_cte_at out_valid_cap
-             hoare_vcg_const_imp_lift_R hoare_vcg_all_liftE_R
+             hoare_vcg_const_imp_liftE_R hoare_vcg_all_liftE_R
              thread_set_tcb_ipc_buffer_cap_cleared_invs
              thread_set_invs_trivial[OF ball_tcb_cap_casesI]
              hoare_vcg_all_lift thread_set_valid_cap out_emptyable

--- a/proof/invariant-abstract/AARCH64/ArchVCPU_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchVCPU_AI.thy
@@ -211,7 +211,7 @@ lemma associate_vcpu_tcb_valid_cur_vcpu:
   apply (wpsimp wp: hoare_vcg_imp_lift')
         apply (wpsimp wp: arch_thread_set_wp)
        apply (wpsimp wp: arch_thread_set_wp)
-      apply (rule_tac Q="\<lambda>_ s. valid_cur_vcpu s \<and> sym_refs (state_hyp_refs_of s)" in hoare_post_imp)
+      apply (rule_tac Q'="\<lambda>_ s. valid_cur_vcpu s \<and> sym_refs (state_hyp_refs_of s)" in hoare_post_imp)
        apply (clarsimp simp: pred_tcb_at_def obj_at_def valid_cur_vcpu_def active_cur_vcpu_of_def)
       by (wpsimp wp: get_vcpu_wp hoare_drop_imps)+
 
@@ -448,7 +448,7 @@ lemma rec_del_valid_cur_vcpu[wp]:
    rec_del call
    \<lbrace>\<lambda>_. valid_cur_vcpu\<rbrace>"
   (is "\<lbrace>?pre\<rbrace> _ \<lbrace>_\<rbrace>")
-  apply (rule_tac Q="\<lambda>_. ?pre" in hoare_post_imp, fastforce)
+  apply (rule_tac Q'="\<lambda>_. ?pre" in hoare_post_imp, fastforce)
   by (rule rec_del_preservation; wpsimp)
 
 crunch cap_delete
@@ -459,7 +459,7 @@ lemma cap_revoke_valid_cur_vcpu[wp]:
    cap_revoke slot
    \<lbrace>\<lambda>_. valid_cur_vcpu\<rbrace>"
   (is "\<lbrace>?pre\<rbrace> _ \<lbrace>_\<rbrace>")
-  apply (rule_tac Q="\<lambda>_. ?pre" in hoare_post_imp, fastforce)
+  apply (rule_tac Q'="\<lambda>_. ?pre" in hoare_post_imp, fastforce)
   by (wpsimp wp: cap_revoke_preservation)
 
 crunch cancel_badged_sends, invoke_irq_control, invoke_irq_handler

--- a/proof/invariant-abstract/ARM/ArchArch_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchArch_AI.thy
@@ -1237,9 +1237,9 @@ lemma find_pd_for_asid_lookup_pd_wp:
   "\<lbrace> \<lambda>s. valid_vspace_objs s \<and> (\<forall>pd. vspace_at_asid asid pd s \<and> page_directory_at pd s
     \<and> (\<exists>\<rhd> pd) s \<longrightarrow> Q pd s) \<rbrace> find_pd_for_asid asid \<lbrace> Q \<rbrace>, -"
   apply (rule hoare_strengthen_postE_R)
-   apply (rule hoare_vcg_conj_lift_R[OF find_pd_for_asid_page_directory])
-   apply (rule hoare_vcg_conj_lift_R[OF find_pd_for_asid_lookup, simplified])
-   apply (rule hoare_vcg_conj_lift_R[OF find_pd_for_asid_pd_at_asid, simplified])
+   apply (rule hoare_vcg_conj_liftE_R[OF find_pd_for_asid_page_directory])
+   apply (rule hoare_vcg_conj_liftE_R[OF find_pd_for_asid_lookup, simplified])
+   apply (rule hoare_vcg_conj_liftE_R[OF find_pd_for_asid_pd_at_asid, simplified])
    apply (wp (once) find_pd_for_asid_inv)
   apply auto
   done
@@ -1352,7 +1352,7 @@ lemma arch_decode_inv_wf[wp]:
     apply (cases "invocation_type label = ArchInvocationLabel ARMPageMap")
      apply (rename_tac dev word rights vmpage_size option)
      apply (rule hoare_pre)
-      apply (wp whenE_throwError_wp check_vp_wpR hoare_vcg_const_imp_lift_R
+      apply (wp whenE_throwError_wp check_vp_wpR hoare_vcg_const_imp_liftE_R
                 create_mapping_entries_parent_for_refs find_pd_for_asid_pd_at_asid
                 create_mapping_entries_valid_slots create_mapping_entries_same_refs_ex
                 find_pd_for_asid_lookup_pd_wp hoare_vcg_disj_lift_R

--- a/proof/invariant-abstract/ARM/ArchCNodeInv_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchCNodeInv_AI.thy
@@ -712,7 +712,7 @@ next
     apply simp
     apply (rule hoare_pre_spec_validE)
      apply (wp replace_cap_invs | simp add: is_cap_simps)+
-      apply (rule_tac Q="\<lambda>rv s. Q s \<and> invs s \<and> cte_wp_at (\<lambda>cap. cap = rv) slot s
+      apply (rule_tac Q'="\<lambda>rv s. Q s \<and> invs s \<and> cte_wp_at (\<lambda>cap. cap = rv) slot s
                              \<and> cte_wp_at (\<lambda>cap. cap = cap.NullCap
                                         \<or> \<not> False \<and> is_zombie cap
                                             \<and> (ptr, nat_to_cref (zombie_cte_bits bits) n)

--- a/proof/invariant-abstract/ARM/ArchDetSchedDomainTime_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchDetSchedDomainTime_AI.thy
@@ -74,7 +74,7 @@ lemma timer_tick_valid_domain_time:
            wp: reschedule_required_valid_domain_time hoare_vcg_const_imp_lift gts_wp
                (* unless we hit dec_domain_time we know ?dtnot0 holds on the state, so clean up the
                   postcondition once we hit thread_set_time_slice *)
-               hoare_post_imp[where Q="\<lambda>_. ?dtnot0" and R="\<lambda>_ s. domain_time s = 0 \<longrightarrow> X s"
+               hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and R="\<lambda>_ s. domain_time s = 0 \<longrightarrow> X s"
                                 and a="thread_set_time_slice t ts" for X t ts]
                hoare_drop_imp[where f="ethread_get t f" for t f])
   apply fastforce
@@ -88,11 +88,11 @@ lemma handle_interrupt_valid_domain_time [DetSchedDomainTime_AI_assms]:
   apply (case_tac "maxIRQ < i", solves \<open>wpsimp wp: hoare_false_imp\<close>)
   apply clarsimp
   apply (wpsimp simp: arch_mask_irq_signal_def)
-        apply (rule hoare_post_imp[where Q="\<lambda>_. ?dtnot0" and a="send_signal p c" for p c], fastforce)
+        apply (rule hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and a="send_signal p c" for p c], fastforce)
         apply wpsimp
-       apply (rule hoare_post_imp[where Q="\<lambda>_. ?dtnot0" and a="get_cap p" for p], fastforce)
+       apply (rule hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and a="get_cap p" for p], fastforce)
       apply (wpsimp wp: timer_tick_valid_domain_time simp: handle_reserved_irq_def)+
-     apply (rule hoare_post_imp[where Q="\<lambda>_. ?dtnot0" and a="get_irq_state i" for i], fastforce)
+     apply (rule hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and a="get_irq_state i" for i], fastforce)
    apply wpsimp+
   done
 

--- a/proof/invariant-abstract/ARM/ArchDetSchedDomainTime_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchDetSchedDomainTime_AI.thy
@@ -74,8 +74,8 @@ lemma timer_tick_valid_domain_time:
            wp: reschedule_required_valid_domain_time hoare_vcg_const_imp_lift gts_wp
                (* unless we hit dec_domain_time we know ?dtnot0 holds on the state, so clean up the
                   postcondition once we hit thread_set_time_slice *)
-               hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and R="\<lambda>_ s. domain_time s = 0 \<longrightarrow> X s"
-                                and a="thread_set_time_slice t ts" for X t ts]
+               hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and Q="\<lambda>_ s. domain_time s = 0 \<longrightarrow> X s"
+                                and f="thread_set_time_slice t ts" for X t ts]
                hoare_drop_imp[where f="ethread_get t f" for t f])
   apply fastforce
   done
@@ -88,11 +88,11 @@ lemma handle_interrupt_valid_domain_time [DetSchedDomainTime_AI_assms]:
   apply (case_tac "maxIRQ < i", solves \<open>wpsimp wp: hoare_false_imp\<close>)
   apply clarsimp
   apply (wpsimp simp: arch_mask_irq_signal_def)
-        apply (rule hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and a="send_signal p c" for p c], fastforce)
+        apply (rule hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and f="send_signal p c" for p c], fastforce)
         apply wpsimp
-       apply (rule hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and a="get_cap p" for p], fastforce)
+       apply (rule hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and f="get_cap p" for p], fastforce)
       apply (wpsimp wp: timer_tick_valid_domain_time simp: handle_reserved_irq_def)+
-     apply (rule hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and a="get_irq_state i" for i], fastforce)
+     apply (rule hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and f="get_irq_state i" for i], fastforce)
    apply wpsimp+
   done
 

--- a/proof/invariant-abstract/ARM/ArchDetype_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchDetype_AI.thy
@@ -572,7 +572,7 @@ lemma delete_objects_invs[wp]:
   apply (simp add: freeMemory_def word_size_def bind_assoc
                    empty_fail_mapM_x ef_storeWord)
    apply (rule hoare_pre)
-   apply (rule_tac G="is_aligned ptr bits \<and> word_size_bits \<le> bits \<and> bits \<le> word_bits"
+   apply (rule_tac P'="is_aligned ptr bits \<and> word_size_bits \<le> bits \<and> bits \<le> word_bits"
                 in hoare_grab_asm)
    apply (simp add: mapM_storeWord_clear_um[unfolded word_size_def]
                     intvl_range_conv[where 'a=machine_word_len, folded word_bits_def])

--- a/proof/invariant-abstract/ARM/ArchFinalise_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchFinalise_AI.thy
@@ -147,7 +147,7 @@ lemma delete_asid_pool_unmapped[wp]:
    \<lbrace>\<lambda>rv s. \<not> ([VSRef (ucast (asid_high_bits_of asid)) None] \<rhd> poolptr) s\<rbrace>"
   apply (simp add: delete_asid_pool_def)
   apply wp
-    apply (rule hoare_strengthen_post [where Q="\<lambda>_. \<top>"])
+    apply (rule hoare_strengthen_post[where Q'="\<lambda>_. \<top>"])
      apply wp+
     defer
     apply wp+
@@ -423,7 +423,7 @@ lemma arch_finalise_cap_replaceable[wp]:
                 vs_lookup_pages_eq_ap[THEN fun_cong, symmetric]
                 is_cap_simps vs_cap_ref_def
                 no_cap_to_obj_with_diff_ref_Null o_def
-  notes wps = hoare_drop_imp[where R="%_. is_final_cap' cap" for cap]
+  notes wps = hoare_drop_imp[where Q'="%_. is_final_cap' cap" for cap]
               unmap_page_table_unmapped3 valid_cap_typ
   shows
     "\<lbrace>\<lambda>s. s \<turnstile> cap.ArchObjectCap cap \<and>
@@ -519,7 +519,7 @@ lemma suspend_unlive':
   supply hoare_vcg_if_split[wp_split del] if_split[split del]
   apply (wp | simp only: obj_at_exst_update)+
      apply (simp add: obj_at_def live_def hyp_live_def)
-     apply (rule_tac Q="\<lambda>_. bound_tcb_at ((=) None) t" in hoare_strengthen_post)
+     apply (rule_tac Q'="\<lambda>_. bound_tcb_at ((=) None) t" in hoare_strengthen_post)
       supply hoare_vcg_if_split[wp_split]
       apply wp
      apply (auto simp: pred_tcb_def2)[1]
@@ -1601,7 +1601,7 @@ lemma delete_asid_pool_unmapped2:
    apply (wp delete_asid_pool_unmapped)
   apply (simp add: delete_asid_pool_def)
   apply wp
-      apply (rule_tac Q="\<lambda>rv s. ?Q s \<and> asid_table = arm_asid_table (arch_state s)"
+      apply (rule_tac Q'="\<lambda>rv s. ?Q s \<and> asid_table = arm_asid_table (arch_state s)"
                  in hoare_post_imp)
        apply (clarsimp simp: fun_upd_def[symmetric])
        apply (drule vs_lookup_clear_asid_table[rule_format])

--- a/proof/invariant-abstract/ARM/ArchFinalise_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchFinalise_AI.thy
@@ -728,9 +728,8 @@ lemma flush_table_empty:
   apply (wp find_pd_for_asid_inv mapM_wp
     | simp
     | wpc
-    | rule_tac
-        Q="\<lambda>_ s. obj_at (empty_table (set (arm_global_pts (arch_state s)))) word s"
-        in hoare_strengthen_post)+
+    | rule_tac Q'="\<lambda>_ s. obj_at (empty_table (set (arm_global_pts (arch_state s)))) word s"
+            in hoare_strengthen_post)+
   done
 
 lemma unmap_page_table_empty:

--- a/proof/invariant-abstract/ARM/ArchInterrupt_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchInterrupt_AI.thy
@@ -137,7 +137,7 @@ lemma invoke_irq_handler_invs'[Interrupt_AI_asms]:
     apply (wp valid_cap_typ [OF cap_delete_one_typ_at])
      apply (strengthen real_cte_tcb_valid)
      apply (wp real_cte_at_typ_valid [OF cap_delete_one_typ_at])
-     apply (rule_tac Q="\<lambda>rv s. is_ntfn_cap cap \<and> invs s
+     apply (rule_tac Q'="\<lambda>rv s. is_ntfn_cap cap \<and> invs s
                               \<and> cte_wp_at (is_derived (cdt s) prod cap) prod s"
                 in hoare_post_imp)
       apply (clarsimp simp: is_cap_simps is_derived_def cte_wp_at_caps_of_state)
@@ -209,7 +209,7 @@ lemma (* handle_interrupt_invs *) [Interrupt_AI_asms]:
      apply (wp dmo_maskInterrupt_invs maskInterrupt_invs_ARCH dmo_ackInterrupt send_signal_interrupt_states
             | wpc | simp add: arch_mask_irq_signal_def)+
      apply (wp get_cap_wp send_signal_interrupt_states)
-    apply (rule_tac Q="\<lambda>rv. invs and (\<lambda>s. st = interrupt_states s irq)" in hoare_post_imp)
+    apply (rule_tac Q'="\<lambda>rv. invs and (\<lambda>s. st = interrupt_states s irq)" in hoare_post_imp)
      apply (clarsimp simp: ex_nonz_cap_to_def invs_valid_objs)
      apply (intro allI exI, erule cte_wp_at_weakenE)
      apply (clarsimp simp: is_cap_simps)

--- a/proof/invariant-abstract/ARM/ArchIpc_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchIpc_AI.thy
@@ -297,7 +297,7 @@ lemma transfer_caps_tcb_caps:
   apply (erule imp)
   apply (wp hoare_vcg_conj_lift hoare_vcg_const_imp_lift hoare_vcg_all_lift
             )
-    apply (rule_tac Q = "\<lambda>rv s.  ( \<forall>x\<in>set rv. real_cte_at x s )
+    apply (rule_tac Q'="\<lambda>rv s.  ( \<forall>x\<in>set rv. real_cte_at x s )
       \<and> cte_wp_at P (t, ref) s \<and> tcb_at t s"
        in hoare_strengthen_post)
      apply (wp get_rs_real_cte_at)
@@ -322,7 +322,7 @@ lemma transfer_caps_non_null_cte_wp_at:
    apply (wp hoare_vcg_ball_lift transfer_caps_loop_cte_wp_at hoare_weak_lift_imp
      | wpc | clarsimp simp:imp)+
    apply (rule hoare_strengthen_post
-            [where Q="\<lambda>rv s'. (cte_wp_at ((\<noteq>) cap.NullCap) ptr) s'
+            [where Q'="\<lambda>rv s'. (cte_wp_at ((\<noteq>) cap.NullCap) ptr) s'
                       \<and> (\<forall>x\<in>set rv. cte_wp_at ((=) cap.NullCap) x s')",
              rotated])
     apply (clarsimp)

--- a/proof/invariant-abstract/ARM/ArchSchedule_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchSchedule_AI.thy
@@ -98,7 +98,7 @@ lemma stt_invs [wp,Schedule_AI_asms]:
   apply (simp add: switch_to_thread_def)
   apply wp
      apply (simp add: trans_state_update[symmetric] del: trans_state_update)
-    apply (rule_tac Q="\<lambda>_. invs and tcb_at t'" in hoare_strengthen_post, wp)
+    apply (rule_tac Q'="\<lambda>_. invs and tcb_at t'" in hoare_strengthen_post, wp)
     apply (clarsimp simp: invs_def valid_state_def valid_idle_def
                           valid_irq_node_def valid_machine_state_def)
     apply (fastforce simp: cur_tcb_def obj_at_def

--- a/proof/invariant-abstract/ARM/ArchTcb_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchTcb_AI.thy
@@ -245,12 +245,12 @@ lemma tc_invs[Tcb_AI_asms]:
         | (strengthen invs_strengthen)+
         | rule wp_split_const_if wp_split_const_if_R
                    hoare_vcg_all_liftE_R
-                   hoare_vcg_E_elim hoare_vcg_const_imp_lift_R
-                   hoare_vcg_R_conj
+                   hoare_vcg_conj_elimE hoare_vcg_const_imp_liftE_R
+                   hoare_vcg_conj_liftE_R
         | (wp out_invs_trivial case_option_wpE cap_delete_deletes
              cap_delete_valid_cap cap_insert_valid_cap out_cte_at
              cap_insert_cte_at cap_delete_cte_at out_valid_cap
-             hoare_vcg_const_imp_lift_R hoare_vcg_all_liftE_R
+             hoare_vcg_const_imp_liftE_R hoare_vcg_all_liftE_R
              thread_set_tcb_ipc_buffer_cap_cleared_invs
              thread_set_invs_trivial[OF ball_tcb_cap_casesI]
              hoare_vcg_all_lift thread_set_valid_cap out_emptyable

--- a/proof/invariant-abstract/ARM/ArchVSpaceEntries_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchVSpaceEntries_AI.thy
@@ -675,7 +675,7 @@ lemma init_arch_objects_valid_pdpt:
              split del: if_split)
   apply (rule hoare_pre)
    apply (wp | wpc)+
-     apply (rule_tac Q="\<lambda>rv. valid_pdpt_objs and pspace_aligned and valid_arch_state"
+     apply (rule_tac Q'="\<lambda>rv. valid_pdpt_objs and pspace_aligned and valid_arch_state"
                   in hoare_post_imp, simp)
      apply (rule mapM_x_wp')
      apply (rule hoare_pre, wp copy_global_mappings_valid_pdpt_objs)

--- a/proof/invariant-abstract/ARM/ArchVSpace_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchVSpace_AI.thy
@@ -993,7 +993,7 @@ lemma set_vm_root_for_flush_asid_map [wp]:
   apply (simp add: set_vm_root_for_flush_def)
   apply (wp|wpc|simp)+
    apply (rule hoare_strengthen_post [where
-               Q="\<lambda>_. valid_asid_map and K (asid \<le> mask asid_bits)"])
+               Q'="\<lambda>_. valid_asid_map and K (asid \<le> mask asid_bits)"])
     apply wp
    apply simp
   apply wp

--- a/proof/invariant-abstract/ARM_HYP/ArchArch_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchArch_AI.thy
@@ -911,7 +911,7 @@ lemma associate_vcpu_tcb_sym_refs_hyp[wp]:
                              obj_at (\<lambda>ko. hyp_refs_of ko = {} ) t s  \<and>
                              sym_refs (state_hyp_refs_of s)"
                           in hoare_triv)
-      apply (rule_tac Q="\<lambda>rv s. obj_at (\<lambda>ko. hyp_refs_of ko = {} ) vr s \<and>
+      apply (rule_tac Q'="\<lambda>rv s. obj_at (\<lambda>ko. hyp_refs_of ko = {} ) vr s \<and>
                                 obj_at (\<lambda>ko. hyp_refs_of ko = {} ) t s  \<and>
                                 sym_refs (state_hyp_refs_of s)"
                              in hoare_post_imp)
@@ -924,7 +924,7 @@ lemma associate_vcpu_tcb_sym_refs_hyp[wp]:
        apply (wp | wpc | clarsimp)+
       apply (simp add: obj_at_def)
      apply (wp  get_vcpu_ko | wpc | clarsimp)+
-   apply (rule_tac Q="\<lambda>rv s. (\<exists>t'. obj_at (\<lambda>tcb. tcb = TCB t' \<and> rv = tcb_vcpu (tcb_arch t')) t s) \<and>
+   apply (rule_tac Q'="\<lambda>rv s. (\<exists>t'. obj_at (\<lambda>tcb. tcb = TCB t' \<and> rv = tcb_vcpu (tcb_arch t')) t s) \<and>
                              sym_refs (state_hyp_refs_of s)"
                           in hoare_post_imp)
     apply (clarsimp simp: obj_at_def)
@@ -1109,7 +1109,7 @@ lemma associate_vcpu_tcb_valid_arch_state[wp]:
   "associate_vcpu_tcb vcpu tcb \<lbrace>valid_arch_state\<rbrace>"
   apply (clarsimp simp: associate_vcpu_tcb_def)
   apply (wpsimp wp: vcpu_switch_valid_arch)
-        apply (rule_tac Q="\<lambda>_. valid_arch_state and obj_at hyp_live vcpu" in hoare_post_imp)
+        apply (rule_tac Q'="\<lambda>_. valid_arch_state and obj_at hyp_live vcpu" in hoare_post_imp)
          apply fastforce
         apply wpsimp
        apply (wpsimp wp: arch_thread_set.valid_arch_state)
@@ -1561,9 +1561,9 @@ lemma find_pd_for_asid_lookup_pd_wp:
   "\<lbrace> \<lambda>s. valid_vspace_objs s \<and> (\<forall>pd. vspace_at_asid asid pd s \<and> page_directory_at pd s
     \<and> (\<exists>\<rhd> pd) s \<longrightarrow> Q pd s) \<rbrace> find_pd_for_asid asid \<lbrace> Q \<rbrace>, -"
   apply (rule hoare_strengthen_postE_R)
-   apply (rule hoare_vcg_conj_lift_R[OF find_pd_for_asid_page_directory])
-   apply (rule hoare_vcg_conj_lift_R[OF find_pd_for_asid_lookup, simplified])
-   apply (rule hoare_vcg_conj_lift_R[OF find_pd_for_asid_pd_at_asid, simplified])
+   apply (rule hoare_vcg_conj_liftE_R[OF find_pd_for_asid_page_directory])
+   apply (rule hoare_vcg_conj_liftE_R[OF find_pd_for_asid_lookup, simplified])
+   apply (rule hoare_vcg_conj_liftE_R[OF find_pd_for_asid_pd_at_asid, simplified])
    apply (wp (once) find_pd_for_asid_inv)
   apply auto
   done
@@ -1688,7 +1688,7 @@ lemma arch_decode_inv_wf[wp]:
       apply (wpsimp wp: whenE_throwError_wp check_vp_wpR create_mapping_entries_parent_for_refs
                         find_pd_for_asid_pd_at_asid create_mapping_entries_valid_slots
                         create_mapping_entries_same_refs_ex hoare_vcg_ex_lift_R hoare_vcg_disj_lift_R
-                        hoare_vcg_const_imp_lift_R find_pd_for_asid_lookup_pd_wp
+                        hoare_vcg_const_imp_liftE_R find_pd_for_asid_lookup_pd_wp
                   simp: valid_arch_inv_def valid_page_inv_def is_pg_cap_def
                         cte_wp_at_caps_of_state[where P="\<lambda>c. same_refs rv c s" for rv s])
       apply (clarsimp simp: neq_Nil_conv)

--- a/proof/invariant-abstract/ARM_HYP/ArchCNodeInv_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchCNodeInv_AI.thy
@@ -728,7 +728,7 @@ next
     apply simp
     apply (rule hoare_pre_spec_validE)
      apply (wp replace_cap_invs | simp add: is_cap_simps)+
-      apply (rule_tac Q="\<lambda>rv s. Q s \<and> invs s \<and> cte_wp_at (\<lambda>cap. cap = rv) slot s
+      apply (rule_tac Q'="\<lambda>rv s. Q s \<and> invs s \<and> cte_wp_at (\<lambda>cap. cap = rv) slot s
                              \<and> cte_wp_at (\<lambda>cap. cap = cap.NullCap
                                         \<or> \<not> False \<and> is_zombie cap
                                             \<and> (ptr, nat_to_cref (zombie_cte_bits bits) n)

--- a/proof/invariant-abstract/ARM_HYP/ArchDetSchedDomainTime_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchDetSchedDomainTime_AI.thy
@@ -95,7 +95,7 @@ lemma vgic_maintenance_valid_domain_time:
   "\<lbrace>\<lambda>s. 0 < domain_time s\<rbrace>
     vgic_maintenance \<lbrace>\<lambda>y s. domain_time s = 0 \<longrightarrow> scheduler_action s = choose_new_thread\<rbrace>"
   unfolding vgic_maintenance_def
-  apply (rule hoare_strengthen_post [where Q="\<lambda>_ s. 0 < domain_time s"])
+  apply (rule hoare_strengthen_post[where Q'="\<lambda>_ s. 0 < domain_time s"])
    apply (wpsimp wp: handle_fault_domain_time_inv hoare_drop_imps)
   apply clarsimp
   done
@@ -104,7 +104,7 @@ lemma vppi_event_valid_domain_time:
   "\<lbrace>\<lambda>s. 0 < domain_time s\<rbrace>
     vppi_event irq \<lbrace>\<lambda>y s. domain_time s = 0 \<longrightarrow> scheduler_action s = choose_new_thread\<rbrace>"
   unfolding vppi_event_def
-  apply (rule hoare_strengthen_post [where Q="\<lambda>_ s. 0 < domain_time s"])
+  apply (rule hoare_strengthen_post[where Q'="\<lambda>_ s. 0 < domain_time s"])
    apply (wpsimp wp: handle_fault_domain_time_inv hoare_drop_imps)
   apply clarsimp
   done
@@ -127,7 +127,7 @@ lemma timer_tick_valid_domain_time:
            wp: reschedule_required_valid_domain_time hoare_vcg_const_imp_lift gts_wp
                (* unless we hit dec_domain_time we know ?dtnot0 holds on the state, so clean up the
                   postcondition once we hit thread_set_time_slice *)
-               hoare_post_imp[where Q="\<lambda>_. ?dtnot0" and R="\<lambda>_ s. domain_time s = 0 \<longrightarrow> X s"
+               hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and R="\<lambda>_ s. domain_time s = 0 \<longrightarrow> X s"
                                 and a="thread_set_time_slice t ts" for X t ts]
                hoare_drop_imp[where f="ethread_get t f" for t f])
   apply fastforce
@@ -143,15 +143,15 @@ lemma handle_interrupt_valid_domain_time [DetSchedDomainTime_AI_assms]:
   apply (case_tac "maxIRQ < i", solves \<open>wpsimp wp: hoare_false_imp\<close>)
   apply clarsimp
   apply (wpsimp simp: arch_mask_irq_signal_def)
-        apply (rule hoare_post_imp[where Q="\<lambda>_. ?dtnot0" and a="send_signal p c" for p c], fastforce)
+        apply (rule hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and a="send_signal p c" for p c], fastforce)
         apply wpsimp
-       apply (rule hoare_post_imp[where Q="\<lambda>_. ?dtnot0" and a="get_cap p" for p], fastforce)
+       apply (rule hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and a="get_cap p" for p], fastforce)
        apply (wpsimp wp: timer_tick_valid_domain_time simp: handle_reserved_irq_def)+
-     apply (rule hoare_post_imp[where Q="\<lambda>_. ?dtnot0" and a="vgic_maintenance"], fastforce)
+     apply (rule hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and a="vgic_maintenance"], fastforce)
      apply wpsimp+
-     apply (rule hoare_post_imp[where Q="\<lambda>_. ?dtnot0" and a="vppi_event i" for i], fastforce)
+     apply (rule hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and a="vppi_event i" for i], fastforce)
      apply wpsimp+
-   apply (rule hoare_post_imp[where Q="\<lambda>_. ?dtnot0" and a="get_irq_state i" for i], fastforce)
+   apply (rule hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and a="get_irq_state i" for i], fastforce)
    apply wpsimp+
   done
 

--- a/proof/invariant-abstract/ARM_HYP/ArchDetSchedDomainTime_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchDetSchedDomainTime_AI.thy
@@ -127,8 +127,8 @@ lemma timer_tick_valid_domain_time:
            wp: reschedule_required_valid_domain_time hoare_vcg_const_imp_lift gts_wp
                (* unless we hit dec_domain_time we know ?dtnot0 holds on the state, so clean up the
                   postcondition once we hit thread_set_time_slice *)
-               hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and R="\<lambda>_ s. domain_time s = 0 \<longrightarrow> X s"
-                                and a="thread_set_time_slice t ts" for X t ts]
+               hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and Q="\<lambda>_ s. domain_time s = 0 \<longrightarrow> X s"
+                                and f="thread_set_time_slice t ts" for X t ts]
                hoare_drop_imp[where f="ethread_get t f" for t f])
   apply fastforce
   done
@@ -143,15 +143,15 @@ lemma handle_interrupt_valid_domain_time [DetSchedDomainTime_AI_assms]:
   apply (case_tac "maxIRQ < i", solves \<open>wpsimp wp: hoare_false_imp\<close>)
   apply clarsimp
   apply (wpsimp simp: arch_mask_irq_signal_def)
-        apply (rule hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and a="send_signal p c" for p c], fastforce)
+        apply (rule hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and f="send_signal p c" for p c], fastforce)
         apply wpsimp
-       apply (rule hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and a="get_cap p" for p], fastforce)
+       apply (rule hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and f="get_cap p" for p], fastforce)
        apply (wpsimp wp: timer_tick_valid_domain_time simp: handle_reserved_irq_def)+
-     apply (rule hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and a="vgic_maintenance"], fastforce)
+     apply (rule hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and f="vgic_maintenance"], fastforce)
      apply wpsimp+
-     apply (rule hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and a="vppi_event i" for i], fastforce)
+     apply (rule hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and f="vppi_event i" for i], fastforce)
      apply wpsimp+
-   apply (rule hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and a="get_irq_state i" for i], fastforce)
+   apply (rule hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and f="get_irq_state i" for i], fastforce)
    apply wpsimp+
   done
 

--- a/proof/invariant-abstract/ARM_HYP/ArchDetype_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchDetype_AI.thy
@@ -645,7 +645,7 @@ lemma delete_objects_invs[wp]:
   apply (simp add: delete_objects_def)
   apply (simp add: freeMemory_def word_size_def bind_assoc ef_storeWord)
    apply (rule hoare_pre)
-   apply (rule_tac G="is_aligned ptr bits \<and> word_size_bits \<le> bits \<and> bits \<le> word_bits"
+   apply (rule_tac P'="is_aligned ptr bits \<and> word_size_bits \<le> bits \<and> bits \<le> word_bits"
                 in hoare_grab_asm)
    apply (simp add: mapM_storeWord_clear_um[unfolded word_size_def]
                     intvl_range_conv[where 'a=machine_word_len, folded word_bits_def])

--- a/proof/invariant-abstract/ARM_HYP/ArchFinalise_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchFinalise_AI.thy
@@ -1531,9 +1531,7 @@ lemma flush_table_empty:
   apply (wp find_pd_for_asid_inv mapM_wp
     | simp
     | wpc
-    | rule_tac
-        Q="\<lambda>_ s. obj_at (empty_table {}) word s"
-        in hoare_strengthen_post)+
+    | rule_tac Q'="\<lambda>_ s. obj_at (empty_table {}) word s" in hoare_strengthen_post)+
   done
 
 lemma unmap_page_table_empty:

--- a/proof/invariant-abstract/ARM_HYP/ArchFinalise_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchFinalise_AI.thy
@@ -143,7 +143,7 @@ lemma delete_asid_pool_unmapped[wp]:
    \<lbrace>\<lambda>rv s. \<not> ([VSRef (ucast (asid_high_bits_of asid)) None] \<rhd> poolptr) s\<rbrace>"
   apply (simp add: delete_asid_pool_def)
   apply wp
-      apply (rule hoare_strengthen_post [where Q="\<lambda>_. \<top>"])
+      apply (rule hoare_strengthen_post[where Q'="\<lambda>_. \<top>"])
       apply wp
      defer
      apply wp+
@@ -760,7 +760,7 @@ lemma dissociate_vcpu_tcb_sym_refs_hyp[wp]:
   "\<lbrace>\<lambda>s. sym_refs (state_hyp_refs_of s)\<rbrace> dissociate_vcpu_tcb vr t \<lbrace>\<lambda>rv s. sym_refs (state_hyp_refs_of s)\<rbrace>"
   apply (simp add: dissociate_vcpu_tcb_def arch_get_sanitise_register_info_def)
   apply (wp arch_thread_set_wp set_vcpu_wp)
-       apply (rule_tac Q="\<lambda>_ s. obj_at (\<lambda>ko. \<exists>tcb. ko = TCB tcb \<and> tcb_vcpu (tcb_arch tcb) = Some vr) t s
+       apply (rule_tac Q'="\<lambda>_ s. obj_at (\<lambda>ko. \<exists>tcb. ko = TCB tcb \<and> tcb_vcpu (tcb_arch tcb) = Some vr) t s
                              \<and> sym_refs (state_hyp_refs_of s)" in hoare_post_imp)
         apply clarsimp
         apply (clarsimp simp: get_tcb_Some_ko_at obj_at_def sym_refs_vcpu_None split: if_splits)
@@ -1124,7 +1124,7 @@ lemma arch_finalise_cap_vcpu:
   notes simps = replaceable_def
                 is_cap_simps vs_cap_ref_def
                 no_cap_to_obj_with_diff_ref_Null o_def
-  notes wps = hoare_drop_imp[where R="%_. is_final_cap' cap" for cap]
+  notes wps = hoare_drop_imp[where Q'="%_. is_final_cap' cap" for cap]
               valid_cap_typ
   shows
   "cap = VCPUCap r \<Longrightarrow> \<lbrace>\<lambda>s. s \<turnstile> cap.ArchObjectCap cap \<and>
@@ -1161,7 +1161,7 @@ lemma arch_finalise_cap_replaceable1:
                 vs_lookup_pages_eq_ap[THEN fun_cong, symmetric]
                 is_cap_simps vs_cap_ref_def
                 no_cap_to_obj_with_diff_ref_Null o_def
-  notes wps = hoare_drop_imp[where R="%_. is_final_cap' cap" for cap]
+  notes wps = hoare_drop_imp[where Q'="%_. is_final_cap' cap" for cap]
               unmap_page_table_unmapped3 valid_cap_typ
   assumes X: "\<forall>r. cap \<noteq> VCPUCap r"
   shows
@@ -1278,7 +1278,7 @@ lemma prepare_thread_delete_unlive0:
 
 lemma prepare_thread_delete_unlive[wp]:
   "\<lbrace>obj_at (Not \<circ> live0) ptr\<rbrace> prepare_thread_delete ptr \<lbrace>\<lambda>rv. obj_at (Not \<circ> live) ptr\<rbrace>"
-  apply (rule_tac Q="\<lambda>rv. obj_at (Not \<circ> live0) ptr and obj_at (Not \<circ> hyp_live) ptr" in hoare_strengthen_post)
+  apply (rule_tac Q'="\<lambda>rv. obj_at (Not \<circ> live0) ptr and obj_at (Not \<circ> hyp_live) ptr" in hoare_strengthen_post)
   apply (wpsimp wp: hoare_vcg_conj_lift prepare_thread_delete_unlive_hyp prepare_thread_delete_unlive0)+
   apply (clarsimp simp: obj_at_def, case_tac ko, simp_all add: is_tcb_def live_def)
   done
@@ -2371,7 +2371,7 @@ lemma delete_asid_pool_unmapped2:
    apply (wp delete_asid_pool_unmapped)
   apply (simp add: delete_asid_pool_def)
   apply wp
-     apply (rule_tac Q="\<lambda>rv s. ?Q s \<and> asid_table = arm_asid_table (arch_state s)"
+     apply (rule_tac Q'="\<lambda>rv s. ?Q s \<and> asid_table = arm_asid_table (arch_state s)"
                 in hoare_post_imp)
       apply (clarsimp simp: fun_upd_def[symmetric])
       apply (drule vs_lookup_clear_asid_table[rule_format])

--- a/proof/invariant-abstract/ARM_HYP/ArchInterrupt_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchInterrupt_AI.thy
@@ -130,7 +130,7 @@ lemma invoke_irq_handler_invs'[Interrupt_AI_asms]:
     apply (wp valid_cap_typ [OF cap_delete_one_typ_at])
      apply (strengthen real_cte_tcb_valid)
      apply (wp real_cte_at_typ_valid [OF cap_delete_one_typ_at])
-     apply (rule_tac Q="\<lambda>rv s. is_ntfn_cap cap \<and> invs s
+     apply (rule_tac Q'="\<lambda>rv s. is_ntfn_cap cap \<and> invs s
                               \<and> cte_wp_at (is_derived (cdt s) prod cap) prod s"
                 in hoare_post_imp)
       apply (clarsimp simp: is_cap_simps is_derived_def cte_wp_at_caps_of_state)
@@ -262,7 +262,7 @@ lemma (* handle_interrupt_invs *) [Interrupt_AI_asms]:
      apply (wp dmo_maskInterrupt_invs maskInterrupt_invs_ARCH dmo_ackInterrupt send_signal_interrupt_states
             | wpc | simp add: arch_mask_irq_signal_def)+
      apply (wp get_cap_wp send_signal_interrupt_states )
-    apply (rule_tac Q="\<lambda>rv. invs and (\<lambda>s. st = interrupt_states s irq)" in hoare_post_imp)
+    apply (rule_tac Q'="\<lambda>rv. invs and (\<lambda>s. st = interrupt_states s irq)" in hoare_post_imp)
      apply (clarsimp simp: ex_nonz_cap_to_def invs_valid_objs)
      apply (intro allI exI, erule cte_wp_at_weakenE)
      apply (clarsimp simp: is_cap_simps)

--- a/proof/invariant-abstract/ARM_HYP/ArchIpc_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchIpc_AI.thy
@@ -300,7 +300,7 @@ lemma transfer_caps_tcb_caps:
   apply (erule imp)
   apply (wp hoare_vcg_conj_lift hoare_vcg_const_imp_lift hoare_vcg_all_lift
             )
-    apply (rule_tac Q = "\<lambda>rv s.  ( \<forall>x\<in>set rv. real_cte_at x s )
+    apply (rule_tac Q'="\<lambda>rv s.  ( \<forall>x\<in>set rv. real_cte_at x s )
       \<and> cte_wp_at P (t, ref) s \<and> tcb_at t s"
        in hoare_strengthen_post)
      apply (wp get_rs_real_cte_at)
@@ -325,7 +325,7 @@ lemma transfer_caps_non_null_cte_wp_at:
    apply (wp hoare_vcg_ball_lift transfer_caps_loop_cte_wp_at hoare_weak_lift_imp
      | wpc | clarsimp simp:imp)+
    apply (rule hoare_strengthen_post
-            [where Q="\<lambda>rv s'. (cte_wp_at ((\<noteq>) cap.NullCap) ptr) s'
+            [where Q'="\<lambda>rv s'. (cte_wp_at ((\<noteq>) cap.NullCap) ptr) s'
                       \<and> (\<forall>x\<in>set rv. cte_wp_at ((=) cap.NullCap) x s')",
              rotated])
     apply (clarsimp)

--- a/proof/invariant-abstract/ARM_HYP/ArchIpc_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchIpc_AI.thy
@@ -55,8 +55,7 @@ lemma derive_cap_is_derived [Ipc_AI_assms]:
                     | fold validE_R_def
                     | erule cte_wp_at_weakenE
                     | simp split: cap.split_asm)+)[11]
-  including no_pre
-  apply(rule hoare_pre, wp hoare_drop_imps arch_derive_cap_is_derived)
+  apply(wp hoare_drop_imps arch_derive_cap_is_derived)
   apply(clarify, drule cte_wp_at_norm, clarify)
   apply(frule(1) cte_wp_at_valid_objs_valid_cap)
   apply(erule cte_wp_at_weakenE)

--- a/proof/invariant-abstract/ARM_HYP/ArchSchedule_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchSchedule_AI.thy
@@ -111,7 +111,7 @@ lemma stt_invs [wp,Schedule_AI_asms]:
   apply (simp add: switch_to_thread_def)
   apply wp
      apply (simp add: trans_state_update[symmetric] del: trans_state_update)
-    apply (rule_tac Q="\<lambda>_. invs and tcb_at t'" in hoare_strengthen_post, wp)
+    apply (rule_tac Q'="\<lambda>_. invs and tcb_at t'" in hoare_strengthen_post, wp)
     apply (clarsimp simp: invs_def valid_state_def valid_idle_def
                           valid_irq_node_def valid_machine_state_def)
     apply (fastforce simp: cur_tcb_def obj_at_def

--- a/proof/invariant-abstract/ARM_HYP/ArchTcb_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchTcb_AI.thy
@@ -247,12 +247,12 @@ lemma tc_invs[Tcb_AI_asms]:
         | (strengthen invs_strengthen)+
         | rule wp_split_const_if wp_split_const_if_R
                    hoare_vcg_all_liftE_R
-                   hoare_vcg_E_elim hoare_vcg_const_imp_lift_R
-                   hoare_vcg_R_conj
+                   hoare_vcg_conj_elimE hoare_vcg_const_imp_liftE_R
+                   hoare_vcg_conj_liftE_R
         | (wp out_invs_trivial case_option_wpE cap_delete_deletes
              cap_delete_valid_cap cap_insert_valid_cap out_cte_at
              cap_insert_cte_at cap_delete_cte_at out_valid_cap
-             hoare_vcg_const_imp_lift_R hoare_vcg_all_liftE_R
+             hoare_vcg_const_imp_liftE_R hoare_vcg_all_liftE_R
              thread_set_tcb_ipc_buffer_cap_cleared_invs
              thread_set_invs_trivial[OF ball_tcb_cap_casesI]
              hoare_vcg_all_lift thread_set_valid_cap out_emptyable

--- a/proof/invariant-abstract/ARM_HYP/ArchVCPU_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchVCPU_AI.thy
@@ -214,7 +214,7 @@ lemma associate_vcpu_tcb_valid_cur_vcpu:
   apply (wpsimp wp: hoare_vcg_imp_lift')
         apply (wpsimp wp: arch_thread_set_wp)
        apply (wpsimp wp: arch_thread_set_wp)
-      apply (rule_tac Q="\<lambda>_ s. valid_cur_vcpu s \<and> sym_refs (state_hyp_refs_of s)" in hoare_post_imp)
+      apply (rule_tac Q'="\<lambda>_ s. valid_cur_vcpu s \<and> sym_refs (state_hyp_refs_of s)" in hoare_post_imp)
        apply (clarsimp simp: pred_tcb_at_def obj_at_def valid_cur_vcpu_def active_cur_vcpu_of_def)
       by (wpsimp wp: get_vcpu_wp hoare_drop_imps)+
 
@@ -458,7 +458,7 @@ lemma rec_del_valid_cur_vcpu[wp]:
    rec_del call
    \<lbrace>\<lambda>_. valid_cur_vcpu\<rbrace>"
   (is "\<lbrace>?pre\<rbrace> _ \<lbrace>_\<rbrace>")
-  apply (rule_tac Q="\<lambda>_. ?pre" in hoare_post_imp, fastforce)
+  apply (rule_tac Q'="\<lambda>_. ?pre" in hoare_post_imp, fastforce)
   by (rule rec_del_preservation; wpsimp)
 
 crunch cap_delete
@@ -469,7 +469,7 @@ lemma cap_revoke_valid_cur_vcpu[wp]:
    cap_revoke slot
    \<lbrace>\<lambda>_. valid_cur_vcpu\<rbrace>"
   (is "\<lbrace>?pre\<rbrace> _ \<lbrace>_\<rbrace>")
-  apply (rule_tac Q="\<lambda>_. ?pre" in hoare_post_imp, fastforce)
+  apply (rule_tac Q'="\<lambda>_. ?pre" in hoare_post_imp, fastforce)
   by (wpsimp wp: cap_revoke_preservation)
 
 crunch cancel_badged_sends, invoke_irq_control, invoke_irq_handler

--- a/proof/invariant-abstract/ARM_HYP/ArchVSpaceEntries_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchVSpaceEntries_AI.thy
@@ -607,7 +607,7 @@ lemma init_arch_objects_valid_pdpt:
              split del: if_split)
   apply (rule hoare_pre)
    apply (wp | wpc)+
-     apply (rule_tac Q="\<lambda>rv. valid_pdpt_objs and pspace_aligned and valid_arch_state"
+     apply (rule_tac Q'="\<lambda>rv. valid_pdpt_objs and pspace_aligned and valid_arch_state"
                   in hoare_post_imp, simp)
      apply (rule mapM_x_wp')
      apply (rule hoare_pre, wp copy_global_mappings_valid_pdpt_objs)

--- a/proof/invariant-abstract/ARM_HYP/ArchVSpace_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchVSpace_AI.thy
@@ -1095,7 +1095,7 @@ lemma set_vm_root_for_flush_asid_map [wp]:
   apply (simp add: set_vm_root_for_flush_def)
   apply (wp|wpc|simp)+
    apply (rule hoare_strengthen_post [where
-               Q="\<lambda>_. valid_asid_map and K (asid \<le> mask asid_bits)"])
+               Q'="\<lambda>_. valid_asid_map and K (asid \<le> mask asid_bits)"])
     apply wp
    apply simp
   apply wp

--- a/proof/invariant-abstract/ARM_HYP/ArchVSpace_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchVSpace_AI.thy
@@ -465,7 +465,7 @@ lemma load_hw_asid_invs[wp]: "\<lbrace>invs\<rbrace> load_hw_asid asid \<lbrace>
 lemma invalidate_tlb_by_asid_invs[wp]:
   "\<lbrace>invs\<rbrace> invalidate_tlb_by_asid asid \<lbrace>\<lambda>_. invs\<rbrace>"
   apply (wpsimp simp: invalidate_tlb_by_asid_def)+
-  apply (rule_tac Q="K invs" in hoare_post_imp)
+  apply (rule_tac Q'="K invs" in hoare_post_imp)
   apply (wpsimp simp: load_hw_asid_invs)+
   done
 
@@ -527,7 +527,7 @@ lemma invalidate_asid_entry_arch_state [wp]:
 lemma flush_space_asid_map[wp]:
   "\<lbrace>valid_asid_map\<rbrace> flush_space space \<lbrace>\<lambda>rv. valid_asid_map\<rbrace>"
   apply (simp add: flush_space_def)
-  apply (wp load_hw_asid_wp | wpc | simp | rule_tac Q="\<lambda>_. valid_asid_map" in hoare_strengthen_post)+
+  apply (wp load_hw_asid_wp | wpc | simp | rule_tac Q'="\<lambda>_. valid_asid_map" in hoare_strengthen_post)+
   done
 
 
@@ -595,7 +595,7 @@ crunch invalidate_asid_entry
 lemma flush_space_pd_at_asid [wp]:
   "\<lbrace>vspace_at_asid a pd\<rbrace> flush_space asid \<lbrace>\<lambda>_. vspace_at_asid a pd\<rbrace>"
   apply (simp add: flush_space_def)
-  apply (wp load_hw_asid_wp|wpc|rule_tac Q="\<lambda>_. vspace_at_asid a pd" in hoare_strengthen_post|simp)+
+  apply (wp load_hw_asid_wp|wpc|rule_tac Q'="\<lambda>_. vspace_at_asid a pd" in hoare_strengthen_post|simp)+
   done
 
 
@@ -703,7 +703,7 @@ lemma dmo_cleanCaches_PoU_invs[wp]: "\<lbrace>invs\<rbrace> do_machine_op cleanC
 
 lemma flush_space_invs[wp]: "\<lbrace>invs\<rbrace> flush_space asid \<lbrace>\<lambda>_. invs\<rbrace>"
   apply (wpsimp simp: flush_space_def)
-  apply (rule_tac Q="K invs" in hoare_post_imp, wpsimp+)
+  apply (rule_tac Q'="K invs" in hoare_post_imp, wpsimp+)
   done
 
 crunch flush_space
@@ -4185,7 +4185,7 @@ lemma unmap_page_table_invs[wp]:
   apply (simp add: unmap_page_table_def)
   apply (rule hoare_pre)
    apply (wp dmo_invs | wpc | simp)+
-      apply (rule_tac Q="\<lambda>_. invs and K (asid \<le> mask asid_bits)" in hoare_post_imp)
+      apply (rule_tac Q'="\<lambda>_. invs and K (asid \<le> mask asid_bits)" in hoare_post_imp)
        apply safe
         apply (drule_tac Q="\<lambda>_ m'. underlying_memory m' p =
                                    underlying_memory m p" in use_valid)
@@ -4658,7 +4658,7 @@ lemma perform_page_table_invocation_invs[wp]:
   apply (cases pti)
    apply (clarsimp simp: valid_pti_def perform_page_table_invocation_def)
    apply (wp dmo_invs)
-    apply (rule_tac Q="\<lambda>_. invs" in hoare_post_imp)
+    apply (rule_tac Q'="\<lambda>_. invs" in hoare_post_imp)
      apply safe
      apply (drule_tac Q="\<lambda>_ m'. underlying_memory m' p =
                                 underlying_memory m p" in use_valid)
@@ -4777,7 +4777,7 @@ lemma find_pd_for_asid_lookup_slot [wp]:
   \<lbrace>\<lambda>rv. \<exists>\<rhd> (lookup_pd_slot rv vptr && ~~ mask pd_bits)\<rbrace>, -"
   apply (rule hoare_pre)
    apply (rule hoare_strengthen_postE_R)
-    apply (rule hoare_vcg_R_conj)
+    apply (rule hoare_vcg_conj_liftE_R)
      apply (rule find_pd_for_asid_lookup)
     apply (rule find_pd_for_asid_aligned_pd)
    apply (simp add: pd_shifting lookup_pd_slot_def Let_def)
@@ -4790,8 +4790,8 @@ lemma find_pd_for_asid_lookup_slot_large_page [wp]:
   \<lbrace>\<lambda>rv. \<exists>\<rhd> (x + lookup_pd_slot rv vptr && ~~ mask pd_bits)\<rbrace>, -"
   apply (rule hoare_pre)
    apply (rule hoare_strengthen_postE_R)
-    apply (rule hoare_vcg_R_conj)
-      apply (rule hoare_vcg_R_conj)
+    apply (rule hoare_vcg_conj_liftE_R)
+      apply (rule hoare_vcg_conj_liftE_R)
        apply (rule find_pd_for_asid_inv [where P="K (x \<in> set [0, 8 .e. 0x78] \<and> is_aligned vptr 25)", THEN valid_validE_R])
      apply (rule find_pd_for_asid_lookup)
     apply (rule find_pd_for_asid_aligned_pd)
@@ -4804,7 +4804,7 @@ lemma find_pd_for_asid_pde_at_add [wp]:
   find_pd_for_asid asid \<lbrace>\<lambda>rv. pde_at (x + lookup_pd_slot rv vptr)\<rbrace>, -"
   apply (rule hoare_pre)
    apply (rule hoare_strengthen_postE_R)
-    apply (rule hoare_vcg_R_conj)
+    apply (rule hoare_vcg_conj_liftE_R)
      apply (rule find_pd_for_asid_inv [where P=
                  "K (x \<in> set [0, 8 .e. 0x78] \<and> is_aligned vptr 25) and pspace_aligned", THEN valid_validE_R])
     apply (rule find_pd_for_asid_page_directory)
@@ -5073,7 +5073,7 @@ lemma unmap_page_invs:
   apply (rule hoare_pre)
    apply (wp flush_page_invs hoare_vcg_const_imp_lift)
     apply (wp hoare_drop_imp[where f="check_mapping_pptr a b c" for a b c]
-              hoare_drop_impE_R[where R="\<lambda>x y. x && mask b = c" for b c]
+              hoare_drop_impE_R[where Q'="\<lambda>x y. x && mask b = c" for b c]
               store_pde_invs_unmap lookup_pt_slot_inv lookup_pt_slot_cap_to2'
               lookup_pt_slot_cap_to_multiple2
               store_pde_invs_unmap mapM_swp_store_pde_invs_unmap
@@ -5083,7 +5083,7 @@ lemma unmap_page_invs:
                      page_directory_at_lookup_mask_aligned_strg
                      page_directory_at_lookup_mask_add_aligned_strg)+
    apply (wp find_pd_for_asid_page_directory
-             hoare_vcg_const_imp_lift_R hoare_vcg_const_Ball_lift_R
+             hoare_vcg_const_imp_liftE_R hoare_vcg_const_Ball_liftE_R
           | wp (once) hoare_drop_imps)+
   apply (auto simp: vmsz_aligned_def)
   done
@@ -5357,7 +5357,7 @@ lemma unmap_page_unmapped:
     (* Establish that pptr reachable, otherwise trivial *)
   apply (rule hoare_name_pre_state2)
   apply (case_tac "\<not> (ref \<unrhd> p) s")
-   apply (rule hoare_pre(1)[OF unmap_page_no_lookup_pages])
+   apply (rule hoare_weaken_pre[OF unmap_page_no_lookup_pages])
    apply clarsimp+
 
      (* This should be somewhere else but isn't *)
@@ -5666,7 +5666,7 @@ lemma perform_page_invs [wp]:
    apply (rule hoare_pre)
     apply (wp dmo_invs arch_update_cap_invs_unmap_page get_cap_wp
               hoare_vcg_const_imp_lift | wpc | simp)+
-      apply (rule_tac Q="\<lambda>_ s. invs s \<and>
+      apply (rule_tac Q'="\<lambda>_ s. invs s \<and>
                                cte_wp_at (\<lambda>c. is_pg_cap c \<and>
                                  (\<forall>ref. vs_cap_ref c = Some ref \<longrightarrow>
                                         \<not> (ref \<unrhd> obj_ref_of c) s)) cslot_ptr s"

--- a/proof/invariant-abstract/CNodeInv_AI.thy
+++ b/proof/invariant-abstract/CNodeInv_AI.thy
@@ -443,7 +443,7 @@ lemma decode_cnode_inv_wf[wp]:
               apply (wp whenE_throwError_wp | wpcw)+
             apply (rename_tac dest_slot y src_slot)
             apply simp
-            apply (rule_tac Q="\<lambda>src_cap. valid_cap src_cap and ex_cte_cap_wp_to is_cnode_cap dest_slot
+            apply (rule_tac Q'="\<lambda>src_cap. valid_cap src_cap and ex_cte_cap_wp_to is_cnode_cap dest_slot
                                        and zombies_final and valid_objs
                                        and real_cte_at src_slot and real_cte_at dest_slot
                                        and cte_wp_at (\<lambda>c. c = src_cap) src_slot
@@ -3129,7 +3129,7 @@ lemma duplicate_creation:
      set_cap cap p'
   \<lbrace>\<lambda>rv s. cte_wp_at (\<lambda>cap. \<not> is_final_cap' cap s) p s\<rbrace>"
   apply (rule hoare_gen_asm)
-  apply (rule hoare_post_imp [where Q="\<lambda>rv. cte_wp_at (\<lambda>c. gen_obj_refs c = gen_obj_refs cap) p
+  apply (rule hoare_post_imp[where Q'="\<lambda>rv. cte_wp_at (\<lambda>c. gen_obj_refs c = gen_obj_refs cap) p
                                         and cte_wp_at ((=) cap) p'"])
    apply (clarsimp simp: cte_wp_at_def)
    apply (case_tac "\<exists>x. x \<in> obj_refs cap \<and> x \<in> obj_refs capa")

--- a/proof/invariant-abstract/CSpaceInv_AI.thy
+++ b/proof/invariant-abstract/CSpaceInv_AI.thy
@@ -1477,7 +1477,7 @@ lemma set_cap_caps_of_state2:
   "\<lbrace>\<lambda>s. P ((caps_of_state s)(p \<mapsto> cap)) (cdt s) (is_original_cap s)\<rbrace>
   set_cap cap p
   \<lbrace>\<lambda>rv s. P (caps_of_state s) (cdt s) (is_original_cap s)\<rbrace>"
-  apply (rule_tac Q="\<lambda>rv s. \<exists>m mr. P (caps_of_state s) m mr
+  apply (rule_tac Q'="\<lambda>rv s. \<exists>m mr. P (caps_of_state s) m mr
                                   \<and> (cdt s = m) \<and> (is_original_cap s = mr)"
            in hoare_post_imp)
    apply simp

--- a/proof/invariant-abstract/CSpace_AI.thy
+++ b/proof/invariant-abstract/CSpace_AI.thy
@@ -4174,7 +4174,7 @@ lemma ensure_empty_inv[wp]:
 
 lemma get_cap_cte_wp_at3:
   "\<lbrace>not cte_wp_at (not P) p\<rbrace> get_cap p \<lbrace>\<lambda>rv s. P rv\<rbrace>"
-  apply (rule hoare_post_imp [where Q="\<lambda>rv. cte_wp_at (\<lambda>c. c = rv) p and not cte_wp_at (not P) p"])
+  apply (rule hoare_post_imp[where Q'="\<lambda>rv. cte_wp_at (\<lambda>c. c = rv) p and not cte_wp_at (not P) p"])
    apply (clarsimp simp: cte_wp_at_def pred_neg_def)
   apply (wp get_cap_cte_wp_at)
   done

--- a/proof/invariant-abstract/DetSchedDomainTime_AI.thy
+++ b/proof/invariant-abstract/DetSchedDomainTime_AI.thy
@@ -472,12 +472,12 @@ lemma call_kernel_domain_time_inv_det_ext:
    apply (rule hoare_pre)
    apply ((wp schedule_domain_time_left handle_interrupt_valid_domain_time
            | wpc | simp)+)[1]
-   apply (rule_tac Q="\<lambda>_ s. 0 < domain_time s \<and> valid_domain_list s" in hoare_strengthen_post)
+   apply (rule_tac Q'="\<lambda>_ s. 0 < domain_time s \<and> valid_domain_list s" in hoare_strengthen_post)
     apply wp
    apply fastforce+
   (* now non-interrupt case; may throw but does not touch domain_time in handle_event *)
   apply (wp schedule_domain_time_left without_preemption_wp handle_interrupt_valid_domain_time)
-    apply (rule_tac Q="\<lambda>_ s. 0 < domain_time s \<and> valid_domain_list s" in hoare_post_imp)
+    apply (rule_tac Q'="\<lambda>_ s. 0 < domain_time s \<and> valid_domain_list s" in hoare_post_imp)
      apply fastforce
     apply (wp handle_event_domain_time_inv)+
    apply (rule_tac Q'="\<lambda>_ s. 0 < domain_time s" in hoare_strengthen_postE_R)

--- a/proof/invariant-abstract/DetSchedSchedule_AI.thy
+++ b/proof/invariant-abstract/DetSchedSchedule_AI.thy
@@ -2093,7 +2093,7 @@ lemma restart_valid_sched[wp]:
                                     set_thread_state_valid_blocked_except
                                     sts_st_tcb_at' cancel_ipc_simple2
                                     possible_switch_to_valid_sched)+
-    apply (rule_tac Q="\<lambda>_. valid_sched and not_cur_thread thread and (\<lambda>s. thread \<noteq> idle_thread s)" in hoare_strengthen_post)
+    apply (rule_tac Q'="\<lambda>_. valid_sched and not_cur_thread thread and (\<lambda>s. thread \<noteq> idle_thread s)" in hoare_strengthen_post)
      apply wp
     apply (simp add: valid_sched_def)
    apply (simp add: if_fun_split)
@@ -2595,7 +2595,7 @@ lemma do_reply_transfer_valid_sched[wp]:
         apply (wp set_thread_state_runnable_valid_queues
                   set_thread_state_runnable_valid_sched_action
                   set_thread_state_valid_blocked_except sts_st_tcb_at')[1]
-       apply (rule_tac Q="\<lambda>_. valid_sched and not_cur_thread receiver
+       apply (rule_tac Q'="\<lambda>_. valid_sched and not_cur_thread receiver
                                and (\<lambda>s. receiver \<noteq> idle_thread s)"
               in hoare_strengthen_post)
         apply wp
@@ -2750,7 +2750,7 @@ lemma send_ipc_valid_sched:
                  set_thread_state_valid_blocked_except sts_st_tcb_at')
       apply (clarsimp simp: conj.commute eq_commute)
       apply (rename_tac recvr q recv_state)
-      apply (rule_tac Q="\<lambda>_. valid_sched and scheduler_act_not thread and not_queued thread
+      apply (rule_tac Q'="\<lambda>_. valid_sched and scheduler_act_not thread and not_queued thread
                               and (\<lambda>s. recvr \<noteq> cur_thread s)
                               and (\<lambda>s. recvr \<noteq> idle_thread s \<and> recvr \<noteq> thread)"
                in hoare_strengthen_post)
@@ -2878,7 +2878,7 @@ lemma send_signal_valid_sched[wp]:
             set_thread_state_runnable_valid_queues set_thread_state_runnable_valid_sched_action
             set_thread_state_valid_blocked_except sts_st_tcb_at' gts_wp  | wpc | clarsimp)+
        apply (rename_tac ntfn a st)
-       apply (rule_tac Q="\<lambda>rv s. valid_sched s \<and> a \<noteq> idle_thread s \<and> not_cur_thread a s" in hoare_strengthen_post)
+       apply (rule_tac Q'="\<lambda>rv s. valid_sched s \<and> a \<noteq> idle_thread s \<and> not_cur_thread a s" in hoare_strengthen_post)
         apply (wp gts_wp get_simple_ko_wp | simp add: valid_sched_def)+
   apply (clarsimp)
   apply (rule conjI, clarsimp, rule conjI)
@@ -2928,7 +2928,7 @@ lemma receive_ipc_valid_sched:
                            set_thread_state_runnable_valid_queues
                            set_thread_state_runnable_valid_sched_action
                            set_thread_state_valid_blocked_except | simp | wpc)+)[3]
-              apply (rule_tac Q="\<lambda>_. valid_sched and scheduler_act_not (sender) and not_queued (sender)
+              apply (rule_tac Q'="\<lambda>_. valid_sched and scheduler_act_not (sender) and not_queued (sender)
                                      and not_cur_thread (sender) and (\<lambda>s. sender \<noteq> idle_thread s)"
                            in hoare_strengthen_post)
                apply wp
@@ -3208,7 +3208,7 @@ lemma handle_recv_valid_sched:
               cong: if_cong)
   apply (wp get_simple_ko_wp handle_fault_valid_sched delete_caller_cap_not_queued
             receive_ipc_valid_sched receive_signal_valid_sched | simp)+
-     apply (rule hoare_vcg_E_elim)
+     apply (rule hoare_vcg_conj_elimE)
       apply (wpsimp simp: lookup_cap_def lookup_slot_for_thread_def)
        apply (wp resolve_address_bits_valid_fault2)+
     apply (simp add: valid_fault_def)
@@ -3327,7 +3327,7 @@ lemma invoke_domain_valid_sched[wp]:
       apply (wp hoare_weak_lift_imp hoare_weak_lift_imp_conj tcb_dequeue_not_queued tcb_sched_action_dequeue_valid_blocked_except)
      apply simp
      apply (wp hoare_vcg_disj_lift)
-     apply (rule_tac Q="\<lambda>_. valid_sched and not_queued t and valid_idle and (\<lambda>s. t \<noteq> idle_thread s)" in hoare_strengthen_post)
+     apply (rule_tac Q'="\<lambda>_. valid_sched and not_queued t and valid_idle and (\<lambda>s. t \<noteq> idle_thread s)" in hoare_strengthen_post)
       apply (wp tcb_sched_action_dequeue_valid_sched_not_runnable tcb_dequeue_not_queued)
      apply (simp add: valid_sched_def valid_sched_action_def)
     apply simp
@@ -3385,7 +3385,7 @@ lemma handle_invocation_valid_sched:
                 apply (wp set_thread_state_runnable_valid_sched)[1]
                apply wp+
          apply (wp gts_wp hoare_vcg_all_lift)
-        apply (rule_tac Q="\<lambda>_. valid_sched" and E="\<lambda>_. valid_sched" in hoare_strengthen_postE)
+        apply (rule_tac Q'="\<lambda>_. valid_sched" and E'="\<lambda>_. valid_sched" in hoare_strengthen_postE)
           apply wp
          apply ((clarsimp simp: st_tcb_at_def obj_at_def)+)[2]
        apply (wp ct_in_state_set set_thread_state_runnable_valid_sched
@@ -3626,14 +3626,14 @@ lemma call_kernel_valid_sched:
    \<lbrace>\<lambda>_. valid_sched\<rbrace>"
   apply (simp add: call_kernel_def)
   apply (wp schedule_valid_sched activate_thread_valid_sched | simp)+
-     apply (rule_tac Q="\<lambda>rv. invs" in hoare_strengthen_post)
+     apply (rule_tac Q'="\<lambda>rv. invs" in hoare_strengthen_post)
       apply wp
      apply (erule invs_valid_idle)
-    apply (rule hoare_strengthen_post [where Q="\<lambda>irq s. irq \<notin> Some ` non_kernel_IRQs \<and> valid_sched s \<and> invs s"])
+    apply (rule hoare_strengthen_post[where Q'="\<lambda>irq s. irq \<notin> Some ` non_kernel_IRQs \<and> valid_sched s \<and> invs s"])
      apply (wpsimp wp: getActiveIRQ_neq_non_kernel)
     apply auto[1]
-   apply (rule_tac Q="\<lambda>rv. valid_sched and invs" and
-                   E="\<lambda>rv. valid_sched and invs" in hoare_strengthen_postE)
+   apply (rule_tac Q'="\<lambda>rv. valid_sched and invs" and
+                   E'="\<lambda>rv. valid_sched and invs" in hoare_strengthen_postE)
      apply (rule valid_validE)
      apply (wp handle_event_valid_sched)
     apply (force intro: active_from_running)+

--- a/proof/invariant-abstract/Deterministic_AI.thy
+++ b/proof/invariant-abstract/Deterministic_AI.thy
@@ -1478,7 +1478,7 @@ lemma set_cap_caps_of_state3:
   "\<lbrace>\<lambda>s. P ((caps_of_state s) (p \<mapsto> cap)) (cdt s)  (exst s) (is_original_cap s)\<rbrace>
   set_cap cap p
   \<lbrace>\<lambda>rv s. P (caps_of_state s) (cdt s) (exst s) (is_original_cap s)\<rbrace>"
-  apply (rule_tac Q="\<lambda>rv s. \<exists>m mr t. P (caps_of_state s) m t mr
+  apply (rule_tac Q'="\<lambda>rv s. \<exists>m mr t. P (caps_of_state s) m t mr
                     \<and> (cdt s = m) \<and> (exst s = t) \<and> (is_original_cap s = mr)"
            in hoare_post_imp)
    apply simp

--- a/proof/invariant-abstract/Finalise_AI.thy
+++ b/proof/invariant-abstract/Finalise_AI.thy
@@ -493,7 +493,7 @@ lemma cancel_ipc_caps_of_state:
   apply (simp add: cancel_ipc_def reply_cancel_ipc_def
              cong: Structures_A.thread_state.case_cong)
   apply (wpsimp wp: cap_delete_one_caps_of_state)
-     apply (rule_tac Q="\<lambda>_ s. (\<forall>p. cte_wp_at can_fast_finalise p s
+     apply (rule_tac Q'="\<lambda>_ s. (\<forall>p. cte_wp_at can_fast_finalise p s
                                 \<longrightarrow> P ((caps_of_state s) (p \<mapsto> cap.NullCap)))
                                 \<and> P (caps_of_state s)"
                   in hoare_post_imp)
@@ -941,7 +941,7 @@ lemma cap_delete_one_deletes_reply:
    \<lbrace>\<lambda>rv s. \<not> has_reply_cap t s\<rbrace>"
   apply (simp add: cap_delete_one_def unless_def is_final_cap_def)
   apply wp
-     apply (rule_tac Q="\<lambda>rv s. \<forall>sl' R. if (sl' = slot)
+     apply (rule_tac Q'="\<lambda>rv s. \<forall>sl' R. if (sl' = slot)
                                then cte_wp_at (\<lambda>c. c = cap.NullCap) sl' s
                                else caps_of_state s sl' \<noteq> Some (cap.ReplyCap t False R)"
                   in hoare_post_imp)

--- a/proof/invariant-abstract/IpcCancel_AI.thy
+++ b/proof/invariant-abstract/IpcCancel_AI.thy
@@ -441,7 +441,7 @@ lemma reply_cancel_ipc_invs:
   shows           "\<lbrace>invs\<rbrace> (reply_cancel_ipc t :: (unit,'z::state_ext) s_monad) \<lbrace>\<lambda>rv. invs\<rbrace>"
   apply (simp add: reply_cancel_ipc_def)
   apply (wp delete)
-  apply (rule_tac Q="\<lambda>rv. invs" in hoare_post_imp)
+  apply (rule_tac Q'="\<lambda>rv. invs" in hoare_post_imp)
    apply (fastforce simp: emptyable_def dest: reply_slot_not_descendant)
   apply (wp thread_set_invs_trivial)
    apply (auto simp: tcb_cap_cases_def)+
@@ -574,7 +574,7 @@ lemma (in delete_one_abs) reply_cancel_ipc_no_reply_cap[wp]:
   shows "\<lbrace>invs and tcb_at t\<rbrace> (reply_cancel_ipc t :: (unit,'a) s_monad) \<lbrace>\<lambda>rv s. \<not> has_reply_cap t s\<rbrace>"
   apply (simp add: reply_cancel_ipc_def)
   apply wp
-        apply (rule_tac Q="\<lambda>rvp s. cte_wp_at (\<lambda>c. c = cap.NullCap) rv s \<and>
+        apply (rule_tac Q'="\<lambda>rvp s. cte_wp_at (\<lambda>c. c = cap.NullCap) rv s \<and>
                                 (\<forall>sl R. sl \<noteq> rv \<longrightarrow>
                                   caps_of_state s sl \<noteq> Some (cap.ReplyCap t False R))"
                   in hoare_strengthen_post)
@@ -583,7 +583,7 @@ lemma (in delete_one_abs) reply_cancel_ipc_no_reply_cap[wp]:
         apply (clarsimp simp: has_reply_cap_def cte_wp_at_caps_of_state is_reply_cap_to_def)
         apply (case_tac "(aa, ba) = (a, b)",simp_all)[1]
        apply (wp hoare_vcg_all_lift | simp del: split_paired_All)+
-   apply (rule_tac Q="\<lambda>_ s. invs s \<and> tcb_at t s" in hoare_post_imp)
+   apply (rule_tac Q'="\<lambda>_ s. invs s \<and> tcb_at t s" in hoare_post_imp)
     apply (erule conjE)
     apply (frule(1) reply_cap_descends_from_master)
     apply (auto dest: reply_master_no_descendants_no_reply[rotated -1])[1]
@@ -599,7 +599,7 @@ lemma (in delete_one_abs) cancel_ipc_no_reply_cap[wp]:
                   cancel_signal_invs cancel_signal_st_tcb_at_general
                   blocked_cancel_ipc_invs blocked_ipc_st_tcb_at_general
         | strengthen reply_cap_doesnt_exist_strg)+
-   apply (rule_tac Q="\<lambda>rv. st_tcb_at ((=) rv) t and invs" in hoare_strengthen_post)
+   apply (rule_tac Q'="\<lambda>rv. st_tcb_at ((=) rv) t and invs" in hoare_strengthen_post)
     apply (wpsimp wp: gts_st_tcb)
    apply (fastforce simp: invs_def valid_state_def st_tcb_at_tcb_at
                    elim!: pred_tcb_weakenE)+
@@ -651,7 +651,7 @@ lemma (in delete_one_pre) reply_cancel_ipc_cte_wp_at_preserved:
   \<lbrace>cte_wp_at P p\<rbrace> (reply_cancel_ipc t :: (unit,'a) s_monad) \<lbrace>\<lambda>rv. cte_wp_at P p\<rbrace>"
   unfolding reply_cancel_ipc_def
   apply (wpsimp wp: delete_one_cte_wp_at_preserved)
-   apply (rule_tac Q="\<lambda>_. cte_wp_at P p" in hoare_post_imp, clarsimp)
+   apply (rule_tac Q'="\<lambda>_. cte_wp_at P p" in hoare_post_imp, clarsimp)
    apply (wpsimp wp: thread_set_cte_wp_at_trivial simp: ran_tcb_cap_cases)
   apply assumption
   done
@@ -746,7 +746,7 @@ lemma reply_cancel_ipc_bound_tcb_at[wp]:
    \<lbrace>\<lambda>_. bound_tcb_at P t\<rbrace>"
   unfolding reply_cancel_ipc_def
   apply (wpsimp wp: cap_delete_one_bound_tcb_at select_inv)
-   apply (rule_tac Q="\<lambda>_. bound_tcb_at P t and valid_mdb and valid_objs and tcb_at p" in  hoare_strengthen_post)
+   apply (rule_tac Q'="\<lambda>_. bound_tcb_at P t and valid_mdb and valid_objs and tcb_at p" in hoare_strengthen_post)
     apply (wpsimp wp: thread_set_no_change_tcb_pred thread_set_mdb)
      apply (fastforce simp:tcb_cap_cases_def)
     apply (wpsimp wp: thread_set_valid_objs_triv simp: ran_tcb_cap_cases)
@@ -786,7 +786,7 @@ lemma suspend_unlive:
   supply hoare_vcg_if_split[wp_split del] if_split[split del]
   apply (wp | simp only: obj_at_exst_update)+
      apply (simp add: obj_at_def)
-     apply (rule_tac Q="\<lambda>_. bound_tcb_at ((=) None) t" in hoare_strengthen_post)
+     apply (rule_tac Q'="\<lambda>_. bound_tcb_at ((=) None) t" in hoare_strengthen_post)
       supply hoare_vcg_if_split[wp_split]
       apply wp
      apply (auto simp: pred_tcb_def2)[1]
@@ -1113,7 +1113,7 @@ lemma cancel_all_signals_unlive[wp]:
    apply (wp
         | wpc
         | simp add: unbind_maybe_notification_def)+
-     apply (rule_tac Q="\<lambda>_. obj_at (is_ntfn and Not \<circ> live) ntfnptr" in hoare_post_imp)
+     apply (rule_tac Q'="\<lambda>_. obj_at (is_ntfn and Not \<circ> live) ntfnptr" in hoare_post_imp)
       apply (fastforce elim: obj_at_weakenE)
      apply (wp mapM_x_wp' sts_obj_at_impossible
           | simp add: is_ntfn)+

--- a/proof/invariant-abstract/Ipc_AI.thy
+++ b/proof/invariant-abstract/Ipc_AI.thy
@@ -584,7 +584,7 @@ lemma cap_insert_assume_null:
    apply (rule bind_wp[OF _ get_cap_sp])+
    apply (clarsimp simp: valid_def cte_wp_at_caps_of_state in_monad
               split del: if_split)
-  apply (erule hoare_pre(1))
+  apply (erule hoare_weaken_pre)
   apply simp
   done
 
@@ -618,7 +618,7 @@ lemma transfer_caps_loop_presM:
            | assumption | simp split del: if_split)+
       apply (rule cap_insert_assume_null)
       apply (wp x hoare_vcg_const_Ball_lift cap_insert_cte_wp_at hoare_weak_lift_imp)+
-      apply (rule hoare_vcg_conj_liftE_R)
+      apply (rule hoare_vcg_conj_liftE_R')
        apply (rule derive_cap_is_derived_foo)
       apply (rule_tac Q' ="\<lambda>cap' s. (vo \<longrightarrow> cap'\<noteq> cap.NullCap \<longrightarrow>
           cte_wp_at (is_derived (cdt s) (aa, b) cap') (aa, b) s)
@@ -627,8 +627,8 @@ lemma transfer_caps_loop_presM:
         prefer 2
         apply clarsimp
         apply assumption
-       apply (rule hoare_vcg_conj_liftE_R)
-         apply (rule hoare_vcg_const_imp_lift_R)
+       apply (rule hoare_vcg_conj_liftE_R')
+         apply (rule hoare_vcg_const_imp_liftE_R)
         apply (rule derive_cap_is_derived)
       apply (wp derive_cap_is_derived_foo)+
   apply (clarsimp simp: cte_wp_at_caps_of_state
@@ -948,11 +948,11 @@ lemma tcl_reply':
   done
 
 lemmas tcl_reply[wp] = tcl_reply' [THEN hoare_strengthen_post
-                                        [where R="\<lambda>_. valid_reply_caps"],
+                                        [where Q="\<lambda>_. valid_reply_caps"],
                                    simplified]
 
 lemmas tcl_reply_masters[wp] = tcl_reply' [THEN hoare_strengthen_post
-                                        [where R="\<lambda>_. valid_reply_masters"],
+                                        [where Q="\<lambda>_. valid_reply_masters"],
                                    simplified]
 
 lemma transfer_caps_loop_irq_node[wp]:
@@ -2543,7 +2543,7 @@ lemma setup_caller_cap_reply[wp]:
    \<lbrace>\<lambda>rv. valid_reply_caps\<rbrace>"
   unfolding setup_caller_cap_def
   apply wp
-   apply (rule_tac Q="\<lambda>rv s. pspace_aligned s \<and> tcb_at st s \<and>
+   apply (rule_tac Q'="\<lambda>rv s. pspace_aligned s \<and> tcb_at st s \<and>
          st_tcb_at (\<lambda>ts. ts = Structures_A.thread_state.BlockedOnReply) st s \<and>
          \<not> has_reply_cap st s"
                  in hoare_post_imp)
@@ -2735,7 +2735,7 @@ lemma complete_signal_invs:
   apply (rule bind_wp[OF _ get_simple_ko_sp])
   apply (rule hoare_pre)
    apply (wp set_ntfn_minor_invs | wpc | simp)+
-   apply (rule_tac Q="\<lambda>_ s. (state_refs_of s ntfnptr = ntfn_bound_refs (ntfn_bound_tcb ntfn))
+   apply (rule_tac Q'="\<lambda>_ s. (state_refs_of s ntfnptr = ntfn_bound_refs (ntfn_bound_tcb ntfn))
                       \<and> (\<exists>T. typ_at T ntfnptr s) \<and> valid_ntfn (ntfn_set_obj ntfn IdleNtfn) s
                       \<and> ((\<exists>y. ntfn_bound_tcb ntfn = Some y) \<longrightarrow> ex_nonz_cap_to ntfnptr s)"
                       in hoare_strengthen_post)
@@ -2775,7 +2775,7 @@ lemma ri_invs':
   apply (rule bind_wp[OF _ gbn_sp])
   apply (rule bind_wp)
   (* set up precondition for old proof *)
-   apply (rule_tac R="ko_at (Endpoint rv) ep and ?pre" in hoare_vcg_if_split)
+   apply (rule_tac P''="ko_at (Endpoint rv) ep and ?pre" in hoare_vcg_if_split)
     apply (wp complete_signal_invs)
    apply (case_tac rv)
      apply (wp | rule hoare_pre, wpc | simp)+
@@ -3385,7 +3385,7 @@ lemma ri_makes_simple:
   apply (rule bind_wp [OF _ gbn_sp])
   apply (rule bind_wp)
    apply (rename_tac ep I DO rv CARE NOT)
-   apply (rule_tac R="ko_at (Endpoint rv) ep and ?pre" in hoare_vcg_if_split)
+   apply (rule_tac P''="ko_at (Endpoint rv) ep and ?pre" in hoare_vcg_if_split)
     apply (wp complete_signal_invs)
    apply (case_tac rv, simp_all)
      apply (rule hoare_pre, wpc)

--- a/proof/invariant-abstract/RISCV64/ArchCNodeInv_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchCNodeInv_AI.thy
@@ -719,7 +719,7 @@ next
     apply simp
     apply (rule hoare_pre_spec_validE)
      apply (wp replace_cap_invs | simp add: is_cap_simps)+
-      apply (rule_tac Q="\<lambda>rv s. Q s \<and> invs s \<and> cte_wp_at (\<lambda>cap. cap = rv) slot s
+      apply (rule_tac Q'="\<lambda>rv s. Q s \<and> invs s \<and> cte_wp_at (\<lambda>cap. cap = rv) slot s
                              \<and> cte_wp_at (\<lambda>cap. cap = cap.NullCap
                                         \<or> \<not> False \<and> is_zombie cap
                                             \<and> (ptr, nat_to_cref (zombie_cte_bits bits) n)

--- a/proof/invariant-abstract/RISCV64/ArchDetSchedDomainTime_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchDetSchedDomainTime_AI.thy
@@ -75,7 +75,7 @@ lemma timer_tick_valid_domain_time:
            wp: reschedule_required_valid_domain_time hoare_vcg_const_imp_lift gts_wp
                (* unless we hit dec_domain_time we know ?dtnot0 holds on the state, so clean up the
                   postcondition once we hit thread_set_time_slice *)
-               hoare_post_imp[where Q="\<lambda>_. ?dtnot0" and R="\<lambda>_ s. domain_time s = 0 \<longrightarrow> X s"
+               hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and R="\<lambda>_ s. domain_time s = 0 \<longrightarrow> X s"
                                 and a="thread_set_time_slice t ts" for X t ts]
                hoare_drop_imp[where f="ethread_get t f" for t f])
   apply fastforce
@@ -89,11 +89,11 @@ lemma handle_interrupt_valid_domain_time [DetSchedDomainTime_AI_assms]:
   apply (case_tac "maxIRQ < i", solves \<open>wpsimp wp: hoare_false_imp\<close>)
   apply clarsimp
   apply (wpsimp simp: arch_mask_irq_signal_def)
-        apply (rule hoare_post_imp[where Q="\<lambda>_. ?dtnot0" and a="send_signal p c" for p c], fastforce)
+        apply (rule hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and a="send_signal p c" for p c], fastforce)
         apply wpsimp
-       apply (rule hoare_post_imp[where Q="\<lambda>_. ?dtnot0" and a="get_cap p" for p], fastforce)
+       apply (rule hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and a="get_cap p" for p], fastforce)
       apply (wpsimp wp: timer_tick_valid_domain_time simp: handle_reserved_irq_def)+
-     apply (rule hoare_post_imp[where Q="\<lambda>_. ?dtnot0" and a="get_irq_state i" for i], fastforce)
+     apply (rule hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and a="get_irq_state i" for i], fastforce)
    apply wpsimp+
   done
 

--- a/proof/invariant-abstract/RISCV64/ArchDetSchedDomainTime_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchDetSchedDomainTime_AI.thy
@@ -75,8 +75,8 @@ lemma timer_tick_valid_domain_time:
            wp: reschedule_required_valid_domain_time hoare_vcg_const_imp_lift gts_wp
                (* unless we hit dec_domain_time we know ?dtnot0 holds on the state, so clean up the
                   postcondition once we hit thread_set_time_slice *)
-               hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and R="\<lambda>_ s. domain_time s = 0 \<longrightarrow> X s"
-                                and a="thread_set_time_slice t ts" for X t ts]
+               hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and Q="\<lambda>_ s. domain_time s = 0 \<longrightarrow> X s"
+                                and f="thread_set_time_slice t ts" for X t ts]
                hoare_drop_imp[where f="ethread_get t f" for t f])
   apply fastforce
   done
@@ -89,11 +89,11 @@ lemma handle_interrupt_valid_domain_time [DetSchedDomainTime_AI_assms]:
   apply (case_tac "maxIRQ < i", solves \<open>wpsimp wp: hoare_false_imp\<close>)
   apply clarsimp
   apply (wpsimp simp: arch_mask_irq_signal_def)
-        apply (rule hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and a="send_signal p c" for p c], fastforce)
+        apply (rule hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and f="send_signal p c" for p c], fastforce)
         apply wpsimp
-       apply (rule hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and a="get_cap p" for p], fastforce)
+       apply (rule hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and f="get_cap p" for p], fastforce)
       apply (wpsimp wp: timer_tick_valid_domain_time simp: handle_reserved_irq_def)+
-     apply (rule hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and a="get_irq_state i" for i], fastforce)
+     apply (rule hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and f="get_irq_state i" for i], fastforce)
    apply wpsimp+
   done
 

--- a/proof/invariant-abstract/RISCV64/ArchDetype_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchDetype_AI.thy
@@ -616,7 +616,7 @@ lemma delete_objects_invs[wp]:
   apply (simp add: delete_objects_def)
   apply (simp add: freeMemory_def word_size_def bind_assoc ef_storeWord)
    apply (rule hoare_pre)
-   apply (rule_tac G="is_aligned ptr bits \<and> word_size_bits \<le> bits \<and> bits \<le> word_bits"
+   apply (rule_tac P'="is_aligned ptr bits \<and> word_size_bits \<le> bits \<and> bits \<le> word_bits"
                 in hoare_grab_asm)
    apply (simp add: mapM_storeWord_clear_um[unfolded word_size_def]
                     intvl_range_conv[where 'a=machine_word_len, folded word_bits_def])

--- a/proof/invariant-abstract/RISCV64/ArchFinalise_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchFinalise_AI.thy
@@ -803,7 +803,7 @@ lemma arch_finalise_cap_replaceable:
                 is_cap_simps vs_cap_ref_def
                 no_cap_to_obj_with_diff_ref_Null o_def
                 reachable_frame_cap_simps
-  notes wps = hoare_drop_imp[where R="%_. is_final_cap' cap" for cap]
+  notes wps = hoare_drop_imp[where Q'="%_. is_final_cap' cap" for cap]
               valid_cap_typ
               unmap_page_unreachable unmap_page_table_unreachable
               delete_asid_unreachable
@@ -897,7 +897,7 @@ lemma prepare_thread_delete_unlive0:
 
 lemma prepare_thread_delete_unlive[wp]:
   "\<lbrace>obj_at (Not \<circ> live0) ptr\<rbrace> prepare_thread_delete ptr \<lbrace>\<lambda>rv. obj_at (Not \<circ> live) ptr\<rbrace>"
-  apply (rule_tac Q="\<lambda>rv. obj_at (Not \<circ> live0) ptr and obj_at (Not \<circ> hyp_live) ptr" in hoare_strengthen_post)
+  apply (rule_tac Q'="\<lambda>rv. obj_at (Not \<circ> live0) ptr and obj_at (Not \<circ> hyp_live) ptr" in hoare_strengthen_post)
   apply (wpsimp wp: hoare_vcg_conj_lift prepare_thread_delete_unlive_hyp prepare_thread_delete_unlive0)
    apply (clarsimp simp: obj_at_def)
   apply (clarsimp simp: obj_at_def, case_tac ko, simp_all add: is_tcb_def live_def)

--- a/proof/invariant-abstract/RISCV64/ArchInterrupt_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchInterrupt_AI.thy
@@ -149,7 +149,7 @@ lemma invoke_irq_handler_invs'[Interrupt_AI_asms]:
     apply (wp valid_cap_typ [OF cap_delete_one_typ_at])
      apply (strengthen real_cte_tcb_valid)
      apply (wp real_cte_at_typ_valid [OF cap_delete_one_typ_at])
-     apply (rule_tac Q="\<lambda>rv s. is_ntfn_cap cap \<and> invs s
+     apply (rule_tac Q'="\<lambda>rv s. is_ntfn_cap cap \<and> invs s
                               \<and> cte_wp_at (is_derived (cdt s) prod cap) prod s"
                 in hoare_post_imp)
       apply (clarsimp simp: is_cap_simps is_derived_def cte_wp_at_caps_of_state)
@@ -244,7 +244,7 @@ lemma (* handle_interrupt_invs *) [Interrupt_AI_asms]:
      apply (wpsimp wp: dmo_maskInterrupt_invs maskInterrupt_invs_ARCH dmo_ackInterrupt
                       send_signal_interrupt_states simp: arch_mask_irq_signal_def)+
      apply (wp get_cap_wp send_signal_interrupt_states )
-    apply (rule_tac Q="\<lambda>rv. invs and (\<lambda>s. st = interrupt_states s irq)" in hoare_post_imp)
+    apply (rule_tac Q'="\<lambda>rv. invs and (\<lambda>s. st = interrupt_states s irq)" in hoare_post_imp)
      apply (clarsimp simp: ex_nonz_cap_to_def invs_valid_objs)
      apply (intro allI exI, erule cte_wp_at_weakenE)
      apply (clarsimp simp: is_cap_simps)

--- a/proof/invariant-abstract/RISCV64/ArchIpc_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchIpc_AI.thy
@@ -287,7 +287,7 @@ lemma transfer_caps_tcb_caps:
          | wpc | simp)+
     apply (erule imp)
    apply (wp hoare_vcg_conj_lift hoare_vcg_const_imp_lift hoare_vcg_all_lift)
-    apply (rule_tac Q = "\<lambda>rv s. (\<forall>x\<in>set rv. real_cte_at x s) \<and> cte_wp_at P (t, ref) s \<and> tcb_at t s"
+    apply (rule_tac Q'="\<lambda>rv s. (\<forall>x\<in>set rv. real_cte_at x s) \<and> cte_wp_at P (t, ref) s \<and> tcb_at t s"
                     in hoare_strengthen_post)
      apply (wp get_rs_real_cte_at)
     apply clarsimp
@@ -311,7 +311,7 @@ lemma transfer_caps_non_null_cte_wp_at:
    apply (wp hoare_vcg_ball_lift transfer_caps_loop_cte_wp_at hoare_weak_lift_imp
      | wpc | clarsimp simp:imp)+
    apply (rule hoare_strengthen_post
-            [where Q="\<lambda>rv s'. (cte_wp_at ((\<noteq>) cap.NullCap) ptr) s'
+            [where Q'="\<lambda>rv s'. (cte_wp_at ((\<noteq>) cap.NullCap) ptr) s'
                       \<and> (\<forall>x\<in>set rv. cte_wp_at ((=) cap.NullCap) x s')",
              rotated])
     apply (clarsimp)

--- a/proof/invariant-abstract/RISCV64/ArchIpc_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchIpc_AI.thy
@@ -55,8 +55,7 @@ lemma derive_cap_is_derived [Ipc_AI_assms]:
                     | fold validE_R_def
                     | erule cte_wp_at_weakenE
                     | simp split: cap.split_asm)+)[11]
-  including no_pre
-  apply(rule hoare_pre, wp hoare_drop_imps arch_derive_cap_is_derived)
+  apply(wp hoare_drop_imps arch_derive_cap_is_derived)
   apply(clarify, drule cte_wp_at_norm, clarify)
   apply(frule(1) cte_wp_at_valid_objs_valid_cap)
   apply(erule cte_wp_at_weakenE)

--- a/proof/invariant-abstract/RISCV64/ArchSchedule_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchSchedule_AI.thy
@@ -92,7 +92,7 @@ lemma stt_invs [wp,Schedule_AI_asms]:
   apply (simp add: switch_to_thread_def)
   apply wp
      apply (simp add: trans_state_update[symmetric] del: trans_state_update)
-    apply (rule_tac Q="\<lambda>_. invs and tcb_at t'" in hoare_strengthen_post, wp)
+    apply (rule_tac Q'="\<lambda>_. invs and tcb_at t'" in hoare_strengthen_post, wp)
     apply (clarsimp simp: invs_def valid_state_def valid_idle_def
                           valid_irq_node_def valid_machine_state_def)
     apply (fastforce simp: cur_tcb_def obj_at_def

--- a/proof/invariant-abstract/RISCV64/ArchTcb_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchTcb_AI.thy
@@ -244,12 +244,12 @@ lemma tc_invs[Tcb_AI_asms]:
                   strengthen imp_consequent[where Q="x = None" for x], simp cong: conj_cong)
         | rule wp_split_const_if wp_split_const_if_R
                    hoare_vcg_all_liftE_R
-                   hoare_vcg_E_elim hoare_vcg_const_imp_lift_R
-                   hoare_vcg_R_conj
+                   hoare_vcg_conj_elimE hoare_vcg_const_imp_liftE_R
+                   hoare_vcg_conj_liftE_R
         | (wp out_invs_trivial case_option_wpE cap_delete_deletes
              cap_delete_valid_cap cap_insert_valid_cap out_cte_at
              cap_insert_cte_at cap_delete_cte_at out_valid_cap
-             hoare_vcg_const_imp_lift_R hoare_vcg_all_liftE_R
+             hoare_vcg_const_imp_liftE_R hoare_vcg_all_liftE_R
              thread_set_tcb_ipc_buffer_cap_cleared_invs
              thread_set_invs_trivial[OF ball_tcb_cap_casesI]
              hoare_vcg_all_lift thread_set_valid_cap out_emptyable

--- a/proof/invariant-abstract/RISCV64/ArchVSpace_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchVSpace_AI.thy
@@ -688,7 +688,7 @@ lemma unmap_page_table_invs[wp]:
   apply (simp add: unmap_page_table_def)
   apply (rule hoare_pre)
    apply (wp dmo_invs | wpc | simp)+
-     apply (rule_tac Q="\<lambda>_. invs" in hoare_post_imp)
+     apply (rule_tac Q'="\<lambda>_. invs" in hoare_post_imp)
       apply safe
        apply (drule_tac Q="\<lambda>_ m'. underlying_memory m' p =
                                   underlying_memory m p" in use_valid)

--- a/proof/invariant-abstract/Retype_AI.thy
+++ b/proof/invariant-abstract/Retype_AI.thy
@@ -1228,7 +1228,7 @@ lemma retype_region_cur_tcb[wp]:
   supply
     is_aligned_neg_mask_eq[simp del]
     is_aligned_neg_mask_weaken[simp del]
-  apply (rule hoare_post_imp [where Q="\<lambda>rv s. \<exists>tp. tcb_at tp s \<and> cur_thread s = tp"])
+  apply (rule hoare_post_imp[where Q'="\<lambda>rv s. \<exists>tp. tcb_at tp s \<and> cur_thread s = tp"])
    apply (simp add: cur_tcb_def)
   apply (wpsimp wp: hoare_vcg_ex_lift retype_region_obj_at_other3 simp: retype_region_def)
   apply (auto simp: cur_tcb_def cong: if_cong)

--- a/proof/invariant-abstract/Schedule_AI.thy
+++ b/proof/invariant-abstract/Schedule_AI.thy
@@ -133,7 +133,7 @@ lemma (in Schedule_AI) stt_invs [wp]:
   apply (simp add: switch_to_thread_def)
   apply wp
      apply (simp add: trans_state_update[symmetric] del: trans_state_update)
-    apply (rule_tac Q="\<lambda>_. invs and tcb_at t'" in hoare_strengthen_post, wp)
+    apply (rule_tac Q'="\<lambda>_. invs and tcb_at t'" in hoare_strengthen_post, wp)
     apply (clarsimp simp: invs_def valid_state_def valid_idle_def
                           valid_irq_node_def valid_machine_state_def)
     apply (fastforce simp: cur_tcb_def obj_at_def

--- a/proof/invariant-abstract/Syscall_AI.thy
+++ b/proof/invariant-abstract/Syscall_AI.thy
@@ -415,7 +415,7 @@ lemma (in Systemcall_AI_Pre2) do_reply_invs[wp]:
           apply (drule st_tcb_at_eq, erule pred_tcb_weaken_strongerE, simp)
           apply clarsimp
          apply (wp handle_fault_reply_has_no_reply_cap)
-     apply (rule_tac Q = "\<lambda>_. st_tcb_at awaiting_reply t and invs and
+     apply (rule_tac Q'="\<lambda>_. st_tcb_at awaiting_reply t and invs and
                          (\<lambda>s. \<not>has_reply_cap t s)" in hoare_strengthen_post[rotated])
       apply (clarsimp)
       apply (erule pred_tcb_weakenE)
@@ -953,7 +953,7 @@ lemma lcs_ex_cap_to2[wp]:
   done
 
 (* FIXME AARCH64: this should really not be wp *)
-declare hoare_vcg_const_imp_lift_E[wp]
+declare hoare_vcg_const_imp_liftE_E[wp]
 
 context Syscall_AI begin
 
@@ -994,7 +994,7 @@ lemma hinv_invs':
   apply simp
   apply (wp sts_st_tcb_at')
   apply (simp only: simp_thms K_def if_apply_def2)
-  apply (rule hoare_vcg_E_elim)
+  apply (rule hoare_vcg_conj_elimE)
   apply (wp | simp add: if_apply_def2)+
   apply (auto simp: ct_in_state_def elim: st_tcb_ex_cap)
   done
@@ -1089,7 +1089,7 @@ lemma delete_caller_cap_simple[wp]:
 
 lemma delete_caller_deletes_caller[wp]:
   "\<lbrace>\<top>\<rbrace> delete_caller_cap t \<lbrace>\<lambda>rv. cte_wp_at ((=) cap.NullCap) (t, tcb_cnode_index 3)\<rbrace>"
-  apply (rule_tac Q="\<lambda>rv. cte_wp_at (\<lambda>c. c = cap.NullCap) (t, tcb_cnode_index 3)"
+  apply (rule_tac Q'="\<lambda>rv. cte_wp_at (\<lambda>c. c = cap.NullCap) (t, tcb_cnode_index 3)"
                in hoare_post_imp,
          clarsimp elim!: cte_wp_at_weakenE)
   apply (simp add: delete_caller_cap_def cap_delete_one_def unless_def, wp)
@@ -1111,7 +1111,7 @@ lemma hw_invs[wp]: "\<lbrace>invs and ct_active\<rbrace> handle_recv is_blocking
     cong: if_cong)
   apply (wp get_simple_ko_wp | clarsimp)+
   apply (wp delete_caller_cap_nonz_cap get_simple_ko_wp hoare_vcg_ball_lift | simp)+
-     apply (rule hoare_vcg_E_elim)
+     apply (rule hoare_vcg_conj_elimE)
       apply (simp add: lookup_cap_def lookup_slot_for_thread_def)
       apply wp
        apply (simp add: split_def)
@@ -1274,7 +1274,7 @@ lemma handle_reply_nonz_cap_to_ct:
   "\<lbrace>\<lambda>s. ex_nonz_cap_to (cur_thread s) s \<and> valid_objs s \<and> valid_mdb s \<and> tcb_at (cur_thread s) s\<rbrace>
      handle_reply
    \<lbrace>\<lambda>rv s :: 'state_ext state. ex_nonz_cap_to (cur_thread s) s\<rbrace>"
-  apply (rule_tac Q="\<lambda>rv s. \<exists>ct. (ct = cur_thread s) \<and> ex_nonz_cap_to ct s"
+  apply (rule_tac Q'="\<lambda>rv s. \<exists>ct. (ct = cur_thread s) \<and> ex_nonz_cap_to ct s"
                in hoare_post_imp)
    apply simp
   apply (wp hoare_vcg_ex_lift handle_reply_nonz_cap)

--- a/proof/invariant-abstract/Syscall_AI.thy
+++ b/proof/invariant-abstract/Syscall_AI.thy
@@ -364,10 +364,10 @@ lemma (in Systemcall_AI_Pre2) do_reply_invs[wp]:
         apply (wp sts_invs_minor)
        apply (clarsimp)
        apply (wp cap_delete_one_st_tcb_at)
-       apply (rule_tac Q = "\<lambda>_. invs and if_live_then_nonz_cap and
+       apply (rule_tac Q'="\<lambda>_. invs and if_live_then_nonz_cap and
                                 st_tcb_at awaiting_reply t and
-                                (\<lambda>s. \<not>has_reply_cap t s)" in
-              hoare_strengthen_post[rotated])
+                                (\<lambda>s. \<not>has_reply_cap t s)"
+                    in hoare_strengthen_post[rotated])
         apply (clarsimp)
         apply (rule conjI, erule(1) st_tcb_ex_cap, clarsimp)
         apply (rule conjI)
@@ -377,13 +377,11 @@ lemma (in Systemcall_AI_Pre2) do_reply_invs[wp]:
         apply (rule disjI1)
         apply (erule pred_tcb_weakenE)
         apply (clarsimp)
-       apply (rule_tac Q = "\<lambda>_. invs and st_tcb_at awaiting_reply t and
-                           (\<lambda>s. \<not>has_reply_cap t s)" in
-              hoare_strengthen_post[rotated], clarsimp)
+       apply (rule_tac Q'="\<lambda>_. invs and st_tcb_at awaiting_reply t and (\<lambda>s. \<not>has_reply_cap t s)"
+                    in hoare_strengthen_post[rotated], clarsimp)
        apply (wp cap_delete_one_reply_st_tcb_at cap_delete_one_deletes_reply | simp)+
-      apply (rule_tac Q = "\<lambda>_. valid_reply_caps and
-                          cte_wp_at (is_reply_cap_to t) slot" in
-             hoare_strengthen_post[rotated], clarsimp)
+      apply (rule_tac Q'="\<lambda>_. valid_reply_caps and cte_wp_at (is_reply_cap_to t) slot"
+                   in hoare_strengthen_post[rotated], clarsimp)
        apply (erule cte_wp_at_weakenE, simp)
       apply (wp)
       apply (rule do_ipc_transfer_non_null_cte_wp_at2, clarsimp simp add: is_reply_cap_to_def)
@@ -396,17 +394,16 @@ lemma (in Systemcall_AI_Pre2) do_reply_invs[wp]:
            apply (clarsimp)
            apply (wp thread_set_cap_to thread_set_it |
                   clarsimp simp add: tcb_cap_cases_def)+
-           apply (rule_tac Q = "\<lambda>_. invs and st_tcb_at awaiting_reply t and
-                               (\<lambda>s. \<not>has_reply_cap t s)" in
-                  hoare_strengthen_post[rotated])
+           apply (rule_tac Q'="\<lambda>_. invs and st_tcb_at awaiting_reply t and (\<lambda>s. \<not>has_reply_cap t s)"
+                        in hoare_strengthen_post[rotated])
             apply (clarsimp)
             apply (erule pred_tcb_weakenE)
             apply (clarsimp)
            apply (wp thread_set_invs_trivial thread_set_no_change_tcb_state
                      thread_set_has_no_reply_cap | clarsimp simp add: tcb_cap_cases_def)+
-         apply (rule_tac Q = "\<lambda>_. st_tcb_at (\<lambda>s. tcb_st_refs_of s = {}) t and invs and
-                             st_tcb_at awaiting_reply t and (\<lambda>s. \<not>has_reply_cap t s)" in
-                hoare_strengthen_post[rotated])
+         apply (rule_tac Q'="\<lambda>_. st_tcb_at (\<lambda>s. tcb_st_refs_of s = {}) t and invs and
+                                 st_tcb_at awaiting_reply t and (\<lambda>s. \<not>has_reply_cap t s)"
+                      in hoare_strengthen_post[rotated])
           apply (clarsimp)
           apply (rule conjI)
            apply (erule(1) st_tcb_ex_cap'[where P=awaiting_reply])
@@ -425,10 +422,9 @@ lemma (in Systemcall_AI_Pre2) do_reply_invs[wp]:
     apply (wp hoare_drop_imp hoare_allI)[1]
    apply (wp assert_wp)
   apply (clarsimp)
-  apply (rule_tac Q = "\<lambda>rv. st_tcb_at ((=) rv) t and tcb_at t' and invs and
-                      emptyable slot and
-                      cte_wp_at (is_reply_cap_to t) slot" in
-         hoare_strengthen_post[rotated])
+  apply (rule_tac Q'="\<lambda>rv. st_tcb_at ((=) rv) t and tcb_at t' and invs and
+                           emptyable slot and cte_wp_at (is_reply_cap_to t) slot"
+               in hoare_strengthen_post[rotated])
    apply (clarsimp simp add: st_tcb_at_tcb_at)
    apply (rule conjI, erule pred_tcb_weakenE, clarsimp)+
    apply (clarsimp simp add: invs_def valid_state_def valid_pspace_def)
@@ -980,8 +976,7 @@ lemma hinv_invs':
 
   apply (wp syscall_valid sts_invs_minor2 rfk_invs
             hoare_vcg_all_lift hoare_vcg_disj_lift | simp split del: if_split)+
-  apply (rule_tac Q = "\<lambda>st. st_tcb_at ((=) st) thread and (invs and Q)" in
-         hoare_post_imp)
+  apply (rule_tac Q'="\<lambda>st. st_tcb_at ((=) st) thread and (invs and Q)" in hoare_post_imp)
   apply (auto elim!: pred_tcb_weakenE st_tcb_ex_cap
               dest: st_tcb_at_idle_thread
               simp: st_tcb_at_tcb_at)[1]
@@ -989,8 +984,7 @@ lemma hinv_invs':
   apply wp
   apply (simp add: ct_in_state_def conj_commute conj_left_commute)
   apply wp
-  apply (rule_tac Q = "\<lambda>rv s. st_tcb_at active thread s \<and> cur_thread s = thread" in
-         hoare_post_imp)
+  apply (rule_tac Q'="\<lambda>rv s. st_tcb_at active thread s \<and> cur_thread s = thread" in hoare_post_imp)
   apply simp
   apply (wp sts_st_tcb_at')
   apply (simp only: simp_thms K_def if_apply_def2)

--- a/proof/invariant-abstract/TcbAcc_AI.thy
+++ b/proof/invariant-abstract/TcbAcc_AI.thy
@@ -962,7 +962,7 @@ lemma ct_in_state_decomp:
   assumes x: "\<lbrace>\<lambda>s. t = (cur_thread s)\<rbrace> f \<lbrace>\<lambda>rv s. t = (cur_thread s)\<rbrace>"
   assumes y: "\<lbrace>Pre\<rbrace> f \<lbrace>\<lambda>rv. st_tcb_at Prop t\<rbrace>"
   shows      "\<lbrace>\<lambda>s. Pre s \<and> t = (cur_thread s)\<rbrace> f \<lbrace>\<lambda>rv. ct_in_state Prop\<rbrace>"
-  apply (rule hoare_post_imp [where Q="\<lambda>rv s. t = cur_thread s \<and> st_tcb_at Prop t s"])
+  apply (rule hoare_post_imp[where Q'="\<lambda>rv s. t = cur_thread s \<and> st_tcb_at Prop t s"])
    apply (clarsimp simp add: ct_in_state_def)
   apply (rule hoare_weaken_pre)
    apply (wp x y)

--- a/proof/invariant-abstract/Tcb_AI.thy
+++ b/proof/invariant-abstract/Tcb_AI.thy
@@ -76,7 +76,7 @@ lemma (in Tcb_AI_1) activate_invs:
     apply wp
     apply (clarsimp elim!: pred_tcb_weakenE
                      simp: ct_in_state_def)
-   apply (rule_tac Q="\<lambda>rv. invs and ct_running" in hoare_post_imp, simp)
+   apply (rule_tac Q'="\<lambda>rv. invs and ct_running" in hoare_post_imp, simp)
    apply (rule hoare_pre)
     apply (wp sts_invs_minor ct_in_state_set)
       apply simp
@@ -88,7 +88,7 @@ lemma (in Tcb_AI_1) activate_invs:
                          valid_idle_def valid_pspace_def
                elim: st_tcb_ex_cap pred_tcb_weakenE,
           auto simp: st_tcb_def2 pred_tcb_at_def obj_at_def)[1]
-  apply (rule_tac Q="\<lambda>rv. invs and ct_idle" in hoare_post_imp, simp)
+  apply (rule_tac Q'="\<lambda>rv. invs and ct_idle" in hoare_post_imp, simp)
   apply (wp activate_idle_invs hoare_post_imp [OF disjI2])
   apply (clarsimp simp: ct_in_state_def elim!: pred_tcb_weakenE)
   done

--- a/proof/invariant-abstract/X64/ArchArch_AI.thy
+++ b/proof/invariant-abstract/X64/ArchArch_AI.thy
@@ -1351,8 +1351,8 @@ lemma decode_page_invocation_wf[wp]:
   apply (cases "invocation_type label = ArchInvocationLabel X64PageMap")
    apply (simp split del: if_split)
    apply (rule hoare_pre)
-    apply (wpsimp wp: whenE_throwError_wp check_vp_wpR hoare_vcg_const_imp_lift_R
-                      hoare_vcg_disj_lift_R hoare_vcg_conj_lift_R create_mapping_entries_parent_for_refs
+    apply (wpsimp wp: whenE_throwError_wp check_vp_wpR hoare_vcg_const_imp_liftE_R
+                      hoare_vcg_disj_lift_R hoare_vcg_conj_liftE_R create_mapping_entries_parent_for_refs
                       hoare_vcg_ex_lift_R find_vspace_for_asid_vspace_at_asid
                       create_mapping_entries_valid_slots create_mapping_entries_same_refs_ex
                       find_vspace_for_asid_lookup_vspace_wp
@@ -1555,7 +1555,7 @@ lemma decode_ioport_control_inv_wf[wp]:
              split del: if_split
                   cong: if_cong)
   apply (rule hoare_pre)
-   apply (wp ensure_empty_stronger hoare_vcg_const_imp_lift_R hoare_vcg_const_imp_lift
+   apply (wp ensure_empty_stronger hoare_vcg_const_imp_liftE_R hoare_vcg_const_imp_lift
              is_ioport_range_free_wp
               | simp add: cte_wp_at_eq_simp valid_iocontrol_inv_def valid_arch_inv_def
                split del: if_split

--- a/proof/invariant-abstract/X64/ArchCNodeInv_AI.thy
+++ b/proof/invariant-abstract/X64/ArchCNodeInv_AI.thy
@@ -743,7 +743,7 @@ next
     apply simp
     apply (rule hoare_pre_spec_validE)
      apply (wp replace_cap_invs | simp add: is_cap_simps)+
-      apply (rule_tac Q="\<lambda>rv s. Q s \<and> invs s \<and> cte_wp_at (\<lambda>cap. cap = rv) slot s
+      apply (rule_tac Q'="\<lambda>rv s. Q s \<and> invs s \<and> cte_wp_at (\<lambda>cap. cap = rv) slot s
                              \<and> cte_wp_at (\<lambda>cap. cap = cap.NullCap
                                         \<or> \<not> False \<and> is_zombie cap
                                             \<and> (ptr, nat_to_cref (zombie_cte_bits bits) n)

--- a/proof/invariant-abstract/X64/ArchDetSchedDomainTime_AI.thy
+++ b/proof/invariant-abstract/X64/ArchDetSchedDomainTime_AI.thy
@@ -89,7 +89,7 @@ lemma timer_tick_valid_domain_time:
            wp: reschedule_required_valid_domain_time hoare_vcg_const_imp_lift gts_wp
                (* unless we hit dec_domain_time we know ?dtnot0 holds on the state, so clean up the
                   postcondition once we hit thread_set_time_slice *)
-               hoare_post_imp[where Q="\<lambda>_. ?dtnot0" and R="\<lambda>_ s. domain_time s = 0 \<longrightarrow> X s"
+               hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and R="\<lambda>_ s. domain_time s = 0 \<longrightarrow> X s"
                                 and a="thread_set_time_slice t ts" for X t ts]
                hoare_drop_imp[where f="ethread_get t f" for t f])
   apply fastforce
@@ -103,11 +103,11 @@ lemma handle_interrupt_valid_domain_time [DetSchedDomainTime_AI_assms]:
   apply (case_tac "maxIRQ < i", solves \<open>wpsimp wp: hoare_false_imp\<close>)
   apply clarsimp
   apply (wpsimp simp: arch_mask_irq_signal_def)
-        apply (rule hoare_post_imp[where Q="\<lambda>_. ?dtnot0" and a="send_signal p c" for p c], fastforce)
+        apply (rule hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and a="send_signal p c" for p c], fastforce)
         apply wpsimp
-       apply (rule hoare_post_imp[where Q="\<lambda>_. ?dtnot0" and a="get_cap p" for p], fastforce)
+       apply (rule hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and a="get_cap p" for p], fastforce)
       apply (wpsimp wp: timer_tick_valid_domain_time simp: handle_reserved_irq_def)+
-     apply (rule hoare_post_imp[where Q="\<lambda>_. ?dtnot0" and a="get_irq_state i" for i], fastforce)
+     apply (rule hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and a="get_irq_state i" for i], fastforce)
    apply wpsimp+
   done
 

--- a/proof/invariant-abstract/X64/ArchDetSchedDomainTime_AI.thy
+++ b/proof/invariant-abstract/X64/ArchDetSchedDomainTime_AI.thy
@@ -89,8 +89,8 @@ lemma timer_tick_valid_domain_time:
            wp: reschedule_required_valid_domain_time hoare_vcg_const_imp_lift gts_wp
                (* unless we hit dec_domain_time we know ?dtnot0 holds on the state, so clean up the
                   postcondition once we hit thread_set_time_slice *)
-               hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and R="\<lambda>_ s. domain_time s = 0 \<longrightarrow> X s"
-                                and a="thread_set_time_slice t ts" for X t ts]
+               hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and Q="\<lambda>_ s. domain_time s = 0 \<longrightarrow> X s"
+                                and f="thread_set_time_slice t ts" for X t ts]
                hoare_drop_imp[where f="ethread_get t f" for t f])
   apply fastforce
   done
@@ -103,11 +103,11 @@ lemma handle_interrupt_valid_domain_time [DetSchedDomainTime_AI_assms]:
   apply (case_tac "maxIRQ < i", solves \<open>wpsimp wp: hoare_false_imp\<close>)
   apply clarsimp
   apply (wpsimp simp: arch_mask_irq_signal_def)
-        apply (rule hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and a="send_signal p c" for p c], fastforce)
+        apply (rule hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and f="send_signal p c" for p c], fastforce)
         apply wpsimp
-       apply (rule hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and a="get_cap p" for p], fastforce)
+       apply (rule hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and f="get_cap p" for p], fastforce)
       apply (wpsimp wp: timer_tick_valid_domain_time simp: handle_reserved_irq_def)+
-     apply (rule hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and a="get_irq_state i" for i], fastforce)
+     apply (rule hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and f="get_irq_state i" for i], fastforce)
    apply wpsimp+
   done
 

--- a/proof/invariant-abstract/X64/ArchDetype_AI.thy
+++ b/proof/invariant-abstract/X64/ArchDetype_AI.thy
@@ -568,7 +568,7 @@ lemma delete_objects_invs[wp]:
   apply (simp add: delete_objects_def)
   apply (simp add: freeMemory_def word_size_def bind_assoc ef_storeWord)
    apply (rule hoare_pre)
-   apply (rule_tac G="is_aligned ptr bits \<and> word_size_bits \<le> bits \<and> bits \<le> word_bits"
+   apply (rule_tac P'="is_aligned ptr bits \<and> word_size_bits \<le> bits \<and> bits \<le> word_bits"
                 in hoare_grab_asm)
    apply (simp add: mapM_storeWord_clear_um[unfolded word_size_def]
                     intvl_range_conv[where 'a=machine_word_len, folded word_bits_def])

--- a/proof/invariant-abstract/X64/ArchFinalise_AI.thy
+++ b/proof/invariant-abstract/X64/ArchFinalise_AI.thy
@@ -108,7 +108,7 @@ lemma delete_asid_pool_unmapped[wp]:
    \<lbrace>\<lambda>rv s. \<not> ([VSRef (ucast (asid_high_bits_of asid)) None] \<rhd> poolptr) s\<rbrace>"
   apply (simp add: delete_asid_pool_def)
   apply wp
-    apply (rule hoare_strengthen_post [where Q="\<lambda>_. \<top>"])
+    apply (rule hoare_strengthen_post[where Q'="\<lambda>_. \<top>"])
      apply wp+
     defer
     apply wp+
@@ -428,7 +428,7 @@ lemma arch_finalise_cap_replaceable[wp]:
                 vs_lookup_pages_eq_ap[THEN fun_cong, symmetric]
                 is_cap_simps vs_cap_ref_def
                 no_cap_to_obj_with_diff_ref_Null o_def
-  notes wps = hoare_drop_imp[where R="%_. is_final_cap' cap" for cap]
+  notes wps = hoare_drop_imp[where Q'="%_. is_final_cap' cap" for cap]
                valid_cap_typ unmap_page_vs_lookup_pages_small
                unmap_page_vs_lookup_pages_large unmap_page_vs_lookup_pages_huge
   shows
@@ -523,7 +523,7 @@ lemma suspend_unlive':
   supply hoare_vcg_if_split[wp_split del] if_split[split del]
   apply (wp | simp only: obj_at_exst_update)+
      apply (simp add: obj_at_def live_def hyp_live_def)
-     apply (rule_tac Q="\<lambda>_. bound_tcb_at ((=) None) t" in hoare_strengthen_post)
+     apply (rule_tac Q'="\<lambda>_. bound_tcb_at ((=) None) t" in hoare_strengthen_post)
       supply hoare_vcg_if_split[wp_split]
       apply wp
      apply (auto simp: pred_tcb_def2)[1]
@@ -1583,7 +1583,7 @@ lemma delete_asid_pool_unmapped2:
    apply (wp delete_asid_pool_unmapped)
   apply (simp add: delete_asid_pool_def)
   apply wp
-      apply (rule_tac Q="\<lambda>rv s. ?Q s \<and> asid_table = x64_asid_table (arch_state s)"
+      apply (rule_tac Q'="\<lambda>rv s. ?Q s \<and> asid_table = x64_asid_table (arch_state s)"
                  in hoare_post_imp)
        apply (clarsimp simp: fun_upd_def[symmetric])
        apply (drule vs_lookup_clear_asid_table[rule_format])

--- a/proof/invariant-abstract/X64/ArchInterrupt_AI.thy
+++ b/proof/invariant-abstract/X64/ArchInterrupt_AI.thy
@@ -115,11 +115,11 @@ lemma arch_decode_irq_control_valid[wp]:
         split del: if_split
              cong: if_cong)
   apply (rule hoare_pre)
-   apply (wp ensure_empty_stronger hoare_vcg_const_imp_lift_R hoare_vcg_const_imp_lift
+   apply (wp ensure_empty_stronger hoare_vcg_const_imp_liftE_R hoare_vcg_const_imp_lift
           | simp add: cte_wp_at_eq_simp split del: if_split
           | wpc
-          | wp hoare_vcg_imp_lift_R[where P="\<lambda>rv s. \<not> x64_num_ioapics (arch_state s) - 1 < args ! 2"]
-          | wp hoare_vcg_imp_lift_R[where P="\<lambda>rv s. x64_num_ioapics (arch_state s) \<noteq> 0"]
+          | wp hoare_vcg_imp_liftE_R[where P="\<lambda>rv s. \<not> x64_num_ioapics (arch_state s) - 1 < args ! 2"]
+          | wp hoare_vcg_imp_liftE_R[where P="\<lambda>rv s. x64_num_ioapics (arch_state s) \<noteq> 0"]
           | wp (once) hoare_drop_imps)+
   apply ( safe; auto simp: word_le_not_less[symmetric] word_leq_minus_one_le
                            irq_plus_min_ge_min irq_plus_min_le_max ioapicIRQLines_def
@@ -235,7 +235,7 @@ lemma invoke_irq_handler_invs'[Interrupt_AI_asms]:
     apply (wp valid_cap_typ [OF cap_delete_one_typ_at])
      apply (strengthen real_cte_tcb_valid)
      apply (wp real_cte_at_typ_valid [OF cap_delete_one_typ_at])
-     apply (rule_tac Q="\<lambda>rv s. is_ntfn_cap cap \<and> invs s
+     apply (rule_tac Q'="\<lambda>rv s. is_ntfn_cap cap \<and> invs s
                               \<and> cte_wp_at (is_derived (cdt s) prod cap) prod s"
                 in hoare_post_imp)
       apply (clarsimp simp: is_cap_simps is_derived_def cte_wp_at_caps_of_state)
@@ -360,7 +360,7 @@ lemma (* handle_interrupt_invs *) [Interrupt_AI_asms]:
      apply (wp dmo_maskInterrupt_invs maskInterrupt_invs_ARCH dmo_ackInterrupt
             | wpc | simp add: arch_mask_irq_signal_def)+
      apply (wp get_cap_wp send_signal_interrupt_states)
-    apply (rule_tac Q="\<lambda>rv. invs and (\<lambda>s. st = interrupt_states s irq)" in hoare_post_imp)
+    apply (rule_tac Q'="\<lambda>rv. invs and (\<lambda>s. st = interrupt_states s irq)" in hoare_post_imp)
      apply (clarsimp simp: ex_nonz_cap_to_def invs_valid_objs)
      apply (intro allI exI, erule cte_wp_at_weakenE)
      apply (clarsimp simp: is_cap_simps)

--- a/proof/invariant-abstract/X64/ArchIpc_AI.thy
+++ b/proof/invariant-abstract/X64/ArchIpc_AI.thy
@@ -297,7 +297,7 @@ lemma transfer_caps_tcb_caps:
   apply (erule imp)
   apply (wp hoare_vcg_conj_lift hoare_vcg_const_imp_lift hoare_vcg_all_lift
             )
-    apply (rule_tac Q = "\<lambda>rv s.  ( \<forall>x\<in>set rv. real_cte_at x s )
+    apply (rule_tac Q'="\<lambda>rv s.  ( \<forall>x\<in>set rv. real_cte_at x s )
       \<and> cte_wp_at P (t, ref) s \<and> tcb_at t s"
        in hoare_strengthen_post)
      apply (wp get_rs_real_cte_at)
@@ -322,7 +322,7 @@ lemma transfer_caps_non_null_cte_wp_at:
    apply (wp hoare_vcg_ball_lift transfer_caps_loop_cte_wp_at hoare_weak_lift_imp
      | wpc | clarsimp simp:imp)+
    apply (rule hoare_strengthen_post
-            [where Q="\<lambda>rv s'. (cte_wp_at ((\<noteq>) cap.NullCap) ptr) s'
+            [where Q'="\<lambda>rv s'. (cte_wp_at ((\<noteq>) cap.NullCap) ptr) s'
                       \<and> (\<forall>x\<in>set rv. cte_wp_at ((=) cap.NullCap) x s')",
              rotated])
     apply (clarsimp)
@@ -440,7 +440,7 @@ lemma do_ipc_transfer_respects_device_region[Ipc_AI_cont_assms]:
          apply (subst ball_conj_distrib)
          apply (wp get_rs_cte_at2 thread_get_wp hoare_weak_lift_imp grs_distinct
                    hoare_vcg_ball_lift hoare_vcg_all_lift hoare_vcg_conj_lift | simp)+
-  apply (rule hoare_strengthen_post[where Q = "\<lambda>r s. cap_refs_respects_device_region s
+  apply (rule hoare_strengthen_post[where Q'="\<lambda>r s. cap_refs_respects_device_region s
           \<and> valid_objs s \<and> valid_mdb s \<and> obj_at (\<lambda>ko. \<exists>tcb. ko = TCB tcb) t s"])
    apply wp
    apply auto[1]

--- a/proof/invariant-abstract/X64/ArchSchedule_AI.thy
+++ b/proof/invariant-abstract/X64/ArchSchedule_AI.thy
@@ -92,7 +92,7 @@ lemma stt_invs [wp,Schedule_AI_asms]:
   apply (simp add: switch_to_thread_def)
   apply wp
      apply (simp add: trans_state_update[symmetric] del: trans_state_update)
-    apply (rule_tac Q="\<lambda>_. invs and tcb_at t'" in hoare_strengthen_post, wp)
+    apply (rule_tac Q'="\<lambda>_. invs and tcb_at t'" in hoare_strengthen_post, wp)
     apply (clarsimp simp: invs_def valid_state_def valid_idle_def
                           valid_irq_node_def valid_machine_state_def)
     apply (fastforce simp: cur_tcb_def obj_at_def

--- a/proof/invariant-abstract/X64/ArchTcb_AI.thy
+++ b/proof/invariant-abstract/X64/ArchTcb_AI.thy
@@ -241,12 +241,12 @@ lemma tc_invs[Tcb_AI_asms]:
                   strengthen imp_consequent[where Q="x = None" for x], simp cong: conj_cong)
         | rule wp_split_const_if wp_split_const_if_R
                    hoare_vcg_all_liftE_R
-                   hoare_vcg_E_elim hoare_vcg_const_imp_lift_R
-                   hoare_vcg_R_conj
+                   hoare_vcg_conj_elimE hoare_vcg_const_imp_liftE_R
+                   hoare_vcg_conj_liftE_R
         | (wp out_invs_trivial case_option_wpE cap_delete_deletes
              cap_delete_valid_cap cap_insert_valid_cap out_cte_at
              cap_insert_cte_at cap_delete_cte_at out_valid_cap
-             hoare_vcg_const_imp_lift_R hoare_vcg_all_liftE_R
+             hoare_vcg_const_imp_liftE_R hoare_vcg_all_liftE_R
              thread_set_tcb_ipc_buffer_cap_cleared_invs
              thread_set_invs_trivial[OF ball_tcb_cap_casesI]
              hoare_vcg_all_lift thread_set_valid_cap out_emptyable

--- a/proof/invariant-abstract/X64/ArchVSpaceEntries_AI.thy
+++ b/proof/invariant-abstract/X64/ArchVSpaceEntries_AI.thy
@@ -534,7 +534,7 @@ lemma init_arch_objects_valid_vspace:
   apply (simp add: init_arch_objects_def)
   apply (rule hoare_pre)
    apply (wp | wpc)+
-     apply (rule_tac Q="\<lambda>rv. valid_vspace_objs' and pspace_aligned and valid_arch_state"
+     apply (rule_tac Q'="\<lambda>rv. valid_vspace_objs' and pspace_aligned and valid_arch_state"
                   in hoare_post_imp, simp)
      apply (rule mapM_x_wp')
      apply (rule hoare_pre, wp copy_global_mappings_valid_vspace_objs')

--- a/proof/invariant-abstract/X64/ArchVSpace_AI.thy
+++ b/proof/invariant-abstract/X64/ArchVSpace_AI.thy
@@ -3051,7 +3051,7 @@ lemma perform_page_directory_invocation_invs[wp]:
   apply (rule hoare_pre)
    apply (wpc | clarsimp simp: cte_wp_at_caps_of_state | wp arch_update_cap_invs_unmap_page_directory get_cap_wp)+
     apply (rule_tac P = "is_pd_cap (ArchObjectCap (PageDirectoryCap p (Some (x1, x2a))))" in hoare_gen_asm)
-    apply (rule_tac Q = "\<lambda>r. cte_wp_at ((=) (ArchObjectCap (PageDirectoryCap p (Some (x1, x2a))))) (a,b)
+    apply (rule_tac Q'="\<lambda>r. cte_wp_at ((=) (ArchObjectCap (PageDirectoryCap p (Some (x1, x2a))))) (a,b)
                              and invs and is_final_cap' (ArchObjectCap (PageDirectoryCap p (Some (x1, x2a))))
                              and (\<lambda>s. (the (vs_cap_ref (ArchObjectCap (PageDirectoryCap p (Some (x1, x2a))))), p) \<notin> vs_lookup_pages s)
                              and obj_at (empty_table {}) (the (aobj_ref (update_map_data
@@ -3133,7 +3133,7 @@ lemma perform_page_table_invocation_invs[wp]:
   apply (rule hoare_pre)
    apply (wpc | clarsimp simp: cte_wp_at_caps_of_state | wp arch_update_cap_invs_unmap_page_table get_cap_wp)+
     apply (rule_tac P = "is_pt_cap (ArchObjectCap (PageTableCap p (Some (x1, x2a))))" in hoare_gen_asm)
-    apply (rule_tac Q = "\<lambda>r. cte_wp_at ((=) (ArchObjectCap (PageTableCap p (Some (x1, x2a))))) (a,b)
+    apply (rule_tac Q'="\<lambda>r. cte_wp_at ((=) (ArchObjectCap (PageTableCap p (Some (x1, x2a))))) (a,b)
                              and invs and is_final_cap' (ArchObjectCap (PageTableCap p (Some (x1, x2a))))
                              and (\<lambda>s. (the (vs_cap_ref (ArchObjectCap (PageTableCap p (Some (x1, x2a))))), p) \<notin> vs_lookup_pages s)
                              and obj_at (empty_table {}) (the (aobj_ref (update_map_data
@@ -3245,7 +3245,7 @@ lemma perform_pdpt_invocation_invs[wp]:
   apply (rule hoare_pre)
    apply (wpc | clarsimp simp: cte_wp_at_caps_of_state | wp arch_update_cap_invs_unmap_pd_pointer_table get_cap_wp)+
     apply (rule_tac P = "is_pdpt_cap (ArchObjectCap (PDPointerTableCap p (Some (x1, x2a))))" in hoare_gen_asm)
-    apply (rule_tac Q = "\<lambda>r. cte_wp_at ((=) (ArchObjectCap (PDPointerTableCap p (Some (x1, x2a))))) (a,b)
+    apply (rule_tac Q'="\<lambda>r. cte_wp_at ((=) (ArchObjectCap (PDPointerTableCap p (Some (x1, x2a))))) (a,b)
                              and invs and is_final_cap' (ArchObjectCap (PDPointerTableCap p (Some (x1, x2a))))
                              and (\<lambda>s. (the (vs_cap_ref (ArchObjectCap (PDPointerTableCap p (Some (x1, x2a))))), p) \<notin> vs_lookup_pages s)
                              and obj_at (empty_table {}) (the (aobj_ref (update_map_data
@@ -3548,7 +3548,7 @@ lemma perform_page_invs [wp]:
    apply (rule hoare_pre)
     apply (wp dmo_invs arch_update_cap_invs_unmap_page get_cap_wp
          | wpc | simp add: perform_page_invocation_unmap_def)+
-        apply (rule_tac Q="\<lambda>_ s. invs s \<and>
+        apply (rule_tac Q'="\<lambda>_ s. invs s \<and>
                                  cte_wp_at (\<lambda>c. is_pg_cap c \<and>
                                    (\<forall>ref. vs_cap_ref c = Some ref \<longrightarrow>
                                           \<not> (ref \<unrhd> obj_ref_of c) s)) cslot_ptr s"

--- a/proof/refine/AARCH64/Arch_R.thy
+++ b/proof/refine/AARCH64/Arch_R.thy
@@ -1331,7 +1331,7 @@ lemma associateVCPUTCB_corres:
                 corres: getObject_vcpu_corres setObject_VCPU_corres vcpuSwitch_corres''
                 wp: hoare_drop_imps get_vcpu_wp getVCPU_wp
          | corres_cases_both simp: vcpu_relation_def)+
-       apply (rule_tac Q="\<lambda>_. invs and tcb_at t" in hoare_strengthen_post)
+       apply (rule_tac Q'="\<lambda>_. invs and tcb_at t" in hoare_strengthen_post)
         apply wp
        apply clarsimp
        apply (rule conjI)
@@ -1339,7 +1339,7 @@ lemma associateVCPUTCB_corres:
         apply (clarsimp simp: obj_at_def in_omonad)
        apply (fastforce simp: obj_at_def in_omonad)
       apply wpsimp+
-      apply (rule_tac Q="\<lambda>_. invs' and tcb_at' t and vcpu_at' v" in hoare_strengthen_post)
+      apply (rule_tac Q'="\<lambda>_. invs' and tcb_at' t and vcpu_at' v" in hoare_strengthen_post)
        apply wpsimp
       apply fastforce
      apply (wpsimp wp: arch_thread_get_wp archThreadGet_wp)+
@@ -1947,14 +1947,14 @@ lemma associateVCPUTCB_invs'[wp]:
   apply (clarsimp simp: associateVCPUTCB_def)
   apply (subst bind_assoc[symmetric], fold associateVCPUTCB_helper_def)
   apply wpsimp
-       apply (rule_tac Q="\<lambda>_ s. invs' s \<and> ko_wp_at' (is_vcpu' and hyp_live') vcpu s" in hoare_post_imp)
+       apply (rule_tac Q'="\<lambda>_ s. invs' s \<and> ko_wp_at' (is_vcpu' and hyp_live') vcpu s" in hoare_post_imp)
         apply simp
        apply (rule hoare_vcg_conj_lift)
         apply (wpsimp wp: assoc_invs'[folded associateVCPUTCB_helper_def])
        apply (clarsimp simp: associateVCPUTCB_helper_def)
        apply (wpsimp simp: vcpu_at_is_vcpu'[symmetric])+
      apply (wpsimp wp: getVCPU_wp)
-    apply (rule_tac Q="\<lambda>_. invs' and obj_at' (\<lambda>tcb. atcbVCPUPtr (tcbArch tcb) = None) tcb and
+    apply (rule_tac Q'="\<lambda>_. invs' and obj_at' (\<lambda>tcb. atcbVCPUPtr (tcbArch tcb) = None) tcb and
                            ex_nonz_cap_to' vcpu and ex_nonz_cap_to' tcb and vcpu_at' vcpu"
                     in hoare_strengthen_post)
      apply wpsimp

--- a/proof/refine/AARCH64/CNodeInv_R.thy
+++ b/proof/refine/AARCH64/CNodeInv_R.thy
@@ -208,7 +208,7 @@ lemma decodeCNodeInvocation_corres:
                       apply (rule corres_trivial)
                       subgoal by (auto simp add: whenE_def, auto simp add: returnOk_def)
                      apply (wp | wpc | simp(no_asm))+
-                 apply (wp hoare_vcg_const_imp_lift_R hoare_vcg_const_imp_lift
+                 apply (wp hoare_vcg_const_imp_liftE_R hoare_vcg_const_imp_lift
                            hoare_vcg_all_liftE_R hoare_vcg_all_lift lsfco_cte_at' hoare_drop_imps
                                 | clarsimp)+
          subgoal by (auto elim!: valid_cnode_capI)
@@ -6110,7 +6110,7 @@ lemma reduceZombie_invs'':
           apply (wp | simp)+
          apply (rule getCTE_wp)
         apply (wp | simp)+
-      apply (rule_tac Q="\<lambda>cte s. rv = capZombiePtr cap +
+      apply (rule_tac Q'="\<lambda>cte s. rv = capZombiePtr cap +
                                       of_nat (capZombieNumber cap) * 2^cteSizeBits - 2^cteSizeBits
                               \<and> cte_wp_at' (\<lambda>c. c = cte) slot s \<and> invs' s
                               \<and> no_cte_prop Q s \<and> sch_act_simple s"
@@ -6436,8 +6436,8 @@ lemmas cteDelete_typ_at'_lifts [wp] = typ_at_lifts [OF cteDelete_typ_at']
 
 lemma cteDelete_cte_at:
   "\<lbrace>\<top>\<rbrace> cteDelete slot bool \<lbrace>\<lambda>rv. cte_at' slot\<rbrace>"
-  apply (rule_tac Q="\<lambda>s. cte_at' slot s \<or> \<not> cte_at' slot s"
-               in hoare_pre(1))
+  apply (rule_tac P'="\<lambda>s. cte_at' slot s \<or> \<not> cte_at' slot s"
+               in hoare_weaken_pre)
    apply (rule hoare_strengthen_post)
     apply (rule hoare_vcg_disj_lift)
      apply (rule typ_at_lifts, rule cteDelete_typ_at')
@@ -6476,7 +6476,7 @@ lemma cteDelete_cte_wp_at_invs:
       apply (clarsimp simp: cte_wp_at_ctes_of)
      apply wp
     apply (simp add: imp_conjR conj_comms)
-    apply (rule_tac Q="\<lambda>rv s. invs' s \<and> sch_act_simple s \<and>
+    apply (rule_tac Q'="\<lambda>rv s. invs' s \<and> sch_act_simple s \<and>
                    (fst rv \<longrightarrow>
                        cte_wp_at' (\<lambda>cte. removeable' slot s (cteCap cte)) slot s) \<and>
                    (fst rv \<longrightarrow>
@@ -6486,9 +6486,9 @@ lemma cteDelete_cte_wp_at_invs:
                                          cteCap cte = NullCap \<or>
                                          (\<exists>zb n. cteCap cte = Zombie slot zb n))
                                   slot s)"
-                and E="\<lambda>rv. \<top>" in hoare_strengthen_postE)
+                and E'="\<lambda>rv. \<top>" in hoare_strengthen_postE)
       apply (wp finaliseSlot_invs finaliseSlot_removeable finaliseSlot_sch_act_simple
-                hoare_drop_imps(2)[OF finaliseSlot_irqs])
+                hoare_drop_impE_R[OF finaliseSlot_irqs])
        apply (rule hoare_strengthen_postE_R, rule finaliseSlot_abort_cases)
        apply (clarsimp simp: cte_wp_at_ctes_of dest!: isCapDs)
       apply simp
@@ -6509,7 +6509,7 @@ lemma cteDelete_cte_wp_at_invs:
                              p s"
                in hoare_strengthen_postE_R)
     apply (wp finaliseSlot_invs finaliseSlot_removeable finaliseSlot_sch_act_simple
-              hoare_drop_imps(2)[OF finaliseSlot_irqs])
+              hoare_drop_impE_R[OF finaliseSlot_irqs])
     apply (rule hoare_strengthen_postE_R [OF finaliseSlot_cte_wp_at[where p=p and P=P]])
       apply simp+
     apply (clarsimp simp: cte_wp_at_ctes_of)
@@ -6711,7 +6711,7 @@ proof (induct rule: finalise_induct3)
           apply ((wp | simp add: locateSlot_conv)+)[2]
         apply (rule drop_spec_validE)
         apply simp
-        apply (rule_tac Q="\<lambda>rv s. revoke_progress_ord m (option_map capToRPO \<circ> cteCaps_of s)
+        apply (rule_tac Q'="\<lambda>rv s. revoke_progress_ord m (option_map capToRPO \<circ> cteCaps_of s)
                                      \<and> cte_wp_at' (\<lambda>cte. cteCap cte = fst rvb) sl s"
                          in hoare_post_imp)
          apply (clarsimp simp: o_def cte_wp_at_ctes_of capToRPO_def
@@ -7282,7 +7282,7 @@ next
                 apply (rule updateCap_corres)
                  apply simp
                 apply (simp add: is_cap_simps)
-               apply (rule_tac R="\<lambda>rv. cte_at' (cte_map ?target)" in hoare_post_add)
+               apply (rule_tac Q'="\<lambda>rv. cte_at' (cte_map ?target)" in hoare_post_add)
                apply (wp, (wp getCTE_wp)+)
               apply (clarsimp simp: cte_wp_at_ctes_of)
              apply (rule no_fail_pre, wp, simp)
@@ -7444,7 +7444,7 @@ lemma cteRevoke_typ_at':
 
 lemma cteRevoke_invs':
   "\<lbrace>invs' and sch_act_simple\<rbrace> cteRevoke ptr \<lbrace>\<lambda>rv. invs'\<rbrace>"
-  apply (rule_tac Q="\<lambda>rv. invs' and sch_act_simple" in hoare_strengthen_post)
+  apply (rule_tac Q'="\<lambda>rv. invs' and sch_act_simple" in hoare_strengthen_post)
   apply (wp cteRevoke_preservation cteDelete_invs' cteDelete_sch_act_simple)+
     apply simp_all
   done
@@ -9018,7 +9018,7 @@ proof (induct rule: finalise_spec_induct)
             apply (unfold Let_def split_def fst_conv snd_conv
                           case_Zombie_assert_fold haskell_fail_def)
             apply (wp getCTE_wp' preemptionPoint_invR| simp add: o_def irq_state_independent_HI)+
-            apply (rule hoare_post_imp [where Q="\<lambda>_. valid_irq_states'"])
+            apply (rule hoare_post_imp[where Q'="\<lambda>_. valid_irq_states'"])
              apply simp
             apply wp[1]
            apply (rule spec_strengthen_postE)
@@ -9061,7 +9061,7 @@ lemma cteDelete_irq_states':
   apply (simp add: cteDelete_def split_def)
   apply (wp whenE_wp)
    apply (rule hoare_strengthen_postE)
-     apply (rule hoare_valid_validE)
+     apply (rule valid_validE)
      apply (rule finaliseSlot_irq_states')
     apply simp
    apply simp

--- a/proof/refine/AARCH64/CNodeInv_R.thy
+++ b/proof/refine/AARCH64/CNodeInv_R.thy
@@ -6523,8 +6523,8 @@ lemma cteDelete_sch_act_simple:
      cteDelete slot exposed \<lbrace>\<lambda>rv. sch_act_simple\<rbrace>"
   apply (simp add: cteDelete_def whenE_def split_def)
   apply (wp hoare_drop_imps | simp)+
-  apply (rule_tac hoare_strengthen_postE [where Q="\<lambda>rv. sch_act_simple"
-                                       and E="\<lambda>rv. sch_act_simple"])
+  apply (rule_tac hoare_strengthen_postE [where Q'="\<lambda>rv. sch_act_simple"
+                                       and E'="\<lambda>rv. sch_act_simple"])
     apply (rule valid_validE)
     apply (wp finaliseSlot_sch_act_simple)
     apply simp+

--- a/proof/refine/AARCH64/CSpace_R.thy
+++ b/proof/refine/AARCH64/CSpace_R.thy
@@ -2147,7 +2147,7 @@ lemma cteInsert_mdb' [wp]:
   cteInsert cap src dest
   \<lbrace>\<lambda>_. valid_mdb'\<rbrace>"
   apply (simp add:valid_mdb'_def valid_mdb_ctes_def)
-  apply (rule_tac Q = "\<lambda>r s. valid_dlist (ctes_of s) \<and> irq_control (ctes_of s) \<and>
+  apply (rule_tac Q'="\<lambda>r s. valid_dlist (ctes_of s) \<and> irq_control (ctes_of s) \<and>
                no_0 (ctes_of s) \<and> mdb_chain_0 (ctes_of s) \<and>
                mdb_chunked (ctes_of s) \<and> untyped_mdb' (ctes_of s) \<and> untyped_inc' (ctes_of s) \<and>
                Q s" for Q
@@ -3963,12 +3963,12 @@ lemma setupReplyMaster_corres:
        apply (fastforce dest: pspace_relation_no_reply_caps
                              state_relation_pspace_relation)
       apply (clarsimp simp: cte_map_def tcb_cnode_index_def cte_wp_at_ctes_of)
-     apply (rule_tac Q="\<lambda>rv. einvs and tcb_at t and
+     apply (rule_tac Q'="\<lambda>rv. einvs and tcb_at t and
                              cte_wp_at ((=) rv) (t, tcb_cnode_index 2)"
                   in hoare_strengthen_post)
       apply (wp hoare_drop_imps get_cap_wp)
      apply (clarsimp simp: invs_def valid_state_def elim!: cte_wp_at_weakenE)
-    apply (rule_tac Q="\<lambda>rv. valid_pspace' and valid_mdb' and
+    apply (rule_tac Q'="\<lambda>rv. valid_pspace' and valid_mdb' and
                             cte_wp_at' ((=) rv) (cte_map (t, tcb_cnode_index 2))"
                  in hoare_strengthen_post)
      apply (wp hoare_drop_imps getCTE_wp')

--- a/proof/refine/AARCH64/Detype_R.thy
+++ b/proof/refine/AARCH64/Detype_R.thy
@@ -65,7 +65,7 @@ lemma descendants_range_in_lift':
   apply (simp only: Ball_def[unfolded imp_conv_disj])
   apply (rule hoare_pre)
    apply (wp hoare_vcg_all_lift hoare_vcg_disj_lift st cap_range)
-   apply (rule_tac Q = "\<lambda>r s. cte_wp_at' (\<lambda>c. capRange (cteCap c) \<inter> S = {}) x s"
+   apply (rule_tac Q'="\<lambda>r s. cte_wp_at' (\<lambda>c. capRange (cteCap c) \<inter> S = {}) x s"
       in hoare_strengthen_post)
     apply (wp cap_range)
    apply (clarsimp simp:cte_wp_at_ctes_of null_filter'_def)
@@ -1830,7 +1830,7 @@ lemma deleteObjects_invs':
 proof -
   show ?thesis
   apply (rule hoare_pre)
-   apply (rule_tac G="is_aligned ptr bits \<and> 3 \<le> bits \<and> bits \<le> word_bits" in hoare_grab_asm)
+   apply (rule_tac P'="is_aligned ptr bits \<and> 3 \<le> bits \<and> bits \<le> word_bits" in hoare_grab_asm)
    apply (clarsimp simp add: deleteObjects_def2)
    apply (simp add: freeMemory_def bind_assoc doMachineOp_bind)
    apply (simp add: bind_assoc[where f="\<lambda>_. modify f" for f, symmetric])
@@ -3798,7 +3798,7 @@ lemma createNewCaps_pspace_no_overlap':
          apply simp+
     apply (simp add:range_cover_def)
    apply (simp add:range_cover.sz(1)[where 'a=machine_word_len, folded word_bits_def])
-  apply (rule_tac Q = "\<lambda>r. pspace_no_overlap' (ptr + (1 + of_nat n << Types_H.getObjectSize ty us))
+  apply (rule_tac Q'="\<lambda>r. pspace_no_overlap' (ptr + (1 + of_nat n << Types_H.getObjectSize ty us))
                                               (Types_H.getObjectSize ty us) and
                            pspace_aligned' and pspace_distinct'" in hoare_strengthen_post)
    apply (case_tac ty)

--- a/proof/refine/AARCH64/Finalise_R.thy
+++ b/proof/refine/AARCH64/Finalise_R.thy
@@ -3712,7 +3712,7 @@ lemma no_idle_thread_cap:
 
 lemmas getCTE_no_0_obj'_helper
   = getCTE_inv
-    hoare_strengthen_post[where Q'="\<lambda>_. no_0_obj'" and P=no_0_obj' and a="getCTE slot" for slot]
+    hoare_strengthen_post[where Q'="\<lambda>_. no_0_obj'" and P=no_0_obj' and f="getCTE slot" for slot]
 
 context begin interpretation Arch . (*FIXME: arch_split*)
 

--- a/proof/refine/AARCH64/Finalise_R.thy
+++ b/proof/refine/AARCH64/Finalise_R.thy
@@ -1823,7 +1823,7 @@ lemma isFinalCapability_inv:
   apply (simp add: isFinalCapability_def Let_def
               split del: if_split cong: if_cong)
   apply (rule hoare_pre, wp)
-   apply (rule hoare_post_imp [where Q="\<lambda>s. P"], simp)
+   apply (rule hoare_post_imp[where Q'="\<lambda>s. P"], simp)
    apply wp
   apply simp
   done
@@ -3087,7 +3087,7 @@ lemma cancelIPC_bound_tcb_at'[wp]:
   apply (simp add: getThreadReplySlot_def locateSlot_conv liftM_def)
   apply (rule hoare_pre)
    apply (wp capDeleteOne_bound_tcb_at' getCTE_ctes_of)
-   apply (rule_tac Q="\<lambda>_. bound_tcb_at' P tptr" in hoare_post_imp)
+   apply (rule_tac Q'="\<lambda>_. bound_tcb_at' P tptr" in hoare_post_imp)
    apply (clarsimp simp: capHasProperty_def cte_wp_at_ctes_of)
    apply (wp threadSet_pred_tcb_no_state | simp)+
   done
@@ -3712,7 +3712,7 @@ lemma no_idle_thread_cap:
 
 lemmas getCTE_no_0_obj'_helper
   = getCTE_inv
-    hoare_strengthen_post[where Q="\<lambda>_. no_0_obj'" and P=no_0_obj' and a="getCTE slot" for slot]
+    hoare_strengthen_post[where Q'="\<lambda>_. no_0_obj'" and P=no_0_obj' and a="getCTE slot" for slot]
 
 context begin interpretation Arch . (*FIXME: arch_split*)
 

--- a/proof/refine/AARCH64/Interrupt_R.thy
+++ b/proof/refine/AARCH64/Interrupt_R.thy
@@ -808,7 +808,7 @@ proof -
                      apply (wp gts_wp)
                     apply (wp gts_wp')
                    apply (rule_tac
-                            Q="\<lambda>rv. tcb_at rv and einvs
+                            Q'="\<lambda>rv. tcb_at rv and einvs
                                     and (\<lambda>_. valid_fault (ExceptionTypes_A.fault.ArchFault rva))"
                             in hoare_post_imp)
                     apply (clarsimp cong: imp_cong conj_cong simp: not_pred_tcb runnable_eq pred_conj_def)
@@ -881,7 +881,7 @@ lemma vppiEvent_corres:
                 is runnable directly afterwards, which is obvious and should not propagate further;
                 clean up the postconditions of the thread_get and threadGet *)
            apply (rule_tac
-                    Q="\<lambda>rv. tcb_at rv and einvs
+                    Q'="\<lambda>rv. tcb_at rv and einvs
                             and (\<lambda>_. valid_fault (ExceptionTypes_A.fault.ArchFault
                                                     (AARCH64_A.VPPIEvent irq)))"
                     in hoare_post_imp)

--- a/proof/refine/AARCH64/Interrupt_R.thy
+++ b/proof/refine/AARCH64/Interrupt_R.thy
@@ -363,7 +363,7 @@ lemma invokeIRQHandler_corres:
        apply simp
        apply (rule corres_split_nor[OF cap_delete_one_corres])
          apply (rule cteInsert_corres, simp+)
-        apply (rule_tac Q="\<lambda>rv s. einvs s \<and> cte_wp_at (\<lambda>c. c = cap.NullCap) irq_slot s
+        apply (rule_tac Q'="\<lambda>rv s. einvs s \<and> cte_wp_at (\<lambda>c. c = cap.NullCap) irq_slot s
                                   \<and> (a, b) \<noteq> irq_slot
                                   \<and> cte_wp_at (is_derived (cdt s) (a, b) cap) (a, b) s"
                       in hoare_post_imp)
@@ -816,7 +816,7 @@ proof -
                     apply (fastforce simp: pred_tcb_at_def obj_at_def)
                    apply wp
                   apply clarsimp
-                  apply (rule_tac Q="\<lambda>rv x. tcb_at' rv x
+                  apply (rule_tac Q'="\<lambda>rv x. tcb_at' rv x
                                             \<and> invs' x
                                             \<and> sch_act_not rv x"
                            in hoare_post_imp)
@@ -889,7 +889,7 @@ lemma vppiEvent_corres:
             apply (strengthen st_tcb_ex_cap'[where P=active], fastforce)
            apply wp
           apply (clarsimp cong: imp_cong conj_cong simp: pred_conj_def)
-          apply (rule_tac Q="\<lambda>rv x. tcb_at' rv x
+          apply (rule_tac Q'="\<lambda>rv x. tcb_at' rv x
                                     \<and> invs' x
                                     \<and> sch_act_not rv x" in hoare_post_imp)
            apply (rename_tac rv s)
@@ -1025,7 +1025,7 @@ lemma timerTick_invs'[wp]:
   apply (wpsimp wp: threadSet_invs_trivial threadSet_pred_tcb_no_state
                     rescheduleRequired_all_invs_but_ct_not_inQ
               simp: tcb_cte_cases_def)
-      apply (rule_tac Q="\<lambda>rv. invs'" in hoare_post_imp)
+      apply (rule_tac Q'="\<lambda>rv. invs'" in hoare_post_imp)
        apply (clarsimp simp: invs'_def valid_state'_def)
       apply (simp add: decDomainTime_def)
       apply wp
@@ -1036,7 +1036,7 @@ lemma timerTick_invs'[wp]:
                            hoare_vcg_imp_lift threadSet_ct_idle_or_in_cur_domain')+
             apply (rule hoare_strengthen_post[OF tcbSchedAppend_all_invs_but_ct_not_inQ'])
             apply (wpsimp simp: invs'_def valid_state'_def valid_pspace'_def sch_act_wf_weak)+
-           apply (rule_tac Q="\<lambda>_. invs'" in hoare_strengthen_post)
+           apply (rule_tac Q'="\<lambda>_. invs'" in hoare_strengthen_post)
             apply (wpsimp wp: threadSet_pred_tcb_no_state threadSet_tcbDomain_triv
                               threadSet_valid_objs' threadSet_timeslice_invs)+
            apply (clarsimp simp: invs'_def valid_state'_def valid_pspace'_def)
@@ -1083,7 +1083,7 @@ lemma vgicMaintenance_invs'[wp]:
             apply (strengthen st_tcb_ex_cap''[where P=active'])
             apply (strengthen invs_iflive')
             apply (clarsimp cong: imp_cong conj_cong simp: pred_conj_def)
-            apply (rule_tac Q="\<lambda>_ s. tcb_at' (ksCurThread s) s
+            apply (rule_tac Q'="\<lambda>_ s. tcb_at' (ksCurThread s) s
                                       \<and> invs' s
                                       \<and> sch_act_not (ksCurThread s) s"
                     in hoare_post_imp)
@@ -1117,7 +1117,7 @@ lemma vppiEvent_invs'[wp]:
             apply (strengthen st_tcb_ex_cap''[where P=active'])
             apply (strengthen invs_iflive')
             apply (clarsimp cong: imp_cong conj_cong simp: pred_conj_def)
-            apply (rule_tac Q="\<lambda>_ s. tcb_at' (ksCurThread s) s
+            apply (rule_tac Q'="\<lambda>_ s. tcb_at' (ksCurThread s) s
                                       \<and> invs' s
                                       \<and> sch_act_not (ksCurThread s) s"
                     in hoare_post_imp)
@@ -1139,7 +1139,7 @@ lemma hint_invs[wp]:
   apply (simp add: handleInterrupt_def getSlotCap_def cong: irqstate.case_cong)
   apply (rule conjI; rule impI)
    apply (wp dmo_maskInterrupt_True getCTE_wp' | wpc | simp add: doMachineOp_bind maskIrqSignal_def)+
-    apply (rule_tac Q="\<lambda>rv. invs'" in hoare_post_imp)
+    apply (rule_tac Q'="\<lambda>rv. invs'" in hoare_post_imp)
      apply (clarsimp simp: cte_wp_at_ctes_of ex_nonz_cap_to'_def)
      apply fastforce
     apply (wpsimp wp: threadSet_invs_trivial getIRQState_wp

--- a/proof/refine/AARCH64/IpcCancel_R.thy
+++ b/proof/refine/AARCH64/IpcCancel_R.thy
@@ -900,7 +900,7 @@ lemma (in delete_one_conc_pre) cancelIPC_sch_act_simple[wp]:
   apply (wp hoare_drop_imps delete_one_sch_act_simple
        | simp add: getThreadReplySlot_def | wpcw
        | rule sch_act_simple_lift
-       | (rule_tac Q="\<lambda>rv. sch_act_simple" in hoare_post_imp, simp))+
+       | (rule_tac Q'="\<lambda>rv. sch_act_simple" in hoare_post_imp, simp))+
   done
 
 lemma cancelSignal_st_tcb_at:
@@ -910,7 +910,7 @@ lemma cancelSignal_st_tcb_at:
    \<lbrace>\<lambda>rv. st_tcb_at' P t\<rbrace>"
   apply (simp add: cancelSignal_def Let_def list_case_If)
   apply (wp sts_st_tcb_at'_cases hoare_vcg_const_imp_lift
-            hoare_drop_imp[where R="%rv s. P' rv" for P'])
+            hoare_drop_imp[where Q'="%rv s. P' rv" for P'])
    apply clarsimp+
   done
 
@@ -999,7 +999,7 @@ lemma (in delete_one_conc_pre) cancelIPC_tcb_at_runnable':
     apply (case_tac rv; simp)
    apply (wp sts_pred_tcb_neq'  | simp | wpc)+
            apply (clarsimp)
-           apply (rule_tac Q="\<lambda>rv. ?PRE" in hoare_post_imp, fastforce)
+           apply (rule_tac Q'="\<lambda>rv. ?PRE" in hoare_post_imp, fastforce)
            apply (wp cteDeleteOne_tcb_at_runnable'
                     threadSet_pred_tcb_no_state
                     cancelSignal_tcb_at_runnable'
@@ -1098,7 +1098,7 @@ lemma sts_weak_sch_act_wf[wp]:
   including classic_wp_pre
   apply (simp add: setThreadState_def)
   apply (wp rescheduleRequired_weak_sch_act_wf)
-  apply (rule_tac Q="\<lambda>_ s. weak_sch_act_wf (ksSchedulerAction s) s" in hoare_post_imp, simp)
+  apply (rule_tac Q'="\<lambda>_ s. weak_sch_act_wf (ksSchedulerAction s) s" in hoare_post_imp, simp)
   apply (simp add: weak_sch_act_wf_def)
   apply (wp hoare_vcg_all_lift)
    apply (wps threadSet_nosch)
@@ -1226,11 +1226,11 @@ lemma (in delete_one) suspend_corres:
            apply wp
           apply (wpsimp wp: sts_valid_objs')
           apply (wpsimp simp: update_restart_pc_def updateRestartPC_def valid_tcb_state'_def)+
-       apply (rule hoare_post_imp[where Q = "\<lambda>rv s. einvs s \<and> tcb_at t s"])
+       apply (rule hoare_post_imp[where Q'="\<lambda>rv s. einvs s \<and> tcb_at t s"])
         apply (simp add: invs_implies invs_strgs valid_queues_in_correct_ready_q
                          valid_queues_ready_qs_distinct valid_sched_def)
        apply wp
-      apply (rule hoare_post_imp[where Q = "\<lambda>_ s. invs' s \<and> tcb_at' t s"])
+      apply (rule hoare_post_imp[where Q'="\<lambda>_ s. invs' s \<and> tcb_at' t s"])
        apply (fastforce simp: invs'_def valid_tcb_state'_def)
       apply (wpsimp simp: update_restart_pc_def updateRestartPC_def)+
    apply fastforce+
@@ -1425,7 +1425,7 @@ lemma (in delete_one_conc) suspend_invs'[wp]:
   apply (simp add: suspend_def)
   apply (wpsimp wp: sts_invs_minor' gts_wp' simp: updateRestartPC_def
          | strengthen no_refs_simple_strg')+
-   apply (rule_tac Q="\<lambda>_. invs' and sch_act_simple and st_tcb_at' simple' t
+   apply (rule_tac Q'="\<lambda>_. invs' and sch_act_simple and st_tcb_at' simple' t
                           and (\<lambda>s. t \<noteq> ksIdleThread s)"
                 in hoare_post_imp)
     apply clarsimp
@@ -1453,7 +1453,7 @@ lemma (in delete_one_conc_pre) suspend_sch_act_simple[wp]:
 lemma (in delete_one_conc) suspend_objs':
   "\<lbrace>invs' and sch_act_simple and tcb_at' t and (\<lambda>s. t \<noteq> ksIdleThread s)\<rbrace>
    suspend t \<lbrace>\<lambda>rv. valid_objs'\<rbrace>"
-  apply (rule_tac Q="\<lambda>_. invs'" in hoare_strengthen_post)
+  apply (rule_tac Q'="\<lambda>_. invs'" in hoare_strengthen_post)
    apply (wp suspend_invs')
   apply fastforce
   done
@@ -1567,7 +1567,7 @@ proof -
         apply (rule ep_cancel_corres_helper)
        apply (rule mapM_x_wp')
        apply (wp weak_sch_act_wf_lift_linear set_thread_state_runnable_weak_valid_sched_action | simp)+
-      apply (rule_tac R="\<lambda>_ s. \<forall>x\<in>set list. tcb_at' x s \<and> valid_objs' s \<and> pspace_aligned' s \<and> pspace_distinct' s"
+      apply (rule_tac Q'="\<lambda>_ s. \<forall>x\<in>set list. tcb_at' x s \<and> valid_objs' s \<and> pspace_aligned' s \<and> pspace_distinct' s"
                    in hoare_post_add)
       apply (rule mapM_x_wp')
       apply ((wpsimp wp: hoare_vcg_const_Ball_lift mapM_x_wp' sts_st_tcb' sts_valid_objs'
@@ -1627,7 +1627,7 @@ lemma cancelAllSignals_corres:
                  set_thread_state_runnable_weak_valid_sched_action
             | simp)+
       apply (rename_tac list)
-      apply (rule_tac R="\<lambda>_ s. (\<forall>x\<in>set list. tcb_at' x s) \<and> valid_objs' s
+      apply (rule_tac Q'="\<lambda>_ s. (\<forall>x\<in>set list. tcb_at' x s) \<and> valid_objs' s
                                \<and> sym_heap_sched_pointers s \<and> valid_sched_pointers s \<and> valid_objs' s
                                \<and> pspace_aligned' s \<and> pspace_distinct' s"
                    in hoare_post_add)
@@ -1675,7 +1675,7 @@ proof -
   show ?thesis
   apply (simp add: setThreadState_def)
   apply (wpsimp wp: hoare_vcg_imp_lift [OF nrct])
-   apply (rule_tac Q="\<lambda>_. ?PRE" in hoare_post_imp)
+   apply (rule_tac Q'="\<lambda>_. ?PRE" in hoare_post_imp)
     apply (clarsimp)
    apply (rule hoare_convert_imp [OF threadSet_nosch threadSet_ct])
   apply assumption
@@ -1927,7 +1927,7 @@ lemma cancelAllIPC_valid_objs'[wp]:
   apply (rule bind_wp [OF _ get_ep_sp'])
   apply (rule hoare_pre)
    apply (wp set_ep_valid_objs' setSchedulerAction_valid_objs')
-    apply (rule_tac Q="\<lambda>_ s. valid_objs' s \<and> pspace_aligned' s \<and> pspace_distinct' s
+    apply (rule_tac Q'="\<lambda>_ s. valid_objs' s \<and> pspace_aligned' s \<and> pspace_distinct' s
                              \<and> (\<forall>x\<in>set (epQueue ep). tcb_at' x s)"
                     in hoare_post_imp)
      apply simp
@@ -1953,7 +1953,7 @@ lemma cancelAllSignals_valid_objs'[wp]:
     apply (wp, simp)
    apply (wp, simp)
   apply (rename_tac list)
-  apply (rule_tac Q="\<lambda>rv s. valid_objs' s \<and> (\<forall>x\<in>set list. tcb_at' x s)"
+  apply (rule_tac Q'="\<lambda>rv s. valid_objs' s \<and> (\<forall>x\<in>set list. tcb_at' x s)"
                   in hoare_post_imp)
    apply (simp add: valid_ntfn'_def)
   apply (simp add: Ball_def)
@@ -2257,7 +2257,7 @@ lemma cancelBadgedSends_corres:
     apply (rule corres_split_nor[OF setEndpoint_corres])
        apply (simp add: ep_relation_def)
       apply (rule corres_split_eqr[OF _ _ _ hoare_post_add
-                                             [where R="\<lambda>_. valid_objs' and pspace_aligned'
+                                             [where Q'="\<lambda>_. valid_objs' and pspace_aligned'
                                                            and pspace_distinct'"]])
          apply (rule_tac S="(=)"
                      and Q="\<lambda>xs s. (\<forall>x \<in> set xs. (epptr, TCBBlockedSend) \<in> state_refs_of s x) \<and>

--- a/proof/refine/AARCH64/Ipc_R.thy
+++ b/proof/refine/AARCH64/Ipc_R.thy
@@ -493,7 +493,7 @@ next
         apply clarsimp
         apply assumption
        apply (subst imp_conjR)
-       apply (rule hoare_vcg_conj_liftE_R)
+       apply (rule hoare_vcg_conj_liftE_R')
         apply (rule derive_cap_is_derived)
        apply (wp derive_cap_is_derived_foo)+
       apply (simp split del: if_split)
@@ -505,7 +505,7 @@ next
        apply clarsimp
        apply assumption
       apply (subst imp_conjR)
-      apply (rule hoare_vcg_conj_liftE_R)
+      apply (rule hoare_vcg_conj_liftE_R')
        apply (rule hoare_strengthen_postE_R[OF deriveCap_derived])
        apply (clarsimp simp:cte_wp_at_ctes_of)
       apply (wp deriveCap_derived_foo)
@@ -617,7 +617,7 @@ lemma cteInsert_assume_Null:
    apply (rule bind_wp[OF _ getCTE_sp])+
    apply (rule hoare_name_pre_state)
    apply (clarsimp simp: cte_wp_at_ctes_of)
-  apply (erule hoare_pre(1))
+  apply (erule hoare_weaken_pre)
   apply simp
   done
 
@@ -1779,7 +1779,7 @@ declare asUser_global_refs' [wp]
 lemma lec_valid_cap' [wp]:
   "\<lbrace>valid_objs'\<rbrace> lookupExtraCaps thread xa mi \<lbrace>\<lambda>rv s. (\<forall>x\<in>set rv. s \<turnstile>' fst x)\<rbrace>, -"
   apply (rule hoare_pre, rule hoare_strengthen_postE_R)
-    apply (rule hoare_vcg_conj_lift_R[where R=valid_objs' and S="\<lambda>_. valid_objs'"])
+    apply (rule hoare_vcg_conj_liftE_R[where R=valid_objs' and S="\<lambda>_. valid_objs'"])
      apply (rule lookupExtraCaps_srcs)
     apply wp
    apply (clarsimp simp: cte_wp_at_ctes_of)
@@ -2160,7 +2160,7 @@ lemma doReplyTransfer_corres:
           apply (fastforce)
          apply (clarsimp simp:is_cap_simps)
         apply (wp weak_valid_sched_action_lift)+
-       apply (rule_tac Q="\<lambda>_ s. valid_objs' s \<and> cur_tcb' s \<and> tcb_at' receiver s
+       apply (rule_tac Q'="\<lambda>_ s. valid_objs' s \<and> cur_tcb' s \<and> tcb_at' receiver s
                                 \<and> sch_act_wf (ksSchedulerAction s) s
                                 \<and> sym_heap_sched_pointers s \<and> valid_sched_pointers s
                                 \<and> pspace_aligned' s \<and> pspace_distinct' s"
@@ -2217,7 +2217,7 @@ lemma doReplyTransfer_corres:
                              threadSet_tcbDomain_triv threadSet_valid_objs'
                              threadSet_sched_pointers threadSet_valid_sched_pointers
                         | simp add: valid_tcb_state'_def)+
-     apply (rule_tac Q="\<lambda>_. valid_sched and cur_tcb and tcb_at sender and tcb_at receiver and
+     apply (rule_tac Q'="\<lambda>_. valid_sched and cur_tcb and tcb_at sender and tcb_at receiver and
                             valid_objs and pspace_aligned and pspace_distinct"
                      in hoare_strengthen_post [rotated], clarsimp)
      apply (wp)
@@ -2225,7 +2225,7 @@ lemma doReplyTransfer_corres:
       apply (assumption)
      apply (rule conjI, clarsimp)
      apply (clarsimp simp add: invs_def valid_state_def valid_pspace_def)
-    apply (rule_tac Q="\<lambda>_. tcb_at' sender and tcb_at' receiver and invs'"
+    apply (rule_tac Q'="\<lambda>_. tcb_at' sender and tcb_at' receiver and invs'"
                     in hoare_strengthen_post [rotated])
      apply (solves\<open>auto simp: invs'_def valid_state'_def\<close>)
     apply wp
@@ -2303,14 +2303,14 @@ lemma setupCallerCap_corres:
                               tcb_cnode_index_def cte_level_bits_def)
             apply (simp add: cte_map_def tcbCallerSlot_def
                              tcb_cnode_index_def cte_level_bits_def)
-           apply (rule_tac R="\<lambda>rv. cte_at' (receiver + 2 ^ cte_level_bits * tcbCallerSlot)"
+           apply (rule_tac Q'="\<lambda>rv. cte_at' (receiver + 2 ^ cte_level_bits * tcbCallerSlot)"
                     in hoare_post_add)
 
            apply (wp, (wp getSlotCap_wp)+)
           apply blast
          apply (rule no_fail_pre, wp)
          apply (clarsimp simp: cte_wp_at'_def cte_at'_def)
-        apply (rule_tac R="\<lambda>rv. cte_at' (sender + 2 ^ cte_level_bits * tcbReplySlot)"
+        apply (rule_tac Q'="\<lambda>rv. cte_at' (sender + 2 ^ cte_level_bits * tcbReplySlot)"
                      in hoare_post_add)
         apply (wp, (wp getCTE_wp')+)
        apply blast
@@ -2645,7 +2645,7 @@ lemma sendSignal_corres:
                                valid_queues_in_correct_ready_q valid_queues_ready_qs_distinct
                                valid_sched_valid_queues
                   | simp add: valid_tcb_state_def)+
-         apply (rule_tac Q="\<lambda>rv. invs' and tcb_at' a" in hoare_strengthen_post)
+         apply (rule_tac Q'="\<lambda>rv. invs' and tcb_at' a" in hoare_strengthen_post)
           apply wp
          apply (fastforce simp: invs'_def valid_state'_def sch_act_wf_weak valid_tcb_state'_def)
         apply (rule setNotification_corres)
@@ -2673,7 +2673,7 @@ lemma sendSignal_corres:
           apply (rule corres_split[OF asUser_setRegister_corres])
             apply (rule possibleSwitchTo_corres)
            apply ((wp | simp)+)[1]
-          apply (rule_tac Q="\<lambda>_. (\<lambda>s. sch_act_wf (ksSchedulerAction s) s) and
+          apply (rule_tac Q'="\<lambda>_. (\<lambda>s. sch_act_wf (ksSchedulerAction s) s) and
                                  cur_tcb' and
                                  st_tcb_at' runnable' (hd list) and valid_objs' and
                                  sym_heap_sched_pointers and valid_sched_pointers and
@@ -2872,7 +2872,7 @@ lemma cancelIPC_nonz_cap_to'[wp]:
        | wpc
        | simp
        | clarsimp elim!: cte_wp_at_weakenE'
-       | rule hoare_post_imp[where Q="\<lambda>rv. ex_nonz_cap_to' p"])+
+       | rule hoare_post_imp[where Q'="\<lambda>rv. ex_nonz_cap_to' p"])+
   done
 
 
@@ -2952,7 +2952,7 @@ proof -
           apply (wpc)
            apply (wp | simp)+
        apply (wpc, wp+)
-     apply (rule_tac Q="\<lambda>_. ?PRE t'" in hoare_post_imp, clarsimp)
+     apply (rule_tac Q'="\<lambda>_. ?PRE t'" in hoare_post_imp, clarsimp)
      apply (wp)
     apply simp
     done
@@ -2964,7 +2964,7 @@ proof -
     apply (wp)
         apply (wp hoare_convert_imp)[1]
        apply (wp)
-      apply (rule_tac Q="\<lambda>_. ?PRE t'" in hoare_post_imp, clarsimp)
+      apply (rule_tac Q'="\<lambda>_. ?PRE t'" in hoare_post_imp, clarsimp)
       apply (wp hoare_convert_imp | simp)+
      done
   show ?thesis
@@ -2977,16 +2977,16 @@ proof -
         apply (wp)+
            apply (wp hoare_convert_imp)[1]
           apply (wpc, wp+)
-        apply (rule_tac Q="\<lambda>_. ?PRE t'" in hoare_post_imp, clarsimp)
+        apply (rule_tac Q'="\<lambda>_. ?PRE t'" in hoare_post_imp, clarsimp)
         apply (wp cdo)+
-         apply (rule_tac Q="\<lambda>_. ?PRE t'" in hoare_post_imp, clarsimp)
+         apply (rule_tac Q'="\<lambda>_. ?PRE t'" in hoare_post_imp, clarsimp)
          apply ((wp aipc hoare_convert_imp)+)[6]
     apply (wp)
        apply (wp hoare_convert_imp)[1]
       apply (wpc, wp+)
-    apply (rule_tac Q="\<lambda>_. ?PRE t'" in hoare_post_imp, clarsimp)
+    apply (rule_tac Q'="\<lambda>_. ?PRE t'" in hoare_post_imp, clarsimp)
     apply (wp)
-   apply (rule_tac Q="\<lambda>_. ?PRE t'" in hoare_post_imp, clarsimp)
+   apply (rule_tac Q'="\<lambda>_. ?PRE t'" in hoare_post_imp, clarsimp)
    apply (wp)
   apply simp
   done
@@ -3241,7 +3241,7 @@ lemma receiveIPC_corres:
                                              valid_sched_action_def)
                      apply (clarsimp split: if_split_asm)
                     apply (clarsimp | wp do_ipc_transfer_tcb_caps)+
-                   apply (rule_tac Q="\<lambda>_ s. sch_act_wf (ksSchedulerAction s) s
+                   apply (rule_tac Q'="\<lambda>_ s. sch_act_wf (ksSchedulerAction s) s
                                             \<and> sym_heap_sched_pointers s \<and> valid_sched_pointers s
                                             \<and> pspace_aligned' s \<and> pspace_distinct' s"
                                 in hoare_post_imp)
@@ -3504,7 +3504,7 @@ lemma setupCallerCap_vp[wp]:
   apply (simp add: valid_pspace'_def setupCallerCap_def getThreadCallerSlot_def
                    getThreadReplySlot_def locateSlot_conv getSlotCap_def)
   apply (wp getCTE_wp)
-  apply (rule_tac Q="\<lambda>_. valid_pspace' and
+  apply (rule_tac Q'="\<lambda>_. valid_pspace' and
                          tcb_at' sender and tcb_at' rcvr"
                   in hoare_post_imp)
    apply (clarsimp simp: valid_cap'_def o_def cte_wp_at_ctes_of isCap_simps
@@ -3537,7 +3537,7 @@ lemma setupCallerCap_ifunsafe[wp]:
   apply (wp getSlotCap_cte_wp_at
        | simp add: unique_master_reply_cap' | strengthen eq_imp_strg
        | wp (once) hoare_drop_imp[where f="getCTE rs" for rs])+
-   apply (rule_tac Q="\<lambda>rv. valid_objs' and tcb_at' rcvr and ex_nonz_cap_to' rcvr"
+   apply (rule_tac Q'="\<lambda>rv. valid_objs' and tcb_at' rcvr and ex_nonz_cap_to' rcvr"
                 in hoare_post_imp)
     apply (clarsimp simp: ex_nonz_tcb_cte_caps' tcbCallerSlot_def
                           objBits_def objBitsKO_def dom_def cte_level_bits_def)
@@ -3694,7 +3694,7 @@ lemma completeSignal_invs:
   apply (rule bind_wp[OF _ get_ntfn_sp'])
   apply (rule hoare_pre)
    apply (wp set_ntfn_minor_invs' | wpc | simp)+
-    apply (rule_tac Q="\<lambda>_ s. (state_refs_of' s ntfnptr = ntfn_bound_refs' (ntfnBoundTCB ntfn))
+    apply (rule_tac Q'="\<lambda>_ s. (state_refs_of' s ntfnptr = ntfn_bound_refs' (ntfnBoundTCB ntfn))
                            \<and> ntfn_at' ntfnptr s
                            \<and> valid_ntfn' (ntfnObj_update (\<lambda>_. Structures_H.ntfn.IdleNtfn) ntfn) s
                            \<and> ((\<exists>y. ntfnBoundTCB ntfn = Some y) \<longrightarrow> ex_nonz_cap_to' ntfnptr s)
@@ -3723,7 +3723,7 @@ lemma setupCallerCap_urz[wp]:
                    getThreadCallerSlot_def getThreadReplySlot_def
                    locateSlot_conv)
   apply (wp getCTE_wp')
-  apply (rule_tac Q="\<lambda>_. untyped_ranges_zero' and valid_mdb' and valid_objs'" in hoare_post_imp)
+  apply (rule_tac Q'="\<lambda>_. untyped_ranges_zero' and valid_mdb' and valid_objs'" in hoare_post_imp)
    apply (clarsimp simp: cte_wp_at_ctes_of cteCaps_of_def untyped_derived_eq_def
                          isCap_simps)
   apply (wp sts_valid_pspace_hangers)
@@ -3775,7 +3775,7 @@ lemma ri_invs' [wp]:
   apply (rule bind_wp [OF _ gbn_sp'])
   apply (rule bind_wp)
   (* set up precondition for old proof *)
-   apply (rule_tac R="ko_at' ep (capEPPtr cap) and ?pre" in hoare_vcg_if_split)
+   apply (rule_tac P''="ko_at' ep (capEPPtr cap) and ?pre" in hoare_vcg_if_split)
     apply (wp completeSignal_invs)
    apply (case_tac ep)
      \<comment> \<open>endpoint = RecvEP\<close>
@@ -4037,9 +4037,9 @@ lemma si_invs'[wp]:
                hoare_convert_imp [OF setEndpoint_nosch setEndpoint_ct']
                hoare_drop_imp [where f="threadGet tcbFault t"]
              | rule_tac f="getThreadState a" in hoare_drop_imp
-             | wp (once) hoare_drop_imp[where R="\<lambda>_ _. call"]
-               hoare_drop_imp[where R="\<lambda>_ _. \<not> call"]
-               hoare_drop_imp[where R="\<lambda>_ _. cg"]
+             | wp (once) hoare_drop_imp[where Q'="\<lambda>_ _. call"]
+               hoare_drop_imp[where Q'="\<lambda>_ _. \<not> call"]
+               hoare_drop_imp[where Q'="\<lambda>_ _. cg"]
              | simp    add: valid_tcb_state'_def case_bool_If
                             case_option_If
                       cong: if_cong

--- a/proof/refine/AARCH64/Ipc_R.thy
+++ b/proof/refine/AARCH64/Ipc_R.thy
@@ -53,7 +53,7 @@ lemma lsfco_cte_at':
    apply (wp)
   apply (clarsimp simp: split_def unlessE_def
              split del: if_split)
-  apply (wp hoare_drop_imps throwE_R)
+  apply (wpsimp wp: hoare_drop_imps throwE_R)
   done
 
 declare unifyFailure_wp [wp]
@@ -1779,7 +1779,7 @@ declare asUser_global_refs' [wp]
 lemma lec_valid_cap' [wp]:
   "\<lbrace>valid_objs'\<rbrace> lookupExtraCaps thread xa mi \<lbrace>\<lambda>rv s. (\<forall>x\<in>set rv. s \<turnstile>' fst x)\<rbrace>, -"
   apply (rule hoare_pre, rule hoare_strengthen_postE_R)
-    apply (rule hoare_vcg_conj_liftE_R[where R=valid_objs' and S="\<lambda>_. valid_objs'"])
+    apply (rule hoare_vcg_conj_liftE_R[where P'=valid_objs' and Q'="\<lambda>_. valid_objs'"])
      apply (rule lookupExtraCaps_srcs)
     apply wp
    apply (clarsimp simp: cte_wp_at_ctes_of)

--- a/proof/refine/AARCH64/Refine.thy
+++ b/proof/refine/AARCH64/Refine.thy
@@ -221,12 +221,12 @@ lemma set_thread_state_sched_act:
      apply (simp add: set_thread_state_ext_def)
      apply wp
         apply (rule hoare_pre_cont)
-       apply (rule_tac Q="\<lambda>rv. (\<lambda>s. runnable ts) and (\<lambda>s. P (scheduler_action s))"
+       apply (rule_tac Q'="\<lambda>rv. (\<lambda>s. runnable ts) and (\<lambda>s. P (scheduler_action s))"
                in hoare_strengthen_post)
         apply wp
        apply force
       apply (wp gts_st_tcb_at)+
-    apply (rule_tac Q="\<lambda>rv. st_tcb_at ((=) state) thread and (\<lambda>s. runnable state) and (\<lambda>s. P (scheduler_action s))" in hoare_strengthen_post)
+    apply (rule_tac Q'="\<lambda>rv. st_tcb_at ((=) state) thread and (\<lambda>s. runnable state) and (\<lambda>s. P (scheduler_action s))" in hoare_strengthen_post)
      apply (simp add: st_tcb_at_def)
      apply (wp obj_set_prop_at)+
     apply (force simp: st_tcb_at_def obj_at_def)
@@ -265,7 +265,7 @@ lemma kernel_entry_invs:
   \<lbrace>\<lambda>rv. einvs and (\<lambda>s. ct_running s \<or> ct_idle s)
     and (\<lambda>s. 0 < domain_time s) and valid_domain_list
     and (\<lambda>s. scheduler_action s = resume_cur_thread)\<rbrace>"
-  apply (rule_tac Q="\<lambda>rv. invs and (\<lambda>s. ct_running s \<or> ct_idle s) and valid_sched and
+  apply (rule_tac Q'="\<lambda>rv. invs and (\<lambda>s. ct_running s \<or> ct_idle s) and valid_sched and
                            (\<lambda>s. 0 < domain_time s) and valid_domain_list and
                            valid_list and (\<lambda>s. scheduler_action s = resume_cur_thread)"
             in hoare_post_imp)
@@ -311,7 +311,7 @@ lemma do_user_op_invs2:
   do_user_op f tc
    \<lbrace>\<lambda>_. (einvs  and ct_running and (\<lambda>s. scheduler_action s = resume_cur_thread))
         and (\<lambda>s. 0 < domain_time s) and valid_domain_list \<rbrace>"
-  apply (rule_tac Q="\<lambda>_. valid_list and valid_sched and
+  apply (rule_tac Q'="\<lambda>_. valid_list and valid_sched and
    (\<lambda>s. scheduler_action s = resume_cur_thread) and (invs and ct_running) and
    (\<lambda>s. 0 < domain_time s) and valid_domain_list"
    in hoare_strengthen_post)
@@ -398,7 +398,7 @@ lemma ckernel_invs:
   apply (rule hoare_pre)
    apply (wp activate_invs' activate_sch_act schedule_sch
              schedule_sch_act_simple he_invs' schedule_invs' hoare_vcg_if_lift3
-             hoare_drop_imp[where R="\<lambda>_. kernelExitAssertions"]
+             hoare_drop_imp[where Q'="\<lambda>_. kernelExitAssertions"]
           | simp add: no_irq_getActiveIRQ
           | strengthen non_kernel_IRQs_strg[where Q=True, simplified], simp cong: conj_cong)+
   done
@@ -591,22 +591,22 @@ lemma kernel_corres':
           apply simp
           apply (wpsimp wp: hoare_drop_imps hoare_vcg_all_lift simp: schact_is_rct_def)[1]
          apply simp
-         apply (rule_tac Q="\<lambda>irq s. invs' s \<and>
+         apply (rule_tac Q'="\<lambda>irq s. invs' s \<and>
                               (\<forall>irq'. irq = Some irq' \<longrightarrow>
                                  intStateIRQTable (ksInterruptState s ) irq' \<noteq>
                                  IRQInactive)"
                       in hoare_post_imp)
           apply simp
          apply (wp doMachineOp_getActiveIRQ_IRQ_active handle_event_valid_sched | simp)+
-       apply (rule_tac Q="\<lambda>_. \<top>" and E="\<lambda>_. invs'" in hoare_strengthen_postE)
+       apply (rule_tac Q'="\<lambda>_. \<top>" and E'="\<lambda>_. invs'" in hoare_strengthen_postE)
          apply wpsimp+
        apply (simp add: invs'_def valid_state'_def)
       apply (rule corres_split[OF schedule_corres])
         apply (rule activateThread_corres)
        apply (wp schedule_invs' hoare_vcg_if_lift2 dmo_getActiveIRQ_non_kernel
               | simp cong: rev_conj_cong | strengthen None_drop | subst Ex_Some_conv)+
-     apply (rule_tac Q="\<lambda>_. valid_sched and invs and valid_list" and
-                     E="\<lambda>_. valid_sched and invs and valid_list"
+     apply (rule_tac Q'="\<lambda>_. valid_sched and invs and valid_list" and
+                     E'="\<lambda>_. valid_sched and invs and valid_list"
             in hoare_strengthen_postE)
        apply (wp handle_event_valid_sched hoare_vcg_imp_lift' |simp)+
        apply (wp handle_event_valid_sched hoare_vcg_if_lift3

--- a/proof/refine/AARCH64/Retype_R.thy
+++ b/proof/refine/AARCH64/Retype_R.thy
@@ -4296,20 +4296,21 @@ lemma createNewCaps_idle'[wp]:
              split del: if_split)
   apply (cases ty, simp_all add: Arch_createNewCaps_def
                       split del: if_split)
-         apply (rename_tac apiobject_type)
-         apply (case_tac apiobject_type, simp_all split del: if_split)[1]
-             apply (wp, simp)
+        apply (rename_tac apiobject_type)
+        apply (case_tac apiobject_type, simp_all split del: if_split)[1]
+            apply wpsimp
+           (* The following step does not use wpsimp to avoid clarsimp_no_cond, which for some reason
+              leads to a failed proof state. If this could be fixed then the inclusion of
+              classic_wp_pre could also be removed. *)
            including classic_wp_pre
-           apply (wp mapM_x_wp'
-                     createObjects_idle'
-                     threadSet_idle'
-                   | simp add: projectKO_opt_tcb projectKO_opt_cte mult_2
-                               makeObject_cte makeObject_tcb archObjSize_def
-                               tcb_cte_cases_def objBitsKO_def APIType_capBits_def
-                               objBits_def createObjects_def cteSizeBits_def
-                   | simp add: field_simps
-                   | intro conjI impI
-                   | fastforce simp: curDomain_def)+
+           apply (wp mapM_x_wp' createObjects_idle' threadSet_idle'
+                  | simp add: projectKO_opt_tcb projectKO_opt_cte mult_2
+                              makeObject_cte makeObject_tcb archObjSize_def
+                              tcb_cte_cases_def objBitsKO_def APIType_capBits_def
+                              objBits_def createObjects_def cteSizeBits_def
+                  | simp add: field_simps
+                  | intro conjI impI
+                  | clarsimp simp: curDomain_def)+
   done
 
 crunch createNewCaps

--- a/proof/refine/AARCH64/Retype_R.thy
+++ b/proof/refine/AARCH64/Retype_R.thy
@@ -4222,7 +4222,7 @@ lemma createNewCaps_cur:
         cur_tcb' s\<rbrace>
       createNewCaps ty ptr n us d
    \<lbrace>\<lambda>rv. cur_tcb'\<rbrace>"
-  apply (rule hoare_post_imp [where Q="\<lambda>rv s. \<exists>t. ksCurThread s = t \<and> tcb_at' t s"])
+  apply (rule hoare_post_imp[where Q'="\<lambda>rv s. \<exists>t. ksCurThread s = t \<and> tcb_at' t s"])
    apply (simp add: cur_tcb'_def)
   apply (wp hoare_vcg_ex_lift createNewCaps_obj_at')
   apply (clarsimp simp: pspace_no_overlap'_def cur_tcb'_def valid_pspace'_def)
@@ -4329,7 +4329,7 @@ lemma createNewCaps_global_refs':
      createNewCaps ty ptr n us d
    \<lbrace>\<lambda>rv. valid_global_refs'\<rbrace>"
   apply (simp add: valid_global_refs'_def valid_cap_sizes'_def valid_refs'_def)
-  apply (rule_tac Q="\<lambda>rv s. \<forall>ptr. \<not> cte_wp_at' (\<lambda>cte. (kernel_data_refs \<inter> capRange (cteCap cte) \<noteq> {}
+  apply (rule_tac Q'="\<lambda>rv s. \<forall>ptr. \<not> cte_wp_at' (\<lambda>cte. (kernel_data_refs \<inter> capRange (cteCap cte) \<noteq> {}
         \<or> 2 ^ capBits (cteCap cte) > gsMaxObjectSize s)) ptr s \<and> global_refs' s \<subseteq> kernel_data_refs"
                  in hoare_post_imp)
    apply (auto simp: cte_wp_at_ctes_of linorder_not_less elim!: ranE)[1]
@@ -4880,7 +4880,7 @@ proof (rule hoare_gen_asm, elim conjE)
     "\<lbrace>ct_not_inQ and valid_pspace' and pspace_no_overlap' ptr sz\<rbrace>
      createNewCaps ty ptr n us dev \<lbrace>\<lambda>_. ct_not_inQ\<rbrace>"
     unfolding ct_not_inQ_def
-    apply (rule_tac Q="\<lambda>s. ksSchedulerAction s = ResumeCurrentThread
+    apply (rule_tac P'="\<lambda>s. ksSchedulerAction s = ResumeCurrentThread
                              \<longrightarrow> (obj_at' (Not \<circ> tcbQueued) (ksCurThread s) s
                                   \<and> valid_pspace' s \<and> pspace_no_overlap' ptr sz s)"
                     in hoare_pre_imp, clarsimp)
@@ -5019,7 +5019,7 @@ lemma createObjects_no_cte_valid_global:
       createObjects ptr n val gbits
    \<lbrace>\<lambda>rv s. valid_global_refs' s\<rbrace>"
   apply (simp add: valid_global_refs'_def valid_cap_sizes'_def valid_refs'_def)
-  apply (rule_tac Q="\<lambda>rv s. \<forall>ptr. \<not> cte_wp_at' (\<lambda>cte. (kernel_data_refs \<inter> capRange (cteCap cte) \<noteq> {}
+  apply (rule_tac Q'="\<lambda>rv s. \<forall>ptr. \<not> cte_wp_at' (\<lambda>cte. (kernel_data_refs \<inter> capRange (cteCap cte) \<noteq> {}
         \<or> 2 ^ capBits (cteCap cte) > gsMaxObjectSize s)) ptr s \<and> global_refs' s \<subseteq> kernel_data_refs"
                  in hoare_post_imp)
    apply (auto simp: cte_wp_at_ctes_of linorder_not_less elim!: ranE)[1]
@@ -5124,7 +5124,7 @@ lemma createObjects_cur':
         cur_tcb' s\<rbrace>
       createObjects ptr n val gbits
    \<lbrace>\<lambda>rv s. cur_tcb' s\<rbrace>"
-  apply (rule hoare_post_imp [where Q="\<lambda>rv s. \<exists>t. ksCurThread s = t \<and> tcb_at' t s"])
+  apply (rule hoare_post_imp[where Q'="\<lambda>rv s. \<exists>t. ksCurThread s = t \<and> tcb_at' t s"])
    apply (simp add: cur_tcb'_def)
   apply (wp hoare_vcg_ex_lift createObjects_orig_obj_at3)
   apply (clarsimp simp: cur_tcb'_def)
@@ -5210,7 +5210,7 @@ proof -
       createObjects ptr n val gbits \<lbrace>\<lambda>_. ct_not_inQ\<rbrace>"
     (is "\<lbrakk> _; _ \<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s. ct_not_inQ s \<and> ?REST s\<rbrace> _ \<lbrace>_\<rbrace>")
     apply (simp add: ct_not_inQ_def)
-    apply (rule_tac Q="\<lambda>s. (ksSchedulerAction s = ResumeCurrentThread) \<longrightarrow>
+    apply (rule_tac P'="\<lambda>s. (ksSchedulerAction s = ResumeCurrentThread) \<longrightarrow>
                              (obj_at' (Not \<circ> tcbQueued) (ksCurThread s) s \<and> ?REST s)"
              in hoare_pre_imp, clarsimp)
     apply (rule hoare_convert_imp [OF createObjects_nosch])

--- a/proof/refine/AARCH64/Schedule_R.thy
+++ b/proof/refine/AARCH64/Schedule_R.thy
@@ -2124,7 +2124,7 @@ lemma schedule_corres:
                           tcbSchedEnqueue_invs'_not_ResumeCurrentThread thread_get_wp
                      del: gets_wp
                   | strengthen valid_objs'_valid_tcbs')+
-       apply (clarsimp simp: conj_ac if_apply_def2 cong: imp_cong conj_cong del: hoare_gets)
+       apply (clarsimp simp: conj_ac if_apply_def2 cong: imp_cong conj_cong)
        apply (wp gets_wp)+
 
    (* abstract final subgoal *)

--- a/proof/refine/AARCH64/Schedule_R.thy
+++ b/proof/refine/AARCH64/Schedule_R.thy
@@ -754,7 +754,7 @@ lemma tcbSchedDequeue_valid_mdb'[wp]:
   "\<lbrace>valid_mdb' and valid_objs'\<rbrace> tcbSchedDequeue tcbPtr \<lbrace>\<lambda>_. valid_mdb'\<rbrace>"
   unfolding tcbSchedDequeue_def
   apply (wpsimp simp: bitmap_fun_defs setQueue_def wp: threadSet_mdb' tcbQueueRemove_valid_mdb')
-      apply (rule_tac Q="\<lambda>_. tcb_at' tcbPtr" in hoare_post_imp)
+      apply (rule_tac Q'="\<lambda>_. tcb_at' tcbPtr" in hoare_post_imp)
        apply (fastforce simp: tcb_cte_cases_def cteSizeBits_def)
       apply (wpsimp wp: threadGet_wp)+
   apply (fastforce simp: obj_at'_def)
@@ -1078,7 +1078,7 @@ lemma tcbSchedDequeue_not_tcbQueued:
   "\<lbrace>\<top>\<rbrace> tcbSchedDequeue t \<lbrace>\<lambda>_. obj_at' (\<lambda>x. \<not> tcbQueued x) t\<rbrace>"
   apply (simp add: tcbSchedDequeue_def)
   apply (wp|clarsimp)+
-  apply (rule_tac Q="\<lambda>queued. obj_at' (\<lambda>x. tcbQueued x = queued) t" in hoare_post_imp)
+  apply (rule_tac Q'="\<lambda>queued. obj_at' (\<lambda>x. tcbQueued x = queued) t" in hoare_post_imp)
      apply (clarsimp simp: obj_at'_def)
     apply (wpsimp wp: threadGet_wp)+
   apply (clarsimp simp: obj_at'_def)
@@ -2118,7 +2118,7 @@ lemma schedule_corres:
 
            apply (clarsimp simp: conj_ac cong: conj_cong)
            apply wp
-           apply (rule_tac Q="\<lambda>_ s. valid_blocked_except t s \<and> scheduler_action s = switch_thread t"
+           apply (rule_tac Q'="\<lambda>_ s. valid_blocked_except t s \<and> scheduler_action s = switch_thread t"
                     in hoare_post_imp, fastforce)
            apply (wp add: tcb_sched_action_enqueue_valid_blocked_except
                           tcbSchedEnqueue_invs'_not_ResumeCurrentThread thread_get_wp
@@ -2387,7 +2387,7 @@ lemma schedule_invs':
     apply (wpsimp wp: scheduleChooseNewThread_invs' ssa_invs'
                       chooseThread_invs_no_cicd' setSchedulerAction_invs' setSchedulerAction_direct
                       switchToThread_tcb_in_cur_domain' switchToThread_ct_not_queued_2
-           | wp hoare_disjI2[where R="\<lambda>_ s. tcb_in_cur_domain' (ksCurThread s) s"]
+           | wp hoare_disjI2[where Q'="\<lambda>_ s. tcb_in_cur_domain' (ksCurThread s) s"]
            | wp hoare_drop_imp[where f="isHighestPrio d p" for d p]
            | simp only: obj_at'_activatable_st_tcb_at'[simplified comp_def]
            | strengthen invs'_invs_no_cicd

--- a/proof/refine/AARCH64/SubMonad_R.thy
+++ b/proof/refine/AARCH64/SubMonad_R.thy
@@ -76,7 +76,7 @@ lemma threadSet_modify_asUser:
    apply (clarsimp simp: threadSet_def setObject_def split_def
                          updateObject_default_def)
    apply wp
-   apply (rule_tac Q="\<lambda>rv. obj_at' ((=) rv) t and ((=) st)" in hoare_post_imp)
+   apply (rule_tac Q'="\<lambda>rv. obj_at' ((=) rv) t and ((=) st)" in hoare_post_imp)
     apply (clarsimp simp: asUser_replace_def Let_def obj_at'_def fun_upd_def
                    split: option.split kernel_object.split)
    apply (wp getObject_obj_at' | clarsimp simp: objBits_simps' atcbContextSet_def)+

--- a/proof/refine/AARCH64/Syscall_R.thy
+++ b/proof/refine/AARCH64/Syscall_R.thy
@@ -340,7 +340,7 @@ lemma threadSet_tcbDomain_update_sch_act_wf[wp]:
      apply (wps setObject_sa_unchanged)
      apply (wp hoare_weak_lift_imp getObject_tcb_wp hoare_vcg_all_lift)+
    apply (rename_tac word)
-   apply (rule_tac Q="\<lambda>_ s. ksSchedulerAction s = SwitchToThread word \<longrightarrow>
+   apply (rule_tac Q'="\<lambda>_ s. ksSchedulerAction s = SwitchToThread word \<longrightarrow>
                             st_tcb_at' runnable' word s \<and> tcb_in_cur_domain' word s \<and> word \<noteq> t"
                    in hoare_strengthen_post)
     apply (wp hoare_vcg_all_lift hoare_vcg_conj_lift hoare_vcg_imp_lift)+
@@ -377,20 +377,20 @@ lemma setDomain_corres:
          apply ((wpsimp wp: hoare_vcg_imp_lift' ethread_set_not_queued_valid_queues hoare_vcg_all_lift
                  | strengthen valid_objs'_valid_tcbs' valid_queues_in_correct_ready_q
                               valid_queues_ready_qs_distinct)+)[1]
-        apply (rule_tac Q="\<lambda>_. valid_objs' and sym_heap_sched_pointers and valid_sched_pointers
+        apply (rule_tac Q'="\<lambda>_. valid_objs' and sym_heap_sched_pointers and valid_sched_pointers
                                and pspace_aligned' and pspace_distinct'
                                and (\<lambda>s. sch_act_wf (ksSchedulerAction s) s) and tcb_at' tptr"
                      in hoare_strengthen_post[rotated])
          apply (fastforce simp: invs'_def valid_state'_def sch_act_wf_weak st_tcb_at'_def o_def)
         apply (wpsimp wp: threadSet_valid_objs' threadSet_sched_pointers
                           threadSet_valid_sched_pointers)+
-       apply (rule_tac Q="\<lambda>_ s. valid_queues s \<and> not_queued tptr s
+       apply (rule_tac Q'="\<lambda>_ s. valid_queues s \<and> not_queued tptr s
                                 \<and> pspace_aligned s \<and> pspace_distinct s \<and> valid_etcbs s
                                 \<and> weak_valid_sched_action s"
                     in hoare_post_imp)
         apply (fastforce simp: pred_tcb_at_def obj_at_def)
        apply (wpsimp wp: tcb_dequeue_not_queued)
-      apply (rule_tac Q = "\<lambda>_ s. invs' s \<and> obj_at' (Not \<circ> tcbQueued) tptr s \<and> sch_act_simple s
+      apply (rule_tac Q'="\<lambda>_ s. invs' s \<and> obj_at' (Not \<circ> tcbQueued) tptr s \<and> sch_act_simple s
                                  \<and>  tcb_at' tptr s"
                    in hoare_strengthen_post[rotated])
        apply (clarsimp simp: invs'_def valid_state'_def valid_pspace'_def sch_act_simple_def)
@@ -792,7 +792,7 @@ lemma doReply_invs[wp]:
           apply simp
           apply (wp (once) sts_st_tcb')
           apply wp
-         apply (rule_tac Q="\<lambda>_ s. invs' s \<and> t \<noteq> ksIdleThread s \<and> st_tcb_at' awaiting_reply' t s"
+         apply (rule_tac Q'="\<lambda>_ s. invs' s \<and> t \<noteq> ksIdleThread s \<and> st_tcb_at' awaiting_reply' t s"
                  in hoare_post_imp)
           apply clarsimp
           apply (rule conjI, erule pred_tcb'_weakenE, case_tac st, clarsimp+)
@@ -805,7 +805,7 @@ lemma doReply_invs[wp]:
           apply (case_tac st, clarsimp+)
          apply (wp cteDeleteOne_reply_pred_tcb_at)+
         apply clarsimp
-        apply (rule_tac Q="\<lambda>_. (\<lambda>s. t \<noteq> ksIdleThread s)
+        apply (rule_tac Q'="\<lambda>_. (\<lambda>s. t \<noteq> ksIdleThread s)
                                and cte_wp_at' (\<lambda>cte. \<exists>grant. cteCap cte
                                                              = capability.ReplyCap t False grant) slot"
                      in hoare_strengthen_post [rotated])
@@ -817,7 +817,7 @@ lemma doReply_invs[wp]:
         apply (erule cte_wp_at_weakenE')
         apply (fastforce)
        apply (wp sts_invs_minor'' sts_st_tcb' hoare_weak_lift_imp)
-             apply (rule_tac Q="\<lambda>_ s. invs' s \<and> sch_act_simple s
+             apply (rule_tac Q'="\<lambda>_ s. invs' s \<and> sch_act_simple s
                                       \<and> st_tcb_at' awaiting_reply' t s
                                       \<and> t \<noteq> ksIdleThread s"
                           in hoare_post_imp)
@@ -832,7 +832,7 @@ lemma doReply_invs[wp]:
               apply (case_tac st, clarsimp+)
              apply (wp threadSet_invs_trivial threadSet_st_tcb_at2 hoare_weak_lift_imp
                     | clarsimp simp add: inQ_def)+
-           apply (rule_tac Q="\<lambda>_. invs' and tcb_at' t
+           apply (rule_tac Q'="\<lambda>_. invs' and tcb_at' t
                                  and sch_act_simple and st_tcb_at' awaiting_reply' t"
                    in hoare_strengthen_post [rotated])
             apply clarsimp
@@ -949,7 +949,7 @@ lemma setDomain_invs':
   apply (simp add:setDomain_def )
   apply (wp add: when_wp hoare_weak_lift_imp hoare_weak_lift_imp_conj rescheduleRequired_all_invs_but_extra
                  tcbSchedEnqueue_valid_action hoare_vcg_if_lift2)
-     apply (rule_tac Q = "\<lambda>r s. all_invs_but_sch_extra s \<and> curThread = ksCurThread s
+     apply (rule_tac Q'="\<lambda>r s. all_invs_but_sch_extra s \<and> curThread = ksCurThread s
       \<and> (ptr \<noteq> curThread \<longrightarrow> ct_not_inQ s \<and> sch_act_wf (ksSchedulerAction s) s \<and> ct_idle_or_in_cur_domain' s)"
       in hoare_strengthen_post[rotated])
       apply (clarsimp simp:invs'_def valid_state'_def st_tcb_at'_def[symmetric] valid_pspace'_def)
@@ -961,7 +961,7 @@ lemma setDomain_invs':
       apply assumption
      apply (wp hoare_weak_lift_imp threadSet_pred_tcb_no_state threadSet_not_curthread_ct_domain
                threadSet_tcbDomain_update_ct_not_inQ | simp)+
-    apply (rule_tac Q = "\<lambda>r s. invs' s \<and> curThread = ksCurThread s \<and> sch_act_simple s
+    apply (rule_tac Q'="\<lambda>r s. invs' s \<and> curThread = ksCurThread s \<and> sch_act_simple s
                              \<and> domain \<le> maxDomain
                              \<and> (ptr \<noteq> curThread \<longrightarrow> ct_not_inQ s \<and> sch_act_not ptr s)"
       in hoare_strengthen_post[rotated])
@@ -1193,7 +1193,7 @@ lemma handleInvocation_corres:
                       apply (wp reply_from_kernel_tcb_at)
                      apply (rule impI, wp+)
                      apply (wpsimp wp: hoare_drop_imps|strengthen invs_distinct invs_psp_aligned)+
-               apply (rule_tac Q="\<lambda>rv. einvs and schact_is_rct and valid_invocation rve
+               apply (rule_tac Q'="\<lambda>rv. einvs and schact_is_rct and valid_invocation rve
                                    and (\<lambda>s. thread = cur_thread s)
                                    and st_tcb_at active thread"
                           in hoare_post_imp)
@@ -1201,7 +1201,7 @@ lemma handleInvocation_corres:
                                elim!: st_tcb_weakenE)
                apply (wp sts_st_tcb_at' set_thread_state_simple_sched_action
                          set_thread_state_schact_is_rct set_thread_state_active_valid_sched)
-              apply (rule_tac Q="\<lambda>rv. invs' and valid_invocation' rve'
+              apply (rule_tac Q'="\<lambda>rv. invs' and valid_invocation' rve'
                                       and (\<lambda>s. thread = ksCurThread s)
                                       and st_tcb_at' active' thread
                                       and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread)"
@@ -1213,7 +1213,7 @@ lemma handleInvocation_corres:
              apply (wp lec_caps_to lsft_ex_cte_cap_to
                     | simp add: split_def liftE_bindE[symmetric]
                                 ct_in_state'_def ball_conj_distrib
-                    | rule hoare_vcg_E_elim)+
+                    | rule hoare_vcg_conj_elimE)+
    apply (clarsimp simp: tcb_at_invs invs_valid_objs
                          valid_tcb_state_def ct_in_state_def
                          simple_from_active invs_mdb
@@ -1282,7 +1282,7 @@ lemma hinv_invs'[wp]:
          apply (clarsimp simp: valid_idle'_def valid_state'_def
                                invs'_def pred_tcb_at'_def obj_at'_def idle_tcb'_def)
         apply wp+
-       apply (rule_tac Q="\<lambda>rv'. invs' and valid_invocation' rv
+       apply (rule_tac Q'="\<lambda>rv'. invs' and valid_invocation' rv
                                 and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread)
                                 and (\<lambda>s. ksCurThread s = thread)
                                 and st_tcb_at' active' thread"
@@ -1484,7 +1484,7 @@ lemma handleRecv_isBlocking_corres':
           apply (rule handleFault_corres)
           apply simp
          apply (wp get_simple_ko_wp | wpcw | simp)+
-         apply (rule hoare_vcg_E_elim)
+         apply (rule hoare_vcg_conj_elimE)
           apply (simp add: lookup_cap_def lookup_slot_for_thread_def)
           apply wp
            apply (simp add: split_def)
@@ -1532,14 +1532,14 @@ lemma hw_invs'[wp]:
                          deleteCallerCap_ct']
                     | wpc | simp add: ct_in_state'_def whenE_def split del: if_split)+
      apply (rule validE_validE_R)
-     apply (rule_tac Q="\<lambda>rv s. invs' s
+     apply (rule_tac Q'="\<lambda>rv s. invs' s
                              \<and> sch_act_sane s
                              \<and> thread = ksCurThread s
                              \<and> ct_in_state' simple' s
                              \<and> ex_nonz_cap_to' thread s
                              \<and> thread \<noteq> ksIdleThread s
                             \<and> (\<forall>x \<in> zobj_refs' rv. ex_nonz_cap_to' x s)"
-              and E="\<lambda>_ _. True"
+              and E'="\<lambda>_ _. True"
            in hoare_strengthen_postE[rotated])
         apply (clarsimp simp: isCap_simps ct_in_state'_def pred_tcb_at' invs_valid_objs'
                               sch_act_sane_not obj_at'_def pred_tcb_at'_def)
@@ -1588,7 +1588,7 @@ lemma hy_invs':
   "\<lbrace>invs' and ct_active'\<rbrace> handleYield \<lbrace>\<lambda>r. invs' and ct_active'\<rbrace>"
   apply (simp add: handleYield_def)
   apply (wpsimp wp: ct_in_state_thread_state_lift' rescheduleRequired_all_invs_but_ct_not_inQ)
-     apply (rule_tac Q="\<lambda>_. all_invs_but_ct_not_inQ' and ct_active'" in hoare_post_imp)
+     apply (rule_tac Q'="\<lambda>_. all_invs_but_ct_not_inQ' and ct_active'" in hoare_post_imp)
       apply clarsimp
      apply (subst pred_conj_def)
      apply (rule hoare_vcg_conj_lift)
@@ -1812,7 +1812,7 @@ lemma handleReply_nonz_cap_to_ct:
   "\<lbrace>ct_active' and invs' and sch_act_simple\<rbrace>
      handleReply
    \<lbrace>\<lambda>rv s. ex_nonz_cap_to' (ksCurThread s) s\<rbrace>"
-  apply (rule_tac Q="\<lambda>rv. ct_active' and invs'"
+  apply (rule_tac Q'="\<lambda>rv. ct_active' and invs'"
                in hoare_post_imp)
    apply (auto simp: ct_in_state'_def elim: st_tcb_ex_cap'')[1]
   apply (wp | simp)+

--- a/proof/refine/AARCH64/TcbAcc_R.thy
+++ b/proof/refine/AARCH64/TcbAcc_R.thy
@@ -1093,7 +1093,7 @@ lemma threadSet_obj_at'_really_strongest:
   apply (simp add: threadSet_def)
   apply (wp setObject_tcb_strongest)
    apply (subst simp_thms(32)[symmetric], rule hoare_vcg_disj_lift)
-    apply (rule hoare_post_imp [where Q="\<lambda>rv s. \<not> tcb_at' t s \<and> tcb_at' t s"])
+    apply (rule hoare_post_imp[where Q'="\<lambda>rv s. \<not> tcb_at' t s \<and> tcb_at' t s"])
      apply simp
     apply (subst simp_thms(21)[symmetric], rule hoare_vcg_conj_lift)
      apply (rule getObject_inv_tcb)
@@ -1179,7 +1179,7 @@ proof -
   show ?thesis
     apply (rule_tac P=P in P_bool_lift)
      apply (rule pos)
-    apply (rule_tac Q="\<lambda>_ s. \<not> tcb_at' t' s \<or> pred_tcb_at' proj (\<lambda>tcb. \<not> P' tcb) t' s"
+    apply (rule_tac Q'="\<lambda>_ s. \<not> tcb_at' t' s \<or> pred_tcb_at' proj (\<lambda>tcb. \<not> P' tcb) t' s"
              in hoare_post_imp)
      apply (erule disjE)
       apply (clarsimp dest!: pred_tcb_at')
@@ -3344,7 +3344,7 @@ lemma sts_valid_objs':
    setThreadState st t
    \<lbrace>\<lambda>_. valid_objs'\<rbrace>"
   apply (wpsimp simp: setThreadState_def wp: threadSet_valid_objs')
-   apply (rule_tac Q="\<lambda>_. valid_objs' and pspace_aligned' and pspace_distinct'" in hoare_post_imp)
+   apply (rule_tac Q'="\<lambda>_. valid_objs' and pspace_aligned' and pspace_distinct'" in hoare_post_imp)
     apply fastforce
    apply (wpsimp wp: threadSet_valid_objs')
   apply (simp add: valid_tcb'_def tcb_cte_cases_def cteSizeBits_def)
@@ -3608,7 +3608,7 @@ lemma sts_sch_act':
    apply assumption
   apply (case_tac "runnable' st")
    apply ((wp threadSet_runnable_sch_act hoare_drop_imps | simp)+)[1]
-  apply (rule_tac Q="\<lambda>rv s. st_tcb_at' (Not \<circ> runnable') t s \<and>
+  apply (rule_tac Q'="\<lambda>rv s. st_tcb_at' (Not \<circ> runnable') t s \<and>
                      (ksCurThread s \<noteq> t \<or> ksSchedulerAction s \<noteq> ResumeCurrentThread \<longrightarrow>
                             sch_act_wf (ksSchedulerAction s) s)"
                in hoare_post_imp)
@@ -3628,10 +3628,10 @@ lemma sts_sch_act[wp]:
    prefer 2
    apply assumption
   apply (case_tac "runnable' st")
-   apply (rule_tac Q="\<lambda>s. sch_act_wf (ksSchedulerAction s) s"
+   apply (rule_tac P'="\<lambda>s. sch_act_wf (ksSchedulerAction s) s"
                 in hoare_pre_imp, simp)
    apply ((wp hoare_drop_imps threadSet_runnable_sch_act | simp)+)[1]
-  apply (rule_tac Q="\<lambda>rv s. st_tcb_at' (Not \<circ> runnable') t s \<and>
+  apply (rule_tac Q'="\<lambda>rv s. st_tcb_at' (Not \<circ> runnable') t s \<and>
                      (ksCurThread s \<noteq> t \<or> ksSchedulerAction s \<noteq> ResumeCurrentThread \<longrightarrow>
                             sch_act_wf (ksSchedulerAction s) s)"
                in hoare_post_imp)
@@ -3907,7 +3907,7 @@ lemma addToBitmap_valid_bitmapQ:
    addToBitmap d p
    \<lbrace>\<lambda>_. valid_bitmapQ\<rbrace>"
   (is "\<lbrace>?pre\<rbrace> _ \<lbrace>_\<rbrace>")
-  apply (rule_tac Q="\<lambda>_ s. ?pre s \<and> bitmapQ d p s" in hoare_strengthen_post)
+  apply (rule_tac Q'="\<lambda>_ s. ?pre s \<and> bitmapQ d p s" in hoare_strengthen_post)
    apply (wpsimp wp: addToBitmap_valid_bitmapQ_except addToBitmap_bitmapQ)
   apply (fastforce elim: valid_bitmap_valid_bitmapQ_exceptE)
   done
@@ -4603,7 +4603,7 @@ lemma ct_in_state'_decomp:
   assumes x: "\<lbrace>\<lambda>s. t = (ksCurThread s)\<rbrace> f \<lbrace>\<lambda>rv s. t = (ksCurThread s)\<rbrace>"
   assumes y: "\<lbrace>Pre\<rbrace> f \<lbrace>\<lambda>rv. st_tcb_at' Prop t\<rbrace>"
   shows      "\<lbrace>\<lambda>s. Pre s \<and> t = (ksCurThread s)\<rbrace> f \<lbrace>\<lambda>rv. ct_in_state' Prop\<rbrace>"
-  apply (rule hoare_post_imp [where Q="\<lambda>rv s. t = ksCurThread s \<and> st_tcb_at' Prop t s"])
+  apply (rule hoare_post_imp[where Q'="\<lambda>rv s. t = ksCurThread s \<and> st_tcb_at' Prop t s"])
    apply (clarsimp simp add: ct_in_state'_def)
   apply (rule hoare_weaken_pre)
    apply (wp x y)
@@ -4674,7 +4674,7 @@ lemma setQueue_pred_tcb_at[wp]:
   unfolding pred_tcb_at'_def
   apply (rule_tac P=P' in P_bool_lift)
    apply (rule setQueue_obj_at)
-  apply (rule_tac Q="\<lambda>_ s. \<not>typ_at' TCBT t s \<or> obj_at' (Not \<circ> (P \<circ> proj \<circ> tcb_to_itcb')) t s"
+  apply (rule_tac Q'="\<lambda>_ s. \<not>typ_at' TCBT t s \<or> obj_at' (Not \<circ> (P \<circ> proj \<circ> tcb_to_itcb')) t s"
            in hoare_post_imp, simp add: not_obj_at' o_def)
   apply (wp hoare_vcg_disj_lift)
   apply (clarsimp simp: not_obj_at' o_def)
@@ -4953,7 +4953,7 @@ lemma sts_iflive'[wp]:
    \<lbrace>\<lambda>rv. if_live_then_nonz_cap'\<rbrace>"
   apply (simp add: setThreadState_def setQueue_def)
   apply wpsimp
-   apply (rule_tac Q="\<lambda>rv. if_live_then_nonz_cap' and pspace_aligned' and pspace_distinct'"
+   apply (rule_tac Q'="\<lambda>rv. if_live_then_nonz_cap' and pspace_aligned' and pspace_distinct'"
                 in hoare_post_imp)
     apply clarsimp
    apply (wpsimp wp: threadSet_iflive')
@@ -5097,7 +5097,7 @@ lemma tcbSchedEnqueue_ct_not_inQ:
   proof -
     have ts: "\<lbrace>?PRE\<rbrace> threadSet (tcbQueued_update (\<lambda>_. True)) t \<lbrace>\<lambda>_. ct_not_inQ\<rbrace>"
       apply (simp add: ct_not_inQ_def)
-      apply (rule_tac Q="\<lambda>s. ksSchedulerAction s = ResumeCurrentThread
+      apply (rule_tac P'="\<lambda>s. ksSchedulerAction s = ResumeCurrentThread
                   \<longrightarrow> obj_at' (Not \<circ> tcbQueued) (ksCurThread s) s \<and> ksCurThread s \<noteq> t"
                   in hoare_pre_imp, clarsimp)
       apply (rule hoare_convert_imp [OF threadSet_nosch])
@@ -5124,7 +5124,7 @@ lemma tcbSchedAppend_ct_not_inQ:
   proof -
     have ts: "\<lbrace>?PRE\<rbrace> threadSet (tcbQueued_update (\<lambda>_. True)) t \<lbrace>\<lambda>_. ct_not_inQ\<rbrace>"
       apply (simp add: ct_not_inQ_def)
-      apply (rule_tac Q="\<lambda>s. ksSchedulerAction s = ResumeCurrentThread
+      apply (rule_tac P'="\<lambda>s. ksSchedulerAction s = ResumeCurrentThread
                   \<longrightarrow> obj_at' (Not \<circ> tcbQueued) (ksCurThread s) s \<and> ksCurThread s \<noteq> t"
                   in hoare_pre_imp, clarsimp)
       apply (rule hoare_convert_imp [OF threadSet_nosch])
@@ -5151,7 +5151,7 @@ lemma setSchedulerAction_direct:
 lemma rescheduleRequired_ct_not_inQ:
   "\<lbrace>\<top>\<rbrace> rescheduleRequired \<lbrace>\<lambda>_. ct_not_inQ\<rbrace>"
   apply (simp add: rescheduleRequired_def ct_not_inQ_def)
-  apply (rule_tac Q="\<lambda>_ s. ksSchedulerAction s = ChooseNewThread"
+  apply (rule_tac Q'="\<lambda>_ s. ksSchedulerAction s = ChooseNewThread"
            in hoare_post_imp, clarsimp)
   apply (wp setSchedulerAction_direct)
   done
@@ -5222,7 +5222,7 @@ lemma setThreadState_ct_not_inQ:
   including no_pre
   apply (simp add: setThreadState_def)
   apply (wp rescheduleRequired_ct_not_inQ)
-  apply (rule_tac Q="\<lambda>_. ?PRE" in hoare_post_imp, clarsimp)
+  apply (rule_tac Q'="\<lambda>_. ?PRE" in hoare_post_imp, clarsimp)
   apply (wp)
   done
 
@@ -5379,7 +5379,7 @@ lemma removeFromBitmap_valid_bitmapQ[wp]:
    removeFromBitmap d p
    \<lbrace>\<lambda>_. valid_bitmapQ\<rbrace>"
   (is "\<lbrace>?pre\<rbrace> _ \<lbrace>_\<rbrace>")
-  apply (rule_tac Q="\<lambda>_ s. ?pre s \<and> \<not> bitmapQ d p s" in hoare_strengthen_post)
+  apply (rule_tac Q'="\<lambda>_ s. ?pre s \<and> \<not> bitmapQ d p s" in hoare_strengthen_post)
    apply (wpsimp wp: removeFromBitmap_valid_bitmapQ_except removeFromBitmap_bitmapQ)
   apply (fastforce elim: valid_bitmap_valid_bitmapQ_exceptE)
   done

--- a/proof/refine/AARCH64/Tcb_R.thy
+++ b/proof/refine/AARCH64/Tcb_R.thy
@@ -82,7 +82,7 @@ abbreviation
 lemma gts_st_tcb':
   "\<lbrace>tcb_at' t\<rbrace> getThreadState t \<lbrace>\<lambda>rv. st_tcb_at' (\<lambda>st. st = rv) t\<rbrace>"
   apply (rule hoare_weaken_pre)
-   apply (rule hoare_post_imp[where Q="\<lambda>rv s. \<exists>rv'. rv = rv' \<and> st_tcb_at' (\<lambda>st. st = rv') t s"])
+   apply (rule hoare_post_imp[where Q'="\<lambda>rv s. \<exists>rv'. rv = rv' \<and> st_tcb_at' (\<lambda>st. st = rv') t s"])
     apply simp
    apply (wp hoare_vcg_ex_lift)
   apply (clarsimp simp add: pred_tcb_at'_def obj_at'_def)
@@ -107,15 +107,15 @@ lemma activate_invs':
     apply (case_tac rv; simp add: isTS_defs split del: if_split cong: if_cong)
       apply (wp)
       apply (clarsimp simp: ct_in_state'_def)
-     apply (rule_tac Q="\<lambda>rv. invs' and ct_idle'" in hoare_post_imp, simp)
+     apply (rule_tac Q'="\<lambda>rv. invs' and ct_idle'" in hoare_post_imp, simp)
      apply (wp activateIdle_invs)
      apply (clarsimp simp: ct_in_state'_def)
-    apply (rule_tac Q="\<lambda>rv. invs' and ct_running' and sch_act_simple"
+    apply (rule_tac Q'="\<lambda>rv. invs' and ct_running' and sch_act_simple"
                  in hoare_post_imp, simp)
     apply (rule hoare_weaken_pre)
      apply (wp ct_in_state'_set asUser_ct sts_invs_minor'
           | wp (once) sch_act_simple_lift)+
-      apply (rule_tac Q="\<lambda>_. st_tcb_at' runnable' thread
+      apply (rule_tac Q'="\<lambda>_. st_tcb_at' runnable' thread
                              and sch_act_simple and invs'
                              and (\<lambda>s. thread = ksCurThread s)"
                in hoare_post_imp, clarsimp)
@@ -185,7 +185,7 @@ lemma setupReplyMaster_weak_sch_act_wf[wp]:
    \<lbrace>\<lambda>rv s. weak_sch_act_wf (ksSchedulerAction s) s\<rbrace>"
   apply (simp add: setupReplyMaster_def)
   apply (wp)
-    apply (rule_tac Q="\<lambda>_ s. weak_sch_act_wf (ksSchedulerAction s) s"
+    apply (rule_tac Q'="\<lambda>_ s. weak_sch_act_wf (ksSchedulerAction s) s"
                in hoare_post_imp, clarsimp)
     apply (wp)+
   apply assumption
@@ -211,11 +211,11 @@ lemma restart_corres:
               apply (wp set_thread_state_runnable_weak_valid_sched_action sts_st_tcb_at'
                         sts_st_tcb' sts_valid_objs'
                      | clarsimp simp: valid_tcb_state'_def | strengthen valid_objs'_valid_tcbs')+
-         apply (rule_tac Q="\<lambda>rv. valid_sched and cur_tcb and pspace_aligned and pspace_distinct"
+         apply (rule_tac Q'="\<lambda>rv. valid_sched and cur_tcb and pspace_aligned and pspace_distinct"
                          in hoare_strengthen_post)
           apply wp
          apply (fastforce simp: valid_sched_def valid_sched_action_def)
-        apply (rule_tac Q="\<lambda>rv. invs' and ex_nonz_cap_to' t" in hoare_strengthen_post)
+        apply (rule_tac Q'="\<lambda>rv. invs' and ex_nonz_cap_to' t" in hoare_strengthen_post)
          apply wp
         apply (clarsimp simp: invs'_def valid_state'_def sch_act_wf_weak valid_pspace'_def
                               valid_tcb_state'_def)
@@ -347,11 +347,11 @@ lemma invokeTCB_WriteRegisters_corres:
                                   valid_sched_valid_queues valid_objs'_valid_tcbs' invs_valid_objs'
                      | clarsimp simp: invs_def valid_state_def valid_sched_def invs'_def valid_state'_def
                                dest!: global'_no_ex_cap idle_no_ex_cap)+)[2]
-           apply (rule_tac Q="\<lambda>_. einvs and tcb_at dest and ex_nonz_cap_to dest" in hoare_post_imp)
+           apply (rule_tac Q'="\<lambda>_. einvs and tcb_at dest and ex_nonz_cap_to dest" in hoare_post_imp)
             apply (fastforce simp: invs_def valid_sched_weak_strg valid_sched_def valid_state_def
                              dest!: idle_no_ex_cap)
            prefer 2
-           apply (rule_tac Q="\<lambda>_. invs' and tcb_at' dest and ex_nonz_cap_to' dest" in hoare_post_imp)
+           apply (rule_tac Q'="\<lambda>_. invs' and tcb_at' dest and ex_nonz_cap_to' dest" in hoare_post_imp)
             apply (fastforce simp: sch_act_wf_weak invs'_def valid_state'_def dest!: global'_no_ex_cap)
            apply (wpsimp simp: archThreadGet_def)+
    apply fastforce
@@ -457,10 +457,10 @@ proof -
                     apply (rule_tac P=\<top> and P'=\<top> in corres_inst)
                     apply simp
                    apply (solves \<open>wp hoare_weak_lift_imp\<close>)+
-             apply (rule_tac Q="\<lambda>_. einvs and tcb_at dest" in hoare_post_imp)
+             apply (rule_tac Q'="\<lambda>_. einvs and tcb_at dest" in hoare_post_imp)
               apply (fastforce simp: invs_def valid_state_def valid_pspace_def valid_sched_weak_strg valid_sched_def)
              prefer 2
-             apply (rule_tac Q="\<lambda>_. invs' and tcb_at' dest" in hoare_post_imp)
+             apply (rule_tac Q'="\<lambda>_. invs' and tcb_at' dest" in hoare_post_imp)
               apply (fastforce simp: invs'_def valid_state'_def invs_weak_sch_act_wf cur_tcb'_def)
              apply ((wp mapM_x_wp' hoare_weak_lift_imp | (simp add: cur_tcb'_def[symmetric])+)+)[8]
          apply ((wp hoare_weak_lift_imp restart_invs' | wpc | clarsimp simp: if_apply_def2)+)[2]
@@ -528,7 +528,7 @@ lemma tcbSchedDequeue_not_queued:
    \<lbrace>\<lambda>rv. obj_at' (Not \<circ> tcbQueued) t\<rbrace>"
   apply (simp add: tcbSchedDequeue_def)
   apply (wp | simp)+
-  apply (rule_tac Q="\<lambda>rv. obj_at' (\<lambda>obj. tcbQueued obj = rv) t"
+  apply (rule_tac Q'="\<lambda>rv. obj_at' (\<lambda>obj. tcbQueued obj = rv) t"
                in hoare_post_imp)
    apply (clarsimp simp: obj_at'_def)
   apply (wp tg_sp' [where P=\<top>, simplified] | simp)+
@@ -1401,7 +1401,7 @@ proof -
   have B: "\<And>t v. \<lbrace>invs' and tcb_at' t\<rbrace> threadSet (tcbFaultHandler_update v) t \<lbrace>\<lambda>rv. invs'\<rbrace>"
     by (wp threadSet_invs_trivial | clarsimp simp: inQ_def)+
   note stuff = Z B out_invs_trivial hoare_case_option_wp
-    hoare_vcg_const_Ball_lift hoare_vcg_const_Ball_lift_R
+    hoare_vcg_const_Ball_lift hoare_vcg_const_Ball_liftE_R
     cap_delete_deletes cap_delete_valid_cap out_valid_objs
     cap_insert_objs
     cteDelete_deletes cteDelete_sch_act_simple
@@ -1436,7 +1436,7 @@ proof -
                   apply (rule corres_returnOkTT, simp)
                  apply wp
                 apply wp
-               apply (wpsimp wp: hoare_vcg_const_imp_lift_R hoare_vcg_const_imp_lift
+               apply (wpsimp wp: hoare_vcg_const_imp_liftE_R hoare_vcg_const_imp_lift
                                  hoare_vcg_all_liftE_R hoare_vcg_all_lift
                                  as_user_invs thread_set_ipc_tcb_cap_valid
                                  thread_set_tcb_ipc_buffer_cap_cleared_invs
@@ -1457,7 +1457,7 @@ proof -
                                  threadSet_invs_tcbIPCBuffer_update threadSet_cte_wp_at'
                       | strengthen simple_sched_action_sched_act_not)+
                 apply ((wpsimp wp: stuff hoare_vcg_all_liftE_R hoare_vcg_all_lift
-                                   hoare_vcg_const_imp_lift_R hoare_vcg_const_imp_lift
+                                   hoare_vcg_const_imp_liftE_R hoare_vcg_const_imp_lift
                                    threadSet_valid_objs' thread_set_not_state_valid_sched
                                    thread_set_tcb_ipc_buffer_cap_cleared_invs thread_set_cte_wp_at_trivial
                                    thread_set_no_cap_to_trivial getThreadBufferSlot_dom_tcb_cte_cases
@@ -1492,7 +1492,7 @@ proof -
                          in hoare_strengthen_postE_R[simplified validE_R_def, rotated])
              apply (case_tac g'; clarsimp simp: isCap_simps ; clarsimp cong:imp_cong)
             apply (wp add: stuff hoare_vcg_all_liftE_R hoare_vcg_all_lift
-                                 hoare_vcg_const_imp_lift_R hoare_vcg_const_imp_lift setMCPriority_invs'
+                                 hoare_vcg_const_imp_liftE_R hoare_vcg_const_imp_lift setMCPriority_invs'
                                  threadSet_valid_objs' thread_set_not_state_valid_sched setP_invs'
                                  typ_at_lifts [OF setPriority_typ_at']
                                  typ_at_lifts [OF setMCPriority_typ_at']
@@ -1570,15 +1570,15 @@ lemma tc_invs':
       apply (wpsimp wp: hoare_weak_lift_imp hoare_vcg_all_lift
                         checkCap_inv[where P="tcb_at' t" for t] assertDerived_wp_weak
                         threadSet_invs_trivial2 threadSet_tcb'  hoare_vcg_all_lift threadSet_cte_wp_at')+
-       apply (wpsimp wp: hoare_weak_lift_imp_R cteDelete_deletes
-                         hoare_vcg_all_liftE_R hoare_vcg_conj_liftE1 hoare_vcg_const_imp_lift_R hoare_vcg_propE_R
+       apply (wpsimp wp: hoare_weak_lift_impE_R cteDelete_deletes
+                         hoare_vcg_all_liftE_R hoare_vcg_conj_liftE1 hoare_vcg_const_imp_liftE_R hoare_vcg_propE_R
                          cteDelete_invs' cteDelete_invs' cteDelete_typ_at'_lifts)+
      apply (assumption | clarsimp cong: conj_cong imp_cong | (rule case_option_wp_None_returnOk)
             | wpsimp wp: hoare_weak_lift_imp hoare_vcg_all_lift checkCap_inv[where P="tcb_at' t" for t] assertDerived_wp_weak
                          hoare_vcg_imp_lift' hoare_vcg_all_lift checkCap_inv[where P="tcb_at' t" for t]
                          checkCap_inv[where P="valid_cap' c" for c] checkCap_inv[where P=sch_act_simple]
-                         hoare_vcg_const_imp_lift_R assertDerived_wp_weak hoare_weak_lift_imp_R cteDelete_deletes
-                         hoare_vcg_all_liftE_R hoare_vcg_conj_liftE1 hoare_vcg_const_imp_lift_R hoare_vcg_propE_R
+                         hoare_vcg_const_imp_liftE_R assertDerived_wp_weak hoare_weak_lift_impE_R cteDelete_deletes
+                         hoare_vcg_all_liftE_R hoare_vcg_conj_liftE1 hoare_vcg_const_imp_liftE_R hoare_vcg_propE_R
                          cteDelete_invs' cteDelete_typ_at'_lifts cteDelete_sch_act_simple)+
   apply (clarsimp simp: tcb_cte_cases_def cte_level_bits_def objBits_defs tcbIPCBufferSlot_def)
   by (auto dest!: isCapDs isReplyCapD isValidVTableRootD simp: isCap_simps)
@@ -2641,7 +2641,7 @@ lemma inv_tcb_IRQInactive:
   apply (rule hoare_pre)
    apply (wpc |
           wp withoutPreemption_R cteDelete_IRQInactive checkCap_inv
-             hoare_vcg_const_imp_lift_R cteDelete_irq_states'
+             hoare_vcg_const_imp_liftE_R cteDelete_irq_states'
              hoare_vcg_const_imp_lift |
           simp add: split_def)+
   done

--- a/proof/refine/AARCH64/Untyped_R.thy
+++ b/proof/refine/AARCH64/Untyped_R.thy
@@ -400,7 +400,7 @@ next
              apply (simp add: word_le_nat_alt)
             apply (simp add: unat_arith_simps)
            apply wpsimp+
-          apply (rule hoare_strengthen_post [where Q = "\<lambda>r. invs and valid_cap r and cte_at slot"])
+          apply (rule hoare_strengthen_post[where Q'="\<lambda>r. invs and valid_cap r and cte_at slot"])
            apply wp+
           apply (clarsimp simp: is_cap_simps bits_of_def cap_aligned_def
                                 valid_cap_def word_bits_def)
@@ -408,7 +408,7 @@ next
           apply (strengthen refl exI[mk_strg I E] exI[where x=d])+
           apply simp
          apply wp+
-         apply (rule hoare_strengthen_post [where Q = "\<lambda>r. invs' and cte_at' (cte_map slot)"])
+         apply (rule hoare_strengthen_post[where Q'="\<lambda>r. invs' and cte_at' (cte_map slot)"])
           apply wp+
          apply (clarsimp simp:invs_pspace_aligned' invs_pspace_distinct')
         apply (wp whenE_throwError_wp | wp (once) hoare_drop_imps)+
@@ -3167,7 +3167,7 @@ lemma createNewCaps_parent_helper:
                        (\<forall>tup\<in>set (zip (xs rv) rv).
                                 sameRegionAs (cteCap cte) (snd tup)))
     p\<rbrace>"
-  apply (rule hoare_post_imp [where Q="\<lambda>rv s. \<exists>cte. cte_wp_at' ((=) cte) p s
+  apply (rule hoare_post_imp[where Q'="\<lambda>rv s. \<exists>cte. cte_wp_at' ((=) cte) p s
                                            \<and> isUntypedCap (cteCap cte)
                                            \<and> (\<forall>tup\<in>set (zip (xs rv) rv).
                                 sameRegionAs (cteCap cte) (snd tup))"])
@@ -4564,7 +4564,7 @@ lemma resetUntypedCap_invs_etc:
               | strengthen invs_pspace_aligned' invs_pspace_distinct'
               | simp add: ct_in_state'_def
                           sch_act_simple_def
-              | rule hoare_vcg_conj_lift_R
+              | rule hoare_vcg_conj_liftE_R
               | wp (once) preemptionPoint_inv
               | wps
               | wp (once) ex_cte_cap_to'_pres)+
@@ -5240,7 +5240,7 @@ lemma insertNewCap_valid_irq_handlers:
 lemma insertNewCap_ct_idle_or_in_cur_domain'[wp]:
   "\<lbrace>ct_idle_or_in_cur_domain' and ct_active'\<rbrace> insertNewCap parent slot cap \<lbrace>\<lambda>_. ct_idle_or_in_cur_domain'\<rbrace>"
 apply (wp ct_idle_or_in_cur_domain'_lift_futz[where Q=\<top>])
-apply (rule_tac Q="\<lambda>_. obj_at' (\<lambda>tcb. tcbState tcb \<noteq> Structures_H.thread_state.Inactive) t and obj_at' (\<lambda>tcb. d = tcbDomain tcb) t"
+apply (rule_tac Q'="\<lambda>_. obj_at' (\<lambda>tcb. tcbState tcb \<noteq> Structures_H.thread_state.Inactive) t and obj_at' (\<lambda>tcb. d = tcbDomain tcb) t"
              in hoare_strengthen_post)
 apply (wp | clarsimp elim: obj_at'_weakenE)+
 apply (auto simp: obj_at'_def)

--- a/proof/refine/AARCH64/VSpace_R.thy
+++ b/proof/refine/AARCH64/VSpace_R.thy
@@ -907,7 +907,7 @@ lemma setVCPU_valid_arch':
 lemma setObject_vcpu_no_tcb_update:
   "\<lbrakk> vcpuTCBPtr (f vcpu) = vcpuTCBPtr vcpu \<rbrakk>
   \<Longrightarrow> \<lbrace> valid_objs' and ko_at' (vcpu :: vcpu) p\<rbrace> setObject p (f vcpu) \<lbrace> \<lambda>_. valid_objs' \<rbrace>"
-  apply (rule_tac Q="valid_objs' and (ko_at' vcpu p and valid_obj' (KOArch (KOVCPU vcpu)))" in hoare_pre_imp)
+  apply (rule_tac P'="valid_objs' and (ko_at' vcpu p and valid_obj' (KOArch (KOVCPU vcpu)))" in hoare_pre_imp)
    apply (clarsimp)
    apply (simp add: valid_obj'_def)
    apply (drule (1) ko_at_valid_objs', simp)
@@ -1843,7 +1843,7 @@ lemma deleteASID_corres [corres]:
                              wp: set_asid_pool_None_vmid_inv set_asid_pool_vspace_objs_unmap_single)
               apply (wp getASID_wp)+
            apply (rename_tac p pool pool' a b)
-           apply (rule_tac Q="\<lambda>_ s. invs s \<and>
+           apply (rule_tac Q'="\<lambda>_ s. invs s \<and>
                                     (\<exists>high. asid_table s high = Some p \<and>
                                             vmid_for_asid s (asid_of high (asid_low_bits_of asid)) =
                                               None)" in hoare_strengthen_post)

--- a/proof/refine/AARCH64/orphanage/Orphanage.thy
+++ b/proof/refine/AARCH64/orphanage/Orphanage.thy
@@ -558,7 +558,7 @@ lemma tcbSchedDequeue_no_orphans[wp]:
   apply (rule hoare_allI)
   apply (rename_tac tcb_ptr)
   apply (case_tac "tcb_ptr = tcbPtr")
-   apply (rule_tac Q="\<lambda>_ s. st_tcb_at' (\<lambda>state. \<not> is_active_thread_state state) tcbPtr s"
+   apply (rule_tac Q'="\<lambda>_ s. st_tcb_at' (\<lambda>state. \<not> is_active_thread_state state) tcbPtr s"
                 in hoare_post_imp)
     apply fastforce
    apply wpsimp
@@ -575,7 +575,7 @@ lemma switchToIdleThread_no_orphans' [wp]:
   apply (clarsimp simp: switchToIdleThread_def setCurThread_def AARCH64_H.switchToIdleThread_def)
   apply (simp add: no_orphans_disj all_queued_tcb_ptrs_def)
   apply (wpsimp wp: hoare_vcg_all_lift hoare_vcg_disj_lift
-                    hoare_drop_imp[where R="\<lambda>_. idleThreadNotQueued"] hoare_vcg_imp_lift')
+                    hoare_drop_imp[where Q'="\<lambda>_. idleThreadNotQueued"] hoare_vcg_imp_lift')
   apply (force simp: is_active_tcb_ptr_def st_tcb_at_neg' typ_at_tcb')
   done
 
@@ -862,7 +862,7 @@ proof -
      \<lbrace>\<lambda>_. no_orphans\<rbrace>"
     apply (wpsimp wp: scheduleChooseNewThread_no_orphans ssa_no_orphans
                       hoare_vcg_all_lift ThreadDecls_H_switchToThread_no_orphans)+
-     apply (rule_tac Q="\<lambda>_ s. (t = candidate \<longrightarrow> ksCurThread s = candidate) \<and>
+     apply (rule_tac Q'="\<lambda>_ s. (t = candidate \<longrightarrow> ksCurThread s = candidate) \<and>
                                (t \<noteq> candidate \<longrightarrow> sch_act_not t s)"
               in hoare_post_imp)
       apply (wpsimp wp: stt_nosch hoare_weak_lift_imp)+
@@ -1072,7 +1072,7 @@ lemma sendIPC_no_orphans [wp]:
             possibleSwitchTo_almost_no_orphans'
          | wpc
          | clarsimp simp: is_active_thread_state_def isRestart_def isRunning_def)+
-   apply (rule_tac Q="\<lambda>rv. no_orphans and valid_objs' and ko_at' rv epptr
+   apply (rule_tac Q'="\<lambda>rv. no_orphans and valid_objs' and ko_at' rv epptr
                            and (\<lambda>s. sch_act_wf (ksSchedulerAction s) s)" in hoare_post_imp)
     apply (fastforce simp: valid_objs'_def valid_obj'_def valid_ep'_def obj_at'_def)
    apply (wp get_ep_sp' | clarsimp)+
@@ -1277,7 +1277,7 @@ lemma cancelAllIPC_no_orphans [wp]:
                     and I="no_orphans and (\<lambda>s. \<forall>t\<in>set list. tcb_at' t s)"
                      in mapM_x_inv_wp2
              | clarsimp simp: valid_tcb_state'_def)+
-  apply (rule_tac Q="\<lambda>rv. no_orphans and valid_objs' and pspace_aligned' and pspace_distinct' and
+  apply (rule_tac Q'="\<lambda>rv. no_orphans and valid_objs' and pspace_aligned' and pspace_distinct' and
                           ko_at' rv epptr"
                  in hoare_post_imp)
    apply (fastforce simp: valid_obj'_def valid_ep'_def obj_at'_def)
@@ -1301,7 +1301,7 @@ lemma cancelAllSignals_no_orphans [wp]:
    apply (wp sts_valid_objs' set_ntfn_valid_objs' sts_st_tcb'
             hoare_vcg_const_Ball_lift tcbSchedEnqueue_almost_no_orphans|
           clarsimp simp: valid_tcb_state'_def)+
-  apply (rule_tac Q="\<lambda>rv. no_orphans and valid_objs' and pspace_aligned' and pspace_distinct' and
+  apply (rule_tac Q'="\<lambda>rv. no_orphans and valid_objs' and pspace_aligned' and pspace_distinct' and
                           ko_at' rv ntfn"
                  in hoare_post_imp)
    apply (fastforce simp: valid_obj'_def valid_ntfn'_def obj_at'_def)
@@ -1442,7 +1442,7 @@ lemma deleteASIDPool_no_orphans [wp]:
    \<lbrace> \<lambda>rv s. no_orphans s \<rbrace>"
   unfolding deleteASIDPool_def
   apply (wp | clarsimp)+
-     apply (rule_tac Q="\<lambda>rv s. no_orphans s" in hoare_post_imp)
+     apply (rule_tac Q'="\<lambda>rv s. no_orphans s" in hoare_post_imp)
       apply (clarsimp simp: no_orphans_def all_queued_tcb_ptrs_def
                             all_active_tcb_ptrs_def is_active_tcb_ptr_def)
      apply (wp mapM_wp_inv getObject_inv loadObject_default_inv | clarsimp)+
@@ -1541,7 +1541,7 @@ lemma cteRevoke_no_orphans [wp]:
   "\<lbrace> \<lambda>s. no_orphans s \<and> invs' s \<and> sch_act_simple s \<rbrace>
    cteRevoke ptr
    \<lbrace> \<lambda>rv s. no_orphans s \<rbrace>"
-  apply (rule_tac Q="\<lambda>rv s. no_orphans s \<and> invs' s \<and> sch_act_simple s" in hoare_strengthen_post)
+  apply (rule_tac Q'="\<lambda>rv s. no_orphans s \<and> invs' s \<and> sch_act_simple s" in hoare_strengthen_post)
    apply (wpsimp wp: cteRevoke_preservation cteDelete_invs' cteDelete_sch_act_simple)+
   done
 
@@ -1564,7 +1564,7 @@ lemma doReplyTransfer_no_orphans[wp]:
          | wpc | clarsimp simp: is_active_thread_state_def isRunning_def isRestart_def
          | wp (once) hoare_drop_imps
          | strengthen sch_act_wf_weak)+
-              apply (rule_tac Q="\<lambda>rv. invs' and no_orphans" in hoare_post_imp)
+              apply (rule_tac Q'="\<lambda>rv. invs' and no_orphans" in hoare_post_imp)
                apply (fastforce simp: inQ_def)
               apply (wp hoare_drop_imps | clarsimp)+
   apply (clarsimp simp:invs'_def valid_state'_def valid_pspace'_def)
@@ -1638,7 +1638,7 @@ lemma setPriority_no_orphans[wp]:
    \<lbrace>\<lambda>_. no_orphans\<rbrace>"
   unfolding setPriority_def
   apply wpsimp
-    apply (rule_tac Q="\<lambda>_ s. almost_no_orphans tptr s \<and> weak_sch_act_wf (ksSchedulerAction s) s" in hoare_post_imp)
+    apply (rule_tac Q'="\<lambda>_ s. almost_no_orphans tptr s \<and> weak_sch_act_wf (ksSchedulerAction s) s" in hoare_post_imp)
      apply clarsimp
      apply (clarsimp simp: is_active_tcb_ptr_runnable' pred_tcb_at'_def obj_at'_def
                            almost_no_orphans_no_orphans elim!: almost_no_orphans_no_orphans')
@@ -1690,7 +1690,7 @@ lemma tc_no_orphans:
                checkCap_inv[where P="valid_cap' c" for c] checkCap_inv[where P=sch_act_simple]
                checkCap_inv[where P=no_orphans] checkCap_inv[where P="tcb_at' a"]
                threadSet_cte_wp_at' hoare_vcg_all_liftE_R hoare_vcg_all_lift threadSet_no_orphans
-               hoare_vcg_const_imp_lift_R hoare_weak_lift_imp hoare_drop_imp threadSet_ipcbuffer_invs
+               hoare_vcg_const_imp_liftE_R hoare_weak_lift_imp hoare_drop_imp threadSet_ipcbuffer_invs
           | (simp add: locateSlotTCB_def locateSlotBasic_def objBits_def
                      objBitsKO_def tcbIPCBufferSlot_def tcb_cte_cases_def,
            wp hoare_return_sp)
@@ -1791,7 +1791,7 @@ lemma performASIDControlInvocation_no_orphans [wp]:
   apply (clarsimp simp: performASIDControlInvocation_def
                   split: asidcontrol_invocation.splits)
   apply (wp hoare_weak_lift_imp | clarsimp)+
-    apply (rule_tac Q="\<lambda>rv s. no_orphans s" in hoare_post_imp)
+    apply (rule_tac Q'="\<lambda>rv s. no_orphans s" in hoare_post_imp)
      apply (clarsimp simp: no_orphans_def all_active_tcb_ptrs_def
                            is_active_tcb_ptr_def all_queued_tcb_ptrs_def)
     apply (wp | clarsimp simp:placeNewObject_def2)+
@@ -1860,7 +1860,7 @@ lemma handleInvocation_no_orphans [wp]:
   unfolding handleInvocation_def
   apply (rule hoare_pre)
    apply (wp syscall_valid' setThreadState_isRestart_no_orphans | wpc | clarsimp)+
-          apply (rule_tac Q="\<lambda>state s. no_orphans s \<and> invs' s \<and>
+          apply (rule_tac Q'="\<lambda>state s. no_orphans s \<and> invs' s \<and>
                              (state = Structures_H.thread_state.Restart \<longrightarrow>
                               st_tcb_at' isRestart thread s)"
                        in hoare_post_imp)
@@ -1919,7 +1919,7 @@ notes if_cong[cong] shows
   apply (clarsimp simp: whenE_def split del: if_split | wp hoare_drop_imps getNotification_wp | wpc )+ (*takes a while*)
      apply (rule_tac Q'="\<lambda>rv s. no_orphans s \<and> invs' s" in hoare_strengthen_postE_R)
       apply (wp, fastforce)
-    apply (rule_tac Q="\<lambda>rv s. no_orphans s \<and> invs' s" in hoare_post_imp)
+    apply (rule_tac Q'="\<lambda>rv s. no_orphans s \<and> invs' s" in hoare_post_imp)
      apply (wp | clarsimp | fastforce)+
   done
 
@@ -1931,7 +1931,7 @@ lemma handleReply_no_orphans [wp]:
   unfolding handleReply_def
   apply (wpsimp wp: hoare_drop_imps)
      apply (wp (once) hoare_vcg_all_lift)
-      apply (rule_tac Q="\<lambda>rv s. no_orphans s \<and> invs' s \<and> tcb_at' thread s \<and>
+      apply (rule_tac Q'="\<lambda>rv s. no_orphans s \<and> invs' s \<and> tcb_at' thread s \<and>
                                 valid_cap' rv s" in hoare_post_imp)
        apply (wpsimp wp: hoare_drop_imps
                      simp: valid_cap'_def invs'_def cur_tcb'_def valid_state'_def)+

--- a/proof/refine/AARCH64/orphanage/Orphanage.thy
+++ b/proof/refine/AARCH64/orphanage/Orphanage.thy
@@ -1985,8 +1985,8 @@ theorem callKernel_no_orphans[wp]:
   apply (wpsimp wp: hoare_drop_imp[where f=activateThread] schedule_invs'
          (* getActiveIRQ can't return a non-kernel IRQ *)
          | wp (once) hoare_post_imp[
-                       where a="doMachineOp (getActiveIRQ True)"
-                         and Q="\<lambda>rv s. no_orphans s \<and> invs' s \<and> rv \<notin> Some ` non_kernel_IRQs"])+
+                       where f="doMachineOp (getActiveIRQ True)"
+                         and Q'="\<lambda>rv s. no_orphans s \<and> invs' s \<and> rv \<notin> Some ` non_kernel_IRQs"])+
   done
 
 end

--- a/proof/refine/ARM/Arch_R.thy
+++ b/proof/refine/ARM/Arch_R.thy
@@ -1659,8 +1659,8 @@ lemma arch_decodeInvocation_wf[wp]:
                 cong: list.case_cong prod.case_cong)
      apply (rule hoare_pre)
       apply (wpsimp simp: valid_arch_inv'_def valid_page_inv'_def)
-            apply (rule hoare_vcg_conj_lift_R,(wp ensureSafeMapping_inv)[1])+
-            apply (wpsimp wp: whenE_throwError_wp checkVP_wpR hoare_vcg_const_imp_lift_R
+            apply (rule hoare_vcg_conj_liftE_R,(wp ensureSafeMapping_inv)[1])+
+            apply (wpsimp wp: whenE_throwError_wp checkVP_wpR hoare_vcg_const_imp_liftE_R
                               hoare_drop_impE_R ensureSafeMapping_valid_slots_duplicated'
                               createMappingEntries_valid_pde_slots' findPDForASID_page_directory_at'
                         simp: valid_arch_inv'_def valid_page_inv'_def)+

--- a/proof/refine/ARM/CNodeInv_R.thy
+++ b/proof/refine/ARM/CNodeInv_R.thy
@@ -206,7 +206,7 @@ lemma decodeCNodeInvocation_corres:
                       apply (rule corres_trivial)
                       subgoal by (auto simp add: whenE_def, auto simp add: returnOk_def)
                      apply (wp | wpc | simp(no_asm))+
-                 apply (wp hoare_vcg_const_imp_lift_R hoare_vcg_const_imp_lift
+                 apply (wp hoare_vcg_const_imp_liftE_R hoare_vcg_const_imp_lift
                            hoare_vcg_all_liftE_R hoare_vcg_all_lift lsfco_cte_at' hoare_drop_imps
                                 | clarsimp)+
          subgoal by (auto elim!: valid_cnode_capI)
@@ -6101,7 +6101,7 @@ lemma reduceZombie_invs'':
           apply (wp | simp)+
          apply (rule getCTE_wp)
         apply (wp | simp)+
-      apply (rule_tac Q="\<lambda>cte s. rv = capZombiePtr cap +
+      apply (rule_tac Q'="\<lambda>cte s. rv = capZombiePtr cap +
                                       of_nat (capZombieNumber cap) * 2^cteSizeBits - 2^cteSizeBits
                               \<and> cte_wp_at' (\<lambda>c. c = cte) slot s \<and> invs' s
                               \<and> no_cte_prop Q s \<and> sch_act_simple s"
@@ -6424,8 +6424,8 @@ lemmas cteDelete_typ_at'_lifts [wp] = typ_at_lifts [OF cteDelete_typ_at']
 
 lemma cteDelete_cte_at:
   "\<lbrace>\<top>\<rbrace> cteDelete slot bool \<lbrace>\<lambda>rv. cte_at' slot\<rbrace>"
-  apply (rule_tac Q="\<lambda>s. cte_at' slot s \<or> \<not> cte_at' slot s"
-               in hoare_pre(1))
+  apply (rule_tac P'="\<lambda>s. cte_at' slot s \<or> \<not> cte_at' slot s"
+               in hoare_weaken_pre)
    apply (rule hoare_strengthen_post)
     apply (rule hoare_vcg_disj_lift)
      apply (rule typ_at_lifts, rule cteDelete_typ_at')
@@ -6464,7 +6464,7 @@ lemma cteDelete_cte_wp_at_invs:
       apply (clarsimp simp: cte_wp_at_ctes_of)
      apply wp
     apply (simp add: imp_conjR conj_comms)
-    apply (rule_tac Q="\<lambda>rv s. invs' s \<and> sch_act_simple s \<and>
+    apply (rule_tac Q'="\<lambda>rv s. invs' s \<and> sch_act_simple s \<and>
                    (fst rv \<longrightarrow>
                        cte_wp_at' (\<lambda>cte. removeable' slot s (cteCap cte)) slot s) \<and>
                    (fst rv \<longrightarrow>
@@ -6475,9 +6475,9 @@ lemma cteDelete_cte_wp_at_invs:
                                          cteCap cte = NullCap \<or>
                                          (\<exists>zb n. cteCap cte = Zombie slot zb n))
                                   slot s)"
-                and E="\<lambda>rv. \<top>" in hoare_strengthen_postE)
+                and E'="\<lambda>rv. \<top>" in hoare_strengthen_postE)
       apply (wp finaliseSlot_invs finaliseSlot_removeable finaliseSlot_sch_act_simple
-                hoare_drop_imps(2)[OF finaliseSlot_irqs])
+                hoare_drop_impE_R[OF finaliseSlot_irqs])
        apply (rule hoare_strengthen_postE_R, rule finaliseSlot_abort_cases)
        apply (clarsimp simp: cte_wp_at_ctes_of dest!: isCapDs)
       apply simp
@@ -6499,7 +6499,7 @@ lemma cteDelete_cte_wp_at_invs:
                              p s"
                in hoare_strengthen_postE_R)
     apply (wp finaliseSlot_invs finaliseSlot_removeable finaliseSlot_sch_act_simple
-              hoare_drop_imps(2)[OF finaliseSlot_irqs])
+              hoare_drop_impE_R[OF finaliseSlot_irqs])
     apply (rule hoare_strengthen_postE_R [OF finaliseSlot_cte_wp_at[where p=p and P=P]])
       apply simp+
     apply (clarsimp simp: cte_wp_at_ctes_of)
@@ -6684,7 +6684,7 @@ proof (induct rule: finalise_induct3)
           apply ((wp | simp add: locateSlot_conv)+)[2]
         apply (rule drop_spec_validE)
         apply simp
-        apply (rule_tac Q="\<lambda>rv s. revoke_progress_ord m (option_map capToRPO \<circ> cteCaps_of s)
+        apply (rule_tac Q'="\<lambda>rv s. revoke_progress_ord m (option_map capToRPO \<circ> cteCaps_of s)
                                      \<and> cte_wp_at' (\<lambda>cte. cteCap cte = fst rvb) sl s"
                          in hoare_post_imp)
          apply (clarsimp simp: o_def cte_wp_at_ctes_of capToRPO_def
@@ -7259,7 +7259,7 @@ next
                 apply (rule updateCap_corres)
                  apply simp
                 apply (simp add: is_cap_simps)
-               apply (rule_tac R="\<lambda>rv. cte_at' (cte_map ?target)" in hoare_post_add)
+               apply (rule_tac Q'="\<lambda>rv. cte_at' (cte_map ?target)" in hoare_post_add)
                apply (wp, (wp getCTE_wp)+)
               apply (clarsimp simp: cte_wp_at_ctes_of)
              apply (rule no_fail_pre, wp, simp)
@@ -7421,7 +7421,7 @@ lemma cteRevoke_typ_at':
 
 lemma cteRevoke_invs':
   "\<lbrace>invs' and sch_act_simple\<rbrace> cteRevoke ptr \<lbrace>\<lambda>rv. invs'\<rbrace>"
-  apply (rule_tac Q="\<lambda>rv. invs' and sch_act_simple" in hoare_strengthen_post)
+  apply (rule_tac Q'="\<lambda>rv. invs' and sch_act_simple" in hoare_strengthen_post)
   apply (wpsimp wp: cteRevoke_preservation cteDelete_invs' cteDelete_sch_act_simple)+
   done
 
@@ -8869,7 +8869,7 @@ proof (induct rule: finalise_spec_induct)
             apply (unfold Let_def split_def fst_conv snd_conv
                           case_Zombie_assert_fold haskell_fail_def)
             apply (wp getCTE_wp' preemptionPoint_invR| simp add: o_def irq_state_independent_HI)+
-            apply (rule hoare_post_imp [where Q="\<lambda>_. valid_irq_states'"])
+            apply (rule hoare_post_imp[where Q'="\<lambda>_. valid_irq_states'"])
              apply simp
             apply wp[1]
            apply (rule spec_strengthen_postE)
@@ -8912,7 +8912,7 @@ lemma cteDelete_irq_states':
   apply (simp add: cteDelete_def split_def)
   apply (wp whenE_wp)
    apply (rule hoare_strengthen_postE)
-     apply (rule hoare_valid_validE)
+     apply (rule valid_validE)
      apply (rule finaliseSlot_irq_states')
     apply simp
    apply simp

--- a/proof/refine/ARM/CNodeInv_R.thy
+++ b/proof/refine/ARM/CNodeInv_R.thy
@@ -6513,8 +6513,8 @@ lemma cteDelete_sch_act_simple:
      cteDelete slot exposed \<lbrace>\<lambda>rv. sch_act_simple\<rbrace>"
   apply (simp add: cteDelete_def whenE_def split_def)
   apply (wp hoare_drop_imps | simp)+
-  apply (rule_tac hoare_strengthen_postE [where Q="\<lambda>rv. sch_act_simple"
-                                       and E="\<lambda>rv. sch_act_simple"])
+  apply (rule_tac hoare_strengthen_postE [where Q'="\<lambda>rv. sch_act_simple"
+                                       and E'="\<lambda>rv. sch_act_simple"])
     apply (rule valid_validE)
     apply (wp finaliseSlot_sch_act_simple)
     apply simp+

--- a/proof/refine/ARM/CSpace_R.thy
+++ b/proof/refine/ARM/CSpace_R.thy
@@ -2147,7 +2147,7 @@ lemma cteInsert_mdb' [wp]:
   cteInsert cap src dest
   \<lbrace>\<lambda>_. valid_mdb'\<rbrace>"
   apply (simp add:valid_mdb'_def valid_mdb_ctes_def)
-  apply (rule_tac Q = "\<lambda>r s. valid_dlist (ctes_of s) \<and> irq_control (ctes_of s) \<and>
+  apply (rule_tac Q'="\<lambda>r s. valid_dlist (ctes_of s) \<and> irq_control (ctes_of s) \<and>
                no_0 (ctes_of s) \<and> mdb_chain_0 (ctes_of s) \<and>
                mdb_chunked (ctes_of s) \<and> untyped_mdb' (ctes_of s) \<and> untyped_inc' (ctes_of s) \<and>
                Q s" for Q
@@ -3963,12 +3963,12 @@ lemma setupReplyMaster_corres:
        apply (fastforce dest: pspace_relation_no_reply_caps
                              state_relation_pspace_relation)
       apply (clarsimp simp: cte_map_def tcb_cnode_index_def cte_wp_at_ctes_of)
-     apply (rule_tac Q="\<lambda>rv. einvs and tcb_at t and
+     apply (rule_tac Q'="\<lambda>rv. einvs and tcb_at t and
                              cte_wp_at ((=) rv) (t, tcb_cnode_index 2)"
                   in hoare_strengthen_post)
       apply (wp hoare_drop_imps get_cap_wp)
      apply (clarsimp simp: invs_def valid_state_def elim!: cte_wp_at_weakenE)
-    apply (rule_tac Q="\<lambda>rv. valid_pspace' and valid_mdb' and
+    apply (rule_tac Q'="\<lambda>rv. valid_pspace' and valid_mdb' and
                             cte_wp_at' ((=) rv) (cte_map (t, tcb_cnode_index 2))"
                  in hoare_strengthen_post)
      apply (wp hoare_drop_imps getCTE_wp')

--- a/proof/refine/ARM/Detype_R.thy
+++ b/proof/refine/ARM/Detype_R.thy
@@ -64,7 +64,7 @@ lemma descendants_range_in_lift':
   apply (simp only: Ball_def[unfolded imp_conv_disj])
   apply (rule hoare_pre)
    apply (wp hoare_vcg_all_lift hoare_vcg_disj_lift st cap_range)
-   apply (rule_tac Q = "\<lambda>r s. cte_wp_at' (\<lambda>c. capRange (cteCap c) \<inter> S = {}) x s"
+   apply (rule_tac Q'="\<lambda>r s. cte_wp_at' (\<lambda>c. capRange (cteCap c) \<inter> S = {}) x s"
       in hoare_strengthen_post)
     apply (wp cap_range)
    apply (clarsimp simp:cte_wp_at_ctes_of null_filter'_def)
@@ -1766,7 +1766,7 @@ lemma deleteObjects_invs':
 proof -
   show ?thesis
   apply (rule hoare_pre)
-   apply (rule_tac G="is_aligned ptr bits \<and> 2 \<le> bits \<and> bits \<le> word_bits" in hoare_grab_asm)
+   apply (rule_tac P'="is_aligned ptr bits \<and> 2 \<le> bits \<and> bits \<le> word_bits" in hoare_grab_asm)
    apply (clarsimp simp add: deleteObjects_def2)
    apply (simp add: freeMemory_def bind_assoc doMachineOp_bind ef_storeWord)
    apply (simp add: bind_assoc[where f="\<lambda>_. modify f" for f, symmetric])
@@ -4138,7 +4138,7 @@ lemma createNewCaps_pspace_no_overlap':
          apply simp+
     apply (simp add:range_cover_def)
    apply (simp add:range_cover.sz(1)[where 'a=32, folded word_bits_def])
-  apply (rule_tac Q = "\<lambda>r. pspace_no_overlap' (ptr + (1 + of_nat n << Types_H.getObjectSize ty us))
+  apply (rule_tac Q'="\<lambda>r. pspace_no_overlap' (ptr + (1 + of_nat n << Types_H.getObjectSize ty us))
                                               (Types_H.getObjectSize ty us) and
                            pspace_aligned' and pspace_distinct'" in hoare_strengthen_post)
    apply (case_tac ty)

--- a/proof/refine/ARM/Finalise_R.thy
+++ b/proof/refine/ARM/Finalise_R.thy
@@ -1787,7 +1787,7 @@ lemma isFinalCapability_inv:
   apply (simp add: isFinalCapability_def Let_def
               split del: if_split cong: if_cong)
   apply (rule hoare_pre, wp)
-   apply (rule hoare_post_imp [where Q="\<lambda>s. P"], simp)
+   apply (rule hoare_post_imp[where Q'="\<lambda>s. P"], simp)
    apply wp
   apply simp
   done
@@ -2445,7 +2445,7 @@ lemma deleteASID_invs'[wp]:
   apply (simp add: deleteASID_def cong: option.case_cong)
   apply (rule hoare_pre)
    apply (wp | wpc)+
-    apply (rule_tac Q="\<lambda>rv. valid_obj' (injectKO rv) and invs'"
+    apply (rule_tac Q'="\<lambda>rv. valid_obj' (injectKO rv) and invs'"
               in hoare_post_imp)
      apply (rename_tac rv s)
      apply (clarsimp split: if_split_asm del: subsetI)
@@ -2727,7 +2727,7 @@ lemma cancelIPC_bound_tcb_at'[wp]:
   apply (simp add: getThreadReplySlot_def locateSlot_conv liftM_def)
   apply (rule hoare_pre)
    apply (wp capDeleteOne_bound_tcb_at' getCTE_ctes_of)
-   apply (rule_tac Q="\<lambda>_. bound_tcb_at' P tptr" in hoare_post_imp)
+   apply (rule_tac Q'="\<lambda>_. bound_tcb_at' P tptr" in hoare_post_imp)
    apply (clarsimp simp: capHasProperty_def cte_wp_at_ctes_of)
    apply (wp threadSet_pred_tcb_no_state | simp)+
   done

--- a/proof/refine/ARM/Interrupt_R.thy
+++ b/proof/refine/ARM/Interrupt_R.thy
@@ -391,7 +391,7 @@ lemma invokeIRQHandler_corres:
        apply simp
        apply (rule corres_split_nor[OF cap_delete_one_corres])
          apply (rule cteInsert_corres, simp+)
-        apply (rule_tac Q="\<lambda>rv s. einvs s \<and> cte_wp_at (\<lambda>c. c = cap.NullCap) irq_slot s
+        apply (rule_tac Q'="\<lambda>rv s. einvs s \<and> cte_wp_at (\<lambda>c. c = cap.NullCap) irq_slot s
                                   \<and> (a, b) \<noteq> irq_slot
                                   \<and> cte_wp_at (is_derived (cdt s) (a, b) cap) (a, b) s"
                       in hoare_post_imp)
@@ -805,7 +805,7 @@ lemma timerTick_invs'[wp]:
   apply (wpsimp wp: threadSet_invs_trivial threadSet_pred_tcb_no_state
                     rescheduleRequired_all_invs_but_ct_not_inQ
               simp: tcb_cte_cases_def)
-      apply (rule_tac Q="\<lambda>rv. invs'" in hoare_post_imp)
+      apply (rule_tac Q'="\<lambda>rv. invs'" in hoare_post_imp)
        apply (clarsimp simp: invs'_def valid_state'_def)
       apply (simp add: decDomainTime_def)
       apply wp
@@ -816,7 +816,7 @@ lemma timerTick_invs'[wp]:
                            hoare_vcg_imp_lift threadSet_ct_idle_or_in_cur_domain')+
             apply (rule hoare_strengthen_post[OF tcbSchedAppend_all_invs_but_ct_not_inQ'])
             apply (wpsimp simp: invs'_def valid_state'_def valid_pspace'_def sch_act_wf_weak)+
-           apply (rule_tac Q="\<lambda>_. invs'" in hoare_strengthen_post)
+           apply (rule_tac Q'="\<lambda>_. invs'" in hoare_strengthen_post)
             apply (wpsimp wp: threadSet_pred_tcb_no_state threadSet_tcbDomain_triv
                               threadSet_valid_objs' threadSet_timeslice_invs)+
            apply (clarsimp simp: invs'_def valid_state'_def valid_pspace'_def)
@@ -854,7 +854,7 @@ lemma hint_invs[wp]:
   apply (rule conjI; rule impI)
    apply (wp dmo_maskInterrupt_True getCTE_wp'
           | wpc | simp add: doMachineOp_bind maskIrqSignal_def )+
-      apply (rule_tac Q="\<lambda>rv. invs'" in hoare_post_imp)
+      apply (rule_tac Q'="\<lambda>rv. invs'" in hoare_post_imp)
        apply (clarsimp simp: cte_wp_at_ctes_of ex_nonz_cap_to'_def)
        apply fastforce
       apply (wp threadSet_invs_trivial | simp add: inQ_def handleReservedIRQ_def)+

--- a/proof/refine/ARM/IpcCancel_R.thy
+++ b/proof/refine/ARM/IpcCancel_R.thy
@@ -927,7 +927,7 @@ lemma (in delete_one_conc_pre) cancelIPC_sch_act_simple[wp]:
   apply (wp hoare_drop_imps delete_one_sch_act_simple
        | simp add: getThreadReplySlot_def | wpcw
        | rule sch_act_simple_lift
-       | (rule_tac Q="\<lambda>rv. sch_act_simple" in hoare_post_imp, simp))+
+       | (rule_tac Q'="\<lambda>rv. sch_act_simple" in hoare_post_imp, simp))+
   done
 
 lemma cancelSignal_st_tcb_at:
@@ -937,7 +937,7 @@ lemma cancelSignal_st_tcb_at:
    \<lbrace>\<lambda>rv. st_tcb_at' P t\<rbrace>"
   apply (simp add: cancelSignal_def Let_def list_case_If)
   apply (wp sts_st_tcb_at'_cases hoare_vcg_const_imp_lift
-            hoare_drop_imp[where R="%rv s. P' rv" for P'])
+            hoare_drop_imp[where Q'="%rv s. P' rv" for P'])
    apply clarsimp+
   done
 
@@ -1026,7 +1026,7 @@ lemma (in delete_one_conc_pre) cancelIPC_tcb_at_runnable':
             in bind_wp)
     apply(case_tac rv; simp)
    apply (wpsimp wp: sts_pred_tcb_neq')+
-           apply (rule_tac Q="\<lambda>rv. ?PRE" in hoare_post_imp, fastforce)
+           apply (rule_tac Q'="\<lambda>rv. ?PRE" in hoare_post_imp, fastforce)
            apply (wp cteDeleteOne_tcb_at_runnable'
                     threadSet_pred_tcb_no_state
                     cancelSignal_tcb_at_runnable'
@@ -1129,7 +1129,7 @@ lemma sts_weak_sch_act_wf[wp]:
   including classic_wp_pre
   apply (simp add: setThreadState_def)
   apply (wp rescheduleRequired_weak_sch_act_wf)
-  apply (rule_tac Q="\<lambda>_ s. weak_sch_act_wf (ksSchedulerAction s) s" in hoare_post_imp, simp)
+  apply (rule_tac Q'="\<lambda>_ s. weak_sch_act_wf (ksSchedulerAction s) s" in hoare_post_imp, simp)
   apply (simp add: weak_sch_act_wf_def)
   apply (wp hoare_vcg_all_lift)
    apply (wps threadSet_nosch)
@@ -1257,11 +1257,11 @@ lemma (in delete_one) suspend_corres:
            apply wp
           apply (wpsimp wp: sts_valid_objs')
           apply (wpsimp simp: update_restart_pc_def updateRestartPC_def valid_tcb_state'_def)+
-       apply (rule hoare_post_imp[where Q = "\<lambda>rv s. einvs s \<and> tcb_at t s"])
+       apply (rule hoare_post_imp[where Q'="\<lambda>rv s. einvs s \<and> tcb_at t s"])
         apply (simp add: invs_implies invs_strgs valid_queues_in_correct_ready_q
                          valid_queues_ready_qs_distinct valid_sched_def)
        apply wp
-      apply (rule hoare_post_imp[where Q = "\<lambda>_ s. invs' s \<and> tcb_at' t s"])
+      apply (rule hoare_post_imp[where Q'="\<lambda>_ s. invs' s \<and> tcb_at' t s"])
        apply (fastforce simp: invs'_def valid_tcb_state'_def)
       apply (wpsimp simp: update_restart_pc_def updateRestartPC_def)+
    apply fastforce+
@@ -1307,7 +1307,7 @@ lemma (in delete_one_conc) suspend_invs'[wp]:
   apply (simp add: suspend_def)
   apply (wpsimp wp: sts_invs_minor' gts_wp' simp: updateRestartPC_def
          | strengthen no_refs_simple_strg')+
-   apply (rule_tac Q="\<lambda>_. invs' and sch_act_simple and st_tcb_at' simple' t
+   apply (rule_tac Q'="\<lambda>_. invs' and sch_act_simple and st_tcb_at' simple' t
                           and (\<lambda>s. t \<noteq> ksIdleThread s)"
                 in hoare_post_imp)
     apply clarsimp
@@ -1337,7 +1337,7 @@ lemma (in delete_one_conc_pre) suspend_sch_act_simple[wp]:
 lemma (in delete_one_conc) suspend_objs':
   "\<lbrace>invs' and sch_act_simple and tcb_at' t and (\<lambda>s. t \<noteq> ksIdleThread s)\<rbrace>
    suspend t \<lbrace>\<lambda>rv. valid_objs'\<rbrace>"
-  apply (rule_tac Q="\<lambda>_. invs'" in hoare_strengthen_post)
+  apply (rule_tac Q'="\<lambda>_. invs'" in hoare_strengthen_post)
    apply (wp suspend_invs')
   apply fastforce
   done
@@ -1450,7 +1450,7 @@ proof -
         apply (rule ep_cancel_corres_helper)
        apply (rule mapM_x_wp')
        apply (wp weak_sch_act_wf_lift_linear set_thread_state_runnable_weak_valid_sched_action | simp)+
-      apply (rule_tac R="\<lambda>_ s. \<forall>x\<in>set list. tcb_at' x s \<and> valid_objs' s \<and> pspace_aligned' s \<and> pspace_distinct' s"
+      apply (rule_tac Q'="\<lambda>_ s. \<forall>x\<in>set list. tcb_at' x s \<and> valid_objs' s \<and> pspace_aligned' s \<and> pspace_distinct' s"
                    in hoare_post_add)
       apply (rule mapM_x_wp')
       apply ((wpsimp wp: hoare_vcg_const_Ball_lift mapM_x_wp' sts_st_tcb' sts_valid_objs'
@@ -1510,7 +1510,7 @@ lemma cancelAllSignals_corres:
                  set_thread_state_runnable_weak_valid_sched_action
             | simp)+
       apply (rename_tac list)
-      apply (rule_tac R="\<lambda>_ s. (\<forall>x\<in>set list. tcb_at' x s) \<and> valid_objs' s
+      apply (rule_tac Q'="\<lambda>_ s. (\<forall>x\<in>set list. tcb_at' x s) \<and> valid_objs' s
                                \<and> sym_heap_sched_pointers s \<and> valid_sched_pointers s \<and> valid_objs' s
                                \<and> pspace_aligned' s \<and> pspace_distinct' s"
                    in hoare_post_add)
@@ -1557,7 +1557,7 @@ proof -
   show ?thesis
   apply (simp add: setThreadState_def)
   apply (wpsimp wp: hoare_vcg_imp_lift [OF nrct])
-   apply (rule_tac Q="\<lambda>_. ?PRE" in hoare_post_imp)
+   apply (rule_tac Q'="\<lambda>_. ?PRE" in hoare_post_imp)
     apply (clarsimp)
    apply (rule hoare_convert_imp [OF threadSet_nosch threadSet_ct])
   apply assumption
@@ -1825,7 +1825,7 @@ lemma cancelAllIPC_valid_objs'[wp]:
   apply (rule bind_wp [OF _ get_ep_sp'])
   apply (rule hoare_pre)
    apply (wp set_ep_valid_objs' setSchedulerAction_valid_objs')
-    apply (rule_tac Q="\<lambda>_ s. valid_objs' s \<and> pspace_aligned' s \<and> pspace_distinct' s
+    apply (rule_tac Q'="\<lambda>_ s. valid_objs' s \<and> pspace_aligned' s \<and> pspace_distinct' s
                              \<and> (\<forall>x\<in>set (epQueue ep). tcb_at' x s)"
                     in hoare_post_imp)
      apply simp
@@ -1851,7 +1851,7 @@ lemma cancelAllSignals_valid_objs'[wp]:
     apply (wp, simp)
    apply (wp, simp)
   apply (rename_tac list)
-  apply (rule_tac Q="\<lambda>rv s. valid_objs' s \<and> (\<forall>x\<in>set list. tcb_at' x s)"
+  apply (rule_tac Q'="\<lambda>rv s. valid_objs' s \<and> (\<forall>x\<in>set list. tcb_at' x s)"
                   in hoare_post_imp)
    apply (simp add: valid_ntfn'_def)
   apply (simp add: Ball_def)
@@ -2155,7 +2155,7 @@ lemma cancelBadgedSends_corres:
     apply (rule corres_split_nor[OF setEndpoint_corres])
        apply (simp add: ep_relation_def)
       apply (rule corres_split_eqr[OF _ _ _ hoare_post_add
-                                             [where R="\<lambda>_. valid_objs' and pspace_aligned'
+                                             [where Q'="\<lambda>_. valid_objs' and pspace_aligned'
                                                            and pspace_distinct'"]])
          apply (rule_tac S="(=)"
                      and Q="\<lambda>xs s. (\<forall>x \<in> set xs. (epptr, TCBBlockedSend) \<in> state_refs_of s x) \<and>

--- a/proof/refine/ARM/Ipc_R.thy
+++ b/proof/refine/ARM/Ipc_R.thy
@@ -478,7 +478,7 @@ next
         apply clarsimp
         apply assumption
        apply (subst imp_conjR)
-       apply (rule hoare_vcg_conj_liftE_R)
+       apply (rule hoare_vcg_conj_liftE_R')
         apply (rule derive_cap_is_derived)
        apply (wp derive_cap_is_derived_foo)+
       apply (simp split del: if_split)
@@ -490,7 +490,7 @@ next
        apply clarsimp
        apply assumption
       apply (subst imp_conjR)
-      apply (rule hoare_vcg_conj_liftE_R)
+      apply (rule hoare_vcg_conj_liftE_R')
        apply (rule hoare_strengthen_postE_R[OF deriveCap_derived])
        apply (clarsimp simp:cte_wp_at_ctes_of)
       apply (wp deriveCap_derived_foo)
@@ -602,7 +602,7 @@ lemma cteInsert_assume_Null:
    apply (rule bind_wp[OF _ getCTE_sp])+
    apply (rule hoare_name_pre_state)
    apply (clarsimp simp: cte_wp_at_ctes_of)
-  apply (erule hoare_pre(1))
+  apply (erule hoare_weaken_pre)
   apply simp
   done
 
@@ -1759,7 +1759,7 @@ declare asUser_global_refs' [wp]
 lemma lec_valid_cap' [wp]:
   "\<lbrace>valid_objs'\<rbrace> lookupExtraCaps thread xa mi \<lbrace>\<lambda>rv s. (\<forall>x\<in>set rv. s \<turnstile>' fst x)\<rbrace>, -"
   apply (rule hoare_pre, rule hoare_strengthen_postE_R)
-    apply (rule hoare_vcg_conj_lift_R[where R=valid_objs' and S="\<lambda>_. valid_objs'"])
+    apply (rule hoare_vcg_conj_liftE_R[where R=valid_objs' and S="\<lambda>_. valid_objs'"])
      apply (rule lookupExtraCaps_srcs)
     apply wp
    apply (clarsimp simp: cte_wp_at_ctes_of)
@@ -2134,7 +2134,7 @@ lemma doReplyTransfer_corres:
           apply (fastforce)
          apply (clarsimp simp:is_cap_simps)
         apply (wp weak_valid_sched_action_lift)+
-       apply (rule_tac Q="\<lambda>_ s. valid_objs' s \<and> cur_tcb' s \<and> tcb_at' receiver s
+       apply (rule_tac Q'="\<lambda>_ s. valid_objs' s \<and> cur_tcb' s \<and> tcb_at' receiver s
                                 \<and> sch_act_wf (ksSchedulerAction s) s
                                 \<and> sym_heap_sched_pointers s \<and> valid_sched_pointers s
                                 \<and> pspace_aligned' s \<and> pspace_distinct' s"
@@ -2191,7 +2191,7 @@ lemma doReplyTransfer_corres:
                          threadSet_tcbDomain_triv threadSet_valid_objs'
                          threadSet_sched_pointers threadSet_valid_sched_pointers
                     | simp add: valid_tcb_state'_def)+
-     apply (rule_tac Q="\<lambda>_. valid_sched and cur_tcb and tcb_at sender and tcb_at receiver and
+     apply (rule_tac Q'="\<lambda>_. valid_sched and cur_tcb and tcb_at sender and tcb_at receiver and
                             valid_objs and pspace_aligned and pspace_distinct"
                      in hoare_strengthen_post [rotated], clarsimp)
      apply (wp)
@@ -2199,7 +2199,7 @@ lemma doReplyTransfer_corres:
       apply (assumption)
      apply (rule conjI, clarsimp)
      apply (clarsimp simp add: invs_def valid_state_def valid_pspace_def)
-    apply (rule_tac Q="\<lambda>_. tcb_at' sender and tcb_at' receiver and invs'"
+    apply (rule_tac Q'="\<lambda>_. tcb_at' sender and tcb_at' receiver and invs'"
                     in hoare_strengthen_post [rotated])
      apply (solves\<open>auto simp: invs'_def valid_state'_def\<close>)
     apply wp
@@ -2281,14 +2281,14 @@ lemma setupCallerCap_corres:
                               tcb_cnode_index_def cte_level_bits_def)
             apply (simp add: cte_map_def tcbCallerSlot_def
                              tcb_cnode_index_def cte_level_bits_def)
-           apply (rule_tac R="\<lambda>rv. cte_at' (receiver + 2 ^ cte_level_bits * tcbCallerSlot)"
+           apply (rule_tac Q'="\<lambda>rv. cte_at' (receiver + 2 ^ cte_level_bits * tcbCallerSlot)"
                     in hoare_post_add)
 
            apply (wp, (wp getSlotCap_wp)+)
           apply blast
          apply (rule no_fail_pre, wp)
          apply (clarsimp simp: cte_wp_at'_def cte_at'_def)
-        apply (rule_tac R="\<lambda>rv. cte_at' (sender + 2 ^ cte_level_bits * tcbReplySlot)"
+        apply (rule_tac Q'="\<lambda>rv. cte_at' (sender + 2 ^ cte_level_bits * tcbReplySlot)"
                      in hoare_post_add)
         apply (wp, (wp getCTE_wp')+)
        apply blast
@@ -2628,7 +2628,7 @@ lemma sendSignal_corres:
                                valid_queues_in_correct_ready_q valid_queues_ready_qs_distinct
                                valid_sched_valid_queues
                   | simp add: valid_tcb_state_def)+
-         apply (rule_tac Q="\<lambda>rv. invs' and tcb_at' a" in hoare_strengthen_post)
+         apply (rule_tac Q'="\<lambda>rv. invs' and tcb_at' a" in hoare_strengthen_post)
           apply wp
          apply (fastforce simp: invs'_def valid_state'_def sch_act_wf_weak valid_tcb_state'_def)
         apply (rule setNotification_corres)
@@ -2656,7 +2656,7 @@ lemma sendSignal_corres:
           apply (rule corres_split[OF asUser_setRegister_corres])
             apply (rule possibleSwitchTo_corres)
            apply ((wp | simp)+)[1]
-          apply (rule_tac Q="\<lambda>_. (\<lambda>s. sch_act_wf (ksSchedulerAction s) s) and
+          apply (rule_tac Q'="\<lambda>_. (\<lambda>s. sch_act_wf (ksSchedulerAction s) s) and
                                  cur_tcb' and
                                  st_tcb_at' runnable' (hd list) and valid_objs' and
                                  sym_heap_sched_pointers and valid_sched_pointers and
@@ -2843,7 +2843,7 @@ lemma cancelIPC_nonz_cap_to'[wp]:
        | wpc
        | simp
        | clarsimp elim!: cte_wp_at_weakenE'
-       | rule hoare_post_imp[where Q="\<lambda>rv. ex_nonz_cap_to' p"])+
+       | rule hoare_post_imp[where Q'="\<lambda>rv. ex_nonz_cap_to' p"])+
   done
 
 
@@ -2923,7 +2923,7 @@ proof -
           apply (wpc)
            apply (wp | simp)+
        apply (wpc, wp+)
-     apply (rule_tac Q="\<lambda>_. ?PRE t'" in hoare_post_imp, clarsimp)
+     apply (rule_tac Q'="\<lambda>_. ?PRE t'" in hoare_post_imp, clarsimp)
      apply (wp)
     apply simp
     done
@@ -2935,7 +2935,7 @@ proof -
     apply (wp)
         apply (wp hoare_convert_imp)[1]
        apply (wp)
-      apply (rule_tac Q="\<lambda>_. ?PRE t'" in hoare_post_imp, clarsimp)
+      apply (rule_tac Q'="\<lambda>_. ?PRE t'" in hoare_post_imp, clarsimp)
       apply (wp hoare_convert_imp | simp)+
      done
   show ?thesis
@@ -2948,16 +2948,16 @@ proof -
         apply (wp)+
            apply (wp hoare_convert_imp)[1]
           apply (wpc, wp+)
-        apply (rule_tac Q="\<lambda>_. ?PRE t'" in hoare_post_imp, clarsimp)
+        apply (rule_tac Q'="\<lambda>_. ?PRE t'" in hoare_post_imp, clarsimp)
         apply (wp cdo)+
-         apply (rule_tac Q="\<lambda>_. ?PRE t'" in hoare_post_imp, clarsimp)
+         apply (rule_tac Q'="\<lambda>_. ?PRE t'" in hoare_post_imp, clarsimp)
          apply ((wp aipc hoare_convert_imp)+)[6]
     apply (wp)
        apply (wp hoare_convert_imp)[1]
       apply (wpc, wp+)
-    apply (rule_tac Q="\<lambda>_. ?PRE t'" in hoare_post_imp, clarsimp)
+    apply (rule_tac Q'="\<lambda>_. ?PRE t'" in hoare_post_imp, clarsimp)
     apply (wp)
-   apply (rule_tac Q="\<lambda>_. ?PRE t'" in hoare_post_imp, clarsimp)
+   apply (rule_tac Q'="\<lambda>_. ?PRE t'" in hoare_post_imp, clarsimp)
    apply (wp)
   apply simp
   done
@@ -3221,7 +3221,7 @@ lemma receiveIPC_corres:
                                              valid_sched_action_def)
                      apply (clarsimp split: if_split_asm)
                     apply (clarsimp | wp do_ipc_transfer_tcb_caps)+
-                   apply (rule_tac Q="\<lambda>_ s. sch_act_wf (ksSchedulerAction s) s
+                   apply (rule_tac Q'="\<lambda>_ s. sch_act_wf (ksSchedulerAction s) s
                                             \<and> sym_heap_sched_pointers s \<and> valid_sched_pointers s
                                             \<and> pspace_aligned' s \<and> pspace_distinct' s"
                                 in hoare_post_imp)
@@ -3484,7 +3484,7 @@ lemma setupCallerCap_vp[wp]:
   apply (simp add: valid_pspace'_def setupCallerCap_def getThreadCallerSlot_def
                    getThreadReplySlot_def locateSlot_conv getSlotCap_def)
   apply (wp getCTE_wp)
-  apply (rule_tac Q="\<lambda>_. valid_pspace' and
+  apply (rule_tac Q'="\<lambda>_. valid_pspace' and
                          tcb_at' sender and tcb_at' rcvr"
                   in hoare_post_imp)
    apply (clarsimp simp: valid_cap'_def o_def cte_wp_at_ctes_of isCap_simps
@@ -3517,7 +3517,7 @@ lemma setupCallerCap_ifunsafe[wp]:
   apply (wp getSlotCap_cte_wp_at
        | simp add: unique_master_reply_cap' | strengthen eq_imp_strg
        | wp (once) hoare_drop_imp[where f="getCTE rs" for rs])+
-   apply (rule_tac Q="\<lambda>rv. valid_objs' and tcb_at' rcvr and ex_nonz_cap_to' rcvr"
+   apply (rule_tac Q'="\<lambda>rv. valid_objs' and tcb_at' rcvr and ex_nonz_cap_to' rcvr"
                 in hoare_post_imp)
     apply (clarsimp simp: ex_nonz_tcb_cte_caps' tcbCallerSlot_def
                           objBits_def objBitsKO_def dom_def cte_level_bits_def)
@@ -3685,7 +3685,7 @@ lemma completeSignal_invs:
   apply (rule bind_wp[OF _ get_ntfn_sp'])
   apply (rule hoare_pre)
    apply (wp set_ntfn_minor_invs' | wpc | simp)+
-    apply (rule_tac Q="\<lambda>_ s. (state_refs_of' s ntfnptr = ntfn_bound_refs' (ntfnBoundTCB ntfn))
+    apply (rule_tac Q'="\<lambda>_ s. (state_refs_of' s ntfnptr = ntfn_bound_refs' (ntfnBoundTCB ntfn))
                            \<and> ntfn_at' ntfnptr s
                            \<and> valid_ntfn' (ntfnObj_update (\<lambda>_. Structures_H.ntfn.IdleNtfn) ntfn) s
                            \<and> ((\<exists>y. ntfnBoundTCB ntfn = Some y) \<longrightarrow> ex_nonz_cap_to' ntfnptr s)
@@ -3715,7 +3715,7 @@ lemma setupCallerCap_urz[wp]:
                    getThreadCallerSlot_def getThreadReplySlot_def
                    locateSlot_conv)
   apply (wp getCTE_wp')
-  apply (rule_tac Q="\<lambda>_. untyped_ranges_zero' and valid_mdb' and valid_objs'" in hoare_post_imp)
+  apply (rule_tac Q'="\<lambda>_. untyped_ranges_zero' and valid_mdb' and valid_objs'" in hoare_post_imp)
    apply (clarsimp simp: cte_wp_at_ctes_of cteCaps_of_def untyped_derived_eq_def
                          isCap_simps)
   apply (wp sts_valid_pspace_hangers)
@@ -3762,7 +3762,7 @@ lemma ri_invs' [wp]:
   apply (rule bind_wp [OF _ gbn_sp'])
   apply (rule bind_wp)
   (* set up precondition for old proof *)
-   apply (rule_tac R="ko_at' ep (capEPPtr cap) and ?pre" in hoare_vcg_if_split)
+   apply (rule_tac P''="ko_at' ep (capEPPtr cap) and ?pre" in hoare_vcg_if_split)
     apply (wp completeSignal_invs)
    apply (case_tac ep)
      \<comment> \<open>endpoint = RecvEP\<close>
@@ -4049,9 +4049,9 @@ lemma si_invs'[wp]:
                hoare_convert_imp [OF setEndpoint_nosch setEndpoint_ct']
                hoare_drop_imp [where f="threadGet tcbFault t"]
              | rule_tac f="getThreadState a" in hoare_drop_imp
-             | wp (once) hoare_drop_imp[where R="\<lambda>_ _. call"]
-               hoare_drop_imp[where R="\<lambda>_ _. \<not> call"]
-               hoare_drop_imp[where R="\<lambda>_ _. cg"]
+             | wp (once) hoare_drop_imp[where Q'="\<lambda>_ _. call"]
+               hoare_drop_imp[where Q'="\<lambda>_ _. \<not> call"]
+               hoare_drop_imp[where Q'="\<lambda>_ _. cg"]
              | simp    add: valid_tcb_state'_def case_bool_If
                             case_option_If
                       cong: if_cong

--- a/proof/refine/ARM/Ipc_R.thy
+++ b/proof/refine/ARM/Ipc_R.thy
@@ -52,7 +52,7 @@ lemma lsfco_cte_at':
    apply (wp)
   apply (clarsimp simp: split_def unlessE_def
              split del: if_split)
-  apply (wp hoare_drop_imps throwE_R)
+  apply (wpsimp wp: hoare_drop_imps throwE_R)
   done
 
 declare unifyFailure_wp [wp]
@@ -1759,7 +1759,7 @@ declare asUser_global_refs' [wp]
 lemma lec_valid_cap' [wp]:
   "\<lbrace>valid_objs'\<rbrace> lookupExtraCaps thread xa mi \<lbrace>\<lambda>rv s. (\<forall>x\<in>set rv. s \<turnstile>' fst x)\<rbrace>, -"
   apply (rule hoare_pre, rule hoare_strengthen_postE_R)
-    apply (rule hoare_vcg_conj_liftE_R[where R=valid_objs' and S="\<lambda>_. valid_objs'"])
+    apply (rule hoare_vcg_conj_liftE_R[where P'=valid_objs' and Q'="\<lambda>_. valid_objs'"])
      apply (rule lookupExtraCaps_srcs)
     apply wp
    apply (clarsimp simp: cte_wp_at_ctes_of)

--- a/proof/refine/ARM/PageTableDuplicates.thy
+++ b/proof/refine/ARM/PageTableDuplicates.thy
@@ -635,7 +635,7 @@ lemma copyGlobalMappings_ksPSpace_stable:
   apply (case_tac "\<not> is_aligned x 2")
    apply (rule hoare_name_pre_state)
    apply (clarsimp)
-   apply (rule_tac Q = "\<lambda>r s. is_aligned (armKSGlobalPD (ksArchState s)) 2
+   apply (rule_tac Q'="\<lambda>r s. is_aligned (armKSGlobalPD (ksArchState s)) 2
       \<and> pspace_aligned' s" in hoare_post_imp)
     apply (frule_tac x = x in not_aligned_eq_None)
      apply simp
@@ -726,7 +726,7 @@ lemma copyGlobalMappings_ksPSpace_stable:
   apply (rule hoare_pre)
    apply (rule hoare_vcg_const_imp_lift)
    apply wp
-    apply (rule_tac Q = "\<lambda>r s'. ksPSpace s' x = ksPSpace s x \<and> globalPD = armKSGlobalPD (ksArchState s)"
+    apply (rule_tac Q'="\<lambda>r s'. ksPSpace s' x = ksPSpace s x \<and> globalPD = armKSGlobalPD (ksArchState s)"
       in hoare_post_imp)
      apply (wp hoare_vcg_all_lift getPDE_wp mapM_x_wp'
         | simp add: storePDE_def setObject_def split_def
@@ -753,7 +753,7 @@ lemma copyGlobalMappings_ksPSpace_same:
   apply clarsimp
   apply (rule hoare_pre)
    apply wp
-    apply (rule_tac Q = "\<lambda>r s'. ksPSpace s' x = ksPSpace s x \<and> globalPD = armKSGlobalPD (ksArchState s)"
+    apply (rule_tac Q'="\<lambda>r s'. ksPSpace s' x = ksPSpace s x \<and> globalPD = armKSGlobalPD (ksArchState s)"
       in hoare_post_imp)
      apply simp
     apply (wp hoare_vcg_all_lift getPDE_wp mapM_x_wp'
@@ -1045,10 +1045,10 @@ lemma createObject_valid_duplicates'[wp]:
   apply (wpc | wp| simp add: ARM_H.createObject_def split del: if_split)+
          apply (simp add: placeNewObject_def placeNewDataObject_def
                           placeNewObject'_def split_def split del: if_split
-           | wp unless_wp[where P="d"] unless_wp[where Q=\<top>]
+           | wp unless_wp[where P="d"] unless_wp[where P'=\<top>]
            | wpc | simp add: alignError_def split del: if_split)+
      apply (rule copyGlobalMappings_valid_duplicates')
-    apply ((wp unless_wp[where P="d"] unless_wp[where Q=\<top>] | wpc
+    apply ((wp unless_wp[where P="d"] unless_wp[where P'=\<top>] | wpc
             | simp add: alignError_def placeNewObject_def
                         placeNewObject'_def split_def split del: if_split)+)[2]
   apply (intro conjI impI)
@@ -2076,7 +2076,7 @@ lemma tc_valid_duplicates':
               checkCap_inv[where P="valid_cap' c" for c]
               checkCap_inv[where P="\<lambda>s. P (ksReadyQueues s)" for P]
               checkCap_inv[where P="\<lambda>s. vs_valid_duplicates' (ksPSpace s)"]
-              checkCap_inv[where P=sch_act_simple] cteDelete_valid_duplicates' hoare_vcg_const_imp_lift_R
+              checkCap_inv[where P=sch_act_simple] cteDelete_valid_duplicates' hoare_vcg_const_imp_liftE_R
               typ_at_lifts[OF setPriority_typ_at'] assertDerived_wp threadSet_cte_wp_at'
               hoare_vcg_all_liftE_R hoare_vcg_all_lift hoare_weak_lift_imp)[1]
           | wpc
@@ -2244,7 +2244,7 @@ lemma handleRecv_valid_duplicates'[wp]:
    apply wp
        apply ((wp getNotification_wp | wpc | simp add: whenE_def split del: if_split)+)[1]
 
-      apply (rule_tac Q="\<lambda>rv s. vs_valid_duplicates' (ksPSpace s)"
+      apply (rule_tac Q'="\<lambda>rv s. vs_valid_duplicates' (ksPSpace s)"
 
                    in hoare_strengthen_postE[rotated])
 

--- a/proof/refine/ARM/Refine.thy
+++ b/proof/refine/ARM/Refine.thy
@@ -226,12 +226,12 @@ lemma set_thread_state_sched_act:
     apply (simp add: set_thread_state_ext_def)
     apply wp
        apply (rule hoare_pre_cont)
-      apply (rule_tac Q="\<lambda>rv. (\<lambda>s. runnable ts) and (\<lambda>s. P (scheduler_action s))"
+      apply (rule_tac Q'="\<lambda>rv. (\<lambda>s. runnable ts) and (\<lambda>s. P (scheduler_action s))"
               in hoare_strengthen_post)
        apply wp
       apply force
      apply (wp gts_st_tcb_at)+
-     apply (rule_tac Q="\<lambda>rv. st_tcb_at ((=) state) thread and (\<lambda>s. runnable state) and (\<lambda>s. P (scheduler_action s))" in hoare_strengthen_post)
+     apply (rule_tac Q'="\<lambda>rv. st_tcb_at ((=) state) thread and (\<lambda>s. runnable state) and (\<lambda>s. P (scheduler_action s))" in hoare_strengthen_post)
      apply (simp add: st_tcb_at_def)
      apply (wp obj_set_prop_at)+
     apply (force simp: st_tcb_at_def obj_at_def)
@@ -270,7 +270,7 @@ lemma kernel_entry_invs:
   \<lbrace>\<lambda>rv. einvs and (\<lambda>s. ct_running s \<or> ct_idle s)
     and (\<lambda>s. 0 < domain_time s) and valid_domain_list
     and (\<lambda>s. scheduler_action s = resume_cur_thread)\<rbrace>"
-  apply (rule_tac Q="\<lambda>rv. invs and (\<lambda>s. ct_running s \<or> ct_idle s) and valid_sched and
+  apply (rule_tac Q'="\<lambda>rv. invs and (\<lambda>s. ct_running s \<or> ct_idle s) and valid_sched and
                            (\<lambda>s. 0 < domain_time s) and valid_domain_list and
                            valid_list and (\<lambda>s. scheduler_action s = resume_cur_thread)"
             in hoare_post_imp)
@@ -316,7 +316,7 @@ lemma do_user_op_invs2:
   do_user_op f tc
    \<lbrace>\<lambda>_. (einvs  and ct_running and (\<lambda>s. scheduler_action s = resume_cur_thread))
         and (\<lambda>s. 0 < domain_time s) and valid_domain_list \<rbrace>"
-  apply (rule_tac Q="\<lambda>_. valid_list and valid_sched and
+  apply (rule_tac Q'="\<lambda>_. valid_list and valid_sched and
    (\<lambda>s. scheduler_action s = resume_cur_thread) and (invs and ct_running) and
    (\<lambda>s. 0 < domain_time s) and valid_domain_list"
    in hoare_strengthen_post)
@@ -391,7 +391,7 @@ lemma ckernel_invs:
   apply (rule hoare_pre)
    apply (wp activate_invs' activate_sch_act schedule_sch
              schedule_sch_act_simple he_invs' schedule_invs'
-             hoare_drop_imp[where R="\<lambda>_. kernelExitAssertions"]
+             hoare_drop_imp[where Q'="\<lambda>_. kernelExitAssertions"]
           | simp add: no_irq_getActiveIRQ)+
   done
 
@@ -567,22 +567,22 @@ lemma kernel_corres':
           apply simp
           apply (wpsimp wp: hoare_drop_imps hoare_vcg_all_lift simp: schact_is_rct_def)[1]
          apply simp
-         apply (rule_tac Q="\<lambda>irq s. invs' s \<and>
+         apply (rule_tac Q'="\<lambda>irq s. invs' s \<and>
                               (\<forall>irq'. irq = Some irq' \<longrightarrow>
                                  intStateIRQTable (ksInterruptState s ) irq' \<noteq>
                                  IRQInactive)"
                       in hoare_post_imp)
           apply simp
          apply (wp doMachineOp_getActiveIRQ_IRQ_active handle_event_valid_sched | simp)+
-       apply (rule_tac Q="\<lambda>_. \<top>" and E="\<lambda>_. invs'" in hoare_strengthen_postE)
+       apply (rule_tac Q'="\<lambda>_. \<top>" and E'="\<lambda>_. invs'" in hoare_strengthen_postE)
          apply wpsimp+
        apply (simp add: invs'_def valid_state'_def)
       apply (rule corres_split[OF schedule_corres])
         apply (rule activateThread_corres)
        apply (wp handle_interrupt_valid_sched[unfolded non_kernel_IRQs_def, simplified]
                  schedule_invs' hoare_vcg_if_lift2 hoare_drop_imps |simp)+
-     apply (rule_tac Q="\<lambda>_. valid_sched and invs and valid_list" and
-                     E="\<lambda>_. valid_sched and invs and valid_list"
+     apply (rule_tac Q'="\<lambda>_. valid_sched and invs and valid_list" and
+                     E'="\<lambda>_. valid_sched and invs and valid_list"
             in hoare_strengthen_postE)
        apply (wp handle_event_valid_sched hoare_vcg_imp_lift' |simp)+
    apply (clarsimp simp: active_from_running schact_is_rct_def)

--- a/proof/refine/ARM/Retype_R.thy
+++ b/proof/refine/ARM/Retype_R.thy
@@ -4202,7 +4202,7 @@ lemma createNewCaps_cur:
         cur_tcb' s\<rbrace>
       createNewCaps ty ptr n us d
    \<lbrace>\<lambda>rv. cur_tcb'\<rbrace>"
-  apply (rule hoare_post_imp [where Q="\<lambda>rv s. \<exists>t. ksCurThread s = t \<and> tcb_at' t s"])
+  apply (rule hoare_post_imp[where Q'="\<lambda>rv s. \<exists>t. ksCurThread s = t \<and> tcb_at' t s"])
    apply (simp add: cur_tcb'_def)
   apply (wp hoare_vcg_ex_lift createNewCaps_obj_at')
   apply (clarsimp simp: pspace_no_overlap'_def cur_tcb'_def valid_pspace'_def)
@@ -4311,7 +4311,7 @@ lemma createNewCaps_global_refs':
      createNewCaps ty ptr n us d
    \<lbrace>\<lambda>rv. valid_global_refs'\<rbrace>"
   apply (simp add: valid_global_refs'_def valid_cap_sizes'_def valid_refs'_def)
-  apply (rule_tac Q="\<lambda>rv s. \<forall>ptr. \<not> cte_wp_at' (\<lambda>cte. (kernel_data_refs \<inter> capRange (cteCap cte) \<noteq> {}
+  apply (rule_tac Q'="\<lambda>rv s. \<forall>ptr. \<not> cte_wp_at' (\<lambda>cte. (kernel_data_refs \<inter> capRange (cteCap cte) \<noteq> {}
         \<or> 2 ^ capBits (cteCap cte) > gsMaxObjectSize s)) ptr s \<and> global_refs' s \<subseteq> kernel_data_refs"
                  in hoare_post_imp)
    apply (auto simp: cte_wp_at_ctes_of linorder_not_less elim!: ranE)[1]
@@ -5030,7 +5030,7 @@ proof (rule hoare_gen_asm, erule conjE)
     "\<lbrace>ct_not_inQ and valid_pspace' and pspace_no_overlap' ptr sz\<rbrace>
      createNewCaps ty ptr n us dev \<lbrace>\<lambda>_. ct_not_inQ\<rbrace>"
     unfolding ct_not_inQ_def
-    apply (rule_tac Q="\<lambda>s. ksSchedulerAction s = ResumeCurrentThread
+    apply (rule_tac P'="\<lambda>s. ksSchedulerAction s = ResumeCurrentThread
                              \<longrightarrow> (obj_at' (Not \<circ> tcbQueued) (ksCurThread s) s
                                   \<and> valid_pspace' s \<and> pspace_no_overlap' ptr sz s)"
                     in hoare_pre_imp, clarsimp)
@@ -5141,7 +5141,7 @@ lemma createObjects_no_cte_valid_global:
       createObjects ptr n val gbits
    \<lbrace>\<lambda>rv s. valid_global_refs' s\<rbrace>"
   apply (simp add: valid_global_refs'_def valid_cap_sizes'_def valid_refs'_def)
-  apply (rule_tac Q="\<lambda>rv s. \<forall>ptr. \<not> cte_wp_at' (\<lambda>cte. (kernel_data_refs \<inter> capRange (cteCap cte) \<noteq> {}
+  apply (rule_tac Q'="\<lambda>rv s. \<forall>ptr. \<not> cte_wp_at' (\<lambda>cte. (kernel_data_refs \<inter> capRange (cteCap cte) \<noteq> {}
         \<or> 2 ^ capBits (cteCap cte) > gsMaxObjectSize s)) ptr s \<and> global_refs' s \<subseteq> kernel_data_refs"
                  in hoare_post_imp)
    apply (auto simp: cte_wp_at_ctes_of linorder_not_less elim!: ranE)[1]
@@ -5252,7 +5252,7 @@ lemma createObjects_cur':
         cur_tcb' s\<rbrace>
       createObjects ptr n val gbits
    \<lbrace>\<lambda>rv s. cur_tcb' s\<rbrace>"
-  apply (rule hoare_post_imp [where Q="\<lambda>rv s. \<exists>t. ksCurThread s = t \<and> tcb_at' t s"])
+  apply (rule hoare_post_imp[where Q'="\<lambda>rv s. \<exists>t. ksCurThread s = t \<and> tcb_at' t s"])
    apply (simp add: cur_tcb'_def)
   apply (wp hoare_vcg_ex_lift createObjects_orig_obj_at3)
   apply (clarsimp simp: cur_tcb'_def)
@@ -5342,7 +5342,7 @@ proof -
       createObjects ptr n val gbits \<lbrace>\<lambda>_. ct_not_inQ\<rbrace>"
     (is "\<lbrakk> _; _ \<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s. ct_not_inQ s \<and> ?REST s\<rbrace> _ \<lbrace>_\<rbrace>")
     apply (simp add: ct_not_inQ_def)
-    apply (rule_tac Q="\<lambda>s. (ksSchedulerAction s = ResumeCurrentThread) \<longrightarrow>
+    apply (rule_tac P'="\<lambda>s. (ksSchedulerAction s = ResumeCurrentThread) \<longrightarrow>
                              (obj_at' (Not \<circ> tcbQueued) (ksCurThread s) s \<and> ?REST s)"
              in hoare_pre_imp, clarsimp)
     apply (rule hoare_convert_imp [OF createObjects_nosch])

--- a/proof/refine/ARM/Retype_R.thy
+++ b/proof/refine/ARM/Retype_R.thy
@@ -4277,20 +4277,17 @@ lemma createNewCaps_idle'[wp]:
              split del: if_split)
   apply (cases ty, simp_all add: Arch_createNewCaps_def
                       split del: if_split)
-         apply (rename_tac apiobject_type)
-         apply (case_tac apiobject_type, simp_all split del: if_split)[1]
-             apply (wp, simp)
-           including classic_wp_pre
-           apply (wp mapM_x_wp'
-                     createObjects_idle'
-                     threadSet_idle'
-                   | simp add: projectKO_opt_tcb projectKO_opt_cte
-                               makeObject_cte makeObject_tcb archObjSize_def
-                               tcb_cte_cases_def objBitsKO_def APIType_capBits_def
-                               ptBits_def pdBits_def pageBits_def objBits_def
-                               createObjects_def pteBits_def pdeBits_def
-                   | intro conjI impI
-                   | fastforce simp: curDomain_def)+
+        apply (rename_tac apiobject_type)
+        apply (case_tac apiobject_type, simp_all split del: if_split)[1]
+            apply wpsimp
+           apply (wpsimp wp: mapM_x_wp' createObjects_idle' threadSet_idle'
+                  | simp add: projectKO_opt_tcb projectKO_opt_cte
+                              makeObject_cte makeObject_tcb archObjSize_def
+                              tcb_cte_cases_def objBitsKO_def APIType_capBits_def
+                              ptBits_def pdBits_def pageBits_def objBits_def
+                              createObjects_def pteBits_def pdeBits_def
+                  | intro conjI impI
+                  | clarsimp simp: curDomain_def)+
   done
 
 crunch createNewCaps

--- a/proof/refine/ARM/Schedule_R.thy
+++ b/proof/refine/ARM/Schedule_R.thy
@@ -645,7 +645,7 @@ lemma tcbSchedDequeue_valid_mdb'[wp]:
   "\<lbrace>valid_mdb' and valid_objs'\<rbrace> tcbSchedDequeue tcbPtr \<lbrace>\<lambda>_. valid_mdb'\<rbrace>"
   unfolding tcbSchedDequeue_def
   apply (wpsimp simp: bitmap_fun_defs setQueue_def wp: threadSet_mdb' tcbQueueRemove_valid_mdb')
-      apply (rule_tac Q="\<lambda>_. tcb_at' tcbPtr" in hoare_post_imp)
+      apply (rule_tac Q'="\<lambda>_. tcb_at' tcbPtr" in hoare_post_imp)
        apply (fastforce simp: tcb_cte_cases_def cteSizeBits_def)
       apply (wpsimp wp: threadGet_wp)+
   apply (fastforce simp: obj_at'_def)
@@ -954,7 +954,7 @@ lemma tcbSchedDequeue_not_tcbQueued:
   "\<lbrace>\<top>\<rbrace> tcbSchedDequeue t \<lbrace>\<lambda>_. obj_at' (\<lambda>x. \<not> tcbQueued x) t\<rbrace>"
   apply (simp add: tcbSchedDequeue_def)
   apply (wp|clarsimp)+
-  apply (rule_tac Q="\<lambda>queued. obj_at' (\<lambda>x. tcbQueued x = queued) t" in hoare_post_imp)
+  apply (rule_tac Q'="\<lambda>queued. obj_at' (\<lambda>x. tcbQueued x = queued) t" in hoare_post_imp)
      apply (clarsimp simp: obj_at'_def)
     apply (wpsimp wp: threadGet_wp)+
   apply (clarsimp simp: obj_at'_def)
@@ -1904,7 +1904,7 @@ lemma schedule_corres:
 
            apply (clarsimp simp: conj_ac cong: conj_cong)
            apply wp
-           apply (rule_tac Q="\<lambda>_ s. valid_blocked_except t s \<and> scheduler_action s = switch_thread t"
+           apply (rule_tac Q'="\<lambda>_ s. valid_blocked_except t s \<and> scheduler_action s = switch_thread t"
                     in hoare_post_imp, fastforce)
            apply (wp add: tcb_sched_action_enqueue_valid_blocked_except
                           tcbSchedEnqueue_invs'_not_ResumeCurrentThread thread_get_wp
@@ -2173,7 +2173,7 @@ lemma schedule_invs':
     apply (wpsimp wp: scheduleChooseNewThread_invs' ssa_invs'
                       chooseThread_invs_no_cicd' setSchedulerAction_invs' setSchedulerAction_direct
                       switchToThread_tcb_in_cur_domain' switchToThread_ct_not_queued_2
-           | wp hoare_disjI2[where R="\<lambda>_ s. tcb_in_cur_domain' (ksCurThread s) s"]
+           | wp hoare_disjI2[where Q'="\<lambda>_ s. tcb_in_cur_domain' (ksCurThread s) s"]
            | wp hoare_drop_imp[where f="isHighestPrio d p" for d p]
            | simp only: obj_at'_activatable_st_tcb_at'[simplified comp_def]
            | strengthen invs'_invs_no_cicd

--- a/proof/refine/ARM/Schedule_R.thy
+++ b/proof/refine/ARM/Schedule_R.thy
@@ -1910,7 +1910,7 @@ lemma schedule_corres:
                           tcbSchedEnqueue_invs'_not_ResumeCurrentThread thread_get_wp
                      del: gets_wp
                   | strengthen valid_objs'_valid_tcbs')+
-       apply (clarsimp simp: conj_ac if_apply_def2 cong: imp_cong conj_cong del: hoare_gets)
+       apply (clarsimp simp: conj_ac if_apply_def2 cong: imp_cong conj_cong)
        apply (wp gets_wp)+
 
    (* abstract final subgoal *)

--- a/proof/refine/ARM/SubMonad_R.thy
+++ b/proof/refine/ARM/SubMonad_R.thy
@@ -79,7 +79,7 @@ lemma threadSet_modify_asUser:
    apply (clarsimp simp: threadSet_def setObject_def split_def
                          updateObject_default_def)
    apply wp
-   apply (rule_tac Q="\<lambda>rv. obj_at' ((=) rv) t and ((=) st)" in hoare_post_imp)
+   apply (rule_tac Q'="\<lambda>rv. obj_at' ((=) rv) t and ((=) st)" in hoare_post_imp)
     apply (clarsimp simp: asUser_replace_def Let_def obj_at'_def
                           projectKOs fun_upd_def
                    split: option.split kernel_object.split)

--- a/proof/refine/ARM/Syscall_R.thy
+++ b/proof/refine/ARM/Syscall_R.thy
@@ -330,7 +330,7 @@ lemma threadSet_tcbDomain_update_sch_act_wf[wp]:
      apply (wps setObject_sa_unchanged)
      apply (wp hoare_weak_lift_imp getObject_tcb_wp hoare_vcg_all_lift)+
    apply (rename_tac word)
-   apply (rule_tac Q="\<lambda>_ s. ksSchedulerAction s = SwitchToThread word \<longrightarrow>
+   apply (rule_tac Q'="\<lambda>_ s. ksSchedulerAction s = SwitchToThread word \<longrightarrow>
                             st_tcb_at' runnable' word s \<and> tcb_in_cur_domain' word s \<and> word \<noteq> t"
                    in hoare_strengthen_post)
     apply (wp hoare_vcg_all_lift hoare_vcg_conj_lift hoare_vcg_imp_lift)+
@@ -367,20 +367,20 @@ lemma setDomain_corres:
          apply ((wpsimp wp: hoare_vcg_imp_lift' ethread_set_not_queued_valid_queues hoare_vcg_all_lift
                  | strengthen valid_objs'_valid_tcbs' valid_queues_in_correct_ready_q
                               valid_queues_ready_qs_distinct)+)[1]
-        apply (rule_tac Q="\<lambda>_. valid_objs' and sym_heap_sched_pointers and valid_sched_pointers
+        apply (rule_tac Q'="\<lambda>_. valid_objs' and sym_heap_sched_pointers and valid_sched_pointers
                                and pspace_aligned' and pspace_distinct'
                                and (\<lambda>s. sch_act_wf (ksSchedulerAction s) s) and tcb_at' tptr"
                      in hoare_strengthen_post[rotated])
          apply (fastforce simp: invs'_def valid_state'_def sch_act_wf_weak st_tcb_at'_def o_def)
         apply (wpsimp wp: threadSet_valid_objs' threadSet_sched_pointers
                           threadSet_valid_sched_pointers)+
-       apply (rule_tac Q="\<lambda>_ s. valid_queues s \<and> not_queued tptr s
+       apply (rule_tac Q'="\<lambda>_ s. valid_queues s \<and> not_queued tptr s
                                 \<and> pspace_aligned s \<and> pspace_distinct s \<and> valid_etcbs s
                                 \<and> weak_valid_sched_action s"
                     in hoare_post_imp)
         apply (fastforce simp: pred_tcb_at_def obj_at_def)
        apply (wpsimp wp: tcb_dequeue_not_queued)
-      apply (rule_tac Q = "\<lambda>_ s. invs' s \<and> obj_at' (Not \<circ> tcbQueued) tptr s \<and> sch_act_simple s
+      apply (rule_tac Q'="\<lambda>_ s. invs' s \<and> obj_at' (Not \<circ> tcbQueued) tptr s \<and> sch_act_simple s
                                  \<and>  tcb_at' tptr s"
                    in hoare_strengthen_post[rotated])
        apply (clarsimp simp: invs'_def valid_state'_def valid_pspace'_def sch_act_simple_def)
@@ -788,7 +788,7 @@ lemma doReply_invs[wp]:
           apply simp
           apply (wp (once) sts_st_tcb')
           apply wp
-         apply (rule_tac Q="\<lambda>_ s. invs' s \<and> t \<noteq> ksIdleThread s \<and> st_tcb_at' awaiting_reply' t s"
+         apply (rule_tac Q'="\<lambda>_ s. invs' s \<and> t \<noteq> ksIdleThread s \<and> st_tcb_at' awaiting_reply' t s"
                  in hoare_post_imp)
           apply clarsimp
           apply (rule conjI, erule pred_tcb'_weakenE, case_tac st, clarsimp+)
@@ -801,7 +801,7 @@ lemma doReply_invs[wp]:
           apply (case_tac st, clarsimp+)
          apply (wp cteDeleteOne_reply_pred_tcb_at)+
         apply clarsimp
-        apply (rule_tac Q="\<lambda>_. (\<lambda>s. t \<noteq> ksIdleThread s)
+        apply (rule_tac Q'="\<lambda>_. (\<lambda>s. t \<noteq> ksIdleThread s)
                                and cte_wp_at' (\<lambda>cte. \<exists>grant. cteCap cte
                                                              = capability.ReplyCap t False grant) slot"
                      in hoare_strengthen_post [rotated])
@@ -813,7 +813,7 @@ lemma doReply_invs[wp]:
         apply (erule cte_wp_at_weakenE')
         apply (fastforce)
        apply (wp sts_invs_minor'' sts_st_tcb' hoare_weak_lift_imp)
-             apply (rule_tac Q="\<lambda>_ s. invs' s \<and> sch_act_simple s
+             apply (rule_tac Q'="\<lambda>_ s. invs' s \<and> sch_act_simple s
                                       \<and> st_tcb_at' awaiting_reply' t s
                                       \<and> t \<noteq> ksIdleThread s"
                           in hoare_post_imp)
@@ -828,7 +828,7 @@ lemma doReply_invs[wp]:
               apply (case_tac st, clarsimp+)
              apply (wp threadSet_invs_trivial threadSet_st_tcb_at2 hoare_weak_lift_imp
                     | clarsimp simp add: inQ_def)+
-           apply (rule_tac Q="\<lambda>_. invs' and tcb_at' t
+           apply (rule_tac Q'="\<lambda>_. invs' and tcb_at' t
                                  and sch_act_simple and st_tcb_at' awaiting_reply' t"
                    in hoare_strengthen_post [rotated])
             apply clarsimp
@@ -940,7 +940,7 @@ lemma setDomain_invs':
   apply (simp add:setDomain_def )
   apply (wp add: when_wp hoare_weak_lift_imp hoare_weak_lift_imp_conj rescheduleRequired_all_invs_but_extra
     tcbSchedEnqueue_valid_action hoare_vcg_if_lift2)
-     apply (rule_tac Q = "\<lambda>r s. all_invs_but_sch_extra s \<and> curThread = ksCurThread s
+     apply (rule_tac Q'="\<lambda>r s. all_invs_but_sch_extra s \<and> curThread = ksCurThread s
       \<and> (ptr \<noteq> curThread \<longrightarrow> ct_not_inQ s \<and> sch_act_wf (ksSchedulerAction s) s \<and> ct_idle_or_in_cur_domain' s)"
       in hoare_strengthen_post[rotated])
       apply (clarsimp simp:invs'_def valid_state'_def st_tcb_at'_def[symmetric] valid_pspace'_def)
@@ -952,7 +952,7 @@ lemma setDomain_invs':
       apply assumption
      apply (wp hoare_weak_lift_imp threadSet_pred_tcb_no_state threadSet_not_curthread_ct_domain
                threadSet_tcbDomain_update_ct_not_inQ | simp)+
-    apply (rule_tac Q = "\<lambda>r s. invs' s \<and> curThread = ksCurThread s \<and> sch_act_simple s
+    apply (rule_tac Q'="\<lambda>r s. invs' s \<and> curThread = ksCurThread s \<and> sch_act_simple s
                              \<and> domain \<le> maxDomain
                              \<and> (ptr \<noteq> curThread \<longrightarrow> ct_not_inQ s \<and> sch_act_not ptr s)"
       in hoare_strengthen_post[rotated])
@@ -1218,7 +1218,7 @@ lemma handleInvocation_corres:
                       apply (wp reply_from_kernel_tcb_at)
                      apply (rule impI, wp+)
                      apply (wpsimp wp: hoare_drop_imps|strengthen invs_distinct invs_psp_aligned)+
-               apply (rule_tac Q="\<lambda>rv. einvs and schact_is_rct and valid_invocation rve
+               apply (rule_tac Q'="\<lambda>rv. einvs and schact_is_rct and valid_invocation rve
                                    and (\<lambda>s. thread = cur_thread s)
                                    and st_tcb_at active thread"
                           in hoare_post_imp)
@@ -1226,7 +1226,7 @@ lemma handleInvocation_corres:
                                elim!: st_tcb_weakenE)
                apply (wp sts_st_tcb_at' set_thread_state_schact_is_rct
                          set_thread_state_active_valid_sched)
-              apply (rule_tac Q="\<lambda>rv. invs' and valid_invocation' rve'
+              apply (rule_tac Q'="\<lambda>rv. invs' and valid_invocation' rve'
                                       and (\<lambda>s. thread = ksCurThread s)
                                       and st_tcb_at' active' thread
                                       and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread)
@@ -1239,7 +1239,7 @@ lemma handleInvocation_corres:
              apply (wp lec_caps_to lsft_ex_cte_cap_to
                     | simp add: split_def liftE_bindE[symmetric]
                                 ct_in_state'_def ball_conj_distrib
-                    | rule hoare_vcg_E_elim)+
+                    | rule hoare_vcg_conj_elimE)+
    apply (clarsimp simp: tcb_at_invs invs_valid_objs
                          valid_tcb_state_def ct_in_state_def
                          simple_from_active invs_mdb
@@ -1309,7 +1309,7 @@ lemma hinv_invs'[wp]:
          apply (clarsimp simp: valid_idle'_def valid_state'_def
                                invs'_def pred_tcb_at'_def obj_at'_def idle_tcb'_def)
         apply wp+
-       apply (rule_tac Q="\<lambda>rv'. invs' and valid_invocation' rv
+       apply (rule_tac Q'="\<lambda>rv'. invs' and valid_invocation' rv
                                 and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread)
                                 and (\<lambda>s. ksCurThread s = thread)
                                 and st_tcb_at' active' thread"
@@ -1512,7 +1512,7 @@ lemma handleRecv_isBlocking_corres':
           apply (rule handleFault_corres)
           apply simp
          apply (wp get_simple_ko_wp | wpcw | simp)+
-         apply (rule hoare_vcg_E_elim)
+         apply (rule hoare_vcg_conj_elimE)
           apply (simp add: lookup_cap_def lookup_slot_for_thread_def)
           apply wp
            apply (simp add: split_def)
@@ -1560,14 +1560,14 @@ lemma hw_invs'[wp]:
                          deleteCallerCap_ct']
                     | wpc | simp add: ct_in_state'_def whenE_def split del: if_split)+
      apply (rule validE_validE_R)
-     apply (rule_tac Q="\<lambda>rv s. invs' s
+     apply (rule_tac Q'="\<lambda>rv s. invs' s
                              \<and> sch_act_sane s
                              \<and> thread = ksCurThread s
                              \<and> ct_in_state' simple' s
                              \<and> ex_nonz_cap_to' thread s
                              \<and> thread \<noteq> ksIdleThread s
                             \<and> (\<forall>x \<in> zobj_refs' rv. ex_nonz_cap_to' x s)"
-              and E="\<lambda>_ _. True"
+              and E'="\<lambda>_ _. True"
            in hoare_strengthen_postE[rotated])
         apply (clarsimp simp: isCap_simps ct_in_state'_def pred_tcb_at' invs_valid_objs'
                               sch_act_sane_not obj_at'_def projectKOs pred_tcb_at'_def)
@@ -1616,7 +1616,7 @@ lemma hy_invs':
   "\<lbrace>invs' and ct_active'\<rbrace> handleYield \<lbrace>\<lambda>r. invs' and ct_active'\<rbrace>"
   apply (simp add: handleYield_def)
   apply (wpsimp wp: ct_in_state_thread_state_lift' rescheduleRequired_all_invs_but_ct_not_inQ)
-     apply (rule_tac Q="\<lambda>_. all_invs_but_ct_not_inQ' and ct_active'" in hoare_post_imp)
+     apply (rule_tac Q'="\<lambda>_. all_invs_but_ct_not_inQ' and ct_active'" in hoare_post_imp)
       apply clarsimp
      apply (subst pred_conj_def)
      apply (rule hoare_vcg_conj_lift)
@@ -1841,7 +1841,7 @@ lemma handleReply_nonz_cap_to_ct:
   "\<lbrace>ct_active' and invs' and sch_act_simple\<rbrace>
      handleReply
    \<lbrace>\<lambda>rv s. ex_nonz_cap_to' (ksCurThread s) s\<rbrace>"
-  apply (rule_tac Q="\<lambda>rv. ct_active' and invs'"
+  apply (rule_tac Q'="\<lambda>rv. ct_active' and invs'"
                in hoare_post_imp)
    apply (auto simp: ct_in_state'_def elim: st_tcb_ex_cap'')[1]
   apply (wp | simp)+
@@ -1957,7 +1957,7 @@ proof -
             apply (rule handleVMFault_corres)
            apply (erule handleFault_corres)
           apply (rule hoare_elim_pred_conjE2)
-          apply (rule hoare_vcg_E_conj, rule valid_validE_E, wp)
+          apply (rule hoare_vcg_conj_liftE_E, rule valid_validE_E, wp)
           apply (wp handle_vm_fault_valid_fault)
          apply (rule hv_inv_ex')
         apply wp

--- a/proof/refine/ARM/TcbAcc_R.thy
+++ b/proof/refine/ARM/TcbAcc_R.thy
@@ -1083,7 +1083,7 @@ lemma threadSet_obj_at'_really_strongest:
   apply (simp add: threadSet_def)
   apply (wp setObject_tcb_strongest)
    apply (subst simp_thms(32)[symmetric], rule hoare_vcg_disj_lift)
-    apply (rule hoare_post_imp [where Q="\<lambda>rv s. \<not> tcb_at' t s \<and> tcb_at' t s"])
+    apply (rule hoare_post_imp[where Q'="\<lambda>rv s. \<not> tcb_at' t s \<and> tcb_at' t s"])
      apply simp
     apply (subst simp_thms(21)[symmetric], rule hoare_vcg_conj_lift)
      apply (rule getObject_inv_tcb)
@@ -1170,7 +1170,7 @@ proof -
   show ?thesis
     apply (rule_tac P=P in P_bool_lift)
      apply (rule pos)
-    apply (rule_tac Q="\<lambda>_ s. \<not> tcb_at' t' s \<or> pred_tcb_at' proj (\<lambda>tcb. \<not> P' tcb) t' s"
+    apply (rule_tac Q'="\<lambda>_ s. \<not> tcb_at' t' s \<or> pred_tcb_at' proj (\<lambda>tcb. \<not> P' tcb) t' s"
              in hoare_post_imp)
      apply (erule disjE)
       apply (clarsimp dest!: pred_tcb_at')
@@ -3320,7 +3320,7 @@ lemma sts_valid_objs':
    setThreadState st t
    \<lbrace>\<lambda>_. valid_objs'\<rbrace>"
   apply (wpsimp simp: setThreadState_def wp: threadSet_valid_objs')
-   apply (rule_tac Q="\<lambda>_. valid_objs' and pspace_aligned' and pspace_distinct'" in hoare_post_imp)
+   apply (rule_tac Q'="\<lambda>_. valid_objs' and pspace_aligned' and pspace_distinct'" in hoare_post_imp)
     apply fastforce
    apply (wpsimp wp: threadSet_valid_objs')
   apply (simp add: valid_tcb'_def tcb_cte_cases_def cteSizeBits_def)
@@ -3585,7 +3585,7 @@ lemma sts_sch_act':
    apply assumption
   apply (case_tac "runnable' st")
    apply ((wp threadSet_runnable_sch_act hoare_drop_imps | simp)+)[1]
-  apply (rule_tac Q="\<lambda>rv s. st_tcb_at' (Not \<circ> runnable') t s \<and>
+  apply (rule_tac Q'="\<lambda>rv s. st_tcb_at' (Not \<circ> runnable') t s \<and>
                      (ksCurThread s \<noteq> t \<or> ksSchedulerAction s \<noteq> ResumeCurrentThread \<longrightarrow>
                             sch_act_wf (ksSchedulerAction s) s)"
                in hoare_post_imp)
@@ -3605,10 +3605,10 @@ lemma sts_sch_act[wp]:
    prefer 2
    apply assumption
   apply (case_tac "runnable' st")
-   apply (rule_tac Q="\<lambda>s. sch_act_wf (ksSchedulerAction s) s"
+   apply (rule_tac P'="\<lambda>s. sch_act_wf (ksSchedulerAction s) s"
                 in hoare_pre_imp, simp)
    apply ((wp hoare_drop_imps threadSet_runnable_sch_act | simp)+)[1]
-  apply (rule_tac Q="\<lambda>rv s. st_tcb_at' (Not \<circ> runnable') t s \<and>
+  apply (rule_tac Q'="\<lambda>rv s. st_tcb_at' (Not \<circ> runnable') t s \<and>
                      (ksCurThread s \<noteq> t \<or> ksSchedulerAction s \<noteq> ResumeCurrentThread \<longrightarrow>
                             sch_act_wf (ksSchedulerAction s) s)"
                in hoare_post_imp)
@@ -3879,7 +3879,7 @@ lemma addToBitmap_valid_bitmapQ:
    addToBitmap d p
    \<lbrace>\<lambda>_. valid_bitmapQ\<rbrace>"
   (is "\<lbrace>?pre\<rbrace> _ \<lbrace>_\<rbrace>")
-  apply (rule_tac Q="\<lambda>_ s. ?pre s \<and> bitmapQ d p s" in hoare_strengthen_post)
+  apply (rule_tac Q'="\<lambda>_ s. ?pre s \<and> bitmapQ d p s" in hoare_strengthen_post)
    apply (wpsimp wp: addToBitmap_valid_bitmapQ_except addToBitmap_bitmapQ)
   apply (fastforce elim: valid_bitmap_valid_bitmapQ_exceptE)
   done
@@ -4576,7 +4576,7 @@ lemma ct_in_state'_decomp:
   assumes x: "\<lbrace>\<lambda>s. t = (ksCurThread s)\<rbrace> f \<lbrace>\<lambda>rv s. t = (ksCurThread s)\<rbrace>"
   assumes y: "\<lbrace>Pre\<rbrace> f \<lbrace>\<lambda>rv. st_tcb_at' Prop t\<rbrace>"
   shows      "\<lbrace>\<lambda>s. Pre s \<and> t = (ksCurThread s)\<rbrace> f \<lbrace>\<lambda>rv. ct_in_state' Prop\<rbrace>"
-  apply (rule hoare_post_imp [where Q="\<lambda>rv s. t = ksCurThread s \<and> st_tcb_at' Prop t s"])
+  apply (rule hoare_post_imp[where Q'="\<lambda>rv s. t = ksCurThread s \<and> st_tcb_at' Prop t s"])
    apply (clarsimp simp add: ct_in_state'_def)
   apply (rule hoare_weaken_pre)
    apply (wp x y)
@@ -4647,7 +4647,7 @@ lemma setQueue_pred_tcb_at[wp]:
   unfolding pred_tcb_at'_def
   apply (rule_tac P=P' in P_bool_lift)
    apply (rule setQueue_obj_at)
-  apply (rule_tac Q="\<lambda>_ s. \<not>typ_at' TCBT t s \<or> obj_at' (Not \<circ> (P \<circ> proj \<circ> tcb_to_itcb')) t s"
+  apply (rule_tac Q'="\<lambda>_ s. \<not>typ_at' TCBT t s \<or> obj_at' (Not \<circ> (P \<circ> proj \<circ> tcb_to_itcb')) t s"
            in hoare_post_imp, simp add: not_obj_at' o_def)
   apply (wp hoare_vcg_disj_lift)
   apply (clarsimp simp: not_obj_at' o_def)
@@ -4898,7 +4898,7 @@ lemma sts_iflive'[wp]:
    \<lbrace>\<lambda>rv. if_live_then_nonz_cap'\<rbrace>"
   apply (simp add: setThreadState_def setQueue_def)
   apply wpsimp
-   apply (rule_tac Q="\<lambda>rv. if_live_then_nonz_cap' and pspace_aligned' and pspace_distinct'"
+   apply (rule_tac Q'="\<lambda>rv. if_live_then_nonz_cap' and pspace_aligned' and pspace_distinct'"
                 in hoare_post_imp)
     apply clarsimp
    apply (wpsimp wp: threadSet_iflive')
@@ -5037,7 +5037,7 @@ lemma tcbSchedEnqueue_ct_not_inQ:
   proof -
     have ts: "\<lbrace>?PRE\<rbrace> threadSet (tcbQueued_update (\<lambda>_. True)) t \<lbrace>\<lambda>_. ct_not_inQ\<rbrace>"
       apply (simp add: ct_not_inQ_def)
-      apply (rule_tac Q="\<lambda>s. ksSchedulerAction s = ResumeCurrentThread
+      apply (rule_tac P'="\<lambda>s. ksSchedulerAction s = ResumeCurrentThread
                   \<longrightarrow> obj_at' (Not \<circ> tcbQueued) (ksCurThread s) s \<and> ksCurThread s \<noteq> t"
                   in hoare_pre_imp, clarsimp)
       apply (rule hoare_convert_imp [OF threadSet_nosch])
@@ -5064,7 +5064,7 @@ lemma tcbSchedAppend_ct_not_inQ:
   proof -
     have ts: "\<lbrace>?PRE\<rbrace> threadSet (tcbQueued_update (\<lambda>_. True)) t \<lbrace>\<lambda>_. ct_not_inQ\<rbrace>"
       apply (simp add: ct_not_inQ_def)
-      apply (rule_tac Q="\<lambda>s. ksSchedulerAction s = ResumeCurrentThread
+      apply (rule_tac P'="\<lambda>s. ksSchedulerAction s = ResumeCurrentThread
                   \<longrightarrow> obj_at' (Not \<circ> tcbQueued) (ksCurThread s) s \<and> ksCurThread s \<noteq> t"
                   in hoare_pre_imp, clarsimp)
       apply (rule hoare_convert_imp [OF threadSet_nosch])
@@ -5091,7 +5091,7 @@ lemma setSchedulerAction_direct:
 lemma rescheduleRequired_ct_not_inQ:
   "\<lbrace>\<top>\<rbrace> rescheduleRequired \<lbrace>\<lambda>_. ct_not_inQ\<rbrace>"
   apply (simp add: rescheduleRequired_def ct_not_inQ_def)
-  apply (rule_tac Q="\<lambda>_ s. ksSchedulerAction s = ChooseNewThread"
+  apply (rule_tac Q'="\<lambda>_ s. ksSchedulerAction s = ChooseNewThread"
            in hoare_post_imp, clarsimp)
   apply (wp setSchedulerAction_direct)
   done
@@ -5162,7 +5162,7 @@ lemma setThreadState_ct_not_inQ:
   including no_pre
   apply (simp add: setThreadState_def)
   apply (wp rescheduleRequired_ct_not_inQ)
-  apply (rule_tac Q="\<lambda>_. ?PRE" in hoare_post_imp, clarsimp)
+  apply (rule_tac Q'="\<lambda>_. ?PRE" in hoare_post_imp, clarsimp)
   apply (wp)
   done
 
@@ -5319,7 +5319,7 @@ lemma removeFromBitmap_valid_bitmapQ[wp]:
    removeFromBitmap d p
    \<lbrace>\<lambda>_. valid_bitmapQ\<rbrace>"
   (is "\<lbrace>?pre\<rbrace> _ \<lbrace>_\<rbrace>")
-  apply (rule_tac Q="\<lambda>_ s. ?pre s \<and> \<not> bitmapQ d p s" in hoare_strengthen_post)
+  apply (rule_tac Q'="\<lambda>_ s. ?pre s \<and> \<not> bitmapQ d p s" in hoare_strengthen_post)
    apply (wpsimp wp: removeFromBitmap_valid_bitmapQ_except removeFromBitmap_bitmapQ)
   apply (fastforce elim: valid_bitmap_valid_bitmapQ_exceptE)
   done

--- a/proof/refine/ARM/Tcb_R.thy
+++ b/proof/refine/ARM/Tcb_R.thy
@@ -81,7 +81,7 @@ abbreviation
 lemma gts_st_tcb':
   "\<lbrace>tcb_at' t\<rbrace> getThreadState t \<lbrace>\<lambda>rv. st_tcb_at' (\<lambda>st. st = rv) t\<rbrace>"
   apply (rule hoare_weaken_pre)
-   apply (rule hoare_post_imp[where Q="\<lambda>rv s. \<exists>rv'. rv = rv' \<and> st_tcb_at' (\<lambda>st. st = rv') t s"])
+   apply (rule hoare_post_imp[where Q'="\<lambda>rv s. \<exists>rv'. rv = rv' \<and> st_tcb_at' (\<lambda>st. st = rv') t s"])
     apply simp
    apply (wp hoare_vcg_ex_lift)
   apply (clarsimp simp add: pred_tcb_at'_def obj_at'_def)
@@ -107,15 +107,15 @@ lemma activate_invs':
                        split del: if_splits cong: if_cong)
       apply (wp)
       apply (clarsimp simp: ct_in_state'_def)
-     apply (rule_tac Q="\<lambda>rv. invs' and ct_idle'" in hoare_post_imp, simp)
+     apply (rule_tac Q'="\<lambda>rv. invs' and ct_idle'" in hoare_post_imp, simp)
      apply (wp activateIdle_invs)
      apply (clarsimp simp: ct_in_state'_def)
-    apply (rule_tac Q="\<lambda>rv. invs' and ct_running' and sch_act_simple"
+    apply (rule_tac Q'="\<lambda>rv. invs' and ct_running' and sch_act_simple"
                  in hoare_post_imp, simp)
     apply (rule hoare_weaken_pre)
      apply (wp ct_in_state'_set asUser_ct sts_invs_minor'
           | wp (once) sch_act_simple_lift)+
-      apply (rule_tac Q="\<lambda>_. st_tcb_at' runnable' thread
+      apply (rule_tac Q'="\<lambda>_. st_tcb_at' runnable' thread
                              and sch_act_simple and invs'
                              and (\<lambda>s. thread = ksCurThread s)"
                in hoare_post_imp, clarsimp)
@@ -194,7 +194,7 @@ lemma setupReplyMaster_weak_sch_act_wf[wp]:
    \<lbrace>\<lambda>rv s. weak_sch_act_wf (ksSchedulerAction s) s\<rbrace>"
   apply (simp add: setupReplyMaster_def)
   apply (wp)
-    apply (rule_tac Q="\<lambda>_ s. weak_sch_act_wf (ksSchedulerAction s) s"
+    apply (rule_tac Q'="\<lambda>_ s. weak_sch_act_wf (ksSchedulerAction s) s"
                in hoare_post_imp, clarsimp)
     apply (wp)+
   apply assumption
@@ -220,11 +220,11 @@ lemma restart_corres:
               apply (wp set_thread_state_runnable_weak_valid_sched_action sts_st_tcb_at'
                         sts_st_tcb' sts_valid_objs'
                      | clarsimp simp: valid_tcb_state'_def | strengthen valid_objs'_valid_tcbs')+
-         apply (rule_tac Q="\<lambda>rv. valid_sched and cur_tcb and pspace_aligned and pspace_distinct"
+         apply (rule_tac Q'="\<lambda>rv. valid_sched and cur_tcb and pspace_aligned and pspace_distinct"
                          in hoare_strengthen_post)
           apply wp
          apply (fastforce simp: valid_sched_def valid_sched_action_def)
-        apply (rule_tac Q="\<lambda>rv. invs' and ex_nonz_cap_to' t" in hoare_strengthen_post)
+        apply (rule_tac Q'="\<lambda>rv. invs' and ex_nonz_cap_to' t" in hoare_strengthen_post)
          apply wp
         apply (clarsimp simp: invs'_def valid_state'_def sch_act_wf_weak valid_pspace'_def
                               valid_tcb_state'_def)
@@ -360,10 +360,10 @@ lemma invokeTCB_WriteRegisters_corres:
                                 valid_sched_valid_queues valid_objs'_valid_tcbs' invs_valid_objs'
                    | clarsimp simp: invs_def valid_state_def valid_sched_def invs'_def valid_state'_def
                              dest!: global'_no_ex_cap idle_no_ex_cap)+)[2]
-         apply (rule_tac Q="\<lambda>_. einvs and tcb_at dest and ex_nonz_cap_to dest" in hoare_strengthen_post[rotated])
+         apply (rule_tac Q'="\<lambda>_. einvs and tcb_at dest and ex_nonz_cap_to dest" in hoare_strengthen_post[rotated])
           apply (fastforce simp: invs_def valid_sched_weak_strg valid_sched_def valid_state_def dest!: idle_no_ex_cap)
          prefer 2
-         apply (rule_tac Q="\<lambda>_. invs' and tcb_at' dest and ex_nonz_cap_to' dest" in hoare_strengthen_post[rotated])
+         apply (rule_tac Q'="\<lambda>_. invs' and tcb_at' dest and ex_nonz_cap_to' dest" in hoare_strengthen_post[rotated])
           apply (fastforce simp: sch_act_wf_weak invs'_def valid_state'_def dest!: global'_no_ex_cap)
          apply (wp | clarsimp)+
   done
@@ -471,10 +471,10 @@ proof -
                     apply (rule_tac P=\<top> and P'=\<top> in corres_inst)
                     apply simp
                    apply (solves \<open>wp hoare_weak_lift_imp\<close>)+
-             apply (rule_tac Q="\<lambda>_. einvs and tcb_at dest" in hoare_post_imp)
+             apply (rule_tac Q'="\<lambda>_. einvs and tcb_at dest" in hoare_post_imp)
               apply (fastforce simp: invs_def valid_state_def valid_pspace_def valid_sched_weak_strg valid_sched_def)
              prefer 2
-             apply (rule_tac Q="\<lambda>_. invs' and tcb_at' dest" in hoare_post_imp)
+             apply (rule_tac Q'="\<lambda>_. invs' and tcb_at' dest" in hoare_post_imp)
               apply (fastforce simp: invs'_def valid_state'_def invs_weak_sch_act_wf cur_tcb'_def)
              apply ((wp mapM_x_wp' hoare_weak_lift_imp | (simp add: cur_tcb'_def[symmetric])+)+)[8]
          apply ((wp hoare_weak_lift_imp restart_invs' | wpc | clarsimp simp: if_apply_def2)+)[2]
@@ -546,7 +546,7 @@ lemma tcbSchedDequeue_not_queued:
    \<lbrace>\<lambda>rv. obj_at' (Not \<circ> tcbQueued) t\<rbrace>"
   apply (simp add: tcbSchedDequeue_def)
   apply (wp | simp)+
-  apply (rule_tac Q="\<lambda>rv. obj_at' (\<lambda>obj. tcbQueued obj = rv) t"
+  apply (rule_tac Q'="\<lambda>rv. obj_at' (\<lambda>obj. tcbQueued obj = rv) t"
                in hoare_post_imp)
    apply (clarsimp simp: obj_at'_def)
   apply (wp tg_sp' [where P=\<top>, simplified] | simp)+
@@ -1436,7 +1436,7 @@ proof -
   have B: "\<And>t v. \<lbrace>invs' and tcb_at' t\<rbrace> threadSet (tcbFaultHandler_update v) t \<lbrace>\<lambda>rv. invs'\<rbrace>"
     by (wp threadSet_invs_trivial | clarsimp simp: inQ_def)+
   note stuff = Z B out_invs_trivial hoare_case_option_wp
-    hoare_vcg_const_Ball_lift hoare_vcg_const_Ball_lift_R
+    hoare_vcg_const_Ball_lift hoare_vcg_const_Ball_liftE_R
     cap_delete_deletes cap_delete_valid_cap out_valid_objs
     cap_insert_objs
     cteDelete_deletes cteDelete_sch_act_simple
@@ -1471,7 +1471,7 @@ proof -
                   apply (rule corres_returnOkTT, simp)
                  apply wp
                 apply wp
-               apply (wpsimp wp: hoare_vcg_const_imp_lift_R hoare_vcg_const_imp_lift
+               apply (wpsimp wp: hoare_vcg_const_imp_liftE_R hoare_vcg_const_imp_lift
                                  hoare_vcg_all_liftE_R hoare_vcg_all_lift
                                  as_user_invs thread_set_ipc_tcb_cap_valid
                                  thread_set_tcb_ipc_buffer_cap_cleared_invs
@@ -1492,7 +1492,7 @@ proof -
                                  threadSet_invs_tcbIPCBuffer_update threadSet_cte_wp_at'
                       | strengthen simple_sched_action_sched_act_not)+
                 apply ((wpsimp wp: stuff hoare_vcg_all_liftE_R hoare_vcg_all_lift
-                                   hoare_vcg_const_imp_lift_R hoare_vcg_const_imp_lift
+                                   hoare_vcg_const_imp_liftE_R hoare_vcg_const_imp_lift
                                    threadSet_valid_objs' thread_set_not_state_valid_sched
                                    thread_set_tcb_ipc_buffer_cap_cleared_invs thread_set_cte_wp_at_trivial
                                    thread_set_no_cap_to_trivial getThreadBufferSlot_dom_tcb_cte_cases
@@ -1528,7 +1528,7 @@ proof -
                          in hoare_strengthen_postE_R[simplified validE_R_def, rotated])
              apply (case_tac g'; clarsimp simp: isCap_simps ; clarsimp elim: invs_valid_objs' cong:imp_cong)
             apply (wp add: stuff hoare_vcg_all_liftE_R hoare_vcg_all_lift
-                                 hoare_vcg_const_imp_lift_R hoare_vcg_const_imp_lift setMCPriority_invs'
+                                 hoare_vcg_const_imp_liftE_R hoare_vcg_const_imp_lift setMCPriority_invs'
                                  threadSet_valid_objs' thread_set_not_state_valid_sched setP_invs'
                                  typ_at_lifts [OF setPriority_typ_at']
                                  typ_at_lifts [OF setMCPriority_typ_at']
@@ -1605,15 +1605,15 @@ lemma tc_invs':
       apply (wpsimp wp: hoare_weak_lift_imp hoare_vcg_all_lift
                         checkCap_inv[where P="tcb_at' t" for t] assertDerived_wp_weak
                         threadSet_invs_trivial2 threadSet_tcb'  hoare_vcg_all_lift threadSet_cte_wp_at')+
-       apply (wpsimp wp: hoare_weak_lift_imp_R cteDelete_deletes
-                         hoare_vcg_all_liftE_R hoare_vcg_conj_liftE1 hoare_vcg_const_imp_lift_R hoare_vcg_propE_R
+       apply (wpsimp wp: hoare_weak_lift_impE_R cteDelete_deletes
+                         hoare_vcg_all_liftE_R hoare_vcg_conj_liftE1 hoare_vcg_const_imp_liftE_R hoare_vcg_propE_R
                          cteDelete_invs' cteDelete_invs' cteDelete_typ_at'_lifts)+
      apply (assumption | clarsimp cong: conj_cong imp_cong | (rule case_option_wp_None_returnOk)
             | wpsimp wp: hoare_weak_lift_imp hoare_vcg_all_lift checkCap_inv[where P="tcb_at' t" for t] assertDerived_wp_weak
                          hoare_vcg_imp_lift' hoare_vcg_all_lift checkCap_inv[where P="tcb_at' t" for t]
                          checkCap_inv[where P="valid_cap' c" for c] checkCap_inv[where P=sch_act_simple]
-                         hoare_vcg_const_imp_lift_R assertDerived_wp_weak hoare_weak_lift_imp_R cteDelete_deletes
-                         hoare_vcg_all_liftE_R hoare_vcg_conj_liftE1 hoare_vcg_const_imp_lift_R hoare_vcg_propE_R
+                         hoare_vcg_const_imp_liftE_R assertDerived_wp_weak hoare_weak_lift_impE_R cteDelete_deletes
+                         hoare_vcg_all_liftE_R hoare_vcg_conj_liftE1 hoare_vcg_const_imp_liftE_R hoare_vcg_propE_R
                          cteDelete_invs' cteDelete_typ_at'_lifts cteDelete_sch_act_simple)+
   apply (clarsimp simp: tcb_cte_cases_def cte_level_bits_def objBits_defs tcbIPCBufferSlot_def)
   by (auto dest!: isCapDs isReplyCapD isValidVTableRootD simp: isCap_simps)
@@ -2654,7 +2654,7 @@ lemma inv_tcb_IRQInactive:
   apply (rule hoare_pre)
    apply (wpc |
           wp withoutPreemption_R cteDelete_IRQInactive checkCap_inv
-             hoare_vcg_const_imp_lift_R cteDelete_irq_states'
+             hoare_vcg_const_imp_liftE_R cteDelete_irq_states'
              hoare_vcg_const_imp_lift |
           simp add: split_def)+
   done

--- a/proof/refine/ARM/Untyped_R.thy
+++ b/proof/refine/ARM/Untyped_R.thy
@@ -399,7 +399,7 @@ next
             apply (simp add: unat_arith_simps)
            apply wp+
           apply simp
-          apply (rule hoare_strengthen_post [where Q = "\<lambda>r. invs and valid_cap r and cte_at slot"])
+          apply (rule hoare_strengthen_post[where Q'="\<lambda>r. invs and valid_cap r and cte_at slot"])
            apply wp+
           apply (clarsimp simp: is_cap_simps bits_of_def cap_aligned_def
                                 valid_cap_def word_bits_def)
@@ -407,7 +407,7 @@ next
           apply (strengthen refl exI[mk_strg I E] exI[where x=d])+
           apply simp
          apply wp+
-         apply (rule hoare_strengthen_post [where Q = "\<lambda>r. invs' and cte_at' (cte_map slot)"])
+         apply (rule hoare_strengthen_post[where Q'="\<lambda>r. invs' and cte_at' (cte_map slot)"])
           apply wp+
          apply (clarsimp simp:invs_pspace_aligned' invs_pspace_distinct')
          apply auto[1]
@@ -3149,7 +3149,7 @@ lemma createNewCaps_parent_helper:
                        (\<forall>tup\<in>set (zip (xs rv) rv).
                                 sameRegionAs (cteCap cte) (snd tup)))
     p\<rbrace>"
-  apply (rule hoare_post_imp [where Q="\<lambda>rv s. \<exists>cte. cte_wp_at' ((=) cte) p s
+  apply (rule hoare_post_imp[where Q'="\<lambda>rv s. \<exists>cte. cte_wp_at' ((=) cte) p s
                                            \<and> isUntypedCap (cteCap cte)
                                            \<and> (\<forall>tup\<in>set (zip (xs rv) rv).
                                 sameRegionAs (cteCap cte) (snd tup))"])
@@ -4516,7 +4516,7 @@ lemma resetUntypedCap_invs_etc:
               | strengthen invs_pspace_aligned' invs_pspace_distinct'
               | simp add: ct_in_state'_def
                           sch_act_simple_def
-              | rule hoare_vcg_conj_lift_R
+              | rule hoare_vcg_conj_liftE_R
               | wp (once) preemptionPoint_inv
               | wps
               | wp (once) ex_cte_cap_to'_pres)+
@@ -5228,7 +5228,7 @@ crunch insertNewCap
 lemma insertNewCap_ct_idle_or_in_cur_domain'[wp]:
   "\<lbrace>ct_idle_or_in_cur_domain' and ct_active'\<rbrace> insertNewCap parent slot cap \<lbrace>\<lambda>_. ct_idle_or_in_cur_domain'\<rbrace>"
 apply (wp ct_idle_or_in_cur_domain'_lift_futz[where Q=\<top>])
-apply (rule_tac Q="\<lambda>_. obj_at' (\<lambda>tcb. tcbState tcb \<noteq> Structures_H.thread_state.Inactive) t and obj_at' (\<lambda>tcb. d = tcbDomain tcb) t"
+apply (rule_tac Q'="\<lambda>_. obj_at' (\<lambda>tcb. tcbState tcb \<noteq> Structures_H.thread_state.Inactive) t and obj_at' (\<lambda>tcb. d = tcbDomain tcb) t"
              in hoare_strengthen_post)
 apply (wp | clarsimp elim: obj_at'_weakenE)+
 apply (auto simp: obj_at'_def)

--- a/proof/refine/ARM/VSpace_R.thy
+++ b/proof/refine/ARM/VSpace_R.thy
@@ -612,12 +612,12 @@ lemma find_pd_for_asid_pd_at_asid_again:
   apply (unfold validE_def, rule hoare_name_pre_state, fold validE_def)
   apply (case_tac "\<exists>pd. vspace_at_asid asid pd s")
    apply clarsimp
-   apply (rule_tac Q="\<lambda>rv s'. s' = s \<and> rv = pd" and E="\<bottom>\<bottom>" in hoare_strengthen_postE)
+   apply (rule_tac Q'="\<lambda>rv s'. s' = s \<and> rv = pd" and E'="\<bottom>\<bottom>" in hoare_strengthen_postE)
      apply (rule hoare_pre, wp find_pd_for_asid_valids)
      apply fastforce
     apply simp+
-  apply (rule_tac Q="\<lambda>rv s'. s' = s \<and> vspace_at_asid asid rv s'"
-              and E="\<lambda>rv s'. s' = s" in hoare_strengthen_postE)
+  apply (rule_tac Q'="\<lambda>rv s'. s' = s \<and> vspace_at_asid asid rv s'"
+              and E'="\<lambda>rv s'. s' = s" in hoare_strengthen_postE)
     apply (rule hoare_pre, wp)
     apply clarsimp+
   done
@@ -1021,7 +1021,7 @@ lemma deleteASIDPool_corres:
               apply (simp only:)
               apply (rule setVMRoot_corres)
              apply wp+
-         apply (rule_tac R="\<lambda>_ s. rv = arm_asid_table (arch_state s)"
+         apply (rule_tac Q'="\<lambda>_ s. rv = arm_asid_table (arch_state s)"
                     in hoare_post_add)
          apply (drule sym, simp only: )
          apply (drule sym, simp only: )
@@ -1037,7 +1037,7 @@ lemma deleteASIDPool_corres:
          apply (rule hoare_vcg_conj_lift,
                  (rule mapM_invalidate[where ptr=ptr])?,
                  ((wp mapM_wp' | simp)+)[1])+
-        apply (rule_tac R="\<lambda>_ s. rv' = armKSASIDTable (ksArchState s)"
+        apply (rule_tac Q'="\<lambda>_ s. rv' = armKSASIDTable (ksArchState s)"
                      in hoare_post_add)
         apply (simp only: pred_conj_def cong: conj_cong)
         apply simp
@@ -1629,11 +1629,11 @@ lemma unmapPage_corres:
                 | wp mapM_wp')+
           apply (fastforce simp: invs_vspace_objs[simplified])
          apply (wp lookupPTSlot_inv mapM_wp' | wpc | clarsimp)+
-        apply (wp hoare_vcg_const_imp_lift_R
+        apply (wp hoare_vcg_const_imp_liftE_R
              | strengthen lookup_pd_slot_kernel_mappings_strg not_in_global_refs_vs_lookup
                page_directory_at_lookup_mask_aligned_strg lookup_pd_slot_kernel_mappings_set_strg
                page_directory_at_lookup_mask_add_aligned_strg
-             | wp hoare_vcg_const_Ball_lift_R
+             | wp hoare_vcg_const_Ball_liftE_R
              | simp)+
    apply (clarsimp simp add: valid_unmap_def valid_asid_def)
    apply (case_tac sz)
@@ -2142,7 +2142,7 @@ proof -
                       apply (clarsimp simp add: when_def)
                       apply (rule invalidate_tlb_by_asid_corres_ex)
                      apply (wp hoare_vcg_ex_lift)+
-                 apply (rule_tac Q="\<lambda>_. K (word \<le> mask asid_bits \<and> word \<noteq> 0) and invs
+                 apply (rule_tac Q'="\<lambda>_. K (word \<le> mask asid_bits \<and> word \<noteq> 0) and invs
                                     and (\<lambda>s. \<exists>pd. vspace_at_asid word pd s)"
                          in hoare_strengthen_post)
                   prefer 2
@@ -2194,7 +2194,7 @@ proof -
                      apply (clarsimp simp: when_def)
                      apply (rule invalidate_tlb_by_asid_corres_ex)
                     apply (wp hoare_vcg_ex_lift)+
-                apply (rule_tac Q="\<lambda>_. K (word \<le> mask asid_bits \<and> word \<noteq> 0) and invs
+                apply (rule_tac Q'="\<lambda>_. K (word \<le> mask asid_bits \<and> word \<noteq> 0) and invs
                                    and (\<lambda>s. \<exists>pd. vspace_at_asid word pd s)" in hoare_strengthen_post)
                  prefer 2
                  apply (auto simp: invs_vspace_objs[simplified])[1]
@@ -3488,7 +3488,7 @@ lemma perform_pt_invs [wp]:
   apply clarsimp
   apply (wp arch_update_updateCap_invs unmapPage_cte_wp_at' getSlotCap_wp|wpc)+
   apply (rename_tac acap word a b)
-  apply (rule_tac Q="\<lambda>_. invs' and cte_wp_at' (\<lambda>cte. \<exists>d r R sz m. cteCap cte =
+  apply (rule_tac Q'="\<lambda>_. invs' and cte_wp_at' (\<lambda>cte. \<exists>d r R sz m. cteCap cte =
                                        ArchObjectCap (PageCap d r R sz m)) word"
                in hoare_strengthen_post)
     apply (wp unmapPage_cte_wp_at')

--- a/proof/refine/ARM/orphanage/Orphanage.thy
+++ b/proof/refine/ARM/orphanage/Orphanage.thy
@@ -575,7 +575,7 @@ lemma tcbSchedDequeue_no_orphans[wp]:
   apply (rule hoare_allI)
   apply (rename_tac tcb_ptr)
   apply (case_tac "tcb_ptr = tcbPtr")
-   apply (rule_tac Q="\<lambda>_ s. st_tcb_at' (\<lambda>state. \<not> is_active_thread_state state) tcbPtr s"
+   apply (rule_tac Q'="\<lambda>_ s. st_tcb_at' (\<lambda>state. \<not> is_active_thread_state state) tcbPtr s"
                 in hoare_post_imp)
     apply fastforce
    apply wpsimp
@@ -863,7 +863,7 @@ proof -
      \<lbrace>\<lambda>_. no_orphans\<rbrace>"
     apply (wpsimp wp: scheduleChooseNewThread_no_orphans ssa_no_orphans
                       hoare_vcg_all_lift ThreadDecls_H_switchToThread_no_orphans)+
-     apply (rule_tac Q="\<lambda>_ s. (t = candidate \<longrightarrow> ksCurThread s = candidate) \<and>
+     apply (rule_tac Q'="\<lambda>_ s. (t = candidate \<longrightarrow> ksCurThread s = candidate) \<and>
                                (t \<noteq> candidate \<longrightarrow> sch_act_not t s)"
               in hoare_post_imp)
       apply (wpsimp wp: stt_nosch hoare_weak_lift_imp)+
@@ -1069,7 +1069,7 @@ lemma sendIPC_no_orphans [wp]:
             possibleSwitchTo_almost_no_orphans'
          | wpc
          | clarsimp simp: is_active_thread_state_def isRestart_def isRunning_def)+
-  apply (rule_tac Q="\<lambda>rv. no_orphans and valid_objs' and ko_at' rv epptr
+  apply (rule_tac Q'="\<lambda>rv. no_orphans and valid_objs' and ko_at' rv epptr
                           and (\<lambda>s. sch_act_wf (ksSchedulerAction s) s)" in hoare_post_imp)
    apply (fastforce simp: valid_objs'_def valid_obj'_def valid_ep'_def obj_at'_def projectKOs)
   apply (wp get_ep_sp' | clarsimp)+
@@ -1294,7 +1294,7 @@ lemma cancelAllIPC_no_orphans[wp]:
                     and I="no_orphans and (\<lambda>s. \<forall>t\<in>set list. tcb_at' t s)"
                      in mapM_x_inv_wp2
              | clarsimp simp: valid_tcb_state'_def)+
-  apply (rule_tac Q="\<lambda>rv. no_orphans and valid_objs' and pspace_aligned' and pspace_distinct'
+  apply (rule_tac Q'="\<lambda>rv. no_orphans and valid_objs' and pspace_aligned' and pspace_distinct'
                           and ko_at' rv epptr"
                in hoare_post_imp)
    apply (fastforce simp: valid_obj'_def valid_ep'_def obj_at'_def projectKOs)
@@ -1318,7 +1318,7 @@ lemma cancelAllSignals_no_orphans[wp]:
    apply (wp sts_valid_objs' set_ntfn_valid_objs' sts_st_tcb'
             hoare_vcg_const_Ball_lift tcbSchedEnqueue_almost_no_orphans|
           clarsimp simp: valid_tcb_state'_def)+
-  apply (rule_tac Q="\<lambda>rv. no_orphans and valid_objs' and pspace_aligned' and pspace_distinct'
+  apply (rule_tac Q'="\<lambda>rv. no_orphans and valid_objs' and pspace_aligned' and pspace_distinct'
                           and ko_at' rv ntfn"
                in hoare_post_imp)
    apply (fastforce simp: valid_obj'_def valid_ntfn'_def obj_at'_def projectKOs)
@@ -1464,7 +1464,7 @@ lemma deleteASIDPool_no_orphans [wp]:
    \<lbrace> \<lambda>rv s. no_orphans s \<rbrace>"
   unfolding deleteASIDPool_def
   apply (wp | clarsimp)+
-     apply (rule_tac Q="\<lambda>rv s. no_orphans s" in hoare_post_imp)
+     apply (rule_tac Q'="\<lambda>rv s. no_orphans s" in hoare_post_imp)
       apply (clarsimp simp: no_orphans_def all_queued_tcb_ptrs_def
                             all_active_tcb_ptrs_def is_active_tcb_ptr_def)
      apply (wp mapM_wp_inv getObject_inv loadObject_default_inv | clarsimp)+
@@ -1580,7 +1580,7 @@ lemma cteRevoke_no_orphans [wp]:
   "\<lbrace> \<lambda>s. no_orphans s \<and> invs' s \<and> sch_act_simple s \<rbrace>
    cteRevoke ptr
    \<lbrace> \<lambda>rv s. no_orphans s \<rbrace>"
-  apply (rule_tac Q="\<lambda>rv s. no_orphans s \<and> invs' s \<and> sch_act_simple s"
+  apply (rule_tac Q'="\<lambda>rv s. no_orphans s \<and> invs' s \<and> sch_act_simple s"
                       in hoare_strengthen_post)
    apply (wp cteRevoke_preservation cteDelete_invs' cteDelete_sch_act_simple)+
       apply auto
@@ -1609,7 +1609,7 @@ lemma doReplyTransfer_no_orphans[wp]:
          | wpc | clarsimp simp: is_active_thread_state_def isRunning_def isRestart_def
          | wp (once) hoare_drop_imps
          | strengthen sch_act_wf_weak)+
-              apply (rule_tac Q="\<lambda>rv. invs' and no_orphans" in hoare_post_imp)
+              apply (rule_tac Q'="\<lambda>rv. invs' and no_orphans" in hoare_post_imp)
                apply (fastforce simp: inQ_def)
               apply (wp hoare_drop_imps | clarsimp)+
   apply (clarsimp simp:invs'_def valid_state'_def valid_pspace'_def)
@@ -1691,7 +1691,7 @@ lemma setPriority_no_orphans[wp]:
    \<lbrace>\<lambda>_. no_orphans\<rbrace>"
   unfolding setPriority_def
   apply wpsimp
-    apply (rule_tac Q="\<lambda>_ s. almost_no_orphans tptr s \<and> weak_sch_act_wf (ksSchedulerAction s) s" in hoare_post_imp)
+    apply (rule_tac Q'="\<lambda>_ s. almost_no_orphans tptr s \<and> weak_sch_act_wf (ksSchedulerAction s) s" in hoare_post_imp)
      apply clarsimp
      apply (clarsimp simp: is_active_tcb_ptr_runnable' pred_tcb_at'_def obj_at'_def
                            almost_no_orphans_no_orphans elim!: almost_no_orphans_no_orphans')
@@ -1748,7 +1748,7 @@ lemma tc_no_orphans:
                checkCap_inv[where P="valid_cap' c" for c] checkCap_inv[where P=sch_act_simple]
                checkCap_inv[where P=no_orphans] checkCap_inv[where P="tcb_at' a"]
                threadSet_cte_wp_at' hoare_vcg_all_liftE_R hoare_vcg_all_lift threadSet_no_orphans
-               hoare_vcg_const_imp_lift_R hoare_weak_lift_imp hoare_drop_imp threadSet_ipcbuffer_invs
+               hoare_vcg_const_imp_liftE_R hoare_weak_lift_imp hoare_drop_imp threadSet_ipcbuffer_invs
           | (simp add: locateSlotTCB_def locateSlotBasic_def objBits_def
                      objBitsKO_def tcbIPCBufferSlot_def tcb_cte_cases_def,
            wp hoare_return_sp)
@@ -1879,7 +1879,7 @@ lemma performASIDControlInvocation_no_orphans [wp]:
   apply (clarsimp simp: performASIDControlInvocation_def
                   split: asidcontrol_invocation.splits)
   apply (wp hoare_weak_lift_imp | clarsimp)+
-    apply (rule_tac Q="\<lambda>rv s. no_orphans s" in hoare_post_imp)
+    apply (rule_tac Q'="\<lambda>rv s. no_orphans s" in hoare_post_imp)
      apply (clarsimp simp: no_orphans_def all_active_tcb_ptrs_def
                            is_active_tcb_ptr_def all_queued_tcb_ptrs_def)
     apply (wp | clarsimp simp:placeNewObject_def2)+
@@ -1974,7 +1974,7 @@ lemma handleInvocation_no_orphans [wp]:
   unfolding handleInvocation_def
   apply (rule hoare_pre)
    apply (wp syscall_valid' setThreadState_isRestart_no_orphans | wpc | clarsimp)+
-          apply (rule_tac Q="\<lambda>state s. no_orphans s \<and> invs' s \<and>
+          apply (rule_tac Q'="\<lambda>state s. no_orphans s \<and> invs' s \<and>
                              (state = Structures_H.thread_state.Restart \<longrightarrow>
                               st_tcb_at' isRestart thread s)"
                        in hoare_post_imp)
@@ -2033,7 +2033,7 @@ notes if_cong[cong] shows
   apply (clarsimp simp: whenE_def split del: if_split | wp hoare_drop_imps getNotification_wp | wpc )+ (*takes a while*)
      apply (rule_tac Q'="\<lambda>rv s. no_orphans s \<and> invs' s" in hoare_strengthen_postE_R)
       apply (wp, fastforce)
-    apply (rule_tac Q="\<lambda>rv s. no_orphans s \<and> invs' s" in hoare_post_imp)
+    apply (rule_tac Q'="\<lambda>rv s. no_orphans s \<and> invs' s" in hoare_post_imp)
      apply (wp | clarsimp | fastforce)+
   done
 
@@ -2046,7 +2046,7 @@ lemma handleReply_no_orphans [wp]:
   apply (rule hoare_pre)
    apply (wp hoare_drop_imps | wpc | clarsimp)+
      apply (wp hoare_vcg_all_lift)
-      apply (rule_tac Q="\<lambda>rv s. no_orphans s \<and> invs' s \<and> tcb_at' thread s \<and>
+      apply (rule_tac Q'="\<lambda>rv s. no_orphans s \<and> invs' s \<and> tcb_at' thread s \<and>
                                 valid_cap' rv s" in hoare_post_imp)
        apply (wp hoare_drop_imps | clarsimp simp: valid_cap'_def
               | clarsimp simp: invs'_def cur_tcb'_def valid_state'_def)+

--- a/proof/refine/ARM_HYP/Arch_R.thy
+++ b/proof/refine/ARM_HYP/Arch_R.thy
@@ -1320,7 +1320,7 @@ lemma associateVCPUTCB_corres:
   apply (corresKsimp search: getObject_vcpu_corres setObject_VCPU_corres vcpuSwitch_corres''
                         wp: get_vcpu_wp getVCPU_wp hoare_vcg_imp_lift'
                       simp: vcpu_relation_def)
-      apply (rule_tac Q="\<lambda>_. invs and tcb_at t" in hoare_strengthen_post)
+      apply (rule_tac Q'="\<lambda>_. invs and tcb_at t" in hoare_strengthen_post)
        apply wp
       apply clarsimp
       apply (rule conjI)
@@ -1329,7 +1329,7 @@ lemma associateVCPUTCB_corres:
        apply (frule (1) sym_refs_vcpu_tcb, fastforce)
        apply (fastforce simp: obj_at_def)+
      apply (wpsimp)+
-     apply (rule_tac Q="\<lambda>_. invs' and tcb_at' t" in hoare_strengthen_post)
+     apply (rule_tac Q'="\<lambda>_. invs' and tcb_at' t" in hoare_strengthen_post)
       apply wpsimp
      apply clarsimp
      apply (rule conjI)
@@ -1891,8 +1891,8 @@ lemma arch_decodeInvocation_wf[wp]:
                  cong: list.case_cong prod.case_cong)
       apply (rule hoare_pre)
        apply (wpsimp simp: valid_arch_inv'_def valid_page_inv'_def)+
-             apply (rule hoare_vcg_conj_lift_R,(wp ensureSafeMapping_inv)[1])+
-             apply (wpsimp wp: whenE_throwError_wp checkVP_wpR hoare_vcg_const_imp_lift_R hoare_drop_impE_R
+             apply (rule hoare_vcg_conj_liftE_R,(wp ensureSafeMapping_inv)[1])+
+             apply (wpsimp wp: whenE_throwError_wp checkVP_wpR hoare_vcg_const_imp_liftE_R hoare_drop_impE_R
                                ensureSafeMapping_valid_slots_duplicated'
                                createMappingEntries_valid_pde_slots' findPDForASID_page_directory_at'
                          simp: valid_arch_inv'_def valid_page_inv'_def)+
@@ -2354,14 +2354,14 @@ lemma associateVCPUTCB_invs'[wp]:
   apply (clarsimp simp: associateVCPUTCB_def)
   apply (subst bind_assoc[symmetric], fold associateVCPUTCB_helper_def)
   apply wpsimp
-       apply (rule_tac Q="\<lambda>_ s. invs' s \<and> ko_wp_at' (is_vcpu' and hyp_live') vcpu s" in hoare_post_imp)
+       apply (rule_tac Q'="\<lambda>_ s. invs' s \<and> ko_wp_at' (is_vcpu' and hyp_live') vcpu s" in hoare_post_imp)
         apply simp
        apply (rule hoare_vcg_conj_lift)
         apply (wpsimp wp: assoc_invs'[folded associateVCPUTCB_helper_def])
        apply (clarsimp simp: associateVCPUTCB_helper_def)
        apply (wpsimp simp: vcpu_at_is_vcpu'[symmetric])+
      apply (wpsimp wp: getVCPU_wp)
-    apply (rule_tac Q="\<lambda>_. invs' and obj_at' (\<lambda>tcb. atcbVCPUPtr (tcbArch tcb) = None) tcb and
+    apply (rule_tac Q'="\<lambda>_. invs' and obj_at' (\<lambda>tcb. atcbVCPUPtr (tcbArch tcb) = None) tcb and
                            ex_nonz_cap_to' vcpu and ex_nonz_cap_to' tcb and vcpu_at' vcpu"
                     in hoare_strengthen_post)
      apply wpsimp

--- a/proof/refine/ARM_HYP/CNodeInv_R.thy
+++ b/proof/refine/ARM_HYP/CNodeInv_R.thy
@@ -6578,8 +6578,8 @@ lemma cteDelete_sch_act_simple:
      cteDelete slot exposed \<lbrace>\<lambda>rv. sch_act_simple\<rbrace>"
   apply (simp add: cteDelete_def whenE_def split_def)
   apply (wp hoare_drop_imps | simp)+
-  apply (rule_tac hoare_strengthen_postE [where Q="\<lambda>rv. sch_act_simple"
-                                       and E="\<lambda>rv. sch_act_simple"])
+  apply (rule_tac hoare_strengthen_postE [where Q'="\<lambda>rv. sch_act_simple"
+                                       and E'="\<lambda>rv. sch_act_simple"])
     apply (rule valid_validE)
     apply (wp finaliseSlot_sch_act_simple)
     apply simp+

--- a/proof/refine/ARM_HYP/CNodeInv_R.thy
+++ b/proof/refine/ARM_HYP/CNodeInv_R.thy
@@ -206,7 +206,7 @@ lemma decodeCNodeInvocation_corres:
                       apply (rule corres_trivial)
                       subgoal by (auto simp add: whenE_def, auto simp add: returnOk_def)
                      apply (wp | wpc | simp(no_asm))+
-                 apply (wp hoare_vcg_const_imp_lift_R hoare_vcg_const_imp_lift
+                 apply (wp hoare_vcg_const_imp_liftE_R hoare_vcg_const_imp_lift
                            hoare_vcg_all_liftE_R hoare_vcg_all_lift lsfco_cte_at' hoare_drop_imps
                                 | clarsimp)+
          subgoal by (auto elim!: valid_cnode_capI)
@@ -6166,7 +6166,7 @@ lemma reduceZombie_invs'':
           apply (wp | simp)+
          apply (rule getCTE_wp)
         apply (wp | simp)+
-      apply (rule_tac Q="\<lambda>cte s. rv = capZombiePtr cap +
+      apply (rule_tac Q'="\<lambda>cte s. rv = capZombiePtr cap +
                                       of_nat (capZombieNumber cap) * 2^cteSizeBits - 2^cteSizeBits
                               \<and> cte_wp_at' (\<lambda>c. c = cte) slot s \<and> invs' s
                               \<and> no_cte_prop Q s \<and> sch_act_simple s"
@@ -6489,8 +6489,8 @@ lemmas cteDelete_typ_at'_lifts [wp] = typ_at_lifts [OF cteDelete_typ_at']
 
 lemma cteDelete_cte_at:
   "\<lbrace>\<top>\<rbrace> cteDelete slot bool \<lbrace>\<lambda>rv. cte_at' slot\<rbrace>"
-  apply (rule_tac Q="\<lambda>s. cte_at' slot s \<or> \<not> cte_at' slot s"
-               in hoare_pre(1))
+  apply (rule_tac P'="\<lambda>s. cte_at' slot s \<or> \<not> cte_at' slot s"
+               in hoare_weaken_pre)
    apply (rule hoare_strengthen_post)
     apply (rule hoare_vcg_disj_lift)
      apply (rule typ_at_lifts, rule cteDelete_typ_at')
@@ -6529,7 +6529,7 @@ lemma cteDelete_cte_wp_at_invs:
       apply (clarsimp simp: cte_wp_at_ctes_of)
      apply wp
     apply (simp add: imp_conjR conj_comms)
-    apply (rule_tac Q="\<lambda>rv s. invs' s \<and> sch_act_simple s \<and>
+    apply (rule_tac Q'="\<lambda>rv s. invs' s \<and> sch_act_simple s \<and>
                    (fst rv \<longrightarrow>
                        cte_wp_at' (\<lambda>cte. removeable' slot s (cteCap cte)) slot s) \<and>
                    (fst rv \<longrightarrow>
@@ -6540,9 +6540,9 @@ lemma cteDelete_cte_wp_at_invs:
                                          cteCap cte = NullCap \<or>
                                          (\<exists>zb n. cteCap cte = Zombie slot zb n))
                                   slot s)"
-                and E="\<lambda>rv. \<top>" in hoare_strengthen_postE)
+                and E'="\<lambda>rv. \<top>" in hoare_strengthen_postE)
       apply (wp finaliseSlot_invs finaliseSlot_removeable finaliseSlot_sch_act_simple
-                hoare_drop_imps(2)[OF finaliseSlot_irqs])
+                hoare_drop_impE_R[OF finaliseSlot_irqs])
        apply (rule hoare_strengthen_postE_R, rule finaliseSlot_abort_cases)
        apply (clarsimp simp: cte_wp_at_ctes_of dest!: isCapDs)
       apply simp
@@ -6564,7 +6564,7 @@ lemma cteDelete_cte_wp_at_invs:
                              p s"
                in hoare_strengthen_postE_R)
     apply (wp finaliseSlot_invs finaliseSlot_removeable finaliseSlot_sch_act_simple
-              hoare_drop_imps(2)[OF finaliseSlot_irqs])
+              hoare_drop_impE_R[OF finaliseSlot_irqs])
     apply (rule hoare_strengthen_postE_R [OF finaliseSlot_cte_wp_at[where p=p and P=P]])
       apply simp+
     apply (clarsimp simp: cte_wp_at_ctes_of)
@@ -6765,7 +6765,7 @@ proof (induct rule: finalise_induct3)
           apply ((wp | simp add: locateSlot_conv)+)[2]
         apply (rule drop_spec_validE)
         apply simp
-        apply (rule_tac Q="\<lambda>rv s. revoke_progress_ord m (option_map capToRPO \<circ> cteCaps_of s)
+        apply (rule_tac Q'="\<lambda>rv s. revoke_progress_ord m (option_map capToRPO \<circ> cteCaps_of s)
                                      \<and> cte_wp_at' (\<lambda>cte. cteCap cte = fst rvb) sl s"
                          in hoare_post_imp)
          apply (clarsimp simp: o_def cte_wp_at_ctes_of capToRPO_def
@@ -7336,7 +7336,7 @@ next
                 apply (rule updateCap_corres)
                  apply simp
                 apply (simp add: is_cap_simps)
-               apply (rule_tac R="\<lambda>rv. cte_at' (cte_map ?target)" in hoare_post_add)
+               apply (rule_tac Q'="\<lambda>rv. cte_at' (cte_map ?target)" in hoare_post_add)
                apply (wp, (wp getCTE_wp)+)
               apply (clarsimp simp: cte_wp_at_ctes_of)
              apply (rule no_fail_pre, wp, simp)
@@ -7498,7 +7498,7 @@ lemma cteRevoke_typ_at':
 
 lemma cteRevoke_invs':
   "\<lbrace>invs' and sch_act_simple\<rbrace> cteRevoke ptr \<lbrace>\<lambda>rv. invs'\<rbrace>"
-  apply (rule_tac Q="\<lambda>rv. invs' and sch_act_simple" in hoare_strengthen_post)
+  apply (rule_tac Q'="\<lambda>rv. invs' and sch_act_simple" in hoare_strengthen_post)
   apply (wp cteRevoke_preservation cteDelete_invs' cteDelete_sch_act_simple)+
     apply simp_all
   done
@@ -9067,7 +9067,7 @@ proof (induct rule: finalise_spec_induct)
             apply (unfold Let_def split_def fst_conv snd_conv
                           case_Zombie_assert_fold haskell_fail_def)
             apply (wp getCTE_wp' preemptionPoint_invR| simp add: o_def irq_state_independent_HI)+
-            apply (rule hoare_post_imp [where Q="\<lambda>_. valid_irq_states'"])
+            apply (rule hoare_post_imp[where Q'="\<lambda>_. valid_irq_states'"])
              apply simp
             apply wp[1]
            apply (rule spec_strengthen_postE)
@@ -9110,7 +9110,7 @@ lemma cteDelete_irq_states':
   apply (simp add: cteDelete_def split_def)
   apply (wp whenE_wp)
    apply (rule hoare_strengthen_postE)
-     apply (rule hoare_valid_validE)
+     apply (rule valid_validE)
      apply (rule finaliseSlot_irq_states')
     apply simp
    apply simp

--- a/proof/refine/ARM_HYP/CSpace_R.thy
+++ b/proof/refine/ARM_HYP/CSpace_R.thy
@@ -2147,7 +2147,7 @@ lemma cteInsert_mdb' [wp]:
   cteInsert cap src dest
   \<lbrace>\<lambda>_. valid_mdb'\<rbrace>"
   apply (simp add:valid_mdb'_def valid_mdb_ctes_def)
-  apply (rule_tac Q = "\<lambda>r s. valid_dlist (ctes_of s) \<and> irq_control (ctes_of s) \<and>
+  apply (rule_tac Q'="\<lambda>r s. valid_dlist (ctes_of s) \<and> irq_control (ctes_of s) \<and>
                no_0 (ctes_of s) \<and> mdb_chain_0 (ctes_of s) \<and>
                mdb_chunked (ctes_of s) \<and> untyped_mdb' (ctes_of s) \<and> untyped_inc' (ctes_of s) \<and>
                Q s" for Q
@@ -4013,12 +4013,12 @@ lemma setupReplyMaster_corres:
        apply (fastforce dest: pspace_relation_no_reply_caps
                              state_relation_pspace_relation)
       apply (clarsimp simp: cte_map_def tcb_cnode_index_def cte_wp_at_ctes_of)
-     apply (rule_tac Q="\<lambda>rv. einvs and tcb_at t and
+     apply (rule_tac Q'="\<lambda>rv. einvs and tcb_at t and
                              cte_wp_at ((=) rv) (t, tcb_cnode_index 2)"
                   in hoare_strengthen_post)
       apply (wp hoare_drop_imps get_cap_wp)
      apply (clarsimp simp: invs_def valid_state_def elim!: cte_wp_at_weakenE)
-    apply (rule_tac Q="\<lambda>rv. valid_pspace' and valid_mdb' and
+    apply (rule_tac Q'="\<lambda>rv. valid_pspace' and valid_mdb' and
                             cte_wp_at' ((=) rv) (cte_map (t, tcb_cnode_index 2))"
                  in hoare_strengthen_post)
      apply (wp hoare_drop_imps getCTE_wp')

--- a/proof/refine/ARM_HYP/Detype_R.thy
+++ b/proof/refine/ARM_HYP/Detype_R.thy
@@ -64,7 +64,7 @@ lemma descendants_range_in_lift':
   apply (simp only: Ball_def[unfolded imp_conv_disj])
   apply (rule hoare_pre)
    apply (wp hoare_vcg_all_lift hoare_vcg_disj_lift st cap_range)
-   apply (rule_tac Q = "\<lambda>r s. cte_wp_at' (\<lambda>c. capRange (cteCap c) \<inter> S = {}) x s"
+   apply (rule_tac Q'="\<lambda>r s. cte_wp_at' (\<lambda>c. capRange (cteCap c) \<inter> S = {}) x s"
       in hoare_strengthen_post)
     apply (wp cap_range)
    apply (clarsimp simp:cte_wp_at_ctes_of null_filter'_def)
@@ -1834,7 +1834,7 @@ lemma deleteObjects_invs':
 proof -
   show ?thesis
   apply (rule hoare_pre)
-   apply (rule_tac G="is_aligned ptr bits \<and> 2 \<le> bits \<and> bits \<le> word_bits" in hoare_grab_asm)
+   apply (rule_tac P'="is_aligned ptr bits \<and> 2 \<le> bits \<and> bits \<le> word_bits" in hoare_grab_asm)
    apply (clarsimp simp add: deleteObjects_def2)
    apply (simp add: freeMemory_def bind_assoc doMachineOp_bind ef_storeWord)
    apply (simp add: bind_assoc[where f="\<lambda>_. modify f" for f, symmetric])
@@ -4084,7 +4084,7 @@ lemma createNewCaps_pspace_no_overlap':
          apply simp+
     apply (simp add:range_cover_def)
    apply (simp add:range_cover.sz(1)[where 'a=32, folded word_bits_def])
-  apply (rule_tac Q = "\<lambda>r. pspace_no_overlap' (ptr + (1 + of_nat n << Types_H.getObjectSize ty us))
+  apply (rule_tac Q'="\<lambda>r. pspace_no_overlap' (ptr + (1 + of_nat n << Types_H.getObjectSize ty us))
                                               (Types_H.getObjectSize ty us) and
                            pspace_aligned' and pspace_distinct'" in hoare_strengthen_post)
    apply (case_tac ty)

--- a/proof/refine/ARM_HYP/Finalise_R.thy
+++ b/proof/refine/ARM_HYP/Finalise_R.thy
@@ -4013,7 +4013,7 @@ lemma no_idle_thread_cap:
 
 lemmas getCTE_no_0_obj'_helper
   = getCTE_inv
-    hoare_strengthen_post[where Q'="\<lambda>_. no_0_obj'" and P=no_0_obj' and a="getCTE slot" for slot]
+    hoare_strengthen_post[where Q'="\<lambda>_. no_0_obj'" and P=no_0_obj' and f="getCTE slot" for slot]
 
 context begin interpretation Arch . (*FIXME: arch_split*)
 context

--- a/proof/refine/ARM_HYP/Finalise_R.thy
+++ b/proof/refine/ARM_HYP/Finalise_R.thy
@@ -1796,7 +1796,7 @@ lemma isFinalCapability_inv:
   apply (simp add: isFinalCapability_def Let_def
               split del: if_split cong: if_cong)
   apply (rule hoare_pre, wp)
-   apply (rule hoare_post_imp [where Q="\<lambda>s. P"], simp)
+   apply (rule hoare_post_imp[where Q'="\<lambda>s. P"], simp)
    apply wp
   apply simp
   done
@@ -2452,7 +2452,7 @@ lemma deleteASID_invs'[wp]:
   apply (simp add: deleteASID_def cong: option.case_cong)
   apply (rule hoare_pre)
    apply (wp | wpc)+
-    apply (rule_tac Q="\<lambda>rv. valid_obj' (injectKO rv) and invs'"
+    apply (rule_tac Q'="\<lambda>rv. valid_obj' (injectKO rv) and invs'"
               in hoare_post_imp)
      apply (rename_tac rv s)
      apply (clarsimp split: if_split_asm del: subsetI)
@@ -3134,7 +3134,7 @@ lemma cancelIPC_bound_tcb_at'[wp]:
   apply (simp add: getThreadReplySlot_def locateSlot_conv liftM_def)
   apply (rule hoare_pre)
    apply (wp capDeleteOne_bound_tcb_at' getCTE_ctes_of)
-   apply (rule_tac Q="\<lambda>_. bound_tcb_at' P tptr" in hoare_post_imp)
+   apply (rule_tac Q'="\<lambda>_. bound_tcb_at' P tptr" in hoare_post_imp)
    apply (clarsimp simp: capHasProperty_def cte_wp_at_ctes_of)
    apply (wp threadSet_pred_tcb_no_state | simp)+
   done
@@ -4013,7 +4013,7 @@ lemma no_idle_thread_cap:
 
 lemmas getCTE_no_0_obj'_helper
   = getCTE_inv
-    hoare_strengthen_post[where Q="\<lambda>_. no_0_obj'" and P=no_0_obj' and a="getCTE slot" for slot]
+    hoare_strengthen_post[where Q'="\<lambda>_. no_0_obj'" and P=no_0_obj' and a="getCTE slot" for slot]
 
 context begin interpretation Arch . (*FIXME: arch_split*)
 context

--- a/proof/refine/ARM_HYP/Interrupt_R.thy
+++ b/proof/refine/ARM_HYP/Interrupt_R.thy
@@ -381,7 +381,7 @@ lemma invokeIRQHandler_corres:
        apply simp
        apply (rule corres_split_nor[OF cap_delete_one_corres])
          apply (rule cteInsert_corres, simp+)
-        apply (rule_tac Q="\<lambda>rv s. einvs s \<and> cte_wp_at (\<lambda>c. c = cap.NullCap) irq_slot s
+        apply (rule_tac Q'="\<lambda>rv s. einvs s \<and> cte_wp_at (\<lambda>c. c = cap.NullCap) irq_slot s
                                   \<and> (a, b) \<noteq> irq_slot
                                   \<and> cte_wp_at (is_derived (cdt s) (a, b) cap) (a, b) s"
                       in hoare_post_imp)
@@ -856,7 +856,7 @@ proof -
                     apply (clarsimp simp: pred_tcb_at_def obj_at_def invs_psp_aligned invs_distinct)
                    apply wp
                   apply clarsimp
-                  apply (rule_tac Q="\<lambda>rv x. tcb_at' rv x
+                  apply (rule_tac Q'="\<lambda>rv x. tcb_at' rv x
                                             \<and> invs' x
                                             \<and> sch_act_not rv x"
                            in hoare_post_imp)
@@ -930,7 +930,7 @@ lemma vppiEvent_corres:
                    clarsimp simp: invs_psp_aligned invs_distinct)
            apply wp
           apply (clarsimp cong: imp_cong conj_cong simp: pred_conj_def)
-          apply (rule_tac Q="\<lambda>rv x. tcb_at' rv x
+          apply (rule_tac Q'="\<lambda>rv x. tcb_at' rv x
                                     \<and> invs' x
                                     \<and> sch_act_not rv x" in hoare_post_imp)
            apply (rename_tac rv s)
@@ -1078,7 +1078,7 @@ lemma timerTick_invs'[wp]:
   apply (wpsimp wp: threadSet_invs_trivial threadSet_pred_tcb_no_state
                     rescheduleRequired_all_invs_but_ct_not_inQ
               simp: tcb_cte_cases_def)
-      apply (rule_tac Q="\<lambda>rv. invs'" in hoare_post_imp)
+      apply (rule_tac Q'="\<lambda>rv. invs'" in hoare_post_imp)
        apply (clarsimp simp: invs'_def valid_state'_def)
       apply (simp add: decDomainTime_def)
       apply wp
@@ -1089,7 +1089,7 @@ lemma timerTick_invs'[wp]:
                            hoare_vcg_imp_lift threadSet_ct_idle_or_in_cur_domain')+
             apply (rule hoare_strengthen_post[OF tcbSchedAppend_all_invs_but_ct_not_inQ'])
             apply (wpsimp simp: invs'_def valid_state'_def valid_pspace'_def sch_act_wf_weak)+
-           apply (rule_tac Q="\<lambda>_. invs'" in hoare_strengthen_post)
+           apply (rule_tac Q'="\<lambda>_. invs'" in hoare_strengthen_post)
             apply (wpsimp wp: threadSet_pred_tcb_no_state threadSet_tcbDomain_triv
                               threadSet_valid_objs' threadSet_timeslice_invs)+
            apply (clarsimp simp: invs'_def valid_state'_def valid_pspace'_def)
@@ -1136,7 +1136,7 @@ lemma vgicMaintenance_invs'[wp]:
             apply (strengthen st_tcb_ex_cap''[where P=active'])
             apply (strengthen invs_iflive')
             apply (clarsimp cong: imp_cong conj_cong simp: pred_conj_def)
-            apply (rule_tac Q="\<lambda>_ s. tcb_at' (ksCurThread s) s
+            apply (rule_tac Q'="\<lambda>_ s. tcb_at' (ksCurThread s) s
                                       \<and> invs' s
                                       \<and> sch_act_not (ksCurThread s) s"
                     in hoare_post_imp)
@@ -1169,7 +1169,7 @@ lemma vppiEvent_invs'[wp]:
             apply (strengthen st_tcb_ex_cap''[where P=active'])
             apply (strengthen invs_iflive')
             apply (clarsimp cong: imp_cong conj_cong simp: pred_conj_def)
-            apply (rule_tac Q="\<lambda>_ s. tcb_at' (ksCurThread s) s
+            apply (rule_tac Q'="\<lambda>_ s. tcb_at' (ksCurThread s) s
                                       \<and> invs' s
                                       \<and> sch_act_not (ksCurThread s) s"
                     in hoare_post_imp)
@@ -1191,7 +1191,7 @@ lemma hint_invs[wp]:
   apply (simp add: handleInterrupt_def getSlotCap_def cong: irqstate.case_cong)
   apply (rule conjI; rule impI)
    apply (wp dmo_maskInterrupt_True getCTE_wp' | wpc | simp add: doMachineOp_bind maskIrqSignal_def)+
-    apply (rule_tac Q="\<lambda>rv. invs'" in hoare_post_imp)
+    apply (rule_tac Q'="\<lambda>rv. invs'" in hoare_post_imp)
      apply (clarsimp simp: cte_wp_at_ctes_of ex_nonz_cap_to'_def)
      apply fastforce
     apply (wpsimp wp: threadSet_invs_trivial getIRQState_wp

--- a/proof/refine/ARM_HYP/Interrupt_R.thy
+++ b/proof/refine/ARM_HYP/Interrupt_R.thy
@@ -848,7 +848,7 @@ proof -
                      apply (wp gts_wp)
                     apply (wp gts_wp')
                    apply (rule_tac
-                            Q="\<lambda>rv. tcb_at rv and einvs
+                            Q'="\<lambda>rv. tcb_at rv and einvs
                                     and (\<lambda>_. valid_fault (ExceptionTypes_A.fault.ArchFault rva))"
                             in hoare_post_imp)
                     apply (clarsimp cong: imp_cong conj_cong simp: not_pred_tcb runnable_eq pred_conj_def)
@@ -921,7 +921,7 @@ lemma vppiEvent_corres:
                 is runnable directly afterwards, which is obvious and should not propagate further;
                 clean up the postconditions of the thread_get and threadGet *)
            apply (rule_tac
-                    Q="\<lambda>rv. tcb_at rv and einvs
+                    Q'="\<lambda>rv. tcb_at rv and einvs
                             and (\<lambda>_. valid_fault (ExceptionTypes_A.fault.ArchFault
                                                     (ARM_A.VPPIEvent irq)))"
                     in hoare_post_imp)

--- a/proof/refine/ARM_HYP/IpcCancel_R.thy
+++ b/proof/refine/ARM_HYP/IpcCancel_R.thy
@@ -935,7 +935,7 @@ lemma (in delete_one_conc_pre) cancelIPC_sch_act_simple[wp]:
   apply (wp hoare_drop_imps delete_one_sch_act_simple
        | simp add: getThreadReplySlot_def | wpcw
        | rule sch_act_simple_lift
-       | (rule_tac Q="\<lambda>rv. sch_act_simple" in hoare_post_imp, simp))+
+       | (rule_tac Q'="\<lambda>rv. sch_act_simple" in hoare_post_imp, simp))+
   done
 
 lemma cancelSignal_st_tcb_at:
@@ -945,7 +945,7 @@ lemma cancelSignal_st_tcb_at:
    \<lbrace>\<lambda>rv. st_tcb_at' P t\<rbrace>"
   apply (simp add: cancelSignal_def Let_def list_case_If)
   apply (wp sts_st_tcb_at'_cases hoare_vcg_const_imp_lift
-            hoare_drop_imp[where R="%rv s. P' rv" for P'])
+            hoare_drop_imp[where Q'="%rv s. P' rv" for P'])
    apply clarsimp+
   done
 
@@ -1033,7 +1033,7 @@ lemma (in delete_one_conc_pre) cancelIPC_tcb_at_runnable':
    apply (rule_tac Q'="\<lambda>st. st_tcb_at' runnable' t and K (runnable' st)" in bind_wp)
     apply(case_tac rv; simp)
    apply (wpsimp wp: sts_pred_tcb_neq')+
-           apply (rule_tac Q="\<lambda>rv. ?PRE" in hoare_post_imp, fastforce)
+           apply (rule_tac Q'="\<lambda>rv. ?PRE" in hoare_post_imp, fastforce)
            apply (wp cteDeleteOne_tcb_at_runnable'
                     threadSet_pred_tcb_no_state
                     cancelSignal_tcb_at_runnable'
@@ -1133,7 +1133,7 @@ lemma sts_weak_sch_act_wf[wp]:
   including classic_wp_pre
   apply (simp add: setThreadState_def)
   apply (wp rescheduleRequired_weak_sch_act_wf)
-  apply (rule_tac Q="\<lambda>_ s. weak_sch_act_wf (ksSchedulerAction s) s" in hoare_post_imp, simp)
+  apply (rule_tac Q'="\<lambda>_ s. weak_sch_act_wf (ksSchedulerAction s) s" in hoare_post_imp, simp)
   apply (simp add: weak_sch_act_wf_def)
   apply (wp hoare_vcg_all_lift)
    apply (wps threadSet_nosch)
@@ -1259,11 +1259,11 @@ lemma (in delete_one) suspend_corres:
            apply (wpsimp simp: update_restart_pc_def updateRestartPC_def)+
           apply (wpsimp wp: sts_valid_objs')
           apply (wpsimp simp: update_restart_pc_def updateRestartPC_def valid_tcb_state'_def)+
-       apply (rule hoare_post_imp[where Q = "\<lambda>_ s. einvs s \<and> tcb_at t s"])
+       apply (rule hoare_post_imp[where Q'="\<lambda>_ s. einvs s \<and> tcb_at t s"])
         apply (simp add: invs_implies invs_strgs valid_queues_in_correct_ready_q
                          valid_queues_ready_qs_distinct valid_sched_def)
        apply wp
-      apply (rule hoare_post_imp[where Q = "\<lambda>_ s. invs' s \<and> tcb_at' t s"])
+      apply (rule hoare_post_imp[where Q'="\<lambda>_ s. invs' s \<and> tcb_at' t s"])
        apply (fastforce simp: invs'_def valid_tcb_state'_def)
       apply (wpsimp simp: update_restart_pc_def updateRestartPC_def)+
    apply fastforce+
@@ -1458,7 +1458,7 @@ lemma (in delete_one_conc) suspend_invs'[wp]:
   apply (simp add: suspend_def)
   apply (wpsimp wp: sts_invs_minor' gts_wp' simp: updateRestartPC_def
          | strengthen no_refs_simple_strg')+
-   apply (rule_tac Q="\<lambda>_. invs' and sch_act_simple and st_tcb_at' simple' t
+   apply (rule_tac Q'="\<lambda>_. invs' and sch_act_simple and st_tcb_at' simple' t
                           and (\<lambda>s. t \<noteq> ksIdleThread s)"
                 in hoare_post_imp)
     apply clarsimp
@@ -1488,7 +1488,7 @@ lemma (in delete_one_conc_pre) suspend_sch_act_simple[wp]:
 lemma (in delete_one_conc) suspend_objs':
   "\<lbrace>invs' and sch_act_simple and tcb_at' t and (\<lambda>s. t \<noteq> ksIdleThread s)\<rbrace>
    suspend t \<lbrace>\<lambda>rv. valid_objs'\<rbrace>"
-  apply (rule_tac Q="\<lambda>_. invs'" in hoare_strengthen_post)
+  apply (rule_tac Q'="\<lambda>_. invs'" in hoare_strengthen_post)
    apply (wp suspend_invs')
   apply fastforce
   done
@@ -1601,7 +1601,7 @@ proof -
         apply (rule ep_cancel_corres_helper)
        apply (rule mapM_x_wp')
        apply (wp weak_sch_act_wf_lift_linear set_thread_state_runnable_weak_valid_sched_action | simp)+
-      apply (rule_tac R="\<lambda>_ s. \<forall>x\<in>set list. tcb_at' x s \<and> valid_objs' s \<and> pspace_aligned' s \<and> pspace_distinct' s"
+      apply (rule_tac Q'="\<lambda>_ s. \<forall>x\<in>set list. tcb_at' x s \<and> valid_objs' s \<and> pspace_aligned' s \<and> pspace_distinct' s"
                    in hoare_post_add)
       apply (rule mapM_x_wp')
       apply ((wpsimp wp: hoare_vcg_const_Ball_lift mapM_x_wp' sts_st_tcb' sts_valid_objs'
@@ -1662,7 +1662,7 @@ lemma cancelAllSignals_corres:
                  set_thread_state_runnable_weak_valid_sched_action
             | simp)+
       apply (rename_tac list)
-      apply (rule_tac R="\<lambda>_ s. (\<forall>x\<in>set list. tcb_at' x s) \<and> valid_objs' s
+      apply (rule_tac Q'="\<lambda>_ s. (\<forall>x\<in>set list. tcb_at' x s) \<and> valid_objs' s
                                \<and> sym_heap_sched_pointers s \<and> valid_sched_pointers s \<and> valid_objs' s
                                \<and> pspace_aligned' s \<and> pspace_distinct' s"
                    in hoare_post_add)
@@ -1710,7 +1710,7 @@ proof -
   show ?thesis
   apply (simp add: setThreadState_def)
   apply (wpsimp wp: hoare_vcg_imp_lift [OF nrct])
-   apply (rule_tac Q="\<lambda>_. ?PRE" in hoare_post_imp)
+   apply (rule_tac Q'="\<lambda>_. ?PRE" in hoare_post_imp)
     apply (clarsimp)
    apply (rule hoare_convert_imp [OF threadSet_nosch threadSet_ct])
   apply assumption
@@ -1961,7 +1961,7 @@ lemma cancelAllIPC_valid_objs'[wp]:
   apply (rule bind_wp [OF _ get_ep_sp'])
   apply (rule hoare_pre)
    apply (wp set_ep_valid_objs' setSchedulerAction_valid_objs')
-    apply (rule_tac Q="\<lambda>_ s. valid_objs' s \<and> pspace_aligned' s \<and> pspace_distinct' s
+    apply (rule_tac Q'="\<lambda>_ s. valid_objs' s \<and> pspace_aligned' s \<and> pspace_distinct' s
                              \<and> (\<forall>x\<in>set (epQueue ep). tcb_at' x s)"
                     in hoare_post_imp)
      apply simp
@@ -1987,7 +1987,7 @@ lemma cancelAllSignals_valid_objs'[wp]:
     apply (wp, simp)
    apply (wp, simp)
   apply (rename_tac list)
-  apply (rule_tac Q="\<lambda>rv s. valid_objs' s \<and> (\<forall>x\<in>set list. tcb_at' x s)"
+  apply (rule_tac Q'="\<lambda>rv s. valid_objs' s \<and> (\<forall>x\<in>set list. tcb_at' x s)"
                   in hoare_post_imp)
    apply (simp add: valid_ntfn'_def)
   apply (simp add: Ball_def)
@@ -2296,7 +2296,7 @@ lemma cancelBadgedSends_corres:
     apply (rule corres_split_nor[OF setEndpoint_corres])
        apply (simp add: ep_relation_def)
       apply (rule corres_split_eqr[OF _ _ _ hoare_post_add
-                                             [where R="\<lambda>_. valid_objs' and pspace_aligned'
+                                             [where Q'="\<lambda>_. valid_objs' and pspace_aligned'
                                                            and pspace_distinct'"]])
          apply (rule_tac S="(=)"
                      and Q="\<lambda>xs s. (\<forall>x \<in> set xs. (epptr, TCBBlockedSend) \<in> state_refs_of s x) \<and>

--- a/proof/refine/ARM_HYP/Ipc_R.thy
+++ b/proof/refine/ARM_HYP/Ipc_R.thy
@@ -489,7 +489,7 @@ next
         apply clarsimp
         apply assumption
        apply (subst imp_conjR)
-       apply (rule hoare_vcg_conj_liftE_R)
+       apply (rule hoare_vcg_conj_liftE_R')
         apply (rule derive_cap_is_derived)
        apply (wp derive_cap_is_derived_foo)+
       apply (simp split del: if_split)
@@ -501,7 +501,7 @@ next
        apply clarsimp
        apply assumption
       apply (subst imp_conjR)
-      apply (rule hoare_vcg_conj_liftE_R)
+      apply (rule hoare_vcg_conj_liftE_R')
        apply (rule hoare_strengthen_postE_R[OF deriveCap_derived])
        apply (clarsimp simp:cte_wp_at_ctes_of)
       apply (wp deriveCap_derived_foo)
@@ -613,7 +613,7 @@ lemma cteInsert_assume_Null:
    apply (rule bind_wp[OF _ getCTE_sp])+
    apply (rule hoare_name_pre_state)
    apply (clarsimp simp: cte_wp_at_ctes_of)
-  apply (erule hoare_pre(1))
+  apply (erule hoare_weaken_pre)
   apply simp
   done
 
@@ -1860,7 +1860,7 @@ declare asUser_global_refs' [wp]
 lemma lec_valid_cap' [wp]:
   "\<lbrace>valid_objs'\<rbrace> lookupExtraCaps thread xa mi \<lbrace>\<lambda>rv s. (\<forall>x\<in>set rv. s \<turnstile>' fst x)\<rbrace>, -"
   apply (rule hoare_pre, rule hoare_strengthen_postE_R)
-    apply (rule hoare_vcg_conj_lift_R[where R=valid_objs' and S="\<lambda>_. valid_objs'"])
+    apply (rule hoare_vcg_conj_liftE_R[where R=valid_objs' and S="\<lambda>_. valid_objs'"])
      apply (rule lookupExtraCaps_srcs)
     apply wp
    apply (clarsimp simp: cte_wp_at_ctes_of)
@@ -2263,7 +2263,7 @@ lemma doReplyTransfer_corres:
           apply (fastforce)
          apply (clarsimp simp:is_cap_simps)
         apply (wp weak_valid_sched_action_lift)+
-       apply (rule_tac Q="\<lambda>_ s. valid_objs' s \<and> cur_tcb' s \<and> tcb_at' receiver s
+       apply (rule_tac Q'="\<lambda>_ s. valid_objs' s \<and> cur_tcb' s \<and> tcb_at' receiver s
                                 \<and> sch_act_wf (ksSchedulerAction s) s
                                 \<and> sym_heap_sched_pointers s \<and> valid_sched_pointers s
                                 \<and> pspace_aligned' s \<and> pspace_distinct' s"
@@ -2320,7 +2320,7 @@ lemma doReplyTransfer_corres:
                              threadSet_tcbDomain_triv threadSet_valid_objs'
                              threadSet_sched_pointers threadSet_valid_sched_pointers
                         | simp add: valid_tcb_state'_def)+
-     apply (rule_tac Q="\<lambda>_. valid_sched and cur_tcb and tcb_at sender and tcb_at receiver and
+     apply (rule_tac Q'="\<lambda>_. valid_sched and cur_tcb and tcb_at sender and tcb_at receiver and
                             valid_objs and pspace_aligned and pspace_distinct"
                      in hoare_strengthen_post [rotated], clarsimp)
      apply (wp)
@@ -2328,7 +2328,7 @@ lemma doReplyTransfer_corres:
       apply (assumption)
      apply (rule conjI, clarsimp)
      apply (clarsimp simp add: invs_def valid_state_def valid_pspace_def)
-    apply (rule_tac Q="\<lambda>_. tcb_at' sender and tcb_at' receiver and invs'"
+    apply (rule_tac Q'="\<lambda>_. tcb_at' sender and tcb_at' receiver and invs'"
                     in hoare_strengthen_post [rotated])
      apply (solves\<open>auto simp: invs'_def valid_state'_def\<close>)
     apply wp
@@ -2410,14 +2410,14 @@ lemma setupCallerCap_corres:
                               tcb_cnode_index_def cte_level_bits_def)
             apply (simp add: cte_map_def tcbCallerSlot_def
                              tcb_cnode_index_def cte_level_bits_def)
-           apply (rule_tac R="\<lambda>rv. cte_at' (receiver + 2 ^ cte_level_bits * tcbCallerSlot)"
+           apply (rule_tac Q'="\<lambda>rv. cte_at' (receiver + 2 ^ cte_level_bits * tcbCallerSlot)"
                     in hoare_post_add)
 
            apply (wp, (wp getSlotCap_wp)+)
           apply blast
          apply (rule no_fail_pre, wp)
          apply (clarsimp simp: cte_wp_at'_def cte_at'_def)
-        apply (rule_tac R="\<lambda>rv. cte_at' (sender + 2 ^ cte_level_bits * tcbReplySlot)"
+        apply (rule_tac Q'="\<lambda>rv. cte_at' (sender + 2 ^ cte_level_bits * tcbReplySlot)"
                      in hoare_post_add)
         apply (wp, (wp getCTE_wp')+)
        apply blast
@@ -2760,7 +2760,7 @@ lemma sendSignal_corres:
                                valid_queues_in_correct_ready_q valid_queues_ready_qs_distinct
                                valid_sched_valid_queues
                   | simp add: valid_tcb_state_def)+
-         apply (rule_tac Q="\<lambda>rv. invs' and tcb_at' a" in hoare_strengthen_post)
+         apply (rule_tac Q'="\<lambda>rv. invs' and tcb_at' a" in hoare_strengthen_post)
           apply wp
          apply (fastforce simp: invs'_def valid_state'_def sch_act_wf_weak valid_tcb_state'_def)
         apply (rule setNotification_corres)
@@ -2788,7 +2788,7 @@ lemma sendSignal_corres:
           apply (rule corres_split[OF asUser_setRegister_corres])
             apply (rule possibleSwitchTo_corres)
            apply ((wp | simp)+)[1]
-          apply (rule_tac Q="\<lambda>_. (\<lambda>s. sch_act_wf (ksSchedulerAction s) s) and
+          apply (rule_tac Q'="\<lambda>_. (\<lambda>s. sch_act_wf (ksSchedulerAction s) s) and
                                  cur_tcb' and
                                  st_tcb_at' runnable' (hd list) and valid_objs' and
                                  sym_heap_sched_pointers and valid_sched_pointers and
@@ -2983,7 +2983,7 @@ lemma cancelIPC_nonz_cap_to'[wp]:
        | wpc
        | simp
        | clarsimp elim!: cte_wp_at_weakenE'
-       | rule hoare_post_imp[where Q="\<lambda>rv. ex_nonz_cap_to' p"])+
+       | rule hoare_post_imp[where Q'="\<lambda>rv. ex_nonz_cap_to' p"])+
   done
 
 
@@ -3063,7 +3063,7 @@ proof -
           apply (wpc)
            apply (wp | simp)+
        apply (wpc, wp+)
-     apply (rule_tac Q="\<lambda>_. ?PRE t'" in hoare_post_imp, clarsimp)
+     apply (rule_tac Q'="\<lambda>_. ?PRE t'" in hoare_post_imp, clarsimp)
      apply (wp)
     apply simp
     done
@@ -3075,7 +3075,7 @@ proof -
     apply (wp)
         apply (wp hoare_convert_imp)[1]
        apply (wp)
-      apply (rule_tac Q="\<lambda>_. ?PRE t'" in hoare_post_imp, clarsimp)
+      apply (rule_tac Q'="\<lambda>_. ?PRE t'" in hoare_post_imp, clarsimp)
       apply (wp hoare_convert_imp | simp)+
      done
   show ?thesis
@@ -3088,16 +3088,16 @@ proof -
         apply (wp)+
            apply (wp hoare_convert_imp)[1]
           apply (wpc, wp+)
-        apply (rule_tac Q="\<lambda>_. ?PRE t'" in hoare_post_imp, clarsimp)
+        apply (rule_tac Q'="\<lambda>_. ?PRE t'" in hoare_post_imp, clarsimp)
         apply (wp cdo)+
-         apply (rule_tac Q="\<lambda>_. ?PRE t'" in hoare_post_imp, clarsimp)
+         apply (rule_tac Q'="\<lambda>_. ?PRE t'" in hoare_post_imp, clarsimp)
          apply ((wp aipc hoare_convert_imp)+)[6]
     apply (wp)
        apply (wp hoare_convert_imp)[1]
       apply (wpc, wp+)
-    apply (rule_tac Q="\<lambda>_. ?PRE t'" in hoare_post_imp, clarsimp)
+    apply (rule_tac Q'="\<lambda>_. ?PRE t'" in hoare_post_imp, clarsimp)
     apply (wp)
-   apply (rule_tac Q="\<lambda>_. ?PRE t'" in hoare_post_imp, clarsimp)
+   apply (rule_tac Q'="\<lambda>_. ?PRE t'" in hoare_post_imp, clarsimp)
    apply (wp)
   apply simp
   done
@@ -3356,7 +3356,7 @@ lemma receiveIPC_corres:
                                              valid_sched_action_def)
                      apply (clarsimp split: if_split_asm)
                     apply (clarsimp | wp do_ipc_transfer_tcb_caps)+
-                   apply (rule_tac Q="\<lambda>_ s. sch_act_wf (ksSchedulerAction s) s
+                   apply (rule_tac Q'="\<lambda>_ s. sch_act_wf (ksSchedulerAction s) s
                                             \<and> sym_heap_sched_pointers s \<and> valid_sched_pointers s
                                             \<and> pspace_aligned' s \<and> pspace_distinct' s"
                                 in hoare_post_imp)
@@ -3632,7 +3632,7 @@ lemma setupCallerCap_vp[wp]:
   apply (simp add: valid_pspace'_def setupCallerCap_def getThreadCallerSlot_def
                    getThreadReplySlot_def locateSlot_conv getSlotCap_def)
   apply (wp getCTE_wp)
-  apply (rule_tac Q="\<lambda>_. valid_pspace' and
+  apply (rule_tac Q'="\<lambda>_. valid_pspace' and
                          tcb_at' sender and tcb_at' rcvr"
                   in hoare_post_imp)
    apply (clarsimp simp: valid_cap'_def o_def cte_wp_at_ctes_of isCap_simps
@@ -3665,7 +3665,7 @@ lemma setupCallerCap_ifunsafe[wp]:
   apply (wp getSlotCap_cte_wp_at
        | simp add: unique_master_reply_cap' | strengthen eq_imp_strg
        | wp (once) hoare_drop_imp[where f="getCTE rs" for rs])+
-   apply (rule_tac Q="\<lambda>rv. valid_objs' and tcb_at' rcvr and ex_nonz_cap_to' rcvr"
+   apply (rule_tac Q'="\<lambda>rv. valid_objs' and tcb_at' rcvr and ex_nonz_cap_to' rcvr"
                 in hoare_post_imp)
     apply (clarsimp simp: ex_nonz_tcb_cte_caps' tcbCallerSlot_def
                           objBits_def objBitsKO_def dom_def cte_level_bits_def)
@@ -3833,7 +3833,7 @@ lemma completeSignal_invs:
   apply (rule bind_wp[OF _ get_ntfn_sp'])
   apply (rule hoare_pre)
    apply (wp set_ntfn_minor_invs' | wpc | simp)+
-    apply (rule_tac Q="\<lambda>_ s. (state_refs_of' s ntfnptr = ntfn_bound_refs' (ntfnBoundTCB ntfn))
+    apply (rule_tac Q'="\<lambda>_ s. (state_refs_of' s ntfnptr = ntfn_bound_refs' (ntfnBoundTCB ntfn))
                            \<and> ntfn_at' ntfnptr s
                            \<and> valid_ntfn' (ntfnObj_update (\<lambda>_. Structures_H.ntfn.IdleNtfn) ntfn) s
                            \<and> ((\<exists>y. ntfnBoundTCB ntfn = Some y) \<longrightarrow> ex_nonz_cap_to' ntfnptr s)
@@ -3863,7 +3863,7 @@ lemma setupCallerCap_urz[wp]:
                    getThreadCallerSlot_def getThreadReplySlot_def
                    locateSlot_conv)
   apply (wp getCTE_wp')
-  apply (rule_tac Q="\<lambda>_. untyped_ranges_zero' and valid_mdb' and valid_objs'" in hoare_post_imp)
+  apply (rule_tac Q'="\<lambda>_. untyped_ranges_zero' and valid_mdb' and valid_objs'" in hoare_post_imp)
    apply (clarsimp simp: cte_wp_at_ctes_of cteCaps_of_def untyped_derived_eq_def
                          isCap_simps)
   apply (wp sts_valid_pspace_hangers)
@@ -3913,7 +3913,7 @@ lemma ri_invs' [wp]:
   apply (rule bind_wp [OF _ gbn_sp'])
   apply (rule bind_wp)
   (* set up precondition for old proof *)
-   apply (rule_tac R="ko_at' ep (capEPPtr cap) and ?pre" in hoare_vcg_if_split)
+   apply (rule_tac P''="ko_at' ep (capEPPtr cap) and ?pre" in hoare_vcg_if_split)
     apply (wp completeSignal_invs)
    apply (case_tac ep)
      \<comment> \<open>endpoint = RecvEP\<close>
@@ -4155,7 +4155,7 @@ lemma setupCallerCap_cap_to' [wp]:
   "\<lbrace>ex_nonz_cap_to' p\<rbrace> setupCallerCap a b c \<lbrace>\<lambda>rv. ex_nonz_cap_to' p\<rbrace>"
   apply (simp add: setupCallerCap_def getThreadCallerSlot_def getThreadReplySlot_def)
   apply (wp cteInsert_cap_to')
-       apply (rule_tac Q="\<lambda>rv. ex_nonz_cap_to' p
+       apply (rule_tac Q'="\<lambda>rv. ex_nonz_cap_to' p
                            and cte_wp_at' (\<lambda>c. (cteCap c) = rv) callerSlot"
                     in hoare_post_imp)
         apply (clarsimp simp: cte_wp_at_ctes_of)
@@ -4216,9 +4216,9 @@ lemma si_invs'[wp]:
                hoare_convert_imp [OF setEndpoint_nosch setEndpoint_ct']
                hoare_drop_imp [where f="threadGet tcbFault t"]
              | rule_tac f="getThreadState a" in hoare_drop_imp
-             | wp (once) hoare_drop_imp[where R="\<lambda>_ _. call"]
-               hoare_drop_imp[where R="\<lambda>_ _. \<not> call"]
-               hoare_drop_imp[where R="\<lambda>_ _. cg"]
+             | wp (once) hoare_drop_imp[where Q'="\<lambda>_ _. call"]
+               hoare_drop_imp[where Q'="\<lambda>_ _. \<not> call"]
+               hoare_drop_imp[where Q'="\<lambda>_ _. cg"]
              | simp    add: valid_tcb_state'_def case_bool_If
                             case_option_If
                       cong: if_cong

--- a/proof/refine/ARM_HYP/Ipc_R.thy
+++ b/proof/refine/ARM_HYP/Ipc_R.thy
@@ -52,7 +52,7 @@ lemma lsfco_cte_at':
    apply (wp)
   apply (clarsimp simp: split_def unlessE_def
              split del: if_split)
-  apply (wp hoare_drop_imps)
+  apply (wpsimp wp: hoare_drop_imps)
   done
 
 declare unifyFailure_wp [wp]
@@ -1860,7 +1860,7 @@ declare asUser_global_refs' [wp]
 lemma lec_valid_cap' [wp]:
   "\<lbrace>valid_objs'\<rbrace> lookupExtraCaps thread xa mi \<lbrace>\<lambda>rv s. (\<forall>x\<in>set rv. s \<turnstile>' fst x)\<rbrace>, -"
   apply (rule hoare_pre, rule hoare_strengthen_postE_R)
-    apply (rule hoare_vcg_conj_liftE_R[where R=valid_objs' and S="\<lambda>_. valid_objs'"])
+    apply (rule hoare_vcg_conj_liftE_R[where P'=valid_objs' and Q'="\<lambda>_. valid_objs'"])
      apply (rule lookupExtraCaps_srcs)
     apply wp
    apply (clarsimp simp: cte_wp_at_ctes_of)

--- a/proof/refine/ARM_HYP/PageTableDuplicates.thy
+++ b/proof/refine/ARM_HYP/PageTableDuplicates.thy
@@ -650,7 +650,7 @@ lemma createObject_valid_duplicates'[wp]:
          apply (simp add: placeNewObject_def placeNewDataObject_def
                           placeNewObject'_def split_def copyGlobalMappings_def
                      split del: if_split
-           | wp unless_wp[where P="d"] unless_wp[where Q=\<top>]
+           | wp unless_wp[where P="d"] unless_wp[where P'=\<top>]
            | wpc | simp add: alignError_def split del: if_split)+
   apply (intro conjI impI)
              apply clarsimp+
@@ -1999,7 +1999,7 @@ lemma tc_valid_duplicates':
                checkCap_inv[where P="\<lambda>s. vs_valid_duplicates' (ksPSpace s)"]
                checkCap_inv[where P=sch_act_simple]
                cteDelete_valid_duplicates'
-               hoare_vcg_const_imp_lift_R
+               hoare_vcg_const_imp_liftE_R
                typ_at_lifts [OF setPriority_typ_at']
                assertDerived_wp
                threadSet_cte_wp_at'
@@ -2185,7 +2185,7 @@ lemma handleRecv_valid_duplicates'[wp]:
    apply wp
        apply ((wp getNotification_wp | wpc | simp add: whenE_def split del: if_split)+)[1]
 
-      apply (rule_tac Q="\<lambda>rv s. vs_valid_duplicates' (ksPSpace s)"
+      apply (rule_tac Q'="\<lambda>rv s. vs_valid_duplicates' (ksPSpace s)"
 
                    in hoare_strengthen_postE[rotated])
 
@@ -2234,7 +2234,7 @@ lemma callKernel_valid_duplicates':
   apply (simp add: callKernel_def fastpathKernelAssertions_def)
   apply (rule hoare_pre)
    apply (wp activate_invs' activate_sch_act schedule_sch
-             hoare_drop_imp[where R="\<lambda>_. kernelExitAssertions"]
+             hoare_drop_imp[where Q'="\<lambda>_. kernelExitAssertions"]
              schedule_sch_act_simple he_invs' hoare_vcg_if_lift3
           | simp add: no_irq_getActiveIRQ
           | strengthen non_kernel_IRQs_strg, simp cong: conj_cong)+

--- a/proof/refine/ARM_HYP/Refine.thy
+++ b/proof/refine/ARM_HYP/Refine.thy
@@ -226,12 +226,12 @@ lemma set_thread_state_sched_act:
     apply (simp add: set_thread_state_ext_def)
     apply wp
        apply (rule hoare_pre_cont)
-      apply (rule_tac Q="\<lambda>rv. (\<lambda>s. runnable ts) and (\<lambda>s. P (scheduler_action s))"
+      apply (rule_tac Q'="\<lambda>rv. (\<lambda>s. runnable ts) and (\<lambda>s. P (scheduler_action s))"
               in hoare_strengthen_post)
        apply wp
       apply force
      apply (wp gts_st_tcb_at)+
-     apply (rule_tac Q="\<lambda>rv. st_tcb_at ((=) state) thread and (\<lambda>s. runnable state) and (\<lambda>s. P (scheduler_action s))" in hoare_strengthen_post)
+     apply (rule_tac Q'="\<lambda>rv. st_tcb_at ((=) state) thread and (\<lambda>s. runnable state) and (\<lambda>s. P (scheduler_action s))" in hoare_strengthen_post)
      apply (simp add: st_tcb_at_def)
      apply (wp obj_set_prop_at)+
     apply (force simp: st_tcb_at_def obj_at_def)
@@ -270,7 +270,7 @@ lemma kernel_entry_invs:
   \<lbrace>\<lambda>rv. einvs and (\<lambda>s. ct_running s \<or> ct_idle s)
     and (\<lambda>s. 0 < domain_time s) and valid_domain_list
     and (\<lambda>s. scheduler_action s = resume_cur_thread)\<rbrace>"
-  apply (rule_tac Q="\<lambda>rv. invs and (\<lambda>s. ct_running s \<or> ct_idle s) and valid_sched and
+  apply (rule_tac Q'="\<lambda>rv. invs and (\<lambda>s. ct_running s \<or> ct_idle s) and valid_sched and
                            (\<lambda>s. 0 < domain_time s) and valid_domain_list and
                            valid_list and (\<lambda>s. scheduler_action s = resume_cur_thread)"
             in hoare_post_imp)
@@ -316,7 +316,7 @@ lemma do_user_op_invs2:
   do_user_op f tc
    \<lbrace>\<lambda>_. (einvs  and ct_running and (\<lambda>s. scheduler_action s = resume_cur_thread))
         and (\<lambda>s. 0 < domain_time s) and valid_domain_list \<rbrace>"
-  apply (rule_tac Q="\<lambda>_. valid_list and valid_sched and
+  apply (rule_tac Q'="\<lambda>_. valid_list and valid_sched and
    (\<lambda>s. scheduler_action s = resume_cur_thread) and (invs and ct_running) and
    (\<lambda>s. 0 < domain_time s) and valid_domain_list"
    in hoare_strengthen_post)
@@ -391,7 +391,7 @@ lemma ckernel_invs:
   apply (rule hoare_pre)
    apply (wp activate_invs' activate_sch_act schedule_sch
              schedule_sch_act_simple he_invs' schedule_invs' hoare_vcg_if_lift3
-             hoare_drop_imp[where R="\<lambda>_. kernelExitAssertions"]
+             hoare_drop_imp[where Q'="\<lambda>_. kernelExitAssertions"]
           | simp add: no_irq_getActiveIRQ
           | strengthen non_kernel_IRQs_strg[where Q=True, simplified], simp cong: conj_cong)+
   done
@@ -580,20 +580,20 @@ lemma kernel_corres':
           apply simp
           apply (wpsimp wp: hoare_drop_imps hoare_vcg_all_lift simp: schact_is_rct_def)[1]
          apply simp
-         apply (rule_tac Q="\<lambda>irq s. irq \<notin> Some ` non_kernel_IRQs \<and> invs' s \<and>
+         apply (rule_tac Q'="\<lambda>irq s. irq \<notin> Some ` non_kernel_IRQs \<and> invs' s \<and>
                               (\<forall>irq'. irq = Some irq' \<longrightarrow>
                                  intStateIRQTable (ksInterruptState s ) irq' \<noteq> IRQInactive)"
                       in hoare_post_imp)
           apply clarsimp
          apply (wp doMachineOp_getActiveIRQ_IRQ_active handle_event_valid_sched | simp)+
-       apply (rule_tac Q="\<lambda>_. \<top>" and E="\<lambda>_. invs'" in hoare_strengthen_postE)
+       apply (rule_tac Q'="\<lambda>_. \<top>" and E'="\<lambda>_. invs'" in hoare_strengthen_postE)
          apply wpsimp+
        apply (simp add: invs'_def valid_state'_def)
       apply (rule corres_split[OF schedule_corres])
         apply (rule activateThread_corres)
        apply (wp schedule_invs' hoare_vcg_if_lift2 dmo_getActiveIRQ_non_kernel
               | simp cong: rev_conj_cong | strengthen None_drop | subst Ex_Some_conv)+
-     apply (rule_tac Q="\<lambda>_. valid_sched and invs and valid_list" and E="\<lambda>_. valid_sched and invs and valid_list"
+     apply (rule_tac Q'="\<lambda>_. valid_sched and invs and valid_list" and E'="\<lambda>_. valid_sched and invs and valid_list"
             in hoare_strengthen_postE)
        apply (wp handle_event_valid_sched hoare_vcg_if_lift3
               | simp

--- a/proof/refine/ARM_HYP/Retype_R.thy
+++ b/proof/refine/ARM_HYP/Retype_R.thy
@@ -4273,7 +4273,7 @@ lemma createNewCaps_cur:
         cur_tcb' s\<rbrace>
       createNewCaps ty ptr n us d
    \<lbrace>\<lambda>rv. cur_tcb'\<rbrace>"
-  apply (rule hoare_post_imp [where Q="\<lambda>rv s. \<exists>t. ksCurThread s = t \<and> tcb_at' t s"])
+  apply (rule hoare_post_imp[where Q'="\<lambda>rv s. \<exists>t. ksCurThread s = t \<and> tcb_at' t s"])
    apply (simp add: cur_tcb'_def)
   apply (wp hoare_vcg_ex_lift createNewCaps_obj_at')
   apply (clarsimp simp: pspace_no_overlap'_def cur_tcb'_def valid_pspace'_def)
@@ -4383,7 +4383,7 @@ lemma createNewCaps_global_refs':
      createNewCaps ty ptr n us d
    \<lbrace>\<lambda>rv. valid_global_refs'\<rbrace>"
   apply (simp add: valid_global_refs'_def valid_cap_sizes'_def valid_refs'_def)
-  apply (rule_tac Q="\<lambda>rv s. \<forall>ptr. \<not> cte_wp_at' (\<lambda>cte. (kernel_data_refs \<inter> capRange (cteCap cte) \<noteq> {}
+  apply (rule_tac Q'="\<lambda>rv s. \<forall>ptr. \<not> cte_wp_at' (\<lambda>cte. (kernel_data_refs \<inter> capRange (cteCap cte) \<noteq> {}
         \<or> 2 ^ capBits (cteCap cte) > gsMaxObjectSize s)) ptr s \<and> global_refs' s \<subseteq> kernel_data_refs"
                  in hoare_post_imp)
    apply (auto simp: cte_wp_at_ctes_of linorder_not_less elim!: ranE)[1]
@@ -5050,7 +5050,7 @@ proof (rule hoare_gen_asm, erule conjE)
     "\<lbrace>ct_not_inQ and valid_pspace' and pspace_no_overlap' ptr sz\<rbrace>
      createNewCaps ty ptr n us dev \<lbrace>\<lambda>_. ct_not_inQ\<rbrace>"
     unfolding ct_not_inQ_def
-    apply (rule_tac Q="\<lambda>s. ksSchedulerAction s = ResumeCurrentThread
+    apply (rule_tac P'="\<lambda>s. ksSchedulerAction s = ResumeCurrentThread
                              \<longrightarrow> (obj_at' (Not \<circ> tcbQueued) (ksCurThread s) s
                                   \<and> valid_pspace' s \<and> pspace_no_overlap' ptr sz s)"
                     in hoare_pre_imp, clarsimp)
@@ -5189,7 +5189,7 @@ lemma createObjects_no_cte_valid_global:
       createObjects ptr n val gbits
    \<lbrace>\<lambda>rv s. valid_global_refs' s\<rbrace>"
   apply (simp add: valid_global_refs'_def valid_cap_sizes'_def valid_refs'_def)
-  apply (rule_tac Q="\<lambda>rv s. \<forall>ptr. \<not> cte_wp_at' (\<lambda>cte. (kernel_data_refs \<inter> capRange (cteCap cte) \<noteq> {}
+  apply (rule_tac Q'="\<lambda>rv s. \<forall>ptr. \<not> cte_wp_at' (\<lambda>cte. (kernel_data_refs \<inter> capRange (cteCap cte) \<noteq> {}
         \<or> 2 ^ capBits (cteCap cte) > gsMaxObjectSize s)) ptr s \<and> global_refs' s \<subseteq> kernel_data_refs"
                  in hoare_post_imp)
    apply (auto simp: cte_wp_at_ctes_of linorder_not_less elim!: ranE)[1]
@@ -5296,7 +5296,7 @@ lemma createObjects_cur':
         cur_tcb' s\<rbrace>
       createObjects ptr n val gbits
    \<lbrace>\<lambda>rv s. cur_tcb' s\<rbrace>"
-  apply (rule hoare_post_imp [where Q="\<lambda>rv s. \<exists>t. ksCurThread s = t \<and> tcb_at' t s"])
+  apply (rule hoare_post_imp[where Q'="\<lambda>rv s. \<exists>t. ksCurThread s = t \<and> tcb_at' t s"])
    apply (simp add: cur_tcb'_def)
   apply (wp hoare_vcg_ex_lift createObjects_orig_obj_at3)
   apply (clarsimp simp: cur_tcb'_def)
@@ -5386,7 +5386,7 @@ proof -
       createObjects ptr n val gbits \<lbrace>\<lambda>_. ct_not_inQ\<rbrace>"
     (is "\<lbrakk> _; _ \<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s. ct_not_inQ s \<and> ?REST s\<rbrace> _ \<lbrace>_\<rbrace>")
     apply (simp add: ct_not_inQ_def)
-    apply (rule_tac Q="\<lambda>s. (ksSchedulerAction s = ResumeCurrentThread) \<longrightarrow>
+    apply (rule_tac P'="\<lambda>s. (ksSchedulerAction s = ResumeCurrentThread) \<longrightarrow>
                              (obj_at' (Not \<circ> tcbQueued) (ksCurThread s) s \<and> ?REST s)"
              in hoare_pre_imp, clarsimp)
     apply (rule hoare_convert_imp [OF createObjects_nosch])

--- a/proof/refine/ARM_HYP/Retype_R.thy
+++ b/proof/refine/ARM_HYP/Retype_R.thy
@@ -4351,18 +4351,19 @@ lemma createNewCaps_idle'[wp]:
                       split del: if_split)
          apply (rename_tac apiobject_type)
          apply (case_tac apiobject_type, simp_all split del: if_split)[1]
-             apply (wp, simp)
-           including classic_wp_pre
-           apply (wp mapM_x_wp'
-                     createObjects_idle'
-                     threadSet_idle'
+             apply wpsimp
+            (* The following step does not use wpsimp to avoid clarsimp_no_cond, which for some reason
+               leads to a failed proof state. If this could be fixed then the inclusion of
+               classic_wp_pre could also be removed. *)
+            including classic_wp_pre
+            apply (wp mapM_x_wp' createObjects_idle' threadSet_idle'
                    | simp add: projectKO_opt_tcb projectKO_opt_cte
                                makeObject_cte makeObject_tcb archObjSize_def
                                tcb_cte_cases_def objBitsKO_def APIType_capBits_def
                                vspace_bits_defs objBits_def
                                createObjects_def
                    | intro conjI impI
-                   | fastforce simp: curDomain_def)+
+                   | clarsimp simp: curDomain_def)+
   done
 
 crunch createNewCaps

--- a/proof/refine/ARM_HYP/Schedule_R.thy
+++ b/proof/refine/ARM_HYP/Schedule_R.thy
@@ -2109,7 +2109,7 @@ lemma schedule_corres:
                           tcbSchedEnqueue_invs'_not_ResumeCurrentThread thread_get_wp
                      del: gets_wp
                   | strengthen valid_objs'_valid_tcbs' invs_valid_pspace')+
-       apply (clarsimp simp: conj_ac if_apply_def2 cong: imp_cong conj_cong del: hoare_gets)
+       apply (clarsimp simp: conj_ac if_apply_def2 cong: imp_cong conj_cong)
        apply (wp gets_wp)+
 
    (* abstract final subgoal *)

--- a/proof/refine/ARM_HYP/Schedule_R.thy
+++ b/proof/refine/ARM_HYP/Schedule_R.thy
@@ -729,7 +729,7 @@ lemma tcbSchedDequeue_valid_mdb'[wp]:
   "\<lbrace>valid_mdb' and valid_objs'\<rbrace> tcbSchedDequeue tcbPtr \<lbrace>\<lambda>_. valid_mdb'\<rbrace>"
   unfolding tcbSchedDequeue_def
   apply (wpsimp simp: bitmap_fun_defs setQueue_def wp: threadSet_mdb' tcbQueueRemove_valid_mdb')
-      apply (rule_tac Q="\<lambda>_. tcb_at' tcbPtr" in hoare_post_imp)
+      apply (rule_tac Q'="\<lambda>_. tcb_at' tcbPtr" in hoare_post_imp)
        apply (fastforce simp: tcb_cte_cases_def cteSizeBits_def)
       apply (wpsimp wp: threadGet_wp)+
   apply (fastforce simp: obj_at'_def)
@@ -1057,7 +1057,7 @@ lemma tcbSchedDequeue_not_tcbQueued:
   "\<lbrace>\<top>\<rbrace> tcbSchedDequeue t \<lbrace>\<lambda>_. obj_at' (\<lambda>x. \<not> tcbQueued x) t\<rbrace>"
   apply (simp add: tcbSchedDequeue_def)
   apply (wp|clarsimp)+
-  apply (rule_tac Q="\<lambda>queued. obj_at' (\<lambda>x. tcbQueued x = queued) t" in hoare_post_imp)
+  apply (rule_tac Q'="\<lambda>queued. obj_at' (\<lambda>x. tcbQueued x = queued) t" in hoare_post_imp)
      apply (clarsimp simp: obj_at'_def)
     apply (wpsimp wp: threadGet_wp)+
   apply (clarsimp simp: obj_at'_def)
@@ -2103,7 +2103,7 @@ lemma schedule_corres:
                     apply wpsimp+
            apply (clarsimp simp: conj_ac cong: conj_cong)
            apply wp
-           apply (rule_tac Q="\<lambda>_ s. valid_blocked_except t s \<and> scheduler_action s = switch_thread t"
+           apply (rule_tac Q'="\<lambda>_ s. valid_blocked_except t s \<and> scheduler_action s = switch_thread t"
                     in hoare_post_imp, fastforce)
            apply (wp add: tcb_sched_action_enqueue_valid_blocked_except
                           tcbSchedEnqueue_invs'_not_ResumeCurrentThread thread_get_wp
@@ -2375,7 +2375,7 @@ lemma schedule_invs':
     apply (wpsimp wp: scheduleChooseNewThread_invs' ssa_invs'
                       chooseThread_invs_no_cicd' setSchedulerAction_invs' setSchedulerAction_direct
                       switchToThread_tcb_in_cur_domain' switchToThread_ct_not_queued_2
-           | wp hoare_disjI2[where R="\<lambda>_ s. tcb_in_cur_domain' (ksCurThread s) s"]
+           | wp hoare_disjI2[where Q'="\<lambda>_ s. tcb_in_cur_domain' (ksCurThread s) s"]
            | wp hoare_drop_imp[where f="isHighestPrio d p" for d p]
            | simp only: obj_at'_activatable_st_tcb_at'[simplified comp_def]
            | strengthen invs'_invs_no_cicd

--- a/proof/refine/ARM_HYP/SubMonad_R.thy
+++ b/proof/refine/ARM_HYP/SubMonad_R.thy
@@ -79,7 +79,7 @@ lemma threadSet_modify_asUser:
    apply (clarsimp simp: threadSet_def setObject_def split_def
                          updateObject_default_def)
    apply wp
-   apply (rule_tac Q="\<lambda>rv. obj_at' ((=) rv) t and ((=) st)" in hoare_post_imp)
+   apply (rule_tac Q'="\<lambda>rv. obj_at' ((=) rv) t and ((=) st)" in hoare_post_imp)
     apply (clarsimp simp: asUser_replace_def Let_def obj_at'_def
                           projectKOs fun_upd_def
                    split: option.split kernel_object.split)

--- a/proof/refine/ARM_HYP/Syscall_R.thy
+++ b/proof/refine/ARM_HYP/Syscall_R.thy
@@ -340,7 +340,7 @@ lemma threadSet_tcbDomain_update_sch_act_wf[wp]:
      apply (wps setObject_sa_unchanged)
      apply (wp hoare_weak_lift_imp getObject_tcb_wp hoare_vcg_all_lift)+
    apply (rename_tac word)
-   apply (rule_tac Q="\<lambda>_ s. ksSchedulerAction s = SwitchToThread word \<longrightarrow>
+   apply (rule_tac Q'="\<lambda>_ s. ksSchedulerAction s = SwitchToThread word \<longrightarrow>
                             st_tcb_at' runnable' word s \<and> tcb_in_cur_domain' word s \<and> word \<noteq> t"
                    in hoare_strengthen_post)
     apply (wp hoare_vcg_all_lift hoare_vcg_conj_lift hoare_vcg_imp_lift)+
@@ -377,20 +377,20 @@ lemma setDomain_corres:
          apply ((wpsimp wp: hoare_vcg_imp_lift' ethread_set_not_queued_valid_queues hoare_vcg_all_lift
                  | strengthen valid_objs'_valid_tcbs' valid_queues_in_correct_ready_q
                               valid_queues_ready_qs_distinct)+)[1]
-        apply (rule_tac Q="\<lambda>_. valid_objs' and sym_heap_sched_pointers and valid_sched_pointers
+        apply (rule_tac Q'="\<lambda>_. valid_objs' and sym_heap_sched_pointers and valid_sched_pointers
                                and pspace_aligned' and pspace_distinct'
                                and (\<lambda>s. sch_act_wf (ksSchedulerAction s) s) and tcb_at' tptr"
                      in hoare_strengthen_post[rotated])
          apply (fastforce simp: invs'_def valid_state'_def sch_act_wf_weak st_tcb_at'_def o_def)
         apply (wpsimp wp: threadSet_valid_objs' threadSet_sched_pointers
                           threadSet_valid_sched_pointers)+
-       apply (rule_tac Q="\<lambda>_ s. valid_queues s \<and> not_queued tptr s
+       apply (rule_tac Q'="\<lambda>_ s. valid_queues s \<and> not_queued tptr s
                                 \<and> pspace_aligned s \<and> pspace_distinct s \<and> valid_etcbs s
                                 \<and> weak_valid_sched_action s"
                     in hoare_post_imp)
         apply (fastforce simp: pred_tcb_at_def obj_at_def)
        apply (wpsimp wp: tcb_dequeue_not_queued)
-      apply (rule_tac Q = "\<lambda>_ s. invs' s \<and> obj_at' (Not \<circ> tcbQueued) tptr s \<and> sch_act_simple s
+      apply (rule_tac Q'="\<lambda>_ s. invs' s \<and> obj_at' (Not \<circ> tcbQueued) tptr s \<and> sch_act_simple s
                                  \<and>  tcb_at' tptr s"
                    in hoare_strengthen_post[rotated])
        apply (clarsimp simp: invs'_def valid_state'_def valid_pspace'_def sch_act_simple_def)
@@ -804,7 +804,7 @@ lemma doReply_invs[wp]:
           apply simp
           apply (wp (once) sts_st_tcb')
           apply wp
-         apply (rule_tac Q="\<lambda>_ s. invs' s \<and> t \<noteq> ksIdleThread s \<and> st_tcb_at' awaiting_reply' t s"
+         apply (rule_tac Q'="\<lambda>_ s. invs' s \<and> t \<noteq> ksIdleThread s \<and> st_tcb_at' awaiting_reply' t s"
                  in hoare_post_imp)
           apply clarsimp
           apply (rule conjI, erule pred_tcb'_weakenE, case_tac st, clarsimp+)
@@ -817,7 +817,7 @@ lemma doReply_invs[wp]:
           apply (case_tac st, clarsimp+)
          apply (wp cteDeleteOne_reply_pred_tcb_at)+
         apply clarsimp
-        apply (rule_tac Q="\<lambda>_. (\<lambda>s. t \<noteq> ksIdleThread s)
+        apply (rule_tac Q'="\<lambda>_. (\<lambda>s. t \<noteq> ksIdleThread s)
                                and cte_wp_at' (\<lambda>cte. \<exists>grant. cteCap cte
                                                              = capability.ReplyCap t False grant) slot"
                      in hoare_strengthen_post [rotated])
@@ -829,7 +829,7 @@ lemma doReply_invs[wp]:
         apply (erule cte_wp_at_weakenE')
         apply (fastforce)
        apply (wp sts_invs_minor'' sts_st_tcb' hoare_weak_lift_imp)
-             apply (rule_tac Q="\<lambda>_ s. invs' s \<and> sch_act_simple s
+             apply (rule_tac Q'="\<lambda>_ s. invs' s \<and> sch_act_simple s
                                       \<and> st_tcb_at' awaiting_reply' t s
                                       \<and> t \<noteq> ksIdleThread s"
                           in hoare_post_imp)
@@ -844,7 +844,7 @@ lemma doReply_invs[wp]:
               apply (case_tac st, clarsimp+)
              apply (wp threadSet_invs_trivial threadSet_st_tcb_at2 hoare_weak_lift_imp
                     | clarsimp simp add: inQ_def)+
-           apply (rule_tac Q="\<lambda>_. invs' and tcb_at' t
+           apply (rule_tac Q'="\<lambda>_. invs' and tcb_at' t
                                  and sch_act_simple and st_tcb_at' awaiting_reply' t"
                    in hoare_strengthen_post [rotated])
             apply clarsimp
@@ -962,7 +962,7 @@ lemma setDomain_invs':
   apply (simp add:setDomain_def )
   apply (wp add: when_wp hoare_weak_lift_imp hoare_weak_lift_imp_conj rescheduleRequired_all_invs_but_extra
     tcbSchedEnqueue_valid_action hoare_vcg_if_lift2)
-     apply (rule_tac Q = "\<lambda>r s. all_invs_but_sch_extra s \<and> curThread = ksCurThread s
+     apply (rule_tac Q'="\<lambda>r s. all_invs_but_sch_extra s \<and> curThread = ksCurThread s
       \<and> (ptr \<noteq> curThread \<longrightarrow> ct_not_inQ s \<and> sch_act_wf (ksSchedulerAction s) s \<and> ct_idle_or_in_cur_domain' s)"
       in hoare_strengthen_post[rotated])
       apply (clarsimp simp:invs'_def valid_state'_def st_tcb_at'_def[symmetric] valid_pspace'_def)
@@ -974,7 +974,7 @@ lemma setDomain_invs':
       apply assumption
      apply (wp hoare_weak_lift_imp threadSet_pred_tcb_no_state threadSet_not_curthread_ct_domain
                threadSet_tcbDomain_update_ct_not_inQ | simp)+
-    apply (rule_tac Q = "\<lambda>r s. invs' s \<and> curThread = ksCurThread s \<and> sch_act_simple s
+    apply (rule_tac Q'="\<lambda>r s. invs' s \<and> curThread = ksCurThread s \<and> sch_act_simple s
                              \<and> domain \<le> maxDomain
                              \<and> (ptr \<noteq> curThread \<longrightarrow> ct_not_inQ s \<and> sch_act_not ptr s)"
       in hoare_strengthen_post[rotated])
@@ -1244,7 +1244,7 @@ lemma handleInvocation_corres:
                       apply (wp reply_from_kernel_tcb_at)
                      apply (rule impI, wp+)
                      apply (wpsimp wp: hoare_drop_imps|strengthen invs_distinct invs_psp_aligned)+
-               apply (rule_tac Q="\<lambda>rv. einvs and schact_is_rct and valid_invocation rve
+               apply (rule_tac Q'="\<lambda>rv. einvs and schact_is_rct and valid_invocation rve
                                    and (\<lambda>s. thread = cur_thread s)
                                    and st_tcb_at active thread"
                           in hoare_post_imp)
@@ -1252,7 +1252,7 @@ lemma handleInvocation_corres:
                                elim!: st_tcb_weakenE)
                apply (wp sts_st_tcb_at' set_thread_state_schact_is_rct
                          set_thread_state_active_valid_sched)
-              apply (rule_tac Q="\<lambda>rv. invs' and valid_invocation' rve'
+              apply (rule_tac Q'="\<lambda>rv. invs' and valid_invocation' rve'
                                       and (\<lambda>s. thread = ksCurThread s)
                                       and st_tcb_at' active' thread
                                       and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread)
@@ -1265,7 +1265,7 @@ lemma handleInvocation_corres:
              apply (wp lec_caps_to lsft_ex_cte_cap_to
                     | simp add: split_def liftE_bindE[symmetric]
                                 ct_in_state'_def ball_conj_distrib
-                    | rule hoare_vcg_E_elim)+
+                    | rule hoare_vcg_conj_elimE)+
    apply (clarsimp simp: tcb_at_invs invs_valid_objs
                          valid_tcb_state_def ct_in_state_def
                          simple_from_active invs_mdb
@@ -1536,7 +1536,7 @@ lemma handleRecv_isBlocking_corres':
           apply (rule handleFault_corres)
           apply simp
          apply (wp get_simple_ko_wp | wpcw | simp)+
-         apply (rule hoare_vcg_E_elim)
+         apply (rule hoare_vcg_conj_elimE)
           apply (simp add: lookup_cap_def lookup_slot_for_thread_def)
           apply wp
            apply (simp add: split_def)
@@ -1584,14 +1584,14 @@ lemma hw_invs'[wp]:
                          deleteCallerCap_ct']
                     | wpc | simp add: ct_in_state'_def whenE_def split del: if_split)+
      apply (rule validE_validE_R)
-     apply (rule_tac Q="\<lambda>rv s. invs' s
+     apply (rule_tac Q'="\<lambda>rv s. invs' s
                              \<and> sch_act_sane s
                              \<and> thread = ksCurThread s
                              \<and> ct_in_state' simple' s
                              \<and> ex_nonz_cap_to' thread s
                              \<and> thread \<noteq> ksIdleThread s
                             \<and> (\<forall>x \<in> zobj_refs' rv. ex_nonz_cap_to' x s)"
-              and E="\<lambda>_ _. True"
+              and E'="\<lambda>_ _. True"
            in hoare_strengthen_postE[rotated])
         apply (clarsimp simp: isCap_simps ct_in_state'_def pred_tcb_at' invs_valid_objs'
                               sch_act_sane_not obj_at'_def projectKOs pred_tcb_at'_def)
@@ -1640,7 +1640,7 @@ lemma hy_invs':
   "\<lbrace>invs' and ct_active'\<rbrace> handleYield \<lbrace>\<lambda>r. invs' and ct_active'\<rbrace>"
   apply (simp add: handleYield_def)
   apply (wpsimp wp: ct_in_state_thread_state_lift' rescheduleRequired_all_invs_but_ct_not_inQ)
-     apply (rule_tac Q="\<lambda>_. all_invs_but_ct_not_inQ' and ct_active'" in hoare_post_imp)
+     apply (rule_tac Q'="\<lambda>_. all_invs_but_ct_not_inQ' and ct_active'" in hoare_post_imp)
       apply clarsimp
      apply (subst pred_conj_def)
      apply (rule hoare_vcg_conj_lift)
@@ -1850,7 +1850,7 @@ lemma handleReply_nonz_cap_to_ct:
   "\<lbrace>ct_active' and invs' and sch_act_simple\<rbrace>
      handleReply
    \<lbrace>\<lambda>rv s. ex_nonz_cap_to' (ksCurThread s) s\<rbrace>"
-  apply (rule_tac Q="\<lambda>rv. ct_active' and invs'"
+  apply (rule_tac Q'="\<lambda>rv. ct_active' and invs'"
                in hoare_post_imp)
    apply (auto simp: ct_in_state'_def elim: st_tcb_ex_cap'')[1]
   apply (wp | simp)+

--- a/proof/refine/ARM_HYP/TcbAcc_R.thy
+++ b/proof/refine/ARM_HYP/TcbAcc_R.thy
@@ -1100,7 +1100,7 @@ lemma threadSet_obj_at'_really_strongest:
   apply (simp add: threadSet_def)
   apply (wp setObject_tcb_strongest)
    apply (subst simp_thms(32)[symmetric], rule hoare_vcg_disj_lift)
-    apply (rule hoare_post_imp [where Q="\<lambda>rv s. \<not> tcb_at' t s \<and> tcb_at' t s"])
+    apply (rule hoare_post_imp[where Q'="\<lambda>rv s. \<not> tcb_at' t s \<and> tcb_at' t s"])
      apply simp
     apply (subst simp_thms(21)[symmetric], rule hoare_vcg_conj_lift)
      apply (rule getObject_inv_tcb)
@@ -1187,7 +1187,7 @@ proof -
   show ?thesis
     apply (rule_tac P=P in P_bool_lift)
      apply (rule pos)
-    apply (rule_tac Q="\<lambda>_ s. \<not> tcb_at' t' s \<or> pred_tcb_at' proj (\<lambda>tcb. \<not> P' tcb) t' s"
+    apply (rule_tac Q'="\<lambda>_ s. \<not> tcb_at' t' s \<or> pred_tcb_at' proj (\<lambda>tcb. \<not> P' tcb) t' s"
              in hoare_post_imp)
      apply (erule disjE)
       apply (clarsimp dest!: pred_tcb_at')
@@ -3363,7 +3363,7 @@ lemma sts_valid_objs':
    setThreadState st t
    \<lbrace>\<lambda>_. valid_objs'\<rbrace>"
   apply (wpsimp simp: setThreadState_def wp: threadSet_valid_objs')
-   apply (rule_tac Q="\<lambda>_. valid_objs' and pspace_aligned' and pspace_distinct'" in hoare_post_imp)
+   apply (rule_tac Q'="\<lambda>_. valid_objs' and pspace_aligned' and pspace_distinct'" in hoare_post_imp)
     apply fastforce
    apply (wpsimp wp: threadSet_valid_objs')
   apply (simp add: valid_tcb'_def tcb_cte_cases_def cteSizeBits_def)
@@ -3628,7 +3628,7 @@ lemma sts_sch_act':
    apply assumption
   apply (case_tac "runnable' st")
    apply ((wp threadSet_runnable_sch_act hoare_drop_imps | simp)+)[1]
-  apply (rule_tac Q="\<lambda>rv s. st_tcb_at' (Not \<circ> runnable') t s \<and>
+  apply (rule_tac Q'="\<lambda>rv s. st_tcb_at' (Not \<circ> runnable') t s \<and>
                      (ksCurThread s \<noteq> t \<or> ksSchedulerAction s \<noteq> ResumeCurrentThread \<longrightarrow>
                             sch_act_wf (ksSchedulerAction s) s)"
                in hoare_post_imp)
@@ -3648,10 +3648,10 @@ lemma sts_sch_act[wp]:
    prefer 2
    apply assumption
   apply (case_tac "runnable' st")
-   apply (rule_tac Q="\<lambda>s. sch_act_wf (ksSchedulerAction s) s"
+   apply (rule_tac P'="\<lambda>s. sch_act_wf (ksSchedulerAction s) s"
                 in hoare_pre_imp, simp)
    apply ((wp hoare_drop_imps threadSet_runnable_sch_act | simp)+)[1]
-  apply (rule_tac Q="\<lambda>rv s. st_tcb_at' (Not \<circ> runnable') t s \<and>
+  apply (rule_tac Q'="\<lambda>rv s. st_tcb_at' (Not \<circ> runnable') t s \<and>
                      (ksCurThread s \<noteq> t \<or> ksSchedulerAction s \<noteq> ResumeCurrentThread \<longrightarrow>
                             sch_act_wf (ksSchedulerAction s) s)"
                in hoare_post_imp)
@@ -3932,7 +3932,7 @@ lemma addToBitmap_valid_bitmapQ:
    addToBitmap d p
    \<lbrace>\<lambda>_. valid_bitmapQ\<rbrace>"
   (is "\<lbrace>?pre\<rbrace> _ \<lbrace>_\<rbrace>")
-  apply (rule_tac Q="\<lambda>_ s. ?pre s \<and> bitmapQ d p s" in hoare_strengthen_post)
+  apply (rule_tac Q'="\<lambda>_ s. ?pre s \<and> bitmapQ d p s" in hoare_strengthen_post)
    apply (wpsimp wp: addToBitmap_valid_bitmapQ_except addToBitmap_bitmapQ)
   apply (fastforce elim: valid_bitmap_valid_bitmapQ_exceptE)
   done
@@ -4628,7 +4628,7 @@ lemma ct_in_state'_decomp:
   assumes x: "\<lbrace>\<lambda>s. t = (ksCurThread s)\<rbrace> f \<lbrace>\<lambda>rv s. t = (ksCurThread s)\<rbrace>"
   assumes y: "\<lbrace>Pre\<rbrace> f \<lbrace>\<lambda>rv. st_tcb_at' Prop t\<rbrace>"
   shows      "\<lbrace>\<lambda>s. Pre s \<and> t = (ksCurThread s)\<rbrace> f \<lbrace>\<lambda>rv. ct_in_state' Prop\<rbrace>"
-  apply (rule hoare_post_imp [where Q="\<lambda>rv s. t = ksCurThread s \<and> st_tcb_at' Prop t s"])
+  apply (rule hoare_post_imp[where Q'="\<lambda>rv s. t = ksCurThread s \<and> st_tcb_at' Prop t s"])
    apply (clarsimp simp add: ct_in_state'_def)
   apply (rule hoare_weaken_pre)
    apply (wp x y)
@@ -4699,7 +4699,7 @@ lemma setQueue_pred_tcb_at[wp]:
   unfolding pred_tcb_at'_def
   apply (rule_tac P=P' in P_bool_lift)
    apply (rule setQueue_obj_at)
-  apply (rule_tac Q="\<lambda>_ s. \<not>typ_at' TCBT t s \<or> obj_at' (Not \<circ> (P \<circ> proj \<circ> tcb_to_itcb')) t s"
+  apply (rule_tac Q'="\<lambda>_ s. \<not>typ_at' TCBT t s \<or> obj_at' (Not \<circ> (P \<circ> proj \<circ> tcb_to_itcb')) t s"
            in hoare_post_imp, simp add: not_obj_at' o_def)
   apply (wp hoare_vcg_disj_lift)
   apply (clarsimp simp: not_obj_at' o_def)
@@ -4981,7 +4981,7 @@ lemma sts_iflive'[wp]:
    \<lbrace>\<lambda>rv. if_live_then_nonz_cap'\<rbrace>"
   apply (simp add: setThreadState_def setQueue_def)
   apply wpsimp
-   apply (rule_tac Q="\<lambda>rv. if_live_then_nonz_cap' and pspace_aligned' and pspace_distinct'"
+   apply (rule_tac Q'="\<lambda>rv. if_live_then_nonz_cap' and pspace_aligned' and pspace_distinct'"
                 in hoare_post_imp)
     apply clarsimp
    apply (wpsimp wp: threadSet_iflive')
@@ -5125,7 +5125,7 @@ lemma tcbSchedEnqueue_ct_not_inQ:
   proof -
     have ts: "\<lbrace>?PRE\<rbrace> threadSet (tcbQueued_update (\<lambda>_. True)) t \<lbrace>\<lambda>_. ct_not_inQ\<rbrace>"
       apply (simp add: ct_not_inQ_def)
-      apply (rule_tac Q="\<lambda>s. ksSchedulerAction s = ResumeCurrentThread
+      apply (rule_tac P'="\<lambda>s. ksSchedulerAction s = ResumeCurrentThread
                   \<longrightarrow> obj_at' (Not \<circ> tcbQueued) (ksCurThread s) s \<and> ksCurThread s \<noteq> t"
                   in hoare_pre_imp, clarsimp)
       apply (rule hoare_convert_imp [OF threadSet_nosch])
@@ -5152,7 +5152,7 @@ lemma tcbSchedAppend_ct_not_inQ:
   proof -
     have ts: "\<lbrace>?PRE\<rbrace> threadSet (tcbQueued_update (\<lambda>_. True)) t \<lbrace>\<lambda>_. ct_not_inQ\<rbrace>"
       apply (simp add: ct_not_inQ_def)
-      apply (rule_tac Q="\<lambda>s. ksSchedulerAction s = ResumeCurrentThread
+      apply (rule_tac P'="\<lambda>s. ksSchedulerAction s = ResumeCurrentThread
                   \<longrightarrow> obj_at' (Not \<circ> tcbQueued) (ksCurThread s) s \<and> ksCurThread s \<noteq> t"
                   in hoare_pre_imp, clarsimp)
       apply (rule hoare_convert_imp [OF threadSet_nosch])
@@ -5179,7 +5179,7 @@ lemma setSchedulerAction_direct:
 lemma rescheduleRequired_ct_not_inQ:
   "\<lbrace>\<top>\<rbrace> rescheduleRequired \<lbrace>\<lambda>_. ct_not_inQ\<rbrace>"
   apply (simp add: rescheduleRequired_def ct_not_inQ_def)
-  apply (rule_tac Q="\<lambda>_ s. ksSchedulerAction s = ChooseNewThread"
+  apply (rule_tac Q'="\<lambda>_ s. ksSchedulerAction s = ChooseNewThread"
            in hoare_post_imp, clarsimp)
   apply (wp setSchedulerAction_direct)
   done
@@ -5250,7 +5250,7 @@ lemma setThreadState_ct_not_inQ:
   including no_pre
   apply (simp add: setThreadState_def)
   apply (wp rescheduleRequired_ct_not_inQ)
-  apply (rule_tac Q="\<lambda>_. ?PRE" in hoare_post_imp, clarsimp)
+  apply (rule_tac Q'="\<lambda>_. ?PRE" in hoare_post_imp, clarsimp)
   apply (wp)
   done
 
@@ -5407,7 +5407,7 @@ lemma removeFromBitmap_valid_bitmapQ[wp]:
    removeFromBitmap d p
    \<lbrace>\<lambda>_. valid_bitmapQ\<rbrace>"
   (is "\<lbrace>?pre\<rbrace> _ \<lbrace>_\<rbrace>")
-  apply (rule_tac Q="\<lambda>_ s. ?pre s \<and> \<not> bitmapQ d p s" in hoare_strengthen_post)
+  apply (rule_tac Q'="\<lambda>_ s. ?pre s \<and> \<not> bitmapQ d p s" in hoare_strengthen_post)
    apply (wpsimp wp: removeFromBitmap_valid_bitmapQ_except removeFromBitmap_bitmapQ)
   apply (fastforce elim: valid_bitmap_valid_bitmapQ_exceptE)
   done

--- a/proof/refine/ARM_HYP/Tcb_R.thy
+++ b/proof/refine/ARM_HYP/Tcb_R.thy
@@ -81,7 +81,7 @@ abbreviation
 lemma gts_st_tcb':
   "\<lbrace>tcb_at' t\<rbrace> getThreadState t \<lbrace>\<lambda>rv. st_tcb_at' (\<lambda>st. st = rv) t\<rbrace>"
   apply (rule hoare_weaken_pre)
-   apply (rule hoare_post_imp[where Q="\<lambda>rv s. \<exists>rv'. rv = rv' \<and> st_tcb_at' (\<lambda>st. st = rv') t s"])
+   apply (rule hoare_post_imp[where Q'="\<lambda>rv s. \<exists>rv'. rv = rv' \<and> st_tcb_at' (\<lambda>st. st = rv') t s"])
     apply simp
    apply (wp hoare_vcg_ex_lift)
   apply (clarsimp simp add: pred_tcb_at'_def obj_at'_def)
@@ -108,15 +108,15 @@ lemma activate_invs':
                        split del: if_splits cong: if_cong)
       apply (wp)
       apply (clarsimp simp: ct_in_state'_def)
-     apply (rule_tac Q="\<lambda>rv. invs' and ct_idle'" in hoare_post_imp, simp)
+     apply (rule_tac Q'="\<lambda>rv. invs' and ct_idle'" in hoare_post_imp, simp)
      apply (wp activateIdle_invs)
      apply (clarsimp simp: ct_in_state'_def)
-    apply (rule_tac Q="\<lambda>rv. invs' and ct_running' and sch_act_simple"
+    apply (rule_tac Q'="\<lambda>rv. invs' and ct_running' and sch_act_simple"
                  in hoare_post_imp, simp)
     apply (rule hoare_weaken_pre)
      apply (wp ct_in_state'_set asUser_ct sts_invs_minor'
           | wp (once) sch_act_simple_lift)+
-      apply (rule_tac Q="\<lambda>_. st_tcb_at' runnable' thread
+      apply (rule_tac Q'="\<lambda>_. st_tcb_at' runnable' thread
                              and sch_act_simple and invs'
                              and (\<lambda>s. thread = ksCurThread s)"
                in hoare_post_imp, clarsimp)
@@ -194,7 +194,7 @@ lemma setupReplyMaster_weak_sch_act_wf[wp]:
    \<lbrace>\<lambda>rv s. weak_sch_act_wf (ksSchedulerAction s) s\<rbrace>"
   apply (simp add: setupReplyMaster_def)
   apply (wp)
-    apply (rule_tac Q="\<lambda>_ s. weak_sch_act_wf (ksSchedulerAction s) s"
+    apply (rule_tac Q'="\<lambda>_ s. weak_sch_act_wf (ksSchedulerAction s) s"
                in hoare_post_imp, clarsimp)
     apply (wp)+
   apply assumption
@@ -220,11 +220,11 @@ lemma restart_corres:
               apply (wp set_thread_state_runnable_weak_valid_sched_action sts_st_tcb_at'
                         sts_st_tcb' sts_valid_objs'
                      | clarsimp simp: valid_tcb_state'_def | strengthen valid_objs'_valid_tcbs')+
-         apply (rule_tac Q="\<lambda>rv. valid_sched and cur_tcb and pspace_aligned and pspace_distinct"
+         apply (rule_tac Q'="\<lambda>rv. valid_sched and cur_tcb and pspace_aligned and pspace_distinct"
                          in hoare_strengthen_post)
           apply wp
          apply (fastforce simp: valid_sched_def valid_sched_action_def)
-        apply (rule_tac Q="\<lambda>rv. invs' and ex_nonz_cap_to' t" in hoare_strengthen_post)
+        apply (rule_tac Q'="\<lambda>rv. invs' and ex_nonz_cap_to' t" in hoare_strengthen_post)
          apply wp
         apply (clarsimp simp: invs'_def valid_state'_def sch_act_wf_weak valid_pspace'_def
                               valid_tcb_state'_def)
@@ -360,10 +360,10 @@ lemma invokeTCB_WriteRegisters_corres:
                                   valid_sched_valid_queues valid_objs'_valid_tcbs' invs_valid_objs'
                      | clarsimp simp: invs_def valid_state_def valid_sched_def invs'_def valid_state'_def
                                dest!: global'_no_ex_cap idle_no_ex_cap)+)[2]
-         apply (rule_tac Q="\<lambda>_. einvs and tcb_at dest and ex_nonz_cap_to dest" in hoare_strengthen_post[rotated])
+         apply (rule_tac Q'="\<lambda>_. einvs and tcb_at dest and ex_nonz_cap_to dest" in hoare_strengthen_post[rotated])
           apply (fastforce simp: invs_def valid_sched_weak_strg valid_sched_def valid_state_def dest!: idle_no_ex_cap)
          prefer 2
-         apply (rule_tac Q="\<lambda>_. invs' and tcb_at' dest and ex_nonz_cap_to' dest" in hoare_strengthen_post[rotated])
+         apply (rule_tac Q'="\<lambda>_. invs' and tcb_at' dest and ex_nonz_cap_to' dest" in hoare_strengthen_post[rotated])
           apply (fastforce simp: sch_act_wf_weak invs'_def valid_state'_def dest!: global'_no_ex_cap)
          apply (wpsimp simp: getSanitiseRegisterInfo_def)+
    apply fastforce
@@ -472,10 +472,10 @@ proof -
                     apply (rule_tac P=\<top> and P'=\<top> in corres_inst)
                     apply simp
                    apply (solves \<open>wp hoare_weak_lift_imp\<close>)+
-             apply (rule_tac Q="\<lambda>_. einvs and tcb_at dest" in hoare_strengthen_post[rotated])
+             apply (rule_tac Q'="\<lambda>_. einvs and tcb_at dest" in hoare_strengthen_post[rotated])
               apply (fastforce simp: invs_def valid_state_def valid_pspace_def valid_sched_weak_strg valid_sched_def)
              prefer 2
-             apply (rule_tac Q="\<lambda>_. invs' and tcb_at' dest" in hoare_strengthen_post[rotated])
+             apply (rule_tac Q'="\<lambda>_. invs' and tcb_at' dest" in hoare_strengthen_post[rotated])
               apply (fastforce simp: invs'_def valid_state'_def invs_weak_sch_act_wf cur_tcb'_def)
              apply ((wp mapM_x_wp' hoare_weak_lift_imp | (simp add: cur_tcb'_def[symmetric])+)+)[8]
          apply ((wp hoare_weak_lift_imp restart_invs' | wpc | clarsimp simp add: if_apply_def2)+)[2]
@@ -544,7 +544,7 @@ lemma tcbSchedDequeue_not_queued:
    \<lbrace>\<lambda>rv. obj_at' (Not \<circ> tcbQueued) t\<rbrace>"
   apply (simp add: tcbSchedDequeue_def)
   apply (wp | simp)+
-  apply (rule_tac Q="\<lambda>rv. obj_at' (\<lambda>obj. tcbQueued obj = rv) t"
+  apply (rule_tac Q'="\<lambda>rv. obj_at' (\<lambda>obj. tcbQueued obj = rv) t"
                in hoare_post_imp)
    apply (clarsimp simp: obj_at'_def)
   apply (wp tg_sp' [where P=\<top>, simplified] | simp)+
@@ -1422,7 +1422,7 @@ proof -
   have B: "\<And>t v. \<lbrace>invs' and tcb_at' t\<rbrace> threadSet (tcbFaultHandler_update v) t \<lbrace>\<lambda>rv. invs'\<rbrace>"
     by (wp threadSet_invs_trivial | clarsimp simp: inQ_def)+
    note stuff = Z B out_invs_trivial hoare_case_option_wp
-               hoare_vcg_const_Ball_lift hoare_vcg_const_Ball_lift_R
+               hoare_vcg_const_Ball_lift hoare_vcg_const_Ball_liftE_R
                cap_delete_deletes cap_delete_valid_cap out_valid_objs
                cap_insert_objs
                cteDelete_deletes cteDelete_sch_act_simple
@@ -1457,7 +1457,7 @@ proof -
                   apply (rule corres_returnOkTT, simp)
                  apply wp
                 apply wp
-               apply (wpsimp wp: hoare_vcg_const_imp_lift_R hoare_vcg_const_imp_lift
+               apply (wpsimp wp: hoare_vcg_const_imp_liftE_R hoare_vcg_const_imp_lift
                                  hoare_vcg_all_liftE_R hoare_vcg_all_lift
                                  as_user_invs thread_set_ipc_tcb_cap_valid
                                  thread_set_tcb_ipc_buffer_cap_cleared_invs
@@ -1478,7 +1478,7 @@ proof -
                                  threadSet_invs_tcbIPCBuffer_update threadSet_cte_wp_at'
                       | strengthen simple_sched_action_sched_act_not)+
                 apply ((wpsimp wp: stuff hoare_vcg_all_liftE_R hoare_vcg_all_lift
-                                   hoare_vcg_const_imp_lift_R hoare_vcg_const_imp_lift
+                                   hoare_vcg_const_imp_liftE_R hoare_vcg_const_imp_lift
                                    threadSet_valid_objs' thread_set_not_state_valid_sched
                                    thread_set_tcb_ipc_buffer_cap_cleared_invs thread_set_cte_wp_at_trivial
                                    thread_set_no_cap_to_trivial getThreadBufferSlot_dom_tcb_cte_cases
@@ -1514,7 +1514,7 @@ proof -
                          in hoare_strengthen_postE_R[simplified validE_R_def, rotated])
              apply (case_tac g'; clarsimp simp: isCap_simps ; clarsimp elim: invs_valid_objs' cong:imp_cong)
             apply (wp add: stuff hoare_vcg_all_liftE_R hoare_vcg_all_lift
-                                 hoare_vcg_const_imp_lift_R hoare_vcg_const_imp_lift setMCPriority_invs'
+                                 hoare_vcg_const_imp_liftE_R hoare_vcg_const_imp_lift setMCPriority_invs'
                                  threadSet_valid_objs' thread_set_not_state_valid_sched setP_invs'
                                  typ_at_lifts [OF setPriority_typ_at']
                                  typ_at_lifts [OF setMCPriority_typ_at']
@@ -1595,15 +1595,15 @@ lemma tc_invs':
       apply (wpsimp wp: hoare_weak_lift_imp hoare_vcg_all_lift
                         checkCap_inv[where P="tcb_at' t" for t] assertDerived_wp_weak
                         threadSet_invs_trivial2 threadSet_tcb'  hoare_vcg_all_lift threadSet_cte_wp_at')+
-       apply (wpsimp wp: hoare_weak_lift_imp_R cteDelete_deletes
-                         hoare_vcg_all_liftE_R hoare_vcg_conj_liftE1 hoare_vcg_const_imp_lift_R hoare_vcg_propE_R
+       apply (wpsimp wp: hoare_weak_lift_impE_R cteDelete_deletes
+                         hoare_vcg_all_liftE_R hoare_vcg_conj_liftE1 hoare_vcg_const_imp_liftE_R hoare_vcg_propE_R
                          cteDelete_invs' cteDelete_invs' cteDelete_typ_at'_lifts)+
      apply (assumption | clarsimp cong: conj_cong imp_cong | (rule case_option_wp_None_returnOk)
             | wpsimp wp: hoare_weak_lift_imp hoare_vcg_all_lift checkCap_inv[where P="tcb_at' t" for t] assertDerived_wp_weak
                          hoare_vcg_imp_lift' hoare_vcg_all_lift checkCap_inv[where P="tcb_at' t" for t]
                          checkCap_inv[where P="valid_cap' c" for c] checkCap_inv[where P=sch_act_simple]
-                         hoare_vcg_const_imp_lift_R assertDerived_wp_weak hoare_weak_lift_imp_R cteDelete_deletes
-                         hoare_vcg_all_liftE_R hoare_vcg_conj_liftE1 hoare_vcg_const_imp_lift_R hoare_vcg_propE_R
+                         hoare_vcg_const_imp_liftE_R assertDerived_wp_weak hoare_weak_lift_impE_R cteDelete_deletes
+                         hoare_vcg_all_liftE_R hoare_vcg_conj_liftE1 hoare_vcg_const_imp_liftE_R hoare_vcg_propE_R
                          cteDelete_invs' cteDelete_typ_at'_lifts cteDelete_sch_act_simple)+
   apply (clarsimp simp: tcb_cte_cases_def cte_level_bits_def objBits_defs
                         tcbIPCBufferSlot_def)
@@ -2687,7 +2687,7 @@ lemma inv_tcb_IRQInactive:
   apply (rule hoare_pre)
    apply (wpc |
           wp withoutPreemption_R cteDelete_IRQInactive checkCap_inv
-             hoare_vcg_const_imp_lift_R cteDelete_irq_states'
+             hoare_vcg_const_imp_liftE_R cteDelete_irq_states'
              hoare_vcg_const_imp_lift |
           simp add: split_def)+
   done

--- a/proof/refine/ARM_HYP/Untyped_R.thy
+++ b/proof/refine/ARM_HYP/Untyped_R.thy
@@ -398,7 +398,7 @@ next
            apply wp+
           apply (wp hoare_drop_impE_R hoare_vcg_all_liftE_R
                  | clarsimp)+
-          apply (rule hoare_strengthen_post [where Q = "\<lambda>r. invs and valid_cap r and cte_at slot"])
+          apply (rule hoare_strengthen_post[where Q'="\<lambda>r. invs and valid_cap r and cte_at slot"])
            apply wp+
           apply (clarsimp simp: is_cap_simps bits_of_def cap_aligned_def
                                 valid_cap_def word_bits_def)
@@ -406,7 +406,7 @@ next
           apply (strengthen refl exI[mk_strg I E] exI[where x=d])+
           apply simp
          apply wp+
-         apply (rule hoare_strengthen_post [where Q = "\<lambda>r. invs' and cte_at' (cte_map slot)"])
+         apply (rule hoare_strengthen_post[where Q'="\<lambda>r. invs' and cte_at' (cte_map slot)"])
           apply wp+
          apply (clarsimp simp:invs_pspace_aligned' invs_pspace_distinct')
          apply auto[1]
@@ -3206,7 +3206,7 @@ lemma createNewCaps_parent_helper:
                        (\<forall>tup\<in>set (zip (xs rv) rv).
                                 sameRegionAs (cteCap cte) (snd tup)))
     p\<rbrace>"
-  apply (rule hoare_post_imp [where Q="\<lambda>rv s. \<exists>cte. cte_wp_at' ((=) cte) p s
+  apply (rule hoare_post_imp[where Q'="\<lambda>rv s. \<exists>cte. cte_wp_at' ((=) cte) p s
                                            \<and> isUntypedCap (cteCap cte)
                                            \<and> (\<forall>tup\<in>set (zip (xs rv) rv).
                                 sameRegionAs (cteCap cte) (snd tup))"])
@@ -4571,7 +4571,7 @@ lemma resetUntypedCap_invs_etc:
               | strengthen invs_pspace_aligned' invs_pspace_distinct'
               | simp add: ct_in_state'_def
                           sch_act_simple_def
-              | rule hoare_vcg_conj_lift_R
+              | rule hoare_vcg_conj_liftE_R
               | wp (once) preemptionPoint_inv
               | wps
               | wp (once) ex_cte_cap_to'_pres)+
@@ -5289,7 +5289,7 @@ crunch insertNewCap
 lemma insertNewCap_ct_idle_or_in_cur_domain'[wp]:
   "\<lbrace>ct_idle_or_in_cur_domain' and ct_active'\<rbrace> insertNewCap parent slot cap \<lbrace>\<lambda>_. ct_idle_or_in_cur_domain'\<rbrace>"
 apply (wp ct_idle_or_in_cur_domain'_lift_futz[where Q=\<top>])
-apply (rule_tac Q="\<lambda>_. obj_at' (\<lambda>tcb. tcbState tcb \<noteq> Structures_H.thread_state.Inactive) t and obj_at' (\<lambda>tcb. d = tcbDomain tcb) t"
+apply (rule_tac Q'="\<lambda>_. obj_at' (\<lambda>tcb. tcbState tcb \<noteq> Structures_H.thread_state.Inactive) t and obj_at' (\<lambda>tcb. d = tcbDomain tcb) t"
              in hoare_strengthen_post)
 apply (wp | clarsimp elim: obj_at'_weakenE)+
 apply (auto simp: obj_at'_def)

--- a/proof/refine/ARM_HYP/VSpace_R.thy
+++ b/proof/refine/ARM_HYP/VSpace_R.thy
@@ -739,12 +739,12 @@ lemma find_pd_for_asid_pd_at_asid_again:
   apply (unfold validE_def, rule hoare_name_pre_state, fold validE_def)
   apply (case_tac "\<exists>pd. vspace_at_asid asid pd s")
    apply clarsimp
-   apply (rule_tac Q="\<lambda>rv s'. s' = s \<and> rv = pd" and E="\<bottom>\<bottom>" in hoare_strengthen_postE)
+   apply (rule_tac Q'="\<lambda>rv s'. s' = s \<and> rv = pd" and E'="\<bottom>\<bottom>" in hoare_strengthen_postE)
      apply (rule hoare_pre, wp find_pd_for_asid_valids)
      apply fastforce
     apply simp+
-  apply (rule_tac Q="\<lambda>rv s'. s' = s \<and> vspace_at_asid asid rv s'"
-              and E="\<lambda>rv s'. s' = s" in hoare_strengthen_postE)
+  apply (rule_tac Q'="\<lambda>rv s'. s' = s \<and> vspace_at_asid asid rv s'"
+              and E'="\<lambda>rv s'. s' = s" in hoare_strengthen_postE)
     apply (rule hoare_pre, wp)
     apply clarsimp+
   done
@@ -1563,7 +1563,7 @@ lemma deleteASIDPool_corres:
               apply (simp only:)
               apply (rule setVMRoot_corres)
              apply wp+
-         apply (rule_tac R="\<lambda>_ s. rv = arm_asid_table (arch_state s)"
+         apply (rule_tac Q'="\<lambda>_ s. rv = arm_asid_table (arch_state s)"
                     in hoare_post_add)
          apply (drule sym, simp only: )
          apply (drule sym, simp only: )
@@ -1578,7 +1578,7 @@ lemma deleteASIDPool_corres:
          apply (rule hoare_vcg_conj_lift,
                  (rule mapM_invalidate[where ptr=ptr])?,
                  ((wp mapM_wp' | simp)+)[1])+
-        apply (rule_tac R="\<lambda>_ s. rv' = armKSASIDTable (ksArchState s)"
+        apply (rule_tac Q'="\<lambda>_ s. rv' = armKSASIDTable (ksArchState s)"
                      in hoare_post_add)
         apply (simp only: pred_conj_def cong: conj_cong)
         apply simp
@@ -2052,7 +2052,7 @@ lemma valid_objs_valid_vcpu': "\<lbrakk> valid_objs' s ; ko_at' (t :: vcpu) p s 
 lemma setObject_vcpu_no_tcb_update:
   "\<lbrakk> vcpuTCBPtr (f vcpu) = vcpuTCBPtr vcpu \<rbrakk>
   \<Longrightarrow> \<lbrace> valid_objs' and ko_at' (vcpu :: vcpu) p\<rbrace> setObject p (f vcpu) \<lbrace> \<lambda>_. valid_objs' \<rbrace>"
-  apply (rule_tac Q="valid_objs' and (ko_at' vcpu p and valid_obj' (KOArch (KOVCPU vcpu)))" in hoare_pre_imp)
+  apply (rule_tac P'="valid_objs' and (ko_at' vcpu p and valid_obj' (KOArch (KOVCPU vcpu)))" in hoare_pre_imp)
    apply (clarsimp)
    apply (frule valid_objs_valid_vcpu')
     apply assumption+
@@ -2299,11 +2299,11 @@ lemma unmapPage_corres:
                  | wp hoare_drop_imps
                  | wp mapM_wp' | assumption)+
           apply auto[1]
-         apply (wpsimp wp: hoare_vcg_const_imp_lift_R lookupPTSlot_inv
+         apply (wpsimp wp: hoare_vcg_const_imp_liftE_R lookupPTSlot_inv
                | strengthen not_in_global_refs_vs_lookup
                  page_directory_at_lookup_mask_aligned_strg
                  page_directory_at_lookup_mask_add_aligned_strg
-               | wp hoare_vcg_const_Ball_lift_R mapM_wp')+
+               | wp hoare_vcg_const_Ball_liftE_R mapM_wp')+
    apply (clarsimp simp add: valid_unmap_def valid_asid_def)
    apply (case_tac sz)
       apply (auto simp: invs_def valid_state_def
@@ -2868,7 +2868,7 @@ proof -
                     apply wp
                    apply (wpsimp, safe; wpsimp wp: hoare_vcg_ex_lift)
                   apply wpsimp
-                 apply (rule_tac Q="\<lambda>_. K (word \<le> mask asid_bits \<and> word \<noteq> 0) and invs
+                 apply (rule_tac Q'="\<lambda>_. K (word \<le> mask asid_bits \<and> word \<noteq> 0) and invs
                                     and (\<lambda>s. \<exists>pd. vspace_at_asid word pd s)" in hoare_strengthen_post)
                   prefer 2
                   apply auto[1]
@@ -2928,7 +2928,7 @@ proof -
                    apply wp
                   apply (wpsimp, safe ; wpsimp wp: hoare_vcg_ex_lift)
                  apply wpsimp
-                apply (rule_tac Q="\<lambda>_. K (word \<le> mask asid_bits \<and> word \<noteq> 0) and invs
+                apply (rule_tac Q'="\<lambda>_. K (word \<le> mask asid_bits \<and> word \<noteq> 0) and invs
                                    and (\<lambda>s. \<exists>pd. vspace_at_asid word pd s)" in hoare_strengthen_post)
                  prefer 2
                  apply auto[1]
@@ -5323,7 +5323,7 @@ lemma perform_pt_invs [wp]:
   apply clarsimp
   apply (wp arch_update_updateCap_invs unmapPage_cte_wp_at' getSlotCap_wp|wpc)+
   apply (rename_tac acap word a b)
-  apply (rule_tac Q="\<lambda>_. invs' and cte_wp_at' (\<lambda>cte. \<exists>d r R sz m. cteCap cte =
+  apply (rule_tac Q'="\<lambda>_. invs' and cte_wp_at' (\<lambda>cte. \<exists>d r R sz m. cteCap cte =
                                        ArchObjectCap (PageCap d r R sz m)) word"
                in hoare_strengthen_post)
     apply (wp unmapPage_cte_wp_at')

--- a/proof/refine/Move_R.thy
+++ b/proof/refine/Move_R.thy
@@ -69,7 +69,7 @@ lemma hoare_vcg_if_lift3:
   \<lbrace>R\<rbrace> f \<lbrace>\<lambda>rv s. (if P rv s then X rv else Y rv) s\<rbrace>"
   by auto
 
-lemmas hoare_pre_post = hoare_pre_imp[where R="\<lambda>_. Q" and Q=Q for Q]
+lemmas hoare_pre_post = hoare_pre_imp[where Q="\<lambda>_. Q" and P'=Q for Q]
 
 lemmas corres_underlying_gets_pre_rhs =
   corres_symb_exec_r[OF _ _ gets_inv no_fail_pre[OF no_fail_gets TrueI]]

--- a/proof/refine/RISCV64/CNodeInv_R.thy
+++ b/proof/refine/RISCV64/CNodeInv_R.thy
@@ -207,7 +207,7 @@ lemma decodeCNodeInvocation_corres:
                       apply (rule corres_trivial)
                       subgoal by (auto simp add: whenE_def, auto simp add: returnOk_def)
                      apply (wp | wpc | simp(no_asm))+
-                 apply (wp hoare_vcg_const_imp_lift_R hoare_vcg_const_imp_lift
+                 apply (wp hoare_vcg_const_imp_liftE_R hoare_vcg_const_imp_lift
                            hoare_vcg_all_liftE_R hoare_vcg_all_lift lsfco_cte_at' hoare_drop_imps
                                 | clarsimp)+
          subgoal by (auto elim!: valid_cnode_capI)
@@ -6112,7 +6112,7 @@ lemma reduceZombie_invs'':
           apply (wp | simp)+
          apply (rule getCTE_wp)
         apply (wp | simp)+
-      apply (rule_tac Q="\<lambda>cte s. rv = capZombiePtr cap +
+      apply (rule_tac Q'="\<lambda>cte s. rv = capZombiePtr cap +
                                       of_nat (capZombieNumber cap) * 2^cteSizeBits - 2^cteSizeBits
                               \<and> cte_wp_at' (\<lambda>c. c = cte) slot s \<and> invs' s
                               \<and> no_cte_prop Q s \<and> sch_act_simple s"
@@ -6438,8 +6438,8 @@ lemmas cteDelete_typ_at'_lifts [wp] = typ_at_lifts [OF cteDelete_typ_at']
 
 lemma cteDelete_cte_at:
   "\<lbrace>\<top>\<rbrace> cteDelete slot bool \<lbrace>\<lambda>rv. cte_at' slot\<rbrace>"
-  apply (rule_tac Q="\<lambda>s. cte_at' slot s \<or> \<not> cte_at' slot s"
-               in hoare_pre(1))
+  apply (rule_tac P'="\<lambda>s. cte_at' slot s \<or> \<not> cte_at' slot s"
+               in hoare_weaken_pre)
    apply (rule hoare_strengthen_post)
     apply (rule hoare_vcg_disj_lift)
      apply (rule typ_at_lifts, rule cteDelete_typ_at')
@@ -6478,7 +6478,7 @@ lemma cteDelete_cte_wp_at_invs:
       apply (clarsimp simp: cte_wp_at_ctes_of)
      apply wp
     apply (simp add: imp_conjR conj_comms)
-    apply (rule_tac Q="\<lambda>rv s. invs' s \<and> sch_act_simple s \<and>
+    apply (rule_tac Q'="\<lambda>rv s. invs' s \<and> sch_act_simple s \<and>
                    (fst rv \<longrightarrow>
                        cte_wp_at' (\<lambda>cte. removeable' slot s (cteCap cte)) slot s) \<and>
                    (fst rv \<longrightarrow>
@@ -6488,9 +6488,9 @@ lemma cteDelete_cte_wp_at_invs:
                                          cteCap cte = NullCap \<or>
                                          (\<exists>zb n. cteCap cte = Zombie slot zb n))
                                   slot s)"
-                and E="\<lambda>rv. \<top>" in hoare_strengthen_postE)
+                and E'="\<lambda>rv. \<top>" in hoare_strengthen_postE)
       apply (wp finaliseSlot_invs finaliseSlot_removeable finaliseSlot_sch_act_simple
-                hoare_drop_imps(2)[OF finaliseSlot_irqs])
+                hoare_drop_impE_R[OF finaliseSlot_irqs])
        apply (rule hoare_strengthen_postE_R, rule finaliseSlot_abort_cases)
        apply (clarsimp simp: cte_wp_at_ctes_of dest!: isCapDs)
       apply simp
@@ -6511,7 +6511,7 @@ lemma cteDelete_cte_wp_at_invs:
                              p s"
                in hoare_strengthen_postE_R)
     apply (wp finaliseSlot_invs finaliseSlot_removeable finaliseSlot_sch_act_simple
-              hoare_drop_imps(2)[OF finaliseSlot_irqs])
+              hoare_drop_impE_R[OF finaliseSlot_irqs])
     apply (rule hoare_strengthen_postE_R [OF finaliseSlot_cte_wp_at[where p=p and P=P]])
       apply simp+
     apply (clarsimp simp: cte_wp_at_ctes_of)
@@ -6689,7 +6689,7 @@ proof (induct rule: finalise_induct3)
           apply ((wp | simp add: locateSlot_conv)+)[2]
         apply (rule drop_spec_validE)
         apply simp
-        apply (rule_tac Q="\<lambda>rv s. revoke_progress_ord m (option_map capToRPO \<circ> cteCaps_of s)
+        apply (rule_tac Q'="\<lambda>rv s. revoke_progress_ord m (option_map capToRPO \<circ> cteCaps_of s)
                                      \<and> cte_wp_at' (\<lambda>cte. cteCap cte = fst rvb) sl s"
                          in hoare_post_imp)
          apply (clarsimp simp: o_def cte_wp_at_ctes_of capToRPO_def
@@ -7260,7 +7260,7 @@ next
                 apply (rule updateCap_corres)
                  apply simp
                 apply (simp add: is_cap_simps)
-               apply (rule_tac R="\<lambda>rv. cte_at' (cte_map ?target)" in hoare_post_add)
+               apply (rule_tac Q'="\<lambda>rv. cte_at' (cte_map ?target)" in hoare_post_add)
                apply (wp, (wp getCTE_wp)+)
               apply (clarsimp simp: cte_wp_at_ctes_of)
              apply (rule no_fail_pre, wp, simp)
@@ -7422,7 +7422,7 @@ lemma cteRevoke_typ_at':
 
 lemma cteRevoke_invs':
   "\<lbrace>invs' and sch_act_simple\<rbrace> cteRevoke ptr \<lbrace>\<lambda>rv. invs'\<rbrace>"
-  apply (rule_tac Q="\<lambda>rv. invs' and sch_act_simple" in hoare_strengthen_post)
+  apply (rule_tac Q'="\<lambda>rv. invs' and sch_act_simple" in hoare_strengthen_post)
   apply (wp cteRevoke_preservation cteDelete_invs' cteDelete_sch_act_simple)+
     apply simp_all
   done
@@ -8957,7 +8957,7 @@ proof (induct rule: finalise_spec_induct)
             apply (unfold Let_def split_def fst_conv snd_conv
                           case_Zombie_assert_fold haskell_fail_def)
             apply (wp getCTE_wp' preemptionPoint_invR| simp add: o_def irq_state_independent_HI)+
-            apply (rule hoare_post_imp [where Q="\<lambda>_. valid_irq_states'"])
+            apply (rule hoare_post_imp[where Q'="\<lambda>_. valid_irq_states'"])
              apply simp
             apply wp[1]
            apply (rule spec_strengthen_postE)
@@ -9000,7 +9000,7 @@ lemma cteDelete_irq_states':
   apply (simp add: cteDelete_def split_def)
   apply (wp whenE_wp)
    apply (rule hoare_strengthen_postE)
-     apply (rule hoare_valid_validE)
+     apply (rule valid_validE)
      apply (rule finaliseSlot_irq_states')
     apply simp
    apply simp

--- a/proof/refine/RISCV64/CNodeInv_R.thy
+++ b/proof/refine/RISCV64/CNodeInv_R.thy
@@ -6525,8 +6525,8 @@ lemma cteDelete_sch_act_simple:
      cteDelete slot exposed \<lbrace>\<lambda>rv. sch_act_simple\<rbrace>"
   apply (simp add: cteDelete_def whenE_def split_def)
   apply (wp hoare_drop_imps | simp)+
-  apply (rule_tac hoare_strengthen_postE [where Q="\<lambda>rv. sch_act_simple"
-                                       and E="\<lambda>rv. sch_act_simple"])
+  apply (rule_tac hoare_strengthen_postE [where Q'="\<lambda>rv. sch_act_simple"
+                                       and E'="\<lambda>rv. sch_act_simple"])
     apply (rule valid_validE)
     apply (wp finaliseSlot_sch_act_simple)
     apply simp+

--- a/proof/refine/RISCV64/CSpace_R.thy
+++ b/proof/refine/RISCV64/CSpace_R.thy
@@ -2146,7 +2146,7 @@ lemma cteInsert_mdb' [wp]:
   cteInsert cap src dest
   \<lbrace>\<lambda>_. valid_mdb'\<rbrace>"
   apply (simp add:valid_mdb'_def valid_mdb_ctes_def)
-  apply (rule_tac Q = "\<lambda>r s. valid_dlist (ctes_of s) \<and> irq_control (ctes_of s) \<and>
+  apply (rule_tac Q'="\<lambda>r s. valid_dlist (ctes_of s) \<and> irq_control (ctes_of s) \<and>
                no_0 (ctes_of s) \<and> mdb_chain_0 (ctes_of s) \<and>
                mdb_chunked (ctes_of s) \<and> untyped_mdb' (ctes_of s) \<and> untyped_inc' (ctes_of s) \<and>
                Q s" for Q
@@ -3957,12 +3957,12 @@ lemma setupReplyMaster_corres:
        apply (fastforce dest: pspace_relation_no_reply_caps
                              state_relation_pspace_relation)
       apply (clarsimp simp: cte_map_def tcb_cnode_index_def cte_wp_at_ctes_of)
-     apply (rule_tac Q="\<lambda>rv. einvs and tcb_at t and
+     apply (rule_tac Q'="\<lambda>rv. einvs and tcb_at t and
                              cte_wp_at ((=) rv) (t, tcb_cnode_index 2)"
                   in hoare_strengthen_post)
       apply (wp hoare_drop_imps get_cap_wp)
      apply (clarsimp simp: invs_def valid_state_def elim!: cte_wp_at_weakenE)
-    apply (rule_tac Q="\<lambda>rv. valid_pspace' and valid_mdb' and
+    apply (rule_tac Q'="\<lambda>rv. valid_pspace' and valid_mdb' and
                             cte_wp_at' ((=) rv) (cte_map (t, tcb_cnode_index 2))"
                  in hoare_strengthen_post)
      apply (wp hoare_drop_imps getCTE_wp')

--- a/proof/refine/RISCV64/Detype_R.thy
+++ b/proof/refine/RISCV64/Detype_R.thy
@@ -64,7 +64,7 @@ lemma descendants_range_in_lift':
   apply (simp only: Ball_def[unfolded imp_conv_disj])
   apply (rule hoare_pre)
    apply (wp hoare_vcg_all_lift hoare_vcg_disj_lift st cap_range)
-   apply (rule_tac Q = "\<lambda>r s. cte_wp_at' (\<lambda>c. capRange (cteCap c) \<inter> S = {}) x s"
+   apply (rule_tac Q'="\<lambda>r s. cte_wp_at' (\<lambda>c. capRange (cteCap c) \<inter> S = {}) x s"
       in hoare_strengthen_post)
     apply (wp cap_range)
    apply (clarsimp simp:cte_wp_at_ctes_of null_filter'_def)
@@ -1687,7 +1687,7 @@ lemma deleteObjects_invs':
 proof -
   show ?thesis
   apply (rule hoare_pre)
-   apply (rule_tac G="is_aligned ptr bits \<and> 3 \<le> bits \<and> bits \<le> word_bits" in hoare_grab_asm)
+   apply (rule_tac P'="is_aligned ptr bits \<and> 3 \<le> bits \<and> bits \<le> word_bits" in hoare_grab_asm)
    apply (clarsimp simp add: deleteObjects_def2)
    apply (simp add: freeMemory_def bind_assoc doMachineOp_bind ef_storeWord)
    apply (simp add: bind_assoc[where f="\<lambda>_. modify f" for f, symmetric])
@@ -3643,7 +3643,7 @@ lemma createNewCaps_pspace_no_overlap':
          apply simp+
     apply (simp add:range_cover_def)
    apply (simp add:range_cover.sz(1)[where 'a=machine_word_len, folded word_bits_def])
-  apply (rule_tac Q = "\<lambda>r. pspace_no_overlap' (ptr + (1 + of_nat n << Types_H.getObjectSize ty us))
+  apply (rule_tac Q'="\<lambda>r. pspace_no_overlap' (ptr + (1 + of_nat n << Types_H.getObjectSize ty us))
                                               (Types_H.getObjectSize ty us) and
                            pspace_aligned' and pspace_distinct'" in hoare_strengthen_post)
    apply (case_tac ty)

--- a/proof/refine/RISCV64/Finalise_R.thy
+++ b/proof/refine/RISCV64/Finalise_R.thy
@@ -1832,7 +1832,7 @@ lemma isFinalCapability_inv:
   apply (simp add: isFinalCapability_def Let_def
               split del: if_split cong: if_cong)
   apply (rule hoare_pre, wp)
-   apply (rule hoare_post_imp [where Q="\<lambda>s. P"], simp)
+   apply (rule hoare_post_imp[where Q'="\<lambda>s. P"], simp)
    apply wp
   apply simp
   done
@@ -2738,7 +2738,7 @@ lemma cancelIPC_bound_tcb_at'[wp]:
   apply (simp add: getThreadReplySlot_def locateSlot_conv liftM_def)
   apply (rule hoare_pre)
    apply (wp capDeleteOne_bound_tcb_at' getCTE_ctes_of)
-   apply (rule_tac Q="\<lambda>_. bound_tcb_at' P tptr" in hoare_post_imp)
+   apply (rule_tac Q'="\<lambda>_. bound_tcb_at' P tptr" in hoare_post_imp)
    apply (clarsimp simp: capHasProperty_def cte_wp_at_ctes_of)
    apply (wp threadSet_pred_tcb_no_state | simp)+
   done

--- a/proof/refine/RISCV64/Interrupt_R.thy
+++ b/proof/refine/RISCV64/Interrupt_R.thy
@@ -380,7 +380,7 @@ lemma invokeIRQHandler_corres:
        apply simp
        apply (rule corres_split_nor[OF cap_delete_one_corres])
          apply (rule cteInsert_corres, simp+)
-        apply (rule_tac Q="\<lambda>rv s. einvs s \<and> cte_wp_at (\<lambda>c. c = cap.NullCap) irq_slot s
+        apply (rule_tac Q'="\<lambda>rv s. einvs s \<and> cte_wp_at (\<lambda>c. c = cap.NullCap) irq_slot s
                                   \<and> (a, b) \<noteq> irq_slot
                                   \<and> cte_wp_at (is_derived (cdt s) (a, b) cap) (a, b) s"
                       in hoare_post_imp)
@@ -787,7 +787,7 @@ lemma timerTick_invs'[wp]:
   apply (wpsimp wp: threadSet_invs_trivial threadSet_pred_tcb_no_state
                     rescheduleRequired_all_invs_but_ct_not_inQ
               simp: tcb_cte_cases_def)
-      apply (rule_tac Q="\<lambda>rv. invs'" in hoare_post_imp)
+      apply (rule_tac Q'="\<lambda>rv. invs'" in hoare_post_imp)
        apply (clarsimp simp: invs'_def valid_state'_def)
       apply (simp add: decDomainTime_def)
       apply wp
@@ -798,7 +798,7 @@ lemma timerTick_invs'[wp]:
                            hoare_vcg_imp_lift threadSet_ct_idle_or_in_cur_domain')+
             apply (rule hoare_strengthen_post[OF tcbSchedAppend_all_invs_but_ct_not_inQ'])
             apply (wpsimp simp: invs'_def valid_state'_def valid_pspace'_def sch_act_wf_weak)+
-           apply (rule_tac Q="\<lambda>_. invs'" in hoare_strengthen_post)
+           apply (rule_tac Q'="\<lambda>_. invs'" in hoare_strengthen_post)
             apply (wpsimp wp: threadSet_pred_tcb_no_state threadSet_tcbDomain_triv
                               threadSet_valid_objs' threadSet_timeslice_invs)+
            apply (clarsimp simp: invs'_def valid_state'_def valid_pspace'_def)
@@ -837,7 +837,7 @@ lemma hint_invs[wp]:
 
    apply (wp dmo_maskInterrupt_True getCTE_wp'
     | wpc | simp add: doMachineOp_bind maskIrqSignal_def )+
-    apply (rule_tac Q="\<lambda>rv. invs'" in hoare_post_imp)
+    apply (rule_tac Q'="\<lambda>rv. invs'" in hoare_post_imp)
      apply (clarsimp simp: cte_wp_at_ctes_of ex_nonz_cap_to'_def)
      apply fastforce
     apply (wp threadSet_invs_trivial | simp add: inQ_def handleReservedIRQ_def)+

--- a/proof/refine/RISCV64/IpcCancel_R.thy
+++ b/proof/refine/RISCV64/IpcCancel_R.thy
@@ -906,7 +906,7 @@ lemma (in delete_one_conc_pre) cancelIPC_sch_act_simple[wp]:
   apply (wp hoare_drop_imps delete_one_sch_act_simple
        | simp add: getThreadReplySlot_def | wpcw
        | rule sch_act_simple_lift
-       | (rule_tac Q="\<lambda>rv. sch_act_simple" in hoare_post_imp, simp))+
+       | (rule_tac Q'="\<lambda>rv. sch_act_simple" in hoare_post_imp, simp))+
   done
 
 lemma cancelSignal_st_tcb_at:
@@ -916,7 +916,7 @@ lemma cancelSignal_st_tcb_at:
    \<lbrace>\<lambda>rv. st_tcb_at' P t\<rbrace>"
   apply (simp add: cancelSignal_def Let_def list_case_If)
   apply (wp sts_st_tcb_at'_cases hoare_vcg_const_imp_lift
-            hoare_drop_imp[where R="%rv s. P' rv" for P'])
+            hoare_drop_imp[where Q'="%rv s. P' rv" for P'])
    apply clarsimp+
   done
 
@@ -1005,7 +1005,7 @@ lemma (in delete_one_conc_pre) cancelIPC_tcb_at_runnable':
     apply (case_tac rv; simp)
    apply (wp sts_pred_tcb_neq'  | simp | wpc)+
            apply (clarsimp)
-           apply (rule_tac Q="\<lambda>rv. ?PRE" in hoare_post_imp, fastforce)
+           apply (rule_tac Q'="\<lambda>rv. ?PRE" in hoare_post_imp, fastforce)
            apply (wp cteDeleteOne_tcb_at_runnable'
                     threadSet_pred_tcb_no_state
                     cancelSignal_tcb_at_runnable'
@@ -1104,7 +1104,7 @@ lemma sts_weak_sch_act_wf[wp]:
   including classic_wp_pre
   apply (simp add: setThreadState_def)
   apply (wp rescheduleRequired_weak_sch_act_wf)
-  apply (rule_tac Q="\<lambda>_ s. weak_sch_act_wf (ksSchedulerAction s) s" in hoare_post_imp, simp)
+  apply (rule_tac Q'="\<lambda>_ s. weak_sch_act_wf (ksSchedulerAction s) s" in hoare_post_imp, simp)
   apply (simp add: weak_sch_act_wf_def)
   apply (wp hoare_vcg_all_lift)
    apply (wps threadSet_nosch)
@@ -1232,11 +1232,11 @@ lemma (in delete_one) suspend_corres:
            apply wp
           apply (wpsimp wp: sts_valid_objs')
           apply (wpsimp simp: update_restart_pc_def updateRestartPC_def valid_tcb_state'_def)+
-       apply (rule hoare_post_imp[where Q = "\<lambda>rv s. einvs s \<and> tcb_at t s"])
+       apply (rule hoare_post_imp[where Q'="\<lambda>rv s. einvs s \<and> tcb_at t s"])
         apply (simp add: invs_implies invs_strgs valid_queues_in_correct_ready_q
                          valid_queues_ready_qs_distinct valid_sched_def)
        apply wp
-      apply (rule hoare_post_imp[where Q = "\<lambda>_ s. invs' s \<and> tcb_at' t s"])
+      apply (rule hoare_post_imp[where Q'="\<lambda>_ s. invs' s \<and> tcb_at' t s"])
        apply (fastforce simp: invs'_def valid_tcb_state'_def)
       apply (wpsimp simp: update_restart_pc_def updateRestartPC_def)+
    apply fastforce+
@@ -1279,7 +1279,7 @@ lemma (in delete_one_conc) suspend_invs'[wp]:
   apply (simp add: suspend_def)
   apply (wpsimp wp: sts_invs_minor' gts_wp' simp: updateRestartPC_def
          | strengthen no_refs_simple_strg')+
-   apply (rule_tac Q="\<lambda>_. invs' and sch_act_simple and st_tcb_at' simple' t
+   apply (rule_tac Q'="\<lambda>_. invs' and sch_act_simple and st_tcb_at' simple' t
                           and (\<lambda>s. t \<noteq> ksIdleThread s)"
                 in hoare_post_imp)
     apply clarsimp
@@ -1307,7 +1307,7 @@ lemma (in delete_one_conc_pre) suspend_sch_act_simple[wp]:
 lemma (in delete_one_conc) suspend_objs':
   "\<lbrace>invs' and sch_act_simple and tcb_at' t and (\<lambda>s. t \<noteq> ksIdleThread s)\<rbrace>
    suspend t \<lbrace>\<lambda>rv. valid_objs'\<rbrace>"
-  apply (rule_tac Q="\<lambda>_. invs'" in hoare_strengthen_post)
+  apply (rule_tac Q'="\<lambda>_. invs'" in hoare_strengthen_post)
    apply (wp suspend_invs')
   apply fastforce
   done
@@ -1421,7 +1421,7 @@ proof -
         apply (rule ep_cancel_corres_helper)
        apply (rule mapM_x_wp')
        apply (wp weak_sch_act_wf_lift_linear set_thread_state_runnable_weak_valid_sched_action | simp)+
-      apply (rule_tac R="\<lambda>_ s. \<forall>x\<in>set list. tcb_at' x s \<and> valid_objs' s \<and> pspace_aligned' s \<and> pspace_distinct' s"
+      apply (rule_tac Q'="\<lambda>_ s. \<forall>x\<in>set list. tcb_at' x s \<and> valid_objs' s \<and> pspace_aligned' s \<and> pspace_distinct' s"
                    in hoare_post_add)
       apply (rule mapM_x_wp')
       apply ((wpsimp wp: hoare_vcg_const_Ball_lift mapM_x_wp' sts_st_tcb' sts_valid_objs'
@@ -1481,7 +1481,7 @@ lemma cancelAllSignals_corres:
                  set_thread_state_runnable_weak_valid_sched_action
             | simp)+
       apply (rename_tac list)
-      apply (rule_tac R="\<lambda>_ s. (\<forall>x\<in>set list. tcb_at' x s) \<and> valid_objs' s
+      apply (rule_tac Q'="\<lambda>_ s. (\<forall>x\<in>set list. tcb_at' x s) \<and> valid_objs' s
                                \<and> sym_heap_sched_pointers s \<and> valid_sched_pointers s \<and> valid_objs' s
                                \<and> pspace_aligned' s \<and> pspace_distinct' s"
                    in hoare_post_add)
@@ -1529,7 +1529,7 @@ proof -
   show ?thesis
   apply (simp add: setThreadState_def)
   apply (wpsimp wp: hoare_vcg_imp_lift [OF nrct])
-   apply (rule_tac Q="\<lambda>_. ?PRE" in hoare_post_imp)
+   apply (rule_tac Q'="\<lambda>_. ?PRE" in hoare_post_imp)
     apply (clarsimp)
    apply (rule hoare_convert_imp [OF threadSet_nosch threadSet_ct])
   apply assumption
@@ -1780,7 +1780,7 @@ lemma cancelAllIPC_valid_objs'[wp]:
   apply (rule bind_wp [OF _ get_ep_sp'])
   apply (rule hoare_pre)
    apply (wp set_ep_valid_objs' setSchedulerAction_valid_objs')
-    apply (rule_tac Q="\<lambda>_ s. valid_objs' s \<and> pspace_aligned' s \<and> pspace_distinct' s
+    apply (rule_tac Q'="\<lambda>_ s. valid_objs' s \<and> pspace_aligned' s \<and> pspace_distinct' s
                              \<and> (\<forall>x\<in>set (epQueue ep). tcb_at' x s)"
                     in hoare_post_imp)
      apply simp
@@ -1806,7 +1806,7 @@ lemma cancelAllSignals_valid_objs'[wp]:
     apply (wp, simp)
    apply (wp, simp)
   apply (rename_tac list)
-  apply (rule_tac Q="\<lambda>rv s. valid_objs' s \<and> (\<forall>x\<in>set list. tcb_at' x s)"
+  apply (rule_tac Q'="\<lambda>rv s. valid_objs' s \<and> (\<forall>x\<in>set list. tcb_at' x s)"
                   in hoare_post_imp)
    apply (simp add: valid_ntfn'_def)
   apply (simp add: Ball_def)
@@ -2107,7 +2107,7 @@ lemma cancelBadgedSends_corres:
     apply (rule corres_split_nor[OF setEndpoint_corres])
        apply (simp add: ep_relation_def)
       apply (rule corres_split_eqr[OF _ _ _ hoare_post_add
-                                             [where R="\<lambda>_. valid_objs' and pspace_aligned'
+                                             [where Q'="\<lambda>_. valid_objs' and pspace_aligned'
                                                            and pspace_distinct'"]])
          apply (rule_tac S="(=)"
                      and Q="\<lambda>xs s. (\<forall>x \<in> set xs. (epptr, TCBBlockedSend) \<in> state_refs_of s x) \<and>

--- a/proof/refine/RISCV64/Ipc_R.thy
+++ b/proof/refine/RISCV64/Ipc_R.thy
@@ -492,7 +492,7 @@ next
         apply clarsimp
         apply assumption
        apply (subst imp_conjR)
-       apply (rule hoare_vcg_conj_liftE_R)
+       apply (rule hoare_vcg_conj_liftE_R')
         apply (rule derive_cap_is_derived)
        apply (wp derive_cap_is_derived_foo)+
       apply (simp split del: if_split)
@@ -504,7 +504,7 @@ next
        apply clarsimp
        apply assumption
       apply (subst imp_conjR)
-      apply (rule hoare_vcg_conj_liftE_R)
+      apply (rule hoare_vcg_conj_liftE_R')
        apply (rule hoare_strengthen_postE_R[OF deriveCap_derived])
        apply (clarsimp simp:cte_wp_at_ctes_of)
       apply (wp deriveCap_derived_foo)
@@ -616,7 +616,7 @@ lemma cteInsert_assume_Null:
    apply (rule bind_wp[OF _ getCTE_sp])+
    apply (rule hoare_name_pre_state)
    apply (clarsimp simp: cte_wp_at_ctes_of)
-  apply (erule hoare_pre(1))
+  apply (erule hoare_weaken_pre)
   apply simp
   done
 
@@ -1816,7 +1816,7 @@ declare asUser_global_refs' [wp]
 lemma lec_valid_cap' [wp]:
   "\<lbrace>valid_objs'\<rbrace> lookupExtraCaps thread xa mi \<lbrace>\<lambda>rv s. (\<forall>x\<in>set rv. s \<turnstile>' fst x)\<rbrace>, -"
   apply (rule hoare_pre, rule hoare_strengthen_postE_R)
-    apply (rule hoare_vcg_conj_lift_R[where R=valid_objs' and S="\<lambda>_. valid_objs'"])
+    apply (rule hoare_vcg_conj_liftE_R[where R=valid_objs' and S="\<lambda>_. valid_objs'"])
      apply (rule lookupExtraCaps_srcs)
     apply wp
    apply (clarsimp simp: cte_wp_at_ctes_of)
@@ -2195,7 +2195,7 @@ lemma doReplyTransfer_corres:
           apply (fastforce)
          apply (clarsimp simp:is_cap_simps)
         apply (wp weak_valid_sched_action_lift)+
-       apply (rule_tac Q="\<lambda>_ s. valid_objs' s \<and> cur_tcb' s \<and> tcb_at' receiver s
+       apply (rule_tac Q'="\<lambda>_ s. valid_objs' s \<and> cur_tcb' s \<and> tcb_at' receiver s
                                 \<and> sch_act_wf (ksSchedulerAction s) s
                                 \<and> sym_heap_sched_pointers s \<and> valid_sched_pointers s
                                 \<and> pspace_aligned' s \<and> pspace_distinct' s"
@@ -2252,7 +2252,7 @@ lemma doReplyTransfer_corres:
                              threadSet_tcbDomain_triv threadSet_valid_objs'
                              threadSet_sched_pointers threadSet_valid_sched_pointers
                         | simp add: valid_tcb_state'_def)+
-     apply (rule_tac Q="\<lambda>_. valid_sched and cur_tcb and tcb_at sender and tcb_at receiver and
+     apply (rule_tac Q'="\<lambda>_. valid_sched and cur_tcb and tcb_at sender and tcb_at receiver and
                             valid_objs and pspace_aligned and pspace_distinct"
                      in hoare_strengthen_post [rotated], clarsimp)
      apply (wp)
@@ -2260,7 +2260,7 @@ lemma doReplyTransfer_corres:
       apply (assumption)
      apply (rule conjI, clarsimp)
      apply (clarsimp simp add: invs_def valid_state_def valid_pspace_def)
-    apply (rule_tac Q="\<lambda>_. tcb_at' sender and tcb_at' receiver and invs'"
+    apply (rule_tac Q'="\<lambda>_. tcb_at' sender and tcb_at' receiver and invs'"
                     in hoare_strengthen_post [rotated])
      apply (solves\<open>auto simp: invs'_def valid_state'_def\<close>)
     apply wp
@@ -2341,14 +2341,14 @@ lemma setupCallerCap_corres:
                               tcb_cnode_index_def cte_level_bits_def)
             apply (simp add: cte_map_def tcbCallerSlot_def
                              tcb_cnode_index_def cte_level_bits_def)
-           apply (rule_tac R="\<lambda>rv. cte_at' (receiver + 2 ^ cte_level_bits * tcbCallerSlot)"
+           apply (rule_tac Q'="\<lambda>rv. cte_at' (receiver + 2 ^ cte_level_bits * tcbCallerSlot)"
                     in hoare_post_add)
 
            apply (wp, (wp getSlotCap_wp)+)
           apply blast
          apply (rule no_fail_pre, wp)
          apply (clarsimp simp: cte_wp_at'_def cte_at'_def)
-        apply (rule_tac R="\<lambda>rv. cte_at' (sender + 2 ^ cte_level_bits * tcbReplySlot)"
+        apply (rule_tac Q'="\<lambda>rv. cte_at' (sender + 2 ^ cte_level_bits * tcbReplySlot)"
                      in hoare_post_add)
         apply (wp, (wp getCTE_wp')+)
        apply blast
@@ -2683,7 +2683,7 @@ lemma sendSignal_corres:
                                valid_queues_in_correct_ready_q valid_queues_ready_qs_distinct
                                valid_sched_valid_queues
                   | simp add: valid_tcb_state_def)+
-         apply (rule_tac Q="\<lambda>rv. invs' and tcb_at' a" in hoare_strengthen_post)
+         apply (rule_tac Q'="\<lambda>rv. invs' and tcb_at' a" in hoare_strengthen_post)
           apply wp
          apply (fastforce simp: invs'_def valid_state'_def sch_act_wf_weak valid_tcb_state'_def)
         apply (rule setNotification_corres)
@@ -2711,7 +2711,7 @@ lemma sendSignal_corres:
           apply (rule corres_split[OF asUser_setRegister_corres])
             apply (rule possibleSwitchTo_corres)
            apply ((wp | simp)+)[1]
-          apply (rule_tac Q="\<lambda>_. (\<lambda>s. sch_act_wf (ksSchedulerAction s) s) and
+          apply (rule_tac Q'="\<lambda>_. (\<lambda>s. sch_act_wf (ksSchedulerAction s) s) and
                                  cur_tcb' and
                                  st_tcb_at' runnable' (hd list) and valid_objs' and
                                  sym_heap_sched_pointers and valid_sched_pointers and
@@ -2912,7 +2912,7 @@ lemma cancelIPC_nonz_cap_to'[wp]:
        | wpc
        | simp
        | clarsimp elim!: cte_wp_at_weakenE'
-       | rule hoare_post_imp[where Q="\<lambda>rv. ex_nonz_cap_to' p"])+
+       | rule hoare_post_imp[where Q'="\<lambda>rv. ex_nonz_cap_to' p"])+
   done
 
 
@@ -2992,7 +2992,7 @@ proof -
           apply (wpc)
            apply (wp | simp)+
        apply (wpc, wp+)
-     apply (rule_tac Q="\<lambda>_. ?PRE t'" in hoare_post_imp, clarsimp)
+     apply (rule_tac Q'="\<lambda>_. ?PRE t'" in hoare_post_imp, clarsimp)
      apply (wp)
     apply simp
     done
@@ -3004,7 +3004,7 @@ proof -
     apply (wp)
         apply (wp hoare_convert_imp)[1]
        apply (wp)
-      apply (rule_tac Q="\<lambda>_. ?PRE t'" in hoare_post_imp, clarsimp)
+      apply (rule_tac Q'="\<lambda>_. ?PRE t'" in hoare_post_imp, clarsimp)
       apply (wp hoare_convert_imp | simp)+
      done
   show ?thesis
@@ -3017,16 +3017,16 @@ proof -
         apply (wp)+
            apply (wp hoare_convert_imp)[1]
           apply (wpc, wp+)
-        apply (rule_tac Q="\<lambda>_. ?PRE t'" in hoare_post_imp, clarsimp)
+        apply (rule_tac Q'="\<lambda>_. ?PRE t'" in hoare_post_imp, clarsimp)
         apply (wp cdo)+
-         apply (rule_tac Q="\<lambda>_. ?PRE t'" in hoare_post_imp, clarsimp)
+         apply (rule_tac Q'="\<lambda>_. ?PRE t'" in hoare_post_imp, clarsimp)
          apply ((wp aipc hoare_convert_imp)+)[6]
     apply (wp)
        apply (wp hoare_convert_imp)[1]
       apply (wpc, wp+)
-    apply (rule_tac Q="\<lambda>_. ?PRE t'" in hoare_post_imp, clarsimp)
+    apply (rule_tac Q'="\<lambda>_. ?PRE t'" in hoare_post_imp, clarsimp)
     apply (wp)
-   apply (rule_tac Q="\<lambda>_. ?PRE t'" in hoare_post_imp, clarsimp)
+   apply (rule_tac Q'="\<lambda>_. ?PRE t'" in hoare_post_imp, clarsimp)
    apply (wp)
   apply simp
   done
@@ -3284,7 +3284,7 @@ lemma receiveIPC_corres:
                                              valid_sched_action_def)
                      apply (clarsimp split: if_split_asm)
                     apply (clarsimp | wp do_ipc_transfer_tcb_caps)+
-                   apply (rule_tac Q="\<lambda>_ s. sch_act_wf (ksSchedulerAction s) s
+                   apply (rule_tac Q'="\<lambda>_ s. sch_act_wf (ksSchedulerAction s) s
                                             \<and> sym_heap_sched_pointers s \<and> valid_sched_pointers s
                                             \<and> pspace_aligned' s \<and> pspace_distinct' s"
                                 in hoare_post_imp)
@@ -3544,7 +3544,7 @@ lemma setupCallerCap_vp[wp]:
   apply (simp add: valid_pspace'_def setupCallerCap_def getThreadCallerSlot_def
                    getThreadReplySlot_def locateSlot_conv getSlotCap_def)
   apply (wp getCTE_wp)
-  apply (rule_tac Q="\<lambda>_. valid_pspace' and
+  apply (rule_tac Q'="\<lambda>_. valid_pspace' and
                          tcb_at' sender and tcb_at' rcvr"
                   in hoare_post_imp)
    apply (clarsimp simp: valid_cap'_def o_def cte_wp_at_ctes_of isCap_simps
@@ -3575,7 +3575,7 @@ lemma setupCallerCap_ifunsafe[wp]:
   apply (wp getSlotCap_cte_wp_at
        | simp add: unique_master_reply_cap' | strengthen eq_imp_strg
        | wp (once) hoare_drop_imp[where f="getCTE rs" for rs])+
-   apply (rule_tac Q="\<lambda>rv. valid_objs' and tcb_at' rcvr and ex_nonz_cap_to' rcvr"
+   apply (rule_tac Q'="\<lambda>rv. valid_objs' and tcb_at' rcvr and ex_nonz_cap_to' rcvr"
                 in hoare_post_imp)
     apply (clarsimp simp: ex_nonz_tcb_cte_caps' tcbCallerSlot_def
                           objBits_def objBitsKO_def dom_def cte_level_bits_def)
@@ -3732,7 +3732,7 @@ lemma completeSignal_invs:
   apply (rule bind_wp[OF _ get_ntfn_sp'])
   apply (rule hoare_pre)
    apply (wp set_ntfn_minor_invs' | wpc | simp)+
-    apply (rule_tac Q="\<lambda>_ s. (state_refs_of' s ntfnptr = ntfn_bound_refs' (ntfnBoundTCB ntfn))
+    apply (rule_tac Q'="\<lambda>_ s. (state_refs_of' s ntfnptr = ntfn_bound_refs' (ntfnBoundTCB ntfn))
                            \<and> ntfn_at' ntfnptr s
                            \<and> valid_ntfn' (ntfnObj_update (\<lambda>_. Structures_H.ntfn.IdleNtfn) ntfn) s
                            \<and> ((\<exists>y. ntfnBoundTCB ntfn = Some y) \<longrightarrow> ex_nonz_cap_to' ntfnptr s)
@@ -3762,7 +3762,7 @@ lemma setupCallerCap_urz[wp]:
                    getThreadCallerSlot_def getThreadReplySlot_def
                    locateSlot_conv)
   apply (wp getCTE_wp')
-  apply (rule_tac Q="\<lambda>_. untyped_ranges_zero' and valid_mdb' and valid_objs'" in hoare_post_imp)
+  apply (rule_tac Q'="\<lambda>_. untyped_ranges_zero' and valid_mdb' and valid_objs'" in hoare_post_imp)
    apply (clarsimp simp: cte_wp_at_ctes_of cteCaps_of_def untyped_derived_eq_def
                          isCap_simps)
   apply (wp sts_valid_pspace_hangers)
@@ -3814,7 +3814,7 @@ lemma ri_invs' [wp]:
   apply (rule bind_wp [OF _ gbn_sp'])
   apply (rule bind_wp)
   (* set up precondition for old proof *)
-   apply (rule_tac R="ko_at' ep (capEPPtr cap) and ?pre" in hoare_vcg_if_split)
+   apply (rule_tac P''="ko_at' ep (capEPPtr cap) and ?pre" in hoare_vcg_if_split)
     apply (wp completeSignal_invs)
    apply (case_tac ep)
      \<comment> \<open>endpoint = RecvEP\<close>
@@ -4088,9 +4088,9 @@ lemma si_invs'[wp]:
                hoare_convert_imp [OF setEndpoint_nosch setEndpoint_ct']
                hoare_drop_imp [where f="threadGet tcbFault t"]
              | rule_tac f="getThreadState a" in hoare_drop_imp
-             | wp (once) hoare_drop_imp[where R="\<lambda>_ _. call"]
-               hoare_drop_imp[where R="\<lambda>_ _. \<not> call"]
-               hoare_drop_imp[where R="\<lambda>_ _. cg"]
+             | wp (once) hoare_drop_imp[where Q'="\<lambda>_ _. call"]
+               hoare_drop_imp[where Q'="\<lambda>_ _. \<not> call"]
+               hoare_drop_imp[where Q'="\<lambda>_ _. cg"]
              | simp    add: valid_tcb_state'_def case_bool_If
                             case_option_If
                       cong: if_cong

--- a/proof/refine/RISCV64/Ipc_R.thy
+++ b/proof/refine/RISCV64/Ipc_R.thy
@@ -52,7 +52,7 @@ lemma lsfco_cte_at':
    apply (wp)
   apply (clarsimp simp: split_def unlessE_def
              split del: if_split)
-  apply (wp hoare_drop_imps throwE_R)
+  apply (wpsimp wp: hoare_drop_imps throwE_R)
   done
 
 declare unifyFailure_wp [wp]
@@ -1816,7 +1816,7 @@ declare asUser_global_refs' [wp]
 lemma lec_valid_cap' [wp]:
   "\<lbrace>valid_objs'\<rbrace> lookupExtraCaps thread xa mi \<lbrace>\<lambda>rv s. (\<forall>x\<in>set rv. s \<turnstile>' fst x)\<rbrace>, -"
   apply (rule hoare_pre, rule hoare_strengthen_postE_R)
-    apply (rule hoare_vcg_conj_liftE_R[where R=valid_objs' and S="\<lambda>_. valid_objs'"])
+    apply (rule hoare_vcg_conj_liftE_R[where P'=valid_objs' and Q'="\<lambda>_. valid_objs'"])
      apply (rule lookupExtraCaps_srcs)
     apply wp
    apply (clarsimp simp: cte_wp_at_ctes_of)

--- a/proof/refine/RISCV64/Refine.thy
+++ b/proof/refine/RISCV64/Refine.thy
@@ -220,12 +220,12 @@ lemma set_thread_state_sched_act:
      apply (simp add: set_thread_state_ext_def)
      apply wp
         apply (rule hoare_pre_cont)
-       apply (rule_tac Q="\<lambda>rv. (\<lambda>s. runnable ts) and (\<lambda>s. P (scheduler_action s))"
+       apply (rule_tac Q'="\<lambda>rv. (\<lambda>s. runnable ts) and (\<lambda>s. P (scheduler_action s))"
                in hoare_strengthen_post)
         apply wp
        apply force
       apply (wp gts_st_tcb_at)+
-    apply (rule_tac Q="\<lambda>rv. st_tcb_at ((=) state) thread and (\<lambda>s. runnable state) and (\<lambda>s. P (scheduler_action s))" in hoare_strengthen_post)
+    apply (rule_tac Q'="\<lambda>rv. st_tcb_at ((=) state) thread and (\<lambda>s. runnable state) and (\<lambda>s. P (scheduler_action s))" in hoare_strengthen_post)
      apply (simp add: st_tcb_at_def)
      apply (wp obj_set_prop_at)+
     apply (force simp: st_tcb_at_def obj_at_def)
@@ -264,7 +264,7 @@ lemma kernel_entry_invs:
   \<lbrace>\<lambda>rv. einvs and (\<lambda>s. ct_running s \<or> ct_idle s)
     and (\<lambda>s. 0 < domain_time s) and valid_domain_list
     and (\<lambda>s. scheduler_action s = resume_cur_thread)\<rbrace>"
-  apply (rule_tac Q="\<lambda>rv. invs and (\<lambda>s. ct_running s \<or> ct_idle s) and valid_sched and
+  apply (rule_tac Q'="\<lambda>rv. invs and (\<lambda>s. ct_running s \<or> ct_idle s) and valid_sched and
                            (\<lambda>s. 0 < domain_time s) and valid_domain_list and
                            valid_list and (\<lambda>s. scheduler_action s = resume_cur_thread)"
             in hoare_post_imp)
@@ -310,7 +310,7 @@ lemma do_user_op_invs2:
   do_user_op f tc
    \<lbrace>\<lambda>_. (einvs  and ct_running and (\<lambda>s. scheduler_action s = resume_cur_thread))
         and (\<lambda>s. 0 < domain_time s) and valid_domain_list \<rbrace>"
-  apply (rule_tac Q="\<lambda>_. valid_list and valid_sched and
+  apply (rule_tac Q'="\<lambda>_. valid_list and valid_sched and
    (\<lambda>s. scheduler_action s = resume_cur_thread) and (invs and ct_running) and
    (\<lambda>s. 0 < domain_time s) and valid_domain_list"
    in hoare_strengthen_post)
@@ -565,22 +565,22 @@ lemma kernel_corres':
           apply simp
           apply (wpsimp wp: hoare_drop_imps hoare_vcg_all_lift simp: schact_is_rct_def)[1]
          apply simp
-         apply (rule_tac Q="\<lambda>irq s. invs' s \<and>
+         apply (rule_tac Q'="\<lambda>irq s. invs' s \<and>
                               (\<forall>irq'. irq = Some irq' \<longrightarrow>
                                  intStateIRQTable (ksInterruptState s ) irq' \<noteq>
                                  IRQInactive)"
                       in hoare_post_imp)
           apply simp
          apply (wp doMachineOp_getActiveIRQ_IRQ_active handle_event_valid_sched | simp)+
-       apply (rule_tac Q="\<lambda>_. \<top>" and E="\<lambda>_. invs'" in hoare_strengthen_postE)
+       apply (rule_tac Q'="\<lambda>_. \<top>" and E'="\<lambda>_. invs'" in hoare_strengthen_postE)
          apply wpsimp+
        apply (simp add: invs'_def valid_state'_def)
       apply (rule corres_split[OF schedule_corres])
         apply (rule activateThread_corres)
        apply (wp handle_interrupt_valid_sched[unfolded non_kernel_IRQs_def, simplified]
                  schedule_invs' hoare_vcg_if_lift2 hoare_drop_imps |simp)+
-     apply (rule_tac Q="\<lambda>_. valid_sched and invs and valid_list" and
-                     E="\<lambda>_. valid_sched and invs and valid_list"
+     apply (rule_tac Q'="\<lambda>_. valid_sched and invs and valid_list" and
+                     E'="\<lambda>_. valid_sched and invs and valid_list"
             in hoare_strengthen_postE)
        apply (wp handle_event_valid_sched hoare_vcg_imp_lift' |simp)+
    apply (clarsimp simp: active_from_running schact_is_rct_def)

--- a/proof/refine/RISCV64/Retype_R.thy
+++ b/proof/refine/RISCV64/Retype_R.thy
@@ -4223,19 +4223,16 @@ lemma createNewCaps_idle'[wp]:
              split del: if_split)
   apply (cases ty, simp_all add: Arch_createNewCaps_def
                       split del: if_split)
-         apply (rename_tac apiobject_type)
-         apply (case_tac apiobject_type, simp_all split del: if_split)[1]
-             apply (wp, simp)
-           including classic_wp_pre
-           apply (wp mapM_x_wp'
-                     createObjects_idle'
-                     threadSet_idle'
-                   | simp add: projectKO_opt_tcb projectKO_opt_cte
-                               makeObject_cte makeObject_tcb archObjSize_def
-                               tcb_cte_cases_def objBitsKO_def APIType_capBits_def
-                               objBits_def createObjects_def bit_simps cteSizeBits_def
-                   | intro conjI impI
-                   | fastforce simp: curDomain_def)+
+      apply (rename_tac apiobject_type)
+      apply (case_tac apiobject_type, simp_all split del: if_split)[1]
+          apply wpsimp
+         apply (wpsimp wp: mapM_x_wp' createObjects_idle' threadSet_idle'
+                | simp add: projectKO_opt_tcb projectKO_opt_cte
+                            makeObject_cte makeObject_tcb archObjSize_def
+                            tcb_cte_cases_def objBitsKO_def APIType_capBits_def
+                            objBits_def createObjects_def bit_simps cteSizeBits_def
+                | intro conjI impI
+                | clarsimp simp: curDomain_def)+
   done
 
 crunch createNewCaps

--- a/proof/refine/RISCV64/Retype_R.thy
+++ b/proof/refine/RISCV64/Retype_R.thy
@@ -4145,7 +4145,7 @@ lemma createNewCaps_cur:
         cur_tcb' s\<rbrace>
       createNewCaps ty ptr n us d
    \<lbrace>\<lambda>rv. cur_tcb'\<rbrace>"
-  apply (rule hoare_post_imp [where Q="\<lambda>rv s. \<exists>t. ksCurThread s = t \<and> tcb_at' t s"])
+  apply (rule hoare_post_imp[where Q'="\<lambda>rv s. \<exists>t. ksCurThread s = t \<and> tcb_at' t s"])
    apply (simp add: cur_tcb'_def)
   apply (wp hoare_vcg_ex_lift createNewCaps_obj_at')
   apply (clarsimp simp: pspace_no_overlap'_def cur_tcb'_def valid_pspace'_def)
@@ -4253,7 +4253,7 @@ lemma createNewCaps_global_refs':
      createNewCaps ty ptr n us d
    \<lbrace>\<lambda>rv. valid_global_refs'\<rbrace>"
   apply (simp add: valid_global_refs'_def valid_cap_sizes'_def valid_refs'_def)
-  apply (rule_tac Q="\<lambda>rv s. \<forall>ptr. \<not> cte_wp_at' (\<lambda>cte. (kernel_data_refs \<inter> capRange (cteCap cte) \<noteq> {}
+  apply (rule_tac Q'="\<lambda>rv s. \<forall>ptr. \<not> cte_wp_at' (\<lambda>cte. (kernel_data_refs \<inter> capRange (cteCap cte) \<noteq> {}
         \<or> 2 ^ capBits (cteCap cte) > gsMaxObjectSize s)) ptr s \<and> global_refs' s \<subseteq> kernel_data_refs"
                  in hoare_post_imp)
    apply (auto simp: cte_wp_at_ctes_of linorder_not_less elim!: ranE)[1]
@@ -4846,7 +4846,7 @@ proof (rule hoare_gen_asm, elim conjE)
     "\<lbrace>ct_not_inQ and valid_pspace' and pspace_no_overlap' ptr sz\<rbrace>
      createNewCaps ty ptr n us dev \<lbrace>\<lambda>_. ct_not_inQ\<rbrace>"
     unfolding ct_not_inQ_def
-    apply (rule_tac Q="\<lambda>s. ksSchedulerAction s = ResumeCurrentThread
+    apply (rule_tac P'="\<lambda>s. ksSchedulerAction s = ResumeCurrentThread
                              \<longrightarrow> (obj_at' (Not \<circ> tcbQueued) (ksCurThread s) s
                                   \<and> valid_pspace' s \<and> pspace_no_overlap' ptr sz s)"
                     in hoare_pre_imp, clarsimp)
@@ -4984,7 +4984,7 @@ lemma createObjects_no_cte_valid_global:
       createObjects ptr n val gbits
    \<lbrace>\<lambda>rv s. valid_global_refs' s\<rbrace>"
   apply (simp add: valid_global_refs'_def valid_cap_sizes'_def valid_refs'_def)
-  apply (rule_tac Q="\<lambda>rv s. \<forall>ptr. \<not> cte_wp_at' (\<lambda>cte. (kernel_data_refs \<inter> capRange (cteCap cte) \<noteq> {}
+  apply (rule_tac Q'="\<lambda>rv s. \<forall>ptr. \<not> cte_wp_at' (\<lambda>cte. (kernel_data_refs \<inter> capRange (cteCap cte) \<noteq> {}
         \<or> 2 ^ capBits (cteCap cte) > gsMaxObjectSize s)) ptr s \<and> global_refs' s \<subseteq> kernel_data_refs"
                  in hoare_post_imp)
    apply (auto simp: cte_wp_at_ctes_of linorder_not_less elim!: ranE)[1]
@@ -5093,7 +5093,7 @@ lemma createObjects_cur':
         cur_tcb' s\<rbrace>
       createObjects ptr n val gbits
    \<lbrace>\<lambda>rv s. cur_tcb' s\<rbrace>"
-  apply (rule hoare_post_imp [where Q="\<lambda>rv s. \<exists>t. ksCurThread s = t \<and> tcb_at' t s"])
+  apply (rule hoare_post_imp[where Q'="\<lambda>rv s. \<exists>t. ksCurThread s = t \<and> tcb_at' t s"])
    apply (simp add: cur_tcb'_def)
   apply (wp hoare_vcg_ex_lift createObjects_orig_obj_at3)
   apply (clarsimp simp: cur_tcb'_def)
@@ -5180,7 +5180,7 @@ proof -
       createObjects ptr n val gbits \<lbrace>\<lambda>_. ct_not_inQ\<rbrace>"
     (is "\<lbrakk> _; _ \<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s. ct_not_inQ s \<and> ?REST s\<rbrace> _ \<lbrace>_\<rbrace>")
     apply (simp add: ct_not_inQ_def)
-    apply (rule_tac Q="\<lambda>s. (ksSchedulerAction s = ResumeCurrentThread) \<longrightarrow>
+    apply (rule_tac P'="\<lambda>s. (ksSchedulerAction s = ResumeCurrentThread) \<longrightarrow>
                              (obj_at' (Not \<circ> tcbQueued) (ksCurThread s) s \<and> ?REST s)"
              in hoare_pre_imp, clarsimp)
     apply (rule hoare_convert_imp [OF createObjects_nosch])

--- a/proof/refine/RISCV64/Schedule_R.thy
+++ b/proof/refine/RISCV64/Schedule_R.thy
@@ -647,7 +647,7 @@ lemma tcbSchedDequeue_valid_mdb'[wp]:
   "\<lbrace>valid_mdb' and valid_objs'\<rbrace> tcbSchedDequeue tcbPtr \<lbrace>\<lambda>_. valid_mdb'\<rbrace>"
   unfolding tcbSchedDequeue_def
   apply (wpsimp simp: bitmap_fun_defs setQueue_def wp: threadSet_mdb' tcbQueueRemove_valid_mdb')
-      apply (rule_tac Q="\<lambda>_. tcb_at' tcbPtr" in hoare_post_imp)
+      apply (rule_tac Q'="\<lambda>_. tcb_at' tcbPtr" in hoare_post_imp)
        apply (fastforce simp: tcb_cte_cases_def cteSizeBits_def)
       apply (wpsimp wp: threadGet_wp)+
   apply (fastforce simp: obj_at'_def)
@@ -930,7 +930,7 @@ lemma tcbSchedDequeue_not_tcbQueued:
   "\<lbrace>\<top>\<rbrace> tcbSchedDequeue t \<lbrace>\<lambda>_. obj_at' (\<lambda>x. \<not> tcbQueued x) t\<rbrace>"
   apply (simp add: tcbSchedDequeue_def)
   apply (wp|clarsimp)+
-  apply (rule_tac Q="\<lambda>queued. obj_at' (\<lambda>x. tcbQueued x = queued) t" in hoare_post_imp)
+  apply (rule_tac Q'="\<lambda>queued. obj_at' (\<lambda>x. tcbQueued x = queued) t" in hoare_post_imp)
      apply (clarsimp simp: obj_at'_def)
     apply (wpsimp wp: threadGet_wp)+
   apply (clarsimp simp: obj_at'_def)
@@ -1961,7 +1961,7 @@ lemma schedule_corres:
 
            apply (clarsimp simp: conj_ac cong: conj_cong)
            apply wp
-           apply (rule_tac Q="\<lambda>_ s. valid_blocked_except t s \<and> scheduler_action s = switch_thread t"
+           apply (rule_tac Q'="\<lambda>_ s. valid_blocked_except t s \<and> scheduler_action s = switch_thread t"
                     in hoare_post_imp, fastforce)
            apply (wp add: tcb_sched_action_enqueue_valid_blocked_except
                           tcbSchedEnqueue_invs'_not_ResumeCurrentThread thread_get_wp
@@ -2232,7 +2232,7 @@ lemma schedule_invs':
     apply (wpsimp wp: scheduleChooseNewThread_invs' ssa_invs'
                       chooseThread_invs_no_cicd' setSchedulerAction_invs' setSchedulerAction_direct
                       switchToThread_tcb_in_cur_domain' switchToThread_ct_not_queued_2
-           | wp hoare_disjI2[where R="\<lambda>_ s. tcb_in_cur_domain' (ksCurThread s) s"]
+           | wp hoare_disjI2[where Q'="\<lambda>_ s. tcb_in_cur_domain' (ksCurThread s) s"]
            | wp hoare_drop_imp[where f="isHighestPrio d p" for d p]
            | simp only: obj_at'_activatable_st_tcb_at'[simplified comp_def]
            | strengthen invs'_invs_no_cicd

--- a/proof/refine/RISCV64/Schedule_R.thy
+++ b/proof/refine/RISCV64/Schedule_R.thy
@@ -1967,7 +1967,7 @@ lemma schedule_corres:
                           tcbSchedEnqueue_invs'_not_ResumeCurrentThread thread_get_wp
                      del: gets_wp
                   | strengthen valid_objs'_valid_tcbs')+
-       apply (clarsimp simp: conj_ac if_apply_def2 cong: imp_cong conj_cong del: hoare_gets)
+       apply (clarsimp simp: conj_ac if_apply_def2 cong: imp_cong conj_cong)
        apply (wp gets_wp)+
 
    (* abstract final subgoal *)

--- a/proof/refine/RISCV64/SubMonad_R.thy
+++ b/proof/refine/RISCV64/SubMonad_R.thy
@@ -80,7 +80,7 @@ lemma threadSet_modify_asUser:
    apply (clarsimp simp: threadSet_def setObject_def split_def
                          updateObject_default_def)
    apply wp
-   apply (rule_tac Q="\<lambda>rv. obj_at' ((=) rv) t and ((=) st)" in hoare_post_imp)
+   apply (rule_tac Q'="\<lambda>rv. obj_at' ((=) rv) t and ((=) st)" in hoare_post_imp)
     apply (clarsimp simp: asUser_replace_def Let_def obj_at'_def fun_upd_def
                    split: option.split kernel_object.split)
    apply (wp getObject_obj_at' | clarsimp simp: objBits_simps' atcbContextSet_def)+

--- a/proof/refine/RISCV64/Syscall_R.thy
+++ b/proof/refine/RISCV64/Syscall_R.thy
@@ -339,7 +339,7 @@ lemma threadSet_tcbDomain_update_sch_act_wf[wp]:
      apply (wps setObject_sa_unchanged)
      apply (wp hoare_weak_lift_imp getObject_tcb_wp hoare_vcg_all_lift)+
    apply (rename_tac word)
-   apply (rule_tac Q="\<lambda>_ s. ksSchedulerAction s = SwitchToThread word \<longrightarrow>
+   apply (rule_tac Q'="\<lambda>_ s. ksSchedulerAction s = SwitchToThread word \<longrightarrow>
                             st_tcb_at' runnable' word s \<and> tcb_in_cur_domain' word s \<and> word \<noteq> t"
                    in hoare_strengthen_post)
     apply (wp hoare_vcg_all_lift hoare_vcg_conj_lift hoare_vcg_imp_lift)+
@@ -376,20 +376,20 @@ lemma setDomain_corres:
          apply ((wpsimp wp: hoare_vcg_imp_lift' ethread_set_not_queued_valid_queues hoare_vcg_all_lift
                  | strengthen valid_objs'_valid_tcbs' valid_queues_in_correct_ready_q
                               valid_queues_ready_qs_distinct)+)[1]
-        apply (rule_tac Q="\<lambda>_. valid_objs' and sym_heap_sched_pointers and valid_sched_pointers
+        apply (rule_tac Q'="\<lambda>_. valid_objs' and sym_heap_sched_pointers and valid_sched_pointers
                                and pspace_aligned' and pspace_distinct'
                                and (\<lambda>s. sch_act_wf (ksSchedulerAction s) s) and tcb_at' tptr"
                      in hoare_strengthen_post[rotated])
          apply (fastforce simp: invs'_def valid_state'_def sch_act_wf_weak st_tcb_at'_def o_def)
         apply (wpsimp wp: threadSet_valid_objs' threadSet_sched_pointers
                           threadSet_valid_sched_pointers)+
-       apply (rule_tac Q="\<lambda>_ s. valid_queues s \<and> not_queued tptr s
+       apply (rule_tac Q'="\<lambda>_ s. valid_queues s \<and> not_queued tptr s
                                 \<and> pspace_aligned s \<and> pspace_distinct s \<and> valid_etcbs s
                                 \<and> weak_valid_sched_action s"
                     in hoare_post_imp)
         apply (fastforce simp: pred_tcb_at_def obj_at_def)
        apply (wpsimp wp: tcb_dequeue_not_queued)
-      apply (rule_tac Q = "\<lambda>_ s. invs' s \<and> obj_at' (Not \<circ> tcbQueued) tptr s \<and> sch_act_simple s
+      apply (rule_tac Q'="\<lambda>_ s. invs' s \<and> obj_at' (Not \<circ> tcbQueued) tptr s \<and> sch_act_simple s
                                  \<and>  tcb_at' tptr s"
                    in hoare_strengthen_post[rotated])
        apply (clarsimp simp: invs'_def valid_state'_def valid_pspace'_def sch_act_simple_def)
@@ -793,7 +793,7 @@ lemma doReply_invs[wp]:
           apply simp
           apply (wp (once) sts_st_tcb')
           apply wp
-         apply (rule_tac Q="\<lambda>_ s. invs' s \<and> t \<noteq> ksIdleThread s \<and> st_tcb_at' awaiting_reply' t s"
+         apply (rule_tac Q'="\<lambda>_ s. invs' s \<and> t \<noteq> ksIdleThread s \<and> st_tcb_at' awaiting_reply' t s"
                  in hoare_post_imp)
           apply clarsimp
           apply (rule conjI, erule pred_tcb'_weakenE, case_tac st, clarsimp+)
@@ -806,7 +806,7 @@ lemma doReply_invs[wp]:
           apply (case_tac st, clarsimp+)
          apply (wp cteDeleteOne_reply_pred_tcb_at)+
         apply clarsimp
-        apply (rule_tac Q="\<lambda>_. (\<lambda>s. t \<noteq> ksIdleThread s)
+        apply (rule_tac Q'="\<lambda>_. (\<lambda>s. t \<noteq> ksIdleThread s)
                                and cte_wp_at' (\<lambda>cte. \<exists>grant. cteCap cte
                                                              = capability.ReplyCap t False grant) slot"
                      in hoare_strengthen_post [rotated])
@@ -818,7 +818,7 @@ lemma doReply_invs[wp]:
         apply (erule cte_wp_at_weakenE')
         apply (fastforce)
        apply (wp sts_invs_minor'' sts_st_tcb' hoare_weak_lift_imp)
-             apply (rule_tac Q="\<lambda>_ s. invs' s \<and> sch_act_simple s
+             apply (rule_tac Q'="\<lambda>_ s. invs' s \<and> sch_act_simple s
                                       \<and> st_tcb_at' awaiting_reply' t s
                                       \<and> t \<noteq> ksIdleThread s"
                           in hoare_post_imp)
@@ -833,7 +833,7 @@ lemma doReply_invs[wp]:
               apply (case_tac st, clarsimp+)
              apply (wp threadSet_invs_trivial threadSet_st_tcb_at2 hoare_weak_lift_imp
                     | clarsimp simp add: inQ_def)+
-           apply (rule_tac Q="\<lambda>_. invs' and tcb_at' t
+           apply (rule_tac Q'="\<lambda>_. invs' and tcb_at' t
                                  and sch_act_simple and st_tcb_at' awaiting_reply' t"
                    in hoare_strengthen_post [rotated])
             apply clarsimp
@@ -946,7 +946,7 @@ lemma setDomain_invs':
   apply (simp add:setDomain_def )
   apply (wp add: when_wp hoare_weak_lift_imp hoare_weak_lift_imp_conj rescheduleRequired_all_invs_but_extra
                  tcbSchedEnqueue_valid_action hoare_vcg_if_lift2)
-     apply (rule_tac Q = "\<lambda>r s. all_invs_but_sch_extra s \<and> curThread = ksCurThread s
+     apply (rule_tac Q'="\<lambda>r s. all_invs_but_sch_extra s \<and> curThread = ksCurThread s
       \<and> (ptr \<noteq> curThread \<longrightarrow> ct_not_inQ s \<and> sch_act_wf (ksSchedulerAction s) s \<and> ct_idle_or_in_cur_domain' s)"
       in hoare_strengthen_post[rotated])
       apply (clarsimp simp:invs'_def valid_state'_def st_tcb_at'_def[symmetric] valid_pspace'_def)
@@ -958,7 +958,7 @@ lemma setDomain_invs':
       apply assumption
      apply (wp hoare_weak_lift_imp threadSet_pred_tcb_no_state threadSet_not_curthread_ct_domain
                threadSet_tcbDomain_update_ct_not_inQ | simp)+
-    apply (rule_tac Q = "\<lambda>r s. invs' s \<and> curThread = ksCurThread s \<and> sch_act_simple s
+    apply (rule_tac Q'="\<lambda>r s. invs' s \<and> curThread = ksCurThread s \<and> sch_act_simple s
                              \<and> domain \<le> maxDomain
                              \<and> (ptr \<noteq> curThread \<longrightarrow> ct_not_inQ s \<and> sch_act_not ptr s)"
       in hoare_strengthen_post[rotated])
@@ -1190,7 +1190,7 @@ lemma handleInvocation_corres:
                       apply (wp reply_from_kernel_tcb_at)
                      apply (rule impI, wp+)
                      apply (wpsimp wp: hoare_drop_imps|strengthen invs_distinct invs_psp_aligned)+
-               apply (rule_tac Q="\<lambda>rv. einvs and schact_is_rct and valid_invocation rve
+               apply (rule_tac Q'="\<lambda>rv. einvs and schact_is_rct and valid_invocation rve
                                    and (\<lambda>s. thread = cur_thread s)
                                    and st_tcb_at active thread"
                           in hoare_post_imp)
@@ -1198,7 +1198,7 @@ lemma handleInvocation_corres:
                                elim!: st_tcb_weakenE)
                apply (wp sts_st_tcb_at' set_thread_state_schact_is_rct
                          set_thread_state_active_valid_sched)
-              apply (rule_tac Q="\<lambda>rv. invs' and valid_invocation' rve'
+              apply (rule_tac Q'="\<lambda>rv. invs' and valid_invocation' rve'
                                       and (\<lambda>s. thread = ksCurThread s)
                                       and st_tcb_at' active' thread
                                       and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread)"
@@ -1210,7 +1210,7 @@ lemma handleInvocation_corres:
              apply (wp lec_caps_to lsft_ex_cte_cap_to
                     | simp add: split_def liftE_bindE[symmetric]
                                 ct_in_state'_def ball_conj_distrib
-                    | rule hoare_vcg_E_elim)+
+                    | rule hoare_vcg_conj_elimE)+
    apply (clarsimp simp: tcb_at_invs invs_valid_objs
                          valid_tcb_state_def ct_in_state_def
                          simple_from_active invs_mdb
@@ -1279,7 +1279,7 @@ lemma hinv_invs'[wp]:
          apply (clarsimp simp: valid_idle'_def valid_state'_def
                                invs'_def pred_tcb_at'_def obj_at'_def idle_tcb'_def)
         apply wp+
-       apply (rule_tac Q="\<lambda>rv'. invs' and valid_invocation' rv
+       apply (rule_tac Q'="\<lambda>rv'. invs' and valid_invocation' rv
                                 and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread)
                                 and (\<lambda>s. ksCurThread s = thread)
                                 and st_tcb_at' active' thread"
@@ -1481,7 +1481,7 @@ lemma handleRecv_isBlocking_corres':
           apply (rule handleFault_corres)
           apply simp
          apply (wp get_simple_ko_wp | wpcw | simp)+
-         apply (rule hoare_vcg_E_elim)
+         apply (rule hoare_vcg_conj_elimE)
           apply (simp add: lookup_cap_def lookup_slot_for_thread_def)
           apply wp
            apply (simp add: split_def)
@@ -1529,14 +1529,14 @@ lemma hw_invs'[wp]:
                          deleteCallerCap_ct']
                     | wpc | simp add: ct_in_state'_def whenE_def split del: if_split)+
      apply (rule validE_validE_R)
-     apply (rule_tac Q="\<lambda>rv s. invs' s
+     apply (rule_tac Q'="\<lambda>rv s. invs' s
                              \<and> sch_act_sane s
                              \<and> thread = ksCurThread s
                              \<and> ct_in_state' simple' s
                              \<and> ex_nonz_cap_to' thread s
                              \<and> thread \<noteq> ksIdleThread s
                             \<and> (\<forall>x \<in> zobj_refs' rv. ex_nonz_cap_to' x s)"
-              and E="\<lambda>_ _. True"
+              and E'="\<lambda>_ _. True"
            in hoare_strengthen_postE[rotated])
         apply (clarsimp simp: isCap_simps ct_in_state'_def pred_tcb_at' invs_valid_objs'
                               sch_act_sane_not obj_at'_def pred_tcb_at'_def)
@@ -1585,7 +1585,7 @@ lemma hy_invs':
   "\<lbrace>invs' and ct_active'\<rbrace> handleYield \<lbrace>\<lambda>r. invs' and ct_active'\<rbrace>"
   apply (simp add: handleYield_def)
   apply (wpsimp wp: ct_in_state_thread_state_lift' rescheduleRequired_all_invs_but_ct_not_inQ)
-     apply (rule_tac Q="\<lambda>_. all_invs_but_ct_not_inQ' and ct_active'" in hoare_post_imp)
+     apply (rule_tac Q'="\<lambda>_. all_invs_but_ct_not_inQ' and ct_active'" in hoare_post_imp)
       apply clarsimp
      apply (subst pred_conj_def)
      apply (rule hoare_vcg_conj_lift)
@@ -1803,7 +1803,7 @@ lemma handleReply_nonz_cap_to_ct:
   "\<lbrace>ct_active' and invs' and sch_act_simple\<rbrace>
      handleReply
    \<lbrace>\<lambda>rv s. ex_nonz_cap_to' (ksCurThread s) s\<rbrace>"
-  apply (rule_tac Q="\<lambda>rv. ct_active' and invs'"
+  apply (rule_tac Q'="\<lambda>rv. ct_active' and invs'"
                in hoare_post_imp)
    apply (auto simp: ct_in_state'_def elim: st_tcb_ex_cap'')[1]
   apply (wp | simp)+
@@ -1917,7 +1917,7 @@ proof -
             apply (rule handleVMFault_corres)
            apply (erule handleFault_corres)
           apply (rule hoare_elim_pred_conjE2)
-          apply (rule hoare_vcg_E_conj, rule valid_validE_E, wp)
+          apply (rule hoare_vcg_conj_liftE_E, rule valid_validE_E, wp)
           apply (wp handle_vm_fault_valid_fault)
          apply (rule hv_inv_ex')
         apply wp

--- a/proof/refine/RISCV64/TcbAcc_R.thy
+++ b/proof/refine/RISCV64/TcbAcc_R.thy
@@ -1075,7 +1075,7 @@ lemma threadSet_obj_at'_really_strongest:
   apply (simp add: threadSet_def)
   apply (wp setObject_tcb_strongest)
    apply (subst simp_thms(32)[symmetric], rule hoare_vcg_disj_lift)
-    apply (rule hoare_post_imp [where Q="\<lambda>rv s. \<not> tcb_at' t s \<and> tcb_at' t s"])
+    apply (rule hoare_post_imp[where Q'="\<lambda>rv s. \<not> tcb_at' t s \<and> tcb_at' t s"])
      apply simp
     apply (subst simp_thms(21)[symmetric], rule hoare_vcg_conj_lift)
      apply (rule getObject_inv_tcb)
@@ -1161,7 +1161,7 @@ proof -
   show ?thesis
     apply (rule_tac P=P in P_bool_lift)
      apply (rule pos)
-    apply (rule_tac Q="\<lambda>_ s. \<not> tcb_at' t' s \<or> pred_tcb_at' proj (\<lambda>tcb. \<not> P' tcb) t' s"
+    apply (rule_tac Q'="\<lambda>_ s. \<not> tcb_at' t' s \<or> pred_tcb_at' proj (\<lambda>tcb. \<not> P' tcb) t' s"
              in hoare_post_imp)
      apply (erule disjE)
       apply (clarsimp dest!: pred_tcb_at')
@@ -3311,7 +3311,7 @@ lemma sts_valid_objs':
    setThreadState st t
    \<lbrace>\<lambda>_. valid_objs'\<rbrace>"
   apply (wpsimp simp: setThreadState_def wp: threadSet_valid_objs')
-   apply (rule_tac Q="\<lambda>_. valid_objs' and pspace_aligned' and pspace_distinct'" in hoare_post_imp)
+   apply (rule_tac Q'="\<lambda>_. valid_objs' and pspace_aligned' and pspace_distinct'" in hoare_post_imp)
     apply fastforce
    apply (wpsimp wp: threadSet_valid_objs')
   apply (simp add: valid_tcb'_def tcb_cte_cases_def cteSizeBits_def)
@@ -3578,7 +3578,7 @@ lemma sts_sch_act':
    apply assumption
   apply (case_tac "runnable' st")
    apply ((wp threadSet_runnable_sch_act hoare_drop_imps | simp)+)[1]
-  apply (rule_tac Q="\<lambda>rv s. st_tcb_at' (Not \<circ> runnable') t s \<and>
+  apply (rule_tac Q'="\<lambda>rv s. st_tcb_at' (Not \<circ> runnable') t s \<and>
                      (ksCurThread s \<noteq> t \<or> ksSchedulerAction s \<noteq> ResumeCurrentThread \<longrightarrow>
                             sch_act_wf (ksSchedulerAction s) s)"
                in hoare_post_imp)
@@ -3598,10 +3598,10 @@ lemma sts_sch_act[wp]:
    prefer 2
    apply assumption
   apply (case_tac "runnable' st")
-   apply (rule_tac Q="\<lambda>s. sch_act_wf (ksSchedulerAction s) s"
+   apply (rule_tac P'="\<lambda>s. sch_act_wf (ksSchedulerAction s) s"
                 in hoare_pre_imp, simp)
    apply ((wp hoare_drop_imps threadSet_runnable_sch_act | simp)+)[1]
-  apply (rule_tac Q="\<lambda>rv s. st_tcb_at' (Not \<circ> runnable') t s \<and>
+  apply (rule_tac Q'="\<lambda>rv s. st_tcb_at' (Not \<circ> runnable') t s \<and>
                      (ksCurThread s \<noteq> t \<or> ksSchedulerAction s \<noteq> ResumeCurrentThread \<longrightarrow>
                             sch_act_wf (ksSchedulerAction s) s)"
                in hoare_post_imp)
@@ -3877,7 +3877,7 @@ lemma addToBitmap_valid_bitmapQ:
    addToBitmap d p
    \<lbrace>\<lambda>_. valid_bitmapQ\<rbrace>"
   (is "\<lbrace>?pre\<rbrace> _ \<lbrace>_\<rbrace>")
-  apply (rule_tac Q="\<lambda>_ s. ?pre s \<and> bitmapQ d p s" in hoare_strengthen_post)
+  apply (rule_tac Q'="\<lambda>_ s. ?pre s \<and> bitmapQ d p s" in hoare_strengthen_post)
    apply (wpsimp wp: addToBitmap_valid_bitmapQ_except addToBitmap_bitmapQ)
   apply (fastforce elim: valid_bitmap_valid_bitmapQ_exceptE)
   done
@@ -4572,7 +4572,7 @@ lemma ct_in_state'_decomp:
   assumes x: "\<lbrace>\<lambda>s. t = (ksCurThread s)\<rbrace> f \<lbrace>\<lambda>rv s. t = (ksCurThread s)\<rbrace>"
   assumes y: "\<lbrace>Pre\<rbrace> f \<lbrace>\<lambda>rv. st_tcb_at' Prop t\<rbrace>"
   shows      "\<lbrace>\<lambda>s. Pre s \<and> t = (ksCurThread s)\<rbrace> f \<lbrace>\<lambda>rv. ct_in_state' Prop\<rbrace>"
-  apply (rule hoare_post_imp [where Q="\<lambda>rv s. t = ksCurThread s \<and> st_tcb_at' Prop t s"])
+  apply (rule hoare_post_imp[where Q'="\<lambda>rv s. t = ksCurThread s \<and> st_tcb_at' Prop t s"])
    apply (clarsimp simp add: ct_in_state'_def)
   apply (rule hoare_weaken_pre)
    apply (wp x y)
@@ -4643,7 +4643,7 @@ lemma setQueue_pred_tcb_at[wp]:
   unfolding pred_tcb_at'_def
   apply (rule_tac P=P' in P_bool_lift)
    apply (rule setQueue_obj_at)
-  apply (rule_tac Q="\<lambda>_ s. \<not>typ_at' TCBT t s \<or> obj_at' (Not \<circ> (P \<circ> proj \<circ> tcb_to_itcb')) t s"
+  apply (rule_tac Q'="\<lambda>_ s. \<not>typ_at' TCBT t s \<or> obj_at' (Not \<circ> (P \<circ> proj \<circ> tcb_to_itcb')) t s"
            in hoare_post_imp, simp add: not_obj_at' o_def)
   apply (wp hoare_vcg_disj_lift)
   apply (clarsimp simp: not_obj_at' o_def)
@@ -4904,7 +4904,7 @@ lemma sts_iflive'[wp]:
    \<lbrace>\<lambda>rv. if_live_then_nonz_cap'\<rbrace>"
   apply (simp add: setThreadState_def setQueue_def)
   apply wpsimp
-   apply (rule_tac Q="\<lambda>rv. if_live_then_nonz_cap' and pspace_aligned' and pspace_distinct'"
+   apply (rule_tac Q'="\<lambda>rv. if_live_then_nonz_cap' and pspace_aligned' and pspace_distinct'"
                 in hoare_post_imp)
     apply clarsimp
    apply (wpsimp wp: threadSet_iflive')
@@ -5048,7 +5048,7 @@ lemma tcbSchedEnqueue_ct_not_inQ:
   proof -
     have ts: "\<lbrace>?PRE\<rbrace> threadSet (tcbQueued_update (\<lambda>_. True)) t \<lbrace>\<lambda>_. ct_not_inQ\<rbrace>"
       apply (simp add: ct_not_inQ_def)
-      apply (rule_tac Q="\<lambda>s. ksSchedulerAction s = ResumeCurrentThread
+      apply (rule_tac P'="\<lambda>s. ksSchedulerAction s = ResumeCurrentThread
                   \<longrightarrow> obj_at' (Not \<circ> tcbQueued) (ksCurThread s) s \<and> ksCurThread s \<noteq> t"
                   in hoare_pre_imp, clarsimp)
       apply (rule hoare_convert_imp [OF threadSet_nosch])
@@ -5075,7 +5075,7 @@ lemma tcbSchedAppend_ct_not_inQ:
   proof -
     have ts: "\<lbrace>?PRE\<rbrace> threadSet (tcbQueued_update (\<lambda>_. True)) t \<lbrace>\<lambda>_. ct_not_inQ\<rbrace>"
       apply (simp add: ct_not_inQ_def)
-      apply (rule_tac Q="\<lambda>s. ksSchedulerAction s = ResumeCurrentThread
+      apply (rule_tac P'="\<lambda>s. ksSchedulerAction s = ResumeCurrentThread
                   \<longrightarrow> obj_at' (Not \<circ> tcbQueued) (ksCurThread s) s \<and> ksCurThread s \<noteq> t"
                   in hoare_pre_imp, clarsimp)
       apply (rule hoare_convert_imp [OF threadSet_nosch])
@@ -5102,7 +5102,7 @@ lemma setSchedulerAction_direct:
 lemma rescheduleRequired_ct_not_inQ:
   "\<lbrace>\<top>\<rbrace> rescheduleRequired \<lbrace>\<lambda>_. ct_not_inQ\<rbrace>"
   apply (simp add: rescheduleRequired_def ct_not_inQ_def)
-  apply (rule_tac Q="\<lambda>_ s. ksSchedulerAction s = ChooseNewThread"
+  apply (rule_tac Q'="\<lambda>_ s. ksSchedulerAction s = ChooseNewThread"
            in hoare_post_imp, clarsimp)
   apply (wp setSchedulerAction_direct)
   done
@@ -5173,7 +5173,7 @@ lemma setThreadState_ct_not_inQ:
   including no_pre
   apply (simp add: setThreadState_def)
   apply (wp rescheduleRequired_ct_not_inQ)
-  apply (rule_tac Q="\<lambda>_. ?PRE" in hoare_post_imp, clarsimp)
+  apply (rule_tac Q'="\<lambda>_. ?PRE" in hoare_post_imp, clarsimp)
   apply (wp)
   done
 
@@ -5330,7 +5330,7 @@ lemma removeFromBitmap_valid_bitmapQ[wp]:
    removeFromBitmap d p
    \<lbrace>\<lambda>_. valid_bitmapQ\<rbrace>"
   (is "\<lbrace>?pre\<rbrace> _ \<lbrace>_\<rbrace>")
-  apply (rule_tac Q="\<lambda>_ s. ?pre s \<and> \<not> bitmapQ d p s" in hoare_strengthen_post)
+  apply (rule_tac Q'="\<lambda>_ s. ?pre s \<and> \<not> bitmapQ d p s" in hoare_strengthen_post)
    apply (wpsimp wp: removeFromBitmap_valid_bitmapQ_except removeFromBitmap_bitmapQ)
   apply (fastforce elim: valid_bitmap_valid_bitmapQ_exceptE)
   done

--- a/proof/refine/RISCV64/Tcb_R.thy
+++ b/proof/refine/RISCV64/Tcb_R.thy
@@ -81,7 +81,7 @@ abbreviation
 lemma gts_st_tcb':
   "\<lbrace>tcb_at' t\<rbrace> getThreadState t \<lbrace>\<lambda>rv. st_tcb_at' (\<lambda>st. st = rv) t\<rbrace>"
   apply (rule hoare_weaken_pre)
-   apply (rule hoare_post_imp[where Q="\<lambda>rv s. \<exists>rv'. rv = rv' \<and> st_tcb_at' (\<lambda>st. st = rv') t s"])
+   apply (rule hoare_post_imp[where Q'="\<lambda>rv s. \<exists>rv'. rv = rv' \<and> st_tcb_at' (\<lambda>st. st = rv') t s"])
     apply simp
    apply (wp hoare_vcg_ex_lift)
   apply (clarsimp simp add: pred_tcb_at'_def obj_at'_def)
@@ -106,15 +106,15 @@ lemma activate_invs':
     apply (case_tac rv; simp add: isTS_defs split del: if_split cong: if_cong)
       apply (wp)
       apply (clarsimp simp: ct_in_state'_def)
-     apply (rule_tac Q="\<lambda>rv. invs' and ct_idle'" in hoare_post_imp, simp)
+     apply (rule_tac Q'="\<lambda>rv. invs' and ct_idle'" in hoare_post_imp, simp)
      apply (wp activateIdle_invs)
      apply (clarsimp simp: ct_in_state'_def)
-    apply (rule_tac Q="\<lambda>rv. invs' and ct_running' and sch_act_simple"
+    apply (rule_tac Q'="\<lambda>rv. invs' and ct_running' and sch_act_simple"
                  in hoare_post_imp, simp)
     apply (rule hoare_weaken_pre)
      apply (wp ct_in_state'_set asUser_ct sts_invs_minor'
           | wp (once) sch_act_simple_lift)+
-      apply (rule_tac Q="\<lambda>_. st_tcb_at' runnable' thread
+      apply (rule_tac Q'="\<lambda>_. st_tcb_at' runnable' thread
                              and sch_act_simple and invs'
                              and (\<lambda>s. thread = ksCurThread s)"
                in hoare_post_imp, clarsimp)
@@ -184,7 +184,7 @@ lemma setupReplyMaster_weak_sch_act_wf[wp]:
    \<lbrace>\<lambda>rv s. weak_sch_act_wf (ksSchedulerAction s) s\<rbrace>"
   apply (simp add: setupReplyMaster_def)
   apply (wp)
-    apply (rule_tac Q="\<lambda>_ s. weak_sch_act_wf (ksSchedulerAction s) s"
+    apply (rule_tac Q'="\<lambda>_ s. weak_sch_act_wf (ksSchedulerAction s) s"
                in hoare_post_imp, clarsimp)
     apply (wp)+
   apply assumption
@@ -210,11 +210,11 @@ lemma restart_corres:
               apply (wp set_thread_state_runnable_weak_valid_sched_action sts_st_tcb_at'
                         sts_st_tcb' sts_valid_objs'
                      | clarsimp simp: valid_tcb_state'_def | strengthen valid_objs'_valid_tcbs')+
-         apply (rule_tac Q="\<lambda>rv. valid_sched and cur_tcb and pspace_aligned and pspace_distinct"
+         apply (rule_tac Q'="\<lambda>rv. valid_sched and cur_tcb and pspace_aligned and pspace_distinct"
                          in hoare_strengthen_post)
           apply wp
          apply (fastforce simp: valid_sched_def valid_sched_action_def)
-        apply (rule_tac Q="\<lambda>rv. invs' and ex_nonz_cap_to' t" in hoare_strengthen_post)
+        apply (rule_tac Q'="\<lambda>rv. invs' and ex_nonz_cap_to' t" in hoare_strengthen_post)
          apply wp
         apply (clarsimp simp: invs'_def valid_state'_def sch_act_wf_weak valid_pspace'_def
                               valid_tcb_state'_def)
@@ -344,10 +344,10 @@ lemma invokeTCB_WriteRegisters_corres:
                                 valid_sched_valid_queues valid_objs'_valid_tcbs' invs_valid_objs'
                    | clarsimp simp: invs_def valid_state_def valid_sched_def invs'_def valid_state'_def
                              dest!: global'_no_ex_cap idle_no_ex_cap)+)[2]
-         apply (rule_tac Q="\<lambda>_. einvs and tcb_at dest and ex_nonz_cap_to dest" in hoare_post_imp)
+         apply (rule_tac Q'="\<lambda>_. einvs and tcb_at dest and ex_nonz_cap_to dest" in hoare_post_imp)
           apply (fastforce simp: invs_def valid_sched_weak_strg valid_sched_def valid_state_def dest!: idle_no_ex_cap)
          prefer 2
-         apply (rule_tac Q="\<lambda>_. invs' and tcb_at' dest and ex_nonz_cap_to' dest" in hoare_post_imp)
+         apply (rule_tac Q'="\<lambda>_. invs' and tcb_at' dest and ex_nonz_cap_to' dest" in hoare_post_imp)
           apply (fastforce simp: sch_act_wf_weak invs'_def valid_state'_def dest!: global'_no_ex_cap)
          apply wpsimp+
   done
@@ -451,10 +451,10 @@ proof -
                     apply (rule_tac P=\<top> and P'=\<top> in corres_inst)
                     apply simp
                    apply (solves \<open>wp hoare_weak_lift_imp\<close>)+
-             apply (rule_tac Q="\<lambda>_. einvs and tcb_at dest" in hoare_post_imp)
+             apply (rule_tac Q'="\<lambda>_. einvs and tcb_at dest" in hoare_post_imp)
               apply (fastforce simp: invs_def valid_state_def valid_pspace_def valid_sched_weak_strg valid_sched_def)
              prefer 2
-             apply (rule_tac Q="\<lambda>_. invs' and tcb_at' dest" in hoare_post_imp)
+             apply (rule_tac Q'="\<lambda>_. invs' and tcb_at' dest" in hoare_post_imp)
               apply (fastforce simp: invs'_def valid_state'_def invs_weak_sch_act_wf cur_tcb'_def)
              apply ((wp mapM_x_wp' hoare_weak_lift_imp | (simp add: cur_tcb'_def[symmetric])+)+)[8]
          apply ((wp hoare_weak_lift_imp restart_invs' | wpc | clarsimp simp: if_apply_def2)+)[2]
@@ -523,7 +523,7 @@ lemma tcbSchedDequeue_not_queued:
    \<lbrace>\<lambda>rv. obj_at' (Not \<circ> tcbQueued) t\<rbrace>"
   apply (simp add: tcbSchedDequeue_def)
   apply (wp | simp)+
-  apply (rule_tac Q="\<lambda>rv. obj_at' (\<lambda>obj. tcbQueued obj = rv) t"
+  apply (rule_tac Q'="\<lambda>rv. obj_at' (\<lambda>obj. tcbQueued obj = rv) t"
                in hoare_post_imp)
    apply (clarsimp simp: obj_at'_def)
   apply (wp tg_sp' [where P=\<top>, simplified] | simp)+
@@ -1398,7 +1398,7 @@ proof -
   have B: "\<And>t v. \<lbrace>invs' and tcb_at' t\<rbrace> threadSet (tcbFaultHandler_update v) t \<lbrace>\<lambda>rv. invs'\<rbrace>"
     by (wp threadSet_invs_trivial | clarsimp simp: inQ_def)+
   note stuff = Z B out_invs_trivial hoare_case_option_wp
-    hoare_vcg_const_Ball_lift hoare_vcg_const_Ball_lift_R
+    hoare_vcg_const_Ball_lift hoare_vcg_const_Ball_liftE_R
     cap_delete_deletes cap_delete_valid_cap out_valid_objs
     cap_insert_objs
     cteDelete_deletes cteDelete_sch_act_simple
@@ -1433,7 +1433,7 @@ proof -
                   apply (rule corres_returnOkTT, simp)
                  apply wp
                 apply wp
-               apply (wpsimp wp: hoare_vcg_const_imp_lift_R hoare_vcg_const_imp_lift
+               apply (wpsimp wp: hoare_vcg_const_imp_liftE_R hoare_vcg_const_imp_lift
                                  hoare_vcg_all_liftE_R hoare_vcg_all_lift
                                  as_user_invs thread_set_ipc_tcb_cap_valid
                                  thread_set_tcb_ipc_buffer_cap_cleared_invs
@@ -1454,7 +1454,7 @@ proof -
                                  threadSet_invs_tcbIPCBuffer_update threadSet_cte_wp_at'
                       | strengthen simple_sched_action_sched_act_not)+
                 apply ((wpsimp wp: stuff hoare_vcg_all_liftE_R hoare_vcg_all_lift
-                                   hoare_vcg_const_imp_lift_R hoare_vcg_const_imp_lift
+                                   hoare_vcg_const_imp_liftE_R hoare_vcg_const_imp_lift
                                    threadSet_valid_objs' thread_set_not_state_valid_sched
                                    thread_set_tcb_ipc_buffer_cap_cleared_invs thread_set_cte_wp_at_trivial
                                    thread_set_no_cap_to_trivial getThreadBufferSlot_dom_tcb_cte_cases
@@ -1489,7 +1489,7 @@ proof -
                          in hoare_strengthen_postE_R[simplified validE_R_def, rotated])
              apply (case_tac g'; clarsimp simp: isCap_simps ; clarsimp cong:imp_cong)
             apply (wp add: stuff hoare_vcg_all_liftE_R hoare_vcg_all_lift
-                                 hoare_vcg_const_imp_lift_R hoare_vcg_const_imp_lift setMCPriority_invs'
+                                 hoare_vcg_const_imp_liftE_R hoare_vcg_const_imp_lift setMCPriority_invs'
                                  threadSet_valid_objs' thread_set_not_state_valid_sched setP_invs'
                                  typ_at_lifts [OF setPriority_typ_at']
                                  typ_at_lifts [OF setMCPriority_typ_at']
@@ -1567,15 +1567,15 @@ lemma tc_invs':
       apply (wpsimp wp: hoare_weak_lift_imp hoare_vcg_all_lift
                         checkCap_inv[where P="tcb_at' t" for t] assertDerived_wp_weak
                         threadSet_invs_trivial2 threadSet_tcb'  hoare_vcg_all_lift threadSet_cte_wp_at')+
-       apply (wpsimp wp: hoare_weak_lift_imp_R cteDelete_deletes
-                         hoare_vcg_all_liftE_R hoare_vcg_conj_liftE1 hoare_vcg_const_imp_lift_R hoare_vcg_propE_R
+       apply (wpsimp wp: hoare_weak_lift_impE_R cteDelete_deletes
+                         hoare_vcg_all_liftE_R hoare_vcg_conj_liftE1 hoare_vcg_const_imp_liftE_R hoare_vcg_propE_R
                          cteDelete_invs' cteDelete_invs' cteDelete_typ_at'_lifts)+
      apply (assumption | clarsimp cong: conj_cong imp_cong | (rule case_option_wp_None_returnOk)
             | wpsimp wp: hoare_weak_lift_imp hoare_vcg_all_lift checkCap_inv[where P="tcb_at' t" for t] assertDerived_wp_weak
                          hoare_vcg_imp_lift' hoare_vcg_all_lift checkCap_inv[where P="tcb_at' t" for t]
                          checkCap_inv[where P="valid_cap' c" for c] checkCap_inv[where P=sch_act_simple]
-                         hoare_vcg_const_imp_lift_R assertDerived_wp_weak hoare_weak_lift_imp_R cteDelete_deletes
-                         hoare_vcg_all_liftE_R hoare_vcg_conj_liftE1 hoare_vcg_const_imp_lift_R hoare_vcg_propE_R
+                         hoare_vcg_const_imp_liftE_R assertDerived_wp_weak hoare_weak_lift_impE_R cteDelete_deletes
+                         hoare_vcg_all_liftE_R hoare_vcg_conj_liftE1 hoare_vcg_const_imp_liftE_R hoare_vcg_propE_R
                          cteDelete_invs' cteDelete_typ_at'_lifts cteDelete_sch_act_simple)+
   apply (clarsimp simp: tcb_cte_cases_def cte_level_bits_def objBits_defs tcbIPCBufferSlot_def)
   by (auto dest!: isCapDs isReplyCapD isValidVTableRootD simp: isCap_simps)
@@ -2649,7 +2649,7 @@ lemma inv_tcb_IRQInactive:
   apply (rule hoare_pre)
    apply (wpc |
           wp withoutPreemption_R cteDelete_IRQInactive checkCap_inv
-             hoare_vcg_const_imp_lift_R cteDelete_irq_states'
+             hoare_vcg_const_imp_liftE_R cteDelete_irq_states'
              hoare_vcg_const_imp_lift |
           simp add: split_def)+
   done

--- a/proof/refine/RISCV64/Untyped_R.thy
+++ b/proof/refine/RISCV64/Untyped_R.thy
@@ -398,7 +398,7 @@ next
              apply (simp add: word_le_nat_alt)
             apply (simp add: unat_arith_simps)
            apply wpsimp+
-          apply (rule hoare_strengthen_post [where Q = "\<lambda>r. invs and valid_cap r and cte_at slot"])
+          apply (rule hoare_strengthen_post[where Q'="\<lambda>r. invs and valid_cap r and cte_at slot"])
            apply wp+
           apply (clarsimp simp: is_cap_simps bits_of_def cap_aligned_def
                                 valid_cap_def word_bits_def)
@@ -406,7 +406,7 @@ next
           apply (strengthen refl exI[mk_strg I E] exI[where x=d])+
           apply simp
          apply wp+
-         apply (rule hoare_strengthen_post [where Q = "\<lambda>r. invs' and cte_at' (cte_map slot)"])
+         apply (rule hoare_strengthen_post[where Q'="\<lambda>r. invs' and cte_at' (cte_map slot)"])
           apply wp+
          apply (clarsimp simp:invs_pspace_aligned' invs_pspace_distinct')
         apply (wp whenE_throwError_wp | wp (once) hoare_drop_imps)+
@@ -3171,7 +3171,7 @@ lemma createNewCaps_parent_helper:
                        (\<forall>tup\<in>set (zip (xs rv) rv).
                                 sameRegionAs (cteCap cte) (snd tup)))
     p\<rbrace>"
-  apply (rule hoare_post_imp [where Q="\<lambda>rv s. \<exists>cte. cte_wp_at' ((=) cte) p s
+  apply (rule hoare_post_imp[where Q'="\<lambda>rv s. \<exists>cte. cte_wp_at' ((=) cte) p s
                                            \<and> isUntypedCap (cteCap cte)
                                            \<and> (\<forall>tup\<in>set (zip (xs rv) rv).
                                 sameRegionAs (cteCap cte) (snd tup))"])
@@ -4542,7 +4542,7 @@ lemma resetUntypedCap_invs_etc:
               | strengthen invs_pspace_aligned' invs_pspace_distinct'
               | simp add: ct_in_state'_def
                           sch_act_simple_def
-              | rule hoare_vcg_conj_lift_R
+              | rule hoare_vcg_conj_liftE_R
               | wp (once) preemptionPoint_inv
               | wps
               | wp (once) ex_cte_cap_to'_pres)+
@@ -5222,7 +5222,7 @@ lemma insertNewCap_valid_irq_handlers:
 lemma insertNewCap_ct_idle_or_in_cur_domain'[wp]:
   "\<lbrace>ct_idle_or_in_cur_domain' and ct_active'\<rbrace> insertNewCap parent slot cap \<lbrace>\<lambda>_. ct_idle_or_in_cur_domain'\<rbrace>"
 apply (wp ct_idle_or_in_cur_domain'_lift_futz[where Q=\<top>])
-apply (rule_tac Q="\<lambda>_. obj_at' (\<lambda>tcb. tcbState tcb \<noteq> Structures_H.thread_state.Inactive) t and obj_at' (\<lambda>tcb. d = tcbDomain tcb) t"
+apply (rule_tac Q'="\<lambda>_. obj_at' (\<lambda>tcb. tcbState tcb \<noteq> Structures_H.thread_state.Inactive) t and obj_at' (\<lambda>tcb. d = tcbDomain tcb) t"
              in hoare_strengthen_post)
 apply (wp | clarsimp elim: obj_at'_weakenE)+
 apply (auto simp: obj_at'_def)

--- a/proof/refine/RISCV64/orphanage/Orphanage.thy
+++ b/proof/refine/RISCV64/orphanage/Orphanage.thy
@@ -562,7 +562,7 @@ lemma tcbSchedDequeue_no_orphans[wp]:
   apply (rule hoare_allI)
   apply (rename_tac tcb_ptr)
   apply (case_tac "tcb_ptr = tcbPtr")
-   apply (rule_tac Q="\<lambda>_ s. st_tcb_at' (\<lambda>state. \<not> is_active_thread_state state) tcbPtr s"
+   apply (rule_tac Q'="\<lambda>_ s. st_tcb_at' (\<lambda>state. \<not> is_active_thread_state state) tcbPtr s"
                 in hoare_post_imp)
     apply fastforce
    apply wpsimp
@@ -851,7 +851,7 @@ proof -
      \<lbrace>\<lambda>_. no_orphans\<rbrace>"
     apply (wpsimp wp: scheduleChooseNewThread_no_orphans ssa_no_orphans
                       hoare_vcg_all_lift ThreadDecls_H_switchToThread_no_orphans)+
-     apply (rule_tac Q="\<lambda>_ s. (t = candidate \<longrightarrow> ksCurThread s = candidate) \<and>
+     apply (rule_tac Q'="\<lambda>_ s. (t = candidate \<longrightarrow> ksCurThread s = candidate) \<and>
                                (t \<noteq> candidate \<longrightarrow> sch_act_not t s)"
               in hoare_post_imp)
       apply (wpsimp wp: stt_nosch hoare_weak_lift_imp)+
@@ -1077,7 +1077,7 @@ lemma sendIPC_no_orphans [wp]:
             possibleSwitchTo_almost_no_orphans'
          | wpc
          | clarsimp simp: is_active_thread_state_def isRestart_def isRunning_def)+
-  apply (rule_tac Q="\<lambda>rv. no_orphans and valid_objs' and ko_at' rv epptr
+  apply (rule_tac Q'="\<lambda>rv. no_orphans and valid_objs' and ko_at' rv epptr
                           and (\<lambda>s. sch_act_wf (ksSchedulerAction s) s)" in hoare_post_imp)
    apply (fastforce simp: valid_objs'_def valid_obj'_def valid_ep'_def obj_at'_def)
   apply (wp get_ep_sp' | clarsimp)+
@@ -1293,7 +1293,7 @@ lemma cancelAllIPC_no_orphans [wp]:
                     and I="no_orphans and (\<lambda>s. \<forall>t\<in>set list. tcb_at' t s)"
                      in mapM_x_inv_wp2
              | clarsimp simp: valid_tcb_state'_def)+
-  apply (rule_tac Q="\<lambda>rv. no_orphans and valid_objs' and pspace_aligned' and pspace_distinct' and
+  apply (rule_tac Q'="\<lambda>rv. no_orphans and valid_objs' and pspace_aligned' and pspace_distinct' and
                           ko_at' rv epptr"
                  in hoare_post_imp)
    apply (fastforce simp: valid_obj'_def valid_ep'_def obj_at'_def)
@@ -1317,7 +1317,7 @@ lemma cancelAllSignals_no_orphans [wp]:
    apply (wp sts_valid_objs' set_ntfn_valid_objs' sts_st_tcb'
             hoare_vcg_const_Ball_lift tcbSchedEnqueue_almost_no_orphans|
           clarsimp simp: valid_tcb_state'_def)+
-  apply (rule_tac Q="\<lambda>rv. no_orphans and valid_objs' and pspace_aligned' and pspace_distinct' and
+  apply (rule_tac Q'="\<lambda>rv. no_orphans and valid_objs' and pspace_aligned' and pspace_distinct' and
                           ko_at' rv ntfn"
                  in hoare_post_imp)
    apply (fastforce simp: valid_obj'_def valid_ntfn'_def obj_at'_def)
@@ -1430,7 +1430,7 @@ lemma deleteASIDPool_no_orphans [wp]:
    \<lbrace> \<lambda>rv s. no_orphans s \<rbrace>"
   unfolding deleteASIDPool_def
   apply (wp | clarsimp)+
-     apply (rule_tac Q="\<lambda>rv s. no_orphans s" in hoare_post_imp)
+     apply (rule_tac Q'="\<lambda>rv s. no_orphans s" in hoare_post_imp)
       apply (clarsimp simp: no_orphans_def all_queued_tcb_ptrs_def
                             all_active_tcb_ptrs_def is_active_tcb_ptr_def)
      apply (wp mapM_wp_inv getObject_inv loadObject_default_inv | clarsimp)+
@@ -1536,7 +1536,7 @@ lemma cteRevoke_no_orphans [wp]:
   "\<lbrace> \<lambda>s. no_orphans s \<and> invs' s \<and> sch_act_simple s \<rbrace>
    cteRevoke ptr
    \<lbrace> \<lambda>rv s. no_orphans s \<rbrace>"
-  apply (rule_tac Q="\<lambda>rv s. no_orphans s \<and> invs' s \<and> sch_act_simple s"
+  apply (rule_tac Q'="\<lambda>rv s. no_orphans s \<and> invs' s \<and> sch_act_simple s"
                       in hoare_strengthen_post)
    apply (wp cteRevoke_preservation cteDelete_invs' cteDelete_sch_act_simple)+
       apply auto
@@ -1562,7 +1562,7 @@ lemma doReplyTransfer_no_orphans[wp]:
          | wpc | clarsimp simp: is_active_thread_state_def isRunning_def isRestart_def
          | wp (once) hoare_drop_imps
          | strengthen sch_act_wf_weak)+
-              apply (rule_tac Q="\<lambda>rv. invs' and no_orphans" in hoare_post_imp)
+              apply (rule_tac Q'="\<lambda>rv. invs' and no_orphans" in hoare_post_imp)
                apply (fastforce simp: inQ_def)
               apply (wp hoare_drop_imps | clarsimp)+
   apply (clarsimp simp:invs'_def valid_state'_def valid_pspace'_def)
@@ -1638,7 +1638,7 @@ lemma setPriority_no_orphans[wp]:
    \<lbrace>\<lambda>_. no_orphans\<rbrace>"
   unfolding setPriority_def
   apply wpsimp
-    apply (rule_tac Q="\<lambda>_ s. almost_no_orphans tptr s \<and> weak_sch_act_wf (ksSchedulerAction s) s" in hoare_post_imp)
+    apply (rule_tac Q'="\<lambda>_ s. almost_no_orphans tptr s \<and> weak_sch_act_wf (ksSchedulerAction s) s" in hoare_post_imp)
      apply clarsimp
      apply (clarsimp simp: is_active_tcb_ptr_runnable' pred_tcb_at'_def obj_at'_def
                            almost_no_orphans_no_orphans elim!: almost_no_orphans_no_orphans')
@@ -1695,7 +1695,7 @@ lemma tc_no_orphans:
                checkCap_inv[where P="valid_cap' c" for c] checkCap_inv[where P=sch_act_simple]
                checkCap_inv[where P=no_orphans] checkCap_inv[where P="tcb_at' a"]
                threadSet_cte_wp_at' hoare_vcg_all_liftE_R hoare_vcg_all_lift threadSet_no_orphans
-               hoare_vcg_const_imp_lift_R hoare_weak_lift_imp hoare_drop_imp threadSet_ipcbuffer_invs
+               hoare_vcg_const_imp_liftE_R hoare_weak_lift_imp hoare_drop_imp threadSet_ipcbuffer_invs
           | (simp add: locateSlotTCB_def locateSlotBasic_def objBits_def
                      objBitsKO_def tcbIPCBufferSlot_def tcb_cte_cases_def,
            wp hoare_return_sp)
@@ -1823,7 +1823,7 @@ lemma performASIDControlInvocation_no_orphans [wp]:
   apply (clarsimp simp: performASIDControlInvocation_def
                   split: asidcontrol_invocation.splits)
   apply (wp hoare_weak_lift_imp | clarsimp)+
-    apply (rule_tac Q="\<lambda>rv s. no_orphans s" in hoare_post_imp)
+    apply (rule_tac Q'="\<lambda>rv s. no_orphans s" in hoare_post_imp)
      apply (clarsimp simp: no_orphans_def all_active_tcb_ptrs_def
                            is_active_tcb_ptr_def all_queued_tcb_ptrs_def)
     apply (wp | clarsimp simp:placeNewObject_def2)+
@@ -1907,7 +1907,7 @@ lemma handleInvocation_no_orphans [wp]:
   unfolding handleInvocation_def
   apply (rule hoare_pre)
    apply (wp syscall_valid' setThreadState_isRestart_no_orphans | wpc | clarsimp)+
-          apply (rule_tac Q="\<lambda>state s. no_orphans s \<and> invs' s \<and>
+          apply (rule_tac Q'="\<lambda>state s. no_orphans s \<and> invs' s \<and>
                              (state = Structures_H.thread_state.Restart \<longrightarrow>
                               st_tcb_at' isRestart thread s)"
                        in hoare_post_imp)
@@ -1966,7 +1966,7 @@ notes if_cong[cong] shows
   apply (clarsimp simp: whenE_def split del: if_split | wp hoare_drop_imps getNotification_wp | wpc )+ (*takes a while*)
      apply (rule_tac Q'="\<lambda>rv s. no_orphans s \<and> invs' s" in hoare_strengthen_postE_R)
       apply (wp, fastforce)
-    apply (rule_tac Q="\<lambda>rv s. no_orphans s \<and> invs' s" in hoare_post_imp)
+    apply (rule_tac Q'="\<lambda>rv s. no_orphans s \<and> invs' s" in hoare_post_imp)
      apply (wp | clarsimp | fastforce)+
   done
 
@@ -1979,7 +1979,7 @@ lemma handleReply_no_orphans [wp]:
   apply (rule hoare_pre)
    apply (wp hoare_drop_imps | wpc | clarsimp)+
      apply (wp hoare_vcg_all_lift)
-      apply (rule_tac Q="\<lambda>rv s. no_orphans s \<and> invs' s \<and> tcb_at' thread s \<and>
+      apply (rule_tac Q'="\<lambda>rv s. no_orphans s \<and> invs' s \<and> tcb_at' thread s \<and>
                                 valid_cap' rv s" in hoare_post_imp)
        apply (wp hoare_drop_imps | clarsimp simp: valid_cap'_def
               | clarsimp simp: invs'_def cur_tcb'_def valid_state'_def)+

--- a/proof/refine/X64/Arch_R.thy
+++ b/proof/refine/X64/Arch_R.thy
@@ -541,8 +541,8 @@ lemma find_vspace_for_asid_lookup_slot [wp]:
   \<lbrace>\<lambda>rv. \<exists>\<rhd> (lookup_pml4_slot rv vptr && ~~ mask pml4_bits)\<rbrace>, -"
   apply (rule hoare_pre)
    apply (rule hoare_strengthen_postE_R)
-    apply (rule hoare_vcg_R_conj)
-     apply (rule hoare_vcg_R_conj)
+    apply (rule hoare_vcg_conj_liftE_R)
+     apply (rule hoare_vcg_conj_liftE_R)
       apply (rule find_vspace_for_asid_inv [where P="\<top>", THEN valid_validE_R])
      apply (rule find_vspace_for_asid_lookup)
     apply (rule find_vspace_for_asid_aligned_pm)
@@ -1612,7 +1612,7 @@ lemma decode_page_inv_wf[wp]:
    apply (simp add: split_def split del: if_split
               cong: list.case_cong prod.case_cong)
    apply (rule hoare_pre)
-    apply (wp createMappingEntries_wf checkVP_wpR whenE_throwError_wp hoare_vcg_const_imp_lift_R
+    apply (wp createMappingEntries_wf checkVP_wpR whenE_throwError_wp hoare_vcg_const_imp_liftE_R
            | wpc | simp add: valid_arch_inv'_def valid_page_inv'_def | wp (once) hoare_drop_imps)+
    apply (clarsimp simp: neq_Nil_conv invs_valid_objs' linorder_not_le
                            cte_wp_at_ctes_of)

--- a/proof/refine/X64/CNodeInv_R.thy
+++ b/proof/refine/X64/CNodeInv_R.thy
@@ -6658,8 +6658,8 @@ lemma cteDelete_sch_act_simple:
      cteDelete slot exposed \<lbrace>\<lambda>rv. sch_act_simple\<rbrace>"
   apply (simp add: cteDelete_def whenE_def split_def)
   apply (wp hoare_drop_imps | simp)+
-  apply (rule_tac hoare_strengthen_postE [where Q="\<lambda>rv. sch_act_simple"
-                                       and E="\<lambda>rv. sch_act_simple"])
+  apply (rule_tac hoare_strengthen_postE [where Q'="\<lambda>rv. sch_act_simple"
+                                       and E'="\<lambda>rv. sch_act_simple"])
     apply (rule valid_validE)
     apply (wp finaliseSlot_sch_act_simple)
     apply simp+

--- a/proof/refine/X64/CNodeInv_R.thy
+++ b/proof/refine/X64/CNodeInv_R.thy
@@ -207,7 +207,7 @@ lemma decodeCNodeInvocation_corres:
                       apply (rule corres_trivial)
                       subgoal by (auto simp add: whenE_def, auto simp add: returnOk_def)
                      apply (wp | wpc | simp(no_asm))+
-                 apply (wp hoare_vcg_const_imp_lift_R hoare_vcg_const_imp_lift
+                 apply (wp hoare_vcg_const_imp_liftE_R hoare_vcg_const_imp_lift
                            hoare_vcg_all_liftE_R hoare_vcg_all_lift lsfco_cte_at' hoare_drop_imps
                                 | clarsimp)+
          subgoal by (auto elim!: valid_cnode_capI)
@@ -6229,7 +6229,7 @@ lemma reduceZombie_invs'':
           apply (wp | simp)+
          apply (rule getCTE_wp)
         apply (wp | simp)+
-      apply (rule_tac Q="\<lambda>cte s. rv = capZombiePtr cap +
+      apply (rule_tac Q'="\<lambda>cte s. rv = capZombiePtr cap +
                                       of_nat (capZombieNumber cap) * 2^cteSizeBits - 2^cteSizeBits
                               \<and> cte_wp_at' (\<lambda>c. c = cte) slot s \<and> invs' s
                               \<and> no_cte_prop Q s \<and> sch_act_simple s"
@@ -6571,8 +6571,8 @@ lemmas cteDelete_typ_at'_lifts [wp] = typ_at_lifts [OF cteDelete_typ_at']
 
 lemma cteDelete_cte_at:
   "\<lbrace>\<top>\<rbrace> cteDelete slot bool \<lbrace>\<lambda>rv. cte_at' slot\<rbrace>"
-  apply (rule_tac Q="\<lambda>s. cte_at' slot s \<or> \<not> cte_at' slot s"
-               in hoare_pre(1))
+  apply (rule_tac P'="\<lambda>s. cte_at' slot s \<or> \<not> cte_at' slot s"
+               in hoare_weaken_pre)
    apply (rule hoare_strengthen_post)
     apply (rule hoare_vcg_disj_lift)
      apply (rule typ_at_lifts, rule cteDelete_typ_at')
@@ -6611,7 +6611,7 @@ lemma cteDelete_cte_wp_at_invs:
       apply (clarsimp simp: cte_wp_at_ctes_of)
      apply wp
     apply (simp add: imp_conjR conj_comms)
-    apply (rule_tac Q="\<lambda>rv s. invs' s \<and> sch_act_simple s \<and>
+    apply (rule_tac Q'="\<lambda>rv s. invs' s \<and> sch_act_simple s \<and>
                    (fst rv \<longrightarrow>
                        cte_wp_at' (\<lambda>cte. removeable' slot s (cteCap cte)) slot s) \<and>
                    (fst rv \<longrightarrow>
@@ -6621,9 +6621,9 @@ lemma cteDelete_cte_wp_at_invs:
                                          cteCap cte = NullCap \<or>
                                          (\<exists>zb n. cteCap cte = Zombie slot zb n))
                                   slot s)"
-                and E="\<lambda>rv. \<top>" in hoare_strengthen_postE)
+                and E'="\<lambda>rv. \<top>" in hoare_strengthen_postE)
       apply (wp finaliseSlot_invs finaliseSlot_removeable finaliseSlot_sch_act_simple
-                hoare_drop_imps(2)[OF finaliseSlot_irqs])
+                hoare_drop_impE_R[OF finaliseSlot_irqs])
        apply (rule hoare_strengthen_postE_R, rule finaliseSlot_abort_cases)
        apply (clarsimp simp: cte_wp_at_ctes_of dest!: isCapDs)
       apply simp
@@ -6644,7 +6644,7 @@ lemma cteDelete_cte_wp_at_invs:
                              p s"
                in hoare_strengthen_postE_R)
     apply (wp finaliseSlot_invs finaliseSlot_removeable finaliseSlot_sch_act_simple
-              hoare_drop_imps(2)[OF finaliseSlot_irqs])
+              hoare_drop_impE_R[OF finaliseSlot_irqs])
     apply (rule hoare_strengthen_postE_R [OF finaliseSlot_cte_wp_at[where p=p and P=P]])
       apply simp+
     apply (clarsimp simp: cte_wp_at_ctes_of)
@@ -6832,7 +6832,7 @@ proof (induct rule: finalise_induct3)
           apply ((wp | simp add: locateSlot_conv)+)[2]
         apply (rule drop_spec_validE)
         apply simp
-        apply (rule_tac Q="\<lambda>rv s. revoke_progress_ord m (option_map capToRPO \<circ> cteCaps_of s)
+        apply (rule_tac Q'="\<lambda>rv s. revoke_progress_ord m (option_map capToRPO \<circ> cteCaps_of s)
                                      \<and> cte_wp_at' (\<lambda>cte. cteCap cte = fst rvb) sl s"
                          in hoare_post_imp)
          apply (clarsimp simp: o_def cte_wp_at_ctes_of capToRPO_def
@@ -7403,7 +7403,7 @@ next
                 apply (rule updateCap_corres)
                  apply simp
                 apply (simp add: is_cap_simps)
-               apply (rule_tac R="\<lambda>rv. cte_at' (cte_map ?target)" in hoare_post_add)
+               apply (rule_tac Q'="\<lambda>rv. cte_at' (cte_map ?target)" in hoare_post_add)
                apply (wp, (wp getCTE_wp)+)
               apply (clarsimp simp: cte_wp_at_ctes_of)
              apply (rule no_fail_pre, wp, simp)
@@ -7565,7 +7565,7 @@ lemma cteRevoke_typ_at':
 
 lemma cteRevoke_invs':
   "\<lbrace>invs' and sch_act_simple\<rbrace> cteRevoke ptr \<lbrace>\<lambda>rv. invs'\<rbrace>"
-  apply (rule_tac Q="\<lambda>rv. invs' and sch_act_simple" in hoare_strengthen_post)
+  apply (rule_tac Q'="\<lambda>rv. invs' and sch_act_simple" in hoare_strengthen_post)
   apply (wp cteRevoke_preservation cteDelete_invs' cteDelete_sch_act_simple)+
     apply simp_all
   done
@@ -9167,7 +9167,7 @@ proof (induct rule: finalise_spec_induct)
             apply (unfold Let_def split_def fst_conv snd_conv
                           case_Zombie_assert_fold haskell_fail_def)
             apply (wp getCTE_wp' preemptionPoint_invR| simp add: o_def irq_state_independent_HI)+
-            apply (rule hoare_post_imp [where Q="\<lambda>_. valid_irq_states'"])
+            apply (rule hoare_post_imp[where Q'="\<lambda>_. valid_irq_states'"])
              apply simp
             apply wp[1]
            apply (rule spec_strengthen_postE)
@@ -9210,7 +9210,7 @@ lemma cteDelete_irq_states':
   apply (simp add: cteDelete_def split_def)
   apply (wp whenE_wp)
    apply (rule hoare_strengthen_postE)
-     apply (rule hoare_valid_validE)
+     apply (rule valid_validE)
      apply (rule finaliseSlot_irq_states')
     apply simp
    apply simp

--- a/proof/refine/X64/CSpace_R.thy
+++ b/proof/refine/X64/CSpace_R.thy
@@ -2239,7 +2239,7 @@ lemma cteInsert_mdb' [wp]:
   cteInsert cap src dest
   \<lbrace>\<lambda>_. valid_mdb'\<rbrace>"
   apply (simp add:valid_mdb'_def valid_mdb_ctes_def)
-  apply (rule_tac Q = "\<lambda>r s. valid_dlist (ctes_of s) \<and> irq_control (ctes_of s) \<and>
+  apply (rule_tac Q'="\<lambda>r s. valid_dlist (ctes_of s) \<and> irq_control (ctes_of s) \<and>
                no_0 (ctes_of s) \<and> mdb_chain_0 (ctes_of s) \<and> ioport_control (ctes_of s) \<and>
                mdb_chunked (ctes_of s) \<and> untyped_mdb' (ctes_of s) \<and> untyped_inc' (ctes_of s) \<and>
                Q s" for Q
@@ -4162,12 +4162,12 @@ lemma setupReplyMaster_corres:
        apply (fastforce dest: pspace_relation_no_reply_caps
                              state_relation_pspace_relation)
       apply (clarsimp simp: cte_map_def tcb_cnode_index_def cte_wp_at_ctes_of)
-     apply (rule_tac Q="\<lambda>rv. einvs and tcb_at t and
+     apply (rule_tac Q'="\<lambda>rv. einvs and tcb_at t and
                              cte_wp_at ((=) rv) (t, tcb_cnode_index 2)"
                   in hoare_strengthen_post)
       apply (wp hoare_drop_imps get_cap_wp)
      apply (clarsimp simp: invs_def valid_state_def elim!: cte_wp_at_weakenE)
-    apply (rule_tac Q="\<lambda>rv. valid_pspace' and valid_mdb' and
+    apply (rule_tac Q'="\<lambda>rv. valid_pspace' and valid_mdb' and
                             cte_wp_at' ((=) rv) (cte_map (t, tcb_cnode_index 2))"
                  in hoare_strengthen_post)
      apply (wp hoare_drop_imps getCTE_wp')

--- a/proof/refine/X64/Detype_R.thy
+++ b/proof/refine/X64/Detype_R.thy
@@ -64,7 +64,7 @@ lemma descendants_range_in_lift':
   apply (simp only: Ball_def[unfolded imp_conv_disj])
   apply (rule hoare_pre)
    apply (wp hoare_vcg_all_lift hoare_vcg_disj_lift st cap_range)
-   apply (rule_tac Q = "\<lambda>r s. cte_wp_at' (\<lambda>c. capRange (cteCap c) \<inter> S = {}) x s"
+   apply (rule_tac Q'="\<lambda>r s. cte_wp_at' (\<lambda>c. capRange (cteCap c) \<inter> S = {}) x s"
       in hoare_strengthen_post)
     apply (wp cap_range)
    apply (clarsimp simp:cte_wp_at_ctes_of null_filter'_def)
@@ -1801,7 +1801,7 @@ lemma deleteObjects_invs':
 proof -
   show ?thesis
   apply (rule hoare_pre)
-   apply (rule_tac G="is_aligned ptr bits \<and> 3 \<le> bits \<and> bits \<le> word_bits" in hoare_grab_asm)
+   apply (rule_tac P'="is_aligned ptr bits \<and> 3 \<le> bits \<and> bits \<le> word_bits" in hoare_grab_asm)
    apply (clarsimp simp add: deleteObjects_def2)
    apply (simp add: freeMemory_def bind_assoc doMachineOp_bind ef_storeWord)
    apply (simp add: bind_assoc[where f="\<lambda>_. modify f" for f, symmetric])
@@ -4360,7 +4360,7 @@ lemma createNewCaps_pspace_no_overlap':
          apply simp+
     apply (simp add:range_cover_def)
    apply (simp add:range_cover.sz(1)[where 'a=machine_word_len, folded word_bits_def])
-  apply (rule_tac Q = "\<lambda>r. pspace_no_overlap' (ptr + (1 + of_nat n << Types_H.getObjectSize ty us))
+  apply (rule_tac Q'="\<lambda>r. pspace_no_overlap' (ptr + (1 + of_nat n << Types_H.getObjectSize ty us))
                                               (Types_H.getObjectSize ty us) and
                            pspace_aligned' and pspace_distinct'" in hoare_strengthen_post)
    apply (case_tac ty)

--- a/proof/refine/X64/Finalise_R.thy
+++ b/proof/refine/X64/Finalise_R.thy
@@ -1955,7 +1955,7 @@ lemma isFinalCapability_inv:
   apply (simp add: isFinalCapability_def Let_def
               split del: if_split cong: if_cong)
   apply (rule hoare_pre, wp)
-   apply (rule hoare_post_imp [where Q="\<lambda>s. P"], simp)
+   apply (rule hoare_post_imp[where Q'="\<lambda>s. P"], simp)
    apply wp
   apply simp
   done
@@ -2586,7 +2586,7 @@ lemma deleteASID_invs'[wp]:
   apply (simp add: deleteASID_def cong: option.case_cong)
   apply (rule hoare_pre)
    apply (wp | wpc)+
-    apply (rule_tac Q="\<lambda>rv. valid_obj' (injectKO rv) and invs'"
+    apply (rule_tac Q'="\<lambda>rv. valid_obj' (injectKO rv) and invs'"
               in hoare_post_imp)
      apply (rename_tac rv s)
      apply (clarsimp split: if_split_asm del: subsetI)
@@ -2895,7 +2895,7 @@ lemma cancelIPC_bound_tcb_at'[wp]:
   apply (simp add: getThreadReplySlot_def locateSlot_conv liftM_def)
   apply (rule hoare_pre)
    apply (wp capDeleteOne_bound_tcb_at' getCTE_ctes_of)
-   apply (rule_tac Q="\<lambda>_. bound_tcb_at' P tptr" in hoare_post_imp)
+   apply (rule_tac Q'="\<lambda>_. bound_tcb_at' P tptr" in hoare_post_imp)
    apply (clarsimp simp: capHasProperty_def cte_wp_at_ctes_of)
    apply (wp threadSet_pred_tcb_no_state | simp)+
   done

--- a/proof/refine/X64/Interrupt_R.thy
+++ b/proof/refine/X64/Interrupt_R.thy
@@ -388,7 +388,7 @@ lemma invokeIRQHandler_corres:
        apply simp
        apply (rule corres_split_nor[OF cap_delete_one_corres])
          apply (rule cteInsert_corres, simp+)
-        apply (rule_tac Q="\<lambda>rv s. einvs s \<and> cte_wp_at (\<lambda>c. c = cap.NullCap) irq_slot s
+        apply (rule_tac Q'="\<lambda>rv s. einvs s \<and> cte_wp_at (\<lambda>c. c = cap.NullCap) irq_slot s
                                   \<and> (a, b) \<noteq> irq_slot
                                   \<and> cte_wp_at (is_derived (cdt s) (a, b) cap) (a, b) s"
                       in hoare_post_imp)
@@ -855,7 +855,7 @@ lemma timerTick_invs'[wp]:
   apply (wpsimp wp: threadSet_invs_trivial threadSet_pred_tcb_no_state
                     rescheduleRequired_all_invs_but_ct_not_inQ
               simp: tcb_cte_cases_def)
-      apply (rule_tac Q="\<lambda>rv. invs'" in hoare_post_imp)
+      apply (rule_tac Q'="\<lambda>rv. invs'" in hoare_post_imp)
        apply (clarsimp simp: invs'_def valid_state'_def)
       apply (simp add: decDomainTime_def)
       apply wp
@@ -866,7 +866,7 @@ lemma timerTick_invs'[wp]:
                            hoare_vcg_imp_lift threadSet_ct_idle_or_in_cur_domain')+
             apply (rule hoare_strengthen_post[OF tcbSchedAppend_all_invs_but_ct_not_inQ'])
             apply (wpsimp simp: invs'_def valid_state'_def valid_pspace'_def sch_act_wf_weak)+
-           apply (rule_tac Q="\<lambda>_. invs'" in hoare_strengthen_post)
+           apply (rule_tac Q'="\<lambda>_. invs'" in hoare_strengthen_post)
             apply (wpsimp wp: threadSet_pred_tcb_no_state threadSet_tcbDomain_triv
                               threadSet_valid_objs' threadSet_timeslice_invs)+
            apply (clarsimp simp: invs'_def valid_state'_def valid_pspace'_def)
@@ -905,7 +905,7 @@ lemma hint_invs[wp]:
 
    apply (wp dmo_maskInterrupt_True getCTE_wp'
           | wpc | simp add: doMachineOp_bind maskIrqSignal_def)+
-    apply (rule_tac Q="\<lambda>rv. invs'" in hoare_post_imp)
+    apply (rule_tac Q'="\<lambda>rv. invs'" in hoare_post_imp)
      apply (clarsimp simp: cte_wp_at_ctes_of ex_nonz_cap_to'_def)
      apply fastforce
     apply (wp threadSet_invs_trivial | simp add: inQ_def handleReservedIRQ_def)+

--- a/proof/refine/X64/IpcCancel_R.thy
+++ b/proof/refine/X64/IpcCancel_R.thy
@@ -915,7 +915,7 @@ lemma (in delete_one_conc_pre) cancelIPC_sch_act_simple[wp]:
   apply (wp hoare_drop_imps delete_one_sch_act_simple
        | simp add: getThreadReplySlot_def | wpcw
        | rule sch_act_simple_lift
-       | (rule_tac Q="\<lambda>rv. sch_act_simple" in hoare_post_imp, simp))+
+       | (rule_tac Q'="\<lambda>rv. sch_act_simple" in hoare_post_imp, simp))+
   done
 
 lemma cancelSignal_st_tcb_at:
@@ -925,7 +925,7 @@ lemma cancelSignal_st_tcb_at:
    \<lbrace>\<lambda>rv. st_tcb_at' P t\<rbrace>"
   apply (simp add: cancelSignal_def Let_def list_case_If)
   apply (wp sts_st_tcb_at'_cases hoare_vcg_const_imp_lift
-            hoare_drop_imp[where R="%rv s. P' rv" for P'])
+            hoare_drop_imp[where Q'="%rv s. P' rv" for P'])
    apply clarsimp+
   done
 
@@ -1015,7 +1015,7 @@ lemma (in delete_one_conc_pre) cancelIPC_tcb_at_runnable':
     apply (case_tac rv; simp)
    apply (wp sts_pred_tcb_neq'  | simp | wpc)+
            apply (clarsimp)
-           apply (rule_tac Q="\<lambda>rv. ?PRE" in hoare_post_imp, fastforce)
+           apply (rule_tac Q'="\<lambda>rv. ?PRE" in hoare_post_imp, fastforce)
            apply (wp cteDeleteOne_tcb_at_runnable'
                     threadSet_pred_tcb_no_state
                     cancelSignal_tcb_at_runnable'
@@ -1117,7 +1117,7 @@ lemma sts_weak_sch_act_wf[wp]:
   including classic_wp_pre
   apply (simp add: setThreadState_def)
   apply (wp rescheduleRequired_weak_sch_act_wf)
-  apply (rule_tac Q="\<lambda>_ s. weak_sch_act_wf (ksSchedulerAction s) s" in hoare_post_imp, simp)
+  apply (rule_tac Q'="\<lambda>_ s. weak_sch_act_wf (ksSchedulerAction s) s" in hoare_post_imp, simp)
   apply (simp add: weak_sch_act_wf_def)
   apply (wp hoare_vcg_all_lift)
    apply (wps threadSet_nosch)
@@ -1256,11 +1256,11 @@ lemma (in delete_one) suspend_corres:
            apply wpsimp
           apply (wpsimp wp: sts_valid_objs')
          apply (wpsimp simp: update_restart_pc_def updateRestartPC_def valid_tcb_state'_def)+
-       apply (rule hoare_post_imp[where Q = "\<lambda>rv s. einvs s \<and> tcb_at t s"])
+       apply (rule hoare_post_imp[where Q'="\<lambda>rv s. einvs s \<and> tcb_at t s"])
         apply (simp add: invs_implies invs_strgs valid_queues_in_correct_ready_q
                          valid_queues_ready_qs_distinct valid_sched_def)
        apply wp
-      apply (rule hoare_post_imp[where Q = "\<lambda>_ s. invs' s \<and> tcb_at' t s"])
+      apply (rule hoare_post_imp[where Q'="\<lambda>_ s. invs' s \<and> tcb_at' t s"])
        apply (fastforce simp: invs'_def valid_tcb_state'_def)
       apply (wpsimp simp: update_restart_pc_def updateRestartPC_def)+
    apply fastforce
@@ -1342,7 +1342,7 @@ lemma setThreadState_oa_queued:
       apply (simp add: setThreadState_def)
       apply (wp rescheduleRequired_oa_queued)
       apply (simp add: sch_act_simple_def)
-      apply (rule_tac Q="\<lambda>_. ?Q R" in hoare_post_imp, clarsimp)
+      apply (rule_tac Q'="\<lambda>_. ?Q R" in hoare_post_imp, clarsimp)
       apply (wp threadSet_obj_at'_strongish)
       apply (clarsimp)
       done
@@ -1382,7 +1382,7 @@ lemma (in delete_one_conc) suspend_invs'[wp]:
   apply (simp add: suspend_def)
   apply (wpsimp wp: sts_invs_minor' gts_wp' simp: updateRestartPC_def
          | strengthen no_refs_simple_strg')+
-   apply (rule_tac Q="\<lambda>_. invs' and sch_act_simple and st_tcb_at' simple' t
+   apply (rule_tac Q'="\<lambda>_. invs' and sch_act_simple and st_tcb_at' simple' t
                           and (\<lambda>s. t \<noteq> ksIdleThread s)"
                 in hoare_post_imp)
     apply clarsimp
@@ -1410,7 +1410,7 @@ lemma (in delete_one_conc_pre) suspend_sch_act_simple[wp]:
 lemma (in delete_one_conc) suspend_objs':
   "\<lbrace>invs' and sch_act_simple and tcb_at' t and (\<lambda>s. t \<noteq> ksIdleThread s)\<rbrace>
    suspend t \<lbrace>\<lambda>rv. valid_objs'\<rbrace>"
-  apply (rule_tac Q="\<lambda>_. invs'" in hoare_strengthen_post)
+  apply (rule_tac Q'="\<lambda>_. invs'" in hoare_strengthen_post)
    apply (wp suspend_invs')
   apply fastforce
   done
@@ -1526,7 +1526,7 @@ proof -
         apply (rule ep_cancel_corres_helper)
        apply (rule mapM_x_wp')
        apply (wp weak_sch_act_wf_lift_linear set_thread_state_runnable_weak_valid_sched_action | simp)+
-      apply (rule_tac R="\<lambda>_ s. \<forall>x\<in>set list. tcb_at' x s \<and> valid_objs' s \<and> pspace_aligned' s \<and> pspace_distinct' s"
+      apply (rule_tac Q'="\<lambda>_ s. \<forall>x\<in>set list. tcb_at' x s \<and> valid_objs' s \<and> pspace_aligned' s \<and> pspace_distinct' s"
                    in hoare_post_add)
       apply (rule mapM_x_wp')
       apply ((wpsimp wp: hoare_vcg_const_Ball_lift mapM_x_wp' sts_st_tcb' sts_valid_objs'
@@ -1587,7 +1587,7 @@ lemma cancelAllSignals_corres:
                  set_thread_state_runnable_weak_valid_sched_action
             | simp)+
       apply (rename_tac list)
-      apply (rule_tac R="\<lambda>_ s. (\<forall>x\<in>set list. tcb_at' x s) \<and> valid_objs' s
+      apply (rule_tac Q'="\<lambda>_ s. (\<forall>x\<in>set list. tcb_at' x s) \<and> valid_objs' s
                                \<and> sym_heap_sched_pointers s \<and> valid_sched_pointers s \<and> valid_objs' s
                                \<and> pspace_aligned' s \<and> pspace_distinct' s"
                    in hoare_post_add)
@@ -1635,7 +1635,7 @@ proof -
   show ?thesis
   apply (simp add: setThreadState_def)
   apply (wpsimp wp: hoare_vcg_imp_lift [OF nrct])
-   apply (rule_tac Q="\<lambda>_. ?PRE" in hoare_post_imp)
+   apply (rule_tac Q'="\<lambda>_. ?PRE" in hoare_post_imp)
     apply (clarsimp)
    apply (rule hoare_convert_imp [OF threadSet_nosch threadSet_ct])
   apply assumption
@@ -1885,7 +1885,7 @@ lemma cancelAllIPC_valid_objs'[wp]:
   apply (rule bind_wp [OF _ get_ep_sp'])
   apply (rule hoare_pre)
    apply (wp set_ep_valid_objs' setSchedulerAction_valid_objs')
-    apply (rule_tac Q="\<lambda>_ s. valid_objs' s \<and> pspace_aligned' s \<and> pspace_distinct' s
+    apply (rule_tac Q'="\<lambda>_ s. valid_objs' s \<and> pspace_aligned' s \<and> pspace_distinct' s
                              \<and> (\<forall>x\<in>set (epQueue ep). tcb_at' x s)"
                     in hoare_post_imp)
      apply simp
@@ -1911,7 +1911,7 @@ lemma cancelAllSignals_valid_objs'[wp]:
     apply (wp, simp)
    apply (wp, simp)
   apply (rename_tac list)
-  apply (rule_tac Q="\<lambda>rv s. valid_objs' s \<and> (\<forall>x\<in>set list. tcb_at' x s)"
+  apply (rule_tac Q'="\<lambda>rv s. valid_objs' s \<and> (\<forall>x\<in>set list. tcb_at' x s)"
                   in hoare_post_imp)
    apply (simp add: valid_ntfn'_def)
   apply (simp add: Ball_def)
@@ -2217,7 +2217,7 @@ lemma cancelBadgedSends_corres:
   apply (rule corres_guard_imp)
     apply (rule corres_split_nor[OF setEndpoint_corres])
        apply (simp add: ep_relation_def)
-      apply (rule corres_split_eqr[OF _ _ _ hoare_post_add[where R="\<lambda>_. valid_objs'"]])
+      apply (rule corres_split_eqr[OF _ _ _ hoare_post_add[where Q'="\<lambda>_. valid_objs'"]])
          apply (rule_tac S="(=)"
                      and Q="\<lambda>xs s. (\<forall>x \<in> set xs. (epptr, TCBBlockedSend) \<in> state_refs_of s x) \<and>
                                    distinct xs \<and> valid_etcbs s \<and>

--- a/proof/refine/X64/Ipc_R.thy
+++ b/proof/refine/X64/Ipc_R.thy
@@ -493,7 +493,7 @@ next
         apply clarsimp
         apply assumption
        apply (subst imp_conjR)
-       apply (rule hoare_vcg_conj_liftE_R)
+       apply (rule hoare_vcg_conj_liftE_R')
         apply (rule derive_cap_is_derived)
        apply (wp derive_cap_is_derived_foo)+
       apply (simp split del: if_split)
@@ -505,7 +505,7 @@ next
        apply clarsimp
        apply assumption
       apply (subst imp_conjR)
-      apply (rule hoare_vcg_conj_liftE_R)
+      apply (rule hoare_vcg_conj_liftE_R')
        apply (rule hoare_strengthen_postE_R[OF deriveCap_derived])
        apply (clarsimp simp:cte_wp_at_ctes_of)
       apply (wp deriveCap_derived_foo)
@@ -617,7 +617,7 @@ lemma cteInsert_assume_Null:
    apply (rule bind_wp[OF _ getCTE_sp])+
    apply (rule hoare_name_pre_state)
    apply (clarsimp simp: cte_wp_at_ctes_of)
-  apply (erule hoare_pre(1))
+  apply (erule hoare_weaken_pre)
   apply simp
   done
 
@@ -1851,7 +1851,7 @@ declare asUser_global_refs' [wp]
 lemma lec_valid_cap' [wp]:
   "\<lbrace>valid_objs'\<rbrace> lookupExtraCaps thread xa mi \<lbrace>\<lambda>rv s. (\<forall>x\<in>set rv. s \<turnstile>' fst x)\<rbrace>, -"
   apply (rule hoare_pre, rule hoare_strengthen_postE_R)
-    apply (rule hoare_vcg_conj_lift_R[where R=valid_objs' and S="\<lambda>_. valid_objs'"])
+    apply (rule hoare_vcg_conj_liftE_R[where R=valid_objs' and S="\<lambda>_. valid_objs'"])
      apply (rule lookupExtraCaps_srcs)
     apply wp
    apply (clarsimp simp: cte_wp_at_ctes_of)
@@ -2242,7 +2242,7 @@ lemma doReplyTransfer_corres:
           apply (fastforce)
          apply (clarsimp simp:is_cap_simps)
         apply (wp weak_valid_sched_action_lift)+
-       apply (rule_tac Q="\<lambda>_ s. valid_objs' s \<and> cur_tcb' s \<and> tcb_at' receiver s
+       apply (rule_tac Q'="\<lambda>_ s. valid_objs' s \<and> cur_tcb' s \<and> tcb_at' receiver s
                                 \<and> sch_act_wf (ksSchedulerAction s) s
                                 \<and> sym_heap_sched_pointers s \<and> valid_sched_pointers s
                                 \<and> pspace_aligned' s \<and> pspace_distinct' s"
@@ -2303,14 +2303,14 @@ lemma doReplyTransfer_corres:
                          threadSet_tcbDomain_triv threadSet_valid_objs'
                          threadSet_sched_pointers threadSet_valid_sched_pointers
                     | simp add: valid_tcb_state'_def)+
-     apply (rule_tac Q="\<lambda>_. valid_sched and cur_tcb and tcb_at sender and tcb_at receiver and
+     apply (rule_tac Q'="\<lambda>_. valid_sched and cur_tcb and tcb_at sender and tcb_at receiver and
                             valid_objs and pspace_aligned and pspace_distinct"
                      in hoare_strengthen_post [rotated], clarsimp)
      apply (wp)
      apply (rule hoare_chain [OF cap_delete_one_invs])
       apply (assumption)
      apply fastforce
-    apply (rule_tac Q="\<lambda>_. tcb_at' sender and tcb_at' receiver and invs'"
+    apply (rule_tac Q'="\<lambda>_. tcb_at' sender and tcb_at' receiver and invs'"
                     in hoare_strengthen_post [rotated])
      apply (solves\<open>auto simp: invs'_def valid_state'_def\<close>)
     apply wp
@@ -2391,14 +2391,14 @@ lemma setupCallerCap_corres:
                               tcb_cnode_index_def cte_level_bits_def)
             apply (simp add: cte_map_def tcbCallerSlot_def
                              tcb_cnode_index_def cte_level_bits_def)
-           apply (rule_tac R="\<lambda>rv. cte_at' (receiver + 2 ^ cte_level_bits * tcbCallerSlot)"
+           apply (rule_tac Q'="\<lambda>rv. cte_at' (receiver + 2 ^ cte_level_bits * tcbCallerSlot)"
                     in hoare_post_add)
 
            apply (wp, (wp getSlotCap_wp)+)
           apply blast
          apply (rule no_fail_pre, wp)
          apply (clarsimp simp: cte_wp_at'_def cte_at'_def)
-        apply (rule_tac R="\<lambda>rv. cte_at' (sender + 2 ^ cte_level_bits * tcbReplySlot)"
+        apply (rule_tac Q'="\<lambda>rv. cte_at' (sender + 2 ^ cte_level_bits * tcbReplySlot)"
                      in hoare_post_add)
         apply (wp, (wp getCTE_wp')+)
        apply blast
@@ -2731,7 +2731,7 @@ lemma sendSignal_corres:
                                valid_queues_in_correct_ready_q valid_queues_ready_qs_distinct
                                valid_sched_valid_queues
                   | simp add: valid_tcb_state_def)+
-         apply (rule_tac Q="\<lambda>rv. invs' and tcb_at' a" in hoare_strengthen_post)
+         apply (rule_tac Q'="\<lambda>rv. invs' and tcb_at' a" in hoare_strengthen_post)
           apply wp
          apply (fastforce simp: invs'_def valid_state'_def sch_act_wf_weak valid_tcb_state'_def)
         apply (rule setNotification_corres)
@@ -2759,7 +2759,7 @@ lemma sendSignal_corres:
           apply (rule corres_split[OF asUser_setRegister_corres])
             apply (rule possibleSwitchTo_corres)
            apply ((wp | simp)+)[1]
-          apply (rule_tac Q="\<lambda>_. (\<lambda>s. sch_act_wf (ksSchedulerAction s) s) and
+          apply (rule_tac Q'="\<lambda>_. (\<lambda>s. sch_act_wf (ksSchedulerAction s) s) and
                                  cur_tcb' and
                                  st_tcb_at' runnable' (hd list) and valid_objs' and
                                  sym_heap_sched_pointers and valid_sched_pointers and
@@ -2937,7 +2937,7 @@ lemma cancelIPC_nonz_cap_to'[wp]:
        | wpc
        | simp
        | clarsimp elim!: cte_wp_at_weakenE'
-       | rule hoare_post_imp[where Q="\<lambda>rv. ex_nonz_cap_to' p"])+
+       | rule hoare_post_imp[where Q'="\<lambda>rv. ex_nonz_cap_to' p"])+
   done
 
 
@@ -3017,7 +3017,7 @@ proof -
           apply (wpc)
            apply (wp | simp)+
        apply (wpc, wp+)
-     apply (rule_tac Q="\<lambda>_. ?PRE t'" in hoare_post_imp, clarsimp)
+     apply (rule_tac Q'="\<lambda>_. ?PRE t'" in hoare_post_imp, clarsimp)
      apply (wp)
     apply simp
     done
@@ -3029,7 +3029,7 @@ proof -
     apply (wp)
         apply (wp hoare_convert_imp)[1]
        apply (wp)
-      apply (rule_tac Q="\<lambda>_. ?PRE t'" in hoare_post_imp, clarsimp)
+      apply (rule_tac Q'="\<lambda>_. ?PRE t'" in hoare_post_imp, clarsimp)
       apply (wp hoare_convert_imp | simp)+
      done
   show ?thesis
@@ -3042,16 +3042,16 @@ proof -
         apply (wp)+
            apply (wp hoare_convert_imp)[1]
           apply (wpc, wp+)
-        apply (rule_tac Q="\<lambda>_. ?PRE t'" in hoare_post_imp, clarsimp)
+        apply (rule_tac Q'="\<lambda>_. ?PRE t'" in hoare_post_imp, clarsimp)
         apply (wp cdo)+
-         apply (rule_tac Q="\<lambda>_. ?PRE t'" in hoare_post_imp, clarsimp)
+         apply (rule_tac Q'="\<lambda>_. ?PRE t'" in hoare_post_imp, clarsimp)
          apply ((wp aipc hoare_convert_imp)+)[6]
     apply (wp)
        apply (wp hoare_convert_imp)[1]
       apply (wpc, wp+)
-    apply (rule_tac Q="\<lambda>_. ?PRE t'" in hoare_post_imp, clarsimp)
+    apply (rule_tac Q'="\<lambda>_. ?PRE t'" in hoare_post_imp, clarsimp)
     apply (wp)
-   apply (rule_tac Q="\<lambda>_. ?PRE t'" in hoare_post_imp, clarsimp)
+   apply (rule_tac Q'="\<lambda>_. ?PRE t'" in hoare_post_imp, clarsimp)
    apply (wp)
   apply simp
   done
@@ -3310,7 +3310,7 @@ lemma receiveIPC_corres:
                                              valid_sched_action_def)
                      apply (clarsimp split: if_split_asm)
                     apply (clarsimp | wp do_ipc_transfer_tcb_caps)+
-                   apply (rule_tac Q="\<lambda>_ s. sch_act_wf (ksSchedulerAction s) s
+                   apply (rule_tac Q'="\<lambda>_ s. sch_act_wf (ksSchedulerAction s) s
                                             \<and> sym_heap_sched_pointers s \<and> valid_sched_pointers s
                                             \<and> pspace_aligned' s \<and> pspace_distinct' s"
                                 in hoare_post_imp)
@@ -3563,7 +3563,7 @@ lemma setupCallerCap_vp[wp]:
   apply (simp add: valid_pspace'_def setupCallerCap_def getThreadCallerSlot_def
                    getThreadReplySlot_def locateSlot_conv getSlotCap_def)
   apply (wp getCTE_wp)
-  apply (rule_tac Q="\<lambda>_. valid_pspace' and
+  apply (rule_tac Q'="\<lambda>_. valid_pspace' and
                          tcb_at' sender and tcb_at' rcvr"
                   in hoare_post_imp)
    apply (clarsimp simp: valid_cap'_def o_def cte_wp_at_ctes_of isCap_simps
@@ -3596,7 +3596,7 @@ lemma setupCallerCap_ifunsafe[wp]:
   apply (wp getSlotCap_cte_wp_at
        | simp add: unique_master_reply_cap' | strengthen eq_imp_strg
        | wp (once) hoare_drop_imp[where f="getCTE rs" for rs])+
-   apply (rule_tac Q="\<lambda>rv. valid_objs' and tcb_at' rcvr and ex_nonz_cap_to' rcvr"
+   apply (rule_tac Q'="\<lambda>rv. valid_objs' and tcb_at' rcvr and ex_nonz_cap_to' rcvr"
                 in hoare_post_imp)
     apply (clarsimp simp: ex_nonz_tcb_cte_caps' tcbCallerSlot_def
                           objBits_def objBitsKO_def dom_def cte_level_bits_def)
@@ -3768,7 +3768,7 @@ lemma completeSignal_invs:
   apply (rule bind_wp[OF _ get_ntfn_sp'])
   apply (rule hoare_pre)
    apply (wp set_ntfn_minor_invs' | wpc | simp)+
-    apply (rule_tac Q="\<lambda>_ s. (state_refs_of' s ntfnptr = ntfn_bound_refs' (ntfnBoundTCB ntfn))
+    apply (rule_tac Q'="\<lambda>_ s. (state_refs_of' s ntfnptr = ntfn_bound_refs' (ntfnBoundTCB ntfn))
                            \<and> ntfn_at' ntfnptr s
                            \<and> valid_ntfn' (ntfnObj_update (\<lambda>_. Structures_H.ntfn.IdleNtfn) ntfn) s
                            \<and> ((\<exists>y. ntfnBoundTCB ntfn = Some y) \<longrightarrow> ex_nonz_cap_to' ntfnptr s)
@@ -3798,7 +3798,7 @@ lemma setupCallerCap_urz[wp]:
                    getThreadCallerSlot_def getThreadReplySlot_def
                    locateSlot_conv)
   apply (wp getCTE_wp')
-  apply (rule_tac Q="\<lambda>_. untyped_ranges_zero' and valid_mdb' and valid_objs'" in hoare_post_imp)
+  apply (rule_tac Q'="\<lambda>_. untyped_ranges_zero' and valid_mdb' and valid_objs'" in hoare_post_imp)
    apply (clarsimp simp: cte_wp_at_ctes_of cteCaps_of_def untyped_derived_eq_def
                          isCap_simps)
   apply (wp sts_valid_pspace_hangers)
@@ -3851,7 +3851,7 @@ lemma ri_invs' [wp]:
   apply (rule bind_wp [OF _ gbn_sp'])
   apply (rule bind_wp)
   (* set up precondition for old proof *)
-   apply (rule_tac R="ko_at' ep (capEPPtr cap) and ?pre" in hoare_vcg_if_split)
+   apply (rule_tac P''="ko_at' ep (capEPPtr cap) and ?pre" in hoare_vcg_if_split)
     apply (wp completeSignal_invs)
    apply (case_tac ep)
      \<comment> \<open>endpoint = RecvEP\<close>
@@ -4138,9 +4138,9 @@ lemma si_invs'[wp]:
                hoare_convert_imp [OF setEndpoint_nosch setEndpoint_ct']
                hoare_drop_imp [where f="threadGet tcbFault t"]
              | rule_tac f="getThreadState a" in hoare_drop_imp
-             | wp (once) hoare_drop_imp[where R="\<lambda>_ _. call"]
-               hoare_drop_imp[where R="\<lambda>_ _. \<not> call"]
-               hoare_drop_imp[where R="\<lambda>_ _. cg"]
+             | wp (once) hoare_drop_imp[where Q'="\<lambda>_ _. call"]
+               hoare_drop_imp[where Q'="\<lambda>_ _. \<not> call"]
+               hoare_drop_imp[where Q'="\<lambda>_ _. cg"]
              | simp    add: valid_tcb_state'_def case_bool_If
                             case_option_If
                       cong: if_cong

--- a/proof/refine/X64/Ipc_R.thy
+++ b/proof/refine/X64/Ipc_R.thy
@@ -53,7 +53,7 @@ lemma lsfco_cte_at':
    apply (wp)
   apply (clarsimp simp: split_def unlessE_def
              split del: if_split)
-  apply (wp hoare_drop_imps throwE_R)
+  apply (wpsimp wp: hoare_drop_imps throwE_R)
   done
 
 declare unifyFailure_wp [wp]
@@ -1851,7 +1851,7 @@ declare asUser_global_refs' [wp]
 lemma lec_valid_cap' [wp]:
   "\<lbrace>valid_objs'\<rbrace> lookupExtraCaps thread xa mi \<lbrace>\<lambda>rv s. (\<forall>x\<in>set rv. s \<turnstile>' fst x)\<rbrace>, -"
   apply (rule hoare_pre, rule hoare_strengthen_postE_R)
-    apply (rule hoare_vcg_conj_liftE_R[where R=valid_objs' and S="\<lambda>_. valid_objs'"])
+    apply (rule hoare_vcg_conj_liftE_R[where P'=valid_objs' and Q'="\<lambda>_. valid_objs'"])
      apply (rule lookupExtraCaps_srcs)
     apply wp
    apply (clarsimp simp: cte_wp_at_ctes_of)

--- a/proof/refine/X64/Refine.thy
+++ b/proof/refine/X64/Refine.thy
@@ -226,12 +226,12 @@ lemma set_thread_state_sched_act:
     apply (simp add: set_thread_state_ext_def)
     apply wp
        apply (rule hoare_pre_cont)
-      apply (rule_tac Q="\<lambda>rv. (\<lambda>s. runnable ts) and (\<lambda>s. P (scheduler_action s))"
+      apply (rule_tac Q'="\<lambda>rv. (\<lambda>s. runnable ts) and (\<lambda>s. P (scheduler_action s))"
               in hoare_strengthen_post)
        apply wp
       apply force
      apply (wp gts_st_tcb_at)+
-     apply (rule_tac Q="\<lambda>rv. st_tcb_at ((=) state) thread and (\<lambda>s. runnable state) and (\<lambda>s. P (scheduler_action s))" in hoare_strengthen_post)
+     apply (rule_tac Q'="\<lambda>rv. st_tcb_at ((=) state) thread and (\<lambda>s. runnable state) and (\<lambda>s. P (scheduler_action s))" in hoare_strengthen_post)
      apply (simp add: st_tcb_at_def)
      apply (wp obj_set_prop_at)+
     apply (force simp: st_tcb_at_def obj_at_def)
@@ -270,7 +270,7 @@ lemma kernel_entry_invs:
   \<lbrace>\<lambda>rv. einvs and (\<lambda>s. ct_running s \<or> ct_idle s)
     and (\<lambda>s. 0 < domain_time s) and valid_domain_list
     and (\<lambda>s. scheduler_action s = resume_cur_thread)\<rbrace>"
-  apply (rule_tac Q="\<lambda>rv. invs and (\<lambda>s. ct_running s \<or> ct_idle s) and valid_sched and
+  apply (rule_tac Q'="\<lambda>rv. invs and (\<lambda>s. ct_running s \<or> ct_idle s) and valid_sched and
                            (\<lambda>s. 0 < domain_time s) and valid_domain_list and
                            valid_list and (\<lambda>s. scheduler_action s = resume_cur_thread)"
             in hoare_post_imp)
@@ -316,7 +316,7 @@ lemma do_user_op_invs2:
   do_user_op f tc
    \<lbrace>\<lambda>_. (einvs  and ct_running and (\<lambda>s. scheduler_action s = resume_cur_thread))
         and (\<lambda>s. 0 < domain_time s) and valid_domain_list \<rbrace>"
-  apply (rule_tac Q="\<lambda>_. valid_list and valid_sched and
+  apply (rule_tac Q'="\<lambda>_. valid_list and valid_sched and
    (\<lambda>s. scheduler_action s = resume_cur_thread) and (invs and ct_running) and
    (\<lambda>s. 0 < domain_time s) and valid_domain_list"
    in hoare_strengthen_post)
@@ -391,7 +391,7 @@ lemma ckernel_invs:
   apply (rule hoare_pre)
    apply (wp activate_invs' activate_sch_act schedule_sch
              schedule_sch_act_simple he_invs' schedule_invs'
-             hoare_drop_imp[where R="\<lambda>_. kernelExitAssertions"]
+             hoare_drop_imp[where Q'="\<lambda>_. kernelExitAssertions"]
           | simp add: no_irq_getActiveIRQ)+
   done
 
@@ -560,21 +560,21 @@ lemma kernel_corres':
           apply simp
           apply (wpsimp wp: hoare_drop_imps hoare_vcg_all_lift simp: schact_is_rct_def)[1]
          apply simp
-         apply (rule_tac Q="\<lambda>irq s. invs' s \<and>
+         apply (rule_tac Q'="\<lambda>irq s. invs' s \<and>
                               (\<forall>irq'. irq = Some irq' \<longrightarrow>
                                  intStateIRQTable (ksInterruptState s ) irq' \<noteq>
                                  IRQInactive)"
                       in hoare_post_imp)
           apply simp
          apply (wp doMachineOp_getActiveIRQ_IRQ_active handle_event_valid_sched | simp)+
-       apply (rule_tac Q="\<lambda>_. \<top>" and E="\<lambda>_. invs'" in hoare_strengthen_postE)
+       apply (rule_tac Q'="\<lambda>_. \<top>" and E'="\<lambda>_. invs'" in hoare_strengthen_postE)
          apply wpsimp+
        apply (simp add: invs'_def valid_state'_def)
       apply (rule corres_split[OF schedule_corres])
         apply (rule activateThread_corres)
        apply (wp schedule_invs' hoare_vcg_if_lift2 hoare_drop_imps
                  handle_interrupt_valid_sched[unfolded non_kernel_IRQs_def, simplified] |simp)+
-     apply (rule_tac Q="\<lambda>_. valid_sched and invs and valid_list" and E="\<lambda>_. valid_sched and invs and valid_list"
+     apply (rule_tac Q'="\<lambda>_. valid_sched and invs and valid_list" and E'="\<lambda>_. valid_sched and invs and valid_list"
             in hoare_strengthen_postE)
        apply (wp handle_event_valid_sched |simp)+
    apply (clarsimp simp: active_from_running schact_is_rct_def)

--- a/proof/refine/X64/Retype_R.thy
+++ b/proof/refine/X64/Retype_R.thy
@@ -4312,7 +4312,7 @@ lemma createNewCaps_cur:
         cur_tcb' s\<rbrace>
       createNewCaps ty ptr n us d
    \<lbrace>\<lambda>rv. cur_tcb'\<rbrace>"
-  apply (rule hoare_post_imp [where Q="\<lambda>rv s. \<exists>t. ksCurThread s = t \<and> tcb_at' t s"])
+  apply (rule hoare_post_imp[where Q'="\<lambda>rv s. \<exists>t. ksCurThread s = t \<and> tcb_at' t s"])
    apply (simp add: cur_tcb'_def)
   apply (wp hoare_vcg_ex_lift createNewCaps_obj_at')
   apply (clarsimp simp: pspace_no_overlap'_def cur_tcb'_def valid_pspace'_def)
@@ -4427,7 +4427,7 @@ lemma createNewCaps_global_refs':
      createNewCaps ty ptr n us d
    \<lbrace>\<lambda>rv. valid_global_refs'\<rbrace>"
   apply (simp add: valid_global_refs'_def valid_cap_sizes'_def valid_refs'_def)
-  apply (rule_tac Q="\<lambda>rv s. \<forall>ptr. \<not> cte_wp_at' (\<lambda>cte. (kernel_data_refs \<inter> capRange (cteCap cte) \<noteq> {}
+  apply (rule_tac Q'="\<lambda>rv s. \<forall>ptr. \<not> cte_wp_at' (\<lambda>cte. (kernel_data_refs \<inter> capRange (cteCap cte) \<noteq> {}
         \<or> 2 ^ capBits (cteCap cte) > gsMaxObjectSize s)) ptr s \<and> global_refs' s \<subseteq> kernel_data_refs"
                  in hoare_post_imp)
    apply (auto simp: cte_wp_at_ctes_of linorder_not_less elim!: ranE)[1]
@@ -5062,7 +5062,7 @@ proof (rule hoare_gen_asm, elim conjE)
     "\<lbrace>ct_not_inQ and valid_pspace' and pspace_no_overlap' ptr sz\<rbrace>
      createNewCaps ty ptr n us dev \<lbrace>\<lambda>_. ct_not_inQ\<rbrace>"
     unfolding ct_not_inQ_def
-    apply (rule_tac Q="\<lambda>s. ksSchedulerAction s = ResumeCurrentThread
+    apply (rule_tac P'="\<lambda>s. ksSchedulerAction s = ResumeCurrentThread
                              \<longrightarrow> (obj_at' (Not \<circ> tcbQueued) (ksCurThread s) s
                                   \<and> valid_pspace' s \<and> pspace_no_overlap' ptr sz s)"
                     in hoare_pre_imp, clarsimp)
@@ -5200,7 +5200,7 @@ lemma createObjects_no_cte_valid_global:
       createObjects ptr n val gbits
    \<lbrace>\<lambda>rv s. valid_global_refs' s\<rbrace>"
   apply (simp add: valid_global_refs'_def valid_cap_sizes'_def valid_refs'_def)
-  apply (rule_tac Q="\<lambda>rv s. \<forall>ptr. \<not> cte_wp_at' (\<lambda>cte. (kernel_data_refs \<inter> capRange (cteCap cte) \<noteq> {}
+  apply (rule_tac Q'="\<lambda>rv s. \<forall>ptr. \<not> cte_wp_at' (\<lambda>cte. (kernel_data_refs \<inter> capRange (cteCap cte) \<noteq> {}
         \<or> 2 ^ capBits (cteCap cte) > gsMaxObjectSize s)) ptr s \<and> global_refs' s \<subseteq> kernel_data_refs"
                  in hoare_post_imp)
    apply (auto simp: cte_wp_at_ctes_of linorder_not_less elim!: ranE)[1]
@@ -5331,7 +5331,7 @@ lemma createObjects_cur':
         cur_tcb' s\<rbrace>
       createObjects ptr n val gbits
    \<lbrace>\<lambda>rv s. cur_tcb' s\<rbrace>"
-  apply (rule hoare_post_imp [where Q="\<lambda>rv s. \<exists>t. ksCurThread s = t \<and> tcb_at' t s"])
+  apply (rule hoare_post_imp[where Q'="\<lambda>rv s. \<exists>t. ksCurThread s = t \<and> tcb_at' t s"])
    apply (simp add: cur_tcb'_def)
   apply (wp hoare_vcg_ex_lift createObjects_orig_obj_at3)
   apply (clarsimp simp: cur_tcb'_def)
@@ -5424,7 +5424,7 @@ proof -
       createObjects ptr n val gbits \<lbrace>\<lambda>_. ct_not_inQ\<rbrace>"
     (is "\<lbrakk> _; _ \<rbrakk> \<Longrightarrow> \<lbrace>\<lambda>s. ct_not_inQ s \<and> ?REST s\<rbrace> _ \<lbrace>_\<rbrace>")
     apply (simp add: ct_not_inQ_def)
-    apply (rule_tac Q="\<lambda>s. (ksSchedulerAction s = ResumeCurrentThread) \<longrightarrow>
+    apply (rule_tac P'="\<lambda>s. (ksSchedulerAction s = ResumeCurrentThread) \<longrightarrow>
                              (obj_at' (Not \<circ> tcbQueued) (ksCurThread s) s \<and> ?REST s)"
              in hoare_pre_imp, clarsimp)
     apply (rule hoare_convert_imp [OF createObjects_nosch])

--- a/proof/refine/X64/Retype_R.thy
+++ b/proof/refine/X64/Retype_R.thy
@@ -4396,17 +4396,14 @@ lemma createNewCaps_idle'[wp]:
                       split del: if_split)
          apply (rename_tac apiobject_type)
          apply (case_tac apiobject_type, simp_all split del: if_split)[1]
-             apply (wp, simp)
-           including classic_wp_pre
-           apply (wp mapM_x_wp'
-                     createObjects_idle'
-                     threadSet_idle'
+             apply wpsimp
+            apply (wpsimp wp: mapM_x_wp' createObjects_idle' threadSet_idle'
                    | simp add: projectKO_opt_tcb projectKO_opt_cte
                                makeObject_cte makeObject_tcb archObjSize_def
                                tcb_cte_cases_def objBitsKO_def APIType_capBits_def
                                objBits_def createObjects_def bit_simps
                    | intro conjI impI
-                   | fastforce simp: curDomain_def)+
+                   | clarsimp simp: curDomain_def)+
   done
 
 crunch createNewCaps

--- a/proof/refine/X64/Schedule_R.thy
+++ b/proof/refine/X64/Schedule_R.thy
@@ -597,7 +597,7 @@ lemma tcbSchedDequeue_valid_mdb'[wp]:
   "\<lbrace>valid_mdb' and valid_objs'\<rbrace> tcbSchedDequeue tcbPtr \<lbrace>\<lambda>_. valid_mdb'\<rbrace>"
   unfolding tcbSchedDequeue_def
   apply (wpsimp simp: bitmap_fun_defs setQueue_def wp: threadSet_mdb' tcbQueueRemove_valid_mdb')
-      apply (rule_tac Q="\<lambda>_. tcb_at' tcbPtr" in hoare_post_imp)
+      apply (rule_tac Q'="\<lambda>_. tcb_at' tcbPtr" in hoare_post_imp)
        apply (fastforce simp: tcb_cte_cases_def cteSizeBits_def)
       apply (wpsimp wp: threadGet_wp)+
   apply (fastforce simp: obj_at'_def)
@@ -903,7 +903,7 @@ lemma tcbSchedDequeue_not_tcbQueued:
   "\<lbrace>\<top>\<rbrace> tcbSchedDequeue t \<lbrace>\<lambda>_. obj_at' (\<lambda>x. \<not> tcbQueued x) t\<rbrace>"
   apply (simp add: tcbSchedDequeue_def)
   apply (wp|clarsimp)+
-  apply (rule_tac Q="\<lambda>queued. obj_at' (\<lambda>x. tcbQueued x = queued) t" in hoare_post_imp)
+  apply (rule_tac Q'="\<lambda>queued. obj_at' (\<lambda>x. tcbQueued x = queued) t" in hoare_post_imp)
      apply (clarsimp simp: obj_at'_def)
     apply (wpsimp wp: threadGet_wp)+
   apply (clarsimp simp: obj_at'_def)
@@ -1905,7 +1905,7 @@ lemma schedule_corres:
 
            apply (clarsimp simp: conj_ac cong: conj_cong)
            apply wp
-           apply (rule_tac Q="\<lambda>_ s. valid_blocked_except t s \<and> scheduler_action s = switch_thread t"
+           apply (rule_tac Q'="\<lambda>_ s. valid_blocked_except t s \<and> scheduler_action s = switch_thread t"
                     in hoare_post_imp, fastforce)
            apply (wp add: tcb_sched_action_enqueue_valid_blocked_except
                           tcbSchedEnqueue_invs'_not_ResumeCurrentThread thread_get_wp
@@ -2173,7 +2173,7 @@ lemma schedule_invs':
     apply (wpsimp wp: scheduleChooseNewThread_invs' ssa_invs'
                       chooseThread_invs_no_cicd' setSchedulerAction_invs' setSchedulerAction_direct
                       switchToThread_tcb_in_cur_domain' switchToThread_ct_not_queued_2
-           | wp hoare_disjI2[where R="\<lambda>_ s. tcb_in_cur_domain' (ksCurThread s) s"]
+           | wp hoare_disjI2[where Q'="\<lambda>_ s. tcb_in_cur_domain' (ksCurThread s) s"]
            | wp hoare_drop_imp[where f="isHighestPrio d p" for d p]
            | simp only: obj_at'_activatable_st_tcb_at'[simplified comp_def]
            | strengthen invs'_invs_no_cicd

--- a/proof/refine/X64/Schedule_R.thy
+++ b/proof/refine/X64/Schedule_R.thy
@@ -1911,7 +1911,7 @@ lemma schedule_corres:
                           tcbSchedEnqueue_invs'_not_ResumeCurrentThread thread_get_wp
                      del: gets_wp
                   | strengthen valid_objs'_valid_tcbs')+
-       apply (clarsimp simp: conj_ac if_apply_def2 cong: imp_cong conj_cong del: hoare_gets)
+       apply (clarsimp simp: conj_ac if_apply_def2 cong: imp_cong conj_cong)
        apply (wp gets_wp)+
 
    (* abstract final subgoal *)

--- a/proof/refine/X64/SubMonad_R.thy
+++ b/proof/refine/X64/SubMonad_R.thy
@@ -76,7 +76,7 @@ lemma threadSet_modify_asUser:
    apply (clarsimp simp: threadSet_def setObject_def split_def
                          updateObject_default_def)
    apply wp
-   apply (rule_tac Q="\<lambda>rv. obj_at' ((=) rv) t and ((=) st)" in hoare_post_imp)
+   apply (rule_tac Q'="\<lambda>rv. obj_at' ((=) rv) t and ((=) st)" in hoare_post_imp)
     apply (clarsimp simp: asUser_replace_def Let_def obj_at'_def
                           projectKOs fun_upd_def
                    split: option.split kernel_object.split)

--- a/proof/refine/X64/Syscall_R.thy
+++ b/proof/refine/X64/Syscall_R.thy
@@ -339,7 +339,7 @@ lemma threadSet_tcbDomain_update_sch_act_wf[wp]:
      apply (wps setObject_sa_unchanged)
      apply (wp hoare_weak_lift_imp getObject_tcb_wp hoare_vcg_all_lift)+
    apply (rename_tac word)
-   apply (rule_tac Q="\<lambda>_ s. ksSchedulerAction s = SwitchToThread word \<longrightarrow>
+   apply (rule_tac Q'="\<lambda>_ s. ksSchedulerAction s = SwitchToThread word \<longrightarrow>
                             st_tcb_at' runnable' word s \<and> tcb_in_cur_domain' word s \<and> word \<noteq> t"
                    in hoare_strengthen_post)
     apply (wp hoare_vcg_all_lift hoare_vcg_conj_lift hoare_vcg_imp_lift)+
@@ -376,20 +376,20 @@ lemma setDomain_corres:
          apply ((wpsimp wp: hoare_vcg_imp_lift' ethread_set_not_queued_valid_queues hoare_vcg_all_lift
                  | strengthen valid_objs'_valid_tcbs' valid_queues_in_correct_ready_q
                               valid_queues_ready_qs_distinct)+)[1]
-        apply (rule_tac Q="\<lambda>_. valid_objs' and sym_heap_sched_pointers and valid_sched_pointers
+        apply (rule_tac Q'="\<lambda>_. valid_objs' and sym_heap_sched_pointers and valid_sched_pointers
                                and pspace_aligned' and pspace_distinct'
                                and (\<lambda>s. sch_act_wf (ksSchedulerAction s) s) and tcb_at' tptr"
                      in hoare_strengthen_post[rotated])
          apply (fastforce simp: invs'_def valid_state'_def sch_act_wf_weak st_tcb_at'_def o_def)
         apply (wpsimp wp: threadSet_valid_objs' threadSet_sched_pointers
                           threadSet_valid_sched_pointers)+
-       apply (rule_tac Q="\<lambda>_ s. valid_queues s \<and> not_queued tptr s
+       apply (rule_tac Q'="\<lambda>_ s. valid_queues s \<and> not_queued tptr s
                                 \<and> pspace_aligned s \<and> pspace_distinct s \<and> valid_etcbs s
                                 \<and> weak_valid_sched_action s"
                     in hoare_post_imp)
         apply (fastforce simp: pred_tcb_at_def obj_at_def)
        apply (wpsimp wp: tcb_dequeue_not_queued)
-      apply (rule_tac Q = "\<lambda>_ s. invs' s \<and> obj_at' (Not \<circ> tcbQueued) tptr s \<and> sch_act_simple s
+      apply (rule_tac Q'="\<lambda>_ s. invs' s \<and> obj_at' (Not \<circ> tcbQueued) tptr s \<and> sch_act_simple s
                                  \<and>  tcb_at' tptr s"
                    in hoare_strengthen_post[rotated])
        apply (clarsimp simp: invs'_def valid_state'_def valid_pspace'_def sch_act_simple_def)
@@ -796,7 +796,7 @@ lemma doReply_invs[wp]:
           apply simp
           apply (wp (once) sts_st_tcb')
           apply wp
-         apply (rule_tac Q="\<lambda>_ s. invs' s \<and> t \<noteq> ksIdleThread s \<and> st_tcb_at' awaiting_reply' t s"
+         apply (rule_tac Q'="\<lambda>_ s. invs' s \<and> t \<noteq> ksIdleThread s \<and> st_tcb_at' awaiting_reply' t s"
                  in hoare_post_imp)
           apply clarsimp
           apply (rule conjI, erule pred_tcb'_weakenE, case_tac st, clarsimp+)
@@ -809,7 +809,7 @@ lemma doReply_invs[wp]:
           apply (case_tac st, clarsimp+)
          apply (wp cteDeleteOne_reply_pred_tcb_at)+
         apply clarsimp
-        apply (rule_tac Q="\<lambda>_. (\<lambda>s. t \<noteq> ksIdleThread s)
+        apply (rule_tac Q'="\<lambda>_. (\<lambda>s. t \<noteq> ksIdleThread s)
                                and cte_wp_at' (\<lambda>cte. \<exists>grant. cteCap cte
                                                              = capability.ReplyCap t False grant) slot"
                      in hoare_strengthen_post [rotated])
@@ -821,7 +821,7 @@ lemma doReply_invs[wp]:
         apply (erule cte_wp_at_weakenE')
         apply (fastforce)
        apply (wp sts_invs_minor'' sts_st_tcb' hoare_weak_lift_imp)
-             apply (rule_tac Q="\<lambda>_ s. invs' s \<and> sch_act_simple s
+             apply (rule_tac Q'="\<lambda>_ s. invs' s \<and> sch_act_simple s
                                       \<and> st_tcb_at' awaiting_reply' t s
                                       \<and> t \<noteq> ksIdleThread s"
                           in hoare_post_imp)
@@ -836,7 +836,7 @@ lemma doReply_invs[wp]:
               apply (case_tac st, clarsimp+)
              apply (wp threadSet_invs_trivial threadSet_st_tcb_at2 hoare_weak_lift_imp
                     | clarsimp simp add: inQ_def)+
-           apply (rule_tac Q="\<lambda>_. invs' and tcb_at' t
+           apply (rule_tac Q'="\<lambda>_. invs' and tcb_at' t
                                  and sch_act_simple and st_tcb_at' awaiting_reply' t"
                    in hoare_strengthen_post [rotated])
             apply clarsimp
@@ -946,7 +946,7 @@ lemma setDomain_invs':
   apply (simp add:setDomain_def )
   apply (wp add: when_wp hoare_weak_lift_imp hoare_weak_lift_imp_conj rescheduleRequired_all_invs_but_extra
     tcbSchedEnqueue_valid_action hoare_vcg_if_lift2)
-     apply (rule_tac Q = "\<lambda>r s. all_invs_but_sch_extra s \<and> curThread = ksCurThread s
+     apply (rule_tac Q'="\<lambda>r s. all_invs_but_sch_extra s \<and> curThread = ksCurThread s
       \<and> (ptr \<noteq> curThread \<longrightarrow> ct_not_inQ s \<and> sch_act_wf (ksSchedulerAction s) s \<and> ct_idle_or_in_cur_domain' s)"
       in hoare_strengthen_post[rotated])
       apply (clarsimp simp:invs'_def valid_state'_def st_tcb_at'_def[symmetric] valid_pspace'_def)
@@ -958,7 +958,7 @@ lemma setDomain_invs':
       apply assumption
      apply (wp hoare_weak_lift_imp threadSet_pred_tcb_no_state threadSet_not_curthread_ct_domain
                threadSet_tcbDomain_update_ct_not_inQ | simp)+
-    apply (rule_tac Q = "\<lambda>r s. invs' s \<and> curThread = ksCurThread s \<and> sch_act_simple s
+    apply (rule_tac Q'="\<lambda>r s. invs' s \<and> curThread = ksCurThread s \<and> sch_act_simple s
                              \<and> domain \<le> maxDomain
                              \<and> (ptr \<noteq> curThread \<longrightarrow> ct_not_inQ s \<and> sch_act_not ptr s)"
       in hoare_strengthen_post[rotated])
@@ -1198,7 +1198,7 @@ lemma handleInvocation_corres:
                  apply (simp cong: conj_cong)
                  apply (simp cong: rev_conj_cong)
                  apply (wpsimp wp: hoare_drop_imps)+
-               apply (rule_tac Q="\<lambda>rv. einvs and schact_is_rct and valid_invocation rve
+               apply (rule_tac Q'="\<lambda>rv. einvs and schact_is_rct and valid_invocation rve
                                    and (\<lambda>s. thread = cur_thread s)
                                    and st_tcb_at active thread"
                           in hoare_post_imp)
@@ -1206,7 +1206,7 @@ lemma handleInvocation_corres:
                                elim!: st_tcb_weakenE)
                apply (wp sts_st_tcb_at' set_thread_state_schact_is_rct
                          set_thread_state_active_valid_sched)
-              apply (rule_tac Q="\<lambda>rv. invs' and valid_invocation' rve'
+              apply (rule_tac Q'="\<lambda>rv. invs' and valid_invocation' rve'
                                       and (\<lambda>s. thread = ksCurThread s)
                                       and st_tcb_at' active' thread
                                       and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread)"
@@ -1218,7 +1218,7 @@ lemma handleInvocation_corres:
              apply (wp lec_caps_to lsft_ex_cte_cap_to
                     | simp add: split_def liftE_bindE[symmetric]
                                 ct_in_state'_def ball_conj_distrib
-                    | rule hoare_vcg_E_elim)+
+                    | rule hoare_vcg_conj_elimE)+
    apply (clarsimp simp: tcb_at_invs invs_valid_objs
                          valid_tcb_state_def ct_in_state_def
                          simple_from_active invs_mdb)
@@ -1287,7 +1287,7 @@ lemma hinv_invs'[wp]:
          apply (clarsimp simp: valid_idle'_def valid_state'_def
                                invs'_def pred_tcb_at'_def obj_at'_def idle_tcb'_def)
         apply wp+
-       apply (rule_tac Q="\<lambda>rv'. invs' and valid_invocation' rv
+       apply (rule_tac Q'="\<lambda>rv'. invs' and valid_invocation' rv
                                 and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread)
                                 and (\<lambda>s. ksCurThread s = thread)
                                 and st_tcb_at' active' thread"
@@ -1489,7 +1489,7 @@ lemma handleRecv_isBlocking_corres':
           apply (rule handleFault_corres)
           apply simp
          apply (wp get_simple_ko_wp | wpcw | simp)+
-         apply (rule hoare_vcg_E_elim)
+         apply (rule hoare_vcg_conj_elimE)
           apply (simp add: lookup_cap_def lookup_slot_for_thread_def)
           apply wp
            apply (simp add: split_def)
@@ -1537,14 +1537,14 @@ lemma hw_invs'[wp]:
                          deleteCallerCap_ct']
                     | wpc | simp add: ct_in_state'_def whenE_def split del: if_split)+
      apply (rule validE_validE_R)
-     apply (rule_tac Q="\<lambda>rv s. invs' s
+     apply (rule_tac Q'="\<lambda>rv s. invs' s
                              \<and> sch_act_sane s
                              \<and> thread = ksCurThread s
                              \<and> ct_in_state' simple' s
                              \<and> ex_nonz_cap_to' thread s
                              \<and> thread \<noteq> ksIdleThread s
                             \<and> (\<forall>x \<in> zobj_refs' rv. ex_nonz_cap_to' x s)"
-              and E="\<lambda>_ _. True"
+              and E'="\<lambda>_ _. True"
            in hoare_strengthen_postE[rotated])
         apply (clarsimp simp: isCap_simps ct_in_state'_def pred_tcb_at' invs_valid_objs'
                               sch_act_sane_not obj_at'_def projectKOs pred_tcb_at'_def)
@@ -1593,7 +1593,7 @@ lemma hy_invs':
   "\<lbrace>invs' and ct_active'\<rbrace> handleYield \<lbrace>\<lambda>r. invs' and ct_active'\<rbrace>"
   apply (simp add: handleYield_def)
   apply (wpsimp wp: ct_in_state_thread_state_lift' rescheduleRequired_all_invs_but_ct_not_inQ)
-     apply (rule_tac Q="\<lambda>_. all_invs_but_ct_not_inQ' and ct_active'" in hoare_post_imp)
+     apply (rule_tac Q'="\<lambda>_. all_invs_but_ct_not_inQ' and ct_active'" in hoare_post_imp)
       apply clarsimp
      apply (subst pred_conj_def)
      apply (rule hoare_vcg_conj_lift)
@@ -1810,7 +1810,7 @@ lemma handleReply_nonz_cap_to_ct:
   "\<lbrace>ct_active' and invs' and sch_act_simple\<rbrace>
      handleReply
    \<lbrace>\<lambda>rv s. ex_nonz_cap_to' (ksCurThread s) s\<rbrace>"
-  apply (rule_tac Q="\<lambda>rv. ct_active' and invs'"
+  apply (rule_tac Q'="\<lambda>rv. ct_active' and invs'"
                in hoare_post_imp)
    apply (auto simp: ct_in_state'_def elim: st_tcb_ex_cap'')[1]
   apply (wp | simp)+
@@ -1924,7 +1924,7 @@ proof -
             apply (rule handleVMFault_corres)
            apply (erule handleFault_corres)
           apply (rule hoare_elim_pred_conjE2)
-          apply (rule hoare_vcg_E_conj, rule valid_validE_E, wp)
+          apply (rule hoare_vcg_conj_liftE_E, rule valid_validE_E, wp)
           apply (wp handle_vm_fault_valid_fault)
          apply (rule hv_inv_ex')
         apply wp

--- a/proof/refine/X64/TcbAcc_R.thy
+++ b/proof/refine/X64/TcbAcc_R.thy
@@ -1039,7 +1039,7 @@ lemma threadSet_obj_at'_really_strongest:
   apply (simp add: threadSet_def)
   apply (wp setObject_tcb_strongest)
    apply (subst simp_thms(32)[symmetric], rule hoare_vcg_disj_lift)
-    apply (rule hoare_post_imp [where Q="\<lambda>rv s. \<not> tcb_at' t s \<and> tcb_at' t s"])
+    apply (rule hoare_post_imp[where Q'="\<lambda>rv s. \<not> tcb_at' t s \<and> tcb_at' t s"])
      apply simp
     apply (subst simp_thms(21)[symmetric], rule hoare_vcg_conj_lift)
      apply (rule getObject_inv_tcb)
@@ -1126,7 +1126,7 @@ proof -
   show ?thesis
     apply (rule_tac P=P in P_bool_lift)
      apply (rule pos)
-    apply (rule_tac Q="\<lambda>_ s. \<not> tcb_at' t' s \<or> pred_tcb_at' proj (\<lambda>tcb. \<not> P' tcb) t' s"
+    apply (rule_tac Q'="\<lambda>_ s. \<not> tcb_at' t' s \<or> pred_tcb_at' proj (\<lambda>tcb. \<not> P' tcb) t' s"
              in hoare_post_imp)
      apply (erule disjE)
       apply (clarsimp dest!: pred_tcb_at')
@@ -3271,7 +3271,7 @@ lemma sts_valid_objs':
    setThreadState st t
    \<lbrace>\<lambda>_. valid_objs'\<rbrace>"
   apply (wpsimp simp: setThreadState_def wp: threadSet_valid_objs')
-   apply (rule_tac Q="\<lambda>_. valid_objs' and pspace_aligned' and pspace_distinct'" in hoare_post_imp)
+   apply (rule_tac Q'="\<lambda>_. valid_objs' and pspace_aligned' and pspace_distinct'" in hoare_post_imp)
     apply fastforce
    apply (wpsimp wp: threadSet_valid_objs')
   apply (simp add: valid_tcb'_def tcb_cte_cases_def cteSizeBits_def)
@@ -3527,7 +3527,7 @@ lemma sts_sch_act':
    apply assumption
   apply (case_tac "runnable' st")
    apply ((wp threadSet_runnable_sch_act hoare_drop_imps | simp)+)[1]
-  apply (rule_tac Q="\<lambda>rv s. st_tcb_at' (Not \<circ> runnable') t s \<and>
+  apply (rule_tac Q'="\<lambda>rv s. st_tcb_at' (Not \<circ> runnable') t s \<and>
                      (ksCurThread s \<noteq> t \<or> ksSchedulerAction s \<noteq> ResumeCurrentThread \<longrightarrow>
                             sch_act_wf (ksSchedulerAction s) s)"
                in hoare_post_imp)
@@ -3547,10 +3547,10 @@ lemma sts_sch_act[wp]:
    prefer 2
    apply assumption
   apply (case_tac "runnable' st")
-   apply (rule_tac Q="\<lambda>s. sch_act_wf (ksSchedulerAction s) s"
+   apply (rule_tac P'="\<lambda>s. sch_act_wf (ksSchedulerAction s) s"
                 in hoare_pre_imp, simp)
    apply ((wp hoare_drop_imps threadSet_runnable_sch_act | simp)+)[1]
-  apply (rule_tac Q="\<lambda>rv s. st_tcb_at' (Not \<circ> runnable') t s \<and>
+  apply (rule_tac Q'="\<lambda>rv s. st_tcb_at' (Not \<circ> runnable') t s \<and>
                      (ksCurThread s \<noteq> t \<or> ksSchedulerAction s \<noteq> ResumeCurrentThread \<longrightarrow>
                             sch_act_wf (ksSchedulerAction s) s)"
                in hoare_post_imp)
@@ -3826,7 +3826,7 @@ lemma addToBitmap_valid_bitmapQ:
    addToBitmap d p
    \<lbrace>\<lambda>_. valid_bitmapQ\<rbrace>"
   (is "\<lbrace>?pre\<rbrace> _ \<lbrace>_\<rbrace>")
-  apply (rule_tac Q="\<lambda>_ s. ?pre s \<and> bitmapQ d p s" in hoare_strengthen_post)
+  apply (rule_tac Q'="\<lambda>_ s. ?pre s \<and> bitmapQ d p s" in hoare_strengthen_post)
    apply (wpsimp wp: addToBitmap_valid_bitmapQ_except addToBitmap_bitmapQ)
   apply (fastforce elim: valid_bitmap_valid_bitmapQ_exceptE)
   done
@@ -4535,7 +4535,7 @@ lemma ct_in_state'_decomp:
   assumes x: "\<lbrace>\<lambda>s. t = (ksCurThread s)\<rbrace> f \<lbrace>\<lambda>rv s. t = (ksCurThread s)\<rbrace>"
   assumes y: "\<lbrace>Pre\<rbrace> f \<lbrace>\<lambda>rv. st_tcb_at' Prop t\<rbrace>"
   shows      "\<lbrace>\<lambda>s. Pre s \<and> t = (ksCurThread s)\<rbrace> f \<lbrace>\<lambda>rv. ct_in_state' Prop\<rbrace>"
-  apply (rule hoare_post_imp [where Q="\<lambda>rv s. t = ksCurThread s \<and> st_tcb_at' Prop t s"])
+  apply (rule hoare_post_imp[where Q'="\<lambda>rv s. t = ksCurThread s \<and> st_tcb_at' Prop t s"])
    apply (clarsimp simp add: ct_in_state'_def)
   apply (rule hoare_weaken_pre)
    apply (wp x y)
@@ -4606,7 +4606,7 @@ lemma setQueue_pred_tcb_at[wp]:
   unfolding pred_tcb_at'_def
   apply (rule_tac P=P' in P_bool_lift)
    apply (rule setQueue_obj_at)
-  apply (rule_tac Q="\<lambda>_ s. \<not>typ_at' TCBT t s \<or> obj_at' (Not \<circ> (P \<circ> proj \<circ> tcb_to_itcb')) t s"
+  apply (rule_tac Q'="\<lambda>_ s. \<not>typ_at' TCBT t s \<or> obj_at' (Not \<circ> (P \<circ> proj \<circ> tcb_to_itcb')) t s"
            in hoare_post_imp, simp add: not_obj_at' o_def)
   apply (wp hoare_vcg_disj_lift)
   apply (clarsimp simp: not_obj_at' o_def)
@@ -4870,7 +4870,7 @@ lemma sts_iflive'[wp]:
    \<lbrace>\<lambda>rv. if_live_then_nonz_cap'\<rbrace>"
   apply (simp add: setThreadState_def setQueue_def)
   apply wpsimp
-   apply (rule_tac Q="\<lambda>rv. if_live_then_nonz_cap' and pspace_aligned' and pspace_distinct'"
+   apply (rule_tac Q'="\<lambda>rv. if_live_then_nonz_cap' and pspace_aligned' and pspace_distinct'"
                 in hoare_post_imp)
     apply clarsimp
    apply (wpsimp wp: threadSet_iflive')
@@ -5015,7 +5015,7 @@ lemma tcbSchedEnqueue_ct_not_inQ:
   proof -
     have ts: "\<lbrace>?PRE\<rbrace> threadSet (tcbQueued_update (\<lambda>_. True)) t \<lbrace>\<lambda>_. ct_not_inQ\<rbrace>"
       apply (simp add: ct_not_inQ_def)
-      apply (rule_tac Q="\<lambda>s. ksSchedulerAction s = ResumeCurrentThread
+      apply (rule_tac P'="\<lambda>s. ksSchedulerAction s = ResumeCurrentThread
                   \<longrightarrow> obj_at' (Not \<circ> tcbQueued) (ksCurThread s) s \<and> ksCurThread s \<noteq> t"
                   in hoare_pre_imp, clarsimp)
       apply (rule hoare_convert_imp [OF threadSet_nosch])
@@ -5042,7 +5042,7 @@ lemma tcbSchedAppend_ct_not_inQ:
   proof -
     have ts: "\<lbrace>?PRE\<rbrace> threadSet (tcbQueued_update (\<lambda>_. True)) t \<lbrace>\<lambda>_. ct_not_inQ\<rbrace>"
       apply (simp add: ct_not_inQ_def)
-      apply (rule_tac Q="\<lambda>s. ksSchedulerAction s = ResumeCurrentThread
+      apply (rule_tac P'="\<lambda>s. ksSchedulerAction s = ResumeCurrentThread
                   \<longrightarrow> obj_at' (Not \<circ> tcbQueued) (ksCurThread s) s \<and> ksCurThread s \<noteq> t"
                   in hoare_pre_imp, clarsimp)
       apply (rule hoare_convert_imp [OF threadSet_nosch])
@@ -5069,7 +5069,7 @@ lemma setSchedulerAction_direct:
 lemma rescheduleRequired_ct_not_inQ:
   "\<lbrace>\<top>\<rbrace> rescheduleRequired \<lbrace>\<lambda>_. ct_not_inQ\<rbrace>"
   apply (simp add: rescheduleRequired_def ct_not_inQ_def)
-  apply (rule_tac Q="\<lambda>_ s. ksSchedulerAction s = ChooseNewThread"
+  apply (rule_tac Q'="\<lambda>_ s. ksSchedulerAction s = ChooseNewThread"
            in hoare_post_imp, clarsimp)
   apply (wp setSchedulerAction_direct)
   done
@@ -5133,7 +5133,7 @@ lemma setThreadState_ct_not_inQ:
   including no_pre
   apply (simp add: setThreadState_def)
   apply (wp rescheduleRequired_ct_not_inQ)
-  apply (rule_tac Q="\<lambda>_. ?PRE" in hoare_post_imp, clarsimp)
+  apply (rule_tac Q'="\<lambda>_. ?PRE" in hoare_post_imp, clarsimp)
   apply (wp)
   done
 
@@ -5292,7 +5292,7 @@ lemma removeFromBitmap_valid_bitmapQ[wp]:
    removeFromBitmap d p
    \<lbrace>\<lambda>_. valid_bitmapQ\<rbrace>"
   (is "\<lbrace>?pre\<rbrace> _ \<lbrace>_\<rbrace>")
-  apply (rule_tac Q="\<lambda>_ s. ?pre s \<and> \<not> bitmapQ d p s" in hoare_strengthen_post)
+  apply (rule_tac Q'="\<lambda>_ s. ?pre s \<and> \<not> bitmapQ d p s" in hoare_strengthen_post)
    apply (wpsimp wp: removeFromBitmap_valid_bitmapQ_except removeFromBitmap_bitmapQ)
   apply (fastforce elim: valid_bitmap_valid_bitmapQ_exceptE)
   done

--- a/proof/refine/X64/Tcb_R.thy
+++ b/proof/refine/X64/Tcb_R.thy
@@ -81,7 +81,7 @@ abbreviation
 lemma gts_st_tcb':
   "\<lbrace>tcb_at' t\<rbrace> getThreadState t \<lbrace>\<lambda>rv. st_tcb_at' (\<lambda>st. st = rv) t\<rbrace>"
   apply (rule hoare_weaken_pre)
-   apply (rule hoare_post_imp[where Q="\<lambda>rv s. \<exists>rv'. rv = rv' \<and> st_tcb_at' (\<lambda>st. st = rv') t s"])
+   apply (rule hoare_post_imp[where Q'="\<lambda>rv s. \<exists>rv'. rv = rv' \<and> st_tcb_at' (\<lambda>st. st = rv') t s"])
     apply simp
    apply (wp hoare_vcg_ex_lift)
   apply (clarsimp simp add: pred_tcb_at'_def obj_at'_def)
@@ -107,15 +107,15 @@ lemma activate_invs':
     apply (case_tac rv, simp_all add: isTS_defs)
       apply (wp)
       apply (clarsimp simp: ct_in_state'_def)
-     apply (rule_tac Q="\<lambda>rv. invs' and ct_idle'" in hoare_post_imp, simp)
+     apply (rule_tac Q'="\<lambda>rv. invs' and ct_idle'" in hoare_post_imp, simp)
      apply (wp activateIdle_invs)
      apply (clarsimp simp: ct_in_state'_def)
-    apply (rule_tac Q="\<lambda>rv. invs' and ct_running' and sch_act_simple"
+    apply (rule_tac Q'="\<lambda>rv. invs' and ct_running' and sch_act_simple"
                  in hoare_post_imp, simp)
     apply (rule hoare_weaken_pre)
      apply (wp ct_in_state'_set asUser_ct sts_invs_minor'
           | wp (once) sch_act_simple_lift)+
-      apply (rule_tac Q="\<lambda>_. st_tcb_at' runnable' thread
+      apply (rule_tac Q'="\<lambda>_. st_tcb_at' runnable' thread
                              and sch_act_simple and invs'
                              and (\<lambda>s. thread = ksCurThread s)"
                in hoare_post_imp, clarsimp)
@@ -193,7 +193,7 @@ lemma setupReplyMaster_weak_sch_act_wf[wp]:
    \<lbrace>\<lambda>rv s. weak_sch_act_wf (ksSchedulerAction s) s\<rbrace>"
   apply (simp add: setupReplyMaster_def)
   apply (wp)
-    apply (rule_tac Q="\<lambda>_ s. weak_sch_act_wf (ksSchedulerAction s) s"
+    apply (rule_tac Q'="\<lambda>_ s. weak_sch_act_wf (ksSchedulerAction s) s"
                in hoare_post_imp, clarsimp)
     apply (wp)+
   apply assumption
@@ -219,11 +219,11 @@ lemma restart_corres:
               apply (wp set_thread_state_runnable_weak_valid_sched_action sts_st_tcb_at'
                         sts_st_tcb' sts_valid_objs'
                      | clarsimp simp: valid_tcb_state'_def | strengthen valid_objs'_valid_tcbs')+
-         apply (rule_tac Q="\<lambda>rv. valid_sched and cur_tcb and pspace_aligned and pspace_distinct"
+         apply (rule_tac Q'="\<lambda>rv. valid_sched and cur_tcb and pspace_aligned and pspace_distinct"
                          in hoare_strengthen_post)
           apply wp
          apply (fastforce simp: valid_sched_def valid_sched_action_def)
-        apply (rule_tac Q="\<lambda>rv. invs' and ex_nonz_cap_to' t" in hoare_strengthen_post)
+        apply (rule_tac Q'="\<lambda>rv. invs' and ex_nonz_cap_to' t" in hoare_strengthen_post)
          apply wp
         apply (clarsimp simp: invs'_def valid_state'_def sch_act_wf_weak valid_pspace'_def
                               valid_tcb_state'_def)
@@ -365,10 +365,10 @@ lemma invokeTCB_WriteRegisters_corres:
                                 valid_sched_valid_queues valid_objs'_valid_tcbs' invs_valid_objs'
                    | clarsimp simp: invs_def valid_state_def valid_sched_def invs'_def valid_state'_def
                              dest!: global'_no_ex_cap idle_no_ex_cap)+)[2]
-         apply (rule_tac Q="\<lambda>_. einvs and tcb_at dest and ex_nonz_cap_to dest" in hoare_post_imp)
+         apply (rule_tac Q'="\<lambda>_. einvs and tcb_at dest and ex_nonz_cap_to dest" in hoare_post_imp)
           apply (fastforce simp: invs_def valid_sched_weak_strg valid_sched_def valid_state_def dest!: idle_no_ex_cap)
          prefer 2
-         apply (rule_tac Q="\<lambda>_. invs' and tcb_at' dest and ex_nonz_cap_to' dest" in hoare_post_imp)
+         apply (rule_tac Q'="\<lambda>_. invs' and tcb_at' dest and ex_nonz_cap_to' dest" in hoare_post_imp)
           apply (fastforce simp: sch_act_wf_weak invs'_def valid_state'_def dest!: global'_no_ex_cap)
          apply wpsimp+
    apply fastforce
@@ -476,10 +476,10 @@ proof -
                     apply (rule_tac P=\<top> and P'=\<top> in corres_inst)
                     apply simp
                    apply ((solves \<open>wpsimp wp: hoare_weak_lift_imp\<close>)+)
-                 apply (rule_tac Q="\<lambda>_. einvs and tcb_at dest" in hoare_post_imp)
+                 apply (rule_tac Q'="\<lambda>_. einvs and tcb_at dest" in hoare_post_imp)
                   apply (fastforce simp: invs_def valid_sched_weak_strg valid_sched_def)
                  prefer 2
-                 apply (rule_tac Q="\<lambda>_. invs' and tcb_at' dest" in hoare_post_imp)
+                 apply (rule_tac Q'="\<lambda>_. invs' and tcb_at' dest" in hoare_post_imp)
                   apply (fastforce simp: invs'_def valid_state'_def invs_weak_sch_act_wf cur_tcb'_def)
                  apply ((wp mapM_x_wp' hoare_weak_lift_imp | simp flip: cur_tcb'_def)+)[8]
          apply ((wp hoare_weak_lift_imp restart_invs' | wpc |
@@ -552,7 +552,7 @@ lemma tcbSchedDequeue_not_queued:
    \<lbrace>\<lambda>rv. obj_at' (Not \<circ> tcbQueued) t\<rbrace>"
   apply (simp add: tcbSchedDequeue_def)
   apply (wp | simp)+
-  apply (rule_tac Q="\<lambda>rv. obj_at' (\<lambda>obj. tcbQueued obj = rv) t"
+  apply (rule_tac Q'="\<lambda>rv. obj_at' (\<lambda>obj. tcbQueued obj = rv) t"
                in hoare_post_imp)
    apply (clarsimp simp: obj_at'_def)
   apply (wp tg_sp' [where P=\<top>, simplified] | simp)+
@@ -1467,7 +1467,7 @@ proof -
   have B: "\<And>t v. \<lbrace>invs' and tcb_at' t\<rbrace> threadSet (tcbFaultHandler_update v) t \<lbrace>\<lambda>rv. invs'\<rbrace>"
     by (wp threadSet_invs_trivial | clarsimp simp: inQ_def)+
   note stuff = Z B out_invs_trivial hoare_case_option_wp
-    hoare_vcg_const_Ball_lift hoare_vcg_const_Ball_lift_R
+    hoare_vcg_const_Ball_lift hoare_vcg_const_Ball_liftE_R
     cap_delete_deletes cap_delete_valid_cap out_valid_objs
     cap_insert_objs
     cteDelete_deletes cteDelete_sch_act_simple
@@ -1502,7 +1502,7 @@ proof -
                   apply (rule corres_returnOkTT, simp)
                  apply wp
                 apply wp
-               apply (wpsimp wp: hoare_vcg_const_imp_lift_R hoare_vcg_const_imp_lift
+               apply (wpsimp wp: hoare_vcg_const_imp_liftE_R hoare_vcg_const_imp_lift
                                  hoare_vcg_all_liftE_R hoare_vcg_all_lift
                                  as_user_invs thread_set_ipc_tcb_cap_valid
                                  thread_set_tcb_ipc_buffer_cap_cleared_invs
@@ -1523,7 +1523,7 @@ proof -
                                  threadSet_invs_tcbIPCBuffer_update threadSet_cte_wp_at'
                       | strengthen simple_sched_action_sched_act_not)+
                 apply ((wpsimp wp: stuff hoare_vcg_all_liftE_R hoare_vcg_all_lift
-                                   hoare_vcg_const_imp_lift_R hoare_vcg_const_imp_lift
+                                   hoare_vcg_const_imp_liftE_R hoare_vcg_const_imp_lift
                                    threadSet_valid_objs' thread_set_not_state_valid_sched
                                    thread_set_tcb_ipc_buffer_cap_cleared_invs thread_set_cte_wp_at_trivial
                                    thread_set_no_cap_to_trivial getThreadBufferSlot_dom_tcb_cte_cases
@@ -1559,7 +1559,7 @@ proof -
                          in hoare_strengthen_postE_R[simplified validE_R_def, rotated])
              apply (case_tac g'; clarsimp simp: isCap_simps ; clarsimp elim: invs_valid_objs' cong:imp_cong)
             apply (wp add: stuff hoare_vcg_all_liftE_R hoare_vcg_all_lift
-                                 hoare_vcg_const_imp_lift_R hoare_vcg_const_imp_lift setMCPriority_invs'
+                                 hoare_vcg_const_imp_liftE_R hoare_vcg_const_imp_lift setMCPriority_invs'
                                  threadSet_valid_objs' thread_set_not_state_valid_sched setP_invs'
                                  typ_at_lifts [OF setPriority_typ_at']
                                  typ_at_lifts [OF setMCPriority_typ_at']
@@ -1637,15 +1637,15 @@ lemma tc_invs':
       apply (wpsimp wp: hoare_weak_lift_imp hoare_vcg_all_lift
                         checkCap_inv[where P="tcb_at' t" for t] assertDerived_wp_weak
                         threadSet_invs_trivial2 threadSet_tcb'  hoare_vcg_all_lift threadSet_cte_wp_at')+
-       apply (wpsimp wp: hoare_weak_lift_imp_R cteDelete_deletes
-                         hoare_vcg_all_liftE_R hoare_vcg_conj_liftE1 hoare_vcg_const_imp_lift_R hoare_vcg_propE_R
+       apply (wpsimp wp: hoare_weak_lift_impE_R cteDelete_deletes
+                         hoare_vcg_all_liftE_R hoare_vcg_conj_liftE1 hoare_vcg_const_imp_liftE_R hoare_vcg_propE_R
                          cteDelete_invs' cteDelete_invs' cteDelete_typ_at'_lifts)+
      apply (assumption | clarsimp cong: conj_cong imp_cong | (rule case_option_wp_None_returnOk)
             | wpsimp wp: hoare_weak_lift_imp hoare_vcg_all_lift checkCap_inv[where P="tcb_at' t" for t] assertDerived_wp_weak
                          hoare_vcg_imp_lift' hoare_vcg_all_lift checkCap_inv[where P="tcb_at' t" for t]
                          checkCap_inv[where P="valid_cap' c" for c] checkCap_inv[where P=sch_act_simple]
-                         hoare_vcg_const_imp_lift_R assertDerived_wp_weak hoare_weak_lift_imp_R cteDelete_deletes
-                         hoare_vcg_all_liftE_R hoare_vcg_conj_liftE1 hoare_vcg_const_imp_lift_R hoare_vcg_propE_R
+                         hoare_vcg_const_imp_liftE_R assertDerived_wp_weak hoare_weak_lift_impE_R cteDelete_deletes
+                         hoare_vcg_all_liftE_R hoare_vcg_conj_liftE1 hoare_vcg_const_imp_liftE_R hoare_vcg_propE_R
                          cteDelete_invs' cteDelete_typ_at'_lifts cteDelete_sch_act_simple)+
   apply (clarsimp simp: tcb_cte_cases_def cte_level_bits_def objBits_defs tcbIPCBufferSlot_def)
   by (auto dest!: isCapDs isReplyCapD isValidVTableRootD simp: isCap_simps)
@@ -2727,7 +2727,7 @@ lemma inv_tcb_IRQInactive:
   apply (rule hoare_pre)
    apply (wpc |
           wp withoutPreemption_R cteDelete_IRQInactive checkCap_inv
-             hoare_vcg_const_imp_lift_R cteDelete_irq_states'
+             hoare_vcg_const_imp_liftE_R cteDelete_irq_states'
              hoare_vcg_const_imp_lift |
           simp add: split_def)+
   done

--- a/proof/refine/X64/Untyped_R.thy
+++ b/proof/refine/X64/Untyped_R.thy
@@ -397,7 +397,7 @@ next
             apply (simp add: unat_arith_simps)
            apply wp+
           apply clarsimp
-          apply (rule hoare_strengthen_post [where Q = "\<lambda>r. invs and valid_cap r and cte_at slot"])
+          apply (rule hoare_strengthen_post[where Q'="\<lambda>r. invs and valid_cap r and cte_at slot"])
            apply wp+
           apply (clarsimp simp: is_cap_simps bits_of_def cap_aligned_def
                                 valid_cap_def word_bits_def)
@@ -405,7 +405,7 @@ next
           apply (strengthen refl exI[mk_strg I E] exI[where x=d])+
           apply simp
          apply wp+
-         apply (rule hoare_strengthen_post [where Q = "\<lambda>r. invs' and cte_at' (cte_map slot)"])
+         apply (rule hoare_strengthen_post[where Q'="\<lambda>r. invs' and cte_at' (cte_map slot)"])
           apply wp+
          apply (clarsimp simp:invs_pspace_aligned' invs_pspace_distinct')
         apply (wp whenE_throwError_wp | wp (once) hoare_drop_imps)+
@@ -3261,7 +3261,7 @@ lemma createNewCaps_parent_helper:
                        (\<forall>tup\<in>set (zip (xs rv) rv).
                                 sameRegionAs (cteCap cte) (snd tup)))
     p\<rbrace>"
-  apply (rule hoare_post_imp [where Q="\<lambda>rv s. \<exists>cte. cte_wp_at' ((=) cte) p s
+  apply (rule hoare_post_imp[where Q'="\<lambda>rv s. \<exists>cte. cte_wp_at' ((=) cte) p s
                                            \<and> isUntypedCap (cteCap cte)
                                            \<and> (\<forall>tup\<in>set (zip (xs rv) rv).
                                 sameRegionAs (cteCap cte) (snd tup))"])
@@ -4647,7 +4647,7 @@ lemma resetUntypedCap_invs_etc:
               | strengthen invs_pspace_aligned' invs_pspace_distinct'
               | simp add: ct_in_state'_def
                           sch_act_simple_def
-              | rule hoare_vcg_conj_lift_R
+              | rule hoare_vcg_conj_liftE_R
               | wp (once) preemptionPoint_inv
               | wps
               | wp (once) ex_cte_cap_to'_pres)+
@@ -5349,7 +5349,7 @@ crunch insertNewCap
 lemma insertNewCap_ct_idle_or_in_cur_domain'[wp]:
   "\<lbrace>ct_idle_or_in_cur_domain' and ct_active'\<rbrace> insertNewCap parent slot cap \<lbrace>\<lambda>_. ct_idle_or_in_cur_domain'\<rbrace>"
   apply (wp ct_idle_or_in_cur_domain'_lift_futz[where Q=\<top>])
-   apply (rule_tac Q="\<lambda>_. obj_at' (\<lambda>tcb. tcbState tcb \<noteq> Structures_H.thread_state.Inactive) t and
+   apply (rule_tac Q'="\<lambda>_. obj_at' (\<lambda>tcb. tcbState tcb \<noteq> Structures_H.thread_state.Inactive) t and
                           obj_at' (\<lambda>tcb. d = tcbDomain tcb) t"
                 in hoare_strengthen_post)
     apply (wp | clarsimp elim: obj_at'_weakenE)+

--- a/proof/refine/X64/VSpace_R.thy
+++ b/proof/refine/X64/VSpace_R.thy
@@ -423,7 +423,7 @@ lemma deleteASIDPool_corres:
               apply (simp only:)
               apply (rule setVMRoot_corres[OF refl])
              apply wp+
-         apply (rule_tac R="\<lambda>_ s. rv = x64_asid_table (arch_state s)"
+         apply (rule_tac Q'="\<lambda>_ s. rv = x64_asid_table (arch_state s)"
                   in hoare_post_add)
          apply (drule sym, simp only: )
          apply (drule sym, simp only: )
@@ -436,7 +436,7 @@ lemma deleteASIDPool_corres:
                            valid_vs_lookup_unmap_strg)
          apply (wp mapM_wp')+
          apply simp
-        apply (rule_tac R="\<lambda>_ s. rv' = x64KSASIDTable (ksArchState s)"
+        apply (rule_tac Q'="\<lambda>_ s. rv' = x64KSASIDTable (ksArchState s)"
                  in hoare_post_add)
         apply (simp only: pred_conj_def cong: conj_cong)
         apply simp
@@ -2601,7 +2601,7 @@ lemma perform_page_invs [wp]:
          | wpc
          | clarsimp simp: performPageInvocationUnmap_def)+
    apply (rename_tac acap word a b)
-   apply (rule_tac Q="\<lambda>_. invs' and cte_wp_at' (\<lambda>cte. \<exists>r R mt sz d m. cteCap cte =
+   apply (rule_tac Q'="\<lambda>_. invs' and cte_wp_at' (\<lambda>cte. \<exists>r R mt sz d m. cteCap cte =
                                        ArchObjectCap (PageCap r R mt sz d m)) word"
                in hoare_strengthen_post)
     apply (wp unmapPage_cte_wp_at')

--- a/sys-init/DuplicateCaps_SI.thy
+++ b/sys-init/DuplicateCaps_SI.thy
@@ -189,10 +189,10 @@ lemma duplicate_cap_sep_general:
   apply clarsimp
   apply (frule well_formed_finite [where obj_id=obj_id])
   apply (clarsimp simp: si_caps_at_def)
-  apply (rule hoare_chain [where
-   P="\<guillemotleft>((si_cnode_id, unat free_cptr) \<mapsto>c NullCap \<and>* si_objects) \<and>*
+  apply (rule hoare_chain[where
+   P'="\<guillemotleft>((si_cnode_id, unat free_cptr) \<mapsto>c NullCap \<and>* si_objects) \<and>*
         (\<And>* obj_id \<in> {obj_id. real_object_at obj_id spec}. si_cap_at t orig_caps spec dev obj_id) \<and>* R\<guillemotright>" and
-   Q="\<lambda>rv.\<guillemotleft>(si_cap_at t (map_of (zip [obj\<leftarrow>obj_ids. obj_filter obj spec]
+   Q'="\<lambda>rv.\<guillemotleft>(si_cap_at t (map_of (zip [obj\<leftarrow>obj_ids. obj_filter obj spec]
             free_cptrs)) spec dev obj_id \<and>* si_objects) \<and>*
         (\<And>* obj_id \<in> {obj_id. real_object_at obj_id spec}. si_cap_at t orig_caps spec dev obj_id) \<and>* R\<guillemotright>"])
     apply (rule sep_set_conj_map_singleton_wp [where x=obj_id])

--- a/sys-init/InitCSpace_SI.thy
+++ b/sys-init/InitCSpace_SI.thy
@@ -1543,7 +1543,7 @@ lemma init_cnode_slot_copy_not_original_sep:
                                        object_fields_empty spec t obj_id \<and>*
                                        si_objects) \<and>*
                                       si_objs_caps_at t orig_caps spec dev {obj_id. cnode_at obj_id spec} \<and>* R\<guillemotright>"
-                          and Q="\<lambda>_. \<guillemotleft>(object_slot_initialised spec t obj_id slot \<and>*
+                          and Q'="\<lambda>_. \<guillemotleft>(object_slot_initialised spec t obj_id slot \<and>*
                                        si_cap_at t dup_caps spec dev obj_id \<and>*
                                        object_fields_empty spec t obj_id \<and>*
                                        si_objects) \<and>*

--- a/sys-init/InitCSpace_SI.thy
+++ b/sys-init/InitCSpace_SI.thy
@@ -1538,7 +1538,7 @@ lemma init_cnode_slot_copy_not_original_sep:
    apply (clarsimp simp: cap_at_def)
    apply (rename_tac cap)
    (* Rearrange to work with the sep_list_conj_map_singleton_wp rule. *)
-   apply (rule hoare_chain [where P="\<guillemotleft>(object_slot_empty spec t obj_id slot \<and>*
+   apply (rule hoare_chain[where P'="\<guillemotleft>(object_slot_empty spec t obj_id slot \<and>*
                                        si_cap_at t dup_caps spec dev obj_id \<and>*
                                        object_fields_empty spec t obj_id \<and>*
                                        si_objects) \<and>*


### PR DESCRIPTION
This makes further improvements to the consistency of the monad rule sets, following on from https://github.com/seL4/l4v/pull/759. In particular, it includes additional lemma renamings missed in that PR, and changes the variables used in the lemmas to avoid `R` and `G` being used in pre or post-conditions. These variable names are instead reserved for the rely and guarantee conditions in the trace monad's RG rule set.