### PR TITLE
github: remove rt branch test; switch to mcs-devel.xml

### DIFF
--- a/.github/workflows/proof.yml
+++ b/.github/workflows/proof.yml
@@ -9,8 +9,6 @@ on:
     paths-ignore:
       - '**.md'
       - '**.txt'
-    branches:
-      - rt
   # this action needs access to secrets.
   # The actual test runs in a no-privilege VM, so it's Ok to run on untrusted PRs.
   pull_request_target:
@@ -41,7 +39,7 @@ jobs:
         L4V_ARCH: ${{ matrix.arch }}
         NUM_DOMAINS: ${{ inputs.NUM_DOMAINS }}
         L4V_FEATURES: MCS
-        manifest: mcs.xml
+        manifest: mcs-devel.xml
         skip_dups: true
         session: '-x AutoCorresSEL4' # exclude large AutoCorresSEL4 session for PRs
         token: ${{ secrets.READ_TOKEN }}


### PR DESCRIPTION
- switch off the rt branch test -- to be added to the deployment workflow later (via merge from master)
- switch the PR test to the mcs-devel.xml manifest which is taking the role devel.xml has on the master branch

This will still use the fixed seL4 revision the mcs-devel manifest, but that revision can now be bumped with the `bump-ver-manifest` script, and in the future will also receive pre-process equivalent updates.