### PR TITLE
arch-split Refine up to Invariants_H for AARCH64 (Draft)

### DIFF
--- a/proof/crefine/AARCH64/ADT_C.thy
+++ b/proof/crefine/AARCH64/ADT_C.thy
@@ -787,6 +787,7 @@ lemma map_to_ctes_tcb_ctes:
   "ctes_of s' = ctes_of s \<Longrightarrow>
    ko_at' tcb p s \<Longrightarrow> ko_at' tcb' p s' \<Longrightarrow>
    \<forall>x\<in>ran tcb_cte_cases. fst x tcb' = fst x tcb"
+  supply raw_tcb_cte_cases_simps[simp] (* FIXME arch-split: legacy, try use tcb_cte_cases_neqs *)
   apply (clarsimp simp add: ran_tcb_cte_cases)
   apply (clarsimp simp: obj_at'_real_def ko_wp_at'_def projectKO_opt_tcb
                  split: kernel_object.splits)

--- a/proof/crefine/AARCH64/ArchMove_C.thy
+++ b/proof/crefine/AARCH64/ArchMove_C.thy
@@ -34,15 +34,6 @@ lemma ps_clear_is_aligned_ksPSpace_None:
                     power_overflow)
   by assumption
 
-lemma ps_clear_is_aligned_ctes_None:
-  assumes "ps_clear p tcbBlockSizeBits s"
-      and "is_aligned p tcbBlockSizeBits"
-  shows "ksPSpace s (p + 2*2^cteSizeBits) = None"
-    and "ksPSpace s (p + 3*2^cteSizeBits) = None"
-    and "ksPSpace s (p + 4*2^cteSizeBits) = None"
-  by (auto intro: assms ps_clear_is_aligned_ksPSpace_None
-            simp: objBits_defs mask_def)+
-
 lemma word_shift_by_3:
   "x * 8 = (x::'a::len word) << 3"
   by (simp add: shiftl_t2n)
