### PR TITLE
Update arch-split doc; rename arch_split->arch-split

### DIFF
--- a/docs/arch-split.md
+++ b/docs/arch-split.md
@@ -111,7 +111,7 @@ theory Retype_R
 imports VSpace_R
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma placeNewObject_def2:
  "placeNewObject ptr val gb = createObjects' ptr 1 (injectKO val) gb"
@@ -199,7 +199,7 @@ architecture. If we saw such a reference in a generic theory, we would
 immediately recognise that something was wrong.
 
 The convention is that in architecture-specific theories, we initially
-give *all* types, constants and lemmas with the architecture-specific
+give *all* types, constants and lemmas the architecture-specific
 `arch_global_naming` scheme. Then, in generic theories, we use
 *requalification* to selectively extract just those types, constants and
 facts which are expected to exist on all architectures.
@@ -339,7 +339,7 @@ available unqualified until the end of the context block. Indeed, in this case,
 the only purpose of the anonymous context block is to limit the scope of this
 `interpretation`.
 
-Note: It is critical to the success of arch_split that we *never* interpret the
+Note: It is critical to the success of arch-split that we *never* interpret the
 Arch locale, *except* inside an appropriate context block.
 
 In a generic theory, we typically only interpret the Arch locale to keep
@@ -770,7 +770,7 @@ will only ever look at the heap, so this proof will always work.
 
 There are some considerations when using this strategy:
 
-1. We use the Arch locale without a `global_naming`, as its performance better
+1. We use the Arch locale without `global_naming`, as its performance is better
    than entering the Arch locale and proving the lemma there. This means its
    qualified name will be `Arch.valid_arch_cap_pspaceI`, but this is acceptable
    since:
@@ -869,7 +869,7 @@ The workflow:
     intra-theory dependencies" above.
 
 - Look in the generic theory for a block of the form
-  `context Arch begin (* FIXME: arch_split *) ... end`.
+  `context Arch begin (* FIXME: arch-split *) ... end`.
 
   - These indicate things that we've previously classified as belonging in an
     arch-specific theory.
@@ -881,7 +881,7 @@ The workflow:
 - Look for subsequent breakage in the generic theory.
 
   - If this is in a subsequent Arch block (`context Arch begin (* FIXME:
-    arch_split *) ... end`), just move that block.
+    arch-split *) ... end`), just move that block.
 
   - Otherwise, if it's not obvious what to do, have a conversation with someone.
     We'll add more tips here as the process becomes clearer.

--- a/docs/arch-split.md
+++ b/docs/arch-split.md
@@ -151,11 +151,12 @@ want to prevent, however, inadvertent references to types, constants and facts
 which are only internal to a particular architecture (e.g. definitions of
 constants).
 
-To help achieve this hiding, we provide a custom command, **global_naming**,
-that modifies the way qualified names are generated. The primary use of
-`global_naming` is in architecture-specific theories, to ensure that by default,
-types, constants and lemmas are given an architecture-specific qualified name,
-even though they are part of the Arch locale.
+To help achieve this hiding, we provide the custom commands **global_naming**
+and **arch_global_naming**, which modify the way qualified names are generated.
+The primary use of these commands is in architecture-specific theories, to
+ensure that by default, types, constants and lemmas are given an
+architecture-specific qualified name, even though they are part of the Arch
+locale.
 
 - `l4v/proof/invariant-abstract/ARM/ArchADT_AI.thy`
 
@@ -169,6 +170,12 @@ begin
 
 context Arch begin global_naming ARM
 definition "get_pd_of_thread ≡ ..."
+end
+
+(* the more convenient and preferred way to achieve the above when L4V_ARCH=ARM
+   is to use arch_global_naming, spiritually equivalent to `global_naming $L4V_ARCH` *)
+context Arch begin arch_global_naming
+(* ... *)
 end
 
 (* Back in the global context, we can't refer to these names without naming a particular architecture! *)
@@ -192,8 +199,8 @@ architecture. If we saw such a reference in a generic theory, we would
 immediately recognise that something was wrong.
 
 The convention is that in architecture-specific theories, we initially
-give *all* types, constants and lemmas with an architecture-specific
-`global_naming` scheme. Then, in generic theories, we use
+give *all* types, constants and lemmas with the architecture-specific
+`arch_global_naming` scheme. Then, in generic theories, we use
 *requalification* to selectively extract just those types, constants and
 facts which are expected to exist on all architectures.
 
@@ -204,8 +211,13 @@ We provide three custom commands for giving existing names new bindings
 in the global namespace: **requalify_types**, **requalify_consts**,
 **requalify_facts**, for types, constants and facts respectively. The
 new name is based on the context in which the requalification command is
-executed. We use requalification in various ways, depending on the
-situation.
+executed. As with `global_naming`, we provide `L4V_ARCH`-aware versions of
+these commands: **arch_requalify_types**, **arch_requalify_consts** and
+**arch_requalify_types**.
+
+To understand how these commands function, see `lib/test/Requalify_Test.thy`.
+
+We use requalification in various ways, depending on the situation.
 
 The most basic use is to take a name from the Arch context and make it
 available in the global context without qualification. This should be
@@ -220,11 +232,73 @@ done for any type, constant or fact:
    type, constant or fact, so that the unqualified name unambiguously denotes
    the architecture-specific concept for the current architecture.
 
-Note: the `requalify_*` commands will warn when the unqualified name is already
-available in the global context (see: Dealing with name clashes). To suppress
-this warning, pass `(aliasing)` as the first parameter.
+Note: the `[arch_]requalify_*` commands will warn when the unqualified name is
+already available in the global context (see: Dealing with name clashes). To
+suppress this warning, pass `(aliasing)` as the first parameter.
 
-We do this in a generic theory:
+
+### Requalifying in practice
+
+Let's use the generic theory `l4v/proof/invariant-abstract/ADT_AI.thy` as an
+example:
+
+```isabelle
+theory ADT_AI
+imports
+  "./$L4V_ARCH/ArchADT_AI"
+begin
+
+term empty_context (* Free variable. *)
+```
+
+The constant `empty_context` is not visible in the theory scope, as it was
+defined inside the Arch locale, likely with `arch_global_naming`, thus visible
+as (for example) `ARM.empty_context`. We want to make this constant available
+to generic proofs. The obvious way to do this is:
+
+```isabelle
+requalify_consts ARM.empty_context (* avoid: can only be done in Arch theories *)
+```
+
+Unfortunately, on another platforms such as RISCV64, the constant will have a
+different qualified name. We can instead appeal to `L4V_ARCH` again, since we
+already rely on it to select the correct theories for the current architecture:
+
+```isabelle
+arch_requalify_consts empty_context (* preferred *)
+
+(* The requalified constant is now available unqualified in the global context. *)
+term empty_context
+
+(* However, its definition is not. *)
+thm empty_context_def (* ERROR *)
+```
+
+In some cases, consts/types/facts may be thrown into the `Arch` context without
+further qualification. In such cases, normal requalification may be used:
+
+```isabelle
+requalify_consts Arch.empty_context (* standard locale version, likely due to missing global_naming *)
+```
+
+
+### Requalifying inside "Arch" theories
+
+While requalifying inside `Arch*` theories is possible, as seen above, it
+requires duplicating the requalify command(s) on every architecture, and so
+should be avoided. However, it is not always possible to conveniently do so,
+particularly when defining constants inside `Arch`, then having to use those
+constants to instantiate locales, before heading back into the `Arch` context.
+
+
+### Requalifying via interpretation (slow)
+
+Using `arch_requalify_*` commands still implicitly appeals to the name of the
+architecture while in a generic theory. This has the advantage of being fast and
+thus is preferred, but we describe the old interpretation method here for
+reference (for dealing with older theories or older repository versions).
+
+We can do this in a generic theory:
 
 - `l4v/proof/invariant-abstract/ADT_AI.thy`
 
@@ -268,38 +342,12 @@ the only purpose of the anonymous context block is to limit the scope of this
 Note: It is critical to the success of arch_split that we *never* interpret the
 Arch locale, *except* inside an appropriate context block.
 
-In a generic theory, we typically only interpret the Arch locale:
+In a generic theory, we typically only interpret the Arch locale to keep
+existing proofs checking until we find time to factor out the
+architecture-dependent parts. The `.` in `context begin interpretation Arch .`
+in the middle of AInvs takes 7.5s, so repeated use of this technique should be
+avoided when possible.
 
-- to requalify names with no qualifier, or
-
-- to keep existing proofs checking until we find time to factor out the
-  architecture-dependent parts.
-
-
-### Unconventional requalification shortcut
-
-While the expected convention is to perform requalify commands in the generic
-theory as described above, there exists a shortcut for doing so in
-architecture-specific theories when outside the Arch context:
-
-```isabelle
-requalify_facts
-  ARM.user_mem_dom_cong
-
-thm user_mem_dom_cong      (* ok *)
-thm ARM.user_mem_dom_cong  (* ok *)
-thm Arch.user_mem_dom_cong (* ERROR *)
-```
-
-This immediately makes the fact available in the global context. While it is a
-violation of expected conventions and needs to be repeated in every
-arch-specific theory file, there is one important difference:
-* the `.` in `context begin interpretation Arch .` in the middle of AInvs takes 7.5s
-* `requalify_facts` in the global context is nearly instant (even for
-multiple facts).
-
-This disparity will only get worse as the Arch context grows bigger, and
-might indicate the need for some alternative functionality.
 
 
 ### Requalifying into the Arch locale
@@ -319,10 +367,12 @@ thm ARM.user_mem_dom_cong  (* ok *)
 thm Arch.user_mem_dom_cong (* ok *)
 ```
 
-This functionality can be useful when we want to give an architecture-specific
-constant/type/fact a generic name, but not mix it with generic namespace (see
-also Dealing with name clashes, as this affects lookup order inside
-interpretations).
+Generally, we want to avoid unprefixed names in the Arch locale, preferring to
+use a `global_naming` to generate a prefix instead. However, when the generic
+and arch-specific short names are identical, this functionality allows giving
+an architecture-specific constant/type/fact a generic name while not mixing it
+with generic namespace (see also "Dealing with name clashes", as this affects
+lookup order inside interpretations).
 
 One can target any locale in this fashion, although the usefulness to arch-split
 is then decreased, since short names might not be visible past a naming prefix:
@@ -444,7 +494,16 @@ Haskell specs. We use `ARM` everywhere else. This means that the arch-specific
 references only require either an `ARM_A` or `ARM_H` qualifier. No theory
 qualifier is required, and the result is more robust to theory reorganisation.
 
-In the future, when we are properly splitting the refinement proofs, we will may
+Requalification of consts/types/facts from these prefixes should be done as
+follows:
+
+```isabelle
+arch_requalify_const some_const (* requalifies ARM.some_const *)
+arch_requalify_const (A) some_const (* requalifies ARM_A.some_const *)
+arch_requalify_const (H) some_const (* requalifies ARM_H.some_const *)
+```
+
+In the future, when we are properly splitting the refinement proofs, we may
 want to extend this approach by introducing `Arch_A` and `Arch_H`
 `global_naming` schemes to disambiguate overloaded requalified names.
 
@@ -685,6 +744,39 @@ While strictly speaking, there is no requirement that `Foo_AI_2` includes
 proved to be instantly available in case it's needed in the proof chain. This
 generates limited duplication: a fact from `Foo_AI_1` will be duplicated in
 `Foo_AI_2`, but not in `Foo_AI_3+`.
+
+
+### Temporarily proving a fact in the Arch locale
+
+The concept of "generic consequences of architecture-specific properties" shows
+up in a few places. Normally, as outlined above, we prefer either exporting
+enough facts to prove the property in the generic context or requiring the
+property as a locale assumption. However, sometimes we end up in a situation
+where the same proof will work on all architectures and spelling it out with
+locale assumptions is inconvenient. For example (from `Invariants_AI`):
+
+```isabelle
+(* generic consequence of architecture-specific details *)
+lemma (in Arch) valid_arch_cap_pspaceI:
+  "⟦ valid_arch_cap acap s; kheap s = kheap s' ⟧ ⟹ valid_arch_cap acap s'"
+  unfolding valid_arch_cap_def
+  by (auto intro: obj_at_pspaceI split: arch_cap.split)
+
+requalify_facts Arch.valid_arch_cap_pspaceI
+```
+
+In this case, no matter what the architecture, the `valid_arch_cap` function
+will only ever look at the heap, so this proof will always work.
+
+There are some considerations when using this strategy:
+
+1. We use the Arch locale without a `global_naming`, as its performance better
+   than entering the Arch locale and proving the lemma there. This means its
+   qualified name will be `Arch.valid_arch_cap_pspaceI`, but this is acceptable
+   since:
+2. The lemma is immediately requalified into the generic context, so we never
+   really want to use its qualified name again.
+3. This technique is rarely used, *use sparingly*!
 
 
 ## Qualifying non-locale-compatible commands

--- a/proof/access-control/ARM/ArchIpc_AC.thy
+++ b/proof/access-control/ARM/ArchIpc_AC.thy
@@ -192,7 +192,7 @@ declare arch_get_sanitise_register_info_inv[Ipc_AC_assms]
 end
 
 
-context is_extended begin interpretation Arch . (*FIXME: arch_split*)
+context is_extended begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma list_integ_lift_in_ipc[Ipc_AC_assms]:
   assumes li:

--- a/proof/access-control/ARM/ExampleSystem.thy
+++ b/proof/access-control/ARM/ExampleSystem.thy
@@ -8,7 +8,7 @@ theory ExampleSystem
 imports ArchAccess_AC
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition
   nat_to_bl :: "nat \<Rightarrow> nat \<Rightarrow> bool list option"

--- a/proof/access-control/RISCV64/ExampleSystem.thy
+++ b/proof/access-control/RISCV64/ExampleSystem.thy
@@ -8,7 +8,7 @@ theory ExampleSystem
 imports ArchAccess_AC
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition
   nat_to_bl :: "nat \<Rightarrow> nat \<Rightarrow> bool list option"

--- a/proof/bisim/Syscall_S.thy
+++ b/proof/bisim/Syscall_S.thy
@@ -8,7 +8,7 @@ theory Syscall_S
 imports Separation
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma syscall_bisim:
   assumes bs:

--- a/proof/crefine/AARCH64/ADT_C.thy
+++ b/proof/crefine/AARCH64/ADT_C.thy
@@ -220,7 +220,7 @@ end
 consts
   Init_C' :: "unit observable \<Rightarrow> cstate global_state set"
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition "Init_C \<equiv> \<lambda>((tc,s),m,e). Init_C' ((tc, truncate_state s),m,e)"
 
@@ -345,7 +345,7 @@ lemma cint_rel_to_H:
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition
   "cstate_to_machine_H s \<equiv>
@@ -630,7 +630,7 @@ lemma carch_state_to_H_correct:
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma tcb_queue_rel_unique:
   "hp NULL = None \<Longrightarrow>

--- a/proof/crefine/AARCH64/Arch_C.thy
+++ b/proof/crefine/AARCH64/Arch_C.thy
@@ -12,7 +12,7 @@ begin
 
 unbundle l4v_word_context
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 crunch unmapPageTable
   for gsMaxObjectSize[wp]: "\<lambda>s. P (gsMaxObjectSize s)"

--- a/proof/crefine/AARCH64/CLevityCatch.thy
+++ b/proof/crefine/AARCH64/CLevityCatch.thy
@@ -73,7 +73,7 @@ qed
 (* end holding area *)
 
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 (* Short-hand for  unfolding cumbersome machine constants *)
 (* FIXME MOVE these should be in refine, and the _eq forms should NOT be declared [simp]! *)

--- a/proof/crefine/AARCH64/DetWP.thy
+++ b/proof/crefine/AARCH64/DetWP.thy
@@ -9,7 +9,7 @@ theory DetWP
 imports "Lib.DetWPLib" "CBaseRefine.Include_C"
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma det_wp_doMachineOp [wp]:
   "det_wp (\<lambda>_. P) f \<Longrightarrow> det_wp (\<lambda>_. P) (doMachineOp f)"

--- a/proof/crefine/AARCH64/Fastpath_C.thy
+++ b/proof/crefine/AARCH64/Fastpath_C.thy
@@ -17,7 +17,7 @@ imports
   "CLib.MonadicRewrite_C"
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma setCTE_obj_at'_queued:
   "\<lbrace>obj_at' (\<lambda>tcb. P (tcbQueued tcb)) t\<rbrace> setCTE p v \<lbrace>\<lambda>rv. obj_at' (\<lambda>tcb. P (tcbQueued tcb)) t\<rbrace>"

--- a/proof/crefine/AARCH64/Fastpath_Defs.thy
+++ b/proof/crefine/AARCH64/Fastpath_Defs.thy
@@ -15,7 +15,7 @@ theory Fastpath_Defs
 imports ArchMove_C
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition
  "fastpaths sysc \<equiv> case sysc of

--- a/proof/crefine/AARCH64/Fastpath_Equiv.thy
+++ b/proof/crefine/AARCH64/Fastpath_Equiv.thy
@@ -45,7 +45,7 @@ lemma setCTE_tcbContext:
   apply (rule setObject_cte_obj_at_tcb', simp_all)
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma setThreadState_tcbContext:
  "setThreadState st tptr \<lbrace>obj_at' (\<lambda>tcb. P ((atcbContextGet o tcbArch) tcb)) t\<rbrace>"

--- a/proof/crefine/AARCH64/Invoke_C.thy
+++ b/proof/crefine/AARCH64/Invoke_C.thy
@@ -1382,7 +1382,7 @@ lemma decodeCNodeInvocation_ccorres:
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemmas setCTE_def3 = setCTE_def2[THEN eq_reflection]
 

--- a/proof/crefine/AARCH64/Ipc_C.thy
+++ b/proof/crefine/AARCH64/Ipc_C.thy
@@ -14,7 +14,7 @@ imports
   IsolatedThreadAction
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition
   "replyFromKernel_success_empty thread \<equiv> do
@@ -292,7 +292,7 @@ lemma ccap_relation_reply_helpers:
                      cap_reply_cap_lift_def word_size
               elim!: ccap_relationE)
 
-(*FIXME: arch_split: C kernel names hidden by Haskell names *)
+(*FIXME: arch-split: C kernel names hidden by Haskell names *)
 (*FIXME: fupdate simplification issues for 2D arrays *)
 abbreviation "syscallMessageC \<equiv>  kernel_all_global_addresses.fault_messages.[unat MessageID_Syscall]"
 lemmas syscallMessageC_def = kernel_all_substitute.fault_messages_def
@@ -315,7 +315,7 @@ lemma syscallMessage_ccorres:
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition
   "handleArchFaultReply' f sender receiver tag \<equiv>
@@ -1041,7 +1041,7 @@ lemma setMR_ccorres_dc:
 end
 
 (* FIXME: move *)
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 crunch setMR
   for valid_pspace'[wp]: "valid_pspace'"
 crunch setMR

--- a/proof/crefine/AARCH64/IsolatedThreadAction.thy
+++ b/proof/crefine/AARCH64/IsolatedThreadAction.thy
@@ -156,7 +156,7 @@ lemma partial_overwrite_fun_upd:
   apply (clarsimp split: if_split)
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma get_tcb_state_regs_ko_at':
   "ko_at' ko p s \<Longrightarrow> get_tcb_state_regs (ksPSpace s p)
@@ -1349,7 +1349,7 @@ lemma bind_assoc:
      = do x \<leftarrow> m; y \<leftarrow> f x; g y od"
   by (rule bind_assoc)
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma setObject_modify_assert:
   "\<lbrakk> updateObject v = updateObject_default v \<rbrakk>

--- a/proof/crefine/AARCH64/Recycle_C.thy
+++ b/proof/crefine/AARCH64/Recycle_C.thy
@@ -533,7 +533,7 @@ lemma heap_to_user_data_in_user_mem'[simp]:
       apply simp+
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma setObject_asidpool_gs[wp]:
   "setObject ptr (vcpu::asidpool) \<lbrace>\<lambda>s. P (gsMaxObjectSize s)\<rbrace>"

--- a/proof/crefine/AARCH64/Retype_C.thy
+++ b/proof/crefine/AARCH64/Retype_C.thy
@@ -41,7 +41,7 @@ lemma zero_le_sint: "\<lbrakk> 0 \<le> (a :: machine_word); a < 0x80000000000000
   apply simp
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma map_option_byte_to_word_heap:
   assumes disj: "\<And>(off :: 9 word) x. x<8 \<Longrightarrow> p + ucast off * 8 + x \<notin> S " (*9=page table index*)
@@ -7833,7 +7833,7 @@ lemma APIType_capBits_min:
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma createNewCaps_1_gsCNodes_p:
   "\<lbrace>\<lambda>s. P (gsCNodes s p) \<and> p \<noteq> ptr\<rbrace> createNewCaps newType ptr 1 n dev\<lbrace>\<lambda>rv s. P (gsCNodes s p)\<rbrace>"

--- a/proof/crefine/AARCH64/SR_lemmas_C.thy
+++ b/proof/crefine/AARCH64/SR_lemmas_C.thy
@@ -12,7 +12,7 @@ imports
   "Refine.Invariants_H"
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 section "vm rights"
 

--- a/proof/crefine/AARCH64/Schedule_C.thy
+++ b/proof/crefine/AARCH64/Schedule_C.thy
@@ -12,7 +12,7 @@ begin
 
 instance tcb              :: no_vcpu by intro_classes auto
 
-(*FIXME: arch_split: move up?*)
+(*FIXME: arch-split: move up?*)
 context Arch begin
 context begin global_naming global
 requalify_facts

--- a/proof/crefine/AARCH64/StateRelation_C.thy
+++ b/proof/crefine/AARCH64/StateRelation_C.thy
@@ -10,7 +10,7 @@ theory StateRelation_C
 imports Wellformed_C
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition
   "lifth p s \<equiv> the (clift (t_hrs_' s) p)"
@@ -81,7 +81,7 @@ text \<open>
   which can subsequently be instantiated for
   @{text kernel_all_global_addresses} as well as @{text kernel_all_substitute}.
 \<close>
-locale state_rel = Arch + substitute_pre + (*FIXME: arch_split*)
+locale state_rel = Arch + substitute_pre + (*FIXME: arch-split*)
   fixes armKSKernelVSpace_C :: "machine_word \<Rightarrow> arm_vspace_region_use"
 
 locale kernel = kernel_all_substitute + state_rel
@@ -133,7 +133,7 @@ definition carch_state_relation :: "Arch.kernel_state \<Rightarrow> globals \<Ri
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition
   cmachine_state_relation :: "machine_state \<Rightarrow> globals \<Rightarrow> bool"
@@ -709,7 +709,7 @@ where
            ((\<not> (d \<le> maxDomain \<and> i < l2BitmapSize))
             \<longrightarrow>  abitmap2 (d, i) = 0)"
 
-end (* interpretation Arch . (*FIXME: arch_split*) *)
+end (* interpretation Arch . (*FIXME: arch-split*) *)
 
 definition
    region_is_bytes' :: "machine_word \<Rightarrow> nat \<Rightarrow> heap_typ_desc \<Rightarrow> bool"

--- a/proof/crefine/AARCH64/SyscallArgs_C.thy
+++ b/proof/crefine/AARCH64/SyscallArgs_C.thy
@@ -13,13 +13,13 @@ imports
   StoreWord_C  DetWP
 begin
 
-(*FIXME: arch_split: C kernel names hidden by Haskell names *)
+(*FIXME: arch-split: C kernel names hidden by Haskell names *)
 context kernel_m begin
 abbreviation "msgRegistersC \<equiv> kernel_all_substitute.msgRegisters"
 lemmas msgRegistersC_def = kernel_all_substitute.msgRegisters_def
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 declare word_neq_0_conv[simp del]
 
@@ -1201,7 +1201,7 @@ lemma getSyscallArg_ccorres_foo:
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma invocation_eq_use_type:
   "\<lbrakk> value \<equiv> (value' :: 32 signed word);

--- a/proof/crefine/AARCH64/Syscall_C.thy
+++ b/proof/crefine/AARCH64/Syscall_C.thy
@@ -15,7 +15,7 @@ imports
   Arch_C
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 crunch replyFromKernel
   for sch_act_wf[wp]: "\<lambda>s. sch_act_wf (ksSchedulerAction s) s"
 end

--- a/proof/crefine/AARCH64/Tcb_C.thy
+++ b/proof/crefine/AARCH64/Tcb_C.thy
@@ -59,7 +59,7 @@ lemma doMachineOp_sched:
   apply fastforce
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 crunch restart
   for curThread[wp]: "\<lambda>s. P (ksCurThread s)"
   (wp: crunch_wps simp: crunch_simps)
@@ -1105,7 +1105,7 @@ lemma Arch_performTransfer_ccorres:
      apply simp+
   done
 
-(*FIXME: arch_split: C kernel names hidden by Haskell names *)
+(*FIXME: arch-split: C kernel names hidden by Haskell names *)
 abbreviation "frameRegistersC \<equiv> kernel_all_substitute.frameRegisters"
 lemmas frameRegistersC_def = kernel_all_substitute.frameRegisters_def
 abbreviation "gpRegistersC \<equiv> kernel_all_substitute.gpRegisters"

--- a/proof/crefine/AARCH64/VSpace_C.thy
+++ b/proof/crefine/AARCH64/VSpace_C.thy
@@ -19,7 +19,7 @@ autocorres
     c_locale = kernel_all_substitute
   ] "../c/build/$L4V_ARCH/kernel_all.c_pp"
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma ccorres_name_pre_C:
   "(\<And>s. s \<in> P' \<Longrightarrow> ccorres_underlying sr \<Gamma> r xf arrel axf P {s} hs f g)

