### PR TITLE
Remove IO ports from non-X64 arches, move valid_ioports into valid_arch_state on X64

### DIFF
--- a/proof/access-control/ARM/ArchIpc_AC.thy
+++ b/proof/access-control/ARM/ArchIpc_AC.thy
@@ -63,6 +63,10 @@ lemma tcb_context_no_change[Ipc_AC_assms]:
   apply (auto simp: arch_tcb_context_set_def)
   done
 
+lemma transfer_caps_loop_valid_arch[Ipc_AC_assms]:
+  "transfer_caps_loop ep buffer n caps slots mi \<lbrace>valid_arch_state :: det_ext state \<Rightarrow> _\<rbrace>"
+  by (wp valid_arch_state_lift_aobj_at_no_caps transfer_caps_loop_aobj_at)
+
 end
 
 

--- a/proof/access-control/CNode_AC.thy
+++ b/proof/access-control/CNode_AC.thy
@@ -8,6 +8,19 @@ theory CNode_AC
 imports ArchAccess_AC
 begin
 
+(* Note: exporting the following diverges from AInvs interfaces where valid_arch_state is
+   permitted to depend on caps (due to supporting x64). If x64 access control is to go ahead,
+   these will need more careful management. *)
+arch_requalify_facts
+  set_cap_valid_arch_state
+  cap_insert_simple_valid_arch_state
+
+lemmas [wp] = set_cap_valid_arch_state cap_insert_simple_valid_arch_state
+
+crunch set_untyped_cap_as_full
+  for valid_arch_state[wp]: valid_arch_state
+
+
 section\<open>CNode-specific AC.\<close>
 
 
@@ -32,7 +45,6 @@ crunch cap_swap_ext,cap_move_ext,empty_slot_ext
 
 crunch set_untyped_cap_as_full
   for integrity_autarch: "integrity aag X st"
-
 
 locale CNode_AC_1 =
   fixes aag :: "'a PAS"
@@ -1010,8 +1022,6 @@ locale CNode_AC_3 = CNode_AC_2 +
     "arch_post_cap_deletion irqopt \<lbrace>pas_refined aag\<rbrace>"
   and aobj_ref'_same_aobject:
     "same_aobject_as ao' ao \<Longrightarrow> aobj_ref' ao = aobj_ref' ao'"
-  and set_untyped_cap_as_full_valid_arch_state[wp]:
-    "set_untyped_cap_as_full src_cap new_cap src_slot \<lbrace>\<lambda>s :: det_ext state. valid_arch_state s\<rbrace>"
 begin
 
 lemma cap_insert_pas_refined:

--- a/proof/access-control/Finalise_AC.thy
+++ b/proof/access-control/Finalise_AC.thy
@@ -372,7 +372,7 @@ crunch suspend
   for pspace_aligned[wp]: "\<lambda>s :: det_ext state. pspace_aligned s"
   and valid_vspace_objs[wp]: "\<lambda>s :: det_ext state. valid_vspace_objs s"
   and valid_arch_state[wp]: "\<lambda>s :: det_ext state. valid_arch_state s"
-  (wp: dxo_wp_weak hoare_drop_imps simp: crunch_simps)
+  (wp: dxo_wp_weak hoare_drop_imps simp: crunch_simps simp: tcb_cap_cases_def)
 
 crunch suspend
   for pas_refined[wp]: "pas_refined aag"

--- a/proof/access-control/RISCV64/ArchIpc_AC.thy
+++ b/proof/access-control/RISCV64/ArchIpc_AC.thy
@@ -66,6 +66,10 @@ lemma tcb_context_no_change[Ipc_AC_assms]:
   apply (auto simp: arch_tcb_context_set_def)
   done
 
+lemma transfer_caps_loop_valid_arch[Ipc_AC_assms]:
+  "transfer_caps_loop ep buffer n caps slots mi \<lbrace>valid_arch_state :: det_ext state \<Rightarrow> _\<rbrace>"
+  by (wp valid_arch_state_lift_aobj_at_no_caps transfer_caps_loop_aobj_at)
+
 end
 
 

--- a/proof/infoflow/ARM/ArchRetype_IF.thy
+++ b/proof/infoflow/ARM/ArchRetype_IF.thy
@@ -12,6 +12,15 @@ context Arch begin global_naming ARM
 
 named_theorems Retype_IF_assms
 
+lemma do_ipc_transfer_valid_arch_no_caps[wp]:
+  "do_ipc_transfer s ep bg grt r \<lbrace>valid_arch_state\<rbrace>"
+  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps do_ipc_transfer_aobj_at)
+
+lemma create_cap_valid_arch_state_no_caps[wp]:
+  "\<lbrace>valid_arch_state \<rbrace> create_cap tp sz p dev ref
+   \<lbrace>\<lambda>rv. valid_arch_state\<rbrace>"
+  by (wp valid_arch_state_lift_aobj_at_no_caps create_cap_aobj_at)
+
 lemma cacheRangeOp_ev[wp]:
   "(\<And>a b. equiv_valid_inv I A \<top> (oper a b))
    \<Longrightarrow> equiv_valid_inv I A \<top> (cacheRangeOp oper x y z)"

--- a/proof/infoflow/ARM/ArchTcb_IF.thy
+++ b/proof/infoflow/ARM/ArchTcb_IF.thy
@@ -185,6 +185,7 @@ lemma tc_reads_respects_f[Tcb_IF_assms]:
                            cap_delete_pas_refined' itr_wps(12) itr_wps(14) cap_insert_cte_at
                            checked_insert_no_cap_to hoare_vcg_const_imp_liftE_R hoare_vcg_conj_lift
                            as_user_reads_respects_f thread_set_mdb cap_delete_invs
+                           thread_set_valid_arch_state
                       | wpc
                       | simp add: emptyable_def tcb_cap_cases_def tcb_cap_valid_def
                                   tcb_at_st_tcb_at when_def
@@ -231,6 +232,7 @@ lemma tc_reads_respects_f[Tcb_IF_assms]:
              thread_set_pas_refined thread_set_emptyable thread_set_valid_cap
              thread_set_cte_at thread_set_no_cap_to_trivial
              thread_set_tcb_fault_handler_update_only_timer_irq_inv
+             thread_set_valid_arch_state
           | simp add: tcb_cap_cases_def | wpc | wp (once) hoare_drop_imp)+
   apply (clarsimp simp: authorised_tcb_inv_def  authorised_tcb_inv_extra_def emptyable_def)
   by (clarsimp simp: is_cap_simps is_cnode_or_valid_arch_def is_valid_vtable_root_def det_setRegister

--- a/proof/infoflow/Arch_IF.thy
+++ b/proof/infoflow/Arch_IF.thy
@@ -8,6 +8,14 @@ theory Arch_IF
 imports ArchRetype_IF
 begin
 
+(* Note: exporting the following diverges from AInvs interfaces where valid_arch_state is
+   permitted to depend on caps (due to supporting x64). If x64 confidentiality is to go ahead,
+   this will need more careful management. *)
+arch_requalify_facts
+  do_ipc_transfer_valid_arch_no_caps
+
+lemmas [wp] = do_ipc_transfer_valid_arch_no_caps
+
 abbreviation irq_state_of_state :: "det_state \<Rightarrow> nat" where
   "irq_state_of_state s \<equiv> irq_state (machine_state s)"
 

--- a/proof/infoflow/Finalise_IF.thy
+++ b/proof/infoflow/Finalise_IF.thy
@@ -1489,7 +1489,8 @@ crunch deleting_irq_handler
 
 crunch cancel_ipc
   for globals_equiv[wp]: "globals_equiv st"
-  (wp: mapM_x_wp select_inv hoare_drop_imps hoare_vcg_if_lift2 simp: unless_def)
+  (wp: mapM_x_wp select_inv hoare_drop_imps hoare_vcg_if_lift2 thread_set_valid_arch_state
+   simp: unless_def tcb_cap_cases_def)
 
 lemma suspend_globals_equiv[ wp]:
   "\<lbrace>globals_equiv st and (\<lambda>s. t \<noteq> idle_thread s) and valid_arch_state\<rbrace>

--- a/proof/infoflow/Ipc_IF.thy
+++ b/proof/infoflow/Ipc_IF.thy
@@ -1600,9 +1600,9 @@ lemma do_reply_transfer_reads_respects_f:
             cap_delete_one_silc_inv do_ipc_transfer_silc_inv
             set_thread_state_pas_refined thread_set_fault_pas_refined'
             possible_switch_to_reads_respects[THEN reads_respects_f[where aag=aag and st=st and Q=\<top>]]
-            when_ev
+            when_ev thread_set_valid_arch_state
          | wpc
-         | simp split del: if_split
+         | simp split del: if_split add: tcb_cap_cases_def
          | wp (once) reads_respects_f[where aag=aag and st=st]
          | elim conjE
          | wp (once) hoare_drop_imps)+
