### PR TITLE
Remove valid_ioports' from X64 Refine

### DIFF
--- a/proof/crefine/X64/Arch_C.thy
+++ b/proof/crefine/X64/Arch_C.thy
@@ -4869,6 +4869,7 @@ lemma invokeX86PortControl_ccorres:
    apply (clarsimp cong: StateSpace.state.fold_congs globals.fold_congs)
    apply (rule ccorres_Guard_Seq)
    apply (clarsimp simp: liftE_def bind_assoc return_returnOk)
+   apply (rule ccorres_stateAssert)
    apply (ctac add: setIOPortMask_ccorres)
      apply csymbr
      apply (ctac(no_vcg) add: cteInsert_ccorres)

--- a/proof/refine/X64/Detype_R.thy
+++ b/proof/refine/X64/Detype_R.thy
@@ -636,7 +636,6 @@ lemma valid_objs: "valid_objs' s'"
   and      arch: "valid_arch_state' s'"
   and      virq: "valid_irq_node' (irq_node' s') s'"
   and     virqh: "valid_irq_handlers' s'"
-  and  vioports: "valid_ioports' s'"
   and     virqs: "valid_irq_states' s'"
   and no_0_objs: "no_0_obj' s'"
   and  ctnotinQ: "ct_not_inQ s'"
@@ -1577,13 +1576,6 @@ proof (simp add: invs'_def valid_state'_def valid_pspace'_def
                      cteCaps_of_def tree_to_ctes Ball_def)
     apply (erule allEI)
     apply (clarsimp simp: ran_def)
-    done
-
-  show "valid_ioports' ?s" using vioports
-    apply (simp add: valid_ioports'_simps Ball_def cteCaps_of_def, clarsimp)
-    apply (rule conjI, rule allEI, assumption, (auto simp: ran_def)[1])
-    apply (erule allEI)
-    apply (auto simp: ran_def)
     done
 
   from irq_ctrl

--- a/proof/refine/X64/InterruptAcc_R.thy
+++ b/proof/refine/X64/InterruptAcc_R.thy
@@ -55,7 +55,6 @@ lemma setIRQState_invs[wp]:
                         if_unsafe_then_cap'_def ex_cte_cap_to'_def
                         valid_irq_handlers'_def irq_issued'_def
                         cteCaps_of_def valid_irq_masks'_def
-                        valid_ioports'_simps
                         bitmapQ_defs valid_bitmaps_def)
   apply (rule conjI, clarsimp)
   apply (clarsimp simp: irqs_masked'_def ct_not_inQ_def)

--- a/proof/refine/X64/Interrupt_R.thy
+++ b/proof/refine/X64/Interrupt_R.thy
@@ -602,7 +602,7 @@ lemma updateIRQState_invs'[wp]:
                          valid_irq_handlers'_def irq_issued'_def
                          cteCaps_of_def valid_irq_masks'_def
                          bitmapQ_defs  valid_x64_irq_state'_def
-                         valid_ioports'_def all_ioports_issued'_def issued_ioports'_def)
+                         all_ioports_issued'_def issued_ioports'_def)
   done
 
 lemma dmo_ioapicMapPinToVector_invs'[wp]:

--- a/proof/refine/X64/InvariantUpdates_H.thy
+++ b/proof/refine/X64/InvariantUpdates_H.thy
@@ -272,10 +272,6 @@ lemma valid_arch_state'_interrupt[simp]:
 
 context begin interpretation Arch . (*FIXME: arch-split*)
 