--- a/proof/crefine/AARCH64/Wellformed_C.thy
+++ b/proof/crefine/AARCH64/Wellformed_C.thy
@@ -15,7 +15,7 @@ imports
   "CSpec.Substitute"
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 (* Takes an address and ensures it can be given to a function expecting a canonical address.
    Canonical addresses on 64-bit machines aren't really 64-bit, due to bus sizes. Hence, structures
@@ -303,7 +303,7 @@ record cte_CL =
   cap_CL :: cap_CL
   cteMDBNode_CL :: mdb_node_CL
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition
   cte_lift :: "cte_C \<rightharpoonup> cte_CL"

--- a/proof/crefine/ARM/ADT_C.thy
+++ b/proof/crefine/ARM/ADT_C.thy
@@ -193,7 +193,7 @@ end
 consts
   Init_C' :: "unit observable \<Rightarrow> cstate global_state set"
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition "Init_C \<equiv> \<lambda>((tc,s),m,e). Init_C' ((tc, truncate_state s),m,e)"
 
@@ -320,7 +320,7 @@ lemma cint_rel_to_H:
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition
   "cstate_to_machine_H s \<equiv>
@@ -625,7 +625,7 @@ lemma (in kernel_m)  carch_state_to_H_correct:
   apply (fastforce simp: valid_asid_table'_def)
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma tcb_queue_rel_unique:
   "hp NULL = None \<Longrightarrow>

--- a/proof/crefine/ARM/Arch_C.thy
+++ b/proof/crefine/ARM/Arch_C.thy
@@ -9,7 +9,7 @@ theory Arch_C
 imports Recycle_C
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 crunch unmapPageTable
   for ctes_of[wp]: "\<lambda>s. P (ctes_of s)"
   (wp: crunch_wps simp: crunch_simps)

--- a/proof/crefine/ARM/CLevityCatch.thy
+++ b/proof/crefine/ARM/CLevityCatch.thy
@@ -13,7 +13,7 @@ imports
   Boolean_C
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 (* Rule previously in the simpset, now not. *)
 declare ptr_add_def' [simp]

--- a/proof/crefine/ARM/DetWP.thy
+++ b/proof/crefine/ARM/DetWP.thy
@@ -8,7 +8,7 @@ theory DetWP
 imports "Lib.DetWPLib" "CBaseRefine.Include_C"
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma det_wp_doMachineOp [wp]:
   "det_wp (\<lambda>_. P) f \<Longrightarrow> det_wp (\<lambda>_. P) (doMachineOp f)"

--- a/proof/crefine/ARM/Fastpath_C.thy
+++ b/proof/crefine/ARM/Fastpath_C.thy
@@ -17,7 +17,7 @@ imports
   "CLib.MonadicRewrite_C"
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma setCTE_obj_at'_queued:
   "\<lbrace>obj_at' (\<lambda>tcb. P (tcbQueued tcb)) t\<rbrace> setCTE p v \<lbrace>\<lambda>rv. obj_at' (\<lambda>tcb. P (tcbQueued tcb)) t\<rbrace>"

--- a/proof/crefine/ARM/Fastpath_Defs.thy
+++ b/proof/crefine/ARM/Fastpath_Defs.thy
@@ -15,7 +15,7 @@ theory Fastpath_Defs
 imports ArchMove_C
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition
  "fastpaths sysc \<equiv> case sysc of

--- a/proof/crefine/ARM/Fastpath_Equiv.thy
+++ b/proof/crefine/ARM/Fastpath_Equiv.thy
@@ -45,7 +45,7 @@ lemma setCTE_tcbContext:
   apply (rule setObject_cte_obj_at_tcb', simp_all)
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma setThreadState_tcbContext:
  "setThreadState st tptr \<lbrace>obj_at' (\<lambda>tcb. P ((atcbContextGet o tcbArch) tcb)) t\<rbrace>"

--- a/proof/crefine/ARM/Finalise_C.thy
+++ b/proof/crefine/ARM/Finalise_C.thy
@@ -1097,7 +1097,7 @@ lemma offset_xf_for_sequence:
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 crunch invalidateHWASIDEntry
   for pde_mappings'[wp]: "valid_pde_mappings'"
 end
@@ -1140,7 +1140,7 @@ lemma invalidateASIDEntry_ccorres:
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 crunch invalidateASIDEntry
   for obj_at'[wp]: "obj_at' P p"
 crunch flushSpace

--- a/proof/crefine/ARM/Invoke_C.thy
+++ b/proof/crefine/ARM/Invoke_C.thy
@@ -1371,7 +1371,7 @@ lemma decodeCNodeInvocation_ccorres:
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma setCTE_sch_act_wf[wp]:
   "\<lbrace> \<lambda>s. sch_act_wf (ksSchedulerAction s) s \<rbrace>

--- a/proof/crefine/ARM/Ipc_C.thy
+++ b/proof/crefine/ARM/Ipc_C.thy
@@ -13,7 +13,7 @@ imports
   IsolatedThreadAction
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition
   "replyFromKernel_success_empty thread \<equiv> do
@@ -275,7 +275,7 @@ lemma ccap_relation_reply_helpers:
                      cap_reply_cap_lift_def word_size
               elim!: ccap_relationE)
 
-(*FIXME: arch_split: C kernel names hidden by Haskell names *)
+(*FIXME: arch-split: C kernel names hidden by Haskell names *)
 (*FIXME: fupdate simplification issues for 2D arrays *)
 abbreviation "syscallMessageC \<equiv>  kernel_all_global_addresses.fault_messages.[unat MessageID_Syscall]"
 lemmas syscallMessageC_def = kernel_all_substitute.fault_messages_def
@@ -298,7 +298,7 @@ lemma syscallMessage_ccorres:
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition
   "handleArchFaultReply' f sender receiver tag \<equiv> do
@@ -883,7 +883,7 @@ lemma setMR_ccorres_dc:
 end
 
 (* FIXME: move *)
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 crunch setMR
   for valid_pspace'[wp]: "valid_pspace'"
 crunch setMR

--- a/proof/crefine/ARM/IsolatedThreadAction.thy
+++ b/proof/crefine/ARM/IsolatedThreadAction.thy
@@ -9,7 +9,7 @@ theory IsolatedThreadAction
 imports ArchMove_C
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 datatype tcb_state_regs =
   TCBStateRegs (tsrState : thread_state) (tsrContext : "MachineTypes.register \<Rightarrow> machine_word")
@@ -960,7 +960,7 @@ lemma bind_assoc:
      = do x \<leftarrow> m; y \<leftarrow> f x; g y od"
   by (rule bind_assoc)
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma setObject_modify_assert:
   "\<lbrakk> updateObject v = updateObject_default v \<rbrakk>

--- a/proof/crefine/ARM/PSpace_C.thy
+++ b/proof/crefine/ARM/PSpace_C.thy
@@ -8,7 +8,7 @@ theory PSpace_C
 imports Ctac_lemmas_C
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma setObject_obj_at_pre:
   "\<lbrakk> updateObject ko = updateObject_default ko;

--- a/proof/crefine/ARM/Recycle_C.thy
+++ b/proof/crefine/ARM/Recycle_C.thy
@@ -350,7 +350,7 @@ lemma heap_to_user_data_in_user_mem'[simp]:
       apply simp+
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 crunch invalidateTLBByASID
   for pde_mappings'[wp]: "valid_pde_mappings'"

--- a/proof/crefine/ARM/Refine_C.thy
+++ b/proof/crefine/ARM/Refine_C.thy
@@ -10,7 +10,7 @@ theory Refine_C
 imports Init_C Fastpath_Equiv Fastpath_C CToCRefine
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 crunch handleVMFault
   for ksQ[wp]: "\<lambda>s. P (ksReadyQueues s)"
   (ignore: getFAR getDFSR getIFSR)

--- a/proof/crefine/ARM/Retype_C.thy
+++ b/proof/crefine/ARM/Retype_C.thy
@@ -17,7 +17,7 @@ declare word_neq_0_conv [simp del]
 instance cte_C :: array_outer_max_size
   by intro_classes simp
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma map_option_byte_to_word_heap:
   assumes disj: "\<And>(off :: 10 word) x. x<4 \<Longrightarrow> p + ucast off * 4 + x \<notin> S "
@@ -4141,7 +4141,7 @@ lemma placeNewObject_pde:
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 end
 
 lemma dom_disj_union:
@@ -6356,7 +6356,7 @@ lemma APIType_capBits_min:
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma createNewCaps_1_gsCNodes_p:
   "\<lbrace>\<lambda>s. P (gsCNodes s p) \<and> p \<noteq> ptr\<rbrace> createNewCaps newType ptr 1 n dev\<lbrace>\<lambda>rv s. P (gsCNodes s p)\<rbrace>"

--- a/proof/crefine/ARM/SR_lemmas_C.thy
+++ b/proof/crefine/ARM/SR_lemmas_C.thy
@@ -10,7 +10,7 @@ imports
   "Refine.Invariants_H"
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 section "ctes"
 

--- a/proof/crefine/ARM/Schedule_C.thy
+++ b/proof/crefine/ARM/Schedule_C.thy
@@ -9,7 +9,7 @@ theory Schedule_C
 imports Tcb_C Detype_C
 begin
 
-(*FIXME: arch_split: move up?*)
+(*FIXME: arch-split: move up?*)
 context Arch begin
 context begin global_naming global
 requalify_facts

--- a/proof/crefine/ARM/StateRelation_C.thy
+++ b/proof/crefine/ARM/StateRelation_C.thy
@@ -8,7 +8,7 @@ theory StateRelation_C
 imports Wellformed_C
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition
   "lifth p s \<equiv> the (clift (t_hrs_' s) p)"
@@ -100,7 +100,7 @@ text \<open>
   which can subsequently be instantiated for
   @{text kernel_all_global_addresses} as well as @{text kernel_all_substitute}.
 \<close>
-locale state_rel = Arch + substitute_pre + (*FIXME: arch_split*)
+locale state_rel = Arch + substitute_pre + (*FIXME: arch-split*)
   fixes armKSKernelVSpace_C :: "machine_word \<Rightarrow> arm_vspace_region_use"
 
 locale kernel = kernel_all_substitute + state_rel
@@ -134,7 +134,7 @@ where
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition
   cmachine_state_relation :: "machine_state \<Rightarrow> globals \<Rightarrow> bool"

--- a/proof/crefine/ARM/SyscallArgs_C.thy
+++ b/proof/crefine/ARM/SyscallArgs_C.thy
@@ -12,13 +12,13 @@ imports
   StoreWord_C  DetWP
 begin
 
-(*FIXME: arch_split: C kernel names hidden by Haskell names *)
+(*FIXME: arch-split: C kernel names hidden by Haskell names *)
 context kernel_m begin
 abbreviation "msgRegistersC \<equiv> kernel_all_substitute.msgRegisters"
 lemmas msgRegistersC_def = kernel_all_substitute.msgRegisters_def
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 declare word_neq_0_conv[simp del]
 
@@ -1256,7 +1256,7 @@ lemma getSyscallArg_ccorres_foo:
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma invocation_eq_use_type:
   "\<lbrakk> value \<equiv> (value' :: 32 signed word);

--- a/proof/crefine/ARM/Syscall_C.thy
+++ b/proof/crefine/ARM/Syscall_C.thy
@@ -14,7 +14,7 @@ imports
   Arch_C
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 crunch replyFromKernel
   for sch_act_wf[wp]: "\<lambda>s. sch_act_wf (ksSchedulerAction s) s"
 end

--- a/proof/crefine/ARM/Tcb_C.thy
+++ b/proof/crefine/ARM/Tcb_C.thy
@@ -58,7 +58,7 @@ lemma doMachineOp_sched:
   apply fastforce
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 crunch restart
   for curThread[wp]: "\<lambda>s. P (ksCurThread s)"
@@ -1029,7 +1029,7 @@ lemma Arch_performTransfer_ccorres:
      apply simp+
   done
 
-(*FIXME: arch_split: C kernel names hidden by Haskell names *)
+(*FIXME: arch-split: C kernel names hidden by Haskell names *)
 abbreviation "frameRegistersC \<equiv> kernel_all_substitute.frameRegisters"
 lemmas frameRegistersC_def = kernel_all_substitute.frameRegisters_def
 abbreviation "gpRegistersC \<equiv> kernel_all_substitute.gpRegisters"

--- a/proof/crefine/ARM/VSpace_C.thy
+++ b/proof/crefine/ARM/VSpace_C.thy
@@ -1141,7 +1141,7 @@ lemma rf_sr_armKSNextASID:
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 crunch invalidateASID
   for armKSNextASID[wp]: "\<lambda>s. P (armKSNextASID (ksArchState s))"
@@ -1615,7 +1615,7 @@ lemma doFlush_ccorres:
   done
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 crunch setVMRootForFlush
   for gsMaxObjectSize[wp]: "\<lambda>s. P (gsMaxObjectSize s)"
   (wp: crunch_wps)
@@ -1860,7 +1860,7 @@ lemma flushPage_ccorres:
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 crunch flushPage
   for no_0_obj'[wp]: "no_0_obj'"
 end

--- a/proof/crefine/ARM/Wellformed_C.thy
+++ b/proof/crefine/ARM/Wellformed_C.thy
@@ -14,7 +14,7 @@ imports
   "CSpec.Substitute"
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 abbreviation
   cte_Ptr :: "word32 \<Rightarrow> cte_C ptr" where "cte_Ptr == Ptr"
@@ -232,7 +232,7 @@ record cte_CL =
   cap_CL :: cap_CL
   cteMDBNode_CL :: mdb_node_CL
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition
   cte_lift :: "cte_C \<rightharpoonup> cte_CL"

--- a/proof/crefine/ARM_HYP/ADT_C.thy
+++ b/proof/crefine/ARM_HYP/ADT_C.thy
@@ -213,7 +213,7 @@ end
 consts
   Init_C' :: "unit observable \<Rightarrow> cstate global_state set"
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition "Init_C \<equiv> \<lambda>((tc,s),m,e). Init_C' ((tc, truncate_state s),m,e)"
 
@@ -634,7 +634,7 @@ lemma (in kernel_m)  carch_state_to_H_correct:
   apply (fastforce simp: valid_asid_table'_def)
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma tcb_queue_rel_unique:
   "hp NULL = None \<Longrightarrow>

--- a/proof/crefine/ARM_HYP/Arch_C.thy
+++ b/proof/crefine/ARM_HYP/Arch_C.thy
@@ -11,7 +11,7 @@ begin
 
 unbundle l4v_word_context
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 crunch unmapPageTable
   for ctes_of[wp]: "\<lambda>s. P (ctes_of s)"
   (wp: crunch_wps simp: crunch_simps)

--- a/proof/crefine/ARM_HYP/CLevityCatch.thy
+++ b/proof/crefine/ARM_HYP/CLevityCatch.thy
@@ -13,7 +13,7 @@ imports
   Boolean_C
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 declare word_neq_0_conv [simp del]
 

--- a/proof/crefine/ARM_HYP/DetWP.thy
+++ b/proof/crefine/ARM_HYP/DetWP.thy
@@ -8,7 +8,7 @@ theory DetWP
 imports "Lib.DetWPLib" "CBaseRefine.Include_C"
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma det_wp_doMachineOp [wp]:
   "det_wp (\<lambda>_. P) f \<Longrightarrow> det_wp (\<lambda>_. P) (doMachineOp f)"

--- a/proof/crefine/ARM_HYP/Fastpath_C.thy
+++ b/proof/crefine/ARM_HYP/Fastpath_C.thy
@@ -17,7 +17,7 @@ imports
   "CLib.MonadicRewrite_C"
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma setCTE_obj_at'_queued:
   "\<lbrace>obj_at' (\<lambda>tcb. P (tcbQueued tcb)) t\<rbrace> setCTE p v \<lbrace>\<lambda>rv. obj_at' (\<lambda>tcb. P (tcbQueued tcb)) t\<rbrace>"

--- a/proof/crefine/ARM_HYP/Fastpath_Defs.thy
+++ b/proof/crefine/ARM_HYP/Fastpath_Defs.thy
@@ -15,7 +15,7 @@ theory Fastpath_Defs
 imports ArchMove_C
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition
  "fastpaths sysc \<equiv> case sysc of

--- a/proof/crefine/ARM_HYP/Fastpath_Equiv.thy
+++ b/proof/crefine/ARM_HYP/Fastpath_Equiv.thy
@@ -45,7 +45,7 @@ lemma setCTE_tcbContext:
   apply (rule setObject_cte_obj_at_tcb', simp_all)
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma setThreadState_tcbContext:
  "setThreadState st tptr \<lbrace>obj_at' (\<lambda>tcb. P ((atcbContextGet o tcbArch) tcb)) t\<rbrace>"

--- a/proof/crefine/ARM_HYP/Finalise_C.thy
+++ b/proof/crefine/ARM_HYP/Finalise_C.thy
@@ -1131,7 +1131,7 @@ lemma offset_xf_for_sequence:
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 crunch invalidateHWASIDEntry
   for pde_mappings'[wp]: "valid_pde_mappings'"
 end
@@ -1174,7 +1174,7 @@ lemma invalidateASIDEntry_ccorres:
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 crunch invalidateASIDEntry
   for obj_at'[wp]: "obj_at' P p"
 crunch flushSpace

--- a/proof/crefine/ARM_HYP/Invoke_C.thy
+++ b/proof/crefine/ARM_HYP/Invoke_C.thy
@@ -1390,7 +1390,7 @@ lemma decodeCNodeInvocation_ccorres:
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemmas setCTE_def3 = setCTE_def2[THEN eq_reflection]
 

--- a/proof/crefine/ARM_HYP/Ipc_C.thy
+++ b/proof/crefine/ARM_HYP/Ipc_C.thy
@@ -13,7 +13,7 @@ imports
   IsolatedThreadAction
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition
   "replyFromKernel_success_empty thread \<equiv> do
@@ -346,7 +346,7 @@ lemma ccap_relation_reply_helpers:
                      cap_reply_cap_lift_def word_size
               elim!: ccap_relationE)
 
-(*FIXME: arch_split: C kernel names hidden by Haskell names *)
+(*FIXME: arch-split: C kernel names hidden by Haskell names *)
 (*FIXME: fupdate simplification issues for 2D arrays *)
 abbreviation "syscallMessageC \<equiv>  kernel_all_global_addresses.fault_messages.[unat MessageID_Syscall]"
 lemmas syscallMessageC_def = kernel_all_substitute.fault_messages_def
@@ -369,7 +369,7 @@ lemma syscallMessage_ccorres:
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition
   "handleArchFaultReply' f sender receiver tag \<equiv>
@@ -1088,7 +1088,7 @@ lemma setMR_ccorres_dc:
 end
 
 (* FIXME: move *)
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 crunch setMR
   for valid_pspace'[wp]: "valid_pspace'"
 crunch setMR

--- a/proof/crefine/ARM_HYP/IsolatedThreadAction.thy
+++ b/proof/crefine/ARM_HYP/IsolatedThreadAction.thy
@@ -9,7 +9,7 @@ theory IsolatedThreadAction
 imports ArchMove_C
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 datatype tcb_state_regs =
   TCBStateRegs (tsrState : thread_state) (tsrContext : "MachineTypes.register \<Rightarrow> machine_word")
@@ -1235,7 +1235,7 @@ lemma bind_assoc:
      = do x \<leftarrow> m; y \<leftarrow> f x; g y od"
   by (rule bind_assoc)
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma setObject_modify_assert:
   "\<lbrakk> updateObject v = updateObject_default v \<rbrakk>

--- a/proof/crefine/ARM_HYP/Recycle_C.thy
+++ b/proof/crefine/ARM_HYP/Recycle_C.thy
@@ -576,7 +576,7 @@ lemma heap_to_user_data_in_user_mem'[simp]:
       apply simp+
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 crunch invalidateTLBByASID
   for pde_mappings'[wp]: "valid_pde_mappings'"

--- a/proof/crefine/ARM_HYP/Retype_C.thy
+++ b/proof/crefine/ARM_HYP/Retype_C.thy
@@ -20,7 +20,7 @@ instance cte_C :: array_outer_max_size
 instance virq_C :: array_inner_packed
   by intro_classes simp
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 
 lemma map_option_byte_to_word_heap:
@@ -4713,7 +4713,7 @@ lemma placeNewObject_pde:
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 end
 
 lemma dom_disj_union:
@@ -7691,7 +7691,7 @@ lemma APIType_capBits_min:
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma createNewCaps_1_gsCNodes_p:
   "\<lbrace>\<lambda>s. P (gsCNodes s p) \<and> p \<noteq> ptr\<rbrace> createNewCaps newType ptr 1 n dev\<lbrace>\<lambda>rv s. P (gsCNodes s p)\<rbrace>"

--- a/proof/crefine/ARM_HYP/SR_lemmas_C.thy
+++ b/proof/crefine/ARM_HYP/SR_lemmas_C.thy
@@ -10,7 +10,7 @@ imports
   "Refine.Invariants_H"
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 section "ctes"
 

--- a/proof/crefine/ARM_HYP/Schedule_C.thy
+++ b/proof/crefine/ARM_HYP/Schedule_C.thy
@@ -11,7 +11,7 @@ begin
 
 instance tcb              :: no_vcpu by intro_classes auto
 
-(*FIXME: arch_split: move up?*)
+(*FIXME: arch-split: move up?*)
 context Arch begin
 context begin global_naming global
 requalify_facts

--- a/proof/crefine/ARM_HYP/StateRelation_C.thy
+++ b/proof/crefine/ARM_HYP/StateRelation_C.thy
@@ -8,7 +8,7 @@ theory StateRelation_C
 imports Wellformed_C
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition
   "lifth p s \<equiv> the (clift (t_hrs_' s) p)"
@@ -96,7 +96,7 @@ text \<open>
   which can subsequently be instantiated for
   @{text kernel_all_global_addresses} as well as @{text kernel_all_substitute}.
 \<close>
-locale state_rel = Arch + substitute_pre + (*FIXME: arch_split*)
+locale state_rel = Arch + substitute_pre + (*FIXME: arch-split*)
   fixes armKSKernelVSpace_C :: "machine_word \<Rightarrow> arm_vspace_region_use"
 
 locale kernel = kernel_all_substitute + state_rel
@@ -139,7 +139,7 @@ where
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition
   cmachine_state_relation :: "machine_state \<Rightarrow> globals \<Rightarrow> bool"
@@ -702,7 +702,7 @@ where
            ((\<not> (d \<le> maxDomain \<and> i < l2BitmapSize))
             \<longrightarrow>  abitmap2 (d, i) = 0)"
 
-end (* interpretation Arch . (*FIXME: arch_split*) *)
+end (* interpretation Arch . (*FIXME: arch-split*) *)
 
 definition
    region_is_bytes' :: "word32 \<Rightarrow> nat \<Rightarrow> heap_typ_desc \<Rightarrow> bool"

--- a/proof/crefine/ARM_HYP/SyscallArgs_C.thy
+++ b/proof/crefine/ARM_HYP/SyscallArgs_C.thy
@@ -12,13 +12,13 @@ imports
   StoreWord_C  DetWP
 begin
 
-(*FIXME: arch_split: C kernel names hidden by Haskell names *)
+(*FIXME: arch-split: C kernel names hidden by Haskell names *)
 context kernel_m begin
 abbreviation "msgRegistersC \<equiv> kernel_all_substitute.msgRegisters"
 lemmas msgRegistersC_def = kernel_all_substitute.msgRegisters_def
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 declare word_neq_0_conv[simp del]
 
@@ -1289,7 +1289,7 @@ lemma getSyscallArg_ccorres_foo:
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma invocation_eq_use_type:
   "\<lbrakk> value \<equiv> (value' :: 32 signed word);

--- a/proof/crefine/ARM_HYP/Syscall_C.thy
+++ b/proof/crefine/ARM_HYP/Syscall_C.thy
@@ -14,7 +14,7 @@ imports
   Arch_C
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 crunch replyFromKernel
   for sch_act_wf[wp]: "\<lambda>s. sch_act_wf (ksSchedulerAction s) s"
 end

--- a/proof/crefine/ARM_HYP/Tcb_C.thy
+++ b/proof/crefine/ARM_HYP/Tcb_C.thy
@@ -58,7 +58,7 @@ lemma doMachineOp_sched:
   apply fastforce
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 crunch restart
   for curThread[wp]: "\<lambda>s. P (ksCurThread s)"
@@ -1090,7 +1090,7 @@ lemma Arch_performTransfer_ccorres:
      apply simp+
   done
 
-(*FIXME: arch_split: C kernel names hidden by Haskell names *)
+(*FIXME: arch-split: C kernel names hidden by Haskell names *)
 abbreviation "frameRegistersC \<equiv> kernel_all_substitute.frameRegisters"
 lemmas frameRegistersC_def = kernel_all_substitute.frameRegisters_def
 abbreviation "gpRegistersC \<equiv> kernel_all_substitute.gpRegisters"

--- a/proof/crefine/ARM_HYP/VSpace_C.thy
+++ b/proof/crefine/ARM_HYP/VSpace_C.thy
@@ -9,7 +9,7 @@ theory VSpace_C
 imports TcbAcc_C CSpace_C PSpace_C TcbQueue_C
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma ccorres_name_pre_C:
   "(\<And>s. s \<in> P' \<Longrightarrow> ccorres_underlying sr \<Gamma> r xf arrel axf P {s} hs f g)
@@ -1218,7 +1218,7 @@ lemma rf_sr_armKSNextASID:
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 crunch invalidateASID
   for armKSNextASID[wp]: "\<lambda>s. P (armKSNextASID (ksArchState s))"
@@ -2727,7 +2727,7 @@ lemma doFlush_ccorres:
   done
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 crunch setVMRootForFlush
   for gsMaxObjectSize[wp]: "\<lambda>s. P (gsMaxObjectSize s)"
   (wp: crunch_wps)
@@ -3041,7 +3041,7 @@ lemmas unfold_checkMapping_return
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 crunch flushPage
   for no_0_obj'[wp]: "no_0_obj'"
 end

--- a/proof/crefine/ARM_HYP/Wellformed_C.thy
+++ b/proof/crefine/ARM_HYP/Wellformed_C.thy
@@ -14,7 +14,7 @@ imports
   "CSpec.Substitute"
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 abbreviation
   cte_Ptr :: "word32 \<Rightarrow> cte_C ptr" where "cte_Ptr == Ptr"
@@ -265,7 +265,7 @@ record cte_CL =
   cap_CL :: cap_CL
   cteMDBNode_CL :: mdb_node_CL
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition
   cte_lift :: "cte_C \<rightharpoonup> cte_CL"

--- a/proof/crefine/RISCV64/ADT_C.thy
+++ b/proof/crefine/RISCV64/ADT_C.thy
@@ -194,7 +194,7 @@ end
 consts
   Init_C' :: "unit observable \<Rightarrow> cstate global_state set"
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition "Init_C \<equiv> \<lambda>((tc,s),m,e). Init_C' ((tc, truncate_state s),m,e)"
 
@@ -566,7 +566,7 @@ lemma carch_state_to_H_correct:
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma tcb_queue_rel_unique:
   "hp NULL = None \<Longrightarrow>

--- a/proof/crefine/RISCV64/Arch_C.thy
+++ b/proof/crefine/RISCV64/Arch_C.thy
@@ -12,7 +12,7 @@ begin
 
 unbundle l4v_word_context
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 crunch unmapPageTable
   for gsMaxObjectSize[wp]: "\<lambda>s. P (gsMaxObjectSize s)"

--- a/proof/crefine/RISCV64/CLevityCatch.thy
+++ b/proof/crefine/RISCV64/CLevityCatch.thy
@@ -13,7 +13,7 @@ imports
   Boolean_C
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 (* Short-hand for  unfolding cumbersome machine constants *)
 (* FIXME MOVE these should be in refine, and the _eq forms should NOT be declared [simp]! *)

--- a/proof/crefine/RISCV64/DetWP.thy
+++ b/proof/crefine/RISCV64/DetWP.thy
@@ -9,7 +9,7 @@ theory DetWP
 imports "Lib.DetWPLib" "CBaseRefine.Include_C"
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma det_wp_doMachineOp [wp]:
   "det_wp (\<lambda>_. P) f \<Longrightarrow> det_wp (\<lambda>_. P) (doMachineOp f)"

--- a/proof/crefine/RISCV64/Invoke_C.thy
+++ b/proof/crefine/RISCV64/Invoke_C.thy
@@ -1382,7 +1382,7 @@ lemma decodeCNodeInvocation_ccorres:
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemmas setCTE_def3 = setCTE_def2[THEN eq_reflection]
 

--- a/proof/crefine/RISCV64/Ipc_C.thy
+++ b/proof/crefine/RISCV64/Ipc_C.thy
@@ -14,7 +14,7 @@ imports
   IsolatedThreadAction
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition
   "replyFromKernel_success_empty thread \<equiv> do
@@ -294,7 +294,7 @@ lemma ccap_relation_reply_helpers:
                      cap_reply_cap_lift_def word_size
               elim!: ccap_relationE)
 
-(*FIXME: arch_split: C kernel names hidden by Haskell names *)
+(*FIXME: arch-split: C kernel names hidden by Haskell names *)
 (*FIXME: fupdate simplification issues for 2D arrays *)
 abbreviation "syscallMessageC \<equiv>  kernel_all_global_addresses.fault_messages.[unat MessageID_Syscall]"
 lemmas syscallMessageC_def = kernel_all_substitute.fault_messages_def
@@ -317,7 +317,7 @@ lemma syscallMessage_ccorres:
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition
   "handleArchFaultReply' f sender receiver tag \<equiv> do
@@ -1015,7 +1015,7 @@ lemma setMR_ccorres_dc:
 end
 
 (* FIXME: move *)
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 crunch setMR
   for valid_pspace'[wp]: "valid_pspace'"
 crunch setMR

--- a/proof/crefine/RISCV64/IsolatedThreadAction.thy
+++ b/proof/crefine/RISCV64/IsolatedThreadAction.thy
@@ -112,7 +112,7 @@ lemmas setNotification_tcb = set_ntfn_tcb_obj_at'
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma setObject_modify:
   fixes v :: "'a :: pspace_storable" shows
@@ -161,7 +161,7 @@ lemma partial_overwrite_fun_upd:
   apply (clarsimp split: if_split)
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma get_tcb_state_regs_ko_at':
   "ko_at' ko p s \<Longrightarrow> get_tcb_state_regs (ksPSpace s p)
@@ -994,7 +994,7 @@ lemma bind_assoc:
      = do x \<leftarrow> m; y \<leftarrow> f x; g y od"
   by (rule bind_assoc)
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma setObject_modify_assert:
   "\<lbrakk> updateObject v = updateObject_default v \<rbrakk>

--- a/proof/crefine/RISCV64/Recycle_C.thy
+++ b/proof/crefine/RISCV64/Recycle_C.thy
@@ -520,7 +520,7 @@ lemma heap_to_user_data_in_user_mem'[simp]:
       apply simp+
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 crunch deleteASIDPool
   for gsMaxObjectSize[wp]: "\<lambda>s. P (gsMaxObjectSize s)"
   (wp: crunch_wps getObject_inv loadObject_default_inv

--- a/proof/crefine/RISCV64/Refine_C.thy
+++ b/proof/crefine/RISCV64/Refine_C.thy
@@ -20,7 +20,7 @@ imports
   CToCRefine
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 crunch handleVMFault
   for ksQ[wp]: "\<lambda>s. P (ksReadyQueues s)"
 end

--- a/proof/crefine/RISCV64/Retype_C.thy
+++ b/proof/crefine/RISCV64/Retype_C.thy
@@ -46,7 +46,7 @@ lemma zero_le_sint: "\<lbrakk> 0 \<le> (a :: machine_word); a < 0x80000000000000
   apply simp
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma map_option_byte_to_word_heap:
   assumes disj: "\<And>(off :: 9 word) x. x<8 \<Longrightarrow> p + ucast off * 8 + x \<notin> S " (*9=page table index*)
@@ -6797,7 +6797,7 @@ lemma APIType_capBits_min:
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma createNewCaps_1_gsCNodes_p:
   "\<lbrace>\<lambda>s. P (gsCNodes s p) \<and> p \<noteq> ptr\<rbrace> createNewCaps newType ptr 1 n dev\<lbrace>\<lambda>rv s. P (gsCNodes s p)\<rbrace>"

--- a/proof/crefine/RISCV64/SR_lemmas_C.thy
+++ b/proof/crefine/RISCV64/SR_lemmas_C.thy
@@ -11,7 +11,7 @@ imports
   "Refine.Invariants_H"
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 section "vm rights"
 

--- a/proof/crefine/RISCV64/Schedule_C.thy
+++ b/proof/crefine/RISCV64/Schedule_C.thy
@@ -10,7 +10,7 @@ theory Schedule_C
 imports Tcb_C Detype_C
 begin
 
-(*FIXME: arch_split: move up?*)
+(*FIXME: arch-split: move up?*)
 context Arch begin
 context begin global_naming global
 requalify_facts

--- a/proof/crefine/RISCV64/StateRelation_C.thy
+++ b/proof/crefine/RISCV64/StateRelation_C.thy
@@ -9,7 +9,7 @@ theory StateRelation_C
 imports Wellformed_C
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition
   "lifth p s \<equiv> the (clift (t_hrs_' s) p)"
@@ -80,7 +80,7 @@ text \<open>
   which can subsequently be instantiated for
   @{text kernel_all_global_addresses} as well as @{text kernel_all_substitute}.
 \<close>
-locale state_rel = Arch + substitute_pre + (*FIXME: arch_split*)
+locale state_rel = Arch + substitute_pre + (*FIXME: arch-split*)
   fixes riscvKSKernelVSpace_C :: "machine_word \<Rightarrow> riscvvspace_region_use"
 
 locale kernel = kernel_all_substitute + state_rel
@@ -129,7 +129,7 @@ where
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition
   cmachine_state_relation :: "machine_state \<Rightarrow> globals \<Rightarrow> bool"
@@ -631,7 +631,7 @@ where
            ((\<not> (d \<le> maxDomain \<and> i < l2BitmapSize))
             \<longrightarrow>  abitmap2 (d, i) = 0)"
 
-end (* interpretation Arch . (*FIXME: arch_split*) *)
+end (* interpretation Arch . (*FIXME: arch-split*) *)
 
 definition
    region_is_bytes' :: "machine_word \<Rightarrow> nat \<Rightarrow> heap_typ_desc \<Rightarrow> bool"

--- a/proof/crefine/RISCV64/SyscallArgs_C.thy
+++ b/proof/crefine/RISCV64/SyscallArgs_C.thy
@@ -13,13 +13,13 @@ imports
   StoreWord_C  DetWP
 begin
 
-(*FIXME: arch_split: C kernel names hidden by Haskell names *)
+(*FIXME: arch-split: C kernel names hidden by Haskell names *)
 context kernel_m begin
 abbreviation "msgRegistersC \<equiv> kernel_all_substitute.msgRegisters"
 lemmas msgRegistersC_def = kernel_all_substitute.msgRegisters_def
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 declare word_neq_0_conv[simp del]
 
@@ -1190,7 +1190,7 @@ lemma getSyscallArg_ccorres_foo:
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma invocation_eq_use_type:
   "\<lbrakk> value \<equiv> (value' :: 32 signed word);

--- a/proof/crefine/RISCV64/Syscall_C.thy
+++ b/proof/crefine/RISCV64/Syscall_C.thy
@@ -15,7 +15,7 @@ imports
   Arch_C
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 crunch replyFromKernel
   for sch_act_wf[wp]: "\<lambda>s. sch_act_wf (ksSchedulerAction s) s"
 end

--- a/proof/crefine/RISCV64/Tcb_C.thy
+++ b/proof/crefine/RISCV64/Tcb_C.thy
@@ -59,7 +59,7 @@ lemma doMachineOp_sched:
   apply fastforce
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 crunch restart
   for curThread[wp]: "\<lambda>s. P (ksCurThread s)"
@@ -1113,7 +1113,7 @@ lemma Arch_performTransfer_ccorres:
      apply simp+
   done
 
-(*FIXME: arch_split: C kernel names hidden by Haskell names *)
+(*FIXME: arch-split: C kernel names hidden by Haskell names *)
 abbreviation "frameRegistersC \<equiv> kernel_all_substitute.frameRegisters"
 lemmas frameRegistersC_def = kernel_all_substitute.frameRegisters_def
 abbreviation "gpRegistersC \<equiv> kernel_all_substitute.gpRegisters"

--- a/proof/crefine/RISCV64/VSpace_C.thy
+++ b/proof/crefine/RISCV64/VSpace_C.thy
@@ -19,7 +19,7 @@ autocorres
     c_locale = kernel_all_substitute
   ] "../c/build/$L4V_ARCH/kernel_all.c_pp"
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma ccorres_name_pre_C:
   "(\<And>s. s \<in> P' \<Longrightarrow> ccorres_underlying sr \<Gamma> r xf arrel axf P {s} hs f g)

--- a/proof/crefine/RISCV64/Wellformed_C.thy
+++ b/proof/crefine/RISCV64/Wellformed_C.thy
@@ -15,7 +15,7 @@ imports
   "CSpec.Substitute"
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 abbreviation
   cte_Ptr :: "word64 \<Rightarrow> cte_C ptr" where "cte_Ptr == Ptr"
@@ -246,7 +246,7 @@ record cte_CL =
   cap_CL :: cap_CL
   cteMDBNode_CL :: mdb_node_CL
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition
   cte_lift :: "cte_C \<rightharpoonup> cte_CL"

--- a/proof/crefine/X64/ADT_C.thy
+++ b/proof/crefine/X64/ADT_C.thy
@@ -201,7 +201,7 @@ end
 consts
   Init_C' :: "unit observable \<Rightarrow> cstate global_state set"
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition "Init_C \<equiv> \<lambda>((tc,s),m,e). Init_C' ((tc, truncate_state s),m,e)"
 
@@ -604,7 +604,7 @@ lemma carch_state_to_H_correct:
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma tcb_queue_rel_unique:
   "hp NULL = None \<Longrightarrow>

--- a/proof/crefine/X64/Arch_C.thy
+++ b/proof/crefine/X64/Arch_C.thy
@@ -11,7 +11,7 @@ begin
 
 unbundle l4v_word_context
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 crunch unmapPageTable, unmapPageDirectory, unmapPDPT
   for gsMaxObjectSize[wp]: "\<lambda>s. P (gsMaxObjectSize s)"

--- a/proof/crefine/X64/CLevityCatch.thy
+++ b/proof/crefine/X64/CLevityCatch.thy
@@ -13,7 +13,7 @@ imports
   Boolean_C
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 (* Short-hand for  unfolding cumbersome machine constants *)
 

--- a/proof/crefine/X64/DetWP.thy
+++ b/proof/crefine/X64/DetWP.thy
@@ -8,7 +8,7 @@ theory DetWP
 imports "Lib.DetWPLib" "CBaseRefine.Include_C"
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma det_wp_doMachineOp [wp]:
   "det_wp (\<lambda>_. P) f \<Longrightarrow> det_wp (\<lambda>_. P) (doMachineOp f)"

--- a/proof/crefine/X64/Invoke_C.thy
+++ b/proof/crefine/X64/Invoke_C.thy
@@ -1380,7 +1380,7 @@ lemma decodeCNodeInvocation_ccorres:
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemmas setCTE_def3 = setCTE_def2[THEN eq_reflection]
 

--- a/proof/crefine/X64/Ipc_C.thy
+++ b/proof/crefine/X64/Ipc_C.thy
@@ -13,7 +13,7 @@ imports
   IsolatedThreadAction
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition
   "replyFromKernel_success_empty thread \<equiv> do
@@ -293,7 +293,7 @@ lemma ccap_relation_reply_helpers:
                      cap_reply_cap_lift_def word_size
               elim!: ccap_relationE)
 
-(*FIXME: arch_split: C kernel names hidden by Haskell names *)
+(*FIXME: arch-split: C kernel names hidden by Haskell names *)
 (*FIXME: fupdate simplification issues for 2D arrays *)
 abbreviation "syscallMessageC \<equiv>  kernel_all_global_addresses.fault_messages.[unat MessageID_Syscall]"
 lemmas syscallMessageC_def = kernel_all_substitute.fault_messages_def
@@ -316,7 +316,7 @@ lemma syscallMessage_ccorres:
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition
   "handleArchFaultReply' f sender receiver tag \<equiv> do
@@ -1016,7 +1016,7 @@ lemma setMR_ccorres_dc:
 end
 
 (* FIXME: move *)
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 crunch setMR
   for valid_pspace'[wp]: "valid_pspace'"
 crunch setMR

--- a/proof/crefine/X64/IsolatedThreadAction.thy
+++ b/proof/crefine/X64/IsolatedThreadAction.thy
@@ -111,7 +111,7 @@ lemmas setNotification_tcb = set_ntfn_tcb_obj_at'
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma setObject_modify:
   fixes v :: "'a :: pspace_storable" shows
@@ -162,7 +162,7 @@ lemma partial_overwrite_fun_upd:
   apply (clarsimp split: if_split)
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma get_tcb_state_regs_ko_at':
   "ko_at' ko p s \<Longrightarrow> get_tcb_state_regs (ksPSpace s p)
@@ -982,7 +982,7 @@ lemma bind_assoc:
      = do x \<leftarrow> m; y \<leftarrow> f x; g y od"
   by (rule bind_assoc)
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma setObject_modify_assert:
   "\<lbrakk> updateObject v = updateObject_default v \<rbrakk>

--- a/proof/crefine/X64/Recycle_C.thy
+++ b/proof/crefine/X64/Recycle_C.thy
@@ -555,7 +555,7 @@ lemma heap_to_user_data_in_user_mem'[simp]:
       apply simp+
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 crunch deleteASIDPool
   for gsMaxObjectSize[wp]: "\<lambda>s. P (gsMaxObjectSize s)"
   (wp: crunch_wps getObject_inv loadObject_default_inv

--- a/proof/crefine/X64/Refine_C.thy
+++ b/proof/crefine/X64/Refine_C.thy
@@ -20,7 +20,7 @@ imports
   CToCRefine
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 crunch handleVMFault
   for ksQ[wp]: "\<lambda>s. P (ksReadyQueues s)"
 end

--- a/proof/crefine/X64/Retype_C.thy
+++ b/proof/crefine/X64/Retype_C.thy
@@ -46,7 +46,7 @@ lemma zero_le_sint: "\<lbrakk> 0 \<le> (a :: machine_word); a < 0x80000000000000
   apply simp
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma map_option_byte_to_word_heap:
   assumes disj: "\<And>(off :: 9 word) x. x<8 \<Longrightarrow> p + ucast off * 8 + x \<notin> S " (*9=page table index*)
@@ -7908,7 +7908,7 @@ lemma APIType_capBits_min:
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma createNewCaps_1_gsCNodes_p:
   "\<lbrace>\<lambda>s. P (gsCNodes s p) \<and> p \<noteq> ptr\<rbrace> createNewCaps newType ptr 1 n dev\<lbrace>\<lambda>rv s. P (gsCNodes s p)\<rbrace>"

--- a/proof/crefine/X64/SR_lemmas_C.thy
+++ b/proof/crefine/X64/SR_lemmas_C.thy
@@ -10,7 +10,7 @@ imports
   "Refine.Invariants_H"
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 section "ctes"
 

--- a/proof/crefine/X64/Schedule_C.thy
+++ b/proof/crefine/X64/Schedule_C.thy
@@ -9,7 +9,7 @@ theory Schedule_C
 imports Tcb_C Detype_C
 begin
 
-(*FIXME: arch_split: move up?*)
+(*FIXME: arch-split: move up?*)
 context Arch begin
 context begin global_naming global
 requalify_facts

--- a/proof/crefine/X64/StateRelation_C.thy
+++ b/proof/crefine/X64/StateRelation_C.thy
@@ -8,7 +8,7 @@ theory StateRelation_C
 imports Wellformed_C
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition
   "lifth p s \<equiv> the (clift (t_hrs_' s) p)"
@@ -79,7 +79,7 @@ text \<open>
   which can subsequently be instantiated for
   @{text kernel_all_global_addresses} as well as @{text kernel_all_substitute}.
 \<close>
-locale state_rel = Arch + substitute_pre + (*FIXME: arch_split*)
+locale state_rel = Arch + substitute_pre + (*FIXME: arch-split*)
   fixes x64KSKernelVSpace_C :: "machine_word \<Rightarrow> x64vspace_region_use"
 
 locale kernel = kernel_all_substitute + state_rel
@@ -197,7 +197,7 @@ where
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition
   cmachine_state_relation :: "machine_state \<Rightarrow> globals \<Rightarrow> bool"
@@ -863,7 +863,7 @@ where
            ((\<not> (d \<le> maxDomain \<and> i < l2BitmapSize))
             \<longrightarrow>  abitmap2 (d, i) = 0)"
 
-end (* interpretation Arch . (*FIXME: arch_split*) *)
+end (* interpretation Arch . (*FIXME: arch-split*) *)
 
 definition
    region_is_bytes' :: "machine_word \<Rightarrow> nat \<Rightarrow> heap_typ_desc \<Rightarrow> bool"

--- a/proof/crefine/X64/SyscallArgs_C.thy
+++ b/proof/crefine/X64/SyscallArgs_C.thy
@@ -12,13 +12,13 @@ imports
   StoreWord_C  DetWP
 begin
 
-(*FIXME: arch_split: C kernel names hidden by Haskell names *)
+(*FIXME: arch-split: C kernel names hidden by Haskell names *)
 context kernel_m begin
 abbreviation "msgRegistersC \<equiv> kernel_all_substitute.msgRegisters"
 lemmas msgRegistersC_def = kernel_all_substitute.msgRegisters_def
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 declare word_neq_0_conv[simp del]
 
@@ -1196,7 +1196,7 @@ lemma getSyscallArg_ccorres_foo:
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma invocation_eq_use_type:
   "\<lbrakk> value \<equiv> (value' :: 32 signed word);

--- a/proof/crefine/X64/Syscall_C.thy
+++ b/proof/crefine/X64/Syscall_C.thy
@@ -14,7 +14,7 @@ imports
   Arch_C
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 crunch replyFromKernel
   for sch_act_wf[wp]: "\<lambda>s. sch_act_wf (ksSchedulerAction s) s"
 end

--- a/proof/crefine/X64/Tcb_C.thy
+++ b/proof/crefine/X64/Tcb_C.thy
@@ -58,7 +58,7 @@ lemma doMachineOp_sched:
   apply fastforce
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 crunch restart
   for curThread[wp]: "\<lambda>s. P (ksCurThread s)"
@@ -1098,7 +1098,7 @@ lemma Arch_performTransfer_ccorres:
      apply simp+
   done
 
-(*FIXME: arch_split: C kernel names hidden by Haskell names *)
+(*FIXME: arch-split: C kernel names hidden by Haskell names *)
 abbreviation "frameRegistersC \<equiv> kernel_all_substitute.frameRegisters"
 lemmas frameRegistersC_def = kernel_all_substitute.frameRegisters_def
 abbreviation "gpRegistersC \<equiv> kernel_all_substitute.gpRegisters"

--- a/proof/crefine/X64/VSpace_C.thy
+++ b/proof/crefine/X64/VSpace_C.thy
@@ -18,7 +18,7 @@ autocorres
     c_locale = kernel_all_substitute
   ] "../c/build/$L4V_ARCH/kernel_all.c_pp"
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma ccorres_name_pre_C:
   "(\<And>s. s \<in> P' \<Longrightarrow> ccorres_underlying sr \<Gamma> r xf arrel axf P {s} hs f g)
@@ -999,7 +999,7 @@ lemma ccorres_from_vcg_might_throw:
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 end
 

--- a/proof/crefine/X64/Wellformed_C.thy
+++ b/proof/crefine/X64/Wellformed_C.thy
@@ -14,7 +14,7 @@ imports
   "CSpec.Substitute"
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 abbreviation
   cte_Ptr :: "word64 \<Rightarrow> cte_C ptr" where "cte_Ptr == Ptr"
@@ -270,7 +270,7 @@ record cte_CL =
   cap_CL :: cap_CL
   cteMDBNode_CL :: mdb_node_CL
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition
   cte_lift :: "cte_C \<rightharpoonup> cte_CL"

--- a/proof/dpolicy/Dpolicy.thy
+++ b/proof/dpolicy/Dpolicy.thy
@@ -23,7 +23,7 @@ downloaded from
 https://trustworthy.systems/publications/nictaabstracts/Klein_AEMSKH_14.abstract
 *)
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition
   cdl_cap_auth_conferred :: "cdl_cap \<Rightarrow> auth set"

