### PR TITLE
github: remove haskellstack.org from link check

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -31,3 +31,5 @@ jobs:
       - uses: seL4/ci-actions/link-check@master
         with:
           token: ${{ secrets.READ_TOKEN }}
+          # produces 403 for link checkers now:
+          exclude_urls: ".*haskellstack.org.*"


### PR DESCRIPTION
The site doesn't like link checkers any more, so we're removing it from the check.