### PR TITLE
Add GIC v3 support for AArch64 platforms

### DIFF
--- a/proof/crefine/AARCH64/ADT_C.thy
+++ b/proof/crefine/AARCH64/ADT_C.thy
@@ -624,7 +624,7 @@ lemma carch_state_to_H_correct:
    apply (simp add: ccur_vcpu_to_H_correct)
   apply (rule conjI)
   using valid[simplified valid_arch_state'_def]
-   apply (clarsimp simp: max_armKSGICVCPUNumListRegs_def unat_of_nat_eq)
+   apply (clarsimp simp: max_armKSGICVCPUNumListRegs_val unat_of_nat_eq)
   apply (simp add: pt_t)
   done
 
@@ -1018,7 +1018,7 @@ lemma cpspace_vcpu_relation_unique:
    apply clarsimp
    apply (rule ext)
    apply (rename_tac r)
-   apply (case_tac "64 \<le> r"; simp)
+   apply (case_tac "max_armKSGICVCPUNumListRegs \<le> r"; simp)
   apply (rule conjI)
    apply (rule ext, blast)
   apply (rule conjI, blast)

--- a/proof/crefine/AARCH64/Invoke_C.thy
+++ b/proof/crefine/AARCH64/Invoke_C.thy
@@ -1804,7 +1804,7 @@ inline assembly, so we must appeal to the axiomatisation of inline assembly to s
 \<close>
 lemma preemptionPoint_hrs_htd:
   "\<forall>\<sigma>. \<Gamma>\<turnstile>\<^bsub>/UNIV\<^esub> {\<sigma>} Call preemptionPoint_'proc \<lbrace>hrs_htd \<acute>t_hrs = hrs_htd \<^bsup>\<sigma>\<^esup>t_hrs\<rbrace>"
-  by (rule allI, rule conseqPre, vcg, clarsimp simp: asm_spec_enabled elim!: asm_specE)
+  by (rule allI, rule conseqPre, vcg exspec=isIRQPending_modifies, clarsimp simp: asm_spec_enabled elim!: asm_specE)
 
 lemma resetUntypedCap_ccorres:
   notes upt.simps[simp del] Collect_const[simp del] replicate_numeral[simp del]

--- a/proof/crefine/AARCH64/StateRelation_C.thy
+++ b/proof/crefine/AARCH64/StateRelation_C.thy
@@ -528,8 +528,8 @@ definition cvgic_relation :: "gicvcpuinterface \<Rightarrow> gicVCpuIface_C \<Ri
        gicVCpuIface_C.hcr_C cvgic = vgicHCR vgic
      \<and> gicVCpuIface_C.vmcr_C cvgic = vgicVMCR vgic
      \<and> gicVCpuIface_C.apr_C cvgic = vgicAPR vgic
-     \<and> (\<forall>i\<le>63. vgicLR vgic i = virq_to_H ((gicVCpuIface_C.lr_C cvgic).[i]))
-     \<and> (\<forall>i\<ge>64. vgicLR vgic i = 0)"
+     \<and> (\<forall>i<max_armKSGICVCPUNumListRegs. vgicLR vgic i = virq_to_H ((gicVCpuIface_C.lr_C cvgic).[i]))
+     \<and> (\<forall>i\<ge>max_armKSGICVCPUNumListRegs. vgicLR vgic i = 0)"
 
 definition cvcpu_relation :: "vcpu \<Rightarrow> vcpu_C \<Rightarrow> bool" where
   "cvcpu_relation vcpu cvcpu \<equiv>

--- a/proof/crefine/AARCH64/Wellformed_C.thy
+++ b/proof/crefine/AARCH64/Wellformed_C.thy
@@ -86,8 +86,10 @@ abbreviation
 abbreviation
   vs_Ptr :: "machine_word \<Rightarrow> vs_ptr" where "vs_Ptr == Ptr"
 
+value_type vgic_lr_len = "max_armKSGICVCPUNumListRegs"
+
 abbreviation
-  vgic_lr_C_Ptr :: "addr \<Rightarrow> (virq_C[64]) ptr" where "vgic_lr_C_Ptr \<equiv> Ptr"
+  vgic_lr_C_Ptr :: "addr \<Rightarrow> (virq_C[vgic_lr_len]) ptr" where "vgic_lr_C_Ptr \<equiv> Ptr"
 abbreviation
   vgic_C_Ptr :: "addr \<Rightarrow> gicVCpuIface_C ptr" where "vgic_C_Ptr \<equiv> Ptr"
 abbreviation
@@ -615,6 +617,25 @@ schematic_goal hcrVCPU_val:
   "hcrVCPU = ?val"
   by (simp add: hcrVCPU_def hcrCommon_def hcrTWE_def hcrTWI_def
                 Kernel_Config.config_DISABLE_WFI_WFE_TRAPS_def)
+
+
+text \<open>@{text max_armKSGICVCPUNumListRegs} interface\<close>
+
+(* The definition is in Invariants_H, but the properties are only needed in
+   CRefine. *)
+
+schematic_goal max_armKSGICVCPUNumListRegs_val:
+  "max_armKSGICVCPUNumListRegs = numeral ?n"
+  by (simp add: max_armKSGICVCPUNumListRegs_def Kernel_Config.config_ARM_GIC_V3_def)
+
+lemma max_armKSGICVCPUNumListRegs_msb:
+  "n < max_armKSGICVCPUNumListRegs \<Longrightarrow> \<not> msb (word_of_nat n :: machine_word)"
+  by (rule not_msb_from_less)
+     (simp add: max_armKSGICVCPUNumListRegs_val word_less_nat_alt unat_of_nat)
+
+lemma max_armKSGICVCPUNumListRegs_word_bits:
+  "max_armKSGICVCPUNumListRegs \<le> word_bits"
+  by (simp add: max_armKSGICVCPUNumListRegs_val word_bits_def)
 
 (* end of Kernel_Config interface section *)
 

--- a/proof/refine/AARCH64/ArchInvsDefs_H.thy
+++ b/proof/refine/AARCH64/ArchInvsDefs_H.thy
@@ -216,7 +216,7 @@ definition valid_asid_table' :: "(asid \<rightharpoonup> machine_word) \<Rightar
 definition "is_vcpu' \<equiv> \<lambda>ko. \<exists>vcpu. ko = (KOArch (KOVCPU vcpu))"
 
 definition max_armKSGICVCPUNumListRegs :: nat where
-  "max_armKSGICVCPUNumListRegs \<equiv> 63"
+  "max_armKSGICVCPUNumListRegs \<equiv> if config_ARM_GIC_V3 then 16 else 64"
 
 definition valid_arch_state' :: "kernel_state \<Rightarrow> bool" where
   "valid_arch_state' \<equiv> \<lambda>s.
@@ -225,7 +225,7 @@ definition valid_arch_state' :: "kernel_state \<Rightarrow> bool" where
    (case armHSCurVCPU (ksArchState s) of
       Some (v, b) \<Rightarrow> ko_wp_at' (is_vcpu' and hyp_live') v s
       | _ \<Rightarrow> True) \<and>
-   armKSGICVCPUNumListRegs (ksArchState s) \<le> max_armKSGICVCPUNumListRegs \<and>
+   armKSGICVCPUNumListRegs (ksArchState s) < max_armKSGICVCPUNumListRegs \<and>
    canonical_address (addrFromKPPtr (armKSGlobalUserVSpace (ksArchState s)))"
 
 definition archMakeObjectT :: "arch_kernel_object_type \<Rightarrow> kernel_object" where
@@ -236,4 +236,8 @@ definition archMakeObjectT :: "arch_kernel_object_type \<Rightarrow> kernel_obje
       | VCPUT \<Rightarrow> injectKO (makeObject :: vcpu)"
 
 end
+
+(* Need to declare code equation outside Arch locale *)
+declare AARCH64.max_armKSGICVCPUNumListRegs_def[code]
+
 end

--- a/proof/refine/AARCH64/Arch_R.thy
+++ b/proof/refine/AARCH64/Arch_R.thy
@@ -840,9 +840,7 @@ lemma decodeARMVCPUInvocation_corres:
      apply (clarsimp simp: shiftL_nat whenE_bindE_throwError_to_if)
      apply (corresKsimp wp: get_vcpu_wp)
      apply (clarsimp simp: archinv_relation_def vcpu_invocation_map_def
-                           valid_cap'_def valid_cap_def isVIRQActive_def is_virq_active_def
-                           virqType_def virq_type_def
-                           make_virq_def makeVIRQ_def)
+                           valid_cap'_def valid_cap_def)
     (* read register *)
     apply (clarsimp simp: decode_vcpu_read_register_def decodeVCPUReadReg_def)
     apply (cases args; clarsimp simp: isCap_simps whenE_def split: if_split)

--- a/proof/refine/AARCH64/InterruptAcc_R.thy
+++ b/proof/refine/AARCH64/InterruptAcc_R.thy
@@ -166,5 +166,25 @@ lemma preemptionPoint_invs [wp]:
   "\<lbrace>invs'\<rbrace> preemptionPoint \<lbrace>\<lambda>_. invs'\<rbrace>"
   by (wp preemptionPoint_inv | clarsimp)+
 
+lemma virqType_eq[simp]:
+  "virqType = virq_type"
+  unfolding virqType_def virq_type_def virq_type_shift_def virqTypeShift_def
+  by simp
+
+lemma virqSetEOIIRQEN_eq[simp]:
+  "AARCH64_H.virqSetEOIIRQEN = AARCH64_A.virqSetEOIIRQEN"
+  unfolding virqSetEOIIRQEN_def AARCH64_A.virqSetEOIIRQEN_def eoiirqenShift_def eoiirqen_shift_def
+  by (simp cong: if_cong)
+
+lemma isVIRQActive_eq[simp]:
+  "isVIRQActive = is_virq_active"
+  unfolding isVIRQActive_def is_virq_active_def
+  by simp
+
+lemma makeVIRQ_eq[simp]:
+  "makeVIRQ = make_virq"
+  unfolding make_virq_def makeVIRQ_def
+  by (clarsimp simp: virq_type_shift_def eoiirqen_shift_def virqTypeShift_def eoiirqenShift_def)
+
 end
 end

--- a/proof/refine/AARCH64/Interrupt_R.thy
+++ b/proof/refine/AARCH64/Interrupt_R.thy
@@ -736,16 +736,6 @@ lemma dmo_gets_wp:
 crunch vgicUpdateLR
   for ksCurThread[wp]: "\<lambda>s. P (ksCurThread s)"
 
-lemma virqType_eq[simp]:
-  "virqType = virq_type"
-  unfolding virqType_def virq_type_def
-  by simp
-
-lemma virqSetEOIIRQEN_eq[simp]:
-  "AARCH64_H.virqSetEOIIRQEN = AARCH64_A.virqSetEOIIRQEN"
-  unfolding virqSetEOIIRQEN_def AARCH64_A.virqSetEOIIRQEN_def
-  by auto
-
 lemma not_pred_tcb':
   "(\<not>pred_tcb_at' proj P t s) = (\<not>tcb_at' t s \<or> pred_tcb_at' proj (\<lambda>a. \<not>P a) t s)"
   by (auto simp: pred_tcb_at'_def obj_at'_def)

--- a/spec/abstract/AARCH64/ArchInterrupt_A.thy
+++ b/spec/abstract/AARCH64/ArchInterrupt_A.thy
@@ -17,7 +17,7 @@ definition virqSetEOIIRQEN :: "virq \<Rightarrow> machine_word \<Rightarrow> vir
   "virqSetEOIIRQEN virq v \<equiv>
      if virq_type virq = 3
      then virq
-     else (virq && ~~0x80000) || ((v << 19) && 0x80000)"
+     else (virq && ~~(1 << eoiirqen_shift)) || ((v << eoiirqen_shift) && (1 << eoiirqen_shift))"
 
 definition vgic_maintenance :: "(unit,'z::state_ext) s_monad" where
   "vgic_maintenance = do

--- a/spec/cspec/c/gen-config-thy.py
+++ b/spec/cspec/c/gen-config-thy.py
@@ -113,7 +113,7 @@ known_config_keys = {
     'CONFIG_DEBUG_DISABLE_L1_DCACHE': (bool, None),
     'CONFIG_DEBUG_DISABLE_BRANCH_PREDICTION': (bool, None),
     'CONFIG_ARM_HYPERVISOR_SUPPORT': (bool, None),
-    'CONFIG_ARM_GIC_V3_SUPPORT': (bool, None),
+    'CONFIG_ARM_GIC_V3_SUPPORT': (bool, 'config_ARM_GIC_V3'),
     'CONFIG_AARCH64_VSPACE_S2_START_L1': (bool, None),
     'CONFIG_ARM_HYP_ENABLE_VCPU_CP14_SAVE_AND_RESTORE': (bool, None),
     'CONFIG_ARM_ERRATA_430973': (bool, None),

--- a/spec/cspec/c/gen-config-thy.py
+++ b/spec/cspec/c/gen-config-thy.py
@@ -38,11 +38,16 @@ string = 'string'
 nat = 'nat'
 word = 'machine_word'
 
-# All known config keys that could be set in a gen_config.h file.
-# The dict maps config key to (type, definition name)
+# All known config keys that could be set in a gen_config.h file. The dict maps
+# config key to (type, definition name)
 #
-# This table duplicates some information from the kernel build system, but
-# only which keys exist, not their values.
+# This table duplicates some information from the kernel build system, but only
+# which keys exist, not their values.
+#
+# If they are used in Haskell, the translated config key names have to start
+# with a lower case letter, because Haskell enforces that only datatype
+# constructores start with upper case. For new names, we tend to use `config_`
+# as prefix and potentially shorten the C name a bit.
 known_config_keys = {
     'CONFIG_ARM_HIKEY_OUTSTANDING_PREFETCHERS': (bool, None),
     'CONFIG_ARM_HIKEY_PREFETCHER_STRIDE': (bool, None),

--- a/spec/design/skel/AARCH64/ArchHypervisor_H.thy
+++ b/spec/design/skel/AARCH64/ArchHypervisor_H.thy
@@ -18,9 +18,9 @@ begin
 context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Object/VCPU/AARCH64.hs CONTEXT AARCH64_H decls_only \
-  ONLY countTrailingZeros irqVPPIEventIndex
+  ONLY countTrailingZeros irqVPPIEventIndex virqTypeShift eoiirqenShift
 #INCLUDE_HASKELL SEL4/Object/VCPU/AARCH64.hs CONTEXT AARCH64_H bodies_only \
-  ONLY countTrailingZeros irqVPPIEventIndex
+  ONLY countTrailingZeros irqVPPIEventIndex virqTypeShift eoiirqenShift
 #INCLUDE_HASKELL SEL4/Object/VCPU/AARCH64.hs CONTEXT AARCH64_H ArchInv=Arch \
   ONLY vcpuUpdate vgicUpdate vgicUpdateLR vcpuSaveReg vcpuRestoreReg \
     vcpuSaveRegRange vcpuRestoreRegRange vcpuWriteReg vcpuReadReg saveVirtTimer \

--- a/spec/design/skel/AARCH64/Hardware_H.thy
+++ b/spec/design/skel/AARCH64/Hardware_H.thy
@@ -37,7 +37,9 @@ context Arch begin arch_global_naming (H)
   enableFpuEL01 \
   getFAR getDFSR getIFSR getHSR setHCR getESR  getSCTLR setSCTLR \
   addressTranslateS1 \
-  readVCPUHardwareReg writeVCPUHardwareReg vcpuBits
+  readVCPUHardwareReg writeVCPUHardwareReg vcpuBits \
+  config_DISABLE_WFI_WFE_TRAPS \
+  config_ARM_GIC_V3
 
 end
 

--- a/spec/design/skel/AARCH64/VCPU_H.thy
+++ b/spec/design/skel/AARCH64/VCPU_H.thy
@@ -22,8 +22,8 @@ context Arch begin arch_global_naming (H)
     vcpuSaveRegRange vcpuRestoreRegRange vcpuWriteReg vcpuReadReg saveVirtTimer \
     restoreVirtTimer vcpuDisable vcpuEnable vcpuRestore vcpuSave vcpuSwitch \
     vcpuInvalidateActive vcpuCleanInvalidateActive countTrailingZeros virqType \
-    virqSetEOIIRQEN vgicMaintenance vppiEvent irqVPPIEventIndex armvVCPUSave \
-    curVCPUActive
+    virqTypeShift eoiirqenShift virqSetEOIIRQEN vgicMaintenance vppiEvent \
+    irqVPPIEventIndex armvVCPUSave curVCPUActive
 
 end
 end

--- a/spec/haskell/src/SEL4/Machine/Hardware/AARCH64.hs
+++ b/spec/haskell/src/SEL4/Machine/Hardware/AARCH64.hs
@@ -464,12 +464,16 @@ vgicHCREN = (0x1 :: Word32) -- VGIC_HCR_EN
 gicVCPUMaxNumLR = (64 :: Int)
 
 
-{- Config parameter -}
+{- Config parameters -}
 
 -- The size of the physical address space in hyp mode can be configured on some platforms.
 config_ARM_PA_SIZE_BITS_40 :: Bool
 config_ARM_PA_SIZE_BITS_40 = error "generated from CMake config"
 
--- Wether to trap WFI/WFE instructions or not in hyp mode
+-- Whether to trap WFI/WFE instructions or not in hyp mode.
 config_DISABLE_WFI_WFE_TRAPS :: Bool
 config_DISABLE_WFI_WFE_TRAPS = error "generated from CMake config"
+
+-- Whether to use the GICv3. Defaults to GICv2 when set to False.
+config_ARM_GIC_V3 :: Bool
+config_ARM_GIC_V3 = error "generated from CMake config"


### PR DESCRIPTION
- make the option `config_ARM_GIC_V3` visible to the proofs (cherry-pick from SGI PR #733)
- adjust specs to configurable `virq` bit positions and widths
- update proofs, including:
  - abstract over the value of `max_armKSGICVCPUNumListRegs` (changes with GIC version)
  - adjust `virq` access proofs
  - abstract over `vcpu_t` type size in C (changes with GIC version, because number of LR registers changes)
 
This PR enables the functional correctness proof on all remaining AArch64 platforms.

Test with: seL4/seL4#1337