### PR TITLE
Update ARM AInvs and Access for det_ext changes

### DIFF
--- a/proof/access-control/ARM/ArchAccess.thy
+++ b/proof/access-control/ARM/ArchAccess.thy
@@ -88,6 +88,11 @@ lemmas state_vrefs_upd =
   revokable_update.state_vrefs
   machine_state_update.state_vrefs
   more_update.state_vrefs
+  scheduler_action_update.state_vrefs
+  domain_index_update.state_vrefs
+  cur_domain_update.state_vrefs
+  domain_time_update.state_vrefs
+  ready_queues_update.state_vrefs
 
 end
 
@@ -138,6 +143,7 @@ abbreviation integrity_asids_aux ::
      pp_opt = pp_opt' \<or> (\<forall>asid'. asid' \<noteq> 0 \<and> asid_high_bits_of asid' = asid_high_bits_of asid
                                  \<longrightarrow> pasASIDAbs aag asid' \<in> subjects)"
 
+\<comment> \<open>FIXME: could we define integrity_asids to operate on arch_state only?\<close>
 definition integrity_asids ::
   "'a PAS \<Rightarrow> 'a set \<Rightarrow> obj_ref \<Rightarrow> asid \<Rightarrow> 'y::state_ext state \<Rightarrow> 'z:: state_ext state  \<Rightarrow> bool" where
   "integrity_asids aag subjects x a s s' \<equiv>
@@ -159,6 +165,11 @@ lemmas integrity_asids_updates =
   interrupt_update.integrity_asids_update
   cur_thread_update.integrity_asids_update
   machine_state_update.integrity_asids_update
+  scheduler_action_update.integrity_asids_update
+  domain_index_update.integrity_asids_update
+  cur_domain_update.integrity_asids_update
+  domain_time_update.integrity_asids_update
+  ready_queues_update.integrity_asids_update
 
 (* The kheap isn't used in ARM's integrity_asids definition,
    but we need the following lemmas in some generic contexts *)

--- a/proof/access-control/ARM/ArchArch_AC.thy
+++ b/proof/access-control/ARM/ArchArch_AC.thy
@@ -1011,21 +1011,20 @@ lemma delete_asid_respects:
   by (wpsimp wp: set_asid_pool_respects_clear hoare_vcg_all_lift
            simp: obj_at_def pas_refined_refl delete_asid_def asid_pool_integrity_def)
 
-lemma authorised_arch_inv_sa_update:
+lemma authorised_arch_inv_sa_update[simp]:
   "authorised_arch_inv aag i (scheduler_action_update (\<lambda>_. act) s) =
    authorised_arch_inv aag i s"
   by (clarsimp simp: authorised_arch_inv_def authorised_page_inv_def authorised_slots_def
               split: arch_invocation.splits page_invocation.splits)
 
+crunch set_thread_state_act
+  for authorised_arch_inv[wp]: "authorised_arch_inv aag i"
+
 lemma set_thread_state_authorised_arch_inv[wp]:
   "set_thread_state ref ts \<lbrace>authorised_arch_inv aag i\<rbrace>"
   unfolding set_thread_state_def
-  apply (wpsimp wp: dxo_wp_weak)
-     apply (clarsimp simp: authorised_arch_inv_def authorised_page_inv_def authorised_slots_def
-                    split: arch_invocation.splits page_invocation.splits)
-    apply (wpsimp wp: set_object_wp)+
-  by (clarsimp simp: authorised_arch_inv_def authorised_page_inv_def authorised_slots_def
-              split: arch_invocation.splits page_invocation.splits)
+  apply (wpsimp wp: set_object_wp)
+  by (clarsimp simp: authorised_arch_inv_def)
 
 end
 

--- a/proof/access-control/ARM/ArchCNode_AC.thy
+++ b/proof/access-control/ARM/ArchCNode_AC.thy
@@ -114,15 +114,12 @@ lemma list_integ_lift[CNode_AC_assms]:
     "\<lbrace>list_integ (cdt_change_allowed aag {pasSubject aag} (cdt st) (tcb_states_of_state st)) st and Q\<rbrace>
      f
      \<lbrace>\<lambda>_. list_integ (cdt_change_allowed aag {pasSubject aag}  (cdt st) (tcb_states_of_state st)) st\<rbrace>"
-  assumes ekh: "\<And>P. f \<lbrace>\<lambda>s. P (ekheap s)\<rbrace>"
-  assumes rq: "\<And>P. f \<lbrace>\<lambda>s. P (ready_queues s)\<rbrace>"
   shows "\<lbrace>integrity aag X st and Q\<rbrace> f \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (rule hoare_pre)
    apply (unfold integrity_def[abs_def] integrity_asids_def)
    apply (simp only: integrity_cdt_list_as_list_integ)
-   apply (rule hoare_lift_Pf2[where f="ekheap"])
-    apply (simp add: tcb_states_of_state_def get_tcb_def)
-    apply (wp li[simplified tcb_states_of_state_def get_tcb_def] ekh rq)+
+   apply (simp add: tcb_states_of_state_def get_tcb_def)
+   apply (wp li[simplified tcb_states_of_state_def get_tcb_def])+
   apply (simp only: integrity_cdt_list_as_list_integ)
   apply (simp add: tcb_states_of_state_def get_tcb_def)
   done
@@ -374,16 +371,9 @@ lemma auth_graph_map_def2:
   "auth_graph_map f S = (\<lambda>(x, auth, y). (f x, auth, f y)) ` S"
   by (auto simp add: auth_graph_map_def image_def intro: rev_bexI)
 
-(* FIXME move to AInvs *)
-lemma store_pte_ekheap[wp]:
-  "store_pte p pte \<lbrace>\<lambda>s. P (ekheap s)\<rbrace>"
-  apply (simp add: store_pte_def set_pt_def)
-  apply (wp get_object_wp)
-  apply simp
-  done
-
 crunch store_pte
-  for asid_table_inv[wp]: "\<lambda>s. P (asid_table s)"
+  for etcbs_of[wp]: "\<lambda>s. P (etcbs_of s)"
+  and asid_table_inv[wp]: "\<lambda>s. P (asid_table s)"
 
 lemma store_pte_pas_refined[wp]:
   "\<lbrace>pas_refined aag and
@@ -499,13 +489,6 @@ lemma set_asid_pool_thread_bound_ntfns[wp]:
   apply (clarsimp simp: thread_bound_ntfns_def obj_at_def get_tcb_def tcb_states_of_state_def
                  elim!: rsubst[where P=P, OF _ ext]
                  split: kernel_object.split_asm option.split)
-  done
-
-(* FIXME move to AInvs *)
-lemma set_asid_pool_ekheap[wp]:
-  "set_asid_pool p pool \<lbrace>\<lambda>s. P (ekheap s)\<rbrace>"
-  apply (simp add: set_asid_pool_def)
-  apply (wp get_object_wp | simp)+
   done
 
 lemma set_asid_pool_pas_refined[wp]:

--- a/proof/access-control/ARM/ArchIpc_AC.thy
+++ b/proof/access-control/ARM/ArchIpc_AC.thy
@@ -17,6 +17,7 @@ declare handle_arch_fault_reply_typ_at[Ipc_AC_assms]
 
 crunch cap_insert_ext
   for integrity_asids[Ipc_AC_assms, wp]: "integrity_asids aag subjects x a st"
+  (ignore_del: cap_insert_ext) \<comment> \<open>FIXME: should these ext consts still be ignored in DetSched_AI files and beyond?\<close>
 
 lemma arch_derive_cap_auth_derived[Ipc_AC_assms]:
   "\<lbrace>\<top>\<rbrace> arch_derive_cap acap \<lbrace>\<lambda>rv _. rv \<noteq> NullCap \<longrightarrow> auth_derived rv (ArchObjectCap acap)\<rbrace>, -"
@@ -203,8 +204,6 @@ lemma list_integ_lift_in_ipc[Ipc_AC_assms]:
    "\<lbrace>list_integ (cdt_change_allowed aag {pasSubject aag} (cdt st) (tcb_states_of_state st)) st and Q\<rbrace>
     f
     \<lbrace>\<lambda>_. list_integ (cdt_change_allowed aag {pasSubject aag} (cdt st) (tcb_states_of_state st)) st\<rbrace>"
-  assumes ekh: "\<And>P. \<lbrace>\<lambda>s. P (ekheap s)\<rbrace> f \<lbrace>\<lambda>rv s. P (ekheap s)\<rbrace>"
-  assumes rq: "\<And>P. \<lbrace> \<lambda>s. P (ready_queues s) \<rbrace> f \<lbrace> \<lambda>rv s. P (ready_queues s) \<rbrace>"
   shows "\<lbrace>integrity_tcb_in_ipc aag X receiver epptr ctxt st and Q\<rbrace>
          f
          \<lbrace>\<lambda>_. integrity_tcb_in_ipc aag X receiver epptr ctxt st\<rbrace>"
@@ -212,9 +211,8 @@ lemma list_integ_lift_in_ipc[Ipc_AC_assms]:
   apply (simp del:split_paired_All)
   apply (rule hoare_pre)
    apply (simp only: integrity_cdt_list_as_list_integ)
-   apply (rule hoare_lift_Pf2[where f="ekheap"])
-    apply (simp add: tcb_states_of_state_def get_tcb_def)
-    apply (wp li[simplified tcb_states_of_state_def get_tcb_def] ekh rq)+
+   apply (simp add: tcb_states_of_state_def get_tcb_def)
+   apply (wp li[simplified tcb_states_of_state_def get_tcb_def])+
   apply (simp only: integrity_cdt_list_as_list_integ)
   apply (simp add: tcb_states_of_state_def get_tcb_def)
   done

--- a/proof/access-control/ARM/ArchRetype_AC.thy
+++ b/proof/access-control/ARM/ArchRetype_AC.thy
@@ -17,7 +17,7 @@ lemma invs_mdb_cte':
 context retype_region_proofs begin interpretation Arch .
 
 lemma vs_refs_no_global_pts_default[simp]:
