### PR TITLE
github: upgrade permissions for annotation action

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -44,11 +44,14 @@ jobs:
   thylint:
     name: 'Theory Linter'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
     steps:
     - uses: seL4/ci-actions/thylint@master
       with:
         token: ${{ secrets.READ_TOKEN }}
-    - uses: yuzutech/annotations-action@v0.4.0
+    - uses: yuzutech/annotations-action@v0.5.0
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         title: 'File annotations for theory linter'


### PR DESCRIPTION
- `GITHUB_TOKEN`` does not have write access for checks any more by default. Provide explicitly instead.
- bump annotation action version.