### PR TITLE
Arch-split overhaul for design spec

### DIFF
--- a/proof/crefine/AARCH64/Invoke_C.thy
+++ b/proof/crefine/AARCH64/Invoke_C.thy
@@ -2812,10 +2812,10 @@ lemma ctes_of_ex_cte_cap_to':
 
 
 lemma Arch_isFrameType_spec:
-  "\<forall>s. \<Gamma> \<turnstile> \<lbrace>s. unat \<acute>type \<le> fromEnum (maxBound::ArchTypes_H.object_type)\<rbrace>
+  "\<forall>s. \<Gamma> \<turnstile> \<lbrace>s. unat \<acute>type \<le> fromEnum (maxBound::object_type)\<rbrace>
              Call Arch_isFrameType_'proc
   \<lbrace> \<acute>ret__unsigned_long =
-     from_bool (isFrameType ((toEnum (unat \<^bsup>s\<^esup> type))::ArchTypes_H.object_type))\<rbrace>"
+     from_bool (isFrameType ((toEnum (unat \<^bsup>s\<^esup> type))::object_type))\<rbrace>"
   apply vcg
   apply (simp add: toEnum_object_type_to_H)
   apply (frule object_type_from_to_H)

--- a/proof/crefine/AARCH64/Retype_C.thy
+++ b/proof/crefine/AARCH64/Retype_C.thy
@@ -5047,7 +5047,7 @@ lemma placeNewObject_user_data:
   done
 
 definition