--- a/proof/drefine/Arch_DR.thy
+++ b/proof/drefine/Arch_DR.thy
@@ -8,7 +8,7 @@ theory Arch_DR
 imports Untyped_DR
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition
  "make_arch_duplicate cap \<equiv> case cap of

--- a/proof/drefine/CNode_DR.thy
+++ b/proof/drefine/CNode_DR.thy
@@ -8,7 +8,7 @@ theory CNode_DR
 imports Finalise_DR
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition
   translate_cnode_invocation :: "Invocations_A.cnode_invocation \<Rightarrow> cdl_cnode_invocation"

--- a/proof/drefine/Finalise_DR.thy
+++ b/proof/drefine/Finalise_DR.thy
@@ -11,7 +11,7 @@ imports
   "AInvs.VSpaceEntries_AI"
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition
  "transform_pd_slot_ref x
@@ -1929,7 +1929,7 @@ lemma (in pspace_update_eq) pd_pt_relation_update[iff]:
   "pd_pt_relation a b c (f s) = pd_pt_relation a b c s"
   by (simp add: pd_pt_relation_def pspace)
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 crunch flush_page
   for cdt[wp]: "\<lambda>s. P (cdt s)"

--- a/proof/drefine/Intent_DR.thy
+++ b/proof/drefine/Intent_DR.thy
@@ -8,7 +8,7 @@ theory Intent_DR
 imports Corres_D
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition not_idle_thread:: "obj_ref \<Rightarrow> 'z::state_ext state \<Rightarrow> bool"
   where

--- a/proof/drefine/Interrupt_DR.thy
+++ b/proof/drefine/Interrupt_DR.thy
@@ -8,7 +8,7 @@ theory Interrupt_DR
 imports Ipc_DR
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma arch_decode_irq_control_error_corres:
   "\<not> (\<exists> ui. (Some (IrqControlIntent ui)) = (transform_intent (invocation_type label) args)) \<Longrightarrow>

--- a/proof/drefine/Ipc_DR.thy
+++ b/proof/drefine/Ipc_DR.thy
@@ -8,7 +8,7 @@ theory Ipc_DR
 imports CNode_DR
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 abbreviation
   "thread_is_running y s \<equiv> st_tcb_at ((=) Structures_A.Running) y s"

--- a/proof/drefine/KHeap_DR.thy
+++ b/proof/drefine/KHeap_DR.thy
@@ -8,7 +8,7 @@ theory KHeap_DR
 imports Intent_DR
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 declare arch_post_cap_deletion_def[simp]
 lemmas post_cap_deletion_simps[simp] = post_cap_deletion_def[simplified arch_post_cap_deletion_def]

--- a/proof/drefine/Refine_D.thy
+++ b/proof/drefine/Refine_D.thy
@@ -12,7 +12,7 @@ theory Refine_D
 imports Syscall_DR
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 text \<open>
   Toplevel @{text dcorres} theorem.

