### PR TITLE
verification for deferred cache flush in untyped reset

### DIFF
--- a/lib/Monad_Commute.thy
+++ b/lib/Monad_Commute.thy
@@ -140,6 +140,21 @@ lemma mapM_x_commute:
   apply auto
   done
 
+(* Proof needs to be different from mapM_x_commute, to eliminate "distinct" *)
+lemma mapM_x_commute_T:
+  assumes commute: "\<And>r. monad_commute \<top> (b r) a"
+  shows "monad_commute \<top> (mapM_x b xs) a"
+  apply (induct xs)
+   apply (clarsimp simp: mapM_x_Nil return_def bind_def monad_commute_def)
+  apply (clarsimp simp: mapM_x_Cons)
+  apply (rule monad_commute_guard_imp)
+   apply (rule commute_commute, rule monad_commute_split)
+     apply (rule commute_commute, assumption)
+    apply (rule commute_commute, rule commute)
+   apply wp
+  apply clarsimp
+  done
+
 lemma commute_name_pre_state:
   assumes "\<And>s. P s \<Longrightarrow> monad_commute ((=) s) f g"
   shows "monad_commute P f g"

--- a/proof/access-control/DomainSepInv.thy
+++ b/proof/access-control/DomainSepInv.thy
@@ -315,7 +315,7 @@ locale DomainSepInv_1 =
   and arch_post_cap_deletion_domain_sep_inv[wp]:
     "arch_post_cap_deletion acap \<lbrace>\<lambda>s :: det_ext state. domain_sep_inv irqs st s\<rbrace>"
   and init_arch_objects_domain_sep_inv[wp]:
-    "init_arch_objects typ ptr n sz refs \<lbrace>\<lambda>s :: det_ext state. domain_sep_inv irqs st s\<rbrace>"
+    "init_arch_objects typ dev ptr n sz refs \<lbrace>\<lambda>s :: det_ext state. domain_sep_inv irqs st s\<rbrace>"
   and prepare_thread_delete_domain_sep_inv[wp]:
     "prepare_thread_delete t \<lbrace>\<lambda>s :: det_ext state. domain_sep_inv irqs st s\<rbrace>"
   and arch_finalise_cap_rv:

--- a/proof/access-control/RISCV64/ArchRetype_AC.thy
+++ b/proof/access-control/RISCV64/ArchRetype_AC.thy
@@ -250,7 +250,7 @@ crunch delete_objects
   (ignore: do_machine_op freeMemory)
 
 lemma init_arch_objects_pas_cur_domain[Retype_AC_assms, wp]:
-  "init_arch_objects tp ptr n us refs \<lbrace>pas_cur_domain aag\<rbrace>"
+  "init_arch_objects tp dev ptr n us refs \<lbrace>pas_cur_domain aag\<rbrace>"
   by wp
 
 lemma retype_region_pas_cur_domain[Retype_AC_assms, wp]:

--- a/proof/access-control/Retype_AC.thy
+++ b/proof/access-control/Retype_AC.thy
@@ -184,15 +184,15 @@ locale Retype_AC_1 =
     "\<And>tp. is_aligned p (obj_bits_api (ArchObject tp) n)
            \<Longrightarrow> aobj_ref' (arch_default_cap tp p n dev) \<subseteq> ptr_range p (obj_bits_api (ArchObject tp) n)"
   and init_arch_objects_pas_refined:
-    "\<And>tp. \<lbrace>pas_refined aag and post_retype_invs tp refs
+    "\<And>tp dev. \<lbrace>pas_refined aag and post_retype_invs tp refs
                             and (\<lambda>s. \<forall>x\<in>set refs. x \<notin> global_refs s)
                             and K (\<forall>ref \<in> set refs. is_aligned ref (obj_bits_api tp obj_sz))\<rbrace>
-           init_arch_objects tp ptr bits obj_sz refs
-           \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
+               init_arch_objects tp dev ptr bits obj_sz refs
+               \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   and dmo_freeMemory_invs:
     "do_machine_op (freeMemory ptr bits) \<lbrace>\<lambda>s :: det_ext state. invs s\<rbrace>"
   and init_arch_objects_pas_cur_domain[wp]:
-    "\<And>tp. init_arch_objects tp ptr n us refs \<lbrace>pas_cur_domain aag\<rbrace>"
+    "\<And>tp dev. init_arch_objects tp dev ptr n us refs \<lbrace>pas_cur_domain aag\<rbrace>"
   and retype_region_pas_cur_domain[wp]:
     "\<And>tp. retype_region ptr n us tp dev \<lbrace>pas_cur_domain aag\<rbrace>"
   and reset_untyped_cap_pas_cur_domain[wp]:
@@ -222,7 +222,7 @@ locale Retype_AC_1 =
   and init_arch_objects_integrity:
     "\<lbrace>integrity aag X st and K (\<forall>x\<in>set refs. is_subject aag x)
                          and K (\<forall>ref \<in> set refs. is_aligned ref (obj_bits_api new_type obj_sz))\<rbrace>
-     init_arch_objects new_type ptr num_objects obj_sz refs
+     init_arch_objects new_type dev ptr num_objects obj_sz refs
      \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   and integrity_asids_detype:
     "\<forall>r \<in> R. pasObjectAbs aag r \<in> subjects

--- a/proof/access-control/Syscall_AC.thy
+++ b/proof/access-control/Syscall_AC.thy
@@ -504,7 +504,7 @@ locale Syscall_AC_1 =
   and handle_reserved_irq_arch_state[wp]:
     "\<And>P. handle_reserved_irq irq \<lbrace>\<lambda>s :: det_ext state. P (arch_state s)\<rbrace>"
   and init_arch_objects_arch_state[wp]:
-    "\<And>P. init_arch_objects new_type ptr n sz refs \<lbrace>\<lambda>s :: det_ext state. P (arch_state s)\<rbrace>"
+    "\<And>P. init_arch_objects new_type dev ptr n sz refs \<lbrace>\<lambda>s :: det_ext state. P (arch_state s)\<rbrace>"
   and getActiveIRQ_inv:
     "\<And>P. \<forall>f s. P s \<longrightarrow> P (irq_state_update f s)
           \<Longrightarrow> \<lbrace>P\<rbrace> getActiveIRQ in_kernel \<lbrace>\<lambda>rv. P\<rbrace>"

