### PR TITLE
haskell: sync hcrNative with C changes

### DIFF
--- a/spec/haskell/src/SEL4/Machine/Hardware/AARCH64.hs
+++ b/spec/haskell/src/SEL4/Machine/Hardware/AARCH64.hs
@@ -443,7 +443,7 @@ check_export_arch_timer = error "Unimplemented - machine op"
 {- Constants -}
 
 hcrVCPU =  (0x80086039 :: Word) -- HCR_VCPU
-hcrNative = (0x8e28703b :: Word) -- HCR_NATIVE
+hcrNative = (0x8E28103B :: Word) -- HCR_NATIVE
 sctlrEL1VM = (0x34d58820 :: Word) -- SCTLR_EL1_VM
 sctlrDefault  = (0x34d59824 :: Word) -- SCTLR_DEFAULT
 vgicHCREN = (0x1 :: Word32) -- VGIC_HCR_EN

--- a/spec/haskell/src/SEL4/Machine/Hardware/ARM.lhs
+++ b/spec/haskell/src/SEL4/Machine/Hardware/ARM.lhs
@@ -876,7 +876,7 @@ FIXME ARMHYP consider moving to platform code?
 #ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
 
 > hcrVCPU =  (0x87039 :: Word) -- HCR_VCPU
-> hcrNative = (0xfe8703b :: Word) -- HCR_NATIVE
+> hcrNative = (0xFE8103B :: Word) -- HCR_NATIVE
 > vgicHCREN = (0x1 :: Word) -- VGIC_HCR_EN
 > sctlrDefault = (0xc5187c :: Word) -- SCTLR_DEFAULT
 > actlrDefault = (0x40 :: Word) -- ACTLR_DEFAULT


### PR DESCRIPTION
seL4/seL4#1251 changes the value of HCR_NATIVE which we mirror in the Haskell spec.

Test with: seL4/seL4#1251