### PR TITLE
x64 crefine: proof update after change to C

### DIFF
--- a/proof/crefine/X64/Arch_C.thy
+++ b/proof/crefine/X64/Arch_C.thy
@@ -5423,6 +5423,7 @@ proof -
     apply (clarsimp simp: isCap_simps decodeX64PortInvocation_def Let_def)
     apply (cinit' lift: invLabel_' length___unsigned_long_' slot_' current_extra_caps_' cap_' buffer_' call_')
      apply (clarsimp cong: StateSpace.state.fold_congs globals.fold_congs)
+     apply csymbr
      apply (rule ccorres_Cond_rhs) (* IN invocations *)
       apply (erule ccorres_disj_division)
        \<comment> \<open>In8\<close>


### PR DESCRIPTION
Updates proof after https://github.com/seL4/seL4/pull/1347

`decodeX86PortInvocation` was modified to include some explicit variable initialization to satisfy GCC.

Test with: seL4/seL4#1347