-  createObject_hs_preconds :: "machine_word \<Rightarrow> ArchTypes_H.object_type \<Rightarrow> nat \<Rightarrow> bool \<Rightarrow> kernel_state \<Rightarrow> bool"
+  createObject_hs_preconds :: "machine_word \<Rightarrow> object_type \<Rightarrow> nat \<Rightarrow> bool \<Rightarrow> kernel_state \<Rightarrow> bool"
 where
   "createObject_hs_preconds regionBase newType userSize d \<equiv>
      (invs' and pspace_no_overlap' regionBase (getObjectSize newType userSize)
@@ -5070,14 +5070,14 @@ abbreviation
 
 (* these preconds actually used throughout the proof *)
 abbreviation(input)
-  createObject_c_preconds1 :: "machine_word \<Rightarrow> ArchTypes_H.object_type \<Rightarrow> nat \<Rightarrow> bool \<Rightarrow> (globals myvars) set"
+  createObject_c_preconds1 :: "machine_word \<Rightarrow> object_type \<Rightarrow> nat \<Rightarrow> bool \<Rightarrow> (globals myvars) set"
 where
   "createObject_c_preconds1 regionBase newType userSize deviceMemory \<equiv>
     {s. region_actually_is_dev_bytes regionBase (2 ^ getObjectSize newType userSize) deviceMemory s}"
 
 (* these preconds used at start of proof *)
 definition
-  createObject_c_preconds :: "machine_word \<Rightarrow> ArchTypes_H.object_type \<Rightarrow> nat \<Rightarrow> bool \<Rightarrow> (globals myvars) set"
+  createObject_c_preconds :: "machine_word \<Rightarrow> object_type \<Rightarrow> nat \<Rightarrow> bool \<Rightarrow> (globals myvars) set"
 where
   "createObject_c_preconds regionBase newType userSize deviceMemory \<equiv>
   (createObject_c_preconds1 regionBase newType userSize deviceMemory

--- a/proof/crefine/ARM/Invoke_C.thy
+++ b/proof/crefine/ARM/Invoke_C.thy
@@ -2623,10 +2623,10 @@ lemma ctes_of_ex_cte_cap_to':
 
 
 lemma Arch_isFrameType_spec:
-  "\<forall>s. \<Gamma> \<turnstile> \<lbrace>s. unat \<acute>type \<le> fromEnum (maxBound::ArchTypes_H.object_type)\<rbrace>
+  "\<forall>s. \<Gamma> \<turnstile> \<lbrace>s. unat \<acute>type \<le> fromEnum (maxBound::object_type)\<rbrace>
              Call Arch_isFrameType_'proc
   \<lbrace> \<acute>ret__unsigned_long =
-     from_bool (isFrameType ((toEnum (unat \<^bsup>s\<^esup> type))::ArchTypes_H.object_type))\<rbrace>"
+     from_bool (isFrameType ((toEnum (unat \<^bsup>s\<^esup> type))::object_type))\<rbrace>"
   apply vcg
   apply (simp add: toEnum_object_type_to_H)
   apply (frule object_type_from_to_H)

--- a/proof/crefine/ARM/Retype_C.thy
+++ b/proof/crefine/ARM/Retype_C.thy
@@ -4350,7 +4350,7 @@ lemma placeNewObject_user_data:
 
 
 definition
-  createObject_hs_preconds :: "word32 \<Rightarrow> ArchTypes_H.object_type \<Rightarrow> nat \<Rightarrow> bool \<Rightarrow> kernel_state \<Rightarrow> bool"
+  createObject_hs_preconds :: "word32 \<Rightarrow> object_type \<Rightarrow> nat \<Rightarrow> bool \<Rightarrow> kernel_state \<Rightarrow> bool"
 where
   "createObject_hs_preconds regionBase newType userSize d \<equiv>
      (invs' and pspace_no_overlap' regionBase (getObjectSize newType userSize)
@@ -4373,14 +4373,14 @@ abbreviation
 
 (* these preconds actually used throughout the proof *)
 abbreviation(input)
-  createObject_c_preconds1 :: "word32 \<Rightarrow> ArchTypes_H.object_type \<Rightarrow> nat \<Rightarrow> bool \<Rightarrow> (globals myvars) set"
+  createObject_c_preconds1 :: "word32 \<Rightarrow> object_type \<Rightarrow> nat \<Rightarrow> bool \<Rightarrow> (globals myvars) set"
 where
   "createObject_c_preconds1 regionBase newType userSize deviceMemory \<equiv>
     {s. region_actually_is_dev_bytes regionBase (2 ^ getObjectSize newType userSize) deviceMemory s}"
 
 (* these preconds used at start of proof *)
 definition
-  createObject_c_preconds :: "word32 \<Rightarrow> ArchTypes_H.object_type \<Rightarrow> nat \<Rightarrow> bool \<Rightarrow> (globals myvars) set"
+  createObject_c_preconds :: "word32 \<Rightarrow> object_type \<Rightarrow> nat \<Rightarrow> bool \<Rightarrow> (globals myvars) set"
 where
   "createObject_c_preconds regionBase newType userSize deviceMemory \<equiv>
   (createObject_c_preconds1 regionBase newType userSize deviceMemory

--- a/proof/crefine/ARM_HYP/Invoke_C.thy
+++ b/proof/crefine/ARM_HYP/Invoke_C.thy
@@ -2828,10 +2828,10 @@ lemma ctes_of_ex_cte_cap_to':
 
 
 lemma Arch_isFrameType_spec:
-  "\<forall>s. \<Gamma> \<turnstile> \<lbrace>s. unat \<acute>type \<le> fromEnum (maxBound::ArchTypes_H.object_type)\<rbrace>
+  "\<forall>s. \<Gamma> \<turnstile> \<lbrace>s. unat \<acute>type \<le> fromEnum (maxBound::object_type)\<rbrace>
              Call Arch_isFrameType_'proc
   \<lbrace> \<acute>ret__unsigned_long =
-     from_bool (isFrameType ((toEnum (unat \<^bsup>s\<^esup> type))::ArchTypes_H.object_type))\<rbrace>"
+     from_bool (isFrameType ((toEnum (unat \<^bsup>s\<^esup> type))::object_type))\<rbrace>"
   apply vcg
   apply (simp add: toEnum_object_type_to_H)
   apply (frule object_type_from_to_H)

--- a/proof/crefine/ARM_HYP/Retype_C.thy
+++ b/proof/crefine/ARM_HYP/Retype_C.thy
@@ -4919,7 +4919,7 @@ lemma placeNewObject_user_data:
 
 
 definition
-  createObject_hs_preconds :: "word32 \<Rightarrow> ArchTypes_H.object_type \<Rightarrow> nat \<Rightarrow> bool \<Rightarrow> kernel_state \<Rightarrow> bool"
+  createObject_hs_preconds :: "word32 \<Rightarrow> object_type \<Rightarrow> nat \<Rightarrow> bool \<Rightarrow> kernel_state \<Rightarrow> bool"
 where
   "createObject_hs_preconds regionBase newType userSize d \<equiv>
      (invs' and pspace_no_overlap' regionBase (getObjectSize newType userSize)
@@ -4942,14 +4942,14 @@ abbreviation
 
 (* these preconds actually used throughout the proof *)
 abbreviation(input)
-  createObject_c_preconds1 :: "word32 \<Rightarrow> ArchTypes_H.object_type \<Rightarrow> nat \<Rightarrow> bool \<Rightarrow> (globals myvars) set"
+  createObject_c_preconds1 :: "word32 \<Rightarrow> object_type \<Rightarrow> nat \<Rightarrow> bool \<Rightarrow> (globals myvars) set"
 where
   "createObject_c_preconds1 regionBase newType userSize deviceMemory \<equiv>
     {s. region_actually_is_dev_bytes regionBase (2 ^ getObjectSize newType userSize) deviceMemory s}"
 
 (* these preconds used at start of proof *)
 definition
-  createObject_c_preconds :: "word32 \<Rightarrow> ArchTypes_H.object_type \<Rightarrow> nat \<Rightarrow> bool \<Rightarrow> (globals myvars) set"
+  createObject_c_preconds :: "word32 \<Rightarrow> object_type \<Rightarrow> nat \<Rightarrow> bool \<Rightarrow> (globals myvars) set"
 where
   "createObject_c_preconds regionBase newType userSize deviceMemory \<equiv>
   (createObject_c_preconds1 regionBase newType userSize deviceMemory

--- a/proof/crefine/RISCV64/Invoke_C.thy
+++ b/proof/crefine/RISCV64/Invoke_C.thy
@@ -2774,10 +2774,10 @@ lemma ctes_of_ex_cte_cap_to':
 
 
 lemma Arch_isFrameType_spec:
-  "\<forall>s. \<Gamma> \<turnstile> \<lbrace>s. unat \<acute>type \<le> fromEnum (maxBound::ArchTypes_H.object_type)\<rbrace>
+  "\<forall>s. \<Gamma> \<turnstile> \<lbrace>s. unat \<acute>type \<le> fromEnum (maxBound::object_type)\<rbrace>
              Call Arch_isFrameType_'proc
   \<lbrace> \<acute>ret__unsigned_long =
-     from_bool (isFrameType ((toEnum (unat \<^bsup>s\<^esup> type))::ArchTypes_H.object_type))\<rbrace>"
+     from_bool (isFrameType ((toEnum (unat \<^bsup>s\<^esup> type))::object_type))\<rbrace>"
   apply vcg
   apply (simp add: toEnum_object_type_to_H)
   apply (frule object_type_from_to_H)

--- a/proof/crefine/RISCV64/Retype_C.thy
+++ b/proof/crefine/RISCV64/Retype_C.thy
@@ -4796,7 +4796,7 @@ lemma placeNewObject_user_data:
   done
 
 definition
-  createObject_hs_preconds :: "machine_word \<Rightarrow> ArchTypes_H.object_type \<Rightarrow> nat \<Rightarrow> bool \<Rightarrow> kernel_state \<Rightarrow> bool"
+  createObject_hs_preconds :: "machine_word \<Rightarrow> object_type \<Rightarrow> nat \<Rightarrow> bool \<Rightarrow> kernel_state \<Rightarrow> bool"
 where
   "createObject_hs_preconds regionBase newType userSize d \<equiv>
      (invs' and pspace_no_overlap' regionBase (getObjectSize newType userSize)
@@ -4819,14 +4819,14 @@ abbreviation
 
 (* these preconds actually used throughout the proof *)
 abbreviation(input)
-  createObject_c_preconds1 :: "machine_word \<Rightarrow> ArchTypes_H.object_type \<Rightarrow> nat \<Rightarrow> bool \<Rightarrow> (globals myvars) set"
+  createObject_c_preconds1 :: "machine_word \<Rightarrow> object_type \<Rightarrow> nat \<Rightarrow> bool \<Rightarrow> (globals myvars) set"
 where
   "createObject_c_preconds1 regionBase newType userSize deviceMemory \<equiv>
     {s. region_actually_is_dev_bytes regionBase (2 ^ getObjectSize newType userSize) deviceMemory s}"
 
 (* these preconds used at start of proof *)
 definition
-  createObject_c_preconds :: "machine_word \<Rightarrow> ArchTypes_H.object_type \<Rightarrow> nat \<Rightarrow> bool \<Rightarrow> (globals myvars) set"
+  createObject_c_preconds :: "machine_word \<Rightarrow> object_type \<Rightarrow> nat \<Rightarrow> bool \<Rightarrow> (globals myvars) set"
 where
   "createObject_c_preconds regionBase newType userSize deviceMemory \<equiv>
   (createObject_c_preconds1 regionBase newType userSize deviceMemory

--- a/proof/crefine/X64/Invoke_C.thy
+++ b/proof/crefine/X64/Invoke_C.thy
@@ -2800,10 +2800,10 @@ lemma ctes_of_ex_cte_cap_to':
 
 
 lemma Arch_isFrameType_spec:
-  "\<forall>s. \<Gamma> \<turnstile> \<lbrace>s. unat \<acute>type \<le> fromEnum (maxBound::ArchTypes_H.object_type)\<rbrace>
+  "\<forall>s. \<Gamma> \<turnstile> \<lbrace>s. unat \<acute>type \<le> fromEnum (maxBound::object_type)\<rbrace>
              Call Arch_isFrameType_'proc
   \<lbrace> \<acute>ret__unsigned_long =
-     from_bool (isFrameType ((toEnum (unat \<^bsup>s\<^esup> type))::ArchTypes_H.object_type))\<rbrace>"
+     from_bool (isFrameType ((toEnum (unat \<^bsup>s\<^esup> type))::object_type))\<rbrace>"
   apply vcg
   apply (simp add: toEnum_object_type_to_H)
   apply (frule object_type_from_to_H)

--- a/proof/crefine/X64/Retype_C.thy
+++ b/proof/crefine/X64/Retype_C.thy
@@ -5628,7 +5628,7 @@ lemma placeNewObject_user_data:
   done
 
 definition
-  createObject_hs_preconds :: "machine_word \<Rightarrow> ArchTypes_H.object_type \<Rightarrow> nat \<Rightarrow> bool \<Rightarrow> kernel_state \<Rightarrow> bool"
+  createObject_hs_preconds :: "machine_word \<Rightarrow> object_type \<Rightarrow> nat \<Rightarrow> bool \<Rightarrow> kernel_state \<Rightarrow> bool"
 where
   "createObject_hs_preconds regionBase newType userSize d \<equiv>
      (invs' and pspace_no_overlap' regionBase (getObjectSize newType userSize)
@@ -5651,14 +5651,14 @@ abbreviation
 
 (* these preconds actually used throughout the proof *)
 abbreviation(input)
-  createObject_c_preconds1 :: "machine_word \<Rightarrow> ArchTypes_H.object_type \<Rightarrow> nat \<Rightarrow> bool \<Rightarrow> (globals myvars) set"
+  createObject_c_preconds1 :: "machine_word \<Rightarrow> object_type \<Rightarrow> nat \<Rightarrow> bool \<Rightarrow> (globals myvars) set"
 where
   "createObject_c_preconds1 regionBase newType userSize deviceMemory \<equiv>
     {s. region_actually_is_dev_bytes regionBase (2 ^ getObjectSize newType userSize) deviceMemory s}"
 
 (* these preconds used at start of proof *)
 definition
-  createObject_c_preconds :: "machine_word \<Rightarrow> ArchTypes_H.object_type \<Rightarrow> nat \<Rightarrow> bool \<Rightarrow> (globals myvars) set"
+  createObject_c_preconds :: "machine_word \<Rightarrow> object_type \<Rightarrow> nat \<Rightarrow> bool \<Rightarrow> (globals myvars) set"
 where
   "createObject_c_preconds regionBase newType userSize deviceMemory \<equiv>
   (createObject_c_preconds1 regionBase newType userSize deviceMemory

--- a/proof/refine/AARCH64/Syscall_R.thy
+++ b/proof/refine/AARCH64/Syscall_R.thy
@@ -535,7 +535,7 @@ crunch InterruptDecls_H.invokeIRQHandler
   for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
 
 lemmas invokeIRQHandler_typ_ats[wp] =
-  typ_at_lifts [OF InterruptDecls_H_invokeIRQHandler_typ_at']
+  typ_at_lifts [OF invokeIRQHandler_typ_at']
 
 crunch setDomain
   for tcb_at'[wp]: "tcb_at' tptr"

--- a/proof/refine/ARM/Syscall_R.thy
+++ b/proof/refine/ARM/Syscall_R.thy
@@ -526,7 +526,7 @@ crunch InterruptDecls_H.invokeIRQHandler
   for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
 
 lemmas invokeIRQHandler_typ_ats[wp] =
-  typ_at_lifts [OF InterruptDecls_H_invokeIRQHandler_typ_at']
+  typ_at_lifts [OF invokeIRQHandler_typ_at']
 
 crunch setDomain
   for tcb_at'[wp]: "tcb_at' tptr"

--- a/proof/refine/ARM/orphanage/Orphanage.thy
+++ b/proof/refine/ARM/orphanage/Orphanage.thy
@@ -1797,11 +1797,11 @@ lemma invokeIRQControl_no_orphans [wp]:
   apply (wp | clarsimp)+
   done
 
-lemma invokeIRQHandler_no_orphans [wp]:
+lemma arch_invokeIRQHandler_no_orphans[wp]:
   "\<lbrace> \<lambda>s. no_orphans s \<and> invs' s \<rbrace>
-   invokeIRQHandler i
+   ARM_H.invokeIRQHandler i
    \<lbrace> \<lambda>reply s. no_orphans s \<rbrace>"
-  apply (cases i, simp_all add: invokeIRQHandler_def)
+  apply (cases i, simp_all add: ARM_H.invokeIRQHandler_def)
     apply (wp | clarsimp | fastforce)+
   done
 
@@ -1939,7 +1939,7 @@ lemma setDomain_no_orphans [wp]:
   apply (fastforce simp: tcb_at_typ_at'  is_active_tcb_ptr_runnable')
   done
 
-crunch InterruptDecls_H.invokeIRQHandler
+crunch invokeIRQHandler
   for no_orphans[wp]: no_orphans
 
 lemma performInvocation_no_orphans [wp]:

--- a/proof/refine/ARM_HYP/Syscall_R.thy
+++ b/proof/refine/ARM_HYP/Syscall_R.thy
@@ -536,7 +536,7 @@ crunch InterruptDecls_H.invokeIRQHandler
   for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
 
 lemmas invokeIRQHandler_typ_ats[wp] =
-  typ_at_lifts [OF InterruptDecls_H_invokeIRQHandler_typ_at']
+  typ_at_lifts [OF invokeIRQHandler_typ_at']
 
 crunch setDomain
   for tcb_at'[wp]: "tcb_at' tptr"

--- a/proof/refine/RISCV64/Syscall_R.thy
+++ b/proof/refine/RISCV64/Syscall_R.thy
@@ -534,7 +534,7 @@ crunch InterruptDecls_H.invokeIRQHandler
   for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
 
 lemmas invokeIRQHandler_typ_ats[wp] =
-  typ_at_lifts [OF InterruptDecls_H_invokeIRQHandler_typ_at']
+  typ_at_lifts [OF invokeIRQHandler_typ_at']
 
 crunch setDomain
   for tcb_at'[wp]: "tcb_at' tptr"

--- a/proof/refine/X64/Syscall_R.thy
+++ b/proof/refine/X64/Syscall_R.thy
@@ -535,7 +535,7 @@ crunch InterruptDecls_H.invokeIRQHandler
   for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
 
 lemmas invokeIRQHandler_typ_ats[wp] =
-  typ_at_lifts [OF InterruptDecls_H_invokeIRQHandler_typ_at']
+  typ_at_lifts [OF invokeIRQHandler_typ_at']
 
 crunch setDomain
   for tcb_at'[wp]: "tcb_at' tptr"

--- a/spec/design/m-skel/AARCH64/MachineTypes.thy
+++ b/spec/design/m-skel/AARCH64/MachineTypes.thy
@@ -14,7 +14,7 @@ imports
   Platform
 begin
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 #INCLUDE_SETTINGS keep_constructor=hyp_fault_type
 #INCLUDE_SETTINGS keep_constructor=virt_timer
@@ -33,11 +33,9 @@ section "Types"
 
 end
 
-context begin interpretation Arch .
-requalify_types register vcpureg vppievent_irq virt_timer
-end
+arch_requalify_types register vcpureg vppievent_irq virt_timer
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 #INCLUDE_HASKELL SEL4/Machine/RegisterSet/AARCH64.hs CONTEXT AARCH64 instanceproofs
 #INCLUDE_HASKELL SEL4/Object/Structures/AARCH64.hs CONTEXT AARCH64 instanceproofs ONLY VPPIEventIRQ VirtTimer
@@ -73,7 +71,7 @@ where
 
 end_qualify
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 text \<open>
   The machine monad is used for operations on the state defined above.
@@ -85,7 +83,7 @@ end
 translations
   (type) "'c AARCH64.machine_monad" <= (type) "(AARCH64.machine_state, 'c) nondet_monad"
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 text \<open>
   After kernel initialisation all IRQs are masked.
@@ -122,11 +120,9 @@ definition
 
 end
 
-context begin interpretation Arch .
-requalify_types vmpage_size
-end
+arch_requalify_types vmpage_size
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 #INCLUDE_HASKELL SEL4/Machine/Hardware/AARCH64.hs CONTEXT AARCH64 instanceproofs ONLY VMFaultType HypFaultType VMPageSize
 

--- a/spec/design/m-skel/ARM/MachineTypes.thy
+++ b/spec/design/m-skel/ARM/MachineTypes.thy
@@ -15,7 +15,7 @@ imports
   Platform
 begin
 
-context Arch begin global_naming ARM
+context Arch begin arch_global_naming
 
 text \<open>
   An implementation of the machine's types, defining register set
@@ -29,11 +29,9 @@ section "Types"
 
 end
 
-context begin interpretation Arch .
-requalify_types register
-end
+arch_requalify_types register
 
-context Arch begin global_naming ARM
+context Arch begin arch_global_naming
 
 #INCLUDE_HASKELL SEL4/Machine/RegisterSet/ARM.lhs CONTEXT ARM instanceproofs
 (*>*)
@@ -83,7 +81,7 @@ where
 
 end_qualify
 
-context Arch begin global_naming ARM
+context Arch begin arch_global_naming
 
 text \<open>
   The machine monad is used for operations on the state defined above.
@@ -95,7 +93,7 @@ end
 translations
   (type) "'c ARM.machine_monad" <= (type) "(ARM.machine_state, 'c) nondet_monad"
 
-context Arch begin global_naming ARM
+context Arch begin arch_global_naming
 
 text \<open>
   After kernel initialisation all IRQs are masked.
@@ -137,11 +135,9 @@ definition
 
 end
 
-context begin interpretation Arch .
-requalify_types vmpage_size
-end
+arch_requalify_types vmpage_size
 
-context Arch begin global_naming ARM
+context Arch begin arch_global_naming
 
 #INCLUDE_HASKELL SEL4/Machine/Hardware/ARM.lhs CONTEXT ARM instanceproofs ONLY HardwareASID VMFaultType VMPageSize HypFaultType
 

--- a/spec/design/m-skel/ARM_HYP/MachineTypes.thy
+++ b/spec/design/m-skel/ARM_HYP/MachineTypes.thy
@@ -14,7 +14,7 @@ imports
   Setup_Locale
   Platform
 begin
-context Arch begin global_naming ARM_HYP
+context Arch begin arch_global_naming
 
 #INCLUDE_SETTINGS keep_constructor=hyp_fault_type
 #INCLUDE_SETTINGS keep_constructor=virt_timer
@@ -33,12 +33,9 @@ section "Types"
 
 end
 
-context begin interpretation Arch .
-requalify_types register vcpureg vppievent_irq virt_timer
+arch_requalify_types register vcpureg vppievent_irq virt_timer
 
-end
-
-context Arch begin global_naming ARM_HYP
+context Arch begin arch_global_naming
 
 #INCLUDE_HASKELL SEL4/Machine/RegisterSet/ARM.lhs CONTEXT ARM_HYP instanceproofs
 #INCLUDE_HASKELL SEL4/Object/Structures/ARM.lhs CONTEXT ARM_HYP instanceproofs ONLY VPPIEventIRQ VirtTimer
@@ -89,7 +86,7 @@ where
 
 end_qualify
 
-context Arch begin global_naming ARM_HYP
+context Arch begin arch_global_naming
 
 text \<open>
   The machine monad is used for operations on the state defined above.
@@ -101,7 +98,7 @@ end
 translations
   (type) "'c ARM_HYP.machine_monad" <= (type) "(ARM_HYP.machine_state, 'c) nondet_monad"
 
-context Arch begin global_naming ARM_HYP
+context Arch begin arch_global_naming
 
 text \<open>
   After kernel initialisation all IRQs are masked.
@@ -143,11 +140,9 @@ definition
 
 end
 
-context begin interpretation Arch .
-requalify_types vmpage_size
-end
+arch_requalify_types vmpage_size
 
-context Arch begin global_naming ARM_HYP
+context Arch begin arch_global_naming
 
 #INCLUDE_HASKELL SEL4/Machine/Hardware/ARM.lhs CONTEXT ARM_HYP instanceproofs ONLY HardwareASID VMFaultType HypFaultType VMPageSize
 

--- a/spec/design/m-skel/RISCV64/MachineTypes.thy
+++ b/spec/design/m-skel/RISCV64/MachineTypes.thy
@@ -15,7 +15,7 @@ imports
   Platform
 begin
 
-context Arch begin global_naming RISCV64
+context Arch begin arch_global_naming
 
 text \<open>
   An implementation of the machine's types, defining register set
@@ -29,11 +29,9 @@ section "Types"
 
 end
 
-context begin interpretation Arch .
-requalify_types register
-end
+arch_requalify_types register
 
-context Arch begin global_naming RISCV64
+context Arch begin arch_global_naming
 
 #INCLUDE_HASKELL SEL4/Machine/RegisterSet/RISCV64.hs CONTEXT RISCV64 instanceproofs
 (*>*)
@@ -68,7 +66,7 @@ where
 
 end_qualify
 
-context Arch begin global_naming RISCV64
+context Arch begin arch_global_naming
 
 text \<open>
   The machine monad is used for operations on the state defined above.
@@ -80,7 +78,7 @@ end
 translations
   (type) "'c RISCV64.machine_monad" <= (type) "(RISCV64.machine_state, 'c) nondet_monad"
 
-context Arch begin global_naming RISCV64
+context Arch begin arch_global_naming
 
 text \<open>
   After kernel initialisation all IRQs are masked.
@@ -112,11 +110,9 @@ definition
 
 end
 
-context begin interpretation Arch .
-requalify_types vmpage_size
-end
+arch_requalify_types vmpage_size
 
-context Arch begin global_naming RISCV64
+context Arch begin arch_global_naming
 
 #INCLUDE_HASKELL SEL4/Machine/Hardware/RISCV64.hs CONTEXT RISCV64 instanceproofs ONLY VMFaultType HypFaultType VMPageSize
 

--- a/spec/design/m-skel/X64/MachineTypes.thy
+++ b/spec/design/m-skel/X64/MachineTypes.thy
@@ -15,7 +15,7 @@ imports
   Platform
 begin
 
-context Arch begin global_naming X64
+context Arch begin arch_global_naming
 
 text \<open>
   An implementation of the machine's types, defining register set
@@ -29,11 +29,9 @@ section "Types"
 
 end
 
-context begin interpretation Arch .
-requalify_types register gdtslot
-end
+arch_requalify_types register gdtslot
 
-context Arch begin global_naming X64
+context Arch begin arch_global_naming
 
 #INCLUDE_HASKELL SEL4/Machine/RegisterSet/X64.lhs CONTEXT X64 instanceproofs
 (*>*)
@@ -65,7 +63,7 @@ consts irq_oracle :: "nat \<Rightarrow> word8"
 
 end_qualify
 
-context Arch begin global_naming X64
+context Arch begin arch_global_naming
 
 text \<open>
   The machine monad is used for operations on the state defined above.
@@ -77,7 +75,7 @@ end
 translations
   (type) "'c X64.machine_monad" <= (type) "(X64.machine_state, 'c) nondet_monad"
 
-context Arch begin global_naming X64
+context Arch begin arch_global_naming
 
 text \<open>
   After kernel initialisation all IRQs are masked.
@@ -109,11 +107,9 @@ definition
 
 end
 
-context begin interpretation Arch .
-requalify_types vmpage_size vmmap_type
-end
+arch_requalify_types vmpage_size vmmap_type
 
-context Arch begin global_naming X64
+context Arch begin arch_global_naming
 
 #INCLUDE_HASKELL SEL4/Machine/Hardware/X64.lhs CONTEXT X64 instanceproofs ONLY VMFaultType HypFaultType VMPageSize VMMapType
 

--- a/spec/design/skel/AARCH64/ArchFaultHandler_H.thy
+++ b/spec/design/skel/AARCH64/ArchFaultHandler_H.thy
@@ -10,7 +10,7 @@ theory ArchFaultHandler_H
 imports TCB_H Structures_H
 begin
 
-context Arch begin global_naming AARCH64_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL_PREPARSE SEL4/API/Failures/AARCH64.hs
 

--- a/spec/design/skel/AARCH64/ArchFault_H.thy
+++ b/spec/design/skel/AARCH64/ArchFault_H.thy
@@ -12,7 +12,7 @@ theory ArchFault_H
 imports Types_H
 begin
 
-context Arch begin global_naming AARCH64_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/API/Failures/AARCH64.hs CONTEXT AARCH64_H decls_only
 #INCLUDE_HASKELL SEL4/API/Failures/AARCH64.hs CONTEXT AARCH64_H bodies_only

--- a/spec/design/skel/AARCH64/ArchHypervisor_H.thy
+++ b/spec/design/skel/AARCH64/ArchHypervisor_H.thy
@@ -15,7 +15,7 @@ imports
   FaultHandlerDecls_H
   InterruptDecls_H
 begin
-context Arch begin global_naming AARCH64_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Object/VCPU/AARCH64.hs CONTEXT AARCH64_H decls_only \
   ONLY countTrailingZeros irqVPPIEventIndex

--- a/spec/design/skel/AARCH64/ArchInterruptDecls_H.thy
+++ b/spec/design/skel/AARCH64/ArchInterruptDecls_H.thy
@@ -8,7 +8,7 @@ theory ArchInterruptDecls_H
 imports RetypeDecls_H CNode_H
 begin
 
-context Arch begin global_naming AARCH64_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Object/Interrupt/AARCH64.hs CONTEXT AARCH64_H decls_only ArchInv= Arch=MachineOps NOT plic_complete_claim
 

--- a/spec/design/skel/AARCH64/ArchInterrupt_H.thy
+++ b/spec/design/skel/AARCH64/ArchInterrupt_H.thy
@@ -13,7 +13,7 @@ imports
   ArchHypervisor_H
 begin
 
-context Arch begin global_naming AARCH64_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Object/Interrupt/AARCH64.hs CONTEXT AARCH64_H bodies_only ArchInv= Arch= NOT plic_complete_claim
 

--- a/spec/design/skel/AARCH64/ArchInvocationLabels_H.thy
+++ b/spec/design/skel/AARCH64/ArchInvocationLabels_H.thy
@@ -11,7 +11,7 @@ imports
   "Word_Lib.Enumeration"
   Setup_Locale
 begin
-context Arch begin global_naming AARCH64_H
+context Arch begin arch_global_naming (H)
 
 text \<open>
   An enumeration of arch-specific system call labels.
@@ -21,11 +21,12 @@ text \<open>
 
 end
 
-context begin interpretation Arch .
-requalify_types arch_invocation_label
-end
+(* not possible to move this requalification to generic, since enum instance proofs must
+   be done outside of Arch locale *)
+arch_requalify_types (H)
+  arch_invocation_label
 
-context Arch begin global_naming AARCH64_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/API/InvocationLabels/AARCH64.hs CONTEXT AARCH64_H instanceproofs ONLY ArchInvocationLabel
 

--- a/spec/design/skel/AARCH64/ArchLabelFuns_H.thy
+++ b/spec/design/skel/AARCH64/ArchLabelFuns_H.thy
@@ -10,7 +10,7 @@ chapter "Architecture-specific Invocation Label Functions"
 theory ArchLabelFuns_H
 imports InvocationLabels_H
 begin
-context Arch begin global_naming AARCH64_H
+context Arch begin arch_global_naming (H)
 
 text \<open>
   Arch-specific functions on invocation labels

--- a/spec/design/skel/AARCH64/ArchPSpace_H.thy
+++ b/spec/design/skel/AARCH64/ArchPSpace_H.thy
@@ -11,7 +11,7 @@ imports
   ObjectInstances_H
 begin
 
-context Arch begin global_naming AARCH64_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Model/PSpace/AARCH64.hs decls_only ONLY pTablePartialOverlap
 #INCLUDE_HASKELL SEL4/Model/PSpace/AARCH64.hs NOT pTablePartialOverlap

--- a/spec/design/skel/AARCH64/ArchRetypeDecls_H.thy
+++ b/spec/design/skel/AARCH64/ArchRetypeDecls_H.thy
@@ -16,7 +16,7 @@ imports
   ArchObjInsts_H
 begin
 
-context Arch begin global_naming AARCH64_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL_PREPARSE SEL4/Object/Structures/AARCH64.hs
 

--- a/spec/design/skel/AARCH64/ArchRetype_H.thy
+++ b/spec/design/skel/AARCH64/ArchRetype_H.thy
@@ -16,7 +16,7 @@ imports
   VCPU_H
 begin
 
-context Arch begin global_naming AARCH64_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Object/ObjectType/AARCH64.hs CONTEXT AARCH64_H Arch.Types=ArchTypes_H ArchInv=ArchRetypeDecls_H NOT bodies_only
 #INCLUDE_HASKELL SEL4/API/Invocation/AARCH64.hs CONTEXT AARCH64_H bodies_only \

--- a/spec/design/skel/AARCH64/ArchStateData_H.thy
+++ b/spec/design/skel/AARCH64/ArchStateData_H.thy
@@ -18,7 +18,7 @@ imports
   ArchStructures_H
 begin
 
-context Arch begin global_naming AARCH64_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Model/StateData/AARCH64.hs CONTEXT AARCH64_H NOT ArmVSpaceRegionUse
 

--- a/spec/design/skel/AARCH64/ArchStructures_H.thy
+++ b/spec/design/skel/AARCH64/ArchStructures_H.thy
@@ -12,7 +12,7 @@ imports
   Hardware_H
 begin
 
-context Arch begin global_naming AARCH64_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_SETTINGS keep_constructor=asidpool
 #INCLUDE_SETTINGS keep_constructor=arch_tcb
@@ -54,10 +54,8 @@ where
 
 end
 
-context begin interpretation Arch .
-
-requalify_types
+(* not possible to move this requalification to generic, as some arches don't have vcpu *)
+arch_requalify_types (H)
   vcpu
 
-end
 end

--- a/spec/design/skel/AARCH64/ArchTCB_H.thy
+++ b/spec/design/skel/AARCH64/ArchTCB_H.thy
@@ -8,7 +8,7 @@ theory ArchTCB_H
 imports TCBDecls_H
 begin
 
-context Arch begin global_naming AARCH64_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Object/TCB/AARCH64.hs RegisterSet= CONTEXT AARCH64_H
 

--- a/spec/design/skel/AARCH64/ArchThreadDecls_H.thy
+++ b/spec/design/skel/AARCH64/ArchThreadDecls_H.thy
@@ -17,7 +17,7 @@ imports
   KernelInitMonad_H
 begin
 
-context Arch begin global_naming AARCH64_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Kernel/Thread/AARCH64.hs CONTEXT AARCH64_H decls_only
 

--- a/spec/design/skel/AARCH64/ArchThread_H.thy
+++ b/spec/design/skel/AARCH64/ArchThread_H.thy
@@ -15,7 +15,7 @@ imports
   ArchHypervisor_H
 begin
 
-context Arch begin global_naming AARCH64_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Kernel/Thread/AARCH64.hs CONTEXT AARCH64_H Arch=MachineOps ArchReg=MachineTypes bodies_only
 

--- a/spec/design/skel/AARCH64/ArchTypes_H.thy
+++ b/spec/design/skel/AARCH64/ArchTypes_H.thy
@@ -20,7 +20,7 @@ begin
 
 #INCLUDE_HASKELL SEL4/API/Types/Universal.lhs all_bits
 
-context Arch begin global_naming AARCH64_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/API/Types/AARCH64.hs CONTEXT AARCH64_H
 
@@ -73,10 +73,6 @@ instantiation AARCH64_H.object_type :: enumeration_both
 begin
 interpretation Arch .
 instance by (intro_classes, simp add: enum_alt_object_type)
-end
-
-context begin interpretation Arch .
-requalify_types object_type
 end
 
 end

--- a/spec/design/skel/AARCH64/ArchVSpaceDecls_H.thy
+++ b/spec/design/skel/AARCH64/ArchVSpaceDecls_H.thy
@@ -11,7 +11,7 @@ theory ArchVSpaceDecls_H
 imports ArchRetypeDecls_H InvocationLabels_H
 begin
 
-context Arch begin global_naming AARCH64_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL_PREPARSE SEL4/Object/Structures.lhs CONTEXT AARCH64_H
 #INCLUDE_HASKELL_PREPARSE SEL4/API/InvocationLabels/AARCH64.hs CONTEXT AARCH64

--- a/spec/design/skel/AARCH64/ArchVSpace_H.thy
+++ b/spec/design/skel/AARCH64/ArchVSpace_H.thy
@@ -17,7 +17,7 @@ imports
   ArchHypervisor_H
 begin
 
-context Arch begin global_naming AARCH64_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Kernel/VSpace/AARCH64.hs CONTEXT AARCH64_H bodies_only ArchInv=ArchRetypeDecls_H ONLY pteAtIndex getPPtrFromHWPTE isPageTablePTE ptBitsLeft
 

--- a/spec/design/skel/AARCH64/Arch_Structs_B.thy
+++ b/spec/design/skel/AARCH64/Arch_Structs_B.thy
@@ -13,7 +13,7 @@ theory Arch_Structs_B
 imports Setup_Locale
 begin
 
-context Arch begin global_naming AARCH64_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Model/StateData/AARCH64.hs CONTEXT AARCH64_H ONLY ArmVSpaceRegionUse
 

--- a/spec/design/skel/AARCH64/Hardware_H.thy
+++ b/spec/design/skel/AARCH64/Hardware_H.thy
@@ -11,7 +11,7 @@ imports
   State_H
 begin
 
-context Arch begin global_naming AARCH64_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Machine/Hardware/AARCH64.hs Platform=Platform.AARCH64 CONTEXT AARCH64_H \
   NOT PT_Type plic_complete_claim getMemoryRegions getDeviceRegions getKernelDevices \
@@ -41,11 +41,10 @@ context Arch begin global_naming AARCH64_H
 
 end
 
-context begin interpretation Arch .
-requalify_types vmrights
-end
+arch_requalify_types (H)
+  vmrights
 
-context Arch begin global_naming AARCH64_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Machine/Hardware/AARCH64.hs CONTEXT AARCH64_H instanceproofs NOT plic_complete_claim HardwareASID VMFaultType VMPageSize VMPageEntry HypFaultType
 
@@ -53,7 +52,7 @@ context Arch begin global_naming AARCH64_H
 
 (* Kernel_Config provides a generic numeral, Haskell expects type irq *)
 abbreviation (input) maxIRQ :: irq where
-  "maxIRQ == Kernel_Config.maxIRQ"
+  "maxIRQ \<equiv> Kernel_Config.maxIRQ"
 
 end (* context AARCH64 *)
 

--- a/spec/design/skel/AARCH64/RegisterSet_H.thy
+++ b/spec/design/skel/AARCH64/RegisterSet_H.thy
@@ -12,7 +12,7 @@ imports
   "Lib.HaskellLib_H"
   MachineOps
 begin
-context Arch begin global_naming AARCH64_H
+context Arch begin arch_global_naming (H)
 
 definition newFPUState :: "fpu_state" where
   "newFPUState \<equiv> FPUState (K 0) 0 0 "

--- a/spec/design/skel/AARCH64/State_H.thy
+++ b/spec/design/skel/AARCH64/State_H.thy
@@ -14,7 +14,7 @@ theory State_H
 imports
   RegisterSet_H
 begin
-context Arch begin global_naming AARCH64_H
+context Arch begin arch_global_naming (H)
 
 definition
   Word :: "machine_word \<Rightarrow> machine_word"
@@ -26,16 +26,14 @@ where
 
 end
 
-context begin interpretation Arch .
-
-requalify_consts
+(* Note: while this requalify and arch-generic Haskell import of WordLib.lhs could be moved to
+   a generic theory, no good candidate theory exists at the moment. *)
+arch_requalify_consts (H)
   wordBits
-
-end
 
 #INCLUDE_HASKELL Data/WordLib.lhs all_bits NOT wordBits
 
-context Arch begin global_naming AARCH64_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Machine/RegisterSet.lhs Arch=AARCH64 CONTEXT AARCH64_H all_bits NOT UserContext UserMonad getRegister setRegister newContext mask Word PPtr
 

--- a/spec/design/skel/AARCH64/VCPU_H.thy
+++ b/spec/design/skel/AARCH64/VCPU_H.thy
@@ -14,7 +14,7 @@ imports
   Invocations_H
   TCB_H
 begin
-context Arch begin global_naming AARCH64_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL_PREPARSE SEL4/Object/Structures.lhs CONTEXT AARCH64_H
 #INCLUDE_HASKELL SEL4/Object/VCPU/AARCH64.hs CONTEXT AARCH64_H ArchInv=Arch \

--- a/spec/design/skel/ARM/ArchFaultHandler_H.thy
+++ b/spec/design/skel/ARM/ArchFaultHandler_H.thy
@@ -10,7 +10,7 @@ theory ArchFaultHandler_H
 imports TCB_H Structures_H
 begin
 
-context Arch begin global_naming ARM_H
+context Arch begin arch_global_naming (H)
 
 
 #INCLUDE_HASKELL_PREPARSE SEL4/API/Failures/ARM.lhs

--- a/spec/design/skel/ARM/ArchFault_H.thy
+++ b/spec/design/skel/ARM/ArchFault_H.thy
@@ -11,7 +11,7 @@
 theory ArchFault_H
 imports Types_H
 begin
-context Arch begin global_naming ARM_H
+context Arch begin arch_global_naming (H)
 
 
 #INCLUDE_HASKELL SEL4/API/Failures/ARM.lhs CONTEXT ARM_H decls_only

--- a/spec/design/skel/ARM/ArchHypervisor_H.thy
+++ b/spec/design/skel/ARM/ArchHypervisor_H.thy
@@ -14,7 +14,7 @@ imports
   KI_Decls_H
   InterruptDecls_H
 begin
-context Arch begin global_naming ARM_H
+context Arch begin arch_global_naming (H)
 
 
 #INCLUDE_HASKELL SEL4/Kernel/Hypervisor/ARM.lhs Arch= CONTEXT ARM_H decls_only ArchInv= ArchLabels=

--- a/spec/design/skel/ARM/ArchInterruptDecls_H.thy
+++ b/spec/design/skel/ARM/ArchInterruptDecls_H.thy
@@ -8,7 +8,7 @@ theory ArchInterruptDecls_H
 imports RetypeDecls_H CNode_H
 begin
 
-context Arch begin global_naming ARM_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Object/Interrupt/ARM.lhs CONTEXT ARM_H decls_only ArchInv=
 

--- a/spec/design/skel/ARM/ArchInterrupt_H.thy
+++ b/spec/design/skel/ARM/ArchInterrupt_H.thy
@@ -13,7 +13,7 @@ imports
   ArchHypervisor_H
 begin
 
-context Arch begin global_naming ARM_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Object/Interrupt/ARM.lhs Arch= CONTEXT ARM_H bodies_only ArchInv=
 

--- a/spec/design/skel/ARM/ArchInvocationLabels_H.thy
+++ b/spec/design/skel/ARM/ArchInvocationLabels_H.thy
@@ -11,7 +11,7 @@ imports
     "Word_Lib.Enumeration"
     Setup_Locale
 begin
-context Arch begin global_naming ARM_H
+context Arch begin arch_global_naming (H)
 
 text \<open>
   An enumeration of arch-specific system call labels.
@@ -21,11 +21,12 @@ text \<open>
 
 end
 
-context begin interpretation Arch .
-requalify_types arch_invocation_label
-end
+(* not possible to move this requalification to generic, since enum instance proofs must
+   be done outside of Arch locale *)
+arch_requalify_types (H)
+  arch_invocation_label
 
-context Arch begin global_naming ARM_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/API/InvocationLabels/ARM.lhs CONTEXT ARM_H instanceproofs ONLY ArchInvocationLabel
 

--- a/spec/design/skel/ARM/ArchLabelFuns_H.thy
+++ b/spec/design/skel/ARM/ArchLabelFuns_H.thy
@@ -9,7 +9,7 @@ chapter "Architecture-specific Invocation Label Functions"
 theory ArchLabelFuns_H
 imports InvocationLabels_H
 begin
-context Arch begin global_naming ARM_H
+context Arch begin arch_global_naming (H)
 text \<open>
   Arch-specific functions on invocation labels
 \<close>

--- a/spec/design/skel/ARM/ArchPSpace_H.thy
+++ b/spec/design/skel/ARM/ArchPSpace_H.thy
@@ -11,7 +11,7 @@ imports
   ObjectInstances_H
 begin
 
-context Arch begin global_naming ARM_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Model/PSpace/ARM.hs
 

--- a/spec/design/skel/ARM/ArchRetypeDecls_H.thy
+++ b/spec/design/skel/ARM/ArchRetypeDecls_H.thy
@@ -15,7 +15,7 @@ imports
   PSpaceFuns_H
   ArchObjInsts_H
 begin
-context Arch begin global_naming ARM_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/API/Invocation/ARM.lhs CONTEXT ARM_H decls_only NOT isPageFlushLabel isPDFlushLabel Invocation IRQControlInvocation CopyRegisterSets
 

--- a/spec/design/skel/ARM/ArchRetype_H.thy
+++ b/spec/design/skel/ARM/ArchRetype_H.thy
@@ -13,7 +13,7 @@ imports
   Hardware_H
   KI_Decls_H
 begin
-context Arch begin global_naming ARM_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Object/ObjectType/ARM.lhs CONTEXT ARM_H Arch.Types= ArchInv= bodies_only
 #INCLUDE_HASKELL SEL4/API/Invocation/ARM.lhs bodies_only CONTEXT ARM_H NOT isPDFlushLabel isPageFlushLabel

--- a/spec/design/skel/ARM/ArchStateData_H.thy
+++ b/spec/design/skel/ARM/ArchStateData_H.thy
@@ -16,7 +16,7 @@ imports
   ArchTypes_H
   ArchStructures_H
 begin
-context Arch begin global_naming ARM_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Model/StateData/ARM.lhs CONTEXT ARM_H NOT ArmVSpaceRegionUse
 

--- a/spec/design/skel/ARM/ArchStructures_H.thy
+++ b/spec/design/skel/ARM/ArchStructures_H.thy
@@ -10,7 +10,7 @@ imports
   Types_H
   Hardware_H
 begin
-context Arch begin global_naming ARM_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_SETTINGS keep_constructor=asidpool
 #INCLUDE_SETTINGS keep_constructor=arch_tcb

--- a/spec/design/skel/ARM/ArchTCB_H.thy
+++ b/spec/design/skel/ARM/ArchTCB_H.thy
@@ -7,7 +7,7 @@
 theory ArchTCB_H
 imports TCBDecls_H
 begin
-context Arch begin global_naming ARM_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Object/TCB/ARM.lhs RegisterSet= CONTEXT ARM_H
 

--- a/spec/design/skel/ARM/ArchThreadDecls_H.thy
+++ b/spec/design/skel/ARM/ArchThreadDecls_H.thy
@@ -17,7 +17,7 @@ imports
   KernelInitMonad_H
 begin
 
-context Arch begin global_naming ARM_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Kernel/Thread/ARM.lhs CONTEXT Arch decls_only
 

--- a/spec/design/skel/ARM/ArchThread_H.thy
+++ b/spec/design/skel/ARM/ArchThread_H.thy
@@ -12,7 +12,7 @@ imports
   TCBDecls_H
   ArchVSpaceDecls_H
 begin
-context Arch begin global_naming ARM_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Kernel/Thread/ARM.lhs CONTEXT ARM_H ARMHardware=ARM bodies_only
 

--- a/spec/design/skel/ARM/ArchTypes_H.thy
+++ b/spec/design/skel/ARM/ArchTypes_H.thy
@@ -19,7 +19,7 @@ begin
 
 #INCLUDE_HASKELL SEL4/API/Types/Universal.lhs all_bits
 
-context Arch begin global_naming ARM_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/API/Types/ARM.lhs CONTEXT ARM_H
 
@@ -72,10 +72,6 @@ instantiation ARM_H.object_type :: enumeration_both
 begin
 interpretation Arch .
 instance by (intro_classes, simp add: enum_alt_object_type)
-end
-
-context begin interpretation Arch .
-requalify_types object_type
 end
 
 end

--- a/spec/design/skel/ARM/ArchVSpaceDecls_H.thy
+++ b/spec/design/skel/ARM/ArchVSpaceDecls_H.thy
@@ -9,7 +9,7 @@ chapter "Retyping Objects"
 theory ArchVSpaceDecls_H
 imports ArchRetypeDecls_H InvocationLabels_H
 begin
-context Arch begin global_naming ARM_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL_PREPARSE SEL4/Object/Structures.lhs CONTEXT ARM_H
 #INCLUDE_HASKELL SEL4/Kernel/VSpace/ARM.lhs CONTEXT ARM_H decls_only ArchInv=

--- a/spec/design/skel/ARM/ArchVSpace_H.thy
+++ b/spec/design/skel/ARM/ArchVSpace_H.thy
@@ -16,7 +16,7 @@ imports
   ArchVSpaceDecls_H
   ArchHypervisor_H
 begin
-context Arch begin global_naming ARM_H
+context Arch begin arch_global_naming (H)
 
 
 #INCLUDE_HASKELL SEL4/Kernel/VSpace/ARM.lhs CONTEXT ARM_H bodies_only ArchInv=ArchRetypeDecls_H.ARM ArchLabels=ArchInvocationLabels_H.ARM NOT checkPDAt checkPTAt checkPDASIDMapMembership checkValidMappingSize vptrFromPPtr

--- a/spec/design/skel/ARM/Arch_Structs_B.thy
+++ b/spec/design/skel/ARM/Arch_Structs_B.thy
@@ -11,7 +11,7 @@ chapter "Common, Architecture-Specific Data Types"
 theory Arch_Structs_B
 imports Main Setup_Locale
 begin
-context Arch begin global_naming ARM_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Model/StateData/ARM.lhs CONTEXT ARM_H ONLY ArmVSpaceRegionUse
 

--- a/spec/design/skel/ARM/Hardware_H.thy
+++ b/spec/design/skel/ARM/Hardware_H.thy
@@ -9,17 +9,16 @@ imports
   MachineOps
   State_H
 begin
-context Arch begin global_naming ARM_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Machine/Hardware/ARM.lhs Platform=Platform.ARM CONTEXT ARM_H NOT getMemoryRegions getDeviceRegions getKernelDevices loadWord storeWord storeWordVM getActiveIRQ ackInterrupt maskInterrupt configureTimer resetTimer debugPrint getRestartPC setNextPC clearMemory clearMemoryVM initMemory freeMemory writeTTBR0 setGlobalPD  setTTBCR setHardwareASID invalidateLocalTLB invalidateLocalTLB_ASID invalidateLocalTLB_VAASID cleanByVA cleanByVA_PoU invalidateByVA invalidateByVA_I invalidate_I_PoU cleanInvalByVA branchFlush clean_D_PoU cleanInvalidate_D_PoC cleanInvalidate_D_PoU cleanInvalidateL2Range invalidateL2Range cleanL2Range isb dsb dmb getIFSR getDFSR getFAR HardwareASID wordFromPDE wordFromPTE VMFaultType VMPageSize HypFaultType pageBits pageBitsForSize toPAddr cacheLineBits cacheLine lineStart cacheRangeOp cleanCacheRange_PoC cleanInvalidateCacheRange_RAM cleanCacheRange_RAM cleanCacheRange_PoU invalidateCacheRange_RAM invalidateCacheRange_I branchFlushRange cleanCaches_PoU cleanInvalidateL1Caches addrFromPPtr ptrFromPAddr initIRQController setIRQTrigger MachineData paddrBase pptrBase pptrTop paddrTop kernelELFPAddrBase kernelELFBase kernelELFBaseOffset pptrBaseOffset addrFromKPPtr
 
 end
 
-context begin interpretation Arch .
-requalify_types vmrights
-end
+arch_requalify_types (H)
+  vmrights
 
-context Arch begin global_naming ARM_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Machine/Hardware/ARM.lhs CONTEXT ARM_H instanceproofs NOT HardwareASID VMFaultType VMPageSize HypFaultType
 
@@ -28,6 +27,10 @@ context Arch begin global_naming ARM_H
 (* Kernel_Config provides a generic numeral, Haskell expects type irq *)
 abbreviation (input) maxIRQ :: irq where
   "maxIRQ == Kernel_Config.maxIRQ"
+
+(* provide ARM/ARM_HYP machine op in _H global_prefix for arch-split *)
+abbreviation (input) initIRQController where
+  "initIRQController \<equiv> ARM.initIRQController"
 
 end
 end

--- a/spec/design/skel/ARM/RegisterSet_H.thy
+++ b/spec/design/skel/ARM/RegisterSet_H.thy
@@ -11,7 +11,7 @@ imports
   "Lib.HaskellLib_H"
   MachineOps
 begin
-context Arch begin global_naming ARM_H
+context Arch begin arch_global_naming (H)
 
 definition
   newContext :: "user_context"

--- a/spec/design/skel/ARM/State_H.thy
+++ b/spec/design/skel/ARM/State_H.thy
@@ -16,7 +16,7 @@ imports
   RegisterSet_H
   MachineOps
 begin
-context Arch begin global_naming ARM_H
+context Arch begin arch_global_naming (H)
 
 definition
   Word :: "machine_word \<Rightarrow> machine_word"
@@ -28,16 +28,14 @@ where
 
 end
 
-context begin interpretation Arch .
-
-requalify_consts
+(* Note: while this requalify and arch-generic Haskell import of WordLib.lhs could be moved to
+   a generic theory, no good candidate theory exists at the moment. *)
+arch_requalify_consts (H)
   wordBits
-
-end
 
 #INCLUDE_HASKELL Data/WordLib.lhs all_bits NOT wordBits
 
-context Arch begin global_naming ARM_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Machine/RegisterSet.lhs Arch=ARM CONTEXT ARM_H all_bits NOT UserContext UserMonad getRegister setRegister newContext mask Word PPtr
 

--- a/spec/design/skel/ARM_HYP/ArchFaultHandler_H.thy
+++ b/spec/design/skel/ARM_HYP/ArchFaultHandler_H.thy
@@ -10,7 +10,7 @@ theory ArchFaultHandler_H
 imports TCB_H Structures_H
 begin
 
-context Arch begin global_naming ARM_HYP_H
+context Arch begin arch_global_naming (H)
 
 
 #INCLUDE_HASKELL_PREPARSE SEL4/API/Failures/ARM.lhs

--- a/spec/design/skel/ARM_HYP/ArchFault_H.thy
+++ b/spec/design/skel/ARM_HYP/ArchFault_H.thy
@@ -11,7 +11,7 @@
 theory ArchFault_H
 imports Types_H
 begin
-context Arch begin global_naming ARM_HYP_H
+context Arch begin arch_global_naming (H)
 
 
 #INCLUDE_HASKELL SEL4/API/Failures/ARM.lhs CONTEXT ARM_HYP_H decls_only

--- a/spec/design/skel/ARM_HYP/ArchHypervisor_H.thy
+++ b/spec/design/skel/ARM_HYP/ArchHypervisor_H.thy
@@ -14,7 +14,7 @@ imports
   FaultHandlerDecls_H
   InterruptDecls_H
 begin
-context Arch begin global_naming ARM_HYP_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Object/VCPU/ARM.lhs CONTEXT ARM_HYP_H decls_only ONLY countTrailingZeros irqVPPIEventIndex
 #INCLUDE_HASKELL SEL4/Object/VCPU/ARM.lhs CONTEXT ARM_HYP_H bodies_only ONLY countTrailingZeros irqVPPIEventIndex

--- a/spec/design/skel/ARM_HYP/ArchInterruptDecls_H.thy
+++ b/spec/design/skel/ARM_HYP/ArchInterruptDecls_H.thy
@@ -8,7 +8,7 @@ theory ArchInterruptDecls_H
 imports RetypeDecls_H CNode_H
 begin
 
-context Arch begin global_naming ARM_HYP_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Object/Interrupt/ARM.lhs CONTEXT Arch decls_only ArchInv=
 

--- a/spec/design/skel/ARM_HYP/ArchInterrupt_H.thy
+++ b/spec/design/skel/ARM_HYP/ArchInterrupt_H.thy
@@ -13,7 +13,7 @@ imports
   ArchHypervisor_H
 begin
 
-context Arch begin global_naming ARM_HYP_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Object/Interrupt/ARM.lhs Arch= CONTEXT ARM_HYP_H bodies_only ArchInv= NOT initInterruptController
 

--- a/spec/design/skel/ARM_HYP/ArchInvocationLabels_H.thy
+++ b/spec/design/skel/ARM_HYP/ArchInvocationLabels_H.thy
@@ -11,7 +11,7 @@ imports
     "Word_Lib.Enumeration"
     Setup_Locale
 begin
-context Arch begin global_naming ARM_HYP_H
+context Arch begin arch_global_naming (H)
 
 text \<open>
   An enumeration of arch-specific system call labels.
@@ -21,11 +21,12 @@ text \<open>
 
 end
 
-context begin interpretation Arch .
-requalify_types arch_invocation_label
-end
+(* not possible to move this requalification to generic, since enum instance proofs must
+   be done outside of Arch locale *)
+arch_requalify_types (H)
+  arch_invocation_label
 
-context Arch begin global_naming ARM_HYP_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/API/InvocationLabels/ARM.lhs CONTEXT ARM_HYP_H instanceproofs ONLY ArchInvocationLabel
 

--- a/spec/design/skel/ARM_HYP/ArchLabelFuns_H.thy
+++ b/spec/design/skel/ARM_HYP/ArchLabelFuns_H.thy
@@ -9,7 +9,7 @@ chapter "Architecture-specific Invocation Label Functions"
 theory ArchLabelFuns_H
 imports InvocationLabels_H
 begin
-context Arch begin global_naming ARM_HYP_H
+context Arch begin arch_global_naming (H)
 text \<open>
   Arch-specific functions on invocation labels
 \<close>

--- a/spec/design/skel/ARM_HYP/ArchPSpace_H.thy
+++ b/spec/design/skel/ARM_HYP/ArchPSpace_H.thy
@@ -11,7 +11,7 @@ imports
   ObjectInstances_H
 begin
 
-context Arch begin global_naming ARM_HYP_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Model/PSpace/ARM.hs
 

--- a/spec/design/skel/ARM_HYP/ArchRetypeDecls_H.thy
+++ b/spec/design/skel/ARM_HYP/ArchRetypeDecls_H.thy
@@ -15,7 +15,7 @@ imports
   PSpaceFuns_H
   ArchObjInsts_H
 begin
-context Arch begin global_naming ARM_HYP_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/API/Invocation/ARM.lhs CONTEXT ARM_HYP_H decls_only NOT isPageFlushLabel isPDFlushLabel Invocation IRQControlInvocation CopyRegisterSets
 

--- a/spec/design/skel/ARM_HYP/ArchRetype_H.thy
+++ b/spec/design/skel/ARM_HYP/ArchRetype_H.thy
@@ -14,7 +14,7 @@ imports
   VCPU_H
   KI_Decls_H
 begin
-context Arch begin global_naming ARM_HYP_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Object/ObjectType/ARM.lhs CONTEXT ARM_HYP_H Arch.Types= ArchInv= bodies_only
 #INCLUDE_HASKELL SEL4/API/Invocation/ARM.lhs bodies_only CONTEXT ARM_HYP_H NOT isPDFlushLabel isPageFlushLabel

--- a/spec/design/skel/ARM_HYP/ArchStateData_H.thy
+++ b/spec/design/skel/ARM_HYP/ArchStateData_H.thy
@@ -16,7 +16,7 @@ imports
   ArchTypes_H
   ArchStructures_H
 begin
-context Arch begin global_naming ARM_HYP_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Model/StateData/ARM.lhs CONTEXT ARM_HYP_H NOT ArmVSpaceRegionUse
 

--- a/spec/design/skel/ARM_HYP/ArchStructures_H.thy
+++ b/spec/design/skel/ARM_HYP/ArchStructures_H.thy
@@ -10,7 +10,7 @@ imports
   Types_H
   Hardware_H
 begin
-context Arch begin global_naming ARM_HYP_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_SETTINGS keep_constructor=asidpool
 #INCLUDE_SETTINGS keep_constructor=arch_tcb
@@ -52,10 +52,8 @@ where
 
 end
 
-context begin interpretation Arch .
-
-requalify_types
+(* not possible to move this requalification to generic, as some arches don't have vcpu *)
+arch_requalify_types (H)
   vcpu
 
-end
 end

--- a/spec/design/skel/ARM_HYP/ArchTCB_H.thy
+++ b/spec/design/skel/ARM_HYP/ArchTCB_H.thy
@@ -7,7 +7,7 @@
 theory ArchTCB_H
 imports TCBDecls_H
 begin
-context Arch begin global_naming ARM_HYP_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Object/TCB/ARM.lhs RegisterSet= CONTEXT ARM_HYP_H
 

--- a/spec/design/skel/ARM_HYP/ArchThreadDecls_H.thy
+++ b/spec/design/skel/ARM_HYP/ArchThreadDecls_H.thy
@@ -17,7 +17,7 @@ imports
   KernelInitMonad_H
 begin
 
-context Arch begin global_naming ARM_HYP_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Kernel/Thread/ARM.lhs CONTEXT Arch decls_only
 

--- a/spec/design/skel/ARM_HYP/ArchThread_H.thy
+++ b/spec/design/skel/ARM_HYP/ArchThread_H.thy
@@ -13,7 +13,7 @@ imports
   ArchVSpaceDecls_H
   ArchHypervisor_H
 begin
-context Arch begin global_naming ARM_HYP_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Kernel/Thread/ARM.lhs CONTEXT ARM_HYP_H ARMHardware=ARM_HYP bodies_only
 

--- a/spec/design/skel/ARM_HYP/ArchTypes_H.thy
+++ b/spec/design/skel/ARM_HYP/ArchTypes_H.thy
@@ -19,7 +19,7 @@ begin
 
 #INCLUDE_HASKELL SEL4/API/Types/Universal.lhs all_bits
 
-context Arch begin global_naming ARM_HYP_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/API/Types/ARM.lhs CONTEXT ARM_HYP_H
 
@@ -73,10 +73,6 @@ instantiation ARM_HYP_H.object_type :: enumeration_both
 begin
 interpretation Arch .
 instance by (intro_classes, simp add: enum_alt_object_type)
-end
-
-context begin interpretation Arch .
-requalify_types object_type
 end
 
 end

--- a/spec/design/skel/ARM_HYP/ArchVSpaceDecls_H.thy
+++ b/spec/design/skel/ARM_HYP/ArchVSpaceDecls_H.thy
@@ -9,7 +9,7 @@ chapter "Retyping Objects"
 theory ArchVSpaceDecls_H
 imports ArchRetypeDecls_H InvocationLabels_H
 begin
-context Arch begin global_naming ARM_HYP_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL_PREPARSE SEL4/Object/Structures.lhs CONTEXT ARM_HYP_H
 #INCLUDE_HASKELL SEL4/Kernel/VSpace/ARM.lhs CONTEXT ARM_HYP_H decls_only NOT pageBase ArchInv=

--- a/spec/design/skel/ARM_HYP/ArchVSpace_H.thy
+++ b/spec/design/skel/ARM_HYP/ArchVSpace_H.thy
@@ -15,7 +15,7 @@ imports
   ArchVSpaceDecls_H
   ArchHypervisor_H
 begin
-context Arch begin global_naming ARM_HYP_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Kernel/VSpace/ARM.lhs CONTEXT ARM_HYP_H bodies_only ArchInv=ArchRetypeDecls_H.ARM_HYP ArchLabels=ArchInvocationLabels_H.ARM_HYP NOT checkPDAt checkPTAt checkPDASIDMapMembership checkValidMappingSize vptrFromPPtr
 

--- a/spec/design/skel/ARM_HYP/Arch_Structs_B.thy
+++ b/spec/design/skel/ARM_HYP/Arch_Structs_B.thy
@@ -11,7 +11,7 @@ chapter "Common, Architecture-Specific Data Types"
 theory Arch_Structs_B
 imports Main Setup_Locale
 begin
-context Arch begin global_naming ARM_HYP_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Model/StateData/ARM.lhs CONTEXT ARM_HYP_H ONLY ArmVSpaceRegionUse
 

--- a/spec/design/skel/ARM_HYP/Hardware_H.thy
+++ b/spec/design/skel/ARM_HYP/Hardware_H.thy
@@ -9,17 +9,16 @@ imports
   MachineOps
   State_H
 begin
-context Arch begin global_naming ARM_HYP_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Machine/Hardware/ARM.lhs Platform=Platform.ARM_HYP CONTEXT ARM_HYP_H NOT getMemoryRegions getDeviceRegions getKernelDevices loadWord storeWord storeWordVM getActiveIRQ ackInterrupt maskInterrupt configureTimer resetTimer debugPrint getRestartPC setNextPC clearMemory clearMemoryVM initMemory freeMemory writeTTBR0 setGlobalPD  setTTBCR setHardwareASID invalidateLocalTLB invalidateLocalTLB_ASID invalidateLocalTLB_VAASID cleanByVA cleanByVA_PoU invalidateByVA invalidateByVA_I invalidate_I_PoU cleanInvalByVA branchFlush clean_D_PoU cleanInvalidate_D_PoC cleanInvalidate_D_PoU cleanInvalidateL2Range invalidateL2Range cleanL2Range isb dsb dmb getIFSR getDFSR getFAR HardwareASID wordFromPDE wordFromPTE VMFaultType HypFaultType VMPageSize pageBits pageBitsForSize toPAddr paddrBase pptrBase pptrTop paddrTop kernelELFPAddrBase kernelELFBase kernelELFBaseOffset pptrBaseOffset cacheLineBits cacheLine lineStart cacheRangeOp cleanCacheRange_PoC cleanInvalidateCacheRange_RAM cleanCacheRange_RAM cleanCacheRange_PoU invalidateCacheRange_RAM invalidateCacheRange_I branchFlushRange cleanCaches_PoU cleanInvalidateL1Caches addrFromPPtr ptrFromPAddr addrFromKPPtr initIRQController MachineData hapFromVMRights wordsFromPDE wordsFromPTE writeContextIDAndPD hcrVCPU hcrNative vgicHCREN sctlrDefault actlrDefault gicVCPUMaxNumLR getHSR setHCR getHDFAR addressTranslateS1 getSCTLR setSCTLR getACTLR setACTLR get_gic_vcpu_ctrl_hcr set_gic_vcpu_ctrl_hcr get_gic_vcpu_ctrl_vmcr set_gic_vcpu_ctrl_vmcr get_gic_vcpu_ctrl_apr set_gic_vcpu_ctrl_apr get_gic_vcpu_ctrl_vtr get_gic_vcpu_ctrl_eisr0 get_gic_vcpu_ctrl_eisr1 get_gic_vcpu_ctrl_misr get_gic_vcpu_ctrl_lr set_gic_vcpu_ctrl_lr setCurrentPDPL2 readVCPUHardwareReg setIRQTrigger writeVCPUHardwareReg getTPIDRURO setTPIDRURO get_cntv_cval_64 set_cntv_cval_64 set_cntv_off_64 get_cntv_off_64 read_cntpct
 
 end
 
-context begin interpretation Arch .
-requalify_types vmrights
-end
+arch_requalify_types (H)
+  vmrights
 
-context Arch begin global_naming ARM_HYP_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Machine/Hardware/ARM.lhs CONTEXT ARM_HYP_H instanceproofs NOT HardwareASID VMFaultType HypFaultType VMPageSize
 
@@ -27,7 +26,11 @@ context Arch begin global_naming ARM_HYP_H
 
 (* Kernel_Config provides a generic numeral, Haskell expects type irq *)
 abbreviation (input) maxIRQ :: irq where
-  "maxIRQ == Kernel_Config.maxIRQ"
+  "maxIRQ \<equiv> Kernel_Config.maxIRQ"
+
+(* provide ARM/ARM_HYP machine op in _H global_prefix for arch-split *)
+abbreviation (input) initIRQController where
+  "initIRQController \<equiv> ARM_HYP.initIRQController"
 
 end
 end

--- a/spec/design/skel/ARM_HYP/RegisterSet_H.thy
+++ b/spec/design/skel/ARM_HYP/RegisterSet_H.thy
@@ -11,7 +11,7 @@ imports
   "Lib.HaskellLib_H"
   MachineOps
 begin
-context Arch begin global_naming ARM_HYP_H
+context Arch begin arch_global_naming (H)
 
 definition
   newContext :: "user_context"

--- a/spec/design/skel/ARM_HYP/State_H.thy
+++ b/spec/design/skel/ARM_HYP/State_H.thy
@@ -16,7 +16,7 @@ imports
   RegisterSet_H
   MachineOps
 begin
-context Arch begin global_naming ARM_HYP_H
+context Arch begin arch_global_naming (H)
 
 definition
   Word :: "machine_word \<Rightarrow> machine_word"
@@ -28,16 +28,14 @@ where
 
 end
 
-context begin interpretation Arch .
-
-requalify_consts
+(* Note: while this requalify and arch-generic Haskell import of WordLib.lhs could be moved to
+   a generic theory, no good candidate theory exists at the moment. *)
+arch_requalify_consts (H)
   wordBits
-
-end
 
 #INCLUDE_HASKELL Data/WordLib.lhs all_bits NOT wordBits
 
-context Arch begin global_naming ARM_HYP_H
+context Arch begin arch_global_naming (H)
 
 
 #INCLUDE_HASKELL SEL4/Machine/RegisterSet.lhs Arch=ARM_HYP CONTEXT ARM_HYP_H all_bits NOT UserContext UserMonad getRegister setRegister newContext mask Word PPtr

--- a/spec/design/skel/ARM_HYP/VCPU_H.thy
+++ b/spec/design/skel/ARM_HYP/VCPU_H.thy
@@ -13,7 +13,7 @@ imports
   Invocations_H
   TCB_H
 begin
-context Arch begin global_naming ARM_HYP_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL_PREPARSE SEL4/Object/Structures.lhs CONTEXT ARM_HYP_H
 #INCLUDE_HASKELL SEL4/Object/VCPU/ARM.lhs CONTEXT ARM_HYP_H ArchInv=Arch NOT vcpuUpdate vgicUpdate vgicUpdateLR vcpuSaveReg vcpuRestoreReg vcpuSaveRegRange vcpuRestoreRegRange vcpuWriteReg vcpuReadReg saveVirtTimer restoreVirtTimer vcpuDisable vcpuEnable vcpuRestore vcpuSave vcpuSwitch vcpuInvalidateActive vcpuCleanInvalidateActive countTrailingZeros virqSetEOIIRQEN vgicMaintenance vppiEvent irqVPPIEventIndex armvVCPUSave

--- a/spec/design/skel/FaultHandler_H.thy
+++ b/spec/design/skel/FaultHandler_H.thy
@@ -13,15 +13,14 @@ imports
   ArchFaultHandler_H
 begin
 
-context begin interpretation Arch .
-requalify_consts
-  syscallMessage
-  fromVPtr
-  exceptionMessage
-  debugPrint
+arch_requalify_consts (H)
   makeArchFaultMessage
   handleArchFaultReply
-end
+
+(* clobbers previously requalified abstract spec constants with design spec versions *)
+arch_requalify_consts (aliasing, H)
+  syscallMessage
+  exceptionMessage
 
 #INCLUDE_HASKELL_PREPARSE SEL4/API/Failures.lhs
 

--- a/spec/design/skel/FaultMonad_H.thy
+++ b/spec/design/skel/FaultMonad_H.thy
@@ -7,13 +7,10 @@
 chapter "The Fault Monad"
 
 theory FaultMonad_H
-imports KernelStateData_H Fault_H
+imports
+  KernelStateData_H
+  Fault_H
 begin
-
-context begin interpretation Arch .
-requalify_consts
-  getActiveIRQ
-end
 
 type_synonym ('f, 'a) kernel_f = "('f + 'a) kernel"
 

--- a/spec/design/skel/Fault_H.thy
+++ b/spec/design/skel/Fault_H.thy
@@ -14,11 +14,8 @@ theory Fault_H
 imports ArchFault_H
 begin
 
-context begin interpretation Arch .
-
-requalify_types
+arch_requalify_types (H)
   arch_fault
-end
 
 #INCLUDE_HASKELL_PREPARSE SEL4/API/Types.lhs
 #INCLUDE_HASKELL SEL4/API/Failures.lhs decls_only

--- a/spec/design/skel/Hypervisor_H.thy
+++ b/spec/design/skel/Hypervisor_H.thy
@@ -15,9 +15,7 @@ imports
   KernelInitMonad_H
 begin
 
-context begin interpretation Arch .
-requalify_consts
+arch_requalify_consts (H)
   handleHypervisorFault
-end
 
 end

--- a/spec/design/skel/Intermediate_H.thy
+++ b/spec/design/skel/Intermediate_H.thy
@@ -10,11 +10,6 @@ theory Intermediate_H
 imports "API_H"
 begin
 
-context begin interpretation Arch .
-requalify_consts
-  clearMemory
-end
-
 (*
  * Intermediate function bodies that were once in the Haskell spec, but are
  * now no longer.

--- a/spec/design/skel/Interrupt_H.thy
+++ b/spec/design/skel/Interrupt_H.thy
@@ -16,34 +16,32 @@ begin
 
 context Arch begin
 
+(* match Haskell, expects these under Arch. *)
 requalify_consts
   checkIRQ
-  decodeIRQControlInvocation
-  performIRQControl
-  invokeIRQHandler
-  initInterruptController
   handleReservedIRQ
   maskIrqSignal
 
+(* disambiguate name clash between Arch and non-arch consts with same names *)
+requalify_consts (aliasing)
+  decodeIRQControlInvocation
+  invokeIRQHandler
+  performIRQControl
+  initInterruptController
+
 context begin global_naming global
-requalify_consts
+requalify_consts (aliasing)
   InterruptDecls_H.decodeIRQControlInvocation
+  InterruptDecls_H.invokeIRQHandler
   InterruptDecls_H.performIRQControl
-end
+  InterruptDecls_H.initInterruptController
 
 end
+end
 
-context begin interpretation Arch .
-
-requalify_consts
+(* override Kernel_Config const with constrained abbreviation from Hardware_H *)
+arch_requalify_consts (aliasing, H)
   maxIRQ
-  minIRQ
-  maskInterrupt
-  ackInterrupt
-  resetTimer
-  debugPrint
-
-end
 
 #INCLUDE_HASKELL_PREPARSE SEL4/Object/Structures.lhs
 #INCLUDE_HASKELL SEL4/Object/Interrupt.lhs bodies_only

--- a/spec/design/skel/InvocationLabels_H.thy
+++ b/spec/design/skel/InvocationLabels_H.thy
@@ -10,11 +10,6 @@ theory InvocationLabels_H
 imports ArchInvocationLabels_H
 begin
 
-context begin interpretation Arch .
-requalify_types
-  arch_invocation_label
-end
-
 text \<open>
   An enumeration of all system call labels.
 \<close>

--- a/spec/design/skel/Invocations_H.thy
+++ b/spec/design/skel/Invocations_H.thy
@@ -10,6 +10,8 @@ imports
   ArchRetypeDecls_H
   ArchLabelFuns_H
 begin
+
+(* Haskell expects these with Arch prefix *)
 requalify_types (in Arch)
   copy_register_sets irqcontrol_invocation
   invocation
@@ -17,9 +19,10 @@ requalify_types (in Arch)
 #INCLUDE_HASKELL SEL4/API/Invocation.lhs Arch=Arch NOT GenInvocationLabels InvocationLabel
 #INCLUDE_HASKELL SEL4/API/InvocationLabels.lhs ONLY invocationType genInvocationType
 
+(* disambiguate name clash between Arch and non-arch consts with same names *)
 context Arch begin
 context begin global_naming global
-requalify_types
+requalify_types (aliasing)
   Invocations_H.invocation
 end
 end

--- a/spec/design/skel/KernelInit_H.thy
+++ b/spec/design/skel/KernelInit_H.thy
@@ -15,14 +15,10 @@ imports
   Thread_H
 begin
 
-context begin interpretation Arch .
-
-requalify_consts
+arch_requalify_consts
   getMemoryRegions
   addrFromPPtr
   init_machine_state
-
-end
 
 requalify_consts (in Arch)
   newKernelState
@@ -77,11 +73,19 @@ newKernelState_def:
         ksMachineState = init_machine_state
 \<rparr>"
 
+(* disambiguate name clash between Arch and non-arch consts with same names *)
 context Arch begin
-requalify_facts
+requalify_facts (aliasing)
+   newKernelState_def
+requalify_consts (aliasing)
+   newKernelState
+
+context begin global_naming global
+requalify_facts (aliasing)
    KernelInit_H.newKernelState_def
-requalify_consts
+requalify_consts (aliasing)
    KernelInit_H.newKernelState
+end
 end
 
 end

--- a/spec/design/skel/KernelStateData_H.thy
+++ b/spec/design/skel/KernelStateData_H.thy
@@ -18,13 +18,6 @@ imports
   ArchStateData_H
 begin
 
-context begin interpretation Arch .
-
-requalify_types
-  vmpage_size
-
-end
-
 requalify_types (in Arch)
   kernel_state
 

--- a/spec/design/skel/Notification_H.thy
+++ b/spec/design/skel/Notification_H.thy
@@ -14,10 +14,8 @@ theory Notification_H imports    "NotificationDecls_H"
   ObjectInstances_H
 begin
 
-context begin interpretation Arch .
-requalify_consts
+arch_requalify_consts (H)
   badgeRegister
-end
 
 #INCLUDE_HASKELL SEL4/Object/Notification.lhs bodies_only
 

--- a/spec/design/skel/ObjectInstances_H.thy
+++ b/spec/design/skel/ObjectInstances_H.thy
@@ -18,11 +18,9 @@ imports
   Config_H
 begin
 
-context begin interpretation Arch .
-requalify_consts
+arch_requalify_consts (H)
   VPtr
   newContext
-end
 
 lemma projectKO_eq2:
   "((obj,s') \<in> fst (projectKO ko s)) = (projectKO_opt ko = Some obj \<and> s' = s)"

--- a/spec/design/skel/PSpaceFuns_H.thy
+++ b/spec/design/skel/PSpaceFuns_H.thy
@@ -14,15 +14,7 @@ imports
   "Lib.DataMap"
 begin
 
-context begin interpretation Arch .
-requalify_consts
-  fromPPtr
-  PPtr
-  freeMemory
-  storeWord
-  loadWord
-end
-
+(* Haskell expects this with Arch prefix *)
 requalify_consts (in Arch)
   deleteGhost
 

--- a/spec/design/skel/PSpaceStorable_H.thy
+++ b/spec/design/skel/PSpaceStorable_H.thy
@@ -11,13 +11,11 @@ imports
   "Lib.DataMap"
 begin
 
-context begin interpretation Arch .
-requalify_types
+arch_requalify_types (H)
   arch_kernel_object_type
 
-requalify_consts
+arch_requalify_consts (H)
   archTypeOf
-end
 
 lemma UserData_singleton [simp]:
   "(v = UserData) = True" "(UserData = v) = True"

--- a/spec/design/skel/RISCV64/ArchFaultHandler_H.thy
+++ b/spec/design/skel/RISCV64/ArchFaultHandler_H.thy
@@ -10,7 +10,7 @@ theory ArchFaultHandler_H
 imports TCB_H Structures_H
 begin
 
-context Arch begin global_naming RISCV64_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL_PREPARSE SEL4/API/Failures/RISCV64.hs
 

--- a/spec/design/skel/RISCV64/ArchFault_H.thy
+++ b/spec/design/skel/RISCV64/ArchFault_H.thy
@@ -12,7 +12,7 @@ theory ArchFault_H
 imports Types_H
 begin
 
-context Arch begin global_naming RISCV64_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/API/Failures/RISCV64.hs CONTEXT RISCV64_H decls_only
 #INCLUDE_HASKELL SEL4/API/Failures/RISCV64.hs CONTEXT RISCV64_H bodies_only

--- a/spec/design/skel/RISCV64/ArchHypervisor_H.thy
+++ b/spec/design/skel/RISCV64/ArchHypervisor_H.thy
@@ -14,7 +14,7 @@ imports
   KI_Decls_H
   InterruptDecls_H
 begin
-context Arch begin global_naming RISCV64_H
+context Arch begin arch_global_naming (H)
 
 
 #INCLUDE_HASKELL SEL4/Kernel/Hypervisor/RISCV64.hs Arch= CONTEXT RISCV64_H decls_only ArchInv= ArchLabels=

--- a/spec/design/skel/RISCV64/ArchInterruptDecls_H.thy
+++ b/spec/design/skel/RISCV64/ArchInterruptDecls_H.thy
@@ -8,7 +8,7 @@ theory ArchInterruptDecls_H
 imports RetypeDecls_H CNode_H
 begin
 
-context Arch begin global_naming RISCV64_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Object/Interrupt/RISCV64.hs CONTEXT RISCV64_H decls_only ArchInv= Arch=MachineOps NOT plic_complete_claim
 

--- a/spec/design/skel/RISCV64/ArchInterrupt_H.thy
+++ b/spec/design/skel/RISCV64/ArchInterrupt_H.thy
@@ -13,7 +13,7 @@ imports
   ArchHypervisor_H
 begin
 
-context Arch begin global_naming RISCV64_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Object/Interrupt/RISCV64.hs CONTEXT RISCV64_H bodies_only ArchInv= Arch= NOT plic_complete_claim
 

--- a/spec/design/skel/RISCV64/ArchInvocationLabels_H.thy
+++ b/spec/design/skel/RISCV64/ArchInvocationLabels_H.thy
@@ -11,7 +11,7 @@ imports
   "Word_Lib.Enumeration"
   Setup_Locale
 begin
-context Arch begin global_naming RISCV64_H
+context Arch begin arch_global_naming (H)
 
 text \<open>
   An enumeration of arch-specific system call labels.
@@ -21,11 +21,12 @@ text \<open>
 
 end
 
-context begin interpretation Arch .
-requalify_types arch_invocation_label
-end
+(* not possible to move this requalification to generic, since enum instance proofs must
+   be done outside of Arch locale *)
+arch_requalify_types (H)
+  arch_invocation_label
 
-context Arch begin global_naming RISCV64_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/API/InvocationLabels/RISCV64.hs CONTEXT RISCV64_H instanceproofs ONLY ArchInvocationLabel
 

--- a/spec/design/skel/RISCV64/ArchPSpace_H.thy
+++ b/spec/design/skel/RISCV64/ArchPSpace_H.thy
@@ -11,7 +11,7 @@ imports
   ObjectInstances_H
 begin
 
-context Arch begin global_naming RISCV64_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Model/PSpace/RISCV64.hs
 

--- a/spec/design/skel/RISCV64/ArchRetypeDecls_H.thy
+++ b/spec/design/skel/RISCV64/ArchRetypeDecls_H.thy
@@ -15,7 +15,7 @@ imports
   ArchObjInsts_H
 begin
 
-context Arch begin global_naming RISCV64_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL_PREPARSE SEL4/Object/Structures/RISCV64.hs
 

--- a/spec/design/skel/RISCV64/ArchRetype_H.thy
+++ b/spec/design/skel/RISCV64/ArchRetype_H.thy
@@ -14,7 +14,7 @@ imports
   KI_Decls_H
 begin
 
-context Arch begin global_naming RISCV64_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Object/ObjectType/RISCV64.hs CONTEXT RISCV64_H Arch.Types=ArchTypes_H ArchInv=ArchRetypeDecls_H NOT bodies_only
 #INCLUDE_HASKELL SEL4/API/Invocation/RISCV64.hs CONTEXT RISCV64_H bodies_only

--- a/spec/design/skel/RISCV64/ArchStateData_H.thy
+++ b/spec/design/skel/RISCV64/ArchStateData_H.thy
@@ -17,7 +17,7 @@ imports
   ArchStructures_H
 begin
 
-context Arch begin global_naming RISCV64_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Model/StateData/RISCV64.hs CONTEXT RISCV64_H NOT RISCVVSpaceRegionUse
 

--- a/spec/design/skel/RISCV64/ArchStructures_H.thy
+++ b/spec/design/skel/RISCV64/ArchStructures_H.thy
@@ -11,7 +11,7 @@ imports
   Hardware_H
 begin
 
-context Arch begin global_naming RISCV64_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_SETTINGS keep_constructor=asidpool
 #INCLUDE_SETTINGS keep_constructor=arch_tcb

--- a/spec/design/skel/RISCV64/ArchTCB_H.thy
+++ b/spec/design/skel/RISCV64/ArchTCB_H.thy
@@ -8,7 +8,7 @@ theory ArchTCB_H
 imports TCBDecls_H
 begin
 
-context Arch begin global_naming RISCV64_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Object/TCB/RISCV64.hs RegisterSet= CONTEXT RISCV64_H
 

--- a/spec/design/skel/RISCV64/ArchThreadDecls_H.thy
+++ b/spec/design/skel/RISCV64/ArchThreadDecls_H.thy
@@ -17,7 +17,7 @@ imports
   KernelInitMonad_H
 begin
 
-context Arch begin global_naming RISCV64_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Kernel/Thread/RISCV64.hs CONTEXT RISCV64_H decls_only
 

--- a/spec/design/skel/RISCV64/ArchThread_H.thy
+++ b/spec/design/skel/RISCV64/ArchThread_H.thy
@@ -13,7 +13,7 @@ imports
   ArchVSpaceDecls_H
 begin
 
-context Arch begin global_naming RISCV64_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Kernel/Thread/RISCV64.hs CONTEXT RISCV64_H Arch=MachineOps ArchReg=MachineTypes bodies_only
 

--- a/spec/design/skel/RISCV64/ArchTypes_H.thy
+++ b/spec/design/skel/RISCV64/ArchTypes_H.thy
@@ -19,7 +19,7 @@ begin
 
 #INCLUDE_HASKELL SEL4/API/Types/Universal.lhs all_bits
 
-context Arch begin global_naming RISCV64_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/API/Types/RISCV64.hs CONTEXT RISCV64_H
 
@@ -70,10 +70,6 @@ instantiation RISCV64_H.object_type :: enumeration_both
 begin
 interpretation Arch .
 instance by (intro_classes, simp add: enum_alt_object_type)
-end
-
-context begin interpretation Arch .
-requalify_types object_type
 end
 
 end

--- a/spec/design/skel/RISCV64/ArchVSpaceDecls_H.thy
+++ b/spec/design/skel/RISCV64/ArchVSpaceDecls_H.thy
@@ -10,7 +10,7 @@ theory ArchVSpaceDecls_H
 imports ArchRetypeDecls_H InvocationLabels_H
 begin
 
-context Arch begin global_naming RISCV64_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL_PREPARSE SEL4/Object/Structures.lhs CONTEXT RISCV64_H
 #INCLUDE_HASKELL_PREPARSE SEL4/API/InvocationLabels/RISCV64.hs CONTEXT RISCV64

--- a/spec/design/skel/RISCV64/ArchVSpace_H.thy
+++ b/spec/design/skel/RISCV64/ArchVSpace_H.thy
@@ -16,7 +16,7 @@ imports
   ArchVSpaceDecls_H
 begin
 
-context Arch begin global_naming RISCV64_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Kernel/VSpace/RISCV64.hs CONTEXT RISCV64_H bodies_only ArchInv=ArchRetypeDecls_H ONLY pteAtIndex getPPtrFromHWPTE isPageTablePTE ptBitsLeft
 

--- a/spec/design/skel/RISCV64/Arch_Structs_B.thy
+++ b/spec/design/skel/RISCV64/Arch_Structs_B.thy
@@ -12,7 +12,7 @@ theory Arch_Structs_B
 imports Setup_Locale
 begin
 
-context Arch begin global_naming RISCV64_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Model/StateData/RISCV64.hs CONTEXT RISCV64_H ONLY RISCVVSpaceRegionUse
 

--- a/spec/design/skel/RISCV64/Hardware_H.thy
+++ b/spec/design/skel/RISCV64/Hardware_H.thy
@@ -10,21 +10,25 @@ imports
   State_H
 begin
 
-context Arch begin global_naming RISCV64_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Machine/Hardware/RISCV64.hs Platform=Platform.RISCV64 CONTEXT RISCV64_H NOT plic_complete_claim getMemoryRegions getDeviceRegions getKernelDevices loadWord storeWord storeWordVM getActiveIRQ ackInterrupt maskInterrupt configureTimer resetTimer debugPrint getRestartPC setNextPC clearMemory clearMemoryVM initMemory freeMemory setHardwareASID wordFromPDE wordFromPTE VMFaultType HypFaultType VMPageSize pageBits pageBitsForSize toPAddr addrFromPPtr ptrFromPAddr sfence physBase paddrBase pptrBase pptrBaseOffset pptrTop pptrUserTop kernelELFBase kernelELFBaseOffset kernelELFPAddrBase addrFromKPPtr ptTranslationBits vmFaultTypeFSR read_stval setVSpaceRoot hwASIDFlush setIRQTrigger
 
 end
 
-context begin interpretation Arch .
-requalify_types vmrights
-end
+arch_requalify_types (H)
+  vmrights
 
-context Arch begin global_naming RISCV64_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Machine/Hardware/RISCV64.hs CONTEXT RISCV64_H instanceproofs NOT plic_complete_claim HardwareASID VMFaultType VMPageSize VMPageEntry HypFaultType
 
 #INCLUDE_HASKELL SEL4/Machine/Hardware/RISCV64.hs CONTEXT RISCV64_H ONLY wordFromPTE
+
+(* Unlike on Arm architectures, maxIRQ comes from Platform definitions.
+   We provide this abbreviation to match arch-split expectations. *)
+abbreviation (input) maxIRQ :: irq where
+  "maxIRQ \<equiv> Platform.RISCV64.maxIRQ"
 
 end (* context RISCV64 *)
 

--- a/spec/design/skel/RISCV64/RegisterSet_H.thy
+++ b/spec/design/skel/RISCV64/RegisterSet_H.thy
@@ -11,7 +11,7 @@ imports
   "Lib.HaskellLib_H"
   MachineOps
 begin
-context Arch begin global_naming RISCV64_H
+context Arch begin arch_global_naming (H)
 
 definition
   newContext :: "user_context"

--- a/spec/design/skel/RISCV64/State_H.thy
+++ b/spec/design/skel/RISCV64/State_H.thy
@@ -14,7 +14,7 @@ theory State_H
 imports
   RegisterSet_H
 begin
-context Arch begin global_naming RISCV64_H
+context Arch begin arch_global_naming (H)
 
 definition
   Word :: "machine_word \<Rightarrow> machine_word"
@@ -26,16 +26,14 @@ where
 
 end
 
-context begin interpretation Arch .
-
-requalify_consts
+(* Note: while this requalify and arch-generic Haskell import of WordLib.lhs could be moved to
+   a generic theory, no good candidate theory exists at the moment. *)
+arch_requalify_consts (H)
   wordBits
-
-end
 
 #INCLUDE_HASKELL Data/WordLib.lhs all_bits NOT wordBits
 
-context Arch begin global_naming RISCV64_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Machine/RegisterSet.lhs Arch=RISCV64 CONTEXT RISCV64_H all_bits NOT UserContext UserMonad getRegister setRegister newContext mask Word PPtr
 

--- a/spec/design/skel/Retype_H.thy
+++ b/spec/design/skel/Retype_H.thy
@@ -15,22 +15,28 @@ imports
 begin
 
 context Arch begin
+
+(* match Haskell, expects these under Arch. *)
 requalify_consts
+  cteRightsBits cteGuardBits
+
+(* disambiguate name clash between Arch and non-arch consts with same names *)
+requalify_consts (aliasing)
   deriveCap finaliseCap postCapDeletion isCapRevocable
   hasCancelSendRights sameRegionAs isPhysicalCap
   sameObjectAs updateCapData maskCapRights
   createObject capUntypedPtr capUntypedSize
   performInvocation decodeInvocation prepareThreadDelete
-  cteRightsBits cteGuardBits
 
 context begin global_naming global
 
-requalify_consts
+requalify_consts (aliasing)
   RetypeDecls_H.deriveCap RetypeDecls_H.finaliseCap RetypeDecls_H.postCapDeletion
+  RetypeDecls_H.isCapRevocable
   RetypeDecls_H.hasCancelSendRights RetypeDecls_H.sameRegionAs RetypeDecls_H.isPhysicalCap
   RetypeDecls_H.sameObjectAs RetypeDecls_H.updateCapData RetypeDecls_H.maskCapRights
   RetypeDecls_H.createObject RetypeDecls_H.capUntypedPtr RetypeDecls_H.capUntypedSize
-  RetypeDecls_H.performInvocation RetypeDecls_H.decodeInvocation RetypeDecls_H.isCapRevocable
+  RetypeDecls_H.performInvocation RetypeDecls_H.decodeInvocation
 end
 
 end

--- a/spec/design/skel/Structures_H.thy
+++ b/spec/design/skel/Structures_H.thy
@@ -19,27 +19,20 @@ imports
   ArchStructures_H
 begin
 
-context begin interpretation Arch .
-
-requalify_types
-  irq
+arch_requalify_types (H)
   arch_capability
-  user_context
   arch_kernel_object
   asid
   arch_tcb
 
-requalify_consts
+arch_requalify_consts (H)
   archObjSize
-  pageBits
   nullPointer
   newArchTCB
   fromPPtr
   PPtr
   atcbContextGet
   atcbContextSet
-
-end
 
 #INCLUDE_HASKELL SEL4/Object/Structures.lhs decls_only NOT isNullCap isUntypedCap isIRQControlCap isReplyCap isDomainCap isNotificationCap
 #INCLUDE_HASKELL SEL4/Object/Structures.lhs bodies_only NOT kernelObjectTypeName isNullCap isUntypedCap isIRQControlCap isReplyCap isDomainCap isNotificationCap

--- a/spec/design/skel/TCBDecls_H.thy
+++ b/spec/design/skel/TCBDecls_H.thy
@@ -10,11 +10,7 @@ theory TCBDecls_H
 imports FaultMonad_H Invocations_H
 begin
 
-context begin interpretation Arch .
-requalify_types
-  user_monad
-end
-
-#INCLUDE_HASKELL SEL4/Object/TCB.lhs decls_only NOT archThreadGet archThreadSet
+#INCLUDE_HASKELL SEL4/Object/TCB.lhs decls_only \
+  NOT archThreadGet archThreadSet sanitiseRegister getSanitiseRegisterInfo
 
 end

--- a/spec/design/skel/TCB_H.thy
+++ b/spec/design/skel/TCB_H.thy
@@ -15,24 +15,21 @@ imports
   ArchTCB_H
 begin
 
-context begin interpretation Arch .
-requalify_consts
+arch_requalify_consts (H)
   decodeTransfer
-  gpRegisters
-  frameRegisters
-  getRegister
-  setNextPC
-  getRestartPC
-  sanitiseRegister
-  getSanitiseRegisterInfo
-  setRegister
   performTransfer
   msgInfoRegister
   msgRegisters
   fromVPtr
   postModifyRegisters
+  sanitiseRegister
+  getSanitiseRegisterInfo
+
+(* clobbers previously requalified abstract spec constants with design spec versions *)
+arch_requalify_consts (aliasing, H)
+  gpRegisters
+  frameRegisters
   tlsBaseRegister
-end
 
 abbreviation "mapMaybe \<equiv> option_map"
 

--- a/spec/design/skel/Thread_H.thy
+++ b/spec/design/skel/Thread_H.thy
@@ -15,32 +15,31 @@ imports
   Config_H
 begin
 
+arch_requalify_consts (H)
+  capRegister
+  faultRegister
+  nextInstructionRegister
+
 context Arch begin
 
+(* match Haskell, expects these under Arch. *)
 requalify_consts
   activateIdleThread
+
+(* disambiguate name clash between Arch and non-arch consts with same names *)
+requalify_consts (aliasing)
   configureIdleThread
   switchToIdleThread
   switchToThread
 
 context begin global_naming global
 
-requalify_consts
+requalify_consts (aliasing)
   ThreadDecls_H.configureIdleThread
   ThreadDecls_H.switchToIdleThread
   ThreadDecls_H.switchToThread
 
 end
-
-end
-
-context begin interpretation Arch .
-
-requalify_consts
-  capRegister
-  faultRegister
-  nextInstructionRegister
-
 end
 
 #INCLUDE_HASKELL SEL4/Kernel/Thread.lhs Arch=Arch bodies_only NOT doNormalTransfer doIPCTransfer doReplyTransfer doNormalTransfer transferCaps transferCapsToSlots

--- a/spec/design/skel/Types_H.thy
+++ b/spec/design/skel/Types_H.thy
@@ -12,28 +12,25 @@ chapter "Types visible in the API"
 
 theory Types_H
 imports
+  MachineExports
   ArchTypes_H
 begin
 
-context begin interpretation Arch .
-requalify_types
+arch_requalify_types (H)
   object_type
-  machine_word
   paddr
   vptr
 
-requalify_consts
+arch_requalify_consts (H)
   getObjectSize
   fromAPIType
   toAPIType
   isFrameType
   pageType
-  ptrFromPAddr
   tcbBlockSizeBits
 
-requalify_facts
+arch_requalify_facts (H)
   tcbBlockSizeBits_def
-end
 
 #INCLUDE_HASKELL SEL4/API/Types.lhs all_bits NOT wordsFromBootInfo messageInfoFromWord wordFromMessageInfo ObjectType getObjectSize fromAPIType toAPIType isFrameType pageType
 #INCLUDE_HASKELL SEL4/API/Types.lhs all_bits ONLY wordsFromBootInfo messageInfoFromWord wordFromMessageInfo

--- a/spec/design/skel/Untyped_H.thy
+++ b/spec/design/skel/Untyped_H.thy
@@ -14,16 +14,11 @@ imports
   Invocations_H
   InvocationLabels_H
   Config_H
-  MachineExports
 begin
 
-context begin interpretation Arch .
-
-requalify_consts
+arch_requalify_consts (H)
   minUntypedSizeBits
   maxUntypedSizeBits
-
-end
 
 consts
   cNodeOverlap :: "(machine_word \<Rightarrow> nat option) \<Rightarrow> (machine_word \<Rightarrow> bool) \<Rightarrow> bool"

--- a/spec/design/skel/VSpace_H.thy
+++ b/spec/design/skel/VSpace_H.thy
@@ -15,14 +15,10 @@ imports
   KernelInitMonad_H
 begin
 
-context begin interpretation Arch .
-requalify_consts
+arch_requalify_consts (H)
   mapKernelWindow
   activateGlobalVSpace
-  configureTimer
-  initL2Cache
   initIRQController
-
   createIPCBufferFrame
   createBIFrame
   createFramesOfRegion
@@ -36,7 +32,6 @@ requalify_consts
   checkValidIPCBuffer
   lookupIPCBuffer
   vptrFromPPtr
-end
 
 #INCLUDE_HASKELL SEL4/Kernel/VSpace.lhs Arch= ONLY initKernelVM initPlatform initCPU
 

--- a/spec/design/skel/X64/ArchFaultHandler_H.thy
+++ b/spec/design/skel/X64/ArchFaultHandler_H.thy
@@ -10,7 +10,7 @@ theory ArchFaultHandler_H
 imports TCB_H Structures_H
 begin
 
-context Arch begin global_naming X64_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL_PREPARSE SEL4/API/Failures/X64.lhs
 

--- a/spec/design/skel/X64/ArchFault_H.thy
+++ b/spec/design/skel/X64/ArchFault_H.thy
@@ -12,7 +12,7 @@ theory ArchFault_H
 imports Types_H
 begin
 
-context Arch begin global_naming X64_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/API/Failures/X64.lhs CONTEXT X64_H decls_only
 #INCLUDE_HASKELL SEL4/API/Failures/X64.lhs CONTEXT X64_H bodies_only

--- a/spec/design/skel/X64/ArchHook_H.thy
+++ b/spec/design/skel/X64/ArchHook_H.thy
@@ -10,7 +10,7 @@ theory ArchHook_H
 imports KernelStateData_H
 begin
 
-context Arch begin global_naming X64_H
+context Arch begin arch_global_naming (H)
 
 definition
   cEntryHook :: "unit kernel"

--- a/spec/design/skel/X64/ArchHypervisor_H.thy
+++ b/spec/design/skel/X64/ArchHypervisor_H.thy
@@ -15,7 +15,7 @@ imports
   InterruptDecls_H
 begin
 
-context Arch begin global_naming X64_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Kernel/Hypervisor/X64.lhs Arch= CONTEXT X64_H decls_only ArchInv= ArchLabels=
 #INCLUDE_HASKELL SEL4/Kernel/Hypervisor/X64.lhs Arch= CONTEXT X64_H bodies_only ArchInv= ArchLabels=

--- a/spec/design/skel/X64/ArchInterruptDecls_H.thy
+++ b/spec/design/skel/X64/ArchInterruptDecls_H.thy
@@ -8,7 +8,7 @@ theory ArchInterruptDecls_H
 imports RetypeDecls_H CNode_H
 begin
 
-context Arch begin global_naming X64_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Object/Interrupt/X64.lhs CONTEXT X64_H decls_only ArchInv= Arch=MachineOps
 

--- a/spec/design/skel/X64/ArchInterrupt_H.thy
+++ b/spec/design/skel/X64/ArchInterrupt_H.thy
@@ -13,7 +13,7 @@ imports
   ArchHypervisor_H
 begin
 
-context Arch begin global_naming X64_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Object/Interrupt/X64.lhs CONTEXT X64_H bodies_only ArchInv= Arch=
 

--- a/spec/design/skel/X64/ArchInvocationLabels_H.thy
+++ b/spec/design/skel/X64/ArchInvocationLabels_H.thy
@@ -11,7 +11,7 @@ imports
   "Word_Lib.Enumeration"
   Setup_Locale
 begin
-context Arch begin global_naming X64_H
+context Arch begin arch_global_naming (H)
 
 text \<open>
   An enumeration of arch-specific system call labels.
@@ -21,11 +21,12 @@ text \<open>
 
 end
 
-context begin interpretation Arch .
-requalify_types arch_invocation_label
-end
+(* not possible to move this requalification to generic, since enum instance proofs must
+   be done outside of Arch locale *)
+arch_requalify_types (H)
+  arch_invocation_label
 
-context Arch begin global_naming X64_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/API/InvocationLabels/X64.lhs CONTEXT X64_H instanceproofs ONLY ArchInvocationLabel
 

--- a/spec/design/skel/X64/ArchPSpace_H.thy
+++ b/spec/design/skel/X64/ArchPSpace_H.thy
@@ -11,7 +11,7 @@ imports
   ObjectInstances_H
 begin
 
-context Arch begin global_naming X64_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Model/PSpace/X64.hs
 

--- a/spec/design/skel/X64/ArchRetypeDecls_H.thy
+++ b/spec/design/skel/X64/ArchRetypeDecls_H.thy
@@ -15,7 +15,7 @@ imports
   ArchObjInsts_H
 begin
 
-context Arch begin global_naming X64_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/API/Invocation/X64.lhs CONTEXT X64_H decls_only NOT Invocation IRQControlInvocation
 

--- a/spec/design/skel/X64/ArchRetype_H.thy
+++ b/spec/design/skel/X64/ArchRetype_H.thy
@@ -14,7 +14,7 @@ imports
   KI_Decls_H
 begin
 
-context Arch begin global_naming X64_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Object/ObjectType/X64.lhs CONTEXT X64_H Arch.Types=ArchTypes_H ArchInv=ArchRetypeDecls_H NOT bodies_only
 #INCLUDE_HASKELL SEL4/API/Invocation/X64.lhs CONTEXT X64_H bodies_only

--- a/spec/design/skel/X64/ArchStateData_H.thy
+++ b/spec/design/skel/X64/ArchStateData_H.thy
@@ -17,7 +17,7 @@ imports
   ArchStructures_H
 begin
 
-context Arch begin global_naming X64_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Model/StateData/X64.lhs CONTEXT X64_H NOT X64VSpaceRegionUse
 

--- a/spec/design/skel/X64/ArchStructures_H.thy
+++ b/spec/design/skel/X64/ArchStructures_H.thy
@@ -11,7 +11,7 @@ imports
   Hardware_H
 begin
 
-context Arch begin global_naming X64_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_SETTINGS keep_constructor=asidpool
 #INCLUDE_SETTINGS keep_constructor=arch_tcb

--- a/spec/design/skel/X64/ArchTCB_H.thy
+++ b/spec/design/skel/X64/ArchTCB_H.thy
@@ -8,7 +8,7 @@ theory ArchTCB_H
 imports TCBDecls_H
 begin
 
-context Arch begin global_naming X64_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Object/TCB/X64.lhs RegisterSet= CONTEXT X64_H
 

--- a/spec/design/skel/X64/ArchThreadDecls_H.thy
+++ b/spec/design/skel/X64/ArchThreadDecls_H.thy
@@ -17,7 +17,7 @@ imports
   KernelInitMonad_H
 begin
 
-context Arch begin global_naming X64_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Kernel/Thread/X64.lhs CONTEXT X64_H decls_only
 

--- a/spec/design/skel/X64/ArchThread_H.thy
+++ b/spec/design/skel/X64/ArchThread_H.thy
@@ -14,7 +14,7 @@ imports
 begin
 
 
-context Arch begin global_naming X64_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Kernel/Thread/X64.lhs CONTEXT X64_H Arch=MachineOps ArchReg=MachineTypes bodies_only
 

--- a/spec/design/skel/X64/ArchTypes_H.thy
+++ b/spec/design/skel/X64/ArchTypes_H.thy
@@ -19,7 +19,7 @@ begin
 
 #INCLUDE_HASKELL SEL4/API/Types/Universal.lhs all_bits
 
-context Arch begin global_naming X64_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/API/Types/X64.lhs CONTEXT X64_H
 
@@ -73,10 +73,6 @@ instantiation X64_H.object_type :: enumeration_both
 begin
 interpretation Arch .
 instance by (intro_classes, simp add: enum_alt_object_type)
-end
-
-context begin interpretation Arch .
-requalify_types object_type
 end
 
 end

--- a/spec/design/skel/X64/ArchVSpaceDecls_H.thy
+++ b/spec/design/skel/X64/ArchVSpaceDecls_H.thy
@@ -10,7 +10,7 @@ theory ArchVSpaceDecls_H
 imports ArchRetypeDecls_H InvocationLabels_H
 begin
 
-context Arch begin global_naming X64_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL_PREPARSE SEL4/Object/Structures.lhs CONTEXT X64_H
 #INCLUDE_HASKELL_PREPARSE SEL4/API/InvocationLabels/X64.lhs CONTEXT X64

--- a/spec/design/skel/X64/ArchVSpace_H.thy
+++ b/spec/design/skel/X64/ArchVSpace_H.thy
@@ -16,7 +16,7 @@ imports
   ArchVSpaceDecls_H
 begin
 
-context Arch begin global_naming X64_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Kernel/VSpace/X64.lhs CONTEXT X64_H bodies_only ArchInv=ArchRetypeDecls_H NOT checkPML4At checkPDPTAt checkPDAt checkPTAt checkValidMappingSize
 #INCLUDE_HASKELL SEL4/Object/IOPort/X64.lhs CONTEXT X64_H bodies_only ArchInv=ArchRetypeDecls_H

--- a/spec/design/skel/X64/Arch_Structs_B.thy
+++ b/spec/design/skel/X64/Arch_Structs_B.thy
@@ -12,7 +12,7 @@ theory Arch_Structs_B
 imports Main Setup_Locale
 begin
 
-context Arch begin global_naming X64_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Model/StateData/X64.lhs CONTEXT X64_H ONLY X64VSpaceRegionUse
 

--- a/spec/design/skel/X64/Hardware_H.thy
+++ b/spec/design/skel/X64/Hardware_H.thy
@@ -10,21 +10,25 @@ imports
   State_H
 begin
 
-context Arch begin global_naming X64_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Machine/Hardware/X64.lhs Platform=Platform.X64 CONTEXT X64_H NOT getMemoryRegions getDeviceRegions getKernelDevices loadWord storeWord storeWordVM getActiveIRQ ackInterrupt maskInterrupt configureTimer resetTimer debugPrint getRestartPC setNextPC clearMemory clearMemoryVM initMemory freeMemory wordFromPDE wordFromPTE VMFaultType HypFaultType VMMapType VMPageSize pageBits pageBitsForSize paddrBase pptrBase pptrTop pptrBaseOffset kernelELFBaseOffset kernelELFPAddrBase kernelELFBase toPAddr addrFromPPtr ptrFromPAddr addrFromKPPtr setCurrentUserCR3 getCurrentUserCR3 invalidateTLB invalidateTLBEntry mfence wordFromPML4E wordFromPDPTE firstValidIODomain numIODomainIDBits hwASIDInvalidate getFaultAddress irqIntOffset maxPCIBus maxPCIDev maxPCIFunc ioapicIRQLines ioapicMapPinToVector irqStateIRQIOAPICNew irqStateIRQMSINew updateIRQState in8 out8 in16 out16 in32 out32 invalidatePageStructureCache writeCR3 invalidateASID invalidateTranslationSingleASID invalidateLocalPageStructureCacheASID ptTranslationBits nativeThreadUsingFPU switchFpuOwner
 
 end
 
-context begin interpretation Arch .
-requalify_types vmrights
-end
+arch_requalify_types (H)
+  vmrights
 
-context Arch begin global_naming X64_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Machine/Hardware/X64.lhs CONTEXT X64_H instanceproofs NOT VMFaultType VMPageSize VMPageEntry VMMapType HypFaultType
 
 #INCLUDE_HASKELL SEL4/Machine/Hardware/X64.lhs CONTEXT X64_H ONLY wordFromPDE wordFromPTE wordFromPML4E wordFromPDPTE
+
+(* Unlike on Arm architectures, maxIRQ comes from Platform definitions.
+   We provide this abbreviation to match arch-split expectations. *)
+abbreviation (input) maxIRQ :: irq where
+  "maxIRQ \<equiv> Platform.X64.maxIRQ"
 
 end (* context X64 *)
 

--- a/spec/design/skel/X64/RegisterSet_H.thy
+++ b/spec/design/skel/X64/RegisterSet_H.thy
@@ -11,7 +11,7 @@ imports
   "Lib.HaskellLib_H"
   MachineOps
 begin
-context Arch begin global_naming X64_H
+context Arch begin arch_global_naming (H)
 
 definition
   newContext :: "user_context"

--- a/spec/design/skel/X64/State_H.thy
+++ b/spec/design/skel/X64/State_H.thy
@@ -14,7 +14,7 @@ theory State_H
 imports
   RegisterSet_H
 begin
-context Arch begin global_naming X64_H
+context Arch begin arch_global_naming (H)
 
 definition
   Word :: "machine_word \<Rightarrow> machine_word"
@@ -26,16 +26,14 @@ where
 
 end
 
-context begin interpretation Arch .
-
-requalify_consts
+(* Note: while this requalify and arch-generic Haskell import of WordLib.lhs could be moved to
+   a generic theory, no good candidate theory exists at the moment. *)
+arch_requalify_consts (H)
   wordBits
-
-end
 
 #INCLUDE_HASKELL Data/WordLib.lhs all_bits NOT wordBits
 
-context Arch begin global_naming X64_H
+context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Machine/RegisterSet.lhs Arch=X64 CONTEXT X64_H all_bits NOT UserContext UserMonad getRegister setRegister newContext mask Word PPtr
 

--- a/spec/machine/MachineExports.thy
+++ b/spec/machine/MachineExports.thy
@@ -16,6 +16,8 @@ arch_requalify_types
   vmfault_type
   hyp_fault_type
   irq
+  user_monad
+  user_context
 
 arch_requalify_consts
   getActiveIRQ
@@ -39,6 +41,11 @@ arch_requalify_consts
   clearMemory
   non_kernel_IRQs
   tlsBaseRegister
+  debugPrint
+  configureTimer
+  initL2Cache
+  ptrFromPAddr
+  pageBits
 
 (* HERE IS THE PLACE FOR GENERIC WORD LEMMAS FOR ALL ARCHITECTURES *)
 


### PR DESCRIPTION
The adventure continues, this time deploying `arch_requalify` and `arch_global_naming` to the design spec skeleton files.
Previously @corlewis benchmarked https://github.com/seL4/l4v/pull/805 as having 13-18% wall time improvement for ASpec, and 9-14% improvement for AInvs. This time I'm expecting only a bit of improvement in ExecSpec/BaseRefine/CBaseRefine, since only 52 cases of `context begin interpretation Arch .` were eliminated from the design spec in total.

🦆🦆🦆 I have split up the commits to be topical, which should make reviewing this easier, but it's a bit too much granularity to shove into l4v. Opinions welcome on how many commits we want this squashed to.

- [ ] still need to add FIXME arch_split to PR linter to stop people reintroducing it