--- a/proof/crefine/AARCH64/Invoke_C.thy
+++ b/proof/crefine/AARCH64/Invoke_C.thy
@@ -1649,43 +1649,34 @@ lemma clearMemory_untyped_ccorres:
   apply (cinit' lift: bits_' ptr___ptr_to_unsigned_long_')
    apply (rule_tac P="ptr \<noteq> 0 \<and> sz < word_bits" in ccorres_gen_asm)
    apply (simp add: clearMemory_def)
-   apply (simp add: doMachineOp_bind storeWord_empty_fail)
-   apply (rule ccorres_split_nothrow_novcg_dc)
-      apply (rule_tac P="?P" and P'="{s. region_actually_is_bytes ptr (2 ^ sz) s}" in ccorres_from_vcg)
-      apply (rule allI, rule conseqPre, vcg)
-      apply clarsimp
-      apply (rule conjI; clarsimp)
-       apply (simp add: word_less_nat_alt unat_of_nat word_bits_def)
-      apply (clarsimp simp: isCap_simps valid_cap'_def capAligned_def
-                            is_aligned_no_wrap'[OF _ word64_power_less_1]
-                            unat_of_nat_eq word_bits_def)
-      apply (simp add: is_aligned_weaken is_aligned_triv[THEN is_aligned_weaken])
-      apply (clarsimp simp: ghost_assertion_size_logic[unfolded o_def] region_actually_is_bytes_dom_s)
-      apply (clarsimp simp: field_simps word_size_def mapM_x_storeWord_step
-                            word_bits_def cte_wp_at_ctes_of)
-      apply (frule ctes_of_valid', clarify+)
-      apply (simp add: doMachineOp_def split_def exec_gets)
-      apply (simp add: select_f_def simpler_modify_def bind_def valid_cap_simps' capAligned_def)
-      apply (subst pspace_no_overlap_underlying_zero_update; simp?)
-       apply (case_tac sz, simp_all)[1]
-       apply (case_tac nat, simp_all)[1]
-       apply (case_tac nata, simp_all)[1]
-      apply (clarsimp dest!: region_actually_is_bytes)
-      apply (drule(1) rf_sr_rep0)
-      apply (clarsimp simp: rf_sr_def cstate_relation_def Let_def
-                            carch_state_relation_def cmachine_state_relation_def)
-     apply csymbr
-     apply (ctac add: cleanCacheRange_RAM_ccorres)
-    apply wp
-   apply (simp add: guard_is_UNIV_def unat_of_nat
-                    word_bits_def capAligned_def word_of_nat_less)
+   apply (rule_tac P="?P" and P'="{s. region_actually_is_bytes ptr (2 ^ sz) s}" in ccorres_from_vcg)
+   apply (rule allI, rule conseqPre, vcg)
+   apply clarsimp
+   apply (rule conjI; clarsimp)
+    apply (simp add: word_less_nat_alt unat_of_nat word_bits_def)
+   apply (clarsimp simp: isCap_simps valid_cap'_def capAligned_def
+                         is_aligned_no_wrap'[OF _ word64_power_less_1]
+                         unat_of_nat_eq word_bits_def)
+   apply (simp add: is_aligned_weaken is_aligned_triv[THEN is_aligned_weaken])
+   apply (clarsimp simp: ghost_assertion_size_logic[unfolded o_def] region_actually_is_bytes_dom_s)
+   apply (clarsimp simp: field_simps word_size_def mapM_x_storeWord_step
+                         word_bits_def cte_wp_at_ctes_of)
+   apply (frule ctes_of_valid', clarify+)
+   apply (simp add: doMachineOp_def split_def exec_gets)
+   apply (simp add: select_f_def simpler_modify_def bind_def valid_cap_simps' capAligned_def)
+   apply (subst pspace_no_overlap_underlying_zero_update; simp?)
+    apply (case_tac sz, simp_all)[1]
+    apply (case_tac nat, simp_all)[1]
+    apply (case_tac nata, simp_all)[1]
+   apply (clarsimp dest!: region_actually_is_bytes)
+   apply (drule(1) rf_sr_rep0)
+   apply (clarsimp simp: rf_sr_def cstate_relation_def Let_def
+                         carch_state_relation_def cmachine_state_relation_def)
   apply (clarsimp simp: cte_wp_at_ctes_of)
   apply (frule ctes_of_valid'; clarify?)
   apply (clarsimp simp: isCap_simps valid_cap_simps' capAligned_def
                         word_of_nat_less Kernel_Config.resetChunkBits_def
                         word_bits_def unat_2p_sub_1)
-  apply (strengthen is_aligned_no_wrap'[where sz=sz] is_aligned_addrFromPPtr_n)+
-  apply (simp add: addrFromPPtr_mask_cacheLineBits pptrBaseOffset_alignment_def)
   apply (cases "ptr = 0"; simp)
   apply (drule subsetD, rule intvl_self, simp)
   apply simp

--- a/proof/crefine/AARCH64/Machine_C.thy
+++ b/proof/crefine/AARCH64/Machine_C.thy
@@ -199,6 +199,13 @@ assumes cleanCacheRange_RAM_preserves_kernel_bytes:
           \<and> (\<forall>x. snd (hrs_htd (t_hrs_' (globals s)) x) 0 \<noteq> None
                  \<longrightarrow> hrs_mem (t_hrs_' (globals t)) x = hrs_mem (t_hrs_' (globals s)) x)}"
 
+assumes cleanCacheRange_PoU_preserves_kernel_bytes:
+  "\<forall>s. \<Gamma>\<turnstile>\<^bsub>/UNIV\<^esub> {s} Call cleanCacheRange_PoU_'proc
+       {t. hrs_htd (t_hrs_' (globals t)) = hrs_htd (t_hrs_' (globals s))
+           \<and> (\<forall>x. snd (hrs_htd (t_hrs_' (globals s)) x) 0 \<noteq> None
+                  \<longrightarrow> hrs_mem (t_hrs_' (globals t)) x = hrs_mem (t_hrs_' (globals s)) x)}"
+
+
 (* Hypervisor-related machine ops *)
 
 (* ARM Hypervisor hardware register getters and setters *)

--- a/proof/crefine/AARCH64/Recycle_C.thy
+++ b/proof/crefine/AARCH64/Recycle_C.thy
@@ -252,8 +252,6 @@ lemma range_cover_nca_neg: "\<And>x p (off :: 9 word).
   apply (simp add: pageBits_def objBits_simps)
   done
 
-lemmas unat_of_nat32' = unat_of_nat_eq[where 'a=32]
-
 lemma clearMemory_PageCap_ccorres:
   "ccorres dc xfdc (invs' and valid_cap' (ArchObjectCap (FrameCap ptr undefined sz False None))
            and (\<lambda>s. 2 ^ pageBitsForSize sz \<le> gsMaxObjectSize s)
@@ -268,30 +266,27 @@ lemma clearMemory_PageCap_ccorres:
   apply (cinit' lift: bits_' ptr___ptr_to_unsigned_long_')
    apply (rule_tac P="capAligned (ArchObjectCap (FrameCap ptr undefined sz False None))"
                 in ccorres_gen_asm)
-   apply (rule ccorres_Guard_Seq)
+   apply (rule ccorres_Guard)
    apply (simp add: clearMemory_def)
-   apply (simp add: doMachineOp_bind)
-   apply (rule ccorres_split_nothrow_novcg_dc)
-      apply (rule_tac P="?P" in ccorres_from_vcg[where P'=UNIV])
-      apply (rule allI, rule conseqPre, vcg)
-      apply (clarsimp simp: valid_cap'_def capAligned_def
-                            is_aligned_no_wrap'[OF _ word64_power_less_1])
-      apply (prop_tac "ptr \<noteq> 0")
-       subgoal
-         apply (simp add: frame_at'_def)
-         apply (drule_tac x=0 in spec)
-         apply (clarsimp simp: pageBitsForSize_def bit_simps split: vmpage_size.splits)
-         done
-      apply simp
-      apply (prop_tac "3 \<le> pageBitsForSize sz")
-       apply (simp add: pageBitsForSize_def bit_simps split: vmpage_size.split)
-      apply (rule conjI)
-       apply (erule is_aligned_weaken)
-       apply (clarsimp simp: pageBitsForSize_def split: vmpage_size.splits)
-      apply (rule conjI)
-       apply (rule is_aligned_power2)
-       apply (clarsimp simp: pageBitsForSize_def split: vmpage_size.splits)
-      apply (clarsimp simp: ghost_assertion_size_logic[unfolded o_def])
+   apply (rule_tac P="?P" in ccorres_from_vcg[where P'=UNIV])
+   apply (rule allI, rule conseqPre, vcg)
+   apply (clarsimp simp: valid_cap'_def capAligned_def
+                         is_aligned_no_wrap'[OF _ word64_power_less_1])
+   apply (prop_tac "ptr \<noteq> 0")
+    subgoal
+      apply (simp add: frame_at'_def)
+      apply (drule_tac x=0 in spec)
+      apply (clarsimp simp: pageBitsForSize_def bit_simps split: vmpage_size.splits)
+      done
+   apply simp
+   apply (prop_tac "3 \<le> pageBitsForSize sz")
+    apply (simp add: pageBitsForSize_def bit_simps split: vmpage_size.split)
+   apply (rule conjI)
+    apply (erule is_aligned_weaken)
+    apply (clarsimp simp: pageBitsForSize_def split: vmpage_size.splits)
+   apply (rule conjI)
+    apply (rule is_aligned_power2)
+    apply (clarsimp simp: pageBitsForSize_def split: vmpage_size.splits)
    apply (clarsimp simp: ghost_assertion_size_logic[unfolded o_def] frame_at'_def)
    apply (simp add: flex_user_data_at_rf_sr_dom_s bit_simps)
    apply (clarsimp simp: field_simps word_size_def mapM_x_storeWord_step)
@@ -308,7 +303,7 @@ lemma clearMemory_PageCap_ccorres:
     apply (erule allfEI[where f=of_nat])
     apply (clarsimp simp: bit_simps)
     apply (subst(asm) of_nat_power, assumption)
-    apply simp
+     apply simp
      apply (insert pageBitsForSize_64 [of sz])[1]
      apply (erule order_le_less_trans [rotated])
      apply simp
@@ -376,19 +371,8 @@ lemma clearMemory_PageCap_ccorres:
     apply (simp add: bit_simps)
     apply (simp add: of_nat_power[where 'a=64, folded word_bits_def])
     apply (simp add: pageBits_def ko_at_projectKO_opt[OF user_data_at_ko])
-   (* FIXME AARCH64 indentation *)
    apply (rule inj_Ptr)
-     apply csymbr
-     apply (ctac add: cleanCacheRange_RAM_ccorres)
-    apply wp
-   apply (simp add: guard_is_UNIV_def unat_of_nat
-                    word_bits_def capAligned_def word_of_nat_less)
-  apply (clarsimp simp: word_bits_def valid_cap'_def
-                        capAligned_def word_of_nat_less)
-  apply (frule is_aligned_addrFromPPtr_n, simp add: pageBitsForSize_def split: vmpage_size.splits)
-  apply (simp add: bit_simps pptrBaseOffset_alignment_def)+
-  apply (simp add: is_aligned_no_overflow' addrFromPPtr_mask_cacheLineBits)
-  apply (simp add: pageBitsForSize_def bit_simps split: vmpage_size.splits)
+  apply (clarsimp simp: word_bits_def valid_cap'_def capAligned_def word_of_nat_less)
   done
 
 declare replicate_numeral [simp]

--- a/proof/crefine/ARM/Invoke_C.thy
+++ b/proof/crefine/ARM/Invoke_C.thy
@@ -1517,45 +1517,37 @@ lemma clearMemory_untyped_ccorres:
   apply (cinit' lift: bits_' ptr___ptr_to_unsigned_long_')
    apply (rule_tac P="ptr \<noteq> 0 \<and> sz < word_bits"
                 in ccorres_gen_asm)
-   apply (rule ccorres_Guard_Seq)
+   apply (rule ccorres_Guard)
    apply (simp add: clearMemory_def)
-   apply (simp add: doMachineOp_bind ef_storeWord)
-   apply (rule ccorres_split_nothrow_novcg_dc)
-      apply (rule_tac P="?P" and P'="{s. region_actually_is_bytes ptr (2 ^ sz) s}"
-         in ccorres_from_vcg)
-      apply (rule allI, rule conseqPre, vcg)
-      apply clarsimp
-      apply (clarsimp simp: isCap_simps valid_cap'_def capAligned_def
-                            is_aligned_no_wrap'[OF _ word32_power_less_1]
-                            unat_of_nat_eq word_bits_def)
-      apply (simp add: is_aligned_weaken is_aligned_triv[THEN is_aligned_weaken])
-      apply (clarsimp simp: ghost_assertion_size_logic[unfolded o_def]
-                            region_actually_is_bytes_dom_s)
-      apply (clarsimp simp: field_simps word_size_def mapM_x_storeWord_step
-                            word_bits_def cte_wp_at_ctes_of)
-      apply (frule ctes_of_valid', clarify+)
-      apply (simp add: doMachineOp_def split_def exec_gets)
-      apply (simp add: select_f_def simpler_modify_def bind_def
-                       valid_cap_simps' capAligned_def)
-      apply (subst pspace_no_overlap_underlying_zero_update, simp+)
-       apply (case_tac sz, simp_all)[1]
-       apply (case_tac nat, simp_all)[1]
-      apply (clarsimp dest!: region_actually_is_bytes)
-      apply (drule(1) rf_sr_rep0)
-      apply (clarsimp simp: rf_sr_def cstate_relation_def Let_def
-                            carch_state_relation_def cmachine_state_relation_def)
-     apply csymbr
-     apply (ctac add: cleanCacheRange_RAM_ccorres)
-    apply wp
-   apply (simp add: guard_is_UNIV_def unat_of_nat
-                    word_bits_def capAligned_def word_of_nat_less)
+   apply (rule_tac P="?P" and P'="{s. region_actually_is_bytes ptr (2 ^ sz) s}" in ccorres_from_vcg)
+   apply (rule allI, rule conseqPre, vcg)
+   apply clarsimp
+   apply (clarsimp simp: isCap_simps valid_cap'_def capAligned_def
+                         is_aligned_no_wrap'[OF _ word32_power_less_1]
+                         unat_of_nat_eq word_bits_def)
+   apply (simp add: is_aligned_weaken is_aligned_triv[THEN is_aligned_weaken])
+   apply (clarsimp simp: ghost_assertion_size_logic[unfolded o_def]
+                         region_actually_is_bytes_dom_s)
+   apply (clarsimp simp: field_simps word_size_def mapM_x_storeWord_step
+                         word_bits_def cte_wp_at_ctes_of)
+   apply (frule ctes_of_valid', clarify+)
+   apply (simp add: doMachineOp_def split_def exec_gets)
+   apply (simp add: select_f_def simpler_modify_def bind_def
+                    valid_cap_simps' capAligned_def)
+   apply (subst pspace_no_overlap_underlying_zero_update, simp+)
+    apply (case_tac sz, simp_all)[1]
+    apply (case_tac nat, simp_all)[1]
+   apply (clarsimp dest!: region_actually_is_bytes)
+   apply (drule(1) rf_sr_rep0)
+   apply (clarsimp simp: rf_sr_def cstate_relation_def Let_def
+                         carch_state_relation_def cmachine_state_relation_def)
+  apply (simp add: guard_is_UNIV_def unat_of_nat
+                   word_bits_def capAligned_def word_of_nat_less)
   apply (clarsimp simp: cte_wp_at_ctes_of)
   apply (frule ctes_of_valid', clarify+)
   apply (clarsimp simp: isCap_simps valid_cap_simps' capAligned_def
                         word_of_nat_less Kernel_Config.resetChunkBits_def
                         word_bits_def unat_2p_sub_1)
-  apply (strengthen is_aligned_no_wrap'[where sz=sz] is_aligned_addrFromPPtr_n)+
-  apply simp
   apply (cases "ptr = 0")
    apply (drule subsetD, rule intvl_self, simp)
    apply (simp split: if_split_asm)

--- a/proof/crefine/ARM/Retype_C.thy
+++ b/proof/crefine/ARM/Retype_C.thy
@@ -4533,6 +4533,40 @@ lemma cond_second_eq_seq_ccorres:
   apply (auto elim!: exec_Normal_elim_cases intro: exec.Seq exec.CondTrue exec.CondFalse)
   done
 
+lemma placeNewDataObject_dev_ccorres:
+  "ccorresG rf_sr \<Gamma> dc xfdc
+  (createObject_hs_preconds regionBase newType us True
+      and K (APIType_capBits newType us = pageBits + us))
+  ({s. region_actually_is_bytes regionBase (2 ^ (pageBits + us)) s})
+  hs
+  (placeNewDataObject regionBase us True)
+  (global_htd_update (\<lambda>s. (ptr_retyps (2^us) (Ptr regionBase :: user_data_device_C ptr))))"
+  apply (simp add: placeNewDataObject_def ccorres_cond_univ_iff)
+  apply (rule ccorres_guard_imp, rule placeNewObject_user_data_device, simp_all)
+  apply (clarsimp simp: createObject_hs_preconds_def invs'_def
+                        valid_state'_def valid_pspace'_def)
+  done
+
+lemma placeNewDataObject_no_dev_ccorres:
+  "ccorresG rf_sr \<Gamma> dc xfdc
+  (createObject_hs_preconds regionBase newType us False
+      and K (APIType_capBits newType us = pageBits + us))
+  ({s. region_actually_is_bytes regionBase (2 ^ (pageBits + us)) s
+      \<and> (heap_list_is_zero (hrs_mem (t_hrs_' (globals s))) regionBase (2 ^ (pageBits + us)))})
+  hs
+  (placeNewDataObject regionBase us False)
+  (global_htd_update (\<lambda>s. (ptr_retyps (2^us) (Ptr regionBase :: user_data_C ptr))))"
+  apply (simp add: placeNewDataObject_def ccorres_cond_empty_iff)
+  apply (rule ccorres_guard_imp, rule placeNewObject_user_data, simp_all)
+  apply (clarsimp simp: createObject_hs_preconds_def invs'_def
+                        valid_state'_def valid_pspace'_def)
+  apply (frule range_cover.sz(1), simp add: word_bits_def)
+  done
+
+crunch placeNewDataObject
+  for gsMaxObjectSize[wp]: "\<lambda>s. P (gsMaxObjectSize s)"
+  (simp: crunch_simps)
+
 lemma Arch_createObject_ccorres:
   assumes t: "toAPIType newType = None"
   shows "ccorres (\<lambda>a b. ccap_relation (ArchObjectCap a) b) ret__struct_cap_C_'
@@ -4552,179 +4586,284 @@ proof -
     apply (frule range_cover.aligned)
     apply (cut_tac t)
     apply (case_tac newType,
-           simp_all add: toAPIType_def
-               bind_assoc
-               ARMLargePageBits_def)
+           simp_all add: toAPIType_def bind_assoc ARMLargePageBits_def)
 
+         apply (in_case "SmallPageObject")
          apply (cinit' lift: t_' regionBase_' userSize_' deviceMemory_')
           apply (simp add: object_type_from_H_def Kernel_C_defs)
           apply (simp add: ccorres_cond_univ_iff ccorres_cond_empty_iff
-                      ARMLargePageBits_def ARMSmallPageBits_def
-                      ARMSectionBits_def ARMSuperSectionBits_def asidInvalid_def
-                      sle_positive APIType_capBits_def shiftL_nat objBits_simps
-                      ptBits_def archObjSize_def pageBits_def word_sle_def word_sless_def
-                      fold_eq_0_to_bool)
-          apply (ccorres_remove_UNIV_guard)
-          apply (clarsimp simp: hrs_htd_update ptBits_def objBits_simps archObjSize_def
-            ARM_H.createObject_def pageBits_def
-            cond_second_eq_seq_ccorres modify_gsUserPages_update
-            intro!: ccorres_rhs_assoc)
-          apply ((rule ccorres_return_C | simp | wp | vcg
-            | (rule match_ccorres, ctac add:
-                    placeNewDataObject_ccorres[where us=0 and newType=newType, simplified]
-                    gsUserPages_update_ccorres[folded modify_gsUserPages_update])
-            | (rule match_ccorres, csymbr))+)[1]
-         apply (intro conjI)
-          apply (clarsimp simp: createObject_hs_preconds_def
-                                APIType_capBits_def pageBits_def)
-         apply (clarsimp simp: pageBits_def ccap_relation_def APIType_capBits_def
-                    framesize_to_H_def cap_to_H_simps cap_small_frame_cap_lift
-                    vmrights_to_H_def mask_def vm_rights_defs)
+                           asidInvalid_def APIType_capBits_def shiftL_nat objBits_simps
+                           ptBits_def pageBits_def word_sle_def word_sless_def fold_eq_0_to_bool)
+          apply (clarsimp simp: hrs_htd_update ptBits_def objBits_simps
+                                ARM_H.createObject_def pageBits_def
+                                cond_second_eq_seq_ccorres modify_gsUserPages_update
+                          intro!: ccorres_rhs_assoc)
+          apply (rule ccorres_cases[where P=deviceMemory])
+           apply clarsimp
+           apply (rule ccorres_rhs_assoc)+
+           apply (rule ccorres_split_nothrow_novcg)
+               apply (rule placeNewDataObject_dev_ccorres[where us=0 and newType=newType, simplified])
+              apply ceqv
+             apply  (ctac (no_vcg) add: gsUserPages_update_ccorres[folded modify_gsUserPages_update])
+               apply ccorres_rewrite
+               apply csymbr
+               apply (rule ccorres_return_C; simp)
+              apply wp
+              apply (clarsimp simp: pageBits_def ccap_relation_def APIType_capBits_def
+                                    framesize_to_H_def cap_to_H_simps cap_small_frame_cap_lift
+                                    vmrights_to_H_def vm_rights_defs,
+                     simp add: mask_def)
+            apply wp
+           apply (simp add: guard_is_UNIV_def)
+          apply clarsimp
+          apply (rule ccorres_rhs_assoc)+
+          apply (rule ccorres_split_nothrow_novcg)
+              apply (rule placeNewDataObject_no_dev_ccorres[where us=0 and newType=newType, simplified])
+             apply ceqv
+            apply  (ctac (no_vcg) add: gsUserPages_update_ccorres[folded modify_gsUserPages_update])
+              apply csymbr+
+              apply (rule ccorres_Guard_Seq)
+              apply (ctac (no_vcg) add: cleanCacheRange_RAM_ccorres)
+               apply ccorres_rewrite
+               apply csymbr
+               apply (rule ccorres_return_C; simp)
+              apply wp
+             apply wp
+            apply (clarsimp simp: pageBits_def ccap_relation_def APIType_capBits_def
+                                  framesize_to_H_def cap_to_H_simps cap_small_frame_cap_lift
+                                  vmrights_to_H_def vm_rights_defs gen_framesize_to_H_def
+                                  vm_page_size_defs)
+            apply (simp add: mask_def)
+           apply wpsimp
+          apply (simp add: guard_is_UNIV_def)
+         apply (clarsimp simp: createObject_hs_preconds_def frameSizeConstants_defs
+                               APIType_capBits_def pageBits_def is_aligned_no_overflow_mask)
+         apply (rule conjI)
+          apply (drule is_aligned_addrFromPPtr_n, simp)
+          apply (simp add: is_aligned_no_overflow_mask)
+         apply (simp add: mask_def)
 
-        \<comment> \<open>Page objects: could possibly fix the duplication here\<close>
+        apply (in_case "LargePageObject")
         apply (cinit' lift: t_' regionBase_' userSize_' deviceMemory_')
          apply (simp add: object_type_from_H_def Kernel_C_defs)
          apply (simp add: ccorres_cond_univ_iff ccorres_cond_empty_iff
-                     ARMLargePageBits_def ARMSmallPageBits_def
-                     ARMSectionBits_def ARMSuperSectionBits_def asidInvalid_def
-                     sle_positive APIType_capBits_def shiftL_nat objBits_simps
-                     ptBits_def archObjSize_def pageBits_def word_sle_def word_sless_def
-                     fold_eq_0_to_bool)
-         apply (ccorres_remove_UNIV_guard)
-         apply (clarsimp simp: hrs_htd_update ptBits_def objBits_simps archObjSize_def
-           ARM_H.createObject_def pageBits_def
-           cond_second_eq_seq_ccorres modify_gsUserPages_update
-           intro!: ccorres_rhs_assoc)
-         apply ((rule ccorres_return_C | simp | wp | vcg
-           | (rule match_ccorres, ctac add:
-                   placeNewDataObject_ccorres[where us=4 and newType=newType, simplified]
-                   gsUserPages_update_ccorres[folded modify_gsUserPages_update])
-           | (rule match_ccorres, csymbr))+)[1]
-        apply (intro conjI)
-         apply (clarsimp simp: createObject_hs_preconds_def
-                               APIType_capBits_def pageBits_def)
-        apply (clarsimp simp: pageBits_def ccap_relation_def APIType_capBits_def
-                   framesize_to_H_def cap_to_H_simps cap_frame_cap_lift
-                   vmrights_to_H_def mask_def vm_rights_defs vm_page_size_defs
-                   cl_valid_cap_def c_valid_cap_def
-                   is_aligned_neg_mask_eq_concrete[THEN sym])
+                          asidInvalid_def APIType_capBits_def shiftL_nat objBits_simps
+                          ptBits_def pageBits_def word_sle_def word_sless_def fold_eq_0_to_bool)
+         apply (clarsimp simp: hrs_htd_update ptBits_def objBits_simps
+                               ARM_H.createObject_def pageBits_def
+                               cond_second_eq_seq_ccorres modify_gsUserPages_update
+                         intro!: ccorres_rhs_assoc)
+         apply (rule ccorres_cases[where P=deviceMemory])
+          apply clarsimp
+          apply (rule ccorres_rhs_assoc)+
+          apply (rule ccorres_split_nothrow_novcg)
+              apply (rule placeNewDataObject_dev_ccorres[where us=4 and newType=newType, simplified])
+             apply ceqv
+            apply  (ctac (no_vcg) add: gsUserPages_update_ccorres[folded modify_gsUserPages_update])
+              apply ccorres_rewrite
+              apply csymbr
+              apply (rule ccorres_return_C; simp)
+             apply wp
+            apply (clarsimp simp: pageBits_def ccap_relation_def APIType_capBits_def
+                                  framesize_to_H_def cap_to_H_simps cap_frame_cap_lift
+                                  vmrights_to_H_def vm_rights_defs gen_framesize_to_H_def
+                                  is_aligned_neg_mask_eq_concrete[THEN sym]
+                                  vm_page_size_defs cl_valid_cap_def c_valid_cap_def mask_def)
+           apply wp
+          apply (simp add: guard_is_UNIV_def)
+         apply clarsimp
+         apply (rule ccorres_rhs_assoc)+
+         apply (rule ccorres_split_nothrow_novcg)
+             apply (rule placeNewDataObject_no_dev_ccorres[where us=4 and newType=newType, simplified])
+            apply ceqv
+           apply  (ctac (no_vcg) add: gsUserPages_update_ccorres[folded modify_gsUserPages_update])
+             apply csymbr+
+             apply (rule ccorres_Guard_Seq)
+             apply (ctac (no_vcg) add: cleanCacheRange_RAM_ccorres)
+              apply ccorres_rewrite
+              apply csymbr
+              apply (rule ccorres_return_C; simp)
+             apply wp
+            apply wp
+           apply (clarsimp simp: pageBits_def ccap_relation_def APIType_capBits_def
+                                 framesize_to_H_def cap_to_H_simps cap_frame_cap_lift
+                                 vmrights_to_H_def vm_rights_defs gen_framesize_to_H_def
+                                 is_aligned_neg_mask_eq_concrete[THEN sym]
+                                 vm_page_size_defs cl_valid_cap_def c_valid_cap_def mask_def)
+          apply wpsimp
+         apply (simp add: guard_is_UNIV_def)
+        apply (clarsimp simp: createObject_hs_preconds_def frameSizeConstants_defs
+                              APIType_capBits_def pageBits_def is_aligned_no_overflow_mask)
+        apply (rule conjI)
+         apply (drule is_aligned_addrFromPPtr_n, simp)
+         apply (simp add: is_aligned_no_overflow_mask)
+        apply (simp add: mask_def)
 
+       apply (in_case "SectionObject")
        apply (cinit' lift: t_' regionBase_' userSize_' deviceMemory_')
         apply (simp add: object_type_from_H_def Kernel_C_defs)
         apply (simp add: ccorres_cond_univ_iff ccorres_cond_empty_iff
-                    ARMLargePageBits_def ARMSmallPageBits_def
-                    ARMSectionBits_def ARMSuperSectionBits_def asidInvalid_def
-                    sle_positive APIType_capBits_def shiftL_nat objBits_simps
-                    ptBits_def archObjSize_def pageBits_def word_sle_def word_sless_def
-                    fold_eq_0_to_bool)
-        apply (ccorres_remove_UNIV_guard)
-        apply (clarsimp simp: hrs_htd_update ptBits_def objBits_simps archObjSize_def
-          ARM_H.createObject_def pageBits_def
-          cond_second_eq_seq_ccorres modify_gsUserPages_update
-          intro!: ccorres_rhs_assoc)
-        apply ((rule ccorres_return_C | simp | wp | vcg
-          | (rule match_ccorres, ctac add:
-                  placeNewDataObject_ccorres[where us=8 and newType=newType, simplified]
-                  gsUserPages_update_ccorres[folded modify_gsUserPages_update])
-          | (rule match_ccorres, csymbr))+)[1]
-       apply (intro conjI)
-        apply (clarsimp simp: createObject_hs_preconds_def
-                              APIType_capBits_def pageBits_def)
-       apply (clarsimp simp: pageBits_def ccap_relation_def APIType_capBits_def
-                  framesize_to_H_def cap_to_H_simps cap_frame_cap_lift
-                  vmrights_to_H_def mask_def vm_rights_defs vm_page_size_defs
-                  cl_valid_cap_def c_valid_cap_def
-                  is_aligned_neg_mask_eq_concrete[THEN sym])
+                        asidInvalid_def APIType_capBits_def shiftL_nat objBits_simps
+                        ptBits_def pageBits_def word_sle_def word_sless_def fold_eq_0_to_bool)
+        apply (clarsimp simp: hrs_htd_update ptBits_def objBits_simps
+                               ARM_H.createObject_def pageBits_def
+                               cond_second_eq_seq_ccorres modify_gsUserPages_update
+                        intro!: ccorres_rhs_assoc)
+        apply (rule ccorres_cases[where P=deviceMemory])
+         apply clarsimp
+         apply (rule ccorres_rhs_assoc)+
+         apply (rule ccorres_split_nothrow_novcg)
+             apply (rule placeNewDataObject_dev_ccorres[where us=8 and newType=newType, simplified])
+            apply ceqv
+           apply  (ctac (no_vcg) add: gsUserPages_update_ccorres[folded modify_gsUserPages_update])
+             apply ccorres_rewrite
+             apply csymbr
+             apply (rule ccorres_return_C; simp)
+            apply wp
+           apply (clarsimp simp: pageBits_def ccap_relation_def APIType_capBits_def
+                                 framesize_to_H_def cap_to_H_simps cap_frame_cap_lift
+                                 vmrights_to_H_def vm_rights_defs gen_framesize_to_H_def
+                                 is_aligned_neg_mask_eq_concrete[THEN sym]
+                                 vm_page_size_defs cl_valid_cap_def c_valid_cap_def mask_def)
+          apply wp
+         apply (simp add: guard_is_UNIV_def)
+        apply clarsimp
+        apply (rule ccorres_rhs_assoc)+
+        apply (rule ccorres_split_nothrow_novcg)
+            apply (rule placeNewDataObject_no_dev_ccorres[where us=8 and newType=newType, simplified])
+           apply ceqv
+          apply  (ctac (no_vcg) add: gsUserPages_update_ccorres[folded modify_gsUserPages_update])
+            apply csymbr+
+            apply (rule ccorres_Guard_Seq)
+            apply (ctac (no_vcg) add: cleanCacheRange_RAM_ccorres)
+             apply ccorres_rewrite
+             apply csymbr
+             apply (rule ccorres_return_C; simp)
+            apply wp
+           apply wp
+          apply (clarsimp simp: pageBits_def ccap_relation_def APIType_capBits_def
+                                framesize_to_H_def cap_to_H_simps cap_frame_cap_lift
+                                vmrights_to_H_def vm_rights_defs gen_framesize_to_H_def
+                                is_aligned_neg_mask_eq_concrete[THEN sym]
+                                vm_page_size_defs cl_valid_cap_def c_valid_cap_def mask_def)
+         apply wpsimp
+        apply (simp add: guard_is_UNIV_def)
+       apply (clarsimp simp: createObject_hs_preconds_def frameSizeConstants_defs
+                             APIType_capBits_def pageBits_def is_aligned_no_overflow_mask)
+       apply (rule conjI)
+        apply (drule is_aligned_addrFromPPtr_n, simp)
+        apply (simp add: is_aligned_no_overflow_mask)
+       apply (simp add: mask_def)
 
+      apply (in_case "SuperSectionObject")
       apply (cinit' lift: t_' regionBase_' userSize_' deviceMemory_')
        apply (simp add: object_type_from_H_def Kernel_C_defs)
        apply (simp add: ccorres_cond_univ_iff ccorres_cond_empty_iff
-                   ARMLargePageBits_def ARMSmallPageBits_def
-                   ARMSectionBits_def ARMSuperSectionBits_def asidInvalid_def
-                   sle_positive APIType_capBits_def shiftL_nat objBits_simps
-                   ptBits_def archObjSize_def pageBits_def word_sle_def word_sless_def
-                   fold_eq_0_to_bool)
-       apply (ccorres_remove_UNIV_guard)
-       apply (clarsimp simp: hrs_htd_update ptBits_def objBits_simps archObjSize_def
-         ARM_H.createObject_def pageBits_def
-         cond_second_eq_seq_ccorres modify_gsUserPages_update
-         intro!: ccorres_rhs_assoc)
-       apply ((rule ccorres_return_C | simp | wp | vcg
-         | (rule match_ccorres, ctac add:
-                 placeNewDataObject_ccorres[where us=12 and newType=newType, simplified]
-                 gsUserPages_update_ccorres[folded modify_gsUserPages_update])
-         | (rule match_ccorres, csymbr))+)[1]
-      apply (intro conjI)
-       apply (clarsimp simp: createObject_hs_preconds_def
-                             APIType_capBits_def pageBits_def)
-      apply (clarsimp simp: pageBits_def ccap_relation_def APIType_capBits_def
-                 framesize_to_H_def cap_to_H_simps cap_frame_cap_lift
-                 vmrights_to_H_def mask_def vm_rights_defs vm_page_size_defs
-                 cl_valid_cap_def c_valid_cap_def
-                 is_aligned_neg_mask_eq_concrete[THEN sym])
+                         asidInvalid_def APIType_capBits_def shiftL_nat objBits_simps
+                         ptBits_def pageBits_def word_sle_def word_sless_def fold_eq_0_to_bool)
+       apply (clarsimp simp: hrs_htd_update ptBits_def objBits_simps
+                              ARM_H.createObject_def pageBits_def
+                              cond_second_eq_seq_ccorres modify_gsUserPages_update
+                       intro!: ccorres_rhs_assoc)
+       apply (rule ccorres_cases[where P=deviceMemory])
+        apply clarsimp
+        apply (rule ccorres_rhs_assoc)+
+        apply (rule ccorres_split_nothrow_novcg)
+            apply (rule placeNewDataObject_dev_ccorres[where us=12 and newType=newType, simplified])
+           apply ceqv
+          apply  (ctac (no_vcg) add: gsUserPages_update_ccorres[folded modify_gsUserPages_update])
+            apply ccorres_rewrite
+            apply csymbr
+            apply (rule ccorres_return_C; simp)
+           apply wp
+          apply (clarsimp simp: pageBits_def ccap_relation_def APIType_capBits_def
+                                framesize_to_H_def cap_to_H_simps cap_frame_cap_lift
+                                vmrights_to_H_def vm_rights_defs gen_framesize_to_H_def
+                                is_aligned_neg_mask_eq_concrete[THEN sym]
+                                vm_page_size_defs cl_valid_cap_def c_valid_cap_def mask_def)
+         apply wp
+        apply (simp add: guard_is_UNIV_def)
+       apply clarsimp
+       apply (rule ccorres_rhs_assoc)+
+       apply (rule ccorres_split_nothrow_novcg)
+           apply (rule placeNewDataObject_no_dev_ccorres[where us=12 and newType=newType, simplified])
+          apply ceqv
+         apply  (ctac (no_vcg) add: gsUserPages_update_ccorres[folded modify_gsUserPages_update])
+           apply csymbr+
+           apply (rule ccorres_Guard_Seq)
+           apply (ctac (no_vcg) add: cleanCacheRange_RAM_ccorres)
+            apply ccorres_rewrite
+            apply csymbr
+            apply (rule ccorres_return_C; simp)
+           apply wp
+          apply wp
+         apply (clarsimp simp: pageBits_def ccap_relation_def APIType_capBits_def
+                               framesize_to_H_def cap_to_H_simps cap_frame_cap_lift
+                               vmrights_to_H_def vm_rights_defs gen_framesize_to_H_def
+                               is_aligned_neg_mask_eq_concrete[THEN sym]
+                               vm_page_size_defs cl_valid_cap_def c_valid_cap_def mask_def)
+        apply wpsimp
+       apply (simp add: guard_is_UNIV_def)
+      apply (clarsimp simp: createObject_hs_preconds_def frameSizeConstants_defs
+                            APIType_capBits_def pageBits_def is_aligned_no_overflow_mask)
+      apply (rule conjI)
+       apply (drule is_aligned_addrFromPPtr_n, simp)
+       apply (simp add: is_aligned_no_overflow_mask)
+      apply (simp add: mask_def)
 
-     \<comment> \<open>PageTableObject\<close>
+     apply (in_case "PageTableObject")
      apply (cinit' lift: t_' regionBase_' userSize_' deviceMemory_')
       apply (simp add: object_type_from_H_def Kernel_C_defs)
-      apply (simp add: ccorres_cond_univ_iff ccorres_cond_empty_iff
-                  ARMLargePageBits_def ARMSmallPageBits_def
-                  ARMSectionBits_def ARMSuperSectionBits_def asidInvalid_def
-                  sle_positive APIType_capBits_def shiftL_nat objBits_simps
-                  ptBits_def archObjSize_def pageBits_def word_sle_def word_sless_def)
-      apply (ccorres_remove_UNIV_guard)
+      apply (simp add: ccorres_cond_univ_iff ccorres_cond_empty_iff asidInvalid_def
+                       APIType_capBits_def shiftL_nat objBits_simps
+                       ptBits_def archObjSize_def pageBits_def word_sle_def word_sless_def)
       apply (rule ccorres_rhs_assoc)+
       apply (clarsimp simp: hrs_htd_update ptBits_def objBits_simps archObjSize_def
-        ARM_H.createObject_def pageBits_def)
+                            ARM_H.createObject_def pageBits_def pt_bits_def)
       apply (ctac pre only: add: placeNewObject_pte[simplified])
         apply csymbr
-        apply (rule ccorres_return_C)
-          apply simp
-         apply simp
-        apply simp
+        apply (ctac (no_vcg) add: cleanCacheRange_PoU_ccorres)
+         apply csymbr
+         apply (rule ccorres_return_C; simp)
+        apply wp
        apply wp
       apply vcg
      apply clarify
      apply (intro conjI)
       apply (clarsimp simp: invs_pspace_aligned' invs_pspace_distinct' invs_valid_global'
-                            APIType_capBits_def invs_valid_objs'
-                            invs_urz)
-     apply clarsimp
-     apply (clarsimp simp: pageBits_def ccap_relation_def APIType_capBits_def
-                framesize_to_H_def cap_to_H_simps cap_page_table_cap_lift
-                is_aligned_neg_mask_eq vmrights_to_H_def
-                Kernel_C.VMReadWrite_def Kernel_C.VMNoAccess_def
-                Kernel_C.VMKernelOnly_def Kernel_C.VMReadOnly_def)
-     apply (simp add: isFrameType_def)
+                            APIType_capBits_def invs_valid_objs' is_aligned_no_overflow_mask
+                            invs_urz pteBits_def)
+      apply (rule conjI, simp add: mask_def)
+      apply (drule is_aligned_addrFromPPtr_n, simp)
+      apply (simp add: is_aligned_no_overflow_mask)
+     apply (clarsimp simp: ccap_relation_def APIType_capBits_def
+                           framesize_to_H_def cap_to_H_simps cap_page_table_cap_lift
+                           vmrights_to_H_def pteBits_def vmrights_defs)
+     apply (clarsimp simp: isFrameType_def mask_def is_aligned_neg_mask_eq_concrete[THEN sym])
 
-    \<comment> \<open>PageDirectoryObject\<close>
+    apply (in_case "PageDirectoryObject")
     apply (cinit' lift: t_' regionBase_' userSize_' deviceMemory_')
      apply (simp add: object_type_from_H_def Kernel_C_defs)
      apply (simp add: ccorres_cond_univ_iff ccorres_cond_empty_iff
-                asidInvalid_def sle_positive APIType_capBits_def shiftL_nat
-                objBits_simps archObjSize_def
-                ptBits_def pageBits_def pdBits_def word_sle_def word_sless_def)
-     apply (ccorres_remove_UNIV_guard)
+                      asidInvalid_def APIType_capBits_def shiftL_nat
+                      objBits_simps archObjSize_def isFrameType_def
+                      ptBits_def pageBits_def pdBits_def word_sle_def word_sless_def)
      apply (rule ccorres_rhs_assoc)+
      apply (clarsimp simp: hrs_htd_update ptBits_def objBits_simps archObjSize_def
-        ARM_H.createObject_def pageBits_def pdBits_def)
+                           ARM_H.createObject_def pageBits_def pdBits_def pd_bits_def)
      apply (ctac pre only: add: placeNewObject_pde[simplified])
        apply (ctac add: copyGlobalMappings_ccorres)
          apply csymbr
          apply (ctac add: cleanCacheRange_PoU_ccorres)
            apply csymbr
-           apply (rule ccorres_return_C)
-             apply simp
-            apply simp
-           apply simp
+           apply (rule ccorres_return_C; simp)
           apply wp
          apply clarsimp
          apply vcg
         apply wp
        apply (clarsimp simp: pageBits_def ccap_relation_def APIType_capBits_def
-                  framesize_to_H_def cap_to_H_simps cap_page_directory_cap_lift
-                  is_aligned_neg_mask_eq vmrights_to_H_def
-                  Kernel_C.VMReadWrite_def Kernel_C.VMNoAccess_def
-                  Kernel_C.VMKernelOnly_def Kernel_C.VMReadOnly_def)
+                             framesize_to_H_def cap_to_H_simps cap_page_directory_cap_lift
+                             vmrights_to_H_def vm_rights_defs)
        apply (vcg exspec=copyGlobalMappings_modifies)
       apply (clarsimp simp:placeNewObject_def2)
       apply (wp createObjects'_pde_mappings' createObjects'_page_directory_at_global[where sz=pdBits]
@@ -4732,22 +4871,23 @@ proof -
      apply clarsimp
      apply vcg
     apply (clarsimp simp: invs_pspace_aligned' invs_pspace_distinct'
-               archObjSize_def invs_valid_global' makeObject_pde pdBits_def
-               pageBits_def range_cover.aligned projectKOs APIType_capBits_def
-               object_type_from_H_def objBits_simps pdeBits_def
-               invs_valid_objs' isFrameType_def)
+                          archObjSize_def invs_valid_global' makeObject_pde pdBits_def
+                          pageBits_def range_cover.aligned projectKOs APIType_capBits_def
+                          object_type_from_H_def objBits_simps pdeBits_def
+                          invs_valid_objs' isFrameType_def)
     apply (frule invs_arch_state')
     apply (frule range_cover.aligned)
     apply (frule is_aligned_addrFromPPtr_n, simp)
     apply (intro conjI, simp_all)
-         apply fastforce
-        apply fastforce
-       apply (clarsimp simp: pageBits_def pdeBits_def
-                             valid_arch_state'_def page_directory_at'_def pdBits_def)
-      apply (clarsimp simp: is_aligned_no_overflow'[where n=14, simplified] pdeBits_def
-                            field_simps is_aligned_mask[symmetric] mask_AND_less_0
-                            cacheLineBits_le_PageDirectoryObject_sz[unfolded APIType_capBits_def,
-                                                                    simplified])+
+           apply fastforce
+          apply fastforce
+         apply (clarsimp simp: valid_arch_state'_def page_directory_at'_def)
+        apply (simp add: mask_def)
+       apply (simp add: is_aligned_no_overflow_mask)
+      apply (drule is_aligned_addrFromPPtr_n, simp)
+      apply (simp add: is_aligned_no_overflow_mask)
+     apply (clarsimp simp: is_aligned_mask[symmetric] mask_AND_less_0)
+    apply (clarsimp simp: mask_def)
     done
 qed
 
@@ -6472,6 +6612,43 @@ lemma cleanCacheRange_PoU_preserves_bytes:
               elim!: byte_regions_unmodified_trans byte_regions_unmodified_trans[rotated],
         (simp_all add: h_t_valid_field)+)
 
+lemma cleanByVA_preserves_bytes:
+  "\<forall>s. \<Gamma>\<turnstile>\<^bsub>/UNIV\<^esub> {s} Call cleanByVA_'proc
+      {t. hrs_htd (t_hrs_' (globals t)) = hrs_htd (t_hrs_' (globals s))
+         \<and> byte_regions_unmodified' s t}"
+  apply (rule allI, rule conseqPost, rule cleanByVA_preserves_kernel_bytes[rule_format])
+   apply simp_all
+  apply (clarsimp simp: byte_regions_unmodified_def)
+  done
+
+lemma cleanCacheRange_PoC_preserves_bytes:
+  "\<forall>s. \<Gamma>\<turnstile>\<^bsub>/UNIV\<^esub> {s} Call cleanCacheRange_PoC_'proc
+      {t. hrs_htd (t_hrs_' (globals t)) = hrs_htd (t_hrs_' (globals s))
+         \<and> byte_regions_unmodified' s t}"
+  apply (hoare_rule HoarePartial.ProcNoRec1)
+  apply (clarsimp simp only: whileAnno_def)
+  apply (subst whileAnno_def[symmetric, where V=undefined
+               and I="{t. hrs_htd (t_hrs_' (globals t)) = hrs_htd (t_hrs_' (globals s))
+                          \<and> byte_regions_unmodified' s t}" for s])
+  apply (rule conseqPre, vcg exspec=cleanByVA_preserves_bytes)
+  by (safe intro!: byte_regions_unmodified_hrs_mem_update
+            elim!: byte_regions_unmodified_trans byte_regions_unmodified_trans[rotated],
+      (simp_all add: h_t_valid_field)+)
+
+lemma cleanCacheRange_RAM_preserves_bytes:
+  "\<forall>s. \<Gamma>\<turnstile>\<^bsub>/UNIV\<^esub> {s} Call cleanCacheRange_RAM_'proc
+      {t. hrs_htd (t_hrs_' (globals t)) = hrs_htd (t_hrs_' (globals s))
+         \<and> byte_regions_unmodified' s t}"
+  apply (hoare_rule HoarePartial.ProcNoRec1, rule allI)
+  apply (rule conseqPre, vcg exspec=cleanCacheRange_PoC_preserves_bytes
+                             exspec=cleanL2Range_preserves_kernel_bytes
+                             exspec=dsb_preserves_kernel_bytes)
+  apply (safe intro!: byte_regions_unmodified_hrs_mem_update
+            elim!: byte_regions_unmodified_trans byte_regions_unmodified_trans[rotated],
+      (simp_all add: h_t_valid_field)+)
+  apply (clarsimp simp: byte_regions_unmodified_def)
+  done
+
 lemma hrs_htd_update_canon:
   "hrs_htd_update (\<lambda>_. f (hrs_htd hrs)) hrs = hrs_htd_update f hrs"
   by (cases hrs, simp add: hrs_htd_update_def hrs_htd_def)
@@ -6490,15 +6667,18 @@ lemma Arch_createObject_preserves_bytes:
                              exspec=copyGlobalMappings_preserves_bytes
                              exspec=addrFromPPtr_modifies
                              exspec=cleanCacheRange_PoU_preserves_bytes
-                             exspec=cap_page_directory_cap_new_modifies)
+                             exspec=cleanCacheRange_RAM_preserves_bytes
+                             exspec=cap_page_directory_cap_new_modifies) find_names ARMSmallPage_def
   apply (safe intro!: byte_regions_unmodified_hrs_mem_update,
          (simp_all add: h_t_valid_field hrs_htd_update)+)
-            apply (safe intro!: ptr_retyp_d ptr_retyps_out)
-            apply (simp_all add: object_type_from_H_def Kernel_C_defs APIType_capBits_def
-                            split: object_type.split_asm apiobject_type.split_asm)
-  apply (rule byte_regions_unmodified_flip, simp)
-  apply (rule byte_regions_unmodified_trans[rotated],
-         assumption, simp_all add: hrs_htd_update_canon hrs_htd_update)
+                     apply (safe intro!: ptr_retyp_d ptr_retyps_out)
+                     apply (simp_all add: object_type_from_H_def Kernel_C_defs APIType_capBits_def
+                                          vm_page_size_defs
+                                     split: object_type.split_asm apiobject_type.split_asm)
+          apply (all \<open>(solves \<open>simp add: mask_def\<close>)?\<close>)
+       apply (rule byte_regions_unmodified_flip, simp,
+              rule byte_regions_unmodified_trans[rotated], assumption;
+              simp add: hrs_htd_update_canon hrs_htd_update)+
   done
 
 lemma ptr_arr_retyps_eq_outside_dom:
@@ -6648,6 +6828,16 @@ lemma insertNewCap_ccorres:
   apply (simp add: untypedZeroRange_def Let_def)
   done
 
+lemma Arch_createObject_not_untyped:
+  "\<forall>s. \<Gamma>\<turnstile>\<^bsub>/UNIV\<^esub>
+   {s} Call Arch_createObject_'proc {t. cap_get_tag (ret__struct_cap_C_' t) \<noteq> scast cap_untyped_cap}"
+  apply (rule allI, rule conseqPre)
+   apply (vcg exspec=cleanCacheRange_PoU_modifies
+              exspec=cleanCacheRange_RAM_modifies
+              exspec=copyGlobalMappings_modifies)
+  apply (clarsimp simp: cap_tag_defs vm_page_size_defs mask_def)
+  done
+
 lemma createObject_untyped_region_is_zero_bytes:
   "\<forall>\<sigma>. \<Gamma>\<turnstile>\<^bsub>/UNIV\<^esub> {s. let tp = (object_type_to_H (t_' s));
           sz = APIType_capBits tp (unat (userSize_' s))
@@ -6659,9 +6849,8 @@ lemma createObject_untyped_region_is_zero_bytes:
    {t. cap_get_tag (ret__struct_cap_C_' t) = scast cap_untyped_cap
          \<longrightarrow> (case untypedZeroRange (cap_to_H (the (cap_lift (ret__struct_cap_C_' t)))) of None \<Rightarrow> True
           | Some (a, b) \<Rightarrow> region_actually_is_zero_bytes a (unat ((b + 1) - a)) t)}"
-  apply (rule allI, rule conseqPre, vcg exspec=copyGlobalMappings_modifies
-      exspec=Arch_initContext_modifies
-      exspec=cleanCacheRange_PoU_modifies)
+  apply (rule allI, rule conseqPre,
+         vcg exspec=Arch_createObject_not_untyped exspec=Arch_initContext_modifies)
   apply (clarsimp simp: cap_tag_defs)
   apply (simp add: cap_lift_untyped_cap cap_tag_defs cap_to_H_simps
                    cap_untyped_cap_lift_def object_type_from_H_def)

--- a/proof/crefine/ARM_HYP/Invoke_C.thy
+++ b/proof/crefine/ARM_HYP/Invoke_C.thy
@@ -1677,45 +1677,37 @@ lemma clearMemory_untyped_ccorres:
   apply (cinit' lift: bits_' ptr___ptr_to_unsigned_long_')
    apply (rule_tac P="ptr \<noteq> 0 \<and> sz < word_bits"
                 in ccorres_gen_asm)
-   apply (rule ccorres_Guard_Seq)
+   apply (rule ccorres_Guard)
    apply (simp add: clearMemory_def)
-   apply (simp add: doMachineOp_bind ef_storeWord)
-   apply (rule ccorres_split_nothrow_novcg_dc)
-      apply (rule_tac P="?P" and P'="{s. region_actually_is_bytes ptr (2 ^ sz) s}"
-         in ccorres_from_vcg)
-      apply (rule allI, rule conseqPre, vcg)
-      apply clarsimp
-      apply (clarsimp simp: isCap_simps valid_cap'_def capAligned_def
-                            is_aligned_no_wrap'[OF _ word32_power_less_1]
-                            unat_of_nat_eq word_bits_def)
-      apply (simp add: is_aligned_weaken is_aligned_triv[THEN is_aligned_weaken])
-      apply (clarsimp simp: ghost_assertion_size_logic[unfolded o_def]
-                            region_actually_is_bytes_dom_s)
-      apply (clarsimp simp: field_simps word_size_def mapM_x_storeWord_step
-                            word_bits_def cte_wp_at_ctes_of)
-      apply (frule ctes_of_valid', clarify+)
-      apply (simp add: doMachineOp_def split_def exec_gets)
-      apply (simp add: select_f_def simpler_modify_def bind_def
-                       valid_cap_simps' capAligned_def)
-      apply (subst pspace_no_overlap_underlying_zero_update, simp+)
-       apply (case_tac sz, simp_all)[1]
-       apply (case_tac nat, simp_all)[1]
-      apply (clarsimp dest!: region_actually_is_bytes)
-      apply (drule(1) rf_sr_rep0)
-      apply (clarsimp simp: rf_sr_def cstate_relation_def Let_def
-                            carch_state_relation_def cmachine_state_relation_def)
-     apply csymbr
-     apply (ctac add: cleanCacheRange_RAM_ccorres)
-    apply wp
-   apply (simp add: guard_is_UNIV_def unat_of_nat
-                    word_bits_def capAligned_def word_of_nat_less)
+   apply (rule_tac P="?P" and P'="{s. region_actually_is_bytes ptr (2 ^ sz) s}" in ccorres_from_vcg)
+   apply (rule allI, rule conseqPre, vcg)
+   apply clarsimp
+   apply (clarsimp simp: isCap_simps valid_cap'_def capAligned_def
+                         is_aligned_no_wrap'[OF _ word32_power_less_1]
+                         unat_of_nat_eq word_bits_def)
+   apply (simp add: is_aligned_weaken is_aligned_triv[THEN is_aligned_weaken])
+   apply (clarsimp simp: ghost_assertion_size_logic[unfolded o_def]
+                         region_actually_is_bytes_dom_s)
+   apply (clarsimp simp: field_simps word_size_def mapM_x_storeWord_step
+                         word_bits_def cte_wp_at_ctes_of)
+   apply (frule ctes_of_valid', clarify+)
+   apply (simp add: doMachineOp_def split_def exec_gets)
+   apply (simp add: select_f_def simpler_modify_def bind_def
+                    valid_cap_simps' capAligned_def)
+   apply (subst pspace_no_overlap_underlying_zero_update, simp+)
+    apply (case_tac sz, simp_all)[1]
+    apply (case_tac nat, simp_all)[1]
+   apply (clarsimp dest!: region_actually_is_bytes)
+   apply (drule(1) rf_sr_rep0)
+   apply (clarsimp simp: rf_sr_def cstate_relation_def Let_def
+                         carch_state_relation_def cmachine_state_relation_def)
+  apply (simp add: guard_is_UNIV_def unat_of_nat
+                   word_bits_def capAligned_def word_of_nat_less)
   apply (clarsimp simp: cte_wp_at_ctes_of)
   apply (frule ctes_of_valid', clarify+)
   apply (clarsimp simp: isCap_simps valid_cap_simps' capAligned_def
                         word_of_nat_less Kernel_Config.resetChunkBits_def
                         word_bits_def unat_2p_sub_1)
-  apply (strengthen is_aligned_no_wrap'[where sz=sz] is_aligned_addrFromPPtr_n)+
-  apply simp
   apply (cases "ptr = 0")
    apply (drule subsetD, rule intvl_self, simp)
    apply (simp split: if_split_asm)

--- a/proof/crefine/ARM_HYP/Machine_C.thy
+++ b/proof/crefine/ARM_HYP/Machine_C.thy
@@ -224,7 +224,7 @@ assumes getFAR_ccorres:
            (doMachineOp getFAR)
            (Call getFAR_'proc)"
 
-(* FIXME ARMHYP double-check this, assumption is ccorres holds regardless of in_kernel *)
+(* assumption is ccorres holds regardless of in_kernel *)
 assumes getActiveIRQ_ccorres:
 "\<And>in_kernel.
    ccorres (\<lambda>(a::irq option) c::machine_word.

--- a/proof/crefine/ARM_HYP/Recycle_C.thy
+++ b/proof/crefine/ARM_HYP/Recycle_C.thy
@@ -264,121 +264,109 @@ lemma clearMemory_PageCap_ccorres:
   apply (cinit' lift: bits_' ptr___ptr_to_unsigned_long_')
    apply (rule_tac P="capAligned (ArchObjectCap (PageCap False ptr undefined sz None))"
                 in ccorres_gen_asm)
-   apply (rule ccorres_Guard_Seq)
+   apply (rule ccorres_Guard)
    apply (simp add: clearMemory_def)
-   apply (simp add: doMachineOp_bind ef_storeWord)
-   apply (rule ccorres_split_nothrow_novcg_dc)
-      apply (rule_tac P="?P" in ccorres_from_vcg[where P'=UNIV])
-      apply (rule allI, rule conseqPre, vcg)
-      apply (clarsimp simp: valid_cap'_def capAligned_def
-                            is_aligned_no_wrap'[OF _ word32_power_less_1])
-      apply (subgoal_tac "2 \<le> pageBitsForSize sz")
-       prefer 2
-       apply (simp add: pageBitsForSize_def split: vmpage_size.split)
-      apply (rule conjI)
-       apply (erule is_aligned_weaken)
-       apply (clarsimp simp: pageBitsForSize_def split: vmpage_size.splits)
-      apply (rule conjI)
-       apply (rule is_aligned_power2)
-       apply (clarsimp simp: pageBitsForSize_def split: vmpage_size.splits)
-      apply (clarsimp simp: ghost_assertion_size_logic[unfolded o_def])
-      apply (simp add: flex_user_data_at_rf_sr_dom_s)
-      apply (clarsimp simp: field_simps word_size_def mapM_x_storeWord_step)
-      apply (simp add: doMachineOp_def split_def exec_gets)
-      apply (simp add: select_f_def simpler_modify_def bind_def)
-      apply (fold replicateHider_def)[1]
-      apply (subst coerce_heap_update_to_heap_updates'
-                         [where chunk=4096 and m="2 ^ (pageBitsForSize sz - pageBits)"])
-       apply (simp add: pageBitsForSize_def pageBits_def
-                 split: vmpage_size.split)
-      apply (subst coerce_memset_to_heap_update_user_data)
-      apply (subgoal_tac "\<forall>p<2 ^ (pageBitsForSize sz - pageBits).
-                               x \<Turnstile>\<^sub>c (Ptr (ptr + of_nat p * 0x1000) :: user_data_C ptr)")
-       prefer 2
-       apply (erule allfEI[where f=of_nat])
-       apply clarsimp
-       apply (subst(asm) of_nat_power, assumption)
-        apply simp
-        apply (insert pageBitsForSize_32 [of sz])[1]
-        apply (erule order_le_less_trans [rotated])
-        apply simp
-       apply (simp, drule ko_at_projectKO_opt[OF user_data_at_ko])
-       apply (clarsimp simp: rf_sr_def cstate_relation_def Let_def cpspace_relation_def)
-       apply (erule cmap_relationE1, simp(no_asm) add: heap_to_user_data_def Let_def)
-        apply fastforce
-       subgoal by (simp add: pageBits_def typ_heap_simps)
-      apply (clarsimp simp: rf_sr_def cstate_relation_def Let_def)
-      apply (clarsimp simp: cpspace_relation_def typ_heap_simps
-                            clift_foldl_hrs_mem_update foldl_id
-                            carch_state_relation_def
-                            cmachine_state_relation_def
-                            foldl_fun_upd_const[unfolded fun_upd_def]
-                            power_user_page_foldl_zero_ranges
-                            dom_heap_to_device_data)
-      apply (rule conjI[rotated])
-       apply (simp add:pageBitsForSize_mess_multi)
-       apply (rule cmap_relationI)
-        apply (clarsimp simp: dom_heap_to_device_data cmap_relation_def)
-        apply (simp add:cuser_user_data_device_relation_def)
-      apply (subst help_force_intvl_range_conv, assumption)
-        subgoal by (simp add: pageBitsForSize_def split: vmpage_size.split)
-       apply assumption
-      apply (subst heap_to_user_data_update_region)
-       apply (drule map_to_user_data_aligned, clarsimp)
-       apply (rule aligned_range_offset_mem[where m=pageBits], simp_all)[1]
-       apply (rule pbfs_atleast_pageBits)
-      apply (erule cmap_relation_If_upd)
-        apply (clarsimp simp: cuser_user_data_relation_def order_less_le_trans[OF unat_lt2p])
-        apply (simp add: update_ti_t_word32_0s)
-       apply (rule image_cong[OF _ refl])
-       apply (rule set_eqI, rule iffI)
-        apply (clarsimp simp del: atLeastAtMost_iff)
-        apply (drule map_to_user_data_aligned, clarsimp)
-        apply (simp only: mask_in_range[symmetric])
-        apply (rule_tac x="unat ((xa && mask (pageBitsForSize sz)) >> pageBits)" in image_eqI)
-         apply (simp add: subtract_mask(2)[symmetric])
-         apply (cut_tac w="xa - ptr" and n=pageBits in and_not_mask[symmetric])
-         apply (simp add: shiftl_t2n field_simps pageBits_def)
-         apply (subst is_aligned_neg_mask_eq, simp_all)[1]
-         apply (erule aligned_sub_aligned, simp_all add: word_bits_def)[1]
-         apply (erule is_aligned_weaken)
-         apply (rule pbfs_atleast_pageBits[unfolded pageBits_def])
-        apply simp
-        apply (rule unat_less_power)
-         apply (fold word_bits_def, simp)
-        apply (rule shiftr_less_t2n)
-        apply (simp add: pbfs_atleast_pageBits)
-        apply (rule and_mask_less_size)
-        apply (simp add: word_bits_def word_size)
-       apply (rule IntI)
-        apply (clarsimp simp del: atLeastAtMost_iff)
-        apply (subst aligned_range_offset_mem, assumption, simp_all)[1]
-        apply (rule order_le_less_trans[rotated], erule shiftl_less_t2n [OF of_nat_power],
-               simp_all add: word_bits_def)[1]
-         apply (insert pageBitsForSize_32 [of sz])[1]
-         apply (erule order_le_less_trans [rotated])
-         subgoal by simp
-        subgoal by (simp add: pageBits_def shiftl_t2n field_simps)
-       apply clarsimp
-       apply (drule_tac x="of_nat n" in spec)
-       apply (simp add: of_nat_power[where 'a=32, folded word_bits_def])
-       apply (rule exI)
-       subgoal by (simp add: pageBits_def ko_at_projectKO_opt[OF user_data_at_ko])
+   apply (rule_tac P="?P" in ccorres_from_vcg[where P'=UNIV])
+   apply (rule allI, rule conseqPre, vcg)
+   apply (clarsimp simp: valid_cap'_def capAligned_def
+                         is_aligned_no_wrap'[OF _ word32_power_less_1])
+   apply (prop_tac "ptr \<noteq> 0", simp)
+   apply simp
+   apply (prop_tac "2 \<le> pageBitsForSize sz")
+    apply (simp add: pageBitsForSize_def split: vmpage_size.split)
+   apply (rule conjI)
+    apply (erule is_aligned_weaken, simp)
+   apply (rule conjI)
+    apply (rule is_aligned_power2, simp)
+   apply (clarsimp simp: ghost_assertion_size_logic[unfolded o_def])
+   apply (simp add: flex_user_data_at_rf_sr_dom_s)
+   apply (clarsimp simp: field_simps word_size_def mapM_x_storeWord_step)
+   apply (simp add: doMachineOp_def split_def exec_gets)
+   apply (simp add: select_f_def simpler_modify_def bind_def)
+   apply (fold replicateHider_def)[1]
+   apply (subst coerce_heap_update_to_heap_updates'
+                      [where chunk=4096 and m="2 ^ (pageBitsForSize sz - pageBits)"])
+    apply (simp add: pageBitsForSize_def pageBits_def
+              split: vmpage_size.split)
+   apply (subst coerce_memset_to_heap_update_user_data)
+   apply (subgoal_tac "\<forall>p<2 ^ (pageBitsForSize sz - pageBits).
+                            x \<Turnstile>\<^sub>c (Ptr (ptr + of_nat p * 0x1000) :: user_data_C ptr)")
+    prefer 2
+    apply (erule allfEI[where f=of_nat])
+    apply clarsimp
+    apply (subst(asm) of_nat_power, assumption)
+     apply simp
+     apply (insert pageBitsForSize_32 [of sz])[1]
+     apply (erule order_le_less_trans [rotated])
+     apply simp
+    apply (simp, drule ko_at_projectKO_opt[OF user_data_at_ko])
+    apply (clarsimp simp: rf_sr_def cstate_relation_def Let_def cpspace_relation_def)
+    apply (erule cmap_relationE1, simp(no_asm) add: heap_to_user_data_def Let_def)
+     apply fastforce
+    subgoal by (simp add: pageBits_def typ_heap_simps)
+   apply (clarsimp simp: rf_sr_def cstate_relation_def Let_def)
+   apply (clarsimp simp: cpspace_relation_def typ_heap_simps
+                         clift_foldl_hrs_mem_update foldl_id
+                         carch_state_relation_def
+                         cmachine_state_relation_def
+                         foldl_fun_upd_const[unfolded fun_upd_def]
+                         power_user_page_foldl_zero_ranges
+                         dom_heap_to_device_data)
+   apply (rule conjI[rotated])
+    apply (simp add:pageBitsForSize_mess_multi)
+    apply (rule cmap_relationI)
+     apply (clarsimp simp: dom_heap_to_device_data cmap_relation_def)
+    apply (simp add:cuser_user_data_device_relation_def)
+   apply (subst help_force_intvl_range_conv, assumption)
+     subgoal by (simp add: pageBitsForSize_def split: vmpage_size.split)
+    apply assumption
+   apply (subst heap_to_user_data_update_region)
+    apply (drule map_to_user_data_aligned, clarsimp)
+    apply (rule aligned_range_offset_mem[where m=pageBits], simp_all)[1]
+    apply (rule pbfs_atleast_pageBits)
+   apply (erule cmap_relation_If_upd)
+     apply (clarsimp simp: cuser_user_data_relation_def order_less_le_trans[OF unat_lt2p])
+     apply (simp add: update_ti_t_word32_0s)
+    apply (rule image_cong[OF _ refl])
+    apply (rule set_eqI, rule iffI)
+     apply (clarsimp simp del: atLeastAtMost_iff)
+     apply (drule map_to_user_data_aligned, clarsimp)
+     apply (simp only: mask_in_range[symmetric])
+     apply (rule_tac x="unat ((xa && mask (pageBitsForSize sz)) >> pageBits)" in image_eqI)
+      apply (simp add: subtract_mask(2)[symmetric])
+      apply (cut_tac w="xa - ptr" and n=pageBits in and_not_mask[symmetric])
+      apply (simp add: shiftl_t2n field_simps pageBits_def)
+      apply (subst is_aligned_neg_mask_eq, simp_all)[1]
+      apply (erule aligned_sub_aligned, simp_all add: word_bits_def)[1]
+      apply (erule is_aligned_weaken)
+      apply (rule pbfs_atleast_pageBits[unfolded pageBits_def])
+     apply simp
+     apply (rule unat_less_power)
+      apply (fold word_bits_def, simp)
+     apply (rule shiftr_less_t2n)
+     apply (simp add: pbfs_atleast_pageBits)
+     apply (rule and_mask_less_size)
+     apply (simp add: word_bits_def word_size)
+    apply (rule IntI)
+     apply (clarsimp simp del: atLeastAtMost_iff)
+     apply (subst aligned_range_offset_mem, assumption, simp_all)[1]
+     apply (rule order_le_less_trans[rotated], erule shiftl_less_t2n [OF of_nat_power],
+            simp_all add: word_bits_def)[1]
+      apply (insert pageBitsForSize_32 [of sz])[1]
+      apply (erule order_le_less_trans [rotated])
       subgoal by simp
-     apply csymbr
-     apply (ctac add: cleanCacheRange_RAM_ccorres)
-    apply wp
-   apply (simp add: guard_is_UNIV_def unat_of_nat
-                    word_bits_def capAligned_def word_of_nat_less)
+     subgoal by (simp add: pageBits_def shiftl_t2n field_simps)
+    apply clarsimp
+    apply (drule_tac x="of_nat n" in spec)
+    apply (simp add: of_nat_power[where 'a=32, folded word_bits_def])
+    apply (rule exI)
+    subgoal by (simp add: pageBits_def ko_at_projectKO_opt[OF user_data_at_ko])
+   subgoal by simp
+  apply (simp add: guard_is_UNIV_def unat_of_nat
+                   word_bits_def capAligned_def word_of_nat_less)
   apply (clarsimp simp: word_bits_def valid_cap'_def
                         capAligned_def word_of_nat_less)
-  apply (frule is_aligned_addrFromPPtr_n, simp add: pageBitsForSize_def split: vmpage_size.splits)
-  by (clarsimp simp: is_aligned_no_overflow'[where n=12, simplified]
-                     is_aligned_no_overflow'[where n=16, simplified]
-                     is_aligned_no_overflow'[where n=21, simplified]
-                     is_aligned_no_overflow'[where n=25, simplified] pageBits_def
-                     is_aligned_mask[symmetric] mask_AND_less_0
-                     pageBitsForSize_def split: vmpage_size.splits)
+  done
 
 lemma coerce_memset_to_heap_update_asidpool:
   "heap_update_list x (replicateHider 4096 0)

--- a/proof/crefine/ARM_HYP/Retype_C.thy
+++ b/proof/crefine/ARM_HYP/Retype_C.thy
@@ -5676,6 +5676,40 @@ lemma placeNewObject_vcpu_ccorres:
   apply fastforce
   done
 
+lemma placeNewDataObject_dev_ccorres:
+  "ccorresG rf_sr \<Gamma> dc xfdc
+  (createObject_hs_preconds regionBase newType us True
+      and K (APIType_capBits newType us = pageBits + us))
+  ({s. region_actually_is_bytes regionBase (2 ^ (pageBits + us)) s})
+  hs
+  (placeNewDataObject regionBase us True)
+  (global_htd_update (\<lambda>s. (ptr_retyps (2^us) (Ptr regionBase :: user_data_device_C ptr))))"
+  apply (simp add: placeNewDataObject_def ccorres_cond_univ_iff)
+  apply (rule ccorres_guard_imp, rule placeNewObject_user_data_device, simp_all)
+  apply (clarsimp simp: createObject_hs_preconds_def invs'_def
+                        valid_state'_def valid_pspace'_def)
+  done
+
+lemma placeNewDataObject_no_dev_ccorres:
+  "ccorresG rf_sr \<Gamma> dc xfdc
+  (createObject_hs_preconds regionBase newType us False
+      and K (APIType_capBits newType us = pageBits + us))
+  ({s. region_actually_is_bytes regionBase (2 ^ (pageBits + us)) s
+      \<and> (heap_list_is_zero (hrs_mem (t_hrs_' (globals s))) regionBase (2 ^ (pageBits + us)))})
+  hs
+  (placeNewDataObject regionBase us False)
+  (global_htd_update (\<lambda>s. (ptr_retyps (2^us) (Ptr regionBase :: user_data_C ptr))))"
+  apply (simp add: placeNewDataObject_def ccorres_cond_empty_iff)
+  apply (rule ccorres_guard_imp, rule placeNewObject_user_data, simp_all)
+  apply (clarsimp simp: createObject_hs_preconds_def invs'_def
+                        valid_state'_def valid_pspace'_def)
+  apply (frule range_cover.sz(1), simp add: word_bits_def)
+  done
+
+crunch placeNewDataObject
+  for gsMaxObjectSize[wp]: "\<lambda>s. P (gsMaxObjectSize s)"
+  (simp: crunch_simps)
+
 lemma Arch_createObject_ccorres:
   assumes t: "toAPIType newType = None"
   notes is_aligned_neg_mask_eq[simp del]
@@ -5698,173 +5732,285 @@ proof -
     apply (cut_tac t)
     apply (case_tac newType,
            simp_all add: toAPIType_def bind_assoc ARMLargePageBits_def)
-         apply (cinit' lift: t_' regionBase_' userSize_' deviceMemory_')
-          apply (simp add: object_type_from_H_def Kernel_C_defs)
-          apply (simp add: ccorres_cond_univ_iff ccorres_cond_empty_iff
-                           ARMLargePageBits_def ARMSmallPageBits_def
-                           ARMSectionBits_def ARMSuperSectionBits_def asidInvalid_def
-                           sle_positive APIType_capBits_def shiftL_nat objBits_simps
-                           ptBits_def archObjSize_def pageBits_def word_sle_def word_sless_def
-                           fold_eq_0_to_bool)
-          apply (ccorres_remove_UNIV_guard)
-          apply (clarsimp simp: hrs_htd_update ptBits_def objBits_simps archObjSize_def
-                                ARM_HYP_H.createObject_def pageBits_def
-                                cond_second_eq_seq_ccorres modify_gsUserPages_update
-                        intro!: ccorres_rhs_assoc)
-          apply ((rule ccorres_return_C | simp | wp | vcg
-                  | (rule match_ccorres, ctac add:
-                          placeNewDataObject_ccorres[where us=0 and newType=newType, simplified]
-                          gsUserPages_update_ccorres[folded modify_gsUserPages_update])
-                  | (rule match_ccorres, csymbr))+)[1]
-         apply (intro conjI)
-          apply (clarsimp simp: createObject_hs_preconds_def
-                                APIType_capBits_def pageBits_def)
-         apply (clarsimp simp: pageBits_def ccap_relation_def APIType_capBits_def
-                               framesize_to_H_def cap_to_H_simps cap_small_frame_cap_lift
-                               vmrights_to_H_def vm_rights_defs is_aligned_neg_mask_eq,
-                simp add: mask_def)
+          apply (in_case "SmallPageObject")
+          apply (cinit' lift: t_' regionBase_' userSize_' deviceMemory_')
+           apply (simp add: object_type_from_H_def Kernel_C_defs)
+           apply (simp add: ccorres_cond_univ_iff ccorres_cond_empty_iff
+                            asidInvalid_def APIType_capBits_def shiftL_nat objBits_simps
+                            ptBits_def pageBits_def word_sle_def word_sless_def fold_eq_0_to_bool)
+           apply (clarsimp simp: hrs_htd_update ptBits_def objBits_simps
+                                 ARM_HYP_H.createObject_def pageBits_def
+                                 cond_second_eq_seq_ccorres modify_gsUserPages_update
+                           intro!: ccorres_rhs_assoc)
+           apply (rule ccorres_cases[where P=deviceMemory])
+            apply clarsimp
+            apply (rule ccorres_rhs_assoc)+
+            apply (rule ccorres_split_nothrow_novcg)
+                apply (rule placeNewDataObject_dev_ccorres[where us=0 and newType=newType, simplified])
+               apply ceqv
+              apply  (ctac (no_vcg) add: gsUserPages_update_ccorres[folded modify_gsUserPages_update])
+                apply ccorres_rewrite
+                apply csymbr
+                apply (rule ccorres_return_C; simp)
+               apply wp
+              apply (clarsimp simp: pageBits_def ccap_relation_def APIType_capBits_def
+                                    framesize_to_H_def cap_to_H_simps cap_small_frame_cap_lift
+                                    vmrights_to_H_def vm_rights_defs is_aligned_neg_mask_eq,
+                     simp add: mask_def)
+             apply wp
+            apply (simp add: guard_is_UNIV_def)
+           apply clarsimp
+           apply (rule ccorres_rhs_assoc)+
+           apply (rule ccorres_split_nothrow_novcg)
+               apply (rule placeNewDataObject_no_dev_ccorres[where us=0 and newType=newType, simplified])
+              apply ceqv
+             apply  (ctac (no_vcg) add: gsUserPages_update_ccorres[folded modify_gsUserPages_update])
+               apply csymbr+
+               apply (rule ccorres_Guard_Seq)
+               apply (ctac (no_vcg) add: cleanCacheRange_RAM_ccorres)
+                apply ccorres_rewrite
+                apply csymbr
+                apply (rule ccorres_return_C; simp)
+               apply wp
+              apply wp
+             apply (clarsimp simp: pageBits_def ccap_relation_def APIType_capBits_def
+                                   framesize_to_H_def cap_to_H_simps cap_small_frame_cap_lift
+                                   vmrights_to_H_def vm_rights_defs is_aligned_neg_mask_eq gen_framesize_to_H_def
+                                   vm_page_size_defs)
+             apply (simp add: mask_def)
+            apply wpsimp
+           apply (simp add: guard_is_UNIV_def)
+          apply (clarsimp simp: createObject_hs_preconds_def frameSizeConstants_defs
+                                APIType_capBits_def pageBits_def is_aligned_no_overflow_mask)
+          apply (rule conjI)
+           apply (drule is_aligned_addrFromPPtr_n, simp)
+           apply (simp add: is_aligned_no_overflow_mask)
+          apply (simp add: mask_def)
 
-        \<comment> \<open>Page objects: could possibly fix the duplication here\<close>
+          apply (in_case "LargePageObject")
+          apply (cinit' lift: t_' regionBase_' userSize_' deviceMemory_')
+           apply (simp add: object_type_from_H_def Kernel_C_defs)
+           apply (simp add: ccorres_cond_univ_iff ccorres_cond_empty_iff
+                            asidInvalid_def APIType_capBits_def shiftL_nat objBits_simps
+                            ptBits_def pageBits_def word_sle_def word_sless_def fold_eq_0_to_bool)
+           apply (clarsimp simp: hrs_htd_update ptBits_def objBits_simps
+                                 ARM_HYP_H.createObject_def pageBits_def
+                                 cond_second_eq_seq_ccorres modify_gsUserPages_update
+                           intro!: ccorres_rhs_assoc)
+          apply (rule ccorres_cases[where P=deviceMemory])
+           apply clarsimp
+           apply (rule ccorres_rhs_assoc)+
+           apply (rule ccorres_split_nothrow_novcg)
+               apply (rule placeNewDataObject_dev_ccorres[where us=4 and newType=newType, simplified])
+              apply ceqv
+             apply  (ctac (no_vcg) add: gsUserPages_update_ccorres[folded modify_gsUserPages_update])
+               apply ccorres_rewrite
+               apply csymbr
+               apply (rule ccorres_return_C; simp)
+              apply wp
+             apply (clarsimp simp: pageBits_def ccap_relation_def APIType_capBits_def
+                                   framesize_to_H_def cap_to_H_simps cap_frame_cap_lift
+                                   vmrights_to_H_def vm_rights_defs gen_framesize_to_H_def
+                                   is_aligned_neg_mask_eq_concrete[THEN sym]
+                                   vm_page_size_defs cl_valid_cap_def c_valid_cap_def mask_def)
+            apply wp
+           apply (simp add: guard_is_UNIV_def)
+          apply clarsimp
+          apply (rule ccorres_rhs_assoc)+
+          apply (rule ccorres_split_nothrow_novcg)
+              apply (rule placeNewDataObject_no_dev_ccorres[where us=4 and newType=newType, simplified])
+             apply ceqv
+            apply  (ctac (no_vcg) add: gsUserPages_update_ccorres[folded modify_gsUserPages_update])
+              apply csymbr+
+              apply (rule ccorres_Guard_Seq)
+              apply (ctac (no_vcg) add: cleanCacheRange_RAM_ccorres)
+               apply ccorres_rewrite
+               apply csymbr
+               apply (rule ccorres_return_C; simp)
+              apply wp
+             apply wp
+            apply (clarsimp simp: pageBits_def ccap_relation_def APIType_capBits_def
+                                  framesize_to_H_def cap_to_H_simps cap_frame_cap_lift
+                                  vmrights_to_H_def vm_rights_defs gen_framesize_to_H_def
+                                  is_aligned_neg_mask_eq_concrete[THEN sym]
+                                  vm_page_size_defs cl_valid_cap_def c_valid_cap_def mask_def)
+           apply wpsimp
+          apply (simp add: guard_is_UNIV_def)
+         apply (clarsimp simp: createObject_hs_preconds_def frameSizeConstants_defs
+                               APIType_capBits_def pageBits_def is_aligned_no_overflow_mask)
+         apply (rule conjI)
+          apply (drule is_aligned_addrFromPPtr_n, simp)
+          apply (simp add: is_aligned_no_overflow_mask)
+         apply (simp add: mask_def)
+
+        apply (in_case "SectionObject")
         apply (cinit' lift: t_' regionBase_' userSize_' deviceMemory_')
          apply (simp add: object_type_from_H_def Kernel_C_defs)
          apply (simp add: ccorres_cond_univ_iff ccorres_cond_empty_iff
-                          ARMLargePageBits_def ARMSmallPageBits_def
-                          ARMSectionBits_def ARMSuperSectionBits_def asidInvalid_def
-                          sle_positive APIType_capBits_def shiftL_nat objBits_simps
-                          ptBits_def archObjSize_def pageBits_def word_sle_def word_sless_def
-                          fold_eq_0_to_bool)
-         apply (ccorres_remove_UNIV_guard)
-         apply (clarsimp simp: hrs_htd_update ptBits_def objBits_simps archObjSize_def
+                          asidInvalid_def APIType_capBits_def shiftL_nat objBits_simps
+                          ptBits_def pageBits_def word_sle_def word_sless_def fold_eq_0_to_bool)
+         apply (clarsimp simp: hrs_htd_update ptBits_def objBits_simps
                                ARM_HYP_H.createObject_def pageBits_def
                                cond_second_eq_seq_ccorres modify_gsUserPages_update
-                       intro!: ccorres_rhs_assoc)
-         apply ((rule ccorres_return_C | simp | wp | vcg
-           | (rule match_ccorres, ctac add:
-                   placeNewDataObject_ccorres[where us=4 and newType=newType, simplified]
-                   gsUserPages_update_ccorres[folded modify_gsUserPages_update])
-           | (rule match_ccorres, csymbr))+)[1]
-        apply (intro conjI)
-         apply (clarsimp simp: createObject_hs_preconds_def
-                               APIType_capBits_def pageBits_def)
-        apply (clarsimp simp: pageBits_def ccap_relation_def APIType_capBits_def
-                              framesize_to_H_def cap_to_H_simps cap_frame_cap_lift
-                              vmrights_to_H_def mask_def vm_rights_defs vm_page_size_defs
-                              cl_valid_cap_def c_valid_cap_def
-                              is_aligned_neg_mask_eq_concrete[THEN sym])
+                         intro!: ccorres_rhs_assoc)
+         apply (rule ccorres_cases[where P=deviceMemory])
+          apply clarsimp
+          apply (rule ccorres_rhs_assoc)+
+          apply (rule ccorres_split_nothrow_novcg)
+              apply (rule placeNewDataObject_dev_ccorres[where us=9 and newType=newType, simplified])
+             apply ceqv
+            apply  (ctac (no_vcg) add: gsUserPages_update_ccorres[folded modify_gsUserPages_update])
+              apply ccorres_rewrite
+              apply csymbr
+              apply (rule ccorres_return_C; simp)
+             apply wp
+            apply (clarsimp simp: pageBits_def ccap_relation_def APIType_capBits_def
+                                  framesize_to_H_def cap_to_H_simps cap_frame_cap_lift
+                                  vmrights_to_H_def vm_rights_defs gen_framesize_to_H_def
+                                  is_aligned_neg_mask_eq_concrete[THEN sym]
+                                  vm_page_size_defs cl_valid_cap_def c_valid_cap_def mask_def)
+           apply wp
+          apply (simp add: guard_is_UNIV_def)
+         apply clarsimp
+         apply (rule ccorres_rhs_assoc)+
+         apply (rule ccorres_split_nothrow_novcg)
+             apply (rule placeNewDataObject_no_dev_ccorres[where us=9 and newType=newType, simplified])
+            apply ceqv
+           apply  (ctac (no_vcg) add: gsUserPages_update_ccorres[folded modify_gsUserPages_update])
+             apply csymbr+
+             apply (rule ccorres_Guard_Seq)
+             apply (ctac (no_vcg) add: cleanCacheRange_RAM_ccorres)
+              apply ccorres_rewrite
+              apply csymbr
+              apply (rule ccorres_return_C; simp)
+             apply wp
+            apply wp
+           apply (clarsimp simp: pageBits_def ccap_relation_def APIType_capBits_def
+                                 framesize_to_H_def cap_to_H_simps cap_frame_cap_lift
+                                 vmrights_to_H_def vm_rights_defs gen_framesize_to_H_def
+                                 is_aligned_neg_mask_eq_concrete[THEN sym]
+                                 vm_page_size_defs cl_valid_cap_def c_valid_cap_def mask_def)
+          apply wpsimp
+         apply (simp add: guard_is_UNIV_def)
+        apply (clarsimp simp: createObject_hs_preconds_def frameSizeConstants_defs
+                              APIType_capBits_def pageBits_def is_aligned_no_overflow_mask)
+        apply (rule conjI)
+         apply (drule is_aligned_addrFromPPtr_n, simp)
+         apply (simp add: is_aligned_no_overflow_mask)
+        apply (simp add: mask_def)
 
+       apply (in_case "SuperSectionObject")
        apply (cinit' lift: t_' regionBase_' userSize_' deviceMemory_')
         apply (simp add: object_type_from_H_def Kernel_C_defs)
         apply (simp add: ccorres_cond_univ_iff ccorres_cond_empty_iff
-                         ARMLargePageBits_def ARMSmallPageBits_def
-                         ARMSectionBits_def ARMSuperSectionBits_def asidInvalid_def
-                         sle_positive APIType_capBits_def shiftL_nat objBits_simps
-                         ptBits_def archObjSize_def pageBits_def word_sle_def word_sless_def
-                         fold_eq_0_to_bool)
-        apply (ccorres_remove_UNIV_guard)
-        apply (clarsimp simp: hrs_htd_update ptBits_def objBits_simps archObjSize_def
+                         asidInvalid_def APIType_capBits_def shiftL_nat objBits_simps
+                         ptBits_def pageBits_def word_sle_def word_sless_def fold_eq_0_to_bool)
+        apply (clarsimp simp: hrs_htd_update ptBits_def objBits_simps
                               ARM_HYP_H.createObject_def pageBits_def
                               cond_second_eq_seq_ccorres modify_gsUserPages_update
-                      intro!: ccorres_rhs_assoc)
-        apply ((rule ccorres_return_C | simp | wp | vcg
-          | (rule match_ccorres, ctac add:
-                  placeNewDataObject_ccorres[where us=9 and newType=newType, simplified]
-                  gsUserPages_update_ccorres[folded modify_gsUserPages_update])
-          | (rule match_ccorres, csymbr))+)[1]
-       apply (intro conjI)
-        apply (clarsimp simp: createObject_hs_preconds_def
-                              APIType_capBits_def pageBits_def)
-       apply (clarsimp simp: pageBits_def ccap_relation_def APIType_capBits_def
-                             framesize_to_H_def cap_to_H_simps cap_frame_cap_lift
-                             vmrights_to_H_def mask_def vm_rights_defs vm_page_size_defs
-                             cl_valid_cap_def c_valid_cap_def
-                             is_aligned_neg_mask_eq_concrete[THEN sym])
+                        intro!: ccorres_rhs_assoc)
+        apply (rule ccorres_cases[where P=deviceMemory])
+         apply clarsimp
+         apply (rule ccorres_rhs_assoc)+
+         apply (rule ccorres_split_nothrow_novcg)
+             apply (rule placeNewDataObject_dev_ccorres[where us=13 and newType=newType, simplified])
+            apply ceqv
+           apply  (ctac (no_vcg) add: gsUserPages_update_ccorres[folded modify_gsUserPages_update])
+             apply ccorres_rewrite
+             apply csymbr
+             apply (rule ccorres_return_C; simp)
+            apply wp
+           apply (clarsimp simp: pageBits_def ccap_relation_def APIType_capBits_def
+                                 framesize_to_H_def cap_to_H_simps cap_frame_cap_lift
+                                 vmrights_to_H_def vm_rights_defs gen_framesize_to_H_def
+                                 is_aligned_neg_mask_eq_concrete[THEN sym]
+                                 vm_page_size_defs cl_valid_cap_def c_valid_cap_def mask_def)
+          apply wp
+         apply (simp add: guard_is_UNIV_def)
+        apply clarsimp
+        apply (rule ccorres_rhs_assoc)+
+        apply (rule ccorres_split_nothrow_novcg)
+            apply (rule placeNewDataObject_no_dev_ccorres[where us=13 and newType=newType, simplified])
+           apply ceqv
+          apply  (ctac (no_vcg) add: gsUserPages_update_ccorres[folded modify_gsUserPages_update])
+            apply csymbr+
+            apply (rule ccorres_Guard_Seq)
+            apply (ctac (no_vcg) add: cleanCacheRange_RAM_ccorres)
+             apply ccorres_rewrite
+             apply csymbr
+             apply (rule ccorres_return_C; simp)
+            apply wp
+           apply wp
+          apply (clarsimp simp: pageBits_def ccap_relation_def APIType_capBits_def
+                                framesize_to_H_def cap_to_H_simps cap_frame_cap_lift
+                                vmrights_to_H_def vm_rights_defs gen_framesize_to_H_def
+                                is_aligned_neg_mask_eq_concrete[THEN sym]
+                                vm_page_size_defs cl_valid_cap_def c_valid_cap_def mask_def)
+         apply wpsimp
+        apply (simp add: guard_is_UNIV_def)
+       apply (clarsimp simp: createObject_hs_preconds_def frameSizeConstants_defs
+                             APIType_capBits_def pageBits_def is_aligned_no_overflow_mask)
+       apply (rule conjI)
+        apply (drule is_aligned_addrFromPPtr_n, simp)
+        apply (simp add: is_aligned_no_overflow_mask)
+       apply (simp add: mask_def)
 
+      apply (in_case "PageTableObject")
       apply (cinit' lift: t_' regionBase_' userSize_' deviceMemory_')
        apply (simp add: object_type_from_H_def Kernel_C_defs)
-       apply (simp add: ccorres_cond_univ_iff ccorres_cond_empty_iff
-                        ARMLargePageBits_def ARMSmallPageBits_def
-                        ARMSectionBits_def ARMSuperSectionBits_def asidInvalid_def
-                        sle_positive APIType_capBits_def shiftL_nat objBits_simps
-                        ptBits_def archObjSize_def pageBits_def word_sle_def word_sless_def
-                        fold_eq_0_to_bool)
-       apply (ccorres_remove_UNIV_guard)
+       apply (simp add: ccorres_cond_univ_iff ccorres_cond_empty_iff asidInvalid_def
+                        APIType_capBits_def shiftL_nat objBits_simps
+                        ptBits_def archObjSize_def pageBits_def word_sle_def word_sless_def)
+       apply (rule ccorres_rhs_assoc)+
        apply (clarsimp simp: hrs_htd_update ptBits_def objBits_simps archObjSize_def
-         ARM_HYP_H.createObject_def pageBits_def
-         cond_second_eq_seq_ccorres modify_gsUserPages_update
-         intro!: ccorres_rhs_assoc)
-       apply ((rule ccorres_return_C | simp | wp | vcg
-         | (rule match_ccorres, ctac add:
-                 placeNewDataObject_ccorres[where us=13 and newType=newType, simplified]
-                 gsUserPages_update_ccorres[folded modify_gsUserPages_update])
-         | (rule match_ccorres, csymbr))+)[1]
+                             ARM_HYP_H.createObject_def pageBits_def pt_bits_def pte_bits_def)
+       apply (ctac pre only: add: placeNewObject_pte[simplified])
+         apply csymbr
+         apply (ctac (no_vcg) add: cleanCacheRange_PoU_ccorres)
+          apply csymbr
+          apply (rule ccorres_return_C; simp)
+         apply wp
+        apply wp
+       apply vcg
+      apply clarify
       apply (intro conjI)
-       apply (clarsimp simp: createObject_hs_preconds_def
-                             APIType_capBits_def pageBits_def)
+       apply (clarsimp simp: invs_pspace_aligned' invs_pspace_distinct' invs_valid_global'
+                             APIType_capBits_def invs_valid_objs' is_aligned_no_overflow_mask
+                             invs_urz)
+       apply (rule conjI, simp add: mask_def)
+       apply (drule is_aligned_addrFromPPtr_n, simp)
+       apply (simp add: is_aligned_no_overflow_mask)
+      apply clarsimp
       apply (clarsimp simp: pageBits_def ccap_relation_def APIType_capBits_def
-                            framesize_to_H_def cap_to_H_simps cap_frame_cap_lift
-                            vmrights_to_H_def mask_def vm_rights_defs vm_page_size_defs
-                            cl_valid_cap_def c_valid_cap_def
-                            is_aligned_neg_mask_eq_concrete[THEN sym])
+                            framesize_to_H_def cap_to_H_simps cap_page_table_cap_lift
+                            is_aligned_neg_mask_eq vmrights_to_H_def
+                            Kernel_C.VMReadWrite_def Kernel_C.VMNoAccess_def
+                            Kernel_C.VMKernelOnly_def Kernel_C.VMReadOnly_def)
+      apply (clarsimp simp: isFrameType_def mask_def is_aligned_neg_mask_eq_concrete[THEN sym])
 
-     \<comment> \<open>PageTableObject\<close>
+     apply (in_case "PageDirectoryObject")
      apply (cinit' lift: t_' regionBase_' userSize_' deviceMemory_')
       apply (simp add: object_type_from_H_def Kernel_C_defs)
       apply (simp add: ccorres_cond_univ_iff ccorres_cond_empty_iff
-                       ARMLargePageBits_def ARMSmallPageBits_def
-                       ARMSectionBits_def ARMSuperSectionBits_def asidInvalid_def
-                       sle_positive APIType_capBits_def shiftL_nat objBits_simps
-                       ptBits_def archObjSize_def pageBits_def word_sle_def word_sless_def)
-      apply (ccorres_remove_UNIV_guard)
+                       asidInvalid_def APIType_capBits_def shiftL_nat
+                       objBits_simps archObjSize_def isFrameType_def
+                       ptBits_def pageBits_def pdBits_def word_sle_def word_sless_def)
       apply (rule ccorres_rhs_assoc)+
       apply (clarsimp simp: hrs_htd_update ptBits_def objBits_simps archObjSize_def
-                            ARM_HYP_H.createObject_def pageBits_def pt_bits_def)
-      apply (ctac pre only: add: placeNewObject_pte[simplified])
-        apply csymbr
-        apply (rule ccorres_return_C)
-          apply simp
-         apply simp
-        apply simp
-       apply wp
-      apply vcg
-     apply clarify
-     apply (intro conjI)
-      apply (clarsimp simp: invs_pspace_aligned' invs_pspace_distinct' invs_valid_global'
-                            APIType_capBits_def invs_valid_objs'
-                            invs_urz)
-     apply clarsimp
-     apply (clarsimp simp: pageBits_def ccap_relation_def APIType_capBits_def
-                           framesize_to_H_def cap_to_H_simps cap_page_table_cap_lift
-                           is_aligned_neg_mask_eq vmrights_to_H_def
-                           Kernel_C.VMReadWrite_def Kernel_C.VMNoAccess_def
-                           Kernel_C.VMKernelOnly_def Kernel_C.VMReadOnly_def)
-     apply (clarsimp simp: isFrameType_def)
-     apply (rule sym)
-     apply (simp add: is_aligned_neg_mask_eq'[symmetric] is_aligned_weaken)
-
-    \<comment> \<open>PageDirectoryObject\<close>
-    apply (cinit' lift: t_' regionBase_' userSize_' deviceMemory_')
-     apply (simp add: object_type_from_H_def Kernel_C_defs)
-     apply (simp add: ccorres_cond_univ_iff ccorres_cond_empty_iff
-                      asidInvalid_def sle_positive APIType_capBits_def shiftL_nat
-                      objBits_simps archObjSize_def
-                      ptBits_def pageBits_def pdBits_def word_sle_def word_sless_def)
-     apply (ccorres_remove_UNIV_guard)
-     apply (rule ccorres_rhs_assoc)+
-     apply (clarsimp simp: hrs_htd_update ptBits_def objBits_simps archObjSize_def
-                           ARM_HYP_H.createObject_def pageBits_def pdBits_def pd_bits_def)
-     apply (ctac pre only: add: placeNewObject_pde[simplified])
-       apply (ctac add: copyGlobalMappings_ccorres)
-         apply csymbr
-         apply (ctac add: cleanCacheRange_PoU_ccorres)
-           apply csymbr
-           apply (rule ccorres_return_C)
+                            ARM_HYP_H.createObject_def pageBits_def pdBits_def pd_bits_def)
+      apply (ctac pre only: add: placeNewObject_pde[simplified])
+        apply (ctac add: copyGlobalMappings_ccorres)
+          apply csymbr
+          apply (ctac add: cleanCacheRange_PoU_ccorres)
+            apply csymbr
+            apply (rule ccorres_return_C)
+              apply simp
              apply simp
             apply simp
-           apply simp
-          apply wp
-         apply clarsimp
-         apply vcg
-        apply wp
+           apply wp
+          apply clarsimp
+          apply vcg
+         apply wp
        apply (clarsimp simp: pageBits_def ccap_relation_def APIType_capBits_def
                              framesize_to_H_def cap_to_H_simps cap_page_directory_cap_lift
                              is_aligned_neg_mask_eq vmrights_to_H_def
@@ -5884,17 +6030,20 @@ proof -
     apply (frule invs_arch_state')
     apply (frule range_cover.aligned)
     apply (frule is_aligned_addrFromPPtr_n, simp)
-    apply (intro conjI, simp_all add: table_bits_defs)[1]
-        apply fastforce
-       apply ((clarsimp simp: is_aligned_no_overflow'[where n=14, simplified]
-                              field_simps is_aligned_mask[symmetric] mask_AND_less_0
-                              cacheLineBits_le_ptBits[unfolded ptBits_def pteBits_def, simplified])+)[3]
+     apply (intro conjI, simp_all add: table_bits_defs)[1]
+          apply fastforce
+         apply (clarsimp simp: mask_def)
+        apply (simp add: is_aligned_no_overflow_mask)
+       apply (drule is_aligned_addrFromPPtr_n, simp)
+       apply (simp add: is_aligned_no_overflow_mask)
+      apply (clarsimp simp: is_aligned_mask[symmetric] mask_AND_less_0)
+     apply (simp add: mask_def)
     \<comment> \<open>VCPU\<close>
     apply (cinit' lift: t_' regionBase_' userSize_' deviceMemory_')
      apply (simp add: object_type_from_H_def Kernel_C_defs)
      apply ccorres_rewrite
      apply (simp add: ccorres_cond_univ_iff ccorres_cond_empty_iff
-                      asidInvalid_def sle_positive APIType_capBits_def shiftL_nat
+                      asidInvalid_def APIType_capBits_def shiftL_nat
                       objBits_simps archObjSize_def word_sle_def word_sless_def)
      apply (clarsimp simp: hrs_htd_update ptBits_def objBits_simps archObjSize_def
                            ARM_HYP_H.createObject_def pageBits_def pdBits_def)
@@ -7809,6 +7958,43 @@ lemma cleanCacheRange_PoU_preserves_bytes:
               elim!: byte_regions_unmodified_trans byte_regions_unmodified_trans[rotated],
         (simp_all add: h_t_valid_field)+)
 
+lemma cleanByVA_preserves_bytes:
+  "\<forall>s. \<Gamma>\<turnstile>\<^bsub>/UNIV\<^esub> {s} Call cleanByVA_'proc
+      {t. hrs_htd (t_hrs_' (globals t)) = hrs_htd (t_hrs_' (globals s))
+         \<and> byte_regions_unmodified' s t}"
+  apply (rule allI, rule conseqPost, rule cleanByVA_preserves_kernel_bytes[rule_format])
+   apply simp_all
+  apply (clarsimp simp: byte_regions_unmodified_def)
+  done
+
+lemma cleanCacheRange_PoC_preserves_bytes:
+  "\<forall>s. \<Gamma>\<turnstile>\<^bsub>/UNIV\<^esub> {s} Call cleanCacheRange_PoC_'proc
+      {t. hrs_htd (t_hrs_' (globals t)) = hrs_htd (t_hrs_' (globals s))
+         \<and> byte_regions_unmodified' s t}"
+  apply (hoare_rule HoarePartial.ProcNoRec1)
+  apply (clarsimp simp only: whileAnno_def)
+  apply (subst whileAnno_def[symmetric, where V=undefined
+               and I="{t. hrs_htd (t_hrs_' (globals t)) = hrs_htd (t_hrs_' (globals s))
+                          \<and> byte_regions_unmodified' s t}" for s])
+  apply (rule conseqPre, vcg exspec=cleanByVA_preserves_bytes)
+  by (safe intro!: byte_regions_unmodified_hrs_mem_update
+            elim!: byte_regions_unmodified_trans byte_regions_unmodified_trans[rotated],
+      (simp_all add: h_t_valid_field)+)
+
+lemma cleanCacheRange_RAM_preserves_bytes:
+  "\<forall>s. \<Gamma>\<turnstile>\<^bsub>/UNIV\<^esub> {s} Call cleanCacheRange_RAM_'proc
+      {t. hrs_htd (t_hrs_' (globals t)) = hrs_htd (t_hrs_' (globals s))
+         \<and> byte_regions_unmodified' s t}"
+  apply (hoare_rule HoarePartial.ProcNoRec1, rule allI)
+  apply (rule conseqPre, vcg exspec=cleanCacheRange_PoC_preserves_bytes
+                             exspec=cleanL2Range_preserves_kernel_bytes
+                             exspec=dsb_preserves_kernel_bytes)
+  apply (safe intro!: byte_regions_unmodified_hrs_mem_update
+            elim!: byte_regions_unmodified_trans byte_regions_unmodified_trans[rotated],
+      (simp_all add: h_t_valid_field)+)
+  apply (clarsimp simp: byte_regions_unmodified_def)
+  done
+
 lemma hrs_htd_update_canon:
   "hrs_htd_update (\<lambda>_. f (hrs_htd hrs)) hrs = hrs_htd_update f hrs"
   by (cases hrs, simp add: hrs_htd_update_def hrs_htd_def)
@@ -7822,21 +8008,24 @@ lemma Arch_createObject_preserves_bytes:
   apply (hoare_rule HoarePartial.ProcNoRec1)
   apply clarsimp
   apply (rule conseqPre, vcg exspec=cap_small_frame_cap_new_modifies
-    exspec=cap_frame_cap_new_modifies
-    exspec=cap_page_table_cap_new_modifies
-    exspec=copyGlobalMappings_preserves_bytes
-    exspec=addrFromPPtr_modifies
-    exspec=cleanCacheRange_PoU_preserves_bytes
-    exspec=cap_page_directory_cap_new_modifies
-    exspec=cap_vcpu_cap_new_modifies)
+                             exspec=cap_frame_cap_new_modifies
+                             exspec=cap_page_table_cap_new_modifies
+                             exspec=copyGlobalMappings_preserves_bytes
+                             exspec=addrFromPPtr_modifies
+                             exspec=cleanCacheRange_PoU_preserves_bytes
+                             exspec=cleanCacheRange_RAM_preserves_bytes
+                             exspec=cap_page_directory_cap_new_modifies
+                             exspec=cap_vcpu_cap_new_modifies)
+  apply (clarsimp simp: vm_page_size_defs)
   apply (safe intro!: byte_regions_unmodified_hrs_mem_update,
          (simp_all add: h_t_valid_field hrs_htd_update)+)
-             apply (safe intro!: ptr_retyp_d ptr_retyps_out)
-             apply (simp_all add: object_type_from_H_def Kernel_C_defs APIType_capBits_def
-                           split: object_type.split_asm ArchTypes_H.apiobject_type.split_asm)
-   apply (rule byte_regions_unmodified_flip, simp)
-   apply (rule byte_regions_unmodified_trans[rotated],
-          assumption, simp_all add: hrs_htd_update_canon hrs_htd_update)
+                     apply (safe intro!: ptr_retyp_d ptr_retyps_out)
+                     apply (simp_all add: object_type_from_H_def Kernel_C_defs APIType_capBits_def
+                                   split: object_type.split_asm ArchTypes_H.apiobject_type.split_asm)
+           apply (all \<open>(solves \<open>simp add: mask_def\<close>)?\<close>)
+        apply (rule byte_regions_unmodified_flip, simp,
+               rule byte_regions_unmodified_trans[rotated], assumption;
+               simp add: hrs_htd_update_canon hrs_htd_update)+
   apply (drule intvlD)
   apply clarsimp
   apply (erule notE, rule intvlI)
@@ -7991,6 +8180,14 @@ lemma insertNewCap_ccorres:
   apply (simp add: untypedZeroRange_def Let_def)
   done
 
+lemma Arch_createObject_not_untyped:
+  "\<forall>s. \<Gamma>\<turnstile>\<^bsub>/UNIV\<^esub>
+   {s} Call Arch_createObject_'proc {t. cap_get_tag (ret__struct_cap_C_' t) \<noteq> scast cap_untyped_cap}"
+  apply (rule allI, rule conseqPre)
+   apply (vcg exspec=cleanCacheRange_PoU_modifies exspec=cleanCacheRange_RAM_modifies)
+  apply (clarsimp simp: cap_tag_defs vm_page_size_defs mask_def)
+  done
+
 lemma createObject_untyped_region_is_zero_bytes:
   "\<forall>\<sigma>. \<Gamma>\<turnstile>\<^bsub>/UNIV\<^esub> {s. let tp = (object_type_to_H (t_' s));
           sz = APIType_capBits tp (unat (userSize_' s))
@@ -8002,16 +8199,13 @@ lemma createObject_untyped_region_is_zero_bytes:
    {t. cap_get_tag (ret__struct_cap_C_' t) = scast cap_untyped_cap
          \<longrightarrow> (case untypedZeroRange (cap_to_H (the (cap_lift (ret__struct_cap_C_' t)))) of None \<Rightarrow> True
           | Some (a, b) \<Rightarrow> region_actually_is_zero_bytes a (unat ((b + 1) - a)) t)}"
-  apply (rule allI, rule conseqPre, vcg exspec=copyGlobalMappings_modifies
-      exspec=Arch_initContext_modifies
-      exspec=cleanCacheRange_PoU_modifies)
+  apply (rule allI, rule conseqPre, vcg exspec=Arch_createObject_not_untyped)
   apply (clarsimp simp: cap_tag_defs Let_def)
   apply (simp add: cap_lift_untyped_cap cap_tag_defs cap_to_H_simps
                    cap_untyped_cap_lift_def object_type_from_H_def)
   apply (simp add: untypedZeroRange_def split: if_split)
   apply (clarsimp simp: getFreeRef_def Let_def object_type_to_H_def untypedBits_defs)
-  apply (simp add:  APIType_capBits_def
-                   less_mask_eq word_less_nat_alt)
+  apply (simp add: APIType_capBits_def less_mask_eq word_less_nat_alt)
   done
 
 lemma createNewObjects_ccorres:

--- a/proof/crefine/X64/Arch_C.thy
+++ b/proof/crefine/X64/Arch_C.thy
@@ -1468,21 +1468,6 @@ lemma obj_at_pte_aligned:
                   elim!: is_aligned_weaken)
   done
 
-(* FIXME x64: dont know what these are for yet *)
-lemma addrFromPPtr_mask_5:
-  "addrFromPPtr ptr && mask (5::nat) = ptr && mask (5::nat)"
-  apply (simp add:addrFromPPtr_def X64.pptrBase_def)
-  apply word_bitwise
-  apply (simp add:mask_def)
-  done
-
-lemma addrFromPPtr_mask_6:
-  "addrFromPPtr ptr && mask (6::nat) = ptr && mask (6::nat)"
-  apply (simp add:addrFromPPtr_def X64.pptrBase_def)
-  apply word_bitwise
-  apply (simp add:mask_def)
-  done
-
 lemma cpde_relation_invalid:
  "cpde_relation pdea pde \<Longrightarrow> (pde_get_tag pde = scast pde_pde_pt \<and> pde_pde_pt_CL.present_CL (pde_pde_pt_lift pde) = 0) = isInvalidPDE pdea"
   apply (simp add: cpde_relation_def Let_def)

--- a/proof/infoflow/ADT_IF.thy
+++ b/proof/infoflow/ADT_IF.thy
@@ -959,7 +959,7 @@ locale ADT_IF_1 =
   and arch_invoke_irq_control_noErr[wp]:
     "\<And>Q. \<lbrace>\<top>\<rbrace> arch_invoke_irq_control ici -, \<lbrace>\<lambda>rv s :: det_state. Q rv s\<rbrace>"
   and init_arch_objects_irq_state_of_state[wp]:
-    "\<And>P. init_arch_objects new_type ptr num_objects obj_sz refs \<lbrace>\<lambda>s. P (irq_state_of_state s)\<rbrace>"
+    "\<And>P. init_arch_objects new_type dev ptr num_objects obj_sz refs \<lbrace>\<lambda>s. P (irq_state_of_state s)\<rbrace>"
   and getActiveIRQ_None:
     "(None, s') \<in> fst (do_machine_op (getActiveIRQ in_kernel) (s :: det_state))
      \<Longrightarrow> irq_at (irq_state (machine_state s) + 1) (irq_masks (machine_state s)) = None"

--- a/proof/infoflow/ARM/ArchADT_IF.thy
+++ b/proof/infoflow/ARM/ArchADT_IF.thy
@@ -148,9 +148,9 @@ lemma arch_invoke_irq_control_noErr[ADT_IF_assms, wp]:
   "\<lbrace>\<top>\<rbrace> arch_invoke_irq_control a -, \<lbrace>Q\<rbrace>"
   by (cases a; wpsimp)
 
-crunch cleanCacheRange_PoU
+crunch cleanCacheRange_PoU, cleanCacheRange_RAM
   for irq_state[wp]: "\<lambda>s. P (irq_state s)"
-  (ignore_del: cleanCacheRange_PoU cleanByVA_PoU)
+  (ignore_del: cleanCacheRange_PoU cleanByVA_PoU cleanL2Range dsb cleanByVA)
 
 crunch init_arch_objects
   for irq_state_of_state[ADT_IF_assms, wp]: "\<lambda>s. P (irq_state_of_state s)"

--- a/proof/infoflow/FinalCaps.thy
+++ b/proof/infoflow/FinalCaps.thy
@@ -347,9 +347,9 @@ locale FinalCaps_1 =
   and arch_switch_to_thread_silc_inv[wp]:
     "arch_switch_to_thread t \<lbrace>silc_inv aag st\<rbrace>"
   and init_arch_objects_silc_inv[wp]:
-    "init_arch_objects typ ptr num sz refs \<lbrace>silc_inv aag st\<rbrace>"
+    "init_arch_objects typ dev ptr num sz refs \<lbrace>silc_inv aag st\<rbrace>"
   and init_arch_objects_cte_wp_at[wp]:
-    "\<And>P. init_arch_objects typ ptr num sz refs \<lbrace>\<lambda>s :: det_state. P (cte_wp_at P' slot s)\<rbrace>"
+    "\<And>P. init_arch_objects typ dev ptr num sz refs \<lbrace>\<lambda>s :: det_state. P (cte_wp_at P' slot s)\<rbrace>"
   and finalise_cap_makes_halted:
     "\<lbrace>invs and valid_cap cap and (\<lambda>s. ex = is_final_cap' cap s) and cte_wp_at ((=) cap) slot\<rbrace>
      finalise_cap cap ex

--- a/proof/infoflow/PasUpdates.thy
+++ b/proof/infoflow/PasUpdates.thy
@@ -130,7 +130,7 @@ locale PasUpdates_2 = PasUpdates_1 +
   and handle_arch_fault_reply_domain_fields[wp]:
     "handle_arch_fault_reply vmf thread x y \<lbrace>domain_fields P\<rbrace>"
   and init_arch_objects_domain_fields[wp]:
-    "init_arch_objects typ ptr num sz refs \<lbrace>domain_fields P\<rbrace>"
+    "init_arch_objects typ dev ptr num sz refs \<lbrace>domain_fields P\<rbrace>"
   and state_asids_to_policy_pasSubject_update:
     "state_asids_to_policy (aag\<lparr>pasSubject := subject\<rparr>) s =
      state_asids_to_policy aag s"

--- a/proof/infoflow/RISCV64/ArchIRQMasks_IF.thy
+++ b/proof/infoflow/RISCV64/ArchIRQMasks_IF.thy
@@ -152,7 +152,7 @@ lemma invoke_tcb_irq_masks[IRQMasks_IF_assms]:
   by fastforce+
 
 lemma init_arch_objects_irq_masks:
-  "init_arch_objects new_type ptr num_objects obj_sz refs \<lbrace>\<lambda>s. P (irq_masks_of_state s)\<rbrace>"
+  "init_arch_objects new_type dev ptr num_objects obj_sz refs \<lbrace>\<lambda>s. P (irq_masks_of_state s)\<rbrace>"
   by (rule init_arch_objects_inv)
 
 end

--- a/proof/infoflow/RISCV64/ArchRetype_IF.thy
+++ b/proof/infoflow/RISCV64/ArchRetype_IF.thy
@@ -227,7 +227,7 @@ lemma dmo_freeMemory_globals_equiv[Retype_IF_assms]:
   done
 
 lemma init_arch_objects_reads_respects_g:
-  "reads_respects_g aag l \<top> (init_arch_objects new_type ptr num_objects obj_sz refs)"
+  "reads_respects_g aag l \<top> (init_arch_objects new_type dev ptr num_objects obj_sz refs)"
   unfolding init_arch_objects_def by wp
 
 lemma copy_global_mappings_globals_equiv:

--- a/proof/invariant-abstract/AARCH64/ArchDetSchedAux_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchDetSchedAux_AI.thy
@@ -19,6 +19,7 @@ crunch init_arch_objects
   and valid_queues[wp]: valid_queues
   and valid_sched_action[wp]: valid_sched_action
   and valid_sched[wp]: valid_sched
+  (wp: mapM_x_wp')
 
 (* already proved earlier *)
 declare invoke_untyped_cur_thread[DetSchedAux_AI_assms]

--- a/proof/invariant-abstract/AARCH64/ArchRetype_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchRetype_AI.thy
@@ -147,13 +147,10 @@ lemma init_arch_objects_invs_from_restricted:
   "\<lbrace>post_retype_invs new_type refs
          and (\<lambda>s. global_refs s \<inter> set refs = {})
          and K (\<forall>ref \<in> set refs. is_aligned ref (obj_bits_api new_type obj_sz))\<rbrace>
-     init_arch_objects new_type ptr bits obj_sz refs
+     init_arch_objects new_type dev ptr bits obj_sz refs
    \<lbrace>\<lambda>_. invs\<rbrace>"
   apply (simp add: init_arch_objects_def split del: if_split)
-  apply (rule hoare_pre)
-   apply (wp hoare_vcg_const_Ball_lift
-             valid_irq_node_typ
-                  | wpc)+
+  apply (wpsimp wp: dmo_invs_lift mapM_x_wp')
   apply (auto simp: post_retype_invs_def)
   done
 
@@ -981,7 +978,7 @@ crunch init_arch_objects
 
 lemma init_arch_objects_excap:
   "\<lbrace>ex_cte_cap_wp_to P p\<rbrace>
-      init_arch_objects tp ptr bits us refs
+      init_arch_objects tp dev ptr bits us refs
    \<lbrace>\<lambda>rv s. ex_cte_cap_wp_to P p s\<rbrace>"
   by (wp ex_cte_cap_to_pres)
 

--- a/proof/invariant-abstract/AARCH64/ArchUntyped_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchUntyped_AI.thy
@@ -192,15 +192,17 @@ lemma cap_refs_in_kernel_windowD2:
 
 lemma init_arch_objects_descendants_range[wp,Untyped_AI_assms]:
   "\<lbrace>\<lambda>(s::'state_ext::state_ext state). descendants_range x cref s \<rbrace>
-   init_arch_objects ty ptr n us y
+   init_arch_objects ty dev ptr n us y
    \<lbrace>\<lambda>rv s. descendants_range x cref s\<rbrace>"
-  unfolding init_arch_objects_def by wp
+  unfolding init_arch_objects_def descendants_range_def
+  by (wp mapM_x_wp' | wps)+ simp
 
 lemma init_arch_objects_caps_overlap_reserved[wp,Untyped_AI_assms]:
   "\<lbrace>\<lambda>(s::'state_ext::state_ext state). caps_overlap_reserved S s\<rbrace>
-   init_arch_objects ty ptr n us y
+   init_arch_objects ty dev ptr n us y
    \<lbrace>\<lambda>rv s. caps_overlap_reserved S s\<rbrace>"
-  unfolding init_arch_objects_def by wp
+  unfolding init_arch_objects_def caps_overlap_reserved_def
+  by (wp mapM_x_wp' | wps)+ simp
 
 lemma set_untyped_cap_invs_simple[Untyped_AI_assms]:
   "\<lbrace>\<lambda>s. descendants_range_in {ptr .. ptr+2^sz - 1} cref s \<and> pspace_no_overlap_range_cover ptr sz s \<and> invs s
@@ -325,9 +327,9 @@ lemma init_arch_objects_nonempty_table[Untyped_AI_assms, wp]:
   "\<lbrace>(\<lambda>s. \<not> (obj_at (nonempty_table (set (second_level_tables (arch_state s)))) r s)
          \<and> valid_global_objs s \<and> valid_arch_state s \<and> pspace_aligned s) and
     K (\<forall>ref\<in>set refs. is_aligned ref (obj_bits_api tp us))\<rbrace>
-        init_arch_objects tp ptr bits us refs
+        init_arch_objects tp dev ptr bits us refs
    \<lbrace>\<lambda>rv s. \<not> (obj_at (nonempty_table (set (second_level_tables (arch_state s)))) r s)\<rbrace>"
-  unfolding init_arch_objects_def by wpsimp
+  unfolding init_arch_objects_def by (wpsimp wp: mapM_x_wp')
 
 lemma nonempty_table_caps_of[Untyped_AI_assms]:
   "nonempty_table S ko \<Longrightarrow> caps_of ko = {}"
@@ -344,6 +346,7 @@ lemma nonempty_default[simp, Untyped_AI_assms]:
 
 crunch init_arch_objects
   for cte_wp_at_iin[wp]: "\<lambda>s. P (cte_wp_at (P' (interrupt_irq_node s)) p s)"
+  (wp: mapM_x_wp')
 
 lemmas init_arch_objects_ex_cte_cap_wp_to = init_arch_objects_excap
 

--- a/proof/invariant-abstract/AARCH64/ArchVSpaceEntries_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchVSpaceEntries_AI.thy
@@ -176,9 +176,9 @@ lemma init_arch_objects_valid_vspace:
   "\<lbrace>valid_vspace_objs' and pspace_aligned and valid_arch_state
            and K (orefs = retype_addrs ptr type n us)
            and K (range_cover ptr sz (obj_bits_api type us) n)\<rbrace>
-     init_arch_objects type ptr n obj_sz orefs
+     init_arch_objects type dev ptr n obj_sz orefs
    \<lbrace>\<lambda>rv. valid_vspace_objs'\<rbrace>"
-  unfolding init_arch_objects_def by wpsimp
+  unfolding init_arch_objects_def by (wpsimp wp: mapM_x_wp')
 
 lemma delete_objects_valid_vspace_objs'[wp]:
   "\<lbrace>valid_vspace_objs'\<rbrace> delete_objects ptr bits \<lbrace>\<lambda>rv. valid_vspace_objs'\<rbrace>"

--- a/proof/invariant-abstract/ARM/ArchRetype_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchRetype_AI.thy
@@ -599,14 +599,11 @@ lemma init_arch_objects_invs_from_restricted:
   "\<lbrace>post_retype_invs new_type refs
          and (\<lambda>s. global_refs s \<inter> set refs = {})
          and K (\<forall>ref \<in> set refs. is_aligned ref (obj_bits_api new_type obj_sz))\<rbrace>
-     init_arch_objects new_type ptr bits obj_sz refs
+     init_arch_objects new_type dev ptr bits obj_sz refs
    \<lbrace>\<lambda>_. invs\<rbrace>"
   apply (simp add: init_arch_objects_def split del: if_split)
-  apply (rule hoare_pre)
-   apply (wp mapM_copy_global_invs_mappings_restricted
-             hoare_vcg_const_Ball_lift
-             valid_irq_node_typ
-                  | wpc)+
+  apply (wpsimp wp: mapM_copy_global_invs_mappings_restricted dmo_invs_lift
+                    mapM_x_wp'[where f="\<lambda>r. do_machine_op (m r)" for m])
   apply (auto simp: post_retype_invs_def default_arch_object_def
                     pd_bits_def pageBits_def obj_bits_api_def
                     global_refs_def)
@@ -1363,7 +1360,7 @@ crunch init_arch_objects
 
 lemma init_arch_objects_excap:
   "\<lbrace>ex_cte_cap_wp_to P p\<rbrace>
-      init_arch_objects tp ptr bits us refs
+      init_arch_objects tp dev ptr bits us refs
    \<lbrace>\<lambda>rv s. ex_cte_cap_wp_to P p s\<rbrace>"
   by (wp ex_cte_cap_to_pres)
 

--- a/proof/invariant-abstract/ARM/ArchVSpaceEntries_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchVSpaceEntries_AI.thy
@@ -668,26 +668,25 @@ lemma init_arch_objects_valid_pdpt:
   "\<lbrace>valid_pdpt_objs and pspace_aligned and valid_arch_state
            and K (\<exists>us sz. orefs = retype_addrs ptr type n us
                \<and> range_cover ptr sz (obj_bits_api type us) n)\<rbrace>
-     init_arch_objects type ptr n obj_sz orefs
+     init_arch_objects type dev ptr n obj_sz orefs
    \<lbrace>\<lambda>rv. valid_pdpt_objs\<rbrace>"
   apply (rule hoare_gen_asm)+
-  apply (clarsimp simp: init_arch_objects_def
-             split del: if_split)
-  apply (rule hoare_pre)
-   apply (wp | wpc)+
-     apply (rule_tac Q'="\<lambda>rv. valid_pdpt_objs and pspace_aligned and valid_arch_state"
-                  in hoare_post_imp, simp)
-     apply (rule mapM_x_wp')
-     apply (rule hoare_pre, wp copy_global_mappings_valid_pdpt_objs)
-     apply clarsimp
-     apply (drule_tac sz=sz in retype_addrs_aligned)
-        apply (simp add:range_cover_def)
-       apply (drule range_cover.sz,simp add:word_bits_def)
-      apply (simp add:range_cover_def)
-     apply (clarsimp simp:obj_bits_api_def pd_bits_def pageBits_def
-       arch_kobj_size_def default_arch_object_def range_cover_def)+
+  apply (clarsimp simp: init_arch_objects_def split del: if_split)
+  apply (wp | wpc)+
+     apply (wpsimp wp: mapM_x_wp' hoare_vcg_op_lift)
+    apply (wpsimp wp: mapM_x_wp' hoare_vcg_op_lift)
+   apply (rule_tac Q'="\<lambda>rv. valid_pdpt_objs and pspace_aligned and valid_arch_state"
+                   in hoare_post_imp, simp)
    apply wp
-  apply simp
+   apply (rule mapM_x_wp')
+   apply (wp copy_global_mappings_valid_pdpt_objs)
+   apply clarsimp
+   apply (drule_tac sz=sz in retype_addrs_aligned)
+      apply (simp add:range_cover_def)
+     apply (drule range_cover.sz,simp add:word_bits_def)
+    apply (simp add:range_cover_def)
+   apply (clarsimp simp: obj_bits_api_def pd_bits_def pageBits_def
+                         arch_kobj_size_def default_arch_object_def range_cover_def)+
   done
 
 lemma delete_objects_valid_pdpt:

--- a/proof/invariant-abstract/ARM_HYP/ArchRetype_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchRetype_AI.thy
@@ -439,14 +439,11 @@ lemma init_arch_objects_invs_from_restricted:
   "\<lbrace>post_retype_invs new_type refs
          and (\<lambda>s. global_refs s \<inter> set refs = {})
          and K (\<forall>ref \<in> set refs. is_aligned ref (obj_bits_api new_type obj_sz))\<rbrace>
-     init_arch_objects new_type ptr bits obj_sz refs
+     init_arch_objects new_type dev ptr bits obj_sz refs
    \<lbrace>\<lambda>_. invs\<rbrace>"
   apply (simp add: init_arch_objects_def split del: if_split)
-  apply (rule hoare_pre)
-   apply (wp mapM_copy_global_invs_mappings_restricted
-             hoare_vcg_const_Ball_lift
-             valid_irq_node_typ
-                  | wpc)+
+  apply (wpsimp wp: mapM_copy_global_invs_mappings_restricted dmo_invs_lift
+                    mapM_x_wp'[where f="\<lambda>r. do_machine_op (m r)" for m])
   apply (auto simp: post_retype_invs_def default_arch_object_def
                     pd_bits_def pageBits_def obj_bits_api_def
                     global_refs_def)
@@ -1213,7 +1210,7 @@ crunch init_arch_objects
 
 lemma init_arch_objects_excap:
   "\<lbrace>ex_cte_cap_wp_to P p\<rbrace>
-      init_arch_objects tp ptr bits us refs
+      init_arch_objects tp dev ptr bits us refs
    \<lbrace>\<lambda>rv s. ex_cte_cap_wp_to P p s\<rbrace>"
   by (wp ex_cte_cap_to_pres)
 

--- a/proof/invariant-abstract/ARM_HYP/ArchUntyped_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchUntyped_AI.thy
@@ -186,24 +186,13 @@ lemma copy_global_mappings_hoare_lift:(*FIXME: arch-split  \<rightarrow> these d
   done
 
 lemma init_arch_objects_hoare_lift:
-  assumes wp: "\<And>oper. \<lbrace>(P::'state_ext::state_ext state\<Rightarrow>bool)\<rbrace> do_machine_op oper \<lbrace>\<lambda>rv :: unit. Q\<rbrace>"
-              "\<And>ptr val. \<lbrace>P\<rbrace> store_pde ptr val \<lbrace>\<lambda>rv. P\<rbrace>"
-  shows       "\<lbrace>P and Q\<rbrace> init_arch_objects tp ptr sz us adds \<lbrace>\<lambda>rv. Q\<rbrace>"
-proof -
-  have pres: "\<And>oper. \<lbrace>P and Q\<rbrace> do_machine_op oper \<lbrace>\<lambda>rv :: unit. Q\<rbrace>"
-             "\<lbrace>P and Q\<rbrace> return () \<lbrace>\<lambda>rv. Q\<rbrace>"
-    by (wp wp | simp)+
-  show ?thesis
-    apply (simp add: init_arch_objects_def
-                  pres reserve_region_def
-           split: Structures_A.apiobject_type.split
-                  aobject_type.split)
-    apply clarsimp
-    apply (rule hoare_pre)
-     apply (wp mapM_x_wp' copy_global_mappings_hoare_lift wp)
-    apply simp
-    done
-qed
+  assumes wp: "\<And>oper. \<lbrace>(Q::'state_ext::state_ext state\<Rightarrow>bool)\<rbrace> do_machine_op oper \<lbrace>\<lambda>rv :: unit. Q\<rbrace>"
+              "\<And>ptr val. \<lbrace>Q\<rbrace> store_pde ptr val \<lbrace>\<lambda>rv. Q\<rbrace>"
+  shows       "\<lbrace>Q\<rbrace> init_arch_objects tp dev ptr sz us adds \<lbrace>\<lambda>rv. Q\<rbrace>"
+  supply if_split[split del]
+  apply (simp add: init_arch_objects_def reserve_region_def)
+  apply (wpsimp wp: mapM_x_wp' copy_global_mappings_hoare_lift wp)
+  done
 
 
 lemma cap_refs_in_kernel_windowD2:
@@ -215,28 +204,20 @@ lemma cap_refs_in_kernel_windowD2:
   done
 
 lemma init_arch_objects_descendants_range[wp,Untyped_AI_assms]:
-  "\<lbrace>\<lambda>(s::'state_ext::state_ext state). descendants_range x cref s \<rbrace> init_arch_objects ty ptr n us y
+  "\<lbrace>\<lambda>(s::'state_ext::state_ext state). descendants_range x cref s \<rbrace> init_arch_objects ty dev ptr n us y
           \<lbrace>\<lambda>rv s. descendants_range x cref s\<rbrace>"
-  apply (simp add:descendants_range_def)
-  apply (rule hoare_pre)
-   apply (wp retype_region_mdb init_arch_objects_hoare_lift)
-    apply (wps do_machine_op_mdb)
-    apply (wp hoare_vcg_ball_lift)
-   apply (rule hoare_pre)
-    apply (wps store_pde_mdb_inv)
-    apply wp
-   apply simp
-  apply fastforce
+  apply (simp add: descendants_range_def)
+  apply (wp retype_region_mdb init_arch_objects_hoare_lift)
+    apply (wp_pre, wps do_machine_op_mdb, wp, simp)+
+  apply simp
   done
 
 lemma init_arch_objects_caps_overlap_reserved[wp,Untyped_AI_assms]:
   "\<lbrace>\<lambda>(s::'state_ext::state_ext state). caps_overlap_reserved S s\<rbrace>
-   init_arch_objects ty ptr n us y
+   init_arch_objects ty dev ptr n us y
    \<lbrace>\<lambda>rv s. caps_overlap_reserved S s\<rbrace>"
   apply (simp add:caps_overlap_reserved_def)
-  apply (rule hoare_pre)
-   apply (wp retype_region_mdb init_arch_objects_hoare_lift)
-  apply fastforce
+  apply (wp retype_region_mdb init_arch_objects_hoare_lift)
   done
 
 lemma set_untyped_cap_invs_simple[Untyped_AI_assms]:
@@ -408,12 +389,10 @@ lemma init_arch_objects_nonempty_table[Untyped_AI_assms, wp]:
   "\<lbrace>(\<lambda>s. \<not> (obj_at (nonempty_table (set (second_level_tables (arch_state s)))) r s)
          \<and> valid_global_objs s \<and> valid_arch_state s \<and> pspace_aligned s) and
     K (\<forall>ref\<in>set refs. is_aligned ref (obj_bits_api tp us))\<rbrace>
-        init_arch_objects tp ptr bits us refs
+        init_arch_objects tp dev ptr bits us refs
    \<lbrace>\<lambda>rv s. \<not> (obj_at (nonempty_table (set (second_level_tables (arch_state s)))) r s)\<rbrace>"
-  apply (rule hoare_gen_asm)
   apply (simp add: init_arch_objects_def split del: if_split)
-  apply (rule hoare_pre)
-   apply (wp unless_wp | wpc | simp add: reserve_region_def)+
+  apply (wpsimp wp: mapM_x_wp'[where f="\<lambda>r. do_machine_op (m r)" for m])
   apply (clarsimp simp: obj_bits_api_def default_arch_object_def pd_bits_def pageBits_def)
   done
 

--- a/proof/invariant-abstract/ARM_HYP/ArchVSpaceEntries_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchVSpaceEntries_AI.thy
@@ -600,26 +600,25 @@ lemma init_arch_objects_valid_pdpt:
   "\<lbrace>valid_pdpt_objs and pspace_aligned and valid_arch_state
            and K (\<exists>us sz. orefs = retype_addrs ptr type n us
                \<and> range_cover ptr sz (obj_bits_api type us) n)\<rbrace>
-     init_arch_objects type ptr n obj_sz orefs
+     init_arch_objects type dev ptr n obj_sz orefs
    \<lbrace>\<lambda>rv. valid_pdpt_objs\<rbrace>"
   apply (rule hoare_gen_asm)+
-  apply (clarsimp simp: init_arch_objects_def
-             split del: if_split)
-  apply (rule hoare_pre)
-   apply (wp | wpc)+
-     apply (rule_tac Q'="\<lambda>rv. valid_pdpt_objs and pspace_aligned and valid_arch_state"
-                  in hoare_post_imp, simp)
-     apply (rule mapM_x_wp')
-     apply (rule hoare_pre, wp copy_global_mappings_valid_pdpt_objs)
-     apply clarsimp
-     apply (drule_tac sz=sz in retype_addrs_aligned)
-        apply (simp add:range_cover_def)
-       apply (drule range_cover.sz,simp add:word_bits_def)
-      apply (simp add:range_cover_def)
-     apply (clarsimp simp:obj_bits_api_def pd_bits_def pageBits_def
-       arch_kobj_size_def default_arch_object_def range_cover_def)+
+  apply (clarsimp simp: init_arch_objects_def split del: if_split)
+  apply (wp | wpc)+
+     apply (wpsimp wp: mapM_x_wp' hoare_vcg_op_lift)
+    apply (wpsimp wp: mapM_x_wp' hoare_vcg_op_lift)
+   apply (rule_tac Q'="\<lambda>rv. valid_pdpt_objs and pspace_aligned and valid_arch_state"
+                   in hoare_post_imp, simp)
    apply wp
-  apply simp
+   apply (rule mapM_x_wp')
+   apply (wp copy_global_mappings_valid_pdpt_objs)
+   apply clarsimp
+   apply (drule_tac sz=sz in retype_addrs_aligned)
+      apply (simp add: range_cover_def)
+     apply (drule range_cover.sz,simp add:word_bits_def)
+    apply (simp add: range_cover_def)
+   apply (clarsimp simp: obj_bits_api_def pd_bits_def pageBits_def
+                         arch_kobj_size_def default_arch_object_def range_cover_def)+
   done
 
 lemma delete_objects_valid_pdpt:

--- a/proof/invariant-abstract/DetSchedAux_AI.thy
+++ b/proof/invariant-abstract/DetSchedAux_AI.thy
@@ -146,9 +146,9 @@ locale DetSchedAux_AI_det_ext = DetSchedAux_AI "TYPE(det_ext)" +
         invoke_untyped ui
       \<lbrace>\<lambda>r s. st_tcb_at (Not o inactive) t s \<longrightarrow> etcb_at P t s\<rbrace> "
   assumes init_arch_objects_valid_etcbs[wp]:
-    "\<And>t r n sz refs. \<lbrace>valid_etcbs\<rbrace> init_arch_objects t r n sz refs \<lbrace>\<lambda>_. valid_etcbs\<rbrace>"
+    "\<And>t d r n sz refs. \<lbrace>valid_etcbs\<rbrace> init_arch_objects t d r n sz refs \<lbrace>\<lambda>_. valid_etcbs\<rbrace>"
   assumes init_arch_objects_valid_blocked[wp]:
-    "\<And>t r n sz refs. \<lbrace>valid_blocked\<rbrace> init_arch_objects t r n sz refs \<lbrace>\<lambda>_. valid_blocked\<rbrace>"
+    "\<And>t d r n sz refs. \<lbrace>valid_blocked\<rbrace> init_arch_objects t d r n sz refs \<lbrace>\<lambda>_. valid_blocked\<rbrace>"
   assumes invoke_untyped_cur_domain[wp]:
     "\<And>P i. \<lbrace>\<lambda>s. P (cur_domain s)\<rbrace> invoke_untyped i \<lbrace>\<lambda>_ s. P (cur_domain s)\<rbrace>"
   assumes invoke_untyped_ready_queues[wp]:

--- a/proof/invariant-abstract/DetSchedDomainTime_AI.thy
+++ b/proof/invariant-abstract/DetSchedDomainTime_AI.thy
@@ -49,7 +49,7 @@ locale DetSchedDomainTime_AI =
   assumes handle_arch_fault_reply_domain_list_inv'[wp]:
     "\<And>P f t x y. \<lbrace>\<lambda>s. P (domain_list s)\<rbrace> handle_arch_fault_reply f t x y \<lbrace>\<lambda>_ s. P (domain_list s)\<rbrace>"
   assumes init_arch_objects_domain_list_inv'[wp]:
-    "\<And>P t p n s r. \<lbrace>\<lambda>s. P (domain_list s)\<rbrace> init_arch_objects t p n s r \<lbrace>\<lambda>_ s. P (domain_list s)\<rbrace>"
+    "\<And>P t d p n s r. \<lbrace>\<lambda>s. P (domain_list s)\<rbrace> init_arch_objects t d p n s r \<lbrace>\<lambda>_ s. P (domain_list s)\<rbrace>"
   assumes arch_post_modify_registers_domain_list_inv'[wp]:
     "\<And>P t p. \<lbrace>\<lambda>s. P (domain_list s)\<rbrace> arch_post_modify_registers t p \<lbrace>\<lambda>_ s. P (domain_list s)\<rbrace>"
   assumes arch_invoke_irq_control_domain_list_inv'[wp]:
@@ -71,7 +71,7 @@ locale DetSchedDomainTime_AI =
   assumes handle_arch_fault_reply_domain_time_inv'[wp]:
     "\<And>P f t x y. \<lbrace>\<lambda>s. P (domain_time s)\<rbrace> handle_arch_fault_reply f t x y \<lbrace>\<lambda>_ s. P (domain_time s)\<rbrace>"
   assumes init_arch_objects_domain_time_inv'[wp]:
-    "\<And>P t p n s r. \<lbrace>\<lambda>s. P (domain_time s)\<rbrace> init_arch_objects t p n s r \<lbrace>\<lambda>_ s. P (domain_time s)\<rbrace>"
+    "\<And>P t d p n s r. \<lbrace>\<lambda>s. P (domain_time s)\<rbrace> init_arch_objects t d p n s r \<lbrace>\<lambda>_ s. P (domain_time s)\<rbrace>"
   assumes arch_post_modify_registers_domain_time_inv'[wp]:
     "\<And>P t p. \<lbrace>\<lambda>s. P (domain_time s)\<rbrace> arch_post_modify_registers t p \<lbrace>\<lambda>_ s. P (domain_time s)\<rbrace>"
   assumes arch_invoke_irq_control_domain_time_inv'[wp]:

--- a/proof/invariant-abstract/RISCV64/ArchRetype_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchRetype_AI.thy
@@ -211,7 +211,7 @@ lemma init_arch_objects_invs_from_restricted:
   "\<lbrace>post_retype_invs new_type refs
          and (\<lambda>s. global_refs s \<inter> set refs = {})
          and K (\<forall>ref \<in> set refs. is_aligned ref (obj_bits_api new_type obj_sz))\<rbrace>
-     init_arch_objects new_type ptr bits obj_sz refs
+     init_arch_objects new_type dev ptr bits obj_sz refs
    \<lbrace>\<lambda>_. invs\<rbrace>"
   apply (simp add: init_arch_objects_def split del: if_split)
   apply (rule hoare_pre)
@@ -1047,7 +1047,7 @@ crunch init_arch_objects
 
 lemma init_arch_objects_excap:
   "\<lbrace>ex_cte_cap_wp_to P p\<rbrace>
-      init_arch_objects tp ptr bits us refs
+      init_arch_objects tp dev ptr bits us refs
    \<lbrace>\<lambda>rv s. ex_cte_cap_wp_to P p s\<rbrace>"
   by (wp ex_cte_cap_to_pres)
 

--- a/proof/invariant-abstract/RISCV64/ArchUntyped_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchUntyped_AI.thy
@@ -191,13 +191,13 @@ lemma cap_refs_in_kernel_windowD2:
 
 lemma init_arch_objects_descendants_range[wp,Untyped_AI_assms]:
   "\<lbrace>\<lambda>(s::'state_ext::state_ext state). descendants_range x cref s \<rbrace>
-   init_arch_objects ty ptr n us y
+   init_arch_objects ty dev ptr n us y
    \<lbrace>\<lambda>rv s. descendants_range x cref s\<rbrace>"
   unfolding init_arch_objects_def by wp
 
 lemma init_arch_objects_caps_overlap_reserved[wp,Untyped_AI_assms]:
   "\<lbrace>\<lambda>(s::'state_ext::state_ext state). caps_overlap_reserved S s\<rbrace>
-   init_arch_objects ty ptr n us y
+   init_arch_objects ty dev ptr n us y
    \<lbrace>\<lambda>rv s. caps_overlap_reserved S s\<rbrace>"
   unfolding init_arch_objects_def by wp
 
@@ -327,7 +327,7 @@ lemma init_arch_objects_nonempty_table[Untyped_AI_assms, wp]:
   "\<lbrace>(\<lambda>s. \<not> (obj_at (nonempty_table (set (second_level_tables (arch_state s)))) r s)
          \<and> valid_global_objs s \<and> valid_arch_state s \<and> pspace_aligned s) and
     K (\<forall>ref\<in>set refs. is_aligned ref (obj_bits_api tp us))\<rbrace>
-        init_arch_objects tp ptr bits us refs
+        init_arch_objects tp dev ptr bits us refs
    \<lbrace>\<lambda>rv s. \<not> (obj_at (nonempty_table (set (second_level_tables (arch_state s)))) r s)\<rbrace>"
   unfolding init_arch_objects_def by wpsimp
 

--- a/proof/invariant-abstract/RISCV64/ArchVSpaceEntries_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchVSpaceEntries_AI.thy
@@ -202,7 +202,7 @@ lemma init_arch_objects_valid_vspace:
   "\<lbrace>valid_vspace_objs' and pspace_aligned and valid_arch_state
            and K (orefs = retype_addrs ptr type n us)
            and K (range_cover ptr sz (obj_bits_api type us) n)\<rbrace>
-     init_arch_objects type ptr n obj_sz orefs
+     init_arch_objects type dev ptr n obj_sz orefs
    \<lbrace>\<lambda>rv. valid_vspace_objs'\<rbrace>"
   unfolding init_arch_objects_def by wpsimp
 

--- a/proof/invariant-abstract/Untyped_AI.thy
+++ b/proof/invariant-abstract/Untyped_AI.thy
@@ -279,12 +279,15 @@ locale Untyped_AI_arch =
                               (kheap s)\<rparr> \<turnstile> ArchObjectCap (arch_default_cap x6 (ptr_add ptr (y * 2 ^ obj_bits_api (ArchObject x6) us)) us dev)"
 
   assumes init_arch_objects_descendants_range[wp]:
-  "\<And>x cref ty ptr n us y. \<lbrace>\<lambda>(s::'state_ext state). descendants_range x cref s \<rbrace> init_arch_objects ty ptr n us y
-          \<lbrace>\<lambda>rv s. descendants_range x cref s\<rbrace>"
+  "\<And>x cref ty dev ptr n us y.
+     \<lbrace>\<lambda>(s::'state_ext state). descendants_range x cref s \<rbrace>
+     init_arch_objects ty dev ptr n us y
+     \<lbrace>\<lambda>rv s. descendants_range x cref s\<rbrace>"
   assumes  init_arch_objects_caps_overlap_reserved[wp]:
-  "\<And>S ty ptr n us y. \<lbrace>\<lambda>(s::'state_ext state). caps_overlap_reserved S s\<rbrace>
-   init_arch_objects ty ptr n us y
-   \<lbrace>\<lambda>rv s. caps_overlap_reserved S s\<rbrace>"
+  "\<And>S ty dev ptr n us y.
+     \<lbrace>\<lambda>(s::'state_ext state). caps_overlap_reserved S s\<rbrace>
+     init_arch_objects ty dev ptr n us y
+     \<lbrace>\<lambda>rv s. caps_overlap_reserved S s\<rbrace>"
   assumes delete_objects_rewrite:
   "\<And>sz ptr. \<lbrakk> word_size_bits \<le> sz; sz\<le> word_bits; ptr && ~~ mask sz = ptr \<rbrakk>
       \<Longrightarrow> delete_objects ptr sz =
@@ -3026,7 +3029,7 @@ locale Untyped_AI_nonempty_table =
   "\<lbrace>(\<lambda>s. \<not> (obj_at (nonempty_table (set (second_level_tables (arch_state s)))) r s)
          \<and> valid_global_objs s \<and> valid_arch_state s \<and> pspace_aligned s) and
     K (\<forall>ref\<in>set refs. is_aligned ref (obj_bits_api tp us))\<rbrace>
-        init_arch_objects tp ptr bits us refs
+        init_arch_objects tp dev ptr bits us refs
    \<lbrace>\<lambda>rv. \<lambda>s :: 'state_ext state. \<not> (obj_at (nonempty_table (set (second_level_tables (arch_state s)))) r s)\<rbrace>"
   assumes create_cap_ioports[wp]:
   "\<And>tp oref sz dev cref p. \<lbrace>valid_ioports and cte_wp_at (\<lambda>_. True) cref\<rbrace>
@@ -3607,13 +3610,13 @@ lemma invoke_untyp_invs':
             and K (cref \<in> set slots \<and> oref \<in> set (retype_addrs ptr tp (length slots) us))
             and K (range_cover ptr sz (obj_bits_api tp us) (length slots))\<rbrace>
          create_cap tp us slot dev (cref,oref) \<lbrace>\<lambda>_. Q\<rbrace>"
- assumes init_arch_Q: "\<And>tp slot reset sz slots ptr n us refs dev.
+ assumes init_arch_Q: "\<And>tp dev slot reset sz slots ptr n us refs dev.
    ui = Invocations_A.Retype slot reset (ptr && ~~ mask sz) ptr tp us slots dev
     \<Longrightarrow> \<lbrace>Q and post_retype_invs tp refs
        and cte_wp_at (\<lambda>c. \<exists>idx. c = UntypedCap dev (ptr && ~~ mask sz) sz idx) slot
        and K (refs = retype_addrs ptr tp n us
          \<and> range_cover ptr sz (obj_bits_api tp us) n)\<rbrace>
-     init_arch_objects tp ptr n us refs \<lbrace>\<lambda>_. Q\<rbrace>"
+     init_arch_objects tp dev ptr n us refs \<lbrace>\<lambda>_. Q\<rbrace>"
  assumes retype_region_Q: "\<And>ptr us tp slot reset sz slots dev.
     ui = Invocations_A.Retype slot reset (ptr && ~~ mask sz) ptr tp us slots dev
     \<Longrightarrow> \<lbrace>\<lambda>s. invs s \<and> Q s

--- a/proof/invariant-abstract/X64/ArchRetype_AI.thy
+++ b/proof/invariant-abstract/X64/ArchRetype_AI.thy
@@ -538,7 +538,7 @@ lemma init_arch_objects_invs_from_restricted:
   "\<lbrace>post_retype_invs new_type refs
          and (\<lambda>s. global_refs s \<inter> set refs = {})
          and K (\<forall>ref \<in> set refs. is_aligned ref (obj_bits_api new_type obj_sz))\<rbrace>
-     init_arch_objects new_type ptr bits obj_sz refs
+     init_arch_objects new_type dev ptr bits obj_sz refs
    \<lbrace>\<lambda>_. invs\<rbrace>"
   apply (simp add: init_arch_objects_def)
   apply (rule hoare_pre)
@@ -1287,7 +1287,7 @@ crunch init_arch_objects
   (wp: crunch_wps)
 
 lemma init_arch_objects_excap[wp]:
-  "\<lbrace>ex_cte_cap_wp_to P p\<rbrace> init_arch_objects tp ptr bits us refs \<lbrace>\<lambda>rv. ex_cte_cap_wp_to P p\<rbrace>"
+  "\<lbrace>ex_cte_cap_wp_to P p\<rbrace> init_arch_objects tp dev ptr bits us refs \<lbrace>\<lambda>rv. ex_cte_cap_wp_to P p\<rbrace>"
   by (wp ex_cte_cap_to_pres )
 
 crunch init_arch_objects

--- a/proof/invariant-abstract/X64/ArchUntyped_AI.thy
+++ b/proof/invariant-abstract/X64/ArchUntyped_AI.thy
@@ -190,7 +190,7 @@ lemma copy_global_mappings_hoare_lift:(*FIXME: arch-split  \<rightarrow> these d
 
 lemma init_arch_objects_hoare_lift:
   assumes wp:  "\<And>ptr val. \<lbrace>P\<rbrace> store_pml4e ptr val \<lbrace>\<lambda>rv. P\<rbrace>"
-  shows       "\<lbrace>P\<rbrace> init_arch_objects tp ptr sz us adds \<lbrace>\<lambda>rv. P\<rbrace>"
+  shows       "\<lbrace>P\<rbrace> init_arch_objects tp dev ptr sz us adds \<lbrace>\<lambda>rv. P\<rbrace>"
 proof -
   have pres: "\<lbrace>P\<rbrace> return () \<lbrace>\<lambda>rv. P\<rbrace>"
     by (wp wp | simp)+
@@ -215,7 +215,7 @@ lemma cap_refs_in_kernel_windowD2:
   done
 
 lemma init_arch_objects_descendants_range[wp,Untyped_AI_assms]:
-  "\<lbrace>\<lambda>(s::'state_ext::state_ext state). descendants_range x cref s \<rbrace> init_arch_objects ty ptr n us y
+  "\<lbrace>\<lambda>(s::'state_ext::state_ext state). descendants_range x cref s \<rbrace> init_arch_objects ty dev ptr n us y
           \<lbrace>\<lambda>rv s. descendants_range x cref s\<rbrace>"
   apply (simp add:descendants_range_def)
   apply (rule hoare_pre)
@@ -230,7 +230,7 @@ lemma init_arch_objects_descendants_range[wp,Untyped_AI_assms]:
 
 lemma init_arch_objects_caps_overlap_reserved[wp,Untyped_AI_assms]:
   "\<lbrace>\<lambda>(s::'state_ext::state_ext state). caps_overlap_reserved S s\<rbrace>
-   init_arch_objects ty ptr n us y
+   init_arch_objects ty dev ptr n us y
    \<lbrace>\<lambda>rv s. caps_overlap_reserved S s\<rbrace>"
   apply (simp add:caps_overlap_reserved_def)
   apply (rule hoare_pre)
@@ -533,7 +533,7 @@ lemma init_arch_objects_nonempty_table[Untyped_AI_assms, wp]:
   "\<lbrace>(\<lambda>s. \<not> (obj_at (nonempty_table (set (second_level_tables (arch_state s)))) r s)
          \<and> valid_global_objs s \<and> valid_arch_state s \<and> pspace_aligned s) and
     K (\<forall>ref\<in>set refs. is_aligned ref (obj_bits_api tp us))\<rbrace>
-        init_arch_objects tp ptr bits us refs
+        init_arch_objects tp dev ptr bits us refs
    \<lbrace>\<lambda>rv s. \<not> (obj_at (nonempty_table (set (second_level_tables (arch_state s)))) r s)\<rbrace>"
   apply (rule hoare_gen_asm)
   apply (simp add: init_arch_objects_def split del: if_split)

--- a/proof/invariant-abstract/X64/ArchVSpaceEntries_AI.thy
+++ b/proof/invariant-abstract/X64/ArchVSpaceEntries_AI.thy
@@ -528,7 +528,7 @@ lemma init_arch_objects_valid_vspace:
   "\<lbrace>valid_vspace_objs' and pspace_aligned and valid_arch_state
            and K (orefs = retype_addrs ptr type n us)
            and K (range_cover ptr sz (obj_bits_api type us) n)\<rbrace>
-     init_arch_objects type ptr n obj_sz orefs
+     init_arch_objects type dev ptr n obj_sz orefs
    \<lbrace>\<lambda>rv. valid_vspace_objs'\<rbrace>"
   apply (rule hoare_gen_asm)+
   apply (simp add: init_arch_objects_def)

--- a/proof/refine/ARM_HYP/Detype_R.thy
+++ b/proof/refine/ARM_HYP/Detype_R.thy
@@ -3230,6 +3230,17 @@ lemma setCTE_doMachineOp_commute:
   apply (wp|clarsimp|fastforce)+
   done
 
+lemma setCTE_when_doMachineOp_commute:
+  assumes nf: "no_fail Q (doMachineOp x)"
+  shows "monad_commute (cte_at' dest and pspace_aligned' and pspace_distinct' and Q)
+  (setCTE dest cte)
+  (when P (doMachineOp x))"
+  apply (cases P; simp add: setCTE_doMachineOp_commute nf)
+  apply (rule monad_commute_guard_imp)
+   apply (rule return_commute[THEN commute_commute])
+  apply simp
+  done
+
 lemma placeNewObject_valid_arch_state:
   "\<lbrace>valid_arch_state' and
     pspace_no_overlap' ptr (objBitsKO (injectKOS val) + us) and
@@ -3520,6 +3531,7 @@ lemma createObject_setCTE_commute:
                      setCTE_modify_gsUserPages_commute[of \<top>]
                      modify_wp[of "%_. \<top>"]
                      setCTE_doMachineOp_commute
+                     setCTE_when_doMachineOp_commute
                      setCTE_placeNewObject_commute
                      monad_commute_if_weak_r
                      copyGlobalMappings_setCTE_commute[THEN commute_commute]
@@ -3676,6 +3688,13 @@ lemma copyGlobalMappings_gsUntypedZeroRanges_commute':
      (copyGlobalMappings ptr)
      (modify (\<lambda>s. s \<lparr> gsUntypedZeroRanges := f (gsUntypedZeroRanges s) \<rparr> ))"
   by (simp add: copyGlobalMappings_def monad_commute_guard_imp return_commute)
+
+lemma dmo_gsUntypedZeroRanges_commute:
+  "monad_commute \<top> (modify (\<lambda>s. s\<lparr>gsUntypedZeroRanges := f (gsUntypedZeroRanges s)\<rparr>))
+                   (doMachineOp m)"
+  apply (clarsimp simp: monad_commute_def doMachineOp_def)
+  apply monad_eq
+  by (auto simp: select_f_def)
 
 lemma createObject_gsUntypedZeroRanges_commute:
   "monad_commute
@@ -4572,8 +4591,8 @@ lemma dmo'_when_fail_comm:
 
 (* FIXME: move *)
 lemma dmo'_gets_ksPSpace_comm:
-  "doMachineOp f >>= (\<lambda>_. gets ksPSpace >>= m) =
-   gets ksPSpace >>= (\<lambda>x. doMachineOp f >>= (\<lambda>_. m x))"
+  "doMachineOp f >>= (\<lambda>y. gets ksPSpace >>= m y) =
+   gets ksPSpace >>= (\<lambda>x. doMachineOp f >>= (\<lambda>y. m y x))"
   apply (rule ext)
   apply (clarsimp simp: doMachineOp_def simpler_modify_def simpler_gets_def
                         return_def select_f_def bind_def split_def image_def
@@ -4612,14 +4631,15 @@ proof -
     done
 qed
 
-lemma dmo'_createObjects'_comm:
+lemma dmo'_createObjects'_commute:
   assumes ef: "empty_fail f"
-  shows "do _ \<leftarrow> doMachineOp f; x \<leftarrow> createObjects' ptr n obj us; m x od =
-         do x \<leftarrow> createObjects' ptr n obj us; _ \<leftarrow> doMachineOp f; m x od"
-  apply (simp add: createObjects'_def bind_assoc split_def unless_def
-                   alignError_def dmo'_when_fail_comm[OF ef]
-                   dmo'_gets_ksPSpace_comm
-                   dmo'_ksPSpace_update_comm'[OF ef, symmetric])
+  shows "monad_commute \<top> (doMachineOp f) (createObjects' ptr n obj us)"
+  apply (clarsimp simp: createObjects'_def bind_assoc split_def unless_def
+                        alignError_def monad_commute_def
+                        dmo'_when_fail_comm[OF ef]
+                        dmo'_gets_ksPSpace_comm
+                        dmo'_ksPSpace_update_comm'[OF ef, symmetric])
+  apply (rule_tac x=s in fun_cong)
   apply (rule arg_cong_bind1)
   apply (rule arg_cong_bind1)
   apply (rename_tac u w)
@@ -4628,27 +4648,16 @@ lemma dmo'_createObjects'_comm:
   apply (simp add: assert_into_when dmo'_when_fail_comm[OF ef])
   done
 
-lemma dmo'_gsUserPages_upd_comm:
-  assumes "empty_fail f"
-  shows "doMachineOp f >>= (\<lambda>x. modify (gsUserPages_update g) >>= (\<lambda>_. m x)) =
-         modify (gsUserPages_update g) >>= (\<lambda>_. doMachineOp f >>= m)"
-proof -
-  have ksMachineState_ksPSpace_update:
-    "\<forall>s. ksMachineState (gsUserPages_update g s) = ksMachineState s"
-    by simp
-  have updates_independent:
-    "\<And>f. gsUserPages_update g \<circ> ksMachineState_update f =
-          ksMachineState_update f \<circ> gsUserPages_update g"
-    by (rule ext) simp
-  from assms
-  show ?thesis
-    apply (simp add: doMachineOp_def split_def bind_assoc)
-    apply (simp add: gets_modify_comm2[OF ksMachineState_ksPSpace_update])
-    apply (rule arg_cong_bind1)
-    apply (simp add: empty_fail_def select_f_walk[OF empty_fail_modify]
-                     modify_modify_bind updates_independent)
-    done
-qed
+lemmas map_dmo'_createObjects'_comm = dmo'_createObjects'_commute[THEN mapM_x_commute_T]
+
+lemma dmo'_gsUserPages_upd_commute:
+  "monad_commute \<top> (doMachineOp f) (modify (gsUserPages_update g))"
+  apply (clarsimp simp: monad_commute_def doMachineOp_def bind_assoc)
+  apply monad_eq
+  apply (auto simp: select_f_def)
+  done
+
+lemmas dmo'_gsUserPages_upd_map_commute = dmo'_gsUserPages_upd_commute[THEN mapM_x_commute_T]
 
 lemma rewrite_step:
   assumes rewrite: "\<And>s. P s \<Longrightarrow> f s = f' s"
@@ -4841,6 +4850,13 @@ lemma createTCBs_tcb_at':
    apply (rule ccontr)
    apply simp
   apply (simp add: objBits_simps shiftl_t2n)
+  done
+
+lemma mapM_x_copyGlobalMappings_noop:
+  "mapM_x copyGlobalMappings xs = return ()"
+  apply (induct xs)
+   apply (simp add: mapM_x_Nil)
+  apply (simp add: mapM_x_Cons copyGlobalMappings_def)
   done
 
 lemma createNewCaps_Cons:
@@ -5052,259 +5068,141 @@ proof -
 
        \<comment> \<open>SmallPageObject\<close>
        apply (simp add: Arch_createNewCaps_def
-                        Retype_H.createObject_def createObjects_def bind_assoc
-                        ARM_HYP_H.toAPIType_def ARM_HYP_H.toAPIType_def
+                        Retype_H.createObject_def createObjects_def bind_assoc toAPIType_def
                         ARM_HYP_H.createObject_def placeNewDataObject_def)
        apply (intro conjI impI)
+        (* device *)
         apply (subst monad_eq, rule createObjects_Cons)
              apply (simp_all add: field_simps shiftl_t2n pageBits_def
-                        getObjectSize_def ARM_HYP_H.getObjectSize_def
-                        objBits_simps)[6]
-        apply (simp add: bind_assoc placeNewObject_def2 objBits_simps
-                         getObjectSize_def ARM_HYP_H.getObjectSize_def
+                                  getObjectSize_def objBits_simps)[6]
+        apply (simp add: bind_assoc placeNewObject_def2 objBits_simps getObjectSize_def
                          pageBits_def add.commute append)
-        apply ((subst gsUserPages_update gsCNodes_update
-                    gsUserPages_upd_createObjects'_comm
-                    dmo'_createObjects'_comm dmo'_gsUserPages_upd_comm
-                   | simp add: modify_modify_bind o_def)+)[1]
+         apply ((subst gsUserPages_update gsCNodes_update
+                       gsUserPages_upd_createObjects'_comm
+                       monad_commute_simple'[OF dmo'_gsUserPages_upd_map_commute]
+                 | simp add: modify_modify_bind o_def)+)[1]
+        (* not device *)
         apply (subst monad_eq, rule createObjects_Cons)
              apply (simp_all add: field_simps shiftl_t2n pageBits_def
-                        getObjectSize_def ARM_HYP_H.getObjectSize_def
-                        objBits_simps)[6]
-        apply (simp add: bind_assoc placeNewObject_def2 objBits_simps
-                         getObjectSize_def ARM_HYP_H.getObjectSize_def
-                         pageBits_def add.commute append)
+                                  getObjectSize_def objBits_simps)[6]
+        apply (simp add: bind_assoc placeNewObject_def2 objBits_simps getObjectSize_def
+                         pageBits_def add.commute append mapM_x_append mapM_x_singleton)
         apply (subst gsUserPages_update gsCNodes_update
-                    gsUserPages_upd_createObjects'_comm
-                    dmo'_createObjects'_comm dmo'_gsUserPages_upd_comm
-                   | simp add: modify_modify_bind o_def)+
+                     gsUserPages_upd_createObjects'_comm
+                     monad_commute_simple'[OF map_dmo'_createObjects'_comm]
+                     monad_commute_simple'[OF dmo'_gsUserPages_upd_map_commute]
+               | simp add: modify_modify_bind o_def)+
       \<comment> \<open>LargePageObject\<close>
-      apply (simp add: Arch_createNewCaps_def
-                       Retype_H.createObject_def createObjects_def bind_assoc
-                       ARM_HYP_H.toAPIType_def ARM_HYP_H.toAPIType_def
-                       ARM_HYP_H.createObject_def placeNewDataObject_def)
+      apply (simp add: Arch_createNewCaps_def Retype_H.createObject_def createObjects_def bind_assoc
+                       ARM_HYP_H.toAPIType_def ARM_HYP_H.createObject_def placeNewDataObject_def)
       apply (intro conjI impI)
+       (* device *)
        apply (subst monad_eq, rule createObjects_Cons)
             apply (simp_all add: field_simps shiftl_t2n pageBits_def
-                       getObjectSize_def ARM_HYP_H.getObjectSize_def
-                       objBits_simps)[6]
-       apply (simp add: bind_assoc placeNewObject_def2 objBits_simps
-                        getObjectSize_def ARM_HYP_H.getObjectSize_def
+                                 getObjectSize_def objBits_simps)[6]
+       apply (simp add: bind_assoc placeNewObject_def2 objBits_simps getObjectSize_def
                         pageBits_def add.commute append)
        apply ((subst gsUserPages_update gsCNodes_update
-                   gsUserPages_upd_createObjects'_comm
-                   dmo'_createObjects'_comm dmo'_gsUserPages_upd_comm
-                  | simp add: modify_modify_bind o_def)+)[1]
+                     gsUserPages_upd_createObjects'_comm
+                     monad_commute_simple'[OF dmo'_gsUserPages_upd_map_commute]
+               | simp add: modify_modify_bind o_def)+)[1]
+      (* not device *)
       apply (subst monad_eq, rule createObjects_Cons)
             apply (simp_all add: field_simps shiftl_t2n pageBits_def
-                       ARM_HYP_H.getObjectSize_def objBits_simps)[6]
+                                 ARM_HYP_H.getObjectSize_def objBits_simps)[6]
       apply (simp add: bind_assoc placeNewObject_def2 objBits_simps
                         ARM_HYP_H.getObjectSize_def
-                       pageBits_def add.commute append)
+                       pageBits_def add.commute append mapM_x_append mapM_x_singleton)
       apply (subst gsUserPages_update gsCNodes_update
                    gsUserPages_upd_createObjects'_comm
-                   dmo'_createObjects'_comm dmo'_gsUserPages_upd_comm
+                   monad_commute_simple'[OF map_dmo'_createObjects'_comm]
+                   monad_commute_simple'[OF dmo'_gsUserPages_upd_map_commute]
              | simp add: modify_modify_bind o_def)+
      \<comment> \<open>SectionObject\<close>
-     apply (simp add: Arch_createNewCaps_def
-                      Retype_H.createObject_def createObjects_def bind_assoc
-                      toAPIType_def ARM_HYP_H.toAPIType_def
-                      ARM_HYP_H.createObject_def placeNewDataObject_def)
+     apply (simp add: Arch_createNewCaps_def Retype_H.createObject_def createObjects_def bind_assoc
+                      toAPIType_def ARM_HYP_H.createObject_def placeNewDataObject_def)
      apply (intro conjI impI)
+      (* device *)
       apply (subst monad_eq, rule createObjects_Cons)
            apply (simp_all add: field_simps shiftl_t2n pageBits_def
-                      getObjectSize_def ARM_HYP_H.getObjectSize_def
-                      objBits_simps)[6]
+                                getObjectSize_def objBits_simps)[6]
       apply (simp add: bind_assoc placeNewObject_def2 objBits_simps
-                       getObjectSize_def ARM_HYP_H.getObjectSize_def
-                       pageBits_def add.commute append)
+                       getObjectSize_def pageBits_def add.commute append)
       apply ((subst gsUserPages_update gsCNodes_update
                     gsUserPages_upd_createObjects'_comm
-                    dmo'_createObjects'_comm dmo'_gsUserPages_upd_comm
+                    monad_commute_simple'[OF dmo'_gsUserPages_upd_map_commute]
               | simp add: modify_modify_bind o_def)+)[1]
+     (* not device *)
      apply (subst monad_eq, rule createObjects_Cons)
            apply (simp_all add: field_simps shiftl_t2n pageBits_def
-                      ARM_HYP_H.getObjectSize_def objBits_simps)[6]
-     apply (simp add: bind_assoc placeNewObject_def2 objBits_simps
-                       ARM_HYP_H.getObjectSize_def
-                      pageBits_def add.commute append)
+                                ARM_HYP_H.getObjectSize_def objBits_simps)[6]
+     apply (simp add: bind_assoc placeNewObject_def2 objBits_simps ARM_HYP_H.getObjectSize_def
+                      pageBits_def add.commute append mapM_x_append mapM_x_singleton)
      apply (subst gsUserPages_update gsCNodes_update
                   gsUserPages_upd_createObjects'_comm
-                  dmo'_createObjects'_comm dmo'_gsUserPages_upd_comm
+                  monad_commute_simple'[OF map_dmo'_createObjects'_comm]
+                  monad_commute_simple'[OF dmo'_gsUserPages_upd_map_commute]
             | simp add: modify_modify_bind o_def)+
     \<comment> \<open>SuperSectionObject\<close>
-    apply (simp add: Arch_createNewCaps_def
-                     Retype_H.createObject_def createObjects_def bind_assoc
-                     toAPIType_def ARM_HYP_H.toAPIType_def
-                     ARM_HYP_H.createObject_def placeNewDataObject_def)
+    apply (simp add: Arch_createNewCaps_def Retype_H.createObject_def createObjects_def bind_assoc
+                     toAPIType_def ARM_HYP_H.createObject_def placeNewDataObject_def)
     apply (intro conjI impI)
+     (* device *)
      apply (subst monad_eq, rule createObjects_Cons)
           apply (simp_all add: field_simps shiftl_t2n pageBits_def
-                     getObjectSize_def ARM_HYP_H.getObjectSize_def
-                     objBits_simps)[6]
+                               getObjectSize_def objBits_simps)[6]
      apply (simp add: bind_assoc placeNewObject_def2 objBits_simps
-                      getObjectSize_def ARM_HYP_H.getObjectSize_def
-                      pageBits_def add.commute append)
+                      getObjectSize_def pageBits_def add.commute append)
      apply ((subst gsUserPages_update gsCNodes_update
-                 gsUserPages_upd_createObjects'_comm
-                 dmo'_createObjects'_comm dmo'_gsUserPages_upd_comm
-               | simp add: modify_modify_bind o_def)+)[1]
+                   gsUserPages_upd_createObjects'_comm
+                   monad_commute_simple'[OF dmo'_gsUserPages_upd_map_commute]
+             | simp add: modify_modify_bind o_def)+)[1]
+    (* not device *)
     apply (subst monad_eq, rule createObjects_Cons)
           apply (simp_all add: field_simps shiftl_t2n pageBits_def
-                     ARM_HYP_H.getObjectSize_def objBits_simps)[6]
-    apply (simp add: bind_assoc placeNewObject_def2 objBits_simps
-                      ARM_HYP_H.getObjectSize_def
-                     pageBits_def add.commute append)
+                               ARM_HYP_H.getObjectSize_def objBits_simps)[6]
+    apply (simp add: bind_assoc placeNewObject_def2 objBits_simps pageBits_def
+                     ARM_HYP_H.getObjectSize_def add.commute append mapM_x_append mapM_x_singleton)
     apply (subst gsUserPages_update gsCNodes_update
                  gsUserPages_upd_createObjects'_comm
-                 dmo'_createObjects'_comm dmo'_gsUserPages_upd_comm
+                 monad_commute_simple'[OF map_dmo'_createObjects'_comm]
+                 monad_commute_simple'[OF dmo'_gsUserPages_upd_map_commute]
            | simp add: modify_modify_bind o_def)+
-   \<comment> \<open>PageTableObject\<close>
-   apply (simp add:Arch_createNewCaps_def Retype_H.createObject_def
-           createObjects_def bind_assoc ARM_HYP_H.toAPIType_def
-           ARM_HYP_H.createObject_def)
-         apply (subst monad_eq,rule createObjects_Cons)
-             apply ((simp add: field_simps shiftl_t2n archObjSize_def
-               getObjectSize_def ARM_HYP_H.getObjectSize_def
-               objBits_simps vspace_bits_defs)+)[6]
-         apply (simp add:bind_assoc placeNewObject_def2)
-         apply (simp add: field_simps
-               getObjectSize_def  vspace_bits_defs archObjSize_def
-               ARM_HYP_H.getObjectSize_def placeNewObject_def2
-               objBits_simps append)
-
-\<comment> \<open>PageDirectoryObject\<close>
-         apply (simp add:Arch_createNewCaps_def Retype_H.createObject_def
-           createObjects_def bind_assoc ARM_HYP_H.toAPIType_def
-           ARM_HYP_H.createObject_def)
-         apply (subgoal_tac "distinct (map (\<lambda>n. ptr + (n << 14)) [0.e.((of_nat n)::word32)])")
-         prefer 2
-          apply (clarsimp simp: objBits_simps archObjSize_def vspace_bits_defs
-                                ARM_HYP_H.getObjectSize_def)
-          apply (subst upto_enum_word)
-          apply (clarsimp simp:distinct_map)
-          apply (frule range_cover.range_cover_n_le)
-          apply (frule range_cover.range_cover_n_less)
-          apply (rule conjI)
-           apply (clarsimp simp:inj_on_def)
-           apply (rule ccontr)
-           apply (erule_tac bnd = "2^(word_bits - 14)" in shift_distinct_helper[rotated 3])
-                apply simp
-               apply (simp add:word_bits_def)
-              apply (erule less_le_trans[OF word_of_nat_less])
-              apply (simp add: word_of_nat_le word_bits_def)
-              apply (erule less_le_trans[OF word_of_nat_less])
-              apply (simp add:word_of_nat_le word_bits_def)
-            apply (frule range_cover.unat_of_nat_n[OF range_cover_le[where n = n]])
-             apply simp
-            apply (rule ccontr)
-            apply simp
-            apply (drule of_nat_inj32[THEN iffD1,rotated -1])
-             apply (simp_all add: word_bits_def)[3]
-           apply (clarsimp)
-           apply (erule_tac bnd = "2^(word_bits - 14)" in shift_distinct_helper[rotated 3])
-                apply simp
-               apply (simp add:word_bits_def)
-             apply (simp add:word_of_nat_less word_bits_def)
-             apply (erule less_le_trans[OF word_of_nat_less])
-             apply (simp add:word_of_nat_le word_bits_def)
-           apply (rule ccontr)
-           apply (frule range_cover.unat_of_nat_n[OF range_cover_le[where n = n]])
-            apply simp
-           apply simp
-           apply (drule of_nat_inj32[THEN iffD1,rotated -1])
-            apply (simp_all add: word_bits_def)[3]
-         apply (subst monad_eq,rule createObjects_Cons)
-               apply ((simp add: field_simps shiftl_t2n vspace_bits_defs archObjSize_def
-                 ARM_HYP_H.getObjectSize_def
-                 objBits_simps ptBits_def)+)[6]
-         apply (simp add:objBits_simps archObjSize_def vspace_bits_defs ARM_HYP_H.getObjectSize_def)
-         apply (simp add:bind_assoc)
-         apply (simp add: placeNewObject_def2[where val = "makeObject::ARM_HYP_H.pde",simplified,symmetric])
-         apply (rule_tac Q = "\<lambda>r s. valid_arch_state' s \<and>
-           (\<forall>x\<le>of_nat n. page_directory_at' (ptr + (x << 14)) s) \<and> Q s" for Q in monad_eq_split)
-           apply (rule sym)
-           apply (subst bind_assoc[symmetric])
-           apply (subst monad_commute_simple)
-             apply (rule commute_commute[OF monad_commute_split])
-               apply (rule placeNewObject_doMachineOp_commute)
-              apply (rule mapM_x_commute[where f = id])
-               apply (rule placeNewObject_copyGlobalMapping_commute)
-              apply (wp copyGlobalMappings_pspace_no_overlap' mapM_x_wp'| clarsimp)+
-            apply (clarsimp simp:objBits_simps archObjSize_def vspace_bits_defs word_bits_conv)
-            apply assumption (* resolve assumption , yuck *)
-           apply (simp add:append mapM_x_append bind_assoc)
-           apply (rule monad_eq_split[where Q = "\<lambda> r s.  pspace_aligned' s \<and> pspace_distinct' s
-             \<and> valid_arch_state' s \<and> (\<forall>r \<le> of_nat n. page_directory_at' (ptr + (r << 14)) s)
-             \<and>  page_directory_at' (ptr + ((1 + of_nat n) << 14)) s"])
-           apply (rule monad_eq_split[where Q = "\<lambda> r s.  pspace_aligned' s \<and> pspace_distinct' s
-             \<and> valid_arch_state' s \<and> (\<forall>r \<le> of_nat n. page_directory_at' (ptr + (r << 14)) s)
-             \<and>  page_directory_at' (ptr + ((1 + of_nat n) << 14)) s"])
-              apply (subst monad_commute_simple)
-                apply (rule doMachineOp_copyGlobalMapping_commute)
-               apply (clarsimp simp:field_simps)
-              apply (simp add:field_simps mapM_x_singleton)
-              apply (rule monad_eq_split[where Q = "\<lambda> r s.  pspace_aligned' s \<and> pspace_distinct' s
-             \<and> valid_arch_state' s \<and> page_directory_at' (ptr + (1 + of_nat n << 14)) s"])
-                apply (subst doMachineOp_bind)
-                  apply (wp empty_fail_mapM_x empty_fail_cleanCacheRange_PoU)+
-                apply (simp add:bind_assoc objBits_simps field_simps archObjSize_def shiftL_nat)
-               apply wp
-              apply simp
-             apply (rule mapM_x_wp')
-             apply (rule hoare_pre)
-             apply (wp copyGlobalMappings_pspace_no_overlap' | clarsimp)+
-                apply (clarsimp simp:page_directory_at'_def)
-                apply (wp hoare_vcg_all_lift hoare_vcg_imp_lift)
-                apply ((clarsimp simp:page_directory_at'_def)+)[2]
-              apply (wp placeNewObject_pspace_aligned' placeNewObject_pspace_distinct')
-              apply (simp add:placeNewObject_def2 field_simps)
-              apply (rule hoare_vcg_conj_lift)
-               apply (rule createObjects'_wp_subst)
-               apply (wp createObjects_valid_arch[where sz = 14])
-              apply (rule hoare_vcg_conj_lift)
-               apply (clarsimp simp:page_directory_at'_def)
-               apply (wp hoare_vcg_all_lift hoare_vcg_imp_lift createObjects'_typ_at[where sz = 14])
-              apply (rule hoare_strengthen_post[OF createObjects'_page_directory_at'[where sz = 14]])
-              apply simp
-             apply (clarsimp simp:objBits_simps page_directory_at'_def vspace_bits_defs
-               field_simps archObjSize_def word_bits_conv range_cover_full
-               aligned_add_aligned range_cover.aligned is_aligned_shiftl_self)
-             apply (frule pspace_no_overlap'_le2[where ptr' = "(ptr + (1 + of_nat n << 14))"])
-               apply (subst shiftl_t2n,subst mult.commute, subst suc_of_nat)
-               apply (rule order_trans[OF range_cover_bound,where n1 = "1 + n"])
-                 apply (erule range_cover_le,simp)
-                apply simp
-               apply (rule word_sub_1_le)
-               apply (drule(1) range_cover_no_0[where p = "n+1"])
-                apply simp
-               apply simp
-              apply (erule(1) range_cover_tail_mask)
-           apply (rule hoare_vcg_conj_lift)
-           apply (rule createObjects'_wp_subst)
-            apply (wp createObjects_valid_arch[where sz = sz])
-           apply (wp createObjects'_page_directory_at'[where sz = sz]
-             createObjects'_psp_aligned[where sz = sz]
-             createObjects'_psp_distinct[where sz = sz] hoare_vcg_imp_lift
-             createObjects'_pspace_no_overlap[where sz = sz]
-            | simp add:objBits_simps archObjSize_def vspace_bits_defs field_simps)+
-         apply (drule range_cover_le[where n = "Suc n"])
-          apply simp
-         apply (clarsimp simp:word_bits_def valid_pspace'_def vspace_bits_defs)
-         apply (clarsimp simp:aligned_add_aligned[OF range_cover.aligned] is_aligned_shiftl_self word_bits_def vspace_bits_defs)+
-\<comment> \<open>VCPUObject\<close>
-      apply (simp add: Arch_createNewCaps_def
-                       Retype_H.createObject_def createObjects_def bind_assoc
-                       ARM_HYP_H.toAPIType_def ARM_HYP_H.toAPIType_def
-                       ARM_HYP_H.createObject_def placeNewDataObject_def)
-      apply (subst monad_eq, rule createObjects_Cons)
-            apply (simp_all add: field_simps shiftl_t2n vcpu_bits_def vspace_bits_defs
-                        getObjectSize_def ARM_HYP_H.getObjectSize_def archObjSize_def
-                        objBits_simps)[7]
-      apply (simp add: bind_assoc placeNewObject_def2 objBits_simps
-                         getObjectSize_def ARM_HYP_H.getObjectSize_def
-                         vcpu_bits_def pageBits_def add.commute append)
-    done
+    \<comment> \<open>PageTableObject\<close>
+    apply (simp add: Arch_createNewCaps_def Retype_H.createObject_def createObjects_def bind_assoc
+                     ARM_HYP_H.toAPIType_def ARM_HYP_H.createObject_def)
+    apply (subst monad_eq, rule createObjects_Cons)
+          apply ((simp add: field_simps shiftl_t2n vspace_bits_defs archObjSize_def
+                            getObjectSize_def objBits_simps ptBits_def)+)[6]
+    apply (simp add: bind_assoc placeNewObject_def2)
+    apply (simp add: field_simps bind_assoc gets_modify_def
+                     getObjectSize_def placeNewObject_def2 objBits_simps append mapM_x_append
+                     mapM_x_singleton archObjSize_def)
+    apply (subst monad_commute_simple'[OF map_dmo'_createObjects'_comm]
+           | simp add: modify_modify_bind o_def
+           | simp only: o_def cong: if_cong)+
+    apply (simp add: vspace_bits_defs)
+   \<comment> \<open>PageDirectoryObject\<close>
+   apply (simp add: Arch_createNewCaps_def toAPIType_def bind_assoc
+                    createObjects_def createObject_def ARM_HYP_H.createObject_def)
+   apply (subst monad_eq, rule createObjects_Cons; simp?)
+    apply (simp add: objBits_simps getObjectSize_def archObjSize_def vspace_bits_defs)
+   apply (simp add: getObjectSize_def placeNewObject_def2 objBits_simps append mapM_x_append
+                    bind_assoc mapM_x_singleton archObjSize_def)
+   apply (simp add: mapM_x_copyGlobalMappings_noop copyGlobalMappings_def)
+   apply (subst monad_commute_simple'[OF map_dmo'_createObjects'_comm]
+          | simp add: modify_modify_bind o_def
+          | simp only: o_def cong: if_cong)+
+   apply (simp add: vspace_bits_defs field_simps)
+  \<comment> \<open>VCPUObject\<close>
+  apply (simp add: Arch_createNewCaps_def Retype_H.createObject_def createObjects_def bind_assoc
+                   ARM_HYP_H.toAPIType_def ARM_HYP_H.createObject_def placeNewDataObject_def)
+  apply (subst monad_eq, rule createObjects_Cons)
+        apply (simp_all add: field_simps shiftl_t2n vcpu_bits_def vspace_bits_defs
+                    getObjectSize_def archObjSize_def objBits_simps)[7]
+  apply (simp add: bind_assoc placeNewObject_def2 objBits_simps
+                   getObjectSize_def vcpu_bits_def pageBits_def add.commute append)
+  done
 qed
 
 lemma createObject_def2:
@@ -5525,21 +5423,20 @@ lemma ArchCreateObject_pspace_no_overlap':
      (ptr + (of_nat n << APIType_capBits ty userSize)) userSize d
    \<lbrace>\<lambda>archCap. pspace_no_overlap'
                 (ptr + (1 + of_nat n << APIType_capBits ty userSize)) sz\<rbrace>"
-  apply (rule hoare_pre)
-   apply (clarsimp simp:ARM_HYP_H.createObject_def)
-   apply wpc
+  supply if_split[split del]
+  apply (clarsimp simp:ARM_HYP_H.createObject_def)
+  apply wpc
           apply (wp doMachineOp_psp_no_overlap
-              createObjects'_pspace_no_overlap2 hoare_when_weak_wp
-              copyGlobalMappings_pspace_no_overlap'
-              createObjects'_psp_aligned[where sz = sz]
-              createObjects'_psp_distinct[where sz = sz]
-            | simp add: placeNewObject_def2 word_shiftl_add_distrib
-            | simp add: placeNewObject_def2 word_shiftl_add_distrib
-            | simp add: placeNewDataObject_def placeNewObject_def2 word_shiftl_add_distrib
-                        field_simps  split del: if_splits
-            | clarsimp simp add: add.assoc[symmetric],wp createObjects'_pspace_no_overlap2[where n =0 and sz = sz,simplified]
-            | clarsimp simp add: APIType_capBits_def objBits_simps pageBits_def)+
-
+                    createObjects'_pspace_no_overlap2
+                    createObjects'_psp_aligned[where sz = sz]
+                    createObjects'_psp_distinct[where sz = sz]
+                 | simp add: placeNewObject_def2 word_shiftl_add_distrib
+                 | simp add: copyGlobalMappings_def
+                 | simp add: placeNewDataObject_def placeNewObject_def2 word_shiftl_add_distrib
+                             field_simps
+                 | clarsimp simp add: add.assoc[symmetric],
+                   wp createObjects'_pspace_no_overlap2[where n =0 and sz = sz,simplified]
+                 | clarsimp simp add: APIType_capBits_def objBits_simps pageBits_def)+
   apply (clarsimp simp: conj_comms)
   apply (frule(1) range_cover_no_0[where p = n])
    apply simp
@@ -5555,7 +5452,7 @@ lemma ArchCreateObject_pspace_no_overlap':
    apply simp
   apply (frule pspace_no_overlap'_le2)
     apply (rule range_cover_compare_offset)
-     apply simp+
+      apply simp+
    apply (clarsimp simp:word_shiftl_add_distrib
               ,simp add:field_simps)
    apply (clarsimp simp:add.assoc[symmetric])
@@ -5566,9 +5463,9 @@ lemma ArchCreateObject_pspace_no_overlap':
     apply (metis numeral_2_eq_2)
    apply (simp add:shiftl_t2n field_simps)
   apply (intro conjI allI)
-  apply (clarsimp simp: field_simps word_bits_conv archObjSize_def vspace_bits_defs
-                        APIType_capBits_def shiftl_t2n objBits_simps
-         | rule conjI | erule range_cover_le,simp)+
+         apply (clarsimp simp: field_simps word_bits_conv archObjSize_def vspace_bits_defs
+                               APIType_capBits_def shiftl_t2n objBits_simps
+                | rule conjI | erule range_cover_le,simp)+
   done
 
 lemma to_from_apiTypeD: "toAPIType ty = Some x \<Longrightarrow> ty = fromAPIType x"

--- a/proof/refine/ARM_HYP/Retype_R.thy
+++ b/proof/refine/ARM_HYP/Retype_R.thy
@@ -2375,7 +2375,7 @@ proof -
       apply (clarsimp simp: ARM_HYP_H.toAPIType_def APIType_capBits_def
                      split: ARM_HYP_H.object_type.splits)
        \<comment> \<open>SmallPageObject\<close>
-       apply wp
+       apply (wp mapM_x_wp' hoare_vcg_op_lift)
        apply (simp add: valid_cap'_def capAligned_def n_less_word_bits
                         ball_conj_distrib)
        apply ((wp createObjects_aligned2 createObjects_nonzero[OF not_0 ,simplified]
@@ -2383,7 +2383,7 @@ proof -
          | simp add: objBits_if_dev pageBits_def ptr range_cover_n_wb)+)
        apply (simp add:pageBits_def ptr word_bits_def)
       \<comment> \<open>LargePageObject\<close>
-      apply wp
+      apply (wp mapM_x_wp' hoare_vcg_op_lift)
       apply (simp add: valid_cap'_def capAligned_def n_less_word_bits
                        ball_conj_distrib)
       apply (wp createObjects_aligned2 createObjects_nonzero[OF not_0 ,simplified]
@@ -2392,7 +2392,7 @@ proof -
       apply (simp add:pageBits_def ptr word_bits_def)
 
      \<comment> \<open>SectionObject\<close>
-     apply wp
+     apply (wp mapM_x_wp' hoare_vcg_op_lift)
      apply (simp add: valid_cap'_def capAligned_def n_less_word_bits
                       ball_conj_distrib)
      apply (wp createObjects_aligned2 createObjects_nonzero[OF not_0 ,simplified]
@@ -2401,7 +2401,7 @@ proof -
      apply (simp add: pageBits_def ptr word_bits_def)
 
     \<comment> \<open>SuperSectionObject\<close>
-    apply wp
+    apply (wp mapM_x_wp' hoare_vcg_op_lift)
     apply (simp add: valid_cap'_def capAligned_def n_less_word_bits
                      ball_conj_distrib)
     apply (wp createObjects_aligned2 createObjects_nonzero[OF not_0 ,simplified]
@@ -2410,7 +2410,7 @@ proof -
     apply (simp add:pageBits_def ptr word_bits_def)
 
    \<comment> \<open>PageTableObject\<close>
-    apply wp
+    apply (wp mapM_x_wp' hoare_vcg_op_lift)
      apply (simp add: valid_cap'_def capAligned_def n_less_word_bits)
      apply (simp only: imp_conv_disj page_table_at'_def
                        typ_at_to_obj_at_arches)
@@ -2427,8 +2427,7 @@ proof -
      apply (clarsimp simp: objBits_simps archObjSize_def vspace_bits_defs)
     apply clarsimp
   \<comment> \<open>PageDirectoryObject\<close>
-   apply (wp hoare_vcg_const_Ball_lift)
-   apply (wp mapM_x_wp' )
+   apply (wp mapM_x_wp' hoare_vcg_op_lift)
    apply (simp add: valid_cap'_def capAligned_def n_less_word_bits)
    apply (simp only: imp_conv_disj page_directory_at'_def
                      typ_at_to_obj_at_arches)
@@ -2692,9 +2691,9 @@ lemma corres_retype:
   done
 
 lemma init_arch_objects_APIType_map2:
-  "init_arch_objects (APIType_map2 (Inr ty)) ptr bits sz refs =
+  "init_arch_objects (APIType_map2 (Inr ty)) dev ptr bits sz refs =
      (case ty of APIObjectType _ \<Rightarrow> return ()
-   | _ \<Rightarrow> init_arch_objects (APIType_map2 (Inr ty)) ptr bits sz refs)"
+   | _ \<Rightarrow> init_arch_objects (APIType_map2 (Inr ty)) dev ptr bits sz refs)"
   apply (clarsimp split: ARM_HYP_H.object_type.split)
   apply (simp add: init_arch_objects_def APIType_map2_def
             split: apiobject_type.split)
@@ -4370,9 +4369,6 @@ crunch createNewCaps
   for ksArch[wp]: "\<lambda>s. P (ksArchState s)"
   (simp: crunch_simps unless_def wp: crunch_wps)
 crunch createNewCaps
-  for it[wp]: "\<lambda>s. P (ksIdleThread s)"
-  (simp: crunch_simps unless_def wp: crunch_wps updateObject_default_inv)
-crunch createNewCaps
   for gsMaxObjectSize[wp]: "\<lambda>s. P (gsMaxObjectSize s)"
   (simp: crunch_simps unless_def wp: crunch_wps updateObject_default_inv)
 
@@ -4497,7 +4493,9 @@ lemma createNewCaps_pde_mappings'[wp]:
               split del: if_split cong: option.case_cong
                                         object_type.case_cong)
   apply (rule hoare_pre)
-   apply (wp mapM_x_copyGlobalMappings_pde_mappings' | wpc
+   apply (wp mapM_x_copyGlobalMappings_pde_mappings'
+             mapM_x_wp'[where f="\<lambda>r. doMachineOp (m r)" for m]
+         | wpc
          | simp split del: if_split)+
     apply (rule_tac P="range_cover ptr sz (APIType_capBits ty us) n \<and> n\<noteq> 0" in hoare_gen_asm)
     apply (rule hoare_strengthen_post)
@@ -4800,6 +4798,9 @@ lemma createObjects_pspace_domain_valid:
 crunch copyGlobalMappings, doMachineOp
   for pspace_domain_valid[wp]: "pspace_domain_valid"
   (wp: crunch_wps)
+
+crunch doMachineOp
+  for pspace_domain_valid[wp]: pspace_domain_valid
 
 lemma createNewCaps_pspace_domain_valid[wp]:
   "\<lbrace>pspace_domain_valid and K ({ptr .. (ptr && ~~ mask sz) + 2 ^ sz - 1}
@@ -5543,15 +5544,6 @@ lemma createObjects_Not_tcbQueued:
   apply (auto simp: obj_at'_def projectKOs project_inject objBitsKO_def objBits_def makeObject_tcb)
   done
 
-lemma init_arch_objects_APIType_map2_noop:
-  "tp \<noteq> Inr PageDirectoryObject
-   \<longrightarrow> init_arch_objects (APIType_map2 tp) ptr n m addrs
-    = return ()"
-  apply (simp add: init_arch_objects_def APIType_map2_def)
-  apply (cases tp, simp_all split: kernel_object.split arch_kernel_object.split
-    object_type.split apiobject_type.split)
-  done
-
 lemma data_page_relation_retype:
   "obj_relation_retype (ArchObj (DataPage False pgsz)) KOUserData"
   "obj_relation_retype (ArchObj (DataPage True pgsz)) KOUserDataDevice"
@@ -5560,6 +5552,28 @@ lemma data_page_relation_retype:
                    pbfs_atleast_pageBits)
    apply (clarsimp simp: image_def)+
   done
+
+lemma init_arch_objects_APIType_map2_VCPU_noop:
+  "init_arch_objects (APIType_map2 (Inr VCPUObject)) dev ptr n m addrs = return ()"
+  apply (simp add: init_arch_objects_def APIType_map2_def)
+  done
+
+lemma regroup_createObjects_dmo_userPages:
+  "(do
+      addrs <- createObjects y n ko sz;
+      _ <- modify (\<lambda>ks. ks\<lparr>gsUserPages := g ks addrs\<rparr>);
+      _ <- when P (mapM_x (\<lambda>addr. doMachineOp (m addr)) addrs);
+      return (f addrs)
+    od) = (do
+      (addrs, faddrs) <- (do
+        addrs <- createObjects y n ko sz;
+        _ <- modify (\<lambda>ks. ks\<lparr>gsUserPages := g ks addrs\<rparr>);
+        return (addrs, f addrs)
+       od);
+      _ <- when P (mapM_x (\<lambda>addr. doMachineOp (m addr)) addrs);
+      return faddrs
+    od)"
+  by (simp add: bind_assoc)
 
 lemma corres_retype_region_createNewCaps:
   "corres ((\<lambda>r r'. length r = length r' \<and> list_all2 cap_relation r r')
@@ -5573,7 +5587,7 @@ lemma corres_retype_region_createNewCaps:
                   \<and> valid_pspace' s \<and> valid_arch_state' s
                   \<and> range_cover y sz (obj_bits_api (APIType_map2 (Inr ty)) us) n \<and> n\<noteq> 0)
             (do x \<leftarrow> retype_region y n us (APIType_map2 (Inr ty)) dev :: obj_ref list det_ext_monad;
-                init_arch_objects (APIType_map2 (Inr ty)) y n us x;
+                init_arch_objects (APIType_map2 (Inr ty)) dev y n us x;
                 return x od)
             (createNewCaps ty y n us dev)"
   apply (rule_tac F="range_cover y sz
@@ -5677,89 +5691,137 @@ lemma corres_retype_region_createNewCaps:
         apply (clarsimp simp: list_all2_same list_all2_map1 list_all2_map2
                               objBits_simps allRights_def APIType_map2_def
                    split del: if_split)
-          \<comment> \<open>SmallPageObject\<close>
+        \<comment> \<open>SmallPageObject\<close>
+        apply (subst retype_region2_extra_ext_trivial)
+         apply (simp add: APIType_map2_def)
+        apply (simp add: corres_liftM2_simp[unfolded liftM_def] split del: if_split)
+        apply (simp add: init_arch_objects_def split del: if_split)
+        apply (subst regroup_createObjects_dmo_userPages)
+        apply (rule corres_guard_imp)
+          apply (rule corres_split)
+             apply (rule corres_retype_update_gsI,
+                    simp_all add: APIType_map2_def makeObjectKO_def
+                                  arch_default_cap_def obj_bits_api_def3
+                                  default_object_def default_arch_object_def pageBits_def
+                                  ext objBits_simps range_cover.aligned,
+                    simp_all add: data_page_relation_retype)[1]
+            apply (simp add: APIType_map2_def vs_apiobj_size_def
+                        flip: when_def split del: if_split cong: if_cong)
+            apply (rule corres_split)
+               apply corres
+               apply (rule corres_mapM_x', clarsimp)
+                  apply (corres corres: corres_machine_op)
+                 apply wp+
+               apply (rule refl)
+              apply (rule corres_returnTT)
+              apply (simp add: APIType_map2_def arch_default_cap_def vm_read_write_def vmrights_map_def
+                               list_all2_map1 list_all2_map2 list_all2_same)
+             apply ((wpsimp split_del: if_split)+)[6]
+       \<comment> \<open>LargePageObject\<close>
        apply (subst retype_region2_extra_ext_trivial)
         apply (simp add: APIType_map2_def)
        apply (simp add: corres_liftM2_simp[unfolded liftM_def] split del: if_split)
-       apply (rule corres_rel_imp)
-        apply (simp add: init_arch_objects_APIType_map2_noop split del: if_split)
-        apply (rule corres_guard_imp)
-          apply (rule corres_retype_update_gsI,
-                 simp_all add: APIType_map2_def makeObjectKO_def
-                     arch_default_cap_def obj_bits_api_def3
-                     default_object_def default_arch_object_def pageBits_def
-                     ext objBits_simps range_cover.aligned,
-                     simp_all add: data_page_relation_retype)[1]
-         apply simp+
-       apply (simp add: APIType_map2_def arch_default_cap_def vmrights_map_def
-                vm_read_write_def list_all2_map1 list_all2_map2 list_all2_same)
-         \<comment> \<open>LargePageObject\<close>
+       apply (simp add: init_arch_objects_def split del: if_split)
+       apply (subst regroup_createObjects_dmo_userPages)
+       apply (rule corres_guard_imp)
+         apply (rule corres_split)
+            apply (rule corres_retype_update_gsI,
+                   simp_all add: APIType_map2_def makeObjectKO_def
+                                 arch_default_cap_def obj_bits_api_def3
+                                 default_object_def default_arch_object_def pageBits_def
+                                 ext objBits_simps range_cover.aligned,
+                   simp_all add: data_page_relation_retype)[1]
+           apply (simp add: APIType_map2_def vs_apiobj_size_def
+                       flip: when_def split del: if_split cong: if_cong)
+           apply (rule corres_split)
+              apply corres
+              apply (rule corres_mapM_x', clarsimp)
+                 apply (corres corres: corres_machine_op)
+                apply wp+
+              apply (rule refl)
+             apply (rule corres_returnTT)
+             apply (simp add: APIType_map2_def arch_default_cap_def vm_read_write_def vmrights_map_def
+                              list_all2_map1 list_all2_map2 list_all2_same)
+            apply ((wpsimp split_del: if_split)+)[6]
+      \<comment> \<open>SectionObject\<close>
       apply (subst retype_region2_extra_ext_trivial)
        apply (simp add: APIType_map2_def)
       apply (simp add: corres_liftM2_simp[unfolded liftM_def] split del: if_split)
-      apply (rule corres_rel_imp)
-       apply (simp add: init_arch_objects_APIType_map2_noop split del: if_split)
-       apply (rule corres_guard_imp)
-         apply (rule corres_retype_update_gsI,
-                simp_all add: APIType_map2_def makeObjectKO_def
-                    arch_default_cap_def obj_bits_api_def3
-                    default_object_def default_arch_object_def pageBits_def
-                    ext objBits_simps range_cover.aligned,
-                    simp_all add: data_page_relation_retype)[1]
-        apply simp+
-      apply (simp add: APIType_map2_def arch_default_cap_def vmrights_map_def
-               vm_read_write_def list_all2_map1 list_all2_map2 list_all2_same)
-        \<comment> \<open>SectionObject\<close>
+      apply (simp add: init_arch_objects_def split del: if_split)
+      apply (subst regroup_createObjects_dmo_userPages)
+      apply (rule corres_guard_imp)
+        apply (rule corres_split)
+           apply (rule corres_retype_update_gsI,
+                  simp_all add: APIType_map2_def makeObjectKO_def
+                                arch_default_cap_def obj_bits_api_def3
+                                default_object_def default_arch_object_def pageBits_def
+                                ext objBits_simps range_cover.aligned,
+                  simp_all add: data_page_relation_retype)[1]
+          apply (simp add: APIType_map2_def vs_apiobj_size_def
+                      flip: when_def split del: if_split cong: if_cong)
+          apply (rule corres_split)
+             apply corres
+             apply (rule corres_mapM_x', clarsimp)
+                apply (corres corres: corres_machine_op)
+               apply wp+
+             apply (rule refl)
+            apply (rule corres_returnTT)
+            apply (simp add: APIType_map2_def arch_default_cap_def vm_read_write_def vmrights_map_def
+                             list_all2_map1 list_all2_map2 list_all2_same)
+           apply ((wpsimp split_del: if_split)+)[6]
+     \<comment> \<open>SuperSectionObject\<close>
      apply (subst retype_region2_extra_ext_trivial)
       apply (simp add: APIType_map2_def)
      apply (simp add: corres_liftM2_simp[unfolded liftM_def] split del: if_split)
-     apply (rule corres_rel_imp)
-      apply (simp add: init_arch_objects_APIType_map2_noop split del: if_split)
-      apply (rule corres_guard_imp)
-        apply (rule corres_retype_update_gsI,
-               simp_all add: APIType_map2_def makeObjectKO_def
-                   arch_default_cap_def obj_bits_api_def3
-                   default_object_def default_arch_object_def pageBits_def
-                   ext objBits_simps range_cover.aligned,
-                   simp_all add: data_page_relation_retype)[1]
-       apply simp+
-     apply (simp add: APIType_map2_def arch_default_cap_def vmrights_map_def
-              vm_read_write_def list_all2_map1 list_all2_map2 list_all2_same)
-    \<comment> \<open>SuperSectionObject\<close>
+     apply (simp add: init_arch_objects_def split del: if_split)
+     apply (subst regroup_createObjects_dmo_userPages)
+     apply (rule corres_guard_imp)
+       apply (rule corres_split)
+          apply (rule corres_retype_update_gsI,
+                 simp_all add: APIType_map2_def makeObjectKO_def
+                               arch_default_cap_def obj_bits_api_def3
+                               default_object_def default_arch_object_def pageBits_def
+                               ext objBits_simps range_cover.aligned,
+                 simp_all add: data_page_relation_retype)[1]
+         apply (simp add: APIType_map2_def vs_apiobj_size_def
+                     flip: when_def split del: if_split cong: if_cong)
+         apply (rule corres_split)
+            apply corres
+            apply (rule corres_mapM_x', clarsimp)
+               apply (corres corres: corres_machine_op)
+              apply wp+
+            apply (rule refl)
+           apply (rule corres_returnTT)
+           apply (simp add: APIType_map2_def arch_default_cap_def vm_read_write_def vmrights_map_def
+                            list_all2_map1 list_all2_map2 list_all2_same)
+          apply ((wpsimp split_del: if_split)+)[6]
+    \<comment> \<open>PageTable\<close>
     apply (subst retype_region2_extra_ext_trivial)
      apply (simp add: APIType_map2_def)
-    apply (simp add: corres_liftM2_simp[unfolded liftM_def] split del: if_split)
-    apply (rule corres_rel_imp)
-     apply (simp add: init_arch_objects_APIType_map2_noop split del: if_split)
-     apply (rule corres_guard_imp)
-       apply (rule corres_retype_update_gsI,
-              simp_all add: APIType_map2_def makeObjectKO_def
-                  arch_default_cap_def obj_bits_api_def3
-                  default_object_def default_arch_object_def pageBits_def
-                  ext objBits_simps range_cover.aligned,
-                  simp_all add: data_page_relation_retype)[1]
-      apply simp+
-    apply (simp add: APIType_map2_def arch_default_cap_def vmrights_map_def
-             vm_read_write_def list_all2_map1 list_all2_map2 list_all2_same)
-  \<comment> \<open>PageTable\<close>
-   apply (subst retype_region2_extra_ext_trivial)
-    apply (simp add: APIType_map2_def)
-   apply (simp_all add: corres_liftM2_simp[unfolded liftM_def])
-   apply (rule corres_guard_imp)
-    apply (simp add: init_arch_objects_APIType_map2_noop)
-    apply (rule corres_rel_imp)
-       apply (rule corres_retype[where 'a =pte],
-            simp_all add: APIType_map2_def obj_bits_api_def
-                          default_arch_object_def objBits_simps
-                          archObjSize_def vspace_bits_defs
-                          makeObjectKO_def range_cover.aligned)[1]
-     apply (rule pagetable_relation_retype)
-    apply (wp | simp)+
-    apply (clarsimp simp: list_all2_map1 list_all2_map2 list_all2_same
-                          APIType_map2_def arch_default_cap_def)
-   apply simp+
+    apply (simp add: corres_liftM2_simp[unfolded liftM_def])
+    apply (simp add: init_arch_objects_def  split del: if_split)
+    apply (rule corres_guard_imp)
+      apply (rule corres_split)
+         apply (rule corres_retype[where 'a =pte],
+                simp_all add: APIType_map2_def obj_bits_api_def
+                              default_arch_object_def objBits_simps
+                              archObjSize_def vspace_bits_defs
+                              makeObjectKO_def range_cover.aligned)[1]
+         apply (rule pagetable_relation_retype)
+        apply (clarsimp simp: APIType_map2_def vs_apiobj_size_def)
+        apply (rule corres_split)
+           apply (rule corres_mapM_x', clarsimp)
+              apply (corres corres: corres_machine_op)
+             apply wp+
+           apply (rule refl)
+          apply (rule corres_returnTT)
+          apply corres
+          apply (clarsimp simp: list_all2_map1 list_all2_map2 list_all2_same
+                                APIType_map2_def arch_default_cap_def)
+         apply ((wpsimp split_del: if_split)+)[6]
    defer
-  \<comment> \<open>PageDirectory\<close>
+   \<comment> \<open>PageDirectory\<close>
+   apply (simp only: bind_assoc)
    apply (rule corres_guard_imp)
      apply (rule corres_split_eqr)
         apply (rule corres_retype[where ty = "Inr PageDirectoryObject" and 'a = pde
@@ -5787,18 +5849,14 @@ lemma corres_retype_region_createNewCaps:
             apply (rule corres_return[where P =\<top> and P'=\<top>,THEN iffD2])
             apply simp
            apply wp+
-         apply (simp add: liftM_def[symmetric] o_def list_all2_map1
-                          list_all2_map2 list_all2_same
-                          arch_default_cap_def mapM_x_mapM)
-         apply (simp add: dc_def[symmetric])
-         apply (rule corres_machine_op)
-         apply (rule corres_Id)
-           apply (simp add: shiftl_t2n shiftL_nat
-                            vspace_bits_defs)
-          apply simp
-         apply (simp add: mapM_discarded[where g = "return ()",simplified,symmetric])
-         apply (rule no_fail_pre)
-          apply (wp no_fail_mapM|clarsimp)+
+         apply (rule corres_split, rule corres_mapM_x', rule corres_machine_op)
+               apply (clarsimp simp: vs_apiobj_size_def)
+               apply (rule corres_underlying_trivial_dc, wp)
+              apply wp+
+            apply (rule refl)
+           apply (rule corres_returnTT)
+           apply (simp add: list_all2_map1 list_all2_map2 list_all2_same arch_default_cap_def)
+          apply wp+
       apply (rule hoare_vcg_conj_lift)
        apply (rule hoare_post_imp)
         prefer 2
@@ -5848,25 +5906,26 @@ lemma corres_retype_region_createNewCaps:
                       APIType_map2_def default_arch_object_def default_object_def archObjSize_def
                       vspace_bits_defs fromIntegral_def toInteger_nat fromInteger_nat)[2]
   \<comment> \<open>VCPUObject\<close>
-      apply (subst retype_region2_extra_ext_trivial)
-       apply (simp add: APIType_map2_def)
-      apply (simp add: corres_liftM2_simp[unfolded liftM_def] split del: if_split)
-      apply (rule corres_rel_imp)
-       apply (simp add: init_arch_objects_APIType_map2_noop split del: if_split)
-       apply (rule corres_guard_imp)
-            apply (rule corres_retype[where 'a = vcpu],
-                   simp_all add: obj_bits_api_def objBits_simps pageBits_def default_arch_object_def
-                                 APIType_map2_def makeObjectKO_def archObjSize_def vcpu_bits_def
-                                 other_objs_default_relation)[1]
-            apply (fastforce simp: range_cover_def)
-           apply (simp add: no_gs_types_def)
-          apply (auto simp add: obj_relation_retype_def range_cover_def objBitsKO_def arch_kobj_size_def default_object_def
-                           archObjSize_def vcpu_bits_def pageBits_def obj_bits_def cte_level_bits_def default_arch_object_def
-                           other_obj_relation_def vcpu_relation_def default_vcpu_def makeObject_vcpu
-                           makeVCPUObject_def default_gic_vcpu_interface_def vgic_map_def)[1]
-         apply simp+
-        apply (clarsimp simp: list_all2_same list_all2_map1 list_all2_map2
-                              objBits_simps APIType_map2_def arch_default_cap_def)
+  apply (subst retype_region2_extra_ext_trivial)
+   apply (simp add: APIType_map2_def)
+  apply (simp add: corres_liftM2_simp[unfolded liftM_def] split del: if_split)
+  apply (rule corres_rel_imp)
+   apply (simp add: init_arch_objects_APIType_map2_VCPU_noop split del: if_split)
+   apply (rule corres_guard_imp)
+     apply (rule corres_retype[where 'a = vcpu],
+            simp_all add: obj_bits_api_def objBits_simps pageBits_def default_arch_object_def
+                          APIType_map2_def makeObjectKO_def archObjSize_def vcpu_bits_def
+                          other_objs_default_relation)[1]
+       apply (fastforce simp: range_cover_def)
+      apply (simp add: no_gs_types_def)
+     apply (auto simp: obj_relation_retype_def range_cover_def objBitsKO_def arch_kobj_size_def
+                       default_object_def default_arch_object_def
+                       archObjSize_def vcpu_bits_def pageBits_def obj_bits_def cte_level_bits_def
+                       other_obj_relation_def vcpu_relation_def default_vcpu_def makeObject_vcpu
+                       makeVCPUObject_def default_gic_vcpu_interface_def vgic_map_def)[1]
+    apply simp+
+  apply (clarsimp simp: list_all2_same list_all2_map1 list_all2_map2
+                        objBits_simps APIType_map2_def arch_default_cap_def)
   done
 
 end

--- a/proof/refine/RISCV64/Retype_R.thy
+++ b/proof/refine/RISCV64/Retype_R.thy
@@ -2615,9 +2615,9 @@ lemma corres_retype:
   done
 
 lemma init_arch_objects_APIType_map2:
-  "init_arch_objects (APIType_map2 (Inr ty)) ptr bits sz refs =
+  "init_arch_objects (APIType_map2 (Inr ty)) dev ptr bits sz refs =
      (case ty of APIObjectType _ \<Rightarrow> return ()
-   | _ \<Rightarrow> init_arch_objects (APIType_map2 (Inr ty)) ptr bits sz refs)"
+   | _ \<Rightarrow> init_arch_objects (APIType_map2 (Inr ty)) dev ptr bits sz refs)"
   apply (clarsimp split: RISCV64_H.object_type.split)
   apply (simp add: init_arch_objects_def APIType_map2_def
             split: apiobject_type.split)
@@ -5335,7 +5335,7 @@ lemma createObjects_Not_tcbQueued:
   done
 
 lemma init_arch_objects_APIType_map2_noop:
-  "init_arch_objects (APIType_map2 tp) ptr n m addrs = return ()"
+  "init_arch_objects (APIType_map2 tp) dev ptr n m addrs = return ()"
   apply (simp add: init_arch_objects_def APIType_map2_def)
   done
 
@@ -5359,7 +5359,7 @@ lemma corres_retype_region_createNewCaps:
                   \<and> valid_pspace' s \<and> valid_arch_state' s
                   \<and> range_cover y sz (obj_bits_api (APIType_map2 (Inr ty)) us) n \<and> n\<noteq> 0)
             (do x \<leftarrow> retype_region y n us (APIType_map2 (Inr ty)) dev :: obj_ref list det_ext_monad;
-                init_arch_objects (APIType_map2 (Inr ty)) y n us x;
+                init_arch_objects (APIType_map2 (Inr ty)) dev y n us x;
                 return x od)
             (createNewCaps ty y n us dev)"
   apply (rule_tac F="range_cover y sz (obj_bits_api (APIType_map2 (Inr ty)) us) n

--- a/proof/refine/X64/Retype_R.thy
+++ b/proof/refine/X64/Retype_R.thy
@@ -2721,9 +2721,9 @@ lemma corres_retype:
   done
 
 lemma init_arch_objects_APIType_map2:
-  "init_arch_objects (APIType_map2 (Inr ty)) ptr bits sz refs =
+  "init_arch_objects (APIType_map2 (Inr ty)) dev ptr bits sz refs =
      (case ty of APIObjectType _ \<Rightarrow> return ()
-   | _ \<Rightarrow> init_arch_objects (APIType_map2 (Inr ty)) ptr bits sz refs)"
+   | _ \<Rightarrow> init_arch_objects (APIType_map2 (Inr ty)) dev ptr bits sz refs)"
   apply (clarsimp split: X64_H.object_type.split)
   apply (simp add: init_arch_objects_def APIType_map2_def
             split: apiobject_type.split)
@@ -5579,7 +5579,7 @@ lemma createObjects_Not_tcbQueued:
 
 lemma init_arch_objects_APIType_map2_noop:
   "tp \<noteq> Inr PML4Object
-   \<longrightarrow> init_arch_objects (APIType_map2 tp) ptr n m addrs
+   \<longrightarrow> init_arch_objects (APIType_map2 tp) dev ptr n m addrs
     = return ()"
   apply (simp add: init_arch_objects_def APIType_map2_def)
   apply (cases tp, simp_all split: kernel_object.split arch_kernel_object.split
@@ -5645,7 +5645,7 @@ lemma corres_retype_region_createNewCaps:
                   \<and> valid_pspace' s \<and> valid_arch_state' s
                   \<and> range_cover y sz (obj_bits_api (APIType_map2 (Inr ty)) us) n \<and> n\<noteq> 0)
             (do x \<leftarrow> retype_region y n us (APIType_map2 (Inr ty)) dev :: obj_ref list det_ext_monad;
-                init_arch_objects (APIType_map2 (Inr ty)) y n us x;
+                init_arch_objects (APIType_map2 (Inr ty)) dev y n us x;
                 return x od)
             (createNewCaps ty y n us dev)"
   apply (rule_tac F="range_cover y sz (obj_bits_api (APIType_map2 (Inr ty)) us) n

--- a/spec/abstract/AARCH64/ArchRetype_A.thy
+++ b/spec/abstract/AARCH64/ArchRetype_A.thy
@@ -24,9 +24,34 @@ definition reserve_region :: "obj_ref \<Rightarrow> nat \<Rightarrow> bool \<Rig
 
 text \<open>Initialise architecture-specific objects.\<close>
 
+definition vs_apiobj_size where
+  "vs_apiobj_size ty \<equiv>
+     case ty of
+       ArchObject SmallPageObj \<Rightarrow> pageBitsForSize ARMSmallPage
+     | ArchObject LargePageObj \<Rightarrow> pageBitsForSize ARMLargePage
+     | ArchObject HugePageObj \<Rightarrow> pageBitsForSize ARMHugePage
+     | ArchObject PageTableObj \<Rightarrow> table_size NormalPT_T
+     | ArchObject VSpaceObj \<Rightarrow> table_size VSRootPT_T"
+
 definition init_arch_objects ::
-  "apiobject_type \<Rightarrow> obj_ref \<Rightarrow> nat \<Rightarrow> nat \<Rightarrow> obj_ref list \<Rightarrow> (unit,'z::state_ext) s_monad" where
-  "init_arch_objects new_type ptr num_objects obj_sz refs \<equiv> return ()"
+  "apiobject_type \<Rightarrow> bool \<Rightarrow> obj_ref \<Rightarrow> nat \<Rightarrow> nat \<Rightarrow> obj_ref list \<Rightarrow> (unit,'z::state_ext) s_monad"
+  where
+  "init_arch_objects new_type is_device ptr num_objects obj_sz refs \<equiv>
+     if \<not>is_device \<and>
+        new_type \<in> {ArchObject SmallPageObj, ArchObject LargePageObj, ArchObject HugePageObj}
+     then
+       mapM_x (\<lambda>ref. do_machine_op $
+                       cleanCacheRange_RAM ref (ref + mask (vs_apiobj_size new_type))
+                                           (addrFromPPtr ref))
+              refs
+     else if new_type \<in> {ArchObject PageTableObj, ArchObject VSpaceObj}
+     then
+       mapM_x (\<lambda>ref. do_machine_op $
+                       cleanCacheRange_PoU ref (ref + mask (vs_apiobj_size new_type))
+                                           (addrFromPPtr ref))
+              refs
+     else
+       return ()"
 
 definition empty_context :: user_context where
   "empty_context \<equiv> UserContext (FPUState (\<lambda>_. 0) 0 0) (\<lambda>_. 0)"

--- a/spec/abstract/ARM/ArchRetype_A.thy
+++ b/spec/abstract/ARM/ArchRetype_A.thy
@@ -26,15 +26,38 @@ definition
 
 text \<open>Initialise architecture-specific objects.\<close>
 
-definition
-  init_arch_objects :: "apiobject_type \<Rightarrow> obj_ref \<Rightarrow> nat \<Rightarrow> nat \<Rightarrow> obj_ref list \<Rightarrow> (unit,'z::state_ext) s_monad"
-where
-  "init_arch_objects new_type ptr num_objects obj_sz refs
-    \<equiv> if new_type = ArchObject PageDirectoryObj then (do
-      mapM_x copy_global_mappings refs;
-      do_machine_op $ mapM_x (\<lambda>x. cleanCacheRange_PoU x (x + ((1::word32) << pd_bits) - 1)
-                                                      (addrFromPPtr x)) refs
-    od) else return ()"
+definition vs_apiobj_size where
+  "vs_apiobj_size ty \<equiv>
+     case ty of
+       ArchObject SmallPageObj \<Rightarrow> pageBitsForSize ARMSmallPage
+     | ArchObject LargePageObj \<Rightarrow> pageBitsForSize ARMLargePage
+     | ArchObject SectionObj \<Rightarrow> pageBitsForSize ARMSection
+     | ArchObject SuperSectionObj \<Rightarrow> pageBitsForSize ARMSuperSection
+     | ArchObject PageTableObj \<Rightarrow> pt_bits
+     | ArchObject PageDirectoryObj \<Rightarrow> pd_bits"
+
+definition init_arch_objects ::
+  "apiobject_type \<Rightarrow> bool \<Rightarrow> obj_ref \<Rightarrow> nat \<Rightarrow> nat \<Rightarrow> obj_ref list \<Rightarrow> (unit,'z::state_ext) s_monad"
+  where
+  "init_arch_objects new_type is_device ptr num_objects obj_sz refs \<equiv> do
+     when (new_type = ArchObject PageDirectoryObj) $ mapM_x copy_global_mappings refs;
+     if \<not>is_device \<and>
+        new_type \<in> {ArchObject SmallPageObj, ArchObject LargePageObj,
+                    ArchObject SectionObj, ArchObject SuperSectionObj}
+     then
+       mapM_x (\<lambda>ref. do_machine_op $
+                       cleanCacheRange_RAM ref (ref + mask (vs_apiobj_size new_type))
+                                           (addrFromPPtr ref))
+              refs
+     else if new_type \<in> {ArchObject PageTableObj, ArchObject PageDirectoryObj}
+     then
+       mapM_x (\<lambda>ref. do_machine_op $
+                       cleanCacheRange_PoU ref (ref + mask (vs_apiobj_size new_type))
+                                           (addrFromPPtr ref))
+              refs
+     else
+       return ()
+   od"
 
 definition
   empty_context :: user_context where

--- a/spec/abstract/ARM_HYP/ArchRetype_A.thy
+++ b/spec/abstract/ARM_HYP/ArchRetype_A.thy
@@ -26,15 +26,38 @@ definition
 
 text \<open>Initialise architecture-specific objects.\<close>
 
-definition
-  init_arch_objects :: "apiobject_type \<Rightarrow> obj_ref \<Rightarrow> nat \<Rightarrow> nat \<Rightarrow> obj_ref list \<Rightarrow> (unit,'z::state_ext) s_monad"
-where
-  "init_arch_objects new_type ptr num_objects obj_sz refs
-    \<equiv> if new_type = ArchObject PageDirectoryObj then (do
-      mapM_x copy_global_mappings refs;
-      do_machine_op $ mapM_x (\<lambda>x. cleanCacheRange_PoU x (x + ((1::word32) << pd_bits) - 1)
-                                                      (addrFromPPtr x)) refs
-    od) else return ()"
+definition vs_apiobj_size where
+  "vs_apiobj_size ty \<equiv>
+     case ty of
+       ArchObject SmallPageObj \<Rightarrow> pageBitsForSize ARMSmallPage
+     | ArchObject LargePageObj \<Rightarrow> pageBitsForSize ARMLargePage
+     | ArchObject SectionObj \<Rightarrow> pageBitsForSize ARMSection
+     | ArchObject SuperSectionObj \<Rightarrow> pageBitsForSize ARMSuperSection
+     | ArchObject PageTableObj \<Rightarrow> pt_bits
+     | ArchObject PageDirectoryObj \<Rightarrow> pd_bits"
+
+definition init_arch_objects ::
+  "apiobject_type \<Rightarrow> bool \<Rightarrow> obj_ref \<Rightarrow> nat \<Rightarrow> nat \<Rightarrow> obj_ref list \<Rightarrow> (unit,'z::state_ext) s_monad"
+  where
+  "init_arch_objects new_type is_device ptr num_objects obj_sz refs \<equiv> do
+     when (new_type = ArchObject PageDirectoryObj) $ mapM_x copy_global_mappings refs;
+     if \<not>is_device \<and>
+        new_type \<in> {ArchObject SmallPageObj, ArchObject LargePageObj,
+                    ArchObject SectionObj, ArchObject SuperSectionObj}
+     then
+       mapM_x (\<lambda>ref. do_machine_op $
+                       cleanCacheRange_RAM ref (ref + mask (vs_apiobj_size new_type))
+                                           (addrFromPPtr ref))
+              refs
+     else if new_type \<in> {ArchObject PageTableObj, ArchObject PageDirectoryObj}
+     then
+       mapM_x (\<lambda>ref. do_machine_op $
+                       cleanCacheRange_PoU ref (ref + mask (vs_apiobj_size new_type))
+                                           (addrFromPPtr ref))
+              refs
+     else
+       return ()
+   od"
 
 definition
   empty_context :: user_context where

--- a/spec/abstract/RISCV64/ArchRetype_A.thy
+++ b/spec/abstract/RISCV64/ArchRetype_A.thy
@@ -25,9 +25,9 @@ definition reserve_region :: "obj_ref \<Rightarrow> nat \<Rightarrow> bool \<Rig
 text \<open>Initialise architecture-specific objects.\<close>
 
 definition init_arch_objects ::
-  "apiobject_type \<Rightarrow> obj_ref \<Rightarrow> nat \<Rightarrow> nat \<Rightarrow> obj_ref list \<Rightarrow> (unit,'z::state_ext) s_monad"
+  "apiobject_type \<Rightarrow> bool \<Rightarrow> obj_ref \<Rightarrow> nat \<Rightarrow> nat \<Rightarrow> obj_ref list \<Rightarrow> (unit,'z::state_ext) s_monad"
   where
-  "init_arch_objects new_type ptr num_objects obj_sz refs \<equiv> return ()"
+  "init_arch_objects new_type is_device ptr num_objects obj_sz refs \<equiv> return ()"
 
 definition empty_context :: user_context
   where

--- a/spec/abstract/Retype_A.thy
+++ b/spec/abstract/Retype_A.thy
@@ -189,7 +189,7 @@ doE
 
   \<comment> \<open>Create new objects.\<close>
   orefs \<leftarrow> retype_region retype_base (length slots) obj_sz new_type is_device;
-  init_arch_objects new_type retype_base (length slots) obj_sz orefs;
+  init_arch_objects new_type is_device retype_base (length slots) obj_sz orefs;
   sequence_x (map (create_cap new_type obj_sz src_slot is_device) (zip slots orefs))
 od odE"
 

--- a/spec/abstract/X64/ArchRetype_A.thy
+++ b/spec/abstract/X64/ArchRetype_A.thy
@@ -27,10 +27,10 @@ definition
 text \<open>Initialise architecture-specific objects.\<close>
 
 definition
-  init_arch_objects :: "apiobject_type \<Rightarrow> obj_ref \<Rightarrow> nat \<Rightarrow> nat \<Rightarrow> obj_ref list
+  init_arch_objects :: "apiobject_type \<Rightarrow> bool \<Rightarrow> obj_ref \<Rightarrow> nat \<Rightarrow> nat \<Rightarrow> obj_ref list
    \<Rightarrow> (unit,'z::state_ext) s_monad"
 where
-  "init_arch_objects new_type ptr num_objects obj_sz refs
+  "init_arch_objects new_type is_device ptr num_objects obj_sz refs
     \<equiv> when (new_type = ArchObject PML4Obj) (mapM_x copy_global_mappings refs)"
 
 definition

--- a/spec/design/skel/ARM/ArchIntermediate_H.thy
+++ b/spec/design/skel/ARM/ArchIntermediate_H.thy
@@ -20,6 +20,11 @@ private abbreviation (input)
         modify (\<lambda>ks. ks \<lparr> gsUserPages := (\<lambda> addr.
           if addr `~elem~` map fromPPtr addrs then Just pSize
           else gsUserPages ks addr)\<rparr>);
+        when (\<not>dev) $
+          mapM_x (\<lambda>addr. doMachineOp $
+                            cleanCacheRange_RAM addr
+                                                (addr + mask (pageBitsForSize pSize))
+                                                (addrFromPPtr addr)) addrs;
         return $ map (\<lambda>n. PageCap dev (PPtr (fromPPtr n)) VMReadWrite pSize Nothing) addrs
      od)"
 
@@ -29,6 +34,8 @@ private abbreviation (input)
       addrs \<leftarrow> createObjects regionBase numObjects (injectKO objectProto) tableSize;
       pts \<leftarrow> return (map (PPtr \<circ> fromPPtr) addrs);
       initialiseMappings pts;
+      mapM_x (\<lambda>addr. doMachineOp $
+                       cleanCacheRange_PoU addr (addr + mask tableBits) (addrFromPPtr addr)) addrs;
       return $ map (\<lambda>pt. cap pt Nothing) pts
     od)"
 
@@ -51,10 +58,7 @@ defs Arch_createNewCaps_def:
         | PageDirectoryObject \<Rightarrow>
             createNewTableCaps regionBase numObjects pdBits (makeObject::pde) PageDirectoryCap
               (\<lambda>pds. do objSize \<leftarrow> return (((1::nat) `~shiftL~` pdBits));
-                        mapM_x copyGlobalMappings pds;
-                        doMachineOp $ mapM_x (\<lambda>x. cleanCacheRange_PoU x
-                                                    (x + (fromIntegral objSize) - 1)
-                                                    (addrFromPPtr x)) pds
+                        mapM_x copyGlobalMappings pds
                      od)
         )"
 

--- a/spec/machine/AARCH64/MachineOps.thy
+++ b/spec/machine/AARCH64/MachineOps.thy
@@ -414,12 +414,10 @@ lemmas cache_machine_op_defs =
 
 subsection "Clearing Memory"
 
-text \<open>Clear memory contents to recycle it as user memory\<close>
+text \<open>Clear memory contents to recycle it as user memory. Do not yet flush the cache.\<close>
 definition clearMemory :: "machine_word \<Rightarrow> nat \<Rightarrow> unit machine_monad" where
-  "clearMemory ptr bytelength \<equiv> do
-     mapM_x (\<lambda>p. storeWord p 0) [ptr, ptr + word_size .e. ptr + (of_nat bytelength) - 1];
-     cleanCacheRange_RAM ptr (ptr + of_nat bytelength - 1) (addrFromPPtr ptr)
-   od"
+  "clearMemory ptr bytelength \<equiv>
+     mapM_x (\<lambda>p. storeWord p 0) [ptr, ptr + word_size .e. ptr + (of_nat bytelength) - 1]"
 
 text \<open>Haskell simulator interface stub.\<close>
 definition clearMemoryVM :: "machine_word \<Rightarrow> nat \<Rightarrow> unit machine_monad" where

--- a/spec/machine/ARM/MachineOps.thy
+++ b/spec/machine/ARM/MachineOps.thy
@@ -454,14 +454,12 @@ where
 
 section "Memory Clearance"
 
-text \<open>Clear memory contents to recycle it as user memory\<close>
+text \<open>Clear memory contents to recycle it as user memory. Do not yet flush the cache.\<close>
 definition
   clearMemory :: "machine_word \<Rightarrow> nat \<Rightarrow> unit machine_monad"
   where
  "clearMemory ptr bytelength \<equiv>
-  do mapM_x (\<lambda>p. storeWord p 0) [ptr, ptr + word_size .e. ptr + (of_nat bytelength) - 1];
-     cleanCacheRange_RAM ptr (ptr + of_nat bytelength - 1) (addrFromPPtr ptr)
-  od"
+    mapM_x (\<lambda>p. storeWord p 0) [ptr, ptr + word_size .e. ptr + (of_nat bytelength) - 1]"
 
 definition
   clearMemoryVM :: "machine_word \<Rightarrow> nat \<Rightarrow> unit machine_monad"

--- a/spec/machine/ARM_HYP/MachineOps.thy
+++ b/spec/machine/ARM_HYP/MachineOps.thy
@@ -473,14 +473,12 @@ where
 
 section "Memory Clearance"
 
-text \<open>Clear memory contents to recycle it as user memory\<close>
+text \<open>Clear memory contents to recycle it as user memory. Do not yet flush the cache.\<close>
 definition
   clearMemory :: "machine_word \<Rightarrow> nat \<Rightarrow> unit machine_monad"
   where
  "clearMemory ptr bytelength \<equiv>
-  do mapM_x (\<lambda>p. storeWord p 0) [ptr, ptr + word_size .e. ptr + (of_nat bytelength) - 1];
-     cleanCacheRange_RAM ptr (ptr + of_nat bytelength - 1) (addrFromPPtr ptr)
-  od"
+    mapM_x (\<lambda>p. storeWord p 0) [ptr, ptr + word_size .e. ptr + (of_nat bytelength) - 1]"
 
 definition
   clearMemoryVM :: "machine_word \<Rightarrow> nat \<Rightarrow> unit machine_monad"


### PR DESCRIPTION
Verification update for PR seL4/seL4#1289 where we defer the cache flush from untyped reset to the actual retype operation, which means that only flushes that are actually necessary will be performed.

This reduces the time for an untyped reset from 25 sec to 1.5 sec on the `tx2` board with 8GB of memory. Smaller, but still significant benefits for boards with less memory.

This was a lot more fiddly than I thought and touches some ugly old proofs. I've tried to streamline them at least a little bit and make them more consistent, but they have not become much prettier.

Test with: seL4/seL4#1289