@@ -88,6 +79,15 @@ where
 lemmas unat64_eq_of_nat = unat_eq_of_nat[where 'a=64, folded word_bits_def]
 
 context begin interpretation Arch .
+
+lemma ps_clear_is_aligned_ctes_None:
+  assumes "ps_clear p tcbBlockSizeBits s"
+      and "is_aligned p tcbBlockSizeBits"
+  shows "ksPSpace s (p + 2*2^cteSizeBits) = None"
+    and "ksPSpace s (p + 3*2^cteSizeBits) = None"
+    and "ksPSpace s (p + 4*2^cteSizeBits) = None"
+  by (auto intro: assms ps_clear_is_aligned_ksPSpace_None
+            simp: objBits_defs mask_def)+
 
 crunch archThreadGet
   for inv'[wp]: P

--- a/proof/crefine/AARCH64/Finalise_C.thy
+++ b/proof/crefine/AARCH64/Finalise_C.thy
@@ -2391,7 +2391,7 @@ lemma associateVCPUTCB_ccorres:
          apply vcg
         apply wpsimp
        apply (vcg exspec=dissociateVCPUTCB_modifies)
-      apply ((wpsimp wp: hoare_vcg_all_lift hoare_drop_imps
+      apply ((wpsimp wp: hoare_vcg_all_lift hoare_drop_imps valid_arch_tcb_lift'
               | strengthen invs_valid_objs' invs_arch_state')+)[1]
      apply (vcg exspec=dissociateVCPUTCB_modifies)
     apply (rule_tac Q'="\<lambda>_. invs' and vcpu_at' vcpuptr and tcb_at' tptr" in hoare_post_imp)

--- a/proof/crefine/AARCH64/IsolatedThreadAction.thy
+++ b/proof/crefine/AARCH64/IsolatedThreadAction.thy
@@ -142,11 +142,11 @@ end
 
 lemmas getObject_return_tcb
     = getObject_return[OF meta_eq_to_obj_eq, OF loadObject_tcb,
-                       unfolded objBits_simps, simplified]
+                       unfolded gen_objBits_simps, simplified]
 
 lemmas setObject_modify_tcb
     = setObject_modify[OF _ meta_eq_to_obj_eq, OF _ updateObject_tcb,
-                       unfolded objBits_simps, simplified]
+                       unfolded gen_objBits_simps, simplified]
 
 lemma partial_overwrite_fun_upd:
   "inj idx \<Longrightarrow>

--- a/proof/crefine/AARCH64/Recycle_C.thy
+++ b/proof/crefine/AARCH64/Recycle_C.thy
@@ -502,10 +502,10 @@ lemma heap_to_user_data_in_user_mem'[simp]:
    apply (subst is_aligned_add_helper[THEN conjunct2,where n1 = 3])
      apply (erule aligned_add_aligned)
       apply (simp add: is_aligned_mult_triv2[where n = 3,simplified])
-     apply  (clarsimp simp: objBits_simps AARCH64.pageBits_def)
+     apply  (clarsimp simp: gen_objBits_simps AARCH64.pageBits_def)
     apply simp
    apply (rule is_aligned_add_helper[THEN conjunct2])
-    apply (simp add: AARCH64.pageBits_def objBits_simps)
+    apply (simp add: AARCH64.pageBits_def gen_objBits_simps)
    apply (rule word_less_power_trans2[where k = 3,simplified])
      apply (rule less_le_trans[OF ucast_less])
       apply simp+

--- a/proof/crefine/Move_C.thy
+++ b/proof/crefine/Move_C.thy
@@ -131,13 +131,11 @@ lemma length_Suc_0_conv:
 
 lemma imp_ignore: "B \<Longrightarrow> A \<longrightarrow> B" by blast
 
-lemma cteSizeBits_eq:
-  "cteSizeBits = cte_level_bits"
-  by (simp add: cte_level_bits_def cteSizeBits_def)
+lemmas cteSizeBits_eq = cteSizeBits_cte_level_bits
 
 lemma cteSizeBits_le_cte_level_bits[simp]:
   "cteSizeBits \<le> cte_level_bits"
-  by (simp add: cte_level_bits_def cteSizeBits_def)
+  by (simp add: cteSizeBits_eq)
 
 lemma unat_ucast_prio_mask_simp[simp]:
   "unat (ucast (p::priority) && mask m :: machine_word) = unat (p && mask m)"
@@ -344,6 +342,20 @@ lemma word_eq_cast_unsigned:
   "(x = y) = (UCAST ('a signed \<rightarrow> ('a :: len)) x = ucast y)"
   by (simp add: word_eq_iff nth_ucast)
 
+(* tcbIPCBufferSlot is last slot in TCB *)
+(* FIXME arch-split: Arch is needed for wordSizeCase, proof is same on all arches *)
+lemma (in Arch) cteSizeBits_2ptcbBlockSizeBits[simplified tcbIPCBufferSlot_def]:
+  "n \<le> tcbIPCBufferSlot \<Longrightarrow> n << cteSizeBits < 2 ^ tcbBlockSizeBits"
+  unfolding tcbIPCBufferSlot_def tcbBlockSizeBits_def cteSizeBits_def
+  apply (simp only: wordSizeCase_simp)
+  apply (rule shiftl_less_t2n; simp)
+  apply unat_arith
+  done
+
+requalify_facts Arch.cteSizeBits_2ptcbBlockSizeBits
+
+lemmas zero_less_2p_tcbBlockSizeBits = cteSizeBits_2ptcbBlockSizeBits[where n=0, simplified]
+
 lemma ran_tcb_cte_cases:
   "ran tcb_cte_cases =
    {(Structures_H.tcbCTable, tcbCTable_update),
@@ -351,7 +363,8 @@ lemma ran_tcb_cte_cases:
     (Structures_H.tcbReply, tcbReply_update),
     (Structures_H.tcbCaller, tcbCaller_update),
     (tcbIPCBufferFrame, tcbIPCBufferFrame_update)}"
-  by (auto simp add: tcb_cte_cases_def cteSizeBits_def split: if_split_asm)
+  unfolding tcb_cte_cases_def
+  by (auto split: if_split_asm simp: tcb_cte_cases_neqs)
 
 lemma user_data_at_ko:
   "typ_at' UserDataT p s \<Longrightarrow> ko_at' UserData p s"
@@ -568,7 +581,7 @@ lemma threadGet_again:
    (threadGet ext t >>= n) s' = n rv s'"
   apply (clarsimp simp add: threadGet_def liftM_def in_monad)
   apply (frule use_valid [OF _ getObject_obj_at'])
-     apply (simp add: objBits_simps')+
+     apply (simp add: gen_objBits_simps tcbBlockSizeBits_def)+ (* FIXME arch-split: tcbBlockSizeBits *)
   apply (frule getObject_tcb_det)
   apply (clarsimp simp: bind_def split_def)
   apply (insert no_fail_getObject_tcb)
@@ -623,15 +636,16 @@ lemma mapM_only_length:
 
 lemma tcb_aligned':
   "tcb_at' t s \<Longrightarrow> is_aligned t tcbBlockSizeBits"
-  apply (drule obj_at_aligned')
-   apply (simp add: objBits_simps)
-  apply (simp add: objBits_simps)
-  done
+  by (drule obj_at_aligned'; simp add: gen_objBits_simps)
 
-lemma cte_at_0' [dest!]:
+(* identical proof on all arches *)
+lemma (in Arch) cte_at_0'[dest!]:
   "\<lbrakk> cte_at' 0 s; no_0_obj' s \<rbrakk> \<Longrightarrow> False"
   apply (clarsimp simp: cte_wp_at_obj_cases')
   by (auto simp: tcb_cte_cases_def is_aligned_def objBits_simps' dest!:tcb_aligned' split: if_split_asm)
+
+requalify_facts Arch.cte_at_0'
+lemmas [dest!] = cte_at_0'
 
 lemma getMessageInfo_le3:
   "\<lbrace>\<top>\<rbrace> getMessageInfo sender \<lbrace>\<lambda>rv s. unat (msgExtraCaps rv) \<le> 3\<rbrace>"
@@ -1119,45 +1133,54 @@ lemma updateObject_cte_tcb:
         return (KOTCB (updF (\<lambda>_. ctea) tcb))
     od)"
   using tc unfolding tcb_cte_cases_def
-  apply -
-  apply (clarsimp simp add: updateObject_cte Let_def
-    tcb_cte_cases_def objBits_simps' tcbSlots shiftl_t2n
-    split: if_split_asm cong: if_cong)
-  done
+  by (clarsimp simp: updateObject_cte Let_def tcb_cte_cases_neqs gen_objBits_simps tcbSlots
+               split: if_split_asm
+               cong: if_cong)
+
+lemma self_elim:
+  "\<And>P Q. \<lbrakk> P \<Longrightarrow> Q; P \<rbrakk> \<Longrightarrow> Q"
+  by blast
 
 lemma tcb_cte_cases_in_range1:
   assumes tc:"tcb_cte_cases (y - x) = Some v"
   and     al: "is_aligned x tcbBlockSizeBits"
   shows   "x \<le> y"
 proof -
-  note objBits_defs [simp]
-
   from tc obtain q where yq: "y = x + q" and qv: "q < 2 ^ tcbBlockSizeBits"
     unfolding tcb_cte_cases_def
-    by (simp add: diff_eq_eq split: if_split_asm)
+    by (clarsimp simp: diff_eq_eq tcbSlot_defs
+                 simp del: shiftl_1
+                 elim!: self_elim
+                 intro!: cteSizeBits_2ptcbBlockSizeBits zero_less_2p_tcbBlockSizeBits
+                 split: if_split_asm)
 
   have "x \<le> x + 2 ^ tcbBlockSizeBits - 1" using al
     by (rule is_aligned_no_overflow)
 
   hence "x \<le> x + q" using qv
-    apply simp
-    apply unat_arith
-    apply simp
-    done
+    by unat_arith
 
   thus ?thesis using yq by simp
 qed
+
+lemma tcbBlockSizeBits_word_less_sub_le:
+  fixes x :: machine_word
+  shows "(x \<le> 2 ^ tcbBlockSizeBits - 1) = (x < 2 ^ tcbBlockSizeBits)"
+  unfolding tcbBlockSizeBits_def
+  by (subst word_less_sub_le; simp)
 
 lemma tcb_cte_cases_in_range2:
   assumes tc: "tcb_cte_cases (y - x) = Some v"
   and     al: "is_aligned x tcbBlockSizeBits"
   shows   "y \<le> x + 2 ^ tcbBlockSizeBits - 1"
 proof -
-  note objBits_defs [simp]
-
   from tc obtain q where yq: "y = x + q" and qv: "q \<le> 2 ^ tcbBlockSizeBits - 1"
     unfolding tcb_cte_cases_def
-    by (simp add: diff_eq_eq split: if_split_asm)
+    by (clarsimp simp: diff_eq_eq tcbSlot_defs tcbBlockSizeBits_word_less_sub_le
+                 simp del: shiftl_1
+                 elim!: self_elim
+                 intro!: cteSizeBits_2ptcbBlockSizeBits zero_less_2p_tcbBlockSizeBits
+                 split: if_split_asm)
 
   have "x + q \<le> x + (2 ^ tcbBlockSizeBits - 1)" using qv
     apply (rule word_plus_mono_right)

--- a/proof/refine/AARCH64/ArchInvsDefs_H.thy
+++ b/proof/refine/AARCH64/ArchInvsDefs_H.thy
@@ -1,0 +1,230 @@
+(*
+ * Copyright 2023, Proofcraft Pty Ltd
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+(* This theory contains the arch-dependent part of invariant definitions.
+   Due to the large amount of definitions, we place it before Invariants_H rather than fixing
+   constants in locales. *)
+
+theory ArchInvsDefs_H
+imports
+  InvariantsPre_H
+  ArchMove_R
+begin
+
+(* disambiguate name clash between Arch and non-arch definitions with same names *)
+context Arch begin
+
+lemmas haskell_crunch_def[crunch_def] =
+  deriveCap_def finaliseCap_def
+  hasCancelSendRights_def sameRegionAs_def isPhysicalCap_def
+  sameObjectAs_def updateCapData_def maskCapRights_def
+  createObject_def capUntypedPtr_def capUntypedSize_def
+  performInvocation_def decodeInvocation_def
+
+context begin global_naming global
+requalify_facts (aliasing)
+  Retype_H.deriveCap_def Retype_H.finaliseCap_def
+  Retype_H.hasCancelSendRights_def Retype_H.sameRegionAs_def Retype_H.isPhysicalCap_def
+  Retype_H.sameObjectAs_def Retype_H.updateCapData_def Retype_H.maskCapRights_def
+  Retype_H.createObject_def Retype_H.capUntypedPtr_def Retype_H.capUntypedSize_def
+  Retype_H.performInvocation_def Retype_H.decodeInvocation_def
+end
+end
+
+context Arch begin arch_global_naming
+
+declare lookupPTSlotFromLevel.simps[simp del]
+declare lookupPTFromLevel.simps[simp del]
+
+abbreviation vcpu_at' :: "obj_ref \<Rightarrow> kernel_state \<Rightarrow> bool" where
+  "vcpu_at' \<equiv> typ_at' (ArchT VCPUT)"
+
+abbreviation pte_at' :: "obj_ref \<Rightarrow> kernel_state \<Rightarrow> bool" where
+  "pte_at' \<equiv> typ_at' (ArchT PTET)"
+
+(* hyp_refs *)
+
+definition tcb_vcpu_refs' :: "machine_word option \<Rightarrow> (obj_ref \<times> reftype) set" where
+  "tcb_vcpu_refs' t \<equiv> set_option t \<times> {TCBHypRef}"
+
+definition tcb_hyp_refs' :: "arch_tcb \<Rightarrow> (obj_ref \<times> reftype) set" where
+  "tcb_hyp_refs' t \<equiv> tcb_vcpu_refs' (AARCH64_H.atcbVCPUPtr t)"
+
+definition vcpu_tcb_refs' :: "obj_ref option \<Rightarrow> (obj_ref \<times> reftype) set" where
+  "vcpu_tcb_refs' t \<equiv> set_option t \<times> {HypTCBRef}"
+
+definition refs_of_a' :: "arch_kernel_object \<Rightarrow> (obj_ref \<times> reftype) set" where
+  "refs_of_a' x \<equiv> case x of
+     AARCH64_H.KOASIDPool asidpool \<Rightarrow> {}
+   | AARCH64_H.KOPTE pte \<Rightarrow> {}
+   | AARCH64_H.KOVCPU vcpu \<Rightarrow> vcpu_tcb_refs' (AARCH64_H.vcpuTCBPtr vcpu)"
+
+definition arch_live' :: "arch_kernel_object \<Rightarrow> bool" where
+  "arch_live' ao \<equiv> case ao of
+     AARCH64_H.KOVCPU vcpu \<Rightarrow> bound (AARCH64_H.vcpuTCBPtr vcpu)
+   | _ \<Rightarrow>  False"
+
+definition hyp_live' :: "kernel_object \<Rightarrow> bool" where
+  "hyp_live' ko \<equiv> case ko of
+     (KOTCB tcb) \<Rightarrow> bound (AARCH64_H.atcbVCPUPtr (tcbArch tcb))
+   | (KOArch ako) \<Rightarrow> arch_live' ako
+   |  _ \<Rightarrow> False"
+
+primrec azobj_refs' :: "arch_capability \<Rightarrow> obj_ref set" where
+  "azobj_refs' (ASIDPoolCap _ _) = {}"
+| "azobj_refs' ASIDControlCap = {}"
+| "azobj_refs' (FrameCap _ _ _ _ _) = {}"
+| "azobj_refs' (PageTableCap _ _ _) = {}"
+| "azobj_refs' (VCPUCap v) = {v}"
+
+lemma azobj_refs'_only_vcpu:
+  "(x \<in> azobj_refs' acap) = (acap = VCPUCap x)"
+  by (cases acap) auto
+
+
+section "Valid caps and objects (design spec)"
+
+primrec acapBits :: "arch_capability \<Rightarrow> nat" where
+  "acapBits (ASIDPoolCap _ _)       = asidLowBits + word_size_bits"
+| "acapBits ASIDControlCap          = asidHighBits + word_size_bits"
+| "acapBits (FrameCap _ _ sz _ _)   = pageBitsForSize sz"
+| "acapBits (PageTableCap _ pt_t _) = table_size pt_t"
+| "acapBits (VCPUCap v)             = vcpuBits"
+
+definition page_table_at' :: "pt_type \<Rightarrow> obj_ref \<Rightarrow> kernel_state \<Rightarrow> bool" where
+ "page_table_at' pt_t p \<equiv> \<lambda>s.
+    is_aligned p (ptBits pt_t) \<and>
+    (\<forall>i \<le> mask (ptTranslationBits pt_t). pte_at' (p + (i << pte_bits)) s)"
+
+lemmas vspace_table_at'_defs = page_table_at'_def
+
+abbreviation asid_pool_at' :: "obj_ref \<Rightarrow> kernel_state \<Rightarrow> bool" where
+  "asid_pool_at' \<equiv> typ_at' (ArchT ASIDPoolT)"
+
+definition asid_wf :: "asid \<Rightarrow> bool" where
+  "asid_wf asid \<equiv> asid \<le> mask asid_bits"
+
+definition wellformed_mapdata' :: "asid \<times> vspace_ref \<Rightarrow> bool" where
+  "wellformed_mapdata' \<equiv> \<lambda>(asid, vref). 0 < asid \<and> asid_wf asid \<and> vref \<in> user_region"
+
+definition wellformed_acap' :: "arch_capability \<Rightarrow> bool" where
+  "wellformed_acap' ac \<equiv>
+   case ac of
+     ASIDPoolCap r asid \<Rightarrow> is_aligned asid asid_low_bits \<and> asid_wf asid
+   | FrameCap r rghts sz dev  mapdata \<Rightarrow>
+       case_option True wellformed_mapdata' mapdata \<and>
+       case_option True (swp vmsz_aligned sz \<circ> snd) mapdata
+   | PageTableCap pt_t r (Some mapdata) \<Rightarrow> wellformed_mapdata' mapdata
+   | _ \<Rightarrow> True"
+
+lemmas wellformed_acap'_simps[simp] = wellformed_acap'_def[split_simps arch_capability.split]
+
+definition frame_at' :: "obj_ref \<Rightarrow> vmpage_size \<Rightarrow> bool \<Rightarrow> kernel_state \<Rightarrow> bool" where
+  "frame_at' r sz dev s \<equiv>
+     \<forall>p < 2 ^ (pageBitsForSize sz - pageBits).
+       typ_at' (if dev then UserDataDeviceT else UserDataT) (r + (p << pageBits)) s"
+
+definition valid_arch_cap_ref' :: "arch_capability \<Rightarrow> kernel_state \<Rightarrow> bool" where
+  "valid_arch_cap_ref' ac s \<equiv> case ac of
+     ASIDPoolCap r as \<Rightarrow> typ_at' (ArchT ASIDPoolT) r s
+   | ASIDControlCap \<Rightarrow> True
+   | FrameCap r rghts sz dev mapdata \<Rightarrow> frame_at' r sz dev s
+   | PageTableCap r pt_t mapdata \<Rightarrow> page_table_at' pt_t r s
+   | VCPUCap r \<Rightarrow> vcpu_at' r s"
+
+lemmas valid_arch_cap_ref'_simps[simp] =
+  valid_arch_cap_ref'_def[split_simps arch_capability.split]
+
+definition valid_arch_cap' :: "arch_capability \<Rightarrow> kernel_state \<Rightarrow> bool" where
+  "valid_arch_cap' cap \<equiv> \<lambda>s. wellformed_acap' cap \<and> valid_arch_cap_ref' cap s"
+
+lemmas valid_arch_cap'_simps[simp] =
+  valid_arch_cap'_def[unfolded wellformed_acap'_def valid_arch_cap_ref'_def,
+                      split_simps arch_capability.split, simplified]
+
+definition arch_cap'_fun_lift :: "(arch_capability \<Rightarrow> 'a) \<Rightarrow> 'a \<Rightarrow> capability \<Rightarrow> 'a" where
+  "arch_cap'_fun_lift P F c \<equiv> case c of ArchObjectCap ac \<Rightarrow> P ac | _ \<Rightarrow> F"
+
+lemmas arch_cap'_fun_lift_simps[simp] = arch_cap'_fun_lift_def[split_simps capability.split]
+
+definition valid_acap' :: "capability \<Rightarrow> kernel_state \<Rightarrow> bool" where
+  "valid_acap' \<equiv> arch_cap'_fun_lift valid_arch_cap' \<top>"
+
+definition is_device_frame_cap' :: "capability \<Rightarrow> bool" where
+  "is_device_frame_cap' cap \<equiv> case cap of ArchObjectCap (FrameCap _ _ _ dev _) \<Rightarrow> dev | _ \<Rightarrow> False"
+
+definition   valid_arch_tcb' :: "Structures_H.arch_tcb \<Rightarrow> kernel_state \<Rightarrow> bool" where
+  "valid_arch_tcb' \<equiv> \<lambda>t s. \<forall>v. atcbVCPUPtr t = Some v \<longrightarrow> vcpu_at' v s "
+
+definition valid_vcpu' :: "vcpu \<Rightarrow> bool" where
+  "valid_vcpu' v \<equiv> case vcpuTCBPtr v of None \<Rightarrow> True | Some vt \<Rightarrow> is_aligned vt tcbBlockSizeBits"
+
+(* This is a slight abuse of "canonical_address". What we really need to know for ADT_C in CRefine
+   is that the top pageBits bits of TablePTEs have a known value, because we shift left by pageBits.
+   What we actually know is that this is a physical address, so it is bound by the physical address
+   space size, which depending on config can be 40, 44, or 48. 48 happens to also be the bound for
+   the virtual address space, which canonical_address is for. This is good enough for our purposes. *)
+definition ppn_bounded :: "pte \<Rightarrow> bool" where
+  "ppn_bounded pte \<equiv> case pte of PageTablePTE ppn \<Rightarrow> canonical_address ppn | _ \<Rightarrow> True"
+
+definition valid_arch_obj' :: "arch_kernel_object \<Rightarrow> bool" where
+  "valid_arch_obj' ako \<equiv> case ako of
+     KOPTE pte \<Rightarrow> ppn_bounded pte
+   | KOVCPU vcpu \<Rightarrow> valid_vcpu' vcpu
+   | _ \<Rightarrow> True"
+
+primrec
+  acapClass :: "arch_capability \<Rightarrow> capclass"
+where
+  "acapClass (ASIDPoolCap _ _)    = PhysicalClass"
+| "acapClass ASIDControlCap       = ASIDMasterClass"
+| "acapClass (FrameCap _ _ _ _ _) = PhysicalClass"
+| "acapClass (PageTableCap _ _ _) = PhysicalClass"
+| "acapClass (VCPUCap _) = PhysicalClass"
+
+definition
+  isArchFrameCap :: "capability \<Rightarrow> bool"
+where
+ "isArchFrameCap cap \<equiv> case cap of ArchObjectCap (FrameCap _ _ _ _ _) \<Rightarrow> True | _ \<Rightarrow> False"
+
+(* Addresses of all PTEs in a VSRoot table at p *)
+definition table_refs' :: "machine_word \<Rightarrow> machine_word set" where
+  "table_refs' p \<equiv> (\<lambda>i. p + (i << pte_bits)) ` mask_range 0 (ptTranslationBits VSRootPT_T)"
+
+definition global_refs' :: "kernel_state \<Rightarrow> obj_ref set" where
+  "global_refs' \<equiv> \<lambda>s.
+   {ksIdleThread s} \<union>
+   table_refs' (armKSGlobalUserVSpace (ksArchState s)) \<union>
+   range (\<lambda>irq :: irq. irq_node' s + (ucast irq << cteSizeBits))"
+
+definition valid_asid_table' :: "(asid \<rightharpoonup> machine_word) \<Rightarrow> bool" where
+  "valid_asid_table' table \<equiv> dom table \<subseteq> mask_range 0 asid_high_bits \<and> 0 \<notin> ran table"
+
+definition "is_vcpu' \<equiv> \<lambda>ko. \<exists>vcpu. ko = (KOArch (KOVCPU vcpu))"
+
+definition max_armKSGICVCPUNumListRegs :: nat where
+  "max_armKSGICVCPUNumListRegs \<equiv> 63"
+
+definition valid_arch_state' :: "kernel_state \<Rightarrow> bool" where
+  "valid_arch_state' \<equiv> \<lambda>s.
+   valid_asid_table' (armKSASIDTable (ksArchState s)) \<and>
+   0 \<notin> ran (armKSVMIDTable (ksArchState s)) \<and>
+   (case armHSCurVCPU (ksArchState s) of
+      Some (v, b) \<Rightarrow> ko_wp_at' (is_vcpu' and hyp_live') v s
+      | _ \<Rightarrow> True) \<and>
+   armKSGICVCPUNumListRegs (ksArchState s) \<le> max_armKSGICVCPUNumListRegs \<and>
+   canonical_address (addrFromKPPtr (armKSGlobalUserVSpace (ksArchState s)))"
+
+definition archMakeObjectT :: "arch_kernel_object_type \<Rightarrow> kernel_object" where
+  "archMakeObjectT atp \<equiv>
+     case atp
+     of PTET \<Rightarrow> injectKO (makeObject :: pte)
+      | ASIDPoolT \<Rightarrow> injectKO (makeObject :: asidpool)
+      | VCPUT \<Rightarrow> injectKO (makeObject :: vcpu)"
+
+end
+end

--- a/proof/refine/AARCH64/ArchInvsLemmas_H.thy
+++ b/proof/refine/AARCH64/ArchInvsLemmas_H.thy
@@ -1,0 +1,502 @@
+(*
+ * Copyright 2023, Proofcraft Pty Ltd
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory ArchInvsLemmas_H
+imports
+  Invariants_H
+begin
+
+context Arch begin arch_global_naming
+
+named_theorems Invariants_H_pspaceI_assms
+
+(* FIXME arch-split: word_size is available outside of Arch due to Word_Setup, but to provide
+   more guard rails during arch-split we are hiding the Haskell constant definition outside of
+   Arch. To be evaluated as arch-split proceeds, since it can always be made generic again. *)
+schematic_goal wordBits_def': "wordBits = numeral ?n" (* arch-specific consequence *)
+  by (simp add: wordBits_def word_size)
+
+lemmas wordRadix_def' = wordRadix_def[simplified]
+
+lemma wordSizeCase_simp[simp]: "wordSizeCase a b = b"
+  by (simp add: wordSizeCase_def wordBits_def word_size)
+
+lemmas objBits_defs = tcbBlockSizeBits_def epSizeBits_def ntfnSizeBits_def cteSizeBits_def vcpuBits_def
+lemmas untypedBits_defs = minUntypedSizeBits_def maxUntypedSizeBits_def
+lemmas objBits_simps = objBits_def objBitsKO_def word_size_def archObjSize_def
+lemmas objBits_simps' = objBits_simps objBits_defs
+
+lemma frame_at'_pspaceI:
+  "frame_at' p sz d s \<Longrightarrow> ksPSpace s = ksPSpace s' \<Longrightarrow> frame_at' p sz d s'"
+  by (simp add: frame_at'_def typ_at'_def ko_wp_at'_def ps_clear_def)
+
+lemma valid_cap'_pspaceI[Invariants_H_pspaceI_assms]:
+  "s \<turnstile>' cap \<Longrightarrow> ksPSpace s = ksPSpace s' \<Longrightarrow> s' \<turnstile>' cap"
+  unfolding valid_cap'_def
+  by (cases cap)
+     (auto intro: obj_at'_pspaceI[rotated]
+                  cte_wp_at'_pspaceI valid_untyped'_pspaceI
+                  typ_at'_pspaceI[rotated] frame_at'_pspaceI[rotated]
+            simp: vspace_table_at'_defs valid_arch_cap'_def valid_arch_cap_ref'_def
+           split: arch_capability.split zombie_type.split option.splits)
+
+lemma valid_obj'_pspaceI[Invariants_H_pspaceI_assms]:
+  "valid_obj' obj s \<Longrightarrow> ksPSpace s = ksPSpace s' \<Longrightarrow> valid_obj' obj s'"
+  unfolding valid_obj'_def
+  by (cases obj)
+     (auto simp: valid_ep'_def valid_ntfn'_def valid_tcb'_def valid_cte'_def
+                 valid_tcb_state'_def valid_bound_tcb'_def
+                 valid_bound_ntfn'_def valid_arch_tcb'_def
+           split: Structures_H.endpoint.splits Structures_H.notification.splits
+                  Structures_H.thread_state.splits ntfn.splits option.splits
+           intro: obj_at'_pspaceI valid_cap'_pspaceI typ_at'_pspaceI)
+
+lemma tcb_space_clear[Invariants_H_pspaceI_assms]:
+  "\<lbrakk> tcb_cte_cases (y - x) = Some (getF, setF);
+     is_aligned x tcbBlockSizeBits; ps_clear x tcbBlockSizeBits s;
+     ksPSpace s x = Some (KOTCB tcb); ksPSpace s y = Some v;
+     \<lbrakk> x = y; getF = tcbCTable; setF = tcbCTable_update \<rbrakk> \<Longrightarrow> P
+    \<rbrakk> \<Longrightarrow> P"
+  apply (cases "x = y")
+   apply simp
+  apply (clarsimp simp: ps_clear_def mask_def add_diff_eq)
+  apply (drule_tac a=y in equals0D)
+  apply (simp add: domI)
+  apply (subgoal_tac "\<exists>z. y = x + z \<and> z < 2 ^ tcbBlockSizeBits")
+   apply (elim exE conjE)
+   apply (frule(1) is_aligned_no_wrap'[rotated, rotated])
+   apply (simp add: word_bits_conv objBits_defs)
+   apply (erule notE, subst field_simps, rule word_plus_mono_right)
+    apply (drule word_le_minus_one_leq,simp,erule is_aligned_no_wrap')
+   apply (simp add: word_bits_conv)
+  apply (simp add: objBits_defs)
+  apply (rule_tac x="y - x" in exI)
+  apply (simp add: tcb_cte_cases_def cteSizeBits_def split: if_split_asm)
+  done
+
+end
+
+global_interpretation Invariants_H_pspaceI?: Invariants_H_pspaceI
+  proof goal_cases
+  interpret Arch .
+  case 1 show ?case by (intro_locales; (unfold_locales; (fact Invariants_H_pspaceI_assms)?)?)
+  qed
+
+context Arch begin arch_global_naming
+
+named_theorems Invariants_H_cte_ats_assms
+
+(* FIXME arch-split: for proofs which require exact offsets lining up instead of cteSizeBits *)
+lemma raw_tcb_cte_cases_simps:
+  "tcb_cte_cases 32 = Some (tcbVTable, tcbVTable_update)"
+  "tcb_cte_cases 64 = Some (tcbReply, tcbReply_update)"
+  "tcb_cte_cases 96 = Some (tcbCaller, tcbCaller_update)"
+  "tcb_cte_cases 128 = Some (tcbIPCBufferFrame, tcbIPCBufferFrame_update)"
+  by (simp add: tcb_cte_cases_def cteSizeBits_def)+
+
+lemma cte_wp_at_cases'[Invariants_H_cte_ats_assms]:
+  shows "cte_wp_at' P p s =
+  ((\<exists>cte. ksPSpace s p = Some (KOCTE cte) \<and> is_aligned p cte_level_bits
+             \<and> P cte \<and> ps_clear p cteSizeBits s) \<or>
+   (\<exists>n tcb getF setF. ksPSpace s (p - n) = Some (KOTCB tcb) \<and> is_aligned (p - n) tcbBlockSizeBits
+             \<and> tcb_cte_cases n = Some (getF, setF) \<and> P (getF tcb) \<and> ps_clear (p - n) tcbBlockSizeBits s))"
+  (is "?LHS = ?RHS")
+  supply raw_tcb_cte_cases_simps[simp]
+  apply (rule iffI)
+   apply (clarsimp simp: cte_wp_at'_def split_def
+                         getObject_def bind_def simpler_gets_def
+                         assert_opt_def return_def fail_def
+                  split: option.splits
+                    del: disjCI)
+   apply (clarsimp simp: loadObject_cte typeError_def alignError_def
+                         fail_def return_def objBits_simps'
+                         is_aligned_mask[symmetric] alignCheck_def
+                         tcbVTableSlot_def field_simps tcbCTableSlot_def
+                         tcbReplySlot_def tcbCallerSlot_def
+                         tcbIPCBufferSlot_def
+                         lookupAround2_char1
+                         cte_level_bits_def Ball_def
+                         unless_def when_def bind_def
+                  split: kernel_object.splits if_split_asm option.splits
+                    del: disjCI)
+        apply (subst(asm) in_magnitude_check3, simp+,
+               simp split: if_split_asm, (rule disjI2)?, intro exI, rule conjI,
+               erule rsubst[where P="\<lambda>x. ksPSpace s x = v" for s v],
+               fastforce simp add: field_simps, simp)+
+   apply (subst(asm) in_magnitude_check3, simp+)
+   apply (simp split: if_split_asm
+                add: )
+  apply (simp add: cte_wp_at'_def getObject_def split_def
+                   bind_def simpler_gets_def return_def
+                   assert_opt_def fail_def objBits_defs
+            split: option.splits)
+  apply (elim disjE conjE exE)
+   apply (erule(1) ps_clear_lookupAround2)
+     apply simp
+    apply (simp add: field_simps)
+    apply (erule is_aligned_no_wrap')
+     apply (simp add: cte_level_bits_def word_bits_conv)
+    apply (simp add: cte_level_bits_def)
+   apply (simp add: loadObject_cte unless_def alignCheck_def
+                    is_aligned_mask[symmetric] objBits_simps'
+                    cte_level_bits_def magnitudeCheck_def
+                    return_def fail_def)
+   apply (clarsimp simp: bind_def return_def when_def fail_def
+                  split: option.splits)
+   apply simp
+  apply (erule(1) ps_clear_lookupAround2)
+    prefer 3
+    apply (simp add: loadObject_cte unless_def alignCheck_def
+                     is_aligned_mask[symmetric] objBits_simps'
+                     cte_level_bits_def magnitudeCheck_def
+                     return_def fail_def tcbCTableSlot_def tcbVTableSlot_def
+                     tcbIPCBufferSlot_def tcbReplySlot_def tcbCallerSlot_def
+              split: option.split_asm)
+     apply (clarsimp simp: bind_def tcb_cte_cases_def cteSizeBits_def split: if_split_asm)
+    apply (clarsimp simp: bind_def tcb_cte_cases_def iffD2[OF linorder_not_less]
+                          return_def cteSizeBits_def
+                   split: if_split_asm)
+   apply (subgoal_tac "p - n \<le> (p - n) + n", simp)
+   apply (erule is_aligned_no_wrap')
+    apply (simp add: word_bits_conv)
+   apply (simp add: tcb_cte_cases_def cteSizeBits_def split: if_split_asm)
+  apply (subgoal_tac "(p - n) + n \<le> (p - n) + 0x7FF")
+   apply (simp add: field_simps)
+  apply (rule word_plus_mono_right)
+   apply (simp add: tcb_cte_cases_def cteSizeBits_def split: if_split_asm)
+  apply (erule is_aligned_no_wrap')
+  apply simp
+  done
+
+lemma cte_wp_atE'[consumes 1, case_names CTE TCB]:
+  assumes cte: "cte_wp_at' P ptr s"
+  and   r1: "\<And>cte.
+    \<lbrakk> ksPSpace s ptr = Some (KOCTE cte); ps_clear ptr cte_level_bits s;
+      is_aligned ptr cte_level_bits; P cte \<rbrakk> \<Longrightarrow> R"
+  and   r2: "\<And> tcb ptr' getF setF.
+  \<lbrakk> ksPSpace s ptr' = Some (KOTCB tcb); ps_clear ptr' tcbBlockSizeBits s; is_aligned ptr' tcbBlockSizeBits;
+     tcb_cte_cases (ptr - ptr') = Some (getF, setF); P (getF tcb) \<rbrakk> \<Longrightarrow> R"
+  shows "R"
+  by (rule disjE [OF iffD1 [OF cte_wp_at_cases' cte]]) (auto intro: r1 r2 simp: cte_level_bits_def objBits_defs)
+
+lemma cte_wp_at_cteI':
+  assumes "ksPSpace s ptr = Some (KOCTE cte)"
+  assumes "is_aligned ptr cte_level_bits"
+  assumes "ps_clear ptr cte_level_bits s"
+  assumes "P cte"
+  shows "cte_wp_at' P ptr s"
+  using assms by (simp add: cte_wp_at_cases' cte_level_bits_def objBits_defs)
+
+lemma cte_at_typ'[Invariants_H_cte_ats_assms]:
+  "cte_at' c = (\<lambda>s. typ_at' CTET c s \<or> (\<exists>n. typ_at' TCBT (c - n) s \<and> n \<in> dom tcb_cte_cases))"
+proof -
+  have P: "\<And>ko. (koTypeOf ko = CTET) = (\<exists>cte. ko = KOCTE cte)"
+          "\<And>ko. (koTypeOf ko = TCBT) = (\<exists>tcb. ko = KOTCB tcb)"
+    by (case_tac ko, simp_all)+
+  have Q: "\<And>P f. (\<exists>x. (\<exists>y. x = f y) \<and> P x) = (\<exists>y. P (f y))"
+    by fastforce
+  show ?thesis
+    by (fastforce simp: cte_wp_at_cases' obj_at'_real_def typ_at'_def
+                        ko_wp_at'_def objBits_simps' P Q conj_comms cte_level_bits_def)
+qed
+
+(* interface lemma *)
+lemma tcb_at_cte_at':
+  "tcb_at' t s \<Longrightarrow> cte_at' t s"
+  apply (clarsimp simp add: cte_wp_at_cases' obj_at'_def projectKO_def
+                       del: disjCI)
+  apply (case_tac ko)
+   apply (simp_all add: projectKO_opt_tcb fail_def)
+  apply (rule exI[where x=0])
+  apply (clarsimp simp add: return_def objBits_simps)
+  done
+
+end
+
+global_interpretation Invariants_H_cte_ats?: Invariants_H_cte_ats
+  proof goal_cases
+  interpret Arch .
+  case 1 show ?case by (intro_locales; (unfold_locales; fact Invariants_H_cte_ats_assms)?)
+  qed
+
+
+(* arch-specific consequences of kernel_state field update identities *)
+
+context Arch_pspace_update_eq'
+begin
+
+lemma page_table_at_update' [iff]:
+  "page_table_at' pt_t p (f s) = page_table_at' pt_t p s"
+  by (simp add: page_table_at'_def)
+
+lemma frame_at_update' [iff]:
+  "frame_at' p sz d (f s) = frame_at' p sz d s"
+  by (simp add: frame_at'_def)
+
+end
+
+context Arch begin arch_global_naming
+
+lemma mask_wordRadix_less_wordBits:
+  assumes sz: "wordRadix \<le> size w"
+  shows "unat ((w::'a::len word) && mask wordRadix) < wordBits"
+  using word_unat_mask_lt[where m=wordRadix and w=w] assms
+  by (simp add: wordRadix_def wordBits_def')
+
+lemma priority_mask_wordRadix_size:
+  "unat ((w::priority) && mask wordRadix) < wordBits"
+  by (rule mask_wordRadix_less_wordBits, simp add: wordRadix_def word_size)
+
+lemma canonical_address_mask_eq:
+  "canonical_address p = (p && mask (Suc canonical_bit) = p)"
+  by (simp add: canonical_address_def canonical_address_of_def ucast_ucast_mask canonical_bit_def)
+
+lemma canonical_address_and:
+  "canonical_address p \<Longrightarrow> canonical_address (p && b)"
+  by (simp add: canonical_address_range word_and_le)
+
+lemma canonical_address_add:
+  assumes "is_aligned p n"
+  assumes "f < 2 ^ n"
+  assumes "n \<le> canonical_bit"
+  assumes "canonical_address p"
+  shows "canonical_address (p + f)"
+proof -
+  from `f < 2 ^ n`
+  have "f \<le> mask n"
+    by (simp add: mask_plus_1 plus_one_helper)
+
+  from `canonical_address p`
+  have "p && mask (Suc canonical_bit) = p"
+    by (simp add: canonical_address_mask_eq)
+  moreover
+  from `f \<le> mask n` `is_aligned p n`
+  have "p + f = p || f"
+    by (simp add: word_and_or_mask_aligned)
+  moreover
+  from `f \<le> mask n` `n \<le> canonical_bit`
+  have "f \<le> mask (Suc canonical_bit)"
+    using le_smaller_mask by fastforce
+  hence "f && mask (Suc canonical_bit) = f"
+    by (simp add: le_mask_imp_and_mask)
+  ultimately
+  have "(p + f) && mask (Suc canonical_bit) = p + f"
+    by (simp add: word_ao_dist)
+  thus ?thesis
+    by (simp add: canonical_address_mask_eq)
+qed
+
+lemma range_cover_canonical_address:
+  "\<lbrakk> range_cover ptr sz us n ; p < n ;
+     canonical_address (ptr && ~~ mask sz) ; sz \<le> maxUntypedSizeBits \<rbrakk>
+   \<Longrightarrow> canonical_address (ptr + of_nat p * 2 ^ us)"
+  apply (subst word_plus_and_or_coroll2[symmetric, where w = "mask sz"])
+  apply (subst add.commute)
+  apply (subst add.assoc)
+  apply (rule canonical_address_add[where n=sz] ; simp add: untypedBits_defs is_aligned_neg_mask)
+   apply (drule (1) range_cover.range_cover_compare)
+   apply (clarsimp simp: word_less_nat_alt)
+   apply unat_arith
+  apply (simp add: canonical_bit_def)
+  done
+
+lemma tcb_hyp_refs_of'_simps[simp]:
+  "tcb_hyp_refs' atcb = tcb_vcpu_refs' (atcbVCPUPtr atcb)"
+  by (auto simp: tcb_hyp_refs'_def)
+
+lemma tcb_vcpu_refs_of'_simps[simp]:
+  "tcb_vcpu_refs' (Some vc) = {(vc, TCBHypRef)}"
+  "tcb_vcpu_refs' None = {}"
+  by (auto simp: tcb_vcpu_refs'_def)
+
+lemma vcpu_tcb_refs_of'_simps[simp]:
+  "vcpu_tcb_refs' (Some tcb) = {(tcb, HypTCBRef)}"
+  "vcpu_tcb_refs' None = {}"
+  by (auto simp: vcpu_tcb_refs'_def)
+
+lemma refs_of_a'_simps[simp]:
+  "refs_of_a' (KOASIDPool p) = {}"
+  "refs_of_a' (KOPTE pt) = {}"
+  "refs_of_a' (KOVCPU v) = vcpu_tcb_refs' (vcpuTCBPtr v)"
+ by (auto simp: refs_of_a'_def)
+
+lemma vcpu_at_is_vcpu':
+  "vcpu_at' v = ko_wp_at' is_vcpu' v"
+  apply (rule ext)
+  apply (clarsimp simp: typ_at'_def is_vcpu'_def ko_wp_at'_def)
+  apply (rule iffI; clarsimp?)
+  apply (case_tac ko; simp; rename_tac ako; case_tac ako; simp)
+  done
+
+lemma hyp_refs_of_rev':
+ "(x, TCBHypRef) \<in> hyp_refs_of' ko =
+    (\<exists>tcb. ko = KOTCB tcb \<and> (atcbVCPUPtr (tcbArch tcb) = Some x))"
+ "(x, HypTCBRef) \<in> hyp_refs_of' ko =
+    (\<exists>v. ko = KOArch (KOVCPU v) \<and> (vcpuTCBPtr v = Some x))"
+  by (auto simp: hyp_refs_of'_def tcb_hyp_refs'_def tcb_vcpu_refs'_def
+                    vcpu_tcb_refs'_def refs_of_a'_def
+              split: kernel_object.splits arch_kernel_object.splits option.split)
+
+lemma hyp_refs_of_hyp_live':
+  "hyp_refs_of' ko \<noteq> {} \<Longrightarrow> hyp_live' ko"
+  apply (cases ko, simp_all)
+   apply (rename_tac tcb_ext)
+   apply (simp add: tcb_hyp_refs'_def hyp_live'_def)
+   apply (case_tac "atcbVCPUPtr (tcbArch tcb_ext)"; clarsimp)
+  apply (clarsimp simp: hyp_live'_def arch_live'_def refs_of_a'_def vcpu_tcb_refs'_def
+                  split: arch_kernel_object.splits option.splits)
+  done
+
+lemma hyp_refs_of_live':
+  "hyp_refs_of' ko \<noteq> {} \<Longrightarrow> live' ko"
+  by (cases ko, simp_all add: live'_def hyp_refs_of_hyp_live')
+
+lemmas valid_cap_simps' =
+  valid_cap'_def[split_simps capability.split arch_capability.split]
+
+lemma is_physical_cases:
+ "(capClass cap = PhysicalClass) =
+  (case cap of NullCap                         \<Rightarrow> False
+             | DomainCap                       \<Rightarrow> False
+             | IRQControlCap                   \<Rightarrow> False
+             | IRQHandlerCap irq               \<Rightarrow> False
+             | ReplyCap r m cr                 \<Rightarrow> False
+             | ArchObjectCap ASIDControlCap    \<Rightarrow> False
+             | _                               \<Rightarrow> True)"
+  by (simp split: capability.splits arch_capability.splits zombie_type.splits)
+
+lemma typ_at_lift_page_table_at':
+  assumes x: "\<And>T p. f \<lbrace>typ_at' T p\<rbrace>"
+  shows "f \<lbrace>page_table_at' pt_t p\<rbrace>"
+  unfolding page_table_at'_def
+  by (wpsimp wp: hoare_vcg_all_lift hoare_vcg_imp_lift' x)
+
+lemma typ_at_lift_asid_at':
+  "(\<And>T p. \<lbrace>typ_at' T p\<rbrace> f \<lbrace>\<lambda>_. typ_at' T p\<rbrace>) \<Longrightarrow> \<lbrace>asid_pool_at' p\<rbrace> f \<lbrace>\<lambda>_. asid_pool_at' p\<rbrace>"
+  by assumption
+
+lemma typ_at_lift_vcpu_at':
+  "(\<And>T p. \<lbrace>typ_at' T p\<rbrace> f \<lbrace>\<lambda>_. typ_at' T p\<rbrace>) \<Longrightarrow> \<lbrace>vcpu_at' p\<rbrace> f \<lbrace>\<lambda>_. vcpu_at' p\<rbrace>"
+  by assumption
+
+lemma typ_at_lift_frame_at':
+  assumes "\<And>T p. f \<lbrace>typ_at' T p\<rbrace>"
+  shows "f \<lbrace>frame_at' p sz d\<rbrace>"
+  unfolding frame_at'_def
+  by (wpsimp wp: hoare_vcg_all_lift hoare_vcg_const_imp_lift assms split_del: if_split)
+
+lemma typ_at_lift_valid_cap':
+  assumes P: "\<And>P T p. \<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace> f \<lbrace>\<lambda>rv s. P (typ_at' T p s)\<rbrace>"
+  shows      "\<lbrace>\<lambda>s. valid_cap' cap s\<rbrace> f \<lbrace>\<lambda>rv s. valid_cap' cap s\<rbrace>"
+  including no_pre
+  apply (simp add: valid_cap'_def)
+  apply wp
+  apply (case_tac cap;
+         simp add: valid_cap'_def P[of id, simplified] typ_at_lift_tcb'
+                   hoare_vcg_prop typ_at_lift_ep'
+                   typ_at_lift_ntfn' typ_at_lift_cte_at'
+                   hoare_vcg_conj_lift [OF typ_at_lift_cte_at'])
+     apply (rename_tac zombie_type nat)
+     apply (case_tac zombie_type; simp)
+      apply (wp typ_at_lift_tcb' P hoare_vcg_all_lift typ_at_lift_cte')+
+    apply (rename_tac arch_capability)
+    apply (case_tac arch_capability,
+           simp_all add: P[of id, simplified] vspace_table_at'_defs
+                         hoare_vcg_prop All_less_Ball
+                    split del: if_split)
+       apply (wp hoare_vcg_const_Ball_lift P typ_at_lift_valid_untyped'
+                 hoare_vcg_all_lift typ_at_lift_cte' typ_at_lift_frame_at')+
+  done
+
+(* interface lemma *)
+lemma valid_arch_tcb_lift':
+  assumes x: "\<And>T p. \<lbrace>typ_at' T p\<rbrace> f \<lbrace>\<lambda>rv. typ_at' T p\<rbrace>"
+  shows "\<lbrace>\<lambda>s. valid_arch_tcb' tcb s\<rbrace> f \<lbrace>\<lambda>rv s. valid_arch_tcb' tcb s\<rbrace>"
+  apply (clarsimp simp add: valid_arch_tcb'_def)
+  apply (cases "atcbVCPUPtr tcb"; simp)
+   apply (wp x)+
+  done
+
+lemmas typ_at_lifts =
+           typ_at_lift_tcb' typ_at_lift_ep' typ_at_lift_ntfn' typ_at_lift_cte' typ_at_lift_cte_at'
+           typ_at_lift_valid_untyped' typ_at_lift_valid_cap' valid_bound_tcb_lift
+           typ_at_lift_page_table_at' typ_at_lift_asid_at' typ_at_lift_vcpu_at'
+
+lemma valid_arch_state_armKSGlobalUserVSpace:
+  "valid_arch_state' s \<Longrightarrow> canonical_address (addrFromKPPtr (armKSGlobalUserVSpace (ksArchState s)))"
+  by (simp add: valid_arch_state'_def)
+
+lemma page_table_pte_atI':
+  "\<lbrakk> page_table_at' pt_t p s; i \<le> mask (ptTranslationBits pt_t) \<rbrakk> \<Longrightarrow>
+   pte_at' (p + (i << pte_bits)) s"
+  by (simp add: page_table_at'_def)
+
+lemmas bit_simps' = pteBits_def asidHighBits_def asidPoolBits_def asid_low_bits_def
+                    asid_high_bits_def bit_simps
+
+lemma objBitsT_simps:
+  "objBitsT EndpointT = epSizeBits"
+  "objBitsT NotificationT = ntfnSizeBits"
+  "objBitsT CTET = cteSizeBits"
+  "objBitsT TCBT = tcbBlockSizeBits"
+  "objBitsT UserDataT = pageBits"
+  "objBitsT UserDataDeviceT = pageBits"
+  "objBitsT KernelDataT = pageBits"
+  "objBitsT (ArchT PTET) = word_size_bits"
+  "objBitsT (ArchT ASIDPoolT) = pageBits"
+  "objBitsT (ArchT VCPUT) = vcpuBits"
+  unfolding objBitsT_def makeObjectT_def archMakeObjectT_def
+  by (simp add: makeObject_simps objBits_simps bit_simps')+
+
+(* interface lemma - exports only generic equations from objBitsT_simps *)
+lemmas gen_objBitsT_simps = objBitsT_simps(1-7)
+
+(* interface lemma *)
+lemma objBitsT_koTypeOf:
+  "(objBitsT (koTypeOf ko)) = objBitsKO ko"
+  apply (cases ko; simp add: objBits_simps objBitsT_simps)
+  apply (rename_tac arch_kernel_object)
+  apply (case_tac arch_kernel_object; simp add: archObjSize_def objBitsT_simps bit_simps')
+  done
+
+end
+
+qualify AARCH64_H (in Arch)
+
+(*
+  Then idea with this class is to be able to generically constrain
+  predicates over pspace_storable values to are not of type VCPU,
+  this is useful for invariants such as obj_at' that are trivially
+  true (sort of) if the predicate and the function (in the Hoare triple)
+  manipulate different types of objects
+*)
+
+class no_vcpu = pspace_storable +
+  assumes not_vcpu: "koType TYPE('a) \<noteq> ArchT AARCH64_H.VCPUT"
+
+instance tcb              :: no_vcpu by intro_classes auto
+instance endpoint         :: no_vcpu by intro_classes auto
+instance notification     :: no_vcpu by intro_classes auto
+instance cte              :: no_vcpu by intro_classes auto
+instance user_data        :: no_vcpu by intro_classes auto
+instance user_data_device :: no_vcpu by intro_classes auto
+
+end_qualify
+
+instantiation AARCH64_H.asidpool :: no_vcpu
+begin
+interpretation Arch .
+instance by intro_classes auto
+end
+
+instantiation AARCH64_H.pte :: no_vcpu
+begin
+interpretation Arch .
+instance by intro_classes auto
+end
+
+end

--- a/proof/refine/AARCH64/ArchMove_R.thy
+++ b/proof/refine/AARCH64/ArchMove_R.thy
@@ -16,10 +16,7 @@ begin
 lemmas cte_index_repair = mult.commute[where a="(2::'a::len word) ^ cte_level_bits"]
 lemmas cte_index_repair_sym = cte_index_repair[symmetric]
 
-lemma invs_valid_ioc[elim!]: "invs s \<Longrightarrow> valid_ioc s"
-  by (clarsimp simp add: invs_def valid_state_def)
-
-context begin interpretation Arch .
+context Arch begin arch_global_naming
 
 lemma get_pt_mapM_x_lower:
   assumes g: "\<And>P pt x. \<lbrace> \<lambda>s. P (kheap s pt_ptr) \<rbrace> g pt x \<lbrace> \<lambda>_ s. P (kheap s pt_ptr) \<rbrace>"

--- a/proof/refine/AARCH64/CNodeInv_R.thy
+++ b/proof/refine/AARCH64/CNodeInv_R.thy
@@ -5729,6 +5729,7 @@ lemma cte_wp_at_disj_eq':
 
 lemma valid_Zombie_cte_at':
   "\<lbrakk> s \<turnstile>' Zombie p zt m; n < zombieCTEs zt \<rbrakk> \<Longrightarrow> cte_at' (p + (of_nat n * 2^cteSizeBits)) s"
+  supply raw_tcb_cte_cases_simps[simp] (* FIXME arch-split: legacy, try use tcb_cte_cases_neqs *)
   apply (clarsimp simp: valid_cap'_def split: zombie_type.split_asm)
    apply (clarsimp simp: obj_at'_def objBits_simps)
    apply (subgoal_tac "tcb_cte_cases (of_nat n * 2^cteSizeBits) \<noteq> None")

--- a/proof/refine/AARCH64/CSpace1_R.thy
+++ b/proof/refine/AARCH64/CSpace1_R.thy
@@ -212,6 +212,7 @@ lemma tcb_cases_related:
   "tcb_cap_cases ref = Some (getF, setF, restr) \<Longrightarrow>
     \<exists>getF' setF'. (\<forall>x. tcb_cte_cases (cte_map (x, ref) - x) = Some (getF', setF'))
                \<and> (\<forall>tcb tcb'. tcb_relation tcb tcb' \<longrightarrow> cap_relation (getF tcb) (cteCap (getF' tcb')))"
+  supply raw_tcb_cte_cases_simps[simp] (* FIXME arch-split: legacy, try use tcb_cte_cases_neqs *)
   by (simp add: tcb_cap_cases_def tcb_cnode_index_def to_bl_1
                 cte_map_def' tcb_relation_def
          split: if_split_asm)

--- a/proof/refine/AARCH64/CSpace_R.thy
+++ b/proof/refine/AARCH64/CSpace_R.thy
@@ -4204,6 +4204,7 @@ lemma setupReplyMaster_invs'[wp]:
   "\<lbrace>invs' and tcb_at' t and ex_nonz_cap_to' t\<rbrace>
      setupReplyMaster t
    \<lbrace>\<lambda>rv. invs'\<rbrace>"
+  supply raw_tcb_cte_cases_simps[simp] (* FIXME arch-split: legacy, try use tcb_cte_cases_neqs *)
   apply (simp add: invs'_def valid_state'_def)
   apply (rule hoare_pre)
    apply (wp setupReplyMaster_valid_pspace' sch_act_wf_lift tcb_in_cur_domain'_lift ct_idle_or_in_cur_domain'_lift

--- a/proof/refine/AARCH64/Finalise_R.thy
+++ b/proof/refine/AARCH64/Finalise_R.thy
@@ -3212,7 +3212,7 @@ lemma tcbQueueRemove_tcbSchedNext_tcbSchedPrev_None_obj_at':
   apply (wpsimp wp: threadSet_wp getTCB_wp)
   by (fastforce dest!: heap_ls_last_None
                  simp: list_queue_relation_def prev_queue_head_def queue_end_valid_def
-                       obj_at'_def opt_map_def ps_clear_def objBits_simps
+                       obj_at'_def opt_map_def ps_clear_def AARCH64.objBits_simps
                 split: if_splits)
 
 lemma tcbSchedDequeue_tcbSchedNext_tcbSchedPrev_None_obj_at':
@@ -3295,7 +3295,7 @@ lemma (in delete_one_conc_pre) finaliseCap_replaceable:
   apply (frule cte_wp_at_valid_objs_valid_cap', clarsimp+)
   apply (case_tac "cteCap cte",
          simp_all add: isCap_simps capRange_def cap_has_cleanup'_def
-                       final_matters'_def objBits_simps
+                       final_matters'_def AARCH64.objBits_simps
                        not_Final_removeable finaliseCap_def,
          simp_all add: removeable'_def)
      (* thread *)
@@ -3588,6 +3588,8 @@ global_interpretation delete_one_conc_pre
   by (unfold_locales, wp)
      (wp cteDeleteOne_tcbDomain_obj_at' cteDeleteOne_typ_at' cteDeleteOne_reply_pred_tcb_at | simp)+
 
+context begin interpretation Arch . (*FIXME: arch-split*)
+
 lemma cteDeleteOne_invs[wp]:
   "\<lbrace>invs'\<rbrace> cteDeleteOne ptr \<lbrace>\<lambda>rv. invs'\<rbrace>"
   apply (simp add: cteDeleteOne_def unless_def
@@ -3616,6 +3618,8 @@ lemma cteDeleteOne_invs[wp]:
         | wp (once) isFinal[where x=ptr])+
   apply (fastforce simp: cte_wp_at_ctes_of)
   done
+
+end
 
 global_interpretation delete_one_conc_fr: delete_one_conc
   by unfold_locales wp
@@ -3699,7 +3703,7 @@ lemma finaliseCap_valid_cap[wp]:
   apply simp
   apply (intro conjI impI)
    apply (clarsimp simp: valid_cap'_def isCap_simps capAligned_def
-                         objBits_simps shiftL_nat)+
+                         AARCH64.objBits_simps shiftL_nat)+
   done
 
 lemma no_idle_thread_cap:
@@ -3997,7 +4001,7 @@ lemma finaliseCap_corres:
        apply (rule corres_guard_imp)
          apply (rule corres_split[OF unbindMaybeNotification_corres])
            apply (rule cancelAllSignals_corres)
-          apply (wp abs_typ_at_lifts unbind_maybe_notification_invs typ_at_lifts hoare_drop_imps hoare_vcg_all_lift | wpc)+
+          apply (wp abs_typ_at_lifts unbind_maybe_notification_invs AARCH64.typ_at_lifts hoare_drop_imps hoare_vcg_all_lift | wpc)+
         apply (clarsimp simp: valid_cap_def)
        apply (clarsimp simp: valid_cap'_def)
       apply (fastforce simp: final_matters'_def shiftL_nat zbits_map_def)

--- a/proof/refine/AARCH64/InvariantUpdates_H.thy
+++ b/proof/refine/AARCH64/InvariantUpdates_H.thy
@@ -5,10 +5,102 @@
  *)
 
 theory InvariantUpdates_H
-imports Invariants_H
+imports ArchInvsLemmas_H
 begin
 
+(* generic consequences which require arch-specific proofs from ArchInvsLemmas_H *)
+arch_requalify_facts
+  cte_wp_atE'
+  cte_wp_at_cteI'
+  tcb_at_cte_at'
+  typ_at_lift_valid_cap'
+  valid_arch_tcb_lift'
+  tcb_at_cte_at'
+  gen_objBitsT_simps
+  objBitsT_koTypeOf (* FIXME arch-split: consider declaring [simp] here rather than Schedule_R *)
+
+(* arch-specific typ_at_lifts in Arch *) (* FIXME arch-split: currently unused *)
+lemmas gen_typ_at_lifts =
+         typ_at_lift_tcb' typ_at_lift_ep' typ_at_lift_ntfn' typ_at_lift_cte' typ_at_lift_cte_at'
+         typ_at_lift_valid_untyped' typ_at_lift_valid_cap' valid_bound_tcb_lift
+         valid_arch_tcb_lift'
+
+(* these depend on interpretations in ArchInvLemmas_H *)
+context pspace_update_eq'
+begin
+
+lemma valid_space_update [iff]:
+  "valid_pspace' (f s) = valid_pspace' s"
+  by (fastforce simp: valid_pspace' pspace)
+
+lemma cte_wp_at_update [iff]:
+  "cte_wp_at' P p (f s) = cte_wp_at' P p s"
+  by (fastforce intro: cte_wp_at'_pspaceI simp: pspace)
+
+lemma ex_nonz_cap_to_eq'[iff]:
+  "ex_nonz_cap_to' p (f s) = ex_nonz_cap_to' p s"
+  by (simp add: ex_nonz_cap_to'_def)
+
+lemma iflive_update [iff]:
+  "if_live_then_nonz_cap' (f s) = if_live_then_nonz_cap' s"
+  by (simp add: if_live_then_nonz_cap'_def ex_nonz_cap_to'_def)
+
+lemma valid_objs_update [iff]:
+  "valid_objs' (f s) = valid_objs' s"
+  apply (simp add: valid_objs'_def pspace)
+  apply (fastforce intro: valid_obj'_pspaceI simp: pspace)
+  done
+
+lemma valid_cap_update [iff]:
+  "(f s) \<turnstile>' c = s \<turnstile>' c"
+  by (auto intro: valid_cap'_pspaceI simp: pspace)
+
+end
+
+context p_arch_idle_update_eq'
+begin
+
+lemma ifunsafe_update [iff]:
+  "if_unsafe_then_cap' (f s) = if_unsafe_then_cap' s"
+  by (simp add: if_unsafe_then_cap'_def ex_cte_cap_to'_def int_nd)
+
+end
+
+
 (* FIXME: use locales to shorten this work *)
+
+(* FIXME arch-split: MOVE, or try make generic *)
+context Arch begin arch_global_naming
+
+lemma invs'_gsCNodes_update[simp]:
+  "invs' (gsCNodes_update f s') = invs' s'"
+  apply (clarsimp simp: invs'_def valid_state'_def valid_bitmaps_def bitmapQ_defs
+                        valid_irq_node'_def valid_irq_handlers'_def irq_issued'_def irqs_masked'_def
+                        valid_machine_state'_def cur_tcb'_def)
+  apply (cases "ksSchedulerAction s'";
+         simp add: ct_in_state'_def tcb_in_cur_domain'_def ct_idle_or_in_cur_domain'_def
+                   ct_not_inQ_def)
+  done
+
+lemma invs'_gsUserPages_update[simp]:
+  "invs' (gsUserPages_update f s') = invs' s'"
+  apply (clarsimp simp: invs'_def valid_state'_def valid_bitmaps_def bitmapQ_defs
+                        valid_irq_node'_def valid_irq_handlers'_def irq_issued'_def irqs_masked'_def
+                        valid_machine_state'_def cur_tcb'_def)
+  apply (cases "ksSchedulerAction s'";
+         simp add: ct_in_state'_def tcb_in_cur_domain'_def ct_idle_or_in_cur_domain'_def
+                   ct_not_inQ_def)
+  done
+
+end
+
+(* FIXME arch-split: locale interface? *)
+arch_requalify_facts
+  invs'_gsCNodes_update
+  invs'_gsUserPages_update
+
+lemmas [simp] = invs'_gsCNodes_update invs'_gsUserPages_update
+
 
 lemma ps_clear_domE[elim?]:
   "\<lbrakk> ps_clear x n s; dom (ksPSpace s) = dom (ksPSpace s') \<rbrakk> \<Longrightarrow> ps_clear x n s'"
@@ -29,6 +121,10 @@ lemma ct_in_current_domain_ksMachineState[simp]:
   "ct_idle_or_in_cur_domain' (ksMachineState_update p s) = ct_idle_or_in_cur_domain' s"
   by (simp add: ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def)
 
+(* FIXME arch-split: MOVE *)
+context Arch begin arch_global_naming
+
+(* FIXME arch-split: export? *)
 lemma invs'_machine:
   assumes mask: "irq_masks (f (ksMachineState s)) =
                  irq_masks (ksMachineState s)"
@@ -48,6 +144,7 @@ proof -
     done
 qed
 
+(* FIXME arch-split: export? *)
 lemma invs_no_cicd'_machine:
   assumes mask: "irq_masks (f (ksMachineState s)) =
                  irq_masks (ksMachineState s)"
@@ -66,6 +163,8 @@ proof -
                    cong: option.case_cong)
     done
 qed
+
+end
 
 lemma pspace_no_overlap_queues [simp]:
   "pspace_no_overlap' w sz (ksReadyQueues_update f s) = pspace_no_overlap' w sz s"
@@ -93,6 +192,9 @@ lemma inQ_context[simp]:
   "inQ d p (tcbArch_update f tcb) = inQ d p tcb"
   by (cases tcb, simp add: inQ_def)
 
+(* FIXME arch-split: MOVE *)
+context Arch begin arch_global_naming
+
 lemma valid_tcb'_tcbQueued[simp]:
   "valid_tcb' (tcbQueued_update f tcb) = valid_tcb' tcb"
   by (cases tcb, rule ext, simp add: valid_tcb'_def tcb_cte_cases_def cteSizeBits_def)
@@ -104,6 +206,39 @@ lemma valid_tcb'_tcbFault_update[simp]:
 lemma valid_tcb'_tcbTimeSlice_update[simp]:
   "valid_tcb' (tcbTimeSlice_update f tcb) s = valid_tcb' tcb s"
   by (simp add:valid_tcb'_def tcb_cte_cases_def cteSizeBits_def)
+
+lemma invs'_wu[simp]:
+  "invs' (ksWorkUnitsCompleted_update f s) = invs' s"
+  apply (simp add: invs'_def cur_tcb'_def valid_state'_def valid_bitmaps_def
+                   valid_irq_node'_def valid_machine_state'_def
+                   ct_not_inQ_def ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def
+                   bitmapQ_defs)
+  done
+
+lemma valid_arch_state'_interrupt[simp]:
+  "valid_arch_state' (ksInterruptState_update f s) = valid_arch_state' s"
+  by (simp add: valid_arch_state'_def cong: option.case_cong)
+
+end
+
+(* FIXME arch-split: locales? *)
+arch_requalify_facts
+  valid_tcb'_tcbQueued
+  valid_tcb'_tcbFault_update
+  valid_tcb'_tcbTimeSlice_update
+  invs'_wu
+  valid_arch_state'_interrupt (* FIXME arch-split: safe to export? any arch where this wouldn't be true *)
+
+lemmas [simp] =
+  valid_tcb'_tcbQueued
+  valid_tcb'_tcbFault_update
+  valid_tcb'_tcbTimeSlice_update
+  invs'_wu
+  valid_arch_state'_interrupt
+
+lemma if_unsafe_then_cap_arch'[simp]:
+  "if_unsafe_then_cap' (ksArchState_update f s) = if_unsafe_then_cap' s"
+  by (simp add: if_unsafe_then_cap'_def ex_cte_cap_to'_def)
 
 lemma valid_bitmaps_ksSchedulerAction_update[simp]:
    "valid_bitmaps (ksSchedulerAction_update f s) = valid_bitmaps s"
@@ -187,8 +322,17 @@ lemma ex_cte_cap_wp_to_work_units[simp]:
     = ex_cte_cap_wp_to' P slot s"
   by (simp add: ex_cte_cap_wp_to'_def)
 
+(* add_upd_simps does not play nice with itself, so we need to give one instance a name prefix *)
+context begin global_naming add_upd_invs'_gsUntypedZeroRanges
+
+add_upd_simps "invs' (gsUntypedZeroRanges_update f s)"
+  (obj_at'_real_def)
+
+end
+lemmas [simp] = add_upd_invs'_gsUntypedZeroRanges.upd_simps
+
 add_upd_simps "ct_in_state' P (gsUntypedZeroRanges_update f s)"
-declare upd_simps[simp]
+lemmas [simp] = upd_simps
 
 lemma ct_not_inQ_ksArchState_update[simp]:
   "ct_not_inQ (ksArchState_update f s) = ct_not_inQ s"
@@ -263,18 +407,6 @@ lemma ct_in_state_ksSched[simp]:
   apply auto
   done
 
-lemma invs'_wu [simp]:
-  "invs' (ksWorkUnitsCompleted_update f s) = invs' s"
-  apply (simp add: invs'_def cur_tcb'_def valid_state'_def valid_bitmaps_def
-                   valid_irq_node'_def valid_machine_state'_def
-                   ct_not_inQ_def ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def
-                   bitmapQ_defs)
-  done
-
-lemma valid_arch_state'_interrupt[simp]:
-  "valid_arch_state' (ksInterruptState_update f s) = valid_arch_state' s"
-  by (simp add: valid_arch_state'_def cong: option.case_cong)
-
 lemma valid_bitmapQ_ksSchedulerAction_upd[simp]:
   "valid_bitmapQ (ksSchedulerAction_update f s) = valid_bitmapQ s"
   unfolding bitmapQ_defs by simp
@@ -318,11 +450,6 @@ lemma sch_act_simple_ksReadyQueuesL2Bitmap[simp]:
   apply (simp add: sch_act_simple_def)
   done
 
-lemma ksDomainTime_invs[simp]:
-  "invs' (ksDomainTime_update f s) = invs' s"
-  by (simp add: invs'_def valid_state'_def cur_tcb'_def ct_not_inQ_def ct_idle_or_in_cur_domain'_def
-                tcb_in_cur_domain'_def valid_machine_state'_def bitmapQ_defs)
-
 lemma valid_machine_state'_ksDomainTime[simp]:
   "valid_machine_state' (ksDomainTime_update f s) = valid_machine_state' s"
   by (simp add:valid_machine_state'_def)
@@ -347,13 +474,32 @@ lemma ct_not_inQ_update_stt[simp]:
   "ct_not_inQ (s\<lparr>ksSchedulerAction := SwitchToThread t\<rparr>)"
    by (simp add: ct_not_inQ_def)
 
+
+(* FIXME arch-split: MOVE *)
+context Arch begin arch_global_naming
+
+lemma ksDomainTime_invs[simp]:
+  "invs' (ksDomainTime_update f s) = invs' s"
+  by (simp add: invs'_def valid_state'_def cur_tcb'_def ct_not_inQ_def ct_idle_or_in_cur_domain'_def
+                tcb_in_cur_domain'_def valid_machine_state'_def bitmapQ_defs)
+
 lemma invs'_update_cnt[elim!]:
   "invs' s \<Longrightarrow> invs' (s\<lparr>ksSchedulerAction := ChooseNewThread\<rparr>)"
    by (clarsimp simp: invs'_def valid_state'_def valid_queues_def valid_irq_node'_def cur_tcb'_def
                       ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def bitmapQ_defs)
 
+end
 
-context begin interpretation Arch .
+(* FIXME arch-split: locales? *)
+arch_requalify_facts
+  ksDomainTime_invs
+  invs'_update_cnt
+
+lemmas [simp] = ksDomainTime_invs
+lemmas [elim!] = invs'_update_cnt
+
+(* FIXME arch-split: MOVE *)
+context Arch begin arch_global_naming
 
 lemma valid_arch_state'_vmid_next_update[simp]:
   "valid_arch_state' (s\<lparr>ksArchState := armKSNextVMID_update f (ksArchState s)\<rparr>) =

--- a/proof/refine/AARCH64/IpcCancel_R.thy
+++ b/proof/refine/AARCH64/IpcCancel_R.thy
@@ -121,7 +121,7 @@ crunch cancelSignal
 context delete_one_conc_pre
 begin
 
-lemmas delete_one_typ_ats[wp] = typ_at_lifts [OF delete_one_typ_at]
+lemmas delete_one_typ_ats[wp] = AARCH64.typ_at_lifts [OF delete_one_typ_at]
 
 lemma cancelIPC_tcb_at'[wp]:
   "\<lbrace>tcb_at' t\<rbrace> cancelIPC t' \<lbrace>\<lambda>_. tcb_at' t\<rbrace>"
@@ -1836,8 +1836,14 @@ lemma ct_not_in_ntfnQueue:
 
 crunch rescheduleRequired
   for valid_pspace'[wp]: "valid_pspace'"
+
+context begin interpretation Arch . (*FIXME: arch-split*)
+
 crunch rescheduleRequired
   for valid_global_refs'[wp]: "valid_global_refs'"
+
+end
+
 crunch rescheduleRequired
   for valid_machine_state'[wp]: "valid_machine_state'"
 
@@ -1993,7 +1999,7 @@ lemma threadSet_not_tcb[wp]:
   by (clarsimp simp: threadSet_def valid_def getObject_def
                      setObject_def in_monad loadObject_default_def
                      ko_wp_at'_def split_def in_magnitude_check
-                     objBits_simps' updateObject_default_def
+                     AARCH64.objBits_simps' updateObject_default_def
                      ps_clear_upd projectKO_opt_tcb)
 
 lemma setThreadState_not_tcb[wp]:

--- a/proof/refine/AARCH64/Ipc_R.thy
+++ b/proof/refine/AARCH64/Ipc_R.thy
@@ -1649,6 +1649,7 @@ lemma doFaultTransfer_invs[wp]:
 lemma lookupIPCBuffer_valid_ipc_buffer [wp]:
   "\<lbrace>valid_objs'\<rbrace> VSpace_H.lookupIPCBuffer b s \<lbrace>case_option \<top> valid_ipc_buffer_ptr'\<rbrace>"
   unfolding lookupIPCBuffer_def AARCH64_H.lookupIPCBuffer_def
+  supply raw_tcb_cte_cases_simps[simp] (* FIXME arch-split: legacy, try use tcb_cte_cases_neqs *)
   apply (simp add: Let_def getSlotCap_def getThreadBufferSlot_def
                    locateSlot_conv threadGet_def comp_def)
   apply (wp getCTE_wp getObject_tcb_wp | wpc)+
@@ -3534,6 +3535,7 @@ lemma setupCallerCap_ifunsafe[wp]:
    \<lbrace>\<lambda>rv. if_unsafe_then_cap'\<rbrace>"
   unfolding setupCallerCap_def getThreadCallerSlot_def
             getThreadReplySlot_def locateSlot_conv
+  supply raw_tcb_cte_cases_simps[simp] (* FIXME arch-split: legacy, try use tcb_cte_cases_neqs *)
   apply (wp getSlotCap_cte_wp_at
        | simp add: unique_master_reply_cap' | strengthen eq_imp_strg
        | wp (once) hoare_drop_imp[where f="getCTE rs" for rs])+

--- a/proof/refine/AARCH64/KHeap_R.thy
+++ b/proof/refine/AARCH64/KHeap_R.thy
@@ -245,6 +245,7 @@ lemma updateObject_cte_is_tcb_or_cte:
     \<and> ko' = KOTCB (setF (\<lambda>x. cte) tcb) \<and> is_aligned q tcbBlockSizeBits \<and> ps_clear q tcbBlockSizeBits s) \<or>
   (\<exists>cte'. ko = KOCTE cte' \<and> ko' = KOCTE cte \<and> s' = s
         \<and> p = q \<and> is_aligned p cte_level_bits \<and> ps_clear p cte_level_bits s)"
+  supply raw_tcb_cte_cases_simps[simp] (* FIXME arch-split: legacy, try use tcb_cte_cases_neqs *)
   apply (clarsimp simp: updateObject_cte typeError_def alignError_def
                         tcbVTableSlot_def tcbCTableSlot_def to_bl_1 rev_take  objBits_simps'
                         in_monad map_bits_to_bl cte_level_bits_def in_magnitude_check
@@ -1199,6 +1200,7 @@ lemma typ_at'_valid_obj'_lift:
   assumes P: "\<And>P T p. \<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace> f \<lbrace>\<lambda>rv s. P (typ_at' T p s)\<rbrace>"
   notes [wp] = hoare_vcg_all_lift hoare_vcg_imp_lift hoare_vcg_const_Ball_lift typ_at_lifts [OF P]
   shows      "\<lbrace>\<lambda>s. valid_obj' obj s\<rbrace> f \<lbrace>\<lambda>rv s. valid_obj' obj s\<rbrace>"
+  supply raw_tcb_cte_cases_simps[simp] (* FIXME arch-split: legacy, try use tcb_cte_cases_neqs *)
   apply (cases obj; simp add: valid_obj'_def hoare_TrueI)
       apply (rename_tac endpoint)
       apply (case_tac endpoint; simp add: valid_ep'_def, wp)
@@ -1210,7 +1212,7 @@ lemma typ_at'_valid_obj'_lift:
     apply (case_tac "tcbState tcb";
            simp add: valid_tcb'_def valid_tcb_state'_def split_def opt_tcb_at'_def
                      valid_bound_ntfn'_def;
-           wpsimp wp: hoare_case_option_wp hoare_case_option_wp2;
+           wpsimp wp: hoare_case_option_wp hoare_case_option_wp2 valid_arch_tcb_lift' P;
            (clarsimp split: option.splits)?)
    apply (wpsimp simp: valid_cte'_def)
   apply wp

--- a/proof/refine/AARCH64/LevityCatch.thy
+++ b/proof/refine/AARCH64/LevityCatch.thy
@@ -43,7 +43,7 @@ lemma updateObject_default_inv:
   by (wpsimp wp: magnitudeCheck_inv alignCheck_inv projectKO_inv)
 
 
-context begin interpretation Arch .
+context Arch begin arch_global_naming
 
 lemmas makeObject_simps =
   makeObject_endpoint makeObject_notification makeObject_cte

--- a/proof/refine/AARCH64/RAB_FN.thy
+++ b/proof/refine/AARCH64/RAB_FN.thy
@@ -80,6 +80,8 @@ lemma isCNodeCap_capUntypedPtr_capCNodePtr:
   "isCNodeCap c \<Longrightarrow> capUntypedPtr c = capCNodePtr c"
   by (clarsimp simp: isCap_simps)
 
+context begin interpretation Arch . (*FIXME: arch-split*)
+
 lemma resolveAddressBitsFn_eq:
   "monadic_rewrite F E (\<lambda>s. (isCNodeCap cap \<longrightarrow> (\<exists>slot. cte_wp_at' (\<lambda>cte. cteCap cte = cap) slot s))
         \<and> valid_objs' s \<and> cnode_caps_gsCNodes' s)
@@ -143,5 +145,7 @@ proof (induct cap capptr bits rule: resolveAddressBits.induct)
   apply (simp add: isCap_simps capAligned_def word_bits_def and_mask_less')
   done
 qed
+
+end
 
 end

--- a/proof/refine/AARCH64/Retype_R.thy
+++ b/proof/refine/AARCH64/Retype_R.thy
@@ -1169,8 +1169,8 @@ lemma ksPSpace_update_gs_eq[simp]:
 
 end
 
-global_interpretation update_gs: PSpace_update_eq "update_gs ty us ptrs"
-  by (simp add: PSpace_update_eq_def)
+global_interpretation update_gs: pspace_update_eq' "update_gs ty us ptrs"
+  by (simp add: pspace_update_eq'_def)
 
 context begin interpretation Arch . (*FIXME: arch-split*)
 

--- a/proof/refine/AARCH64/TcbAcc_R.thy
+++ b/proof/refine/AARCH64/TcbAcc_R.thy
@@ -6,7 +6,7 @@
  *)
 
 theory TcbAcc_R
-imports CSpace_R ArchMove_R
+imports CSpace_R
 begin
 
 context begin interpretation Arch . (*FIXME: arch-split*)
@@ -4045,6 +4045,8 @@ lemma isRunnable_const:
   "\<lbrace>st_tcb_at' runnable' t\<rbrace> isRunnable t \<lbrace>\<lambda>runnable _. runnable \<rbrace>"
   by (rule isRunnable_wp)
 
+context begin interpretation Arch . (*FIXME: arch-split*)
+
 lemma valid_ipc_buffer_ptr'D:
   assumes yv: "y < unat max_ipc_words"
   and    buf: "valid_ipc_buffer_ptr' a s"
@@ -4133,6 +4135,8 @@ lemma storeWordUser_corres:
    apply (frule (1) valid_ipc_buffer_ptr'D [OF y])
   apply (simp add: valid_ipc_buffer_ptr'_def)
   done
+
+end
 
 lemma load_word_corres:
   "corres (=) \<top>
@@ -4433,6 +4437,7 @@ qed
 
 lemma cte_at_tcb_at_32':
   "tcb_at' t s \<Longrightarrow> cte_at' (t + 32) s"
+  supply raw_tcb_cte_cases_simps[simp] (* FIXME arch-split: legacy, try use tcb_cte_cases_neqs *)
   apply (simp add: cte_at'_obj_at')
   apply (rule disjI2, rule bexI[where x=32])
    apply simp

--- a/proof/refine/AARCH64/Tcb_R.thy
+++ b/proof/refine/AARCH64/Tcb_R.thy
@@ -1014,6 +1014,7 @@ lemma threadcontrol_corres_helper4:
     (checkCapAt (capability.ThreadCap a) (cte_map slot)
        (assertDerived (cte_map (ab, ba)) ac (cteInsert ac (cte_map (ab, ba)) (cte_map (a, tcb_cnode_index 4)))))
   \<lbrace>\<lambda>_ s. sym_heap_sched_pointers s \<and> valid_sched_pointers s \<and> valid_tcbs' s\<rbrace>"
+  supply raw_tcb_cte_cases_simps[simp] (* FIXME arch-split: legacy, try use tcb_cte_cases_neqs *)
   apply (wpsimp wp:
          | strengthen invs_sym_heap_sched_pointers invs_valid_sched_pointers
                       invs_valid_objs' valid_objs'_valid_tcbs')+
@@ -1303,6 +1304,7 @@ proof -
             od odE od)
         g')" (is "corres _ ?T2_pre ?T2_pre' _ _")
     using z u
+    supply raw_tcb_cte_cases_simps[simp] (* FIXME arch-split: legacy, try use tcb_cte_cases_neqs *)
     apply -
     apply (rule corres_guard_imp[where P=P and P'=P'
                                   and Q="P and cte_at (a, tcb_cnode_index 4)"

--- a/proof/refine/AARCH64/orphanage/Orphanage.thy
+++ b/proof/refine/AARCH64/orphanage/Orphanage.thy
@@ -1669,6 +1669,7 @@ lemma tc_no_orphans:
     K (valid_option_prio d \<and> valid_option_prio mcp) \<rbrace>
       invokeTCB (tcbinvocation.ThreadControl a sl b' mcp d e' f' g)
    \<lbrace> \<lambda>rv s. no_orphans s \<rbrace>"
+  supply raw_tcb_cte_cases_simps[simp] (* FIXME arch-split: legacy, try use tcb_cte_cases_neqs *)
   apply (rule hoare_gen_asm)
   apply (rule hoare_gen_asm)
   apply (rule hoare_gen_asm)

--- a/proof/refine/InvariantsPre_H.thy
+++ b/proof/refine/InvariantsPre_H.thy
@@ -1,0 +1,140 @@
+(*
+ * Copyright 2023, Proofcraft Pty Ltd
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+(* Preliminary definitions required to define arch-specific invariants and properties.
+   These are primarily related to obj_at' and storability.
+*)
+
+theory InvariantsPre_H
+imports
+  LevityCatch
+  "AInvs.ArchDetSchedSchedule_AI"
+  "Lib.Heap_List"
+  Move_R
+begin
+
+(* global data and code of the kernel, not covered by any cap *)
+axiomatization
+  kernel_data_refs :: "word64 set"
+
+
+section \<open>Locale Setup for kernel_state Field Update Identities\<close>
+
+text \<open>
+  These locales identify which updates are the identity function on specific field access
+  predicates. For instance, when a function doesn't change the @{term ksPSpace} component of the
+  state, that function is the identity on all predicates that only depend on @{term ksPSpace}.\<close>
+
+text \<open>
+  Since locales can dynamically gain conclusions, we want to avoid situations where someone adds
+  a conclusion somewhere in the locale graph and is surprised that it does not appear for
+  extensions of that locale. For arch-split there is an extra complication, where the conclusions
+  might use arch-specific facts, thus needing to be in Arch.
+
+  This means that for every one of the update locales, we have to add an additional Arch locale.
+  In order to not leave gaps in the locale graph, when we combine update locales, the Arch locale
+  for their combination must also see the conclusions of \emph{their} Arch locales, leading to a
+  pattern of @{text "C = A + B"} followed by @{text "ArchC = C + ArchA + ArchB"}.\<close>
+
+locale pspace_update_eq' =
+  fixes f :: "kernel_state \<Rightarrow> kernel_state"
+  assumes pspace: "ksPSpace (f s) = ksPSpace s"
+
+locale Arch_pspace_update_eq' = pspace_update_eq' + Arch
+
+locale arch_idle_update_eq' =
+  fixes f :: "kernel_state \<Rightarrow> kernel_state"
+  assumes arch: "ksArchState (f s) = ksArchState s"
+  assumes idle: "ksIdleThread (f s) = ksIdleThread s"
+  assumes int_nd:  "intStateIRQNode (ksInterruptState (f s))
+                    = intStateIRQNode (ksInterruptState s)"
+  assumes maxObj: "gsMaxObjectSize (f s) = gsMaxObjectSize s"
+
+locale Arch_arch_idle_update_eq' = arch_idle_update_eq' + Arch
+
+locale p_arch_idle_update_eq' = pspace_update_eq' + arch_idle_update_eq'
+locale Arch_p_arch_idle_update_eq' =
+         Arch_pspace_update_eq' + Arch_arch_idle_update_eq' + p_arch_idle_update_eq'
+
+locale int_update_eq' =
+  fixes f :: "kernel_state \<Rightarrow> kernel_state"
+  assumes int:  "ksInterruptState (f s) = ksInterruptState s"
+
+(* FIXME arch-split: unused, can replace by int_update_eq' to optimise *)
+locale Arch_int_update_eq' = int_update_eq' + Arch
+
+locale p_cur_update_eq' = pspace_update_eq' +
+  assumes curt: "ksCurThread (f s) = ksCurThread s"
+  assumes curd: "ksCurDomain (f s) = ksCurDomain s"
+
+(* FIXME arch-split: unused, can replace by p_cur_update_eq' to optimise *)
+locale Arch_p_cur_update_eq' = p_cur_update_eq' + Arch
+
+locale p_int_update_eq' = pspace_update_eq' + int_update_eq'
+locale Arch_p_int_update_eq' = Arch_pspace_update_eq' + Arch_int_update_eq' + p_int_update_eq'
+
+locale p_int_cur_update_eq' = p_int_update_eq' + p_cur_update_eq'
+locale Arch_p_int_cur_update_eq' = Arch_p_int_update_eq' + Arch_p_cur_update_eq' + p_int_cur_update_eq'
+
+locale p_arch_idle_int_update_eq' = p_arch_idle_update_eq' + p_int_update_eq'
+locale Arch_p_arch_idle_int_update_eq' =
+         Arch_p_arch_idle_update_eq' + Arch_p_int_update_eq' + p_arch_idle_int_update_eq'
+
+locale p_arch_idle_int_cur_update_eq' = p_arch_idle_int_update_eq' + p_cur_update_eq'
+locale Arch_p_arch_idle_int_cur_update_eq' =
+         p_arch_idle_int_cur_update_eq' + Arch_p_arch_idle_int_update_eq' + Arch_p_cur_update_eq'
+
+
+section \<open>Kernel Objects in Memory\<close>
+
+text \<open>
+  We do not make use of the VPtr/Ptr/Register abstraction in proofs, only for type safety in Haskell\<close>
+(* FIXME arch-split: add to simpset? *)
+arch_requalify_facts (H)
+  PPtr_def
+  fromPPtr_def
+  VPtr_def
+  fromVPtr_def
+  fromVPtr_update_def
+  Register_def
+
+definition ps_clear :: "obj_ref \<Rightarrow> nat \<Rightarrow> kernel_state \<Rightarrow> bool" where
+  "ps_clear p n s \<equiv> (mask_range p n - {p}) \<inter> dom (ksPSpace s) = {}"
+
+definition pspace_no_overlap' :: "obj_ref \<Rightarrow> nat \<Rightarrow> kernel_state \<Rightarrow> bool" where
+  "pspace_no_overlap' ptr bits \<equiv>
+     \<lambda>s. \<forall>x ko. ksPSpace s x = Some ko \<longrightarrow>
+                (mask_range x (objBitsKO ko)) \<inter> {ptr .. (ptr && ~~ mask bits) + mask bits} = {}"
+
+definition ko_wp_at' :: "(kernel_object \<Rightarrow> bool) \<Rightarrow> obj_ref \<Rightarrow> kernel_state \<Rightarrow> bool" where
+  "ko_wp_at' P p s \<equiv> \<exists>ko. ksPSpace s p = Some ko \<and> is_aligned p (objBitsKO ko) \<and> P ko \<and>
+                          ps_clear p (objBitsKO ko) s"
+
+definition obj_at' :: "('a::pspace_storable \<Rightarrow> bool) \<Rightarrow> machine_word \<Rightarrow> kernel_state \<Rightarrow> bool" where
+  obj_at'_real_def:
+  "obj_at' P p s \<equiv> ko_wp_at' (\<lambda>ko. \<exists>obj. projectKO_opt ko = Some obj \<and> P obj) p s"
+
+definition typ_at' :: "kernel_object_type \<Rightarrow> machine_word \<Rightarrow> kernel_state \<Rightarrow> bool" where
+  "typ_at' T \<equiv> ko_wp_at' (\<lambda>ko. koTypeOf ko = T)"
+
+abbreviation ko_at' :: "'a::pspace_storable \<Rightarrow> obj_ref \<Rightarrow> kernel_state \<Rightarrow> bool" where
+  "ko_at' v \<equiv> obj_at' (\<lambda>k. k = v)"
+
+abbreviation irq_node' :: "kernel_state \<Rightarrow> obj_ref" where
+  "irq_node' s \<equiv> intStateIRQNode (ksInterruptState s)"
+
+(* FIXME arch-split: consider adding to simpset early in Refine, then changing over definitions *)
+(* proof is identical on all arches *)
+lemma (in Arch) cteSizeBits_cte_level_bits:
+  "cteSizeBits = cte_level_bits"
+  unfolding cteSizeBits_def cte_level_bits_def
+  by (simp add: wordSizeCase_def wordBits_def word_size)
+
+requalify_facts
+  Arch.cteSizeBits_cte_level_bits
+
+end

--- a/proof/refine/Move_R.thy
+++ b/proof/refine/Move_R.thy
@@ -12,6 +12,9 @@ imports
 
 begin
 
+lemma invs_valid_ioc[elim!]: "invs s \<Longrightarrow> valid_ioc s"
+  by (clarsimp simp add: invs_def valid_state_def)
+
 lemma zip_map_rel:
   assumes "(x,y) \<in> set (zip xs ys)" "map f xs = map g ys"
   shows "f x = g y"
@@ -58,6 +61,15 @@ lemma unaligned_helper:
   done
 
 declare word_unat_power[symmetric, simp del]
+
+lemma neq_out_intv:
+  "\<lbrakk> a \<noteq> b; b \<notin> {a..a + c - 1} - {a} \<rbrakk> \<Longrightarrow> b \<notin> {a..a + c - 1}"
+  by simp
+
+lemma ptr_range_mask_range:
+  "{ptr..ptr + 2 ^ bits - 1} = mask_range ptr bits"
+  unfolding mask_def
+  by simp
 
 lemma oblivious_mapM_x:
   "\<forall>x\<in>set xs. oblivious f (g x) \<Longrightarrow> oblivious f (mapM_x g xs)"


### PR DESCRIPTION
🦆🦆🦆 This PR needs feedback before I deploy anything to the other arches or move further. In an attempt to make the diff a bit more useful for reviewing than "new files added with stuff", `Invariants_H` got duplicated into each of the new files, and then clobbered by the actual file contents.
**Do not attempt to review the whole thing at once**, or the "duplicate and move Invariants_H" commit which will be squashed into once all this works.
The Refine fixup commit is not really indicative of any policies I'm aiming for in the future, it's just there so Refine builds.
The plan is: once we are OK with the way things are done, I'll expand this PR with deployment to other arches, fix up CRefine, and then we can merge it to master before continuing the arch-split train.

Invariants_H gets split into 4 files processed in this order:
    - InvariantsPre_H: initial setup
    - ArchInvsDefs_H: arch-specific invariant property definitions
    - Invariants_H: remains to store arch-generic
      invariants/properties/lemmas
    - ArchInvsLemmas: locale interpretations and arch-specific
      invariant-related lemmas

Several lemmas/interpretations/locales got moved to InvariantUpdates_H in order to resolve dependencies without introducing more files.

AARCH64 Refine will build, but CRefine is currently broken.