@@ -1987,8 +1987,10 @@ lemma send_fault_ipc_globals_equiv:
   apply (wp)
      apply (simp add: Let_def)
      apply (wp send_ipc_globals_equiv thread_set_globals_equiv thread_set_valid_objs''
-               thread_set_fault_valid_global_refs thread_set_valid_idle_trivial thread_set_refs_trivial
-            | wpc | simp)+
+               thread_set_fault_valid_global_refs thread_set_valid_idle_trivial
+               thread_set_refs_trivial thread_set_valid_arch_state
+               thread_set_tcb_fault_update_valid_mdb
+            | wpc | simp add: tcb_cap_cases_def)+
     apply (rule_tac Q'="\<lambda>_. globals_equiv st and valid_objs and valid_arch_state and
                             valid_global_refs and pspace_distinct and pspace_aligned and
                             valid_global_objs and K (valid_fault fault) and valid_idle and
@@ -2000,8 +2002,9 @@ lemma send_fault_ipc_globals_equiv:
   done
 
 crunch send_fault_ipc
-  for valid_arch_state[wp]: valid_arch_state
-  (wp: dxo_wp_weak hoare_drop_imps simp: crunch_simps)
+  for valid_arch_statex[wp]: valid_arch_state
+  (wp: dxo_wp_weak hoare_drop_imps thread_set_valid_arch_state crunch_wps
+   simp: crunch_simps tcb_cap_cases_def)
 
 lemma handle_fault_globals_equiv:
   "\<lbrace>globals_equiv st and valid_objs and valid_arch_state and valid_global_refs
@@ -2033,7 +2036,8 @@ lemma do_reply_transfer_globals_equiv:
   unfolding do_reply_transfer_def
   apply (wp set_thread_state_globals_equiv cap_delete_one_globals_equiv do_ipc_transfer_globals_equiv
             thread_set_globals_equiv handle_fault_reply_globals_equiv dxo_wp_weak
-         | wpc | simp split del: if_split)+
+            thread_set_valid_arch_state
+         | wpc | simp split del: if_split add: tcb_cap_cases_def)+
      apply (rule_tac Q'="\<lambda>_. globals_equiv st and valid_arch_state and valid_objs and valid_arch_state
                                              and valid_global_refs and pspace_distinct
                                              and pspace_aligned and valid_global_objs

--- a/proof/infoflow/RISCV64/ArchRetype_IF.thy
+++ b/proof/infoflow/RISCV64/ArchRetype_IF.thy
@@ -12,6 +12,15 @@ context Arch begin global_naming RISCV64
 
 named_theorems Retype_IF_assms
 
+lemma do_ipc_transfer_valid_arch_no_caps[wp]:
+  "do_ipc_transfer s ep bg grt r \<lbrace>valid_arch_state\<rbrace>"
+  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps do_ipc_transfer_aobj_at)
+
+lemma create_cap_valid_arch_state_no_caps[wp]:
+  "\<lbrace>valid_arch_state \<rbrace> create_cap tp sz p dev ref
+   \<lbrace>\<lambda>rv. valid_arch_state\<rbrace>"
+  by (wp valid_arch_state_lift_aobj_at_no_caps create_cap_aobj_at)
+
 lemma modify_underlying_memory_update_0_ev:
   "equiv_valid_inv (equiv_machine_state P) (equiv_machine_state Q) \<top>
                    (modify (underlying_memory_update (\<lambda>m. m(x := word_rsplit 0 ! 7,

--- a/proof/infoflow/RISCV64/ArchTcb_IF.thy
+++ b/proof/infoflow/RISCV64/ArchTcb_IF.thy
@@ -181,6 +181,7 @@ lemma tc_reads_respects_f[Tcb_IF_assms]:
                            cap_delete_pas_refined' itr_wps(12) itr_wps(14) cap_insert_cte_at
                            checked_insert_no_cap_to hoare_vcg_const_imp_liftE_R hoare_vcg_conj_lift
                            as_user_reads_respects_f thread_set_mdb cap_delete_invs
+                           thread_set_valid_arch_state
                       | wpc
                       | simp add: emptyable_def tcb_cap_cases_def tcb_cap_valid_def
                                   tcb_at_st_tcb_at when_def
@@ -220,6 +221,7 @@ lemma tc_reads_respects_f[Tcb_IF_assms]:
     apply (simp add: option_update_thread_def tcb_cap_cases_def
            | wp hoare_weak_lift_imp hoare_weak_lift_imp_conj thread_set_pas_refined
                 reads_respects_f[OF thread_set_reads_respects, where st=st and Q="\<top>"]
+                thread_set_valid_arch_state
            | wpc)+
    apply (wp hoare_vcg_all_lift thread_set_tcb_fault_handler_update_invs
              thread_set_tcb_fault_handler_update_silc_inv
@@ -227,6 +229,7 @@ lemma tc_reads_respects_f[Tcb_IF_assms]:
              thread_set_pas_refined thread_set_emptyable thread_set_valid_cap
              thread_set_cte_at thread_set_no_cap_to_trivial
              thread_set_tcb_fault_handler_update_only_timer_irq_inv
+             thread_set_valid_arch_state
           | simp add: tcb_cap_cases_def | wpc | wp (once) hoare_drop_imp)+
   apply (clarsimp simp: authorised_tcb_inv_def authorised_tcb_inv_extra_def emptyable_def)
   apply (clarsimp simp: invs_psp_aligned invs_vspace_objs invs_arch_state)

--- a/proof/infoflow/Tcb_IF.thy
+++ b/proof/infoflow/Tcb_IF.thy
@@ -196,7 +196,7 @@ begin
 
 crunch cap_swap_for_delete
   for valid_arch_state[wp]: valid_arch_state
-  (wp: dxo_wp_weak)
+  (wp: dxo_wp_weak simp: crunch_simps)
 
 lemma rec_del_globals_equiv:
   "\<lbrace>\<lambda>s. invs s \<and> globals_equiv st s \<and> emptyable (slot_rdcall call) s \<and> valid_rec_del_call call s\<rbrace>

--- a/proof/invariant-abstract/AARCH64/ArchAcc_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchAcc_AI.thy
@@ -2821,8 +2821,7 @@ lemma cap_refs_respects_device_region_dmo:
   done
 
 crunch do_machine_op
-  for valid_ioports[wp]: valid_ioports
-  and valid_vspace_objs[wp]: valid_vspace_objs
+  for valid_vspace_objs[wp]: valid_vspace_objs
   and valid_kernel_mappings[wp]: valid_kernel_mappings
   and equal_kernel_mappings[wp]: equal_kernel_mappings
   and valid_asid_map[wp]: valid_asid_map

--- a/proof/invariant-abstract/AARCH64/ArchArch_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchArch_AI.thy
@@ -611,13 +611,6 @@ lemma safe_parent_cap_is_device:
   "safe_parent_for m p cap pcap \<Longrightarrow> cap_is_device cap = cap_is_device pcap"
   by (simp add: safe_parent_for_def)
 
-lemma cap_insert_ioports_ap:
-  "\<lbrace>valid_ioports and (\<lambda>s. cte_wp_at (\<lambda>cap'. safe_ioport_insert cap cap' s) dest s) and
-        K (is_ap_cap cap)\<rbrace>
-     cap_insert cap src dest
-   \<lbrace>\<lambda>rv. valid_ioports\<rbrace>"
-  by wpsimp
-
 crunch cap_insert
   for aobjs_of[wp]: "\<lambda>s. P (aobjs_of s)"
   (wp: crunch_wps)
@@ -642,7 +635,7 @@ lemma cap_insert_ap_invs:
   apply (simp cong: conj_cong)
   apply (rule hoare_pre)
    apply (wp cap_insert_simple_mdb cap_insert_iflive
-             cap_insert_zombies cap_insert_ifunsafe cap_insert_ioports_ap
+             cap_insert_zombies cap_insert_ifunsafe
              cap_insert_valid_global_refs cap_insert_idle
              valid_irq_node_typ cap_insert_simple_arch_caps_ap)
   apply (clarsimp simp: is_simple_cap_def cte_wp_at_caps_of_state is_cap_simps)

--- a/proof/invariant-abstract/AARCH64/ArchCNodeInv_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchCNodeInv_AI.thy
@@ -427,15 +427,8 @@ lemma cap_swap_cap_refs_in_kernel_window[wp, CNodeInv_AI_assms]:
                simp: cte_wp_at_caps_of_state weak_derived_cap_range)
   done
 
-
-lemma cap_swap_ioports[wp, CNodeInv_AI_assms]:
-  "\<lbrace>valid_ioports and cte_wp_at (weak_derived c) a and cte_wp_at (weak_derived c') b\<rbrace>
-     cap_swap c a c' b
-   \<lbrace>\<lambda>rv. valid_ioports\<rbrace>"
-  by wpsimp
-
 lemma cap_swap_vms[wp, CNodeInv_AI_assms]:
-  "\<lbrace>valid_machine_state\<rbrace>  cap_swap c a c' b \<lbrace>\<lambda>rv. valid_machine_state\<rbrace>"
+  "\<lbrace>valid_machine_state\<rbrace> cap_swap c a c' b \<lbrace>\<lambda>rv. valid_machine_state\<rbrace>"
   apply (simp add: valid_machine_state_def in_user_frame_def)
   apply (wp cap_swap_typ_at
             hoare_vcg_all_lift hoare_vcg_ex_lift hoare_vcg_disj_lift)
@@ -525,6 +518,12 @@ lemma prepare_thread_delete_thread_cap [CNodeInv_AI_assms]:
    \<lbrace>\<lambda>rv s. caps_of_state s x = Some (cap.ThreadCap p)\<rbrace>"
   by (wpsimp simp: prepare_thread_delete_def)
 
+lemma cap_swap_valid_arch_state[wp, CNodeInv_AI_assms]:
+  "\<lbrace>valid_arch_state and cte_wp_at (weak_derived c) a and cte_wp_at (weak_derived c') b\<rbrace>
+   cap_swap c a c' b
+   \<lbrace>\<lambda>_. valid_arch_state\<rbrace>"
+  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps cap_swap_aobj_at)
+
 end
 
 
@@ -541,7 +540,7 @@ termination rec_del by (rule rec_del_termination)
 context Arch begin arch_global_naming
 
 lemma post_cap_delete_pre_is_final_cap':
-  "\<lbrakk>valid_ioports s; caps_of_state s slot = Some cap; is_final_cap' cap s; cap_cleanup_opt cap \<noteq> NullCap\<rbrakk>
+  "\<lbrakk> caps_of_state s slot = Some cap; is_final_cap' cap s; cap_cleanup_opt cap \<noteq> NullCap\<rbrakk>
    \<Longrightarrow> post_cap_delete_pre (cap_cleanup_opt cap) ((caps_of_state s)(slot \<mapsto> NullCap))"
   apply (clarsimp simp: cap_cleanup_opt_def cte_wp_at_def post_cap_delete_pre_def
                       split: cap.split_asm if_split_asm
@@ -932,14 +931,6 @@ global_interpretation CNodeInv_AI_4?: CNodeInv_AI_4
 
 context Arch begin arch_global_naming
 
-lemma cap_move_ioports:
-  "\<lbrace>valid_ioports and cte_wp_at ((=) cap.NullCap) ptr'
-         and cte_wp_at (weak_derived cap) ptr
-         and cte_wp_at (\<lambda>c. c \<noteq> cap.NullCap) ptr and K (ptr \<noteq> ptr')\<rbrace>
-     cap_move cap ptr ptr'
-   \<lbrace>\<lambda>rv. valid_ioports\<rbrace>"
-  by wpsimp
-
 lemma cap_move_invs[wp, CNodeInv_AI_assms]:
   "\<lbrace>invs and valid_cap cap and cte_wp_at ((=) cap.NullCap) ptr'
          and tcb_cap_valid cap ptr'
@@ -959,7 +950,6 @@ lemma cap_move_invs[wp, CNodeInv_AI_assms]:
    apply (wpe cap_move_replies)
    apply (wpe cap_move_valid_arch_caps)
    apply (wpe cap_move_valid_ioc)
-   apply (wpe cap_move_ioports)
    apply (simp add: cap_move_def set_cdt_def)
    apply (rule hoare_pre)
     apply (wp set_cap_valid_objs set_cap_idle set_cap_typ_at

--- a/proof/invariant-abstract/AARCH64/ArchCSpaceInv_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchCSpaceInv_AI.thy
@@ -14,20 +14,9 @@ begin
 
 context Arch begin arch_global_naming
 
-definition
-   safe_ioport_insert :: "cap \<Rightarrow> cap \<Rightarrow> 'a::state_ext state \<Rightarrow> bool"
-where
-  "safe_ioport_insert newcap oldcap \<equiv> \<lambda>_. True"
-
-lemma safe_ioport_insert_triv:
-  "\<not>is_arch_cap newcap \<Longrightarrow> safe_ioport_insert newcap oldcap s"
-  by (clarsimp simp: safe_ioport_insert_def)
-
-lemma set_cap_ioports':
- "\<lbrace>\<lambda>s. valid_ioports s \<and> cte_wp_at (\<lambda>cap'. safe_ioport_insert cap cap' s) ptr s\<rbrace>
-    set_cap cap ptr
-  \<lbrace>\<lambda>rv. valid_ioports\<rbrace>"
-  by wpsimp
+lemma set_cap_valid_arch_state[wp]:
+  "set_cap cap ptr \<lbrace> valid_arch_state \<rbrace>"
+  by (wp valid_arch_state_lift_aobj_at_no_caps set_cap.aobj_at)
 
 lemma replace_cap_invs:
   "\<lbrace>\<lambda>s. invs s \<and> cte_wp_at (replaceable s p cap) p s

--- a/proof/invariant-abstract/AARCH64/ArchCSpace_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchCSpace_AI.thy
@@ -477,15 +477,15 @@ lemma cap_insert_simple_arch_caps_no_ap:
   apply (intro conjI impI allI)
   by (auto simp:is_simple_cap_def[simplified is_simple_cap_arch_def] is_cap_simps)
 
-lemma setup_reply_master_ioports[wp, CSpace_AI_assms]:
-  "\<lbrace>valid_ioports\<rbrace> setup_reply_master c \<lbrace>\<lambda>rv. valid_ioports\<rbrace>"
-  by wpsimp
+lemma cap_insert_derived_valid_arch_state[CSpace_AI_assms]:
+  "\<lbrace>valid_arch_state and (\<lambda>s. cte_wp_at (is_derived (cdt s) src cap) src s)\<rbrace>
+   cap_insert cap src dest
+   \<lbrace>\<lambda>rv. valid_arch_state \<rbrace>"
+  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps cap_insert_aobj_at cap_insert_aobj_at)
 
-lemma cap_insert_derived_ioports[CSpace_AI_assms]:
-  "\<lbrace>valid_ioports and (\<lambda>s. cte_wp_at (is_derived (cdt s) src cap) src s)\<rbrace>
-     cap_insert cap src dest
-   \<lbrace>\<lambda>rv. valid_ioports\<rbrace>"
-  by wpsimp
+lemma setup_reply_master_arch[CSpace_AI_assms]:
+  "setup_reply_master t \<lbrace> valid_arch_state \<rbrace>"
+  by (wpsimp simp: setup_reply_master_def wp: get_cap_wp)
 
 end
 
@@ -513,6 +513,10 @@ lemma is_cap_simps':
   by (cases cap, auto simp: is_zombie_def is_arch_cap_def is_nondevice_page_cap_def
                             is_reply_cap_def is_master_reply_cap_def is_FrameCap_def
                      split: cap.splits arch_cap.splits)+
+
+lemma cap_insert_simple_valid_arch_state[wp]:
+  "cap_insert cap src dest \<lbrace> valid_arch_state\<rbrace>"
+  by (wp valid_arch_state_lift_aobj_at_no_caps cap_insert_aobj_at)+
 
 lemma cap_insert_simple_invs:
   "\<lbrace>invs and valid_cap cap and tcb_cap_valid cap dest and

--- a/proof/invariant-abstract/AARCH64/ArchDetype_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchDetype_AI.thy
@@ -108,10 +108,6 @@ lemma state_hyp_refs_of_detype:
   "state_hyp_refs_of (detype S s) = (\<lambda>x. if x \<in> S then {} else state_hyp_refs_of s x)"
   by (rule ext, simp add: state_hyp_refs_of_def detype_def)
 
-lemma valid_ioports_detype[Detype_AI_assms]:
-  "valid_ioports s \<Longrightarrow> valid_ioports (detype (untyped_range cap) s)"
-  by simp
-
 end
 
 interpretation Detype_AI?: Detype_AI

--- a/proof/invariant-abstract/AARCH64/ArchFinalise_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchFinalise_AI.thy
@@ -1980,10 +1980,6 @@ lemma (* zombie_cap_two_nonidles *)[Finalise_AI_assms]:
   apply (cases ptr, auto dest: valid_idle_has_null_cap_ARCH[rotated -1])[1]
   done
 
-crunch empty_slot, finalise_cap, send_ipc, receive_ipc
-  for ioports[wp]: valid_ioports
-  (wp: crunch_wps valid_ioports_lift simp: crunch_simps ignore: set_object)
-
 lemma arch_derive_cap_notzombie[wp]:
   "\<lbrace>\<top>\<rbrace> arch_derive_cap acap \<lbrace>\<lambda>rv s. \<not> is_zombie rv\<rbrace>, -"
   by (cases acap; wpsimp simp: arch_derive_cap_def is_zombie_def o_def)

--- a/proof/invariant-abstract/AARCH64/ArchInvariants_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchInvariants_AI.thy
@@ -721,9 +721,6 @@ definition valid_asid_map :: "'z::state_ext state \<Rightarrow> bool" where
 definition valid_global_objs :: "'z::state_ext state \<Rightarrow> bool" where
   "valid_global_objs \<equiv> \<top>"
 
-definition valid_ioports :: "'z::state_ext state \<Rightarrow> bool" where
-  [simp]: "valid_ioports \<equiv> \<top>"
-
 
 (* This definition is needed as interface for other architectures only.
    In other architectures, S is a set of object references (to global tables) that
@@ -3141,10 +3138,6 @@ context Arch_p_arch_update_eq begin
 
 sublocale Arch_p_asid_table_update_eq
   by unfold_locales (simp add: arch)
-
-lemma valid_ioports_update[iff]:
-  "valid_ioports (f s) = valid_ioports s"
-  by simp
 
 lemma cur_vcpu_update [iff]:
   "cur_vcpu (f s) = cur_vcpu s"

--- a/proof/invariant-abstract/AARCH64/ArchIpc_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchIpc_AI.thy
@@ -11,7 +11,7 @@ begin
 
 context Arch begin arch_global_naming
 
-named_theorems Ipc_AI_assms
+named_theorems Ipc_AI_1_assms
 
 lemma cap_asid_PageCap_None[simp]:
   "cap_asid (ArchObjectCap (FrameCap r R pgsz dev None)) = None"
@@ -37,7 +37,7 @@ lemma arch_derive_cap_is_derived:
              | rule conjI)+)
   done
 
-lemma derive_cap_is_derived [Ipc_AI_assms]:
+lemma derive_cap_is_derived [Ipc_AI_1_assms]:
   "\<lbrace>\<lambda>s. c'\<noteq> cap.NullCap \<longrightarrow> cte_wp_at (\<lambda>cap. cap_master_cap cap = cap_master_cap c'
                      \<and> (cap_badge cap, cap_badge c') \<in> capBadge_ordering False
                      \<and> cap_asid cap = cap_asid c'
@@ -63,7 +63,19 @@ lemma derive_cap_is_derived [Ipc_AI_assms]:
   apply(clarsimp simp: valid_cap_def)
   done
 
-lemma is_derived_cap_rights [simp, Ipc_AI_assms]:
+end
+
+interpretation Ipc_AI?: Ipc_AI
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case by (unfold_locales; (fact Ipc_AI_1_assms)?)
+qed
+
+context Arch begin arch_global_naming
+
+named_theorems Ipc_AI_2_assms
+
+lemma is_derived_cap_rights [simp, Ipc_AI_2_assms]:
   "is_derived m p (cap_rights_update R c) = is_derived m p c"
   apply (rule ext)
   apply (simp add: cap_rights_update_def is_derived_def is_cap_simps)
@@ -75,12 +87,12 @@ lemma is_derived_cap_rights [simp, Ipc_AI_assms]:
            split: arch_cap.split cap.split bool.splits)
 
 
-lemma data_to_message_info_valid [Ipc_AI_assms]:
+lemma data_to_message_info_valid [Ipc_AI_2_assms]:
   "valid_message_info (data_to_message_info w)"
   by (simp add: valid_message_info_def data_to_message_info_def  word_and_le1 msg_max_length_def
                 msg_max_extra_caps_def Let_def not_less mask_def)
 
-lemma get_extra_cptrs_length[wp, Ipc_AI_assms]:
+lemma get_extra_cptrs_length[wp, Ipc_AI_2_assms]:
   "\<lbrace>\<lambda>s . valid_message_info mi\<rbrace>
    get_extra_cptrs buf mi
    \<lbrace>\<lambda>rv s. length rv \<le> msg_max_extra_caps\<rbrace>"
@@ -95,17 +107,17 @@ lemma get_extra_cptrs_length[wp, Ipc_AI_assms]:
                  intro: length_upt)
   done
 
-lemma cap_asid_rights_update [simp, Ipc_AI_assms]:
+lemma cap_asid_rights_update [simp, Ipc_AI_2_assms]:
   "cap_asid (cap_rights_update R c) = cap_asid c"
   by (simp add: cap_rights_update_def acap_rights_update_def cap_asid_def
          split: cap.splits arch_cap.splits)
 
-lemma cap_rights_update_vs_cap_ref[simp, Ipc_AI_assms]:
+lemma cap_rights_update_vs_cap_ref[simp, Ipc_AI_2_assms]:
   "vs_cap_ref (cap_rights_update rs cap) = vs_cap_ref cap"
   by (simp add: vs_cap_ref_def vs_cap_ref_arch_def cap_rights_update_def acap_rights_update_def
          split: cap.split arch_cap.split)
 
-lemma is_derived_cap_rights2[simp, Ipc_AI_assms]:
+lemma is_derived_cap_rights2[simp, Ipc_AI_2_assms]:
   "is_derived m p c (cap_rights_update R c') = is_derived m p c c'"
   apply (case_tac c'; simp add: cap_rights_update_def)
      apply (clarsimp simp: is_derived_def is_cap_simps cap_master_cap_def vs_cap_ref_def
@@ -114,12 +126,12 @@ lemma is_derived_cap_rights2[simp, Ipc_AI_assms]:
   apply (case_tac acap1)
   by (auto simp: acap_rights_update_def)
 
-lemma cap_range_update [simp, Ipc_AI_assms]:
+lemma cap_range_update [simp, Ipc_AI_2_assms]:
   "cap_range (cap_rights_update R cap) = cap_range cap"
   by (simp add: cap_range_def cap_rights_update_def acap_rights_update_def
          split: cap.splits arch_cap.splits)
 
-lemma derive_cap_idle[wp, Ipc_AI_assms]:
+lemma derive_cap_idle[wp, Ipc_AI_2_assms]:
   "\<lbrace>\<lambda>s. global_refs s \<inter> cap_range cap = {}\<rbrace>
    derive_cap slot cap
   \<lbrace>\<lambda>c s. global_refs s \<inter> cap_range c = {}\<rbrace>, -"
@@ -131,7 +143,7 @@ lemma derive_cap_idle[wp, Ipc_AI_assms]:
   apply (case_tac arch_cap, simp_all)
   done
 
-lemma arch_derive_cap_objrefs_iszombie [Ipc_AI_assms]:
+lemma arch_derive_cap_objrefs_iszombie [Ipc_AI_2_assms]:
   "\<lbrace>\<lambda>s . P (set_option (aobj_ref cap)) False s\<rbrace>
      arch_derive_cap cap
    \<lbrace>\<lambda>rv s. rv \<noteq> NullCap \<longrightarrow> P (obj_refs rv) (is_zombie rv) s\<rbrace>,-"
@@ -139,7 +151,7 @@ lemma arch_derive_cap_objrefs_iszombie [Ipc_AI_assms]:
       apply(rule hoare_pre, wpsimp+)+
   done
 
-lemma obj_refs_remove_rights[simp, Ipc_AI_assms]:
+lemma obj_refs_remove_rights[simp, Ipc_AI_2_assms]:
   "obj_refs (remove_rights rs cap) = obj_refs cap"
   by (auto simp add: remove_rights_def cap_rights_update_def
                 acap_rights_update_def
@@ -151,7 +163,7 @@ lemma storeWord_um_inv:
    \<lbrace>\<lambda>_ s. is_aligned a 3 \<and> x \<in> {a,a+1,a+2,a+3,a+4,a+5,a+6,a+7} \<or> underlying_memory s x = um x\<rbrace>"
   by (wpsimp simp: upto.simps storeWord_def is_aligned_mask)
 
-lemma store_word_offs_vms[wp, Ipc_AI_assms]:
+lemma store_word_offs_vms[wp, Ipc_AI_2_assms]:
   "\<lbrace>valid_machine_state\<rbrace> store_word_offs ptr offs v \<lbrace>\<lambda>_. valid_machine_state\<rbrace>"
 proof -
   have aligned_offset_ignore:
@@ -190,12 +202,12 @@ proof -
     done
 qed
 
-lemma is_zombie_update_cap_data[simp, Ipc_AI_assms]:
+lemma is_zombie_update_cap_data[simp, Ipc_AI_2_assms]:
   "is_zombie (update_cap_data P data cap) = is_zombie cap"
   by (simp add: update_cap_data_closedform arch_update_cap_data_def is_zombie_def
          split: cap.splits)
 
-lemma valid_msg_length_strengthen [Ipc_AI_assms]:
+lemma valid_msg_length_strengthen [Ipc_AI_2_assms]:
   "valid_message_info mi \<longrightarrow> unat (mi_length mi) \<le> msg_max_length"
   apply (clarsimp simp: valid_message_info_def)
   apply (subgoal_tac "unat (mi_length mi) \<le> unat (of_nat msg_max_length :: machine_word)")
@@ -203,17 +215,17 @@ lemma valid_msg_length_strengthen [Ipc_AI_assms]:
   apply (clarsimp simp: un_ui_le word_le_def)
   done
 
-lemma copy_mrs_in_user_frame[wp, Ipc_AI_assms]:
+lemma copy_mrs_in_user_frame[wp, Ipc_AI_2_assms]:
   "\<lbrace>in_user_frame p\<rbrace> copy_mrs t buf t' buf' n \<lbrace>\<lambda>rv. in_user_frame p\<rbrace>"
   by (simp add: in_user_frame_def) (wp hoare_vcg_ex_lift)
 
 lemma as_user_getRestart_invs[wp]: "\<lbrace>P\<rbrace> as_user t getRestartPC \<lbrace>\<lambda>_. P\<rbrace>"
   by (simp add: getRestartPC_def, rule user_getreg_inv)
 
-lemma make_arch_fault_msg_invs[wp, Ipc_AI_assms]: "make_arch_fault_msg f t \<lbrace>invs\<rbrace>"
+lemma make_arch_fault_msg_invs[wp, Ipc_AI_2_assms]: "make_arch_fault_msg f t \<lbrace>invs\<rbrace>"
   by (cases f; wpsimp)
 
-lemma make_fault_message_inv[wp, Ipc_AI_assms]:
+lemma make_fault_message_inv[wp, Ipc_AI_2_assms]:
   "make_fault_msg ft t \<lbrace>invs\<rbrace>"
   apply (cases ft, simp_all split del: if_split)
      apply (wp as_user_inv getRestartPC_inv mapM_wp'
@@ -223,14 +235,14 @@ lemma make_fault_message_inv[wp, Ipc_AI_assms]:
 crunch make_fault_msg
   for tcb_at[wp]: "tcb_at t"
 
-lemma do_fault_transfer_invs[wp, Ipc_AI_assms]:
+lemma do_fault_transfer_invs[wp, Ipc_AI_2_assms]:
   "\<lbrace>invs and tcb_at receiver\<rbrace>
       do_fault_transfer badge sender receiver recv_buf
    \<lbrace>\<lambda>rv. invs\<rbrace>"
   by (simp add: do_fault_transfer_def split_def | wp
     | clarsimp split: option.split)+
 
-lemma lookup_ipc_buffer_in_user_frame[wp, Ipc_AI_assms]:
+lemma lookup_ipc_buffer_in_user_frame[wp, Ipc_AI_2_assms]:
   "\<lbrace>valid_objs and tcb_at t\<rbrace> lookup_ipc_buffer b t
    \<lbrace>case_option (\<lambda>_. True) in_user_frame\<rbrace>"
   apply (simp add: lookup_ipc_buffer_def)
@@ -327,9 +339,9 @@ lemma transfer_caps_non_null_cte_wp_at:
   done
 
 crunch do_fault_transfer
-  for cte_wp_at[wp,Ipc_AI_assms]: "cte_wp_at P p"
+  for cte_wp_at[wp,Ipc_AI_2_assms]: "cte_wp_at P p"
 
-lemma do_normal_transfer_non_null_cte_wp_at [Ipc_AI_assms]:
+lemma do_normal_transfer_non_null_cte_wp_at [Ipc_AI_2_assms]:
   assumes imp: "\<And>c. P c \<Longrightarrow> \<not> is_untyped_cap c"
   shows  "\<lbrace>valid_objs and cte_wp_at (P and ((\<noteq>) cap.NullCap)) ptr\<rbrace>
    do_normal_transfer st send_buffer ep b gr rt recv_buffer
@@ -340,7 +352,7 @@ lemma do_normal_transfer_non_null_cte_wp_at [Ipc_AI_assms]:
     | clarsimp simp:imp)+
   done
 
-lemma is_derived_ReplyCap [simp, Ipc_AI_assms]:
+lemma is_derived_ReplyCap [simp, Ipc_AI_2_assms]:
   "\<And>m p R. is_derived m p (cap.ReplyCap t False R) = (\<lambda>c. is_master_reply_cap c \<and> obj_ref_of c = t)"
   apply (subst fun_eq_iff)
   apply clarsimp
@@ -361,7 +373,7 @@ lemma do_normal_transfer_tcb_caps:
      | simp add:imp)+
   done
 
-lemma do_ipc_transfer_tcb_caps [Ipc_AI_assms]:
+lemma do_ipc_transfer_tcb_caps [Ipc_AI_2_assms]:
   assumes imp: "\<And>c. P c \<Longrightarrow> \<not> is_untyped_cap c"
   shows
   "\<lbrace>valid_objs and cte_wp_at P (t, ref) and tcb_at t\<rbrace>
@@ -373,7 +385,7 @@ lemma do_ipc_transfer_tcb_caps [Ipc_AI_assms]:
        | wpc | simp add:imp)+
   done
 
-lemma setup_caller_cap_valid_global_objs[wp, Ipc_AI_assms]:
+lemma setup_caller_cap_valid_global_objs[wp, Ipc_AI_2_assms]:
   "\<lbrace>valid_global_objs\<rbrace> setup_caller_cap send recv grant \<lbrace>\<lambda>rv. valid_global_objs\<rbrace>"
   apply (simp add: valid_global_objs_def)
   unfolding setup_caller_cap_def
@@ -381,9 +393,9 @@ lemma setup_caller_cap_valid_global_objs[wp, Ipc_AI_assms]:
   done
 
 crunch handle_arch_fault_reply, arch_get_sanitise_register_info
-  for inv[Ipc_AI_assms]: P
+  for inv[Ipc_AI_2_assms]: P
 
-lemma transfer_caps_loop_valid_vspace_objs[wp, Ipc_AI_assms]:
+lemma transfer_caps_loop_valid_vspace_objs[wp, Ipc_AI_2_assms]:
   "\<lbrace>valid_vspace_objs\<rbrace>
       transfer_caps_loop ep buffer n caps slots mi
     \<lbrace>\<lambda>rv. valid_vspace_objs\<rbrace>"
@@ -399,72 +411,72 @@ lemma transfer_caps_loop_valid_vspace_objs[wp, Ipc_AI_assms]:
   done
 
 crunch  make_arch_fault_msg
-  for aligned[wp, Ipc_AI_assms]: "pspace_aligned"
+  for aligned[wp, Ipc_AI_2_assms]: "pspace_aligned"
 crunch  make_arch_fault_msg
-  for distinct[wp, Ipc_AI_assms]: "pspace_distinct"
+  for distinct[wp, Ipc_AI_2_assms]: "pspace_distinct"
 crunch  make_arch_fault_msg
-  for vmdb[wp, Ipc_AI_assms]: "valid_mdb"
+  for vmdb[wp, Ipc_AI_2_assms]: "valid_mdb"
 crunch  make_arch_fault_msg
-  for ifunsafe[wp, Ipc_AI_assms]: "if_unsafe_then_cap"
+  for ifunsafe[wp, Ipc_AI_2_assms]: "if_unsafe_then_cap"
 crunch  make_arch_fault_msg
-  for iflive[wp, Ipc_AI_assms]: "if_live_then_nonz_cap"
+  for iflive[wp, Ipc_AI_2_assms]: "if_live_then_nonz_cap"
 crunch  make_arch_fault_msg
-  for state_refs_of[wp, Ipc_AI_assms]: "\<lambda>s. P (state_refs_of s)"
+  for state_refs_of[wp, Ipc_AI_2_assms]: "\<lambda>s. P (state_refs_of s)"
 crunch  make_arch_fault_msg
-  for ct[wp, Ipc_AI_assms]: "cur_tcb"
+  for ct[wp, Ipc_AI_2_assms]: "cur_tcb"
 crunch  make_arch_fault_msg
-  for zombies[wp, Ipc_AI_assms]: "zombies_final"
+  for zombies[wp, Ipc_AI_2_assms]: "zombies_final"
 crunch  make_arch_fault_msg
-  for it[wp, Ipc_AI_assms]: "\<lambda>s. P (idle_thread s)"
+  for it[wp, Ipc_AI_2_assms]: "\<lambda>s. P (idle_thread s)"
 crunch  make_arch_fault_msg
-  for valid_globals[wp, Ipc_AI_assms]: "valid_global_refs"
+  for valid_globals[wp, Ipc_AI_2_assms]: "valid_global_refs"
 crunch  make_arch_fault_msg
-  for reply_masters[wp, Ipc_AI_assms]: "valid_reply_masters"
+  for reply_masters[wp, Ipc_AI_2_assms]: "valid_reply_masters"
 crunch  make_arch_fault_msg
-  for valid_idle[wp, Ipc_AI_assms]: "valid_idle"
+  for valid_idle[wp, Ipc_AI_2_assms]: "valid_idle"
 crunch  make_arch_fault_msg
-  for arch[wp, Ipc_AI_assms]: "\<lambda>s. P (arch_state s)"
+  for arch[wp, Ipc_AI_2_assms]: "\<lambda>s. P (arch_state s)"
 crunch  make_arch_fault_msg
-  for typ_at[wp, Ipc_AI_assms]: "\<lambda>s. P (typ_at T p s)"
+  for typ_at[wp, Ipc_AI_2_assms]: "\<lambda>s. P (typ_at T p s)"
 crunch  make_arch_fault_msg
-  for irq_node[wp, Ipc_AI_assms]: "\<lambda>s. P (interrupt_irq_node s)"
+  for irq_node[wp, Ipc_AI_2_assms]: "\<lambda>s. P (interrupt_irq_node s)"
 crunch  make_arch_fault_msg
-  for valid_reply[wp, Ipc_AI_assms]: "valid_reply_caps"
+  for valid_reply[wp, Ipc_AI_2_assms]: "valid_reply_caps"
 crunch  make_arch_fault_msg
-  for irq_handlers[wp, Ipc_AI_assms]: "valid_irq_handlers"
+  for irq_handlers[wp, Ipc_AI_2_assms]: "valid_irq_handlers"
 crunch  make_arch_fault_msg
-  for vspace_objs[wp, Ipc_AI_assms]: "valid_vspace_objs"
+  for vspace_objs[wp, Ipc_AI_2_assms]: "valid_vspace_objs"
 crunch  make_arch_fault_msg
-  for global_objs[wp, Ipc_AI_assms]: "valid_global_objs"
+  for global_objs[wp, Ipc_AI_2_assms]: "valid_global_objs"
 crunch  make_arch_fault_msg
-  for global_vspace_mapping[wp, Ipc_AI_assms]: "valid_global_vspace_mappings"
+  for global_vspace_mapping[wp, Ipc_AI_2_assms]: "valid_global_vspace_mappings"
 crunch  make_arch_fault_msg
-  for arch_caps[wp, Ipc_AI_assms]: "valid_arch_caps"
+  for arch_caps[wp, Ipc_AI_2_assms]: "valid_arch_caps"
 crunch  make_arch_fault_msg
-  for eq_ker_map[wp, Ipc_AI_assms]: "equal_kernel_mappings"
+  for eq_ker_map[wp, Ipc_AI_2_assms]: "equal_kernel_mappings"
 crunch  make_arch_fault_msg
-  for asid_map[wp, Ipc_AI_assms]: "valid_asid_map"
+  for asid_map[wp, Ipc_AI_2_assms]: "valid_asid_map"
 crunch  make_arch_fault_msg
-  for only_idle[wp, Ipc_AI_assms]: "only_idle"
+  for only_idle[wp, Ipc_AI_2_assms]: "only_idle"
 crunch  make_arch_fault_msg
-  for pspace_in_kernel_window[wp, Ipc_AI_assms]: "pspace_in_kernel_window"
+  for pspace_in_kernel_window[wp, Ipc_AI_2_assms]: "pspace_in_kernel_window"
 crunch  make_arch_fault_msg
-  for cap_refs_in_kernel_window[wp, Ipc_AI_assms]: "cap_refs_in_kernel_window"
+  for cap_refs_in_kernel_window[wp, Ipc_AI_2_assms]: "cap_refs_in_kernel_window"
 crunch  make_arch_fault_msg
-  for valid_objs[wp, Ipc_AI_assms]: "valid_objs"
+  for valid_objs[wp, Ipc_AI_2_assms]: "valid_objs"
 crunch  make_arch_fault_msg
-  for valid_ioc[wp, Ipc_AI_assms]: "valid_ioc"
+  for valid_ioc[wp, Ipc_AI_2_assms]: "valid_ioc"
 crunch  make_arch_fault_msg
-  for pred_tcb[wp, Ipc_AI_assms]: "pred_tcb_at proj P t"
+  for pred_tcb[wp, Ipc_AI_2_assms]: "pred_tcb_at proj P t"
 crunch  make_arch_fault_msg
-  for cap_to[wp, Ipc_AI_assms]: "ex_nonz_cap_to p"
+  for cap_to[wp, Ipc_AI_2_assms]: "ex_nonz_cap_to p"
 
 crunch  make_arch_fault_msg
-  for v_ker_map[wp, Ipc_AI_assms]: "valid_kernel_mappings"
+  for v_ker_map[wp, Ipc_AI_2_assms]: "valid_kernel_mappings"
  (simp: valid_kernel_mappings_def)
 
 crunch  make_arch_fault_msg
-  for obj_at[wp, Ipc_AI_assms]: "\<lambda>s. P (obj_at P' pd s)"
+  for obj_at[wp, Ipc_AI_2_assms]: "\<lambda>s. P (obj_at P' pd s)"
   (wp: as_user_inv getRestartPC_inv mapM_wp'  simp: getRegister_def)
 
 lemma dmo_addressTranslateS1_valid_machine_state[wp]:
@@ -472,7 +484,7 @@ lemma dmo_addressTranslateS1_valid_machine_state[wp]:
   by (wpsimp wp: dmo_valid_machine_state)
 
 crunch make_arch_fault_msg
-  for vms[wp, Ipc_AI_assms]: valid_machine_state
+  for vms[wp, Ipc_AI_2_assms]: valid_machine_state
   (wp: as_user_inv getRestartPC_inv mapM_wp'  simp: getRegister_def ignore: do_machine_op)
 
 lemma dmo_addressTranslateS1_valid_irq_states[wp]:
@@ -480,7 +492,7 @@ lemma dmo_addressTranslateS1_valid_irq_states[wp]:
   by (wpsimp wp: dmo_valid_irq_states)
 
 crunch make_arch_fault_msg
-  for valid_irq_states[wp, Ipc_AI_assms]: "valid_irq_states"
+  for valid_irq_states[wp, Ipc_AI_2_assms]: "valid_irq_states"
   (wp: as_user_inv getRestartPC_inv mapM_wp'  simp: getRegister_def ignore: do_machine_op)
 
 lemma dmo_addressTranslateS1_cap_refs_respects_device_region[wp]:
@@ -488,20 +500,39 @@ lemma dmo_addressTranslateS1_cap_refs_respects_device_region[wp]:
   by (wpsimp wp: cap_refs_respects_device_region_dmo)
 
 crunch make_arch_fault_msg
-  for cap_refs_respects_device_region[wp, Ipc_AI_assms]: "cap_refs_respects_device_region"
+  for cap_refs_respects_device_region[wp, Ipc_AI_2_assms]: "cap_refs_respects_device_region"
   (wp: as_user_inv getRestartPC_inv mapM_wp'  simp: getRegister_def ignore: do_machine_op)
+
+lemma setup_caller_cap_aobj_at:
+  "arch_obj_pred P' \<Longrightarrow>
+  \<lbrace>\<lambda>s. P (obj_at P' pd s)\<rbrace> setup_caller_cap st rt grant \<lbrace>\<lambda>r s. P (obj_at P' pd s)\<rbrace>"
+  unfolding setup_caller_cap_def
+  by (wpsimp wp: cap_insert_aobj_at sts.aobj_at)
+
+lemma setup_caller_cap_valid_arch[Ipc_AI_2_assms, wp]:
+  "setup_caller_cap st rt grant \<lbrace>valid_arch_state\<rbrace>"
+  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps[rotated -1] setup_caller_cap_aobj_at)
+
+lemma transfer_caps_loop_valid_arch[Ipc_AI_2_assms]:
+  "\<And>slots caps ep buffer n mi.
+    \<lbrace>valid_arch_state and valid_objs and valid_mdb and K (distinct slots)
+         and (\<lambda>s. \<forall>x \<in> set slots. real_cte_at x s \<and> cte_wp_at (\<lambda>cap. cap = cap.NullCap) x s)
+         and transfer_caps_srcs caps\<rbrace>
+      transfer_caps_loop ep buffer n caps slots mi
+    \<lbrace>\<lambda>_. valid_arch_state\<rbrace>"
+  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps transfer_caps_loop_aobj_at)
 
 end
 
-interpretation Ipc_AI?: Ipc_AI
+interpretation Ipc_AI?: Ipc_AI_2
 proof goal_cases
   interpret Arch .
-  case 1 show ?case by (unfold_locales; (fact Ipc_AI_assms)?)
+  case 1 show ?case by (unfold_locales; (fact Ipc_AI_2_assms)?)
 qed
 
 context Arch begin arch_global_naming
 
-named_theorems Ipc_AI_cont_assms
+named_theorems Ipc_AI_3_assms
 
 lemma dmo_addressTranslateS1_pspace_respects_device_region[wp]:
   "do_machine_op (addressTranslateS1 addr) \<lbrace> pspace_respects_device_region \<rbrace>"
@@ -512,10 +543,10 @@ crunch make_fault_msg
   (wp: as_user_inv getRestartPC_inv mapM_wp'  simp: getRegister_def ignore: do_machine_op)
 
 crunch do_ipc_transfer
-  for pspace_respects_device_region[wp, Ipc_AI_cont_assms]: "pspace_respects_device_region"
+  for pspace_respects_device_region[wp, Ipc_AI_3_assms]: "pspace_respects_device_region"
   (wp: crunch_wps ignore: const_on_failure simp: crunch_simps)
 
-lemma do_ipc_transfer_respects_device_region[Ipc_AI_cont_assms]:
+lemma do_ipc_transfer_respects_device_region[Ipc_AI_3_assms]:
   "\<lbrace>cap_refs_respects_device_region and tcb_at t and  valid_objs and valid_mdb\<rbrace>
    do_ipc_transfer t ep bg grt r
    \<lbrace>\<lambda>rv. cap_refs_respects_device_region\<rbrace>"
@@ -533,7 +564,7 @@ lemma set_mrs_state_hyp_refs_of[wp]:
   by (wp set_mrs_thread_set_dmo thread_set_hyp_refs_trivial | simp)+
 
 crunch do_ipc_transfer
-  for state_hyp_refs_of[wp, Ipc_AI_cont_assms]: "\<lambda> s. P (state_hyp_refs_of s)"
+  for state_hyp_refs_of[wp, Ipc_AI_3_assms]: "\<lambda> s. P (state_hyp_refs_of s)"
   (wp: crunch_wps simp: zipWithM_x_mapM)
 
 lemma arch_derive_cap_untyped:
@@ -554,11 +585,18 @@ lemma valid_arch_mdb_cap_swap:
             ((caps_of_state s)(a \<mapsto> c', b \<mapsto> c))"
   by (auto simp: valid_arch_mdb_def)
 
+lemma do_ipc_transfer_valid_arch[Ipc_AI_3_assms]:
+  "\<lbrace>valid_arch_state and valid_objs and valid_mdb \<rbrace>
+   do_ipc_transfer s ep bg grt r
+   \<lbrace>\<lambda>rv. valid_arch_state\<rbrace>"
+  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps do_ipc_transfer_aobj_at)
+
 end
 
-interpretation Ipc_AI_cont?: Ipc_AI_cont
+interpretation Ipc_AI?: Ipc_AI_3
 proof goal_cases
   interpret Arch .
-  case 1 show ?case by (unfold_locales;(fact Ipc_AI_cont_assms)?)
+  case 1 show ?case by (unfold_locales; (fact Ipc_AI_3_assms)?)
 qed
+
 end

--- a/proof/invariant-abstract/AARCH64/ArchKHeap_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchKHeap_AI.thy
@@ -808,7 +808,9 @@ lemma aobjs_of_lift_aobj_at:
   apply (simp flip: aobjs_of_ako_at_Some)
   done
 
-lemma valid_arch_state_lift_aobj_at:
+(* intended for use inside Arch, as opposed to the interface lemma valid_arch_state_lift_aobj_at,
+   since this architecture does not need cap preservation for valid_arch_state *)
+lemma valid_arch_state_lift_aobj_at_no_caps:
   "f \<lbrace>valid_arch_state\<rbrace>"
   unfolding valid_arch_state_def valid_asid_table_def valid_global_arch_objs_def pt_at_eq
   apply (wp_pre, wps arch aobjs_of_lift_aobj_at)
@@ -816,6 +818,12 @@ lemma valid_arch_state_lift_aobj_at:
                      aobjs_of_lift_aobj_at arch)
   apply simp
   done
+
+(* interface lemma *)
+lemma valid_arch_state_lift_aobj_at:
+  assumes caps: "\<And>P. f \<lbrace>\<lambda>s. P (caps_of_state s)\<rbrace>"
+  shows "f \<lbrace>valid_arch_state\<rbrace>"
+  by (rule valid_arch_state_lift_aobj_at_no_caps)
 
 end
 end
@@ -1009,14 +1017,6 @@ lemma valid_arch_tcb_same_type:
   "\<lbrakk> valid_arch_tcb t s; valid_obj p k s; kheap s p = Some ko; a_type k = a_type ko \<rbrakk>
    \<Longrightarrow> valid_arch_tcb t (s\<lparr>kheap := (kheap s)(p \<mapsto> k)\<rparr>)"
   by (auto simp: valid_arch_tcb_def obj_at_def)
-
-
-(* interface lemma *)
-lemma valid_ioports_lift:
-  assumes x: "\<And>P. f \<lbrace>\<lambda>rv. P (caps_of_state s)\<rbrace>"
-  assumes y: "\<And>P. f \<lbrace>\<lambda>s. P (arch_state s)\<rbrace>"
-  shows      "f \<lbrace>valid_ioports\<rbrace>"
-  by wpsimp
 
 (* interface lemma *)
 lemma valid_arch_mdb_lift:

--- a/proof/invariant-abstract/AARCH64/ArchTcbAcc_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchTcbAcc_AI.thy
@@ -162,6 +162,11 @@ lemma tcb_context_update_aux: "arch_tcb_context_set (P (arch_tcb_context_get atc
                                = tcb_context_update (\<lambda>ctx. P ctx) atcb"
   by (simp add: arch_tcb_context_set_def arch_tcb_context_get_def)
 
+lemma thread_set_valid_arch_state[TcbAcc_AI_assms]:
+  "(\<And>tcb. \<forall>(getF, v) \<in> ran tcb_cap_cases. getF (f tcb) = getF tcb)
+   \<Longrightarrow> thread_set f t \<lbrace> valid_arch_state \<rbrace>"
+  by (wp valid_arch_state_lift_aobj_at_no_caps thread_set.aobj_at)
+
 end
 
 global_interpretation TcbAcc_AI?: TcbAcc_AI

--- a/proof/invariant-abstract/AARCH64/ArchUntyped_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchUntyped_AI.thy
@@ -319,10 +319,6 @@ lemma create_cap_cap_refs_in_kernel_window[wp, Untyped_AI_assms]:
   apply blast
   done
 
-lemma create_cap_ioports[wp, Untyped_AI_assms]:
-  "\<lbrace>valid_ioports and cte_wp_at (\<lambda>_. True) cref\<rbrace> create_cap tp sz p dev (cref,oref) \<lbrace>\<lambda>rv. valid_ioports\<rbrace>"
-  by wpsimp
-
 lemma init_arch_objects_nonempty_table[Untyped_AI_assms, wp]:
   "\<lbrace>(\<lambda>s. \<not> (obj_at (nonempty_table (set (second_level_tables (arch_state s)))) r s)
          \<and> valid_global_objs s \<and> valid_arch_state s \<and> pspace_aligned s) and
@@ -361,6 +357,18 @@ lemma obj_is_device_vui_eq[Untyped_AI_assms]:
   apply (simp add: default_arch_object_def split: aobject_type.split)
   apply (auto simp: arch_is_frame_type_def)
   done
+
+lemma create_cap_valid_arch_state[wp, Untyped_AI_assms]:
+  "\<lbrace>valid_arch_state and cte_wp_at (\<lambda>_. True) cref\<rbrace>
+   create_cap tp sz p dev (cref,oref)
+   \<lbrace>\<lambda>rv. valid_arch_state\<rbrace>"
+  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps create_cap_aobj_at)
+
+lemma set_cap_non_arch_valid_arch_state[Untyped_AI_assms]:
+ "\<lbrace>\<lambda>s. valid_arch_state s \<and> cte_wp_at (\<lambda>_. \<not>is_arch_cap cap) ptr s\<rbrace>
+  set_cap cap ptr
+  \<lbrace>\<lambda>rv. valid_arch_state \<rbrace>"
+  by wpsimp
 
 end
 

--- a/proof/invariant-abstract/ARM/ArchCNodeInv_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchCNodeInv_AI.thy
@@ -423,7 +423,7 @@ lemma cap_swap_cap_refs_in_kernel_window[wp, CNodeInv_AI_assms]:
 
 
 lemma cap_swap_vms[wp, CNodeInv_AI_assms]:
-  "\<lbrace>valid_machine_state\<rbrace>  cap_swap c a c' b \<lbrace>\<lambda>rv. valid_machine_state\<rbrace>"
+  "\<lbrace>valid_machine_state\<rbrace> cap_swap c a c' b \<lbrace>\<lambda>rv. valid_machine_state\<rbrace>"
   apply (simp add: valid_machine_state_def in_user_frame_def)
   apply (wp cap_swap_typ_at
             hoare_vcg_all_lift hoare_vcg_ex_lift hoare_vcg_disj_lift)
@@ -518,11 +518,11 @@ lemma prepare_thread_delete_thread_cap [CNodeInv_AI_assms]:
    \<lbrace>\<lambda>rv s. caps_of_state s x = Some (cap.ThreadCap p)\<rbrace>"
   by (wpsimp simp: prepare_thread_delete_def)
 
-lemma cap_swap_ioports[wp, CNodeInv_AI_assms]:
-  "\<lbrace>valid_ioports and cte_wp_at (weak_derived c) a and cte_wp_at (weak_derived c') b\<rbrace>
-     cap_swap c a c' b
-   \<lbrace>\<lambda>rv. valid_ioports\<rbrace>"
-  by wpsimp
+lemma cap_swap_valid_arch_state[wp, CNodeInv_AI_assms]:
+  "\<lbrace>valid_arch_state and cte_wp_at (weak_derived c) a and cte_wp_at (weak_derived c') b\<rbrace>
+   cap_swap c a c' b
+   \<lbrace>\<lambda>_. valid_arch_state\<rbrace>"
+  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps cap_swap_aobj_at)
 
 end
 
@@ -541,7 +541,7 @@ context Arch begin arch_global_naming
 
 lemma post_cap_delete_pre_is_final_cap':
   "\<And>rv s'' rva s''a s.
-       \<lbrakk>valid_ioports s; caps_of_state s slot = Some cap; is_final_cap' cap s; cap_cleanup_opt cap \<noteq> NullCap\<rbrakk>
+       \<lbrakk> caps_of_state s slot = Some cap; is_final_cap' cap s; cap_cleanup_opt cap \<noteq> NullCap\<rbrakk>
        \<Longrightarrow> post_cap_delete_pre (cap_cleanup_opt cap) ((caps_of_state s)(slot \<mapsto> NullCap))"
   apply (clarsimp simp: cap_cleanup_opt_def cte_wp_at_def post_cap_delete_pre_def arch_cap_cleanup_opt_def
                       split: cap.split_asm if_split_asm

--- a/proof/invariant-abstract/ARM/ArchCSpaceInv_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchCSpaceInv_AI.thy
@@ -14,24 +14,6 @@ begin
 
 context Arch begin arch_global_naming
 
-definition
-   safe_ioport_insert :: "cap \<Rightarrow> cap \<Rightarrow> 'a::state_ext state \<Rightarrow> bool"
-where
-  "safe_ioport_insert newcap oldcap s \<equiv> True"
-
-declare safe_ioport_insert_def[simp]
-
-lemma safe_ioport_insert_triv:
-  "\<not>is_arch_cap newcap \<Longrightarrow> safe_ioport_insert newcap oldcap s"
-  by clarsimp
-
-lemma set_cap_ioports':
- "\<lbrace>\<lambda>s. valid_ioports s
-      \<and> cte_wp_at (\<lambda>cap'. safe_ioport_insert cap cap' s) ptr s\<rbrace>
-    set_cap cap ptr
-  \<lbrace>\<lambda>rv. valid_ioports\<rbrace>"
-  by wpsimp
-
 lemma unique_table_refs_no_cap_asidE:
   "\<lbrakk>caps_of_state s p = Some cap;
     unique_table_refs (caps_of_state s)\<rbrakk>
@@ -47,6 +29,10 @@ lemma unique_table_refs_no_cap_asidE:
 
 lemmas unique_table_refs_no_cap_asidD
      = unique_table_refs_no_cap_asidE[where S="{}"]
+
+lemma set_cap_valid_arch_state[wp]:
+  "set_cap cap ptr \<lbrace> valid_arch_state \<rbrace>"
+  by (wp valid_arch_state_lift_aobj_at_no_caps set_cap.aobj_at)
 
 lemma replace_cap_invs:
   "\<lbrace>\<lambda>s. invs s \<and> cte_wp_at (replaceable s p cap) p s

--- a/proof/invariant-abstract/ARM/ArchCSpace_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchCSpace_AI.thy
@@ -517,15 +517,15 @@ lemma cap_insert_simple_arch_caps_no_ap:
   apply (intro conjI impI allI)
   by (auto simp:is_simple_cap_def[simplified is_simple_cap_arch_def] is_cap_simps)
 
-lemma setup_reply_master_ioports[wp, CSpace_AI_assms]:
-  "\<lbrace>valid_ioports\<rbrace> setup_reply_master c \<lbrace>\<lambda>rv. valid_ioports\<rbrace>"
-  by wpsimp
+lemma cap_insert_derived_valid_arch_state[CSpace_AI_assms]:
+  "\<lbrace>valid_arch_state and (\<lambda>s. cte_wp_at (is_derived (cdt s) src cap) src s)\<rbrace>
+   cap_insert cap src dest
+   \<lbrace>\<lambda>rv. valid_arch_state \<rbrace>"
+  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps cap_insert_aobj_at cap_insert_aobj_at)
 
-lemma cap_insert_derived_ioports[CSpace_AI_assms]:
-  "\<lbrace>valid_ioports and (\<lambda>s. cte_wp_at (is_derived (cdt s) src cap) src s)\<rbrace>
-     cap_insert cap src dest
-   \<lbrace>\<lambda>rv. valid_ioports\<rbrace>"
-  by wpsimp
+lemma setup_reply_master_arch[CSpace_AI_assms]:
+  "setup_reply_master t \<lbrace> valid_arch_state \<rbrace>"
+  by (wpsimp simp: setup_reply_master_def wp: get_cap_wp)
 
 end
 
@@ -553,6 +553,10 @@ lemma is_cap_simps':
   by (cases cap,  (auto simp: is_zombie_def is_arch_cap_def is_nondevice_page_cap_def
                               is_reply_cap_def is_master_reply_cap_def is_nondevice_page_cap_arch_def
                        split: cap.splits arch_cap.splits )+)+
+
+lemma cap_insert_simple_valid_arch_state[wp]:
+  "cap_insert cap src dest \<lbrace> valid_arch_state\<rbrace>"
+  by (wp valid_arch_state_lift_aobj_at_no_caps cap_insert_aobj_at)+
 
 lemma cap_insert_simple_invs:
   "\<lbrace>invs and valid_cap cap and tcb_cap_valid cap dest and

--- a/proof/invariant-abstract/ARM/ArchDetype_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchDetype_AI.thy
@@ -114,10 +114,6 @@ lemma state_hyp_refs_of_detype:
   "state_hyp_refs_of (detype S s) = (\<lambda>x. if x \<in> S then {} else state_hyp_refs_of s x)"
   by (rule ext, simp add: state_hyp_refs_of_def detype_def)
 
-lemma valid_ioports_detype[Detype_AI_assms]:
-  "valid_ioports s \<Longrightarrow> valid_ioports (detype (untyped_range cap) s)"
-  by auto
-
 end
 
 interpretation Detype_AI?: Detype_AI

--- a/proof/invariant-abstract/ARM/ArchFinalise_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchFinalise_AI.thy
@@ -1678,10 +1678,6 @@ lemma (* zombie_cap_two_nonidles *)[Finalise_AI_assms]:
   apply (cases ptr, auto dest: valid_idle_has_null_cap_ARCH[rotated -1])[1]
   done
 
-crunch empty_slot, finalise_cap, send_ipc, receive_ipc
-  for ioports[wp]: valid_ioports
-  (wp: crunch_wps valid_ioports_lift simp: crunch_simps ignore: set_object)
-
 lemma arch_derive_cap_notzombie[wp]:
   "\<lbrace>\<top>\<rbrace> arch_derive_cap acap \<lbrace>\<lambda>rv s. \<not> is_zombie rv\<rbrace>, -"
   by (cases acap; wpsimp simp: arch_derive_cap_def is_zombie_def o_def)

--- a/proof/invariant-abstract/ARM/ArchInvariants_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchInvariants_AI.thy
@@ -948,14 +948,9 @@ where
             vspace_at_asid asid pd s \<and> asid \<noteq> 0)"
 
 definition
-  valid_ioports :: "'z::state_ext state \<Rightarrow> bool"
-where
-  "valid_ioports \<equiv> \<lambda>s. True"
-
-definition
   "valid_arch_mdb r cs \<equiv> True"
 
-declare valid_ioports_def[simp] valid_arch_mdb_def[simp]
+declare valid_arch_mdb_def[simp]
 
 section "Lemmas"
 

--- a/proof/invariant-abstract/ARM/ArchIpc_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchIpc_AI.thy
@@ -10,7 +10,7 @@ begin
 
 context Arch begin arch_global_naming
 
-named_theorems Ipc_AI_assms
+named_theorems Ipc_AI_1_assms
 
 lemma cap_asid_PageCap_None [simp]:
   "cap_asid (ArchObjectCap (PageCap dev r R pgsz None)) = None"
@@ -36,7 +36,7 @@ lemma arch_derive_cap_is_derived:
              | rule conjI)+)
   done
 
