### PR TITLE
github: add tests for exynos5, zynqmp, bcm2711

### DIFF
--- a/.github/workflows/proof-deploy.yml
+++ b/.github/workflows/proof-deploy.yml
@@ -38,6 +38,13 @@ jobs:
       matrix:
         arch: [ARM, ARM_HYP, AARCH64, RISCV64, X64]
         num_domains: ['1', '']
+        include:
+          - arch: ARM_HYP
+            plat: exynos5
+          - arch: AARCH64
+            plat: zynqmp
+          - arch: AARCH64
+            plat: bcm2711
     # test only most recent push:
     concurrency: l4v-regression-${{ github.ref }}-${{ strategy.job-index }}
     steps:
@@ -92,7 +99,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [imx8-fpu-ver, exynos5-ver]
+        branch: [imx8-fpu-ver]
     steps:
     - name: Checkout
       uses: actions/checkout@v4


### PR DESCRIPTION
Since the proofs are now more generic,
- exynos5 no longer needs a separate proof branch, and
- zynqmp and bcm2711 are now supported for AARCH64

Test these on push/merge to the master branch for manifest deployment, but not for pull requests or weekly (to save CI cost).