### PR TITLE
github: fix platform build matrix

### DIFF
--- a/.github/workflows/proof-deploy.yml
+++ b/.github/workflows/proof-deploy.yml
@@ -38,6 +38,7 @@ jobs:
       matrix:
         arch: [ARM, ARM_HYP, AARCH64, RISCV64, X64]
         num_domains: ['1', '']
+        plat: ['']
         include:
           - arch: ARM_HYP
             plat: exynos5
@@ -52,6 +53,7 @@ jobs:
       uses: seL4/ci-actions/aws-proofs@master
       with:
         L4V_ARCH: ${{ matrix.arch }}
+        L4V_PLAT: ${{ matrix.plat }}
         xml: ${{ needs.code.outputs.xml }}
         NUM_DOMAINS: ${{ matrix.num_domains }}
       env:
@@ -61,13 +63,13 @@ jobs:
     - name: Upload kernel builds
       uses: actions/upload-artifact@v4
       with:
-        name: kernel-builds-${{ matrix.num_domains }}-${{ matrix.arch }}
+        name: kernel-builds-${{ matrix.num_domains }}-${{ matrix.arch }}-${{ matrix.plat }}
         path: artifacts/kernel-builds
         if-no-files-found: ignore
     - name: Upload logs
       uses: actions/upload-artifact@v4
       with:
-        name: logs-${{ matrix.num_domains }}-${{ matrix.arch }}
+        name: logs-${{ matrix.num_domains }}-${{ matrix.arch }}-${{ matrix.plat }}
         path: logs.tar.xz
 
   deploy:


### PR DESCRIPTION
- `include` values are modifying existing combinations when they would not otherwise overwrite a value, but we don't want that. Instead we make sure that `plat` is set for the rest of the matrix and that it would be overwritten by the `include` values. This gives us additional jobs, which is what we want.

- actually use the `plat` value from the build matrix in the aws call

- use `plat` value for upload artifacts as well