### PR TITLE
Discard ARM Refine proofs on rt branch

### DIFF
--- a/proof/refine/ARM/ADT_H.thy
+++ b/proof/refine/ARM/ADT_H.thy
@@ -12,11 +12,6 @@ imports
   Syscall_R
 begin
 
-(* FIXME: many of the naming conventions in this file are wrong. Definitions should start with
-          lower case letters, and should be under_score, not camelCase. Some, possibly many of
-          the functions here can benefit from projections that have been developed since this
-          was originally written *)
-
 text \<open>
   The general refinement calculus (see theory Simulation) requires
   the definition of a so-called ``abstract datatype'' for each refinement layer.
@@ -284,13 +279,12 @@ definition
                    | Structures_H.RecvEP q \<Rightarrow> Structures_A.RecvEP q"
 
 definition
-  "NtfnMap ntfn \<equiv>
+  "AEndpointMap ntfn \<equiv>
       \<lparr> ntfn_obj = case ntfnObj ntfn of
                        Structures_H.IdleNtfn \<Rightarrow> Structures_A.IdleNtfn
                      | Structures_H.WaitingNtfn q \<Rightarrow> Structures_A.WaitingNtfn q
                      | Structures_H.ActiveNtfn b \<Rightarrow> Structures_A.ActiveNtfn b
-      , ntfn_bound_tcb = ntfnBoundTCB ntfn
-      , ntfn_sc = ntfnSc ntfn \<rparr>"
+      , ntfn_bound_tcb = ntfnBoundTCB ntfn \<rparr>"
 
 fun
   CapabilityMap :: "capability \<Rightarrow> cap"
@@ -306,10 +300,8 @@ fun
    cap.CNodeCap ref n (bin_to_bl l (uint L))"
 | "CapabilityMap (capability.ThreadCap ref) = cap.ThreadCap ref"
 | "CapabilityMap capability.DomainCap = cap.DomainCap"
-| "CapabilityMap (capability.ReplyCap ref gr) =
-   cap.ReplyCap ref {x. gr \<and> x = AllowGrant \<or> x = AllowWrite}"
-| "CapabilityMap (SchedContextCap sc n) = cap.SchedContextCap sc (n - min_sched_context_bits)"
-| "CapabilityMap SchedControlCap = cap.SchedControlCap"
+| "CapabilityMap (capability.ReplyCap ref master gr) =
+   cap.ReplyCap ref master {x. gr \<and> x = AllowGrant \<or> x = AllowWrite}"
 | "CapabilityMap capability.IRQControlCap = cap.IRQControlCap"
 | "CapabilityMap (capability.IRQHandlerCap irq) = cap.IRQHandlerCap irq"
 | "CapabilityMap (capability.Zombie p b n) =
@@ -357,10 +349,10 @@ where
               Structures_A.thread_state.Inactive"
 | "ThStateMap Structures_H.thread_state.IdleThreadState =
               Structures_A.thread_state.IdleThreadState"
-| "ThStateMap (Structures_H.thread_state.BlockedOnReply r) =
-              Structures_A.thread_state.BlockedOnReply (the r)"
-| "ThStateMap (Structures_H.thread_state.BlockedOnReceive oref grant r) =
-              Structures_A.thread_state.BlockedOnReceive oref r \<lparr> receiver_can_grant = grant \<rparr>"
+| "ThStateMap Structures_H.thread_state.BlockedOnReply =
+              Structures_A.thread_state.BlockedOnReply"
+| "ThStateMap (Structures_H.thread_state.BlockedOnReceive oref grant) =
+              Structures_A.thread_state.BlockedOnReceive oref \<lparr> receiver_can_grant = grant \<rparr>"
 | "ThStateMap (Structures_H.thread_state.BlockedOnSend oref badge grant grant_reply call) =
               Structures_A.thread_state.BlockedOnSend oref
                 \<lparr> sender_badge = badge,
@@ -404,8 +396,6 @@ primrec
 where
   "FaultMap (Fault_H.fault.CapFault ref b failure) =
      ExceptionTypes_A.fault.CapFault ref b (LookupFailureMap failure)"
-| "FaultMap (Fault_H.fault.Timeout b) =
-     ExceptionTypes_A.fault.Timeout b"
 | "FaultMap (Fault_H.fault.ArchFault fault) =
      ExceptionTypes_A.fault.ArchFault (ArchFaultMap fault)"
 | "FaultMap (Fault_H.fault.UnknownSyscallException n) =
@@ -418,7 +408,7 @@ lemma ArchFaultMap_arch_fault_map: "ArchFaultMap (arch_fault_map f) = f"
 
 lemma FaultMap_fault_map[simp]:
   "valid_fault ft \<Longrightarrow> FaultMap (fault_map ft) = ft"
-  apply (case_tac ft; simp)
+  apply (case_tac ft, simp_all)
    apply (simp add: valid_fault_def LookupFailureMap_lookup_failure_map word_bits_def)
   apply (rule ArchFaultMap_arch_fault_map)
   done
@@ -435,48 +425,23 @@ definition
   "TcbMap tcb \<equiv>
      \<lparr>tcb_ctable = CapabilityMap (cteCap (tcbCTable tcb)),
       tcb_vtable = CapabilityMap (cteCap (tcbVTable tcb)),
+      tcb_reply = CapabilityMap (cteCap (tcbReply tcb)),
+      tcb_caller = CapabilityMap (cteCap (tcbCaller tcb)),
       tcb_ipcframe = CapabilityMap (cteCap (tcbIPCBufferFrame tcb)),
-      tcb_fault_handler = CapabilityMap (cteCap (tcbFaultHandler tcb)),
-      tcb_timeout_handler = CapabilityMap (cteCap (tcbTimeoutHandler tcb)),
       tcb_state = ThStateMap (tcbState tcb),
+      tcb_fault_handler = to_bl (tcbFaultHandler tcb),
       tcb_ipc_buffer = tcbIPCBuffer tcb,
       tcb_fault = map_option FaultMap (tcbFault tcb),
       tcb_bound_notification = tcbBoundNotification tcb,
       tcb_mcpriority = tcbMCP tcb,
-      tcb_sched_context = tcbSchedContext tcb,
-      tcb_yield_to = tcbYieldTo tcb,
-      tcb_priority = tcbPriority tcb,
-      tcb_domain = tcbDomain tcb,
       tcb_arch = ArchTcbMap (tcbArch tcb)\<rparr>"
 
-definition absCNode :: "nat \<Rightarrow> (obj_ref \<rightharpoonup> kernel_object) \<Rightarrow> obj_ref \<Rightarrow> Structures_A.kernel_object"
-  where
-  "absCNode sz h a \<equiv> CNode sz (\<lambda>bl. if length bl = sz
-                                     then Some (CapabilityMap
-                                                  (case (h (a + of_bl bl * 2^cteSizeBits)) of
-                                                     Some (KOCTE cte) \<Rightarrow> cteCap cte))
-                                     else None)"
-
-definition scMap :: "(obj_ref \<rightharpoonup> obj_ref) \<Rightarrow> sched_context \<Rightarrow> Structures_A.sched_context" where
-  "scMap replyPrevs sc = \<lparr>
-     sc_period     = scPeriod sc,
-     sc_budget     = if scRefillMax sc > 0
-                     then refills_sum (refills_map (scRefillHead sc) (scRefillCount sc)
-                                                   (scRefillMax sc) (scRefills sc))
-                     else 0,
-     sc_consumed   = scConsumed sc,
-     sc_tcb        = scTCB sc,
-     sc_ntfn       = scNtfn sc,
-     sc_refills    = refills_map (scRefillHead sc) (scRefillCount sc) (scRefillMax sc) (scRefills sc),
-     sc_refill_max = scRefillMax sc,
-     sc_badge      = scBadge sc,
-     sc_yield_from = scYieldFrom sc,
-     sc_replies    = heap_walk replyPrevs (scReply sc) [],
-     sc_sporadic   = scSporadic sc
-   \<rparr>"
-
-definition replyMap :: "reply \<Rightarrow>  Structures_A.reply" where
-  "replyMap r = \<lparr> reply_tcb = replyTCB r, reply_sc = replySC r \<rparr>"
+definition
+ "absCNode sz h a \<equiv> CNode sz (%bl.
+  if length bl = sz
+    then Some (CapabilityMap (case (h (a + of_bl bl * 2^cteSizeBits)) of
+                                Some (KOCTE cte) \<Rightarrow> cteCap cte))
+  else None)"
 
 definition
   absHeap :: "(word32 \<rightharpoonup> vmpage_size) \<Rightarrow> (word32 \<rightharpoonup> nat) \<Rightarrow>
@@ -485,15 +450,12 @@ definition
   "absHeap ups cns h \<equiv> \<lambda>x.
      case h x of
        Some (KOEndpoint ep) \<Rightarrow> Some (Endpoint (EndpointMap ep))
-     | Some (KONotification ntfn) \<Rightarrow> Some (Notification (NtfnMap ntfn))
+     | Some (KONotification ntfn) \<Rightarrow> Some (Notification (AEndpointMap ntfn))
      | Some KOKernelData \<Rightarrow> undefined \<comment> \<open>forbidden by pspace_relation\<close>
      | Some KOUserData \<Rightarrow> map_option (ArchObj \<circ> DataPage False) (ups x)
      | Some KOUserDataDevice \<Rightarrow> map_option (ArchObj \<circ> DataPage True) (ups x)
      | Some (KOTCB tcb) \<Rightarrow> Some (TCB (TcbMap tcb))
      | Some (KOCTE cte) \<Rightarrow> map_option (%sz. absCNode sz h x) (cns x)
-     | Some (KOReply reply) \<Rightarrow> Some (Structures_A.Reply (replyMap reply))
-     | Some (KOSchedContext sc) \<Rightarrow> Some (Structures_A.SchedContext
-                                           (scMap (h |> reply_of' |> replyPrev) sc) (scSize sc))
      | Some (KOArch ako) \<Rightarrow> map_option ArchObj (absHeapArch h x ako)
      | None \<Rightarrow> None"
 
@@ -514,6 +476,16 @@ lemma unaligned_page_offsets_helper:
   apply clarsimp
   apply (case_tac vmpage_size, simp_all add: pageBits_def)
     apply (frule_tac i=n and k="0x1000" in word_mult_less_mono1, simp+)+
+  done
+
+(* FIXME: move *)
+lemma unaligned_helper:
+  "\<lbrakk>is_aligned x n; y\<noteq>0; y < 2 ^ n\<rbrakk> \<Longrightarrow> \<not> is_aligned (x + y) n"
+  apply (simp (no_asm_simp) add: is_aligned_mask)
+  apply (simp add: mask_add_aligned)
+  apply (cut_tac mask_eq_iff_w2p[of n y], simp_all add: word_size)
+  apply (rule ccontr)
+  apply (simp add: not_less power_overflow word_bits_conv)
   done
 
 lemma pspace_aligned_distinct_None:
@@ -596,30 +568,15 @@ lemma pspace_aligned_distinct_None':
    apply assumption+
   done
 
-context
-begin
-
-private method ako =
-  find_goal \<open>match premises in "kheap s p = Some (ArchObj ako)" for s p ako \<Rightarrow> succeed\<close>,
-  (rename_tac ako, case_tac ako;
-   clarsimp simp: other_obj_relation_def pte_relation_def pde_relation_def split: if_split_asm)
-
-private method ko =
-  case_tac ko; clarsimp simp: other_obj_relation_def cte_relation_def split: if_split_asm
-
-
 lemma absHeap_correct:
   assumes pspace_aligned:  "pspace_aligned s"
   assumes pspace_distinct: "pspace_distinct s"
   assumes valid_objs:      "valid_objs s"
-  assumes valid_refills:   "active_scs_valid s"
   assumes pspace_relation: "pspace_relation (kheap s) (ksPSpace s')"
   assumes ghost_relation:  "ghost_relation (kheap s) (gsUserPages s') (gsCNodes s')"
-  assumes replies:         "sc_replies_relation s s'"
 shows
   "absHeap (gsUserPages s') (gsCNodes s') (ksPSpace s') = kheap s"
 proof -
-  note relatedE = pspace_dom_relatedE[OF _ pspace_relation]
   from ghost_relation
   have gsUserPages:
     "\<And>a sz. (\<exists>dev. kheap s a = Some (ArchObj (DataPage dev sz))) \<longleftrightarrow>
@@ -630,274 +587,377 @@ proof -
     by (fastforce simp add: ghost_relation_def)+
 
   show "?thesis"
-    supply image_cong_simp [cong del]
+  supply  image_cong_simp [cong del]
     apply (rule ext)
     apply (simp add: absHeap_def split: option.splits)
     apply (rule conjI)
      using pspace_relation
-     apply (clarsimp simp: pspace_relation_def pspace_dom_def UNION_eq dom_def Collect_eq)
+     apply (clarsimp simp add: pspace_relation_def pspace_dom_def UNION_eq
+                               dom_def Collect_eq)
      apply (erule_tac x=x in allE)
      apply clarsimp
      apply (case_tac "kheap s x", simp)
-     apply (rename_tac ko)
      apply (erule_tac x=x in allE, clarsimp)
      apply (erule_tac x=x in allE, simp add: Ball_def)
      apply (erule_tac x=x in allE, clarsimp)
 
-     apply (case_tac ko; simp add: other_obj_relation_def split: if_split_asm kernel_object.splits)
+     apply (case_tac a)
+         apply (simp_all add: other_obj_relation_def
+                       split: if_split_asm Structures_H.kernel_object.splits)
       apply (rename_tac sz cs)
-      apply (clarsimp simp: image_def cte_map_def well_formed_cnode_n_def Collect_eq dom_def)
+      apply (clarsimp simp add: image_def cte_map_def
+                 well_formed_cnode_n_def Collect_eq dom_def)
       apply (erule_tac x="replicate sz False" in allE)+
       apply simp
      apply (rename_tac arch_kernel_obj)
-     apply (case_tac arch_kernel_obj; simp add: image_def)
+     apply (case_tac arch_kernel_obj, simp_all add: image_def)
        apply (erule_tac x=0 in allE, simp)
       apply (erule_tac x=0 in allE, simp)
      apply clarsimp
      apply (erule_tac x=0 in allE, simp add: pageBits_def)
      apply (rename_tac vmpage_size)
-     apply (case_tac vmpage_size; simp)
+     apply (case_tac vmpage_size, simp_all)
 
-    apply (clarsimp split: kernel_object.splits)
+    apply clarsimp
     apply (intro conjI impI allI)
-             apply (erule relatedE, ko, ako)
-             apply (clarsimp simp: ep_relation_def EndpointMap_def
-                             split: Structures_A.endpoint.splits)
-            apply (erule relatedE, ko, ako)
-            apply (clarsimp simp: ntfn_relation_def NtfnMap_def
-                            split: Structures_A.ntfn.splits)
-           apply (erule relatedE, ko, ako)
-          apply (erule relatedE, ko, ako)
-          apply (rename_tac vmpage_size n)
-          apply (cut_tac a=y and sz=vmpage_size in gsUserPages, clarsimp split: if_split_asm)
-          apply (case_tac "n=0", simp)
-          apply (case_tac "kheap s (y + n * 2 ^ pageBits)")
-           apply (rule ccontr)
-           apply (clarsimp dest!: gsUserPages[symmetric, THEN iffD1] )
-          using pspace_aligned
-          apply (simp add: pspace_aligned_def dom_def)
-          apply (erule_tac x=y in allE)
-          apply (case_tac "n=0",(simp split: if_split_asm)+)
-          apply (frule (2) unaligned_page_offsets_helper)
-          apply (frule_tac y="n*2^pageBits" in pspace_aligned_distinct_None'
-                                            [OF pspace_aligned pspace_distinct])
-           apply simp
-           apply (rule conjI, clarsimp simp add: word_gt_0)
-           apply (simp add: is_aligned_mask)
-           apply (clarsimp simp add: pageBits_def mask_def)
-           apply (case_tac vmpage_size; frule_tac i=n and k="0x1000" in word_mult_less_mono1; simp)
-          apply simp
+           apply (erule pspace_dom_relatedE[OF _ pspace_relation])
+           apply clarsimp
+           apply (case_tac ko, simp_all add: tcb_relation_cut_def other_obj_relation_def)
+             apply (clarsimp simp add: cte_relation_def split: if_split_asm)
+            apply (clarsimp simp add: ep_relation_def EndpointMap_def
+                     split: Structures_A.endpoint.splits)
+           apply (clarsimp simp add: EndpointMap_def
+                    split: Structures_A.endpoint.splits)
+           apply (rename_tac arch_kernel_obj)
+           apply (case_tac arch_kernel_obj,
+                  simp_all add: other_obj_relation_def)
+             apply (clarsimp simp add: pte_relation_def)
+            apply (clarsimp simp add: pde_relation_def)
+           apply (clarsimp split: if_split_asm)+
 
-         apply (erule relatedE, ko, ako)
-         apply (rename_tac vmpage_size n)
-         apply (cut_tac a=y and sz=vmpage_size in gsUserPages, clarsimp split: if_split_asm)
-         apply (case_tac "n=0", simp)
-         apply (case_tac "kheap s (y + n * 2 ^ pageBits)")
-          apply (rule ccontr)
-          apply (clarsimp dest!: gsUserPages[symmetric, THEN iffD1])
-         using pspace_aligned
-         apply (simp add: pspace_aligned_def dom_def)
-         apply (erule_tac x=y in allE)
-         apply (case_tac "n=0"; simp)
-         apply (frule (2) unaligned_page_offsets_helper)
-         apply (frule_tac y="n*2^pageBits" in pspace_aligned_distinct_None'
-                                           [OF pspace_aligned pspace_distinct])
-          apply simp
-          apply (rule conjI, clarsimp simp add: word_gt_0)
-          apply (simp add: is_aligned_mask)
-          apply (clarsimp simp add: pageBits_def mask_def)
-          apply (case_tac vmpage_size; frule_tac i=n and k="0x1000" in word_mult_less_mono1; simp)
-         apply simp
+          apply (erule pspace_dom_relatedE[OF _ pspace_relation])
+          apply (case_tac ko, simp_all add: tcb_relation_cut_def other_obj_relation_def)
+            apply (clarsimp simp add: cte_relation_def split: if_split_asm)
+           apply (clarsimp simp add: ntfn_relation_def AEndpointMap_def
+                    split: Structures_A.ntfn.splits)
+          apply (clarsimp simp add: AEndpointMap_def
+                   split: Structures_A.ntfn.splits)
+          apply (rename_tac arch_kernel_obj)
+          apply (case_tac arch_kernel_obj, simp_all add: other_obj_relation_def)
+            apply (clarsimp simp add: pte_relation_def)
+           apply (clarsimp simp add: pde_relation_def)
+          apply (clarsimp split: if_split_asm)+
 
-        apply (erule relatedE, ko, ako)
-        apply (clarsimp simp: TcbMap_def tcb_relation_def valid_obj_def)
-        apply (rename_tac tcb y tcb')
-        apply (case_tac tcb, case_tac tcb')
-        apply (simp add: thread_state_relation_imp_ThStateMap)
-        apply (subgoal_tac "map_option FaultMap (tcbFault tcb) = tcb_fault")
-         prefer 2
-         apply (simp add: fault_rel_optionation_def)
-         using valid_objs[simplified valid_objs_def dom_def fun_app_def, simplified]
-         apply (erule_tac x=y in allE)
-         apply (clarsimp simp: valid_obj_def valid_tcb_def split: option.splits)
-        using valid_objs[simplified valid_objs_def Ball_def dom_def fun_app_def]
+         apply (erule pspace_dom_relatedE[OF _ pspace_relation])
+         apply (case_tac ko, simp_all add: tcb_relation_cut_def other_obj_relation_def)
+           apply (clarsimp simp add: cte_relation_def split: if_split_asm)
+         apply (rename_tac arch_kernel_obj)
+         apply (case_tac arch_kernel_obj, simp_all add: other_obj_relation_def)
+           apply (clarsimp simp add: pte_relation_def)
+          apply (clarsimp simp add: pde_relation_def)
+         apply (clarsimp split: if_split_asm)+
+
+        apply (erule pspace_dom_relatedE[OF _ pspace_relation])
+        apply (case_tac ko, simp_all add: tcb_relation_cut_def other_obj_relation_def)
+          apply (clarsimp simp add: cte_relation_def split: if_split_asm)
+        apply (rename_tac arch_kernel_obj)
+        apply (case_tac arch_kernel_obj, simp_all add: other_obj_relation_def)
+          apply (clarsimp simp add: pte_relation_def)
+         apply (clarsimp simp add: pde_relation_def)
+        apply (rename_tac vmpage_size)
+        apply (cut_tac a=y and sz=vmpage_size in gsUserPages, clarsimp split: if_split_asm)
+        apply (case_tac "n=0", simp)
+        apply (case_tac "kheap s (y + n * 2 ^ pageBits)")
+         apply (rule ccontr)
+         apply (clarsimp dest!: gsUserPages[symmetric, THEN iffD1] )
+        using pspace_aligned
+        apply (simp add: pspace_aligned_def dom_def)
         apply (erule_tac x=y in allE)
-        apply (clarsimp simp: cap_relation_imp_CapabilityMap valid_obj_def valid_tcb_def
-                              ran_tcb_cap_cases valid_cap_def2 arch_tcb_relation_imp_ArchTcnMap)
-
-       apply (erule relatedE, ko, ako)
-       apply (simp add: absCNode_def cte_map_def)
-       apply (cut_tac a=y and n=sz in gsCNodes, clarsimp)
-       using pspace_aligned[simplified pspace_aligned_def]
-       apply (drule_tac x=y in bspec, clarsimp)
-       apply clarsimp
-       apply (case_tac "(of_bl ya::word32) * 2^cte_level_bits = 0", simp)
-        apply (rule ext)
-        apply simp
-        apply (rule conjI)
-         prefer 2
-         using valid_objs[simplified valid_objs_def Ball_def dom_def fun_app_def]
-         apply (erule_tac x=y in allE)
-         apply (clarsimp simp: valid_obj_def valid_cs_def valid_cs_size_def
-                               well_formed_cnode_n_def dom_def Collect_eq)
-         apply (frule_tac x=ya in spec, simp)
-         apply (erule_tac x=bl in allE)
-         apply clarsimp
-        apply (frule pspace_relation_absD[OF _ pspace_relation])
-        apply (simp add: cte_map_def)
-        apply (drule_tac x="y + of_bl bl * 2^cte_level_bits" in spec)
-        apply clarsimp
-        apply (erule_tac x="cte_relation bl" in allE)
-        apply (erule impE)
-         apply (fastforce simp add: well_formed_cnode_n_def)
-        apply clarsimp
-        apply (clarsimp simp add: cte_relation_def)
-        apply (rule cap_relation_imp_CapabilityMap)
-         using valid_objs[simplified valid_objs_def Ball_def dom_def fun_app_def]
-         apply (erule_tac x=y in allE)
-         apply (clarsimp simp: valid_obj_def valid_cs_def valid_cap_def2 ran_def)
-         apply (fastforce simp: cte_level_bits_def cteSizeBits_def)+
-       apply (subgoal_tac "kheap s (y + of_bl ya * 2^cte_level_bits) = None")
+        apply (case_tac "n=0",(simp split: if_split_asm)+)
+        apply (frule (2) unaligned_page_offsets_helper)
+        apply (frule_tac y="n*2^pageBits" in pspace_aligned_distinct_None'
+                                          [OF pspace_aligned pspace_distinct])
+         apply simp
+         apply (rule conjI, clarsimp simp add: word_gt_0)
+         apply (simp add: is_aligned_mask)
+         apply (clarsimp simp add: pageBits_def mask_def)
+        apply (case_tac vmpage_size; simp)
+          apply ((frule_tac i=n and k="0x1000" in word_mult_less_mono1, simp+)+)[4]
+        apply (erule pspace_dom_relatedE[OF _ pspace_relation])
+        apply (case_tac ko, simp_all add: tcb_relation_cut_def other_obj_relation_def)
+          apply (clarsimp simp add: cte_relation_def split: if_split_asm)
+        apply (rename_tac arch_kernel_obj)
+        apply (case_tac arch_kernel_obj, simp_all add: other_obj_relation_def)
+          apply (clarsimp simp add: pte_relation_def)
+         apply (clarsimp simp add: pde_relation_def)
+        apply (rename_tac vmpage_size)
+        apply (cut_tac a=y and sz=vmpage_size in gsUserPages, clarsimp split: if_split_asm)
+        apply (case_tac "n=0", simp)
+        apply (case_tac "kheap s (y + n * 2 ^ pageBits)")
+         apply (rule ccontr)
+         apply (clarsimp dest!: gsUserPages[symmetric, THEN iffD1])
+        using pspace_aligned
+        apply (simp add: pspace_aligned_def dom_def)
+        apply (erule_tac x=y in allE)
+        apply (case_tac "n=0",simp+)
+        apply (frule (2) unaligned_page_offsets_helper)
+        apply (frule_tac y="n*2^pageBits" in pspace_aligned_distinct_None'
+                                          [OF pspace_aligned pspace_distinct])
+         apply simp
+         apply (rule conjI, clarsimp simp add: word_gt_0)
+         apply (simp add: is_aligned_mask)
+         apply (clarsimp simp add: pageBits_def mask_def)
+        apply (case_tac vmpage_size; simp)
+          apply ((frule_tac i=n and k="0x1000" in word_mult_less_mono1, simp+)+)[4]
+       apply (erule pspace_dom_relatedE[OF _ pspace_relation])
+       apply (case_tac ko, simp_all add: tcb_relation_cut_def other_obj_relation_def)
+         apply (clarsimp simp add: cte_relation_def split: if_split_asm)
         prefer 2
-        using valid_objs[simplified valid_objs_def Ball_def dom_def fun_app_def]
+        apply (rename_tac arch_kernel_obj)
+        apply (case_tac arch_kernel_obj, simp_all add: other_obj_relation_def)
+          apply (clarsimp simp add: pte_relation_def)
+         apply (clarsimp simp add: pde_relation_def)
+        apply (clarsimp split: if_split_asm)
+       apply (clarsimp simp add: TcbMap_def tcb_relation_def valid_obj_def)
+       apply (rename_tac tcb y tcb')
+       apply (case_tac tcb)
+       apply (case_tac tcb')
+       apply (simp add: thread_state_relation_imp_ThStateMap)
+       apply (subgoal_tac "map_option FaultMap (tcbFault tcb) = tcb_fault")
+        prefer 2
+        apply (simp add: fault_rel_optionation_def)
+        using valid_objs[simplified valid_objs_def dom_def fun_app_def,
+                         simplified]
         apply (erule_tac x=y in allE)
-        apply (clarsimp simp add: valid_obj_def valid_cs_def valid_cs_size_def)
-        apply (rule pspace_aligned_distinct_None'[OF
-                    pspace_aligned pspace_distinct], assumption)
-        apply (clarsimp simp: word_neq_0_conv power_add cte_index_repair)
-        apply (simp add: well_formed_cnode_n_def dom_def Collect_eq)
-        apply (erule_tac x=ya in allE)+
-        apply (rule word_mult_less_mono1)
-          apply (subgoal_tac "sz = length ya")
-           apply simp
-           apply (rule of_bl_length, (simp add: word_bits_def)+)[1]
-          apply fastforce
-         apply (simp add: cte_level_bits_def)
-        apply (simp add: word_bits_conv cte_level_bits_def)
-        apply (drule_tac a="2::nat" in power_strict_increasing, simp+)
-       apply (rule ccontr, clarsimp)
-       apply (cut_tac a="y + of_bl ya * 2^cte_level_bits" and n=yc in gsCNodes)
-       apply clarsimp
-
-      (* mapping architecture-specific objects *)
-      apply clarsimp
-      apply (rename_tac x arch_kernel_object)
-      apply (erule relatedE, ko)
-      apply (rename_tac y P arch_kernel_obj)
-      apply (case_tac arch_kernel_object; simp add: absHeapArch_def split: asidpool.splits)
-
-        apply clarsimp
-        apply (case_tac arch_kernel_obj)
-           apply (simp add: other_obj_relation_def asid_pool_relation_def inv_def o_def)
-          apply (clarsimp simp add:  pte_relation_def)
-         apply (clarsimp simp add:  pde_relation_def)
-        apply (clarsimp split: if_split_asm)+
-
-       apply (case_tac arch_kernel_obj)
-          apply (simp add: other_obj_relation_def asid_pool_relation_def inv_def o_def)
-         using pspace_aligned[simplified pspace_aligned_def Ball_def dom_def]
-         apply (erule_tac x=y in allE)
-         apply (clarsimp simp add: pte_relation_def absPageTable_def pt_bits_def pageBits_def)
-         apply (rule conjI)
-          prefer 2
-          apply clarsimp
-          apply (rule sym)
-          apply (rule pspace_aligned_distinct_None'[OF pspace_aligned pspace_distinct]; simp)
-          apply (cut_tac x=ya and n="2^10" in
-                 ucast_less_shiftl_helper[where 'a=32,simplified word_bits_conv]; simp)
-          apply (clarsimp simp add: word_gt_0)
-         apply clarsimp
-         apply (subgoal_tac "ucast ya << 2 = 0")
-          prefer 2
-          apply (rule ccontr)
-          apply (frule_tac x=y in unaligned_helper, assumption)
-           apply (rule ucast_less_shiftl_helper; simp)
-          apply simp
-         apply simp
-         apply (rule ext)
-         apply (frule pspace_relation_absD[OF _ pspace_relation])
-         apply simp
-         apply (erule_tac x=offs in allE)
+        apply (clarsimp simp: valid_obj_def valid_tcb_def
+                        split: option.splits)
+       using valid_objs[simplified valid_objs_def Ball_def dom_def fun_app_def]
+       apply (erule_tac x=y in allE)
+       apply (clarsimp simp add: cap_relation_imp_CapabilityMap valid_obj_def
+                                 valid_tcb_def ran_tcb_cap_cases valid_cap_def2
+                                 arch_tcb_relation_imp_ArchTcnMap)
+      apply (simp add: absCNode_def cte_map_def)
+      apply (erule pspace_dom_relatedE[OF _ pspace_relation])
+      apply (case_tac ko, simp_all add: tcb_relation_cut_def other_obj_relation_def
+                                 split: if_split_asm)
+       prefer 2
+       apply (rename_tac arch_kernel_obj)
+       apply (case_tac arch_kernel_obj, simp_all add: other_obj_relation_def)
          apply (clarsimp simp add: pte_relation_def)
-         using valid_objs[simplified valid_objs_def fun_app_def dom_def, simplified]
-         apply (erule_tac x=y in allE)
-         apply (clarsimp simp add: valid_obj_def wellformed_pte_def)
-         apply (erule_tac x=offs in allE)
-         apply (rename_tac pte')
-         apply (case_tac pte', simp_all add: pte_relation_aligned_def)[1]
-          apply (clarsimp split: ARM_A.pte.splits)
-          apply (rule set_eqI, clarsimp)
-          apply (case_tac x; simp)
-         apply (clarsimp split: ARM_A.pte.splits)
-         apply (rule set_eqI, clarsimp)
-         apply (case_tac x; simp)
         apply (clarsimp simp add: pde_relation_def)
        apply (clarsimp split: if_split_asm)
-
-      apply (case_tac arch_kernel_obj)
-         apply (simp add: other_obj_relation_def asid_pool_relation_def inv_def o_def)
-        apply (clarsimp simp add:  pte_relation_def)
-       using pspace_aligned
-       apply (simp add: pspace_aligned_def dom_def)
+      apply (simp add: cte_map_def)
+      apply (clarsimp simp add: cte_relation_def)
+      apply (cut_tac a=y and n=sz in gsCNodes, clarsimp)
+      using pspace_aligned[simplified pspace_aligned_def]
+      apply (drule_tac x=y in bspec, clarsimp)
+      apply clarsimp
+      apply (case_tac "(of_bl ya::word32) * 2^cte_level_bits = 0", simp)
+       apply (rule ext)
+       apply simp
+       apply (rule conjI)
+        prefer 2
+        using valid_objs[simplified valid_objs_def Ball_def dom_def
+                                    fun_app_def]
+        apply (erule_tac x=y in allE)
+        apply (clarsimp simp add: valid_obj_def valid_cs_def valid_cs_size_def
+                    well_formed_cnode_n_def dom_def Collect_eq)
+        apply (frule_tac x=ya in spec, simp)
+        apply (erule_tac x=bl in allE)
+        apply clarsimp+
+       apply (frule pspace_relation_absD[OF _ pspace_relation])
+       apply (simp add: cte_map_def)
+       apply (drule_tac x="y + of_bl bl * 2^cte_level_bits" in spec)
+       apply clarsimp
+       apply (erule_tac x="cte_relation bl" in allE)
+       apply (erule impE)
+        apply (fastforce simp add: well_formed_cnode_n_def)
+       apply clarsimp
+       apply (clarsimp simp add: cte_relation_def)
+       apply (rule cap_relation_imp_CapabilityMap)
+        using valid_objs[simplified valid_objs_def Ball_def dom_def
+                                    fun_app_def]
+        apply (erule_tac x=y in allE)
+        apply (clarsimp simp: valid_obj_def valid_cs_def valid_cap_def2 ran_def)
+        apply (fastforce simp: cte_level_bits_def cteSizeBits_def)+
+      apply (subgoal_tac "kheap s (y + of_bl ya * 2^cte_level_bits) = None")
+       prefer 2
+       using valid_objs[simplified valid_objs_def Ball_def dom_def fun_app_def]
        apply (erule_tac x=y in allE)
-       apply (clarsimp simp add: pde_relation_def absPageDirectory_def pd_bits_def pageBits_def)
+       apply (clarsimp simp add: valid_obj_def valid_cs_def valid_cs_size_def)
+       apply (rule pspace_aligned_distinct_None'[OF
+                   pspace_aligned pspace_distinct], assumption)
+       apply (clarsimp simp: word_neq_0_conv power_add cte_index_repair)
+       apply (simp add: well_formed_cnode_n_def dom_def Collect_eq)
+       apply (erule_tac x=ya in allE)+
+       apply (rule word_mult_less_mono1)
+         apply (subgoal_tac "sz = length ya")
+          apply simp
+          apply (rule of_bl_length, (simp add: word_bits_def)+)[1]
+         apply fastforce
+        apply (simp add: cte_level_bits_def)
+       apply (simp add: word_bits_conv cte_level_bits_def)
+       apply (drule_tac a="2::nat" in power_strict_increasing, simp+)
+      apply (rule ccontr, clarsimp)
+      apply (cut_tac a="y + of_bl ya * 2^cte_level_bits" and n=yc in gsCNodes)
+      apply clarsimp
+
+    (* mapping architecture-specific objects *)
+    apply clarsimp
+    apply (erule pspace_dom_relatedE[OF _ pspace_relation])
+    apply (case_tac ko, simp_all add: tcb_relation_cut_def other_obj_relation_def)
+     apply (clarsimp simp add: cte_relation_def split: if_split_asm)
+    apply (rename_tac arch_kernel_object y ko P arch_kernel_obj)
+    apply (case_tac arch_kernel_object, simp_all add: absHeapArch_def
+                                            split: asidpool.splits)
+
+      apply clarsimp
+      apply (case_tac arch_kernel_obj)
+         apply (simp add: other_obj_relation_def asid_pool_relation_def
+                          inv_def o_def)
+        apply (clarsimp simp add:  pte_relation_def)
+       apply (clarsimp simp add:  pde_relation_def)
+      apply (clarsimp split: if_split_asm)+
+
+     apply (case_tac arch_kernel_obj)
+        apply (simp add: other_obj_relation_def asid_pool_relation_def inv_def
+                         o_def)
+       using pspace_aligned[simplified pspace_aligned_def Ball_def dom_def]
+       apply (erule_tac x=y in allE)
+       apply (clarsimp simp add: pte_relation_def absPageTable_def
+                                 pt_bits_def pageBits_def)
        apply (rule conjI)
         prefer 2
         apply clarsimp
         apply (rule sym)
-        apply (rule pspace_aligned_distinct_None' [OF pspace_aligned pspace_distinct]; simp)
-        apply (cut_tac x=ya and n="2^14" in
-               ucast_less_shiftl_helper[where 'a=32, simplified word_bits_conv]; simp)
+        apply (rule pspace_aligned_distinct_None'
+                    [OF pspace_aligned pspace_distinct], simp+)
+        apply (cut_tac x=ya and n="2^10" in
+               ucast_less_shiftl_helper[where 'a=32,simplified word_bits_conv], simp+)
         apply (clarsimp simp add: word_gt_0)
        apply clarsimp
        apply (subgoal_tac "ucast ya << 2 = 0")
         prefer 2
         apply (rule ccontr)
         apply (frule_tac x=y in unaligned_helper, assumption)
-         apply (rule ucast_less_shiftl_helper; simp)
-        apply simp
-       apply simp
+         apply (rule ucast_less_shiftl_helper, simp_all)
        apply (rule ext)
        apply (frule pspace_relation_absD[OF _ pspace_relation])
        apply simp
        apply (erule_tac x=offs in allE)
-       apply (clarsimp simp add: pde_relation_def)
-
-       using valid_objs[simplified valid_objs_def fun_app_def dom_def,simplified]
+       apply (clarsimp simp add: pte_relation_def)
+       using valid_objs[simplified valid_objs_def fun_app_def dom_def,
+                        simplified]
        apply (erule_tac x=y in allE)
-       apply (clarsimp simp add: valid_obj_def wellformed_pde_def)
+       apply (clarsimp simp add: valid_obj_def wellformed_pte_def)
        apply (erule_tac x=offs in allE)
-       apply (rename_tac pde')
-       apply (case_tac pde'; simp add: pde_relation_aligned_def)
-          apply (clarsimp split: ARM_A.pde.splits)+
-         apply (fastforce simp add: subset_eq)
-        apply (clarsimp split: ARM_A.pde.splits)
+       apply (rename_tac pte')
+       apply (case_tac pte', simp_all add: pte_relation_aligned_def)[1]
+        apply (clarsimp split: ARM_A.pte.splits)
         apply (rule set_eqI, clarsimp)
-        apply (case_tac x; simp)
-       apply (clarsimp split: ARM_A.pde.splits)
+        apply (case_tac x, simp_all)[1]
+       apply (clarsimp split: ARM_A.pte.splits)
        apply (rule set_eqI, clarsimp)
-       apply (case_tac x; simp)
-      apply (clarsimp simp add: pde_relation_def split: if_split_asm)
+       apply (case_tac x, simp_all)[1]
+      apply (clarsimp simp add: pde_relation_def)
+     apply (clarsimp split: if_split_asm)+
 
-     apply (rule relatedE, assumption, ko, ako)
-     apply (clarsimp simp: sc_relation_def scMap_def sc_replies_prevs_walk[OF replies])
-     apply (intro conjI impI)
-       apply (prop_tac "valid_refills y s")
-        apply (fastforce intro: valid_refills active_scs_validE
-                          simp: vs_all_heap_simps active_sc_def)
-       apply (clarsimp simp: valid_refills_def vs_all_heap_simps rr_valid_refills_def
-                      split: if_splits)
-      apply (insert valid_refills)
-      apply (force simp: active_scs_valid_def valid_refills_def vs_all_heap_simps
-                         active_sc_def
-                  split: if_splits)
+    apply (case_tac arch_kernel_obj)
+       apply (simp add: other_obj_relation_def asid_pool_relation_def inv_def
+                        o_def)
+      apply (clarsimp simp add:  pte_relation_def)
+     using pspace_aligned
+     apply (simp add: pspace_aligned_def dom_def)
+     apply (erule_tac x=y in allE)
+     apply (clarsimp simp add: pde_relation_def absPageDirectory_def
+                               pd_bits_def pageBits_def)
+     apply (rule conjI)
+      prefer 2
+      apply clarsimp
+      apply (rule sym)
+      apply (rule pspace_aligned_distinct_None'
+                  [OF pspace_aligned pspace_distinct], simp+)
+      apply (cut_tac x=ya and n="2^14" in
+             ucast_less_shiftl_helper[where 'a=32, simplified word_bits_conv], simp+)
+      apply (clarsimp simp add: word_gt_0)
+     apply clarsimp
+     apply (subgoal_tac "ucast ya << 2 = 0")
+      prefer 2
+      apply (rule ccontr)
+      apply (frule_tac x=y in unaligned_helper, assumption)
+       apply (rule ucast_less_shiftl_helper, simp_all)
+     apply (rule ext)
+     apply (frule pspace_relation_absD[OF _ pspace_relation])
+     apply simp
+     apply (erule_tac x=offs in allE)
+     apply (clarsimp simp add: pde_relation_def)
 
-    apply (erule relatedE, ko, ako)
-    apply (clarsimp simp: reply_relation_def replyMap_def)
+     using valid_objs[simplified valid_objs_def fun_app_def dom_def,simplified]
+     apply (erule_tac x=y in allE)
+     apply (clarsimp simp add: valid_obj_def wellformed_pde_def)
+     apply (erule_tac x=offs in allE)
+     apply (rename_tac pde')
+     apply (case_tac pde', simp_all add: pde_relation_aligned_def)[1]
+        apply (clarsimp split: ARM_A.pde.splits)+
+       apply (fastforce simp add: subset_eq)
+      apply (clarsimp split: ARM_A.pde.splits)
+      apply (rule set_eqI, clarsimp)
+      apply (case_tac x, simp_all)[1]
+     apply (clarsimp split: ARM_A.pde.splits)
+     apply (rule set_eqI, clarsimp)
+     apply (case_tac x, simp_all)[1]
+    apply (clarsimp simp add: pde_relation_def split: if_split_asm)
     done
 qed
 
-end
+definition
+  "EtcbMap tcb \<equiv>
+     \<lparr>tcb_priority = tcbPriority tcb,
+      time_slice = tcbTimeSlice tcb,
+      tcb_domain = tcbDomain tcb\<rparr>"
+
+definition
+  absEkheap :: "(word32 \<rightharpoonup> Structures_H.kernel_object) \<Rightarrow> obj_ref \<Rightarrow> etcb option"
+  where
+  "absEkheap h \<equiv> \<lambda>x.
+     case h x of
+       Some (KOTCB tcb) \<Rightarrow> Some (EtcbMap tcb)
+     | _ \<Rightarrow> None"
+
+lemma absEkheap_correct:
+assumes pspace_relation: "pspace_relation (kheap s) (ksPSpace s')"
+assumes ekheap_relation: "ekheap_relation (ekheap s) (ksPSpace s')"
+assumes vetcbs: "valid_etcbs s"
+shows
+  "absEkheap (ksPSpace s') = ekheap s"
+  apply (rule ext)
+  apply (clarsimp simp: absEkheap_def split: option.splits Structures_H.kernel_object.splits)
+  apply (subgoal_tac "\<forall>x. (\<exists>tcb. kheap s x = Some (TCB tcb)) =
+                          (\<exists>tcb'. ksPSpace s' x = Some (KOTCB tcb'))")
+   using vetcbs ekheap_relation
+   apply (clarsimp simp: valid_etcbs_def is_etcb_at_def dom_def ekheap_relation_def st_tcb_at_def obj_at_def)
+   apply (erule_tac x=x in allE)+
+   apply (rule conjI, force)
+   apply clarsimp
+   apply (rule conjI, clarsimp simp: EtcbMap_def etcb_relation_def)+
+   apply clarsimp
+  using pspace_relation
+  apply (clarsimp simp add: pspace_relation_def pspace_dom_def UNION_eq
+                              dom_def Collect_eq)
+  apply (rule iffI)
+   apply (erule_tac x=x in allE)+
+   apply (case_tac "ksPSpace s' x", clarsimp)
+    apply (erule_tac x=x in allE, clarsimp)
+   apply clarsimp
+   apply (case_tac a, simp_all add: tcb_relation_cut_def other_obj_relation_def)
+  apply (insert pspace_relation)
+  apply (clarsimp simp: obj_at'_def projectKOs)
+  apply (erule(1) pspace_dom_relatedE)
+  apply (erule(1) obj_relation_cutsE)
+  apply (clarsimp simp: other_obj_relation_def
+                 split: Structures_A.kernel_object.split_asm  if_split_asm
+                        ARM_A.arch_kernel_obj.split_asm)+
+  done
 
 text \<open>The following function can be used to reverse cte_map.\<close>
 definition
@@ -968,11 +1028,12 @@ lemma TCB_implies_KOTCB:
 lemma cte_at_CNodeI:
   "\<lbrakk>kheap s a = Some (CNode (length b) cs); well_formed_cnode_n (length b) cs\<rbrakk>
    \<Longrightarrow> cte_at (a,b) s"
-  apply (subgoal_tac "\<exists>y. cs b = Some y")
-   apply clarsimp
-   apply (rule_tac cte=y in cte_wp_at_cteI[of s _ "length b" cs]; simp)
-  apply (simp add: well_formed_cnode_n_def dom_def Collect_eq)
-  done
+apply (subgoal_tac "\<exists>y. cs b = Some y")
+ apply clarsimp
+ apply (rule_tac cte=y in cte_wp_at_cteI[of s _ "length b" cs],
+        simp_all)
+apply (simp add: well_formed_cnode_n_def dom_def Collect_eq)
+done
 
 lemma cteMap_correct:
   assumes rel:              "(s,s') \<in> state_relation"
@@ -1735,6 +1796,13 @@ lemma absSchedulerAction_correct:
 definition
   "absExst s \<equiv>
      \<lparr>work_units_completed_internal = ksWorkUnitsCompleted s,
+      scheduler_action_internal = absSchedulerAction (ksSchedulerAction s),
+      ekheap_internal = absEkheap (ksPSpace s),
+      domain_list_internal = ksDomSchedule s,
+      domain_index_internal = ksDomScheduleIdx s,
+      cur_domain_internal = ksCurDomain s,
+      domain_time_internal = ksDomainTime s,
+      ready_queues_internal = (\<lambda>d p. heap_walk (tcbSchedNexts_of s) (tcbQueueHead (ksReadyQueues s (d, p))) []),
       cdt_list_internal = absCDTList (cteMap (gsCNodes s)) (ctes_of s)\<rparr>"
 
 lemma absExst_correct:
@@ -1742,11 +1810,15 @@ lemma absExst_correct:
   assumes rel: "(s, s') \<in> state_relation"
   shows "absExst s' = exst s"
   apply (rule det_ext.equality)
-      using rel invs invs'
-      apply (simp_all add: absExst_def absSchedulerAction_correct
-                           absCDTList_correct[THEN fun_cong] state_relation_def invs_def valid_state_def
-                           ready_queues_relation_def invs'_def
-                           valid_pspace_def valid_sched_def valid_pspace'_def curry_def fun_eq_iff)
+           using rel invs invs'
+           apply (simp_all add: absExst_def absSchedulerAction_correct absEkheap_correct
+                                absCDTList_correct[THEN fun_cong] state_relation_def invs_def
+                                valid_state_def ready_queues_relation_def ready_queue_relation_def
+                                invs'_def valid_state'_def
+                                valid_pspace_def valid_sched_def valid_pspace'_def curry_def
+                                fun_eq_iff)
+   apply (fastforce simp: absEkheap_correct)
+  apply (fastforce simp: list_queue_relation_def Let_def dest: heap_ls_is_walk)
   done
 
 
@@ -1756,17 +1828,6 @@ definition
     cdt = absCDT (cteMap (gsCNodes s)) (ctes_of s),
     is_original_cap = absIsOriginalCap (cteMap (gsCNodes s)) (ksPSpace s),
     cur_thread = ksCurThread s, idle_thread = ksIdleThread s,
-    consumed_time = ksConsumedTime s,
-    cur_time = ksCurTime s,
-    cur_sc = ksCurSc s,
-    reprogram_timer = ksReprogramTimer s,
-    scheduler_action = absSchedulerAction (ksSchedulerAction s),
-    domain_list = ksDomSchedule s,
-    domain_index = ksDomScheduleIdx s,
-    cur_domain = ksCurDomain s,
-    domain_time = ksDomainTime s,
-    ready_queues = curry (ksReadyQueues s),
-    release_queue = ksReleaseQueue s,
     machine_state = observable_memory (ksMachineState s) (user_mem' s),
     interrupt_irq_node = absInterruptIRQNode (ksInterruptState s),
     interrupt_states = absInterruptStates (ksInterruptState s),

--- a/proof/refine/ARM/ArchMove_R.thy
+++ b/proof/refine/ARM/ArchMove_R.thy
@@ -17,4 +17,13 @@ lemmas cte_index_repair_sym = cte_index_repair[symmetric]
 
 lemmas of_nat_inj32 = of_nat_inj[where 'a=32, folded word_bits_def]
 
+context begin
+interpretation Arch .
+
+(* Move to Deterministic_AI*)
+crunch copy_global_mappings
+  for valid_etcbs[wp]: valid_etcbs (wp: mapM_x_wp')
+
+end
+
 end

--- a/proof/refine/ARM/Bits_R.thy
+++ b/proof/refine/ARM/Bits_R.thy
@@ -20,8 +20,7 @@ crunch_ignore (add:
   storeWordVM loadWord setRegister getRegister getRestartPC
   debugPrint setNextPC maskInterrupt clearMemory throw_on_false
   unifyFailure ignoreFailure empty_on_failure emptyOnFailure clearMemoryVM null_cap_on_failure
-  setNextPC getRestartPC assertDerived throw_on_false getObject setObject updateObject loadObject
-  ifM andM orM whenM whileM haskell_assert)
+  setNextPC getRestartPC assertDerived throw_on_false getObject setObject updateObject loadObject)
 
 context Arch begin (*FIXME: arch-split*)
 
@@ -57,9 +56,7 @@ lemma isCap_simps:
   "isNotificationCap v = (\<exists>v0 v1 v2 v3. v = NotificationCap v0 v1 v2 v3)"
   "isEndpointCap v = (\<exists>v0 v1 v2 v3 v4 v5. v = EndpointCap v0 v1 v2 v3 v4 v5)"
   "isUntypedCap v = (\<exists>d v0 v1 f. v = UntypedCap d v0 v1 f)"
-  "isReplyCap v = (\<exists>v0 v1. v = ReplyCap v0 v1)"
-  "isSchedContextCap v = (\<exists>v0 v1. v = SchedContextCap v0 v1)"
-  "isSchedControlCap v = (v = SchedControlCap)"
+  "isReplyCap v = (\<exists>v0 v1 v2. v = ReplyCap v0 v1 v2)"
   "isIRQControlCap v = (v = IRQControlCap)"
   "isIRQHandlerCap v = (\<exists>v0. v = IRQHandlerCap v0)"
   "isNullCap v = (v = NullCap)"
@@ -97,27 +94,6 @@ lemma projectKO_ntfn:
   "(projectKO_opt ko = Some t) = (ko = KONotification t)"
   by (cases ko) (auto simp: projectKO_opts_defs)
 
-lemma projectKO_reply:
-  "(projectKO_opt ko = Some t) = (ko = KOReply t)"
-  by (cases ko) (auto simp: projectKO_opts_defs)
-
-lemma reply_of'_KOReply[simp]:
-  "reply_of' (KOReply reply) = Some reply"
-  apply (clarsimp simp: projectKO_reply)
-  done
-
-lemma projectKO_sc:
-  "(projectKO_opt ko = Some t) = (ko = KOSchedContext t)"
-  by (cases ko) (auto simp: projectKO_opts_defs)
-
-lemma sc_of'_Sched[simp]:
-  "sc_of' (KOSchedContext sc) = Some sc"
-  by (simp add: projectKO_sc)
-
-lemma tcb_of'_TCB[simp]:
-  "tcb_of' (KOTCB tcb) = Some tcb"
-  by (simp add: projectKO_tcb)
-
 lemma projectKO_ASID:
   "(projectKO_opt ko = Some t) = (ko = KOArch (KOASIDPool t))"
   by (cases ko)
@@ -145,9 +121,9 @@ lemma projectKO_user_data_device:
 
 
 lemmas projectKOs =
-  projectKO_ntfn projectKO_ep projectKO_cte projectKO_tcb projectKO_reply projectKO_sc
+  projectKO_ntfn projectKO_ep projectKO_cte projectKO_tcb
   projectKO_ASID projectKO_PTE projectKO_PDE projectKO_user_data projectKO_user_data_device
-  projectKO_eq
+  projectKO_eq projectKO_eq2
 
 lemma capAligned_epI:
   "ep_at' p s \<Longrightarrow> capAligned (EndpointCap p a b c d e)"
@@ -175,24 +151,13 @@ lemma capAligned_tcbI:
                   dest!: ko_wp_at_aligned simp: objBits_simps' projectKOs)
   done
 
-lemma capAligned_replyI:
-  "reply_at' p s \<Longrightarrow> capAligned (ReplyCap p r)"
+lemma capAligned_reply_tcbI:
+  "tcb_at' p s \<Longrightarrow> capAligned (ReplyCap p m r)"
   apply (clarsimp simp: obj_at'_real_def capAligned_def
                         objBits_simps word_bits_def capUntypedPtr_def isCap_simps)
   apply (fastforce dest: ko_wp_at_norm
                   dest!: ko_wp_at_aligned simp: objBits_simps' projectKOs)
   done
-
-lemma capAligned_sched_contextI:
-  "\<lbrakk>sc_at'_n r p s; sc_size_bounds r\<rbrakk>
-      \<Longrightarrow> capAligned (SchedContextCap p r)"
-  by (clarsimp simp: obj_at'_real_def capAligned_def sc_size_bounds_def ko_wp_at'_def isCap_simps
-                     objBits_simps word_bits_def capUntypedPtr_def maxUntypedSizeBits_def)
-
-lemma sc_at'_n_sc_at':
-  "sc_at'_n n p s \<Longrightarrow> sc_at' p s"
-  apply (clarsimp simp: ko_wp_at'_def obj_at'_def projectKOs)
-  by (case_tac ko; clarsimp)
 
 lemma ko_at_valid_objs':
   assumes ko: "ko_at' k p s"
@@ -201,39 +166,6 @@ lemma ko_at_valid_objs':
   shows "valid_obj' (injectKO k) s" using ko vo
   by (clarsimp simp: valid_objs'_def obj_at'_def projectKOs
                      project_inject ranI)
-
-lemmas ko_at_valid_objs'_pre =
-  ko_at_valid_objs'[simplified project_inject, atomized, simplified, rule_format]
-
-lemmas ep_ko_at_valid_objs_valid_ep' =
-  ko_at_valid_objs'_pre[where 'a=endpoint, simplified injectKO_defs valid_obj'_def, simplified]
-
-lemmas ntfn_ko_at_valid_objs_valid_ntfn' =
-  ko_at_valid_objs'_pre[where 'a=notification, simplified injectKO_defs valid_obj'_def,
-                        simplified]
-
-lemmas tcb_ko_at_valid_objs_valid_tcb' =
-  ko_at_valid_objs'_pre[where 'a=tcb, simplified injectKO_defs valid_obj'_def, simplified]
-
-lemmas cte_ko_at_valid_objs_valid_cte' =
-  ko_at_valid_objs'_pre[where 'a=cte, simplified injectKO_defs valid_obj'_def, simplified]
-
-lemmas sc_ko_at_valid_objs_valid_sc' =
-  ko_at_valid_objs'_pre[where 'a=sched_context, simplified injectKO_defs valid_obj'_def,
-                        simplified]
-
-lemmas reply_ko_at_valid_objs_valid_reply' =
-  ko_at_valid_objs'_pre[where 'a=reply, simplified injectKO_defs valid_obj'_def, simplified]
-
-(* FIXME: arch split *)
-lemmas pde_ko_at_valid_objs_valid_pde' =
-  ko_at_valid_objs'_pre[where 'a=pde, simplified injectKO_pde valid_obj'_def, simplified]
-
-lemmas pte_ko_at_valid_objs_valid_pte' =
-  ko_at_valid_objs'_pre[where 'a=pte, simplified injectKO_pde valid_obj'_def, simplified]
-
-lemmas asidpool_ko_at_valid_objs_valid_asid_pool' =
-  ko_at_valid_objs'_pre[where 'a=asidpool, simplified injectKO_pde valid_obj'_def, simplified]
 
 lemma obj_at_valid_objs':
   "\<lbrakk> obj_at' P p s; valid_objs' s \<rbrakk> \<Longrightarrow>
@@ -269,9 +201,6 @@ lemma getIdleThread_corres [corres]:
 
 lemma git_wp [wp]: "\<lbrace>\<lambda>s. P (ksIdleThread s) s\<rbrace> getIdleThread \<lbrace>P\<rbrace>"
   by (unfold getIdleThread_def, wp)
-
-lemma getIdleSc_wp [wp]: "\<lbrace>\<lambda>s. P (ksIdleSC s) s\<rbrace> getIdleSC \<lbrace>P\<rbrace>"
-  by (unfold getIdleSC_def, wp)
 
 lemma gsa_wp [wp]: "\<lbrace>\<lambda>s. P (ksSchedulerAction s) s\<rbrace> getSchedulerAction \<lbrace>P\<rbrace>"
   by (unfold getSchedulerAction_def, wp)

--- a/proof/refine/ARM/CSpace1_R.thy
+++ b/proof/refine/ARM/CSpace1_R.thy
@@ -11,6 +11,7 @@
 theory CSpace1_R
 imports
   CSpace_I
+  "AInvs.ArchDetSchedSchedule_AI"
 begin
 
 context Arch begin global_naming ARM_A (*FIXME: arch-split*)
@@ -136,7 +137,7 @@ lemma obj_size_relation:
   "\<lbrakk> cap_relation c c'; capClass c' = PhysicalClass \<rbrakk> \<Longrightarrow>
   obj_size c = capUntypedSize c'"
   apply (cases c, simp_all add: objBits_simps' zbits_map_def
-                                cte_level_bits_def min_sched_context_bits_def
+                                cte_level_bits_def
                          split: option.splits sum.splits)
   apply (rename_tac arch_cap)
   apply (case_tac arch_cap,
@@ -145,14 +146,25 @@ lemma obj_size_relation:
   done
 
 lemma same_region_as_relation:
-  "\<lbrakk> cap_relation c d; cap_relation c' d' \<rbrakk> \<Longrightarrow> same_region_as c c' = sameRegionAs d d'"
+    "\<lbrakk> cap_relation c d; cap_relation c' d' \<rbrakk> \<Longrightarrow>
+  same_region_as c c' = sameRegionAs d d'"
   apply (cases c)
-               apply clarsimp
-              apply (clarsimp simp: sameRegionAs_def isCap_simps Let_def is_phyiscal_relation)
-              apply (auto simp: obj_ref_of_relation obj_size_relation cong: conj_cong)[1]
-             apply ((cases c', auto simp: sameRegionAs_def isCap_simps Let_def)+)[11]
-  apply (cases c'; (clarsimp simp: same_arch_region_as_relation|
-                      clarsimp simp: sameRegionAs_def isCap_simps Let_def)+)
+            apply clarsimp
+           apply (clarsimp simp: sameRegionAs_def isCap_simps Let_def is_phyiscal_relation)
+           apply (auto simp: obj_ref_of_relation obj_size_relation cong: conj_cong)[1]
+          apply (cases c', auto simp: sameRegionAs_def isCap_simps Let_def)[1]
+         apply (cases c', auto simp: sameRegionAs_def isCap_simps Let_def)[1]
+        apply (cases c', auto simp: sameRegionAs_def isCap_simps Let_def)[1]
+       apply (cases c', auto simp: sameRegionAs_def isCap_simps Let_def bits_of_def)[1]
+      apply (cases c', auto simp: sameRegionAs_def isCap_simps Let_def)[1]
+     apply (cases c', auto simp: sameRegionAs_def isCap_simps Let_def)[1]
+    apply (cases c', auto simp: sameRegionAs_def isCap_simps Let_def)[1]
+   apply (cases c', auto simp: sameRegionAs_def isCap_simps Let_def)[1]
+   apply (cases c', auto simp: sameRegionAs_def isCap_simps Let_def)[1]
+  apply simp
+  apply (cases c')
+  apply (clarsimp simp: same_arch_region_as_relation|
+         clarsimp simp: sameRegionAs_def isCap_simps Let_def)+
   done
 
 lemma can_be_is:
@@ -180,20 +192,23 @@ lemma can_be_is:
   apply (auto simp: Let_def)[1]
   done
 
-lemma no_ofail_cte_wp_at'_readObject[simp]:
-  "no_ofail (cte_wp_at' (P::cte \<Rightarrow> bool) p) (readObject p::cte kernel_r)"
-  by (clarsimp simp: cte_wp_at'_def getObject_def readObject_def obind_def omonad_defs split_def
-                     no_ofail_def gets_the_def gets_def get_def bind_def
-                     return_def assert_opt_def fail_def
-              split: option.splits)
-
-lemma no_fail_getObject [wp]:
-  "no_fail (cte_at' p) (getObject p::cte kernel)"
-  by (clarsimp simp: getCTE_def getObject_def no_ofail_gets_the)
-
 lemma no_fail_getCTE [wp]:
   "no_fail (cte_at' p) (getCTE p)"
-  by (wpsimp simp: getCTE_def)
+  apply (simp add: getCTE_def getObject_def split_def
+                   loadObject_cte alignCheck_def unless_def
+                   alignError_def is_aligned_mask[symmetric]
+             cong: kernel_object.case_cong)
+  apply (rule no_fail_pre, (wp | wpc)+)
+  apply (clarsimp simp: cte_wp_at'_def getObject_def
+                        loadObject_cte split_def in_monad
+                 dest!: in_singleton
+             split del: if_split)
+  apply (clarsimp simp: in_monad typeError_def objBits_simps
+                        magnitudeCheck_def
+                 split: kernel_object.split_asm if_split_asm option.split_asm
+             split del: if_split)
+       apply simp+
+  done
 
 lemma tcb_cases_related:
   "tcb_cap_cases ref = Some (getF, setF, restr) \<Longrightarrow>
@@ -215,7 +230,7 @@ lemma pspace_relation_cte_wp_at:
    apply (simp add: unpleasant_helper)
    apply (drule spec, drule mp, erule domI)
    apply (clarsimp simp: cte_relation_def)
-   apply (drule(2) aligned'_distinct'_ko_at'I[where 'a=cte], simp)
+   apply (drule(2) aligned_distinct_obj_atI'[where 'a=cte])
     apply simp
    apply (drule ko_at_imp_cte_wp_at')
    apply (clarsimp elim!: cte_wp_at_weakenE')
@@ -223,7 +238,7 @@ lemma pspace_relation_cte_wp_at:
   apply (drule(1) pspace_relation_absD)
   apply (clarsimp simp: tcb_relation_cut_def)
   apply (simp split: kernel_object.split_asm)
-  apply (drule(2) aligned'_distinct'_ko_at'I[where 'a=tcb], simp)
+  apply (drule(2) aligned_distinct_obj_atI'[where 'a=tcb])
    apply simp
   apply (drule tcb_cases_related)
   apply (clarsimp simp: obj_at'_def projectKOs objBits_simps)
@@ -350,7 +365,8 @@ proof (induct rule: resolveAddressBits.induct)
     apply (elim exE conjE)
     apply (simp only: split: if_split_asm)
      apply (clarsimp simp: in_monad locateSlot_conv stateAssert_def)
-     apply (cases cap; simp add: isCap_defs)
+     apply (cases cap)
+       apply (simp_all add: isCap_defs)[12]
      apply (clarsimp simp add: valid_cap'_def objBits_simps' cte_level_bits_def
                         split: option.split_asm)
     apply (simp only: in_bindE_R K_bind_def)
@@ -360,7 +376,8 @@ proof (induct rule: resolveAddressBits.induct)
      apply (simp only: in_bindE_R K_bind_def)
      apply (frule (12) 1 [OF refl], (assumption | rule refl)+)
      apply (clarsimp simp: in_monad locateSlot_conv objBits_simps stateAssert_def)
-     apply (cases cap; simp add: isCap_defs)
+     apply (cases cap)
+       apply (simp_all add: isCap_defs)[12]
      apply (frule in_inv_by_hoareD [OF getSlotCap_inv])
      apply simp
      apply (frule (1) post_by_hoare [OF getSlotCap_valid_cap])
@@ -369,7 +386,8 @@ proof (induct rule: resolveAddressBits.induct)
      apply (drule (1) bspec)
      apply simp
     apply (clarsimp simp: in_monad locateSlot_conv objBits_simps stateAssert_def)
-    apply (cases cap; simp add: isCap_defs)
+    apply (cases cap)
+     apply (simp_all add: isCap_defs)[12]
     apply (frule in_inv_by_hoareD [OF getSlotCap_inv])
     apply (clarsimp simp: valid_cap'_def cte_level_bits_def objBits_defs)
     done
@@ -410,15 +428,17 @@ proof -
   } note x = this
   from assms
   show ?thesis
-  apply (cases c; simp add: simps)
-   defer
+  apply (cases c)
+            apply (simp_all add: simps)[5]
+       defer
+       apply (simp_all add: simps)[4]
    apply (clarsimp simp: simps the_arch_cap_def)
    apply (rename_tac arch_cap)
    apply (case_tac arch_cap)
-        apply (simp_all add: arch_update_cap_data_def
+        apply (simp_all add: simps arch_update_cap_data_def
                              ARM_H.updateCapData_def)[5]
   \<comment> \<open>CNodeCap\<close>
-  apply (simp add: word_bits_def the_cnode_cap_def andCapRights_def
+  apply (simp add: simps word_bits_def the_cnode_cap_def andCapRights_def
                    rightsFromWord_def data_to_rights_def nth_ucast cteRightsBits_def
                    cteGuardBits_def)
   apply (insert x)
@@ -431,7 +451,6 @@ proof -
   done
 qed
 
-end
 
 lemma cte_map_shift:
   assumes bl: "to_bl cref' = zs @ cref"
@@ -586,8 +605,8 @@ proof (induct a arbitrary: c' cref' bits rule: resolve_address_bits'.induct)
         apply (simp add: caps isCap_defs Let_def whenE_bindE_throwError_to_if)
         apply (subst cnode_cap_case_if)
         apply (corresKsimp search: getSlotCap_corres IH
-                              wp: get_cap_wp getSlotCap_valid hoare_drop_imps
-                            simp: locateSlot_conv stateAssert_def)
+                              wp: get_cap_wp getSlotCap_valid no_fail_stateAssert
+                            simp: locateSlot_conv)
         apply (simp add: drop_postfix_eq)
         apply clarsimp
         apply (prop_tac "is_aligned ptr (cte_level_bits + cbits) \<and> cbits \<le> word_bits - cte_level_bits")
@@ -618,15 +637,15 @@ proof (induct a arbitrary: c' cref' bits rule: resolve_address_bits'.induct)
             apply (erule (2) valid_CNodeCapE)
             apply (erule (3) cte_map_shift')
             apply simp
-           apply (erule (1) cte_map_shift; assumption?)
-           subgoal by simp
-          apply (clarsimp simp: cte_level_bits_def)
-          apply (rule conjI)
-           apply (clarsimp simp: valid_cap_def cap_table_at_gsCNodes isCap_simps)
-          apply (rule and_mask_less_size, simp add: word_bits_def word_size cte_level_bits_def)
-          apply (clarsimp split: if_splits)
-          done
-        done
+              apply (erule (1) cte_map_shift; assumption?)
+              subgoal by simp
+              apply (clarsimp simp: cte_level_bits_def)
+           apply (rule conjI)
+             apply (clarsimp simp: valid_cap_def cap_table_at_gsCNodes isCap_simps)
+             apply (rule and_mask_less_size, simp add: word_bits_def word_size cte_level_bits_def)
+           apply (clarsimp split: if_splits)
+           done
+         done
     }
     ultimately
     show ?thesis by fast
@@ -707,7 +726,7 @@ lemma lookupSlotForThread_corres:
    prefer 2
    apply (rule hoare_weaken_preE)
     apply (rule resolveAddressBits_cte_at')
-   apply (simp add: invs'_def valid_pspace'_def)
+   apply (simp add: invs'_def valid_state'_def valid_pspace'_def)
   apply (simp add: returnOk_def split_def)
   done
 
@@ -744,9 +763,9 @@ lemma lookupCap_corres:
 lemma setObject_cte_obj_at_tcb':
   assumes x: "\<And>tcb f. P (tcbCTable_update f tcb) = P tcb"
              "\<And>tcb f. P (tcbVTable_update f tcb) = P tcb"
+             "\<And>tcb f. P (tcbReply_update f tcb) = P tcb"
+             "\<And>tcb f. P (tcbCaller_update f tcb) = P tcb"
              "\<And>tcb f. P (tcbIPCBufferFrame_update f tcb) = P tcb"
-             "\<And>tcb f. P (tcbFaultHandler_update f tcb) = P tcb"
-             "\<And>tcb f. P (tcbTimeoutHandler_update f tcb) = P tcb"
   shows
   "\<lbrace>\<lambda>s. P' (obj_at' (P :: tcb \<Rightarrow> bool) p s)\<rbrace>
   setObject c (cte::cte)
@@ -763,12 +782,17 @@ lemma setObject_cte_obj_at_tcb':
                         Structures_H.kernel_object.split_asm)
   done
 
-crunch setCTE
-  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  and sc_at'_n[wp]: "\<lambda>s. P (sc_at'_n n p s)"
+lemma setCTE_typ_at':
+  "\<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace> setCTE c cte \<lbrace>\<lambda>_ s. P (typ_at' T p s)\<rbrace>"
+  by (clarsimp simp add: setCTE_def) (wp setObject_typ_at')
 
-global_interpretation setCTE: typ_at_all_props' "setCTE p v"
-  by typ_at_props'
+lemmas setObject_typ_at [wp] = setObject_typ_at' [where P=id, simplified]
+
+lemma setCTE_typ_at [wp]:
+  "\<lbrace>typ_at' T p\<rbrace> setCTE c cte \<lbrace>\<lambda>_. typ_at' T p\<rbrace>"
+  by (clarsimp simp add: setCTE_def) wp
+
+lemmas setCTE_typ_ats [wp] = typ_at_lifts [OF setCTE_typ_at']
 
 lemma setObject_cte_ksCurDomain[wp]:
   "\<lbrace>\<lambda>s. P (ksCurDomain s)\<rbrace> setObject ptr (cte::cte) \<lbrace>\<lambda>_ s. P (ksCurDomain s)\<rbrace>"
@@ -868,7 +892,13 @@ lemma cap_insert_objs' [wp]:
    cteInsert cap src dest \<lbrace>\<lambda>rv. valid_objs'\<rbrace>"
   including no_pre
   apply (simp add: cteInsert_def updateCap_def setUntypedCapAsFull_def bind_assoc split del: if_split)
-  apply (wpsimp wp: setCTE_valid_objs | rule hoare_drop_imp)+
+  apply (wp setCTE_valid_objs)
+      apply simp
+      apply wp+
+      apply (clarsimp simp: updateCap_def)
+      apply (wp|simp)+
+    apply (rule hoare_drop_imp)+
+    apply wp+
   apply (rule hoare_strengthen_post[OF getCTE_sp])
   apply (clarsimp simp: cte_wp_at_ctes_of isCap_simps
                  dest!: ctes_of_valid_cap'')
@@ -884,7 +914,11 @@ lemma cteInsert_weak_cte_wp_at:
   apply (wp setCTE_weak_cte_wp_at updateMDB_weak_cte_wp_at hoare_weak_lift_imp | simp)+
    apply (wp getCTE_ctes_wp)+
    apply (clarsimp simp: isCap_simps split:if_split_asm| rule conjI)+
-  done
+done
+
+lemma setCTE_valid_cap:
+  "\<lbrace>valid_cap' c\<rbrace> setCTE ptr cte \<lbrace>\<lambda>r. valid_cap' c\<rbrace>"
+  by (rule typ_at_lifts, rule setCTE_typ_at')
 
 lemma set_is_modify:
   "m p = Some cte \<Longrightarrow>
@@ -925,8 +959,6 @@ abbreviation
 
 abbreviation
   "revokable' a b \<equiv> global.isCapRevocable b a"
-
-context begin interpretation Arch . (*FIXME: arch-split*)
 
 declare arch_is_cap_revocable_def[simp] ARM_H.isCapRevocable_def[simp]
 
@@ -1207,7 +1239,10 @@ definition
   capBadge cap = capBadge cap' \<and>
   capASID cap = capASID cap' \<and>
   cap_asid_base' cap = cap_asid_base' cap' \<and>
-  cap_vptr' cap = cap_vptr' cap'"
+  cap_vptr' cap = cap_vptr' cap' \<and>
+  \<comment> \<open>check all fields of ReplyCap except capReplyCanGrant\<close>
+  (isReplyCap cap \<longrightarrow> capTCBPtr cap = capTCBPtr cap' \<and>
+                     capReplyMaster cap = capReplyMaster cap')"
 
 lemma capASID_update [simp]:
   "capASID (RetypeDecls_H.updateCapData P x c) = capASID c"
@@ -1262,10 +1297,14 @@ lemma updateCapData_Reply:
   done
 
 lemma weak_derived_updateCapData:
-  "\<lbrakk> updateCapData P x c \<noteq> NullCap; weak_derived' c c';
-     capBadge (updateCapData P x c) = capBadge c' \<rbrakk>
+  "\<lbrakk> (updateCapData P x c) \<noteq> NullCap; weak_derived' c c';
+      capBadge (updateCapData P x c) = capBadge c' \<rbrakk>
   \<Longrightarrow> weak_derived' (updateCapData P x c) c'"
-  by (clarsimp simp add: weak_derived'_def updateCapData_Master)
+  apply (clarsimp simp add: weak_derived'_def updateCapData_Master)
+  apply (clarsimp elim: impE dest!: iffD1[OF updateCapData_Reply])
+  apply (clarsimp simp: isCap_simps)
+  apply (clarsimp simp: Let_def isCap_simps updateCapData_def)
+  done
 
 lemma maskCapRights_Reply[simp]:
   "isReplyCap (maskCapRights r c) = isReplyCap c"
@@ -1659,35 +1698,41 @@ proof -
     done
 qed
 
+definition pspace_relations where
+  "pspace_relations ekh kh kh' \<equiv> pspace_relation kh kh' \<and> ekheap_relation ekh kh'"
+
 lemma set_cap_not_quite_corres_prequel:
   assumes cr:
-  "pspace_relation (kheap s) (ksPSpace s')"
+  "pspace_relations (ekheap s) (kheap s) (ksPSpace s')"
   "(x,t') \<in> fst (setCTE p' c' s')"
   "valid_objs s" "pspace_aligned s" "pspace_distinct s" "cte_at p s"
   "pspace_aligned' s'" "pspace_distinct' s'"
   assumes c: "cap_relation c (cteCap c')"
   assumes p: "p' = cte_map p"
   shows "\<exists>t. ((),t) \<in> fst (set_cap c p s) \<and>
-             pspace_relation (kheap t) (ksPSpace t')"
+             pspace_relations (ekheap t) (kheap t) (ksPSpace t')"
   using cr
   apply (clarsimp simp: setCTE_def setObject_def in_monad split_def)
   apply (drule(1) updateObject_cte_is_tcb_or_cte[OF _ refl, rotated])
   apply (elim disjE exE conjE)
-   apply (clarsimp simp: lookupAround2_char1)
+   apply (clarsimp simp: lookupAround2_char1 pspace_relations_def)
    apply (frule(5) cte_map_pulls_tcb_to_abstract[OF p])
     apply (simp add: domI)
    apply (frule tcb_cases_related2)
    apply (clarsimp simp: set_cap_def2 split_def bind_def get_object_def
                          simpler_gets_def assert_def fail_def return_def
-                         set_object_def get_def put_def gets_the_def)
-   apply (erule(2) pspace_relation_update_tcbs)
-   apply (simp add: c)
-  apply clarsimp
+                         set_object_def get_def put_def)
+   apply (rule conjI)
+    apply (erule(2) pspace_relation_update_tcbs)
+    apply (simp add: c)
+   apply (clarsimp simp: ekheap_relation_def pspace_relation_def)
+   apply (drule bspec, erule domI)
+   apply (clarsimp simp: etcb_relation_def tcb_cte_cases_def split: if_split_asm)
+  apply (clarsimp simp: pspace_relations_def)
   apply (frule(5) cte_map_pulls_cte_to_abstract[OF p])
   apply (clarsimp simp: set_cap_def split_def bind_def get_object_def
                         simpler_gets_def assert_def fail_def return_def
-                        set_object_def get_def put_def domI gets_the_def
-                        a_type_def[split_simps kernel_object.split arch_kernel_obj.split])
+                        set_object_def get_def put_def domI a_type_def[split_simps kernel_object.split arch_kernel_obj.split])
   apply (erule(1) valid_objsE)
   apply (clarsimp simp: valid_obj_def valid_cs_def valid_cs_size_def exI)
   apply (intro conjI impI)
@@ -1705,6 +1750,9 @@ lemma set_cap_not_quite_corres_prequel:
      apply (simp add: cte_at_cases domI well_formed_cnode_invsI[OF cr(3)])
     apply clarsimp
    apply (simp add: c)
+  apply (clarsimp simp: ekheap_relation_def pspace_relation_def)
+  apply (drule bspec, erule domI)
+  apply (clarsimp simp: etcb_relation_def tcb_cte_cases_def split: if_split_asm)
   apply (simp add: wf_cs_insert)
   done
 
@@ -1717,20 +1765,15 @@ lemma setCTE_pspace_only:
 
 lemma set_cap_not_quite_corres:
   assumes cr:
-  "pspace_relation (kheap s) (ksPSpace s')"
+  "pspace_relations (ekheap s) (kheap s) (ksPSpace s')"
   "cur_thread s = ksCurThread s'"
   "idle_thread s = ksIdleThread s'"
-  "idle_sc_ptr = ksIdleSC s'"
   "machine_state s = ksMachineState s'"
   "work_units_completed s = ksWorkUnitsCompleted s'"
   "domain_index s = ksDomScheduleIdx s'"
   "domain_list s = ksDomSchedule s'"
   "cur_domain s = ksCurDomain s'"
   "domain_time s = ksDomainTime s'"
-  "consumed_time s = ksConsumedTime s'"
-  "cur_time s = ksCurTime s'"
-  "cur_sc s = ksCurSc s'"
-  "reprogram_timer s = ksReprogramTimer s'"
   "(x,t') \<in> fst (updateCap p' c' s')"
   "valid_objs s" "pspace_aligned s" "pspace_distinct s" "cte_at p s"
   "pspace_aligned' s'" "pspace_distinct' s'"
@@ -1739,30 +1782,24 @@ lemma set_cap_not_quite_corres:
   assumes c: "cap_relation c c'"
   assumes p: "p' = cte_map p"
   shows "\<exists>t. ((),t) \<in> fst (set_cap c p s) \<and>
-             pspace_relation (kheap t) (ksPSpace t') \<and>
+             pspace_relations (ekheap t) (kheap t) (ksPSpace t') \<and>
              cdt t = cdt s \<and>
              cdt_list t = cdt_list s \<and>
+             ekheap t = ekheap s \<and>
              scheduler_action t = scheduler_action s \<and>
              ready_queues t = ready_queues s \<and>
-             release_queue t = release_queue s \<and>
              is_original_cap t = is_original_cap s \<and>
              interrupt_state_relation (interrupt_irq_node t) (interrupt_states t)
                               (ksInterruptState t') \<and>
              (arch_state t, ksArchState t') \<in> arch_state_relation \<and>
              cur_thread t = ksCurThread t' \<and>
              idle_thread t = ksIdleThread t' \<and>
-             idle_sc_ptr = ksIdleSC t' \<and>
              machine_state t = ksMachineState t' \<and>
              work_units_completed t = ksWorkUnitsCompleted t' \<and>
              domain_index t = ksDomScheduleIdx t' \<and>
              domain_list t = ksDomSchedule t' \<and>
              cur_domain t = ksCurDomain t' \<and>
-             domain_time t = ksDomainTime t' \<and>
-             consumed_time t = ksConsumedTime t' \<and>
-             cur_time t = ksCurTime t' \<and>
-             cur_sc t = ksCurSc t' \<and>
-             reprogram_timer t = ksReprogramTimer t' \<and>
-             sc_replies_of t = sc_replies_of s"
+             domain_time t = ksDomainTime t'"
   using cr
   apply (clarsimp simp: updateCap_def in_monad)
   apply (drule use_valid [OF _ getCTE_sp[where P="\<lambda>s. s2 = s" for s2], OF _ refl])
@@ -1774,12 +1811,9 @@ lemma set_cap_not_quite_corres:
   apply (erule exEI)
   apply clarsimp
   apply (frule setCTE_pspace_only)
-  apply (prop_tac "sc_replies_of x = sc_replies_of s")
-   apply (erule use_valid[OF _ set_cap.valid_sched_pred], simp)
   apply (clarsimp simp: set_cap_def split_def in_monad set_object_def
-                        get_object_def)
-  apply (rename_tac obj ps' x' obj' kobj)
-  apply (case_tac obj; clarsimp simp: fail_def return_def split: if_split_asm)
+                        get_object_def
+                 split: Structures_A.kernel_object.split_asm if_split_asm)
   done
 
 lemma descendants_of_eq':
@@ -1803,54 +1837,46 @@ lemma descendants_of_eq':
   apply simp
   done
 
-\<comment>\<open>
-  This turned out to be the least-annoying way to deal with
-  the subgoal @{term
-    "ps' |> reply_of' |> replyNext_of = replyNexts_of s'"
-  } which shows up in the proof of `updateCap_corres`.
-
-  `ps'` here comes from `ksPSpace s''`, where `s''` is the new state
-  after `setObject`. Unforutnately, @{thm setObject_cte_replies_of'} is
-  specified in terms of `replies_of'`, which uses `ksPSpace` as an
-  accessor and so can't be used for a goal that refers to the PSpace
-  directly.
-\<close>
-lemma setObject_cte_replies_of'_use_valid_ksPSpace:
+lemma setObject_cte_tcbSchedPrevs_of_use_valid_ksPSpace:
   assumes step: "(x, s\<lparr>ksPSpace := ps\<rparr>) \<in> fst (setObject p (cte :: cte) s)"
-      and pre: "P (replies_of' s)"
-  shows "P (ps |> reply_of')"
-  using use_valid[OF step setObject_cte_replies_of'] pre
+  assumes pre: "P (tcbSchedPrevs_of s)"
+  shows "P (ps |> tcb_of' |> tcbSchedPrev)"
+  using use_valid[OF step setObject_cte_tcbSchedPrevs_of(1)] pre
   by auto
 
-lemma setObject_cte_scs_of'_use_valid_ksPSpace:
+lemma setObject_cte_tcbSchedNexts_of_use_valid_ksPSpace:
   assumes step: "(x, s\<lparr>ksPSpace := ps\<rparr>) \<in> fst (setObject p (cte :: cte) s)"
-      and pre: "P (scs_of' s)"
-  shows "P (ps |> sc_of')"
-  using use_valid[OF step setObject_scs_of'(1)] pre
+  assumes pre: "P (tcbSchedNexts_of s)"
+  shows "P (ps |> tcb_of' |> tcbSchedNext)"
+  using use_valid[OF step setObject_cte_tcbSchedNexts_of(1)] pre
+  by auto
+
+lemma setObject_cte_inQ_of_use_valid_ksPSpace:
+  assumes step: "(x, s\<lparr>ksPSpace := ps\<rparr>) \<in> fst (setObject p (cte :: cte) s)"
+  assumes pre: "P (inQ domain priority |< tcbs_of' s)"
+  shows "P (inQ domain priority |< (ps |> tcb_of'))"
+  using use_valid[OF step setObject_cte_inQ(1)] pre
   by auto
 
 lemma updateCap_stuff:
   assumes "(x, s'') \<in> fst (updateCap p cap s')"
-  shows "ctes_of s'' = modify_map (ctes_of s') p (cteCap_update (K cap)) \<and>
+  shows "(ctes_of s'' = modify_map (ctes_of s') p (cteCap_update (K cap))) \<and>
          gsUserPages s'' = gsUserPages s' \<and>
          gsCNodes s'' = gsCNodes s' \<and>
          ksMachineState s'' = ksMachineState s' \<and>
          ksWorkUnitsCompleted s'' = ksWorkUnitsCompleted s' \<and>
          ksCurThread s'' = ksCurThread s' \<and>
          ksIdleThread s'' = ksIdleThread s' \<and>
-         ksIdleSC s'' = ksIdleSC s' \<and>
          ksReadyQueues s'' = ksReadyQueues s' \<and>
-         ksReleaseQueue s'' = ksReleaseQueue s' \<and>
          ksSchedulerAction s'' = ksSchedulerAction s' \<and>
          (ksArchState s'' = ksArchState s') \<and>
          (pspace_aligned' s' \<longrightarrow> pspace_aligned' s'') \<and>
          (pspace_distinct' s' \<longrightarrow> pspace_distinct' s'') \<and>
-         replyPrevs_of s'' = replyPrevs_of s' \<and>
-         scReplies_of s'' = scReplies_of s' \<and>
-         ksConsumedTime s'' = ksConsumedTime s' \<and>
-         ksCurTime s'' = ksCurTime s' \<and>
-         ksCurSc s'' = ksCurSc s' \<and>
-         ksReprogramTimer s'' = ksReprogramTimer s'" using assms
+         tcbSchedPrevs_of s'' = tcbSchedPrevs_of s' \<and>
+         tcbSchedNexts_of s'' = tcbSchedNexts_of s' \<and>
+         (\<forall>domain priority.
+            (inQ domain priority |< tcbs_of' s'') = (inQ domain priority |< tcbs_of' s'))"
+  using assms
   apply (clarsimp simp: updateCap_def in_monad)
   apply (drule use_valid [where P="\<lambda>s. s2 = s" for s2, OF _ getCTE_sp refl])
   apply (rule conjI)
@@ -1859,16 +1885,11 @@ lemma updateCap_stuff:
   apply (frule setCTE_pspace_only)
   apply (clarsimp simp: setCTE_def)
   apply (intro conjI impI)
-     apply (erule use_valid [OF _ setObject_aligned])
-      apply (clarsimp simp: updateObject_cte in_monad typeError_def
-                            in_magnitude_check objBits_simps
-                     split: kernel_object.split_asm if_split_asm)
-    apply (erule use_valid [OF _ setObject_distinct])
-     apply (clarsimp simp: updateObject_cte in_monad typeError_def
-                           in_magnitude_check objBits_simps
-                    split: kernel_object.split_asm if_split_asm)
-   apply (erule setObject_cte_replies_of'_use_valid_ksPSpace; simp)
-  apply (erule setObject_cte_scs_of'_use_valid_ksPSpace; simp)
+      apply (erule(1) use_valid [OF _ setObject_aligned])
+     apply (erule(1) use_valid [OF _ setObject_distinct])
+    apply (erule setObject_cte_tcbSchedPrevs_of_use_valid_ksPSpace; simp)
+   apply (erule setObject_cte_tcbSchedNexts_of_use_valid_ksPSpace; simp)
+  apply (fastforce elim: setObject_cte_inQ_of_use_valid_ksPSpace)
   done
 
 (* FIXME: move *)
@@ -2185,33 +2206,24 @@ lemma ctes_of_valid:
   apply (fastforce)
   done
 
-lemma readObject_cte_at'[simplified]:
-  "bound (readObject p s :: cte option) \<Longrightarrow> cte_at' p s"
-  unfolding cte_wp_at'_def getObject_def
-  by (clarsimp simp: omonad_defs split_def gets_the_def exec_gets return_def)
-
-lemma readObject_cte_ko_at':
-  "readObject p s = Some (cte :: cte) \<Longrightarrow> cte_wp_at' ((=) cte) p s"
-  unfolding cte_wp_at'_def getObject_def
-  by (clarsimp simp: omonad_defs split_def gets_the_def exec_gets return_def)
-
-lemma no_fail_setObject_cte [wp]:
-  "no_fail (cte_at' t) (setObject t (t'::cte))"
-  unfolding setObject_def
-  apply (clarsimp simp: updateObject_cte gets_the_def alignCheck_def is_aligned_mask[symmetric]
-             split del: if_split cong: kernel_object.case_cong)
-  apply (wp|wpc)+
-  apply (clarsimp simp: cte_wp_at'_def getObject_def split_def
-                        in_monad loadObject_cte readObject_def omonad_defs
-                 dest!: in_singleton split: option.splits split del: if_split)
-  by (fastforce simp: read_typeError_def objBits_simps
-                      read_magnitudeCheck_def ohaskell_assert_def
-               split: kernel_object.split_asm if_split_asm
-           split del: if_split)
-
 lemma no_fail_setCTE [wp]:
   "no_fail (cte_at' p) (setCTE p c)"
-  unfolding setCTE_def by wp
+  apply (clarsimp simp: setCTE_def setObject_def split_def unless_def
+                        updateObject_cte alignCheck_def alignError_def
+                        typeError_def is_aligned_mask[symmetric]
+                  cong: kernel_object.case_cong)
+  apply (wp|wpc)+
+  apply (clarsimp simp: cte_wp_at'_def getObject_def split_def
+                        in_monad loadObject_cte
+                 dest!: in_singleton
+             split del: if_split)
+  apply (clarsimp simp: typeError_def alignCheck_def alignError_def
+                        in_monad is_aligned_mask[symmetric] objBits_simps
+                        magnitudeCheck_def
+                 split: kernel_object.split_asm if_split_asm option.splits
+             split del: if_split)
+    apply simp_all
+  done
 
 lemma no_fail_updateCap [wp]:
   "no_fail (cte_at' p) (updateCap p cap')"
@@ -2264,20 +2276,23 @@ lemma is_final_untyped_ptrs:
   done
 
 lemma capClass_ztc_relation:
-  "\<lbrakk> is_zombie c \<or> is_cnode_cap c \<or> is_thread_cap c; cap_relation c c' \<rbrakk>
-   \<Longrightarrow> capClass c' = PhysicalClass"
+  "\<lbrakk> is_zombie c \<or> is_cnode_cap c \<or> is_thread_cap c;
+       cap_relation c c' \<rbrakk> \<Longrightarrow> capClass c' = PhysicalClass"
   by (auto simp: is_cap_simps)
+
+lemma pspace_relationsD:
+  "\<lbrakk>pspace_relation kh kh'; ekheap_relation ekh kh'\<rbrakk> \<Longrightarrow> pspace_relations ekh kh kh'"
+  by (simp add: pspace_relations_def)
 
 lemma updateCap_corres:
   "\<lbrakk>cap_relation cap cap';
     is_zombie cap \<or> is_cnode_cap cap \<or> is_thread_cap cap \<rbrakk>
-   \<Longrightarrow> corres dc (\<lambda>s. invs s
-                      \<and> cte_wp_at
-                          (\<lambda>c. (is_zombie c \<or> is_cnode_cap c \<or> is_thread_cap c)
-                            \<and> is_final_cap' c s
-                            \<and> obj_ref_of c = obj_ref_of cap
-                            \<and> obj_size c = obj_size cap)
-                          slot s)
+   \<Longrightarrow> corres dc (\<lambda>s. invs s \<and>
+                      cte_wp_at (\<lambda>c. (is_zombie c \<or> is_cnode_cap c \<or>
+                                      is_thread_cap c) \<and>
+                                     is_final_cap' c s \<and>
+                                     obj_ref_of c = obj_ref_of cap \<and>
+                                     obj_size c = obj_size cap) slot s)
                  invs'
                  (set_cap cap slot) (updateCap (cte_map slot) cap')"
   apply (rule corres_stronger_no_failI)
@@ -2290,30 +2305,39 @@ lemma updateCap_corres:
     apply fastforce
    apply (clarsimp simp: cte_wp_at_ctes_of)
   apply (clarsimp simp add: state_relation_def)
+  apply (drule(1) pspace_relationsD)
   apply (frule (3) set_cap_not_quite_corres; fastforce?)
    apply (erule cte_wp_at_weakenE, rule TrueI)
   apply clarsimp
   apply (rule bexI)
    prefer 2
    apply simp
-  apply (clarsimp simp: in_set_cap_cte_at_swp)
+  apply (clarsimp simp: in_set_cap_cte_at_swp pspace_relations_def)
   apply (drule updateCap_stuff)
-  apply (rename_tac abs conc conc' abs')
-
-  (* FIXME RT: replace this with whatever comes out of VER-1248. *)
+  apply simp
   apply (extract_conjunct \<open>match conclusion in "ghost_relation _ _ _" \<Rightarrow> -\<close>)
    apply (clarsimp simp: ghost_relation_typ_at set_cap_a_type_inv data_at_def)
-
-  apply (extract_conjunct \<open>match conclusion in "sched_act_relation _ _" \<Rightarrow> -\<close>)
-   apply clarsimp
-
-  apply (extract_conjunct \<open>match conclusion in "cdt_relation _ _ _" \<Rightarrow> -\<close>)
-   apply (case_tac "ctes_of conc (cte_map slot)")
-    apply (simp add: modify_map_None)
-   apply (simp add: modify_map_apply)
-   apply (simp add: cdt_relation_def del: split_paired_All)
+  apply (rule conjI)
+   prefer 2
+   apply (rule conjI)
+    apply (unfold cdt_list_relation_def)[1]
+    apply (intro allI impI)
+    apply (erule_tac x=c in allE)
+    apply (auto elim!: modify_map_casesE)[1]
+   apply (unfold revokable_relation_def)[1]
+   apply (drule set_cap_caps_of_state_monad)
+   apply (simp add: cte_wp_at_caps_of_state del: split_paired_All)
    apply (intro allI impI)
-   apply (rule use_update_ztc_one [OF descendants_of_update_ztc])
+   apply (erule_tac x=c in allE)
+   apply (erule impE[where P="\<exists>y. v = Some y" for v])
+    apply (clarsimp simp: null_filter_def is_zombie_def split: if_split_asm)
+   apply (auto elim!: modify_map_casesE del: disjE)[1]
+  apply (case_tac "ctes_of b (cte_map slot)")
+   apply (simp add: modify_map_None)
+  apply (simp add: modify_map_apply)
+  apply (simp add: cdt_relation_def del: split_paired_All)
+  apply (intro allI impI)
+  apply (rule use_update_ztc_one [OF descendants_of_update_ztc])
          apply simp
         apply assumption
        apply (auto simp: is_cap_simps isCap_simps)[1]
@@ -2331,35 +2355,13 @@ lemma updateCap_corres:
    apply (drule cte_wp_at_norm, clarsimp)
    apply (drule(1) pspace_relation_ctes_ofI, clarsimp+)
    apply (simp add: is_cap_simps, elim disjE exE, simp_all add: isCap_simps)[1]
-   apply clarsimp
-
-  apply (extract_conjunct \<open>match conclusion in "ready_queues_relation _ _" \<Rightarrow> -\<close>)
-   apply (case_tac "ctes_of conc (cte_map slot)")
-    apply (simp add: modify_map_None)
-   apply (simp add: modify_map_apply)
-
-  apply (extract_conjunct \<open>match conclusion in "cdt_list_relation _ _ _" \<Rightarrow> -\<close>)
-   apply (unfold cdt_list_relation_def)[1]
-   apply (intro allI impI)
-   apply (erule_tac x=c in allE)
-   apply (auto elim!: modify_map_casesE)[1]
-
-  apply (extract_conjunct \<open>match conclusion in "revokable_relation _ _ _" \<Rightarrow> -\<close>)
-   apply (unfold revokable_relation_def)[1]
-   apply (drule set_cap_caps_of_state_monad)
-   apply (simp add: cte_wp_at_caps_of_state del: split_paired_All)
-   apply (intro allI impI)
-   apply (erule_tac x=c in allE)
-   apply (erule impE[where P="\<exists>y. v = Some y" for v])
-    apply (clarsimp simp: null_filter_def is_zombie_def split: if_split_asm)
-   apply (auto elim!: modify_map_casesE del: disjE)[1]
-
-  apply (extract_conjunct \<open>match conclusion in "release_queue_relation _ _" \<Rightarrow> -\<close>)
-   apply (clarsimp simp: release_queue_relation_def
-                  elim!: use_valid[OF _ set_cap.valid_sched_pred])
-
-  apply (clarsimp simp: sc_replies_relation_def)
+  apply clarsimp
   done
+
+lemma exst_set_cap:
+  "(x,s') \<in> fst (set_cap p c s) \<Longrightarrow> exst s' = exst s"
+  by (clarsimp simp: set_cap_def in_monad split_def get_object_def set_object_def
+               split: if_split_asm Structures_A.kernel_object.splits)
 
 lemma updateMDB_eqs:
   assumes "(x, s'') \<in> fst (updateMDB p f s')"
@@ -2367,9 +2369,7 @@ lemma updateMDB_eqs:
          ksWorkUnitsCompleted s'' = ksWorkUnitsCompleted s' \<and>
          ksCurThread s'' = ksCurThread s' \<and>
          ksIdleThread s'' = ksIdleThread s' \<and>
-         ksIdleSC s'' = ksIdleSC s' \<and>
          ksReadyQueues s'' = ksReadyQueues s' \<and>
-         ksReleaseQueue s'' = ksReleaseQueue s' \<and>
          ksInterruptState s'' = ksInterruptState s' \<and>
          ksArchState s'' = ksArchState s' \<and>
          ksSchedulerAction s'' = ksSchedulerAction s' \<and>
@@ -2434,6 +2434,24 @@ lemma updateMDB_pspace_relation:
   apply fastforce
   done
 
+lemma updateMDB_ekheap_relation:
+  assumes "(x, s'') \<in> fst (updateMDB p f s')"
+  assumes "ekheap_relation (ekheap s) (ksPSpace s')"
+  shows "ekheap_relation (ekheap s) (ksPSpace s'')" using assms
+  apply (clarsimp simp: updateMDB_def Let_def setCTE_def setObject_def in_monad ekheap_relation_def etcb_relation_def split_def split: if_split_asm)
+  apply (drule(1) updateObject_cte_is_tcb_or_cte[OF _ refl, rotated])
+  apply (drule_tac P="(=) s'" in use_valid [OF _ getCTE_sp], rule refl)
+  apply (drule bspec, erule domI)
+  apply (clarsimp simp: tcb_cte_cases_def lookupAround2_char1 split: if_split_asm)
+  done
+
+lemma updateMDB_pspace_relations:
+  assumes "(x, s'') \<in> fst (updateMDB p f s')"
+  assumes "pspace_relations (ekheap s) (kheap s) (ksPSpace s')"
+  assumes "pspace_aligned' s'" "pspace_distinct' s'"
+  shows "pspace_relations (ekheap s) (kheap s) (ksPSpace s'')" using assms
+  by (simp add: pspace_relations_def updateMDB_pspace_relation updateMDB_ekheap_relation)
+
 lemma updateMDB_ctes_of:
   assumes "(x, s') \<in> fst (updateMDB p f s)"
   assumes "no_0 (ctes_of s)"
@@ -2448,52 +2466,70 @@ lemma updateMDB_ctes_of:
   done
 
 crunch updateMDB
-  for replies_of'[wp]: "\<lambda>s. P (replies_of' s)"
-  and scs_of'[wp]: "\<lambda>s. P (scs_of' s)"
-  and ksConsumedTime[wp]: "\<lambda>s. P (ksConsumedTime s)"
-  and ksCurTime[wp]: "\<lambda>s. P (ksCurTime s)"
-  and ksCurSc[wp]: "\<lambda>s. P (ksCurSc s)"
-  and ksReprogramTimer[wp]: "\<lambda>s. P (ksReprogramTimer s)"
-  and aligned[wp]: pspace_aligned'
-  and pdistinct[wp]: pspace_distinct'
+  for aligned[wp]: "pspace_aligned'"
+crunch updateMDB
+  for pdistinct[wp]: "pspace_distinct'"
+crunch updateMDB
+  for tcbSchedPrevs_of[wp]: "\<lambda>s. P (tcbSchedPrevs_of s)"
+crunch updateMDB
+  for tcbSchedNexts_of[wp]: "\<lambda>s. P (tcbSchedNexts_of s)"
+crunch updateMDB
+  for inQ_opt_pred[wp]: "\<lambda>s. P (inQ d p |< tcbs_of' s)"
+crunch updateMDB
+  for inQ_opt_pred'[wp]: "\<lambda>s. P (\<lambda>d p. inQ d p |< tcbs_of' s)"
+crunch updateMDB
+  for ksReadyQueues[wp]: "\<lambda>s. P (ksReadyQueues s)"
   (wp: crunch_wps simp: crunch_simps setObject_def updateObject_cte)
+
+lemma setCTE_rdyq_projs[wp]:
+  "setCTE p f \<lbrace>\<lambda>s. P (ksReadyQueues s) (tcbSchedNexts_of s) (tcbSchedPrevs_of s)
+                      (\<lambda>d p. inQ d p |< tcbs_of' s)\<rbrace>"
+  apply (rule hoare_lift_Pf2[where f=ksReadyQueues])
+   apply (rule hoare_lift_Pf2[where f=tcbSchedNexts_of])
+    apply (rule hoare_lift_Pf2[where f=tcbSchedPrevs_of])
+     apply wpsimp+
+  done
+
+crunch updateMDB
+  for rdyq_projs[wp]:"\<lambda>s. P (ksReadyQueues s) (tcbSchedNexts_of s) (tcbSchedPrevs_of s)
+                             (\<lambda>d p. inQ d p |< tcbs_of' s)"
 
 lemma updateMDB_the_lot:
   assumes "(x, s'') \<in> fst (updateMDB p f s')"
-  assumes "pspace_relation (kheap s) (ksPSpace s')"
+  assumes "pspace_relations (ekheap s) (kheap s) (ksPSpace s')"
   assumes "pspace_aligned' s'" "pspace_distinct' s'" "no_0 (ctes_of s')"
   shows "ctes_of s'' = modify_map (ctes_of s') p (cteMDBNode_update f) \<and>
          ksMachineState s'' = ksMachineState s' \<and>
          ksWorkUnitsCompleted s'' = ksWorkUnitsCompleted s' \<and>
          ksCurThread s'' = ksCurThread s' \<and>
          ksIdleThread s'' = ksIdleThread s' \<and>
-         ksIdleSC s'' = ksIdleSC s' \<and>
          ksReadyQueues s'' = ksReadyQueues s' \<and>
-         ksReleaseQueue s'' = ksReleaseQueue s' \<and>
          ksSchedulerAction s'' = ksSchedulerAction s' \<and>
          ksInterruptState s'' = ksInterruptState s' \<and>
          ksArchState s'' = ksArchState s' \<and>
          gsUserPages s'' = gsUserPages s' \<and>
          gsCNodes s'' = gsCNodes s' \<and>
-         pspace_relation (kheap s) (ksPSpace s'') \<and>
+         pspace_relations (ekheap s) (kheap s) (ksPSpace s'') \<and>
          pspace_aligned' s'' \<and> pspace_distinct' s'' \<and>
          no_0 (ctes_of s'') \<and>
          ksDomScheduleIdx s'' = ksDomScheduleIdx s' \<and>
          ksDomSchedule s''    = ksDomSchedule s' \<and>
          ksCurDomain s''      = ksCurDomain s' \<and>
          ksDomainTime s''     = ksDomainTime s' \<and>
-         ksConsumedTime s''   = ksConsumedTime s' \<and>
-         ksCurTime s''        = ksCurTime s' \<and>
-         ksCurSc s''          = ksCurSc s' \<and>
-         ksReprogramTimer s'' = ksReprogramTimer s' \<and>
-         replyPrevs_of s'' = replyPrevs_of s' \<and>
-         scReplies_of s'' = scReplies_of s'"
-  using assms
-  apply (simp add: updateMDB_eqs updateMDB_pspace_relation split del: if_split)
+         tcbSchedNexts_of s'' = tcbSchedNexts_of s' \<and>
+         tcbSchedPrevs_of s'' = tcbSchedPrevs_of s' \<and>
+         (\<forall>domain priority.
+            (inQ domain priority |< tcbs_of' s'') = (inQ domain priority |< tcbs_of' s'))"
+using assms
+  apply (simp add: updateMDB_eqs updateMDB_pspace_relations split del: if_split)
   apply (frule (1) updateMDB_ctes_of)
   apply clarsimp
-  apply (erule use_valid, wp)
-  apply simp
+  apply (rule conjI)
+   apply (erule use_valid)
+    apply wp
+   apply simp
+  apply (erule use_valid, wpsimp wp: hoare_vcg_all_lift)
+  apply (simp add: comp_def)
   done
 
 lemma revokable_eq:
@@ -2630,7 +2666,20 @@ lemma subtree_next_0:
 definition
   "isArchCap P cap \<equiv> case cap of ArchObjectCap acap \<Rightarrow> P acap | _ \<Rightarrow> False"
 
-lemmas isArchCap_simps[simp] = isArchCap_def[split_simps capability.split]
+lemma isArchCap_simps[simp]:
+  "isArchCap P (capability.ThreadCap xc) = False"
+  "isArchCap P capability.NullCap = False"
+  "isArchCap P capability.DomainCap = False"
+  "isArchCap P (capability.NotificationCap xca xba xaa xd) = False"
+  "isArchCap P (capability.EndpointCap xda xcb xbb xab xe xi) = False"
+  "isArchCap P (capability.IRQHandlerCap xf) = False"
+  "isArchCap P (capability.Zombie xbc xac xg) = False"
+  "isArchCap P (capability.ArchObjectCap xh) = P xh"
+  "isArchCap P (capability.ReplyCap xad xi xia) = False"
+  "isArchCap P (capability.UntypedCap d xae xj f) = False"
+  "isArchCap P (capability.CNodeCap xfa xea xdb xcc) = False"
+  "isArchCap P capability.IRQControlCap = False"
+  by (simp add: isArchCap_def)+
 
 definition
   vsCapRef :: "capability \<Rightarrow> vs_ref list option"
@@ -2678,6 +2727,8 @@ definition
   badge_derived' cap' cap \<and>
   (isUntypedCap cap \<longrightarrow> descendants_of' p m = {}) \<and>
   (isReplyCap cap = isReplyCap cap') \<and>
+  (isReplyCap cap \<longrightarrow> capReplyMaster cap) \<and>
+  (isReplyCap cap' \<longrightarrow> \<not> capReplyMaster cap') \<and>
   (vsCapRef cap = vsCapRef cap' \<or> isArchCap isPageCap cap') \<and>
   ((isArchCap isPageTableCap cap \<or> isArchCap isPageDirectoryCap cap)
         \<longrightarrow> capASID cap = capASID cap' \<and> capASID cap \<noteq> None)"
@@ -2703,11 +2754,18 @@ lemma capBadge_ordering_relation:
   "\<lbrakk> cap_relation c c'; cap_relation d d' \<rbrakk> \<Longrightarrow>
   ((capBadge c', capBadge d') \<in> capBadge_ordering f) =
   ((cap_badge c, cap_badge d) \<in> capBadge_ordering f)"
-  by (cases c, auto simp add: cap_badge_def capBadge_ordering_def split: cap.splits)
+  apply (cases c)
+   apply (auto simp add: cap_badge_def capBadge_ordering_def split: cap.splits)
+  done
 
 lemma is_reply_cap_relation:
-  "cap_relation c c' \<Longrightarrow> is_reply_cap c = (isReplyCap c')"
+  "cap_relation c c' \<Longrightarrow> is_reply_cap c = (isReplyCap c' \<and> \<not> capReplyMaster c')"
   by (cases c, auto simp: is_cap_simps isCap_simps)
+
+lemma is_reply_master_relation:
+  "cap_relation c c' \<Longrightarrow>
+   is_master_reply_cap c = (isReplyCap c' \<and> capReplyMaster c')"
+  by (cases c, auto simp add: is_cap_simps isCap_simps)
 
 lemma cap_asid_cap_relation:
   "cap_relation c c' \<Longrightarrow> capASID c' = cap_asid c"
@@ -2727,28 +2785,30 @@ lemma is_derived_eq:
   apply (rule conjI)
    apply (clarsimp simp: is_cap_simps isCap_simps)
    apply (cases c, auto simp: isCap_simps cap_master_cap_def capMasterCap_def)[1]
-    apply (simp add:vsCapRef_def)
-   apply (simp add:vs_cap_ref_def)
-  apply (cases "isIRQControlCap d'")
+  apply (simp add:vsCapRef_def)
+  apply (simp add:vs_cap_ref_def)
+  apply (case_tac "isIRQControlCap d'")
    apply (frule(1) master_cap_relation)
    apply (clarsimp simp: isCap_simps cap_master_cap_def
-                         is_zombie_def is_reply_cap_def
+                         is_zombie_def is_reply_cap_def is_master_reply_cap_def
                   split: cap_relation_split_asm arch_cap.split_asm)[1]
   apply (frule(1) master_cap_relation)
   apply (frule(1) cap_badge_relation)
   apply (frule cap_asid_cap_relation)
   apply (frule(1) capBadge_ordering_relation)
-  apply (case_tac d; simp add: isCap_simps is_cap_simps cap_master_cap_def
-                               vs_cap_ref_def vsCapRef_def capMasterCap_def
-                          split: cap_relation_split_asm arch_cap.split_asm)
-      apply ((auto split:arch_cap.splits arch_capability.splits)[3])
-   apply (clarsimp split:option.splits arch_cap.splits arch_capability.splits)
-   apply (intro conjI|clarsimp)+
-     apply fastforce
-    apply clarsimp+
+  apply (case_tac d)
+   apply (simp_all add: isCap_simps is_cap_simps cap_master_cap_def
+     vs_cap_ref_def vsCapRef_def capMasterCap_def
+     split: cap_relation_split_asm arch_cap.split_asm)
+   apply fastforce
+  apply ((auto split:arch_cap.splits arch_capability.splits)[3])
   apply (clarsimp split:option.splits arch_cap.splits arch_capability.splits)
   apply (intro conjI|clarsimp)+
-  apply fastforce
+    apply fastforce
+   apply clarsimp+
+  apply (clarsimp split:option.splits arch_cap.splits arch_capability.splits)
+  apply (intro conjI|clarsimp)+
+   apply fastforce
   done
 end
 
@@ -3681,6 +3741,7 @@ lemma setCTE_UntypedCap_corres:
    apply (clarsimp simp: cte_wp_at_ctes_of)
   apply clarsimp
   apply (clarsimp simp add: state_relation_def split_def)
+  apply (drule (1) pspace_relationsD)
   apply (frule_tac c = "cap.UntypedCap dev r bits idx"
                 in set_cap_not_quite_corres_prequel)
          apply assumption+
@@ -3691,26 +3752,41 @@ lemma setCTE_UntypedCap_corres:
   apply (rule bexI)
    prefer 2
    apply assumption
+  apply (clarsimp simp: pspace_relations_def)
+  apply (subst conj_assoc[symmetric])
   apply clarsimp
-  apply (rename_tac abs conc conc' abs')
-
-  (* FIXME RT: replace this with whatever comes out of VER-1248. *)
-  apply (extract_conjunct \<open>match conclusion in "ghost_relation _ _ _" \<Rightarrow> -\<close>)
+  apply (rule conjI)
+   apply (frule setCTE_pspace_only)
+   apply (clarsimp simp: set_cap_def in_monad split_def get_object_def set_object_def
+                    split: if_split_asm Structures_A.kernel_object.splits)
+  apply (extract_conjunct \<open>match conclusion in "ready_queues_relation _ _" \<Rightarrow> -\<close>)
+   apply (clarsimp simp: ready_queues_relation_def Let_def)
+   apply (rule use_valid[OF _ setCTE_tcbSchedPrevs_of], assumption)
+   apply (rule use_valid[OF _ setCTE_tcbSchedNexts_of], assumption)
+   apply (rule use_valid[OF _ setCTE_ksReadyQueues], assumption)
+   apply (rule use_valid[OF _ setCTE_inQ_opt_pred], assumption)
+   apply (rule use_valid[OF _ set_cap_exst], assumption)
+   apply clarsimp
+  apply (rule conjI)
    apply (frule setCTE_pspace_only)
    apply (clarsimp simp: ghost_relation_typ_at set_cap_a_type_inv data_at_def)
-
-  apply (extract_conjunct \<open>match conclusion in "cdt_list_relation _ _ _" \<Rightarrow> -\<close>)
-   apply (frule mdb_set_cap, frule exst_set_cap)
-   apply (erule use_valid [OF _ setCTE_ctes_of_wp])
-   apply (clarsimp simp: cdt_list_relation_def cte_wp_at_ctes_of split: if_split_asm)
-
-  apply (extract_conjunct \<open>match conclusion in "revokable_relation _ _ _" \<Rightarrow> -\<close>)
+  apply (rule conjI)
+   prefer 2
+   apply (rule conjI)
+    apply (frule mdb_set_cap, frule exst_set_cap)
+    apply (erule use_valid [OF _ setCTE_ctes_of_wp])
+    apply (clarsimp simp: cdt_list_relation_def cte_wp_at_ctes_of split: if_split_asm)
+   apply (rule conjI)
+    prefer 2
+    apply (frule setCTE_pspace_only)
+    apply clarsimp
+    apply (clarsimp simp: set_cap_def in_monad split_def get_object_def set_object_def
+                    split: if_split_asm Structures_A.kernel_object.splits)
    apply (frule set_cap_caps_of_state_monad)
    apply (drule is_original_cap_set_cap)
    apply clarsimp
    apply (erule use_valid [OF _ setCTE_ctes_of_wp])
    apply (clarsimp simp: revokable_relation_def simp del: fun_upd_apply)
-   apply (rename_tac oref cidx cap' cap'' node)
    apply (clarsimp split: if_split_asm)
     apply (frule cte_map_inj_eq)
          prefer 2
@@ -3723,41 +3799,26 @@ lemma setCTE_UntypedCap_corres:
      apply fastforce
     apply clarsimp
     apply (simp add: null_filter_def split: if_split_asm)
-    apply (erule_tac x=oref in allE, erule_tac x=cidx in allE)
+    apply (erule_tac x=aa in allE, erule_tac x=bb in allE)
     apply (case_tac cte)
     apply (clarsimp simp: cte_wp_at_caps_of_state is_cap_simps isCap_simps cte_wp_at_ctes_of)
    apply (simp add: null_filter_def cte_wp_at_caps_of_state split: if_split_asm)
-   apply (erule_tac x=oref in allE, erule_tac x=cidx in allE)
+   apply (erule_tac x=aa in allE, erule_tac x=bb in allE)
    apply (clarsimp)
-
-  apply (extract_conjunct \<open>match conclusion in "cdt_relation _ _ _" \<Rightarrow> -\<close>)
-   apply (clarsimp simp: cdt_relation_def)
-   apply (rename_tac oref cidx)
-   apply (frule set_cap_caps_of_state_monad)
-   apply (frule mdb_set_cap)
-   apply clarsimp
-   apply (erule use_valid [OF _ setCTE_ctes_of_wp])
-   apply (frule cte_wp_at_norm)
-   apply (clarsimp simp:cte_wp_at_ctes_of simp del: fun_upd_apply)
-   apply (drule_tac slot = "cte_map (oref, cidx)" in updateUntypedCap_descendants_of)
-    apply (clarsimp simp:isCap_simps)
-   apply (drule_tac x = oref in spec)
-   apply (drule_tac x = cidx in spec)
-   apply (erule impE)
-    apply (clarsimp simp: cte_wp_at_caps_of_state split:if_splits)
-   apply auto[1]
-
-  apply (extract_conjunct \<open>match conclusion in "sc_replies_relation _ _" \<Rightarrow> -\<close>)
-   apply (clarsimp simp: sc_replies_relation_def
-                  elim!: use_valid[OF _ set_cap.valid_sched_pred])
-   apply (rule use_valid[OF _ setCTE_replies_of'], assumption)
-   apply (rule use_valid[OF _ setCTE_scs_of'], assumption)
-   apply clarsimp
-
-  apply (frule setCTE_pspace_only)
-  apply (clarsimp simp: set_cap_def in_monad split_def get_object_def set_object_def)
-  apply (rename_tac obj ps' s'' obj' kobj; case_tac obj;
-         simp add: fail_def return_def split: if_split_asm)
+  apply (clarsimp simp: cdt_relation_def)
+  apply (frule set_cap_caps_of_state_monad)
+  apply (frule mdb_set_cap)
+  apply clarsimp
+  apply (erule use_valid [OF _ setCTE_ctes_of_wp])
+  apply (frule cte_wp_at_norm)
+  apply (clarsimp simp:cte_wp_at_ctes_of simp del: fun_upd_apply)
+  apply (drule_tac slot = "cte_map (aa,bb)" in updateUntypedCap_descendants_of)
+   apply (clarsimp simp:isCap_simps)
+  apply (drule_tac x = aa in spec)
+  apply (drule_tac x = bb in spec)
+  apply (erule impE)
+   apply (clarsimp simp: cte_wp_at_caps_of_state split:if_splits)
+  apply auto
   done
 
 lemma getCTE_get:
@@ -3797,7 +3858,20 @@ lemma setUntypedCapAsFull_corres:
   done
 
 (* FIXME: SELFOUR-421 move *)
-lemmas isUntypedCap_simps[simp] = isUntypedCap_def[split_simps capability.split]
+lemma isUntypedCap_simps[simp]:
+  "isUntypedCap (capability.UntypedCap uu uv uw ux) = True"
+  "isUntypedCap (capability.NullCap) = False"
+  "isUntypedCap (capability.EndpointCap v va vb vc vd ve) = False"
+  "isUntypedCap (capability.NotificationCap v va vb vc) = False"
+  "isUntypedCap (capability.ReplyCap v1 v2 v3) = False"
+  "isUntypedCap (capability.CNodeCap x1 x2 x3 x4) = False"
+  "isUntypedCap (capability.ThreadCap v) = False"
+  "isUntypedCap (capability.DomainCap) = False"
+  "isUntypedCap (capability.IRQControlCap) = False"
+  "isUntypedCap (capability.IRQHandlerCap y1) = False"
+  "isUntypedCap (capability.Zombie v va1 vb1) = False"
+  "isUntypedCap (capability.ArchObjectCap z) = False"
+  by (simp_all add: isUntypedCap_def split: capability.splits)
 
 lemma cap_relation_masked_as_full:
   "\<lbrakk>cap_relation src_cap src_cap';cap_relation c c'\<rbrakk> \<Longrightarrow>
@@ -4307,7 +4381,6 @@ lemma irq_control_preserve:
   apply (simp add:dom misc)+
   done
 end
-
 locale mdb_inv_preserve =
   fixes m m'
   assumes dom: "\<And>x. (x\<in> dom m)  = (x\<in> dom m')"
@@ -4315,6 +4388,7 @@ locale mdb_inv_preserve =
   isUntypedCap (cteCap cte) = isUntypedCap (cteCap cte')
   \<and> isNullCap (cteCap cte) = isNullCap (cteCap cte')
   \<and> isReplyCap (cteCap cte) = isReplyCap (cteCap cte')
+  \<and> (isReplyCap (cteCap cte) \<longrightarrow> capReplyMaster (cteCap cte) = capReplyMaster (cteCap cte'))
   \<and> isNotificationCap (cteCap cte)  = isNotificationCap (cteCap cte')
   \<and> (isNotificationCap (cteCap cte) \<longrightarrow> (capNtfnBadge (cteCap cte) = capNtfnBadge (cteCap cte')))
   \<and> (isEndpointCap (cteCap cte) = isEndpointCap (cteCap cte'))
@@ -4421,44 +4495,59 @@ lemma descendants_of:
   done
 
 lemma by_products:
-  "no_0 m = no_0 m' \<and> mdb_chain_0 m = mdb_chain_0 m'\<and> valid_nullcaps m = valid_nullcaps m'"
-  apply (intro conjI)
-    apply (clarsimp simp:no_0_def)
-    apply (rule ccontr)
-    apply (simp add:dom_in)
-    apply (subst (asm) dom[symmetric])
-    apply fastforce
+  "reply_masters_rvk_fb m = reply_masters_rvk_fb m'
+ \<and> no_0 m = no_0 m' \<and> mdb_chain_0 m = mdb_chain_0 m'
+ \<and> valid_nullcaps m = valid_nullcaps m'"
+apply (intro conjI)
+  apply (simp add:ran_dom reply_masters_rvk_fb_def mdb_inv_preserve_def dom misc sameRegion mdb_next)
+    apply (rule iffI)
+    apply clarsimp
+    apply (drule_tac x = y in bspec)
+     apply (rule iffD2[OF dom])
+     apply clarsimp
+    apply (frule iffD2[OF dom,OF domI],rotate_tac)
+    apply (clarsimp simp:misc)+
+    apply (drule_tac x = y in bspec)
+     apply (rule iffD1[OF dom])
+     apply clarsimp
+    apply (frule iffD1[OF dom,OF domI],rotate_tac)
+   apply (clarsimp simp:misc)+
+   apply (clarsimp simp:no_0_def)
+   apply (rule ccontr)
+   apply (simp add:dom_in)
+   apply (subst (asm) dom[symmetric])
+   apply fastforce
    apply (rule iffI)
-    apply (clarsimp simp:mdb_chain_0_def)
-    apply (drule_tac x =x in bspec)
-     apply (rule iffD2[OF dom],clarsimp)
-    apply (erule_tac iffD1[OF connect_eqv_singleE,rotated])
-    apply (cut_tac p = p in mdb_next)
-    apply (clarsimp simp: mdb_next_rel_def)
    apply (clarsimp simp:mdb_chain_0_def)
-   apply (drule_tac x =x in bspec)
-    apply (rule iffD1[OF dom],clarsimp)
-   apply (erule_tac iffD1[OF connect_eqv_singleE,rotated])
-   apply (cut_tac p = p in mdb_next)
-   apply (clarsimp simp: mdb_next_rel_def)
-  apply (simp add:valid_nullcaps_def)
-  apply (rule forall_eq,clarsimp)+
-  apply (rule iffI)
-   apply clarsimp
-   apply (frule iffD2[OF dom,OF domI])
-   apply (clarsimp)
-   apply (case_tac y)
-   apply (drule misc)
-    apply assumption
-   apply (clarsimp simp:isCap_simps)
-  apply clarsimp
-  apply (frule iffD1[OF dom,OF domI])
-  apply (clarsimp)
-  apply (case_tac y)
-  apply (drule misc)
-   apply assumption
-  apply (clarsimp simp:isCap_simps)
-  done
+      apply (drule_tac x =x in bspec)
+      apply (rule iffD2[OF dom],clarsimp)
+      apply (erule_tac iffD1[OF connect_eqv_singleE,rotated])
+      apply (cut_tac p = p in mdb_next)
+      apply (clarsimp simp: mdb_next_rel_def)
+    apply (clarsimp simp:mdb_chain_0_def)
+      apply (drule_tac x =x in bspec)
+      apply (rule iffD1[OF dom],clarsimp)
+      apply (erule_tac iffD1[OF connect_eqv_singleE,rotated])
+      apply (cut_tac p = p in mdb_next)
+      apply (clarsimp simp: mdb_next_rel_def)
+   apply (simp add:valid_nullcaps_def)
+   apply (rule forall_eq,clarsimp)+
+     apply (rule iffI)
+      apply clarsimp
+      apply (frule iffD2[OF dom,OF domI])
+      apply (clarsimp)
+      apply (case_tac y)
+      apply (drule misc)
+        apply assumption
+        apply (clarsimp simp:isCap_simps)
+     apply clarsimp
+     apply (frule iffD1[OF dom,OF domI])
+     apply (clarsimp)
+     apply (case_tac y)
+     apply (drule misc)
+       apply assumption
+       apply (clarsimp simp:isCap_simps)
+done
 
 end
 
@@ -4503,7 +4592,7 @@ lemma updateCap_cte_wp_at':
         updateCap ptr cap \<lbrace>\<lambda>rv s. Q (cte_wp_at' P' p s)\<rbrace>"
   apply (simp add:updateCap_def cte_wp_at_ctes_of)
   apply (wp setCTE_ctes_of_wp getCTE_wp)
-  apply (clarsimp simp: cte_wp_at_ctes_of)
+  apply (clarsimp simp: cte_wp_at_ctes_of split del: if_split)
   apply (case_tac cte, auto split: if_split)
   done
 
@@ -4597,6 +4686,22 @@ lemma updateCapFreeIndex_class_links:
   apply (subgoal_tac "mdb_inv_preserve (Q (ctes_of s)) (Q (modify_map (ctes_of s) src
               (cteCap_update (\<lambda>_. capFreeIndex_update (\<lambda>_. index) (cteCap srcCTE)))))")
     apply (drule mdb_inv_preserve.preserve_stuff)
+    apply simp
+  apply (rule preserve)
+  apply (rule mdb_inv_preserve_updateCap)
+    apply (clarsimp simp:cte_wp_at_ctes_of)+
+done
+
+lemma updateCapFreeIndex_reply_masters_rvk_fb:
+  assumes preserve:"\<And>m m'. mdb_inv_preserve m m' \<Longrightarrow> mdb_inv_preserve (Q m) (Q m')"
+  shows
+ "\<lbrace>\<lambda>s. P (reply_masters_rvk_fb (Q (ctes_of s))) \<and> cte_wp_at' (\<lambda>c. c = srcCTE \<and> isUntypedCap (cteCap c)) src s\<rbrace>
+  updateCap src (capFreeIndex_update (\<lambda>_. index) (cteCap srcCTE))
+ \<lbrace>\<lambda>r s. P (reply_masters_rvk_fb (Q (ctes_of s)))\<rbrace>"
+  apply (wp updateCap_ctes_of_wp)
+  apply (subgoal_tac "mdb_inv_preserve (Q (ctes_of s)) (Q (modify_map (ctes_of s) src
+              (cteCap_update (\<lambda>_. capFreeIndex_update (\<lambda>_. index) (cteCap srcCTE)))))")
+    apply (drule mdb_inv_preserve.by_products)
     apply simp
   apply (rule preserve)
   apply (rule mdb_inv_preserve_updateCap)
@@ -4797,6 +4902,19 @@ setUntypedCapAsFull (cteCap srcCTE) cap src
   apply clarsimp
 done
 
+lemma setUntypedCapAsFull_reply_masters_rvk_fb:
+  assumes preserve:"\<And>m m'. mdb_inv_preserve m m' \<Longrightarrow> mdb_inv_preserve (Q m) (Q m')"
+  shows
+ "\<lbrace>\<lambda>s. P (reply_masters_rvk_fb (Q (ctes_of s))) \<and> cte_wp_at' (\<lambda>c. c = srcCTE) src s\<rbrace>
+setUntypedCapAsFull (cteCap srcCTE) cap src
+ \<lbrace>\<lambda>r s. P (reply_masters_rvk_fb (Q (ctes_of s)))\<rbrace>"
+  apply (clarsimp simp:setUntypedCapAsFull_def split:if_splits,intro conjI impI)
+    apply (wp updateCapFreeIndex_reply_masters_rvk_fb)
+    apply (clarsimp simp:cte_wp_at_ctes_of preserve)+
+  apply wp
+  apply clarsimp
+done
+
 lemma modify_map_eq[simp]:
   "\<lbrakk>m slot = Some srcCTE; cap = cteCap srcCTE\<rbrakk>
    \<Longrightarrow>(modify_map m slot (cteCap_update (\<lambda>_. cap))) = m"
@@ -4823,10 +4941,11 @@ lemma setUntypedCapAsFull_valid_cap:
   "\<lbrace>valid_cap' cap and cte_wp_at' ((=) srcCTE) slot\<rbrace>
    setUntypedCapAsFull (cteCap srcCTE) c slot
    \<lbrace>\<lambda>r. valid_cap' cap\<rbrace>"
-  apply (clarsimp simp:setUntypedCapAsFull_def updateCap_def split:if_splits)
+  apply (clarsimp simp:setUntypedCapAsFull_def split:if_splits)
   apply (intro conjI impI)
-   apply wpsimp+
-  done
+    apply (clarsimp simp:updateCap_def)
+  apply (wp|clarsimp)+
+done
 
 lemma cteCap_update_simps:
   "cteCap_update f srcCTE = CTE (f (cteCap srcCTE)) (cteMDBNode srcCTE)"
@@ -4910,41 +5029,42 @@ crunch set_untyped_cap_as_full
 
 lemma updateMDB_the_lot':
   assumes "(x, s'') \<in> fst (updateMDB p f s')"
-  assumes "pspace_relation (kheap s) (ksPSpace s')"
-  assumes "pspace_aligned' s'" "pspace_distinct' s'" "no_0 (ctes_of s')"
+  assumes "pspace_relations (ekheap sa) (kheap s) (ksPSpace s')"
+  assumes "pspace_aligned' s'" "pspace_distinct' s'" "no_0 (ctes_of s')" "ekheap s = ekheap sa"
   shows "ctes_of s'' = modify_map (ctes_of s') p (cteMDBNode_update f) \<and>
          ksMachineState s'' = ksMachineState s' \<and>
          ksWorkUnitsCompleted s'' = ksWorkUnitsCompleted s' \<and>
          ksCurThread s'' = ksCurThread s' \<and>
          ksIdleThread s'' = ksIdleThread s' \<and>
-         ksIdleSC s'' = ksIdleSC s' \<and>
          ksReadyQueues s'' = ksReadyQueues s' \<and>
-         ksReleaseQueue s'' = ksReleaseQueue s' \<and>
          ksSchedulerAction s'' = ksSchedulerAction s' \<and>
          ksInterruptState s'' = ksInterruptState s' \<and>
          ksArchState s'' = ksArchState s' \<and>
          gsUserPages s'' = gsUserPages s' \<and>
          gsCNodes s'' = gsCNodes s' \<and>
-         pspace_relation (kheap s) (ksPSpace s'') \<and>
+         pspace_relations (ekheap s) (kheap s) (ksPSpace s'') \<and>
          pspace_aligned' s'' \<and> pspace_distinct' s'' \<and>
          no_0 (ctes_of s'') \<and>
          ksDomScheduleIdx s'' = ksDomScheduleIdx s' \<and>
          ksDomSchedule s''    = ksDomSchedule s' \<and>
          ksCurDomain s''      = ksCurDomain s' \<and>
          ksDomainTime s''     = ksDomainTime s' \<and>
-         ksConsumedTime s''   = ksConsumedTime s' \<and>
-         ksCurTime s''        = ksCurTime s' \<and>
-         ksCurSc s''          = ksCurSc s' \<and>
-         ksReprogramTimer s'' = ksReprogramTimer s' \<and>
-         replyPrevs_of s'' = replyPrevs_of s' \<and>
-         scReplies_of s'' = scReplies_of s'"
-  by (rule updateMDB_the_lot; fastforce intro: assms)
+         tcbSchedNexts_of s'' = tcbSchedNexts_of s' \<and>
+         tcbSchedPrevs_of s'' = tcbSchedPrevs_of s' \<and>
+         (\<forall>domain priority.
+            (inQ domain priority |< tcbs_of' s'') = (inQ domain priority |< tcbs_of' s'))"
+  apply (rule updateMDB_the_lot)
+      using assms
+      apply (fastforce simp: pspace_relations_def)+
+   done
 
 lemma cte_map_inj_eq':
-  "\<lbrakk> cte_map p = cte_map p';
-     cte_at p s \<and> cte_at p' s \<and> valid_objs s \<and> pspace_aligned s \<and> pspace_distinct s\<rbrakk>
+  "\<lbrakk>(cte_map p = cte_map p');
+   cte_at p s \<and> cte_at p' s \<and>
+   valid_objs s \<and> pspace_aligned s \<and> pspace_distinct s\<rbrakk>
   \<Longrightarrow> p = p'"
-  by (rule cte_map_inj_eq; fastforce)
+  apply (rule cte_map_inj_eq; fastforce)
+  done
 
 context begin interpretation Arch . (*FIXME: arch-split*)
 lemma cteInsert_corres:
@@ -5000,12 +5120,13 @@ lemma cteInsert_corres:
                apply (simp+)[3]
             apply (clarsimp simp: corres_underlying_def state_relation_def
                                   in_monad valid_mdb'_def valid_mdb_ctes_def)
-            apply (drule (22) set_cap_not_quite_corres)
-              apply fastforce
+            apply (drule (1) pspace_relationsD)
+            apply (drule (18) set_cap_not_quite_corres)
              apply (rule refl)
             apply (elim conjE exE)
             apply (rule bind_execI, assumption)
-            apply (prop_tac "mdb_insert_abs (cdt a) src dest")
+            apply (subgoal_tac "mdb_insert_abs (cdt a) src dest")
+             prefer 2
              apply (erule mdb_insert_abs.intro)
               apply (rule mdb_Null_None)
                apply (simp add: op_equal)
@@ -5013,34 +5134,32 @@ lemma cteInsert_corres:
              apply (rule mdb_Null_descendants)
               apply (simp add: op_equal)
              apply simp
-            apply (prop_tac "no_mloop (cdt a)")
+            apply (subgoal_tac "no_mloop (cdt a)")
+             prefer 2
              apply (simp add: valid_mdb_def)
-            apply (clarsimp simp: exec_gets update_cdt_def bind_assoc
-                                  set_cdt_def exec_get exec_put set_original_def modify_def
+            apply (clarsimp simp: exec_gets update_cdt_def bind_assoc set_cdt_def
+                                  exec_get exec_put set_original_def modify_def
                         simp del: fun_upd_apply
-                   | (rule bind_execI[where f="cap_insert_ext x y z i p" for x y z i p],
-                      clarsimp simp: exec_gets exec_get put_def
-                                     mdb_insert_abs.cap_insert_ext_det_def2 update_cdt_list_def
-                                     set_cdt_list_def,
-                      rule refl))+
+                   | (rule bind_execI[where f="cap_insert_ext x y z i p" for x y z i p], clarsimp simp: exec_gets exec_get put_def mdb_insert_abs.cap_insert_ext_det_def2 update_cdt_list_def set_cdt_list_def, rule refl))+
             apply (clarsimp simp: put_def state_relation_def)
             apply (drule updateCap_stuff)
             apply clarsimp
             apply (drule (3) updateMDB_the_lot', simp, simp, elim conjE)
             apply (drule (3) updateMDB_the_lot', simp, simp, elim conjE)
-            apply (drule (3) updateMDB_the_lot', simp, simp, elim conjE)
+            apply (drule (3) updateMDB_the_lot', simp, simp,  elim conjE)
             apply (clarsimp simp: cte_wp_at_ctes_of nullPointer_def
                              prev_update_modify_mdb_relation)
-            apply (prop_tac "cte_map dest \<noteq> 0")
-             apply (clarsimp simp: valid_mdb'_def
-                              valid_mdb_ctes_def no_0_def)
-            apply (prop_tac "cte_map src \<noteq> 0")
-             apply (clarsimp simp: valid_mdb'_def
-                              valid_mdb_ctes_def no_0_def)
+            apply (subgoal_tac "cte_map dest \<noteq> 0")
+             prefer 2
+             apply (clarsimp simp: valid_mdb'_def valid_mdb_ctes_def no_0_def)
+            apply (subgoal_tac "cte_map src \<noteq> 0")
+             prefer 2
+             apply (clarsimp simp: valid_mdb'_def valid_mdb_ctes_def no_0_def)
             apply (thin_tac "ksMachineState t = p" for p t)+
             apply (thin_tac "ksCurThread t = p" for p t)+
             apply (thin_tac "ksIdleThread t = p" for p t)+
             apply (thin_tac "ksSchedulerAction t = p" for p t)+
+            apply (clarsimp simp: pspace_relations_def)
 
             apply (rule conjI)
              apply (clarsimp simp: ghost_relation_typ_at set_cap_a_type_inv data_at_def)
@@ -5055,11 +5174,13 @@ lemma cteInsert_corres:
               apply (case_tac "rv'")
               apply (rename_tac dest_node)
               apply (clarsimp simp: in_set_cap_cte_at_swp)
-              apply (prop_tac "cte_at src a \<and> is_derived (cdt a) src c src_cap")
+              apply (subgoal_tac "cte_at src a \<and> is_derived (cdt a) src c src_cap")
+               prefer 2
                apply (fastforce simp: cte_wp_at_def)
               apply (erule conjE)
-              apply (prop_tac "mdb_insert (ctes_of b) (cte_map src) (maskedAsFull src_cap' c') src_node
+              apply (subgoal_tac "mdb_insert (ctes_of b) (cte_map src) (maskedAsFull src_cap' c') src_node
                                  (cte_map dest) NullCap dest_node")
+               prefer 2
                apply (rule mdb_insert.intro)
                  apply (rule mdb_ptr.intro)
                   apply (rule vmdb.intro, simp add: valid_mdb_ctes_def)
@@ -5125,7 +5246,8 @@ lemma cteInsert_corres:
                  subgoal by(fastforce)
                 apply(simp)
                 apply(rule impI)
-                apply(prop_tac "cte_at ca a")
+                apply(subgoal_tac "cte_at ca a")
+                 prefer 2
                  apply(rule cte_at_next_slot)
                     apply(simp_all)[4]
                 apply(clarsimp simp: modify_map_def const_def)
@@ -5211,7 +5333,7 @@ lemma cteInsert_corres:
                   apply (subst is_derived_eq[symmetric]; assumption)
                  apply assumption
                 subgoal by (clarsimp simp: cte_wp_at_def is_derived_def is_cap_simps cap_master_cap_simps
-                                    dest!: cap_master_cap_eqDs)
+                                    dest!:cap_master_cap_eqDs)
                apply (subgoal_tac "is_original_cap a src = mdbRevocable src_node")
                 apply (frule(4) iffD1[OF is_derived_eq])
                 apply (drule_tac src_cap' = src_cap' in
@@ -5222,8 +5344,7 @@ lemma cteInsert_corres:
                apply simp
                apply (erule impE)
                 apply (clarsimp simp: null_filter_def cte_wp_at_caps_of_state split: if_splits)
-                subgoal by (clarsimp simp: masked_as_full_def is_cap_simps free_index_update_def
-                                    split: if_splits)
+                subgoal by (clarsimp simp: masked_as_full_def is_cap_simps free_index_update_def split: if_splits)
                apply(simp)
 
               apply(subgoal_tac "cdt_list (a) src = []")
@@ -5271,9 +5392,12 @@ lemma cteInsert_corres:
                    apply(case_tac z)
                    apply(erule_tac x="(aa, bb)" in allE)+
                    subgoal by(fastforce)
-                  apply(drule cte_map_inj_eq'; simp)
-                 apply(drule cte_map_inj_eq'; simp)
-                apply(drule cte_map_inj_eq'; simp)
+                  apply(drule cte_map_inj_eq')
+                   apply(simp_all)[2]
+                 apply(drule cte_map_inj_eq')
+                  apply(simp_all)[2]
+                apply(drule cte_map_inj_eq')
+                 apply(simp_all)[2]
                apply(erule_tac x="(aa, bb)" in allE)+
                subgoal by(fastforce)
 
@@ -5332,7 +5456,8 @@ lemma cteInsert_corres:
              apply (clarsimp simp: revokable_relation_def  split: if_split)
              apply (rule conjI)
               apply clarsimp
-              apply (prop_tac "mdbRevocable node = revokable' (cteCap srcCTE) c'")
+              apply (subgoal_tac "mdbRevocable node = revokable' (cteCap srcCTE) c'")
+               prefer 2
                apply (case_tac rv')
                subgoal by (clarsimp simp add: const_def modify_map_def split: if_split_asm)
               apply simp
@@ -5343,12 +5468,13 @@ lemma cteInsert_corres:
                 apply assumption
                apply assumption
               subgoal by (clarsimp simp: cap_master_cap_simps cte_wp_at_def is_derived_def is_cap_simps
-                                  split: if_splits dest!:cap_master_cap_eqDs)
+                                  split:if_splits dest!:cap_master_cap_eqDs)
              apply clarsimp
              apply (case_tac srcCTE)
              apply (case_tac rv')
              apply clarsimp
-             apply (prop_tac "\<exists>cap' node'. ctes_of b (cte_map (aa,bb)) = Some (CTE cap' node')")
+             apply (subgoal_tac "\<exists>cap' node'. ctes_of b (cte_map (aa,bb)) = Some (CTE cap' node')")
+              prefer 2
               apply (clarsimp simp: modify_map_def split: if_split_asm)
               apply (case_tac z)
               subgoal by clarsimp
@@ -5356,11 +5482,11 @@ lemma cteInsert_corres:
              apply (drule set_cap_caps_of_state_monad)+
              apply (subgoal_tac "null_filter (caps_of_state a) (aa,bb) \<noteq> None")
               prefer 2
-              subgoal by (clarsimp simp: cte_wp_at_caps_of_state null_filter_def
-                                  split: if_splits)
+              subgoal by (clarsimp simp: cte_wp_at_caps_of_state null_filter_def split: if_splits)
 
              apply clarsimp
-             apply (prop_tac "cte_at (aa,bb) a")
+             apply (subgoal_tac "cte_at (aa,bb) a")
+              prefer 2
               apply (drule null_filter_caps_of_stateD)
               apply (erule cte_wp_at_weakenE, rule TrueI)
              apply (subgoal_tac "mdbRevocable node = mdbRevocable node'")
@@ -5368,7 +5494,6 @@ lemma cteInsert_corres:
              apply (subgoal_tac "cte_map (aa,bb) \<noteq> cte_map dest")
               subgoal by (clarsimp simp: modify_map_def split: if_split_asm)
              apply (erule (5) cte_map_inj)
-
             apply (wp set_untyped_cap_full_valid_objs set_untyped_cap_as_full_valid_mdb
                set_untyped_cap_as_full_cte_wp_at setUntypedCapAsFull_valid_cap
                setUntypedCapAsFull_cte_wp_at | clarsimp simp: cte_wp_at_caps_of_state| wps)+
@@ -5385,11 +5510,13 @@ lemma cteInsert_corres:
   apply (case_tac "rv'")
   apply (rename_tac dest_node)
   apply (clarsimp simp: in_set_cap_cte_at_swp)
-  apply (prop_tac "cte_at src a \<and> is_derived (cdt a) src c src_cap")
+  apply (subgoal_tac "cte_at src a \<and> is_derived (cdt a) src c src_cap")
+   prefer 2
    subgoal by (fastforce simp: cte_wp_at_def)
   apply (erule conjE)
-  apply (prop_tac "mdb_insert (ctes_of b) (cte_map src) (maskedAsFull src_cap' c') src_node
+  apply (subgoal_tac "mdb_insert (ctes_of b) (cte_map src) (maskedAsFull src_cap' c') src_node
                                  (cte_map dest) NullCap dest_node")
+   prefer 2
    apply (rule mdb_insert.intro)
      apply (rule mdb_ptr.intro)
       subgoal by (rule vmdb.intro, simp add: valid_mdb_ctes_def)
@@ -5408,10 +5535,12 @@ lemma cteInsert_corres:
    apply (rule mdb_insert_der_axioms.intro)
    apply (simp add: is_derived_eq)
   apply (simp (no_asm_simp) add: cdt_relation_def split: if_split)
-  apply (prop_tac "descendants_of dest (cdt a) = {}")
+  apply (subgoal_tac "descendants_of dest (cdt a) = {}")
+   prefer 2
    apply (drule mdb_insert.dest_no_descendants)
-   subgoal by (fastforce simp add: cdt_relation_def)
-  apply (prop_tac "mdb_insert_abs (cdt a) src dest")
+   subgoal by (fastforce simp add: cdt_relation_def simp del: split_paired_All)
+  apply (subgoal_tac "mdb_insert_abs (cdt a) src dest")
+   prefer 2
    apply (erule mdb_insert_abs.intro)
     apply (rule mdb_None)
       apply (erule(1) mdb_insert.descendants_not_dest)
@@ -5444,11 +5573,11 @@ lemma cteInsert_corres:
                           dest!:cap_master_cap_eqDs)
     apply (subgoal_tac "is_original_cap a src = mdbRevocable src_node")
      prefer 2
-     apply (simp add: revokable_relation_def)
+     apply (simp add: revokable_relation_def del: split_paired_All)
      apply (erule_tac x=src in allE)
      apply (erule impE)
       apply (clarsimp simp: null_filter_def cte_wp_at_caps_of_state cap_master_cap_simps
-                     split: if_splits dest!:cap_master_cap_eqDs)
+       split: if_splits dest!:cap_master_cap_eqDs)
       subgoal by (clarsimp simp: masked_as_full_def is_cap_simps free_index_update_def split: if_splits)
      subgoal by simp
     subgoal by clarsimp
@@ -5458,7 +5587,7 @@ lemma cteInsert_corres:
           prefer 2
           apply assumption
          apply (simp_all)[6]
-   apply (simp add: cdt_relation_def split: if_split)
+   apply (simp add: cdt_relation_def split: if_split del: split_paired_All)
    apply clarsimp
    apply (drule (5) cte_map_inj)+
    apply simp
@@ -5486,7 +5615,7 @@ lemma cteInsert_corres:
                         dest!:cap_master_cap_eqDs)
    apply (subgoal_tac "is_original_cap a src = mdbRevocable src_node")
     subgoal by simp
-   apply (simp add: revokable_relation_def)
+   apply (simp add: revokable_relation_def del: split_paired_All)
    apply (erule_tac x=src in allE)
    apply (erule impE)
     apply (clarsimp simp: null_filter_def cte_wp_at_caps_of_state split: if_splits)
@@ -5496,13 +5625,12 @@ lemma cteInsert_corres:
   apply (frule_tac p="(aa, bb)" in in_set_cap_cte_at)
   apply (rule conjI)
    apply (clarsimp simp: descendants_of_eq')
-   subgoal by (simp add: cdt_relation_def)
+   subgoal by (simp add: cdt_relation_def del: split_paired_All)
   apply (clarsimp simp: descendants_of_eq')
-  subgoal by (simp add: cdt_relation_def)
+  subgoal by (simp add: cdt_relation_def del: split_paired_All)
   done
 
-(* FIXME RT: This is the sort of crap we should get rid of when possible, or
-   at least make it more localised. VER-1250 *)
+
 declare if_split [split]
 
 lemma updateCap_no_0:
@@ -6468,10 +6596,10 @@ lemma cteSwap_corres:
   apply (clarsimp simp: corres_underlying_def in_monad
                         state_relation_def)
   apply (clarsimp simp: valid_mdb'_def)
-  apply (drule (16) set_cap_not_quite_corres)
-          apply fastforce
-         apply (erule cte_wp_at_weakenE, rule TrueI)
-        apply assumption+
+  apply (drule(1) pspace_relationsD)
+  apply (drule (12) set_cap_not_quite_corres)
+      apply (erule cte_wp_at_weakenE, rule TrueI)
+     apply assumption+
    apply (rule refl)
   apply (elim exE conjE)
   apply (rule bind_execI, assumption)
@@ -6489,9 +6617,8 @@ lemma cteSwap_corres:
                          use_valid [OF _ set_cap_distinct]
                          cte_wp_at_weakenE)
   apply (elim conjE)
-  apply (drule (18) set_cap_not_quite_corres)
-        apply simp
-       apply fastforce
+  apply (drule (14) set_cap_not_quite_corres)
+       apply simp
       apply assumption+
    apply (rule refl)
   apply (elim exE conjE)
@@ -6505,19 +6632,20 @@ lemma cteSwap_corres:
   apply (simp cong: option.case_cong)
   apply (drule updateCap_stuff, elim conjE, erule(1) impE)
   apply (drule (2) updateMDB_the_lot')
-    apply (erule (1) impE, assumption)
-   apply (fastforce simp only: no_0_modify_map)
+     apply (erule (1) impE, assumption)
+    apply (fastforce simp only: no_0_modify_map)
+   apply assumption
   apply (elim conjE TrueE, simp only:)
-  apply (drule (2) updateMDB_the_lot', assumption, fastforce simp only: no_0_modify_map)
-  apply (drule in_getCTE, clarsimp)
-  apply (drule (2) updateMDB_the_lot', assumption, fastforce simp only: no_0_modify_map)
+  apply (drule (2) updateMDB_the_lot', fastforce, simp only: no_0_modify_map, assumption)
+  apply (drule in_getCTE, elim conjE, simp only:)
+  apply (drule (2) updateMDB_the_lot', fastforce, simp only: no_0_modify_map, assumption)
   apply (elim conjE TrueE, simp only:)
-  apply (drule (2) updateMDB_the_lot', assumption, fastforce simp only: no_0_modify_map)
+  apply (drule (2) updateMDB_the_lot', fastforce, simp only: no_0_modify_map, assumption)
   apply (elim conjE TrueE, simp only:)
-  apply (drule (2) updateMDB_the_lot', assumption, fastforce simp only: no_0_modify_map)
+  apply (drule (2) updateMDB_the_lot', fastforce, simp only: no_0_modify_map, assumption)
   apply (elim conjE TrueE, simp only:)
-  apply (drule (2) updateMDB_the_lot', assumption, fastforce simp only: no_0_modify_map)
-  apply (simp only: refl)
+  apply (drule (2) updateMDB_the_lot', fastforce, simp only: no_0_modify_map, assumption)
+  apply (simp only: pspace_relations_def refl)
   apply (rule conjI, rule TrueI)+
   apply (thin_tac "ksMachineState t = p" for t p)+
   apply (thin_tac "ksCurThread t = p" for t p)+
@@ -6551,7 +6679,6 @@ lemma cteSwap_corres:
      apply (erule weak_derived_sym')
     apply (erule weak_derived_sym')
    apply assumption
-
   apply (rule conjI)
    subgoal by (simp only: simp_thms ghost_relation_typ_at set_cap_a_type_inv ARM.data_at_def)
   apply (thin_tac "ksMachineState t = p" for t p)+
@@ -6569,6 +6696,7 @@ lemma cteSwap_corres:
   apply (thin_tac "domain_index t = p" for t p)+
   apply (thin_tac "domain_list t = p" for t p)+
   apply (thin_tac "domain_time t = p" for t p)+
+  apply (thin_tac "ekheap t = p" for t p)+
   apply (thin_tac "scheduler_action t = p" for t p)+
   apply (thin_tac "ksArchState t = p" for t p)+
   apply (thin_tac "gsCNodes t = p" for t p)+
@@ -6577,6 +6705,7 @@ lemma cteSwap_corres:
   apply (thin_tac "ksIdleThread t = p" for t p)+
   apply (thin_tac "gsUserPages t = p" for t p)+
   apply (thin_tac "pspace_relation s s'" for s s')+
+  apply (thin_tac "ekheap_relation e p" for e p)+
   apply (thin_tac "interrupt_state_relation n s s'" for n s s')+
   apply (thin_tac "(s,s') \<in> arch_state_relation" for s s')+
   apply(subst conj_assoc[symmetric])
@@ -6718,35 +6847,54 @@ lemma cteSwap_corres:
     apply(fastforce split: option.split)
    apply(simp)
   apply(frule finite_depth)
-  apply(frule mdb_swap.n_next; (simp (no_asm_simp))?)
+  apply(frule mdb_swap.n_next)
+   apply(simp)
   apply(case_tac "(aa, bb)=src")
    apply(case_tac "next_slot dest (cdt_list (a)) (cdt a) = Some src")
     apply(simp)
     apply(erule_tac x="fst dest" in allE, erule_tac x="snd dest" in allE)
     apply(simp)
    apply(simp)
-   apply(case_tac "next_slot dest (cdt_list (a)) (cdt a)"; (simp (no_asm_simp))?)
+   apply(case_tac "next_slot dest (cdt_list (a)) (cdt a)")
+    apply(simp)
+   apply(simp)
    apply(erule_tac x="fst dest" in allE, erule_tac x="snd dest" in allE)
    apply(simp)
    apply(subgoal_tac "mdbNext dest_node \<noteq> cte_map src")
     apply(simp)
    apply(simp)
-   apply(rule_tac s=a in cte_map_inj; (simp (no_asm_simp))?)
-    apply(rule cte_at_next_slot'; (simp (no_asm_simp))?)
-   apply(erule cte_wp_at_weakenE, rule TrueI)
+   apply(rule_tac s=a in cte_map_inj)
+        apply(simp)
+       apply(rule cte_at_next_slot')
+          apply(simp)
+         apply(simp)
+        apply(simp)
+       apply(simp)
+      apply(erule cte_wp_at_weakenE, rule TrueI)
+     apply(simp_all)[3]
   apply(case_tac "(aa, bb)=dest")
    apply(case_tac "next_slot src (cdt_list (a)) (cdt a) = Some dest")
     apply(simp)
     apply(erule_tac x="fst src" in allE, erule_tac x="snd src" in allE)
     apply(simp)
    apply(simp)
-   apply(case_tac "next_slot src (cdt_list (a)) (cdt a)"; (simp (no_asm_simp))?)
+   apply(case_tac "next_slot src (cdt_list (a)) (cdt a)")
+    apply(simp)
+   apply(simp)
    apply(erule_tac x="fst src" in allE, erule_tac x="snd src" in allE)
    apply(simp)
-   apply(subgoal_tac "mdbNext src_node \<noteq> cte_map dest"; (simp (no_asm_simp))?)
-   apply(rule_tac s=a in cte_map_inj; (simp (no_asm_simp))?)
-    apply(rule cte_at_next_slot'; (simp (no_asm_simp))?)
-   apply(erule cte_wp_at_weakenE, rule TrueI)
+   apply(subgoal_tac "mdbNext src_node \<noteq> cte_map dest")
+    apply(simp)
+   apply(simp)
+   apply(rule_tac s=a in cte_map_inj)
+        apply(simp)
+       apply(rule cte_at_next_slot')
+          apply(simp)
+         apply(simp)
+        apply(simp)
+       apply(simp)
+      apply(erule cte_wp_at_weakenE, rule TrueI)
+     apply(simp_all)[3]
   apply(case_tac "next_slot (aa, bb) (cdt_list (a)) (cdt a) = Some src")
    apply(simp)
    apply(erule_tac x=aa in allE, erule_tac x=bb in allE)
@@ -6757,20 +6905,24 @@ lemma cteSwap_corres:
                         cte_map (aa, bb) = mdbPrev src_node")
      apply(clarsimp)
     apply(rule conjI)
-     apply(rule cte_map_inj; (simp (no_asm_simp))?)
+     apply(rule cte_map_inj)
+          apply(simp_all)[6]
      apply(erule cte_wp_at_weakenE, simp)
     apply(rule conjI)
-     apply(rule cte_map_inj; (simp (no_asm_simp))?)
-     apply(erule cte_wp_at_weakenE, simp (no_asm_simp))
-    apply(frule mdb_swap.m_exists, simp (no_asm_simp))
+     apply(rule cte_map_inj)
+          apply(simp_all)[6]
+     apply(erule cte_wp_at_weakenE, simp)
+    apply(frule mdb_swap.m_exists)
+     apply(simp)
     apply(clarsimp)
     apply(frule_tac cte="CTE cap' node'" in valid_mdbD1')
       apply(clarsimp)
-     apply(simp (no_asm_simp) add: valid_mdb'_def)
+     apply(simp add: valid_mdb'_def)
     apply(clarsimp)
-   apply(rule cte_at_next_slot; simp (no_asm_simp))
+   apply(rule cte_at_next_slot)
+      apply(simp_all)[4]
   apply(case_tac "next_slot (aa, bb) (cdt_list (a)) (cdt a) = Some dest")
-   apply(simp (no_asm_simp))
+   apply(simp)
    apply(erule_tac x=aa in allE, erule_tac x=bb in allE)
    apply(simp)
    apply(subgoal_tac "cte_at (aa, bb) a")
@@ -6781,22 +6933,25 @@ lemma cteSwap_corres:
       apply(clarsimp)
      apply(clarsimp simp: mdb_swap.prev_dest_src)
     apply(rule conjI)
-     apply(rule cte_map_inj; (simp (no_asm_simp))?)
-     apply(erule cte_wp_at_weakenE, simp (no_asm_simp))
+     apply(rule cte_map_inj)
+          apply(simp_all)[6]
+     apply(erule cte_wp_at_weakenE, simp)
     apply(rule conjI)
-     apply(rule cte_map_inj; (simp (no_asm_simp))?)
-     apply(erule cte_wp_at_weakenE, simp (no_asm_simp))
+     apply(rule cte_map_inj)
+          apply(simp_all)[6]
+     apply(erule cte_wp_at_weakenE, simp)
     apply(frule mdb_swap.m_exists)
-     apply(simp (no_asm_simp))
+     apply(simp)
     apply(clarsimp)
     apply(frule_tac cte="CTE cap' node'" in valid_mdbD1')
       apply(clarsimp)
-     apply(simp (no_asm_simp) add: valid_mdb'_def)
+     apply(simp add: valid_mdb'_def)
     apply(clarsimp)
-   apply(rule cte_at_next_slot; (simp (no_asm_simp))?)
-  apply(simp (no_asm_simp))
+   apply(rule cte_at_next_slot)
+      apply(simp_all)[4]
+  apply(simp)
   apply(case_tac "next_slot (aa, bb) (cdt_list (a)) (cdt a)")
-   apply(simp (no_asm_simp))
+   apply(simp)
   apply(clarsimp)
   apply(erule_tac x=aa in allE, erule_tac x=bb in allE)
   apply(simp)
@@ -6807,36 +6962,38 @@ lemma cteSwap_corres:
                       cte_map (aa, bb) \<noteq> mdbPrev dest_node")
     apply(clarsimp)
    apply(rule conjI)
-    apply(rule cte_map_inj; (simp (no_asm_simp))?)
-    apply(erule cte_wp_at_weakenE, simp (no_asm_simp))
+    apply(rule cte_map_inj)
+         apply(simp_all)[6]
+    apply(erule cte_wp_at_weakenE, simp)
    apply(rule conjI)
-    apply(rule cte_map_inj; (simp (no_asm_simp))?)
-    apply(erule cte_wp_at_weakenE, simp (no_asm_simp))
+    apply(rule cte_map_inj)
+         apply simp_all[6]
+    apply(erule cte_wp_at_weakenE, simp)
    apply(rule conjI)
     apply(frule mdb_swap.m_exists)
-     apply(simp (no_asm_simp))
+     apply(simp)
     apply(clarsimp)
      apply(frule_tac cte="CTE src_cap src_node" in valid_mdbD2')
-     subgoal by (clarsimp)
-     apply(simp (no_asm_simp) add: valid_mdb'_def)
+      subgoal by (clarsimp)
+     apply(simp add: valid_mdb'_def)
     apply(clarsimp)
-    apply(drule cte_map_inj_eq; (simp (no_asm_simp))?)
-      apply(rule cte_at_next_slot'; simp (no_asm_simp))
-     apply(erule cte_wp_at_weakenE, simp (no_asm_simp))
-    apply simp
+    apply(drule cte_map_inj_eq)
+         apply(rule cte_at_next_slot')
+            apply(simp_all)[9]
+    apply(erule cte_wp_at_weakenE, simp)
    apply(frule mdb_swap.m_exists)
-    apply(simp (no_asm_simp))
+    apply(simp)
    apply(clarsimp)
    apply(frule_tac cte="CTE dest_cap dest_node" in valid_mdbD2')
      apply(clarsimp)
-    apply(simp (no_asm_simp) add: valid_mdb'_def)
+    apply(simp add: valid_mdb'_def)
    apply(clarsimp)
-   apply(drule cte_map_inj_eq; (simp (no_asm_simp))?)
-     apply(rule cte_at_next_slot'; simp (no_asm_simp))
-    apply(erule cte_wp_at_weakenE)
-    apply (simp (no_asm_simp))
-   apply simp
+   apply(drule cte_map_inj_eq)
+         apply(rule cte_at_next_slot')
+           apply(simp_all)[9]
+    apply(erule cte_wp_at_weakenE, simp)
   by (rule cte_at_next_slot; simp)
+
 
 lemma capSwapForDelete_corres:
   assumes "src' = cte_map src" "dest' = cte_map dest"

--- a/proof/refine/ARM/Corres.thy
+++ b/proof/refine/ARM/Corres.thy
@@ -13,22 +13,9 @@ abbreviation
  "corres \<equiv> corres_underlying state_relation False True"
 
 abbreviation
- "cross_rel \<equiv> cross_rel_ul state_relation"
-
-lemmas cross_rel_def = cross_rel_ul_def
-
-abbreviation
  "corresK \<equiv> corres_underlyingK state_relation False True"
 
 abbreviation
   "ex_abs \<equiv> ex_abs_underlying state_relation"
-
-abbreviation "sr_inv P P' f \<equiv> sr_inv_ul state_relation P P' f"
-
-lemmas sr_inv_def = sr_inv_ul_def
-
-lemmas sr_inv_imp = sr_inv_ul_imp[of state_relation]
-
-lemmas sr_inv_bind = sr_inv_ul_bind[where sr=state_relation]
 
 end

--- a/proof/refine/ARM/Detype_R.thy
+++ b/proof/refine/ARM/Detype_R.thy
@@ -1,5 +1,4 @@
 (*
- * Copyright 2022, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -10,6 +9,10 @@ imports Retype_R
 begin
 
 context begin interpretation Arch . (*FIXME: arch-split*)
+
+text \<open>Establishing that the invariants are maintained
+        when a region of memory is detyped, that is,
+        removed from the model.\<close>
 
 definition
   "descendants_range_in' S p \<equiv>
@@ -89,12 +92,13 @@ lemma descendants_range'_def2:
   "descendants_range' cap p = descendants_range_in' (capRange cap) p"
   by (simp add: descendants_range_in'_def descendants_range'_def)
 
+
 defs deletionIsSafe_def:
-  "deletionIsSafe \<equiv> \<lambda>ptr bits s. \<forall>p.
-        (ko_wp_at' live' p s \<longrightarrow> p \<notin> {ptr .. ptr + 2 ^ bits - 1})
-        \<and> (p \<in> set (ksReleaseQueue s) \<longrightarrow> obj_at' (runnable' \<circ> tcbState) p s)
-        \<and> (\<forall>ko. ksPSpace s p = Some (KOArch ko) \<and> p \<in> {ptr .. ptr + 2 ^ bits - 1}
-                \<longrightarrow> 6 \<le> bits)"
+  "deletionIsSafe \<equiv> \<lambda>ptr bits s. \<forall>p t m r.
+       (cte_wp_at' (\<lambda>cte. cteCap cte = capability.ReplyCap t m r) p s \<longrightarrow>
+       t \<notin> {ptr .. ptr + 2 ^ bits - 1}) \<and>
+       (\<forall>ko. ksPSpace s p = Some (KOArch ko) \<and> p \<in> {ptr .. ptr + 2 ^ bits - 1}
+        \<longrightarrow> 6 \<le> bits)"
 
 defs deletionIsSafe_delete_locale_def:
   "deletionIsSafe_delete_locale \<equiv> \<lambda>ptr bits s. \<forall>p. ko_wp_at' live' p s \<longrightarrow> p \<notin> {ptr .. ptr + 2 ^ bits - 1}"
@@ -110,17 +114,10 @@ defs cNodePartialOverlap_def:
       \<or> (\<not> {p .. p + 2 ^ (cte_level_bits + n) - 1} \<subseteq> {p. inRange p}
         \<and> \<not> {p .. p + 2 ^ (cte_level_bits + n) - 1} \<subseteq> {p. \<not> inRange p}))"
 
-defs release_q_runnable_asrt_def:
-  "release_q_runnable_asrt \<equiv>
-     \<lambda>s. \<forall>p. p \<in> set (ksReleaseQueue s) \<longrightarrow> obj_at' (runnable' \<circ> tcbState) p s"
-
 (* FIXME: move *)
 lemma deleteObjects_def2:
   "is_aligned ptr bits \<Longrightarrow>
    deleteObjects ptr bits = do
-     stateAssert sym_refs_asrt [];
-     stateAssert valid_idle'_asrt [];
-     stateAssert release_q_runnable_asrt [];
      stateAssert (deletionIsSafe ptr bits) [];
      stateAssert (deletionIsSafe_delete_locale ptr bits) [];
      doMachineOp (freeMemory ptr bits);
@@ -134,7 +131,9 @@ lemma deleteObjects_def2:
      stateAssert ksASIDMapSafe []
    od"
   apply (simp add: deleteObjects_def is_aligned_mask[symmetric] unless_def deleteGhost_def)
-  apply (rule bind_eqI, rule ext)+
+  apply (rule bind_eqI, rule ext)
+  apply (rule bind_eqI, rule ext)
+  apply (rule bind_eqI, rule ext)
   apply (simp add: bind_assoc[symmetric])
   apply (rule bind_cong[rotated], rule refl)
   apply (simp add: bind_assoc modify_modify deleteRange_def gets_modify_def)
@@ -153,9 +152,6 @@ lemma deleteObjects_def2:
 lemma deleteObjects_def3:
   "deleteObjects ptr bits =
    do
-     stateAssert sym_refs_asrt [];
-     stateAssert valid_idle'_asrt [];
-     stateAssert release_q_runnable_asrt [];
      assert (is_aligned ptr bits);
      stateAssert (deletionIsSafe ptr bits) [];
      stateAssert (deletionIsSafe_delete_locale ptr bits) [];
@@ -180,14 +176,11 @@ lemma obj_relation_cuts_in_obj_range:
        kheap s x = Some ko; valid_objs s; pspace_aligned s \<rbrakk> \<Longrightarrow> y \<in> obj_range x ko"
   apply (cases ko, simp_all)
    apply (clarsimp split: if_split_asm)
-    apply (subgoal_tac "cte_at (x, ya) s")
-     apply (drule(2) cte_at_cte_map_in_obj_bits)
-     apply (simp add: obj_range_def)
-    apply (fastforce intro: cte_wp_at_cteI)
-   apply (prop_tac "y = x")
-    apply (meson old.prod.inject singletonD)
-   apply simp
-   apply (frule(1) pspace_alignedD)
+   apply (subgoal_tac "cte_at (x, ya) s")
+    apply (drule(2) cte_at_cte_map_in_obj_bits)
+    apply (simp add: obj_range_def)
+   apply (fastforce intro: cte_wp_at_cteI)
+  apply (frule(1) pspace_alignedD)
   apply (frule valid_obj_sizes, erule ranI)
   apply (rename_tac arch_kernel_obj)
   apply (case_tac arch_kernel_obj, simp_all)
@@ -396,7 +389,7 @@ lemma cte_wp_at_delete':
               del: atLeastAtMost_iff)
   apply (simp add: objBits_simps)
   apply (frule(1) tcb_cte_cases_aligned_helpers)
-  apply (simp)
+  apply (simp add: is_aligned_neg_mask_eq)
   done
 
 lemma map_to_ctes_delete:
@@ -437,9 +430,9 @@ next
     apply (subst card_Un_disjoint; simp)
      apply (clarsimp simp: field_simps)
     apply (subst suc)
-    apply (erule word_plus_mono_right2)
+     apply (erule word_plus_mono_right2)
      apply (simp add: field_simps)
-     apply simp
+    apply simp
     apply (simp add: unatSuc)
     done
 qed
@@ -448,204 +441,13 @@ end
 
 locale detype_locale' = detype_locale + constrains s::"det_state"
 
-context begin interpretation Arch . (*FIXME: arch-split*)
-
-text \<open>Invariant preservation across concrete deletion\<close>
-
-lemma caps_containedD':
-  "\<lbrakk> ctes_of s p = Some cte; ctes_of s p' = Some cte';
-     \<not> isUntypedCap (cteCap cte); capRange (cteCap cte) \<inter> untypedRange (cteCap cte') \<noteq> {};
-     caps_contained' (ctes_of s) \<rbrakk> \<Longrightarrow>
-     capRange (cteCap cte) \<subseteq> untypedRange (cteCap cte')"
-  apply (cases cte, cases cte')
-  apply (simp add: caps_contained'_def)
-  apply blast
-  done
-
-lemma untyped_mdbD':
-  "\<lbrakk> ctes p = Some cte; ctes p' = Some cte';
-     isUntypedCap (cteCap cte); capRange (cteCap cte') \<inter> untypedRange (cteCap cte) \<noteq> {};
-     \<not> isUntypedCap (cteCap cte');
-     untyped_mdb' ctes \<rbrakk> \<Longrightarrow> p' \<in> descendants_of' p ctes"
-  by (cases cte, cases cte', simp add: untyped_mdb'_def)
-
-lemma ko_wp_at_state_refs_ofD:
-  "\<lbrakk> ko_wp_at' P p s \<rbrakk> \<Longrightarrow> (\<exists>ko. P ko \<and> state_refs_of' s p = refs_of' ko)"
-  by (fastforce simp: ko_wp_at'_def state_refs_of'_def)
-
-lemma sym_refs_ko_wp_atD:
-  "\<lbrakk> ko_wp_at' P p s; sym_refs (state_refs_of' s) \<rbrakk>
-      \<Longrightarrow> (\<exists>ko. P ko \<and> state_refs_of' s p = refs_of' ko
-                    \<and> (\<forall>(x, tp) \<in> refs_of' ko. (p, symreftype tp) \<in> state_refs_of' s x))"
-  apply (clarsimp dest!: ko_wp_at_state_refs_ofD)
-  apply (rule exI, erule conjI)
-  apply (drule sym)
-  apply clarsimp
-  apply (erule(1) sym_refsD)
-  done
-
-lemma zobj_refs_capRange:
-  "capAligned c \<Longrightarrow> zobj_refs' c \<subseteq> capRange c"
-  by (cases c, simp_all add: capRange_def capAligned_def is_aligned_no_overflow)
-end
-
-locale delete_locale =
-  fixes s' and base and bits and ptr and idx and d
-  assumes     cap: "cte_wp_at' (\<lambda>cte. cteCap cte = UntypedCap d base bits idx) ptr s'"
-  and      nodesc: "descendants_range' (UntypedCap d base bits idx) ptr (ctes_of s')"
-  and        invs: "invs' s'"
-  and    sym_refs: "sym_refs (state_refs_of' s')"
-  and valid_idle': "valid_idle' s'"
-  and      ct_act: "ct_active' s'"
-  and     sa_simp: "sch_act_simple s'"
-  and          al: "is_aligned base bits"
-  and      rlqrun: "\<forall>p. p \<in> set (ksReleaseQueue s') \<longrightarrow> obj_at' (runnable' \<circ> tcbState) p s'"
-
-context delete_locale
-begin
-interpretation Arch . (*FIXME: arch-split*)
-lemma  valid_objs: "valid_objs' s'"
-  and    vreplies: "valid_replies' s'"
-  and      pspace: "valid_pspace' s'"
-  and          pa: "pspace_aligned' s'"
-  and          pd: "pspace_distinct' s'"
-  and          bd: "pspace_bounded' s'"
-  and          vq: "valid_queues s'"
-  and         vq': "valid_queues' s'"
-  and        vrlq: "valid_release_queue s'"
-  and       vrlq': "valid_release_queue' s'"
-  and   list_refs: "sym_refs (list_refs_of_replies' s')"
-  and      iflive: "if_live_then_nonz_cap' s'"
-  and    ifunsafe: "if_unsafe_then_cap' s'"
-  and       dlist: "valid_dlist (ctes_of s')"
-  and        no_0: "no_0 (ctes_of s')"
-  and     chain_0: "mdb_chain_0 (ctes_of s')"
-  and      badges: "valid_badges (ctes_of s')"
-  and   contained: "caps_contained' (ctes_of s')"
-  and     chunked: "mdb_chunked (ctes_of s')"
-  and        umdb: "untyped_mdb' (ctes_of s')"
-  and        uinc: "untyped_inc' (ctes_of s')"
-  and    nullcaps: "valid_nullcaps (ctes_of s')"
-  and      ut_rev: "ut_revocable' (ctes_of s')"
-  and      dist_z: "distinct_zombies (ctes_of s')"
-  and    irq_ctrl: "irq_control (ctes_of s')"
-  and      clinks: "class_links (ctes_of s')"
-  and        refs: "valid_global_refs' s'"
-  and        arch: "valid_arch_state' s'"
-  and        virq: "valid_irq_node' (irq_node' s') s'"
-  and       virqh: "valid_irq_handlers' s'"
-  and       virqs: "valid_irq_states' s'"
-  and   no_0_objs: "no_0_obj' s'"
-  and    pde_maps: "valid_pde_mappings' s'"
-  and irqs_masked: "irqs_masked' s'"
-  and         cdm: "ksCurDomain s' \<le> maxDomain"
-  and         vds: "valid_dom_schedule' s'"
-  using invs
-  by (auto simp add: invs'_def valid_pspace'_def valid_mdb'_def valid_mdb_ctes_def)
-
-abbreviation
-  "base_bits \<equiv> {base .. base + (2 ^ bits - 1)}"
-
-abbreviation
-  "pspace' \<equiv> \<lambda>x. if base \<le> x \<and> x \<le> base + (2 ^ bits - 1) then None else ksPSpace s' x"
-
-abbreviation
-  "state' \<equiv> (s' \<lparr> ksPSpace := pspace' \<rparr>)"
-
-abbreviation
-  "replies' \<equiv> pspace' |> reply_of'"
-
-lemma ko_wp_at'[simp]:
-  "\<And>P p. (ko_wp_at' P p state') = (ko_wp_at' P p s' \<and> p \<notin> base_bits)"
-  by (fastforce simp add: ko_wp_at_delete'[OF pd])
-
-lemma obj_at'[simp]:
-  "\<And>P p. (obj_at' P p state') = (obj_at' P p s' \<and> p \<notin> base_bits)"
-  by (fastforce simp add: obj_at'_real_def)
-
-lemma typ_at'[simp]:
-  "typ_at' P p state' = (typ_at' P p s' \<and> p \<notin> base_bits)"
-  by (simp add: typ_at'_def)
-
-lemma valid_untyped[simp]:
-  "s' \<turnstile>' UntypedCap d base bits idx"
-  using cte_wp_at_valid_objs_valid_cap' [OF cap valid_objs]
-  by clarsimp
-
-lemma cte_wp_at'[simp]:
-  "\<And>P p. (cte_wp_at' P p state') = (cte_wp_at' P p s' \<and> p \<notin> base_bits)"
-  by (fastforce simp:cte_wp_at_delete'[where idx = idx,OF valid_untyped pd ])
-
-(* the bits of caps they need for validity argument are within their capRanges *)
-lemma valid_cap_ctes_pre:
-    "\<And>c. s' \<turnstile>' c \<Longrightarrow> case c of CNodeCap ref bits g gs
-                      \<Rightarrow> \<forall>x. ref + (x && mask bits) * 2^cteSizeBits \<in> capRange c
-                    | Zombie ref (ZombieCNode bits) n
-                      \<Rightarrow> \<forall>x. ref + (x && mask bits) * 2^cteSizeBits \<in> capRange c
-                    | ArchObjectCap (PageTableCap ref data)
-                      \<Rightarrow> \<forall>x < 0x100. ref + x * 2^pteBits \<in> capRange c \<comment> \<open>number of entries in page table\<close>
-                    | ArchObjectCap (PageDirectoryCap ref data)
-                      \<Rightarrow> \<forall>x < 0x1000. ref + x * 2^pdeBits \<in> capRange c \<comment> \<open>number of entries in page directory\<close>
-                    | _ \<Rightarrow> True"
-  apply (drule valid_capAligned)
-  apply (simp split: capability.split zombie_type.split arch_capability.split, safe)
-     using pre_helper[where a=cteSizeBits]
-     apply (clarsimp simp add: capRange_def capAligned_def objBits_simps field_simps)
-    apply (clarsimp simp add: capRange_def capAligned_def
-                    simp del: atLeastAtMost_iff capBits.simps)
-    apply (rule pre_helper2, simp_all add: word_bits_def pteBits_def)[1]
-   apply (clarsimp simp add: capRange_def capAligned_def
-                   simp del: atLeastAtMost_iff capBits.simps)
-   apply (rule pre_helper2, simp_all add: word_bits_def pdeBits_def)[1]
-  using pre_helper[where a=cteSizeBits]
-  apply (clarsimp simp add: capRange_def capAligned_def objBits_simps field_simps)
-  done
-
-lemma valid_cap':
-    "\<And>p c. \<lbrakk> s' \<turnstile>' c; cte_wp_at' (\<lambda>cte. cteCap cte = c) p s';
-             capRange c \<inter> {base .. base + (2 ^ bits - 1)} = {} \<rbrakk> \<Longrightarrow> state' \<turnstile>' c"
-  apply (subgoal_tac "capClass c = PhysicalClass \<longrightarrow> capUntypedPtr c \<in> capRange c")
-   apply (subgoal_tac "capClass c = PhysicalClass \<longrightarrow>
-                        capUntypedPtr c \<notin> {base .. base + (2 ^ bits - 1)}")
-    apply (frule valid_cap_ctes_pre)
-    apply (case_tac c, simp_all add: valid_cap'_def
-                                del: atLeastAtMost_iff
-                              split: zombie_type.split_asm)
-       apply (simp add: field_simps del: atLeastAtMost_iff)
-       apply blast
-      apply (rename_tac arch_capability)
-      apply (case_tac arch_capability,
-             simp_all add: ARM_H.capUntypedPtr_def
-                           page_table_at'_def page_directory_at'_def
-                           shiftl_t2n
-                      del: atLeastAtMost_iff)[1]
-        apply (rename_tac word vmrights vmpage_size option)
-        apply (subgoal_tac "\<forall>p < 2 ^ (pageBitsForSize vmpage_size - pageBits).
-                               word + p * 2 ^ pageBits \<in> capRange c")
-         apply blast
-        apply (clarsimp simp: capRange_def capAligned_def)
-        apply (frule word_less_power_trans2,
-               rule pbfs_atleast_pageBits, simp add: word_bits_def)
-        apply (rule context_conjI)
-         apply (erule(1) is_aligned_no_wrap')
-        apply (simp only: add_diff_eq[symmetric])
-        apply (rule word_plus_mono_right)
-         apply simp
-        apply (erule is_aligned_no_overflow')
-       apply (simp add: field_simps pteBits_def del: atLeastAtMost_iff)
-       apply blast
-      apply (simp add: field_simps pdeBits_def del: atLeastAtMost_iff)
-      apply blast
-     apply (simp add: valid_untyped'_def)
-    apply (simp add: field_simps del: atLeastAtMost_iff)
-    apply blast
-   apply blast
-  apply (clarsimp simp: capAligned_capUntypedPtr)
-  done
-
-lemma objRefs_notrange:
-  assumes asms: "ctes_of s' p = Some c" "\<not> isUntypedCap (cteCap c)"
-  shows "capRange (cteCap c) \<inter> base_bits = {}"
+lemma (in detype_locale') deletionIsSafe:
+  assumes sr: "(s, s') \<in> state_relation"
+  and    cap: "cap = cap.UntypedCap d base magnitude idx"
+  and      vs: "valid_pspace s"
+  and      al: "is_aligned base magnitude"
+  and      vu: "valid_untyped (cap.UntypedCap d base magnitude idx) s"
+  shows       "deletionIsSafe base magnitude s'"
 proof -
   interpret Arch . (* FIXME: arch-split *)
   note [simp del] = atLeastatMost_subset_iff atLeastLessThan_iff atLeastAtMost_iff
@@ -663,109 +465,67 @@ proof -
           (\<forall>ptr m r. \<not> cte_wp_at' (\<lambda>cte. cteCap cte = ReplyCap t m r) ptr s')"
     unfolding deletionIsSafe_def
     apply -
-    apply (rule ccontr)
-    apply (drule untyped_mdbD' [OF ctes_of _ _ _ _ umdb])
-       apply (simp add: isUntypedCap_def)
-      apply (simp add: field_simps)
-     apply assumption
-    using nodesc
-    apply (simp add:descendants_range'_def2)
-    apply (drule(1) descendants_range_inD')
-     apply (simp add:asms)
-    apply (simp add:p_assoc_help)
+    apply (erule allEI)
+    apply (rule impI, drule(1) mp)
+    apply (thin_tac "t \<in> S" for S)
+    apply (intro allI)
+    apply (clarsimp simp: cte_wp_at_neg2 cte_wp_at_ctes_of
+                simp del: split_paired_All)
+    apply (frule pspace_relation_cte_wp_atI [rotated])
+      apply (rule invs_valid_objs [OF invs])
+     apply (rule state_relation_pspace_relation [OF sr])
+    apply (clarsimp simp: cte_wp_at_neg2 simp del: split_paired_All)
+    apply (drule_tac x="(a,b)" in spec)
+    apply (clarsimp simp: cte_wp_cte_at cte_wp_at_caps_of_state)
+    apply (case_tac c, simp_all)
+    apply fastforce
     done
-qed
 
-lemma ctes_of_valid [elim!]:
-  "ctes_of s' p = Some cte \<Longrightarrow> s' \<turnstile>' cteCap cte"
-  by (case_tac cte, simp add: ctes_of_valid_cap' [OF _ valid_objs])
-
-lemma valid_cap2:
-  "\<lbrakk> cte_wp_at' (\<lambda>cte. cteCap cte = c) p s' \<rbrakk> \<Longrightarrow> state' \<turnstile>' c"
-  apply (case_tac "isUntypedCap c")
-   apply (drule cte_wp_at_valid_objs_valid_cap' [OF _ valid_objs])
-   apply (clarsimp simp: valid_cap'_def isCap_simps valid_untyped'_def)
-  apply (rule valid_cap'[rotated], assumption)
-   apply (clarsimp simp: cte_wp_at_ctes_of dest!: objRefs_notrange)
-  apply (clarsimp simp: cte_wp_at_ctes_of)
-  done
-
-lemma ex_nonz_cap_notRange:
-  "ex_nonz_cap_to' p s' \<Longrightarrow> p \<notin> base_bits"
-  apply (clarsimp simp: ex_nonz_cap_to'_def cte_wp_at_ctes_of)
-  apply (case_tac "isUntypedCap (cteCap cte)")
-   apply (clarsimp simp: isCap_simps)
-  apply (drule subsetD[OF zobj_refs_capRange, rotated])
-   apply (rule valid_capAligned, erule ctes_of_valid)
-  apply (drule(1) objRefs_notrange)
-  apply (drule_tac a=p in equals0D)
-  apply simp
-  done
-
-lemma live_notRange:
-  "\<lbrakk> ko_wp_at' P p s'; \<And>ko. P ko \<Longrightarrow> live' ko \<rbrakk> \<Longrightarrow> p \<notin> base_bits"
-  apply (drule if_live_then_nonz_capE' [OF iflive ko_wp_at'_weakenE])
-   apply simp
-  apply (erule ex_nonz_cap_notRange)
-  done
-
-lemma deletionIsSafe_holds:
-  assumes sr: "(s, s') \<in> state_relation"
-  and    cap: "cap = cap.UntypedCap d base bits idx"
-  and     vs: "valid_pspace s"
-  and     al: "is_aligned base bits"
-  and     vu: "valid_untyped (cap.UntypedCap d base bits idx) s"
-  shows "deletionIsSafe base bits s'"
-proof -
-  interpret Arch . (* FIXME: arch-split *)
-
-  have arch: "\<And> ko p. \<lbrakk> ksPSpace s' p = Some (KOArch ko); p \<in> {base..base + 2 ^ bits - 1} \<rbrakk>
-                       \<Longrightarrow> 6 \<le> bits"
+  have arch: "\<And> ko p. \<lbrakk> ksPSpace s' p = Some (KOArch ko); p \<in> {base..base + 2 ^ magnitude - 1} \<rbrakk>
+             \<Longrightarrow> 6 \<le> magnitude"
     using sr vs vu
     apply (clarsimp simp: state_relation_def)
-    apply (erule (1) pspace_dom_relatedE)
-    apply (frule obj_relation_cuts_eqv_base_in_detype_range[symmetric]; simp?)
-      apply (clarsimp simp: valid_pspace_def)+
-    apply (clarsimp simp: valid_untyped_def)
+    apply (erule(1) pspace_dom_relatedE)
+    apply (frule obj_relation_cuts_eqv_base_in_detype_range[symmetric])
+        apply simp
+       apply (clarsimp simp:valid_pspace_def)+
+      apply simp
+    apply (clarsimp simp:valid_untyped_def)
     apply (drule spec)+
     apply (erule(1) impE)
     apply (erule impE)
-     apply (drule p_in_obj_range; fastforce)
+     apply (drule p_in_obj_range)
+       apply (clarsimp)+
+     apply blast
     apply clarsimp
     apply (drule card_mono[rotated])
      apply fastforce
-    apply (clarsimp simp: valid_pspace_def obj_range_def p_assoc_help)
+    apply (clarsimp simp:valid_pspace_def obj_range_def p_assoc_help)
     apply (subst (asm) word_range_card)
      apply (rule is_aligned_no_overflow')
      apply (erule(1) pspace_alignedD)
     apply (subst (asm) word_range_card)
      apply (rule is_aligned_no_overflow'[OF al])
     apply (rule ccontr)
-    apply (simp add: not_le)
-    apply (prop_tac "obj_bits koa < 32")
-     apply (case_tac koa, simp_all add: objBits_simps word_bits_def)
-       apply (drule(1) valid_cs_size_objsI)
-       apply (clarsimp simp: valid_cs_size_def word_bits_def cte_level_bits_def)
-      apply (clarsimp split: if_splits)
+    apply (simp add:not_le)
+    apply (subgoal_tac "obj_bits koa < 32")
+     prefer 2
+     apply (case_tac koa,simp_all add:objBits_simps word_bits_def)
+      apply (drule(1) valid_cs_size_objsI)
+      apply (clarsimp simp:valid_cs_size_def word_bits_def cte_level_bits_def)
      apply (rename_tac arch_kernel_obj)
-     apply (case_tac arch_kernel_obj; simp add: pageBits_def word_bits_def)
-     apply (simp add: pageBitsForSize_def split: vmpage_size.splits)
-    apply (case_tac koa
-           ; simp add: other_obj_relation_def objBits_simps cte_relation_def
-                split: if_splits)
-     apply (rename_tac arch_kernel_obj
-            , case_tac arch_kernel_obj
-            ; simp add: arch_kobj_size_def pageBits_def pageBitsForSize_def)+
+     apply (case_tac arch_kernel_obj,simp_all add:pageBits_def word_bits_def)
+     apply (simp add:pageBitsForSize_def split:vmpage_size.splits)
+    apply (subgoal_tac "6 \<le> obj_bits koa")
+     apply simp
+    apply (case_tac koa, simp_all add: other_obj_relation_def
+                                       objBits_simps cte_relation_def
+                                split: if_splits)
+    apply (rename_tac arch_kernel_obj,
+           case_tac arch_kernel_obj;
+           simp add: arch_kobj_size_def pageBits_def pageBitsForSize_def)+
     done
-
-  thus ?thesis
-  apply -
-  apply (clarsimp simp: deletionIsSafe_def)
-  apply (intro conjI; blast?)
-   apply (fastforce simp: x_power_minus_1 dest!: live_notRange)
-  apply (insert rlqrun)
-  apply simp
-  done
+  thus ?thesis using cte by (auto simp: deletionIsSafe_def)
 qed
 
 context begin interpretation Arch . (*FIXME: arch-split*)
@@ -1075,6 +835,11 @@ lemma corres_machine_op:
    apply (simp_all add: state_relation_def swp_def)
   done
 
+lemma ekheap_relation_detype:
+  "ekheap_relation ekh kh \<Longrightarrow>
+   ekheap_relation (\<lambda>x. if P x then None else (ekh x)) (\<lambda>x. if P x then None else (kh x))"
+  by (fastforce simp add: ekheap_relation_def split: if_split_asm)
+
 lemma cap_table_at_gsCNodes_eq:
   "(s, s') \<in> state_relation
     \<Longrightarrow> (gsCNodes s' ptr = Some bits) = cap_table_at bits ptr s"
@@ -1116,42 +881,6 @@ lemma sym_refs_hyp_refs_triv[simp]: "sym_refs (state_hyp_refs_of s)"
   apply (case_tac "kheap s x"; simp add: hyp_refs_of_def)
   apply (rename_tac ko)
   apply (case_tac ko; clarsimp)
-  done
-
-lemma freeMemory_deletionIsSafe[wp]:
-  "doMachineOp (freeMemory base magnitude) \<lbrace>deletionIsSafe base magnitude\<rbrace>"
-  apply (clarsimp simp: doMachineOp_def)
-  apply wpsimp
-  apply (clarsimp simp: deletionIsSafe_def)
-  done
-
-lemma detype_ReplyPrevs_of:
-  "\<lbrakk>pspace_aligned' s'; pspace_distinct' s'; pspace_bounded' s'; \<forall>p. p \<in> S \<longrightarrow> \<not> ko_wp_at' live' p s'\<rbrakk>
-   \<Longrightarrow> ((\<lambda>x. if x \<in> S then None else ksPSpace s' x) |> reply_of' |> replyPrev)
-       = replyPrevs_of s'"
-  apply (prop_tac "\<And>p reply_ptr. (replyPrevs_of s' p = Some reply_ptr) \<Longrightarrow> p \<notin> S")
-   apply (clarsimp simp: opt_map_def split: option.splits)
-   apply (drule_tac x=p in spec)
-   apply (clarsimp simp: ko_wp_at'_def pred_neg_def live'_def projectKOs live_reply'_def
-                  split: Structures_H.kernel_object.splits)
-  using pspace_alignedD' pspace_distinctD' pspace_boundedD' apply clarsimp
-  apply (rule ext)
-  apply (clarsimp simp: vs_all_heap_simps opt_map_def in_opt_map_eq
-                  split: option.splits)
-  by force
-
-lemma detype_sc_replies_relation:
-  "\<lbrakk>pspace_aligned' s'; pspace_distinct' s'; pspace_bounded' s'; \<forall>p. p \<in> {lower..upper} \<longrightarrow> \<not> ko_wp_at' live' p s';
-    sc_replies_relation s s'\<rbrakk>
-   \<Longrightarrow> sc_replies_relation_2 (sc_replies_of (detype {lower..upper} s))
-                         ((\<lambda>x. if lower \<le> x \<and> x \<le> upper
-                               then None else ksPSpace s' x) |> sc_of' |> scReply)
-                         ((\<lambda>x. if lower \<le> x \<and> x \<le> upper
-                               then None else ksPSpace s' x) |> reply_of' |> replyPrev)"
-  apply (clarsimp simp: sc_replies_relation_def detype_def)
-  apply (frule detype_ReplyPrevs_of[where S="{lower..upper}"]; simp)
-  apply (clarsimp simp: vs_all_heap_simps opt_map_def in_opt_map_eq
-                 split: if_splits Structures_A.kernel_object.splits)
   done
 
 crunch doMachineOp
@@ -1238,23 +967,23 @@ lemma deleteObjects_corres:
            \<and> ct_active' s'
            \<and> s' \<turnstile>' (UntypedCap d base magnitude idx))
       (delete_objects base magnitude) (deleteObjects base magnitude)"
-    (is "_ \<Longrightarrow> _ \<Longrightarrow> corres _ _ ?conc_guard _ _")
-  apply add_sym_refs
-  apply add_valid_idle'
-  apply add_release_q_runnable
   apply (simp add: deleteObjects_def2)
-  apply (rule corres_stateAssert_add_assertion[rotated])
-   apply (clarsimp simp: sym_refs_asrt_def)
-  apply (rule corres_stateAssert_add_assertion[rotated])
-   apply (clarsimp simp: valid_idle'_asrt_def)
-  apply (rule corres_stateAssert_add_assertion[rotated])
-   apply (clarsimp simp: release_q_runnable_asrt_def)
-  apply (rule corres_stateAssert_add_assertion)
+  apply (rule corres_stateAssert_implied[where P'=\<top>, simplified])
    prefer 2
    apply clarsimp
-   apply (rule delete_locale.deletionIsSafe_holds
-          ; (fastforce simp: delete_locale_def valid_cap_simps sch_act_simple_def state_relation_def
-                             sched_act_relation_def pred_conj_def)?)
+   apply (rule_tac cap="cap.UntypedCap d base magnitude idx" and ptr="(a,b)" and s=s
+                in detype_locale'.deletionIsSafe,
+          simp_all add: detype_locale'_def detype_locale_def invs_valid_pspace)[1]
+   apply (simp add: valid_cap_simps)
+  apply (rule corres_stateAssert_add_assertion[rotated])
+   apply (rule_tac ptr=ptr and idx=idx and d=d in delete_locale.deletionIsSafe_delete_locale_holds)
+   apply (clarsimp simp: delete_locale_def)
+   apply (intro conjI)
+    apply (fastforce simp: sch_act_simple_def state_relation_def schact_is_rct_def)
+   apply (rule_tac cap="cap.UntypedCap d base magnitude idx" and ptr="(a,b)" and s=s
+                in detype_locale'.deletionIsSafe,
+          simp_all add: detype_locale'_def detype_locale_def invs_valid_pspace)[1]
+   apply (simp add:valid_cap_simps)
   apply (simp add: bind_assoc[symmetric])
   apply (rule corres_stateAssert_implied2)
      defer
@@ -1263,22 +992,24 @@ lemma deleteObjects_corres:
      apply (rule delete_objects_invs)
     apply fastforce
    apply (simp add: doMachineOp_def split_def)
-   apply wpsimp
-   apply (frule invs_valid_pspace')
-   apply (rule conjI
-          ; clarsimp simp: pspace_distinct'_def ps_clear_def dom_if_None Diff_Int_distrib
-                           valid_pspace'_def pspace_aligned'_def)
+   apply wp
+   apply (clarsimp simp: invs'_def valid_state'_def valid_pspace'_def pspace_distinct'_def
+                         pspace_aligned'_def)
+   apply (rule conjI)
+    subgoal by fastforce
+   apply (clarsimp simp add: pspace_distinct'_def ps_clear_def
+                             dom_if_None Diff_Int_distrib)
   apply (simp add: delete_objects_def)
   apply (rule_tac Q="\<lambda>_ s. valid_objs s \<and> valid_list s \<and>
                            (\<exists>cref. cte_wp_at ((=) (cap.UntypedCap d base magnitude idx)) cref s \<and>
-                                   descendants_range (cap.UntypedCap d base magnitude idx) cref s) \<and>
+                           descendants_range (cap.UntypedCap d base magnitude idx) cref s ) \<and>
                            s \<turnstile> cap.UntypedCap d base magnitude idx \<and> pspace_aligned s \<and>
                            valid_mdb s \<and> pspace_distinct s \<and> if_live_then_nonz_cap s \<and>
                            zombies_final s \<and> sym_refs (state_refs_of s) \<and>
                            untyped_children_in_mdb s \<and> if_unsafe_then_cap s \<and>
-                           valid_global_refs s \<and> valid_replies s \<and> fault_tcbs_valid_states s" and
-                  Q'="\<lambda>_ s. s \<turnstile>' UntypedCap d base magnitude idx \<and>
-                            valid_pspace' s \<and> deletionIsSafe base magnitude s"
+                           valid_global_refs s"
+              and Q'="\<lambda>_ s. s \<turnstile>' capability.UntypedCap d base magnitude idx \<and>
+                            valid_pspace' s \<and> deletionIsSafe_delete_locale base magnitude s"
                in corres_underlying_split)
      apply (rule corres_bind_return)
      apply (rule corres_guard_imp[where r=dc])
@@ -1292,9 +1023,14 @@ lemma deleteObjects_corres:
     apply (simp add: valid_pspace'_def)
     apply (rule state_relation_null_filterE, assumption,
            simp_all add: pspace_aligned'_cut pspace_distinct'_cut)[1]
-           apply (simp add: detype_def)
-          apply (intro exI, fastforce)
-         apply (rule ext, clarsimp simp add: null_filter_def)
+            apply (simp add: detype_def, rule state.equality; simp add: detype_ext_def)
+           apply (intro exI, fastforce)
+          apply (rule ext, clarsimp simp add: null_filter_def)
+          apply (rule sym, rule ccontr, clarsimp)
+          apply (drule(4) cte_map_not_null_outside')
+           apply (fastforce simp add: cte_wp_at_caps_of_state)
+          apply simp
+         apply (rule ext, clarsimp simp: null_filter'_def map_to_ctes_delete[simplified field_simps])
          apply (rule sym, rule ccontr, clarsimp)
          apply (frule(2) pspace_relation_cte_wp_atI[OF state_relation_pspace_relation])
          apply (elim exE)
@@ -1306,41 +1042,25 @@ lemma deleteObjects_corres:
          apply (frule_tac cref="(aa, ba)" in cte_map_untyped_range,
                 erule cte_wp_at_weakenE[OF _ TrueI], assumption+)
          apply simp
-        apply (rule ext, clarsimp simp add: null_filter'_def
-                           map_to_ctes_delete[simplified field_simps])
-        apply (rule sym, rule ccontr, clarsimp)
-        apply (frule(2) pspace_relation_cte_wp_atI
-                        [OF state_relation_pspace_relation])
-        apply (elim exE)
-        apply (frule(4) cte_map_not_null_outside')
-         apply (rule cte_wp_at_weakenE, erule conjunct1)
-         apply (case_tac y, clarsimp)
-         apply (clarsimp simp: valid_mdb'_def valid_mdb_ctes_def
-                               valid_nullcaps_def)
-        apply clarsimp
-        apply (frule_tac cref="(aa, ba)" in cte_map_untyped_range,
-               erule cte_wp_at_weakenE[OF _ TrueI], assumption+)
-        apply simp
-       apply (rule detype_pspace_relation[simplified],
-              simp_all add: state_relation_pspace_relation valid_pspace_def)[1]
-        apply (simp add: valid_cap'_def capAligned_def)
-       apply (clarsimp simp: valid_cap_def, assumption)
-      apply (rule detype_sc_replies_relation; blast?)
-       apply (clarsimp simp: deletionIsSafe_def)
-      apply (erule state_relation_sc_replies_relation)
+        apply (rule detype_pspace_relation[simplified],
+               simp_all add: state_relation_pspace_relation valid_pspace_def)[1]
+         apply (simp add: valid_cap'_def capAligned_def)
+        apply (clarsimp simp: valid_cap_def, assumption)
+       apply (fastforce simp add: detype_def detype_ext_def intro!: ekheap_relation_detype)
+      apply (rule detype_ready_queues_relation; blast?)
+       apply (clarsimp simp: deletionIsSafe_delete_locale_def)
+      apply (frule state_relation_ready_queues_relation)
+      apply (simp add: ready_queues_relation_def Let_def)
      apply (clarsimp simp: state_relation_def ghost_relation_of_heap detype_def)
      apply (drule_tac t="gsUserPages s'" in sym)
      apply (drule_tac t="gsCNodes s'" in sym)
-     apply (auto simp: ups_of_heap_def cns_of_heap_def ext
-                split: option.splits kernel_object.splits)[1]
+     apply (auto simp add: ups_of_heap_def cns_of_heap_def ext
+                    split: option.splits kernel_object.splits)[1]
     apply (simp add: valid_mdb_def)
-   apply (wp hoare_vcg_ex_lift hoare_vcg_ball_lift
-          | wps
-          | simp add: invs_def valid_state_def valid_pspace_def descendants_range_def
-                      valid_cap_simps
-          | wp (once) hoare_drop_imps)+
-  apply (rule invs_valid_pspace')
-  apply simp
+   apply (wp hoare_vcg_ex_lift hoare_vcg_ball_lift | wps |
+          simp add: invs_def valid_state_def valid_pspace_def
+                    descendants_range_def | wp (once) hoare_drop_imps)+
+  apply fastforce
   done
 end
 
@@ -1365,150 +1085,64 @@ lemma untyped_range_live_idle':
   using live_idle_untyped_range' by blast
 
 lemma valid_obj':
-  "\<lbrakk> valid_obj' obj s'; ko_wp_at' ((=) obj) p s'; sym_refs (state_refs_of' s');
-     sym_refs (list_refs_of_replies' s'); pspace_aligned' s'; pspace_distinct' s'; pspace_bounded' s'\<rbrakk>
+  "\<lbrakk> valid_obj' obj s'; ko_wp_at' ((=) obj) p s'; sym_heap_sched_pointers s' \<rbrakk>
    \<Longrightarrow> valid_obj' obj state'"
   apply (case_tac obj, simp_all add: valid_obj'_def)
-        apply (clarsimp dest!: refs_of' simp flip: injectKO_ep)
-        apply (fastforce simp: valid_ep'_def split: endpoint.splits)
-       apply (clarsimp dest!: refs_of' simp flip: injectKO_ntfn)
-       apply (fastforce simp: valid_ntfn'_def valid_bound_obj'_def split: option.splits ntfn.splits)
-      apply (clarsimp simp flip: injectKO_tcb)
-      apply (frule refs_of')
-      apply (frule (2) sym_refs_ko_wp_atD)
-      apply (clarsimp simp: valid_tcb'_def ko_wp_at'_def objBits_simps)
-      apply (rule conjI)
-       apply (erule ballEI, clarsimp elim!: ranE)
-       apply (rule_tac p="p + x" in valid_cap2)
-       apply (erule (2) cte_wp_at_tcbI')
-        apply fastforce
-       apply simp
-      apply (clarsimp simp: valid_tcb_state'_def valid_bound_reply'_def
-                     split: option.splits thread_state.splits)
-     apply (clarsimp simp: valid_cte'_def)
-     apply (rule_tac p=p in valid_cap2)
-     apply (clarsimp simp: ko_wp_at'_def objBits_simps' cte_level_bits_def[symmetric])
-     apply (erule(2) cte_wp_at_cteI')
+      apply (rename_tac endpoint)
+      apply (case_tac endpoint, simp_all add: valid_ep'_def)[1]
+       apply (clarsimp dest!: sym_refs_ko_wp_atD [OF _ sym_refs])
+       apply (drule(1) bspec)+
+       apply (clarsimp dest!: refs_notRange)
+      apply (clarsimp dest!: sym_refs_ko_wp_atD [OF _ sym_refs])
+      apply (drule(1) bspec)+
+      apply (clarsimp dest!: refs_notRange)
+     apply (rename_tac notification)
+     apply (case_tac notification, simp_all add: valid_ntfn'_def valid_bound_tcb'_def)[1]
+     apply (rename_tac ntfn bound)
+     apply (case_tac ntfn, simp_all split:option.splits)[1]
+        apply ((clarsimp dest!: sym_refs_ko_wp_atD [OF _ sym_refs] refs_notRange)+)[4]
+      apply (drule(1) bspec)+
+      apply (clarsimp dest!: refs_notRange)
+     apply (clarsimp dest!: sym_refs_ko_wp_atD [OF _ sym_refs] refs_notRange)
+    apply (frule sym_refs_ko_wp_atD [OF _ sym_refs])
+    apply (clarsimp simp: valid_tcb'_def ko_wp_at'_def
+                          objBits_simps)
+    apply (rule conjI)
+     apply (erule ballEI, clarsimp elim!: ranE)
+     apply (rule_tac p="p + x" in valid_cap2)
+     apply (erule(2) cte_wp_at_tcbI')
+      apply fastforce
      apply simp
-    apply (rename_tac arch_kernel_object)
-    apply (case_tac "arch_kernel_object", simp_all)
-      apply (rename_tac asidpool)
-      apply (case_tac asidpool, clarsimp simp: page_directory_at'_def)
-     apply (rename_tac pte)
-     apply (case_tac pte, simp_all add: valid_mapping'_def)
-    apply (rename_tac pde)
-    apply (case_tac pde, simp_all add: valid_mapping'_def)
-   apply (clarsimp dest!: refs_of' simp flip: injectKO_sc)
-   apply (clarsimp simp: valid_sched_context'_def valid_bound_obj'_def split: option.splits)
-  apply (rename_tac reply)
-  apply (clarsimp simp flip: injectKO_reply)
-  apply (frule (1) refs_of')
-  apply (clarsimp simp: ko_wp_at'_def valid_reply'_def valid_bound_tcb'_def)
-  apply (rule conjI; (solves \<open>clarsimp split: option.splits\<close>)?)+
-   apply (case_tac "replyPrev reply = None"; clarsimp?)
-   apply (frule replyPrev_list_refs_of_replies[rotated])
-    apply (simp add: obj_at'_def projectKOs)
-  using sym_refs_def live_notRange list_refs_of_replies_live' apply fastforce
-  apply (case_tac "replyNext reply = None"; clarsimp?)
-  apply (rename_tac reply_next)
-  apply (case_tac reply_next; clarsimp)
-  apply (frule replyNext_list_refs_of_replies[rotated], simp)
-   apply (simp add: obj_at'_def projectKOs)
-  using sym_refs_def live_notRange list_refs_of_replies_live' apply fastforce
-  done
-
-lemma state_refs_for_state':
-  "\<lbrakk> pspace_aligned' s'; pspace_distinct' s'; pspace_distinct' state' \<rbrakk>
-   \<Longrightarrow> state_refs_of' state' = (\<lambda>x. if x \<in> base_bits then {} else state_refs_of' s' x)"
-  apply (rule ext)
-  by (auto simp: state_refs_of'_def intro!: pspace_distinctD' split: option.splits)
-
-lemma sc_tcb_not_idle_thread'_helper:
-  "\<lbrakk> pspace_aligned' s'; pspace_distinct' s'; pspace_bounded' s'; scTCB sc = Some tp;
-     ksPSpace s' scp = Some (KOSchedContext sc); sym_refs (state_refs_of' s') \<rbrakk>
-   \<Longrightarrow> (scp, TCBSchedContext) \<in> state_refs_of' s' tp"
-  apply (clarsimp simp: state_refs_of'_def
-                 elim!: sym_refsE)
-  by (simp add: pspace_alignedD' pspace_distinctD' pspace_boundedD')
-
-lemma sc_tcb_not_idle_thread':
-  "\<lbrakk> pspace_aligned' s'; pspace_distinct' s'; ksPSpace s' scp = Some (KOSchedContext sc);
-     scp \<noteq> idle_sc_ptr; valid_global_refs' s'; valid_pspace' s';
-     if_live_then_nonz_cap' s'; sym_refs (state_refs_of' s')\<rbrakk>
-   \<Longrightarrow> scTCB sc \<noteq> Some (ksIdleThread s')"
-  apply (frule (1) global'_no_ex_cap)
-  apply (rule valid_objsE'; fastforce?)
-  apply (clarsimp simp: valid_obj_def valid_sched_context_def is_tcb obj_at_def)
-  apply (frule sc_tcb_not_idle_thread'_helper; blast?)
-  apply (insert valid_idle')
-  apply (clarsimp simp: valid_idle'_def pred_tcb_at'_def obj_at'_def projectKOs state_refs_of'_def
-                        live'_def idle_tcb'_def
-                 dest!: sc_tcb_not_idle_thread'_helper if_live_then_nonz_capD')
-  done
-
-lemma thread_not_idle_implies_sc_not_idle'_helper:
-  "\<lbrakk> pspace_aligned' s'; pspace_distinct' s'; pspace_bounded' s'; tcbSchedContext tcb = Some scp;
-     ksPSpace s' tp = Some (KOTCB tcb); sym_refs (state_refs_of' s') \<rbrakk>
-   \<Longrightarrow> (tp, SCTcb) \<in> state_refs_of' s' scp"
-  apply (clarsimp simp: state_refs_of'_def
-                 elim!: sym_refsE)
-  by (simp add: pspace_alignedD' pspace_distinctD' pspace_boundedD')
-
-lemma thread_not_idle_implies_sc_not_idle':
-  "\<lbrakk> pspace_aligned' s'; pspace_distinct' s'; pspace_bounded' s'; ksPSpace s' tp = Some (KOTCB tcb);
-     tp \<noteq> idle_thread_ptr; valid_global_refs' s'; valid_objs' s';
-     valid_idle' s'; if_live_then_nonz_cap' s'; sym_refs (state_refs_of' s') \<rbrakk>
-   \<Longrightarrow> tcbSchedContext tcb \<noteq> Some idle_sc_ptr"
-  apply (frule global'_sc_no_ex_cap)
-   apply (blast intro: pspace)
-  apply (rule valid_objsE'; simp?)
-  apply (clarsimp simp: valid_obj'_def valid_tcb'_def is_sc_obj_def obj_at'_def)
-  apply (rename_tac ko obj)
-  apply (case_tac ko; clarsimp simp: projectKOs)
-   apply (drule (5) thread_not_idle_implies_sc_not_idle'_helper)
-   apply (drule if_live_then_nonz_capE'[where p=idle_sc_ptr])
-    apply (fastforce simp: ko_wp_at'_def  live_sc'_def state_refs_of'_def
-                    dest!: thread_not_idle_implies_sc_not_idle_helper)
-   apply fastforce
-  done
-
-lemma state_refs:
-  "\<lbrakk>pspace_aligned' s'; pspace_distinct' s'; pspace_bounded' s';
-    pspace_distinct' state'; sym_refs (state_refs_of' s')\<rbrakk>
-  \<Longrightarrow> (state_refs_of' state') = (state_refs_of' s')"
-  apply (rule ext)
-  apply (clarsimp simp: state_refs_for_state')
-  apply (rename_tac x)
-  apply (prop_tac "x \<in> base_bits", simp)
-  apply (frule untyped_range_live_idle')
-  apply (clarsimp simp: state_refs_of'_def split: option.splits)
-  apply (rename_tac ko)
-  apply (case_tac ko; simp)
-      apply (fastforce simp: ep_q_refs_of'_def ko_wp_at'_def)
-     apply (fastforce simp: ntfn_q_refs_of'_def ko_wp_at'_def live_ntfn'_def state_refs_of'_def
-                     split: ntfn.splits)
-    apply (insert refs valid_objs valid_idle' iflive pspace)
-    apply (frule (8) thread_not_idle_implies_sc_not_idle')
-     apply (fastforce simp: state_refs_of'_def)
-    apply (fastforce simp: ko_wp_at'_def)
-   apply (frule (6) sc_tcb_not_idle_thread')
-    apply (fastforce simp: state_refs_of'_def)
-   apply (clarsimp simp: ko_wp_at'_def live_sc'_def  valid_idle'_def)
-  apply (clarsimp simp: ko_wp_at'_def live_reply'_def)
-  done
-
-
-lemma list_refs_of_reply'_state':
-  "\<lbrakk>pspace_aligned' s'; pspace_distinct' s'; pspace_bounded' s'; pspace_distinct' state'\<rbrakk>
-   \<Longrightarrow> (map_set (replies' ||> list_refs_of_reply')) = (list_refs_of_replies' s')"
-  apply (rule ext)
-  apply (clarsimp simp: list_refs_of_replies'_def list_refs_of_reply'_def opt_map_def
-                 split: option.splits)
-  apply (rename_tac x reply_ptr reply)
-  apply (prop_tac "x \<in> base_bits", simp)
-  apply (frule untyped_range_live_idle')
-  apply (clarsimp simp: live'_def ko_wp_at'_def live_reply'_def projectKOs)
-  using pspace_alignedD' pspace_distinctD' pspace_boundedD' apply clarsimp
+    apply (intro conjI)
+       apply (rename_tac tcb)
+       apply (case_tac "tcbState tcb"; clarsimp simp: valid_tcb_state'_def  dest!: refs_notRange)
+      apply (rename_tac tcb)
+      apply (case_tac "tcbState tcb";
+             clarsimp simp: valid_tcb_state'_def valid_bound_ntfn'_def
+                     dest!: refs_notRange split: option.splits)
+     apply (clarsimp simp: none_top_bool_cases)
+     apply (rename_tac prev)
+     apply (cut_tac P=live' and p=prev in live_notRange; fastforce?)
+     apply (fastforce dest: sym_heapD2[where p'=p]
+                      simp: opt_map_def ko_wp_at'_def obj_at'_def projectKOs)
+    apply (clarsimp simp: none_top_bool_cases)
+    apply (rename_tac "next")
+    apply (cut_tac P=live' and p="next" in live_notRange; fastforce?)
+    apply (fastforce dest!: sym_heapD1[where p=p]
+                     simp: opt_map_def ko_wp_at'_def obj_at'_def projectKOs)
+   apply (clarsimp simp: valid_cte'_def)
+   apply (rule_tac p=p in valid_cap2)
+   apply (clarsimp simp: ko_wp_at'_def objBits_simps' cte_level_bits_def[symmetric])
+   apply (erule(2) cte_wp_at_cteI')
+   apply simp
+  apply (rename_tac arch_kernel_object)
+  apply (case_tac "arch_kernel_object", simp_all)
+    apply (rename_tac asidpool)
+    apply (case_tac asidpool, clarsimp simp: page_directory_at'_def)
+   apply (rename_tac pte)
+   apply (case_tac pte, simp_all add: valid_mapping'_def)
+  apply(rename_tac pde)
+  apply (case_tac pde, simp_all add: valid_mapping'_def)
   done
 
 lemma tcbSchedNexts_of_pspace':
@@ -1736,14 +1370,12 @@ lemma exists_disj:
    by auto
 
 lemma (in delete_locale) delete_invs':
-  assumes "\<forall>t. t \<in> set (ksReleaseQueue s) \<longrightarrow> obj_at' (runnable' \<circ> tcbState) t s"
-  and "sym_refs (state_refs_of' s')"
-  shows "invs' (ksMachineState_update
-             (\<lambda>ms. underlying_memory_update
-                (\<lambda>m x. if base \<le> x \<and> x \<le> base + (2 ^ bits - 1) then 0 else m x) ms)
-              state')" (is "invs' (?state'')")
+  "invs' (ksMachineState_update
+           (\<lambda>ms. underlying_memory_update
+              (\<lambda>m x. if base \<le> x \<and> x \<le> base + (2 ^ bits - 1) then 0 else m x) ms)
+           state')" (is "invs' (?state'')")
 using vds
-proof (simp add: invs'_def valid_pspace'_def (* FIXME: do not simp here *)
+proof (simp add: invs'_def valid_state'_def valid_pspace'_def
                  valid_mdb'_def valid_mdb_ctes_def,
        safe)
   interpret Arch . (*FIXME: arch-split*)
@@ -1757,65 +1389,24 @@ proof (simp add: invs'_def valid_pspace'_def (* FIXME: do not simp here *)
     by (clarsimp simp add: pspace_distinct'_def ps_clear_def
                            dom_if_None Diff_Int_distrib)
 
-  show "pspace_bounded' ?s" using bd
-    by (simp add: pspace_bounded'_def dom_def)
-
-  show "valid_objs' ?s" using valid_objs assms
+  show "valid_objs' ?s" using valid_objs sym_sched
     apply (clarsimp simp: valid_objs'_def ran_def)
-    apply (insert list_refs pa pd bd)
-    apply (rule_tac p=a in valid_obj'; fastforce?)
-    apply (frule pspace_alignedD'[OF _ pa])
-    apply (frule pspace_distinctD'[OF _ pd])
-    apply (frule pspace_boundedD'[OF _ bd])
-    apply (clarsimp simp: ko_wp_at'_def)
+    apply (rule_tac p=a in valid_obj')
+      apply fastforce
+     apply (frule pspace_alignedD'[OF _ pa])
+     apply (frule pspace_distinctD'[OF _ pd])
+     apply (clarsimp simp: ko_wp_at'_def)
+    apply fastforce
     done
 
-  show "valid_replies' ?s" using vreplies assms
-    apply (clarsimp simp: valid_replies'_def simp del: imp_disjL)
-    apply (prop_tac "rptr \<notin> base_bits")
-     apply (clarsimp simp: opt_map_def)
-    apply (drule_tac x=rptr in spec, drule mp)
-     apply (fastforce simp: opt_map_def)
-    apply clarsimp
-    apply (prop_tac "tptr \<notin> base_bits")
-     apply (rule live_notRange[where P=live']; clarsimp?)
-     apply (fastforce simp: ko_wp_at'_def pred_tcb_at'_def obj_at'_def projectKOs)
-    apply (clarsimp simp: pred_tcb_at'_def opt_map_def)
+  from sym_refs show "sym_refs (state_refs_of' ?s)"
+    apply -
+    apply (clarsimp simp: state_refs_ko_wp_at_eq
+                   elim!: rsubst[where P=sym_refs])
+    apply (rule ext)
+    apply safe
+    apply (simp add: refs_notRange[simplified] state_refs_ko_wp_at_eq)
     done
-
-  show "sym_refs (map_set (replies' ||> list_refs_of_reply'))"
-    apply (insert pa pd bd pspace_distinct'_state' list_refs)
-    by (subst list_refs_of_reply'_state'; blast?)
-
-  from vq show "valid_queues ?s"
-    apply (clarsimp simp: valid_queues_def bitmapQ_defs)
-    apply (clarsimp simp: valid_queues_no_bitmap_def)
-    apply (drule spec, drule spec, drule conjunct1, drule(1) bspec)
-    apply (clarsimp simp: obj_at'_real_def)
-    apply (frule if_live_then_nonz_capE'[OF iflive, OF ko_wp_at'_weakenE])
-     apply (clarsimp simp: projectKOs inQ_def)
-    apply (clarsimp dest!: ex_nonz_cap_notRange)
-    done
-
-  from vq' show "valid_queues' ?s"
-    by (simp add: valid_queues'_def)
-
-  from rlqrun show "valid_release_queue ?s"
-    apply (clarsimp simp: valid_release_queue_def)
-    apply (insert assms vrlq)
-    apply (drule_tac x=t and P="\<lambda>t. t \<in> set (ksReleaseQueue s)
-                                    \<longrightarrow> obj_at' (runnable' \<circ> tcbState) t s"
-                  in spec)
-    apply (clarsimp simp: obj_at'_real_def)
-    apply (drule_tac x=t in spec, simp)
-    apply (frule live_notRange)
-     apply (fastforce simp: projectKOs live'_def ko_wp_at'_def obj_at'_def
-                     split: Structures_H.thread_state.splits)
-    apply (clarsimp simp: valid_release_queue_def obj_at'_real_def)
-    done
-
-  from vrlq' show "valid_release_queue' ?s"
-    by (simp add: valid_release_queue'_def)
 
   show "if_live_then_nonz_cap' ?s" using iflive
     apply (clarsimp simp: if_live_then_nonz_cap'_def)
@@ -1835,6 +1426,19 @@ proof (simp add: invs'_def valid_pspace'_def (* FIXME: do not simp here *)
   have "ksIdleThread s' \<notin> ?ran"
     apply (simp add: cte_wp_at_ctes_of valid_global_refs'_def valid_refs'_def)
     apply blast
+    done
+  with idle show "valid_idle' ?s"
+    apply (clarsimp simp: valid_idle'_def pred_tcb_at'_def obj_at'_def projectKOs)
+    apply (clarsimp simp add: ps_clear_def dom_if_None Diff_Int_distrib)
+    done
+
+  from tcb_at_invs' [OF invs] ct_act
+  show "cur_tcb' ?s" unfolding cur_tcb'_def
+    apply (clarsimp simp: cur_tcb'_def ct_in_state'_def)
+    apply (drule st_tcb)
+      apply simp
+     apply simp
+    apply (simp add: pred_tcb_at'_def)
     done
 
   let ?ctes' = ctes'
@@ -1959,6 +1563,11 @@ proof (simp add: invs'_def valid_pspace'_def (* FIXME: do not simp here *)
     apply clarsimp
     done
 
+  show "reply_masters_rvk_fb ?ctes'"
+    using rep_r_fb
+    by (simp add: tree_to_ctes reply_masters_rvk_fb_def
+                  ball_ran_eq)
+
   from virqs
   show "valid_irq_states' s'" .
 
@@ -1974,13 +1583,20 @@ proof (simp add: invs'_def valid_pspace'_def (* FIXME: do not simp here *)
   show "irqs_masked' state'"
     by (simp add: irqs_masked'_def)
 
+  from sa_simp ct_act
+  show "sch_act_wf (ksSchedulerAction s') state'"
+    apply (simp add: sch_act_simple_def)
+    apply (case_tac "ksSchedulerAction s'", simp_all add: ct_in_state'_def)
+    apply (fastforce dest!: st_tcb elim!: pred_tcb'_weakenE)
+    done
+
   from invs
-  have "pspace_domain_valid s'" by (simp add: invs'_def)
+  have "pspace_domain_valid s'" by (simp add: invs'_def valid_state'_def)
   thus "pspace_domain_valid state'"
     by (simp add: pspace_domain_valid_def)
 
   from invs
-  have "valid_machine_state' s'" by (simp add: invs'_def)
+  have "valid_machine_state' s'" by (simp add: invs'_def valid_state'_def)
   thus "valid_machine_state' ?state''"
     apply (clarsimp simp: valid_machine_state'_def)
     apply (drule_tac x=p in spec)
@@ -2003,10 +1619,42 @@ proof (simp add: invs'_def valid_pspace'_def (* FIXME: do not simp here *)
     apply (auto simp add: x_power_minus_1)
     done
 
+  from sa_simp ctnotinQ
+  show "ct_not_inQ state'"
+    apply (clarsimp simp: ct_not_inQ_def pred_tcb_at'_def)
+    apply (drule obj_at'_and
+                   [THEN iffD2, OF conjI,
+                    OF ct_act [unfolded ct_in_state'_def pred_tcb_at'_def]])
+    apply (clarsimp simp: obj_at'_real_def)
+    apply (frule if_live_then_nonz_capE'[OF iflive, OF ko_wp_at'_weakenE])
+     apply (clarsimp simp: projectKOs)
+     apply (case_tac "tcbState obj")
+            apply (clarsimp simp: projectKOs)+
+    apply (clarsimp dest!: ex_nonz_cap_notRange)
+    done
+
+  from ctcd show "ct_idle_or_in_cur_domain' state'"
+    apply (simp add: ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def)
+    apply (intro impI)
+    apply (elim disjE impE)
+     apply simp+
+    apply (intro impI)
+    apply (rule disjI2)
+    apply (drule obj_at'_and
+                   [THEN iffD2, OF conjI,
+                    OF ct_act [unfolded ct_in_state'_def st_tcb_at'_def]])
+    apply (clarsimp simp: obj_at'_real_def)
+    apply (frule if_live_then_nonz_capE'[OF iflive, OF ko_wp_at'_weakenE])
+     apply (clarsimp simp: projectKOs)
+     apply (case_tac "tcbState obj")
+            apply (clarsimp simp: projectKOs)+
+    apply (clarsimp dest!: ex_nonz_cap_notRange elim!: ko_wp_at'_weakenE)
+    done
+
   from cdm show "ksCurDomain s' \<le> maxDomain" .
 
   from invs
-  have urz: "untyped_ranges_zero' s'" by (simp add: invs'_def)
+  have urz: "untyped_ranges_zero' s'" by (simp add: invs'_def valid_state'_def)
   show "untyped_ranges_zero_inv (cteCaps_of state')
     (gsUntypedZeroRanges s')"
     apply (simp add: untyped_zero_ranges_cte_def
@@ -2074,6 +1722,7 @@ lemma deleteObjects_null_filter:
      and K (bits < word_bits \<and> is_aligned ptr bits)\<rbrace>
   deleteObjects ptr bits
   \<lbrace>\<lambda>rv s.  P (null_filter' (ctes_of s))\<rbrace>"
+  apply (simp add: deleteObjects_def3)
   apply (simp add: deleteObjects_def3 doMachineOp_def split_def)
   apply wp
   apply clarsimp
@@ -2085,7 +1734,6 @@ lemma deleteObjects_null_filter:
    apply (subgoal_tac "ksPSpace (s\<lparr>ksMachineState := snd ((), b)\<rparr>) =
                        ksPSpace s", simp only:, simp)
   apply (unfold_locales, simp_all)
-   apply (clarsimp simp: deletionIsSafe_def sym_refs_asrt_def valid_idle'_asrt_def)+
   done
 
 lemma deleteObjects_descendants:
@@ -2129,11 +1777,8 @@ proof -
   apply (simp cong: if_cong)
   apply (subgoal_tac "is_aligned ptr bits \<and> 2 \<le> bits \<and> bits < word_bits",simp)
    apply clarsimp
-   apply (frule delete_locale.intro; simp add: deletionIsSafe_def sym_refs_asrt_def valid_idle'_asrt_def)
-    apply (rule subst[rotated, where P=invs'], erule delete_locale.delete_invs')
-     apply (clarsimp simp: deletionIsSafe_def)
-     apply blast
-    apply blast
+   apply (frule(2) delete_locale.intro, simp_all)[1]
+   apply (rule subst[rotated, where P=invs'], erule delete_locale.delete_invs')
    apply (simp add: field_simps)
   apply clarsimp
   apply (drule invs_valid_objs')
@@ -2163,12 +1808,12 @@ lemma deleteObjects_st_tcb_at':
      apply (fastforce elim: ko_wp_at'_weakenE)
     apply (erule if_live_then_nonz_capD' [rotated])
      apply (clarsimp simp: projectKOs)
-    apply (clarsimp simp: invs'_def)
+    apply (clarsimp simp: invs'_def valid_state'_def)
    apply (clarsimp simp: pred_tcb_at'_def obj_at'_real_def
                   field_simps ko_wp_at'_def ps_clear_def
                   cong:if_cong
                   split: option.splits)
-  apply (simp add: delete_locale_def deletionIsSafe_def sym_refs_asrt_def valid_idle'_asrt_def)
+  apply (simp add: delete_locale_def)
   done
 
 lemma deleteObjects_cap_to':
@@ -2194,22 +1839,20 @@ lemma deleteObjects_cap_to':
                          else ksPSpace s x\<rparr>)",erule ssubst)
     apply (simp add: field_simps ex_cte_cap_wp_to'_def cong:if_cong)
    apply simp
-  apply (simp add: delete_locale_def deletionIsSafe_def sym_refs_asrt_def valid_idle'_asrt_def)
+  apply (simp add: delete_locale_def)
   done
 
 lemma valid_untyped_no_overlap:
   "\<lbrakk> valid_untyped' d ptr bits idx s; is_aligned ptr bits; valid_pspace' s \<rbrakk>
   \<Longrightarrow> pspace_no_overlap' ptr bits (s\<lparr>ksPSpace := ksPSpace s |` (- {ptr .. ptr + 2 ^ bits - 1})\<rparr>)"
   apply (clarsimp simp del: atLeastAtMost_iff
-                  simp: pspace_no_overlap'_def valid_cap'_def valid_untyped'_def)
+            simp: pspace_no_overlap'_def valid_cap'_def valid_untyped'_def is_aligned_neg_mask_eq)
   apply (drule_tac x=x in spec)
   apply (drule restrict_map_Some_iff[THEN iffD1])
   apply clarsimp
   apply (frule pspace_alignedD')
    apply (simp add: valid_pspace'_def)
   apply (frule pspace_distinctD')
-   apply (simp add: valid_pspace'_def)
-  apply (frule pspace_boundedD')
    apply (simp add: valid_pspace'_def)
   apply (unfold ko_wp_at'_def obj_range'_def)
   apply (drule (1) aligned_ranges_subset_or_disjoint)
@@ -2284,12 +1927,6 @@ lemma deleteObjects_invs_derivatives:
      and K (bits < word_bits \<and> is_aligned ptr bits)\<rbrace>
      deleteObjects ptr bits
    \<lbrace>\<lambda>rv. pspace_distinct'\<rbrace>"
-  "\<lbrace>cte_wp_at' (\<lambda>c. cteCap c = UntypedCap d ptr bits idx) p
-     and invs' and ct_active' and sch_act_simple
-     and (\<lambda>s. descendants_range' (UntypedCap d ptr bits idx) p (ctes_of s))
-     and K (bits < word_bits \<and> is_aligned ptr bits)\<rbrace>
-     deleteObjects ptr bits
-   \<lbrace>\<lambda>rv. pspace_bounded'\<rbrace>"
   by (safe intro!: hoare_strengthen_post [OF deleteObjects_invs'])
 
 lemma deleteObjects_nosch:
@@ -2314,45 +1951,35 @@ definition pspace_no_overlap_cell' where
 
 lemma pspace_no_overlap'_lift:
   assumes typ_at:"\<And>slot P Q. \<lbrace>\<lambda>s. P (typ_at' Q slot s)\<rbrace> f \<lbrace>\<lambda>r s. P (typ_at' Q slot s) \<rbrace>"
-  assumes sz: "\<And>p n. \<lbrace>\<lambda>s. sc_at'_n n p s\<rbrace> f \<lbrace>\<lambda>rv s. sc_at'_n n p s\<rbrace>"
-  assumes ps :"\<lbrace>Q and pspace_aligned' and pspace_distinct' and pspace_bounded'\<rbrace>
-                  f \<lbrace>\<lambda>r s. pspace_aligned' s \<and> pspace_distinct' s \<and> pspace_bounded' s\<rbrace>"
-  shows "\<lbrace>Q and pspace_aligned' and pspace_distinct' and pspace_bounded' and pspace_no_overlap' ptr sz\<rbrace>
-                f \<lbrace>\<lambda>r. pspace_no_overlap' ptr sz\<rbrace>"
+  assumes ps :"\<lbrace>Q\<rbrace> f \<lbrace>\<lambda>r s. pspace_aligned' s \<and> pspace_distinct' s \<rbrace>"
+  shows "\<lbrace>Q and pspace_no_overlap' ptr sz \<rbrace> f \<lbrace>\<lambda>r. pspace_no_overlap' ptr sz\<rbrace>"
 proof -
-  note blah[simp del] = untyped_range.simps usable_untyped_range.simps atLeastAtMost_simps
+  note blah[simp del] = untyped_range.simps usable_untyped_range.simps atLeastAtMost_iff atLeastatMost_subset_iff atLeastLessThan_iff
+          Int_atLeastAtMost atLeastatMost_empty_iff split_paired_Ex
   show ?thesis
     apply (clarsimp simp:valid_def pspace_no_overlap'_def)
     apply (drule_tac x = x in spec)
     apply (subgoal_tac "\<exists>ko'. ksPSpace s x = Some ko' \<and> koTypeOf ko = koTypeOf ko'")
-     apply (clarsimp, frule koType_objBitsKO; clarsimp)
-     apply (frule_tac p1=x and n1="objBitsKO ko'" in use_valid[OF _ sz])
-      apply (fastforce simp: ko_wp_at'_def dest: pspace_alignedD' pspace_distinctD' pspace_boundedD')
-     apply (clarsimp simp: ko_wp_at'_def)
+     apply (clarsimp dest!:objBits_type)
     apply (rule ccontr)
     apply clarsimp
     apply (frule_tac slot1 = x and Q1 = "koTypeOf ko" and P1 = "\<lambda>a. \<not> a" in use_valid[OF _ typ_at])
-     apply (clarsimp simp:typ_at'_def ko_wp_at'_def)+
-    apply (frule use_valid[OF _ ps])
-     apply (clarsimp simp:valid_pspace'_def)+
+    apply (clarsimp simp:typ_at'_def ko_wp_at'_def)+
+    apply (frule(1) use_valid[OF _ ps])
+    apply (clarsimp simp:valid_pspace'_def)
     apply (frule(1) pspace_alignedD')
-    apply (frule(1) pspace_distinctD')
-    apply (drule(1) pspace_boundedD')
+    apply (drule(1) pspace_distinctD')
     apply simp
-    done
+  done
 qed
 
-lemmas pspace_no_overlap'_lift2 = pspace_no_overlap'_lift[where Q=\<top>, simplified]
-
-crunch setCTE, insertNewCap
-  for sc_at'_n[wp]: "\<lambda>s. P (sc_at'_n n p s)"
-  (simp: crunch_simps wp: crunch_wps)
-
 lemma setCTE_pspace_no_overlap':
-  "\<lbrace>pspace_aligned' and pspace_distinct' and pspace_bounded' and pspace_no_overlap' ptr sz\<rbrace>
+  "\<lbrace>pspace_aligned' and pspace_distinct' and pspace_no_overlap' ptr sz\<rbrace>
    setCTE cte src
    \<lbrace>\<lambda>r. pspace_no_overlap' ptr sz\<rbrace>"
-   by (rule pspace_no_overlap'_lift2; wpsimp wp: setCTE_typ_at')
+   apply (rule pspace_no_overlap'_lift; wp setCTE_typ_at')
+   apply auto
+   done
 
 lemma getCTE_commute:
   assumes cte_at_modify:
@@ -2400,12 +2027,12 @@ qed
 
 definition "cte_check \<equiv> \<lambda>b src a next. (case b of
      KOTCB tcb \<Rightarrow> (is_aligned a (objBits tcb)
-        \<and> (case next of None \<Rightarrow> True | Some z \<Rightarrow> 2^objBits tcb \<le> z - a)) \<and>
+        \<and> (case next of None \<Rightarrow> True | Some z \<Rightarrow> 2^(objBits tcb) \<le> z - a)) \<and>
         (src - a = tcbVTableSlot << cteSizeBits
         \<or> src - a = tcbCTableSlot << cteSizeBits
-        \<or> src - a = tcbIPCBufferSlot << cteSizeBits
-        \<or> src - a = tcbFaultHandlerSlot << cteSizeBits
-        \<or> src - a = tcbTimeoutHandlerSlot << cteSizeBits)
+        \<or> src - a = tcbReplySlot << cteSizeBits
+        \<or> src - a = tcbCallerSlot << cteSizeBits
+        \<or> src - a = tcbIPCBufferSlot << cteSizeBits )
      | KOCTE v1 \<Rightarrow> ( src = a \<and> (is_aligned a (objBits (makeObject::cte)))
         \<and> (case next of None \<Rightarrow> True | Some z \<Rightarrow> 2^(objBits (makeObject::cte)) \<le> z - a))
      | _ \<Rightarrow> False)"
@@ -2421,11 +2048,11 @@ definition locateCTE where
 
 definition cte_update where
   "cte_update  \<equiv> \<lambda>cte b src a. (case b of
-     KOTCB tcb \<Rightarrow> if src - a = tcbVTableSlot << cteSizeBits then KOTCB (tcbVTable_update (\<lambda>_. cte) tcb)
-        else if src - a = tcbCTableSlot << cteSizeBits then KOTCB (tcbCTable_update (\<lambda>_. cte) tcb)
-        else if src - a = tcbIPCBufferSlot << cteSizeBits then KOTCB (tcbIPCBufferFrame_update (\<lambda>_. cte) tcb)
-        else if src - a = tcbFaultHandlerSlot << cteSizeBits then KOTCB (tcbFaultHandler_update (\<lambda>_. cte) tcb)
-        else if src - a = tcbTimeoutHandlerSlot << cteSizeBits then KOTCB (tcbTimeoutHandler_update (\<lambda>_. cte) tcb)
+     KOTCB tcb \<Rightarrow> if (src - a = tcbVTableSlot << cteSizeBits) then KOTCB (tcbVTable_update (\<lambda>_. cte) tcb)
+        else if (src - a = tcbCTableSlot << cteSizeBits) then KOTCB (tcbCTable_update (\<lambda>_. cte) tcb)
+        else if (src - a = tcbReplySlot << cteSizeBits) then KOTCB (tcbReply_update (\<lambda>_. cte) tcb)
+        else if (src - a = tcbCallerSlot << cteSizeBits) then KOTCB (tcbCaller_update (\<lambda>_. cte) tcb)
+        else if (src - a = tcbIPCBufferSlot << cteSizeBits) then KOTCB (tcbIPCBufferFrame_update (\<lambda>_. cte) tcb)
         else KOTCB tcb
      | KOCTE v1 \<Rightarrow> KOCTE cte
      | x \<Rightarrow> x)"
@@ -2435,15 +2062,21 @@ lemma simpler_updateObject_def:
    (\<lambda>s. (if (cte_check b src a next) then ({(cte_update cte b src a,s)}, False)
          else fail s))"
   apply (rule ext)
-  apply (clarsimp simp: ObjectInstances_H.updateObject_cte objBits_simps)
-  apply (case_tac b; simp add: cte_check_def typeError_def fail_def tcbSlot_defs cteSizeBits_def)
-  by (intro conjI;
-      clarsimp simp: alignCheck_def unless_def when_def not_less[symmetric]
-                     alignError_def is_aligned_mask magnitudeCheck_def assert_def
-                     cte_update_def return_def tcbSlot_defs objBits_simps cteSizeBits_def
-                     read_alignCheck_def ounless_def read_magnitudeCheck_def read_alignError_def
-               split:option.splits;
-      fastforce simp:return_def fail_def bind_def)+
+  apply (clarsimp simp:ObjectInstances_H.updateObject_cte objBits_simps)
+  apply (case_tac b)
+   apply (simp_all add:cte_check_def typeError_def fail_def
+          tcbIPCBufferSlot_def
+          tcbCallerSlot_def tcbReplySlot_def
+          tcbCTableSlot_def tcbVTableSlot_def)
+   by (intro conjI impI;
+        clarsimp simp:alignCheck_def unless_def when_def not_less[symmetric]
+         alignError_def is_aligned_mask magnitudeCheck_def
+         cte_update_def return_def tcbIPCBufferSlot_def
+         tcbCallerSlot_def tcbReplySlot_def
+         tcbCTableSlot_def tcbVTableSlot_def objBits_simps
+         cteSizeBits_def split:option.splits;
+          fastforce simp:return_def fail_def bind_def)+
+
 
 lemma setCTE_def2:
  "(setCTE src cte) =
@@ -2472,9 +2105,10 @@ lemma pspace_no_overlapD3':
 
 lemma singleton_locateCTE:
   "a \<in> fst (locateCTE src s) = ({a} = fst (locateCTE src s))"
-  apply (clarsimp simp: locateCTE_def assert_opt_def assert_def gets_def get_def bind_def return_def
-                        split_def)
-  apply (clarsimp simp: return_def fail_def split: if_splits option.splits)+
+  apply (clarsimp simp:locateCTE_def assert_opt_def assert_def
+    gets_def get_def bind_def return_def split_def)
+  apply (clarsimp simp:return_def fail_def
+    split:if_splits option.splits)+
   done
 
 lemma locateCTE_inv:
@@ -2495,19 +2129,35 @@ lemma locateCTE_case:
   done
 
 lemma cte_wp_at_top:
-  "cte_wp_at' \<top> src s
-   = (\<exists>a b. fst (lookupAround2 src (ksPSpace s)) = Some (a, b) \<and>
-            cte_check b src a (snd (lookupAround2 src (ksPSpace s))))"
-  apply (simp add: cte_wp_at'_def getObject_def gets_def get_def bind_def return_def split_def
-                   assert_opt_def fail_def gets_the_def readObject_def omonad_defs obind_def
-            split: option.splits)
-  apply (clarsimp simp: loadObject_cte)
-  by (case_tac b;
-      simp add: typeError_def read_typeError_def obind_def omonad_defs cte_check_def
-                read_alignCheck_def read_magnitudeCheck_def read_alignError_def is_aligned_mask
-                objBits_simps tcbSlot_defs cteSizeBits_def
-         split: option.split;
-      fastforce)
+  "(cte_wp_at' \<top> src s)
+  = (\<exists>a b. ( fst (lookupAround2 src (ksPSpace s)) = Some (a, b) \<and>
+  cte_check b src a (snd (lookupAround2 src (ksPSpace s)))))"
+  apply (simp add:cte_wp_at'_def getObject_def gets_def
+    get_def bind_def return_def split_def
+    assert_opt_def fail_def
+    split:option.splits)
+  apply (clarsimp simp:loadObject_cte)
+  apply (case_tac b,simp_all)
+       apply ((simp add: typeError_def fail_def cte_check_def
+                  split: Structures_H.kernel_object.splits)+)[5]
+    apply (simp add:loadObject_cte cte_check_def
+      tcbIPCBufferSlot_def tcbCallerSlot_def
+      tcbReplySlot_def tcbCTableSlot_def
+      tcbVTableSlot_def objBits_simps cteSizeBits_def)
+    apply (simp add:alignCheck_def bind_def
+      alignError_def fail_def return_def objBits_simps
+      magnitudeCheck_def in_monad is_aligned_mask
+      when_def unless_def split:option.splits)
+    apply (intro conjI impI allI,simp_all add:not_le)
+   apply (clarsimp simp:cte_check_def)
+   apply (simp add:alignCheck_def bind_def
+     alignError_def fail_def return_def objBits_simps
+     magnitudeCheck_def in_monad is_aligned_mask
+     when_def unless_def split:option.splits)
+    apply (intro conjI impI allI,simp_all add:not_le)
+  apply (simp add:typeError_def fail_def
+         cte_check_def split:Structures_H.kernel_object.splits)+
+  done
 
 lemma locateCTE_monad:
   assumes ko_wp_at: "\<And>Q dest.
@@ -2520,12 +2170,9 @@ lemma locateCTE_monad:
   "\<lbrace>\<lambda>s. P3 s \<rbrace> f \<lbrace>\<lambda>a s. pspace_distinct' s\<rbrace>"
   assumes psp_aligned:
   "\<lbrace>\<lambda>s. P4 s \<rbrace> f \<lbrace>\<lambda>a s. pspace_aligned' s\<rbrace>"
-  assumes psp_bounded:
-  "\<lbrace>\<lambda>s. P5 s \<rbrace> f \<lbrace>\<lambda>a s. pspace_bounded' s\<rbrace>"
   shows
   "\<lbrakk>{(ptr, s)} = fst (locateCTE src s);
-    (r, s') \<in> fst (f s);pspace_aligned' s;pspace_distinct' s; pspace_bounded' s;
-    (P1 and P2 and P3 and P4 and P5) s\<rbrakk>
+    (r, s') \<in> fst (f s);pspace_aligned' s;pspace_distinct' s;(P1 and P2 and P3 and P4) s\<rbrakk>
    \<Longrightarrow> {(ptr,s')} = fst (locateCTE src s')"
 proof -
   have src_in_range:
@@ -2534,16 +2181,20 @@ proof -
     fix obj src a m
     show "\<And>s'. \<lbrakk>cte_check obj src a m; ksPSpace s' a = Some obj\<rbrakk> \<Longrightarrow> src \<in> {a..a + 2 ^ objBitsKO obj - 1}"
       by (case_tac obj)
-         (auto simp add: cte_check_def objBits_simps' diff_eq_eq add.commute[where b=a]
-                         word_plus_mono_right is_aligned_no_wrap' tcbSlot_defs)
+         (auto simp add: cte_check_def objBits_simps' diff_eq_eq
+                         add.commute[where b=a]
+                         word_plus_mono_right is_aligned_no_wrap'
+                         tcbVTableSlot_def tcbCTableSlot_def tcbReplySlot_def
+                         tcbCallerSlot_def tcbIPCBufferSlot_def )
   qed
 
-  note blah[simp del] = usableUntypedRange.simps atLeastAtMost_simps
+  note blah[simp del] = usableUntypedRange.simps atLeastAtMost_iff
+          atLeastatMost_subset_iff atLeastLessThan_iff
+          Int_atLeastAtMost atLeastatMost_empty_iff split_paired_Ex
 
   have step1:
     "\<lbrakk>(ptr, s) \<in> fst (locateCTE src s);
-      (r, s') \<in> fst (f s); pspace_aligned' s; pspace_distinct' s; pspace_bounded' s;
-      (P1 and P2 and P3 and P4 and P5) s\<rbrakk>
+      (r, s') \<in> fst (f s); pspace_aligned' s; pspace_distinct' s; (P1 and P2 and P3 and P4) s\<rbrakk>
      \<Longrightarrow> (ptr,s') \<in> fst (locateCTE src s')"
   apply (frule use_valid[OF _ locateCTE_case])
    apply simp
@@ -2559,15 +2210,12 @@ proof -
   apply (frule_tac dest1 = ptr and  Q1 = "\<lambda>x. x = objBitsKO b" in use_valid[OF _ ko_wp_at])
    apply (frule(1) pspace_alignedD')
    apply (frule(1) pspace_distinctD')
-   apply (frule(1) pspace_boundedD')
    apply (auto simp add:ko_wp_at'_def)[1]
   apply (clarsimp simp add:ko_wp_at'_def)
   apply (rule ccontr)
   apply (frule use_valid[OF _ psp_distinct])
    apply simp
   apply (frule use_valid[OF _ psp_aligned])
-   apply simp
-  apply (frule use_valid[OF _ psp_bounded])
    apply simp
   apply (frule_tac x = a in pspace_distinctD')
    apply simp
@@ -2581,11 +2229,10 @@ proof -
   apply (drule(1) src_in_range)+
   apply (drule base_member_set[OF pspace_alignedD'])
     apply simp
-   apply (simp add: word_bits_def)
-  apply (frule base_member_set[OF pspace_alignedD'])
+   apply (simp add:objBitsKO_bounded2[unfolded word_bits_def,simplified])
+  apply (drule base_member_set[OF pspace_alignedD'])
     apply simp
-   apply (fold word_bits_def)
-   apply (erule (1) pspace_boundedD')
+   apply (simp add:objBitsKO_bounded2[unfolded word_bits_def,simplified])
   apply (clarsimp simp: field_simps)
   apply (elim disjE; fastforce simp: mask_def p_assoc_help)
   done
@@ -2594,8 +2241,7 @@ proof -
     "(r, s') \<in> fst (f s)"
     "pspace_aligned' s"
     "pspace_distinct' s"
-    "pspace_bounded' s"
-    "(P1 and P2 and P3 and P4 and P5) s"
+    "(P1 and P2 and P3 and P4) s"
   thus ?thesis
   using assms step1
   by (clarsimp simp:singleton_locateCTE)
@@ -2615,17 +2261,14 @@ lemma locateCTE_commute:
   assumes nf: "no_fail P0 f" "no_fail P1 (locateCTE src)"
   and psp_distinct: "\<lbrace>\<lambda>s. P2 s \<rbrace> f \<lbrace>\<lambda>a s. pspace_distinct' s\<rbrace>"
   and psp_aligned: "\<lbrace>\<lambda>s. P3 s \<rbrace> f \<lbrace>\<lambda>a s. pspace_aligned' s\<rbrace>"
-  and psp_bounded: "\<lbrace>\<lambda>s. P4 s \<rbrace> f \<lbrace>\<lambda>a s. pspace_bounded' s\<rbrace>"
   assumes ko_wp_at: "\<And>Q dest.
   \<lbrace>\<lambda>s. (P0 and P1 and P2 and P3) s  \<and> ko_wp_at' (\<lambda>obj. Q (objBitsKO obj))  dest s \<rbrace> f
   \<lbrace>\<lambda>a s. ko_wp_at' (\<lambda>obj. Q (objBitsKO obj)) dest s\<rbrace>"
   and cte_wp_at: "\<And> dest.
   \<lbrace>\<lambda>s. (P0 and P1 and P2 and P3) s \<and> cte_wp_at' \<top> dest s \<rbrace> f
   \<lbrace>\<lambda>a s. cte_wp_at' \<top> dest s\<rbrace>"
-  shows "monad_commute
-           (P0 and P1 and P2 and P3 and P4 and P5
-                        and pspace_aligned' and pspace_distinct' and pspace_bounded')
-           (locateCTE src) f"
+  shows "monad_commute (P0 and P1 and P2 and P3 and P4 and P5 and pspace_aligned' and pspace_distinct')
+  (locateCTE src) f"
 proof -
   have same:
     "\<And>ptr val next s s'. (ptr, s') \<in> fst (locateCTE src s)
@@ -2640,7 +2283,7 @@ proof -
      apply (clarsimp)
      apply (rule bexI[rotated], assumption)
      apply (frule singleton_locateCTE[THEN iffD1])
-     apply (frule locateCTE_monad [OF ko_wp_at cte_wp_at psp_distinct psp_aligned psp_bounded])
+     apply (frule locateCTE_monad [OF ko_wp_at cte_wp_at psp_distinct psp_aligned])
          apply assumption+
       apply simp
      apply (clarsimp)
@@ -2656,7 +2299,7 @@ proof -
     apply (frule_tac s = s in same)
     apply clarsimp
     apply (frule_tac s1 = s in singleton_locateCTE[THEN iffD1])
-    apply (frule locateCTE_monad [OF ko_wp_at cte_wp_at psp_distinct psp_aligned psp_bounded])
+    apply (frule locateCTE_monad [OF ko_wp_at cte_wp_at psp_distinct psp_aligned])
         apply assumption+
      apply simp
     apply (rule bexI[rotated],assumption)
@@ -2678,7 +2321,7 @@ proof -
    apply (frule same)
    apply simp
    apply (frule singleton_locateCTE[THEN iffD1])
-   apply (frule locateCTE_monad [OF ko_wp_at cte_wp_at psp_distinct psp_aligned psp_bounded])
+   apply (frule locateCTE_monad [OF ko_wp_at cte_wp_at psp_distinct psp_aligned])
        apply assumption+
     apply simp
    apply (clarsimp)
@@ -2697,28 +2340,31 @@ lemma createObject_cte_wp_at':
   "\<lbrace>\<lambda>s. Types_H.getObjectSize ty us < word_bits \<and>
         is_aligned ptr (Types_H.getObjectSize ty us) \<and>
         pspace_no_overlap' ptr (Types_H.getObjectSize ty us) s \<and>
-        (ty = APIObjectType SchedContextObject \<longrightarrow> sc_size_bounds us) \<and>
-        cte_wp_at' (\<lambda>c. P c) slot s \<and> pspace_aligned' s \<and> pspace_distinct' s \<and> pspace_bounded' s\<rbrace>
+        cte_wp_at' (\<lambda>c. P c) slot s \<and> pspace_aligned' s \<and>
+        pspace_distinct' s\<rbrace>
    RetypeDecls_H.createObject ty ptr us d
    \<lbrace>\<lambda>r s. cte_wp_at' (\<lambda>c. P c) slot s \<rbrace>"
   apply (simp add:createObject_def)
   apply (rule hoare_pre)
-  by (wpc
-    | wp createObjects_orig_cte_wp_at'[where sz = "(Types_H.getObjectSize ty us)"]
-         threadSet_cte_wp_at'
-    | simp add: ARM_H.createObject_def placeNewDataObject_def unless_def placeNewObject_def2
-                objBits_simps range_cover_full curDomain_def pageBits_def ptBits_def pdBits_def
-                getObjSize_simps archObjSize_def apiGetObjectSize_def tcbBlockSizeBits_def
-                epSizeBits_def ntfnSizeBits_def scBits_simps cteSizeBits_def pteBits_def pdeBits_def
-    | intro conjI impI | clarsimp dest!: arch_toAPIType_simps)+
+   apply (wpc
+        | wp createObjects_orig_cte_wp_at'[where sz = "(Types_H.getObjectSize ty us)"]
+             threadSet_cte_wp_at'
+        | simp add: ARM_H.createObject_def placeNewDataObject_def
+                    unless_def placeNewObject_def2 objBits_simps range_cover_full
+                    curDomain_def pageBits_def ptBits_def
+                    pdBits_def getObjSize_simps archObjSize_def
+                    apiGetObjectSize_def tcbBlockSizeBits_def
+                    epSizeBits_def ntfnSizeBits_def
+                    cteSizeBits_def pteBits_def pdeBits_def
+        | intro conjI impI | clarsimp dest!: arch_toAPIType_simps)+
+  done
 
 lemma createObject_getCTE_commute:
   "monad_commute
-     (cte_wp_at' (\<lambda>_. True) dests and pspace_aligned' and pspace_distinct' and pspace_bounded' and
+     (cte_wp_at' (\<lambda>_. True) dests and pspace_aligned' and pspace_distinct' and
       pspace_no_overlap' ptr (Types_H.getObjectSize ty us) and
       K (ptr \<noteq> dests) and K (Types_H.getObjectSize ty us < word_bits) and
-      K (is_aligned ptr (Types_H.getObjectSize ty us)) and
-      K (ty = APIObjectType SchedContextObject \<longrightarrow> sc_size_bounds us))
+      K (is_aligned ptr (Types_H.getObjectSize ty us)))
      (RetypeDecls_H.createObject ty ptr us d) (getCTE dests)"
   apply (rule monad_commute_guard_imp[OF commute_commute])
    apply (rule getCTE_commute)
@@ -2746,7 +2392,7 @@ lemma simpler_placeNewObject_def:
     apply clarsimp
     apply (drule(1) pspace_alignedD')
     apply (simp add:is_aligned_no_overflow)
-   apply (clarsimp simp: shiftL_nat p_assoc_help)
+   apply (clarsimp simp: is_aligned_neg_mask_eq shiftL_nat p_assoc_help)
   apply simp
   done
 
@@ -2755,17 +2401,15 @@ lemma fail_set: "fst (fail s) = {}"
 
 lemma locateCTE_cte_no_fail:
  "no_fail (cte_at' src) (locateCTE src)"
-  apply (clarsimp simp: no_fail_def cte_wp_at'_def getObject_def
-                        locateCTE_def return_def gets_def get_def bind_def split_def
-                        gets_the_def readObject_def omonad_defs obind_def
-                        assert_opt_def assert_def fail_set
-                 split: option.splits)
+  apply (clarsimp simp:no_fail_def cte_wp_at'_def getObject_def
+     locateCTE_def return_def gets_def get_def bind_def split_def
+     assert_opt_def assert_def in_fail fail_set split:option.splits)
   apply (clarsimp simp:cte_check_def ObjectInstances_H.loadObject_cte)
+  apply (drule in_singleton)
   by (auto simp: objBits_simps cteSizeBits_def alignError_def
-                 alignCheck_def in_monad is_aligned_mask magnitudeCheck_def
-                 typeError_def read_typeError_def read_magnitudeCheck_def
-                 ohaskell_fail_def ohaskell_assert_def
-           cong: if_cong split: if_splits option.splits kernel_object.splits)
+    alignCheck_def in_monad is_aligned_mask magnitudeCheck_def
+    typeError_def
+    cong: if_cong split: if_splits option.splits kernel_object.splits)
 
 lemma not_in_new_cap_addrs:
   "\<lbrakk>is_aligned ptr (objBitsKO obj + us);
@@ -2792,14 +2436,14 @@ lemma not_in_new_cap_addrs:
 lemma placeNewObject_pspace_aligned':
   "\<lbrace>K (is_aligned ptr (objBitsKO (injectKOS val) + us) \<and>
         objBitsKO (injectKOS val) + us < word_bits) and
-    pspace_aligned' and pspace_distinct' and pspace_bounded' and
+    pspace_aligned' and pspace_distinct' and
     pspace_no_overlap' ptr (objBitsKO (injectKOS val) + us)\<rbrace>
    placeNewObject ptr val us
    \<lbrace>\<lambda>r s. pspace_aligned' s\<rbrace>"
   apply (clarsimp simp:valid_def)
   apply (simp add:simpler_placeNewObject_def simpler_modify_def)
   apply (subst data_map_insert_def[symmetric])+
-  apply (erule (3) Retype_R.retype_aligned_distinct' [unfolded data_map_insert_def[symmetric]])
+  apply (erule(2) Retype_R.retype_aligned_distinct' [unfolded data_map_insert_def[symmetric]])
   apply (rule range_cover_rel[OF range_cover_full])
      apply simp+
   done
@@ -2808,28 +2452,14 @@ lemma placeNewObject_pspace_distinct':
   "\<lbrace>\<lambda>s. objBitsKO (injectKOS val) + us < word_bits \<and>
         is_aligned ptr (objBitsKO (injectKOS val) + us) \<and>
         pspace_no_overlap' ptr (objBitsKO (injectKOS val) + us) s \<and>
-        pspace_aligned' s \<and> pspace_distinct' s \<and> pspace_bounded' s\<rbrace>
+        pspace_aligned' s \<and> pspace_distinct' s\<rbrace>
    placeNewObject ptr val us
    \<lbrace>\<lambda>a. pspace_distinct'\<rbrace>"
  apply (clarsimp simp:valid_def)
   apply (simp add:simpler_placeNewObject_def simpler_modify_def)
  apply (subst data_map_insert_def[symmetric])+
- apply (erule (3) Retype_R.retype_aligned_distinct'[unfolded data_map_insert_def[symmetric]])
- apply (rule range_cover_rel[OF range_cover_full])
-  apply simp+
- done
-
-lemma placeNewObject_pspace_bounded':
-  "\<lbrace>\<lambda>s. objBitsKO (injectKOS val) + us < word_bits \<and>
-        is_aligned ptr (objBitsKO (injectKOS val) + us) \<and>
-        pspace_no_overlap' ptr (objBitsKO (injectKOS val) + us) s \<and>
-        pspace_aligned' s \<and> pspace_distinct' s \<and> pspace_bounded' s\<rbrace>
-   placeNewObject ptr val us
-   \<lbrace>\<lambda>a. pspace_bounded'\<rbrace>"
- apply (clarsimp simp:valid_def)
-  apply (simp add:simpler_placeNewObject_def simpler_modify_def)
- apply (subst data_map_insert_def[symmetric])+
- apply (erule (3) Retype_R.retype_aligned_distinct'[unfolded data_map_insert_def[symmetric]])
+ apply (erule(2) Retype_R.retype_aligned_distinct'
+   [unfolded data_map_insert_def[symmetric]])
  apply (rule range_cover_rel[OF range_cover_full])
   apply simp+
  done
@@ -2841,7 +2471,7 @@ lemma placeNewObject_ko_wp_at':
         objBitsKO (injectKOS val) + us < word_bits \<and>
         is_aligned ptr (objBitsKO (injectKOS val) + us) \<and>
         pspace_no_overlap' ptr (objBitsKO (injectKOS val) + us) s \<and>
-        pspace_aligned' s \<and> pspace_distinct' s \<and> pspace_bounded' s\<rbrace>
+        pspace_aligned' s \<and> pspace_distinct' s\<rbrace>
    placeNewObject ptr val us
    \<lbrace>\<lambda>a. ko_wp_at' P slot\<rbrace>"
   apply (clarsimp simp:valid_def split del:if_split)
@@ -2880,7 +2510,7 @@ lemma placeNewObject_cte_wp_at':
   "\<lbrace>K (is_aligned ptr (objBitsKO (injectKOS val) + us) \<and>
        objBitsKO (injectKOS val) + us < word_bits) and
     K (ptr \<noteq> src) and cte_wp_at' P src and
-    pspace_aligned' and pspace_distinct' and pspace_bounded' and
+    pspace_aligned' and pspace_distinct' and
     pspace_no_overlap' ptr (objBitsKO (injectKOS val) + us)\<rbrace>
    placeNewObject ptr val us
    \<lbrace>\<lambda>r s. cte_wp_at' P src s\<rbrace>"
@@ -2895,7 +2525,7 @@ lemma placeNewObject_cte_wp_at'':
   objBitsKO (injectKOS val) + us < word_bits \<and>
   is_aligned ptr (objBitsKO (injectKOS val) + us) \<and>
   pspace_no_overlap' ptr (objBitsKO (injectKOS val) + us) s \<and>
-  pspace_aligned' s \<and> pspace_distinct' s \<and> pspace_bounded' s\<rbrace>
+  pspace_aligned' s \<and> pspace_distinct' s\<rbrace>
   placeNewObject ptr val us \<lbrace>\<lambda>a s. cte_wp_at' P slot s\<rbrace>"
   apply (simp add:cte_wp_at_cases_mask' obj_at'_real_def)
   apply (wp hoare_vcg_disj_lift placeNewObject_ko_wp_at')
@@ -2925,14 +2555,13 @@ lemma placeNewObject_locateCTE_commute:
      (K (is_aligned ptr (objBitsKO (injectKOS val) + us) \<and>
          (objBitsKO (injectKOS val) + us) < word_bits \<and> ptr \<noteq> src) and
       pspace_no_overlap' ptr (objBitsKO (injectKOS val) + us) and
-      pspace_aligned' and pspace_distinct' and pspace_bounded' and cte_at' src)
+      pspace_aligned' and pspace_distinct' and cte_at' src)
      (placeNewObject ptr val us) (locateCTE src)"
   apply (rule monad_commute_guard_imp)
   apply (rule commute_commute[OF locateCTE_commute])
       apply (wp no_fail_placeNewObject locateCTE_cte_no_fail
         placeNewObject_pspace_aligned'
         placeNewObject_pspace_distinct'
-        placeNewObject_pspace_bounded'
         placeNewObject_ko_wp_at' | simp)+
     apply (clarsimp simp:ko_wp_at'_def)
     apply (drule(3) not_in_new_cap_addrs)
@@ -2997,7 +2626,8 @@ lemma placeNewObject_modify_commute:
     apply simp
    apply (drule_tac x = ptr' in in_empty_interE)
      apply (clarsimp simp:is_aligned_no_overflow)
-    apply (clarsimp simp:range_cover_def ptr_add_def obj_range'_def p_assoc_help)
+    apply (clarsimp simp:range_cover_def ptr_add_def
+     is_aligned_neg_mask_eq obj_range'_def p_assoc_help)
    apply simp
   done
 
@@ -3023,9 +2653,9 @@ lemma locateCTE_ko_wp_at':
    \<lbrace>\<lambda>rv. ko_wp_at' \<top> rv \<rbrace>"
   apply (clarsimp simp:locateCTE_def split_def)
   apply wp
-  apply (clarsimp simp: cte_wp_at'_def getObject_def gets_the_def  obind_def omonad_defs
-                        gets_def split_def get_def bind_def return_def readObject_def
-                        ko_wp_at'_def lookupAround2_char1 assert_opt_def)
+  apply (clarsimp simp:cte_wp_at'_def getObject_def
+    gets_def split_def get_def bind_def return_def
+    ko_wp_at'_def lookupAround2_char1 assert_opt_def)
   apply (clarsimp split:option.splits
     simp:fail_def return_def lookupAround2_char1)
   apply (case_tac ba)
@@ -3033,10 +2663,10 @@ lemma locateCTE_ko_wp_at':
     apply (clarsimp simp:lookupAround2_char1
       objBits_simps cte_update_def)
     apply (drule(1) pspace_distinctD')+
-    apply (simp add: objBits_simps' word_bits_def)
+    apply (simp add:objBits_simps)
   apply (clarsimp simp:objBits_simps cte_update_def)
   apply (drule(1) pspace_distinctD')+
-  apply (simp add: objBits_simps' word_bits_def)
+  apply (simp add:objBits_simps)
   done
 
 
@@ -3045,7 +2675,7 @@ lemma setCTE_placeNewObject_commute:
      (K (is_aligned ptr (objBitsKO (injectKOS val) + us) \<and>
          objBitsKO (injectKOS val) + us < word_bits) and
       K(ptr \<noteq> src) and cte_wp_at' (\<lambda>_. True) src and
-      pspace_aligned' and pspace_distinct' and pspace_bounded' and
+      pspace_aligned' and pspace_distinct' and
       pspace_no_overlap' ptr (objBitsKO (injectKOS val) + us))
      (setCTE src cte) (placeNewObject ptr val us)"
   apply (clarsimp simp: setCTE_def2 split_def)
@@ -3065,29 +2695,65 @@ lemma doMachineOp_upd_heap_commute:
   done
 
 lemma magnitudeCheck_det:
-  "\<lbrakk>ksPSpace s ptr = Some ko; is_aligned ptr (objBitsKO ko); objBitsKO ko < word_bits;
+  "\<lbrakk>ksPSpace s ptr = Some ko; is_aligned ptr (objBitsKO ko);
     ps_clear ptr (objBitsKO ko) s\<rbrakk>
-   \<Longrightarrow> magnitudeCheck ptr (snd (lookupAround2 ptr (ksPSpace s))) (objBitsKO ko) s =
+   \<Longrightarrow> magnitudeCheck ptr (snd (lookupAround2 ptr (ksPSpace s)))
+                          (objBitsKO ko) s =
        ({((), s)},False)"
-  apply (frule in_magnitude_check'[THEN iffD2]; simp)
-  apply (subgoal_tac "\<not> snd (magnitudeCheck ptr (snd (lookupAround2 ptr (ksPSpace s))) (objBitsKO ko) s)")
+  apply (frule in_magnitude_check'[THEN iffD2])
+   apply (case_tac ko)
+     apply (simp add: objBits_simps' pageBits_def)+
+    apply (rename_tac arch_kernel_object)
+    apply (case_tac arch_kernel_object)
+     apply (simp add:archObjSize_def pageBits_def pteBits_def pdeBits_def)+
+  apply (subgoal_tac
+    "\<not> snd (magnitudeCheck ptr (snd (lookupAround2 ptr (ksPSpace s))) (objBitsKO ko) s)")
    apply (drule singleton_in_magnitude_check)
    apply (drule_tac x = s in spec)
-   apply (case_tac "(magnitudeCheck ptr (snd (lookupAround2 ptr (ksPSpace s))) (objBitsKO ko) s)")
-   apply simp
+   apply (case_tac
+    "(magnitudeCheck ptr (snd (lookupAround2 ptr (ksPSpace s))) (objBitsKO ko) s)")
+    apply simp
   apply (rule ccontr)
-  apply (clarsimp simp: magnitudeCheck_assert assert_def fail_def return_def
-                  split: if_splits option.splits)
+  apply (clarsimp simp:magnitudeCheck_assert assert_def fail_def return_def
+    split:if_splits option.splits)
   done
 
 lemma getPDE_det:
   "ko_wp_at' ((=) (KOArch (KOPDE pde))) p s
    \<Longrightarrow> getObject p s = ({((pde::ARM_H.pde),s)},False)"
-  by (clarsimp simp: getObject_def split_def gets_the_def ko_wp_at'_def obj_at'_def
-                     bind_def gets_def return_def get_def projectKOs
-                     assert_opt_def fail_def typ_at'_def
-                     no_ofailD[OF no_ofail_pde_at'_readObject]
-              split: if_splits option.splits)
+  apply (clarsimp simp:ko_wp_at'_def getObject_def split_def
+                       bind_def gets_def return_def get_def
+                       assert_opt_def split:if_splits)
+
+  apply (clarsimp simp: fail_def return_def lookupAround2_known1)
+   apply (simp add: loadObject_default_def)
+  apply (clarsimp simp:projectKO_def projectKO_opt_pde alignCheck_def
+    is_aligned_mask objBits_simps unless_def)
+  apply (clarsimp simp:bind_def return_def)
+  apply (intro conjI)
+   apply (intro set_eqI iffI)
+    apply clarsimp
+    apply (subst (asm) in_magnitude_check')
+     apply (simp add:archObjSize_def is_aligned_mask pteBits_def pdeBits_def)+
+    apply (rule bexI[rotated])
+     apply (rule in_magnitude_check'[THEN iffD2])
+      apply (simp add:is_aligned_mask)+
+   apply (clarsimp simp:image_def)
+  apply (clarsimp simp:magnitudeCheck_assert assert_def
+    objBits_def archObjSize_def
+    return_def fail_def lookupAround2_char2 split:option.splits if_split_asm)
+  apply (rule ccontr)
+  apply (simp add:ps_clear_def field_simps pteBits_def pdeBits_def)
+  apply (erule_tac x = x2 in in_empty_interE)
+   apply (clarsimp simp:less_imp_le)
+   apply (rule conjI)
+    apply (subst add.commute)
+    apply (rule word_diff_ls')
+     apply (clarsimp simp: not_le plus_one_helper)
+    apply (subst add.commute)
+    apply (simp add: is_aligned_no_wrap' is_aligned_mask)
+  apply auto
+  done
 
 lemma in_dom_eq:
   "m a = Some obj \<Longrightarrow> dom (\<lambda>b. if b = a then Some g else m b) = dom m"
@@ -3166,7 +2832,7 @@ lemma getPDE_doMachineOp_commute:
 
 lemma getPDE_placeNewObject_commute:
   "monad_commute
-     (pde_at' src and pspace_distinct' and pspace_aligned' and pspace_bounded' and
+     (pde_at' src and pspace_distinct' and pspace_aligned' and
       pspace_no_overlap' ptr (objBitsKO (injectKOS val) + sz) and
       K (is_aligned ptr (objBitsKO (injectKOS val) + sz) \<and>
          objBitsKO (injectKOS val) + sz < word_bits) )
@@ -3202,15 +2868,15 @@ lemma storePDE_det:
    \<Longrightarrow> storePDE ptr (new_pde::ARM_H.pde) s =
        modify
          (ksPSpace_update (\<lambda>_. (ksPSpace s)(ptr \<mapsto> KOArch (KOPDE new_pde)))) s"
-  apply (clarsimp simp: ko_wp_at'_def storePDE_def split_def
-                        bind_def gets_def return_def
-                        get_def setObject_def
-                        assert_opt_def split:if_splits)
-  apply (clarsimp simp: lookupAround2_known1 return_def alignCheck_def
-                        updateObject_default_def split_def gets_the_def
-                        archObjSize_def unless_def projectKO_def read_alignCheck_def
-                        projectKO_opt_pde bind_def when_def omonad_defs
-                        is_aligned_mask[symmetric] objBits_simps)
+  apply (clarsimp simp:ko_wp_at'_def storePDE_def split_def
+                       bind_def gets_def return_def
+                       get_def setObject_def
+                       assert_opt_def split:if_splits)
+  apply (clarsimp simp:lookupAround2_known1 return_def alignCheck_def
+                       updateObject_default_def split_def
+                       archObjSize_def unless_def projectKO_def
+                       projectKO_opt_pde bind_def when_def
+                       is_aligned_mask[symmetric] objBits_simps)
   apply (drule magnitudeCheck_det)
     apply (simp add:objBits_simps archObjSize_def)+
   apply (simp add:simpler_modify_def)
@@ -3293,28 +2959,13 @@ lemma modify_pde_pspace_aligned':
   apply simp
   done
 
-lemma modify_pde_pspace_bounded':
-  "\<lbrace>pde_at' ptr and pspace_bounded'\<rbrace>
-   modify (ksPSpace_update (\<lambda>ps. ps(ptr \<mapsto> KOArch (KOPDE new_pde))))
-   \<lbrace>\<lambda>a. pspace_bounded'\<rbrace>"
-  apply (clarsimp simp: simpler_modify_def ko_wp_at'_def valid_def typ_at'_def)
-  apply (case_tac ko,simp_all)
-  apply (rename_tac arch_kernel_object)
-  apply (case_tac arch_kernel_object,simp_all)
-  apply (subst pspace_bounded'_def)
-  apply (intro ballI)
-  apply (erule domE)
-  apply (clarsimp split:if_splits)
-   apply (simp add:objBits_simps archObjSize_def)
-  apply (fastforce dest!: pspace_boundedD')
-  done
-
 lemma modify_pde_psp_no_overlap':
   "\<lbrace>pde_at' ptr and pspace_no_overlap' ptr' sz\<rbrace>
    modify (ksPSpace_update (\<lambda>ps. ps(ptr \<mapsto> KOArch (KOPDE new_pde))))
    \<lbrace>\<lambda>a. pspace_no_overlap' ptr' sz\<rbrace>"
   proof -
-  note blah[simp del] = untyped_range.simps usable_untyped_range.simps atLeastAtMost_simps
+  note blah[simp del] = untyped_range.simps usable_untyped_range.simps atLeastAtMost_iff atLeastatMost_subset_iff atLeastLessThan_iff
+          Int_atLeastAtMost atLeastatMost_empty_iff split_paired_Ex
   show ?thesis
   apply (clarsimp simp:simpler_modify_def ko_wp_at'_def
     valid_def typ_at'_def)
@@ -3397,7 +3048,7 @@ lemma doMachineOp_storePDE_commute:
 
 lemma storePDE_placeNewObject_commute:
   "monad_commute
-     (pde_at' src and pspace_distinct' and pspace_aligned' and pspace_bounded' and
+     (pde_at' src and pspace_distinct' and pspace_aligned' and
       pspace_no_overlap' ptr (objBitsKO (injectKOS val) + sz) and
       K (is_aligned ptr (objBitsKO (injectKOS val) + sz) \<and>
       objBitsKO (injectKOS val) + sz < word_bits) )
@@ -3459,7 +3110,9 @@ lemma modify_obj_commute':
   done
 
 lemma cte_wp_at_modify_pde:
-  notes blah[simp del] =  atLeastAtMost_simps
+  notes blah[simp del] =  atLeastatMost_subset_iff atLeastLessThan_iff
+          Int_atLeastAtMost atLeastatMost_empty_iff split_paired_Ex
+          atLeastAtMost_iff
   shows
   "\<lbrakk>ksPSpace s ptr' = Some (KOArch (KOPDE pde)); pspace_aligned' s;cte_wp_at' \<top> ptr s\<rbrakk>
        \<Longrightarrow> cte_wp_at' \<top> ptr (s\<lparr>ksPSpace := (ksPSpace s)(ptr' \<mapsto> (KOArch (KOPDE pde')))\<rparr>)"
@@ -3469,9 +3122,11 @@ lemma cte_wp_at_modify_pde:
    apply (rule disjI1)
    apply (clarsimp simp add:ko_wp_at'_def)
    apply (intro conjI impI)
-       apply (simp add:objBits_simps archObjSize_def)
-      apply (clarsimp simp:projectKO_opt_cte)
-     apply (clarsimp simp: ps_clear_def objBits_simps archObjSize_def)+
+      apply (simp add:objBits_simps archObjSize_def)
+     apply (clarsimp simp:projectKO_opt_cte)
+    apply (simp add:ps_clear_def)+
+    apply (clarsimp simp:objBits_simps archObjSize_def)
+   apply (simp add:ps_clear_def)
    apply (rule ccontr)
    apply simp
    apply (erule in_emptyE, blast)
@@ -3479,9 +3134,11 @@ lemma cte_wp_at_modify_pde:
   apply (rule disjI2)
   apply (clarsimp simp:ko_wp_at'_def)
   apply (intro conjI impI)
-      apply (simp add:objBits_simps archObjSize_def)+
-     apply (clarsimp simp:projectKO_opt_cte projectKO_opt_tcb)
-    apply (clarsimp simp: ps_clear_def objBits_simps archObjSize_def)+
+     apply (simp add:objBits_simps archObjSize_def)+
+    apply (clarsimp simp:projectKO_opt_cte projectKO_opt_tcb)
+    apply (simp add:ps_clear_def)+
+   apply (clarsimp simp:objBits_simps archObjSize_def)
+  apply (simp add:ps_clear_def)
   apply (rule ccontr)
   apply simp
   apply (erule in_emptyE)
@@ -3489,9 +3146,11 @@ lemma cte_wp_at_modify_pde:
   done
 
 lemma storePDE_setCTE_commute:
-  notes blah[simp del] =  atLeastAtMost_simps
+  notes blah[simp del] =  atLeastatMost_subset_iff atLeastLessThan_iff
+          Int_atLeastAtMost atLeastatMost_empty_iff split_paired_Ex
+          atLeastAtMost_iff
   shows "monad_commute
-     (pde_at' ptr and pspace_distinct' and pspace_aligned' and pspace_bounded' and
+     (pde_at' ptr and pspace_distinct' and pspace_aligned' and
       cte_wp_at' (\<lambda>_. True) src)
      (setCTE src cte) (storePDE ptr (new_pde::ARM_H.pde))"
   apply (rule commute_name_pre_state)
@@ -3513,38 +3172,33 @@ lemma storePDE_setCTE_commute:
    apply (rule monad_commute_split)
      apply (subst modify_specify)
      apply (rule modify_obj_commute')
-    apply (subst modify_specify)
     apply (rule commute_commute[OF locateCTE_commute])
-          apply (rule no_fail_modify)
-         apply (rule locateCTE_cte_no_fail)
-        apply (rule modify_pde_pspace_distinct')
-       apply (rule modify_pde_pspace_aligned')
-      apply (rule modify_pde_pspace_bounded')
-     apply (wpsimp wp: modify_wp)
-     apply (case_tac "dest = ptr"; clarsimp?)
-      apply (subst non_sc_same_typ_at'_ko_wp_at'_set_ko'_iff[unfolded unfold_set_ko',
-                                                             unfolded fun_upd_def];
-             force?)
-      apply (clarsimp simp: ko_wp_at'_def typ_at'_def)
-      apply (erule_tac P=Q in rsubst)
-      apply (rule koType_objBitsKO; simp)
-     apply (subst ko_wp_at'_set_ko'_distinct[simplified unfold_set_ko',
-                                                   unfolded fun_upd_def];
-            clarsimp simp: ko_wp_at'_def typ_at'_def)
-    apply (clarsimp simp: simpler_modify_def valid_def)
-    apply (frule typ_at'_ksPSpace_exI, clarsimp)
-    apply (rule cte_wp_at_modify_pde[unfolded unfold_set_ko']; simp)
+         apply (wp locateCTE_cte_no_fail no_fail_modify
+                   modify_pde_pspace_distinct'
+                   modify_pde_pspace_aligned'| subst modify_specify)+
+     apply (clarsimp simp:simpler_modify_def valid_def typ_at'_def)
+     apply (clarsimp simp:ko_wp_at'_def dest!: koTypeOf_pde)
+     apply (intro conjI impI)
+        apply (clarsimp simp:objBits_simps archObjSize_def)+
+      apply (simp add:ps_clear_def in_dom_eq)
+     apply (simp add:ps_clear_def in_dom_eq)
+    apply (clarsimp simp:simpler_modify_def valid_def)
+    apply (clarsimp simp:typ_at'_def ko_wp_at'_def)
+    apply (case_tac ko,simp_all add:koTypeOf_def )[1]
+    apply (rename_tac arch_kernel_object)
+    apply (case_tac arch_kernel_object,simp_all add:archTypeOf_def)[1]
+    apply (erule(2) cte_wp_at_modify_pde)
    apply wp
    apply (thin_tac "cte_wp_at' P src s" for P s)+
    apply (clarsimp simp: typ_at'_def cte_wp_at_obj_cases_mask obj_at'_real_def)
    apply (wp locateCTE_ret_neq locateCTE_ko_wp_at')
-  apply (clarsimp simp: ko_wp_at'_def objBits_simps archObjSize_def typ_at'_def)
+  apply (clarsimp simp:ko_wp_at'_def objBits_simps archObjSize_def typ_at'_def)
   apply fastforce
   done
 
 lemma setCTE_gets_globalPD_commute:
   "monad_commute
-     (cte_wp_at' (\<lambda>_. True) src and pspace_distinct' and pspace_aligned' and pspace_bounded')
+     (cte_wp_at' (\<lambda>_. True) src and pspace_distinct' and pspace_aligned')
      (setCTE src cte) (gets (armKSGlobalPD \<circ> ksArchState))"
   apply (simp add:setCTE_def2)
   apply (rule monad_commute_guard_imp)
@@ -3554,6 +3208,7 @@ lemma setCTE_gets_globalPD_commute:
          apply (wp locateCTE_cte_no_fail)+
      apply clarsimp
     apply (wp|clarsimp)+
+  apply fastforce
   done
 
 lemma placeNewObject_gets_globalPD_commute:
@@ -3577,7 +3232,7 @@ lemma placeNewObject_gets_globalPD_commute:
 
 lemma copyGlobalMappings_setCTE_commute:
   "monad_commute
-     (valid_arch_state' and pspace_distinct' and pspace_aligned' and pspace_bounded' and
+     (valid_arch_state' and pspace_distinct' and pspace_aligned' and
       cte_wp_at' (\<lambda>_. True) src and page_directory_at' ptr)
      (copyGlobalMappings ptr) (setCTE src cte)"
   apply (clarsimp simp:copyGlobalMappings_def)
@@ -3596,15 +3251,9 @@ lemma copyGlobalMappings_setCTE_commute:
   apply (clarsimp simp: pteBits_def pdeBits_def)
   done
 
-lemma dmo_bounded'[wp]:
-  "doMachineOp f \<lbrace>pspace_bounded'\<rbrace>"
-  apply (simp add: doMachineOp_def split_def)
-  apply wpsimp
-  done
-
 lemma setCTE_doMachineOp_commute:
   assumes nf: "no_fail Q (doMachineOp x)"
-  shows "monad_commute (cte_at' dest and pspace_aligned' and pspace_distinct' and pspace_bounded' and Q)
+  shows "monad_commute (cte_at' dest and pspace_aligned' and pspace_distinct' and Q)
   (setCTE dest cte)
   (doMachineOp x)"
   apply (simp add:setCTE_def2 split_def)
@@ -3631,7 +3280,7 @@ lemma setCTE_when_doMachineOp_commute:
 lemma placeNewObject_valid_arch_state:
   "\<lbrace>valid_arch_state' and
     pspace_no_overlap' ptr (objBitsKO (injectKOS val) + us) and
-    pspace_aligned' and pspace_distinct' and pspace_bounded' and
+    pspace_aligned' and pspace_distinct' and
     K (is_aligned ptr (objBitsKO (injectKOS val) + us)) and
     K ( (objBitsKO (injectKOS val)+ us)< word_bits)\<rbrace>
    placeNewObject ptr val us
@@ -3646,7 +3295,7 @@ lemma placeNewObject_valid_arch_state:
 
 lemma placeNewObject_pd_at':
   "\<lbrace>K (is_aligned ptr pdBits) and pspace_no_overlap' ptr pdBits and
-    pspace_aligned' and pspace_distinct' and pspace_bounded'\<rbrace>
+    pspace_aligned' and pspace_distinct'\<rbrace>
    placeNewObject ptr (makeObject::ARM_H.pde)
                       (pdBits - objBits (makeObject::ARM_H.pde))
    \<lbrace>\<lambda>rv s. page_directory_at' ptr s\<rbrace>"
@@ -3683,10 +3332,39 @@ lemma setCTE_modify_gsUserPages_commute:
 lemma getTCB_det:
   "ko_wp_at' ((=) (KOTCB tcb)) p s
    \<Longrightarrow> getObject p s = ({(tcb,s)},False)"
-  by (clarsimp simp: ko_wp_at'_def getObject_def split_def gets_the_def
-                     bind_def gets_def return_def get_def fail_def assert_opt_def
-                     no_ofailD[OF no_ofail_tcb_at'_readObject] obj_at'_def projectKOs
-              split: if_splits option.split dest!: readObject_misc_ko_at')
+  apply (clarsimp simp:ko_wp_at'_def getObject_def split_def
+                       bind_def gets_def return_def get_def
+                       assert_opt_def split:if_splits)
+  apply (clarsimp simp: fail_def return_def lookupAround2_known1)
+   apply (simp add:loadObject_default_def)
+  apply (clarsimp simp:projectKO_def projectKO_opt_tcb alignCheck_def
+    is_aligned_mask objBits_simps' unless_def)
+  apply (clarsimp simp:bind_def return_def)
+  apply (intro conjI)
+   apply (intro set_eqI iffI)
+    apply clarsimp
+    apply (subst (asm) in_magnitude_check')
+     apply (simp add:archObjSize_def is_aligned_mask)+
+    apply (rule bexI[rotated])
+     apply (rule in_magnitude_check'[THEN iffD2])
+      apply (simp add:is_aligned_mask)+
+   apply (clarsimp simp:image_def)
+  apply (clarsimp simp:magnitudeCheck_assert assert_def
+    objBits_def archObjSize_def
+    return_def fail_def lookupAround2_char2 split:option.splits if_split_asm)
+  apply (rule ccontr)
+  apply (simp add:ps_clear_def field_simps)
+  apply (erule_tac x = x2 in in_empty_interE)
+   apply (clarsimp simp:less_imp_le)
+   apply (rule conjI)
+    apply (subst add.commute)
+    apply (rule word_diff_ls')
+     apply (clarsimp simp:field_simps not_le plus_one_helper)
+    apply (subst add.commute)
+    apply (simp add: is_aligned_no_wrap' is_aligned_mask)
+   apply simp
+  apply auto
+  done
 
 lemma threadSet_det:
   "tcb_at' ptr s
@@ -3700,10 +3378,10 @@ lemma threadSet_det:
   apply (clarsimp simp:setObject_def gets_def get_def)
   apply (subst bind_def)
   apply (clarsimp simp:split_def)
-  apply (simp add:lookupAround2_known1 bind_assoc projectKO_def gets_the_def
-    assert_opt_def updateObject_default_def projectKO_opt_tcb omonad_defs)
-  apply (clarsimp simp: read_alignCheck_def omonad_defs
-    alignCheck_def unless_def when_def gets_the_def
+  apply (simp add:lookupAround2_known1 bind_assoc projectKO_def
+    assert_opt_def updateObject_default_def projectKO_opt_tcb)
+  apply (clarsimp simp add:
+    alignCheck_def unless_def when_def
     is_aligned_mask objBits_simps)
   apply (clarsimp simp:magnitudeCheck_det bind_def)
   apply (cut_tac ko = "KOTCB obj" in magnitudeCheck_det)
@@ -3714,11 +3392,12 @@ lemma threadSet_det:
 
 lemma setCTE_modify_tcbDomain_commute:
  " monad_commute
-    (tcb_at' ptr and cte_wp_at' (\<lambda>_. True) src and pspace_distinct' and pspace_aligned' and pspace_bounded')
-    (setCTE src cte)
+    (tcb_at' ptr and cte_wp_at' (\<lambda>_. True) src and pspace_distinct' and pspace_aligned') (setCTE src cte)
     (threadSet (tcbDomain_update (\<lambda>_. ra)) ptr)"
   proof -
-    note blah[simp del] =  atLeastAtMost_simps
+    note blah[simp del] =  atLeastatMost_subset_iff atLeastLessThan_iff
+          Int_atLeastAtMost atLeastatMost_empty_iff split_paired_Ex
+          atLeastAtMost_iff
 
     have hint:
       "\<And>P ptr a cte b src ra. monad_commute (tcb_at' ptr and ko_wp_at' P a )
@@ -3731,16 +3410,15 @@ lemma setCTE_modify_tcbDomain_commute:
       prefer 2
        apply (clarsimp simp:obj_at'_def)
        apply (intro conjI impI)
-            apply simp
-           apply (clarsimp simp: projectKO_eq projectKO_opt_tcb
-                          split: Structures_H.kernel_object.split_asm)
-           apply (simp add:cte_update_def)
-          apply (clarsimp simp: projectKO_eq projectKO_opt_tcb
-                         split: Structures_H.kernel_object.split_asm)
-          apply (simp add:ps_clear_def)
-         apply clarsimp
-        apply (clarsimp simp: projectKO_eq projectKO_opt_tcb
-                       split: Structures_H.kernel_object.split_asm)
+           apply simp
+          apply (clarsimp simp:projectKO_eq
+            projectKO_opt_tcb split:Structures_H.kernel_object.split_asm)
+          apply (simp add:cte_update_def)
+         apply (clarsimp simp:projectKO_eq
+           projectKO_opt_tcb split:Structures_H.kernel_object.split_asm)
+         apply (simp add:ps_clear_def)
+        apply (clarsimp simp:projectKO_eq
+          projectKO_opt_tcb split:Structures_H.kernel_object.split_asm)
        apply (simp add:ps_clear_def)
        apply (rule ccontr,simp)
        apply (erule in_emptyE)
@@ -3805,23 +3483,24 @@ crunch curDomain
   for inv[wp]: P
 
 lemma placeNewObject_tcb_at':
-  "\<lbrace>pspace_aligned' and pspace_distinct'
-    and pspace_no_overlap' ptr (objBits (makeObject::tcb))
-    and  K (is_aligned ptr (objBits (makeObject::tcb))) \<rbrace>
-   placeNewObject ptr (makeObject::tcb) 0
-   \<lbrace>\<lambda>rv s. tcb_at' ptr s \<rbrace>"
+  notes [simp del] = atLeastatMost_subset_iff atLeastLessThan_iff
+                     Int_atLeastAtMost atLeastatMost_empty_iff split_paired_Ex atLeastAtMost_iff
+  shows "\<lbrace> pspace_aligned' and pspace_distinct'
+             and pspace_no_overlap' ptr (objBits (makeObject::tcb))
+             and  K(is_aligned ptr  (objBits (makeObject::tcb))) \<rbrace>
+         placeNewObject ptr (makeObject::tcb) 0
+         \<lbrace>\<lambda>_ s. tcb_at' ptr s \<rbrace>"
   apply (simp add: placeNewObject_def placeNewObject'_def split_def)
-  apply (wp unless_wp | wpc | simp add: alignError_def)+
-  apply (auto simp: obj_at'_def is_aligned_mask lookupAround2_None1 lookupAround2_char1 field_simps
-                    projectKO_opt_tcb projectKO_def return_def ps_clear_def objBits_simps' oassert_opt_def
-                    word_bits_def
-              split: if_splits
-             dest!: pspace_no_overlap_disjoint')
-  done
+  apply (wp unless_wp |wpc | simp add:alignError_def)+
+  by (auto simp: obj_at'_def is_aligned_mask lookupAround2_None1
+                    lookupAround2_char1 field_simps objBits_simps
+                    projectKO_opt_tcb projectKO_def return_def ps_clear_def
+           split: if_splits
+           dest!: pspace_no_overlap_disjoint')
 
 lemma monad_commute_if_weak_r:
-  "\<lbrakk>monad_commute P1 f h1; monad_commute P2 f h2\<rbrakk> \<Longrightarrow>
-    monad_commute (P1 and P2) f (if d then h1 else h2)"
+"\<lbrakk>monad_commute P1 f h1; monad_commute P2 f h2\<rbrakk> \<Longrightarrow>
+  monad_commute (P1 and P2) f (if d then h1 else h2)"
   apply (clarsimp)
   apply (intro conjI impI)
    apply (erule monad_commute_guard_imp,simp)+
@@ -3830,13 +3509,11 @@ lemma monad_commute_if_weak_r:
 lemma createObject_setCTE_commute:
   "monad_commute
      (cte_wp_at' (\<lambda>_. True) src and
-        pspace_aligned' and pspace_distinct' and pspace_bounded' and
+        pspace_aligned' and pspace_distinct' and
         pspace_no_overlap' ptr (Types_H.getObjectSize ty us) and
         valid_arch_state' and K (ptr \<noteq> src) and
         K (is_aligned ptr (Types_H.getObjectSize ty us)) and
-        K (Types_H.getObjectSize ty us < word_bits) and
-        K (ty = APIObjectType ArchTypes_H.apiobject_type.SchedContextObject \<longrightarrow>
-             sc_size_bounds us))
+        K (Types_H.getObjectSize ty us < word_bits))
      (RetypeDecls_H.createObject ty ptr us d)
      (setCTE src cte)"
   apply (rule commute_grab_asm)+
@@ -3848,45 +3525,45 @@ lemma createObject_setCTE_commute:
          simp_all add: ARM_H.toAPIType_def)
         apply (rename_tac apiobject_type)
         apply (case_tac apiobject_type)
-              apply (simp_all add: ARM_H.getObjectSize_def apiGetObjectSize_def
-                                   tcbBlockSizeBits_def epSizeBits_def ntfnSizeBits_def
-                                   cteSizeBits_def)
-              \<comment> \<open>Untyped\<close>
-              apply (simp add: monad_commute_guard_imp[OF return_commute])
-             \<comment> \<open>TCB\<close>
-             apply (rule monad_commute_guard_imp[OF commute_commute])
-              apply (rule monad_commute_split[OF monad_commute_split[OF commute_commute]])
-                  apply (rule return_commute)
-                 apply (rule setCTE_placeNewObject_commute)
+            apply (simp_all add:
+                       ARM_H.getObjectSize_def apiGetObjectSize_def
+                       tcbBlockSizeBits_def epSizeBits_def ntfnSizeBits_def
+                       cteSizeBits_def)
+            \<comment> \<open>Untyped\<close>
+            apply (simp add: monad_commute_guard_imp[OF return_commute])
+           \<comment> \<open>TCB, EP, NTFN\<close>
+           apply (rule monad_commute_guard_imp[OF commute_commute])
+            apply (rule monad_commute_split[OF monad_commute_split])
+                apply (rule monad_commute_split[OF commute_commute[OF return_commute]])
+                 apply (rule setCTE_modify_tcbDomain_commute)
                 apply wp
                apply (rule curDomain_commute)
-               apply (wpsimp simp: objBits_simps')+
-             \<comment> \<open>EP, NTFN\<close>
-             apply (rule monad_commute_guard_imp[OF commute_commute],
-                    rule monad_commute_split[OF commute_commute[OF return_commute]],
-                    rule setCTE_placeNewObject_commute,
-                    (wpsimp simp: objBits_simps')+)+
-          \<comment> \<open>CNode\<close>
-          apply (rule monad_commute_guard_imp[OF commute_commute])
-           apply (rule monad_commute_split)+
-               apply (rule return_commute[THEN commute_commute])
-              apply (rule setCTE_modify_gsCNode_commute[of \<top>])
-             apply (rule hoare_triv[of \<top>])
-             apply wp
-            apply (rule setCTE_placeNewObject_commute)
-         apply (wpsimp simp: objBits_simps')+
-           \<comment> \<open>SchedContext, Reply\<close>
-           apply (rule monad_commute_guard_imp[OF commute_commute],
-                  rule monad_commute_split[OF commute_commute[OF return_commute]],
-                  rule setCTE_placeNewObject_commute,
-                  (wpsimp simp: objBits_simps' scBits_simps)+)+
+               apply wp+
+             apply (rule setCTE_placeNewObject_commute)
+            apply (wp  placeNewObject_tcb_at' placeNewObject_cte_wp_at'
+              placeNewObject_pspace_distinct'
+              placeNewObject_pspace_aligned'
+              | clarsimp simp: objBits_simps')+
+           apply (rule monad_commute_guard_imp[OF commute_commute]
+            ,rule monad_commute_split[OF commute_commute[OF return_commute]]
+            ,rule setCTE_placeNewObject_commute
+            ,(wp|clarsimp simp: objBits_simps')+)+
+        \<comment> \<open>CNode\<close>
+        apply (rule monad_commute_guard_imp[OF commute_commute])
+         apply (rule monad_commute_split)+
+             apply (rule return_commute[THEN commute_commute])
+            apply (rule setCTE_modify_gsCNode_commute[of \<top>])
+           apply (rule hoare_triv[of \<top>])
+           apply wp
+          apply (rule setCTE_placeNewObject_commute)
+         apply (wp|clarsimp simp: objBits_simps')+
        \<comment> \<open>Arch Objects\<close>
-       apply ((rule monad_commute_guard_imp[OF commute_commute],
-               rule monad_commute_split[OF commute_commute[OF return_commute]],
-               clarsimp simp: ARM_H.createObject_def
-                              placeNewDataObject_def bind_assoc split
-                         del: if_splits,
-               (rule monad_commute_split return_commute[THEN commute_commute]
+       apply ((rule monad_commute_guard_imp[OF commute_commute]
+              , rule monad_commute_split[OF commute_commute[OF return_commute]]
+              , clarsimp simp: ARM_H.createObject_def
+                               placeNewDataObject_def bind_assoc split
+                          del: if_splits
+              ,(rule monad_commute_split return_commute[THEN commute_commute]
                      setCTE_modify_gsUserPages_commute[of \<top>]
                      modify_wp[of "%_. \<top>"]
                      setCTE_doMachineOp_commute
@@ -3896,7 +3573,6 @@ lemma createObject_setCTE_commute:
                      copyGlobalMappings_setCTE_commute[THEN commute_commute]
                  | wp placeNewObject_pspace_distinct'
                       placeNewObject_pspace_aligned'
-                      placeNewObject_pspace_bounded'
                       placeNewObject_cte_wp_at'
                       placeNewObject_valid_arch_state placeNewObject_pd_at'
                  | erule is_aligned_weaken
@@ -3910,12 +3586,10 @@ lemma createObject_updateMDB_commute:
   "monad_commute
      ((\<lambda>s. src \<noteq> 0 \<longrightarrow> cte_wp_at' (\<lambda>_. True) src s) and
       pspace_no_overlap' ptr (Types_H.getObjectSize ty us) and
-      pspace_aligned' and pspace_distinct' and pspace_bounded' and valid_arch_state' and
+      pspace_aligned' and pspace_distinct' and valid_arch_state' and
       K (ptr \<noteq> src) and
       K (is_aligned ptr (Types_H.getObjectSize ty us)) and
-      K ((Types_H.getObjectSize ty us) < word_bits) and
-      K (ty = APIObjectType ArchTypes_H.apiobject_type.SchedContextObject \<longrightarrow>
-           sc_size_bounds us))
+      K ((Types_H.getObjectSize ty us)< word_bits))
      (updateMDB src f) (RetypeDecls_H.createObject ty ptr us d)"
   apply (clarsimp simp:updateMDB_def split:if_split_asm)
   apply (intro conjI impI)
@@ -3925,11 +3599,11 @@ lemma createObject_updateMDB_commute:
      apply (rule createObject_setCTE_commute)
     apply (rule createObject_getCTE_commute)
    apply wp
-  apply (auto simp:range_cover_full sc_size_bounds_def)
+  apply (auto simp:range_cover_full)
   done
 
 lemma updateMDB_pspace_no_overlap':
-  "\<lbrace>pspace_aligned' and pspace_distinct' and pspace_bounded' and pspace_no_overlap' ptr sz\<rbrace>
+  "\<lbrace>pspace_aligned' and pspace_distinct' and pspace_no_overlap' ptr sz\<rbrace>
    updateMDB slot f
    \<lbrace>\<lambda>rv s. pspace_no_overlap' ptr sz s\<rbrace>"
   apply (rule hoare_pre)
@@ -4024,14 +3698,13 @@ lemma threadSet_gsUntypedZeroRanges_commute':
   "monad_commute \<top>
      (threadSet fn ptr)
      (modify (\<lambda>s. s \<lparr> gsUntypedZeroRanges := f (gsUntypedZeroRanges s) \<rparr> ))"
-  apply (simp add: threadSet_def getObject_def setObject_def readObject_def)
+  apply (simp add: threadSet_def getObject_def setObject_def)
   apply (rule commute_commute)
   apply (strengthen monad_commute_guard_imp[OF monad_commute_split[where P="\<top>" and Q="\<top>\<top>"], OF _ _ hoare_vcg_prop]
-     | simp add: modify_commute updateObject_default_def alignCheck_assert obind_def
+     | simp add: modify_commute updateObject_default_def alignCheck_assert
                  magnitudeCheck_assert return_commute return_commute[THEN commute_commute]
-                 projectKO_def assert_commute2 assert_commute2[THEN commute_commute]
-                 assert_opt_def2 loadObject_default_def gets_the_def omonad_defs
-                 read_magnitudeCheck_assert
+                 projectKO_def2 assert_commute2 assert_commute2[THEN commute_commute]
+                 assert_opt_def2 loadObject_default_def
           split: option.split prod.split)+
   apply (simp add: monad_commute_def exec_gets exec_modify)
   done
@@ -4055,13 +3728,12 @@ lemma copyGlobalMappings_gsUntypedZeroRanges_commute':
   apply (rule monad_commute_guard_imp)
    apply (rule commute_commute[OF monad_commute_split[where P="\<top>"]])
      apply (rule mapM_x_commute[where f = id and P="\<top>\<top>"])
-      apply (simp add: storePDE_def getObject_def setObject_def readObject_def cong: bind_cong)
+      apply (simp add: storePDE_def getObject_def setObject_def cong: bind_cong)
       apply (strengthen monad_commute_guard_imp[OF monad_commute_split[where P="\<top>" and Q="\<top>\<top>"], OF _ _ hoare_vcg_prop]
          | simp add: modify_commute updateObject_default_def alignCheck_assert
                      magnitudeCheck_assert return_commute return_commute[THEN commute_commute]
-                     projectKO_def assert_commute2 assert_commute2[THEN commute_commute]
-                     assert_opt_def2 loadObject_default_def gets_the_def
-                     read_magnitudeCheck_assert omonad_defs obind_def
+                     projectKO_def2 assert_commute2 assert_commute2[THEN commute_commute]
+                     assert_opt_def2 loadObject_default_def
               split: option.split prod.split)+
       apply (simp add: monad_commute_def exec_gets exec_modify)
      apply wp
@@ -4114,9 +3786,8 @@ lemma case_eq_if_isUntypedCap:
 lemma createObject_updateTrackedFreeIndex_commute:
   "monad_commute
      (cte_wp_at' (\<lambda>_. True) slot and pspace_aligned' and pspace_distinct' and
-      pspace_bounded' and pspace_no_overlap' ptr (Types_H.getObjectSize ty us) and
+      pspace_no_overlap' ptr (Types_H.getObjectSize ty us) and
       valid_arch_state' and
-      K (ty = APIObjectType SchedContextObject \<longrightarrow> sc_size_bounds us) and
       K (ptr \<noteq> slot) and K (Types_H.getObjectSize ty us < word_bits) and
       K (is_aligned ptr (Types_H.getObjectSize ty us)))
      (RetypeDecls_H.createObject ty ptr us dev) (updateTrackedFreeIndex slot idx)"
@@ -4132,9 +3803,8 @@ lemma createObject_updateTrackedFreeIndex_commute:
 lemma createObject_updateNewFreeIndex_commute:
   "monad_commute
      (cte_wp_at' (\<lambda>_. True) slot and pspace_aligned' and pspace_distinct' and
-      pspace_bounded' and pspace_no_overlap' ptr (Types_H.getObjectSize ty us) and
+      pspace_no_overlap' ptr (Types_H.getObjectSize ty us) and
       valid_arch_state' and
-      K (ty = APIObjectType SchedContextObject \<longrightarrow> sc_size_bounds us) and
       K (ptr \<noteq> slot) and K (Types_H.getObjectSize ty us < word_bits) and
       K (is_aligned ptr (Types_H.getObjectSize ty us)))
      (RetypeDecls_H.createObject ty ptr us dev) (updateNewFreeIndex slot)"
@@ -4151,7 +3821,7 @@ lemma createObject_updateNewFreeIndex_commute:
 
 lemma new_cap_object_comm_helper:
   "monad_commute
-     (pspace_aligned' and pspace_distinct' and pspace_bounded' and (\<lambda>s. no_0 (ctes_of s)) and
+     (pspace_aligned' and pspace_distinct' and (\<lambda>s. no_0 (ctes_of s)) and
       (\<lambda>s. weak_valid_dlist (ctes_of s)) and
       (\<lambda>s. valid_nullcaps (ctes_of s)) and
       cte_wp_at' (\<lambda>c. isUntypedCap (cteCap c)) parent and
@@ -4160,9 +3830,7 @@ lemma new_cap_object_comm_helper:
       valid_arch_state' and
       K (Types_H.getObjectSize ty us<word_bits) and
       K (cap \<noteq> capability.NullCap) and
-      K (is_aligned ptr (Types_H.getObjectSize ty us) \<and> ptr \<noteq> 0 \<and> parent \<noteq> 0) and
-      K (ty = APIObjectType ArchTypes_H.apiobject_type.SchedContextObject \<longrightarrow>
-           sc_size_bounds us))
+      K (is_aligned ptr (Types_H.getObjectSize ty us) \<and> ptr \<noteq> 0 \<and> parent \<noteq> 0))
      (RetypeDecls_H.createObject ty ptr us d) (insertNewCap parent slot cap)"
   apply (clarsimp simp:insertNewCap_def bind_assoc liftM_def)
   apply (rule monad_commute_guard_imp)
@@ -4174,13 +3842,13 @@ lemma new_cap_object_comm_helper:
         apply (rule createObject_updateNewFreeIndex_commute)
        apply (wp getCTE_wp hoare_vcg_imp_lift hoare_vcg_disj_lift valid_arch_state'_updateMDB
          updateMDB_pspace_no_overlap' setCTE_pspace_no_overlap'
-         | clarsimp simp: conj_comms)+
+         | clarsimp simp:conj_comms)+
   apply (clarsimp simp:cte_wp_at_ctes_of)
   apply (frule_tac slot = slot in pspace_no_overlapD2')
    apply simp+
   apply (frule_tac slot = parent in pspace_no_overlapD2')
    apply simp+
-  apply (case_tac ctea, clarsimp simp: sc_size_bounds_def)
+  apply (case_tac ctea,clarsimp)
   apply (frule_tac p = slot in nullcapsD')
      apply simp+
   apply (subgoal_tac "(mdbNext (cteMDBNode cte) = 0 \<or>
@@ -4197,11 +3865,14 @@ lemma new_cap_object_comm_helper:
 
 crunch updateNewFreeIndex
   for pspace_aligned'[wp]: "pspace_aligned'"
-  and pspace_distinct'[wp]: "pspace_distinct'"
-  and pspace_bounded'[wp]: "pspace_bounded'"
-  and valid_arch_state'[wp]: "valid_arch_state'"
-  and pspace_no_overlap'[wp]: "pspace_no_overlap' ptr n"
-  and ctes_of[wp]: "\<lambda>s. P (ctes_of s)"
+crunch updateNewFreeIndex
+  for pspace_distinct'[wp]: "pspace_distinct'"
+crunch updateNewFreeIndex
+  for valid_arch_state'[wp]: "valid_arch_state'"
+crunch updateNewFreeIndex
+  for pspace_no_overlap'[wp]: "pspace_no_overlap' ptr n"
+crunch updateNewFreeIndex
+  for ctes_of[wp]: "\<lambda>s. P (ctes_of s)"
 
 lemma updateNewFreeIndex_cte_wp_at[wp]:
   "\<lbrace>\<lambda>s. P (cte_wp_at' P' p s)\<rbrace> updateNewFreeIndex slot \<lbrace>\<lambda>rv s. P (cte_wp_at' P' p s)\<rbrace>"
@@ -4216,9 +3887,7 @@ lemma new_cap_object_commute:
       K (distinct (map fst (zip list caps))) and
       K (\<forall>cap \<in> set caps. cap \<noteq> capability.NullCap) and
       K (Types_H.getObjectSize ty us <word_bits) and
-      K (is_aligned ptr (Types_H.getObjectSize ty us) \<and> ptr \<noteq> 0) and
-      K (ty = APIObjectType ArchTypes_H.apiobject_type.SchedContextObject \<longrightarrow>
-           sc_size_bounds us))
+      K (is_aligned ptr (Types_H.getObjectSize ty us) \<and> ptr \<noteq> 0))
      (RetypeDecls_H.createObject ty ptr us d)
      (zipWithM_x (insertNewCap parent) list caps)"
   apply (clarsimp simp:zipWithM_x_mapM_x)
@@ -4227,9 +3896,9 @@ lemma new_cap_object_commute:
     apply (simp add:split_def)
     apply (rule new_cap_object_comm_helper)
    apply (clarsimp simp:insertNewCap_def split_def)
-   apply (wpsimp wp: updateMDB_weak_cte_wp_at updateMDB_pspace_no_overlap'
-                     getCTE_wp valid_arch_state'_updateMDB
-                     setCTE_weak_cte_wp_at setCTE_pspace_no_overlap')
+   apply (wp updateMDB_weak_cte_wp_at updateMDB_pspace_no_overlap'
+             getCTE_wp valid_arch_state'_updateMDB
+             setCTE_weak_cte_wp_at setCTE_pspace_no_overlap')
    apply (clarsimp simp:cte_wp_at_ctes_of simp del:fun_upd_apply)
    apply (case_tac "parent \<noteq> aa")
     prefer 2
@@ -4276,7 +3945,9 @@ lemma createObjects'_pspace_no_overlap:
    createObjects' ptr (Suc n) val us
    \<lbrace>\<lambda>addrs s. pspace_no_overlap' (ptr + (1 + of_nat n << gz)) gz s\<rbrace>"
 proof -
-  note simps [simp del] = untyped_range.simps usable_untyped_range.simps atLeastAtMost_simps
+  note simps [simp del] = untyped_range.simps usable_untyped_range.simps atLeastAtMost_iff
+                          atLeastatMost_subset_iff atLeastLessThan_iff
+                          Int_atLeastAtMost atLeastatMost_empty_iff split_paired_Ex
   assume "gz = (objBitsKO val) + us"
   thus ?thesis
     apply -
@@ -4348,13 +4019,13 @@ lemma createNewCaps_not_nc:
   by (wpsimp simp: Arch_createNewCaps_def split_del: if_split)
 
 lemma doMachineOp_psp_no_overlap:
-  "\<lbrace>\<lambda>s. pspace_no_overlap' ptr sz s \<and> pspace_aligned' s \<and> pspace_distinct' s \<and> pspace_bounded' s\<rbrace>
+  "\<lbrace>\<lambda>s. pspace_no_overlap' ptr sz s \<and> pspace_aligned' s \<and> pspace_distinct' s \<rbrace>
    doMachineOp f
    \<lbrace>\<lambda>y s. pspace_no_overlap' ptr sz s\<rbrace>"
-  by (wpsimp wp: pspace_no_overlap'_lift2)
+  by (wp pspace_no_overlap'_lift,simp)
 
 lemma createObjects'_psp_distinct:
-  "\<lbrace>pspace_aligned' and pspace_distinct' and pspace_bounded' and
+  "\<lbrace>pspace_aligned' and pspace_distinct' and
     pspace_no_overlap' ptr sz and
     K (range_cover ptr sz ((objBitsKO ko) + us) n \<and> n \<noteq> 0
     \<and> is_aligned ptr (objBitsKO ko + us) \<and> objBitsKO ko + us < word_bits)\<rbrace>
@@ -4371,7 +4042,7 @@ lemma createObjects'_psp_distinct:
   apply clarsimp
   apply (subst data_map_insert_def[symmetric])+
   apply (simp add: range_cover.unat_of_nat_n_shift)
-  apply (drule (3) retype_aligned_distinct'(1)[where ko = ko and n= "n*2^us" ])
+  apply (drule(2) retype_aligned_distinct'(1)[where ko = ko and n= "n*2^us" ])
    apply (erule range_cover_rel)
     apply simp
    apply clarsimp
@@ -4379,7 +4050,7 @@ lemma createObjects'_psp_distinct:
   done
 
 lemma createObjects'_psp_aligned:
-  "\<lbrace>pspace_aligned' and pspace_distinct' and pspace_bounded' and
+  "\<lbrace>pspace_aligned' and pspace_distinct' and
     pspace_no_overlap' ptr sz and
     K (range_cover ptr sz ((objBitsKO ko) + us) n \<and> n \<noteq> 0
     \<and> is_aligned ptr (objBitsKO ko + us) \<and> objBitsKO ko + us < word_bits)\<rbrace>
@@ -4394,31 +4065,7 @@ lemma createObjects'_psp_aligned:
   apply (rule hoare_pre)
    apply (wpc|wp|simp add: unless_def alignError_def del: fun_upd_apply hoare_fail_any)+
   apply clarsimp
-  apply (frule (3) retype_aligned_distinct'(3)[where ko = ko and n= "n*2^us" ])
-   apply (erule range_cover_rel)
-    apply simp
-   apply clarsimp
-  apply (subst data_map_insert_def[symmetric])+
-  apply (simp add: range_cover.unat_of_nat_n_shift)
-  done
-
-lemma createObjects'_psp_bounded:
-  "\<lbrace>pspace_aligned' and pspace_distinct' and pspace_bounded' and
-    pspace_no_overlap' ptr sz and
-    K (range_cover ptr sz ((objBitsKO ko) + us) n \<and> n \<noteq> 0
-    \<and> is_aligned ptr (objBitsKO ko + us) \<and> objBitsKO ko + us < word_bits)\<rbrace>
-   createObjects' ptr n ko us
-   \<lbrace>\<lambda>rv s. pspace_bounded' s\<rbrace>"
-  apply (rule hoare_name_pre_state)
-  apply (clarsimp simp: createObjects'_def split_def)
-  apply (subst new_cap_addrs_fold')
-   apply (drule range_cover_not_zero_shift[where gbits = us,rotated])
-     apply simp+
-   apply unat_arith
-  apply (rule hoare_pre)
-   apply (wpc|wp|simp add: unless_def alignError_def del: fun_upd_apply hoare_fail_any)+
-  apply clarsimp
-  apply (frule (3) retype_aligned_distinct'(2)[where ko = ko and n= "n*2^us" ])
+  apply (frule(2) retype_aligned_distinct'(2)[where ko = ko and n= "n*2^us" ])
    apply (erule range_cover_rel)
     apply simp
    apply clarsimp
@@ -4427,12 +4074,12 @@ lemma createObjects'_psp_bounded:
   done
 
 lemma copyGlobalMappings_pspace_no_overlap':
-  "\<lbrace>pspace_aligned' and pspace_distinct' and pspace_bounded' and pspace_no_overlap' ptr sz\<rbrace>
+  "\<lbrace>pspace_aligned' and pspace_distinct' and pspace_no_overlap' ptr sz\<rbrace>
    copyGlobalMappings xa
    \<lbrace>\<lambda>ya. pspace_no_overlap' ptr sz\<rbrace>"
   apply (rule hoare_pre)
    apply (clarsimp simp:copyGlobalMappings_def)
-   apply (wpsimp wp: mapM_x_wp_inv pspace_no_overlap'_lift2)
+   apply (wp mapM_x_wp_inv pspace_no_overlap'_lift)
   apply clarsimp
   done
 
@@ -4441,7 +4088,8 @@ lemma pspace_no_overlap'_le:
   assumes b: "sz < word_bits"
   shows "pspace_no_overlap' ptr sz' s"
   proof -
-  note blah[simp del] = untyped_range.simps usable_untyped_range.simps atLeastAtMost_simps
+  note blah[simp del] = untyped_range.simps usable_untyped_range.simps atLeastAtMost_iff atLeastatMost_subset_iff atLeastLessThan_iff
+          Int_atLeastAtMost atLeastatMost_empty_iff split_paired_Ex
   have diff_cancel: "\<And>a b c. (a::word32) + b - c = b + (a - c)"
    by simp
   have bound :"(ptr && ~~ mask sz') - (ptr && ~~ mask sz) \<le> 2 ^ sz - 2 ^ sz'"
@@ -4470,7 +4118,8 @@ lemma pspace_no_overlap'_le2:
   assumes "pspace_no_overlap' ptr sz s" "ptr \<le> ptr'"  "ptr' &&~~ mask sz = ptr && ~~ mask sz"
   shows "pspace_no_overlap' ptr' sz s"
   proof -
-  note blah[simp del] = untyped_range.simps usable_untyped_range.simps atLeastAtMost_simps
+  note blah[simp del] = untyped_range.simps usable_untyped_range.simps atLeastAtMost_iff atLeastatMost_subset_iff atLeastLessThan_iff
+          Int_atLeastAtMost atLeastatMost_empty_iff split_paired_Ex
   show ?thesis
     using assms
     apply (clarsimp simp:pspace_no_overlap'_def)
@@ -4492,8 +4141,7 @@ lemma pspace_no_overlap'_tail:
 
 lemma createNewCaps_pspace_no_overlap':
   "\<lbrace>\<lambda>s. range_cover ptr sz (Types_H.getObjectSize ty us) (Suc (Suc n)) \<and>
-        pspace_aligned' s \<and> pspace_distinct' s \<and> pspace_bounded' s \<and> pspace_no_overlap' ptr sz s \<and>
-        (ty = APIObjectType SchedContextObject \<longrightarrow> sc_size_bounds us) \<and>
+        pspace_aligned' s \<and> pspace_distinct' s \<and> pspace_no_overlap' ptr sz s \<and>
         ptr \<noteq> 0\<rbrace>
    createNewCaps ty ptr (Suc n) us d
    \<lbrace>\<lambda>r s. pspace_no_overlap'
@@ -4520,22 +4168,19 @@ lemma createNewCaps_pspace_no_overlap':
                               createObjects_def)
         apply (rule hoare_pre)
          apply wpc
-               apply (clarsimp simp: apiGetObjectSize_def curDomain_def ARM_H.toAPIType_def
-                                     tcbBlockSizeBits_def ARM_H.getObjectSize_def objBits_simps
-                                     epSizeBits_def ntfnSizeBits_def cteSizeBits_def pageBits_def
-                                     ptBits_def archObjSize_def pdBits_def createObjects_def
-                                     Arch_createNewCaps_def scBits_simps word_bits_def
-                                     range_cover_le[where n = "Suc n"] range_cover.aligned
-                              split: apiobject_type.splits
-                     | wp doMachineOp_psp_no_overlap
-                          createObjects'_pspace_no_overlap[where sz = sz]
-                          createObjects'_psp_aligned[where sz = sz]
-                          createObjects'_psp_distinct[where sz = sz]
-                          copyGlobalMappings_pspace_aligned' mapM_x_wp_inv
-                          copyGlobalMappings_pspace_no_overlap'[where sz = sz]
-                     | (frule range_cover_sz'; fastforce simp: untypedBits_defs)
-                     | assumption)+
-       apply ((clarsimp simp: apiGetObjectSize_def
+    apply (clarsimp simp: apiGetObjectSize_def  curDomain_def
+                          ARM_H.toAPIType_def tcbBlockSizeBits_def
+                          ARM_H.getObjectSize_def objBits_simps epSizeBits_def ntfnSizeBits_def
+                          cteSizeBits_def pageBits_def ptBits_def archObjSize_def pdBits_def
+                          createObjects_def Arch_createNewCaps_def
+                    split: apiobject_type.splits
+           | wp doMachineOp_psp_no_overlap createObjects'_pspace_no_overlap[where sz = sz]
+                createObjects'_psp_aligned[where sz = sz] createObjects'_psp_distinct[where sz = sz]
+                copyGlobalMappings_pspace_aligned' mapM_x_wp_inv
+                copyGlobalMappings_pspace_no_overlap'[where sz = sz] | assumption)+
+           apply (intro conjI range_cover_le[where n = "Suc n"] | simp)+
+            apply ((simp add:objBits_simps pageBits_def range_cover_def word_bits_def)+)[5]
+       by ((clarsimp simp: apiGetObjectSize_def
                               ARM_H.toAPIType_def tcbBlockSizeBits_def
                               ARM_H.getObjectSize_def objBits_simps epSizeBits_def ntfnSizeBits_def
                               cteSizeBits_def pageBits_def ptBits_def archObjSize_def pdBits_def
@@ -4545,12 +4190,10 @@ lemma createNewCaps_pspace_no_overlap':
                         split: apiobject_type.splits
                | wp doMachineOp_psp_no_overlap createObjects'_pspace_no_overlap
                     createObjects'_psp_aligned createObjects'_psp_distinct
-                    createObjects'_psp_bounded
                     copyGlobalMappings_pspace_aligned' mapM_x_wp_inv
                     copyGlobalMappings_pspace_no_overlap'
                | assumption | clarsimp simp: word_bits_def
                | intro conjI range_cover_le[where n = "Suc n"] range_cover.aligned)+)[6]
-  done
 
 lemma objSize_eq_capBits:
   "Types_H.getObjectSize ty us = APIType_capBits ty us"
@@ -4579,7 +4222,8 @@ lemma createNewCaps_ret_len:
           erule hoare_strengthen_post[OF createObjects_ret],clarsimp+ | intro conjI impI)+
        apply (rule hoare_pre,
           ((wp+)
-              | simp add: Arch_createNewCaps_def toAPIType_def unat_of_nat_minus_1
+              | simp add: Arch_createNewCaps_def toAPIType_def
+                          ARM_H.toAPIType_def unat_of_nat_minus_1
               | erule hoare_strengthen_post[OF createObjects_ret],clarsimp+
               | intro conjI impI)+)+
    done
@@ -4716,7 +4360,8 @@ lemma pspace_no_overlap'_modify:
           (((1::word32) + of_nat n << objBitsKO val + us) + ptr)
           (objBitsKO val + us)\<rbrace>"
   proof -
-  note blah[simp del] = untyped_range.simps usable_untyped_range.simps atLeastAtMost_simps
+  note blah[simp del] = untyped_range.simps usable_untyped_range.simps atLeastAtMost_iff atLeastatMost_subset_iff atLeastLessThan_iff
+          Int_atLeastAtMost atLeastatMost_empty_iff split_paired_Ex
   show ?thesis
   apply (clarsimp simp:simpler_modify_def valid_def pspace_no_overlap'_def)
   apply (frule(1) range_cover_tail_mask)
@@ -4749,7 +4394,7 @@ qed
 
 lemma placeNewObject_copyGlobalMapping_commute:
   "monad_commute
-     (valid_arch_state' and pspace_distinct' and pspace_aligned' and pspace_bounded' and
+     (valid_arch_state' and pspace_distinct' and pspace_aligned' and
       page_directory_at' r and
       pspace_no_overlap' ptr (objBitsKO (injectKOS val) + us) and
       K (objBitsKO (injectKOS val) + us < word_bits \<and>
@@ -4762,7 +4407,7 @@ lemma placeNewObject_copyGlobalMapping_commute:
       apply (rule monad_commute_split[OF _ getPDE_placeNewObject_commute])
        apply (rule storePDE_placeNewObject_commute)
       apply wp
-      apply (wp pspace_no_overlap'_lift2 | clarsimp)+
+      apply (wp pspace_no_overlap'_lift | clarsimp)+
     apply (rule placeNewObject_gets_globalPD_commute)
    apply wp
   apply clarsimp
@@ -4774,7 +4419,7 @@ lemma placeNewObject_copyGlobalMapping_commute:
 
 lemma createObjects_Cons:
   "\<lbrakk>range_cover ptr sz (objBitsKO val + us) (Suc (Suc n));
-    pspace_distinct' s;pspace_aligned' s; pspace_bounded' s;
+    pspace_distinct' s;pspace_aligned' s;
     pspace_no_overlap' ptr sz s;pspace_aligned' s; ptr \<noteq> 0\<rbrakk>
    \<Longrightarrow> createObjects' ptr (Suc (Suc n)) val us s =
        (do createObjects' ptr (Suc n) val us;
@@ -4851,7 +4496,7 @@ lemma createObjects_Cons:
           apply (simp add:range_cover_def)
          apply (erule range_cover.sz(1)[where 'a=32, folded word_bits_def])
         apply (subst data_map_insert_def[symmetric])
-        apply (drule(3) retype_aligned_distinct'(3))
+        apply (drule(2) retype_aligned_distinct'(2))
          prefer 2
          apply (simp cong: kernel_state.fold_congs)
         apply (drule range_cover_le[where n = "Suc n"])
@@ -4872,7 +4517,7 @@ lemma placeNewObject_doMachineOp_commute:
   "monad_commute
      (K (us < word_bits \<and> is_aligned ptr (objBitsKO (injectKOS ty) + us) \<and>
          objBitsKO (injectKOS ty) + us < word_bits) and
-      pspace_aligned' and pspace_distinct' and pspace_bounded' and
+      pspace_aligned' and pspace_distinct' and
       pspace_no_overlap' ptr ((objBitsKO (injectKOS ty)) +  us))
      (placeNewObject ptr ty us) (doMachineOp f)"
   apply (rule commute_name_pre_state)
@@ -5000,7 +4645,7 @@ lemmas mapM_doMachineOp_copyGlobalMapping_commute =
 
 lemma createObjects'_page_directory_at':
   "\<lbrace>K (range_cover ptr sz 14 (Suc n)) and
-    pspace_aligned' and pspace_distinct' and pspace_bounded' and pspace_no_overlap' ptr sz\<rbrace>
+    pspace_aligned' and pspace_distinct' and pspace_no_overlap' ptr sz\<rbrace>
    createObjects' ptr (Suc n) (KOArch (KOPDE makeObject)) 12
    \<lbrace>\<lambda>rv s. (\<forall>x\<le>of_nat n. page_directory_at' (ptr + (x << 14)) s)\<rbrace>"
   apply (rule createObjects'_wp_subst)
@@ -5111,7 +4756,7 @@ lemma createObjects_setDomain_commute:
   "monad_commute
   (\<lambda>s. range_cover ptr'  (objBitsKO (KOTCB makeObject))
        (objBitsKO (KOTCB makeObject) + 0) (Suc 0) \<and>
-  pspace_aligned' s \<and> pspace_distinct' s \<and> pspace_bounded' s \<and>
+  pspace_aligned' s \<and> pspace_distinct' s \<and>
   pspace_no_overlap' ptr' (objBitsKO (KOTCB makeObject)) s \<and>
   tcb_at' ptr s \<and> is_aligned ptr' (objBitsKO (KOTCB makeObject)))
   (createObjects' ptr' (Suc 0) (KOTCB makeObject) 0)
@@ -5128,6 +4773,35 @@ lemma createObjects_setDomain_commute:
   apply (clarsimp split:Structures_H.kernel_object.splits)
   done
 
+
+lemma createObjects_setDomains_commute:
+  "monad_commute
+      (\<lambda>s. \<forall>x\<in> set xs. tcb_at' (f x) s \<and>
+      range_cover ptr (objBitsKO (KOTCB makeObject)) (objBitsKO (KOTCB makeObject)) (Suc 0) \<and>
+      pspace_aligned' s \<and>
+      pspace_distinct' s \<and>
+      pspace_no_overlap' ptr (objBitsKO (KOTCB makeObject)) s \<and>
+      is_aligned ptr (objBitsKO (KOTCB makeObject)))
+  (mapM_x (threadSet (tcbDomain_update (\<lambda>_. r))) (map f xs))
+  (createObjects' ptr (Suc 0) (KOTCB makeObject) 0)"
+  proof (induct xs)
+    case Nil
+    show ?case
+      apply (simp add:monad_commute_def mapM_x_Nil)
+    done
+    next
+    case (Cons x xs)
+    show ?case
+    apply (simp add:mapM_x_Cons)
+    apply (rule monad_commute_guard_imp)
+    apply (rule commute_commute[OF monad_commute_split])
+     apply (rule commute_commute[OF Cons.hyps])
+     apply (rule createObjects_setDomain_commute)
+     apply (wp hoare_vcg_ball_lift)
+    apply clarsimp
+   done
+  qed
+
 lemma createObjects'_pspace_no_overlap2:
   "\<lbrace>pspace_no_overlap' (ptr + (1 + of_nat n << gz)) sz
        and K (gz = (objBitsKO val) + us)
@@ -5135,7 +4809,8 @@ lemma createObjects'_pspace_no_overlap2:
     createObjects' ptr (Suc n) val us
   \<lbrace>\<lambda>addrs s. pspace_no_overlap' (ptr + (1 + of_nat n << gz)) sz s\<rbrace>"
 proof -
-  note blah[simp del] = untyped_range.simps usable_untyped_range.simps atLeastAtMost_simps
+  note blah[simp del] = untyped_range.simps usable_untyped_range.simps atLeastAtMost_iff atLeastatMost_subset_iff atLeastLessThan_iff
+          Int_atLeastAtMost atLeastatMost_empty_iff split_paired_Ex
   show ?thesis
   apply (rule hoare_gen_asm)+
   apply (clarsimp simp:createObjects'_def split_def new_cap_addrs_fold')
@@ -5279,11 +4954,11 @@ lemma new_cap_addrs_def2:
   by (simp add:new_cap_addrs_def upto_enum_word unat_of_nat Fun.comp_def)
 
 lemma createTCBs_tcb_at':
-  "\<lbrace>\<lambda>s. pspace_aligned' s \<and> pspace_distinct' s \<and> pspace_bounded' s \<and>
+  "\<lbrace>\<lambda>s. pspace_aligned' s \<and> pspace_distinct' s \<and>
    pspace_no_overlap' ptr sz s \<and>
    range_cover ptr sz
-  (objBitsKO (KOTCB (tcbDomain_update (\<lambda>_. curdom) makeObject))) (Suc n) \<rbrace>
-  createObjects' ptr (Suc n) (KOTCB (tcbDomain_update (\<lambda>_. curdom) makeObject)) 0
+  (objBitsKO (KOTCB makeObject)) (Suc n) \<rbrace>
+  createObjects' ptr (Suc n) (KOTCB makeObject) 0
   \<lbrace>\<lambda>rv s.
   (\<forall>x\<in>set [0.e.of_nat n]. tcb_at' (ptr + x * 2^tcbBlockSizeBits) s)\<rbrace>"
   apply (simp add:createObjects'_def split_def alignError_def)
@@ -5292,8 +4967,8 @@ lemma createTCBs_tcb_at':
   apply clarsimp
   apply (subgoal_tac "(\<forall>x\<le>of_nat n.
     tcb_at' (ptr + x * 2^tcbBlockSizeBits) (s\<lparr>ksPSpace :=
-    foldr (\<lambda>addr. data_map_insert addr (KOTCB (tcbDomain_update (\<lambda>_. curdom) makeObject)))
-    (new_cap_addrs (Suc n) ptr (KOTCB (tcbDomain_update (\<lambda>_. curdom) makeObject)))
+    foldr (\<lambda>addr. data_map_insert addr (KOTCB makeObject))
+    (new_cap_addrs (Suc n) ptr (KOTCB makeObject))
     (ksPSpace s)\<rparr>))")
   apply (subst (asm) new_cap_addrs_def2)
    apply (drule range_cover.weak)
@@ -5309,39 +4984,10 @@ lemma createTCBs_tcb_at':
   apply (simp add: objBits_simps shiftl_t2n)
   done
 
-lemma curDomain_createObjects'_comm:
-  "do x \<leftarrow> createObjects' ptr n obj us;
-      y \<leftarrow> curDomain;
-      m x y
-   od =
-   do y \<leftarrow> curDomain;
-      x \<leftarrow> createObjects' ptr n obj us;
-      m x y
-   od"
-  apply (rule ext)
-  apply (case_tac x)
-  by (auto simp: createObjects'_def split_def bind_assoc return_def unless_def
-                 when_def simpler_gets_def alignError_def fail_def assert_def
-                 bind_def curDomain_def modify_def get_def put_def
-          split: option.splits)
-
-lemma curDomain_twice_simp:
-  "do x \<leftarrow> curDomain;
-      y \<leftarrow> curDomain;
-      m x y
-   od =
-   do x \<leftarrow> curDomain;
-      m x x
-   od"
-  apply (rule ext)
-  apply (case_tac x)
-  by (auto simp: simpler_gets_def bind_def curDomain_def)
-
 lemma createNewCaps_Cons:
   assumes cover:"range_cover ptr sz (Types_H.getObjectSize ty us) (Suc (Suc n))"
   and "valid_pspace' s" "valid_arch_state' s"
   and "pspace_no_overlap' ptr sz s"
-  and "ty = APIObjectType SchedContextObject \<longrightarrow> sc_size_bounds us"
   and "ptr \<noteq> 0"
   shows "createNewCaps ty ptr (Suc (Suc n)) us d s
  = (do x \<leftarrow> createNewCaps ty ptr (Suc n) us d;
@@ -5424,87 +5070,126 @@ proof -
                          Arch_createNewCaps_def)
         apply (rename_tac apiobject_type)
         apply (case_tac apiobject_type)
-              apply (simp_all add: bind_assoc ARM_H.toAPIType_def)
-              \<comment> \<open>Untyped\<close>
-              apply (simp add:
-                bind_assoc ARM_H.getObjectSize_def
-                mapM_def sequence_def Retype_H.createObject_def
-                ARM_H.toAPIType_def
-                createObjects_def ARM_H.createObject_def
-                Arch_createNewCaps_def comp_def
-                apiGetObjectSize_def shiftl_t2n field_simps
-                shiftL_nat mapM_x_def sequence_x_def append
-                fromIntegral_def integral_inv[unfolded Fun.comp_def])
-             \<comment> \<open>TCB\<close>
-              apply (simp add:
-                bind_assoc ARM_H.getObjectSize_def
-                mapM_def sequence_def Retype_H.createObject_def
-                ARM_H.toAPIType_def objBitsKO_def
-                createObjects_def ARM_H.createObject_def
-                Arch_createNewCaps_def comp_def append
-                apiGetObjectSize_def shiftl_t2n field_simps
-                shiftL_nat fromIntegral_def integral_inv[unfolded Fun.comp_def])
-             apply (subst curDomain_createObjects'_comm)
-             apply (subst curDomain_twice_simp)
-             apply (simp add: monad_eq_simp_state)
-             apply (intro conjI; clarsimp simp: in_monad)
-               apply ((fastforce simp: curDomain_def simpler_gets_def return_def placeNewObject_def2
-                                       field_simps shiftl_t2n bind_assoc objBits_simps in_monad
-                                       createObjects_Cons[where
-                                         val="KOTCB (tcbDomain_update (\<lambda>_. ksCurDomain s) makeObject)"
-                                         and s=s, simplified objBitsKO_def])+)[2]
-              apply ((clarsimp simp: curDomain_def simpler_gets_def return_def split_def bind_def
-                                    field_simps shiftl_t2n bind_assoc objBits_simps placeNewObject_def2
-                                    createObjects_Cons[where
-                                      val="KOTCB (tcbDomain_update (\<lambda>_. ksCurDomain s) makeObject)"
-                                      and s=s, simplified objBitsKO_def])+)[1]
-            \<comment> \<open>EP, NTFN\<close>
-            apply (((simp add:
-                        ARM_H.getObjectSize_def
-                        mapM_def sequence_def Retype_H.createObject_def
-                        ARM_H.toAPIType_def
-                        createObjects_def ARM_H.createObject_def
-                        Arch_createNewCaps_def comp_def
-                        apiGetObjectSize_def shiftl_t2n field_simps
-                        shiftL_nat mapM_x_def sequence_x_def append
-                        fromIntegral_def integral_inv[unfolded Fun.comp_def])+
-                     , subst monad_eq, rule createObjects_Cons
-                     , (simp add: field_simps shiftl_t2n bind_assoc pageBits_def
-                                 objBits_simps' placeNewObject_def2)+)+)[2]
-          \<comment> \<open>CNode\<close>
-          apply (simp add: cteSizeBits_def pageBits_def tcbBlockSizeBits_def
-                        epSizeBits_def ntfnSizeBits_def pdBits_def bind_assoc
-                        ARM_H.getObjectSize_def
-                        mapM_def sequence_def Retype_H.createObject_def
-                        ARM_H.toAPIType_def
-                        createObjects_def ARM_H.createObject_def
-                        Arch_createNewCaps_def comp_def
-                        apiGetObjectSize_def shiftl_t2n field_simps
-                        shiftL_nat mapM_x_def sequence_x_def append
-                        fromIntegral_def integral_inv[unfolded Fun.comp_def])+
-          apply (subst monad_eq, rule createObjects_Cons)
-                apply (simp add: field_simps shiftl_t2n bind_assoc pageBits_def
-                                 objBits_simps' placeNewObject_def2)+
-          apply (subst gsCNodes_update gsCNodes_upd_createObjects'_comm)+
-          apply (simp add: modify_modify_bind)
-          apply (rule fun_cong[where x=s])
-          apply (rule arg_cong_bind[OF refl ext])+
-          apply (rule arg_cong_bind[OF _ refl])
-          apply (rule arg_cong[where f=modify, OF ext], simp)
-          apply (rule arg_cong2[where f=gsCNodes_update, OF ext refl])
-          apply (rule ext)
-          apply simp
-         \<comment> \<open>SC, Reply\<close>
-         apply ((simp add: cteSizeBits_def pageBits_def tcbBlockSizeBits_def scBits_simps
-                           epSizeBits_def ntfnSizeBits_def pdBits_def bind_assoc objBits_simps
-                           mapM_def sequence_def Retype_H.createObject_def ARM_H.toAPIType_def
-                           createObjects_def ARM_H.createObject_def Arch_createNewCaps_def comp_def
-                           apiGetObjectSize_def shiftl_t2n field_simps shiftL_nat mapM_x_def
-                           sequence_x_def append fromIntegral_def ARM_H.getObjectSize_def
-                           integral_inv[unfolded Fun.comp_def],
-                 subst monad_eq, rule createObjects_Cons;
-                 fastforce simp: field_simps shiftl_t2n bind_assoc pageBits_def objBits_simps'
-                                 placeNewObject_def2 scBits_simps)+)[2]
+            apply (simp_all add: bind_assoc ARM_H.toAPIType_def
+                                 )
+            \<comment> \<open>Untyped\<close>
+            apply (simp add:
+              bind_assoc ARM_H.getObjectSize_def
+              mapM_def sequence_def Retype_H.createObject_def
+              ARM_H.toAPIType_def
+              createObjects_def ARM_H.createObject_def
+              Arch_createNewCaps_def comp_def
+              apiGetObjectSize_def shiftl_t2n field_simps
+              shiftL_nat mapM_x_def sequence_x_def append
+              fromIntegral_def integral_inv[unfolded Fun.comp_def])
+           \<comment> \<open>TCB, EP, NTFN\<close>
+           apply (simp add: bind_assoc
+                      ARM_H.getObjectSize_def
+                      sequence_def Retype_H.createObject_def
+                      ARM_H.toAPIType_def
+                      createObjects_def ARM_H.createObject_def
+                      Arch_createNewCaps_def comp_def
+                      apiGetObjectSize_def shiftl_t2n field_simps
+                      shiftL_nat append mapM_x_append2
+                      fromIntegral_def integral_inv[unfolded Fun.comp_def])+
+           apply (subst monad_eq)
+            apply (rule createObjects_Cons)
+                 apply (simp add: field_simps shiftl_t2n bind_assoc pageBits_def
+                               objBits_simps placeNewObject_def2)+
+           apply (rule_tac Q = "\<lambda>r s. pspace_aligned' s \<and>
+               pspace_distinct' s \<and>
+               pspace_no_overlap' (ptr + (2^tcbBlockSizeBits + of_nat n * 2^tcbBlockSizeBits)) (objBitsKO (KOTCB makeObject)) s \<and>
+               range_cover (ptr + 2^tcbBlockSizeBits) sz
+               (objBitsKO (KOTCB makeObject)) (Suc n)
+               \<and> (\<forall>x\<in>set [0.e.of_nat n]. tcb_at' (ptr + x * 2^tcbBlockSizeBits) s)"
+               in monad_eq_split2)
+              apply simp
+             apply (subst monad_commute_simple[symmetric])
+               apply (rule commute_commute[OF curDomain_commute])
+               apply (wpsimp+)[2]
+             apply (rule_tac Q = "\<lambda>r s. r = (ksCurDomain s) \<and>
+               pspace_aligned' s \<and>
+               pspace_distinct' s \<and>
+               pspace_no_overlap' (ptr + (2^tcbBlockSizeBits + of_nat n * 2^tcbBlockSizeBits)) (objBitsKO (KOTCB makeObject)) s \<and>
+               range_cover (ptr + 2^tcbBlockSizeBits) sz
+               (objBitsKO (KOTCB makeObject)) (Suc n)
+               \<and> (\<forall>x\<in>set [0.e.of_nat n]. tcb_at' (ptr + x * 2^tcbBlockSizeBits) s)
+             " in  monad_eq_split)
+               apply (subst monad_commute_simple[symmetric])
+                 apply (rule createObjects_setDomains_commute)
+                apply (clarsimp simp:objBits_simps)
+                apply (rule conj_impI)
+                 apply (erule aligned_add_aligned)
+                  apply (rule aligned_add_aligned[where n = tcbBlockSizeBits])
+                    apply (simp add:is_aligned_def objBits_defs)
+                   apply (cut_tac is_aligned_shift[where m = tcbBlockSizeBits and k = "of_nat n",
+                     unfolded shiftl_t2n,simplified])
+                   apply (simp add:field_simps)+
+                apply (erule range_cover_full)
+                apply (simp add: word_bits_conv objBits_defs)
+               apply (rule_tac Q = "\<lambda>x s. (ksCurDomain s) = ra" in monad_eq_split2)
+                  apply simp
+                 apply (rule_tac Q = "\<lambda>x s. (ksCurDomain s) = ra" in monad_eq_split)
+                   apply (subst rewrite_step[where f = curDomain and
+                     P ="\<lambda>s. ksCurDomain s = ra" and f' = "return ra"])
+                     apply (simp add:curDomain_def bind_def gets_def get_def)
+                    apply simp
+                   apply (simp add:mapM_x_singleton)
+                  apply wp
+                 apply simp
+                apply (wp mapM_x_wp')
+               apply simp
+              apply (simp add:curDomain_def,wp)
+             apply simp
+            apply (wp createObjects'_psp_aligned[where sz = sz]
+              createObjects'_psp_distinct[where sz = sz])
+            apply (rule hoare_vcg_conj_lift)
+             apply (rule hoare_post_imp[OF _ createObjects'_pspace_no_overlap
+                [unfolded shiftl_t2n,where gz = tcbBlockSizeBits and sz = sz,simplified]])
+              apply (simp add:objBits_simps field_simps)
+             apply (simp add: objBits_simps)
+            apply (wp createTCBs_tcb_at')
+           apply (clarsimp simp:objBits_simps word_bits_def field_simps)
+           apply (frule range_cover_le[where n = "Suc n"],simp+)
+           apply (drule range_cover_offset[where p = 1,rotated])
+            apply simp
+           apply (simp add: objBits_defs)
+          apply (((simp add:
+                      ARM_H.getObjectSize_def
+                      mapM_def sequence_def Retype_H.createObject_def
+                      ARM_H.toAPIType_def
+                      createObjects_def ARM_H.createObject_def
+                      Arch_createNewCaps_def comp_def
+                      apiGetObjectSize_def shiftl_t2n field_simps
+                      shiftL_nat mapM_x_def sequence_x_def append
+                      fromIntegral_def integral_inv[unfolded Fun.comp_def])+
+                   , subst monad_eq, rule createObjects_Cons
+                   , (simp add: field_simps shiftl_t2n bind_assoc pageBits_def
+                               objBits_simps' placeNewObject_def2)+)+)[2]
+        \<comment> \<open>CNode\<close>
+        apply (simp add: cteSizeBits_def pageBits_def tcbBlockSizeBits_def
+                      epSizeBits_def ntfnSizeBits_def pdBits_def bind_assoc
+                      ARM_H.getObjectSize_def
+                      mapM_def sequence_def Retype_H.createObject_def
+                      ARM_H.toAPIType_def
+                      createObjects_def ARM_H.createObject_def
+                      Arch_createNewCaps_def comp_def
+                      apiGetObjectSize_def shiftl_t2n field_simps
+                      shiftL_nat mapM_x_def sequence_x_def append
+                      fromIntegral_def integral_inv[unfolded Fun.comp_def])+
+        apply (subst monad_eq, rule createObjects_Cons)
+              apply (simp add: field_simps shiftl_t2n bind_assoc pageBits_def
+                               objBits_simps' placeNewObject_def2)+
+        apply (subst gsCNodes_update gsCNodes_upd_createObjects'_comm)+
+        apply (simp add: modify_modify_bind)
+        apply (rule fun_cong[where x=s])
+        apply (rule arg_cong_bind[OF refl ext])+
+        apply (rule arg_cong_bind[OF _ refl])
+        apply (rule arg_cong[where f=modify, OF ext], simp)
+        apply (rule arg_cong2[where f=gsCNodes_update, OF ext refl])
+        apply (rule ext)
+        apply simp
+
        \<comment> \<open>SmallPageObject\<close>
        apply (simp add: Arch_createNewCaps_def
                         Retype_H.createObject_def createObjects_def bind_assoc toAPIType_def
@@ -5733,8 +5418,7 @@ lemma createNewObjects_def2:
     valid_arch_state' s;
     range_cover ptr sz (Types_H.getObjectSize ty us) (length dslots);
     ptr \<noteq> 0;
-    ksCurDomain s \<le> maxDomain;
-    ty = APIObjectType ArchTypes_H.apiobject_type.SchedContextObject \<longrightarrow> sc_size_bounds us\<rbrakk>
+    ksCurDomain s \<le> maxDomain\<rbrakk>
    \<Longrightarrow> createNewObjects ty parent dslots ptr us d s =
        insertNewCaps ty parent dslots ptr us d s"
   apply (clarsimp simp:insertNewCaps_def createNewObjects_def neq_Nil_conv)
@@ -5756,8 +5440,6 @@ lemma createNewObjects_def2:
     {ptr..ptr +  (1 + of_nat (length ys)) * 2 ^ (Types_H.getObjectSize ty us) - 1} s"
   assume range_cover: "range_cover ptr sz (Types_H.getObjectSize ty us) (Suc (length ys))"
   assume unt_at: "cte_wp_at' (\<lambda>c. isUntypedCap (cteCap c)) parent s"
-  assume min_sched_bits: "ty = APIObjectType ArchTypes_H.apiobject_type.SchedContextObject \<longrightarrow>
-                            sc_size_bounds us"
   show "zipWithM_x
         (\<lambda>num slot.
             RetypeDecls_H.createObject ty ((num << Types_H.getObjectSize ty us) + ptr) us d >>=
@@ -5806,8 +5488,8 @@ lemma createNewObjects_def2:
       apply (simp add:snoc.hyps bind_assoc)
       apply (rule sym)
       apply (subst monad_eq)
-       apply (erule createNewCaps_Cons[OF _ valid_psp valid_arch_state psp_no_overlap min_sched_bits
-                                         not_0])
+       apply (erule createNewCaps_Cons[OF _ valid_psp valid_arch_state psp_no_overlap not_0])
+      apply (rule sym)
       apply (simp add:bind_assoc del:upto_enum_nat)
       apply (rule_tac Q = "(\<lambda>r s. (\<forall>cap\<in>set r. cap \<noteq> capability.NullCap) \<and>
                             cte_wp_at' (\<lambda>c. isUntypedCap (cteCap c)) parent s \<and>
@@ -5815,37 +5497,40 @@ lemma createNewObjects_def2:
                             (\<forall>slot\<in>set as. cte_wp_at' (\<lambda>c. cteCap c = capability.NullCap) slot s) \<and>
                             pspace_no_overlap' (ptr + (1 + of_nat (length as) << Types_H.getObjectSize ty us))
                             (Types_H.getObjectSize ty us) s
-                            \<and> valid_pspace' s \<and> valid_arch_state' s
-                            \<and> (ty = APIObjectType SchedContextObject \<longrightarrow> sc_size_bounds us)
-                            \<and> Q r s)" for Q in monad_eq_split)
+                            \<and> valid_pspace' s \<and> valid_arch_state' s \<and> Q r s)" for Q in monad_eq_split)
         apply (subst append_Cons[symmetric])
-         apply (subst zipWithM_x_append1)
-         apply clarsimp
-         apply assumption
+        apply (subst zipWithM_x_append1)
+        apply clarsimp
+        apply assumption
         apply (clarsimp simp:field_simps)
-        apply (subst monad_commute_simple)
+        apply (subst monad_commute_simple[OF commute_commute])
          apply (rule new_cap_object_commute)
-        apply (frule_tac p = "1 + length as" in range_cover_no_0[rotated]; clarsimp)
-        apply (intro conjI)
-          apply (simp add:range_cover_def word_bits_def)
-         apply (rule aligned_add_aligned[OF range_cover.aligned],simp)
-          apply (rule is_aligned_shiftl_self)
-         apply simp
-         apply (metis range_cover_ptr_le snoc(8) word_le_0_iff)
-        apply (clarsimp simp: createNewCaps_def min_sched_bits)
+         apply (clarsimp)
+        apply (frule_tac p = "1 + length as" in range_cover_no_0[rotated])
+          apply clarsimp
+          apply simp
+          apply (subst (asm) Abs_fnat_hom_add[symmetric])
+         apply (intro conjI)
+         apply (simp add:range_cover_def word_bits_def)
+           apply (rule aligned_add_aligned[OF range_cover.aligned],simp)
+         apply (rule is_aligned_shiftl_self)
+         apply (simp add:range_cover_def)
+           apply (simp add:range_cover_def)
+          apply (clarsimp simp:field_simps shiftl_t2n)
+         apply (clarsimp simp:createNewCaps_def)
         apply (wp createNewCaps_not_nc createNewCaps_pspace_no_overlap'[where sz = sz]
                   createNewCaps_cte_wp_at'[where sz = sz] hoare_vcg_ball_lift
                   createNewCaps_valid_pspace[where sz = sz]
                   createNewCaps_obj_at'[where sz=sz])
           apply simp
          apply (rule range_cover_le)
-           apply (simp add:objSize_eq_capBits caps_r min_sched_bits)+
+           apply (simp add:objSize_eq_capBits caps_r)+
         apply (wp createNewCaps_ret_len createNewCaps_valid_arch_state)
        apply (frule range_cover_le[where n = "Suc (length as)"])
         apply simp+
        using psp_no_overlap caps_r valid_psp unt_at caps_no_overlap valid_arch_state
-       apply (clarsimp simp: valid_pspace'_def objSize_eq_capBits min_sched_bits)
-       apply (auto simp: kscd min_sched_bits[unfolded sc_size_bounds_def])
+       apply (clarsimp simp: valid_pspace'_def objSize_eq_capBits)
+       apply (auto simp: kscd)
        done
   qed
 qed
@@ -5861,8 +5546,7 @@ assumes check: "distinct dslots"
   \<and> caps_no_overlap'' ptr sz s
   \<and> caps_overlap_reserved'
    {ptr..ptr + of_nat (length dslots) * 2^ (Types_H.getObjectSize ty us) - 1} s
-  \<and> valid_pspace' s \<and> valid_arch_state' s \<and> ksCurDomain s \<le> maxDomain
-  \<and> (ty = APIObjectType ArchTypes_H.apiobject_type.SchedContextObject \<longrightarrow> sc_size_bounds us))"
+  \<and> valid_pspace' s \<and> valid_arch_state' s \<and> ksCurDomain s \<le> maxDomain)"
 shows "corres r P P' f (createNewObjects ty parent dslots ptr us d)"
   using check cover not_0
   apply (clarsimp simp:corres_underlying_def)
@@ -5888,10 +5572,7 @@ lemma createNewObjects_wp_helper:
   and valid_pspace'
   and valid_arch_state'
   and caps_overlap_reserved'
-   {ptr..ptr + of_nat (length dslots) * 2^ (Types_H.getObjectSize ty us) - 1}
-  and (\<lambda>s. ksCurDomain s \<le> maxDomain)
-  and K (ty = APIObjectType ArchTypes_H.apiobject_type.SchedContextObject \<longrightarrow>
-           sc_size_bounds us))
+   {ptr..ptr + of_nat (length dslots) * 2^ (Types_H.getObjectSize ty us) - 1} and (\<lambda>s. ksCurDomain s \<le> maxDomain))
   \<rbrace> (createNewObjects ty parent dslots ptr us d) \<lbrace>Q\<rbrace>"
   using assms
   apply (clarsimp simp:valid_def)
@@ -5912,7 +5593,7 @@ lemma createObject_def3:
 lemma ArchCreateObject_pspace_no_overlap':
   "\<lbrace>\<lambda>s. pspace_no_overlap'
           (ptr + (of_nat n << APIType_capBits ty userSize)) sz s \<and>
-        pspace_aligned' s \<and> pspace_distinct' s \<and> pspace_bounded' s \<and>
+        pspace_aligned' s \<and> pspace_distinct' s \<and>
         range_cover ptr sz (APIType_capBits ty userSize) (n + 2) \<and> ptr \<noteq> 0\<rbrace>
    ARM_H.createObject ty
      (ptr + (of_nat n << APIType_capBits ty userSize)) userSize d
@@ -5970,9 +5651,8 @@ lemma to_from_apiTypeD: "toAPIType ty = Some x \<Longrightarrow> ty = fromAPITyp
 lemma createObject_pspace_no_overlap':
   "\<lbrace>\<lambda>s. pspace_no_overlap'
           (ptr + (of_nat n << APIType_capBits ty userSize)) sz s \<and>
-        pspace_aligned' s \<and> pspace_distinct' s \<and> pspace_bounded' s
+        pspace_aligned' s \<and> pspace_distinct' s
         \<and> range_cover ptr sz (APIType_capBits ty userSize) (n + 2)
-        \<and> (ty = APIObjectType SchedContextObject \<longrightarrow> sc_size_bounds userSize)
         \<and> ptr \<noteq> 0\<rbrace>
    createObject ty (ptr + (of_nat n << APIType_capBits ty userSize)) userSize d
    \<lbrace>\<lambda>rv s. pspace_no_overlap'
@@ -5982,19 +5662,35 @@ lemma createObject_pspace_no_overlap':
    apply wpc
     apply (wp ArchCreateObject_pspace_no_overlap')
    apply wpc
-         apply wp
-        \<comment> \<open>TCB\<close>
-        apply (wp createObjects'_pspace_no_overlap2[where n =0 and sz = sz,simplified]
-             | simp add: curDomain_def placeNewObject_def2 word_shiftl_add_distrib field_simps)+
-         apply (simp add:add.assoc[symmetric])
-         apply (wp createObjects'_pspace_no_overlap2[where n =0 and sz = sz,simplified])
-        apply (wpsimp simp: curDomain_def)
-       \<comment> \<open>other objects\<close>
-       apply ((wp createObjects'_pspace_no_overlap2
-             | simp add: placeNewObject_def2 word_shiftl_add_distrib field_simps)+,
-               simp add:add.assoc[symmetric],
-               wp createObjects'_pspace_no_overlap2[where n =0 and sz = sz,simplified])+
-   \<comment> \<open>Cleanup\<close>
+       apply wp
+      apply (simp add:placeNewObject_def2)
+      apply (wp doMachineOp_psp_no_overlap createObjects'_pspace_no_overlap2
+        | simp add: placeNewObject_def2 curDomain_def word_shiftl_add_distrib
+        field_simps)+
+      apply (simp add:add.assoc[symmetric])
+      apply (wp createObjects'_pspace_no_overlap2
+        [where n =0 and sz = sz,simplified])
+     apply (simp add:placeNewObject_def2)
+     apply (wp doMachineOp_psp_no_overlap createObjects'_pspace_no_overlap2
+        | simp add: placeNewObject_def2 word_shiftl_add_distrib
+        field_simps)+
+     apply (simp add:add.assoc[symmetric])
+     apply (wp createObjects'_pspace_no_overlap2
+        [where n =0 and sz = sz,simplified])
+    apply (simp add:placeNewObject_def2)
+    apply (wp doMachineOp_psp_no_overlap createObjects'_pspace_no_overlap2
+      | simp add: placeNewObject_def2 word_shiftl_add_distrib
+      field_simps)+
+    apply (simp add:add.assoc[symmetric])
+    apply (wp createObjects'_pspace_no_overlap2
+      [where n =0 and sz = sz,simplified])
+   apply (simp add:placeNewObject_def2)
+   apply (wp doMachineOp_psp_no_overlap createObjects'_pspace_no_overlap2
+     | simp add: placeNewObject_def2 word_shiftl_add_distrib
+     field_simps)+
+   apply (simp add:add.assoc[symmetric])
+   apply (wp createObjects'_pspace_no_overlap2
+     [where n =0 and sz = sz,simplified])
   apply clarsimp
   apply (frule(1) range_cover_no_0[where p = n])
    apply simp
@@ -6012,30 +5708,29 @@ lemma createObject_pspace_no_overlap':
    apply (simp add:shiftl_t2n field_simps)
   apply (frule range_cover_offset[rotated,where p = n])
    apply simp+
-  by (auto simp: word_shiftl_add_distrib field_simps shiftl_t2n elim: range_cover_le)
-     (auto simp add: APIType_capBits_def fromAPIType_def objBits_def scBits_simps objBits_simps
-              dest!: to_from_apiTypeD)
+  apply (auto simp: word_shiftl_add_distrib field_simps shiftl_t2n elim: range_cover_le,
+    auto simp add: APIType_capBits_def fromAPIType_def objBits_def
+        dest!: to_from_apiTypeD)
+  done
 
 lemma createObject_pspace_aligned_distinct':
-  "\<lbrace>pspace_aligned' and K (is_aligned ptr (APIType_capBits ty us)) and pspace_bounded'
+  "\<lbrace>pspace_aligned' and K (is_aligned ptr (APIType_capBits ty us))
    and pspace_distinct' and pspace_no_overlap' ptr (APIType_capBits ty us)
-   and K (ty = APIObjectType apiobject_type.CapTableObject \<longrightarrow> us < 28)
-   and K (ty = APIObjectType ArchTypes_H.apiobject_type.SchedContextObject \<longrightarrow>
-            sc_size_bounds us)\<rbrace>
+   and K (ty = APIObjectType apiobject_type.CapTableObject \<longrightarrow> us < 28)\<rbrace>
   createObject ty ptr us d
-  \<lbrace>\<lambda>xa s. pspace_aligned' s \<and> pspace_distinct' s \<and> pspace_bounded' s\<rbrace>"
+  \<lbrace>\<lambda>xa s. pspace_aligned' s \<and> pspace_distinct' s\<rbrace>"
   apply (rule hoare_pre)
   apply (wp placeNewObject_pspace_aligned' unless_wp
-      placeNewObject_pspace_distinct' placeNewObject_pspace_bounded'
+      placeNewObject_pspace_distinct'
     | simp add:ARM_H.createObject_def
       Retype_H.createObject_def objBits_simps
       curDomain_def placeNewDataObject_def
           split del: if_split
     | wpc | intro conjI impI)+
-  by (auto simp: APIType_capBits_def pdBits_def objBits_simps' pteBits_def pdeBits_def
-                 pageBits_def word_bits_def archObjSize_def ptBits_def ARM_H.toAPIType_def
-                 untypedBits_defs scBits_simps
-          split: ARM_H.object_type.splits apiobject_type.splits)
+  apply (auto simp:APIType_capBits_def pdBits_def objBits_simps' pteBits_def pdeBits_def
+    pageBits_def word_bits_def archObjSize_def ptBits_def ARM_H.toAPIType_def
+    split:ARM_H.object_type.splits apiobject_type.splits)
+  done
 
 declare objSize_eq_capBits [simp]
 
@@ -6091,23 +5786,22 @@ lemma insertNewCap_wps[wp]:
       insertNewCap parent slot cap
    \<lbrace>\<lambda>rv s. P (cteCaps_of s)\<rbrace>"
   apply (simp_all add: insertNewCap_def)
-   apply (wpsimp wp: hoare_drop_imps)+
+   apply (wp hoare_drop_imps
+            | simp add: o_def)+
   apply (fastforce elim!: rsubst[where P=P])
   done
 
 crunch insertNewCap
   for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  and pspace_bounded'[wp]: pspace_bounded'
   (wp: crunch_wps)
 
 lemma createNewObjects_pspace_no_overlap':
-  "\<lbrace>pspace_no_overlap' ptr sz and pspace_aligned' and pspace_distinct' and pspace_bounded'
+  "\<lbrace>pspace_no_overlap' ptr sz and pspace_aligned' and pspace_distinct'
   and K (range_cover ptr sz (Types_H.getObjectSize ty us) (Suc (length dests)))
   and K (ptr \<noteq> 0)
-  and K (ty = APIObjectType apiobject_type.CapTableObject \<longrightarrow> us < 28)
-  and K (ty = APIObjectType apiobject_type.SchedContextObject \<longrightarrow> sc_size_bounds us)\<rbrace>
+  and K (ty = APIObjectType apiobject_type.CapTableObject \<longrightarrow> us < 28)\<rbrace>
   createNewObjects ty src dests ptr us d
-  \<lbrace>\<lambda>rv s.  pspace_aligned' s \<and> pspace_distinct' s \<and> pspace_bounded' s \<and>
+  \<lbrace>\<lambda>rv s.  pspace_aligned' s \<and> pspace_distinct' s \<and>
   pspace_no_overlap' ((of_nat (length dests) << APIType_capBits ty us) + ptr) sz s\<rbrace>"
   apply (rule hoare_gen_asm)+
   proof (induct rule:rev_induct )
@@ -6126,39 +5820,41 @@ lemma createNewObjects_pspace_no_overlap':
      apply (subst createNewObjects_Cons)
       apply (drule range_cover.weak)
       apply (simp add: word_bits_def)
-     apply (wpsimp wp: pspace_no_overlap'_lift2)
-       apply (simp add: conj_comms)
-       apply (subst conj_assoc[symmetric])
-       apply (subst conj_assoc[symmetric])
-       apply (rule hoare_vcg_conj_lift)
-        apply (rule hoare_post_imp[OF _ createObject_pspace_aligned_distinct'])
-        apply simp
-       apply (simp add:field_simps)
-       apply (wp createObject_pspace_no_overlap')
-      apply (clarsimp simp: conj_comms)
-      apply (rule hoare_pre)
-       apply (subst conj_assoc[symmetric])
-       apply (subst conj_assoc[symmetric])
-       apply (rule hoare_vcg_conj_lift)
-        apply (rule hoare_post_imp[OF _ snoc.hyps])
-            apply (simp add:snoc)+
-       apply wp
-       apply (simp add: conj_comms field_simps)
-       apply (rule hoare_post_imp)
-        apply (erule context_conjI)
-        apply (intro conjI)
-         apply (rule aligned_add_aligned[OF range_cover.aligned
-                                            is_aligned_shiftl_self])
+     apply (wp pspace_no_overlap'_lift)
+      apply (simp add: conj_comms)
+      apply (rule hoare_vcg_conj_lift)
+       apply (rule hoare_post_imp[OF _ createObject_pspace_aligned_distinct'])
+       apply simp
+      apply (rule hoare_vcg_conj_lift)
+       apply (rule hoare_post_imp[OF _ createObject_pspace_aligned_distinct'])
+       apply simp
+      apply (simp add:field_simps)
+      apply (wp createObject_pspace_no_overlap')
+     apply (clarsimp simp: conj_comms)
+     apply (rule hoare_pre)
+      apply (rule hoare_vcg_conj_lift)
+       apply (rule hoare_post_imp[OF _ snoc.hyps])
+       apply (simp add:snoc)+
+      apply (rule hoare_vcg_conj_lift)
+       apply (rule hoare_post_imp[OF _ snoc.hyps])
+       apply (simp add:snoc)+
+      apply wp
+     apply (simp add: conj_comms field_simps)
+     apply (rule hoare_post_imp)
+     apply (erule context_conjI)
+      apply (intro conjI)
+        apply (rule aligned_add_aligned[OF range_cover.aligned
+                                           is_aligned_shiftl_self])
           apply simp
          apply simp
         apply simp
-        apply (erule pspace_no_overlap'_le)
-         apply (simp add: range_cover.sz[where 'a=32, folded word_bits_def])+
-       apply (rule hoare_post_imp[OF _ snoc.hyps])
-           apply (simp add:field_simps snoc)+
-     using snoc
-     apply simp
-     done
+       apply (erule pspace_no_overlap'_le)
+       apply (simp add: range_cover.sz[where 'a=32, folded word_bits_def])+
+     apply (rule hoare_post_imp[OF _ snoc.hyps])
+     apply (simp add:field_simps snoc)+
+    using snoc
+    apply simp
+  done
 qed
 
 end

--- a/proof/refine/ARM/EmptyFail.thy
+++ b/proof/refine/ARM/EmptyFail.thy
@@ -12,26 +12,38 @@ begin
    Unless there is a good reason, they should all be [intro!, wp, simp] *)
 
 lemma empty_fail_projectKO [simp, intro!]:
-  "empty_fail (gets_the $ projectKO v)" by wpsimp
+  "empty_fail (projectKO v)"
+  unfolding empty_fail_def projectKO_def
+  by (simp add: return_def fail_def split: option.splits)
 
 lemma empty_fail_alignCheck [intro!, wp, simp]:
   "empty_fail (alignCheck a b)"
-  unfolding alignCheck_def by wpsimp
+  unfolding alignCheck_def
+  by (fastforce simp: alignError_def)
 
 lemma empty_fail_magnitudeCheck [intro!, wp, simp]:
   "empty_fail (magnitudeCheck a b c)"
-  unfolding magnitudeCheck_def by wpsimp
+  unfolding magnitudeCheck_def
+  by (fastforce split: option.splits)
 
 lemma empty_fail_loadObject_default [intro!, wp, simp]:
-  shows "empty_fail (gets_the $ loadObject_default x b c d)" by wpsimp
+  shows "empty_fail (loadObject_default x b c d)"
+  by (auto simp: loadObject_default_def
+           split: option.splits)
 
 lemma empty_fail_threadGet [intro!, wp, simp]:
   "empty_fail (threadGet f p)"
-  by (wpsimp simp: threadGet_def)
+  by (fastforce simp: threadGet_def getObject_def split_def)
 
 lemma empty_fail_getCTE [intro!, wp, simp]:
   "empty_fail (getCTE slot)"
-  by (wpsimp simp: getCTE_def getObject_def)
+  apply (simp add: getCTE_def getObject_def split_def)
+  apply (intro empty_fail_bind, simp_all)
+  apply (simp add: loadObject_cte typeError_def alignCheck_def alignError_def
+                   magnitudeCheck_def
+            split: Structures_H.kernel_object.split)
+  apply (auto split: option.split)
+  done
 
 lemma empty_fail_updateObject_cte [intro!, wp, simp]:
   "empty_fail (updateObject (v :: cte) ko a b c)"
@@ -53,13 +65,15 @@ lemma empty_fail_getSlotCap [intro!, wp, simp]:
 context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma empty_fail_getObject:
-  "empty_fail (getObject x :: 'a :: pspace_storable kernel)"
-  apply (wpsimp simp: getObject_def split_def)
+  assumes "\<And>b c d. empty_fail (loadObject x b c d::'a :: pspace_storable kernel)"
+  shows "empty_fail (getObject x :: 'a :: pspace_storable kernel)"
+  apply (simp add: getObject_def split_def)
+  apply (safe intro!: assms)
   done
 
 lemma empty_fail_getObject_tcb [intro!, wp, simp]:
   shows "empty_fail (getObject x :: tcb kernel)"
-  by (wpsimp wp: empty_fail_getObject)
+  by (auto intro: empty_fail_getObject)
 
 lemma empty_fail_updateTrackedFreeIndex [intro!, wp, simp]:
   shows "empty_fail (updateTrackedFreeIndex p idx)"
@@ -82,7 +96,7 @@ lemma empty_fail_getIRQSlot [intro!, wp, simp]:
 
 lemma empty_fail_getObject_ntfn [intro!, wp, simp]:
   "empty_fail (getObject p :: Structures_H.notification kernel)"
-  by (wpsimp wp: empty_fail_getObject)
+  by (simp add: empty_fail_getObject)
 
 lemma empty_fail_getNotification [intro!, wp, simp]:
   "empty_fail (getNotification ep)"
@@ -96,11 +110,11 @@ lemma empty_fail_lookupIPCBuffer [intro!, wp, simp]:
 
 lemma empty_fail_updateObject_default [intro!, wp, simp]:
   "empty_fail (updateObject_default v ko a b c)"
-  by (wpsimp simp: updateObject_default_def)
+  by (fastforce simp: updateObject_default_def typeError_def unless_def split: kernel_object.splits)
 
 lemma empty_fail_threadSet [intro!, wp, simp]:
   "empty_fail (threadSet f p)"
-  by (wpsimp simp: threadSet_def setObject_def)
+  by (fastforce simp: threadSet_def getObject_def setObject_def split_def)
 
 lemma empty_fail_getThreadState[iff]:
   "empty_fail (getThreadState t)"

--- a/proof/refine/ARM/InitLemmas.thy
+++ b/proof/refine/ARM/InitLemmas.thy
@@ -23,8 +23,8 @@ declare unless_True[simp]
 declare maybe_fail_bind_fail[simp]
 
 crunch setPriority
-  for cte_wp_at'[wp]: "cte_wp_at' P p"
-  and irq_node'[wp]: "\<lambda>s. P (irq_node' s)"
-  (simp: crunch_simps wp: crunch_wps)
+  for cte_wp_at'[wp]: "cte_wp_at' P p" (simp: crunch_simps)
+crunch setPriority
+  for irq_node'[wp]: "\<lambda>s. P (irq_node' s)" (simp: crunch_simps)
 
 end

--- a/proof/refine/ARM/InterruptAcc_R.thy
+++ b/proof/refine/ARM/InterruptAcc_R.thy
@@ -18,6 +18,10 @@ lemma getIRQSlot_corres:
                    ucast_nat_def shiftl_t2n)
   done
 
+crunch get_irq_slot
+  for inv[wp]: "P"
+crunch getIRQSlot
+  for inv[wp]: "P"
 
 context begin interpretation Arch . (*FIXME: arch-split*)
 
@@ -49,25 +53,27 @@ lemma setIRQState_invs[wp]:
    \<lbrace>\<lambda>rv. invs'\<rbrace>"
   apply (simp add: setIRQState_def setInterruptState_def getInterruptState_def)
   apply (wp dmo_maskInterrupt)
-  apply (clarsimp simp: invs'_def cur_tcb'_def
-                        Invariants_H.valid_queues_def valid_queues'_def valid_release_queue_def
-                        valid_release_queue'_def valid_dom_schedule'_def
-                        valid_irq_node'_def
+  apply (clarsimp simp: invs'_def valid_state'_def cur_tcb'_def
+                        valid_idle'_def valid_irq_node'_def
                         valid_arch_state'_def valid_global_refs'_def
                         global_refs'_def valid_machine_state'_def
                         if_unsafe_then_cap'_def ex_cte_cap_to'_def
                         valid_irq_handlers'_def irq_issued'_def
                         cteCaps_of_def valid_irq_masks'_def
-                        bitmapQ_defs valid_queues_no_bitmap_def irqs_masked'_def)
-  apply fastforce
+                        bitmapQ_defs valid_bitmaps_def)
+  apply (rule conjI, clarsimp)
+  apply (clarsimp simp: irqs_masked'_def ct_not_inQ_def)
+  apply (rule conjI)
+   apply fastforce
+  apply (simp add: ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def)
   done
 
 lemma getIRQSlot_real_cte[wp]:
   "\<lbrace>invs'\<rbrace> getIRQSlot irq \<lbrace>real_cte_at'\<rbrace>"
   apply (simp add: getIRQSlot_def getInterruptState_def locateSlot_conv)
   apply wp
-  apply (clarsimp simp: invs'_def valid_irq_node'_def cteSizeBits_def shiftl_t2n
-                        cte_level_bits_def ucast_nat_def)
+  apply (clarsimp simp: invs'_def valid_state'_def valid_irq_node'_def
+                        cte_level_bits_def ucast_nat_def cteSizeBits_def shiftl_t2n)
   done
 
 lemma getIRQSlot_cte_at[wp]:
@@ -89,285 +95,38 @@ lemma work_units_and_irq_state_state_relationI [intro!]:
    \<in> state_relation"
   by (simp add: state_relation_def swp_def)
 
-lemma update_work_units_corres[corres]:
-  "corres (dc \<oplus> dc) \<top> \<top> (liftE update_work_units) (liftE (modifyWorkUnits (\<lambda>op. op + 1)))"
-  apply (clarsimp simp: update_work_units_def modifyWorkUnits_def)
-  apply (rule corres_modify)
-  apply (clarsimp simp: state_relation_def)
-  done
-
-lemma getCurTime_corres[corres]:
-  "corres (=) \<top> \<top> (gets cur_time) getCurTime"
-  apply (simp add: getCurTime_def state_relation_def)
-  done
-
-lemma getDomainTime_corres[corres]:
-  "corres (=) \<top> \<top> (gets domain_time) getDomainTime"
-  apply (simp add: getDomainTime_def state_relation_def)
-  done
-
-lemma getCurTime_sp:
-  "\<lbrace>P\<rbrace> getCurTime \<lbrace>\<lambda>rv s. rv = ksCurTime s \<and> P s\<rbrace>"
-  apply wpsimp
-  done
-
-lemma updateTimeStamp_corres[corres]:
-  "corres dc \<top> \<top> update_time_stamp updateTimeStamp"
-  apply (clarsimp simp: update_time_stamp_def updateTimeStamp_def setConsumedTime_def)
-  apply (prop_tac "minBudget = MIN_BUDGET")
-   apply (clarsimp simp: minBudget_def MIN_BUDGET_def kernelWCETTicks_def)
-  apply (rule corres_underlying_split[rotated 2, OF gets_sp getCurTime_sp])
-   apply corresKsimp
-  apply (rule corres_underlying_split[where r'="(=)"])
-     apply (rule corres_guard_imp)
-       apply (rule corres_machine_op)
-       apply corresKsimp
-        apply (wpsimp simp: getCurrentTime_def)
-       apply simp
-      apply simp
-     apply simp
-    apply (rule_tac P=\<top> and P'=\<top> in corres_inst)
-    apply (clarsimp simp: setCurTime_def)
-    apply (rule corres_guard_imp)
-      apply (rule corres_split[OF corres_modify])
-         apply (clarsimp simp: state_relation_def cdt_relation_def)
-        apply (clarsimp simp: setConsumedTime_def)
-        apply (rule_tac Q'="\<lambda>rv s. rv = ksConsumedTime s" in corres_symb_exec_r)
-           apply (rule corres_guard_imp)
-             apply (rule corres_split[OF corres_modify])
-                apply (simp add: state_relation_def cdt_relation_def)
-               apply (rule corres_guard_imp)
-                 apply (rule corres_rel_imp)
-                  apply (rule corres_split[OF getDomainTime_corres])
-                    apply (rule corres_when, rule refl)
-                    apply (fastforce intro: setDomainTime_corres)
-                   apply (wpsimp simp: getConsumedTime_def)+
-  done
-
-lemma refillSufficient_corres:
-  "sc_ptr = scPtr
-   \<Longrightarrow> corres (=) (valid_objs and pspace_aligned and pspace_distinct
-                   and sc_refills_sc_at (\<lambda>refills. refills \<noteq> []) sc_ptr)
-                  valid_objs'
-              (get_sc_refill_sufficient sc_ptr consumed)
-              (refillSufficient scPtr consumed)"
-  apply (rule corres_cross[where Q' = "sc_at' scPtr", OF sc_at'_cross_rel])
-   apply (fastforce simp: obj_at_def is_sc_obj_def valid_obj_def valid_pspace_def sc_at_pred_n_def)
-  apply (clarsimp simp: get_sc_refill_sufficient_def refillSufficient_def getCurTime_def)
-  apply (rule corres_guard_imp)
-    apply (rule corres_symb_exec_r)
-       apply (rule_tac R="\<lambda>sc s. sc_refills sc \<noteq> []"
-                   and R'= "\<lambda>sc' s. valid_objs' s \<and> ko_at' sc' scPtr s \<and> refills = scRefills sc'"
-                    in corres_split[OF get_sc_corres])
-         apply (rename_tac sc sc')
-         apply clarsimp
-         apply (prop_tac "r_amount (refill_hd sc) = rAmount (refillHd sc')")
-          apply (fastforce dest: sc_ko_at_valid_objs_valid_sc'
-                                 refill_hd_relation2)
-         apply (clarsimp simp: refill_sufficient_def sufficientRefills_def refillHd_def
-                               refill_capacity_def refillsCapacity_def MIN_BUDGET_def
-                               minBudget_def kernelWCETTicks_def)
-        apply (wpsimp wp: get_sc_inv'
-                    simp: getRefills_def)+
-   apply (fastforce dest: valid_objs_valid_sched_context_size
-                    simp: sc_at_pred_n_def obj_at_def is_sc_obj_def)
-  apply (clarsimp simp: obj_at'_def projectKOs)
-  done
-
-lemma modifyWorkUnits_valid_objs'[wp]:
-  "modifyWorkUnits f \<lbrace>valid_objs'\<rbrace>"
-  apply (clarsimp simp: modifyWorkUnits_def)
-  apply wpsimp
-  done
-
-lemma setWorkUnits_corres[corres]:
-  "corres dc \<top> \<top> reset_work_units (setWorkUnits 0)"
-  apply (clarsimp simp: reset_work_units_def setWorkUnits_def)
-  apply (rule corres_modify)
-  apply (clarsimp simp: state_relation_def)
-  done
-
-crunch updateTimeStamp
-  for valid_objs'[wp]: valid_objs'
-
-lemma getCurSc_sp:
-  "\<lbrace>P\<rbrace> getCurSc \<lbrace>\<lambda>rv s. rv = ksCurSc s \<and> P s\<rbrace>"
-  apply (wpsimp wp: getCurSc_def)
-  done
-
-lemma getConsumedTime_sp:
-  "\<lbrace>P\<rbrace> getConsumedTime \<lbrace>\<lambda>rv s. rv = ksConsumedTime s \<and> P s\<rbrace>"
-  apply wpsimp
-  done
-
-lemma scActive_corres:
-  "corres (=) (sc_at scPtr and pspace_aligned and pspace_distinct)
-              \<top>
-          (get_sc_active scPtr)
-          (scActive scPtr)"
-  apply (rule corres_cross[where Q' = "sc_at' scPtr", OF sc_at'_cross_rel])
-   apply (fastforce simp: obj_at_def is_sc_obj_def valid_obj_def valid_pspace_def sc_at_pred_n_def)
-  apply (corresKsimp corres: get_sc_corres
-                      simp: sc_relation_def get_sc_active_def scActive_def active_sc_def)
-  done
-
-lemma getConsumedTime_corres[corres]:
-  "corres (=) \<top> \<top> (gets consumed_time) getConsumedTime"
-  apply (simp add: getConsumedTime_def state_relation_def)
-  done
-
-lemma isCurDomainExpired_corres[corres]:
-  "corres (=) \<top> \<top> (gets is_cur_domain_expired) isCurDomainExpired"
-  apply (simp add: is_cur_domain_expired_def isCurDomainExpired_def getDomainTime_def
-                   getConsumedTime_def)
-  apply (clarsimp simp: corres_underlying_def gets_def bind_def get_def return_def
-                        state_relation_def)
-  done
-
-lemma scActive_sp:
-  "\<lbrace>P\<rbrace>
-   scActive scPtr
-   \<lbrace>\<lambda>rv s. P s \<and> (\<exists>sc. ko_at' sc scPtr s \<and> rv = (0 < scRefillMax sc))\<rbrace>"
-  apply (simp add: scActive_def)
-  apply (rule bind_wp_fwd)
-   apply (rule get_sc_sp')
-  apply (wp hoare_return_sp)
-  apply (clarsimp simp: obj_at'_def projectKOs)
-  done
-
 lemma preemptionPoint_corres:
-  "corres (dc \<oplus> dc)
-          (\<lambda>s. valid_objs s \<and> cur_sc_tcb s \<and> pspace_aligned s \<and> pspace_distinct s
-               \<and> active_scs_valid s \<and> valid_machine_time s)
-          valid_objs'
-          preemption_point
-          preemptionPoint"
-  (is "corres _ ?abs ?conc _ _")
-  supply if_split[split del]
+  "corres (dc \<oplus> dc) \<top> \<top> preemption_point preemptionPoint"
   apply (simp add: preemption_point_def preemptionPoint_def)
-  apply (rule corres_splitEE_skip
-         ; corresKsimp corres: update_work_units_corres
-                        simp: update_work_units_def)
-  apply (clarsimp simp: bindE_def liftE_def)
-  apply (rule_tac Q'="\<lambda>rv s. rv = ksWorkUnitsCompleted s \<and> ?conc s" in corres_symb_exec_r[rotated])
-     apply (wpsimp simp: getWorkUnits_def)+
-  apply (rename_tac work_units)
-  apply (clarsimp simp: OR_choiceE_def whenE_def work_units_limit_reached_def bindE_def liftE_def)
-  apply (rule_tac Q="\<lambda>rv s. rv = s \<and> ?abs s" in corres_symb_exec_l[rotated])
-     apply wpsimp+
-  apply (rename_tac ex)
-  apply (rule_tac Q="\<lambda>s. ex = s \<and> work_units = work_units_completed s \<and> ?abs s"
-              and Q'="\<lambda>s. work_units = ksWorkUnitsCompleted s \<and> valid_objs' s"
-              in stronger_corres_guard_imp[rotated])
-    apply (clarsimp simp: state_relation_def)
-   apply simp
-  apply (rule_tac Q="\<lambda>rv s. \<exists>rv'' t. rv = (rv'', s) \<and> rv'' = (workUnitsLimit \<le> work_units) \<and> ?abs s"
-               in corres_symb_exec_l[rotated])
-     apply (clarsimp simp: select_f_def mk_ef_def bind_def gets_def exs_valid_def get_def return_def
-                           wrap_ext_bool_det_ext_ext_def)
-    apply wpsimp
-    apply (clarsimp simp: select_f_def mk_ef_def bind_def gets_def get_def return_def
-                          work_units_limit_def wrap_ext_bool_det_ext_ext_def Kernel_Config.workUnitsLimit_def)
-   apply wpsimp
-  apply (clarsimp simp: select_f_def mk_ef_def bind_def gets_def exs_valid_def get_def return_def
-                        work_units_limit_def wrap_ext_bool_det_ext_ext_def Kernel_Config.workUnitsLimit_def)
-  apply (case_tac rv; clarsimp)
-  apply (rename_tac bool state)
-  apply (rule_tac F="bool = (workUnitsLimit \<le> work_units) \<and> ?abs state" in corres_req)
-   apply simp
-  apply (rule corres_guard_imp)
-    apply (rule corres_if3)
-      apply clarsimp
-     apply (rule_tac P="?abs" and P'="?conc" in corres_inst)
-     apply (rule corres_split_skip)
-        apply (wpsimp simp: reset_work_units_def)
-       apply (wpsimp simp: setWorkUnits_def)
-      apply (corresKsimp corres: setWorkUnits_corres)
-     apply (rule corres_split_skip)
-        apply wpsimp
-       apply wpsimp
-      apply (corresKsimp corres: updateTimeStamp_corres)
-     apply (rule corres_split_skip)
-        apply (wpsimp simp: cur_sc_tcb_def)
-       apply wpsimp
-      apply (corresKsimp corres: corres_machine_op)
-     apply (rule corres_underlying_split[rotated 2, OF gets_sp getCurSc_sp])
-      apply (corresKsimp corres: getCurSc_corres)
-     apply (rule corres_underlying_split[rotated 2, OF gets_sp getConsumedTime_sp])
-      apply (corresKsimp corres: getConsumedTime_corres)
-     apply (clarsimp simp: andM_def ifM_def bind_assoc)
-     apply (rule corres_underlying_split[rotated 2, OF get_sc_active_sp scActive_sp])
-      apply (corresKsimp corres: scActive_corres)
-      apply (fastforce dest: valid_objs_valid_sched_context_size
-                       simp: cur_sc_tcb_def obj_at_def is_sc_obj_def sc_at_pred_n_def)
-     apply (clarsimp split: if_split)
-     apply (intro conjI impI)
-      apply (rule corres_guard_imp)
-      apply (rule corres_split[OF refillSufficient_corres]; simp)
-          apply (rule corres_split[OF isCurDomainExpired_corres])
-            apply (clarsimp simp: returnOk_def
-                           split: if_split)
-           apply wpsimp
-          apply (wpsimp simp: isCurDomainExpired_def)+
-       apply (prop_tac "is_active_sc (cur_sc s) s")
-        apply (clarsimp simp: obj_at_def vs_all_heap_simps active_sc_def)
-       apply (frule (1) active_scs_validE)
-       apply (clarsimp simp: obj_at_def is_sc_obj_def sc_at_pred_n_def vs_all_heap_simps
-                             active_sc_def sc_valid_refills_def rr_valid_refills_def
-                      split: if_splits)
-      apply simp
-     apply corresKsimp
-    apply (fastforce intro: corres_returnOkTT)
-   apply (clarsimp split: if_split)
-  apply (clarsimp split: if_split)
-  done
+  by (auto simp: preemption_point_def preemptionPoint_def o_def gets_def liftE_def whenE_def getActiveIRQ_def
+                 corres_underlying_def select_def bind_def get_def bindE_def select_f_def modify_def
+                 alternative_def throwError_def returnOk_def return_def lift_def doMachineOp_def split_def
+                 put_def getWorkUnits_def setWorkUnits_def modifyWorkUnits_def do_machine_op_def
 
-lemma updateTimeStamp_inv:
-   "\<lbrakk>updateTimeStamp_independent P; time_state_independent_H P; getCurrentTime_independent_H P;
-     domain_time_independent_H P\<rbrakk>
-    \<Longrightarrow> updateTimeStamp \<lbrace>P\<rbrace>"
-  apply (simp add: updateTimeStamp_def doMachineOp_def getCurrentTime_def)
-  apply (rule bind_wp_fwd_skip, wpsimp)
-  apply (rule bind_wp_fwd_skip, wpsimp)
-   apply (fastforce simp: time_state_independent_H_def getCurrentTime_independent_H_def in_monad)
-  apply (rule bind_wp_fwd_skip, wpsimp simp: setCurTime_def)
-   apply (clarsimp simp: updateTimeStamp_independent_def)
-   apply (drule_tac x="\<lambda>_. curTime'" in spec)
-   apply (drule_tac x=id in spec)
-   apply fastforce
-  apply (wpsimp simp: setConsumedTime_def setDomainTime_def getDomainTime_def)
-  apply (clarsimp simp: updateTimeStamp_independent_def)
-  apply (drule_tac x=id in spec)
-  apply (fastforce simp: update_time_stamp_independent_A_def domain_time_independent_H_def)
-  done
+                 update_work_units_def wrap_ext_bool_det_ext_ext_def work_units_limit_def workUnitsLimit_def
+                 work_units_limit_reached_def OR_choiceE_def reset_work_units_def mk_ef_def
+           elim: state_relationE)
+  (* what? *)
+  (* who says our proofs are not automatic.. *)
 
 lemma preemptionPoint_inv:
   assumes "(\<And>f s. P (ksWorkUnitsCompleted_update f s) = P s)"
           "irq_state_independent_H P"
-          "updateTimeStamp_independent P"
-          "getCurrentTime_independent_H P"
-          "time_state_independent_H P"
-          "domain_time_independent_H P"
-  shows "preemptionPoint \<lbrace>P\<rbrace>"
-  using assms
-  apply (simp add: preemptionPoint_def setWorkUnits_def getWorkUnits_def modifyWorkUnits_def
-                   setConsumedTime_def setCurTime_def)
-  apply (rule validE_valid)
-  apply (rule bindE_wp_fwd_skip, solves wpsimp)+
-  apply (clarsimp simp: whenE_def)
-  apply (intro conjI impI; (solves wpsimp)?)
-  apply (rule bindE_wp_fwd_skip, solves wpsimp)+
-  apply (rename_tac preempt)
-  apply (case_tac preempt; clarsimp)
-   apply (rule bindE_wp_fwd_skip)
-    apply (wpsimp wp: updateTimeStamp_inv)
-  apply (rule bindE_wp_fwd_skip, solves wpsimp)+
-  apply (wpsimp wp: getRefills_wp hoare_drop_imps
-              simp: isCurDomainExpired_def getDomainTime_def refillSufficient_def)
+  shows "\<lbrace>P\<rbrace> preemptionPoint \<lbrace>\<lambda>_. P\<rbrace>" using assms
+  apply (simp add: preemptionPoint_def setWorkUnits_def getWorkUnits_def modifyWorkUnits_def)
+  apply (wpc
+          | wp whenE_wp bind_wp [OF _ select_inv] hoare_drop_imps
+          | simp)+
   done
 
-lemma ct_in_state_machine_state_independent[intro!, simp]:
-  "ct_in_state P (machine_state_update f s) = ct_in_state P s"
+lemma ct_running_irq_state_independent[intro!, simp]:
+  "ct_running (s \<lparr>machine_state := machine_state s \<lparr>irq_state := f (irq_state (machine_state s)) \<rparr> \<rparr>)
+   = ct_running s"
+  by (simp add: ct_in_state_def)
+
+lemma ct_idle_irq_state_independent[intro!, simp]:
+  "ct_idle (s \<lparr>machine_state := machine_state s \<lparr>irq_state := f (irq_state (machine_state s)) \<rparr> \<rparr>)
+   = ct_idle s"
   by (simp add: ct_in_state_def)
 
 lemma typ_at'_irq_state_independent[simp, intro!]:
@@ -380,39 +139,28 @@ lemma sch_act_simple_irq_state_independent[intro!, simp]:
    sch_act_simple s"
   by (simp add: sch_act_simple_def)
 
-method invs'_independent_method
-  = (clarsimp simp: irq_state_independent_H_def invs'_def
-                    valid_pspace'_def valid_replies'_def sch_act_wf_def
-                    valid_queues_def sym_refs_def state_refs_of'_def
-                    if_live_then_nonz_cap'_def if_unsafe_then_cap'_def
-                    valid_global_refs'_def
-                    valid_arch_state'_def valid_irq_node'_def
-                    valid_irq_handlers'_def valid_irq_states'_def
-                    irqs_masked'_def bitmapQ_defs valid_queues_no_bitmap_def
-                    valid_queues'_def valid_pde_mappings'_def
-                    pspace_domain_valid_def cur_tcb'_def
-                    valid_machine_state'_def tcb_in_cur_domain'_def ex_cte_cap_wp_to'_def
-                    valid_mdb'_def ct_in_state'_def
-                    valid_release_queue_def valid_release_queue'_def valid_dom_schedule'_def
-              cong: if_cong option.case_cong)
-
-lemma
-  shows invs'_irq_state_independent [simp, intro!]:
+lemma invs'_irq_state_independent [simp, intro!]:
   "invs' (s\<lparr>ksMachineState := ksMachineState s
-                 \<lparr>irq_state := f (irq_state (ksMachineState s))\<rparr>\<rparr>)
-   = invs' s"
-  and invs'_updateTimeStamp_independent [simp, intro!]:
-  "invs' (s\<lparr>ksCurTime := f' (ksCurTime s), ksConsumedTime := g (ksConsumedTime s)\<rparr>)
-   = invs' s"
-  and invs'_getCurrentTime_independent [simp, intro!]:
-  "invs' (s\<lparr>ksMachineState
-            := ksMachineState s \<lparr>last_machine_time
-                                 := f'' (last_machine_time (ksMachineState s)) (time_state (ksMachineState s))\<rparr>\<rparr>)
-   = invs' s"
-  and invs'_time_state_independent [simp, intro!]:
-  "invs' (s\<lparr>ksMachineState := ksMachineState s \<lparr>time_state := f''' (time_state (ksMachineState s))\<rparr>\<rparr>)
-   = invs' s"
-  by invs'_independent_method+
+                 \<lparr>irq_state := f (irq_state (ksMachineState s))\<rparr>\<rparr>) =
+   invs' s"
+  apply (clarsimp simp: irq_state_independent_H_def invs'_def valid_state'_def
+          valid_pspace'_def sch_act_wf_def
+          valid_queues_def sym_refs_def state_refs_of'_def
+          if_live_then_nonz_cap'_def if_unsafe_then_cap'_def
+          valid_idle'_def valid_global_refs'_def
+          valid_arch_state'_def valid_irq_node'_def
+          valid_irq_handlers'_def valid_irq_states'_def
+          irqs_masked'_def bitmapQ_defs valid_pde_mappings'_def
+          pspace_domain_valid_def cur_tcb'_def
+          valid_machine_state'_def tcb_in_cur_domain'_def
+          ct_not_inQ_def ct_idle_or_in_cur_domain'_def
+          cong: if_cong option.case_cong)
+  apply (rule iffI[rotated])
+   apply (clarsimp)
+   apply (case_tac "ksSchedulerAction s", simp_all)
+  apply clarsimp
+  apply (case_tac "ksSchedulerAction s", simp_all)
+  done
 
 lemma preemptionPoint_invs [wp]:
   "\<lbrace>invs'\<rbrace> preemptionPoint \<lbrace>\<lambda>_. invs'\<rbrace>"

--- a/proof/refine/ARM/InvariantUpdates_H.thy
+++ b/proof/refine/ARM/InvariantUpdates_H.thy
@@ -38,10 +38,29 @@ lemma invs'_machine:
 proof -
   show ?thesis
     apply (cases "ksSchedulerAction s")
-    apply (simp_all add: invs'_def cur_tcb'_def ct_in_state'_def
-                         ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def
-                         valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs
-                         vms ct_not_inQ_def valid_dom_schedule'_def
+    apply (simp_all add: invs'_def valid_state'_def cur_tcb'_def ct_in_state'_def
+                    ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def
+                    valid_bitmaps_def bitmapQ_defs
+                    vms ct_not_inQ_def
+                    state_refs_of'_def ps_clear_def
+                    valid_irq_node'_def mask
+              cong: option.case_cong)
+    done
+qed
+
+lemma invs_no_cicd'_machine:
+  assumes mask: "irq_masks (f (ksMachineState s)) =
+                 irq_masks (ksMachineState s)"
+  assumes vms: "valid_machine_state' (ksMachineState_update f s) =
+                valid_machine_state' s"
+  shows "invs_no_cicd' (ksMachineState_update f s) = invs_no_cicd' s"
+proof -
+  show ?thesis
+    apply (cases "ksSchedulerAction s")
+    apply (simp_all add: all_invs_but_ct_idle_or_in_cur_domain'_def valid_state'_def
+                         cur_tcb'_def ct_in_state'_def ct_idle_or_in_cur_domain'_def
+                         tcb_in_cur_domain'_def valid_bitmaps_def bitmapQ_defs
+                         vms ct_not_inQ_def
                          state_refs_of'_def ps_clear_def
                          valid_irq_node'_def mask
                    cong: option.case_cong)
@@ -76,6 +95,14 @@ lemma valid_tcb'_tcbQueued[simp]:
 lemma valid_tcb'_tcbFault_update[simp]:
   "valid_tcb' tcb s \<Longrightarrow> valid_tcb' (tcbFault_update f tcb) s"
   by (clarsimp simp: valid_tcb'_def  tcb_cte_cases_def cteSizeBits_def)
+
+lemma valid_tcb'_tcbTimeSlice_update[simp]:
+  "valid_tcb' (tcbTimeSlice_update f tcb) s = valid_tcb' tcb s"
+  by (simp add:valid_tcb'_def tcb_cte_cases_def cteSizeBits_def)
+
+lemma valid_bitmaps_ksSchedulerAction_update[simp]:
+   "valid_bitmaps (ksSchedulerAction_update f s) = valid_bitmaps s"
+   by (simp add: valid_bitmaps_def bitmapQ_defs)
 
 lemma ex_cte_cap_wp_to'_gsCNodes_update[simp]:
   "ex_cte_cap_wp_to' P p (gsCNodes_update f s') = ex_cte_cap_wp_to' P p s'"
@@ -130,10 +157,6 @@ lemma valid_bitmaps_ksWorkUnitsCompleted[simp]:
   "valid_bitmaps (ksWorkUnitsCompleted_update f s) = valid_bitmaps s"
   by (simp add: valid_bitmaps_def bitmapQ_defs)
 
-lemma valid_queues_ksReprogramTimer[simp]:
-  "valid_queues (ksReprogramTimer_update f s) = valid_queues s"
-  by (simp add: valid_queues_def valid_queues_no_bitmap_def bitmapQ_defs)
-
 lemma valid_irq_node'_ksCurDomain[simp]:
   "valid_irq_node' w (ksCurDomain_update f s) = valid_irq_node' w s"
   by (simp add: valid_irq_node'_def)
@@ -153,58 +176,6 @@ lemma valid_irq_node'_ksDomainTime[simp]:
 lemma valid_irq_node'_ksWorkUnitsCompleted[simp]:
   "valid_irq_node' w (ksWorkUnitsCompleted_update f s) = valid_irq_node' w s"
   by (simp add: valid_irq_node'_def)
-
-lemma valid_irq_node'_ksReprogramTimer[simp]:
-  "valid_irq_node' w (ksReprogramTimer_update f s) = valid_irq_node' w s"
-  by (simp add: valid_irq_node'_def)
-
-lemma valid_release_queue_ksWorkUnitsCompleted[simp]:
-  "valid_release_queue (ksWorkUnitsCompleted_update f s) = valid_release_queue s"
-  by (simp add: valid_release_queue_def)
-
-lemma valid_release_queue_ksReprogramTimer[simp]:
-  "valid_release_queue (ksReprogramTimer_update f s) = valid_release_queue s"
-  by (simp add: valid_release_queue_def)
-
-lemma valid_release_queue_ksDomainTime[simp]:
-  "valid_release_queue (ksDomainTime_update f s) = valid_release_queue s"
-  by (simp add: valid_release_queue_def)
-
-lemma valid_release_queue_ksCurDomain[simp]:
-  "valid_release_queue (ksCurDomain_update f s) = valid_release_queue s"
-  by (simp add: valid_release_queue_def)
-
-lemma valid_release_queue_ksDomScheduleIdx[simp]:
-  "valid_release_queue (ksDomScheduleIdx_update f s) = valid_release_queue s"
-  by (simp add: valid_release_queue_def)
-
-lemma valid_release_queue_ksSchedulerAction[simp]:
-  "valid_release_queue (ksSchedulerAction_update f s) = valid_release_queue s"
-  by (simp add: valid_release_queue_def)
-
-lemma valid_release_queue'_ksSchedulerAction[simp]:
-  "valid_release_queue' (ksSchedulerAction_update f s) = valid_release_queue' s"
-  by (simp add: valid_release_queue'_def)
-
-lemma valid_release_queue'_ksWorkUnitsCompleted[simp]:
-  "valid_release_queue' (ksWorkUnitsCompleted_update f s) = valid_release_queue' s"
-  by (simp add: valid_release_queue'_def)
-
-lemma valid_release_queue'_ksReprogramTimer[simp]:
-  "valid_release_queue' (ksReprogramTimer_update f s) = valid_release_queue' s"
-  by (simp add: valid_release_queue'_def)
-
-lemma valid_release_queue'_ksDomainTime[simp]:
-  "valid_release_queue' (ksDomainTime_update f s) = valid_release_queue' s"
-  by (simp add: valid_release_queue'_def)
-
-lemma valid_release_queue'_ksCurDomain[simp]:
-  "valid_release_queue' (ksCurDomain_update f s) = valid_release_queue' s"
-  by (simp add: valid_release_queue'_def)
-
-lemma valid_release_queue'_ksDomScheduleIdx[simp]:
-  "valid_release_queue' (ksDomScheduleIdx_update f s) = valid_release_queue' s"
-  by (simp add: valid_release_queue'_def)
 
 lemma ex_cte_cap_wp_to_work_units[simp]:
   "ex_cte_cap_wp_to' P slot (ksWorkUnitsCompleted_update f s)
@@ -287,22 +258,17 @@ lemma ct_in_state_ksSched[simp]:
   apply auto
   done
 
-lemma invs'_wu[simp]:
+lemma invs'_wu [simp]:
   "invs' (ksWorkUnitsCompleted_update f s) = invs' s"
-  apply (simp add: invs'_def cur_tcb'_def valid_queues_def
-                   valid_queues'_def valid_release_queue_def valid_release_queue'_def
-                   valid_irq_node'_def valid_machine_state'_def ct_not_inQ_def
-                   ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def bitmapQ_defs
-                   valid_queues_no_bitmap_def valid_dom_schedule'_def)
+  apply (simp add: invs'_def cur_tcb'_def valid_state'_def valid_bitmaps_def
+                   valid_irq_node'_def valid_machine_state'_def
+                   ct_not_inQ_def ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def
+                   bitmapQ_defs)
   done
 
 lemma valid_arch_state'_interrupt[simp]:
   "valid_arch_state' (ksInterruptState_update f s) = valid_arch_state' s"
   by (simp add: valid_arch_state'_def cong: option.case_cong)
-
-lemma valid_inQ_queues_ksSchedulerAction_update[simp]:
-  "valid_inQ_queues (ksSchedulerAction_update f s) = valid_inQ_queues s"
-  by (simp add: valid_inQ_queues_def)
 
 lemma valid_bitmapQ_ksSchedulerAction_upd[simp]:
   "valid_bitmapQ (ksSchedulerAction_update f s) = valid_bitmapQ s"
@@ -349,15 +315,8 @@ lemma sch_act_simple_ksReadyQueuesL2Bitmap[simp]:
 
 lemma ksDomainTime_invs[simp]:
   "invs' (ksDomainTime_update f s) = invs' s"
-  by (simp add: invs'_def cur_tcb'_def
-                valid_release_queue_def valid_release_queue'_def
-                valid_machine_state'_def ct_not_inQ_def
-                ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def valid_dom_schedule'_def)
-
-lemma ksSchedulerAction_invs'[simp]:
-  "invs' (ksSchedulerAction_update f s) = invs' s"
-  by (auto simp: invs'_def valid_release_queue_def valid_release_queue'_def
-                 valid_machine_state'_def  valid_irq_node'_def valid_dom_schedule'_def)
+  by (simp add: invs'_def valid_state'_def cur_tcb'_def ct_not_inQ_def ct_idle_or_in_cur_domain'_def
+                tcb_in_cur_domain'_def valid_machine_state'_def bitmapQ_defs)
 
 lemma valid_machine_state'_ksDomainTime[simp]:
   "valid_machine_state' (ksDomainTime_update f s) = valid_machine_state' s"
@@ -385,98 +344,7 @@ lemma ct_not_inQ_update_stt[simp]:
 
 lemma invs'_update_cnt[elim!]:
   "invs' s \<Longrightarrow> invs' (s\<lparr>ksSchedulerAction := ChooseNewThread\<rparr>)"
-  by (clarsimp simp: invs'_def cur_tcb'_def valid_dom_schedule'_def
-                     valid_release_queue_def valid_release_queue'_def
-                     valid_irq_node'_def valid_machine_state'_def ct_not_inQ_def
-                     ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def)
-
-lemma ksReprogramTimer_update_misc[simp]:
-  "\<And>f. valid_machine_state' (ksReprogramTimer_update f s) = valid_machine_state' s"
-  "\<And>f. ct_not_inQ (ksReprogramTimer_update f s) = ct_not_inQ s"
-  "\<And>f. ct_idle_or_in_cur_domain' (ksReprogramTimer_update f s) = ct_idle_or_in_cur_domain' s"
-  "\<And>f. cur_tcb' (ksReprogramTimer_update f s) = cur_tcb' s"
-  apply (clarsimp simp: valid_machine_state'_def ct_not_inQ_def ct_idle_or_in_cur_domain'_def
-                        tcb_in_cur_domain'_def cur_tcb'_def)+
-  done
-
-lemma valid_machine_state'_ksReleaseQueue[simp]:
-  "valid_machine_state' (ksReleaseQueue_update f s) = valid_machine_state' s"
-  unfolding valid_machine_state'_def
-  by simp
-
-lemma ct_idle_or_in_cur_domain'_ksReleaseQueue[simp]:
-  "ct_idle_or_in_cur_domain' (ksReleaseQueue_update f s) = ct_idle_or_in_cur_domain' s"
-  unfolding ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def
-  by simp
-
-lemma valid_inQ_queues_updates[simp]:
-  "\<And>f. valid_inQ_queues (ksReprogramTimer_update f s) = valid_inQ_queues s"
-  "\<And>f. valid_inQ_queues (ksReleaseQueue_update f s) = valid_inQ_queues s"
-  by (auto simp: valid_inQ_queues_def)
-
-lemma valid_tcb_state'_update[simp]:
-  "\<And>f. valid_tcb_state' ts (ksReadyQueues_update f s) = valid_tcb_state' ts s"
-  "\<And>f. valid_tcb_state' ts (ksReadyQueuesL1Bitmap_update f s) = valid_tcb_state' ts s"
-  "\<And>f. valid_tcb_state' ts (ksReadyQueuesL2Bitmap_update f s) = valid_tcb_state' ts s"
-  by (auto simp: valid_tcb_state'_def valid_bound_obj'_def split: thread_state.splits option.splits)
-
-lemma ct_not_inQ_ksReleaseQueue_upd[simp]:
-  "ct_not_inQ (ksReleaseQueue_update f s) = ct_not_inQ s"
-  by (simp add: ct_not_inQ_def)
-
-lemma valid_irq_node'_ksReleaseQueue_upd[simp]:
-  "valid_irq_node' (irq_node' s) (ksReleaseQueue_update f s) = valid_irq_node' (irq_node' s) s"
-  by (simp add: valid_irq_node'_def)
-
-lemma cur_tcb'_ksReleaseQueue_upd[simp]:
-  "cur_tcb' (ksReleaseQueue_update f s) = cur_tcb' s"
-  by (simp add: cur_tcb'_def)
-
-lemma valid_queues_ksReleaseQueue_upd[simp]:
-  "valid_queues (ksReleaseQueue_update f s) = valid_queues s"
-  by (simp add: valid_queues_def valid_queues_no_bitmap_def valid_bitmapQ_def
-                bitmapQ_def bitmapQ_no_L1_orphans_def bitmapQ_no_L2_orphans_def)
-
-lemma valid_queues'_ksReleaseQueue_upd[simp]:
-  "valid_queues' (ksReleaseQueue_update f s) = valid_queues' s"
-  by (simp add: valid_queues'_def)
-
-lemma sch_act_sane_ksReprogramTimer[simp]:
-  "sch_act_sane (ksReprogramTimer_update f s) = sch_act_sane s"
-  by (simp add: sch_act_sane_def)
-
-lemma valid_obj'_scPeriod_update[simp]:
-  "valid_obj' (KOSchedContext (scPeriod_update (\<lambda>_. period) sc')) = valid_obj' (KOSchedContext sc')"
-  by (fastforce simp: valid_obj'_def valid_sched_context'_def valid_sched_context_size'_def objBits_simps)
-
-lemma valid_sched_context_size'_scReply_update[simp]:
-  "valid_sched_context_size' (scReply_update f sc) = valid_sched_context_size' sc"
-  by (clarsimp simp: valid_sched_context_size'_def objBits_simps)
-
-lemma valid_sched_context'_scBadge_update[simp]:
-  "valid_sched_context' (scBadge_update f ko) s = valid_sched_context' ko s"
-  by (clarsimp simp: valid_sched_context'_def)
-
-lemma valid_sched_context_size'_scBadge_update[simp]:
-  "valid_sched_context_size' (scBadge_update f sc) = valid_sched_context_size' sc"
-  by (clarsimp simp: valid_sched_context_size'_def objBits_simps)
-
-lemma valid_sched_context'_scSporadic_update[simp]:
-  "valid_sched_context' (scSporadic_update f ko) s = valid_sched_context' ko s"
-  by (clarsimp simp: valid_sched_context'_def)
-
-lemma valid_sched_context_size'_scSporadic_update[simp]:
-  "valid_sched_context_size' (scSporadic_update f sc) = valid_sched_context_size' sc"
-  by (clarsimp simp: valid_sched_context_size'_def objBits_simps)
-
-lemma valid_tcb_yield_to_update[elim!]:
-  "valid_tcb tp tcb s \<Longrightarrow> sc_at scp s \<Longrightarrow> valid_tcb tp (tcb_yield_to_update (\<lambda>_. Some scp) tcb) s"
-  by (auto simp: valid_tcb_def tcb_cap_cases_def)
-
-lemma valid_ipc_buffer_ptr'_ks_updates[simp]:
-  "valid_ipc_buffer_ptr' buf (ksSchedulerAction_update f s) = valid_ipc_buffer_ptr' buf s"
-  "valid_ipc_buffer_ptr' buf (ksReprogramTimer_update g s) = valid_ipc_buffer_ptr' buf s"
-  "valid_ipc_buffer_ptr' buf (ksReleaseQueue_update h s) = valid_ipc_buffer_ptr' buf s"
-  by (simp add: valid_ipc_buffer_ptr'_def)+
+   by (clarsimp simp: invs'_def valid_state'_def valid_irq_node'_def cur_tcb'_def
+                      ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def bitmapQ_defs)
 
 end

--- a/proof/refine/ARM/IpcCancel_R.thy
+++ b/proof/refine/ARM/IpcCancel_R.thy
@@ -7,17 +7,16 @@
 theory IpcCancel_R
 imports
   Schedule_R
-  Reply_R
   "Lib.SimpStrategy"
 begin
 context begin interpretation Arch . (*FIXME: arch-split*)
 
 crunch cancelAllIPC
- for aligned'[wp]: pspace_aligned'
-  (wp: crunch_wps mapM_x_wp' simp: unless_def crunch_simps)
+  for aligned'[wp]: pspace_aligned'
+  (wp: crunch_wps mapM_x_wp' simp: unless_def)
 crunch cancelAllIPC
- for distinct'[wp]: pspace_distinct'
-  (wp: crunch_wps mapM_x_wp' simp: unless_def crunch_simps)
+  for distinct'[wp]: pspace_distinct'
+  (wp: crunch_wps mapM_x_wp' simp: unless_def)
 
 crunch cancelAllSignals
   for aligned'[wp]: pspace_aligned'
@@ -26,16 +25,11 @@ crunch cancelAllSignals
   for distinct'[wp]: pspace_distinct'
   (wp: crunch_wps mapM_x_wp')
 
-lemma cancelSignal_st_tcb_at'_cases:
-  "\<lbrace>\<lambda>s. (t = t' \<longrightarrow> Q (P Inactive)) \<and> (t \<noteq> t' \<longrightarrow> Q (st_tcb_at' P t s))\<rbrace>
-   cancelSignal t' n
-   \<lbrace>\<lambda>_ s. Q (st_tcb_at' P t s)\<rbrace>"
-  unfolding cancelSignal_def replyRemoveTCB_def cleanReply_def
-  by (wpsimp wp: sts_st_tcb_at'_cases_strong getNotification_wp hoare_vcg_imp_lift')
-
 lemma cancelSignal_simple[wp]:
   "\<lbrace>\<top>\<rbrace> cancelSignal t ntfn \<lbrace>\<lambda>rv. st_tcb_at' simple' t\<rbrace>"
-  by (wpsimp wp: cancelSignal_st_tcb_at'_cases)
+  apply (simp add: cancelSignal_def Let_def)
+  apply (wp setThreadState_st_tcb | simp)+
+  done
 
 lemma cancelSignal_pred_tcb_at':
   "\<lbrace>pred_tcb_at' proj P t' and K (t \<noteq> t')\<rbrace>
@@ -45,77 +39,81 @@ lemma cancelSignal_pred_tcb_at':
   apply (wp sts_pred_tcb_neq' getNotification_wp | wpc | clarsimp)+
   done
 
-lemma cancelSignal_tcb_at':
-  "cancelSignal tptr ntfnptr \<lbrace>\<lambda>s. P (tcb_at' tptr' s)\<rbrace>"
-  unfolding cancelSignal_def Let_def
-  apply (wpsimp wp: hoare_drop_imp)
+crunch emptySlot
+  for pred_tcb_at'[wp]: "pred_tcb_at' proj P t"
+  (wp: setCTE_pred_tcb_at')
+
+lemma set_ep_pred_tcb_at' [wp]:
+  "\<lbrace> pred_tcb_at' proj P t \<rbrace>
+   setEndpoint ep v
+   \<lbrace> \<lambda>rv. pred_tcb_at' proj P t \<rbrace>"
+  apply (simp add: setEndpoint_def pred_tcb_at'_def)
+  apply (rule obj_at_setObject2)
+   apply simp
+  apply (simp add: updateObject_default_def in_monad projectKOs)
   done
 
 defs capHasProperty_def:
   "capHasProperty ptr P \<equiv> cte_wp_at' (\<lambda>c. P (cteCap c)) ptr"
 end
-
-lemma blockedCancelIPC_st_tcb_at:
-  "\<lbrace>\<lambda>s. (t = t' \<longrightarrow> Q (P Inactive)) \<and> (t \<noteq> t' \<longrightarrow> Q (st_tcb_at' P t s))\<rbrace>
-   blockedCancelIPC st t' rptr
-   \<lbrace>\<lambda>_ s. Q (st_tcb_at' P t s)\<rbrace>"
-  unfolding blockedCancelIPC_def getBlockingObject_def
-  by (wpsimp wp: sts_st_tcb_at'_cases_strong replyUnlink_st_tcb_at' getEndpoint_wp hoare_vcg_imp_lift')
-
-lemma cancelIPC_st_tcb_at':
-  "\<lbrace>\<lambda>s. if t' = t \<and> st_tcb_at' (\<lambda>st. st \<notin> {Running, Restart, IdleThreadState}) t' s
-        then P (P' Inactive)
-        else P (st_tcb_at' P' t' s)\<rbrace>
-   cancelIPC t
-   \<lbrace>\<lambda>rv s. P (st_tcb_at' P' t' s)\<rbrace>"
-  apply (clarsimp simp: cancelIPC_def)
-  apply (rule bind_wp[OF _ stateAssert_sp])
-  apply (rule bind_wp[OF _ stateAssert_sp])
-  apply (rule bind_wp[OF _ gts_sp'])
-  apply (wpsimp wp: blockedCancelIPC_st_tcb_at replyRemoveTCB_st_tcb_at'_cases
-                    cancelSignal_st_tcb_at'_cases threadSet_pred_tcb_no_state)
-  apply (auto simp: pred_tcb_at'_def obj_at'_def)
-  done
-
-lemma cancelIPC_simple[wp]:
-  "\<lbrace>\<top>\<rbrace> cancelIPC t \<lbrace>\<lambda>rv. st_tcb_at' simple' t\<rbrace>"
-  unfolding cancelIPC_def blockedCancelIPC_def
-  apply (wpsimp wp: setThreadState_st_tcb gts_wp' threadSet_wp
-              simp: Let_def tcb_obj_at'_pred_tcb'_set_obj'_iff)
-  apply (clarsimp simp: st_tcb_at'_def o_def obj_at'_def isBlockedOnReply_def)
-  done
-
-lemma cancelIPC_st_tcb_at'_different_thread:
-  "\<lbrace>\<lambda>s. P (st_tcb_at' st t' s) \<and> t \<noteq> t'\<rbrace> cancelIPC t \<lbrace>\<lambda>rv s. P (st_tcb_at' st t' s)\<rbrace>"
-  by (wpsimp wp: cancelIPC_st_tcb_at')
-
 (* Assume various facts about cteDeleteOne, proved in Finalise_R *)
 locale delete_one_conc_pre =
   assumes delete_one_st_tcb_at:
     "\<And>P. (\<And>st. simple' st \<longrightarrow> P st) \<Longrightarrow>
      \<lbrace>st_tcb_at' P t\<rbrace> cteDeleteOne slot \<lbrace>\<lambda>rv. st_tcb_at' P t\<rbrace>"
-  assumes delete_one_typ_at[wp]:
+  assumes delete_one_typ_at:
     "\<And>P. \<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace> cteDeleteOne slot \<lbrace>\<lambda>rv s. P (typ_at' T p s)\<rbrace>"
-  assumes delete_one_sc_at'_n[wp]:
-    "\<And>P. cteDeleteOne slot \<lbrace>\<lambda>s. P (sc_at'_n n p s)\<rbrace>"
   assumes delete_one_aligned:
     "\<lbrace>pspace_aligned'\<rbrace> cteDeleteOne slot \<lbrace>\<lambda>rv. pspace_aligned'\<rbrace>"
   assumes delete_one_distinct:
     "\<lbrace>pspace_distinct'\<rbrace> cteDeleteOne slot \<lbrace>\<lambda>rv. pspace_distinct'\<rbrace>"
   assumes delete_one_it:
     "\<And>P. \<lbrace>\<lambda>s. P (ksIdleThread s)\<rbrace> cteDeleteOne cap \<lbrace>\<lambda>rv s. P (ksIdleThread s)\<rbrace>"
+  assumes delete_one_sch_act_simple:
+    "\<lbrace>sch_act_simple\<rbrace> cteDeleteOne sl \<lbrace>\<lambda>rv. sch_act_simple\<rbrace>"
+  assumes delete_one_sch_act_not:
+    "\<And>t. \<lbrace>sch_act_not t\<rbrace> cteDeleteOne sl \<lbrace>\<lambda>rv. sch_act_not t\<rbrace>"
+  assumes delete_one_reply_st_tcb_at:
+    "\<And>P t. \<lbrace>\<lambda>s. st_tcb_at' P t s \<and> (\<exists>t' r. cte_wp_at' (\<lambda>cte. cteCap cte = ReplyCap t' False r) slot s)\<rbrace>
+      cteDeleteOne slot
+     \<lbrace>\<lambda>rv. st_tcb_at' P t\<rbrace>"
   assumes delete_one_ksCurDomain:
     "\<And>P. \<lbrace>\<lambda>s. P (ksCurDomain s)\<rbrace> cteDeleteOne sl \<lbrace>\<lambda>_ s. P (ksCurDomain s)\<rbrace>"
   assumes delete_one_tcbDomain_obj_at':
     "\<And>P. \<lbrace>obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace> cteDeleteOne slot \<lbrace>\<lambda>_. obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>"
 
-lemma cancelSignal_st_tcb_at':
-  "\<lbrace>K (P Inactive)\<rbrace>
-   cancelSignal t ntfn
-   \<lbrace>\<lambda>_. st_tcb_at' P t\<rbrace>"
-  unfolding cancelSignal_def Let_def
-  apply (rule hoare_gen_asm_single)
-  apply (wpsimp wp: setThreadState_st_tcb_at'_cases)
+lemma (in delete_one_conc_pre) cancelIPC_simple[wp]:
+  "\<lbrace>\<top>\<rbrace> cancelIPC t \<lbrace>\<lambda>rv. st_tcb_at' simple' t\<rbrace>"
+  apply (simp add: cancelIPC_def Let_def getThreadReplySlot_def
+             cong: Structures_H.thread_state.case_cong list.case_cong)
+  apply (rule bind_wp [OF _ gts_sp'])
+  apply (rule hoare_pre)
+   apply (wpc
+           | wp sts_st_tcb_at'_cases hoare_vcg_conj_lift
+                hoare_vcg_const_imp_lift delete_one_st_tcb_at
+                threadSet_pred_tcb_no_state
+                hoare_strengthen_post [OF cancelSignal_simple]
+           | simp add: o_def if_fun_split
+           | rule hoare_drop_imps
+           | clarsimp elim!: pred_tcb'_weakenE)+
+  apply (auto simp: pred_tcb_at'
+             elim!: pred_tcb'_weakenE)
+  done
+
+lemma (in delete_one_conc_pre) cancelIPC_st_tcb_at':
+  "\<lbrace>st_tcb_at' P t' and K (t \<noteq> t')\<rbrace>
+     cancelIPC t
+   \<lbrace>\<lambda>rv. st_tcb_at' P t'\<rbrace>"
+  apply (simp add: cancelIPC_def Let_def getThreadReplySlot_def locateSlot_conv
+                   capHasProperty_def isCap_simps)
+  apply (wp sts_pred_tcb_neq' hoare_drop_imps delete_one_reply_st_tcb_at
+       | wpc | clarsimp)+
+          apply (wp getCTE_wp | clarsimp)+
+         apply (wp hoare_vcg_ex_lift threadSet_cte_wp_at' hoare_vcg_imp_lift
+                   cancelSignal_pred_tcb_at' sts_pred_tcb_neq' getEndpoint_wp gts_wp'
+                   threadSet_pred_tcb_no_state
+              | wpc | clarsimp)+
+  apply (auto simp: cte_wp_at_ctes_of isCap_simps)
   done
 
 context begin interpretation Arch .
@@ -123,296 +121,214 @@ crunch emptySlot
   for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
 end
 
-sublocale delete_one_conc_pre < delete_one: typ_at_all_props' "cteDeleteOne slot"
-  by typ_at_props'
+crunch cancelSignal
+  for tcb_at'[wp]: "tcb_at' t"
+  (wp: crunch_wps simp: crunch_simps)
+
+context delete_one_conc_pre
+begin
+
+lemmas delete_one_typ_ats[wp] = typ_at_lifts [OF delete_one_typ_at]
+
+lemma cancelIPC_tcb_at'[wp]:
+  "\<lbrace>tcb_at' t\<rbrace> cancelIPC t' \<lbrace>\<lambda>_. tcb_at' t\<rbrace>"
+  apply (simp add: cancelIPC_def Let_def getThreadReplySlot_def)
+  apply (wp delete_one_typ_ats hoare_drop_imps
+       | simp add: o_def if_apply_def2 | wpc | assumption)+
+  done
+
+end
 
 declare if_weak_cong [cong]
 declare delete_remove1 [simp]
 declare delete.simps [simp del]
 
-lemma sch_act_wf_weak_sch_act_wf[elim!]:
-  "sch_act_wf (ksSchedulerAction s) s \<Longrightarrow> weak_sch_act_wf (ksSchedulerAction s) s"
-  by (clarsimp simp: weak_sch_act_wf_def)
-
-lemma replyTCB_update_corres:
-  "corres dc (reply_at rp) (reply_at' rp)
-            (set_reply_obj_ref reply_tcb_update rp new)
-            (updateReply rp (replyTCB_update (\<lambda>_. new)))"
-  apply (simp add: update_sk_obj_ref_def updateReply_def)
-  apply (rule corres_guard_imp)
-    apply (rule corres_split[OF get_reply_corres])
-      apply (rule set_reply_corres)
-      apply (simp add: reply_relation_def)
-  by (wpsimp simp: obj_at'_def replyPrev_same_def)+
-
-lemma replyUnlinkTcb_corres:
-  "corres dc
-     (valid_tcbs and pspace_aligned and pspace_distinct
-       and st_tcb_at (\<lambda>st. \<exists>ep pl. st = Structures_A.BlockedOnReceive ep (Some rp) pl
-                           \<or> st = Structures_A.BlockedOnReply rp) t
-       and reply_tcb_reply_at ((=) (Some t)) rp)
-        (valid_tcbs' and valid_release_queue_iff)
-        (reply_unlink_tcb t rp) (replyUnlink rp t)" (is "corres _ _ ?conc_guard _ _")
-  apply (rule_tac Q="?conc_guard
-         and st_tcb_at' (\<lambda>st. (\<exists>ep pl. st = BlockedOnReceive ep (receiver_can_grant pl) (Some rp))
-                               \<or> st = BlockedOnReply (Some rp)) t"
-         in corres_cross_over_guard)
-   apply clarsimp
-   apply (drule (1) st_tcb_at_coerce_concrete; clarsimp simp: state_relation_def)
-   apply (fastforce simp: pred_tcb_at'_def obj_at'_def)
-  apply (simp add: reply_unlink_tcb_def replyUnlink_def liftM_def)
-  apply (rule corres_guard_imp)
-    apply (rule corres_split[OF get_reply_corres])
-      apply (rule corres_assert_gen_asm_l)
-      apply (rename_tac reply'; prop_tac "replyTCB reply' = Some t")
-       apply (clarsimp simp: reply_relation_def)
-      apply simp
-      apply (rule corres_split[OF getThreadState_corres])
-        apply (rule corres_assert_gen_asm_l)
-        apply (rule corres_stateAssert_implied[where P'=\<top>, simplified])
-         apply (rule corres_split[OF replyTCB_update_corres])
-           apply (rule setThreadState_corres)
-           apply (clarsimp simp: thread_state_relation_def)
-          apply wpsimp
-
-         apply (wpsimp simp: updateReply_def)
-        apply (fastforce simp: replyUnlink_assertion_def thread_state_relation_def)
-       apply (wpsimp wp: hoare_vcg_disj_lift gts_wp get_simple_ko_wp)+
-   apply (clarsimp simp: sk_obj_at_pred_def obj_at_def is_reply pred_tcb_at_def is_tcb)
-  apply (clarsimp simp: obj_at'_def st_tcb_at'_def projectKOs)
-  apply (prop_tac "reply_at' rp s")
-   apply (fastforce simp: valid_tcbs'_def valid_tcb'_def valid_tcb_state'_def)
-  apply (clarsimp simp: obj_at'_def projectKOs)
+lemma invs_weak_sch_act_wf[elim!]:
+  "invs' s \<Longrightarrow> weak_sch_act_wf (ksSchedulerAction s) s"
+  apply (drule invs_sch_act_wf')
+  apply (clarsimp simp: weak_sch_act_wf_def)
   done
 
-lemma setNotification_valid_tcb'[wp]:
-  "setNotification ntfn val \<lbrace>valid_tcb' tcb\<rbrace>"
-  apply (clarsimp simp: setNotification_def)
-  apply (rule setObject_valid_tcb')
-  done
-
-lemma setNotification_valid_tcbs'[wp]:
-  "setNotification ntfn val \<lbrace>valid_tcbs'\<rbrace>"
-  unfolding valid_tcbs'_def
-  by (wpsimp wp: set_ntfn'.setObject_wp hoare_vcg_all_lift hoare_vcg_imp_lift'
-           simp: setNotification_def)+
-
-lemma setEndpoint_valid_tcb'[wp]:
-  "setEndpoint epPtr val \<lbrace>valid_tcb' tcb\<rbrace>"
-  apply (clarsimp simp: setEndpoint_def)
-  apply (rule setObject_valid_tcb')
-  done
-
-lemma setEndpoint_valid_tcbs'[wp]:
-  "setEndpoint ePtr val \<lbrace>valid_tcbs'\<rbrace>"
-  unfolding valid_tcbs'_def
-  by (wpsimp wp: set_ep'.setObject_wp hoare_vcg_all_lift hoare_vcg_imp_lift'
-           simp: setEndpoint_def)+
-
-lemma replyUnlink_valid_tcbs'[wp]:
-  "replyUnlink replyPtr tcbPtr \<lbrace>valid_tcbs'\<rbrace>"
-  apply (clarsimp simp: replyUnlink_def getReply_def
-                        updateReply_def)
-  apply (wpsimp wp: set_reply'.getObject_wp set_reply'.getObject_wp gts_wp'
-              simp: valid_tcb_state'_def )
-  done
+crunch set_endpoint
+  for tcb_at[wp]: "tcb_at t"
+crunch setEndpoint
+  for tcb_at'[wp]: "tcb_at' t"
 
 lemma blocked_cancelIPC_corres:
-  "\<lbrakk> st = Structures_A.BlockedOnReceive epPtr reply_opt p' \<or>
-     st = Structures_A.BlockedOnSend epPtr p; thread_state_relation st st';
-     st = Structures_A.BlockedOnSend epPtr p \<longrightarrow> reply_opt = None \<rbrakk> \<Longrightarrow>
-   corres dc (valid_objs and pspace_aligned and pspace_distinct
-              and st_tcb_at ((=) st) t and (\<lambda>s. sym_refs (state_refs_of s)))
-             (valid_objs' and valid_release_queue_iff and st_tcb_at' ((=) st') t)
-           (blocked_cancel_ipc st t reply_opt)
-           (blockedCancelIPC st' t reply_opt)" (is "\<lbrakk> _ ; _ ; _ \<rbrakk> \<Longrightarrow> corres _ (?abs_guard and _) _ _ _")
-  apply add_sym_refs
-  apply (prop_tac "getBlockingObject st' = return epPtr")
-   apply (case_tac st; clarsimp simp: getBlockingObject_def epBlocked_def)
-  apply (simp add: blocked_cancel_ipc_def blockedCancelIPC_def gbep_ret)
+  "\<lbrakk> st = Structures_A.BlockedOnReceive epPtr p' \<or>
+     st = Structures_A.BlockedOnSend epPtr p; thread_state_relation st st' \<rbrakk> \<Longrightarrow>
+   corres dc (invs and st_tcb_at ((=) st) t) (invs' and st_tcb_at' ((=) st') t)
+           (blocked_cancel_ipc st t)
+           (do ep \<leftarrow> getEndpoint epPtr;
+               y \<leftarrow> assert (\<not> (case ep of IdleEP \<Rightarrow> True | _ \<Rightarrow> False));
+               ep' \<leftarrow>
+               if remove1 t (epQueue ep) = [] then return IdleEP
+               else
+                 return $ epQueue_update (%_. (remove1 t (epQueue ep))) ep;
+               y \<leftarrow> setEndpoint epPtr ep';
+               setThreadState Structures_H.thread_state.Inactive t
+            od)"
+  apply (simp add: blocked_cancel_ipc_def gbep_ret)
   apply (rule corres_guard_imp)
     apply (rule corres_split[OF getEndpoint_corres])
       apply (rule_tac F="ep \<noteq> IdleEP" in corres_gen_asm2)
       apply (rule corres_assert_assume[rotated])
        apply (clarsimp split: endpoint.splits)
-       \<comment>\<open>drop sym_refs assumtions; add reply_tcb link\<close>
-      apply (rule_tac P="?abs_guard and (\<lambda>s. bound reply_opt \<longrightarrow> reply_tcb_reply_at ((=) (Some t)) (the reply_opt) s)
-                         and valid_ep rv
-                         and (\<lambda>_. (st = Structures_A.BlockedOnSend epPtr p
-                                      \<longrightarrow> (\<exists>list. rv = Structures_A.SendEP list))
-                                \<and> (st = Structures_A.thread_state.BlockedOnReceive epPtr reply_opt p'
-                                     \<longrightarrow> (\<exists>list. rv = Structures_A.RecvEP list)))"
-                  and P'="valid_objs' and valid_release_queue_iff and st_tcb_at' ((=) st') t
-                          and valid_ep' ep"
-                   in corres_inst)
-      \<comment>\<open>cross over replyTCB\<close>
-      apply (rule_tac Q="\<lambda>s. bound reply_opt \<longrightarrow> obj_at' (\<lambda>r. replyTCB r = Some t) (the reply_opt) s" in corres_cross_add_guard)
-       apply clarsimp
-       apply (drule state_relationD)
-       apply (frule_tac s'=s' in pspace_aligned_cross, simp)
-       apply (frule_tac s'=s' in pspace_distinct_cross, simp, simp)
-       apply (clarsimp simp: obj_at_def sk_obj_at_pred_def)
-       apply (rename_tac rp list reply)
-       apply (drule_tac x=rp in pspace_relation_absD, simp)
-       apply (clarsimp simp: obj_relation_cuts_def2 obj_at'_def reply_relation_def projectKOs)
-       apply (rename_tac ko)
-       apply (case_tac ko; simp)
-       apply (rename_tac reply')
-       apply (frule_tac x=rp in pspace_alignedD', simp)
-       apply (frule_tac x=rp in pspace_distinctD', simp)
-       apply (drule_tac x=rp in pspace_boundedD'[OF _ pspace_relation_pspace_bounded'], simp)
-       apply (clarsimp simp: reply_relation_def)
-       \<comment>\<open>main corres proof\<close>
-      apply (rule corres_gen_asm)
-      apply (erule disjE; clarsimp simp: ep_relation_def get_ep_queue_def split del: if_split)
-       \<comment>\<open>BlockedOnReceive\<close>
+      apply (rule_tac P="invs and st_tcb_at ((=) st) t" and
+                      P'="invs' and st_tcb_at' ((=) st') t" in corres_inst)
+      apply (case_tac rv)
+        apply (simp add: ep_relation_def)
+       apply (simp add: get_ep_queue_def ep_relation_def split del: if_split)
        apply (rename_tac list)
-       apply (cases reply_opt;
-              simp split del: if_split add: bind_assoc cong: if_cong)
-         \<comment>\<open>reply_opt = None\<close>
+       apply (case_tac "remove1 t list")
+        apply simp
         apply (rule corres_guard_imp)
           apply (rule corres_split[OF setEndpoint_corres])
-             apply (simp add: ep_relation_def split: list.split)
+             apply (simp add: ep_relation_def)
             apply (rule setThreadState_corres)
             apply simp
-           apply wpsimp+
-         apply (frule (1) Receive_or_Send_ep_at[rotated], fastforce)
-         apply (intro conjI;
-                clarsimp simp: st_tcb_at_def obj_at_def is_ep is_tcb
-                       intro!: valid_ep_remove1_RecvEP)
-        apply clarsimp
-        apply (frule Receive_or_Send_ep_at'[rotated], simp)
-         apply (simp add: thread_state_relation_def)
-        apply (fastforce simp: valid_ep'_def)
-         \<comment>\<open>reply_opt bound\<close>
+           apply (simp add: valid_tcb_state_def pred_conj_def)
+           apply (wp weak_sch_act_wf_lift)+
+         apply (clarsimp simp: st_tcb_at_tcb_at)
+         apply (clarsimp simp: st_tcb_at_def obj_at_def)
+         apply (erule pspace_valid_objsE)
+          apply fastforce
+         apply (auto simp: valid_tcb_state_def valid_tcb_def
+                           valid_obj_def obj_at_def)[1]
+        apply (clarsimp simp: pred_tcb_at')
+        apply (clarsimp simp: pred_tcb_at'_def)
+        apply (drule obj_at_ko_at')
+        apply clarify
+        apply (drule ko_at_valid_objs')
+          apply fastforce
+         apply (simp add: projectKOs)
+        apply (auto simp add: valid_obj'_def valid_tcb'_def
+                              valid_tcb_state'_def)[1]
+       apply clarsimp
        apply (rule corres_guard_imp)
-         apply (rule_tac R="\<lambda>_. ep_at epPtr and reply_tcb_reply_at ((=) (Some t)) a  and ?abs_guard"
-                     and R'="\<lambda>_. ep_at' epPtr and obj_at' (\<lambda>r. replyTCB r = Some t) a
-                                 and valid_objs' and valid_release_queue_iff
-                                 and st_tcb_at' ((=) st') t"
-                      in corres_split[OF setEndpoint_corres])
-            apply (simp add: ep_relation_def split: list.split)
-           apply (rule corres_guard_imp)
-             apply (rule corres_split[OF replyUnlinkTcb_corres])
-               apply (rule setThreadState_corres, simp)
-              apply wpsimp
-             apply (wpsimp wp: replyUnlink_valid_objs')
-            apply (fastforce simp: pred_tcb_at_def obj_at_def is_tcb)
-           apply (fastforce simp: obj_at'_def pred_tcb_at'_def)
-          apply (wpsimp wp: set_simple_ko_wp)
-         apply (wpsimp wp: set_ep'.set_wp)
-        apply clarsimp
-        apply (frule (1) Reply_or_Receive_reply_at[rotated], fastforce)
-        apply (frule (1) Receive_or_Send_ep_at[rotated], fastforce)
+         apply (rule corres_split[OF setEndpoint_corres])
+            apply (simp add: ep_relation_def)
+           apply (rule setThreadState_corres)
+           apply simp
+          apply (wp)+
         apply (clarsimp simp: st_tcb_at_tcb_at)
-        apply (rule conjI, clarsimp simp: obj_at_def is_ep)
-        apply (rule conjI, clarsimp simp: sk_obj_at_pred_def obj_at_def)
-        apply (intro conjI)
-           apply (fastforce elim!: valid_objs_ep_update intro!: valid_ep_remove1_RecvEP)
-          apply (clarsimp elim!: pspace_aligned_obj_update dest!: invs_psp_aligned
-                           simp: a_type_def is_ep)
-         apply (clarsimp elim!: pspace_distinct_same_type dest!: invs_distinct
-                          simp: a_type_def is_ep obj_at_def)
-        apply (clarsimp simp: pred_tcb_at_def obj_at_def is_ep)
-       apply (clarsimp split del: if_split)
-       apply (frule (1) Receive_or_Send_ep_at'[rotated], blast)
-       apply (clarsimp split del: if_split)
-       apply (rule conjI, clarsimp simp: obj_at'_def projectKOs ps_clear_upd objBits_simps)
-       apply (rule conjI; clarsimp simp: pred_tcb_at'_def obj_at'_def projectKOs ps_clear_upd)
-       apply (intro conjI impI; clarsimp?)
-         apply (erule valid_objs'_ep_update)
-          apply (case_tac "remove1 t list"
-                 ; clarsimp simp: valid_ep'_def obj_at'_def projectKOs
-                 ; metis distinct.simps(2) distinct_remove1 list.set_intros(1) list.set_intros(2)
-                         set_remove1)
-         apply (clarsimp simp: obj_at'_def projectKOs)
-        apply ((clarsimp simp: obj_at'_def projectKOs valid_ep'_def)+)[2]
-        apply (erule valid_release_queue_ksPSpace_update)
-         apply ((clarsimp simp: ko_wp_at'_def objBitsKO_def koTypeOf_def)+)[2]
-       apply (erule valid_release_queue'_ksPSpace_update)
-        apply ((clarsimp simp: ko_wp_at'_def objBitsKO_def koTypeOf_def)+)[2]
-      \<comment>\<open>BlockedOnSend\<close>
+        apply (clarsimp simp: st_tcb_at_def obj_at_def)
+        apply (erule pspace_valid_objsE)
+         apply fastforce
+        apply (auto simp: valid_tcb_state_def valid_tcb_def
+                          valid_obj_def obj_at_def)[1]
+       apply (clarsimp simp: pred_tcb_at')
+       apply (clarsimp simp: pred_tcb_at'_def)
+       apply (drule obj_at_ko_at')
+       apply clarify
+       apply (drule ko_at_valid_objs')
+         apply fastforce
+        apply (simp add: projectKOs)
+       apply (auto simp add: valid_obj'_def valid_tcb'_def
+                             valid_tcb_state'_def)[1]
+      apply (simp add: get_ep_queue_def ep_relation_def split del: if_split)
       apply (rename_tac list)
+      apply (case_tac "remove1 t list")
+       apply simp
+       apply (rule corres_guard_imp)
+         apply (rule corres_split[OF setEndpoint_corres])
+            apply (simp add: ep_relation_def)
+           apply (rule setThreadState_corres)
+           apply simp
+          apply (simp add: valid_tcb_state_def pred_conj_def)
+          apply (wp weak_sch_act_wf_lift)+
+        apply (clarsimp simp: st_tcb_at_tcb_at)
+        apply (clarsimp simp: st_tcb_at_def obj_at_def)
+        apply (erule pspace_valid_objsE)
+         apply fastforce
+        apply (auto simp: valid_tcb_state_def valid_tcb_def
+                          valid_obj_def obj_at_def)[1]
+       apply (clarsimp simp: pred_tcb_at')
+       apply (clarsimp simp: pred_tcb_at'_def)
+       apply (drule obj_at_ko_at')
+       apply clarify
+       apply (drule ko_at_valid_objs')
+         apply fastforce
+        apply (simp add: projectKOs)
+       apply (auto simp add: valid_obj'_def valid_tcb'_def
+                             valid_tcb_state'_def)[1]
+      apply clarsimp
       apply (rule corres_guard_imp)
         apply (rule corres_split[OF setEndpoint_corres])
-           apply (simp add: ep_relation_def split: list.split)
+           apply (simp add: ep_relation_def)
           apply (rule setThreadState_corres)
           apply simp
-         apply (simp add: valid_tcb_state_def pred_conj_def)
-         apply wpsimp+
-       apply (frule (1) Receive_or_Send_ep_at[rotated], fastforce)
-       apply (intro conjI;
-              clarsimp simp: st_tcb_at_def obj_at_def is_ep is_tcb
-                     intro!: valid_ep_remove1_SendEP)
-      apply (clarsimp split del: if_split)
-      apply (frule (1) Receive_or_Send_ep_at'[rotated], blast)
-      apply (fastforce simp: valid_ep'_def)
-     apply (wpsimp wp: getEndpoint_wp hoare_vcg_conj_lift get_simple_ko_wp)+
-   apply (frule (2) Receive_or_Send_ep_at, clarsimp)
-   apply (rule conjI, clarsimp)
-    apply (drule (1) st_tcb_recv_reply_state_refs)
-    apply (clarsimp simp: sk_obj_at_pred_def obj_at_def)
-   apply (rule conjI)
-    apply (clarsimp simp: obj_at_def)
-    apply (erule (1) valid_objsE[where x=epPtr])
-    apply (clarsimp simp: valid_obj_def)
-   apply (erule disjE; clarsimp simp: obj_at_def pred_tcb_at_def)
-    apply (frule (2) sym_ref_BlockedOnReceive_RecvEP[OF _ _ sym], simp)
-   apply (frule (2) sym_ref_BlockedOnSend_SendEP[OF _ _ sym], simp)
+         apply (wp)+
+       apply (clarsimp simp: st_tcb_at_tcb_at)
+       apply (clarsimp simp: st_tcb_at_def obj_at_def)
+       apply (erule pspace_valid_objsE)
+        apply fastforce
+       apply (auto simp: valid_tcb_state_def valid_tcb_def
+                         valid_obj_def obj_at_def)[1]
+      apply (clarsimp simp: pred_tcb_at')
+      apply (clarsimp simp: pred_tcb_at'_def)
+      apply (drule obj_at_ko_at')
+      apply clarify
+      apply (drule ko_at_valid_objs')
+        apply fastforce
+       apply (simp add: projectKOs)
+      apply (auto simp add: valid_obj'_def valid_tcb'_def
+                            valid_tcb_state'_def)[1]
+     apply (wp getEndpoint_wp)+
+   apply (clarsimp simp: st_tcb_at_def obj_at_def)
+   apply (erule pspace_valid_objsE)
+    apply fastforce
+   apply (auto simp: valid_tcb_state_def valid_tcb_def
+                     valid_obj_def obj_at_def)[1]
   apply clarsimp
-  apply (rule context_conjI)
-   apply (erule (1) Receive_or_Send_ep_at'[rotated])
-   apply (fastforce simp: thread_state_relation_def)
-  apply (clarsimp simp: obj_at'_def projectKOs )
   apply (rule conjI)
-   apply (erule (1) valid_objsE', clarsimp simp: valid_obj'_def)
-  apply (erule disjE)
-   apply (fastforce dest!: sym_ref_BlockedOnReceive_RecvEP' simp: ko_wp_at'_def)
-  apply (fastforce dest!: sym_ref_BlockedOnSend_SendEP' simp: ko_wp_at'_def)
+   apply (clarsimp simp: pred_tcb_at'_def)
+   apply (drule obj_at_ko_at')
+   apply clarify
+   apply (drule ko_at_valid_objs')
+     apply fastforce
+    apply (simp add: projectKOs)
+   apply (auto simp add: valid_obj'_def valid_tcb'_def
+                         valid_tcb_state'_def)[1]
+  apply (fastforce simp: ko_wp_at'_def obj_at'_def projectKOs dest: sym_refs_st_tcb_atD')
   done
 
 lemma cancelSignal_corres:
   "corres dc
-          (invs and valid_ready_qs and st_tcb_at ((=) (Structures_A.BlockedOnNotification ntfn)) t)
+          (invs and st_tcb_at ((=) (Structures_A.BlockedOnNotification ntfn)) t)
           (invs' and st_tcb_at' ((=) (BlockedOnNotification ntfn)) t)
           (cancel_signal t ntfn)
           (cancelSignal t ntfn)"
-  apply add_sym_refs
-  apply add_ready_qs_runnable
   apply (simp add: cancel_signal_def cancelSignal_def Let_def)
-  apply (rule corres_stateAssert_add_assertion[rotated])
-   apply clarsimp
   apply (rule corres_guard_imp)
     apply (rule corres_split[OF getNotification_corres])
       apply (rule_tac F="isWaitingNtfn (ntfnObj ntfnaa)" in corres_gen_asm2)
-      apply (case_tac "ntfn_obj ntfna"; simp add: ntfn_relation_def isWaitingNtfn_def)
-      apply (case_tac "ntfna", case_tac "ntfnaa")
-      apply clarsimp
-      apply wpfix
-      apply (rename_tac list bound_tcb sc)
-      apply (rule_tac R="remove1 t list = []" in corres_cases')
-       apply (simp del: dc_simp)
+      apply (case_tac "ntfn_obj ntfna")
+        apply (simp add: ntfn_relation_def isWaitingNtfn_def)
+       apply (simp add: isWaitingNtfn_def ntfn_relation_def split del: if_split)
+       apply (rename_tac list)
+       apply (rule_tac R="remove1 t list = []" in corres_cases)
+        apply (simp del: dc_simp)
+        apply (rule corres_split[OF setNotification_corres])
+           apply (simp add: ntfn_relation_def)
+          apply (rule setThreadState_corres)
+          apply simp
+         apply (wp)+
+       apply (simp add: list_case_If del: dc_simp)
        apply (rule corres_split[OF setNotification_corres])
-          apply (simp add: ntfn_relation_def)
+          apply (clarsimp simp add: ntfn_relation_def neq_Nil_conv)
          apply (rule setThreadState_corres)
          apply simp
-        apply (wp abs_typ_at_lifts)+
-      apply (simp add: list_case_If del: dc_simp)
-      apply (rule corres_split[OF setNotification_corres])
-         apply (clarsimp simp add: ntfn_relation_def)
-        apply (rule setThreadState_corres)
-        apply simp
-       apply (wp abs_typ_at_lifts)+
-     apply (wp get_simple_ko_wp getNotification_wp)+
+        apply (wp)+
+      apply (simp add: isWaitingNtfn_def ntfn_relation_def)
+     apply (wp getNotification_wp)+
    apply (clarsimp simp: conj_comms st_tcb_at_tcb_at)
    apply (clarsimp simp: st_tcb_at_def obj_at_def)
-   apply (erule pspace_valid_objsE, fastforce)
+   apply (erule pspace_valid_objsE)
+    apply fastforce
    apply (clarsimp simp: valid_obj_def valid_tcb_def valid_tcb_state_def)
    apply (drule sym, simp add: obj_at_def)
-   apply clarsimp
-   apply (erule pspace_valid_objsE[where p=ntfn], fastforce)
-   apply (fastforce simp: valid_obj_def valid_ntfn_def
-                   split: option.splits Structures_A.ntfn.splits)
+   apply fastforce
   apply (clarsimp simp: conj_comms pred_tcb_at' cong: conj_cong)
   apply (rule conjI)
    apply (simp add: pred_tcb_at'_def)
@@ -423,10 +339,10 @@ lemma cancelSignal_corres:
     apply (simp add: projectKOs)
    apply (clarsimp simp: valid_obj'_def valid_tcb'_def valid_tcb_state'_def)
    apply (drule sym, simp)
-  apply (intro conjI impI allI; fastforce?)
+  apply (clarsimp simp: invs_weak_sch_act_wf)
   apply (drule sym_refs_st_tcb_atD', fastforce)
   apply (fastforce simp: isWaitingNtfn_def ko_wp_at'_def obj_at'_def projectKOs
-                         ntfn_bound_refs'_def get_refs_def
+                         ntfn_bound_refs'_def
                   split: Structures_H.notification.splits ntfn.splits option.splits)
   done
 
@@ -435,6 +351,127 @@ lemma cte_map_tcb_2:
   by (simp add: cte_map_def tcb_cnode_index_def to_bl_1)
 
 context begin interpretation Arch . (*FIXME: arch-split*)
+
+lemma cte_wp_at_master_reply_cap_to_ex_rights:
+  "cte_wp_at (is_master_reply_cap_to t) ptr
+   = (\<lambda>s. \<exists>rights. cte_wp_at ((=) (cap.ReplyCap t True rights)) ptr s)"
+  by (rule ext, rule iffI; clarsimp simp: cte_wp_at_def is_master_reply_cap_to_def)
+
+lemma cte_wp_at_reply_cap_to_ex_rights:
+  "cte_wp_at (is_reply_cap_to t) ptr
+   = (\<lambda>s. \<exists>rights. cte_wp_at ((=) (cap.ReplyCap t False rights)) ptr s)"
+  by (rule ext, rule iffI; clarsimp simp: cte_wp_at_def is_reply_cap_to_def)
+
+lemma reply_no_descendants_mdbNext_null:
+  assumes descs: "descendants_of (t, tcb_cnode_index 2) (cdt s) = {}"
+  and        sr: "(s, s') \<in> state_relation"
+  and      invs: "valid_reply_caps s" "valid_reply_masters s"
+                 "valid_objs s" "valid_mdb s" "valid_mdb' s'" "pspace_aligned' s'"
+                 "pspace_distinct' s'"
+  and       tcb: "st_tcb_at (Not \<circ> halted) t s"
+  and       cte: "ctes_of s' (t + 2*2^cte_level_bits) = Some cte"
+  shows          "mdbNext (cteMDBNode cte) = nullPointer"
+proof -
+  from invs st_tcb_at_reply_cap_valid[OF tcb]
+    have "cte_wp_at (is_master_reply_cap_to t) (t, tcb_cnode_index 2) s"
+    by (fastforce simp: cte_wp_at_caps_of_state is_cap_simps is_master_reply_cap_to_def)
+
+  hence "\<exists>r. cteCap cte = capability.ReplyCap t True r"
+    using invs sr
+    by (fastforce simp: cte_wp_at_master_reply_cap_to_ex_rights
+                        cte_wp_at_ctes_of cte cte_map_def tcb_cnode_index_def
+                  dest: pspace_relation_cte_wp_at state_relation_pspace_relation)
+
+  hence class_link:
+    "\<forall>cte'. ctes_of s' (mdbNext (cteMDBNode cte)) = Some cte' \<longrightarrow>
+            capClass (cteCap cte') = ReplyClass t"
+    using invs
+    apply (clarsimp simp: valid_mdb'_def valid_mdb_ctes_def)
+    apply (drule class_linksD[where m="ctes_of s'", OF cte])
+      apply (simp add: mdb_next_unfold cte)
+     apply assumption
+    apply simp
+    done
+
+  from invs tcb descs have "\<forall>ptr m g.
+      cte_wp_at ((=) (cap.ReplyCap t m g)) ptr s \<longrightarrow> ptr = (t, tcb_cnode_index 2)"
+    apply (intro allI impI)
+    apply (case_tac m)
+     apply (fastforce simp: invs_def valid_state_def valid_reply_masters_def
+                            cte_wp_at_master_reply_cap_to_ex_rights)
+    apply (fastforce simp: has_reply_cap_def cte_wp_at_reply_cap_to_ex_rights
+                     dest: reply_master_no_descendants_no_reply elim: st_tcb_at_tcb_at)
+    done
+  hence "\<forall>ptr m mdb r.
+      ctes_of s' ptr = Some (CTE (capability.ReplyCap t m r) mdb) \<longrightarrow> ptr = t + 2*2^cte_level_bits"
+    using sr invs
+    apply (intro allI impI)
+    apply (drule(2) pspace_relation_cte_wp_atI
+                    [OF state_relation_pspace_relation])
+    apply (elim exE, case_tac c, simp_all del: split_paired_All)
+    apply (elim allE, erule impE, fastforce)
+    apply (clarsimp simp: cte_map_def tcb_cnode_index_def)
+    done
+  hence class_unique:
+    "\<forall>ptr cte'. ctes_of s' ptr = Some cte' \<longrightarrow>
+                capClass (cteCap cte') = ReplyClass t \<longrightarrow>
+                ptr = t + 2*2^cte_level_bits"
+    apply (intro allI impI)
+    apply (case_tac cte', rename_tac cap node, case_tac cap, simp_all)
+    apply (rename_tac arch_capability)
+    apply (case_tac arch_capability, simp_all)
+    done
+
+  from invs have no_null: "ctes_of s' nullPointer = None"
+    by (clarsimp simp: no_0_def nullPointer_def valid_mdb'_def valid_mdb_ctes_def)
+
+  from invs cte have no_loop: "mdbNext (cteMDBNode cte) \<noteq> t + 2*2^cte_level_bits"
+    by (fastforce simp: mdb_next_rel_def mdb_next_def
+                       valid_mdb'_def
+                 dest: valid_mdb_no_loops no_loops_direct_simp)
+
+  from invs cte have
+    "mdbNext (cteMDBNode cte) \<noteq> nullPointer \<longrightarrow>
+     (\<exists>cte'. ctes_of s' (mdbNext (cteMDBNode cte)) = Some cte')"
+    by (fastforce simp: valid_mdb'_def valid_mdb_ctes_def nullPointer_def
+                 elim: valid_dlistEn)
+  hence
+    "mdbNext (cteMDBNode cte) \<noteq> nullPointer \<longrightarrow>
+     mdbNext (cteMDBNode cte) = t + 2*2^cte_level_bits"
+    using class_link class_unique
+    by clarsimp
+  thus ?thesis
+    by (simp add: no_loop)
+qed
+
+lemma reply_descendants_mdbNext_nonnull:
+  assumes descs: "descendants_of (t, tcb_cnode_index 2) (cdt s) \<noteq> {}"
+  and        sr: "(s, s') \<in> state_relation"
+  and       tcb: "st_tcb_at (Not \<circ> halted) t s"
+  and       cte: "ctes_of s' (t + 2*2^cte_level_bits) = Some cte"
+  shows          "mdbNext (cteMDBNode cte) \<noteq> nullPointer"
+proof -
+  from tcb have "cte_at (t, tcb_cnode_index 2) s"
+    by (simp add: st_tcb_at_tcb_at tcb_at_cte_at dom_tcb_cap_cases)
+  hence "descendants_of' (t + 2*2^cte_level_bits) (ctes_of s') \<noteq> {}"
+    using sr descs
+    by (fastforce simp: state_relation_def cdt_relation_def cte_map_def tcb_cnode_index_def)
+  thus ?thesis
+    using cte unfolding nullPointer_def
+    by (fastforce simp: descendants_of'_def dest: subtree_next_0)
+qed
+
+lemma reply_descendants_of_mdbNext:
+  "\<lbrakk> (s, s') \<in> state_relation; valid_reply_caps s; valid_reply_masters s;
+     valid_objs s; valid_mdb s; valid_mdb' s'; pspace_aligned' s';
+     pspace_distinct' s'; st_tcb_at (Not \<circ> halted) t s;
+     ctes_of s' (t + 2*2^cte_level_bits) = Some cte \<rbrakk> \<Longrightarrow>
+   (descendants_of (t, tcb_cnode_index 2) (cdt s) = {}) =
+       (mdbNext (cteMDBNode cte) = nullPointer)"
+  apply (case_tac "descendants_of (t, tcb_cnode_index 2) (cdt s) = {}")
+   apply (simp add: reply_no_descendants_mdbNext_null)
+  apply (simp add: reply_descendants_mdbNext_nonnull)
+  done
 
 lemma reply_mdbNext_is_descendantD:
   assumes sr: "(s, s') \<in> state_relation"
@@ -464,14 +501,12 @@ end
 
 locale delete_one_conc = delete_one_conc_pre +
   assumes delete_one_invs:
-    "\<And>p. \<lbrace>invs' and sch_act_simple\<rbrace> cteDeleteOne p \<lbrace>\<lambda>rv. invs'\<rbrace>"
+    "\<And>p. \<lbrace>invs'\<rbrace> cteDeleteOne p \<lbrace>\<lambda>rv. invs'\<rbrace>"
 
 locale delete_one = delete_one_conc + delete_one_abs +
   assumes delete_one_corres:
-    "corres dc
-          (einvs and simple_sched_action and cte_wp_at can_fast_finalise ptr
-           and current_time_bounded)
-          (invs' and cte_at' (cte_map ptr))
+    "corres dc (einvs and cte_wp_at can_fast_finalise ptr)
+               (invs' and cte_at' (cte_map ptr))
           (cap_delete_one ptr) (cteDeleteOne (cte_map ptr))"
 
 lemma (in delete_one) cancelIPC_ReplyCap_corres:
@@ -505,765 +540,93 @@ lemma (in delete_one) cancelIPC_ReplyCap_corres:
        apply (simp add: exst_same_def)
       apply (fastforce simp: st_tcb_at_tcb_at)
      apply clarsimp
-     apply (fastforce simp: opt_map_red dest!: sc_at'_cross[OF state_relation_pspace_relation])
-    apply (clarsimp simp: opt_map_red obj_at_simps)+
-  apply (rule corres_symb_exec_r)
-     apply (rule_tac P'="ko_at' sc' ptr and ko_at' reply' rp
-                         and pspace_aligned' and pspace_distinct' and  K (scReply sc' = Some rp)" in corres_inst)
-     apply (rule corres_gen_asm2')
-     apply (rule_tac Q="sc_obj_at (objBits sc' - minSchedContextBits) ptr" in corres_cross_add_abs_guard)
-      apply (fastforce dest!: state_relationD ko_at_sc_cross)
+    defer
+    apply (wp thread_set_invs_trivial thread_set_no_change_tcb_state
+              threadSet_invs_trivial threadSet_pred_tcb_no_state thread_set_not_state_valid_sched
+         | fastforce simp: tcb_cap_cases_def inQ_def
+         | wp (once) sch_act_simple_lift)+
+  apply (rule corres_underlying_split)
      apply (rule corres_guard_imp)
-       apply (rule_tac P="(\<lambda>s. (sc_replies_of s |> hd_opt) ptr = Some rp)
-                          and sc_obj_at (objBits sc' - minSchedContextBits) ptr"
-                  and n1="objBits sc' - minSchedContextBits"
-                            in monadic_rewrite_corres_l[OF update_sched_context_rewrite])
-       apply (rule corres_symb_exec_l)
-          apply (rule corres_guard_imp)
-            apply (rule_tac P="(\<lambda>s. kheap s ptr =
-                                       Some (kernel_object.SchedContext sc (objBits sc' - minSchedContextBits)))
-                               and K (rp = hd (sc_replies sc))"
-                        and P'="ko_at' sc' ptr and ko_at' reply' rp
-                               and pspace_distinct' and pspace_aligned'"  in corres_inst)
-            apply (rule corres_gen_asm')
-            apply (rule stronger_corres_guard_imp)
-              apply (rule_tac sc=sc and sc'=sc' in setSchedContext_update_corres; simp?)
-               apply (clarsimp simp: sc_relation_def objBits_simps)+
-            apply (clarsimp simp: obj_at'_def projectKOs)
-            apply (prop_tac "heap_ls (replyPrevs_of s') (Some rp) (sc_replies sc)")
-             apply (drule state_relation_sc_replies_relation)
-             apply (drule (2) sc_replies_relation_prevs_list, simp)
-            apply (case_tac "sc_replies sc"; clarsimp simp: opt_map_red)
-           apply simp
-          apply simp
-         apply (wpsimp wp: get_sched_context_exs_valid simp: is_sc_obj_def obj_at_def)
-          apply (rename_tac ko xs; case_tac ko; clarsimp)
-         apply simp
-        apply (wpsimp simp: obj_at_def is_sc_obj_def vs_heap_simps opt_pred_def)
-       apply (wpsimp wp: get_sched_context_no_fail simp: obj_at_def is_sc_obj)
-      apply (clarsimp simp: obj_at_def is_sc_obj_def)
-     apply simp
-    apply (wpsimp simp: projectKOs obj_at'_def)+
+       apply (rule get_cap_corres [where cslot_ptr="(t, tcb_cnode_index 2)",
+                                          simplified cte_map_tcb_2 cte_index_repair_sym])
+      apply (clarsimp dest!: st_tcb_at_tcb_at
+                             tcb_at_cte_at [where ref="tcb_cnode_index 2"])
+     apply (clarsimp simp: invs'_def valid_state'_def valid_pspace'_def)
+    defer
+    apply (rule hoare_vcg_conj_lift [OF get_cap_inv get_cap_cte_wp_at, simplified])
+   apply (rule hoare_vcg_conj_lift [OF getCTE_inv getCTE_cte_wp_at, simplified])
+  apply (rename_tac cte)
+  apply (rule corres_symb_exec_l [OF _ _ gets_sp])
+    apply (rule_tac F="\<exists>r. cap = cap.ReplyCap t True r \<and>
+                       cteCap cte = capability.ReplyCap t True (AllowGrant \<in> r)" in corres_req)
+     apply (fastforce simp: cte_wp_at_caps_of_state is_cap_simps
+                     dest!: st_tcb_at_reply_cap_valid)
+    apply (rule_tac F="(descs = {}) = (mdbNext (cteMDBNode cte) = nullPointer)"
+                 in corres_req)
+     apply (fastforce simp: st_tcb_at_tcb_at cte_wp_at_ctes_of st_tcb_def2 cte_index_repair
+                     dest: reply_descendants_of_mdbNext)
+    apply (elim exE)
+    apply (case_tac "descs = {}", simp add: when_def)
+    apply (rule_tac F="\<exists>sl. descs = {sl}" in corres_req)
+     apply (fastforce intro: st_tcb_at_tcb_at dest: reply_master_one_descendant)
+    apply (erule exE, frule singleton_eqD)
+    apply (rule_tac F="mdbNext (cteMDBNode cte) = cte_map sl" in corres_req)
+     apply (clarsimp dest!: st_tcb_at_tcb_at)
+     apply (fastforce simp: cte_wp_at_ctes_of cte_level_bits_def
+                    elim!: reply_mdbNext_is_descendantD)
+    apply (simp add: when_def getSlotCap_def capHasProperty_def
+                del: split_paired_Ex)
+    apply (rule corres_guard_imp)
+      apply (rule_tac P'="\<lambda>s. \<exists>r'. cte_wp_at ((=) (cap.ReplyCap t False r')) sl s"
+                   in corres_stateAssert_implied [OF delete_one_corres])
+      apply (fastforce dest: pspace_relation_cte_wp_at
+                            state_relation_pspace_relation
+                      simp: cte_wp_at_ctes_of isCap_simps)
+     apply (fastforce simp: invs_def valid_state_def valid_mdb_def reply_mdb_def
+                           reply_masters_mdb_def cte_wp_at_caps_of_state
+                           can_fast_finalise_def)
+    apply (fastforce simp: valid_mdb'_def valid_mdb_ctes_def
+                          cte_wp_at_ctes_of nullPointer_def
+                    elim: valid_dlistEn dest: invs_mdb')
+   apply (simp add: exs_valid_def gets_def get_def return_def bind_def
+               del: split_paired_Ex split_paired_All)
+  apply (wp)
   done
+qed
 
-lemma sched_context_donate_weak_valid_sched_action[wp]:
-  "\<lbrace>weak_valid_sched_action and bound_sc_tcb_at ((=) None) tcb_ptr\<rbrace>
-   sched_context_donate sc_ptr tcb_ptr
-   \<lbrace>\<lambda>_. weak_valid_sched_action\<rbrace>"
-  apply (wpsimp wp: set_tcb_obj_ref_wp update_sched_context_wp test_reschedule_wp
-                    tcb_sched_action_wp get_sc_obj_ref_wp
-              simp: sched_context_donate_def tcb_release_remove_def)
-  apply (frule weak_valid_sched_action_no_sc_sched_act_not)
-   apply (fastforce simp: vs_all_heap_simps tcb_at_kh_simps)
-  by (auto simp: obj_at_kh_kheap_simps vs_all_heap_simps fun_upd_def pred_map_simps tcb_sched_dequeue_def scheduler_act_not_def
-                 valid_sched_action_def weak_valid_sched_action_def opt_map_simps map_join_simps
-           cong: conj_cong)
-
-crunch sched_context_donate
-  for sc_at[wp]: "sc_at scp"
-  (simp: crunch_simps wp: crunch_wps)
-
-crunch rescheduleRequired, setQueue, tcbSchedEnqueue, tcbReleaseRemove, updateReply
-  for scReplies_of[wp]: "\<lambda>s. P' (scReplies_of s)"
-  (simp: crunch_simps wp: crunch_wps)
-
-crunch updateReply, setSchedContext, updateSchedContext
-  for tcbSCs_of[wp]: "\<lambda>s. P' (tcbSCs_of s)"
-  and list_refs_of_replies'[wp]: "\<lambda>s. P (list_refs_of_replies' s)"
-  (simp: crunch_simps opt_map_Some_eta_fold wp: crunch_wps)
-
-lemma scReplies_of_scTCB_update[simp]:
-  "\<lbrakk> ko_at' sc scp s\<rbrakk>
-   \<Longrightarrow> P (\<lambda>a. if a = scp then scReply (scTCB_update (\<lambda>_. Some tp) sc) else scReplies_of s a)
-       \<longleftrightarrow> P (scReplies_of s)"
-  by (fastforce simp: obj_at'_def projectKOs opt_map_red elim!: rsubst[where P=P])
-
-crunch schedContextDonate
-  for replies_of': "\<lambda>s. P (replies_of' s)" (* this interfers with list_refs_of_replies' *)
-  and scReplies_of[wp]: "\<lambda>s. P' (scReplies_of s)"
-  (simp: crunch_simps wp: crunch_wps)
-
-lemma updateReply_replyNext_update_None:
-  "\<lbrace> \<top> \<rbrace>
-   updateReply rp (replyNext_update Map.empty)
-   \<lbrace>\<lambda>rv s. (replies_of' s |> replyNext) rp = None \<rbrace>"
-  by (wpsimp wp: updateReply_wp_all)
-
-lemma update_sched_context_sc_replies_update_tl:
-  "\<lbrace>\<lambda>s. \<exists>x. (kheap s |> sc_of ||> sc_replies) scp = Some (x#list)\<rbrace>
-   update_sched_context scp (sc_replies_update tl)
-   \<lbrace>\<lambda>_. sc_replies_sc_at ((=) list) scp\<rbrace>"
-  apply (wpsimp wp: update_sched_context_wp)
-  apply (clarsimp simp: obj_at_def sc_replies_sc_at_def opt_map_red)
-  done
-
-lemma setSchedContext_local_sym_refs:
-  "\<lbrace>\<lambda>s. ko_at' r' rp s \<and> ko_at' sc scp s \<and> replyPrev r' \<noteq> Some rp
-        \<and> (\<forall>p'. p' \<noteq> scp \<longrightarrow> scReplies_of s p' \<noteq> Some rp)\<rbrace>
-   setSchedContext scp (scReply_update (\<lambda>_. replyPrev r') sc)
-   \<lbrace>\<lambda>rv s. \<forall>p'. scReplies_of s p' \<noteq> Some rp\<rbrace>"
-  apply (wpsimp wp: setObject_sc_wp simp: setSchedContext_def)
-  apply (clarsimp simp: obj_at'_def projectKOs opt_map_red elim!: opt_mapE split: if_split_asm)
-  apply (drule_tac x=p' in spec)
-  apply (clarsimp simp: opt_map_red)
-  done
-
-lemma replyPop_corres:
-  "\<lbrakk>st = Structures_A.thread_state.BlockedOnReply rp;
-    st' = Structures_H.thread_state.BlockedOnReply (Some rp)\<rbrakk> \<Longrightarrow>
-   corres dc
-     (valid_objs and pspace_aligned and pspace_distinct
-      and st_tcb_at ((=) st) t and weak_valid_sched_action
-      and sc_at scp and reply_at rp and active_scs_valid
-      and valid_replies and (\<lambda>s. sym_refs (state_refs_of s))
-      and bound_sc_tcb_at ((=) tcbsc) t
-      and reply_tcb_reply_at ((=) (Some t)) rp
-      and (\<lambda>s. sc_with_reply rp s = Some scp)
-      and (\<lambda>s. (sc_replies_of s |> hd_opt) scp = Some rp))
-     (valid_objs' and valid_release_queue_iff and valid_queues and valid_queues'
-      and reply_at' rp and sc_at' scp
-      and (\<lambda>s'. sym_refs (list_refs_of_replies' s')))
-     (do x <- reply_unlink_sc scp rp;
-         y <- when (tcbsc = None) (sched_context_donate scp t);
-         reply_unlink_tcb t rp
-      od)
-     (replyPop rp t)"
-  (is "\<lbrakk> _ ; _ \<rbrakk> \<Longrightarrow> corres _ (?abs_guard and valid_replies and (\<lambda>s. sym_refs (state_refs_of s))
-                              and bound_sc_tcb_at ((=) tcbsc) t and reply_tcb_reply_at ((=) (Some t)) rp
-                              and (\<lambda>s. sc_with_reply rp s = _) and ?sc_replies)
-                             (?conc_guard and (\<lambda>s'. sym_refs (list_refs_of_replies' s'))) _ _")
-  supply if_split[split del] opt_mapE[elim!]
-  apply add_sym_refs
-  apply (rule_tac Q="st_tcb_at' ((=) st') t" in corres_cross_add_guard)
-   apply (fastforce dest!: st_tcb_at_coerce_concrete elim!: pred_tcb'_weakenE)
-  apply (rule_tac Q="\<lambda>s. tcbSCs_of s t = tcbsc" in corres_cross_add_guard)
-   apply (fastforce dest!: bound_sc_tcb_at_cross elim!: obj_at'_weakenE)
-  apply (rule_tac Q="pspace_distinct'" in corres_cross_add_guard)
-   apply (fastforce dest!: pspace_distinct_cross)
-  apply (rule_tac Q="pspace_aligned'" in corres_cross_add_guard)
-   apply (fastforce dest!: pspace_aligned_cross)
-  apply (rule_tac Q="pspace_bounded'" in corres_cross_add_guard)
-   apply (fastforce dest!: pspace_relation_pspace_bounded'[OF state_relation_pspace_relation])
-  apply (rule_tac Q="\<lambda>s. scReplies_of s scp = Some rp" in corres_cross_add_guard)
-   apply (fastforce simp: opt_map_red obj_at'_def projectKOs
-                   dest!: sc_replies_relation_scReplies_of state_relation_sc_replies_relation)
-  apply (simp add: reply_unlink_sc_def replyPop_def bind_assoc liftM_def)
-  apply (rule_tac Q="\<lambda>sc. ?abs_guard and reply_tcb_reply_at ((=) (Some t)) rp
-                          and (\<lambda>s. \<exists>n. ko_at (Structures_A.SchedContext sc n) scp s)
-                          and bound_sc_tcb_at ((=) tcbsc) t
-                          and K (\<exists>ls. sc_replies sc = rp#ls \<and> distinct (rp#ls))"
-         in corres_symb_exec_l)
-     apply (rename_tac sc)
-     apply (rule corres_gen_asm') (* sc_replies sc = rp # ls, distinct (rp#ls) *)
-     apply (rule corres_stateAssert_add_assertion[rotated])
-      apply (clarsimp simp: sym_refs_asrt_def)
-     apply (rule corres_guard_imp)
-       apply (rule corres_split[OF get_reply_corres])
-         apply (rename_tac r r')
-         apply (rule_tac P="?abs_guard and reply_tcb_reply_at ((=) (Some t)) rp
-                            and ko_at (Structures_A.Reply r) rp and bound_sc_tcb_at ((=) tcbsc) t
-                            and (\<lambda>s. \<exists>n. ko_at (Structures_A.SchedContext sc n) scp s)"
-                     and P'="?conc_guard and (\<lambda>s'. sym_refs (list_refs_of_replies' s'))
-                            and pspace_aligned' and pspace_distinct' and pspace_bounded' and (\<lambda>s. sym_refs (state_refs_of' s))
-                            and st_tcb_at' ((=) st') t and (\<lambda>s. tcbSCs_of s t = tcbsc) and ko_at' r' rp
-                            and (\<lambda>s. scReplies_of s scp = Some rp)
-                            and K (replyTCB r' = Some t) and K (replyNext r' = Some (Head scp))"
-                in corres_inst)
-         apply (rule corres_gen_asm2') (* replyNext r' = Some (Head scp) *)
-         apply (rule corres_gen_asm2') (* replyTCB r' = Some t *)
-         apply (erule exE, rename_tac list)
-         apply (rule_tac F="case list of [] \<Rightarrow> replyPrev r' = None | a#_ \<Rightarrow> replyPrev r' = Some a"
-                in corres_req)
-          apply (clarsimp simp: obj_at_simps)
-          apply (drule (1) sc_replies_relation_prevs_list'[OF state_relation_sc_replies_relation])
-          apply (clarsimp simp: opt_map_red del: opt_mapE)
-          apply (case_tac list; simp)
-         apply (simp add: bind_assoc)
-         apply (rule corres_symb_exec_l) (* assert reply_sc r = Some scp *)
-            apply (rule corres_symb_exec_r) (* get threadState for t *)
-               apply (rename_tac state)
-               apply (rule_tac P="?abs_guard and reply_tcb_reply_at ((=) (Some t)) rp
-                                  and ko_at (Structures_A.Reply r) rp
-                                  and bound_sc_tcb_at ((=) tcbsc) t
-                                  and (\<lambda>s. \<exists>n. ko_at (Structures_A.SchedContext sc n) scp s)"
-                           and P'="?conc_guard and (\<lambda>s'. sym_refs (list_refs_of_replies' s'))
-                                  and pspace_aligned' and pspace_distinct' and pspace_bounded'
-                                  and (\<lambda>s. sym_refs (state_refs_of' s)) and st_tcb_at' ((=) st') t
-                                  and (\<lambda>s. tcbSCs_of s t = tcbsc)
-                                  and (\<lambda>s. scReplies_of s scp = Some rp)
-                                  and ko_at' r' rp and sc_at' scp and K (state = st')"
-                      in corres_inst)
-               apply (rule corres_gen_asm2')
-               apply (simp add: bind_assoc isReply_def isHead_def)
-               apply (subst bind_assoc[symmetric, where m="getSchedContext _"])
-               apply (rule corres_guard_imp)
-                 apply (rule corres_split[OF setSchedContext_pop_head_corres[where rp=rp]])
-                    apply simp  (* scReplies at scp = replyPrev r', tl (sc_replies sc) *)
-                   apply (rule corres_split[where r'=dc])
-                      apply (case_tac list; simp)
-                      apply (rename_tac a ls)
-                      apply (rule_tac P="?abs_guard and reply_tcb_reply_at ((=) (Some t)) rp
-                                         and sc_replies_sc_at ((=) (a#ls)) scp
-                                         and ko_at (Structures_A.Reply r) rp
-                                         and bound_sc_tcb_at ((=) tcbsc) t"
-                                  and P'="?conc_guard and (\<lambda>s'. sym_refs (list_refs_of_replies' s'))
-                                         and st_tcb_at' ((=) st') t and (\<lambda>s. tcbSCs_of s t = tcbsc)
-                                          and ko_at' r' rp and (\<lambda>s. \<forall>p'. scReplies_of s p' \<noteq> Some rp)
-                                         and (\<lambda>s. \<forall>p'. replyPrevs_of s p' \<noteq> Some rp)"
-                             in corres_inst)
-                      apply (rule stronger_corres_guard_imp)
-                        apply (rule updateReply_replyPrev_same_corres)
-                        apply (clarsimp simp: reply_relation_def)
-                       apply clarsimp
-                       apply (clarsimp simp: sc_replies_sc_at_def obj_at_def is_sc_obj)
-                       apply (erule (1) valid_objsE[where x=scp])
-                       apply (clarsimp simp: valid_obj_def valid_sched_context_def dest!: sym[of _ "sc_replies _"])
-                       apply (clarsimp simp: obj_at_def)
-                      apply clarsimp
-                      apply (erule valid_objsE'[where x=rp])
-                       apply (fastforce simp: obj_at'_def projectKOs)
-                      apply (clarsimp simp: valid_obj'_def valid_reply'_def)
-                     apply (rule corres_guard_imp)
-                       apply (rule corres_split[OF updateReply_replyNext_not_head_corres])
-                          apply (clarsimp simp: isHead_def)
-                         apply (rule_tac P="?abs_guard and reply_tcb_reply_at ((=) (Some t)) rp
-                                             and bound_sc_tcb_at ((=) tcbsc) t
-                                             and sc_replies_sc_at (\<lambda>ls. rp \<notin> set ls) scp
-                                             and reply_sc_reply_at ((=) None) rp "
-                                     and P'="?conc_guard and st_tcb_at' ((=) st') t
-                                             and (\<lambda>s. (replies_of' s |> replyNext) rp = None)
-                                             and (\<lambda>s. \<forall>p'. replyPrevs_of s p' \<noteq> Some rp)
-                                             and (\<lambda>s. \<forall>p'. scReplies_of s p' \<noteq> Some rp)
-                                             and (\<lambda>s. tcbSCs_of s t = tcbsc)"
-                                in corres_inst)
-                         apply (rule_tac Q'="\<lambda>rv. ?conc_guard and st_tcb_at' ((=) st') t
-                                                  and (\<lambda>s. (replies_of' s |> replyNext) rp = None)
-                                                  and (\<lambda>s. \<forall>p'. replyPrevs_of s p' \<noteq> Some rp)
-                                                  and (\<lambda>s. \<forall>p'. scReplies_of s p' \<noteq> Some rp)
-                                                  and (\<lambda>s. tcbSCs_of s t = rv)"
-                                in corres_symb_exec_r)
-                            apply (rename_tac tcbsc')
-                            apply (rule stronger_corres_guard_imp)
-                              apply (rule_tac Q'="K (tcbsc' = tcbsc)" in corres_inst_add)
-                              apply (rule corres_gen_asm2')
-                              apply (rule corres_split[OF corres_when2])
-                                  apply simp
-                                 apply (rule schedContextDonate_corres) (* donate *)
-                                apply (rule_tac P="?abs_guard and reply_tcb_reply_at ((=) (Some t)) rp"
-                                            and P'="valid_objs' and valid_release_queue_iff
-                                                   and st_tcb_at' ((=) st') t and reply_at' rp
-                                                   and (\<lambda>s. (replies_of' s |> replyNext) rp = None)
-                                                   and (\<lambda>s. \<forall>p'. replyPrevs_of s p' \<noteq> Some rp)
-                                                   and (\<lambda>s. \<forall>p'. scReplies_of s p' \<noteq> Some rp)"
-                                       in corres_inst)
-                                apply (rule corres_symb_exec_r_sr_strong) (* replyPrev at rp = None *)
-                                   apply (rule corres_guard_imp)
-                                     apply (rule replyUnlinkTcb_corres)
-                                    apply (clarsimp simp: valid_objs_valid_tcbs elim!: pred_tcb_weakenE)
-                                   apply simp
-                                  apply (simp add: cleanReply_def)
-                                  apply (rule_tac Q'="\<lambda>_ s. reply_at' rp s \<and> (replies_of' s |> replyNext) rp = None
-                                                            \<and> (\<forall>p'. replyPrevs_of s p' \<noteq> Some rp)
-                                                            \<and> (\<forall>p'. scReplies_of s p' \<noteq> Some rp)"
-                                         in sr_inv_ul_bind[rotated])
-                                    apply (rule updateReply_sr_inv)
-                                     apply (clarsimp simp: reply_relation_def)
-                                    apply (intro conjI impI allI)
-                                    apply (erule sc_replies_relation_replyNext_None; clarsimp)
-                                    apply (clarsimp simp: obj_at'_def projectKOs opt_map_red)
-                                   apply clarsimp
-                                   apply (wpsimp wp: updateReply_wp_all)
-                                   apply (clarsimp simp: obj_at'_def projectKOs objBits_simps ps_clear_upd opt_map_red)
-                                   apply (rename_tac s s' reply' sc')
-                                   apply (intro conjI allI; clarsimp split: if_split_asm simp: projectKOs)
-                                   apply (rename_tac scp' sc'')
-                                   apply (drule_tac x=scp' in spec[where P="\<lambda>x. scReplies_of _ x \<noteq> Some rp"])
-                                   apply (clarsimp simp: opt_map_red)
-                                  apply (clarsimp simp: sr_inv_def updateReply_def)
-                                  apply (clarsimp simp: setReply_def getReply_def getObject_def
-                                                        setObject_def split_def objBits_simps'
-                                                        updateObject_default_def in_monad fail_def
-                                                        in_magnitude_check obj_at_simps return_def
-                                                        loadObject_default_def ARM_H.fromPPtr_def
-                                                 split: if_split_asm option.split_asm
-                                                 dest!: readObject_misc_ko_at')
-                                  apply (prop_tac "(ksPSpace s')(rp \<mapsto>
-                                                          KOReply (replyNext_update Map.empty reply))
-                                                   = ksPSpace s'")
-                                   apply (rule ext)
-                                   apply (clarsimp simp: opt_map_red split: if_split)
-                                   apply (case_tac reply; simp)
-                                  apply simp
-                                 apply wpsimp
-                                apply wpsimp
-                               apply wpsimp
-                              apply (rule hoare_when_cases, simp)
-                              apply (wpsimp wp: schedContextDonate_valid_objs'
-                                                schedContextDonate_replies_of' schedContextDonate_reply_projs)
-                             apply (fastforce split: if_split)
-                            apply (clarsimp simp: pred_tcb_at'_def opt_map_red obj_at_simps pred_tcb_at_def)
-                            apply (drule (1) pspace_relation_absD[OF _ state_relation_pspace_relation, where x=t])
-                            apply (rename_tac tcb' sc')
-                            apply (clarsimp simp: other_obj_relation_def tcb_relation_def)
-                           apply (wpsimp wp: threadGet_wp)
-                           apply (clarsimp simp: obj_at'_def projectKOs opt_map_red)
-                          apply wpsimp
-                         apply wpsimp
-                        apply wpsimp
-                       apply (wpsimp wp: updateReply_valid_objs' updateReply_replyNext_update_None)
-                      apply wpsimp
-                      apply simp
-                     apply simp
-                    apply wpsimp
-                   apply (elim conjE)
-                   apply (wpsimp wp: updateReply_valid_objs' simp: valid_reply'_def)
-                  apply (clarsimp cong: conj_cong imp_cong simp: pred_conj_def)
-                  apply (wpsimp wp: update_sched_context_sc_replies_update_tl)
-                  apply (rule_tac Q'="\<lambda>_. sc_replies_sc_at ((=) list) scp" in hoare_strengthen_post[rotated])
-                   apply (clarsimp simp: sc_replies_sc_at_def obj_at_def)
-                  apply (wpsimp wp: update_sched_context_sc_replies_update_tl)
-                 apply (fold updateSchedContext_def)
-                 apply (rule_tac Q'="\<lambda>_. valid_objs' and valid_release_queue_iff
-                                        and valid_queues and valid_queues'
-                                        and ko_at' r' rp and sc_at' scp
-                                        and (\<lambda>s. sym_refs (list_refs_of_replies' s))
-                                        and st_tcb_at' ((=) (Structures_H.thread_state.BlockedOnReply (Some rp))) t
-                                        and (\<lambda>s. \<forall>p'. scReplies_of s p' \<noteq> Some rp)
-                                        and (\<lambda>s. \<forall>p'. replyPrevs_of s p' \<noteq> Some rp)
-                                        and (\<lambda>s. tcbSCs_of s t = tcbsc)"
-                        in hoare_strengthen_post[rotated])
-                  apply (clarsimp split: if_split simp: valid_reply'_def opt_map_Some_eta_fold obj_at'_def)
-                 apply (wpsimp wp: hoare_vcg_if_lift2 hoare_drop_imp simp: valid_reply'_def)
-                 apply (rule hoare_vcg_conj_lift)
-                  apply (wpsimp wp: updateSchedContext_wp)
-                 apply wpsimp
-                 apply (rule hoare_vcg_conj_lift)
-                  apply (wpsimp wp: setSchedContext_local_sym_refs simp: updateSchedContext_def)
-                 apply wpsimp
-                apply (clarsimp simp: sc_replies_sc_at_def obj_at_def is_sc_obj opt_map_red)
-                apply (rule conjI, clarsimp simp: vs_all_heap_simps opt_map_red)
-                apply (rename_tac n sc0)
-                apply (clarsimp simp: reply_relation_def)
-                apply (erule (1) valid_objsE[where x=scp])
-                apply (clarsimp simp: valid_obj_def valid_sched_context_def obj_at_def)
-                apply (case_tac "sc_replies sc0"; simp)
-                apply (intro conjI impI allI; rename_tac ls; case_tac ls; clarsimp)
-               apply (clarsimp simp: valid_obj'_def projectKOs opt_map_red opt_map_Some_eta_fold)
-               apply (intro conjI impI)
-                   apply (fastforce simp: obj_at'_def opt_map_red opt_pred_def projectKOs
-                                          valid_sched_context'_def valid_obj'_def valid_reply'_def)
-                  apply (fold fun_upd_def)
-                  apply (clarsimp simp: obj_at'_def projectKOs opt_map_red ps_clear_upd objBits_simps
-                                 split: if_split)
-                 apply (fastforce dest!: sym_refs_replyNext_replyPrev_sym[where rp'=rp and rp=rp, THEN iffD2]
-                                   simp: obj_at_simps opt_map_red)
-                apply (clarsimp del: opt_mapE)
-                apply (drule (4) sym_refs_scReplies[simplified sym_heap_def, rule_format, THEN iffD1])
-                apply (clarsimp simp: obj_at'_def projectKOs opt_map_red)
-               apply (clarsimp del: opt_mapE)
-               apply (drule (1) reply_sym_heap_Prev_Next[simplified sym_heap_def, rule_format, THEN iffD1])
-               apply (clarsimp simp: obj_at'_def projectKOs opt_map_red)
-              apply wpsimp
-              apply (fastforce elim!: pred_tcb'_weakenE)
-             apply wpsimp
-            apply wpsimp
-           apply (wpsimp simp: assert_def reply_relation_def split: if_split)
-          apply wpsimp
-         apply (wpsimp simp: reply_relation_def)
-        apply wpsimp
-        apply (wpsimp wp: get_simple_ko_wp)
-       apply wpsimp
-      apply simp
-     apply (clarsimp del: opt_mapE)
-     apply (rule conjI)
-      apply (clarsimp simp: sym_refs_asrt_def pred_tcb_at'_def obj_at'_def projectKOs)
-      apply (drule sym_ref_Receive_or_Reply_replyTCB')
-        apply (fastforce simp: obj_at'_def projectKOs)
-       apply (rule disjI2, rule sym, simp)
-      apply clarsimp
-     apply (drule (4) sym_refs_scReplies[simplified sym_heap_def, rule_format, THEN iffD1])
-     apply (clarsimp simp: obj_at'_def projectKOs opt_map_red)
-    apply (wpsimp wp: get_sched_context_exs_valid)
-     apply (clarsimp simp: obj_at_def is_sc_obj)
-    apply simp
-   apply wpsimp
-   apply (prop_tac "distinct (sc_replies sc)")
-    apply (fastforce simp: valid_obj_def obj_at_def is_sc_obj valid_sched_context_def)
-   apply (clarsimp simp: obj_at_simps opt_map_red vs_all_heap_simps)
-  apply wpsimp
-  apply (clarsimp simp: obj_at_def is_sc_obj)
-  done
-
-lemma get_tcb_obj_ref_exs_valid[wp]:
-  "\<exists>tcb. kheap s tp = Some (Structures_A.TCB tcb)
-   \<Longrightarrow> \<lbrace>(=) s\<rbrace> get_tcb_obj_ref f tp \<exists>\<lbrace>\<lambda>_. (=) s\<rbrace>"
-  by (clarsimp simp: get_tcb_obj_ref_def thread_get_def gets_the_def get_tcb_def bind_def
-                     gets_def get_def return_def exs_valid_def
-              split: Structures_A.kernel_object.splits)
-
-lemma replyRemove_corres:
-  "\<lbrakk> st = Structures_A.thread_state.BlockedOnReply rp;
-     st'= BlockedOnReply (Some rp)\<rbrakk> \<Longrightarrow>
-   corres dc (valid_objs and pspace_aligned and pspace_distinct and valid_replies
-              and weak_valid_sched_action and active_scs_valid
-              and st_tcb_at ((=) st) t and (\<lambda>s. sym_refs (state_refs_of s)))
-             (valid_objs' and valid_release_queue_iff and valid_queues and valid_queues'
-              and (\<lambda>s'. sym_refs (list_refs_of_replies' s')) and K (rp' = rp))
-             (reply_remove t rp) (replyRemove rp' t)"
-  (is "\<lbrakk> _ ; _ \<rbrakk> \<Longrightarrow> corres _ ?abs_guard ?conc_guard _ _")
-  apply (rule corres_gen_asm2', simp only:)
-  apply add_sym_refs
-  apply (rule_tac Q="st_tcb_at' ((=) st') t" in corres_cross_add_guard)
-   apply (fastforce dest!: st_tcb_at_coerce_concrete elim!: pred_tcb'_weakenE)
-  apply (clarsimp simp: reply_remove_def replyRemove_def)
-  apply (rule corres_stateAssert_add_assertion[rotated])
-   apply (clarsimp simp: sym_refs_asrt_def)
-  apply (rule corres_guard_imp)
-    apply (rule corres_split[OF get_reply_corres])
-      apply (rename_tac reply reply')
-      apply (rule_tac P="?abs_guard and ko_at (Structures_A.Reply reply) rp"
-                 and P'="?conc_guard and (\<lambda>s. sym_refs (state_refs_of' s)) and st_tcb_at' ((=) st') t
-                         and ko_at' reply' rp"
-             in corres_inst)
-      apply (rule corres_guard_imp)
-        apply (rule corres_assert_gen_asm_l)
-        apply (prop_tac "reply_tcb reply = replyTCB reply'")
-         apply (clarsimp simp: reply_relation_def)
-        apply (clarsimp simp: assert_opt_def isReply_def split del: if_split)
-        apply (rule_tac P="?abs_guard and ko_at (Structures_A.Reply reply) rp"
-                   and P'="?conc_guard and (\<lambda>s. sym_refs (state_refs_of' s)) and st_tcb_at' ((=) st') t
-                           and ko_at' reply' rp"
-               in corres_inst)
-        apply (rule_tac Q'="\<lambda>rv'. ?conc_guard and st_tcb_at' ((=) st') t and (\<lambda>s'. sym_refs (state_refs_of' s'))
-                                  and ko_at' reply' rp and K (rv' = st')"
-               in corres_symb_exec_r)
-           apply (rename_tac rv')
-           apply (rule corres_gen_asm2')
-           apply (simp only:)
-           apply (rule corres_guard_imp)
-             apply (rule corres_assert_gen_asm2; simp split del: if_split)
-             apply (rule corres_symb_exec_l)
-                apply (rename_tac sc_opt)
-                apply (rule_tac P="?abs_guard and (\<lambda>s. sc_with_reply rp s = sc_opt) and  ko_at (Structures_A.Reply reply) rp"
-                           and P'="?conc_guard and (\<lambda>s. sym_refs (state_refs_of' s)) and ko_at' reply' rp"
-                       in corres_inst)
-                apply (rule_tac Q="(\<lambda>s'. sc_with_reply' rp s' = sc_opt) and pspace_aligned'
-                                         and pspace_distinct' and pspace_bounded'"
-                       in corres_cross_add_guard)
-                 apply (frule pspace_relation_pspace_bounded'[OF state_relation_pspace_relation])
-                 apply (fastforce simp: sc_replies_relation_sc_with_reply_cross_eq
-                                 dest!: state_relationD pspace_distinct_cross dest: pspace_aligned_cross)
-                apply (case_tac sc_opt; simp split del: if_split add: bind_assoc)
-                 (* sc_with_reply rp s = None *)
-                 apply (rule_tac F="replySC reply' = None" in corres_req)
-                  apply (fastforce dest!: sc_with_reply_None_reply_sc_reply_at replySCs_of_cross
-                                   elim!: obj_at_weakenE
-                                    simp: is_reply obj_at'_def projectKOs opt_map_red)
-                 apply (clarsimp simp: replySC_None_not_head)
-                 apply (simp only: bind_assoc[symmetric])
-                 apply (rule corres_symb_exec_r_sr)
-                    apply (rule corres_guard_imp)
-                      apply (rule replyUnlinkTcb_corres[simplified dc_def])
-                     apply (fastforce dest: valid_objs_valid_tcbs st_tcb_reply_state_refs
-                                      simp: obj_at_def is_reply reply_tcb_reply_at_def elim!: pred_tcb_weakenE)
-                    apply simp
-                   apply (rule sr_inv_imp)
-                     apply (erule sr_inv_sc_with_reply_None_helper)
-                    apply (fastforce elim!: obj_at_weakenE simp: is_reply)
-                   apply simp
-                  apply (wpsimp wp: updateReply_valid_objs' simp: valid_reply'_def obj_at'_def)
-                  apply (fastforce elim!: reply_ko_at_valid_objs_valid_reply')
-                 apply (wpsimp wp: no_fail_sc_wtih_reply_None_helper, simp)
-                (* sc_with_reply \<noteq> None : rp is in a reply stack *)
-                apply (rename_tac scp)
-                apply (rule_tac F="replyNext reply' \<noteq> None" in corres_req)
-                 apply clarsimp
-                 apply (prop_tac "sc_at scp s")
-                  apply (fastforce dest!: sc_with_reply_SomeD1
-                                    simp: sc_replies_sc_at_def obj_at_def is_sc_obj_def
-                                    elim: valid_sched_context_size_objsI)
-                 apply (prop_tac "sc_at' scp s'")
-                  apply (fastforce dest!: state_relationD sc_at_cross)
-                 apply (drule sc_with_reply'_SomeD, clarsimp)
-                 apply (case_tac "hd xs = rp")
-                  apply (drule heap_path_head, clarsimp)
-                  apply (drule (3) sym_refs_scReplies)
-                  apply (clarsimp simp: obj_at'_def projectKOs sym_heap_def elim!: opt_mapE)
-                 apply (frule (1) heap_path_takeWhile_lookup_next)
-                 apply (frule heap_path_head, clarsimp)
-                 apply (prop_tac "takeWhile ((\<noteq>) rp) xs = hd xs # tl (takeWhile ((\<noteq>) rp) xs)")
-                  apply (case_tac xs; simp)
-                 apply (simp del: heap_path.simps)
-                 apply (drule_tac p1="hd xs" and ps1="tl (takeWhile ((\<noteq>) rp) xs)"
-                        in sym_refs_reply_heap_path_doubly_linked_Nexts_rev[where p'=rp, THEN iffD1])
-                  apply clarsimp
-                 apply (case_tac "rev (tl (takeWhile ((\<noteq>) rp) xs))";
-                        clarsimp simp: obj_at'_def projectKOs elim!: opt_mapE)
-                apply (clarsimp simp: liftM_def bind_assoc split del: if_split)
-                apply (rename_tac next_reply)
-                apply (rule_tac Q="\<lambda>sc. ?abs_guard
-                                        and (\<lambda>s. \<exists>n. kheap s scp = Some (Structures_A.SchedContext sc n))
-                                        and (\<lambda>s. sc_with_reply rp s = Some scp)
-                                        and ko_at (Structures_A.Reply reply) rp
-                                        and  K (rp \<in> set (sc_replies sc))"
-                       in corres_symb_exec_l)
-                   apply (rename_tac sc)
-                   apply (rule_tac Q="\<lambda>s. scReplies_of s scp = hd_opt (sc_replies sc) \<and> sc_at' scp s"
-                          in corres_cross_add_guard)
-                    apply (clarsimp; rule conjI)
-                     apply (frule state_relation_sc_replies_relation)
-                     apply (frule sc_replies_relation_scReplies_of[symmetric])
-                       apply (fastforce dest!: sc_at_cross valid_objs_valid_sched_context_size
-                                         simp: obj_at_def is_sc_obj_def obj_at'_def)
-                      apply (fastforce dest!: sc_at_cross valid_objs_valid_sched_context_size
-                                        simp: obj_at_def is_sc_obj_def state_relation_def obj_at'_def
-                                              projectKOs opt_map_def)
-                     apply (clarsimp simp: sc_replies_of_scs_def map_project_def opt_map_def
-                                           scs_of_kh_def)
-                    apply (fastforce dest!: state_relation_pspace_relation sc_at_cross
-                                            valid_objs_valid_sched_context_size
-                                      simp: obj_at_def is_sc_obj)
-                   apply (rule corres_gen_asm')
-                   apply (rule corres_symb_exec_l)
-                      apply (rename_tac tcbsc)
-                      apply (rule_tac P="?abs_guard and (\<lambda>s. sc_with_reply rp s = Some scp)
-                                         and obj_at (\<lambda>ko. \<exists>n. ko = Structures_A.SchedContext sc n) scp
-                                         and bound_sc_tcb_at ((=) tcbsc) t
-                                         and ko_at (Structures_A.Reply reply) rp
-                                         and reply_sc_reply_at
-                                                  (\<lambda>ko. (hd (sc_replies sc) = rp \<longrightarrow> Some scp = ko)
-                                                      \<and> (hd (sc_replies sc) \<noteq> rp \<longrightarrow> None = ko)) rp"
-                             in corres_inst)
-                      apply (rule_tac F="(hd (sc_replies sc) = rp \<longrightarrow> replySC reply' = Some scp)
-                                          \<and> (hd (sc_replies sc) \<noteq> rp \<longrightarrow> replySC reply' = None)"
-                             in corres_req, clarsimp)
-                       apply (drule (1) replySCs_of_cross)
-                       apply (clarsimp simp: obj_at'_def opt_map_red projectKOs getHeadScPtr_def
-                                      split: reply_next.splits)
-                      apply (case_tac "hd (sc_replies sc) = rp"; simp add: bind_assoc split del: if_split)
-
-                       (* hd (sc_replies sc) = rp & replysc = Some scp: rp is at the head of the queue *)
-                       apply (simp add: isHead_def)
-                       apply (rule corres_guard_imp)
-                         (* replyPop *)
-                         apply (rule replyPop_corres[simplified dc_def]; simp)
-                        apply (clarsimp simp: obj_at_def is_sc_obj is_reply opt_map_red
-                                              reply_tcb_reply_at_def vs_all_heap_simps)
-                        apply (drule (1) valid_sched_context_size_objsI, simp)
-                        apply (drule sc_with_reply_SomeD)
-                        apply (metis list.sel(1) list.set_cases)
-                       apply (clarsimp simp: obj_at'_def projectKOs)
-
-                      (* rp is in the middle of the reply stack *)
-                      (* hd (sc_replies sc) \<noteq> rp & rp \<in> set (sc_replies sc) *)
-                      apply (simp add: reply_unlink_sc_def bind_assoc liftM_def split del: if_split)
-                      apply (rule_tac Q="\<lambda>rv. ?abs_guard and (\<lambda>s. sc_with_reply rp s = Some scp)
-                                              and obj_at (\<lambda>ko. \<exists>n. ko = kernel_object.SchedContext sc n) scp
-                                              and bound_sc_tcb_at ((=) tcbsc) t
-                                              and ko_at (Structures_A.Reply reply) rp
-                                              and reply_sc_reply_at ((=) None) rp and K (rv = sc)"
-                             in corres_symb_exec_l)
-                         apply (rule corres_gen_asm', simp split del: if_split)
-                         apply (rule_tac Q="\<lambda>rv. ?abs_guard and (\<lambda>s. sc_with_reply rp s = Some scp)
-                                                  and obj_at (\<lambda>ko. \<exists>n. ko = kernel_object.SchedContext sc n) scp
-                                                  and bound_sc_tcb_at ((=) tcbsc) t
-                                                  and ko_at (Structures_A.Reply reply) rp
-                                                  and reply_sc_reply_at ((=) None) rp and K (rv = reply)"
-                                in corres_symb_exec_l)
-                            apply (rule corres_gen_asm')
-                            apply (simp split del: if_split add: bind_assoc)
-                            apply (rule corres_guard_imp)
-                              apply (rule_tac Q="?conc_guard and ko_at' reply' rp and sc_at' scp
-                                                 and (\<lambda>s'. sym_refs (state_refs_of' s'))
-                                                 and (\<lambda>s'. sc_with_reply' rp s' = Some scp)
-                                                 and (\<lambda>s'. scReplies_of s' scp = hd_opt (sc_replies sc))
-                                                 and (\<lambda>s'. \<forall>prp. replyPrev reply' = Some prp
-                                                                 \<longrightarrow> replyNexts_of s' prp = Some rp)"
-                                     in corres_assert_gen_asm_l)
-                              apply (clarsimp simp: getHeadScPtr_def isHead_def neq_conv[symmetric]
-                                             split: reply_next.splits)
-                              apply (rename_tac nxt_rp)
-                              apply (rule stronger_corres_guard_imp)
-                                apply (rule corres_split
-                                              [OF updateReply_replyPrev_takeWhile_middle_corres])
-                                    apply simp
-                                   apply simp
-                                  apply (rule_tac P ="?abs_guard and reply_sc_reply_at ((=) None) rp
-                                                       and ko_at (Structures_A.Reply reply) rp
-                                                       and bound_sc_tcb_at ((=) tcbsc) t" and
-                                                  Q ="\<lambda>s. sc_with_reply rp s = None" and
-                                                  P'="valid_objs' and valid_release_queue_iff
-                                                      and ko_at' reply' rp and sc_at' scp" and
-                                                  Q'="(\<lambda>s'. \<forall>prp. replyPrev reply' = Some prp
-                                                                  \<longrightarrow> replyNexts_of s' prp = Some rp)"
-                                        in corres_inst_add)
-                                  apply (rule corres_symb_exec_r_sr)
-                                     apply (rule corres_symb_exec_r_sr)
-                                        apply (rule corres_guard_imp)
-                                          apply (rule replyUnlinkTcb_corres[simplified dc_def])
-                                         apply (fastforce dest: valid_objs_valid_tcbs st_tcb_reply_state_refs
-                                                          simp: obj_at_def is_reply reply_tcb_reply_at_def elim!: pred_tcb_weakenE)
-                                        apply simp
-                                       apply (rule sr_inv_imp)
-                                         apply (rule cleanReply_sr_inv)
-                                        apply simp
-                                       apply simp
-                                      apply wpsimp
-                                     apply wpsimp
-                                     apply (clarsimp dest!: state_relationD simp: reply_sc_reply_at_def)
-                                     apply (fastforce intro!: reply_at_cross elim!: obj_at_weakenE simp: is_reply)
-                                    apply (clarsimp cong: conj_cong)
-                                    apply (case_tac "replyPrev reply'"; simp)
-                                    apply (rename_tac prev_rp)
-                                    apply (rule sr_inv_imp)
-                                      apply (rule_tac P =\<top> and
-                                                      P'=" (\<lambda>s'. \<forall>prp. replyPrev reply' = Some prp
-                                                                       \<longrightarrow> replyNexts_of s' prev_rp = Some rp)"
-                                             in updateReply_sr_inv)
-                                       apply (clarsimp simp: reply_relation_def projectKOs obj_at'_def obj_at_def
-                                                      elim!: opt_mapE)
-                                      apply clarsimp
-                                      apply (drule_tac rp=prev_rp in sc_replies_relation_replyNext_update, simp)
-                                      apply simp
-                                     apply simp
-                                    apply clarsimp
-                                   apply wpsimp
-                                  apply wpsimp
-                                  apply (clarsimp dest!: reply_ko_at_valid_objs_valid_reply'
-                                                   simp: valid_reply'_def)
-                                 apply (wpsimp wp: sc_replies_update_takeWhile_sc_with_reply
-                                                   sc_replies_update_takeWhile_middle_sym_refs
-                                                   sc_replies_update_takeWhile_valid_replies)
-                                apply (wpsimp wp: updateReply_valid_objs' updateReply_ko_at'_other)
-                               apply (clarsimp cong: conj_cong)
-                               apply simp
-                              apply (clarsimp simp: valid_reply'_def)
-                              apply (rule context_conjI)
-                               apply (clarsimp simp: obj_at'_def projectKOs opt_map_red)
-                              apply (clarsimp simp: obj_at_def del: opt_mapE)
-                              apply (frule (1) valid_sched_context_objsI)
-                              apply (clarsimp simp: valid_sched_context_def del: opt_mapE)
-                              apply (frule (4) next_reply_in_sc_replies[OF state_relation_sc_replies_relation])
-                                 apply (fastforce dest!: state_relationD pspace_aligned_cross pspace_distinct_cross)
-                                apply (fastforce dest!: state_relationD pspace_distinct_cross)
-                               apply (fastforce dest!: state_relationD pspace_relation_pspace_bounded')
-                              apply (clarsimp simp: obj_at'_def)
-                              apply (clarsimp simp: vs_heap_simps)
-                             apply clarsimp
-                             apply (rule conjI)
-                              apply (clarsimp simp: list_all_iff dest!: set_takeWhileD)
-                             apply (clarsimp simp: reply_relation_def)
-                            apply (fastforce elim!: sym_refs_replyNext_replyPrev_sym[THEN iffD2]
-                                              simp: opt_map_red obj_at'_def projectKOs)
-                           apply (wpsimp simp: get_sk_obj_ref_def wp: get_reply_exs_valid)
-                            apply (fastforce dest!: Reply_or_Receive_reply_at[rotated]
-                                              simp: obj_at_def is_reply)
-                           apply simp
-                          apply (wpsimp wp: get_simple_ko_wp)
-                          apply (clarsimp simp: obj_at_def reply_sc_reply_at_def)
-                         apply (wpsimp simp: get_sk_obj_ref_def get_simple_ko_def obj_at_def
-                                         wp: get_object_wp)
-                         apply (fastforce simp: obj_at_def is_reply partial_inv_def a_type_def)
-                        apply (wpsimp wp: get_sched_context_exs_valid)
-                         apply (drule sc_with_reply_SomeD)
-                         apply clarsimp+
-                       apply (wpsimp simp: obj_at_def)
-                      apply (wpsimp wp: get_sched_context_no_fail)
-                      apply (fastforce elim!: valid_sched_context_size_objsI simp: obj_at_def is_sc_obj_def)
-                     apply (wpsimp simp: pred_tcb_at_def obj_at_def)
-                    apply (wpsimp wp: gbsc_bound_tcb simp: obj_at_def)
-                    apply (clarsimp simp: obj_at_def reply_sc_reply_at_def is_reply)
-                    apply (case_tac "sc_replies sc"; simp)
-                    apply (intro conjI impI)
-                     apply (fastforce dest!: sym_refs_reply_sc_reply_at
-                                       simp: sc_replies_sc_at_def obj_at_def reply_sc_reply_at_def)
-                    apply (fastforce dest!: sc_replies_middle_reply_sc_None
-                                      simp: vs_heap_simps obj_at_def is_sc_obj is_reply reply_sc_reply_at_def
-                                     elim!: valid_sched_context_size_objsI opt_mapE)
-                   apply (wpsimp simp: get_tcb_obj_ref_def thread_get_def st_tcb_def2)
-                  apply (wpsimp wp: get_sched_context_exs_valid)
-                   apply (fastforce dest!: sc_with_reply_SomeD1 simp: sc_replies_sc_at_def obj_at_def)
-                  apply simp
-                 apply wpsimp
-                 apply (fastforce dest!: sc_with_reply_SomeD1 simp: sc_replies_sc_at_def obj_at_def)
-                apply (wpsimp wp: get_sched_context_no_fail)
-                apply (fastforce dest!: sc_with_reply_SomeD1 simp: sc_replies_sc_at_def is_sc_obj obj_at_def
-                                 elim!: obj_at_weakenE valid_sched_context_size_objsI)
-               apply wpsimp
-              apply wpsimp
-             apply wpsimp
-            apply simp
-           apply (fastforce dest!: st_tcb_at_valid_st2 simp: valid_tcb_state_def)
-          apply clarsimp
-          apply (wpsimp simp: op_equal)
-         apply wpsimp
-        apply wpsimp
-       apply (fastforce dest: valid_objs_valid_tcbs st_tcb_reply_state_refs
-                         simp: obj_at_def is_reply reply_tcb_reply_at_def)
-      apply clarsimp
-     apply (wpsimp wp: get_simple_ko_ko_at)
-    apply wpsimp
-   apply clarsimp
-   apply (fastforce dest!: st_tcb_at_valid_st2 simp: valid_tcb_state_def)
-  apply (fastforce dest: tcb_in_valid_state' simp: valid_tcb_state'_def)
-  done
-
-lemma cancel_ipc_corres:
-  "corres dc (invs and valid_ready_qs and tcb_at t) invs'
+lemma (in delete_one) cancel_ipc_corres:
+  "corres dc (einvs and tcb_at t) (invs' and tcb_at' t)
       (cancel_ipc t) (cancelIPC t)"
-  apply add_sym_refs
-  apply add_ready_qs_runnable
-  apply (rule_tac Q="tcb_at' t" in corres_cross_add_guard)
-   apply (fastforce dest!: state_relationD elim!: tcb_at_cross)
   apply (simp add: cancel_ipc_def cancelIPC_def Let_def)
-  apply (rule corres_stateAssert_add_assertion[rotated])
-   apply (clarsimp simp: sym_refs_asrt_def)
-  apply (rule corres_stateAssert_add_assertion[rotated])
-   apply clarsimp
   apply (rule corres_guard_imp)
     apply (rule corres_split[OF getThreadState_corres])
-      apply (rule corres_split)
-         apply (rule threadset_corres; simp?)
-         apply (clarsimp simp: tcb_relation_def fault_rel_optionation_def)
-        apply (rule_tac P="invs and valid_ready_qs and st_tcb_at ((=) state) t" and
-                        P'="invs' and st_tcb_at' ((=) statea) t" in corres_inst)
-        apply (case_tac state, simp_all add: isTS_defs list_case_If gbep_ret')[1]
-           apply (rule corres_guard_imp)
-             apply (rename_tac epPtr reply pl)
-             apply (rule_tac st = "Structures_A.thread_state.BlockedOnReceive epPtr reply pl"
-                    in blocked_cancelIPC_corres[simplified])
-               apply simp
-              apply (clarsimp simp: thread_state_relation_def)
-             apply simp+
-            apply (clarsimp simp: invs_implies)
-           apply (clarsimp simp: invs'_implies)
-          apply (rule corres_guard_imp)
-            apply (rename_tac epPtr data)
-            apply (rule_tac st = "Structures_A.thread_state.BlockedOnSend epPtr data"
-                   in blocked_cancelIPC_corres[where reply_opt=None, simplified])
-             apply simp
-            apply (clarsimp simp: thread_state_relation_def)
-           apply simp
-           apply (clarsimp simp: invs_implies)
-          apply (clarsimp simp: invs'_implies)
+      apply (rule_tac P="einvs and st_tcb_at ((=) state) t" and
+                      P'="invs' and st_tcb_at' ((=) statea) t" in corres_inst)
+      apply (case_tac state, simp_all add: isTS_defs list_case_If)[1]
          apply (rule corres_guard_imp)
-           apply (rule replyRemoveTCB_corres)
+           apply (rule blocked_cancelIPC_corres)
+            apply fastforce
+           apply fastforce
           apply simp
-          apply (clarsimp simp: thread_state_relation_def)
-          apply (clarsimp simp: invs_implies)
-         apply (clarsimp simp: invs'_implies)
+         apply simp
+        apply (clarsimp simp add: isTS_defs list_case_If)
         apply (rule corres_guard_imp)
-          apply (rule cancelSignal_corres)
-         apply simp+
-       apply (wpsimp wp: thread_set_invs_fault_None thread_set_valid_ready_qs thread_set_no_change_tcb_state)
-      apply (wpsimp wp: threadSet_pred_tcb_no_state threadSet_invs_trivial)+
-     apply (wp gts_sp[where P="\<top>", simplified])+
+          apply (rule blocked_cancelIPC_corres)
+           apply fastforce
+          apply fastforce
+         apply simp
+        apply simp
+       apply (rule corres_guard_imp)
+         apply (rule cancelIPC_ReplyCap_corres)
+        apply (clarsimp elim!: st_tcb_weakenE)
+       apply (clarsimp elim!: pred_tcb'_weakenE)
+      apply (rule corres_guard_imp [OF cancelSignal_corres], simp+)
+     apply (wp gts_sp[where P="\<top>",simplified])+
     apply (rule hoare_strengthen_post)
      apply (rule gts_sp'[where P="\<top>"])
     apply (clarsimp elim!: pred_tcb'_weakenE)
-   apply simp
-  apply (clarsimp simp: inQ_def obj_at'_def projectKOs valid_release_queue'_def
-                 dest!: invs_valid_release_queue')
+   apply fastforce
+  apply simp
   done
 
 lemma setNotification_utr[wp]:
@@ -1272,6 +635,10 @@ lemma setNotification_utr[wp]:
   apply (rule hoare_pre, wp untyped_ranges_zero_lift)
   apply (simp add: o_def)
   done
+
+crunch setEndpoint
+  for gsUntypedZeroRanges[wp]: "\<lambda>s. P (gsUntypedZeroRanges s)"
+  (wp: setObject_ksPSpace_only updateObject_default_inv)
 
 lemma setEndpoint_utr[wp]:
   "\<lbrace>untyped_ranges_zero'\<rbrace> setEndpoint p ep \<lbrace>\<lambda>rv. untyped_ranges_zero'\<rbrace>"
@@ -1282,6 +649,10 @@ lemma setEndpoint_utr[wp]:
 
 declare cart_singleton_empty [simp]
 declare cart_singleton_empty2[simp]
+
+crunch setNotification
+  for ksQ[wp]: "\<lambda>s. P (ksReadyQueues s p)"
+  (wp: setObject_queues_unchanged_tcb updateObject_default_inv)
 
 lemma sch_act_simple_not_t[simp]: "sch_act_simple s \<Longrightarrow> sch_act_not t s"
   by (clarsimp simp: sch_act_simple_def)
@@ -1294,72 +665,80 @@ crunch setNotification
   (wp: valid_bitmaps_lift)
 
 lemma cancelSignal_invs':
-  "\<lbrace>invs' and st_tcb_at' (\<lambda>st. st = BlockedOnNotification ntfn) t\<rbrace>
-   cancelSignal t ntfn
-   \<lbrace>\<lambda>_. invs'\<rbrace>"
+  "\<lbrace>invs' and st_tcb_at' (\<lambda>st. st = BlockedOnNotification ntfn) t and sch_act_not t\<rbrace>
+    cancelSignal t ntfn \<lbrace>\<lambda>rv. invs'\<rbrace>"
   proof -
-    have NIQ: "\<And>s. \<lbrakk> valid_queues s;
-                     \<forall>d p. \<forall>t\<in>set (ksReadyQueues s (d, p)). st_tcb_at' runnable' t s;
-                     st_tcb_at' (Not \<circ> runnable') t s \<rbrakk>
-                     \<Longrightarrow> \<forall>d p. t \<notin> set (ksReadyQueues s (d,p))"
-      apply (clarsimp simp add: pred_tcb_at'_def Invariants_H.valid_queues_def
-                                valid_queues_no_bitmap_def)
-      apply (drule spec | drule(1) bspec | clarsimp simp: obj_at'_def inQ_def)+
-      done
     have NTFNSN: "\<And>ntfn ntfn'.
                     \<lbrace>\<lambda>s. sch_act_not (ksCurThread s) s \<rbrace> setNotification ntfn ntfn'
                     \<lbrace>\<lambda>_ s. sch_act_not (ksCurThread s) s\<rbrace>"
       apply (rule hoare_weaken_pre)
-       apply (wps)
+       apply (wps setNotification_ksCurThread)
        apply (wp, simp)
       done
     show ?thesis
-      apply (simp add: cancelSignal_def invs'_def Let_def valid_dom_schedule'_def)
-      apply (rule bind_wp[OF _ stateAssert_sp])
+      apply (simp add: cancelSignal_def invs'_def valid_state'_def Let_def)
       apply (wp valid_irq_node_lift sts_sch_act' irqs_masked_lift
-                hoare_vcg_all_lift [OF set_ntfn'.ksReadyQueues]
-                setThreadState_ct_not_inQ NTFNSN set_ntfn'.get_wp
-                hoare_vcg_all_lift set_ntfn'.ksReadyQueues hoare_vcg_imp_lift'
+                hoare_vcg_all_lift
+                setThreadState_ct_not_inQ NTFNSN
+                hoare_vcg_all_lift
               | simp add: valid_tcb_state'_def list_case_If split del: if_split)+
-      apply (clarsimp simp: pred_tcb_at' ready_qs_runnable_def)
-      apply (frule (1) NIQ)
-       apply (clarsimp simp: pred_tcb_at'_def obj_at'_def)
-      apply (case_tac "ntfnObj ko", simp_all add: isWaitingNtfn_def)
+       prefer 2
+       apply assumption
+      apply (rule hoare_strengthen_post)
+       apply (rule get_ntfn_sp')
+      apply (rename_tac rv s)
+      apply (clarsimp simp: pred_tcb_at')
       apply (rule conjI)
        apply (clarsimp simp: valid_ntfn'_def)
-       apply normalise_obj_at'
+       apply (case_tac "ntfnObj rv", simp_all add: isWaitingNtfn_def)
        apply (frule ko_at_valid_objs')
          apply (simp add: valid_pspace_valid_objs')
         apply (clarsimp simp: projectKO_opt_ntfn split: kernel_object.splits)
-       apply (simp add: valid_obj'_def valid_ntfn'_def)
-       apply (rule conjI, clarsimp simp: pred_tcb_at'_def obj_at'_def)
-       apply (rule conjI, erule_tac rfs'="list_refs_of_replies' s" in delta_sym_refs)
-         subgoal
-         by (auto simp: symreftype_inverse' list_refs_of_replies'_def
-                        get_refs_def2 opt_map_def
-                 split: option.splits)
-        subgoal
-        by (auto simp: symreftype_inverse' list_refs_of_replies'_def
-                       get_refs_def2 opt_map_def
-                split: option.splits)
-        apply (frule obj_at_valid_objs', clarsimp)
-        apply (clarsimp simp: projectKOs valid_obj'_def valid_ntfn'_def)
-        apply (frule st_tcb_at_state_refs_ofD')
-        apply (frule ko_at_state_refs_ofD')
-        apply (fastforce simp: get_refs_def elim!: if_live_state_refsE split: option.splits)
-       apply (frule obj_at_valid_objs', clarsimp)
-       apply (clarsimp simp: projectKOs valid_obj'_def valid_ntfn'_def)
-       apply (rule conjI, clarsimp split: option.splits)
+        apply (simp add: valid_obj'_def valid_ntfn'_def)
        apply (frule st_tcb_at_state_refs_ofD')
        apply (frule ko_at_state_refs_ofD')
-       apply (rule conjI)
-        apply (clarsimp simp: pred_tcb_at'_def obj_at'_def)
-       apply (rule conjI)
+       apply (rule conjI, erule delta_sym_refs)
+         apply (clarsimp simp: ntfn_bound_refs'_def split: if_split_asm)
         apply (clarsimp split: if_split_asm)
-        apply (fastforce simp: list_refs_of_replies'_def opt_map_def o_def split: option.splits)
-       apply (fastforce simp: get_refs_def elim!: if_live_state_refsE split: option.splits)
-       done
+          subgoal
+          by (fastforce simp: symreftype_inverse' ntfn_bound_refs'_def
+                               tcb_bound_refs'_def ntfn_q_refs_of'_def obj_at'_def projectKOs
+                        split: ntfn.splits option.splits)
+         subgoal
+         by (fastforce simp: symreftype_inverse' ntfn_bound_refs'_def
+                                tcb_bound_refs'_def)
+        subgoal
+        by (fastforce simp: symreftype_inverse' ntfn_bound_refs'_def
+                               tcb_bound_refs'_def ntfn_q_refs_of'_def remove1_empty
+                        split: ntfn.splits)
+       apply (rule conjI, clarsimp elim!: if_live_state_refsE)
+       apply (fastforce simp: sym_refs_def dest!: idle'_no_refs)
+      apply (case_tac "ntfnObj rv", simp_all)
+      apply (frule obj_at_valid_objs', clarsimp)
+      apply (clarsimp simp: projectKOs valid_obj'_def valid_ntfn'_def)
+      apply (rule conjI, clarsimp split: option.splits)
+      apply (frule st_tcb_at_state_refs_ofD')
+      apply (frule ko_at_state_refs_ofD')
+      apply (rule conjI)
+       apply (erule delta_sym_refs)
+        apply (fastforce simp: ntfn_bound_refs'_def split: if_split_asm)
+       apply (clarsimp split: if_split_asm)
+        apply (fastforce simp: symreftype_inverse' ntfn_bound_refs'_def tcb_bound_refs'_def
+                               set_eq_subset)
+       apply (fastforce simp: symreftype_inverse' ntfn_bound_refs'_def tcb_bound_refs'_def
+                              set_eq_subset)
+      apply (clarsimp simp: valid_pspace'_def)
+      apply (rule conjI, clarsimp elim!: if_live_state_refsE)
+      apply (rule conjI)
+       apply (case_tac "ntfnBoundTCB rv")
+        apply (clarsimp elim!: if_live_state_refsE)+
+            apply (rule conjI, clarsimp split: option.splits)
+      apply (clarsimp dest!: idle'_no_refs)
+      done
   qed
+
+lemmas setEndpoint_valid_arch[wp]
+    = valid_arch_state_lift' [OF setEndpoint_typ_at' set_ep_arch']
 
 lemma ep_redux_simps3:
   "ep_q_refs_of' (case xs of [] \<Rightarrow> IdleEP | y # ys \<Rightarrow> RecvEP (y # ys))
@@ -1370,154 +749,189 @@ lemma ep_redux_simps3:
 
 lemma setEndpoint_pde_mappings'[wp]:
   "\<lbrace>valid_pde_mappings'\<rbrace> setEndpoint ptr val \<lbrace>\<lambda>rv. valid_pde_mappings'\<rbrace>"
-  by (wp valid_pde_mappings_lift')
+  apply (wp valid_pde_mappings_lift')
+   apply (simp add: setEndpoint_def)
+   apply (rule obj_at_setObject2)
+   apply (clarsimp dest!: updateObject_default_result)+
+  done
+
+declare setEndpoint_ksMachine [wp]
+declare setEndpoint_valid_irq_states' [wp]
+
+lemma setEndpoint_vms[wp]:
+  "\<lbrace>valid_machine_state'\<rbrace> setEndpoint epptr ep' \<lbrace>\<lambda>_. valid_machine_state'\<rbrace>"
+  by (simp add: valid_machine_state'_def pointerInUserData_def pointerInDeviceData_def)
+     (wp hoare_vcg_all_lift hoare_vcg_disj_lift)
+
+crunch setEndpoint
+  for ksQ[wp]: "\<lambda>s. P (ksReadyQueues s p)"
+  (wp: setObject_queues_unchanged_tcb updateObject_default_inv)
+
+crunch setEndpoint
+  for sch_act_not[wp]: "sch_act_not t"
+
+crunch setEndpoint
+  for ksCurDomain[wp]: "\<lambda>s. P (ksCurDomain s)"
+  (wp: setObject_ep_cur_domain)
+
+lemma setEndpoint_ksDomSchedule[wp]:
+  "\<lbrace>\<lambda>s. P (ksDomSchedule s)\<rbrace> setEndpoint ptr ep \<lbrace>\<lambda>_ s. P (ksDomSchedule s)\<rbrace>"
+  apply (simp add: setEndpoint_def setObject_def split_def)
+  apply (wp updateObject_default_inv | simp)+
+  done
+
+lemma setEndpoint_ct_idle_or_in_cur_domain'[wp]:
+  "\<lbrace> ct_idle_or_in_cur_domain' \<rbrace> setEndpoint ptr ep \<lbrace> \<lambda>_. ct_idle_or_in_cur_domain' \<rbrace>"
+  apply (rule ct_idle_or_in_cur_domain'_lift)
+  apply (wp hoare_vcg_disj_lift hoare_vcg_imp_lift setObject_ep_ct
+       | rule obj_at_setObject2
+       | clarsimp simp: updateObject_default_def in_monad setEndpoint_def)+
+  done
+
+lemma setEndpoint_ct_not_inQ[wp]:
+  "\<lbrace>ct_not_inQ\<rbrace> setEndpoint eeptr ep' \<lbrace>\<lambda>_. ct_not_inQ\<rbrace>"
+  apply (rule ct_not_inQ_lift [OF setEndpoint_nosch])
+  apply (simp add: setEndpoint_def)
+  apply (rule hoare_weaken_pre)
+   apply (wps setObject_ep_ct)
+   apply (wp obj_at_setObject2)
+   apply (clarsimp simp: updateObject_default_def in_monad)+
+  done
+
+lemma setEndpoint_ksDomScheduleIdx[wp]:
+  "setEndpoint ptr ep \<lbrace>\<lambda>s. P (ksDomScheduleIdx s)\<rbrace>"
+  apply (simp add: setEndpoint_def setObject_def split_def)
+  apply (wp updateObject_default_inv | simp)+
+  done
 
 end
 
-crunch cancelIPC
-  for ksCurDomain[wp]: "\<lambda>s. P (ksCurDomain s)"
-  and ksDomSchedule[wp]: "\<lambda>s. P (ksDomSchedule s)"
-  and ksInterruptState[wp]: "\<lambda>s. P (ksInterruptState s)"
-  and ksMachineState[wp]: "\<lambda>s. P (ksMachineState s)"
-  and ksDomScheduleIdx[wp]: "\<lambda>s. P (ksDomScheduleIdx s)"
-  and sch_act_simple[wp]: "sch_act_simple"
-  and valid_pde_mappings'[wp]: "valid_pde_mappings'"
-  and ifunsafe'[wp]: "if_unsafe_then_cap'"
-  and global_refs'[wp]: "valid_global_refs'"
-  and valid_arch'[wp]: "valid_arch_state'"
-  and typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  and vms'[wp]: "valid_machine_state'"
-  and ct_idle_or_in_cur_domain'[wp]: ct_idle_or_in_cur_domain'
-  and pspace_domain_valid[wp]: pspace_domain_valid
-  and ntfn_at'[wp]: "ntfn_at' t"
-  (wp: crunch_wps simp: crunch_simps)
+crunch setEndpoint
+  for sym_heap_sched_pointers[wp]: sym_heap_sched_pointers
+  and valid_sched_pointers[wp]: valid_sched_pointers
+  and valid_bitmaps[wp]: valid_bitmaps
+  (wp: valid_bitmaps_lift simp: updateObject_default_def)
 
-crunch blockedCancelIPC
-  for valid_queues[wp]: valid_queues
-  and replyNexts_replyPrevs[wp]: "\<lambda>s. P (replyNexts_of s) (replyPrevs_of s)"
-  (wp: crunch_wps)
-
-crunch cancelSignal, replyRemoveTCB
-  for sch_act_wf[wp]: "\<lambda>s. sch_act_wf (ksSchedulerAction s) s"
-  (wp: crunch_wps sts_sch_act')
-
-lemma blockedCancelIPC_sch_act_wf[wp]:
-  "\<lbrace>\<lambda>s. sch_act_wf (ksSchedulerAction s) s \<and> sch_act_not tptr s\<rbrace>
-   blockedCancelIPC st tptr rptrOpt
-   \<lbrace>\<lambda>_ s. sch_act_wf (ksSchedulerAction s) s\<rbrace>"
-  unfolding blockedCancelIPC_def getBlockingObject_def epBlocked_def
-  apply (wpsimp wp: hoare_vcg_imp_lift' getEndpoint_wp haskell_assert_wp sts_sch_act')
+lemma (in delete_one_conc) cancelIPC_invs[wp]:
+  shows "\<lbrace>tcb_at' t and invs'\<rbrace> cancelIPC t \<lbrace>\<lambda>rv. invs'\<rbrace>"
+proof -
+  have P: "\<And>xs v f. (case xs of [] \<Rightarrow> return v | y # ys \<Rightarrow> return (f (y # ys)))
+                         = return (case xs of [] \<Rightarrow> v | y # ys \<Rightarrow> f xs)"
+    by (clarsimp split: list.split)
+  have EPSCHN: "\<And>eeptr ep'. \<lbrace>\<lambda>s. sch_act_not (ksCurThread s) s\<rbrace>
+                             setEndpoint eeptr ep'
+                             \<lbrace>\<lambda>_ s. sch_act_not (ksCurThread s) s\<rbrace>"
+    apply (rule hoare_weaken_pre)
+     apply (wps setEndpoint_ct')
+     apply (wp, simp)
+    done
+  have Q:
+    "\<And>epptr. \<lbrace>st_tcb_at' (\<lambda>st. \<exists>a. (st = BlockedOnReceive epptr a)
+                            \<or> (\<exists>a b c d. st = BlockedOnSend epptr a b c d)) t
+                  and invs'\<rbrace>
+      do ep \<leftarrow> getEndpoint epptr;
+         y \<leftarrow> assert (\<not> (case ep of IdleEP \<Rightarrow> True | _ \<Rightarrow> False));
+         ep' \<leftarrow> case remove1 t (epQueue ep)
+                of [] \<Rightarrow> return Structures_H.endpoint.IdleEP
+                | x # xs \<Rightarrow> return (epQueue_update (%_. x # xs) ep);
+         y \<leftarrow> setEndpoint epptr ep';
+         setThreadState Inactive t
+      od \<lbrace>\<lambda>rv. invs'\<rbrace>"
+    apply (simp add: invs'_def valid_state'_def)
+    apply (subst P)
+    apply (wp valid_irq_node_lift valid_global_refs_lift' valid_arch_state_lift'
+              irqs_masked_lift sts_sch_act'
+              hoare_vcg_all_lift [OF setEndpoint_ksQ]
+              setThreadState_ct_not_inQ EPSCHN
+              hoare_vcg_all_lift
+              | simp add: valid_tcb_state'_def split del: if_split
+              | wpc)+
+     prefer 2
+     apply assumption
+    apply (rule hoare_strengthen_post [OF get_ep_sp'])
+    apply (clarsimp simp: pred_tcb_at' fun_upd_def[symmetric] conj_comms
+               split del: if_split cong: if_cong)
+    apply (rule conjI, clarsimp simp: valid_pspace'_def)
+    apply (rule conjI, clarsimp simp: valid_pspace'_def)
+    apply (rule conjI, clarsimp simp: valid_idle'_def pred_tcb_at'_def obj_at'_def idle_tcb'_def)
+    apply (frule obj_at_valid_objs', clarsimp)
+    apply (clarsimp simp: projectKOs valid_obj'_def)
+    apply (rule conjI)
+     apply (clarsimp simp: obj_at'_def valid_ep'_def projectKOs
+                    dest!: pred_tcb_at')
+    apply (clarsimp, rule conjI)
+     apply (auto simp: pred_tcb_at'_def obj_at'_def)[1]
+    apply (rule conjI)
+     apply (clarsimp split: Structures_H.endpoint.split_asm list.split
+                      simp: valid_ep'_def)
+      apply (rename_tac list x xs)
+      apply (frule distinct_remove1[where x=t])
+      apply (cut_tac xs=list in set_remove1_subset[where x=t])
+      apply auto[1]
+     apply (rename_tac list x xs)
+     apply (frule distinct_remove1[where x=t])
+     apply (cut_tac xs=list in set_remove1_subset[where x=t])
+     apply auto[1]
+    apply (frule(1) sym_refs_ko_atD')
+    apply (rule conjI)
+     apply (clarsimp elim!: if_live_state_refsE split: Structures_H.endpoint.split_asm)
+    apply (drule st_tcb_at_state_refs_ofD')
+    apply (clarsimp simp: ep_redux_simps3 valid_ep'_def
+                   split: Structures_H.endpoint.split_asm
+                    cong: list.case_cong)
+     apply (frule_tac x=t in distinct_remove1)
+     apply (frule_tac x=t in set_remove1_eq)
+     by (auto elim!: delta_sym_refs
+               simp: symreftype_inverse' tcb_st_refs_of'_def tcb_bound_refs'_def
+              split: thread_state.splits if_split_asm)
+  have R:
+    "\<lbrace>invs' and tcb_at' t\<rbrace>
+     do y \<leftarrow> threadSet (\<lambda>tcb. tcb \<lparr> tcbFault := None \<rparr>) t;
+        slot \<leftarrow> getThreadReplySlot t;
+        callerCap \<leftarrow> liftM (mdbNext \<circ> cteMDBNode) (getCTE slot);
+        when (callerCap \<noteq> nullPointer) (do
+            y \<leftarrow> stateAssert (capHasProperty callerCap (\<lambda>cap. isReplyCap cap
+                                                           \<and> \<not> capReplyMaster cap))
+                [];
+            cteDeleteOne callerCap
+        od)
+     od
+     \<lbrace>\<lambda>rv. invs'\<rbrace>"
+    unfolding getThreadReplySlot_def
+    by (wp valid_irq_node_lift delete_one_invs hoare_drop_imps
+           threadSet_invs_trivial irqs_masked_lift
+      | simp add: o_def if_apply_def2
+      | fastforce simp: inQ_def)+
+  show ?thesis
+    apply (simp add:   cancelIPC_def crunch_simps
+               cong:   if_cong list.case_cong)
+    apply (rule bind_wp [OF _ gts_sp'])
+    apply (case_tac state,
+           simp_all add: isTS_defs)
+           apply (safe intro!: hoare_weaken_pre[OF Q]
+                               hoare_weaken_pre[OF R]
+                               hoare_weaken_pre[OF return_wp]
+                               hoare_weaken_pre[OF cancelSignal_invs']
+                       elim!: pred_tcb'_weakenE)
+          apply (auto simp: pred_tcb_at'_def obj_at'_def
+                      dest: invs_sch_act_wf')
   done
+qed
 
-lemma nonempty_epQueue_remove1_valid_ep':
-  "\<lbrakk>valid_ep' ep s; remove1 tptr (epQueue ep) = x # xs; ep \<noteq> IdleEP\<rbrakk>
-   \<Longrightarrow> valid_ep' (epQueue_update (\<lambda>_. x # xs) ep) s"
-  apply (case_tac ep
-         ; clarsimp simp: valid_ep'_def
-         ; metis (full_types) distinct.simps(2) distinct_remove1 list.set_intros(1)
-                              list.set_intros(2) notin_set_remove1)
-  done
-
-lemma blockedCancelIPC_valid_pspace'[wp]:
-  "\<lbrace>valid_pspace' and st_tcb_at' ((=) st) tptr\<rbrace>
-   blockedCancelIPC st tptr rptrOpt
-   \<lbrace>\<lambda>_. valid_pspace'\<rbrace>"
-  supply opt_mapE[elim!]
-  unfolding valid_pspace'_def blockedCancelIPC_def getBlockingObject_def
-  apply (wpsimp wp: valid_mdb'_lift hoare_vcg_imp_lift getEndpoint_wp
-                    hoare_vcg_all_lift sts'_valid_replies' replyUnlink_st_tcb_at'
-              simp: valid_tcb_state'_def epBlocked_def)
-  apply (rule ccontr, normalise_obj_at')
-  apply (match premises in epQueue: "_ (valid_ep' ep s)" for ep s \<Rightarrow>
-         \<open>rule meta_mp[rotated, where P="valid_ep' ep s"]\<close>)
-   apply (drule(1) ep_ko_at_valid_objs_valid_ep')
-   apply (case_tac "remove1 tptr (epQueue ko)"; clarsimp)
-    apply (clarsimp simp: valid_ep'_def)
-   apply (fastforce dest: nonempty_epQueue_remove1_valid_ep'[rotated])
-  apply (case_tac "rptrOpt"; clarsimp simp: pred_tcb_at'_eq_commute)
-   apply (fastforce simp: pred_tcb_at'_def obj_at'_def projectKOs)
-  apply (rename_tac rptr reply KOreply)
-  apply (drule_tac rptr=rptr in valid_replies'D[simplified pred_tcb_at'_eq_commute])
-   apply (clarsimp simp: opt_pred_def)
-  apply (fastforce simp: pred_tcb_at'_def obj_at'_def projectKOs)
-  done
-
-lemma cancelIPC_sch_act_wf[wp]:
-  "\<lbrace>\<lambda>s. sch_act_wf (ksSchedulerAction s) s \<and> sch_act_not tptr s\<rbrace>
-   cancelIPC tptr
-   \<lbrace>\<lambda>_ s. sch_act_wf (ksSchedulerAction s) s\<rbrace>"
-  unfolding cancelIPC_def
-  apply (wpsimp wp: gts_wp' hoare_vcg_imp_lift' threadSet_sch_act hoare_vcg_all_lift
-                    replyRemoveTCB_sch_act_wf)
-  done
-
-crunch getBlockingObject
-  for inv: P
-
-lemma blockedCancelIPC_if_live'[wp]:
-  "blockedCancelIPC st tptr epptr \<lbrace>if_live_then_nonz_cap'\<rbrace>"
-  unfolding blockedCancelIPC_def getBlockingObject_def
-  apply (wpsimp wp: getEndpoint_wp haskell_assert_wp)
-  apply (clarsimp simp: if_live_then_nonz_cap'_def endpoint.disc_eq_case endpoint_live')
-  done
-
-lemma blockedCancelIPC_valid_idle':
-  "\<lbrace>valid_idle' and (\<lambda>s. tptr \<noteq> ksIdleThread s)\<rbrace>
-   blockedCancelIPC st tptr epptr
-   \<lbrace>\<lambda>_. valid_idle'\<rbrace>"
-  unfolding blockedCancelIPC_def getBlockingObject_def
-  apply (wpsimp wp: getEndpoint_wp)
-  done
-
-crunch blockedCancelIPC
-  for ct_not_inQ[wp]: ct_not_inQ
-  and cur_tcb'[wp]: "cur_tcb'"
-  and ctes_of[wp]: "\<lambda>s. P (ctes_of s)"
-  and valid_queues'[wp]: valid_queues'
-  and valid_release_queue[wp]: valid_release_queue
-  and valid_release_queue'[wp]: valid_release_queue'
-  and untyped_ranges_zero'[wp]: "untyped_ranges_zero'"
-  (wp: crunch_wps)
-
-lemma blockedCancelIPC_invs':
-  "\<lbrace>invs' and st_tcb_at' ((=) st) tptr\<rbrace>
-   blockedCancelIPC st tptr rptrOpt
-   \<lbrace>\<lambda>_. invs'\<rbrace>"
-  apply (rule hoare_strengthen_pre_via_assert_backward[
-                where E="obj_at' ((\<noteq>) IdleEP) (the (epBlocked st))
-                         and K (\<exists>x. epBlocked st = Some x)"])
-   apply (simp add: blockedCancelIPC_def getBlockingObject_def)
-   apply (wpsimp wp: getEndpoint_wp)
-   apply (clarsimp simp: obj_at'_def)
-  unfolding invs'_def decompose_list_refs_of_replies' valid_dom_schedule'_def
-  apply (wpsimp wp: valid_irq_node_lift typ_at_lifts
-                    valid_irq_handlers_lift' valid_irq_states_lift' irqs_masked_lift
-              simp: cteCaps_of_def pred_tcb_at'_def)
-  done
-
-lemma threadSet_fault_invs':
-  "threadSet (tcbFault_update upd) t \<lbrace>invs'\<rbrace>"
-  apply (wpsimp wp: threadSet_invs_trivial)
-  apply (clarsimp simp: inQ_def)
-  apply (rule conjI)
-   apply clarsimp
-  apply (frule invs_valid_release_queue')
-  apply (clarsimp simp: valid_release_queue'_def obj_at'_def)
-  done
-
-lemma cancelIPC_invs'[wp]:
-  "cancelIPC t \<lbrace>invs'\<rbrace>"
-  unfolding cancelIPC_def Let_def
-  apply (wpsimp wp: blockedCancelIPC_invs' replyRemoveTCB_invs' cancelSignal_invs'
-                    hoare_vcg_all_lift hoare_vcg_imp_lift' threadSet_fault_invs' gts_wp'
-              simp: pred_tcb_at'_def)
-  apply normalise_obj_at'
-  apply (rename_tac tcb)
-  apply (case_tac "tcbState tcb"; clarsimp)
+lemma (in delete_one_conc_pre) cancelIPC_sch_act_simple[wp]:
+  "\<lbrace>sch_act_simple\<rbrace>
+    cancelIPC t
+   \<lbrace>\<lambda>rv. sch_act_simple\<rbrace>"
+  apply (simp add: cancelIPC_def cancelSignal_def Let_def
+             cong: if_cong Structures_H.thread_state.case_cong)
+  apply (wp hoare_drop_imps delete_one_sch_act_simple
+       | simp add: getThreadReplySlot_def | wpcw
+       | rule sch_act_simple_lift
+       | (rule_tac Q'="\<lambda>rv. sch_act_simple" in hoare_post_imp, simp))+
   done
 
 lemma cancelSignal_st_tcb_at:
-  assumes [simp]: "P Inactive" shows
+  assumes x[simp]: "P Inactive" shows
   "\<lbrace>st_tcb_at' P t\<rbrace>
      cancelSignal t' ntfn
    \<lbrace>\<lambda>rv. st_tcb_at' P t\<rbrace>"
@@ -1527,12 +941,19 @@ lemma cancelSignal_st_tcb_at:
    apply clarsimp+
   done
 
-lemma cancelIPC_st_tcb_at:
-  assumes [simp]: "\<And>st. simple' st \<longrightarrow> P st" shows
-  "cancelIPC t' \<lbrace>st_tcb_at' P t\<rbrace>"
-  unfolding cancelIPC_def
-  apply (wpsimp wp: blockedCancelIPC_st_tcb_at replyRemoveTCB_st_tcb_at'_cases
-                    cancelSignal_st_tcb_at threadSet_pred_tcb_no_state gts_wp')
+lemma (in delete_one_conc_pre) cancelIPC_st_tcb_at:
+  assumes x[simp]: "\<And>st. simple' st \<longrightarrow> P st" shows
+  "\<lbrace>st_tcb_at' P t\<rbrace>
+     cancelIPC t'
+   \<lbrace>\<lambda>rv. st_tcb_at' P t\<rbrace>"
+  apply (simp add: cancelIPC_def Let_def getThreadReplySlot_def
+             cong: if_cong Structures_H.thread_state.case_cong)
+  apply (rule bind_wp [OF _ gts_sp'])
+  apply (case_tac rv, simp_all add: isTS_defs list_case_If)
+         apply (wp sts_st_tcb_at'_cases delete_one_st_tcb_at
+                   threadSet_pred_tcb_no_state
+                   cancelSignal_st_tcb_at hoare_drop_imps
+                | clarsimp simp: o_def if_fun_split)+
   done
 
 lemma weak_sch_act_wf_lift_linear:
@@ -1545,6 +966,12 @@ lemma weak_sch_act_wf_lift_linear:
   apply simp_all
   done
 
+lemma sts_sch_act_not[wp]:
+  "\<lbrace>sch_act_not t\<rbrace> setThreadState st t' \<lbrace>\<lambda>rv. sch_act_not t\<rbrace>"
+  apply (simp add: setThreadState_def rescheduleRequired_def)
+  apply (wp hoare_drop_imps | simp | wpcw)+
+  done
+
 crunch cancelSignal, setBoundNotification
   for sch_act_not[wp]: "sch_act_not t"
   (wp: crunch_wps)
@@ -1555,16 +982,70 @@ lemma cancelSignal_tcb_at_runnable':
   unfolding cancelSignal_def
   by (wpsimp wp: sts_pred_tcb_neq' hoare_drop_imp)
 
-lemma setThreadState_st_tcb_at'_test_unaffected:
-  "\<lbrace>\<lambda>s. st_tcb_at' test t s \<and> test st\<rbrace>
-   setThreadState st t'
-   \<lbrace>\<lambda>_. st_tcb_at' test t\<rbrace>"
-  apply (wpsimp wp: sts_st_tcb')
-  done
+lemma cancelAllIPC_tcb_at_runnable':
+  "\<lbrace>st_tcb_at' runnable' t\<rbrace> cancelAllIPC epptr \<lbrace>\<lambda>_. st_tcb_at' runnable' t\<rbrace>"
+  unfolding cancelAllIPC_def
+  by (wpsimp wp: mapM_x_wp' sts_st_tcb' hoare_drop_imp)
+
+lemma cancelAllSignals_tcb_at_runnable':
+  "\<lbrace>st_tcb_at' runnable' t\<rbrace> cancelAllSignals ntfnptr \<lbrace>\<lambda>_. st_tcb_at' runnable' t\<rbrace>"
+  unfolding cancelAllSignals_def
+  by (wpsimp wp: mapM_x_wp' sts_st_tcb' hoare_drop_imp)
 
 crunch unbindNotification, bindNotification, unbindMaybeNotification
   for st_tcb_at'[wp]: "st_tcb_at' P p"
   (wp: threadSet_pred_tcb_no_state ignore: threadSet)
+
+lemma (in delete_one_conc_pre) finaliseCap_tcb_at_runnable':
+  "\<lbrace>st_tcb_at' runnable' t\<rbrace> finaliseCap cap final True \<lbrace>\<lambda>_. st_tcb_at' runnable' t\<rbrace>"
+  apply (clarsimp simp add: finaliseCap_def Let_def)
+  apply (rule conjI | clarsimp | wp cancelAllIPC_tcb_at_runnable' getObject_ntfn_inv
+                                    cancelAllSignals_tcb_at_runnable'
+       | wpc)+
+  done
+
+crunch isFinalCapability
+  for pred_tcb_at'[wp]: "pred_tcb_at' proj st t"
+  (simp: crunch_simps)
+
+lemma (in delete_one_conc_pre) cteDeleteOne_tcb_at_runnable':
+  "\<lbrace>st_tcb_at' runnable' t\<rbrace> cteDeleteOne callerCap \<lbrace>\<lambda>_. st_tcb_at' runnable' t\<rbrace>"
+  apply (simp add: cteDeleteOne_def unless_def)
+  apply (wp finaliseCap_tcb_at_runnable' | clarsimp | wp (once) hoare_drop_imps)+
+  done
+
+crunch getThreadReplySlot, getEndpoint
+  for pred_tcb_at'[wp]: "pred_tcb_at' proj st t"
+
+lemma (in delete_one_conc_pre) cancelIPC_tcb_at_runnable':
+  "\<lbrace>st_tcb_at' runnable' t'\<rbrace> cancelIPC t \<lbrace>\<lambda>_. st_tcb_at' runnable' t'\<rbrace>"
+  (is "\<lbrace>?PRE\<rbrace> _ \<lbrace>_\<rbrace>")
+  apply (clarsimp simp: cancelIPC_def Let_def)
+  apply (case_tac "t'=t")
+   apply (rule_tac Q'="\<lambda>st. st_tcb_at' runnable' t and K (runnable' st)"
+            in bind_wp)
+    apply(case_tac rv; simp)
+   apply (wpsimp wp: sts_pred_tcb_neq')+
+           apply (rule_tac Q'="\<lambda>rv. ?PRE" in hoare_post_imp, fastforce)
+           apply (wp cteDeleteOne_tcb_at_runnable'
+                    threadSet_pred_tcb_no_state
+                    cancelSignal_tcb_at_runnable'
+                    sts_pred_tcb_neq' hoare_drop_imps
+                  | wpc | simp add: o_def if_fun_split)+
+  done
+
+crunch cancelSignal
+  for ksCurDomain[wp]: "\<lambda>s. P (ksCurDomain s)"
+  (wp: crunch_wps)
+
+lemma (in delete_one_conc_pre) cancelIPC_ksCurDomain[wp]:
+  "\<lbrace>\<lambda>s. P (ksCurDomain s)\<rbrace> cancelIPC t \<lbrace>\<lambda>_ s. P (ksCurDomain s)\<rbrace>"
+apply (simp add: cancelIPC_def Let_def)
+apply (wp hoare_vcg_conj_lift delete_one_ksCurDomain
+     | wpc
+     | rule hoare_drop_imps
+     | simp add: getThreadReplySlot_def o_def if_fun_split)+
+done
 
 (* FIXME move *)
 lemma setBoundNotification_not_ntfn:
@@ -1577,41 +1058,32 @@ lemma setBoundNotification_not_ntfn:
      | simp)+
   done
 
-lemma cancelSignal_tcb_obj_at':
-  "(\<And>tcb st qd. P (tcb\<lparr>tcbState := st, tcbQueued := qd\<rparr>) \<longleftrightarrow> P tcb)
-     \<Longrightarrow> cancelSignal t word \<lbrace>obj_at' P t'\<rbrace>"
-  apply (simp add: cancelSignal_def)
-  apply (wpsimp wp: setThreadState_not_st getNotification_wp)
+lemma setBoundNotification_tcb_in_cur_domain'[wp]:
+  "\<lbrace>tcb_in_cur_domain' t'\<rbrace> setBoundNotification st t \<lbrace>\<lambda>_. tcb_in_cur_domain' t'\<rbrace>"
+  apply (simp add: tcb_in_cur_domain'_def)
+  apply (rule hoare_pre)
+  apply wps
+  apply (wp setBoundNotification_not_ntfn | simp)+
   done
 
-crunch replyRemoveTCB, cancelSignal, getBlockingObject, blockedCancelIPC
-  for obj_at'_only_st_qd_ft: "\<lambda>s. P (obj_at' (Q :: tcb \<Rightarrow> bool) t s)"
-  (simp: crunch_simps pred_tcb_at'_def wp: crunch_wps)
 
-(* FIXME: Proved outside of `crunch` because without the `[where P=P]` constraint, the
-   postcondition unifies with the precondition in a wonderfully exponential way. VER-1337 *)
-lemma cancelIPC_obj_at'_only_st_qd_ft:
-  "\<lbrace>\<lambda>s. P (obj_at' Q t' s) \<and>
-        (\<forall>upd tcb. Q (tcbState_update upd tcb) = Q tcb) \<and>
-        (\<forall>upd tcb. Q (tcbQueued_update upd tcb) = Q tcb) \<and>
-        (\<forall>upd tcb. Q (tcbFault_update upd tcb) = Q tcb)\<rbrace>
-   cancelIPC t
-   \<lbrace>\<lambda>_ s. P (obj_at' Q t' s)\<rbrace>"
-  unfolding cancelIPC_def Let_def
-  apply (wpsimp wp: scheduleTCB_obj_at'_only_st_qd_ft[where P=P]
-                    threadSet_obj_at'_only_st_qd_ft[where P=P]
-                    setThreadState_obj_at'_only_st_qd_ft[where P=P]
-                    replyUnlink_obj_at'_only_st_qd_ft[where P=P]
-                    getBlockingObject_obj_at'_only_st_qd_ft[where P=P]
-                    replyRemoveTCB_obj_at'_only_st_qd_ft[where P=P]
-                    blockedCancelIPC_obj_at'_only_st_qd_ft[where P=P]
-                    cancelSignal_obj_at'_only_st_qd_ft[where P=P]
-                    hoare_drop_imp)
-  done
+lemma setThreadState_tcbDomain_obj_at'[wp]:
+  "setThreadState ts t \<lbrace>obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>"
+  unfolding setThreadState_def
+  by wpsimp
 
-lemma cancelIPC_tcbDomain_obj_at':
+crunch cancelSignal
+  for tcbDomain_obj_at'[wp]: "obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'"
+  (wp: crunch_wps)
+
+lemma (in delete_one_conc_pre) cancelIPC_tcbDomain_obj_at':
   "\<lbrace>obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace> cancelIPC t \<lbrace>\<lambda>_. obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>"
-  apply (wpsimp wp: cancelIPC_obj_at'_only_st_qd_ft)
+  apply (simp add: cancelIPC_def Let_def)
+  apply (wp hoare_vcg_conj_lift
+            delete_one_tcbDomain_obj_at'
+       | wpc
+       | rule hoare_drop_imps
+       | simp add: getThreadReplySlot_def o_def if_fun_split)+
   done
 
 lemma (in delete_one_conc_pre) cancelIPC_tcb_in_cur_domain':
@@ -1622,21 +1094,59 @@ lemma (in delete_one_conc_pre) cancelIPC_tcb_in_cur_domain':
    apply (wp cancelIPC_tcbDomain_obj_at' | simp)+
   done
 
+lemma (in delete_one_conc_pre) cancelIPC_sch_act_not:
+  "\<lbrace>sch_act_not t'\<rbrace> cancelIPC t \<lbrace>\<lambda>_. sch_act_not t'\<rbrace>"
+  apply (simp add: cancelIPC_def Let_def)
+  apply (wp hoare_vcg_conj_lift
+            delete_one_sch_act_not
+       | wpc
+       | simp add: getThreadReplySlot_def o_def if_apply_def2
+              split del: if_split
+       | rule hoare_drop_imps)+
+  done
+
+lemma (in delete_one_conc_pre) cancelIPC_weak_sch_act_wf:
+  "\<lbrace>\<lambda>s. weak_sch_act_wf (ksSchedulerAction s) s\<rbrace>
+      cancelIPC t
+   \<lbrace>\<lambda>rv s. weak_sch_act_wf (ksSchedulerAction s) s\<rbrace>"
+  apply (rule weak_sch_act_wf_lift_linear)
+  apply (wp cancelIPC_sch_act_not cancelIPC_tcb_in_cur_domain' cancelIPC_tcb_at_runnable')+
+  done
+
 text \<open>The suspend operation, significant as called from delete\<close>
 
-lemma setBoundNotification_tcb_in_cur_domain'[wp]:
-  "setBoundNotification st t \<lbrace>tcb_in_cur_domain' t'\<rbrace>"
-  apply (simp add: tcb_in_cur_domain'_def)
-  apply (rule hoare_pre)
-   apply wps
-  apply (wp setBoundNotification_not_ntfn | simp)+
+lemma rescheduleRequired_weak_sch_act_wf:
+  "\<lbrace>\<top>\<rbrace> rescheduleRequired \<lbrace>\<lambda>rv s. weak_sch_act_wf (ksSchedulerAction s) s\<rbrace>"
+  apply (simp add: rescheduleRequired_def setSchedulerAction_def)
+  apply (wp hoare_TrueI | simp add: weak_sch_act_wf_def)+
   done
+
+lemma sts_weak_sch_act_wf[wp]:
+  "\<lbrace>\<lambda>s. weak_sch_act_wf (ksSchedulerAction s) s
+        \<and> (ksSchedulerAction s = SwitchToThread t \<longrightarrow> runnable' st)\<rbrace>
+   setThreadState st t
+   \<lbrace>\<lambda>_ s. weak_sch_act_wf (ksSchedulerAction s) s\<rbrace>"
+  including classic_wp_pre
+  apply (simp add: setThreadState_def)
+  apply (wp rescheduleRequired_weak_sch_act_wf)
+  apply (rule_tac Q'="\<lambda>_ s. weak_sch_act_wf (ksSchedulerAction s) s" in hoare_post_imp, simp)
+  apply (simp add: weak_sch_act_wf_def)
+  apply (wp hoare_vcg_all_lift)
+   apply (wps threadSet_nosch)
+   apply (wp hoare_vcg_const_imp_lift threadSet_pred_tcb_at_state threadSet_tcbDomain_triv | simp)+
+  done
+
+lemma sbn_nosch[wp]:
+  "\<lbrace>\<lambda>s. P (ksSchedulerAction s)\<rbrace> setBoundNotification ntfn t \<lbrace>\<lambda>rv s. P (ksSchedulerAction s)\<rbrace>"
+  by (simp add: setBoundNotification_def, wp threadSet_nosch)
+
 
 lemma sbn_weak_sch_act_wf[wp]:
   "\<lbrace>\<lambda>s. weak_sch_act_wf (ksSchedulerAction s) s\<rbrace>
    setBoundNotification ntfn t
    \<lbrace>\<lambda>_ s. weak_sch_act_wf (ksSchedulerAction s) s\<rbrace>"
-  by (wp weak_sch_act_wf_lift)
+  by (wp weak_sch_act_wf_lift sbn_st_tcb')
+
 
 lemma set_ep_weak_sch_act_wf[wp]:
   "\<lbrace>\<lambda>s. weak_sch_act_wf (ksSchedulerAction s) s\<rbrace>
@@ -1653,14 +1163,25 @@ lemma setObject_ntfn_sa_unchanged[wp]:
   apply (wp | simp add: updateObject_default_def)+
   done
 
+lemma setObject_oa_unchanged[wp]:
+  "\<lbrace>\<lambda>s. obj_at' (\<lambda>tcb::tcb. P tcb) t s\<rbrace>
+    setObject ptr (ntfn::Structures_H.notification)
+   \<lbrace>\<lambda>rv s.  obj_at' P t s\<rbrace>"
+  apply (rule obj_at_setObject2)
+  apply (clarsimp simp add: updateObject_type
+                            updateObject_default_def
+                            in_monad)
+  done
+
 lemma setNotification_weak_sch_act_wf[wp]:
   "\<lbrace>\<lambda>s. weak_sch_act_wf (ksSchedulerAction s) s\<rbrace>
     setNotification ntfnptr ntfn
    \<lbrace>\<lambda>_ s. weak_sch_act_wf (ksSchedulerAction s) s\<rbrace>"
   apply (wp hoare_vcg_all_lift hoare_convert_imp hoare_vcg_conj_lift
-         | simp add: weak_sch_act_wf_def st_tcb_at'_def tcb_in_cur_domain'_def)+
-   apply (wps )
-   apply (wp  | simp add: o_def)+
+         | simp add: setNotification_def weak_sch_act_wf_def st_tcb_at'_def tcb_in_cur_domain'_def)+
+   apply (rule hoare_pre)
+    apply (wps setObject_ntfn_cur_domain)
+    apply (wp setObject_ntfn_obj_at'_tcb | simp add: o_def)+
   done
 
 lemmas ipccancel_weak_sch_act_wfs
@@ -1672,7 +1193,9 @@ lemma updateObject_ep_inv:
 
 lemma asUser_tcbQueued_inv[wp]:
   "\<lbrace>obj_at' (\<lambda>tcb. P (tcbQueued tcb)) t'\<rbrace> asUser t m \<lbrace>\<lambda>_. obj_at' (\<lambda>tcb. P (tcbQueued tcb)) t'\<rbrace>"
-  by (wpsimp wp: getObject_tcb_wp simp: obj_at'_def asUser_def tcb_in_cur_domain'_def threadGet_getObject)
+  apply (simp add: asUser_def tcb_in_cur_domain'_def threadGet_def)
+  apply (wp threadSet_obj_at'_strongish getObject_tcb_wp | wpc | simp | clarsimp simp: obj_at'_def)+
+  done
 
 context begin interpretation Arch .
 
@@ -1707,58 +1230,41 @@ lemma as_user_ready_qs_distinct[wp]:
   apply (wpsimp wp: set_object_wp)
   by (clarsimp simp: ready_qs_distinct_def)
 
-crunch ThreadDecls_H.suspend
-  (* FIXME RT: VER-1016 *)
-  for tcb_at'_better[wp]: "\<lambda>s. P (tcb_at' t s)"
-  (rule: sch_act_simple_lift
-     wp: crunch_wps
-   simp: crunch_simps if_fun_split st_tcb_at'_def)
-
 lemma (in delete_one) suspend_corres:
   "corres dc (einvs and tcb_at t) (invs' and tcb_at' t)
-             (SchedContext_A.suspend t) (ThreadDecls_H.suspend t)"
-  apply (simp add: SchedContext_A.suspend_def Thread_H.suspend_def)
-  apply add_sym_refs
-  apply (rule corres_stateAssert_add_assertion)
-   prefer 2
-   apply (clarsimp simp: sym_refs_asrt_def)
+        (IpcCancel_A.suspend t) (ThreadDecls_H.suspend t)"
+  apply (rule corres_cross_over_guard[where P'=P' and Q="tcb_at' t and P'" for P'])
+   apply (fastforce dest!: tcb_at_cross state_relation_pspace_relation)
+  apply (simp add: IpcCancel_A.suspend_def Thread_H.suspend_def)
   apply (rule corres_guard_imp)
     apply (rule corres_split_nor[OF cancel_ipc_corres])
-      apply (rule corres_split[OF getThreadState_corres], rename_tac state state')
-        apply (simp only: when_def)
-        apply (rule corres_split[OF corres_if])
-             apply (case_tac state; clarsimp?)
-            apply (clarsimp simp: update_restart_pc_def updateRestartPC_def)
+      apply (rule corres_split[OF getThreadState_corres])
+        apply (rule corres_split_nor)
+           apply (rule corres_if)
+             apply (case_tac state; simp)
+            apply (simp add: update_restart_pc_def updateRestartPC_def)
             apply (rule asUser_corres')
             apply (simp add: ARM.nextInstructionRegister_def ARM.faultRegister_def
-                             ARM_H.nextInstructionRegister_def ARM_H.faultRegister_def
-                             ARM_H.Register_def)
+                             ARM_H.nextInstructionRegister_def ARM_H.faultRegister_def)
+            apply (simp add: ARM_H.Register_def)
+            apply (subst unit_dc_is_eq)
             apply (rule corres_underlying_trivial)
             apply (wpsimp simp: ARM.setRegister_def ARM.getRegister_def)
-           apply (rule corres_rel_imp)
-            apply (rule corres_return_trivial)
-           apply simp
-          apply (rule corres_split[OF setThreadState_corres], simp)
-            apply (rule corres_split[OF tcbSchedDequeue_corres'])
-              apply (rule corres_split[OF tcbReleaseRemove_corres], simp)
-                apply (rule schedContextCancelYieldTo_corres)
-               apply wpsimp+
-          apply (wpsimp simp: update_restart_pc_def updateRestartPC_def)
-          apply (rule hoare_post_imp[where Q'="\<lambda>rv s. invs s \<and> tcb_at t s"], fastforce)
-          apply wp
-         apply wpsimp
-        apply (rule hoare_post_imp[where Q'="\<lambda>rv s. invs' s \<and> tcb_at' t s"])
-         apply (fastforce simp: invs'_def dest!: valid_queues_inQ_queues)
-        apply wp
-         apply (clarsimp simp: updateRestartPC_def)
-         apply wpsimp
-        apply wpsimp
-       apply (wpsimp wp: gts_wp)
-      apply (wpsimp wp: gts_wp')
-     apply (rule hoare_post_imp[where Q'="\<lambda>rv s. invs s \<and> tcb_at t s"], fastforce)
-     apply wpsimp
-    apply (rule hoare_post_imp[where Q'="\<lambda>rv s. invs' s \<and> tcb_at' t s"], fastforce)
-    apply (wpsimp wp: hoare_drop_imps)+
+           apply (rule corres_return_trivial)
+          apply (rule corres_split_nor[OF setThreadState_corres])
+             apply wpsimp
+            apply (rule tcbSchedDequeue_corres, simp)
+           apply wp
+          apply (wpsimp wp: sts_valid_objs')
+          apply (wpsimp simp: update_restart_pc_def updateRestartPC_def valid_tcb_state'_def)+
+       apply (rule hoare_post_imp[where Q'="\<lambda>rv s. einvs s \<and> tcb_at t s"])
+        apply (simp add: invs_implies invs_strgs valid_queues_in_correct_ready_q
+                         valid_queues_ready_qs_distinct valid_sched_def)
+       apply wp
+      apply (rule hoare_post_imp[where Q'="\<lambda>_ s. invs' s \<and> tcb_at' t s"])
+       apply (fastforce simp: invs'_def valid_tcb_state'_def)
+      apply (wpsimp simp: update_restart_pc_def updateRestartPC_def)+
+   apply fastforce+
   done
 
 lemma (in delete_one) prepareThreadDelete_corres:
@@ -1766,58 +1272,28 @@ lemma (in delete_one) prepareThreadDelete_corres:
         (prepare_thread_delete t) (ArchRetypeDecls_H.ARM_H.prepareThreadDelete t)"
   by (simp add: ArchVSpace_A.ARM_A.prepare_thread_delete_def ArchRetype_H.ARM_H.prepareThreadDelete_def)
 
-lemma rescheduleRequired_oa_queued:
-  "\<lbrace> (\<lambda>s. P (obj_at' (\<lambda>tcb. Q (tcbQueued tcb) (tcbDomain tcb) (tcbPriority tcb)) t' s)) and sch_act_simple\<rbrace>
-    rescheduleRequired
-   \<lbrace>\<lambda>_ s. P (obj_at' (\<lambda>tcb. Q (tcbQueued tcb) (tcbDomain tcb) (tcbPriority tcb)) t' s)\<rbrace>"
-  (is "\<lbrace>?OAQ t' p and sch_act_simple\<rbrace> _ \<lbrace>_\<rbrace>")
-  apply (simp add: rescheduleRequired_def sch_act_simple_def)
-  apply (rule_tac Q'="\<lambda>rv s. (rv = ResumeCurrentThread \<or> rv = ChooseNewThread)
-                       \<and> ?OAQ t' p s" in bind_wp)
-   including classic_wp_pre
-   apply (wp | clarsimp)+
-   apply (case_tac x)
-     apply (wp | clarsimp)+
+lemma no_refs_simple_strg':
+  "st_tcb_at' simple' t s' \<and> P {} \<longrightarrow> st_tcb_at' (\<lambda>st. P (tcb_st_refs_of' st)) t s'"
+  by (fastforce elim!: pred_tcb'_weakenE)+
+
+crunch cancelSignal
+  for it[wp]: "\<lambda>s. P (ksIdleThread s)"
+  (wp: crunch_wps simp: crunch_simps)
+
+lemma (in delete_one_conc_pre) cancelIPC_it[wp]:
+  "\<lbrace>\<lambda>s. P (ksIdleThread s)\<rbrace>
+   cancelIPC t
+   \<lbrace>\<lambda>_ s. P (ksIdleThread s)\<rbrace>"
+  apply (simp add: cancelIPC_def Let_def getThreadReplySlot_def)
+  apply (wp hoare_drop_imps delete_one_it | wpc | simp add:if_apply_def2 Fun.comp_def)+
   done
 
+crunch threadGet
+  for ksQ: "\<lambda>s. P (ksReadyQueues s p)"
 
-(* FIXME: rename uses of setThreadState_oa_queued; the "_queued" suffix doesn't make sense
-   any more. VER-1332 *)
-lemmas setThreadState_oa_queued = setThreadState_oa
-
-lemma setBoundNotification_oa_queued:
-  "\<lbrace>\<lambda>s. P' (obj_at' (\<lambda>tcb. P (tcbQueued tcb) (tcbDomain tcb) (tcbPriority tcb)) t' s) \<rbrace>
-    setBoundNotification ntfn t
-   \<lbrace>\<lambda>_ s. P' (obj_at' (\<lambda>tcb. P (tcbQueued tcb) (tcbDomain tcb) (tcbPriority tcb)) t' s) \<rbrace>"
-  (is "\<lbrace>\<lambda>s. P' (?Q P s)\<rbrace> _ \<lbrace>\<lambda>_ s. P' (?Q P s)\<rbrace>")
-  proof (rule P_bool_lift [where P=P'])
-    show pos:
-      "\<And>R. \<lbrace> ?Q R \<rbrace> setBoundNotification ntfn t \<lbrace>\<lambda>_. ?Q R \<rbrace>"
-      apply (simp add: setBoundNotification_def)
-      apply (wp threadSet_obj_at'_strongish)
-      apply (clarsimp)
-      done
-    show "\<lbrace>\<lambda>s. \<not> ?Q P s\<rbrace> setBoundNotification ntfn t \<lbrace>\<lambda>_ s. \<not> ?Q P s\<rbrace>"
-      by (simp add: not_obj_at' comp_def, wp hoare_convert_imp pos)
-  qed
-
-lemma tcbSchedDequeue_t_notksQ:
-  "\<lbrace>\<lambda>s. t \<in> set (ksReadyQueues s (d, p)) \<longrightarrow>
-           obj_at' (\<lambda>tcb. tcbQueued tcb \<and> tcbDomain tcb = d \<and> tcbPriority tcb = p) t s\<rbrace>
-    tcbSchedDequeue t
-   \<lbrace>\<lambda>_ s. t \<notin> set (ksReadyQueues s (d, p))\<rbrace>"
-  apply (rule_tac P'="(\<lambda>s. t \<notin> set (ksReadyQueues s (d, p)))
-                            or obj_at'(\<lambda>tcb. tcbQueued tcb \<and> tcbDomain tcb = d \<and> tcbPriority tcb = p) t"
-               in hoare_pre_imp, clarsimp)
-  apply (rule hoare_pre_disj)
-   apply (wp tcbSchedDequeue_notksQ)[1]
-  apply (simp add: tcbSchedDequeue_def  removeFromBitmap_conceal_def[symmetric])
-  apply wp
-        apply (rule hoare_pre_post, assumption)
-        apply (clarsimp simp: bitmap_fun_defs removeFromBitmap_conceal_def, wp, clarsimp)
-       apply (wp threadGet_wp)+
-  apply (auto simp: obj_at'_real_def ko_wp_at'_def)
-  done
+crunch tcbSchedDequeue
+  for ct_idle_or_in_cur_domain'[wp]: ct_idle_or_in_cur_domain'
+  (wp: crunch_wps)
 
 lemma asUser_sch_act_simple[wp]:
   "\<lbrace>sch_act_simple\<rbrace> asUser s t \<lbrace>\<lambda>_. sch_act_simple\<rbrace>"
@@ -1826,27 +1302,40 @@ lemma asUser_sch_act_simple[wp]:
   done
 
 lemma (in delete_one_conc) suspend_invs'[wp]:
-  "\<lbrace>invs' and tcb_at' t\<rbrace>
-   ThreadDecls_H.suspend t
-   \<lbrace>\<lambda>rv. invs'\<rbrace>" (is "valid ?pre _ _")
-  apply (simp add: suspend_def updateRestartPC_def getThreadState_def)
-  apply (rule bind_wp[OF _ stateAssert_sp])
-  apply (rule_tac Q'="\<lambda>_. ?pre and st_tcb_at' simple' t"
-               in bind_wp_fwd)
-   apply (wpsimp wp: cancelIPC_simple)
-  apply (rule bind_wp_fwd_skip, wpsimp)
-  apply (rule bind_wp_fwd_skip)
-   apply clarsimp
-   apply (wpsimp simp: updateRestartPC_def)
-  apply (rule_tac Q'="\<lambda>_. ?pre and st_tcb_at' ((=) Inactive) t"
-               in bind_wp_fwd)
-   apply (wpsimp wp: sts_invs_minor' sts_st_tcb_at'_cases)
-   apply (fastforce elim: pred_tcb'_weakenE)
-  apply (wpsimp wp: tcbReleaseRemove_invs' schedContextCancelYieldTo_invs')
+  "\<lbrace>invs' and sch_act_simple and tcb_at' t and (\<lambda>s. t \<noteq> ksIdleThread s)\<rbrace>
+   ThreadDecls_H.suspend t \<lbrace>\<lambda>rv. invs'\<rbrace>"
+  apply (simp add: suspend_def)
+  apply (wpsimp wp: sts_invs_minor' gts_wp' simp: updateRestartPC_def
+         | strengthen no_refs_simple_strg')+
+   apply (rule_tac Q'="\<lambda>_. invs' and sch_act_simple and st_tcb_at' simple' t
+                          and (\<lambda>s. t \<noteq> ksIdleThread s)"
+                in hoare_post_imp)
+    apply clarsimp
+   apply wpsimp
+  apply (fastforce elim: pred_tcb'_weakenE)
+  done
+
+lemma (in delete_one_conc_pre) suspend_tcb'[wp]:
+  "\<lbrace>tcb_at' t'\<rbrace> ThreadDecls_H.suspend t \<lbrace>\<lambda>rv. tcb_at' t'\<rbrace>"
+  apply (simp add: suspend_def unless_def)
+  apply wp
+      apply (wpsimp simp: updateRestartPC_def)
+     apply (wp hoare_drop_imps |clarsimp|rule conjI)+
+  done
+
+lemma (in delete_one_conc_pre) suspend_sch_act_simple[wp]:
+  "\<lbrace>sch_act_simple\<rbrace>
+  ThreadDecls_H.suspend t \<lbrace>\<lambda>rv. sch_act_simple\<rbrace>"
+  apply (simp add: suspend_def when_def updateRestartPC_def)
+  apply (wp cancelIPC_sch_act_simple | simp add: unless_def
+       | rule sch_act_simple_lift)+
+      apply (simp add: updateRestartPC_def)
+      apply (rule asUser_nosch)
+     apply wpsimp+
   done
 
 lemma (in delete_one_conc) suspend_objs':
-  "\<lbrace>invs' and tcb_at' t\<rbrace>
+  "\<lbrace>invs' and sch_act_simple and tcb_at' t and (\<lambda>s. t \<noteq> ksIdleThread s)\<rbrace>
    suspend t \<lbrace>\<lambda>rv. valid_objs'\<rbrace>"
   apply (rule_tac Q'="\<lambda>_. invs'" in hoare_strengthen_post)
    apply (wp suspend_invs')
@@ -1862,7 +1351,7 @@ lemma (in delete_one_conc_pre) suspend_st_tcb_at':
   apply (wp sts_st_tcb_at'_cases threadSet_pred_tcb_no_state
             cancelIPC_st_tcb_at hoare_drop_imps asUser_pred_tcb_at' x
          | simp)+
-  apply (clarsimp simp: pred_tcb_at'_def obj_at'_def)
+  apply clarsimp
   done
 
 lemmas (in delete_one_conc_pre) suspend_makes_simple' =
@@ -1875,6 +1364,9 @@ lemma suspend_makes_inactive:
   apply (wp threadSet_pred_tcb_no_state setThreadState_st_tcb | simp)+
   done
 
+declare threadSet_sch_act_sane [wp]
+declare setThreadState_sch_act_sane [wp]
+
 lemma tcbSchedEnqueue_sch_act_not_ct[wp]:
   "\<lbrace>\<lambda>s. sch_act_not (ksCurThread s) s\<rbrace> tcbSchedEnqueue t \<lbrace>\<lambda>_ s. sch_act_not (ksCurThread s) s\<rbrace>"
   by (rule hoare_weaken_pre, wps, wp, simp)
@@ -1886,521 +1378,154 @@ lemma sts_sch_act_not_ct[wp]:
 
 text \<open>Cancelling all IPC in an endpoint or notification object\<close>
 
-global_interpretation refillUnblockCheck: typ_at_all_props' "refillUnblockCheck scp"
-  by typ_at_props'
-
-global_interpretation ifCondRefillUnblockCheck: typ_at_all_props' "ifCondRefillUnblockCheck scp act ast"
-  by typ_at_props'
-
-lemma updateSchedContext_valid_tcbs'[wp]:
-  "updateSchedContext scp f \<lbrace> valid_tcbs' \<rbrace>"
-  unfolding updateSchedContext_def setSchedContext_def getSchedContext_def
-  apply (wpsimp wp: setObject_valid_tcbs'[where P=\<top>])
-    apply (clarsimp simp: projectKOs updateObject_default_def in_monad)
-   apply (wpsimp wp: getObject_inv)
-  by simp
-
-lemma valid_refills'_tcbQueued_update[simp]:
-  "scp \<noteq> t \<Longrightarrow>
-   valid_refills' scp
-            (s\<lparr>ksPSpace := (ksPSpace s)(t \<mapsto> KOTCB (tcbQueued_update (\<lambda>_. True) tcb))\<rparr>)
-   = valid_refills' scp s"
-  by (clarsimp simp: valid_refills'_def opt_pred_def)
-
-lemma threadSet_valid_refills'[wp]:
-  "threadSet f tp \<lbrace> valid_refills' scp \<rbrace>"
-  apply (wpsimp wp: threadSet_wp)
-  by (clarsimp simp: valid_refills'_def projectKOs obj_at'_def opt_pred_def
-              dest!: opt_predD split: kernel_object.splits option.splits
-              elim!: opt_mapE)
-
-crunch setThreadState
-  for valid_refills'[wp]: "valid_refills' scp"
-
-crunch ifCondRefillUnblockCheck
-  for valid_objs'[wp]: valid_objs'
-  and valid_tcbs'[wp]: valid_tcbs'
-  (wp: hoare_vcg_if_lift2 crunch_wps simp: crunch_simps)
-
-lemma restart_thread_if_no_fault_corres:
-  "corres dc (valid_sched_action and tcb_at t and pspace_aligned and pspace_distinct
-              and valid_tcbs and active_scs_valid and current_time_bounded)
-             (valid_queues and valid_queues' and valid_release_queue_iff and valid_objs')
-             (restart_thread_if_no_fault t)
-             (restartThreadIfNoFault t)"
-    (is "corres _ _ ?conc_guard _ _")
-  apply (rule corres_cross_over_guard[where Q="?conc_guard and tcb_at' t"])
-   apply (fastforce intro: tcb_at_cross)
-  apply (clarsimp simp: restart_thread_if_no_fault_def restartThreadIfNoFault_def)
-  apply (rule corres_guard_imp)
-    apply (rule corres_split
-                  [OF threadGet_corres[where r=fault_rel_optionation] _ thread_get_wp threadGet_wp])
-     apply (clarsimp simp: tcb_relation_def)
-    apply (rule corres_if)
-      apply (clarsimp simp: fault_rel_optionation_def)
-     apply (rule corres_split[OF setThreadState_corres])
-        apply (clarsimp simp: fault_rel_optionation_def)
-       apply clarsimp
-       apply (rule corres_split_eqr[OF get_tcb_obj_ref_corres])
-          apply (clarsimp simp: tcb_relation_def)
-         apply (rule corres_split[OF ifCondRefillUnblockCheck_corres])
-           apply (rule possibleSwitchTo_corres, simp)
-          apply (wpsimp simp: if_cond_refill_unblock_check_def
-                          wp: refill_unblock_check_active_scs_valid)
-         apply wpsimp
-        apply (rule_tac Q'="\<lambda>scopt s. case_option True (\<lambda>p. sc_at p s) scopt \<and>
-                                     tcb_at t s \<and> valid_sched_action s \<and>
-                                     pspace_aligned s \<and> pspace_distinct s \<and> valid_tcbs s \<and>
-                                     active_scs_valid s \<and> current_time_bounded s"
-               in hoare_strengthen_post[rotated])
-         apply (fastforce split: option.splits simp: obj_at_def is_sc_obj opt_map_red opt_pred_def)
-        apply (wpsimp wp: thread_get_wp' simp: get_tcb_obj_ref_def)
-       apply (clarsimp simp: bool.case_eq_if option.case_eq_if)
-       apply (wpsimp wp: threadGet_wp)
-      apply (rule_tac Q'="\<lambda>scopt s. tcb_at t s \<and> valid_sched_action s \<and>
-                                   pspace_aligned s \<and> pspace_distinct s \<and> valid_tcbs s \<and>
-                                   active_scs_valid s \<and> current_time_bounded s"
-             in hoare_strengthen_post[rotated])
-       apply (fastforce split: option.split simp: valid_tcbs_def valid_tcb_def valid_bound_obj_def)
-      apply (wpsimp wp: sts_typ_ats set_thread_state_valid_sched_action)
-     apply (rule hoare_strengthen_post[where Q'="\<lambda>_ s. tcb_at' t s \<and> valid_objs' s
-                                                    \<and> valid_release_queue_iff s
-                                                    \<and> valid_queues s \<and> valid_queues' s", rotated])
-      apply (clarsimp simp: obj_at_simps)
-     apply (wpsimp wp: sts_st_tcb_at'_cases hoare_drop_imp)
-    apply (rule setThreadState_corres)
-    apply clarsimp
-   apply (clarsimp simp: obj_at_def is_tcb_def invs_def valid_state_def)
-   apply (clarsimp split: Structures_A.kernel_object.splits)
-  apply (clarsimp simp: obj_at'_def projectKOs valid_tcb_state'_def)
+lemma ep_cancel_corres_helper:
+  "corres dc ((\<lambda>s. \<forall>t \<in> set list. tcb_at t s) and valid_etcbs and valid_queues
+                                              and pspace_aligned and pspace_distinct)
+             (valid_objs' and sym_heap_sched_pointers and valid_sched_pointers)
+          (mapM_x (\<lambda>t. do
+                        y \<leftarrow> set_thread_state t Structures_A.Restart;
+                        tcb_sched_action tcb_sched_enqueue t
+                     od) list)
+          (mapM_x (\<lambda>t. do
+                        y \<leftarrow> setThreadState Structures_H.thread_state.Restart t;
+                        tcbSchedEnqueue t
+                     od) list)"
+  apply (rule_tac Q'=pspace_aligned' in corres_cross_add_guard)
+   apply (fastforce dest: pspace_aligned_cross)
+  apply (rule_tac Q'=pspace_distinct' in corres_cross_add_guard)
+   apply (fastforce dest: pspace_distinct_cross)
+  apply (rule_tac S="{t. (fst t = snd t) \<and> fst t \<in> set list}"
+                     in corres_mapM_x)
+      apply clarsimp
+      apply (rule corres_guard_imp)
+        apply (subst bind_return_unit, rule corres_split[OF _ tcbSchedEnqueue_corres])
+           apply simp
+           apply (rule corres_guard_imp [OF setThreadState_corres])
+             apply simp
+            apply (simp add: valid_tcb_state_def)
+           apply simp
+          apply simp
+         apply (wpsimp wp: sts_st_tcb_at')
+        apply (wpsimp wp: sts_valid_objs' | strengthen valid_objs'_valid_tcbs')+
+       apply fastforce
+      apply (wpsimp wp: hoare_vcg_const_Ball_lift set_thread_state_runnable_valid_queues
+                        sts_st_tcb_at' sts_valid_objs'
+                  simp: valid_tcb_state'_def)+
   done
 
-crunch possibleSwitchTo
-  for sc_at'_n[wp]: "\<lambda>s. P (sc_at'_n n p s)"
+crunch set_simple_ko
+  for ready_qs_distinct[wp]: ready_qs_distinct
+  and in_correct_ready_q[wp]: in_correct_ready_q
+  (rule: ready_qs_distinct_lift wp: crunch_wps)
 
-global_interpretation possibleSwitchTo: typ_at_all_props' "possibleSwitchTo target"
-  by typ_at_props'
-
-crunch ifCondRefillUnblockCheck
-  for pred_tcb_at'[wp]: "pred_tcb_at' proj P p"
-  and weak_sch_act_wf[wp]: "\<lambda>s. weak_sch_act_wf (ksSchedulerAction s) s"
-  and cur_tcb'[wp]: cur_tcb'
-  (simp: crunch_simps wp: whileLoop_wp)
-
-lemma cancelAllIPC_loop_body_st_tcb_at'_other:
-  "\<lbrace>\<lambda>s. st_tcb_at' P t' s \<and> tcb_at' t' s \<and> t' \<noteq> t\<rbrace>
-   cancelAllIPC_loop_body t
-   \<lbrace>\<lambda>_. st_tcb_at' P t'\<rbrace>"
-  apply (clarsimp simp: cancelAllIPC_loop_body_def restartThreadIfNoFault_def)
-  apply (rule bind_wp_fwd_skip, wpsimp)
-  apply (rule bind_wp_fwd_skip, wpsimp wp: replyUnlink_st_tcb_at')
-  apply (wpsimp wp: threadGet_wp)
-     apply (rule hoare_strengthen_post[where Q'="\<lambda>_. st_tcb_at' P t'", rotated])
-      apply (clarsimp simp: obj_at'_def)
-     apply (wpsimp wp: sts_st_tcb_at'_cases threadGet_wp)+
-  apply (clarsimp simp: obj_at'_def)
-  done
-
-lemma cancelAllIPC_loop_body_weak_sch_act_wf:
-  "\<lbrace>\<lambda>s. weak_sch_act_wf (ksSchedulerAction s) s \<and> tcb_at' t s \<and> st_tcb_at' (not runnable') t s\<rbrace>
-   cancelAllIPC_loop_body t
-   \<lbrace>\<lambda>_ s. weak_sch_act_wf (ksSchedulerAction s) s\<rbrace>"
-  apply (clarsimp simp: cancelAllIPC_loop_body_def restartThreadIfNoFault_def)
-  apply (rule bind_wp_fwd_skip, wpsimp)
-  apply (rule bind_wp_fwd_skip, wpsimp wp: replyUnlink_st_tcb_at')
-  apply (wpsimp wp: sts_st_tcb_at'_cases hoare_drop_imps)
-  apply (clarsimp simp: weak_sch_act_wf_def pred_neg_def st_tcb_at'_def obj_at'_def)
-  done
-
-crunch cancelAllIPC_loop_body
-  for valid_queues'[wp]: valid_queues'
-  and valid_release_queue[wp]: valid_release_queue
-  and valid_release_queue'[wp]: valid_release_queue'
-  and valid_objs'[wp]: valid_objs'
-  and tcb_at'[wp]: "\<lambda>s. tcb_at' threadPtr s"
-  and typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  and sc_at'_n[wp]: "\<lambda>s. P (sc_at'_n n p s)"
-  (simp: valid_tcb_state'_def crunch_simps wp: whileLoop_wp ignore: updateSchedContext)
-
-global_interpretation cancelAllIPC_loop_body: typ_at_all_props' "cancelAllIPC_loop_body t"
-  by typ_at_props'
-
-lemma cancelAllIPC_loop_body_valid_queues:
-  "\<lbrace>\<lambda>s. valid_queues s \<and> valid_tcbs' s\<rbrace>
-   cancelAllIPC_loop_body t
-   \<lbrace>\<lambda>_. valid_queues\<rbrace>"
-  apply (clarsimp simp: cancelAllIPC_loop_body_def restartThreadIfNoFault_def)
-  apply (rule bind_wp_fwd_skip, wpsimp)
-  apply (rule bind_wp_fwd_skip, wpsimp)
-   apply (clarsimp simp: weak_sch_act_wf_def pred_neg_def st_tcb_at'_def obj_at'_def)
-  apply (wpsimp wp: sts_valid_queues sts_st_tcb_at'_cases hoare_drop_imps)
-  done
-
-lemma cancelAllIPC_corres_helper:
-  "distinct list \<Longrightarrow>
-   corres dc
-          ((\<lambda>s. \<forall>t \<in> set list. blocked_on_send_recv_tcb_at t s \<and> t \<noteq> idle_thread s
-                               \<and> reply_unlink_ts_pred t s)
-            and (valid_sched and valid_tcbs and pspace_aligned and pspace_distinct
-                 and current_time_bounded and (\<lambda>s. heap_refs_inv (tcb_scps_of s) (sc_tcbs_of s))))
-          ((\<lambda>s. \<forall>t \<in> set list. tcb_at' t s)
-            and (valid_queues and valid_queues' and valid_objs' and valid_release_queue_iff))
-     (mapM_x cancel_all_ipc_loop_body list)
-     (mapM_x cancelAllIPC_loop_body list)"
-  unfolding cancel_all_ipc_loop_body_def cancelAllIPC_loop_body_def
-  apply (rule_tac S="{t. (fst t = snd t) \<and> fst t \<in> set list}" in corres_mapM_x_scheme)
-          apply clarsimp
-          apply (rename_tac t)
-          apply (rule corres_guard_imp)
-            apply (rule corres_split[OF getThreadState_corres], rename_tac st st')
-              apply (rule_tac P="\<lambda>s. blocked_on_send_recv_tcb_at t s \<and> t \<noteq> idle_thread s
-                                     \<and> reply_unlink_ts_pred t s \<and> valid_sched s \<and> valid_tcbs s
-                                     \<and> pspace_aligned s \<and> pspace_distinct s
-                                     \<and> st_tcb_at ((=) st) t s \<and> current_time_bounded s"
-                          and P'="\<lambda>s. valid_queues s \<and> valid_queues' s \<and> valid_objs' s
-                                      \<and> valid_release_queue_iff s"
-                           in corres_inst)
-              apply (case_tac "\<exists>ep r_opt pl.
-                                st = Structures_A.thread_state.BlockedOnReceive ep r_opt pl")
-               apply (clarsimp simp: when_def split: option.splits)
-               apply (intro conjI impI allI; clarsimp simp: isReceive_def)
-                apply (corresKsimp corres: restart_thread_if_no_fault_corres)
-                apply (clarsimp simp: pred_tcb_at_def obj_at_def is_tcb valid_sched_def)
-               apply (rule corres_guard_imp)
-                 apply (rule corres_split[OF replyUnlinkTcb_corres])
-                    apply (rule corres_guard_imp)
-                      apply (rule restart_thread_if_no_fault_corres)
-                     apply simp
-                    apply simp
-                  apply (wpsimp wp: reply_unlink_tcb_valid_sched_action)
-                 apply wpsimp
-                apply (fastforce simp: vs_all_heap_simps pred_tcb_at_def obj_at_def
-                                       reply_unlink_ts_pred_def)
-               apply clarsimp
-              apply (prop_tac "\<not> isReceive st'")
-               apply (case_tac st; clarsimp simp: isReceive_def)
-              apply (case_tac st
-                     ; clarsimp simp: isReceive_def
-                     ; (corresKsimp corres: restart_thread_if_no_fault_corres
-                        , fastforce simp: obj_at_def))
-             apply (wpsimp wp: gts_wp)
-            apply (wpsimp wp: gts_wp')
-           apply (clarsimp simp: vs_all_heap_simps obj_at_def is_tcb_def)
-          apply clarsimp
-         apply (fold cancel_all_ipc_loop_body_def)
-         apply (intro hoare_vcg_conj_lift_pre_fix
-                ; (solves \<open>wpsimp wp: gts_wp simp: cancel_all_ipc_loop_body_def\<close>)?)
-          apply (wpsimp wp: restart_thread_if_no_fault_tcb_sts_of_other
-                            reply_unlink_tcb_tcb_sts_of_other gts_wp
-                      simp: cancel_all_ipc_loop_body_def)
-         apply (wpsimp wp: cancel_all_ipc_loop_body_reply_unlink_ts_pred_other)
-        apply (wpsimp simp: restartThreadIfNoFault_def)
-       apply (wpsimp wp: cancel_all_ipc_loop_body_valid_sched gts_wp
-                   simp: cancel_all_ipc_loop_body_def)
-      apply (fold cancelAllIPC_loop_body_def)
-      apply (wpsimp wp: cancelAllIPC_loop_body_weak_sch_act_wf cancelAllIPC_loop_body_valid_queues)
-     apply fastforce+
-  done
-
-lemmas reply_unlink_tcb_typ_at_lifts[wp] = abs_typ_at_lifts[OF reply_unlink_tcb_typ_at]
-
-lemma in_send_ep_queue_TCBBlockedSend:
-  "\<lbrakk>kheap s epptr = Some (Endpoint (Structures_A.SendEP queue)); t \<in> set queue; invs s\<rbrakk>
-   \<Longrightarrow> (epptr, TCBBlockedSend) \<in> state_refs_of s t"
-  apply (prop_tac "valid_ep (Structures_A.SendEP queue) s")
-   apply (fastforce simp: valid_objs_def valid_obj_def dest!: invs_valid_objs)
-  apply (clarsimp simp: state_refs_of_def valid_ep_def split: option.splits)
-  apply (intro conjI impI allI; (fastforce simp: obj_at_def)?)
-  apply (prop_tac "(t, EPSend) \<in> state_refs_of s epptr", clarsimp simp: state_refs_of_def)
-  apply (clarsimp simp: sym_refs_def dest!: invs_sym_refs)
-  apply (fastforce simp: state_refs_of_def)
-  done
-
-lemma cancelAllIPC_corres:
-  "corres dc (invs and valid_sched and ep_at ep_ptr and current_time_bounded)
-             (invs' and ep_at' ep_ptr)
-             (cancel_all_ipc ep_ptr) (cancelAllIPC ep_ptr)"
+lemma ep_cancel_corres:
+  "corres dc (invs and valid_sched and ep_at ep) (invs' and ep_at' ep)
+             (cancel_all_ipc ep) (cancelAllIPC ep)"
 proof -
   have P:
-    "\<And>list. distinct list \<Longrightarrow>
-         corres dc
-          ((\<lambda>s. \<forall>t \<in> set list. blocked_on_send_recv_tcb_at t s \<and> t \<noteq> idle_thread s
-                               \<and> reply_unlink_ts_pred t s)
-            and (valid_sched and valid_tcbs and pspace_aligned and pspace_distinct and ep_at ep_ptr
-                 and current_time_bounded and (\<lambda>s. heap_refs_inv (tcb_scps_of s) (sc_tcbs_of s))))
-          ((\<lambda>s. \<forall>t \<in> set list. tcb_at' t s)
-            and (valid_queues and valid_queues' and valid_objs' and valid_release_queue_iff
-                 and ep_at' ep_ptr))
-     (do set_endpoint ep_ptr Structures_A.IdleEP;
-         mapM_x cancel_all_ipc_loop_body list;
-         reschedule_required
-      od)
-     (do setEndpoint ep_ptr IdleEP;
-         mapM_x cancelAllIPC_loop_body list;
-         rescheduleRequired
-     od)" (is "\<And>list. _ \<Longrightarrow> corres _ (?abs_guard list) (?conc_guard list) _ _")
-    apply (rule corres_guard_imp)
-      apply (rule corres_split[OF setEndpoint_corres])
-         apply (simp add: ep_relation_def)
-        apply clarsimp
-        apply (rule corres_split)
-           apply (erule cancelAllIPC_corres_helper)
-          apply (rule rescheduleRequired_corres)
-         apply (rule_tac P'="?abs_guard list" in hoare_weaken_pre)
-          apply (rule hoare_strengthen_post)
-           apply (rule ball_mapM_x_scheme)
-             apply (intro hoare_vcg_conj_lift_pre_fix
-                    ; (solves \<open>wpsimp wp: gts_wp simp: cancel_all_ipc_loop_body_def\<close>)?)
-              apply (wpsimp wp: restart_thread_if_no_fault_tcb_sts_of_other
-                                reply_unlink_tcb_tcb_sts_of_other gts_wp
-                          simp: cancel_all_ipc_loop_body_def)
-             apply (wpsimp wp: cancel_all_ipc_loop_body_reply_unlink_ts_pred_other)
-            apply (wpsimp wp: cancel_all_ipc_loop_body_valid_sched gts_wp
-                        simp: cancel_all_ipc_loop_body_def)
-           apply simp
-          apply fastforce
-         apply simp
-        apply (rule_tac P'="?conc_guard list" in hoare_weaken_pre)
-         apply (rule hoare_strengthen_post)
-          apply (rule ball_mapM_x_scheme)
-            apply (wpsimp wp: cancelAllIPC_loop_body_st_tcb_at'_other)
-           apply (wpsimp wp: cancelAllIPC_loop_body_weak_sch_act_wf
-                             cancelAllIPC_loop_body_valid_queues
-                             cancelAllIPC_loop_body_st_tcb_at'_other)
-          apply (simp add: valid_objs'_valid_tcbs')+
-       apply (wpsimp wp: hoare_vcg_all_lift hoare_vcg_const_Ball_lift hoare_vcg_imp_lift'
-                   simp: reply_unlink_ts_pred_def)+
-    apply (clarsimp simp: valid_ep'_def)
+    "\<And>list.
+     corres dc (\<lambda>s. (\<forall>t \<in> set list. tcb_at t s) \<and> valid_pspace s \<and> ep_at ep s
+                        \<and> valid_etcbs s \<and> weak_valid_sched_action s \<and> valid_queues s)
+               (\<lambda>s. (\<forall>t \<in> set list. tcb_at' t s) \<and> valid_pspace' s
+                         \<and> ep_at' ep s \<and> weak_sch_act_wf (ksSchedulerAction s) s
+                         \<and> valid_objs' s \<and> sym_heap_sched_pointers s \<and> valid_sched_pointers s)
+               (do x \<leftarrow> set_endpoint ep Structures_A.IdleEP;
+                   x \<leftarrow> mapM_x (\<lambda>t. do
+                        y \<leftarrow> set_thread_state t Structures_A.Restart;
+                        tcb_sched_action tcb_sched_enqueue t
+                     od) list;
+                   reschedule_required
+               od)
+               (do x \<leftarrow> setEndpoint ep IdleEP;
+                   x \<leftarrow> mapM_x (\<lambda>t. do
+                        y \<leftarrow> setThreadState Structures_H.thread_state.Restart t;
+                        tcbSchedEnqueue t
+                     od) list;
+                   rescheduleRequired
+                od)"
+    apply (rule corres_underlying_split)
+       apply (rule corres_guard_imp [OF setEndpoint_corres])
+         apply (simp add: ep_relation_def)+
+      apply (rule corres_split[OF _ rescheduleRequired_corres])
+        apply (rule ep_cancel_corres_helper)
+       apply (rule mapM_x_wp')
+       apply (wp weak_sch_act_wf_lift_linear set_thread_state_runnable_weak_valid_sched_action | simp)+
+      apply (rule_tac Q'="\<lambda>_ s. \<forall>x\<in>set list. tcb_at' x s \<and> valid_objs' s \<and> pspace_aligned' s \<and> pspace_distinct' s"
+                   in hoare_post_add)
+      apply (rule mapM_x_wp')
+      apply ((wpsimp wp: hoare_vcg_const_Ball_lift mapM_x_wp' sts_st_tcb' sts_valid_objs'
+                   simp: valid_tcb_state'_def
+              | strengthen valid_objs'_valid_tcbs')+)[3]
+     apply fastforce
+    apply (wp hoare_vcg_const_Ball_lift set_ep_valid_objs'
+           | (clarsimp simp: valid_ep'_def)
+           | (drule (1) bspec, clarsimp simp: valid_pspace'_def valid_tcb'_def valid_ep'_def
+           | strengthen valid_objs'_valid_tcbs'))+
     done
 
   show ?thesis
-    apply (clarsimp simp: cancel_all_ipc_def[folded cancel_all_ipc_loop_body_def]
-                          cancelAllIPC_def[folded restartThreadIfNoFault_def
-                                           , folded cancelAllIPC_loop_body_def])
-    apply (subst forM_x_def fun_app_def)+
-    apply add_sym_refs
-    apply (rule corres_stateAssert_add_assertion[rotated])
-     apply (clarsimp simp: pred_conj_def sym_refs_asrt_def)
-    apply add_sch_act_wf
-    apply (rule corres_stateAssert_add_assertion[rotated])
-     apply (clarsimp simp: sch_act_wf_asrt_def)
-    apply (rule corres_underlying_split[OF _ _ get_simple_ko_sp get_ep_sp'])
-     apply (rule corres_guard_imp [OF getEndpoint_corres]
-            ; simp add: ep_relation_def get_ep_queue_def)
-    apply (rename_tac ep ep')
-    apply (case_tac "ep = Structures_A.IdleEP \<or> ep' = Structures_H.IdleEP")
-     apply (case_tac ep; case_tac ep'; simp add: ep_relation_def get_ep_queue_def)
-    apply (simp add: endpoint.case_eq_if Structures_A.endpoint.case_eq_if del: K_bind_def)
-    apply (simp add: get_ep_queue_def Structures_A.endpoint.case_eq_if)
-    apply (rule_tac F="epQueue ep' = ep_queue ep \<and> distinct (ep_queue ep)" in corres_req)
-     apply (rule conjI; clarsimp)
-      apply (case_tac ep; clarsimp simp: ep_relation_def)
-     apply (drule (1) valid_objs_ko_at[OF invs_valid_objs])
-     apply (case_tac ep; clarsimp simp: valid_obj_def valid_ep_def)
-    apply simp
-    apply (rule corres_guard_imp)
-      apply (rule P[simplified])
-      apply simp
-     apply (clarsimp; rule conjI; (fastforce simp: invs_def)?)
-     apply clarsimp
-     apply (prop_tac "t \<noteq> idle_thread s")
-      apply (case_tac ep;
-             fastforce simp: obj_at_def invs_def valid_state_def valid_pspace_def
-                      dest!: not_idle_tcb_in_SendEp not_idle_tcb_in_RecvEp)
-     apply (prop_tac "st_tcb_at is_blocked_on_send_recv t s")
-      apply (case_tac ep; erule_tac t=t in ep_queued_st_tcb_at; (fastforce simp: invs_def)?)
-     apply (clarsimp simp: pred_tcb_at_disj tcb_at_kh_simps[symmetric] reply_unlink_ts_pred_def
-                           conj_disj_distribR is_blocked_on_receive_def is_blocked_on_send_def)
-     apply (fastforce simp: pred_tcb_at_def obj_at_def
-                     elim!: st_tcb_recv_reply_state_refs[OF _ invs_sym_refs, simplified op_equal])
-    apply (clarsimp simp: invs'_def valid_pspace'_def valid_objs'_valid_tcbs')
-    apply (fastforce dest!: ep_ko_at_valid_objs_valid_ep' simp: valid_ep'_def split: endpoint.split_asm)
+    apply (simp add: cancel_all_ipc_def cancelAllIPC_def)
+    apply (rule corres_stateAssert_ignore)
+     apply (fastforce intro: ksReadyQueues_asrt_cross)
+    apply (rule corres_underlying_split [OF _ _ get_simple_ko_sp get_ep_sp'])
+     apply (rule corres_guard_imp [OF getEndpoint_corres], simp+)
+    apply (case_tac epa, simp_all add: ep_relation_def
+                                       get_ep_queue_def)
+     apply (rule corres_guard_imp [OF P]
+             | clarsimp simp: valid_obj_def valid_ep_def
+                              valid_obj'_def valid_ep'_def
+                              invs_valid_pspace projectKOs
+                              valid_sched_def valid_sched_action_def
+             | erule obj_at_valid_objsE
+             | drule ko_at_valid_objs'
+             | rule conjI | clarsimp simp: invs'_def valid_state'_def)+
     done
 qed
 
-lemma ntfn_cancel_corres_helper:
-  "corres dc
-          ((\<lambda>s. \<forall>t \<in> set list. tcb_at t s \<and> t \<noteq> idle_thread s
-                               \<and> blocked_on_recv_ntfn_tcb_at t s)
-           and valid_sched
-           and valid_objs
-           and pspace_aligned
-           and pspace_distinct and (\<lambda>s. heap_refs_inv (tcb_scps_of s) (sc_tcbs_of s))
-           and cur_tcb and current_time_bounded
-           and K (distinct list))
-          ((\<lambda>s. \<forall>t \<in> set list. tcb_at' t s)
-           and (\<lambda>s. weak_sch_act_wf (ksSchedulerAction s) s)
-           and Invariants_H.valid_queues
-           and valid_queues'
-           and valid_objs'
-           and valid_release_queue_iff)
-          (mapM_x (\<lambda>t. do y \<leftarrow> set_thread_state t Structures_A.Restart;
-                          sc_opt <- get_tcb_obj_ref tcb_sched_context t;
-                          y <- if_sporadic_cur_sc_assert_refill_unblock_check sc_opt;
-                          possible_switch_to t
-                       od) list)
-          (mapM_x (\<lambda>t. do y \<leftarrow> setThreadState Structures_H.thread_state.Restart t;
-                          scOpt <- threadGet tcbSchedContext t;
-                          y <- ifCondRefillUnblockCheck scOpt (Some False) (Some True);
-                          possibleSwitchTo t
-                       od) list)"
-  (is "corres _ _ ?conc_guard _ _")
-  apply (rule corres_gen_asm')
-  apply (rule corres_cross_over_guard[where Q="?conc_guard and cur_tcb'"])
-   apply (fastforce simp: cur_tcb_cross)
-  apply (subst pred_conj_assoc[symmetric])+
-  apply (rule_tac S="{t. (fst t = snd t) \<and> fst t \<in> set list}" in corres_mapM_x_scheme
-         ; ((subst pred_conj_assoc)+)?)
-          apply clarsimp
-          apply (rule corres_guard_imp)
-            apply (rename_tac tp)
-            apply (rule corres_split[OF setThreadState_corres])
-               apply clarsimp
-              apply (rule corres_split_eqr[OF get_tcb_obj_ref_corres])
-                 apply (clarsimp simp: tcb_relation_def)
-                apply (rule corres_split[OF ifCondRefillUnblockCheck_corres])
-                  apply (rule possibleSwitchTo_corres, simp)
-                 apply (wpsimp simp: if_cond_refill_unblock_check_def
-                                 wp: refill_unblock_check_active_scs_valid)
-                apply wpsimp
-               apply (wpsimp wp: get_tcb_obj_ref_wp)
-              apply (wpsimp wp: threadGet_wp)
-             apply (clarsimp cong: conj_cong imp_cong all_cong)
-             apply (rule_tac Q'="\<lambda>_. pspace_aligned and pspace_distinct and current_time_bounded
-                                    and active_scs_valid and valid_tcbs
-                                    and valid_sched_action and tcb_at tp"
-                    in hoare_strengthen_post[rotated])
-              apply (fastforce simp: pred_tcb_at_def is_tcb is_sc_obj obj_at_def opt_map_red
-                                     valid_tcbs_def valid_tcb_def valid_bound_obj_def opt_pred_def
-                              split: option.splits)
-             apply (wp set_thread_state_valid_sched_action)
-            apply (simp add: option.case_eq_if bool.case_eq_if)
-            apply (rule_tac Q'="\<lambda>_. valid_queues and valid_queues' and valid_release_queue_iff
-                                   and valid_objs' and tcb_at' tp"
-                   in hoare_strengthen_post[rotated])
-             apply (clarsimp simp: valid_objs'_valid_tcbs' obj_at'_def)
-            apply (wp setThreadState_st_tcb)
-           apply force
-          apply (clarsimp simp: valid_tcb_state'_def)
-         apply (wpsimp wp: set_thread_state_pred_map_tcb_sts_of)
-        apply (wpsimp wp: typ_at_lifts)
-       apply (clarsimp simp: pred_conj_def)
-       apply (rename_tac tp)
-       apply (wpsimp wp: get_tcb_obj_ref_wp possible_switch_to_valid_sched_weak hoare_vcg_imp_lift')
-        apply (rule_tac Q'="\<lambda>_ s. tcb_at tp s \<longrightarrow>
-                                   (bound (tcb_scps_of s tp) \<longrightarrow>  not_in_release_q tp s)
-                                   \<and> current_time_bounded s
-                                   \<and> heap_refs_inv (tcb_scps_of s) (sc_tcbs_of s)
-                                   \<and> (pred_map (\<lambda>a. \<exists>y. a = Some y) (tcb_scps_of s) tp
-                                       \<and> not_in_release_q tp s
-                                           \<longrightarrow> pred_map runnable (tcb_sts_of s) tp
-                                               \<and> released_sc_tcb_at tp s
-                                               \<and> active_scs_valid s
-                                               \<and> tp \<noteq> idle_thread s)
-                                   \<and> pspace_distinct s \<and>  cur_tcb s \<and> valid_objs s
-                                   \<and>  pspace_aligned s
-                                   \<and> valid_sched_except_blocked s
-                                   \<and> valid_blocked_except tp s"
-                in hoare_strengthen_post[rotated])
-         apply (clarsimp simp: obj_at_def is_tcb vs_all_heap_simps opt_map_red)
-         apply (rename_tac scp t tcb' sc n)
-         apply (clarsimp simp: heap_refs_inv_def2)
-         apply (frule_tac x=tp and y=scp in spec2)
-         apply (drule_tac x=t and y=scp in spec2)
-         apply (clarsimp simp: pred_map_eq vs_all_heap_simps opt_map_red)
-        apply (wpsimp wp: set_thread_state_pred_map_tcb_sts_of possible_switch_to_valid_sched_weak
-                          set_thread_state_break_valid_sched[simplified pred_conj_def]
-                          hoare_vcg_imp_lift')
-       apply clarsimp
-       apply (rule conjI, clarsimp simp: tcb_at_kh_simps[symmetric])
-        apply (drule valid_release_q_not_in_release_q_not_runnable[OF valid_sched_valid_release_q])
-         apply (erule pred_tcb_weakenE)
-         apply (clarsimp simp: is_blocked_thread_state_defs)
-         apply (case_tac "itcb_state tcb"; simp)
-        apply clarsimp
-       apply clarsimp
-       apply (rule conjI)
-        apply (frule valid_sched_released_ipc_queues)
-        apply (fastforce simp: released_ipc_queues_defs vs_all_heap_simps)
-       apply (erule valid_sched_active_scs_valid)
-      apply (wpsimp wp: hoare_vcg_const_Ball_lift typ_at_lifts sts_st_tcb')
-     apply (auto simp: valid_tcb_state'_def)
+(* FIXME move *)
+lemma set_ntfn_tcb_obj_at' [wp]:
+  "\<lbrace>obj_at' (P::tcb \<Rightarrow> bool) t\<rbrace>
+     setNotification ntfn v
+   \<lbrace>\<lambda>_. obj_at' P t\<rbrace>"
+  apply (clarsimp simp: setNotification_def, wp)
   done
-
-lemma refill_unblock_check_weak_valid_sched_action[wp]:
-  "\<lbrace>weak_valid_sched_action and active_scs_valid\<rbrace>
-   refill_unblock_check sc_ptr
-   \<lbrace>\<lambda>rv. weak_valid_sched_action\<rbrace>"
-  apply (clarsimp simp: weak_valid_sched_action_def)
-  apply (wpsimp wp: hoare_vcg_all_lift hoare_vcg_imp_lift'')
-  done
-
-crunch if_cond_refill_unblock_check
-  for weak_valid_sched_action[wp]: weak_valid_sched_action
-  (simp: crunch_simps)
 
 lemma cancelAllSignals_corres:
-  "corres dc (invs and valid_sched and ntfn_at ntfn and current_time_bounded)
-             (invs' and ntfn_at' ntfn)
+  "corres dc (invs and valid_sched and ntfn_at ntfn) (invs' and ntfn_at' ntfn)
              (cancel_all_signals ntfn) (cancelAllSignals ntfn)"
-  apply add_sch_act_wf
   apply (simp add: cancel_all_signals_def cancelAllSignals_def)
-  apply add_sym_refs
-  apply (intro corres_stateAssert_add_assertion)
-    apply (rule corres_underlying_split [OF _ _ get_simple_ko_sp get_ntfn_sp'])
-     apply (rule corres_guard_imp [OF getNotification_corres])
-      apply simp+
-    apply (case_tac "ntfn_obj ntfna", simp_all add: ntfn_relation_def)
-    apply (rule corres_guard_imp)
-      apply (rule corres_split[OF setNotification_corres])
-         apply (simp add: ntfn_relation_def)
-        apply (rule corres_split [OF ntfn_cancel_corres_helper])
-          apply (rule rescheduleRequired_corres)
-         apply (simp add: dc_def)
-         apply (rename_tac list)
-         apply (rule_tac Q'="\<lambda>_ s. (\<forall>x\<in>set list. released_if_bound_sc_tcb_at x s)
-                                  \<and> current_time_bounded s"
-                in hoare_post_add)
-         apply (rule mapM_x_wp')
-         apply wpsimp
-            apply (wpsimp wp: hoare_vcg_ball_lift hoare_vcg_imp_lift)
-           apply (wpsimp wp: get_tcb_obj_ref_wp)
-          apply (wpsimp wp: set_thread_state_weak_valid_sched_action
-                            set_thread_state_pred_map_tcb_sts_of hoare_vcg_imp_lift
-                      simp: disj_imp)
-           apply (rule hoare_pre_cont)
-          apply (wpsimp wp: set_thread_state_weak_valid_sched_action
-                            set_thread_state_pred_map_tcb_sts_of hoare_vcg_imp_lift)
-         apply clarsimp
-         apply (rule conjI; clarsimp)
-          apply fastforce
-         apply (fastforce simp: vs_all_heap_simps)
-        apply (rename_tac list)
-        apply (rule_tac Q'="\<lambda>_ s. weak_sch_act_wf (ksSchedulerAction s) s"
-               in hoare_post_add)
-        apply (rule mapM_x_wp')
-        apply (rule hoare_name_pre_state)
-        apply (wpsimp wp: hoare_vcg_const_Ball_lift
-                          sts_st_tcb' setThreadState_not_st
-                    simp: valid_tcb_state'_def)
-       apply (wpsimp wp: hoare_vcg_const_Ball_lift)+
-     apply (clarsimp simp: invs_def valid_state_def valid_pspace_def)
-     apply (erule (1) obj_at_valid_objsE)
-     apply (frule valid_sched_active_scs_valid)
-     apply (clarsimp simp: valid_obj_def valid_ntfn_def not_idle_tcb_in_waitingntfn
-                           valid_sched_weak_valid_sched_action
-                    dest!: valid_objs_valid_tcbs)
-     apply (clarsimp simp: ball_conj_distrib[symmetric])
-     apply (rename_tac q s t)
-     apply (rule context_conjI)
-      apply (drule_tac x=ntfn and y=t and tp=TCBSignal in sym_refsE
-             ; clarsimp simp: in_state_refs_of_iff refs_of_rev vs_all_heap_simps)
-     apply (clarsimp simp: valid_sched_released_ipc_queues released_ipc_queues_blocked_on_recv_ntfn_E1)
-    apply clarsimp
-    apply (frule invs'_valid_tcbs')
-    apply (fastforce simp: invs'_def valid_ntfn'_def
-                           valid_obj'_def projectKOs sym_refs_asrt_def sch_act_wf_asrt_def
-           | drule ko_at_valid_objs')+
+  apply (rule corres_stateAssert_ignore)
+   apply (fastforce intro: ksReadyQueues_asrt_cross)
+  apply (rule corres_underlying_split [OF _ _ get_simple_ko_sp get_ntfn_sp'])
+   apply (rule corres_guard_imp [OF getNotification_corres])
+    apply simp+
+  apply (case_tac "ntfn_obj ntfna", simp_all add: ntfn_relation_def)
+  apply (rule corres_guard_imp)
+    apply (rule corres_split[OF setNotification_corres])
+       apply (simp add: ntfn_relation_def)
+      apply (rule corres_split[OF _ rescheduleRequired_corres])
+        apply (rule ep_cancel_corres_helper)
+       apply (wp mapM_x_wp'[where 'b="det_ext state"]
+                 weak_sch_act_wf_lift_linear
+                 set_thread_state_runnable_weak_valid_sched_action
+            | simp)+
+      apply (rename_tac list)
+      apply (rule_tac Q'="\<lambda>_ s. (\<forall>x\<in>set list. tcb_at' x s) \<and> valid_objs' s
+                               \<and> sym_heap_sched_pointers s \<and> valid_sched_pointers s \<and> valid_objs' s
+                               \<and> pspace_aligned' s \<and> pspace_distinct' s"
+                   in hoare_post_add)
+      apply (rule mapM_x_wp')
+      apply (rule hoare_name_pre_state)
+      apply (wpsimp wp: hoare_vcg_const_Ball_lift sts_st_tcb' sts_valid_objs'
+                  simp: valid_tcb_state'_def
+             | strengthen valid_objs'_valid_tcbs')+
+     apply (wp hoare_vcg_const_Ball_lift set_ntfn_aligned' set_ntfn_valid_objs'
+               weak_sch_act_wf_lift_linear
+          | simp)+
+   apply (clarsimp simp: invs'_def valid_state'_def invs_valid_pspace valid_obj_def valid_ntfn_def
+                         invs_weak_sch_act_wf valid_ntfn'_def valid_pspace'_def
+                         valid_sched_def valid_sched_action_def valid_obj'_def projectKOs
+          | erule obj_at_valid_objsE | drule ko_at_valid_objs' | fastforce)+
   done
 
 lemma ep'_Idle_case_helper:
@@ -2430,148 +1555,82 @@ proof -
      \<lbrace>\<lambda>_ s. ksSchedulerAction s \<noteq> ResumeCurrentThread\<rbrace>"
     by (rule hoare_strengthen_post [OF rescheduleRequired_notresume], simp)
   show ?thesis
-  apply (simp add: setThreadState_def scheduleTCB_def)
-  apply (wpsimp wp: hoare_vcg_imp_lift [OF nrct] isSchedulable_wp hoare_vcg_if_lift2)
+  apply (simp add: setThreadState_def)
+  apply (wpsimp wp: hoare_vcg_imp_lift [OF nrct])
    apply (rule_tac Q'="\<lambda>_. ?PRE" in hoare_post_imp)
-    apply clarsimp
-   apply (rule hoare_convert_imp [OF threadSet.ksSchedulerAction threadSet.ct])
+    apply (clarsimp)
+   apply (rule hoare_convert_imp [OF threadSet_nosch threadSet_ct])
   apply assumption
   done
 qed
 
-lemma replyUnlink_valid_irq_node'[wp]:
-  "replyUnlink r t \<lbrace>\<lambda> s. valid_irq_node' (irq_node' s) s\<rbrace>"
-  unfolding replyUnlink_def
-  by (wpsimp wp: valid_irq_node_lift gts_wp')
-
-lemma replyUnlink_ksQ[wp]:
-  "\<lbrace>\<lambda>s. P (ksReadyQueues s p) t\<rbrace>
-   replyUnlink r t
-   \<lbrace>\<lambda>_ s. P (ksReadyQueues s p) t\<rbrace>"
-  unfolding replyUnlink_def
-  by (wpsimp wp: gts_wp' sts_ksQ)
-
-lemma weak_sch_act_wf_D1:
-  "weak_sch_act_wf sa s \<Longrightarrow> (\<forall>t. sa = SwitchToThread t \<longrightarrow> st_tcb_at' runnable' t s)"
-  by (simp add: weak_sch_act_wf_def)
-
-lemma updateSchedContext_valid_pspace'[wp]:
-  "\<lbrace>valid_pspace' and
-    (\<lambda>s. \<forall>sc. (valid_sched_context' sc s \<longrightarrow> valid_sched_context' (f sc) s)
-              \<and> (valid_sched_context_size' sc \<longrightarrow> valid_sched_context_size' (f sc)))\<rbrace>
-   updateSchedContext scp f
-   \<lbrace>\<lambda>_. valid_pspace'\<rbrace>"
-  unfolding updateSchedContext_def
-  apply wpsimp
-  by (fastforce simp: obj_at'_def projectKOs valid_obj'_def)
-
-lemma refillPopHead_valid_pspace'[wp]:
-  "\<lbrace>valid_pspace' and (\<lambda>s. ((\<lambda>n. 1 < n) |< (scs_of' s ||> scRefillCount)) scp)\<rbrace>
-   refillPopHead scp
-   \<lbrace>\<lambda>_. valid_pspace'\<rbrace>"
-  unfolding refillPopHead_def updateSchedContext_def
-  apply (wpsimp wp: whileLoop_valid_inv)
-  by (fastforce simp: obj_at'_def projectKOs valid_obj'_def refillNextIndex_def MIN_REFILLS_def
-                      valid_sched_context'_def valid_sched_context_size'_def scBits_simps objBits_simps
-               dest!: opt_predD
-               elim!: opt_mapE)
-
-lemma refillUnblockCheck_ko_wp_at_not_live[wp]:
-  "refillUnblockCheck scp \<lbrace>\<lambda>s. P (ko_wp_at' (Not \<circ> live') p' s)\<rbrace>"
-  unfolding refillUnblockCheck_def refillHeadOverlappingLoop_def mergeRefills_def
-  apply (wpsimp wp: whileLoop_valid_inv updateSchedContext_wp hoare_drop_imps
-              simp: updateRefillHd_def refillPopHead_def)
-        apply (clarsimp simp: ko_wp_at'_def obj_at'_def projectKOs runReaderT_def
-                              opt_map_red refillNextIndex_def
-                   split del: if_split
-                       elim!: rsubst[where P=P])
-        apply (frule refillHeadOverlapping_implies_count_greater_than_one)
-         apply (fastforce simp: obj_at'_def projectKOs)
-        apply (rule iffI; clarsimp simp: opt_map_red split: if_splits)
-            apply (fastforce simp: objBits_simps' live_sc'_def)+
-         apply (clarsimp simp: ps_clear_upd)+
-       apply (wpsimp wp: updateSchedContext_wp simp: updateRefillHd_def)
-      apply (wpsimp wp: hoare_drop_imps refillReady_wp isRoundRobin_wp simp: setReprogramTimer_def)+
-  apply (clarsimp simp: ko_wp_at'_def obj_at'_def projectKOs opt_map_red
-             split del: if_split
-                 elim!: rsubst[where P=P])
-  apply (intro iffI; clarsimp simp: opt_map_red)
-   apply (fold fun_upd_def)
-   apply (fastforce simp: objBits_simps')
-  apply (clarsimp simp: opt_map_red ps_clear_upd split: if_splits)
-  done
-
-lemma refillUnblockCheck_refs_of'[wp]:
-  "refillUnblockCheck sc_ptr \<lbrace>\<lambda>s. P (state_refs_of' s)\<rbrace>"
-  unfolding refillUnblockCheck_def refillHeadOverlappingLoop_def mergeRefills_def
-  apply (wpsimp simp: updateRefillHd_def refillPopHead_def
-                  wp: hoare_drop_imp whileLoop_valid_inv isRoundRobin_wp updateSchedContext_wp)
-        apply (clarsimp simp: runReaderT_def elim!: rsubst[where P=P])
-        apply (clarsimp simp: obj_at'_def projectKOs opt_map_red refillNextIndex_def)
-        apply (fastforce simp: state_refs_of'_def get_refs_def2 ps_clear_upd objBits_simps option.case_eq_if
-                        split: if_splits)
-       apply (wpsimp wp: updateSchedContext_wp refillReady_wp isRoundRobin_wp
-                   simp: updateRefillHd_def setReprogramTimer_def)+
-  apply (fold fun_upd_def)
-  apply (clarsimp simp: obj_at'_def projectKOs opt_map_red
-                intro!: ext elim!: rsubst[where P=P])
-  apply (fastforce simp: state_refs_of'_def get_refs_def2 ps_clear_upd objBits_simps option.case_eq_if
-                  split: if_splits)
-  done
-
-crunch ifCondRefillUnblockCheck
-  for ex_nonz_cap_to'[wp]: "ex_nonz_cap_to' t"
-  and valid_pspace'[wp]: valid_pspace'
-  and list_refs_of_replies'[wp]: "\<lambda>s. P (list_refs_of_replies' s)"
-  and if_live_then_nonz_cap'[wp]: if_live_then_nonz_cap'
-  and irq_node'[wp]: "\<lambda>s. P (irq_node' s)"
-  and valid_machine_state'[wp]: valid_machine_state'
-  and ksInterrupt[wp]: "\<lambda>s. P (ksInterruptState s)"
-  and unlive[wp]: "ko_wp_at' (Not \<circ> live') p"
-  and refs_of'[wp]: "\<lambda>s. P (state_refs_of' s)"
-  (wp: crunch_wps simp: crunch_simps valid_pspace'_def ignore: threadSet)
+lemma tcbSchedEnqueue_valid_pspace'[wp]:
+  "tcbSchedEnqueue tcbPtr \<lbrace>valid_pspace'\<rbrace>"
+  unfolding valid_pspace'_def
+  by wpsimp
 
 lemma cancel_all_invs'_helper:
-  "\<lbrace>invs' and (\<lambda>s. sch_act_wf (ksSchedulerAction s) s)
-    and (\<lambda>s. (\<forall>x \<in> set q.
-                tcb_at' x s \<and> ex_nonz_cap_to' x s \<and> sch_act_not x s \<and>
-                st_tcb_at' (\<lambda>st. (\<exists>obj grant reply. st = BlockedOnReceive obj grant reply) \<or>
-                           (\<exists>obj badge grant grantreply iscall.
-                            st = BlockedOnSend obj badge grant grantreply iscall)) x s)
-         \<and> distinct q)\<rbrace>
-   mapM_x (\<lambda>t. do st <- getThreadState t;
-                  y <- case if isReceive st then replyObject st else None of None \<Rightarrow> return () | Some x \<Rightarrow> replyUnlink x t;
-                  fault <- threadGet tcbFault t;
-                  if fault = None then do y <- setThreadState Structures_H.thread_state.Restart t;
-                                          scOpt <- threadGet tcbSchedContext t;
-                                          y \<leftarrow> ifCondRefillUnblockCheck scOpt (Some False) (Some True);
-                                          possibleSwitchTo t
-                                       od
-                  else setThreadState Structures_H.thread_state.Inactive t
-               od) q
-   \<lbrace>\<lambda>rv. invs'\<rbrace>"
-  supply if_split[split del] comp_apply[simp del]
-  unfolding valid_dom_schedule'_def invs'_def
+  "\<lbrace>all_invs_but_sym_refs_ct_not_inQ' and (\<lambda>s. \<forall>x \<in> set q. tcb_at' x s)
+         and (\<lambda>s. sym_refs (\<lambda>x. if x \<in> set q then {r \<in> state_refs_of' s x. snd r = TCBBound}
+                                else state_refs_of' s x)
+                \<and>  (\<forall>x \<in> set q. ex_nonz_cap_to' x s))\<rbrace>
+     mapM_x (\<lambda>t. do
+                   y \<leftarrow> setThreadState Structures_H.thread_state.Restart t;
+                   tcbSchedEnqueue t
+                 od) q
+   \<lbrace>\<lambda>rv. all_invs_but_ct_not_inQ'\<rbrace>"
   apply (rule mapM_x_inv_wp2)
    apply clarsimp
-  apply (wpsimp wp: valid_irq_node_lift valid_irq_handlers_lift'' irqs_masked_lift
-                    hoare_vcg_const_Ball_lift sts_st_tcb' setThreadState_not_st
-                    possibleSwitchTo_sch_act_not_other)
-       apply (strengthen weak_sch_act_wf_D1)
-       apply (wpsimp wp: valid_irq_node_lift hoare_vcg_const_Ball_lift
-                         sts_valid_queues sts_st_tcb' setThreadState_not_st sts_sch_act'
-                  split: if_splits)+
-     apply (wp hoare_drop_imp)
-    apply (wpsimp wp: hoare_vcg_const_Ball_lift hoare_vcg_all_lift gts_wp' hoare_vcg_imp_lift
-                      replyUnlink_valid_objs' replyUnlink_st_tcb_at'
-                simp: valid_tcb_state'_def)+
-  apply (rule conjI)
-   apply (fastforce simp: global'_no_ex_cap pred_tcb_at'_def obj_at'_def)
+  apply (rule hoare_pre)
+   apply (wp valid_irq_node_lift valid_irq_handlers_lift'' irqs_masked_lift
+             hoare_vcg_const_Ball_lift untyped_ranges_zero_lift sts_st_tcb' sts_valid_objs'
+        | simp add: cteCaps_of_def o_def)+
+  apply (unfold fun_upd_apply Invariants_H.tcb_st_refs_of'_simps)
   apply clarsimp
-  apply (apply_conjunct \<open>intro impI\<close>,
-         (frule (1) valid_replies'_other_state; clarsimp))+
-  apply (fastforce simp: global'_no_ex_cap)
+  apply (intro conjI)
+  apply (clarsimp simp: valid_tcb_state'_def global'_no_ex_cap
+                 elim!: rsubst[where P=sym_refs]
+                 dest!: set_mono_suffix
+                intro!: ext
+       | (drule (1) bspec, clarsimp simp: valid_pspace'_def valid_tcb'_def))+
   done
+
+lemma ep_q_refs_max:
+  "\<lbrakk> ko_at' r p s; sym_refs (state_refs_of' s); r \<noteq> IdleEP \<rbrakk>
+      \<Longrightarrow> (state_refs_of' s p \<subseteq> (set (epQueue r) \<times> {EPSend, EPRecv}))
+       \<and> (\<forall>x\<in>set (epQueue r). \<exists>ntfnptr. state_refs_of' s x \<subseteq>
+                                  {(p, TCBBlockedSend), (p, TCBBlockedRecv), (ntfnptr, TCBBound)})"
+  apply (frule(1) sym_refs_ko_atD')
+  apply (drule ko_at_state_refs_ofD')
+  apply (case_tac r)
+    apply (clarsimp simp: st_tcb_at_refs_of_rev' tcb_bound_refs'_def
+             | rule conjI | drule(1) bspec | drule st_tcb_at_state_refs_ofD'
+             | case_tac ntfnptr)+
+  done
+
+crunch setEndpoint
+  for ct'[wp]: "\<lambda>s. P (ksCurThread s)"
+  (wp: setObject_ep_ct)
+
+crunch setNotification
+  for ct'[wp]: "\<lambda>s. P (ksCurThread s)"
+  (wp: setObject_ntfn_ct)
+
+lemma tcbSchedEnqueue_cur_tcb'[wp]:
+  "\<lbrace>cur_tcb'\<rbrace> tcbSchedEnqueue t \<lbrace>\<lambda>_. cur_tcb'\<rbrace>"
+  by (simp add: tcbSchedEnqueue_def unless_def)
+     (wp threadSet_cur setQueue_cur | simp)+
+
+lemma rescheduleRequired_invs'[wp]:
+  "\<lbrace>invs'\<rbrace> rescheduleRequired \<lbrace>\<lambda>rv. invs'\<rbrace>"
+  apply (simp add: rescheduleRequired_def)
+  apply (wp ssa_invs' | simp | wpc)+
+  done
+
+lemma invs_rct_ct_activatable':
+  "\<lbrakk> invs' s; ksSchedulerAction s = ResumeCurrentThread \<rbrakk>
+   \<Longrightarrow> st_tcb_at' activatable' (ksCurThread s) s"
+  by (simp add: invs'_def valid_state'_def ct_in_state'_def)
 
 lemma not_in_epQueue:
   assumes ko_at:  "ko_at' r ep_ptr s" and
@@ -2604,11 +1663,11 @@ lemma not_in_epQueue:
        apply (drule state_refs_of'_elemD)
        apply (simp add: st_tcb_at_refs_of_rev')
        apply (erule pred_tcb'_weakenE)
-       apply (clarsimp simp: isBlockedOnReply_def)
+       apply (clarsimp)
       apply (drule state_refs_of'_elemD)
       apply (simp add: st_tcb_at_refs_of_rev')
       apply (erule pred_tcb'_weakenE)
-      apply (clarsimp simp: isBlockedOnReply_def)
+      apply (clarsimp)
       done
 
     with st_act show False
@@ -2643,11 +1702,9 @@ lemma not_in_ntfnQueue:
       apply (drule ko_at_state_refs_ofD')
       apply (case_tac "ntfnObj r")
         apply (clarsimp simp: st_tcb_at_refs_of_rev' ntfn_bound_refs'_def
-               | drule st_tcb_at_state_refs_ofD')+
-        apply (drule_tac x="(t, NTFNSignal)" in bspec, clarsimp)
-        apply (clarsimp simp: st_tcb_at_refs_of_rev' sym_refs_def dest!: st_tcb_at_state_refs_ofD')
-       apply (fastforce simp: st_tcb_at_refs_of_rev' sym_refs_def dest!: st_tcb_at_state_refs_ofD')
-      apply (metis (full_types, opaque_lifting) sym_refs_simp symreftype.simps(3))
+             | drule st_tcb_at_state_refs_ofD')+
+      apply (drule_tac x="(t, NTFNSignal)" in bspec, clarsimp)
+      apply (clarsimp simp: st_tcb_at_refs_of_rev' dest!: st_tcb_at_state_refs_ofD')
       done
 
     with ko_at have "st_tcb_at' (Not \<circ> simple') t s"
@@ -2655,7 +1712,7 @@ lemma not_in_ntfnQueue:
       apply (drule state_refs_of'_elemD)
       apply (simp add: st_tcb_at_refs_of_rev')
       apply (erule pred_tcb'_weakenE)
-      apply (clarsimp simp: isBlockedOnReply_def)
+      apply (clarsimp)
       done
 
     with st_act show False
@@ -2671,202 +1728,158 @@ lemma ct_not_in_ntfnQueue:
   using assms unfolding ct_in_state'_def
   by (rule not_in_ntfnQueue)
 
+crunch rescheduleRequired
+  for valid_pspace'[wp]: "valid_pspace'"
+crunch rescheduleRequired
+  for valid_global_refs'[wp]: "valid_global_refs'"
+crunch rescheduleRequired
+  for valid_machine_state'[wp]: "valid_machine_state'"
+
 lemma sch_act_wf_weak[elim!]:
   "sch_act_wf sa s \<Longrightarrow> weak_sch_act_wf sa s"
   by (case_tac sa, (simp add: weak_sch_act_wf_def)+)
 
+lemma rescheduleRequired_all_invs_but_ct_not_inQ:
+  "\<lbrace>all_invs_but_ct_not_inQ'\<rbrace> rescheduleRequired \<lbrace>\<lambda>_. invs'\<rbrace>"
+  apply (simp add: invs'_def valid_state'_def)
+  apply (rule hoare_pre)
+   apply (wp rescheduleRequired_ct_not_inQ
+             valid_irq_node_lift valid_irq_handlers_lift''
+             irqs_masked_lift cur_tcb_lift
+             untyped_ranges_zero_lift
+             | simp add: cteCaps_of_def o_def)+
+  apply (auto simp: sch_act_wf_weak)
+  done
+
 lemma cancelAllIPC_invs'[wp]:
-  "cancelAllIPC ep_ptr \<lbrace>invs'\<rbrace>"
-  supply valid_dom_schedule'_def[simp]
-  unfolding cancelAllIPC_def cancelAllIPC_loop_body_def restartThreadIfNoFault_def
-  apply (simp add: ep'_Idle_case_helper cong del: if_cong)
-  apply (intro bind_wp[OF _ stateAssert_sp])
-  apply (wpsimp wp: rescheduleRequired_invs' cancel_all_invs'_helper
-                    hoare_vcg_const_Ball_lift
-                    valid_global_refs_lift' valid_arch_state_lift'
-                    valid_irq_node_lift ssa_invs' sts_sch_act' getEndpoint_wp
-                    irqs_masked_lift)
-    apply (clarsimp simp: invs'_def valid_ep'_def)
-    apply (wpsimp wp: hoare_vcg_const_Ball_lift)
-   apply (wpsimp wp: getEndpoint_wp)
-  apply (clarsimp simp: invs'_def valid_ep'_def)
+  "\<lbrace>invs'\<rbrace> cancelAllIPC ep_ptr \<lbrace>\<lambda>rv. invs'\<rbrace>"
+  apply (simp add: cancelAllIPC_def ep'_Idle_case_helper cong del: if_cong)
+  apply (rule bind_wp[OF _ stateAssert_sp])
+  apply (wp rescheduleRequired_all_invs_but_ct_not_inQ
+            cancel_all_invs'_helper hoare_vcg_const_Ball_lift
+            valid_global_refs_lift' valid_arch_state_lift'
+            valid_irq_node_lift ssa_invs' sts_sch_act'
+            irqs_masked_lift
+         | simp only: sch_act_wf.simps forM_x_def | simp)+
+   prefer 2
+   apply assumption
+  apply (rule hoare_strengthen_post [OF get_ep_sp'])
+  apply (rename_tac rv s)
+  apply (clarsimp simp: invs'_def valid_state'_def valid_ep'_def)
   apply (frule obj_at_valid_objs', fastforce)
   apply (clarsimp simp: projectKOs valid_obj'_def)
   apply (rule conjI)
-   apply (metis fold_list_refs_of_replies')
-  apply (clarsimp simp: sym_refs_asrt_def sch_act_wf_asrt_def)
-  apply (rule conjI)
+   apply (case_tac rv, simp_all add: valid_ep'_def)[1]
+  apply (rule conjI[rotated])
    apply (drule(1) sym_refs_ko_atD')
-   apply (clarsimp simp: valid_ep'_def st_tcb_at_refs_of_rev' split: endpoint.splits)
-     apply (intro conjI)
-      apply ((drule(1) bspec | drule st_tcb_at_state_refs_ofD'
-              | clarsimp elim!: if_live_state_refsE split: if_splits)+)[1]
-     apply (fastforce simp: runnable'_def st_tcb_at'_def obj_at'_def)
-    apply (fastforce elim!: pred_tcb'_weakenE)
-   apply (intro conjI)
-     apply ((drule(1) bspec | drule st_tcb_at_state_refs_ofD'
-             | clarsimp elim!: if_live_state_refsE split: if_splits)+)[1]
-    apply (fastforce simp: runnable'_def st_tcb_at'_def obj_at'_def)
-   apply (fastforce elim!: pred_tcb'_weakenE)
-  apply (clarsimp simp: valid_ep'_def split: endpoint.splits)
-  done
-
-lemma ex_nonz_cap_to'_tcb_in_WaitingNtfn'_q:
-  "\<lbrakk>ko_at' ntfn ntfnPtr s; ntfnObj ntfn = Structures_H.ntfn.WaitingNtfn q; valid_objs' s;
-    sym_refs (state_refs_of' s); if_live_then_nonz_cap' s; t \<in> set q\<rbrakk>
-   \<Longrightarrow> ex_nonz_cap_to' t s"
-  apply (clarsimp simp: sym_refs_def)
-  apply (erule_tac x = ntfnPtr in allE)
-  apply (drule_tac x = "(t, NTFNSignal)" in bspec)
-   apply (clarsimp simp: state_refs_of'_def obj_at'_def refs_of'_def projectKOs)
-  apply (fastforce intro: if_live_state_refsE)
-  done
-
-lemma cancelAllSignals_invs'_helper:
-  "\<lbrace>invs' and (\<lambda>s. sch_act_wf (ksSchedulerAction s) s)
-    and (\<lambda>s. (\<forall>x \<in> set q. st_tcb_at' (\<lambda>st. \<exists>ref. st = BlockedOnNotification ref) x s
-                          \<and> ex_nonz_cap_to' x s))
-    and K (distinct q)\<rbrace>
-    mapM_x (\<lambda>t. do y <- setThreadState Structures_H.thread_state.Restart t;
-                        scOpt <- threadGet tcbSchedContext t;
-                        y \<leftarrow> ifCondRefillUnblockCheck scOpt (Some False) (Some True);
-                        possibleSwitchTo t
-                od) q
-   \<lbrace>\<lambda>rv. invs'\<rbrace>"
-  unfolding valid_dom_schedule'_def invs'_def
-  apply (rule hoare_gen_asm)
-  apply (rule mapM_x_inv_wp2)
-   apply clarsimp
-  apply (wpsimp wp: sts_st_tcb_at'_cases valid_irq_node_lift irqs_masked_lift
-                    hoare_vcg_const_Ball_lift hoare_vcg_all_lift hoare_vcg_imp_lift'
-              simp: cteCaps_of_def o_def)
-  apply (fastforce simp: valid_tcb_state'_def global'_no_ex_cap
-                         pred_tcb_at'_def obj_at'_def distinct_imply_not_in_tail)
-  done
-
-lemma ntfn_queued_st_tcb_at':
-  "\<And>P. \<lbrakk>ko_at' ntfn ptr s; (t, rt) \<in> ntfn_q_refs_of' (ntfnObj ntfn);
-         valid_objs' s; sym_refs (state_refs_of' s);
-         \<And>ref. P (BlockedOnNotification ref) \<rbrakk>
-   \<Longrightarrow> st_tcb_at' P t s"
-  apply (case_tac "ntfnObj ntfn", simp_all)
-  apply (frule(1) sym_refs_ko_atD')
-  apply (clarsimp)
-  apply (erule_tac y="(t,NTFNSignal)" in my_BallE)
-   apply (clarsimp simp: refs_of_rev' pred_tcb_at'_def obj_at'_def ko_wp_at'_def projectKOs)+
+   apply (case_tac rv, simp_all add: st_tcb_at_refs_of_rev')[1]
+    apply (clarsimp elim!: if_live_state_refsE
+           | drule(1) bspec | drule st_tcb_at_state_refs_ofD')+
+  apply (drule(2) ep_q_refs_max)
+  apply (erule delta_sym_refs)
+   apply (clarsimp dest!: symreftype_inverse' split: if_split_asm | drule(1) bspec subsetD)+
   done
 
 lemma cancelAllSignals_invs'[wp]:
-  "cancelAllSignals ntfnPtr \<lbrace>invs'\<rbrace>"
+  "\<lbrace>invs'\<rbrace> cancelAllSignals ntfn \<lbrace>\<lambda>rv. invs'\<rbrace>"
   apply (simp add: cancelAllSignals_def)
-  apply (intro bind_wp[OF _ stateAssert_sp])
-  apply (rule bind_wp[OF _ get_ntfn_sp'])
-  apply (case_tac "ntfnObj ntfn"; simp)
-    apply wpsimp
-   apply wpsimp
-  apply (wpsimp wp: rescheduleRequired_invs' sts_st_tcb_at'_cases
-                    cancelAllSignals_invs'_helper hoare_vcg_const_Ball_lift
-                    hoare_drop_imps hoare_vcg_all_lift
-              simp: valid_dom_schedule'_def)
-   apply (clarsimp simp: invs'_def valid_dom_schedule'_def)
-   apply (wpsimp wp: hoare_vcg_const_Ball_lift)
-  apply (clarsimp simp: invs'_def valid_pspace'_def valid_ntfn'_def
-                        valid_dom_schedule'_def)
-  apply (prop_tac "valid_ntfn' ntfn s")
-   apply (frule (2) ntfn_ko_at_valid_objs_valid_ntfn')
-  apply (clarsimp simp: valid_ntfn'_def)
-  apply (intro conjI impI)
-    apply (clarsimp simp: list_refs_of_replies'_def opt_map_def o_def split: option.splits)
-    apply (fastforce intro: if_live_then_nonz_capE'
-                      simp: ko_wp_at'_def live'_def obj_at'_def projectKOs live_ntfn'_def)
-   apply (fastforce elim!: ex_nonz_cap_to'_tcb_in_WaitingNtfn'_q ntfn_queued_st_tcb_at'
-                    simp: sym_refs_asrt_def sch_act_wf_asrt_def)+
+  apply (rule bind_wp[OF _ stateAssert_sp])
+  apply (rule bind_wp [OF _ get_ntfn_sp'])
+  apply (case_tac "ntfnObj ntfna", simp_all)
+    apply (wp, simp)
+   apply (wp, simp)
+  apply (rule hoare_pre)
+   apply (wp rescheduleRequired_all_invs_but_ct_not_inQ
+             cancel_all_invs'_helper hoare_vcg_const_Ball_lift
+             valid_irq_node_lift ssa_invs' irqs_masked_lift
+          | simp only: sch_act_wf.simps)+
+  apply (clarsimp simp: invs'_def valid_state'_def valid_ntfn'_def)
+  apply (frule obj_at_valid_objs', clarsimp)
+  apply (clarsimp simp: projectKOs valid_obj'_def valid_ntfn'_def)
+  apply (drule(1) sym_refs_ko_atD')
+  apply (rule conjI, clarsimp elim!: if_live_state_refsE)
+  apply (rule conjI[rotated])
+   apply (clarsimp elim!: if_live_state_refsE)
+   apply (drule_tac x="(x, NTFNSignal)" in bspec)
+    apply (clarsimp simp: st_tcb_at_refs_of_rev')+
+   apply (drule st_tcb_at_state_refs_ofD')
+   apply clarsimp
+  apply (erule delta_sym_refs)
+   apply (clarsimp split: if_split_asm)
+  apply (clarsimp split: if_split_asm)
+   apply (fastforce simp: symreftype_inverse' ntfn_bound_refs'_def)
+  apply (drule_tac x="(x, NTFNSignal)" in bspec)
+   apply (clarsimp simp: st_tcb_at_refs_of_rev')+
+  apply (drule st_tcb_at_state_refs_ofD')
+  apply (fastforce simp: symreftype_inverse' ntfn_bound_refs'_def tcb_bound_refs'_def)
   done
 
-lemma setQueue_valid_ep'[wp]:
-  "setQueue domain prio q \<lbrace>valid_ep' ep\<rbrace>"
-  apply (clarsimp simp: setQueue_def)
-  apply wpsimp
-  apply (clarsimp simp: valid_ep'_def split: endpoint.splits)
-  done
-
-lemma tcbSchedEnqueue_valid_ep'[wp]:
-  "tcbSchedEnqueue thread \<lbrace>valid_ep' ep\<rbrace>"
-  apply (clarsimp simp: tcbSchedEnqueue_def unless_def when_def)
-  apply (rule bind_wp_fwd_skip, wpsimp)
-  apply clarsimp
-  apply (rule bind_wp_fwd_skip, wpsimp wp: hoare_if)+
-  apply (wpsimp wp: threadSet_wp)
-  apply (fastforce simp: valid_ep'_def obj_at'_def projectKOs objBitsKO_def split: endpoint.splits)
-  done
+crunch tcbSchedEnqueue
+  for valid_objs'[wp]: valid_objs'
+  (simp: unless_def valid_tcb'_def tcb_cte_cases_def)
 
 lemma cancelAllIPC_valid_objs'[wp]:
-  "\<lbrace>valid_objs'\<rbrace> cancelAllIPC ep \<lbrace>\<lambda>rv. valid_objs'\<rbrace>"
-  apply (simp add: cancelAllIPC_def ep'_Idle_case_helper cong del: if_cong)
-  apply (repeat_unless \<open>rule bind_wp[OF _ get_ep_sp']\<close>
-                       \<open>rule bind_wp_fwd_skip, wpsimp\<close>)
-  apply (rule hoare_if; (solves \<open>wpsimp\<close>)?)
-  apply (rule_tac Q'="\<lambda>_ s. valid_objs' s \<and> valid_ep' epa s" in bind_wp_fwd)
-   apply (wpsimp wp: set_ep_valid_objs')
-   apply (frule (1) ep_ko_at_valid_objs_valid_ep')
-   apply (fastforce simp: valid_ep'_def obj_at'_def projectKOs objBitsKO_def split: endpoint.splits)
-  apply (rule bind_wp)
-   apply wpsimp
-  apply (rule_tac Q'="\<lambda>_ s. valid_objs' s \<and> valid_ep' ep s" in hoare_strengthen_post; clarsimp)
-  apply (rule mapM_x_wp')
-  by wpsimp
+  "\<lbrace>valid_objs' and pspace_aligned' and pspace_distinct'\<rbrace> cancelAllIPC ep \<lbrace>\<lambda>rv. valid_objs'\<rbrace>"
+  apply (simp add: cancelAllIPC_def ep'_Idle_case_helper  cong del: if_cong)
+  apply (rule bind_wp[OF _ stateAssert_sp])
+  apply (rule bind_wp [OF _ get_ep_sp'])
+  apply (rule hoare_pre)
+   apply (wp set_ep_valid_objs' setSchedulerAction_valid_objs')
+    apply (rule_tac Q'="\<lambda>_ s. valid_objs' s \<and> pspace_aligned' s \<and> pspace_distinct' s
+                             \<and> (\<forall>x\<in>set (epQueue ep). tcb_at' x s)"
+                    in hoare_post_imp)
+     apply simp
+    apply (simp add: Ball_def)
+    apply (wp mapM_x_wp' sts_valid_objs'
+              hoare_vcg_all_lift hoare_vcg_const_imp_lift)+
+     apply simp
+    apply (simp add: valid_tcb_state'_def)
+   apply (wp set_ep_valid_objs' hoare_vcg_all_lift hoare_vcg_const_imp_lift)
+  apply (clarsimp)
+  apply (frule(1) ko_at_valid_objs')
+   apply (simp add: projectKOs)
+  apply (clarsimp simp: valid_obj'_def valid_ep'_def)
+  apply (case_tac epa, simp_all)
+  done
 
 lemma cancelAllSignals_valid_objs'[wp]:
   "\<lbrace>valid_objs' and pspace_aligned' and pspace_distinct'\<rbrace> cancelAllSignals ntfn \<lbrace>\<lambda>rv. valid_objs'\<rbrace>"
   apply (simp add: cancelAllSignals_def)
-  apply (repeat_unless \<open>rule bind_wp[OF _ get_ntfn_sp']\<close>
-                       \<open>rule bind_wp_fwd_skip, wpsimp\<close>)
+  apply (rule bind_wp[OF _ stateAssert_sp])
+  apply (rule bind_wp [OF _ get_ntfn_sp'])
   apply (case_tac "ntfnObj ntfna", simp_all)
     apply (wp, simp)
    apply (wp, simp)
   apply (rename_tac list)
   apply (rule_tac Q'="\<lambda>rv s. valid_objs' s \<and> (\<forall>x\<in>set list. tcb_at' x s)"
                   in hoare_post_imp)
-   apply simp
-  apply (wpsimp wp: setSchedulerAction_valid_objs' mapM_x_wp' sts_valid_objs'
-                    hoare_vcg_ball_lift typ_at_lifts)
-  apply (auto simp: projectKOs valid_obj'_def valid_ntfn'_def
-              dest: ko_at_valid_objs')
+   apply (simp add: valid_ntfn'_def)
+  apply (simp add: Ball_def)
+  apply (wp setSchedulerAction_valid_objs' mapM_x_wp'
+            sts_valid_objs' hoare_vcg_all_lift hoare_vcg_const_imp_lift
+       | simp)+
+   apply (simp add: valid_tcb_state'_def)
+  apply (wp set_ntfn_valid_objs' hoare_vcg_all_lift hoare_vcg_const_imp_lift)
+  apply clarsimp
+  apply (frule(1) ko_at_valid_objs')
+   apply (simp add: projectKOs)
+  apply (clarsimp simp: valid_obj'_def valid_ntfn'_def)
   done
 
 lemma cancelAllIPC_st_tcb_at:
-  "\<lbrace>st_tcb_at' P t and K (P Inactive \<and> P Restart)\<rbrace>
-   cancelAllIPC epptr
-   \<lbrace>\<lambda>_. st_tcb_at' P t\<rbrace>"
-  unfolding cancelAllIPC_def cancelAllIPC_loop_body_def restartThreadIfNoFault_def
-  apply (rule hoare_gen_asm)
-  apply simp
-  apply (intro bind_wp[OF _ stateAssert_sp])
-  apply (intro bind_wp[OF _ get_ep_sp'])
-  apply (clarsimp simp: endpoint.case_eq_if)
-  apply (rule conjI)
-   apply wpsimp
-  apply (wpsimp wp: mapM_x_wp' sts_st_tcb_at'_cases threadGet_wp hoare_vcg_imp_lift
-              simp: obj_at_ko_at'_eq[where P=\<top>, simplified])
-     apply (rule_tac Q'="\<lambda>_. tcb_at' x and st_tcb_at' P t" in hoare_strengthen_post)
-      apply (wpsimp wp: replyUnlink_st_tcb_at')
-     apply (clarsimp simp: pred_tcb_at'_def obj_at'_def projectKOs)
-    apply (wpsimp wp: gts_wp')
-    apply (fastforce simp: obj_at_ko_at'_eq[where P=\<top>, simplified])
-   apply wpsimp
-  by clarsimp
+  assumes x[simp]: "P Restart" shows
+  "\<lbrace>st_tcb_at' P t\<rbrace> cancelAllIPC epptr \<lbrace>\<lambda>rv. st_tcb_at' P t\<rbrace>"
+  unfolding cancelAllIPC_def
+  by (wp ep'_cases_weak_wp mapM_x_wp' sts_st_tcb_at'_cases | clarsimp)+
 
 lemmas cancelAllIPC_makes_simple[wp] =
        cancelAllIPC_st_tcb_at [where P=simple', simplified]
 
 lemma cancelAllSignals_st_tcb_at:
-  "\<lbrace>st_tcb_at' P t and K (P Restart)\<rbrace>
-   cancelAllSignals epptr
-   \<lbrace>\<lambda>_. st_tcb_at' P t\<rbrace>"
+  assumes x[simp]: "P Restart" shows
+  "\<lbrace>st_tcb_at' P t\<rbrace> cancelAllSignals epptr \<lbrace>\<lambda>rv. st_tcb_at' P t\<rbrace>"
   unfolding cancelAllSignals_def
-  apply (rule hoare_gen_asm)
-  apply (wpsimp wp: mapM_x_wp' sts_st_tcb_at'_cases getNotification_wp)
-  done
+  by (wp ntfn'_cases_weak_wp mapM_x_wp' sts_st_tcb_at'_cases | clarsimp)+
 
 lemmas cancelAllSignals_makes_simple[wp] =
        cancelAllSignals_st_tcb_at [where P=simple', simplified]
@@ -2935,165 +1948,90 @@ lemma threadSet_unlive_other:
    \<lbrace>\<lambda>rv. ko_wp_at' (Not \<circ> live') p\<rbrace>"
   by (clarsimp simp: threadSet_def valid_def getObject_def
                      setObject_def in_monad loadObject_default_def
-                     ko_wp_at'_def projectKOs split_def in_magnitude_check
-                     objBits_simps' updateObject_default_def
+                     ko_wp_at'_def  split_def in_magnitude_check
+                     objBits_simps' updateObject_default_def projectKOs
                      ps_clear_upd ARM_H.fromPPtr_def)
-
-lemma rescheduleRequired_unlive[wp]:
-  "\<lbrace>\<lambda>s. ko_wp_at' (Not \<circ> live') p s \<and> sch_act_not p s\<rbrace>
-   rescheduleRequired
-   \<lbrace>\<lambda>_. ko_wp_at' (Not \<circ> live') p\<rbrace>"
-  unfolding rescheduleRequired_def
-  apply (wpsimp wp: setObject_ko_wp_at getObject_tcb_wp isSchedulable_wp
-              simp: objBits_simps' bitmap_fun_defs tcbSchedEnqueue_def unless_def
-                    threadSet_def setQueue_def threadGet_getObject)+
-  by (fastforce simp: o_def dest!: obj_at_ko_at'[where P=\<top>])
 
 lemma tcbSchedEnqueue_unlive_other:
   "\<lbrace>ko_wp_at' (Not \<circ> live') p and K (p \<noteq> t)\<rbrace>
    tcbSchedEnqueue t
    \<lbrace>\<lambda>_. ko_wp_at' (Not \<circ> live') p\<rbrace>"
-  apply (simp add: tcbSchedEnqueue_def)
-  apply (wpsimp wp: threadGet_wp threadSet_unlive_other)
-  apply (fastforce simp: obj_at'_def projectKOs ko_wp_at'_def)
+  apply (simp add: tcbSchedEnqueue_def tcbQueuePrepend_def setQueue_def)
+  apply (wpsimp wp: threadGet_wp threadSet_unlive_other simp:  bitmap_fun_defs)
+  apply (normalise_obj_at', rename_tac tcb)
+  apply (clarsimp simp: ready_queue_relation_def ksReadyQueues_asrt_def)
+  apply (drule_tac x="tcbDomain tcb" in spec)
+  apply (drule_tac x="tcbPriority tcb" in spec)
+  apply (clarsimp simp: tcbQueueEmpty_def)
+  apply (frule (1) tcbQueueHead_ksReadyQueues)
+  apply (drule_tac x=p in spec)
+  apply (fastforce dest!: inQ_implies_tcbQueueds_of
+                    simp: tcbQueueEmpty_def ko_wp_at'_def opt_pred_def opt_map_def projectKOs
+                   split: option.splits)
   done
 
-crunch scheduleTCB
-  for unlive[wp]: "ko_wp_at' (Not \<circ> live') p"
-  (wp: crunch_wps isSchedulable_inv simp: crunch_simps)
-
-lemma setThreadState_unlive_other:
-  "\<lbrace>ko_wp_at' (Not \<circ> live') p and sch_act_not p and K (p \<noteq> t)\<rbrace>
-   setThreadState st t
-   \<lbrace>\<lambda>rv. ko_wp_at' (Not \<circ> live') p\<rbrace>"
-  unfolding setThreadState_def
-  apply (wpsimp wp: threadSet_wp)
-  apply (fastforce simp: ko_wp_at'_def obj_at'_def)
-  done
-
-context begin interpretation Arch . (*FIXME: arch-split*)
-
-lemma possibleSwitchTo_unlive_other:
-  "\<lbrace>ko_wp_at' (Not \<circ> live') p and sch_act_not p and K (p \<noteq> t)\<rbrace>
-   possibleSwitchTo t
+lemma rescheduleRequired_unlive[wp]:
+  "\<lbrace>\<lambda>s. ko_wp_at' (Not \<circ> live') p s \<and> ksSchedulerAction s \<noteq> SwitchToThread p\<rbrace>
+   rescheduleRequired
    \<lbrace>\<lambda>_. ko_wp_at' (Not \<circ> live') p\<rbrace>"
-  apply (simp add: possibleSwitchTo_def inReleaseQueue_def)
-  apply (wpsimp wp: tcbSchedEnqueue_unlive_other threadGet_wp rescheduleRequired_unlive)+
-  apply (auto simp: obj_at'_def ko_wp_at'_def)
+  supply comp_apply[simp del]
+  unfolding rescheduleRequired_def
+  apply (wpsimp wp: tcbSchedEnqueue_unlive_other)
   done
 
-lemma setThreadState_Inactive_unlive:
-  "\<lbrace>ko_wp_at' (Not \<circ> live') p and sch_act_not p\<rbrace>
-   setThreadState Inactive tptr
-   \<lbrace>\<lambda>_. ko_wp_at' (Not o live') p\<rbrace>"
-  apply (clarsimp simp: setThreadState_def)
-  apply (wpsimp wp: threadSet_wp)
-  apply (fastforce simp: ko_wp_at'_def obj_at'_def projectKOs is_aligned_def ps_clear_def objBitsKO_def)
-  done
-
-lemma replyUnlink_unlive:
-  "\<lbrace>ko_wp_at' (Not \<circ> live') p and sch_act_not p\<rbrace>
-   replyUnlink replyPtr tcbPtr
-   \<lbrace>\<lambda>_. ko_wp_at' (Not o live') p\<rbrace>"
-  apply (clarsimp simp: replyUnlink_def updateReply_def)
-  apply (wpsimp wp: setThreadState_Inactive_unlive set_reply'.set_wp gts_wp')
-  apply (fastforce simp: ko_wp_at'_def obj_at'_def projectKOs is_aligned_def ps_clear_def
-                         objBitsKO_def live'_def live_reply'_def)
-  done
+lemmas setEndpoint_ko_wp_at'
+    = setObject_ko_wp_at'[where 'a=endpoint, folded setEndpoint_def, simplified]
 
 lemma cancelAllIPC_unlive:
   "\<lbrace>valid_objs' and (\<lambda>s. sch_act_wf (ksSchedulerAction s) s)\<rbrace>
-   cancelAllIPC ep
-   \<lbrace>\<lambda>rv. ko_wp_at' (Not \<circ> live') ep\<rbrace>"
-  unfolding cancelAllIPC_def cancelAllIPC_loop_body_def restartThreadIfNoFault_def
-  apply (simp add: ep'_Idle_case_helper)
-  apply (repeat_unless \<open>rule bind_wp[OF _ get_ep_sp']\<close>
-                       \<open>rule bind_wp_fwd_skip, wpsimp\<close>)
-  apply (rename_tac endpoint)
-  apply (rule hoare_if)
-   apply (wpsimp simp: ko_wp_at'_def live'_def obj_at'_def projectKOs)
-
-  apply (rule_tac Q'="\<lambda>_ s. valid_objs' s
-                           \<and> sch_act_wf (ksSchedulerAction s) s
-                           \<and> ko_wp_at' (Not \<circ> live') ep s
-                           \<and> ep_at' ep s
-                           \<and> valid_ep' endpoint s"
-               in bind_wp_fwd)
-   apply (wpsimp wp: set_ep_valid_objs' set_ep'.sch_act_wf)
-    apply (wpsimp wp: set_ep'.set_wp)
-   apply (clarsimp simp del: fun_upd_apply)
-   apply (frule (1) ep_ko_at_valid_objs_valid_ep')
-   apply (clarsimp simp: valid_ep'_def ko_wp_at'_def obj_at'_def projectKOs objBitsKO_def
-                         ps_clear_def)
-   apply (fastforce simp: valid_ep'_def obj_at'_def projectKOs objBitsKO_def split: endpoint.splits)
-
-  apply clarsimp
-  apply (rule_tac P'="\<lambda>s. valid_objs' s
-                         \<and> sch_act_not ep s
-                         \<and> ko_wp_at' (Not \<circ> live') ep s
-                         \<and> ep_at' ep s
-                         \<and> valid_ep' endpoint s"
-               in hoare_weaken_pre[rotated])
-   apply (clarsimp simp: st_tcb_at'_def obj_at'_def projectKOs)
-  apply (rule bind_wp)
-   apply (wpsimp wp: rescheduleRequired_unlive)
-  apply (rule hoare_strengthen_post)
-   apply (rule mapM_x_wp')
-   apply (rule bind_wp_fwd_skip, wpsimp)
-   apply (rule bind_wp_fwd_skip, wpsimp wp: replyUnlink_valid_objs' replyUnlink_unlive)
-   apply (wpsimp wp: possibleSwitchTo_unlive_other setThreadState_unlive_other hoare_drop_imps
-                     possibleSwitchTo_sch_act_not_other)
-   apply (clarsimp simp: valid_tcb_state'_def obj_at'_def projectKOs)
-   apply (fastforce simp: valid_ep'_def obj_at'_def projectKOs split: endpoint.splits)
-  apply clarsimp
-  done
-
-lemma cancelAllSignals_unlive_helper:
-  "\<lbrace>\<lambda>s. (\<forall>x\<in>set xs. tcb_at' x s) \<and> ko_wp_at' (Not \<circ> live') p s
-         \<and> sch_act_not p s \<and> p \<notin> set xs\<rbrace>
-   mapM_x (\<lambda>t. do
-                 y \<leftarrow> setThreadState Structures_H.thread_state.Restart t;
-                 scOpt <- threadGet tcbSchedContext t;
-                 y <- ifCondRefillUnblockCheck scOpt (Some False) (Some True);
-                 possibleSwitchTo t
-               od) xs
-   \<lbrace>\<lambda>rv s. (\<forall>x\<in>set xs. tcb_at' x s) \<and> ko_wp_at' (Not \<circ> live') p s
-           \<and>sch_act_not p s\<rbrace>"
-  apply (rule hoare_strengthen_post)
-   apply (rule mapM_x_wp')
-   apply (rule hoare_pre)
-    apply (wpsimp wp: hoare_vcg_const_Ball_lift setThreadState_unlive_other
-                      possibleSwitchTo_unlive_other possibleSwitchTo_sch_act_not_other)
-   apply clarsimp
-  apply clarsimp
+      cancelAllIPC ep \<lbrace>\<lambda>rv. ko_wp_at' (Not \<circ> live') ep\<rbrace>"
+  apply (simp add: cancelAllIPC_def ep'_Idle_case_helper)
+  apply (rule bind_wp[OF _ stateAssert_sp])
+  apply (rule bind_wp [OF _ get_ep_sp'])
+  apply (rule hoare_pre)
+   apply (wp cancelAll_unlive_helper setEndpoint_ko_wp_at'
+             hoare_vcg_const_Ball_lift rescheduleRequired_unlive
+             mapM_x_wp'
+        | simp add: objBits_simps')+
+  apply (clarsimp simp: projectKO_opt_tcb)
+  apply (frule(1) obj_at_valid_objs')
+  apply (intro conjI impI)
+  apply (clarsimp simp: valid_obj'_def valid_ep'_def projectKOs
+                        obj_at'_def pred_tcb_at'_def ko_wp_at'_def
+                 split: endpoint.split_asm)+
   done
 
 lemma cancelAllSignals_unlive:
   "\<lbrace>\<lambda>s. valid_objs' s \<and> sch_act_wf (ksSchedulerAction s) s
-      \<and> obj_at' (\<lambda>ko. ntfnBoundTCB ko = None) ntfnptr s
-      \<and> obj_at' (\<lambda>ko. ntfnSc ko = None) ntfnptr s\<rbrace>
-   cancelAllSignals ntfnptr
-   \<lbrace>\<lambda>rv. ko_wp_at' (Not \<circ> live') ntfnptr\<rbrace>"
+      \<and> obj_at' (\<lambda>ko. ntfnBoundTCB ko = None) ntfnptr s\<rbrace>
+      cancelAllSignals ntfnptr \<lbrace>\<lambda>rv. ko_wp_at' (Not \<circ> live') ntfnptr\<rbrace>"
   apply (simp add: cancelAllSignals_def)
-  apply (repeat_unless \<open>rule bind_wp[OF _ get_ntfn_sp']\<close>
-                       \<open>rule bind_wp_fwd_skip, wpsimp\<close>)
-  apply (case_tac "ntfnObj ntfn"; simp)
+  apply (rule bind_wp[OF _ stateAssert_sp])
+  apply (rule bind_wp [OF _ get_ntfn_sp'])
+  apply (case_tac "ntfnObj ntfn", simp_all add: setNotification_def)
     apply wp
-    apply (fastforce simp: obj_at'_real_def projectKOs live_ntfn'_def ko_wp_at'_def)
+    apply (fastforce simp: obj_at'_real_def projectKOs
+                     dest: obj_at_conj'
+                     elim: ko_wp_at'_weakenE)
    apply wp
-   apply (fastforce simp: obj_at'_real_def projectKOs live_ntfn'_def ko_wp_at'_def)
+   apply (fastforce simp: obj_at'_real_def projectKOs
+                    dest: obj_at_conj'
+                    elim: ko_wp_at'_weakenE)
   apply (wp rescheduleRequired_unlive)
-    apply (rule cancelAllSignals_unlive_helper[THEN hoare_strengthen_post])
-    apply fastforce
-   apply (wpsimp wp: hoare_vcg_const_Ball_lift set_ntfn'.ko_wp_at
-               simp: objBits_simps')
-  apply (clarsimp, frule (1) ko_at_valid_objs'_pre,
-         clarsimp simp: valid_obj'_def valid_ntfn'_def)
-  apply (intro conjI[rotated]; clarsimp)
-    apply (fastforce simp: obj_at'_def projectKOs)
-   apply (clarsimp simp: pred_tcb_at'_def obj_at'_def projectKOs)
-  apply (clarsimp simp: live_ntfn'_def ko_wp_at'_def obj_at'_def)
+   apply (wp cancelAll_unlive_helper)
+   apply ((wp mapM_x_wp' setObject_ko_wp_at' hoare_vcg_const_Ball_lift)+,
+          simp_all add: objBits_simps', simp_all)
+   apply (fold setNotification_def, wp)
+  apply (intro conjI[rotated])
+     apply (clarsimp simp: pred_tcb_at'_def obj_at'_def projectKOs)
+    apply (clarsimp simp: projectKOs projectKO_opt_tcb)
+   apply (fastforce simp: ko_wp_at'_def valid_obj'_def valid_ntfn'_def
+                         obj_at'_def projectKOs)+
   done
+
+crunch tcbSchedEnqueue
+  for ep_at'[wp]: "ep_at' epptr"
+  (simp: unless_def)
 
 declare if_cong[cong]
 
@@ -3101,42 +2039,30 @@ lemma insert_eqD:
   "A = insert a B \<Longrightarrow> a \<in> A"
   by blast
 
-crunch setSchedulerAction
-  for tcb_in_cur_domain'[wp]: "tcb_in_cur_domain' p"
-  (simp: tcb_in_cur_domain'_def wp_del: ssa_wp)
-
-crunch possibleSwitchTo
-  for tcb_in_cur_domain'[wp]: "tcb_in_cur_domain' p"
-  and ksCurThread[wp]: "\<lambda>s. P (ksCurThread s)"
-  (wp: crunch_wps)
-
 lemma cancelBadgedSends_filterM_helper':
   notes if_cong[cong del]
   shows
   "\<forall>ys.
-   \<lbrace>\<lambda>s. invs' s \<and> sch_act_wf (ksSchedulerAction s) s
+   \<lbrace>\<lambda>s. all_invs_but_sym_refs_ct_not_inQ' s
            \<and> ex_nonz_cap_to' epptr s \<and> ep_at' epptr s
            \<and> sym_refs ((state_refs_of' s) (epptr := set (xs @ ys) \<times> {EPSend}))
            \<and> (\<forall>y \<in> set (xs @ ys). state_refs_of' s y = {(epptr, TCBBlockedSend)}
-                                                        \<union> tcb_non_st_state_refs_of' s y)
+                                       \<union> {r \<in> state_refs_of' s y. snd r = TCBBound})
            \<and> distinct (xs @ ys)\<rbrace>
       filterM (\<lambda>t. do st \<leftarrow> getThreadState t;
-                      if blockingIPCBadge st = badge
-                      then
-                        do restartThreadIfNoFault t;
+                      if blockingIPCBadge st = badge then
+                        do y \<leftarrow> setThreadState Structures_H.thread_state.Restart t;
+                           y \<leftarrow> tcbSchedEnqueue t;
                            return False
                         od
                       else return True
                    od) xs
-   \<lbrace>\<lambda>rv s. invs' s \<and> sch_act_wf (ksSchedulerAction s) s
+   \<lbrace>\<lambda>rv s. all_invs_but_sym_refs_ct_not_inQ' s
            \<and> ex_nonz_cap_to' epptr s \<and> ep_at' epptr s
            \<and> sym_refs ((state_refs_of' s) (epptr := (set rv \<union> set ys) \<times> {EPSend}))
            \<and> (\<forall>y \<in> set ys. state_refs_of' s y = {(epptr, TCBBlockedSend)}
-                                                 \<union> tcb_non_st_state_refs_of' s y)
+                                   \<union> {r \<in> state_refs_of' s y. snd r = TCBBound})
            \<and> distinct rv \<and> distinct (xs @ ys) \<and> set rv \<subseteq> set xs \<and> (\<forall>x \<in> set xs. tcb_at' x s)\<rbrace>"
-  supply valid_dom_schedule'_def[simp]
-  unfolding restartThreadIfNoFault_def
-  apply (simp only: invs'_def)
   apply (rule_tac xs=xs in rev_induct)
    apply clarsimp
    apply wp
@@ -3144,102 +2070,66 @@ lemma cancelBadgedSends_filterM_helper':
   apply (clarsimp simp: filterM_append bind_assoc simp del: set_append distinct_append)
   apply (drule spec, erule bind_wp_fwd)
   apply (rule bind_wp [OF _ gts_inv'])
-  apply (simp add: opt_map_Some_eta_fold split del: if_split)
   apply (rule hoare_pre)
-   apply (wpsimp wp: valid_irq_node_lift hoare_vcg_const_Ball_lift
-                     valid_irq_handlers_lift'' irqs_masked_lift sts_st_tcb'
-                     hoare_vcg_all_lift sts_sch_act'
-                     threadGet_inv[THEN hoare_drop_imp] hoare_vcg_imp_lift'
-               simp: cteCaps_of_def o_def)
-  apply (clarsimp simp: opt_map_Some_eta_fold)
+   apply (wp valid_irq_node_lift hoare_vcg_const_Ball_lift sts_sch_act'
+             sch_act_wf_lift valid_irq_handlers_lift'' cur_tcb_lift irqs_masked_lift
+             sts_st_tcb' untyped_ranges_zero_lift
+        | clarsimp simp: cteCaps_of_def o_def)+
   apply (frule insert_eqD, frule state_refs_of'_elemD)
   apply (clarsimp simp: valid_tcb_state'_def st_tcb_at_refs_of_rev')
   apply (frule pred_tcb_at')
   apply (rule conjI[rotated], blast)
-  apply (clarsimp cong: conj_cong)
-  apply (thin_tac "sym_refs _") \<comment> \<open>this removes the list_refs_of_reply' sym_refs premise\<close>
+  apply (clarsimp simp: valid_pspace'_def cong: conj_cong)
   apply (intro conjI)
-          apply (find_goal \<open>match conclusion in "sym_refs _" \<Rightarrow> \<open>-\<close>\<close>)
-          apply (erule delta_sym_refs)
-           apply (fastforce split: if_split_asm)
-          subgoal (* this takes approximately 15s *)
-          by (auto simp: state_refs_of'_def symreftype_inverse' projectKOs
-                         tcb_bound_refs'_def obj_at'_def get_refs_def2 tcb_st_refs_of'_def
-                  split: option.splits if_splits thread_state.splits)
-         by (fastforce simp: valid_pspace'_def valid_tcb'_def pred_tcb_at'_def obj_at'_def subsetD
-                      elim!: valid_objs_valid_tcbE' st_tcb_ex_cap'')+
+     apply (fastforce simp: valid_tcb'_def dest!: st_tcb_ex_cap'')
+    apply (clarsimp simp: valid_idle'_def pred_tcb_at'_def obj_at'_def idle_tcb'_def)
+   apply (erule delta_sym_refs)
+    by (fastforce elim!: obj_atE'
+                   simp: state_refs_of'_def tcb_bound_refs'_def subsetD symreftype_inverse' projectKOs
+                  split: if_split_asm)+
 
 lemmas cancelBadgedSends_filterM_helper
     = spec [where x=Nil, OF cancelBadgedSends_filterM_helper', simplified]
 
-lemma cancelBadgedSends_invs'[wp]:
+lemma cancelBadgedSends_invs[wp]:
   notes if_cong[cong del]
   shows
-  "cancelBadgedSends epptr badge \<lbrace>invs'\<rbrace>"
+  "\<lbrace>invs'\<rbrace> cancelBadgedSends epptr badge \<lbrace>\<lambda>rv. invs'\<rbrace>"
   apply (simp add: cancelBadgedSends_def)
-  apply (intro bind_wp[OF _ stateAssert_sp])
+  apply (rule bind_wp[OF _ stateAssert_sp])
   apply (rule bind_wp [OF _ get_ep_sp'], rename_tac ep)
   apply (case_tac ep, simp_all)
     apply ((wp | simp)+)[2]
   apply (subst bind_assoc [where g="\<lambda>_. rescheduleRequired",
                            symmetric])+
   apply (rule bind_wp
-                [OF rescheduleRequired_invs'])
-  apply (simp add: list_case_return invs'_def valid_dom_schedule'_def cong: list.case_cong)
+                [OF rescheduleRequired_all_invs_but_ct_not_inQ])
+  apply (simp add: list_case_return cong: list.case_cong)
   apply (rule hoare_pre, wp valid_irq_node_lift irqs_masked_lift)
+    apply simp
     apply (rule hoare_strengthen_post,
            rule cancelBadgedSends_filterM_helper[where epptr=epptr])
-    apply (clarsimp simp: ep_redux_simps3 fun_upd_def[symmetric] o_def)
-    apply (clarsimp simp add: valid_ep'_def invs'_def valid_dom_schedule'_def comp_def
-                       split: list.split)
+    apply (clarsimp simp: ep_redux_simps3 fun_upd_def[symmetric])
+    apply (clarsimp simp add: valid_ep'_def split: list.split)
     apply blast
-   apply (simp add: list_case_return invs'_def valid_dom_schedule'_def)
    apply (wp valid_irq_node_lift irqs_masked_lift | wp (once) sch_act_sane_lift)+
-  apply (clarsimp simp: valid_ep'_def fun_upd_def[symmetric]
+  apply (clarsimp simp: invs'_def valid_state'_def
+                        valid_ep'_def fun_upd_def[symmetric]
                         obj_at'_weakenE[OF _ TrueI])
   apply (frule obj_at_valid_objs', clarsimp)
   apply (clarsimp simp: valid_obj'_def valid_ep'_def projectKOs)
   apply (frule if_live_then_nonz_capD', simp add: obj_at'_real_def)
    apply (clarsimp simp: projectKOs)
-  apply (clarsimp simp: sym_refs_asrt_def)
   apply (frule(1) sym_refs_ko_atD')
-  apply (clarsimp simp add: fun_upd_idem st_tcb_at_refs_of_rev' o_def sch_act_wf_asrt_def)
+  apply (clarsimp simp add: fun_upd_idem
+                            st_tcb_at_refs_of_rev')
   apply (drule (1) bspec, drule st_tcb_at_state_refs_ofD', clarsimp)
-  apply (auto simp: tcb_bound_refs'_def get_refs_def
-             split: option.splits)
+  apply (fastforce simp: set_eq_subset tcb_bound_refs'_def)
   done
 
-lemma restart_thread_if_no_fault_valid_sched_blocked_on_send:
-  "\<lbrace>\<lambda>s. valid_sched s \<and> tcb_at t s \<and> heap_refs_inv (tcb_scps_of s) (sc_tcbs_of s)
-        \<and> current_time_bounded s
-        \<and> (epptr, TCBBlockedSend) \<in> state_refs_of s t \<and> t \<noteq> idle_thread s\<rbrace>
-   restart_thread_if_no_fault t
-   \<lbrace>\<lambda>_. valid_sched\<rbrace>"
-  apply (wpsimp wp: restart_thread_if_no_fault_valid_sched gts_wp)
-  apply (frule valid_sched_released_ipc_queues)
-  apply (frule TCBBlockedSend_in_state_refs_of)
-  apply (prop_tac "blocked_on_send_tcb_at t s")
-   apply (fastforce simp: is_blocked_thread_state_defs vs_all_heap_simps obj_at_def pred_tcb_at_def)
-  apply (drule (1) released_ipc_queues_blocked_on_send_E1)
-  apply (intro conjI)
-   apply (clarsimp simp: pred_tcb_at_def obj_at_def vs_all_heap_simps)
-   apply (metis runnable.simps)
-  apply (clarsimp simp: is_timeout_fault_opt_def vs_all_heap_simps obj_at_def pred_tcb_at_def)
-  done
-
-lemma in_send_ep_queue_TCBBlockedSend':
-  "\<lbrakk>ko_at' (Structures_H.SendEP queue) epptr s; x \<in> set queue;
-    sym_refs (state_refs_of' s); valid_objs' s\<rbrakk>
-   \<Longrightarrow> ko_wp_at' (\<lambda>ko. (epptr, TCBBlockedSend) \<in> refs_of' ko) x s"
-  apply (prop_tac "valid_ep' (Structures_H.SendEP queue) s")
-   apply (fastforce simp: valid_objs'_def valid_obj'_def obj_at'_def projectKOs
-                   split: kernel_object.splits)
-  apply (clarsimp simp: valid_ep'_def)
-  apply (prop_tac "(x, EPSend) \<in> state_refs_of' s epptr")
-   apply (clarsimp simp: state_refs_of'_def obj_at'_def projectKOs)
-  apply (clarsimp simp: sym_refs_def)
-  apply (fastforce simp: ko_wp_at'_def obj_at'_def projectKOs state_refs_of'_def)
-  done
+crunch tcb_sched_action
+  for state_refs_of[wp]: "\<lambda>s. P (state_refs_of s)"
+  (ignore_del: tcb_sched_action)
 
 lemma setEndpoint_valid_tcbs'[wp]:
   "setEndpoint ePtr val \<lbrace>valid_tcbs'\<rbrace>"
@@ -3250,145 +2140,87 @@ lemma setEndpoint_valid_tcbs'[wp]:
   done
 
 lemma cancelBadgedSends_corres:
-  "corres dc (invs and valid_sched and ep_at epptr and current_time_bounded)
-             (invs' and ep_at' epptr)
+  "corres dc (invs and valid_sched and ep_at epptr) (invs' and ep_at' epptr)
          (cancel_badged_sends epptr bdg) (cancelBadgedSends epptr bdg)"
-  apply add_sym_refs
-  apply add_sch_act_wf
-  apply (clarsimp simp: cancel_badged_sends_def cancelBadgedSends_def)
-  apply (rule corres_stateAssert_add_assertion[rotated])
-   apply (clarsimp simp: sym_refs_asrt_def)
-  apply (rule corres_stateAssert_add_assertion[rotated])
-   apply (clarsimp simp: sch_act_wf_asrt_def)
+  apply (simp add: cancel_badged_sends_def cancelBadgedSends_def)
+  apply (rule corres_stateAssert_ignore)
+   apply (fastforce intro: ksReadyQueues_asrt_cross)
   apply (rule corres_guard_imp)
-    apply (rule corres_split[OF getEndpoint_corres _ get_simple_ko_sp get_ep_sp'
-                             , where Q="invs and valid_sched and current_time_bounded"
-                                 and Q'="invs' and (\<lambda>s. sym_refs (state_refs_of' s))
-                                         and (\<lambda>s. sch_act_wf (ksSchedulerAction s) s)"])
+    apply (rule corres_split[OF getEndpoint_corres _ get_simple_ko_sp get_ep_sp',
+                                 where Q="invs and valid_sched" and Q'=invs'])
     apply simp_all
-  apply (case_tac ep; simp add: ep_relation_def)
-  apply (rename_tac queue)
+  apply (case_tac ep, simp_all add: ep_relation_def)
   apply (simp add: filterM_mapM list_case_return cong: list.case_cong)
   apply (rule corres_guard_imp)
     apply (rule corres_split_nor[OF setEndpoint_corres])
-       apply (clarsimp simp: ep_relation_def)
-      apply (rule_tac F="distinct queue" in corres_gen_asm)
-      apply (rule corres_split_eqr)
-         apply (rule_tac P="\<lambda>s. valid_sched s \<and> pspace_aligned s \<and> pspace_distinct s \<and> valid_tcbs s
-                                \<and> heap_refs_inv (tcb_scps_of s) (sc_tcbs_of s) \<and> current_time_bounded s"
-                     and Q="\<lambda>t s. tcb_at t s \<and> (epptr, TCBBlockedSend) \<in> state_refs_of s t
-                                  \<and> t \<noteq> idle_thread s"
-                     and P'="\<lambda>s. valid_objs' s \<and> weak_sch_act_wf (ksSchedulerAction s) s \<and> valid_queues s
-                                 \<and> valid_queues' s \<and> valid_tcbs' s \<and> valid_release_queue_iff s"
-                     and Q'="\<lambda>t s. tcb_at' t s \<and> st_tcb_at' (not runnable') t s"
-                     and S="{t. (fst t = snd t) \<and> fst t \<in> set queue}"
-                     and r="(=)"
-                     and r'="(=)"
-                  in corres_mapM_scheme
-                ; (solves fastforce)?)
-             apply (clarsimp simp: liftM_def[symmetric])
-             apply (rule corres_guard_imp)
-               apply (rule corres_split[OF getThreadState_corres])
-                 apply (rule_tac F="\<exists>pl. st = Structures_A.BlockedOnSend epptr pl"
-                              in corres_gen_asm)
-                 apply (rule corres_if2[where Q=\<top> and Q'=\<top>])
-                   apply (clarsimp simp: blocking_ipc_badge_def blockingIPCBadge_def
-                                  split: thread_state.splits)
-                  apply (clarsimp simp: o_def dc_def[symmetric] liftM_def)
-                  apply (rule corres_guard_imp)
-                    apply (rule corres_split[OF restart_thread_if_no_fault_corres])
-                      unfolding restartThreadIfNoFault_def
-                      apply (rule corres_return_eq_same, simp)
-                     apply (rule wp_post_taut)
-                    apply (rule wp_post_taut)
-                   apply simp+
-                apply (wpsimp wp: gts_wp)
-               apply (wpsimp wp: gts_wp')
-              apply (clarsimp simp: st_tcb_def2 st_tcb_at_refs_of_rev valid_sched_def
-                              dest!: state_refs_of_elemD)
-             apply (clarsimp simp: st_tcb_def2 st_tcb_at_refs_of_rev)
-            apply (wpsimp wp: gts_wp)
-           apply (wpsimp wp: sts_st_tcb_at'_cases threadGet_wp gts_wp' hoare_vcg_imp_lift
-                       simp: obj_at_ko_at'_eq[where P=\<top>, simplified])
-           apply (clarsimp simp: obj_at'_def pred_neg_def)
-          apply (wpsimp wp: restart_thread_if_no_fault_valid_sched_blocked_on_send[where epptr=epptr]
-                            gts_wp)
-         apply (wpsimp wp: sts_weak_sch_act_wf sts_st_tcb_at'_cases hoare_vcg_imp_lift
-                           setThreadState_valid_queues' threadGet_wp gts_wp'
-                     simp: obj_at_ko_at'_eq[where P=\<top>, simplified])
-         apply (fastforce simp: valid_tcb_state'_def obj_at'_def projectKOs st_tcb_at'_def
-                                pred_neg_def weak_sch_act_wf_def)
-        apply (rule corres_split[OF ])
-           apply (rule setEndpoint_corres)
-           apply (simp split: list.split add: ep_relation_def)
-          apply (rule rescheduleRequired_corres)
+       apply (simp add: ep_relation_def)
+      apply (rule corres_split_eqr[OF _ _ _ hoare_post_add
+                                             [where Q'="\<lambda>_. valid_objs' and pspace_aligned'
+                                                           and pspace_distinct'"]])
+         apply (rule_tac S="(=)"
+                     and Q="\<lambda>xs s. (\<forall>x \<in> set xs. (epptr, TCBBlockedSend) \<in> state_refs_of s x) \<and>
+                                   distinct xs \<and> valid_etcbs s \<and>
+                                   in_correct_ready_q s \<and> ready_qs_distinct s \<and>
+                                   pspace_aligned s \<and> pspace_distinct s"
+                    and Q'="\<lambda>_ s. valid_objs' s \<and> sym_heap_sched_pointers s \<and> valid_sched_pointers s
+                                  \<and> pspace_aligned' s \<and> pspace_distinct' s"
+                     in corres_mapM_list_all2[where r'="(=)"],
+                simp_all add: list_all2_refl)[1]
+           apply (clarsimp simp: liftM_def[symmetric] o_def)
+           apply (rule corres_guard_imp)
+             apply (rule corres_split[OF getThreadState_corres])
+               apply (rule_tac F="\<exists>pl. st = Structures_A.BlockedOnSend epptr pl"
+                            in corres_gen_asm)
+               apply (clarsimp simp: o_def dc_def[symmetric] liftM_def)
+               apply (rule corres_split[OF setThreadState_corres])
+                  apply simp
+                 apply (rule corres_split[OF tcbSchedEnqueue_corres], simp)
+                   apply (rule corres_trivial)
+                   apply simp
+                  apply wp+
+               apply simp
+               apply (wp sts_st_tcb_at' gts_st_tcb_at sts_valid_objs'
+                      | strengthen valid_objs'_valid_tcbs')+
+            apply (clarsimp simp: valid_tcb_state_def tcb_at_def st_tcb_def2
+                                  st_tcb_at_refs_of_rev
+                           dest!: state_refs_of_elemD elim!: tcb_at_is_etcb_at[rotated])
+            apply (simp add: valid_tcb_state'_def)
+          apply (wp hoare_vcg_const_Ball_lift gts_wp | clarsimp)+
+            apply (wp hoare_vcg_imp_lift sts_st_tcb' sts_valid_objs'
+                      | clarsimp simp: valid_tcb_state'_def)+
+        apply (rule corres_split[OF _ rescheduleRequired_corres])
+          apply (rule setEndpoint_corres)
+          apply (simp split: list.split add: ep_relation_def)
          apply (wp weak_sch_act_wf_lift_linear)+
-       apply (rule_tac Q'="\<lambda>_ s. valid_tcbs s \<and> pspace_aligned s \<and> pspace_distinct s
-                                \<and> ep_at epptr s \<and> valid_sched s
-                                \<and> heap_refs_inv (tcb_scps_of s) (sc_tcbs_of s)
-                                \<and> current_time_bounded s"
-                    in hoare_strengthen_post)
-        apply (rule_tac Q="\<lambda>t s. tcb_at t s \<and> (epptr, TCBBlockedSend) \<in> state_refs_of s t
-                                 \<and> t \<noteq> idle_thread s"
-                     in ball_mapM_scheme)
-          apply (wpsimp wp: restart_thread_if_no_fault_tcb_sts_of_other gts_wp)
-         apply (wpsimp wp: restart_thread_if_no_fault_valid_sched_blocked_on_send[where epptr=epptr]
-                           gts_wp)
-        apply simp
-       apply fastforce
-      apply (rule_tac P'="(\<lambda>s. \<forall>t\<in>set queue. tcb_at' t s \<and> st_tcb_at' (not runnable') t s)
-                         and (\<lambda>s. valid_tcbs' s \<and> weak_sch_act_wf (ksSchedulerAction s) s
-                                  \<and> valid_queues s \<and> valid_queues' s \<and> valid_release_queue_iff s
-                                  \<and> ep_at' epptr s)"
-                   in hoare_weaken_pre[rotated], clarsimp)
-       apply simp
-      apply (rule hoare_strengthen_post)
-       apply (rule_tac Q="\<lambda>t s. tcb_at' t s \<and> st_tcb_at' (not runnable') t s"
-                    in ball_mapM_scheme)
-         apply (wpsimp wp: sts_st_tcb_at'_cases threadGet_wp gts_wp' hoare_vcg_imp_lift
-                     simp: obj_at_ko_at'_eq[where P=\<top>, simplified])
-         apply (clarsimp simp: obj_at'_def pred_neg_def)
-        apply (wpsimp wp: sts_st_tcb_at'_cases threadGet_wp gts_wp' hoare_vcg_imp_lift
-                    simp: obj_at_ko_at'_eq[where P=\<top>, simplified])
-        apply (fastforce simp: valid_tcb_state'_def obj_at'_def projectKOs st_tcb_at'_def
-                               pred_neg_def weak_sch_act_wf_def)
-       apply simp
-      apply simp
-     apply (wpsimp wp: hoare_vcg_ball_lift)
-    apply (wpsimp wp: hoare_vcg_ball_lift)
-   apply (clarsimp simp: obj_at_def is_ep_def cong: conj_cong)
-   apply (prop_tac "valid_ep (Structures_A.SendEP queue) s")
-    apply (fastforce simp: valid_objs_def valid_obj_def
-                     dest: invs_valid_objs)
-   apply (intro conjI impI allI ballI
-          ; (fastforce simp: valid_ep_def obj_at_def is_tcb_def)?)
-    apply (fastforce intro: in_send_ep_queue_TCBBlockedSend)
-   apply (rule not_idle_tcb_in_SendEp; fastforce)
-  apply (clarsimp cong: conj_cong)
-  apply (prop_tac "valid_ep' (Structures_H.SendEP queue) s")
-   apply (fastforce simp: valid_objs'_def valid_obj'_def obj_at'_def projectKOs
-                    dest: invs_valid_objs')
-  apply (intro conjI impI ballI
-         ; (fastforce simp: valid_ep'_def obj_at'_def projectKOs)?)
-  apply (frule (2) in_send_ep_queue_TCBBlockedSend')
-   apply fastforce
-  apply (fastforce simp: st_tcb_at_refs_of_rev' st_tcb_at'_def obj_at'_def pred_neg_def)
+       apply (wpsimp wp: mapM_wp' set_thread_state_runnable_weak_valid_sched_action
+                    simp: valid_tcb_state'_def)
+       apply ((wpsimp wp: hoare_vcg_imp_lift mapM_wp' sts_valid_objs' simp: valid_tcb_state'_def
+               | strengthen valid_objs'_valid_tcbs')+)[1]
+    apply (wpsimp wp: set_ep_valid_objs')+
+   apply (clarsimp simp: conj_comms)
+   apply (frule sym_refs_ko_atD, clarsimp+)
+   apply (rule obj_at_valid_objsE, assumption+, clarsimp+)
+   apply (clarsimp simp: valid_obj_def valid_ep_def valid_sched_def valid_sched_action_def)
+   apply (rule conjI, fastforce)
+   apply (rule conjI, fastforce)
+   apply (rule conjI, fastforce)
+   apply (rule conjI, erule obj_at_weakenE, clarsimp simp: is_ep)
+   apply (rule conjI, fastforce)
+   apply (clarsimp simp: st_tcb_at_refs_of_rev)
+   apply (drule(1) bspec, drule st_tcb_at_state_refs_ofD, clarsimp)
+   apply (simp add: set_eq_subset)
+  apply (clarsimp simp: obj_at'_weakenE[OF _ TrueI])
+  apply (fastforce simp: valid_ep'_def)
   done
 
-crunch schedContextCancelYieldTo, tcbReleaseRemove
-  for tcbQueued[wp]: "obj_at' (\<lambda>obj. \<not> tcbQueued obj) t"
-  (wp: crunch_wps simp: crunch_simps setReleaseQueue_def setReprogramTimer_def getReleaseQueue_def)
+crunch updateRestartPC
+  for tcb_at'[wp]: "tcb_at' t"
+  (simp: crunch_simps)
 
 lemma suspend_unqueued:
   "\<lbrace>\<top>\<rbrace> suspend t \<lbrace>\<lambda>rv. obj_at' (Not \<circ> tcbQueued) t\<rbrace>"
-  apply (simp add: suspend_def unless_def tcbSchedDequeue_def)
-  apply (wp hoare_vcg_if_lift hoare_vcg_conj_lift hoare_vcg_imp_lift)
-          apply (wpsimp simp: threadGet_getObject comp_def wp: getObject_tcb_wp)+
-      apply (rule hoare_strengthen_post, rule hoare_TrueI)
-      apply (fastforce simp: obj_at'_def projectKOs)
-     apply (rule hoare_TrueI)
-    apply wpsimp+
-  done
+  unfolding suspend_def
+  by (wpsimp simp: comp_def wp: tcbSchedDequeue_not_tcbQueued)
 
 crunch prepareThreadDelete
   for unqueued: "obj_at' (Not \<circ> tcbQueued) t"

--- a/proof/refine/ARM/KernelInit_R.thy
+++ b/proof/refine/ARM/KernelInit_R.thy
@@ -40,8 +40,6 @@ axiomatization where
 
 axiomatization where
   ckernel_init_domain_list:
-  "((tc,s),x) \<in> Init_H
-   \<Longrightarrow> length (ksDomSchedule s) > 0
-       \<and> (\<forall>(d,time) \<in> set (ksDomSchedule s). us_to_ticks (time * \<mu>s_in_ms) > 0)"
+  "((tc,s),x) \<in> Init_H \<Longrightarrow> length (ksDomSchedule s) > 0 \<and> (\<forall>(d,time) \<in> set (ksDomSchedule s). time > 0)"
 
 end

--- a/proof/refine/ARM/LevityCatch.thy
+++ b/proof/refine/ARM/LevityCatch.thy
@@ -14,10 +14,6 @@ begin
 (* Try again, clagged from Include *)
 no_notation bind_drop (infixl ">>" 60)
 
-lemma read_magnitudeCheck_assert:
-  "read_magnitudeCheck x y n = oassert (case y of None \<Rightarrow> True | Some z \<Rightarrow> 1 << n \<le> z - x)"
-  by (fastforce simp: read_magnitudeCheck_def split: option.split)
-
 lemma magnitudeCheck_assert:
   "magnitudeCheck x y n = assert (case y of None \<Rightarrow> True | Some z \<Rightarrow> 1 << n \<le> z - x)"
   apply (simp add: magnitudeCheck_def assert_def when_def
@@ -31,18 +27,16 @@ lemmas makeObject_simps =
   makeObject_asidpool
 end
 
-lemma projectKO_inv : "\<lbrace>P\<rbrace> gets_the $ projectKO ko \<lbrace>\<lambda>rv. P\<rbrace>"
-  by wpsimp
+lemma projectKO_inv : "\<lbrace>P\<rbrace> projectKO ko \<lbrace>\<lambda>rv. P\<rbrace>"
+  by (simp add: projectKO_def fail_def valid_def return_def
+           split: option.splits)
 
 (****** From GeneralLib *******)
 
-lemma read_alignCheck_assert:
-  "read_alignCheck ptr n = oassert (is_aligned ptr n)"
-  by (simp add: is_aligned_mask read_alignCheck_def read_alignError_def ounless_def)
-
 lemma alignCheck_assert:
   "alignCheck ptr n = assert (is_aligned ptr n)"
-  by (simp add: read_alignCheck_assert alignCheck_def)
+  by (simp add: is_aligned_mask alignCheck_def assert_def
+                alignError_def unless_def when_def)
 
 lemma magnitudeCheck_inv:   "\<lbrace>P\<rbrace> magnitudeCheck x y n \<lbrace>\<lambda>rv. P\<rbrace>"
   apply (clarsimp simp add: magnitudeCheck_def split: option.splits)

--- a/proof/refine/ARM/Machine_R.thy
+++ b/proof/refine/ARM/Machine_R.thy
@@ -54,7 +54,7 @@ lemma dmo_maskInterrupt:
 lemma dmo_maskInterrupt_True:
   "\<lbrace>invs'\<rbrace> doMachineOp (maskInterrupt True irq) \<lbrace>\<lambda>_. invs'\<rbrace>"
   apply (wp dmo_maskInterrupt)
-  apply (clarsimp simp: invs'_def valid_dom_schedule'_def)
+  apply (clarsimp simp: invs'_def valid_state'_def)
   apply (simp add: valid_irq_masks'_def valid_machine_state'_def
                    ct_not_inQ_def ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def)
   done

--- a/proof/refine/ARM/RAB_FN.thy
+++ b/proof/refine/ARM/RAB_FN.thy
@@ -78,7 +78,7 @@ declare resolveAddressBitsFn.simps[simp del]
 
 lemma isCNodeCap_capUntypedPtr_capCNodePtr:
   "isCNodeCap c \<Longrightarrow> capUntypedPtr c = capCNodePtr c"
-  by (clarsimp simp: isCap_simps State_H.ARM_H.PPtr_def)
+  by (clarsimp simp: isCap_simps)
 
 lemma resolveAddressBitsFn_eq:
   "monadic_rewrite F E (\<lambda>s. (isCNodeCap cap \<longrightarrow> (\<exists>slot. cte_wp_at' (\<lambda>cte. cteCap cte = cap) slot s))

--- a/proof/refine/ARM/Refine.thy
+++ b/proof/refine/ARM/Refine.thy
@@ -86,7 +86,6 @@ lemma typ_at_UserDataI:
               split: Structures_A.kernel_object.split_asm
                      Structures_H.kernel_object.split_asm
                      if_split_asm arch_kernel_obj.split_asm)
-  apply (case_tac ko; simp)
   apply (rename_tac vmpage_size n)
   apply (rule_tac x = vmpage_size in exI)
   apply (subst conjunct2 [OF is_aligned_add_helper])
@@ -118,7 +117,6 @@ lemma typ_at_DeviceDataI:
               split: Structures_A.kernel_object.split_asm
                      Structures_H.kernel_object.split_asm
                      if_split_asm arch_kernel_obj.split_asm)
-  apply (case_tac ko; simp)
   apply (rename_tac vmpage_size n)
   apply (rule_tac x = vmpage_size in exI)
   apply (subst conjunct2 [OF is_aligned_add_helper])
@@ -130,7 +128,7 @@ lemma typ_at_DeviceDataI:
   done
 
 lemma pointerInUserData_relation:
-  "\<lbrakk> (s,s') \<in> state_relation; invs' s'; valid_state s\<rbrakk>
+  "\<lbrakk> (s,s') \<in> state_relation; valid_state' s'; valid_state s\<rbrakk>
    \<Longrightarrow> pointerInUserData p s' = in_user_frame p s"
   apply (simp add: pointerInUserData_def in_user_frame_def)
   apply (rule iffI)
@@ -139,7 +137,7 @@ lemma pointerInUserData_relation:
   apply (drule_tac sz = sz and
                    n = "(p && mask (pageBitsForSize sz)) >> pageBits"
     in typ_at_AUserDataI [where s = s and s' = s'])
-      apply fastforce+
+      apply (fastforce simp: valid_state'_def)+
    apply (rule shiftr_less_t2n')
     apply (simp add: pbfs_atleast_pageBits mask_twice)
    apply (case_tac sz, simp_all)[1]
@@ -156,7 +154,7 @@ lemma pointerInUserData_relation:
   done
 
 lemma pointerInDeviceData_relation:
-  "\<lbrakk> (s,s') \<in> state_relation; invs' s'; valid_state s\<rbrakk>
+  "\<lbrakk> (s,s') \<in> state_relation; valid_state' s'; valid_state s\<rbrakk>
    \<Longrightarrow> pointerInDeviceData p s' = in_device_frame p s"
   apply (simp add: pointerInDeviceData_def in_device_frame_def)
   apply (rule iffI)
@@ -165,7 +163,7 @@ lemma pointerInDeviceData_relation:
   apply (drule_tac sz = sz and
                    n = "(p && mask (pageBitsForSize sz)) >> pageBits"
     in typ_at_ADeviceDataI [where s = s and s' = s'])
-      apply (fastforce simp: invs'_def)+
+      apply (fastforce simp: valid_state'_def)+
    apply (rule shiftr_less_t2n')
     apply (simp add: pbfs_atleast_pageBits mask_twice)
    apply (case_tac sz, simp_all)[1]
@@ -182,7 +180,7 @@ lemma pointerInDeviceData_relation:
   done
 
 lemma user_mem_relation:
-  "\<lbrakk>(s,s') \<in> state_relation; invs' s'; valid_state s\<rbrakk>
+  "\<lbrakk>(s,s') \<in> state_relation; valid_state' s'; valid_state s\<rbrakk>
    \<Longrightarrow> user_mem' s' = user_mem s"
   apply (rule ext)
   apply (clarsimp simp: user_mem_def user_mem'_def pointerInUserData_relation pointerInDeviceData_relation)
@@ -190,199 +188,140 @@ lemma user_mem_relation:
   done
 
 lemma device_mem_relation:
-  "\<lbrakk>(s,s') \<in> state_relation; invs' s'; valid_state s\<rbrakk>
+  "\<lbrakk>(s,s') \<in> state_relation; valid_state' s'; valid_state s\<rbrakk>
    \<Longrightarrow> device_mem' s' = device_mem s"
-  unfolding device_mem_def device_mem'_def
-  by (rule ext) (clarsimp simp: pointerInUserData_relation pointerInDeviceData_relation)
+  apply (rule ext)
+  apply (clarsimp simp: device_mem_def device_mem'_def pointerInUserData_relation
+     pointerInDeviceData_relation)
+  done
 
 lemma absKState_correct:
-  assumes invs: "einvs (s :: det_ext state)" and invs': "invs' s'"
-  assumes rel: "(s,s') \<in> state_relation"
-  shows "absKState s' = abs_state s"
+assumes invs: "einvs (s :: det_ext state)" and invs': "invs' s'"
+assumes rel: "(s,s') \<in> state_relation"
+shows "absKState s' = abs_state s"
   using assms
   apply (intro state.equality, simp_all add: absKState_def abs_state_def)
-                      apply (rule absHeap_correct; clarsimp simp: state_relation_sc_replies_relation)
-                      apply (clarsimp elim!: state_relationE)
-                     apply (rule absCDT_correct; clarsimp)
-                    apply (rule absIsOriginalCap_correct; clarsimp)
-                   apply (simp add: state_relation_def)
-                  apply (simp add: state_relation_def)
-                 apply (clarsimp simp: state_relation_def)
-                apply (simp add: state_relation_def)
-               apply (simp add: state_relation_def)
-              apply (simp add: state_relation_def)
-             apply (rule absSchedulerAction_correct, simp add: state_relation_def)
-            apply (simp add: state_relation_def)
-           apply (simp add: state_relation_def)
-          apply (simp add: state_relation_def)
-         apply (simp add: state_relation_def)
-        apply (fastforce simp: curry_def state_relation_def ready_queues_relation_def)
-       apply (simp add: state_relation_def release_queue_relation_def)
+           apply (rule absHeap_correct, clarsimp+)
+           apply (clarsimp elim!: state_relationE)
+          apply (rule absCDT_correct, clarsimp+)
+         apply (rule absIsOriginalCap_correct, clarsimp+)
+        apply (simp add: state_relation_def)
+       apply (simp add: state_relation_def)
       apply (clarsimp simp:  user_mem_relation invs_def invs'_def)
       apply (simp add: state_relation_def)
      apply (rule absInterruptIRQNode_correct, simp add: state_relation_def)
     apply (rule absInterruptStates_correct, simp add: state_relation_def)
    apply (rule absArchState_correct, simp)
-  apply (rule absExst_correct; simp)
+  apply (rule absExst_correct, simp+)
   done
 
 text \<open>The top-level invariance\<close>
 
-lemma kernel_entry_invs_det_ext:
-  "\<lbrace>\<lambda>s. invs s \<and> schact_is_rct s \<and> cur_sc_active s \<and> ct_not_in_release_q s
-          \<and> (e \<noteq> Interrupt \<longrightarrow> ct_running s)\<rbrace>
-   kernel_entry e us
-   \<lbrace>\<lambda>_ s :: det_state. invs s \<and> (ct_running s \<or> ct_idle s)\<rbrace>"
-  apply (simp add: kernel_entry_def)
-  apply (wp akernel_invs_det_ext thread_set_invs_trivial thread_set_ct_in_state
-            hoare_weak_lift_imp hoare_vcg_disj_lift hoare_vcg_imp_lift'
-         | clarsimp simp add: tcb_cap_cases_def)+
+lemma set_thread_state_sched_act:
+  "\<lbrace>(\<lambda>s. runnable state) and (\<lambda>s. P (scheduler_action s))\<rbrace>
+  set_thread_state thread state
+  \<lbrace>\<lambda>rs s. P (scheduler_action (s::det_state))\<rbrace>"
+  apply (simp add: set_thread_state_def)
+  apply wp
+    apply (simp add: set_thread_state_ext_def)
+    apply wp
+       apply (rule hoare_pre_cont)
+      apply (rule_tac Q'="\<lambda>rv. (\<lambda>s. runnable ts) and (\<lambda>s. P (scheduler_action s))"
+              in hoare_strengthen_post)
+       apply wp
+      apply force
+     apply (wp gts_st_tcb_at)+
+     apply (rule_tac Q'="\<lambda>rv. st_tcb_at ((=) state) thread and (\<lambda>s. runnable state) and (\<lambda>s. P (scheduler_action s))" in hoare_strengthen_post)
+     apply (simp add: st_tcb_at_def)
+     apply (wp obj_set_prop_at)+
+    apply (force simp: st_tcb_at_def obj_at_def)
+  apply wp
+  apply clarsimp
   done
 
-lemma kernel_entry_valid_sched:
-  "\<lbrace>\<lambda>s. valid_sched s \<and> invs s \<and> schact_is_rct s
-        \<and> cur_sc_active s \<and> ct_not_in_release_q s
-        \<and> (ct_running s \<or> ct_idle s) \<and> (e \<noteq> Interrupt \<longrightarrow> ct_running s)
-        \<and> valid_machine_time s \<and> current_time_bounded s \<and> consumed_time_bounded s
-        \<and> cur_sc_offset_ready (consumed_time s) s
-        \<and> cur_sc_offset_sufficient (consumed_time s) s\<rbrace>
-   kernel_entry e us
-   \<lbrace>\<lambda>_. valid_sched :: det_state \<Rightarrow> _\<rbrace>"
-  apply (simp add: kernel_entry_def)
-  apply (wp call_kernel_valid_sched thread_set_invs_trivial thread_set_ct_in_state
-            hoare_weak_lift_imp hoare_vcg_disj_lift thread_set_not_state_valid_sched
-         | clarsimp simp add: tcb_cap_cases_def)+
-  done
+lemma activate_thread_sched_act:
+  "\<lbrace>ct_in_state activatable and (\<lambda>s. P (scheduler_action s))\<rbrace>
+  activate_thread
+  \<lbrace>\<lambda>rs s. P (scheduler_action (s::det_state))\<rbrace>"
+  by (simp add: activate_thread_def set_thread_state_def arch_activate_idle_thread_def
+      | (wp set_thread_state_sched_act gts_wp)+ | wpc)+
 
-abbreviation (input) mcs_invs where
-  "mcs_invs s \<equiv> einvs s
-                 \<and> scheduler_action s = resume_cur_thread
-                 \<and> cur_sc_active s \<and> ct_not_in_release_q s
-                 \<and> valid_machine_time s \<and> current_time_bounded s \<and> consumed_time_bounded s
-                 \<and> (cur_sc_offset_ready (consumed_time s) s
-                    \<and> cur_sc_offset_sufficient (consumed_time s) s)
-                 \<and> valid_domain_list s "
+lemma schedule_sched_act_rct[wp]:
+  "\<lbrace>\<top>\<rbrace> Schedule_A.schedule
+  \<lbrace>\<lambda>rs (s::det_state). scheduler_action s = resume_cur_thread\<rbrace>"
+  unfolding Schedule_A.schedule_def
+  by (wpsimp)
+
+lemma call_kernel_sched_act_rct[wp]:
+  "\<lbrace>einvs and (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_running s)
+     and (\<lambda>s. scheduler_action s = resume_cur_thread)\<rbrace>
+  call_kernel e
+  \<lbrace>\<lambda>rs (s::det_state). scheduler_action s = resume_cur_thread\<rbrace>"
+  apply (simp add: call_kernel_def)
+  apply (wp activate_thread_sched_act | simp)+
+  apply (clarsimp simp: active_from_running)
+  done
 
 lemma kernel_entry_invs:
-  "\<lbrace>\<lambda>s. mcs_invs s \<and> (ct_running s \<or> ct_idle s) \<and> (e \<noteq> Interrupt \<longrightarrow> ct_running s)\<rbrace>
-   kernel_entry e us
-   \<lbrace>\<lambda>_ s. mcs_invs s \<and> (ct_running s \<or> ct_idle s)\<rbrace>"
-  apply (rule_tac Q'="\<lambda>_ s. (invs s \<and> (ct_running s \<or> ct_idle s))
-                           \<and> (cur_sc_offset_ready (consumed_time s) s
-                              \<and> cur_sc_offset_sufficient (consumed_time s) s)
-                           \<and> valid_sched s
-                           \<and> valid_domain_list s
-                           \<and> valid_list s \<and> scheduler_action s = resume_cur_thread
-                           \<and> cur_sc_active s \<and> ct_not_in_release_q s
-                           \<and> valid_machine_time s \<and> current_time_bounded s
-                           \<and> consumed_time_bounded s"
+  "\<lbrace>einvs and (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_running s)
+    and (\<lambda>s. 0 < domain_time s) and valid_domain_list and (ct_running or ct_idle)
+    and (\<lambda>s. scheduler_action s = resume_cur_thread)\<rbrace>
+  kernel_entry e us
+  \<lbrace>\<lambda>rv. einvs and (\<lambda>s. ct_running s \<or> ct_idle s)
+    and (\<lambda>s. 0 < domain_time s) and valid_domain_list
+    and (\<lambda>s. scheduler_action s = resume_cur_thread)\<rbrace>"
+  apply (rule_tac Q'="\<lambda>rv. invs and (\<lambda>s. ct_running s \<or> ct_idle s) and valid_sched and
+                           (\<lambda>s. 0 < domain_time s) and valid_domain_list and
+                           valid_list and (\<lambda>s. scheduler_action s = resume_cur_thread)"
             in hoare_post_imp)
    apply clarsimp
-  apply (rule hoare_vcg_conj_lift_pre_fix)
-   apply (wpsimp wp: kernel_entry_invs_det_ext)
-  apply (rule hoare_vcg_conj_lift_pre_fix)
-   apply (clarsimp simp: kernel_entry_def)
-   apply (wp thread_set_invs_trivial thread_set_not_state_valid_sched hoare_vcg_disj_lift
-             ct_in_state_thread_state_lift thread_set_no_change_tcb_state
-             hoare_weak_lift_imp call_kernel_cur_sc_offset_ready_and_sufficient
-          | clarsimp simp: tcb_cap_cases_def)+
-  apply (rule hoare_vcg_conj_lift_pre_fix)
-   apply (wpsimp wp: kernel_entry_valid_sched)
-  apply (rule hoare_vcg_conj_lift_pre_fix)
-   apply (clarsimp simp: kernel_entry_def)
-   apply (wpsimp wp: call_kernel_domain_list_inv_det_ext | clarsimp simp: active_from_running)+
-  apply (rule hoare_vcg_conj_lift_pre_fix)
-   apply (clarsimp simp: kernel_entry_def)
-   apply wpsimp
-  apply (rule hoare_vcg_conj_lift_pre_fix)
-   apply (clarsimp simp: kernel_entry_def)
-   apply (wp thread_set_invs_trivial thread_set_not_state_valid_sched hoare_vcg_disj_lift
-             ct_in_state_thread_state_lift thread_set_no_change_tcb_state hoare_weak_lift_imp
-             call_kernel_schact_is_rct[unfolded schact_is_rct_def]
-          | clarsimp simp: tcb_cap_cases_def)+
-  apply (rule hoare_vcg_conj_lift_pre_fix)
-   apply (clarsimp simp: kernel_entry_def)
-   apply (wp thread_set_invs_trivial thread_set_not_state_valid_sched hoare_vcg_disj_lift
-             ct_in_state_thread_state_lift thread_set_no_change_tcb_state hoare_weak_lift_imp
-             call_kernel_cur_sc_active
-          | clarsimp simp: tcb_cap_cases_def)+
-  apply (rule hoare_vcg_conj_lift_pre_fix)
-   apply (clarsimp simp: kernel_entry_def)
-   apply (wp thread_set_invs_trivial thread_set_not_state_valid_sched hoare_vcg_disj_lift
-             ct_in_state_thread_state_lift thread_set_no_change_tcb_state
-             hoare_weak_lift_imp call_kernel_ct_not_in_release_q
-          | clarsimp simp: tcb_cap_cases_def)+
-  apply (rule hoare_vcg_conj_lift_pre_fix)
-   apply (clarsimp simp: kernel_entry_def)
-   apply wpsimp
-  apply (rule hoare_vcg_conj_lift_pre_fix)
-   apply (clarsimp simp: kernel_entry_def)
-   apply (wpsimp wp: call_kernel_current_time_bounded)
-  apply (clarsimp simp: kernel_entry_def)
-  apply (wpsimp wp: call_kernel_consumed_time_bounded)
+  apply (simp add: kernel_entry_def)
+  apply (wp akernel_invs_det_ext call_kernel_valid_sched thread_set_invs_trivial
+            thread_set_ct_running thread_set_not_state_valid_sched
+            hoare_vcg_disj_lift ct_in_state_thread_state_lift thread_set_no_change_tcb_state
+            call_kernel_domain_time_inv_det_ext call_kernel_domain_list_inv_det_ext
+            hoare_weak_lift_imp
+      | clarsimp simp add: tcb_cap_cases_def active_from_running)+
   done
 
 definition
-  "full_invs
-     \<equiv> {((tc, s :: det_ext state), m, e). mcs_invs s
-                                          \<and> (ct_running s \<or> ct_idle s)
-                                          \<and> (m = KernelMode \<longrightarrow> e \<noteq> None)
-                                          \<and> (m = UserMode \<longrightarrow> ct_running s)
-                                          \<and> (m = IdleMode \<longrightarrow> ct_idle s)
-                                          \<and> (e \<noteq> None \<and> e \<noteq> Some Interrupt \<longrightarrow> ct_running s)}"
+  "full_invs \<equiv> {((tc, s :: det_ext state), m, e). einvs s \<and>
+                                 (ct_running s \<or> ct_idle s) \<and>
+                                 (m = KernelMode \<longrightarrow> e \<noteq> None) \<and>
+                                 (m = UserMode \<longrightarrow> ct_running s) \<and>
+                                 (m = IdleMode \<longrightarrow> ct_idle s) \<and>
+                                 (e \<noteq> None \<and> e \<noteq> Some Interrupt \<longrightarrow> ct_running s) \<and>
+                                 0 < domain_time s \<and> valid_domain_list s \<and>
+                                 (scheduler_action s = resume_cur_thread)}"
 
-crunch do_user_op, check_active_irq
-  for valid_list[wp]: valid_list
-  and valid_sched[wp]: valid_sched
-  and sched_act[wp]: "\<lambda>s. P (scheduler_action s)"
-  and domain_time[wp]: "\<lambda>s. P (domain_time s)"
-  and cur_sc_active[wp]: cur_sc_active
-  and ct_not_in_release_q[wp]: ct_not_in_release_q
-  and current_time_bounded[wp]: current_time_bounded
-  and cur_sc_offset_ready[wp]: "\<lambda>s. cur_sc_offset_ready (consumed_time s) s"
-  and cur_sc_offset_sufficient[wp]: "\<lambda>s. cur_sc_offset_sufficient (consumed_time s) s"
-  and consumed_time_bounded[wp]: consumed_time_bounded
-
-lemma device_update_valid_machine_time[wp]:
-  "do_machine_op (device_memory_update ds) \<lbrace>valid_machine_time\<rbrace>"
-  apply (simp add: do_machine_op_def device_memory_update_def simpler_modify_def select_f_def
-                   gets_def get_def bind_def valid_def return_def)
+lemma do_user_op_valid_list:"\<lbrace>valid_list\<rbrace> do_user_op f tc \<lbrace>\<lambda>_. valid_list\<rbrace>"
+  unfolding do_user_op_def
+  apply (wp | simp add: split_def)+
   done
 
-lemma user_memory_update_valid_machine_time[wp]:
-  "do_machine_op (user_memory_update ds) \<lbrace>valid_machine_time\<rbrace>"
-  apply (simp add: do_machine_op_def user_memory_update_def simpler_modify_def select_f_def
-                   gets_def get_def bind_def valid_def return_def)
+lemma do_user_op_valid_sched:"\<lbrace>valid_sched\<rbrace> do_user_op f tc \<lbrace>\<lambda>_. valid_sched\<rbrace>"
+  unfolding do_user_op_def
+  apply (wp | simp add: split_def)+
   done
 
-lemma do_user_op_valid_machine_time[wp]:
-  "do_user_op f tc \<lbrace>valid_machine_time\<rbrace>"
-  apply (simp add: do_user_op_def)
-  apply wpsimp
-  done
-
-lemma check_active_irq_valid_machine_time[wp]:
-  "check_active_irq \<lbrace>valid_machine_time\<rbrace>"
-  apply (clarsimp simp: check_active_irq_def)
-  apply (wpsimp wp: getActiveIRQ_inv)
+lemma do_user_op_sched_act:
+  "\<lbrace>\<lambda>s. P (scheduler_action s)\<rbrace> do_user_op f tc \<lbrace>\<lambda>_ s. P (scheduler_action s)\<rbrace>"
+  unfolding do_user_op_def
+  apply (wp | simp add: split_def)+
   done
 
 lemma do_user_op_invs2:
-  "do_user_op f tc
-   \<lbrace>\<lambda>s. mcs_invs s \<and> ct_running s\<rbrace>"
-  apply (rule_tac Q'="\<lambda>_ s. (invs s \<and> ct_running s) \<and> valid_list s \<and> valid_sched s
-                           \<and> scheduler_action s = resume_cur_thread
-                           \<and> valid_domain_list s
-                           \<and> cur_sc_active s \<and> ct_not_in_release_q s
-                           \<and> valid_machine_time s \<and> current_time_bounded s
-                           \<and> consumed_time_bounded s
-                           \<and> cur_sc_offset_ready (consumed_time s) s
-                           \<and> cur_sc_offset_sufficient (consumed_time s) s"
-               in hoare_post_imp, fastforce)
-  apply (rule hoare_vcg_conj_lift_pre_fix)
-   apply (wpsimp wp: do_user_op_invs[simplified pred_conj_def])
-  apply (wp do_user_op_valid_list do_user_op_valid_sched do_user_op_sched_act do_user_op_domain_time
-         | fastforce)+
+  "\<lbrace>einvs  and ct_running and (\<lambda>s. scheduler_action s = resume_cur_thread)
+    and (\<lambda>s. 0 < domain_time s) and valid_domain_list \<rbrace>
+  do_user_op f tc
+   \<lbrace>\<lambda>_. (einvs  and ct_running and (\<lambda>s. scheduler_action s = resume_cur_thread))
+        and (\<lambda>s. 0 < domain_time s) and valid_domain_list \<rbrace>"
+  apply (rule_tac Q'="\<lambda>_. valid_list and valid_sched and
+   (\<lambda>s. scheduler_action s = resume_cur_thread) and (invs and ct_running) and
+   (\<lambda>s. 0 < domain_time s) and valid_domain_list"
+   in hoare_strengthen_post)
+  apply (wp do_user_op_valid_list do_user_op_valid_sched do_user_op_sched_act
+    do_user_op_invs | simp | force)+
   done
 
 lemmas ext_init_def = ext_init_det_ext_ext_def ext_init_unit_def
@@ -396,68 +335,16 @@ lemmas valid_list_inits[simp] = valid_list_init[simplified]
 lemma valid_sched_init[simp]:
   "valid_sched init_A_st"
   apply (simp add: valid_sched_def init_A_st_def ext_init_def)
-  apply (insert getCurrentTime_buffer_bound MIN_BUDGET_le_MAX_PERIOD')
-  apply (clarsimp simp: init_kheap_def obj_at_def idle_thread_ptr_def init_globals_frame_def
-                        init_global_pd_def ct_not_in_q_def valid_sched_action_def is_activatable_def
-                        ct_in_cur_domain_2_def valid_idle_etcb_def etcb_at'_def
-                        valid_ready_qs_def ready_or_release_2_def in_queues_2_def
-                        idle_sc_ptr_def valid_blocked_defs default_domain_def minBound_word
-                        released_ipc_queues_defs active_reply_scs_def active_if_reply_sc_at_def
-                        active_sc_def MIN_REFILLS_def)
-  by (auto simp: vs_all_heap_simps active_scs_valid_def cfg_valid_refills_def
-                 rr_valid_refills_def MIN_REFILLS_def bounded_release_time_def
-                 default_sched_context_def MAX_PERIOD_def active_sc_def
-          intro: order_trans[OF mult_left_mono, OF us_to_ticks_helper])
+  apply (clarsimp simp: valid_etcbs_def init_kheap_def st_tcb_at_kh_def obj_at_kh_def
+                    obj_at_def is_etcb_at_def idle_thread_ptr_def init_globals_frame_def
+                    init_global_pd_def valid_queues_2_def ct_not_in_q_def not_queued_def
+                    valid_sched_action_def is_activatable_def
+                    ct_in_cur_domain_2_def valid_blocked_2_def valid_idle_etcb_def etcb_at'_def default_etcb_def)
+  done
 
 lemma valid_domain_list_init[simp]:
   "valid_domain_list init_A_st"
-  apply (insert domain_time_pos)
-  apply (simp add: init_A_st_def ext_init_def valid_domain_list_def)
-  done
-
-lemma cur_sc_active_init[simp]:
-  "cur_sc_active init_A_st"
-  apply (clarsimp simp: init_A_st_def init_kheap_def vs_all_heap_simps active_sc_def MIN_REFILLS_def)
-  done
-
-lemma ct_not_in_release_q_init[simp]:
-  "ct_not_in_release_q init_A_st"
-  apply (clarsimp simp: init_A_st_def init_kheap_def not_in_release_q_def in_queue_2_def)
-  done
-
-lemma valid_machine_time_init[simp]:
-  "valid_machine_time init_A_st"
-  apply (clarsimp simp: init_A_st_def valid_machine_time_def init_machine_state_def)
-  done
-
-lemma current_time_bounded_init[simp]:
-  "current_time_bounded init_A_st"
-  apply (insert getCurrentTime_buffer_no_overflow)
-  apply (clarsimp simp: current_time_bounded_def init_A_st_def)
-  done
-
-lemma consumed_time_bounded_init[simp]:
-  "consumed_time_bounded init_A_st"
-  apply (clarsimp simp: init_kheap_def init_A_st_def)
-  done
-
-lemma cur_sc_offset_ready_and_sufficient[simp]:
-  "cur_sc_offset_ready (consumed_time init_A_st) init_A_st
-   \<and> cur_sc_offset_sufficient (consumed_time init_A_st) init_A_st"
-  apply (clarsimp simp: init_A_st_def)
-  done
-
-lemma check_active_irq_invs:
-  "check_active_irq \<lbrace>\<lambda>s. mcs_invs s \<and> (ct_running s \<or> ct_idle s)\<rbrace>"
-  by (wpsimp simp: check_active_irq_def ct_in_state_def)
-
-lemma check_active_irq_invs_just_running:
-  "check_active_irq \<lbrace>\<lambda>s. mcs_invs s \<and> ct_running s\<rbrace>"
-  by (wpsimp simp: check_active_irq_def ct_in_state_def)
-
-lemma check_active_irq_invs_just_idle:
-  "check_active_irq \<lbrace>\<lambda>s. mcs_invs s \<and> ct_idle s\<rbrace>"
-  by (wpsimp simp: check_active_irq_def ct_in_state_def)
+  by (simp add: init_A_st_def ext_init_def valid_domain_list_def)
 
 lemma akernel_invariant:
   "ADT_A uop \<Turnstile> full_invs"
@@ -468,55 +355,44 @@ lemma akernel_invariant:
    apply (simp add: Let_def Init_A_def)
    apply (simp add: init_A_st_def ext_init_def)
   apply (clarsimp simp: ADT_A_def global_automaton_def)
+
   apply (rename_tac tc' s' mode' e' tc s mode e)
   apply (elim disjE)
              apply ((clarsimp simp: kernel_call_A_def
-                    | drule use_valid[OF _ kernel_entry_invs])+)[2]
+                   | drule use_valid[OF _ kernel_entry_invs])+)[2]
            apply ((clarsimp simp: do_user_op_A_def monad_to_transition_def
                                   check_active_irq_A_def
-                  | drule use_valid[OF _ do_user_op_invs2]
-                  | drule use_valid[OF _ check_active_irq_invs_just_running]
-                  | drule use_valid[OF _ do_user_op_cur_sc_active])+)[2]
+                 | drule use_valid[OF _ do_user_op_invs2]
+                 | drule use_valid[OF _ check_active_irq_invs_just_running])+)[2]
          apply ((clarsimp simp add: check_active_irq_A_def
-                | drule use_valid[OF _ check_active_irq_invs])+)[1]
+               | drule use_valid[OF _ check_active_irq_invs])+)[1]
         apply (clarsimp simp: ct_in_state_def st_tcb_at_def obj_at_def)
        apply ((clarsimp simp add: do_user_op_A_def check_active_irq_A_def
-              | drule use_valid[OF _ do_user_op_invs2]
-              | drule use_valid[OF _ check_active_irq_invs_just_running])+)[1]
+             | drule use_valid[OF _ do_user_op_invs2]
+             | drule use_valid[OF _ check_active_irq_invs_just_running])+)[1]
       apply (clarsimp simp: ct_in_state_def st_tcb_at_def obj_at_def)
      apply (clarsimp simp: ct_in_state_def st_tcb_at_def obj_at_def)
     apply ((clarsimp simp add: check_active_irq_A_def
-           | drule use_valid[OF _ check_active_irq_invs])+)[1]
-   apply ((clarsimp simp add: check_active_irq_A_def
-          | drule use_valid[OF _ check_active_irq_invs_just_idle])+)[1]
-  apply ((clarsimp simp add: check_active_irq_A_def
          | drule use_valid[OF _ check_active_irq_invs])+)[1]
+   apply ((clarsimp simp add: check_active_irq_A_def
+        | drule use_valid[OF _ check_active_irq_invs_just_idle])+)[1]
+  apply ((clarsimp simp add: check_active_irq_A_def
+        | drule use_valid[OF _ check_active_irq_invs])+)[1]
   done
 
 lemma ckernel_invs:
-  "\<lbrace>invs' and (\<lambda>s. vs_valid_duplicates' (ksPSpace s))
-    and (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_running' s) and (ct_running' or ct_idle')
-    and (\<lambda>s. is_active_sc' (ksCurSc s) s) and sym_heap_tcbSCs
-    and (\<lambda>s. obj_at' (\<lambda>sc. scTCB sc = Some (ksCurThread s)) (ksCurSc s) s)
-    and (\<lambda>s. pred_map (\<lambda>tcb. \<not> tcbInReleaseQueue tcb) (tcbs_of' s) (ksCurThread s))
-    and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread)\<rbrace>
-   callKernel e
-   \<lbrace>\<lambda>_. invs'\<rbrace>"
-  apply (simp add: callKernel_def mcsPreemptionPoint_def)
+  "\<lbrace>invs' and (\<lambda>s. vs_valid_duplicates' (ksPSpace s)) and
+               (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_running' s) and
+               (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread)\<rbrace>
+  callKernel e
+  \<lbrace>\<lambda>rs. (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread)
+    and (invs' and (ct_running' or ct_idle'))\<rbrace>"
+  apply (simp add: callKernel_def)
   apply (rule hoare_pre)
-   apply (wpsimp wp: hoare_drop_imp[where Q'="\<lambda>_. kernelExitAssertions"] activate_invs')
-     apply (rule hoare_drop_imp)
-     apply (wpsimp wp: schedule_invs')
-    apply (wpsimp wp: stateAssert_wp)
-   apply (wpsimp wp: isSchedulable_wp hoare_drop_imp)
-    apply (intro iffI; clarsimp simp: isScActive_def isSchedulable_bool_def)
-   apply (rule hoare_strengthen_postE[where E'="\<lambda>_. invs'" and Q=Q and R=Q for Q])
-     apply wpsimp
-    apply (clarsimp simp: active_from_running')+
-  apply (clarsimp simp: sym_heap_def pred_map_def)
-  apply (rule_tac x="ksCurSc s" in exI)
-  apply (clarsimp simp: obj_at_simps is_active_sc'_def isScActive_def opt_map_red pred_map_def
-                        opt_pred_def)
+   apply (wp activate_invs' activate_sch_act schedule_sch
+             schedule_sch_act_simple he_invs' schedule_invs'
+             hoare_drop_imp[where Q'="\<lambda>_. kernelExitAssertions"]
+          | simp add: no_irq_getActiveIRQ)+
   done
 
 (* abstract and haskell have identical domain list fields *)
@@ -539,59 +415,52 @@ lemma corres_cross_over_fastpathKernelAssertions:
      (fastforce elim: fastpathKernelAssertions_cross)+
 
 defs kernelExitAssertions_def:
-  "kernelExitAssertions s \<equiv> valid_domain_list' s"
+  "kernelExitAssertions s \<equiv> 0 < ksDomainTime s \<and> valid_domain_list' s"
 
 lemma callKernel_domain_time_left:
-  "\<lbrace> \<top> \<rbrace> callKernel e \<lbrace>\<lambda>_ s. valid_domain_list' s \<rbrace>"
+  "\<lbrace> \<top> \<rbrace> callKernel e \<lbrace>\<lambda>_ s. 0 < ksDomainTime s \<and> valid_domain_list' s \<rbrace>"
   unfolding callKernel_def kernelExitAssertions_def by wpsimp
 
-lemma threadSet_is_active_sc'[wp]:
-  "threadSet f tp \<lbrace>\<lambda>s. is_active_sc' scp s\<rbrace>"
-  by (wpsimp simp: is_active_sc'_def)
-
-lemma threadSet_sym_heap_tcbSCs:
-  "\<forall>x. tcbSchedContext (f x) = tcbSchedContext x \<Longrightarrow>
-  threadSet f t \<lbrace>\<lambda>s. P (tcbSCs_of s) (scTCBs_of s)\<rbrace>"
-  unfolding threadSet_def
-  apply (rule bind_wp[OF _ get_tcb_sp'])
-  apply (wpsimp wp: setObject_tcb_tcbs_of' | wps)+
-  apply (prop_tac "((\<lambda>a. if a = t then Some (f tcb) else tcbs_of' s a) |>
-              tcbSchedContext) = tcbSCs_of s")
-   apply (rule ext)
-   apply (clarsimp simp: obj_at'_def projectKOs opt_map_def)
-  apply simp
-  done
-
 lemma kernelEntry_invs':
-  "\<lbrace> invs' and (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_running' s)
-    and (ct_running' or ct_idle')
-    and (\<lambda>s. vs_valid_duplicates' (ksPSpace s))
-    and (\<lambda>s. is_active_sc' (ksCurSc s) s) and sym_heap_tcbSCs
-    and (\<lambda>s. obj_at' (\<lambda>sc. scTCB sc = Some (ksCurThread s)) (ksCurSc s) s)
-    and (\<lambda>s. pred_map (\<lambda>tcb. \<not> tcbInReleaseQueue tcb) (tcbs_of' s) (ksCurThread s))
-    and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread)
-    and valid_domain_list' \<rbrace>
+  "\<lbrace> invs' and (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_running' s) and
+           (ct_running' or ct_idle') and
+           (\<lambda>s. vs_valid_duplicates' (ksPSpace s)) and
+           (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread) and
+           (\<lambda>s. 0 < ksDomainTime s) and valid_domain_list' \<rbrace>
   kernelEntry e tc
-  \<lbrace>\<lambda>_. invs' and (\<lambda>s. vs_valid_duplicates' (ksPSpace s))\<rbrace>"
-  apply (rule_tac P'1="\<lambda>s. obj_at' (\<lambda>tcb. tcbSchedContext tcb = Some (ksCurSc s)) (ksCurThread s) s"
-         in hoare_pre_add[THEN iffD2])
-   apply (clarsimp simp: obj_at'_tcb_scs_of_equiv obj_at'_sc_tcbs_of_equiv sym_heap_def)
-   apply (fastforce simp: ct_in_state'_def pred_tcb_at'_def obj_at'_def)
+  \<lbrace>\<lambda>rs. (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread) and
+         (invs' and (ct_running' or ct_idle')) and
+         (\<lambda>s. vs_valid_duplicates' (ksPSpace s)) and
+         (\<lambda>s. 0 < ksDomainTime s) and valid_domain_list' \<rbrace>"
   apply (simp add: kernelEntry_def)
-  apply (wpsimp wp: ckernel_invs callKernel_valid_duplicates' threadSet_invs_trivial
-                    threadSet_ct_in_state' hoare_weak_lift_imp hoare_vcg_disj_lift threadSet_sym_heap_tcbSCs
-         | wps)+
-    apply (rule hoare_vcg_conj_lift)
-     apply (wpsimp wp: threadSet_wp)
-    apply (wpsimp wp: threadSet_invs_trivial; simp?)
-    apply (wpsimp wp: threadSet_ct_running' hoare_weak_lift_imp)+
-  apply (fastforce simp: obj_at'_def projectKOs pred_map_def opt_map_red)
+  apply (wp ckernel_invs callKernel_valid_duplicates' callKernel_domain_time_left
+            threadSet_invs_trivial threadSet_ct_running'
+            TcbAcc_R.dmo_invs' hoare_weak_lift_imp
+            callKernel_domain_time_left
+         | clarsimp simp: user_memory_update_def no_irq_def tcb_at_invs'
+                          valid_domain_list'_def)+
   done
 
 lemma absKState_correct':
   "\<lbrakk>einvs s; invs' s'; (s,s') \<in> state_relation\<rbrakk>
    \<Longrightarrow> absKState s' = abs_state s"
-  by (rule absKState_correct)
+  apply (intro state.equality, simp_all add: absKState_def abs_state_def)
+           apply (rule absHeap_correct)
+               apply (clarsimp simp: valid_state_def valid_pspace_def)+
+           apply (clarsimp dest!: state_relationD)
+          apply (rule absCDT_correct)
+                apply (clarsimp simp: valid_state_def valid_pspace_def
+                                      valid_state'_def valid_pspace'_def)+
+         apply (rule absIsOriginalCap_correct, clarsimp+)
+        apply (simp add: state_relation_def)
+       apply (simp add: state_relation_def)
+      apply (clarsimp simp: user_mem_relation invs_def invs'_def)
+      apply (simp add: state_relation_def)
+     apply (rule absInterruptIRQNode_correct, simp add: state_relation_def)
+    apply (rule absInterruptStates_correct, simp add: state_relation_def)
+   apply (erule absArchState_correct)
+  apply (rule absExst_correct, simp, assumption+)
+  done
 
 lemma ptable_lift_abs_state[simp]:
   "ptable_lift t (abs_state s) = ptable_lift t s"
@@ -612,12 +481,13 @@ proof -
   from invs invs' rel have [simp]: "absKState s' = abs_state s"
     by - (rule absKState_correct', simp_all)
   from invs have valid: "valid_state s" by auto
+  from invs' have valid': "valid_state' s'" by auto
   have "in_user_frame y s \<or> in_device_frame y s "
     by (rule ptable_rights_imp_frame[OF valid rights[simplified]
                                              trans[simplified]])
   thus ?thesis
-   by (auto simp add: pointerInUserData_relation[OF rel invs' valid]
-     pointerInDeviceData_relation[OF rel invs' valid])
+   by (auto simp add: pointerInUserData_relation[OF rel valid' valid]
+     pointerInDeviceData_relation[OF rel valid' valid])
 qed
 
 
@@ -626,8 +496,7 @@ lemma device_update_invs':
    \<lbrace>\<lambda>_. invs'\<rbrace>"
    apply (simp add: doMachineOp_def device_memory_update_def simpler_modify_def select_f_def
                     gets_def get_def bind_def valid_def return_def)
-   by (clarsimp simp: invs'_def valid_irq_states'_def valid_machine_state'_def
-                      valid_dom_schedule'_def)
+   by (clarsimp simp: invs'_def valid_state'_def valid_irq_states'_def valid_machine_state'_def)
 
 lemmas ex_abs_def = ex_abs_underlying_def[where sr=state_relation and P=G,abs_def] for G
 
@@ -637,11 +506,11 @@ crunch doMachineOp
 lemma doUserOp_invs':
   "\<lbrace>invs' and ex_abs einvs and
     (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread) and ct_running' and
-    valid_domain_list'\<rbrace>
+    (\<lambda>s. 0 < ksDomainTime s) and valid_domain_list'\<rbrace>
    doUserOp f tc
    \<lbrace>\<lambda>_. invs' and
         (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread) and ct_running' and
-        valid_domain_list'\<rbrace>"
+        (\<lambda>s. 0 < ksDomainTime s) and valid_domain_list'\<rbrace>"
   apply (simp add: doUserOp_def split_def ex_abs_def)
   apply (wp device_update_invs'
     | (wp (once) dmo_invs', wpsimp simp: no_irq_modify device_memory_update_def
@@ -663,155 +532,9 @@ lemma doUserOp_valid_duplicates':
 
 text \<open>The top-level correspondence\<close>
 
-lemma kernel_preemption_corres:
-  "corres (dc \<oplus> dc)
-     (einvs and current_time_bounded and scheduler_act_sane
-      and (\<lambda>s. schact_is_rct s \<longrightarrow> cur_sc_active s)
-      and (\<lambda>s. schact_is_rct s \<longrightarrow> ct_in_state activatable s)
-      and cur_sc_chargeable and ct_not_blocked
-      and (\<lambda>s. cur_sc_active s \<longrightarrow> cur_sc_offset_ready (consumed_time s) s) and ct_not_queued
-      and consumed_time_bounded and ct_not_in_release_q)
-      invs'
-     (liftE preemption_path)
-     (liftE (do irq_opt <- doMachineOp (getActiveIRQ True);
-                   _ <- mcsPreemptionPoint irq_opt;
-                   when (\<exists>y. irq_opt = Some y) (handleInterrupt (the irq_opt))
-                od))" (is "corres _ ?P ?P' _ _")
-  apply (rule_tac Q="\<lambda>s. sc_at' (ksCurSc s) s" in corres_cross_add_guard)
-   apply clarsimp
-   apply (frule (1) cur_sc_tcb_sc_at_cur_sc[OF invs_valid_objs invs_cur_sc_tcb])
-   apply (drule state_relationD, clarsimp)
-   apply (erule sc_at_cross; fastforce simp: invs_def valid_state_def valid_pspace_def)
-  apply (rule corres_guard_imp)
-    apply (simp add: preemption_path_def mcsPreemptionPoint_def bind_assoc)
-    apply (rule corres_split[OF corres_machine_op])
-       apply (rule corres_underlying_trivial)
-       apply (rule no_fail_getActiveIRQ)
-      apply (clarsimp simp: dc_def[symmetric])
-      apply (rule corres_split_eqr[OF getCurThread_corres])
-        apply (rule corres_split_eqr[OF isSchedulable_corres])
-          apply (rename_tac irq ct sched)
-          apply (rule corres_split[OF corres_if2])
-               apply simp
-              apply (rule_tac P="?P and (\<lambda>s. ct = cur_thread s) and (\<lambda>s. sched = schedulable ct s)
-                                 and K sched"
-                         and P'="?P' and (\<lambda>s. ct = ksCurThread s)
-                                 and (\<lambda>s. sched = isSchedulable_bool ct s)"
-                     in corres_inst)
-              apply (rule corres_gen_asm')
-              apply(rule corres_guard_imp)
-                apply (rule corres_split_eqr[OF checkBudget_corres])
-                  apply (simp only: K_bind_def)
-                  apply (rule corres_return_trivial)
-                 apply wpsimp
-                apply wpsimp
-               apply (clarsimp simp: valid_sched_def runnable_eq_active
-                                     schedulable_def2 active_sc_tcb_at_def2 tcb_at_kh_simps[symmetric]
-                                     pred_tcb_at_def obj_at_def)
-               apply (rename_tac scp tcb)
-               apply (prop_tac "cur_sc_tcb_are_bound s \<and> scp = cur_sc s")
-                apply (clarsimp simp: cur_sc_chargeable_def)
-                apply (drule_tac x=scp in spec, clarsimp simp: vs_all_heap_simps)
-               apply clarsimp
-              apply simp
-             apply (simp add: get_sc_active_def active_sc_def dc_def[symmetric])
-             apply (rule corres_split_eqr[OF getCurSc_corres])
-               apply (rule corres_split[OF get_sc_corres])
-                 apply (rename_tac csc sc sc')
-                 apply (rule corres_if2)
-                   apply (clarsimp simp: sc_relation_def)
-                  apply (rule_tac P="?P and (\<lambda>s. ct = cur_thread s) and (\<lambda>s. sched = schedulable ct s)
-                                     and (\<lambda>s. \<exists>n. ko_at (Structures_A.SchedContext sc n) (cur_sc s) s)
-                                     and K (\<not>sched) and K (0 < sc_refill_max sc)"
-                             and P'="?P' and (\<lambda>s. ct = ksCurThread s)
-                                     and (\<lambda>s. sched = isSchedulable_bool ct s)"
-                         in corres_inst)
-                  apply(rule corres_guard_imp)
-                    apply (rule corres_split_eqr[OF getConsumedTime_corres])
-                      apply (rule chargeBudget_corres)
-                     apply wpsimp
-                    apply wpsimp
-                   apply (prop_tac "cur_sc_active s")
-                    apply (clarsimp simp: obj_at_def is_sc_active_kh_simp[symmetric]
-                                          is_sc_active_def2)
-                    apply (clarsimp simp: active_sc_def)
-                   apply (clarsimp simp: valid_sched_def)
-                   apply clarsimp
-                 apply (rule setConsumedTime_corres)
-                 apply simp
-                apply wpsimp
-               apply wpsimp
-              apply wpsimp
-             apply wpsimp
-            apply (rule_tac x=irq in option_corres)
-              apply (rule_tac P=\<top> and P'=\<top> in corres_inst)
-              apply (simp add: when_def)
-             apply (rule corres_when, simp)
-             apply simp
-             apply (rule handleInterrupt_corres)
-            apply simp
-           apply (rule hoare_vcg_if_split)
-            apply (wpsimp wp: check_budget_valid_sched hoare_vcg_imp_lift')
-           apply (wpsimp wp: hoare_vcg_if_split)
-               apply (wpsimp wp: charge_budget_valid_sched hoare_vcg_imp_lift')
-              apply wpsimp
-             apply wpsimp
-            apply wpsimp
-           apply wpsimp
-          apply (rule_tac Q'="\<lambda>_ s. bound irq \<longrightarrow> invs' s \<and> (intStateIRQTable (ksInterruptState s) (the irq) \<noteq>
-                                   irqstate.IRQInactive)"
-                 in hoare_strengthen_post[rotated])
-           apply clarsimp
-          apply (wpsimp wp: hoare_vcg_imp_lift')
-         apply clarsimp
-         apply (wpsimp wp: is_schedulable_wp')
-        apply (wpsimp wp: isSchedulable_wp cong: conj_cong imp_cong)
-       apply wpsimp
-      apply wpsimp
-     apply (rule_tac Q'="\<lambda>_ s. invs s \<and>  valid_sched s \<and> valid_list s \<and> scheduler_act_sane s \<and>
-                              consumed_time_bounded s \<and> ct_not_blocked s \<and> ct_not_in_release_q s \<and>
-                              current_time_bounded s \<and> cur_sc_chargeable s \<and>
-                              (cur_sc_active s \<longrightarrow> cur_sc_offset_ready (consumed_time s) s) \<and>
-                              (schact_is_rct s \<longrightarrow> cur_sc_active s) \<and> ct_not_queued s \<and>
-                              (schact_is_rct s \<longrightarrow> ct_in_state activatable s)"
-            in hoare_strengthen_post[rotated])
-      apply clarsimp
-      apply (frule ct_not_blocked_cur_sc_not_blocked, clarsimp)
-      apply clarsimp
-      apply (clarsimp simp: invs_def valid_state_def valid_pspace_def valid_objs_valid_tcbs
-                            valid_sched_def cur_tcb_def ct_in_state_kh_simp[symmetric])
-      apply (intro conjI; clarsimp simp: schedulable_def2 ct_in_state_def)
-        apply (clarsimp simp: current_time_bounded_def)
-        apply (rule context_conjI)
-         apply (clarsimp simp: cur_sc_tcb_def sc_tcb_sc_at_def obj_at_def is_sc_obj)
-         apply (erule (1) valid_sched_context_size_objsI)
-        apply clarsimp
-       apply (frule (1) cur_sc_chargeable_when_ct_active_sc)
-       apply (frule (1) active_sc_tcb_at_ct_cur_sc_active[THEN iffD2])
-       apply (clarsimp simp: current_time_bounded_def)
-      apply (rule context_conjI)
-       apply (clarsimp simp: vs_all_heap_simps obj_at_def)
-      apply (drule consumed_time_bounded_helper)
-       apply clarsimp
-      apply clarsimp
-     apply wpsimp
-    apply (rule_tac Q'="\<lambda>irq s. invs' s \<and> sc_at' (ksCurSc s) s \<and>
-                               (\<forall>irq'. irq = Some irq' \<longrightarrow>
-                                         intStateIRQTable (ksInterruptState s ) irq' \<noteq> IRQInactive)"
-           in hoare_post_imp)
-     apply (clarsimp simp: invs'_def valid_pspace'_def valid_objs'_valid_tcbs')
-    apply ((wp doMachineOp_getActiveIRQ_IRQ_active  | simp)+)[1]
-   apply clarsimp
-  apply (clarsimp simp: invs'_def)
-  done
-
 lemma kernel_corres':
   "corres dc (einvs and (\<lambda>s. event \<noteq> Interrupt \<longrightarrow> ct_running s) and (ct_running or ct_idle)
-              and current_time_bounded and consumed_time_bounded and valid_machine_time
-              and ct_not_in_release_q and cur_sc_active
-              and (\<lambda>s. cur_sc_offset_ready (consumed_time s) s)
-              and (\<lambda>s. cur_sc_offset_sufficient (consumed_time s) s)
-              and (\<lambda>s. scheduler_action s = resume_cur_thread))
+               and (\<lambda>s. scheduler_action s = resume_cur_thread))
              (invs' and (\<lambda>s. event \<noteq> Interrupt \<longrightarrow> ct_running' s) and (ct_running' or ct_idle') and
               (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread) and
               (\<lambda>s. vs_valid_duplicates' (ksPSpace s)))
@@ -819,155 +542,57 @@ lemma kernel_corres':
              (do _ \<leftarrow> runExceptT $
                       handleEvent event `~catchError~`
                         (\<lambda>_. withoutPreemption $ do
-                               irq_opt <- doMachineOp (getActiveIRQ True);
-                               _ \<leftarrow> mcsPreemptionPoint irq_opt;
-                               when (isJust irq_opt) $ handleInterrupt (fromJust irq_opt)
+                               irq <- doMachineOp (getActiveIRQ True);
+                               when (isJust irq) $ handleInterrupt (fromJust irq)
                              od);
-                 _ \<leftarrow> stateAssert rct_imp_activatable'_asrt [];
                  _ \<leftarrow> ThreadDecls_H.schedule;
-                 _ \<leftarrow> stateAssert rct_imp_activatable'_asrt [];
                  activateThread
-              od)" (is "corres _ ?P ?P' _ _")
-  unfolding call_kernel_def
-  apply add_cur_tcb'
-  apply (rule_tac Q="\<lambda>s. obj_at' (\<lambda>sc. scTCB sc = Some (ksCurThread s)) (ksCurSc s) s" in corres_cross_add_guard)
-   apply (fastforce simp: invs_def valid_state_def valid_pspace_def intro!: cur_sc_tcb_cross)
-  apply (rule_tac Q="\<lambda>s'. pred_map (\<lambda>tcb. \<not> tcbInReleaseQueue tcb) (tcbs_of' s') (ksCurThread s')"
-         in corres_cross_add_guard)
-   apply (clarsimp, frule tcb_at_invs)
-   apply (fastforce simp: not_in_release_q_def release_queue_relation_def pred_map_def opt_map_red obj_at'_def
-                          invs'_def valid_pspace'_def projectKOs valid_release_queue'_def cur_tcb'_def
-                   dest!: state_relationD)
-  apply (rule_tac Q="\<lambda>s'. pred_map (\<lambda>scPtr. isScActive scPtr s') (tcbSCs_of s') (ksCurThread s')"
-         in corres_cross_add_guard)
-   apply clarsimp
-   apply (frule invs_cur_sc_tcb_symref, clarsimp simp: schact_is_rct)
-   apply (prop_tac "sc_at (cur_sc s) s")
-    apply (frule invs_cur_sc_tcb)
-    apply (clarsimp simp: cur_sc_tcb_def sc_tcb_sc_at_def obj_at_def is_sc_obj)
-    apply (erule (1) valid_sched_context_size_objsI[OF invs_valid_objs])
-   apply (frule (4) active_sc_at'_cross[OF _ invs_psp_aligned invs_distinct])
-   apply (clarsimp simp: active_sc_at'_def obj_at'_def projectKOs cur_tcb'_def pred_tcb_at_def
-                         is_sc_obj obj_at_def  pred_map_def isScActive_def
-                  dest!: state_relationD)
-   apply (rule_tac x="cur_sc s" in exI, clarsimp simp: opt_map_red)
-   apply (frule_tac x="ksCurThread s'" in pspace_relation_absD, simp)
-   apply (fastforce simp: other_obj_relation_def tcb_relation_def)
-  apply simp
+              od)"
+  unfolding call_kernel_def callKernel_def
+  apply (simp add: call_kernel_def callKernel_def)
   apply (rule corres_guard_imp)
     apply (rule corres_split)
        apply (rule corres_split_handle[OF handleEvent_corres])
-         (* handle *)
-         apply (rule kernel_preemption_corres)
-        apply (rule_tac E'="\<lambda>_ s. einvs s \<and> scheduler_act_sane s \<and> cur_sc_chargeable s \<and>
-                                 (schact_is_rct s \<longrightarrow> cur_sc_active s) \<and> ct_not_queued s \<and>
-                                 (schact_is_rct s \<longrightarrow> ct_in_state activatable s) \<and>
-                                 (cur_sc_active s \<longrightarrow> cur_sc_offset_ready (consumed_time s) s) \<and>
-                                 ct_not_blocked s \<and> current_time_bounded s \<and>
-                                 ct_not_in_release_q s \<and> consumed_time_bounded s"
-               in hoare_strengthen_postE[where Q=Q and R=Q for Q])
-          apply (wpsimp wp: handle_event_schact_is_rct_imp_ct_activatable
-                            handle_event_schact_is_rct_imp_cur_sc_active call_kernel_schact_is_rct
-                            handle_event_scheduler_act_sane handle_event_ct_not_queuedE_E
-                            handle_event_cur_sc_chargeable handle_event_cur_sc_more_than_ready
-                            handle_event_valid_sched)
          apply simp
-        apply (clarsimp simp: cur_sc_chargeable_def)
+         apply (rule corres_split[OF corres_machine_op])
+            apply (rule corres_underlying_trivial)
+            apply (rule no_fail_getActiveIRQ)
+           apply clarsimp
+           apply (rule_tac x=irq in option_corres)
+            apply (rule_tac P=\<top> and P'=\<top> in corres_inst)
+            apply (simp add: when_def)
+           apply (rule corres_when[simplified dc_def], simp)
+           apply simp
+           apply (rule handleInterrupt_corres[simplified dc_def])
+          apply simp
+          apply (wpsimp wp: hoare_drop_imps hoare_vcg_all_lift simp: schact_is_rct_def)[1]
+         apply simp
+         apply (rule_tac Q'="\<lambda>irq s. invs' s \<and>
+                              (\<forall>irq'. irq = Some irq' \<longrightarrow>
+                                 intStateIRQTable (ksInterruptState s ) irq' \<noteq>
+                                 IRQInactive)"
+                      in hoare_post_imp)
+          apply simp
+         apply (wp doMachineOp_getActiveIRQ_IRQ_active handle_event_valid_sched | simp)+
        apply (rule_tac Q'="\<lambda>_. \<top>" and E'="\<lambda>_. invs'" in hoare_strengthen_postE)
          apply wpsimp+
-      apply (rule_tac P="invs and valid_sched and current_time_bounded
-                         and ct_ready_if_schedulable and scheduler_act_sane
-                         and (\<lambda>s. schact_is_rct s \<longrightarrow> cur_sc_active s)
-                         and (\<lambda>s. schact_is_rct s \<longrightarrow> ct_in_state activatable s)
-                         and (\<lambda>s. schact_is_rct s \<longrightarrow> ct_not_in_release_q s)
-                         and cur_sc_more_than_ready and consumed_time_bounded
-                         and cur_sc_in_release_q_imp_zero_consumed"
-                  and P'=invs' in corres_inst)
-      apply (rule corres_stateAssert_add_assertion)
-       apply (simp add: rct_imp_activatable'_asrt_def)
-       apply (rule corres_guard_imp)
-         apply (rule corres_split[OF schedule_corres])
-           apply (rule_tac P="invs and valid_sched and current_time_bounded
-                              and cur_sc_active and schact_is_rct
-                              and ct_in_state activatable
-                              and (\<lambda>s. cur_sc_offset_ready (consumed_time s) s \<and>
-                                       cur_sc_offset_sufficient (consumed_time s) s)"
-                       and P'="invs' and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread)"
-                  in corres_inst)
-           apply (rule corres_stateAssert_add_assertion)
-            apply (rule corres_guard_imp)
-              apply (rule activateThread_corres)
-             apply simp
-            apply simp
-           apply (clarsimp simp: ct_in_state_def ct_in_state'_def)
-           apply (drule (3) st_tcb_at_coerce_concrete[OF _ _ invs_psp_aligned invs_distinct])
-           apply (clarsimp simp: pred_tcb_at'_def obj_at'_def projectKOs state_relation_def)
-           apply (rename_tac st; case_tac st; clarsimp)
-          apply (wpsimp wp: schedule_valid_sched
-                            schedule_cur_sc_active schedule_ct_activateable
-                            schedule_cur_sc_offset_ready_and_sufficient)
-         apply (wpsimp wp: schedule_invs' schedule_sch)
-        apply clarsimp
-       apply clarsimp
-      apply (clarsimp simp: rct_imp_activatable'_asrt_def)
-      apply (clarsimp simp: ct_in_state_def ct_in_state'_def)
-      apply (prop_tac "schact_is_rct s")
-       apply (clarsimp simp: state_relation_def schact_is_rct_def sched_act_relation_def)
-       apply (case_tac "scheduler_action s"; clarsimp)
-      apply (drule schact_is_rct, clarsimp)
-      apply (frule (3) st_tcb_at_coerce_concrete[OF _ _ invs_psp_aligned invs_distinct])
-      apply (clarsimp simp: pred_tcb_at'_def obj_at'_def projectKOs state_relation_def)
-      apply (rename_tac st; case_tac st; clarsimp)
-     apply wpsimp
-      apply (wpsimp wp: preemption_path_valid_sched
-                        preemption_path_current_time_bounded
-                        preemption_point_scheduler_act_sane
-                        preemption_path_schact_is_rct_imp_ct_not_in_release_q
-                        preemption_path_cur_sc_more_than_ready
-                        preemption_path_consumed_time_bounded
-                        preemption_path_cur_sc_in_release_q_imp_zero_consumed
-                        preemption_path_ct_ready_if_schedulable)
-     apply ((wpsimp wp: he_invs handle_event_valid_sched handle_event_scheduler_act_sane
-                        handle_event_cur_sc_chargeable handle_event_schact_is_rct_imp_cur_sc_active
-                        handle_event_schact_is_rct_imp_ct_activatable
-                        handle_event_schact_is_rct_imp_ct_not_in_release_q
-                        handle_event_cur_sc_in_release_q_imp_zero_consumed
-             | strengthen ct_not_blocked_imp_ct_not_blocked_on_receive
-                          ct_not_blocked_imp_ct_not_blocked_on_ntfn)+)[1]
-    apply (wpsimp wp: he_invs')
-      apply (wpsimp simp: mcsPreemptionPoint_def wp: isSchedulable_wp)
-     apply (wpsimp wp: dmo_getirq_inv)
-     apply (clarsimp simp: isSchedulable_bool_def isScActive_def)
-    apply (rule_tac Q'="\<lambda>_. invs'" and E'="\<lambda>_. invs'" in hoare_strengthen_postE)
-      apply (wpsimp wp: he_invs')
-     apply simp
-    apply clarsimp
-   apply (clarsimp  cong: conj_cong)
-   apply (intro conjI, clarsimp simp: active_from_running)
-        apply (rule valid_sched_ct_not_queued; clarsimp?)
-       apply (erule (2) cur_sc_active_ct_not_in_release_q_imp_ct_running_imp_ct_schedulable, clarsimp)
-      apply (clarsimp simp: ct_in_state_def pred_tcb_at_def obj_at_def cur_tcb_def is_tcb
-                     dest!: invs_cur)
-     apply (clarsimp simp: invs_def valid_state_def valid_pspace_def
-                           invs_strengthen_cur_sc_tcb_are_bound)
-    apply (fastforce simp: ct_in_state_def pred_tcb_at_def obj_at_def cur_tcb_def is_tcb
-                    dest!: invs_cur)
-   apply (clarsimp, rule schact_is_rct_ct_released; simp?)
-   apply (frule (1) cur_sc_not_idle_sc_ptr')
-    apply (clarsimp simp: invs_def valid_state_def valid_pspace_def
-                          invs_strengthen_cur_sc_tcb_are_bound)
-   apply simp
+       apply (simp add: invs'_def valid_state'_def)
+      apply (rule corres_split[OF schedule_corres])
+        apply (rule activateThread_corres)
+       apply (wp handle_interrupt_valid_sched[unfolded non_kernel_IRQs_def, simplified]
+                 schedule_invs' hoare_vcg_if_lift2 hoare_drop_imps |simp)+
+     apply (rule_tac Q'="\<lambda>_. valid_sched and invs and valid_list" and
+                     E'="\<lambda>_. valid_sched and invs and valid_list"
+            in hoare_strengthen_postE)
+       apply (wp handle_event_valid_sched hoare_vcg_imp_lift' |simp)+
+   apply (clarsimp simp: active_from_running schact_is_rct_def)
   apply (clarsimp simp: active_from_running')
   done
 
 lemma kernel_corres:
-  "corres dc (einvs and (\<lambda>s. event \<noteq> Interrupt \<longrightarrow> ct_running s) and (ct_running or ct_idle)
-              and current_time_bounded and consumed_time_bounded and valid_machine_time
-              and ct_not_in_release_q and cur_sc_active
-              and (\<lambda>s. cur_sc_offset_ready (consumed_time s) s)
-              and (\<lambda>s. cur_sc_offset_sufficient (consumed_time s) s)
-              and (\<lambda>s. scheduler_action s = resume_cur_thread)
-              and valid_domain_list)
+  "corres dc (einvs and (\<lambda>s. event \<noteq> Interrupt \<longrightarrow> ct_running s) and (ct_running or ct_idle) and
+              (\<lambda>s. scheduler_action s = resume_cur_thread) and
+              (\<lambda>s. 0 < domain_time s \<and> valid_domain_list s))
              (invs' and (\<lambda>s. event \<noteq> Interrupt \<longrightarrow> ct_running' s) and (ct_running' or ct_idle') and
               (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread) and
               (\<lambda>s. vs_valid_duplicates' (ksPSpace s)))
@@ -979,7 +604,7 @@ lemma kernel_corres:
     apply (rule corres_add_noop_lhs2)
     apply (simp only: bind_assoc[symmetric])
     apply (rule corres_split[where r'=dc and
-                                   R="\<lambda>_ s. valid_domain_list s" and
+                                   R="\<lambda>_ s. 0 < domain_time s \<and> valid_domain_list s" and
                                    R'="\<lambda>_. \<top>"])
        apply (simp only: bind_assoc)
        apply (rule kernel_corres')
@@ -987,7 +612,7 @@ lemma kernel_corres:
        apply simp
       apply (simp add: kernelExitAssertions_def state_relation_def)
      apply (wp call_kernel_domain_time_inv_det_ext call_kernel_domain_list_inv_det_ext)
-    apply wpsimp
+    apply wp
    apply clarsimp
   apply clarsimp
   done
@@ -1004,51 +629,43 @@ lemma device_mem_corres:
                          invs_def invs'_def
                          corres_underlying_def device_mem_relation)
 
-crunch thread_set
- for domain_time_inv[wp]: "\<lambda>s. P (domain_time s)"
-
 lemma entry_corres:
-  "corres (=)
-      (\<lambda>s. mcs_invs s \<and> (ct_running s \<or> ct_idle s) \<and> (event \<noteq> Interrupt \<longrightarrow> ct_running s))
-      (invs' and (\<lambda>s. event \<noteq> Interrupt \<longrightarrow> ct_running' s) and (ct_running' or ct_idle')
-       and valid_domain_list'
-       and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread)
-       and (\<lambda>s. vs_valid_duplicates' (ksPSpace s)))
-      (kernel_entry event tc) (kernelEntry event tc)"
+  "corres (=) (einvs and (\<lambda>s. event \<noteq> Interrupt \<longrightarrow> ct_running s) and
+                  (\<lambda>s. 0 < domain_time s) and valid_domain_list and (ct_running or ct_idle) and
+                  (\<lambda>s. scheduler_action s = resume_cur_thread))
+                 (invs' and (\<lambda>s. event \<noteq> Interrupt \<longrightarrow> ct_running' s) and
+                  (\<lambda>s. 0 < ksDomainTime s) and valid_domain_list' and (ct_running' or ct_idle') and
+                  (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread) and
+                  (\<lambda>s. vs_valid_duplicates' (ksPSpace s)))
+          (kernel_entry event tc) (kernelEntry event tc)"
   apply (simp add: kernel_entry_def kernelEntry_def)
-  apply add_cur_tcb'
   apply (rule corres_guard_imp)
     apply (rule corres_split[OF getCurThread_corres])
       apply (rule corres_split)
          apply simp
-         apply (rule threadset_corresT)
-           apply (simp add: tcb_relation_def arch_tcb_relation_def
-                            arch_tcb_context_set_def atcbContextSet_def)
-          apply (clarsimp simp: tcb_cap_cases_def)
-         apply (clarsimp simp: tcb_cte_cases_def)
-        apply (rule corres_split [OF kernel_corres])
-          apply (rule_tac P=invs and P'=\<top> in corres_inst)
-          apply add_cur_tcb'
-          apply (rule corres_guard_imp)
-            apply (rule corres_split_eqr[OF getCurThread_corres])
-              apply (rule threadGet_corres)
-              apply (simp add: tcb_relation_def arch_tcb_relation_def
-                               arch_tcb_context_get_def atcbContextGet_def)
-             apply wp+
-           apply clarsimp
-          apply (clarsimp simp: cur_tcb'_def)
-         apply (rule hoare_strengthen_post, rule akernel_invs_det_ext, simp add: invs_def cur_tcb_def)
-        apply wpsimp
-       apply (wp thread_set_invs_trivial
+         apply (rule threadset_corresT; simp?)
+            apply (simp add: tcb_relation_def arch_tcb_relation_def
+                             arch_tcb_context_set_def atcbContextSet_def)
+           apply (clarsimp simp: tcb_cap_cases_def)
+          apply (clarsimp simp: tcb_cte_cases_def)
+         apply (simp add: exst_same_def)
+        apply (rule corres_split[OF kernel_corres])
+          apply (rule corres_split_eqr[OF getCurThread_corres])
+            apply (rule threadGet_corres)
+            apply (simp add: tcb_relation_def arch_tcb_relation_def
+                             arch_tcb_context_get_def atcbContextGet_def)
+           apply wp+
+         apply (rule hoare_strengthen_post, rule akernel_invs_det_ext, fastforce simp: invs_def cur_tcb_def)
+        apply (rule hoare_strengthen_post, rule ckernel_invs, simp add: invs'_def cur_tcb'_def)
+       apply (wp thread_set_invs_trivial thread_set_ct_running
                  threadSet_invs_trivial threadSet_ct_running'
                  thread_set_not_state_valid_sched hoare_weak_lift_imp
                  hoare_vcg_disj_lift ct_in_state_thread_state_lift
               | simp add: tcb_cap_cases_def ct_in_state'_def thread_set_no_change_tcb_state
                           schact_is_rct_def
               | (wps, wp threadSet_st_tcb_at2) )+
-   apply (clarsimp simp: invs_def cur_tcb_def)
-  apply (clarsimp simp: ct_in_state'_def cur_tcb'_def invs'_def valid_release_queue'_def
-                        projectKOs obj_at'_def)
+   apply (fastforce simp: invs_def cur_tcb_def)
+  apply (clarsimp simp: ct_in_state'_def)
   done
 
 lemma corres_gets_machine_state:
@@ -1058,7 +675,8 @@ lemma corres_gets_machine_state:
 
 lemma do_user_op_corres:
   "corres (=) (einvs and ct_running)
-              invs'
+                 (invs' and (%s. ksSchedulerAction s = ResumeCurrentThread) and
+                  ct_running')
           (do_user_op f tc) (doUserOp f tc)"
   apply (simp add: do_user_op_def doUserOp_def split_def)
   apply (rule corres_guard_imp)
@@ -1111,22 +729,25 @@ lemma ct_idle_related:
   done
 
 definition
-  "full_invs'
-     \<equiv> {((tc,s),m,e). invs' s \<and> vs_valid_duplicates' (ksPSpace s)
-                      \<and> ex_abs (\<lambda>s :: det_state. mcs_invs s
-                                                  \<and> (ct_running s \<or> ct_idle s)
-                                                  \<and> (e \<noteq> None \<and> e \<noteq> Some Interrupt \<longrightarrow> ct_running s)) s
-                      \<and> (m = KernelMode \<longrightarrow> e \<noteq> None)
-                      \<and> (m = UserMode \<longrightarrow> ct_running' s)
-                      \<and> (m = IdleMode \<longrightarrow> ct_idle' s)}"
+  "full_invs' \<equiv> {((tc,s),m,e). invs' s \<and> vs_valid_duplicates' (ksPSpace s) \<and>
+                          ex_abs (einvs::det_ext state \<Rightarrow> bool) s \<and>
+                          ksSchedulerAction s = ResumeCurrentThread \<and>
+                          (ct_running' s \<or> ct_idle' s) \<and>
+                          (m = KernelMode \<longrightarrow> e \<noteq> None) \<and>
+                          (m = UserMode \<longrightarrow> ct_running' s) \<and>
+                          (m = IdleMode \<longrightarrow> ct_idle' s) \<and>
+                          (e \<noteq> None \<and> e \<noteq> Some Interrupt \<longrightarrow> ct_running' s) \<and>
+                          0 < ksDomainTime s \<and> valid_domain_list' s}"
 
 lemma checkActiveIRQ_valid_duplicates':
-  "checkActiveIRQ \<lbrace>\<lambda>s. vs_valid_duplicates' (ksPSpace s)\<rbrace>"
+  "\<lbrace>\<lambda>s. vs_valid_duplicates' (ksPSpace s)\<rbrace>
+   checkActiveIRQ
+   \<lbrace>\<lambda>_ s. vs_valid_duplicates' (ksPSpace s)\<rbrace>"
   apply (simp add: checkActiveIRQ_def)
   apply wp
   done
 
-lemma checkActiveIRQ_corres':
+lemma check_active_irq_corres':
   "corres (=) \<top> \<top> (check_active_irq) (checkActiveIRQ)"
   apply (simp add: check_active_irq_def checkActiveIRQ_def)
   apply (rule corres_guard_imp)
@@ -1136,43 +757,48 @@ lemma checkActiveIRQ_corres':
      apply (wp | simp )+
   done
 
-lemma checkActiveIRQ_corres:
+lemma check_active_irq_corres:
   "corres (=)
     (invs and (ct_running or ct_idle) and einvs and (\<lambda>s. scheduler_action s = resume_cur_thread)
-     and valid_domain_list)
-    (invs' and (\<lambda>s. vs_valid_duplicates' (ksPSpace s)))
+     and (\<lambda>s. 0 < domain_time s) and valid_domain_list)
+    (invs' and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread)
+      and (\<lambda>s. 0 < ksDomainTime s) and valid_domain_list' and (ct_running' or ct_idle')
+      and (\<lambda>s. vs_valid_duplicates' (ksPSpace s)))
     (check_active_irq) (checkActiveIRQ)"
   apply (rule corres_guard_imp)
-    apply (rule checkActiveIRQ_corres', auto)
+    apply (rule check_active_irq_corres', auto)
   done
 
 lemma checkActiveIRQ_just_running_corres:
   "corres (=)
     (invs and ct_running and einvs and (\<lambda>s. scheduler_action s = resume_cur_thread)
-      and valid_domain_list)
-    (invs' and (\<lambda>s. vs_valid_duplicates' (ksPSpace s)))
+      and (\<lambda>s. 0 < domain_time s) and valid_domain_list)
+    (invs' and ct_running' and (\<lambda>s. vs_valid_duplicates' (ksPSpace s))
+      and (\<lambda>s. 0 < ksDomainTime s) and valid_domain_list'
+      and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread))
     (check_active_irq) (checkActiveIRQ)"
   apply (rule corres_guard_imp)
-    apply (rule checkActiveIRQ_corres', auto)
+    apply (rule check_active_irq_corres', auto)
   done
 
 lemma checkActiveIRQ_just_idle_corres:
   "corres (=)
     (invs and ct_idle and einvs and (\<lambda>s. scheduler_action s = resume_cur_thread)
-      and valid_domain_list)
+      and (\<lambda>s. 0 < domain_time s)  and valid_domain_list)
     (invs' and ct_idle' and (\<lambda>s. vs_valid_duplicates' (ksPSpace s))
-      and valid_domain_list'
+      and (\<lambda>s. 0 < ksDomainTime s) and valid_domain_list'
       and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread))
     (check_active_irq) (checkActiveIRQ)"
   apply (rule corres_guard_imp)
-    apply (rule checkActiveIRQ_corres', auto)
+    apply (rule check_active_irq_corres', auto)
   done
 
 lemma checkActiveIRQ_invs':
   "\<lbrace>invs' and ex_abs invs and (ct_running' or ct_idle')
     and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread)\<rbrace>
    checkActiveIRQ
-   \<lbrace>\<lambda>_. invs' and (ct_running' or ct_idle') and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread)\<rbrace>"
+   \<lbrace>\<lambda>_. invs' and (ct_running' or ct_idle')
+    and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread)\<rbrace>"
   apply (simp add: checkActiveIRQ_def ex_abs_def)
   apply (wp dmo_invs' | simp)+
   done
@@ -1181,7 +807,8 @@ lemma checkActiveIRQ_invs'_just_running:
   "\<lbrace>invs' and ex_abs invs and ct_running'
     and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread)\<rbrace>
    checkActiveIRQ
-   \<lbrace>\<lambda>_. invs' and ct_running' and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread)\<rbrace>"
+   \<lbrace>\<lambda>_. invs' and ct_running'
+    and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread)\<rbrace>"
   apply (simp add: checkActiveIRQ_def)
   apply (wp | simp)+
   done
@@ -1190,7 +817,8 @@ lemma checkActiveIRQ_invs'_just_idle:
   "\<lbrace>invs' and ex_abs invs and ct_idle'
     and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread)\<rbrace>
    checkActiveIRQ
-   \<lbrace>\<lambda>_. invs' and ct_idle' and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread)\<rbrace>"
+   \<lbrace>\<lambda>_. invs' and ct_idle'
+    and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread)\<rbrace>"
   apply (simp add: checkActiveIRQ_def)
   apply (wp | simp)+
   done
@@ -1200,11 +828,6 @@ lemma sched_act_rct_related:
      \<Longrightarrow> scheduler_action a = resume_cur_thread"
   by (case_tac "scheduler_action a", simp_all add: state_relation_def)
 
-lemma resume_cur_thread_cross:
-  "\<lbrakk> (a, c) \<in> state_relation; scheduler_action a = resume_cur_thread\<rbrakk>
-     \<Longrightarrow> ksSchedulerAction c = ResumeCurrentThread"
-  by (case_tac "scheduler_action a", simp_all add: state_relation_def)
-
 lemma domain_time_rel_eq:
   "(a, c) \<in> state_relation \<Longrightarrow> P (ksDomainTime c) = P (domain_time a)"
   by (clarsimp simp: state_relation_def)
@@ -1212,28 +835,6 @@ lemma domain_time_rel_eq:
 lemma domain_list_rel_eq:
   "(a, c) \<in> state_relation \<Longrightarrow> P (ksDomSchedule c) = P (domain_list a)"
   by (clarsimp simp: state_relation_def)
-
-lemma ct_running_cross:
-  "\<lbrakk>(a,c) \<in> state_relation; ct_running a; pspace_aligned a; pspace_distinct a\<rbrakk> \<Longrightarrow> ct_running' c"
-  apply (clarsimp simp: ct_in_state_def ct_in_state'_def)
-  apply (frule st_tcb_at_coerce_concrete)
-     apply fastforce+
-  apply (clarsimp simp: obj_at_simps state_relation_def)
-  done
-
-lemma ct_idle_cross:
-  "\<lbrakk>(a,c) \<in> state_relation; ct_idle a; pspace_aligned a; pspace_distinct a\<rbrakk> \<Longrightarrow> ct_idle' c"
-  apply (clarsimp simp: ct_in_state_def ct_in_state'_def)
-  apply (frule st_tcb_at_coerce_concrete)
-     apply fastforce+
-  apply (clarsimp simp: obj_at_simps state_relation_def)
-  done
-
-lemma ct_running_or_idle_cross:
-  "\<lbrakk>(a,c) \<in> state_relation; ct_running a \<or> ct_idle a; pspace_aligned a; pspace_distinct a\<rbrakk>
-   \<Longrightarrow> ct_running' c \<or> ct_idle' c"
-  apply (fastforce dest: ct_running_cross ct_idle_cross)
-  done
 
 lemma ckernel_invariant:
   "ADT_H uop \<Turnstile> full_invs'"
@@ -1251,65 +852,28 @@ lemma ckernel_invariant:
     apply (frule akernel_init_invs[THEN bspec])
     apply (rule_tac x = s in exI)
     apply (clarsimp simp: Init_A_def)
-
-    apply (clarsimp simp: Init_A_def init_A_st_def)
-
    apply (insert ckernel_init_invs)[1]
    apply clarsimp
    apply (frule ckernel_init_sch_norm)
    apply (frule ckernel_init_ctr)
    apply (frule ckernel_init_domain_time)
    apply (frule ckernel_init_domain_list)
-   apply (clarsimp simp: ex_abs_def)
    apply (fastforce simp: Init_H_def valid_domain_list'_def)
-
   apply (clarsimp simp: ADT_A_def ADT_H_def global_automaton_def)
 
   apply (erule_tac P="a \<and> (\<exists>x. b x)" for a b in disjE)
-   apply (clarsimp simp: ex_abs_def kernel_call_H_def)
-   apply (rename_tac uc' conc_state' uc conc_state abs_state event)
-   apply (drule use_valid[OF _ valid_corres_combined])
-       apply (rule kernel_entry_invs)
-      apply (rule corres_guard_imp)
-        apply (rule entry_corres)
-       apply force
-      apply force
-     apply (rule hoare_weaken_pre)
-      apply (rule kernelEntry_invs')
-     apply clarsimp
-     apply (rename_tac s' s; intro conjI)
-        apply (prop_tac "cur_sc s = ksCurSc s'", fastforce dest!: state_relationD)
-        apply (prop_tac "sc_at (cur_sc s) s")
-         apply (rule cur_sc_tcb_sc_at_cur_sc[OF invs_valid_objs invs_cur_sc_tcb]; simp)
-        apply (prop_tac "sc_at' (ksCurSc s') s'")
-         apply (rule sc_at_cross[OF state_relation_pspace_relation invs_psp_aligned invs_distinct]; simp)
-        apply (prop_tac "is_active_sc' (ksCurSc s') s'")
-         apply (rule is_active_sc'2_cross[OF _ invs_psp_aligned invs_distinct], simp+)
 
-       apply (clarsimp simp: invs'_def valid_pspace'_def, rule sym_refs_tcbSCs; simp?)
-       apply (clarsimp simp: invs_def valid_state_def valid_pspace_def state_refs_of_cross_eq)
-      apply (fastforce dest!: cur_sc_tcb_cross[simplified schact_is_rct_def]
-                        simp: invs_def valid_state_def valid_pspace_def)
-     apply (clarsimp simp: invs'_def valid_release_queue'_def)
-     apply (prop_tac "cur_tcb' s'")
-      apply (rule cur_tcb_cross[OF invs_cur invs_psp_aligned invs_distinct]; simp?)
-     apply (clarsimp simp: cur_tcb'_def)
-     apply (clarsimp simp: pred_map_def obj_at'_def projectKOs opt_map_red not_in_release_q_def
-                           release_queue_relation_def
-                    dest!: state_relationD)
+  apply (clarsimp simp: kernel_call_H_def)
 
-    apply clarsimp
-    apply (rule_tac x=abs_state in exI)
-    apply (intro conjI; (clarsimp; fail)?)
-      subgoal by (fastforce intro: ct_running_cross)
-     apply (rule ct_running_or_idle_cross; simp?; fastforce)
-    subgoal by (fastforce intro!: resume_cur_thread_cross)
-
-   apply clarsimp
-   apply (intro conjI impI)
-     apply metis
-    apply metis
-   apply (fastforce dest!: ct_running_or_idle_cross)
+   apply (drule use_valid[OF _ valid_corres_combined
+                            [OF kernel_entry_invs entry_corres],
+                            OF _ kernelEntry_invs'[THEN hoare_weaken_pre]])
+     subgoal by fastforce
+    apply (fastforce simp: ex_abs_def sch_act_simple_def ct_running_related ct_idle_related
+                           sched_act_rct_related)
+   apply (clarsimp simp: kernel_call_H_def)
+   subgoal by (fastforce simp: ex_abs_def sch_act_simple_def ct_running_related ct_idle_related
+                              sched_act_rct_related)
 
   apply (erule_tac P="a \<and> b" for a b in disjE)
    apply (clarsimp simp add: do_user_op_H_def monad_to_transition_def)
@@ -1319,13 +883,11 @@ lemma ckernel_invariant:
      apply (rule valid_corres_combined[OF do_user_op_invs2 corres_guard_imp2[OF do_user_op_corres]])
       apply clarsimp
      apply (rule doUserOp_invs'[THEN hoare_weaken_pre])
-     apply (clarsimp simp: ex_abs_def)
-     apply (rule conjI)
-      apply metis
-     apply (fastforce intro: resume_cur_thread_cross ct_running_cross)
+     apply (fastforce simp: ex_abs_def)
     apply (clarsimp simp: ex_abs_def, rule_tac x=s in exI,
-           clarsimp simp: ct_running_related sched_act_rct_related)
-   apply (fastforce simp: ex_abs_def)
+            clarsimp simp: ct_running_related sched_act_rct_related)
+   apply (clarsimp simp: ex_abs_def)
+   apply (fastforce simp: ex_abs_def ct_running_related sched_act_rct_related)
 
   apply (erule_tac P="a \<and> b \<and> c \<and> (\<exists>x. d x)" for a b c d in disjE)
    apply (clarsimp simp add: do_user_op_H_def monad_to_transition_def)
@@ -1335,59 +897,42 @@ lemma ckernel_invariant:
      apply (rule valid_corres_combined[OF do_user_op_invs2 corres_guard_imp2[OF do_user_op_corres]])
       apply clarsimp
      apply (rule doUserOp_invs'[THEN hoare_weaken_pre])
-     apply (clarsimp simp: ex_abs_def)
-     apply (rule conjI)
-      apply metis
-     apply (fastforce intro: resume_cur_thread_cross ct_running_cross)
-    apply (fastforce simp: ex_abs_def ct_running_related sched_act_rct_related)
-   apply (fastforce simp: ex_abs_def)
-
-  apply (erule_tac P="a \<and> b" for a b in disjE)
-   apply (clarsimp simp: check_active_irq_H_def)
-   apply (drule use_valid)
-     apply (rule hoare_vcg_conj_lift)
-      apply (rule checkActiveIRQ_valid_duplicates')
-     apply (rule valid_corres_combined[OF check_active_irq_invs_just_running corres_guard_imp2[OF checkActiveIRQ_just_running_corres]])
-      apply clarsimp
-     apply (rule checkActiveIRQ_invs'_just_running[THEN hoare_weaken_pre])
-     apply (clarsimp simp: ex_abs_def)
-     apply (rule conjI)
-      apply blast
-     apply (fastforce intro: resume_cur_thread_cross ct_running_cross)
-    apply (fastforce simp: ex_abs_def ct_running_related sched_act_rct_related)
-   apply (fastforce simp: ex_abs_def)
-
-  apply (erule_tac P="a \<and> b" for a b in disjE)
-   apply (clarsimp simp: check_active_irq_H_def)
-   apply (drule use_valid)
-     apply (rule hoare_vcg_conj_lift)
-      apply (rule checkActiveIRQ_valid_duplicates')
-     apply (rule valid_corres_combined[OF check_active_irq_invs_just_idle corres_guard_imp2[OF checkActiveIRQ_just_idle_corres]])
-      apply clarsimp
-     apply (rule checkActiveIRQ_invs'_just_idle[THEN hoare_weaken_pre])
      apply (fastforce simp: ex_abs_def)
-    apply (clarsimp simp: ex_abs_def)
-    apply (rule_tac x=s in exI)
-    apply clarsimp
-    apply (intro conjI)
-     apply (fastforce intro: ct_idle_related)
-    apply (fastforce intro: resume_cur_thread_cross)
+    apply (fastforce simp: ex_abs_def ct_running_related sched_act_rct_related)
+   apply (fastforce simp: ex_abs_def)
+
+  apply (erule_tac P="a \<and> b" for a b in disjE)
+   apply (clarsimp simp: check_active_irq_H_def)
+   apply (drule use_valid)
+     apply (rule hoare_vcg_conj_lift)
+      apply (rule checkActiveIRQ_valid_duplicates')
+     apply (rule valid_corres_combined[OF check_active_irq_invs_just_running checkActiveIRQ_just_running_corres])
+     apply (rule checkActiveIRQ_invs'_just_running[THEN hoare_weaken_pre])
+     apply (fastforce simp: ex_abs_def)
+    apply (fastforce simp: ex_abs_def ct_running_related sched_act_rct_related)
+   apply (fastforce simp: ex_abs_def)
+
+  apply (erule_tac P="a \<and> b" for a b in disjE)
+   apply (clarsimp simp: check_active_irq_H_def)
+   apply (drule use_valid)
+     apply (rule hoare_vcg_conj_lift)
+      apply (rule checkActiveIRQ_valid_duplicates')
+     apply (rule valid_corres_combined[OF check_active_irq_invs_just_idle checkActiveIRQ_just_idle_corres])
+     apply (rule checkActiveIRQ_invs'_just_idle[THEN hoare_weaken_pre])
+     apply clarsimp
+     apply (fastforce simp: ex_abs_def)
+    apply (fastforce simp: ex_abs_def ct_idle_related sched_act_rct_related)
    apply (fastforce simp: ex_abs_def)
 
   apply (clarsimp simp: check_active_irq_H_def)
    apply (drule use_valid)
-    apply (rule hoare_vcg_conj_lift)
+     apply (rule hoare_vcg_conj_lift)
      apply (rule checkActiveIRQ_valid_duplicates')
-    apply (rule valid_corres_combined[OF check_active_irq_invs_just_idle corres_guard_imp2[OF checkActiveIRQ_just_idle_corres]])
-     apply clarsimp
-    apply (rule checkActiveIRQ_invs'_just_idle[THEN hoare_weaken_pre])
-    apply (fastforce simp: ex_abs_def)
-   apply (clarsimp simp: ex_abs_def)
-   apply (rule_tac x=s in exI)
-   apply clarsimp
-   apply (intro conjI)
-    apply (fastforce intro: ct_idle_related)
-   apply (fastforce intro: resume_cur_thread_cross)
+    apply (rule valid_corres_combined[OF check_active_irq_invs check_active_irq_corres])
+    apply (rule checkActiveIRQ_invs'[THEN hoare_weaken_pre])
+    apply clarsimp
+     apply (fastforce simp: ex_abs_def)
+   apply (fastforce simp: ex_abs_def ct_running_related ct_idle_related sched_act_rct_related)
   apply (fastforce simp: ex_abs_def)
   done
 
@@ -1408,28 +953,26 @@ lemma fw_sim_A_H:
 
    apply (erule_tac P="a \<and> (\<exists>x. b x)" for a b in disjE)
     apply (clarsimp simp add: kernel_call_H_def kernel_call_A_def)
-    apply (rename_tac abs_state uc' conc_state' conc_state event)
-    apply (rule rev_mp, rule_tac tc=tc and event=event in entry_corres)
+    apply (rule rev_mp, rule_tac tc=tc and event=x in entry_corres)
     apply (clarsimp simp: corres_underlying_def)
-    apply (drule_tac x="(abs_state, conc_state)" in bspec, blast)
+    apply (drule (1) bspec)
+    apply (clarsimp simp: sch_act_simple_def)
+    apply (drule (1) bspec)
     apply clarsimp
-    apply (frule (1) ct_running_or_idle_cross; clarsimp)
-    apply (prop_tac "event \<noteq> Interrupt \<longrightarrow> ct_running' conc_state", fastforce dest!: ct_running_cross)
-    apply (prop_tac "valid_domain_list' conc_state \<and> ksSchedulerAction conc_state = ResumeCurrentThread")
-     apply (clarsimp simp: state_relation_def)
+    apply (rule conjI)
+     apply clarsimp
+     apply (rule_tac x=b in exI)
+     apply (rule conjI)
+      apply (rule impI, simp)
+     apply (frule (2) ct_running_related)
     apply clarsimp
-    apply (drule_tac x="(uc', conc_state')" in bspec, blast)
+    apply (rule_tac x=b in exI)
+    apply (drule use_valid, rule kernelEntry_invs')
+     apply (simp add: sch_act_simple_def)
     apply clarsimp
-    apply (frule use_valid[OF _ kernel_entry_invs])
-     apply force
-    apply (rename_tac abs_state')
-    apply (intro conjI impI allI; simp)
-     apply (rule_tac x=abs_state' in exI)
-     apply (prop_tac "ct_running abs_state'", rule ct_running_related; simp)
-    apply clarsimp
-    apply (rule_tac x=abs_state' in exI)
-    apply clarsimp
-    apply (drule_tac a=abs_state' in ct_running_cross; clarsimp)
+    apply (frule (1) ct_idle_related)
+    apply (clarsimp simp: ct_in_state_def st_tcb_at_def obj_at_def)
+
    apply (erule_tac P="a \<and> b" for a b in disjE)
     apply (clarsimp simp: do_user_op_H_def do_user_op_A_def monad_to_transition_def)
     apply (rule rev_mp, rule_tac tc1=tc and f1=uop and P="ct_running and einvs" in corres_guard_imp2[OF do_user_op_corres])
@@ -1450,20 +993,20 @@ lemma fw_sim_A_H:
 
    apply (erule_tac P="a \<and> b" for a b in disjE)
     apply (clarsimp simp: check_active_irq_H_def check_active_irq_A_def)
-    apply (rule rev_mp, rule checkActiveIRQ_corres')
+    apply (rule rev_mp, rule check_active_irq_corres)
     apply (clarsimp simp: corres_underlying_def)
     apply fastforce
 
    apply (erule_tac P="a \<and> b" for a b in disjE)
     apply (clarsimp simp: check_active_irq_H_def check_active_irq_A_def)
-    apply (rule rev_mp, rule checkActiveIRQ_corres')
+    apply (rule rev_mp, rule check_active_irq_corres)
     apply (clarsimp simp: corres_underlying_def)
     apply fastforce
 
    apply (clarsimp simp: check_active_irq_H_def check_active_irq_A_def)
-   apply (rule rev_mp, rule checkActiveIRQ_corres')
+   apply (rule rev_mp, rule check_active_irq_corres)
    apply (clarsimp simp: corres_underlying_def)
-   apply fastforce
+    apply fastforce
 
   apply (clarsimp simp: absKState_correct dest!: lift_state_relationD)
   done

--- a/proof/refine/ARM/Retype_R.thy
+++ b/proof/refine/ARM/Retype_R.thy
@@ -18,13 +18,11 @@ definition
   APIType_map2 :: "kernel_object + ARM_H.object_type \<Rightarrow> Structures_A.apiobject_type"
 where
  "APIType_map2 ty \<equiv> case ty of
-      Inr (APIObjectType Untyped) \<Rightarrow> Structures_A.Untyped
-    | Inr (APIObjectType TCBObject) \<Rightarrow> Structures_A.TCBObject
-    | Inr (APIObjectType EndpointObject) \<Rightarrow> Structures_A.EndpointObject
-    | Inr (APIObjectType NotificationObject) \<Rightarrow> Structures_A.NotificationObject
-    | Inr (APIObjectType CapTableObject) \<Rightarrow> Structures_A.CapTableObject
-    | Inr (APIObjectType ReplyObject) \<Rightarrow> Structures_A.ReplyObject
-    | Inr (APIObjectType SchedContextObject) \<Rightarrow> Structures_A.SchedContextObject
+      Inr (APIObjectType ArchTypes_H.Untyped) \<Rightarrow> Structures_A.Untyped
+    | Inr (APIObjectType ArchTypes_H.TCBObject) \<Rightarrow> Structures_A.TCBObject
+    | Inr (APIObjectType ArchTypes_H.EndpointObject) \<Rightarrow> Structures_A.EndpointObject
+    | Inr (APIObjectType ArchTypes_H.NotificationObject) \<Rightarrow> Structures_A.NotificationObject
+    | Inr (APIObjectType ArchTypes_H.CapTableObject) \<Rightarrow> Structures_A.CapTableObject
     | Inr PageTableObject \<Rightarrow> ArchObject PageTableObj
     | Inr PageDirectoryObject \<Rightarrow> ArchObject PageDirectoryObj
     | Inr LargePageObject \<Rightarrow> ArchObject LargePageObj
@@ -56,17 +54,20 @@ lemma createObjects_ret:
                         shiftl_t2n power_add)
   done
 
+lemma objBitsKO_bounded2[simp]:
+  "objBitsKO ko < word_bits"
+  by (simp add: objBits_simps' word_bits_def pageBits_def archObjSize_def pdeBits_def pteBits_def
+           split: Structures_H.kernel_object.split arch_kernel_object.split)
+
 definition
   APIType_capBits :: "ARM_H.object_type \<Rightarrow> nat \<Rightarrow> nat"
 where
   "APIType_capBits ty us \<equiv> case ty of
-      APIObjectType Untyped \<Rightarrow> us
-    | APIObjectType TCBObject \<Rightarrow> objBits (makeObject :: tcb)
-    | APIObjectType EndpointObject \<Rightarrow> objBits (makeObject :: endpoint)
-    | APIObjectType NotificationObject \<Rightarrow> objBits (makeObject :: notification)
-    | APIObjectType ReplyObject \<Rightarrow> objBits (makeObject :: reply)
-    | APIObjectType CapTableObject \<Rightarrow> objBits (makeObject :: cte) + us
-    | APIObjectType SchedContextObject \<Rightarrow> us
+      APIObjectType ArchTypes_H.Untyped \<Rightarrow> us
+    | APIObjectType ArchTypes_H.TCBObject \<Rightarrow> objBits (makeObject :: tcb)
+    | APIObjectType ArchTypes_H.EndpointObject \<Rightarrow> objBits (makeObject :: endpoint)
+    | APIObjectType ArchTypes_H.NotificationObject \<Rightarrow> objBits (makeObject :: Structures_H.notification)
+    | APIObjectType ArchTypes_H.CapTableObject \<Rightarrow> objBits (makeObject :: cte) + us
     | SmallPageObject \<Rightarrow> pageBitsForSize ARMSmallPage
     | LargePageObject \<Rightarrow> pageBitsForSize ARMLargePage
     | SectionObject \<Rightarrow> pageBitsForSize ARMSection
@@ -75,20 +76,15 @@ where
     | PageDirectoryObject \<Rightarrow> 14"
 
 definition
-  makeObjectKO :: "bool \<Rightarrow> nat \<Rightarrow> domain \<Rightarrow> (kernel_object + ARM_H.object_type) \<rightharpoonup> kernel_object"
+  makeObjectKO :: "bool \<Rightarrow> (kernel_object + ARM_H.object_type) \<rightharpoonup> kernel_object"
 where
-  "makeObjectKO dev us d ty \<equiv> case ty of
+  "makeObjectKO dev ty \<equiv> case ty of
       Inl KOUserData \<Rightarrow> Some KOUserData
     | Inl (KOArch (KOASIDPool _)) \<Rightarrow> Some (KOArch (KOASIDPool makeObject))
-    | Inr (APIObjectType ArchTypes_H.TCBObject) \<Rightarrow> Some (KOTCB (tcbDomain_update (\<lambda>_. d) makeObject))
+    | Inr (APIObjectType ArchTypes_H.TCBObject) \<Rightarrow> Some (KOTCB makeObject)
     | Inr (APIObjectType ArchTypes_H.EndpointObject) \<Rightarrow> Some (KOEndpoint makeObject)
     | Inr (APIObjectType ArchTypes_H.NotificationObject) \<Rightarrow> Some (KONotification makeObject)
     | Inr (APIObjectType ArchTypes_H.CapTableObject) \<Rightarrow> Some (KOCTE makeObject)
-    | Inr (APIObjectType ArchTypes_H.ReplyObject) \<Rightarrow> Some (KOReply makeObject)
-    | Inr (APIObjectType ArchTypes_H.SchedContextObject) \<Rightarrow>
-            Some (KOSchedContext ((makeObject :: sched_context)
-                                     \<lparr>scRefills := replicate (refillAbsoluteMax' us) emptyRefill,
-                                      scSize := us - minSchedContextBits\<rparr>))
     | Inr PageTableObject \<Rightarrow> Some (KOArch (KOPTE makeObject))
     | Inr PageDirectoryObject \<Rightarrow> Some (KOArch (KOPDE makeObject))
     | Inr SmallPageObject \<Rightarrow> Some (if dev then KOUserDataDevice else KOUserData)
@@ -112,12 +108,6 @@ lemma valid_obj_makeObject_tcb [simp]:
   unfolding valid_obj'_def valid_tcb'_def  valid_tcb_state'_def
   by (clarsimp simp: makeObject_tcb makeObject_cte tcb_cte_cases_def minBound_word)
 
-lemma valid_obj_makeObject_tcb_tcbDomain_update [simp]:
-  "d \<le> maxDomain \<Longrightarrow> valid_obj' (KOTCB (tcbDomain_update (\<lambda>_. d) makeObject)) s"
-  unfolding valid_obj'_def valid_tcb'_def  valid_tcb_state'_def
-  by (clarsimp simp: makeObject_tcb makeObject_cte
-                     tcb_cte_cases_def maxDomain_def maxPriority_def numPriorities_def minBound_word)
-
 lemma valid_obj_makeObject_endpoint [simp]:
   "valid_obj' (KOEndpoint makeObject) s"
   unfolding valid_obj'_def valid_ep'_def
@@ -127,29 +117,6 @@ lemma valid_obj_makeObject_notification [simp]:
   "valid_obj' (KONotification makeObject) s"
   unfolding valid_obj'_def valid_ntfn'_def
   by (clarsimp simp: makeObject_notification)
-
-lemma valid_obj_makeObject_reply [simp]:
-  "valid_obj' (KOReply makeObject) s"
-  unfolding valid_obj'_def valid_reply'_def
-  by (clarsimp simp: makeObject_reply)
-
-lemma valid_sc_size'_makeObject_sc':
-  "sc_size_bounds us \<Longrightarrow>
-     valid_sched_context_size'
-       ((makeObject :: sched_context)\<lparr>scRefills := replicate (refillAbsoluteMax' us) emptyRefill,
-                                      scSize := us - minSchedContextBits\<rparr>)"
-  by (clarsimp simp: makeObject_sc valid_sched_context_size'_def scBits_simps
-                     objBits_def objBitsKO_def)
-
-lemma valid_obj_makeObject_sched_context [simp]:
-  "sc_size_bounds us \<Longrightarrow>
-     valid_obj' (KOSchedContext ((makeObject :: sched_context)
-                                    \<lparr>scRefills := replicate (refillAbsoluteMax' us) emptyRefill,
-                                     scSize := us - minSchedContextBits\<rparr>)) s"
-  unfolding valid_obj'_def valid_sched_context'_def
-  using sc_size_bounds_def
-  by (clarsimp simp: valid_sc_size'_makeObject_sc')
-     (clarsimp simp: makeObject_sc)
 
 lemma valid_obj_makeObject_user_data [simp]:
   "valid_obj' (KOUserData) s"
@@ -175,7 +142,6 @@ lemma valid_obj_makeObject_asid_pool[simp]:
 lemmas valid_obj_makeObject_rules =
   valid_obj_makeObject_user_data valid_obj_makeObject_tcb
   valid_obj_makeObject_endpoint valid_obj_makeObject_notification
-  valid_obj_makeObject_reply valid_obj_makeObject_sched_context
   valid_obj_makeObject_cte valid_obj_makeObject_pte valid_obj_makeObject_pde
   valid_obj_makeObject_asid_pool valid_obj_makeObject_user_data_device
 
@@ -330,14 +296,14 @@ lemma cte_at_next_slot'':
 
 
 lemma state_relation_null_filterE:
-  "\<lbrakk> (s, s') \<in> state_relation; t = kheap_update f s;
+  "\<lbrakk> (s, s') \<in> state_relation; t = kheap_update f (ekheap_update ef s);
      \<exists>f' g' h'.
      t' = s'\<lparr>ksPSpace := f' (ksPSpace s'), gsUserPages := g' (gsUserPages s'),
              gsCNodes := h' (gsCNodes s')\<rparr>;
      null_filter (caps_of_state t) = null_filter (caps_of_state s);
      null_filter' (ctes_of t') = null_filter' (ctes_of s');
      pspace_relation (kheap t) (ksPSpace t');
-     sc_replies_relation t t';
+     ekheap_relation (ekheap t) (ksPSpace t'); ready_queues_relation t t';
      ghost_relation (kheap t) (gsUserPages t') (gsCNodes t'); valid_list s;
      pspace_aligned' s'; pspace_distinct' s'; valid_objs s; valid_mdb s;
      pspace_aligned' t'; pspace_distinct' t';
@@ -355,11 +321,12 @@ lemma state_relation_null_filterE:
     apply (case_tac "cdt s (a, b)")
      apply (subst mdb_cte_at_no_descendants, assumption)
       apply (simp add: cte_wp_at_caps_of_state swp_def)
-     apply (cut_tac s="kheap_update f s"  and
+     apply (cut_tac s="kheap_update f (ekheap_update ef s)"  and
                     s'="s'\<lparr>ksPSpace := f' (ksPSpace s'),
                            gsUserPages := g' (gsUserPages s'),
                            gsCNodes := h' (gsCNodes s')\<rparr>"
             in pspace_relation_ctes_ofI, simp_all)[1]
+      apply (simp add: trans_state_update[symmetric] del: trans_state_update)
       apply (erule caps_of_state_cteD)
      apply (clarsimp simp: descendants_of'_def)
      apply (case_tac cte)
@@ -430,7 +397,7 @@ lemma foldr_update_ko_wp_at':
   assumes pv: "pspace_aligned' s" "pspace_distinct' s"
      and pv': "pspace_aligned' (ksPSpace_update (\<lambda>x xa. if xa \<in> set addrs then Some obj else ksPSpace s xa) s)"
               "pspace_distinct' (ksPSpace_update (\<lambda>x xa. if xa \<in> set addrs then Some obj else ksPSpace s xa) s)"
-      and al: "\<forall>x \<in> set addrs. is_aligned x (objBitsKO obj)" "objBitsKO obj < word_bits"
+      and al: "\<forall>x \<in> set addrs. is_aligned x (objBitsKO obj)"
    shows
   "ko_wp_at' P p (ksPSpace_update (\<lambda>x xa. if xa \<in> set addrs then Some obj else ksPSpace s xa) s)
          = (if p \<in> set addrs then P obj
@@ -453,7 +420,7 @@ lemma foldr_update_obj_at':
   assumes pv: "pspace_aligned' s" "pspace_distinct' s"
      and pv': "pspace_aligned' (ksPSpace_update (\<lambda>x xa. if xa \<in> set addrs then Some obj else ksPSpace s xa) s)"
               "pspace_distinct' (ksPSpace_update (\<lambda>x xa. if xa \<in> set addrs then Some obj else ksPSpace s xa) s)"
-      and al: "\<forall>x \<in> set addrs. is_aligned x (objBitsKO obj)" "objBitsKO obj < word_bits"
+      and al: "\<forall>x \<in> set addrs. is_aligned x (objBitsKO obj)"
    shows
   "obj_at' P p (ksPSpace_update (\<lambda>x xa. if xa \<in> set addrs then Some obj else ksPSpace s xa) s)
          = (if p \<in> set addrs then (\<exists>obj'. projectKO_opt obj = Some obj' \<and> P obj')
@@ -463,12 +430,12 @@ lemma foldr_update_obj_at':
   done
 
 lemma makeObjectKO_eq:
-  assumes x: "makeObjectKO dev us d tp = Some v"
+  assumes x: "makeObjectKO dev tp = Some v"
   shows
   "(v = KOCTE cte) =
        (tp = Inr (APIObjectType ArchTypes_H.CapTableObject) \<and> cte = makeObject)"
   "(v = KOTCB tcb) =
-       (tp = Inr (APIObjectType ArchTypes_H.TCBObject) \<and> tcb = (tcbDomain_update (\<lambda>_. d) makeObject))"
+       (tp = Inr (APIObjectType ArchTypes_H.TCBObject) \<and> tcb = makeObject)"
   using x
   by (simp add: makeObjectKO_def eq_commute
          split: apiobject_type.split_asm sum.split_asm kernel_object.split_asm
@@ -523,11 +490,11 @@ lemma ps_clearD:
   done
 
 lemma cte_wp_at_retype':
-  assumes ko: "makeObjectKO dev us d tp = Some obj"
+  assumes ko: "makeObjectKO dev tp = Some obj"
       and pv: "pspace_aligned' s" "pspace_distinct' s"
      and pv': "pspace_aligned' (ksPSpace_update (\<lambda>x xa. if xa \<in> set addrs then Some obj else ksPSpace s xa) s)"
               "pspace_distinct' (ksPSpace_update (\<lambda>x xa. if xa \<in> set addrs then Some obj else ksPSpace s xa) s)"
-      and al: "\<forall>x \<in> set addrs. is_aligned x (objBitsKO obj)""objBitsKO obj < word_bits"
+      and al: "\<forall>x \<in> set addrs. is_aligned x (objBitsKO obj)"
       and pn: "\<forall>x \<in> set addrs. ksPSpace s x = None"
    shows
   "cte_wp_at' P p (ksPSpace_update (\<lambda>x xa. if xa \<in> set addrs then Some obj else ksPSpace s xa) s)
@@ -544,14 +511,13 @@ lemma cte_wp_at_retype':
      apply (simp only: cte_wp_at_obj_cases_mask foldr_update_obj_at'[OF pv pv' al])
      apply (simp    add: projectKOs the_ctes_makeObject
                          makeObjectKO_eq [OF ko]
-                         makeObject_cte
+                         makeObject_cte dom_def
               split del: if_split
                    cong: if_cong)
      apply (insert al ko)
-     apply simp
-     apply (safe; simp)
-              apply ((fastforce simp: makeObjectKO_def makeObject_cte makeObject_tcb tcb_cte_cases_def
-                              split: if_split_asm)+)[10]
+     apply (simp, safe, simp_all)
+      apply fastforce
+     apply fastforce
     apply (clarsimp elim!: obj_atE' simp: projectKOs objBits_simps)
     apply (drule ps_clearD[where y=p and n=tcbBlockSizeBits])
        apply simp
@@ -563,11 +529,11 @@ lemma cte_wp_at_retype':
   done
 
 lemma ctes_of_retype:
-  assumes ko: "makeObjectKO dev us d tp = Some obj"
+  assumes ko: "makeObjectKO dev tp = Some obj"
       and pv: "pspace_aligned' s" "pspace_distinct' s"
      and pv': "pspace_aligned' (ksPSpace_update (\<lambda>x xa. if xa \<in> set addrs then Some obj else ksPSpace s xa) s)"
               "pspace_distinct' (ksPSpace_update (\<lambda>x xa. if xa \<in> set addrs then Some obj else ksPSpace s xa) s)"
-      and al: "\<forall>x \<in> set addrs. is_aligned x (objBitsKO obj)" "objBitsKO obj < word_bits"
+      and al: "\<forall>x \<in> set addrs. is_aligned x (objBitsKO obj)"
       and pn: "\<forall>x \<in> set addrs. ksPSpace s x = None"
    shows
   "map_to_ctes (\<lambda> xa. if xa \<in> set addrs then Some obj else ksPSpace s xa)
@@ -592,11 +558,11 @@ lemma None_ctes_of_cte_at:
   by (fastforce simp add: cte_wp_at_ctes_of)
 
 lemma null_filter_ctes_retype:
-  assumes ko: "makeObjectKO dev us d tp = Some obj"
+  assumes ko: "makeObjectKO dev tp = Some obj"
       and pv: "pspace_aligned' s" "pspace_distinct' s"
      and pv': "pspace_aligned' (ksPSpace_update (\<lambda>x xa. if xa \<in> set addrs then Some obj else ksPSpace s xa) s)"
               "pspace_distinct' (ksPSpace_update (\<lambda>x xa. if xa \<in> set addrs then Some obj else ksPSpace s xa) s)"
-      and al: "\<forall>x \<in> set addrs. is_aligned x (objBitsKO obj)" "objBitsKO obj < word_bits"
+      and al: "\<forall>x \<in> set addrs. is_aligned x (objBitsKO obj)"
       and pn: "\<forall>x \<in> set addrs. ksPSpace s x = None"
   shows
   "null_filter' (map_to_ctes (foldr (\<lambda>addr. data_map_insert addr obj) addrs (ksPSpace s)))
@@ -623,12 +589,11 @@ lemma null_filter_ctes_retype:
    apply (insert ko[symmetric], simp add: makeObjectKO_def objBits_simps)
    apply clarsimp
    apply (subst(asm) subtract_mask[symmetric],
-          erule_tac v="if x \<in> set addrs then KOTCB (tcbDomain_update (\<lambda>_. d) makeObject)
-                                        else KOCTE cte"
+          erule_tac v="if x \<in> set addrs then KOTCB makeObject else KOCTE cte"
                 in tcb_space_clear)
        apply (simp add: is_aligned_mask word_bw_assocs)
       apply assumption
-     apply fastforce
+     apply simp
     apply simp
    apply (simp add: pn)
   apply (clarsimp simp: makeObjectKO_def)
@@ -743,14 +708,7 @@ lemma APIType_map2_Untyped[simp]:
   "(APIType_map2 tp = Structures_A.Untyped)
         = (tp = Inr (APIObjectType ArchTypes_H.Untyped))"
  by (simp add: APIType_map2_def
-        split: sum.split object_type.split kernel_object.split arch_kernel_object.splits
-                apiobject_type.split)
-
-lemma APIType_map2_SchedContext[simp]:
-  "(APIType_map2 tp = Structures_A.SchedContextObject)
-        = (tp = Inr (APIObjectType SchedContextObject))"
- by (simp add: APIType_map2_def
-        split: sum.split object_type.split kernel_object.split arch_kernel_object.splits
+         split: sum.split object_type.split kernel_object.split arch_kernel_object.splits
                 apiobject_type.split)
 
 lemma obj_relation_retype_leD:
@@ -759,14 +717,13 @@ lemma obj_relation_retype_leD:
   by (simp add: obj_relation_retype_def)
 
 lemma obj_relation_retype_default_leD:
-  "\<lbrakk> obj_relation_retype (default_object (APIType_map2 ty) dev us d) ko;
-       ty \<noteq> Inr (APIObjectType ArchTypes_H.Untyped);
-       ty = Inr (APIObjectType SchedContextObject) \<longrightarrow> min_sched_context_bits \<le> us \<rbrakk>
+  "\<lbrakk> obj_relation_retype (default_object (APIType_map2 ty) dev us) ko;
+       ty \<noteq> Inr (APIObjectType ArchTypes_H.Untyped) \<rbrakk>
       \<Longrightarrow> objBitsKO ko \<le> obj_bits_api (APIType_map2 ty) us"
-  by (clarsimp simp: obj_relation_retype_def objBits_def obj_bits_dev_irr)
+  by (simp add: obj_relation_retype_def objBits_def obj_bits_dev_irr)
 
 lemma makeObjectKO_Untyped:
-  "makeObjectKO dev us d ty = Some v \<Longrightarrow> ty \<noteq> Inr (APIObjectType ArchTypes_H.Untyped)"
+  "makeObjectKO dev ty = Some v \<Longrightarrow> ty \<noteq> Inr (APIObjectType ArchTypes_H.Untyped)"
   by (clarsimp simp: makeObjectKO_def)
 
 lemma obj_relation_cuts_trivial:
@@ -789,23 +746,22 @@ lemma obj_relation_cuts_trivial:
 
 lemma obj_relation_retype_addrs_eq:
   assumes not_unt:"ty \<noteq> Inr (APIObjectType ArchTypes_H.Untyped)"
-  assumes tysc: "ty = Inr (APIObjectType SchedContextObject) \<longrightarrow> min_sched_context_bits \<le> us"
   assumes  amp: "m = 2^ ((obj_bits_api (APIType_map2 ty) us) - (objBitsKO ko)) * n"
-  assumes  orr: "obj_relation_retype (default_object (APIType_map2 ty) dev us d) ko"
+  assumes  orr: "obj_relation_retype (default_object (APIType_map2 ty) dev us) ko"
   shows  "\<lbrakk> range_cover ptr sz (obj_bits_api (APIType_map2 ty) us) n \<rbrakk> \<Longrightarrow>
    (\<Union>x \<in> set (retype_addrs ptr (APIType_map2 ty) n us).
-            fst ` obj_relation_cuts (default_object (APIType_map2 ty) dev us d) x)
+            fst ` obj_relation_cuts (default_object (APIType_map2 ty) dev us) x)
       = set (new_cap_addrs m ptr ko)"
   apply (rule set_eqI, rule iffI)
    apply (clarsimp simp: retype_addrs_def)
    apply (rename_tac p a b)
    apply (drule obj_relation_retype_cutsD[OF _ orr])
-   apply (cut_tac obj_relation_retype_default_leD[OF orr not_unt tysc])
+   apply (cut_tac obj_relation_retype_default_leD[OF orr not_unt])
    apply (clarsimp simp: new_cap_addrs_def image_def
                   dest!: less_two_pow_divD)
    apply (rule_tac x="p * 2 ^ (obj_bits_api (APIType_map2 ty) us - objBitsKO ko) + unat y"
                  in rev_bexI)
-    apply (simp add: amp obj_bits_api_default_object not_unt tysc obj_bits_dev_irr)
+    apply (simp add: amp obj_bits_api_default_object not_unt obj_bits_dev_irr)
     apply (rule less_le_trans[OF nat_add_left_cancel_less[THEN iffD2]])
     apply (erule unat_mono)
       apply (subst unat_power_lower)
@@ -821,7 +777,7 @@ lemma obj_relation_retype_addrs_eq:
   apply (clarsimp simp: new_cap_addrs_def retype_addrs_def
                  dest!: less_two_pow_divD)
   apply (rename_tac p)
-  apply (cut_tac obj_relation_retype_default_leD[OF orr not_unt tysc])
+  apply (cut_tac obj_relation_retype_default_leD[OF orr not_unt])
   apply (cut_tac obj_relation_retype_leD[OF orr])
   apply (case_tac "n = 0")
    apply (simp add:amp)
@@ -850,20 +806,18 @@ lemma obj_relation_retype_addrs_eq:
    apply (rule power_strict_increasing)
    apply (rule le_less_trans[OF diff_le_self])
   apply (clarsimp simp: range_cover_def obj_bits_api_default_object obj_bits_dev_irr
-                        not_unt word_bits_def tysc)+
-  done
+                        not_unt word_bits_def)+
+done
 
 lemma objBits_le_obj_bits_api:
-  "ty = Inr (APIObjectType SchedContextObject) \<longrightarrow> min_sched_context_bits \<le> us \<Longrightarrow>
-   makeObjectKO dev us d ty = Some ko \<Longrightarrow>
+  "makeObjectKO dev ty = Some ko \<Longrightarrow>
    objBitsKO ko \<le> obj_bits_api (APIType_map2 ty) us"
   apply (case_tac ty)
-    by (auto simp: default_arch_object_def pageBits_def archObjSize_def pteBits_def pdeBits_def
-                   makeObjectKO_def objBits_simps' APIType_map2_def obj_bits_api_def slot_bits_def
-                   scBits_simps
-            split: Structures_H.kernel_object.splits arch_kernel_object.splits object_type.splits
-                   Structures_H.kernel_object.splits arch_kernel_object.splits apiobject_type.splits
-                   if_split_asm)
+    apply (auto simp: default_arch_object_def pageBits_def archObjSize_def pteBits_def pdeBits_def
+                      makeObjectKO_def objBits_simps' APIType_map2_def obj_bits_api_def slot_bits_def
+               split: Structures_H.kernel_object.splits arch_kernel_object.splits object_type.splits
+                      Structures_H.kernel_object.splits arch_kernel_object.splits apiobject_type.splits)
+  done
 
 lemma obj_relation_retype_other_obj:
   "\<lbrakk> is_other_obj_relation_type (a_type ko); other_obj_relation ko ko' \<rbrakk>
@@ -878,68 +832,18 @@ lemma obj_relation_retype_other_obj:
                          arch_kernel_obj.split_asm arch_kernel_object.split)
   done
 
-lemma retype_kheap_dom_same:
-  assumes pn: "pspace_no_overlap_range_cover ptr sz s"
-  and    vs: "valid_pspace s" "valid_mdb s"
-  and cover: "range_cover ptr sz (obj_bits_api (APIType_map2 ty) us) n"
-  shows
-  "kheap s x = Some v \<Longrightarrow>
-     (foldr (\<lambda>p ps. ps(p \<mapsto> default_object (APIType_map2 ty) dev us d))
-                (retype_addrs ptr (APIType_map2 ty) n us) (kheap s)) x = Some v"
-proof -
-  have dom_not_ra:
-    "\<forall>x \<in> dom (kheap s). x \<notin> set (retype_addrs ptr (APIType_map2 ty) n us)"
-    apply clarsimp
-    apply (erule(1) pspace_no_overlapC[OF pn _ _ cover vs(1)])
-    done
-  assume H: "kheap s x = Some v"
-  thus ?thesis
-    apply -
-    apply (frule bspec [OF dom_not_ra, OF domI])
-    apply (simp add: foldr_upd_app_if)
-    done
-qed
-
-lemma retype_ksPSpace_dom_same:
-  fixes x v
-  assumes vs': "pspace_aligned' s'" "pspace_distinct' s'"
-  and   pn': "pspace_no_overlap' ptr sz s'"
-  and    ko: "makeObjectKO dev us d ty = Some ko"
-  and  tysc: "ty = Inr (APIObjectType SchedContextObject) \<longrightarrow> min_sched_context_bits \<le> us"
-  and cover: "range_cover ptr sz (obj_bits_api (APIType_map2 ty) us) n"
-  and num_r: "m = 2 ^ (obj_bits_api (APIType_map2 ty) us - objBitsKO ko) * n"
-  shows
-  "ksPSpace s' x = Some v \<Longrightarrow>
-    foldr (\<lambda>addr. data_map_insert addr ko) (new_cap_addrs m ptr ko) (ksPSpace s') x
-      = Some v"
-proof -
-  have cover':"range_cover ptr sz (objBitsKO ko) m"
-    by (rule range_cover_rel[OF cover objBits_le_obj_bits_api[OF tysc ko] num_r])
-  assume "ksPSpace s' x = Some v"
-  thus ?thesis
-    apply (clarsimp simp:foldr_upd_app_if[folded data_map_insert_def])
-    apply (drule domI[where m = "ksPSpace s'"])
-    apply (drule(1) IntI)
-    apply (erule_tac A = "A \<inter> B" for A B in in_emptyE[rotated])
-    apply (rule disjoint_subset[OF new_cap_addrs_subset[OF cover']])
-    apply (clarsimp simp:ptr_add_def field_simps)
-    apply (rule pspace_no_overlap_disjoint'[OF vs'(1) pn'])
-    done
-qed
-
 lemma retype_pspace_relation:
   assumes  sr: "pspace_relation (kheap s) (ksPSpace s')"
       and  vs: "valid_pspace s" "valid_mdb s"
       and vs': "pspace_aligned' s'" "pspace_distinct' s'"
       and  pn: "pspace_no_overlap_range_cover ptr sz s"
       and pn': "pspace_no_overlap' ptr sz s'"
-      and  ko: "makeObjectKO dev us d ty = Some ko"
-      and tysc: "ty = Inr (APIObjectType SchedContextObject) \<longrightarrow> min_sched_context_bits \<le> us"
+      and  ko: "makeObjectKO dev ty = Some ko"
       and cover: "range_cover ptr sz (obj_bits_api (APIType_map2 ty) us) n"
-      and orr: "obj_relation_retype (default_object (APIType_map2 ty) dev us d) ko"
+      and orr: "obj_relation_retype (default_object (APIType_map2 ty) dev us) ko"
       and num_r: "m = 2 ^ (obj_bits_api (APIType_map2 ty) us - objBitsKO ko) * n"
   shows
-  "pspace_relation (foldr (\<lambda>p ps. ps(p \<mapsto> default_object (APIType_map2 ty) dev us d))
+  "pspace_relation (foldr (\<lambda>p ps. ps(p \<mapsto> default_object (APIType_map2 ty) dev us))
                               (retype_addrs ptr (APIType_map2 ty) n us) (kheap s))
             (foldr (\<lambda>addr. data_map_insert addr ko) (new_cap_addrs m ptr ko) (ksPSpace s'))"
   (is "pspace_relation ?ps ?ps'")
@@ -958,7 +862,7 @@ proof
     "set (retype_addrs ptr (APIType_map2 ty) n us) \<inter> dom (kheap s) = {}"
     by auto
 
-  note pdom = pspace_dom_upd [OF dom_Int_ra, where ko="default_object (APIType_map2 ty) dev us d"]
+  note pdom = pspace_dom_upd [OF dom_Int_ra, where ko="default_object (APIType_map2 ty) dev us"]
 
   have pdom': "dom ?ps' = dom (ksPSpace s') \<union> set (new_cap_addrs m ptr ko)"
     by (clarsimp simp add: foldr_upd_app_if[folded data_map_insert_def]
@@ -973,12 +877,26 @@ proof
   thus "pspace_dom ?ps = dom ?ps'"
     apply (simp add: pdom pdom')
     apply (rule arg_cong[where f="\<lambda>T. S \<union> T" for S])
-    apply (rule obj_relation_retype_addrs_eq[OF not_unt tysc num_r orr cover])
+    apply (rule obj_relation_retype_addrs_eq[OF not_unt num_r orr cover])
     done
 
-  note dom_same = retype_kheap_dom_same[OF pn vs cover]
-
-  note dom_same' = retype_ksPSpace_dom_same[OF vs' pn' ko tysc cover num_r]
+  have dom_same:
+    "\<And>x v. kheap s x = Some v \<Longrightarrow> ?ps x = Some v"
+    apply (frule bspec [OF dom_not_ra, OF domI])
+    apply (simp add: foldr_upd_app_if)
+    done
+  have cover':"range_cover ptr sz (objBitsKO ko) m"
+    by (rule range_cover_rel[OF cover objBits_le_obj_bits_api[OF ko] num_r])
+  have dom_same':
+    "\<And>x v. ksPSpace s' x = Some v \<Longrightarrow> ?ps' x = Some v"
+    apply (clarsimp simp:foldr_upd_app_if[folded data_map_insert_def])
+    apply (drule domI[where m = "ksPSpace s'"])
+    apply (drule(1) IntI)
+    apply (erule_tac A = "A \<inter> B" for A B in in_emptyE[rotated])
+    apply (rule disjoint_subset[OF new_cap_addrs_subset[OF cover']])
+    apply (clarsimp simp:ptr_add_def field_simps)
+    apply (rule pspace_no_overlap_disjoint'[OF vs'(1) pn'])
+  done
 
   show "\<forall>x \<in> dom ?ps. \<forall>(y, P) \<in> obj_relation_cuts (the (?ps x)) x.
                    P (the (?ps x)) (the (?ps' y))"
@@ -989,7 +907,7 @@ proof
      apply (rule conjI)
       apply (drule obj_relation_retype_cutsD [OF _ orr], clarsimp)
      apply (rule impI, erule notE)
-     apply (simp add: obj_relation_retype_addrs_eq[OF not_unt tysc num_r orr cover,symmetric])
+     apply (simp add: obj_relation_retype_addrs_eq[OF not_unt num_r orr cover,symmetric])
      apply (erule rev_bexI)
      apply (simp add: image_def)
      apply (erule rev_bexI, simp)
@@ -1015,6 +933,79 @@ lemma foldr_upd_app_if': "foldr (\<lambda>p ps. ps(p := f p)) as g = (\<lambda>x
   apply (rule ext)
   apply simp
   done
+
+lemma etcb_rel_makeObject: "etcb_relation default_etcb makeObject"
+  apply (simp add: etcb_relation_def default_etcb_def)
+  apply (simp add: makeObject_tcb default_priority_def default_domain_def)
+  done
+
+
+lemma ekh_at_tcb_at: "valid_etcbs_2 ekh kh \<Longrightarrow> ekh x = Some y  \<Longrightarrow> \<exists>tcb. kh x = Some (TCB tcb)"
+  apply (simp add: valid_etcbs_2_def
+                   st_tcb_at_kh_def obj_at_kh_def
+                   is_etcb_at'_def obj_at_def)
+  apply force
+  done
+
+lemma default_etcb_default_domain_futz [simp]:
+  "default_etcb\<lparr>tcb_domain := default_domain\<rparr> = default_etcb"
+unfolding default_etcb_def by simp
+
+lemma retype_ekheap_relation:
+  assumes  sr: "ekheap_relation (ekheap s) (ksPSpace s')"
+      and  sr': "pspace_relation (kheap s) (ksPSpace s')"
+      and  vs: "valid_pspace s" "valid_mdb s"
+      and et: "valid_etcbs s"
+      and vs': "pspace_aligned' s'" "pspace_distinct' s'"
+      and  pn: "pspace_no_overlap_range_cover ptr sz s"
+      and pn': "pspace_no_overlap' ptr sz s'"
+      and  ko: "makeObjectKO dev ty = Some ko"
+      and cover: "range_cover ptr sz (obj_bits_api (APIType_map2 ty) us) n"
+      and orr: "obj_relation_retype (default_object (APIType_map2 ty) dev us) ko"
+      and num_r: "m = 2 ^ (obj_bits_api (APIType_map2 ty) us - objBitsKO ko) * n"
+  shows
+  "ekheap_relation (foldr (\<lambda>p ps. ps(p := default_ext (APIType_map2 ty) default_domain))
+                              (retype_addrs ptr (APIType_map2 ty) n us) (ekheap s))
+            (foldr (\<lambda>addr. data_map_insert addr ko) (new_cap_addrs m ptr ko) (ksPSpace s'))"
+  (is "ekheap_relation ?ps ?ps'")
+  proof -
+  have not_unt: "ty \<noteq> Inr (APIObjectType ArchTypes_H.Untyped)"
+     by (rule makeObjectKO_Untyped[OF ko])
+  show ?thesis
+    apply (case_tac "ty \<noteq> Inr (APIObjectType apiobject_type.TCBObject)")
+     apply (insert ko)
+     apply (cut_tac retype_pspace_relation[OF sr' vs vs' pn pn' ko cover orr num_r])
+     apply (simp add: foldr_upd_app_if' foldr_upd_app_if[folded data_map_insert_def])
+     apply (simp add: obj_relation_retype_addrs_eq[OF not_unt num_r orr cover,symmetric])
+     apply (insert sr)
+     apply (clarsimp simp add: ekheap_relation_def
+                      pspace_relation_def default_ext_def cong: if_cong
+                      split: if_split_asm)
+      subgoal by (clarsimp simp add: makeObjectKO_def APIType_map2_def cong: if_cong
+                              split: sum.splits Structures_H.kernel_object.splits
+                                     arch_kernel_object.splits ARM_H.object_type.splits apiobject_type.splits)
+
+     apply (frule ekh_at_tcb_at[OF et])
+     apply (intro impI conjI)
+      apply clarsimp
+      apply (drule_tac x=a in bspec,force)
+      apply (clarsimp simp add: tcb_relation_cut_def split: if_split_asm)
+       apply (case_tac ko,simp_all)
+       apply (clarsimp simp add: makeObjectKO_def cong: if_cong split: sum.splits Structures_H.kernel_object.splits
+                                 arch_kernel_object.splits ARM_H.object_type.splits
+                                 apiobject_type.splits if_split_asm)
+      apply (drule_tac x=xa in bspec,simp)
+      subgoal by force
+     subgoal by force
+    apply (simp add: foldr_upd_app_if' foldr_upd_app_if[folded data_map_insert_def])
+    apply (simp add: obj_relation_retype_addrs_eq[OF not_unt num_r orr cover,symmetric])
+    apply (clarsimp simp add: APIType_map2_def default_ext_def ekheap_relation_def
+           default_object_def makeObjectKO_def etcb_rel_makeObject
+           cong: if_cong
+           split: if_split_asm)
+    apply force
+  done
+qed
 
 lemma pspace_no_overlapD':
   "\<lbrakk> ksPSpace s x = Some ko; pspace_no_overlap' p bits s \<rbrakk>
@@ -1080,13 +1071,10 @@ qed
 
 lemma retype_aligned_distinct':
   assumes vs': "pspace_aligned' s'" "pspace_distinct' s'"
-      and bd : "pspace_bounded' s'"
       and pn': "pspace_no_overlap' ptr sz s'"
       and cover: "range_cover ptr sz (objBitsKO ko) n "
   shows
   "pspace_distinct' (s' \<lparr>ksPSpace := foldr (\<lambda>addr. data_map_insert addr ko)
-                                             (new_cap_addrs n ptr ko) (ksPSpace s')\<rparr>)"
-  "pspace_bounded' (s' \<lparr>ksPSpace := foldr (\<lambda>addr. data_map_insert addr ko)
                                              (new_cap_addrs n ptr ko) (ksPSpace s')\<rparr>)"
   "pspace_aligned' (s' \<lparr>ksPSpace := foldr (\<lambda>addr. data_map_insert addr ko)
                                              (new_cap_addrs n ptr ko) (ksPSpace s')\<rparr>)"
@@ -1105,6 +1093,9 @@ proof -
                        split: if_split_asm)
     apply (drule bspec, erule domI, simp)
     done
+
+  have okov: "objBitsKO ko < word_bits"
+    by (simp add: objBits_def)
 
   have new_range_disjoint:
     "\<And>x. x \<in> set (new_cap_addrs n ptr ko) \<Longrightarrow>
@@ -1142,15 +1133,6 @@ proof -
     apply (rule disjoint_subset[OF Diff_subset])
     apply (erule pspace_no_overlapD' [OF _ pn'])
     done
-
-  show bd': "pspace_bounded' ?s'" using bd
-    apply (subst foldr_upd_app_if[folded data_map_insert_def])
-    apply (clarsimp simp: pspace_bounded'_def split: if_split_asm)
-    using cover
-     apply (simp add: range_cover_def word_bits_def)
-    apply (drule bspec, erule domI, simp)
-    done
-
 qed
 
 definition
@@ -1207,173 +1189,188 @@ lemma update_gs_simps[simp]:
                                else ups x)"
   by (simp_all add: update_gs_def)
 
-lemma retype_obj_at'_not:
-  assumes ad: "pspace_aligned' s" "pspace_distinct' s"
-  and     pn: "pspace_no_overlap' ptr sz s"
-  and  cover: "range_cover ptr sz (objBitsKO val + gbits) n"
-  shows "\<And>P x. x \<in> set (new_cap_addrs (2 ^ gbits * n) ptr val) \<Longrightarrow> \<not> obj_at' P x s"
-proof -
-  note cover' = range_cover_rel[where sbit' = "objBitsKO val",OF cover _ refl,simplified]
-  show "\<And>P x. x \<in> set (new_cap_addrs (2 ^ gbits * n) ptr val) \<Longrightarrow> \<not> obj_at' P x s"
-    apply (clarsimp simp: obj_at'_def)
-    apply (drule subsetD [OF new_cap_addrs_subset [OF cover' ]])
-    apply (insert pspace_no_overlap_disjoint' [OF ad(1) pn])
-    apply (drule domI[where m = "ksPSpace s"])
-    apply (drule(1) orthD2)
-    apply (clarsimp simp:ptr_add_def p_assoc_help)
-    done
-qed
-
-lemma retype_ko_wp_at'_not:
-  assumes ad: "pspace_aligned' s" "pspace_distinct' s"
-  and     pn: "pspace_no_overlap' ptr sz s"
-  and  cover: "range_cover ptr sz (objBitsKO val + gbits) n"
-  shows "\<And>P x. x \<in> set (new_cap_addrs (2 ^ gbits * n) ptr val) \<Longrightarrow> \<not> ko_wp_at' P x s"
-proof -
-  note cover' = range_cover_rel[where sbit' = "objBitsKO val",OF cover _ refl,simplified]
-  show "\<And>P x. x \<in> set (new_cap_addrs (2 ^ gbits * n) ptr val) \<Longrightarrow> \<not> ko_wp_at' P x s"
-    apply (clarsimp simp: ko_wp_at'_def)
-    apply (drule subsetD [OF new_cap_addrs_subset [OF cover' ]])
-    apply (insert pspace_no_overlap_disjoint' [OF ad(1) pn])
-    apply (drule domI[where m = "ksPSpace s"])
-    apply (drule(1) orthD2)
-    apply (clarsimp simp:ptr_add_def p_assoc_help)
-    done
-qed
-
-lemma retype_replyPrevs_of:
-  assumes  pr: "pspace_relation (kheap s) (ksPSpace s')"
-      and  vs: "valid_pspace s" "valid_mdb s"
-      and vs': "pspace_aligned' s'" "pspace_distinct' s'"
-      and  pn: "pspace_no_overlap_range_cover ptr sz s"
-      and pn': "pspace_no_overlap' ptr sz s'"
-      and  ko: "makeObjectKO dev us d ty = Some ko"
-      and tysc: "ty = Inr (APIObjectType SchedContextObject) \<longrightarrow> min_sched_context_bits \<le> us"
-      and cover: "range_cover ptr sz (obj_bits_api (APIType_map2 ty) us) n"
-      and orr: "obj_relation_retype (default_object (APIType_map2 ty) dev us d) ko"
-      and num_r: "m = 2 ^ (obj_bits_api (APIType_map2 ty) us - objBitsKO ko) * n"
+lemma retype_ksPSpace_dom_same:
+  fixes x v
+  assumes   vs': "pspace_aligned' s'" "pspace_distinct' s'"
+  assumes   pn': "pspace_no_overlap' ptr sz s'"
+  assumes    ko: "makeObjectKO dev ty = Some ko"
+  assumes cover: "range_cover ptr sz (obj_bits_api (APIType_map2 ty) us) n"
+  assumes num_r: "m = 2 ^ (obj_bits_api (APIType_map2 ty) us - objBitsKO ko) * n"
   shows
-  "replyPrevs_of
-     (s'\<lparr>ksPSpace := foldr (\<lambda>addr. data_map_insert addr ko) (new_cap_addrs m ptr ko) (ksPSpace s')\<rparr>)
-    = replyPrevs_of s'" (is "replyPrevs_of ?ps' = replyPrevs_of s'")
+    "ksPSpace s' x = Some v \<Longrightarrow>
+     foldr (\<lambda>addr. data_map_insert addr ko) (new_cap_addrs m ptr ko) (ksPSpace s') x
+      = Some v"
 proof -
-  note dom_same' = retype_ksPSpace_dom_same[OF vs' pn' ko tysc cover num_r]
+  have cover':"range_cover ptr sz (objBitsKO ko) m"
+    by (rule range_cover_rel[OF cover objBits_le_obj_bits_api[OF ko] num_r])
+  assume "ksPSpace s' x = Some v"
+  thus ?thesis
+    apply (clarsimp simp:foldr_upd_app_if[folded data_map_insert_def])
+    apply (drule domI[where m = "ksPSpace s'"])
+    apply (drule(1) IntI)
+    apply (erule_tac A = "A \<inter> B" for A B in in_emptyE[rotated])
+    apply (rule disjoint_subset[OF new_cap_addrs_subset[OF cover']])
+    apply (clarsimp simp:ptr_add_def field_simps)
+    apply (rule pspace_no_overlap_disjoint'[OF vs'(1) pn'])
+    done
+qed
+
+lemma retype_ksPSpace_None:
+  assumes ad: "pspace_aligned' s" "pspace_distinct' s" "pspace_bounded' s"
+  assumes pn: "pspace_no_overlap' ptr sz s"
+  assumes cover: "range_cover ptr sz (objBitsKO val + gbits) n"
+  shows "\<And>x. x \<in> set (new_cap_addrs (2 ^ gbits * n) ptr val) \<Longrightarrow> ksPSpace s x = None"
+proof -
+  note cover' = range_cover_rel[where sbit' = "objBitsKO val",OF cover _ refl,simplified]
+  show "\<And>x. x \<in> set (new_cap_addrs (2 ^ gbits * n) ptr val) \<Longrightarrow> ksPSpace s x = None"
+    apply (drule subsetD[OF new_cap_addrs_subset [OF cover' ]])
+    apply (insert pspace_no_overlap_disjoint' [OF ad(1) pn])
+    apply (fastforce simp: ptr_add_def p_assoc_help)
+    done
+qed
+
+lemma retype_tcbSchedPrevs_of:
+  assumes   vs': "pspace_aligned' s'" "pspace_distinct' s'"
+  assumes   pn': "pspace_no_overlap' ptr sz s'"
+  assumes    ko: "makeObjectKO dev ty = Some ko"
+  assumes cover: "range_cover ptr sz (obj_bits_api (APIType_map2 ty) us) n"
+  assumes num_r: "m = 2 ^ (obj_bits_api (APIType_map2 ty) us - objBitsKO ko) * n"
+  shows
+    "tcbSchedPrevs_of
+       (s'\<lparr>ksPSpace := foldr (\<lambda>addr. data_map_insert addr ko) (new_cap_addrs m ptr ko) (ksPSpace s')\<rparr>)
+     = tcbSchedPrevs_of s'"
+proof -
+  note dom_same' = retype_ksPSpace_dom_same[OF vs' pn' ko cover num_r]
   show ?thesis
     apply (rule ext)
-    using pr
     apply (clarsimp simp: opt_map_def split: option.splits)
     apply (intro impI conjI allI; (drule dom_same'; simp)?)
-    apply (clarsimp simp:foldr_upd_app_if[folded data_map_insert_def] projectKO_opt_reply
+    apply (clarsimp simp: foldr_upd_app_if[folded data_map_insert_def]
                    split: if_split_asm kernel_object.split_asm)
     using ko
     by (cases ty;
-        simp add: makeObjectKO_def makeObject_reply
+        simp add: makeObjectKO_def makeObject_tcb projectKOs
            split: kernel_object.split_asm arch_kernel_object.split_asm object_type.split_asm
-                 apiobject_type.split_asm if_split_asm)
-        fastforce
+                  apiobject_type.split_asm if_split_asm)
+       fastforce+
 qed
 
-lemma retype_sc_replies_relation:
-  assumes  sr: "sc_replies_relation s s'"
-      and  pr: "pspace_relation (kheap s) (ksPSpace s')"
-      and  vs: "valid_pspace s" "valid_mdb s"
-      and vs': "pspace_aligned' s'" "pspace_distinct' s'"
-      and  pn: "pspace_no_overlap_range_cover ptr sz s"
-      and pn': "pspace_no_overlap' ptr sz s'"
-      and  ko: "makeObjectKO dev us d ty = Some ko"
-      and tysc: "ty = Inr (APIObjectType SchedContextObject) \<longrightarrow> min_sched_context_bits \<le> us"
-      and cover: "range_cover ptr sz (obj_bits_api (APIType_map2 ty) us) n"
-      and orr: "obj_relation_retype (default_object (APIType_map2 ty) dev us d) ko"
-      and num_r: "m = 2 ^ (obj_bits_api (APIType_map2 ty) us - objBitsKO ko) * n"
+lemma retype_tcbSchedNexts_of:
+  assumes   vs': "pspace_aligned' s'" "pspace_distinct' s'"
+  assumes   pn': "pspace_no_overlap' ptr sz s'"
+  assumes    ko: "makeObjectKO dev ty = Some ko"
+  assumes cover: "range_cover ptr sz (obj_bits_api (APIType_map2 ty) us) n"
+  assumes num_r: "m = 2 ^ (obj_bits_api (APIType_map2 ty) us - objBitsKO ko) * n"
   shows
-  "sc_replies_relation
-     (s \<lparr>kheap := foldr (\<lambda>p. data_map_insert p (default_object (APIType_map2 ty) dev us d))
-                                           (retype_addrs ptr (APIType_map2 ty) n us) (kheap s)\<rparr>)
-     (s'\<lparr>ksPSpace := foldr (\<lambda>addr. data_map_insert addr ko) (new_cap_addrs m ptr ko) (ksPSpace s')\<rparr>)"
+    "tcbSchedNexts_of
+       (s'\<lparr>ksPSpace := foldr (\<lambda>addr. data_map_insert addr ko) (new_cap_addrs m ptr ko) (ksPSpace s')\<rparr>)
+     = tcbSchedNexts_of s'"
 proof -
-  have not_unt: "ty \<noteq> Inr (APIObjectType ArchTypes_H.Untyped)"
-    by (rule makeObjectKO_Untyped[OF ko])
-
-  note not_unt = makeObjectKO_Untyped [OF ko]
-
-  note dom_same = retype_kheap_dom_same[OF pn vs cover]
-
-  note dom_same' = retype_ksPSpace_dom_same[OF vs' pn' ko tysc cover num_r]
-
+  note dom_same' = retype_ksPSpace_dom_same[OF vs' pn' ko cover num_r]
   show ?thesis
-    using sr pr
-    unfolding sc_replies_relation_def
-    apply (clarsimp simp: sc_replies_of_scs_def map_project_def scs_of_kh_def
-                   split: Structures_A.kernel_object.split_asm
-                   elim!: opt_mapE)
-    apply (rename_tac sc n'; drule_tac x=p and y="sc_replies sc" in spec2)
-    apply (clarsimp simp: foldr_upd_app_if[folded data_map_insert_def] split: if_split_asm)
-     apply (case_tac "p \<in> set (new_cap_addrs m ptr ko)")
-      apply (case_tac "APIType_map2 ty"; simp add: default_object_def not_unt)
+    apply (rule ext)
+    apply (clarsimp simp: opt_map_def split: option.splits)
+    apply (intro impI conjI allI; (drule dom_same'; simp)?)
+    apply (clarsimp simp: foldr_upd_app_if[folded data_map_insert_def]
+                   split: if_split_asm kernel_object.split_asm)
     using ko
-      apply (clarsimp simp: makeObjectKO_def makeObject_sc default_sched_context_def
-                            opt_map_def projectKO_opt_sc)
-     apply (erule notE)
-     apply (clarsimp simp: pspace_relation_def)
-     apply (simp add: obj_relation_retype_addrs_eq[OF not_unt tysc num_r orr cover,symmetric])
-    apply (clarsimp simp: scs_of_kh_def opt_map_Some sc_replies_of_scs_def map_project_Some)
-    apply (fold foldr_upd_app_if[folded data_map_insert_def])
-    apply (simp only: retype_replyPrevs_of[OF pr vs vs' pn pn' ko tysc cover orr num_r, simplified])
-    apply (clarsimp simp: pspace_relation_def)
-    apply (drule_tac x=p in bspec, fastforce)
-    apply (prop_tac "p \<in> dom (ksPSpace s')")
-     apply (clarsimp simp: pspace_dom_def split: if_split_asm, fastforce)
-    apply (clarsimp split: if_split_asm kernel_object.splits)
-    apply (frule dom_same')
-    apply (clarsimp simp: opt_map_def)
-    done
+    by (cases ty;
+        simp add: makeObjectKO_def makeObject_tcb projectKOs
+           split: kernel_object.split_asm arch_kernel_object.split_asm object_type.split_asm
+                  apiobject_type.split_asm if_split_asm)
+       fastforce+
 qed
+
+lemma retype_inQ:
+  assumes   vs': "pspace_aligned' s'" "pspace_distinct' s'"
+  assumes   pn': "pspace_no_overlap' ptr sz s'"
+  assumes    ko: "makeObjectKO dev ty = Some ko"
+  assumes cover: "range_cover ptr sz (obj_bits_api (APIType_map2 ty) us) n"
+  assumes num_r: "m = 2 ^ (obj_bits_api (APIType_map2 ty) us - objBitsKO ko) * n"
+  shows
+    "\<forall>d p.
+      inQ d p |< tcbs_of'
+       (s'\<lparr>ksPSpace := foldr (\<lambda>addr. data_map_insert addr ko) (new_cap_addrs m ptr ko) (ksPSpace s')\<rparr>)
+      = inQ d p |< tcbs_of' s'"
+proof -
+  note dom_same' = retype_ksPSpace_dom_same[OF vs' pn' ko cover num_r]
+  show ?thesis
+    apply (intro allI)
+    apply (rule ext)
+    apply (clarsimp simp: inQ_def opt_pred_def opt_map_def split: option.splits)
+    apply (intro impI conjI allI; (drule dom_same'; simp)?)
+    apply (clarsimp simp: foldr_upd_app_if[folded data_map_insert_def]
+                   split: if_split_asm kernel_object.split_asm)
+    using ko
+    by (cases ty;
+        fastforce simp  add: makeObjectKO_def makeObject_tcb projectKOs
+           split: kernel_object.split_asm arch_kernel_object.split_asm object_type.split_asm
+                  apiobject_type.split_asm if_split_asm
+        | fastforce)+
+qed
+
+lemma retype_ready_queues_relation:
+  assumes  rlqr: "ready_queues_relation s s'"
+  assumes   vs': "pspace_aligned' s'" "pspace_distinct' s'"
+  assumes   pn': "pspace_no_overlap' ptr sz s'"
+  assumes    ko: "makeObjectKO dev ty = Some ko"
+  assumes cover: "range_cover ptr sz (obj_bits_api (APIType_map2 ty) us) n"
+  assumes num_r: "m = 2 ^ (obj_bits_api (APIType_map2 ty) us - objBitsKO ko) * n"
+  shows
+    "ready_queues_relation
+       (s \<lparr>kheap := foldr (\<lambda>p. data_map_insert p (default_object (APIType_map2 ty) dev us))
+                                             (retype_addrs ptr (APIType_map2 ty) n us) (kheap s)\<rparr>)
+       (s'\<lparr>ksPSpace := foldr (\<lambda>addr. data_map_insert addr ko) (new_cap_addrs m ptr ko) (ksPSpace s')\<rparr>)"
+  using rlqr
+  unfolding ready_queues_relation_def Let_def
+  by (clarsimp simp: retype_tcbSchedNexts_of[OF vs' pn' ko cover num_r, simplified]
+                     retype_tcbSchedPrevs_of[OF vs' pn' ko cover num_r, simplified]
+                     retype_inQ[OF vs' pn' ko cover num_r, simplified])
 
 lemma retype_state_relation:
   notes data_map_insert_def[simp del]
   assumes  sr:   "(s, s') \<in> state_relation"
       and  vs:   "valid_pspace s" "valid_mdb s"
-      and  et:   "valid_list s"
+      and  et:   "valid_etcbs s" "valid_list s"
       and vs':   "pspace_aligned' s'" "pspace_distinct' s'"
-      and bd':   "pspace_bounded' s'"
       and  pn:   "pspace_no_overlap_range_cover ptr sz s"
       and pn':   "pspace_no_overlap' ptr sz s'"
-      and tysc: "ty = Inr (APIObjectType SchedContextObject) \<longrightarrow> min_sched_context_bits \<le> us"
       and cover: "range_cover ptr sz (obj_bits_api (APIType_map2 ty) us) n"
-      and  ko:   "makeObjectKO dev us d ty = Some ko"
+      and  ko:   "makeObjectKO dev ty = Some ko"
       and api:   "obj_bits_api (APIType_map2 ty) us \<le> sz"
-      and orr:   "obj_relation_retype (default_object (APIType_map2 ty) dev us d) ko"
+      and orr:   "obj_relation_retype (default_object (APIType_map2 ty) dev us) ko"
       and num_r: "m = 2 ^ (obj_bits_api (APIType_map2 ty) us - objBitsKO ko) * n"
   shows
-  "(s \<lparr>kheap :=
-              foldr (\<lambda>p. data_map_insert p (default_object (APIType_map2 ty) dev us d))
+  "(ekheap_update
+              (\<lambda>_. foldr (\<lambda>p ekh a. if a = p then default_ext (APIType_map2 ty) default_domain else ekh a)
+                    (retype_addrs ptr (APIType_map2 ty) n us) (ekheap s))
+            s
+           \<lparr>kheap :=
+              foldr (\<lambda>p. data_map_insert p (default_object (APIType_map2 ty) dev us))
                (retype_addrs ptr (APIType_map2 ty) n us) (kheap s)\<rparr>,
            update_gs (APIType_map2 ty) us (set (retype_addrs ptr (APIType_map2 ty) n us))
             (s'\<lparr>ksPSpace :=
                   foldr (\<lambda>addr. data_map_insert addr ko) (new_cap_addrs m ptr ko)
                    (ksPSpace s')\<rparr>))
           \<in> state_relation"
-  (is "(s\<lparr>kheap := ?ps\<rparr>, update_gs _ _ _ (s'\<lparr>ksPSpace := ?ps'\<rparr>))
-       \<in> state_relation"
-   is "(?t, ?t') \<in> state_relation")
-  proof (rule state_relation_null_filterE[OF sr refl _ _ _ _ _ _ _ vs'],
-         simp_all add: trans_state_update[symmetric] del: trans_state_update) (* FIXME: don't simp here *)
+  (is "(ekheap_update (\<lambda>_. ?eps) s\<lparr>kheap := ?ps\<rparr>, update_gs _ _ _ (s'\<lparr>ksPSpace := ?ps'\<rparr>))
+       \<in> state_relation")
+  proof (rule state_relation_null_filterE[OF sr refl _ _ _ _ _ _ _ _ vs'], simp_all add: trans_state_update[symmetric] del: trans_state_update)
 
   have cover':"range_cover ptr sz (objBitsKO ko) m"
-    by (rule range_cover_rel[OF cover objBits_le_obj_bits_api[OF tysc ko] num_r])
+    by (rule range_cover_rel[OF cover objBits_le_obj_bits_api[OF ko] num_r])
   have al':"is_aligned ptr (objBitsKO ko)"
     using cover'
     by (simp add:range_cover_def)
-  have bd:"objBitsKO ko < word_bits"
-    using cover'
-    by (simp add:range_cover_def word_bits_def)
   have sz:"sz < word_bits"
     using cover'
     by (simp add:range_cover_def word_bits_def)
+  let ?t = "s\<lparr>kheap := ?ps\<rparr>"
   let ?tp = "APIType_map2 ty"
   let ?al = "retype_addrs ptr ?tp n us"
+  let ?t' = "update_gs ?tp us (set ?al) (s'\<lparr>ksPSpace := ?ps'\<rparr>)"
 
-  note pad' = retype_aligned_distinct' [OF vs' bd' pn' cover']
+  note pad' = retype_aligned_distinct' [OF vs' pn' cover']
   thus pa': "pspace_aligned' (s'\<lparr>ksPSpace := ?ps'\<rparr>)"
    and pd': "pspace_distinct' (s'\<lparr>ksPSpace := ?ps'\<rparr>)"
     by simp_all
@@ -1396,13 +1393,12 @@ lemma retype_state_relation:
   note nc_al' = nc_al[unfolded objBits_def]
   show "null_filter' (map_to_ctes ?ps') = null_filter' (ctes_of s')"
     apply (rule null_filter_ctes_retype [OF ko vs' pa'' pd''])
-      apply (simp add: nc_al)
-     apply (simp add: bd)
+     apply (simp add: nc_al)
     apply clarsimp
     apply (drule subsetD [OF new_cap_addrs_subset [OF cover']])
     apply (insert pspace_no_overlap_disjoint'[OF vs'(1) pn'])
     apply (drule orthD1)
-     apply (simp add:ptr_add_def field_simps)
+      apply (simp add:ptr_add_def field_simps)
     apply clarsimp
     done
 
@@ -1422,8 +1418,14 @@ lemma retype_state_relation:
     using sr by (simp add: state_relation_def)
 
   thus "pspace_relation ?ps ?ps'"
-    by (rule retype_pspace_relation [OF _ vs vs' pn pn' ko tysc cover orr num_r,
+    by (rule retype_pspace_relation [OF _ vs vs' pn pn' ko cover orr num_r,
         folded data_map_insert_def])
+
+  have "ekheap_relation (ekheap (s)) (ksPSpace s')"
+  using sr by (simp add: state_relation_def)
+
+  thus "ekheap_relation ?eps ?ps'"
+    by (fold fun_upd_apply) (rule retype_ekheap_relation[OF _ pspr vs et(1) vs' pn pn' ko cover orr num_r])
 
   have pn2: "\<forall>a\<in>set ?al. kheap s a = None"
     by (rule ccontr) (clarsimp simp: pspace_no_overlapD1[OF pn _ cover vs(1)])
@@ -1493,30 +1495,6 @@ lemma retype_state_relation:
       by (simp add: ghost_relation_of_heap,
           simp add: CapTableObject update_gs_def ext)
   next
-    case ReplyObject
-    from pn2
-    have [simp]: "ups_of_heap ?ps = ups_of_heap (kheap s)"
-      by - (rule ext, induct (?al),
-            simp_all add: ups_of_heap_def default_object_def data_map_insert_def ReplyObject)
-    from pn2
-    have [simp]: "cns_of_heap ?ps = cns_of_heap (kheap s)"
-      by - (rule ext, induct (?al),
-            simp_all add: cns_of_heap_def default_object_def data_map_insert_def ReplyObject)
-    from gr show ?thesis
-      by (simp add: ghost_relation_of_heap, simp add: ReplyObject update_gs_def)
-  next
-    case SchedContextObject
-    from pn2
-    have [simp]: "ups_of_heap ?ps = ups_of_heap (kheap s)"
-      by - (rule ext, induct (?al),
-            simp_all add: ups_of_heap_def default_object_def data_map_insert_def SchedContextObject)
-    from pn2
-    have [simp]: "cns_of_heap ?ps = cns_of_heap (kheap s)"
-      by - (rule ext, induct (?al),
-            simp_all add: cns_of_heap_def default_object_def data_map_insert_def SchedContextObject)
-    from gr show ?thesis
-      by (simp add: ghost_relation_of_heap, simp add: SchedContextObject update_gs_def)
-  next
     case (ArchObject ao)
     from pn2
     have [simp]: "cns_of_heap ?ps = cns_of_heap (kheap s)"
@@ -1544,16 +1522,14 @@ lemma retype_state_relation:
     apply (clarsimp simp: update_gs_def
                    split: Structures_A.apiobject_type.splits)
     apply (intro conjI impI)
-           apply (subst ex_comm, rule_tac x=id in exI,
-                  subst ex_comm, rule_tac x=id in exI, fastforce)+
-       apply (subst ex_comm, rule_tac x=id in exI)
-       apply (subst ex_comm)
-       apply (rule_tac x="\<lambda>cns x. if x\<in>set ?al then Some us else cns x" in exI,
-              simp)
-       apply (rule_tac x="\<lambda>x. foldr (\<lambda>addr. data_map_insert addr ko)
-                                    (new_cap_addrs m ptr ko) x" in exI, simp)
-      apply (subst ex_comm, rule_tac x=id in exI,
-             subst ex_comm, rule_tac x=id in exI, fastforce)+
+         apply (subst ex_comm, rule_tac x=id in exI,
+                subst ex_comm, rule_tac x=id in exI, fastforce)+
+     apply (subst ex_comm, rule_tac x=id in exI)
+     apply (subst ex_comm)
+     apply (rule_tac x="\<lambda>cns x. if x\<in>set ?al then Some us else cns x" in exI,
+            simp)
+     apply (rule_tac x="\<lambda>x. foldr (\<lambda>addr. data_map_insert addr ko)
+                                  (new_cap_addrs m ptr ko) x" in exI, simp)
     apply clarsimp
     apply (rule_tac x="\<lambda>x. foldr (\<lambda>addr. data_map_insert addr ko)
                                  (new_cap_addrs m ptr ko) x" in exI)
@@ -1570,15 +1546,6 @@ lemma retype_state_relation:
                                   else cns x" in exI, simp)
       apply (rule_tac x=id in exI, simp)+
     done
-
-  have scr: "sc_replies_relation s s'"
-    using sr by (simp add: state_relation_def)
-
-  thus
-    "sc_replies_relation_2 (sc_replies_of_kh ?ps) (?ps' |> sc_of' |> scReply)
-                                                     (?ps' |> reply_of' |> replyPrev)"
-    using retype_sc_replies_relation [OF _ pspr vs vs' pn pn' ko tysc cover orr num_r]
-    by clarsimp
 
   have rdyqrel: "ready_queues_relation s s'"
     using sr by (simp add: state_relation_def)
@@ -1756,30 +1723,78 @@ next
   finally show ?case by (rule sym)
 qed
 
-lemma objBitsKO_gt_0: "0 < (objBitsKO ko)"
-  apply (case_tac ko; simp add: objBits_simps' pageBits_def bit_simps')
-  apply (rename_tac arch_kernel_object)
-  by (case_tac arch_kernel_object; simp add: archObjSize_def pageBits_def pteBits_def pdeBits_def)
+lemma awkward_fold_futz:
+  "fold (\<lambda>p ekh. ekh(p \<mapsto> the (ekh p)\<lparr>tcb_domain := cur_domain s\<rparr>)) ptrs ekh
+ = (\<lambda>x. if x \<in> set ptrs then Some ((the (ekh x))\<lparr>tcb_domain := cur_domain s\<rparr>) else ekh x)"
+by (induct ptrs arbitrary: ekh) (simp_all add: fun_eq_iff)
+
+lemma retype_region2_ext_retype_region_ext_futz:
+  "retype_region2_ext ptrs type >>= (\<lambda>_. retype_region2_extra_ext ptrs type)
+ = retype_region_ext ptrs type"
+proof(cases type)
+  case TCBObject
+  have complete_futz:
+    "\<And>F x. modify (ekheap_update (\<lambda>_. F (cur_domain x) (ekheap x))) x = modify (ekheap_update (\<lambda>ekh. F (cur_domain x) ekh)) x"
+    by (simp add: modify_def get_def get_etcb_def put_def bind_def return_def)
+  have second_futz:
+  "\<And>f G.
+   do modify (ekheap_update f);
+      cdom \<leftarrow> gets (\<lambda>s. cur_domain s);
+      G cdom
+   od =
+   do cdom \<leftarrow> gets (\<lambda>s. cur_domain s);
+      modify (ekheap_update f);
+      G cdom
+   od"
+    by (simp add: bind_def gets_def get_def return_def simpler_modify_def)
+  from TCBObject show ?thesis
+    apply (clarsimp simp: retype_region_ext_def retype_region2_ext_def retype_region2_extra_ext_def when_def bind_assoc)
+    apply (clarsimp simp: exec_gets fun_eq_iff)
+    apply (subst complete_futz)
+    apply (simp add: second_futz[simplified] exec_gets)
+    apply (simp add: default_ext_def exec_modify)
+    apply (subst mapM_x_modify_futz[where ptrs="rev ptrs", simplified])
+     apply (simp add: foldr_upd_app_if_eta_futz)
+    apply (simp add: modify_def exec_get put_def o_def)
+    apply (simp add: foldr_upd_app_if_eta_futz foldr_conv_fold awkward_fold_futz)
+    apply (simp cong: if_cong)
+    done
+qed (auto simp: fun_eq_iff retype_region_ext_def retype_region2_ext_def retype_region2_extra_ext_def
+                put_def gets_def get_def bind_def return_def mk_ef_def modify_def foldr_upd_app_if' when_def default_ext_def)
+
+lemma retype_region2_ext_retype_region:
+  "(retype_region ptr numObjects o_bits type dev :: (obj_ref list, det_ext) s_monad)
+ = (do ptrs \<leftarrow> retype_region2 ptr numObjects o_bits type dev;
+       retype_region2_extra_ext ptrs type;
+       return ptrs
+    od)"
+apply (clarsimp simp: retype_region_def retype_region2_def when_def bind_assoc)
+ apply safe
+ defer
+ apply (simp add: retype_region2_extra_ext_def)
+apply (subst retype_region_ext_modify_kheap_futz'[simplified bind_assoc])
+apply (subst retype_region2_ext_retype_region_ext_futz[symmetric])
+apply (simp add: bind_assoc)
+done
 
 lemma getObject_tcb_gets:
   "getObject addr >>= (\<lambda>x::tcb. gets proj >>= (\<lambda>y. G x y))
-   = gets proj >>= (\<lambda>y. getObject addr >>= (\<lambda>x. G x y))"
-  by (auto simp: exec_gets fun_eq_iff intro: bind_apply_cong
-           dest!: in_inv_by_hoareD[OF getObject_tcb_inv])
+ = gets proj >>= (\<lambda>y. getObject addr >>= (\<lambda>x. G x y))"
+by (auto simp: exec_gets fun_eq_iff intro: bind_apply_cong dest!: in_inv_by_hoareD[OF getObject_inv_tcb])
 
 lemma setObject_tcb_gets_ksCurDomain:
   "setObject addr (tcb::tcb) >>= (\<lambda>_. gets ksCurDomain >>= G)
-   = gets ksCurDomain >>= (\<lambda>x. setObject addr tcb >>= (\<lambda>_. G x))"
-  apply (clarsimp simp: exec_gets fun_eq_iff)
-  apply (rule bind_apply_cong)
-   apply simp
-  apply (drule_tac P1="\<lambda>cdom. cdom = ksCurDomain x" in use_valid[OF _ setObject_cd_inv])
-   apply (simp_all add: exec_gets)
-  done
+ = gets ksCurDomain >>= (\<lambda>x. setObject addr tcb >>= (\<lambda>_. G x))"
+apply (clarsimp simp: exec_gets fun_eq_iff)
+apply (rule bind_apply_cong)
+ apply simp
+apply (drule_tac P1="\<lambda>cdom. cdom = ksCurDomain x" in use_valid[OF _ setObject_cd_inv])
+apply (simp_all add: exec_gets)
+done
 
 lemma curDomain_mapM_x_futz:
   "curDomain >>= (\<lambda>cdom. mapM_x (threadSet (F cdom)) addrs)
-   = mapM_x (\<lambda>addr. curDomain >>= (\<lambda>cdom. threadSet (F cdom) addr)) addrs"
+ = mapM_x (\<lambda>addr. curDomain >>= (\<lambda>cdom. threadSet (F cdom) addr)) addrs"
 proof(induct addrs)
   case Nil thus ?case
     by (simp add: curDomain_def mapM_x_def sequence_x_def bind_def gets_def get_def return_def)
@@ -1804,42 +1819,55 @@ next
     done
 qed
 
+(*
+
+The existing proof continues below.
+
+*)
+
+lemma modify_ekheap_update_ekheap:
+  "modify (\<lambda>s. ekheap_update f s) = do s \<leftarrow> gets ekheap; modify (\<lambda>s'. s'\<lparr>ekheap := f s\<rparr>) od"
+by (simp add: modify_def gets_def get_def put_def bind_def return_def split_def fun_eq_iff)
+
 lemma corres_retype':
   assumes    not_zero: "n \<noteq> 0"
   and         aligned: "is_aligned ptr (objBitsKO ko + gbits)"
-  and    obj_bits_api: "obj_bits_api (APIType_map2 ty) us = objBitsKO ko + gbits"
-  and           check: "(sz < obj_bits_api (APIType_map2 ty)  us) = (sz < objBitsKO ko + gbits)"
-  and              ko: "makeObjectKO dev us d ty = Some ko"
-  and            tysc: "ty = Inr (APIObjectType SchedContextObject) \<longrightarrow> min_sched_context_bits \<le> us"
+  and    obj_bits_api: "obj_bits_api (APIType_map2 ty) us =
+                        objBitsKO ko + gbits"
+  and           check: "(sz < obj_bits_api (APIType_map2 ty)  us)
+                           = (sz < objBitsKO ko + gbits)"
+  and             usv: "APIType_map2 ty = Structures_A.CapTableObject \<Longrightarrow> 0 < us"
+  and              ko: "makeObjectKO dev ty = Some ko"
   and             orr: "obj_bits_api (APIType_map2 ty) us \<le> sz \<Longrightarrow>
-                        obj_relation_retype (default_object (APIType_map2 ty) dev us d) ko"
+                        obj_relation_retype
+                          (default_object (APIType_map2 ty) dev us) ko"
   and           cover: "range_cover ptr sz (obj_bits_api (APIType_map2 ty) us) n"
   shows "corres (\<lambda>rv rv'. rv' = g rv)
-                (\<lambda>s. valid_pspace s \<and> pspace_no_overlap_range_cover ptr sz s
-                     \<and> valid_mdb s \<and> valid_list s)
-                (\<lambda>s. pspace_aligned' s \<and> pspace_distinct' s \<and> pspace_no_overlap' ptr sz s
-                      \<and> (ty = Inr (APIObjectType TCBObject) \<longrightarrow> d = ksCurDomain s))
-                (retype_region ptr n us (APIType_map2 ty) dev)
-                (do addrs \<leftarrow> createObjects ptr n ko gbits;
-                    _ \<leftarrow> modify (update_gs (APIType_map2 ty) us (set addrs));
-                    return (g addrs)
-                 od)"
+  (\<lambda>s. valid_pspace s \<and> pspace_no_overlap_range_cover ptr sz s
+     \<and> valid_mdb s \<and> valid_etcbs s \<and> valid_list s)
+  (\<lambda>s. pspace_aligned' s \<and> pspace_distinct' s \<and> pspace_no_overlap' ptr sz s)
+  (retype_region2 ptr n us (APIType_map2 ty) dev)
+  (do addrs \<leftarrow> createObjects ptr n ko gbits;
+      _ \<leftarrow> modify (update_gs (APIType_map2 ty) us (set addrs));
+      return (g addrs) od)"
   (is "corres ?r ?P ?P' ?C ?A")
 proof -
   note data_map_insert_def[simp del]
-  have not_zero':"(of_nat n::machine_word) \<noteq> 0"
+  have not_zero':"((of_nat n)::word32) \<noteq> 0"
     by (rule range_cover_not_zero[OF not_zero cover])
-  have shiftr_not_zero:" (of_nat n::machine_word) << gbits \<noteq> 0"
+  have shiftr_not_zero:" ((of_nat n)::word32) << gbits \<noteq> 0"
     apply (rule range_cover_not_zero_shift[OF not_zero cover])
     apply (simp add:obj_bits_api)
     done
-  have unat_of_nat_shift:"unat ((of_nat n::machine_word) << gbits) = n * 2^ gbits"
+  have unat_of_nat_shift:"unat (((of_nat n)::word32) << gbits) =
+                          (n * 2^ gbits)"
     apply (rule range_cover.unat_of_nat_n_shift[OF cover])
     using obj_bits_api
     apply simp
     done
   have unat_of_nat_shift':
-    "unat ((of_nat n::machine_word) * 2^(gbits + objBitsKO ko)) = n * 2^(gbits + objBitsKO ko)"
+    "unat (((of_nat n)::word32) * 2^(gbits + objBitsKO ko)) =
+     n * 2^(gbits + objBitsKO ko)"
     apply (subst mult.commute)
     apply (simp add:shiftl_t2n[symmetric])
     apply (rule range_cover.unat_of_nat_n_shift[OF cover])
@@ -1847,29 +1875,32 @@ proof -
     apply simp
     done
   have unat_of_nat_n':
-    "unat (((of_nat n)::machine_word) * 2 ^ (gbits + objBitsKO ko)) \<noteq> 0"
+    "unat (((of_nat n)::word32) * 2 ^ (gbits + objBitsKO ko)) \<noteq> 0"
     by (simp add:unat_of_nat_shift' not_zero)
   have bound:"obj_bits_api (APIType_map2 ty) us \<le> sz"
     using cover
     by (simp add:range_cover_def)
   have n_estimate: "n < 2 ^ (word_bits - (objBitsKO ko + gbits))"
     apply (rule le_less_trans)
-     apply (rule range_cover.range_cover_n_le(2)[OF cover])
+    apply (rule range_cover.range_cover_n_le(2)[OF cover])
     apply (rule power_strict_increasing)
-     apply (simp add:obj_bits_api ko)
-     apply (rule diff_less_mono)
+    apply (simp add:obj_bits_api ko)
+    apply (rule diff_less_mono)
     using cover obj_bits_api
-      apply (simp_all add:range_cover_def ko word_bits_def)
+    apply (simp_all add:range_cover_def ko word_bits_def)
     done
 
   have set_retype_addrs_fold:
-    "image (\<lambda>n. ptr + 2 ^ obj_bits_api (APIType_map2 ty) us * n) {x. x \<le> of_nat n - 1} =
+    "image (\<lambda>n. ptr + 2 ^ obj_bits_api (APIType_map2 ty) us * n)
+           {x. x \<le> of_nat n - 1} =
      set (retype_addrs ptr (APIType_map2 ty) n us)"
-    apply (clarsimp simp: retype_addrs_def image_def Bex_def ptr_add_def Collect_eq)
+    apply (clarsimp simp: retype_addrs_def image_def Bex_def ptr_add_def
+                          Collect_eq)
     apply (rule iffI)
      apply (clarsimp simp: field_simps word_le_nat_alt)
      apply (rule_tac x="unat x" in exI)
-     apply (simp add: unat_sub_if_size range_cover.unat_of_nat_n[OF cover] not_le not_zero
+     apply (simp add: unat_sub_if_size range_cover.unat_of_nat_n[OF cover]
+                      not_le not_zero
                split: if_split_asm)
     apply (clarsimp simp: field_simps word_le_nat_alt)
     apply (rule_tac x="of_nat x" in exI)
@@ -1896,7 +1927,7 @@ proof -
   have al': "is_aligned ptr (obj_bits_api (APIType_map2 ty) us)"
      by (simp add: obj_bits_api ko)
   show ?thesis
-  apply (simp add: when_def retype_region_def createObjects'_def
+  apply (simp add: when_def retype_region2_def createObjects'_def
                    createObjects_def aligned obj_bits_api[symmetric]
                    ko[symmetric] al' shiftl_t2n data_map_insert_def[symmetric]
                    is_aligned_mask[symmetric] split_def unless_def
@@ -1904,91 +1935,80 @@ proof -
         split del: if_split)
   apply (subst retype_addrs_fold)+
   apply (subst if_P)
-    using ko
-    apply (clarsimp simp: makeObjectKO_def)
-   apply (simp add: bind_assoc)
-   apply (rule corres_guard_imp)
-     apply (rule_tac r'=pspace_relation in corres_underlying_split)
-        apply (clarsimp dest!: state_relation_pspace_relation)
-       apply (simp add: gets_def)
-       apply (rule corres_symb_exec_l[rotated])
-          apply (rule exs_valid_get)
-         apply (rule get_sp)
-        apply (simp add: get_def no_fail_def)
-       apply (rule corres_symb_exec_r)
-          apply (simp add: not_less modify_modify bind_assoc[symmetric]
-                           obj_bits_api[symmetric] shiftl_t2n upto_enum_red'
+   using ko
+   apply (clarsimp simp: makeObjectKO_def)
+  apply (simp add: bind_assoc retype_region2_ext_def)
+  apply (rule corres_guard_imp)
+    apply (subst modify_ekheap_update_ekheap)
+    apply (simp only: bind_assoc)
+    apply (rule kheap_ekheap_double_gets)
+    apply (rule corres_symb_exec_r)
+       apply (simp add: not_less modify_modify bind_assoc[symmetric]
+                          obj_bits_api[symmetric] shiftl_t2n upto_enum_red'
                            range_cover.unat_of_nat_n[OF cover])
-          apply (rule corres_guard_imp)
-            apply (rule corres_split_nor[OF _ corres_trivial])
-               apply (rename_tac ps ps' sa)
-               apply (rule_tac P="\<lambda>s. ps = kheap s \<and> sa = s \<and> ?P s" and
-                               P'="\<lambda>s. ps' = ksPSpace s \<and> ?P' s" in corres_modify)
-               apply(frule curdomain_relation[THEN sym])
-               apply (simp add: set_retype_addrs_fold new_caps_adds_fold)
-               apply (drule retype_state_relation[OF _ _ _ _ _ _ _ _ _ tysc cover _ _ orr],
-                      simp_all add: ko not_zero obj_bits_api
-                                    bound[simplified obj_bits_api ko])[1]
-                apply (erule pspace_relation_pspace_bounded')
-               apply (cases ty; simp; rename_tac tp; case_tac tp;
-                      clarsimp simp: default_object_def APIType_map2_def
-                              split: arch_kernel_object.splits apiobject_type.splits)
-              apply (clarsimp simp: retype_addrs_fold[symmetric] ptr_add_def upto_enum_red' not_zero'
-                                    range_cover.unat_of_nat_n[OF cover] word_le_sub1)
-              apply (rule_tac f=g in arg_cong)
-              apply clarsimp
-             apply wpsimp+
-           apply simp+
-         apply (clarsimp split: option.splits)
-         apply (intro conjI impI)
-          apply (clarsimp|wp)+
-        apply (clarsimp split: option.splits)
-        apply wpsimp
-       apply (clarsimp split: option.splits)
-       apply (intro conjI impI)
-        apply wp
-       apply (clarsimp simp:lookupAround2_char1)
-       apply wp
-       apply (clarsimp simp: obj_bits_api ko)
-       apply (drule(1) pspace_no_overlap_disjoint')
-       apply (rule_tac x1 = a in ccontr[OF in_empty_interE])
-         apply simp
-        apply (clarsimp simp: not_less shiftL_nat)
-        apply (erule order_trans)
-        apply (subst p_assoc_help)
-        apply (subst word_plus_and_or_coroll2[symmetric,where w = "mask sz"])
-        apply (subst add.commute)
-        apply (subst add.assoc)
-        apply (rule word_plus_mono_right)
-         using cover
-         apply -
-         apply (rule iffD2[OF word_le_nat_alt])
-         apply (subst word_of_nat_minus)
-          using not_zero
-          apply simp
-         apply (rule le_trans[OF unat_plus_gt])
-         apply simp
-         apply (subst unat_minus_one)
-          apply (subst mult.commute)
-          apply (rule word_power_nonzero_32)
-            apply (rule of_nat_less_pow_32[OF n_estimate])
-            apply (simp add:word_bits_def objBitsKO_gt_0 ko)
-           apply (simp add:range_cover_def obj_bits_api ko word_bits_def)
-          apply (cut_tac not_zero',clarsimp simp:ko)
-         apply(clarsimp simp:field_simps ko)
-         apply (subst unat_sub[OF word_1_le_power])
-          apply (simp add:range_cover_def)
-         apply (subst diff_add_assoc[symmetric])
-          apply (cut_tac unat_of_nat_n',simp add:ko)
-         apply (clarsimp simp: obj_bits_api ko)
-         apply (rule diff_le_mono)
-         apply (frule range_cover.range_cover_compare_bound)
-         apply (cut_tac obj_bits_api unat_of_nat_shift')
-         apply (clarsimp simp:add.commute range_cover_def ko)
-        apply (rule is_aligned_no_wrap'[OF is_aligned_neg_mask,OF le_refl ])
-        apply (simp add:range_cover_def domI)+
-      apply wpsimp+
-   done
+       apply (rule corres_split_nor[OF _ corres_trivial])
+          apply (rename_tac x eps ps)
+          apply (rule_tac P="\<lambda>s. x = kheap s \<and> eps = ekheap (s) \<and> ?P s" and
+                          P'="\<lambda>s. ps = ksPSpace s \<and> ?P' s" in corres_modify)
+          apply (simp add: set_retype_addrs_fold new_caps_adds_fold)
+          apply (erule retype_state_relation[OF _ _ _ _ _ _ _ _ _ cover _ _ orr],
+                 simp_all add: ko not_zero obj_bits_api
+                               bound[simplified obj_bits_api ko])[1]
+         apply (clarsimp simp: retype_addrs_fold[symmetric] ptr_add_def upto_enum_red' not_zero'
+                               range_cover.unat_of_nat_n[OF cover] word_le_sub1
+                         simp del: word_of_nat_eq_0_iff)
+         apply (rule_tac f=g in arg_cong)
+         apply clarsimp
+        apply wp+
+      apply (clarsimp split: option.splits)
+      apply (intro conjI impI)
+       apply (clarsimp|wp)+
+     apply (clarsimp split: option.splits)
+     apply wpsimp
+    apply (clarsimp split: option.splits)
+    apply (intro conjI impI)
+     apply wp
+    apply (clarsimp simp:lookupAround2_char1)
+    apply wp
+    apply (clarsimp simp: obj_bits_api ko)
+    apply (drule(1) pspace_no_overlap_disjoint')
+    apply (rule_tac x1 = a in ccontr[OF in_empty_interE])
+      apply simp
+     apply (clarsimp simp: not_less shiftL_nat)
+     apply (erule order_trans)
+     apply (subst p_assoc_help)
+     apply (subst word_plus_and_or_coroll2[symmetric,where w = "mask sz"])
+     apply (subst add.commute)
+     apply (subst add.assoc)
+     apply (rule word_plus_mono_right)
+      using cover
+      apply -
+      apply (rule iffD2[OF word_le_nat_alt])
+      apply (subst word_of_nat_minus)
+       using not_zero
+       apply simp
+      apply (rule le_trans[OF unat_plus_gt])
+      apply simp
+      apply (subst unat_minus_one)
+       apply (subst mult.commute)
+       apply (rule word_power_nonzero_32)
+         apply (rule of_nat_less_pow_32[OF n_estimate])
+         apply (simp add:word_bits_def objBitsKO_gt_0 ko)
+        apply (simp add:range_cover_def obj_bits_api ko word_bits_def)
+       apply (cut_tac not_zero',clarsimp simp:ko)
+      apply(clarsimp simp:field_simps ko)
+      apply (subst unat_sub[OF word_1_le_power])
+       apply (simp add:range_cover_def)
+      apply (subst diff_add_assoc[symmetric])
+       apply (cut_tac unat_of_nat_n',simp add:ko)
+      apply (clarsimp simp: obj_bits_api ko)
+      apply (rule diff_le_mono)
+      apply (frule range_cover.range_cover_compare_bound)
+      apply (cut_tac obj_bits_api unat_of_nat_shift')
+      apply (clarsimp simp:add.commute range_cover_def ko)
+     apply (rule is_aligned_no_wrap'[OF is_aligned_neg_mask,OF le_refl ])
+     apply (simp add:range_cover_def domI)+
+  done
 qed
 
 lemma createObjects_corres':
@@ -1996,13 +2016,13 @@ lemma createObjects_corres':
    \<Longrightarrow> corres dc P P' f (createObjects' a b ko d)"
   apply (clarsimp simp:corres_underlying_def createObjects_def return_def)
   apply (rule conjI)
-   apply (clarsimp simp:bind_def split_def)
-   apply (drule(1) bspec)
-   apply (clarsimp simp:image_def)
-   apply (drule(1) bspec)
-   apply clarsimp
-   apply (erule bexI[rotated])
-   apply simp
+  apply (clarsimp simp:bind_def split_def)
+    apply (drule(1) bspec)
+    apply (clarsimp simp:image_def)
+    apply (drule(1) bspec)
+    apply clarsimp
+    apply (erule bexI[rotated])
+    apply simp
   apply (clarsimp simp:bind_def split_def image_def)
   apply (drule(1) bspec|clarsimp)+
   done
@@ -2012,7 +2032,6 @@ lemmas retype_aligned_distinct'' = retype_aligned_distinct'
 
 lemma retype_ko_wp_at':
   assumes vs: "pspace_aligned' s" "pspace_distinct' s"
-     and  bd:  "pspace_bounded' s"
      and  pn: "pspace_no_overlap' ptr sz s"
    and cover: "range_cover ptr sz (objBitsKO obj) n"
   shows
@@ -2022,16 +2041,14 @@ lemma retype_ko_wp_at':
                          else ko_wp_at' P p s)"
   apply (subst foldr_upd_app_if[folded data_map_insert_def])
   apply (rule foldr_update_ko_wp_at' [OF vs])
-    apply (simp add: retype_aligned_distinct'' [OF vs bd pn cover])+
-   apply (rule new_cap_addrs_aligned)
+    apply (simp add: retype_aligned_distinct'' [OF vs pn cover])+
+  apply (rule new_cap_addrs_aligned)
   using cover
-   apply (simp add:range_cover_def cover)
-  using cover
-  apply (simp add:range_cover_def word_bits_def)
+  apply (simp add:range_cover_def cover)
   done
 
 lemma retype_obj_at':
-  assumes vs: "pspace_aligned' s" "pspace_distinct' s" "pspace_bounded' s"
+  assumes vs: "pspace_aligned' s" "pspace_distinct' s"
      and  pn: "pspace_no_overlap' ptr sz s"
      and cover: "range_cover ptr sz (objBitsKO obj) n"
   shows
@@ -2040,10 +2057,11 @@ lemma retype_obj_at':
      = (if p \<in> set (new_cap_addrs n ptr obj) then (\<exists>ko. projectKO_opt obj = Some ko \<and> P ko)
                          else obj_at' P p s)"
   unfolding obj_at'_real_def
-  by (rule retype_ko_wp_at'[OF vs pn cover])
+  apply (rule retype_ko_wp_at'[OF vs pn cover])
+done
 
 lemma retype_obj_at_disj':
-  assumes vs: "pspace_aligned' s" "pspace_distinct' s" "pspace_bounded' s"
+  assumes vs: "pspace_aligned' s" "pspace_distinct' s"
      and  pn: "pspace_no_overlap' ptr sz s"
      and cover: "range_cover ptr sz (objBitsKO obj) n"
   shows
@@ -2060,14 +2078,14 @@ lemma retype_obj_at_disj':
     apply (simp add:ptr_add_def p_assoc_help domI)+
   done
 
-declare word_unat_power[symmetric,simp] (* FIXME: remove *)
+declare word_unat_power[symmetric,simp]
 
 lemma createObjects_ko_at_strg:
   fixes ptr :: word32
   assumes    cover: "range_cover ptr sz ((objBitsKO ko) + gbits) n"
   assumes    not_0: "n\<noteq> 0"
   assumes       pi: "projectKO_opt ko  = Some val"
-  shows "\<lbrace>\<lambda>s. pspace_no_overlap' ptr sz s \<and> pspace_aligned' s \<and> pspace_distinct' s \<and> pspace_bounded' s\<rbrace>
+  shows "\<lbrace>\<lambda>s. pspace_no_overlap' ptr sz s \<and> pspace_aligned' s \<and> pspace_distinct' s\<rbrace>
              createObjects ptr n ko gbits
          \<lbrace>\<lambda>r s. \<forall>x \<in> set r. \<forall>offs < 2 ^ gbits. ko_at' val (x + (offs << objBitsKO ko)) s\<rbrace>"
 proof -
@@ -2081,96 +2099,101 @@ proof -
   have in_new:"\<And>idx offs. \<lbrakk>idx \<le> of_nat n - 1;offs<2 ^ gbits\<rbrakk>
     \<Longrightarrow> ptr + (idx << objBitsKO ko + gbits) + (offs << objBitsKO ko)
         \<in> set (new_cap_addrs (n * 2 ^ gbits) ptr ko)"
-    apply (insert range_cover_not_zero[OF not_0 cover] not_0)
-    apply (clarsimp simp:new_cap_addrs_def image_def)
-    apply (rule_tac x ="unat (2 ^ gbits * idx + offs)" in bexI)
-     apply (subst add.commute)
-     apply (simp add:shiftl_shiftl[symmetric])
-     apply (simp add:shiftl_t2n distrib_left[symmetric])
-    apply simp
-    apply (rule unat_less_helper)
-    apply (rule less_le_trans)
-     apply (erule word_plus_strict_mono_right)
-     apply (subst distrib_left[where c = "1 :: 32 word",symmetric,simplified])
-     apply (subst mult.commute[where a = "2^gbits"])+
-     apply (insert cover)
-     apply (rule word_mult_le_iff[THEN iffD2])
-        apply (simp add:p2_gt_0)
-        apply (clarsimp simp:range_cover_def word_bits_def)
-       apply (drule range_cover_rel[where sbit' = "objBitsKO ko "])
+      apply (insert range_cover_not_zero[OF not_0 cover] not_0)
+      apply (clarsimp simp:new_cap_addrs_def image_def)
+      apply (rule_tac x ="unat (2 ^ gbits * idx + offs)" in bexI)
+        apply (subst add.commute)
+        apply (simp add:shiftl_shiftl[symmetric])
+        apply (simp add:shiftl_t2n distrib_left[symmetric])
+      apply simp
+      apply (rule unat_less_helper)
+      apply (rule less_le_trans)
+       apply (erule word_plus_strict_mono_right)
+       apply (subst distrib_left[where c = "1 :: 32 word",symmetric,simplified])
+       apply (subst mult.commute[where a = "2^gbits"])+
+       apply (insert cover)
+       apply (rule word_mult_le_iff[THEN iffD2])
+         apply (simp add:p2_gt_0)
+         apply (clarsimp simp:range_cover_def word_bits_def)
+         apply (drule range_cover_rel[where sbit' = "objBitsKO ko "])
+           apply simp
+          apply simp
+         apply (rule less_le_trans)
+          apply (rule range_cover.range_cover_le_n_less)
+           apply simp
+          apply (subst unat_power_lower)
+           using cover
+           apply (clarsimp simp:range_cover_def)
+          apply (simp add:field_simps)
+          apply (rule unat_le_helper)
+          apply (erule order_trans[OF _ word_sub_1_le])
+          apply (simp add:range_cover_not_zero[OF not_0 cover])
+         apply (simp add:word_bits_def)
+        apply (drule range_cover_rel[where sbit' = "objBitsKO ko "])
+          apply simp
          apply simp
-        apply simp
-       apply (rule less_le_trans)
-        apply (rule range_cover.range_cover_le_n_less)
-         apply simp
+        apply (erule less_le_trans[OF range_cover.range_cover_le_n_less(1)])
         apply (subst unat_power_lower)
          using cover
          apply (clarsimp simp:range_cover_def)
         apply (simp add:field_simps)
-        apply (rule unat_le_helper)
-        apply (erule order_trans[OF _ word_sub_1_le])
-        apply (simp add:range_cover_not_zero[OF not_0 cover])
+        apply (rule unat_le_helper[OF inc_le])
+        apply (simp add:word_leq_minus_one_le)
        apply (simp add:word_bits_def)
-      apply (drule range_cover_rel[where sbit' = "objBitsKO ko "])
-        apply simp
-       apply simp
-      apply (erule less_le_trans[OF range_cover.range_cover_le_n_less(1)])
-       apply (subst unat_power_lower)
-        using cover
-        apply (clarsimp simp:range_cover_def)
-       apply (simp add:field_simps)
-       apply (rule unat_le_helper[OF inc_le])
-       apply (simp add:word_leq_minus_one_le)
-      apply (simp add:word_bits_def)
-     apply (rule no_plus_overflow_neg)
-     apply (rule less_le_trans[where y = "of_nat n"])
-      apply unat_arith
-     using range_cover.range_cover_n_less[OF cover]
+      apply (rule no_plus_overflow_neg)
+      apply (rule less_le_trans[where y = "of_nat n"])
+       apply unat_arith
+      using range_cover.range_cover_n_less[OF cover]
      apply (simp add:word_bits_def)
     apply (subst distrib_left[where c = "1 :: 32 word",symmetric,simplified])
-    apply (subst mult.commute)
-    apply simp
-    apply (rule word_mult_le_iff[THEN iffD2])
+   apply (subst mult.commute)
+   apply simp
+   apply (rule word_mult_le_iff[THEN iffD2])
        apply (simp add:p2_gt_0)
-       apply (simp add:range_cover_def word_bits_def)
-      apply (drule range_cover_rel[where sbit' = "objBitsKO ko "])
-        apply simp
-       apply simp
-      apply (rule less_le_trans)
-       apply (rule range_cover.range_cover_le_n_less)
-        apply simp
-       apply (subst unat_power_lower)
-        using cover
-        apply (clarsimp simp:range_cover_def)
-       apply (simp add:field_simps)
-       apply (rule unat_le_helper)
-       apply unat_arith
-      apply (simp add:word_bits_def)
+      apply (simp add:range_cover_def word_bits_def)
      apply (drule range_cover_rel[where sbit' = "objBitsKO ko "])
        apply simp
       apply simp
      apply (rule less_le_trans)
-      apply (erule range_cover.range_cover_le_n_less)
-      apply (simp add:range_cover.unat_of_nat_n[OF cover])
-      apply (simp add: unat_le_helper)
-     apply (simp add:word_bits_def)
+     apply (rule range_cover.range_cover_le_n_less)
+       apply simp
+     apply (subst unat_power_lower)
+       using cover
+       apply (clarsimp simp:range_cover_def)
+      apply (simp add:field_simps)
+     apply (rule unat_le_helper)
     apply unat_arith
-    done
+   apply (simp add:word_bits_def)
+   apply (drule range_cover_rel[where sbit' = "objBitsKO ko "])
+       apply simp
+      apply simp
+     apply (rule less_le_trans)
+      apply (erule range_cover.range_cover_le_n_less)
+     apply (simp add:range_cover.unat_of_nat_n[OF cover])
+    apply (simp add: unat_le_helper)
+   apply (simp add:word_bits_def)
+  apply unat_arith
+  done
   show ?thesis
-    apply (simp add: split_def createObjects_def lookupAround2_pspace_no
-                     alignError_def unless_def createObjects'_def)
-    apply (wp|simp add:data_map_insert_def[symmetric]
-                   cong: if_cong del: fun_upd_apply data_map_insert_def)+
-       apply (wpc|wp|clarsimp simp del:fun_upd_apply)+
-    apply (subst new_cap_addrs_fold'[OF shiftr_not_zero])+
-    apply (subst data_map_insert_def[symmetric])+
-    apply (subst retype_obj_at_disj'; simp add:valid_pspace'_def unat_of_nat_shiftl)+
-     apply (rule range_cover_rel[OF cover]; simp)
-    apply (subst retype_obj_at_disj'; simp add:valid_pspace'_def unat_of_nat_shiftl)
-     apply (rule range_cover_rel[OF cover]; simp)
-    using range_cover.unat_of_nat_n_shift[OF cover,where gbits = gbits,simplified] pi
-    apply (simp add: in_new)
-    done
+  apply (simp add: split_def createObjects_def lookupAround2_pspace_no
+                   alignError_def unless_def createObjects'_def)
+  apply (rule hoare_pre)
+   apply (wp|simp add:data_map_insert_def[symmetric]
+     cong: if_cong del: fun_upd_apply data_map_insert_def)+
+   apply (wpc|wp|clarsimp simp del:fun_upd_apply)+
+   apply (subst new_cap_addrs_fold'[OF shiftr_not_zero])+
+   apply (subst data_map_insert_def[symmetric])+
+   apply (subst retype_obj_at_disj')
+     apply (simp add:valid_pspace'_def unat_of_nat_shiftl)+
+     apply (rule range_cover_rel[OF cover])
+     apply simp+
+   apply (subst retype_obj_at_disj')
+     apply (simp add:valid_pspace'_def unat_of_nat_shiftl)+
+     apply (rule range_cover_rel[OF cover])
+     apply simp+
+  using range_cover.unat_of_nat_n_shift[OF cover,where gbits = gbits,simplified] pi
+  apply (simp add: in_new)
+  done
 qed
 
 lemma createObjects_ko_at:
@@ -2200,6 +2223,9 @@ lemma createObjects_obj_at:
   apply (clarsimp elim!: obj_at'_weakenE)
   done
 
+(* until we figure out what we really need of page
+   mappings it's just alignment, which, fortunately,
+   is trivial *)
 lemma createObjects_aligned:
   assumes al: "is_aligned ptr (objBitsKO ko + gbits)"
   and bound :"n < 2 ^ word_bits" "n\<noteq>0"
@@ -2210,7 +2236,7 @@ lemma createObjects_aligned:
    apply (rule createObjects_ret[OF bound])
   apply (clarsimp dest!: less_two_pow_divD)
   apply (rule is_aligned_ptr_add_helper[OF al])
-     apply (simp_all add:bound')
+  apply (simp_all add:bound')
   done
 
 lemma createObjects_aligned2:
@@ -2256,27 +2282,6 @@ lemma createObjects_nonzero:
 lemma objBits_if_dev:
     "objBitsKO (if dev then KOUserDataDevice else KOUserData) = pageBits"
   by (simp add: objBitsKO_def)
-
-lemma createObjects_sc_at'_n:
-  fixes ptr :: word32 and val :: sched_context
-  assumes  cover:"range_cover ptr sz ((objBitsKO ko) + gbits) n"
-  and      not_0:"n \<noteq> 0"
-  and       pi: "\<exists>(val::sched_context). projectKO_opt ko = Some val"
-  shows
-  "\<lbrace>\<lambda>s. pspace_no_overlap' ptr sz s \<and> valid_pspace' s\<rbrace>
-   createObjects ptr n ko gbits
-   \<lbrace>\<lambda>r s. \<forall>x \<in> set r. \<forall>offs < 2 ^ gbits.
-                         sc_at'_n (objBitsKO ko) (x + (offs << objBitsKO ko)) s\<rbrace>"
-  apply (rule exE[OF pi])
-  apply (prop_tac "objBitsKO ko = objBits x")
-   apply (clarsimp simp: projectKOs objBits_def)
-  apply (erule_tac val1 = x in
-            hoare_post_imp [OF _ createObjects_ko_at [OF cover not_0 ],rotated])
-  apply (intro allI ballI impI)
-  apply (drule(1) bspec)
-  apply (drule spec, drule(1) mp)
-  apply (clarsimp simp: ko_wp_at'_def obj_at'_def projectKOs objBits_def)
-  done
 
 lemma cwo_ret:
   assumes  cover:"range_cover ptr sz v n"
@@ -2328,7 +2333,6 @@ show ?thesis
       projectKO_opts_defs split: kernel_object.splits)
   done
 qed
-
 lemmas capFreeIndex_update_valid_untyped' =
   capFreeIndex_update_valid_cap'[unfolded valid_cap'_def,simplified,THEN conjunct2,THEN conjunct1]
 
@@ -2338,14 +2342,14 @@ lemma createNewCaps_valid_cap:
   assumes not_0: "n \<noteq> 0"
   assumes ct: "ty = APIObjectType ArchTypes_H.CapTableObject \<Longrightarrow> 0 < us"
               "ty = APIObjectType apiobject_type.Untyped \<Longrightarrow> minUntypedSizeBits \<le> us \<and> us \<le> maxUntypedSizeBits"
-              "ty = APIObjectType ArchTypes_H.SchedContextObject \<Longrightarrow> sc_size_bounds us"
   assumes ptr: " ptr \<noteq> 0"
   shows "\<lbrace>\<lambda>s. pspace_no_overlap' ptr sz s \<and> valid_pspace' s\<rbrace>
            createNewCaps ty ptr n us dev
          \<lbrace>\<lambda>r s. (\<forall>cap \<in> set r. s \<turnstile>' cap)\<rbrace>"
 proof -
-  note [simp del] = untyped_range.simps usable_untyped_range.simps atLeastAtMost_simps
-  note [split del] = if_split
+  note blah[simp del] = untyped_range.simps usable_untyped_range.simps atLeastAtMost_iff atLeastatMost_subset_iff atLeastLessThan_iff
+          Int_atLeastAtMost atLeastatMost_empty_iff split_paired_Ex
+  note if_split_def[split del] = if_splits
 
   show ?thesis
   proof(cases "Types_H.toAPIType ty")
@@ -2471,17 +2475,16 @@ proof -
         apply (simp_all add: ARM_H.toAPIType_def
                              fromIntegral_def toInteger_nat fromInteger_nat APIType_capBits_def curDomain_def
                       split: ARM_H.object_type.splits)
-        apply wp
-         apply (rule hoare_post_imp)
-          prefer 2
-          apply (rule createObjects_obj_at [where 'a = "tcb" and sz=sz,OF _ not_0])
-        using cover
-           apply (clarsimp simp: ARM_H.toAPIType_def APIType_capBits_def objBits_simps
-                          split: ARM_H.object_type.splits)
-          apply (simp add: projectKOs)
-         apply (clarsimp simp: valid_cap'_def objBits_simps)
-         apply (fastforce intro: capAligned_tcbI)
-        apply wp
+        apply (wp mapM_x_wp' hoare_vcg_const_Ball_lift)+
+        apply (rule hoare_post_imp)
+         prefer 2
+         apply (rule createObjects_obj_at [where 'a = "tcb",OF _ not_0])
+          using cover
+          apply (clarsimp simp: ARM_H.toAPIType_def APIType_capBits_def objBits_simps
+                         split: ARM_H.object_type.splits)
+         apply (simp add: projectKOs)
+        apply (clarsimp simp: valid_cap'_def objBits_simps)
+        apply (fastforce intro: capAligned_tcbI)
         done
     next
       case EndpointObject with Some cover ct show ?thesis
@@ -2554,56 +2557,15 @@ proof -
          apply (clarsimp simp add: shiftl_t2n)
         apply simp
         done
-    next
-      case ReplyObject with Some cover ct show ?thesis
-        including no_pre
-        apply (clarsimp simp: Arch_createNewCaps_def createNewCaps_def)
-        apply (simp_all add: ARM_H.toAPIType_def
-                             fromIntegral_def toInteger_nat fromInteger_nat APIType_capBits_def
-                      split: ARM_H.object_type.splits)
-        apply wp
-        apply (rule hoare_post_imp)
-         prefer 2
-         apply (rule createObjects_obj_at [where 'a=reply, OF _ not_0])
-        using cover
-          apply (clarsimp simp: ARM_H.toAPIType_def objBits_simps
-                         split: ARM_H.object_type.splits)
-         apply (simp add: projectKOs)
-        apply (simp add: valid_cap'_def)
-        apply (clarsimp simp: valid_cap'_def objBits_simps)
-        apply (fastforce intro: capAligned_replyI)
-        done
-    next
-      case SchedContextObject with Some cover ct show ?thesis
-        including no_pre
-        apply (clarsimp simp: Arch_createNewCaps_def createNewCaps_def)
-        apply (simp_all add: ARM_H.toAPIType_def
-                             fromIntegral_def toInteger_nat fromInteger_nat APIType_capBits_def
-                      split: ARM_H.object_type.splits)
-        apply wp
-        apply (rule hoare_post_imp)
-         prefer 2
-         apply (rule createObjects_sc_at'_n [OF _ not_0])
-        using cover ct(3)
-          apply (clarsimp simp: ARM_H.toAPIType_def objBits_simps APIType_capBits_def scBits_simps
-                         split: ARM_H.object_type.splits
-                         dest!: ct(3))
-         apply (simp add: projectKOs)
-        apply (clarsimp, drule bspec, simp)
-        apply (prop_tac "sc_at'_n us cap s")
-         apply (clarsimp simp: objBitsKO_def scBits_simps)
-        apply (clarsimp simp: valid_cap'_def capAligned_sched_contextI sc_size_bounds_def)
-        done
     qed
   qed
 qed
 
 lemma other_objs_default_relation:
   "\<lbrakk> case ty of Structures_A.EndpointObject \<Rightarrow> ko = injectKO (makeObject :: endpoint)
-             | Structures_A.NotificationObject \<Rightarrow> ko = injectKO (makeObject :: notification)
-             | Structures_A.TCBObject \<Rightarrow> ko = injectKO (tcbDomain_update (\<lambda>_. d) makeObject)
-                          | _ \<Rightarrow> False \<rbrakk> \<Longrightarrow>
-    obj_relation_retype (default_object ty dev n d) ko"
+             | Structures_A.NotificationObject \<Rightarrow> ko = injectKO (makeObject :: Structures_H.notification)
+             | _ \<Rightarrow> False \<rbrakk> \<Longrightarrow>
+    obj_relation_retype (default_object ty dev n) ko"
   apply (rule obj_relation_retype_other_obj)
    apply (clarsimp simp: default_object_def
                          is_other_obj_relation_type_def
@@ -2615,7 +2577,7 @@ lemma other_objs_default_relation:
                         default_ep_def makeObject_endpoint default_notification_def
                         makeObject_notification default_ntfn_def
                         fault_rel_optionation_def
-                        initContext_def default_priority_def
+                        initContext_def
                         arch_tcb_context_get_def atcbContextGet_def
                         default_arch_tcb_def newArchTCB_def
                         arch_tcb_relation_def
@@ -2631,7 +2593,7 @@ lemma tcb_relation_retype:
 
 lemma captable_relation_retype:
   "n < word_bits \<Longrightarrow>
-   obj_relation_retype (default_object Structures_A.CapTableObject dev n d) (KOCTE makeObject)"
+   obj_relation_retype (default_object Structures_A.CapTableObject dev n) (KOCTE makeObject)"
   apply (clarsimp simp: obj_relation_retype_def default_object_def
                         wf_empty_bits objBits_simps'
                         dom_empty_cnode ex_with_length cte_level_bits_def)
@@ -2648,26 +2610,8 @@ lemma captable_relation_retype:
   apply (simp add: less_mask_eq)
   done
 
-lemma reply_relation_retype:
-  "obj_relation_retype (default_object Structures_A.ReplyObject dev n d)
-                                 (KOReply makeObject)"
-  by (simp add: default_object_def reply_relation_def default_reply_def
-                makeObject_reply obj_relation_retype_def
-                objBits_simps word_bits_def replySizeBits_def)
-
-lemma sc_relation_retype:
-  "\<lbrakk>sc_size_bounds n\<rbrakk> \<Longrightarrow>
-   obj_relation_retype (default_object Structures_A.SchedContextObject dev n d)
-                       (KOSchedContext ((makeObject :: sched_context)
-                                           \<lparr>scRefills := replicate (refillAbsoluteMax' n) emptyRefill,
-                                            scSize := n - minSchedContextBits\<rparr>))"
-  by (clarsimp simp: default_object_def sc_relation_def default_sched_context_def
-                     makeObject_sc obj_relation_retype_def valid_sched_context_size_def
-                     objBits_simps word_bits_def scBits_simps refills_map_def refill_map_def
-                     emptyRefill_def)
-
 lemma pagetable_relation_retype:
-  "obj_relation_retype (default_object (ArchObject PageTableObj) dev n d)
+  "obj_relation_retype (default_object (ArchObject PageTableObj) dev n)
                        (KOArch (KOPTE makeObject))"
   apply (simp add: default_object_def default_arch_object_def
                    makeObject_pte obj_relation_retype_def
@@ -2681,7 +2625,7 @@ lemma pagetable_relation_retype:
   done
 
 lemma pagedirectory_relation_retype:
-  "obj_relation_retype (default_object (ArchObject PageDirectoryObj) dev n d)
+  "obj_relation_retype (default_object (ArchObject PageDirectoryObj) dev n)
                        (KOArch (KOPDE makeObject))"
   apply (simp add: default_object_def default_arch_object_def
                    makeObject_pde obj_relation_retype_def
@@ -2702,27 +2646,26 @@ lemma corres_retype:
   and         aligned: "is_aligned ptr (objBitsKO ko + gbits)"
   and    obj_bits_api: "obj_bits_api (APIType_map2 ty) us = objBitsKO ko + gbits"
   and              tp: "APIType_map2 ty \<in> no_gs_types"
-  and              ko: "makeObjectKO dev us d ty = Some ko"
-  and            tysc: "ty = Inr (APIObjectType SchedContextObject) \<longrightarrow> min_sched_context_bits \<le> us"
+  and              ko: "makeObjectKO dev ty = Some ko"
   and             orr: "obj_bits_api (APIType_map2 ty) us \<le> sz \<Longrightarrow>
-                        obj_relation_retype (default_object (APIType_map2 ty) dev us d) ko"
+                        obj_relation_retype (default_object (APIType_map2 ty) dev us) ko"
   and           cover: "range_cover ptr sz (obj_bits_api (APIType_map2 ty) us) n"
   shows "corres (=)
   (\<lambda>s. valid_pspace s \<and> pspace_no_overlap_range_cover ptr sz s
-     \<and> valid_mdb s \<and> valid_list s)
+     \<and> valid_mdb s \<and> valid_etcbs s \<and> valid_list s)
   (\<lambda>s. pspace_aligned' s \<and> pspace_distinct' s \<and> pspace_no_overlap' ptr sz s
-       \<and> (\<exists>val. ko = injectKO val)
-       \<and> (ty = Inr (APIObjectType TCBObject) \<longrightarrow> d = ksCurDomain s))
-  (retype_region ptr n us (APIType_map2 ty) dev) (createObjects ptr n ko gbits)"
+       \<and> (\<exists>val. ko = injectKO val))
+  (retype_region2 ptr n us (APIType_map2 ty) dev) (createObjects ptr n ko gbits)"
   apply (rule corres_guard_imp)
     apply (rule_tac F = "(\<exists>val. ko = injectKO val)" in corres_gen_asm2)
     apply (erule exE)
     apply (rule corres_rel_imp)
-    apply (rule corres_retype'[where g=id and ty=ty and sz = sz,OF not_zero aligned _ _ ko
+    apply (rule corres_retype'[where g=id and ty=ty and sz = sz,OF not_zero aligned _ _ _ ko
            ,simplified update_gs_id[OF tp] modify_id_return,simplified])
-           using assms
-           apply (simp_all add: objBits_def no_gs_types_def)
-   by auto
+        using assms
+        apply (simp_all add: objBits_def no_gs_types_def)
+  apply auto
+  done
 
 lemma init_arch_objects_APIType_map2:
   "init_arch_objects (APIType_map2 (Inr ty)) dev ptr bits sz refs =
@@ -2744,7 +2687,7 @@ lemma pde_relation_aligned_eq:
   done
 
 lemma copyGlobalMappings_corres:
-  "corres dc (valid_arch_state and pspace_aligned and page_directory_at pd)
+  "corres dc (valid_arch_state and valid_etcbs and pspace_aligned and page_directory_at pd)
              (valid_arch_state' and page_directory_at' pd)
           (copy_global_mappings pd)
           (copyGlobalMappings pd)"
@@ -2759,7 +2702,8 @@ lemma copyGlobalMappings_corres:
       apply (simp add: liftM_def[symmetric])
       apply (rule_tac S="(=)" and r'=dc
                   and Q="\<lambda>xs s. \<forall>x \<in> set xs. pde_at (global_pd + (x << 2)) s
-                                             \<and> pde_at (pd + (x << 2)) s \<and> pspace_aligned s"
+                                             \<and> pde_at (pd + (x << 2)) s \<and> pspace_aligned s \<and>
+                                             valid_etcbs s"
                   and Q'="\<lambda>xs s. \<forall>x \<in> set xs. pde_at' (global_pd + (x << 2)) s
                                              \<and> pde_at' (pd + (x << 2)) s"
                          in corres_mapM_list_all2, (simp add: pdeBits_def)+)
@@ -2770,7 +2714,7 @@ lemma copyGlobalMappings_corres:
              apply (drule(1) pde_relation_aligned_eq)
              apply fastforce
             apply (wp hoare_vcg_const_Ball_lift | simp)+
-      apply (simp add: kernel_base_def pptrBase_def list_all2_refl pageBits_def)
+      apply (simp add: kernel_base_def ARM.pptrBase_def pptrBase_def list_all2_refl pageBits_def)
      apply wp+
    apply (clarsimp simp: valid_arch_state_def)
    apply (auto elim: page_directory_pde_atI is_aligned_weaken[OF pd_aligned])[1]
@@ -2818,7 +2762,8 @@ lemma nullPointer_0_simp[simp]:
 
 lemma descendants_of_retype':
   assumes P: "\<And>p. P p \<Longrightarrow> m p = None"
-  shows "descendants_of' p (\<lambda>p. if P p then Some makeObject else m p) = descendants_of' p m"
+  shows "descendants_of' p (\<lambda>p. if P p then Some makeObject else m p) =
+         descendants_of' p m"
   apply (rule set_eqI)
   apply (simp add: descendants_of'_def)
   apply (rule iffI)
@@ -3078,12 +3023,21 @@ lemma dist_z_n: "distinct_zombies n"
   apply (clarsimp simp: isCap_simps)
   done
 
+lemma reply_masters_rvk_fb_m: "reply_masters_rvk_fb m"
+  using valid by auto
+
+lemma reply_masters_rvk_fb_n: "reply_masters_rvk_fb n"
+  using reply_masters_rvk_fb_m
+  by (simp add: n_def reply_masters_rvk_fb_def
+                ball_ran_eq makeObject_cte isCap_simps)
+
 lemma valid_n:
   "valid_mdb_ctes n"
   by (simp add: valid_mdb_ctes_def dlist_n no_0_n mdb_chain_0_n
                 valid_badges_n caps_contained_n untyped_mdb_n
                 untyped_inc_n mdb_chunked_n valid_nullcaps_n ut_rev_n
-                class_links_n irq_control_n dist_z_n)
+                class_links_n irq_control_n dist_z_n
+                reply_masters_rvk_fb_n)
 
 end
 
@@ -3119,20 +3073,18 @@ proof -
       using not_0 n_less
       apply simp
       done
-    have bd[simp]: "objBitsKO val < word_bits"
-      using assms by (clarsimp simp: range_cover_def word_bits_def)
     have "ptr' + 2 ^ objBitsKO val - 1 \<le> ptr + of_nat n * 2 ^ objBitsKO val - 1"
       using cover
       apply (subst decomp)
       apply (simp add:add.assoc[symmetric])
       apply (simp add:p_assoc_help)
       apply (rule order_trans[OF word_plus_mono_left word_plus_mono_right])
-       using mem_p not_0
+         using mem_p not_0
          apply (clarsimp simp:new_cap_addrs_def shiftl_t2n)
          apply (rule word_plus_mono_right)
           apply (subst mult.commute)
           apply (rule word_mult_le_mono1[OF word_of_nat_le])
-          using n_less not_0
+            using n_less not_0
             apply (simp add:unat_of_nat_minus_1)
            apply (rule p2_gt_0[THEN iffD2])
            apply (simp add:word_bits_def range_cover_def)
@@ -3140,17 +3092,17 @@ proof -
           apply (clarsimp simp: unat_of_nat_minus_1[OF n_less(1) not_0])
           apply (rule nat_less_power_trans2
             [OF range_cover.range_cover_le_n_less(2),OF cover, folded word_bits_def])
-          apply (simp add:unat_of_nat_m1 less_imp_le)
-         apply (simp add:range_cover_def word_bits_def)
-        apply (rule machine_word_plus_mono_right_split[where sz = sz])
+           apply (simp add:unat_of_nat_m1 less_imp_le)
+          apply (simp add:range_cover_def word_bits_def)
+         apply (rule machine_word_plus_mono_right_split[where sz = sz])
           using range_cover.range_cover_compare[OF cover,where p = "unat (of_nat n - (1::machine_word))"]
-        apply (clarsimp simp:unat_of_nat_m1)
-       apply (simp add:range_cover_def word_bits_def)
-      apply (rule olen_add_eqv[THEN iffD2])
-      apply (subst add.commute[where a = "2^objBitsKO val - 1"])
-     apply (subst p_assoc_help[symmetric])
-     apply (rule is_aligned_no_overflow)
-     apply (clarsimp simp:range_cover_def word_bits_def)
+          apply (clarsimp simp:unat_of_nat_m1)
+         apply (simp add:range_cover_def word_bits_def)
+        apply (rule olen_add_eqv[THEN iffD2])
+        apply (subst add.commute[where a = "2^objBitsKO val - 1"])
+        apply (subst p_assoc_help[symmetric])
+        apply (rule is_aligned_no_overflow)
+        apply (clarsimp simp:range_cover_def word_bits_def)
         apply (erule aligned_add_aligned[OF _  is_aligned_mult_triv2]; simp)
        apply simp
       by (meson assms(1) is_aligned_add is_aligned_mult_triv2 is_aligned_no_overflow' range_cover_def)
@@ -3161,7 +3113,7 @@ proof -
     apply (frule(1) obj_range'_subset)
     apply (simp add: obj_range'_def)
     apply (cases "n = 0"; clarsimp simp:new_cap_addrs_def)
-   done
+    done
 qed
 
 lemma caps_no_overlapD'':
@@ -3169,7 +3121,8 @@ lemma caps_no_overlapD'':
    \<Longrightarrow> untypedRange c \<inter> {ptr .. (ptr && ~~ mask sz) + 2 ^ sz - 1} \<noteq> {} \<longrightarrow>
        {ptr .. (ptr && ~~ mask sz) + 2 ^ sz - 1} \<subseteq> untypedRange c"
   apply (clarsimp simp: cte_wp_at_ctes_of isCap_simps caps_no_overlap''_def
-              simp del: atLeastAtMost_simps)
+        simp del:atLeastAtMost_iff atLeastatMost_subset_iff atLeastLessThan_iff
+        Int_atLeastAtMost atLeastatMost_empty_iff)
   apply (drule_tac x = cte in bspec)
     apply fastforce
   apply (erule(1) impE)
@@ -3183,61 +3136,57 @@ lemma valid_untyped'_helper:
   and  cover  : "range_cover ptr sz (objBitsKO val) n"
   and  range  : "caps_no_overlap'' ptr sz s"
   and  pres   : "isUntypedCap c \<longrightarrow> usableUntypedRange c \<inter>  {ptr..ptr + of_nat n * 2 ^ objBitsKO val - 1} = {}"
-  shows "\<lbrakk>pspace_aligned' s; pspace_distinct' s;  pspace_bounded' s; pspace_no_overlap' ptr sz s\<rbrakk>
-          \<Longrightarrow> valid_cap' c (s\<lparr>ksPSpace := foldr (\<lambda>addr. data_map_insert addr val)
-                                                      (new_cap_addrs n ptr val) (ksPSpace s)\<rparr>)"
-proof -
-  note blah[simp del] = atLeastAtMost_simps
-  note cover' = range_cover_rel[where sbit' = "objBitsKO val",OF cover _ refl,simplified]
-  assume pn : "pspace_aligned' s" "pspace_distinct' s" "pspace_bounded' s"
-  and no_overlap: "pspace_no_overlap' ptr sz s"
+  shows "\<lbrakk>pspace_aligned' s; pspace_distinct' s; pspace_no_overlap' ptr sz s\<rbrakk>
+ \<Longrightarrow> valid_cap' c (s\<lparr>ksPSpace := foldr (\<lambda>addr. data_map_insert addr val) (new_cap_addrs n ptr val) (ksPSpace s)\<rparr>)"
+  proof -
+  note blah[simp del] = atLeastAtMost_iff atLeastatMost_subset_iff atLeastLessThan_iff
+        Int_atLeastAtMost atLeastatMost_empty_iff
+  assume pn : "pspace_aligned' s" "pspace_distinct' s"
+  and   no_overlap: "pspace_no_overlap' ptr sz s"
   show ?thesis
-    using pn pres no_overlap valid cover cte_wp_at_ctes_of[THEN iffD1,OF cte_at]
-      caps_no_overlapD''[OF cte_at range]
-    apply (clarsimp simp:valid_cap'_def retype_ko_wp_at')
-    apply (case_tac "cteCap cte"; simp add: valid_cap'_def cte_wp_at_obj_cases'
-                                  valid_pspace'_def retype_obj_at_disj' retype_ko_wp_at'
-                           split: zombie_type.split_asm)
-      apply (rename_tac arch_capability)
-      apply (case_tac arch_capability;
-             simp add: retype_obj_at_disj' typ_at_to_obj_at_arches
-                       page_table_at'_def page_directory_at'_def split del: if_split)
-      apply (fastforce simp: typ_at_to_obj_at_arches retype_obj_at_disj')
-     unfolding valid_untyped'_def
-     apply (intro allI)
-     apply (rule ccontr)
-     apply clarify
-     using cover[unfolded range_cover_def]
-     apply (clarsimp simp:isCap_simps retype_ko_wp_at' split:if_split_asm)
-      apply (thin_tac "\<forall>x. Q x" for Q)
-      apply (frule aligned_untypedRange_non_empty)
-       apply (simp add:isCap_simps)
-      apply (elim disjE)
-       apply (frule(1) obj_range'_subset)
-       apply (erule impE)
-        apply (drule(1) psubset_subset_trans)
-        apply (drule Int_absorb1[OF psubset_imp_subset])
-        apply (drule aligned_untypedRange_non_empty)
-         apply (simp add:isCap_simps)
-        apply (simp add:Int_ac)
-       apply (drule(1) subset_trans)
-       apply blast
-      apply (frule(1) obj_range'_subset_strong)
-      apply (drule(1) non_disjoing_subset)
-      apply blast
-     apply (thin_tac "\<forall>x. Q x" for Q)
-     apply (frule aligned_untypedRange_non_empty)
+  using pn pres no_overlap valid cover cte_wp_at_ctes_of[THEN iffD1,OF cte_at]
+        caps_no_overlapD''[OF cte_at range]
+  apply (clarsimp simp:valid_cap'_def retype_ko_wp_at')
+  apply (case_tac "cteCap cte"; simp add: valid_cap'_def cte_wp_at_obj_cases'
+                                valid_pspace'_def retype_obj_at_disj'
+                         split: zombie_type.split_asm)
+   apply (rename_tac arch_capability)
+   apply (case_tac arch_capability;
+          simp add: retype_obj_at_disj' typ_at_to_obj_at_arches
+                    page_table_at'_def page_directory_at'_def split del: if_splits)
+    apply (fastforce simp: typ_at_to_obj_at_arches retype_obj_at_disj')
+                           unfolding valid_untyped'_def
+  apply (intro allI)
+  apply (rule ccontr)
+  apply clarify
+  using cover[unfolded range_cover_def]
+  apply (clarsimp simp:isCap_simps retype_ko_wp_at' split:if_split_asm)
+   apply (thin_tac "\<forall>x. Q x" for Q)
+   apply (frule aligned_untypedRange_non_empty)
+    apply (simp add:isCap_simps)
+   apply (elim disjE)
+    apply (frule(1) obj_range'_subset)
+    apply (erule impE)
+     apply (drule(1) psubset_subset_trans)
+     apply (drule Int_absorb1[OF psubset_imp_subset])
+     apply (drule aligned_untypedRange_non_empty)
       apply (simp add:isCap_simps)
-     apply (frule(1) obj_range'_subset)
-     apply (drule(1) subset_trans)
-     apply (erule impE)
-      apply clarsimp
-      apply blast
-     apply blast
+     apply (simp add:Int_ac)
+    apply (drule(1) subset_trans)
+    apply blast
+   apply (frule(1) obj_range'_subset_strong)
+   apply (drule(1) non_disjoing_subset)
+   apply blast
+  apply (thin_tac "\<forall>x. Q x" for Q)
+  apply (frule aligned_untypedRange_non_empty)
+   apply (simp add:isCap_simps)
+  apply (frule(1) obj_range'_subset)
+  apply (drule(1) subset_trans)
+   apply (erule impE)
     apply clarsimp
-    apply (drule (3) retype_ko_wp_at'_not[where gbits=0, simplified, OF _ _ _ cover])
-    apply (erule notE, simp)
-    done
+    apply blast
+   apply blast
+  done
 qed
 
 definition caps_overlap_reserved' :: "word32 set \<Rightarrow> kernel_state \<Rightarrow> bool"
@@ -3246,17 +3195,13 @@ where
   (isUntypedCap (cteCap cte) \<longrightarrow> usableUntypedRange (cteCap cte) \<inter> S = {})"
 
 lemma createObjects_valid_pspace':
-  assumes  mko: "makeObjectKO dev us d ty = Some val"
-  and    max_d: "ty = Inr (APIObjectType TCBObject) \<longrightarrow> d \<le> maxDomain"
+  assumes  mko: "makeObjectKO dev ty = Some val"
   and    not_0: "n \<noteq> 0"
-  and     tysc: "ty = Inr (APIObjectType SchedContextObject) \<longrightarrow> sc_size_bounds us"
   and    cover: "range_cover ptr sz (objBitsKO val + gbits) n"
   shows "\<lbrace>\<lambda>s. pspace_no_overlap' ptr sz s \<and> valid_pspace' s \<and> caps_no_overlap'' ptr sz s
             \<and> caps_overlap_reserved' {ptr .. ptr + of_nat (n * 2^gbits * 2 ^ objBitsKO val ) - 1} s
             \<and> ptr \<noteq> 0\<rbrace>
-         createObjects' ptr n val gbits
-         \<lbrace>\<lambda>r. valid_pspace'\<rbrace>"
-  (* FIXME: clean this up *)
+  createObjects' ptr n val gbits \<lbrace>\<lambda>r. valid_pspace'\<rbrace>"
   apply (cut_tac not_0)
   apply (simp add: split_def createObjects'_def
                    lookupAround2_pspace_no
@@ -3285,9 +3230,7 @@ proof (intro conjI impI)
 
   assume pn: "pspace_no_overlap' ptr sz s"
      and vo: "valid_objs' s"
-     and vr: "valid_replies' s"
      and ad: "pspace_aligned' s" "pspace_distinct' s"
-     and bd: "pspace_bounded' s"
      and pc: "caps_no_overlap'' ptr sz s"
     and mdb: "valid_mdb' s"
     and p_0: "ptr \<noteq> 0"
@@ -3301,7 +3244,7 @@ proof (intro conjI impI)
 
   note cover' = range_cover_rel[where sbit' = "objBitsKO val",OF cover _ refl,simplified]
 
-  note ad' = retype_aligned_distinct'[OF ad bd pn cover']
+  note ad' = retype_aligned_distinct'[OF ad pn cover']
 
   note shift = range_cover.unat_of_nat_n_shift[OF cover,where gbits=gbits,simplified]
 
@@ -3317,7 +3260,7 @@ proof (intro conjI impI)
   using ad' shift
     by (simp add:field_simps)
 
-  note obj_at_disj = retype_obj_at_disj' [OF ad bd pn cover']
+  note obj_at_disj = retype_obj_at_disj' [OF ad pn cover']
 
   note obj_at_disj' = obj_at_disj [unfolded foldr_upd_app_if[folded data_map_insert_def]]
 
@@ -3332,7 +3275,7 @@ proof (intro conjI impI)
 
   have valid_cap: "\<And>cap q. \<lbrakk> s \<turnstile>' cap; cte_wp_at' (\<lambda>cte. cteCap cte = cap) q s \<rbrakk>
                       \<Longrightarrow> ?s' \<turnstile>' cap"
-     apply (rule valid_untyped'_helper[OF _ _ _ pc _ ad bd pn ])
+     apply (rule valid_untyped'_helper[OF _ _ _ pc _ ad pn ])
           apply simp+
         apply (subst mult.commute)
         apply (rule cover')
@@ -3343,13 +3286,13 @@ proof (intro conjI impI)
      apply simp
    done
 
-  show valid_objs: "valid_objs' ?s'" using vo tysc
+  show valid_objs: "valid_objs' ?s'" using vo
     apply (clarsimp simp: valid_objs'_def
                           foldr_upd_app_if[folded data_map_insert_def]
                    elim!: ranE
                    split: if_split_asm)
      apply (insert sym[OF mko])[1]
-     apply (clarsimp simp: makeObjectKO_def max_d
+     apply (clarsimp simp: makeObjectKO_def
                     split: bool.split_asm sum.split_asm
                            ARM_H.object_type.split_asm
                            apiobject_type.split_asm
@@ -3358,73 +3301,49 @@ proof (intro conjI impI)
     apply (drule bspec, erule ranI)
     apply (subst mult.commute)
     apply (case_tac obj; simp add: valid_obj'_def)
-          apply (rename_tac endpoint)
-          apply (case_tac endpoint; simp add: valid_ep'_def obj_at_disj')
-         apply (rename_tac notification)
-         apply (case_tac notification; simp add: valid_ntfn'_def valid_bound_tcb'_def obj_at_disj')
-         apply (rename_tac ntfn xa xb)
-         apply (case_tac ntfn, simp_all, (clarsimp simp: obj_at_disj' split:option.splits)+)
-        apply (rename_tac tcb)
-        apply (case_tac tcb, clarsimp simp add: valid_tcb'_def)
-        apply (frule pspace_alignedD' [OF _ ad(1)])
-        apply (frule pspace_distinctD' [OF _ ad(2)])
-        apply (simp add: objBits_simps)
-        apply (subst mult.commute)
-        apply (intro conjI ballI)
-            apply (clarsimp elim!: ranE)
-            apply (rule valid_cap[unfolded foldr_upd_app_if[folded data_map_insert_def]])
-             apply (fastforce)
-            apply (rule_tac ptr="x + xa" in cte_wp_at_tcbI', assumption+)
-             apply fastforce
-            apply simp
-           apply (rename_tac thread_state mcp priority inQ inRQ option vptr bound tcbsc tcbyt user_context)
-           apply (case_tac thread_state, simp_all add: valid_tcb_state'_def
-                                                       valid_bound_ntfn'_def obj_at_disj'
-                                                split: option.splits)[4]
-       apply (simp add: valid_cte'_def)
-       apply (frule pspace_alignedD' [OF _ ad(1)])
-       apply (frule pspace_distinctD' [OF _ ad(2)])
-       apply (simp add: objBits_simps')
-       apply (subst mult.commute)
-       apply (erule valid_cap[unfolded foldr_upd_app_if[folded data_map_insert_def]])
-       apply (erule(2) cte_wp_at_cteI'[unfolded cte_level_bits_def])
+        apply (rename_tac endpoint)
+        apply (case_tac endpoint; simp add: valid_ep'_def obj_at_disj')
+       apply (rename_tac notification)
+       apply (case_tac notification; simp add: valid_ntfn'_def valid_bound_tcb'_def obj_at_disj')
+       apply (rename_tac ntfn xa)
+       apply (case_tac ntfn, simp_all, (clarsimp simp: obj_at_disj' split:option.splits)+)
+      apply (rename_tac tcb)
+      apply (case_tac tcb, clarsimp simp add: valid_tcb'_def)
+      apply (frule pspace_alignedD' [OF _ ad(1)])
+      apply (frule pspace_distinctD' [OF _ ad(2)])
+      apply (simp add: objBits_simps)
+      apply (subst mult.commute)
+      apply (intro conjI ballI)
+       apply (clarsimp elim!: ranE)
+       apply (rule valid_cap[unfolded foldr_upd_app_if[folded data_map_insert_def]])
+        apply (fastforce)
+       apply (rule_tac ptr="x + xa" in cte_wp_at_tcbI', assumption+)
+        apply fastforce
        apply simp
-      apply (rename_tac arch_kernel_object)
-      apply (case_tac arch_kernel_object; simp)
-        apply (rename_tac asidpool)
-        apply (case_tac asidpool, clarsimp simp: page_directory_at'_def
-                                                 typ_at_to_obj_at_arches
-                                                 obj_at_disj')
-       apply (rename_tac pte)
-       apply (case_tac pte; simp add: valid_mapping'_def)
-      apply (rename_tac pde)
-      apply (case_tac pde; simp add: valid_mapping'_def page_table_at'_def
-                                     typ_at_to_obj_at_arches obj_at_disj')
-     apply (rename_tac sc)
-     apply (case_tac sc; simp add: valid_sched_context'_def valid_bound_tcb'_def obj_at_disj'
-                            split: option.splits)
-    apply (rename_tac reply)
-    apply (case_tac reply; fastforce simp: valid_reply'_def valid_bound_tcb'_def obj_at_disj'
-                    split: option.splits)
+      apply (rename_tac thread_state mcp priority bool option nat cptr vptr bound tcbprev tcbnext user_context)
+      apply (case_tac thread_state, simp_all add: valid_tcb_state'_def valid_bound_tcb'_def
+                                                  valid_bound_ntfn'_def obj_at_disj' opt_tcb_at'_def
+                                           split: option.splits)[4]
+     apply (simp add: valid_cte'_def)
+     apply (frule pspace_alignedD' [OF _ ad(1)])
+     apply (frule pspace_distinctD' [OF _ ad(2)])
+     apply (simp add: objBits_simps')
+     apply (subst mult.commute)
+     apply (erule valid_cap[unfolded foldr_upd_app_if[folded data_map_insert_def]])
+     apply (erule(2) cte_wp_at_cteI'[unfolded cte_level_bits_def])
+     apply simp
+    apply (rename_tac arch_kernel_object)
+    apply (case_tac arch_kernel_object; simp)
+      apply (rename_tac asidpool)
+      apply (case_tac asidpool, clarsimp simp: page_directory_at'_def
+                                               typ_at_to_obj_at_arches
+                                               obj_at_disj')
+     apply (rename_tac pte)
+     apply (case_tac pte; simp add: valid_mapping'_def)
+    apply (rename_tac pde)
+    apply (case_tac pde; simp add: valid_mapping'_def page_table_at'_def
+                                   typ_at_to_obj_at_arches obj_at_disj')
     done
-
-  show valid_replies': "valid_replies' ?s'" using vr
-    apply (subst mult.commute)
-    apply (clarsimp simp: valid_replies'_def pred_tcb_at'_def obj_at_disj'
-                          foldr_upd_app_if[folded data_map_insert_def]
-                   elim!: ranE
-                   split: if_split_asm)
-    apply (insert sym[OF mko])[1]
-    apply (clarsimp simp: makeObjectKO_def projectKOs opt_map_def makeObject_reply
-                   split: bool.split_asm sum.split_asm
-                          ARM_H.object_type.split_asm
-                          apiobject_type.split_asm
-                          kernel_object.split_asm
-                          arch_kernel_object.split_asm
-                          if_splits option.splits)
-    apply fastforce
-    done
-
   have not_0: "0 \<notin> set (new_cap_addrs (2 ^ gbits * n) ptr val)"
     using p_0
     apply clarsimp
@@ -3435,13 +3354,12 @@ proof (intro conjI impI)
     apply (simp add: valid_mdb'_def foldr_upd_app_if[folded data_map_insert_def])
     apply (subst mult.commute)
     apply (subst ctes_of_retype [OF mko ad])
-         apply (rule ad'[unfolded foldr_upd_app_if[folded data_map_insert_def]])+
-       apply (simp add: objBits_def[symmetric] new_cap_addrs_aligned [OF al])
-      using cover apply (clarsimp simp: range_cover_def word_bits_def)
+        apply (rule ad'[unfolded foldr_upd_app_if[folded data_map_insert_def]])+
+      apply (simp add: objBits_def[symmetric] new_cap_addrs_aligned [OF al])
      apply (rule ballI, drule subsetD [OF new_cap_addrs_subset [OF cover']])
      apply (insert pspace_no_overlap_disjoint' [OF ad(1) pn])
      apply (drule_tac x = x in orthD1)
-      apply (simp add:ptr_add_def p_assoc_help)
+       apply (simp add:ptr_add_def p_assoc_help)
      apply fastforce
     apply (fold makeObject_cte)
     apply (rule retype_mdb.valid_n)
@@ -3485,24 +3403,19 @@ proof (intro conjI impI)
     using not_0 no_0_obj'
     by (simp add: no_0_obj'_def data_map_ext field_simps foldr_upd_app_other)
 
-  show bounded': "pspace_bounded' ?s'"
-  using ad' shift range_cover.unat_of_nat_n_shift[OF cover,where gbits=gbits,simplified]
-    by (simp add: field_simps )
 qed
 
 abbreviation
  "injectKOS \<equiv> (injectKO :: ('a :: pspace_storable) \<Rightarrow> kernel_object)"
 
 lemma createObjects_valid_pspace_untyped':
-  assumes  mko: "makeObjectKO dev us d ty = Some val"
-  and    max_d: "ty = Inr (APIObjectType TCBObject) \<longrightarrow> d \<le> maxDomain"
+  assumes  mko: "makeObjectKO dev ty = Some val"
   and    not_0: "n \<noteq> 0"
-  and     tysc: "ty = Inr (APIObjectType SchedContextObject) \<longrightarrow> sc_size_bounds us"
   and    cover: "range_cover ptr sz (objBitsKO val + gbits) n"
   shows "\<lbrace>\<lambda>s. pspace_no_overlap' ptr sz s \<and> valid_pspace' s \<and> caps_no_overlap'' ptr sz s \<and> ptr \<noteq> 0
             \<and> caps_overlap_reserved' {ptr .. ptr + of_nat (n * 2^gbits * 2 ^ objBitsKO val ) - 1} s \<rbrace>
   createObjects' ptr n val gbits \<lbrace>\<lambda>r. valid_pspace'\<rbrace>"
-  apply (wp createObjects_valid_pspace' [OF mko max_d not_0 tysc cover])
+  apply (wp createObjects_valid_pspace' [OF mko not_0 cover])
   apply simp
   done
 
@@ -3511,28 +3424,34 @@ lemma getObject_valid_pde'[wp]:
   apply (rule hoare_chain)
     apply (rule hoare_vcg_conj_lift)
      apply (rule getObject_ko_at, simp)
+     apply (simp add: objBits_simps archObjSize_def pdeBits_def)
     apply (rule getObject_inv[where P=valid_objs'])
+    apply (simp add: loadObject_default_inv)
    apply simp
   apply (clarsimp simp: projectKOs valid_obj'_def dest!: obj_at_valid_objs')
   done
 
 crunch copyGlobalMappings
   for valid_objs'[wp]: "valid_objs'"
-  and pspace_aligned'[wp]: "pspace_aligned'"
-  and pspace_distinct'[wp]: "pspace_distinct'"
-  and pspace_bounded'[wp]: "pspace_bounded'"
-  and valid_mdb[wp]: "valid_mdb'"
-  and no_0_obj' [wp]: no_0_obj'
   (ignore: storePDE wp: crunch_wps)
+crunch copyGlobalMappings
+  for pspace_aligned'[wp]: "pspace_aligned'"
+  (wp: crunch_wps)
+crunch copyGlobalMappings
+  for pspace_distinct'[wp]: "pspace_distinct'"
+  (wp: crunch_wps)
 
-lemma copyGlobalMappings_valid_replies'[wp]:
-  "\<lbrace>valid_replies' and pspace_aligned' and pspace_distinct'\<rbrace>
-   copyGlobalMappings pd
-   \<lbrace>\<lambda>_. valid_replies'\<rbrace>" (is "\<lbrace>?Pre\<rbrace> _ \<lbrace>_\<rbrace>")
-  unfolding copyGlobalMappings_def
-  by (wpsimp wp: mapM_x_inv_wp[where I="?Pre"])
+lemmas storePDE_valid_mdb[wp]
+    = storePDE_ctes[where P=valid_mdb_ctes, folded valid_mdb'_def]
+crunch copyGlobalMappings
+  for valid_mdb[wp]: "valid_mdb'"
+  (wp: crunch_wps)
 
-lemma copyGlobalMappings_valid_pspace'[wp]:
+crunch copyGlobalMappings
+  for no_0_obj'[wp]: no_0_obj'
+  (wp: crunch_wps)
+
+lemma copyGlobalMappings_valid_pspace[wp]:
   "\<lbrace>valid_pspace'\<rbrace> copyGlobalMappings pd \<lbrace>\<lambda>rv. valid_pspace'\<rbrace>"
   by (simp add: valid_pspace'_def | wp)+
 
@@ -3547,14 +3466,11 @@ proof -
   note unat_of_nat_shift = range_cover.unat_of_nat_n_shift[OF cover,where gbits=gbits,simplified]
   have cover' :"range_cover ptr sz (objBitsKO val) (n*2^gbits)"
     by (rule range_cover_rel[OF cover],simp+)
-  have bd: "objBitsKO val < word_bits"
-    using cover
-    by (simp add: range_cover_def word_bits_def)
   have upbound:" unat ((((of_nat n)::word32) * 2 ^ gbits)) * unat ((2::word32) ^ objBitsKO val) < 2 ^ word_bits"
-    using range_cover.range_cover_le_n_less[OF cover' le_refl] cover' bd
+    using range_cover.range_cover_le_n_less[OF cover' le_refl] cover'
     apply -
-      apply (drule nat_less_power_trans)
-       apply (simp add:range_cover_def)
+    apply (drule nat_less_power_trans)
+     apply (simp add:range_cover_def)
     apply (fold word_bits_def)
     using unat_of_nat_shift not_0
     apply (simp add:field_simps shiftl_t2n)
@@ -3567,63 +3483,63 @@ proof -
     using cover
     by (simp add:range_cover_def word_bits_def)
   thus ?thesis
-  apply -
-  apply (insert not_0 cover ptr_in bd)
-  apply (frule range_cover.range_cover_le_n_less[OF _ le_refl])
-  apply (fold word_bits_def)
-  apply (simp add:shiftL_nat )
-  apply (simp add:range_cover.unat_of_nat_n_shift)
-  apply (clarsimp simp:new_cap_addrs_def shiftl_t2n)
-  apply (rename_tac pa)
-  apply (rule word_plus_mono_right)
-    apply (rule order_trans)
-    apply (subst mult.commute)
-    apply (rule word_mult_le_iff[THEN iffD2])
-       apply (clarsimp simp:p2_gt_0 range_cover_def word_bits_def)
-      apply (drule range_cover_rel[where sbit' = "0"])
-        apply (simp+)[2]
-      apply (erule less_le_trans[OF range_cover.range_cover_le_n_less(2)])
-       apply (clarsimp simp:field_simps power_add)
-       apply (rule unat_le_helper)
-       apply (rule of_nat_mono_maybe_le[THEN iffD1])
-         using range_cover.range_cover_le_n_less[OF cover' le_refl]
-       apply (simp_all only:word_bits_def[symmetric])
+    apply -
+    apply (insert not_0 cover ptr_in)
+    apply (frule range_cover.range_cover_le_n_less[OF _ le_refl])
+    apply (fold word_bits_def)
+    apply (simp add:shiftL_nat )
+    apply (simp add:range_cover.unat_of_nat_n_shift)
+    apply (clarsimp simp:new_cap_addrs_def shiftl_t2n)
+    apply (rename_tac pa)
+    apply (rule word_plus_mono_right)
+     apply (rule order_trans)
+      apply (subst mult.commute)
+      apply (rule word_mult_le_iff[THEN iffD2])
+         apply (clarsimp simp:p2_gt_0 range_cover_def word_bits_def)
+        apply (drule range_cover_rel[where sbit' = "0"])
+          apply (simp+)[2]
+        apply (erule less_le_trans[OF range_cover.range_cover_le_n_less(2)])
+         apply (clarsimp simp:field_simps power_add)
+         apply (rule unat_le_helper)
+         apply (rule of_nat_mono_maybe_le[THEN iffD1])
+           using range_cover.range_cover_le_n_less[OF cover' le_refl]
+           apply (simp_all only:word_bits_def[symmetric])
+        apply simp
+       apply (drule nat_less_power_trans)
+        apply (simp add:range_cover_def word_bits_def)
+       apply (rule less_le_trans[OF mult_less_mono1])
+         apply (rule unat_mono)
+         apply (rule_tac y1= "pa" in  of_nat_mono_maybe'[THEN iffD1,rotated -1])
+           apply (assumption)
+          apply (simp add:word_bits_def)
+         apply (simp add:word_bits_def)
+        apply simp
+       using unat_of_nat_shift
+       apply (simp add:field_simps shiftl_t2n)
       apply simp
-     apply (drule nat_less_power_trans)
-      apply (simp add:range_cover_def word_bits_def)
-     apply (rule less_le_trans[OF mult_less_mono1])
-       apply (rule unat_mono)
-       apply (rule_tac y1= "pa" in  of_nat_mono_maybe'[THEN iffD1,rotated -1])
-         apply (assumption)
-        apply (simp add:word_bits_def)
-       apply (simp add:word_bits_def)
-      apply simp
-        using unat_of_nat_shift
-      apply (simp add:field_simps shiftl_t2n)
-     apply simp
-    apply (rule word_less_sub_1)
-    apply (simp add:power_add field_simps)
-    apply (subst mult.assoc[symmetric])
-    apply (rule word_mult_less_mono1)
-      apply (rule word_of_nat_less)
-      using unat_of_nat_shift
-      apply (simp add:shiftl_t2n field_simps)
-      apply (meson less_exp of_nat_less_pow_32 word_gt_a_gt_0)
-   using upbound
-   apply (simp add:word_bits_def)
-   apply (rule machine_word_plus_mono_right_split[where sz = sz])
-    apply (rule less_le_trans[rotated -1])
-     apply (rule range_cover.range_cover_compare_bound[OF cover'])
-    apply (simp add: unat_minus_one[OF not_0'])
-    using range_cover.unat_of_nat_n_shift[OF cover le_refl]
-    apply (simp add:shiftl_t2n power_add field_simps)
-  apply (simp add:range_cover_def word_bits_def)
-  done
+     apply (rule word_less_sub_1)
+     apply (simp add:power_add field_simps)
+     apply (subst mult.assoc[symmetric])
+     apply (rule word_mult_less_mono1)
+       apply (rule word_of_nat_less)
+       using unat_of_nat_shift
+       apply (simp add:shiftl_t2n field_simps)
+      apply (meson less_exp objBitsKO_bounded2 of_nat_less_pow_32 word_gt_a_gt_0)
+     using upbound
+     apply (simp add:word_bits_def)
+    apply (rule machine_word_plus_mono_right_split[where sz = sz])
+     apply (rule less_le_trans[rotated -1])
+      apply (rule range_cover.range_cover_compare_bound[OF cover'])
+     apply (simp add: unat_minus_one[OF not_0'])
+     using range_cover.unat_of_nat_n_shift[OF cover le_refl]
+     apply (simp add:shiftl_t2n power_add field_simps)
+    apply (simp add:range_cover_def word_bits_def)
+    done
 qed
 
 lemma createObjects_orig_ko_wp_at2':
   "\<lbrace>\<lambda>s. range_cover ptr sz (objBitsKO val + gbits) n \<and> n \<noteq> 0
-      \<and> pspace_aligned' s \<and> pspace_distinct' s \<and> pspace_bounded' s
+      \<and> pspace_aligned' s \<and> pspace_distinct' s
       \<and> P (ko_wp_at' P' p s)
       \<and> (P' val \<longrightarrow> P True)
       \<and> pspace_no_overlap' ptr sz s\<rbrace>
@@ -3670,7 +3586,7 @@ lemma createObjects_orig_ko_wp_at2':
 lemma createObjects_orig_obj_at2':
   "\<lbrace>\<lambda>s. n \<noteq> 0
       \<and> range_cover ptr sz (objBitsKO val + gbits) n
-      \<and> pspace_aligned' s \<and> pspace_distinct' s \<and> pspace_bounded' s
+      \<and> pspace_aligned' s \<and> pspace_distinct' s
       \<and> P (obj_at' P' p s)
       \<and> \<not> (case_option False P' (projectKO_opt val))
       \<and> pspace_no_overlap' ptr sz s\<rbrace>
@@ -3682,7 +3598,7 @@ lemma createObjects_orig_cte_wp_at2':
   "\<lbrace>\<lambda>s. P (cte_wp_at' P' p s)
       \<and> n \<noteq> 0
       \<and> range_cover ptr sz (objBitsKO val + gbits) n
-      \<and> pspace_aligned' s \<and> pspace_distinct' s \<and> pspace_bounded' s
+      \<and> pspace_aligned' s \<and> pspace_distinct' s
       \<and> \<not> (case_option False P' (projectKO_opt val))
       \<and> (\<forall>(getF, setF) \<in> ran tcb_cte_cases.
               \<not> (case_option False (P' \<circ> getF) (projectKO_opt val)))
@@ -3697,13 +3613,19 @@ lemma createObjects_orig_cte_wp_at2':
              | simp add: o_def cong: option.case_cong)+
   done
 
+lemma threadSet_cte_wp_at2'T:
+  assumes "\<forall>tcb. \<forall>(getF, setF) \<in> ran tcb_cte_cases. getF (F tcb) = getF tcb"
+  shows "\<lbrace>\<lambda>s. P (cte_wp_at' P' p s)\<rbrace> threadSet F t \<lbrace>\<lambda>rv s. P (cte_wp_at' P' p s)\<rbrace>"
+  using assms by (rule threadSet_cte_wp_at'T)
+
+lemmas threadSet_cte_wp_at2' =
+  threadSet_cte_wp_at2'T [OF all_tcbI, OF ball_tcb_cte_casesI]
+
 lemma createNewCaps_cte_wp_at2:
   "\<lbrace>\<lambda>s. P (cte_wp_at' P' p s) \<and> \<not> P' makeObject
       \<and> n \<noteq> 0
-      \<and> (ty = APIObjectType ArchTypes_H.apiobject_type.SchedContextObject
-               \<longrightarrow> minSchedContextBits \<le> objsz)
       \<and> range_cover ptr sz (APIType_capBits ty objsz) n
-      \<and> pspace_aligned' s \<and> pspace_distinct' s \<and> pspace_bounded' s
+      \<and> pspace_aligned' s \<and> pspace_distinct' s
       \<and> pspace_no_overlap' ptr sz s\<rbrace>
      createNewCaps ty ptr n objsz dev
    \<lbrace>\<lambda>rv s. P (cte_wp_at' P' p s)\<rbrace>"
@@ -3714,19 +3636,24 @@ lemma createNewCaps_cte_wp_at2:
                            split del: if_split cong: if_cong)
         apply (rename_tac apiobject_type)
         apply (case_tac apiobject_type; simp split del: if_split)
-              apply (rule hoare_pre, wp, simp add:createObjects_def)
-  by (wpsimp wp: createObjects_orig_cte_wp_at2'[where sz = sz] mapM_x_wp' split_del: if_split
-           simp: createObjects_def curDomain_def objBits_simps APIType_capBits_def
-    | simp add: projectKO_opts_defs makeObject_tcb tcb_cte_cases_def Let_def
-                scBits_simps objBits_if_dev objBits_simps
-                archObjSize_def pdBits_def pdeBits_def ptBits_def pteBits_def pageBits_def
-           split del: if_split
-    | simp)+
+            apply (rule hoare_pre, wp, simp add:createObjects_def)
+           apply ((wp createObjects_orig_cte_wp_at2'[where sz = sz]
+                     mapM_x_wp' threadSet_cte_wp_at2')+
+                   | assumption
+                   | clarsimp simp: APIType_capBits_def
+                                    projectKOs projectKO_opts_defs
+                                    makeObject_tcb tcb_cte_cases_def
+                                    pageBits_def archObjSize_def ptBits_def
+                                    pdBits_def createObjects_def curDomain_def
+                                    Let_def objBits_if_dev
+                         split del: if_split
+                   | simp add: objBits_simps pteBits_def pdeBits_def)+
+  done
 
 lemma createObjects_orig_obj_at':
   "\<lbrace>\<lambda>s. n \<noteq> 0
       \<and> range_cover ptr sz (objBitsKO val + gbits) n
-      \<and> pspace_aligned' s \<and> pspace_distinct' s \<and> pspace_bounded' s
+      \<and> pspace_aligned' s \<and> pspace_distinct' s
       \<and> obj_at' P p s
       \<and> pspace_no_overlap' ptr sz s\<rbrace>
   createObjects' ptr n val gbits \<lbrace>\<lambda>r. obj_at' P p\<rbrace>"
@@ -3770,7 +3697,7 @@ crunch doMachineOp
 
 lemma createObjects_orig_cte_wp_at':
   "\<lbrace>\<lambda>s. range_cover ptr sz (objBitsKO val + gbits) n \<and> n \<noteq> 0
-      \<and> pspace_aligned' s \<and> pspace_distinct' s \<and> pspace_bounded' s
+      \<and> pspace_aligned' s \<and> pspace_distinct' s
       \<and> cte_wp_at' P p s
       \<and> pspace_no_overlap' ptr sz s\<rbrace>
   createObjects' ptr n val gbits \<lbrace>\<lambda>r s. cte_wp_at' P p s\<rbrace>"
@@ -3782,9 +3709,7 @@ lemma createObjects_orig_cte_wp_at':
 lemma createNewCaps_cte_wp_at':
   "\<lbrace>\<lambda>s. cte_wp_at' P p s
       \<and> range_cover ptr sz (APIType_capBits ty us) n \<and> n \<noteq> 0
-      \<and> (ty = APIObjectType ArchTypes_H.apiobject_type.SchedContextObject
-               \<longrightarrow> sc_size_bounds us)
-      \<and> pspace_aligned' s \<and> pspace_distinct' s \<and> pspace_bounded' s
+      \<and> pspace_aligned' s \<and> pspace_distinct' s
       \<and> pspace_no_overlap' ptr sz s\<rbrace>
      createNewCaps ty ptr n us dev
    \<lbrace>\<lambda>rv. cte_wp_at' P p\<rbrace>"
@@ -3798,8 +3723,7 @@ lemma createNewCaps_cte_wp_at':
            apply (wp createObjects_orig_cte_wp_at'[where sz = sz] mapM_x_wp'
                      threadSet_cte_wp_at'T
                   | clarsimp simp: objBits_simps APIType_capBits_def createObjects_def curDomain_def
-                                   pageBits_def ptBits_def pdBits_def archObjSize_def pteBits_def
-                                   pdeBits_def scBits_simps
+                    pageBits_def ptBits_def pdBits_def archObjSize_def pteBits_def pdeBits_def
                   | intro conjI impI
                   | force simp: tcb_cte_cases_def)+
   done
@@ -3830,20 +3754,23 @@ lemma valid_cap'_range_no_overlap:
                     page_table_at'_def page_directory_at'_def)
    apply (fastforce simp: typ_at_to_obj_at_arches retype_obj_at_disj')
   apply (rename_tac word nat1 nat2)
-  apply (clarsimp simp: valid_untyped'_def retype_ko_wp_at'
-              simp del: atLeastAtMost_simps)
+  apply (clarsimp simp:valid_untyped'_def retype_ko_wp_at'
+        simp del: atLeastAtMost_iff atLeastatMost_subset_iff atLeastLessThan_iff
+        Int_atLeastAtMost atLeastatMost_empty_iff)
   apply (frule aligned_untypedRange_non_empty)
    apply (simp add:isCap_simps)
   apply (intro conjI impI)
    apply (intro allI)
    apply (drule_tac x = ptr' in spec)
    apply (rule ccontr)
-   apply (clarsimp simp del: atLeastAtMost_simps)
+   apply (clarsimp simp del: atLeastAtMost_iff atLeastatMost_subset_iff atLeastLessThan_iff
+                             Int_atLeastAtMost atLeastatMost_empty_iff)
    apply (erule disjE)
     apply (drule(2) disjoint_subset2 [OF obj_range'_subset])
     apply (drule(1) disjoint_subset2[OF psubset_imp_subset])
     apply (simp add: Int_absorb ptr_add_def p_assoc_help
-                del: atLeastAtMost_simps)
+                del: atLeastAtMost_iff atLeastatMost_subset_iff atLeastLessThan_iff
+                     Int_atLeastAtMost atLeastatMost_empty_iff)
    apply (drule(1) obj_range'_subset)
    apply (drule_tac A'=" {word + of_nat nat2..word + 2 ^ nat1 - 1}" in disjoint_subset[rotated])
     apply clarsimp
@@ -3856,14 +3783,13 @@ lemma valid_cap'_range_no_overlap:
   apply (intro allI)
   apply (drule_tac x = ptr' in spec)
   apply (rule ccontr)
-  apply (clarsimp simp del: atLeastAtMost_simps)
+  apply (clarsimp simp del: atLeastAtMost_iff atLeastatMost_subset_iff atLeastLessThan_iff
+                            Int_atLeastAtMost atLeastatMost_empty_iff)
   apply (drule(2) disjoint_subset2 [OF obj_range'_subset])
   apply (drule(1) disjoint_subset2)
   apply (simp add: Int_absorb ptr_add_def p_assoc_help
-              del: atLeastAtMost_simps)
-  apply (clarsimp simp: retype_ko_wp_at')
-    apply (drule (4) retype_ko_wp_at'_not[where gbits=0, simplified])
-  apply (erule notE, simp)
+              del: atLeastAtMost_iff atLeastatMost_subset_iff atLeastLessThan_iff
+                   Int_atLeastAtMost atLeastatMost_empty_iff)
   done
 
 lemma createObjects_cte_wp_at':
@@ -3888,13 +3814,11 @@ lemma createObjects_cte_wp_at':
 lemma createNewCaps_cte_wp_at:
   assumes cover: "range_cover ptr sz (APIType_capBits ty us) n"
   and not_0 : "n \<noteq> 0"
-  and  tysc : "ty = APIObjectType ArchTypes_H.apiobject_type.SchedContextObject
-                      \<longrightarrow> sc_size_bounds us"
   shows "\<lbrace>\<lambda>s. cte_wp_at' P p s \<and> valid_pspace' s \<and> pspace_no_overlap' ptr sz s\<rbrace>
   createNewCaps ty ptr n us dev
   \<lbrace>\<lambda>_. cte_wp_at' P p\<rbrace>"
   apply (wp createNewCaps_cte_wp_at')
-  apply (auto simp: cover not_0 tysc)
+  apply (auto simp: cover not_0)
   done
 
 lemma createObjects_ret2:
@@ -3923,7 +3847,7 @@ lemma createObjects_state_refs_of'':
   "\<lbrace>\<lambda>s. n \<noteq> 0
         \<and> range_cover ptr sz (objBitsKO val + gbits) n
         \<and> P (state_refs_of' s) \<and> refs_of' val = {}
-        \<and> pspace_aligned' s \<and> pspace_distinct' s \<and> pspace_bounded' s
+        \<and> pspace_aligned' s \<and> pspace_distinct' s
         \<and> pspace_no_overlap' ptr sz s\<rbrace>
      createObjects' ptr n val gbits
    \<lbrace>\<lambda>rv s. P (state_refs_of' s)\<rbrace>"
@@ -3941,16 +3865,13 @@ lemma createObjects_state_refs_of'':
      apply simp+
   done
 
-crunch copyGlobalMappings, curDomain
-for state_refs_of'[wp]: "\<lambda>s. P (state_refs_of' s)"
-and replies_of'[wp]: "\<lambda>s. P (replies_of' s)"
+crunch copyGlobalMappings
+  for state_refs_of'[wp]: "\<lambda>s. P (state_refs_of' s)"
   (wp: crunch_wps)
 
 lemma createNewCaps_state_refs_of':
   assumes cover: "range_cover ptr sz (APIType_capBits ty us) n"
   and     not_0: "n \<noteq> 0"
-  and     tysc : "ty = APIObjectType ArchTypes_H.apiobject_type.SchedContextObject
-                         \<longrightarrow> sc_size_bounds us"
   shows
   "\<lbrace>\<lambda>s. valid_pspace' s \<and> pspace_no_overlap' ptr sz s
         \<and> P (state_refs_of' s)\<rbrace>
@@ -3964,20 +3885,21 @@ lemma createNewCaps_state_refs_of':
         apply (rename_tac apiobject_type)
         apply (case_tac apiobject_type; simp split del: if_split)
             apply (rule hoare_pre, wp, simp)
-           apply (insert cover not_0 tysc)
-           by (wp mapM_x_wp' createObjects_state_refs_of'' threadSet_state_refs_of'
-             | simp add: not_0 pspace_no_overlap'_def objBitsKO_def APIType_capBits_def
-                         valid_pspace'_def makeObject_tcb makeObject_endpoint objBits_def
-                         makeObject_notification pageBits_def ptBits_def pdBits_def
-                         archObjSize_def createObjects_def curDomain_def scBits_simps
-                         pdeBits_def pteBits_def makeObject_sc makeObject_reply
-             | intro conjI impI )+
+           apply (insert cover not_0)
+           apply (wp mapM_x_wp' createObjects_state_refs_of'' threadSet_state_refs_of'
+                    | simp add: not_0 pspace_no_overlap'_def objBitsKO_def APIType_capBits_def
+                                valid_pspace'_def makeObject_tcb makeObject_endpoint objBits_def
+                                makeObject_notification pageBits_def ptBits_def pdBits_def
+                                archObjSize_def createObjects_def curDomain_def
+                                pdeBits_def pteBits_def
+             | intro conjI impI)+
+  done
 
 lemma createObjects_iflive':
   "\<lbrace>\<lambda>s. if_live_then_nonz_cap' s \<and> \<not> live' val
         \<and> n \<noteq> 0
         \<and> range_cover ptr sz (objBitsKO val + gbits) n
-        \<and> pspace_aligned' s \<and> pspace_distinct' s \<and> pspace_bounded' s
+        \<and> pspace_aligned' s \<and> pspace_distinct' s
         \<and> pspace_no_overlap' ptr sz s\<rbrace>
      createObjects' ptr n val gbits
    \<lbrace>\<lambda>rv s. if_live_then_nonz_cap' s\<rbrace>"
@@ -3989,123 +3911,21 @@ lemma createObjects_iflive':
              createObjects_orig_cte_wp_at')
   apply clarsimp
   apply (intro conjI allI impI)
-    apply simp_all
+  apply simp_all
   apply (rule ccontr)
   apply clarsimp
   apply (drule(1) if_live_then_nonz_capE')
   apply (fastforce simp: ex_nonz_cap_to'_def)
   done
 
-lemma createObjects_list_refs_of_replies'':
-  "\<lbrace>\<lambda>s. n \<noteq> 0
-        \<and> range_cover ptr sz (objBitsKO val + gbits) n
-        \<and> P (list_refs_of_replies' s)
-        \<and> (case val of KOReply r \<Rightarrow> replyNext_of r = None \<and> replyPrev r = None
-                     | _ \<Rightarrow> True)
-        \<and> pspace_aligned' s \<and> pspace_distinct' s \<and> pspace_bounded' s
-        \<and> pspace_no_overlap' ptr sz s\<rbrace>
-     createObjects' ptr n val gbits
-   \<lbrace>\<lambda>rv s. P (list_refs_of_replies' s)\<rbrace>" (is "\<lbrace> \<lambda>s. _ \<and> _ \<and> ?Pre s \<rbrace> _ \<lbrace>\<lambda>_. _\<rbrace>")
-proof -
-  show ?thesis
-    apply (rule hoare_grab_asm)
-    apply (rule hoare_grab_asm)
-  proof -
-    assume not_0: "\<not> n = 0"
-      and cover: "range_cover ptr sz ((objBitsKO val) + gbits) n"
-    then show
-      "\<lbrace>\<lambda>s. ?Pre s\<rbrace>
-       createObjects' ptr n val gbits
-     \<lbrace>\<lambda>rv s. P (list_refs_of_replies' s)\<rbrace>"
-    proof -
-      have shiftr_not_zero:" 1 \<le> ((of_nat n)::word32) << gbits"
-        using range_cover_not_zero_shift[OF not_0 cover,where gbits = gbits]
-        by (simp add:word_le_sub1)
-      note unat_of_nat_shiftl = range_cover.unat_of_nat_n_shift[OF cover,where gbits = gbits,simplified]
-      show ?thesis
-        apply (clarsimp simp: createObjects'_def unless_def alignError_def split_def)
-        apply (wp | clarsimp simp del: fun_upd_apply)+
-        apply (erule ssubst[where P = P,rotated])
-        apply (clarsimp simp: shiftL_nat data_map_insert_def[symmetric]
-                              new_cap_addrs_fold'[OF shiftr_not_zero]
-                    simp del: data_map_insert_def)
-        using range_cover.unat_of_nat_n_shift[OF cover, where gbits=gbits, simplified]
-        apply simp
-        apply (rule ext)
-        apply (rule set_eqI)
-        apply (rule iffI; clarsimp simp: map_set_def opt_map_def foldr_upd_app_if
-                                         projectKO_opt_reply list_refs_of_reply'_def
-                                  split: option.splits if_split_asm)
-         apply (cases val; fastforce)
-        apply (intro conjI impI)
-         apply clarsimp
-         apply (frule_tac x=x in retype_obj_at'_not[OF _ _ _ cover, where P=\<top>], simp+)
-          apply (simp add: semiring_normalization_rules(7))
-         apply (erule notE)
-         apply (clarsimp simp: obj_at'_def projectKOs)
-         apply (frule pspace_alignedD'; clarsimp)
-         apply (frule pspace_distinctD'; clarsimp)
-         apply (frule pspace_boundedD'; clarsimp)
-         apply (clarsimp split: kernel_object.splits)
-                 apply (rule_tac x=x2a in exI)
-                 apply (fastforce simp: projectKO_opts_defs)+
-        apply (intro allI impI)
-        apply (split kernel_object.split_asm; simp add: get_refs_def2)
-        apply (frule_tac x=x in retype_obj_at'_not[OF _ _ _ cover, where P=\<top>], simp+)
-         apply (simp add: semiring_normalization_rules(7))
-        apply (erule notE)
-        apply (clarsimp simp: obj_at'_def projectKOs)
-        apply (frule pspace_alignedD'; clarsimp)
-        apply (frule pspace_distinctD'; clarsimp)
-        apply (frule pspace_boundedD'; clarsimp)
-        apply (clarsimp split: kernel_object.splits)
-        apply (rule_tac x=x2a in exI)
-        apply (fastforce simp: projectKO_opts_defs)
-        done
-    qed
-  qed
-qed
-
-lemma createNewCaps_list_refs_of_replies':
-  assumes cover: "range_cover ptr sz (APIType_capBits ty us) n"
-  and     not_0: "n \<noteq> 0"
-  and     tysc : "ty = APIObjectType ArchTypes_H.apiobject_type.SchedContextObject
-                         \<longrightarrow> sc_size_bounds us"
-  shows
-  "\<lbrace>\<lambda>s. valid_pspace' s \<and> pspace_no_overlap' ptr sz s
-        \<and> P (list_refs_of_replies' s)\<rbrace>
-     createNewCaps ty ptr n us dev
-   \<lbrace>\<lambda>rv s. P (list_refs_of_replies' s)\<rbrace>"
-  unfolding createNewCaps_def
-  apply (clarsimp simp: ARM_H.toAPIType_def
-             split del: if_split)
-  apply (cases ty; simp add: createNewCaps_def Arch_createNewCaps_def
-                        split del: if_split)
-        apply (rename_tac apiobject_type)
-        apply (case_tac apiobject_type; simp split del: if_split)
-            apply (rule hoare_pre, wp, simp)
-           apply (insert cover not_0 tysc)
-           apply (wpsimp wp: mapM_x_wp' createObjects_list_refs_of_replies''
-                       simp: curDomain_def)
-           by (wpsimp wp: mapM_x_wp' createObjects_list_refs_of_replies''[simplified o_def]
-             | simp add: not_0 pspace_no_overlap'_def objBitsKO_def APIType_capBits_def
-                         valid_pspace'_def makeObject_tcb makeObject_endpoint objBits_def
-                         makeObject_notification pageBits_def ptBits_def pdBits_def
-                         archObjSize_def createObjects_def curDomain_def o_def scBits_simps
-                         pdeBits_def pteBits_def makeObject_sc makeObject_reply
-             | intro conjI impI )+
-
 crunch copyGlobalMappings
- for ksReadyQueues[wp]: "\<lambda>s. P (ksReadyQueues s)"
+  for ksReadyQueues[wp]: "\<lambda>s. P (ksReadyQueues s)"
   (wp: updateObject_default_inv crunch_wps)
 crunch copyGlobalMappings
   for ksReadyQueuesL1[wp]: "\<lambda>s. P (ksReadyQueuesL1Bitmap s)"
   (wp: updateObject_default_inv crunch_wps)
 crunch copyGlobalMappings
   for ksReadyQueuesL2[wp]: "\<lambda>s. P (ksReadyQueuesL2Bitmap s)"
-  (wp: updateObject_default_inv crunch_wps)
-crunch copyGlobalMappings
- for ksReleaseQueue[wp]: "\<lambda>s. P (ksReleaseQueue s)"
   (wp: updateObject_default_inv crunch_wps)
 
 crunch copyGlobalMappings
@@ -4120,31 +3940,30 @@ crunch copyGlobalMappings
 lemma createNewCaps_iflive'[wp]:
   assumes cover: "range_cover ptr sz (APIType_capBits ty us) n"
   and     not_0: "n \<noteq> 0"
-  and     tysc : "ty = APIObjectType ArchTypes_H.apiobject_type.SchedContextObject
-                         \<longrightarrow> sc_size_bounds us"
   shows
   "\<lbrace>\<lambda>s. valid_pspace' s \<and> pspace_no_overlap' ptr sz s
         \<and> if_live_then_nonz_cap' s\<rbrace>
      createNewCaps ty ptr n us dev
    \<lbrace>\<lambda>rv s. if_live_then_nonz_cap' s\<rbrace>"
   unfolding createNewCaps_def
-  apply (insert cover tysc)
-  apply (clarsimp simp: toAPIType_def)
+  apply (insert cover)
+  apply (clarsimp simp: toAPIType_def ARM_H.toAPIType_def)
   apply (cases ty, simp_all add: createNewCaps_def Arch_createNewCaps_def
                       split del: if_split)
         apply (rename_tac apiobject_type)
         apply (case_tac apiobject_type, simp_all split del: if_split)[1]
-              apply (rule hoare_pre, wp, simp)
-  by (wp mapM_x_wp' createObjects_iflive' threadSet_iflive'
-    | simp add: not_0 pspace_no_overlap'_def createObjects_def
-                valid_pspace'_def makeObject_tcb makeObject_endpoint
-                makeObject_notification objBitsKO_def curDomain_def scBits_simps
-                live_ntfn'_def live_sc'_def live_reply'_def makeObject_sc
-                APIType_capBits_def objBits_def pageBits_def makeObject_reply
-                archObjSize_def ptBits_def pdBits_def pteBits_def pdeBits_def
-        split del: if_split
-    | simp split: if_split
-    | fastforce)+
+            apply (rule hoare_pre, wp, simp)
+           apply (wp mapM_x_wp' createObjects_iflive' threadSet_iflive'
+                | simp add: not_0 pspace_no_overlap'_def createObjects_def
+                                valid_pspace'_def makeObject_tcb makeObject_endpoint
+                                 makeObject_notification objBitsKO_def
+                                 APIType_capBits_def objBits_def pageBits_def
+                                 archObjSize_def ptBits_def pdBits_def
+                                 pteBits_def pdeBits_def
+                                 curDomain_def split del:if_split
+                | simp split: if_split
+                | fastforce)+
+  done
 
 lemma createObjects_pspace_only:
   "\<lbrakk> \<And>f s. P (ksPSpace_update f s) = P s \<rbrakk>
@@ -4158,10 +3977,6 @@ lemma createObjects'_qs[wp]:
   "\<lbrace>\<lambda>s. P (ksReadyQueues s)\<rbrace> createObjects' ptr n val gbits \<lbrace>\<lambda>rv s. P (ksReadyQueues s)\<rbrace>"
   by (rule createObjects_pspace_only, simp)
 
-lemma createObjects'_rlq[wp]:
-  "\<lbrace>\<lambda>s. P (ksReleaseQueue s)\<rbrace> createObjects' ptr n val gbits \<lbrace>\<lambda>rv s. P (ksReleaseQueue s)\<rbrace>"
-  by (rule createObjects_pspace_only, simp)
-
 lemma createObjects'_qsL1[wp]:
   "\<lbrace>\<lambda>s. P (ksReadyQueuesL1Bitmap s)\<rbrace> createObjects' ptr n val gbits \<lbrace>\<lambda>rv s. P (ksReadyQueuesL1Bitmap s)\<rbrace>"
   by (rule createObjects_pspace_only, simp)
@@ -4170,9 +3985,17 @@ lemma createObjects'_qsL2[wp]:
   "\<lbrace>\<lambda>s. P (ksReadyQueuesL2Bitmap s)\<rbrace> createObjects' ptr n val gbits \<lbrace>\<lambda>rv s. P (ksReadyQueuesL2Bitmap s)\<rbrace>"
   by (rule createObjects_pspace_only, simp)
 
+(* FIXME move these 2 to TcbAcc_R *)
+lemma threadSet_qsL1[wp]:
+  "\<lbrace>\<lambda>s. P (ksReadyQueuesL1Bitmap s)\<rbrace> threadSet f t \<lbrace>\<lambda>rv s. P (ksReadyQueuesL1Bitmap s)\<rbrace>"
+  by (simp add: threadSet_def | wp updateObject_default_inv)+
+
+lemma threadSet_qsL2[wp]:
+  "\<lbrace>\<lambda>s. P (ksReadyQueuesL2Bitmap s)\<rbrace> threadSet f t \<lbrace>\<lambda>rv s. P (ksReadyQueuesL2Bitmap s)\<rbrace>"
+  by (simp add: threadSet_def | wp updateObject_default_inv)+
+
 crunch createObjects, createNewCaps
   for qs[wp]: "\<lambda>s. P (ksReadyQueues s)"
-  and rlqs[wp]: "\<lambda>s. P (ksReleaseQueue s)"
   and qsL1[wp]: "\<lambda>s. P (ksReadyQueuesL1Bitmap s)"
   and qsL2[wp]: "\<lambda>s. P (ksReadyQueuesL2Bitmap s)"
   (simp: crunch_simps wp: crunch_wps)
@@ -4227,7 +4050,7 @@ lemma copyGlobalMappings_ko_wp_at:
      apply (simp add: objBits_simps archObjSize_def)
     apply (simp add: pdeBits_def)
    apply (simp cong: if_cong split del: if_split)
-   apply (wp getObject_inv | simp split del: if_split)+
+   apply (wp getObject_inv loadObject_default_inv | simp split del: if_split)+
    apply (clarsimp simp: obj_at'_def ko_wp_at'_def projectKOs)
   apply (wp | simp)+
   done
@@ -4236,20 +4059,20 @@ lemma threadSet_ko_wp_at2':
   "\<lbrace>\<lambda>s. P (ko_wp_at' P' p s) \<and> (\<forall>tcb_x :: tcb. P' (injectKO (F tcb_x)) = P' (injectKO tcb_x))\<rbrace>
      threadSet F ptr
    \<lbrace>\<lambda>_ s. P (ko_wp_at' P' p s)\<rbrace>"
-  apply (simp add: threadSet_def split del: if_split)
-  apply (wp setObject_ko_wp_at getObject_tcb_wp | simp add: objBits_simps')+
-  apply (auto simp: ko_wp_at'_def obj_at'_def projectKOs)
-  done
+apply (simp add: threadSet_def split del: if_split)
+apply (wp setObject_ko_wp_at getObject_tcb_wp | simp add: objBits_simps')+
+apply (auto simp: ko_wp_at'_def obj_at'_def projectKOs)
+done
 
 lemma threadSet_ko_wp_at2'_futz:
   "\<lbrace>\<lambda>s. P (ko_wp_at' P' p s) \<and> obj_at' Q ptr s
-           \<and> (\<forall>tcb_x :: tcb. Q tcb_x \<longrightarrow> P' (injectKO (F tcb_x)) = P' (injectKO tcb_x))\<rbrace>
-       threadSet F ptr
-     \<lbrace>\<lambda>_ s. P (ko_wp_at' P' p s)\<rbrace>"
-  apply (simp add: threadSet_def split del: if_split)
-  apply (wp setObject_ko_wp_at getObject_tcb_wp | simp add: objBits_simps')+
-  apply (auto simp: ko_wp_at'_def obj_at'_def projectKOs)
-  done
+         \<and> (\<forall>tcb_x :: tcb. Q tcb_x \<longrightarrow> P' (injectKO (F tcb_x)) = P' (injectKO tcb_x))\<rbrace>
+     threadSet F ptr
+   \<lbrace>\<lambda>_ s. P (ko_wp_at' P' p s)\<rbrace>"
+apply (simp add: threadSet_def split del: if_split)
+apply (wp setObject_ko_wp_at getObject_tcb_wp | simp add: objBits_simps')+
+apply (auto simp: ko_wp_at'_def obj_at'_def projectKOs)
+done
 
 lemma mapM_x_threadSet_createNewCaps_futz:
   "\<lbrace>\<lambda>s. P (ko_wp_at' P' p s) \<and> (\<forall>addr\<in>set addrs. obj_at' (\<lambda>tcb. \<not>tcbQueued tcb \<and> tcbState tcb = Inactive) addr s)
@@ -4268,7 +4091,7 @@ lemma mapM_x_threadSet_createNewCaps_futz:
 lemma createObjects_makeObject_not_tcbQueued:
   assumes "range_cover ptr sz (objBitsKO tcb) n"
   assumes "n \<noteq> 0" "tcb = injectKO (makeObject::tcb)"
-  shows "\<lbrace>\<lambda>s. pspace_no_overlap' ptr sz s \<and> pspace_aligned' s \<and> pspace_distinct' s \<and> pspace_bounded' s\<rbrace>
+  shows "\<lbrace>\<lambda>s. pspace_no_overlap' ptr sz s \<and> pspace_aligned' s \<and> pspace_distinct' s\<rbrace>
            createObjects ptr n tcb 0
          \<lbrace>\<lambda>rv s. \<forall>addr\<in>set rv. obj_at' (\<lambda>tcb. \<not> tcbQueued tcb \<and> tcbState tcb = Structures_H.thread_state.Inactive) addr s\<rbrace>"
   apply (rule hoare_strengthen_post[OF createObjects_ko_at_strg[where 'a=tcb]])
@@ -4279,31 +4102,29 @@ lemma createObjects_makeObject_not_tcbQueued:
 
 lemma createObjects_ko_wp_at2:
   "\<lbrace>\<lambda>s. range_cover ptr sz (objBitsKO ko + gbits) n \<and> n \<noteq> 0
-      \<and> pspace_aligned' s \<and> pspace_distinct' s \<and> pspace_bounded' s
+      \<and> pspace_aligned' s \<and> pspace_distinct' s
       \<and> P (ko_wp_at' P' p s)
       \<and> (P' ko \<longrightarrow> P True)
       \<and> pspace_no_overlap' ptr sz s\<rbrace>
     createObjects ptr n ko gbits
    \<lbrace>\<lambda>_ s. P (ko_wp_at' P' p s)\<rbrace>"
-  apply (simp add: createObjects_def)
-  apply (wp createObjects_orig_ko_wp_at2')
-  apply auto
-  done
+apply (simp add: createObjects_def)
+apply (wp createObjects_orig_ko_wp_at2')
+apply auto
+done
 
 lemma createNewCaps_ko_wp_atQ':
   "\<lbrace>(\<lambda>s. P (ko_wp_at' P' p s)
        \<and> range_cover ptr sz (APIType_capBits ty us) n \<and> n \<noteq> 0
-       \<and> (ty = APIObjectType ArchTypes_H.apiobject_type.SchedContextObject
-               \<longrightarrow> sc_size_bounds us)
-       \<and> pspace_aligned' s \<and> pspace_distinct' s \<and> pspace_bounded' s
+       \<and> pspace_aligned' s \<and> pspace_distinct' s
        \<and> pspace_no_overlap' ptr sz s)
        and K (\<forall>pde_x :: pde. P' (injectKO pde_x)
                    \<longrightarrow> (\<forall>pde_y :: pde. P' (injectKO pde_y)))
        and K (\<forall>d (tcb_x :: tcb). \<not>tcbQueued tcb_x \<and> tcbState tcb_x = Inactive
                    \<longrightarrow> P' (injectKO (tcb_x \<lparr> tcbDomain := d \<rparr>)) = P' (injectKO tcb_x))
-       and (\<lambda>s. \<forall>v. makeObjectKO dev us (ksCurDomain s) (Inr ty) = Some v
+       and K (\<forall>v. makeObjectKO d (Inr ty) = Some v
                  \<longrightarrow> P' v \<longrightarrow> P True)\<rbrace>
-     createNewCaps ty ptr n us dev
+     createNewCaps ty ptr n us d
    \<lbrace>\<lambda>rv s. P (ko_wp_at' P' p s)\<rbrace>"
   apply (rule hoare_name_pre_state)
   apply (clarsimp simp: createNewCaps_def ARM_H.toAPIType_def
@@ -4313,14 +4134,19 @@ lemma createNewCaps_ko_wp_atQ':
         apply (rename_tac apiobject_type)
         apply (case_tac apiobject_type, simp_all split del: if_split)[1]
             apply (rule hoare_pre, wp, simp)
-  by (wpsimp wp: mapM_x_wp' createObjects_makeObject_not_tcbQueued
-                 createObjects_obj_at createObjects_ko_wp_at2[where sz=sz]
-                 copyGlobalMappings_ko_wp_at[where v="\<forall>pde :: pde. P' (injectKO pde)"]
-           split_del: if_split
-           simp: curDomain_def APIType_capBits_def objBitsKO_def objBits_def makeObjectKO_def
-                 pageBits_def pdBits_def ptBits_def scBits_simps
-                 pteBits_def pdeBits_def sc_size_bounds_def archObjSize_def
-    | split if_split_asm[where Q=dev] | fastforce)+
+           apply ((wp mapM_x_threadSet_createNewCaps_futz
+                     mapM_x_wp'
+                     createObjects_obj_at
+                     createObjects_ko_wp_at2 createObjects_makeObject_not_tcbQueued
+                     copyGlobalMappings_ko_wp_at[where v="\<forall>pde :: pde. P' (injectKO pde)"]
+                   | simp add: makeObjectKO_def objBitsKO_def archObjSize_def APIType_capBits_def
+                               objBits_def pageBits_def pdBits_def ptBits_def curDomain_def
+                               pteBits_def pdeBits_def
+                          split del: if_split
+                   | split if_split_asm[where Q=d]
+                   | intro conjI impI | fastforce)+)
+  done
+
 
 lemmas createNewCaps_ko_wp_at'
     = createNewCaps_ko_wp_atQ'[simplified, unfolded fold_K]
@@ -4335,34 +4161,29 @@ lemmas createNewCaps_obj_at2 =
 lemma createNewCaps_obj_at'':
   "\<lbrace>\<lambda>s. obj_at' (P :: ('a :: pspace_storable) \<Rightarrow> bool) p s
        \<and> range_cover ptr sz (APIType_capBits ty us) n \<and> n \<noteq> 0
-       \<and> pspace_aligned' s \<and> pspace_distinct' s \<and> pspace_bounded' s
+       \<and> pspace_aligned' s \<and> pspace_distinct' s
        \<and> pspace_no_overlap' ptr sz s
-       \<and> (ty = APIObjectType ArchTypes_H.apiobject_type.SchedContextObject
-                \<longrightarrow> sc_size_bounds us)
        \<and> (koType(TYPE('a)) = koType(TYPE(pde))
                \<longrightarrow> (\<forall>x. P x)
                 \<and> (\<forall>pde :: pde. \<exists>x :: 'a. injectKO x = injectKO pde))
-       \<and> (\<forall>tcb d. \<not>tcbQueued tcb \<and> tcbState tcb = Inactive
-               \<longrightarrow> ((\<exists>obj :: 'a. injectKOS obj = KOTCB (tcb\<lparr>tcbDomain := d\<rparr>) \<and> P obj)
-                       \<longleftrightarrow> (\<exists>obj :: 'a. injectKOS obj = KOTCB tcb \<and> P obj)))\<rbrace>
+       \<and> (\<forall>tcb d. \<not>tcbQueued tcb \<and> tcbState tcb = Inactive \<longrightarrow> ((\<exists>obj :: 'a. injectKOS obj = KOTCB (tcb\<lparr>tcbDomain := d\<rparr>) \<and> P obj) \<longleftrightarrow> (\<exists>obj :: 'a. injectKOS obj = KOTCB tcb \<and> P obj)))\<rbrace>
      createNewCaps ty ptr n us d
    \<lbrace>\<lambda>rv s. obj_at' P p s\<rbrace>"
   apply (simp add: obj_at'_real_def)
   apply (wp createNewCaps_ko_wp_at')
   apply clarsimp
   apply (intro conjI impI)
-     apply simp+
-   apply (clarsimp simp: projectKOs dest!: iffD1 [OF project_koType, OF exI])
-   apply (clarsimp simp:project_inject)+
-  done
+    apply simp+
+    apply clarsimp
+  apply (clarsimp simp: projectKOs dest!: iffD1 [OF project_koType, OF exI])
+  apply (clarsimp simp:project_inject)+
+done
 
 lemma createNewCaps_obj_at':
   "\<lbrace>\<lambda>s. obj_at' (P :: ('a :: pspace_storable) \<Rightarrow> bool) p s
        \<and> range_cover ptr sz (APIType_capBits ty us) n \<and> n \<noteq> 0
-       \<and> pspace_aligned' s \<and> pspace_distinct' s \<and> pspace_bounded' s
+       \<and> pspace_aligned' s \<and> pspace_distinct' s
        \<and> pspace_no_overlap' ptr sz s
-       \<and> (ty = APIObjectType ArchTypes_H.apiobject_type.SchedContextObject
-                \<longrightarrow> sc_size_bounds us)
        \<and> koType(TYPE('a)) \<noteq> koType(TYPE(pde))
        \<and> (\<forall>tcb d. \<not>tcbQueued tcb \<and> tcbState tcb = Inactive \<longrightarrow> ((\<exists>obj :: 'a. injectKOS obj = KOTCB (tcb\<lparr>tcbDomain := d\<rparr>) \<and> P obj) \<longleftrightarrow> (\<exists>obj :: 'a. injectKOS obj = KOTCB tcb \<and> P obj)))\<rbrace>
      createNewCaps ty ptr n us d
@@ -4377,8 +4198,6 @@ lemma createNewCaps_cur:
   "\<lbrakk>range_cover ptr sz (APIType_capBits ty us) n ; n \<noteq> 0\<rbrakk> \<Longrightarrow>
    \<lbrace>\<lambda>s. valid_pspace' s \<and>
         pspace_no_overlap' ptr sz s \<and>
-        (ty = APIObjectType ArchTypes_H.apiobject_type.SchedContextObject
-                \<longrightarrow> sc_size_bounds us) \<and>
         cur_tcb' s\<rbrace>
       createNewCaps ty ptr n us d
    \<lbrace>\<lambda>rv. cur_tcb'\<rbrace>"
@@ -4398,8 +4217,6 @@ lemma createNewCaps_ifunsafe':
   "\<lbrace>\<lambda>s. valid_pspace' s \<and>
         pspace_no_overlap' ptr sz s \<and>
         range_cover ptr sz (APIType_capBits ty us) n \<and> n \<noteq> 0 \<and>
-        (ty = APIObjectType ArchTypes_H.apiobject_type.SchedContextObject
-               \<longrightarrow> sc_size_bounds us) \<and>
         if_unsafe_then_cap' s\<rbrace>
       createNewCaps ty ptr n us d
    \<lbrace>\<lambda>rv s. if_unsafe_then_cap' s\<rbrace>"
@@ -4409,8 +4226,10 @@ lemma createNewCaps_ifunsafe':
    apply (rule hoare_use_eq_irq_node' [OF createNewCaps_ksInterrupt])
    apply (wp hoare_vcg_all_lift hoare_vcg_disj_lift
              createNewCaps_cte_wp_at2 hoare_vcg_ex_lift)
-  by (auto simp: makeObject_cte pspace_no_overlap'_def sc_size_bounds_def
-                valid_pspace'_def)
+  apply (simp add: makeObject_cte pspace_no_overlap'_def
+                   valid_pspace'_def)
+  apply auto
+  done
 
 lemma createObjects_nosch'[wp]:
   "\<lbrace>\<lambda>s. P (ksSchedulerAction s)\<rbrace>
@@ -4437,10 +4256,10 @@ lemma createObjects_idle':
   apply (rule hoare_pre)
    apply (clarsimp simp add: valid_idle'_def pred_tcb_at'_def)
    apply (rule hoare_vcg_conj_lift)
-   apply (rule hoare_as_subst [OF createObjects'_it])
-   apply (wp createObjects_orig_obj_at'
-             createObjects_orig_cte_wp_at2'
-             hoare_vcg_all_lift | simp)+
+    apply (rule hoare_as_subst [OF createObjects'_it])
+    apply (wp createObjects_orig_obj_at'
+              createObjects_orig_cte_wp_at2'
+              hoare_vcg_all_lift | simp)+
   apply (clarsimp simp: valid_idle'_def projectKOs o_def
                         pred_tcb_at'_def valid_pspace'_def
                   cong: option.case_cong)
@@ -4449,8 +4268,6 @@ lemma createObjects_idle':
 
 lemma createNewCaps_idle'[wp]:
   "\<lbrace>valid_idle' and valid_pspace' and pspace_no_overlap' ptr sz
-       and K (ty = APIObjectType ArchTypes_H.apiobject_type.SchedContextObject
-               \<longrightarrow> sc_size_bounds us)
        and K (range_cover ptr sz (APIType_capBits ty us) n \<and> n \<noteq> 0)\<rbrace>
    createNewCaps ty ptr n us d
    \<lbrace>\<lambda>rv. valid_idle'\<rbrace>"
@@ -4459,13 +4276,18 @@ lemma createNewCaps_idle'[wp]:
              split del: if_split)
   apply (cases ty, simp_all add: Arch_createNewCaps_def
                       split del: if_split)
-         apply (rename_tac apiobject_type)
-         apply (case_tac apiobject_type, simp_all split del: if_split)[1]
-  by (wpsimp wp: createObjects_idle'[where sz=sz] mapM_x_wp' split_del: if_split
-           simp: curDomain_def APIType_capBits_def createObjects_def
-    | simp add: tcb_cte_cases_def projectKO_opt_tcb projectKO_opt_cte makeObject_tcb makeObject_cte
-                objBits_def objBitsKO_def ptBits_def pdBits_def pteBits_def pdeBits_def pageBits_def
-                scBits_simps archObjSize_def)+
+        apply (rename_tac apiobject_type)
+        apply (case_tac apiobject_type, simp_all split del: if_split)[1]
+            apply wpsimp
+           apply (wpsimp wp: mapM_x_wp' createObjects_idle' threadSet_idle'
+                  | simp add: projectKO_opt_tcb projectKO_opt_cte
+                              makeObject_cte makeObject_tcb archObjSize_def
+                              tcb_cte_cases_def objBitsKO_def APIType_capBits_def
+                              ptBits_def pdBits_def pageBits_def objBits_def
+                              createObjects_def pteBits_def pdeBits_def
+                  | intro conjI impI
+                  | clarsimp simp: curDomain_def)+
+  done
 
 crunch createNewCaps
   for ksArch[wp]: "\<lambda>s. P (ksArchState s)"
@@ -4476,10 +4298,8 @@ crunch createNewCaps
 
 lemma createNewCaps_global_refs':
   "\<lbrace>\<lambda>s. range_cover ptr sz (APIType_capBits ty us) n \<and> n \<noteq> 0
-       \<and> pspace_aligned' s \<and> pspace_distinct' s \<and> pspace_bounded' s
+       \<and> pspace_aligned' s \<and> pspace_distinct' s
        \<and> pspace_no_overlap' ptr sz s \<and> valid_global_refs' s
-       \<and> (ty = APIObjectType ArchTypes_H.apiobject_type.SchedContextObject
-                \<longrightarrow> sc_size_bounds us)
        \<and> 0 < gsMaxObjectSize s\<rbrace>
      createNewCaps ty ptr n us d
    \<lbrace>\<lambda>rv. valid_global_refs'\<rbrace>"
@@ -4495,7 +4315,8 @@ lemma createNewCaps_global_refs':
    apply (rule hoare_use_eq [where f=irq_node', OF createNewCaps_ksInterrupt])
    apply (rule hoare_use_eq [where f=gsMaxObjectSize], wp)
    apply (wp hoare_vcg_all_lift createNewCaps_cte_wp_at2[where sz=sz])
-  apply (clarsimp simp: cte_wp_at_ctes_of global_refs'_def sc_size_bounds_def makeObject_cte)
+  apply (clarsimp simp: cte_wp_at_ctes_of global_refs'_def
+                        makeObject_cte)
   apply (auto simp: linorder_not_less ball_ran_eq)
   done
 
@@ -4506,9 +4327,7 @@ lemma koTypeOf_eq_UserDataT:
 
 lemma createNewCaps_valid_arch_state:
   "\<lbrace>(\<lambda>s. valid_arch_state' s \<and> valid_pspace' s \<and> pspace_no_overlap' ptr sz s
-        \<and> (tp = APIObjectType ArchTypes_H.CapTableObject \<longrightarrow> us > 0)
-        \<and> (ty = APIObjectType ArchTypes_H.apiobject_type.SchedContextObject
-                \<longrightarrow> sc_size_bounds us))
+        \<and> (tp = APIObjectType ArchTypes_H.CapTableObject \<longrightarrow> us > 0))
        and K (range_cover ptr sz (APIType_capBits ty us) n \<and> n \<noteq> 0)\<rbrace>
      createNewCaps ty ptr n us d
    \<lbrace>\<lambda>rv. valid_arch_state'\<rbrace>"
@@ -4550,9 +4369,7 @@ lemma valid_irq_handlers_cte_wp_at_form':
 
 lemma createNewCaps_irq_handlers':
   "\<lbrace>valid_irq_handlers' and pspace_no_overlap' ptr sz
-       and pspace_aligned' and pspace_distinct' and pspace_bounded'
-       and K (ty = APIObjectType ArchTypes_H.apiobject_type.SchedContextObject
-                   \<longrightarrow> sc_size_bounds us)
+       and pspace_aligned' and pspace_distinct'
        and K (range_cover ptr sz (APIType_capBits ty us) n \<and> n \<noteq> 0)\<rbrace>
      createNewCaps ty ptr n us d
    \<lbrace>\<lambda>rv. valid_irq_handlers'\<rbrace>"
@@ -4560,7 +4377,7 @@ lemma createNewCaps_irq_handlers':
    apply (wp hoare_vcg_all_lift hoare_vcg_disj_lift
              createNewCaps_cte_wp_at2)
   apply (clarsimp simp: makeObject_cte)
-  apply (auto simp: sc_size_bounds_def)
+  apply auto
   done
 
 lemma valid_pde_mappings'_def3:
@@ -4573,7 +4390,7 @@ lemma valid_pde_mappings'_def3:
 
 lemma createObjects'_pde_mappings'[wp]:
   "\<lbrace>\<lambda>s. valid_pde_mappings' s \<and> range_cover ptr sz (objBitsKO val + gbits) n  \<and> n \<noteq> 0
-            \<and> pspace_aligned' s \<and> pspace_distinct' s \<and> pspace_bounded' s
+            \<and> pspace_aligned' s \<and> pspace_distinct' s
             \<and> pspace_no_overlap' ptr sz s
             \<and> (\<forall>pde. projectKO_opt val = Some pde \<longrightarrow> pde = InvalidPDE)\<rbrace>
        createObjects' ptr n val gbits
@@ -4589,7 +4406,7 @@ lemma createObjects'_pde_mappings'[wp]:
 
 lemma createObjects_pde_mappings'[wp]:
   "\<lbrace>\<lambda>s. valid_pde_mappings' s \<and> range_cover ptr sz (objBitsKO ko + gbits) n  \<and> n \<noteq> 0
-            \<and> pspace_aligned' s \<and> pspace_distinct' s \<and> pspace_bounded' s
+            \<and> pspace_aligned' s \<and> pspace_distinct' s
             \<and> pspace_no_overlap' ptr sz s
             \<and> (\<forall>pde. projectKO_opt ko = Some pde \<longrightarrow> pde = InvalidPDE)\<rbrace>
        createObjects ptr n ko gbits
@@ -4635,10 +4452,8 @@ lemma mapM_x_copyGlobalMappings_pde_mappings':
 
 lemma createNewCaps_pde_mappings'[wp]:
   "\<lbrace>\<lambda>s. valid_pde_mappings' s \<and> range_cover ptr sz (APIType_capBits ty us) n \<and> n \<noteq> 0
-            \<and> (ty = APIObjectType ArchTypes_H.apiobject_type.SchedContextObject
-                 \<longrightarrow> sc_size_bounds us)
             \<and> valid_arch_state' s
-            \<and> pspace_aligned' s \<and> pspace_distinct' s \<and> pspace_bounded' s
+            \<and> pspace_aligned' s \<and> pspace_distinct' s
             \<and> pspace_no_overlap' ptr sz s\<rbrace>
        createNewCaps ty ptr n us d
    \<lbrace>\<lambda>_. valid_pde_mappings'\<rbrace>"
@@ -4664,8 +4479,9 @@ lemma createNewCaps_pde_mappings'[wp]:
   apply (case_tac ty; simp)
         apply (rename_tac apiobject_type)
         apply (case_tac apiobject_type)
-  by (auto simp: ARM_H.toAPIType_def objBits_simps ptBits_def pageBits_def pteBits_def pdeBits_def
-                 makeObject_pde valid_arch_state'_def pdBits_def page_directory_at'_def scBits_simps)
+  apply (auto simp: ARM_H.toAPIType_def objBits_simps ptBits_def pageBits_def pteBits_def pdeBits_def
+                    makeObject_pde valid_arch_state'_def pdBits_def page_directory_at'_def)
+  done
 
 lemma createObjects'_irq_states' [wp]:
   "\<lbrace>valid_irq_states'\<rbrace> createObjects' a b c d \<lbrace>\<lambda>_. valid_irq_states'\<rbrace>"
@@ -4681,6 +4497,9 @@ crunch createNewCaps
 crunch createObjects
   for ksMachine[wp]: "\<lambda>s. P (ksMachineState s)"
   (simp: crunch_simps unless_def)
+crunch createObjects
+  for cur_domain[wp]: "\<lambda>s. P (ksCurDomain s)"
+  (simp: unless_def)
 
 lemma createObjects_valid_bitmaps:
   "createObjects' ptr n val gbits \<lbrace>valid_bitmaps\<rbrace>"
@@ -4840,14 +4659,9 @@ lemma mapM_x_threadSet_valid_pspace:
 lemma createNewCaps_valid_pspace:
   assumes  not_0: "n \<noteq> 0"
   and      cover: "range_cover ptr sz (APIType_capBits ty us) n"
-  and       tysc: "ty = APIObjectType ArchTypes_H.apiobject_type.SchedContextObject
-                     \<longrightarrow> sc_size_bounds us"
-  shows
-  "\<lbrace>\<lambda>s. pspace_no_overlap' ptr sz s \<and> valid_pspace' s
-     \<and> caps_no_overlap'' ptr sz s \<and> ptr \<noteq> 0 \<and> caps_overlap_reserved' {ptr..ptr + of_nat n * 2^(APIType_capBits ty us) - 1} s
-     \<and> ksCurDomain s \<le> maxDomain\<rbrace>
-   createNewCaps ty ptr n us dev
-   \<lbrace>\<lambda>r. valid_pspace'\<rbrace>"
+  shows "\<lbrace>\<lambda>s. pspace_no_overlap' ptr sz s \<and> valid_pspace' s
+  \<and> caps_no_overlap'' ptr sz s \<and> ptr \<noteq> 0 \<and> caps_overlap_reserved' {ptr..ptr + of_nat n * 2^(APIType_capBits ty us) - 1} s \<and> ksCurDomain s \<le> maxDomain\<rbrace>
+  createNewCaps ty ptr n us dev \<lbrace>\<lambda>r. valid_pspace'\<rbrace>"
   unfolding createNewCaps_def Arch_createNewCaps_def
   using valid_obj_makeObject_rules
   apply (clarsimp simp: ARM_H.toAPIType_def
@@ -4855,22 +4669,17 @@ lemma createNewCaps_valid_pspace:
   apply (cases ty, simp_all split del: if_split)
         apply (rename_tac apiobject_type)
         apply (case_tac apiobject_type, simp_all split del: if_split)
-              apply (rule hoare_pre, wp, clarsimp)
-             apply (insert cover tysc)
-             (* for TCBObject, we need to know a bit more about tcbDomain *)
-             apply (simp add: curDomain_def)
-             apply (rule bind_wp[OF _ gets_sp])
-             apply (clarsimp simp: createObjects_def)
-             apply (rule hoare_assume_pre)
-  by (wpsimp wp: createObjects_valid_pspace_untyped'[of dev us _ "Inr ty", where ptr=ptr]
-                 mapM_x_wp'
-      split_del: if_split
-           simp: createObjects_def makeObjectKO_def objBits_def objBitsKO_def scBits_simps
-                 not_0 APIType_capBits_def field_simps pageBits_def
-                 archObjSize_def ptBits_def pteBits_def scBits_simps
-                 pt_bits_def word_size_bits_def  archObjSize_def ptBits_def pdBits_def
-                 pteBits_def pdeBits_def
-      | simp add: power_add)+
+            apply (rule hoare_pre, wp, clarsimp)
+           apply (insert cover)
+           apply (wp createObjects_valid_pspace_untyped' [OF _ not_0 , where ty="Inr ty" and sz = sz]
+                     mapM_x_threadSet_valid_pspace mapM_x_wp'
+                 | simp add: makeObjectKO_def archObjSize_def APIType_capBits_def
+                             objBits_simps pageBits_def pdBits_def ptBits_def not_0
+                             createObjects_def curDomain_def
+                             pteBits_def pdeBits_def
+                 | intro conjI impI
+                 | simp add: power_add field_simps)+
+done
 
 lemma copyGlobalMappings_inv[wp]:
   "\<lbrace>\<lambda>s. P (ksMachineState s)\<rbrace>
@@ -4900,11 +4709,8 @@ lemma doMachineOp_mapM_x_wp:
 
 
 lemma createNewCaps_vms:
-  "\<lbrace>pspace_aligned' and pspace_distinct' and pspace_bounded'
-    and pspace_no_overlap' ptr sz and
+  "\<lbrace>pspace_aligned' and pspace_distinct' and pspace_no_overlap' ptr sz and
     K (range_cover ptr sz (APIType_capBits ty us) n \<and> 0 < n) and
-    K (ty = APIObjectType ArchTypes_H.apiobject_type.SchedContextObject
-                \<longrightarrow> sc_size_bounds us) and
     valid_machine_state'\<rbrace>
    createNewCaps ty ptr n us dev
    \<lbrace>\<lambda>archCaps. valid_machine_state'\<rbrace>"
@@ -4924,8 +4730,9 @@ lemma createNewCaps_vms:
                split del: if_split
          | assumption)+
   apply (case_tac ty)
-  by (auto simp: APIType_capBits_def archObjSize_def objBits_simps pageBits_def ptBits_def
-                 pdBits_def ARM_H.toAPIType_def object_type.splits pteBits_def pdeBits_def scBits_simps)
+   apply (auto simp: APIType_capBits_def archObjSize_def objBits_simps pageBits_def ptBits_def
+                     pdBits_def ARM_H.toAPIType_def object_type.splits pteBits_def pdeBits_def)
+  done
 
 lemma createObjects_pspace_domain_valid':
   "\<lbrace>\<lambda>s. range_cover ptr sz (objBitsKO val + gbits) n \<and> n \<noteq> 0
@@ -4963,7 +4770,7 @@ lemma createObjects_pspace_domain_valid:
   apply (simp add: objBits_def)
   done
 
-crunch copyGlobalMappings, doMachineOp
+crunch copyGlobalMappings
   for pspace_domain_valid[wp]: "pspace_domain_valid"
   (wp: crunch_wps)
 
@@ -4973,9 +4780,7 @@ crunch doMachineOp
 lemma createNewCaps_pspace_domain_valid[wp]:
   "\<lbrace>pspace_domain_valid and K ({ptr .. (ptr && ~~ mask sz) + 2 ^ sz - 1}
             \<inter> kernel_data_refs = {}
-        \<and> range_cover ptr sz (APIType_capBits ty us) n \<and> 0 < n)
-       and K (ty = APIObjectType ArchTypes_H.apiobject_type.SchedContextObject
-                \<longrightarrow> sc_size_bounds us)\<rbrace>
+        \<and> range_cover ptr sz (APIType_capBits ty us) n \<and> 0 < n)\<rbrace>
     createNewCaps ty ptr n us dev
    \<lbrace>\<lambda>rv. pspace_domain_valid\<rbrace>"
   apply (simp add: createNewCaps_def)
@@ -4986,8 +4791,14 @@ lemma createNewCaps_pspace_domain_valid[wp]:
                      split del: if_split)+
   apply (simp add: ARM_H.toAPIType_def
             split: object_type.splits)
-  by (auto simp: objBits_simps APIType_capBits_def pageBits_def scBits_simps
-                 pteBits_def pdeBits_def archObjSize_def ptBits_def pdBits_def)
+  apply (auto simp: objBits_simps APIType_capBits_def pageBits_def
+                    pteBits_def pdeBits_def
+                    archObjSize_def ptBits_def pdBits_def)
+  done
+
+crunch createNewCaps
+  for cur_domain[wp]: "\<lambda>s. P (ksCurDomain s)"
+  (wp: crunch_wps)
 
 (* FIXME: move *)
 lemma ct_idle_or_in_cur_domain'_lift_futz:
@@ -5010,26 +4821,22 @@ proof -
   show ?thesis
     apply (simp add: ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def)
     apply (rule hoare_pre)
-     apply (wps a b c d)
-     apply (wp hoare_weak_lift_imp e' hoare_vcg_disj_lift)
+    apply (wps a b c d)
+    apply (wp hoare_weak_lift_imp e' hoare_vcg_disj_lift)
     apply (auto simp: obj_at'_def ct_in_state'_def projectKOs st_tcb_at'_def)
     done
 qed
 
 lemma createNewCaps_ct_idle_or_in_cur_domain':
-  "\<lbrace>ct_idle_or_in_cur_domain' and pspace_aligned' and pspace_distinct' and pspace_bounded'
-    and pspace_no_overlap' ptr sz
-    and K (ty = APIObjectType ArchTypes_H.apiobject_type.SchedContextObject
-                \<longrightarrow> sc_size_bounds us)
-    and ct_active' and K (range_cover ptr sz (APIType_capBits ty us) n \<and> 0 < n) \<rbrace>
+  "\<lbrace>ct_idle_or_in_cur_domain' and pspace_aligned' and pspace_distinct' and pspace_no_overlap' ptr sz and ct_active' and K (range_cover ptr sz (APIType_capBits ty us) n \<and> 0 < n) \<rbrace>
     createNewCaps ty ptr n us dev
    \<lbrace>\<lambda>rv. ct_idle_or_in_cur_domain'\<rbrace>"
-  by (wp ct_idle_or_in_cur_domain'_lift_futz createNewCaps_obj_at'[where sz=sz] | simp)+
+apply (wp ct_idle_or_in_cur_domain'_lift_futz createNewCaps_obj_at'[where sz=sz] | simp)+
+done
 
 lemma sch_act_wf_lift_asm_futz:
   assumes tcb: "\<And>P t. \<lbrace>st_tcb_at' P t and Q \<rbrace> f \<lbrace>\<lambda>rv. st_tcb_at' P t\<rbrace>"
-  assumes tcbDomain: "\<And>P t. \<lbrace>obj_at' (\<lambda>tcb. runnable' (tcbState tcb) \<longrightarrow> P (tcbDomain tcb)) t and Q\<rbrace>
-                             f \<lbrace>\<lambda>rv. obj_at' (\<lambda>tcb. runnable' (tcbState tcb) \<longrightarrow> P (tcbDomain tcb)) t\<rbrace>"
+  assumes tcbDomain: "\<And>P t. \<lbrace>obj_at' (\<lambda>tcb. runnable' (tcbState tcb) \<longrightarrow> P (tcbDomain tcb)) t and Q\<rbrace> f \<lbrace>\<lambda>rv. obj_at' (\<lambda>tcb. runnable' (tcbState tcb) \<longrightarrow> P (tcbDomain tcb)) t\<rbrace>"
   assumes kCT: "\<And>P. \<lbrace>\<lambda>s. P (ksCurThread s)\<rbrace> f \<lbrace>\<lambda>_ s. P (ksCurThread s)\<rbrace>"
   assumes kCD: "\<And>P. \<lbrace>\<lambda>s. P (ksCurDomain s)\<rbrace> f \<lbrace>\<lambda>_ s. P (ksCurDomain s)\<rbrace>"
   assumes ksA: "\<And>P. \<lbrace>\<lambda>s. P (ksSchedulerAction s)\<rbrace> f \<lbrace>\<lambda>_ s. P (ksSchedulerAction s)\<rbrace>"
@@ -5061,11 +4868,7 @@ lemma sch_act_wf_lift_asm_futz:
   done
 
 lemma createNewCaps_sch_act_wf:
-  "\<lbrace>(\<lambda>s. sch_act_wf (ksSchedulerAction s) s) and pspace_aligned' and pspace_distinct'
-       and pspace_bounded' and pspace_no_overlap' ptr sz
-       and K (ty = APIObjectType ArchTypes_H.apiobject_type.SchedContextObject
-                \<longrightarrow> sc_size_bounds us)
-       and K (range_cover ptr sz (APIType_capBits ty us) n \<and> 0 < n)\<rbrace>
+  "\<lbrace>(\<lambda>s. sch_act_wf (ksSchedulerAction s) s) and pspace_aligned' and pspace_distinct' and pspace_no_overlap' ptr sz and K (range_cover ptr sz (APIType_capBits ty us) n \<and> 0 < n)\<rbrace>
      createNewCaps ty ptr n us dev
    \<lbrace>\<lambda>_ s. sch_act_wf (ksSchedulerAction s) s\<rbrace>"
   apply (wp sch_act_wf_lift_asm_futz
@@ -5101,45 +4904,39 @@ crunch createNewCaps
   (wp: mapM_x_wp' simp: crunch_simps)
 
 lemma createObjects_null_filter':
-  "\<lbrace>\<lambda>s. P (null_filter' (ctes_of s)) \<and> makeObjectKO dev us d ty = Some val \<and>
+  "\<lbrace>\<lambda>s. P (null_filter' (ctes_of s)) \<and> makeObjectKO dev ty = Some val \<and>
         range_cover ptr sz (objBitsKO val + gbits) n \<and> n \<noteq> 0 \<and>
-        pspace_aligned' s \<and> pspace_distinct' s \<and> pspace_bounded' s \<and> pspace_no_overlap' ptr sz s\<rbrace>
+        pspace_aligned' s \<and> pspace_distinct' s \<and> pspace_no_overlap' ptr sz s\<rbrace>
    createObjects' ptr n val gbits
    \<lbrace>\<lambda>addrs a. P (null_filter' (ctes_of a))\<rbrace>"
-  apply (clarsimp simp: createObjects'_def split_def)
-  apply (wp unless_wp| wpc
-         | clarsimp simp: alignError_def split del: if_split simp del:fun_upd_apply)+
-  apply (subst new_cap_addrs_fold')
-   apply (simp add:unat_1_0 unat_gt_0)
-   apply (rule range_cover_not_zero_shift)
+   apply (clarsimp simp: createObjects'_def split_def)
+   apply (wp unless_wp|wpc
+          | clarsimp simp:haskell_assert_def alignError_def
+            split del: if_splits simp del:fun_upd_apply)+
+   apply (subst new_cap_addrs_fold')
+     apply (simp add:unat_1_0 unat_gt_0)
+     apply (rule range_cover_not_zero_shift)
      apply fastforce+
-  apply (subst new_cap_addrs_fold')
-   apply (simp add:unat_1_0 unat_gt_0)
-   apply (rule range_cover_not_zero_shift)
-     apply simp
-    apply assumption
-   apply simp
-  apply (subst data_map_insert_def[symmetric])+
-  apply (frule (3) retype_aligned_distinct'[where ko = val])
-   apply (erule range_cover_rel)
-    apply simp+
-  apply (frule (3) retype_aligned_distinct'(2)[where ko = val])
-   apply (erule range_cover_rel)
-    apply simp+
-  apply (frule (3) retype_aligned_distinct'(3)[where ko = val])
-   apply (erule range_cover_rel)
-    apply simp+
-  apply (frule null_filter_ctes_retype[where addrs =
-                                       "new_cap_addrs (unat ((of_nat n::word32) << gbits)) ptr val"])
-        apply assumption+
-       apply (prop_tac "objBitsKO val < word_bits")
-        apply (clarsimp simp: range_cover_def word_bits_def)
-      apply (clarsimp simp: field_simps foldr_upd_app_if[folded data_map_insert_def] shiftl_t2n
-                            range_cover.unat_of_nat_shift)+
+   apply (subst new_cap_addrs_fold')
+    apply (simp add:unat_1_0 unat_gt_0)
+    apply (rule range_cover_not_zero_shift)
+      apply simp
+     apply assumption
+    apply simp
+   apply (subst data_map_insert_def[symmetric])+
+   apply (frule(2) retype_aligned_distinct'[where ko = val])
+    apply (erule range_cover_rel)
+     apply simp+
+   apply (frule(2) retype_aligned_distinct'(2)[where ko = val])
+    apply (erule range_cover_rel)
+     apply simp+
+   apply (frule null_filter_ctes_retype
+     [where addrs = "(new_cap_addrs (unat (((of_nat n)::word32) << gbits)) ptr val)"])
+          apply assumption+
+     apply (clarsimp simp:field_simps foldr_upd_app_if[folded data_map_insert_def] shiftl_t2n range_cover.unat_of_nat_shift)+
     apply (rule new_cap_addrs_aligned[THEN bspec])
-     apply (erule range_cover.aligned[OF range_cover_rel])
-      apply simp+
-    apply (clarsimp simp: range_cover_def word_bits_def)
+    apply (erule range_cover.aligned[OF range_cover_rel])
+     apply simp+
    apply (clarsimp simp:shiftl_t2n field_simps range_cover.unat_of_nat_shift)
    apply (drule subsetD[OF new_cap_addrs_subset,rotated])
     apply (erule range_cover_rel)
@@ -5152,36 +4949,36 @@ lemma createObjects_null_filter':
     apply (drule(1) pspace_alignedD')
     apply (clarsimp)
     apply (erule is_aligned_no_overflow)
-   apply (simp del: atLeastAtMost_simps
-               add: Int_ac ptr_add_def p_assoc_help)
+    apply (simp del:atLeastAtMost_iff atLeastatMost_subset_iff atLeastLessThan_iff
+        Int_atLeastAtMost atLeastatMost_empty_iff add:Int_ac ptr_add_def p_assoc_help)
   apply (simp add:field_simps foldr_upd_app_if[folded data_map_insert_def] shiftl_t2n)
   apply auto
   done
 
 lemma createNewCaps_null_filter':
   "\<lbrace>(\<lambda>s. P (null_filter' (ctes_of s)))
-      and pspace_aligned' and pspace_distinct' and pspace_bounded' and pspace_no_overlap' ptr sz
-      and K (ty = APIObjectType ArchTypes_H.apiobject_type.SchedContextObject
-                \<longrightarrow> sc_size_bounds us)
+      and pspace_aligned' and pspace_distinct' and pspace_no_overlap' ptr sz
       and K (range_cover ptr sz (APIType_capBits ty us) n \<and> n \<noteq> 0) \<rbrace>
      createNewCaps ty ptr n us dev
    \<lbrace>\<lambda>_ s. P (null_filter' (ctes_of s))\<rbrace>"
   apply (rule hoare_gen_asm)
   apply (simp add: createNewCaps_def toAPIType_def
                    Arch_createNewCaps_def
-            split del: if_split cong: option.case_cong)
+               split del: if_split cong: option.case_cong)
   apply (cases ty, simp_all split del: if_split)
           apply (rename_tac apiobject_type)
           apply (case_tac apiobject_type, simp_all split del: if_split)
               apply (rule hoare_pre, wp,simp)
-             by (simp add: createObjects_def makeObjectKO_def scBits_simps
-                           APIType_capBits_def objBits_def pageBits_def
-                           archObjSize_def ptBits_def pdBits_def curDomain_def objBits_if_dev
-                    split del: if_split
-                | wp createObjects_null_filter'[where ty = "Inr ty" and sz = sz and dev=dev]
-                     copyGlobalMappings_ctes_of threadSet_ctes_of mapM_x_wp'
-                | simp add: objBits_simps pteBits_def pdeBits_def
-                | fastforce)+
+             apply (simp add: createObjects_def makeObjectKO_def
+                              APIType_capBits_def objBits_def pageBits_def
+                              archObjSize_def ptBits_def pdBits_def curDomain_def
+                              objBits_if_dev
+                       split del: if_split
+                    | wp createObjects_null_filter'[where ty = "Inr ty" and sz = sz and dev=dev]
+                         copyGlobalMappings_ctes_of threadSet_ctes_of mapM_x_wp'
+                    | simp add: objBits_simps pteBits_def pdeBits_def
+                    | fastforce)+
+  done
 
 crunch createNewCaps
   for gsUntypedZeroRanges[wp]: "\<lambda>s. P (gsUntypedZeroRanges s)"
@@ -5203,9 +5000,7 @@ lemma untyped_ranges_zero_inv_null_filter_cteCaps_of:
 
 lemma createNewCaps_urz:
   "\<lbrace>untyped_ranges_zero'
-      and pspace_aligned' and pspace_distinct' and pspace_bounded' and pspace_no_overlap' ptr sz
-      and K (ty = APIObjectType ArchTypes_H.apiobject_type.SchedContextObject
-                \<longrightarrow> sc_size_bounds us)
+      and pspace_aligned' and pspace_distinct' and pspace_no_overlap' ptr sz
       and K (range_cover ptr sz (APIType_capBits ty us) n \<and> n \<noteq> 0) \<rbrace>
    createNewCaps ty ptr n us dev
    \<lbrace>\<lambda>archCaps. untyped_ranges_zero'\<rbrace>"
@@ -5217,30 +5012,42 @@ lemma createNewCaps_urz:
   done
 
 lemma createNewCaps_invs':
-  "\<lbrace>((\<lambda>s. invs' s \<and> ct_active' s \<and> pspace_no_overlap' ptr sz s
+  "\<lbrace>(\<lambda>s. invs' s \<and> ct_active' s \<and> pspace_no_overlap' ptr sz s
         \<and> caps_no_overlap'' ptr sz s \<and> ptr \<noteq> 0
         \<and> {ptr .. (ptr && ~~ mask sz) + 2 ^ sz - 1} \<inter> kernel_data_refs = {}
         \<and> caps_overlap_reserved' {ptr..ptr + of_nat n * 2^(APIType_capBits ty us) - 1} s
         \<and> (ty = APIObjectType ArchTypes_H.CapTableObject \<longrightarrow> us > 0)
         \<and> gsMaxObjectSize s > 0)
-        and K (ty = APIObjectType ArchTypes_H.SchedContextObject \<longrightarrow> sc_size_bounds us))
        and K (range_cover ptr sz (APIType_capBits ty us) n \<and> n \<noteq> 0)\<rbrace>
      createNewCaps ty ptr n us dev
    \<lbrace>\<lambda>rv. invs'\<rbrace>"
   (is "\<lbrace>?P and K ?Q\<rbrace> ?f \<lbrace>\<lambda>rv. invs'\<rbrace>")
 proof (rule hoare_gen_asm, erule conjE)
   assume cover: "range_cover ptr sz (APIType_capBits ty us) n" and not_0: "n \<noteq> 0"
+  have cnc_ct_not_inQ:
+    "\<lbrace>ct_not_inQ and valid_pspace' and pspace_no_overlap' ptr sz\<rbrace>
+     createNewCaps ty ptr n us dev \<lbrace>\<lambda>_. ct_not_inQ\<rbrace>"
+    unfolding ct_not_inQ_def
+    apply (rule_tac P'="\<lambda>s. ksSchedulerAction s = ResumeCurrentThread
+                             \<longrightarrow> (obj_at' (Not \<circ> tcbQueued) (ksCurThread s) s
+                                  \<and> valid_pspace' s \<and> pspace_no_overlap' ptr sz s)"
+                    in hoare_pre_imp, clarsimp)
+    apply (rule hoare_convert_imp [OF createNewCaps_nosch])
+    apply (rule hoare_weaken_pre)
+     apply (wps createNewCaps_ct)
+     apply (wp createNewCaps_obj_at')
+    using cover not_0
+    apply (fastforce simp: valid_pspace'_def)
+    done
   show "\<lbrace>?P\<rbrace>
      createNewCaps ty ptr n us dev
    \<lbrace>\<lambda>rv. invs'\<rbrace>"
-  apply (rule hoare_gen_asm)
-  apply (simp add: invs'_def valid_dom_schedule'_def
+  apply (simp add: invs'_def valid_state'_def
                    pointerInUserData_def typ_at'_def)
     apply (rule hoare_pre)
      apply (wp createNewCaps_valid_pspace [OF not_0 cover]
-               createNewCaps_state_refs_of' [OF cover not_0]
-               createNewCaps_list_refs_of_replies' [OF cover not_0]
-               createNewCaps_iflive' [OF cover not_0]
+               createNewCaps_state_refs_of' [OF cover not_0 ]
+               createNewCaps_iflive' [OF cover not_0 ]
                irqs_masked_lift
                createNewCaps_ifunsafe'
                createNewCaps_cur [OF cover not_0]
@@ -5266,7 +5073,7 @@ qed
 
 lemma createObjects_pred_tcb_at':
   "\<lbrace>pred_tcb_at' proj P t and K (range_cover ptr sz (objBitsKO val + gbits) n \<and> n \<noteq> 0)
-     and pspace_aligned' and pspace_distinct' and pspace_bounded' and pspace_no_overlap' ptr sz\<rbrace>
+     and pspace_aligned' and pspace_distinct' and pspace_no_overlap' ptr sz\<rbrace>
   createObjects ptr n val gbits \<lbrace>\<lambda>rv. pred_tcb_at' proj P t\<rbrace>"
   apply (simp add: pred_tcb_at'_def createObjects_def)
   apply (wp createObjects_orig_obj_at')
@@ -5275,7 +5082,7 @@ lemma createObjects_pred_tcb_at':
 
 lemma createObjects_ex_cte_cap_to [wp]:
   "\<lbrace>\<lambda>s. range_cover ptr sz (objBitsKO val + gbits) n \<and> n \<noteq> 0 \<and> pspace_aligned' s \<and>
-        pspace_distinct' s \<and> pspace_bounded' s \<and> ex_cte_cap_to' p s \<and> pspace_no_overlap' ptr sz s\<rbrace>
+        pspace_distinct' s \<and> ex_cte_cap_to' p s \<and> pspace_no_overlap' ptr sz s\<rbrace>
   createObjects ptr n val gbits \<lbrace>\<lambda>r. ex_cte_cap_to' p\<rbrace>"
   apply (simp add: ex_cte_cap_to'_def createObjects_def)
   apply (rule hoare_lift_Pf2 [where f="irq_node'"])
@@ -5286,14 +5093,13 @@ lemma createObjects_ex_cte_cap_to [wp]:
 
 lemma createObjects_orig_obj_at3:
   "\<lbrace>\<lambda>s. obj_at' P p s \<and> range_cover ptr sz (objBitsKO val + gbits) n \<and> n \<noteq> 0 \<and>
-        pspace_aligned' s \<and> pspace_bounded' s \<and>
+        pspace_aligned' s \<and>
         pspace_distinct' s \<and> pspace_no_overlap' ptr sz s\<rbrace>
   createObjects ptr n val gbits \<lbrace>\<lambda>r. obj_at' P p\<rbrace>"
   by (wp createObjects_orig_obj_at'[where sz = sz] | simp add: createObjects_def)+
 
 lemma createObjects_sch:
-  "\<lbrace>(\<lambda>s. sch_act_wf (ksSchedulerAction s) s) and pspace_aligned' and pspace_distinct'
-      and pspace_bounded' and pspace_no_overlap' ptr sz
+  "\<lbrace>(\<lambda>s. sch_act_wf (ksSchedulerAction s) s) and pspace_aligned' and pspace_distinct' and pspace_no_overlap' ptr sz
       and K (range_cover ptr sz (objBitsKO val + gbits) n \<and> n \<noteq> 0)\<rbrace>
   createObjects ptr n val gbits
   \<lbrace>\<lambda>rv s. sch_act_wf (ksSchedulerAction s) s\<rbrace>"
@@ -5326,7 +5132,7 @@ lemma createObjects_no_cte_ifunsafe':
 lemma createObjects_no_cte_valid_global:
   assumes no_cte: "\<And>c. projectKO_opt val \<noteq> Some (c::cte)"
   assumes no_tcb: "\<And>t. projectKO_opt val \<noteq> Some (t::tcb)"
-  shows "\<lbrace>\<lambda>s. pspace_aligned' s \<and> pspace_distinct' s \<and> pspace_bounded' s \<and>
+  shows "\<lbrace>\<lambda>s. pspace_aligned' s \<and> pspace_distinct' s \<and>
         pspace_no_overlap' ptr sz s \<and>
         range_cover ptr sz (objBitsKO val + gbits) n \<and> n \<noteq> 0 \<and>
         valid_global_refs' s\<rbrace>
@@ -5354,7 +5160,7 @@ lemma createObjects'_typ_at:
   "\<lbrace>\<lambda>s. n \<noteq> 0 \<and>
         range_cover ptr sz (objBitsKO val + gbits) n \<and>
         typ_at' T p s \<and>
-        pspace_aligned' s \<and> pspace_distinct' s \<and> pspace_bounded' s \<and>
+        pspace_aligned' s \<and> pspace_distinct' s \<and>
         pspace_no_overlap' ptr sz s\<rbrace>
   createObjects' ptr n val gbits \<lbrace>\<lambda>r s. typ_at' T p s\<rbrace>"
   apply (rule hoare_grab_asm)+
@@ -5394,7 +5200,7 @@ lemma createObjects'_typ_at:
   done
 
 lemma createObjects_valid_arch:
-  "\<lbrace>\<lambda>s. valid_arch_state' s \<and> pspace_aligned' s \<and> pspace_distinct' s \<and> pspace_bounded' s \<and>
+  "\<lbrace>\<lambda>s. valid_arch_state' s \<and> pspace_aligned' s \<and> pspace_distinct' s \<and>
         pspace_no_overlap' ptr sz s \<and> range_cover ptr sz (objBitsKO val + gbits) n \<and> n \<noteq> 0 \<rbrace>
       createObjects ptr n val gbits
    \<lbrace>\<lambda>rv s. valid_arch_state' s\<rbrace>"
@@ -5411,7 +5217,7 @@ lemma createObjects_valid_arch:
   done
 
 lemma createObjects_irq_state:
-  "\<lbrace>\<lambda>s. pspace_aligned' s \<and> pspace_distinct' s \<and> pspace_bounded' s \<and>
+  "\<lbrace>\<lambda>s. pspace_aligned' s \<and> pspace_distinct' s \<and>
         pspace_no_overlap' ptr sz s \<and>
         range_cover ptr sz (objBitsKO val + gbits) n \<and> n \<noteq> 0 \<and>
         valid_irq_node' (irq_node' s) s\<rbrace>
@@ -5425,7 +5231,7 @@ lemma createObjects_no_cte_irq_handlers:
   assumes no_cte: "\<And>c. projectKO_opt val \<noteq> Some (c::cte)"
   assumes no_tcb: "\<And>t. projectKO_opt val \<noteq> Some (t::tcb)"
   shows
-  "\<lbrace>\<lambda>s. pspace_aligned' s \<and> pspace_distinct' s \<and> pspace_bounded' s \<and>
+  "\<lbrace>\<lambda>s. pspace_aligned' s \<and> pspace_distinct' s \<and>
         pspace_no_overlap' ptr sz s \<and>
         range_cover ptr sz (objBitsKO val + gbits) n \<and> n \<noteq> 0 \<and>
         valid_irq_handlers' s\<rbrace>
@@ -5439,7 +5245,7 @@ lemma createObjects_no_cte_irq_handlers:
   done
 
 lemma createObjects_cur':
-  "\<lbrace>\<lambda>s. pspace_aligned' s \<and> pspace_distinct' s \<and> pspace_bounded' s \<and>
+  "\<lbrace>\<lambda>s. pspace_aligned' s \<and> pspace_distinct' s \<and>
         pspace_no_overlap' ptr sz s \<and> range_cover ptr sz (objBitsKO val + gbits) n \<and> n \<noteq> 0 \<and>
         cur_tcb' s\<rbrace>
       createObjects ptr n val gbits
@@ -5453,7 +5259,7 @@ lemma createObjects_cur':
 
 lemma createObjects_vms'[wp]:
   "\<lbrace>(\<lambda>_.  (range_cover ptr sz  (objBitsKO val + gbits) n \<and> 0 < n)) and pspace_aligned' and
-     pspace_distinct' and pspace_bounded' and pspace_no_overlap' ptr sz and valid_machine_state'\<rbrace>
+     pspace_distinct' and pspace_no_overlap' ptr sz and valid_machine_state'\<rbrace>
       createObjects ptr n val gbits
    \<lbrace>\<lambda>rv. valid_machine_state'\<rbrace>"
   apply (simp add: valid_machine_state'_def pointerInUserData_def pointerInDeviceData_def
@@ -5469,10 +5275,10 @@ lemma createObjects_ct_idle_or_in_cur_domain':
        and K (range_cover ptr sz (objBitsKO val + gSize) n \<and> n \<noteq> 0)\<rbrace>
      createObjects ptr n val gSize
    \<lbrace>\<lambda>_. ct_idle_or_in_cur_domain'\<rbrace>"
-  apply (rule hoare_gen_asm)
-  apply (wp ct_idle_or_in_cur_domain'_lift_futz createObjects_obj_at_other[where sz=sz])
-    apply simp_all
-  done
+apply (rule hoare_gen_asm)
+apply (wp ct_idle_or_in_cur_domain'_lift_futz createObjects_obj_at_other[where sz=sz])
+apply simp_all
+done
 
 lemma untyped_zero_ranges_cte_def:
   "untyped_ranges_zero_inv (cteCaps_of s) rs
@@ -5483,8 +5289,12 @@ lemma untyped_zero_ranges_cte_def:
   apply (safe, metis+)
   done
 
+crunch createObjects
+  for gsUntypedZeroRanges[wp]: "\<lambda>s. P (gsUntypedZeroRanges s)"
+  (simp: unless_def)
+
 lemma createObjects_untyped_ranges_zero':
-  assumes moKO: "makeObjectKO dev us d ty = Some val"
+  assumes moKO: "makeObjectKO dev ty = Some val"
   shows
   "\<lbrace>ct_active' and valid_pspace' and pspace_no_overlap' ptr sz
        and untyped_ranges_zero'
@@ -5510,13 +5320,9 @@ lemma createObjects_untyped_ranges_zero':
   done
 
 lemma createObjects_no_cte_invs:
-  assumes moKO: "makeObjectKO dev us d ty = Some val"
+  assumes moKO: "makeObjectKO dev ty = Some val"
   assumes no_cte: "\<And>c. projectKO_opt val \<noteq> Some (c::cte)"
   assumes no_tcb: "\<And>t. projectKO_opt val \<noteq> Some (t::tcb)"
-  and     tysc: "ty = Inr (APIObjectType SchedContextObject) \<longrightarrow> sc_size_bounds us"
-  and     mdom: "ty =
-        Inr (APIObjectType ArchTypes_H.apiobject_type.TCBObject) \<longrightarrow>
-        d \<le> maxDomain"
   shows
   "\<lbrace>\<lambda>s. range_cover ptr sz ((objBitsKO val) + gbits) n \<and> n \<noteq> 0 \<and> invs' s \<and> ct_active' s
         \<and> pspace_no_overlap' ptr sz s \<and> ptr \<noteq> 0
@@ -5524,8 +5330,6 @@ lemma createObjects_no_cte_invs:
         \<and> caps_overlap_reserved' {ptr..ptr + of_nat (n * 2 ^ gbits * 2 ^ objBitsKO val) - 1} s
         \<and> caps_no_overlap'' ptr sz s \<and>
        refs_of' val = {} \<and> \<not> live' val
-        \<and> (case val of KOReply r \<Rightarrow> replyNext_of r = None \<and> replyPrev r = None
-                     | _ \<Rightarrow> True)
             \<and> (\<forall>pde. projectKO_opt val = Some pde \<longrightarrow> pde = InvalidPDE)\<rbrace>
   createObjects ptr n val gbits
   \<lbrace>\<lambda>rv. invs'\<rbrace>"
@@ -5546,77 +5350,155 @@ proof -
       apply (simp)+
     done
   show ?thesis
-    apply (rule hoare_grab_asm)+
-    apply (clarsimp simp: invs'_def valid_dom_schedule'_def)
-     apply (rule hoare_pre)
-      apply (rule hoare_vcg_conj_lift)
-       apply (simp add: createObjects_def,wp createObjects_valid_pspace_untyped')
-          apply (wp assms | simp add: objBits_def)+
-      apply (wp createObjects_sch createObjects_queues)
-      apply (rule hoare_vcg_conj_lift)
-       apply (simp add: createObjects_def)
-       apply (wp createObjects_state_refs_of'')
-       apply (wpsimp wp: createObjects_list_refs_of_replies'')
-      apply (rule hoare_vcg_conj_lift)
-       apply (simp add: createObjects_def)
-       apply (wp createObjects_iflive')
-      apply (wp createObjects_no_cte_ifunsafe' irqs_masked_lift
-                createObjects_idle' createObjects_no_cte_valid_global
-                createObjects_valid_arch createObjects_irq_state
-                createObjects_no_cte_irq_handlers createObjects_cur'
-                createObjects_queues' [OF no_tcb]
-                createObjects_release_queue' [OF no_tcb]
-                createObjects_release_queue
-                assms | simp add: objBits_def )+
-      apply (rule hoare_vcg_conj_lift)
-      apply (wp createObjects_no_cte_ifunsafe' irqs_masked_lift
-                createObjects_idle' createObjects_no_cte_valid_global
-                createObjects_valid_arch createObjects_irq_state
-                createObjects_no_cte_irq_handlers createObjects_cur'
-                createObjects_queues' [OF no_tcb] assms
-                createObjects_release_queue' [OF no_tcb]
-                createObjects_release_queue
-                createObjects_pspace_domain_valid co_ct_not_inQ
-                createObjects_ct_idle_or_in_cur_domain'
-                createObjects_untyped_ranges_zero'[OF moKO]
-            | simp)+
-    apply clarsimp
-    apply ((intro conjI; assumption?); simp add: valid_pspace'_def objBits_def)
-    done
+  apply (rule hoare_grab_asm)+
+   apply (clarsimp simp: invs'_def valid_state'_def)
+   apply wp
+   apply (rule hoare_pre)
+   apply (rule hoare_vcg_conj_lift)
+   apply (simp add: createObjects_def,wp createObjects_valid_pspace_untyped')
+   apply (wp assms | simp add: objBits_def)+
+   apply (wp createObjects_sch)
+   apply (rule hoare_vcg_conj_lift)
+    apply (simp add: createObjects_def)
+    apply (wp createObjects_state_refs_of'')
+   apply (rule hoare_vcg_conj_lift)
+    apply (simp add: createObjects_def)
+    apply (wp createObjects_iflive')
+   apply (wp createObjects_no_cte_ifunsafe' irqs_masked_lift
+             createObjects_idle' createObjects_no_cte_valid_global
+             createObjects_valid_arch createObjects_irq_state
+             createObjects_no_cte_irq_handlers createObjects_cur'
+             assms | simp add: objBits_def)+
+  apply (rule hoare_vcg_conj_lift)
+   apply (simp add: createObjects_def)
+   apply (wp createObjects_idle')
+   apply (wp createObjects_no_cte_ifunsafe' irqs_masked_lift
+             createObjects_idle' createObjects_no_cte_valid_global
+             createObjects_valid_arch createObjects_irq_state
+             createObjects_no_cte_irq_handlers createObjects_cur'
+             assms
+             createObjects_pspace_domain_valid co_ct_not_inQ
+             createObjects_ct_idle_or_in_cur_domain'
+             createObjects_untyped_ranges_zero'[OF moKO]
+         | simp)+
+  apply (rule hoare_vcg_conj_lift)
+   apply (simp add: createObjects_def)
+   apply (wpsimp wp: createObjects_sched_queues)
+  apply (rule hoare_vcg_conj_lift)
+   apply (simp add: createObjects_def)
+   apply (wpsimp wp: createObjects_valid_sched_pointers)
+  apply (rule hoare_vcg_conj_lift)
+   apply (simp add: createObjects_def)
+   apply (wpsimp wp: createObjects_valid_bitmaps)
+   apply (wp createObjects_no_cte_ifunsafe' irqs_masked_lift
+             createObjects_idle' createObjects_no_cte_valid_global
+             createObjects_valid_arch createObjects_irq_state
+             createObjects_no_cte_irq_handlers createObjects_cur'
+             assms
+             createObjects_pspace_domain_valid co_ct_not_inQ
+             createObjects_ct_idle_or_in_cur_domain'
+             createObjects_untyped_ranges_zero'[OF moKO]
+         | simp)+
+  apply clarsimp
+  apply ((intro conjI; assumption?); simp add: valid_pspace'_def objBits_def)
+  apply (fastforce simp add: no_cte no_tcb split_def split: option.splits)
+  apply (auto simp: invs'_def no_tcb valid_state'_def no_cte
+             split: option.splits kernel_object.splits)
+  done
 qed
 
 lemma corres_retype_update_gsI:
   assumes not_zero: "n \<noteq> 0"
   and      aligned: "is_aligned ptr (objBitsKO ko + gbits)"
-  and obj_bits_api: "obj_bits_api (APIType_map2 ty) us = objBitsKO ko + gbits"
-  and        check: "sz < obj_bits_api (APIType_map2 ty) us \<longleftrightarrow> sz < objBitsKO ko + gbits"
-  and           ko: "makeObjectKO dev us d ty = Some ko"
-  and            tysc: "ty = Inr (APIObjectType SchedContextObject) \<longrightarrow> min_sched_context_bits \<le> us"
+  and obj_bits_api: "obj_bits_api (APIType_map2 ty) us =
+                     objBitsKO ko + gbits"
+  and        check: "sz < obj_bits_api (APIType_map2 ty) us \<longleftrightarrow>
+                     sz < objBitsKO ko + gbits"
+  and          usv: "APIType_map2 ty = Structures_A.CapTableObject \<Longrightarrow> 0 < us"
+  and           ko: "makeObjectKO dev ty = Some ko"
   and          orr: "obj_bits_api (APIType_map2 ty) us \<le> sz \<Longrightarrow>
-                     obj_relation_retype (default_object (APIType_map2 ty) dev us d) ko"
+                     obj_relation_retype
+                       (default_object (APIType_map2 ty) dev us) ko"
   and        cover: "range_cover ptr sz (obj_bits_api (APIType_map2 ty) us) n"
   and            f: "f = update_gs (APIType_map2 ty) us"
   shows "corres (\<lambda>rv rv'. rv' = g rv)
          (\<lambda>s. valid_pspace s \<and> pspace_no_overlap_range_cover ptr sz s
-            \<and> valid_mdb s \<and>  valid_list s)
+            \<and> valid_mdb s \<and> valid_etcbs s \<and> valid_list s)
          (\<lambda>s. pspace_aligned' s \<and> pspace_distinct' s \<and>
-              pspace_no_overlap' ptr sz s \<and>
-              (ty = Inr (APIObjectType TCBObject) \<longrightarrow> d = ksCurDomain s))
-         (retype_region ptr n us (APIType_map2 ty) dev)
+              pspace_no_overlap' ptr sz s)
+         (retype_region2 ptr n us (APIType_map2 ty) dev)
          (do addrs \<leftarrow> createObjects ptr n ko gbits;
              _ \<leftarrow> modify (f (set addrs));
              return (g addrs)
           od)"
-  using corres_retype' [OF not_zero aligned obj_bits_api check ko tysc orr cover]
-  by (clarsimp simp: f)
+  using corres_retype' [OF not_zero aligned obj_bits_api check usv ko orr cover]
+  by (simp add: f)
 
 lemma gcd_corres: "corres (=) \<top> \<top> (gets cur_domain) curDomain"
   by (simp add: curDomain_def state_relation_def)
 
-lemma createObjects_tcb_at':
+lemma retype_region2_extra_ext_mapM_x_corres:
+  shows "corres dc
+           (valid_etcbs and (\<lambda>s. \<forall>addr\<in>set addrs. tcb_at addr s))
+           (\<lambda>s. \<forall>addr\<in>set addrs. obj_at' (Not \<circ> tcbQueued) addr s)
+           (retype_region2_extra_ext addrs Structures_A.apiobject_type.TCBObject)
+           (mapM_x (\<lambda>addr. do cdom \<leftarrow> curDomain;
+                              threadSet (tcbDomain_update (\<lambda>_. cdom)) addr
+                           od)
+             addrs)"
+  apply (rule corres_guard_imp)
+    apply (simp add: retype_region2_extra_ext_def curDomain_mapM_x_futz[symmetric] when_def)
+    apply (rule corres_split_eqr[OF gcd_corres])
+      apply (rule_tac S="Id \<inter> {(x, y). x \<in> set addrs}"
+                  and P="\<lambda>s. (\<forall>t \<in> set addrs. tcb_at t s) \<and> valid_etcbs s"
+                  and P'="\<lambda>s. \<forall>t \<in> set addrs. obj_at' (Not \<circ> tcbQueued) t s"
+                   in corres_mapM_x)
+          apply simp
+          apply (rule corres_guard_imp)
+            apply (rule ethread_set_corres, simp_all add: etcb_relation_def non_exst_same_def)[1]
+            apply (case_tac tcb')
+            apply simp
+           apply fastforce
+          apply (fastforce simp: obj_at'_def)
+         apply (wp hoare_vcg_ball_lift | simp)+
+        apply (clarsimp simp: obj_at'_def)
+       apply fastforce
+      apply auto[1]
+     apply (wp | simp add: curDomain_def)+
+  done
+
+lemma retype_region2_extra_ext_trivial:
+  "ty \<noteq> APIType_map2 (Inr (APIObjectType apiobject_type.TCBObject))
+      \<Longrightarrow> retype_region2_extra_ext ptrs ty = return ()"
+by (simp add: retype_region2_extra_ext_def when_def APIType_map2_def)
+
+lemma retype_region2_ext_retype_region_ArchObject_PageDirectoryObj:
+  "retype_region ptr n us (APIType_map2 (Inr PageDirectoryObject)) dev =
+  (retype_region2 ptr n us (APIType_map2 (Inr PageDirectoryObject)) dev :: obj_ref list det_ext_monad)"
+by (simp add: retype_region2_ext_retype_region retype_region2_extra_ext_def when_def APIType_map2_def)
+
+lemma retype_region2_valid_etcbs[wp]:"\<lbrace>valid_etcbs\<rbrace> retype_region2 a b c d dev \<lbrace>\<lambda>_. valid_etcbs\<rbrace>"
+  apply (simp add: retype_region2_def)
+  apply (simp add: retype_region2_ext_def bind_assoc)
+  apply wp
+  apply (clarsimp simp del: fun_upd_apply)
+  apply (blast intro: valid_etcb_fold_update)
+  done
+
+lemma retype_region2_obj_at:
+  assumes tytcb: "ty = Structures_A.apiobject_type.TCBObject"
+  shows "\<lbrace>\<top>\<rbrace> retype_region2 ptr n us ty dev \<lbrace>\<lambda>rv s. \<forall>x \<in> set rv. tcb_at x s\<rbrace>"
+  using tytcb unfolding retype_region2_def
+  apply (simp only: return_bind bind_return foldr_upd_app_if fun_app_def K_bind_def)
+  apply (wp dxo_wp_weak | simp)+
+  apply (auto simp: obj_at_def default_object_def is_tcb_def)
+  done
+
+lemma createObjects_Not_tcbQueued:
   "\<lbrakk>range_cover ptr sz (objBitsKO (injectKOS (makeObject::tcb))) n; n \<noteq> 0\<rbrakk> \<Longrightarrow>
-   \<lbrace>\<lambda>s. pspace_no_overlap' ptr sz s \<and> pspace_aligned' s \<and> pspace_distinct' s \<and> pspace_bounded' s\<rbrace>
-   createObjects ptr n (KOTCB makeObject) 0 \<lbrace>\<lambda>ptrs s. \<forall>addr\<in>set ptrs. tcb_at' addr s\<rbrace>"
+   \<lbrace>\<lambda>s. pspace_no_overlap' ptr sz s \<and> pspace_aligned' s \<and> pspace_distinct' s\<rbrace>
+   createObjects ptr n (KOTCB makeObject) 0
+   \<lbrace>\<lambda>ptrs s. \<forall>addr\<in>set ptrs. obj_at' (Not \<circ> tcbQueued) addr s\<rbrace>"
   apply (rule hoare_strengthen_post[OF createObjects_ko_at_strg[where val = "(makeObject :: tcb)"]])
   apply (auto simp: obj_at'_def projectKOs project_inject objBitsKO_def objBits_def makeObject_tcb)
   done
@@ -5650,13 +5532,11 @@ lemma regroup_createObjects_dmo_userPages:
 lemma corres_retype_region_createNewCaps:
   "corres ((\<lambda>r r'. length r = length r' \<and> list_all2 cap_relation r r')
                \<circ> map (\<lambda>ref. default_cap (APIType_map2 (Inr ty)) ref us dev))
-            (\<lambda>s. valid_pspace s \<and> valid_mdb s \<and> valid_list s \<and> valid_arch_state s
+            (\<lambda>s. valid_pspace s \<and> valid_mdb s \<and> valid_etcbs s \<and> valid_list s \<and> valid_arch_state s
                    \<and> caps_no_overlap y sz s \<and> pspace_no_overlap_range_cover y sz s
                    \<and> caps_overlap_reserved {y..y + of_nat n * 2 ^ (obj_bits_api (APIType_map2 (Inr ty)) us) - 1} s
                    \<and> (\<exists>slot. cte_wp_at (\<lambda>c. up_aligned_area y sz \<subseteq> cap_range c \<and> cap_is_device c = dev) slot s)
-                   \<and> (APIType_map2 (Inr ty) = Structures_A.CapTableObject \<longrightarrow> 0 < us)
-                   \<and> (APIType_map2 (Inr ty) = Structures_A.SchedContextObject
-                            \<longrightarrow> sc_size_bounds us))
+                   \<and> (APIType_map2 (Inr ty) = Structures_A.CapTableObject \<longrightarrow> 0 < us))
             (\<lambda>s. pspace_aligned' s \<and> pspace_distinct' s \<and> pspace_no_overlap' y sz s
                   \<and> valid_pspace' s \<and> valid_arch_state' s
                   \<and> range_cover y sz (obj_bits_api (APIType_map2 (Inr ty)) us) n \<and> n\<noteq> 0)
@@ -5668,9 +5548,7 @@ lemma corres_retype_region_createNewCaps:
                        (obj_bits_api (APIType_map2 (Inr ty)) us) n \<and>
                      n \<noteq> 0 \<and>
                      (APIType_map2 (Inr ty) = Structures_A.CapTableObject
-                       \<longrightarrow> 0 < us)
-                     \<and> (APIType_map2 (Inr ty) = Structures_A.SchedContextObject
-                            \<longrightarrow> sc_size_bounds us)"
+                       \<longrightarrow> 0 < us)"
             in corres_req, simp)
   apply (clarsimp simp add: createNewCaps_def toAPIType_def
                  split del: if_split cong: if_cong)
@@ -5679,87 +5557,80 @@ lemma corres_retype_region_createNewCaps:
                       split del: if_split)
         apply (rename_tac apiobject_type)
         apply (case_tac apiobject_type, simp_all split del: if_split)
-              \<comment> \<open>Untyped\<close>
-              apply (simp     add: retype_region_def obj_bits_api_def
-                                   APIType_map2_def
-                        split del: if_split
-                             cong: if_cong)
-              apply (subst upto_enum_red')
-               apply (drule range_cover_not_zero[rotated])
-                apply simp
-               apply unat_arith
-              apply (clarsimp simp: list_all2_same enum_word_def  range_cover.unat_of_nat_n
-                                    list_all2_map1 list_all2_map2
-                                    ptr_add_def fromIntegral_def toInteger_nat fromInteger_nat)
-              apply (subst unat_of_nat_minus_1)
-                apply (rule le_less_trans[OF range_cover.range_cover_n_le(2) power_strict_increasing])
-                  apply simp
-                 apply (clarsimp simp: range_cover_def)
-                 apply (arith+)[4]
-             \<comment> \<open>TCB\<close>
-             apply (simp_all add: curDomain_def split del: if_split)
-             apply (rule corres_underlying_gets_pre_rhs[rotated])
-              apply (rule gets_sp)
-             apply (rule corres_guard_imp)
-               apply (rule corres_bind_return)
-               apply (rule corres_split_eqr)
-                  apply (rule corres_retype[where 'a = tcb],
-                         simp_all add: obj_bits_api_def objBits_simps' pageBits_def
-                                       APIType_map2_def makeObjectKO_def)[1]
-                   apply (fastforce simp: range_cover_def)
-                  apply (simp add: other_objs_default_relation)
-                 apply (rule corres_returnTT, simp)
-                 apply (clarsimp simp: list_all2_same list_all2_map1 list_all2_map2
-                                       objBits_simps APIType_map2_def)
-                apply ((wp | simp add: APIType_map2_def)+)[1]
-               apply ((wp createObjects_tcb_at'[where sz=sz] | simp add: APIType_map2_def objBits_simps' obj_bits_api_def)+)[1]
+            \<comment> \<open>Untyped\<close>
+            apply (simp     add: retype_region_def obj_bits_api_def
+                                 APIType_map2_def
+                      split del: if_split
+                           cong: if_cong)
+            apply (subst upto_enum_red')
+             apply (drule range_cover_not_zero[rotated])
               apply simp
-             apply simp
-            \<comment> \<open>CapTable\<close>
-            apply (find_goal \<open>match premises in "_ = ArchTypes_H.apiobject_type.CapTableObject" \<Rightarrow> \<open>-\<close>\<close>)
-            apply (subst bind_assoc_return_reverse[of "createObjects y n (KOCTE makeObject) us"])
-            apply (subst liftM_def [of "map (\<lambda>addr. capability.CNodeCap addr us 0 0)", symmetric])
+             apply unat_arith
+            apply (clarsimp simp: list_all2_same enum_word_def  range_cover.unat_of_nat_n
+                                  list_all2_map1 list_all2_map2
+                                  ptr_add_def fromIntegral_def toInteger_nat fromInteger_nat)
+            apply (subst unat_of_nat_minus_1)
+              apply (rule le_less_trans[OF range_cover.range_cover_n_le(2) power_strict_increasing])
+                apply simp
+               apply (clarsimp simp: range_cover_def)
+               apply (arith+)[4]
+           \<comment> \<open>TCB, EP, NTFN\<close>
+           apply (simp_all add: retype_region2_ext_retype_region bind_cong[OF curDomain_mapM_x_futz refl, unfolded bind_assoc]
+                     split del: if_split)[9] (* not PageDirectoryObject *)
+           apply (rule corres_guard_imp)
+             apply (rule corres_split_eqr)
+                apply (rule corres_retype[where 'a = tcb],
+                       simp_all add: obj_bits_api_def objBits_simps' pageBits_def
+                                    APIType_map2_def makeObjectKO_def
+                                    tcb_relation_retype)[1]
+                apply (fastforce simp: range_cover_def)
+               apply (rule corres_split_nor)
+                  apply (simp add: APIType_map2_def)
+                  apply (rule retype_region2_extra_ext_mapM_x_corres)
+                 apply (rule corres_trivial, simp)
+                 apply (clarsimp simp: list_all2_same list_all2_map1 list_all2_map2
+                objBits_simps APIType_map2_def)
+                apply wp
+               apply wp
+              apply ((wp retype_region2_obj_at | simp add: APIType_map2_def)+)[1]
+             apply ((wp createObjects_Not_tcbQueued[where sz=sz] | simp add: APIType_map2_def objBits_simps' obj_bits_api_def)+)[1]
             apply simp
-            apply (rule corres_rel_imp)
-             apply (rule corres_guard_imp)
-               apply (rule corres_retype_update_gsI,
-                      simp_all add: obj_bits_api_def objBits_simps' pageBits_def
-                                    APIType_map2_def makeObjectKO_def slot_bits_def
-                                    field_simps ext)[1]
-                apply ((clarsimp simp : range_cover_def APIType_map2_def word_bits_def
-                                        list_all2_same list_all2_map1 list_all2_map2
-                      | rule captable_relation_retype)+)[5]
-           \<comment> \<open>EP, NTFN\<close>
-           apply (simp add: liftM_def[symmetric] split del: if_split)
-           apply (rule corres_rel_imp)
-            apply (rule corres_guard_imp)
-              apply (rule corres_retype[where 'a = endpoint],
-                     simp_all add: obj_bits_api_def objBits_simps' pageBits_def
-                                   APIType_map2_def makeObjectKO_def
-                                   other_objs_default_relation)[1]
-              apply ((simp add: range_cover_def APIType_map2_def
-                             list_all2_same list_all2_map1 list_all2_map2)+)[4]
+           apply simp
+          apply (subst retype_region2_extra_ext_trivial)
+           apply (simp add: APIType_map2_def)
           apply (simp add: liftM_def[symmetric] split del: if_split)
           apply (rule corres_rel_imp)
            apply (rule corres_guard_imp)
-             apply (rule corres_retype[where 'a = notification],
+             apply (rule corres_retype[where 'a = endpoint],
                     simp_all add: obj_bits_api_def objBits_simps' pageBits_def
                                   APIType_map2_def makeObjectKO_def
                                   other_objs_default_relation)[1]
-             apply ((simp add: range_cover_def APIType_map2_def
-                               list_all2_same list_all2_map1 list_all2_map2)+)[4]
-         \<comment> \<open>SchedContext\<close>
+             apply (fastforce simp: range_cover_def)
+            apply simp
+           apply simp
+          apply (clarsimp simp: list_all2_same list_all2_map1 list_all2_map2
+                                objBits_simps APIType_map2_def)
+         apply (subst retype_region2_extra_ext_trivial)
+          apply (simp add: APIType_map2_def)
          apply (simp add: liftM_def[symmetric] split del: if_split)
          apply (rule corres_rel_imp)
           apply (rule corres_guard_imp)
-            apply (rule corres_retype[where 'a = sched_context],
+            apply (rule corres_retype[where 'a = notification],
                    simp_all add: obj_bits_api_def objBits_simps' pageBits_def
-                                 APIType_map2_def makeObjectKO_def scBits_simps
-                                 sc_relation_retype)[1]
-            apply ((simp add: range_cover_def APIType_map2_def sc_size_bounds_def
-                              list_all2_same list_all2_map1 list_all2_map2 sc_const_eq)+)[4]
-        \<comment> \<open>Reply\<close>
-        apply (simp add: liftM_def[symmetric] split del: if_split)
+                                 APIType_map2_def makeObjectKO_def
+                                 other_objs_default_relation)[1]
+            apply (fastforce simp: range_cover_def)
+           apply simp
+          apply simp
+         apply (clarsimp simp: list_all2_same list_all2_map1 list_all2_map2
+                               objBits_simps APIType_map2_def)
+        \<comment> \<open>CapTable\<close>
+        apply (subst retype_region2_extra_ext_trivial)
+         apply (simp add: APIType_map2_def)
+        apply (subst bind_assoc_return_reverse[of "createObjects y n (KOCTE makeObject) us"])
+        apply (subst liftM_def
+               [of "map (\<lambda>addr. capability.CNodeCap addr us 0 0)", symmetric])
+        apply simp
         apply (rule corres_rel_imp)
          apply (rule corres_guard_imp)
            apply (rule corres_retype_update_gsI,
@@ -5852,6 +5723,8 @@ lemma corres_retype_region_createNewCaps:
                             list_all2_map1 list_all2_map2 list_all2_same)
           apply ((wpsimp split_del: if_split)+)[6]
     \<comment> \<open>SuperSectionObject\<close>
+    apply (subst retype_region2_extra_ext_trivial)
+     apply (simp add: APIType_map2_def)
     apply (simp add: corres_liftM2_simp[unfolded liftM_def] split del: if_split)
     apply (simp add: init_arch_objects_def split del: if_split)
     apply (subst regroup_createObjects_dmo_userPages)
@@ -5905,7 +5778,7 @@ lemma corres_retype_region_createNewCaps:
   apply (rule corres_guard_imp)
     apply (rule corres_split_eqr)
        apply (rule corres_retype[where ty = "Inr PageDirectoryObject" and 'a = pde
-                    , simplified],
+                    , simplified, folded retype_region2_ext_retype_region_ArchObject_PageDirectoryObj],
               simp_all add: APIType_map2_def obj_bits_api_def
                             default_arch_object_def objBits_simps
                             archObjSize_def pdBits_def pageBits_def

--- a/proof/refine/ARM/Schedule_R.thy
+++ b/proof/refine/ARM/Schedule_R.thy
@@ -5,7 +5,7 @@
  *)
 
 theory Schedule_R
-imports SchedContext_R InterruptAcc_R
+imports VSpace_R
 begin
 
 context begin interpretation Arch . (*FIXME: arch-split*)
@@ -15,107 +15,10 @@ declare hoare_weak_lift_imp[wp_split del]
 (* Levity: added (20090713 10:04:12) *)
 declare sts_rel_idle [simp]
 
-crunch refillHeadOverlappingLoop, headInsufficientLoop, setRefillHd
-  for valid_queues[wp]: valid_queues
-  and valid_queues'[wp]: valid_queues'
-  and valid_release_queue[wp]: valid_release_queue
-  and valid_release_queue'[wp]: valid_release_queue'
-  and typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  and sc_at'_n[wp]: "\<lambda>s. P (sc_at'_n T p s)"
-  (wp: crunch_wps)
-
-crunch tcbReleaseDequeue
-  for sc_at'_n[wp]: "\<lambda>s. Q (sc_at'_n n p s)"
-  (simp: crunch_simps wp: crunch_wps)
-
-crunch refillUnblockCheck, refillBudgetCheck, ifCondRefillUnblockCheck, refillBudgetCheckRoundRobin
-  for valid_queues[wp]: valid_queues
-  and valid_queues'[wp]: valid_queues'
-  and valid_release_queue[wp]: valid_release_queue
-  and valid_release_queue'[wp]: valid_release_queue'
-  and typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  and sc_at'_n[wp]: "\<lambda>s. Q (sc_at'_n n p s)"
-  and pspace_aligned'[wp]: pspace_aligned'
-  and pspace_distinct'[wp]: pspace_distinct'
-  and pspace_bounded'[wp]: pspace_bounded'
-  and no_0_obj'[wp]: no_0_obj'
-  and ctes_of[wp]: "\<lambda>s. P (ctes_of s)"
-  and sch_act_wf[wp]: "\<lambda>s. sch_act_wf (ksSchedulerAction s) s"
-  and if_unsafe_then_cap'[wp]: if_unsafe_then_cap'
-  and valid_global_refs'[wp]: valid_global_refs'
-  and valid_arch_state'[wp]: valid_arch_state'
-  and valid_irq_node[wp]: "\<lambda>s. valid_irq_node' (irq_node' s) s"
-  and valid_irq_handlers'[wp]: valid_irq_handlers'
-  and valid_irq_states'[wp]: valid_irq_states'
-  and irqs_masked'[wp]: irqs_masked'
-  and valid_pde_mappings'[wp]: valid_pde_mappings'
-  and pspace_domain_valid[wp]: pspace_domain_valid
-  and ksDomSchedule[wp]: "\<lambda>s. P (ksDomSchedule s)"
-  and ksCurdomain[wp]: "\<lambda>s. P (ksCurDomain s)"
-  and ksDomScheduleIdx[wp]: "\<lambda>s. P (ksDomScheduleIdx s)"
-  and untyped_ranges_zero'[wp]: untyped_ranges_zero'
-  and cur_tcb'[wp]: cur_tcb'
-  and ct_not_inQ[wp]: ct_not_inQ
-  and valid_dom_schedule'[wp]: valid_dom_schedule'
-  and ksCurSc[wp]: "\<lambda>s. P (ksCurSc s)"
-  (wp: crunch_wps valid_dom_schedule'_lift simp: crunch_simps refillSingle_def)
-
-crunch commitTime, refillNew, refillUpdate
-  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  and sc_at'_n[wp]: "\<lambda>s. P (sc_at'_n n p s)"
-  (wp: crunch_wps simp: crunch_simps)
-
-end
-
-global_interpretation tcbReleaseDequeue: typ_at_all_props' tcbReleaseDequeue
-  by typ_at_props'
-
-global_interpretation refillPopHead: typ_at_all_props' "refillPopHead scPtr"
-  by typ_at_props'
-
-global_interpretation updateRefillTl: typ_at_all_props' "updateRefillTl scPtr f"
-  by typ_at_props'
-
-global_interpretation handleOverrunLoopBody: typ_at_all_props' "handleOverrunLoopBody usage"
-  by typ_at_props'
-
-global_interpretation handleOverrunLoop: typ_at_all_props' "handleOverrunLoop usage"
-  by typ_at_props'
-
-global_interpretation scheduleUsed: typ_at_all_props' "scheduleUsed scPtr new"
-  by typ_at_props'
-
-global_interpretation updateRefillHd: typ_at_all_props' "updateRefillHd scPtr f"
-  by typ_at_props'
-
-global_interpretation mergeRefills: typ_at_all_props' "mergeRefills scPtr"
-  by typ_at_props'
-
-global_interpretation setRefillHd: typ_at_all_props' "setRefillHd scPtr v"
-  by typ_at_props'
-
-global_interpretation nonOverlappingMergeRefills: typ_at_all_props' "nonOverlappingMergeRefills scPtr"
-  by typ_at_props'
-
-global_interpretation refillBudgetCheck: typ_at_all_props' "refillBudgetCheck usage"
-  by typ_at_props'
-
-global_interpretation refillBudgetCheckRoundRobin: typ_at_all_props' "refillBudgetCheckRoundRobin usage"
-  by typ_at_props'
-
-global_interpretation commitTime: typ_at_all_props' "commitTime"
-   by typ_at_props'
-
-global_interpretation refillNew: typ_at_all_props' "refillNew scPtr maxRefills budget period"
-  by typ_at_props'
-
-global_interpretation refillUpdate: typ_at_all_props' "refillUpdate  scPtr newPeriod newBudget newMaxRefills"
-  by typ_at_props'
-
-global_interpretation updateSchedContext: typ_at_all_props' "updateSchedContext scPtr f"
-  by typ_at_props'
-
-context begin interpretation Arch . (*FIXME: arch-split*)
+lemma corres_if2:
+ "\<lbrakk> G = G'; G \<Longrightarrow> corres r P P' a c; \<not> G' \<Longrightarrow> corres r Q Q' b d \<rbrakk>
+    \<Longrightarrow> corres r (if G then P else Q) (if G' then P' else Q') (if G then a else b) (if G' then c else d)"
+  by simp
 
 lemma findM_awesome':
   assumes x: "\<And>x xs. suffix (x # xs) xs' \<Longrightarrow>
@@ -142,7 +45,7 @@ proof -
     apply (rule corres_guard_imp)
       apply (rule corres_split[OF x])
          apply assumption
-        apply (rule corres_if3)
+        apply (rule corres_if2)
           apply (case_tac ra, clarsimp+)[1]
          apply (rule corres_trivial, clarsimp)
          apply (case_tac ra, simp_all)[1]
@@ -154,6 +57,9 @@ proof -
 qed
 
 lemmas findM_awesome = findM_awesome' [OF _ _ _ suffix_order.refl]
+
+(* Levity: added (20090721 10:56:29) *)
+declare objBitsT_koTypeOf [simp]
 
 lemma arch_switchToThread_corres:
   "corres dc (valid_arch_state and valid_objs and valid_asid_map
@@ -175,8 +81,7 @@ lemma arch_switchToThread_corres:
       apply (rule corres_machine_op[OF corres_rel_imp])
       apply (rule corres_underlying_trivial)
        apply (simp add: ARM.clearExMonitor_def | wp)+
-   apply clarsimp
-  apply (clarsimp simp: valid_pspace'_def)
+  apply clarsimp
   done
 
 lemma schedule_choose_new_thread_sched_act_rct[wp]:
@@ -184,17 +89,7 @@ lemma schedule_choose_new_thread_sched_act_rct[wp]:
   unfolding schedule_choose_new_thread_def
   by wp
 
-lemma obj_at'_tcbQueued_cross:
-  "(s,s') \<in> state_relation \<Longrightarrow> obj_at' tcbQueued t s' \<Longrightarrow> valid_queues' s' \<Longrightarrow>
-    obj_at (\<lambda>ko. \<exists>tcb. ko = TCB tcb \<and> tcb_priority tcb = p \<and> tcb_domain tcb = d) t s \<Longrightarrow>
-    t \<in> set (ready_queues s d p)"
-  apply (clarsimp simp: state_relation_def ready_queues_relation_def valid_queues'_def)
-  apply (subgoal_tac "obj_at' (inQ d p) t s'", simp)
-  apply (clarsimp simp: obj_at'_def inQ_def obj_at_def projectKO_eq projectKO_tcb)
-  apply (frule (2) pspace_relation_tcb_domain_priority)
-  apply clarsimp
-  done
-
+\<comment> \<open>This proof shares many similarities with the proof of @{thm tcbSchedEnqueue_corres}\<close>
 lemma tcbSchedAppend_corres:
   "tcb_ptr = tcbPtr \<Longrightarrow>
    corres dc
@@ -566,14 +461,13 @@ crunch tcbSchedEnqueue
   (wp: threadSet_cur)
 
 lemma tcbSchedEnqueue_invs'[wp]:
-  "\<lbrace>invs' and st_tcb_at' runnable' t\<rbrace>
+  "\<lbrace>invs' and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread \<longrightarrow> ksCurThread s \<noteq> t)\<rbrace>
    tcbSchedEnqueue t
    \<lbrace>\<lambda>_. invs'\<rbrace>"
-  apply (simp add: invs'_def valid_dom_schedule'_def)
-  apply (wpsimp wp: valid_irq_node_lift irqs_masked_lift valid_irq_handlers_lift' cur_tcb_lift
-                    untyped_ranges_zero_lift
+  apply (simp add: invs'_def valid_state'_def valid_pspace'_def)
+  apply (wpsimp wp: valid_irq_node_lift valid_irq_handlers_lift'' irqs_masked_lift
+                    untyped_ranges_zero_lift tcbSchedEnqueue_ct_not_inQ
               simp: cteCaps_of_def o_def)
-  apply (auto elim!: st_tcb_ex_cap'')
   done
 
 crunch tcbSchedAppend
@@ -668,42 +562,43 @@ lemma tcbSchedAppend_valid_bitmaps[wp]:
   apply (clarsimp simp: valid_bitmaps_def)
   done
 
-crunch tcbSchedAppend
-  for list_refs_of_replies'[wp]: "\<lambda>s. P (list_refs_of_replies' s)"
-
-lemma tcbSchedAppend_valid_release_queue[wp]:
-  "tcbSchedAppend t \<lbrace>valid_release_queue\<rbrace>"
-  unfolding tcbSchedAppend_def
-  apply (wpsimp simp: valid_release_queue_def Ball_def addToBitmap_def
-                      modifyReadyQueuesL2Bitmap_def getReadyQueuesL2Bitmap_def
-                      modifyReadyQueuesL1Bitmap_def getReadyQueuesL1Bitmap_def
-                  wp: hoare_vcg_all_lift hoare_vcg_imp_lift' threadGet_wp)
-  by (auto simp: obj_at'_def)
-
-crunch addToBitmap
-  for ksReleaseQueue[wp]: "\<lambda>s. P (ksReleaseQueue s)"
-
-lemma tcbSchedAppend_valid_release_queue'[wp]:
-  "tcbSchedAppend t \<lbrace>valid_release_queue'\<rbrace>"
-  unfolding tcbSchedAppend_def threadGet_def
-  apply (wpsimp simp: valid_release_queue'_def
-                  wp: threadSet_valid_release_queue' hoare_vcg_all_lift hoare_vcg_imp_lift'
-                      getObject_tcb_wp)
-  apply (clarsimp simp: obj_at'_def)
-  done
-
 lemma tcbSchedAppend_invs'[wp]:
-  "\<lbrace>invs' and st_tcb_at' runnable' t\<rbrace>
+  "\<lbrace>invs' and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread \<longrightarrow> ksCurThread s \<noteq> t)\<rbrace>
    tcbSchedAppend t
    \<lbrace>\<lambda>_. invs'\<rbrace>"
-  apply (simp add: invs'_def valid_dom_schedule'_def)
-  apply (rule hoare_pre)
-   apply (wp tcbSchedAppend_ct_not_inQ valid_irq_node_lift irqs_masked_lift hoare_vcg_disj_lift
-             valid_irq_handlers_lift' cur_tcb_lift ct_idle_or_in_cur_domain'_lift2
-             untyped_ranges_zero_lift
-        | simp add: cteCaps_of_def o_def
-        | auto elim!: st_tcb_ex_cap'' valid_objs'_maxDomain valid_objs'_maxPriority split: thread_state.split_asm simp: valid_pspace'_def)+
+  apply (simp add: invs'_def valid_state'_def valid_pspace'_def)
+  apply (wpsimp wp: valid_irq_node_lift valid_irq_handlers_lift'' irqs_masked_lift
+                    untyped_ranges_zero_lift tcbSchedAppend_ct_not_inQ
+                    ct_idle_or_in_cur_domain'_lift2 cur_tcb_lift
+              simp: cteCaps_of_def o_def)
   done
+
+lemma tcbSchedAppend_all_invs_but_ct_not_inQ':
+  "\<lbrace>invs'\<rbrace>
+   tcbSchedAppend t
+   \<lbrace>\<lambda>_. all_invs_but_ct_not_inQ'\<rbrace>"
+  apply (simp add: invs'_def valid_state'_def valid_pspace'_def)
+  apply (wpsimp wp: valid_irq_node_lift valid_irq_handlers_lift'' irqs_masked_lift
+                    untyped_ranges_zero_lift tcbSchedAppend_ct_not_inQ
+                    ct_idle_or_in_cur_domain'_lift2 cur_tcb_lift
+              simp: cteCaps_of_def o_def)
+  done
+
+lemma tcbSchedEnqueue_invs'_not_ResumeCurrentThread:
+  "\<lbrace>invs'
+    and st_tcb_at' runnable' t
+    and (\<lambda>s. ksSchedulerAction s \<noteq> ResumeCurrentThread)\<rbrace>
+     tcbSchedEnqueue t
+   \<lbrace>\<lambda>_. invs'\<rbrace>"
+  by wpsimp
+
+lemma tcbSchedAppend_invs'_not_ResumeCurrentThread:
+  "\<lbrace>invs'
+    and st_tcb_at' runnable' t
+    and (\<lambda>s. ksSchedulerAction s \<noteq> ResumeCurrentThread)\<rbrace>
+     tcbSchedAppend t
+   \<lbrace>\<lambda>_. invs'\<rbrace>"
+  by wpsimp
 
 lemma tcb_at'_has_tcbDomain:
  "tcb_at' t s \<Longrightarrow> \<exists>p. obj_at' (\<lambda>tcb. tcbDomain tcb = p) t s"
@@ -758,14 +653,10 @@ lemma tcbSchedDequeue_valid_mdb'[wp]:
 
 lemma tcbSchedDequeue_invs'[wp]:
   "tcbSchedDequeue t \<lbrace>invs'\<rbrace>"
-  unfolding invs'_def
-  apply (rule hoare_pre)
-   apply (wp valid_irq_node_lift irqs_masked_lift
-             valid_irq_handlers_lift' cur_tcb_lift ct_idle_or_in_cur_domain'_lift2
-             tcbSchedDequeue_valid_queues untyped_ranges_zero_lift
-          | simp add: cteCaps_of_def o_def valid_dom_schedule'_def)+
-  apply (auto simp: valid_pspace'_def obj_at'_def
-              dest: valid_objs'_maxDomain[where t=t] valid_objs'_maxPriority[where t=t])
+  apply (simp add: invs'_def valid_state'_def valid_pspace'_def)
+  apply (wpsimp wp: valid_irq_node_lift valid_irq_handlers_lift'' irqs_masked_lift
+                    untyped_ranges_zero_lift ct_idle_or_in_cur_domain'_lift2 cur_tcb_lift
+              simp: cteCaps_of_def o_def)
   done
 
 lemma ready_qs_runnable_cross:
@@ -813,18 +704,25 @@ lemma valid_idle_tcb_at:
   by (clarsimp simp: valid_idle_def pred_tcb_at_def obj_at_def is_tcb_def)
 
 lemma setCurThread_corres:
-  "corres dc (pspace_aligned and pspace_distinct and valid_ready_qs) \<top>
-             (modify (cur_thread_update (\<lambda>_. t))) (setCurThread t)"
-  apply add_ready_qs_runnable
-  apply (unfold setCurThread_def)
-  apply (rule corres_stateAssert_add_assertion[rotated]; clarsimp)
+  "corres dc (valid_idle and valid_queues and valid_etcbs and pspace_aligned and pspace_distinct) \<top>
+     (modify (cur_thread_update (\<lambda>_. t))) (setCurThread t)"
+  apply (clarsimp simp: setCurThread_def)
+  apply (rule corres_stateAssert_add_assertion[rotated])
+   apply (clarsimp simp: idleThreadNotQueued_def)
+   apply (frule (2) idle_thread_not_queued)
+   apply (frule state_relation_pspace_relation)
+   apply (frule state_relation_ready_queues_relation)
+   apply (frule state_relation_idle_thread)
+   apply (frule valid_idle_tcb_at)
+   apply (frule (3) tcb_at_cross)
+   apply (fastforce dest!: in_ready_q_tcbQueued_eq[THEN arg_cong_Not, THEN iffD1]
+                     simp: obj_at'_def projectKOs opt_pred_def opt_map_def)
   apply (rule corres_modify)
   apply (simp add: state_relation_def swp_def)
   done
 
-lemma arch_switch_thread_tcb_at' [wp]:
-  "Arch.switchToThread t \<lbrace>\<lambda>s. P (tcb_at' t s)\<rbrace>"
-  by (unfold ARM_H.switchToThread_def, wp typ_at_lifts)
+lemma arch_switch_thread_tcb_at' [wp]: "\<lbrace>tcb_at' t\<rbrace> Arch.switchToThread t \<lbrace>\<lambda>_. tcb_at' t\<rbrace>"
+  by (unfold ARM_H.switchToThread_def, wp typ_at_lift_tcb')
 
 crunch "switchToThread"
   for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
@@ -845,8 +743,6 @@ proof -
     by (rule lift_neg_pred_tcb_at' [OF ArchThreadDecls_H_ARM_H_switchToThread_typ_at' pos])
 qed
 
-crunch doMachineOp
-  for ksQ[wp]: "\<lambda>s. P (ksReadyQueues s)"
 
 crunch storeWordUser
   for ksQ[wp]: "\<lambda>s. P (ksReadyQueues s p)"
@@ -890,18 +786,14 @@ lemma valid_queues_ready_qs_distinct[elim!]:
   "valid_queues s \<Longrightarrow> ready_qs_distinct s"
   by (clarsimp simp: valid_queues_def ready_qs_distinct_def)
 
-crunch arch_switch_to_thread
-  for pspace_aligned[wp]: pspace_aligned
-  and pspace_distinct[wp]: pspace_distinct
-
 lemma switchToThread_corres:
   "corres dc (valid_arch_state and valid_objs and valid_asid_map
-                and valid_vspace_objs and pspace_aligned and pspace_distinct and valid_ready_qs
+                and valid_vspace_objs and pspace_aligned and pspace_distinct
                 and valid_vs_lookup and valid_global_objs
                 and unique_table_refs o caps_of_state
-                and st_tcb_at runnable t)
-             (valid_arch_state' and valid_pspace' and Invariants_H.valid_queues
-                and st_tcb_at' runnable' t and cur_tcb')
+                and st_tcb_at runnable t and valid_etcbs
+                and valid_queues and valid_idle)
+             (no_0_obj' and sym_heap_sched_pointers and valid_objs' and valid_arch_state')
              (switch_to_thread t) (switchToThread t)"
   apply (rule_tac Q'="st_tcb_at' runnable' t" in corres_cross_add_guard)
    apply (fastforce intro!: st_tcb_at_runnable_cross simp: obj_at_def is_tcb_def)
@@ -920,23 +812,14 @@ lemma switchToThread_corres:
     apply (rule corres_guard_imp)
       apply (rule corres_split[OF arch_switchToThread_corres])
         apply (rule corres_split[OF tcbSchedDequeue_corres setCurThread_corres])
-         apply (wpsimp wp: tcb_sched_dequeue_valid_ready_qs | clarsimp simp: st_tcb_at_tcb_at)+
-    done
-
-  show ?thesis
-    apply -
-    apply (simp add: switch_to_thread_def Thread_H.switchToThread_def)
-    apply add_ready_qs_runnable
-    apply (rule corres_stateAssert_add_assertion)
-     apply (rule corres_symb_exec_l[where Q = "\<lambda> s rv. (?PA and (=) rv) s"])
-        apply (rule corres_symb_exec_l)
-           apply (rule corres_guard_imp[OF mainpart])
-            apply (auto intro: no_fail_pre [OF no_fail_assert] no_fail_pre [OF no_fail_get]
-                         dest: st_tcb_at_tcb_at [THEN get_tcb_at]
-                   | simp add: assert_def
-                   | wp)+
-    done
-qed
+          apply (wpsimp simp: is_tcb_def)+
+     apply (fastforce intro!: st_tcb_at_tcb_at)
+    apply wpsimp
+   apply wpsimp
+   apply (fastforce dest!: st_tcb_at_tcb_at simp: tcb_at_def)
+  apply wpsimp
+  apply (fastforce dest!: st_tcb_at_tcb_at simp: tcb_at_def)
+  done
 
 lemma arch_switchToIdleThread_corres:
   "corres dc (valid_arch_state and valid_objs and valid_asid_map and unique_table_refs \<circ> caps_of_state and
@@ -950,34 +833,26 @@ lemma arch_switchToIdleThread_corres:
   apply (clarsimp simp: valid_idle_def valid_idle'_def pred_tcb_at_def obj_at_def is_tcb obj_at'_def)
   done
 
-crunch switchToIdleThread
-  for ready_qs_runnable[wp]: "\<lambda>s. \<forall>d p. \<forall>t\<in>set (ksReadyQueues s (d, p)).
-                       st_tcb_at' runnable' t s"
-  (simp: crunch_simps)
-
 lemma switchToIdleThread_corres:
-  "corres dc (invs and valid_ready_qs) invs' switch_to_idle_thread switchToIdleThread"
-  apply add_ready_qs_runnable
-  apply add_valid_idle'
+  "corres dc
+     (invs and valid_queues and valid_etcbs)
+     invs_no_cicd'
+     switch_to_idle_thread switchToIdleThread"
   apply (simp add: switch_to_idle_thread_def Thread_H.switchToIdleThread_def)
-  apply (rule corres_stateAssert_add_assertion[rotated])
-   apply clarsimp
-  apply (rule corres_stateAssert_add_assertion[rotated])
-   apply (clarsimp simp: valid_idle'_asrt_def)
+  apply add_ready_qs_runnable
+  apply (rule corres_stateAssert_ignore, fastforce)
   apply (rule corres_guard_imp)
     apply (rule corres_split[OF getIdleThread_corres])
       apply (rule corres_split[OF arch_switchToIdleThread_corres])
-        apply (unfold setCurThread_def)
-        apply (rule corres_stateAssert_add_assertion)
-         apply clarsimp
-         apply (rule corres_modify)
-        apply (simp add: state_relation_def cdt_relation_def)
-        apply (simp only: ready_qs_runnable_def)
-       apply wpsimp+
+        apply clarsimp
+        apply (rule setCurThread_corres)
+       apply wpsimp
+      apply (simp add: state_relation_def cdt_relation_def)
+      apply wpsimp+
    apply (simp add: invs_unique_refs invs_valid_vs_lookup invs_valid_objs invs_valid_asid_map
                     invs_arch_state invs_valid_global_objs invs_psp_aligned invs_distinct
                     invs_valid_idle invs_vspace_objs)
-  apply (simp add: invs'_def valid_pspace'_def ready_qs_runnable_def)
+  apply (simp add: all_invs_but_ct_idle_or_in_cur_domain'_def valid_state'_def valid_pspace'_def)
   done
 
 lemma gq_sp: "\<lbrace>P\<rbrace> getQueue d p \<lbrace>\<lambda>rv. P and (\<lambda>s. ksReadyQueues s (d, p) = rv)\<rbrace>"
@@ -992,86 +867,55 @@ lemma sch_act_wf:
 declare gq_wp[wp]
 declare setQueue_obj_at[wp]
 
-lemma setCurThread_invs':
-  "\<lbrace>invs' and tcb_at' t\<rbrace>
-   setCurThread t
-   \<lbrace>\<lambda>_. invs'\<rbrace>"
-  apply (simp add: setCurThread_def)
-  apply wp
-  apply (clarsimp simp add: invs'_def cur_tcb'_def valid_queues_def valid_release_queue_def
-                            valid_release_queue'_def sch_act_wf ct_in_state'_def
-                            state_refs_of'_def ps_clear_def valid_irq_node'_def valid_queues'_def
-                            ct_idle_or_in_cur_domain'_def
-                            bitmapQ_defs valid_queues_no_bitmap_def valid_dom_schedule'_def
-                      cong: option.case_cong)
-  done
+lemma threadSet_timeslice_invs:
+  "\<lbrace>invs' and tcb_at' t\<rbrace> threadSet (tcbTimeSlice_update b) t \<lbrace>\<lambda>rv. invs'\<rbrace>"
+  by (wp threadSet_invs_trivial, simp_all add: inQ_def cong: conj_cong)
 
-lemma valid_queues_not_runnable_not_queued:
-  fixes s
-  assumes  vq: "valid_queues s"
-      and rqr: "\<forall>d p. (\<forall>t \<in> set (ksReadyQueues s (d, p)). st_tcb_at' runnable' t s)"
-      and vq': "valid_queues' s"
-      and  st: "st_tcb_at' (Not \<circ> runnable') t s"
-  shows "obj_at' (Not \<circ> tcbQueued) t s"
-proof (rule ccontr)
-  assume "\<not> obj_at' (Not \<circ> tcbQueued) t s"
-  moreover from st have "typ_at' TCBT t s"
-    by (rule pred_tcb_at' [THEN tcb_at_typ_at' [THEN iffD1]])
-  ultimately have "obj_at' tcbQueued t s"
-    by (clarsimp simp: not_obj_at' comp_def)
-
-  moreover
-  from st [THEN pred_tcb_at', THEN tcb_at'_has_tcbPriority]
-  obtain p where tp: "obj_at' (\<lambda>tcb. tcbPriority tcb = p) t s"
-    by clarsimp
-
-  moreover
-  from st [THEN pred_tcb_at', THEN tcb_at'_has_tcbDomain]
-  obtain d where td: "obj_at' (\<lambda>tcb. tcbDomain tcb = d) t s"
-    by clarsimp
-
-  ultimately
-  have "t \<in> set (ksReadyQueues s (d, p))" using vq'
-    unfolding valid_queues'_def
-    apply -
-    apply (drule_tac x=d in spec)
-    apply (drule_tac x=p in spec)
-    apply (drule_tac x=t in spec)
-    apply (erule impE)
-     apply (fastforce simp add: inQ_def obj_at'_def)
-    apply (assumption)
+lemma setCurThread_invs_no_cicd':
+  "\<lbrace>invs_no_cicd' and st_tcb_at' activatable' t and obj_at' (\<lambda>x. \<not> tcbQueued x) t and tcb_in_cur_domain' t\<rbrace>
+     setCurThread t
+   \<lbrace>\<lambda>rv. invs'\<rbrace>"
+proof -
+  have ct_not_inQ_ct: "\<And>s t . \<lbrakk> ct_not_inQ s; obj_at' (\<lambda>x. \<not> tcbQueued x) t s\<rbrakk> \<Longrightarrow> ct_not_inQ (s\<lparr> ksCurThread := t \<rparr>)"
+    apply (simp add: ct_not_inQ_def o_def)
     done
-
-  with vq rqr have "st_tcb_at' runnable' t s"
-    unfolding Invariants_H.valid_queues_def valid_queues_no_bitmap_def
-    apply -
-    apply clarsimp
-    done
-
-  with st show False
-    apply (clarsimp simp: st_tcb_at'_def obj_at'_def)
+  show ?thesis
+    apply (simp add: setCurThread_def)
+    apply wp
+    apply (clarsimp simp add: all_invs_but_ct_idle_or_in_cur_domain'_def invs'_def cur_tcb'_def
+                              valid_state'_def sch_act_wf ct_in_state'_def state_refs_of'_def
+                              ps_clear_def valid_irq_node'_def ct_not_inQ_ct
+                              ct_idle_or_in_cur_domain'_def bitmapQ_defs valid_bitmaps_def
+                        cong: option.case_cong)
     done
 qed
 
-(*
- * The idle thread is not part of any ready queues.
- *)
-lemma idle'_not_tcbQueued':
- assumes   vq:  "Invariants_H.valid_queues s"
-     and  rqr:  "\<forall>d p. (\<forall>t \<in> set (ksReadyQueues s (d, p)). st_tcb_at' runnable' t s)"
-     and  vq':  "valid_queues' s"
-     and idle: "valid_idle' s"
- shows "obj_at' (Not \<circ> tcbQueued) (ksIdleThread s) s"
- proof -
-   from idle have stidle: "st_tcb_at' (Not \<circ> runnable') (ksIdleThread s) s"
-     by (clarsimp simp: valid_idle'_def pred_tcb_at'_def obj_at'_def projectKOs idle_tcb'_def)
+(* Don't use this rule when considering the idle thread. The invariant ct_idle_or_in_cur_domain'
+   says that either "tcb_in_cur_domain' t" or "t = ksIdleThread s".
+   Use setCurThread_invs_idle_thread instead. *)
+lemma setCurThread_invs:
+  "\<lbrace>invs' and st_tcb_at' activatable' t and obj_at' (\<lambda>x. \<not> tcbQueued x) t and
+    tcb_in_cur_domain' t\<rbrace> setCurThread t \<lbrace>\<lambda>rv. invs'\<rbrace>"
+  by (rule hoare_pre, rule setCurThread_invs_no_cicd')
+     (simp add: invs'_to_invs_no_cicd'_def)
 
-   with vq rqr vq' show ?thesis
-     by (rule valid_queues_not_runnable_not_queued)
- qed
+lemma setCurThread_invs_no_cicd'_idle_thread:
+  "\<lbrace>invs_no_cicd' and (\<lambda>s. t = ksIdleThread s) \<rbrace> setCurThread t \<lbrace>\<lambda>_. invs'\<rbrace>"
+  apply (simp add: setCurThread_def)
+  apply wp
+  apply (clarsimp simp: all_invs_but_ct_idle_or_in_cur_domain'_def invs'_def cur_tcb'_def
+                        valid_state'_def valid_idle'_def
+                        sch_act_wf ct_in_state'_def state_refs_of'_def
+                        ps_clear_def valid_irq_node'_def
+                        ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def
+                        valid_queues_def bitmapQ_defs valid_bitmaps_def pred_tcb_at'_def
+                  cong: option.case_cong)
+  apply (clarsimp simp: idle_tcb'_def ct_not_inQ_def ps_clear_def obj_at'_def projectKOs
+                        st_tcb_at'_def idleThreadNotQueued_def)
+  done
 
 lemma clearExMonitor_invs'[wp]:
-  "doMachineOp ARM.clearExMonitor \<lbrace>invs'\<rbrace>"
+  "\<lbrace>invs'\<rbrace> doMachineOp ARM.clearExMonitor \<lbrace>\<lambda>rv. invs'\<rbrace>"
   apply (wp dmo_invs' no_irq)
    apply (simp add: no_irq_clearExMonitor)
   apply (clarsimp simp: ARM.clearExMonitor_def machine_op_lift_def
@@ -1079,7 +923,7 @@ lemma clearExMonitor_invs'[wp]:
   done
 
 lemma Arch_switchToThread_invs[wp]:
-  "\<lbrace>invs'\<rbrace> Arch.switchToThread t \<lbrace>\<lambda>rv. invs'\<rbrace>"
+  "\<lbrace>invs' and tcb_at' t\<rbrace> Arch.switchToThread t \<lbrace>\<lambda>rv. invs'\<rbrace>"
   apply (simp add: ARM_H.switchToThread_def)
   apply (wp; auto)
   done
@@ -1128,8 +972,16 @@ lemma Arch_switchToThread_obj_at[wp]:
 
 declare doMachineOp_obj_at[wp]
 
+lemma clearExMonitor_invs_no_cicd'[wp]:
+  "\<lbrace>invs_no_cicd'\<rbrace> doMachineOp ARM.clearExMonitor \<lbrace>\<lambda>rv. invs_no_cicd'\<rbrace>"
+  apply (wp dmo_invs_no_cicd' no_irq)
+   apply (simp add: no_irq_clearExMonitor)
+  apply (clarsimp simp: ARM.clearExMonitor_def machine_op_lift_def
+                        in_monad select_f_def)
+  done
+
 crunch asUser
- for valid_arch_state'[wp]: "valid_arch_state'"
+  for valid_arch_state'[wp]: "valid_arch_state'"
 (wp: crunch_wps simp: crunch_simps)
 
 crunch asUser
@@ -1166,22 +1018,36 @@ crunch asUser
 
 lemmas asUser_cteCaps_of[wp] = cteCaps_of_ctes_of_lift[OF asUser_ctes_of]
 
-lemma switchToThread_invs'_helper:
-  "\<lbrace>invs' and tcb_at' t\<rbrace>
-   do y \<leftarrow> ARM_H.switchToThread t;
-      y \<leftarrow> tcbSchedDequeue t;
-      setCurThread t
-   od
-   \<lbrace>\<lambda>rv. invs' \<rbrace>"
-  apply (wp setCurThread_invs' tcbSchedDequeue_not_tcbQueued Arch_switchToThread_pred_tcb')
-  apply auto
+lemma Arch_switchToThread_invs_no_cicd':
+  "\<lbrace>invs_no_cicd'\<rbrace> Arch.switchToThread t \<lbrace>\<lambda>rv. invs_no_cicd'\<rbrace>"
+  apply (simp add: ARM_H.switchToThread_def)
+  by (wp|rule setVMRoot_invs_no_cicd')+
+
+
+lemma tcbSchedDequeue_invs_no_cicd'[wp]:
+  "tcbSchedDequeue t \<lbrace>invs_no_cicd'\<rbrace>"
+  unfolding all_invs_but_ct_idle_or_in_cur_domain'_def valid_state'_def valid_pspace'_def
+  apply (wp tcbSchedDequeue_ct_not_inQ sch_act_wf_lift valid_irq_node_lift irqs_masked_lift
+            valid_irq_handlers_lift' cur_tcb_lift ct_idle_or_in_cur_domain'_lift2
+            untyped_ranges_zero_lift
+        | simp add: cteCaps_of_def o_def)+
+  apply clarsimp
   done
 
-lemma switchToThread_invs'[wp]:
-  "\<lbrace>invs' and tcb_at' t\<rbrace> switchToThread t \<lbrace>\<lambda>_. invs' \<rbrace>"
+lemma switchToThread_invs_no_cicd':
+  "\<lbrace>invs_no_cicd' and tcb_in_cur_domain' t \<rbrace> ThreadDecls_H.switchToThread t \<lbrace>\<lambda>rv. invs' \<rbrace>"
+  apply (simp add: Thread_H.switchToThread_def)
+  apply (wp setCurThread_invs_no_cicd' tcbSchedDequeue_not_tcbQueued
+            Arch_switchToThread_invs_no_cicd' Arch_switchToThread_pred_tcb')
+  apply (auto elim!: pred_tcb'_weakenE)
+  done
+
+lemma switchToThread_invs[wp]:
+  "\<lbrace>invs' and tcb_in_cur_domain' t \<rbrace> switchToThread t \<lbrace>\<lambda>rv. invs' \<rbrace>"
   apply (simp add: Thread_H.switchToThread_def )
-  apply (wp setCurThread_invs' Arch_switchToThread_invs dmo_invs'
-            doMachineOp_obj_at tcbSchedDequeue_not_tcbQueued)
+  apply (wp threadSet_timeslice_invs setCurThread_invs
+             Arch_switchToThread_invs dmo_invs'
+             doMachineOp_obj_at tcbSchedDequeue_not_tcbQueued)
   by (auto elim!: pred_tcb'_weakenE)
 
 lemma setCurThread_ct_in_state:
@@ -1196,10 +1062,13 @@ qed
 
 lemma switchToThread_ct_in_state[wp]:
   "\<lbrace>obj_at' (P \<circ> tcbState) t\<rbrace> switchToThread t \<lbrace>\<lambda>rv. ct_in_state' P\<rbrace>"
-  apply (simp add: Thread_H.switchToThread_def tcbSchedEnqueue_def unless_def)
-  apply (wp setCurThread_ct_in_state Arch_switchToThread_obj_at
+proof -
+  show ?thesis
+    apply (simp add: Thread_H.switchToThread_def tcbSchedEnqueue_def unless_def)
+    apply (wp setCurThread_ct_in_state Arch_switchToThread_obj_at
          | simp add: o_def cong: if_cong)+
-  done
+    done
+qed
 
 lemma setCurThread_obj_at[wp]:
   "\<lbrace>obj_at' P addr\<rbrace> setCurThread t \<lbrace>\<lambda>rv. obj_at' P addr\<rbrace>"
@@ -1207,6 +1076,9 @@ lemma setCurThread_obj_at[wp]:
   apply wp
   apply (fastforce intro: obj_at'_pspaceI)
   done
+
+crunch setQueue
+  for cap_to'[wp]: "ex_nonz_cap_to' p"
 
 lemma dmo_cap_to'[wp]:
   "\<lbrace>ex_nonz_cap_to' p\<rbrace>
@@ -1238,6 +1110,10 @@ lemma iflive_inQ_nonz_cap_strg:
 lemmas iflive_inQ_nonz_cap[elim]
     = mp [OF iflive_inQ_nonz_cap_strg, OF conjI[rotated]]
 
+crunch threadSet
+  for ksRQ[wp]: "\<lambda>s. P (ksReadyQueues s)"
+  (wp: updateObject_default_inv)
+
 declare Cons_eq_tails[simp]
 
 crunch "ThreadDecls_H.switchToThread"
@@ -1248,60 +1124,48 @@ lemma obj_tcb_at':
   "obj_at' (\<lambda>tcb::tcb. P tcb) t s \<Longrightarrow> tcb_at' t s"
   by (clarsimp simp: obj_at'_def)
 
-lemma valid_queues_not_tcbQueued_not_ksQ:
-  fixes s
-  assumes   vq: "valid_queues s"
-      and notq: "obj_at' (Not \<circ> tcbQueued) t s"
-  shows "\<forall>d p. t \<notin> set (ksReadyQueues s (d, p))"
-proof (rule ccontr, simp , erule exE, erule exE)
-  fix d p
-  assume "t \<in> set (ksReadyQueues s (d, p))"
-  with vq have "obj_at' (inQ d p) t s"
-    by (fastforce intro: valid_queues_obj_at'D)
-  hence "obj_at' tcbQueued t s"
-    apply (rule obj_at'_weakenE)
-    apply (simp only: inQ_def)
-    done
-  with notq show "False"
-    by (clarsimp simp: obj_at'_def)
-qed
-
-lemma not_tcbQueued_not_ksQ:
-  fixes s
-  assumes "invs' s"
-      and "obj_at' (Not \<circ> tcbQueued) t s"
-  shows "\<forall>d p. t \<notin> set (ksReadyQueues s (d, p))"
-  apply (insert assms)
-  apply (clarsimp simp add: invs'_def)
-  apply (drule(1) valid_queues_not_tcbQueued_not_ksQ)
-  apply clarsimp
+lemma tcb_at_typ_at':
+  "tcb_at' p s = typ_at' TCBT p s"
+  unfolding typ_at'_def
+  apply rule
+  apply (clarsimp simp add: obj_at'_def ko_wp_at'_def projectKOs)
+  apply (clarsimp simp add: obj_at'_def ko_wp_at'_def projectKOs)
+  apply (case_tac ko, simp_all)
   done
 
-lemma ct_not_ksQ:
-  "\<lbrakk> ct_not_inQ s; valid_queues s; ksSchedulerAction s = ResumeCurrentThread \<rbrakk>
-   \<Longrightarrow> \<forall>p. ksCurThread s \<notin> set (ksReadyQueues s p)"
-  apply (clarsimp simp: ct_not_inQ_def)
-  apply (frule(1) valid_queues_not_tcbQueued_not_ksQ)
-  apply (fastforce)
-  done
-
-lemma scheduleTCB_rct:
-  "\<lbrace>\<lambda>s. (t = ksCurThread s \<longrightarrow> isSchedulable_bool t s)
-        \<and> ksSchedulerAction s = ResumeCurrentThread\<rbrace>
-   scheduleTCB t
-   \<lbrace>\<lambda>_ s. ksSchedulerAction s = ResumeCurrentThread\<rbrace>"
-  unfolding scheduleTCB_def
-  by (wpsimp wp: isSchedulable_wp | rule hoare_pre_cont)+
+crunch getCurThread
+  for nosch[wp]: "\<lambda>s. P (ksSchedulerAction s)"
 
 lemma setThreadState_rct:
-  "\<lbrace>\<lambda>s. (t = ksCurThread s \<longrightarrow> runnable' st
-      \<and> pred_map (\<lambda>tcb. \<not>(tcbInReleaseQueue tcb)) (tcbs_of' s) t
-      \<and> pred_map (\<lambda>scPtr. isScActive scPtr s) (tcbSCs_of s) t)
+  "\<lbrace>\<lambda>s. (runnable' st \<or> ksCurThread s \<noteq> t)
         \<and> ksSchedulerAction s = ResumeCurrentThread\<rbrace>
    setThreadState st t
    \<lbrace>\<lambda>_ s. ksSchedulerAction s = ResumeCurrentThread\<rbrace>"
-  unfolding setThreadState_def
-  by (wpsimp wp: scheduleTCB_rct hoare_vcg_all_lift hoare_vcg_imp_lift' threadSet_isSchedulable_bool)
+  apply (simp add: setThreadState_def)
+  apply (rule hoare_pre_disj')
+   apply (rule bind_wp [OF _
+                 hoare_vcg_conj_lift
+                   [OF threadSet_tcbState_st_tcb_at' [where P=runnable']
+                       threadSet_nosch]])
+   apply (rule bind_wp [OF _
+                 hoare_vcg_conj_lift [OF isRunnable_const isRunnable_inv]])
+   apply (clarsimp simp: when_def)
+   apply (case_tac rv)
+    apply (clarsimp, wp)[1]
+   apply (clarsimp)
+  apply (rule bind_wp [OF _
+                hoare_vcg_conj_lift
+                  [OF threadSet_ct threadSet_nosch]])
+  apply (rule bind_wp [OF _ isRunnable_inv])
+  apply (rule bind_wp [OF _
+                hoare_vcg_conj_lift
+                  [OF gct_wp gct_wp]])
+  apply (rename_tac ct)
+  apply (case_tac "ct\<noteq>t")
+   apply (clarsimp simp: when_def)
+   apply (wp)[1]
+  apply (clarsimp)
+  done
 
 lemma bitmapQ_lookupBitmapPriority_simp: (* neater unfold, actual unfold is really ugly *)
   "\<lbrakk> ksReadyQueuesL1Bitmap s d \<noteq> 0 ;
@@ -1440,39 +1304,29 @@ lemma getReadyQueuesL2Bitmap_inv[wp]:
   unfolding getReadyQueuesL2Bitmap_def by wp
 
 lemma switchToThread_lookupBitmapPriority_wp:
-  "\<lbrace>\<lambda>s. invs' s \<and> bitmapQ (ksCurDomain s) (lookupBitmapPriority (ksCurDomain s) s) s \<and>
-        t = hd (ksReadyQueues s (ksCurDomain s, lookupBitmapPriority (ksCurDomain s) s)) \<rbrace>
+  "\<lbrace>\<lambda>s. invs_no_cicd' s \<and> bitmapQ (ksCurDomain s) (lookupBitmapPriority (ksCurDomain s) s) s \<and>
+        t = the (tcbQueueHead (ksReadyQueues s (ksCurDomain s, lookupBitmapPriority (ksCurDomain s) s)))\<rbrace>
    ThreadDecls_H.switchToThread t
    \<lbrace>\<lambda>rv. invs'\<rbrace>"
-proof -
-  have switchToThread_pre:
-    "\<And>s p t.\<lbrakk> valid_queues s ; \<forall>d p. \<forall>t \<in> set (ksReadyQueues s (d, p)). st_tcb_at' runnable' t s;
-              bitmapQ (ksCurDomain s) p s ; t = hd (ksReadyQueues s (ksCurDomain s, p)) \<rbrakk>
-            \<Longrightarrow> st_tcb_at' runnable' t s \<and> tcb_in_cur_domain' t s"
-    unfolding valid_queues_def
-    apply (clarsimp dest!: bitmapQ_ksReadyQueuesI)
-    apply (case_tac "ksReadyQueues s (ksCurDomain s, p)", simp)
-    apply (rename_tac t ts)
-    apply (drule_tac t=t and p=p and d="ksCurDomain s" in valid_queues_no_bitmap_objD)
-     apply simp
-    apply (fastforce intro: cons_set_intro
-                      elim: obj_at'_weaken
-                      simp: inQ_def tcb_in_cur_domain'_def)
-    done
-  thus ?thesis
-    apply (simp add: Thread_H.switchToThread_def)
-    apply (rule bind_wp[OF _ stateAssert_sp])
-    apply (wp switchToThread_invs'_helper)
-    apply (fastforce simp: st_tcb_at'_def obj_at_simps invs'_def ready_qs_runnable_def)
-    done
-qed
+  apply (simp add: Thread_H.switchToThread_def)
+  apply (wp setCurThread_invs_no_cicd' tcbSchedDequeue_not_tcbQueued
+            Arch_switchToThread_invs_no_cicd')
+  apply (auto elim!: pred_tcb'_weakenE)
+  apply (prop_tac "valid_bitmapQ s")
+   apply (clarsimp simp: all_invs_but_ct_idle_or_in_cur_domain'_def valid_bitmaps_def)
+  apply (clarsimp simp: ready_queue_relation_def ksReadyQueues_asrt_def valid_bitmapQ_bitmapQ_simp)
+  apply (drule_tac x="ksCurDomain s" in spec)
+  apply (drule_tac x="lookupBitmapPriority (ksCurDomain s) s" in spec)
+  apply (clarsimp simp: all_invs_but_ct_idle_or_in_cur_domain'_def valid_pspace'_def)
+  apply (frule (3) obj_at'_tcbQueueHead_ksReadyQueues)
+  apply (clarsimp simp: tcb_in_cur_domain'_def obj_at'_def tcbQueueEmpty_def inQ_def)
+  done
 
-lemma switchToIdleThread_invs':
-  "switchToIdleThread \<lbrace>invs'\<rbrace>"
+lemma switchToIdleThread_invs_no_cicd':
+  "\<lbrace>invs_no_cicd'\<rbrace> switchToIdleThread \<lbrace>\<lambda>rv. invs'\<rbrace>"
   apply (clarsimp simp: Thread_H.switchToIdleThread_def ARM_H.switchToIdleThread_def)
-  apply (wpsimp wp: setCurThread_invs')
-  apply (clarsimp simp: invs'_def valid_idle'_asrt_def
-                 dest!: valid_idle'_tcb_at')
+  apply (wp setCurThread_invs_no_cicd'_idle_thread setVMRoot_invs_no_cicd')
+  apply (clarsimp simp: all_invs_but_ct_idle_or_in_cur_domain'_def valid_idle'_def)
   done
 
 crunch "Arch.switchToIdleThread"
@@ -1487,9 +1341,11 @@ lemma setCurThread_const:
 
 
 
-crunch switchToIdleThread, switchToThread, chooseThread
+crunch switchToIdleThread
   for it[wp]: "\<lambda>s. P (ksIdleThread s)"
-  (wp: crunch_wps)
+crunch switchToThread
+  for it[wp]: "\<lambda>s. P (ksIdleThread s)"
+    (ignore: clearExMonitor)
 
 lemma switchToIdleThread_curr_is_idle:
   "\<lbrace>\<top>\<rbrace> switchToIdleThread \<lbrace>\<lambda>rv s. ksCurThread s = ksIdleThread s\<rbrace>"
@@ -1499,6 +1355,16 @@ lemma switchToIdleThread_curr_is_idle:
    apply (wp setCurThread_const)
   apply (simp)
  done
+
+lemma chooseThread_it[wp]:
+  "\<lbrace>\<lambda>s. P (ksIdleThread s)\<rbrace> chooseThread \<lbrace>\<lambda>_ s. P (ksIdleThread s)\<rbrace>"
+  supply if_split[split del]
+  by (wpsimp simp: chooseThread_def curDomain_def bitmap_fun_defs)
+
+lemma threadGet_inv [wp]: "\<lbrace>P\<rbrace> threadGet f t \<lbrace>\<lambda>rv. P\<rbrace>"
+  apply (simp add: threadGet_def)
+  apply (wp | simp)+
+  done
 
 lemma corres_split_sched_act:
   "\<lbrakk>sched_act_relation act act';
@@ -1521,16 +1387,28 @@ lemma corres_split_sched_act:
     apply (rule corres_guard_imp, force+)+
     done
 
+lemma corres_assert_ret:
+  "corres dc (\<lambda>s. P) \<top> (assert P) (return ())"
+  apply (rule corres_no_failI)
+   apply simp
+  apply (simp add: assert_def return_def fail_def)
+  done
+
+lemma corres_assert_assume_r:
+  "corres dc P Q f (g ())
+  \<Longrightarrow> corres dc P (Q and (\<lambda>s. Q')) f (assert Q' >>= g)"
+  by (force simp: corres_underlying_def assert_def return_def bind_def fail_def)
+
 crunch tcbSchedEnqueue
- for cur[wp]: cur_tcb'
+  for cur[wp]: cur_tcb'
   (simp: unless_def)
 
-lemma is_schedulable_exs_valid[wp]:
-  "active_sc_tcb_at t s \<Longrightarrow> \<lbrace>(=) s\<rbrace> is_schedulable t \<exists>\<lbrace>\<lambda>r. (=) s\<rbrace>"
-  apply (clarsimp simp: is_schedulable_def exs_valid_def Bex_def pred_map_def vs_all_heap_simps
-                 split: option.splits)
-  apply (clarsimp simp: in_monad get_tcb_ko_at obj_at_def get_sched_context_def Option.is_none_def
-                        get_object_def)
+lemma thread_get_exs_valid[wp]:
+  "tcb_at t s \<Longrightarrow> \<lbrace>(=) s\<rbrace> thread_get f t \<exists>\<lbrace>\<lambda>r. (=) s\<rbrace>"
+  apply (clarsimp simp: get_thread_state_def  assert_opt_def fail_def
+             thread_get_def gets_the_def exs_valid_def gets_def
+             get_def bind_def return_def split: option.splits)
+  apply (erule get_tcb_at)
   done
 
 lemma gts_exs_valid[wp]:
@@ -1546,24 +1424,17 @@ lemma guarded_switch_to_corres:
                 and valid_vspace_objs and pspace_aligned and pspace_distinct
                 and valid_vs_lookup and valid_global_objs
                 and unique_table_refs o caps_of_state
-                and schedulable t and valid_ready_qs)
-             (valid_arch_state' and valid_pspace' and Invariants_H.valid_queues
-                and st_tcb_at' runnable' t and cur_tcb')
+                and st_tcb_at runnable t and valid_etcbs and valid_queues and valid_idle)
+             (valid_arch_state' and no_0_obj' and sym_heap_sched_pointers and valid_objs')
              (guarded_switch_to t) (switchToThread t)"
   apply (simp add: guarded_switch_to_def)
   apply (rule corres_guard_imp)
-    apply (rule corres_symb_exec_l'[OF _ thread_get_exs_valid])
-      apply (rule corres_assert_opt_assume_l)
-      apply (rule corres_symb_exec_l'[OF _ is_schedulable_exs_valid])
-        apply (rule corres_assert_assume_l)
-        apply (rule switchToThread_corres)
-       apply assumption
-      apply (wpsimp wp: is_schedulable_wp)
-     apply assumption
-    apply (wpsimp wp: thread_get_wp')
-   apply (clarsimp simp: schedulable_def2 tcb_at_kh_simps pred_map_def vs_all_heap_simps
-                         obj_at_def is_tcb)
-  apply simp
+    apply (rule corres_symb_exec_l'[OF _ gts_exs_valid])
+      apply (rule corres_assert_assume_l)
+      apply (rule switchToThread_corres)
+     apply (force simp: st_tcb_at_tcb_at)
+    apply (wp gts_st_tcb_at)
+   apply (force simp: st_tcb_at_tcb_at projectKOs)+
   done
 
 abbreviation "enumPrio \<equiv> [0.e.maxPriority]"
@@ -1598,144 +1469,30 @@ lemma corres_gets_queues_getReadyQueuesL1Bitmap:
   apply (fastforce simp: bitmapL1_zero_ksReadyQueues list_queue_relation_def tcbQueueEmpty_def)
   done
 
-lemma tcb_at'_cross_rel:
-  "cross_rel (pspace_aligned and pspace_distinct and tcb_at t) (tcb_at' t)"
-  unfolding cross_rel_def state_relation_def
-  apply clarsimp
-  by (erule (3) tcb_at_cross)
-
-lemma sc_at'_cross_rel:
-  "cross_rel (pspace_aligned and pspace_distinct and sc_at t) (sc_at' t)"
-  unfolding cross_rel_def state_relation_def
-  apply clarsimp
-  by (erule (3) sc_at_cross)
-
-lemma ntfn_at'_cross_rel:
-  "cross_rel (pspace_aligned and pspace_distinct and ntfn_at t) (ntfn_at' t)"
-  unfolding cross_rel_def state_relation_def
-  apply clarsimp
-  by (erule (3) ntfn_at_cross)
-
-lemma runnable_cross_rel:
-  "cross_rel (pspace_aligned and pspace_distinct and st_tcb_at runnable t)
-             (\<lambda>s'. pred_map (\<lambda>tcb. runnable' (tcbState tcb)) (tcbs_of' s') t)"
-  apply (rule cross_rel_imp[OF tcb_at'_cross_rel[where t=t]])
-  apply (clarsimp simp: cross_rel_def)
-  apply (subgoal_tac "pspace_relation (kheap s) (ksPSpace s')")
-  apply (clarsimp simp: tcb_at_kh_simps pred_map_def cross_rel_def obj_at'_def)
-  apply (clarsimp simp: vs_all_heap_simps pspace_relation_def)
-  apply (drule_tac x=t in bspec; clarsimp)
-  apply (clarsimp simp: other_obj_relation_def split: option.splits)
-  apply (case_tac "ko"; simp)
-  apply (clarsimp simp: opt_map_def)
-  apply (clarsimp simp: tcb_relation_def thread_state_relation_def)
-  apply (case_tac "tcb_state b"; simp add: runnable_def)
-  apply clarsimp
-  apply clarsimp
-  done
-
-lemma tcbInReleaseQueue_cross_rel:
-  "cross_rel (pspace_aligned and pspace_distinct and tcb_at t and not_in_release_q t)
-             (\<lambda>s'. valid_release_queue' s' \<longrightarrow> pred_map (\<lambda>tcb. \<not> tcbInReleaseQueue tcb) (tcbs_of' s') t)"
-  apply (rule cross_rel_imp[OF tcb_at'_cross_rel[where t=t]])
-  apply (clarsimp simp: cross_rel_def)
-  apply (subgoal_tac "pspace_relation (kheap s) (ksPSpace s')")
-  apply (clarsimp simp: pred_map_def cross_rel_def obj_at'_def obj_at_def is_tcb)
-  apply (clarsimp simp: vs_all_heap_simps pspace_relation_def)
-  apply (drule_tac x=t in bspec; clarsimp)
-  apply (clarsimp simp: other_obj_relation_def split: option.splits)
-  apply (case_tac "koa"; simp)
-  apply (clarsimp simp: opt_map_def)
-  apply (subgoal_tac "obj_at' tcbInReleaseQueue t s'")
-  apply (subgoal_tac "release_queue_relation (release_queue s) (ksReleaseQueue s')")
-  apply (clarsimp simp: release_queue_relation_def not_in_release_q_def valid_release_queue'_def)
-  apply (clarsimp simp: state_relation_def)
-  apply (clarsimp simp: obj_at'_def projectKO_eq Bits_R.projectKO_tcb)
-  apply clarsimp
-  apply clarsimp
-  done
-
-lemma isScActive_cross_rel:
-  "cross_rel (pspace_aligned and pspace_distinct and valid_objs and active_sc_tcb_at t)
-             (\<lambda>s'. pred_map ((\<lambda>scPtr. isScActive scPtr s')) (tcbSCs_of s') t)"
-  apply (rule cross_rel_imp[OF tcb_at'_cross_rel[where t=t]])
-   apply (clarsimp simp: cross_rel_def)
-   apply (subgoal_tac "pspace_relation (kheap s) (ksPSpace s')")
-    apply (clarsimp simp: pred_map_def obj_at'_real_def ko_wp_at'_def vs_all_heap_simps)
-    apply (subgoal_tac "sc_at' ref' s'")
-     apply (clarsimp simp: vs_all_heap_simps pspace_relation_def)
-     apply (drule_tac x=t in bspec, clarsimp)
-     apply (clarsimp simp: other_obj_relation_def split: option.splits)
-     apply (rename_tac s s' scp ko' tcb sc n x)
-     apply (case_tac "ko'"; simp)
-     apply (subgoal_tac "pspace_relation (kheap s) (ksPSpace s')")
-      apply (clarsimp simp: vs_all_heap_simps pspace_relation_def)
-      apply (drule_tac x=scp in bspec, clarsimp)
-      apply (subgoal_tac "valid_sched_context_size n")
-       apply (clarsimp simp: other_obj_relation_def split: option.splits)
-       apply (clarsimp simp: obj_at'_def projectKO_eq Bits_R.projectKO_sc)
-       apply (clarsimp simp: opt_map_def tcb_relation_def)
-       apply (rule_tac x=scp in exI, simp)
-       apply (clarsimp simp: isScActive_def active_sc_def)
-       apply (clarsimp simp: obj_at'_def projectKO_eq Bits_R.projectKO_sc pred_map_def opt_map_def)
-       apply (clarsimp simp: sc_relation_def)
-      apply (rule_tac sc=sc in  valid_objs_valid_sched_context_size, assumption)
-      apply (fastforce)
-     apply clarsimp
-    apply (erule (2) sc_at_cross)
-    apply (clarsimp simp: obj_at_def is_sc_obj_def)
-    apply (rule_tac sc=ya in  valid_objs_valid_sched_context_size, assumption)
-    apply (fastforce)
-   apply clarsimp
-  apply (clarsimp simp: obj_at_kh_kheap_simps pred_map_def vs_all_heap_simps is_tcb)
-  done
-
-lemma isSchedulable_bool_cross_rel:
-  "cross_rel (pspace_aligned and pspace_distinct and valid_objs and schedulable t) (\<lambda>s'. valid_release_queue' s' \<longrightarrow> isSchedulable_bool t s')"
-  apply (rule cross_rel_imp[OF isScActive_cross_rel[where t=t]])
-   apply (rule cross_rel_imp[OF tcbInReleaseQueue_cross_rel[where t=t]])
-    apply (rule cross_rel_imp[OF runnable_cross_rel[where t=t]])
-     apply (clarsimp simp: isSchedulable_bool_def pred_map_conj[simplified pred_conj_def])
-    apply (clarsimp simp: schedulable_def2)+
-  done
-
-lemmas tcb_at'_example = corres_cross[where Q' = "tcb_at' t" for t, OF tcb_at'_cross_rel]
-
 lemma guarded_switch_to_chooseThread_fragment_corres:
   "corres dc
-    (P and schedulable t and invs and valid_ready_qs)
-    (P' and invs' and tcb_at' t)
-          (guarded_switch_to t)
-          (do schedulable \<leftarrow> isSchedulable t;
-              y \<leftarrow> assert schedulable;
-              ThreadDecls_H.switchToThread t
-           od)"
-  apply add_cur_tcb'
-  apply (rule corres_cross'[OF isSchedulable_bool_cross_rel[where t=t], rotated])
-    apply (clarsimp simp: invs_def valid_state_def valid_pspace_def)
-   apply (clarsimp simp: invs'_def)
-   unfolding guarded_switch_to_def
-   apply simp
-   apply (rule corres_guard_imp)
-     apply (rule corres_symb_exec_l_Ex)
-     apply (rule corres_symb_exec_l_Ex)
-     apply (rule corres_split[OF isSchedulable_corres])
-       apply (rule corres_assert_assume_l)
-       apply (rule corres_assert_assume_r)
-       apply (rule switchToThread_corres)
-      apply (wpsimp wp: is_schedulable_wp)
-     apply (wpsimp wp: isSchedulable_wp)
-    apply (prop_tac "st_tcb_at runnable t s \<and> bound_sc_tcb_at bound t s")
-     apply (clarsimp simp: schedulable_def2 tcb_at_kh_simps pred_map_def vs_all_heap_simps)
-    apply (clarsimp simp: st_tcb_at_tcb_at invs_def valid_state_def valid_pspace_def valid_sched_def
+    (P and st_tcb_at runnable t and invs and valid_sched)
+    (P' and invs_no_cicd')
+    (guarded_switch_to t)
+    (do runnable \<leftarrow> isRunnable t;
+        y \<leftarrow> assert runnable;
+        ThreadDecls_H.switchToThread t
+     od)"
+  apply (rule_tac Q'="st_tcb_at' runnable' t" in corres_cross_add_guard)
+   apply (fastforce intro!: st_tcb_at_runnable_cross simp: obj_at_def is_tcb_def)
+  unfolding guarded_switch_to_def isRunnable_def
+  apply simp
+  apply (rule corres_guard_imp)
+    apply (rule corres_split[OF getThreadState_corres])
+      apply (rule corres_assert_assume_l)
+      apply (rule corres_assert_assume_r)
+      apply (rule switchToThread_corres)
+     apply (wp gts_st_tcb_at)+
+   apply (clarsimp simp: st_tcb_at_tcb_at invs_def valid_state_def valid_pspace_def valid_sched_def
                           invs_valid_vs_lookup invs_unique_refs)
-    apply (clarsimp simp: thread_get_def in_monad pred_tcb_at_def obj_at_def get_tcb_ko_at)
-   apply (prop_tac "st_tcb_at' runnable' t s")
-    apply (clarsimp simp: pred_tcb_at'_def isSchedulable_bool_def pred_map_def obj_at'_def
-                          projectKO_eq
-                   elim!: opt_mapE)
-   apply fastforce
-  by (auto simp: invs'_def)
+  apply (auto elim!: pred_tcb'_weakenE split: thread_state.splits
+              simp: pred_tcb_at' runnable'_def all_invs_but_ct_idle_or_in_cur_domain'_def)
+  done
 
 lemma Max_prio_helper:
   "ready_queues_relation s s'
@@ -1756,27 +1513,30 @@ lemma Max_prio_helper:
 lemma bitmap_lookup_queue_is_max_non_empty:
   "\<lbrakk> valid_bitmaps s'; (s, s') \<in> state_relation; invs s;
      ksReadyQueuesL1Bitmap s' (ksCurDomain s') \<noteq> 0 \<rbrakk>
-   \<Longrightarrow> ksReadyQueues s' (ksCurDomain s', lookupBitmapPriority (ksCurDomain s') s') =
-        max_non_empty_queue (ready_queues s (cur_domain s))"
-  unfolding valid_queues_def
-  by (clarsimp simp add: max_non_empty_queue_def lookupBitmapPriority_Max_eqI
-                         state_relation_def ready_queues_relation_def)
+   \<Longrightarrow> the (tcbQueueHead (ksReadyQueues s' (ksCurDomain s', lookupBitmapPriority (ksCurDomain s') s')))
+       = hd (max_non_empty_queue (ready_queues s (cur_domain s)))"
+  apply (clarsimp simp: max_non_empty_queue_def valid_bitmaps_def lookupBitmapPriority_Max_eqI)
+  apply (frule curdomain_relation)
+  apply (drule state_relation_ready_queues_relation)
+  apply (simp add: Max_prio_helper)
+  apply (clarsimp simp: ready_queues_relation_def ready_queue_relation_def Let_def
+                        list_queue_relation_def)
+  apply (frule (2) bitmapL1_zero_ksReadyQueues[THEN arg_cong_Not, THEN iffD1])
+  apply clarsimp
+  apply (cut_tac P="\<lambda>x. \<not> tcbQueueEmpty (ksReadyQueues s' (ksCurDomain s', x))"
+              in setcomp_Max_has_prop)
+   apply fastforce
+  apply (clarsimp simp: ready_queues_relation_def Let_def list_queue_relation_def tcbQueueEmpty_def)
+  apply (drule_tac x="ksCurDomain s'" in spec)
+  apply (drule_tac x="Max {prio. \<not> tcbQueueEmpty (ksReadyQueues s' (ksCurDomain s', prio))}"
+                in spec)
+  using heap_path_head tcbQueueEmpty_def
+  by fastforce
 
 lemma ksReadyQueuesL1Bitmap_return_wp:
   "\<lbrace>\<lambda>s. P (ksReadyQueuesL1Bitmap s d) s \<rbrace> getReadyQueuesL1Bitmap d \<lbrace>\<lambda>rv s. P rv s\<rbrace>"
   unfolding getReadyQueuesL1Bitmap_def
   by wp
-
-lemma ksReadyQueuesL1Bitmap_st_tcb_at':
-  "\<lbrakk> ksReadyQueuesL1Bitmap s (ksCurDomain s) \<noteq> 0; valid_queues s;
-    (\<forall>d p. (\<forall>t \<in> set (ksReadyQueues s (d, p)). st_tcb_at' runnable' t s))\<rbrakk>
-   \<Longrightarrow> st_tcb_at' runnable' (hd (ksReadyQueues s (ksCurDomain s, lookupBitmapPriority (ksCurDomain s) s))) s"
-  apply (drule bitmapQ_from_bitmap_lookup; clarsimp simp: valid_queues_def)
-  apply (clarsimp simp add: valid_bitmapQ_bitmapQ_simp)
-  apply (case_tac "ksReadyQueues s (ksCurDomain s, lookupBitmapPriority (ksCurDomain s) s)")
-   apply simp
-  apply (fastforce intro: cons_set_intro)
-  done
 
 lemma curDomain_or_return_0:
   "\<lbrakk> \<lbrace>P\<rbrace> curDomain \<lbrace>\<lambda>rv s. Q rv s \<rbrace>; \<And>s. P s \<Longrightarrow> ksCurDomain s \<le> maxDomain \<rbrakk>
@@ -1785,59 +1545,74 @@ lemma curDomain_or_return_0:
   apply (simp add: valid_def curDomain_def simpler_gets_def return_def maxDomain_def)
   done
 
+lemma invs_no_cicd_ksCurDomain_maxDomain':
+  "invs_no_cicd' s \<Longrightarrow> ksCurDomain s \<le> maxDomain"
+  unfolding invs_no_cicd'_def by simp
+
 lemma chooseThread_corres:
-  "corres dc (invs and valid_ready_qs and ready_or_release) invs'
-     choose_thread chooseThread" (is "corres _ ?PREI ?PREH _ _")
-  apply add_ready_qs_runnable
-  unfolding choose_thread_def chooseThread_def
-  apply (rule corres_stateAssert_add_assertion[rotated])
-   apply (clarsimp simp: ready_qs_runnable_def)
-  apply (simp only: return_bind Let_def K_bind_def)
-  apply (subst if_swap[where P="_ \<noteq> 0"]) (* put switchToIdleThread on first branch*)
-  apply (rule corres_guard_imp)
-    apply (rule corres_split[OF curDomain_corres'])
-      apply clarsimp
-      apply (rule corres_split[OF corres_gets_queues_getReadyQueuesL1Bitmap])
-        apply (erule corres_if2[OF sym])
-         apply (rule switchToIdleThread_corres)
-        apply (rule corres_symb_exec_r)
-           apply (rule corres_symb_exec_r)
-              apply (rule_tac
-                       P="\<lambda>s. ?PREI s \<and> queues = ready_queues s (cur_domain s) \<and>
-                              schedulable (hd (max_non_empty_queue queues)) s" and
-                       P'="\<lambda>s. (?PREH s ) \<and> st_tcb_at' runnable' (hd queue) s \<and>
-                               l1 = ksReadyQueuesL1Bitmap s (ksCurDomain s) \<and>
-                               l1 \<noteq> 0 \<and>
-                               queue = ksReadyQueues s (ksCurDomain s,
-                                         lookupBitmapPriority (ksCurDomain s) s)" and
-                       F="hd queue = hd (max_non_empty_queue queues)" in corres_req)
-               apply (fastforce simp: bitmap_lookup_queue_is_max_non_empty invs'_def)
-              apply clarsimp
-              apply (rule corres_guard_imp)
-                apply (rule_tac P=\<top> and P'=\<top> in guarded_switch_to_chooseThread_fragment_corres)
-               apply (wp | clarsimp simp: getQueue_def getReadyQueuesL2Bitmap_def)+
-      apply (wp hoare_vcg_conj_lift hoare_vcg_imp_lift ksReadyQueuesL1Bitmap_return_wp)
-     apply (wpsimp wp: curDomain_or_return_0)+
-    apply (fastforce simp: invs_ksCurDomain_maxDomain')
-   apply (clarsimp simp: valid_sched_def DetSchedInvs_AI.valid_ready_qs_def max_non_empty_queue_def)
-   apply (erule_tac x="cur_domain s" in allE)
-   apply (erule_tac x="Max {prio. ready_queues s (cur_domain s) prio \<noteq> []}" in allE)
-   apply (case_tac "ready_queues s (cur_domain s) (Max {prio. ready_queues s (cur_domain s) prio \<noteq> []})")
-    apply (clarsimp)
-    apply (subgoal_tac
-             "ready_queues s (cur_domain s) (Max {prio. ready_queues s (cur_domain s) prio \<noteq> []}) \<noteq> []")
-     apply (fastforce elim!: setcomp_Max_has_prop)
-    apply (fastforce elim!: setcomp_Max_has_prop)
-   apply (clarsimp simp: tcb_at_kh_simps schedulable_def2 released_sc_tcb_at_def)
-   apply (subgoal_tac "in_ready_q a s", fastforce simp: ready_or_release_def)
-   apply (clarsimp simp: in_ready_q_def)
-    apply (rule_tac x="cur_domain s" in exI)
-    apply (rule_tac x="Max {prio. ready_queues s (cur_domain s) prio \<noteq> []}" in exI)
+  "corres dc (invs and valid_sched) invs_no_cicd' choose_thread chooseThread"
+  (is "corres _ ?PREI ?PREH _ _")
+proof -
+
+  (* if we only have one domain, we are in it *)
+  have one_domain_case:
+    "\<And>s. \<lbrakk> invs_no_cicd' s; numDomains \<le> 1 \<rbrakk> \<Longrightarrow> ksCurDomain s = 0"
+    by (simp add: all_invs_but_ct_idle_or_in_cur_domain'_def maxDomain_def)
+
+  show ?thesis
+    supply if_split[split del]
+    apply (clarsimp simp: choose_thread_def chooseThread_def)
+    apply add_ready_qs_runnable
+    apply (rule corres_stateAssert_add_assertion[rotated])
+     apply (fastforce intro: ksReadyQueues_asrt_cross)
+    apply (rule corres_stateAssert_add_assertion[rotated])
+     apply fastforce
+    apply (simp only: return_bind Let_def)
+    apply (subst if_swap[where P="_ \<noteq> 0"]) (* put switchToIdleThread on first branch*)
+    apply (rule corres_guard_imp)
+      apply (rule corres_split[OF curDomain_corres'])
+        apply clarsimp
+        apply (rule corres_split[OF corres_gets_queues_getReadyQueuesL1Bitmap])
+          apply (erule corres_if2[OF sym])
+           apply (rule switchToIdleThread_corres)
+          apply (rule corres_symb_exec_r)
+             apply (rule corres_symb_exec_r)
+                apply (rule_tac P="\<lambda>s. ?PREI s \<and> queues = ready_queues s (cur_domain s)
+                                       \<and> st_tcb_at runnable (hd (max_non_empty_queue queues)) s"
+                            and P'="\<lambda>s. ?PREH s \<and> l1 = ksReadyQueuesL1Bitmap s (ksCurDomain s)
+                                        \<and> l1 \<noteq> 0
+                                        \<and> queue = ksReadyQueues s (ksCurDomain s,
+                                                                   lookupBitmapPriority (ksCurDomain s) s)"
+                            and F="the (tcbQueueHead queue) = hd (max_non_empty_queue queues)"
+                             in corres_req)
+                 apply (fastforce simp: bitmap_lookup_queue_is_max_non_empty
+                                        all_invs_but_ct_idle_or_in_cur_domain'_def)
+                apply clarsimp
+                apply (rule corres_guard_imp)
+                  apply (rule_tac P=\<top> and P'=\<top> in guarded_switch_to_chooseThread_fragment_corres)
+                 apply (wpsimp simp: getQueue_def getReadyQueuesL2Bitmap_def)+
+        apply (wp hoare_vcg_conj_lift hoare_vcg_imp_lift ksReadyQueuesL1Bitmap_return_wp)
+       apply (wpsimp wp: curDomain_or_return_0 simp: curDomain_def)+
+     apply (clarsimp simp: valid_sched_def max_non_empty_queue_def valid_queues_def split: if_splits)
+     apply (erule_tac x="cur_domain s" in allE)
+     apply (erule_tac x="Max {prio. ready_queues s (cur_domain s) prio \<noteq> []}" in allE)
+     apply (case_tac "ready_queues s (cur_domain s)
+                                     (Max {prio. ready_queues s (cur_domain s) prio
+                      \<noteq> []})")
+      apply (clarsimp)
+      apply (subgoal_tac "ready_queues s (cur_domain s)
+                                         (Max {prio. ready_queues s (cur_domain s) prio \<noteq> []})
+                          \<noteq> []")
+       apply fastforce
+      apply (fastforce elim!: setcomp_Max_has_prop)
+     apply fastforce
     apply clarsimp
-  apply (simp add: invs_ksCurDomain_maxDomain')
-  apply (clarsimp simp: ready_qs_runnable_def)
-  apply (fastforce intro: ksReadyQueuesL1Bitmap_st_tcb_at')
-  done
+    apply (frule invs_no_cicd_ksCurDomain_maxDomain')
+    apply (prop_tac "valid_bitmaps s")
+     apply (simp add: all_invs_but_ct_idle_or_in_cur_domain'_def)
+    apply (fastforce dest: one_domain_case split: if_splits)
+    done
+qed
 
 lemma thread_get_comm: "do x \<leftarrow> thread_get f p; y \<leftarrow> gets g; k x y od =
            do y \<leftarrow> gets g; x \<leftarrow> thread_get f p; k x y od"
@@ -1857,49 +1632,38 @@ lemma schact_bind_inside: "do x \<leftarrow> f; (case act of resume_cur_thread \
   apply (case_tac act,simp_all)
   done
 
+interpretation tcb_sched_action_extended: is_extended' "tcb_sched_action f a"
+  by (unfold_locales)
+
 lemma getDomainTime_corres:
   "corres (=) \<top> \<top> (gets domain_time) getDomainTime"
   by (simp add: getDomainTime_def state_relation_def)
 
-lemma \<mu>s_in_ms_equiv:
-  "\<mu>s_in_ms = usInMs"
-  by (simp add: usInMs_def \<mu>s_in_ms_def)
-
-lemma us_to_ticks_equiv:
-  "us_to_ticks = usToTicks"
-  by (simp add: usToTicks_def)
-
-lemma reset_work_units_equiv:
-  "do_extended_op (modify (work_units_completed_update (\<lambda>_. 0)))
-   = (modify (work_units_completed_update (\<lambda>_. 0)))"
-  by (clarsimp simp: reset_work_units_def[symmetric])
-
 lemma nextDomain_corres:
   "corres dc \<top> \<top> next_domain nextDomain"
-  apply (clarsimp simp: next_domain_def nextDomain_def reset_work_units_equiv modify_modify)
+  apply (simp add: next_domain_def nextDomain_def)
   apply (rule corres_modify)
-  apply (simp add: state_relation_def Let_def dschLength_def dschDomain_def cdt_relation_def
-                   \<mu>s_in_ms_equiv us_to_ticks_equiv)
+  apply (simp add: state_relation_def Let_def dschLength_def dschDomain_def)
   done
 
 lemma next_domain_valid_sched[wp]:
   "\<lbrace> valid_sched and (\<lambda>s. scheduler_action s  = choose_new_thread)\<rbrace> next_domain \<lbrace> \<lambda>_. valid_sched \<rbrace>"
   apply (simp add: next_domain_def Let_def)
   apply (wp, simp add: valid_sched_def valid_sched_action_2_def ct_not_in_q_2_def)
-  apply (fastforce simp: valid_blocked_defs)
+  apply (simp add:valid_blocked_2_def)
   done
 
-lemma nextDomain_invs':
-  "nextDomain \<lbrace>invs'\<rbrace>"
-  apply (simp add: nextDomain_def Let_def dschLength_def)
+lemma nextDomain_invs_no_cicd':
+  "\<lbrace> invs' and (\<lambda>s. ksSchedulerAction s = ChooseNewThread)\<rbrace> nextDomain \<lbrace> \<lambda>_. invs_no_cicd' \<rbrace>"
+  apply (simp add: nextDomain_def Let_def dschLength_def dschDomain_def)
   apply wp
-  apply (clarsimp simp: invs'_def valid_machine_state'_def dschDomain_def valid_dom_schedule'_def)
+  apply (clarsimp simp: invs'_def valid_state'_def valid_machine_state'_def
+                        ct_not_inQ_def cur_tcb'_def ct_idle_or_in_cur_domain'_def dschDomain_def
+                        all_invs_but_ct_idle_or_in_cur_domain'_def)
   done
 
 lemma scheduleChooseNewThread_fragment_corres:
-  "corres dc (invs and valid_ready_qs and ready_or_release
-              and (\<lambda>s. scheduler_action s = choose_new_thread))
-             (invs' and (\<lambda>s. ksSchedulerAction s = ChooseNewThread))
+  "corres dc (invs and valid_sched and (\<lambda>s. scheduler_action s = choose_new_thread)) (invs' and (\<lambda>s. ksSchedulerAction s = ChooseNewThread))
      (do _ \<leftarrow> when (domainTime = 0) next_domain;
          choose_thread
       od)
@@ -1909,18 +1673,18 @@ lemma scheduleChooseNewThread_fragment_corres:
   apply (subst bind_dummy_ret_val)
   apply (subst bind_dummy_ret_val)
   apply (rule corres_guard_imp)
-    apply (rule corres_split[OF corres_when])
-        apply simp
+    apply (rule corres_split)
+       apply (rule corres_when, simp)
        apply (rule nextDomain_corres)
       apply simp
       apply (rule chooseThread_corres)
-     apply (wp nextDomain_invs')+
-   apply (clarsimp simp: valid_sched_def invs'_def)+
+     apply (wp nextDomain_invs_no_cicd')+
+   apply (clarsimp simp: valid_sched_def invs'_def valid_state'_def all_invs_but_ct_idle_or_in_cur_domain'_def)+
   done
 
 lemma scheduleSwitchThreadFastfail_corres:
   "\<lbrakk> ct \<noteq> it \<longrightarrow> (tp = tp' \<and> cp = cp') ; ct = ct' ; it = it' \<rbrakk> \<Longrightarrow>
-   corres ((=)) (tcb_at ct) (tcb_at' ct)
+   corres ((=)) (is_etcb_at ct) (tcb_at' ct)
      (schedule_switch_thread_fastfail ct it cp tp)
      (scheduleSwitchThreadFastfail ct' it' cp' tp')"
   by (clarsimp simp: schedule_switch_thread_fastfail_def scheduleSwitchThreadFastfail_def)
@@ -1959,23 +1723,26 @@ lemma isHighestPrio_corres:
          apply (wpsimp simp: if_apply_def2 wp: hoare_drop_imps ksReadyQueuesL1Bitmap_return_wp)+
   done
 
+crunch set_scheduler_action
+  for valid_idle_etcb[wp]: valid_idle_etcb
+
 crunch isHighestPrio
- for inv[wp]: P
+  for inv[wp]: P
 crunch curDomain
- for inv[wp]: P
+  for inv[wp]: P
+crunch schedule_switch_thread_fastfail
+  for inv[wp]: P
 crunch scheduleSwitchThreadFastfail
- for inv[wp]: P
+  for inv[wp]: P
 
 lemma setSchedulerAction_invs': (* not in wp set, clobbered by ssa_wp *)
-  "\<lbrace>\<lambda>s. invs' s \<rbrace> setSchedulerAction ChooseNewThread \<lbrace>\<lambda>_. invs' \<rbrace>"
-  by (wpsimp simp: invs'_def cur_tcb'_def valid_irq_node'_def ct_not_inQ_def
-                   valid_queues_def valid_release_queue_def valid_release_queue'_def
-                   valid_queues_no_bitmap_def valid_queues'_def ct_idle_or_in_cur_domain'_def
-                   valid_dom_schedule'_def)
+  "setSchedulerAction ChooseNewThread \<lbrace>invs' \<rbrace>"
+  by (wpsimp simp: invs'_def cur_tcb'_def valid_state'_def valid_irq_node'_def ct_not_inQ_def
+                   ct_idle_or_in_cur_domain'_def)
 
 lemma scheduleChooseNewThread_corres:
   "corres dc
-    (\<lambda>s. invs s \<and> valid_ready_qs s \<and> ready_or_release s \<and> scheduler_action s = choose_new_thread)
+    (\<lambda>s. invs s \<and> valid_sched s \<and> scheduler_action s = choose_new_thread)
     (\<lambda>s. invs' s \<and> ksSchedulerAction s = ChooseNewThread)
            schedule_choose_new_thread scheduleChooseNewThread"
   unfolding schedule_choose_new_thread_def scheduleChooseNewThread_def
@@ -1985,17 +1752,239 @@ lemma scheduleChooseNewThread_corres:
         apply (rule setSchedulerAction_corres)
         apply (wp | simp)+
     apply (wp | simp add: getDomainTime_def)+
+   apply auto
   done
+
+crunch guarded_switch_to
+  for static_inv[wp]: "\<lambda>_. P"
+
+lemma ethread_get_when_corres:
+  assumes x: "\<And>etcb tcb'. etcb_relation etcb tcb' \<Longrightarrow> r (f etcb) (f' tcb')"
+  shows      "corres (\<lambda>rv rv'. b \<longrightarrow> r rv rv') (is_etcb_at t) (tcb_at' t)
+                (ethread_get_when b f t) (threadGet f' t)"
+  apply (clarsimp simp: ethread_get_when_def)
+  apply (rule conjI; clarsimp)
+  apply (rule corres_guard_imp, rule ethreadget_corres; simp add: x)
+  apply (clarsimp simp: threadGet_def)
+  apply (rule corres_noop)
+  apply wpsimp+
+  done
+
+lemma tcb_sched_enqueue_in_correct_ready_q[wp]:
+  "tcb_sched_action tcb_sched_enqueue t \<lbrace>in_correct_ready_q\<rbrace> "
+  unfolding tcb_sched_action_def tcb_sched_enqueue_def set_tcb_queue_def
+  apply wpsimp
+  apply (clarsimp simp: in_correct_ready_q_def obj_at_def etcb_at_def is_etcb_at_def
+                 split: option.splits)
+  done
+
+lemma tcb_sched_append_in_correct_ready_q[wp]:
+  "tcb_sched_action tcb_sched_append tcb_ptr \<lbrace>in_correct_ready_q\<rbrace> "
+  unfolding tcb_sched_action_def tcb_sched_append_def
+  apply wpsimp
+  apply (clarsimp simp: in_correct_ready_q_def obj_at_def etcb_at_def is_etcb_at_def
+                 split: option.splits)
+  done
+
+lemma tcb_sched_enqueue_ready_qs_distinct[wp]:
+  "tcb_sched_action tcb_sched_enqueue t \<lbrace>ready_qs_distinct\<rbrace> "
+  unfolding tcb_sched_action_def set_tcb_queue_def
+  apply (wpsimp wp: thread_get_wp')
+  apply (clarsimp simp: ready_qs_distinct_def etcb_at_def is_etcb_at_def split: option.splits)
+  done
+
+lemma tcb_sched_append_ready_qs_distinct[wp]:
+  "tcb_sched_action tcb_sched_append t \<lbrace>ready_qs_distinct\<rbrace> "
+  unfolding tcb_sched_action_def tcb_sched_append_def set_tcb_queue_def
+  apply (wpsimp wp: thread_get_wp')
+  apply (clarsimp simp: ready_qs_distinct_def etcb_at_def is_etcb_at_def split: option.splits)
+  done
+
+crunch set_scheduler_action
+  for in_correct_ready_q[wp]: in_correct_ready_q
+  and ready_qs_distinct[wp]: ready_qs_distinct
+  (wp: crunch_wps simp: in_correct_ready_q_def ready_qs_distinct_def)
+
+crunch reschedule_required
+  for in_correct_ready_q[wp]: in_correct_ready_q
+  and ready_qs_distinct[wp]: ready_qs_distinct
+  (ignore: tcb_sched_action wp: crunch_wps ignore_del: reschedule_required)
+
+lemma schedule_corres:
+  "corres dc (invs and valid_sched and valid_list) invs' (Schedule_A.schedule) ThreadDecls_H.schedule"
+  supply ethread_get_wp[wp del]
+  supply tcbSchedEnqueue_invs'[wp del]
+  supply tcbSchedEnqueue_invs'_not_ResumeCurrentThread[wp del]
+  supply setSchedulerAction_direct[wp]
+  supply if_split[split del]
+
+  apply (clarsimp simp: Schedule_A.schedule_def Thread_H.schedule_def)
+  apply (subst thread_get_test)
+  apply (subst thread_get_comm)
+  apply (subst schact_bind_inside)
+  apply (rule corres_guard_imp)
+    apply (rule corres_split[OF getCurThread_corres[THEN corres_rel_imp[where r="\<lambda>x y. y = x"],simplified]])
+      apply (rule corres_split[OF getSchedulerAction_corres])
+        apply (rule corres_split_sched_act,assumption)
+          apply (rule_tac P="tcb_at ct" in corres_symb_exec_l')
+            apply (rule_tac corres_symb_exec_l)
+               apply simp
+               apply (rule corres_assert_ret)
+              apply ((wpsimp wp: thread_get_wp' gets_exs_valid)+)
+         prefer 2
+         (* choose thread *)
+         apply clarsimp
+         apply (rule corres_split[OF thread_get_isRunnable_corres])
+           apply (rule corres_split)
+              apply (rule corres_when, simp)
+              apply (rule tcbSchedEnqueue_corres, simp)
+             apply (rule scheduleChooseNewThread_corres, simp)
+            apply (wp thread_get_wp' tcbSchedEnqueue_invs' hoare_vcg_conj_lift hoare_drop_imps
+                   | clarsimp)+
+        (* switch to thread *)
+        apply (rule corres_split[OF thread_get_isRunnable_corres],
+                rename_tac was_running wasRunning)
+          apply (rule corres_split)
+             apply (rule corres_when, simp)
+             apply (rule tcbSchedEnqueue_corres, simp)
+            apply (rule corres_split[OF getIdleThread_corres], rename_tac it it')
+              apply (rule_tac F="was_running \<longrightarrow> ct \<noteq> it" in corres_gen_asm)
+              apply (rule corres_split)
+                 apply (rule ethreadget_corres[where r="(=)"])
+                 apply (clarsimp simp: etcb_relation_def)
+                apply (rename_tac tp tp')
+                apply (rule corres_split)
+                   apply (rule ethread_get_when_corres[where r="(=)"])
+                   apply (clarsimp simp: etcb_relation_def)
+                  apply (rename_tac cp cp')
+                  apply (rule corres_split)
+                     apply (rule scheduleSwitchThreadFastfail_corres; simp)
+                    apply (rule corres_split[OF curDomain_corres])
+                      apply (rule corres_split[OF isHighestPrio_corres]; simp only:)
+                        apply (rule corres_if, simp)
+                         apply (rule corres_split[OF tcbSchedEnqueue_corres], simp)
+                           apply (simp, fold dc_def)
+                           apply (rule corres_split)
+                              apply (rule setSchedulerAction_corres; simp)
+                             apply (rule scheduleChooseNewThread_corres)
+                            apply (wp | simp)+
+                            apply (simp add: valid_sched_def)
+                            apply wp
+                            apply (rule hoare_vcg_conj_lift)
+                             apply (rule_tac t=t in set_scheduler_action_cnt_valid_blocked')
+                            apply (wpsimp wp: setSchedulerAction_invs')+
+                          apply (wp tcb_sched_action_enqueue_valid_blocked hoare_vcg_all_lift enqueue_thread_queued)
+                         apply (wp tcbSchedEnqueue_invs'_not_ResumeCurrentThread)
+                        apply (rule corres_if, fastforce)
+                         apply (rule corres_split[OF tcbSchedAppend_corres], simp)
+                           apply (simp, fold dc_def)
+                           apply (rule corres_split)
+                              apply (rule setSchedulerAction_corres; simp)
+                             apply (rule scheduleChooseNewThread_corres)
+                            apply (wp | simp)+
+                            apply (simp add: valid_sched_def)
+                            apply wp
+                            apply (rule hoare_vcg_conj_lift)
+                             apply (rule_tac t=t in set_scheduler_action_cnt_valid_blocked')
+                            apply (wpsimp wp: setSchedulerAction_invs')+
+                          apply (wp tcb_sched_action_append_valid_blocked hoare_vcg_all_lift append_thread_queued)
+                         apply (wp tcbSchedAppend_invs'_not_ResumeCurrentThread)
+
+                        apply (rule corres_split[OF guarded_switch_to_corres], simp)
+                          apply (rule setSchedulerAction_corres[simplified dc_def])
+                          apply (wp | simp)+
+
+                      (* isHighestPrio *)
+                      apply (clarsimp simp: if_apply_def2)
+                      apply ((wp (once) hoare_drop_imp)+)[1]
+
+                     apply (simp add: if_apply_def2)
+                     apply ((wp (once) hoare_drop_imp)+)[1]
+                    apply wpsimp+
+
+           apply (clarsimp simp: conj_ac cong: conj_cong)
+           apply wp
+           apply (rule_tac Q'="\<lambda>_ s. valid_blocked_except t s \<and> scheduler_action s = switch_thread t"
+                    in hoare_post_imp, fastforce)
+           apply (wp add: tcb_sched_action_enqueue_valid_blocked_except
+                          tcbSchedEnqueue_invs'_not_ResumeCurrentThread thread_get_wp
+                     del: gets_wp
+                  | strengthen valid_objs'_valid_tcbs')+
+       apply (clarsimp simp: conj_ac if_apply_def2 cong: imp_cong conj_cong)
+       apply (wp gets_wp)+
+
+   (* abstract final subgoal *)
+   apply clarsimp
+
+   subgoal for s
+     apply (clarsimp split: Deterministic_A.scheduler_action.splits
+                     simp: invs_psp_aligned invs_distinct invs_valid_objs invs_arch_state
+                           invs_vspace_objs[simplified] tcb_at_invs)
+     apply (rule conjI, clarsimp)
+      apply (fastforce simp: invs_def
+                            valid_sched_def valid_sched_action_def is_activatable_def
+                            st_tcb_at_def obj_at_def valid_state_def only_idle_def
+                            )
+     apply (rule conjI, clarsimp)
+      subgoal for candidate
+        apply (clarsimp simp: valid_sched_def invs_def valid_state_def cur_tcb_def
+                               valid_arch_caps_def valid_sched_action_def
+                               weak_valid_sched_action_def tcb_at_is_etcb_at
+                               tcb_at_is_etcb_at[OF st_tcb_at_tcb_at[rotated]]
+                               valid_blocked_except_def valid_blocked_def)
+        apply (fastforce simp add: pred_tcb_at_def obj_at_def is_tcb valid_idle_def)
+        done
+     (* choose new thread case *)
+     apply (intro impI conjI allI tcb_at_invs
+            | fastforce simp: invs_def cur_tcb_def valid_etcbs_def
+                              valid_sched_def  st_tcb_at_def obj_at_def valid_state_def
+                              weak_valid_sched_action_def not_cur_thread_def)+
+     done
+
+  (* haskell final subgoal *)
+  apply (clarsimp simp: if_apply_def2 invs'_def valid_state'_def valid_sched_def
+                  cong: imp_cong  split: scheduler_action.splits)
+  apply (fastforce simp: cur_tcb'_def valid_pspace'_def)
+  done
+
+lemma ssa_all_invs_but_ct_not_inQ':
+  "\<lbrace>all_invs_but_ct_not_inQ' and sch_act_wf sa and
+   (\<lambda>s. sa = ResumeCurrentThread \<longrightarrow> ksCurThread s = ksIdleThread s \<or> tcb_in_cur_domain' (ksCurThread s) s)\<rbrace>
+   setSchedulerAction sa \<lbrace>\<lambda>rv. all_invs_but_ct_not_inQ'\<rbrace>"
+proof -
+  show ?thesis
+    apply (simp add: setSchedulerAction_def)
+    apply wp
+    apply (clarsimp simp add: invs'_def valid_state'_def cur_tcb'_def
+                              state_refs_of'_def ps_clear_def valid_irq_node'_def
+                              tcb_in_cur_domain'_def ct_idle_or_in_cur_domain'_def bitmapQ_defs
+                        cong: option.case_cong)
+    done
+qed
 
 lemma ssa_ct_not_inQ:
   "\<lbrace>\<lambda>s. sa = ResumeCurrentThread \<longrightarrow> obj_at' (Not \<circ> tcbQueued) (ksCurThread s) s\<rbrace>
    setSchedulerAction sa \<lbrace>\<lambda>rv. ct_not_inQ\<rbrace>"
   by (simp add: setSchedulerAction_def ct_not_inQ_def, wp, clarsimp)
 
+lemma ssa_all_invs_but_ct_not_inQ''[simplified]:
+  "\<lbrace>\<lambda>s. (all_invs_but_ct_not_inQ' s \<and> sch_act_wf sa s)
+    \<and> (sa = ResumeCurrentThread \<longrightarrow> ksCurThread s = ksIdleThread s \<or> tcb_in_cur_domain' (ksCurThread s) s)
+    \<and> (sa = ResumeCurrentThread \<longrightarrow> obj_at' (Not \<circ> tcbQueued) (ksCurThread s) s)\<rbrace>
+   setSchedulerAction sa \<lbrace>\<lambda>rv. invs'\<rbrace>"
+  apply (simp only: all_invs_but_not_ct_inQ_check' [symmetric])
+  apply (rule hoare_elim_pred_conj)
+  apply (wp hoare_vcg_conj_lift [OF ssa_all_invs_but_ct_not_inQ' ssa_ct_not_inQ])
+  apply (clarsimp)
+  done
+
 lemma ssa_invs':
-  "setSchedulerAction sa \<lbrace>invs'\<rbrace>"
-  apply (wp ssa_ct_not_inQ)
-  apply (clarsimp simp: invs'_def valid_irq_node'_def valid_dom_schedule'_def)
+  "\<lbrace>invs' and sch_act_wf sa and
+    (\<lambda>s. sa = ResumeCurrentThread \<longrightarrow> ksCurThread s = ksIdleThread s \<or> tcb_in_cur_domain' (ksCurThread s) s) and
+    (\<lambda>s. sa = ResumeCurrentThread \<longrightarrow> obj_at' (Not \<circ> tcbQueued) (ksCurThread s) s)\<rbrace>
+   setSchedulerAction sa \<lbrace>\<lambda>rv. invs'\<rbrace>"
+  apply (wp ssa_all_invs_but_ct_not_inQ'')
+  apply (clarsimp simp add: invs'_def valid_state'_def)
   done
 
 lemma getDomainTime_wp[wp]: "\<lbrace>\<lambda>s. P (ksDomainTime s) s \<rbrace> getDomainTime \<lbrace> P \<rbrace>"
@@ -2003,12 +1992,12 @@ lemma getDomainTime_wp[wp]: "\<lbrace>\<lambda>s. P (ksDomainTime s) s \<rbrace>
   by wp
 
 lemma switchToThread_ct_not_queued_2:
-  "\<lbrace>invs' and tcb_at' t\<rbrace> switchToThread t \<lbrace>\<lambda>rv s. obj_at' (Not \<circ> tcbQueued) (ksCurThread s) s\<rbrace>"
+  "\<lbrace>invs_no_cicd' and tcb_at' t\<rbrace> switchToThread t \<lbrace>\<lambda>rv s. obj_at' (Not \<circ> tcbQueued) (ksCurThread s) s\<rbrace>"
   (is "\<lbrace>_\<rbrace> _ \<lbrace>\<lambda>_. ?POST\<rbrace>")
   apply (simp add: Thread_H.switchToThread_def)
-  apply wp
+  apply (wp)
     apply (simp add: ARM_H.switchToThread_def setCurThread_def)
-    apply (wpsimp wp: tcbSchedDequeue_not_tcbQueued hoare_drop_imps)+
+    apply (wp tcbSchedDequeue_not_tcbQueued hoare_drop_imp | simp )+
   done
 
 lemma setCurThread_obj_at':
@@ -2021,982 +2010,177 @@ proof -
     done
 qed
 
-lemma switchToIdleThread_ct_not_queued:
-  "\<lbrace> invs' \<rbrace> switchToIdleThread \<lbrace>\<lambda>_ s. obj_at' (Not \<circ> tcbQueued) (ksCurThread s) s \<rbrace>"
+lemma switchToIdleThread_ct_not_queued_no_cicd':
+  "\<lbrace>invs_no_cicd'\<rbrace> switchToIdleThread \<lbrace>\<lambda>_ s. obj_at' (Not \<circ> tcbQueued) (ksCurThread s) s \<rbrace>"
   apply (simp add: Thread_H.switchToIdleThread_def)
   apply (wp setCurThread_obj_at')
-  apply (intro impI)
-  apply (rule idle'_not_tcbQueued')
-     apply (simp add: ready_qs_runnable_def invs'_def valid_idle'_asrt_def)+
+  apply (clarsimp simp: ready_qs_runnable_def)
+  apply (drule_tac x="ksIdleThread s" in spec)
+  apply (clarsimp simp: invs_no_cicd'_def valid_idle'_def st_tcb_at'_def idle_tcb'_def obj_at'_def)
   done
 
 lemma switchToIdleThread_activatable_2[wp]:
-  "\<lbrace>invs'\<rbrace> switchToIdleThread \<lbrace>\<lambda>_. ct_in_state' activatable'\<rbrace>"
+  "\<lbrace>invs_no_cicd'\<rbrace> switchToIdleThread \<lbrace>\<lambda>rv. ct_in_state' activatable'\<rbrace>"
   apply (simp add: Thread_H.switchToIdleThread_def
                    ARM_H.switchToIdleThread_def)
   apply (wp setCurThread_ct_in_state)
-  apply (clarsimp simp: invs'_def valid_idle'_def valid_idle'_asrt_def
+  apply (clarsimp simp: all_invs_but_ct_idle_or_in_cur_domain'_def valid_state'_def valid_idle'_def
                         pred_tcb_at'_def obj_at'_def idle_tcb'_def)
   done
 
 lemma switchToThread_tcb_in_cur_domain':
   "\<lbrace>tcb_in_cur_domain' thread\<rbrace>
    ThreadDecls_H.switchToThread thread
-   \<lbrace>\<lambda>_ s. tcb_in_cur_domain' (ksCurThread s) s\<rbrace>"
+   \<lbrace>\<lambda>y s. tcb_in_cur_domain' (ksCurThread s) s\<rbrace>"
   apply (simp add: Thread_H.switchToThread_def setCurThread_def)
-  apply (wpsimp wp: tcbSchedDequeue_not_tcbQueued tcbSchedDequeue_tcbDomain
-                    hoare_drop_imps)
+  apply (wpsimp wp: tcbSchedDequeue_not_tcbQueued hoare_drop_imps)
   done
 
-lemma chooseThread_invs'_posts: (* generic version *)
-  "\<lbrace> invs' \<rbrace> chooseThread
+lemma chooseThread_invs_no_cicd'_posts: (* generic version *)
+  "\<lbrace> invs_no_cicd' \<rbrace> chooseThread
    \<lbrace>\<lambda>rv s. obj_at' (Not \<circ> tcbQueued) (ksCurThread s) s \<and>
            ct_in_state' activatable' s \<and>
            (ksCurThread s = ksIdleThread s \<or> tcb_in_cur_domain' (ksCurThread s) s) \<rbrace>"
-  unfolding chooseThread_def Let_def
-  apply (simp only: return_bind, simp split del: if_split)
-  apply (rule bind_wp[OF _ stateAssert_sp])
-  apply (rule bind_wp[where Q'="\<lambda>rv s. invs' s \<and> rv = ksCurDomain s \<and> ready_qs_runnable s"])
-   apply (rule_tac Q'="\<lambda>rv s. invs' s \<and> curdom = ksCurDomain s \<and>
-                             rv = ksReadyQueuesL1Bitmap s curdom \<and> ready_qs_runnable s"
-                in bind_wp)
-    apply (rename_tac l1)
-    apply (case_tac "l1 = 0")
-     (* switch to idle thread *)
-     apply simp
-     apply (rule hoare_pre)
-      apply (wp (once) switchToIdleThread_ct_not_queued)
-      apply (wp (once))
-      apply ((wp hoare_disjI1 switchToIdleThread_curr_is_idle)+)[1]
+    (is "\<lbrace>_\<rbrace> _ \<lbrace>\<lambda>_. ?POST\<rbrace>")
+proof -
+  note switchToThread_invs[wp del]
+  note switchToThread_invs_no_cicd'[wp del]
+  note switchToThread_lookupBitmapPriority_wp[wp]
+  note assert_wp[wp del]
+  note if_split[split del]
+
+  (* if we only have one domain, we are in it *)
+  have one_domain_case:
+    "\<And>s. \<lbrakk> invs_no_cicd' s; numDomains \<le> 1 \<rbrakk> \<Longrightarrow> ksCurDomain s = 0"
+    by (simp add: all_invs_but_ct_idle_or_in_cur_domain'_def maxDomain_def)
+
+  show ?thesis
+    apply (clarsimp simp: chooseThread_def Let_def curDomain_def)
+    apply (rule bind_wp[OF _ stateAssert_sp])+
+    apply (simp only: return_bind, simp)
+    apply (rule bind_wp[where Q'="\<lambda>rv s. invs_no_cicd' s \<and> rv = ksCurDomain s
+                                              \<and> ksReadyQueues_asrt s \<and> ready_qs_runnable s"])
+     apply (rule_tac Q'="\<lambda>rv s. invs_no_cicd' s \<and> curdom = ksCurDomain s \<and>
+                                rv = ksReadyQueuesL1Bitmap s curdom \<and>
+                                ksReadyQueues_asrt s \<and> ready_qs_runnable s" in bind_wp)
+      apply (rename_tac l1)
+      apply (case_tac "l1 = 0")
+       (* switch to idle thread *)
+       apply simp
+       apply (rule hoare_pre)
+        apply (wp (once) switchToIdleThread_ct_not_queued_no_cicd')
+        apply (wp (once))
+        apply ((wp hoare_disjI1 switchToIdleThread_curr_is_idle)+)[1]
        apply simp
       (* we have a thread to switch to *)
-    apply (clarsimp simp: bitmap_fun_defs)
-    apply (wp assert_inv switchToThread_ct_not_queued_2 assert_inv hoare_disjI2
-              switchToThread_tcb_in_cur_domain' isSchedulable_wp)
-    apply clarsimp
-    apply (clarsimp simp: valid_queues_def lookupBitmapPriority_def[symmetric]
-                          ready_qs_runnable_def invs'_def)
-    apply (drule (3) lookupBitmapPriority_obj_at')
-    apply normalise_obj_at'
-    apply (fastforce simp: tcb_in_cur_domain'_def inQ_def elim: obj_at'_weaken)
-   apply (wpsimp simp: bitmap_fun_defs)
-  apply (wpsimp wp: curDomain_or_return_0[simplified] simp: invs_ksCurDomain_maxDomain')
-  done
+      apply (clarsimp simp: bitmap_fun_defs)
+      apply (wp assert_inv switchToThread_ct_not_queued_2 assert_inv hoare_disjI2
+                switchToThread_tcb_in_cur_domain')
+      apply (clarsimp simp:  all_invs_but_ct_idle_or_in_cur_domain'_def valid_pspace'_def
+                             valid_bitmaps_def)
+      apply (frule (6) lookupBitmapPriority_obj_at')
+      apply (clarsimp simp: tcb_in_cur_domain'_def obj_at'_def tcbQueueEmpty_def inQ_def)
+     apply (wpsimp simp: bitmap_fun_defs curDomain_def one_domain_case)+
+    done
+qed
 
 lemma chooseThread_activatable_2:
-  "\<lbrace>invs'\<rbrace> chooseThread \<lbrace>\<lambda>_. ct_in_state' activatable'\<rbrace>"
+  "\<lbrace>invs_no_cicd'\<rbrace> chooseThread \<lbrace>\<lambda>rv. ct_in_state' activatable'\<rbrace>"
   apply (rule hoare_pre, rule hoare_strengthen_post)
-    apply (rule chooseThread_invs'_posts)
+    apply (rule chooseThread_invs_no_cicd'_posts)
    apply simp+
   done
 
 lemma chooseThread_ct_not_queued_2:
-  "\<lbrace> invs' \<rbrace> chooseThread \<lbrace>\<lambda>_ s. obj_at' (Not \<circ> tcbQueued) (ksCurThread s) s\<rbrace>"
+  "\<lbrace> invs_no_cicd'\<rbrace> chooseThread \<lbrace>\<lambda>rv s. obj_at' (Not \<circ> tcbQueued) (ksCurThread s) s\<rbrace>"
     (is "\<lbrace>_\<rbrace> _ \<lbrace>\<lambda>_. ?POST\<rbrace>")
   apply (rule hoare_pre, rule hoare_strengthen_post)
-    apply (rule chooseThread_invs'_posts)
+    apply (rule chooseThread_invs_no_cicd'_posts)
    apply simp+
   done
 
-lemma chooseThread_invs'':
-  "chooseThread \<lbrace>invs'\<rbrace>"
-  unfolding chooseThread_def Let_def
-  apply (simp only: return_bind, simp split del: if_split)
-  apply (rule bind_wp[OF _ stateAssert_sp])
-  apply (rule bind_wp[where Q'="\<lambda>rv s. invs' s \<and> rv = ksCurDomain s \<and> ready_qs_runnable s"])
-   apply (rule_tac Q'="\<lambda>rv s. invs' s \<and> curdom = ksCurDomain s \<and>
-                             rv = ksReadyQueuesL1Bitmap s curdom \<and> ready_qs_runnable s"
-                in bind_wp)
-    apply (rename_tac l1)
-    apply (case_tac "l1 = 0")
-     (* switch to idle thread *)
-     apply (simp, wp switchToIdleThread_invs', simp)
-    (* we have a thread to switch to *)
-    apply (clarsimp simp: bitmap_fun_defs)
-    apply (wp assert_inv isSchedulable_wp)
-    apply (clarsimp simp: valid_queues_def invs'_def)
-   apply (wpsimp simp: bitmap_fun_defs)
-  apply (wpsimp wp: curDomain_or_return_0[simplified] simp: invs_ksCurDomain_maxDomain')
-  done
+lemma chooseThread_invs_no_cicd':
+  "\<lbrace> invs_no_cicd' \<rbrace> chooseThread \<lbrace>\<lambda>rv. invs' \<rbrace>"
+proof -
+  note switchToThread_invs[wp del]
+  note switchToThread_invs_no_cicd'[wp del]
+  note switchToThread_lookupBitmapPriority_wp[wp]
+  note assert_wp[wp del]
+  note if_split[split del]
+
+  (* if we only have one domain, we are in it *)
+  have one_domain_case:
+    "\<And>s. \<lbrakk> invs_no_cicd' s; numDomains \<le> 1 \<rbrakk> \<Longrightarrow> ksCurDomain s = 0"
+    by (simp add: all_invs_but_ct_idle_or_in_cur_domain'_def maxDomain_def)
+
+  (* NOTE: do *not* unfold numDomains in the rest of the proof,
+           it should work for any number *)
+
+  (* FIXME this is almost identical to the chooseThread_invs_no_cicd'_posts proof, can generalise? *)
+  show ?thesis
+    apply (clarsimp simp: chooseThread_def Let_def curDomain_def)
+    apply (rule bind_wp[OF _ stateAssert_sp])+
+    apply (simp only: return_bind, simp)
+    apply (rule bind_wp[where Q'="\<lambda>rv s. invs_no_cicd' s \<and> rv = ksCurDomain s
+                                              \<and> ksReadyQueues_asrt s \<and> ready_qs_runnable s"])
+     apply (rule_tac Q'="\<lambda>rv s. invs_no_cicd' s \<and> curdom = ksCurDomain s \<and>
+                                rv = ksReadyQueuesL1Bitmap s curdom \<and>
+                                ksReadyQueues_asrt s \<and> ready_qs_runnable s" in bind_wp)
+      apply (rename_tac l1)
+      apply (case_tac "l1 = 0")
+       (* switch to idle thread *)
+       apply (simp, wp switchToIdleThread_invs_no_cicd', simp)
+      (* we have a thread to switch to *)
+      apply (clarsimp simp: bitmap_fun_defs)
+      apply (wp assert_inv)
+      apply (clarsimp simp:  all_invs_but_ct_idle_or_in_cur_domain'_def valid_pspace'_def
+                             valid_bitmaps_def)
+      apply (frule (6) lookupBitmapPriority_obj_at')
+      apply (clarsimp simp: tcb_in_cur_domain'_def obj_at'_def tcbQueueEmpty_def inQ_def)
+      apply (fastforce elim: bitmapQ_from_bitmap_lookup simp: lookupBitmapPriority_def)
+     apply (wpsimp simp: bitmap_fun_defs curDomain_def one_domain_case)+
+    done
+qed
 
 lemma chooseThread_in_cur_domain':
-  "\<lbrace> invs' \<rbrace> chooseThread \<lbrace>\<lambda>rv s. ksCurThread s = ksIdleThread s \<or> tcb_in_cur_domain' (ksCurThread s) s\<rbrace>"
+  "\<lbrace> invs_no_cicd' \<rbrace> chooseThread \<lbrace>\<lambda>rv s. ksCurThread s = ksIdleThread s \<or> tcb_in_cur_domain' (ksCurThread s) s\<rbrace>"
   apply (rule hoare_pre, rule hoare_strengthen_post)
-    apply (rule chooseThread_invs'_posts, simp_all)
+    apply (rule chooseThread_invs_no_cicd'_posts, simp_all)
   done
 
 lemma scheduleChooseNewThread_invs':
-  "scheduleChooseNewThread \<lbrace>invs'\<rbrace>"
+  "\<lbrace> invs' and (\<lambda>s. ksSchedulerAction s = ChooseNewThread) \<rbrace>
+   scheduleChooseNewThread
+   \<lbrace> \<lambda>_ s. invs' s \<rbrace>"
   unfolding scheduleChooseNewThread_def
-  apply (wpsimp wp: ssa_invs' chooseThread_invs'' chooseThread_ct_not_queued_2
-                    chooseThread_activatable_2 chooseThread_invs''
-                    chooseThread_in_cur_domain' nextDomain_invs' chooseThread_ct_not_queued_2)
+  apply (wpsimp wp: ssa_invs' chooseThread_invs_no_cicd' chooseThread_ct_not_queued_2
+                    chooseThread_activatable_2 chooseThread_invs_no_cicd'
+                    chooseThread_in_cur_domain' nextDomain_invs_no_cicd' chooseThread_ct_not_queued_2)
+  apply (clarsimp simp: invs'_to_invs_no_cicd'_def)
   done
-
-lemma setReprogramTimer_invs'[wp]:
-  "setReprogramTimer v \<lbrace>invs'\<rbrace>"
-  unfolding setReprogramTimer_def
-  apply wpsimp
-  by (clarsimp simp: invs'_def valid_machine_state'_def cur_tcb'_def
-                     ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def ct_not_inQ_def
-                     valid_dom_schedule'_def)
-
-lemma machine_op_lift_underlying_memory_invar:
-  "(x, b) \<in> fst (machine_op_lift a m) \<Longrightarrow> underlying_memory b = underlying_memory m"
-  by (clarsimp simp: in_monad machine_op_lift_def machine_rest_lift_def select_f_def)
-
-lemma setNextInterrupt_invs'[wp]:
-  "setNextInterrupt \<lbrace>invs'\<rbrace>"
-  unfolding setNextInterrupt_def
-  apply (wpsimp wp: dmo_invs' ARM.setDeadline_irq_masks threadGet_wp getReleaseQueue_wp)
-  apply (clarsimp simp: obj_at'_real_def ko_wp_at'_def)
-  by (auto simp: in_monad setDeadline_def machine_op_lift_underlying_memory_invar)
-
-lemma setCurSc_invs'[wp]:
-  "setCurSc v \<lbrace>invs'\<rbrace>"
-  unfolding setCurSc_def
-  apply wpsimp
-  apply (clarsimp simp: invs'_def valid_machine_state'_def cur_tcb'_def
-                        ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def ct_not_inQ_def
-                        valid_queues_def valid_queues_no_bitmap_def valid_bitmapQ_def bitmapQ_def
-                        bitmapQ_no_L2_orphans_def bitmapQ_no_L1_orphans_def valid_irq_node'_def
-                        valid_queues'_def valid_release_queue_def valid_release_queue'_def
-                        valid_dom_schedule'_def)
-  done
-
-lemma setConsumedTime_invs'[wp]:
-  "setConsumedTime v \<lbrace>invs'\<rbrace>"
-  unfolding setConsumedTime_def
-  apply wpsimp
-  apply (clarsimp simp: invs'_def valid_machine_state'_def cur_tcb'_def
-                        ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def ct_not_inQ_def
-                        valid_queues_def valid_queues_no_bitmap_def valid_bitmapQ_def bitmapQ_def
-                        bitmapQ_no_L2_orphans_def bitmapQ_no_L1_orphans_def valid_irq_node'_def
-                        valid_queues'_def valid_release_queue_def valid_release_queue'_def
-                        valid_dom_schedule'_def)
-  done
-
-lemma setDomainTime_invs'[wp]:
-  "setDomainTime v \<lbrace>invs'\<rbrace>"
-  unfolding setDomainTime_def
-  apply wpsimp
-  done
-
-lemma valid_idle'_ko_at_idle_sc_is_idle':
-  "\<lbrakk>valid_idle' s; ko_at' ko scPtr s\<rbrakk> \<Longrightarrow> (scPtr = idle_sc_ptr \<longrightarrow> idle_sc' ko)"
-  apply (clarsimp simp: valid_idle'_def obj_at'_real_def ko_wp_at'_def)
-  done
-
-lemma refillTailIndex_bounded:
-  "valid_sched_context' ko s \<Longrightarrow> 0 < scRefillMax ko \<longrightarrow> refillTailIndex ko < scRefillMax ko"
-  apply (clarsimp simp: valid_sched_context'_def refillTailIndex_def Let_def split: if_split)
-  by linarith
-
-lemma refillAddTail_valid_objs'[wp]:
-  "refillAddTail scPtr t \<lbrace>valid_objs'\<rbrace>"
-  apply (simp add: refillAddTail_def)
-  apply (wpsimp wp: set_sc_valid_objs' getRefillNext_wp getRefillSize_wp
-              simp: updateSchedContext_def)
-  apply (frule (1) sc_ko_at_valid_objs_valid_sc', clarsimp)
-  apply (clarsimp simp: valid_obj'_def obj_at'_def projectKOs opt_map_red opt_pred_def)
-  apply (intro conjI)
-   apply (frule refillTailIndex_bounded)
-   apply (clarsimp simp: valid_sched_context'_def)
-  apply (frule refillTailIndex_bounded)
-  apply (clarsimp simp: valid_sched_context_size'_def objBits_simps valid_sched_context'_def)
-  done
-
-lemma refillAddTail_invs'[wp]:
-  "refillAddTail scPtr t \<lbrace>invs'\<rbrace>"
-  apply (simp add: refillAddTail_def)
-  apply (wpsimp wp: setSchedContext_invs' getRefillNext_wp getRefillSize_wp
-              simp: updateSchedContext_def)
-  apply (frule (1) invs'_ko_at_valid_sched_context', clarsimp)
-  apply (drule ko_at'_inj, assumption, clarsimp)+
-  apply (intro conjI)
-    apply (fastforce dest: live_sc'_ko_ex_nonz_cap_to')
-   apply (frule refillTailIndex_bounded)
-   apply (clarsimp simp: valid_sched_context'_def)
-  apply (frule refillTailIndex_bounded)
-  apply (clarsimp simp: valid_sched_context_size'_def objBits_def objBitsKO_def valid_sched_context'_def)
-  done
-
-lemma refillBudgetCheckRoundRobin_invs'[wp]:
-  "\<lbrace>invs' and (\<lambda>s. active_sc_at' (ksCurSc s) s)\<rbrace>
-   refillBudgetCheckRoundRobin consumed
-   \<lbrace>\<lambda>_. invs'\<rbrace>"
-  supply if_split [split del]
-  apply (simp add: refillBudgetCheckRoundRobin_def updateRefillTl_def updateRefillHd_def)
-  apply (wpsimp simp:  wp: updateSchedContext_refills_invs')
-    apply (rule_tac Q'="\<lambda>_. invs' and active_sc_at' scPtr" in hoare_strengthen_post[rotated])
-     apply clarsimp
-     apply (frule (1) invs'_ko_at_valid_sched_context', clarsimp)
-     apply (clarsimp simp: valid_sched_context'_def active_sc_at'_def obj_at'_real_def
-                           ko_wp_at'_def valid_sched_context_size'_def objBits_def objBitsKO_def)
-    apply (wpsimp wp: updateSchedContext_refills_invs' getCurTime_wp updateSchedContext_active_sc_at')
-   apply (wpsimp wp: )
-  apply clarsimp
-  apply (frule invs'_ko_at_valid_sched_context', simp, clarsimp)
-  apply (clarsimp simp: valid_sched_context'_def active_sc_at'_def obj_at'_real_def ko_wp_at'_def
-                        valid_sched_context_size'_def objBits_def objBitsKO_def)
-  done
-
-lemma updateRefillTl_valid_objs'[wp]:
-  "updateRefillTl scPtr f \<lbrace>valid_objs'\<rbrace>"
-  apply (clarsimp simp: updateRefillTl_def updateSchedContext_def)
-  apply (wpsimp wp: set_sc_valid_objs')
-  apply (fastforce dest: sc_ko_at_valid_objs_valid_sc'
-                   simp: valid_sched_context'_def valid_sched_context_size'_def objBits_simps)
-  done
-
-crunch scheduleUsed
-  for valid_objs'[wp]: valid_objs'
-  (simp: refillFull_def refillEmpty_def)
-
-lemma updateRefillTl_invs'[wp]:
-  "updateRefillTl scPtr f \<lbrace>invs'\<rbrace>"
-  apply (clarsimp simp: updateRefillTl_def)
-  apply (wpsimp wp: updateSchedContext_invs')
-  apply (intro conjI)
-   apply (fastforce dest: invs_iflive'
-                    elim: if_live_then_nonz_capE'
-                    simp: valid_idle'_def obj_at'_def ko_wp_at'_def live_sc'_def projectKOs)
-  apply (fastforce dest: sc_ko_at_valid_objs_valid_sc'
-                   simp: valid_sched_context'_def valid_sched_context_size'_def objBits_simps)
-  done
-
-lemma updateRefillTl_if_live_then_nonz_cap'[wp]:
-  "updateRefillTl scPtr f \<lbrace>if_live_then_nonz_cap'\<rbrace>"
-  apply (clarsimp simp: updateRefillTl_def updateSchedContext_def)
-  apply (wpsimp wp: setSchedContext_iflive')
-  apply (fastforce elim: if_live_then_nonz_capE'
-                   simp: valid_idle'_def obj_at'_def ko_wp_at'_def live_sc'_def projectKOs)
-  done
-
-lemma scheduleUsed_if_live_then_nonz_cap'[wp]:
-  "scheduleUsed scPtr refill \<lbrace>if_live_then_nonz_cap'\<rbrace>"
-  apply (wpsimp simp: scheduleUsed_def refillAddTail_def updateSchedContext_def
-                  wp: getRefillSize_wp refillFull_wp refillEmpty_wp getRefillNext_wp)
-  apply (fastforce intro: if_live_then_nonz_capE'
-                    simp: ko_wp_at'_def obj_at'_real_def projectKO_sc live_sc'_def)
-  done
-
-lemma updateSchedContext_valid_idle':
-  "\<lbrace>valid_idle' and (\<lambda>s. \<forall>sc. idle_sc' sc \<longrightarrow> idle_sc' (f sc))\<rbrace>
-   updateSchedContext scPtr f
-   \<lbrace>\<lambda>_. valid_idle'\<rbrace>"
-  apply (clarsimp simp: updateSchedContext_def)
-  apply wpsimp
-  apply (fastforce simp: valid_idle'_def obj_at'_def)
-  done
-
-crunch scheduleUsed, updateRefillHd, refillPopHead
-  for valid_idle'[wp]: valid_idle'
-  (wp: updateSchedContext_valid_idle')
-
-lemma scheduleUsed_invs'[wp]:
-  "scheduleUsed scPtr refill \<lbrace>invs'\<rbrace>"
-  apply (simp add: scheduleUsed_def)
-  apply (wpsimp wp: refillFull_wp refillEmpty_wp)
-  done
-
-lemma refillPopHead_valid_objs'[wp]:
-  "\<lbrace>valid_objs' and obj_at' (\<lambda>sc'. 1 < scRefillCount sc') scPtr \<rbrace>
-   refillPopHead scPtr
-   \<lbrace>\<lambda>_. valid_objs'\<rbrace>"
-  apply (clarsimp simp: refillPopHead_def updateSchedContext_def getRefillNext_def)
-  apply (wpsimp wp: set_sc_valid_objs')
-  apply (frule (1) sc_ko_at_valid_objs_valid_sc')
-  apply (clarsimp simp: readRefillNext_def readSchedContext_def)
-  by (fastforce simp: obj_at'_def projectKOs scBits_simps refillNextIndex_def
-                      valid_sched_context'_def valid_sched_context_size'_def objBits_simps'
-               dest!: readObject_misc_ko_at')
-
-lemma refillPopHead_invs'[wp]:
-  "\<lbrace>invs' and obj_at' (\<lambda>sc'. 1 < scRefillCount sc') scPtr\<rbrace>
-   refillPopHead scPtr
-   \<lbrace>\<lambda>_. invs'\<rbrace>"
-  apply (simp add: refillPopHead_def)
-  apply (wpsimp wp: updateSchedContext_invs' getRefillNext_wp)
-  apply (intro conjI; intro allI impI)
-   apply (clarsimp simp: obj_at'_def)
-   apply (rule if_live_then_nonz_capE')
-    apply (erule invs_iflive')
-   apply (clarsimp simp: ko_wp_at'_def obj_at'_def projectKO_eq projectKO_sc live_sc'_def)
-  apply (fastforce dest!: invs'_ko_at_valid_sched_context'
-                    simp: valid_sched_context'_def valid_sched_context_size'_def
-                          refillNextIndex_def obj_at_simps)
-  done
-
-lemma refillPopHead_active_sc_at'[wp]:
-  "refillPopHead scPtr \<lbrace>active_sc_at' scPtr'\<rbrace>"
-  apply (simp add: refillPopHead_def)
-  apply (wpsimp wp: updateSchedContext_active_sc_at' getRefillNext_wp)
-  done
-
-lemma refillAddTail_active_sc_at'[wp]:
-  "refillAddTail scPtr refill \<lbrace>active_sc_at' scPtr'\<rbrace>"
-  apply (simp add: refillAddTail_def getRefillSize_def refillTailIndex_def)
-  apply (wpsimp wp: updateSchedContext_active_sc_at' hoare_drop_imps getRefillNext_wp)
-  done
-
-lemma updateRefillTl_active_sc_at'[wp]:
-  "updateRefillTl scPtr f \<lbrace>active_sc_at' scPtr'\<rbrace>"
-  apply (simp add: updateRefillTl_def)
-  apply (wpsimp wp: updateSchedContext_active_sc_at' hoare_drop_imps getRefillNext_wp)
-  done
-
-crunch scheduleUsed
-  for active_sc_at'[wp]: "active_sc_at' scPtr"
-  (wp: crunch_wps)
-
-crunch refillPopHead
-  for ex_nonz_cap_to'[wp]: "ex_nonz_cap_to' scPtr"
-
-lemma updateRefillHd_invs':
-  "\<lbrace>invs' and active_sc_at' scPtr\<rbrace> updateRefillHd scPtr f \<lbrace>\<lambda>_. invs'\<rbrace>"
-  apply (clarsimp simp: updateRefillHd_def)
-  apply (wpsimp wp: updateSchedContext_invs')
-  apply (intro conjI; intro allI impI)
-   apply (fastforce dest: live_sc'_ko_ex_nonz_cap_to')
-  apply (frule invs'_ko_at_valid_sched_context', simp, clarsimp)
-  apply (clarsimp simp: valid_sched_context'_def active_sc_at'_def obj_at'_real_def ko_wp_at'_def
-                        valid_sched_context_size'_def objBits_def objBitsKO_def)
-  done
-
-lemma updateRefillHd_active_sc_at'[wp]:
-  "updateRefillHd scPtr f \<lbrace>active_sc_at' scPr\<rbrace>"
-  apply (clarsimp simp: updateRefillHd_def)
-  apply (wpsimp wp: updateSchedContext_active_sc_at')
-  done
-
-lemma updateRefillHd_active_sc_at'_ksCurSc[wp]:
-  "updateRefillHd scPtr f \<lbrace>\<lambda>s. active_sc_at' (ksCurSc s) s\<rbrace>"
-  apply (rule_tac f=ksCurSc in hoare_lift_Pf)
-   apply wpsimp
-  apply (clarsimp simp: updateRefillHd_def updateSchedContext_def)
-  apply wpsimp
-  done
-
-lemma setRefillHd_active_sc_at'[wp]:
-  "setRefillHd scPtr f \<lbrace>active_sc_at' scPr\<rbrace>"
-  apply (clarsimp simp: setRefillHd_def)
-  apply (wpsimp wp: updateSchedContext_active_sc_at')
-  done
-
-lemma setReprogramTimer_obj_at'[wp]:
-  "setReprogramTimer b \<lbrace>\<lambda>s. Q (obj_at' P t s)\<rbrace>"
-  unfolding active_sc_at'_def
-  by (wpsimp simp: setReprogramTimer_def)
-
-lemma setReprogramTimer_active_sc_at'[wp]:
-  "setReprogramTimer b \<lbrace>active_sc_at' scPtr\<rbrace>"
-  unfolding active_sc_at'_def
-  by wpsimp
-
-crunch refillBudgetCheck, refillUnblockCheck
-  for valid_queues[wp]: valid_queues
-  and valid_queues'[wp]: valid_queues'
-  and valid_release_queue[wp]: valid_release_queue
-  and valid_release_queue'[wp]: valid_release_queue'
-  and typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  and sc_at'_n[wp]: "\<lambda>s. P (sc_at'_n T p s)"
-  and active_sc_at'[wp]: "active_sc_at' scPtr"
-  (wp: crunch_wps)
-
-lemma mergeRefills_valid_objs':
-  "\<lbrace>\<lambda>s. valid_objs' s \<and> sc_at' scPtr s \<and> ((\<lambda>sc. 1 < scRefillCount sc) |< scs_of' s) scPtr\<rbrace>
-   mergeRefills scPtr
-   \<lbrace>\<lambda>_. valid_objs'\<rbrace>"
-  apply (clarsimp simp: mergeRefills_def updateRefillHd_def)
-  apply (rule_tac Q'="\<lambda>_ s. valid_objs' s \<and> sc_at' scPtr s" in bind_wp_fwd)
-   apply wpsimp
-   apply (clarsimp simp: obj_at_simps opt_map_red opt_pred_def)
-  apply (wpsimp wp: set_sc_valid_objs' simp: updateSchedContext_def)
-  apply (clarsimp simp: valid_sched_context'_def obj_at_simps valid_obj'_def
-                        valid_sched_context_size'_def opt_map_red opt_pred_def
-                 dest!: sc_ko_at_valid_objs_valid_sc')
-  done
-
-lemma no_ofail_refillHeadOverlapping:
-  "no_ofail (sc_at' scp) (refillHeadOverlapping scp)"
-  unfolding refillHeadOverlapping_def oreturn_def obind_def oliftM_def no_ofail_def
-            readRefillSize_def readRefillNext_def
-  by (clarsimp dest!: no_ofailD[OF no_ofail_readSchedContext])
-
-lemma refillHeadOverlapping_implies_count_greater_than_one:
-  "\<lbrakk>the (refillHeadOverlapping scPtr s); sc_at' scPtr s\<rbrakk>
-   \<Longrightarrow> ((\<lambda>sc. 1 < scRefillCount sc) |< scs_of' s) scPtr"
-  apply (clarsimp simp: refillHeadOverlapping_def readSchedContext_def oliftM_def
-                        readRefillNext_def readRefillSize_def obind_def omonad_defs
-                 split: option.splits dest!: readObject_misc_ko_at')
-   apply (fastforce dest: no_ofail_sc_at'_readObject[unfolded no_ofail_def, rule_format])
-  apply (clarsimp simp: obj_at_simps opt_map_red opt_pred_def MIN_REFILLS_def)
-  done
-
-lemma refillHeadOverlappingLoop_valid_objs':
-  "\<lbrace>\<lambda>s. valid_objs' s \<and> sc_at' scPtr s\<rbrace>
-   refillHeadOverlappingLoop scPtr
-   \<lbrace>\<lambda>_. valid_objs'\<rbrace>"
-  (is "valid ?pre _ _")
-  apply (clarsimp simp: refillHeadOverlappingLoop_def)
-  apply (wpsimp wp: valid_whileLoop[where I="\<lambda>_. ?pre"] mergeRefills_valid_objs')
-    apply (clarsimp simp: runReaderT_def)
-    apply (prop_tac "((\<lambda>sc. 1 < scRefillCount sc) |< scs_of' s) scPtr")
-     apply (fastforce elim: refillHeadOverlapping_implies_count_greater_than_one
-                      simp: obj_at_simps opt_map_red)
-    apply simp+
-  done
-
-lemma updateRefillHd_valid_objs':
-  "\<lbrace>\<lambda>s. valid_objs' s \<and> sc_at' scPtr s\<rbrace>
-   updateRefillHd scPtr f
-   \<lbrace>\<lambda>_. valid_objs'\<rbrace>"
-  apply (clarsimp simp: updateRefillHd_def)
-  apply (wpsimp wp: set_sc_valid_objs' simp: updateSchedContext_def)
-  apply (clarsimp simp: is_active_sc'_def valid_sched_context'_def obj_at_simps valid_obj'_def
-                        valid_sched_context_size'_def opt_map_red opt_pred_def active_sc_at'_rewrite
-                 dest!: sc_ko_at_valid_objs_valid_sc')
-  done
-
-lemma setRefillHd_valid_objs':
-  "\<lbrace>\<lambda>s. valid_objs' s \<and> sc_at' scPtr s\<rbrace>
-   setRefillHd scPtr f
-   \<lbrace>\<lambda>_. valid_objs'\<rbrace>"
-  apply (wpsimp simp: setRefillHd_def
-                  wp: updateRefillHd_valid_objs')
-  done
-
-lemma refillUnblockCheck_valid_objs'[wp]:
-  "refillUnblockCheck scPtr \<lbrace>valid_objs'\<rbrace>"
-  apply (clarsimp simp: refillUnblockCheck_def isRoundRobin_def refillReady_def)
-  apply (wpsimp wp: updateRefillHd_valid_objs' refillHeadOverlappingLoop_valid_objs' scActive_wp)
-  done
-
-lemma refillUnblockCheck_valid_mdb'[wp]:
-  "refillUnblockCheck scPtr \<lbrace>valid_mdb'\<rbrace>"
-  apply (clarsimp simp: refillUnblockCheck_def valid_mdb'_def)
-  apply (wpsimp wp: scActive_wp)
-  done
-
-lemma refillUnblockCheck_valid_machine_state'[wp]:
-  "refillUnblockCheck scPtr \<lbrace>valid_machine_state'\<rbrace>"
-  apply (clarsimp simp: refillUnblockCheck_def refillReady_def isRoundRobin_def
-                        refillHeadOverlappingLoop_def mergeRefills_def updateRefillHd_def
-                        refillPopHead_def updateSchedContext_def setReprogramTimer_def
-                        valid_machine_state'_def pointerInUserData_def pointerInDeviceData_def)
-  apply (wpsimp wp: whileLoop_valid_inv hoare_vcg_all_lift hoare_vcg_disj_lift scActive_wp
-                    hoare_drop_imps getRefillNext_wp)
-  apply fastforce
-  done
-
-lemma refillUnblockCheck_list_refs_of_replies'[wp]:
-  "refillUnblockCheck scPtr \<lbrace>\<lambda>s. P (list_refs_of_replies' s)\<rbrace>"
-  apply (clarsimp simp: refillUnblockCheck_def valid_mdb'_def refillHeadOverlappingLoop_def
-                        mergeRefills_def updateRefillHd_def refillPopHead_def updateSchedContext_def
-                        setReprogramTimer_def refillReady_def isRoundRobin_def)
-  apply (wpsimp wp: whileLoop_valid_inv hoare_drop_imps scActive_wp getRefillNext_wp
-              simp: o_def)
-  done
-
-lemma refillPopHead_if_live_then_nonz_cap'[wp]:
-  "refillPopHead scPtr \<lbrace>if_live_then_nonz_cap'\<rbrace>"
-  apply (clarsimp simp: refillPopHead_def updateSchedContext_def getRefillNext_def)
-  apply wpsimp
-  apply (fastforce intro: if_live_then_nonz_capE'
-                    simp: ko_wp_at'_def obj_at'_real_def projectKO_sc live_sc'_def)
-  done
-
-lemma mergeRefills_if_live_then_nonz_cap'[wp]:
-  "mergeRefills scPtr \<lbrace>if_live_then_nonz_cap'\<rbrace>"
-  apply (clarsimp simp: mergeRefills_def)
-  apply (rule bind_wp_fwd_skip, wpsimp)
-  apply (wpsimp simp: updateRefillHd_def updateSchedContext_def)
-  apply (fastforce intro: if_live_then_nonz_capE'
-                    simp: ko_wp_at'_def obj_at'_real_def projectKO_sc live_sc'_def)
-  done
-
-lemma nonOverlappingMergeRefills_if_live_then_nonz_cap'[wp]:
-  "nonOverlappingMergeRefills scPtr \<lbrace>if_live_then_nonz_cap'\<rbrace>"
-  apply (clarsimp simp: nonOverlappingMergeRefills_def updateRefillHd_def)
-  apply (rule bind_wp_fwd_skip, wpsimp)+
-  by (wpsimp simp: updateSchedContext_def,
-      fastforce intro: if_live_then_nonz_capE'
-                 simp: ko_wp_at'_def obj_at'_real_def projectKO_sc live_sc'_def)+
-
-crunch refillHeadOverlappingLoop, headInsufficientLoop
-  for if_live_then_nonz_cap'[wp]: if_live_then_nonz_cap'
-  (wp: crunch_wps)
-
-lemma updateRefillHd_if_live_then_nonz_cap'[wp]:
-  "updateRefillHd scPtr f \<lbrace>if_live_then_nonz_cap'\<rbrace>"
-  apply (clarsimp simp: updateRefillHd_def updateSchedContext_def)
-  apply wpsimp
-  apply (fastforce intro: if_live_then_nonz_capE'
-                    simp: ko_wp_at'_def obj_at'_real_def projectKO_sc live_sc'_def)
-  done
-
-lemma setRefillHd_if_live_then_nonz_cap'[wp]:
-  "setRefillHd scPtr f \<lbrace>if_live_then_nonz_cap'\<rbrace>"
-  apply (wpsimp simp: setRefillHd_def)
-  done
-
-crunch handleOverrunLoop
-  for if_live_then_nonz_cap'[wp]: if_live_then_nonz_cap'
-  (wp: crunch_wps)
-
-lemma refillUnblockCheck_if_live_then_nonz_cap'[wp]:
-  "refillUnblockCheck scPtr \<lbrace>if_live_then_nonz_cap'\<rbrace>"
-  apply (clarsimp simp: refillUnblockCheck_def setReprogramTimer_def refillReady_def
-                        isRoundRobin_def)
-  apply (wpsimp wp: scActive_wp)
-  done
-
-lemma mergeRefills_valid_idle'[wp]:
-  "mergeRefills scPtr \<lbrace>valid_idle'\<rbrace>"
-  apply (clarsimp simp: mergeRefills_def updateRefillHd_def updateSchedContext_def)
-  apply (rule bind_wp_fwd_skip, wpsimp)
-  apply (wpsimp simp: valid_idle'_def obj_at'_def)
-  done
-
-lemma nonOverlappingMergeRefills_valid_idle'[wp]:
-  "nonOverlappingMergeRefills scPtr \<lbrace>valid_idle'\<rbrace>"
-  apply (clarsimp simp: nonOverlappingMergeRefills_def updateRefillHd_def)
-  apply (rule bind_wp_fwd_skip, wpsimp)+
-  apply (clarsimp simp: updateSchedContext_def,
-         rule bind_wp[OF _ get_sc_sp'],
-         wpsimp simp: valid_idle'_def obj_at'_def)+
-  done
-
-crunch refillHeadOverlappingLoop, headInsufficientLoop, handleOverrunLoop
-  for valid_idle'[wp]: valid_idle'
-  (wp: crunch_wps)
-
-lemma refillUnblockCheck_valid_idle'[wp]:
-  "refillUnblockCheck scPtr \<lbrace>valid_idle'\<rbrace>"
-  apply (clarsimp simp: refillUnblockCheck_def isRoundRobin_def refillReady_def
-                        setReprogramTimer_def updateRefillHd_def updateSchedContext_def)
-  apply (wpsimp wp: scActive_wp)
-  apply (clarsimp simp: valid_idle'_def obj_at'_def)
-  done
-
-crunch refillHeadOverlappingLoop, headInsufficientLoop, handleOverrunLoop
-  for ct_idle_or_in_cur_domain'[wp]: ct_idle_or_in_cur_domain'
-  (wp: crunch_wps)
-
-lemma refillUnblockCheck_ct_idle_or_in_cur_domain'[wp]:
-  "refillUnblockCheck scPtr \<lbrace>ct_idle_or_in_cur_domain'\<rbrace>"
-  apply (clarsimp simp: refillUnblockCheck_def isRoundRobin_def refillReady_def
-                        setReprogramTimer_def updateRefillHd_def)
-  apply (wpsimp wp: scActive_wp)
-  done
-
-crunch refillUnblockCheck, refillBudgetCheck
-  for reply_projs[wp]: "\<lambda>s. P (replyNexts_of s) (replyPrevs_of s) (replyTCBs_of s) (replySCs_of s)"
-  and pred_tcb_at'[wp]: "pred_tcb_at' proj P p"
-  and valid_replies'[wp]: valid_replies'
-  (wp: crunch_wps valid_replies'_lift)
-
-lemma refillUnblockCheck_invs':
-  "refillUnblockCheck scPtr \<lbrace>invs'\<rbrace>"
-  apply (clarsimp simp: invs'_def valid_pspace'_def pred_conj_def)
-  apply wpsimp
-  done
-
-crunch ifCondRefillUnblockCheck
-  for invs'[wp]: invs'
-  (wp: hoare_vcg_if_lift2 crunch_wps simp: crunch_simps)
-
-lemma nonOverlappingMergeRefills_valid_objs':
-  "\<lbrace>\<lambda>s. valid_objs' s \<and> sc_at' scPtr s\<rbrace>
-   nonOverlappingMergeRefills scPtr
-   \<lbrace>\<lambda>_. valid_objs'\<rbrace>"
-  apply (clarsimp simp: nonOverlappingMergeRefills_def updateRefillHd_def)
-  apply (rule bind_wp[OF _ get_sc_sp'])
-  apply (rule_tac bind_wp[OF _ assert_sp])
-  apply (rule_tac Q'="\<lambda>_ s. valid_objs' s \<and> sc_at' scPtr s" in bind_wp_fwd)
-   apply wpsimp
-   apply (clarsimp simp: obj_at'_real_def ko_wp_at'_def)
-  apply (wpsimp wp: set_sc_valid_objs' simp: updateSchedContext_def)
-    apply (rule_tac Q'="\<lambda>_. valid_objs' and sc_at' scPtr" in hoare_strengthen_post[rotated])
-     apply (clarsimp simp: valid_sched_context'_def obj_at_simps valid_obj'_def
-                           valid_sched_context_size'_def opt_map_red opt_pred_def
-                    dest!: sc_ko_at_valid_objs_valid_sc')
-    apply (wpsimp wp: set_sc_valid_objs' setSchedContext_active_sc_at' simp: updateSchedContext_def)+
-  apply (fastforce simp: valid_sched_context'_def obj_at_simps valid_obj'_def
-                         valid_sched_context_size'_def opt_map_red opt_pred_def
-                  dest!: sc_ko_at_valid_objs_valid_sc')
-  done
-
-crunch refillHeadOverlappingLoop, headInsufficientLoop, handleOverrunLoop
-  for active_sc_at'[wp]: "active_sc_at' scPtr"
-  and ksCurSc[wp]: "\<lambda>s. P (ksCurSc s)"
-  (wp: crunch_wps)
-
-lemma headInsufficientLoop_valid_objs':
-  "\<lbrace>\<lambda>s. valid_objs' s \<and> sc_at' scPtr s\<rbrace>
-   headInsufficientLoop scPtr
-   \<lbrace>\<lambda>_. valid_objs'\<rbrace>"
-  (is "valid ?pre _ _")
-  apply (clarsimp simp: headInsufficientLoop_def)
-  apply (wpsimp wp: valid_whileLoop[where I="\<lambda>_. ?pre"] nonOverlappingMergeRefills_valid_objs')
-  done
-
-lemma handleOverrunLoop_valid_objs':
-  "\<lbrace>\<lambda>s. valid_objs' s \<and> active_sc_at' (ksCurSc s) s\<rbrace>
-   handleOverrunLoop usage
-   \<lbrace>\<lambda>_. valid_objs'\<rbrace>"
-  (is "valid ?pre _ _")
-  apply (clarsimp simp: handleOverrunLoop_def)
-  apply (wpsimp wp: valid_whileLoop[where I="\<lambda>_. ?pre"])
-    apply (intro hoare_vcg_conj_lift_pre_fix)
-     apply (clarsimp simp: handleOverrunLoopBody_def)
-     apply (wpsimp wp: updateRefillHd_valid_objs' simp: refillSingle_def)
-     apply (frule (1) sc_ko_at_valid_objs_valid_sc')
-     apply (fastforce simp: valid_sched_context'_def active_sc_at'_def obj_at_simps refillTailIndex_def Let_def
-                     split: if_split_asm)
-    apply (rule_tac f=ksCurSc in hoare_lift_Pf3)
-     apply wpsimp+
-  done
-
-lemma refillBudgetCheck_valid_objs':
-  "refillBudgetCheck usage \<lbrace>valid_objs'\<rbrace>"
-  apply (clarsimp simp: refillBudgetCheck_def isRoundRobin_def refillReady_def getCurSc_def)
-  apply (rule bind_wp[OF _ gets_sp])
-  apply (rule bind_wp[OF _ scActive_sp])
-  apply (rule bind_wp[OF _ assert_sp])
-  apply (wpsimp wp: headInsufficientLoop_valid_objs' handleOverrunLoop_valid_objs'
-                    hoare_vcg_all_lift updateRefillHd_valid_objs' hoare_vcg_if_lift2 hoare_drop_imps)
-  apply (clarsimp simp: active_sc_at'_def obj_at'_def)
-  done
-
-lemma refillBudgetCheck_valid_mdb'[wp]:
-  "refillBudgetCheck usage \<lbrace>valid_mdb'\<rbrace>"
-  apply (clarsimp simp: handleOverrunLoop_def valid_mdb'_def)
-  apply (wpsimp wp: scActive_wp)
-  done
-
-lemma handleOverrunLoop_list_refs_of_replies'[wp]:
-  "handleOverrunLoop usage \<lbrace>\<lambda>s. sym_refs (list_refs_of_replies' s)\<rbrace>"
-  apply (clarsimp simp: handleOverrunLoop_def)
-  apply (wpsimp wp: whileLoop_valid_inv hoare_drop_imps getRefillNext_wp
-                    getRefillSize_wp refillFull_wp refillEmpty_wp
-              simp: o_def handleOverrunLoopBody_def refillPopHead_def updateSchedContext_def
-                    scheduleUsed_def refillAddTail_def  updateRefillHd_def setRefillTl_def
-                    updateRefillTl_def refillSingle_def)
-  done
-
-lemma refillBudgetCheck_list_refs_of_replies'[wp]:
-  "refillBudgetCheck usage \<lbrace>\<lambda>s. sym_refs (list_refs_of_replies' s)\<rbrace>"
-  apply (clarsimp simp: refillBudgetCheck_def refillPopHead_def updateSchedContext_def
-                        setReprogramTimer_def refillReady_def isRoundRobin_def
-                        headInsufficientLoop_def nonOverlappingMergeRefills_def)
-  apply (rule bind_wp_fwd_skip, solves wpsimp)+
-  apply (wpsimp wp: whileLoop_valid_inv hoare_drop_imps refillFull_wp refillEmpty_wp getRefillNext_wp
-                     getRefillSize_wp hoare_vcg_all_lift hoare_vcg_if_lift2
-              simp: o_def scheduleUsed_def refillAddTail_def setRefillHd_def updateRefillHd_def
-                    setRefillTl_def updateRefillTl_def updateSchedContext_def)
-  done
-
-lemma refillBudgetCheck_if_live_then_nonz_cap'[wp]:
-  "refillBudgetCheck uage \<lbrace>if_live_then_nonz_cap'\<rbrace>"
-  apply (wpsimp simp: refillBudgetCheck_def setReprogramTimer_def refillReady_def
-                      isRoundRobin_def
-                  wp: hoare_drop_imps)
-  done
-
-lemma refillBudgetCheck_valid_idle'[wp]:
-  "refillBudgetCheck usage \<lbrace>valid_idle'\<rbrace>"
-  apply (clarsimp simp: refillBudgetCheck_def isRoundRobin_def refillReady_def
-                        setReprogramTimer_def updateRefillHd_def setRefillHd_def)
-  apply (rule bind_wp_fwd_skip, solves wpsimp)+
-  apply (wpsimp wp: updateSchedContext_valid_idle')
-  done
-
-lemma handleOverrunLoop_valid_machine_state'[wp]:
-  "handleOverrunLoop usage \<lbrace>valid_machine_state'\<rbrace>"
-  apply (clarsimp simp: handleOverrunLoop_def)
-  apply (wpsimp wp: whileLoop_valid_inv hoare_drop_imps getRefillNext_wp
-                    getRefillSize_wp refillFull_wp refillEmpty_wp
-              simp: handleOverrunLoopBody_def refillPopHead_def updateSchedContext_def
-                    scheduleUsed_def refillAddTail_def  updateRefillHd_def setRefillTl_def
-                    updateRefillTl_def refillSingle_def)
-  done
-
-lemma refillBudgetCheck_valid_machine_state'[wp]:
-  "refillBudgetCheck usage \<lbrace>valid_machine_state'\<rbrace>"
-  apply (clarsimp simp: refillBudgetCheck_def refillPopHead_def updateSchedContext_def
-                        setReprogramTimer_def refillReady_def isRoundRobin_def
-                        headInsufficientLoop_def nonOverlappingMergeRefills_def)
-  apply (rule bind_wp_fwd_skip, solves wpsimp)+
-  apply (wpsimp wp: whileLoop_valid_inv hoare_vcg_all_lift hoare_vcg_disj_lift scActive_wp hoare_drop_imps
-                    refillFull_wp refillEmpty_wp getRefillNext_wp  getRefillSize_wp
-              simp: scheduleUsed_def refillAddTail_def setRefillTl_def updateRefillTl_def
-                    setRefillHd_def updateRefillHd_def updateSchedContext_def)
-  done
-
-lemma refillBudgetCheck_ct_idle_or_in_cur_domain'[wp]:
-  "refillBudgetCheck usage \<lbrace>ct_idle_or_in_cur_domain'\<rbrace>"
-  apply (clarsimp simp: refillBudgetCheck_def isRoundRobin_def refillReady_def
-                        setReprogramTimer_def updateRefillHd_def)
-  apply (wpsimp wp: getRefillSize_wp refillFull_wp refillEmpty_wp hoare_vcg_all_lift hoare_drop_imps
-                    hoare_vcg_if_lift2
-              simp: scheduleUsed_def refillAddTail_def setRefillTl_def updateRefillTl_def
-                    updateRefillHd_def setRefillHd_def)
-  done
-
-lemma refillBudgetCheck_invs'[wp]:
-  "refillBudgetCheck usage \<lbrace>invs'\<rbrace>"
-  apply (clarsimp simp: invs'_def valid_pspace'_def pred_conj_def)
-  apply (wpsimp wp: refillBudgetCheck_valid_objs')
-  done
-
-lemma commitTime_invs':
-  "commitTime \<lbrace>invs'\<rbrace>"
-  apply (simp add: commitTime_def)
-  apply wpsimp
-       apply (wpsimp wp: updateSchedContext_invs'_indep)
-      apply (clarsimp simp: valid_sched_context'_def valid_sched_context_size'_def objBits_def sc_size_bounds_def objBitsKO_def live_sc'_def)
-      apply (rule_tac Q'="\<lambda>_. invs'" in hoare_strengthen_post)
-       apply (wpsimp wp: isRoundRobin_wp)
-      apply (wpsimp wp: getConsumedTime_wp getCurSc_wp)+
-  by (clarsimp simp: active_sc_at'_def obj_at'_real_def ko_wp_at'_def)
-
-lemma switchSchedContext_invs':
-  "switchSchedContext \<lbrace>invs'\<rbrace>"
-  apply (simp add: switchSchedContext_def)
-  apply (wpsimp wp: commitTime_invs' getReprogramTimer_wp refillUnblockCheck_invs' threadGet_wp simp: getCurSc_def)
-  apply (fastforce simp: obj_at'_def projectKO_eq projectKO_opt_tcb)
-  done
-
-lemma isSchedulable_bool_runnableE:
-  "isSchedulable_bool t s \<Longrightarrow> tcb_at' t s \<Longrightarrow> st_tcb_at' runnable' t s"
-  unfolding isSchedulable_bool_def
-  by (clarsimp simp: pred_tcb_at'_def obj_at'_def pred_map_def projectKO_eq projectKO_opt_tcb
-              elim!: opt_mapE)
-
-lemma rescheduleRequired_invs'[wp]:
-  "rescheduleRequired \<lbrace>invs'\<rbrace>"
-  unfolding rescheduleRequired_def
-  apply (wpsimp wp: ssa_invs' isSchedulable_wp)
-  apply (clarsimp simp: invs'_def isSchedulable_bool_def vs_all_heap_simps
-                        st_tcb_at'_def obj_at_simps pred_map_simps
-                 elim!: opt_mapE)
-  done
-
-lemma rescheduleRequired_ksSchedulerAction[wp]:
-  "\<lbrace>\<lambda>_. P ChooseNewThread\<rbrace> rescheduleRequired \<lbrace>\<lambda>_ s. P (ksSchedulerAction s)\<rbrace>"
-  unfolding rescheduleRequired_def by (wpsimp wp: isSchedulable_wp)
-
-lemma inReleaseQueue_wp:
-  "\<lbrace>\<lambda>s. \<forall>ko. ko_at' ko tcb_ptr s \<longrightarrow> P (tcbInReleaseQueue ko) s\<rbrace>
-   inReleaseQueue tcb_ptr
-   \<lbrace>P\<rbrace>"
-  unfolding inReleaseQueue_def threadGet_getObject
-  apply (wpsimp wp: getObject_tcb_wp)
-  apply (clarsimp simp: obj_at'_def)
-  done
-
-lemma possibleSwitchTo_weak_sch_act[wp]:
-  "\<lbrace>\<lambda>s. weak_sch_act_wf (ksSchedulerAction s) s \<and> st_tcb_at' runnable' t s\<rbrace>
-   possibleSwitchTo t
-   \<lbrace>\<lambda>rv s. weak_sch_act_wf (ksSchedulerAction s) s\<rbrace>"
-  unfolding possibleSwitchTo_def
-  apply (wpsimp wp: inReleaseQueue_wp threadGet_wp rescheduleRequired_weak_sch_act_wf)
-  by (auto simp: obj_at'_def weak_sch_act_wf_def tcb_in_cur_domain'_def
-                 projectKO_eq ps_clear_domE)
-
-crunch possibleSwitchTo
-  for valid_pspace'[wp]: valid_pspace'
-  and valid_queues[wp]: valid_queues
-  and valid_tcbs'[wp]: valid_tcbs'
-  and cap_to'[wp]: "ex_nonz_cap_to' p"
-  and ifunsafe'[wp]: "if_unsafe_then_cap'"
-  and global_refs'[wp]: valid_global_refs'
-  and valid_machine_state'[wp]: valid_machine_state'
-  and cur[wp]: cur_tcb'
-  and valid_queues'[wp]: valid_queues'
-  and valid_release_queue[wp]: valid_release_queue
-  and valid_release_queue'[wp]: valid_release_queue'
-  and refs_of'[wp]: "\<lambda>s. P (state_refs_of' s)"
-  and replies_of'[wp]: "\<lambda>s. P (replies_of' s)"
-  and idle'[wp]: "valid_idle'"
-  and valid_arch'[wp]: valid_arch_state'
-  and irq_node'[wp]: "\<lambda>s. P (irq_node' s)"
-  and typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  and ctes_of[wp]: "\<lambda>s. P (ctes_of s)"
-  and ksInterruptState[wp]: "\<lambda>s. P (ksInterruptState s)"
-  and irq_states' [wp]: valid_irq_states'
-  and pde_mappings' [wp]: valid_pde_mappings'
-  and pspace_domain_valid[wp]: "pspace_domain_valid"
-  and ksCurDomain[wp]: "\<lambda>s. P (ksCurDomain s)"
-  and ksDomSchedule[wp]: "\<lambda>s. P (ksDomSchedule s)"
-  and ksDomScheduleIdx[wp]: "\<lambda>s. P (ksDomScheduleIdx s)"
-  and gsUntypedZeroRanges[wp]: "\<lambda>s. P (gsUntypedZeroRanges s)"
-  and valid_objs'[wp]: valid_objs'
-  and ksArchState[wp]: "\<lambda>s. P (ksArchState s)"
-  and ksIdleThread[wp]: "\<lambda>s. P (ksIdleThread s)"
-  and gsMaxObjectSize[wp]: "\<lambda>s. P (gsMaxObjectSize s)"
-  and valid_irq_handlers'[wp]: valid_irq_handlers'
-  (wp: crunch_wps cur_tcb_lift valid_irq_handlers_lift'' simp: crunch_simps)
-
-lemmas possibleSwitchTo_typ_ats[wp] = typ_at_lifts[OF possibleSwitchTo_typ_at']
-
-lemma possibleSwitchTo_sch_act[wp]:
-  "\<lbrace>\<lambda>s. sch_act_wf (ksSchedulerAction s) s \<and> st_tcb_at' runnable' t s\<rbrace>
-   possibleSwitchTo t
-   \<lbrace>\<lambda>rv s. sch_act_wf (ksSchedulerAction s) s\<rbrace>"
-  apply (wpsimp simp: possibleSwitchTo_def wp: inReleaseQueue_wp threadGet_wp)
-  by (fastforce simp: obj_at'_def tcb_in_cur_domain'_def)
-
-lemma possibleSwitchTo_iflive'[wp]:
-  "\<lbrace>if_live_then_nonz_cap' and ex_nonz_cap_to' t
-      and (\<lambda>s. \<forall>t. ksSchedulerAction s = SwitchToThread t
-                   \<longrightarrow> st_tcb_at' runnable' t s)\<rbrace>
-   possibleSwitchTo t
-   \<lbrace>\<lambda>rv. if_live_then_nonz_cap'\<rbrace>"
-  by (wpsimp simp: possibleSwitchTo_def inReleaseQueue_def
-               wp: hoare_vcg_if_lift2 hoare_drop_imps)
-
-lemma possibleSwitchTo_ct_idle_or_in_cur_domain'[wp]:
-  "possibleSwitchTo t \<lbrace>ct_idle_or_in_cur_domain'\<rbrace>"
-  apply (wpsimp simp: possibleSwitchTo_def
-                  wp: threadGet_wp inReleaseQueue_wp)
-  apply (fastforce simp: obj_at'_def ct_idle_or_in_cur_domain'_def)
-  done
-
-lemma possibleSwitchTo_utr[wp]:
-  "possibleSwitchTo t \<lbrace>untyped_ranges_zero'\<rbrace>"
-  by (wpsimp simp: cteCaps_of_def o_def wp: untyped_ranges_zero_lift)
-
-lemma possibleSwitchTo_invs'[wp]:
-  "\<lbrace>invs' and st_tcb_at' runnable' tptr\<rbrace>
-   possibleSwitchTo tptr
-   \<lbrace>\<lambda>_. invs'\<rbrace>"
-  apply (simp add: possibleSwitchTo_def)
-  apply (wpsimp wp: hoare_vcg_imp_lift threadGet_wp inReleaseQueue_wp ssa_invs')
-  apply (clarsimp simp: invs'_def pred_tcb_at'_def obj_at'_def)
-  done
-
-lemma possibleSwitchTo_sch_act_not_other:
-  "\<lbrace>\<lambda>s. sch_act_not t' s \<and> t' \<noteq> t\<rbrace>
-   possibleSwitchTo t
-   \<lbrace>\<lambda>_. sch_act_not t'\<rbrace>"
-  apply (clarsimp simp: possibleSwitchTo_def)
-  apply (wpsimp wp: threadGet_wp inReleaseQueue_wp)
-  apply (clarsimp simp: obj_at'_def)
-  done
-
-lemma setReleaseQueue_tcb_at'[wp]:
- "setReleaseQueue qs \<lbrace>typ_at' T tcbPtr\<rbrace>"
-  unfolding setReleaseQueue_def
-  by wpsimp
-
-lemma setReleaseQueue_ksReleaseQueue[wp]:
-  "\<lbrace>\<lambda>_. P qs\<rbrace> setReleaseQueue qs \<lbrace>\<lambda>_ s. P (ksReleaseQueue s)\<rbrace>"
-  by (wpsimp simp: setReleaseQueue_def)
-
-lemma setReleaseQueue_pred_tcb_at'[wp]:
- "setReleaseQueue qs \<lbrace>\<lambda>s. P (pred_tcb_at' proj P' t' s)\<rbrace>"
-  by (wpsimp simp: setReleaseQueue_def)
-
-crunch setReprogramTimer, possibleSwitchTo
-  for ksReleaseQueue[wp]: "\<lambda>s. P (ksReleaseQueue s)"
-  (wp: crunch_wps simp: crunch_simps)
-
-lemma tcbReleaseDequeue_distinct_release_queue[wp]:
-  "tcbReleaseDequeue \<lbrace>distinct_release_queue\<rbrace>"
-  unfolding tcbReleaseDequeue_def
-  by (wpsimp simp: distinct_tl)
-
-lemma getReleaseQueue_sp:
-  "\<lbrace>Q\<rbrace> getReleaseQueue \<lbrace>\<lambda>r. (\<lambda>s. r = ksReleaseQueue s) and Q\<rbrace>"
-  unfolding getReleaseQueue_def
-  by wpsimp
-
-lemma releaseQNonEmptyAndReady_implies_releaseQNonEmpty:
-  "the (releaseQNonEmptyAndReady s) \<Longrightarrow> ksReleaseQueue s \<noteq> []"
-  by (clarsimp simp: releaseQNonEmptyAndReady_def readTCBRefillReady_def readReleaseQueue_def
-                     obind_def omonad_defs)
-
-lemma awaken_invs':
-  "awaken \<lbrace>invs'\<rbrace>"
-  apply (clarsimp simp: awaken_def awakenBody_def)
-  apply (rule_tac I="\<lambda>_. invs'" in valid_whileLoop; simp add: runReaderT_def)
-  apply (rule bind_wp[OF _ getReleaseQueue_sp])
-  apply (rule bind_wp[OF _ assert_sp])
-  apply wpsimp
-   apply (rule hoare_drop_imps)
-   apply (rule tcbReleaseDequeue_invs')
-  apply (fastforce intro!: releaseQNonEmptyAndReady_implies_releaseQNonEmpty)
-  done
-
-crunch tcbReleaseDequeue
-  for st_tcb_at'[wp]: "\<lambda>s. Q (st_tcb_at' P p s)"
-  and valid_replies' [wp]: valid_replies'
-  (wp: crunch_wps threadSet_pred_tcb_no_state valid_replies'_lift)
-
-lemma awaken_sch_act_wf[wp]:
-  "awaken \<lbrace>\<lambda>s. sch_act_wf (ksSchedulerAction s) s\<rbrace>"
-  apply (clarsimp simp: awaken_def awakenBody_def)
-  apply (rule_tac I="\<lambda>_ s. sch_act_wf (ksSchedulerAction s) s" in valid_whileLoop; simp add: runReaderT_def)
-  apply (rule bind_wp[OF _ getReleaseQueue_sp])
-  apply (rule bind_wp[OF _ assert_sp])
-  apply wpsimp
-   apply (rule hoare_drop_imp)
-   apply wpsimp
-  apply (fastforce intro!: releaseQNonEmptyAndReady_implies_releaseQNonEmpty)
-  done
-
-crunch awaken
-  for cur_tcb'[wp]: cur_tcb'
-  (wp: crunch_wps)
-
-crunch checkDomainTime
-  for invs'[wp]: invs'
-  and sch_act_wf[wp]: "\<lambda>s. sch_act_wf (ksSchedulerAction s) s"
-  and cur_tcb'[wp]: cur_tcb'
-  (simp: crunch_simps wp: crunch_wps)
 
 lemma schedule_invs':
-  "schedule \<lbrace>invs'\<rbrace>"
-  supply if_split [split del]
-  apply (simp add: schedule_def scAndTimer_def cur_tcb'_asrt_def)
-  apply (intro bind_wp[OF _ stateAssert_sp])
-  apply (clarsimp simp: sch_act_wf_asrt_def)
+  "\<lbrace>invs'\<rbrace> ThreadDecls_H.schedule \<lbrace>\<lambda>rv. invs'\<rbrace>"
+  supply ssa_wp[wp del]
+  apply (simp add: schedule_def)
   apply (rule_tac bind_wp, rename_tac t)
-   apply (rule_tac P'="invs' and (\<lambda>s. sch_act_wf (ksSchedulerAction s) s) and cur_tcb'" in hoare_weaken_pre)
-    apply (rule bind_wp_fwd_skip, wpsimp)
-    apply (rule_tac bind_wp[OF _ getCurThread_sp])
-    apply (rule_tac bind_wp[OF _ isSchedulable_sp])
-    apply (rule_tac bind_wp[OF _ getSchedulerAction_sp])
-    apply (rule bind_wp)
-     apply (wpsimp wp: switchSchedContext_invs')
-    apply (wpsimp wp: scheduleChooseNewThread_invs' isSchedulable_wp setSchedulerAction_invs'
-                      ssa_invs' hoare_vcg_disj_lift)
-           apply (wpsimp simp: isHighestPrio_def')
-          apply (wpsimp wp: curDomain_wp)
-         apply (wpsimp simp: scheduleSwitchThreadFastfail_def)
-        apply (rename_tac tPtr x idleThread targetPrio)
-        apply (rule_tac Q'="\<lambda>_. invs' and st_tcb_at' runnable' tPtr and cur_tcb'"
-                     in hoare_strengthen_post[rotated])
-         apply (prop_tac "st_tcb_at' runnable' tPtr s \<Longrightarrow> obj_at' (\<lambda>a. activatable' (tcbState a)) tPtr s")
-          apply (clarsimp simp: pred_tcb_at'_def obj_at'_def)
-         apply fastforce
-        apply (wpsimp wp: threadGet_wp hoare_drop_imp hoare_vcg_ex_lift)
-       apply (rename_tac tPtr x idleThread)
-       apply (rule_tac Q'="\<lambda>_. invs' and st_tcb_at' runnable' tPtr and cur_tcb'"
-                    in hoare_strengthen_post[rotated])
-        apply (subst obj_at_ko_at'_eq[symmetric], simp)
-       apply (wpsimp wp: threadGet_wp hoare_drop_imp hoare_vcg_ex_lift)
-      apply (rename_tac tPtr x)
-      apply (rule_tac Q'="\<lambda>_. invs' and st_tcb_at' runnable' tPtr and cur_tcb'"
-                   in hoare_strengthen_post[rotated])
-       apply (subst obj_at_ko_at'_eq[symmetric], simp)
-      apply (wpsimp wp: tcbSchedEnqueue_invs' isSchedulable_wp)+
-    apply (fastforce split: if_split dest: isSchedulable_bool_runnableE simp: cur_tcb'_def)
-   apply assumption
-  apply (wpsimp wp: awaken_invs')
+   apply (wp, wpc)
+      \<comment> \<open>action = ResumeCurrentThread\<close>
+      apply (wp)[1]
+     \<comment> \<open>action = ChooseNewThread\<close>
+     apply (wp scheduleChooseNewThread_invs')
+    \<comment> \<open>action = SwitchToThread candidate\<close>
+    apply (wpsimp wp: scheduleChooseNewThread_invs' ssa_invs'
+                      chooseThread_invs_no_cicd' setSchedulerAction_invs' setSchedulerAction_direct
+                      switchToThread_tcb_in_cur_domain' switchToThread_ct_not_queued_2
+           | wp hoare_disjI2[where Q'="\<lambda>_ s. tcb_in_cur_domain' (ksCurThread s) s"]
+           | wp hoare_drop_imp[where f="isHighestPrio d p" for d p]
+           | simp only: obj_at'_activatable_st_tcb_at'[simplified comp_def]
+           | strengthen invs'_invs_no_cicd
+           | wp hoare_vcg_imp_lift)+
+  apply (frule invs_sch_act_wf')
+  apply (auto simp: invs_sch_act_wf' obj_at'_activatable_st_tcb_at'
+                     st_tcb_at'_runnable_is_activatable)
   done
 
 lemma setCurThread_nosch:
@@ -3034,17 +2218,12 @@ lemma chooseThread_nosch:
   apply (simp only: return_bind, simp)
   apply (wp findM_inv | simp)+
   apply (case_tac queue)
-  apply (wp stt_nosch isSchedulable_wp | simp add: curDomain_def bitmap_fun_defs)+
+  apply (wp stt_nosch | simp add: curDomain_def bitmap_fun_defs)+
   done
-
-crunch switchSchedContext, setNextInterrupt
-  for ksSchedulerAction[wp]: "\<lambda>s. P (ksSchedulerAction s)"
-  (wp: crunch_wps hoare_vcg_all_lift simp: crunch_simps)
 
 lemma schedule_sch:
   "\<lbrace>\<top>\<rbrace> schedule \<lbrace>\<lambda>rv s. ksSchedulerAction s = ResumeCurrentThread\<rbrace>"
-  unfolding schedule_def scAndTimer_def
-  by (wpsimp wp: setSchedulerAction_direct simp: getReprogramTimer_def scheduleChooseNewThread_def)
+  by (wp setSchedulerAction_direct | wpc| simp add: schedule_def scheduleChooseNewThread_def)+
 
 lemma schedule_sch_act_simple:
   "\<lbrace>\<top>\<rbrace> schedule \<lbrace>\<lambda>rv. sch_act_simple\<rbrace>"
@@ -3068,33 +2247,32 @@ lemma scheduleChooseNewThread_ct_activatable'[wp]:
    \<lbrace>\<lambda>_. ct_in_state' activatable'\<rbrace>"
   unfolding scheduleChooseNewThread_def
   by (wpsimp simp: ct_in_state'_def
-                wp: ssa_invs' nextDomain_invs'
+                wp: ssa_invs' nextDomain_invs_no_cicd'
                     chooseThread_activatable_2[simplified ct_in_state'_def]
-         | (rule hoare_lift_Pf[where f=ksCurThread], solves wp))+
+         | (rule hoare_lift_Pf[where f=ksCurThread], solves wp)
+         | strengthen invs'_invs_no_cicd)+
 
-lemma st_tcb_at_activatable_coerce_concrete:
-  assumes t: "st_tcb_at activatable t s"
-  assumes sr: "(s, s') \<in> state_relation"
-  assumes tcb: "tcb_at' t s'"
-  shows "st_tcb_at' activatable' t s'"
-  using t
-  apply -
-  apply (rule ccontr)
-  apply (drule pred_tcb_at'_Not[THEN iffD2, OF conjI, OF tcb])
-  apply (drule st_tcb_at_coerce_abstract[OF _ sr])
-  apply (clarsimp simp: st_tcb_def2)
-  apply (case_tac "tcb_state tcb"; simp)
+lemma schedule_ct_activatable'[wp]:
+  "\<lbrace>invs'\<rbrace> ThreadDecls_H.schedule \<lbrace>\<lambda>_. ct_in_state' activatable'\<rbrace>"
+  supply ssa_wp[wp del]
+  apply (simp add: schedule_def)
+  apply (rule_tac bind_wp, rename_tac t)
+   apply (wp, wpc)
+      \<comment> \<open>action = ResumeCurrentThread\<close>
+      apply (wp)[1]
+     \<comment> \<open>action = ChooseNewThread\<close>
+     apply wpsimp
+    \<comment> \<open>action = SwitchToThread\<close>
+    apply (wpsimp wp: ssa_invs' setSchedulerAction_direct ssa_ct
+           | wp hoare_drop_imp[where f="isHighestPrio d p" for d p]
+           | simp only: obj_at'_activatable_st_tcb_at'[simplified comp_def]
+           | strengthen invs'_invs_no_cicd
+           | wp hoare_vcg_imp_lift)+
+  apply (fastforce dest: invs_sch_act_wf' elim: pred_tcb'_weakenE
+                   simp: sch_act_wf obj_at'_activatable_st_tcb_at')
   done
 
-lemma ct_in_state'_activatable_coerce_concrete:
-  "\<lbrakk>ct_in_state activatable s; (s, s') \<in> state_relation; cur_tcb' s'\<rbrakk>
-    \<Longrightarrow> ct_in_state' activatable' s'"
-   unfolding ct_in_state'_def cur_tcb'_def ct_in_state_def
-   apply (rule st_tcb_at_activatable_coerce_concrete[rotated], simp, simp)
-   apply (frule curthread_relation, simp)
-   done
-
-lemma threadSet_sch_act_sane[wp]:
+lemma threadSet_sch_act_sane:
   "\<lbrace>sch_act_sane\<rbrace> threadSet f t \<lbrace>\<lambda>_. sch_act_sane\<rbrace>"
   by (wp sch_act_sane_lift)
 
@@ -3102,2633 +2280,51 @@ lemma rescheduleRequired_sch_act_sane[wp]:
   "\<lbrace>\<top>\<rbrace> rescheduleRequired \<lbrace>\<lambda>rv. sch_act_sane\<rbrace>"
   apply (simp add: rescheduleRequired_def sch_act_sane_def
                    setSchedulerAction_def)
-  by (wp isSchedulable_wp | wpc | clarsimp)+
+  by (wp | wpc | clarsimp)+
 
 crunch setThreadState, setBoundNotification
- for sch_act_sane[wp]: "sch_act_sane"
+  for sch_act_sane: "sch_act_sane"
   (simp: crunch_simps wp: crunch_wps)
 
-lemma weak_sch_act_wf_at_cross:
-  assumes sr: "(s,s') \<in> state_relation"
-  assumes aligned: "pspace_aligned s"
-  assumes distinct: "pspace_distinct s"
-  assumes t: "valid_sched_action s"
-  shows "weak_sch_act_wf (ksSchedulerAction s') s'"
-  using assms
-  apply (clarsimp simp: valid_sched_action_def weak_valid_sched_action_def weak_sch_act_wf_def)
-  apply (frule state_relation_sched_act_relation)
-  apply (rename_tac t)
-  apply (drule_tac x=t in spec)
-  apply (prop_tac "scheduler_action s = switch_thread t")
-   apply (metis sched_act_relation.simps Structures_A.scheduler_action.exhaust
-                scheduler_action.simps)
-  apply (intro conjI impI)
-   apply (rule st_tcb_at_runnable_cross; fastforce?)
-   apply (clarsimp simp: vs_all_heap_simps pred_tcb_at_def obj_at_def)
-  apply (clarsimp simp: switch_in_cur_domain_def in_cur_domain_def etcb_at_def vs_all_heap_simps)
-  apply (prop_tac "tcb_at t s")
-   apply (clarsimp simp: obj_at_def is_tcb_def)
-  apply (frule state_relation_pspace_relation)
-  apply (frule (3) tcb_at_cross)
-  apply (clarsimp simp: tcb_in_cur_domain'_def obj_at'_def projectKOs)
-  apply (frule curdomain_relation)
-  apply (frule (2) pspace_relation_tcb_domain_priority)
-  apply simp
-  done
-
 lemma possibleSwitchTo_corres:
-  "t = t' \<Longrightarrow>
-   corres dc
-    (valid_sched_action and tcb_at t and pspace_aligned and pspace_distinct
-     and valid_tcbs and active_scs_valid)
-    (valid_queues and valid_queues' and valid_release_queue_iff and valid_tcbs')
-      (possible_switch_to t)
-      (possibleSwitchTo t')"
-  supply dc_simp [simp del]
-  apply (rule corres_cross_add_guard[where Q="tcb_at' t"])
-   apply (fastforce intro: tcb_at_cross)
+  "corres dc
+     (valid_etcbs and weak_valid_sched_action and cur_tcb and st_tcb_at runnable t
+      and in_correct_ready_q and ready_qs_distinct and pspace_aligned and pspace_distinct)
+     ((\<lambda>s. weak_sch_act_wf (ksSchedulerAction s) s)
+      and sym_heap_sched_pointers and valid_sched_pointers and valid_objs')
+     (possible_switch_to t) (possibleSwitchTo t)"
+  apply (rule_tac Q'=pspace_aligned' in corres_cross_add_guard)
+   apply (fastforce dest: pspace_aligned_cross)
+  apply (rule_tac Q'=pspace_distinct' in corres_cross_add_guard)
+   apply (fastforce dest: pspace_distinct_cross)
+  supply ethread_get_wp[wp del]
+  apply (rule corres_cross_over_guard[where P'=Q and Q="tcb_at' t and Q" for Q])
+   apply (clarsimp simp: state_relation_def)
+   apply (rule tcb_at_cross, erule st_tcb_at_tcb_at; assumption)
   apply (simp add: possible_switch_to_def possibleSwitchTo_def cong: if_cong)
   apply (rule corres_guard_imp)
-    apply (simp add: get_tcb_obj_ref_def)
-    apply (rule corres_split)
-       apply (rule threadGet_corres[where r="(=)"])
-       apply (clarsimp simp: tcb_relation_def)
-      apply (rule corres_split[OF inReleaseQueue_corres], simp)
-        apply (rule corres_when[rotated])
-         apply (rule corres_split[OF curDomain_corres], simp)
-           apply (rule corres_split)
-              apply (rule threadGet_corres[where r="(=)"])
-              apply (clarsimp simp: tcb_relation_def)
-             apply (rule corres_split[OF getSchedulerAction_corres])
-               apply (rule corres_if, simp)
-                apply (rule tcbSchedEnqueue_corres)
-               apply (rule corres_if[rotated], simp)
-                 apply (rule corres_split[OF rescheduleRequired_corres])
-                   apply (rule tcbSchedEnqueue_corres)
-                  apply wp+
-                apply (rule setSchedulerAction_corres, simp)
-               apply (rename_tac rv rv')
-               apply (case_tac rv; simp)
-              apply (wpsimp simp: if_apply_def2 valid_sched_action_def
-                              wp: hoare_drop_imp inReleaseQueue_inv)+
-  done
-
-lemma ct_active_cross:
-  "\<lbrakk> (s,s') \<in> state_relation; pspace_aligned s; pspace_distinct s; ct_active s \<rbrakk>
-     \<Longrightarrow> ct_active' s'"
-  by (clarsimp simp: state_relation_def ct_in_state_def ct_in_state'_def
-                     st_tcb_at_runnable_cross runnable_eq_active runnable_eq_active'[symmetric])
-
-\<comment> \<open>Strengthen the consequent as necessary, there's more that can be derived from the assumptions\<close>
-lemma ct_released_cross_weak:
-  "\<lbrakk> (s,s') \<in> state_relation; pspace_aligned s; pspace_distinct s; ct_released s; cur_tcb' s' \<rbrakk>
-     \<Longrightarrow> bound_sc_tcb_at' bound (ksCurThread s') s'"
-  apply (clarsimp simp: vs_all_heap_simps obj_at_kh_kheap_simps)
-  apply (clarsimp simp: state_relation_def pspace_relation_def )
-  apply (erule_tac x="ksCurThread s'" in ballE)
-   apply (auto simp: vs_all_heap_simps other_obj_relation_def tcb_relation_def
-                          cur_tcb'_def pred_tcb_at'_def obj_at'_def projectKOs
-                   split: kernel_object.splits)
-  done
-
-lemma setReprogramTimer_corres[corres]:
-  "corres dc \<top> \<top> (modify (reprogram_timer_update (\<lambda>_. b))) (setReprogramTimer b)"
-  apply (unfold setReprogramTimer_def)
-  apply (rule corres_modify)
-  apply (simp add: state_relation_def swp_def)
-  done
-
-lemma getCurTime_corres[corres]:
-  "corres (=) \<top> \<top> (gets cur_time) (getCurTime)"
-  apply (clarsimp simp: getCurTime_def state_relation_def)
-  done
-
-lemma readRefillReady_simp:
-  "readRefillReady scp s
-   = (case readSchedContext scp s
-        of None \<Rightarrow> None
-         | Some sc' \<Rightarrow> Some (rTime (refillHd sc') \<le> (ksCurTime s) + kernelWCETTicks))"
-  by (clarsimp simp: readRefillReady_def readCurTime_def readSchedContext_SomeD asks_def obind_def)
-
-lemma refillReady_corres:
-  "corres (=)
-     (sc_at sc_ptr and
-        (\<lambda>s. ((\<lambda>sc. sc_refills sc \<noteq> []) |< scs_of2 s) sc_ptr))
-     (sc_at' sc_ptr and valid_refills' sc_ptr)
-        (get_sc_refill_ready sc_ptr)
-        (refillReady sc_ptr)"
-  supply getSchedContext_wp[wp del] set_sc'.get_wp[wp del] projection_rewrites[simp]
-  apply (clarsimp simp: refill_ready_def refillReady_def get_sc_refill_ready_def)
-  apply (rule gets_the_corres)
-    apply (wpsimp wp: no_ofail_read_sc_refill_ready)
-    apply (clarsimp simp: is_sc_obj obj_at_def)
-   apply wpsimp
-  apply (clarsimp simp: obj_at_def is_sc_obj dest!: no_ofailD[OF readRefillReady_no_ofail]
-                 intro: no_ofailD[OF no_ofail_read_sc_refill_ready])
-  apply (insert no_ofailD[OF no_ofail_read_sc_refill_ready, rule_format])
-  apply (drule_tac x=s and y=sc_ptr in meta_spec2)
-  apply (prop_tac "\<exists>sc n. kheap s sc_ptr = Some (kernel_object.SchedContext sc n)")
-   apply (clarsimp simp: sc_at_pred_n_def obj_at_def)
-  apply clarsimp
-  apply (clarsimp simp: read_sc_refill_ready_simp readRefillReady_simp readSchedContext_def
-                        read_sched_context_def
-                 split: option.splits dest!: readObject_misc_ko_at')
-  apply (rename_tac n sc' sc)
-  apply (frule state_relation_sc_relation; (clarsimp simp: obj_at'_def obj_at_def projectKOs is_sc_obj))
-     apply fastforce+
-  apply (fastforce simp: kernelWCETTicks_def refill_ready_def state_relation_def refill_map_def
-                         obj_at_def opt_map_red opt_pred_def valid_refills'_def
-                  dest!: refill_hd_relation)
-  done
-
-lemma readTCBRefillReady_no_ofail:
-  "no_ofail (\<lambda>s'. obj_at' (\<lambda>tcb. \<exists>sc. tcbSchedContext tcb = Some sc \<and> sc_at' sc s') t s')
-            (readTCBRefillReady t)"
-  unfolding readTCBRefillReady_def
-  apply (wpsimp wp: ovalid_threadRead)
-  apply (clarsimp simp: obj_at'_def)
-  done
-
-lemma readTCBRefillReady_simp:
-  "\<lbrakk>(s, s') \<in> state_relation; pspace_aligned s; pspace_distinct s; valid_objs s;
-    active_sc_tcb_at t s; active_scs_valid s; valid_objs' s'\<rbrakk>
-   \<Longrightarrow> read_tcb_refill_ready t s = readTCBRefillReady t s'"
-  apply (frule (1) active_scs_valid_tcb_at)
-  apply (clarsimp simp: obj_at_kh_kheap_simps vs_all_heap_simps)
-  apply (rename_tac scp tcb sc n)
-  apply (prop_tac "tcb_at' t s' \<and> sc_at' scp s'")
-   apply (fastforce dest!: state_relationD intro!: sc_at_cross tcb_at_cross
-                     simp: obj_at_def is_tcb is_sc_obj
-                     elim: valid_sched_context_size_objsI)
-  apply clarsimp
-  apply (prop_tac "bound (read_tcb_refill_ready t s)")
-   apply (clarsimp intro!: no_ofailD[OF no_ofail_read_tcb_refill_ready]
-                     simp: pred_tcb_at_def obj_at_def)
-  apply (frule state_relation_pspace_relation)
-  apply (clarsimp simp: pspace_relation_def)
-  apply (drule_tac x=t in bspec, blast)
-  apply (drule_tac x="(t, other_obj_relation)" in bspec, clarsimp)
-  apply (clarsimp simp: other_obj_relation_def tcb_relation_def obj_at'_def projectKOs)
-  apply (prop_tac "bound (readTCBRefillReady t s')")
-   apply (clarsimp intro!: no_ofailD[OF readTCBRefillReady_no_ofail])
-   apply (clarsimp simp: obj_at'_def projectKOs)
-   apply (rule_tac x=scp in exI; clarsimp)
-  apply clarsimp
-  apply (clarsimp simp: read_tcb_refill_ready_def readTCBRefillReady_def oassert_opt_def
-                        readRefillReady_simp read_sc_refill_ready_simp refill_ready'_def obj_at'_def
-                        projectKOs
-                 dest!: read_tcb_obj_ref_SomeD read_sched_context_SomeD readSchedContext_SomeD
-                        threadRead_SomeD
-                 split: option.split_asm)
-  apply (rename_tac sc' sc_ptr tcbPtr)
-  apply (prop_tac "valid_sched_context' sc' s' \<and> valid_sched_context_size' sc'")
-   apply (frule_tac k=sc' and p=sc_ptr in sc_ko_at_valid_objs_valid_sc'[rotated])
-    apply (clarsimp simp: obj_at'_def projectKOs)
-   apply simp
-  apply (frule state_relation_pspace_relation)
-  apply (prop_tac "sc_relation sc n sc'")
-   apply (clarsimp simp: pspace_relation_def)
-   apply (drule_tac x=sc_ptr in bspec, blast)
-   apply (fastforce simp: obj_at'_def projectKOs split: if_splits)
-  apply (frule refill_hd_relation2)
-    apply (clarsimp simp: valid_refills_tcb_at_def valid_refills_def rr_valid_refills_def
-                          pred_tcb_at_def obj_at_def vs_all_heap_simps
-                   split: if_splits)
-   apply (fastforce dest!: sc_ko_at_valid_objs_valid_sc'
-                     simp: obj_at'_def projectKOs)
-  apply (clarsimp simp: kernelWCETTicks_def state_relation_def)
-  done
-
-lemma getReleaseQueue_corres[corres]:
-  "corres (=) \<top> \<top> (gets release_queue) (getReleaseQueue)"
-  unfolding getReleaseQueue_def
-  apply (rule corres_gets_trivial)
-  by (clarsimp simp: state_relation_def release_queue_relation_def)
-
-lemma releaseQNonEmptyAndReady_simp:
-  "releaseQNonEmptyAndReady s
-    = (if ksReleaseQueue s = []
-          then Some False
-          else readTCBRefillReady (head (ksReleaseQueue s)) s)"
-  by (clarsimp simp: releaseQNonEmptyAndReady_def readReleaseQueue_def asks_def obind_def)
-
-lemma releaseQNonEmptyAndReady_eq:
-  "\<lbrakk>(s, s') \<in> state_relation; pspace_aligned s; pspace_distinct s;
-     valid_objs s; valid_release_q s;
-     active_scs_valid s; valid_objs' s'\<rbrakk>
-   \<Longrightarrow> read_release_q_non_empty_and_ready s = releaseQNonEmptyAndReady s'"
-  apply (clarsimp simp: read_release_q_non_empty_and_ready_simp releaseQNonEmptyAndReady_simp)
-  apply (fastforce simp: state_relation_def release_queue_relation_def
-                 intro!: readTCBRefillReady_simp valid_release_q_active_sc)
-  done
-
-lemma ksReleaseQueue_length_well_founded:
-  "wf {((r :: unit, s :: kernel_state), (r', s')). length (ksReleaseQueue s)
-                                                    < length (ksReleaseQueue s')}"
-  apply (insert wf_inv_image[where r="{(m, n). m < n}"
-                               and f="\<lambda>(r :: unit, s :: kernel_state). length (ksReleaseQueue s)"])
-  apply (clarsimp simp: inv_image_def)
-  apply (prop_tac "wf {(m, n). m < n}")
-   apply (fastforce intro: wf)
-  apply (drule meta_mp)
-   apply simp
-  apply (prop_tac "{(x :: unit \<times> global.kernel_state, y ::  unit \<times> global.kernel_state).
-                     (case x of (r, s) \<Rightarrow> length (ksReleaseQueue s))
-                      < (case y of (r, s) \<Rightarrow> length (ksReleaseQueue s))}
-                   = {((r, s), r', s'). length (ksReleaseQueue s) < length (ksReleaseQueue s')}")
-   apply fastforce
-  apply fastforce
-  done
-
-lemma tcbReleaseDequeue_ksReleaseQueue_length_helper:
-  "\<lbrace>\<lambda>s'. ksReleaseQueue s' \<noteq> [] \<and> s' = s\<rbrace>
-   tcbReleaseDequeue
-   \<lbrace>\<lambda>r' s'. length (ksReleaseQueue s') < length (ksReleaseQueue s)\<rbrace>"
-  apply (wpsimp simp: tcbReleaseDequeue_def getReleaseQueue_def setReleaseQueue_def)
-  done
-
-lemma tcbReleaseDequeue_ksReleaseQueue_length:
-  "\<lbrace>\<lambda>s'. the (releaseQNonEmptyAndReady s') \<and> s' = s\<rbrace>
-   tcbReleaseDequeue
-   \<lbrace>\<lambda>r' s'. length (ksReleaseQueue s') < length (ksReleaseQueue s)\<rbrace>"
-  apply (wpsimp wp: tcbReleaseDequeue_ksReleaseQueue_length_helper)
-  apply (fastforce dest: releaseQNonEmptyAndReady_implies_releaseQNonEmpty)
-  done
-
-lemma awakenBody_ksReleaseQueue_length:
-  "\<lbrace>\<lambda>s'. the (releaseQNonEmptyAndReady s') \<and> s' = s\<rbrace>
-   awakenBody
-   \<lbrace>\<lambda>r' s'. length (ksReleaseQueue s') < length (ksReleaseQueue s)\<rbrace>"
-  apply (clarsimp simp: awakenBody_def)
-  apply (wpsimp wp: tcbReleaseDequeue_ksReleaseQueue_length hoare_drop_imps)
-  done
-
-lemma awaken_terminates:
-  "whileLoop_terminates (\<lambda>_ s'. (the (releaseQNonEmptyAndReady s'))) (\<lambda>_. awakenBody) r' s'"
-  apply (rule_tac R="{((r', s'), (r, s)). length (ksReleaseQueue s') < length (ksReleaseQueue s)}"
-               in whileLoop_terminates_inv)
-    apply simp
-   apply clarsimp
-   apply (rule awakenBody_ksReleaseQueue_length)
-  apply (rule ksReleaseQueue_length_well_founded)
-  done
-
-lemma reprogram_timer_update_release_queue_update_monad_commute:
-  "monad_commute \<top> (modify (reprogram_timer_update (\<lambda>_. b))) (modify (release_queue_update q))"
-  apply (clarsimp simp: monad_commute_def modify_def get_def put_def bind_def return_def)
-  done
-
-lemma release_queue_modify_tl:
-  "\<lbrakk>(s, s') \<in> state_relation; valid_release_q s; release_queue s \<noteq> []\<rbrakk>
-   \<Longrightarrow> (s\<lparr>release_queue := filter ((\<noteq>) (hd (release_queue s))) (release_queue s)\<rparr>,
-        s'\<lparr>ksReleaseQueue := tl (release_queue s)\<rparr>) \<in> state_relation"
-  apply (clarsimp simp: state_relation_def cdt_relation_def)
-  apply (clarsimp simp: release_queue_relation_def)
-  apply (prop_tac "ksReleaseQueue s' \<noteq> []", fastforce)
-  apply (rule filter_hd_equals_tl)
-   apply (prop_tac "distinct (release_queue s)")
-    apply (clarsimp simp: valid_release_q_def)
-   apply simp+
-  done
-
-lemma ksReleaseQueue_runnable'_cross_rel:
-  "cross_rel (pspace_aligned and pspace_distinct and valid_release_q)
-             (\<lambda>s'. \<forall>t \<in> set (ksReleaseQueue s'). st_tcb_at' runnable' t s')"
-  apply (clarsimp simp: cross_rel_def)
-  apply (clarsimp simp: valid_release_q_def release_queue_relation_def)
-  apply (frule state_relation_release_queue_relation)
-  apply (clarsimp simp: release_queue_relation_def)
-  apply (prop_tac "st_tcb_at runnable t s")
-   apply (fastforce simp: obj_at_kh_kheap_simps)
-  apply (fastforce intro: sts_rel_runnable
-                   dest!: st_tcb_at_coerce_concrete
-                    simp: st_tcb_at'_def obj_at'_def)
-  done
-
-lemma tcbReleaseDequeue_corres:
-  "corres (=) (pspace_aligned and pspace_distinct and valid_release_q and (\<lambda>s. release_queue s \<noteq> []))
-              \<top>
-              tcb_release_dequeue
-              tcbReleaseDequeue"
-   (is "corres _ _ ?conc _ _")
-  apply (rule corres_cross[where Q'="\<lambda>s'. \<forall>t \<in> set (ksReleaseQueue s'). st_tcb_at' runnable' t s'"
-                           , OF ksReleaseQueue_runnable'_cross_rel], blast)
-  apply (clarsimp simp: tcb_release_dequeue_def tcb_release_remove_def tcbReleaseDequeue_def
-                        setReleaseQueue_def tcb_sched_dequeue_def)
-  apply (rule corres_symb_exec_l[rotated 2, OF gets_sp]; (solves wpsimp)?)
-  apply (rename_tac rq)
-  apply (simp add: bind_assoc)
-  apply (rule corres_underlying_split[rotated 2, OF gets_sp getReleaseQueue_sp])
-   apply (corresKsimp corres: getReleaseQueue_corres)
-
-  apply clarsimp
-  apply (rename_tac rq')
-  apply (rule_tac F="rq' \<noteq> [] \<and> rq' = rq" in corres_req)
-   apply (clarsimp simp: state_relation_def release_queue_relation_def)
-  apply clarsimp
-
-  apply (subst monad_commute_simple'[OF reprogram_timer_update_release_queue_update_monad_commute])
-  apply (rule corres_guard_imp)
-    apply (rule corres_split)
-       apply (rule_tac P="valid_release_q and (\<lambda>s. release_queue s \<noteq> [] \<and> release_queue s = rq)"
-                   and P'="\<lambda>s'. ksReleaseQueue s' \<noteq> []"
-                    in corres_inst)
-       apply (rule corres_modify)
-       apply (fastforce intro: release_queue_modify_tl)
-      apply wpsimp
-      apply (rule corres_add_noop_lhs)
-      apply (rule corres_split[OF threadSet_corres_noop])
-              apply (clarsimp simp: tcb_relation_def)+
-        apply (rule corres_split[OF setReprogramTimer_corres])
-          apply wpsimp+
-  apply (fastforce simp: st_tcb_at'_def)
-  done
-
-lemma tcbInReleaseQueue_update_valid_tcbs'[wp]:
-  "threadSet (tcbInReleaseQueue_update f) tcbPtr \<lbrace>valid_tcbs'\<rbrace>"
-  apply (wpsimp wp: threadSet_valid_tcbs')
-  done
-
-lemma tcbReleaseDequeue_valid_tcbs'[wp]:
-  "tcbReleaseDequeue \<lbrace>valid_tcbs'\<rbrace>"
-  apply (clarsimp simp: tcbReleaseDequeue_def setReleaseQueue_def setReprogramTimer_def)
-  apply ((rule bind_wp_fwd_skip, wpsimp simp: valid_tcbs'_def) | wpsimp)+
-  done
-
-lemma ksReleaseQueue_distinct_cross_rel:
-  "cross_rel (pspace_aligned and pspace_distinct and valid_release_q)
-             (\<lambda>s'. distinct (ksReleaseQueue s'))"
-  apply (clarsimp simp: cross_rel_def)
-  apply (fastforce dest: state_relation_release_queue_relation
-                 intro!: tcb_at_cross
-                   simp: valid_release_q_def release_queue_relation_def vs_all_heap_simps
-                         obj_at_def is_tcb_def)
-  done
-
-lemma ksReleaseQueue_nonempty_cross_rel:
-  "cross_rel (pspace_aligned and pspace_distinct and (\<lambda>s. release_queue s \<noteq> []))
-             (\<lambda>s'. ksReleaseQueue s' \<noteq> [])"
-  apply (clarsimp simp: cross_rel_def)
-   apply (fastforce dest: state_relation_release_queue_relation
-                  intro!: tcb_at_cross
-                    simp: valid_release_q_def release_queue_relation_def vs_all_heap_simps
-                          obj_at_def is_tcb_def)
-  done
-
-lemma isRunnable_no_fail[wp]:
-  "no_fail (tcb_at' tcbPtr) (isRunnable tcbPtr)"
-  apply (wpsimp simp: isRunnable_def)
-  done
-
-lemma awakenBody_corres:
-  "corres dc ((pspace_aligned and pspace_distinct and valid_objs and valid_sched_action
-               and valid_tcbs and valid_release_q and active_scs_valid)
-              and (\<lambda>s. release_queue s \<noteq> []))
-             (valid_objs' and valid_queues and valid_queues' and valid_release_queue_iff)
-             awaken_body
-             awakenBody"
-  (is "corres _ (?pred and _) ?conc _ _")
-  apply (rule corres_cross[where Q'="\<lambda>s'. distinct (ksReleaseQueue s')"
-                           , OF ksReleaseQueue_distinct_cross_rel], blast)
-  apply (rule corres_cross[where Q'="\<lambda>s'. ksReleaseQueue s' \<noteq> []"
-                           , OF ksReleaseQueue_nonempty_cross_rel], blast)
-  apply (rule corres_cross[where Q'="\<lambda>s'. \<forall>t \<in> set (ksReleaseQueue s'). st_tcb_at' runnable' t s'"
-                           , OF ksReleaseQueue_runnable'_cross_rel], blast)
-
-  apply (clarsimp simp: awaken_body_def awakenBody_def)
-  apply (rule corres_symb_exec_r[rotated, OF getReleaseQueue_sp])
-    apply (wpsimp wp: gets_sp simp: getReleaseQueue_def)
-   apply (wpsimp wp: gets_exs_valid
-               simp: getReleaseQueue_def)
-  apply (rule corres_symb_exec_r[rotated, OF assert_inv]; (solves wpsimp)?)
-  apply (rule_tac Q="\<lambda>rv. ?pred and tcb_at rv"
-              and Q'="\<lambda>rv. ?conc and st_tcb_at' runnable' rv"
-               in corres_underlying_split[rotated 2])
-     apply (wpsimp simp: tcb_release_dequeue_def)
-     apply (force simp: valid_release_q_def vs_all_heap_simps obj_at_def is_tcb_def)
-    apply wpsimp
-   apply (corresKsimp corres: tcbReleaseDequeue_corres)
-  apply (rule corres_symb_exec_r[OF _ isRunnable_sp, rotated]; (solves wpsimp)?)
-  apply (rule corres_symb_exec_r[OF _ assert_sp, rotated]; (solves wpsimp)?)
-   apply wpsimp
-   apply (clarsimp simp: st_tcb_at'_def obj_at'_def projectKOs objBitsKO_def)
-   apply (case_tac "tcbState tcb'"; clarsimp)
-  apply (corresKsimp corres: possibleSwitchTo_corres)
-  done
-
-lemma tcbReleaseDequeue_no_fail:
-  "no_fail (\<lambda>s'. (\<forall>tcbPtr \<in> set (ksReleaseQueue s'). tcb_at' tcbPtr s') \<and> ksReleaseQueue s' \<noteq> [])
-           tcbReleaseDequeue"
-  apply (wpsimp simp: tcbReleaseDequeue_def getReleaseQueue_def setReleaseQueue_def
-                      setReprogramTimer_def)
-  done
-
-lemma addToBitmap_no_fail[wp]:
-  "no_fail \<top> (addToBitmap tdom tprio)"
-  apply (wpsimp simp: bitmap_fun_defs)
-  done
-
-lemma tcbSchedEnqueue_no_fail[wp]:
-  "no_fail (tcb_at' tcbPtr) (tcbSchedEnqueue tcbPtr)"
-  apply (clarsimp simp: tcbSchedEnqueue_def)
-  apply (wpsimp wp: hoare_vcg_if_lift2 hoare_drop_imps)
-  done
-
-lemma inReleaseQueue_no_fail[wp]:
-  "no_fail (tcb_at' tcbPtr) (inReleaseQueue tcbPtr)"
-  apply (wpsimp simp: inReleaseQueue_def)
-  done
-
-lemma isSchedulable_no_fail:
-  "no_fail (tcb_at' tcbPtr and valid_objs') (isSchedulable tcbPtr)"
-  apply (clarsimp simp: isSchedulable_def isRunnable_def inReleaseQueue_def)
-  apply (wpsimp wp: no_fail_bind hoare_vcg_imp_lift' hoare_vcg_conj_lift getTCB_wp)
-  apply (fastforce dest: tcb_ko_at_valid_objs_valid_tcb'
-                   simp: valid_tcb'_def)
-  done
-
-lemma rescheduleRequired_no_fail:
-  "no_fail (\<lambda>s'. weak_sch_act_wf (ksSchedulerAction s') s' \<and> valid_objs' s') rescheduleRequired"
-  apply (clarsimp simp: rescheduleRequired_def getSchedulerAction_def isSchedulable_def
-                        setSchedulerAction_def)
-  apply (wpsimp wp: isSchedulable_no_fail hoare_vcg_if_lift2 hoare_drop_imps)
-  apply (clarsimp simp: weak_sch_act_wf_def)
-  done
-
-lemma possibleSwitchTo_no_fail:
-  "no_fail (\<lambda>s'. weak_sch_act_wf (ksSchedulerAction s') s' \<and> valid_objs' s' \<and> tcb_at' tcbPtr s')
-           (possibleSwitchTo tcbPtr)"
-  apply (clarsimp simp: possibleSwitchTo_def inReleaseQueue_def curDomain_def getSchedulerAction_def
-                        setSchedulerAction_def)
-  apply (wpsimp wp: rescheduleRequired_no_fail threadGet_wp simp: setSchedulerAction_def)
-  apply (fastforce simp: obj_at'_def projectKOs objBitsKO_def)
-  done
-
-lemma tcbReleaseDequeue_weak_sch_act_wf[wp]:
-  "tcbReleaseDequeue \<lbrace>\<lambda>s'. weak_sch_act_wf (ksSchedulerAction s') s'\<rbrace>"
-  apply (clarsimp simp: tcbReleaseDequeue_def setReleaseQueue_def setReprogramTimer_def)
-  apply (wpsimp wp: threadSet_wp)
-  apply (fastforce simp: weak_sch_act_wf_def st_tcb_at'_def obj_at'_def projectKOs objBitsKO_def
-                         tcb_in_cur_domain'_def ps_clear_def)
-  done
-
-lemma tcbReleaseQueue_tcb_at'_rv:
-  "\<lbrace>\<lambda>s'. ksReleaseQueue s' \<noteq> [] \<and> tcb_at' (hd (ksReleaseQueue s')) s'\<rbrace>
-   tcbReleaseDequeue
-   \<lbrace>\<lambda>rv. tcb_at' rv\<rbrace>"
-  apply (wpsimp simp: tcbReleaseDequeue_def setReleaseQueue_def)
-  done
-
-lemma awakenBody_no_fail:
-  "no_fail (\<lambda>s'. weak_sch_act_wf (ksSchedulerAction s') s' \<and> valid_objs' s'
-                 \<and> (\<forall>tcbPtr \<in> set (ksReleaseQueue s'). st_tcb_at' runnable' tcbPtr s')
-                 \<and> ksReleaseQueue s' \<noteq> [] \<and> distinct (ksReleaseQueue s'))
-           awakenBody"
-  apply (clarsimp simp: awakenBody_def setReprogramTimer_def)
-  apply (wpsimp wp: possibleSwitchTo_no_fail tcbReleaseDequeue_no_fail tcbReleaseQueue_tcb_at'_rv
-                    hoare_drop_imps
-              simp: getReleaseQueue_def)
-  apply fastforce
-  done
-
-lemma tcbReleaseDequeue_dequeue_inv:
-  "tcbReleaseDequeue \<lbrace>\<lambda>s. tcbPtr \<notin> set (ksReleaseQueue s)\<rbrace>"
-  apply (clarsimp simp: tcbReleaseDequeue_def)
-  apply wpsimp
-  apply (case_tac "ksReleaseQueue s = []"; simp add: list.set_sel(2))
-  done
-
-lemma awaken_corres:
-  "corres dc (pspace_aligned and pspace_distinct and valid_objs and valid_release_q
-              and valid_sched_action and valid_tcbs and active_scs_valid)
-             (\<lambda>s'. weak_sch_act_wf (ksSchedulerAction s') s' \<and> valid_objs' s' \<and> valid_queues s'
-                   \<and> valid_queues' s' \<and> valid_release_queue_iff s')
-             Schedule_A.awaken
-             awaken"
-  apply (rule corres_cross[where Q'="\<lambda>s'. \<forall>t \<in> set (ksReleaseQueue s'). st_tcb_at' runnable' t s'"
-                           , OF ksReleaseQueue_runnable'_cross_rel], blast)
-  apply (rule corres_cross[where Q'="\<lambda>s'. distinct (ksReleaseQueue s')"
-                           , OF ksReleaseQueue_distinct_cross_rel], blast)
-  apply (clarsimp simp: awaken_def Schedule_A.awaken_def runReaderT_def)
-  apply (rule corres_whileLoop; simp)
-       apply (simp add: releaseQNonEmptyAndReady_eq)
-      apply (rule corres_guard_imp)
-        apply (rule awakenBody_corres)
-       apply (fastforce simp: read_release_q_non_empty_and_ready_simp)
-      apply simp
-     apply (clarsimp simp: pred_conj_def)
-     apply (intro hoare_vcg_conj_lift_pre_fix
-            ; (solves \<open>wpsimp simp: Schedule_A.awaken_body_def tcb_release_dequeue_def\<close>)?)
-     apply (wpsimp wp: awaken_body_valid_sched_action)
-     apply (frule valid_release_q_read_release_q_non_empty_and_ready_bound)
-     apply (fastforce dest: read_release_q_non_empty_and_ready_True_simp)
-    apply (wpsimp simp: awakenBody_def runReaderT_def
-                    wp: hoare_vcg_ball_lift2 tcbReleaseDequeue_dequeue_inv hoare_drop_imps)
-    apply (fastforce dest: releaseQNonEmptyAndReady_implies_releaseQNonEmpty)
-   apply (fastforce intro: no_fail_pre awakenBody_no_fail
-                     dest: releaseQNonEmptyAndReady_implies_releaseQNonEmpty)
-  apply (fastforce intro!: awaken_terminates)
-  done
-
-lemma setDeadline_corres:
-  "dl = dl' \<Longrightarrow> corres_underlying Id False True dc \<top> \<top> (setDeadline dl) (setDeadline dl')"
-  by (simp, rule corres_underlying_trivial_gen; wpsimp simp: setDeadline_def)
-
-(* This is not particularly insightful, it just shortens setNextInterrupt_corres *)
-lemma setNextInterrupt_corres_helper:
-  "\<lbrakk>valid_objs' s'; (s, s') \<in> state_relation; active_sc_tcb_at t s;
-    valid_objs s; pspace_aligned s; pspace_distinct s\<rbrakk>
-    \<Longrightarrow> \<exists>tcb. ko_at' tcb t s' \<and> sc_at' (the (tcbSchedContext tcb)) s' \<and>
-        (\<forall>ko. ko_at' ko (the (tcbSchedContext tcb)) s' \<longrightarrow> sc_valid_refills' ko)"
-  apply (subgoal_tac "\<exists>tcb'. ko_at' (tcb'  :: tcb) t s'", clarsimp)
-   apply (clarsimp simp: pred_map_def vs_all_heap_simps)
-   apply (rename_tac tcb' scp tcb sc n)
-   apply (frule_tac pspace_relation_absD, erule state_relation_pspace_relation)
-   apply (clarsimp simp: other_obj_relation_def)
-   apply (subgoal_tac "z = KOTCB tcb'", clarsimp)
-    apply (rule_tac x=tcb' in exI, simp)
-    apply (prop_tac "tcbSchedContext tcb' = Some scp", clarsimp simp: tcb_relation_def, simp)
-    apply (subgoal_tac "sc_at' scp s'", clarsimp)
-     apply (frule_tac x=scp in pspace_relation_absD, erule state_relation_pspace_relation)
-     apply (frule (1) valid_sched_context_size_objsI, clarsimp)
-     apply (subgoal_tac "z = KOSchedContext ko", clarsimp)
-      apply (frule (1) sc_ko_at_valid_objs_valid_sc', clarsimp)
-      apply (clarsimp simp: valid_sched_context'_def sc_relation_def active_sc_def)
-     apply (case_tac z; clarsimp simp: obj_at'_def projectKOs)
-    apply (erule cross_relF [OF _ sc_at'_cross_rel], clarsimp simp: obj_at_def is_sc_obj)
-    apply (erule (1) valid_sched_context_size_objsI)
-   apply (case_tac z; clarsimp simp: obj_at'_def projectKOs)
-  apply (subgoal_tac "tcb_at t s")
-   apply (frule cross_relF [OF _ tcb_at'_cross_rel], clarsimp, assumption)
-   apply (clarsimp simp: obj_at'_def projectKOs)
-  apply (clarsimp simp: obj_at_def vs_all_heap_simps pred_map_def is_tcb)
-  done
-
-lemma setNextInterrupt_corres:
-  "corres dc ((\<lambda>s. active_sc_tcb_at (cur_thread s) s)
-              and (\<lambda>s. \<forall>t \<in> set (release_queue s). active_sc_tcb_at t s)
-              and valid_objs and pspace_aligned and pspace_distinct)
-             valid_objs'
-             set_next_interrupt
-             setNextInterrupt"
-  unfolding setNextInterrupt_def set_next_interrupt_def
-  apply (rule stronger_corres_guard_imp)
-    apply (rule corres_split [OF getCurTime_corres])
-      apply (rule corres_split [OF getCurThread_corres], simp)
-        apply (rule corres_split_eqr[OF get_tcb_obj_ref_corres])
-           apply (clarsimp simp: tcb_relation_def)
-          apply (rule corres_assert_opt_assume_l)
-          apply (rule corres_split [OF get_sc_corres])
-            apply (rule_tac F="sc_valid_refills' rv'" in corres_gen_asm2)
-            apply (rule corres_split [OF corres_if])
-                 apply clarsimp
-                apply (rule corres_split [OF getDomainTime_corres])
-                  apply (simp only: fun_app_def)
-                  apply (rule corres_return_eq_same)
-                  apply (clarsimp simp: refill_hd_relation refill_map_def)
-                 apply wpsimp
-                apply wpsimp
-               apply (rule corres_return_eq_same)
-               apply (clarsimp simp: refill_hd_relation refill_map_def)
-              apply (rule corres_split [OF getReleaseQueue_corres])
-                apply (rule corres_split [OF corres_if], simp)
-                    apply (rule corres_return_eq_same, simp)
-                   apply (rule corres_split_eqr)
-                      apply (simp, rule get_tcb_obj_ref_corres)
-                      apply (clarsimp simp: tcb_relation_def)
-                     apply (rule corres_assert_opt_assume_l)
-                     apply simp
-                     apply (rule corres_split [OF get_sc_corres])
-                       apply (rule_tac F="sc_valid_refills' rv'c" in corres_gen_asm2)
-                       apply (rule corres_return_eq_same)
-                       apply (clarsimp simp: refill_hd_relation refill_map_def)
-                      apply wpsimp
-                     apply wpsimp
-                    apply (wpsimp wp: get_tcb_obj_ref_wp)
-                   apply (wpsimp wp: threadGet_wp)
-                  apply (rule corres_machine_op)
-                  apply (simp del: dc_simp, rule setDeadline_corres, simp)
-                 apply wpsimp+
-         apply (wpsimp wp: get_tcb_obj_ref_wp)
-        apply (wpsimp wp: threadGet_wp)
-       apply wpsimp+
-   apply (fastforce intro!: valid_sched_context_size_objsI
-                      dest: list.set_sel(1)
-                      simp: vs_all_heap_simps obj_at_def is_tcb_def is_sc_obj_def)
-  apply (clarsimp simp: valid_release_q_def)
-  apply (subgoal_tac "(\<exists>tcb. ko_at' tcb (ksCurThread s') s' \<and>
-                    sc_at' (the (tcbSchedContext tcb)) s' \<and>
-                    (\<forall>ko. ko_at' ko (the (tcbSchedContext tcb)) s' \<longrightarrow> sc_valid_refills' ko)) \<and> (ksReleaseQueue s' \<noteq> [] \<longrightarrow> (\<exists>tcb. ko_at' tcb (hd (ksReleaseQueue s')) s' \<and>
-                    sc_at' (the (tcbSchedContext tcb)) s' \<and>
-                    (\<forall>ko. ko_at' ko (the (tcbSchedContext tcb)) s' \<longrightarrow> sc_valid_refills' ko)))")
-   apply (safe, blast, blast)[1]
-   apply (rule_tac x=tcb in exI, simp, safe, blast)[1]
-   apply (prop_tac "ksCurThread s' = cur_thread s", clarsimp simp: state_relation_def, simp)
-  apply (subgoal_tac "(ksReleaseQueue s') = release_queue s", simp)
-   apply (intro conjI impI)
-    apply (rule setNextInterrupt_corres_helper; simp)
-   apply (clarsimp simp: state_relation_def release_queue_relation_def)
-   apply (rule setNextInterrupt_corres_helper; simp?)
-   apply (clarsimp simp: state_relation_def release_queue_relation_def)+
-  done
-
-(* refillUnblockCheck_corres *)
-
-lemma isRoundRobin_corres:
-  "corres (=) (sc_at sc_ptr) (sc_at' sc_ptr)
-              (is_round_robin sc_ptr) (isRoundRobin sc_ptr)"
-  apply (clarsimp simp: is_round_robin_def isRoundRobin_def)
-  apply (corresKsimp corres: get_sc_corres
-                      simp: sc_relation_def)
-  done
-
-lemma refillPopHead_corres:
-  "corres (\<lambda>refill refill'. refill = refill_map refill')
-     (pspace_aligned and pspace_distinct and sc_at sc_ptr
-      and sc_refills_sc_at (\<lambda>refills. 1 < length refills) sc_ptr)
-     (valid_refills' sc_ptr)
-     (refill_pop_head sc_ptr) (refillPopHead sc_ptr)"
-  (is "corres _ ?abs ?conc _ _")
-  supply if_split[split del] opt_pred_def[simp add]
-  apply (rule corres_cross[where Q' = "sc_at' sc_ptr", OF sc_at'_cross_rel], fastforce)
-  apply (clarsimp simp: refill_pop_head_def refillPopHead_def)
-  apply (clarsimp simp: getRefillNext_getSchedContext get_refills_def liftM_def)
-  apply (rule corres_underlying_split[rotated 2, OF get_sched_context_sp get_sc_sp'])
-   apply (rule corres_guard_imp)
-     apply (rule get_sc_corres)
-    apply simp
-   apply simp
-  apply (rename_tac sc')
-  apply (rule_tac F="refill_hd sc = refill_map (refillHd sc')" in corres_req)
-   apply (clarsimp simp: obj_at_def is_sc_obj obj_at'_def projectKOs)
-   apply (frule (1) pspace_relation_absD[OF _ state_relation_pspace_relation])
-   apply (clarsimp elim!: refill_hd_relation simp: valid_refills'_def opt_map_red)
-  apply (rule corres_guard_imp)
-    apply (rule corres_underlying_split[OF updateSchedContext_corres_gen[where
-                                    P="(\<lambda>s. ((\<lambda>sc. 1 < length (sc_refills sc)) |< scs_of2 s) sc_ptr)"
-                                and P'="valid_refills' sc_ptr"]])
-         apply (clarsimp, drule (2) state_relation_sc_relation)
-         apply (clarsimp simp: sc_relation_def refills_map_def tl_map obj_at_simps is_sc_obj opt_map_red)
-         apply (clarsimp simp: valid_refills'_def opt_map_red)
-         apply (subst tl_wrap_slice; clarsimp simp: min_def split: if_split)
-         apply (rule conjI impI; clarsimp simp: refillNextIndex_def wrap_slice_start_0 split: if_splits)
-        apply (fastforce simp: obj_at_simps is_sc_obj opt_map_red dest!: state_relation_sc_replies_relation_sc)
-        apply clarsimp
-       apply (clarsimp simp: objBits_simps)
-      apply simp
-     apply (wpsimp wp: update_sched_context_wp)
-    apply (wpsimp wp: updateSchedContext_wp)
-   apply (clarsimp simp: sc_refills_sc_at_def obj_at_def opt_map_red)
-  apply simp
-  done
-
-lemma refillPopHead_valid_refills'[wp]:
-  "\<lbrace>\<lambda>s. valid_refills' scPtr' s
-        \<and> (scPtr = scPtr' \<longrightarrow> obj_at' (\<lambda>sc'. Suc 0 < scRefillCount sc') scPtr s)\<rbrace>
-   refillPopHead scPtr
-   \<lbrace>\<lambda>_. valid_refills' scPtr'\<rbrace>"
-  apply (clarsimp simp: refillPopHead_def updateSchedContext_def setSchedContext_def)
-  apply (wpsimp wp: setObject_sc_wp)
-  apply (fastforce simp: valid_refills'_def obj_at'_def projectKOs opt_map_def opt_pred_def
-                         refillNextIndex_def)
-  done
-
-lemma refillHeadOverlapping_simp:
-  "sc_at' sc_ptr s' \<Longrightarrow>
-   refillHeadOverlapping sc_ptr s' =
-    (scs_of' s' ||> (\<lambda>sc'. Suc 0 < scRefillCount sc'
-                           \<and> rTime (scRefills sc' ! (if scRefillHead sc' = scRefillMax sc' - Suc 0
-                                                     then 0 else Suc (scRefillHead sc')))
-                                \<le> rTime (refillHd sc') + rAmount (refillHd sc'))) sc_ptr"
-  unfolding refillHeadOverlapping_def
-  apply (frule no_ofailD[OF no_ofail_readSchedContext])
-  apply (fastforce simp: obind_def omonad_defs oliftM_def obj_at'_def projectKOs readRefillNext_def
-                         readRefillSize_def refillIndex_def opt_map_red readSchedContext_def
-                  dest!: readObject_ko_at'_sc split: option.splits)
-  done
-
-lemma refill_head_overlapping_simp:
-  "sc_at sc_ptr s \<Longrightarrow>
-   refill_head_overlapping sc_ptr s =
-     (scs_of2 s ||> (\<lambda>sc. Suc 0 < length (sc_refills sc)
-                         \<and> r_time (hd (tl (sc_refills sc)))
-                                   \<le> r_time (refill_hd sc) + r_amount (refill_hd sc))) sc_ptr"
-  unfolding refill_head_overlapping_def
-  apply (insert no_ofailD[OF no_ofail_read_sched_context])
-  apply (clarsimp simp: obind_def obj_at_def is_sc_obj opt_map_red
-                 split: option.split)
-  apply (drule_tac x=s and y=sc_ptr in meta_spec2)
-  apply (clarsimp dest!: read_sched_context_SomeD)
-  done
-
-lemma refillHeadOverlapping_corres_eq:
-  "\<lbrakk>(s, s') \<in> state_relation; sc_at sc_ptr s; sc_at' sc_ptr s'; valid_refills' sc_ptr s'\<rbrakk>
-   \<Longrightarrow> refill_head_overlapping sc_ptr s = refillHeadOverlapping sc_ptr s'"
-  apply (frule no_ofailD[OF no_ofail_refillHeadOverlapping])
-  apply (insert refillHeadOverlapping_implies_count_greater_than_one[of sc_ptr s'])
-  apply clarsimp
-  apply (drule (2) state_relation_sc_relation)
-  apply (clarsimp simp: obj_at_simps is_sc_obj)
-  apply (rename_tac b n sc sc')
-  apply (case_tac b;
-         clarsimp simp: refillHeadOverlapping_simp refill_head_overlapping_simp obj_at_simps
-                        is_sc_obj sc_relation_def valid_refills'_def refillHd_def
-                        neq_Nil_lengthI tl_drop_1 hd_drop_conv_nth refills_map_def hd_map
-                        hd_wrap_slice wrap_slice_index refill_map_def opt_map_red opt_pred_def
-                 split: if_split_asm)
-  by linarith+
-
-lemma refillPopHead_scs_of'[wp]:
-  "\<lbrace>\<lambda>s'. P ((scs_of' s')(scp \<mapsto> (\<lambda>sc'. scRefillCount_update (\<lambda>_. scRefillCount sc' - Suc 0)
-                                      (scRefillHead_update
-                                          (\<lambda>_. refillNextIndex (scRefillHead sc') sc') sc'))
-                                        (the (scs_of' s' scp))))\<rbrace>
-  refillPopHead scp
-  \<lbrace>\<lambda>_ s'. P (scs_of' s')\<rbrace>"
-  unfolding refillPopHead_def
-  by (wpsimp wp: updateSchedContext_wp)
-
-crunch update_refill_hd, refill_pop_head, merge_refills, schedule_used, handle_overrun_loop_body
-  for is_active_sc2[wp]: "is_active_sc2 scp"
-  (wp: crunch_wps ignore: update_sched_context
-   simp: crunch_simps update_refill_hd_rewrite update_sched_context_set_refills_rewrite)
-
-lemma merge_refills_scs_of2[wp]:
-  "\<lbrace>\<lambda>s. P ((scs_of2 s)(scp \<mapsto> (\<lambda>sc. sc_refills_update
-            (\<lambda>_. merge_refill (refill_hd sc) (hd (tl (sc_refills sc))) # tl (tl (sc_refills sc))) sc)
-                          (the (scs_of2 s scp)))) \<rbrace>
-   merge_refills scp
-   \<lbrace>\<lambda>_ s. P (scs_of2 s)\<rbrace>"
-  unfolding merge_refills_def
-  apply (wpsimp simp: update_refill_hd_rewrite refill_pop_head_def
-                  wp: get_refills_wp set_refills_wp update_sched_context_wp)
-  by (clarsimp simp: is_active_sc2_def obj_at_def opt_map_red)
-
-(* if the loop guard is true, the refill length is greater than one *)
-lemma mergeRefills_corres:
-  "corres dc (sc_at sc_ptr and pspace_aligned and pspace_distinct
-              and (\<lambda>s. ((\<lambda>sc. 1 < length (sc_refills sc)) |< scs_of2 s) sc_ptr))
-             (valid_refills' sc_ptr)
-             (merge_refills sc_ptr) (mergeRefills sc_ptr)"
-  unfolding mergeRefills_def merge_refills_def merge_refill_def
-  apply (rule corres_cross[where Q' = "sc_at' sc_ptr", OF sc_at'_cross_rel], fastforce)
-  apply (rule_tac Q="\<lambda>s'. ((\<lambda>sc'. 1 < scRefillCount sc') |< scs_of' s') sc_ptr" in corres_cross_add_guard)
-   apply clarsimp
-   apply (drule (2) state_relation_sc_relation)
-   apply (clarsimp simp: sc_relation_def)
-   apply (clarsimp simp: valid_refills'_def obj_at_simps is_sc_obj opt_map_red opt_pred_def)
-  apply (rule corres_guard_imp)
-    apply (rule corres_split[OF refillPopHead_corres])
-      apply (rule updateRefillHd_corres, simp)
-       apply (clarsimp simp: refill_map_def merge_refill_def)+
-     apply (rule hoare_strengthen_post[where Q'="\<lambda>_. sc_at sc_ptr", rotated])
-      apply (simp add: active_sc_at_equiv is_active_sc_rewrite[symmetric])
-     apply (wpsimp wp: refill_pop_head_sc_active)
-    apply wpsimp
-   apply (clarsimp simp: obj_at_def is_sc_obj opt_map_red is_active_sc_rewrite active_sc_at_equiv
-                         sc_refills_sc_at_rewrite)
-  apply (fastforce simp: valid_refills'_def obj_at_simps opt_map_red opt_pred_def refillNextIndex_def)
-  done
-
-lemma mergeRefills_valid_refills'[wp]:
-  "\<lbrace>(\<lambda>s. ((\<lambda>sc. 1 < scRefillCount sc) |< scs_of' s) scp) and valid_refills' scp\<rbrace>
-   mergeRefills p
-   \<lbrace>\<lambda>_. valid_refills' scp\<rbrace>"
-  unfolding mergeRefills_def
-  apply (wpsimp simp: updateRefillHd_def refillPopHead_def wp: updateSchedContext_wp)
-  by (fastforce simp: valid_refills'_def obj_at_simps refillNextIndex_def opt_map_red opt_pred_def)
-
-lemma no_fail_refillPopHead[wp]:
-  "no_fail (sc_at' scPtr) (refillPopHead scPtr)"
-  by (wpsimp simp: refillPopHead_def obj_at'_def opt_map_def opt_pred_def objBits_simps projectKOs)
-
-crunch mergeRefills
-  for (no_fail) no_fail[wp]
-  (simp: opt_map_red opt_pred_def obj_at_simps)
-
-lemma refillPopHead_length_decreasing:
-  "\<lbrace>\<lambda>s'. ((\<lambda>sc. 0 < scRefillCount sc) |< scs_of' s') scp \<and> s' = s\<rbrace>
-   refillPopHead scp
-   \<lbrace>\<lambda>r' s'. scRefillCount (the (scs_of' s' scp)) < scRefillCount (the (scs_of' s scp))\<rbrace>"
-  unfolding refillPopHead_def
-  apply (simp add: liftM_def bind_assoc refillHd_def)
-  apply (wpsimp wp: updateSchedContext_wp)
-  by (clarsimp simp: obj_at'_def projectKOs opt_map_red opt_pred_def)
-
-lemma mergeRefills_length_decreasing:
-  "\<lbrace>\<lambda>s'. ((\<lambda>sc. 0 < scRefillCount sc) |< scs_of' s') scp \<and> s' = s\<rbrace>
-   mergeRefills scp
-   \<lbrace>\<lambda>r' s'. scRefillCount (the (scs_of' s' scp)) < scRefillCount (the (scs_of' s scp))\<rbrace>"
-  unfolding mergeRefills_def updateRefillHd_def
-  apply (rule bind_wp[OF _ refillPopHead_length_decreasing])
-  by (wpsimp wp: refillPopHead_length_decreasing updateSchedContext_wp)
-
-lemma scRefillCount_wf:
-  "wf {((r', s'), r, s).
-        scRefillCount (the (scs_of' s' sc_ptr))
-         < scRefillCount (the (scs_of' s sc_ptr))}"
-  apply (prop_tac "{((r', s'), r, s). scRefillCount (the (scs_of' s' sc_ptr))
-                                             < scRefillCount (the (scs_of' s sc_ptr))}
-                     = measure (\<lambda>(r, s). scRefillCount (the (scs_of' s sc_ptr)))")
-   apply (clarsimp simp: measure_def inv_image_def split_def)
-  apply (drule sym)
-  apply (erule subst)
-  apply (rule wf_measure)
-  done
-
-lemma mergeRefills_terminates:
-  "sc_at' sc_ptr s' \<Longrightarrow>
-   whileLoop_terminates
-               (\<lambda>_ s'. the (refillHeadOverlapping sc_ptr s'))
-               (\<lambda>_. mergeRefills sc_ptr) r' s'"
-  apply (rule_tac
-           I="\<lambda>_. sc_at' sc_ptr" and
-           R="{((r', s'), (r, s)). scRefillCount (the (scs_of' s' sc_ptr))
-                                    < scRefillCount (the (scs_of' s sc_ptr))}"
-         in whileLoop_terminates_inv)
-    apply simp
-   apply (wpsimp wp: mergeRefills_length_decreasing)
-   apply (fastforce simp: obj_at_simps opt_map_red opt_pred_def
-                   dest!: refillHeadOverlapping_implies_count_greater_than_one)
-  apply (rule scRefillCount_wf)
-  done
-
-lemma refillHeadOverlappingLoop_corres:
-  "corres dc (sc_at sc_ptr and  pspace_aligned and pspace_distinct)
-             (valid_refills' sc_ptr)
-             (refill_head_overlapping_loop sc_ptr) (refillHeadOverlappingLoop sc_ptr)"
-  unfolding refill_head_overlapping_loop_def refillHeadOverlappingLoop_def runReaderT_def
-  supply refillHeadOverlapping_implies_count_greater_than_one[dest!]
-  apply (rule corres_cross[where Q' = "sc_at' sc_ptr", OF sc_at'_cross_rel], fastforce)
-  apply (rule corres_whileLoop)
-        apply (drule refillHeadOverlapping_corres_eq[where sc_ptr=sc_ptr]; simp add: runReaderT_def)
-       apply simp
-       apply (rule corres_guard_imp
-                      [where P=P and Q=P for P,
-                       where
-                          P'= Q and
-                          Q'="Q and (\<lambda>s. ((\<lambda>sc. 1 < scRefillCount sc) |< scs_of' s) sc_ptr)" for Q])
-         apply (rule corres_cross_add_abs_guard
-                       [where Q="(\<lambda>s. ((\<lambda>sc. 1 < length (sc_refills sc)) |< scs_of2 s) sc_ptr)"])
-          apply clarsimp
-          apply (drule (2) state_relation_sc_relation)
-          apply (clarsimp simp: obj_at_simps is_sc_obj valid_refills'_def sc_relation_def
-                                opt_map_red opt_pred_def)
-         apply (rule corres_guard_imp)
-           apply (rule mergeRefills_corres)
-          apply clarsimp+
-      apply (wpsimp+)[4]
-  apply (fastforce intro!: mergeRefills_terminates)
-  done
-
-lemma refillUnblockCheck_corres:
-  "corres dc
-     (sc_at scp and pspace_aligned and pspace_distinct
-      and (\<lambda>s. ((\<lambda>sc. 0 < length (sc_refills sc)) |< scs_of2 s) scp))
-     (valid_refills' scp)
-     (refill_unblock_check scp) (refillUnblockCheck scp)"
-  unfolding refill_unblock_check_def refillUnblockCheck_def
-  apply (rule corres_cross[where Q' = "sc_at' scp", OF sc_at'_cross_rel], fastforce)
-  apply (rule corres_guard_imp)
-    apply (rule corres_split_eqr[OF isRoundRobin_corres])
-      apply (rule corres_split_eqr[OF refillReady_corres])
-        apply simp
-        apply (rule corres_when, fastforce)
-        apply (rule corres_split[OF setReprogramTimer_corres])
-          apply (rule corres_split[OF getCurTime_corres])
-            apply (rule corres_split[OF updateRefillHd_corres], simp)
-               apply (clarsimp simp: refill_map_def kernelWCETTicks_def)
-              apply (rule refillHeadOverlappingLoop_corres)
-             apply wpsimp
-            apply (wpsimp wp: getCurTime_wp updateSchedContext_wp
-                        simp: updateRefillHd_def)+
-        apply (wpsimp wp: refillReady_wp is_round_robin_wp isRoundRobin_wp
-                    simp: setReprogramTimer_def)+
-      apply (clarsimp simp: obj_at_simps valid_refills'_def opt_map_red opt_pred_def)
-  done
-
-lemma sporadic_implies_active_cross:
-  "\<lbrakk>(s, s') \<in> state_relation; active_scs_valid s; sc_at scPtr s; ko_at' sc scPtr s';
-    scSporadic sc\<rbrakk>
-   \<Longrightarrow> is_active_sc' scPtr s'"
-  apply (frule (1) state_relation_sc_relation[where ptr=scPtr])
-   apply fastforce
-  apply (clarsimp simp: active_scs_valid_def)
-  apply (drule_tac x=scPtr in spec)+
-  by (fastforce dest: is_sc_objD
-                simp: sc_relation_def vs_all_heap_simps active_sc_def is_active_sc'_def
-                      obj_at_simps opt_map_def opt_pred_def)
-
-lemma ifCondRefillUnblockCheck_corres:
-  "corres dc
-     (\<lambda>s. case_option True
-                      (\<lambda>scp. sc_at scp s \<and> active_scs_valid s
-                           \<and> pspace_aligned s \<and> pspace_distinct s
-                           \<and> (((\<lambda>sc. case_option (sc_active sc) \<top> act) |< scs_of2 s) scp)) scp_opt)
-     (\<lambda>s. case_option True (\<lambda>scp. case_option (valid_refills' scp s) (\<lambda>_. valid_objs' s) act) scp_opt)
-        (if_cond_refill_unblock_check scp_opt act ast) (ifCondRefillUnblockCheck scp_opt act ast)"
-  unfolding if_cond_refill_unblock_check_def ifCondRefillUnblockCheck_def
-  apply (cases scp_opt; simp add: maybeM_def)
-  apply (rename_tac scp)
-  apply (rule corres_cross[OF sc_at'_cross_rel], fastforce)
-  apply (rule stronger_corres_guard_imp)
-    apply (rule corres_split[OF get_sc_corres _ get_sched_context_wp getSchedContext_wp])
-    apply (rule corres_split[OF getCurSc_corres])
-      apply (rule corres_when)
-       apply (clarsimp simp: active_sc_def sc_relation_def case_bool_if option.case_eq_if)
-      apply (rule corres_when)
-       apply fastforce
-      apply (rule refillUnblockCheck_corres)
-     apply wpsimp+
-   apply (prop_tac "is_active_sc scp s")
-    apply (cases act; clarsimp)
-     apply (clarsimp simp: vs_all_heap_simps obj_at_kh_kheap_simps opt_map_def opt_pred_def)
-    apply (clarsimp simp: vs_all_heap_simps active_scs_valid_def obj_at_kh_kheap_simps
-                   split: bool.splits)
-    apply (drule_tac x=scp in spec)+
-    apply force
-   apply (drule_tac scp=scp in active_scs_validE[rotated, simplified is_active_sc_rewrite];
-          clarsimp simp: opt_map_red obj_at_def is_active_sc2_def vs_all_heap_simps
-                         valid_refills_def rr_valid_refills_def active_sc_def opt_pred_def
-                  split: if_split_asm)
-  apply (clarsimp simp: case_bool_if option.case_eq_if split: if_split_asm)
-  apply (fastforce elim!: valid_objs'_valid_refills'
-                   dest!: sporadic_implies_active_cross)
-  done
-
-lemma getCurTime_sp:
-  "\<lbrace>P\<rbrace> getCurTime \<lbrace>\<lambda>rv. P and (\<lambda>s. rv = ksCurTime s)\<rbrace>"
-  by (wpsimp simp: getCurTime_def)
-
-lemma ovalid_readRefillReady'[rule_format, simp]:
-  "ovalid (\<lambda>s. sc_at' scp s \<longrightarrow> P (((\<lambda>sc'. rTime (refillHd sc') \<le> ksCurTime s + kernelWCETTicks) |< scs_of' s) scp) s)
-              (readRefillReady scp) P"
-  unfolding readRefillReady_def readSchedContext_def ovalid_def
-  by (fastforce simp: obind_def opt_map_red obj_at'_def projectKOs opt_pred_def
-                dest: use_ovalid[OF ovalid_readCurTime]
-               dest!: readObject_misc_ko_at'
-               split: option.split_asm)+
-
-lemma refillReady_wp':
-  "\<lbrace>\<lambda>s. sc_at' scp s \<longrightarrow>
-        P (((\<lambda>sc'. rTime (refillHd sc') \<le> ksCurTime s + kernelWCETTicks) |< scs_of' s) scp) s\<rbrace>
-   refillReady scp
-   \<lbrace>P\<rbrace>"
-  unfolding refillReady_def
-  by wpsimp (drule use_ovalid[OF ovalid_readRefillReady'])
-
-lemma refillAddTail_corres:
-  "new = refill_map new'
-   \<Longrightarrow> corres dc (sc_at sc_ptr)
-                 (sc_at' sc_ptr and
-                  (\<lambda>s'. ((\<lambda>sc'. scRefillCount sc' < scRefillMax sc' \<and> sc_valid_refills' sc') |< scs_of' s') sc_ptr))
-                 (refill_add_tail sc_ptr new)
-                 (refillAddTail sc_ptr new')"
-  supply projection_rewrites[simp] opt_pred_def[simp add]
-  apply (clarsimp simp: refill_add_tail_def refillAddTail_def getRefillNext_getSchedContext
-                        getRefillSize_def2 liftM_def get_refills_def)
-  apply (rule corres_symb_exec_r[OF _ get_sc_sp', rotated]; (solves wpsimp)?)+
-  apply (rename_tac sc')
-  apply (rule corres_guard_imp)
-    apply (rule corres_assert_assume_r)
-    apply (rule updateSchedContext_corres_gen[where P=\<top>
-                and P'="(\<lambda>s'. ((\<lambda>sc'. scRefillCount sc' < scRefillMax sc' \<and> sc_valid_refills' sc') |< scs_of' s') sc_ptr)"])
-      apply (clarsimp, drule (2) state_relation_sc_relation)
-      apply (clarsimp simp: obj_at_simps is_sc_obj)
-      apply (rename_tac sc')
-      apply (clarsimp simp: sc_relation_def neq_Nil_lengthI opt_map_red)
-      apply (prop_tac "scRefills sc' \<noteq> []")
-       apply (clarsimp simp: neq_Nil_lengthI)
-      apply (clarsimp simp: refills_map_def)
-      apply (subst wrap_slice_append; simp)
-      apply (insert less_linear)[1]
-      apply (drule_tac x="scRefillMax sc'" and y="scRefillHead sc' + scRefillCount sc' + Suc 0" in meta_spec2)
-      apply (erule disjE)
-       apply (simp add: refillNextIndex_def refillTailIndex_def Let_def)
-       apply (intro conjI impI;
-              clarsimp simp: Suc_diff_Suc wrap_slice_updateAt_eq[symmetric] neq_Nil_lengthI
-                             nat_le_Suc_less refill_map_def updateAt_index)
-      apply (erule disjE)
-       apply clarsimp
-       apply (rule conjI)
-        apply (simp add: refillNextIndex_def refillTailIndex_def Let_def)
-        apply (clarsimp simp: wrap_slice_updateAt_eq not_le)
-        apply (metis add_leE le_SucI le_refl lessI mult_is_add.mult_commute not_add_less2 not_less_eq wrap_slice_updateAt_eq)
-       apply (clarsimp simp: refillNextIndex_def refillTailIndex_def Let_def not_le)
-       apply (clarsimp simp: updateAt_index refill_map_def)
-      apply clarsimp
-      apply (rule conjI)
-       apply (clarsimp simp: refillNextIndex_def refillTailIndex_def Let_def)
-       apply (intro conjI impI; (clarsimp simp: not_le wrap_slice_updateAt_eq)?)
-       apply (metis add_leE le_refl le_simps(1) less_SucI mult_is_add.mult_commute nat_neq_iff
-                    not_less_eq trans_less_add2 wrap_slice_updateAt_eq)
-      apply (clarsimp simp: refillNextIndex_def refillTailIndex_def Let_def not_le)
-      apply (clarsimp simp: updateAt_index refill_map_def)
-     apply (fastforce simp: obj_at_simps is_sc_obj opt_map_red
-                     dest!: state_relation_sc_replies_relation_sc)
-    apply (clarsimp simp: objBits_simps)
-   apply (clarsimp simp: obj_at_def is_sc_obj)
-  apply (clarsimp simp: obj_at'_def projectKOs opt_map_red)
-  done
-
-lemma isRoundRobin_sp:
-  "\<lbrace>P\<rbrace>
-   isRoundRobin scPtr
-   \<lbrace>\<lambda>rv s. P s \<and> (\<exists>sc. ko_at' sc scPtr s \<and> rv = (scPeriod sc = 0))\<rbrace>"
-  apply (simp add: isRoundRobin_def)
-  apply (rule bind_wp_fwd)
-   apply (rule get_sc_sp')
-  apply (wp hoare_return_sp)
-  apply (clarsimp simp: obj_at'_def projectKOs)
-  done
-
-lemma maybeAddEmptyTail_corres:
-  "corres dc
-          (is_active_sc2 sc_ptr)
-                 (sc_at' sc_ptr and
-                  (\<lambda>s'. ((\<lambda>sc'. scRefillCount sc' < scRefillMax sc' \<and> sc_valid_refills' sc') |< scs_of' s') sc_ptr))
-          (maybe_add_empty_tail sc_ptr)
-          (maybeAddEmptyTail sc_ptr)" (is "corres _ ?abs ?conc _ _")
-  supply projection_rewrites[simp]
-  apply (rule corres_cross_add_abs_guard[where Q="sc_at sc_ptr"])
-   apply (fastforce dest!: sc_at'_cross[OF state_relation_pspace_relation])
-  apply (clarsimp simp: maybe_add_empty_tail_def maybeAddEmptyTail_def get_refills_def)
-  apply (rule corres_underlying_split[rotated 2, OF is_round_robin_sp isRoundRobin_sp])
-   apply (corresKsimp corres: isRoundRobin_corres)
-  apply (clarsimp simp: obj_at_def is_sc_obj)
-  apply (clarsimp simp: when_def)
-  apply (rule corres_underlying_split[rotated 2, OF get_sched_context_sp get_sc_sp'])
-   apply (corresKsimp corres: get_sc_corres)
-   apply (fastforce intro: valid_objs_valid_sched_context_size
-                     simp: obj_at_def is_sc_obj_def)
-  apply (rename_tac sc')
-  apply (corresKsimp corres: refillAddTail_corres)
-  apply (frule refill_hd_relation; clarsimp simp: obj_at'_def projectKOs opt_map_red opt_pred_def)
-  apply (fastforce dest: valid_objs_valid_sched_context_size
-                   simp: obj_at_def is_sc_obj_def refill_map_def)
-  done
-
-lemma getRefills_sp:
-  "\<lbrace>P\<rbrace>
-   getRefills scPtr
-   \<lbrace>\<lambda>rv s. P s \<and> (\<exists>sc. ko_at' sc scPtr s \<and> (rv = scRefills sc))\<rbrace>"
-  apply (simp add: getRefills_def)
-  apply (rule bind_wp_fwd)
-   apply (rule get_sc_sp')
-  apply (wp hoare_return_sp)
-  apply (clarsimp simp: obj_at'_def projectKOs)
-  done
-
-lemma getCurSc_sp:
-  "\<lbrace>P\<rbrace>
-   getCurSc
-   \<lbrace>\<lambda>rv s. P s \<and> rv = ksCurSc s\<rbrace>"
-  apply (simp add: getCurSc_def)
-  apply (wpsimp wp: hoare_return_sp)
-  done
-
-lemma refillBudgetCheckRoundRobin_corres:
-  "corres dc
-          (cur_sc_active and (\<lambda>s. sc_at (cur_sc s) s))
-          ((\<lambda>s'. valid_refills' (ksCurSc s') s') and (\<lambda>s'. sc_at' (ksCurSc s') s'))
-          (refill_budget_check_round_robin usage) (refillBudgetCheckRoundRobin usage)"
-  supply projection_rewrites[simp]
-  apply (subst is_active_sc_rewrite)
-  apply (clarsimp simp: refill_budget_check_round_robin_def refillBudgetCheckRoundRobin_def)
-  apply (rule corres_underlying_split[rotated 2, OF gets_sp getCurSc_sp])
-   apply (corresKsimp corres: getCurSc_corres)
-  apply (rule_tac Q="\<lambda>s. is_active_sc' (ksCurSc s) s" in corres_cross_add_guard)
-   apply (rule_tac ptr="ksCurSc s'" in is_active_sc'_cross[OF state_relation_pspace_relation]; simp)
-   apply clarsimp
-  apply (rule corres_guard_imp)
-    apply (rule corres_split[OF updateRefillHd_corres], simp)
-       apply (clarsimp simp: refill_map_def)
-      apply (rule updateRefillTl_corres, simp)
-      apply (clarsimp simp: refill_map_def)
-     apply (wpsimp simp: update_refill_hd_rewrite wp: set_refills_wp get_refills_wp)
-    apply (wpsimp wp: hoare_vcg_conj_lift)
-     apply (wpsimp simp: updateRefillHd_def wp: updateSchedContext_wp)
-    apply (wpsimp wp: updateRefillHd_valid_objs')
-   apply (clarsimp simp: obj_at_def is_active_sc2_def is_sc_obj opt_map_red
-                  split: option.split_asm Structures_A.kernel_object.split_asm)
-  apply (clarsimp simp: obj_at_simps fun_upd_def[symmetric] scBits_simps ps_clear_upd)
-  apply (clarsimp simp: is_active_sc'_def valid_obj'_def valid_sched_context'_def valid_refills'_def
-                        opt_pred_def
-                 split: option.split_asm)
-  done
-
-lemma head_insufficient_length_greater_than_one:
-  "\<lbrakk>the (head_insufficient sc_ptr s);
-    pred_map (\<lambda>cfg. unat MIN_BUDGET \<le> refills_unat_sum (scrc_refills cfg)) (sc_refill_cfgs_of s) sc_ptr\<rbrakk>
-   \<Longrightarrow> pred_map (\<lambda>cfg. Suc 0 < length (scrc_refills cfg)) (sc_refill_cfgs_of s) sc_ptr"
-  apply (frule head_insufficient_true_imp_insufficient)
-   apply (clarsimp simp: vs_all_heap_simps)
-  apply (clarsimp simp: vs_all_heap_simps sc_at_ppred_def refills_unat_sum_def word_less_nat_alt)
-  apply (case_tac "sc_refills y"; fastforce dest!: member_le_sum_list)
-  done
-
-lemma length_sc_refills_cross:
-  "\<lbrakk>(s, s') \<in> state_relation; sc_at scp s; sc_at' scp s'; valid_refills' scp s'\<rbrakk>
-   \<Longrightarrow> ((\<lambda>sc. P (length (sc_refills sc))) |< scs_of2 s) scp
-        = ((\<lambda>sc'. P (scRefillCount sc')) |< scs_of' s') scp"
-  apply (drule (2) state_relation_sc_relation)
-  apply (clarsimp simp: obj_at_simps is_sc_obj valid_refills'_def sc_relation_def opt_map_red
-                        opt_pred_def)
-  done
-
-lemma update_refill_hd_comp:
-  "update_refill_hd scPtr (f \<circ> g)
-   = do update_refill_hd scPtr g;
-        update_refill_hd scPtr f
-     od"
-  apply (clarsimp simp: update_refill_hd_def)
-  apply (rule box_equals[OF update_sched_context_decompose]; fastforce)
-  done
-
-lemma updateRefillHd_valid_refills'[wp]:
-  "updateRefillHd scPtr f \<lbrace>valid_refills' scPtr'\<rbrace>"
-  apply (clarsimp simp: updateRefillHd_def updateSchedContext_def setSchedContext_def)
-  apply (wpsimp wp: setObject_sc_wp)
-  apply (clarsimp simp: valid_refills'_def obj_at'_def projectKOs opt_map_def opt_pred_def)
-  done
-
-lemma updateRefillTl_valid_refills'[wp]:
-  "updateRefillTl scPtr f \<lbrace>valid_refills' scPtr'\<rbrace>"
-  apply (clarsimp simp: updateRefillTl_def updateSchedContext_def setSchedContext_def)
-  apply (wpsimp wp: setObject_sc_wp)
-  apply (clarsimp simp: valid_refills'_def obj_at'_def projectKOs opt_map_def opt_pred_def)
-  done
-
-lemma refill_pop_head_is_active_sc[wp]:
-  "refill_pop_head sc_ptr \<lbrace>is_active_sc sc_ptr'\<rbrace>"
-  apply (wpsimp simp: refill_pop_head_def wp: update_sched_context_wp)
-  apply (clarsimp simp: vs_all_heap_simps obj_at_kh_kheap_simps active_sc_def)
-  done
-
-lemma setSchedContext_is_active_sc_at':
-  "\<lbrace>is_active_sc' scPtr' and K (scPtr' = scPtr \<longrightarrow> 0 < scRefillMax sc)\<rbrace>
-   setSchedContext scPtr sc
-   \<lbrace>\<lambda>_ s. is_active_sc' scPtr' s\<rbrace>"
-  apply (wpsimp wp: set_sc'.set_wp opt_map_red
-              simp: StateRelation.is_active_sc'_def opt_pred_def split: if_splits)
-  done
-
-lemma updateSchedContext_is_active_sc_at':
-  "\<lbrace>is_active_sc' scPtr'
-    and (\<lambda>s. scPtr = scPtr' \<longrightarrow> (\<forall>ko. ko_at' ko scPtr s \<longrightarrow> 0 < scRefillMax ko \<longrightarrow> 0 < scRefillMax (f ko)))\<rbrace>
-   updateSchedContext scPtr f
-   \<lbrace>\<lambda>_. is_active_sc' scPtr'\<rbrace>"
-  apply (simp add: updateSchedContext_def)
-  apply (wpsimp wp: setSchedContext_is_active_sc_at')
-  apply (clarsimp simp: is_active_sc'_def obj_at'_def projectKOs opt_map_red opt_pred_def)
-  done
-
-lemma refillPopHead_is_active_sc_at'[wp]:
-  "refillPopHead scPtr \<lbrace>is_active_sc' scPtr'\<rbrace>"
-  apply (simp add: refillPopHead_def)
-  apply (wpsimp wp: updateSchedContext_is_active_sc_at' getRefillNext_wp)
-  done
-
-lemma nonOverlappingMergeRefills_corres:
-  "sc_ptr = scPtr \<Longrightarrow>
-    corres dc (pspace_aligned and pspace_distinct and sc_at sc_ptr and is_active_sc sc_ptr
-                and valid_objs
-                and (\<lambda>s. pred_map (\<lambda>cfg. Suc 0 < length (scrc_refills cfg)) (sc_refill_cfgs_of s) sc_ptr))
-              (valid_refills' sc_ptr)
-    (non_overlapping_merge_refills sc_ptr)
-    (nonOverlappingMergeRefills scPtr)"
-  apply (clarsimp simp: non_overlapping_merge_refills_def nonOverlappingMergeRefills_def)
-  apply (rule corres_cross[OF sc_at'_cross_rel[where t=scPtr]], simp)
-  apply (rule corres_symb_exec_r[OF _ get_sc_sp', rotated]; (solves wpsimp)?)
-  apply (rule_tac Q="is_active_sc' scPtr" in corres_cross_add_guard)
-   apply (fastforce dest: is_active_sc'2_cross)
-  apply (rule_tac Q="obj_at' (\<lambda>sc'. Suc 0 < scRefillCount sc') scPtr"
-               in corres_cross_add_guard)
-   apply (fastforce dest!: length_sc_refills_cross[where P="\<lambda>l. Suc 0 < l"]
-                     simp: opt_map_red opt_pred_def vs_all_heap_simps obj_at'_def projectKOs)
-  apply (rule corres_symb_exec_r[OF _ assert_sp, rotated])
-    apply wpsimp
-   apply (rule no_fail_pre)
-    apply (rule no_fail_assert)
-   apply (clarsimp simp: no_fail_def obj_at'_def projectKOs)
-
-  apply (rule_tac Q="\<lambda>_. sc_at sc_ptr and is_active_sc sc_ptr"
-              and Q'="\<lambda>_. valid_refills' scPtr and sc_at' scPtr"
-               in corres_underlying_split
-         ; (solves wpsimp)?)
-   apply (corresKsimp corres: refillPopHead_corres
-                       simp: obj_at_def vs_all_heap_simps pred_map_simps sc_at_ppred_def)
-  apply (subst update_refill_hd_comp)
-  apply (rule corres_guard_imp)
-     apply (rule corres_underlying_split[OF updateRefillHd_corres])
-         apply blast
-        apply (clarsimp simp: refill_map_def)
-       apply (fastforce intro: updateRefillHd_corres
-                         simp: refill_map_def)
-      apply (wpsimp simp: update_refill_hd_def wp: update_sched_context_wp)
-      apply (clarsimp simp: vs_all_heap_simps active_sc_def is_active_sc2_def obj_at_def opt_map_def)
-     apply (wpsimp simp: updateRefillHd_def simp: objBits_simps)
-    apply (simp add: is_active_sc_rewrite[symmetric])
-   apply blast
-  done
-
-lemma head_insufficient_simp:
-  "sc_at scp s
-   \<Longrightarrow> head_insufficient scp s = Some (sc_at_pred (\<lambda>sc. r_amount (refill_hd sc) < MIN_BUDGET) scp s)"
-  unfolding head_insufficient_def
-  by (clarsimp simp: obind_def read_sched_context_def obj_at_def is_sc_obj sc_at_pred_n_def)
-
-lemma refillHdInsufficient_simp:
-  "sc_at' scp s
-   \<Longrightarrow> refillHdInsufficient scp s
-       = Some (obj_at' (\<lambda>sc :: sched_context. rAmount (refillHd sc) < minBudget) scp s)"
-  unfolding refillHdInsufficient_def
-  apply (clarsimp simp: obind_def readSchedContext_def split: option.splits)
-  apply (frule no_ofailD[OF no_ofail_sc_at'_readObject])
-  apply (clarsimp simp: obj_at'_def dest!: readObject_misc_ko_at')
-  done
-
-lemma head_insufficient_equiv:
-  "\<lbrakk>(s, s') \<in> state_relation; pspace_aligned s; pspace_distinct s; valid_objs s;
-    pred_map (\<lambda>cfg. scrc_refills cfg \<noteq> []) (sc_refill_cfgs_of s) scPtr; valid_refills' scPtr s'\<rbrakk>
-   \<Longrightarrow> head_insufficient scPtr s = refillHdInsufficient scPtr s'"
-  apply (prop_tac "sc_at scPtr s")
-   apply (fastforce dest: valid_objs_valid_sched_context_size
-                    simp: vs_all_heap_simps obj_at_kh_kheap_simps is_sc_obj_def)
-  apply (frule state_relation_pspace_relation)
-  apply (frule sc_at_cross; simp?)
-  apply (frule state_relation_sc_relation; simp?)
-  apply (subst head_insufficient_simp; simp?)
-  apply (subst refillHdInsufficient_simp; simp)
-  apply (frule refill_hd_relation)
-   apply (fastforce simp: vs_all_heap_simps valid_refills'_def opt_map_def opt_pred_def obj_at_simps)
-  apply (clarsimp simp: obj_at_def sc_at_ppred_def obj_at'_def projectKOs minBudget_def refill_map_def
-                        MIN_BUDGET_def kernelWCETTicks_def opt_map_def vs_all_heap_simps)
-  done
-
-lemma refill_pop_head_no_fail:
-  "no_fail (\<lambda>s. (\<exists>sc n. kheap s sc_ptr = Some (Structures_A.SchedContext sc n))
-                \<and> pred_map (\<lambda>cfg. scrc_refills cfg \<noteq> []) (sc_refill_cfgs_of s) sc_ptr)
-           (refill_pop_head sc_ptr)"
-  apply (wpsimp simp: refill_pop_head_def get_refills_def get_sched_context_def
-                  wp: get_object_wp update_sched_context_no_fail)
-  apply (clarsimp simp: obj_at_def a_type_def vs_all_heap_simps is_sc_obj_def)
-  done
-
-lemma refill_pop_head_sched_context_at[wp]:
-  "refill_pop_head sc_ptr' \<lbrace>\<lambda>s. \<exists>sc n. kheap s sc_ptr = Some (Structures_A.SchedContext sc n)\<rbrace>"
-  apply (clarsimp simp: refill_pop_head_def)
-  apply (wpsimp wp: update_sched_context_wp)
-  done
-
-lemma non_overlapping_merge_refills_no_fail:
-  "no_fail (\<lambda>s. (\<exists>sc n. kheap s sc_ptr = Some (Structures_A.SchedContext sc n))
-                \<and> pred_map (\<lambda>cfg. scrc_refills cfg \<noteq> []) (sc_refill_cfgs_of s) sc_ptr)
-           (non_overlapping_merge_refills sc_ptr)"
-  apply (wpsimp wp: refill_pop_head_no_fail
-              simp: non_overlapping_merge_refills_def update_refill_hd_def)
-  done
-
-lemma non_overlapping_merge_refills_is_active_sc[wp]:
-  "non_overlapping_merge_refills sc_ptr \<lbrace>is_active_sc sc_ptr'\<rbrace>"
-  apply (clarsimp simp: non_overlapping_merge_refills_def update_refill_hd_def)
-  apply (rule bind_wp_fwd_skip, solves wpsimp)
-  apply (wpsimp wp: update_sched_context_wp)
-  apply (clarsimp simp: vs_all_heap_simps obj_at_def)
-  done
-
-crunch non_overlapping_merge_refills
-  for valid_objs[wp]: valid_objs
-
-lemma nonOverLappingMergeRefills_valid_refills'[wp]:
-  "nonOverlappingMergeRefills scPtr \<lbrace>valid_refills' scPtr\<rbrace>"
-  apply (wpsimp simp: nonOverlappingMergeRefills_def)
-  apply (clarsimp simp: obj_at'_def)
-  done
-
-definition head_insufficient_loop_measure where
-  "head_insufficient_loop_measure sc_ptr
-     \<equiv> measure (\<lambda>(_, s). case kheap s sc_ptr of Some (Structures_A.SchedContext sc _)
-                                             \<Rightarrow> (length (sc_refills sc)))"
-
-lemma non_overlapping_merge_refills_terminates:
-  "\<lbrakk>pred_map (\<lambda>cfg. refills_unat_sum (scrc_refills cfg) \<le> unat max_time)
-             (sc_refill_cfgs_of s) sc_ptr;
-    pred_map (\<lambda>cfg. unat MIN_BUDGET \<le> refills_unat_sum (scrc_refills cfg))
-             (sc_refill_cfgs_of s) sc_ptr\<rbrakk>
-   \<Longrightarrow> whileLoop_terminates (\<lambda>_ s. the (head_insufficient sc_ptr s))
-                            (\<lambda>_. non_overlapping_merge_refills sc_ptr) r s"
-  (is "\<lbrakk>?P s; ?Q s\<rbrakk> \<Longrightarrow> _")
-  apply (rule_tac I="\<lambda>_. ?P and ?Q"
-               in whileLoop_terminates_inv[where R="head_insufficient_loop_measure sc_ptr"])
-    apply simp
-   apply (intro hoare_vcg_conj_lift_pre_fix)
-    apply (wpsimp wp: non_overlapping_merge_refills_refills_unat_sum_lower_bound
-                      non_overlapping_merge_refills_refills_unat_sum)
-    apply (fastforce dest: head_insufficient_length_at_least_two)
-   apply (wpsimp wp: update_sched_context_wp
-               simp: head_insufficient_loop_measure_def non_overlapping_merge_refills_def
-                     refill_pop_head_def update_refill_hd_def)
-   apply (fastforce dest: head_insufficient_length_at_least_two
-                    simp: vs_all_heap_simps obj_at_def)
-  apply (clarsimp simp: head_insufficient_loop_measure_def)
-  done
-
-lemma refills_unat_sum_MIN_BUDGET_implies_non_empty_refills:
-  "pred_map (\<lambda>cfg. unat MIN_BUDGET \<le> refills_unat_sum (scrc_refills cfg)) (sc_refill_cfgs_of s) sc_ptr
-   \<Longrightarrow> pred_map (\<lambda>cfg. scrc_refills cfg \<noteq> []) (sc_refill_cfgs_of s) sc_ptr"
-  apply (auto simp: vs_all_heap_simps refills_unat_sum_def MIN_BUDGET_nonzero unat_eq_zero)
-  done
-
-lemma headInsufficientLoop_corres:
-  "sc_ptr = scPtr
-   \<Longrightarrow> corres dc (pspace_aligned and pspace_distinct and sc_at sc_ptr and is_active_sc sc_ptr
-                  and valid_objs
-                  and (\<lambda>s. pred_map (\<lambda>cfg. unat MIN_BUDGET \<le> refills_unat_sum (scrc_refills cfg))
-                                    (sc_refill_cfgs_of s) sc_ptr)
-                  and (\<lambda>s. pred_map (\<lambda>cfg. refills_unat_sum (scrc_refills cfg) \<le> unat max_time)
-                                    (sc_refill_cfgs_of s) sc_ptr))
-                 (valid_refills' sc_ptr)
-                 (head_insufficient_loop sc_ptr)
-                 (headInsufficientLoop scPtr)"
-  apply (clarsimp simp: head_insufficient_loop_def headInsufficientLoop_def runReaderT_def)
-  apply (rule_tac Q="active_sc_at' scPtr" in corres_cross_add_guard)
-   apply (fastforce dest: active_sc_at'_cross)
-  apply (rule corres_whileLoop_abs; simp?)
-      apply (frule head_insufficient_equiv[where scPtr=scPtr]; simp?)
-      apply (fastforce intro: refills_unat_sum_MIN_BUDGET_implies_non_empty_refills)
-     apply (corresKsimp corres: nonOverlappingMergeRefills_corres)
-     apply (fastforce dest: head_insufficient_length_at_least_two)
-    apply (wpsimp wp: non_overlapping_merge_refills_no_fail)
-     apply (wpsimp wp: non_overlapping_merge_refills_refills_unat_sum_lower_bound
-                       non_overlapping_merge_refills_refills_unat_sum)
-    apply (fastforce dest: head_insufficient_length_greater_than_one)
-   apply (wpsimp wp: nonOverlappingMergeRefills_valid_objs')
-  apply (fastforce intro!: non_overlapping_merge_refills_terminates)
-  done
-
-lemma refillEmpty_sp:
-  "\<lbrace>P\<rbrace>refillEmpty scp \<lbrace>\<lambda>rv s. P s \<and> (\<forall>ko. ko_at' ko scp s \<longrightarrow> rv = (scRefillCount ko = 0))\<rbrace>"
-  apply (wpsimp wp: refillEmpty_wp)
-  apply (clarsimp simp: obj_at'_def)
-  done
-
-lemma refillFull_sp:
-  "\<lbrace>P\<rbrace> refillFull scp \<lbrace>\<lambda>rv s. P s \<and> (\<forall>ko. ko_at' ko scp s \<longrightarrow> rv = (scRefillCount ko = scRefillMax ko))\<rbrace>"
-  apply (wpsimp wp: refillFull_wp)
-  apply (clarsimp simp: obj_at'_def)
-  done
-
-lemma refillFull_corres:
-  "sc_ptr = scPtr
-   \<Longrightarrow> corres (=) (sc_at sc_ptr and pspace_aligned and pspace_distinct)
-                  (valid_refills' scPtr)
-                  (refill_full sc_ptr)
-                  (refillFull scPtr)"
-  apply (rule_tac Q="sc_at' scPtr" in corres_cross_add_guard)
-   apply (fastforce intro: sc_at_cross)
-  apply (clarsimp simp: refill_full_def refillFull_def)
-  apply (rule corres_underlying_split[rotated 2, OF get_sched_context_sp get_sc_sp'])
-   apply (corresKsimp corres: get_sc_corres)
-  apply (corresKsimp corres: corres_return_eq_same)
-  apply (fastforce simp: sc_relation_def obj_at_simps valid_refills'_def opt_map_red opt_pred_def)
-  done
-
-lemma scheduleUsed_corres:
-  "\<lbrakk>sc_ptr = scPtr; new = refill_map new'\<rbrakk> \<Longrightarrow>
-    corres dc (sc_at sc_ptr and is_active_sc2 sc_ptr and pspace_aligned and pspace_distinct)
-              (valid_refills' scPtr)
-              (schedule_used sc_ptr new)
-              (scheduleUsed scPtr new')"
-  apply (clarsimp simp: schedule_used_def scheduleUsed_def get_refills_def bind_assoc)
-  apply (rule_tac Q="sc_at' scPtr" in corres_cross_add_guard)
-   apply (fastforce intro: sc_at_cross)
-  apply (rule_tac Q="is_active_sc' scPtr" in corres_cross_add_guard)
-   apply (fastforce intro: is_active_sc'_cross)
-  apply (rule corres_underlying_split[rotated 2, OF get_sched_context_sp get_sc_sp'])
-   apply (corresKsimp corres: get_sc_corres)
-  apply (rename_tac sc sc')
-  apply (rule corres_symb_exec_r[rotated, OF assert_sp]; (solves wpsimp)?)
-   apply wpsimp
-   apply (clarsimp simp: is_active_sc'_def obj_at_simps opt_map_red opt_pred_def)
-  apply (rule corres_symb_exec_r[rotated, OF refillEmpty_sp]
-         ; (solves \<open>wpsimp simp: refillEmpty_def\<close>)?)
-  apply (rule_tac F="empty = (sc_refills sc = [])" in corres_req)
-   apply (fastforce dest: length_sc_refills_cross[where P="\<lambda>l. 0 = l"]
-                    simp: valid_refills'_def obj_at_simps opt_map_red opt_pred_def)
-  apply (rule corres_if_split; (solves simp)?)
-   apply (corresKsimp corres: refillAddTail_corres simp: refill_map_def)
-   apply (clarsimp simp: valid_refills'_def obj_at_simps opt_map_red opt_pred_def)
-  apply (rule_tac F="sc_valid_refills' sc'" in corres_req)
-   apply (clarsimp simp: valid_refills'_def obj_at_simps opt_map_red opt_pred_def)
-  apply (rule corres_if_split; (solves simp)?)
-    apply (fastforce dest: refills_tl_equal
-                     simp: refill_map_def can_merge_refill_def)
-   apply (corresKsimp corres: updateRefillTl_corres
-                       simp: refill_map_def)
-  apply (rule corres_underlying_split[rotated 2, OF refill_full_sp refillFull_sp])
-   apply (corresKsimp corres: refillFull_corres)
-  apply (rule corres_if_split; (solves simp)?)
-   apply (corresKsimp corres: refillAddTail_corres)
-   apply (clarsimp simp: refill_map_def obj_at_simps opt_map_red opt_pred_def)
-  apply (corresKsimp corres: updateRefillTl_corres simp: refill_map_def)
-  done
-
-lemma head_time_buffer_simp:
-  "sc_at (cur_sc s) s
-   \<Longrightarrow> head_time_buffer usage s
-       = Some (sc_at_pred (\<lambda>sc. r_amount (refill_hd sc) \<le> usage
-                                \<and> r_time (refill_hd sc) < MAX_RELEASE_TIME)
-                          (cur_sc s) s)"
-  unfolding head_time_buffer_def
-  apply (clarsimp simp: obind_def read_sched_context_def obj_at_def is_sc_obj sc_at_pred_n_def
-                        ogets_def)
-  done
-
-lemma headTimeBuffer_simp:
-  "sc_at' (ksCurSc s) s
-   \<Longrightarrow> headTimeBuffer usage s
-       = Some (obj_at' (\<lambda>sc :: sched_context. rAmount (refillHd sc) \<le> usage
-                                              \<and> rTime (refillHd sc) < maxReleaseTime)
-                       (ksCurSc s) s)"
-  unfolding headTimeBuffer_def
-  apply (clarsimp simp: obind_def readSchedContext_def split: option.splits)
-  apply (frule no_ofailD[OF no_ofail_sc_at'_readObject])
-  apply (fastforce simp: readObject_def obind_def omonad_defs split_def loadObject_default_def
-                         readCurSc_def obj_at'_def ogets_def
-                  split: option.splits if_split_asm)
-  done
-
-lemma head_time_buffer_equiv:
-  "\<lbrakk>(s, s') \<in> state_relation; pspace_aligned s; pspace_distinct s; valid_objs s;
-    pred_map (\<lambda>cfg. scrc_refills cfg \<noteq> []) (sc_refill_cfgs_of s) (cur_sc s);
-    valid_refills' (ksCurSc s') s'; usage = usage'\<rbrakk>
-   \<Longrightarrow> head_time_buffer usage s = headTimeBuffer usage' s'"
-  apply (prop_tac "sc_at (cur_sc s) s")
-   apply (fastforce dest: valid_objs_valid_sched_context_size
-                    simp: vs_all_heap_simps obj_at_kh_kheap_simps is_sc_obj_def)
-  apply (frule state_relation_pspace_relation)
-  apply (frule sc_at_cross; simp?)
-  apply (frule state_relation_sc_relation; simp?)
-  apply (subst head_time_buffer_simp; simp?)
-  apply (subst headTimeBuffer_simp)
-   apply (clarsimp simp: state_relation_def)
-  apply (frule refill_hd_relation)
-    apply (clarsimp simp: valid_refills'_def obj_at_simps state_relation_def)
-   apply (clarsimp simp: sc_ko_at_valid_objs_valid_sc' opt_map_def opt_pred_def obj_at_simps)
-  apply (clarsimp simp: obj_at_def sc_at_ppred_def obj_at'_def projectKOs state_relation_def
-                        maxReleaseTime_equiv opt_map_def vs_all_heap_simps refill_map_def)
-  done
-
-lemma refillSingle_sp:
-  "\<lbrace>P\<rbrace>
-   refillSingle scp
-   \<lbrace>\<lambda>rv s. P s \<and> (\<forall>ko. ko_at' ko scp s \<longrightarrow> rv = (scRefillHead ko = refillTailIndex ko))\<rbrace>"
-  apply (clarsimp simp: refillSingle_def)
-  apply wpsimp
-  apply (clarsimp simp: obj_at'_def)
-  done
-
-crunch updateRefillHd, scheduleUsed
-   for valid_sched_context'[wp]: "valid_sched_context' sc"
-
-lemma handleOverrunLoopBody_corres:
-  "r = r'
-   \<Longrightarrow> corres (=) (\<lambda>s. sc_at (cur_sc s) s \<and> is_active_sc2 (cur_sc s) s
-                       \<and> pspace_aligned s \<and> pspace_distinct s
-                       \<and> pred_map (\<lambda>cfg. scrc_refills cfg \<noteq> []) (sc_refill_cfgs_of s) (cur_sc s))
-                  (\<lambda>s'. valid_refills' (ksCurSc s') s')
-                  (handle_overrun_loop_body r)
-                  (handleOverrunLoopBody r')"
-  apply (rule_tac Q="\<lambda>s'. sc_at' (ksCurSc s') s'" in corres_cross_add_guard)
-   apply (fastforce intro: sc_at_cross simp: state_relation_def)
-  apply (rule_tac Q="\<lambda>s'. is_active_sc' (ksCurSc s') s'" in corres_cross_add_guard)
-   apply (fastforce intro: is_active_sc'_cross simp: state_relation_def)
-  apply (clarsimp simp: handle_overrun_loop_body_def handleOverrunLoopBody_def)
-  apply (rule corres_underlying_split[rotated 2, OF gets_sp getCurSc_sp])
-   apply (corresKsimp corres: getCurSc_corres)
-  apply (rule corres_underlying_split[rotated 2, OF refill_single_sp refillSingle_sp])
-   apply (corresKsimp corres: refillSingle_corres)
-   apply (fastforce simp: obj_at_simps valid_refills'_def opt_map_red opt_pred_def)
-  apply (rule corres_underlying_split[rotated 2, OF get_sched_context_sp get_sc_sp'])
-   apply (corresKsimp corres: get_sc_corres)
-  apply (rename_tac sc sc')
-  apply (rule_tac Q="\<lambda>_ s. sc_refills sc \<noteq> []"
-              and Q'="\<lambda>_ _. sc_valid_refills' sc'"
-              and r'=dc
-               in corres_underlying_split[rotated])
-     apply corresKsimp
-     apply (fastforce dest: refill_hd_relation simp: refill_map_def)
-    apply (wpsimp simp: update_refill_hd_def
-                    wp: update_sched_context_wp)
-    apply (clarsimp simp: vs_all_heap_simps obj_at_def)
-   apply wpsimp
-   apply (clarsimp simp: valid_refills'_def obj_at_simps opt_map_red opt_pred_def)
-  apply (rule corres_if_split; simp?)
-   apply (corresKsimp corres: updateRefillHd_corres)
-   apply (fastforce simp: refill_map_def sc_relation_def)
-  apply (rule_tac F="1 < scRefillCount sc'" in corres_req)
-   apply (frule_tac scp="scPtr" and P="\<lambda>l. 1 < l" in length_sc_refills_cross)
-      apply (clarsimp simp: state_relation_def)
-     apply simp
-    apply (fastforce simp: refill_map_def sc_relation_def)
-   apply (clarsimp simp: opt_map_red opt_pred_def vs_all_heap_simps obj_at'_def projectKOs Suc_lessI)
-  apply (rule corres_guard_imp)
-    apply (rule corres_split[OF refillPopHead_corres])
-      apply (rule scheduleUsed_corres)
-       apply simp
-      apply (clarsimp simp: refill_map_def sc_relation_def)
-     apply wpsimp
-    apply wpsimp
-   apply (clarsimp simp: is_active_sc2_def sc_at_ppred_def obj_at_def is_sc_obj_def active_sc_def
-                         vs_all_heap_simps opt_map_red Suc_lessI)
-  apply (clarsimp simp: obj_at_simps)
-  done
-
-lemma schedule_used_no_fail[wp]:
-  "no_fail (\<lambda>s. (\<exists>sc n. kheap s sc_ptr = Some (Structures_A.SchedContext sc n)))
-           (schedule_used sc_ptr new)"
-  apply (wpsimp simp: schedule_used_defs get_refills_def refill_full_def
-                  wp: update_sched_context_wp)
-  done
-
-lemma handle_overrun_loop_body_no_fail:
-  "no_fail (\<lambda>s. (\<exists>sc n. kheap s (cur_sc s) = Some (Structures_A.SchedContext sc n))
-                \<and> pred_map (\<lambda>cfg. scrc_refills cfg \<noteq> []) (sc_refill_cfgs_of s) (cur_sc s))
-           (handle_overrun_loop_body usage)"
-  unfolding handle_overrun_loop_body_def
-  apply (wpsimp simp: refill_single_def refill_size_def get_refills_def update_refill_hd_def
-                  wp: refill_pop_head_no_fail)
-  done
-
-lemma scheduleUsed_is_active_sc'[wp]:
-  "scheduleUsed scPtr new \<lbrace>is_active_sc' sc_Ptr'\<rbrace>"
-  apply (clarsimp simp: scheduleUsed_def)
-  apply (wpsimp simp: refillAddTail_def updateRefillTl_def
-                  wp: updateSchedContext_wp refillFull_wp refillEmpty_wp)
-  apply (clarsimp simp: obj_at_simps is_active_sc'_def opt_map_def opt_pred_def)
-  done
-
-lemma handleOverrunLoopBody_is_active_sc'[wp]:
-  "handleOverrunLoopBody usage \<lbrace>is_active_sc' sc_ptr\<rbrace>"
-  apply (clarsimp simp: handleOverrunLoopBody_def)
-  apply (wpsimp simp: updateRefillHd_def refillSingle_def
-                  wp: updateSchedContext_wp)
-  apply (clarsimp simp: obj_at_simps is_active_sc'_def opt_map_def opt_pred_def)
-  done
-
-lemma refillAddTail_valid_refills'[wp]:
-  "refillAddTail scPtr refill \<lbrace>valid_refills' ptr\<rbrace>"
-  apply (clarsimp simp: refillAddTail_def)
-  apply (wpsimp wp: updateSchedContext_wp)
-  apply (clarsimp simp: valid_refills'_def obj_at_simps opt_map_red opt_pred_def)
-  done
-
-lemma scheduleUsed_valid_refills'[wp]:
-  "scheduleUsed ptr new \<lbrace>valid_refills' scPtr\<rbrace>"
-  apply (clarsimp simp: scheduleUsed_def)
-  apply (wpsimp wp: refillFull_wp refillEmpty_wp)
-  done
-
-crunch handle_overrun_loop_body
-  for valid_objs[wp]: valid_objs
-
-lemma handleOverrunLoopBody_valid_refills'[wp]:
-  "handleOverrunLoopBody r'  \<lbrace>valid_refills' scPtr\<rbrace>"
-  apply (clarsimp simp: handleOverrunLoopBody_def updateRefillHd_def refillSingle_def)
-  apply wpsimp
-  apply (fastforce simp: valid_refills'_def opt_map_red opt_pred_def obj_at_simps
-                         refillSingle_equiv[THEN arg_cong_Not, symmetric])
-  done
-
-lemma schedule_used_length_nonzero[wp]:
-  "\<lbrace>\<lambda>s. if sc_ptr' = sc_ptr
-        then pred_map \<top> (scs_of s) sc_ptr
-        else pred_map (\<lambda>cfg. scrc_refills cfg \<noteq> []) (sc_refill_cfgs_of s) sc_ptr\<rbrace>
-   schedule_used sc_ptr' new
-   \<lbrace>\<lambda>_ s. pred_map (\<lambda>cfg. scrc_refills cfg \<noteq> []) (sc_refill_cfgs_of s) sc_ptr\<rbrace>"
-  apply (wpsimp wp: update_sched_context_wp get_refills_wp
-              simp: schedule_used_defs)
-  apply (clarsimp simp: obj_at_def vs_all_heap_simps)
-  done
-
-lemma handle_overrun_loop_body_terminates_wf_helper:
-  "wf {((r' :: ticks, s' :: 'a state), (r, s)). unat r' < unat r}"
-  apply (insert wf_inv_image[where r="{(m, n). m < n}"
-                               and f="\<lambda>(r :: ticks, s :: 'a state). unat r"])
-  apply (clarsimp simp: inv_image_def)
-  apply (prop_tac "wf {(m, n). m < n}")
-   apply (fastforce intro: wf)
-  apply (drule meta_mp, simp)
-  apply (prop_tac "{(x :: ticks \<times> 'a state, y :: ticks \<times> 'a state).
-                     (case x of (r, s) \<Rightarrow> unat r)
-                      < (case y of (r, s) \<Rightarrow> unat r)}
-                   = {((r, s), r', s'). unat r < unat r'}")
-    apply fastforce
-  apply fastforce
-  done
-
-\<comment> \<open>The following method can be used to try to solve Hoare triples in the following way.
-    Note that the method works best when the precondition is not schematic.
-    First, if the postcondition is not a conjunction, it will try to solve the goal with the
-    method given to `solves`. The goal will be left untouched if it cannot solve the goal.
-    If the postcondition is a conjunction, the method will pull it apart into all the conjuncts
-    using hoare_vcg_conj_lift_pre_fix. It will then attempt to solve each of these individually.\<close>
-method wps_conj_solves uses wp simp wps
-   = (clarsimp simp: pred_conj_def)?
-     , (intro hoare_vcg_conj_lift_pre_fix
-        ; (solves \<open>rule hoare_weaken_pre, (wpsimp wp: wp simp: simp | wps wps)+\<close>)?)
-       | (solves \<open>rule hoare_weaken_pre, (wpsimp wp: wp simp: simp | wps wps)+\<close>)?
-
-lemma handle_overrun_loop_body_terminates:
-  "\<lbrakk>sc_at (cur_sc s) s;
-    pred_map (\<lambda>cfg. \<forall>refill \<in> set (scrc_refills cfg). 0 < unat (r_amount refill))
-             (sc_refill_cfgs_of s) (cur_sc s);
-    pred_map (\<lambda>cfg. scrc_refills cfg \<noteq> []) (sc_refill_cfgs_of s) (cur_sc s);
-    pred_map (\<lambda>cfg. refills_unat_sum (scrc_refills cfg) = unat (scrc_budget cfg))
-             (sc_refill_cfgs_of s) (cur_sc s)\<rbrakk>
-   \<Longrightarrow> whileLoop_terminates (\<lambda>r s. the (head_time_buffer r s)) handle_overrun_loop_body usage s"
-  (is "\<lbrakk>?P1 s; ?P2 s; ?P3 s; ?P4 s\<rbrakk> \<Longrightarrow> _")
-  apply (rule_tac R="{((r' :: ticks, s' :: 'a state), (r, s)). unat r' < unat r}"
-              and I="\<lambda>_ s'. ?P1 s' \<and> ?P2 s' \<and> ?P3 s' \<and> ?P4 s' \<and> cur_sc s' = cur_sc s"
-               in whileLoop_terminates_inv)
-    apply simp
-   prefer 2
-   apply (fastforce simp: handle_overrun_loop_body_terminates_wf_helper)
-  apply (rename_tac r s')
-  apply (wps_conj_solves wp: handle_overrun_loop_body_non_zero_refills
-                             handle_overrun_loop_body_refills_unat_sum_equals_budget)
-   apply (wpsimp simp: handle_overrun_loop_body_def)
-  apply (rename_tac sc n)
-  apply (subst unat_sub)
-   apply (prop_tac "sc_at (cur_sc s') s'", simp)
-   apply (frule_tac usage=r and s=s' in head_time_buffer_simp)
-   apply (clarsimp simp: sc_at_ppred_def obj_at_def)
-  apply (clarsimp simp: obj_at_def vs_all_heap_simps)
-  apply (frule_tac x="refill_hd sc" in bspec, fastforce)
-  apply (prop_tac "0 < unat r")
-   apply (prop_tac "sc_at (cur_sc s') s'")
-    apply (clarsimp simp: obj_at_def is_sc_obj_def)
-   apply (frule_tac usage=r and s=s' in head_time_buffer_simp)
-   apply (clarsimp simp: sc_at_ppred_def obj_at_def)
-   apply (frule_tac x="refill_hd sc" in bspec, fastforce)
-   apply (fastforce simp: word_le_nat_alt)
-  apply fastforce
-  done
-
-lemma handleOverrunLoop_corres:
-  "usage = usage' \<Longrightarrow>
-   corres (=) (\<lambda>s. sc_at (cur_sc s) s \<and> is_active_sc2 (cur_sc s) s
-                   \<and> pspace_aligned s \<and> pspace_distinct s
-                   \<and> valid_objs s
-                   \<and> pred_map (\<lambda>cfg. scrc_refills cfg \<noteq> []) (sc_refill_cfgs_of s) (cur_sc s)
-                   \<and> pred_map (\<lambda>cfg. \<forall>refill\<in>set (scrc_refills cfg). 0 < unat (r_amount refill))
-                               (sc_refill_cfgs_of s) (cur_sc s)
-                   \<and> pred_map (\<lambda>cfg. refills_unat_sum (scrc_refills cfg) = unat (scrc_budget cfg))
-                               (sc_refill_cfgs_of s) (cur_sc s))
-              (\<lambda>s'. valid_refills' (ksCurSc s') s')
-              (handle_overrun_loop usage)
-              (handleOverrunLoop usage')"
-  apply (rule_tac Q="\<lambda>s'. sc_at' (ksCurSc s') s'" in corres_cross_add_guard)
-   apply (fastforce intro: sc_at_cross simp: state_relation_def)
-  apply (rule_tac Q="\<lambda>s'. is_active_sc' (ksCurSc s') s'" in corres_cross_add_guard)
-   apply (fastforce intro: is_active_sc'_cross simp: state_relation_def)
-  apply (clarsimp simp: handle_overrun_loop_def handleOverrunLoop_def runReaderT_def)
-  apply (rule corres_whileLoop_abs; simp?)
-      apply (frule_tac usage=r' in head_time_buffer_equiv; simp?)
-      apply fastforce
-     apply (corresKsimp corres: handleOverrunLoopBody_corres)
-    apply (wps_conj_solves wp: handle_overrun_loop_body_non_zero_refills
-                               handle_overrun_loop_body_refills_unat_sum_equals_budget)
-   apply wps_conj_solves
-  apply (fastforce intro:  handle_overrun_loop_body_terminates)
-  done
-
-lemma handle_overrun_loop_is_active_sc[wp]:
-  "handle_overrun_loop usage \<lbrace>\<lambda>s. is_active_sc sc_ptr s\<rbrace>"
-  apply handle_overrun_loop_simple
-  done
-
-lemma get_refills_exs_valid[wp]:
-  "sc_at sc_ptr s \<Longrightarrow> \<lbrace>(=) s\<rbrace> get_refills sc_ptr \<exists>\<lbrace>\<lambda>r. (=) s\<rbrace>"
-  apply (clarsimp simp: get_refills_def)
-  apply (wpsimp wp: get_sched_context_exs_valid)
-   apply (erule sc_atD1)
-  apply simp
-  done
-
-crunch handleOverrunLoop
-  for valid_refills'[wp]: "valid_refills' scPtr"
-  (wp: crunch_wps)
-
-lemma refillBudgetCheck_corres:
-  "usage = usage'
-   \<Longrightarrow> corres dc ((\<lambda>s. sc_at (cur_sc s) s \<and> is_active_sc (cur_sc s) s
-                       \<and> valid_objs s
-                       \<and> pspace_aligned s \<and> pspace_distinct s)
-                  and (\<lambda>s. \<not> round_robin (cur_sc s) s \<and> valid_refills (cur_sc s) s))
-                 (\<lambda>s'. valid_refills' (ksCurSc s') s')
-                 (refill_budget_check usage)
-                 (refillBudgetCheck usage')"
-  (is "_ \<Longrightarrow> corres _ (?P and _) _ _ _")
-  apply (rule_tac Q="\<lambda>s'. sc_at' (ksCurSc s') s'" in corres_cross_add_guard)
-   apply (fastforce intro: sc_at_cross simp: state_relation_def)
-  apply (rule_tac Q="\<lambda>s'. is_active_sc' (ksCurSc s') s'" in corres_cross_add_guard)
-   apply (fastforce intro!: is_active_sc'2_cross simp: state_relation_def)
-
-  apply (clarsimp simp: refill_budget_check_def refillBudgetCheck_def)
-  apply (rule corres_underlying_split[rotated 2, OF gets_sp getCurSc_sp])
-   apply (corresKsimp corres: getCurSc_corres)
-  apply (rule corres_symb_exec_r[rotated, OF scActive_sp]; (solves \<open>wpsimp simp: scActive_def\<close>)?)
-  apply (rule corres_symb_exec_r[rotated, OF assert_sp]; (solves wpsimp)?)
-   apply (wpsimp wp: no_fail_assert
-               simp: is_active_sc'_def opt_map_red opt_pred_def obj_at_simps)
-  apply (rule corres_underlying_split[rotated 2, OF is_round_robin_sp isRoundRobin_sp])
-   apply (corresKsimp corres: isRoundRobin_corres)
-  apply (rule corres_symb_exec_l[rotated, OF _  assert_sp]; (solves wpsimp)?)
-  apply (rule_tac F="\<not>roundRobin" in corres_req)
-   apply clarsimp
-  apply (rule corres_symb_exec_r[rotated, OF assert_sp]; (solves wpsimp)?)
-
-  apply (rule_tac Q="\<lambda>usage' s. ?P s
-                                \<and> pred_map (\<lambda>cfg. refills_unat_sum (scrc_refills cfg)
-                                                   = unat (scrc_budget cfg))
-                                           (sc_refill_cfgs_of s) sc_ptr
-                                \<and> pred_map (\<lambda>cfg. MIN_BUDGET \<le> scrc_budget cfg)
-                                            (sc_refill_cfgs_of s) sc_ptr
-                                \<and> sc_ptr = cur_sc s
-                                \<and> (pred_map (\<lambda>cfg. r_time (hd (scrc_refills cfg)) < MAX_RELEASE_TIME)
-                                             (sc_refill_cfgs_of s) (cur_sc s)
-                                   \<longrightarrow> pred_map (\<lambda>cfg. usage' < r_amount (hd (scrc_refills cfg)))
-                                                (sc_refill_cfgs_of s) (cur_sc s))
-                                \<and> pred_map (\<lambda>cfg. scrc_refills cfg \<noteq> [])
-                                            (sc_refill_cfgs_of s) sc_ptr"
-               and Q'="\<lambda>_ s'. valid_refills' scPtr s' \<and> active_sc_at' scPtr s' \<and> scPtr = ksCurSc s'"
-               in corres_underlying_split)
-     apply (corresKsimp corres: handleOverrunLoop_corres)
-     apply (fastforce intro: valid_refills_refills_unat_sum_equals_budget
-                       simp: vs_all_heap_simps cfg_valid_refills_def round_robin_def
-                             sp_valid_refills_def is_active_sc_rewrite[symmetric])
-    apply (find_goal \<open>match conclusion in "\<lbrace>P\<rbrace> handle_overrun_loop _ \<lbrace>Q\<rbrace>" for P Q \<Rightarrow> -\<close>)
-    apply (clarsimp simp: pred_conj_def)
-    apply (intro hoare_vcg_conj_lift_pre_fix; (solves handle_overrun_loop_simple)?)
-      apply wps_conj_solves
-     apply (wpsimp wp: handle_overrun_loop_refills_unat_sum_equals_budget)
-     apply (fastforce intro: valid_refills_refills_unat_sum_equals_budget
-                       simp: vs_all_heap_simps cfg_valid_refills_def round_robin_def
-                             sp_valid_refills_def)
-    apply (clarsimp simp: handle_overrun_loop_def)
-    apply (wpsimp wp: valid_whileLoop[where I="\<lambda>_ s. pred_map \<top> (scs_of s) (cur_sc s)"])
-     apply (fastforce simp: head_time_buffer_true_imp_unat_buffer vs_all_heap_simps
-                            word_less_nat_alt word_le_nat_alt)
-    apply (clarsimp simp: vs_all_heap_simps)
-   apply (find_goal \<open>match conclusion in "\<lbrace>P\<rbrace> handleOverrunLoop _ \<lbrace>Q\<rbrace>" for P Q \<Rightarrow> -\<close>)
-   apply wpsimp
-   apply (clarsimp simp: active_sc_at'_def obj_at_simps)
-
-  apply (clarsimp simp: get_refills_def)
-  apply (rule corres_underlying_split[rotated 2, OF get_sched_context_sp get_sc_sp'])
-   apply (corresKsimp corres: get_sc_corres
-                       simp: state_relation_def active_sc_at'_def obj_at_simps)
-  apply (rename_tac sc sc')
-  apply (rule_tac Q="\<lambda>_ s. ?P s
-                           \<and> pred_map (\<lambda>cfg. refills_unat_sum (scrc_refills cfg)
-                                              = unat (scrc_budget cfg))
-                                       (sc_refill_cfgs_of s) scPtr
-                           \<and> pred_map (\<lambda>cfg. MIN_BUDGET \<le> scrc_budget cfg)
-                                       (sc_refill_cfgs_of s) scPtr
-                           \<and> scPtr = cur_sc s"
-              and Q'="\<lambda>_ s'. valid_refills' scPtr s' \<and> active_sc_at' scPtr s' \<and> scPtr = ksCurSc s'"
-              and r'=dc
-               in corres_underlying_split[rotated])
-     apply (corresKsimp corres: headInsufficientLoop_corres)
-     apply (fastforce simp: vs_all_heap_simps word_le_nat_alt)
-    apply (intro hoare_vcg_conj_lift_pre_fix; (solves wpsimp)?)
-       apply schedule_used_simple
-       apply (clarsimp simp: obj_at_def is_sc_obj_def)
-      apply schedule_used_simple
-     apply (wpsimp wp: schedule_used_refills_unat_sum update_sched_context_wp
-                 simp: update_refill_hd_def)
-     apply (clarsimp simp: obj_at_def vs_all_heap_simps refills_unat_sum_cons
-                           refills_unat_sum_append)
-     apply (subst unat_sub)
-      apply fastforce
-     apply (clarsimp simp: word_less_nat_alt)
-     apply (drule less_imp_le)
-     apply (clarsimp simp: refills_unat_sum_def)
-     apply (case_tac "sc_refills sc"; clarsimp simp: refills_unat_sum_cons)
-    apply schedule_used_simple
-   apply wpsimp
-
-  apply (rule_tac F="refill_hd sc = refill_map (refillHd sc')" in corres_req)
-   apply clarsimp
-   apply (rule refill_hd_relation)
-     apply fastforce
-    apply (clarsimp simp: vs_all_heap_simps obj_at_def)
-   apply (fastforce simp: valid_refills'_def obj_at_simps opt_map_red opt_pred_def)
-
-  apply (clarsimp simp: maxReleaseTime_equiv)
-  apply (simp add: when_def split del: if_split)
-  apply (rule corres_if_split; (solves simp)?)
-   apply (clarsimp simp: refill_map_def)
-  apply (rule corres_symb_exec_l[rotated 2, OF get_sched_context_sp])
-    apply wpsimp
-    apply (clarsimp simp: obj_at_def)
-   apply (find_goal \<open>match conclusion in "\<lbrace>P\<rbrace> f \<exists>\<lbrace>Q\<rbrace>" for P f Q \<Rightarrow> -\<close>)
-   apply (wpsimp wp: get_sched_context_exs_valid)
-    apply (clarsimp simp: obj_at_def)
-   apply simp
-  apply (rename_tac new_sc)
-  apply (rule_tac F="new_sc=sc" in corres_req)
-   apply (clarsimp simp: obj_at_def)
-  apply (subst update_refill_hd_comp)
-  apply (clarsimp simp: bind_assoc)
-  apply (rule corres_guard_imp)
-    apply (rule corres_split[OF updateRefillHd_corres])
-        apply simp
-       apply (clarsimp simp: refill_map_def)
-      apply (rule corres_split[OF updateRefillHd_corres])
-          apply simp
-         apply (clarsimp simp: refill_map_def)
-        apply (rule scheduleUsed_corres)
-         apply simp
-        apply (clarsimp simp: refill_map_def sc_relation_def)
-       apply wpsimp
-      apply wpsimp
-     apply wpsimp
-    apply wpsimp
-   apply (clarsimp simp: is_active_sc_rewrite)
-  apply (fastforce simp: active_sc_at'_def is_active_sc'_def obj_at_simps opt_map_red)
-  done
-
-(* schedule_corres *)
-
-crunch setReprogramTimer
-  for valid_tcbs'[wp]: valid_tcbs'
-  and valid_refills'[wp]: "valid_refills' scPtr"
-  and ksCurSc[wp]: "\<lambda>s. P (ksCurSc s)"
-  (simp: valid_refills'_def)
-
-lemma checkDomainTime_corres:
-  "corres dc (valid_tcbs and weak_valid_sched_action and active_scs_valid and pspace_aligned
-              and pspace_distinct)
-             (valid_tcbs' and valid_queues and valid_queues' and valid_release_queue_iff)
-             check_domain_time
-             checkDomainTime"
-  apply (clarsimp simp: check_domain_time_def checkDomainTime_def)
-  apply (rule corres_guard_imp)
-    apply (rule corres_split[OF isCurDomainExpired_corres])
-      apply (rule corres_when)
-       apply simp
-      apply (rule corres_split[OF setReprogramTimer_corres])
-        apply (rule rescheduleRequired_corres)
-       apply (wpsimp wp: hoare_drop_imps
-                   simp: isCurDomainExpired_def)+
-  done
-
-crunch refill_budget_check_round_robin
-  for sc_at[wp]: "sc_at sc_ptr"
-  and valid_objs[wp]: valid_objs
-  and pspace_aligned[wp]: pspace_aligned
-  and pspace_distinct[wp]: pspace_distinct
-
-lemma commitTime_corres:
-  "corres dc (\<lambda>s. sc_at (cur_sc s) s \<and> valid_objs s \<and> pspace_aligned s \<and> pspace_distinct s
-                  \<and> (cur_sc_active s \<longrightarrow> valid_refills (cur_sc s) s))
-             (\<lambda>s'. is_active_sc' (ksCurSc s') s' \<longrightarrow> valid_refills' (ksCurSc s') s')
-             commit_time
-             commitTime"
-  supply if_split[split del]
-  apply (rule_tac Q="\<lambda>s'. sc_at' (ksCurSc s') s'" in corres_cross_add_guard)
-   apply (fastforce intro: sc_at_cross simp: state_relation_def)
-  apply (clarsimp simp: commit_time_def commitTime_def liftM_def)
-  apply (rule corres_underlying_split[rotated 2, OF gets_sp getCurSc_sp])
-   apply (corresKsimp corres: getCurSc_corres)
-  apply clarsimp
-  apply (rule corres_underlying_split[rotated 2, OF get_sched_context_sp get_sc_sp'])
-   apply (corresKsimp corres: get_sc_corres)
-  apply (rule corres_symb_exec_r[rotated, OF getIdleSC_sp])
-    apply wpsimp
-   apply (wpsimp simp: getIdleSC_def)
-  apply (rename_tac idleSCPtr)
-  apply (rule corres_underlying_split[rotated, where r'=dc])
-     apply (rule setConsumedTime_corres)
-     apply simp
-    apply wpsimp
-   apply wpsimp
-  apply (clarsimp simp: when_def)
-  apply (rule_tac F="idleSCPtr = idle_sc_ptr" in corres_req)
-   apply (clarsimp simp: state_relation_def)
-  apply (rule corres_if_split; fastforce?)
-   apply (fastforce simp: sc_relation_def active_sc_def)
-  apply (rule corres_underlying_split[rotated 2, OF gets_sp getConsumedTime_sp])
-   apply corresKsimp
-  apply clarsimp
-  apply (rename_tac consumed)
-  apply (rule_tac Q="\<lambda>_ s. sc_at (cur_sc s) s \<and> csc = cur_sc s"
-              and Q'="\<lambda>_ s'. sc_at' (ksCurSc s') s' \<and> csc = ksCurSc s'"
-              and r'=dc
-               in corres_underlying_split[rotated])
-     apply (clarsimp simp: updateSchedContext_def)
-     apply (rule corres_symb_exec_r[rotated, OF get_sc_sp'])
-       apply wpsimp
-      apply wpsimp
-     apply (rename_tac sc')
-     apply (prop_tac "(\<lambda>sc. sc\<lparr>sc_consumed := sc_consumed sc + consumed\<rparr>)
-                      = sc_consumed_update (\<lambda>c. c + consumed)")
-      apply force
-     apply (prop_tac "scConsumed_update (\<lambda>_. scConsumed sc' + consumed) sc'
-                      = scConsumed_update (\<lambda>c. c + consumed) sc'")
-      apply (fastforce intro: sched_context.expand)
-     apply (rule_tac P="\<lambda>t. corres dc _ _ (update_sched_context csc t) _" in subst[OF sym])
-      apply assumption
-     apply (rule_tac P="\<lambda>t. corres dc _ _ _ (setSchedContext csc t)" in subst[OF sym])
-      apply assumption
-     apply (rule corres_guard_imp)
-       apply (rule_tac f'="\<lambda>sched_context'. (scConsumed_update (\<lambda>c. c + consumed)) sched_context'"
-                    in setSchedContext_update_sched_context_no_stack_update_corres)
-          apply (clarsimp simp: sc_relation_def opt_map_red opt_map_def active_sc_def)
-         apply fastforce
-        apply (fastforce simp: obj_at_simps)
-       apply (wpsimp simp: isRoundRobin_def | wps)+
-  apply (clarsimp simp: ifM_def split: if_split)
-  apply (rule corres_underlying_split[rotated 2, OF is_round_robin_sp isRoundRobin_sp])
-   apply (corresKsimp corres: isRoundRobin_corres)
-  apply (corresKsimp corres: refillBudgetCheckRoundRobin_corres refillBudgetCheck_corres)
-  apply (fastforce simp: obj_at_def vs_all_heap_simps is_sc_obj_def obj_at_simps sc_relation_def
-                         is_active_sc'_def opt_map_red opt_pred_def active_sc_def)
-  done
-
-crunch ifCondRefillUnblockCheck
-  for valid_objs'[wp]: valid_objs'
-  (simp: crunch_simps)
-
-lemma switchSchedContext_corres:
-  "corres dc (\<lambda>s. valid_state s \<and> cur_tcb s \<and> sc_at (cur_sc s) s  \<and> active_scs_valid s
-                  \<and> current_time_bounded s \<and> active_sc_tcb_at (cur_thread s) s)
-             valid_objs'
-             switch_sched_context
-             switchSchedContext"
-  apply (clarsimp simp: valid_state_def)
-  apply add_cur_tcb'
-  apply (clarsimp simp: switch_sched_context_def switchSchedContext_def)
-  apply (rule corres_underlying_split[rotated 2, OF gets_sp getCurSc_sp])
-   apply (corresKsimp corres: getCurSc_corres)
-  apply (clarsimp, rename_tac curScPtr)
-  apply (rule corres_underlying_split[rotated 2, OF gets_sp getCurThread_sp])
-   apply corresKsimp
-  apply (clarsimp, rename_tac ct)
-  apply (rule corres_underlying_split[rotated 2, OF gsc_sp threadGet_sp, where r'="(=)"])
-   apply (rule corres_guard_imp)
-     apply (rule get_tcb_obj_ref_corres)
-     apply (fastforce simp: tcb_relation_def)
-    apply (fastforce simp: cur_tcb_def)
-   apply (fastforce simp: cur_tcb'_def)
-  apply (clarsimp, rename_tac ctScOpt)
-  apply (rule corres_symb_exec_l[rotated, OF _ assert_opt_sp])
-    apply wpsimp
-    apply (fastforce simp: obj_at_def pred_tcb_at_def vs_all_heap_simps)
-   apply wpsimp
-   apply (fastforce simp: obj_at_def pred_tcb_at_def vs_all_heap_simps)
-  apply (rename_tac scp)
-  apply (rule corres_symb_exec_l[rotated, OF _ get_sched_context_sp])
-    apply (rule get_sched_context_exs_valid)
-    apply (clarsimp simp: sc_at_pred_n_def obj_at_def is_sc_obj_def)
-    apply (rename_tac ko n, case_tac ko; clarsimp)
-   apply wpsimp
-   apply (clarsimp simp: sc_at_pred_n_def obj_at_def is_sc_obj_def)
-  apply (rename_tac ko n, case_tac ko; clarsimp)
-  apply (rule_tac F="the ctScOpt = scp" in corres_req, simp)
-  apply (rule_tac Q="\<lambda>_ s. sc_at (cur_sc s) s \<and> valid_objs s \<and> pspace_aligned s \<and> pspace_distinct s
-                           \<and> (cur_sc_active s \<longrightarrow> valid_refills (cur_sc s) s)"
-              and Q'="\<lambda>_. valid_objs'"
-              and r'=dc
-               in corres_underlying_split;
-         (solves wpsimp)?)
-    apply (clarsimp simp: when_def)
-    apply (rule corres_split_skip; (solves \<open>wpsimp wp: hoare_vcg_ex_lift\<close>)?)
-     apply (corresKsimp corres: setReprogramTimer_corres)
-    apply (corresKsimp corres: ifCondRefillUnblockCheck_corres)
-    apply (fastforce intro: valid_objs'_valid_refills' sc_at_cross is_active_sc'2_cross
-                            valid_sched_context_size_objsI
-                      simp: obj_at_def pred_tcb_at_def vs_all_heap_simps is_sc_obj_def opt_map_red
-                            opt_pred_def)
-   apply (rule corres_split_skip; (solves wpsimp)?)
-    apply (corresKsimp corres: getReprogramTimer_corres)
-   apply (rule_tac Q="\<top>\<top>" and Q'="\<top>\<top>" and r'=dc in corres_underlying_split; (solves wpsimp)?)
-    apply (corresKsimp corres: commitTime_corres)
-    apply (fastforce intro!: valid_objs'_valid_refills' sc_at_cross
-                       simp: state_relation_def)
-   apply (corresKsimp corres: setCurSc_corres)
-  apply (wpsimp wp: hoare_vcg_imp_lift' | wps)+
-  apply (fastforce intro: valid_sched_context_size_objsI active_scs_validE
-                    simp: obj_at_def is_sc_obj_def)
-  done
-
-lemma commit_time_active_sc_tcb_at[wp]:
-  "commit_time \<lbrace>active_sc_tcb_at t\<rbrace>"
-  by (wpsimp simp: commit_time_def)
-
-crunch switch_sched_context
-  for active_sc_tcb_at[wp]: "active_sc_tcb_at t"
-  and not_in_release_q[wp]: "\<lambda>s. t \<notin> set (release_queue s)"
-  and pspace_aligned[wp]: pspace_aligned
-  and pspace_distinct[wp]: pspace_distinct
-  (wp: crunch_wps simp: crunch_simps)
-
-crunch schedule_choose_new_thread
-  for sc_at[wp]: "sc_at sc_ptr"
-  (wp: crunch_wps dxo_wp_weak simp: crunch_simps)
-
-lemma scAndTimer_corres:
-  "corres dc (\<lambda>s. valid_state s \<and> cur_tcb s \<and> sc_at (cur_sc s) s
-                  \<and> active_scs_valid s \<and> valid_release_q s
-                  \<and> current_time_bounded s \<and> active_sc_tcb_at (cur_thread s) s)
-             invs'
-             sc_and_timer
-             scAndTimer"
-  apply (clarsimp simp: sc_and_timer_def scAndTimer_def)
-  apply (rule corres_guard_imp)
-    apply (rule corres_split[OF switchSchedContext_corres])
-      apply (rule corres_split[OF getReprogramTimer_corres])
-        apply (clarsimp simp: when_def)
-        apply (rule corres_split[OF setNextInterrupt_corres])
-          apply (rule setReprogramTimer_corres)
-         apply (wpsimp wp: hoare_vcg_ball_lift2| wps)+
-     apply (rule_tac Q'="\<lambda>_.invs" in hoare_post_imp, fastforce)
-     apply wpsimp+
-    apply (rule_tac Q'="\<lambda>_. invs'" in hoare_post_imp, fastforce)
-    apply (wpsimp wp: switchSchedContext_invs')
-   apply (clarsimp simp: valid_state_def valid_release_q_def)
-  apply fastforce
-  done
-
-lemma tcb_sched_action_valid_state[wp]:
-  "tcb_sched_action action thread \<lbrace>valid_state\<rbrace>"
-  by (wpsimp simp: tcb_sched_action_def set_tcb_queue_def get_tcb_queue_def valid_state_def
-               wp: hoare_drop_imps hoare_vcg_all_lift)
-
-crunch setQueue, addToBitmap
-  for isSchedulable_bool[wp]: "isSchedulable_bool tcbPtr"
-  (simp: bitmap_fun_defs isSchedulable_bool_def isScActive_def)
-
-lemma tcbSchedEnqueue_isSchedulable_bool[wp]:
-  "tcbSchedEnqueue tcbPtr \<lbrace>isSchedulable_bool tcbPtr'\<rbrace>"
-  apply (clarsimp simp: tcbSchedEnqueue_def unless_def)
-  apply (rule bind_wp_fwd_skip, wpsimp)+
-  apply (rule hoare_when_cases, simp)
-  apply (rule bind_wp_fwd_skip, wpsimp)+
-  apply (wpsimp wp: threadSet_wp)
-  apply (fastforce simp: obj_at_simps isSchedulable_bool_def pred_map_simps opt_map_def
-                         isScActive_def
-                  split: option.splits)
-  done
-
-lemma schedule_switch_thread_branch_sc_at_cur_sc:
-  "\<lbrace>valid_objs and cur_sc_tcb\<rbrace>
-   schedule_switch_thread_branch candidate ct ct_schdlble
-   \<lbrace>\<lambda>_ s. sc_at (cur_sc s) s\<rbrace>"
-  apply (rule hoare_weaken_pre)
-   apply (rule_tac f=cur_sc in hoare_lift_Pf2)
-    apply (wpsimp simp: schedule_switch_thread_fastfail_def wp: hoare_drop_imps)+
-  apply (fastforce intro: cur_sc_tcb_sc_at_cur_sc)
-  done
-
-lemma schedule_switch_thread_branch_valid_state_and_cur_tcb:
-  "\<lbrace>\<lambda>s. invs s \<and> scheduler_action s = switch_thread candidate\<rbrace>
-   schedule_switch_thread_branch candidate ct ct_schdlble
-   \<lbrace>\<lambda>_ s. valid_state s \<and> cur_tcb s\<rbrace>"
-  apply (wpsimp simp: schedule_switch_thread_fastfail_def set_scheduler_action_def
-                  wp: switch_to_thread_invs thread_get_inv hoare_drop_imps)
-  done
-
-lemma schedule_corres:
-  "corres dc (invs and valid_sched and current_time_bounded and ct_ready_if_schedulable
-              and (\<lambda>s. schact_is_rct s \<longrightarrow> cur_sc_active s))
-             invs'
-             (Schedule_A.schedule)
-             schedule"
-  apply add_sch_act_wf
-  apply add_cur_tcb'
-  apply (clarsimp simp: Schedule_A.schedule_def schedule_def sch_act_wf_asrt_def cur_tcb'_asrt_def)
-  apply (rule corres_stateAssert_add_assertion[rotated], simp)+
-  apply (rule corres_split_skip)
-     apply (wpsimp wp: awaken_valid_sched hoare_vcg_imp_lift')
-     apply fastforce
-    apply (wpsimp wp: awaken_invs')
-   apply (corresKsimp corres: awaken_corres)
-   apply (fastforce intro: weak_sch_act_wf_at_cross
-                     simp: invs_def valid_state_def)
-  apply (rule corres_split_skip)
-     apply (wpsimp wp: hoare_vcg_imp_lift' cur_sc_active_lift)
-    apply wpsimp
-   apply (corresKsimp corres: checkDomainTime_corres)
-   apply (fastforce intro: weak_sch_act_wf_at_cross
-                     simp: invs_def valid_state_def)
-  apply (rule corres_underlying_split[rotated 2, OF gets_sp getCurThread_sp])
-   apply corresKsimp
-  apply (rule corres_underlying_split[rotated 2, OF is_schedulable_sp' isSchedulable_sp])
-   apply (corresKsimp corres: isSchedulable_corres)
-   apply (fastforce intro: weak_sch_act_wf_at_cross
-                     simp: invs_def valid_state_def state_relation_def cur_tcb_def)
-  apply (rule corres_underlying_split[rotated 2, OF gets_sp getSchedulerAction_sp])
-   apply (corresKsimp corres: getSchedulerAction_corres)
-
-  apply (case_tac "action = resume_cur_thread"; clarsimp)
-   apply (corresKsimp corres: scAndTimer_corres)
-   subgoal by (fastforce intro: valid_sched_context_size_objsI
-                          dest: schact_is_rct_ct_active_sc
-                          simp: invs_def cur_sc_tcb_def sc_at_pred_n_def obj_at_def is_sc_obj_def
-                                valid_state_def valid_sched_def)
-
-  apply (case_tac "action = choose_new_thread")
-   apply (clarsimp simp: bind_assoc)
-   apply (rule corres_guard_imp)
-     apply (rule corres_split[OF corres_when])
-         apply simp
-        apply (rule tcbSchedEnqueue_corres)
-       apply (rule corres_split[OF scheduleChooseNewThread_corres])
-         apply (rule scAndTimer_corres)
-        apply (subst conj_assoc[symmetric])
-        apply ((wpsimp wp: schedule_choose_new_thread_valid_state_cur_tcb
-                           schedule_choose_new_thread_active_sc_tcb_at_cur_thread
-               | rule_tac f=cur_sc in hoare_lift_Pf2
-               | rule_tac f=cur_thread in hoare_lift_Pf2)+)[1]
-       apply (wpsimp wp: scheduleChooseNewThread_invs')
-      apply (wpsimp | wps)+
-    subgoal by (fastforce intro!: cur_sc_tcb_sc_at_cur_sc valid_sched_context_size_objsI
-                            simp: schedulable_def2 pred_tcb_at_def obj_at_def get_tcb_def
-                                  invs_def cur_tcb_def is_tcb_def ct_ready_if_schedulable_def
-                                  vs_all_heap_simps valid_sched_def)
-   apply (fastforce simp: invs'_def isSchedulable_bool_def st_tcb_at'_def pred_map_simps
-                          obj_at_simps cur_tcb'_def
-                   elim!: opt_mapE)
-
-  apply (case_tac action; clarsimp)
-  apply (rule corres_underlying_split[OF _ scAndTimer_corres, where r'=dc])
-
-    apply (find_goal \<open>match conclusion in "\<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>" for P f Q  \<Rightarrow> -\<close>)
-    apply (subst bind_dummy_ret_val)+
-    apply (subst conj_assoc[symmetric])
-    apply (rule hoare_vcg_conj_lift_pre_fix)
-     apply (wpsimp wp: schedule_switch_thread_branch_valid_state_and_cur_tcb)
-    apply (intro hoare_vcg_conj_lift_pre_fix;
-           (solves \<open>wpsimp simp: schedule_switch_thread_fastfail_def
-                             wp: thread_get_inv hoare_drop_imps\<close>)?)
-     apply (wpsimp wp: schedule_switch_thread_branch_sc_at_cur_sc)
-     apply fastforce
-    apply (wpsimp wp: schedule_switch_thread_branch_active_sc_tcb_at_cur_thread)
-    apply (fastforce simp: valid_sched_def valid_sched_action_def weak_valid_sched_action_def
-                           vs_all_heap_simps)
-
-   apply (find_goal \<open>match conclusion in "\<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>" for P f Q  \<Rightarrow> -\<close>)
-   apply (rename_tac target)
-   apply (rule_tac Q'="\<lambda>_ s. invs' s \<and> curThread = ksCurThread s \<and> st_tcb_at' runnable' target s"
-                in bind_wp_fwd)
-    apply wpsimp
-    apply (clarsimp simp: invs'_def isSchedulable_bool_def st_tcb_at'_def pred_map_simps
-                          obj_at_simps cur_tcb'_def sch_act_wf_cases
-                   elim!: opt_mapE
-                   split: scheduler_action.splits)
-   apply (rule bind_wp_fwd_skip, solves wpsimp)+
-   apply (wpsimp wp: scheduleChooseNewThread_invs' ksReadyQueuesL1Bitmap_return_wp
-               simp: isHighestPrio_def scheduleSwitchThreadFastfail_def)
-
-  apply (rename_tac candidate)
-  apply (rule corres_split_skip[where r'="(=)"])
-     apply wpsimp
-     apply (clarsimp simp: schedulable_def2 pred_tcb_at_def obj_at_def valid_sched_def
-                           ct_ready_if_schedulable_def vs_all_heap_simps)
-    apply wpsimp
-    apply (clarsimp simp: invs'_def isSchedulable_bool_def st_tcb_at'_def pred_map_simps
-                          obj_at_simps vs_all_heap_simps cur_tcb'_def
-                   elim!: opt_mapE)
-   apply (corresKsimp corres: tcbSchedEnqueue_corres)
-   apply (fastforce dest: invs_cur
-                    simp: cur_tcb_def)
-
-  apply (rule corres_underlying_split[rotated 2, OF gets_sp getIdleThread_sp])
-   apply corresKsimp
-  apply (rule corres_underlying_split[rotated 2, OF thread_get_sp threadGet_sp, where r'="(=)"])
-   apply (rule corres_guard_imp)
-     apply (rule threadGet_corres)
-     apply (clarsimp simp: tcb_relation_def)
-    apply (fastforce simp: valid_sched_def valid_sched_action_def weak_valid_sched_action_def
-                           vs_all_heap_simps obj_at_def is_tcb_def)
-   apply (clarsimp simp: sch_act_wf_cases split: scheduler_action.splits)
-
-  apply (rule_tac Q="\<lambda>_ s. invs s \<and> valid_ready_qs s \<and> ready_or_release s
-                           \<and> pred_map runnable (tcb_sts_of s) candidate
-                           \<and> released_sc_tcb_at candidate s \<and> not_in_release_q candidate s"
-              and Q'="\<lambda>_ s. invs' s \<and> cur_tcb' s \<and> curThread = ksCurThread s
-                            \<and> st_tcb_at' runnable' candidate s"
-              and r'="(=)"
-               in corres_underlying_split)
-     apply clarsimp
-     apply (rule corres_guard_imp)
-       apply (rule threadGet_corres)
-       apply (clarsimp simp: tcb_relation_def)
-      apply clarsimp
-     apply (clarsimp simp: cur_tcb'_def)
-
-    apply (find_goal \<open>match conclusion in "\<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>" for P f Q  \<Rightarrow> -\<close>)
-    apply (wpsimp wp: thread_get_wp)
-    apply (clarsimp simp: valid_sched_def valid_sched_action_def weak_valid_sched_action_def
-                          in_queue_2_def)
-
-   apply (find_goal \<open>match conclusion in "\<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>" for P f Q  \<Rightarrow> -\<close>)
-   apply (wpsimp wp: threadGet_wp)
-   apply (clarsimp simp: cur_tcb'_def obj_at_simps sch_act_wf_cases
-                  split: scheduler_action.splits)
-
-  apply (rule corres_underlying_split[rotated 2, OF schedule_switch_thread_fastfail_inv
-                                          scheduleSwitchThreadFastfail_inv])
-   apply (corresKsimp corres: scheduleSwitchThreadFastfail_corres)
-   apply (fastforce dest: invs_cur
-                    simp: cur_tcb_def obj_at_def is_tcb_def state_relation_def cur_tcb'_def)
-  apply (rule corres_underlying_split[rotated 2, OF gets_sp curDomain_sp])
-   apply (corresKsimp corres: curDomain_corres)
-  apply (clarsimp simp: isHighestPrio_def' split del: if_split)
-
-  apply (rule corres_underlying_split[rotated 2, OF gets_sp gets_sp, where r'="(=)"])
-   apply (corresKsimp corres: isHighestPrio_corres)
-   apply (clarsimp simp: is_highest_prio_def)
-   apply (subst bitmapL1_zero_ksReadyQueues)
-     apply (fastforce dest: invs_queues simp: valid_queues_def)
-    apply (fastforce dest: invs_queues simp: valid_queues_def)
-   apply (rule disj_cong)
-    apply (fastforce simp: ready_queues_relation_def dest!: state_relationD)
-   apply clarsimp
-   apply (subst lookupBitmapPriority_Max_eqI)
-      apply (fastforce dest: invs_queues simp: valid_queues_def)
-     apply (fastforce dest: invs_queues simp: valid_queues_def)
-    apply (subst bitmapL1_zero_ksReadyQueues)
-      apply (fastforce dest: invs_queues simp: valid_queues_def)
-     apply (fastforce dest: invs_queues simp: valid_queues_def)
-    apply (fastforce simp: ready_queues_relation_def dest!: state_relationD)
-   apply (clarsimp simp: ready_queues_relation_def dest!: state_relationD)
-
-  apply (rule corres_if_split; (solves simp)?)
-   apply (rule corres_guard_imp)
-     apply (rule corres_split[OF tcbSchedEnqueue_corres])
-       apply clarsimp
-       apply (rule corres_split[OF setSchedulerAction_corres])
-          apply (clarsimp simp: sched_act_relation_def)
-         apply (rule scheduleChooseNewThread_corres)
-        apply wpsimp+
-    apply (fastforce simp: obj_at_def vs_all_heap_simps is_tcb_def pred_tcb_at_def)
-   apply fastforce
-
-  apply (rule corres_if_split; (solves simp)?)
-   apply (rule corres_guard_imp)
-     apply (rule corres_split[OF tcbSchedAppend_corres])
-       apply clarsimp
-       apply (rule corres_split[OF setSchedulerAction_corres])
-          apply (clarsimp simp: sched_act_relation_def)
-         apply (rule scheduleChooseNewThread_corres)
-        apply wpsimp+
-    apply (fastforce simp: obj_at_def vs_all_heap_simps is_tcb_def pred_tcb_at_def)
-   apply fastforce
-
-  apply (rule corres_guard_imp)
-    apply (rule corres_split[OF switchToThread_corres])
-      apply clarsimp
-      apply (rule setSchedulerAction_corres)
-      apply (clarsimp simp: sched_act_relation_def)
-     apply wpsimp
-    apply wpsimp
-   apply (clarsimp simp: pred_conj_def)
-   apply (fastforce simp: obj_at_def vs_all_heap_simps pred_tcb_at_def)
-  apply fastforce
+    apply (rule corres_split[OF curDomain_corres], simp)
+      apply (rule corres_split)
+         apply (rule ethreadget_corres[where r="(=)"])
+         apply (clarsimp simp: etcb_relation_def)
+        apply (rule corres_split[OF getSchedulerAction_corres])
+          apply (rule corres_if, simp)
+           apply (rule tcbSchedEnqueue_corres, simp)
+          apply (rule corres_if, simp)
+            apply (case_tac action; simp)
+           apply (rule corres_split[OF rescheduleRequired_corres])
+             apply (rule tcbSchedEnqueue_corres, simp)
+            apply (wp reschedule_required_valid_queues | strengthen valid_objs'_valid_tcbs')+
+          apply (rule setSchedulerAction_corres, simp)
+         apply (wpsimp simp: if_apply_def2
+                       wp: hoare_drop_imp[where f="ethread_get a b" for a b])+
+      apply (wp hoare_drop_imps)[1]
+     apply wp+
+   apply (clarsimp simp: valid_sched_def invs_def valid_state_def cur_tcb_def st_tcb_at_tcb_at
+                          valid_sched_action_def weak_valid_sched_action_def
+                          tcb_at_is_etcb_at[OF st_tcb_at_tcb_at[rotated]])
+  apply (fastforce simp: tcb_at_is_etcb_at)
   done
 
 end
-
-lemma schedContextDonate_valid_queues[wp]:
-  "\<lbrace>valid_queues and valid_objs'\<rbrace> schedContextDonate scPtr tcbPtr \<lbrace>\<lambda>_. valid_queues\<rbrace>"
-  (is "valid ?pre _ _")
-  apply (clarsimp simp: schedContextDonate_def)
-  apply (rule bind_wp[OF _ get_sc_sp'])
-  apply (rule_tac Q'="\<lambda>_. ?pre" in bind_wp_fwd)
-   apply (rule hoare_when_cases, clarsimp)
-   apply (rule_tac Q'="\<lambda>_. ?pre" in bind_wp_fwd)
-    apply (wpsimp wp: tcbSchedDequeue_valid_queues)
-    apply (fastforce intro: valid_objs'_maxDomain valid_objs'_maxPriority)
-   apply (rule bind_wp_fwd_skip)
-    apply (wpsimp wp: tcbReleaseRemove_valid_queues)
-   apply (rule bind_wp_fwd_skip)
-    apply (wpsimp wp: threadSet_valid_queues_new threadSet_valid_objs')
-    apply (clarsimp simp: obj_at'_def inQ_def valid_tcb'_def tcb_cte_cases_def)
-   apply (wpsimp wp: rescheduleRequired_valid_queues)
-   apply fastforce
-  apply (wpsimp wp: threadSet_valid_queues_new hoare_vcg_all_lift hoare_vcg_imp_lift')
-  apply (clarsimp simp: obj_at'_def inQ_def)
-  done
-
-lemma schedContextDonate_valid_queues'[wp]:
-  "schedContextDonate sc t \<lbrace>valid_queues'\<rbrace>"
-  apply (clarsimp simp: schedContextDonate_def)
-  apply (rule bind_wp_fwd_skip, solves wpsimp)
-  apply (rule bind_wp_fwd_skip)
-   apply (rule hoare_when_cases, simp)
-   apply ((rule bind_wp_fwd_skip
-           , wpsimp wp: threadSet_valid_queues' hoare_vcg_imp_lift' simp: inQ_def)
-          | wpsimp wp: threadSet_valid_queues' hoare_vcg_imp_lift' simp: inQ_def)+
-  done
-
-crunch tcbSchedDequeue
-  for ksReleaseQueue[wp]: "\<lambda>s. P (ksReleaseQueue s)"
-
-crunch schedContextDonate
-  for vrq[wp]: valid_release_queue
-  and vrq'[wp]: valid_release_queue'
-  (wp: threadSet_vrq_inv threadSet_vrq'_inv simp: crunch_simps)
-
-crunch schedContextDonate
-  for ex_nonz_cap_to'[wp]: "ex_nonz_cap_to' ptr"
-  (wp: threadSet_cap_to simp: tcb_cte_cases_def)
-
-crunch schedContextDonate
-  for valid_irq_handlers'[wp]: "\<lambda>s. valid_irq_handlers' s"
-  and valid_mdb'[wp]: valid_mdb'
-  (ignore: threadSet
-     simp: comp_def valid_mdb'_def crunch_simps
-       wp: valid_irq_handlers_lift'' threadSet_ctes_of)
-
-crunch schedContextDonate
-  for sch_act_sane[wp]: sch_act_sane
-  and sch_act_simple[wp]: sch_act_simple
-  and sch_act_not[wp]: "sch_act_not t"
-  (wp: crunch_wps simp: crunch_simps rule: sch_act_sane_lift)
-
-crunch schedContextDonate
-  for no_0_obj'[wp]: no_0_obj'
-  and ksInterruptState[wp]: "\<lambda>s. P (ksInterruptState s)"
-  and if_unsafe_then_cap'[wp]: "if_unsafe_then_cap'"
-  and valid_global_refs'[wp]: "valid_global_refs'"
-  and valid_arch_state'[wp]: "valid_arch_state'"
-  and valid_irq_node'[wp]: "\<lambda>s. valid_irq_node' (irq_node' s) s"
-  and valid_irq_states'[wp]: "\<lambda>s. valid_irq_states' s"
-  and valid_machine_state'[wp]: "\<lambda>s. valid_machine_state' s"
-  and ct_not_inQ[wp]: "ct_not_inQ"
-  and ct_idle_or_in_cur_domain'[wp]: "ct_idle_or_in_cur_domain'"
-  and valid_pde_mappings'[wp]: "\<lambda>s. valid_pde_mappings' s"
-  and pspace_domain_valid[wp]: "\<lambda>s. pspace_domain_valid s"
-  and irqs_masked'[wp]: "\<lambda>s. irqs_masked' s"
-  and cur_tcb'[wp]: "cur_tcb'"
-  and urz[wp]: untyped_ranges_zero'
-  and valid_dom_schedule'[wp]: valid_dom_schedule'
-  and reply_projs[wp]: "\<lambda>s. P (replyNexts_of s) (replyPrevs_of s) (replyTCBs_of s) (replySCs_of s)"
-  and valid_replies' [wp]: valid_replies'
-  and pspace_bounded'[wp]: "pspace_bounded'"
-  (simp: comp_def tcb_cte_cases_def crunch_simps
-     wp: threadSet_not_inQ hoare_vcg_imp_lift' valid_irq_node_lift
-         setQueue_cur threadSet_ifunsafe'T threadSet_cur crunch_wps
-         cur_tcb_lift valid_dom_schedule'_lift valid_replies'_lift)
-
-lemma schedContextDonate_valid_pspace':
-  "\<lbrace>valid_pspace' and tcb_at' tcbPtr\<rbrace> schedContextDonate scPtr tcbPtr \<lbrace>\<lambda>_. valid_pspace'\<rbrace>"
-  by (wpsimp wp: schedContextDonate_valid_objs' simp: valid_pspace'_def)
-
-lemma schedContextDonate_if_live_then_nonz_cap':
-  "\<lbrace>\<lambda>s. if_live_then_nonz_cap' s \<and> valid_objs' s \<and>
-        ex_nonz_cap_to' tcbPtr s \<and> ex_nonz_cap_to' scPtr s\<rbrace>
-   schedContextDonate scPtr tcbPtr
-   \<lbrace>\<lambda>_. if_live_then_nonz_cap'\<rbrace>"
-  unfolding schedContextDonate_def
-  by (wpsimp wp: threadSet_iflive'T setSchedContext_iflive' hoare_vcg_all_lift threadSet_cap_to'
-           simp: conj_ac cong: conj_cong | wp hoare_drop_imps | fastforce simp: tcb_cte_cases_def)+
-
-(* `obj_at' (\<lambda>x. scTCB x \<noteq> Some idle_thread_ptr) scPtr s` is
-   needed because sometimes sym_refs doesn't hold in its entirety here. *)
-lemma schedContextDonate_invs':
-  "\<lbrace>\<lambda>s. invs' s \<and> bound_sc_tcb_at' ((=) None) tcbPtr s \<and>
-        ex_nonz_cap_to' scPtr s \<and> ex_nonz_cap_to' tcbPtr s\<rbrace>
-   schedContextDonate scPtr tcbPtr
-   \<lbrace>\<lambda>_. invs'\<rbrace>"
-  apply (simp only: invs'_def)
-  apply (rule_tac E="\<lambda>s. sc_at' scPtr s" in hoare_strengthen_pre_via_assert_backward)
-   apply (simp only: schedContextDonate_def)
-   apply (rule bind_wp[OF _ get_sc_sp'])
-   apply (rule_tac hoare_weaken_pre[OF hoare_pre_cont])
-   apply (clarsimp simp: obj_at'_def)
-  apply (wp schedContextDonate_valid_pspace'
-            schedContextDonate_valid_queues schedContextDonate_valid_queues'
-            schedContextDonate_if_live_then_nonz_cap')
-  apply (clarsimp simp: obj_at'_def projectKO_eq projectKO_sc)
-  apply (auto dest!: global'_sc_no_ex_cap
-              simp: ko_wp_at'_def obj_at'_def projectKO_eq projectKO_tcb
-                    pred_tcb_at'_def)
-  done
-
-lemma tcbSchedDequeue_notksQ:
-  "tcbSchedDequeue t \<lbrace>\<lambda>s. t' \<notin> set(ksReadyQueues s p)\<rbrace>"
-  apply (simp add: tcbSchedDequeue_def)
-  apply (wp hoare_when_weak_wp)
-     apply (rule_tac Q'="\<lambda>_ s. t' \<notin> set(ksReadyQueues s p)" in hoare_post_imp)
-      apply wpsimp+
-  done
-
-lemma tcbSchedDequeue_nonq:
-  "\<lbrace>\<lambda>s. if t=t' then valid_queues s else t' \<notin> set (ksReadyQueues s p)\<rbrace>
-   tcbSchedDequeue t
-   \<lbrace>\<lambda>_ s. t' \<notin> set (ksReadyQueues s p)\<rbrace>"
-  unfolding tcbSchedDequeue_def
-  apply (wpsimp wp: threadGet_wp)
-  apply (case_tac p)
-  apply (fastforce simp: valid_queues_def valid_queues_no_bitmap_def obj_at'_def inQ_def
-                  split: if_splits)
-  done
-
-crunch tcbReleaseRemove
-  for not_queued[wp]: "\<lambda>s. t' \<notin> set (ksReadyQueues s p)"
-  (wp: crunch_wps simp: crunch_simps)
-
-lemma reprogram_timer_corres:
-   "corres dc \<top> \<top>
-      (modify (reprogram_timer_update (\<lambda>_. True)))
-      (setReprogramTimer True)"
-  unfolding setReprogramTimer_def
-  by (rule corres_modify) (simp add: state_relation_def swp_def)
-
-lemma release_queue_corres:
-  "corres (=) \<top> \<top> (gets release_queue) getReleaseQueue"
-  by (simp add: getReleaseQueue_def state_relation_def release_queue_relation_def)
-
-lemma tcbReleaseRemove_corres:
-  "t = t' \<Longrightarrow>
-   corres dc (pspace_aligned and pspace_distinct and tcb_at t) \<top>
-             (tcb_release_remove t) (tcbReleaseRemove t')"
-  unfolding tcb_release_remove_def tcbReleaseRemove_def tcb_sched_dequeue_def setReleaseQueue_def
-  apply clarsimp
-  apply (rule stronger_corres_guard_imp)
-    apply (rule_tac r'="(=)" in corres_split)
-       apply (rule release_queue_corres)
-      apply (rule corres_split)
-         apply (rule corres_when)
-          apply clarsimp
-         apply (rule reprogram_timer_corres)
-        apply (rule corres_add_noop_lhs2)
-        apply (rule corres_split)
-           apply (rule corres_modify)
-           apply (auto simp: release_queue_relation_def state_relation_def swp_def)[1]
-          apply (rule threadSet_corres_noop; clarsimp simp: tcb_relation_def)
-         apply wp
-        apply wp
-       apply clarsimp
-       apply wp
-      apply (rule when_wp)
-      apply clarsimp
-      apply wp
-     apply wp
-    apply clarsimp
-    apply wpsimp
-   apply simp
-   apply metis
-  apply (fastforce simp: state_relation_def tcb_at_cross)
-  done
-
-lemma threadSet_valid_queues_no_state:
-  "\<lbrace>valid_queues and (\<lambda>s. \<forall>p. t \<notin> set (ksReadyQueues s p))\<rbrace>
-   threadSet f t
-   \<lbrace>\<lambda>_. valid_queues\<rbrace>"
-  apply (simp add: threadSet_def)
-  apply wp
-   apply (simp add: valid_queues_def valid_queues_no_bitmap_def' pred_tcb_at'_def)
-   apply (wp hoare_Ball_helper
-             hoare_vcg_all_lift
-             setObject_tcb_strongest)[1]
-  apply (wp getObject_tcb_wp)
-  apply (clarsimp simp: valid_queues_def valid_queues_no_bitmap_def' pred_tcb_at'_def)
-  apply (clarsimp simp: obj_at'_def)
-  done
-
-lemma threadSet_valid_queues'_no_state:
-  "(\<And>tcb. tcbQueued tcb = tcbQueued (f tcb)) \<Longrightarrow>
-   \<lbrace>valid_queues' and (\<lambda>s. \<forall>p. t \<notin> set (ksReadyQueues s p))\<rbrace>
-   threadSet f t
-   \<lbrace>\<lambda>_. valid_queues'\<rbrace>"
-  apply (simp add: valid_queues'_def threadSet_def obj_at'_real_def
-                split del: if_split)
-  apply (simp only: imp_conv_disj)
-  apply (wp hoare_vcg_all_lift hoare_vcg_disj_lift)
-     apply (wp setObject_ko_wp_at | simp add: objBits_simps')+
-    apply (wp getObject_tcb_wp updateObject_default_inv
-               | simp split del: if_split)+
-  apply (clarsimp simp: obj_at'_def ko_wp_at'_def projectKOs
-                        objBits_simps addToQs_def
-             split del: if_split cong: if_cong)
-  apply (fastforce simp: projectKOs inQ_def split: if_split_asm)
-  done
-
-lemma setQueue_valid_tcbs'[wp]:
-  "setQueue qdom prio q \<lbrace>valid_tcbs'\<rbrace>"
-  unfolding valid_tcbs'_def
-  apply (wpsimp wp: hoare_vcg_all_lift hoare_vcg_imp_lift')
-  done
-
-lemma removeFromBitmap_valid_tcbs'[wp]:
-  "removeFromBitmap tdom prio \<lbrace>valid_tcbs'\<rbrace>"
-  apply (wpsimp simp: valid_tcbs'_def bitmap_fun_defs)
-  done
-
-lemma tcbSchedDequeue_valid_tcbs'[wp]:
-  "tcbSchedDequeue tcbPtr \<lbrace>valid_tcbs'\<rbrace>"
-  apply (clarsimp simp: tcbSchedDequeue_def)
-  apply (rule bind_wp_fwd_skip, wpsimp)
-  apply (clarsimp simp: when_def)
-  apply (rule bind_wp_fwd_skip, wpsimp)+
-  apply (wpsimp wp: threadSet_valid_tcbs')
-  done
-
-lemma schedContextDonate_corres_helper:
-  "(case rv' of SwitchToThread x \<Rightarrow> when (x = t \<or> t = cur) rescheduleRequired
-                             | _ \<Rightarrow> when (t = cur) rescheduleRequired) =
-   (when (t = cur \<or> (case rv' of SwitchToThread x \<Rightarrow> t = x | _ \<Rightarrow> False)) rescheduleRequired)"
-  by (case_tac rv'; clarsimp simp: when_def)
-
-crunch tcbReleaseRemove
-  for valid_tcbs'[wp]: valid_tcbs'
-  (wp: crunch_wps)
-
-lemma schedContextDonate_corres:
-  "corres dc (sc_at scp and tcb_at thread and weak_valid_sched_action and pspace_aligned and
-              pspace_distinct and valid_objs and active_scs_valid)
-             (valid_objs' and valid_queues and valid_queues' and
-              valid_release_queue and valid_release_queue')
-             (sched_context_donate scp thread)
-             (schedContextDonate scp thread)"
-  apply (simp add: test_reschedule_def get_sc_obj_ref_def set_tcb_obj_ref_thread_set
-                   schedContextDonate_def sched_context_donate_def schedContextDonate_corres_helper)
-  apply (rule stronger_corres_guard_imp)
-    apply (rule corres_split [OF get_sc_corres])
-      apply (rule corres_split [OF corres_when2])
-          apply (clarsimp simp: sc_relation_def)
-         apply (rule corres_assert_opt_assume_l)
-         apply (rule corres_split_nor)
-            apply (rule_tac x="the (sc_tcb sc)" and x'="the (scTCB sca)" in lift_args_corres)
-             apply (rule tcbSchedDequeue_corres)
-            apply (clarsimp simp: sc_relation_def)
-           apply (rule corres_split_nor)
-              apply (rule tcbReleaseRemove_corres)
-              apply (clarsimp simp: sc_relation_def)
-             apply (rule corres_split_nor)
-                apply (rule_tac x="the (sc_tcb sc)" and x'="the (scTCB sca)" in lift_args_corres)
-                 apply (rule threadset_corresT)
-                   apply (clarsimp simp: tcb_relation_def)
-                  apply (clarsimp simp: tcb_cap_cases_def)
-                 apply (clarsimp simp: tcb_cte_cases_def)
-                apply (clarsimp simp: sc_relation_def)
-               apply (rule corres_split_eqr)
-                  apply (rule getCurThread_corres)
-                 apply (rule_tac r'=sched_act_relation in corres_split)
-                    apply (rule getSchedulerAction_corres)
-                   apply (rule corres_when)
-                    apply (case_tac rv; clarsimp simp: sched_act_relation_def sc_relation_def)
-                   apply (rule rescheduleRequired_corres_weak)
-                  apply wpsimp
-                 apply wpsimp
-                apply wpsimp
-               apply wpsimp
-              apply (wpsimp wp: hoare_drop_imps)
-             apply (wpsimp wp: hoare_drop_imps
-                               threadSet_valid_release_queue threadSet_valid_release_queue'
-                               threadSet_valid_queues_no_state threadSet_valid_queues'_no_state)
-            apply (wpsimp | strengthen weak_valid_sched_action_strg)+
-           apply (rule_tac Q'="\<lambda>_. tcb_at' (the (scTCB sca)) and valid_tcbs' and
-                                  valid_queues and valid_queues' and
-                                  valid_release_queue and valid_release_queue' and
-                                  (\<lambda>s. \<forall>d p. the (scTCB sca) \<notin> set (ksReadyQueues s (d, p)))"
-                        in hoare_strengthen_post[rotated])
-            apply (clarsimp simp: valid_release_queue'_def obj_at'_def)
-           apply (wpsimp wp: tcbReleaseRemove_valid_queues hoare_vcg_all_lift)
-          apply (wpsimp wp: hoare_vcg_all_lift hoare_vcg_imp_lift')
-         apply (wpsimp wp: tcbSchedDequeue_valid_queues hoare_vcg_all_lift tcbSchedDequeue_nonq)
-        apply (rule corres_split
-                   [OF update_sc_no_reply_stack_update_ko_at'_corres
-                         [where f'="scTCB_update (\<lambda>_. Some thread)"]
-                       threadset_corresT])
-                apply (clarsimp simp: sc_relation_def)
-               apply clarsimp
-              apply (clarsimp simp: objBits_def objBitsKO_def)
-             apply clarsimp
-            apply (clarsimp simp: tcb_relation_def)
-           apply (clarsimp simp: tcb_cap_cases_def)
-          apply (clarsimp simp: tcb_cte_cases_def)
-         apply wpsimp
-        apply wpsimp
-       apply (wpsimp wp: hoare_drop_imp)+
-   apply (frule (1) valid_objs_ko_at)
-   apply (fastforce simp: valid_obj_def valid_sched_context_def valid_bound_obj_def obj_at_def)
-  apply (prop_tac "sc_at' scp s' \<and> tcb_at' thread s'")
-   apply (fastforce elim: sc_at_cross tcb_at_cross simp: state_relation_def)
-  apply clarsimp
-  apply (frule valid_objs'_valid_tcbs')
-  apply (rule valid_objsE', assumption)
-   apply (fastforce simp: obj_at'_def projectKO_eq projectKO_sc)
-  apply (clarsimp simp: valid_obj'_def valid_sched_context'_def obj_at'_def projectKOs)
-  apply (frule valid_objs'_valid_tcbs')
-  apply (fastforce simp: valid_obj'_def valid_tcb'_def)
-  done
-
 end

--- a/proof/refine/ARM/SubMonad_R.thy
+++ b/proof/refine/ARM/SubMonad_R.thy
@@ -64,12 +64,12 @@ definition
 lemma threadGet_stateAssert_gets_asUser:
   "threadGet (atcbContextGet o tcbArch) t = do stateAssert (tcb_at' t) []; gets (asUser_fetch t) od"
   apply (rule is_stateAssert_gets [OF _ _ empty_fail_threadGet no_fail_threadGet])
-    apply (clarsimp simp: threadGet_def liftM_def, wp, simp)
-   apply (simp add: threadGet_def liftM_def, wp getObject_tcb_at',
-          clarsimp simp: threadRead_tcb_at')
-  apply (wpsimp simp: threadGet_def)
-  apply (drule use_ovalid[OF ovalid_threadRead_sp], simp)
-  apply (clarsimp simp: obj_at'_def asUser_fetch_def projectKOs atcbContextGet_def o_def)
+    apply (clarsimp simp: threadGet_def liftM_def, wp)
+   apply (simp add: threadGet_def liftM_def, wp getObject_tcb_at')
+  apply (simp add: threadGet_def liftM_def, wp)
+   apply (rule hoare_strengthen_post, rule getObject_obj_at')
+     apply (simp add: objBits_simps')+
+   apply (clarsimp simp: obj_at'_def asUser_fetch_def projectKOs atcbContextGet_def o_def)+
   done
 
 lemma threadSet_modify_asUser:

--- a/proof/refine/ARM/orphanage/Orphanage.thy
+++ b/proof/refine/ARM/orphanage/Orphanage.thy
@@ -1058,7 +1058,7 @@ crunch cteInsert, setExtraBadge, setMessageInfo, transferCaps, copyMRs,
 crunch doIPCTransfer, setMRs, setEndpoint
   for ksReadyQueues [wp]: "\<lambda>s. P (ksReadyQueues s)"
   and no_orphans [wp]: "no_orphans"
-  (wp: transferCapsToSlots_pres1 crunch_wps no_orphans_lift updateObject_default_inv)
+  (wp: no_orphans_lift updateObject_default_inv)
 
 lemma sendIPC_no_orphans [wp]:
   "\<lbrace>\<lambda>s. no_orphans s \<and> valid_objs' s \<and> sch_act_wf (ksSchedulerAction s) s\<rbrace>


### PR DESCRIPTION
This restores the ARM refine proofs to match master. The rt changes to these proofs have not been maintained for a long time and have not been kept up to date with changes made to the specifications and ainvs. There also hasn't been a strong effort to keep them in a consistent state when doing merges in the past. When we want to do these proofs for ARM again in the future we will need to pull in the changes from RISCV64 anyway, and discarding them like this will make merges easier now.