-lemma derive_cap_is_derived [Ipc_AI_assms]:
+lemma derive_cap_is_derived [Ipc_AI_1_assms]:
   "\<lbrace>\<lambda>s. c'\<noteq> cap.NullCap \<longrightarrow> cte_wp_at (\<lambda>cap. cap_master_cap cap = cap_master_cap c'
                      \<and> (cap_badge cap, cap_badge c') \<in> capBadge_ordering False
                      \<and> cap_asid cap = cap_asid c'
@@ -62,7 +62,19 @@ lemma derive_cap_is_derived [Ipc_AI_assms]:
   apply(clarsimp simp: valid_cap_def)
   done
 
-lemma is_derived_cap_rights [simp, Ipc_AI_assms]:
+end
+
+interpretation Ipc_AI?: Ipc_AI
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case by (unfold_locales; (fact Ipc_AI_1_assms)?)
+qed
+
+context Arch begin arch_global_naming
+
+named_theorems Ipc_AI_2_assms
+
+lemma is_derived_cap_rights [simp, Ipc_AI_2_assms]:
   "is_derived m p (cap_rights_update R c) = is_derived m p c"
   apply (rule ext)
   apply (simp add: cap_rights_update_def is_derived_def is_cap_simps)
@@ -74,12 +86,12 @@ lemma is_derived_cap_rights [simp, Ipc_AI_assms]:
            split: arch_cap.split cap.split bool.splits)
 
 
-lemma data_to_message_info_valid [Ipc_AI_assms]:
+lemma data_to_message_info_valid [Ipc_AI_2_assms]:
   "valid_message_info (data_to_message_info w)"
   by (simp add: valid_message_info_def data_to_message_info_def  word_and_le1 msg_max_length_def
                 msg_max_extra_caps_def Let_def not_less mask_def)
 
-lemma get_extra_cptrs_length[wp, Ipc_AI_assms]:
+lemma get_extra_cptrs_length[wp, Ipc_AI_2_assms]:
   "\<lbrace>\<lambda>s . valid_message_info mi\<rbrace>
    get_extra_cptrs buf mi
    \<lbrace>\<lambda>rv s. length rv \<le> msg_max_extra_caps\<rbrace>"
@@ -94,19 +106,19 @@ lemma get_extra_cptrs_length[wp, Ipc_AI_assms]:
                  intro: length_upt)
   done
 
-lemma cap_asid_rights_update [simp, Ipc_AI_assms]:
+lemma cap_asid_rights_update [simp, Ipc_AI_2_assms]:
   "cap_asid (cap_rights_update R c) = cap_asid c"
   apply (simp add: cap_rights_update_def acap_rights_update_def split: cap.splits arch_cap.splits bool.splits)
   apply (clarsimp simp: cap_asid_def)
   done
 
-lemma cap_rights_update_vs_cap_ref[simp, Ipc_AI_assms]:
+lemma cap_rights_update_vs_cap_ref[simp, Ipc_AI_2_assms]:
   "vs_cap_ref (cap_rights_update rs cap) = vs_cap_ref cap"
   by (simp add: vs_cap_ref_def cap_rights_update_def
                 acap_rights_update_def
          split: cap.split arch_cap.split bool.splits)
 
-lemma is_derived_cap_rights2[simp, Ipc_AI_assms]:
+lemma is_derived_cap_rights2[simp, Ipc_AI_2_assms]:
   "is_derived m p c (cap_rights_update R c') = is_derived m p c c'"
   apply (case_tac c')
   apply (simp_all add: cap_rights_update_def)
@@ -116,12 +128,12 @@ lemma is_derived_cap_rights2[simp, Ipc_AI_assms]:
   apply (case_tac acap1)
    by (auto simp: acap_rights_update_def)
 
-lemma cap_range_update [simp, Ipc_AI_assms]:
+lemma cap_range_update [simp, Ipc_AI_2_assms]:
   "cap_range (cap_rights_update R cap) = cap_range cap"
   by (auto simp add: cap_range_def cap_rights_update_def acap_rights_update_def
          split: cap.splits arch_cap.splits bool.splits)
 
-lemma derive_cap_idle[wp, Ipc_AI_assms]:
+lemma derive_cap_idle[wp, Ipc_AI_2_assms]:
   "\<lbrace>\<lambda>s. global_refs s \<inter> cap_range cap = {}\<rbrace>
    derive_cap slot cap
   \<lbrace>\<lambda>c s. global_refs s \<inter> cap_range c = {}\<rbrace>, -"
@@ -133,7 +145,7 @@ lemma derive_cap_idle[wp, Ipc_AI_assms]:
   apply (case_tac arch_cap, simp_all)
   done
 
-lemma arch_derive_cap_objrefs_iszombie [Ipc_AI_assms]:
+lemma arch_derive_cap_objrefs_iszombie [Ipc_AI_2_assms]:
   "\<lbrace>\<lambda>s . P (set_option (aobj_ref cap)) False s\<rbrace>
      arch_derive_cap cap
    \<lbrace>\<lambda>rv s. rv \<noteq> NullCap \<longrightarrow> P (obj_refs rv) (is_zombie rv) s\<rbrace>,-"
@@ -141,7 +153,7 @@ lemma arch_derive_cap_objrefs_iszombie [Ipc_AI_assms]:
       apply(rule hoare_pre, wpc?, wp+, simp)+
   done
 
-lemma obj_refs_remove_rights[simp, Ipc_AI_assms]:
+lemma obj_refs_remove_rights[simp, Ipc_AI_2_assms]:
   "obj_refs (remove_rights rs cap) = obj_refs cap"
   by (auto simp add: remove_rights_def cap_rights_update_def
                 acap_rights_update_def
@@ -156,7 +168,7 @@ lemma storeWord_um_inv:
   apply simp
   done
 
-lemma store_word_offs_vms[wp, Ipc_AI_assms]:
+lemma store_word_offs_vms[wp, Ipc_AI_2_assms]:
   "\<lbrace>valid_machine_state\<rbrace> store_word_offs ptr offs v \<lbrace>\<lambda>_. valid_machine_state\<rbrace>"
 proof -
   have aligned_offset_ignore:
@@ -195,12 +207,12 @@ proof -
     done
 qed
 
-lemma is_zombie_update_cap_data[simp, Ipc_AI_assms]:
+lemma is_zombie_update_cap_data[simp, Ipc_AI_2_assms]:
   "is_zombie (update_cap_data P data cap) = is_zombie cap"
   by (simp add: update_cap_data_closedform is_zombie_def arch_update_cap_data_def
          split: cap.splits)
 
-lemma valid_msg_length_strengthen [Ipc_AI_assms]:
+lemma valid_msg_length_strengthen [Ipc_AI_2_assms]:
   "valid_message_info mi \<longrightarrow> unat (mi_length mi) \<le> msg_max_length"
   apply (clarsimp simp: valid_message_info_def)
   apply (subgoal_tac "unat (mi_length mi) \<le> unat (of_nat msg_max_length :: word32)")
@@ -208,7 +220,7 @@ lemma valid_msg_length_strengthen [Ipc_AI_assms]:
   apply (clarsimp simp: un_ui_le word_le_def)
   done
 
-lemma copy_mrs_in_user_frame[wp, Ipc_AI_assms]:
+lemma copy_mrs_in_user_frame[wp, Ipc_AI_2_assms]:
   "\<lbrace>in_user_frame p\<rbrace> copy_mrs t buf t' buf' n \<lbrace>\<lambda>rv. in_user_frame p\<rbrace>"
   by (simp add: in_user_frame_def) (wp hoare_vcg_ex_lift)
 
@@ -221,21 +233,21 @@ lemma make_arch_fault_msg_inv[wp]: "\<lbrace>P\<rbrace> make_arch_fault_msg f t 
   apply wp
   done
 
-lemma make_fault_message_inv[wp, Ipc_AI_assms]:
+lemma make_fault_message_inv[wp, Ipc_AI_2_assms]:
   "\<lbrace>P\<rbrace> make_fault_msg ft t \<lbrace>\<lambda>rv. P\<rbrace>"
   apply (cases ft, simp_all split del: if_split)
      apply (wp as_user_inv getRestartPC_inv mapM_wp'
               | simp add: getRegister_def)+
   done
 
-lemma do_fault_transfer_invs[wp, Ipc_AI_assms]:
+lemma do_fault_transfer_invs[wp, Ipc_AI_2_assms]:
   "\<lbrace>invs and tcb_at receiver\<rbrace>
       do_fault_transfer badge sender receiver recv_buf
    \<lbrace>\<lambda>rv. invs\<rbrace>"
   by (simp add: do_fault_transfer_def split_def | wp
     | clarsimp split: option.split)+
 
-lemma lookup_ipc_buffer_in_user_frame[wp, Ipc_AI_assms]:
+lemma lookup_ipc_buffer_in_user_frame[wp, Ipc_AI_2_assms]:
   "\<lbrace>valid_objs and tcb_at t\<rbrace> lookup_ipc_buffer b t
    \<lbrace>case_option (\<lambda>_. True) in_user_frame\<rbrace>"
   apply (simp add: lookup_ipc_buffer_def)
@@ -338,9 +350,9 @@ lemma transfer_caps_non_null_cte_wp_at:
   done
 
 crunch do_fault_transfer
-  for cte_wp_at[wp,Ipc_AI_assms]: "cte_wp_at P p"
+  for cte_wp_at[wp,Ipc_AI_2_assms]: "cte_wp_at P p"
 
-lemma do_normal_transfer_non_null_cte_wp_at [Ipc_AI_assms]:
+lemma do_normal_transfer_non_null_cte_wp_at [Ipc_AI_2_assms]:
   assumes imp: "\<And>c. P c \<Longrightarrow> \<not> is_untyped_cap c"
   shows  "\<lbrace>valid_objs and cte_wp_at (P and ((\<noteq>) cap.NullCap)) ptr\<rbrace>
    do_normal_transfer st send_buffer ep b gr rt recv_buffer
@@ -351,7 +363,7 @@ lemma do_normal_transfer_non_null_cte_wp_at [Ipc_AI_assms]:
     | clarsimp simp:imp)+
   done
 
-lemma is_derived_ReplyCap [simp, Ipc_AI_assms]:
+lemma is_derived_ReplyCap [simp, Ipc_AI_2_assms]:
   "\<And>m p R. is_derived m p (cap.ReplyCap t False R) = (\<lambda>c. is_master_reply_cap c \<and> obj_ref_of c = t)"
   apply (subst fun_eq_iff)
   apply clarsimp
@@ -372,7 +384,7 @@ lemma do_normal_transfer_tcb_caps:
      | simp add:imp)+
   done
 
-lemma do_ipc_transfer_tcb_caps [Ipc_AI_assms]:
+lemma do_ipc_transfer_tcb_caps [Ipc_AI_2_assms]:
   assumes imp: "\<And>c. P c \<Longrightarrow> \<not> is_untyped_cap c"
   shows
   "\<lbrace>valid_objs and cte_wp_at P (t, ref) and tcb_at t\<rbrace>
@@ -394,7 +406,7 @@ lemma cap_insert_valid_vso_at[wp]:
   apply (clarsimp simp: valid_vso_at_def)
   by (wpsimp wp: sts_obj_at_impossible sts_typ_ats hoare_vcg_ex_lift)
 
-lemma setup_caller_cap_valid_global_objs[wp, Ipc_AI_assms]:
+lemma setup_caller_cap_valid_global_objs[wp, Ipc_AI_2_assms]:
   "\<lbrace>valid_global_objs\<rbrace> setup_caller_cap send recv grant \<lbrace>\<lambda>rv. valid_global_objs\<rbrace>"
   apply (wp valid_global_objs_lift valid_ao_at_lift)
   unfolding setup_caller_cap_def
@@ -402,9 +414,9 @@ lemma setup_caller_cap_valid_global_objs[wp, Ipc_AI_assms]:
   done
 
 crunch handle_arch_fault_reply, arch_get_sanitise_register_info
-  for inv[Ipc_AI_assms]: P
+  for inv[Ipc_AI_2_assms]: P
 
-lemma transfer_caps_loop_valid_vspace_objs[wp, Ipc_AI_assms]:
+lemma transfer_caps_loop_valid_vspace_objs[wp, Ipc_AI_2_assms]:
   "\<lbrace>valid_vspace_objs\<rbrace>
       transfer_caps_loop ep buffer n caps slots mi
     \<lbrace>\<lambda>rv. valid_vspace_objs\<rbrace>"
@@ -419,25 +431,44 @@ lemma transfer_caps_loop_valid_vspace_objs[wp, Ipc_AI_assms]:
         | assumption | simp split del: if_split)+
   done
 
-declare make_arch_fault_msg_inv[Ipc_AI_assms]
+declare make_arch_fault_msg_inv[Ipc_AI_2_assms]
+
+lemma setup_caller_cap_aobj_at:
+  "arch_obj_pred P' \<Longrightarrow>
+  \<lbrace>\<lambda>s. P (obj_at P' pd s)\<rbrace> setup_caller_cap st rt grant \<lbrace>\<lambda>r s. P (obj_at P' pd s)\<rbrace>"
+  unfolding setup_caller_cap_def
+  by (wpsimp wp: cap_insert_aobj_at sts.aobj_at)
+
+lemma setup_caller_cap_valid_arch[Ipc_AI_2_assms, wp]:
+  "setup_caller_cap st rt grant \<lbrace>valid_arch_state\<rbrace>"
+  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps[rotated -1] setup_caller_cap_aobj_at)
+
+lemma transfer_caps_loop_valid_arch[Ipc_AI_2_assms]:
+  "\<And>slots caps ep buffer n mi.
+    \<lbrace>valid_arch_state and valid_objs and valid_mdb and K (distinct slots)
+         and (\<lambda>s. \<forall>x \<in> set slots. real_cte_at x s \<and> cte_wp_at (\<lambda>cap. cap = cap.NullCap) x s)
+         and transfer_caps_srcs caps\<rbrace>
+      transfer_caps_loop ep buffer n caps slots mi
+    \<lbrace>\<lambda>_. valid_arch_state\<rbrace>"
+  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps transfer_caps_loop_aobj_at)
 
 end
 
-interpretation Ipc_AI?: Ipc_AI
+interpretation Ipc_AI?: Ipc_AI_2
 proof goal_cases
   interpret Arch .
-  case 1 show ?case by (unfold_locales; (fact Ipc_AI_assms)?)
+  case 1 show ?case by (unfold_locales; (fact Ipc_AI_2_assms)?)
 qed
 
 context Arch begin arch_global_naming
 
-named_theorems Ipc_AI_cont_assms
+named_theorems Ipc_AI_3_assms
 
 crunch do_ipc_transfer
-  for pspace_respects_device_region[wp, Ipc_AI_cont_assms]: "pspace_respects_device_region"
+  for pspace_respects_device_region[wp, Ipc_AI_3_assms]: "pspace_respects_device_region"
   (wp: crunch_wps ignore: const_on_failure simp: crunch_simps)
 
-lemma do_ipc_transfer_respects_device_region[Ipc_AI_cont_assms]:
+lemma do_ipc_transfer_respects_device_region[Ipc_AI_3_assms]:
   "\<lbrace>cap_refs_respects_device_region and tcb_at t and  valid_objs and valid_mdb\<rbrace>
    do_ipc_transfer t ep bg grt r
    \<lbrace>\<lambda>rv. cap_refs_respects_device_region\<rbrace>"
@@ -455,7 +486,7 @@ lemma set_mrs_state_hyp_refs_of[wp]:
   by (wp set_mrs_thread_set_dmo thread_set_hyp_refs_trivial | simp)+
 
 crunch do_ipc_transfer
-  for state_hyp_refs_of[wp, Ipc_AI_cont_assms]: "\<lambda> s. P (state_hyp_refs_of s)"
+  for state_hyp_refs_of[wp, Ipc_AI_3_assms]: "\<lambda> s. P (state_hyp_refs_of s)"
   (wp: crunch_wps simp: zipWithM_x_mapM)
 
 lemma arch_derive_cap_untyped:
@@ -474,12 +505,18 @@ lemma valid_arch_mdb_cap_swap:
             ((caps_of_state s)(a \<mapsto> c', b \<mapsto> c))"
   by auto
 
+lemma do_ipc_transfer_valid_arch[Ipc_AI_3_assms]:
+  "\<lbrace>valid_arch_state and valid_objs and valid_mdb \<rbrace>
+   do_ipc_transfer s ep bg grt r
+   \<lbrace>\<lambda>rv. valid_arch_state\<rbrace>"
+  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps do_ipc_transfer_aobj_at)
+
 end
 
-interpretation Ipc_AI?: Ipc_AI_cont
-  proof goal_cases
+interpretation Ipc_AI?: Ipc_AI_3
+proof goal_cases
   interpret Arch .
-  case 1 show ?case by (unfold_locales;(fact Ipc_AI_cont_assms)?)
-  qed
+  case 1 show ?case by (unfold_locales;(fact Ipc_AI_3_assms)?)
+qed
 
 end

--- a/proof/invariant-abstract/ARM/ArchKHeap_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchKHeap_AI.thy
@@ -553,7 +553,9 @@ lemma valid_global_pts_lift:
   apply clarsimp
   done
 
-lemma valid_arch_state_lift_aobj_at:
+(* intended for use inside Arch, as opposed to the interface lemma valid_arch_state_lift_aobj_at,
+   since this architecture does not need cap preservation for valid_arch_state *)
+lemma valid_arch_state_lift_aobj_at_no_caps:
   "\<lbrace>valid_arch_state\<rbrace> f \<lbrace>\<lambda>rv. valid_arch_state\<rbrace>"
   apply (simp add: valid_arch_state_def valid_asid_table_def)
   apply (rule hoare_lift_Pf[where f="arch_state", OF _ arch])
@@ -562,6 +564,15 @@ lemma valid_arch_state_lift_aobj_at:
   done
 
 end
+
+(* interface lemma *)
+lemma valid_arch_state_lift_aobj_at:
+  assumes aobj_at:
+    "\<And>P P' pd. arch_obj_pred P' \<Longrightarrow> \<lbrace>\<lambda>s. P (obj_at P' pd s)\<rbrace> f \<lbrace>\<lambda>r s. P (obj_at P' pd s)\<rbrace>"
+  assumes caps: "\<And>P. \<lbrace>\<lambda>s. P (caps_of_state s)\<rbrace> f \<lbrace>\<lambda>_ s. P (caps_of_state s)\<rbrace>"
+  shows "f \<lbrace>valid_arch_state\<rbrace>"
+  by (intro valid_arch_state_lift_aobj_at_no_caps aobj_at)
+
 end
 
 lemma equal_kernel_mappings_lift:
@@ -847,21 +858,11 @@ lemma valid_arch_tcb_same_type:
    \<Longrightarrow> valid_arch_tcb t (s\<lparr>kheap := (kheap s)(p \<mapsto> k)\<rparr>)"
   by (auto simp: valid_arch_tcb_def obj_at_def)
 
-lemma valid_ioports_lift:
-  assumes x: "\<And>P. \<lbrace>\<lambda>s. P (caps_of_state s)\<rbrace> f \<lbrace>\<lambda>rv s. P (caps_of_state s)\<rbrace>"
-  assumes y: "\<And>P. \<lbrace>\<lambda>s. P (arch_state s)\<rbrace> f \<lbrace>\<lambda>rv s. P (arch_state s)\<rbrace>"
-  shows      "\<lbrace>valid_ioports\<rbrace> f \<lbrace>\<lambda>rv. valid_ioports\<rbrace>"
-  apply simp
-  apply (rule hoare_use_eq [where f=caps_of_state, OF x y])
-  done
-
 lemma valid_arch_mdb_lift:
   assumes c: "\<And>P. \<lbrace>\<lambda>s. P (caps_of_state s)\<rbrace> f \<lbrace>\<lambda>r s. P (caps_of_state s)\<rbrace>"
   assumes r: "\<And>P. \<lbrace>\<lambda>s. P (is_original_cap s)\<rbrace> f \<lbrace>\<lambda>r s. P (is_original_cap s)\<rbrace>"
   shows "\<lbrace>\<lambda>s. valid_arch_mdb (is_original_cap s) (caps_of_state s)\<rbrace> f \<lbrace>\<lambda>r s. valid_arch_mdb (is_original_cap s) (caps_of_state s)\<rbrace>"
-  apply (clarsimp simp: valid_def)
-  done
-
+  by (clarsimp simp: valid_def valid_arch_mdb_def)
 
 end
 end

--- a/proof/invariant-abstract/ARM/ArchTcbAcc_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchTcbAcc_AI.thy
@@ -165,6 +165,11 @@ lemma tcb_context_update_aux: "arch_tcb_context_set (P (arch_tcb_context_get atc
                                = tcb_context_update (\<lambda>ctx. P ctx) atcb"
   by (simp add: arch_tcb_context_set_def arch_tcb_context_get_def)
 
+lemma thread_set_valid_arch_state[TcbAcc_AI_assms]:
+  "(\<And>tcb. \<forall>(getF, v) \<in> ran tcb_cap_cases. getF (f tcb) = getF tcb)
+   \<Longrightarrow> thread_set f t \<lbrace> valid_arch_state \<rbrace>"
+  by (wp valid_arch_state_lift_aobj_at_no_caps thread_set.aobj_at)
+
 end
 
 global_interpretation TcbAcc_AI?: TcbAcc_AI

--- a/proof/invariant-abstract/ARM/ArchUntyped_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchUntyped_AI.thy
@@ -558,8 +558,16 @@ lemma obj_is_device_vui_eq[Untyped_AI_assms]:
   apply (auto simp: arch_is_frame_type_def)
   done
 
-lemma create_cap_ioports[wp, Untyped_AI_assms]:
-  "\<lbrace>valid_ioports and cte_wp_at (\<lambda>_. True) cref\<rbrace> create_cap tp sz p dev (cref,oref) \<lbrace>\<lambda>rv. valid_ioports\<rbrace>"
+lemma create_cap_valid_arch_state[wp, Untyped_AI_assms]:
+  "\<lbrace>valid_arch_state and cte_wp_at (\<lambda>_. True) cref\<rbrace>
+   create_cap tp sz p dev (cref,oref)
+   \<lbrace>\<lambda>rv. valid_arch_state\<rbrace>"
+  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps create_cap_aobj_at)
+
+lemma set_cap_non_arch_valid_arch_state[Untyped_AI_assms]:
+ "\<lbrace>\<lambda>s. valid_arch_state s \<and> cte_wp_at (\<lambda>_. \<not>is_arch_cap cap) ptr s\<rbrace>
+  set_cap cap ptr
+  \<lbrace>\<lambda>rv. valid_arch_state \<rbrace>"
   by wpsimp
 
 end

--- a/proof/invariant-abstract/ARM_HYP/ArchCNodeInv_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchCNodeInv_AI.thy
@@ -437,7 +437,7 @@ lemma cap_swap_cap_refs_in_kernel_window[wp, CNodeInv_AI_assms]:
 
 
 lemma cap_swap_vms[wp, CNodeInv_AI_assms]:
-  "\<lbrace>valid_machine_state\<rbrace>  cap_swap c a c' b \<lbrace>\<lambda>rv. valid_machine_state\<rbrace>"
+  "\<lbrace>valid_machine_state\<rbrace> cap_swap c a c' b \<lbrace>\<lambda>rv. valid_machine_state\<rbrace>"
   apply (simp add: valid_machine_state_def in_user_frame_def)
   apply (wp cap_swap_typ_at
             hoare_vcg_all_lift hoare_vcg_ex_lift hoare_vcg_disj_lift)
@@ -534,11 +534,11 @@ lemma prepare_thread_delete_thread_cap [CNodeInv_AI_assms]:
    \<lbrace>\<lambda>rv s. caps_of_state s x = Some (cap.ThreadCap p)\<rbrace>"
   by (wpsimp simp: prepare_thread_delete_def)
 