--- a/proof/drefine/Schedule_DR.thy
+++ b/proof/drefine/Schedule_DR.thy
@@ -8,7 +8,7 @@ theory Schedule_DR
 imports Finalise_DR
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 (* getActiveTCBs returns a subset of CapDL's all_active_tcbs. *)
 lemma getActiveTCBs_subset:

--- a/proof/drefine/StateTranslationProofs_DR.thy
+++ b/proof/drefine/StateTranslationProofs_DR.thy
@@ -12,7 +12,7 @@ theory StateTranslationProofs_DR
 imports StateTranslation_D
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 declare transform_current_domain_def [simp]
 

--- a/proof/drefine/StateTranslation_D.thy
+++ b/proof/drefine/StateTranslation_D.thy
@@ -16,7 +16,7 @@ theory StateTranslation_D
 imports Lemmas_D
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 type_synonym kernel_object = Structures_A.kernel_object
 type_synonym tcb = Structures_A.tcb

--- a/proof/drefine/Syscall_DR.thy
+++ b/proof/drefine/Syscall_DR.thy
@@ -11,7 +11,7 @@ imports
   Interrupt_DR
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 (*
  * Translate an abstract invocation into a corresponding

--- a/proof/drefine/Tcb_DR.thy
+++ b/proof/drefine/Tcb_DR.thy
@@ -8,7 +8,7 @@ theory Tcb_DR
 imports Ipc_DR Arch_DR
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 (*
  * A "normal" TCB is a non-idle TCB. (Idle is special, because it

--- a/proof/drefine/Untyped_DR.thy
+++ b/proof/drefine/Untyped_DR.thy
@@ -8,7 +8,7 @@ theory Untyped_DR
 imports CNode_DR
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma detype_dcorres:
   "S = {ptr..ptr + 2 ^ sz - 1}

--- a/proof/infoflow/ADT_IF.thy
+++ b/proof/infoflow/ADT_IF.thy
@@ -1487,7 +1487,7 @@ locale invariant_over_ADT_if =
                                 | None \<Rightarrow> det_inv InIdleMode (snd rv)\<rbrace>"
 
 
-locale valid_initial_state_noenabled = invariant_over_ADT_if + (* FIXME: arch_split *)
+locale valid_initial_state_noenabled = invariant_over_ADT_if + (* FIXME: arch-split *)
   fixes s0_internal :: det_state
   fixes initial_aag :: "'a subject_label PAS"
   fixes timer_irq :: irq

--- a/proof/infoflow/ARM/Example_Valid_State.thy
+++ b/proof/infoflow/ARM/Example_Valid_State.thy
@@ -29,7 +29,7 @@ consts s0_context :: user_context
 axiomatization where
   irq_oracle_def: "ARM.irq_oracle \<equiv> \<lambda>pos. if pos mod 10 = 0 then 10 else 0"
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 subsection \<open>We show that the authority graph does not let
               information flow from High to Low\<close>

--- a/proof/infoflow/FinalCaps.thy
+++ b/proof/infoflow/FinalCaps.thy
@@ -15,7 +15,7 @@ theory FinalCaps
 imports ArchInfoFlow_IF
 begin
 
-(* FIXME: arch_split: need to have a label on arch refs*)
+(* FIXME: arch-split: need to have a label on arch refs*)
 fun pasGenAbs :: "'a PAS \<Rightarrow> gen_obj_ref \<Rightarrow> 'a" where
   "pasGenAbs aag (ObjRef ref) = pasObjectAbs aag ref"
 | "pasGenAbs aag (IRQRef ref) = pasIRQAbs aag ref"

--- a/proof/infoflow/RISCV64/Example_Valid_State.thy
+++ b/proof/infoflow/RISCV64/Example_Valid_State.thy
@@ -30,7 +30,7 @@ consts s0_context :: user_context
 axiomatization where
   irq_oracle_def: "RISCV64.irq_oracle \<equiv> \<lambda>pos. if pos mod 10 = 0 then 10 else 0"
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 subsection \<open>We show that the authority graph does not let information flow from High to Low\<close>
 

--- a/proof/infoflow/refine/ARM/Example_Valid_StateH.thy
+++ b/proof/infoflow/refine/ARM/Example_Valid_StateH.thy
@@ -9,7 +9,7 @@ theory Example_Valid_StateH
 imports "InfoFlow.Example_Valid_State" ArchADT_IF_Refine
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 section \<open>Haskell state\<close>
 
@@ -2827,7 +2827,7 @@ axiomatization  where
   kdr_valid_global_refs': "valid_global_refs' s0H_internal" and
   kdr_pspace_domain_valid: "pspace_domain_valid s0H_internal"
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma timer_irq_not_outside_range[simp]:
   "\<not> Kernel_Config.maxIRQ < (timer_irq :: irq)"

--- a/proof/invariant-abstract/AARCH64/ArchFinalise_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchFinalise_AI.thy
@@ -1753,7 +1753,7 @@ lemma invs_valid_arch_capsI:
   "invs s \<Longrightarrow> valid_arch_caps s"
   by (simp add: invs_def valid_state_def)
 
-context Arch begin global_naming AARCH64 (*FIXME: arch_split*)
+context Arch begin global_naming AARCH64 (*FIXME: arch-split*)
 
 lemma do_machine_op_reachable_pg_cap[wp]:
   "\<lbrace>\<lambda>s. P (reachable_frame_cap cap s)\<rbrace>

--- a/proof/invariant-abstract/AARCH64/ArchVCPU_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchVCPU_AI.thy
@@ -9,7 +9,7 @@ theory ArchVCPU_AI
 imports AInvs
 begin
 
-context Arch begin global_naming AARCH64 (*FIXME: arch_split*)
+context Arch begin global_naming AARCH64 (*FIXME: arch-split*)
 
 (* This is similar to cur_vcpu_2, but not close enough to reuse. *)
 definition active_cur_vcpu_of :: "'z state \<Rightarrow> obj_ref option" where

--- a/proof/invariant-abstract/ARM/ArchFinalise_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchFinalise_AI.thy
@@ -1134,7 +1134,7 @@ lemma invs_valid_arch_capsI:
   "invs s \<Longrightarrow> valid_arch_caps s"
   by (simp add: invs_def valid_state_def)
 
-context Arch begin global_naming ARM (*FIXME: arch_split*)
+context Arch begin global_naming ARM (*FIXME: arch-split*)
 
 lemma arch_finalise_case_no_lookup:
   "\<lbrace>pspace_aligned and valid_vspace_objs and valid_objs and

--- a/proof/invariant-abstract/ARM/ArchKernelInit_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchKernelInit_AI.thy
@@ -14,7 +14,7 @@ imports
   Arch_AI
 begin
 
-context Arch begin global_naming ARM (*FIXME: arch_split*)
+context Arch begin global_naming ARM (*FIXME: arch-split*)
 
 text \<open>
   Showing that there is a state that satisfies the abstract invariants.

--- a/proof/invariant-abstract/ARM/ArchRetype_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchRetype_AI.thy
@@ -904,7 +904,7 @@ sublocale retype_region_proofs_gen?: retype_region_proofs_gen
 end
 
 
-context Arch begin global_naming ARM (*FIXME: arch_split*)
+context Arch begin global_naming ARM (*FIXME: arch-split*)
 
 definition
   valid_vs_lookup2 :: "(vs_ref list \<times> word32) set \<Rightarrow> (cslot_ptr \<rightharpoonup> cap) \<Rightarrow> bool"

--- a/proof/invariant-abstract/ARM/ArchUntyped_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchUntyped_AI.thy
@@ -183,7 +183,7 @@ lemma retype_ret_valid_caps_aobj[Untyped_AI_assms]:
 
 
 
-lemma copy_global_mappings_hoare_lift:(*FIXME: arch_split  \<rightarrow> these do not seem to be used globally *)
+lemma copy_global_mappings_hoare_lift:(*FIXME: arch-split  \<rightarrow> these do not seem to be used globally *)
   assumes wp: "\<And>ptr val. \<lbrace>Q\<rbrace> store_pde ptr val \<lbrace>\<lambda>rv. Q\<rbrace>"
   shows       "\<lbrace>Q\<rbrace> copy_global_mappings pd \<lbrace>\<lambda>rv. Q\<rbrace>"
   apply (simp add: copy_global_mappings_def)

--- a/proof/invariant-abstract/ARM/ArchVSpaceEntries_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchVSpaceEntries_AI.thy
@@ -9,7 +9,7 @@ imports VSpaceEntries_AI
 begin
 
 
-context Arch begin global_naming ARM (*FIXME: arch_split*)
+context Arch begin global_naming ARM (*FIXME: arch-split*)
 
 lemma a_type_pdD:
   "a_type ko = AArch APageDirectory \<Longrightarrow> \<exists>pd. ko = ArchObj (PageDirectory pd)"

--- a/proof/invariant-abstract/ARM_HYP/ArchFinalise_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchFinalise_AI.thy
@@ -1901,7 +1901,7 @@ lemma invs_valid_arch_capsI:
   "invs s \<Longrightarrow> valid_arch_caps s"
   by (simp add: invs_def valid_state_def)
 
-context Arch begin global_naming ARM_HYP (*FIXME: arch_split*)
+context Arch begin global_naming ARM_HYP (*FIXME: arch-split*)
 
 lemma arch_finalise_case_no_lookup:
   "\<lbrace>pspace_aligned and valid_vspace_objs and valid_objs and

--- a/proof/invariant-abstract/ARM_HYP/ArchKernelInit_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchKernelInit_AI.thy
@@ -14,7 +14,7 @@ imports
   Arch_AI
 begin
 
-context Arch begin global_naming ARM (*FIXME: arch_split*)
+context Arch begin global_naming ARM (*FIXME: arch-split*)
 
 text \<open>
   Showing that there is a state that satisfies the abstract invariants.

--- a/proof/invariant-abstract/ARM_HYP/ArchRetype_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchRetype_AI.thy
@@ -769,7 +769,7 @@ sublocale retype_region_proofs_gen?: retype_region_proofs_gen
 end
 
 
-context Arch begin global_naming ARM_HYP (*FIXME: arch_split*)
+context Arch begin global_naming ARM_HYP (*FIXME: arch-split*)
 
 definition
   valid_vs_lookup2 :: "(vs_ref list \<times> word32) set \<Rightarrow> word32 set \<Rightarrow> (cslot_ptr \<rightharpoonup> cap) \<Rightarrow> bool"

--- a/proof/invariant-abstract/ARM_HYP/ArchUntyped_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchUntyped_AI.thy
@@ -179,7 +179,7 @@ by (clarsimp simp:valid_cap_def default_object_def cap_aligned_def
         default_arch_object_def valid_vm_rights_def  word_bits_def a_type_def)+
 
 
-lemma copy_global_mappings_hoare_lift:(*FIXME: arch_split  \<rightarrow> these do not seem to be used globally *)
+lemma copy_global_mappings_hoare_lift:(*FIXME: arch-split  \<rightarrow> these do not seem to be used globally *)
   assumes wp: "\<And>ptr val. \<lbrace>Q\<rbrace> store_pde ptr val \<lbrace>\<lambda>rv. Q\<rbrace>"
   shows       "\<lbrace>Q\<rbrace> copy_global_mappings pd \<lbrace>\<lambda>rv. Q\<rbrace>"
   apply (simp add: copy_global_mappings_def)

--- a/proof/invariant-abstract/ARM_HYP/ArchVCPU_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchVCPU_AI.thy
@@ -9,7 +9,7 @@ theory ArchVCPU_AI
 imports AInvs
 begin
 
-context Arch begin global_naming ARM_HYP (*FIXME: arch_split*)
+context Arch begin global_naming ARM_HYP (*FIXME: arch-split*)
 
 definition active_cur_vcpu_of :: "'z state \<Rightarrow> obj_ref option" where
   "active_cur_vcpu_of s \<equiv> case arm_current_vcpu (arch_state s) of Some (vr, True) \<Rightarrow> Some vr

--- a/proof/invariant-abstract/ARM_HYP/ArchVSpaceEntries_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchVSpaceEntries_AI.thy
@@ -8,7 +8,7 @@ theory ArchVSpaceEntries_AI
 imports VSpaceEntries_AI
 begin
 
-context Arch begin global_naming ARM_HYP (*FIXME: arch_split*)
+context Arch begin global_naming ARM_HYP (*FIXME: arch-split*)
 
 lemma a_type_pdD:
   "a_type ko = AArch APageDirectory \<Longrightarrow> \<exists>pd. ko = ArchObj (PageDirectory pd)"

--- a/proof/invariant-abstract/Detype_AI.thy
+++ b/proof/invariant-abstract/Detype_AI.thy
@@ -1020,7 +1020,7 @@ lemma dom_known_length:
   by (drule domI[where m=f], simp)
 
 
-lemma (in Detype_AI) cte_map_not_null_outside: (*FIXME: arch_split*)
+lemma (in Detype_AI) cte_map_not_null_outside: (*FIXME: arch-split*)
   "\<lbrakk> cte_wp_at ((\<noteq>) cap.NullCap) p (s :: 'a state);
      cte_wp_at ((=) cap) p' s;is_untyped_cap cap;
      descendants_range cap p' s; untyped_children_in_mdb s;

--- a/proof/invariant-abstract/RISCV64/ArchFinalise_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchFinalise_AI.thy
@@ -1133,7 +1133,7 @@ lemma invs_valid_arch_capsI:
   "invs s \<Longrightarrow> valid_arch_caps s"
   by (simp add: invs_def valid_state_def)
 
-context Arch begin global_naming RISCV64 (*FIXME: arch_split*)
+context Arch begin global_naming RISCV64 (*FIXME: arch-split*)
 
 lemma do_machine_op_reachable_pg_cap[wp]:
   "\<lbrace>\<lambda>s. P (reachable_frame_cap cap s)\<rbrace>

--- a/proof/invariant-abstract/Schedule_AI.thy
+++ b/proof/invariant-abstract/Schedule_AI.thy
@@ -28,7 +28,7 @@ locale Schedule_AI =
       "\<lbrace>invs\<rbrace> switch_to_idle_thread \<lbrace>\<lambda>rv . (ct_in_state activatable :: 'a state \<Rightarrow> bool)\<rbrace>"
 
 context begin interpretation Arch .
-(* FIXME arch_split: some of these could be moved to generic theories
+(* FIXME arch-split: some of these could be moved to generic theories
    so they don't need to be unqualified. *)
 requalify_facts
   no_irq

--- a/proof/invariant-abstract/X64/ArchFinalise_AI.thy
+++ b/proof/invariant-abstract/X64/ArchFinalise_AI.thy
@@ -1176,7 +1176,7 @@ lemma invs_valid_arch_capsI:
   "invs s \<Longrightarrow> valid_arch_caps s"
   by (simp add: invs_def valid_state_def)
 
-context Arch begin global_naming X64 (*FIXME: arch_split*)
+context Arch begin global_naming X64 (*FIXME: arch-split*)
 
 lemma all_Some_the_strg: "f b = None \<or> P (the (f b)) \<longrightarrow> (\<forall>a. f b = Some a \<longrightarrow> P a)"
   by auto

--- a/proof/invariant-abstract/X64/ArchKernelInit_AI.thy
+++ b/proof/invariant-abstract/X64/ArchKernelInit_AI.thy
@@ -14,7 +14,7 @@ imports
   Arch_AI
 begin
 
-context Arch begin global_naming X64 (*FIXME: arch_split*)
+context Arch begin global_naming X64 (*FIXME: arch-split*)
 
 text \<open>
   Showing that there is a state that satisfies the abstract invariants.

--- a/proof/invariant-abstract/X64/ArchRetype_AI.thy
+++ b/proof/invariant-abstract/X64/ArchRetype_AI.thy
@@ -831,7 +831,7 @@ sublocale retype_region_proofs_gen?: retype_region_proofs_gen
 end
 
 
-context Arch begin global_naming X64 (*FIXME: arch_split*)
+context Arch begin global_naming X64 (*FIXME: arch-split*)
 
 definition
   valid_vs_lookup2 :: "(vs_ref list \<times> machine_word) set \<Rightarrow> (cslot_ptr \<rightharpoonup> cap) \<Rightarrow> bool"

--- a/proof/invariant-abstract/X64/ArchUntyped_AI.thy
+++ b/proof/invariant-abstract/X64/ArchUntyped_AI.thy
@@ -181,7 +181,7 @@ lemma retype_ret_valid_caps_aobj[Untyped_AI_assms]:
 
 
 
-lemma copy_global_mappings_hoare_lift:(*FIXME: arch_split  \<rightarrow> these do not seem to be used globally *)
+lemma copy_global_mappings_hoare_lift:(*FIXME: arch-split  \<rightarrow> these do not seem to be used globally *)
   assumes wp: "\<And>ptr val. \<lbrace>Q\<rbrace> store_pml4e ptr val \<lbrace>\<lambda>rv. Q\<rbrace>"
   shows       "\<lbrace>Q\<rbrace> copy_global_mappings pd \<lbrace>\<lambda>rv. Q\<rbrace>"
   apply (simp add: copy_global_mappings_def)

--- a/proof/invariant-abstract/X64/ArchVSpaceEntries_AI.thy
+++ b/proof/invariant-abstract/X64/ArchVSpaceEntries_AI.thy
@@ -8,7 +8,7 @@ theory ArchVSpaceEntries_AI
 imports VSpaceEntries_AI
 begin
 
-context Arch begin global_naming X64 (*FIXME: arch_split*)
+context Arch begin global_naming X64 (*FIXME: arch-split*)
 
 lemma a_type_pml4D:
   "a_type ko = AArch APageMapL4 \<Longrightarrow> \<exists>pm. ko = ArchObj (PageMapL4 pm)"

--- a/proof/refine/AARCH64/ADT_H.thy
+++ b/proof/refine/AARCH64/ADT_H.thy
@@ -27,7 +27,7 @@ consts
   initBootFrames :: "machine_word list"
   initDataStart :: machine_word
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 text \<open>
   The construction of the abstract data type
@@ -1325,7 +1325,7 @@ locale partial_sort_cdt =
                    "pspace_distinct' s'" "valid_objs s" "valid_mdb s" "valid_list s"
 begin
 
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 
 lemma valid_list_2 : "valid_list_2 t m"
   apply (insert assms')
@@ -1510,7 +1510,7 @@ lemma sort_cdt_list_correct:
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition absCDTList where
   "absCDTList cnp h \<equiv> sort_cdt_list (absCDT cnp h) h"

--- a/proof/refine/AARCH64/ArchAcc_R.thy
+++ b/proof/refine/AARCH64/ArchAcc_R.thy
@@ -15,7 +15,7 @@ begin
 
 unbundle l4v_word_context
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 declare if_cong[cong] (* FIXME: if_cong *)
 

--- a/proof/refine/AARCH64/Arch_R.thy
+++ b/proof/refine/AARCH64/Arch_R.thy
@@ -17,7 +17,7 @@ unbundle l4v_word_context
 
 lemmas [datatype_schematic] = cap.sel list.sel(1) list.sel(3)
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 declare arch_cap.sel [datatype_schematic]
 declare is_aligned_shiftl [intro!]

--- a/proof/refine/AARCH64/Bits_R.thy
+++ b/proof/refine/AARCH64/Bits_R.thy
@@ -22,7 +22,7 @@ crunch_ignore (add: lookupPTSlotFromLevel lookupPTFromLevel)
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma throwE_R: "\<lbrace>\<top>\<rbrace> throw f \<lbrace>P\<rbrace>,-"
   by (simp add: validE_R_def) wp

--- a/proof/refine/AARCH64/CNodeInv_R.thy
+++ b/proof/refine/AARCH64/CNodeInv_R.thy
@@ -16,7 +16,7 @@ begin
 
 unbundle l4v_word_context
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 primrec
   valid_cnode_inv' :: "Invocations_H.cnode_invocation \<Rightarrow> kernel_state \<Rightarrow> bool"
@@ -4936,7 +4936,7 @@ lemma cteSwap_valid_pspace'[wp]:
   apply clarsimp+
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 crunch cteSwap
   for tcb_at[wp]: "tcb_at' t"
@@ -6638,7 +6638,7 @@ lemmas threadSet_ctesCaps_of = cteCaps_of_ctes_of_lift[OF threadSet_ctes_of]
 
 lemmas storePTE_cteCaps_of[wp] = cteCaps_of_ctes_of_lift [OF storePTE_ctes]
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma vcpuSwitch_rvk_prog':
   "vcpuSwitch v \<lbrace>\<lambda>s. revoke_progress_ord m (\<lambda>x. map_option capToRPO (cteCaps_of s x))\<rbrace>"
@@ -7895,7 +7895,7 @@ lemma (in mdb_move) m'_cap:
 context mdb_move
 begin
 
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 
 lemma m_to_src:
   "m \<turnstile> p \<leadsto> src = (p \<noteq> 0 \<and> p = mdbPrev src_node)"
@@ -8426,7 +8426,7 @@ qed
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma cteMove_iflive'[wp]:
   "\<lbrace>\<lambda>s. if_live_then_nonz_cap' s
@@ -8607,7 +8607,7 @@ crunch updateMDB
   for valid_bitmaps[wp]: valid_bitmaps
   (rule: valid_bitmaps_lift)
 
-(* FIXME: arch_split *)
+(* FIXME: arch-split *)
 lemma haskell_assert_inv:
   "haskell_assert Q L \<lbrace>P\<rbrace>"
   by wpsimp

--- a/proof/refine/AARCH64/CSpace1_R.thy
+++ b/proof/refine/AARCH64/CSpace1_R.thy
@@ -14,7 +14,7 @@ imports
   CSpace_I
 begin
 
-context Arch begin global_naming AARCH64_A (*FIXME: arch_split*)
+context Arch begin global_naming AARCH64_A (*FIXME: arch-split*)
 
 lemmas final_matters_def = final_matters_def[simplified final_matters_arch_def]
 
@@ -25,7 +25,7 @@ lemmas final_matters_simps[simp]
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma isMDBParentOf_CTE1:
   "isMDBParentOf (CTE cap node) cte =
@@ -2945,7 +2945,7 @@ locale masterCap =
   fixes cap cap'
   assumes master: "capMasterCap cap = capMasterCap cap'"
 begin
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 
 lemma isZombie [simp]:
   "isZombie cap' = isZombie cap" using master
@@ -3534,7 +3534,7 @@ locale mdb_insert_sib = mdb_insert_der +
            (mdbRevocable_update (\<lambda>a. isCapRevocable c' src_cap)
            (mdbPrev_update (\<lambda>a. src) src_node))))"
 begin
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 
 (* If dest is inserted as sibling, src can not have had children.
    If it had had children, then dest_node which is just a derived copy
@@ -3681,7 +3681,7 @@ lemma descendants:
   by (rule set_eqI) (simp add: descendants_of'_def parent_n_eq)
 
 end
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma mdb_None:
   assumes F: "\<And>p'. cte_map p \<in> descendants_of' p' m' \<Longrightarrow> False"
   assumes R: "cdt_relation (swp cte_at s) (cdt s) m'"
@@ -4534,7 +4534,7 @@ locale mdb_inv_preserve =
   \<and> (\<lambda>x. sameRegionAs x (cteCap cte)) = (\<lambda>x. sameRegionAs x (cteCap cte'))"
   assumes mdb_next:"\<And>p. mdb_next m p = mdb_next m' p"
 begin
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 lemma preserve_stuff:
   "valid_dlist m = valid_dlist m'
  \<and> ut_revocable' m = ut_revocable' m'
@@ -5193,7 +5193,7 @@ lemma cte_map_inj_eq':
   apply (rule cte_map_inj_eq; fastforce)
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma cteInsert_corres:
   notes split_paired_All[simp del] split_paired_Ex[simp del]
         trans_state_update'[symmetric,simp]
@@ -7176,7 +7176,7 @@ lemma subtree_no_parent:
   shows "False" using assms
   by induct (auto simp: parentOf_def mdb_next_unfold)
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma ensureNoChildren_corres:
   "p' = cte_map p \<Longrightarrow>

--- a/proof/refine/AARCH64/CSpace_I.thy
+++ b/proof/refine/AARCH64/CSpace_I.thy
@@ -13,7 +13,7 @@ theory CSpace_I
 imports ArchAcc_R
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma capUntypedPtr_simps [simp]:
   "capUntypedPtr (ThreadCap r) = r"
@@ -1527,7 +1527,7 @@ lemma no_mdb_not_target:
   apply (simp add: no_mdb_def)
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma valid_dlist_init:
   "\<lbrakk> valid_dlist m; m p = Some cte; no_mdb cte \<rbrakk> \<Longrightarrow>
   valid_dlist (m (p \<mapsto> CTE cap initMDBNode))"
@@ -1725,7 +1725,7 @@ lemma untyped_inc_init:
     apply (rule untypedRange_in_capRange)+
   apply (simp add:Int_ac)
   done
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma valid_nullcaps_init:
   "\<lbrakk> valid_nullcaps m; cap \<noteq> NullCap \<rbrakk> \<Longrightarrow> valid_nullcaps (m(p \<mapsto> CTE cap initMDBNode))"
   by (simp add: valid_nullcaps_def initMDBNode_def nullPointer_def)
@@ -1785,7 +1785,7 @@ lemma distinct_zombies_copyE:
 lemmas distinct_zombies_sameE
     = distinct_zombies_copyE [where y=x and x=x for x, simplified,
                               OF _ _ _ _ _]
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma capBits_Master:
   "capBits (capMasterCap cap) = capBits cap"
   by (clarsimp simp: capMasterCap_def split: capability.split arch_capability.split)

--- a/proof/refine/AARCH64/CSpace_R.thy
+++ b/proof/refine/AARCH64/CSpace_R.thy
@@ -54,7 +54,7 @@ locale mdb_move =
   modify_map n (mdbNext src_node)
                (cteMDBNode_update (mdbPrev_update (\<lambda>_. dest)))"
 begin
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 
 
 lemmas src = m_p
@@ -735,7 +735,7 @@ lemma set_cap_not_quite_corres':
                 apply (fastforce simp: c p pspace_relations_def)+
                 done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma cteMove_corres:
   assumes cr: "cap_relation cap cap'"
   notes trans_state_update'[symmetric,simp]
@@ -1122,7 +1122,7 @@ crunch cteInsert
 end
 context mdb_insert
 begin
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 lemma n_src_dest:
   "n \<turnstile> src \<leadsto> dest"
   by (simp add: n_direct_eq)
@@ -1648,7 +1648,7 @@ lemma is_derived_badge_derived':
   "is_derived' m src cap cap' \<Longrightarrow> badge_derived' cap cap'"
   by (simp add: is_derived'_def)
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma cteInsert_mdb_chain_0:
   "\<lbrace>valid_mdb' and pspace_aligned' and pspace_distinct' and (\<lambda>s. src \<noteq> dest) and
@@ -4520,7 +4520,7 @@ locale mdb_insert_simple = mdb_insert +
   assumes simple: "is_simple_cap' c'"
 begin
 
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 
 lemma dest_no_parent_n:
   "n \<turnstile> dest \<rightarrow> p = False"
@@ -4714,7 +4714,7 @@ lemma maskedAsFull_revokable_safe_parent:
      apply (clarsimp simp:isCap_simps is_simple_cap'_def)+
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma cteInsert_simple_corres:
   assumes "cap_relation c c'" "src' = cte_map src" "dest' = cte_map dest"
@@ -5089,7 +5089,7 @@ locale mdb_insert_simple' = mdb_insert_simple +
   fixes n'
   defines  "n' \<equiv> modify_map n (mdbNext src_node) (cteMDBNode_update (mdbPrev_update (\<lambda>_. dest)))"
 begin
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 lemma no_0_n' [intro!]: "no_0 n'" by (auto simp: n'_def)
 lemmas n_0_simps' [iff] = no_0_simps [OF no_0_n']
 
@@ -5786,7 +5786,7 @@ lemma updateCapFreeIndex_no_0:
     apply (clarsimp simp:cte_wp_at_ctes_of)+
 done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma cteInsert_simple_mdb':
   "\<lbrace>valid_mdb' and pspace_aligned' and pspace_distinct' and (\<lambda>s. src \<noteq> dest) and K (capAligned cap) and

--- a/proof/refine/AARCH64/Detype_R.thy
+++ b/proof/refine/AARCH64/Detype_R.thy
@@ -9,7 +9,7 @@ theory Detype_R
 imports Retype_R
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 text \<open>Establishing that the invariants are maintained
         when a region of memory is detyped, that is,
@@ -87,7 +87,7 @@ lemma descendants_range_inD':
   done
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma descendants_range'_def2:
   "descendants_range' cap p = descendants_range_in' (capRange cap) p"
@@ -465,7 +465,7 @@ lemma (in detype_locale') deletionIsSafe:
   and      vu: "valid_untyped (cap.UntypedCap d base magnitude idx) s"
   shows       "deletionIsSafe base magnitude s'"
 proof -
-  interpret Arch . (* FIXME: arch_split *)
+  interpret Arch . (* FIXME: arch-split *)
   note [simp del] = atLeastatMost_subset_iff atLeastLessThan_iff atLeastAtMost_iff
                     Int_atLeastAtMost atLeastatMost_empty_iff split_paired_Ex
   have "\<And>t m r. \<exists>ptr. cte_wp_at ((=) (cap.ReplyCap t m r)) ptr s
@@ -549,7 +549,7 @@ proof -
   thus ?thesis using cte by (auto simp: deletionIsSafe_def)
 qed
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 text \<open>Invariant preservation across concrete deletion\<close>
 
@@ -622,7 +622,7 @@ locale delete_locale =
   and      al: "is_aligned base bits"
   and    safe: "deletionIsSafe base bits s'"
 
-context delete_locale begin interpretation Arch . (*FIXME: arch_split*)
+context delete_locale begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma valid_objs: "valid_objs' s'"
   and        pa: "pspace_aligned' s'"
@@ -855,7 +855,7 @@ lemma sym_refs_TCB_hyp_live':
   done
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 (* FIXME: generalizes lemma SubMonadLib.corres_submonad *)
 (* FIXME: generalizes lemma SubMonad_R.corres_machine_op *)
@@ -1134,7 +1134,7 @@ lemma deleteObjects_corres:
   done
 end
 
-context delete_locale begin interpretation Arch . (*FIXME: arch_split*)
+context delete_locale begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma live_idle_untyped_range':
   "ko_wp_at' live' p s' \<or> p = idle_thread_ptr \<Longrightarrow> p \<notin> base_bits"
@@ -1445,7 +1445,7 @@ using vds
 proof (simp add: invs'_def valid_state'_def valid_pspace'_def
                  valid_mdb'_def valid_mdb_ctes_def,
        safe)
-  interpret Arch . (*FIXME: arch_split*)
+  interpret Arch . (*FIXME: arch-split*)
   let ?s = state'
   let ?ran = base_bits
 
@@ -1818,7 +1818,7 @@ lemma doMachineOp_modify:
   apply (simp add: simpler_gets_def simpler_modify_def bind_def)
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma deleteObjects_invs':
   "\<lbrace>cte_wp_at' (\<lambda>c. cteCap c = UntypedCap d ptr bits idx) p

--- a/proof/refine/AARCH64/EmptyFail.thy
+++ b/proof/refine/AARCH64/EmptyFail.thy
@@ -66,7 +66,7 @@ lemma empty_fail_getSlotCap [intro!, wp, simp]:
   "empty_fail (getSlotCap a)"
   unfolding getSlotCap_def by fastforce
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma empty_fail_getObject:
   assumes "\<And>b c d. empty_fail (loadObject x b c d::'a :: pspace_storable kernel)"

--- a/proof/refine/AARCH64/EmptyFail_H.thy
+++ b/proof/refine/AARCH64/EmptyFail_H.thy
@@ -14,7 +14,7 @@ crunch_ignore (empty_fail)
         CSpaceDecls_H.resolveAddressBits
         doMachineOp suspend restart schedule)
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemmas forM_empty_fail[intro!, wp, simp] = empty_fail_mapM[simplified forM_def[symmetric]]
 lemmas forM_x_empty_fail[intro!, wp, simp] = empty_fail_mapM_x[simplified forM_x_def[symmetric]]

--- a/proof/refine/AARCH64/Finalise_R.thy
+++ b/proof/refine/AARCH64/Finalise_R.thy
@@ -12,7 +12,7 @@ imports
   Retype_R
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 declare doUnbindNotification_def[simp]
 
@@ -187,7 +187,7 @@ locale mdb_empty =
                slot (cteCap_update (%_. capability.NullCap)))
               slot (cteMDBNode_update (const nullMDBNode))"
 begin
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 
 lemmas m_slot_prev = m_p_prev
 lemmas m_slot_next = m_p_next
@@ -1416,7 +1416,7 @@ lemma deletedIRQHandler_irqs_masked'[wp]:
   apply (simp add: irqs_masked'_def)
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 crunch emptySlot
   for irqs_masked'[wp]: "irqs_masked'"
 
@@ -2056,7 +2056,7 @@ lemma (in vmdb) isFinal_untypedParent:
                    sameObjectAs_sym)
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma no_fail_isFinalCapability [wp]:
   "no_fail (valid_mdb' and cte_wp_at' ((=) cte) p) (isFinalCapability cte)"
@@ -3234,7 +3234,7 @@ lemma suspend_tcbSchedNext_tcbSchedPrev_None:
   unfolding suspend_def
   by (wpsimp wp: hoare_drop_imps tcbSchedDequeue_tcbSchedNext_tcbSchedPrev_None_obj_at')
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma archThreadSet_tcbSchedPrevNext[wp]:
   "archThreadSet f t' \<lbrace>obj_at' (\<lambda>tcb. P (tcbSchedNext tcb) (tcbSchedPrev tcb)) t\<rbrace>"
@@ -3368,7 +3368,7 @@ lemma suspend_cte_wp_at':
              | simp add: x)+
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 crunch deleteASIDPool
   for cte_wp_at'[wp]: "cte_wp_at' P p"
@@ -3714,7 +3714,7 @@ lemmas getCTE_no_0_obj'_helper
   = getCTE_inv
     hoare_strengthen_post[where Q'="\<lambda>_. no_0_obj'" and P=no_0_obj' and f="getCTE slot" for slot]
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 crunch invalidateTLBByASID
   for nosch[wp]: "\<lambda>s. P (ksSchedulerAction s)"
@@ -3784,7 +3784,7 @@ lemma (in delete_one) deletingIRQHandler_corres:
   apply (clarsimp simp: cte_wp_at_ctes_of)
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma sym_refs_vcpu_tcb: (* FIXME: move to AInvs *)
   "\<lbrakk> vcpus_of s v = Some vcpu; vcpu_tcb vcpu = Some t; sym_refs (state_hyp_refs_of s) \<rbrakk> \<Longrightarrow>
@@ -4035,7 +4035,7 @@ lemma finaliseCap_corres:
   apply (rule corres_guard_imp [OF arch_finaliseCap_corres], (fastforce simp: valid_sched_def)+)
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma threadSet_ct_idle_or_in_cur_domain':
   "\<lbrace>ct_idle_or_in_cur_domain' and (\<lambda>s. \<forall>tcb. tcbDomain tcb = ksCurDomain s \<longrightarrow> tcbDomain (F tcb) = ksCurDomain s)\<rbrace>

--- a/proof/refine/AARCH64/Init_R.thy
+++ b/proof/refine/AARCH64/Init_R.thy
@@ -11,7 +11,7 @@ imports
 
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 (*
   This provides a very simple witness that the state relation used in the first refinement proof is

--- a/proof/refine/AARCH64/InterruptAcc_R.thy
+++ b/proof/refine/AARCH64/InterruptAcc_R.thy
@@ -19,7 +19,7 @@ lemma getIRQSlot_corres:
                    ucast_nat_def shiftl_t2n)
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma setIRQState_corres:
   "irq_state_relation state state' \<Longrightarrow>

--- a/proof/refine/AARCH64/Interrupt_R.thy
+++ b/proof/refine/AARCH64/Interrupt_R.thy
@@ -15,7 +15,7 @@ begin
 
 context Arch begin
 
-(*FIXME: arch_split: move up *)
+(*FIXME: arch-split: move up *)
 requalify_types
   irqcontrol_invocation
 
@@ -23,11 +23,11 @@ lemmas [crunch_def] = decodeIRQControlInvocation_def performIRQControl_def
 
 context begin global_naming global
 
-(*FIXME: arch_split: move up *)
+(*FIXME: arch-split: move up *)
 requalify_types
   Invocations_H.irqcontrol_invocation
 
-(*FIXME: arch_split*)
+(*FIXME: arch-split*)
 requalify_facts
   Interrupt_H.decodeIRQControlInvocation_def
   Interrupt_H.performIRQControl_def
@@ -88,7 +88,7 @@ where
       ex_cte_cap_to' ptr and real_cte_at' ptr and
       (Not o irq_issued' irq) and K (irq \<le> maxIRQ))"
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma decodeIRQHandlerInvocation_corres:
   "\<lbrakk> list_all2 cap_relation (map fst caps) (map fst caps');

--- a/proof/refine/AARCH64/Invariants_H.thy
+++ b/proof/refine/AARCH64/Invariants_H.thy
@@ -279,7 +279,7 @@ definition live' :: "kernel_object \<Rightarrow> bool" where
   | KOKernelData        => False
   | KOArch ako          => hyp_live' ko"
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 primrec azobj_refs' :: "arch_capability \<Rightarrow> obj_ref set" where
   "azobj_refs' (ASIDPoolCap _ _) = {}"
@@ -1271,7 +1271,7 @@ locale mdb_order = mdb_next +
 
 \<comment> \<open>---------------------------------------------------------------------------\<close>
 section "Alternate split rules for preserving subgoal order"
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma ntfn_splits[split]:
   " P (case ntfn of Structures_H.ntfn.IdleNtfn \<Rightarrow> f1
      | Structures_H.ntfn.ActiveNtfn x \<Rightarrow> f2 x
@@ -2968,7 +2968,7 @@ lemma le_maxDomain_eq_less_numDomains:
   by (auto simp: Kernel_Config.numDomains_def maxDomain_def word_le_nat_alt)
 
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma page_table_pte_atI':
   "\<lbrakk> page_table_at' pt_t p s; i \<le> mask (ptTranslationBits pt_t) \<rbrakk> \<Longrightarrow>
@@ -3126,7 +3126,7 @@ lemma vms_sch_act_update'[iff]:
    valid_machine_state' s"
   by (simp add: valid_machine_state'_def )
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemmas bit_simps' = pteBits_def asidHighBits_def asidPoolBits_def asid_low_bits_def
                     asid_high_bits_def bit_simps

--- a/proof/refine/AARCH64/Invocations_R.thy
+++ b/proof/refine/AARCH64/Invocations_R.thy
@@ -8,7 +8,7 @@ theory Invocations_R
 imports Bits_R
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma invocationType_eq[simp]:
   "invocationType = invocation_type"

--- a/proof/refine/AARCH64/IpcCancel_R.thy
+++ b/proof/refine/AARCH64/IpcCancel_R.thy
@@ -10,7 +10,7 @@ imports
   Schedule_R
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 crunch cancelAllIPC
   for aligned'[wp]: pspace_aligned'
@@ -338,7 +338,7 @@ lemma cte_map_tcb_2:
   "cte_map (t, tcb_cnode_index 2) = t + 2*2^cte_level_bits"
   by (simp add: cte_map_def tcb_cnode_index_def to_bl_1 shiftl_t2n)
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma cte_wp_at_master_reply_cap_to_ex_rights:
   "cte_wp_at (is_master_reply_cap_to t) ptr
@@ -512,7 +512,7 @@ lemma (in delete_one) cancelIPC_ReplyCap_corres:
           od)
        od)"
   proof -
-  interpret Arch . (*FIXME: arch_split*)
+  interpret Arch . (*FIXME: arch-split*)
   show ?thesis
   apply (simp add: reply_cancel_ipc_def getThreadReplySlot_def
                    locateSlot_conv liftM_def tcbReplySlot_def
@@ -645,7 +645,7 @@ crunch setNotification
 lemma sch_act_simple_not_t[simp]: "sch_act_simple s \<Longrightarrow> sch_act_not t s"
   by (clarsimp simp: sch_act_simple_def)
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 crunch setNotification
   for sym_heap_sched_pointers[wp]: sym_heap_sched_pointers
@@ -2030,7 +2030,7 @@ lemma cancelAll_unlive_helper:
   apply (clarsimp elim!: ko_wp_at'_weakenE)
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma setObject_ko_wp_at':
   fixes v :: "'a :: pspace_storable"
   assumes x: "\<And>v :: 'a. updateObject v = updateObject_default v"

--- a/proof/refine/AARCH64/Ipc_R.thy
+++ b/proof/refine/AARCH64/Ipc_R.thy
@@ -9,7 +9,7 @@ theory Ipc_R
 imports Finalise_R
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemmas lookup_slot_wrapper_defs'[simp] =
    lookupSourceSlot_def lookupTargetSlot_def lookupPivotSlot_def

--- a/proof/refine/AARCH64/KHeap_R.thy
+++ b/proof/refine/AARCH64/KHeap_R.thy
@@ -21,7 +21,7 @@ lemma koTypeOf_injectKO:
   apply (simp add: project_koType[symmetric])
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma setObject_modify_variable_size:
   fixes v :: "'a :: pspace_storable" shows
@@ -94,7 +94,7 @@ end
 translations
   (type) "'a kernel" <=(type) "kernel_state \<Rightarrow> ('a \<times> kernel_state) set \<times> bool"
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma no_fail_loadObject_default [wp]:
   "no_fail (\<lambda>s. \<exists>obj. projectKO_opt ko = Some (obj::'a) \<and>

--- a/proof/refine/AARCH64/Machine_R.thy
+++ b/proof/refine/AARCH64/Machine_R.thy
@@ -22,7 +22,7 @@ lemma irq_state_independent_HI[intro!, simp]:
    \<Longrightarrow> irq_state_independent_H P"
   by (simp add: irq_state_independent_H_def)
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma dmo_getirq_inv[wp]:
   "irq_state_independent_H P \<Longrightarrow> \<lbrace>P\<rbrace> doMachineOp (getActiveIRQ in_kernel) \<lbrace>\<lambda>rv. P\<rbrace>"

--- a/proof/refine/AARCH64/PageTableDuplicates.thy
+++ b/proof/refine/AARCH64/PageTableDuplicates.thy
@@ -8,7 +8,7 @@ theory PageTableDuplicates
 imports Syscall_R
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma doMachineOp_ksPSpace_inv[wp]:
   "\<lbrace>\<lambda>s. P (ksPSpace s)\<rbrace> doMachineOp f \<lbrace>\<lambda>ya s. P (ksPSpace s)\<rbrace>"

--- a/proof/refine/AARCH64/Refine.thy
+++ b/proof/refine/AARCH64/Refine.thy
@@ -17,7 +17,7 @@ imports
   PageTableDuplicates
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 text \<open>User memory content is the same on both levels\<close>
 lemma typ_at_AUserDataI:

--- a/proof/refine/AARCH64/Retype_R.thy
+++ b/proof/refine/AARCH64/Retype_R.thy
@@ -13,7 +13,7 @@ theory Retype_R
 imports VSpace_R
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition
   APIType_map2 :: "kernel_object + AARCH64_H.object_type \<Rightarrow> Structures_A.apiobject_type"
@@ -1172,7 +1172,7 @@ end
 global_interpretation update_gs: PSpace_update_eq "update_gs ty us ptrs"
   by (simp add: PSpace_update_eq_def)
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma ksMachineState_update_gs[simp]:
   "ksMachineState (update_gs tp us addrs s) = ksMachineState s"
@@ -1684,7 +1684,7 @@ end
 interpretation retype_region2_ext_extended: is_extended "retype_region2_ext ptrs type"
   by (unfold_locales; wp)
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition
  "retype_region2_extra_ext ptrs type \<equiv>
@@ -1703,7 +1703,7 @@ end
 interpretation retype_region2_extra_ext_extended: is_extended "retype_region2_extra_ext ptrs type"
   by (unfold_locales; wp)
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition
   retype_region2 :: "obj_ref \<Rightarrow> nat \<Rightarrow> nat \<Rightarrow> Structures_A.apiobject_type \<Rightarrow> bool \<Rightarrow> (obj_ref list,'z::state_ext) s_monad"
@@ -2805,7 +2805,7 @@ locale retype_mdb = vmdb +
   defines "n \<equiv> \<lambda>p. if P p then Some makeObject else m p"
 begin
 
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 
 lemma no_0_n: "no_0 n"
   using no_0 by (simp add: no_0_def n_def 0)
@@ -3137,7 +3137,7 @@ lemma caps_no_overlapD'':
   apply blast
 done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma valid_untyped'_helper:
   assumes valid : "valid_cap' c s"

--- a/proof/refine/AARCH64/Schedule_R.thy
+++ b/proof/refine/AARCH64/Schedule_R.thy
@@ -9,7 +9,7 @@ theory Schedule_R
 imports VSpace_R
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 declare hoare_weak_lift_imp[wp_split del]
 

--- a/proof/refine/AARCH64/SubMonad_R.thy
+++ b/proof/refine/AARCH64/SubMonad_R.thy
@@ -44,7 +44,7 @@ lemma doMachineOp_mapM_x:
   done
 
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 definition
   "asUser_fetch \<equiv> \<lambda>t s. case (ksPSpace s t) of
       Some (KOTCB tcb) \<Rightarrow> (atcbContextGet o tcbArch) tcb

--- a/proof/refine/AARCH64/Syscall_R.thy
+++ b/proof/refine/AARCH64/Syscall_R.thy
@@ -13,7 +13,7 @@ theory Syscall_R
 imports Tcb_R Arch_R Interrupt_R
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 (*
 syscall has 5 sections: m_fault h_fault m_error h_error m_finalise

--- a/proof/refine/AARCH64/TcbAcc_R.thy
+++ b/proof/refine/AARCH64/TcbAcc_R.thy
@@ -9,7 +9,7 @@ theory TcbAcc_R
 imports CSpace_R ArchMove_R
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 declare if_weak_cong [cong]
 declare hoare_in_monad_post[wp]

--- a/proof/refine/AARCH64/Tcb_R.thy
+++ b/proof/refine/AARCH64/Tcb_R.thy
@@ -9,7 +9,7 @@ theory Tcb_R
 imports CNodeInv_R
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma asUser_setNextPC_corres:
   "corres dc (tcb_at t and invs) (tcb_at' t and invs')
@@ -1604,7 +1604,7 @@ end
 consts
   copyregsets_map :: "arch_copy_register_sets \<Rightarrow> Arch.copy_register_sets"
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 primrec
   tcbinv_relation :: "tcb_invocation \<Rightarrow> tcbinvocation \<Rightarrow> bool"

--- a/proof/refine/AARCH64/Untyped_R.thy
+++ b/proof/refine/AARCH64/Untyped_R.thy
@@ -13,7 +13,7 @@ begin
 
 unbundle l4v_word_context
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 primrec
   untypinv_relation :: "Invocations_A.untyped_invocation \<Rightarrow>
@@ -974,7 +974,7 @@ locale mdb_insert_again =
 
 context mdb_insert_again
 begin
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 lemmas parent = mdb_ptr_parent.m_p
 lemmas site = mdb_ptr_site.m_p
 
@@ -1362,7 +1362,7 @@ crunch create_cap_ext
 crunch create_cap_ext
   for work_units_completed[wp]: "\<lambda>s. P (work_units_completed s)"
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma updateNewFreeIndex_noop_psp_corres:
   "corres_underlying {(s, s'). pspace_relations (ekheap s) (kheap s) (ksPSpace s')} False True
@@ -1696,7 +1696,7 @@ locale mdb_insert_again_all = mdb_insert_again_child +
   fixes n'
   defines "n' \<equiv> modify_map n (mdbNext parent_node) (cteMDBNode_update (mdbPrev_update (\<lambda>a. site)))"
 begin
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 lemma no_0_n' [simp]: "no_0 n'"
   using no_0_n by (simp add: n'_def)
 
@@ -2672,7 +2672,7 @@ lemma caps_overlap_reserved'_D:
   apply fastforce
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma insertNewCap_valid_mdb:
   "\<lbrace>valid_mdb' and valid_objs' and K (slot \<noteq> p) and
     caps_overlap_reserved' (untypedRange cap) and
@@ -3872,7 +3872,7 @@ lemma cte_wp_at': "cte_wp_at' (\<lambda>cte. cteCap cte = capability.UntypedCap
   using vui
   by (auto simp: cte_wp_at_ctes_of)
 
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 
 lemma idx_cases:
   "((\<not> reset \<and> idx \<le> unat (ptr - (ptr && ~~ mask sz))) \<or> reset \<and> ptr = ptr && ~~ mask sz)"
@@ -4035,7 +4035,7 @@ lemma idx_le_new_offs:
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma valid_sched_etcbs[elim!]: "valid_sched_2 queues ekh sa cdom kh ct it \<Longrightarrow> valid_etcbs_2 ekh kh"
   by (simp add: valid_sched_def)
@@ -4225,7 +4225,7 @@ lemma ex_tupI:
   "P (fst x) (snd x) \<Longrightarrow> \<exists>a b. P a b"
   by blast
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma resetUntypedCap_corres:
   "untypinv_relation ui ui'
@@ -4432,7 +4432,7 @@ lemma ex_cte_cap_wp_to_irq_state_independent_H[simp]:
   "irq_state_independent_H (ex_cte_cap_wp_to' P slot)"
   by (simp add: ex_cte_cap_wp_to'_def)
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma updateFreeIndex_ctes_of:
   "\<lbrace>\<lambda>s.  P (modify_map (ctes_of s) ptr (cteCap_update (capFreeIndex_update (\<lambda>_. idx))))\<rbrace>
@@ -4657,7 +4657,7 @@ lemma (in range_cover) funky_aligned:
 defs canonicalAddressAssert_def:
   "canonicalAddressAssert \<equiv> AARCH64.canonical_address"
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma inv_untyped_corres':
   "\<lbrakk> untypinv_relation ui ui' \<rbrakk> \<Longrightarrow>

--- a/proof/refine/AARCH64/VSpace_R.thy
+++ b/proof/refine/AARCH64/VSpace_R.thy
@@ -17,7 +17,7 @@ lemma cteCaps_of_ctes_of_lift:
   "(\<And>P. \<lbrace>\<lambda>s. P (ctes_of s)\<rbrace> f \<lbrace>\<lambda>_ s. P (ctes_of s)\<rbrace>) \<Longrightarrow> \<lbrace>\<lambda>s. P (cteCaps_of s) \<rbrace> f \<lbrace>\<lambda>_ s. P (cteCaps_of s)\<rbrace>"
   unfolding cteCaps_of_def .
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition
   "vspace_at_asid' vs asid \<equiv> \<lambda>s. \<exists>ap pool entry.

--- a/proof/refine/AARCH64/orphanage/Orphanage.thy
+++ b/proof/refine/AARCH64/orphanage/Orphanage.thy
@@ -14,7 +14,7 @@ text \<open>
   or about to be switched to, or be in a scheduling queue.
 \<close>
 
-(*FIXME: arch_split: move up? *)
+(*FIXME: arch-split: move up? *)
 context Arch begin
 
 requalify_facts
@@ -30,7 +30,7 @@ requalify_facts
 end
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition
    is_active_thread_state :: "thread_state \<Rightarrow> bool"

--- a/proof/refine/ARM/ADT_H.thy
+++ b/proof/refine/ARM/ADT_H.thy
@@ -28,7 +28,7 @@ consts
   initBootFrames :: "word32 list"
   initDataStart :: word32
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 text \<open>
   The construction of the abstract data type
@@ -1457,7 +1457,7 @@ locale partial_sort_cdt = partial_sort "\<lambda> x y.  m' \<turnstile> cte_map 
 
 begin
 
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 
 lemma valid_list_2 : "valid_list_2 t m"
     apply (insert assms')
@@ -1654,7 +1654,7 @@ lemma sort_cdt_list_correct:
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition absCDTList where
 "absCDTList cnp h \<equiv> sort_cdt_list (absCDT cnp h) h"

--- a/proof/refine/ARM/ArchAcc_R.thy
+++ b/proof/refine/ARM/ArchAcc_R.thy
@@ -26,7 +26,7 @@ method simp_to_elim = (drule fun_all, elim allE impE)
 
 end
 
-context Arch begin global_naming ARM_A (*FIXME: arch_split*)
+context Arch begin global_naming ARM_A (*FIXME: arch-split*)
 
 lemma asid_pool_at_ko:
   "asid_pool_at p s \<Longrightarrow> \<exists>pool. ko_at (ArchObj (ARM_A.ASIDPool pool)) p s"
@@ -45,7 +45,7 @@ lemmas valid_vspace_obj_elims [rule_format, elim!] =
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 (*FIXME move *)
 

--- a/proof/refine/ARM/Arch_R.thy
+++ b/proof/refine/ARM/Arch_R.thy
@@ -15,7 +15,7 @@ begin
 
 unbundle l4v_word_context
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 declare is_aligned_shiftl [intro!]
 declare is_aligned_shiftr [intro!]

--- a/proof/refine/ARM/Bits_R.thy
+++ b/proof/refine/ARM/Bits_R.thy
@@ -22,7 +22,7 @@ crunch_ignore (add:
   unifyFailure ignoreFailure empty_on_failure emptyOnFailure clearMemoryVM null_cap_on_failure
   setNextPC getRestartPC assertDerived throw_on_false getObject setObject updateObject loadObject)
 
-context Arch begin (*FIXME: arch_split*)
+context Arch begin (*FIXME: arch-split*)
 
 crunch_ignore (add:
   invalidateLocalTLB_ASID invalidateLocalTLB_VAASID
@@ -33,7 +33,7 @@ crunch_ignore (add:
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma throwE_R: "\<lbrace>\<top>\<rbrace> throw f \<lbrace>P\<rbrace>,-"
   by (simp add: validE_R_def) wp

--- a/proof/refine/ARM/CNodeInv_R.thy
+++ b/proof/refine/ARM/CNodeInv_R.thy
@@ -15,7 +15,7 @@ begin
 
 unbundle l4v_word_context
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 primrec
   valid_cnode_inv' :: "Invocations_H.cnode_invocation \<Rightarrow> kernel_state \<Rightarrow> bool"
@@ -4935,7 +4935,7 @@ lemma cteSwap_valid_pspace'[wp]:
   apply clarsimp+
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 crunch cteSwap
   for tcb_at[wp]: "tcb_at' t"
@@ -6631,7 +6631,7 @@ lemmas threadSet_ctesCaps_of = ctes_of_cteCaps_of_lift[OF threadSet_ctes_of]
 lemmas storePTE_cteCaps_of[wp] = ctes_of_cteCaps_of_lift [OF storePTE_ctes]
 lemmas storePDE_cteCaps_of[wp] = ctes_of_cteCaps_of_lift [OF storePDE_ctes]
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 context
 notes option.case_cong_weak[cong]
@@ -7850,7 +7850,7 @@ lemma (in mdb_move) m'_cap:
 context mdb_move
 begin
 
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 
 lemma m_to_src:
   "m \<turnstile> p \<leadsto> src = (p \<noteq> 0 \<and> p = mdbPrev src_node)"
@@ -8381,7 +8381,7 @@ qed
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma cteMove_iflive'[wp]:
   "\<lbrace>\<lambda>s. if_live_then_nonz_cap' s
@@ -8558,7 +8558,7 @@ crunch updateMDB
   for valid_bitmaps[wp]: valid_bitmaps
   (rule: valid_bitmaps_lift)
 
-(* FIXME: arch_split *)
+(* FIXME: arch-split *)
 lemma haskell_assert_inv:
   "haskell_assert Q L \<lbrace>P\<rbrace>"
   by wpsimp

--- a/proof/refine/ARM/CSpace1_R.thy
+++ b/proof/refine/ARM/CSpace1_R.thy
@@ -14,7 +14,7 @@ imports
   "AInvs.ArchDetSchedSchedule_AI"
 begin
 
-context Arch begin global_naming ARM_A (*FIXME: arch_split*)
+context Arch begin global_naming ARM_A (*FIXME: arch-split*)
 
 lemmas final_matters_def = final_matters_def[simplified final_matters_arch_def]
 
@@ -25,7 +25,7 @@ lemmas final_matters_simps[simp]
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma isMDBParentOf_CTE1:
   "isMDBParentOf (CTE cap node) cte =
@@ -2816,7 +2816,7 @@ locale masterCap =
   fixes cap cap'
   assumes master: "capMasterCap cap = capMasterCap cap'"
 begin
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 
 lemma isZombie [simp]:
   "isZombie cap' = isZombie cap" using master
@@ -3399,7 +3399,7 @@ locale mdb_insert_sib = mdb_insert_der +
            (mdbRevocable_update (\<lambda>a. revokable' src_cap c')
            (mdbPrev_update (\<lambda>a. src) src_node))))"
 begin
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 
 (* If dest is inserted as sibling, src can not have had children.
    If it had had children, then dest_node which is just a derived copy
@@ -3546,7 +3546,7 @@ lemma descendants:
   by (rule set_eqI) (simp add: descendants_of'_def parent_n_eq)
 
 end
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma mdb_None:
   assumes F: "\<And>p'. cte_map p \<in> descendants_of' p' m' \<Longrightarrow> False"
   assumes R: "cdt_relation (swp cte_at s) (cdt s) m'"
@@ -4407,7 +4407,7 @@ locale mdb_inv_preserve =
   \<and> (\<lambda>x. sameRegionAs x (cteCap cte)) = (\<lambda>x. sameRegionAs x (cteCap cte'))"
   assumes mdb_next:"\<And>p. mdb_next m p = mdb_next m' p"
 begin
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 lemma preserve_stuff:
   "valid_dlist m = valid_dlist m'
  \<and> ut_revocable' m = ut_revocable' m'
@@ -5066,7 +5066,7 @@ lemma cte_map_inj_eq':
   apply (rule cte_map_inj_eq; fastforce)
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma cteInsert_corres:
   notes split_paired_All[simp del] split_paired_Ex[simp del]
         trans_state_update'[symmetric,simp]
@@ -7048,7 +7048,7 @@ lemma subtree_no_parent:
   shows "False" using assms
   by induct (auto simp: parentOf_def mdb_next_unfold)
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma ensureNoChildren_corres:
   "p' = cte_map p \<Longrightarrow>

--- a/proof/refine/ARM/CSpace_I.thy
+++ b/proof/refine/ARM/CSpace_I.thy
@@ -12,7 +12,7 @@ theory CSpace_I
 imports ArchAcc_R
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma capUntypedPtr_simps [simp]:
   "capUntypedPtr (ThreadCap r) = r"
@@ -1515,7 +1515,7 @@ lemma no_mdb_not_target:
   apply (simp add: no_mdb_def)
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma valid_dlist_init:
   "\<lbrakk> valid_dlist m; m p = Some cte; no_mdb cte \<rbrakk> \<Longrightarrow>
   valid_dlist (m (p \<mapsto> CTE cap initMDBNode))"
@@ -1713,7 +1713,7 @@ lemma untyped_inc_init:
     apply (rule untypedRange_in_capRange)+
   apply (simp add:Int_ac)
   done
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma valid_nullcaps_init:
   "\<lbrakk> valid_nullcaps m; cap \<noteq> NullCap \<rbrakk> \<Longrightarrow> valid_nullcaps (m(p \<mapsto> CTE cap initMDBNode))"
   by (simp add: valid_nullcaps_def initMDBNode_def nullPointer_def)
@@ -1773,7 +1773,7 @@ lemma distinct_zombies_copyE:
 lemmas distinct_zombies_sameE
     = distinct_zombies_copyE [where y=x and x=x for x, simplified,
                               OF _ _ _ _ _]
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma capBits_Master:
   "capBits (capMasterCap cap) = capBits cap"
   by (clarsimp simp: capMasterCap_def split: capability.split arch_capability.split)

--- a/proof/refine/ARM/CSpace_R.thy
+++ b/proof/refine/ARM/CSpace_R.thy
@@ -53,7 +53,7 @@ locale mdb_move =
   modify_map n (mdbNext src_node)
                (cteMDBNode_update (mdbPrev_update (\<lambda>_. dest)))"
 begin
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 
 
 lemmas src = m_p
@@ -733,7 +733,7 @@ lemma set_cap_not_quite_corres':
                 using cr
                 apply (fastforce simp: c p pspace_relations_def)+
                 done
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma cteMove_corres:
   assumes cr: "cap_relation cap cap'"
   notes trans_state_update'[symmetric,simp]
@@ -1129,7 +1129,7 @@ crunch cteInsert
 end
 context mdb_insert
 begin
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 lemma n_src_dest:
   "n \<turnstile> src \<leadsto> dest"
   by (simp add: n_direct_eq)
@@ -1649,7 +1649,7 @@ lemma untyped_inc_prev_update:
 lemma is_derived_badge_derived':
   "is_derived' m src cap cap' \<Longrightarrow> badge_derived' cap cap'"
   by (simp add: is_derived'_def)
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma cteInsert_mdb_chain_0:
   "\<lbrace>valid_mdb' and pspace_aligned' and pspace_distinct' and (\<lambda>s. src \<noteq> dest) and
     (\<lambda>s. cte_wp_at' (is_derived' (ctes_of s) src cap \<circ> cteCap) src s)\<rbrace>
@@ -4514,7 +4514,7 @@ locale mdb_insert_simple = mdb_insert +
   assumes safe_parent: "safe_parent_for' m src c'"
   assumes simple: "is_simple_cap' c'"
 begin
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 lemma dest_no_parent_n:
   "n \<turnstile> dest \<rightarrow> p = False"
   using src simple safe_parent
@@ -4704,7 +4704,7 @@ lemma maskedAsFull_revokable_safe_parent:
      apply (clarsimp simp:isCap_simps is_simple_cap'_def)+
 done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma cteInsert_simple_corres:
   assumes "cap_relation c c'" "src' = cte_map src" "dest' = cte_map dest"
   notes trans_state_update'[symmetric,simp]
@@ -5084,7 +5084,7 @@ locale mdb_insert_simple' = mdb_insert_simple +
   fixes n'
   defines  "n' \<equiv> modify_map n (mdbNext src_node) (cteMDBNode_update (mdbPrev_update (\<lambda>_. dest)))"
 begin
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 lemma no_0_n' [intro!]: "no_0 n'" by (auto simp: n'_def)
 lemmas n_0_simps' [iff] = no_0_simps [OF no_0_n']
 
@@ -5763,7 +5763,7 @@ lemma mdb:
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma cteInsert_simple_mdb':
   "\<lbrace>valid_mdb' and pspace_aligned' and pspace_distinct' and (\<lambda>s. src \<noteq> dest) and K (capAligned cap) and
     (\<lambda>s. safe_parent_for' (ctes_of s) src cap) and K (is_simple_cap' cap) \<rbrace>

--- a/proof/refine/ARM/Detype_R.thy
+++ b/proof/refine/ARM/Detype_R.thy
@@ -8,7 +8,7 @@ theory Detype_R
 imports Retype_R
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 text \<open>Establishing that the invariants are maintained
         when a region of memory is detyped, that is,
@@ -86,7 +86,7 @@ lemma descendants_range_inD':
   done
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma descendants_range'_def2:
   "descendants_range' cap p = descendants_range_in' (capRange cap) p"
@@ -449,7 +449,7 @@ lemma (in detype_locale') deletionIsSafe:
   and      vu: "valid_untyped (cap.UntypedCap d base magnitude idx) s"
   shows       "deletionIsSafe base magnitude s'"
 proof -
-  interpret Arch . (* FIXME: arch_split *)
+  interpret Arch . (* FIXME: arch-split *)
   note [simp del] = atLeastatMost_subset_iff atLeastLessThan_iff atLeastAtMost_iff
                     Int_atLeastAtMost atLeastatMost_empty_iff split_paired_Ex
   have "\<And>t m r. \<exists>ptr. cte_wp_at ((=) (cap.ReplyCap t m r)) ptr s
@@ -528,7 +528,7 @@ proof -
   thus ?thesis using cte by (auto simp: deletionIsSafe_def)
 qed
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 text \<open>Invariant preservation across concrete deletion\<close>
 
@@ -579,7 +579,7 @@ locale delete_locale =
   and      al: "is_aligned base bits"
   and    safe: "deletionIsSafe base bits s'"
 
-context delete_locale begin interpretation Arch . (*FIXME: arch_split*)
+context delete_locale begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma valid_objs: "valid_objs' s'"
   and        pa: "pspace_aligned' s'"
@@ -794,7 +794,7 @@ lemma refs_notRange:
   done
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma ksASIDMapSafeI:
   "\<lbrakk> (s,s') \<in> state_relation; invs s; pspace_aligned' s' \<and> pspace_distinct' s' \<rbrakk>
@@ -1064,7 +1064,7 @@ lemma deleteObjects_corres:
   done
 end
 
-context delete_locale begin interpretation Arch . (*FIXME: arch_split*)
+context delete_locale begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma live_idle_untyped_range':
   "ko_wp_at' live' p s' \<or> p = idle_thread_ptr \<Longrightarrow> p \<notin> base_bits"
@@ -1378,7 +1378,7 @@ using vds
 proof (simp add: invs'_def valid_state'_def valid_pspace'_def
                  valid_mdb'_def valid_mdb_ctes_def,
        safe)
-  interpret Arch . (*FIXME: arch_split*)
+  interpret Arch . (*FIXME: arch-split*)
   let ?s = state'
   let ?ran = base_bits
 
@@ -1755,7 +1755,7 @@ lemma doMachineOp_modify:
   apply (rule ext)
   apply (simp add: simpler_gets_def simpler_modify_def bind_def)
   done
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma deleteObjects_invs':
   "\<lbrace>cte_wp_at' (\<lambda>c. cteCap c = UntypedCap d ptr bits idx) p
      and invs' and ct_active' and sch_act_simple

--- a/proof/refine/ARM/EmptyFail.thy
+++ b/proof/refine/ARM/EmptyFail.thy
@@ -62,7 +62,7 @@ lemma empty_fail_getSlotCap [intro!, wp, simp]:
   "empty_fail (getSlotCap a)"
   unfolding getSlotCap_def by fastforce
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma empty_fail_getObject:
   assumes "\<And>b c d. empty_fail (loadObject x b c d::'a :: pspace_storable kernel)"

--- a/proof/refine/ARM/EmptyFail_H.thy
+++ b/proof/refine/ARM/EmptyFail_H.thy
@@ -13,7 +13,7 @@ crunch_ignore (empty_fail)
         CSpaceDecls_H.resolveAddressBits
         doMachineOp suspend restart schedule)
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemmas forM_empty_fail[intro!, wp, simp] = empty_fail_mapM[simplified forM_def[symmetric]]
 lemmas forM_x_empty_fail[intro!, wp, simp] = empty_fail_mapM_x[simplified forM_x_def[symmetric]]

--- a/proof/refine/ARM/Finalise_R.thy
+++ b/proof/refine/ARM/Finalise_R.thy
@@ -10,7 +10,7 @@ imports
   InterruptAcc_R
   Retype_R
 begin
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 declare doUnbindNotification_def[simp]
 
@@ -181,7 +181,7 @@ locale mdb_empty =
                slot (cteCap_update (%_. capability.NullCap)))
               slot (cteMDBNode_update (const nullMDBNode))"
 begin
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 
 lemmas m_slot_prev = m_p_prev
 lemmas m_slot_next = m_p_next
@@ -1386,7 +1386,7 @@ lemma deletedIRQHandler_irqs_masked'[wp]:
   apply (simp add: irqs_masked'_def)
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 crunch emptySlot
   for irqs_masked'[wp]: "irqs_masked'"
 
@@ -2019,7 +2019,7 @@ lemma (in vmdb) isFinal_untypedParent:
                    sameObjectAs_sym)
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma no_fail_isFinalCapability [wp]:
   "no_fail (valid_mdb' and cte_wp_at' ((=) cte) p) (isFinalCapability cte)"
@@ -2919,7 +2919,7 @@ lemma suspend_cte_wp_at':
             | simp add: x)+
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 crunch deleteASIDPool
   for cte_wp_at'[wp]: "cte_wp_at' P p"
@@ -3257,7 +3257,7 @@ lemma finaliseCap_valid_cap[wp]:
   done
 
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 crunch "Arch.finaliseCap"
   for nosch[wp]: "\<lambda>s. P (ksSchedulerAction s)"
@@ -3319,7 +3319,7 @@ lemma (in delete_one) deletingIRQHandler_corres:
   apply (clarsimp simp: cte_wp_at_ctes_of)
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma arch_finaliseCap_corres:
   "\<lbrakk> final_matters' (ArchObjectCap cap') \<Longrightarrow> final = final'; acap_relation cap cap' \<rbrakk>
@@ -3535,7 +3535,7 @@ lemma finaliseCap_corres:
   apply (clarsimp split del: if_split simp: o_def)
   apply (rule corres_guard_imp [OF arch_finaliseCap_corres], (fastforce simp: valid_sched_def)+)
   done
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma arch_recycleCap_improve_cases:
    "\<lbrakk> \<not> isPageCap cap; \<not> isPageTableCap cap; \<not> isPageDirectoryCap cap;
          \<not> isASIDControlCap cap \<rbrakk> \<Longrightarrow> (if isASIDPoolCap cap then v else undefined) = v"

--- a/proof/refine/ARM/Init_R.thy
+++ b/proof/refine/ARM/Init_R.thy
@@ -10,7 +10,7 @@ imports
 
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 (*
   This provides a very simple witness that the state relation used in the first refinement proof is

--- a/proof/refine/ARM/InterruptAcc_R.thy
+++ b/proof/refine/ARM/InterruptAcc_R.thy
@@ -23,7 +23,7 @@ crunch get_irq_slot
 crunch getIRQSlot
   for inv[wp]: "P"
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma setIRQState_corres:
   "irq_state_relation state state' \<Longrightarrow>

--- a/proof/refine/ARM/Interrupt_R.thy
+++ b/proof/refine/ARM/Interrupt_R.thy
@@ -14,7 +14,7 @@ begin
 
 context Arch begin
 
-(*FIXME: arch_split: move up *)
+(*FIXME: arch-split: move up *)
 requalify_types
   irqcontrol_invocation
 
@@ -22,11 +22,11 @@ lemmas [crunch_def] = decodeIRQControlInvocation_def performIRQControl_def
 
 context begin global_naming global
 
-(*FIXME: arch_split: move up *)
+(*FIXME: arch-split: move up *)
 requalify_types
   Invocations_H.irqcontrol_invocation
 
-(*FIXME: arch_split*)
+(*FIXME: arch-split*)
 requalify_facts
   Interrupt_H.decodeIRQControlInvocation_def
   Interrupt_H.performIRQControl_def
@@ -90,7 +90,7 @@ where
         ex_cte_cap_to' ptr and real_cte_at' ptr and
         (Not o irq_issued' irq) and K (irq \<le> maxIRQ))"
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma decodeIRQHandlerInvocation_corres:
   "\<lbrakk> list_all2 cap_relation (map fst caps) (map fst caps');

--- a/proof/refine/ARM/Invariants_H.thy
+++ b/proof/refine/ARM/Invariants_H.thy
@@ -47,7 +47,7 @@ lemma le_maxDomain_eq_less_numDomains:
   by (auto simp: Kernel_Config.numDomains_def maxDomain_def word_le_nat_alt)
 
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 \<comment> \<open>---------------------------------------------------------------------------\<close>
 section "Invariants on Executable Spec"
 
@@ -334,7 +334,7 @@ where
 section "Valid caps and objects (Haskell)"
 
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 primrec
   acapBits :: "arch_capability \<Rightarrow> nat"
 where
@@ -391,7 +391,7 @@ definition
 
 
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition
   page_table_at' :: "word32 \<Rightarrow> kernel_state \<Rightarrow> bool"
@@ -1362,7 +1362,7 @@ locale mdb_order = mdb_next +
 
 \<comment> \<open>---------------------------------------------------------------------------\<close>
 section "Alternate split rules for preserving subgoal order"
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma ntfn_splits[split]:
   " P (case ntfn of Structures_H.ntfn.IdleNtfn \<Rightarrow> f1
      | Structures_H.ntfn.ActiveNtfn x \<Rightarrow> f2 x
@@ -2970,7 +2970,7 @@ lemma ex_cte_cap_to'_pres:
    apply assumption
   apply simp
   done
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma page_directory_pde_atI':
   "\<lbrakk> page_directory_at' p s; x < 2 ^ pageBits \<rbrakk> \<Longrightarrow> pde_at' (p + (x << 2)) s"
   by (simp add: page_directory_at'_def pageBits_def)
@@ -3129,7 +3129,7 @@ lemma vms_sch_act_update'[iff]:
   "valid_machine_state' (ksSchedulerAction_update f s) =
    valid_machine_state' s"
   by (simp add: valid_machine_state'_def )
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma objBitsT_simps:
   "objBitsT EndpointT = epSizeBits"
   "objBitsT NotificationT = ntfnSizeBits"

--- a/proof/refine/ARM/Invocations_R.thy
+++ b/proof/refine/ARM/Invocations_R.thy
@@ -8,7 +8,7 @@ theory Invocations_R
 imports Invariants_H
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma invocationType_eq[simp]:
   "invocationType = invocation_type"

--- a/proof/refine/ARM/IpcCancel_R.thy
+++ b/proof/refine/ARM/IpcCancel_R.thy
@@ -9,7 +9,7 @@ imports
   Schedule_R
   "Lib.SimpStrategy"
 begin
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 crunch cancelAllIPC
   for aligned'[wp]: pspace_aligned'
@@ -350,7 +350,7 @@ lemma cte_map_tcb_2:
   "cte_map (t, tcb_cnode_index 2) = t + 2*2^cte_level_bits"
   by (simp add: cte_map_def tcb_cnode_index_def to_bl_1)
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma cte_wp_at_master_reply_cap_to_ex_rights:
   "cte_wp_at (is_master_reply_cap_to t) ptr
@@ -524,7 +524,7 @@ lemma (in delete_one) cancelIPC_ReplyCap_corres:
           od)
        od)"
   proof -
-  interpret Arch . (*FIXME: arch_split*)
+  interpret Arch . (*FIXME: arch-split*)
   show ?thesis
   apply (simp add: reply_cancel_ipc_def getThreadReplySlot_def
                    locateSlot_conv liftM_def tcbReplySlot_def
@@ -657,7 +657,7 @@ crunch setNotification
 lemma sch_act_simple_not_t[simp]: "sch_act_simple s \<Longrightarrow> sch_act_not t s"
   by (clarsimp simp: sch_act_simple_def)
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 crunch setNotification
   for sym_heap_sched_pointers[wp]: sym_heap_sched_pointers
@@ -1928,7 +1928,7 @@ lemma cancelAll_unlive_helper:
   apply (clarsimp elim!: ko_wp_at'_weakenE)
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma setObject_ko_wp_at':
   fixes v :: "'a :: pspace_storable"
   assumes x: "\<And>v :: 'a. updateObject v = updateObject_default v"

--- a/proof/refine/ARM/Ipc_R.thy
+++ b/proof/refine/ARM/Ipc_R.thy
@@ -8,7 +8,7 @@ theory Ipc_R
 imports Finalise_R
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemmas lookup_slot_wrapper_defs'[simp] =
    lookupSourceSlot_def lookupTargetSlot_def lookupPivotSlot_def

--- a/proof/refine/ARM/KHeap_R.thy
+++ b/proof/refine/ARM/KHeap_R.thy
@@ -21,7 +21,7 @@ lemma koTypeOf_injectKO:
   apply (simp add: project_koType[symmetric])
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma setObject_modify_variable_size:
   fixes v :: "'a :: pspace_storable" shows
@@ -87,7 +87,7 @@ end
 translations
   (type) "'a kernel" <=(type) "kernel_state \<Rightarrow> ('a \<times> kernel_state) set \<times> bool"
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma no_fail_loadObject_default [wp]:
   "no_fail (\<lambda>s. \<exists>obj. projectKO_opt ko = Some (obj::'a) \<and>

--- a/proof/refine/ARM/LevityCatch.thy
+++ b/proof/refine/ARM/LevityCatch.thy
@@ -20,7 +20,7 @@ lemma magnitudeCheck_assert:
             split: option.split)
   apply fastforce
   done
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemmas makeObject_simps =
   makeObject_endpoint makeObject_notification makeObject_cte
   makeObject_tcb makeObject_user_data makeObject_pde makeObject_pte
@@ -55,7 +55,7 @@ lemma updateObject_default_inv:
   "\<lbrace>P\<rbrace> updateObject_default obj ko x y n \<lbrace>\<lambda>rv. P\<rbrace>"
   unfolding updateObject_default_def
   by (simp, wp magnitudeCheck_inv alignCheck_inv projectKO_inv, simp)
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma to_from_apiType [simp]: "toAPIType (fromAPIType x) = Some x"
   by (cases x) (auto simp add: fromAPIType_def ARM_H.fromAPIType_def
     toAPIType_def ARM_H.toAPIType_def)

--- a/proof/refine/ARM/Machine_R.thy
+++ b/proof/refine/ARM/Machine_R.thy
@@ -22,7 +22,7 @@ lemma irq_state_independent_HI[intro!, simp]:
    \<Longrightarrow> irq_state_independent_H P"
   by (simp add: irq_state_independent_H_def)
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma dmo_getirq_inv[wp]:
   "irq_state_independent_H P \<Longrightarrow> \<lbrace>P\<rbrace> doMachineOp (getActiveIRQ in_kernel) \<lbrace>\<lambda>rv. P\<rbrace>"

--- a/proof/refine/ARM/PageTableDuplicates.thy
+++ b/proof/refine/ARM/PageTableDuplicates.thy
@@ -8,7 +8,7 @@ theory PageTableDuplicates
 imports Syscall_R
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma set_ep_valid_duplicate' [wp]:
   "\<lbrace>\<lambda>s. vs_valid_duplicates' (ksPSpace s)\<rbrace>

--- a/proof/refine/ARM/Refine.thy
+++ b/proof/refine/ARM/Refine.thy
@@ -16,7 +16,7 @@ imports
   PageTableDuplicates
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 text \<open>User memory content is the same on both levels\<close>
 lemma typ_at_AUserDataI:

--- a/proof/refine/ARM/Retype_R.thy
+++ b/proof/refine/ARM/Retype_R.thy
@@ -12,7 +12,7 @@ theory Retype_R
 imports VSpace_R
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition
   APIType_map2 :: "kernel_object + ARM_H.object_type \<Rightarrow> Structures_A.apiobject_type"
@@ -1163,7 +1163,7 @@ end
 global_interpretation update_gs: PSpace_update_eq "update_gs ty us ptrs"
   by (simp add: PSpace_update_eq_def)
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma ksReadyQueues_update_gs[simp]:
   "ksReadyQueues (update_gs tp us addrs s) = ksReadyQueues s"
@@ -1615,7 +1615,7 @@ end
 interpretation retype_region2_ext_extended: is_extended "retype_region2_ext ptrs type"
   by (unfold_locales; wp)
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition
  "retype_region2_extra_ext ptrs type \<equiv>
@@ -1634,7 +1634,7 @@ end
 interpretation retype_region2_extra_ext_extended: is_extended "retype_region2_extra_ext ptrs type"
   by (unfold_locales; wp)
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition
   retype_region2 :: "obj_ref \<Rightarrow> nat \<Rightarrow> nat \<Rightarrow> Structures_A.apiobject_type \<Rightarrow> bool \<Rightarrow> (obj_ref list,'z::state_ext) s_monad"
@@ -2799,7 +2799,7 @@ locale retype_mdb = vmdb +
   assumes 0: "\<not>P 0"
   defines "n \<equiv> \<lambda>p. if P p then Some makeObject else m p"
 begin
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 
 lemma no_0_n: "no_0 n"
   using no_0 by (simp add: no_0_def n_def 0)
@@ -3130,7 +3130,7 @@ lemma caps_no_overlapD'':
   apply blast
 done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma valid_untyped'_helper:
   assumes valid : "valid_cap' c s"
   and  cte_at : "cte_wp_at' (\<lambda>cap. cteCap cap = c) q s"

--- a/proof/refine/ARM/Schedule_R.thy
+++ b/proof/refine/ARM/Schedule_R.thy
@@ -8,7 +8,7 @@ theory Schedule_R
 imports VSpace_R
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 declare hoare_weak_lift_imp[wp_split del]
 

--- a/proof/refine/ARM/StateRelation.thy
+++ b/proof/refine/ARM/StateRelation.thy
@@ -12,7 +12,7 @@ theory StateRelation
 imports InvariantUpdates_H
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 definition
   cte_map :: "cslot_ptr \<Rightarrow> word32"
 where

--- a/proof/refine/ARM/SubMonad_R.thy
+++ b/proof/refine/ARM/SubMonad_R.thy
@@ -47,7 +47,7 @@ lemma doMachineOp_mapM_x:
   done
 
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 definition
   "asUser_fetch \<equiv> \<lambda>t s. case (ksPSpace s t) of
       Some (KOTCB tcb) \<Rightarrow> (atcbContextGet o tcbArch) tcb

--- a/proof/refine/ARM/Syscall_R.thy
+++ b/proof/refine/ARM/Syscall_R.thy
@@ -12,7 +12,7 @@ theory Syscall_R
 imports Tcb_R Arch_R Interrupt_R
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 (*
 syscall has 5 sections: m_fault h_fault m_error h_error m_finalise

--- a/proof/refine/ARM/TcbAcc_R.thy
+++ b/proof/refine/ARM/TcbAcc_R.thy
@@ -8,7 +8,7 @@ theory TcbAcc_R
 imports CSpace_R ArchMove_R
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 declare if_weak_cong [cong]
 declare hoare_in_monad_post[wp]

--- a/proof/refine/ARM/Tcb_R.thy
+++ b/proof/refine/ARM/Tcb_R.thy
@@ -8,7 +8,7 @@ theory Tcb_R
 imports CNodeInv_R
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma asUser_setNextPC_corres:
   "corres dc (tcb_at t and invs) (tcb_at' t and invs')
@@ -1639,7 +1639,7 @@ end
 consts
   copyregsets_map :: "arch_copy_register_sets \<Rightarrow> Arch.copy_register_sets"
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 primrec
   tcbinv_relation :: "tcb_invocation \<Rightarrow> tcbinvocation \<Rightarrow> bool"

--- a/proof/refine/ARM/Untyped_R.thy
+++ b/proof/refine/ARM/Untyped_R.thy
@@ -9,7 +9,7 @@
 theory Untyped_R
 imports Detype_R Invocations_R InterruptAcc_R
 begin
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 primrec
   untypinv_relation :: "Invocations_A.untyped_invocation \<Rightarrow>
@@ -993,7 +993,7 @@ locale mdb_insert_again =
 
 context mdb_insert_again
 begin
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 lemmas parent = mdb_ptr_parent.m_p
 lemmas site = mdb_ptr_site.m_p
 
@@ -1374,7 +1374,7 @@ crunch create_cap_ext
   and work_units_completed[wp]: "\<lambda>s. P (work_units_completed s)"
   (ignore_del: create_cap_ext)
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma updateNewFreeIndex_noop_psp_corres:
   "corres_underlying {(s, s'). pspace_relations (ekheap s) (kheap s) (ksPSpace s')} False True
@@ -1692,7 +1692,7 @@ locale mdb_insert_again_all = mdb_insert_again_child +
   fixes n'
   defines "n' \<equiv> modify_map n (mdbNext parent_node) (cteMDBNode_update (mdbPrev_update (\<lambda>a. site)))"
 begin
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 lemma no_0_n' [simp]: "no_0 n'"
   using no_0_n by (simp add: n'_def)
 
@@ -2666,7 +2666,7 @@ lemma caps_overlap_reserved'_D:
    apply (erule(2) impE)
   apply fastforce
   done
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma insertNewCap_valid_mdb:
   "\<lbrace>valid_mdb' and valid_objs' and K (slot \<noteq> p) and
     caps_overlap_reserved' (untypedRange cap) and
@@ -3867,7 +3867,7 @@ lemma cte_wp_at': "cte_wp_at' (\<lambda>cte. cteCap cte = capability.UntypedCap
       "\<forall>x\<in>set slots. ex_cte_cap_wp_to' (\<lambda>_. True) x s"
   using vui
   by (auto simp: cte_wp_at_ctes_of)
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 
 lemma idx_cases:
   "((\<not> reset \<and> idx \<le> unat (ptr - (ptr && ~~ mask sz))) \<or> reset \<and> ptr = ptr && ~~ mask sz)"
@@ -4011,7 +4011,7 @@ lemma idx_le_new_offs:
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma valid_sched_etcbs[elim!]: "valid_sched_2 queues ekh sa cdom kh ct it \<Longrightarrow> valid_etcbs_2 ekh kh"
   by (simp add: valid_sched_def)
@@ -4169,7 +4169,7 @@ lemma ex_tupI:
   "P (fst x) (snd x) \<Longrightarrow> \<exists>a b. P a b"
   by blast
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 (* mostly stuff about PPtr/fromPPtr, which seems pretty soft *)
 
 lemma resetUntypedCap_corres:
@@ -4384,7 +4384,7 @@ lemma ex_cte_cap_wp_to_irq_state_independent_H[simp]:
   "irq_state_independent_H (ex_cte_cap_wp_to' P slot)"
   by (simp add: ex_cte_cap_wp_to'_def)
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma updateFreeIndex_ctes_of:
   "\<lbrace>\<lambda>s.  P (modify_map (ctes_of s) ptr (cteCap_update (capFreeIndex_update (\<lambda>_. idx))))\<rbrace>
@@ -4606,7 +4606,7 @@ lemma (in range_cover) funky_aligned:
   apply simp
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 defs archOverlap_def:
   "archOverlap \<equiv> \<lambda>_ _. False"

--- a/proof/refine/ARM/VSpace_R.thy
+++ b/proof/refine/ARM/VSpace_R.thy
@@ -11,14 +11,14 @@
 theory VSpace_R
 imports TcbAcc_R
 begin
-context Arch begin global_naming ARM (*FIXME: arch_split*)
+context Arch begin global_naming ARM (*FIXME: arch-split*)
 
 lemmas store_pte_typ_ats[wp] = store_pte_typ_ats abs_atyp_at_lifts[OF store_pte_typ_at]
 lemmas store_pde_typ_ats[wp] = store_pde_typ_ats abs_atyp_at_lifts[OF store_pde_typ_at]
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition
   "pd_at_asid' pd asid \<equiv> \<lambda>s. \<exists>ap pool.

--- a/proof/refine/ARM/orphanage/Orphanage.thy
+++ b/proof/refine/ARM/orphanage/Orphanage.thy
@@ -14,7 +14,7 @@ text \<open>
   or about to be switched to, or be in a scheduling queue.
 \<close>
 
-(*FIXME: arch_split: move up? *)
+(*FIXME: arch-split: move up? *)
 context Arch begin
 
 requalify_facts
@@ -30,7 +30,7 @@ requalify_facts
 end
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition
    is_active_thread_state :: "thread_state \<Rightarrow> bool"

--- a/proof/refine/ARM_HYP/ADT_H.thy
+++ b/proof/refine/ARM_HYP/ADT_H.thy
@@ -28,7 +28,7 @@ consts
   initBootFrames :: "word32 list"
   initDataStart :: word32
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 text \<open>
   The construction of the abstract data type
@@ -1293,7 +1293,7 @@ locale partial_sort_cdt = partial_sort "\<lambda> x y.  m' \<turnstile> cte_map 
 
 begin
 
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 
 lemma valid_list_2 : "valid_list_2 t m"
     apply (insert assms')
@@ -1490,7 +1490,7 @@ lemma sort_cdt_list_correct:
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition absCDTList where
 "absCDTList cnp h \<equiv> sort_cdt_list (absCDT cnp h) h"

--- a/proof/refine/ARM_HYP/ArchAcc_R.thy
+++ b/proof/refine/ARM_HYP/ArchAcc_R.thy
@@ -26,7 +26,7 @@ method simp_to_elim = (drule fun_all, elim allE impE)
 
 end
 
-context Arch begin global_naming ARM_A (*FIXME: arch_split*)
+context Arch begin global_naming ARM_A (*FIXME: arch-split*)
 
 lemma asid_pool_at_ko:
   "asid_pool_at p s \<Longrightarrow> \<exists>pool. ko_at (ArchObj (ARM_A.ASIDPool pool)) p s"
@@ -45,7 +45,7 @@ lemmas valid_vspace_obj_elims[rule_format, elim!] =
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 (*FIXME move *)
 

--- a/proof/refine/ARM_HYP/Arch_R.thy
+++ b/proof/refine/ARM_HYP/Arch_R.thy
@@ -15,7 +15,7 @@ begin
 
 unbundle l4v_word_context
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 declare is_aligned_shiftl [intro!]
 declare is_aligned_shiftr [intro!]

--- a/proof/refine/ARM_HYP/Bits_R.thy
+++ b/proof/refine/ARM_HYP/Bits_R.thy
@@ -22,7 +22,7 @@ crunch_ignore (add:
   empty_on_failure emptyOnFailure clearMemoryVM null_cap_on_failure setNextPC getRestartPC
   assertDerived throw_on_false getObject setObject updateObject loadObject)
 
-context Arch begin (*FIXME: arch_split*)
+context Arch begin (*FIXME: arch-split*)
 
 crunch_ignore (add:
   invalidateLocalTLB_ASID invalidateLocalTLB_VAASID
@@ -33,7 +33,7 @@ crunch_ignore (add:
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma withoutFailure_wp [wp]:
   "\<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace> withoutFailure f \<lbrace>Q\<rbrace>,\<lbrace>E\<rbrace>"

--- a/proof/refine/ARM_HYP/CNodeInv_R.thy
+++ b/proof/refine/ARM_HYP/CNodeInv_R.thy
@@ -15,7 +15,7 @@ begin
 
 unbundle l4v_word_context
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 primrec
   valid_cnode_inv' :: "Invocations_H.cnode_invocation \<Rightarrow> kernel_state \<Rightarrow> bool"
@@ -4954,7 +4954,7 @@ lemma cteSwap_valid_pspace'[wp]:
   apply clarsimp+
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 crunch cteSwap
   for tcb_at[wp]: "tcb_at' t"
@@ -6701,7 +6701,7 @@ lemmas threadSet_ctesCaps_of = ctes_of_cteCaps_of_lift[OF threadSet_ctes_of]
 lemmas storePTE_cteCaps_of[wp] = ctes_of_cteCaps_of_lift [OF storePTE_ctes]
 lemmas storePDE_cteCaps_of[wp] = ctes_of_cteCaps_of_lift [OF storePDE_ctes]
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma vcpuSwitch_rvk_prog':
   "vcpuSwitch v \<lbrace>\<lambda>s. revoke_progress_ord m (\<lambda>x. map_option capToRPO (cteCaps_of s x))\<rbrace>"
@@ -7944,7 +7944,7 @@ lemma (in mdb_move) m'_cap:
 context mdb_move
 begin
 
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 
 lemma m_to_src:
   "m \<turnstile> p \<leadsto> src = (p \<noteq> 0 \<and> p = mdbPrev src_node)"
@@ -8476,7 +8476,7 @@ qed
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma cteMove_iflive'[wp]:
   "\<lbrace>\<lambda>s. if_live_then_nonz_cap' s
@@ -8653,7 +8653,7 @@ crunch updateMDB
   for valid_bitmaps[wp]: valid_bitmaps
   (rule: valid_bitmaps_lift)
 
-(* FIXME: arch_split *)
+(* FIXME: arch-split *)
 lemma haskell_assert_inv:
   "haskell_assert Q L \<lbrace>P\<rbrace>"
   by wpsimp

--- a/proof/refine/ARM_HYP/CSpace1_R.thy
+++ b/proof/refine/ARM_HYP/CSpace1_R.thy
@@ -14,7 +14,7 @@ imports
   "AInvs.ArchDetSchedSchedule_AI"
 begin
 
-context Arch begin global_naming ARM_A (*FIXME: arch_split*)
+context Arch begin global_naming ARM_A (*FIXME: arch-split*)
 
 lemmas final_matters_def = final_matters_def[simplified final_matters_arch_def]
 
@@ -25,7 +25,7 @@ lemmas final_matters_simps[simp]
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma isMDBParentOf_CTE1:
   "isMDBParentOf (CTE cap node) cte =
@@ -2981,7 +2981,7 @@ locale masterCap =
   fixes cap cap'
   assumes master: "capMasterCap cap = capMasterCap cap'"
 begin
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 
 lemma isZombie [simp]:
   "isZombie cap' = isZombie cap" using master
@@ -3567,7 +3567,7 @@ locale mdb_insert_sib = mdb_insert_der +
            (mdbRevocable_update (\<lambda>a. revokable' src_cap c')
            (mdbPrev_update (\<lambda>a. src) src_node))))"
 begin
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 
 (* If dest is inserted as sibling, src can not have had children.
    If it had had children, then dest_node which is just a derived copy
@@ -3714,7 +3714,7 @@ lemma descendants:
   by (rule set_eqI) (simp add: descendants_of'_def parent_n_eq)
 
 end
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma mdb_None:
   assumes F: "\<And>p'. cte_map p \<in> descendants_of' p' m' \<Longrightarrow> False"
   assumes R: "cdt_relation (swp cte_at s) (cdt s) m'"
@@ -4572,7 +4572,7 @@ locale mdb_inv_preserve =
   \<and> (\<lambda>x. sameRegionAs x (cteCap cte)) = (\<lambda>x. sameRegionAs x (cteCap cte'))"
   assumes mdb_next:"\<And>p. mdb_next m p = mdb_next m' p"
 begin
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 lemma preserve_stuff:
   "valid_dlist m = valid_dlist m'
  \<and> ut_revocable' m = ut_revocable' m'
@@ -5231,7 +5231,7 @@ lemma cte_map_inj_eq':
   apply (rule cte_map_inj_eq; fastforce)
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma cteInsert_corres:
   notes split_paired_All[simp del] split_paired_Ex[simp del]
         trans_state_update'[symmetric,simp]
@@ -7231,7 +7231,7 @@ lemma subtree_no_parent:
   shows "False" using assms
   by induct (auto simp: parentOf_def mdb_next_unfold)
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma ensureNoChildren_corres:
   "p' = cte_map p \<Longrightarrow>

--- a/proof/refine/ARM_HYP/CSpace_I.thy
+++ b/proof/refine/ARM_HYP/CSpace_I.thy
@@ -12,7 +12,7 @@ theory CSpace_I
 imports ArchAcc_R
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma capUntypedPtr_simps [simp]:
   "capUntypedPtr (ThreadCap r) = r"
@@ -1558,7 +1558,7 @@ lemma no_mdb_not_target:
   apply (simp add: no_mdb_def)
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma valid_dlist_init:
   "\<lbrakk> valid_dlist m; m p = Some cte; no_mdb cte \<rbrakk> \<Longrightarrow>
   valid_dlist (m (p \<mapsto> CTE cap initMDBNode))"
@@ -1756,7 +1756,7 @@ lemma untyped_inc_init:
     apply (rule untypedRange_in_capRange)+
   apply (simp add:Int_ac)
   done
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma valid_nullcaps_init:
   "\<lbrakk> valid_nullcaps m; cap \<noteq> NullCap \<rbrakk> \<Longrightarrow> valid_nullcaps (m(p \<mapsto> CTE cap initMDBNode))"
   by (simp add: valid_nullcaps_def initMDBNode_def nullPointer_def)
@@ -1816,7 +1816,7 @@ lemma distinct_zombies_copyE:
 lemmas distinct_zombies_sameE
     = distinct_zombies_copyE [where y=x and x=x for x, simplified,
                               OF _ _ _ _ _]
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma capBits_Master:
   "capBits (capMasterCap cap) = capBits cap"
   by (clarsimp simp: capMasterCap_def split: capability.split arch_capability.split)

--- a/proof/refine/ARM_HYP/CSpace_R.thy
+++ b/proof/refine/ARM_HYP/CSpace_R.thy
@@ -53,7 +53,7 @@ locale mdb_move =
   modify_map n (mdbNext src_node)
                (cteMDBNode_update (mdbPrev_update (\<lambda>_. dest)))"
 begin
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 
 
 lemmas src = m_p
@@ -733,7 +733,7 @@ lemma set_cap_not_quite_corres':
                 using cr
                 apply (fastforce simp: c p pspace_relations_def)+
                 done
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma cteMove_corres:
   assumes cr: "cap_relation cap cap'"
   notes trans_state_update'[symmetric,simp]
@@ -1129,7 +1129,7 @@ crunch cteInsert
 end
 context mdb_insert
 begin
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 lemma n_src_dest:
   "n \<turnstile> src \<leadsto> dest"
   by (simp add: n_direct_eq)
@@ -1649,7 +1649,7 @@ lemma untyped_inc_prev_update:
 lemma is_derived_badge_derived':
   "is_derived' m src cap cap' \<Longrightarrow> badge_derived' cap cap'"
   by (simp add: is_derived'_def)
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma cteInsert_mdb_chain_0:
   "\<lbrace>valid_mdb' and pspace_aligned' and pspace_distinct' and (\<lambda>s. src \<noteq> dest) and
     (\<lambda>s. cte_wp_at' (is_derived' (ctes_of s) src cap \<circ> cteCap) src s)\<rbrace>
@@ -4569,7 +4569,7 @@ locale mdb_insert_simple = mdb_insert +
   assumes safe_parent: "safe_parent_for' m src c'"
   assumes simple: "is_simple_cap' c'"
 begin
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 lemma dest_no_parent_n:
   "n \<turnstile> dest \<rightarrow> p = False"
   using src simple safe_parent
@@ -4759,7 +4759,7 @@ lemma maskedAsFull_revokable_safe_parent:
      apply (clarsimp simp:isCap_simps is_simple_cap'_def)+
 done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma cteInsert_simple_corres:
   assumes "cap_relation c c'" "src' = cte_map src" "dest' = cte_map dest"
   notes trans_state_update'[symmetric,simp]
@@ -5133,7 +5133,7 @@ locale mdb_insert_simple' = mdb_insert_simple +
   fixes n'
   defines  "n' \<equiv> modify_map n (mdbNext src_node) (cteMDBNode_update (mdbPrev_update (\<lambda>_. dest)))"
 begin
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 lemma no_0_n' [intro!]: "no_0 n'" by (auto simp: n'_def)
 lemmas n_0_simps' [iff] = no_0_simps [OF no_0_n']
 
@@ -5833,7 +5833,7 @@ lemma updateCapFreeIndex_no_0:
     apply (clarsimp simp:cte_wp_at_ctes_of)+
 done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma cteInsert_simple_mdb':
   "\<lbrace>valid_mdb' and pspace_aligned' and pspace_distinct' and (\<lambda>s. src \<noteq> dest) and K (capAligned cap) and
     (\<lambda>s. safe_parent_for' (ctes_of s) src cap) and K (is_simple_cap' cap) \<rbrace>

--- a/proof/refine/ARM_HYP/Detype_R.thy
+++ b/proof/refine/ARM_HYP/Detype_R.thy
@@ -8,7 +8,7 @@ theory Detype_R
 imports Retype_R
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 text \<open>Establishing that the invariants are maintained
         when a region of memory is detyped, that is,
@@ -86,7 +86,7 @@ lemma descendants_range_inD':
   done
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma descendants_range'_def2:
   "descendants_range' cap p = descendants_range_in' (capRange cap) p"
@@ -449,7 +449,7 @@ lemma (in detype_locale') deletionIsSafe:
   and      vu: "valid_untyped (cap.UntypedCap d base magnitude idx) s"
   shows       "deletionIsSafe base magnitude s'"
 proof -
-  interpret Arch . (* FIXME: arch_split *)
+  interpret Arch . (* FIXME: arch-split *)
   note blah[simp del] =  atLeastatMost_subset_iff atLeastLessThan_iff
           Int_atLeastAtMost atLeastatMost_empty_iff split_paired_Ex
           atLeastAtMost_iff
@@ -530,7 +530,7 @@ proof -
   thus ?thesis using cte by (auto simp: deletionIsSafe_def)
 qed
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 text \<open>Invariant preservation across concrete deletion\<close>
 
@@ -603,7 +603,7 @@ locale delete_locale =
   and      al: "is_aligned base bits"
   and    safe: "deletionIsSafe base bits s'"
 
-context delete_locale begin interpretation Arch . (*FIXME: arch_split*)
+context delete_locale begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma valid_objs: "valid_objs' s'"
   and        pa: "pspace_aligned' s'"
@@ -847,7 +847,7 @@ lemma sym_refs_TCB_hyp_live':
   done
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma ksASIDMapSafeI:
   "\<lbrakk> (s,s') \<in> state_relation; invs s; pspace_aligned' s' \<and> pspace_distinct' s' \<rbrakk>
@@ -1116,7 +1116,7 @@ lemma deleteObjects_corres:
   done
 end
 
-context delete_locale begin interpretation Arch . (*FIXME: arch_split*)
+context delete_locale begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma live_idle_untyped_range':
   "ko_wp_at' live' p s' \<or> p = idle_thread_ptr \<Longrightarrow> p \<notin> base_bits"
@@ -1445,7 +1445,7 @@ using vds
 proof (simp add: invs'_def valid_state'_def valid_pspace'_def
                  valid_mdb'_def valid_mdb_ctes_def,
        safe)
-  interpret Arch . (*FIXME: arch_split*)
+  interpret Arch . (*FIXME: arch-split*)
   let ?s = state'
   let ?ran = base_bits
 
@@ -1823,7 +1823,7 @@ lemma doMachineOp_modify:
   apply (rule ext)
   apply (simp add: simpler_gets_def simpler_modify_def bind_def)
   done
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma deleteObjects_invs':
   "\<lbrace>cte_wp_at' (\<lambda>c. cteCap c = UntypedCap d ptr bits idx) p
      and invs' and ct_active' and sch_act_simple

--- a/proof/refine/ARM_HYP/EmptyFail.thy
+++ b/proof/refine/ARM_HYP/EmptyFail.thy
@@ -62,7 +62,7 @@ lemma empty_fail_getSlotCap [intro!, wp, simp]:
   "empty_fail (getSlotCap a)"
   unfolding getSlotCap_def by fastforce
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma empty_fail_getObject:
   assumes "\<And>b c d. empty_fail (loadObject x b c d::'a :: pspace_storable kernel)"

--- a/proof/refine/ARM_HYP/EmptyFail_H.thy
+++ b/proof/refine/ARM_HYP/EmptyFail_H.thy
@@ -13,7 +13,7 @@ crunch_ignore (empty_fail)
         CSpaceDecls_H.resolveAddressBits
         doMachineOp suspend restart schedule)
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemmas forM_empty_fail[intro!, wp, simp] = empty_fail_mapM[simplified forM_def[symmetric]]
 lemmas forM_x_empty_fail[intro!, wp, simp] = empty_fail_mapM_x[simplified forM_x_def[symmetric]]

--- a/proof/refine/ARM_HYP/Finalise_R.thy
+++ b/proof/refine/ARM_HYP/Finalise_R.thy
@@ -10,7 +10,7 @@ imports
   InterruptAcc_R
   Retype_R
 begin
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 declare doUnbindNotification_def[simp]
 
@@ -187,7 +187,7 @@ locale mdb_empty =
                slot (cteCap_update (%_. capability.NullCap)))
               slot (cteMDBNode_update (const nullMDBNode))"
 begin
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 
 lemmas m_slot_prev = m_p_prev
 lemmas m_slot_next = m_p_next
@@ -1392,7 +1392,7 @@ lemma deletedIRQHandler_irqs_masked'[wp]:
   apply (simp add: irqs_masked'_def)
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 crunch emptySlot
   for irqs_masked'[wp]: "irqs_masked'"
 
@@ -2028,7 +2028,7 @@ lemma (in vmdb) isFinal_untypedParent:
                    sameObjectAs_sym)
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma no_fail_isFinalCapability [wp]:
   "no_fail (valid_mdb' and cte_wp_at' ((=) cte) p) (isFinalCapability cte)"
@@ -3274,7 +3274,7 @@ lemma suspend_tcbSchedNext_tcbSchedPrev_None:
   unfolding suspend_def
   by (wpsimp wp: hoare_drop_imps tcbSchedDequeue_tcbSchedNext_tcbSchedPrev_None_obj_at')
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma archThreadSet_tcbSchedPrevNext[wp]:
   "archThreadSet f t' \<lbrace>obj_at' (\<lambda>tcb. P (tcbSchedNext tcb) (tcbSchedPrev tcb)) t\<rbrace>"
@@ -3404,7 +3404,7 @@ lemma suspend_cte_wp_at':
              | simp add: x)+
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 crunch deleteASIDPool
   for cte_wp_at'[wp]: "cte_wp_at' P p"
@@ -3742,7 +3742,7 @@ lemma finaliseCap_valid_cap[wp]:
   done
 
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 crunch dissociateVCPUTCB
   for nosch[wp]: "\<lambda>s. P (ksSchedulerAction s)"
@@ -3809,7 +3809,7 @@ lemma (in delete_one) deletingIRQHandler_corres:
   apply (clarsimp simp: cte_wp_at_ctes_of)
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma sym_refs_vcpu_tcb:
   "\<lbrakk> ko_at (ArchObj (VCPU vcpu)) v s; vcpu_tcb vcpu = Some t; sym_refs (state_hyp_refs_of s) \<rbrakk> \<Longrightarrow>
@@ -4015,7 +4015,7 @@ lemmas getCTE_no_0_obj'_helper
   = getCTE_inv
     hoare_strengthen_post[where Q'="\<lambda>_. no_0_obj'" and P=no_0_obj' and f="getCTE slot" for slot]
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 context
 notes option.case_cong_weak[cong]
 begin
@@ -4087,7 +4087,7 @@ lemma finaliseCap_corres:
   apply (rule corres_guard_imp [OF arch_finaliseCap_corres], (fastforce simp: valid_sched_def)+)
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma arch_recycleCap_improve_cases:
    "\<lbrakk> \<not> isPageCap cap; \<not> isPageTableCap cap; \<not> isPageDirectoryCap cap;\<not> isVCPUCap cap;
          \<not> isASIDControlCap cap \<rbrakk> \<Longrightarrow> (if isASIDPoolCap cap then v else undefined) = v"

--- a/proof/refine/ARM_HYP/Init_R.thy
+++ b/proof/refine/ARM_HYP/Init_R.thy
@@ -10,7 +10,7 @@ imports
 
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 (*
   This provides a very simple witness that the state relation used in the first refinement proof is

--- a/proof/refine/ARM_HYP/InterruptAcc_R.thy
+++ b/proof/refine/ARM_HYP/InterruptAcc_R.thy
@@ -23,7 +23,7 @@ crunch get_irq_slot
 crunch getIRQSlot
   for inv[wp]: "P"
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma setIRQState_corres:
   "irq_state_relation state state' \<Longrightarrow>

--- a/proof/refine/ARM_HYP/Interrupt_R.thy
+++ b/proof/refine/ARM_HYP/Interrupt_R.thy
@@ -14,7 +14,7 @@ begin
 
 context Arch begin
 
-(*FIXME: arch_split: move up *)
+(*FIXME: arch-split: move up *)
 requalify_types
   irqcontrol_invocation
 
@@ -22,11 +22,11 @@ lemmas [crunch_def] = decodeIRQControlInvocation_def performIRQControl_def
 
 context begin global_naming global
 
-(*FIXME: arch_split: move up *)
+(*FIXME: arch-split: move up *)
 requalify_types
   Invocations_H.irqcontrol_invocation
 
-(*FIXME: arch_split*)
+(*FIXME: arch-split*)
 requalify_facts
   Interrupt_H.decodeIRQControlInvocation_def
   Interrupt_H.performIRQControl_def
@@ -90,7 +90,7 @@ where
         ex_cte_cap_to' ptr and real_cte_at' ptr and
         (Not o irq_issued' irq) and K (irq \<le> maxIRQ))"
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma decodeIRQHandlerInvocation_corres:
   "\<lbrakk> list_all2 cap_relation (map fst caps) (map fst caps');

--- a/proof/refine/ARM_HYP/Invariants_H.thy
+++ b/proof/refine/ARM_HYP/Invariants_H.thy
@@ -48,7 +48,7 @@ lemma le_maxDomain_eq_less_numDomains:
   by (auto simp: Kernel_Config.numDomains_def maxDomain_def word_le_nat_alt)
 
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 \<comment> \<open>---------------------------------------------------------------------------\<close>
 section "Invariants on Executable Spec"
 
@@ -341,7 +341,7 @@ where
   | KOKernelData        => False
   | KOArch ako          => hyp_live' ko"
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 primrec
   azobj_refs' :: "arch_capability \<Rightarrow> word32 set"
 where
@@ -427,7 +427,7 @@ where
 section "Valid caps and objects (Haskell)"
 
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 primrec
   acapBits :: "arch_capability \<Rightarrow> nat"
 where
@@ -484,7 +484,7 @@ definition
 
 
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition
   page_table_at' :: "word32 \<Rightarrow> kernel_state \<Rightarrow> bool"
@@ -1527,7 +1527,7 @@ locale mdb_order = mdb_next +
 
 \<comment> \<open>---------------------------------------------------------------------------\<close>
 section "Alternate split rules for preserving subgoal order"
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma ntfn_splits[split]:
   " P (case ntfn of Structures_H.ntfn.IdleNtfn \<Rightarrow> f1
      | Structures_H.ntfn.ActiveNtfn x \<Rightarrow> f2 x
@@ -3272,7 +3272,7 @@ lemma ex_cte_cap_to'_pres:
    apply assumption
   apply simp
   done
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma page_directory_pde_atI':
   "\<lbrakk> page_directory_at' p s; x < 2 ^ (pdBits - pdeBits) \<rbrakk> \<Longrightarrow> pde_at' (p + (x << pdeBits)) s"
   by (simp add: page_directory_at'_def pageBits_def pdBits_def pdeBits_def)
@@ -3431,7 +3431,7 @@ lemma vms_sch_act_update'[iff]:
   "valid_machine_state' (ksSchedulerAction_update f s) =
    valid_machine_state' s"
   by (simp add: valid_machine_state'_def )
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma objBitsT_simps:
   "objBitsT EndpointT = epSizeBits"
   "objBitsT NotificationT = ntfnSizeBits"

--- a/proof/refine/ARM_HYP/Invocations_R.thy
+++ b/proof/refine/ARM_HYP/Invocations_R.thy
@@ -8,7 +8,7 @@ theory Invocations_R
 imports Invariants_H
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma invocationType_eq[simp]:
   "invocationType = invocation_type"

--- a/proof/refine/ARM_HYP/IpcCancel_R.thy
+++ b/proof/refine/ARM_HYP/IpcCancel_R.thy
@@ -9,7 +9,7 @@ imports
   Schedule_R
   "Lib.SimpStrategy"
 begin
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 crunch cancelAllIPC
   for aligned'[wp]: pspace_aligned'
@@ -351,7 +351,7 @@ lemma cte_map_tcb_2:
   "cte_map (t, tcb_cnode_index 2) = t + 2*2^cte_level_bits"
   by (simp add: cte_map_def tcb_cnode_index_def to_bl_1)
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma cte_wp_at_master_reply_cap_to_ex_rights:
   "cte_wp_at (is_master_reply_cap_to t) ptr
@@ -525,7 +525,7 @@ lemma (in delete_one) cancelIPC_ReplyCap_corres:
           od)
        od)"
   proof -
-  interpret Arch . (*FIXME: arch_split*)
+  interpret Arch . (*FIXME: arch-split*)
   show ?thesis
   apply (simp add: reply_cancel_ipc_def getThreadReplySlot_def
                    locateSlot_conv liftM_def tcbReplySlot_def
@@ -658,7 +658,7 @@ crunch setNotification
 lemma sch_act_simple_not_t[simp]: "sch_act_simple s \<Longrightarrow> sch_act_not t s"
   by (clarsimp simp: sch_act_simple_def)
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 crunch setNotification
   for sym_heap_sched_pointers[wp]: sym_heap_sched_pointers
@@ -2064,7 +2064,7 @@ lemma cancelAll_unlive_helper:
   apply (clarsimp elim!: ko_wp_at'_weakenE)
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma setObject_ko_wp_at':
   fixes v :: "'a :: pspace_storable"
   assumes x: "\<And>v :: 'a. updateObject v = updateObject_default v"

--- a/proof/refine/ARM_HYP/Ipc_R.thy
+++ b/proof/refine/ARM_HYP/Ipc_R.thy
@@ -8,7 +8,7 @@ theory Ipc_R
 imports Finalise_R
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemmas lookup_slot_wrapper_defs'[simp] =
    lookupSourceSlot_def lookupTargetSlot_def lookupPivotSlot_def

--- a/proof/refine/ARM_HYP/KHeap_R.thy
+++ b/proof/refine/ARM_HYP/KHeap_R.thy
@@ -21,7 +21,7 @@ lemma koTypeOf_injectKO:
   apply (simp add: project_koType[symmetric])
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma setObject_modify_variable_size:
   fixes v :: "'a :: pspace_storable" shows
@@ -94,7 +94,7 @@ end
 translations
   (type) "'a kernel" <=(type) "kernel_state \<Rightarrow> ('a \<times> kernel_state) set \<times> bool"
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma no_fail_loadObject_default [wp]:
   "no_fail (\<lambda>s. \<exists>obj. projectKO_opt ko = Some (obj::'a) \<and>

--- a/proof/refine/ARM_HYP/LevityCatch.thy
+++ b/proof/refine/ARM_HYP/LevityCatch.thy
@@ -20,7 +20,7 @@ lemma magnitudeCheck_assert:
             split: option.split)
   apply fastforce
   done
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemmas makeObject_simps =
   makeObject_endpoint makeObject_notification makeObject_cte
   makeObject_tcb makeObject_user_data makeObject_pde makeObject_pte
@@ -55,7 +55,7 @@ lemma updateObject_default_inv:
   "\<lbrace>P\<rbrace> updateObject_default obj ko x y n \<lbrace>\<lambda>rv. P\<rbrace>"
   unfolding updateObject_default_def
   by (simp, wp magnitudeCheck_inv alignCheck_inv projectKO_inv, simp)
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma to_from_apiType [simp]: "toAPIType (fromAPIType x) = Some x"
   by (cases x) (auto simp add: fromAPIType_def ARM_HYP_H.fromAPIType_def
     toAPIType_def ARM_HYP_H.toAPIType_def)

--- a/proof/refine/ARM_HYP/Machine_R.thy
+++ b/proof/refine/ARM_HYP/Machine_R.thy
@@ -22,7 +22,7 @@ lemma irq_state_independent_HI[intro!, simp]:
    \<Longrightarrow> irq_state_independent_H P"
   by (simp add: irq_state_independent_H_def)
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma dmo_getirq_inv[wp]:
   "irq_state_independent_H P \<Longrightarrow> \<lbrace>P\<rbrace> doMachineOp (getActiveIRQ in_kernel) \<lbrace>\<lambda>rv. P\<rbrace>"

--- a/proof/refine/ARM_HYP/PageTableDuplicates.thy
+++ b/proof/refine/ARM_HYP/PageTableDuplicates.thy
@@ -8,7 +8,7 @@ theory PageTableDuplicates
 imports Syscall_R
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma set_ntfn_valid_duplicate' [wp]:
   "\<lbrace>\<lambda>s. vs_valid_duplicates' (ksPSpace s)\<rbrace>

--- a/proof/refine/ARM_HYP/Refine.thy
+++ b/proof/refine/ARM_HYP/Refine.thy
@@ -16,7 +16,7 @@ imports
   PageTableDuplicates
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 text \<open>User memory content is the same on both levels\<close>
 lemma typ_at_AUserDataI:

--- a/proof/refine/ARM_HYP/Retype_R.thy
+++ b/proof/refine/ARM_HYP/Retype_R.thy
@@ -12,7 +12,7 @@ theory Retype_R
 imports VSpace_R
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition
   APIType_map2 :: "kernel_object + ARM_HYP_H.object_type \<Rightarrow> Structures_A.apiobject_type"
@@ -1176,7 +1176,7 @@ end
 global_interpretation update_gs: PSpace_update_eq "update_gs ty us ptrs"
   by (simp add: PSpace_update_eq_def)
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma update_gs_id:
   "tp \<in> no_gs_types \<Longrightarrow> update_gs tp us addrs = id"
@@ -1628,7 +1628,7 @@ end
 interpretation retype_region2_ext_extended: is_extended "retype_region2_ext ptrs type"
   by (unfold_locales; wp)
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition
  "retype_region2_extra_ext ptrs type \<equiv>
@@ -1647,7 +1647,7 @@ end
 interpretation retype_region2_extra_ext_extended: is_extended "retype_region2_extra_ext ptrs type"
   by (unfold_locales; wp)
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition
   retype_region2 :: "obj_ref \<Rightarrow> nat \<Rightarrow> nat \<Rightarrow> Structures_A.apiobject_type \<Rightarrow> bool \<Rightarrow> (obj_ref list,'z::state_ext) s_monad"
@@ -2796,7 +2796,7 @@ locale retype_mdb = vmdb +
   assumes 0: "\<not>P 0"
   defines "n \<equiv> \<lambda>p. if P p then Some makeObject else m p"
 begin
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 
 lemma no_0_n: "no_0 n"
   using no_0 by (simp add: no_0_def n_def 0)
@@ -3127,7 +3127,7 @@ lemma caps_no_overlapD'':
   apply blast
 done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma valid_untyped'_helper:
   assumes valid : "valid_cap' c s"
   and  cte_at : "cte_wp_at' (\<lambda>cap. cteCap cap = c) q s"

--- a/proof/refine/ARM_HYP/Schedule_R.thy
+++ b/proof/refine/ARM_HYP/Schedule_R.thy
@@ -8,7 +8,7 @@ theory Schedule_R
 imports VSpace_R
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 declare hoare_weak_lift_imp[wp_split del]
 

--- a/proof/refine/ARM_HYP/StateRelation.thy
+++ b/proof/refine/ARM_HYP/StateRelation.thy
@@ -12,7 +12,7 @@ theory StateRelation
 imports InvariantUpdates_H
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 definition
   cte_map :: "cslot_ptr \<Rightarrow> word32"
 where

--- a/proof/refine/ARM_HYP/SubMonad_R.thy
+++ b/proof/refine/ARM_HYP/SubMonad_R.thy
@@ -47,7 +47,7 @@ lemma doMachineOp_mapM_x:
   done
 
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 definition
   "asUser_fetch \<equiv> \<lambda>t s. case (ksPSpace s t) of
       Some (KOTCB tcb) \<Rightarrow> (atcbContextGet o tcbArch) tcb

--- a/proof/refine/ARM_HYP/Syscall_R.thy
+++ b/proof/refine/ARM_HYP/Syscall_R.thy
@@ -12,7 +12,7 @@ theory Syscall_R
 imports Tcb_R Arch_R Interrupt_R
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 (*
 syscall has 5 sections: m_fault h_fault m_error h_error m_finalise

--- a/proof/refine/ARM_HYP/TcbAcc_R.thy
+++ b/proof/refine/ARM_HYP/TcbAcc_R.thy
@@ -8,7 +8,7 @@ theory TcbAcc_R
 imports CSpace_R
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 declare if_weak_cong [cong]
 declare hoare_in_monad_post[wp]

--- a/proof/refine/ARM_HYP/Tcb_R.thy
+++ b/proof/refine/ARM_HYP/Tcb_R.thy
@@ -8,7 +8,7 @@ theory Tcb_R
 imports CNodeInv_R
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma asUser_setNextPC_corres:
   "corres dc (tcb_at t and invs) (tcb_at' t and invs')
@@ -1630,7 +1630,7 @@ end
 consts
   copyregsets_map :: "arch_copy_register_sets \<Rightarrow> Arch.copy_register_sets"
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 primrec
   tcbinv_relation :: "tcb_invocation \<Rightarrow> tcbinvocation \<Rightarrow> bool"

--- a/proof/refine/ARM_HYP/Untyped_R.thy
+++ b/proof/refine/ARM_HYP/Untyped_R.thy
@@ -9,7 +9,7 @@
 theory Untyped_R
 imports Detype_R Invocations_R InterruptAcc_R
 begin
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 primrec
   untypinv_relation :: "Invocations_A.untyped_invocation \<Rightarrow>
@@ -1004,7 +1004,7 @@ locale mdb_insert_again =
 
 context mdb_insert_again
 begin
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 lemmas parent = mdb_ptr_parent.m_p
 lemmas site = mdb_ptr_site.m_p
 
@@ -1395,7 +1395,7 @@ crunch create_cap_ext
   and work_units_completed[wp]: "\<lambda>s. P (work_units_completed s)"
   (ignore_del: create_cap_ext)
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma updateNewFreeIndex_noop_psp_corres:
   "corres_underlying {(s, s'). pspace_relations (ekheap s) (kheap s) (ksPSpace s')} False True
@@ -1750,7 +1750,7 @@ locale mdb_insert_again_all = mdb_insert_again_child +
   fixes n'
   defines "n' \<equiv> modify_map n (mdbNext parent_node) (cteMDBNode_update (mdbPrev_update (\<lambda>a. site)))"
 begin
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 lemma no_0_n' [simp]: "no_0 n'"
   using no_0_n by (simp add: n'_def)
 
@@ -2724,7 +2724,7 @@ lemma caps_overlap_reserved'_D:
    apply (erule(2) impE)
   apply fastforce
   done
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma insertNewCap_valid_mdb:
   "\<lbrace>valid_mdb' and valid_objs' and K (slot \<noteq> p) and
     caps_overlap_reserved' (untypedRange cap) and
@@ -3922,7 +3922,7 @@ lemma cte_wp_at': "cte_wp_at' (\<lambda>cte. cteCap cte = capability.UntypedCap
       "\<forall>x\<in>set slots. ex_cte_cap_wp_to' (\<lambda>_. True) x s"
   using vui
   by (auto simp: cte_wp_at_ctes_of)
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 
 lemma idx_cases:
   "((\<not> reset \<and> idx \<le> unat (ptr - (ptr && ~~ mask sz))) \<or> reset \<and> ptr = ptr && ~~ mask sz)"
@@ -4066,7 +4066,7 @@ lemma idx_le_new_offs:
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma valid_sched_etcbs[elim!]: "valid_sched_2 queues ekh sa cdom kh ct it \<Longrightarrow> valid_etcbs_2 ekh kh"
   by (simp add: valid_sched_def)
@@ -4224,7 +4224,7 @@ lemma ex_tupI:
   "P (fst x) (snd x) \<Longrightarrow> \<exists>a b. P a b"
   by blast
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 (* mostly stuff about PPtr/fromPPtr, which seems pretty soft *)
 
 lemma resetUntypedCap_corres:
@@ -4439,7 +4439,7 @@ lemma ex_cte_cap_wp_to_irq_state_independent_H[simp]:
   "irq_state_independent_H (ex_cte_cap_wp_to' P slot)"
   by (simp add: ex_cte_cap_wp_to'_def)
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma updateFreeIndex_ctes_of:
   "\<lbrace>\<lambda>s.  P (modify_map (ctes_of s) ptr (cteCap_update (capFreeIndex_update (\<lambda>_. idx))))\<rbrace>
@@ -4661,7 +4661,7 @@ lemma (in range_cover) funky_aligned:
   apply simp
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 defs archOverlap_def:
   "archOverlap \<equiv> \<lambda>_ _. False"

--- a/proof/refine/ARM_HYP/VSpace_R.thy
+++ b/proof/refine/ARM_HYP/VSpace_R.thy
@@ -11,14 +11,14 @@
 theory VSpace_R
 imports TcbAcc_R
 begin
-context Arch begin global_naming ARM (*FIXME: arch_split*)
+context Arch begin global_naming ARM (*FIXME: arch-split*)
 
 lemmas store_pte_typ_ats[wp] = store_pte_typ_ats abs_atyp_at_lifts[OF store_pte_typ_at]
 lemmas store_pde_typ_ats[wp] = store_pde_typ_ats abs_atyp_at_lifts[OF store_pde_typ_at]
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma option_case_all_conv:
   "(case x of None \<Rightarrow> True | Some v \<Rightarrow> P v) = (\<forall>v. x = Some v \<longrightarrow> P v)"

--- a/proof/refine/RISCV64/ADT_H.thy
+++ b/proof/refine/RISCV64/ADT_H.thy
@@ -26,7 +26,7 @@ consts
   initBootFrames :: "machine_word list"
   initDataStart :: machine_word
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 text \<open>
   The construction of the abstract data type
@@ -1206,7 +1206,7 @@ locale partial_sort_cdt =
                    "pspace_distinct' s'" "valid_objs s" "valid_mdb s" "valid_list s"
 begin
 
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 
 lemma valid_list_2 : "valid_list_2 t m"
   apply (insert assms')
@@ -1391,7 +1391,7 @@ lemma sort_cdt_list_correct:
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition absCDTList where
   "absCDTList cnp h \<equiv> sort_cdt_list (absCDT cnp h) h"

--- a/proof/refine/RISCV64/ArchAcc_R.thy
+++ b/proof/refine/RISCV64/ArchAcc_R.thy
@@ -14,7 +14,7 @@ begin
 
 unbundle l4v_word_context
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 declare if_cong[cong] (* FIXME: if_cong *)
 

--- a/proof/refine/RISCV64/Arch_R.thy
+++ b/proof/refine/RISCV64/Arch_R.thy
@@ -16,7 +16,7 @@ unbundle l4v_word_context
 
 lemmas [datatype_schematic] = cap.sel list.sel(1) list.sel(3)
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 declare arch_cap.sel [datatype_schematic]
 declare is_aligned_shiftl [intro!]

--- a/proof/refine/RISCV64/Bits_R.thy
+++ b/proof/refine/RISCV64/Bits_R.thy
@@ -29,7 +29,7 @@ crunch_ignore (add: lookupPTSlotFromLevel lookupPTFromLevel)
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma throwE_R: "\<lbrace>\<top>\<rbrace> throw f \<lbrace>P\<rbrace>,-"
   by (simp add: validE_R_def) wp

--- a/proof/refine/RISCV64/CNodeInv_R.thy
+++ b/proof/refine/RISCV64/CNodeInv_R.thy
@@ -15,7 +15,7 @@ begin
 
 unbundle l4v_word_context
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 primrec
   valid_cnode_inv' :: "Invocations_H.cnode_invocation \<Rightarrow> kernel_state \<Rightarrow> bool"
@@ -4935,7 +4935,7 @@ lemma cteSwap_valid_pspace'[wp]:
   apply clarsimp+
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 crunch cteSwap
   for tcb_at[wp]: "tcb_at' t"
@@ -6640,7 +6640,7 @@ lemmas threadSet_ctesCaps_of = cteCaps_of_ctes_of_lift[OF threadSet_ctes_of]
 
 lemmas storePTE_cteCaps_of[wp] = cteCaps_of_ctes_of_lift [OF storePTE_ctes]
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 crunch finaliseCap
   for rvk_prog': "\<lambda>s. revoke_progress_ord m (\<lambda>x. option_map capToRPO (cteCaps_of s x))"
@@ -7873,7 +7873,7 @@ lemma (in mdb_move) m'_cap:
 context mdb_move
 begin
 
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 
 lemma m_to_src:
   "m \<turnstile> p \<leadsto> src = (p \<noteq> 0 \<and> p = mdbPrev src_node)"
@@ -8404,7 +8404,7 @@ qed
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma cteMove_iflive'[wp]:
   "\<lbrace>\<lambda>s. if_live_then_nonz_cap' s
@@ -8585,7 +8585,7 @@ crunch updateMDB
   for valid_bitmaps[wp]: valid_bitmaps
   (rule: valid_bitmaps_lift)
 
-(* FIXME: arch_split *)
+(* FIXME: arch-split *)
 lemma haskell_assert_inv:
   "haskell_assert Q L \<lbrace>P\<rbrace>"
   by wpsimp

--- a/proof/refine/RISCV64/CSpace1_R.thy
+++ b/proof/refine/RISCV64/CSpace1_R.thy
@@ -13,7 +13,7 @@ imports
   CSpace_I
 begin
 
-context Arch begin global_naming RISCV64_A (*FIXME: arch_split*)
+context Arch begin global_naming RISCV64_A (*FIXME: arch-split*)
 
 lemmas final_matters_def = final_matters_def[simplified final_matters_arch_def]
 
@@ -24,7 +24,7 @@ lemmas final_matters_simps[simp]
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma isMDBParentOf_CTE1:
   "isMDBParentOf (CTE cap node) cte =
@@ -2944,7 +2944,7 @@ locale masterCap =
   fixes cap cap'
   assumes master: "capMasterCap cap = capMasterCap cap'"
 begin
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 
 lemma isZombie [simp]:
   "isZombie cap' = isZombie cap" using master
@@ -3533,7 +3533,7 @@ locale mdb_insert_sib = mdb_insert_der +
            (mdbRevocable_update (\<lambda>a. isCapRevocable c' src_cap)
            (mdbPrev_update (\<lambda>a. src) src_node))))"
 begin
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 
 (* If dest is inserted as sibling, src can not have had children.
    If it had had children, then dest_node which is just a derived copy
@@ -3680,7 +3680,7 @@ lemma descendants:
   by (rule set_eqI) (simp add: descendants_of'_def parent_n_eq)
 
 end
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma mdb_None:
   assumes F: "\<And>p'. cte_map p \<in> descendants_of' p' m' \<Longrightarrow> False"
   assumes R: "cdt_relation (swp cte_at s) (cdt s) m'"
@@ -4533,7 +4533,7 @@ locale mdb_inv_preserve =
   \<and> (\<lambda>x. sameRegionAs x (cteCap cte)) = (\<lambda>x. sameRegionAs x (cteCap cte'))"
   assumes mdb_next:"\<And>p. mdb_next m p = mdb_next m' p"
 begin
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 lemma preserve_stuff:
   "valid_dlist m = valid_dlist m'
  \<and> ut_revocable' m = ut_revocable' m'
@@ -5192,7 +5192,7 @@ lemma cte_map_inj_eq':
   apply (rule cte_map_inj_eq; fastforce)
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma cteInsert_corres:
   notes split_paired_All[simp del] split_paired_Ex[simp del]
         trans_state_update'[symmetric,simp]
@@ -7177,7 +7177,7 @@ lemma subtree_no_parent:
   shows "False" using assms
   by induct (auto simp: parentOf_def mdb_next_unfold)
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma ensureNoChildren_corres:
   "p' = cte_map p \<Longrightarrow>

--- a/proof/refine/RISCV64/CSpace_I.thy
+++ b/proof/refine/RISCV64/CSpace_I.thy
@@ -12,7 +12,7 @@ theory CSpace_I
 imports ArchAcc_R
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma capUntypedPtr_simps [simp]:
   "capUntypedPtr (ThreadCap r) = r"
@@ -1521,7 +1521,7 @@ lemma no_mdb_not_target:
   apply (simp add: no_mdb_def)
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma valid_dlist_init:
   "\<lbrakk> valid_dlist m; m p = Some cte; no_mdb cte \<rbrakk> \<Longrightarrow>
   valid_dlist (m (p \<mapsto> CTE cap initMDBNode))"
@@ -1719,7 +1719,7 @@ lemma untyped_inc_init:
     apply (rule untypedRange_in_capRange)+
   apply (simp add:Int_ac)
   done
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma valid_nullcaps_init:
   "\<lbrakk> valid_nullcaps m; cap \<noteq> NullCap \<rbrakk> \<Longrightarrow> valid_nullcaps (m(p \<mapsto> CTE cap initMDBNode))"
   by (simp add: valid_nullcaps_def initMDBNode_def nullPointer_def)
@@ -1779,7 +1779,7 @@ lemma distinct_zombies_copyE:
 lemmas distinct_zombies_sameE
     = distinct_zombies_copyE [where y=x and x=x for x, simplified,
                               OF _ _ _ _ _]
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma capBits_Master:
   "capBits (capMasterCap cap) = capBits cap"
   by (clarsimp simp: capMasterCap_def split: capability.split arch_capability.split)

--- a/proof/refine/RISCV64/CSpace_R.thy
+++ b/proof/refine/RISCV64/CSpace_R.thy
@@ -53,7 +53,7 @@ locale mdb_move =
   modify_map n (mdbNext src_node)
                (cteMDBNode_update (mdbPrev_update (\<lambda>_. dest)))"
 begin
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 
 
 lemmas src = m_p
@@ -734,7 +734,7 @@ lemma set_cap_not_quite_corres':
                 apply (fastforce simp: c p pspace_relations_def)+
                 done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma cteMove_corres:
   assumes cr: "cap_relation cap cap'"
   notes trans_state_update'[symmetric,simp]
@@ -1121,7 +1121,7 @@ crunch cteInsert
 end
 context mdb_insert
 begin
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 lemma n_src_dest:
   "n \<turnstile> src \<leadsto> dest"
   by (simp add: n_direct_eq)
@@ -1647,7 +1647,7 @@ lemma is_derived_badge_derived':
   "is_derived' m src cap cap' \<Longrightarrow> badge_derived' cap cap'"
   by (simp add: is_derived'_def)
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma cteInsert_mdb_chain_0:
   "\<lbrace>valid_mdb' and pspace_aligned' and pspace_distinct' and (\<lambda>s. src \<noteq> dest) and
@@ -4520,7 +4520,7 @@ locale mdb_insert_simple = mdb_insert +
   assumes simple: "is_simple_cap' c'"
 begin
 
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 
 lemma dest_no_parent_n:
   "n \<turnstile> dest \<rightarrow> p = False"
@@ -4714,7 +4714,7 @@ lemma maskedAsFull_revokable_safe_parent:
      apply (clarsimp simp:isCap_simps is_simple_cap'_def)+
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma cteInsert_simple_corres:
   assumes "cap_relation c c'" "src' = cte_map src" "dest' = cte_map dest"
@@ -5089,7 +5089,7 @@ locale mdb_insert_simple' = mdb_insert_simple +
   fixes n'
   defines  "n' \<equiv> modify_map n (mdbNext src_node) (cteMDBNode_update (mdbPrev_update (\<lambda>_. dest)))"
 begin
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 lemma no_0_n' [intro!]: "no_0 n'" by (auto simp: n'_def)
 lemmas n_0_simps' [iff] = no_0_simps [OF no_0_n']
 
@@ -5786,7 +5786,7 @@ lemma updateCapFreeIndex_no_0:
     apply (clarsimp simp:cte_wp_at_ctes_of)+
 done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma cteInsert_simple_mdb':
   "\<lbrace>valid_mdb' and pspace_aligned' and pspace_distinct' and (\<lambda>s. src \<noteq> dest) and K (capAligned cap) and

--- a/proof/refine/RISCV64/Detype_R.thy
+++ b/proof/refine/RISCV64/Detype_R.thy
@@ -8,7 +8,7 @@ theory Detype_R
 imports Retype_R
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 text \<open>Establishing that the invariants are maintained
         when a region of memory is detyped, that is,
@@ -86,7 +86,7 @@ lemma descendants_range_inD':
   done
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma descendants_range'_def2:
   "descendants_range' cap p = descendants_range_in' (capRange cap) p"
@@ -435,7 +435,7 @@ lemma (in detype_locale') deletionIsSafe:
   and      vu: "valid_untyped (cap.UntypedCap d base magnitude idx) s"
   shows       "deletionIsSafe base magnitude s'"
 proof -
-  interpret Arch . (* FIXME: arch_split *)
+  interpret Arch . (* FIXME: arch-split *)
   note [simp del] = atLeastatMost_subset_iff atLeastLessThan_iff atLeastAtMost_iff
                     Int_atLeastAtMost atLeastatMost_empty_iff split_paired_Ex
   have "\<And>t m r. \<exists>ptr. cte_wp_at ((=) (cap.ReplyCap t m r)) ptr s
@@ -519,7 +519,7 @@ proof -
   thus ?thesis using cte by (auto simp: deletionIsSafe_def)
 qed
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 text \<open>Invariant preservation across concrete deletion\<close>
 
@@ -570,7 +570,7 @@ locale delete_locale =
   and      al: "is_aligned base bits"
   and    safe: "deletionIsSafe base bits s'"
 
-context delete_locale begin interpretation Arch . (*FIXME: arch_split*)
+context delete_locale begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma valid_objs: "valid_objs' s'"
   and        pa: "pspace_aligned' s'"
@@ -772,7 +772,7 @@ lemma refs_notRange:
   done
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 (* FIXME: generalizes lemma SubMonadLib.corres_submonad *)
 (* FIXME: generalizes lemma SubMonad_R.corres_machine_op *)
@@ -1000,7 +1000,7 @@ lemma deleteObjects_corres:
   done
 end
 
-context delete_locale begin interpretation Arch . (*FIXME: arch_split*)
+context delete_locale begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma live_idle_untyped_range':
   "ko_wp_at' live' p s' \<or> p = idle_thread_ptr \<Longrightarrow> p \<notin> base_bits"
@@ -1303,7 +1303,7 @@ using vds
 proof (simp add: invs'_def valid_state'_def valid_pspace'_def
                  valid_mdb'_def valid_mdb_ctes_def,
        safe)
-  interpret Arch . (*FIXME: arch_split*)
+  interpret Arch . (*FIXME: arch-split*)
   let ?s = state'
   let ?ran = base_bits
 
@@ -1676,7 +1676,7 @@ lemma doMachineOp_modify:
   apply (simp add: simpler_gets_def simpler_modify_def bind_def)
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma deleteObjects_invs':
   "\<lbrace>cte_wp_at' (\<lambda>c. cteCap c = UntypedCap d ptr bits idx) p
      and invs' and ct_active' and sch_act_simple

--- a/proof/refine/RISCV64/EmptyFail.thy
+++ b/proof/refine/RISCV64/EmptyFail.thy
@@ -66,7 +66,7 @@ lemma empty_fail_getSlotCap [intro!, wp, simp]:
   "empty_fail (getSlotCap a)"
   unfolding getSlotCap_def by fastforce
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma empty_fail_getObject:
   assumes "\<And>b c d. empty_fail (loadObject x b c d::'a :: pspace_storable kernel)"

--- a/proof/refine/RISCV64/EmptyFail_H.thy
+++ b/proof/refine/RISCV64/EmptyFail_H.thy
@@ -13,7 +13,7 @@ crunch_ignore (empty_fail)
         CSpaceDecls_H.resolveAddressBits
         doMachineOp suspend restart schedule)
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemmas forM_empty_fail[intro!, wp, simp] = empty_fail_mapM[simplified forM_def[symmetric]]
 lemmas forM_x_empty_fail[intro!, wp, simp] = empty_fail_mapM_x[simplified forM_x_def[symmetric]]

--- a/proof/refine/RISCV64/Finalise_R.thy
+++ b/proof/refine/RISCV64/Finalise_R.thy
@@ -11,7 +11,7 @@ imports
   Retype_R
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 declare doUnbindNotification_def[simp]
 
@@ -195,7 +195,7 @@ locale mdb_empty =
                slot (cteCap_update (%_. capability.NullCap)))
               slot (cteMDBNode_update (const nullMDBNode))"
 begin
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 
 lemmas m_slot_prev = m_p_prev
 lemmas m_slot_next = m_p_next
@@ -1424,7 +1424,7 @@ lemma deletedIRQHandler_irqs_masked'[wp]:
   apply (simp add: irqs_masked'_def)
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 crunch emptySlot
   for irqs_masked'[wp]: "irqs_masked'"
 
@@ -2065,7 +2065,7 @@ lemma (in vmdb) isFinal_untypedParent:
                    sameObjectAs_sym)
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma no_fail_isFinalCapability [wp]:
   "no_fail (valid_mdb' and cte_wp_at' ((=) cte) p) (isFinalCapability cte)"
@@ -2928,7 +2928,7 @@ lemma suspend_cte_wp_at':
              | simp add: x)+
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 crunch deleteASIDPool
   for cte_wp_at'[wp]: "cte_wp_at' P p"
@@ -3259,7 +3259,7 @@ lemma finaliseCap_valid_cap[wp]:
   done
 
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma unmapPageTable_nosch[wp]:
   "unmapPageTable asid vaddr pt \<lbrace>\<lambda>s. P (ksSchedulerAction s)\<rbrace>"
@@ -3325,7 +3325,7 @@ lemma (in delete_one) deletingIRQHandler_corres:
   apply (clarsimp simp: cte_wp_at_ctes_of)
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma arch_finaliseCap_corres:
   "\<lbrakk> final_matters' (ArchObjectCap cap') \<Longrightarrow> final = final'; acap_relation cap cap' \<rbrakk>
@@ -3555,7 +3555,7 @@ lemma finaliseCap_corres:
   apply (rule corres_guard_imp [OF arch_finaliseCap_corres], (fastforce simp: valid_sched_def)+)
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma threadSet_ct_idle_or_in_cur_domain':
   "\<lbrace>ct_idle_or_in_cur_domain' and (\<lambda>s. \<forall>tcb. tcbDomain tcb = ksCurDomain s \<longrightarrow> tcbDomain (F tcb) = ksCurDomain s)\<rbrace>

--- a/proof/refine/RISCV64/Init_R.thy
+++ b/proof/refine/RISCV64/Init_R.thy
@@ -10,7 +10,7 @@ imports
 
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 (*
   This provides a very simple witness that the state relation used in the first refinement proof is

--- a/proof/refine/RISCV64/InterruptAcc_R.thy
+++ b/proof/refine/RISCV64/InterruptAcc_R.thy
@@ -18,7 +18,7 @@ lemma getIRQSlot_corres:
                    ucast_nat_def shiftl_t2n)
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma setIRQState_corres:
   "irq_state_relation state state' \<Longrightarrow>

--- a/proof/refine/RISCV64/Interrupt_R.thy
+++ b/proof/refine/RISCV64/Interrupt_R.thy
@@ -14,7 +14,7 @@ begin
 
 context Arch begin
 
-(*FIXME: arch_split: move up *)
+(*FIXME: arch-split: move up *)
 requalify_types
   irqcontrol_invocation
 
@@ -22,11 +22,11 @@ lemmas [crunch_def] = decodeIRQControlInvocation_def performIRQControl_def
 
 context begin global_naming global
 
-(*FIXME: arch_split: move up *)
+(*FIXME: arch-split: move up *)
 requalify_types
   Invocations_H.irqcontrol_invocation
 
-(*FIXME: arch_split*)
+(*FIXME: arch-split*)
 requalify_facts
   Interrupt_H.decodeIRQControlInvocation_def
   Interrupt_H.performIRQControl_def
@@ -95,7 +95,7 @@ where
       ex_cte_cap_to' ptr and real_cte_at' ptr and
       (Not o irq_issued' irq) and K (irq \<le> maxIRQ \<and> irq \<noteq> irqInvalid))"
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma decodeIRQHandlerInvocation_corres:
   "\<lbrakk> list_all2 cap_relation (map fst caps) (map fst caps');

--- a/proof/refine/RISCV64/Invariants_H.thy
+++ b/proof/refine/RISCV64/Invariants_H.thy
@@ -1161,7 +1161,7 @@ locale mdb_order = mdb_next +
 
 \<comment> \<open>---------------------------------------------------------------------------\<close>
 section "Alternate split rules for preserving subgoal order"
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma ntfn_splits[split]:
   " P (case ntfn of Structures_H.ntfn.IdleNtfn \<Rightarrow> f1
      | Structures_H.ntfn.ActiveNtfn x \<Rightarrow> f2 x
@@ -2753,7 +2753,7 @@ lemma le_maxDomain_eq_less_numDomains:
   by (auto simp: Kernel_Config.numDomains_def maxDomain_def word_le_nat_alt)
 
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma page_table_pte_atI':
   "page_table_at' p s \<Longrightarrow> pte_at' (p + (ucast (x::pt_index) << pte_bits)) s"
@@ -2910,7 +2910,7 @@ lemma vms_sch_act_update'[iff]:
    valid_machine_state' s"
   by (simp add: valid_machine_state'_def )
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemmas bit_simps' = pteBits_def asidHighBits_def asidPoolBits_def asid_low_bits_def
                     asid_high_bits_def bit_simps

--- a/proof/refine/RISCV64/Invocations_R.thy
+++ b/proof/refine/RISCV64/Invocations_R.thy
@@ -8,7 +8,7 @@ theory Invocations_R
 imports Bits_R
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma invocationType_eq[simp]:
   "invocationType = invocation_type"

--- a/proof/refine/RISCV64/IpcCancel_R.thy
+++ b/proof/refine/RISCV64/IpcCancel_R.thy
@@ -9,7 +9,7 @@ imports
   Schedule_R
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 crunch cancelAllIPC
   for aligned'[wp]: pspace_aligned'
@@ -337,7 +337,7 @@ lemma cte_map_tcb_2:
   "cte_map (t, tcb_cnode_index 2) = t + 2*2^cte_level_bits"
   by (simp add: cte_map_def tcb_cnode_index_def to_bl_1 shiftl_t2n)
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma cte_wp_at_master_reply_cap_to_ex_rights:
   "cte_wp_at (is_master_reply_cap_to t) ptr
@@ -511,7 +511,7 @@ lemma (in delete_one) cancelIPC_ReplyCap_corres:
           od)
        od)"
   proof -
-  interpret Arch . (*FIXME: arch_split*)
+  interpret Arch . (*FIXME: arch-split*)
   show ?thesis
   apply (simp add: reply_cancel_ipc_def getThreadReplySlot_def
                    locateSlot_conv liftM_def tcbReplySlot_def
@@ -644,7 +644,7 @@ crunch setNotification
 lemma sch_act_simple_not_t[simp]: "sch_act_simple s \<Longrightarrow> sch_act_not t s"
   by (clarsimp simp: sch_act_simple_def)
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 crunch setNotification
   for sym_heap_sched_pointers[wp]: sym_heap_sched_pointers
@@ -1883,7 +1883,7 @@ lemma cancelAll_unlive_helper:
   apply (clarsimp elim!: ko_wp_at'_weakenE)
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma setObject_ko_wp_at':
   fixes v :: "'a :: pspace_storable"
   assumes x: "\<And>v :: 'a. updateObject v = updateObject_default v"

--- a/proof/refine/RISCV64/Ipc_R.thy
+++ b/proof/refine/RISCV64/Ipc_R.thy
@@ -8,7 +8,7 @@ theory Ipc_R
 imports Finalise_R
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemmas lookup_slot_wrapper_defs'[simp] =
    lookupSourceSlot_def lookupTargetSlot_def lookupPivotSlot_def

--- a/proof/refine/RISCV64/KHeap_R.thy
+++ b/proof/refine/RISCV64/KHeap_R.thy
@@ -20,7 +20,7 @@ lemma koTypeOf_injectKO:
   apply (simp add: project_koType[symmetric])
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma setObject_modify_variable_size:
   fixes v :: "'a :: pspace_storable" shows
@@ -86,7 +86,7 @@ end
 translations
   (type) "'a kernel" <=(type) "kernel_state \<Rightarrow> ('a \<times> kernel_state) set \<times> bool"
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma no_fail_loadObject_default [wp]:
   "no_fail (\<lambda>s. \<exists>obj. projectKO_opt ko = Some (obj::'a) \<and>

--- a/proof/refine/RISCV64/Machine_R.thy
+++ b/proof/refine/RISCV64/Machine_R.thy
@@ -22,7 +22,7 @@ lemma irq_state_independent_HI[intro!, simp]:
    \<Longrightarrow> irq_state_independent_H P"
   by (simp add: irq_state_independent_H_def)
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma dmo_getirq_inv[wp]:
   "irq_state_independent_H P \<Longrightarrow> \<lbrace>P\<rbrace> doMachineOp (getActiveIRQ in_kernel) \<lbrace>\<lambda>rv. P\<rbrace>"

--- a/proof/refine/RISCV64/PageTableDuplicates.thy
+++ b/proof/refine/RISCV64/PageTableDuplicates.thy
@@ -8,7 +8,7 @@ theory PageTableDuplicates
 imports Syscall_R
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma doMachineOp_ksPSpace_inv[wp]:
   "\<lbrace>\<lambda>s. P (ksPSpace s)\<rbrace> doMachineOp f \<lbrace>\<lambda>ya s. P (ksPSpace s)\<rbrace>"

--- a/proof/refine/RISCV64/Refine.thy
+++ b/proof/refine/RISCV64/Refine.thy
@@ -16,7 +16,7 @@ imports
   PageTableDuplicates
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 text \<open>User memory content is the same on both levels\<close>
 lemma typ_at_AUserDataI:

--- a/proof/refine/RISCV64/Retype_R.thy
+++ b/proof/refine/RISCV64/Retype_R.thy
@@ -12,7 +12,7 @@ theory Retype_R
 imports VSpace_R
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition
   APIType_map2 :: "kernel_object + RISCV64_H.object_type \<Rightarrow> Structures_A.apiobject_type"
@@ -1150,7 +1150,7 @@ end
 global_interpretation update_gs: PSpace_update_eq "update_gs ty us ptrs"
   by (simp add: PSpace_update_eq_def)
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma ksMachineState_update_gs[simp]:
   "ksMachineState (update_gs tp us addrs s) = ksMachineState s"
@@ -1608,7 +1608,7 @@ end
 interpretation retype_region2_ext_extended: is_extended "retype_region2_ext ptrs type"
   by (unfold_locales; wp)
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition
  "retype_region2_extra_ext ptrs type \<equiv>
@@ -1627,7 +1627,7 @@ end
 interpretation retype_region2_extra_ext_extended: is_extended "retype_region2_extra_ext ptrs type"
   by (unfold_locales; wp)
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition
   retype_region2 :: "obj_ref \<Rightarrow> nat \<Rightarrow> nat \<Rightarrow> Structures_A.apiobject_type \<Rightarrow> bool \<Rightarrow> (obj_ref list,'z::state_ext) s_monad"
@@ -2700,7 +2700,7 @@ locale retype_mdb = vmdb +
   defines "n \<equiv> \<lambda>p. if P p then Some makeObject else m p"
 begin
 
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 
 lemma no_0_n: "no_0 n"
   using no_0 by (simp add: no_0_def n_def 0)
@@ -3032,7 +3032,7 @@ lemma caps_no_overlapD'':
   apply blast
 done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma valid_untyped'_helper:
   assumes valid : "valid_cap' c s"

--- a/proof/refine/RISCV64/Schedule_R.thy
+++ b/proof/refine/RISCV64/Schedule_R.thy
@@ -8,7 +8,7 @@ theory Schedule_R
 imports VSpace_R
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 declare hoare_weak_lift_imp[wp_split del]
 

--- a/proof/refine/RISCV64/SubMonad_R.thy
+++ b/proof/refine/RISCV64/SubMonad_R.thy
@@ -48,7 +48,7 @@ lemma doMachineOp_mapM_x:
   done
 
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 definition
   "asUser_fetch \<equiv> \<lambda>t s. case (ksPSpace s t) of
       Some (KOTCB tcb) \<Rightarrow> (atcbContextGet o tcbArch) tcb

--- a/proof/refine/RISCV64/Syscall_R.thy
+++ b/proof/refine/RISCV64/Syscall_R.thy
@@ -12,7 +12,7 @@ theory Syscall_R
 imports Tcb_R Arch_R Interrupt_R
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 (*
 syscall has 5 sections: m_fault h_fault m_error h_error m_finalise

--- a/proof/refine/RISCV64/TcbAcc_R.thy
+++ b/proof/refine/RISCV64/TcbAcc_R.thy
@@ -8,7 +8,7 @@ theory TcbAcc_R
 imports CSpace_R ArchMove_R
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 declare if_weak_cong [cong]
 declare hoare_in_monad_post[wp]

--- a/proof/refine/RISCV64/Tcb_R.thy
+++ b/proof/refine/RISCV64/Tcb_R.thy
@@ -8,7 +8,7 @@ theory Tcb_R
 imports CNodeInv_R
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma asUser_setNextPC_corres:
   "corres dc (tcb_at t and invs) (tcb_at' t and invs')
@@ -1601,7 +1601,7 @@ end
 consts
   copyregsets_map :: "arch_copy_register_sets \<Rightarrow> Arch.copy_register_sets"
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 primrec
   tcbinv_relation :: "tcb_invocation \<Rightarrow> tcbinvocation \<Rightarrow> bool"

--- a/proof/refine/RISCV64/Untyped_R.thy
+++ b/proof/refine/RISCV64/Untyped_R.thy
@@ -12,7 +12,7 @@ begin
 
 unbundle l4v_word_context
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 primrec
   untypinv_relation :: "Invocations_A.untyped_invocation \<Rightarrow>
@@ -970,7 +970,7 @@ locale mdb_insert_again =
 
 context mdb_insert_again
 begin
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 lemmas parent = mdb_ptr_parent.m_p
 lemmas site = mdb_ptr_site.m_p
 
@@ -1355,7 +1355,7 @@ crunch create_cap_ext
 crunch create_cap_ext
   for work_units_completed[wp]: "\<lambda>s. P (work_units_completed s)"
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma updateNewFreeIndex_noop_psp_corres:
   "corres_underlying {(s, s'). pspace_relations (ekheap s) (kheap s) (ksPSpace s')} False True
@@ -1694,7 +1694,7 @@ locale mdb_insert_again_all = mdb_insert_again_child +
   fixes n'
   defines "n' \<equiv> modify_map n (mdbNext parent_node) (cteMDBNode_update (mdbPrev_update (\<lambda>a. site)))"
 begin
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 lemma no_0_n' [simp]: "no_0 n'"
   using no_0_n by (simp add: n'_def)
 
@@ -2670,7 +2670,7 @@ lemma caps_overlap_reserved'_D:
   apply fastforce
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma insertNewCap_valid_mdb:
   "\<lbrace>valid_mdb' and valid_objs' and K (slot \<noteq> p) and
     caps_overlap_reserved' (untypedRange cap) and
@@ -3882,7 +3882,7 @@ lemma cte_wp_at': "cte_wp_at' (\<lambda>cte. cteCap cte = capability.UntypedCap
   using vui
   by (auto simp: cte_wp_at_ctes_of)
 
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 
 lemma idx_cases:
   "((\<not> reset \<and> idx \<le> unat (ptr - (ptr && ~~ mask sz))) \<or> reset \<and> ptr = ptr && ~~ mask sz)"
@@ -4049,7 +4049,7 @@ lemma idx_le_new_offs:
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma valid_sched_etcbs[elim!]: "valid_sched_2 queues ekh sa cdom kh ct it \<Longrightarrow> valid_etcbs_2 ekh kh"
   by (simp add: valid_sched_def)
@@ -4203,7 +4203,7 @@ lemma ex_tupI:
   "P (fst x) (snd x) \<Longrightarrow> \<exists>a b. P a b"
   by blast
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma resetUntypedCap_corres:
   "untypinv_relation ui ui'
@@ -4410,7 +4410,7 @@ lemma ex_cte_cap_wp_to_irq_state_independent_H[simp]:
   "irq_state_independent_H (ex_cte_cap_wp_to' P slot)"
   by (simp add: ex_cte_cap_wp_to'_def)
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma updateFreeIndex_ctes_of:
   "\<lbrace>\<lambda>s.  P (modify_map (ctes_of s) ptr (cteCap_update (capFreeIndex_update (\<lambda>_. idx))))\<rbrace>
@@ -4635,7 +4635,7 @@ lemma (in range_cover) funky_aligned:
 defs canonicalAddressAssert_def:
   "canonicalAddressAssert p \<equiv> RISCV64.canonical_address p"
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 defs archOverlap_def:
   "archOverlap \<equiv> \<lambda>_ _. False"

--- a/proof/refine/RISCV64/VSpace_R.thy
+++ b/proof/refine/RISCV64/VSpace_R.thy
@@ -12,7 +12,7 @@ theory VSpace_R
 imports TcbAcc_R
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition
   "vspace_at_asid' vs asid \<equiv> \<lambda>s. \<exists>ap pool.

--- a/proof/refine/RISCV64/orphanage/Orphanage.thy
+++ b/proof/refine/RISCV64/orphanage/Orphanage.thy
@@ -14,7 +14,7 @@ text \<open>
   or about to be switched to, or be in a scheduling queue.
 \<close>
 
-(*FIXME: arch_split: move up? *)
+(*FIXME: arch-split: move up? *)
 context Arch begin
 
 requalify_facts
@@ -30,7 +30,7 @@ requalify_facts
 end
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition
    is_active_thread_state :: "thread_state \<Rightarrow> bool"

--- a/proof/refine/X64/ADT_H.thy
+++ b/proof/refine/X64/ADT_H.thy
@@ -28,7 +28,7 @@ consts
   initBootFrames :: "machine_word list"
   initDataStart :: machine_word
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 text \<open>
   The construction of the abstract data type
@@ -1639,7 +1639,7 @@ locale partial_sort_cdt = partial_sort "\<lambda> x y.  m' \<turnstile> cte_map 
 
 begin
 
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 
 lemma valid_list_2 : "valid_list_2 t m"
     apply (insert assms')
@@ -1836,7 +1836,7 @@ lemma sort_cdt_list_correct:
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition absCDTList where
 "absCDTList cnp h \<equiv> sort_cdt_list (absCDT cnp h) h"

--- a/proof/refine/X64/ArchAcc_R.thy
+++ b/proof/refine/X64/ArchAcc_R.thy
@@ -12,7 +12,7 @@ theory ArchAcc_R
 imports SubMonad_R ArchMove_R
 begin
 
-context Arch begin global_naming X64_A (*FIXME: arch_split*)
+context Arch begin global_naming X64_A (*FIXME: arch-split*)
 
 lemma asid_pool_at_ko:
   "asid_pool_at p s \<Longrightarrow> \<exists>pool. ko_at (ArchObj (X64_A.ASIDPool pool)) p s"
@@ -25,7 +25,7 @@ lemma asid_pool_at_ko:
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 declare if_cong[cong]
 

--- a/proof/refine/X64/Arch_R.thy
+++ b/proof/refine/X64/Arch_R.thy
@@ -14,7 +14,7 @@ begin
 
 unbundle l4v_word_context
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 declare is_aligned_shiftl [intro!]
 declare is_aligned_shiftr [intro!]

--- a/proof/refine/X64/Bits_R.thy
+++ b/proof/refine/X64/Bits_R.thy
@@ -26,7 +26,7 @@ crunch_ignore (add:
   emptyOnFailure clearMemoryVM null_cap_on_failure setNextPC getRestartPC assertDerived
   throw_on_false setObject getObject updateObject loadObject)
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma throwE_R: "\<lbrace>\<top>\<rbrace> throw f \<lbrace>P\<rbrace>,-"
   by (simp add: validE_R_def) wp

--- a/proof/refine/X64/CNodeInv_R.thy
+++ b/proof/refine/X64/CNodeInv_R.thy
@@ -15,7 +15,7 @@ begin
 
 unbundle l4v_word_context
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 primrec
   valid_cnode_inv' :: "Invocations_H.cnode_invocation \<Rightarrow> kernel_state \<Rightarrow> bool"
@@ -4980,7 +4980,7 @@ lemma cteSwap_valid_pspace'[wp]:
   apply clarsimp+
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 crunch cteSwap
   for tcb_at[wp]: "tcb_at' t"
@@ -6779,7 +6779,7 @@ lemmas storePDE_cteCaps_of[wp] = ctes_of_cteCaps_of_lift [OF storePDE_ctes]
 lemmas storePDPTE_cteCaps_of[wp] = ctes_of_cteCaps_of_lift [OF storePDPTE_ctes]
 lemmas storePML4E_cteCaps_of[wp] = ctes_of_cteCaps_of_lift [OF storePML4E_ctes]
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 context
 notes option.case_cong_weak[cong]
@@ -8017,7 +8017,7 @@ lemma (in mdb_move) m'_cap:
 context mdb_move
 begin
 
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 
 lemma m_to_src:
   "m \<turnstile> p \<leadsto> src = (p \<noteq> 0 \<and> p = mdbPrev src_node)"
@@ -8570,7 +8570,7 @@ qed
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma cteMove_iflive'[wp]:
   "\<lbrace>\<lambda>s. if_live_then_nonz_cap' s
@@ -8775,7 +8775,7 @@ crunch updateMDB
   for valid_bitmaps[wp]: valid_bitmaps
   (rule: valid_bitmaps_lift)
 
-(* FIXME: arch_split *)
+(* FIXME: arch-split *)
 lemma haskell_assert_inv:
   "haskell_assert Q L \<lbrace>P\<rbrace>"
   by wpsimp

--- a/proof/refine/X64/CSpace1_R.thy
+++ b/proof/refine/X64/CSpace1_R.thy
@@ -14,7 +14,7 @@ imports
   "AInvs.ArchDetSchedSchedule_AI"
 begin
 
-context Arch begin global_naming X64_A (*FIXME: arch_split*)
+context Arch begin global_naming X64_A (*FIXME: arch-split*)
 
 lemmas final_matters_def = final_matters_def[simplified final_matters_arch_def]
 
@@ -25,7 +25,7 @@ lemmas final_matters_simps[simp]
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma isMDBParentOf_CTE1:
   "isMDBParentOf (CTE cap node) cte =
@@ -2973,7 +2973,7 @@ locale masterCap =
   fixes cap cap'
   assumes master: "capMasterCap cap = capMasterCap cap'"
 begin
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 
 lemma isZombie [simp]:
   "isZombie cap' = isZombie cap" using master
@@ -3572,7 +3572,7 @@ locale mdb_insert_sib = mdb_insert_der +
            (mdbRevocable_update (\<lambda>a. isCapRevocable c' src_cap)
            (mdbPrev_update (\<lambda>a. src) src_node))))"
 begin
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 
 (* If dest is inserted as sibling, src can not have had children.
    If it had had children, then dest_node which is just a derived copy
@@ -3719,7 +3719,7 @@ lemma descendants:
   by (rule set_eqI) (simp add: descendants_of'_def parent_n_eq)
 
 end
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma mdb_None:
   assumes F: "\<And>p'. cte_map p \<in> descendants_of' p' m' \<Longrightarrow> False"
   assumes R: "cdt_relation (swp cte_at s) (cdt s) m'"
@@ -4612,7 +4612,7 @@ locale mdb_inv_preserve =
   \<and> (\<lambda>x. sameRegionAs x (cteCap cte)) = (\<lambda>x. sameRegionAs x (cteCap cte'))"
   assumes mdb_next:"\<And>p. mdb_next m p = mdb_next m' p"
 begin
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 lemma preserve_stuff:
   "valid_dlist m = valid_dlist m'
  \<and> ut_revocable' m = ut_revocable' m'
@@ -5303,7 +5303,7 @@ lemma cte_map_inj_eq':
   apply (rule cte_map_inj_eq; fastforce)
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma cteInsert_corres:
   notes split_paired_All[simp del] split_paired_Ex[simp del]
         trans_state_update'[symmetric,simp]
@@ -7288,7 +7288,7 @@ lemma subtree_no_parent:
   shows "False" using assms
   by induct (auto simp: parentOf_def mdb_next_unfold)
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma ensureNoChildren_corres:
   "p' = cte_map p \<Longrightarrow>

--- a/proof/refine/X64/CSpace_I.thy
+++ b/proof/refine/X64/CSpace_I.thy
@@ -12,7 +12,7 @@ theory CSpace_I
 imports ArchAcc_R
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma capUntypedPtr_simps [simp]:
   "capUntypedPtr (ThreadCap r) = r"
@@ -1574,7 +1574,7 @@ lemma no_mdb_not_target:
   apply (simp add: no_mdb_def)
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma valid_dlist_init:
   "\<lbrakk> valid_dlist m; m p = Some cte; no_mdb cte \<rbrakk> \<Longrightarrow>
   valid_dlist (m (p \<mapsto> CTE cap initMDBNode))"
@@ -1772,7 +1772,7 @@ lemma untyped_inc_init:
     apply (rule untypedRange_in_capRange)+
   apply (simp add:Int_ac)
   done
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma valid_nullcaps_init:
   "\<lbrakk> valid_nullcaps m; cap \<noteq> NullCap \<rbrakk> \<Longrightarrow> valid_nullcaps (m(p \<mapsto> CTE cap initMDBNode))"
   by (simp add: valid_nullcaps_def initMDBNode_def nullPointer_def)
@@ -1832,7 +1832,7 @@ lemma distinct_zombies_copyE:
 lemmas distinct_zombies_sameE
     = distinct_zombies_copyE [where y=x and x=x for x, simplified,
                               OF _ _ _ _ _]
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma capBits_Master:
   "capBits (capMasterCap cap) = capBits cap"
   by (clarsimp simp: capMasterCap_def split: capability.split arch_capability.split)

--- a/proof/refine/X64/CSpace_R.thy
+++ b/proof/refine/X64/CSpace_R.thy
@@ -53,7 +53,7 @@ locale mdb_move =
   modify_map n (mdbNext src_node)
                (cteMDBNode_update (mdbPrev_update (\<lambda>_. dest)))"
 begin
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 
 
 lemmas src = m_p
@@ -734,7 +734,7 @@ lemma set_cap_not_quite_corres':
                 apply (fastforce simp: c p pspace_relations_def)+
                 done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma cteMove_corres:
   assumes cr: "cap_relation cap cap'"
   notes trans_state_update'[symmetric,simp]
@@ -1130,7 +1130,7 @@ crunch cteInsert
 end
 context mdb_insert
 begin
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 lemma n_src_dest:
   "n \<turnstile> src \<leadsto> dest"
   by (simp add: n_direct_eq)
@@ -1673,7 +1673,7 @@ lemma is_derived_badge_derived':
   "is_derived' m src cap cap' \<Longrightarrow> badge_derived' cap cap'"
   by (simp add: is_derived'_def)
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma cteInsert_mdb_chain_0:
   "\<lbrace>valid_mdb' and pspace_aligned' and pspace_distinct' and (\<lambda>s. src \<noteq> dest) and
@@ -4757,7 +4757,7 @@ locale mdb_insert_simple = mdb_insert +
   assumes safe_parent: "safe_parent_for' m src c'"
   assumes simple: "is_simple_cap' c'"
 begin
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 lemma dest_no_parent_n:
   "n \<turnstile> dest \<rightarrow> p = False"
   using src simple safe_parent
@@ -4957,7 +4957,7 @@ lemma maskedAsFull_revokable_safe_parent:
    apply (rule conjI; clarsimp)
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma cteInsert_simple_corres:
   assumes "cap_relation c c'" "src' = cte_map src" "dest' = cte_map dest"
@@ -5338,7 +5338,7 @@ locale mdb_insert_simple' = mdb_insert_simple +
   fixes n'
   defines  "n' \<equiv> modify_map n (mdbNext src_node) (cteMDBNode_update (mdbPrev_update (\<lambda>_. dest)))"
 begin
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 lemma no_0_n' [intro!]: "no_0 n'" by (auto simp: n'_def)
 lemmas n_0_simps' [iff] = no_0_simps [OF no_0_n']
 
@@ -6093,7 +6093,7 @@ lemma updateCapFreeIndex_no_0:
     apply (clarsimp simp:cte_wp_at_ctes_of)+
 done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma cteInsert_simple_mdb':
   "\<lbrace>valid_mdb' and pspace_aligned' and pspace_distinct' and (\<lambda>s. src \<noteq> dest) and K (capAligned cap) and

--- a/proof/refine/X64/Detype_R.thy
+++ b/proof/refine/X64/Detype_R.thy
@@ -8,7 +8,7 @@ theory Detype_R
 imports Retype_R
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 text \<open>Establishing that the invariants are maintained
         when a region of memory is detyped, that is,
@@ -86,7 +86,7 @@ lemma descendants_range_inD':
   done
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma descendants_range'_def2:
   "descendants_range' cap p = descendants_range_in' (capRange cap) p"
@@ -471,7 +471,7 @@ lemma (in detype_locale') deletionIsSafe:
   and      vu: "valid_untyped (cap.UntypedCap d base magnitude idx) s"
   shows       "deletionIsSafe base magnitude s'"
 proof -
-  interpret Arch . (* FIXME: arch_split *)
+  interpret Arch . (* FIXME: arch-split *)
   note blah[simp del] =  atLeastatMost_subset_iff atLeastLessThan_iff
           Int_atLeastAtMost atLeastatMost_empty_iff split_paired_Ex
           atLeastAtMost_iff
@@ -552,7 +552,7 @@ proof -
   thus ?thesis using cte by (auto simp: deletionIsSafe_def)
 qed
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 text \<open>Invariant preservation across concrete deletion\<close>
 
@@ -603,7 +603,7 @@ locale delete_locale =
   and      al: "is_aligned base bits"
   and    safe: "deletionIsSafe base bits s'"
 
-context delete_locale begin interpretation Arch . (*FIXME: arch_split*)
+context delete_locale begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma valid_objs: "valid_objs' s'"
   and        pa: "pspace_aligned' s'"
@@ -840,7 +840,7 @@ lemma refs_notRange:
   done
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 (* FIXME: generalizes lemma SubMonadLib.corres_submonad *)
 (* FIXME: generalizes lemma SubMonad_R.corres_machine_op *)
@@ -1072,7 +1072,7 @@ lemma deleteObjects_corres:
   done
 end
 
-context delete_locale begin interpretation Arch . (*FIXME: arch_split*)
+context delete_locale begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma live_idle_untyped_range':
   "ko_wp_at' live' p s' \<or> p = idle_thread_ptr \<Longrightarrow> p \<notin> base_bits"
@@ -1390,7 +1390,7 @@ using vds
 proof (simp add: invs'_def valid_state'_def valid_pspace'_def
                  valid_mdb'_def valid_mdb_ctes_def,
        safe)
-  interpret Arch . (*FIXME: arch_split*)
+  interpret Arch . (*FIXME: arch-split*)
   let ?s = state'
   let ?ran = base_bits
 
@@ -1790,7 +1790,7 @@ lemma doMachineOp_modify:
   apply (rule ext)
   apply (simp add: simpler_gets_def simpler_modify_def bind_def)
   done
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma deleteObjects_invs':
   "\<lbrace>cte_wp_at' (\<lambda>c. cteCap c = UntypedCap d ptr bits idx) p
      and invs' and ct_active' and sch_act_simple

--- a/proof/refine/X64/EmptyFail.thy
+++ b/proof/refine/X64/EmptyFail.thy
@@ -66,7 +66,7 @@ lemma empty_fail_getSlotCap [intro!, wp, simp]:
   "empty_fail (getSlotCap a)"
   unfolding getSlotCap_def by fastforce
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma empty_fail_getObject:
   assumes "\<And>b c d. empty_fail (loadObject x b c d::'a :: pspace_storable kernel)"

--- a/proof/refine/X64/EmptyFail_H.thy
+++ b/proof/refine/X64/EmptyFail_H.thy
@@ -13,7 +13,7 @@ crunch_ignore (empty_fail)
         CSpaceDecls_H.resolveAddressBits
         doMachineOp suspend restart schedule)
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemmas forM_empty_fail[intro!, wp, simp] = empty_fail_mapM[simplified forM_def[symmetric]]
 lemmas forM_x_empty_fail[intro!, wp, simp] = empty_fail_mapM_x[simplified forM_x_def[symmetric]]

--- a/proof/refine/X64/Finalise_R.thy
+++ b/proof/refine/X64/Finalise_R.thy
@@ -10,7 +10,7 @@ imports
   InterruptAcc_R
   Retype_R
 begin
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 declare doUnbindNotification_def[simp]
 
@@ -183,7 +183,7 @@ locale mdb_empty =
                slot (cteCap_update (%_. capability.NullCap)))
               slot (cteMDBNode_update (const nullMDBNode))"
 begin
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 
 lemmas m_slot_prev = m_p_prev
 lemmas m_slot_next = m_p_next
@@ -1509,7 +1509,7 @@ lemma deletedIRQHandler_irqs_masked'[wp]:
   apply (simp add: irqs_masked'_def)
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 crunch emptySlot
   for irqs_masked'[wp]: "irqs_masked'"
 
@@ -2189,7 +2189,7 @@ lemma (in vmdb) isFinal_untypedParent:
                    sameObjectAs_sym)
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma no_fail_isFinalCapability [wp]:
   "no_fail (valid_mdb' and cte_wp_at' ((=) cte) p) (isFinalCapability cte)"
@@ -3107,7 +3107,7 @@ lemma suspend_cte_wp_at':
              | simp add: x)+
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 crunch deleteASIDPool
   for cte_wp_at'[wp]: "cte_wp_at' P p"
@@ -3437,7 +3437,7 @@ lemma finaliseCap_valid_cap[wp]:
   done
 
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 crunch "Arch.finaliseCap"
   for nosch[wp]: "\<lambda>s. P (ksSchedulerAction s)"
@@ -3499,7 +3499,7 @@ lemma (in delete_one) deletingIRQHandler_corres:
   apply (clarsimp simp: cte_wp_at_ctes_of)
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma arch_finaliseCap_corres:
   "\<lbrakk> final_matters' (ArchObjectCap cap') \<Longrightarrow> final = final'; acap_relation cap cap' \<rbrakk>
@@ -3725,7 +3725,7 @@ lemma finaliseCap_corres:
   apply (rule corres_guard_imp [OF arch_finaliseCap_corres], (fastforce simp: valid_sched_def)+)
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 crunch copyGlobalMappings
   for ifunsafe'[wp]: "if_unsafe_then_cap'"

--- a/proof/refine/X64/Init_R.thy
+++ b/proof/refine/X64/Init_R.thy
@@ -10,7 +10,7 @@ imports
 
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 (*
   This provides a very simple witness that the state relation used in the first refinement proof is

--- a/proof/refine/X64/InterruptAcc_R.thy
+++ b/proof/refine/X64/InterruptAcc_R.thy
@@ -18,7 +18,7 @@ lemma getIRQSlot_corres:
                    ucast_nat_def shiftl_t2n)
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma setIRQState_corres:
   "irq_state_relation state state' \<Longrightarrow>

--- a/proof/refine/X64/Interrupt_R.thy
+++ b/proof/refine/X64/Interrupt_R.thy
@@ -14,7 +14,7 @@ begin
 
 context Arch begin
 
-(*FIXME: arch_split: move up *)
+(*FIXME: arch-split: move up *)
 requalify_types
   irqcontrol_invocation
 
@@ -22,11 +22,11 @@ lemmas [crunch_def] = decodeIRQControlInvocation_def performIRQControl_def
 
 context begin global_naming global
 
-(*FIXME: arch_split: move up *)
+(*FIXME: arch-split: move up *)
 requalify_types
   Invocations_H.irqcontrol_invocation
 
-(*FIXME: arch_split*)
+(*FIXME: arch-split*)
 requalify_facts
   Interrupt_H.decodeIRQControlInvocation_def
   Interrupt_H.performIRQControl_def
@@ -94,7 +94,7 @@ where
         ex_cte_cap_to' ptr and real_cte_at' ptr and
         (Not o irq_issued' irq) and K (irq \<le> maxIRQ))"
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma decodeIRQHandlerInvocation_corres:
   "\<lbrakk> list_all2 cap_relation (map fst caps) (map fst caps');

--- a/proof/refine/X64/InvariantUpdates_H.thy
+++ b/proof/refine/X64/InvariantUpdates_H.thy
@@ -270,7 +270,7 @@ lemma valid_arch_state'_interrupt[simp]:
   "valid_arch_state' (ksInterruptState_update f s) = valid_arch_state' s"
   by (simp add: valid_arch_state'_def cong: option.case_cong)
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma valid_ioports_cr3_update[simp]:
   "valid_ioports' (s\<lparr>ksArchState := x64KSCurrentUserCR3_update (\<lambda>_. c) (ksArchState s)\<rparr>) = valid_ioports' s"

--- a/proof/refine/X64/Invariants_H.thy
+++ b/proof/refine/X64/Invariants_H.thy
@@ -47,7 +47,7 @@ lemma le_maxDomain_eq_less_numDomains:
   by (auto simp: Kernel_Config.numDomains_def maxDomain_def word_le_nat_alt)
 
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 \<comment> \<open>---------------------------------------------------------------------------\<close>
 section "Invariants on Executable Spec"
 
@@ -338,7 +338,7 @@ where
 section "Valid caps and objects (Haskell)"
 
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 primrec
   acapBits :: "arch_capability \<Rightarrow> nat"
 where
@@ -397,7 +397,7 @@ definition
 
 
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition
   page_table_at' :: "machine_word \<Rightarrow> kernel_state \<Rightarrow> bool"
@@ -1458,7 +1458,7 @@ locale mdb_order = mdb_next +
 
 \<comment> \<open>---------------------------------------------------------------------------\<close>
 section "Alternate split rules for preserving subgoal order"
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma ntfn_splits[split]:
   " P (case ntfn of Structures_H.ntfn.IdleNtfn \<Rightarrow> f1
      | Structures_H.ntfn.ActiveNtfn x \<Rightarrow> f2 x
@@ -3123,7 +3123,7 @@ lemma ex_cte_cap_to'_pres:
    apply assumption
   apply simp
   done
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma page_directory_pde_atI':
   "\<lbrakk> page_directory_at' p s; x < 2 ^ ptTranslationBits \<rbrakk> \<Longrightarrow> pde_at' (p + (x << word_size_bits)) s"
   by (simp add: page_directory_at'_def pageBits_def)
@@ -3299,7 +3299,7 @@ lemma vms_sch_act_update'[iff]:
   "valid_machine_state' (ksSchedulerAction_update f s) =
    valid_machine_state' s"
   by (simp add: valid_machine_state'_def )
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma objBitsT_simps:
   "objBitsT EndpointT = epSizeBits"
   "objBitsT NotificationT = ntfnSizeBits"

--- a/proof/refine/X64/Invocations_R.thy
+++ b/proof/refine/X64/Invocations_R.thy
@@ -8,7 +8,7 @@ theory Invocations_R
 imports Invariants_H
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma invocationType_eq[simp]:
   "invocationType = invocation_type"

--- a/proof/refine/X64/IpcCancel_R.thy
+++ b/proof/refine/X64/IpcCancel_R.thy
@@ -9,7 +9,7 @@ imports
   Schedule_R
   "Lib.SimpStrategy"
 begin
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 crunch cancelAllIPC
   for aligned'[wp]: pspace_aligned'
@@ -350,7 +350,7 @@ lemma cte_map_tcb_2:
   "cte_map (t, tcb_cnode_index 2) = t + 2*2^cte_level_bits"
   by (simp add: cte_map_def tcb_cnode_index_def to_bl_1)
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma cte_wp_at_master_reply_cap_to_ex_rights:
   "cte_wp_at (is_master_reply_cap_to t) ptr
@@ -524,7 +524,7 @@ lemma (in delete_one) cancelIPC_ReplyCap_corres:
           od)
        od)"
   proof -
-  interpret Arch . (*FIXME: arch_split*)
+  interpret Arch . (*FIXME: arch-split*)
   show ?thesis
   apply (simp add: reply_cancel_ipc_def getThreadReplySlot_def
                    locateSlot_conv liftM_def tcbReplySlot_def
@@ -653,7 +653,7 @@ declare cart_singleton_empty2[simp]
 lemma sch_act_simple_not_t[simp]: "sch_act_simple s \<Longrightarrow> sch_act_not t s"
   by (clarsimp simp: sch_act_simple_def)
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 crunch setNotification
   for sym_heap_sched_pointers[wp]: sym_heap_sched_pointers
@@ -1217,7 +1217,7 @@ lemma do_extended_op_pspace_distinct[wp]:
   "do_extended_op f \<lbrace>pspace_distinct\<rbrace>"
   by (wpsimp simp: do_extended_op_def)
 
-context begin interpretation Arch . (* FIXME: arch_split *)
+context begin interpretation Arch . (* FIXME: arch-split *)
 
 crunch arch_post_cap_deletion
   for pspace_aligned[wp]: pspace_aligned
@@ -1988,7 +1988,7 @@ lemma cancelAll_unlive_helper:
   apply (clarsimp elim!: ko_wp_at'_weakenE)
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma setObject_ko_wp_at':
   fixes v :: "'a :: pspace_storable"
   assumes x: "\<And>v :: 'a. updateObject v = updateObject_default v"

--- a/proof/refine/X64/Ipc_R.thy
+++ b/proof/refine/X64/Ipc_R.thy
@@ -8,7 +8,7 @@ theory Ipc_R
 imports Finalise_R
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemmas lookup_slot_wrapper_defs'[simp] =
    lookupSourceSlot_def lookupTargetSlot_def lookupPivotSlot_def

--- a/proof/refine/X64/KHeap_R.thy
+++ b/proof/refine/X64/KHeap_R.thy
@@ -21,7 +21,7 @@ lemma koTypeOf_injectKO:
   apply (simp add: project_koType[symmetric])
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma setObject_modify_variable_size:
   fixes v :: "'a :: pspace_storable" shows
@@ -88,7 +88,7 @@ end
 translations
   (type) "'a kernel" <=(type) "kernel_state \<Rightarrow> ('a \<times> kernel_state) set \<times> bool"
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma no_fail_loadObject_default [wp]:
   "no_fail (\<lambda>s. \<exists>obj. projectKO_opt ko = Some (obj::'a) \<and>

--- a/proof/refine/X64/LevityCatch.thy
+++ b/proof/refine/X64/LevityCatch.thy
@@ -20,7 +20,7 @@ lemma magnitudeCheck_assert:
             split: option.split)
   apply fastforce
   done
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemmas makeObject_simps =
   makeObject_endpoint makeObject_notification makeObject_cte
   makeObject_tcb makeObject_user_data makeObject_pde makeObject_pte
@@ -55,7 +55,7 @@ lemma updateObject_default_inv:
   "\<lbrace>P\<rbrace> updateObject_default obj ko x y n \<lbrace>\<lambda>rv. P\<rbrace>"
   unfolding updateObject_default_def
   by (simp, wp magnitudeCheck_inv alignCheck_inv projectKO_inv, simp)
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma to_from_apiType [simp]: "toAPIType (fromAPIType x) = Some x"
   by (cases x) (auto simp add: fromAPIType_def X64_H.fromAPIType_def
     toAPIType_def X64_H.toAPIType_def)

--- a/proof/refine/X64/Machine_R.thy
+++ b/proof/refine/X64/Machine_R.thy
@@ -22,7 +22,7 @@ lemma irq_state_independent_HI[intro!, simp]:
    \<Longrightarrow> irq_state_independent_H P"
   by (simp add: irq_state_independent_H_def)
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma dmo_getirq_inv[wp]:
   "irq_state_independent_H P \<Longrightarrow> \<lbrace>P\<rbrace> doMachineOp (getActiveIRQ in_kernel) \<lbrace>\<lambda>rv. P\<rbrace>"

--- a/proof/refine/X64/PageTableDuplicates.thy
+++ b/proof/refine/X64/PageTableDuplicates.thy
@@ -8,7 +8,7 @@ theory PageTableDuplicates
 imports Syscall_R
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma doMachineOp_ksPSpace_inv[wp]:
   "\<lbrace>\<lambda>s. P (ksPSpace s)\<rbrace> doMachineOp f \<lbrace>\<lambda>ya s. P (ksPSpace s)\<rbrace>"

--- a/proof/refine/X64/Refine.thy
+++ b/proof/refine/X64/Refine.thy
@@ -16,7 +16,7 @@ imports
   PageTableDuplicates
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 text \<open>User memory content is the same on both levels\<close>
 lemma typ_at_AUserDataI:

--- a/proof/refine/X64/Retype_R.thy
+++ b/proof/refine/X64/Retype_R.thy
@@ -12,7 +12,7 @@ theory Retype_R
 imports TcbAcc_R VSpace_R
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition
   APIType_map2 :: "kernel_object + X64_H.object_type \<Rightarrow> Structures_A.apiobject_type"
@@ -1175,7 +1175,7 @@ end
 global_interpretation update_gs: PSpace_update_eq "update_gs ty us ptrs"
   by (simp add: PSpace_update_eq_def)
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma update_gs_id:
   "tp \<in> no_gs_types \<Longrightarrow> update_gs tp us addrs = id"
@@ -1622,7 +1622,7 @@ end
 interpretation retype_region2_ext_extended: is_extended "retype_region2_ext ptrs type"
   by (unfold_locales; wp)
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition
  "retype_region2_extra_ext ptrs type \<equiv>
@@ -1641,7 +1641,7 @@ end
 interpretation retype_region2_extra_ext_extended: is_extended "retype_region2_extra_ext ptrs type"
   by (unfold_locales; wp)
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition
   retype_region2 :: "obj_ref \<Rightarrow> nat \<Rightarrow> nat \<Rightarrow> Structures_A.apiobject_type \<Rightarrow> bool \<Rightarrow> (obj_ref list,'z::state_ext) s_monad"
@@ -2817,7 +2817,7 @@ locale retype_mdb = vmdb +
   defines "n \<equiv> \<lambda>p. if P p then Some makeObject else m p"
 begin
 
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 
 lemma no_0_n: "no_0 n"
   using no_0 by (simp add: no_0_def n_def 0)
@@ -3157,7 +3157,7 @@ lemma caps_no_overlapD'':
   apply blast
 done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma valid_untyped'_helper:
   assumes valid : "valid_cap' c s"
   and  cte_at : "cte_wp_at' (\<lambda>cap. cteCap cap = c) q s"

--- a/proof/refine/X64/Schedule_R.thy
+++ b/proof/refine/X64/Schedule_R.thy
@@ -8,7 +8,7 @@ theory Schedule_R
 imports VSpace_R
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 declare hoare_weak_lift_imp[wp_split del]
 

--- a/proof/refine/X64/StateRelation.thy
+++ b/proof/refine/X64/StateRelation.thy
@@ -12,7 +12,7 @@ theory StateRelation
 imports InvariantUpdates_H
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition
   cte_map :: "cslot_ptr \<Rightarrow> machine_word"

--- a/proof/refine/X64/SubMonad_R.thy
+++ b/proof/refine/X64/SubMonad_R.thy
@@ -44,7 +44,7 @@ lemma doMachineOp_mapM_x:
   done
 
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 definition
   "asUser_fetch \<equiv> \<lambda>t s. case (ksPSpace s t) of
       Some (KOTCB tcb) \<Rightarrow> (atcbContextGet o tcbArch) tcb

--- a/proof/refine/X64/Syscall_R.thy
+++ b/proof/refine/X64/Syscall_R.thy
@@ -12,7 +12,7 @@ theory Syscall_R
 imports Tcb_R Arch_R Interrupt_R
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 (*
 syscall has 5 sections: m_fault h_fault m_error h_error m_finalise

--- a/proof/refine/X64/TcbAcc_R.thy
+++ b/proof/refine/X64/TcbAcc_R.thy
@@ -8,7 +8,7 @@ theory TcbAcc_R
 imports CSpace_R
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 declare if_weak_cong [cong]
 declare hoare_in_monad_post[wp]

--- a/proof/refine/X64/Tcb_R.thy
+++ b/proof/refine/X64/Tcb_R.thy
@@ -8,7 +8,7 @@ theory Tcb_R
 imports CNodeInv_R
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma asUser_setNextPC_corres:
   "corres dc (tcb_at t and invs) invs'
@@ -1671,7 +1671,7 @@ end
 consts
   copyregsets_map :: "arch_copy_register_sets \<Rightarrow> Arch.copy_register_sets"
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 primrec
   tcbinv_relation :: "tcb_invocation \<Rightarrow> tcbinvocation \<Rightarrow> bool"

--- a/proof/refine/X64/Untyped_R.thy
+++ b/proof/refine/X64/Untyped_R.thy
@@ -9,7 +9,7 @@
 theory Untyped_R
 imports Detype_R Invocations_R InterruptAcc_R
 begin
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 primrec
   untypinv_relation :: "Invocations_A.untyped_invocation \<Rightarrow>
@@ -1032,7 +1032,7 @@ locale mdb_insert_again =
 
 context mdb_insert_again
 begin
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 lemmas parent = mdb_ptr_parent.m_p
 lemmas site = mdb_ptr_site.m_p
 
@@ -1418,7 +1418,7 @@ crunch create_cap_ext
   and work_units_completed[wp]: "\<lambda>s. P (work_units_completed s)"
   (ignore_del: create_cap_ext)
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma updateNewFreeIndex_noop_psp_corres:
   "corres_underlying {(s, s'). pspace_relations (ekheap s) (kheap s) (ksPSpace s')} False True
@@ -1775,7 +1775,7 @@ locale mdb_insert_again_all = mdb_insert_again_child +
   fixes n'
   defines "n' \<equiv> modify_map n (mdbNext parent_node) (cteMDBNode_update (mdbPrev_update (\<lambda>a. site)))"
 begin
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 lemma no_0_n' [simp]: "no_0 n'"
   using no_0_n by (simp add: n'_def)
 
@@ -2758,7 +2758,7 @@ lemma caps_overlap_reserved'_D:
    apply (erule(2) impE)
   apply fastforce
   done
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 lemma insertNewCap_valid_mdb:
   "\<lbrace>valid_mdb' and valid_objs' and K (slot \<noteq> p) and
     caps_overlap_reserved' (untypedRange cap) and
@@ -3979,7 +3979,7 @@ lemma cte_wp_at': "cte_wp_at' (\<lambda>cte. cteCap cte = capability.UntypedCap
       "\<forall>x\<in>set slots. ex_cte_cap_wp_to' (\<lambda>_. True) x s"
   using vui
   by (auto simp: cte_wp_at_ctes_of)
-interpretation Arch . (*FIXME: arch_split*)
+interpretation Arch . (*FIXME: arch-split*)
 
 lemma idx_cases:
   "((\<not> reset \<and> idx \<le> unat (ptr - (ptr && ~~ mask sz))) \<or> reset \<and> ptr = ptr && ~~ mask sz)"
@@ -4144,7 +4144,7 @@ lemma idx_le_new_offs:
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma valid_sched_etcbs[elim!]: "valid_sched_2 queues ekh sa cdom kh ct it \<Longrightarrow> valid_etcbs_2 ekh kh"
   by (simp add: valid_sched_def)
@@ -4302,7 +4302,7 @@ lemma ex_tupI:
   "P (fst x) (snd x) \<Longrightarrow> \<exists>a b. P a b"
   by blast
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 (* mostly stuff about PPtr/fromPPtr, which seems pretty soft *)
 
 lemma resetUntypedCap_corres:
@@ -4515,7 +4515,7 @@ lemma ex_cte_cap_wp_to_irq_state_independent_H[simp]:
   "irq_state_independent_H (ex_cte_cap_wp_to' P slot)"
   by (simp add: ex_cte_cap_wp_to'_def)
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma updateFreeIndex_ctes_of:
   "\<lbrace>\<lambda>s.  P (modify_map (ctes_of s) ptr (cteCap_update (capFreeIndex_update (\<lambda>_. idx))))\<rbrace>
@@ -4737,7 +4737,7 @@ lemma (in range_cover) funky_aligned:
   apply simp
   done
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 defs archOverlap_def:
   "archOverlap \<equiv> \<lambda>_ _. False"

--- a/proof/refine/X64/VSpace_R.thy
+++ b/proof/refine/X64/VSpace_R.thy
@@ -11,11 +11,11 @@
 theory VSpace_R
 imports TcbAcc_R
 begin
-context Arch begin global_naming X64 (*FIXME: arch_split*)
+context Arch begin global_naming X64 (*FIXME: arch-split*)
 
 end
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 definition
   "vspace_at_asid' vs asid \<equiv> \<lambda>s. \<exists>ap pool.

--- a/spec/cspec/AARCH64/Kernel_C.thy
+++ b/spec/cspec/AARCH64/Kernel_C.thy
@@ -25,7 +25,7 @@ end
 
 declare [[populate_globals=true]]
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 (* Sanity checks for array sizes. ptTranslationBits not yet available at definition site. *)
 lemma ptTranslationBits_vs_index_bits:

--- a/spec/cspec/ARM/Kernel_C.thy
+++ b/spec/cspec/ARM/Kernel_C.thy
@@ -23,7 +23,7 @@ end
 
 declare [[populate_globals=true]]
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 type_synonym cghost_state = "(machine_word \<rightharpoonup> vmpage_size) * (machine_word \<rightharpoonup> nat)
     * ghost_assertions"

--- a/spec/cspec/ARM_HYP/Kernel_C.thy
+++ b/spec/cspec/ARM_HYP/Kernel_C.thy
@@ -23,7 +23,7 @@ end
 
 declare [[populate_globals=true]]
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 type_synonym cghost_state = "(machine_word \<rightharpoonup> vmpage_size) * (machine_word \<rightharpoonup> nat)
     * ghost_assertions"

--- a/spec/cspec/RISCV64/Kernel_C.thy
+++ b/spec/cspec/RISCV64/Kernel_C.thy
@@ -23,7 +23,7 @@ end
 
 declare [[populate_globals=true]]
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 type_synonym cghost_state = "(machine_word \<rightharpoonup> vmpage_size) * (machine_word \<rightharpoonup> nat)
     * ghost_assertions"

--- a/spec/cspec/X64/Kernel_C.thy
+++ b/spec/cspec/X64/Kernel_C.thy
@@ -23,7 +23,7 @@ end
 
 declare [[populate_globals=true]]
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 type_synonym cghost_state = "(machine_word \<rightharpoonup> vmpage_size) * (machine_word \<rightharpoonup> nat)
     * ghost_assertions"

--- a/sys-init/InitVSpace_SI.thy
+++ b/sys-init/InitVSpace_SI.thy
@@ -21,7 +21,7 @@ imports
   Lib.Guess_ExI
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 declare
   object_at_predicate_lift[simp]

--- a/sys-init/WellFormed_SI.thy
+++ b/sys-init/WellFormed_SI.thy
@@ -23,7 +23,7 @@ imports
   "AInvs.Rights_AI"
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma cap_has_object_NullCap [simp]:
   "\<not>cap_has_object NullCap"

--- a/sys-init/examples/ExampleSpecIRQ_SI.thy
+++ b/sys-init/examples/ExampleSpecIRQ_SI.thy
@@ -16,7 +16,7 @@ theory ExampleSpecIRQ_SI
 imports SysInit.WellFormed_SI
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 (****************************************************
  * Definitions of all the objects and capabilities. *

--- a/sys-init/examples/ExampleSpec_SI.thy
+++ b/sys-init/examples/ExampleSpec_SI.thy
@@ -16,7 +16,7 @@ theory ExampleSpec_SI
 imports SysInit.WellFormed_SI
 begin
 
-context begin interpretation Arch . (*FIXME: arch_split*)
+context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma object_slots_empty_object [simp]:
   "object_slots (Frame \<lparr>cdl_frame_size_bits = small_frame_size\<rparr>) slot = Some cap \<Longrightarrow> cap = NullCap"


### PR DESCRIPTION
There's a noisy commit for the global rename, which isn't interesting beyond the commit message.
The main thing I'd like a review of is the updates to `docs/arch-split.md` (separate commit) to see whether things make sense. The changes are based off of the test deployment work I did for AARCH64 AInvs.