### PR TITLE
github: more authorised token for annotations

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,28 @@
+# Copyright 2024, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+# Theory Linter action
+
+name: Lint
+
+# needs pull_request_target trigger for more authority on GITHUB_TOKEN when PR
+# originates on a fork
+on: [pull_request_target]
+
+jobs:
+  thylint:
+    name: 'Theory Linter'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: seL4/ci-actions/thylint@master
+      with:
+        token: ${{ secrets.READ_TOKEN }}
+        pr_num: ${{ github.event.pull_request.number }}
+    - uses: yuzutech/annotations-action@v0.5.0
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        title: 'File annotations for theory linter'
+        input: './annotations.json'
+      continue-on-error: true
+      if: always()

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -40,21 +40,3 @@ jobs:
     - uses: seL4/ci-actions/style@master
       with:
         token: ${{ secrets.READ_TOKEN }}
-
-  thylint:
-    name: 'Theory Linter'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      checks: write
-    steps:
-    - uses: seL4/ci-actions/thylint@master
-      with:
-        token: ${{ secrets.READ_TOKEN }}
-    - uses: yuzutech/annotations-action@v0.5.0
-      with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        title: 'File annotations for theory linter'
-        input: './annotations.json'
-      continue-on-error: true
-      if: always()


### PR DESCRIPTION
`GITHUB_TOKEN` only has read access when triggered from a fork on the pull_request trigger, so we use `pull_request_target` instead. This requires passing in the PR number explicitly to the thylint action.

Requires https://github.com/seL4/ci-actions/pull/354 to be merged before we can test it.