-lemma cap_swap_ioports[wp, CNodeInv_AI_assms]:
-  "\<lbrace>valid_ioports and cte_wp_at (weak_derived c) a and cte_wp_at (weak_derived c') b\<rbrace>
-     cap_swap c a c' b
-   \<lbrace>\<lambda>rv. valid_ioports\<rbrace>"
-  by wpsimp
+lemma cap_swap_valid_arch_state[wp, CNodeInv_AI_assms]:
+  "\<lbrace>valid_arch_state and cte_wp_at (weak_derived c) a and cte_wp_at (weak_derived c') b\<rbrace>
+   cap_swap c a c' b
+   \<lbrace>\<lambda>_. valid_arch_state\<rbrace>"
+  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps cap_swap_aobj_at)
 
 end
 
@@ -557,7 +557,7 @@ context Arch begin arch_global_naming
 
 lemma post_cap_delete_pre_is_final_cap':
   "\<And>rv s'' rva s''a s.
-       \<lbrakk>valid_ioports s; caps_of_state s slot = Some cap; is_final_cap' cap s; cap_cleanup_opt cap \<noteq> NullCap\<rbrakk>
+       \<lbrakk> caps_of_state s slot = Some cap; is_final_cap' cap s; cap_cleanup_opt cap \<noteq> NullCap\<rbrakk>
        \<Longrightarrow> post_cap_delete_pre (cap_cleanup_opt cap) ((caps_of_state s)(slot \<mapsto> NullCap))"
   apply (clarsimp simp: cap_cleanup_opt_def cte_wp_at_def post_cap_delete_pre_def arch_cap_cleanup_opt_def
                       split: cap.split_asm if_split_asm

--- a/proof/invariant-abstract/ARM_HYP/ArchCSpaceInv_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchCSpaceInv_AI.thy
@@ -14,24 +14,6 @@ begin
 
 context Arch begin arch_global_naming
 
-definition
-   safe_ioport_insert :: "cap \<Rightarrow> cap \<Rightarrow> 'a::state_ext state \<Rightarrow> bool"
-where
-  "safe_ioport_insert newcap oldcap s \<equiv> True"
-
-declare safe_ioport_insert_def[simp]
-
-lemma safe_ioport_insert_triv:
-  "\<not>is_arch_cap newcap \<Longrightarrow> safe_ioport_insert newcap oldcap s"
-  by clarsimp
-
-lemma set_cap_ioports':
- "\<lbrace>\<lambda>s. valid_ioports s
-      \<and> cte_wp_at (\<lambda>cap'. safe_ioport_insert cap cap' s) ptr s\<rbrace>
-    set_cap cap ptr
-  \<lbrace>\<lambda>rv. valid_ioports\<rbrace>"
-  by wpsimp
-
 lemma unique_table_refs_no_cap_asidE:
   "\<lbrakk>caps_of_state s p = Some cap;
     unique_table_refs (caps_of_state s)\<rbrakk>
@@ -47,6 +29,10 @@ lemma unique_table_refs_no_cap_asidE:
 
 lemmas unique_table_refs_no_cap_asidD
      = unique_table_refs_no_cap_asidE[where S="{}"]
+
+lemma set_cap_valid_arch_state[wp]:
+  "set_cap cap ptr \<lbrace> valid_arch_state \<rbrace>"
+  by (wp valid_arch_state_lift_aobj_at_no_caps set_cap.aobj_at)
 
 lemma replace_cap_invs:
   "\<lbrace>\<lambda>s. invs s \<and> cte_wp_at (replaceable s p cap) p s

--- a/proof/invariant-abstract/ARM_HYP/ArchCSpace_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchCSpace_AI.thy
@@ -516,15 +516,15 @@ lemma cap_insert_simple_arch_caps_no_ap:
   apply (intro conjI impI allI)
   by (auto simp:is_simple_cap_def[simplified is_simple_cap_arch_def] is_cap_simps)
 
-lemma setup_reply_master_ioports[wp, CSpace_AI_assms]:
-  "\<lbrace>valid_ioports\<rbrace> setup_reply_master c \<lbrace>\<lambda>rv. valid_ioports\<rbrace>"
-  by wpsimp
+lemma cap_insert_derived_valid_arch_state[CSpace_AI_assms]:
+  "\<lbrace>valid_arch_state and (\<lambda>s. cte_wp_at (is_derived (cdt s) src cap) src s)\<rbrace>
+   cap_insert cap src dest
+   \<lbrace>\<lambda>rv. valid_arch_state \<rbrace>"
+  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps cap_insert_aobj_at cap_insert_aobj_at)
 
-lemma cap_insert_derived_ioports[CSpace_AI_assms]:
-  "\<lbrace>valid_ioports and (\<lambda>s. cte_wp_at (is_derived (cdt s) src cap) src s)\<rbrace>
-     cap_insert cap src dest
-   \<lbrace>\<lambda>rv. valid_ioports\<rbrace>"
-  by wpsimp
+lemma setup_reply_master_arch[CSpace_AI_assms]:
+  "setup_reply_master t \<lbrace> valid_arch_state \<rbrace>"
+  by (wpsimp simp: setup_reply_master_def wp: get_cap_wp)
 
 end
 
@@ -556,6 +556,10 @@ lemma is_cap_simps':
         apply (cases cap; simp)
         apply (case_tac acap; auto simp: )
 by (cases cap; simp)+
+
+lemma cap_insert_simple_valid_arch_state[wp]:
+  "cap_insert cap src dest \<lbrace> valid_arch_state\<rbrace>"
+  by (wp valid_arch_state_lift_aobj_at_no_caps cap_insert_aobj_at)+
 
 lemma cap_insert_simple_invs:
   "\<lbrace>invs and valid_cap cap and tcb_cap_valid cap dest and

--- a/proof/invariant-abstract/ARM_HYP/ArchDetype_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchDetype_AI.thy
@@ -118,10 +118,6 @@ lemma state_hyp_refs_of_detype:
   "state_hyp_refs_of (detype S s) = (\<lambda>x. if x \<in> S then {} else state_hyp_refs_of s x)"
   by (rule ext, simp add: state_hyp_refs_of_def detype_def)
 
-lemma valid_ioports_detype[Detype_AI_assms]:
-  "valid_ioports s \<Longrightarrow> valid_ioports (detype (untyped_range cap) s)"
-  by auto
-
 end
 
 interpretation Detype_AI?: Detype_AI

--- a/proof/invariant-abstract/ARM_HYP/ArchFinalise_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchFinalise_AI.thy
@@ -2445,10 +2445,6 @@ lemma (* zombie_cap_two_nonidles *)[Finalise_AI_assms]:
   apply (cases ptr, auto dest: valid_idle_has_null_cap_ARCH[rotated -1])[1]
   done
 
-crunch empty_slot, finalise_cap, send_ipc, receive_ipc
-  for ioports[wp]: valid_ioports
-  (wp: crunch_wps valid_ioports_lift simp: crunch_simps ignore: set_object)
-
 lemma arch_derive_cap_notzombie[wp]:
   "\<lbrace>\<top>\<rbrace> arch_derive_cap acap \<lbrace>\<lambda>rv s. \<not> is_zombie rv\<rbrace>, -"
   by (cases acap; wpsimp simp: arch_derive_cap_def is_zombie_def o_def)

--- a/proof/invariant-abstract/ARM_HYP/ArchInvariants_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchInvariants_AI.thy
@@ -946,14 +946,9 @@ where
             vspace_at_asid asid pd s \<and> asid \<noteq> 0)"
 
 definition
-  valid_ioports :: "'z::state_ext state \<Rightarrow> bool"
-where
-  "valid_ioports \<equiv> \<lambda>s. True"
-
-definition
   "valid_arch_mdb r cs \<equiv> True"
 
-declare valid_ioports_def[simp] valid_arch_mdb_def[simp]
+declare valid_arch_mdb_def[simp]
 
 section "Lemmas"
 

--- a/proof/invariant-abstract/ARM_HYP/ArchIpc_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchIpc_AI.thy
@@ -10,7 +10,7 @@ begin
 
 context Arch begin arch_global_naming
 
-named_theorems Ipc_AI_assms
+named_theorems Ipc_AI_1_assms
 
 lemma cap_asid_PageCap_None [simp]:
   "cap_asid (ArchObjectCap (PageCap dev r R pgsz None)) = None"
@@ -36,7 +36,7 @@ lemma arch_derive_cap_is_derived:
              | rule conjI)+)
   done
 
-lemma derive_cap_is_derived [Ipc_AI_assms]:
+lemma derive_cap_is_derived [Ipc_AI_1_assms]:
   "\<lbrace>\<lambda>s. c'\<noteq> cap.NullCap \<longrightarrow> cte_wp_at (\<lambda>cap. cap_master_cap cap = cap_master_cap c'
                      \<and> (cap_badge cap, cap_badge c') \<in> capBadge_ordering False
                      \<and> cap_asid cap = cap_asid c'
@@ -62,7 +62,19 @@ lemma derive_cap_is_derived [Ipc_AI_assms]:
   apply(clarsimp simp: valid_cap_def)
   done
 
-lemma is_derived_cap_rights [simp, Ipc_AI_assms]:
+end
+
+interpretation Ipc_AI?: Ipc_AI
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case by (unfold_locales; (fact Ipc_AI_1_assms)?)
+qed
+
+context Arch begin arch_global_naming
+
+named_theorems Ipc_AI_2_assms
+
+lemma is_derived_cap_rights [simp, Ipc_AI_2_assms]:
   "is_derived m p (cap_rights_update R c) = is_derived m p c"
   apply (rule ext)
   apply (simp add: cap_rights_update_def is_derived_def is_cap_simps)
@@ -74,12 +86,12 @@ lemma is_derived_cap_rights [simp, Ipc_AI_assms]:
            split: arch_cap.split cap.split bool.splits)
 
 
-lemma data_to_message_info_valid [Ipc_AI_assms]:
+lemma data_to_message_info_valid [Ipc_AI_2_assms]:
   "valid_message_info (data_to_message_info w)"
   by (simp add: valid_message_info_def data_to_message_info_def  word_and_le1 msg_max_length_def
                 msg_max_extra_caps_def Let_def not_less mask_def)
 
-lemma get_extra_cptrs_length[wp, Ipc_AI_assms]:
+lemma get_extra_cptrs_length[wp, Ipc_AI_2_assms]:
   "\<lbrace>\<lambda>s . valid_message_info mi\<rbrace>
    get_extra_cptrs buf mi
    \<lbrace>\<lambda>rv s. length rv \<le> msg_max_extra_caps\<rbrace>"
@@ -94,18 +106,18 @@ lemma get_extra_cptrs_length[wp, Ipc_AI_assms]:
                  intro: length_upt)
   done
 
-lemma cap_asid_rights_update [simp, Ipc_AI_assms]:
+lemma cap_asid_rights_update [simp, Ipc_AI_2_assms]:
   "cap_asid (cap_rights_update R c) = cap_asid c"
   apply (simp add: cap_rights_update_def acap_rights_update_def split: cap.splits arch_cap.splits)
   done
 
-lemma cap_rights_update_vs_cap_ref[simp, Ipc_AI_assms]:
+lemma cap_rights_update_vs_cap_ref[simp, Ipc_AI_2_assms]:
   "vs_cap_ref (cap_rights_update rs cap) = vs_cap_ref cap"
   by (simp add: vs_cap_ref_def cap_rights_update_def
                 acap_rights_update_def
          split: cap.split arch_cap.split)
 
-lemma is_derived_cap_rights2[simp, Ipc_AI_assms]:
+lemma is_derived_cap_rights2[simp, Ipc_AI_2_assms]:
   "is_derived m p c (cap_rights_update R c') = is_derived m p c c'"
   apply (case_tac c')
   apply (simp_all add:cap_rights_update_def)
@@ -115,12 +127,12 @@ lemma is_derived_cap_rights2[simp, Ipc_AI_assms]:
   apply (case_tac acap1)
    by (auto simp: acap_rights_update_def)
 
-lemma cap_range_update [simp, Ipc_AI_assms]:
+lemma cap_range_update [simp, Ipc_AI_2_assms]:
   "cap_range (cap_rights_update R cap) = cap_range cap"
   by (simp add: cap_range_def cap_rights_update_def acap_rights_update_def
          split: cap.splits arch_cap.splits)
 
-lemma derive_cap_idle[wp, Ipc_AI_assms]:
+lemma derive_cap_idle[wp, Ipc_AI_2_assms]:
   "\<lbrace>\<lambda>s. global_refs s \<inter> cap_range cap = {}\<rbrace>
    derive_cap slot cap
   \<lbrace>\<lambda>c s. global_refs s \<inter> cap_range c = {}\<rbrace>, -"
@@ -132,7 +144,7 @@ lemma derive_cap_idle[wp, Ipc_AI_assms]:
   apply (case_tac arch_cap, simp_all)
   done
 
-lemma arch_derive_cap_objrefs_iszombie [Ipc_AI_assms]:
+lemma arch_derive_cap_objrefs_iszombie [Ipc_AI_2_assms]:
   "\<lbrace>\<lambda>s . P (set_option (aobj_ref cap)) False s\<rbrace>
      arch_derive_cap cap
    \<lbrace>\<lambda>rv s. rv \<noteq> NullCap \<longrightarrow> P (obj_refs rv) (is_zombie rv) s\<rbrace>,-"
@@ -140,7 +152,7 @@ lemma arch_derive_cap_objrefs_iszombie [Ipc_AI_assms]:
       apply(rule hoare_pre, wpsimp+)+
   done
 
-lemma obj_refs_remove_rights[simp, Ipc_AI_assms]:
+lemma obj_refs_remove_rights[simp, Ipc_AI_2_assms]:
   "obj_refs (remove_rights rs cap) = obj_refs cap"
   by (auto simp add: remove_rights_def cap_rights_update_def
                 acap_rights_update_def
@@ -155,7 +167,7 @@ lemma storeWord_um_inv:
   apply simp
   done
 
-lemma store_word_offs_vms[wp, Ipc_AI_assms]:
+lemma store_word_offs_vms[wp, Ipc_AI_2_assms]:
   "\<lbrace>valid_machine_state\<rbrace> store_word_offs ptr offs v \<lbrace>\<lambda>_. valid_machine_state\<rbrace>"
 proof -
   have aligned_offset_ignore:
@@ -194,12 +206,12 @@ proof -
     done
 qed
 
-lemma is_zombie_update_cap_data[simp, Ipc_AI_assms]:
+lemma is_zombie_update_cap_data[simp, Ipc_AI_2_assms]:
   "is_zombie (update_cap_data P data cap) = is_zombie cap"
   by (simp add: update_cap_data_closedform arch_update_cap_data_def is_zombie_def
          split: cap.splits)
 
-lemma valid_msg_length_strengthen [Ipc_AI_assms]:
+lemma valid_msg_length_strengthen [Ipc_AI_2_assms]:
   "valid_message_info mi \<longrightarrow> unat (mi_length mi) \<le> msg_max_length"
   apply (clarsimp simp: valid_message_info_def)
   apply (subgoal_tac "unat (mi_length mi) \<le> unat (of_nat msg_max_length :: word32)")
@@ -207,20 +219,20 @@ lemma valid_msg_length_strengthen [Ipc_AI_assms]:
   apply (clarsimp simp: un_ui_le word_le_def)
   done
 
-lemma copy_mrs_in_user_frame[wp, Ipc_AI_assms]:
+lemma copy_mrs_in_user_frame[wp, Ipc_AI_2_assms]:
   "\<lbrace>in_user_frame p\<rbrace> copy_mrs t buf t' buf' n \<lbrace>\<lambda>rv. in_user_frame p\<rbrace>"
   by (simp add: in_user_frame_def) (wp hoare_vcg_ex_lift)
 
 lemma as_user_getRestart_invs[wp]: "\<lbrace>P\<rbrace> as_user t getRestartPC \<lbrace>\<lambda>_. P\<rbrace>"
   by (simp add: getRestartPC_def, rule user_getreg_inv)
 
-lemma make_arch_fault_msg_invs[wp, Ipc_AI_assms]: "make_arch_fault_msg f t \<lbrace>invs\<rbrace>"
+lemma make_arch_fault_msg_invs[wp, Ipc_AI_2_assms]: "make_arch_fault_msg f t \<lbrace>invs\<rbrace>"
   apply (cases f)
   apply simp_all
   apply (wpsimp simp: do_machine_op_bind addressTranslateS1_def)
   done
 
-lemma make_fault_message_inv[wp, Ipc_AI_assms]:
+lemma make_fault_message_inv[wp, Ipc_AI_2_assms]:
   "make_fault_msg ft t \<lbrace>invs\<rbrace>"
   apply (cases ft, simp_all split del: if_split)
      apply (wp as_user_inv getRestartPC_inv mapM_wp'
@@ -230,14 +242,14 @@ lemma make_fault_message_inv[wp, Ipc_AI_assms]:
 crunch make_fault_msg
   for tcb_at[wp]: "tcb_at t"
 
-lemma do_fault_transfer_invs[wp, Ipc_AI_assms]:
+lemma do_fault_transfer_invs[wp, Ipc_AI_2_assms]:
   "\<lbrace>invs and tcb_at receiver\<rbrace>
       do_fault_transfer badge sender receiver recv_buf
    \<lbrace>\<lambda>rv. invs\<rbrace>"
   by (simp add: do_fault_transfer_def split_def | wp
     | clarsimp split: option.split)+
 
-lemma lookup_ipc_buffer_in_user_frame[wp, Ipc_AI_assms]:
+lemma lookup_ipc_buffer_in_user_frame[wp, Ipc_AI_2_assms]:
   "\<lbrace>valid_objs and tcb_at t\<rbrace> lookup_ipc_buffer b t
    \<lbrace>case_option (\<lambda>_. True) in_user_frame\<rbrace>"
   apply (simp add: lookup_ipc_buffer_def)
@@ -340,9 +352,9 @@ lemma transfer_caps_non_null_cte_wp_at:
   done
 
 crunch do_fault_transfer
-  for cte_wp_at[wp,Ipc_AI_assms]: "cte_wp_at P p"
+  for cte_wp_at[wp,Ipc_AI_2_assms]: "cte_wp_at P p"
 
-lemma do_normal_transfer_non_null_cte_wp_at [Ipc_AI_assms]:
+lemma do_normal_transfer_non_null_cte_wp_at [Ipc_AI_2_assms]:
   assumes imp: "\<And>c. P c \<Longrightarrow> \<not> is_untyped_cap c"
   shows  "\<lbrace>valid_objs and cte_wp_at (P and ((\<noteq>) cap.NullCap)) ptr\<rbrace>
    do_normal_transfer st send_buffer ep b gr rt recv_buffer
@@ -353,7 +365,7 @@ lemma do_normal_transfer_non_null_cte_wp_at [Ipc_AI_assms]:
     | clarsimp simp:imp)+
   done
 
-lemma is_derived_ReplyCap [simp, Ipc_AI_assms]:
+lemma is_derived_ReplyCap [simp, Ipc_AI_2_assms]:
   "\<And>m p R. is_derived m p (cap.ReplyCap t False R) = (\<lambda>c. is_master_reply_cap c \<and> obj_ref_of c = t)"
   apply (subst fun_eq_iff)
   apply clarsimp
@@ -374,7 +386,7 @@ lemma do_normal_transfer_tcb_caps:
      | simp add:imp)+
   done
 
-lemma do_ipc_transfer_tcb_caps [Ipc_AI_assms]:
+lemma do_ipc_transfer_tcb_caps [Ipc_AI_2_assms]:
   assumes imp: "\<And>c. P c \<Longrightarrow> \<not> is_untyped_cap c"
   shows
   "\<lbrace>valid_objs and cte_wp_at P (t, ref) and tcb_at t\<rbrace>
@@ -386,7 +398,7 @@ lemma do_ipc_transfer_tcb_caps [Ipc_AI_assms]:
        | wpc | simp add:imp)+
   done
 
-lemma setup_caller_cap_valid_global_objs[wp, Ipc_AI_assms]:
+lemma setup_caller_cap_valid_global_objs[wp, Ipc_AI_2_assms]:
   "\<lbrace>valid_global_objs\<rbrace> setup_caller_cap send recv grant \<lbrace>\<lambda>rv. valid_global_objs\<rbrace>"
   apply (simp add: valid_global_objs_def)
   unfolding setup_caller_cap_def
@@ -394,9 +406,9 @@ lemma setup_caller_cap_valid_global_objs[wp, Ipc_AI_assms]:
   done
 
 crunch handle_arch_fault_reply, arch_get_sanitise_register_info
-  for typ_at[Ipc_AI_assms]: "P (typ_at T p s)"
+  for typ_at[Ipc_AI_2_assms]: "P (typ_at T p s)"
 
-lemma transfer_caps_loop_valid_vspace_objs[wp, Ipc_AI_assms]:
+lemma transfer_caps_loop_valid_vspace_objs[wp, Ipc_AI_2_assms]:
   "\<lbrace>valid_vspace_objs\<rbrace>
       transfer_caps_loop ep buffer n caps slots mi
     \<lbrace>\<lambda>rv. valid_vspace_objs\<rbrace>"
@@ -425,95 +437,114 @@ lemma dmo_addressTranslateS1_cap_refs_respects_device_region[wp]:
   by (wpsimp  wp: cap_refs_respects_device_region_dmo)
 
 crunch  make_arch_fault_msg
-  for aligned[wp, Ipc_AI_assms]: "pspace_aligned"
+  for aligned[wp, Ipc_AI_2_assms]: "pspace_aligned"
 crunch  make_arch_fault_msg
-  for distinct[wp, Ipc_AI_assms]: "pspace_distinct"
+  for distinct[wp, Ipc_AI_2_assms]: "pspace_distinct"
 crunch  make_arch_fault_msg
-  for vmdb[wp, Ipc_AI_assms]: "valid_mdb"
+  for vmdb[wp, Ipc_AI_2_assms]: "valid_mdb"
 crunch  make_arch_fault_msg
-  for ifunsafe[wp, Ipc_AI_assms]: "if_unsafe_then_cap"
+  for ifunsafe[wp, Ipc_AI_2_assms]: "if_unsafe_then_cap"
 crunch  make_arch_fault_msg
-  for iflive[wp, Ipc_AI_assms]: "if_live_then_nonz_cap"
+  for iflive[wp, Ipc_AI_2_assms]: "if_live_then_nonz_cap"
 crunch  make_arch_fault_msg
-  for state_refs_of[wp, Ipc_AI_assms]: "\<lambda>s. P (state_refs_of s)"
+  for state_refs_of[wp, Ipc_AI_2_assms]: "\<lambda>s. P (state_refs_of s)"
 crunch  make_arch_fault_msg
-  for ct[wp, Ipc_AI_assms]: "cur_tcb"
+  for ct[wp, Ipc_AI_2_assms]: "cur_tcb"
 crunch  make_arch_fault_msg
-  for zombies[wp, Ipc_AI_assms]: "zombies_final"
+  for zombies[wp, Ipc_AI_2_assms]: "zombies_final"
 crunch  make_arch_fault_msg
-  for it[wp, Ipc_AI_assms]: "\<lambda>s. P (idle_thread s)"
+  for it[wp, Ipc_AI_2_assms]: "\<lambda>s. P (idle_thread s)"
 crunch  make_arch_fault_msg
-  for valid_globals[wp, Ipc_AI_assms]: "valid_global_refs"
+  for valid_globals[wp, Ipc_AI_2_assms]: "valid_global_refs"
 crunch  make_arch_fault_msg
-  for reply_masters[wp, Ipc_AI_assms]: "valid_reply_masters"
+  for reply_masters[wp, Ipc_AI_2_assms]: "valid_reply_masters"
 crunch  make_arch_fault_msg
-  for valid_idle[wp, Ipc_AI_assms]: "valid_idle"
+  for valid_idle[wp, Ipc_AI_2_assms]: "valid_idle"
 crunch  make_arch_fault_msg
-  for arch[wp, Ipc_AI_assms]: "\<lambda>s. P (arch_state s)"
+  for arch[wp, Ipc_AI_2_assms]: "\<lambda>s. P (arch_state s)"
 crunch  make_arch_fault_msg
-  for typ_at[wp, Ipc_AI_assms]: "\<lambda>s. P (typ_at T p s)"
+  for typ_at[wp, Ipc_AI_2_assms]: "\<lambda>s. P (typ_at T p s)"
 crunch  make_arch_fault_msg
-  for irq_node[wp, Ipc_AI_assms]: "\<lambda>s. P (interrupt_irq_node s)"
+  for irq_node[wp, Ipc_AI_2_assms]: "\<lambda>s. P (interrupt_irq_node s)"
 crunch  make_arch_fault_msg
-  for valid_reply[wp, Ipc_AI_assms]: "valid_reply_caps"
+  for valid_reply[wp, Ipc_AI_2_assms]: "valid_reply_caps"
 crunch  make_arch_fault_msg
-  for irq_handlers[wp, Ipc_AI_assms]: "valid_irq_handlers"
+  for irq_handlers[wp, Ipc_AI_2_assms]: "valid_irq_handlers"
 crunch  make_arch_fault_msg
-  for vspace_objs[wp, Ipc_AI_assms]: "valid_vspace_objs"
+  for vspace_objs[wp, Ipc_AI_2_assms]: "valid_vspace_objs"
 crunch  make_arch_fault_msg
-  for global_objs[wp, Ipc_AI_assms]: "valid_global_objs"
+  for global_objs[wp, Ipc_AI_2_assms]: "valid_global_objs"
 crunch  make_arch_fault_msg
-  for global_vspace_mapping[wp, Ipc_AI_assms]: "valid_global_vspace_mappings"
+  for global_vspace_mapping[wp, Ipc_AI_2_assms]: "valid_global_vspace_mappings"
 crunch  make_arch_fault_msg
-  for arch_caps[wp, Ipc_AI_assms]: "valid_arch_caps"
+  for arch_caps[wp, Ipc_AI_2_assms]: "valid_arch_caps"
 crunch  make_arch_fault_msg
-  for v_ker_map[wp, Ipc_AI_assms]: "valid_kernel_mappings"
+  for v_ker_map[wp, Ipc_AI_2_assms]: "valid_kernel_mappings"
 crunch  make_arch_fault_msg
-  for eq_ker_map[wp, Ipc_AI_assms]: "equal_kernel_mappings"
+  for eq_ker_map[wp, Ipc_AI_2_assms]: "equal_kernel_mappings"
 crunch  make_arch_fault_msg
-  for asid_map[wp, Ipc_AI_assms]: "valid_asid_map"
+  for asid_map[wp, Ipc_AI_2_assms]: "valid_asid_map"
 crunch  make_arch_fault_msg
-  for only_idle[wp, Ipc_AI_assms]: "only_idle"
+  for only_idle[wp, Ipc_AI_2_assms]: "only_idle"
 crunch  make_arch_fault_msg
-  for pspace_in_kernel_window[wp, Ipc_AI_assms]: "pspace_in_kernel_window"
+  for pspace_in_kernel_window[wp, Ipc_AI_2_assms]: "pspace_in_kernel_window"
 crunch  make_arch_fault_msg
-  for cap_refs_in_kernel_window[wp, Ipc_AI_assms]: "cap_refs_in_kernel_window"
+  for cap_refs_in_kernel_window[wp, Ipc_AI_2_assms]: "cap_refs_in_kernel_window"
 crunch  make_arch_fault_msg
-  for valid_objs[wp, Ipc_AI_assms]: "valid_objs"
+  for valid_objs[wp, Ipc_AI_2_assms]: "valid_objs"
 crunch  make_arch_fault_msg
-  for valid_ioc[wp, Ipc_AI_assms]: "valid_ioc"
+  for valid_ioc[wp, Ipc_AI_2_assms]: "valid_ioc"
 crunch  make_arch_fault_msg
-  for pred_tcb[wp, Ipc_AI_assms]: "pred_tcb_at proj P t"
+  for pred_tcb[wp, Ipc_AI_2_assms]: "pred_tcb_at proj P t"
 crunch  make_arch_fault_msg
-  for cap_to[wp, Ipc_AI_assms]: "ex_nonz_cap_to p"
+  for cap_to[wp, Ipc_AI_2_assms]: "ex_nonz_cap_to p"
 
 crunch  make_arch_fault_msg