-  "vs_refs_no_global_pts (default_object ty dev us) = {}"
+  "vs_refs_no_global_pts (default_object ty dev us d) = {}"
   by (simp add: default_object_def default_arch_object_def tyunt
                 vs_refs_no_global_pts_def pde_ref2_def pte_ref_def
                 o_def
@@ -33,12 +33,29 @@ end
 
 context retype_region_proofs' begin interpretation Arch .
 
+lemma test:
+  "pas_refined aag s \<Longrightarrow> tcb_domain_map_wellformed aag s"
+  by (simp add: pas_refined_def)
+
+\<comment> \<open>FIXME: move to pas_refined_state_objs_to_policy_subset?\<close>
+lemma pas_refined_subsets_tcb_domain_map_wellformed:
+  "\<lbrakk> pas_refined aag s;
+     state_objs_to_policy s' \<subseteq> state_objs_to_policy s;
+     state_asids_to_policy aag s' \<subseteq> state_asids_to_policy aag s;
+     state_irqs_to_policy aag s' \<subseteq> state_irqs_to_policy aag s;
+     tcb_domain_map_wellformed aag s \<Longrightarrow> tcb_domain_map_wellformed aag s';
+     interrupt_irq_node s' = interrupt_irq_node s \<rbrakk>
+     \<Longrightarrow> pas_refined aag s'"
+  by (simp add: pas_refined_def)
+     (blast dest: auth_graph_map_mono[where G="pasObjectAbs aag"])
+
 lemma pas_refined:
-  "\<lbrakk> invs s; pas_refined aag s \<rbrakk> \<Longrightarrow> pas_refined aag s'"
-  apply (erule pas_refined_state_objs_to_policy_subset)
-     apply (simp add: state_objs_to_policy_def refs_eq vrefs_eq mdb_and_revokable)
-     apply (rule subsetI, rename_tac x, case_tac x, simp)
-     apply (erule state_bits_to_policy.cases)
+  "\<lbrakk> invs s; pas_refined aag s; pas_cur_domain aag s; \<forall>x\<in> set (retype_addrs ptr ty n us). is_subject aag x \<rbrakk>
+   \<Longrightarrow> pas_refined aag s'"
+  apply (erule pas_refined_subsets_tcb_domain_map_wellformed)
+      apply (simp add: state_objs_to_policy_def refs_eq vrefs_eq mdb_and_revokable)
+      apply (rule subsetI, rename_tac x, case_tac x, simp)
+      apply (erule state_bits_to_policy.cases)
             apply (solves \<open>auto intro!: sbta_caps intro: caps_retype split: cap.split\<close>)
            apply (solves \<open>auto intro!: sbta_untyped intro: caps_retype split: cap.split\<close>)
           apply (blast intro: state_bits_to_policy.intros)
@@ -57,7 +74,7 @@ lemma pas_refined:
     apply clarsimp
     apply (erule state_irqs_to_policy_aux.cases)
     apply (solves\<open>auto intro!: sita_controlled intro: caps_retype split: cap.split\<close>)
-   apply (rule domains_of_state)
+   apply (erule (2) tcb_domain_map_wellformed)
   apply simp
   done
 
@@ -427,7 +444,7 @@ lemma retype_region_integrity_asids[Retype_AC_assms]:
      \<forall>x\<in>up_aligned_area ptr sz. is_subject aag x; integrity_asids aag {pasSubject aag} x a s st \<rbrakk>
      \<Longrightarrow> integrity_asids aag {pasSubject aag} x a s
            (st\<lparr>kheap := \<lambda>a. if a \<in> (\<lambda>x. ptr_add ptr (x * 2 ^ obj_bits_api typ o_bits)) ` {0 ..< n}
-                            then Some (default_object typ dev o_bits)
+                            then Some (default_object typ dev o_bits d)
                             else kheap s a\<rparr>)"
   by clarsimp
 

--- a/proof/access-control/ARM/ArchTcb_AC.thy
+++ b/proof/access-control/ARM/ArchTcb_AC.thy
@@ -32,14 +32,12 @@ lemma invoke_tcb_tc_respects_aag[Tcb_AC_assms]:
   apply (rule hoare_gen_asm)+
   apply (subst invoke_tcb.simps)
   apply (subst option_update_thread_def)
-  apply (subst set_priority_extended.dxo_eq)
   apply (rule hoare_weaken_pre)
    apply (rule_tac P="case ep of Some v \<Rightarrow> length v = word_bits | _ \<Rightarrow> True"
                  in hoare_gen_asm)
    apply (simp only: split_def)
    apply (((simp add: conj_comms,
            strengthen imp_consequent[where Q="x = None" for x], simp cong: conj_cong)
-          | strengthen invs_psp_aligned invs_vspace_objs invs_arch_state
           | rule wp_split_const_if wp_split_const_if_R hoare_vcg_all_liftE_R
                  hoare_vcg_conj_elimE hoare_vcg_const_imp_liftE_R hoare_vcg_conj_liftE_R
           | wp restart_integrity_autarch set_mcpriority_integrity_autarch
@@ -79,7 +77,8 @@ lemma invoke_tcb_tc_respects_aag[Tcb_AC_assms]:
           | simp add: ran_tcb_cap_cases dom_tcb_cap_cases[simplified]
                       emptyable_def a_type_def partial_inv_def
           | wpc
-          | strengthen invs_mdb use_no_cap_to_obj_asid_strg
+          | strengthen invs_psp_aligned invs_vspace_objs invs_arch_state
+                       invs_mdb use_no_cap_to_obj_asid_strg
                        tcb_cap_always_valid_strg[where p="tcb_cnode_index 0"]
                        tcb_cap_always_valid_strg[where p="tcb_cnode_index (Suc 0)"]))+
   apply (clarsimp simp: authorised_tcb_inv_def)

--- a/proof/access-control/Access.thy
+++ b/proof/access-control/Access.thy
@@ -246,15 +246,16 @@ unauthorised subjects (see integrity_ready_queues).
 
 \<close>
 
-inductive_set domains_of_state_aux for ekheap where
+\<comment> \<open>FIXME: should this be etcbs_of instead of kheap?\<close>
+inductive_set domains_of_state_aux for etcbs_of where
   domtcbs:
-    "\<lbrakk> ekheap ptr = Some etcb; d = tcb_domain etcb \<rbrakk> \<Longrightarrow> (ptr, d) \<in> domains_of_state_aux ekheap"
+    "\<lbrakk> etcbs_of ptr = Some tcb; d = etcb_domain tcb \<rbrakk> \<Longrightarrow> (ptr, d) \<in> domains_of_state_aux etcbs_of"
 
-abbreviation "domains_of_state s \<equiv> domains_of_state_aux (ekheap s)"
+abbreviation "domains_of_state s \<equiv> domains_of_state_aux (etcbs_of s)"
 
 definition tcb_domain_map_wellformed_aux where
-  "tcb_domain_map_wellformed_aux aag etcbs_doms \<equiv>
-     \<forall>(ptr, d) \<in> etcbs_doms. pasObjectAbs aag ptr \<in> pasDomainAbs aag d"
+  "tcb_domain_map_wellformed_aux aag tcbs_doms \<equiv>
+     \<forall>(ptr, d) \<in> tcbs_doms. pasObjectAbs aag ptr \<in> pasDomainAbs aag d"
 
 abbreviation tcb_domain_map_wellformed where
   "tcb_domain_map_wellformed aag s \<equiv> tcb_domain_map_wellformed_aux aag (domains_of_state s)"
@@ -660,7 +661,7 @@ inductive integrity_obj_alt for aag activate subjects l' ko ko' where
        \<Longrightarrow> integrity_obj_alt aag activate subjects l' ko ko'"
 
 
-subsubsection \<open>ekheap and ready queues\<close>
+subsubsection \<open>ready queues\<close>
 
 text\<open>
 
@@ -678,10 +679,6 @@ text\<open>
 definition integrity_ready_queues where
   "integrity_ready_queues aag subjects queue_labels rq rq' \<equiv>
      pasMayEditReadyQueues aag \<or> (queue_labels \<inter> subjects = {} \<longrightarrow> (\<exists>threads. threads @ rq = rq'))"
-
-inductive integrity_eobj for aag subjects l' eko eko' where
-  tre_lrefl: "l' \<in> subjects \<Longrightarrow> integrity_eobj aag subjects l' eko eko'"
-| tre_orefl: "eko = eko' \<Longrightarrow> integrity_eobj aag subjects l' eko eko'"
 
 
 abbreviation object_integrity where
@@ -846,7 +843,6 @@ definition integrity_subjects ::
   "'a set \<Rightarrow> 'a PAS \<Rightarrow> bool \<Rightarrow> obj_ref set \<Rightarrow> det_ext state \<Rightarrow> det_ext state \<Rightarrow> bool" where
   "integrity_subjects subjects aag activate X s s' \<equiv>
      (\<forall>x. integrity_obj aag activate subjects (pasObjectAbs aag x) (kheap s x) (kheap s' x))
-   \<and> (\<forall>x. integrity_eobj aag subjects (pasObjectAbs aag x) (ekheap s x) (ekheap s' x))
    \<and> integrity_cdt_state aag subjects s s'
    \<and> integrity_cdt_list_state aag subjects s s'
    \<and> (\<forall>x. integrity_interrupts aag subjects x (interrupt_irq_node s x, interrupt_states s x)

--- a/proof/access-control/Access_AC.thy
+++ b/proof/access-control/Access_AC.thy
@@ -228,7 +228,7 @@ lemma is_transferable_null_filter[simp]:
 lemma tcb_domain_map_wellformed_mono:
   "\<lbrakk> domains_of_state s' \<subseteq> domains_of_state s; tcb_domain_map_wellformed pas s \<rbrakk>
      \<Longrightarrow> tcb_domain_map_wellformed pas s'"
-  by (auto simp: tcb_domain_map_wellformed_aux_def get_etcb_def)
+  by (auto simp: tcb_domain_map_wellformed_aux_def)
 
 lemma pas_refined_mem:
   "\<lbrakk> (x, auth, y) \<in> state_objs_to_policy s; pas_refined aag s \<rbrakk>
@@ -460,8 +460,6 @@ lemmas integrity_obj_simps [simp] =
   tro_lrefl[OF singletonI]
   trm_orefl[OF refl]
   trd_orefl[OF refl]
-  tre_lrefl[OF singletonI]
-  tre_orefl[OF refl]
 
 lemma cdt_change_allowedI:
   "\<lbrakk> m \<Turnstile> pptr \<rightarrow>* ptr; cdt_direct_change_allowed aag subjects tcbsts pptr \<rbrakk>
@@ -680,12 +678,6 @@ lemma tro_trans:
   apply clarsimp
   apply (drule_tac x = x in spec)+
   by force
-
-lemma tre_trans:
-  "\<lbrakk> (\<forall>x. integrity_eobj aag es (pasObjectAbs aag x) (ekh x) (ekh' x));
-     (\<forall>x. integrity_eobj aag es (pasObjectAbs aag x) (ekh' x) (ekh'' x)) \<rbrakk>
-     \<Longrightarrow> (\<forall>x. integrity_eobj aag es (pasObjectAbs aag x) (ekh x) (ekh'' x))"
-  by (fastforce elim!: integrity_eobj.cases intro: integrity_eobj.intros)
 
 
 subsection \<open>Integrity transitivity\<close>
@@ -968,7 +960,6 @@ proof -
     apply (frule(3) trcdtlist_trans)
     apply (frule(1) trinterrupts_trans[simplified])
     apply (frule(1) trasids_trans[simplified])
-    apply (frule(1) tre_trans[simplified])
     apply (frule(1) trrqs_trans[simplified])
     by blast
 qed
@@ -1024,15 +1015,13 @@ context Access_AC_2 begin
 
 lemma eintegrity_sa_update[simp]:
   "integrity aag X st (scheduler_action_update f s) = integrity aag X st s"
-  by (simp add: integrity_subjects_def)
+  by (auto simp add: integrity_subjects_def )
 
 lemma trans_state_back[simp]:
   "trans_state (\<lambda>_. exst s) s = s"
   by simp
 
-declare wrap_ext_op_det_ext_ext_def[simp]
-
-crunch set_thread_state_ext
+crunch set_thread_state_act
   for integrity[wp]: "integrity aag X st"
 
 crunch set_thread_state
@@ -1271,7 +1260,7 @@ lemma as_user_thread_bound_ntfn[wp]:
   done
 
 lemma tcb_domain_map_wellformed_lift:
-  assumes 1: "\<And>P. f \<lbrace>\<lambda>s. P (ekheap s)\<rbrace>"
+  assumes 1: "\<And>P. f \<lbrace>\<lambda>s. P (etcbs_of s)\<rbrace>"
   shows "f \<lbrace>tcb_domain_map_wellformed aag\<rbrace>"
   by (rule 1)
 
@@ -1534,10 +1523,6 @@ lemma integrity_mono:
                elim: reply_cap_deletion_integrity_mono cnode_integrity_mono
                      arch_integrity_obj_atomic_mono)[1]
   apply (rule conjI)
-   apply clarsimp
-   apply (drule_tac x=x in spec)+
-   apply (erule integrity_eobj.cases; auto intro: integrity_eobj.intros)
-  apply (rule conjI)
    apply (intro allI)
    apply (drule_tac x=x in spec)+
    apply (erule integrity_cdtE; auto elim: cdt_change_allowed_mono)
@@ -1576,7 +1561,7 @@ lemma tcb_domain_map_wellformed_independent[intro!, simp]:
   "tcb_domain_map_wellformed aag (s\<lparr>machine_state :=
                                     machine_state s\<lparr>irq_state := f (irq_state (machine_state s))\<rparr>\<rparr>) =
    tcb_domain_map_wellformed aag s"
-  by (simp add: tcb_domain_map_wellformed_aux_def get_etcb_def)
+  by (simp add: tcb_domain_map_wellformed_aux_def)
 
 subsection\<open>Transitivity of integrity lemmas and tactics\<close>
 

--- a/proof/access-control/CNode_AC.thy
+++ b/proof/access-control/CNode_AC.thy
@@ -25,9 +25,9 @@ section\<open>CNode-specific AC.\<close>
 
 
 (* FIXME: Move. *)
-lemma tcb_domain_map_wellformed_ekheap[intro!, simp]:
-  "ekheap (P s) = ekheap s \<Longrightarrow> tcb_domain_map_wellformed aag (P s) = tcb_domain_map_wellformed aag s"
-  by (simp add: tcb_domain_map_wellformed_aux_def get_etcb_def)
+lemma tcb_domain_map_wellformed_etcbs_of[intro!, simp]:
+  "etcbs_of (P s) = etcbs_of s \<Longrightarrow> tcb_domain_map_wellformed aag (P s) = tcb_domain_map_wellformed aag s"
+  by (simp add: tcb_domain_map_wellformed_aux_def)
 
 (* FIXME: for some reason crunch does not discover the right precondition *)
 lemma set_cap_integrity_autarch:
@@ -38,10 +38,6 @@ lemma integrity_cdt_list_as_list_integ:
   "cdt_list_integrity_state aag st s =
    list_integ (cdt_change_allowed aag {pasSubject aag} (cdt st) (tcb_states_of_state st)) st s"
   by (fastforce elim: integrity_cdt_listE list_integE intro: list_integI integrity_cdt_list_intros)
-
-crunch cap_swap_ext,cap_move_ext,empty_slot_ext
-  for ekheap[wp]: "\<lambda>s. P (ekheap s)"
-  and ready_queues[wp]: "\<lambda>s. P (ready_queues s)"
 
 crunch set_untyped_cap_as_full
   for integrity_autarch: "integrity aag X st"
@@ -78,19 +74,19 @@ locale CNode_AC_1 =
   and set_cap_state_vrefs:
     "\<And>P. \<lbrace>pspace_aligned and valid_vspace_objs and valid_arch_state and (\<lambda>s. P (state_vrefs s))\<rbrace>
           set_cap cap slot
-          \<lbrace>\<lambda>_ s :: det_ext state. P (state_vrefs s)\<rbrace>"
+          \<lbrace>\<lambda>_ s :: det_state. P (state_vrefs s)\<rbrace>"
   and set_cdt_state_vrefs[wp]:
-    "\<And>P. set_cdt t \<lbrace>\<lambda>s :: det_ext state. P (state_vrefs s)\<rbrace>"
+    "\<And>P. set_cdt t \<lbrace>\<lambda>s :: det_state. P (state_vrefs s)\<rbrace>"
   and set_cdt_state_asids_to_policy[wp]:
-    "\<And>P. set_cdt t \<lbrace>\<lambda>s. P (state_asids_to_policy aag s)\<rbrace>"
+    "\<And>P. set_cdt t \<lbrace>\<lambda>s::det_state. P (state_asids_to_policy aag s)\<rbrace>"
   and arch_post_cap_deletion_integrity[wp]:
     "arch_post_cap_deletion acap \<lbrace>integrity aag X st\<rbrace>"
   and arch_post_cap_deletion_cur_domain[wp]:
-    "\<And>P. arch_post_cap_deletion acap \<lbrace>\<lambda>s. P (cur_domain s)\<rbrace>"
+    "\<And>P. arch_post_cap_deletion acap \<lbrace>\<lambda>s::det_state. P (cur_domain s)\<rbrace>"
   and arch_finalise_cap_cur_domain:
-    "\<And>P. arch_finalise_cap acap final \<lbrace>\<lambda>s. P (cur_domain s)\<rbrace>"
+    "\<And>P. arch_finalise_cap acap final \<lbrace>\<lambda>s::det_state. P (cur_domain s)\<rbrace>"
   and prepare_thread_delete_cur_domain:
-    "\<And>P. prepare_thread_delete p \<lbrace>\<lambda>s. P (cur_domain s)\<rbrace>"
+    "\<And>P. prepare_thread_delete p \<lbrace>\<lambda>s::det_state. P (cur_domain s)\<rbrace>"
   and maskInterrupt_underlying_memory[wp]:
     "\<And>P. maskInterrupt m irq \<lbrace>\<lambda>s. P (underlying_memory s)\<rbrace>"
   and maskInterrupt_device_state[wp]:
@@ -99,29 +95,25 @@ locale CNode_AC_1 =
     "\<And>Q a b c d e.
      \<lbrakk> \<lbrace>list_integ (cdt_change_allowed aag {pasSubject aag} (cdt st) (tcb_states_of_state st)) st and Q\<rbrace>
        cap_insert_ext a b c d e
-       \<lbrace>\<lambda>_. list_integ (cdt_change_allowed aag {pasSubject aag} (cdt st) (tcb_states_of_state st)) st\<rbrace>;
-       \<And>P. cap_insert_ext a b c d e \<lbrace>\<lambda>s. P (ekheap s)\<rbrace>; \<And>P. cap_insert_ext a b c d e \<lbrace>\<lambda>s. P (ready_queues s)\<rbrace> \<rbrakk>
+       \<lbrace>\<lambda>_. list_integ (cdt_change_allowed aag {pasSubject aag} (cdt st) (tcb_states_of_state st)) st\<rbrace> \<rbrakk>
        \<Longrightarrow> \<lbrace>integrity aag X st and Q\<rbrace> cap_insert_ext a b c d e \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   and cap_move_ext_list_integ_lift:
     "\<And>Q a b c d.
      \<lbrakk> \<lbrace>list_integ (cdt_change_allowed aag {pasSubject aag} (cdt st) (tcb_states_of_state st)) st and Q\<rbrace>
        cap_move_ext a b c d
-       \<lbrace>\<lambda>_. list_integ (cdt_change_allowed aag {pasSubject aag} (cdt st) (tcb_states_of_state st)) st\<rbrace>;
-       \<And>P. cap_move_ext a b c d \<lbrace>\<lambda>s. P (ekheap s)\<rbrace>; \<And>P. cap_move_ext a b c d \<lbrace>\<lambda>s. P (ready_queues s)\<rbrace> \<rbrakk>
+       \<lbrace>\<lambda>_. list_integ (cdt_change_allowed aag {pasSubject aag} (cdt st) (tcb_states_of_state st)) st\<rbrace> \<rbrakk>
        \<Longrightarrow> \<lbrace>integrity aag X st and Q\<rbrace> cap_move_ext a b c d \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   and cap_swap_ext_extended_list_integ_lift:
     "\<And>Q a b c d.
      \<lbrakk> \<lbrace>list_integ (cdt_change_allowed aag {pasSubject aag} (cdt st) (tcb_states_of_state st)) st and Q\<rbrace>
        cap_swap_ext a b c d
-       \<lbrace>\<lambda>_. list_integ (cdt_change_allowed aag {pasSubject aag} (cdt st) (tcb_states_of_state st)) st\<rbrace>;
-       \<And>P. cap_swap_ext a b c d \<lbrace>\<lambda>s. P (ekheap s)\<rbrace>; \<And>P. cap_swap_ext a b c d \<lbrace>\<lambda>s. P (ready_queues s)\<rbrace> \<rbrakk>
+       \<lbrace>\<lambda>_. list_integ (cdt_change_allowed aag {pasSubject aag} (cdt st) (tcb_states_of_state st)) st\<rbrace> \<rbrakk>
        \<Longrightarrow> \<lbrace>integrity aag X st and Q\<rbrace> cap_swap_ext a b c d \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   and empty_slot_extended_list_integ_lift:
     "\<And>Q a b.
      \<lbrakk> \<lbrace>list_integ (cdt_change_allowed aag {pasSubject aag} (cdt st) (tcb_states_of_state st)) st and Q\<rbrace>
        empty_slot_ext a b
-       \<lbrace>\<lambda>_. list_integ (cdt_change_allowed aag {pasSubject aag} (cdt st) (tcb_states_of_state st)) st\<rbrace>;
-       \<And>P. empty_slot_ext a b \<lbrace>\<lambda>s. P (ekheap s)\<rbrace>; \<And>P. empty_slot_ext a b \<lbrace>\<lambda>s. P (ready_queues s)\<rbrace> \<rbrakk>
+       \<lbrace>\<lambda>_. list_integ (cdt_change_allowed aag {pasSubject aag} (cdt st) (tcb_states_of_state st)) st\<rbrace> \<rbrakk>
        \<Longrightarrow> \<lbrace>integrity aag X st and Q\<rbrace> empty_slot_ext a b \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
 begin
 
@@ -915,17 +907,12 @@ lemma set_cdt_pas_refined:
               split: if_split_asm | blast)+
   done
 
-lemma pas_refined_original_cap_update[simp]:
-  "pas_refined aag (is_original_cap_update f s) = pas_refined aag s"
-  by (simp add: pas_refined_def state_objs_to_policy_def)
-
-lemma pas_refined_machine_state_update[simp]:
-  "pas_refined aag (machine_state_update f s) = pas_refined aag s"
-  by (simp add: pas_refined_def state_objs_to_policy_def state_refs_of_def)
-
-lemma pas_refined_interrupt_states_update[simp]:
-  "pas_refined aag (interrupt_states_update f s) = pas_refined aag s"
-  by (simp add: pas_refined_def state_objs_to_policy_def state_refs_of_def)
+lemma pas_refined_updates[simp]:
+  "\<And>f. pas_refined aag (is_original_cap_update f s) = pas_refined aag s"
+  "\<And>f. pas_refined aag (machine_state_update f s) = pas_refined aag s"
+  "\<And>f. pas_refined aag (interrupt_states_update f s) = pas_refined aag s"
+  "\<And>f. pas_refined aag (ready_queues_update f s) = pas_refined aag s"
+  by (simp add: pas_refined_def state_objs_to_policy_def)+
 
 crunch deleted_irq_handler
   for pas_refined[wp]: "pas_refined aag"
@@ -947,10 +934,14 @@ lemma update_cdt_pas_refined:
   apply simp
   done
 
+\<comment> \<open>FIXME: move\<close>
 lemma state_objs_to_policy_more_update[simp]:
-  "state_objs_to_policy (trans_state f s) =
-   state_objs_to_policy s"
-  by (simp add: state_objs_to_policy_def)
+  "\<And>f. state_objs_to_policy (trans_state f s) = state_objs_to_policy s"
+  "\<And>f. state_objs_to_policy (scheduler_action_update f s) = state_objs_to_policy s"
+  "\<And>f. state_objs_to_policy (domain_index_update f s) = state_objs_to_policy s"
+  "\<And>f. state_objs_to_policy (cur_domain_update f s) = state_objs_to_policy s"
+  "\<And>f. state_objs_to_policy (domain_time_update f s) = state_objs_to_policy s"
+  by (simp add: state_objs_to_policy_def)+
 
 end
 
@@ -1224,11 +1215,16 @@ lemma mapM_mapM_x_valid:
   "\<lbrace>P\<rbrace> mapM_x f xs \<lbrace>\<lambda>rv. Q\<rbrace> = \<lbrace>P\<rbrace> mapM f xs \<lbrace>\<lambda>rv. Q\<rbrace>"
   by (simp add: mapM_x_mapM liftM_def[symmetric] hoare_liftM_subst)
 
+\<comment> \<open>FIXME: move to ainvs\<close>
+lemma set_thread_state_act_scheduler_action_lift:
+  "\<lbrakk>\<And>f s. P (scheduler_action_update f s) = P s\<rbrakk> \<Longrightarrow> set_thread_state_act t \<lbrace>P\<rbrace>"
+  apply (simp add: set_thread_state_act_def set_scheduler_action_def)
+  by (wpsimp wp: gts_wp)
 
 lemma sts_thread_bound_ntfns[wp]:
   "set_thread_state t st \<lbrace>\<lambda>s. P (thread_bound_ntfns s)\<rbrace>"
   apply (simp add: set_thread_state_def)
-  apply (wpsimp wp: set_object_wp dxo_wp_weak)
+  apply (wpsimp wp: set_object_wp set_thread_state_act_scheduler_action_lift)
   apply (clarsimp simp: thread_bound_ntfns_def get_tcb_def
                  split: if_split option.splits kernel_object.splits
                  elim!: rsubst[where P=P, OF _ ext])
@@ -1239,7 +1235,7 @@ lemma sts_thread_st_auth[wp]:
    set_thread_state t st
    \<lbrace>\<lambda>_ s. P (thread_st_auth s)\<rbrace>"
   apply (simp add: set_thread_state_def)
-  apply (wpsimp wp: set_object_wp dxo_wp_weak)
+  apply (wpsimp wp: set_object_wp set_thread_state_act_scheduler_action_lift)
   apply (clarsimp simp: get_tcb_def thread_st_auth_def tcb_states_of_state_def
                  elim!: rsubst[where P=P, OF _ ext])
   done
@@ -1249,16 +1245,9 @@ lemma sbn_thread_bound_ntfns[wp]:
    set_bound_notification t ntfn
    \<lbrace>\<lambda>_ s. P (thread_bound_ntfns s)\<rbrace>"
   apply (simp add: set_bound_notification_def)
-  apply (wpsimp wp: set_object_wp dxo_wp_weak)
+  apply (wpsimp wp: set_object_wp)
   apply (clarsimp simp: get_tcb_def thread_bound_ntfns_def
                  elim!: rsubst[where P=P, OF _ ext])
-  done
-
-(* FIXME move to AInvs *)
-lemma set_thread_state_ekheap[wp]:
-  "set_thread_state t st \<lbrace>\<lambda>s. P (ekheap s)\<rbrace>"
-  apply (simp add: set_thread_state_def)
-  apply (wpsimp wp: set_scheduler_action_wp simp: set_thread_state_ext_def)
   done
 
 lemma set_simple_ko_tcb_states_of_state[wp]:
@@ -1294,13 +1283,6 @@ lemma set_simple_ko_thread_bound_ntfns[wp]:
                  split: kernel_object.split_asm if_splits)
   done
 
-(* FIXME move to AInvs *)
-lemma set_simple_ko_ekheap[wp]:
-  "set_simple_ko f ptr ep \<lbrace>\<lambda>s. P (ekheap s)\<rbrace>"
-  apply (simp add: set_simple_ko_def)
-  apply (wpsimp wp: get_object_wp)
-  done
-
 
 context CNode_AC_3 begin
 
@@ -1308,8 +1290,8 @@ lemma sts_st_vrefs[wp]:
   "\<lbrace>pspace_aligned and valid_vspace_objs and valid_arch_state and (\<lambda>s. P (state_vrefs s))\<rbrace>
    set_thread_state t st
    \<lbrace>\<lambda>_ s :: det_ext state. P (state_vrefs s)\<rbrace>"
-  apply (simp add: set_thread_state_def del: set_thread_state_ext_extended.dxo_eq)
-  apply (wpsimp wp: set_object_wp dxo_wp_weak)
+  apply (simp add: set_thread_state_def )
+  apply (wpsimp wp: set_object_wp set_thread_state_act_scheduler_action_lift)
   apply (clarsimp simp: state_vrefs_tcb_upd obj_at_def is_obj_defs
                  elim!: rsubst[where P=P, OF _ ext]
                  dest!: get_tcb_SomeD)
@@ -1383,19 +1365,39 @@ lemma thread_set_thread_bound_ntfns_trivT:
 
 context CNode_AC_3 begin
 
+\<comment> \<open>FIXME: move\<close>
+\<comment> \<open>FIXME: horrible proof, domains_of_state_aux could maybe be (etcbs_of s ||> etcb_domain) directly\<close>
+lemma tcb_domain_map_wellformed_lift_strong:
+  assumes 1: "\<And>P. f \<lbrace>\<lambda>s. P (etcbs_of s ||> etcb_domain)\<rbrace>"
+  shows "f \<lbrace>tcb_domain_map_wellformed aag\<rbrace>"
+  apply (clarsimp simp: valid_def  elim!: tcb_domain_map_wellformed_mono[rotated] domains_of_state_aux.cases)
+  apply (subgoal_tac "(etcbs_of s ||> etcb_domain) ptr = Some (etcb_domain tcb)")
+   apply (auto simp: in_opt_map_Some_eq intro!: domtcbs)[1]
+  apply (rule ccontr)
+  apply (frule (1) use_valid[OF _ 1], fastforce simp: in_opt_map_Some_eq)
+  done
+
+lemma thread_set_edomains:
+  "\<lbrakk>\<And>x. tcb_domain (f x) = tcb_domain x\<rbrakk> \<Longrightarrow>
+  thread_set f tptr \<lbrace>\<lambda>s. P (etcbs_of s ||> etcb_domain)\<rbrace>"
+  unfolding thread_set_def
+  apply (wpsimp wp: set_object_wp get_object_wp)
+  by (auto elim!: rsubst[where P=P] dest!: get_tcb_SomeD simp: etcbs_of'_def opt_map_def)
+
 lemma thread_set_pas_refined_triv:
   assumes cps: "\<And>tcb. \<forall>(getF, v)\<in>ran tcb_cap_cases. getF (f tcb) = getF tcb"
        and st: "\<And>tcb. tcb_state (f tcb) = tcb_state tcb"
       and ntfn: "\<And>tcb. tcb_bound_notification (f tcb) = tcb_bound_notification tcb"
+       and dom: "\<And>tcb. tcb_domain (f tcb) = tcb_domain tcb"
      shows "\<lbrace>pas_refined aag and pspace_aligned and valid_vspace_objs and valid_arch_state\<rbrace>
             thread_set f t \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
-  by (wpsimp wp: tcb_domain_map_wellformed_lift thread_set_state_vrefs
+  by (wpsimp wp: tcb_domain_map_wellformed_lift_strong thread_set_state_vrefs thread_set_edomains[OF dom]
            simp: pas_refined_def state_objs_to_policy_def
       | wps thread_set_caps_of_state_trivial[OF cps]
             thread_set_thread_st_auth_trivT[OF st]
             thread_set_thread_bound_ntfns_trivT[OF ntfn])+
 
-lemmas thread_set_pas_refined = thread_set_pas_refined_triv[OF ball_tcb_cap_casesI]
+lemmas thread_set_pas_refined = thread_set_pas_refined_triv[OF ball_tcb_cap_casesI, simplified]
 
 end
 
@@ -1521,7 +1523,7 @@ crunch deleted_irq_handler
   for cur_domain[wp]: "\<lambda>s. P (cur_domain s)"
 
 lemma preemption_point_cur_domain[wp]:
-  "preemption_point \<lbrace>\<lambda>s. P (cur_domain s)\<rbrace>"
+  "preemption_point \<lbrace>\<lambda>s::det_state. P (cur_domain s)\<rbrace>"
   by (wp preemption_point_inv', simp+)
 
 lemma cnode_inv_auth_derivations_If_Insert_Move:
@@ -1533,26 +1535,26 @@ lemma cnode_inv_auth_derivations_If_Insert_Move:
 context CNode_AC_3 begin
 
 lemma post_cap_deletion_cur_domain[wp]:
-  "post_cap_deletion c \<lbrace>\<lambda>s. P (cur_domain s)\<rbrace>"
+  "post_cap_deletion c \<lbrace>\<lambda>s::det_state. P (cur_domain s)\<rbrace>"
   by (wpsimp simp: post_cap_deletion_def)
 
 crunch cap_swap_for_delete, empty_slot
-  for cur_domain[wp]: "\<lambda>s. P (cur_domain s)"
+  for cur_domain[wp]: "\<lambda>s::det_state. P (cur_domain s)"
   (wp: crunch_wps hoare_vcg_if_lift2 simp: unless_def)
 
 crunch finalise_cap
-  for cur_domain[wp]: "\<lambda>s. P (cur_domain s)"
+  for cur_domain[wp]: "\<lambda>s::det_state. P (cur_domain s)"
   (wp: crunch_wps hoare_vcg_if_lift2 simp: unless_def)
 
 lemma rec_del_cur_domain[wp]:
-  "rec_del call \<lbrace>\<lambda>s. P (cur_domain s)\<rbrace>"
+  "rec_del call \<lbrace>\<lambda>s::det_state. P (cur_domain s)\<rbrace>"
   by (rule rec_del_preservation; wp)
 
 crunch cap_delete
-  for cur_domain[wp]: "\<lambda>s. P (cur_domain s)"
+  for cur_domain[wp]: "\<lambda>s::det_state. P (cur_domain s)"
 
 lemma cap_revoke_cur_domain[wp]:
-  "cap_revoke slot \<lbrace>\<lambda>s. P (cur_domain s)\<rbrace>"
+  "cap_revoke slot \<lbrace>\<lambda>s::det_state. P (cur_domain s)\<rbrace>"
   by (rule cap_revoke_preservation2; wp)
 
 end

--- a/proof/access-control/DomainSepInv.thy
+++ b/proof/access-control/DomainSepInv.thy
@@ -106,13 +106,18 @@ lemma domain_sep_inv_triv:
   apply (rule cte_pres, rule irq_pres)
   done
 
-lemma domain_sep_inv_arch_state_update[simp]:
-  "domain_sep_inv irqs st (s\<lparr>arch_state := blah\<rparr>) = domain_sep_inv irqs st s"
-  by (simp add: domain_sep_inv_def)
-
-lemma domain_sep_inv_machine_state_update[simp]:
-  "domain_sep_inv irqs st (s\<lparr>machine_state := X\<rparr>) = domain_sep_inv irqs st s"
-  by (simp add: domain_sep_inv_def)
+lemma domain_sep_inv_updates[simp]:
+  "\<And>f. domain_sep_inv irqs st (trans_state f s) = domain_sep_inv irqs st s"
+  "\<And>f. domain_sep_inv irqs st (arch_state_update f s) = domain_sep_inv irqs st s"
+  "\<And>f. domain_sep_inv irqs st (machine_state_update f s) = domain_sep_inv irqs st s"
+  "\<And>f. domain_sep_inv irqs st (is_original_cap_update f s) = domain_sep_inv irqs st s"
+  "\<And>f. domain_sep_inv irqs st (cdt_update f s) = domain_sep_inv irqs st s"
+  "\<And>f. domain_sep_inv irqs st (scheduler_action_update f s) = domain_sep_inv irqs st s"
+  "\<And>f. domain_sep_inv irqs st (domain_index_update f s) = domain_sep_inv irqs st s"
+  "\<And>f. domain_sep_inv irqs st (cur_domain_update f s) = domain_sep_inv irqs st s"
+  "\<And>f. domain_sep_inv irqs st (domain_time_update f s) = domain_sep_inv irqs st s"
+  "\<And>f. domain_sep_inv irqs st (ready_queues_update f s) = domain_sep_inv irqs st s"
+  by (simp add: domain_sep_inv_def)+
 
 lemma detype_interrupts_states[simp]:
   "interrupt_states (detype S s) = interrupt_states s"
@@ -254,18 +259,6 @@ lemma cte_wp_at_is_derived_domain_sep_inv_cap:
                    dest: cte_wp_at_norm DomainCap_is_derived is_derived_IRQHandlerCap)
   done
 
-lemma domain_sep_inv_exst_update[simp]:
-  "domain_sep_inv irqs st (trans_state f s) = domain_sep_inv irqs st s"
-  by (simp add: domain_sep_inv_def)
-
-lemma domain_sep_inv_is_original_cap_update[simp]:
-  "domain_sep_inv irqs st (s\<lparr>is_original_cap := X\<rparr>) = domain_sep_inv irqs st s"
-  by (simp add: domain_sep_inv_def)
-
-lemma domain_sep_inv_cdt_update[simp]:
-  "domain_sep_inv irqs st (s\<lparr>cdt := X\<rparr>) = domain_sep_inv irqs st s"
-  by (simp add: domain_sep_inv_def)
-
 crunch update_cdt
   for domain_sep_inv[wp]: "domain_sep_inv irqs st"
 
@@ -358,10 +351,13 @@ crunch set_simple_ko
   for domain_sep_inv[wp]: "domain_sep_inv irqs st"
   (wp: domain_sep_inv_triv)
 
+crunch set_thread_state_act
+  for neg_cte_wp_at[wp]: "\<lambda>s. \<not> cte_wp_at P c s"
+
 lemma set_thread_state_neg_cte_wp_at[wp]:
   "set_thread_state a b \<lbrace>\<lambda>s. \<not> cte_wp_at P slot s\<rbrace>"
   apply (simp add: set_thread_state_def)
-  apply (wp set_object_wp get_object_wp dxo_wp_weak| simp)+
+  apply (wp set_object_wp get_object_wp | simp)+
   apply (case_tac "a = fst slot")
    apply (clarsimp split: kernel_object.splits)
    apply (erule notE)
@@ -396,26 +392,27 @@ crunch set_thread_state, set_bound_notification, get_bound_notification
   for domain_sep_inv[wp]: "domain_sep_inv irqs st"
   (wp: domain_sep_inv_triv)
 
-lemma thread_set_tcb_fault_update_neg_cte_wp_at[wp]:
-  "thread_set (tcb_fault_update blah) t \<lbrace>\<lambda>s. \<not> cte_wp_at P slot s\<rbrace>"
-  apply (simp add: thread_set_def)
-  apply (wp set_object_wp get_object_wp | simp)+
-  apply (case_tac "t = fst slot")
-   apply (clarsimp split: kernel_object.splits)
-   apply (erule notE)
-   apply (erule cte_wp_atE)
-    apply (fastforce simp: obj_at_def)
-   apply (drule get_tcb_SomeD)
-   apply (rule cte_wp_at_tcbI)
-     apply simp
-    apply assumption
-   apply (fastforce simp: tcb_cap_cases_def split: if_splits)
-  apply (fastforce elim: cte_wp_atE intro: cte_wp_at_cteI cte_wp_at_tcbI)
-  done
+lemma thread_set_domain_sep_inv_triv:
+  "\<lbrakk>\<And>tcb. \<forall>(getF, v) \<in> ran tcb_cap_cases. getF (f tcb) = getF tcb\<rbrakk>
+   \<Longrightarrow> thread_set f t \<lbrace>domain_sep_inv irqs st\<rbrace>"
+  by (wpsimp wp: domain_sep_inv_triv thread_set_cte_wp_at_trivial simp: ran_tcb_cap_cases)
 
-lemma thread_set_tcb_fault_update_domain_sep_inv[wp]:
-  "thread_set (tcb_fault_update blah) t \<lbrace>domain_sep_inv irqs st\<rbrace>"
-  by (wp domain_sep_inv_triv)
+lemmas thread_set_tcb_fault_update_domain_sep_inv[wp]
+  = thread_set_domain_sep_inv_triv[where f="tcb_fault_update f" for f, simplified ran_tcb_cap_cases, simplified]
+lemmas thread_set_tcb_ipc_buffer_update_domain_sep_inv[wp]
+  = thread_set_domain_sep_inv_triv[where f="tcb_ipc_buffer_update f" for f, simplified ran_tcb_cap_cases, simplified]
+lemmas thread_set_tcb_fault_handler_update_domain_sep_inv[wp]
+  = thread_set_domain_sep_inv_triv[where f="tcb_fault_handler_update f" for f, simplified ran_tcb_cap_cases, simplified]
+lemmas thread_set_tcb_mcpriority_update_domain_sep_inv[wp]
+  = thread_set_domain_sep_inv_triv[where f="tcb_mcpriority_update f" for f, simplified ran_tcb_cap_cases, simplified]
+lemmas thread_set_tcb_priority_update_domain_sep_inv[wp]
+  = thread_set_domain_sep_inv_triv[where f="tcb_priority_update f" for f, simplified ran_tcb_cap_cases, simplified]
+lemmas thread_set_tcb_time_slice_update_domain_sep_inv[wp]
+  = thread_set_domain_sep_inv_triv[where f="tcb_time_slice_update f" for f, simplified ran_tcb_cap_cases, simplified]
+lemmas thread_set_tcb_domain_update_domain_sep_inv[wp]
+  = thread_set_domain_sep_inv_triv[where f="tcb_domain_update f" for f, simplified ran_tcb_cap_cases, simplified]
+lemmas thread_set_tcb_registers_caps_merge_default_tcb_domain_sep_inv[wp]
+  = thread_set_domain_sep_inv_triv[where f="tcb_registers_caps_merge tcb" for tcb, simplified ran_tcb_cap_cases tcb_registers_caps_merge_def, simplified]
 
 crunch as_user
   for domain_sep_inv[wp]: "domain_sep_inv irqs st"
@@ -446,8 +443,8 @@ lemma reply_cancel_ipc_domain_sep_inv[wp]:
    \<lbrace>\<lambda>_ s. domain_sep_inv irqs  (st :: 'state_ext state) (s :: det_ext state)\<rbrace>"
   apply (simp add: reply_cancel_ipc_def)
   apply wp
-  apply (rule hoare_strengthen_post[OF thread_set_tcb_fault_update_domain_sep_inv])
-  apply auto
+   apply (rule hoare_strengthen_post[OF thread_set_tcb_fault_update_domain_sep_inv])
+   apply auto
   done
 
 crunch finalise_cap
@@ -589,31 +586,13 @@ lemma cte_wp_at_weak_derived_ReplyCap:
   apply auto
   done
 
-lemma thread_set_tcb_registers_caps_merge_default_tcb_neg_cte_wp_at[wp]:
-  "thread_set (tcb_registers_caps_merge default_tcb) word \<lbrace>\<lambda>s. \<not> cte_wp_at P slot s\<rbrace>"
-  unfolding thread_set_def
-  apply (wp set_object_wp | simp)+
-  apply (case_tac "word = fst slot")
-   apply (clarsimp split: kernel_object.splits)
-   apply (erule notE)
-   apply (erule cte_wp_atE)
-    apply (fastforce simp: obj_at_def)
-   apply (drule get_tcb_SomeD)
-   apply (rule cte_wp_at_tcbI)
-     apply simp
-    apply assumption
-   apply (clarsimp simp: tcb_cap_cases_def tcb_registers_caps_merge_def split: if_splits)
-  apply (fastforce elim: cte_wp_atE intro: cte_wp_at_cteI cte_wp_at_tcbI)
-  done
-
-lemma thread_set_tcb_registers_caps_merge_default_tcb_domain_sep_inv[wp]:
-  "thread_set (tcb_registers_caps_merge default_tcb) word \<lbrace>domain_sep_inv irqs st\<rbrace>"
-  by (wp domain_sep_inv_triv)
+crunch possible_switch_to
+  for domain_sep_inv[wp]: "domain_sep_inv irqs st"
 
 lemma cancel_badged_sends_domain_sep_inv[wp]:
   "cancel_badged_sends epptr badge \<lbrace>domain_sep_inv irqs st\<rbrace>"
   apply (simp add: cancel_badged_sends_def)
-  apply (wpsimp wp: dxo_wp_weak mapM_wp | simp add: filterM_mapM | wp (once) hoare_drop_imps)+
+  apply (wpsimp wp: mapM_wp | simp add: filterM_mapM | wp (once) hoare_drop_imps)+
   done
 
 lemma create_cap_domain_sep_inv[wp]:
@@ -934,76 +913,13 @@ lemma send_fault_ipc_domain_sep_inv:
 
 crunch do_reply_transfer, handle_fault, reply_from_kernel, restart
   for domain_sep_inv[wp]: "\<lambda>s. domain_sep_inv irqs (st :: 'state_ext state) (s :: det_ext state)"
-  (wp: handle_arch_fault_reply_domain_sep_inv dxo_wp_weak crunch_wps ignore: thread_set)
+  (wp: crunch_wps handle_arch_fault_reply_domain_sep_inv ignore: thread_set)
 
 end
 
 crunch setup_reply_master
   for domain_sep_inv[wp]: "domain_sep_inv irqs st"
   (wp: crunch_wps simp: crunch_simps)
-
-lemma thread_set_tcb_ipc_buffer_update_neg_cte_wp_at[wp]:
-  "thread_set (tcb_ipc_buffer_update f) t \<lbrace>\<lambda>s. \<not> cte_wp_at P slot s\<rbrace>"
-  unfolding thread_set_def
-  apply (wp set_object_wp | simp)+
-  apply (case_tac "t = fst slot")
-   apply (clarsimp split: kernel_object.splits)
-   apply (erule notE)
-   apply (erule cte_wp_atE)
-    apply (fastforce simp: obj_at_def)
-   apply (drule get_tcb_SomeD)
-   apply (rule cte_wp_at_tcbI)
-     apply simp
-    apply assumption
-   apply (fastforce simp: tcb_cap_cases_def split: if_splits)
-  apply (fastforce elim: cte_wp_atE intro: cte_wp_at_cteI cte_wp_at_tcbI)
-  done
-
-lemma thread_set_tcb_ipc_buffer_update_domain_sep_inv[wp]:
-  "thread_set (tcb_ipc_buffer_update f) t \<lbrace>domain_sep_inv irqs st\<rbrace>"
-  by (rule domain_sep_inv_triv; wp)
-
-lemma thread_set_tcb_fault_handler_update_neg_cte_wp_at[wp]:
-  "thread_set (tcb_fault_handler_update f) t \<lbrace>\<lambda>s. \<not> cte_wp_at P slot s\<rbrace>"
-  unfolding thread_set_def
-  apply (wp set_object_wp | simp)+
-  apply (case_tac "t = fst slot")
-   apply (clarsimp split: kernel_object.splits)
-   apply (erule notE)
-   apply (erule cte_wp_atE)
-    apply (fastforce simp: obj_at_def)
-   apply (drule get_tcb_SomeD)
-   apply (rule cte_wp_at_tcbI)
-     apply simp
-    apply assumption
-   apply (fastforce simp: tcb_cap_cases_def split: if_splits)
-  apply (fastforce elim: cte_wp_atE intro: cte_wp_at_cteI cte_wp_at_tcbI)
-  done
-
-lemma thread_set_tcb_fault_handler_update_domain_sep_inv[wp]:
-  "thread_set (tcb_fault_handler_update f) t \<lbrace>domain_sep_inv irqs st\<rbrace>"
-  by (rule domain_sep_inv_triv; wp)
-
-lemma thread_set_tcb_tcb_mcpriority_update_neg_cte_wp_at[wp]:
-  "thread_set (tcb_mcpriority_update f) t \<lbrace>\<lambda>s. \<not> cte_wp_at P slot s\<rbrace>"
-  unfolding thread_set_def
-  apply (wp set_object_wp | simp)+
-  apply (case_tac "t = fst slot")
-   apply (clarsimp split: kernel_object.splits)
-   apply (erule notE)
-   apply (erule cte_wp_atE)
-    apply (fastforce simp: obj_at_def)
-   apply (drule get_tcb_SomeD)
-   apply (rule cte_wp_at_tcbI)
-     apply simp
-    apply assumption
-   apply (fastforce simp: tcb_cap_cases_def split: if_splits)
-  apply (fastforce elim: cte_wp_atE intro: cte_wp_at_cteI cte_wp_at_tcbI)
-  done
-
-lemma thread_set_tcb_tcp_mcpriority_update_domain_sep_inv[wp]:
-  "thread_set (tcb_mcpriority_update f) t \<lbrace>domain_sep_inv irqs st\<rbrace>"
-  by (rule domain_sep_inv_triv; wp)
 
 lemma same_object_as_domain_sep_inv_cap:
   "\<lbrakk> same_object_as a cap; domain_sep_inv_cap irqs cap \<rbrakk>
@@ -1021,18 +937,9 @@ lemma checked_cap_insert_domain_sep_inv:
   apply (erule (1) same_object_as_domain_sep_inv_cap)
   done
 
-crunch bind_notification,reschedule_required
+crunch bind_notification, set_mcpriority, set_priority, invoke_domain
   for domain_sep_inv[wp]: "domain_sep_inv irqs st"
-
-lemma set_mcpriority_domain_sep_inv[wp]:
-  "set_mcpriority tcb_ref mcp \<lbrace>domain_sep_inv irqs st\<rbrace>"
-  unfolding set_mcpriority_def by wp
-
-lemma invoke_domain_domain_set_inv:
-  "invoke_domain word1 word2 \<lbrace>domain_sep_inv irqs st\<rbrace>"
-  apply (simp add: invoke_domain_def)
-  apply (wp dxo_wp_weak | simp)+
-  done
+  (ignore: thread_set)
 
 
 context DomainSepInv_2 begin
@@ -1053,11 +960,10 @@ lemma invoke_tcb_domain_sep_inv:
     apply (simp add: split_def cong: option.case_cong)
     apply (wp checked_cap_insert_domain_sep_inv hoare_vcg_all_liftE_R hoare_vcg_all_lift
               hoare_vcg_const_imp_liftE_R cap_delete_domain_sep_inv cap_delete_deletes
-              dxo_wp_weak cap_delete_valid_cap cap_delete_cte_at hoare_weak_lift_imp
+              cap_delete_valid_cap cap_delete_cte_at hoare_weak_lift_imp
            | wpc | strengthen
            | simp add: option_update_thread_def emptyable_def tcb_cap_cases_def
-                       tcb_cap_valid_def tcb_at_st_tcb_at
-                  del: set_priority_extended.dxo_eq)+
+                       tcb_cap_valid_def tcb_at_st_tcb_at)+
   done
 
 lemma perform_invocation_domain_sep_inv':
@@ -1069,7 +975,6 @@ lemma perform_invocation_domain_sep_inv':
            apply (wp send_ipc_domain_sep_inv invoke_tcb_domain_sep_inv
                      invoke_cnode_domain_sep_inv invoke_control_domain_sep_inv
                      invoke_irq_handler_domain_sep_inv arch_perform_invocation_domain_sep_inv
-                     invoke_domain_domain_set_inv
                   | simp add: split_def | blast)+
   done
 
@@ -1173,9 +1078,9 @@ lemma handle_recv_domain_sep_inv:
     apply (wp | simp add: invs_valid_objs invs_mdb invs_sym_refs tcb_at_invs)+
   done
 
-crunch handle_interrupt, activate_thread, choose_thread
+crunch handle_interrupt, activate_thread, choose_thread, handle_yield
   for domain_sep_inv[wp]: "\<lambda>s. domain_sep_inv irqs (st :: 'state_ext state) (s :: det_ext state)"
-  (wp: dxo_wp_weak crunch_wps)
+  (wp: crunch_wps ignore: thread_set)
 
 lemma handle_event_domain_sep_inv:
   "\<lbrace>domain_sep_inv irqs st and invs and (\<lambda>s. ev \<noteq> Interrupt \<longrightarrow> ct_active s)\<rbrace>
@@ -1184,7 +1089,7 @@ lemma handle_event_domain_sep_inv:
   apply (case_tac ev, simp_all)
       apply (rule hoare_pre)
        apply (wpsimp wp: handle_send_domain_sep_inv handle_call_domain_sep_inv
-                         handle_recv_domain_sep_inv handle_reply_domain_sep_inv hy_inv
+                         handle_recv_domain_sep_inv handle_reply_domain_sep_inv
               | simp add: invs_valid_objs invs_mdb invs_sym_refs valid_fault_def)+
      apply (rule_tac E'="\<lambda>rv s. domain_sep_inv irqs (st :: 'state_ext state) (s :: det_ext state) \<and>
                                 invs s \<and> valid_fault rv"
@@ -1193,11 +1098,14 @@ lemma handle_event_domain_sep_inv:
      apply (wp | simp add: invs_valid_objs invs_mdb invs_sym_refs valid_fault_def | auto)+
   done
 
+crunch next_domain
+  for domain_sep_inv[wp]: "domain_sep_inv irqs st"
+  (simp: crunch_simps)
+
 lemma schedule_domain_sep_inv:
   "(schedule :: (unit,det_ext) s_monad) \<lbrace>domain_sep_inv irqs (st :: 'state_ext state)\<rbrace>"
-  apply (simp add: schedule_def allActiveTCBs_def)
+  apply (simp add: schedule_def)
   apply (wp add: guarded_switch_to_lift hoare_drop_imps
-            del: ethread_get_wp
          | wpc | clarsimp simp: get_thread_state_def thread_get_def trans_state_update'[symmetric]
                                 schedule_choose_new_thread_def)+
   done

--- a/proof/access-control/Finalise_AC.thy
+++ b/proof/access-control/Finalise_AC.thy
@@ -72,12 +72,12 @@ begin
 
 lemma tcb_sched_action_dequeue_integrity':
   "\<lbrace>integrity aag X st and pas_refined aag and
-    (\<lambda>s. pasSubject aag \<in> pasDomainAbs aag (tcb_domain (the (ekheap s thread))))\<rbrace>
+    (\<lambda>s. pasSubject aag \<in> pasDomainAbs aag (etcb_domain (the (etcbs_of s thread))))\<rbrace>
    tcb_sched_action tcb_sched_dequeue thread
    \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (wpsimp simp: tcb_sched_action_def)
   apply (clarsimp simp: integrity_def integrity_ready_queues_def pas_refined_def
-                        tcb_domain_map_wellformed_aux_def etcb_at_def get_etcb_def
+                        tcb_domain_map_wellformed_aux_def etcbs_of'_def obj_at_def
                  split: option.splits)
   done
 
@@ -88,10 +88,10 @@ lemma tcb_sched_action_dequeue_integrity[wp]:
   apply (simp add: tcb_sched_action_def)
   apply wp
   apply (clarsimp simp: integrity_def integrity_ready_queues_def pas_refined_def
-                        tcb_domain_map_wellformed_aux_def etcb_at_def get_etcb_def
+                        tcb_domain_map_wellformed_aux_def
              split: option.splits)
-  apply (erule_tac x="(thread, tcb_domain (the (ekheap s thread)))" in ballE)
-  apply (auto intro: domtcbs)
+  apply (erule_tac x="(thread, etcb_domain (the (etcbs_of s thread)))" in ballE)
+  apply (auto simp: etcbs_of'_def obj_at_def intro: domtcbs)
   done
 
 lemma tcb_sched_action_enqueue_integrity[wp]:
@@ -99,8 +99,8 @@ lemma tcb_sched_action_enqueue_integrity[wp]:
   apply (simp add: tcb_sched_action_def)
   apply wp
   apply (clarsimp simp: integrity_def integrity_ready_queues_def pas_refined_def
-                        tcb_domain_map_wellformed_aux_def tcb_at_def get_etcb_def
-                        tcb_sched_enqueue_def etcb_at_def
+                        tcb_domain_map_wellformed_aux_def tcb_at_def
+                        tcb_sched_enqueue_def
              split: option.splits)
   apply (metis append.simps(2))
   done
@@ -108,12 +108,12 @@ lemma tcb_sched_action_enqueue_integrity[wp]:
 text \<open>See comment for @{thm tcb_sched_action_dequeue_integrity'}\<close>
 lemma tcb_sched_action_append_integrity':
   "\<lbrace>integrity aag X st and
-    (\<lambda>s. pasSubject aag \<in> pasDomainAbs aag (tcb_domain (the (ekheap s thread))))\<rbrace>
+    (\<lambda>s. pasSubject aag \<in> pasDomainAbs aag (etcb_domain (the (etcbs_of s thread))))\<rbrace>
    tcb_sched_action tcb_sched_append thread
    \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (simp add: tcb_sched_action_def)
   apply wp
-  apply (clarsimp simp: integrity_def integrity_ready_queues_def etcb_at_def
+  apply (clarsimp simp: integrity_def integrity_ready_queues_def etcbs_of'_def obj_at_def
                  split: option.splits)
   done
 
@@ -124,10 +124,10 @@ lemma tcb_sched_action_append_integrity[wp]:
   apply (simp add: tcb_sched_action_def)
   apply wp
   apply (clarsimp simp: integrity_def integrity_ready_queues_def pas_refined_def
-                        tcb_domain_map_wellformed_aux_def etcb_at_def get_etcb_def
+                        tcb_domain_map_wellformed_aux_def
                  split: option.splits)
-  apply (erule_tac x="(thread, tcb_domain (the (ekheap s thread)))" in ballE)
-  apply (auto intro: domtcbs)
+  apply (erule_tac x="(thread, etcb_domain (the (etcbs_of s thread)))" in ballE)
+  apply (auto simp: etcbs_of'_def obj_at_def intro: domtcbs)
   done
 
 lemma tcb_sched_action_append_integrity_pasMayEditReadyQueues:
@@ -212,23 +212,16 @@ crunch reschedule_required
   for tcb_domain_map_wellformed[wp]: "tcb_domain_map_wellformed aag"
 
 (* FIXME move to AInvs *)
-lemma tcb_sched_action_ekheap[wp]:
-  "tcb_sched_action p1 p2 \<lbrace>\<lambda>s. P (ekheap s)\<rbrace>"
+lemma tcb_sched_action_etcbs_of[wp]:
+  "tcb_sched_action p1 p2 \<lbrace>\<lambda>s. P (etcbs_of s)\<rbrace>"
   apply (simp add: tcb_sched_action_def)
-  apply wp
-  apply (simp add: etcb_at_def)
+  apply wpsimp
   done
 
 (* FIXME move to CNode *)
 lemma scheduler_action_update_pas_refined[simp]:
   "pas_refined aag (scheduler_action_update (\<lambda>_. param_a) s) = pas_refined aag s"
   by (simp add: pas_refined_def)
-
-lemma set_bound_notification_ekheap[wp]:
-  "set_bound_notification t st \<lbrace>\<lambda>s. P (ekheap s)\<rbrace>"
-  apply (simp add: set_bound_notification_def)
-  apply (wp set_scheduler_action_wp | simp)+
-  done
 
 lemma sbn_thread_st_auth[wp]:
   "set_bound_notification t ntfn \<lbrace>\<lambda>s. P (thread_st_auth s)\<rbrace>"
@@ -277,6 +270,9 @@ lemma unbind_maybe_notification_pas_refined[wp]:
   apply (clarsimp simp: unbind_maybe_notification_def)
   apply (wp set_simple_ko_pas_refined hoare_drop_imps | wpc | simp)+
   done
+
+crunch possible_switch_to
+  for pas_refined[wp]: "pas_refined aag"
 
 lemma cancel_all_ipc_pas_refined[wp]:
   "\<lbrace>pas_refined aag and pspace_aligned and valid_vspace_objs and valid_arch_state\<rbrace>
@@ -987,61 +983,12 @@ lemmas dmo_valid_cap[wp] = valid_cap_typ[OF do_machine_op_obj_at]
 
 context Finalise_AC_1 begin
 
-lemma set_eobject_integrity_autarch:
-  "\<lbrace>integrity aag X st and K (is_subject aag ptr)\<rbrace>
-   set_eobject ptr obj
-   \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
-  apply (simp add: set_eobject_def)
-  apply wp
-  apply (simp add: integrity_subjects_def)
-  done
-
 lemma cancel_badged_sends_pas_refined[wp]:
   "\<lbrace>pas_refined aag and pspace_aligned and valid_vspace_objs and valid_arch_state\<rbrace>
    cancel_badged_sends epptr badge
    \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   unfolding cancel_badged_sends_def
   by (wpsimp simp: filterM_mapM wp: mapM_wp_inv set_thread_state_pas_refined get_simple_ko_wp)
-
-end
-
-
-lemma rsubst':
-  "\<lbrakk> P s s'; s=t; s'=t' \<rbrakk> \<Longrightarrow> P t t'"
-  by auto
-
-lemma thread_set_pas_refined_triv_idleT:
-  assumes cps: "\<And>tcb. \<forall>(getF, v)\<in>ran tcb_cap_cases. getF (f tcb) = getF tcb"
-  and st: "\<And>tcb. P (tcb_state tcb) \<longrightarrow> tcb_state (f tcb) = tcb_state tcb"
-  and ba: "\<And>tcb. Q (tcb_bound_notification tcb)
-                  \<longrightarrow> tcb_bound_notification (f tcb) = tcb_bound_notification tcb"
-  shows "\<lbrace>pas_refined aag and pspace_aligned and valid_vspace_objs and valid_arch_state
-                          and idle_tcb_at (\<lambda>(st, ntfn, arch). P st \<and> Q ntfn \<and> R arch) t\<rbrace>
-         thread_set f t
-         \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
-  apply (simp add: pas_refined_def state_objs_to_policy_def)
-  apply (rule hoare_pre)
-   apply (wps thread_set_caps_of_state_trivial[OF cps])
-   apply (simp add: thread_set_def)
-   apply (wpsimp wp: set_object_wp)
-  apply (clarsimp simp: pred_tcb_def2 fun_upd_def[symmetric]
-                   del: subsetI)
-  apply (subst state_vrefs_tcb_upd, fastforce+)
-   apply (clarsimp simp: tcb_at_def)
-  apply (subst state_vrefs_tcb_upd, fastforce+)
-   apply (clarsimp simp: tcb_at_def)
-  apply (rule conjI)
-   apply (erule_tac P="\<lambda> ts ba. auth_graph_map a (state_bits_to_policy cps ts ba cd vr) \<subseteq> ag"
-                for a cps cd vr ag in rsubst')
-    apply (drule get_tcb_SomeD)
-    apply (rule ext, clarsimp simp add: thread_st_auth_def get_tcb_def st tcb_states_of_state_def)
-   apply (drule get_tcb_SomeD)
-   apply (rule ext, clarsimp simp: thread_bound_ntfns_def get_tcb_def ba)
-  apply (clarsimp)
-  done
-
-
-context Finalise_AC_1 begin
 
 lemma cap_delete_respects:
   "\<lbrace>integrity aag X st and cdt_change_allowed' aag slot and pas_refined aag

--- a/proof/access-control/Ipc_AC.thy
+++ b/proof/access-control/Ipc_AC.thy
@@ -294,13 +294,13 @@ lemma set_scheduler_action_integrity_once_ts_upd:
   apply (simp add: get_tcb_def)
   done
 
-crunch set_thread_state_ext
+crunch set_thread_state_act
   for integrity_once_ts_upd: "integrity_once_ts_upd t ts aag X st"
 
 lemma set_thread_state_integrity_once_ts_upd:
   "set_thread_state t ts' \<lbrace>integrity_once_ts_upd t ts aag X st\<rbrace>"
   apply (simp add: set_thread_state_def)
-  apply (wpsimp wp: set_object_wp set_thread_state_ext_integrity_once_ts_upd)
+  apply (wpsimp wp: set_object_wp set_thread_state_act_integrity_once_ts_upd)
   apply (clarsimp simp: fun_upd_def dest!: get_tcb_SomeD)
   apply (simp add: get_tcb_def cong: if_cong)
   done
@@ -1760,8 +1760,7 @@ locale Ipc_AC_2 = Ipc_AC_1 +
   and empty_slot_extended_list_integ_lift_in_ipc:
     "\<lbrakk> \<lbrace>list_integ (cdt_change_allowed aag {pasSubject aag} (cdt st) (tcb_states_of_state st)) st and Q\<rbrace>
        empty_slot_ext a b
-       \<lbrace>\<lambda>_. list_integ (cdt_change_allowed aag {pasSubject aag} (cdt st) (tcb_states_of_state st)) st\<rbrace>;
-       \<And>P. empty_slot_ext a b \<lbrace>\<lambda>s. P (ekheap s)\<rbrace>; \<And>P. empty_slot_ext a b \<lbrace>\<lambda>s. P (ready_queues s)\<rbrace> \<rbrakk>
+       \<lbrace>\<lambda>_. list_integ (cdt_change_allowed aag {pasSubject aag} (cdt st) (tcb_states_of_state st)) st\<rbrace> \<rbrakk>
        \<Longrightarrow> \<lbrace>integrity_tcb_in_ipc aag X receiver epptr ctxt st and Q\<rbrace>
            empty_slot_ext a b
            \<lbrace>\<lambda>_. integrity_tcb_in_ipc aag X receiver epptr ctxt st\<rbrace>"
@@ -1789,7 +1788,7 @@ lemma cap_insert_ext_integrity_in_ipc_autarch:
   apply (simp add: integrity_tcb_in_ipc_def split del: if_split)
   apply (unfold integrity_def)
   apply (simp only: integrity_cdt_list_as_list_integ)
-  apply (rule hoare_lift_Pf[where f="ekheap"])
+  apply (rule hoare_lift_Pf[where f="etcbs_of"])
    apply (clarsimp simp: integrity_tcb_in_ipc_def integrity_def
                          tcb_states_of_state_def get_tcb_def
               split del: if_split cong: if_cong)
@@ -1966,7 +1965,7 @@ lemma set_original_respects_in_ipc_autarch:
   apply (subst (asm) integrity_asids_updates(6)[symmetric])
   apply (subst integrity_asids_updates(4)[where f=id, symmetric])
   apply (subst (asm) integrity_asids_updates(4)[where f=id, symmetric])
-  apply (fastforce simp: trans_state_def)
+  apply (fastforce simp: trans_state_def abstract_state.defs)
   done
 
 lemma update_cdt_fun_upd_respects_in_ipc_autarch:
@@ -1982,7 +1981,7 @@ lemma update_cdt_fun_upd_respects_in_ipc_autarch:
   apply (subst (asm) integrity_asids_updates(2)[symmetric])
   apply (subst integrity_asids_updates(4)[where f=id, symmetric])
   apply (subst (asm) integrity_asids_updates(4)[where f=id, symmetric])
-  apply (fastforce simp: trans_state_def)
+  apply (fastforce simp: trans_state_def abstract_state.defs)
   done
 
 lemma set_untyped_cap_as_full_integrity_tcb_in_ipc_autarch:
@@ -2120,9 +2119,9 @@ lemma do_ipc_transfer_respects_in_ipc:
 end
 
 
-lemma sts_ext_running_noop:
-  "\<lbrace>P and st_tcb_at (runnable) receiver\<rbrace> set_thread_state_ext receiver \<lbrace>\<lambda>_. P\<rbrace>"
-  apply (simp add: set_thread_state_ext_def get_thread_state_def thread_get_def
+lemma sts_act_running_noop:
+  "\<lbrace>P and st_tcb_at (runnable) receiver\<rbrace> set_thread_state_act receiver \<lbrace>\<lambda>_. P\<rbrace>"
+  apply (simp add: set_thread_state_act_def get_thread_state_def thread_get_def
          | wp set_scheduler_action_wp)+
   apply (clarsimp simp add: st_tcb_at_def obj_at_def get_tcb_def)
   done
@@ -2133,7 +2132,7 @@ lemma set_thread_state_running_respects_in_ipc:
    set_thread_state receiver Running
    \<lbrace>\<lambda>_. integrity_tcb_in_ipc aag X receiver epptr TRFinalOrCall st\<rbrace>"
   apply (simp add: set_thread_state_def)
-  apply (wpsimp wp: set_object_wp sts_ext_running_noop)
+  apply (wpsimp wp: set_object_wp sts_act_running_noop)
   apply (auto simp: st_tcb_at_def obj_at_def get_tcb_def
                     get_tcb_rev update_tcb_state_in_ipc
               cong: if_cong elim: update_tcb_state_in_ipc[unfolded fun_upd_def])
@@ -2200,7 +2199,7 @@ lemma set_original_respects_in_ipc_reply:
   apply (subst (asm) integrity_asids_updates(6)[symmetric])
   apply (subst integrity_asids_updates(4)[where f=id, symmetric])
   apply (subst (asm) integrity_asids_updates(4)[where f=id, symmetric])
-  apply (fastforce simp: trans_state_def)
+  apply (fastforce simp: trans_state_def abstract_state.defs)
   done
 
 end
@@ -2230,7 +2229,7 @@ lemma update_cdt_reply_in_ipc:
   apply (subst (asm) integrity_asids_updates(2)[symmetric])
   apply (subst integrity_asids_updates(4)[where f=id, symmetric])
   apply (subst (asm) integrity_asids_updates(4)[where f=id, symmetric])
-  apply (fastforce simp: trans_state_def)
+  apply (fastforce simp: trans_state_def abstract_state.defs)
   done
 
 end
@@ -2280,10 +2279,10 @@ lemma set_scheduler_action_respects_in_ipc_autarch:
    \<lbrace>\<lambda>_. integrity_tcb_in_ipc aag X receiver epptr ctxt st\<rbrace>"
   unfolding set_scheduler_action_def
   apply (wpsimp simp: integrity_tcb_in_ipc_def integrity_def tcb_states_of_state_def get_tcb_def)
-  apply (subst (asm) integrity_asids_updates(4)[symmetric])
+  apply (subst (asm) integrity_asids_updates(14)[symmetric])
   apply (subst integrity_asids_updates(4)[where f=id, symmetric])
   apply (subst (asm) integrity_asids_updates(4)[where f=id, symmetric])
-  apply (fastforce simp: trans_state_def)
+  apply (fastforce simp: trans_state_def abstract_state.defs)
   done
 
 end
@@ -2302,19 +2301,19 @@ lemma tcb_sched_action_respects_in_ipc_autarch:
   apply wp
   apply (clarsimp simp: integrity_def integrity_tcb_in_ipc_def tcb_states_of_state_def get_tcb_def
                         integrity_ready_queues_def pas_refined_def tcb_domain_map_wellformed_aux_def
-                        tcb_at_def get_etcb_def tcb_sched_enqueue_def etcb_at_def
+                        tcb_at_def tcb_sched_enqueue_def etcb_at_def
                  split: option.splits)
   apply (intro conjI impI)
      apply (fastforce intro: exists_cons_append)
-    apply (subst (asm) integrity_asids_updates(4)[symmetric])
+    apply (subst (asm) integrity_asids_updates(22)[symmetric])
     apply (subst integrity_asids_updates(4)[where f=id, symmetric])
     apply (subst (asm) integrity_asids_updates(4)[where f=id, symmetric])
-    apply (fastforce simp: trans_state_def)
+    apply (fastforce simp: trans_state_def abstract_state.defs)
    apply (fastforce intro: exists_cons_append)
-  apply (subst (asm) integrity_asids_updates(4)[symmetric])
+  apply (subst (asm) integrity_asids_updates(22)[symmetric])
   apply (subst integrity_asids_updates(4)[where f=id, symmetric])
   apply (subst (asm) integrity_asids_updates(4)[where f=id, symmetric])
-  apply (fastforce simp: trans_state_def)
+  apply (fastforce simp: trans_state_def abstract_state.defs)
   done
 
 crunch possible_switch_to, set_thread_state
@@ -2597,7 +2596,7 @@ lemma set_thread_state_running_respects_in_ipc_reply:
    set_thread_state receiver Running
    \<lbrace>\<lambda>_. integrity_tcb_in_ipc aag X receiver epptr TRFinal st\<rbrace>"
   apply (simp add: set_thread_state_def set_object_def get_object_def)
-  apply (wp sts_ext_running_noop)
+  apply (wp sts_act_running_noop)
   apply (auto simp: st_tcb_at_def obj_at_def get_tcb_def
               cong: if_cong
              elim!: fault_tcb_atE elim: update_tcb_state_in_ipc_reply[unfolded fun_upd_def])
@@ -2638,7 +2637,7 @@ lemma set_cdt_empty_slot_respects_in_ipc_autarch:
   apply (subst (asm) integrity_asids_updates(2)[symmetric])
   apply (subst integrity_asids_updates(4)[where f=id, symmetric])
   apply (subst (asm) integrity_asids_updates(4)[where f=id, symmetric])
-  apply (fastforce simp: trans_state_def)
+  apply (fastforce simp: trans_state_def abstract_state.defs)
   done
 
 end
@@ -2726,17 +2725,17 @@ lemma set_scheduler_action_respects_in_fault_reply:
   "set_scheduler_action action \<lbrace>integrity_tcb_in_fault_reply aag X receiver ctxt st\<rbrace>"
   unfolding set_scheduler_action_def
   apply (wpsimp simp: integrity_tcb_in_fault_reply_def integrity_def tcb_states_of_state_def get_tcb_def)
-  apply (subst (asm) integrity_asids_updates(4)[symmetric])
+  apply (subst (asm) integrity_asids_updates(14)[symmetric])
   apply (subst integrity_asids_updates(4)[where f=id, symmetric])
   apply (subst (asm) integrity_asids_updates(4)[where f=id, symmetric])
-  apply (fastforce simp: trans_state_def)
+  apply (fastforce simp: trans_state_def abstract_state.defs)
   done
 
 lemma handle_fault_reply_respects_in_fault_reply:
   "handle_fault_reply f thread label mrs \<lbrace>integrity_tcb_in_fault_reply aag X thread TRFContext st\<rbrace>"
   by (cases f; wpsimp wp: as_user_respects_in_fault_reply handle_arch_fault_reply_typ_at)
 
-crunch set_thread_state_ext
+crunch set_thread_state_act
   for respects_in_fault_reply: "integrity_tcb_in_fault_reply aag X receiver ctxt st"
 
 lemma thread_set_no_fault_respects_in_fault_reply:
@@ -2744,7 +2743,7 @@ lemma thread_set_no_fault_respects_in_fault_reply:
    thread_set (\<lambda>tcb. tcb \<lparr> tcb_fault := None \<rparr>) thread
    \<lbrace>\<lambda>_. integrity_tcb_in_fault_reply aag X thread TRFRemoveFault st\<rbrace>"
   apply (simp add: thread_set_def)
-  apply (wp set_thread_state_ext_respects_in_fault_reply set_object_wp)
+  apply (wp set_thread_state_act_respects_in_fault_reply set_object_wp)
   apply (clarsimp simp: integrity_tcb_in_fault_reply_def)
   apply (erule tcb_in_fault_reply.cases; clarsimp dest!: get_tcb_SomeD)
   apply (rule tifr_remove_fault[OF refl refl])
@@ -2756,7 +2755,7 @@ lemma set_thread_state_respects_in_fault_reply:
    set_thread_state thread tst
    \<lbrace>\<lambda>_. integrity_tcb_in_fault_reply aag X thread TRFFinal st\<rbrace>"
   apply (simp add: set_thread_state_def)
-  apply (wp set_thread_state_ext_respects_in_fault_reply set_object_wp)
+  apply (wp set_thread_state_act_respects_in_fault_reply set_object_wp)
   apply (clarsimp simp: integrity_tcb_in_fault_reply_def)
   apply (erule tcb_in_fault_reply.cases; clarsimp dest!: get_tcb_SomeD)
   apply (rule tifr_reply[OF refl refl])

--- a/proof/access-control/Retype_AC.thy
+++ b/proof/access-control/Retype_AC.thy
@@ -156,7 +156,7 @@ lemma sita_detype:
 lemmas pas_refined_by_subsets = pas_refined_state_objs_to_policy_subset
 
 lemma dtsa_detype: "domains_of_state (detype R s) \<subseteq> domains_of_state s"
-  by (auto simp: detype_def detype_ext_def
+  by (auto simp: detype_def etcbs_of'_def
           intro: domtcbs
           elim!: domains_of_state_aux.cases
           split: if_splits)
@@ -204,9 +204,10 @@ locale Retype_AC_1 =
   and nonzero_data_to_nat_simp:
     "\<And>x. 0 < data_to_nat x \<Longrightarrow> 0 < x"
   and retype_region_proofs'_pas_refined:
-    "\<lbrakk> retype_region_proofs' s ty us ptr sz n dev; invs s; pas_refined aag s \<rbrakk>
+    "\<lbrakk> retype_region_proofs' s ty us ptr sz n dev; invs s; pas_refined aag s;
+       pas_cur_domain aag s; \<forall>x\<in> set (retype_addrs ptr ty n us). is_subject aag x \<rbrakk>
        \<Longrightarrow> pas_refined aag (s\<lparr>kheap := \<lambda>x. if x \<in> set (retype_addrs ptr ty n us)
-                                           then Some (default_object ty dev us)
+                                           then Some (default_object ty dev us (cur_domain s))
                                            else kheap s x\<rparr>)"
   and dmo_freeMemory_respects:
     "\<lbrace>integrity aag X st and K (is_aligned ptr bits \<and> bits < word_bits \<and> word_size_bits \<le> bits
@@ -234,7 +235,7 @@ locale Retype_AC_1 =
        \<forall>x\<in>up_aligned_area ptr sz. is_subject aag x; integrity_asids aag {pasSubject aag} p a s st \<rbrakk>
        \<Longrightarrow> integrity_asids aag {pasSubject aag} p a s
              (st\<lparr>kheap := \<lambda>a. if a \<in> (\<lambda>x. ptr_add ptr (x * 2 ^ obj_bits_api typ o_bits)) ` {0 ..< n}
-                              then Some (default_object typ dev o_bits)
+                              then Some (default_object typ dev o_bits d)
                               else kheap s a\<rparr>)"
 begin
 
@@ -243,7 +244,7 @@ lemma detype_integrity:
      \<Longrightarrow> integrity aag X st (detype refs s)"
   apply (erule integrity_trans)
   apply (clarsimp simp: integrity_def integrity_asids_detype)
-  apply (clarsimp simp: detype_def detype_ext_def integrity_def)
+  apply (clarsimp simp: detype_def integrity_def)
   done
 
 lemma sta_detype:
@@ -326,14 +327,14 @@ lemma retype_region_integrity:
    retype_region ptr num_objects o_bits type dev
    \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (rule hoare_gen_asm)+
-  apply (simp only: retype_region_def retype_region_ext_extended.dxo_eq)
-  apply (simp only: retype_addrs_def retype_region_ext_def
+  apply (simp only: retype_region_def)
+  apply (simp only: retype_addrs_def
                     foldr_upd_app_if' fun_app_def K_bind_def)
   apply wp
   apply (clarsimp simp: not_less)
   apply (erule integrity_trans)
   apply (clarsimp simp: integrity_def retype_region_integrity_asids)
-  apply (fastforce intro: tro_lrefl tre_lrefl
+  apply (fastforce intro: tro_lrefl
                     dest: retype_addrs_subset_ptr_bits[simplified retype_addrs_def]
                     simp: image_def p_assoc_help power_sub)
   done
@@ -418,8 +419,17 @@ end
 
 context retype_region_proofs' begin
 
-lemma domains_of_state: "domains_of_state s' \<subseteq> domains_of_state s"
-  unfolding s'_def by simp
+lemma tcb_domain_map_wellformed:
+  "\<lbrakk>tcb_domain_map_wellformed aag s; pas_cur_domain aag s; \<forall>x\<in> set (retype_addrs ptr ty n us). is_subject aag x\<rbrakk>
+   \<Longrightarrow> tcb_domain_map_wellformed aag s'"
+  unfolding s'_def ps_def
+  apply (clarsimp simp: tcb_domain_map_wellformed_aux_def)
+  apply (erule domains_of_state_aux.cases)
+  apply (clarsimp simp: etcbs_of'_def split: if_split_asm kernel_object.splits)
+   apply (clarsimp simp: default_object_def default_tcb_def tyunt split: apiobject_type.splits)
+   defer
+  apply (force intro: domtcbs)
+  done
 
 (* FIXME MOVE next to cte_at_pres *)
 lemma cte_wp_at_pres:
@@ -436,79 +446,33 @@ lemma caps_of_state_pres:
 
 end
 
-
-lemma retype_region_ext_kheap_update:
-  "\<lbrace>Q xs and R xs\<rbrace> retype_region_ext xs ty \<lbrace>\<lambda>_. Q xs\<rbrace>
-   \<Longrightarrow> \<lbrace>\<lambda>s. Q xs (kheap_update f s) \<and> R xs (kheap_update f s)\<rbrace>
-       retype_region_ext xs ty
-       \<lbrace>\<lambda>_ s. Q xs (kheap_update f s)\<rbrace>"
-  apply (clarsimp simp: valid_def retype_region_ext_def)
-  apply (erule_tac x="kheap_update f s" in allE)
-  apply (clarsimp simp: split_def bind_def gets_def get_def return_def modify_def put_def)
-  done
-
-lemma use_retype_region_proofs_ext':
-  assumes x: "\<And>(s::det_ext state). \<lbrakk> retype_region_proofs s ty us ptr sz n dev; P s \<rbrakk>
+lemma use_retype_region_proofs':
+  assumes x: "\<And>(s::det_ext state). \<lbrakk> retype_region_proofs s ty us ptr sz n dev; P s; pas_cur_domain aag s;
+                                     \<forall>x\<in> set (retype_addrs ptr ty n us). is_subject aag x \<rbrakk>
                                       \<Longrightarrow> Q (retype_addrs ptr ty n us)
                                             (s\<lparr>kheap := \<lambda>x. if x \<in> set (retype_addrs ptr ty n us)
-                                                            then Some (default_object ty dev us )
+                                                            then Some (default_object ty dev us (cur_domain s))
                                                             else kheap s x\<rparr>)"
-  assumes y: "\<And>xs. \<lbrace>Q xs and R xs\<rbrace> retype_region_ext xs ty \<lbrace>\<lambda>_. Q xs\<rbrace>"
-  assumes z: "\<And>f xs s. R xs (kheap_update f s) = R xs s"
   shows
     "\<lbrakk> ty = CapTableObject \<Longrightarrow> 0 < us; \<And>s. P s \<Longrightarrow> Q (retype_addrs ptr ty n us) s \<rbrakk>
        \<Longrightarrow> \<lbrace>\<lambda>s. valid_pspace s \<and> valid_mdb s \<and> range_cover ptr sz (obj_bits_api ty us) n \<and>
                 caps_overlap_reserved {ptr..ptr + of_nat n * 2 ^ obj_bits_api ty us - 1} s \<and>
                 caps_no_overlap ptr sz s \<and> pspace_no_overlap_range_cover ptr sz s \<and>
                 (\<exists>slot. cte_wp_at (\<lambda>c. up_aligned_area ptr sz \<subseteq> cap_range c \<and> cap_is_device c = dev) slot s) \<and>
-                P s \<and> R (retype_addrs ptr ty n us) s\<rbrace>
+                P s \<and> pas_cur_domain aag s \<and> (\<forall>x\<in> set (retype_addrs ptr ty n us). is_subject aag x)\<rbrace>
            retype_region ptr n us ty dev \<lbrace>Q\<rbrace>"
   apply (simp add: retype_region_def split del: if_split)
-  apply (rule hoare_pre, (wp | simp)+)
-    apply (rule retype_region_ext_kheap_update[OF y])
-   apply (wp | simp)+
+  apply wpsimp
   apply (clarsimp simp: retype_addrs_fold
                         foldr_upd_app_if fun_upd_def[symmetric])
   apply safe
-    apply (rule x)
-     apply (rule retype_region_proofs.intro, simp_all)[1]
-      apply (fastforce simp: range_cover_def obj_bits_api_def z slot_bits_def2 word_bits_def)+
+   apply (rule x)
+    apply (rule retype_region_proofs.intro, simp_all)[1]
+     apply (fastforce simp: range_cover_def obj_bits_api_def slot_bits_def2 word_bits_def)+
   done
 
-lemmas use_retype_region_proofs_ext =
-  use_retype_region_proofs_ext'[where Q="\<lambda>_. Q" and P=Q, simplified] for Q
-
-
-context is_extended begin
-
-lemma pas_refined_tcb_domain_map_wellformed':
-  assumes tdmw: "\<lbrace>tcb_domain_map_wellformed aag and P\<rbrace> f \<lbrace>\<lambda>_. tcb_domain_map_wellformed aag\<rbrace>"
-  shows "\<lbrace>pas_refined aag and P\<rbrace> f \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
-  apply (simp add: pas_refined_def)
-  apply (wp tdmw)
-   apply (wp lift_inv)
-   apply simp+
-  done
-
-end
-
-
-lemma retype_region_ext_pas_refined:
-  "\<lbrace>pas_refined aag and pas_cur_domain aag and K (\<forall>x\<in> set xs. is_subject aag x)\<rbrace>
-   retype_region_ext xs ty
-   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
-  including classic_wp_pre
-  apply (subst and_assoc[symmetric])
-  apply (wp retype_region_ext_extended.pas_refined_tcb_domain_map_wellformed')
-  apply (simp add: retype_region_ext_def, wp)
-  apply (clarsimp simp: tcb_domain_map_wellformed_aux_def)
-  apply (erule domains_of_state_aux.cases)
-  apply (clarsimp simp: foldr_upd_app_if' fun_upd_def[symmetric] split: if_split_asm)
-   apply (clarsimp simp: default_ext_def default_etcb_def split: apiobject_type.splits)
-   defer
-  apply (force intro: domtcbs)
-  done
-
+lemmas use_retype_region_proofs =
+  use_retype_region_proofs'[where Q="\<lambda>_. Q" and P=Q, simplified] for Q
 
 context Retype_AC_1 begin
 
@@ -524,12 +488,10 @@ lemma retype_region_pas_refined:
    \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   apply (rule hoare_gen_asm)
   apply (rule hoare_pre)
-   apply (rule use_retype_region_proofs_ext'[where P = "invs and pas_refined aag"])
-       apply clarsimp
-       apply (erule (2) retype_region_proofs'_pas_refined[OF retype_region_proofs'.intro])
-      apply (wp retype_region_ext_pas_refined)
-      apply simp
-     apply auto
+   apply (rule use_retype_region_proofs'[where P = "invs and pas_refined aag"])
+     apply clarsimp
+     apply (erule (4) retype_region_proofs'_pas_refined[OF retype_region_proofs'.intro])
+    apply auto
   done
 
 end
@@ -898,14 +860,11 @@ lemma retype_region_pas_refined':
    \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   apply (rule hoare_gen_asm)+
   apply (rule hoare_weaken_pre)
-   apply (rule use_retype_region_proofs_ext'[where P="invs and pas_refined aag"])
-       apply clarsimp
-       apply (erule (2) retype_region_proofs'_pas_refined[OF retype_region_proofs'.intro])
-      apply (wp retype_region_ext_pas_refined)
-      apply simp
-     apply fastforce
-    apply fastforce
-   apply clarsimp
+   apply (rule use_retype_region_proofs'[where P="invs and pas_refined aag"])
+     apply clarsimp
+     apply (erule (4) retype_region_proofs'_pas_refined[OF retype_region_proofs'.intro])
+    apply simp
+   apply fastforce
   apply clarsimp
   apply (frule valid_cap_range_untyped[OF invs_valid_objs])
    apply (fastforce simp: cte_wp_at_caps_of_state)

--- a/proof/access-control/Syscall_AC.thy
+++ b/proof/access-control/Syscall_AC.thy
@@ -189,13 +189,16 @@ lemma set_thread_state_authorised[wp]:
   apply (wpsimp wp: sts_valid_arch_inv ct_in_state_set)
   done
 
+crunch set_thread_state_act
+  for kheap[wp]: "\<lambda>s. P (kheap s)"
+
 lemma sts_first_restart:
   "\<lbrace>(=) st and (\<lambda>s. thread = cur_thread s)\<rbrace>
    set_thread_state thread Structures_A.thread_state.Restart
    \<lbrace>\<lambda>rv s. \<forall>p ko. kheap s p = Some ko \<longrightarrow>
            (is_tcb ko \<longrightarrow> p \<noteq> cur_thread st) \<longrightarrow> kheap st p = Some ko\<rbrace>"
   unfolding set_thread_state_def
-  by (wpsimp wp: set_object_wp dxo_wp_weak simp: is_tcb)
+  by (wpsimp wp: set_object_wp simp: is_tcb)
 
 lemma lcs_reply_owns:
   "\<lbrace>pas_refined aag and K (is_subject aag thread)\<rbrace>
@@ -397,20 +400,13 @@ lemma handle_reply_respects:
                    dest: invs_cur)
   done
 
-lemma ethread_set_time_slice_pas_refined[wp]:
-  "ethread_set (tcb_time_slice_update f) thread \<lbrace>pas_refined aag\<rbrace>"
-  apply (simp add: ethread_set_def set_eobject_def | wp)+
-  apply (clarsimp simp: pas_refined_def tcb_domain_map_wellformed_aux_def)
-  apply (erule_tac x="(a, b)" in ballE)
-   apply force
-  apply (erule notE)
-  apply (erule domains_of_state_aux.cases, simp add: get_etcb_def split: if_split_asm)
-   apply (force intro: domtcbs)+
-  done
+
 
 lemma thread_set_time_slice_pas_refined[wp]:
-  "thread_set_time_slice tptr time \<lbrace>pas_refined aag\<rbrace>"
-  by (simp add: thread_set_time_slice_def | wp)+
+  "\<lbrace>pas_refined aag and pspace_aligned and valid_vspace_objs and valid_arch_state\<rbrace>
+   thread_set_time_slice tptr time
+   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
+  by (simp add: thread_set_time_slice_def | wp thread_set_pas_refined)+
 
 lemma dec_domain_time_pas_refined[wp]:
   "dec_domain_time \<lbrace>pas_refined aag\<rbrace>"
@@ -420,7 +416,6 @@ lemma dec_domain_time_pas_refined[wp]:
 
 crunch timer_tick
   for pas_refined[wp]: "pas_refined aag"
-  (wp_del: timer_tick_extended.pas_refined_tcb_domain_map_wellformed)
 
 
 locale Syscall_AC_wps =
@@ -580,11 +575,12 @@ lemma dec_domain_time_integrity[wp]:
   done
 
 lemma timer_tick_integrity[wp]:
-  "\<lbrace>integrity aag X st and pas_refined aag and (\<lambda>s. ct_active s \<longrightarrow> is_subject aag (cur_thread s))\<rbrace>
+  "\<lbrace>integrity aag X st and pas_refined aag and (\<lambda>s. ct_active s \<longrightarrow> is_subject aag (cur_thread s))
+    and pspace_aligned and valid_vspace_objs and valid_arch_state\<rbrace>
    timer_tick
    \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (simp add: timer_tick_def)
-  apply (wp ethread_set_integrity_autarch gts_wp
+  apply (wp thread_set_integrity_autarch thread_set_pas_refined gts_wp thread_get_wp
          | wpc | simp add: thread_set_time_slice_def split del: if_split)+
   apply (clarsimp simp: ct_in_state_def st_tcb_at_def obj_at_def)
   done
@@ -630,6 +626,7 @@ lemma handle_interrupt_integrity:
                       ackInterrupt_device_state_inv resetTimer_device_state_inv
             | wpc
             | simp add: get_irq_slot_def get_irq_state_def)+
+  apply (rule conjI[rotated], fastforce) \<comment> \<open>IRQTimer preconditions\<close>
   apply clarsimp
   apply (rule conjI, fastforce)+ \<comment> \<open>valid_objs etc.\<close>
   apply (clarsimp simp: cte_wp_at_caps_of_state)
@@ -675,8 +672,6 @@ lemma valid_fault_Unknown[simp]:
 lemma valid_fault_User[simp]:
   "valid_fault (UserException word1 word2)"
   by (simp add: valid_fault_def)
-
-declare hy_inv[wp del]
 
 lemma handle_yield_integrity[wp]:
   "\<lbrace>integrity aag X st and pas_refined aag and is_subject aag \<circ> cur_thread\<rbrace>
@@ -748,7 +743,7 @@ lemma tcb_sched_action_dequeue_integrity_pasMayEditReadyQueues:
   apply (simp add: tcb_sched_action_def)
   apply wp
   apply (clarsimp simp: integrity_def integrity_ready_queues_def pas_refined_def
-                        tcb_domain_map_wellformed_aux_def etcb_at_def get_etcb_def
+                        tcb_domain_map_wellformed_aux_def etcb_at_def
                  split: option.splits)
   done
 
@@ -776,7 +771,7 @@ See comment for @{thm tcb_sched_action_dequeue_integrity'}
 \<close>
 lemma switch_to_thread_respects':
   "\<lbrace>integrity aag X st and pas_refined aag
-                       and (\<lambda>s. pasSubject aag \<in> pasDomainAbs aag (tcb_domain (the (ekheap s t))))\<rbrace>
+                       and (\<lambda>s. pasSubject aag \<in> pasDomainAbs aag (etcb_domain (the (etcbs_of s t))))\<rbrace>
    switch_to_thread t
    \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   unfolding switch_to_thread_def
@@ -813,9 +808,6 @@ lemma choose_thread_respects:
    apply (clarsimp simp: etcb_at_def)
   (* thread we're switching to is in cur_domain *)
   apply (rule_tac s = "cur_domain s" in subst)
-  apply (clarsimp simp: max_non_empty_queue_def)
-   apply (frule tcb_at_ekheap_dom[OF st_tcb_at_tcb_at])
-    apply (simp add: valid_sched_def)
    apply (clarsimp simp: max_non_empty_queue_def)
    apply (metis (mono_tags, lifting) setcomp_Max_has_prop hd_in_set)
   (* pas_cur_domain *)
@@ -831,7 +823,7 @@ lemma guarded_switch_to_respects:
 
 lemma next_domain_tcb_domain_map_wellformed[wp]:
   "next_domain \<lbrace>tcb_domain_map_wellformed aag\<rbrace>"
-  by (wpsimp simp: next_domain_def thread_set_domain_def ethread_set_def set_eobject_def Let_def)
+  by (wpsimp simp: next_domain_def thread_set_domain_def Let_def wp: dxo_wp_weak )
 
 lemma valid_blocked_2_valid_blocked_except[simp]:
   "valid_blocked_2 queues kh sa ct \<Longrightarrow> valid_blocked_except_2 t queues kh sa ct"
@@ -841,8 +833,8 @@ lemma valid_blocked_2_valid_blocked_except[simp]:
 lemma next_domain_valid_sched:
   "\<lbrace>valid_sched and (\<lambda>s. scheduler_action s = choose_new_thread)\<rbrace> next_domain \<lbrace>\<lambda>_. valid_sched\<rbrace>"
   apply (simp add: next_domain_def Let_def)
-  apply (wp, simp add: valid_sched_def valid_sched_action_2_def ct_not_in_q_2_def)
-  apply (simp add:valid_blocked_2_def)
+  apply (wpsimp wp: dxo_wp_weak)
+  apply (simp add: valid_sched_def)
   done
 
 text \<open>
@@ -852,22 +844,20 @@ because t's domain may contain multiple labels. See the comment for
 \<close>
 lemma valid_sched_action_switch_subject_thread:
    "\<lbrakk> scheduler_action s = switch_thread t; valid_sched_action s;
-      valid_etcbs s; pas_refined aag s; pas_cur_domain aag s \<rbrakk>
-      \<Longrightarrow> pasObjectAbs aag t \<in> pasDomainAbs aag (tcb_domain (the (ekheap s t))) \<and>
-          pasSubject aag \<in> pasDomainAbs aag (tcb_domain (the (ekheap s t)))"
+      pas_refined aag s; pas_cur_domain aag s \<rbrakk>
+      \<Longrightarrow> pasObjectAbs aag t \<in> pasDomainAbs aag (etcb_domain (the (etcbs_of s t))) \<and>
+          pasSubject aag \<in> pasDomainAbs aag (etcb_domain (the (etcbs_of s t)))"
   apply (clarsimp simp: valid_sched_action_def weak_valid_sched_action_2_def
-                        switch_in_cur_domain_2_def in_cur_domain_2_def valid_etcbs_def
-                        etcb_at_def st_tcb_at_def obj_at_def is_etcb_at_def)
-  apply (rule conjI)
-   apply (force simp: pas_refined_def tcb_domain_map_wellformed_aux_def
-                intro: domtcbs)
-  apply force
+                        switch_in_cur_domain_2_def in_cur_domain_2_def etcbs_of'_def
+                        etcb_at_def st_tcb_at_def obj_at_def)
+  apply (fastforce simp: pas_refined_def tcb_domain_map_wellformed_aux_def etcbs_of'_def
+                  intro: domtcbs)
   done
 
 lemma next_domain_integrity[wp]:
   "next_domain \<lbrace>integrity aag X st\<rbrace>"
-  apply (wpsimp simp: next_domain_def thread_set_domain_def ethread_set_def set_eobject_def Let_def)
-  apply (clarsimp simp: get_etcb_def integrity_subjects_def lfp_def)
+  apply (wpsimp simp: next_domain_def Let_def reset_work_units_ext_extended.dxo_eq[simplified reset_work_units_def])
+  apply (clarsimp simp: integrity_subjects_def)
   done
 
 lemma pas_refined_cur_thread[iff]:
@@ -884,6 +874,12 @@ lemma switch_to_idle_thread_pas_refined:
   "switch_to_idle_thread \<lbrace>pas_refined aag\<rbrace>"
   unfolding switch_to_idle_thread_def
   by (wpsimp wp: do_machine_op_pas_refined)
+
+lemma next_domain_pas_refined[wp]:
+  "next_domain \<lbrace>pas_refined aag\<rbrace>"
+  apply (wpsimp simp: next_domain_def Let_def reset_work_units_ext_extended.dxo_eq[simplified reset_work_units_def])
+  apply (clarsimp simp: pas_refined_def)
+  done
 
 lemma schedule_choose_new_thread_integrity:
   "\<lbrace>invs and valid_sched and valid_list and integrity aag X st and pas_refined aag
@@ -906,7 +902,7 @@ lemma schedule_integrity:
                     switch_to_idle_thread_respects choose_thread_respects gts_wp hoare_drop_imps
                     set_scheduler_action_cnt_valid_sched append_thread_queued enqueue_thread_queued
                     tcb_sched_action_enqueue_valid_blocked_except tcb_sched_action_append_integrity'
-         | simp add: allActiveTCBs_def schedule_choose_new_thread_def
+         | simp add: schedule_choose_new_thread_def
          | rule hoare_pre_cont[where f=next_domain])+
   apply (auto simp: obj_at_def st_tcb_at_def not_cur_thread_2_def valid_sched_def
                     valid_sched_action_def weak_valid_sched_action_def
@@ -922,10 +918,9 @@ lemma schedule_integrity_pasMayEditReadyQueues:
           and guarded_pas_domain aag and K (pasMayEditReadyQueues aag)\<rbrace>
    schedule
    \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
-  supply ethread_get_wp[wp del]
   supply schedule_choose_new_thread_integrity[wp]
   supply if_split[split del]
-  apply (simp add: schedule_def wrap_is_highest_prio_def[symmetric])
+  apply (simp add: schedule_def wrap_is_highest_prio_def[symmetric] )
   apply (wp, wpc)
         (* resume current thread *)
         apply wp
@@ -939,7 +934,8 @@ lemma schedule_integrity_pasMayEditReadyQueues:
             (* is_highest_prio *)
             apply (simp add: wrap_is_highest_prio_def)
             apply ((wp (once) hoare_drop_imp)+)[1]
-           apply (wpsimp wp: tcb_sched_action_enqueue_valid_blocked_except hoare_vcg_imp_lift' gts_wp)+
+           apply (wpsimp wp: tcb_sched_action_enqueue_valid_blocked_except hoare_vcg_imp_lift' gts_wp
+                             hoare_vcg_disj_lift hoare_vcg_all_lift)+
   apply (clarsimp simp: if_apply_def2 cong: imp_cong conj_cong)
   apply (safe; ((solves \<open>clarsimp simp: valid_sched_def not_cur_thread_def
                                         valid_sched_action_def weak_valid_sched_action_def\<close>)?))
@@ -952,7 +948,7 @@ crunch choose_thread
 
 lemma schedule_pas_refined:
   "schedule \<lbrace>pas_refined aag\<rbrace>"
-  apply (simp add: schedule_def allActiveTCBs_def)
+  apply (simp add: schedule_def)
   apply (wp add: guarded_switch_to_lift switch_to_thread_pas_refined
                  switch_to_idle_thread_pas_refined gts_wp
                  guarded_switch_to_lift switch_to_thread_respects_pasMayEditReadyQueues
@@ -960,7 +956,6 @@ lemma schedule_pas_refined:
                  next_domain_valid_sched next_domain_valid_queues gts_wp hoare_drop_imps
                  set_scheduler_action_cnt_valid_sched enqueue_thread_queued
                  tcb_sched_action_enqueue_valid_blocked_except
-            del: ethread_get_wp
          | wpc | simp add: schedule_choose_new_thread_def)+
   done
 
@@ -969,10 +964,6 @@ lemmas sequence_x_mapM_x = mapM_x_def [symmetric]
 crunch invoke_untyped
   for arch_state[wp]: "\<lambda>s :: det_ext state. P (arch_state s)"
   (wp: crunch_wps preemption_point_inv mapME_x_inv_wp simp: crunch_simps sequence_x_mapM_x)
-
-crunch_ignore (add: cap_swap_ext cap_move_ext cap_insert_ext create_cap_ext set_thread_state_ext
-                    empty_slot_ext retype_region_ext set_priority ethread_set tcb_sched_action
-                    reschedule_required possible_switch_to next_domain set_domain timer_tick)
 
 lemma zet_zip_contrapos:
   "fst t \<notin> set xs  \<Longrightarrow> t \<notin> set (zip xs ys)"
@@ -1020,6 +1011,9 @@ lemma sts_Restart_ct_active[wp]:
   apply (wp set_object_wp | simp add: set_thread_state_def)+
   apply (clarsimp simp: ct_in_state_def st_tcb_at_def obj_at_def)
   done
+
+crunch reschedule_required
+  for ct_active [wp]: "ct_active"
 
 lemma cancel_all_ipc_ct_active[wp]:
   "cancel_all_ipc ptr \<lbrace>ct_active\<rbrace>"
@@ -1075,9 +1069,9 @@ crunch handle_event
   (wp: syscall_valid crunch_wps check_cap_inv dxo_wp_weak
    simp: crunch_simps ignore: syscall)
 
-crunch ethread_set, timer_tick, possible_switch_to, handle_interrupt
-  for pas_cur_domain[wp]: "pas_cur_domain aag"
-  (wp: crunch_wps simp: crunch_simps ignore_del: ethread_set timer_tick possible_switch_to)
+crunch timer_tick, possible_switch_to, handle_interrupt
+  for pas_cur_domain[wp]: "pas_cur_domain aag :: det_state \<Rightarrow> _"
+  (wp: crunch_wps simp: crunch_simps)
 
 lemma dxo_idle_thread[wp]:
   "\<lbrace>\<lambda>s. P (idle_thread s) \<rbrace> do_extended_op f \<lbrace>\<lambda>_ s. P (idle_thread s)\<rbrace>"
@@ -1106,32 +1100,31 @@ crunch handle_event
   (wp: syscall_valid crunch_wps simp: check_cap_at_def ignore: check_cap_at syscall)
 
 crunch
-  transfer_caps_loop, ethread_set, possible_switch_to, thread_set_priority,
+  transfer_caps_loop, possible_switch_to, thread_set_priority,
   set_priority, set_domain, invoke_domain, cap_move_ext, timer_tick,
   cap_move, cancel_badged_sends, possible_switch_to
-  for cur_domain[wp]: "\<lambda>s. P (cur_domain s)"
-  (wp: crunch_wps simp: filterM_mapM rule: transfer_caps_loop_pres
-   ignore_del: ethread_set set_priority set_domain cap_move_ext timer_tick possible_switch_to)
+  for cur_domain[wp]: "\<lambda>s::det_state. P (cur_domain s)"
+  (wp: crunch_wps simp: filterM_mapM rule: transfer_caps_loop_pres)
 
 lemma invoke_cnode_cur_domain[wp]:
- "invoke_cnode a \<lbrace>\<lambda>s. P (cur_domain s)\<rbrace>"
+ "invoke_cnode a \<lbrace>\<lambda>s::det_state. P (cur_domain s)\<rbrace>"
   apply (simp add: invoke_cnode_def)
   apply (rule hoare_pre)
    apply (wp hoare_drop_imps hoare_vcg_all_lift | wpc | simp split del: if_split)+
   done
 
 crunch handle_event
-  for cur_domain[wp]: "\<lambda>s. P (cur_domain s)"
+  for cur_domain[wp]: "\<lambda>s::det_state. P (cur_domain s)"
   (wp: syscall_valid crunch_wps check_cap_inv
    simp: crunch_simps
    ignore: check_cap_at syscall)
 
 lemma handle_event_guarded_pas_domain[wp]:
-  "handle_event e \<lbrace>guarded_pas_domain aag\<rbrace>"
+  "handle_event e \<lbrace>guarded_pas_domain aag :: det_state \<Rightarrow> _\<rbrace>"
   by (wpsimp wp: guarded_pas_domain_lift)
 
 lemma handle_interrupt_guarded_pas_domain[wp]:
-  "handle_interrupt blah \<lbrace>guarded_pas_domain aag\<rbrace>"
+  "handle_interrupt blah \<lbrace>guarded_pas_domain aag :: det_state \<Rightarrow> _\<rbrace>"
   by (wpsimp wp: guarded_pas_domain_lift)
 
 lemma integrity_irq_state_independent[simp]:

--- a/proof/access-control/Tcb_AC.thy
+++ b/proof/access-control/Tcb_AC.thy
@@ -115,9 +115,9 @@ lemma restart_pas_refined:
    restart t
    \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   apply (simp add: restart_def get_thread_state_def)
-  apply (wp set_thread_state_pas_refined setup_reply_master_pas_refined thread_get_wp'
-         | strengthen invs_mdb
-         | fastforce)+
+  apply (wpsimp wp: set_thread_state_pas_refined setup_reply_master_pas_refined thread_get_wp'
+         | strengthen invs_mdb)+
+  apply fastforce
   done
 
 lemma option_update_thread_set_safe_lift:
@@ -136,20 +136,11 @@ lemma set_priority_integrity_autarch[wp]:
   by (simp add: set_priority_def | wp)+
 
 lemma set_priority_pas_refined[wp]:
-  "\<lbrace>pas_refined aag\<rbrace>
+  "\<lbrace>pas_refined aag and pspace_aligned and valid_vspace_objs and valid_arch_state\<rbrace>
    set_priority tptr prio
    \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
-  apply (simp add: set_priority_def thread_set_priority_def
-                   ethread_set_def set_eobject_def get_etcb_def
-         | wp hoare_vcg_imp_lift')+
-   apply (simp add: tcb_sched_action_def | wp)+
-  apply (clarsimp simp: etcb_at_def pas_refined_def tcb_domain_map_wellformed_aux_def
-                 split: option.splits)
-  apply (erule_tac x="(a, b)" in ballE)
-   apply simp
-  apply (erule domains_of_state_aux.cases)
-  apply (force intro: domtcbs split: if_split_asm)
-  done
+  unfolding set_priority_def thread_set_priority_def
+  by (wpsimp wp: thread_set_pas_refined)
 
 lemma gts_test[wp]:
    "\<lbrace>\<top>\<rbrace> get_thread_state t \<lbrace>\<lambda>rv s. test rv = st_tcb_at test t s\<rbrace>"

--- a/proof/invariant-abstract/ARM/ArchBCorres2_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchBCorres2_AI.thy
@@ -15,11 +15,11 @@ named_theorems BCorres2_AI_assms
 
 crunch invoke_cnode
   for (bcorres) bcorres[wp, BCorres2_AI_assms]: truncate_state
-  (simp: swp_def ignore: clearMemory without_preemption filterM ethread_set )
+  (simp: swp_def ignore: clearMemory without_preemption filterM)
 
 crunch create_cap,init_arch_objects,retype_region,delete_objects
   for (bcorres) bcorres[wp]: truncate_state
-  (ignore: freeMemory clearMemory retype_region_ext)
+  (ignore: freeMemory clearMemory)
 
 crunch set_extra_badge,derive_cap
   for (bcorres) bcorres[wp]: truncate_state (ignore: storeWord)
@@ -28,7 +28,7 @@ crunch invoke_untyped
   for (bcorres) bcorres[wp]: truncate_state
   (ignore: sequence_x)
 
-crunch set_mcpriority,
+crunch set_mcpriority, set_priority,
           arch_get_sanitise_register_info, arch_post_modify_registers
   for (bcorres) bcorres[wp, BCorres2_AI_assms]: truncate_state
 
@@ -142,33 +142,14 @@ lemma handle_vm_fault_bcorres[wp]: "bcorres (handle_vm_fault a b) (handle_vm_fau
 lemma handle_reserved_irq_bcorres[wp]: "bcorres (handle_reserved_irq a) (handle_reserved_irq a)"
   by (simp add: handle_reserved_irq_def; wp)
 
-lemma handle_hypervisor_fault_bcorres[wp]: "bcorres (handle_hypervisor_fault a b) (handle_hypervisor_fault a b)"
-  apply (cases b)
-  apply (simp | wp)+
-  done
+crunch handle_hypervisor_fault, timer_tick
+  for (bcorres) bcorres[wp]: truncate_state
 
 lemma handle_event_bcorres[wp]: "bcorres (handle_event e) (handle_event e)"
   apply (cases e)
   apply (simp add: handle_send_def handle_call_def handle_recv_def handle_reply_def handle_yield_def
                    handle_interrupt_def Let_def arch_mask_irq_signal_def
          | intro impI conjI allI | wp | wpc)+
-  done
-
-crunch guarded_switch_to,switch_to_idle_thread
-  for (bcorres) bcorres[wp]: truncate_state (ignore: storeWord clearExMonitor)
-
-lemma choose_switch_or_idle:
-  "((), s') \<in> fst (choose_thread s) \<Longrightarrow>
-       (\<exists>word. ((),s') \<in> fst (guarded_switch_to word s)) \<or>
-       ((),s') \<in> fst (switch_to_idle_thread s)"
-  apply (simp add: choose_thread_def)
-  apply (clarsimp simp add: switch_to_idle_thread_def bind_def gets_def
-                   arch_switch_to_idle_thread_def in_monad
-                   return_def get_def modify_def put_def
-                    get_thread_state_def
-                   thread_get_def
-                   split: if_split_asm)
-  apply force
   done
 
 end

--- a/proof/invariant-abstract/ARM/ArchBCorres2_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchBCorres2_AI.thy
@@ -74,10 +74,6 @@ lemma  handle_arch_fault_reply_bcorres[wp,BCorres2_AI_assms]:
   "bcorres ( handle_arch_fault_reply a b c d) (handle_arch_fault_reply a b c d)"
   by (cases a; simp add: handle_arch_fault_reply_def; wp)
 
-crunch
-    arch_switch_to_thread,arch_switch_to_idle_thread
-  for (bcorres) bcorres[wp, BCorres2_AI_assms]: truncate_state
-
 end
 
 interpretation BCorres2_AI?: BCorres2_AI
@@ -86,11 +82,9 @@ interpretation BCorres2_AI?: BCorres2_AI
   case 1 show ?case by (unfold_locales; (fact BCorres2_AI_assms)?)
   qed
 
-lemmas schedule_bcorres[wp] = schedule_bcorres1[OF BCorres2_AI_axioms]
-
 context Arch begin arch_global_naming
 
-crunch send_ipc,send_signal,do_reply_transfer,arch_perform_invocation
+crunch send_ipc,send_signal,do_reply_transfer,arch_perform_invocation,invoke_domain
   for (bcorres) bcorres[wp]: truncate_state
   (simp: gets_the_def swp_def ignore: freeMemory clearMemory loadWord cap_fault_on_failure
          storeWord lookup_error_on_failure getRestartPC getRegister mapME)

--- a/proof/invariant-abstract/ARM/ArchDetSchedAux_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchDetSchedAux_AI.thy
@@ -12,92 +12,43 @@ context Arch begin arch_global_naming
 
 named_theorems DetSchedAux_AI_assms
 
+lemma set_pd_etcbs[wp]:
+  "set_pd p pd \<lbrace>\<lambda>s. P (etcbs_of s)\<rbrace>"
+  unfolding set_pd_def
+  apply (wpsimp wp: set_object_wp_strong)
+  by (auto elim!: rsubst[where P=P] simp: etcbs_of'_def obj_at_def a_type_def
+           split: kernel_object.splits)
+
 crunch init_arch_objects
   for exst[wp]: "\<lambda>s. P (exst s)"
-  and ct[wp]: "\<lambda>s. P (cur_thread s)"
-  and valid_etcbs[wp, DetSchedAux_AI_assms]: valid_etcbs
-  (wp: crunch_wps unless_wp valid_etcbs_lift)
+  and etcbs_of[wp, DetSchedAux_AI_assms]: "\<lambda>s. P (etcbs_of s)"
+  and ready_queues[wp, DetSchedAux_AI_assms]: "\<lambda>s. P (ready_queues s)"
+  and idle_thread[wp, DetSchedAux_AI_assms]: "\<lambda>s. P (idle_thread s)"
+  and schedact[wp, DetSchedAux_AI_assms]: "\<lambda>s. P (scheduler_action s)"
+  and cur_domain[wp, DetSchedAux_AI_assms]: "\<lambda>s. P (cur_domain s)"
+  (wp: crunch_wps)
 
-crunch invoke_untyped
-  for ct[wp, DetSchedAux_AI_assms]: "\<lambda>s. P (cur_thread s)"
-  (wp: crunch_wps dxo_wp_weak preemption_point_inv mapME_x_inv_wp
-   simp: crunch_simps do_machine_op_def detype_def mapM_x_defsym unless_def
-   ignore: freeMemory retype_region_ext)
-crunch invoke_untyped
-  for ready_queues[wp, DetSchedAux_AI_assms]: "\<lambda>s. P (ready_queues s)"
-  (wp: crunch_wps mapME_x_inv_wp preemption_point_inv'
-   simp: detype_def detype_ext_def crunch_simps
-          wrap_ext_det_ext_ext_def mapM_x_defsym
-   ignore: freeMemory)
-crunch invoke_untyped
-  for scheduler_action[wp, DetSchedAux_AI_assms]: "\<lambda>s. P (scheduler_action s)"
-  (wp: crunch_wps mapME_x_inv_wp preemption_point_inv'
-   simp: detype_def detype_ext_def crunch_simps
-         wrap_ext_det_ext_ext_def mapM_x_defsym
-   ignore: freeMemory)
-crunch invoke_untyped
-  for cur_domain[wp, DetSchedAux_AI_assms]: "\<lambda>s. P (cur_domain s)"
-  (wp: crunch_wps mapME_x_inv_wp preemption_point_inv'
-   simp: detype_def detype_ext_def crunch_simps
-         wrap_ext_det_ext_ext_def mapM_x_defsym
-   ignore: freeMemory)
-crunch invoke_untyped
-  for idle_thread[wp, DetSchedAux_AI_assms]: "\<lambda>s. P (idle_thread s)"
-  (wp: crunch_wps mapME_x_inv_wp preemption_point_inv dxo_wp_weak
-   simp: detype_def detype_ext_def crunch_simps
-         wrap_ext_det_ext_ext_def mapM_x_defsym
-   ignore: freeMemory retype_region_ext)
+crunch init_arch_objects
+  for valid_queues[wp]: valid_queues
+  and valid_sched_action[wp]: valid_sched_action
+  and valid_sched[wp]: valid_sched
+  (wp: valid_queues_lift valid_sched_action_lift valid_sched_lift)
 
 lemma tcb_sched_action_valid_idle_etcb:
-  "\<lbrace>valid_idle_etcb\<rbrace>
-     tcb_sched_action foo thread
-   \<lbrace>\<lambda>_. valid_idle_etcb\<rbrace>"
-  apply (rule valid_idle_etcb_lift)
-  apply (simp add: tcb_sched_action_def set_tcb_queue_def)
-  apply (wp | simp)+
-  done
-
-lemma delete_objects_etcb_at[wp, DetSchedAux_AI_assms]:
-  "\<lbrace>\<lambda>s::det_ext state. etcb_at P t s\<rbrace> delete_objects a b \<lbrace>\<lambda>r s. etcb_at P t s\<rbrace>"
-  apply (simp add: delete_objects_def)
-  apply (wp)
-  apply (simp add: detype_def detype_ext_def wrap_ext_det_ext_ext_def etcb_at_def|wp)+
-  done
-
-crunch reset_untyped_cap
-  for etcb_at[wp]: "etcb_at P t"
-  (wp: preemption_point_inv' mapME_x_inv_wp crunch_wps
-    simp: unless_def)
-
-crunch reset_untyped_cap
-  for valid_etcbs[wp]: "valid_etcbs"
-  (wp: preemption_point_inv' mapME_x_inv_wp crunch_wps
-    simp: unless_def)
-
-lemma invoke_untyped_etcb_at [DetSchedAux_AI_assms]:
-  "\<lbrace>(\<lambda>s :: det_ext state. etcb_at P t s) and valid_etcbs\<rbrace> invoke_untyped ui \<lbrace>\<lambda>r s. st_tcb_at (Not o inactive) t s \<longrightarrow> etcb_at P t s\<rbrace>"
-  apply (cases ui)
-  apply (simp add: mapM_x_def[symmetric] invoke_untyped_def whenE_def
-           split del: if_split)
-  apply (wp retype_region_etcb_at mapM_x_wp'
-            create_cap_no_pred_tcb_at typ_at_pred_tcb_at_lift
-            hoare_convert_imp[OF create_cap_no_pred_tcb_at]
-            hoare_convert_imp[OF _ init_arch_objects_exst]
-      | simp
-      | (wp (once) hoare_drop_impE_E))+
-  done
-
+  "tcb_sched_action foo thread \<lbrace>valid_idle_etcb\<rbrace>"
+  by (rule valid_idle_etcb_lift)
+     (wpsimp simp: tcb_sched_action_def set_tcb_queue_def)
 
 crunch init_arch_objects
   for valid_blocked[wp, DetSchedAux_AI_assms]: valid_blocked
-  (wp: valid_blocked_lift set_cap_typ_at)
+  (wp: valid_blocked_lift crunch_wps)
 
-lemma perform_asid_control_etcb_at:"\<lbrace>(\<lambda>s. etcb_at P t s) and valid_etcbs\<rbrace>
-          perform_asid_control_invocation aci
-          \<lbrace>\<lambda>r s. st_tcb_at (Not \<circ> inactive) t s \<longrightarrow> etcb_at P t s\<rbrace>"
+lemma perform_asid_control_etcb_at:
+  "\<lbrace>etcb_at P t\<rbrace>
+   perform_asid_control_invocation aci
+   \<lbrace>\<lambda>r s. st_tcb_at (Not \<circ> inactive) t s \<longrightarrow> etcb_at P t s\<rbrace>"
   apply (simp add: perform_asid_control_invocation_def)
-  apply (rule hoare_pre)
-   apply (wp | wpc | simp)+
+  apply wpsimp
        apply (wp hoare_imp_lift_something typ_at_pred_tcb_at_lift)[1]
       apply (rule hoare_drop_imps)
       apply (wp retype_region_etcb_at)+
@@ -105,25 +56,15 @@ lemma perform_asid_control_etcb_at:"\<lbrace>(\<lambda>s. etcb_at P t s) and val
   done
 
 crunch perform_asid_control_invocation
-  for ct[wp]: "\<lambda>s. P (cur_thread s)"
-
-crunch perform_asid_control_invocation
   for idle_thread[wp]: "\<lambda>s. P (idle_thread s)"
+  and valid_blocked[wp]: valid_blocked
+  and schedact[wp]: "\<lambda>s. P (scheduler_action s)"
+  and ready_queues[wp]: "\<lambda>s. P (ready_queues s)"
+  and cur_domain[wp]: "\<lambda>s. P (cur_domain s)"
+  (wp: hoare_weak_lift_imp simp: detype_def)
 
 crunch perform_asid_control_invocation
-  for valid_etcbs[wp]: valid_etcbs (wp: hoare_weak_lift_imp)
-
-crunch perform_asid_control_invocation
-  for valid_blocked[wp]: valid_blocked (wp: hoare_weak_lift_imp)
-
-crunch perform_asid_control_invocation
-  for schedact[wp]: "\<lambda>s :: det_ext state. P (scheduler_action s)" (wp: crunch_wps simp: detype_def detype_ext_def wrap_ext_det_ext_ext_def cap_insert_ext_def ignore: freeMemory)
-
-crunch perform_asid_control_invocation
-  for rqueues[wp]: "\<lambda>s :: det_ext state. P (ready_queues s)" (wp: crunch_wps simp: detype_def detype_ext_def wrap_ext_det_ext_ext_def cap_insert_ext_def ignore: freeMemory)
-
-crunch perform_asid_control_invocation
-  for cur_domain[wp]: "\<lambda>s :: det_ext state. P (cur_domain s)" (wp: crunch_wps simp: detype_def detype_ext_def wrap_ext_det_ext_ext_def cap_insert_ext_def ignore: freeMemory)
+  for ct[wp]: "\<lambda>s. P (cur_thread s)"
 
 lemma perform_asid_control_invocation_valid_sched:
   "\<lbrace>ct_active and invs and valid_aci aci and valid_sched and valid_idle\<rbrace>
@@ -143,25 +84,10 @@ lemma perform_asid_control_invocation_valid_sched:
   apply simp
   done
 
-crunch init_arch_objects
-  for valid_queues[wp]: valid_queues (wp: valid_queues_lift)
-
-crunch init_arch_objects
-  for valid_sched_action[wp]: valid_sched_action (wp: valid_sched_action_lift)
-
-crunch init_arch_objects
-  for valid_sched[wp]: valid_sched (wp: valid_sched_lift)
-
 end
 
 lemmas tcb_sched_action_valid_idle_etcb
     = ARM.tcb_sched_action_valid_idle_etcb
-
-global_interpretation DetSchedAux_AI_det_ext?: DetSchedAux_AI_det_ext
-  proof goal_cases
-  interpret Arch .
-  case 1 show ?case by (unfold_locales; (fact DetSchedAux_AI_assms)?)
-  qed
 
 global_interpretation DetSchedAux_AI?: DetSchedAux_AI
   proof goal_cases

--- a/proof/invariant-abstract/ARM/ArchDetSchedDomainTime_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchDetSchedDomainTime_AI.thy
@@ -68,7 +68,7 @@ lemma timer_tick_valid_domain_time:
    \<lbrace>\<lambda>x s. domain_time s = 0 \<longrightarrow> scheduler_action s = choose_new_thread\<rbrace>" (is "\<lbrace> ?dtnot0 \<rbrace> _ \<lbrace> _ \<rbrace>")
   unfolding timer_tick_def
   supply if_split[split del]
-  supply ethread_get_wp[wp del]
+  supply thread_get_wp[wp del]
   supply if_apply_def2[simp]
   apply (wpsimp
            wp: reschedule_required_valid_domain_time hoare_vcg_const_imp_lift gts_wp
@@ -76,9 +76,12 @@ lemma timer_tick_valid_domain_time:
                   postcondition once we hit thread_set_time_slice *)
                hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and Q="\<lambda>_ s. domain_time s = 0 \<longrightarrow> X s"
                                 and f="thread_set_time_slice t ts" for X t ts]
-               hoare_drop_imp[where f="ethread_get t f" for t f])
+               hoare_drop_imp[where f="thread_get t f" for t f])
   apply fastforce
   done
+
+crunch do_machine_op
+  for domain_time_sched[wp]: "\<lambda>s. P (domain_time s) (scheduler_action s)"
 
 lemma handle_interrupt_valid_domain_time [DetSchedDomainTime_AI_assms]:
   "\<lbrace>\<lambda>s :: det_ext state. 0 < domain_time s \<rbrace>

--- a/proof/invariant-abstract/ARM/ArchDetSchedDomainTime_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchDetSchedDomainTime_AI.thy
@@ -20,9 +20,10 @@ crunch
   arch_activate_idle_thread, arch_switch_to_thread, arch_switch_to_idle_thread,
   handle_arch_fault_reply,
   arch_invoke_irq_control, handle_vm_fault, arch_get_sanitise_register_info,
-  prepare_thread_delete, handle_hypervisor_fault, make_arch_fault_msg,
+  prepare_thread_delete, handle_hypervisor_fault, make_arch_fault_msg, init_arch_objects,
   arch_post_modify_registers, arch_post_cap_deletion, arch_invoke_irq_handler
-  for domain_list_inv[wp, DetSchedDomainTime_AI_assms]: "\<lambda>s. P (domain_list s)"
+  for domain_list_inv[wp, DetSchedDomainTime_AI_assms]: "\<lambda>s::det_state. P (domain_list s)"
+  (wp: crunch_wps)
 
 crunch arch_finalise_cap
   for domain_time_inv[wp, DetSchedDomainTime_AI_assms]: "\<lambda>s. P (domain_time s)"
@@ -34,7 +35,8 @@ crunch
   arch_invoke_irq_control, handle_vm_fault, arch_get_sanitise_register_info,
   prepare_thread_delete, handle_hypervisor_fault,
   arch_post_modify_registers, arch_post_cap_deletion, arch_invoke_irq_handler
-  for domain_time_inv[wp, DetSchedDomainTime_AI_assms]: "\<lambda>s. P (domain_time s)"
+  for domain_time_inv[wp, DetSchedDomainTime_AI_assms]: "\<lambda>s::det_state. P (domain_time s)"
+  (wp: crunch_wps)
 declare init_arch_objects_exst[DetSchedDomainTime_AI_assms]
         make_arch_fault_msg_inv[DetSchedDomainTime_AI_assms]
 
@@ -55,11 +57,11 @@ crunch arch_mask_irq_signal
   for domain_list_inv[wp, DetSchedDomainTime_AI_assms]: "\<lambda>s. P (domain_list s)"
 
 crunch arch_perform_invocation
-  for domain_time_inv[wp, DetSchedDomainTime_AI_assms]: "\<lambda>s. P (domain_time s)"
+  for domain_time_inv[wp, DetSchedDomainTime_AI_assms]: "\<lambda>s::det_state. P (domain_time s)"
   (wp: crunch_wps check_cap_inv)
 
 crunch arch_perform_invocation
-  for domain_list_inv[wp, DetSchedDomainTime_AI_assms]: "\<lambda>s. P (domain_list s)"
+  for domain_list_inv[wp, DetSchedDomainTime_AI_assms]: "\<lambda>s::det_state. P (domain_list s)"
   (wp: crunch_wps check_cap_inv)
 
 lemma timer_tick_valid_domain_time:

--- a/proof/invariant-abstract/ARM/ArchDetSchedSchedule_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchDetSchedSchedule_AI.thy
@@ -20,11 +20,6 @@ crunch
   for prepare_thread_delete_idle_thread[wp, DetSchedSchedule_AI_assms]: "\<lambda>(s:: det_ext state). P (idle_thread s)"
 
 crunch
-  arch_switch_to_idle_thread, arch_switch_to_thread, arch_get_sanitise_register_info, arch_post_modify_registers
-  for valid_etcbs[wp, DetSchedSchedule_AI_assms]: valid_etcbs
-  (simp: crunch_simps ignore: clearExMonitor)
-
-crunch
   switch_to_idle_thread, switch_to_thread, set_vm_root, arch_get_sanitise_register_info, arch_post_modify_registers
   for valid_queues[wp, DetSchedSchedule_AI_assms]: valid_queues
   (simp: crunch_simps ignore: set_tcb_queue tcb_sched_action clearExMonitor)
@@ -35,11 +30,9 @@ crunch
   (simp: crunch_simps ignore: clearExMonitor)
 
 crunch set_vm_root
-  for ct_not_in_q[wp]: "ct_not_in_q"
-  (wp: crunch_wps simp: crunch_simps)
-
-crunch set_vm_root
-  for ct_not_in_q'[wp]: "\<lambda>s. ct_not_in_q_2 (ready_queues s) (scheduler_action s) t"
+  for ready_queues[wp]: "\<lambda>s. P (ready_queues s)"
+  and ct_not_in_q[wp]: "ct_not_in_q"
+  and ct_not_in_q'[wp]: "\<lambda>s. ct_not_in_q_2 (ready_queues s) (scheduler_action s) t"
   (wp: crunch_wps simp: crunch_simps)
 
 lemma switch_to_idle_thread_ct_not_in_q [wp, DetSchedSchedule_AI_assms]:
@@ -54,7 +47,7 @@ lemma switch_to_idle_thread_ct_not_in_q [wp, DetSchedSchedule_AI_assms]:
 
 crunch set_vm_root
   for valid_sched_action'[wp]: "\<lambda>s. valid_sched_action_2 (scheduler_action s)
-                                                 (ekheap s) (kheap s) thread (cur_domain s)"
+                                                 (etcbs_of s) (kheap s) thread (cur_domain s)"
   (wp: crunch_wps simp: crunch_simps)
 
 lemma switch_to_idle_thread_valid_sched_action [wp, DetSchedSchedule_AI_assms]:
@@ -71,7 +64,7 @@ lemma switch_to_idle_thread_valid_sched_action [wp, DetSchedSchedule_AI_assms]:
 
 crunch set_vm_root
   for ct_in_cur_domain'[wp]: "\<lambda>s. ct_in_cur_domain_2 t (idle_thread s)
-                                                   (scheduler_action s) (cur_domain s) (ekheap s)"
+                                                   (scheduler_action s) (cur_domain s) (etcbs_of s)"
   (wp: crunch_wps simp: crunch_simps)
 
 lemma switch_to_idle_thread_ct_in_cur_domain [wp, DetSchedSchedule_AI_assms]:
@@ -102,7 +95,7 @@ crunch set_vm_root
   (wp: crunch_wps whenE_wp simp: crunch_simps)
 
 crunch arch_switch_to_thread
-  for ct_in_cur_domain_2[wp, DetSchedSchedule_AI_assms]: "\<lambda>s. ct_in_cur_domain_2 thread (idle_thread s) (scheduler_action s) (cur_domain s) (ekheap s)"
+  for ct_in_cur_domain_2[wp, DetSchedSchedule_AI_assms]: "\<lambda>s. ct_in_cur_domain_2 thread (idle_thread s) (scheduler_action s) (cur_domain s) (etcbs_of s)"
   (simp: crunch_simps)
 
 crunch set_vm_root
@@ -192,20 +185,19 @@ lemma switch_to_idle_thread_cur_thread_idle_thread [wp, DetSchedSchedule_AI_assm
   "\<lbrace>\<top>\<rbrace> switch_to_idle_thread \<lbrace>\<lambda>_ s. cur_thread s = idle_thread s\<rbrace>"
   by (wp | simp add:switch_to_idle_thread_def arch_switch_to_idle_thread_def)+
 
-lemma set_pd_valid_etcbs[wp]:
-  "\<lbrace>valid_etcbs\<rbrace> set_pd ptr pd \<lbrace>\<lambda>rv. valid_etcbs\<rbrace>"
-  by (wp hoare_drop_imps valid_etcbs_lift | simp add: set_pd_def)+
-
 lemma set_pt_etcbs[wp]:
   "set_pt ptr pt \<lbrace>\<lambda>s. P (etcbs_of s)\<rbrace>"
   unfolding set_pt_def
-  apply (wpsimp wp: set_object_wp get_object_wp)
-  apply (auto elim!: rsubst[where P=P] simp: obj_at_def etcbs_of'_def split: kernel_object.splits)
-  done
+  apply (wpsimp wp: set_object_wp_strong)
+  by (auto elim!: rsubst[where P=P] simp: etcbs_of'_def obj_at_def a_type_def
+           split: kernel_object.splits)
 
-lemma set_asid_pool_valid_etcbs[wp]:
-  "\<lbrace>valid_etcbs\<rbrace> set_asid_pool ptr pool \<lbrace>\<lambda>rv. valid_etcbs\<rbrace>"
-  by (wp hoare_drop_imps valid_etcbs_lift | simp add: set_asid_pool_def)+
+lemma set_asid_pool_etcbs[wp]:
+  "set_asid_pool ptr pool \<lbrace>\<lambda>s. P (etcbs_of s)\<rbrace>"
+  unfolding set_asid_pool_def
+  apply (wpsimp wp: set_object_wp_strong)
+  by (auto elim!: rsubst[where P=P] simp: etcbs_of'_def obj_at_def a_type_def
+           split: kernel_object.splits)
 
 lemma set_pt_valid_sched[wp]:
   "\<lbrace>valid_sched\<rbrace> set_pt ptr pt \<lbrace>\<lambda>rv. valid_sched\<rbrace>"
@@ -224,12 +216,6 @@ crunch
   for ct_not_in_q[wp, DetSchedSchedule_AI_assms]: ct_not_in_q
   (wp: crunch_wps hoare_drop_imps unless_wp select_inv mapM_wp
        subset_refl if_fun_split simp: crunch_simps ignore: tcb_sched_action)
-
-crunch
-  arch_finalise_cap, prepare_thread_delete
-  for valid_etcbs[wp, DetSchedSchedule_AI_assms]: valid_etcbs
-  (wp: hoare_drop_imps unless_wp select_inv mapM_x_wp mapM_wp subset_refl
-       if_fun_split simp: crunch_simps ignore: set_object thread_set)
 
 crunch
   arch_finalise_cap, prepare_thread_delete

--- a/proof/invariant-abstract/ARM/ArchDetSchedSchedule_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchDetSchedSchedule_AI.thy
@@ -142,7 +142,7 @@ lemma arch_switch_to_thread_valid_blocked [wp, DetSchedSchedule_AI_assms]:
   done
 
 lemma switch_to_idle_thread_ct_not_queued [wp, DetSchedSchedule_AI_assms]:
-  "\<lbrace>valid_queues and valid_etcbs and valid_idle\<rbrace>
+  "\<lbrace>valid_queues and valid_idle\<rbrace>
      switch_to_idle_thread
    \<lbrace>\<lambda>rv s. not_queued (cur_thread s) s\<rbrace>"
   apply (simp add: switch_to_idle_thread_def arch_switch_to_idle_thread_def
@@ -196,9 +196,12 @@ lemma set_pd_valid_etcbs[wp]:
   "\<lbrace>valid_etcbs\<rbrace> set_pd ptr pd \<lbrace>\<lambda>rv. valid_etcbs\<rbrace>"
   by (wp hoare_drop_imps valid_etcbs_lift | simp add: set_pd_def)+
 
-lemma set_pt_valid_etcbs[wp]:
-  "\<lbrace>valid_etcbs\<rbrace> set_pt ptr pt \<lbrace>\<lambda>rv. valid_etcbs\<rbrace>"
-  by (wp hoare_drop_imps valid_etcbs_lift | simp add: set_pt_def)+
+lemma set_pt_etcbs[wp]:
+  "set_pt ptr pt \<lbrace>\<lambda>s. P (etcbs_of s)\<rbrace>"
+  unfolding set_pt_def
+  apply (wpsimp wp: set_object_wp get_object_wp)
+  apply (auto elim!: rsubst[where P=P] simp: obj_at_def etcbs_of'_def split: kernel_object.splits)
+  done
 
 lemma set_asid_pool_valid_etcbs[wp]:
   "\<lbrace>valid_etcbs\<rbrace> set_asid_pool ptr pool \<lbrace>\<lambda>rv. valid_etcbs\<rbrace>"
@@ -311,11 +314,9 @@ lemma arch_post_modify_registers_not_idle_thread[DetSchedSchedule_AI_assms]:
 
 crunch arch_post_cap_deletion
   for valid_sched[wp, DetSchedSchedule_AI_assms]: valid_sched
-  and valid_etcbs[wp, DetSchedSchedule_AI_assms]: valid_etcbs
   and ct_not_in_q[wp, DetSchedSchedule_AI_assms]: ct_not_in_q
   and simple_sched_action[wp, DetSchedSchedule_AI_assms]: simple_sched_action
   and not_cur_thread[wp, DetSchedSchedule_AI_assms]: "not_cur_thread t"
-  and is_etcb_at[wp, DetSchedSchedule_AI_assms]: "is_etcb_at t"
   and not_queued[wp, DetSchedSchedule_AI_assms]: "not_queued t"
   and sched_act_not[wp, DetSchedSchedule_AI_assms]: "scheduler_act_not t"
   and weak_valid_sched_action[wp, DetSchedSchedule_AI_assms]: weak_valid_sched_action
@@ -344,6 +345,10 @@ crunch cap_swap_for_delete, cap_move, cancel_badged_sends
   (wp: syscall_valid crunch_wps rec_del_preservation cap_revoke_preservation modify_wp dxo_wp_weak
    simp: crunch_simps check_cap_at_def filterM_mapM unless_def
    ignore: without_preemption filterM rec_del check_cap_at cap_revoke)
+
+crunch arch_switch_to_thread
+  for etcbs_of[wp, DetSchedSchedule_AI_assms]: "\<lambda>s. P (etcbs_of s)"
+  and cur_domain[wp, DetSchedSchedule_AI_assms]: "\<lambda>s. P (cur_domain s)"
 
 end
 

--- a/proof/invariant-abstract/ARM/ArchDetype_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchDetype_AI.thy
@@ -450,9 +450,8 @@ lemma in_user_frame_eq:
                      Int_atLeastAtMost atLeastatMost_empty_iff split_paired_Ex
                      order_class.Icc_eq_Icc
     and [simp] = p2pm1_to_mask
-  shows "p \<notin> untyped_range cap \<Longrightarrow> in_user_frame p
-              (trans_state (\<lambda>_. detype_ext (untyped_range cap) (exst s)) s
-               \<lparr>kheap := \<lambda>x. if x \<in> untyped_range cap then None else kheap s x\<rparr>)
+  shows "p \<notin> untyped_range cap \<Longrightarrow>
+         in_user_frame p (s \<lparr>kheap := \<lambda>x. if x \<in> untyped_range cap then None else kheap s x\<rparr>)
          = in_user_frame p s"
     using cap_is_valid untyped
     apply (cases cap; simp add: in_user_frame_def valid_untyped_def valid_cap_def obj_at_def)
@@ -478,9 +477,7 @@ lemma in_device_frame_eq:
           order_class.Icc_eq_Icc
      and  p2pm1[simp] = p2pm1_to_mask
   shows "p \<notin> untyped_range cap
-       \<Longrightarrow> in_device_frame p
-              (trans_state (\<lambda>_. detype_ext (untyped_range cap) (exst s)) s
-               \<lparr>kheap := \<lambda>x. if x \<in> untyped_range cap then None else kheap s x\<rparr>)
+       \<Longrightarrow> in_device_frame p (s \<lparr>kheap := \<lambda>x. if x \<in> untyped_range cap then None else kheap s x\<rparr>)
          = in_device_frame p s"
     using cap_is_valid untyped
     unfolding in_device_frame_def

--- a/proof/invariant-abstract/ARM/ArchEmptyFail_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchEmptyFail_AI.thy
@@ -142,18 +142,6 @@ crunch
   for (empty_fail) empty_fail[wp, EmptyFail_AI_assms]
 end
 
-global_interpretation EmptyFail_AI_schedule_unit?: EmptyFail_AI_schedule_unit
-  proof goal_cases
-  interpret Arch .
-  case 1 show ?case by (unfold_locales; (fact EmptyFail_AI_assms)?)
-  qed
-
-global_interpretation EmptyFail_AI_schedule_det?: EmptyFail_AI_schedule_det
-  proof goal_cases
-  interpret Arch .
-  case 1 show ?case by (unfold_locales; (fact EmptyFail_AI_assms)?)
-  qed
-
 global_interpretation EmptyFail_AI_schedule?: EmptyFail_AI_schedule
   proof goal_cases
   interpret Arch .
@@ -171,20 +159,8 @@ crunch possible_switch_to, handle_event, activate_thread
          page_table_invocation.splits page_invocation.splits asid_control_invocation.splits
          asid_pool_invocation.splits arch_invocation.splits irq_state.splits syscall.splits
          flush_type.splits page_directory_invocation.splits
-   ignore: resetTimer_impl ackInterrupt_impl ignore_del: possible_switch_to)
+   ignore: resetTimer_impl ackInterrupt_impl)
 end
-
-global_interpretation EmptyFail_AI_call_kernel_unit?: EmptyFail_AI_call_kernel_unit
-  proof goal_cases
-  interpret Arch .
-  case 1 show ?case by (unfold_locales; (fact EmptyFail_AI_assms)?)
-  qed
-
-global_interpretation EmptyFail_AI_call_kernel_det?: EmptyFail_AI_call_kernel_det
-  proof goal_cases
-  interpret Arch .
-  case 1 show ?case by (unfold_locales; (fact EmptyFail_AI_assms)?)
-  qed
 
 global_interpretation EmptyFail_AI_call_kernel?: EmptyFail_AI_call_kernel
   proof goal_cases

--- a/proof/invariant-abstract/ARM/ArchInterrupt_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchInterrupt_AI.thy
@@ -201,6 +201,10 @@ lemma empty_fail_maskInterrupt_ARCH[Interrupt_AI_assms]:
   "empty_fail (maskInterrupt f irq)"
   by (wp | simp add: maskInterrupt_def)+
 
+crunch timer_tick
+  for invs[wp]: invs
+  (wp: thread_set_invs_trivial[OF ball_tcb_cap_casesI])
+
 lemma (* handle_interrupt_invs *) [Interrupt_AI_assms]:
   "\<lbrace>invs\<rbrace> handle_interrupt irq \<lbrace>\<lambda>_. invs\<rbrace>"
   apply (simp add: handle_interrupt_def)

--- a/proof/invariant-abstract/ARM/ArchInvariants_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchInvariants_AI.thy
@@ -2303,84 +2303,47 @@ lemma valid_arch_arch_tcb_context_set[simp]:
   "valid_arch_tcb (arch_tcb_context_set a t) = valid_arch_tcb t"
   by (simp add: arch_tcb_context_set_def)
 
-lemma tcb_arch_ref_context_update:
-  "tcb_arch_ref (t\<lparr>tcb_arch := (arch_tcb_context_set a (tcb_arch t))\<rparr>) = tcb_arch_ref t"
-  by (simp add: tcb_arch_ref_def arch_tcb_context_set_def)
-
-lemma tcb_arch_ref_set_registers:
-  "tcb_arch_ref (tcb\<lparr>tcb_arch := arch_tcb_set_registers regs (tcb_arch tcb)\<rparr>) = tcb_arch_ref tcb"
-  by (simp add: tcb_arch_ref_def)
-
 lemma valid_arch_arch_tcb_set_registers[simp]:
   "valid_arch_tcb (arch_tcb_set_registers a t) = valid_arch_tcb t"
    by (simp add: arch_tcb_set_registers_def)
 
-lemma tcb_arch_ref_ipc_buffer_update: "\<And>tcb.
-       tcb_arch_ref (tcb_ipc_buffer_update f tcb) = tcb_arch_ref tcb"
-  by (simp add: tcb_arch_ref_def)
-
-lemma tcb_arch_ref_mcpriority_update: "\<And>tcb.
-       tcb_arch_ref (tcb_mcpriority_update f tcb) = tcb_arch_ref tcb"
-  by (simp add: tcb_arch_ref_def)
-
-lemma tcb_arch_ref_ctable_update: "\<And>tcb.
-       tcb_arch_ref (tcb_ctable_update f tcb) = tcb_arch_ref tcb"
-  by (simp add: tcb_arch_ref_def)
-
-lemma tcb_arch_ref_vtable_update: "\<And>tcb.
-       tcb_arch_ref (tcb_vtable_update f tcb) = tcb_arch_ref tcb"
-  by (simp add: tcb_arch_ref_def)
-
-lemma tcb_arch_ref_reply_update: "\<And>tcb.
-       tcb_arch_ref (tcb_reply_update f tcb) = tcb_arch_ref tcb"
-  by (simp add: tcb_arch_ref_def)
-
-lemma tcb_arch_ref_caller_update: "\<And>tcb.
-       tcb_arch_ref (tcb_caller_update f tcb) = tcb_arch_ref tcb"
-  by (simp add: tcb_arch_ref_def)
-
-lemma tcb_arch_ref_ipcframe_update: "\<And>tcb.
-       tcb_arch_ref (tcb_ipcframe_update f tcb) = tcb_arch_ref tcb"
-  by (simp add: tcb_arch_ref_def)
-
-lemma tcb_arch_ref_state_update: "\<And>tcb.
-       tcb_arch_ref (tcb_state_update f tcb) = tcb_arch_ref tcb"
-  by (simp add: tcb_arch_ref_def)
-
-lemma tcb_arch_ref_fault_handler_update: "\<And>tcb.
-       tcb_arch_ref (tcb_fault_handler_update f tcb) = tcb_arch_ref tcb"
-  by (simp add: tcb_arch_ref_def)
-
-lemma tcb_arch_ref_fault_update: "\<And>tcb.
-       tcb_arch_ref (tcb_fault_update f tcb) = tcb_arch_ref tcb"
-  by (simp add: tcb_arch_ref_def)
-
-lemma tcb_arch_ref_bound_notification_update: "\<And>tcb.
-       tcb_arch_ref (tcb_bound_notification_update f tcb) = tcb_arch_ref tcb"
-  by (simp add: tcb_arch_ref_def)
-
-
-lemmas tcb_arch_ref_simps[simp] = tcb_arch_ref_ipc_buffer_update tcb_arch_ref_mcpriority_update
-  tcb_arch_ref_ctable_update tcb_arch_ref_vtable_update tcb_arch_ref_reply_update
-  tcb_arch_ref_caller_update tcb_arch_ref_ipcframe_update tcb_arch_ref_state_update
-  tcb_arch_ref_fault_handler_update tcb_arch_ref_fault_update tcb_arch_ref_bound_notification_update
-  tcb_arch_ref_context_update tcb_arch_ref_set_registers
+lemma tcb_arch_ref_simps[simp]:
+  "\<And>f. tcb_arch_ref (tcb_ipc_buffer_update f tcb) = tcb_arch_ref tcb"
+  "\<And>f. tcb_arch_ref (tcb_mcpriority_update f tcb) = tcb_arch_ref tcb"
+  "\<And>f. tcb_arch_ref (tcb_ctable_update f tcb) = tcb_arch_ref tcb"
+  "\<And>f. tcb_arch_ref (tcb_vtable_update f tcb) = tcb_arch_ref tcb"
+  "\<And>f. tcb_arch_ref (tcb_reply_update f tcb) = tcb_arch_ref tcb"
+  "\<And>f. tcb_arch_ref (tcb_caller_update f tcb) = tcb_arch_ref tcb"
+  "\<And>f. tcb_arch_ref (tcb_ipcframe_update f tcb) = tcb_arch_ref tcb"
+  "\<And>f. tcb_arch_ref (tcb_state_update f tcb) = tcb_arch_ref tcb"
+  "\<And>f. tcb_arch_ref (tcb_fault_handler_update f tcb) = tcb_arch_ref tcb"
+  "\<And>f. tcb_arch_ref (tcb_fault_update f tcb) = tcb_arch_ref tcb"
+  "\<And>f. tcb_arch_ref (tcb_bound_notification_update f tcb) = tcb_arch_ref tcb"
+  "\<And>f. tcb_arch_ref (tcb_domain_update f tcb) = tcb_arch_ref tcb"
+  "\<And>f. tcb_arch_ref (tcb_priority_update f tcb) = tcb_arch_ref tcb"
+  "\<And>f. tcb_arch_ref (tcb_time_slice_update f tcb) = tcb_arch_ref tcb"
+  "tcb_arch_ref (t\<lparr>tcb_arch := (arch_tcb_context_set a (tcb_arch t))\<rparr>) = tcb_arch_ref t"
+  "tcb_arch_ref (tcb\<lparr>tcb_arch := arch_tcb_set_registers regs (tcb_arch tcb)\<rparr>) = tcb_arch_ref tcb"
+  by (auto simp: tcb_arch_ref_def arch_tcb_set_registers_def arch_tcb_context_set_def)
 
 lemma hyp_live_tcb_def: "hyp_live (TCB tcb) = bound (tcb_arch_ref tcb)"
   by (clarsimp simp: hyp_live_def tcb_arch_ref_def)
 
 lemma hyp_live_tcb_simps[simp]:
-"\<And>tcb f. hyp_live (TCB (tcb_ipc_buffer_update f tcb)) = hyp_live (TCB tcb)"
-"\<And>tcb f. hyp_live (TCB (tcb_mcpriority_update f tcb)) = hyp_live (TCB tcb)"
-"\<And>tcb f. hyp_live (TCB (tcb_ctable_update f tcb)) = hyp_live (TCB tcb)"
-"\<And>tcb f. hyp_live (TCB (tcb_vtable_update f tcb)) = hyp_live (TCB tcb)"
-"\<And>tcb f. hyp_live (TCB (tcb_reply_update f tcb)) = hyp_live (TCB tcb)"
-"\<And>tcb f. hyp_live (TCB (tcb_caller_update f tcb)) = hyp_live (TCB tcb)"
-"\<And>tcb f. hyp_live (TCB (tcb_ipcframe_update f tcb)) = hyp_live (TCB tcb)"
-"\<And>tcb f. hyp_live (TCB (tcb_state_update f tcb)) = hyp_live (TCB tcb)"
-"\<And>tcb f. hyp_live (TCB (tcb_fault_handler_update f tcb)) = hyp_live (TCB tcb)"
-"\<And>tcb f. hyp_live (TCB (tcb_fault_update f tcb)) = hyp_live (TCB tcb)"
-"\<And>tcb f. hyp_live (TCB (tcb_bound_notification_update f tcb)) = hyp_live (TCB tcb)"
+  "\<And>f. hyp_live (TCB (tcb_ipc_buffer_update f tcb)) = hyp_live (TCB tcb)"
+  "\<And>f. hyp_live (TCB (tcb_mcpriority_update f tcb)) = hyp_live (TCB tcb)"
+  "\<And>f. hyp_live (TCB (tcb_ctable_update f tcb)) = hyp_live (TCB tcb)"
+  "\<And>f. hyp_live (TCB (tcb_vtable_update f tcb)) = hyp_live (TCB tcb)"
+  "\<And>f. hyp_live (TCB (tcb_reply_update f tcb)) = hyp_live (TCB tcb)"
+  "\<And>f. hyp_live (TCB (tcb_caller_update f tcb)) = hyp_live (TCB tcb)"
+  "\<And>f. hyp_live (TCB (tcb_ipcframe_update f tcb)) = hyp_live (TCB tcb)"
+  "\<And>f. hyp_live (TCB (tcb_state_update f tcb)) = hyp_live (TCB tcb)"
+  "\<And>f. hyp_live (TCB (tcb_fault_handler_update f tcb)) = hyp_live (TCB tcb)"
+  "\<And>f. hyp_live (TCB (tcb_fault_update f tcb)) = hyp_live (TCB tcb)"
+  "\<And>f. hyp_live (TCB (tcb_bound_notification_update f tcb)) = hyp_live (TCB tcb)"
+  "\<And>f. hyp_live (TCB (tcb_domain_update f tcb)) = hyp_live (TCB tcb)"
+  "\<And>f. hyp_live (TCB (tcb_priority_update f tcb)) = hyp_live (TCB tcb)"
+  "\<And>f. hyp_live (TCB (tcb_time_slice_update f tcb)) = hyp_live (TCB tcb)"
   by (simp_all add: hyp_live_tcb_def)
 
 

--- a/proof/invariant-abstract/ARM/ArchKHeap_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchKHeap_AI.thy
@@ -839,6 +839,30 @@ lemma state_hyp_refs_of_tcb_state_update:
   apply (clarsimp simp add: ARM.state_hyp_refs_of_def obj_at_def split: option.splits)
   done
 
+lemma state_hyp_refs_of_tcb_domain_update:
+  "kheap s t = Some (TCB tcb) \<Longrightarrow>
+   state_hyp_refs_of (s\<lparr>kheap := (kheap s)(t \<mapsto> TCB (tcb\<lparr>tcb_domain := d\<rparr>))\<rparr>)
+     = state_hyp_refs_of s"
+  apply (rule all_ext)
+  apply (clarsimp simp add: state_hyp_refs_of_def obj_at_def split: option.splits)
+  done
+
+lemma state_hyp_refs_of_tcb_priority_update:
+  "kheap s t = Some (TCB tcb) \<Longrightarrow>
+   state_hyp_refs_of (s\<lparr>kheap := (kheap s)(t \<mapsto> TCB (tcb\<lparr>tcb_priority := p\<rparr>))\<rparr>)
+     = state_hyp_refs_of s"
+  apply (rule all_ext)
+  apply (clarsimp simp add: state_hyp_refs_of_def obj_at_def split: option.splits)
+  done
+
+lemma state_hyp_refs_of_tcb_time_slice_update:
+  "kheap s t = Some (TCB tcb) \<Longrightarrow>
+   state_hyp_refs_of (s\<lparr>kheap := (kheap s)(t \<mapsto> TCB (tcb\<lparr>tcb_time_slice := ts\<rparr>))\<rparr>)
+     = state_hyp_refs_of s"
+  apply (rule all_ext)
+  apply (clarsimp simp add: state_hyp_refs_of_def obj_at_def split: option.splits)
+  done
+
 lemma arch_valid_obj_same_type:
   "\<lbrakk> arch_valid_obj ao s; kheap s p = Some ko; a_type k = a_type ko \<rbrakk>
    \<Longrightarrow> arch_valid_obj ao (s\<lparr>kheap := (kheap s)(p \<mapsto> k)\<rparr>)"
@@ -846,11 +870,11 @@ lemma arch_valid_obj_same_type:
          clarsimp simp: typ_at_same_type)
 
 
-lemma default_arch_object_not_live: "\<not> live (ArchObj (default_arch_object aty dev us))"
+lemma default_arch_object_not_live[simp]: "\<not> live (ArchObj (default_arch_object aty dev us))"
   by (clarsimp simp: default_arch_object_def live_def hyp_live_def arch_live_def
                split: aobject_type.splits)
 
-lemma default_tcb_not_live: "\<not> live (TCB default_tcb)"
+lemma default_tcb_not_live[simp]: "\<not> live (TCB (default_tcb d))"
   by (clarsimp simp: default_tcb_def default_arch_tcb_def live_def hyp_live_def)
 
 lemma valid_arch_tcb_same_type:

--- a/proof/invariant-abstract/ARM/ArchKHeap_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchKHeap_AI.thy
@@ -796,7 +796,7 @@ lemma pspace_respects_region_cong[cong]:
 
 definition "obj_is_device tp dev \<equiv>
   case tp of Untyped \<Rightarrow> dev
-    | _ \<Rightarrow>(case (default_object tp dev 0) of (ArchObj (DataPage dev _)) \<Rightarrow> dev
+    | _ \<Rightarrow>(case default_object tp dev 0 0 of (ArchObj (DataPage dev _)) \<Rightarrow> dev
           | _ \<Rightarrow> False)"
 
 lemma cap_is_device_obj_is_device[simp]:

--- a/proof/invariant-abstract/ARM/ArchRetype_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchRetype_AI.thy
@@ -58,23 +58,14 @@ declare store_pde_state_hyp_refs_of [wp]
 
 (* These also prove facts about copy_global_mappings *)
 crunch init_arch_objects
-  for pspace_aligned[wp]: "pspace_aligned"
-  (ignore: clearMemory wp: crunch_wps unless_wp)
-crunch init_arch_objects
-  for pspace_distinct[wp]: "pspace_distinct"
-  (ignore: clearMemory wp: crunch_wps unless_wp)
-crunch init_arch_objects
-  for mdb_inv[wp]: "\<lambda>s. P (cdt s)"
-  (ignore: clearMemory wp: crunch_wps unless_wp)
-crunch init_arch_objects
-  for valid_mdb[wp]: "valid_mdb"
-  (ignore: clearMemory wp: crunch_wps unless_wp)
-crunch init_arch_objects
-  for cte_wp_at[wp]: "\<lambda>s. P (cte_wp_at P' p s)"
-  (ignore: clearMemory wp: crunch_wps unless_wp)
-crunch init_arch_objects
-  for typ_at[wp]: "\<lambda>s. P (typ_at T p s)"
-  (ignore: clearMemory wp: crunch_wps unless_wp)
+  for pspace_aligned[wp]:  "pspace_aligned"
+  and pspace_distinct[wp]: "pspace_distinct"
+  and mdb_inv[wp]: "\<lambda>s. P (cdt s)"
+  and valid_mdb[wp]: "valid_mdb"
+  and cte_wp_at[wp]: "\<lambda>s. P (cte_wp_at P' p s)"
+  and typ_at[wp]: "\<lambda>s. P (typ_at T p s)"
+  and cur_thread[wp]: "\<lambda>s. P (cur_thread s)"
+  (ignore: clearMemory wp: crunch_wps)
 
 lemma mdb_cte_at_store_pde[wp]:
   "\<lbrace>\<lambda>s. mdb_cte_at (swp (cte_wp_at ((\<noteq>) cap.NullCap)) s) (cdt s)\<rbrace>
@@ -769,23 +760,21 @@ lemma valid_cap:
   using cap
   apply (case_tac cap)
     unfolding valid_cap_def
-    apply (simp_all add: valid_cap_def obj_at_pres cte_at_pres
-                              split: option.split_asm arch_cap.split_asm
-                                     option.splits)
+             apply (simp_all add: valid_cap_def obj_at_pres cte_at_pres
+                           split: option.split_asm arch_cap.split_asm option.splits)
      apply (clarsimp simp add: valid_untyped_def ps_def s'_def)
      apply (intro conjI)
-       apply clarsimp
-       apply (drule disjoint_subset [OF retype_addrs_obj_range_subset [OF _ cover' tyunt]])
-        apply (simp add: Int_ac p_assoc_help[symmetric])
-       apply simp
       apply clarsimp
+      apply (drule disjoint_subset [OF retype_addrs_obj_range_subset [OF _ cover' tyunt]])
+       apply (simp add: Int_ac p_assoc_help[symmetric])
+      apply fastforce
+     apply clarsimp
      apply (drule disjoint_subset [OF retype_addrs_obj_range_subset [OF _ cover' tyunt]])
       apply (simp add: Int_ac p_assoc_help[symmetric])
-     apply simp
-     using cover tyunt
-     apply (simp add: obj_bits_api_def2 split: Structures_A.apiobject_type.splits)
-     apply clarsimp+
-    apply (fastforce elim!: obj_at_pres)+
+     apply fastforce
+    using cover tyunt
+    apply (simp add: obj_bits_api_def2 split: Structures_A.apiobject_type.splits)
+        apply (fastforce elim!: obj_at_pres)+
   done
   qed
 
@@ -802,13 +791,13 @@ lemma valid_arch_state:
                      valid_asid_table_def valid_global_pts_def)
 
 lemma vs_refs_default [simp]:
-  "vs_refs (default_object ty dev us) = {}"
+  "vs_refs (default_object ty dev us d) = {}"
   by (simp add: default_object_def default_arch_object_def tyunt vs_refs_def
                 o_def pde_ref_def graph_of_def
            split: Structures_A.apiobject_type.splits aobject_type.splits)
 
 lemma vs_refs_pages_default [simp]:
-  "vs_refs_pages (default_object ty dev us) = {}"
+  "vs_refs_pages (default_object ty dev us d) = {}"
   by (simp add: default_object_def default_arch_object_def tyunt vs_refs_pages_def
                 o_def pde_ref_pages_def pte_ref_pages_def graph_of_def
            split: Structures_A.apiobject_type.splits aobject_type.splits)
@@ -869,10 +858,10 @@ proof
   fix p ao
   assume p: "(\<exists>\<rhd> p) s'"
   assume "ko_at (ArchObj ao) p s'"
-  hence "ko_at (ArchObj ao) p s \<or> ArchObj ao = default_object ty dev us"
+  hence "ko_at (ArchObj ao) p s \<or> ArchObj ao = default_object ty dev us (cur_domain s)"
     by (simp add: ps_def obj_at_def s'_def split: if_split_asm)
   moreover
-  { assume "ArchObj ao = default_object ty dev us" with tyunt
+  { assume "ArchObj ao = default_object ty dev us (cur_domain s)" with tyunt
     have "valid_vspace_obj ao s'" by (rule valid_vspace_obj_default)
   }
   moreover

--- a/proof/invariant-abstract/ARM/ArchRetype_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchRetype_AI.thy
@@ -667,7 +667,7 @@ lemma valid_untyped_helper [Retype_AI_assms]:
   and     cn   : "caps_no_overlap ptr sz s"
   and     vp   : "valid_pspace s"
   shows "valid_cap c
-           (s\<lparr>kheap := \<lambda>x. if x \<in> set (retype_addrs ptr ty n us) then Some (default_object ty dev us) else kheap s x\<rparr>)"
+           (s\<lparr>kheap := \<lambda>x. if x \<in> set (retype_addrs ptr ty n us) then Some (default_object ty dev us (cur_domain s)) else kheap s x\<rparr>)"
   (is "valid_cap c ?ns")
   proof -
   have obj_at_pres: "\<And>P x. obj_at P x s \<Longrightarrow> obj_at P x ?ns"
@@ -675,7 +675,7 @@ lemma valid_untyped_helper [Retype_AI_assms]:
    (erule pspace_no_overlapC [OF pn _ _ cover vp])
   note blah[simp del] = atLeastAtMost_iff atLeastatMost_subset_iff atLeastLessThan_iff
         Int_atLeastAtMost atLeastatMost_empty_iff
-  have cover':"range_cover ptr sz (obj_bits (default_object ty dev us)) n"
+  have cover':"range_cover ptr sz (obj_bits (default_object ty dev us (cur_domain s))) n"
     using cover tyunt
     by (clarsimp simp: obj_bits_dev_irr)
 
@@ -762,7 +762,7 @@ lemma valid_cap:
   proof -
   note blah[simp del] = atLeastAtMost_iff atLeastatMost_subset_iff atLeastLessThan_iff
         Int_atLeastAtMost atLeastatMost_empty_iff
-  have cover':"range_cover ptr sz (obj_bits (default_object ty dev us)) n"
+  have cover':"range_cover ptr sz (obj_bits (default_object ty dev us (cur_domain s))) n"
     using cover tyunt
     by (clarsimp simp: obj_bits_dev_irr)
   show ?thesis
@@ -1001,7 +1001,7 @@ lemma pspace_respects_device_regionD:
 
 
 lemma default_obj_dev:
-  "\<lbrakk>ty \<noteq> Untyped;default_object ty dev us = ArchObj (DataPage dev' sz)\<rbrakk> \<Longrightarrow> dev = dev'"
+  "\<lbrakk>ty \<noteq> Untyped;default_object ty dev us d = ArchObj (DataPage dev' sz)\<rbrakk> \<Longrightarrow> dev = dev'"
   by (clarsimp simp: default_object_def default_arch_object_def
               split: apiobject_type.split_asm aobject_type.split_asm)
 
@@ -1137,7 +1137,7 @@ lemma pspace_respects_device_region:
   apply (rule pspace_respects_device_regionI)
      apply (clarsimp simp add: pspace_respects_device_region_def s'_def ps_def
                         split: if_split_asm )
-      apply (drule retype_addrs_obj_range_subset[OF _ _ tyunt])
+      apply (drule retype_addrs_obj_range_subset[OF _ _ tyunt, where d'="cur_domain s"])
        using cover tyunt
        apply (simp add: obj_bits_api_def3 split: if_splits)
       apply (frule default_obj_dev[OF tyunt],simp)
@@ -1151,7 +1151,7 @@ lemma pspace_respects_device_region:
      apply fastforce
     apply (clarsimp simp add: pspace_respects_device_region_def s'_def ps_def
                        split: if_split_asm )
-     apply (drule retype_addrs_obj_range_subset[OF _ _ tyunt])
+     apply (drule retype_addrs_obj_range_subset[OF _ _ tyunt, where d'="cur_domain s"])
       using cover tyunt
       apply (simp add: obj_bits_api_def4 split: if_splits)
      apply (frule default_obj_dev[OF tyunt],simp)

--- a/proof/invariant-abstract/ARM/ArchSchedule_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchSchedule_AI.thy
@@ -50,11 +50,9 @@ lemma arch_stt_tcb [wp,Schedule_AI_assms]:
   apply (wp)
   done
 
-lemma arch_stt_runnable[Schedule_AI_assms]:
-  "\<lbrace>st_tcb_at runnable t\<rbrace> arch_switch_to_thread t \<lbrace>\<lambda>r . st_tcb_at runnable t\<rbrace>"
-  apply (simp add: arch_switch_to_thread_def)
-  apply wp
-  done
+lemma arch_stt_st_tcb_at[Schedule_AI_assms]:
+  "arch_switch_to_thread t \<lbrace>st_tcb_at Q t\<rbrace>"
+  by (wpsimp simp: arch_switch_to_thread_def)
 
 lemma arch_stit_invs[wp, Schedule_AI_assms]:
   "\<lbrace>invs\<rbrace> arch_switch_to_idle_thread \<lbrace>\<lambda>r. invs\<rbrace>"
@@ -66,8 +64,15 @@ lemma arch_stit_tcb_at[wp]:
   apply wp
   done
 
+lemma idle_strg:
+  "thread = idle_thread s \<and> invs s \<Longrightarrow> invs (s\<lparr>cur_thread := thread\<rparr>)"
+  by (clarsimp simp: invs_def valid_state_def valid_idle_def cur_tcb_def
+                     pred_tcb_at_def valid_machine_state_def obj_at_def is_tcb_def)
+
 crunch set_vm_root
   for ct[wp]: "\<lambda>s. P (cur_thread s)"
+  and it[wp]: "\<lambda>s. P (idle_thread s)"
+  and scheduler_action[wp]: "\<lambda>s. P (scheduler_action s)"
   (wp: crunch_wps simp: crunch_simps)
 
 lemma arch_stit_activatable[wp, Schedule_AI_assms]:
@@ -77,11 +82,10 @@ lemma arch_stit_activatable[wp, Schedule_AI_assms]:
   done
 
 lemma stit_invs [wp,Schedule_AI_assms]:
-  "\<lbrace>invs\<rbrace> switch_to_idle_thread \<lbrace>\<lambda>rv. invs\<rbrace>"
-  apply (simp add: switch_to_idle_thread_def)
-  apply (wp sct_invs)
-  by (clarsimp simp: invs_def valid_state_def valid_idle_def cur_tcb_def
-                     pred_tcb_at_def valid_machine_state_def obj_at_def is_tcb_def)
+  "switch_to_idle_thread \<lbrace>invs\<rbrace>"
+  apply (simp add: switch_to_idle_thread_def arch_switch_to_idle_thread_def)
+  apply (wpsimp|strengthen idle_strg)+
+  done
 
 lemma stit_activatable[Schedule_AI_assms]:
   "\<lbrace>invs\<rbrace> switch_to_idle_thread \<lbrace>\<lambda>rv . ct_in_state activatable\<rbrace>"
@@ -91,28 +95,15 @@ lemma stit_activatable[Schedule_AI_assms]:
                  elim!: pred_tcb_weaken_strongerE)
   done
 
-lemma stt_invs [wp,Schedule_AI_assms]:
-  "\<lbrace>invs\<rbrace> switch_to_thread t' \<lbrace>\<lambda>_. invs\<rbrace>"
-  apply (simp add: switch_to_thread_def)
-  apply wp
-     apply (simp add: trans_state_update[symmetric] del: trans_state_update)
-    apply (rule_tac Q'="\<lambda>_. invs and tcb_at t'" in hoare_strengthen_post, wp)
-    apply (clarsimp simp: invs_def valid_state_def valid_idle_def
-                          valid_irq_node_def valid_machine_state_def)
-    apply (fastforce simp: cur_tcb_def obj_at_def
-                     elim: valid_pspace_eqI ifunsafe_pspaceI)
-   apply wp+
-  apply clarsimp
-  apply (simp add: is_tcb_def)
-  done
-end
+lemma arch_stt_scheduler_action [wp, Schedule_AI_assms]:
+  "\<lbrace>\<lambda>s. P (scheduler_action s)\<rbrace> arch_switch_to_thread t' \<lbrace>\<lambda>_ s. P (scheduler_action s)\<rbrace>"
+  by (wpsimp simp: arch_switch_to_thread_def)
 
-interpretation Schedule_AI_U?: Schedule_AI_U
-  proof goal_cases
-  interpret Arch .
-  case 1 show ?case
-  by (intro_locales; (unfold_locales; fact Schedule_AI_assms)?)
-  qed
+lemma arch_stit_scheduler_action [wp, Schedule_AI_assms]:
+  "\<lbrace>\<lambda>s. P (scheduler_action s)\<rbrace> arch_switch_to_idle_thread \<lbrace>\<lambda>_ s. P (scheduler_action s)\<rbrace>"
+  by (wpsimp simp: arch_switch_to_idle_thread_def)
+
+end
 
 interpretation Schedule_AI?: Schedule_AI
   proof goal_cases

--- a/proof/invariant-abstract/ARM/ArchUntyped_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchUntyped_AI.thy
@@ -168,8 +168,8 @@ lemma retype_ret_valid_caps_aobj[Untyped_AI_assms]:
   \<lbrakk>pspace_no_overlap_range_cover ptr sz s \<and> x6 \<noteq> ASIDPoolObj \<and>
   range_cover ptr sz (obj_bits_api (ArchObject x6) us) n \<and> ptr \<noteq> 0\<rbrakk>
             \<Longrightarrow> \<forall>y\<in>{0..<n}. s
-                   \<lparr>kheap := foldr (\<lambda>p kh. kh(p \<mapsto> default_object (ArchObject x6) dev us)) (map (\<lambda>p. ptr_add ptr (p * 2 ^ obj_bits_api (ArchObject x6) us)) [0..<n])
-                              (kheap s)\<rparr> \<turnstile> ArchObjectCap (ARM_A.arch_default_cap x6 (ptr_add ptr (y * 2 ^ obj_bits_api (ArchObject x6) us)) us dev)"
+                   \<lparr>kheap := foldr (\<lambda>p kh. kh(p \<mapsto> default_object (ArchObject x6) dev us (cur_domain s))) (map (\<lambda>p. ptr_add ptr (p * 2 ^ obj_bits_api (ArchObject x6) us)) [0..<n])
+                              (kheap s)\<rparr> \<turnstile> ArchObjectCap (arch_default_cap x6 (ptr_add ptr (y * 2 ^ obj_bits_api (ArchObject x6) us)) us dev)"
   apply (rename_tac aobject_type us n)
   apply (case_tac aobject_type)
   by (clarsimp simp: valid_cap_def default_object_def cap_aligned_def
@@ -521,9 +521,8 @@ lemma nonempty_table_caps_of[Untyped_AI_assms]:
 
 
 lemma nonempty_default[simp, Untyped_AI_assms]:
-  "tp \<noteq> Untyped \<Longrightarrow> \<not> nonempty_table S (default_object tp dev us)"
-  apply (case_tac tp, simp_all add: default_object_def nonempty_table_def
-                                    a_type_def)
+  "tp \<noteq> Untyped \<Longrightarrow> \<not> nonempty_table S (default_object tp dev us d)"
+  apply (case_tac tp, simp_all add: default_object_def nonempty_table_def a_type_def)
   apply (rename_tac aobject_type)
   apply (case_tac aobject_type, simp_all add: default_arch_object_def)
    apply (simp_all add: empty_table_def pde_ref_def valid_pde_mappings_def)

--- a/proof/invariant-abstract/ARM/ArchUntyped_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchUntyped_AI.thy
@@ -155,7 +155,7 @@ lemma retype_ret_valid_caps_captable[Untyped_AI_assms]:
       \<and> range_cover ptr sz (obj_bits_api CapTableObject us) n \<and> ptr \<noteq> 0
        \<rbrakk>
          \<Longrightarrow> \<forall>y\<in>{0..<n}. s
-                \<lparr>kheap := foldr (\<lambda>p kh. kh(p \<mapsto> default_object CapTableObject dev us)) (map (\<lambda>p. ptr_add ptr (p * 2 ^ obj_bits_api CapTableObject us)) [0..<n])
+                \<lparr>kheap := foldr (\<lambda>p kh. kh(p \<mapsto> default_object CapTableObject dev us (cur_domain s))) (map (\<lambda>p. ptr_add ptr (p * 2 ^ obj_bits_api CapTableObject us)) [0..<n])
                            (kheap s)\<rparr> \<turnstile> CNodeCap (ptr_add ptr (y * 2 ^ obj_bits_api CapTableObject us)) us []"
 by ((clarsimp simp:valid_cap_def default_object_def cap_aligned_def
         cte_level_bits_def is_obj_defs well_formed_cnode_n_def empty_cnode_def

--- a/proof/invariant-abstract/ARM/ArchVSpace_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchVSpace_AI.thy
@@ -4952,7 +4952,7 @@ lemma invs_aligned_pdD:
 
 lemma valid_vspace_obj_default:
   assumes tyunt: "ty \<noteq> Structures_A.apiobject_type.Untyped"
-  shows "ArchObj ao = default_object ty dev us \<Longrightarrow> valid_vspace_obj ao s'"
+  shows "ArchObj ao = default_object ty dev us d \<Longrightarrow> valid_vspace_obj ao s'"
   apply (cases ty, simp_all add: default_object_def tyunt)
   apply (simp add: valid_vspace_obj_default')
   done


### PR DESCRIPTION
Following on from https://github.com/seL4/l4v/pull/824, this PR copies the AInvs update across to ARM and then additionally updates the Access Control proofs for the changes to det_ext and the scheduler state.