### PR TITLE
fix leftover typos and tweaks from #773

### DIFF
--- a/proof/crefine/AARCH64/Finalise_C.thy
+++ b/proof/crefine/AARCH64/Finalise_C.thy
@@ -965,7 +965,7 @@ lemma unbindMaybeNotification_ccorres:
 
 (* On ARM, irqInvalid is 2^16-1 (i.e. -1 in 16-bit), which, by type, is always greater than maxIRQ *)
 (* This means we could remove the cirq \<noteq> irqInvalid part in the Some clause. Currently left in for
-   proof convencience *)
+   proof convenience *)
 definition irq_opt_relation :: "irq option \<Rightarrow> machine_word \<Rightarrow> bool" where
   "irq_opt_relation airq cirq \<equiv>
      case airq of

--- a/proof/crefine/ARM/Finalise_C.thy
+++ b/proof/crefine/ARM/Finalise_C.thy
@@ -929,7 +929,7 @@ lemma unbindMaybeNotification_ccorres:
 
 (* On ARM, irqInvalid is 2^16-1 (i.e. -1 in 16-bit), which, by type, is always greater than maxIRQ *)
 (* This means we could remove the cirq \<noteq> irqInvalid part in the Some clause. Currently left in for
-   proof convencience *)
+   proof convenience *)
 definition irq_opt_relation :: "irq option \<Rightarrow> machine_word \<Rightarrow> bool" where
   "irq_opt_relation airq cirq \<equiv>
      case airq of

--- a/proof/crefine/ARM_HYP/Finalise_C.thy
+++ b/proof/crefine/ARM_HYP/Finalise_C.thy
@@ -963,7 +963,7 @@ lemma unbindMaybeNotification_ccorres:
 
 (* On ARM, irqInvalid is 2^16-1 (i.e. -1 in 16-bit), which, by type, is always greater than maxIRQ *)
 (* This means we could remove the cirq \<noteq> irqInvalid part in the Some clause. Currently left in for
-   proof convencience *)
+   proof convenience *)
 definition irq_opt_relation :: "irq option \<Rightarrow> machine_word \<Rightarrow> bool" where
   "irq_opt_relation airq cirq \<equiv>
      case airq of

--- a/proof/crefine/ARM_HYP/Refine_C.thy
+++ b/proof/crefine/ARM_HYP/Refine_C.thy
@@ -274,7 +274,7 @@ lemma handleSyscall_ccorres:
                  apply (subst ccorres_seq_skip'[symmetric])
                  apply (rule ccorres_split_nothrow_novcg)
                      apply (rule_tac R=\<top> and xf=xfdc in ccorres_when)
-                      apply (case_tac rv; clarsimp simp: irq_type_never_invalid)
+                      apply (auto simp: irq_type_never_invalid split: option.splits)[1]
                      apply (ctac (no_vcg) add: handleInterrupt_ccorres)
                     apply ceqv
                    apply (rule_tac r=dc and xf=xfdc in ccorres_returnOk_skip[unfolded returnOk_def,simplified])
@@ -303,7 +303,7 @@ lemma handleSyscall_ccorres:
                 apply (rule ccorres_split_nothrow_novcg)
                     apply (rule ccorres_Guard)?
                     apply (rule_tac R=\<top> and xf=xfdc in ccorres_when)
-                     apply (case_tac rv; clarsimp simp: irq_type_never_invalid)
+                     apply (auto simp: irq_type_never_invalid split: option.splits)[1]
                     apply (ctac (no_vcg) add: handleInterrupt_ccorres)
                    apply ceqv
                   apply (rule_tac ccorres_returnOk_skip[unfolded returnOk_def,simplified])
@@ -331,7 +331,7 @@ lemma handleSyscall_ccorres:
                apply (rule ccorres_split_nothrow_novcg)
                    apply (rule ccorres_Guard)?
                    apply (rule_tac R=\<top> and xf=xfdc in ccorres_when)
-                   apply (case_tac rv; clarsimp simp: irq_type_never_invalid)
+                   apply (auto simp: irq_type_never_invalid split: option.splits)[1]
                   apply (ctac (no_vcg) add: handleInterrupt_ccorres)
                   apply ceqv
                  apply (rule_tac ccorres_returnOk_skip[unfolded returnOk_def,simplified])

--- a/spec/abstract/X64/ArchInterrupt_A.thy
+++ b/spec/abstract/X64/ArchInterrupt_A.thy
@@ -32,7 +32,7 @@ end
 
 context begin interpretation Arch .
 
-(* On Arm architectures, maxIRQ is defined in Kernel_Config. On RISCV64 it is defined manually. *)
+(* On Arm architectures, maxIRQ is defined in Kernel_Config. On X64 it is defined manually. *)
 requalify_consts
   maxIRQ
 

--- a/spec/design/skel/AARCH64/ArchInterrupt_H.thy
+++ b/spec/design/skel/AARCH64/ArchInterrupt_H.thy
@@ -15,10 +15,6 @@ begin
 
 context Arch begin global_naming AARCH64_H
 
-(* Kernel_Config provides a generic numeral, Haskell expects type irq *)
-abbreviation (input) maxIRQ :: irq where
-  "maxIRQ == Kernel_Config.maxIRQ"
-
 #INCLUDE_HASKELL SEL4/Object/Interrupt/AARCH64.hs CONTEXT AARCH64_H bodies_only ArchInv= Arch= NOT plic_complete_claim
 
 end

--- a/spec/design/skel/ARM/ArchInterrupt_H.thy
+++ b/spec/design/skel/ARM/ArchInterrupt_H.thy
@@ -15,10 +15,6 @@ begin
 
 context Arch begin global_naming ARM_H
 
-(* Kernel_Config provides a generic numeral, Haskell expects type irq *)
-abbreviation (input) maxIRQ :: irq where
-  "maxIRQ == Kernel_Config.maxIRQ"
-
 #INCLUDE_HASKELL SEL4/Object/Interrupt/ARM.lhs Arch= CONTEXT ARM_H bodies_only ArchInv=
 
 end

--- a/spec/design/skel/ARM_HYP/ArchInterrupt_H.thy
+++ b/spec/design/skel/ARM_HYP/ArchInterrupt_H.thy
@@ -15,10 +15,6 @@ begin
 
 context Arch begin global_naming ARM_HYP_H
 
-(* Kernel_Config provides a generic numeral, Haskell expects type irq *)
-abbreviation (input) maxIRQ :: irq where
-  "maxIRQ == Kernel_Config.maxIRQ"
-
 #INCLUDE_HASKELL SEL4/Object/Interrupt/ARM.lhs Arch= CONTEXT ARM_HYP_H bodies_only ArchInv= NOT initInterruptController
 
 definition initInterruptController :: "unit kernel"


### PR DESCRIPTION
- fix typos
- remove duplicate abbreviation
- reduce diff between ARM and ARM_HYP

Addressing final comments from #773 