-  for obj_at[wp, Ipc_AI_assms]: "\<lambda>s. P (obj_at P' pd s)"
+  for obj_at[wp, Ipc_AI_2_assms]: "\<lambda>s. P (obj_at P' pd s)"
   (wp: as_user_inv getRestartPC_inv mapM_wp'  simp: getRegister_def)
 
 crunch make_arch_fault_msg
-  for vms[wp, Ipc_AI_assms]: valid_machine_state
+  for vms[wp, Ipc_AI_2_assms]: valid_machine_state
   (wp: as_user_inv getRestartPC_inv mapM_wp'  simp: getRegister_def ignore: do_machine_op)
 
 crunch make_arch_fault_msg
-  for valid_irq_states[wp, Ipc_AI_assms]: "valid_irq_states"
+  for valid_irq_states[wp, Ipc_AI_2_assms]: "valid_irq_states"
   (wp: as_user_inv getRestartPC_inv mapM_wp'  simp: getRegister_def ignore: do_machine_op)
 
 crunch make_arch_fault_msg
-  for cap_refs_respects_device_region[wp, Ipc_AI_assms]: "cap_refs_respects_device_region"
+  for cap_refs_respects_device_region[wp, Ipc_AI_2_assms]: "cap_refs_respects_device_region"
   (wp: as_user_inv getRestartPC_inv mapM_wp'  simp: getRegister_def ignore: do_machine_op)
+
+lemma setup_caller_cap_aobj_at:
+  "arch_obj_pred P' \<Longrightarrow>
+  \<lbrace>\<lambda>s. P (obj_at P' pd s)\<rbrace> setup_caller_cap st rt grant \<lbrace>\<lambda>r s. P (obj_at P' pd s)\<rbrace>"
+  unfolding setup_caller_cap_def
+  by (wpsimp wp: cap_insert_aobj_at sts.aobj_at)
+
+lemma setup_caller_cap_valid_arch[Ipc_AI_2_assms, wp]:
+  "setup_caller_cap st rt grant \<lbrace>valid_arch_state\<rbrace>"
+  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps[rotated -1] setup_caller_cap_aobj_at)
+
+lemma transfer_caps_loop_valid_arch[Ipc_AI_2_assms]:
+  "\<And>slots caps ep buffer n mi.
+    \<lbrace>valid_arch_state and valid_objs and valid_mdb and K (distinct slots)
+         and (\<lambda>s. \<forall>x \<in> set slots. real_cte_at x s \<and> cte_wp_at (\<lambda>cap. cap = cap.NullCap) x s)
+         and transfer_caps_srcs caps\<rbrace>
+      transfer_caps_loop ep buffer n caps slots mi
+    \<lbrace>\<lambda>_. valid_arch_state\<rbrace>"
+  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps transfer_caps_loop_aobj_at)
 
 end
 
-interpretation Ipc_AI?: Ipc_AI
+interpretation Ipc_AI?: Ipc_AI_2
 proof goal_cases
   interpret Arch .
-  case 1 show ?case by (unfold_locales; (fact Ipc_AI_assms)?)
+  case 1 show ?case by (unfold_locales; (fact Ipc_AI_2_assms)?)
 qed
 
 context Arch begin arch_global_naming
 
-named_theorems Ipc_AI_cont_assms
+named_theorems Ipc_AI_3_assms
 
 lemma dmo_addressTranslateS1_pspace_respects_device_region[wp]:
   "do_machine_op (addressTranslateS1 pc) \<lbrace>pspace_respects_device_region\<rbrace>"
@@ -524,10 +555,10 @@ crunch make_fault_msg
   (wp: as_user_inv getRestartPC_inv mapM_wp'  simp: getRegister_def ignore: do_machine_op)
 
 crunch do_ipc_transfer
-  for pspace_respects_device_region[wp, Ipc_AI_cont_assms]: "pspace_respects_device_region"
+  for pspace_respects_device_region[wp, Ipc_AI_3_assms]: "pspace_respects_device_region"
   (wp: crunch_wps ignore: const_on_failure simp: crunch_simps)
 
-lemma do_ipc_transfer_respects_device_region[Ipc_AI_cont_assms]:
+lemma do_ipc_transfer_respects_device_region[Ipc_AI_3_assms]:
   "\<lbrace>cap_refs_respects_device_region and tcb_at t and  valid_objs and valid_mdb\<rbrace>
    do_ipc_transfer t ep bg grt r
    \<lbrace>\<lambda>rv. cap_refs_respects_device_region\<rbrace>"
@@ -545,7 +576,7 @@ lemma set_mrs_state_hyp_refs_of[wp]:
   by (wp set_mrs_thread_set_dmo thread_set_hyp_refs_trivial | simp)+
 
 crunch do_ipc_transfer
-  for state_hyp_refs_of[wp, Ipc_AI_cont_assms]: "\<lambda> s. P (state_hyp_refs_of s)"
+  for state_hyp_refs_of[wp, Ipc_AI_3_assms]: "\<lambda> s. P (state_hyp_refs_of s)"
   (wp: crunch_wps simp: zipWithM_x_mapM)
 
 lemma arch_derive_cap_untyped:
@@ -564,11 +595,18 @@ lemma valid_arch_mdb_cap_swap:
             ((caps_of_state s)(a \<mapsto> c', b \<mapsto> c))"
   by auto
 
+lemma do_ipc_transfer_valid_arch[Ipc_AI_3_assms]:
+  "\<lbrace>valid_arch_state and valid_objs and valid_mdb \<rbrace>
+   do_ipc_transfer s ep bg grt r
+   \<lbrace>\<lambda>rv. valid_arch_state\<rbrace>"
+  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps do_ipc_transfer_aobj_at)
+
 end
 
-interpretation Ipc_AI_cont?: Ipc_AI_cont
-  proof goal_cases
+interpretation Ipc_AI?: Ipc_AI_3
+proof goal_cases
   interpret Arch .
-  case 1 show ?case by (unfold_locales;(fact Ipc_AI_cont_assms)?)
-  qed
+  case 1 show ?case by (unfold_locales;(fact Ipc_AI_3_assms)?)
+qed
+
 end

--- a/proof/invariant-abstract/ARM_HYP/ArchKHeap_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchKHeap_AI.thy
@@ -464,7 +464,9 @@ lemma valid_kernel_mappings_lift:
 
 end
 
-lemma valid_arch_state_lift_aobj_at:
+(* intended for use inside Arch, as opposed to the interface lemma valid_arch_state_lift_aobj_at,
+   since this architecture does not need cap preservation for valid_arch_state *)
+lemma valid_arch_state_lift_aobj_at_no_caps:
   assumes aobj_at:
     "\<And>P P' pd. arch_obj_pred P' \<Longrightarrow> \<lbrace>\<lambda>s. P (obj_at P' pd s)\<rbrace> f \<lbrace>\<lambda>r s. P (obj_at P' pd s)\<rbrace>"
   shows "\<lbrace>valid_arch_state\<rbrace> f \<lbrace>\<lambda>rv. valid_arch_state\<rbrace>"
@@ -477,6 +479,14 @@ lemma valid_arch_state_lift_aobj_at:
    apply (clarsimp simp: arch_obj_pred_def non_arch_obj_def is_vcpu_def)
   apply wp
   done
+
+(* interface lemma *)
+lemma valid_arch_state_lift_aobj_at:
+  assumes aobj_at:
+    "\<And>P P' pd. arch_obj_pred P' \<Longrightarrow> \<lbrace>\<lambda>s. P (obj_at P' pd s)\<rbrace> f \<lbrace>\<lambda>r s. P (obj_at P' pd s)\<rbrace>"
+  assumes caps: "\<And>P. \<lbrace>\<lambda>s. P (caps_of_state s)\<rbrace> f \<lbrace>\<lambda>_ s. P (caps_of_state s)\<rbrace>"
+  shows "f \<lbrace>valid_arch_state\<rbrace>"
+  by (intro valid_arch_state_lift_aobj_at_no_caps aobj_at)
 
 end
 
@@ -742,21 +752,11 @@ lemma valid_arch_tcb_same_type:
    \<Longrightarrow> valid_arch_tcb t (s\<lparr>kheap := (kheap s)(p \<mapsto> k)\<rparr>)"
   by (auto simp: valid_arch_tcb_def obj_at_def)
 
-lemma valid_ioports_lift:
-  assumes x: "\<And>P. \<lbrace>\<lambda>s. P (caps_of_state s)\<rbrace> f \<lbrace>\<lambda>rv s. P (caps_of_state s)\<rbrace>"
-  assumes y: "\<And>P. \<lbrace>\<lambda>s. P (arch_state s)\<rbrace> f \<lbrace>\<lambda>rv s. P (arch_state s)\<rbrace>"
-  shows      "\<lbrace>valid_ioports\<rbrace> f \<lbrace>\<lambda>rv. valid_ioports\<rbrace>"
-  apply simp
-  apply (rule hoare_use_eq [where f=caps_of_state, OF x y])
-  done
-
 lemma valid_arch_mdb_lift:
   assumes c: "\<And>P. \<lbrace>\<lambda>s. P (caps_of_state s)\<rbrace> f \<lbrace>\<lambda>r s. P (caps_of_state s)\<rbrace>"
   assumes r: "\<And>P. \<lbrace>\<lambda>s. P (is_original_cap s)\<rbrace> f \<lbrace>\<lambda>r s. P (is_original_cap s)\<rbrace>"
   shows "\<lbrace>\<lambda>s. valid_arch_mdb (is_original_cap s) (caps_of_state s)\<rbrace> f \<lbrace>\<lambda>r s. valid_arch_mdb (is_original_cap s) (caps_of_state s)\<rbrace>"
-  apply (clarsimp simp: valid_def)
-  done
-
+  by (clarsimp simp: valid_def valid_arch_mdb_def)
 
 end
 end

--- a/proof/invariant-abstract/ARM_HYP/ArchTcbAcc_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchTcbAcc_AI.thy
@@ -167,7 +167,10 @@ lemma tcb_context_update_aux: "arch_tcb_context_set (P (arch_tcb_context_get atc
                                = tcb_context_update (\<lambda>ctx. P ctx) atcb"
   by (simp add: arch_tcb_context_set_def arch_tcb_context_get_def)
 
-
+lemma thread_set_valid_arch_state[TcbAcc_AI_assms]:
+  "(\<And>tcb. \<forall>(getF, v) \<in> ran tcb_cap_cases. getF (f tcb) = getF tcb)
+   \<Longrightarrow> thread_set f t \<lbrace> valid_arch_state \<rbrace>"
+  by (wp valid_arch_state_lift_aobj_at_no_caps thread_set.aobj_at)
 
 end
 

--- a/proof/invariant-abstract/ARM_HYP/ArchUntyped_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchUntyped_AI.thy
@@ -443,8 +443,16 @@ lemma obj_is_device_vui_eq[Untyped_AI_assms]:
   apply (auto simp: arch_is_frame_type_def)
   done
 
-lemma create_cap_ioports[wp, Untyped_AI_assms]:
-  "\<lbrace>valid_ioports and cte_wp_at (\<lambda>_. True) cref\<rbrace> create_cap tp sz p dev (cref,oref) \<lbrace>\<lambda>rv. valid_ioports\<rbrace>"
+lemma create_cap_valid_arch_state[wp, Untyped_AI_assms]:
+  "\<lbrace>valid_arch_state and cte_wp_at (\<lambda>_. True) cref\<rbrace>
+   create_cap tp sz p dev (cref,oref)
+   \<lbrace>\<lambda>rv. valid_arch_state\<rbrace>"
+  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps create_cap_aobj_at)
+
+lemma set_cap_non_arch_valid_arch_state[Untyped_AI_assms]:
+ "\<lbrace>\<lambda>s. valid_arch_state s \<and> cte_wp_at (\<lambda>_. \<not>is_arch_cap cap) ptr s\<rbrace>
+  set_cap cap ptr
+  \<lbrace>\<lambda>rv. valid_arch_state \<rbrace>"
   by wpsimp
 
 end

--- a/proof/invariant-abstract/Detype_AI.thy
+++ b/proof/invariant-abstract/Detype_AI.thy
@@ -37,8 +37,6 @@ locale Detype_AI =
                 (\<lambda>m x. if \<exists>k. x = ptr + of_nat k \<and> k < n * word_size then 0 else m x))"
   assumes empty_fail_freeMemory:
     "empty_fail (freeMemory ptr bits)"
-  assumes valid_ioports_detype:
-    "valid_ioports (s::'a state) \<Longrightarrow> valid_ioports (detype (untyped_range cap) s)"
 
 lemma obj_at_detype[simp]:
   "obj_at P p (detype S s) = (p \<notin> S \<and> obj_at P p s)"
@@ -685,11 +683,6 @@ lemma valid_mdb_detype[detype_invs_lemmas]: "valid_mdb (detype (untyped_range ca
    apply (simp add: reply_master_revocable_def detype_def del: split_paired_All)
   apply (simp add: valid_arch_mdb_detype)
   done
-
-lemma valid_ioports_detype[detype_invs_lemmas]:
-  "valid_ioports (detype (untyped_range cap) s)"
-  apply (insert invs, drule invs_valid_ioports)
-  by (clarsimp simp: valid_ioports_detype)
 
 lemma untype_children_detype[detype_invs_lemmas]: "untyped_children_in_mdb (detype (untyped_range cap) s)"
   apply (insert child)

--- a/proof/invariant-abstract/Finalise_AI.thy
+++ b/proof/invariant-abstract/Finalise_AI.thy
@@ -631,7 +631,7 @@ lemma (in Finalise_AI_1) unbind_maybe_notification_invs:
   apply (simp add: unbind_maybe_notification_def invs_def valid_state_def valid_pspace_def)
   apply (rule bind_wp [OF _ get_simple_ko_sp])
   apply (rule hoare_pre)
-   apply (wpsimp wp: valid_irq_node_typ set_simple_ko_valid_objs valid_ioports_lift)
+   apply (wpsimp wp: valid_irq_node_typ set_simple_ko_valid_objs)
   apply simp
   apply safe
   defer 3 defer 6

--- a/proof/invariant-abstract/InterruptAcc_AI.thy
+++ b/proof/invariant-abstract/InterruptAcc_AI.thy
@@ -51,7 +51,6 @@ definition all_invs_but_valid_irq_states_for where
   equal_kernel_mappings and
   valid_asid_map and
   valid_global_objs and
-  valid_ioports and
   valid_global_vspace_mappings and
   pspace_in_kernel_window and
   cap_refs_in_kernel_window and

--- a/proof/invariant-abstract/Invariants_AI.thy
+++ b/proof/invariant-abstract/Invariants_AI.thy
@@ -47,7 +47,6 @@ arch_requalify_consts
   valid_vspace_objs
   valid_arch_caps
   valid_global_objs
-  valid_ioports
   valid_kernel_mappings
   equal_kernel_mappings
   valid_global_vspace_mappings
@@ -75,7 +74,6 @@ arch_requalify_facts
   valid_vspace_obj_typ
   arch_kobj_size_bounded
   global_refs_lift
-  valid_arch_state_lift
   aobj_at_default_arch_cap_valid
   aobj_ref_default
   wf_acap_rights_update_id
@@ -1005,7 +1003,6 @@ where
                   and valid_irq_node
                   and valid_irq_handlers
                   and valid_irq_states
-                  and valid_ioports
                   and valid_machine_state
                   and valid_vspace_objs
                   and valid_arch_caps
@@ -1086,8 +1083,7 @@ abbreviation(input)
        and valid_arch_state and valid_machine_state and valid_irq_states
        and valid_irq_node and valid_irq_handlers and valid_vspace_objs
        and valid_arch_caps and valid_global_objs and valid_kernel_mappings
-       and equal_kernel_mappings and valid_asid_map and valid_ioports
-       and valid_global_vspace_mappings
+       and equal_kernel_mappings and valid_asid_map and valid_global_vspace_mappings
        and pspace_in_kernel_window and cap_refs_in_kernel_window
        and pspace_respects_device_region and cap_refs_respects_device_region
        and cur_tcb"
@@ -2675,10 +2671,6 @@ lemma cap_refs_in_kernel_window_update [iff]:
   "cap_refs_in_kernel_window (f s) = cap_refs_in_kernel_window s"
   by (simp add: cap_refs_in_kernel_window_def arch pspace)
 
-lemma valid_ioports_update[iff]:
-  "valid_ioports (f s) = valid_ioports s"
-  by (simp add: valid_ioports_def arch)
-
 end
 
 
@@ -3351,10 +3343,6 @@ lemma invs_valid_asid_map[elim!]:
   "invs s \<Longrightarrow> valid_asid_map s"
   by (simp add: invs_def valid_state_def)
 
-lemma invs_valid_ioports[elim!]:
-  "invs s \<Longrightarrow> valid_ioports s"
-  by (simp add: invs_def valid_state_def)
-
 lemma invs_equal_kernel_mappings[elim!]:
   "invs s \<Longrightarrow> equal_kernel_mappings s"
   by (simp add:invs_def valid_state_def)
@@ -3473,7 +3461,6 @@ lemmas invs_implies =
   invs_arch_state
   invs_valid_asid_map
   invs_valid_global_objs
-  invs_valid_ioports
   invs_vspace_objs
   invs_psp_aligned
   invs_distinct

--- a/proof/invariant-abstract/IpcCancel_AI.thy
+++ b/proof/invariant-abstract/IpcCancel_AI.thy
@@ -356,7 +356,7 @@ lemma blocked_cancel_ipc_invs:
    apply (simp add: valid_tcb_state_def)
    apply (strengthen reply_cap_doesnt_exist_strg)
    apply simp
-   apply (wp valid_irq_node_typ valid_ioports_lift)
+   apply (wp valid_irq_node_typ)
   apply (subgoal_tac "ep \<noteq> Structures_A.IdleEP")
    apply (clarsimp simp: ep_redux_simps2 cong: if_cong)
    apply (frule(1) if_live_then_nonz_capD, (clarsimp simp: live_def)+)
@@ -365,10 +365,10 @@ lemma blocked_cancel_ipc_invs:
    apply (frule st_tcb_at_state_refs_ofD)
    apply (subgoal_tac "epptr \<notin> set (remove1 t queue)")
     apply (case_tac ep, simp_all add: valid_ep_def)[1]
-     apply (auto elim!: delta_sym_refs pred_tcb_weaken_strongerE
-                 simp: obj_at_def is_ep_def2 idle_not_queued refs_in_tcb_bound_refs
-                 dest: idle_no_refs
-                 split: if_split_asm)[2]
+     apply (timeit \<open>auto elim!: delta_sym_refs pred_tcb_weaken_strongerE
+                         simp: obj_at_def is_ep_def2 idle_not_queued refs_in_tcb_bound_refs
+                         dest: idle_no_refs
+                         split: if_split_asm\<close>)[2] (* slow: ~100s *)
    apply (case_tac ep, simp_all add: valid_ep_def)[1]
     apply (clarsimp, drule(1) bspec, clarsimp simp: obj_at_def is_tcb_def)+
   apply fastforce
@@ -387,7 +387,7 @@ lemma cancel_signal_invs:
   apply (rule bind_wp [OF _ get_simple_ko_sp])
   apply (case_tac "ntfn_obj ntfna", simp_all)[1]
   apply (rule hoare_pre)
-   apply (wp set_simple_ko_valid_objs valid_irq_node_typ sts_only_idle valid_ioports_lift
+   apply (wp set_simple_ko_valid_objs valid_irq_node_typ sts_only_idle
            | simp add: valid_tcb_state_def
            | strengthen reply_cap_doesnt_exist_strg
            | wpc)+
@@ -878,7 +878,7 @@ lemma cancel_all_ipc_invs_helper:
    apply wp
    apply simp
   apply (rule hoare_pre)
-   apply (wp cancel_all_invs_helper hoare_vcg_const_Ball_lift valid_irq_node_typ valid_ioports_lift)
+   apply (wp cancel_all_invs_helper hoare_vcg_const_Ball_lift valid_irq_node_typ)
   apply (clarsimp simp: invs_def valid_state_def valid_pspace_def valid_ep_def live_def)
   apply (rule conjI)
    apply (fastforce simp: live_def is_ep_def elim!: obj_at_weakenE split: kernel_object.splits)
@@ -979,7 +979,7 @@ lemma unbind_notification_invs:
   apply (case_tac ntfnptr, clarsimp, wp, simp)
   apply clarsimp
   apply (rule bind_wp [OF _ get_simple_ko_sp])
-  apply (wp valid_irq_node_typ set_simple_ko_valid_objs valid_ioports_lift
+  apply (wp valid_irq_node_typ set_simple_ko_valid_objs
          | clarsimp split del: if_split)+
   apply (intro conjI impI;
     (match conclusion in "sym_refs r" for r \<Rightarrow> \<open>-\<close>
@@ -1036,7 +1036,7 @@ lemma cancel_all_signals_invs:
   apply (rule bind_wp [OF _ get_simple_ko_sp])
   apply (rule hoare_pre)
    apply (wp cancel_all_invs_helper set_simple_ko_valid_objs valid_irq_node_typ
-             hoare_vcg_const_Ball_lift valid_ioports_lift
+             hoare_vcg_const_Ball_lift
         | wpc
         | simp add: live_def)+
   apply (clarsimp simp: invs_def valid_state_def valid_pspace_def)
@@ -1199,13 +1199,13 @@ lemma cancel_badged_sends_invs[wp]:
   apply (case_tac ep; simp)
     apply wpsimp
    apply (simp add: invs_def valid_state_def valid_pspace_def)
-   apply (wpsimp wp: valid_irq_node_typ valid_ioports_lift)
+   apply (wpsimp wp: valid_irq_node_typ)
      apply (simp add: fun_upd_def[symmetric] ep_redux_simps ep_at_def2[symmetric, simplified]
                 cong: list.case_cong)
      apply (rule hoare_strengthen_post,
             rule cancel_badged_sends_filterM_helper[where epptr=epptr])
      apply (auto intro:obj_at_weakenE)[1]
-    apply (wpsimp wp: valid_irq_node_typ set_endpoint_ep_at valid_ioports_lift)
+    apply (wpsimp wp: valid_irq_node_typ set_endpoint_ep_at)
    apply (clarsimp simp: valid_ep_def conj_comms)
    apply (subst obj_at_weakenE, simp, fastforce)
     apply (clarsimp simp: is_ep_def)

--- a/proof/invariant-abstract/RISCV64/ArchArch_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchArch_AI.thy
@@ -628,13 +628,6 @@ lemma safe_parent_cap_is_device:
   "safe_parent_for m p cap pcap \<Longrightarrow> cap_is_device cap = cap_is_device pcap"
   by (simp add: safe_parent_for_def)
 
-lemma cap_insert_ioports_ap:
-  "\<lbrace>valid_ioports and (\<lambda>s. cte_wp_at (\<lambda>cap'. safe_ioport_insert cap cap' s) dest s) and
-        K (is_ap_cap cap)\<rbrace>
-     cap_insert cap src dest
-   \<lbrace>\<lambda>rv. valid_ioports\<rbrace>"
-  by wpsimp
-
 crunch cap_insert
   for aobjs_of[wp]: "\<lambda>s. P (aobjs_of s)"
   (wp: crunch_wps)
@@ -660,7 +653,7 @@ lemma cap_insert_ap_invs:
   apply (simp cong: conj_cong)
   apply (rule hoare_pre)
    apply (wp cap_insert_simple_mdb cap_insert_iflive
-             cap_insert_zombies cap_insert_ifunsafe cap_insert_ioports_ap
+             cap_insert_zombies cap_insert_ifunsafe
              cap_insert_valid_global_refs cap_insert_idle
              valid_irq_node_typ cap_insert_simple_arch_caps_ap)
   apply (clarsimp simp: is_simple_cap_def cte_wp_at_caps_of_state is_cap_simps)

--- a/proof/invariant-abstract/RISCV64/ArchCNodeInv_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchCNodeInv_AI.thy
@@ -427,15 +427,8 @@ lemma cap_swap_cap_refs_in_kernel_window[wp, CNodeInv_AI_assms]:
                simp: cte_wp_at_caps_of_state weak_derived_cap_range)
   done
 
-
-lemma cap_swap_ioports[wp, CNodeInv_AI_assms]:
-  "\<lbrace>valid_ioports and cte_wp_at (weak_derived c) a and cte_wp_at (weak_derived c') b\<rbrace>
-     cap_swap c a c' b
-   \<lbrace>\<lambda>rv. valid_ioports\<rbrace>"
-  by wpsimp
-
 lemma cap_swap_vms[wp, CNodeInv_AI_assms]:
-  "\<lbrace>valid_machine_state\<rbrace>  cap_swap c a c' b \<lbrace>\<lambda>rv. valid_machine_state\<rbrace>"
+  "\<lbrace>valid_machine_state\<rbrace> cap_swap c a c' b \<lbrace>\<lambda>rv. valid_machine_state\<rbrace>"
   apply (simp add: valid_machine_state_def in_user_frame_def)
   apply (wp cap_swap_typ_at
             hoare_vcg_all_lift hoare_vcg_ex_lift hoare_vcg_disj_lift)
@@ -529,6 +522,12 @@ lemma prepare_thread_delete_thread_cap [CNodeInv_AI_assms]:
    \<lbrace>\<lambda>rv s. caps_of_state s x = Some (cap.ThreadCap p)\<rbrace>"
   by (wpsimp simp: prepare_thread_delete_def)
 
+lemma cap_swap_valid_arch_state[wp, CNodeInv_AI_assms]:
+  "\<lbrace>valid_arch_state and cte_wp_at (weak_derived c) a and cte_wp_at (weak_derived c') b\<rbrace>
+   cap_swap c a c' b
+   \<lbrace>\<lambda>_. valid_arch_state\<rbrace>"
+  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps cap_swap_aobj_at)
+
 end
 
 
@@ -546,7 +545,7 @@ context Arch begin arch_global_naming
 
 lemma post_cap_delete_pre_is_final_cap':
   "\<And>s.
-       \<lbrakk>valid_ioports s; caps_of_state s slot = Some cap; is_final_cap' cap s; cap_cleanup_opt cap \<noteq> NullCap\<rbrakk>
+       \<lbrakk> caps_of_state s slot = Some cap; is_final_cap' cap s; cap_cleanup_opt cap \<noteq> NullCap\<rbrakk>
        \<Longrightarrow> post_cap_delete_pre (cap_cleanup_opt cap) ((caps_of_state s)(slot \<mapsto> NullCap))"
   apply (clarsimp simp: cap_cleanup_opt_def cte_wp_at_def post_cap_delete_pre_def
                       split: cap.split_asm if_split_asm
@@ -943,14 +942,6 @@ global_interpretation CNodeInv_AI_4?: CNodeInv_AI_4
 
 context Arch begin arch_global_naming
 
-lemma cap_move_ioports:
-  "\<lbrace>valid_ioports and cte_wp_at ((=) cap.NullCap) ptr'
-         and cte_wp_at (weak_derived cap) ptr
-         and cte_wp_at (\<lambda>c. c \<noteq> cap.NullCap) ptr and K (ptr \<noteq> ptr')\<rbrace>
-     cap_move cap ptr ptr'
-   \<lbrace>\<lambda>rv. valid_ioports\<rbrace>"
-  by wpsimp
-
 lemma cap_move_invs[wp, CNodeInv_AI_assms]:
   "\<lbrace>invs and valid_cap cap and cte_wp_at ((=) cap.NullCap) ptr'
          and tcb_cap_valid cap ptr'
@@ -970,7 +961,6 @@ lemma cap_move_invs[wp, CNodeInv_AI_assms]:
    apply (wpe cap_move_replies)
    apply (wpe cap_move_valid_arch_caps)
    apply (wpe cap_move_valid_ioc)
-   apply (wpe cap_move_ioports)
    apply (simp add: cap_move_def set_cdt_def)
    apply (rule hoare_pre)
     apply (wp set_cap_valid_objs set_cap_idle set_cap_typ_at

--- a/proof/invariant-abstract/RISCV64/ArchCSpaceInv_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchCSpaceInv_AI.thy
@@ -14,20 +14,9 @@ begin
 
 context Arch begin arch_global_naming
 
-definition
-   safe_ioport_insert :: "cap \<Rightarrow> cap \<Rightarrow> 'a::state_ext state \<Rightarrow> bool"
-where
-  "safe_ioport_insert newcap oldcap \<equiv> \<lambda>_. True"
-
-lemma safe_ioport_insert_triv:
-  "\<not>is_arch_cap newcap \<Longrightarrow> safe_ioport_insert newcap oldcap s"
-  by (clarsimp simp: safe_ioport_insert_def)
-
-lemma set_cap_ioports':
- "\<lbrace>\<lambda>s. valid_ioports s \<and> cte_wp_at (\<lambda>cap'. safe_ioport_insert cap cap' s) ptr s\<rbrace>
-    set_cap cap ptr
-  \<lbrace>\<lambda>rv. valid_ioports\<rbrace>"
-  by wpsimp
+lemma set_cap_valid_arch_state[wp]:
+  "set_cap cap ptr \<lbrace> valid_arch_state \<rbrace>"
+  by (wp valid_arch_state_lift_aobj_at_no_caps set_cap.aobj_at)
 
 lemma replace_cap_invs:
   "\<lbrace>\<lambda>s. invs s \<and> cte_wp_at (replaceable s p cap) p s

--- a/proof/invariant-abstract/RISCV64/ArchCSpace_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchCSpace_AI.thy
@@ -477,15 +477,15 @@ lemma cap_insert_simple_arch_caps_no_ap:
   apply (intro conjI impI allI)
   by (auto simp:is_simple_cap_def[simplified is_simple_cap_arch_def] is_cap_simps)
 
-lemma setup_reply_master_ioports[wp, CSpace_AI_assms]:
-  "\<lbrace>valid_ioports\<rbrace> setup_reply_master c \<lbrace>\<lambda>rv. valid_ioports\<rbrace>"
-  by wpsimp
+lemma cap_insert_derived_valid_arch_state[CSpace_AI_assms]:
+  "\<lbrace>valid_arch_state and (\<lambda>s. cte_wp_at (is_derived (cdt s) src cap) src s)\<rbrace>
+   cap_insert cap src dest
+   \<lbrace>\<lambda>rv. valid_arch_state \<rbrace>"
+  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps cap_insert_aobj_at cap_insert_aobj_at)
 
-lemma cap_insert_derived_ioports[CSpace_AI_assms]:
-  "\<lbrace>valid_ioports and (\<lambda>s. cte_wp_at (is_derived (cdt s) src cap) src s)\<rbrace>
-     cap_insert cap src dest
-   \<lbrace>\<lambda>rv. valid_ioports\<rbrace>"
-  by wpsimp
+lemma setup_reply_master_arch[CSpace_AI_assms]:
+  "setup_reply_master t \<lbrace> valid_arch_state \<rbrace>"
+  by (wpsimp simp: setup_reply_master_def wp: get_cap_wp)
 
 end
 
@@ -513,6 +513,10 @@ lemma is_cap_simps':
   by (cases cap, auto simp: is_zombie_def is_arch_cap_def is_nondevice_page_cap_def
                             is_reply_cap_def is_master_reply_cap_def is_FrameCap_def
                      split: cap.splits arch_cap.splits)+
+
+lemma cap_insert_simple_valid_arch_state[wp]:
+  "cap_insert cap src dest \<lbrace> valid_arch_state\<rbrace>"
+  by (wp valid_arch_state_lift_aobj_at_no_caps cap_insert_aobj_at)+
 
 lemma cap_insert_simple_invs:
   "\<lbrace>invs and valid_cap cap and tcb_cap_valid cap dest and

--- a/proof/invariant-abstract/RISCV64/ArchDetype_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchDetype_AI.thy
@@ -107,10 +107,6 @@ lemma state_hyp_refs_of_detype:
   "state_hyp_refs_of (detype S s) = (\<lambda>x. if x \<in> S then {} else state_hyp_refs_of s x)"
   by (rule ext, simp add: state_hyp_refs_of_def detype_def)
 
-lemma valid_ioports_detype[Detype_AI_assms]:
-  "valid_ioports s \<Longrightarrow> valid_ioports (detype (untyped_range cap) s)"
-  by simp
-
 end
 
 interpretation Detype_AI?: Detype_AI

--- a/proof/invariant-abstract/RISCV64/ArchFinalise_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchFinalise_AI.thy
@@ -1363,10 +1363,6 @@ lemma (* zombie_cap_two_nonidles *)[Finalise_AI_assms]:
   apply (cases ptr, auto dest: valid_idle_has_null_cap_ARCH[rotated -1])[1]
   done
 
-crunch empty_slot, finalise_cap, send_ipc, receive_ipc
-  for ioports[wp]: valid_ioports
-  (wp: crunch_wps valid_ioports_lift simp: crunch_simps ignore: set_object)
-
 lemma arch_derive_cap_notzombie[wp]:
   "\<lbrace>\<top>\<rbrace> arch_derive_cap acap \<lbrace>\<lambda>rv s. \<not> is_zombie rv\<rbrace>, -"
   by (cases acap; wpsimp simp: arch_derive_cap_def is_zombie_def o_def)

--- a/proof/invariant-abstract/RISCV64/ArchInvariants_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchInvariants_AI.thy
@@ -629,9 +629,6 @@ definition valid_asid_map :: "'z::state_ext state \<Rightarrow> bool" where
 definition valid_global_objs :: "'z::state_ext state \<Rightarrow> bool" where
   "valid_global_objs \<equiv> \<top>"
 
-definition valid_ioports :: "'z::state_ext state \<Rightarrow> bool" where
-  [simp]: "valid_ioports \<equiv> \<top>"
-
 
 (* This definition is needed as interface for other architectures only.
    In other architectures, S is a set of object references (to global tables) that
@@ -2778,10 +2775,6 @@ lemma valid_vs_lookup_update [iff]:
 lemma valid_table_caps_update [iff]:
   "valid_table_caps (f s) = valid_table_caps s"
   by (simp add: valid_table_caps_def arch pspace)
-
-lemma valid_ioports_update[iff]:
-  "valid_ioports (f s) = valid_ioports s"
-  by simp
 
 lemma valid_asid_table_update [iff]:
   "valid_asid_table (f s) = valid_asid_table s"

--- a/proof/invariant-abstract/RISCV64/ArchIpc_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchIpc_AI.thy
@@ -10,7 +10,7 @@ begin
 
 context Arch begin arch_global_naming
 
-named_theorems Ipc_AI_assms
+named_theorems Ipc_AI_1_assms
 
 lemma cap_asid_PageCap_None[simp]:
   "cap_asid (ArchObjectCap (FrameCap r R pgsz dev None)) = None"
@@ -36,7 +36,7 @@ lemma arch_derive_cap_is_derived:
              | rule conjI)+)
   done
 
-lemma derive_cap_is_derived [Ipc_AI_assms]:
+lemma derive_cap_is_derived [Ipc_AI_1_assms]:
   "\<lbrace>\<lambda>s. c'\<noteq> cap.NullCap \<longrightarrow> cte_wp_at (\<lambda>cap. cap_master_cap cap = cap_master_cap c'
                      \<and> (cap_badge cap, cap_badge c') \<in> capBadge_ordering False
                      \<and> cap_asid cap = cap_asid c'
@@ -62,7 +62,19 @@ lemma derive_cap_is_derived [Ipc_AI_assms]:
   apply(clarsimp simp: valid_cap_def)
   done
 
-lemma is_derived_cap_rights [simp, Ipc_AI_assms]:
+end
+
+interpretation Ipc_AI?: Ipc_AI
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case by (unfold_locales; (fact Ipc_AI_1_assms)?)
+qed
+
+context Arch begin arch_global_naming
+
+named_theorems Ipc_AI_2_assms
+
+lemma is_derived_cap_rights [simp, Ipc_AI_2_assms]:
   "is_derived m p (cap_rights_update R c) = is_derived m p c"
   apply (rule ext)
   apply (simp add: cap_rights_update_def is_derived_def is_cap_simps)
@@ -74,12 +86,12 @@ lemma is_derived_cap_rights [simp, Ipc_AI_assms]:
            split: arch_cap.split cap.split bool.splits)
 
 
-lemma data_to_message_info_valid [Ipc_AI_assms]:
+lemma data_to_message_info_valid [Ipc_AI_2_assms]:
   "valid_message_info (data_to_message_info w)"
   by (simp add: valid_message_info_def data_to_message_info_def  word_and_le1 msg_max_length_def
                 msg_max_extra_caps_def Let_def not_less mask_def)
 
-lemma get_extra_cptrs_length[wp, Ipc_AI_assms]:
+lemma get_extra_cptrs_length[wp, Ipc_AI_2_assms]:
   "\<lbrace>\<lambda>s . valid_message_info mi\<rbrace>
    get_extra_cptrs buf mi
    \<lbrace>\<lambda>rv s. length rv \<le> msg_max_extra_caps\<rbrace>"
@@ -94,17 +106,17 @@ lemma get_extra_cptrs_length[wp, Ipc_AI_assms]:
                  intro: length_upt)
   done
 
-lemma cap_asid_rights_update [simp, Ipc_AI_assms]:
+lemma cap_asid_rights_update [simp, Ipc_AI_2_assms]:
   "cap_asid (cap_rights_update R c) = cap_asid c"
   by (simp add: cap_rights_update_def acap_rights_update_def cap_asid_def
          split: cap.splits arch_cap.splits)
 
-lemma cap_rights_update_vs_cap_ref[simp, Ipc_AI_assms]:
+lemma cap_rights_update_vs_cap_ref[simp, Ipc_AI_2_assms]:
   "vs_cap_ref (cap_rights_update rs cap) = vs_cap_ref cap"
   by (simp add: vs_cap_ref_def vs_cap_ref_arch_def cap_rights_update_def acap_rights_update_def
          split: cap.split arch_cap.split)
 
-lemma is_derived_cap_rights2[simp, Ipc_AI_assms]:
+lemma is_derived_cap_rights2[simp, Ipc_AI_2_assms]:
   "is_derived m p c (cap_rights_update R c') = is_derived m p c c'"
   apply (case_tac c'; simp add: cap_rights_update_def)
      apply (clarsimp simp: is_derived_def is_cap_simps cap_master_cap_def vs_cap_ref_def
@@ -113,12 +125,12 @@ lemma is_derived_cap_rights2[simp, Ipc_AI_assms]:
   apply (case_tac acap1)
   by (auto simp: acap_rights_update_def)
 
-lemma cap_range_update [simp, Ipc_AI_assms]:
+lemma cap_range_update [simp, Ipc_AI_2_assms]:
   "cap_range (cap_rights_update R cap) = cap_range cap"
   by (simp add: cap_range_def cap_rights_update_def acap_rights_update_def
          split: cap.splits arch_cap.splits)
 
-lemma derive_cap_idle[wp, Ipc_AI_assms]:
+lemma derive_cap_idle[wp, Ipc_AI_2_assms]:
   "\<lbrace>\<lambda>s. global_refs s \<inter> cap_range cap = {}\<rbrace>
    derive_cap slot cap
   \<lbrace>\<lambda>c s. global_refs s \<inter> cap_range c = {}\<rbrace>, -"
@@ -130,7 +142,7 @@ lemma derive_cap_idle[wp, Ipc_AI_assms]:
   apply (case_tac arch_cap, simp_all)
   done
 
-lemma arch_derive_cap_objrefs_iszombie [Ipc_AI_assms]:
+lemma arch_derive_cap_objrefs_iszombie [Ipc_AI_2_assms]:
   "\<lbrace>\<lambda>s . P (set_option (aobj_ref cap)) False s\<rbrace>
      arch_derive_cap cap
    \<lbrace>\<lambda>rv s. rv \<noteq> NullCap \<longrightarrow> P (obj_refs rv) (is_zombie rv) s\<rbrace>,-"
@@ -138,7 +150,7 @@ lemma arch_derive_cap_objrefs_iszombie [Ipc_AI_assms]:
       apply(rule hoare_pre, wpsimp+)+
   done
 
-lemma obj_refs_remove_rights[simp, Ipc_AI_assms]:
+lemma obj_refs_remove_rights[simp, Ipc_AI_2_assms]:
   "obj_refs (remove_rights rs cap) = obj_refs cap"
   by (auto simp add: remove_rights_def cap_rights_update_def
                 acap_rights_update_def
@@ -150,7 +162,7 @@ lemma storeWord_um_inv:
    \<lbrace>\<lambda>_ s. is_aligned a 3 \<and> x \<in> {a,a+1,a+2,a+3,a+4,a+5,a+6,a+7} \<or> underlying_memory s x = um x\<rbrace>"
   by (wpsimp simp: upto.simps storeWord_def is_aligned_mask)
 
-lemma store_word_offs_vms[wp, Ipc_AI_assms]:
+lemma store_word_offs_vms[wp, Ipc_AI_2_assms]:
   "\<lbrace>valid_machine_state\<rbrace> store_word_offs ptr offs v \<lbrace>\<lambda>_. valid_machine_state\<rbrace>"
 proof -
   have aligned_offset_ignore:
@@ -189,12 +201,12 @@ proof -
     done
 qed
 
-lemma is_zombie_update_cap_data[simp, Ipc_AI_assms]:
+lemma is_zombie_update_cap_data[simp, Ipc_AI_2_assms]:
   "is_zombie (update_cap_data P data cap) = is_zombie cap"
   by (simp add: update_cap_data_closedform arch_update_cap_data_def is_zombie_def
          split: cap.splits)
 
-lemma valid_msg_length_strengthen [Ipc_AI_assms]:
+lemma valid_msg_length_strengthen [Ipc_AI_2_assms]:
   "valid_message_info mi \<longrightarrow> unat (mi_length mi) \<le> msg_max_length"
   apply (clarsimp simp: valid_message_info_def)
   apply (subgoal_tac "unat (mi_length mi) \<le> unat (of_nat msg_max_length :: machine_word)")
@@ -202,17 +214,17 @@ lemma valid_msg_length_strengthen [Ipc_AI_assms]:
   apply (clarsimp simp: un_ui_le word_le_def)
   done
 
-lemma copy_mrs_in_user_frame[wp, Ipc_AI_assms]:
+lemma copy_mrs_in_user_frame[wp, Ipc_AI_2_assms]:
   "\<lbrace>in_user_frame p\<rbrace> copy_mrs t buf t' buf' n \<lbrace>\<lambda>rv. in_user_frame p\<rbrace>"
   by (simp add: in_user_frame_def) (wp hoare_vcg_ex_lift)
 
 lemma as_user_getRestart_invs[wp]: "\<lbrace>P\<rbrace> as_user t getRestartPC \<lbrace>\<lambda>_. P\<rbrace>"
   by (simp add: getRestartPC_def, rule user_getreg_inv)
 
-lemma make_arch_fault_msg_invs[wp, Ipc_AI_assms]: "make_arch_fault_msg f t \<lbrace>invs\<rbrace>"
+lemma make_arch_fault_msg_invs[wp, Ipc_AI_2_assms]: "make_arch_fault_msg f t \<lbrace>invs\<rbrace>"
   by (cases f; wpsimp)
 
-lemma make_fault_message_inv[wp, Ipc_AI_assms]:
+lemma make_fault_message_inv[wp, Ipc_AI_2_assms]:
   "make_fault_msg ft t \<lbrace>invs\<rbrace>"
   apply (cases ft, simp_all split del: if_split)
      apply (wp as_user_inv getRestartPC_inv mapM_wp'
@@ -222,14 +234,14 @@ lemma make_fault_message_inv[wp, Ipc_AI_assms]:
 crunch make_fault_msg
   for tcb_at[wp]: "tcb_at t"
 
-lemma do_fault_transfer_invs[wp, Ipc_AI_assms]:
+lemma do_fault_transfer_invs[wp, Ipc_AI_2_assms]:
   "\<lbrace>invs and tcb_at receiver\<rbrace>
       do_fault_transfer badge sender receiver recv_buf
    \<lbrace>\<lambda>rv. invs\<rbrace>"
   by (simp add: do_fault_transfer_def split_def | wp
     | clarsimp split: option.split)+
 
-lemma lookup_ipc_buffer_in_user_frame[wp, Ipc_AI_assms]:
+lemma lookup_ipc_buffer_in_user_frame[wp, Ipc_AI_2_assms]:
   "\<lbrace>valid_objs and tcb_at t\<rbrace> lookup_ipc_buffer b t
    \<lbrace>case_option (\<lambda>_. True) in_user_frame\<rbrace>"
   apply (simp add: lookup_ipc_buffer_def)
@@ -326,9 +338,9 @@ lemma transfer_caps_non_null_cte_wp_at:
   done
 
 crunch do_fault_transfer
-  for cte_wp_at[wp,Ipc_AI_assms]: "cte_wp_at P p"
+  for cte_wp_at[wp,Ipc_AI_2_assms]: "cte_wp_at P p"
 
-lemma do_normal_transfer_non_null_cte_wp_at [Ipc_AI_assms]:
+lemma do_normal_transfer_non_null_cte_wp_at [Ipc_AI_2_assms]:
   assumes imp: "\<And>c. P c \<Longrightarrow> \<not> is_untyped_cap c"
   shows  "\<lbrace>valid_objs and cte_wp_at (P and ((\<noteq>) cap.NullCap)) ptr\<rbrace>
    do_normal_transfer st send_buffer ep b gr rt recv_buffer
@@ -339,7 +351,7 @@ lemma do_normal_transfer_non_null_cte_wp_at [Ipc_AI_assms]:
     | clarsimp simp:imp)+
   done
 
-lemma is_derived_ReplyCap [simp, Ipc_AI_assms]:
+lemma is_derived_ReplyCap [simp, Ipc_AI_2_assms]:
   "\<And>m p R. is_derived m p (cap.ReplyCap t False R) = (\<lambda>c. is_master_reply_cap c \<and> obj_ref_of c = t)"
   apply (subst fun_eq_iff)
   apply clarsimp
@@ -360,7 +372,7 @@ lemma do_normal_transfer_tcb_caps:
      | simp add:imp)+
   done
 
-lemma do_ipc_transfer_tcb_caps [Ipc_AI_assms]:
+lemma do_ipc_transfer_tcb_caps [Ipc_AI_2_assms]:
   assumes imp: "\<And>c. P c \<Longrightarrow> \<not> is_untyped_cap c"
   shows
   "\<lbrace>valid_objs and cte_wp_at P (t, ref) and tcb_at t\<rbrace>
@@ -372,7 +384,7 @@ lemma do_ipc_transfer_tcb_caps [Ipc_AI_assms]:
        | wpc | simp add:imp)+
   done
 
-lemma setup_caller_cap_valid_global_objs[wp, Ipc_AI_assms]:
+lemma setup_caller_cap_valid_global_objs[wp, Ipc_AI_2_assms]:
   "\<lbrace>valid_global_objs\<rbrace> setup_caller_cap send recv grant \<lbrace>\<lambda>rv. valid_global_objs\<rbrace>"
   apply (simp add: valid_global_objs_def)
   unfolding setup_caller_cap_def
@@ -380,9 +392,9 @@ lemma setup_caller_cap_valid_global_objs[wp, Ipc_AI_assms]:
   done
 
 crunch handle_arch_fault_reply, arch_get_sanitise_register_info
-  for inv[Ipc_AI_assms]: P
+  for inv[Ipc_AI_2_assms]: P
 
-lemma transfer_caps_loop_valid_vspace_objs[wp, Ipc_AI_assms]:
+lemma transfer_caps_loop_valid_vspace_objs[wp, Ipc_AI_2_assms]:
   "\<lbrace>valid_vspace_objs\<rbrace>
       transfer_caps_loop ep buffer n caps slots mi
     \<lbrace>\<lambda>rv. valid_vspace_objs\<rbrace>"
@@ -398,105 +410,124 @@ lemma transfer_caps_loop_valid_vspace_objs[wp, Ipc_AI_assms]:
   done
 
 crunch  make_arch_fault_msg
-  for aligned[wp, Ipc_AI_assms]: "pspace_aligned"
+  for aligned[wp, Ipc_AI_2_assms]: "pspace_aligned"
 crunch  make_arch_fault_msg
-  for distinct[wp, Ipc_AI_assms]: "pspace_distinct"
+  for distinct[wp, Ipc_AI_2_assms]: "pspace_distinct"
 crunch  make_arch_fault_msg
-  for vmdb[wp, Ipc_AI_assms]: "valid_mdb"
+  for vmdb[wp, Ipc_AI_2_assms]: "valid_mdb"
 crunch  make_arch_fault_msg
-  for ifunsafe[wp, Ipc_AI_assms]: "if_unsafe_then_cap"
+  for ifunsafe[wp, Ipc_AI_2_assms]: "if_unsafe_then_cap"
 crunch  make_arch_fault_msg
-  for iflive[wp, Ipc_AI_assms]: "if_live_then_nonz_cap"
+  for iflive[wp, Ipc_AI_2_assms]: "if_live_then_nonz_cap"
 crunch  make_arch_fault_msg
-  for state_refs_of[wp, Ipc_AI_assms]: "\<lambda>s. P (state_refs_of s)"
+  for state_refs_of[wp, Ipc_AI_2_assms]: "\<lambda>s. P (state_refs_of s)"
 crunch  make_arch_fault_msg
-  for ct[wp, Ipc_AI_assms]: "cur_tcb"
+  for ct[wp, Ipc_AI_2_assms]: "cur_tcb"
 crunch  make_arch_fault_msg
-  for zombies[wp, Ipc_AI_assms]: "zombies_final"
+  for zombies[wp, Ipc_AI_2_assms]: "zombies_final"
 crunch  make_arch_fault_msg
-  for it[wp, Ipc_AI_assms]: "\<lambda>s. P (idle_thread s)"
+  for it[wp, Ipc_AI_2_assms]: "\<lambda>s. P (idle_thread s)"
 crunch  make_arch_fault_msg
-  for valid_globals[wp, Ipc_AI_assms]: "valid_global_refs"
+  for valid_globals[wp, Ipc_AI_2_assms]: "valid_global_refs"
 crunch  make_arch_fault_msg
-  for reply_masters[wp, Ipc_AI_assms]: "valid_reply_masters"
+  for reply_masters[wp, Ipc_AI_2_assms]: "valid_reply_masters"
 crunch  make_arch_fault_msg
-  for valid_idle[wp, Ipc_AI_assms]: "valid_idle"
+  for valid_idle[wp, Ipc_AI_2_assms]: "valid_idle"
 crunch  make_arch_fault_msg
-  for arch[wp, Ipc_AI_assms]: "\<lambda>s. P (arch_state s)"
+  for arch[wp, Ipc_AI_2_assms]: "\<lambda>s. P (arch_state s)"
 crunch  make_arch_fault_msg
-  for typ_at[wp, Ipc_AI_assms]: "\<lambda>s. P (typ_at T p s)"
+  for typ_at[wp, Ipc_AI_2_assms]: "\<lambda>s. P (typ_at T p s)"
 crunch  make_arch_fault_msg
-  for irq_node[wp, Ipc_AI_assms]: "\<lambda>s. P (interrupt_irq_node s)"
+  for irq_node[wp, Ipc_AI_2_assms]: "\<lambda>s. P (interrupt_irq_node s)"
 crunch  make_arch_fault_msg
-  for valid_reply[wp, Ipc_AI_assms]: "valid_reply_caps"
+  for valid_reply[wp, Ipc_AI_2_assms]: "valid_reply_caps"
 crunch  make_arch_fault_msg
-  for irq_handlers[wp, Ipc_AI_assms]: "valid_irq_handlers"
+  for irq_handlers[wp, Ipc_AI_2_assms]: "valid_irq_handlers"
 crunch  make_arch_fault_msg
-  for vspace_objs[wp, Ipc_AI_assms]: "valid_vspace_objs"
+  for vspace_objs[wp, Ipc_AI_2_assms]: "valid_vspace_objs"
 crunch  make_arch_fault_msg
-  for global_objs[wp, Ipc_AI_assms]: "valid_global_objs"
+  for global_objs[wp, Ipc_AI_2_assms]: "valid_global_objs"
 crunch  make_arch_fault_msg
-  for global_vspace_mapping[wp, Ipc_AI_assms]: "valid_global_vspace_mappings"
+  for global_vspace_mapping[wp, Ipc_AI_2_assms]: "valid_global_vspace_mappings"
 crunch  make_arch_fault_msg
-  for arch_caps[wp, Ipc_AI_assms]: "valid_arch_caps"
+  for arch_caps[wp, Ipc_AI_2_assms]: "valid_arch_caps"
 crunch  make_arch_fault_msg
-  for v_ker_map[wp, Ipc_AI_assms]: "valid_kernel_mappings"
+  for v_ker_map[wp, Ipc_AI_2_assms]: "valid_kernel_mappings"
 crunch  make_arch_fault_msg
-  for eq_ker_map[wp, Ipc_AI_assms]: "equal_kernel_mappings"
+  for eq_ker_map[wp, Ipc_AI_2_assms]: "equal_kernel_mappings"
 crunch  make_arch_fault_msg
-  for asid_map[wp, Ipc_AI_assms]: "valid_asid_map"
+  for asid_map[wp, Ipc_AI_2_assms]: "valid_asid_map"
 crunch  make_arch_fault_msg
-  for only_idle[wp, Ipc_AI_assms]: "only_idle"
+  for only_idle[wp, Ipc_AI_2_assms]: "only_idle"
 crunch  make_arch_fault_msg
-  for pspace_in_kernel_window[wp, Ipc_AI_assms]: "pspace_in_kernel_window"
+  for pspace_in_kernel_window[wp, Ipc_AI_2_assms]: "pspace_in_kernel_window"
 crunch  make_arch_fault_msg
-  for cap_refs_in_kernel_window[wp, Ipc_AI_assms]: "cap_refs_in_kernel_window"
+  for cap_refs_in_kernel_window[wp, Ipc_AI_2_assms]: "cap_refs_in_kernel_window"
 crunch  make_arch_fault_msg
-  for valid_objs[wp, Ipc_AI_assms]: "valid_objs"
+  for valid_objs[wp, Ipc_AI_2_assms]: "valid_objs"
 crunch  make_arch_fault_msg
-  for valid_ioc[wp, Ipc_AI_assms]: "valid_ioc"
+  for valid_ioc[wp, Ipc_AI_2_assms]: "valid_ioc"
 crunch  make_arch_fault_msg
-  for pred_tcb[wp, Ipc_AI_assms]: "pred_tcb_at proj P t"
+  for pred_tcb[wp, Ipc_AI_2_assms]: "pred_tcb_at proj P t"
 crunch  make_arch_fault_msg
-  for cap_to[wp, Ipc_AI_assms]: "ex_nonz_cap_to p"
+  for cap_to[wp, Ipc_AI_2_assms]: "ex_nonz_cap_to p"
 
 crunch  make_arch_fault_msg
-  for obj_at[wp, Ipc_AI_assms]: "\<lambda>s. P (obj_at P' pd s)"
+  for obj_at[wp, Ipc_AI_2_assms]: "\<lambda>s. P (obj_at P' pd s)"
   (wp: as_user_inv getRestartPC_inv mapM_wp'  simp: getRegister_def)
 
 crunch make_arch_fault_msg
-  for vms[wp, Ipc_AI_assms]: valid_machine_state
+  for vms[wp, Ipc_AI_2_assms]: valid_machine_state
   (wp: as_user_inv getRestartPC_inv mapM_wp'  simp: getRegister_def ignore: do_machine_op)
 
 crunch make_arch_fault_msg
-  for valid_irq_states[wp, Ipc_AI_assms]: "valid_irq_states"
+  for valid_irq_states[wp, Ipc_AI_2_assms]: "valid_irq_states"
   (wp: as_user_inv getRestartPC_inv mapM_wp'  simp: getRegister_def ignore: do_machine_op)
 
 crunch make_arch_fault_msg
-  for cap_refs_respects_device_region[wp, Ipc_AI_assms]: "cap_refs_respects_device_region"
+  for cap_refs_respects_device_region[wp, Ipc_AI_2_assms]: "cap_refs_respects_device_region"
   (wp: as_user_inv getRestartPC_inv mapM_wp'  simp: getRegister_def ignore: do_machine_op)
+
+lemma setup_caller_cap_aobj_at:
+  "arch_obj_pred P' \<Longrightarrow>
+  \<lbrace>\<lambda>s. P (obj_at P' pd s)\<rbrace> setup_caller_cap st rt grant \<lbrace>\<lambda>r s. P (obj_at P' pd s)\<rbrace>"
+  unfolding setup_caller_cap_def
+  by (wpsimp wp: cap_insert_aobj_at sts.aobj_at)
+
+lemma setup_caller_cap_valid_arch[Ipc_AI_2_assms, wp]:
+  "setup_caller_cap st rt grant \<lbrace>valid_arch_state\<rbrace>"
+  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps[rotated -1] setup_caller_cap_aobj_at)
+
+lemma transfer_caps_loop_valid_arch[Ipc_AI_2_assms]:
+  "\<And>slots caps ep buffer n mi.
+    \<lbrace>valid_arch_state and valid_objs and valid_mdb and K (distinct slots)
+         and (\<lambda>s. \<forall>x \<in> set slots. real_cte_at x s \<and> cte_wp_at (\<lambda>cap. cap = cap.NullCap) x s)
+         and transfer_caps_srcs caps\<rbrace>
+      transfer_caps_loop ep buffer n caps slots mi
+    \<lbrace>\<lambda>_. valid_arch_state\<rbrace>"
+  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps transfer_caps_loop_aobj_at)
 
 end
 
-interpretation Ipc_AI?: Ipc_AI
+interpretation Ipc_AI?: Ipc_AI_2
 proof goal_cases
   interpret Arch .
-  case 1 show ?case by (unfold_locales; (fact Ipc_AI_assms)?)
+  case 1 show ?case by (unfold_locales; (fact Ipc_AI_2_assms)?)
 qed
 
 context Arch begin arch_global_naming
 
-named_theorems Ipc_AI_cont_assms
+named_theorems Ipc_AI_3_assms
 
 crunch make_fault_msg
   for pspace_respects_device_region[wp]: "pspace_respects_device_region"
   (wp: as_user_inv getRestartPC_inv mapM_wp'  simp: getRegister_def ignore: do_machine_op)
 
 crunch do_ipc_transfer
-  for pspace_respects_device_region[wp, Ipc_AI_cont_assms]: "pspace_respects_device_region"
+  for pspace_respects_device_region[wp, Ipc_AI_3_assms]: "pspace_respects_device_region"
   (wp: crunch_wps ignore: const_on_failure simp: crunch_simps)
 
-lemma do_ipc_transfer_respects_device_region[Ipc_AI_cont_assms]:
+lemma do_ipc_transfer_respects_device_region[Ipc_AI_3_assms]:
   "\<lbrace>cap_refs_respects_device_region and tcb_at t and  valid_objs and valid_mdb\<rbrace>
    do_ipc_transfer t ep bg grt r
    \<lbrace>\<lambda>rv. cap_refs_respects_device_region\<rbrace>"
@@ -514,7 +545,7 @@ lemma set_mrs_state_hyp_refs_of[wp]:
   by (wp set_mrs_thread_set_dmo thread_set_hyp_refs_trivial | simp)+
 
 crunch do_ipc_transfer
-  for state_hyp_refs_of[wp, Ipc_AI_cont_assms]: "\<lambda> s. P (state_hyp_refs_of s)"
+  for state_hyp_refs_of[wp, Ipc_AI_3_assms]: "\<lambda> s. P (state_hyp_refs_of s)"
   (wp: crunch_wps simp: zipWithM_x_mapM)
 
 lemma arch_derive_cap_untyped:
@@ -535,11 +566,18 @@ lemma valid_arch_mdb_cap_swap:
             ((caps_of_state s)(a \<mapsto> c', b \<mapsto> c))"
   by (auto simp: valid_arch_mdb_def)
 
+lemma do_ipc_transfer_valid_arch[Ipc_AI_3_assms]:
+  "\<lbrace>valid_arch_state and valid_objs and valid_mdb \<rbrace>
+   do_ipc_transfer s ep bg grt r
+   \<lbrace>\<lambda>rv. valid_arch_state\<rbrace>"
+  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps do_ipc_transfer_aobj_at)
+
 end
 
-interpretation Ipc_AI_cont?: Ipc_AI_cont
-  proof goal_cases
+interpretation Ipc_AI?: Ipc_AI_3
+proof goal_cases
   interpret Arch .
-  case 1 show ?case by (unfold_locales;(fact Ipc_AI_cont_assms)?)
-  qed
+  case 1 show ?case by (unfold_locales;(fact Ipc_AI_3_assms)?)
+qed
+
 end

--- a/proof/invariant-abstract/RISCV64/ArchKHeap_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchKHeap_AI.thy
@@ -584,13 +584,21 @@ lemma aobjs_of_lift_aobj_at:
   apply (simp flip: aobjs_of_ako_at_Some)
   done
 
-lemma valid_arch_state_lift_aobj_at:
+(* intended for use inside Arch, as opposed to the interface lemma valid_arch_state_lift_aobj_at,
+   since this architecture does not need cap preservation for valid_arch_state *)
+lemma valid_arch_state_lift_aobj_at_no_caps:
   "f \<lbrace>valid_arch_state\<rbrace>"
   unfolding valid_arch_state_def valid_asid_table_def valid_global_arch_objs_def pt_at_eq
   apply (wp_pre, wps arch aobjs_of_lift_aobj_at)
    apply (wpsimp wp: hoare_vcg_all_lift hoare_vcg_ball_lift)
   apply simp
   done
+
+(* interface lemma *)
+lemma valid_arch_state_lift_aobj_at:
+  assumes caps: "\<And>P. f \<lbrace>\<lambda>s. P (caps_of_state s)\<rbrace>"
+  shows "f \<lbrace>valid_arch_state\<rbrace>"
+  by (rule valid_arch_state_lift_aobj_at_no_caps)
 
 end
 end
@@ -764,14 +772,6 @@ lemma valid_arch_tcb_same_type:
   "\<lbrakk> valid_arch_tcb t s; valid_obj p k s; kheap s p = Some ko; a_type k = a_type ko \<rbrakk>
    \<Longrightarrow> valid_arch_tcb t (s\<lparr>kheap := (kheap s)(p \<mapsto> k)\<rparr>)"
   by (auto simp: valid_arch_tcb_def obj_at_def)
-
-
-(* interface lemma *)
-lemma valid_ioports_lift:
-  assumes x: "\<And>P. f \<lbrace>\<lambda>rv. P (caps_of_state s)\<rbrace>"
-  assumes y: "\<And>P. f \<lbrace>\<lambda>s. P (arch_state s)\<rbrace>"
-  shows      "f \<lbrace>valid_ioports\<rbrace>"
-  by wpsimp
 
 (* interface lemma *)
 lemma valid_arch_mdb_lift:

--- a/proof/invariant-abstract/RISCV64/ArchTcbAcc_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchTcbAcc_AI.thy
@@ -162,6 +162,11 @@ lemma tcb_context_update_aux: "arch_tcb_context_set (P (arch_tcb_context_get atc
                                = tcb_context_update (\<lambda>ctx. P ctx) atcb"
   by (simp add: arch_tcb_context_set_def arch_tcb_context_get_def)
 
+lemma thread_set_valid_arch_state[TcbAcc_AI_assms]:
+  "(\<And>tcb. \<forall>(getF, v) \<in> ran tcb_cap_cases. getF (f tcb) = getF tcb)
+   \<Longrightarrow> thread_set f t \<lbrace> valid_arch_state \<rbrace>"
+  by (wp valid_arch_state_lift_aobj_at_no_caps thread_set.aobj_at)
+
 end
 
 global_interpretation TcbAcc_AI?: TcbAcc_AI

--- a/proof/invariant-abstract/RISCV64/ArchUntyped_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchUntyped_AI.thy
@@ -319,10 +319,6 @@ lemma create_cap_cap_refs_in_kernel_window[wp, Untyped_AI_assms]:
   apply blast
   done
 
-lemma create_cap_ioports[wp, Untyped_AI_assms]:
-  "\<lbrace>valid_ioports and cte_wp_at (\<lambda>_. True) cref\<rbrace> create_cap tp sz p dev (cref,oref) \<lbrace>\<lambda>rv. valid_ioports\<rbrace>"
-  by wpsimp
-
 lemma init_arch_objects_nonempty_table[Untyped_AI_assms, wp]:
   "\<lbrace>(\<lambda>s. \<not> (obj_at (nonempty_table (set (second_level_tables (arch_state s)))) r s)
          \<and> valid_global_objs s \<and> valid_arch_state s \<and> pspace_aligned s) and
@@ -360,6 +356,18 @@ lemma obj_is_device_vui_eq[Untyped_AI_assms]:
   apply (simp add: default_arch_object_def split: aobject_type.split)
   apply (auto simp: arch_is_frame_type_def)
   done
+
+lemma create_cap_valid_arch_state[wp, Untyped_AI_assms]:
+  "\<lbrace>valid_arch_state and cte_wp_at (\<lambda>_. True) cref\<rbrace>
+   create_cap tp sz p dev (cref,oref)
+   \<lbrace>\<lambda>rv. valid_arch_state\<rbrace>"
+  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps create_cap_aobj_at)
+
+lemma set_cap_non_arch_valid_arch_state[Untyped_AI_assms]:
+ "\<lbrace>\<lambda>s. valid_arch_state s \<and> cte_wp_at (\<lambda>_. \<not>is_arch_cap cap) ptr s\<rbrace>
+  set_cap cap ptr
+  \<lbrace>\<lambda>rv. valid_arch_state \<rbrace>"
+  by wpsimp
 
 end
 

--- a/proof/invariant-abstract/Retype_AI.thy
+++ b/proof/invariant-abstract/Retype_AI.thy
@@ -893,7 +893,7 @@ abbreviation(input)
        and valid_asid_map and valid_global_vspace_mappings
        and pspace_in_kernel_window and cap_refs_in_kernel_window
        and pspace_respects_device_region and cap_refs_respects_device_region
-       and cur_tcb and valid_ioc and valid_machine_state and valid_ioports"
+       and cur_tcb and valid_ioc and valid_machine_state"
 
 
 lemma all_invs_but_equal_kernel_mappings_restricted_eq:

--- a/proof/invariant-abstract/TcbAcc_AI.thy
+++ b/proof/invariant-abstract/TcbAcc_AI.thy
@@ -172,7 +172,9 @@ locale TcbAcc_AI_valid_ipc_buffer_cap_0 =
     "(\<And>tcb. tcb_state  (f tcb) = tcb_state  tcb) \<Longrightarrow>
         (\<And>tcb. tcb_arch_ref (f tcb) = tcb_arch_ref tcb) \<Longrightarrow>
          \<lbrace>\<lambda>(s::'state_ext state). P (state_hyp_refs_of s)\<rbrace> thread_set f t \<lbrace>\<lambda>rv s. P (state_hyp_refs_of s)\<rbrace>"
-
+  assumes thread_set_valid_arch_state:
+    "(\<And>tcb. \<forall>(getF, v) \<in> ran tcb_cap_cases. getF (f tcb) = getF tcb) \<Longrightarrow>
+       \<lbrace>\<lambda>s::'state_ext state. valid_arch_state s\<rbrace> thread_set f t \<lbrace>\<lambda>rv s. valid_arch_state s\<rbrace>"
 
 context TcbAcc_AI_valid_ipc_buffer_cap_0 begin
 
@@ -422,13 +424,6 @@ lemma thread_set_cap_refs_respects_device_region:
   apply (erule sym)
   done
 
-lemma thread_set_ioports:
-  assumes y: "\<And>tcb. \<forall>(getF, v) \<in> ran tcb_cap_cases.
-                  getF (f tcb) = getF tcb"
-  shows
-  "\<lbrace>valid_ioports\<rbrace> thread_set f t \<lbrace>\<lambda>rv. valid_ioports\<rbrace>"
-  by (wpsimp wp: valid_ioports_lift thread_set_caps_of_state_trivial y)
-
 (* NOTE: The function "thread_set f p" updates a TCB at p using function f.
    It should not be used to change capabilities, though. *)
 lemma thread_set_valid_ioc_trivial:
@@ -468,7 +463,7 @@ lemma thread_set_invs_trivial:
   shows      "\<lbrace>invs::'state_ext state \<Rightarrow> bool\<rbrace> thread_set f t \<lbrace>\<lambda>rv. invs\<rbrace>"
   apply (simp add: invs_def valid_state_def valid_pspace_def)
   apply (rule hoare_weaken_pre)
-   apply (wp thread_set_valid_objs_triv thread_set_ioports
+   apply (wp thread_set_valid_objs_triv thread_set_valid_arch_state
              thread_set_refs_trivial
              thread_set_hyp_refs_trivial
              thread_set_iflive_trivial
@@ -1338,7 +1333,6 @@ locale TcbAcc_AI_pred_tcb_cap_wp_at =
         \<forall>cap. (pred_tcb_at proj P t s \<and> tcb_cap_valid cap (t, ref) s) \<longrightarrow> Q cap\<rbrakk>
       \<Longrightarrow> cte_wp_at Q (t, ref) s"
 
-
 locale TcbAcc_AI_st_tcb_at_cap_wp_at = TcbAcc_AI_pred_tcb_cap_wp_at itcb_state state_ext_t
   for state_ext_t :: "'state_ext::state_ext itself"
 
@@ -1494,9 +1488,7 @@ lemma set_bound_notification_valid_ioc[wp]:
                         if_split_asm)
   done
 
-crunch set_thread_state, set_bound_notification
-  for valid_ioports[wp]: valid_ioports
-  (wp: valid_ioports_lift)
+lemmas [wp] = sts.valid_arch_state sbn.valid_arch_state
 
 lemma sts_invs_minor:
   "\<lbrace>st_tcb_at (\<lambda>st'. tcb_st_refs_of st' = tcb_st_refs_of st) t
@@ -1563,7 +1555,6 @@ lemma sts_invs_minor2:
   apply (drule(1) valid_reply_capsD)
   apply (clarsimp simp: pred_tcb_at_def obj_at_def)
   done (* FIXME tidy *)
-
 
 lemma sbn_invs_minor:
   "\<lbrace>bound_tcb_at (\<lambda>ntfn'. tcb_bound_refs ntfn' = tcb_bound_refs ntfn) t

--- a/proof/invariant-abstract/Tcb_AI.thy
+++ b/proof/invariant-abstract/Tcb_AI.thy
@@ -610,8 +610,8 @@ lemma thread_set_tcb_ipc_buffer_cap_cleared_invs:
              thread_set_valid_reply_caps_trivial
              thread_set_valid_reply_masters_trivial
              valid_irq_node_typ valid_irq_handlers_lift
-             thread_set_caps_of_state_trivial valid_ioports_lift
-             thread_set_arch_caps_trivial
+             thread_set_caps_of_state_trivial thread_set_valid_arch_state
+             thread_set_arch_caps_trivial thread_set_irq_node
              thread_set_only_idle
              thread_set_cap_refs_in_kernel_window
              thread_set_valid_ioc_trivial
@@ -704,7 +704,7 @@ lemma set_mcpriority_invs[wp]:
              thread_set_arch_caps_trivial
              thread_set_only_idle
              thread_set_cap_refs_in_kernel_window
-             thread_set_valid_ioc_trivial valid_ioports_lift
+             thread_set_valid_ioc_trivial thread_set_valid_arch_state
              thread_set_cap_refs_respects_device_region
               | simp add: ran_tcb_cap_cases invs_def valid_state_def valid_pspace_def
               | rule conjI | erule disjE)+
@@ -800,7 +800,7 @@ lemma bind_notification_invs:
    \<lbrace>\<lambda>_. invs\<rbrace>"
   apply (simp add: bind_notification_def invs_def valid_state_def valid_pspace_def)
   apply (rule bind_wp[OF _ get_simple_ko_sp])
-  apply (wp valid_irq_node_typ set_simple_ko_valid_objs simple_obj_set_prop_at valid_ioports_lift
+  apply (wp valid_irq_node_typ set_simple_ko_valid_objs simple_obj_set_prop_at
          | clarsimp simp:idle_no_ex_cap split del: if_split)+
   apply (intro conjI;
     (clarsimp simp: is_ntfn idle_no_ex_cap elim!: obj_at_weakenE)?)

--- a/proof/invariant-abstract/Untyped_AI.thy
+++ b/proof/invariant-abstract/Untyped_AI.thy
@@ -17,11 +17,6 @@ unbundle l4v_word_context (* because of Lib.MonadicRewrite *)
 
 arch_requalify_consts
   second_level_tables
-  safe_ioport_insert
-
-arch_requalify_facts
-  set_cap_ioports'
-  safe_ioport_insert_triv
 
 primrec
   valid_untyped_inv_wcap :: "Invocations_A.untyped_invocation \<Rightarrow> cap option
@@ -299,6 +294,11 @@ locale Untyped_AI_arch =
     \<Longrightarrow> case ui of
         Retype slot reset ptr_base ptr tp us slots dev
         \<Rightarrow> obj_is_device tp dev = dev"
+  assumes set_cap_non_arch_valid_arch_state:
+  "\<And>cap ptr.
+     \<lbrace>\<lambda>s. valid_arch_state s \<and> cte_wp_at (\<lambda>_. \<not>is_arch_cap cap) ptr s\<rbrace>
+     set_cap cap ptr
+     \<lbrace>\<lambda>rv. valid_arch_state :: 'state_ext state \<Rightarrow> _ \<rbrace>"
 
 lemmas is_aligned_triv2 = Aligned.is_aligned_triv
 
@@ -2686,6 +2686,7 @@ lemma caps_of_state_pspace_no_overlapD:
   apply simp
   done
 
+context Untyped_AI_arch begin
 
 lemma set_untyped_cap_invs_simple:
   "\<lbrace>\<lambda>s. descendants_range_in {ptr .. ptr+2^sz - 1} cref s
@@ -2693,7 +2694,7 @@ lemma set_untyped_cap_invs_simple:
   \<and> cte_wp_at (\<lambda>c. is_untyped_cap c \<and> cap_bits c = sz
       \<and> cap_is_device c = dev\<and> obj_ref_of c = ptr) cref s \<and> idx \<le> 2^ sz\<rbrace>
   set_cap (UntypedCap dev ptr sz idx) cref
- \<lbrace>\<lambda>rv s. invs s\<rbrace>"
+ \<lbrace>\<lambda>rv. invs :: 'state_ext state \<Rightarrow> bool \<rbrace>"
   apply (rule hoare_name_pre_state)
   apply (clarsimp simp:cte_wp_at_caps_of_state invs_def valid_state_def)
   apply (rule hoare_pre)
@@ -2702,23 +2703,22 @@ lemma set_untyped_cap_invs_simple:
    apply (simp add:valid_irq_node_def)
    apply wps
    apply (wp hoare_vcg_all_lift set_cap_irq_handlers
-     set_cap_irq_handlers cap_table_at_lift_valid set_cap_ioports'
+     set_cap_irq_handlers cap_table_at_lift_valid set_cap_non_arch_valid_arch_state
      set_cap_typ_at set_cap_valid_arch_caps_simple set_cap_kernel_window_simple
      set_cap_cap_refs_respects_device_region)
   apply (clarsimp simp del: split_paired_Ex)
   apply (strengthen exI[where x=cref])
   apply (clarsimp simp:cte_wp_at_caps_of_state is_cap_simps valid_pspace_def)
   apply (intro conjI; clarsimp?)
-        apply (clarsimp simp: fun_eq_iff)
-       apply (clarsimp split:cap.splits simp:is_cap_simps appropriate_cte_cap_def)
-      apply (drule(1) if_unsafe_then_capD[OF caps_of_state_cteD])
-       apply clarsimp
-      apply (clarsimp simp: is_cap_simps ex_cte_cap_wp_to_def appropriate_cte_cap_def
-                            cte_wp_at_caps_of_state)
-     apply (clarsimp dest!:valid_global_refsD2 simp:cap_range_def)
-    apply (simp add:valid_irq_node_def)
-   apply (clarsimp simp:valid_irq_node_def)
-  apply (clarsimp intro!: safe_ioport_insert_triv simp: is_cap_simps)
+       apply (clarsimp simp: fun_eq_iff)
+      apply (clarsimp split:cap.splits simp:is_cap_simps appropriate_cte_cap_def)
+     apply (drule(1) if_unsafe_then_capD[OF caps_of_state_cteD])
+      apply clarsimp
+     apply (clarsimp simp: is_cap_simps ex_cte_cap_wp_to_def appropriate_cte_cap_def
+                           cte_wp_at_caps_of_state)
+    apply (clarsimp dest!:valid_global_refsD2 simp:cap_range_def)
+   apply (simp add:valid_irq_node_def)
+  apply (clarsimp simp:valid_irq_node_def)
   done
 
 lemma reset_untyped_cap_invs_etc:
@@ -2729,7 +2729,7 @@ lemma reset_untyped_cap_invs_etc:
     reset_untyped_cap slot
   \<lbrace>\<lambda>_. invs and valid_untyped_inv_wcap ui (Some (UntypedCap dev ptr sz 0))
       and ct_active
-      and pspace_no_overlap {ptr .. ptr + 2 ^ sz - 1}\<rbrace>, \<lbrace>\<lambda>_. invs\<rbrace>"
+      and pspace_no_overlap {ptr .. ptr + 2 ^ sz - 1}\<rbrace>, \<lbrace>\<lambda>_. invs :: 'state_ext state \<Rightarrow> bool\<rbrace>"
   (is "\<lbrace>invs and valid_untyped_inv_wcap ?ui (Some ?cap) and ct_active and _\<rbrace>
     ?f \<lbrace>\<lambda>_. invs and ?vu2 and ct_active and ?psp\<rbrace>, \<lbrace>\<lambda>_. invs\<rbrace>")
   apply (simp add: reset_untyped_cap_def)
@@ -2816,6 +2816,8 @@ lemma reset_untyped_cap_invs_etc:
    apply simp
   apply (clarsimp simp: cte_wp_at_caps_of_state)
   done
+
+end
 
 lemma get_cap_prop_known:
   "\<lbrace>cte_wp_at (\<lambda>cp. f cp = v) slot and Q v\<rbrace> get_cap slot \<lbrace>\<lambda>rv. Q (f rv)\<rbrace>"
@@ -2975,10 +2977,6 @@ lemma create_cap_aobj_at:
   unfolding create_cap_def split_def set_cdt_def
   by (wpsimp wp: set_cap.aobj_at)
 
-lemma create_cap_valid_arch_state[wp]:
-  "\<lbrace>valid_arch_state\<rbrace> create_cap type bits ut is_dev cref \<lbrace>\<lambda>_. valid_arch_state\<rbrace>"
-  by (wp valid_arch_state_lift_aobj_at create_cap_aobj_at)
-
 crunch create_cap
   for irq_node[wp]: "\<lambda>s. P (interrupt_irq_node s)"
   (simp: crunch_simps)
@@ -3031,9 +3029,9 @@ locale Untyped_AI_nonempty_table =
     K (\<forall>ref\<in>set refs. is_aligned ref (obj_bits_api tp us))\<rbrace>
         init_arch_objects tp dev ptr bits us refs
    \<lbrace>\<lambda>rv. \<lambda>s :: 'state_ext state. \<not> (obj_at (nonempty_table (set (second_level_tables (arch_state s)))) r s)\<rbrace>"
-  assumes create_cap_ioports[wp]:
-  "\<And>tp oref sz dev cref p. \<lbrace>valid_ioports and cte_wp_at (\<lambda>_. True) cref\<rbrace>
-        create_cap tp sz p dev (cref,oref) \<lbrace>\<lambda>rv (s::'state_ext state). valid_ioports s\<rbrace>"
+  assumes create_cap_valid_arch_state[wp]:
+  "\<And>tp oref sz dev cref p. \<lbrace>valid_arch_state and cte_wp_at (\<lambda>_. True) cref\<rbrace>
+        create_cap tp sz p dev (cref,oref) \<lbrace>\<lambda>rv (s::'state_ext state). valid_arch_state s\<rbrace>"
 
 
 crunch create_cap

--- a/proof/invariant-abstract/X64/ArchAcc_AI.thy
+++ b/proof/invariant-abstract/X64/ArchAcc_AI.thy
@@ -1576,7 +1576,7 @@ lemma set_object_invs[wp]:
     set_object ptr (ArchObj obj)
   \<lbrace> \<lambda>_. invs \<rbrace>"
   apply (clarsimp simp: invs_def valid_state_def valid_pspace_def valid_asid_map_def)
-  apply (wp valid_irq_node_typ valid_irq_handlers_lift valid_ioports_lift
+  apply (wp valid_irq_node_typ valid_irq_handlers_lift valid_arch_state_lift
             set_aobj_valid_global_vspace_mappings set_object_valid_objs)
   apply (clarsimp simp: valid_arch_state_def valid_obj_def)
   done

--- a/proof/invariant-abstract/X64/ArchArch_AI.thy
+++ b/proof/invariant-abstract/X64/ArchArch_AI.thy
@@ -586,10 +586,18 @@ lemma cap_insert_ioports_ap:
      cap_insert cap src dest
    \<lbrace>\<lambda>rv. valid_ioports\<rbrace>"
   apply (simp add: cap_insert_def)
-  apply (wp get_cap_wp set_cap_ioports' set_untyped_cap_as_full_ioports
+  apply (wp get_cap_wp set_cap_ioports_safe set_untyped_cap_as_full_ioports
             set_untyped_cap_as_full_gross_ioports
-         | wpc | simp split del: if_splits)+
+         | wpc | simp split del: if_split)+
   done
+
+lemma cap_insert_valid_arch_state_ap:
+  "\<lbrace>valid_arch_state and (\<lambda>s. cte_wp_at (\<lambda>cap'. safe_ioport_insert cap cap' s) dest s) and
+    K (is_ap_cap cap)\<rbrace>
+   cap_insert cap src dest
+   \<lbrace>\<lambda>rv. valid_arch_state\<rbrace>"
+  by (wp valid_arch_state_lift_ioports_aobj_at cap_insert_aobj_at cap_insert_ioports_ap)+
+     (simp add: valid_arch_state_def)
 
 lemma cap_insert_ap_invs:
   "\<lbrace>invs and valid_cap cap and tcb_cap_valid cap dest and
@@ -611,7 +619,7 @@ lemma cap_insert_ap_invs:
   apply (simp cong: conj_cong)
   apply (rule hoare_pre)
    apply (wp cap_insert_simple_mdb cap_insert_iflive
-             cap_insert_zombies cap_insert_ifunsafe cap_insert_ioports_ap
+             cap_insert_zombies cap_insert_ifunsafe cap_insert_valid_arch_state_ap
              cap_insert_valid_global_refs cap_insert_idle
              valid_irq_node_typ cap_insert_simple_arch_caps_ap)
   apply (clarsimp simp: is_simple_cap_def cte_wp_at_caps_of_state is_cap_simps)

--- a/proof/invariant-abstract/X64/ArchBits_AI.thy
+++ b/proof/invariant-abstract/X64/ArchBits_AI.thy
@@ -10,6 +10,10 @@ begin
 
 context Arch begin arch_global_naming
 
+lemma invs_valid_ioports[elim!]:
+  "invs s \<Longrightarrow> valid_ioports s"
+  by (simp add: invs_def valid_state_def valid_arch_state_def)
+
 lemma invs_unique_table_caps[elim!]:
   "invs s \<Longrightarrow> unique_table_caps (caps_of_state s)"
   by (clarsimp simp: invs_def valid_state_def valid_arch_caps_def)

--- a/proof/invariant-abstract/X64/ArchCSpace_AI.thy
+++ b/proof/invariant-abstract/X64/ArchCSpace_AI.thy
@@ -91,12 +91,12 @@ lemma set_free_index_invs [CSpace_AI_assms]:
   apply (simp add:invs_def valid_state_def)
   apply (rule hoare_pre)
   apply (wp set_free_index_valid_pspace[where cap = cap] set_free_index_valid_mdb
-    set_cap_idle update_cap_ifunsafe)
+            set_cap_idle update_cap_ifunsafe set_cap_no_new_ioports_arch_valid_arch_state)
   apply (simp add:valid_irq_node_def)
   apply wps
   apply (wp hoare_vcg_all_lift set_cap_irq_handlers set_cap.valid_vspace_obj set_cap_valid_arch_caps
             set_cap.valid_global_objs set_cap_irq_handlers cap_table_at_lift_valid set_cap_typ_at
-            set_cap_cap_refs_respects_device_region_spec[where ptr = cref] set_cap_ioports_no_new_ioports)
+            set_cap_cap_refs_respects_device_region_spec[where ptr = cref])
   apply (clarsimp simp:cte_wp_at_caps_of_state)
   apply (rule conjI,simp add:valid_pspace_def)
   apply (rule conjI,clarsimp simp:is_cap_simps)
@@ -401,12 +401,12 @@ lemma valid_ioports_issuedD:
        \<Longrightarrow> cap_ioports cap \<subseteq> issued_ioports (arch_state s)"
   by (auto simp: valid_ioports_def all_ioports_issued_def)
 
-lemma cap_insert_derived_ioports[CSpace_AI_assms]:
+lemma cap_insert_derived_ioports:
   "\<lbrace>valid_ioports and (\<lambda>s. cte_wp_at (is_derived (cdt s) src cap) src s)\<rbrace>
      cap_insert cap src dest
    \<lbrace>\<lambda>rv. valid_ioports\<rbrace>"
   apply (simp add: cap_insert_def)
-  apply (wp get_cap_wp set_cap_ioports' set_untyped_cap_as_full_ioports
+  apply (wp get_cap_wp set_cap_ioports_safe set_untyped_cap_as_full_ioports
             set_untyped_cap_as_full_gross_ioports
          | wpc | simp split del: if_splits)+
   apply (rule impI, erule exE, rule impI)
@@ -419,16 +419,31 @@ lemma cap_insert_derived_ioports[CSpace_AI_assms]:
   apply (drule_tac cap=cap in valid_ioports_issuedD, simp+)
   done
 
+lemma cap_insert_derived_valid_arch_state[CSpace_AI_assms]:
+  "\<lbrace>valid_arch_state and (\<lambda>s. cte_wp_at (is_derived (cdt s) src cap) src s)\<rbrace>
+   cap_insert cap src dest
+   \<lbrace>\<lambda>rv. valid_arch_state \<rbrace>"
+  by (wp valid_arch_state_lift_ioports_aobj_at cap_insert_aobj_at cap_insert_derived_ioports)+
+     (simp add: cap_insert_aobj_at valid_arch_state_def)
+
 lemma cap_insert_simple_ioports:
   "\<lbrace>valid_ioports and (\<lambda>s. cte_wp_at (\<lambda>cap'. safe_ioport_insert cap cap' s) dest s) and
         K (is_simple_cap cap \<and> \<not>is_ap_cap cap)\<rbrace>
      cap_insert cap src dest
    \<lbrace>\<lambda>rv. valid_ioports\<rbrace>"
   apply (simp add: cap_insert_def)
-  apply (wp get_cap_wp set_cap_ioports' set_untyped_cap_as_full_ioports
+  apply (wp get_cap_wp set_cap_ioports_safe set_untyped_cap_as_full_ioports
             set_untyped_cap_as_full_gross_ioports
          | wpc | simp split del: if_splits)+
   done
+
+lemma cap_insert_simple_valid_arch_state:
+  "\<lbrace>valid_arch_state and (\<lambda>s. cte_wp_at (\<lambda>cap'. safe_ioport_insert cap cap' s) dest s) and
+    K (is_simple_cap cap \<and> \<not>is_ap_cap cap)\<rbrace>
+   cap_insert cap src dest
+   \<lbrace>\<lambda>rv. valid_arch_state\<rbrace>"
+  by (wp valid_arch_state_lift_ioports_aobj_at cap_insert_aobj_at cap_insert_simple_ioports)+
+     (simp add: valid_arch_state_def)
 
 end
 
@@ -609,10 +624,15 @@ lemma cap_insert_simple_arch_caps_no_ap:
   apply (clarsimp simp: cte_wp_at_caps_of_state)
   by (auto simp: is_simple_cap_def[simplified is_simple_cap_arch_def] is_cap_simps)
 
-lemma setup_reply_master_ioports[wp, CSpace_AI_assms]:
+lemma setup_reply_master_ioports[wp]:
   "\<lbrace>valid_ioports\<rbrace> setup_reply_master c \<lbrace>\<lambda>rv. valid_ioports\<rbrace>"
   apply (wpsimp simp: setup_reply_master_def wp: set_cap_ioports_no_new_ioports get_cap_wp)
   by (clarsimp simp: cte_wp_at_caps_of_state)
+
+lemma setup_reply_master_arch[CSpace_AI_assms]:
+  "setup_reply_master t \<lbrace> valid_arch_state \<rbrace>"
+  by (wp valid_arch_state_lift_ioports_typ_at setup_reply_master_ioports)+
+     (auto simp: valid_arch_state_def)
 
 end
 
@@ -636,10 +656,11 @@ lemma cap_insert_simple_invs:
     K (is_simple_cap cap \<and> \<not>is_ap_cap cap) and (\<lambda>s. \<forall>irq \<in> cap_irqs cap. irq_issued irq s)
     and (\<lambda>s. cte_wp_at (\<lambda>c. safe_ioport_insert cap c s) dest s)\<rbrace>
   cap_insert cap src dest \<lbrace>\<lambda>rv. invs\<rbrace>"
+  supply cap_insert_derived_valid_arch_state[wp del]
   apply (simp add: invs_def valid_state_def valid_pspace_def)
   apply (rule hoare_pre)
    apply (wp cap_insert_simple_mdb cap_insert_iflive
-             cap_insert_zombies cap_insert_ifunsafe cap_insert_simple_ioports
+             cap_insert_zombies cap_insert_ifunsafe cap_insert_simple_valid_arch_state
              cap_insert_valid_global_refs cap_insert_idle
              valid_irq_node_typ cap_insert_simple_arch_caps_no_ap)
   apply (clarsimp simp: is_simple_cap_def cte_wp_at_caps_of_state)

--- a/proof/invariant-abstract/X64/ArchDetype_AI.thy
+++ b/proof/invariant-abstract/X64/ArchDetype_AI.thy
@@ -107,14 +107,6 @@ lemma state_hyp_refs_of_detype:
   "state_hyp_refs_of (detype S s) = (\<lambda>x. if x \<in> S then {} else state_hyp_refs_of s x)"
   by (rule ext, simp add: state_hyp_refs_of_def detype_def)
 
-lemma valid_ioports_detype[Detype_AI_assms]:
-  "valid_ioports s \<Longrightarrow> valid_ioports (detype (untyped_range cap) s)"
-  apply (clarsimp simp: valid_ioports_def all_ioports_issued_def ioports_no_overlap_def issued_ioports_def more_update.caps_of_state_update)
-  apply (clarsimp simp: detype_def cap_ioports_def ran_def elim!: ranE split: if_splits cap.splits arch_cap.splits)
-  apply (rule conjI)
-   apply (force simp: ran_def)
-  by (metis (full_types) ranI)
-
 end
 
 interpretation Detype_AI?: Detype_AI
@@ -187,10 +179,20 @@ lemma tcb_arch_detype[detype_invs_proofs]:
   apply (clarsimp simp: valid_arch_tcb_def)
   done
 
+lemma valid_ioports_detype:
+  "valid_ioports s \<Longrightarrow> valid_ioports (detype (untyped_range cap) s)"
+  apply (clarsimp simp: valid_ioports_def all_ioports_issued_def ioports_no_overlap_def issued_ioports_def more_update.caps_of_state_update)
+  apply (clarsimp simp: detype_def cap_ioports_def ran_def elim!: ranE split: if_splits cap.splits arch_cap.splits)
+  apply (rule conjI)
+   apply (force simp: ran_def)
+  by (metis (full_types) ranI)
+
 lemma valid_arch_state_detype[detype_invs_proofs]:
   "valid_arch_state (detype (untyped_range cap) s)"
   using valid_vs_lookup valid_arch_state ut_mdb valid_global_refsD [OF globals cap] cap
-  apply (simp add: valid_arch_state_def valid_asid_table_def
+  unfolding valid_arch_state_def
+  apply (strengthen valid_ioports_detype,
+         simp add: valid_arch_state_def valid_asid_table_def
                    valid_global_pdpts_def valid_global_pds_def valid_global_pts_def
                    global_refs_def cap_range_def)
   apply (clarsimp simp: ran_def arch_state_det)

--- a/proof/invariant-abstract/X64/ArchFinalise_AI.thy
+++ b/proof/invariant-abstract/X64/ArchFinalise_AI.thy
@@ -79,7 +79,6 @@ lemma invs_x64_asid_table_unmap:
   apply (simp add: valid_irq_node_def valid_kernel_mappings_def
                    valid_global_objs_arch_update valid_asid_map_def)
   apply (simp add: valid_table_caps_def valid_machine_state_def second_level_tables_def)
-  apply (simp add: valid_ioports_def all_ioports_issued_def issued_ioports_def)
   done
 
 lemma delete_asid_pool_invs[wp]:
@@ -232,7 +231,7 @@ lemma (* empty_slot_invs *) [Finalise_AI_assms]:
                   set_cap_idle valid_irq_node_typ set_cap_typ_at
                   set_cap_irq_handlers set_cap_valid_arch_caps
                   set_cap_cap_refs_respects_device_region_NullCap
-                  set_cap_ioports_no_new_ioports
+                  set_cap_no_new_ioports_arch_valid_arch_state
       | simp add: trans_state_update[symmetric]
              del: trans_state_update fun_upd_apply
        split del: if_split )+

--- a/proof/invariant-abstract/X64/ArchIpc_AI.thy
+++ b/proof/invariant-abstract/X64/ArchIpc_AI.thy
@@ -10,11 +10,7 @@ begin
 
 context Arch begin arch_global_naming
 
-named_theorems Ipc_AI_assms
-
-lemma cap_asid_PageCap_None [simp]:
-  "cap_asid (ArchObjectCap (PageCap d r R typ pgsz None)) = None"
-  by (simp add: cap_asid_def)
+named_theorems Ipc_AI_1_assms
 
 lemma arch_derive_cap_is_derived:
   "\<lbrace>\<lambda>s. cte_wp_at (\<lambda>cap . cap_master_cap cap =
@@ -36,7 +32,7 @@ lemma arch_derive_cap_is_derived:
              | rule conjI)+)
   done
 
-lemma derive_cap_is_derived [Ipc_AI_assms]:
+lemma derive_cap_is_derived [Ipc_AI_1_assms]:
   "\<lbrace>\<lambda>s. c'\<noteq> cap.NullCap \<longrightarrow> cte_wp_at (\<lambda>cap. cap_master_cap cap = cap_master_cap c'
                      \<and> (cap_badge cap, cap_badge c') \<in> capBadge_ordering False
                      \<and> cap_asid cap = cap_asid c'
@@ -62,7 +58,23 @@ lemma derive_cap_is_derived [Ipc_AI_assms]:
   apply(clarsimp simp: valid_cap_def)
   done
 
-lemma is_derived_cap_rights [simp, Ipc_AI_assms]:
+end
+
+interpretation Ipc_AI?: Ipc_AI
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case by (unfold_locales; (fact Ipc_AI_1_assms)?)
+qed
+
+context Arch begin arch_global_naming
+
+named_theorems Ipc_AI_2_assms
+
+lemma cap_asid_PageCap_None [simp]:
+  "cap_asid (ArchObjectCap (PageCap d r R typ pgsz None)) = None"
+  by (simp add: cap_asid_def)
+
+lemma is_derived_cap_rights [simp, Ipc_AI_2_assms]:
   "is_derived m p (cap_rights_update R c) = is_derived m p c"
   apply (rule ext)
   apply (simp add: cap_rights_update_def is_derived_def is_cap_simps)
@@ -74,12 +86,12 @@ lemma is_derived_cap_rights [simp, Ipc_AI_assms]:
            split: arch_cap.split cap.split bool.splits)
 
 
-lemma data_to_message_info_valid [Ipc_AI_assms]:
+lemma data_to_message_info_valid [Ipc_AI_2_assms]:
   "valid_message_info (data_to_message_info w)"
   by (simp add: valid_message_info_def data_to_message_info_def  word_and_le1 msg_max_length_def
                 msg_max_extra_caps_def Let_def not_less mask_def)
 
-lemma get_extra_cptrs_length[wp, Ipc_AI_assms]:
+lemma get_extra_cptrs_length[wp, Ipc_AI_2_assms]:
   "\<lbrace>\<lambda>s . valid_message_info mi\<rbrace>
    get_extra_cptrs buf mi
    \<lbrace>\<lambda>rv s. length rv \<le> msg_max_extra_caps\<rbrace>"
@@ -94,19 +106,19 @@ lemma get_extra_cptrs_length[wp, Ipc_AI_assms]:
                  intro: length_upt)
   done
 
-lemma cap_asid_rights_update [simp, Ipc_AI_assms]:
+lemma cap_asid_rights_update [simp, Ipc_AI_2_assms]:
   "cap_asid (cap_rights_update R c) = cap_asid c"
   apply (simp add: cap_rights_update_def acap_rights_update_def split: cap.splits arch_cap.splits)
   apply (clarsimp simp: cap_asid_def)
   done
 
-lemma cap_rights_update_vs_cap_ref[simp, Ipc_AI_assms]:
+lemma cap_rights_update_vs_cap_ref[simp, Ipc_AI_2_assms]:
   "vs_cap_ref (cap_rights_update rs cap) = vs_cap_ref cap"
   by (simp add: vs_cap_ref_def cap_rights_update_def
                 acap_rights_update_def
          split: cap.split arch_cap.split)
 
-lemma is_derived_cap_rights2[simp, Ipc_AI_assms]:
+lemma is_derived_cap_rights2[simp, Ipc_AI_2_assms]:
   "is_derived m p c (cap_rights_update R c') = is_derived m p c c'"
   apply (case_tac c')
   apply (simp_all add:cap_rights_update_def)
@@ -116,12 +128,12 @@ lemma is_derived_cap_rights2[simp, Ipc_AI_assms]:
   apply (case_tac acap1)
    by (auto simp: acap_rights_update_def)
 
-lemma cap_range_update [simp, Ipc_AI_assms]:
+lemma cap_range_update [simp, Ipc_AI_2_assms]:
   "cap_range (cap_rights_update R cap) = cap_range cap"
   by (simp add: cap_range_def cap_rights_update_def acap_rights_update_def
          split: cap.splits arch_cap.splits)
 
-lemma derive_cap_idle[wp, Ipc_AI_assms]:
+lemma derive_cap_idle[wp, Ipc_AI_2_assms]:
   "\<lbrace>\<lambda>s. global_refs s \<inter> cap_range cap = {}\<rbrace>
    derive_cap slot cap
   \<lbrace>\<lambda>c s. global_refs s \<inter> cap_range c = {}\<rbrace>, -"
@@ -133,7 +145,7 @@ lemma derive_cap_idle[wp, Ipc_AI_assms]:
   apply (case_tac arch_cap, simp_all)
   done
 
-lemma arch_derive_cap_objrefs_iszombie [Ipc_AI_assms]:
+lemma arch_derive_cap_objrefs_iszombie [Ipc_AI_2_assms]:
   "\<lbrace>\<lambda>s . P (set_option (aobj_ref cap)) False s\<rbrace>
      arch_derive_cap cap
    \<lbrace>\<lambda>rv s. rv \<noteq> NullCap \<longrightarrow> P (obj_refs rv) (is_zombie rv) s\<rbrace>,-"
@@ -141,7 +153,7 @@ lemma arch_derive_cap_objrefs_iszombie [Ipc_AI_assms]:
       apply(rule hoare_pre, wpc?, wp+, simp)+
   done
 
-lemma obj_refs_remove_rights[simp, Ipc_AI_assms]:
+lemma obj_refs_remove_rights[simp, Ipc_AI_2_assms]:
   "obj_refs (remove_rights rs cap) = obj_refs cap"
   by (auto simp add: remove_rights_def cap_rights_update_def
                 acap_rights_update_def
@@ -156,7 +168,7 @@ lemma storeWord_um_inv:
   apply (simp add: upto0_7_def)
   done
 
-lemma store_word_offs_vms[wp, Ipc_AI_assms]:
+lemma store_word_offs_vms[wp, Ipc_AI_2_assms]:
   "\<lbrace>valid_machine_state\<rbrace> store_word_offs ptr offs v \<lbrace>\<lambda>_. valid_machine_state\<rbrace>"
 proof -
   have aligned_offset_ignore:
@@ -195,12 +207,12 @@ proof -
     done
 qed
 
-lemma is_zombie_update_cap_data[simp, Ipc_AI_assms]:
+lemma is_zombie_update_cap_data[simp, Ipc_AI_2_assms]:
   "is_zombie (update_cap_data P data cap) = is_zombie cap"
   by (clarsimp simp: update_cap_data_closedform arch_update_cap_data_def is_zombie_def Let_def
          split: cap.splits arch_cap.splits)
 
-lemma valid_msg_length_strengthen [Ipc_AI_assms]:
+lemma valid_msg_length_strengthen [Ipc_AI_2_assms]:
   "valid_message_info mi \<longrightarrow> unat (mi_length mi) \<le> msg_max_length"
   apply (clarsimp simp: valid_message_info_def)
   apply (subgoal_tac "unat (mi_length mi) \<le> unat (of_nat msg_max_length :: machine_word)")
@@ -208,7 +220,7 @@ lemma valid_msg_length_strengthen [Ipc_AI_assms]:
   apply (clarsimp simp: un_ui_le word_le_def)
   done
 
-lemma copy_mrs_in_user_frame[wp, Ipc_AI_assms]:
+lemma copy_mrs_in_user_frame[wp, Ipc_AI_2_assms]:
   "\<lbrace>in_user_frame p\<rbrace> copy_mrs t buf t' buf' n \<lbrace>\<lambda>rv. in_user_frame p\<rbrace>"
   by (simp add: in_user_frame_def) (wp hoare_vcg_ex_lift)
 
@@ -222,21 +234,21 @@ lemma make_arch_fault_msg_invs[wp]: "\<lbrace>P\<rbrace> make_arch_fault_msg f t
   apply wp
   done
 
-lemma make_fault_message_inv[wp, Ipc_AI_assms]:
+lemma make_fault_message_inv[wp, Ipc_AI_2_assms]:
   "\<lbrace>P\<rbrace> make_fault_msg ft t \<lbrace>\<lambda>rv. P\<rbrace>"
   apply (cases ft, simp_all split del: if_split)
      apply (wp as_user_inv getRestartPC_inv mapM_wp'
               | simp add: getRegister_def)+
   done
 
-lemma do_fault_transfer_invs[wp, Ipc_AI_assms]:
+lemma do_fault_transfer_invs[wp, Ipc_AI_2_assms]:
   "\<lbrace>invs and tcb_at receiver\<rbrace>
       do_fault_transfer badge sender receiver recv_buf
    \<lbrace>\<lambda>rv. invs\<rbrace>"
   by (simp add: do_fault_transfer_def split_def | wp
     | clarsimp split: option.split)+
 
-lemma lookup_ipc_buffer_in_user_frame[wp, Ipc_AI_assms]:
+lemma lookup_ipc_buffer_in_user_frame[wp, Ipc_AI_2_assms]:
   "\<lbrace>valid_objs and tcb_at t\<rbrace> lookup_ipc_buffer b t
    \<lbrace>case_option (\<lambda>_. True) in_user_frame\<rbrace>"
   apply (simp add: lookup_ipc_buffer_def)
@@ -338,9 +350,9 @@ lemma transfer_caps_non_null_cte_wp_at:
   done
 
 crunch do_fault_transfer
-  for cte_wp_at[wp,Ipc_AI_assms]: "cte_wp_at P p"
+  for cte_wp_at[wp,Ipc_AI_2_assms]: "cte_wp_at P p"
 
-lemma do_normal_transfer_non_null_cte_wp_at [Ipc_AI_assms]:
+lemma do_normal_transfer_non_null_cte_wp_at [Ipc_AI_2_assms]:
   assumes imp: "\<And>c. P c \<Longrightarrow> \<not> is_untyped_cap c"
   shows  "\<lbrace>valid_objs and cte_wp_at (P and ((\<noteq>) cap.NullCap)) ptr\<rbrace>
    do_normal_transfer st send_buffer ep b gr rt recv_buffer
@@ -351,7 +363,7 @@ lemma do_normal_transfer_non_null_cte_wp_at [Ipc_AI_assms]:
     | clarsimp simp:imp)+
   done
 
-lemma is_derived_ReplyCap [simp, Ipc_AI_assms]:
+lemma is_derived_ReplyCap [simp, Ipc_AI_2_assms]:
   "\<And>m p R. is_derived m p (cap.ReplyCap t False R) = (\<lambda>c. is_master_reply_cap c \<and> obj_ref_of c = t)"
   apply (subst fun_eq_iff)
   apply clarsimp
@@ -372,7 +384,7 @@ lemma do_normal_transfer_tcb_caps:
      | simp add:imp)+
   done
 
-lemma do_ipc_transfer_tcb_caps [Ipc_AI_assms]:
+lemma do_ipc_transfer_tcb_caps [Ipc_AI_2_assms]:
   assumes imp: "\<And>c. P c \<Longrightarrow> \<not> is_untyped_cap c"
   shows
   "\<lbrace>valid_objs and cte_wp_at P (t, ref) and tcb_at t\<rbrace>
@@ -384,14 +396,14 @@ lemma do_ipc_transfer_tcb_caps [Ipc_AI_assms]:
        | wpc | simp add:imp)+
   done
 
-lemma setup_caller_cap_valid_global_objs[wp, Ipc_AI_assms]:
+lemma setup_caller_cap_valid_global_objs[wp, Ipc_AI_2_assms]:
   "\<lbrace>valid_global_objs\<rbrace> setup_caller_cap send recv grant \<lbrace>\<lambda>rv. valid_global_objs\<rbrace>"
   apply (wp valid_global_objs_lift valid_vso_at_lift)
   apply (simp_all add: setup_caller_cap_def split del: if_split)
    apply (wp sts_obj_at_impossible | simp add: tcb_not_empty_table)+
   done
 
-lemma transfer_caps_loop_valid_vspace_objs[wp, Ipc_AI_assms]:
+lemma transfer_caps_loop_valid_vspace_objs[wp, Ipc_AI_2_assms]:
   "\<lbrace>valid_vspace_objs\<rbrace>
       transfer_caps_loop ep buffer n caps slots mi
     \<lbrace>\<lambda>rv. valid_vspace_objs\<rbrace>"
@@ -406,27 +418,82 @@ lemma transfer_caps_loop_valid_vspace_objs[wp, Ipc_AI_assms]:
         | assumption | simp split del: if_split)+
   done
 
-declare make_arch_fault_msg_invs[Ipc_AI_assms]
+declare make_arch_fault_msg_invs[Ipc_AI_2_assms]
 crunch handle_arch_fault_reply, arch_get_sanitise_register_info
-  for typ_at[Ipc_AI_assms]: "P (typ_at T p s)"
+  for typ_at[Ipc_AI_2_assms]: "P (typ_at T p s)"
+
+lemma transfer_caps_loop_ioports:
+  "\<And>slots caps ep buffer n mi.
+    \<lbrace>valid_ioports and valid_objs and valid_mdb and K (distinct slots)
+         and (\<lambda>s. \<forall>x \<in> set slots. real_cte_at x s \<and> cte_wp_at (\<lambda>cap. cap = cap.NullCap) x s)
+         and transfer_caps_srcs caps\<rbrace>
+      transfer_caps_loop ep buffer n caps slots mi
+    \<lbrace>\<lambda>rv. valid_ioports\<rbrace>"
+  apply (rule hoare_pre)
+   apply (rule transfer_caps_loop_presM[where vo=True and em=False and ex=False])
+     apply (wp cap_insert_derived_ioports)
+     apply (clarsimp simp: cte_wp_at_caps_of_state)
+    apply (wp valid_ioports_lift)
+   apply (clarsimp simp:cte_wp_at_caps_of_state|intro conjI ballI)+
+   apply (drule(1) bspec,clarsimp)
+   apply (frule(1) caps_of_state_valid)
+   apply (fastforce simp:valid_cap_def)
+  apply (drule(1) bspec)
+  apply clarsimp
+  done
+
+lemma transfer_caps_loop_valid_arch[Ipc_AI_2_assms]:
+  "\<And>slots caps ep buffer n mi.
+    \<lbrace>valid_arch_state and valid_objs and valid_mdb and K (distinct slots)
+         and (\<lambda>s. \<forall>x \<in> set slots. real_cte_at x s \<and> cte_wp_at (\<lambda>cap. cap = cap.NullCap) x s)
+         and transfer_caps_srcs caps\<rbrace>
+      transfer_caps_loop ep buffer n caps slots mi
+    \<lbrace>\<lambda>_. valid_arch_state\<rbrace>"
+  by (wpsimp wp: valid_arch_state_lift_ioports_aobj_at transfer_caps_loop_ioports
+                 transfer_caps_loop_aobj_at)
+     (simp add: valid_arch_state_def)
+
+lemma setup_caller_cap_aobj_at:
+  "arch_obj_pred P' \<Longrightarrow>
+  \<lbrace>\<lambda>s. P (obj_at P' pd s)\<rbrace> setup_caller_cap st rt grant \<lbrace>\<lambda>r s. P (obj_at P' pd s)\<rbrace>"
+  unfolding setup_caller_cap_def
+  by (wpsimp wp: cap_insert_aobj_at sts.aobj_at)
+
+lemma setup_caller_cap_valid_arch[Ipc_AI_2_assms, wp]:
+  "setup_caller_cap st rt grant \<lbrace>valid_arch_state\<rbrace>"
+  by (wp valid_arch_state_lift_ioports_aobj_at[rotated -1] setup_caller_cap_ioports
+         setup_caller_cap_aobj_at)
+     (simp add: valid_arch_state_def)
+
+crunch do_ipc_transfer
+  for ioports[wp]: "valid_ioports"
+  (wp: crunch_wps hoare_vcg_const_Ball_lift transfer_caps_loop_ioports
+   simp: zipWithM_x_mapM crunch_simps ball_conj_distrib )
 
 end
 
-interpretation Ipc_AI?: Ipc_AI
+interpretation Ipc_AI?: Ipc_AI_2
 proof goal_cases
   interpret Arch .
-  case 1 show ?case by (unfold_locales; (fact Ipc_AI_assms)?)
+  case 1 show ?case by (unfold_locales; (fact Ipc_AI_2_assms)?)
 qed
 
 context Arch begin arch_global_naming
 
-named_theorems Ipc_AI_cont_assms
+named_theorems Ipc_AI_3_assms
 
 crunch do_ipc_transfer
-  for pspace_respects_device_region[wp, Ipc_AI_cont_assms]: "pspace_respects_device_region"
+  for pspace_respects_device_region[wp, Ipc_AI_3_assms]: "pspace_respects_device_region"
   (wp: crunch_wps ignore: const_on_failure simp: crunch_simps)
 
-lemma do_ipc_transfer_respects_device_region[Ipc_AI_cont_assms]:
+lemma do_ipc_transfer_valid_arch[Ipc_AI_3_assms]:
+  "\<lbrace>valid_arch_state and valid_objs and valid_mdb \<rbrace>
+   do_ipc_transfer s ep bg grt r
+   \<lbrace>\<lambda>rv. valid_arch_state\<rbrace>"
+  by (wp valid_arch_state_lift_ioports_aobj_at do_ipc_transfer_ioports do_ipc_transfer_aobj_at)+
+     (simp add: valid_arch_state_def)
+
+lemma do_ipc_transfer_respects_device_region[Ipc_AI_3_assms]:
   "\<lbrace>cap_refs_respects_device_region and tcb_at t and  valid_objs and valid_mdb\<rbrace>
    do_ipc_transfer t ep bg grt r
    \<lbrace>\<lambda>rv. cap_refs_respects_device_region\<rbrace>"
@@ -453,7 +520,7 @@ lemma set_mrs_state_hyp_refs_of[wp]:
   by (wp set_mrs_thread_set_dmo thread_set_hyp_refs_trivial | simp)+
 
 crunch do_ipc_transfer
-  for state_hyp_refs_of[wp, Ipc_AI_cont_assms]: "\<lambda> s. P (state_hyp_refs_of s)"
+  for state_hyp_refs_of[wp, Ipc_AI_3_assms]: "\<lambda> s. P (state_hyp_refs_of s)"
   (wp: crunch_wps simp: zipWithM_x_mapM)
 
 lemma arch_derive_cap_untyped:
@@ -478,10 +545,10 @@ lemma valid_arch_mdb_cap_swap:
 
 end
 
-interpretation Ipc_AI?: Ipc_AI_cont
-  proof goal_cases
+interpretation Ipc_AI?: Ipc_AI_3
+proof goal_cases
   interpret Arch .
-  case 1 show ?case by (unfold_locales; (fact Ipc_AI_cont_assms)?)
-  qed
+  case 1 show ?case by (unfold_locales; (fact Ipc_AI_3_assms)?)
+qed
 
 end

--- a/proof/invariant-abstract/X64/ArchKernelInit_AI.thy
+++ b/proof/invariant-abstract/X64/ArchKernelInit_AI.thy
@@ -301,13 +301,17 @@ lemma invs_A:
                          valid_reply_masters_def valid_global_refs_def
                          valid_refs_def[unfolded cte_wp_at_caps_of_state])
   apply (clarsimp, (thin_tac "_")+) (* use new proven assumptions, then drop them *)
-  apply (rule conjI)
-   apply (clarsimp simp: valid_arch_state_def)
    apply (rule conjI)
-    apply (clarsimp simp: valid_asid_table_def state_defs)
-   apply (simp add: valid_global_pts_def valid_global_pds_def valid_global_pdpts_def
-                    valid_arch_state_def state_defs obj_at_def a_type_def
-                    valid_cr3_def valid_x64_irq_state_def asid_wf_0)
+    apply (clarsimp simp: valid_arch_state_def)
+    apply (rule conjI)
+     apply (clarsimp simp: valid_asid_table_def state_defs)
+    apply (subgoal_tac "valid_ioports init_A_st")
+     apply (simp add: valid_global_pts_def valid_global_pds_def valid_global_pdpts_def
+                      valid_arch_state_def state_defs obj_at_def a_type_def
+                      valid_cr3_def valid_x64_irq_state_def asid_wf_0)
+    apply (clarsimp simp: valid_ioports_def caps_of_state_init_A_st_Null all_ioports_issued_def ran_def
+                          issued_ioports_def ioports_no_overlap_def
+                    cong: rev_conj_cong)
   apply (rule conjI)
    apply (clarsimp simp: valid_irq_node_def obj_at_def state_defs
                          is_cap_table_def wf_empty_bits
@@ -322,10 +326,6 @@ lemma invs_A:
   apply (rule conjI)
    apply (clarsimp simp: valid_irq_states_def state_defs init_machine_state_def
                          valid_irq_masks_def init_irq_masks_def)
-  apply (rule conjI)
-   apply (clarsimp simp: valid_ioports_def caps_of_state_init_A_st_Null all_ioports_issued_def ran_def
-                         issued_ioports_def ioports_no_overlap_def
-                   cong: rev_conj_cong)
   apply (rule conjI)
    apply (clarsimp simp: valid_machine_state_def state_defs
                          init_machine_state_def init_underlying_memory_def)

--- a/proof/invariant-abstract/X64/ArchTcbAcc_AI.thy
+++ b/proof/invariant-abstract/X64/ArchTcbAcc_AI.thy
@@ -173,6 +173,23 @@ lemma tcb_context_update_aux: "arch_tcb_context_set (P (arch_tcb_context_get atc
                                = tcb_context_update (\<lambda>ctx. P ctx) atcb"
   by (simp add: arch_tcb_context_set_def arch_tcb_context_get_def)
 
+crunch set_thread_state, set_bound_notification
+  for valid_ioports[wp]: valid_ioports
+  (wp: valid_ioports_lift)
+
+lemma thread_set_ioports:
+  assumes y: "\<And>tcb. \<forall>(getF, v) \<in> ran tcb_cap_cases.
+                  getF (f tcb) = getF tcb"
+  shows
+  "\<lbrace>valid_ioports\<rbrace> thread_set f t \<lbrace>\<lambda>rv. valid_ioports\<rbrace>"
+  by (wpsimp wp: valid_ioports_lift thread_set_caps_of_state_trivial y)
+
+lemma thread_set_valid_arch_state[TcbAcc_AI_assms]:
+  "(\<And>tcb. \<forall>(getF, v) \<in> ran tcb_cap_cases. getF (f tcb) = getF tcb)
+   \<Longrightarrow> thread_set f t \<lbrace> valid_arch_state \<rbrace>"
+  by (wp valid_arch_state_lift_ioports_aobj_at thread_set_ioports thread_set.aobj_at
+      | simp add: valid_arch_state_def)+
+
 end
 
 global_interpretation TcbAcc_AI?: TcbAcc_AI

--- a/proof/invariant-abstract/X64/ArchUntyped_AI.thy
+++ b/proof/invariant-abstract/X64/ArchUntyped_AI.thy
@@ -266,7 +266,7 @@ lemma set_untyped_cap_invs_simple[Untyped_AI_assms]:
   apply wps
   apply (wp hoare_vcg_all_lift set_cap_irq_handlers set_cap_valid_arch_caps
     set_cap_irq_handlers cap_table_at_lift_valid set_cap_typ_at
-    set_untyped_cap_refs_respects_device_simple set_cap_ioports_no_new_ioports)
+    set_untyped_cap_refs_respects_device_simple set_cap_no_new_ioports_arch_valid_arch_state)
   apply (clarsimp simp:cte_wp_at_caps_of_state is_cap_simps)
   apply (intro conjI,clarsimp)
         apply (rule ext,clarsimp simp:is_cap_simps)
@@ -381,10 +381,17 @@ lemma create_cap_cap_refs_in_kernel_window[wp, Untyped_AI_assms]:
   apply blast
   done
 
-lemma create_cap_ioports[wp, Untyped_AI_assms]:
+lemma create_cap_ioports[wp]:
   "\<lbrace>valid_ioports and cte_wp_at (\<lambda>_. True) cref\<rbrace> create_cap tp sz p dev (cref,oref) \<lbrace>\<lambda>rv. valid_ioports\<rbrace>"
-  by (wpsimp wp: set_cap_ioports' set_cdt_cte_wp_at
+  by (wpsimp wp: set_cap_ioports_safe set_cdt_cte_wp_at
               simp: safe_ioport_insert_not_ioport[OF default_cap_not_ioport] create_cap_def)
+
+lemma create_cap_valid_arch_state[wp, Untyped_AI_assms]:
+  "\<lbrace>valid_arch_state and cte_wp_at (\<lambda>_. True) cref\<rbrace>
+   create_cap tp sz p dev (cref,oref)
+   \<lbrace>\<lambda>rv. valid_arch_state\<rbrace>"
+  by (wp valid_arch_state_lift_ioports_aobj_at create_cap_aobj_at)+
+     (simp add: valid_arch_state_def)
 
 (* FIXME: move *)
 lemma simpler_store_pml4e_def:
@@ -584,6 +591,8 @@ lemma obj_is_device_vui_eq[Untyped_AI_assms]:
   apply (simp add: default_arch_object_def split: aobject_type.split)
   apply (auto simp: arch_is_frame_type_def)
   done
+
+lemmas [Untyped_AI_assms] = set_cap_non_arch_valid_arch_state
 
 end
 

--- a/proof/invariant-abstract/X64/ArchVSpace_AI.thy
+++ b/proof/invariant-abstract/X64/ArchVSpace_AI.thy
@@ -244,6 +244,11 @@ lemma vs_lookup_pages_clear_asid_table:
   apply (clarsimp split: if_split_asm)
   done
 
+lemma valid_ioports_arch_state_simp[simp]:
+  "x64_allocated_io_ports (f (arch_state s)) = x64_allocated_io_ports (arch_state s)
+   \<Longrightarrow> valid_ioports_2 (caps_of_state s) (f (arch_state s)) = valid_ioports s"
+  unfolding valid_ioports_def ioports_no_overlap_def all_ioports_issued_def issued_ioports_def
+  by simp
 
 lemma valid_arch_state_unmap_strg:
   "valid_arch_state s \<longrightarrow>
@@ -252,7 +257,7 @@ lemma valid_arch_state_unmap_strg:
   apply (rule conjI)
    apply (clarsimp simp add: ran_def)
    apply blast
-  apply (clarsimp simp: inj_on_def)
+  apply (clarsimp simp: inj_on_def valid_ioports_def)
   done
 
 lemma valid_vspace_objs_unmap_strg:
@@ -1339,7 +1344,7 @@ lemma arch_update_cap_invs_map:
   apply (rule hoare_pre)
    apply (wp arch_update_cap_pspace arch_update_cap_valid_mdb set_cap_idle
              update_cap_ifunsafe valid_irq_node_typ set_cap_typ_at
-             set_cap_irq_handlers set_cap_valid_arch_caps set_cap_ioports_no_new_ioports
+             set_cap_irq_handlers set_cap_valid_arch_caps set_cap_no_new_ioports_arch_valid_arch_state
              set_cap_cap_refs_respects_device_region_spec[where ptr = p])
   apply (clarsimp simp: cte_wp_at_caps_of_state
               simp del: imp_disjL)
@@ -1418,7 +1423,7 @@ lemma arch_update_cap_invs_unmap_page:
   apply (rule hoare_pre)
    apply (wp arch_update_cap_pspace arch_update_cap_valid_mdb set_cap_idle
              update_cap_ifunsafe valid_irq_node_typ set_cap_typ_at
-             set_cap_irq_handlers set_cap_valid_arch_caps set_cap_ioports_no_new_ioports
+             set_cap_irq_handlers set_cap_valid_arch_caps set_cap_no_new_ioports_arch_valid_arch_state
              set_cap_cap_refs_respects_device_region_spec[where ptr = p])
   apply clarsimp
   apply (clarsimp simp: cte_wp_at_caps_of_state is_arch_update_def
@@ -1457,7 +1462,7 @@ lemma arch_update_cap_invs_unmap_page_table:
   apply (rule hoare_pre)
    apply (wp arch_update_cap_pspace arch_update_cap_valid_mdb set_cap_idle
              update_cap_ifunsafe valid_irq_node_typ set_cap_typ_at
-             set_cap_irq_handlers set_cap_valid_arch_caps set_cap_ioports_no_new_ioports
+             set_cap_irq_handlers set_cap_valid_arch_caps set_cap_no_new_ioports_arch_valid_arch_state
              set_cap_cap_refs_respects_device_region_spec[where ptr = p])
   apply (simp add: final_cap_at_eq)
   apply (clarsimp simp: cte_wp_at_caps_of_state is_arch_update_def
@@ -1501,7 +1506,7 @@ lemma arch_update_cap_invs_unmap_page_directory:
   apply (rule hoare_pre)
    apply (wp arch_update_cap_pspace arch_update_cap_valid_mdb set_cap_idle
              update_cap_ifunsafe valid_irq_node_typ set_cap_typ_at
-             set_cap_irq_handlers set_cap_valid_arch_caps set_cap_ioports_no_new_ioports
+             set_cap_irq_handlers set_cap_valid_arch_caps set_cap_no_new_ioports_arch_valid_arch_state
              set_cap_cap_refs_respects_device_region_spec[where ptr = p])
   apply (simp add: final_cap_at_eq)
   apply (clarsimp simp: cte_wp_at_caps_of_state is_arch_update_def
@@ -1545,7 +1550,7 @@ lemma arch_update_cap_invs_unmap_pd_pointer_table:
   apply (rule hoare_pre)
    apply (wp arch_update_cap_pspace arch_update_cap_valid_mdb set_cap_idle
              update_cap_ifunsafe valid_irq_node_typ set_cap_typ_at
-             set_cap_irq_handlers set_cap_valid_arch_caps set_cap_ioports_no_new_ioports
+             set_cap_irq_handlers set_cap_valid_arch_caps set_cap_no_new_ioports_arch_valid_arch_state
              set_cap_cap_refs_respects_device_region_spec[where ptr = p])
   apply (simp add: final_cap_at_eq)
   apply (clarsimp simp: cte_wp_at_caps_of_state is_arch_update_def

--- a/proof/refine/AARCH64/Finalise_R.thy
+++ b/proof/refine/AARCH64/Finalise_R.thy
@@ -1859,7 +1859,7 @@ lemma final_matters_sameRegion_sameObject:
   done
 
 lemma final_matters_sameRegion_sameObject2:
-  "\<lbrakk> final_matters' cap'; \<not> isUntypedCap cap; \<not> isIRQHandlerCap cap'; \<not> isArchIOPortCap cap' \<rbrakk>
+  "\<lbrakk> final_matters' cap'; \<not> isUntypedCap cap; \<not> isIRQHandlerCap cap' \<rbrakk>
      \<Longrightarrow> sameRegionAs cap cap' = sameObjectAs cap cap'"
   apply (rule iffI)
    apply (erule sameRegionAsE)

--- a/proof/refine/RISCV64/Finalise_R.thy
+++ b/proof/refine/RISCV64/Finalise_R.thy
@@ -1868,7 +1868,7 @@ lemma final_matters_sameRegion_sameObject:
   done
 
 lemma final_matters_sameRegion_sameObject2:
-  "\<lbrakk> final_matters' cap'; \<not> isUntypedCap cap; \<not> isIRQHandlerCap cap'; \<not> isArchIOPortCap cap' \<rbrakk>
+  "\<lbrakk> final_matters' cap'; \<not> isUntypedCap cap; \<not> isIRQHandlerCap cap' \<rbrakk>
      \<Longrightarrow> sameRegionAs cap cap' = sameObjectAs cap cap'"
   apply (rule iffI)
    apply (erule sameRegionAsE)


### PR DESCRIPTION
Commits are non-overlapping and can be reviewed on a commit-by-commit basis. It'll probably need more squashing than what I have now, advice welcome. 🦆🦆🦆

It was always a bit silly that valid_ioports existed on architectures with no IO ports. After discussing with Corey, the idea of moving it into valid_arch_state on X64 and retiring it on other arches came up. This worked, but resulted in changes to the arch-split interface in AInvs due to valid_arch_state now potentially depending on caps.

~~In Refine on X64, I did the same change so that during arch-split we won't need to see IO ports mentioned on arches that don't have them. It also required a fair bit of mangling to get through the extra valid_arch_state' dependency on caps. The hope is that maybe we can get rid of valid_ioports' altogether via assert magic. That will be the next experiment.~~

Edit: experiment was successful, no X64 Refine+CRefine changes needed in this PR anymore

For Access+Infoflow, see commit message.