-lemma valid_ioports_cr3_update[simp]:
-  "valid_ioports' (s\<lparr>ksArchState := x64KSCurrentUserCR3_update (\<lambda>_. c) (ksArchState s)\<rparr>) = valid_ioports' s"
-  by (clarsimp simp: valid_ioports'_simps)
-
 end
 
 lemma valid_bitmapQ_ksSchedulerAction_upd[simp]:

--- a/proof/refine/X64/IpcCancel_R.thy
+++ b/proof/refine/X64/IpcCancel_R.thy
@@ -1655,7 +1655,7 @@ lemma cancel_all_invs'_helper:
   apply (rule mapM_x_inv_wp2)
    apply clarsimp
   apply (rule hoare_pre)
-   apply (wp valid_irq_node_lift valid_irq_handlers_lift'' irqs_masked_lift valid_ioports_lift''
+   apply (wp valid_irq_node_lift valid_irq_handlers_lift'' irqs_masked_lift
              hoare_vcg_const_Ball_lift untyped_ranges_zero_lift sts_st_tcb'
           | simp add: cteCaps_of_def o_def)+
   apply (unfold fun_upd_apply Invariants_H.tcb_st_refs_of'_simps)
@@ -2133,7 +2133,7 @@ lemma cancelBadgedSends_filterM_helper':
   apply (rule hoare_pre)
    apply (wp valid_irq_node_lift hoare_vcg_const_Ball_lift sts_sch_act'
              sch_act_wf_lift valid_irq_handlers_lift'' cur_tcb_lift irqs_masked_lift
-             sts_st_tcb' valid_ioports_lift''
+             sts_st_tcb'
              untyped_ranges_zero_lift
         | clarsimp simp: cteCaps_of_def o_def)+
   apply (frule insert_eqD, frule state_refs_of'_elemD)

--- a/proof/refine/X64/KHeap_R.thy
+++ b/proof/refine/X64/KHeap_R.thy
@@ -2220,19 +2220,6 @@ lemmas set_ntfn_irq_handlers'[wp] = valid_irq_handlers_lift'' [OF set_ntfn_ctes_
 
 lemmas set_ntfn_irq_states' [wp] = valid_irq_states_lift' [OF set_ntfn_ksInterrupt set_ntfn_ksMachine]
 
-lemma valid_ioports_lift':
-  assumes x: "\<And>P. \<lbrace>\<lambda>s. P (cteCaps_of s)\<rbrace> f \<lbrace>\<lambda>rv s. P (cteCaps_of s)\<rbrace>"
-  assumes y: "\<And>P. \<lbrace>\<lambda>s. P (ksArchState s)\<rbrace> f \<lbrace>\<lambda>rv s. P (ksArchState s)\<rbrace>"
-  shows      "\<lbrace>valid_ioports'\<rbrace> f \<lbrace>\<lambda>rv. valid_ioports'\<rbrace>"
-  apply (clarsimp simp: valid_ioports'_def)
-  apply (rule hoare_use_eq [where f="\<lambda>s. ksArchState s"], rule y)
-  apply (rule hoare_use_eq [where f="\<lambda>s. cteCaps_of s"], rule x)
-  apply wp
-  done
-
-lemmas valid_ioports_lift'' = valid_ioports_lift'[unfolded cteCaps_of_def]
-lemmas set_ntfn_ioports'[wp] = valid_ioports_lift''[OF set_ntfn_ctes_of set_ntfn_arch']
-
 lemma set_ntfn_vms'[wp]:
   "\<lbrace>valid_machine_state'\<rbrace> setNotification ptr val \<lbrace>\<lambda>rv. valid_machine_state'\<rbrace>"
   apply (simp add: setNotification_def valid_machine_state'_def pointerInDeviceData_def pointerInUserData_def)
@@ -2451,7 +2438,6 @@ lemma setEndpoint_ksMachine:
 
 lemmas setEndpoint_valid_irq_states'  =
   valid_irq_states_lift' [OF setEndpoint_ksInterruptState setEndpoint_ksMachine]
-lemmas setEndpoint_ioports'[wp] = valid_ioports_lift''[OF set_ep_ctes_of set_ep_arch']
 
 lemma setEndpoint_ct':
   "\<lbrace>\<lambda>s. P (ksCurThread s)\<rbrace> setEndpoint a b \<lbrace>\<lambda>rv s. P (ksCurThread s)\<rbrace>"

--- a/proof/refine/X64/Schedule_R.thy
+++ b/proof/refine/X64/Schedule_R.thy
@@ -459,7 +459,7 @@ lemma tcbSchedEnqueue_invs'[wp]:
    \<lbrace>\<lambda>_. invs'\<rbrace>"
   apply (simp add: invs'_def valid_state'_def valid_pspace'_def)
   apply (wpsimp wp: valid_irq_node_lift valid_irq_handlers_lift'' irqs_masked_lift
-                    untyped_ranges_zero_lift tcbSchedEnqueue_ct_not_inQ valid_ioports_lift'
+                    untyped_ranges_zero_lift tcbSchedEnqueue_ct_not_inQ
               simp: cteCaps_of_def o_def)
   done
 
@@ -499,8 +499,7 @@ lemma tcbSchedAppend_tcb_in_cur_domain'[wp]:
 
 crunch tcbSchedAppend, tcbSchedDequeue
   for arch'[wp]: "\<lambda>s. P (ksArchState s)"
-  and ioports'[wp]: valid_ioports'
-  (simp: unless_def wp: valid_ioports_lift'')
+  (simp: unless_def)
 
 lemma tcbSchedAppend_sch_act_wf[wp]:
   "tcbSchedAppend thread \<lbrace>\<lambda>s. sch_act_wf (ksSchedulerAction s) s\<rbrace>"
@@ -992,12 +991,6 @@ lemma asUser_utr[wp]:
   apply (simp add: cteCaps_of_def)
   apply (rule hoare_pre, wp untyped_ranges_zero_lift)
   apply (simp add: o_def)
-  done
-
-lemma asUser_ioports'[wp]:
-  "\<lbrace>valid_ioports'\<rbrace> asUser t f \<lbrace>\<lambda>rv. valid_ioports'\<rbrace>"
-  apply (simp add: asUser_def split_def)
-  apply (wpsimp wp: valid_ioports_lift'' select_f_inv threadSet_ctes_of)
   done
 
 lemma Arch_switchToThread_invs_no_cicd':

--- a/proof/refine/X64/Syscall_R.thy
+++ b/proof/refine/X64/Syscall_R.thy
@@ -883,7 +883,6 @@ abbreviation (input) "all_invs_but_sch_extra \<equiv>
     valid_irq_handlers' s \<and>
     valid_irq_states' s \<and>
     irqs_masked' s \<and>
-    valid_ioports' s \<and>
     valid_machine_state' s \<and>
     cur_tcb' s \<and>
     untyped_ranges_zero' s \<and>
@@ -917,7 +916,6 @@ lemma threadSet_all_invs_but_sch_extra:
      irqs_masked_lift
      valid_irq_node_lift
      valid_irq_handlers_lift''
-     valid_ioports_lift''
      threadSet_ctes_ofT
      threadSet_not_inQ
      threadSet_tcbDomain_update_ct_idle_or_in_cur_domain'

--- a/proof/refine/X64/TcbAcc_R.thy
+++ b/proof/refine/X64/TcbAcc_R.thy
@@ -1358,7 +1358,7 @@ lemma threadSet_invs_trivialT:
             threadSet_global_refsT
             irqs_masked_lift
             valid_irq_node_lift
-            valid_irq_handlers_lift'' valid_ioports_lift''
+            valid_irq_handlers_lift''
             threadSet_ctes_ofT
             threadSet_not_inQ
             threadSet_ct_idle_or_in_cur_domain'
@@ -5272,8 +5272,6 @@ lemma setBoundNotification_ksDomSchedule[wp]:
 crunch rescheduleRequired, setBoundNotification, setThreadState
   for ksDomScheduleIdx[wp]: "\<lambda>s. P (ksDomScheduleIdx s)"
   and gsUntypedZeroRanges[wp]: "\<lambda>s. P (gsUntypedZeroRanges s)"
-  and ioports'[wp]: valid_ioports'
-  (wp: valid_ioports_lift'')
 
 lemma sts_utr[wp]:
   "\<lbrace>untyped_ranges_zero'\<rbrace> setThreadState st t \<lbrace>\<lambda>_. untyped_ranges_zero'\<rbrace>"

--- a/proof/refine/X64/Tcb_R.thy
+++ b/proof/refine/X64/Tcb_R.thy
@@ -681,10 +681,6 @@ lemma out_corresT:
 
 lemmas out_corres = out_corresT [OF _ all_tcbI, OF ball_tcb_cap_casesI ball_tcb_cte_casesI]
 
-crunch tcbSchedEnqueue
-  for ioports'[wp]: valid_ioports'
-  (wp: crunch_wps valid_ioports_lift'' simp: crunch_simps)
-
 lemma tcbSchedDequeue_sch_act_simple[wp]:
   "tcbSchedDequeue t \<lbrace>sch_act_simple\<rbrace>"
   by (wpsimp simp: sch_act_simple_def)
@@ -708,7 +704,6 @@ lemma threadSet_priority_invs':
             threadSet_idle'T
             valid_irq_node_lift
             valid_irq_handlers_lift''
-            valid_ioports_lift'
             threadSet_ctes_ofT
             threadSet_not_inQ
             threadSet_ct_idle_or_in_cur_domain'
@@ -911,17 +906,6 @@ lemma untyped_derived_eq_from_sameObjectAs:
 lemmas vspace_asid'_simps [simp] =
   vspace_asid'_def [split_simps capability.split arch_capability.split option.split prod.split]
 
-lemma badge_derived_safe_ioport_insert':
-  "\<lbrakk>valid_ioports' s; cteCaps_of s src_slot = Some c; badge_derived' new_cap c\<rbrakk>
-       \<Longrightarrow> safe_ioport_insert' new_cap capability.NullCap s"
-  apply (case_tac new_cap; clarsimp simp: isCap_simps)
-  apply (rename_tac ac, case_tac ac; clarsimp simp: isCap_simps)
-  apply (clarsimp simp: badge_derived'_def)
-  apply (clarsimp simp: safe_ioport_insert'_def valid_ioports'_def)
-  apply (rule conjI, clarsimp elim!: ranE simp: ioports_no_overlap'_def)
-   apply(force simp: ran_def cteCaps_of_def)
-  by (force simp: all_ioports_issued'_def ran_def cteCaps_of_def)
-
 lemma checked_insert_tcb_invs'[wp]:
   "\<lbrace>invs' and cte_wp_at' (\<lambda>cte. cteCap cte = NullCap) slot
          and valid_cap' new_cap
@@ -943,7 +927,6 @@ lemma checked_insert_tcb_invs'[wp]:
                         is_derived'_def untyped_derived_eq_from_sameObjectAs
                         ex_cte_cap_to'_cteCap)
   apply (erule sameObjectAsE)+
-  apply (clarsimp simp: badge_derived_safe_ioport_insert'[OF invs_valid_ioports'])
   apply (clarsimp simp: badge_derived'_def)
   apply (frule capBadgeNone_masters, simp)
   apply (rule conjI)
@@ -1090,7 +1073,7 @@ lemma threadSet_invs_trivialT2:
              threadSet_ifunsafe'T
              threadSet_global_refsT
              valid_irq_node_lift
-             valid_irq_handlers_lift'' valid_ioports_lift''
+             valid_irq_handlers_lift''
              threadSet_ctes_ofT
              threadSet_valid_dom_schedule'
              untyped_ranges_zero_lift

--- a/proof/refine/X64/Untyped_R.thy
+++ b/proof/refine/X64/Untyped_R.thy
@@ -3717,7 +3717,7 @@ lemma updateFreeIndex_clear_invs':
        apply (simp add:updateCap_def)
        apply (wp setCTE_irq_handlers' getCTE_wp)
       apply (simp add:updateCap_def)
-      apply (wp irqs_masked_lift cur_tcb_lift ct_idle_or_in_cur_domain'_lift setCTE_ioports'
+      apply (wp irqs_masked_lift cur_tcb_lift ct_idle_or_in_cur_domain'_lift
                 hoare_vcg_disj_lift untyped_ranges_zero_lift getCTE_wp valid_bitmaps_lift
                | wp (once) hoare_use_eq[where f="gsUntypedZeroRanges"]
                | simp add: getSlotCap_def
@@ -5321,17 +5321,6 @@ lemma insertNewCap_valid_irq_handlers:
   apply auto
   done
 
-crunch updateNewFreeIndex
-  for ioports[wp]: "valid_ioports'"
-
-lemma insertNewCap_ioports':
-  "\<lbrace>valid_ioports' and safe_ioport_insert' cap NullCap\<rbrace>
-     insertNewCap parent slot cap
-   \<lbrace>\<lambda>rv. valid_ioports'\<rbrace>"
-  apply (simp add: insertNewCap_def)
-  apply (wpsimp wp: setCTE_ioports' getCTE_wp)
-  by (clarsimp simp: cte_wp_at_ctes_of)
-
 crunch insertNewCap
   for irq_states'[wp]: valid_irq_states'
   and irqs_masked' [wp]: irqs_masked'
@@ -5400,12 +5389,6 @@ lemma insertNewCap_urz[wp]:
     apply (auto simp add: cteCaps_of_def untypedZeroRange_def isCap_simps)
   done
 
-lemma safe_ioport_insert'_capRange:
-  "capRange cap \<noteq> {} \<Longrightarrow> safe_ioport_insert' cap cap' s"
-  apply (clarsimp simp: safe_ioport_insert'_def)
-  apply (case_tac cap; clarsimp)
-  by (rename_tac ac, case_tac ac; clarsimp simp: capRange_def)
-
 lemma insertNewCap_invs':
   "\<lbrace>invs' and ct_active'
           and valid_cap' cap
@@ -5424,13 +5407,13 @@ lemma insertNewCap_invs':
    apply (wp insertNewCap_valid_pspace' sch_act_wf_lift
              cur_tcb_lift tcb_in_cur_domain'_lift sym_heap_sched_pointers_lift
              insertNewCap_valid_global_refs' valid_bitmaps_lift
-             valid_arch_state_lift' insertNewCap_ioports'
+             valid_arch_state_lift'
              valid_irq_node_lift insertNewCap_valid_irq_handlers)
   apply (clarsimp simp: cte_wp_at_ctes_of)
   apply (frule ctes_of_valid[rotated, where p=parent, OF valid_pspace_valid_objs'])
    apply (fastforce simp: cte_wp_at_ctes_of)
   apply (auto simp: isCap_simps sameRegionAs_def3
-            intro!: capRange_subset_capBits safe_ioport_insert'_capRange
+            intro!: capRange_subset_capBits
               elim: valid_capAligned)
   done
 

--- a/proof/refine/X64/VSpace_R.thy
+++ b/proof/refine/X64/VSpace_R.thy
@@ -1524,7 +1524,6 @@ crunch doMachineOp
   and irq_node'[wp]: "\<lambda>s. P (irq_node' s)"
   and gsMaxObjectSize[wp]: "\<lambda>s. P (gsMaxObjectSize s)"
   and ksInterruptState[wp]: "\<lambda>s. P (ksInterruptState s)"
-  and ioports'[wp]: valid_ioports'
 
 lemma setCurrentUserCR3_invs' [wp]:
   "\<lbrace>invs' and K (valid_cr3' c)\<rbrace> setCurrentUserCR3 c \<lbrace>\<lambda>rv. invs'\<rbrace>"
@@ -2102,7 +2101,7 @@ lemma storePDE_invs[wp]:
    apply (wp sch_act_wf_lift valid_global_refs_lift'
              irqs_masked_lift
              valid_arch_state_lift' valid_irq_node_lift
-             cur_tcb_lift valid_irq_handlers_lift'' valid_ioports_lift''
+             cur_tcb_lift valid_irq_handlers_lift''
              untyped_ranges_zero_lift valid_bitmaps_lift
            | simp add: cteCaps_of_def o_def)+
   apply clarsimp
@@ -2117,7 +2116,7 @@ lemma storePDPTE_invs[wp]:
    apply (wp sch_act_wf_lift valid_global_refs_lift'
              irqs_masked_lift
              valid_arch_state_lift' valid_irq_node_lift
-             cur_tcb_lift valid_irq_handlers_lift'' valid_ioports_lift''
+             cur_tcb_lift valid_irq_handlers_lift''
              untyped_ranges_zero_lift valid_bitmaps_lift
            | simp add: cteCaps_of_def o_def)+
   apply clarsimp
@@ -2132,7 +2131,7 @@ lemma storePML4E_invs[wp]:
    apply (wp sch_act_wf_lift valid_global_refs_lift'
              irqs_masked_lift
              valid_arch_state_lift' valid_irq_node_lift
-             cur_tcb_lift valid_irq_handlers_lift'' valid_ioports_lift''
+             cur_tcb_lift valid_irq_handlers_lift''
              untyped_ranges_zero_lift valid_bitmaps_lift
            | simp add: cteCaps_of_def o_def)+
   apply clarsimp
@@ -2282,7 +2281,7 @@ lemma storePTE_invs [wp]:
   apply (rule hoare_pre)
    apply (wp sch_act_wf_lift valid_global_refs_lift' irqs_masked_lift
              valid_arch_state_lift' valid_irq_node_lift
-             cur_tcb_lift valid_irq_handlers_lift'' valid_ioports_lift''
+             cur_tcb_lift valid_irq_handlers_lift''
              untyped_ranges_zero_lift valid_bitmaps_lift
            | simp add: cteCaps_of_def o_def)+
   apply clarsimp
@@ -2444,7 +2443,7 @@ lemma setASIDPool_invs [wp]:
   apply (rule hoare_pre)
    apply (wp sch_act_wf_lift valid_global_refs_lift' irqs_masked_lift
              valid_arch_state_lift' valid_irq_node_lift
-             cur_tcb_lift valid_irq_handlers_lift'' valid_ioports_lift''
+             cur_tcb_lift valid_irq_handlers_lift''
              untyped_ranges_zero_lift
              updateObject_default_inv valid_bitmaps_lift
            | simp add: cteCaps_of_def

--- a/spec/design/skel/X64/ArchVSpace_H.thy
+++ b/spec/design/skel/X64/ArchVSpace_H.thy
@@ -19,7 +19,7 @@ begin
 context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Kernel/VSpace/X64.lhs CONTEXT X64_H bodies_only ArchInv=ArchRetypeDecls_H NOT checkPML4At checkPDPTAt checkPDAt checkPTAt checkValidMappingSize
-#INCLUDE_HASKELL SEL4/Object/IOPort/X64.lhs CONTEXT X64_H bodies_only ArchInv=ArchRetypeDecls_H
+#INCLUDE_HASKELL SEL4/Object/IOPort/X64.lhs CONTEXT X64_H bodies_only ArchInv=ArchRetypeDecls_H NOT allIOPortsIssued_asrt
 
 defs checkValidMappingSize_def:
   "checkValidMappingSize sz \<equiv> stateAssert

--- a/spec/haskell/src/SEL4/Object/IOPort/X64.lhs
+++ b/spec/haskell/src/SEL4/Object/IOPort/X64.lhs
@@ -19,7 +19,7 @@ This module defines IO port routines, specific to x64.
 > import SEL4.API.Failures
 > import SEL4.Machine.Hardware.X64
 > import SEL4.Model
-> import SEL4.Model.StateData.X64
+> import SEL4.Model.StateData.X64 hiding (KernelState)
 > import SEL4.Object.Structures
 > import SEL4.Object.TCB
 > import SEL4.Object.ObjectType.X64
@@ -120,7 +120,12 @@ This module defines IO port routines, specific to x64.
 >        doMachineOp $ f w
 >        return []
 
->
+We do not need all of IO port validity in the refinement proof, but do need to
+cross over the constraint that all IO port caps in the state have been issued.
+
+> allIOPortsIssued_asrt :: KernelState -> Bool
+> allIOPortsIssued_asrt _ = True
+
 > performX64PortInvocation :: ArchInv.Invocation -> KernelP [Word]
 > performX64PortInvocation (InvokeIOPort (IOPortInvocation port port_data)) = withoutPreemption $
 >     case port_data of
@@ -133,6 +138,7 @@ This module defines IO port routines, specific to x64.
 
 > performX64PortInvocation (InvokeIOPortControl (IOPortControlIssue f l destSlot srcSlot)) =
 >   withoutPreemption $ do
+>     stateAssert allIOPortsIssued_asrt "all_io_ports_issued'"
 >     setIOPortMask f l True
 >     cteInsert (ArchObjectCap (IOPortCap f l)) srcSlot destSlot
 >     return []


### PR DESCRIPTION
🦆🦆🦆 This started with examining the IO port situation and arch-split, in particular complications due to the FC proofs on all architectures mentioning IO ports even when the architectures did not have them.

For AInvs, it was possible to fold valid_ioports into valid_arch_state and do the same for valid_ioports' and valid_arch_state' on X64 Refine... which I initially did in https://github.com/seL4/l4v/pull/829 but it turned out that for Refine this was ugly and didn't make a lot of sense.

At some point when talking with @corlewis about this, he suggested that it might be possible to do some crossing-over and reduce the IO port invariant burden in X64 Refine. After a lot of pain, I managed to figure out a way to bash the specs and proofs into submission, getting rid of valid_ioports' entirely. That's this PR.

With apologies to @corlewis , this PR now has to get merged before https://github.com/seL4/l4v/pull/829 is, because the X64 Refine work on that PR is going to get largely clobbered by these changes (all the AInvs + AC/IF + cleanup of other arches still applies though).

@mbrcknl you might find this one amusing, a sea of red demonstrating the advancement in our proof techniques over time :)