### PR TITLE
Update ARM and AARCH64 AInvs for explicit FPU changes

### DIFF
--- a/lib/BCorres_UL.thy
+++ b/lib/BCorres_UL.thy
@@ -267,6 +267,10 @@ lemma gets_the_bcorres_underlying[wp]:
   "(\<And>s. f' (t s) = f s) \<Longrightarrow> bcorres_underlying t (gets_the f) (gets_the f')"
   by (wpsimp simp: gets_the_def)
 
+lemma maybeM_bcorres_underlying[wp]:
+  "\<lbrakk>\<And>x. y = Some x \<Longrightarrow> bcorres_underlying t (f x) (f' x)\<rbrakk> \<Longrightarrow> bcorres_underlying t (maybeM f y) (maybeM f' y)"
+  by (wpsimp simp: maybeM_def)
+
 ML \<open>
 structure CrunchBCorresInstance : CrunchInstance =
 struct

--- a/proof/access-control/ARM/ArchDomainSepInv.thy
+++ b/proof/access-control/ARM/ArchDomainSepInv.thy
@@ -13,7 +13,8 @@ context Arch begin global_naming ARM_A
 
 named_theorems DomainSepInv_assms
 
-crunch arch_post_cap_deletion, set_pd, set_pt, set_asid_pool, prepare_thread_delete, init_arch_objects
+crunch
+  arch_post_cap_deletion, set_pd, set_pt, set_asid_pool, prepare_thread_delete, init_arch_objects
   for domain_sep_inv[DomainSepInv_assms, wp]: "domain_sep_inv irqs st"
   (wp: domain_sep_inv_triv crunch_wps set_asid_pool_cte_wp_at set_pd_cte_wp_at set_pt_cte_wp_at)
 
@@ -28,7 +29,8 @@ lemma arch_finalise_cap_rv[DomainSepInv_assms]:
 crunch
   invalidate_tlb_by_asid, handle_reserved_irq, handle_vm_fault,
   handle_hypervisor_fault, handle_arch_fault_reply, arch_mask_irq_signal,
-  arch_switch_to_thread, arch_switch_to_idle_thread, arch_activate_idle_thread
+  arch_switch_to_thread, arch_switch_to_idle_thread, arch_activate_idle_thread,
+  arch_prepare_set_domain, arch_prepare_next_domain, arch_post_set_flags
   for domain_sep_inv[DomainSepInv_assms, wp]: "domain_sep_inv irqs st"
 
 lemma arch_derive_cap_domain_sep_inv[DomainSepInv_assms, wp]:

--- a/proof/access-control/ARM/ArchIpc_AC.thy
+++ b/proof/access-control/ARM/ArchIpc_AC.thy
@@ -12,7 +12,7 @@ context Arch begin global_naming ARM_A
 
 named_theorems Ipc_AC_assms
 
-declare make_fault_message_inv[Ipc_AC_assms]
+declare make_fault_msg_inv[Ipc_AC_assms]
 declare handle_arch_fault_reply_typ_at[Ipc_AC_assms]
 
 crunch cap_insert_ext

--- a/proof/access-control/ARM/ArchSyscall_AC.thy
+++ b/proof/access-control/ARM/ArchSyscall_AC.thy
@@ -61,7 +61,7 @@ crunch handle_vm_fault
   for pas_refined[Syscall_AC_assms, wp]: "pas_refined aag"
   and cur_thread[Syscall_AC_assms, wp]: "\<lambda>s. P (cur_thread s)"
   and state_refs_of[Syscall_AC_assms, wp]: "\<lambda>s. P (state_refs_of s)"
-  (wp: as_user_getRestart_invs ignore: as_user)
+  (wp: as_user_getRestart_inv ignore: as_user)
 
 lemma handle_vm_fault_integrity[Syscall_AC_assms]:
   "\<lbrace>integrity aag X st and K (is_subject aag thread)\<rbrace>
@@ -162,7 +162,8 @@ crunch arch_post_cap_deletion
 crunch
   arch_post_modify_registers, arch_invoke_irq_control,
   arch_invoke_irq_handler, arch_perform_invocation, arch_mask_irq_signal,
-  handle_reserved_irq, handle_vm_fault, handle_hypervisor_fault, handle_arch_fault_reply
+  handle_reserved_irq, handle_vm_fault, handle_hypervisor_fault, handle_arch_fault_reply,
+  arch_prepare_set_domain, arch_post_set_flags, arch_prepare_next_domain
   for cur_thread[Syscall_AC_assms, wp]: "\<lambda>s. P (cur_thread s)"
   and idle_thread[Syscall_AC_assms, wp]: "\<lambda>s. P (idle_thread s)"
   and cur_domain[Syscall_AC_assms, wp]:  "\<lambda>s. P (cur_domain s)"
@@ -171,6 +172,14 @@ crunch
 \<comment> \<open>These aren't proved in the previous crunch, and hence need to be declared\<close>
 declare handle_arch_fault_reply_cur_thread[Syscall_AC_assms]
 declare handle_arch_fault_reply_it[Syscall_AC_assms]
+declare arch_prepare_set_domain_idle_thread[Syscall_AC_assms]
+
+crunch arch_prepare_next_domain
+  for pas_refined[Syscall_AC_assms, wp]: "pas_refined aag"
+  and integrity[Syscall_AC_assms, wp]: "integrity aag X st"
+  and ct_not_in_q[Syscall_AC_assms, wp]: ct_not_in_q
+  and valid_sched_action[Syscall_AC_assms, wp]: valid_sched_action
+  and ct_in_cur_domain[Syscall_AC_assms, wp]: ct_in_cur_domain
 
 end
 

--- a/proof/access-control/ARM/ArchTcb_AC.thy
+++ b/proof/access-control/ARM/ArchTcb_AC.thy
@@ -14,7 +14,7 @@ named_theorems Tcb_AC_assms
 
 declare arch_get_sanitise_register_info_inv[Tcb_AC_assms]
 
-crunch arch_post_modify_registers
+crunch arch_post_modify_registers, arch_post_set_flags
   for pas_refined[Tcb_AC_assms, wp]: "pas_refined aag"
 
 lemma arch_post_modify_registers_respects[Tcb_AC_assms]:
@@ -22,6 +22,12 @@ lemma arch_post_modify_registers_respects[Tcb_AC_assms]:
    arch_post_modify_registers cur t
    \<lbrace>\<lambda>_ s. integrity aag X st s\<rbrace>"
   by wpsimp
+
+lemma arch_post_set_flags_respects[Tcb_AC_assms]:
+  "\<lbrace>integrity aag X st and K (is_subject aag t)\<rbrace>
+   arch_post_set_flags t flags
+   \<lbrace>\<lambda>_ s. integrity aag X st s\<rbrace>"
+  by (wpsimp simp: arch_post_set_flags_def)
 
 lemma invoke_tcb_tc_respects_aag[Tcb_AC_assms]:
   "\<lbrace>integrity aag X st and pas_refined aag and einvs and simple_sched_action

--- a/proof/access-control/ARM/ExampleSystem.thy
+++ b/proof/access-control/ARM/ExampleSystem.thy
@@ -315,6 +315,7 @@ where
      tcb_priority           = undefined,
      tcb_time_slice         = undefined,
      tcb_domain             = 0,
+     tcb_flags              = undefined,
      tcb_arch               = \<lparr>tcb_context = undefined\<rparr> \<rparr>"
 
 
@@ -339,6 +340,7 @@ where
      tcb_priority           = undefined,
      tcb_time_slice         = undefined,
      tcb_domain             = 0,
+     tcb_flags              = undefined,
      tcb_arch               = \<lparr>tcb_context = undefined\<rparr>\<rparr>"
 
 definition
@@ -869,6 +871,7 @@ where
      tcb_priority           = undefined,
      tcb_time_slice         = undefined,
      tcb_domain             = 0,
+     tcb_flags              = undefined,
      tcb_arch          = \<lparr>tcb_context = undefined\<rparr>\<rparr>"
 
 
@@ -893,6 +896,7 @@ where
      tcb_priority           = undefined,
      tcb_time_slice         = undefined,
      tcb_domain             = 0,
+     tcb_flags              = undefined,
      tcb_arch               = \<lparr>tcb_context = undefined\<rparr>\<rparr>"
 
 (* the boolean in BlockedOnReceive is True if the object can receive but not send.

--- a/proof/access-control/DomainSepInv.thy
+++ b/proof/access-control/DomainSepInv.thy
@@ -325,6 +325,12 @@ locale DomainSepInv_1 =
     "\<lbrace>\<top>\<rbrace> arch_derive_cap acap \<lbrace>\<lambda>rv s :: det_ext state. domain_sep_inv_cap irqs rv\<rbrace>,-"
   and arch_post_modify_registers_domain_sep_inv[wp]:
     "arch_post_modify_registers cur t \<lbrace>\<lambda>s :: det_ext state. domain_sep_inv irqs st s\<rbrace>"
+  and arch_prepare_set_domain_domain_sep_inv[wp]:
+    "arch_prepare_set_domain t new_dom \<lbrace>\<lambda>s :: det_ext state. domain_sep_inv irqs st s\<rbrace>"
+  and arch_prepare_next_domain_domain_sep_inv[wp]:
+    "arch_prepare_next_domain \<lbrace>\<lambda>s :: det_ext state. domain_sep_inv irqs st s\<rbrace>"
+  and arch_post_set_flags_domain_sep_inv[wp]:
+    "arch_post_set_flags t flags \<lbrace>\<lambda>s :: det_ext state. domain_sep_inv irqs st s\<rbrace>"
   and handle_arch_fault_reply_domain_sep_inv[wp]:
     "handle_arch_fault_reply vmf thread d ds \<lbrace>\<lambda>s :: det_ext state. domain_sep_inv irqs st s\<rbrace>"
   and handle_vm_fault_domain_sep_inv[wp]:
@@ -429,6 +435,8 @@ lemmas thread_set_tcb_domain_update_domain_sep_inv[wp]
   = thread_set_domain_sep_inv_triv[where f="tcb_domain_update f" for f, simplified ran_tcb_cap_cases, simplified]
 lemmas thread_set_tcb_registers_caps_merge_default_tcb_domain_sep_inv[wp]
   = thread_set_domain_sep_inv_triv[where f="tcb_registers_caps_merge tcb" for tcb, simplified ran_tcb_cap_cases tcb_registers_caps_merge_def, simplified]
+lemmas thread_set_tcb_flags_update_domain_sep_inv[wp]
+  = thread_set_domain_sep_inv_triv[where f="tcb_flags_update f" for f, simplified ran_tcb_cap_cases, simplified]
 
 crunch as_user
   for domain_sep_inv[wp]: "domain_sep_inv irqs st"
@@ -877,12 +885,16 @@ lemma checked_cap_insert_domain_sep_inv:
   apply (erule (1) same_object_as_domain_sep_inv_cap)
   done
 
-crunch bind_notification, set_mcpriority, set_priority, invoke_domain
+crunch bind_notification, set_mcpriority, set_priority
   for domain_sep_inv[wp]: "domain_sep_inv irqs st"
   (ignore: thread_set)
 
 
 context DomainSepInv_1 begin
+
+crunch invoke_domain, set_flags
+  for domain_sep_inv[wp]: "domain_sep_inv irqs (st :: 'state_ext state) :: det_ext state \<Rightarrow> _"
+  (ignore: thread_set)
 
 lemma invoke_tcb_domain_sep_inv:
   "\<lbrace>domain_sep_inv irqs st and tcb_inv_wf tinv\<rbrace>

--- a/proof/access-control/Syscall_AC.thy
+++ b/proof/access-control/Syscall_AC.thy
@@ -521,6 +521,28 @@ locale Syscall_AC_1 =
               set_thread_state thread Structures_A.thread_state.Running
      od
      \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
+  and arch_prepare_next_domain_respects[wp]:
+    "arch_prepare_next_domain \<lbrace>integrity aag X st\<rbrace>"
+  assumes arch_prepare_next_domain_pas_refined[wp]:
+    "arch_prepare_next_domain \<lbrace>pas_refined aag\<rbrace>"
+  assumes arch_prepare_next_domain_ct_not_in_q[wp]:
+    "arch_prepare_next_domain \<lbrace>ct_not_in_q :: det_state \<Rightarrow> _\<rbrace>"
+  assumes arch_prepare_next_domain_valid_sched_action[wp]:
+    "arch_prepare_next_domain \<lbrace>valid_sched_action :: det_state \<Rightarrow> _\<rbrace>"
+  assumes arch_prepare_next_domain_ct_in_cur_domain[wp]:
+    "arch_prepare_next_domain \<lbrace>ct_in_cur_domain :: det_state \<Rightarrow> _\<rbrace>"
+  assumes arch_prepare_set_domain_cur_thread[wp]:
+    "\<And>P. arch_prepare_set_domain t new_dom \<lbrace>\<lambda>s :: det_state. P (cur_thread s)\<rbrace>"
+  assumes arch_post_set_flags_cur_thread[wp]:
+    "\<And>P. arch_post_set_flags t flags \<lbrace>\<lambda>s :: det_state. P (cur_thread s)\<rbrace>"
+  assumes arch_prepare_set_domain_idle_thread[wp]:
+    "\<And>P. arch_prepare_set_domain t new_dom \<lbrace>\<lambda>s :: det_state. P (idle_thread s)\<rbrace>"
+  assumes arch_post_set_flags_idle_thread[wp]:
+    "\<And>P. arch_post_set_flags t flags \<lbrace>\<lambda>s :: det_state. P (idle_thread s)\<rbrace>"
+  assumes arch_prepare_set_domain_cur_domain[wp]:
+    "\<And>P. arch_prepare_set_domain t new_dom \<lbrace>\<lambda>s :: det_state. P (cur_domain s)\<rbrace>"
+  assumes arch_post_set_flags_cur_domain[wp]:
+    "\<And>P. arch_post_set_flags t flags \<lbrace>\<lambda>s :: det_state. P (cur_domain s)\<rbrace>"
 
 
 sublocale Syscall_AC_1 \<subseteq> prepare_thread_delete: gpd_wps' "prepare_thread_delete p"

--- a/proof/invariant-abstract/AARCH64/ArchAcc_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchAcc_AI.thy
@@ -1583,6 +1583,11 @@ lemma set_asid_pool_iflive [wp]:
   by (wp set_object_iflive)
      (clarsimp simp: obj_at_def live_def hyp_live_def arch_live_def in_omonad)
 
+lemma set_asid_pool_nonz_cap_to[wp]:
+  "set_asid_pool p ap \<lbrace>ex_nonz_cap_to t\<rbrace>"
+  unfolding set_asid_pool_def
+  by (wpsimp simp: in_omonad obj_at_def)
+
 lemma set_asid_pool_zombies [wp]:
   "set_asid_pool p ap \<lbrace>zombies_final\<rbrace>"
   unfolding set_asid_pool_def
@@ -1996,6 +2001,10 @@ lemma set_asid_pool_None_valid_asid_map[wp]:
   apply (wp hoare_vcg_disj_lift hoare_vcg_ex_lift get_object_wp)
   apply (fastforce simp: entry_for_pool_def obind_None_eq in_omonad split: if_split_asm)
   done
+
+crunch set_asid_pool
+  for valid_cur_fpu[wp]: valid_cur_fpu
+  (wp: valid_cur_fpu_lift)
 
 lemma set_asid_pool_invs_unmap:
   "\<lbrace>invs and
@@ -2745,6 +2754,10 @@ lemma store_pte_valid_global_tables[wp]:
   unfolding store_pte_def valid_global_tables_2_def
   by (wpsimp wp: set_pt_pts_of simp: global_refs_def | wps)+
 
+crunch store_pte
+  for valid_cur_fpu[wp]: valid_cur_fpu
+  (wp: valid_cur_fpu_lift)
+
 lemma store_pte_invs:
   "\<lbrace> invs
      and (\<lambda>s. table_base pt_t p \<notin> global_refs s)
@@ -2830,6 +2843,7 @@ crunch do_machine_op
   and vspace_at_asid[wp]: "\<lambda>s. P (vspace_at_asid a pt s)"
   and valid_vs_lookup[wp]: "\<lambda>s. P (valid_vs_lookup s)"
   and valid_obj[wp]: "valid_obj t obj"
+  and valid_cur_fpu[wp]: valid_cur_fpu
   (simp: valid_kernel_mappings_def wp: valid_obj_typ)
 
 lemma dmo_invs_lift:

--- a/proof/invariant-abstract/AARCH64/ArchArch_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchArch_AI.thy
@@ -1136,6 +1136,12 @@ lemma associate_vcpu_tcb_valid_objs[wp]:
                wp: arch_thread_get_wp
       | simp add: obj_at_def)+
 
+crunch associate_vcpu_tcb
+  for arm_current_fpu_owner[wp]: "\<lambda>s. P (arm_current_fpu_owner (arch_state s))"
+  and arch_tcb_cur_fpu[wp]: "\<lambda>s. P (arch_tcb_at itcb_cur_fpu p s)"
+  and valid_cur_fpu[wp]: valid_cur_fpu
+  (wp: valid_cur_fpu_lift_arch arch_thread_set_no_change_arch_tcb_at crunch_wps)
+
 lemma associate_vcpu_tcb_invs[wp]:
   "\<lbrace>invs and ex_nonz_cap_to vcpu and ex_nonz_cap_to tcb and vcpu_at vcpu and (\<lambda>s. tcb \<noteq> idle_thread s)\<rbrace>
    associate_vcpu_tcb vcpu tcb

--- a/proof/invariant-abstract/AARCH64/ArchBCorres2_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchBCorres2_AI.thy
@@ -29,7 +29,7 @@ crunch invoke_untyped
   for (bcorres) bcorres[wp]: truncate_state
   (ignore: sequence_x)
 
-crunch set_mcpriority, set_priority
+crunch set_mcpriority, set_priority, set_flags, arch_post_set_flags
   for (bcorres) bcorres[wp]: truncate_state
 
 crunch arch_get_sanitise_register_info, arch_post_modify_registers
@@ -71,7 +71,7 @@ lemma make_arch_fault_msg_bcorres[wp,BCorres2_AI_assms]:
   "bcorres (make_arch_fault_msg a b) (make_arch_fault_msg a b)"
   by (cases a; simp ; wp)
 
-lemma  handle_arch_fault_reply_bcorres[wp,BCorres2_AI_assms]:
+lemma handle_arch_fault_reply_bcorres[wp,BCorres2_AI_assms]:
   "bcorres ( handle_arch_fault_reply a b c d) (handle_arch_fault_reply a b c d)"
   by (cases a; simp add: handle_arch_fault_reply_def; wp)
 
@@ -104,7 +104,7 @@ lemma decode_cnode_invocation[wp]: "bcorres (decode_cnode_invocation a b c d) (d
 crunch
   decode_set_ipc_buffer, decode_set_space, decode_set_priority,
   decode_set_mcpriority, decode_set_sched_params, decode_bind_notification,
-  decode_unbind_notification, decode_set_tls_base
+  decode_unbind_notification, decode_set_tls_base, decode_set_flags
   for (bcorres) bcorres[wp]: truncate_state
 
 lemma decode_tcb_configure_bcorres[wp]:

--- a/proof/invariant-abstract/AARCH64/ArchBits_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchBits_AI.thy
@@ -33,6 +33,10 @@ sublocale p_asid_table_current_vcpu_update:
   Arch_p_asid_table_update_eq "\<lambda>s. s\<lparr>arch_state := arm_current_vcpu_update f (arch_state s)\<rparr>"
   by (unfold_locales) auto
 
+sublocale p_asid_table_current_vcpu_update:
+  Arch_p_asid_table_update_eq "\<lambda>s. s\<lparr>arch_state := arm_current_fpu_owner_update f (arch_state s)\<rparr>"
+  by (unfold_locales) auto
+
 
 lemma invs_unique_table_caps[elim!]:
   "invs s \<Longrightarrow> unique_table_caps s"

--- a/proof/invariant-abstract/AARCH64/ArchCNodeInv_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchCNodeInv_AI.thy
@@ -522,7 +522,7 @@ lemma cap_swap_valid_arch_state[wp, CNodeInv_AI_assms]:
   "\<lbrace>valid_arch_state and cte_wp_at (weak_derived c) a and cte_wp_at (weak_derived c') b\<rbrace>
    cap_swap c a c' b
    \<lbrace>\<lambda>_. valid_arch_state\<rbrace>"
-  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps cap_swap_aobj_at)
+  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps cap_swap_typ_ats cap_swap_aobj_at)
 
 end
 

--- a/proof/invariant-abstract/AARCH64/ArchCSpaceInv_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchCSpaceInv_AI.thy
@@ -16,7 +16,7 @@ context Arch begin arch_global_naming
 
 lemma set_cap_valid_arch_state[wp]:
   "set_cap cap ptr \<lbrace> valid_arch_state \<rbrace>"
-  by (wp valid_arch_state_lift_aobj_at_no_caps set_cap.aobj_at)
+  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps set_cap_tcb set_cap.aobj_at)
 
 lemma replace_cap_invs:
   "\<lbrace>\<lambda>s. invs s \<and> cte_wp_at (replaceable s p cap) p s

--- a/proof/invariant-abstract/AARCH64/ArchCSpace_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchCSpace_AI.thy
@@ -481,7 +481,7 @@ lemma cap_insert_derived_valid_arch_state[CSpace_AI_assms]:
   "\<lbrace>valid_arch_state and (\<lambda>s. cte_wp_at (is_derived (cdt s) src cap) src s)\<rbrace>
    cap_insert cap src dest
    \<lbrace>\<lambda>rv. valid_arch_state \<rbrace>"
-  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps cap_insert_aobj_at cap_insert_aobj_at)
+  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps cap_insert_tcb cap_insert_aobj_at)
 
 lemma setup_reply_master_arch[CSpace_AI_assms]:
   "setup_reply_master t \<lbrace> valid_arch_state \<rbrace>"
@@ -516,7 +516,7 @@ lemma is_cap_simps':
 
 lemma cap_insert_simple_valid_arch_state[wp]:
   "cap_insert cap src dest \<lbrace> valid_arch_state\<rbrace>"
-  by (wp valid_arch_state_lift_aobj_at_no_caps cap_insert_aobj_at)+
+  by (wp valid_arch_state_lift_aobj_at_no_caps cap_insert_tcb cap_insert_aobj_at)+
 
 lemma cap_insert_simple_invs:
   "\<lbrace>invs and valid_cap cap and tcb_cap_valid cap dest and
@@ -530,7 +530,7 @@ lemma cap_insert_simple_invs:
   apply (simp add: invs_def valid_state_def valid_pspace_def)
   apply (rule hoare_pre)
    apply (wp cap_insert_simple_mdb cap_insert_iflive
-             cap_insert_zombies cap_insert_ifunsafe
+             cap_insert_zombies cap_insert_ifunsafe valid_cur_fpu_lift
              cap_insert_valid_global_refs cap_insert_idle
              valid_irq_node_typ cap_insert_simple_arch_caps_no_ap)
   apply (clarsimp simp: is_simple_cap_def cte_wp_at_caps_of_state)

--- a/proof/invariant-abstract/AARCH64/ArchDetSchedAux_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchDetSchedAux_AI.thy
@@ -74,9 +74,6 @@ lemma perform_asid_control_invocation_valid_sched:
 
 end
 
-lemmas tcb_sched_action_valid_idle_etcb
-    = AARCH64.tcb_sched_action_valid_idle_etcb
-
 global_interpretation DetSchedAux_AI?: DetSchedAux_AI
 proof goal_cases
   interpret Arch .

--- a/proof/invariant-abstract/AARCH64/ArchDetSchedDomainTime_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchDetSchedDomainTime_AI.thy
@@ -31,7 +31,7 @@ crunch
   arch_invoke_irq_control, arch_get_sanitise_register_info,
   prepare_thread_delete, handle_hypervisor_fault, make_arch_fault_msg, init_arch_objects,
   arch_post_modify_registers, arch_post_cap_deletion, handle_vm_fault,
-  arch_invoke_irq_handler
+  arch_invoke_irq_handler, arch_prepare_next_domain, arch_prepare_set_domain, arch_post_set_flags
   for domain_list_inv[wp, DetSchedDomainTime_AI_assms]: "\<lambda>s::det_state. P (domain_list s)"
   (simp: crunch_simps isFpuEnable_def wp: mapM_wp' transfer_caps_loop_pres crunch_wps)
 
@@ -45,7 +45,8 @@ crunch
   arch_invoke_irq_control, arch_get_sanitise_register_info,
   prepare_thread_delete, handle_hypervisor_fault, handle_vm_fault,
   arch_post_modify_registers, arch_post_cap_deletion, make_arch_fault_msg,
-  arch_invoke_irq_handler, handle_reserved_irq, arch_mask_irq_signal
+  arch_invoke_irq_handler, handle_reserved_irq, arch_mask_irq_signal,
+  arch_prepare_set_domain, arch_post_set_flags
   for domain_time_inv[wp, DetSchedDomainTime_AI_assms]: "\<lambda>s::det_state. P (domain_time s)"
   (simp: crunch_simps wp: transfer_caps_loop_pres crunch_wps)
 

--- a/proof/invariant-abstract/AARCH64/ArchDetSchedDomainTime_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchDetSchedDomainTime_AI.thy
@@ -50,6 +50,8 @@ crunch
   for domain_time_inv[wp, DetSchedDomainTime_AI_assms]: "\<lambda>s::det_state. P (domain_time s)"
   (simp: crunch_simps wp: transfer_caps_loop_pres crunch_wps)
 
+declare make_arch_fault_msg_inv[DetSchedDomainTime_AI_assms]
+
 end
 
 global_interpretation DetSchedDomainTime_AI?: DetSchedDomainTime_AI

--- a/proof/invariant-abstract/AARCH64/ArchDetSchedSchedule_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchDetSchedSchedule_AI.thy
@@ -119,12 +119,12 @@ crunch
   switch_to_idle_thread, switch_to_thread, set_vm_root, arch_get_sanitise_register_info,
   arch_post_modify_registers, arch_prepare_next_domain
   for valid_queues [wp, DetSchedSchedule_AI_assms]: valid_queues
-  (simp: crunch_simps ignore: set_tcb_queue tcb_sched_action)
+  (simp: crunch_simps wp: crunch_wps ignore: tcb_sched_action)
 
 crunch
   switch_to_idle_thread, switch_to_thread, set_vm_root, arch_get_sanitise_register_info, arch_post_modify_registers
   for weak_valid_sched_action [wp, DetSchedSchedule_AI_assms]: weak_valid_sched_action
-  (simp: crunch_simps)
+  (simp: crunch_simps wp: crunch_wps)
 
 crunch set_vm_root
   for ct_not_in_q[wp]: "ct_not_in_q"
@@ -199,22 +199,27 @@ crunch vcpu_disable, vcpu_restore, vcpu_save, vcpu_switch, set_vm_root
 
 crunch arch_switch_to_thread, arch_get_sanitise_register_info, arch_post_modify_registers
   for is_activatable[wp, DetSchedSchedule_AI_assms]: "is_activatable t"
-  (simp: crunch_simps)
+  (simp: crunch_simps wp: crunch_wps)
 
 crunch arch_switch_to_thread, arch_get_sanitise_register_info, arch_post_modify_registers
   for valid_sched_action [wp, DetSchedSchedule_AI_assms]: valid_sched_action
   (simp: crunch_simps ignore: set_asid_pool
-   wp: valid_sched_action_lift[where f="set_asid_pool ptr pool" for ptr pool])
+   wp: crunch_wps valid_sched_action_lift[where f="set_asid_pool ptr pool" for ptr pool])
 
 crunch
   arch_switch_to_thread, arch_get_sanitise_register_info, arch_post_modify_registers,
   arch_prepare_next_domain, arch_post_set_flags, arch_prepare_set_domain
   for valid_sched[wp, DetSchedSchedule_AI_assms]: valid_sched
-  (simp: crunch_simps)
+  (simp: crunch_simps wp: crunch_wps)
 
 crunch set_vm_root
   for exst[wp]: "\<lambda>s. P (exst s)"
   (wp: crunch_wps whenE_wp simp: crunch_simps)
+
+lemma arch_thread_set_ct_in_cur_domain_2[wp]:
+  "arch_thread_set f tptr \<lbrace>\<lambda>s. ct_in_cur_domain_2 thread (idle_thread s) (scheduler_action s) (cur_domain s) (etcbs_of s)\<rbrace>"
+  apply (simp add: arch_thread_set_def set_object_def get_object_def)
+  by wpsimp
 
 crunch arch_switch_to_thread
   for ct_in_cur_domain_2[wp, DetSchedSchedule_AI_assms]: "\<lambda>s. ct_in_cur_domain_2 thread (idle_thread s) (scheduler_action s) (cur_domain s) (etcbs_of s)"
@@ -239,6 +244,7 @@ crunch set_vm_root
 
 crunch switch_to_thread
   for etcb_at[wp, DetSchedSchedule_AI_assms]: "etcb_at P t"
+  (wp: crunch_wps)
 
 crunch
   arch_switch_to_idle_thread

--- a/proof/invariant-abstract/AARCH64/ArchDeterministic_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchDeterministic_AI.thy
@@ -27,7 +27,7 @@ lemma vcpu_switch_valid_list[wp, Deterministic_AI_assms]:
 
 crunch
   cap_swap_for_delete,set_cap,finalise_cap,arch_get_sanitise_register_info,
-  arch_post_modify_registers
+  arch_post_modify_registers, arch_post_set_flags
   for valid_list[wp, Deterministic_AI_assms]: valid_list
   (wp: crunch_wps simp: unless_def crunch_simps)
 declare get_cap_inv[Deterministic_AI_assms]

--- a/proof/invariant-abstract/AARCH64/ArchDetype_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchDetype_AI.thy
@@ -183,7 +183,7 @@ lemma tcb_arch_detype[detype_invs_proofs]:
   apply rotate_tac (* do not pick typ_at *)
   apply (drule live_okE)
    apply (clarsimp simp: live_def hyp_live_def arch_live_def obj_at_def hyp_refs_of_def
-                         refs_of_ao_def vcpu_tcb_refs_def
+                         refs_of_ao_def vcpu_tcb_refs_def tcb_vcpu_refs_def
                   split: kernel_object.splits arch_kernel_obj.splits option.splits)
   apply clarsimp
   done
@@ -339,6 +339,11 @@ lemma valid_arch_state_detype[detype_invs_proofs]:
         cur_vcpu_detype vmid_inv_detype valid_global_arch_objs valid_global_tables
   unfolding valid_arch_state_def pred_conj_def
   by (simp only: valid_asid_table) simp
+
+lemma valid_cur_fpu[detype_invs_proofs]:
+  "valid_cur_fpu (detype (untyped_range cap) s)"
+  using valid_cur_fpu
+  by (auto simp: valid_cur_fpu_def is_tcb_cur_fpu_def live_def arch_tcb_live_def elim!: live_okE)
 
 lemma vs_lookup_asid_pool_level:
   assumes lookup: "vs_lookup_table level asid vref s = Some (level, p)" "vref \<in> user_region"

--- a/proof/invariant-abstract/AARCH64/ArchEmptyFail_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchEmptyFail_AI.thy
@@ -41,7 +41,7 @@ crunch handle_fault
 crunch
   decode_tcb_configure, decode_bind_notification, decode_unbind_notification,
   decode_set_priority, decode_set_mcpriority, decode_set_sched_params,
-  decode_set_tls_base
+  decode_set_tls_base, decode_set_flags
   for (empty_fail) empty_fail[wp]
   (simp: cap.splits arch_cap.splits split_def)
 
@@ -160,7 +160,7 @@ qed
 
 context Arch begin arch_global_naming
 crunch
-  cap_delete, choose_thread
+  cap_delete, choose_thread, arch_prepare_next_domain
   for (empty_fail) empty_fail[wp, EmptyFail_AI_assms]
 end
 

--- a/proof/invariant-abstract/AARCH64/ArchFinalise_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchFinalise_AI.thy
@@ -55,7 +55,7 @@ lemma invs_arm_asid_table_unmap:
                     valid_vs_lookup_unmap_strg valid_arch_state_unmap_strg)
   apply (simp add: valid_irq_node_def valid_kernel_mappings_def)
   apply (simp add: valid_table_caps_def valid_machine_state_def valid_global_objs_def
-                   valid_asid_pool_caps_def equal_kernel_mappings_asid_table_unmap)
+                   valid_asid_pool_caps_def equal_kernel_mappings_asid_table_unmap valid_cur_fpu_defs)
   done
 
 lemma asid_low_bits_of_add:
@@ -355,6 +355,7 @@ lemma as_user_final[wp]:
 
 crunch prepare_thread_delete
   for final[wp]: "is_final_cap' cap"
+  (wp: crunch_wps)
 
 lemma length_and_unat_of_bl_length:
   "(length xs = x \<and> unat (of_bl xs :: 'a::len word) < 2 ^ x) = (length xs = x)"
@@ -402,15 +403,13 @@ crunch arch_finalise_cap
 crunch prepare_thread_delete
   for typ_at[wp,Finalise_AI_assms]: "\<lambda>s. P (typ_at T p s)"
 
-lemma vcpu_set_tcb_at[wp]: "\<lbrace>\<lambda>s. tcb_at p s\<rbrace> set_vcpu t vcpu \<lbrace>\<lambda>_ s. tcb_at p s\<rbrace>"
-  by (wpsimp simp: tcb_at_typ)
-
 crunch dissociate_vcpu_tcb
   for tcb_at[wp]: "\<lambda>s. tcb_at p s"
   (wp: crunch_wps)
 
 crunch prepare_thread_delete
   for tcb_at[wp]: "\<lambda>s. tcb_at p s"
+  (wp: crunch_wps)
 
 lemma (* finalise_cap_new_valid_cap *)[wp,Finalise_AI_assms]:
   "\<lbrace>valid_cap cap\<rbrace> finalise_cap cap x \<lbrace>\<lambda>rv. valid_cap (fst rv)\<rbrace>"
@@ -734,7 +733,8 @@ lemma dissociate_vcpu_tcb_invs[wp]: "\<lbrace>invs\<rbrace> dissociate_vcpu_tcb 
   apply (simp add: invs_def valid_state_def valid_pspace_def)
   apply (simp add: pred_conj_def)
   apply (rule hoare_vcg_conj_lift[rotated])+
-  apply (wpsimp wp: weak_if_wp get_vcpu_wp arch_thread_get_wp as_user_only_idle
+  apply (wpsimp wp: weak_if_wp get_vcpu_wp arch_thread_get_wp as_user_only_idle arch_thread_set_valid_idle
+                    valid_cur_fpu_lift_arch arch_thread_set_no_change_arch_tcb_at
          | simp add: dissociate_vcpu_tcb_def vcpu_invalidate_active_def arch_get_sanitise_register_info_def
          | strengthen valid_arch_state_vcpu_update_str valid_global_refs_vcpu_update_str
          | simp add: vcpu_disable_def valid_global_vspace_mappings_def valid_global_objs_def
@@ -1129,7 +1129,8 @@ lemma prepare_thread_delete_no_cap_to_obj_ref[wp]:
 
 crunch fpu_release
   for obj_at_triv: "obj_at \<top> p"
-  (wp: as_user_wp_thread_set_helper thread_set.aobj_at crunch_wps simp: arch_obj_pred_def)
+  (wp: as_user_wp_thread_set_helper thread_set.aobj_at arch_thread_set.aobj_at crunch_wps
+   simp: arch_obj_pred_def)
 
 lemma prepare_thread_delete_unlive_hyp:
   "\<lbrace>obj_at \<top> ptr\<rbrace> prepare_thread_delete ptr \<lbrace>\<lambda>rv. obj_at (Not \<circ> hyp_live) ptr\<rbrace>"
@@ -1141,24 +1142,95 @@ lemma prepare_thread_delete_unlive_hyp:
 
 crunch fpu_release
   for unlive[wp]: "obj_at (Not \<circ> live0) ptr"
+  (simp: o_def_not wp: crunch_wps)
+
+crunch prepare_thread_delete
+  for unlive0: "obj_at (Not \<circ> live0) t"
+
+\<comment> \<open>arch_tcb_live' is used locally as a predicate that can be passed to obj_at\<close>
+definition arch_tcb_live' :: "kernel_object \<Rightarrow> bool" where
+  "arch_tcb_live' ko \<equiv> case ko of
+     TCB tcb \<Rightarrow> arch_tcb_live (tcb_arch tcb)
+   |  _ \<Rightarrow> False"
+
+lemmas arch_tcb_live'_defs = arch_tcb_live'_def arch_tcb_live_def
+
+lemma set_vcpu_arch_tcb_live'[wp]:
+ "set_vcpu vr v \<lbrace>obj_at (Not \<circ> arch_tcb_live') t\<rbrace>"
+  by (wpsimp wp: set_vcpu_wp simp: obj_at_def arch_tcb_live'_def)
+
+lemma as_user_arch_tcb_live'[wp]:
+  "as_user t f \<lbrace>obj_at (Not \<circ> arch_tcb_live') t'\<rbrace>"
+  unfolding as_user_def
+  apply (wpsimp wp: set_object_wp)
+  by (clarsimp simp: obj_at_def arch_tcb_live'_def dest!: get_tcb_SomeD)
+
+lemma arch_thread_set_vcpu_arch_tcb_live'[wp]:
+  "arch_thread_set (tcb_vcpu_update f) t \<lbrace>obj_at (Not \<circ> arch_tcb_live') vr\<rbrace>"
+  apply (wpsimp simp: arch_thread_set_def wp: set_object_wp)
+  apply (clarsimp simp: obj_at_def arch_tcb_live'_def dest!: get_tcb_SomeD)
+  done
+
+crunch dissociate_vcpu_tcb
+  for arch_tcb_live'[wp]: "obj_at (Not \<circ> arch_tcb_live') t"
+  (wp: crunch_wps simp: o_def_not ignore: arch_thread_set)
+
+lemma arch_thread_set_unlive_arch_tcb[wp]:
+  "\<lbrace>\<lambda>s. vr \<noteq> t \<longrightarrow> obj_at (Not \<circ> arch_tcb_live') vr s\<rbrace>
+   arch_thread_set (tcb_cur_fpu_update \<bottom>) t
+   \<lbrace>\<lambda>_. obj_at (Not \<circ> arch_tcb_live') vr\<rbrace>"
+  apply (wpsimp simp: arch_thread_set_def wp: set_object_wp)
+  apply (clarsimp simp: obj_at_def arch_tcb_live'_defs)
+  done
+
+lemma set_arm_current_fpu_owner_None_unlive_arch_tcb[wp]:
+  "\<lbrace>\<lambda>s. arm_current_fpu_owner (arch_state s) = Some t\<rbrace>
+   set_arm_current_fpu_owner None
+   \<lbrace>\<lambda>_. obj_at (Not \<circ> arch_tcb_live') t\<rbrace>"
+  unfolding set_arm_current_fpu_owner_def
+  by wpsimp
+
+crunch save_fpu_state
+  for unlive_arch_tcb[wp]: "obj_at (Not \<circ> arch_tcb_live') ptr"
+  and arm_current_fpu_owner[wp]: "\<lambda>s. P (arm_current_fpu_owner (arch_state s))"
   (simp: o_def_not)
 
-lemma prepare_thread_delete_unlive0:
-  "\<lbrace>obj_at (Not \<circ> live0) ptr\<rbrace> prepare_thread_delete ptr \<lbrace>\<lambda>rv. obj_at (Not \<circ> live0) ptr\<rbrace>"
+lemma switch_local_fpu_owner_None_unlive_arch_tcb[wp]:
+  "\<lbrace>\<lambda>s. arm_current_fpu_owner (arch_state s) = Some t\<rbrace>
+   switch_local_fpu_owner None
+   \<lbrace>\<lambda>_. obj_at (Not \<circ> arch_tcb_live') t\<rbrace>"
+  unfolding switch_local_fpu_owner_def
+  by wpsimp
+
+lemma fpu_release_unlive_arch_tcb[wp]:
+  "\<lbrace>valid_cur_fpu and tcb_at t\<rbrace>
+   fpu_release t
+   \<lbrace>\<lambda>_. obj_at (Not \<circ> arch_tcb_live') t\<rbrace>"
+  unfolding fpu_release_def
+  by (wpsimp simp: valid_cur_fpu_defs arch_tcb_live'_defs is_tcb)
+
+lemma prepare_thread_delete_unlive_arch_tcb:
+  "\<lbrace>valid_cur_fpu and tcb_at ptr\<rbrace> prepare_thread_delete ptr \<lbrace>\<lambda>rv. obj_at (Not \<circ> arch_tcb_live') ptr\<rbrace>"
   apply (simp add: prepare_thread_delete_def)
-  apply (wpsimp wp: dissociate_vcpu_tcb_unlive0)
-  done
+  by wpsimp
 
 lemma prepare_thread_delete_unlive[wp]:
-  "\<lbrace>obj_at (Not \<circ> live0) ptr\<rbrace> prepare_thread_delete ptr \<lbrace>\<lambda>rv. obj_at (Not \<circ> live) ptr\<rbrace>"
-  apply (rule_tac Q'="\<lambda>rv. obj_at (Not \<circ> live0) ptr and obj_at (Not \<circ> hyp_live) ptr" in hoare_strengthen_post)
-  apply (wpsimp wp: hoare_vcg_conj_lift prepare_thread_delete_unlive_hyp prepare_thread_delete_unlive0)
+  "\<lbrace>valid_cur_fpu and tcb_at ptr and obj_at (Not \<circ> live0) ptr\<rbrace>
+   prepare_thread_delete ptr
+   \<lbrace>\<lambda>rv. obj_at (Not \<circ> live) ptr\<rbrace>"
+  apply (rule_tac Q'="\<lambda>rv. obj_at (Not \<circ> live0) ptr and obj_at (Not \<circ> hyp_live) ptr and obj_at (Not \<circ> arch_tcb_live') ptr"
+               in hoare_strengthen_post)
+  apply (wpsimp wp: hoare_vcg_conj_lift prepare_thread_delete_unlive_hyp prepare_thread_delete_unlive0 prepare_thread_delete_unlive_arch_tcb)
    apply (clarsimp simp: obj_at_def)
-  apply (clarsimp simp: obj_at_def, case_tac ko, simp_all add: is_tcb_def live_def)
+  apply (clarsimp simp: obj_at_def, case_tac ko, simp_all add: is_tcb_def live_def arch_tcb_live'_def)
   done
 
+crunch suspend, unbind_notification
+  for valid_cur_fpu[wp]: valid_cur_fpu
+  (wp: crunch_wps simp: crunch_simps)
+
 lemma finalise_cap_replaceable [Finalise_AI_assms]:
-  "\<lbrace>\<lambda>s. s \<turnstile> cap \<and> x = is_final_cap' cap s \<and> valid_mdb s
+  "\<lbrace>\<lambda>s. s \<turnstile> cap \<and> x = is_final_cap' cap s \<and> valid_mdb s \<and> valid_cur_fpu s
         \<and> cte_wp_at ((=) cap) sl s \<and> valid_objs s \<and> sym_refs (state_refs_of s)
         \<and> (cap_irqs cap \<noteq> {} \<longrightarrow> if_unsafe_then_cap s \<and> valid_global_refs s)
         \<and> (is_arch_cap cap \<longrightarrow> pspace_aligned s \<and>
@@ -1241,7 +1313,7 @@ context Arch begin arch_global_naming
 
 lemma fast_finalise_replaceable[wp]:
   "\<lbrace>\<lambda>s. s \<turnstile> cap \<and> x = is_final_cap' cap s
-     \<and> cte_wp_at ((=) cap) sl s \<and> valid_asid_table s
+     \<and> cte_wp_at ((=) cap) sl s \<and> valid_asid_table s \<and> valid_cur_fpu s
      \<and> valid_mdb s \<and> valid_objs s \<and> sym_refs (state_refs_of s)\<rbrace>
      fast_finalise cap x
    \<lbrace>\<lambda>rv s. cte_wp_at (replaceable s sl cap.NullCap) sl s\<rbrace>"
@@ -1293,11 +1365,11 @@ crunch arch_finalise_cap
 
 crunch
   delete_asid_pool, delete_asid, unmap_page_table, unmap_page, vcpu_invalidate_active
-  for pred_tcb_at[wp]: "pred_tcb_at proj P t"
+  for pred_tcb_at[wp]: "\<lambda>s. Q (pred_tcb_at proj P t s)"
   (simp: crunch_simps wp: crunch_wps test)
 
 crunch arch_finalise_cap
-  for pred_tcb_at[wp_unsafe]: "pred_tcb_at proj P t"
+  for pred_tcb_at[wp_unsafe]: "\<lambda>s. Q (pred_tcb_at proj P t s)"
   (simp: crunch_simps wp: crunch_wps)
 
 lemma set_vcpu_empty[wp]:
@@ -1599,9 +1671,9 @@ lemma valid_table_caps_table [simp]:
   "valid_table_caps (s\<lparr>arch_state := arch_state s\<lparr>arm_asid_table := table'\<rparr>\<rparr>) = valid_table_caps s"
   by (simp add: valid_table_caps_def)
 
-lemma valid_kernel_mappings [iff]:
-  "valid_kernel_mappings (s\<lparr>arch_state := arch_state s\<lparr>arm_asid_table := table'\<rparr>\<rparr>) = valid_kernel_mappings s"
-  by (simp add: valid_kernel_mappings_def)
+lemma valid_cur_fpu_asid_table_update[simp]:
+  "valid_cur_fpu (asid_table_update asid ap s) = valid_cur_fpu s"
+  by (clarsimp simp: valid_cur_fpu_defs)
 
 crunch unmap_page_table, store_pte, delete_asid_pool
   for valid_cap[wp]: "valid_cap c"

--- a/proof/invariant-abstract/AARCH64/ArchInterrupt_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchInterrupt_AI.thy
@@ -221,14 +221,6 @@ lemma dmo_ex_nonz_cap_to[wp]:
 lemma conj_imp_strg:
   "P \<Longrightarrow> (A \<longrightarrow> P) \<and> (B \<longrightarrow> P)" by simp
 
-lemma runnable_eq:
-  "runnable st = (st = Running \<or> st = Restart)"
-  by (cases st; simp)
-
-lemma halted_eq:
-  "halted st = (st = Inactive \<or> st = IdleThreadState)"
-  by (cases st; simp)
-
 crunch vgic_update, vgic_update_lr, vcpu_update for ex_nonz_cap_to[wp]: "ex_nonz_cap_to p"
   (wp: ex_nonz_cap_to_pres)
 

--- a/proof/invariant-abstract/AARCH64/ArchInvariants_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchInvariants_AI.thy
@@ -39,17 +39,24 @@ section "AARCH64-specific invariant definitions"
 qualify AARCH64 (in Arch)
 record iarch_tcb =
   itcb_vcpu :: "obj_ref option"
+  itcb_cur_fpu :: bool
 end_qualify
 
 context Arch begin arch_global_naming
 
 definition arch_tcb_to_iarch_tcb :: "arch_tcb \<Rightarrow> iarch_tcb" where
-  "arch_tcb_to_iarch_tcb arch_tcb \<equiv> \<lparr> itcb_vcpu = tcb_vcpu arch_tcb \<rparr>"
+  "arch_tcb_to_iarch_tcb arch_tcb \<equiv>
+     \<lparr> itcb_vcpu = tcb_vcpu arch_tcb, itcb_cur_fpu = tcb_cur_fpu arch_tcb \<rparr>"
 
 (* Need one of these simp rules for each field in 'iarch_tcb' *)
 lemma arch_tcb_to_iarch_tcb_simps[simp]:
   "itcb_vcpu (arch_tcb_to_iarch_tcb arch_tcb) = tcb_vcpu arch_tcb"
+  "itcb_cur_fpu (arch_tcb_to_iarch_tcb arch_tcb) = tcb_cur_fpu arch_tcb"
   by (auto simp: arch_tcb_to_iarch_tcb_def)
+
+lemma iarch_tcb_simps[simp]:
+  "\<And>f. arch_tcb_to_iarch_tcb (tcb_context_update f arch_tcb) = arch_tcb_to_iarch_tcb arch_tcb"
+  by simp+
 
 lemma iarch_tcb_context_set[simp]:
   "arch_tcb_to_iarch_tcb (arch_tcb_context_set p tcb) = arch_tcb_to_iarch_tcb tcb"
@@ -535,6 +542,11 @@ definition hyp_live :: "kernel_object \<Rightarrow> bool" where
    | ArchObj ao \<Rightarrow> arch_live ao
    |  _ \<Rightarrow> False"
 
+(* A TCB is live if it is the current FPU owner. The link between the TCB's local ghost variable
+   tcb_cur_fpu and the global arm_current_fpu_owner is enforced by valid_cur_fpu. *)
+definition arch_tcb_live :: "arch_tcb \<Rightarrow> bool" where
+  "arch_tcb_live arch_tcb \<equiv> tcb_cur_fpu arch_tcb"
+
 (* The TCB link pointers of VCPUs *)
 locale_abbrev vcpu_tcbs_of :: "'z::state_ext state \<Rightarrow> obj_ref \<Rightarrow> obj_ref option" where
   "vcpu_tcbs_of \<equiv> \<lambda>s. vcpus_of s |> vcpu_tcb"
@@ -553,6 +565,13 @@ locale_abbrev cur_vcpu :: "'z::state_ext state \<Rightarrow> bool" where
   "cur_vcpu \<equiv> \<lambda>s. cur_vcpu_2 (arm_current_vcpu (arch_state s)) (vcpu_hyp_live_of s)"
 
 lemmas cur_vcpu_def = cur_vcpu_2_def
+
+definition is_tcb_cur_fpu :: "obj_ref \<Rightarrow> 'z::state_ext state \<Rightarrow> bool" where
+  "is_tcb_cur_fpu \<equiv> obj_at (\<lambda>ko. \<exists>tcb. ko = TCB tcb \<and> tcb_cur_fpu (tcb_arch tcb))"
+
+(* Each TCB's local ghost variable tcb_cur_fpu is consistent with the global arm_current_fpu_owner *)
+definition valid_cur_fpu :: "'z::state_ext state \<Rightarrow> bool" where
+  "valid_cur_fpu s \<equiv> \<forall>p. arm_current_fpu_owner (arch_state s) = Some p \<longleftrightarrow> is_tcb_cur_fpu p s"
 
 definition pte_rights_of :: "pte \<Rightarrow> rights set" where
   "pte_rights_of pte \<equiv> if is_PagePTE pte then pte_rights pte else {}"
@@ -668,8 +687,9 @@ locale_abbrev valid_global_tables :: "'z::state_ext state \<Rightarrow> bool" wh
 lemmas valid_global_tables_def = valid_global_tables_2_def
 
 definition valid_arch_state :: "'z::state_ext state \<Rightarrow> bool" where
-  "valid_arch_state \<equiv> valid_asid_table and valid_uses and vmid_inv and valid_vmid_table and
-                      cur_vcpu and valid_global_arch_objs and valid_global_tables"
+  "valid_arch_state \<equiv>
+     valid_asid_table and valid_uses and vmid_inv and valid_vmid_table and cur_vcpu and
+     valid_global_arch_objs and valid_global_tables"
 
 (* ---------------------------------------------------------------------------------------------- *)
 
@@ -993,9 +1013,31 @@ lemma addrFromPPtr_ptrFromPAddr_id[simp]:
   "addrFromPPtr (ptrFromPAddr x) = x"
   by (simp add: addrFromPPtr_def ptrFromPAddr_def)
 
-lemma global_refs_asid_table_update [iff]:
-  "global_refs (s\<lparr>arch_state := arm_asid_table_update f (arch_state s)\<rparr>) = global_refs s"
-  by (simp add: global_refs_def)
+lemma global_refs_updates[simp]:
+  "\<And>f. global_refs (s\<lparr>arch_state := arm_asid_table_update f (arch_state s)\<rparr>) = global_refs s"
+  "\<And>f. global_refs (s\<lparr>arch_state := arm_current_fpu_owner_update f (arch_state s)\<rparr>) = global_refs s"
+  by (auto simp: global_refs_def)
+
+lemma vmid_inv_updates[simp]:
+  "\<And>f. vmid_inv (s\<lparr>arch_state := arm_current_fpu_owner_update f (arch_state s)\<rparr>) = vmid_inv s"
+  "\<And>f. vmid_inv (s\<lparr>arch_state := arm_current_vcpu_update f (arch_state s)\<rparr>) = vmid_inv s"
+  by (auto simp: vmid_inv_def)
+
+lemma valid_global_arch_objs_updates[simp]:
+  "\<And>f. valid_global_arch_objs (s\<lparr>arch_state := arm_current_fpu_owner_update f (arch_state s)\<rparr>) = valid_global_arch_objs s"
+  by (auto simp: valid_global_arch_objs_def obj_at_def)
+
+lemma valid_arch_state_updates[simp]:
+  "\<And>f. valid_arch_state (s\<lparr>arch_state := arm_current_fpu_owner_update f (arch_state s)\<rparr>) = valid_arch_state s"
+  by (auto simp: valid_arch_state_def)
+
+lemma valid_global_objs_updates[simp]:
+  "\<And>f. valid_global_objs (s\<lparr>arch_state := arm_current_fpu_owner_update f (arch_state s)\<rparr>) = valid_global_objs s"
+  by (auto simp: valid_global_objs_def)
+
+lemma valid_kernel_mappings_updates[simp]:
+  "\<And>f. valid_kernel_mappings (arch_state_update f s) = valid_kernel_mappings s"
+  by (auto simp: valid_kernel_mappings_def)
 
 lemma pspace_in_kernel_window_arch_update[simp]:
   "arm_kernel_vspace (f (arch_state s)) = arm_kernel_vspace (arch_state s)
@@ -1465,6 +1507,16 @@ lemma hyp_live_tcb_simps[simp]:
   "\<And>f. hyp_live (TCB (tcb_time_slice_update f tcb)) = hyp_live (TCB tcb)"
   by (simp_all add: hyp_live_tcb_def)
 
+lemma arch_tcb_live_simps[simp]:
+  "\<And>f. arch_tcb_live (tcb_context_update f arch_tcb) = arch_tcb_live arch_tcb"
+  "\<And>f. arch_tcb_live (tcb_vcpu_update f arch_tcb) = arch_tcb_live arch_tcb"
+  by (simp_all add: arch_tcb_live_def)
+
+lemma arch_tcb_live_context_simps[simp]:
+  "\<And>f. arch_tcb_live (arch_tcb_context_set f arch_tcb) = arch_tcb_live arch_tcb"
+  "\<And>f. arch_tcb_live (arch_tcb_set_registers f arch_tcb) = arch_tcb_live arch_tcb"
+  by (simp_all add: arch_tcb_context_set_def arch_tcb_set_registers_def)
+
 lemma wellformed_arch_typ:
   assumes [wp]: "\<And>T p. f \<lbrace>typ_at T p\<rbrace>"
   shows "f \<lbrace>arch_valid_obj ao\<rbrace>"
@@ -1512,17 +1564,15 @@ lemma valid_arch_cap_ref_pspaceI[elim]:
   unfolding valid_arch_cap_ref_def
   by (auto intro: obj_at_pspaceI split: arch_cap.split)
 
-lemma valid_arch_tcb_context_update[simp]:
-  "valid_arch_tcb (tcb_context_update f t) = valid_arch_tcb t"
-  unfolding valid_arch_tcb_def obj_at_def by simp
+lemma valid_arch_tcb_simps[simp]:
+  "\<And>f. valid_arch_tcb (tcb_context_update f t) = valid_arch_tcb t"
+  "\<And>f. valid_arch_tcb (tcb_cur_fpu_update f t) = valid_arch_tcb t"
+  by (simp add: valid_arch_tcb_def)+
 
-lemma valid_arch_arch_tcb_context_set[simp]:
-  "valid_arch_tcb (arch_tcb_context_set a t) = valid_arch_tcb t"
-  by (simp add: arch_tcb_context_set_def)
-
-lemma valid_arch_arch_tcb_set_registers[simp]:
-  "valid_arch_tcb (arch_tcb_set_registers a t) = valid_arch_tcb t"
-  by (simp add: arch_tcb_set_registers_def)
+lemma valid_arch_tcb_context_simps[simp]:
+  "\<And>a. valid_arch_tcb (arch_tcb_context_set a t) = valid_arch_tcb t"
+  "\<And>a. valid_arch_tcb (arch_tcb_set_registers a t) = valid_arch_tcb t"
+  by (simp add: arch_tcb_context_set_def arch_tcb_set_registers_def)+
 
 lemma valid_arch_tcb_typ_at:
   "\<lbrakk> valid_arch_tcb t s; \<And>T p. typ_at T p s \<Longrightarrow> typ_at T p s' \<rbrakk> \<Longrightarrow> valid_arch_tcb t s'"
@@ -2725,6 +2775,23 @@ lemma valid_arch_state_lift:
   shows "f \<lbrace>valid_arch_state\<rbrace>"
   by (rule valid_arch_state_lift_arch; fastforce intro: aobjs_of_atyp_lift assms)
 
+lemmas valid_cur_fpu_defs = valid_cur_fpu_def is_tcb_cur_fpu_def obj_at_def
+
+lemma valid_cur_fpu_is_tcb_cur_fpu_unique:
+  "\<lbrakk>valid_cur_fpu s; is_tcb_cur_fpu p s; is_tcb_cur_fpu p' s\<rbrakk> \<Longrightarrow> p = p'"
+  by (metis valid_cur_fpu_def option.inject)
+
+lemma valid_cur_fpu_is_tcb_cur_fpu_unique':
+  "\<lbrakk>valid_cur_fpu s; kheap s p = Some (TCB tcb); tcb_cur_fpu (tcb_arch tcb);
+    kheap s p' = Some (TCB tcb'); tcb_cur_fpu (tcb_arch tcb')\<rbrakk> \<Longrightarrow> p = p'"
+  by (clarsimp simp: valid_cur_fpu_is_tcb_cur_fpu_unique is_tcb_cur_fpu_def obj_at_def)
+
+lemma valid_cur_fpu_updates[simp]:
+  "\<And>f. valid_cur_fpu (s\<lparr>arch_state := arm_next_vmid_update f (arch_state s)\<rparr>) = valid_cur_fpu s"
+  "\<And>f. valid_cur_fpu (s\<lparr>arch_state := arm_vmid_table_update f (arch_state s)\<rparr>) = valid_cur_fpu s"
+  "\<And>f. valid_cur_fpu (s\<lparr>arch_state := arm_current_vcpu_update f (arch_state s)\<rparr>) = valid_cur_fpu s"
+  by (auto simp: valid_cur_fpu_defs)
+
 lemma asid_high_bits_of_and_mask[simp]:
   "asid_high_bits_of (asid && ~~ mask asid_low_bits || ucast (asid_low::asid_low_index)) =
    asid_high_bits_of asid"
@@ -3161,6 +3228,10 @@ sublocale Arch_p_asid_table_update_eq
 lemma cur_vcpu_update [iff]:
   "cur_vcpu (f s) = cur_vcpu s"
   by (simp add: arch)
+
+lemma valid_cur_fpu_update [iff]:
+  "valid_cur_fpu (f s) = valid_cur_fpu s"
+  by (auto simp: valid_cur_fpu_def is_tcb_cur_fpu_def arch)
 
 lemma vmid_inv_update [iff]:
   "vmid_inv (f s) = vmid_inv s"

--- a/proof/invariant-abstract/AARCH64/ArchInvariants_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchInvariants_AI.thy
@@ -1428,6 +1428,7 @@ lemma valid_tcb_arch_ref_lift:
 lemma tcb_arch_ref_simps[simp]:
   "\<And>f. tcb_arch_ref (tcb_ipc_buffer_update f tcb) = tcb_arch_ref tcb"
   "\<And>f. tcb_arch_ref (tcb_mcpriority_update f tcb) = tcb_arch_ref tcb"
+  "\<And>f. tcb_arch_ref (tcb_flags_update f tcb) = tcb_arch_ref tcb"
   "\<And>f. tcb_arch_ref (tcb_ctable_update f tcb) = tcb_arch_ref tcb"
   "\<And>f. tcb_arch_ref (tcb_vtable_update f tcb) = tcb_arch_ref tcb"
   "\<And>f. tcb_arch_ref (tcb_reply_update f tcb) = tcb_arch_ref tcb"

--- a/proof/invariant-abstract/AARCH64/ArchIpc_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchIpc_AI.thy
@@ -219,21 +219,17 @@ lemma copy_mrs_in_user_frame[wp, Ipc_AI_2_assms]:
   "\<lbrace>in_user_frame p\<rbrace> copy_mrs t buf t' buf' n \<lbrace>\<lambda>rv. in_user_frame p\<rbrace>"
   by (simp add: in_user_frame_def) (wp hoare_vcg_ex_lift)
 
-lemma as_user_getRestart_invs[wp]: "\<lbrace>P\<rbrace> as_user t getRestartPC \<lbrace>\<lambda>_. P\<rbrace>"
+lemma as_user_getRestart_inv[wp]:
+  "as_user t getRestartPC \<lbrace>P\<rbrace>"
   by (simp add: getRestartPC_def, rule user_getreg_inv)
 
-lemma make_arch_fault_msg_invs[wp, Ipc_AI_2_assms]: "make_arch_fault_msg f t \<lbrace>invs\<rbrace>"
-  by (cases f; wpsimp)
+lemma make_arch_fault_msg_inv[wp, Ipc_AI_2_assms]:
+  "make_arch_fault_msg ft t \<lbrace>P\<rbrace>"
+  by (cases ft; wpsimp)
 
-lemma make_fault_message_inv[wp, Ipc_AI_2_assms]:
-  "make_fault_msg ft t \<lbrace>invs\<rbrace>"
-  apply (cases ft, simp_all split del: if_split)
-     apply (wp as_user_inv getRestartPC_inv mapM_wp'
-              | simp add: getRegister_def)+
-  done
-
-crunch make_fault_msg
-  for tcb_at[wp]: "tcb_at t"
+lemma make_fault_msg_inv[wp, Ipc_AI_2_assms]:
+  "make_fault_msg ft t \<lbrace>P\<rbrace>"
+  by (cases ft; wpsimp wp: as_user_inv getRestartPC_inv mapM_wp' split_del: if_split)
 
 lemma do_fault_transfer_invs[wp, Ipc_AI_2_assms]:
   "\<lbrace>invs and tcb_at receiver\<rbrace>
@@ -410,98 +406,17 @@ lemma transfer_caps_loop_valid_vspace_objs[wp, Ipc_AI_2_assms]:
         | assumption | simp split del: if_split)+
   done
 
-crunch  make_arch_fault_msg
-  for aligned[wp, Ipc_AI_2_assms]: "pspace_aligned"
-crunch  make_arch_fault_msg
-  for distinct[wp, Ipc_AI_2_assms]: "pspace_distinct"
-crunch  make_arch_fault_msg
-  for vmdb[wp, Ipc_AI_2_assms]: "valid_mdb"
-crunch  make_arch_fault_msg
-  for ifunsafe[wp, Ipc_AI_2_assms]: "if_unsafe_then_cap"
-crunch  make_arch_fault_msg
-  for iflive[wp, Ipc_AI_2_assms]: "if_live_then_nonz_cap"
-crunch  make_arch_fault_msg
-  for state_refs_of[wp, Ipc_AI_2_assms]: "\<lambda>s. P (state_refs_of s)"
-crunch  make_arch_fault_msg
-  for ct[wp, Ipc_AI_2_assms]: "cur_tcb"
-crunch  make_arch_fault_msg
-  for zombies[wp, Ipc_AI_2_assms]: "zombies_final"
-crunch  make_arch_fault_msg
-  for it[wp, Ipc_AI_2_assms]: "\<lambda>s. P (idle_thread s)"
-crunch  make_arch_fault_msg
-  for valid_globals[wp, Ipc_AI_2_assms]: "valid_global_refs"
-crunch  make_arch_fault_msg
-  for reply_masters[wp, Ipc_AI_2_assms]: "valid_reply_masters"
-crunch  make_arch_fault_msg
-  for valid_idle[wp, Ipc_AI_2_assms]: "valid_idle"
-crunch  make_arch_fault_msg
-  for arch[wp, Ipc_AI_2_assms]: "\<lambda>s. P (arch_state s)"
-crunch  make_arch_fault_msg
-  for typ_at[wp, Ipc_AI_2_assms]: "\<lambda>s. P (typ_at T p s)"
-crunch  make_arch_fault_msg
-  for irq_node[wp, Ipc_AI_2_assms]: "\<lambda>s. P (interrupt_irq_node s)"
-crunch  make_arch_fault_msg
-  for valid_reply[wp, Ipc_AI_2_assms]: "valid_reply_caps"
-crunch  make_arch_fault_msg
-  for irq_handlers[wp, Ipc_AI_2_assms]: "valid_irq_handlers"
-crunch  make_arch_fault_msg
-  for vspace_objs[wp, Ipc_AI_2_assms]: "valid_vspace_objs"
-crunch  make_arch_fault_msg
-  for global_objs[wp, Ipc_AI_2_assms]: "valid_global_objs"
-crunch  make_arch_fault_msg
-  for global_vspace_mapping[wp, Ipc_AI_2_assms]: "valid_global_vspace_mappings"
-crunch  make_arch_fault_msg
-  for arch_caps[wp, Ipc_AI_2_assms]: "valid_arch_caps"
-crunch  make_arch_fault_msg
-  for eq_ker_map[wp, Ipc_AI_2_assms]: "equal_kernel_mappings"
-crunch  make_arch_fault_msg
-  for asid_map[wp, Ipc_AI_2_assms]: "valid_asid_map"
-crunch  make_arch_fault_msg
-  for only_idle[wp, Ipc_AI_2_assms]: "only_idle"
-crunch  make_arch_fault_msg
-  for pspace_in_kernel_window[wp, Ipc_AI_2_assms]: "pspace_in_kernel_window"
-crunch  make_arch_fault_msg
-  for cap_refs_in_kernel_window[wp, Ipc_AI_2_assms]: "cap_refs_in_kernel_window"
-crunch  make_arch_fault_msg
-  for valid_objs[wp, Ipc_AI_2_assms]: "valid_objs"
-crunch  make_arch_fault_msg
-  for valid_ioc[wp, Ipc_AI_2_assms]: "valid_ioc"
-crunch  make_arch_fault_msg
-  for pred_tcb[wp, Ipc_AI_2_assms]: "pred_tcb_at proj P t"
-crunch  make_arch_fault_msg
-  for cap_to[wp, Ipc_AI_2_assms]: "ex_nonz_cap_to p"
-
-crunch  make_arch_fault_msg
-  for v_ker_map[wp, Ipc_AI_2_assms]: "valid_kernel_mappings"
- (simp: valid_kernel_mappings_def)
-
-crunch  make_arch_fault_msg
-  for obj_at[wp, Ipc_AI_2_assms]: "\<lambda>s. P (obj_at P' pd s)"
-  (wp: as_user_inv getRestartPC_inv mapM_wp'  simp: getRegister_def)
-
 lemma dmo_addressTranslateS1_valid_machine_state[wp]:
   "do_machine_op (addressTranslateS1 addr) \<lbrace> valid_machine_state \<rbrace>"
   by (wpsimp wp: dmo_valid_machine_state)
-
-crunch make_arch_fault_msg
-  for vms[wp, Ipc_AI_2_assms]: valid_machine_state
-  (wp: as_user_inv getRestartPC_inv mapM_wp'  simp: getRegister_def ignore: do_machine_op)
 
 lemma dmo_addressTranslateS1_valid_irq_states[wp]:
   "do_machine_op (addressTranslateS1 addr) \<lbrace> valid_irq_states \<rbrace>"
   by (wpsimp wp: dmo_valid_irq_states)
 
-crunch make_arch_fault_msg
-  for valid_irq_states[wp, Ipc_AI_2_assms]: "valid_irq_states"
-  (wp: as_user_inv getRestartPC_inv mapM_wp'  simp: getRegister_def ignore: do_machine_op)
-
 lemma dmo_addressTranslateS1_cap_refs_respects_device_region[wp]:
   "do_machine_op (addressTranslateS1 addr) \<lbrace> cap_refs_respects_device_region \<rbrace>"
   by (wpsimp wp: cap_refs_respects_device_region_dmo)
-
-crunch make_arch_fault_msg
-  for cap_refs_respects_device_region[wp, Ipc_AI_2_assms]: "cap_refs_respects_device_region"
-  (wp: as_user_inv getRestartPC_inv mapM_wp'  simp: getRegister_def ignore: do_machine_op)
 
 lemma setup_caller_cap_aobj_at:
   "arch_obj_pred P' \<Longrightarrow>
@@ -511,7 +426,7 @@ lemma setup_caller_cap_aobj_at:
 
 lemma setup_caller_cap_valid_arch[Ipc_AI_2_assms, wp]:
   "setup_caller_cap st rt grant \<lbrace>valid_arch_state\<rbrace>"
-  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps[rotated -1] setup_caller_cap_aobj_at)
+  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps[rotated -1] setup_caller_cap_tcb_at setup_caller_cap_aobj_at)
 
 lemma transfer_caps_loop_valid_arch[Ipc_AI_2_assms]:
   "\<And>slots caps ep buffer n mi.
@@ -520,7 +435,7 @@ lemma transfer_caps_loop_valid_arch[Ipc_AI_2_assms]:
          and transfer_caps_srcs caps\<rbrace>
       transfer_caps_loop ep buffer n caps slots mi
     \<lbrace>\<lambda>_. valid_arch_state\<rbrace>"
-  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps transfer_caps_loop_aobj_at)
+  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps transfer_caps_loop_typ_ats transfer_caps_loop_aobj_at)
 
 end
 
@@ -537,10 +452,6 @@ named_theorems Ipc_AI_3_assms
 lemma dmo_addressTranslateS1_pspace_respects_device_region[wp]:
   "do_machine_op (addressTranslateS1 addr) \<lbrace> pspace_respects_device_region \<rbrace>"
   by (wpsimp wp: pspace_respects_device_region_dmo)
-
-crunch make_fault_msg
-  for pspace_respects_device_region[wp]: "pspace_respects_device_region"
-  (wp: as_user_inv getRestartPC_inv mapM_wp'  simp: getRegister_def ignore: do_machine_op)
 
 crunch do_ipc_transfer
   for pspace_respects_device_region[wp, Ipc_AI_3_assms]: "pspace_respects_device_region"
@@ -589,7 +500,7 @@ lemma do_ipc_transfer_valid_arch[Ipc_AI_3_assms]:
   "\<lbrace>valid_arch_state and valid_objs and valid_mdb \<rbrace>
    do_ipc_transfer s ep bg grt r
    \<lbrace>\<lambda>rv. valid_arch_state\<rbrace>"
-  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps do_ipc_transfer_aobj_at)
+  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps dit_tcb_at do_ipc_transfer_aobj_at)
 
 end
 

--- a/proof/invariant-abstract/AARCH64/ArchKernelInit_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchKernelInit_AI.thy
@@ -284,6 +284,10 @@ lemma tcb_vcpu_init_arch_tcb_None[simp]:
   "tcb_vcpu init_arch_tcb = None"
   by (simp add: init_arch_tcb_def)
 
+lemma tcb_cur_fpu_init_arch_tcb_False[simp]:
+  "tcb_cur_fpu init_arch_tcb = False"
+  by (simp add: init_arch_tcb_def)
+
 lemma pspace_in_kernel_window_init_A_st:
   "pspace_in_kernel_window init_A_st"
   apply (clarsimp simp: pspace_in_kernel_window_def init_A_st_def init_kheap_def)
@@ -330,9 +334,10 @@ lemma invs_A:
                           valid_tcb_def
                    split: if_split_asm)
    apply (simp add: pspace_aligned_init_A pspace_distinct_init_A)
-    apply (clarsimp simp: if_live_then_nonz_cap_def obj_at_def state_defs live_def hyp_live_def arch_live_def)
-    apply (clarsimp simp: zombies_final_def cte_wp_at_cases state_defs ex_nonz_cap_to_def
-                          tcb_cap_cases_def is_zombie_def)
+   apply (clarsimp simp: if_live_then_nonz_cap_def obj_at_def state_defs live_def hyp_live_def
+                         arch_live_def arch_tcb_live_def)
+   apply (clarsimp simp: zombies_final_def cte_wp_at_cases state_defs ex_nonz_cap_to_def
+                         tcb_cap_cases_def is_zombie_def)
    apply (clarsimp simp: sym_refs_def state_refs_of_def state_defs state_hyp_refs_of_def)
   apply (rule conjI)
    apply (clarsimp simp: valid_mdb_def init_cdt_def no_mloop_def
@@ -369,6 +374,7 @@ lemma invs_A:
    apply (simp add: valid_arch_state_def state_defs obj_at_def a_type_def cur_vcpu_2_def
                     vmid_inv_def is_inv_def vmid_for_asid_2_def obind_def
                     valid_global_tables_2_def empty_pt_def valid_vmid_table_def)
+  apply (rule conjI, clarsimp simp: valid_cur_fpu_def is_tcb_cur_fpu_def obj_at_def state_defs)
   apply (rule conjI)
    apply (clarsimp simp: valid_irq_node_def obj_at_def state_defs
                          is_cap_table_def wf_empty_bits

--- a/proof/invariant-abstract/AARCH64/ArchRetype_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchRetype_AI.thy
@@ -438,6 +438,20 @@ lemma valid_global_tables':
   unfolding valid_global_tables_2_def
   by (simp add: pts_of)
 
+lemma is_tcb_cur_fpu':
+  "is_tcb_cur_fpu p s' = is_tcb_cur_fpu p s"
+  apply (clarsimp simp: s'_def ps_def is_tcb_cur_fpu_def obj_at_def)
+  apply (rule iffI; clarsimp)
+   apply (fastforce simp: default_object_def default_tcb_def default_arch_tcb_def tyunt
+                   split: apiobject_type.splits)
+  apply (erule (1) pspace_no_overlapC[OF orth _ _ cover vp])
+  done
+
+lemma valid_cur_fpu':
+  "valid_cur_fpu s \<Longrightarrow> valid_cur_fpu s'"
+  unfolding valid_cur_fpu_def
+  by (clarsimp simp: is_tcb_cur_fpu')
+
 lemma valid_arch_state:
   "valid_arch_state s \<Longrightarrow> valid_arch_state s'"
   apply (simp add: valid_arch_state_def valid_asid_table vcpu_hyp_live_of' vmid_inv'
@@ -835,7 +849,7 @@ lemma post_retype_invs:
   apply (clarsimp simp: invs_def post_retype_invs_def valid_state_def
                      unsafe_rep2 null_filter valid_idle
                      valid_reply_caps valid_reply_masters
-                     valid_global_refs valid_arch_state
+                     valid_global_refs valid_arch_state valid_cur_fpu'
                      valid_irq_node_def obj_at_pres
                      valid_arch_caps valid_global_objs_def
                      valid_vspace_objs'[OF _ valid_arch_state_asid_table valid_pspace_aligned2]

--- a/proof/invariant-abstract/AARCH64/ArchSchedule_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchSchedule_AI.thy
@@ -28,6 +28,37 @@ lemma dmo_mapM_storeWord_0_invs[wp,Schedule_AI_assms]:
    apply wp
   by (simp add: upto.simps word_bits_def)
 
+lemma invs_current_fpu_owner_update:
+  "\<lbrakk>valid_arch_state s\<rbrakk> \<Longrightarrow> invs (s\<lparr>arch_state := arch_state s \<lparr>arm_current_fpu_owner := t\<rparr>\<rparr>) = invs s"
+  by (auto simp: invs_def valid_state_def cur_tcb_def cur_vcpu_at_def obj_at_conj_distrib
+                 valid_global_refs_def valid_asid_map_def valid_arch_state_def
+                 valid_global_objs_def valid_global_vspace_mappings_def cur_vcpu_def
+                 global_refs_def vmid_inv_def valid_global_arch_objs_def in_omonad obj_at_def
+                 hyp_live_def arch_live_def
+          split: option.splits)
+
+lemma invs_current_fpu_owner_update':
+  "\<lbrakk> invs s \<rbrakk> \<Longrightarrow> invs (s\<lparr>arch_state := arch_state s\<lparr>arm_current_fpu_owner := t\<rparr>\<rparr>)"
+  apply (prop_tac "valid_arch_state s", simp add: invs_def valid_state_def)
+  apply (simp add: invs_current_fpu_owner_update)
+  done
+
+crunch save_fpu_state, load_fpu_state
+  for invs[wp]: invs
+  (wp: dmo_invs_lift)
+
+lemma switch_local_fpu_owner_invs:
+  "switch_local_fpu_owner t \<lbrace>invs\<rbrace>"
+  unfolding switch_local_fpu_owner_def
+  by (wpsimp wp: dmo_invs_lift hoare_drop_imps | strengthen invs_current_fpu_owner_update')+
+
+crunch lazy_fpu_restore
+  for invs[wp]: invs
+  and typ_at[wp]: "\<lambda>s. P (typ_at T p s)"
+  and pred_tcb_at[wp]: "\<lambda>s. P (pred_tcb_at proj Q t s)"
+  and scheduler_action[wp]: "\<lambda>s. P (scheduler_action s)"
+  (wp: dmo_invs_lift)
+
 lemma arch_stt_invs [wp,Schedule_AI_assms]:
   "arch_switch_to_thread t' \<lbrace>invs\<rbrace>"
   apply (wpsimp simp: arch_switch_to_thread_def)
@@ -93,6 +124,14 @@ crunch set_vm_root, vcpu_switch
 lemma arch_stt_scheduler_action [wp, Schedule_AI_assms]:
   "\<lbrace>\<lambda>s. P (scheduler_action s)\<rbrace> arch_switch_to_thread t' \<lbrace>\<lambda>_ s. P (scheduler_action s)\<rbrace>"
   by (wpsimp simp: arch_switch_to_thread_def)
+
+crunch arch_prepare_next_domain
+  for ct[wp, Schedule_AI_assms]: "\<lambda>s. P (cur_thread s)"
+  and activatable[wp, Schedule_AI_assms]: "ct_in_state activatable"
+  and pred_tcb_at[wp, Schedule_AI_assms]: "\<lambda>s. P (pred_tcb_at proj Q t s)"
+  and valid_idle[wp, Schedule_AI_assms]: valid_idle
+  and invs[wp, Schedule_AI_assms]: invs
+  (wp: crunch_wps ct_in_state_thread_state_lift)
 
 lemma arch_stit_scheduler_action [wp, Schedule_AI_assms]:
   "\<lbrace>\<lambda>s. P (scheduler_action s)\<rbrace> arch_switch_to_idle_thread \<lbrace>\<lambda>_ s. P (scheduler_action s)\<rbrace>"

--- a/proof/invariant-abstract/AARCH64/ArchSyscall_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchSyscall_AI.thy
@@ -19,6 +19,9 @@ context Arch begin arch_global_naming
 named_theorems Syscall_AI_assms
 
 declare arch_get_sanitise_register_info_invs[Syscall_AI_assms]
+        arch_get_sanitise_register_info_ex_nonz_cap_to[Syscall_AI_assms]
+        make_fault_msg_inv[Syscall_AI_assms]
+
 crunch handle_arch_fault_reply, arch_get_sanitise_register_info
   for pred_tcb_at[wp,Syscall_AI_assms]: "pred_tcb_at proj P t"
 crunch handle_arch_fault_reply
@@ -29,7 +32,7 @@ crunch handle_arch_fault_reply, arch_get_sanitise_register_info
   for it[wp,Syscall_AI_assms]: "\<lambda>s. P (idle_thread s)"
 crunch handle_arch_fault_reply, arch_get_sanitise_register_info
   for caps[wp,Syscall_AI_assms]: "\<lambda>s. P (caps_of_state s)"
-crunch handle_arch_fault_reply, make_fault_msg, arch_get_sanitise_register_info
+crunch handle_arch_fault_reply, arch_get_sanitise_register_info
   for cur_thread[wp,Syscall_AI_assms]: "\<lambda>s. P (cur_thread s)"
 crunch handle_arch_fault_reply, arch_get_sanitise_register_info
   for valid_objs[wp,Syscall_AI_assms]: "valid_objs"
@@ -85,8 +88,6 @@ lemma hvmf_active [Syscall_AI_assms]:
 lemma hvmf_ex_cap[wp, Syscall_AI_assms]:
   "\<lbrace>ex_nonz_cap_to p\<rbrace> handle_vm_fault t b \<lbrace>\<lambda>rv. ex_nonz_cap_to p\<rbrace>"
   unfolding handle_vm_fault_def by (cases b; wpsimp)
-
-declare arch_get_sanitise_register_info_ex_nonz_cap_to[Syscall_AI_assms]
 
 lemma hh_invs[wp, Syscall_AI_assms]:
   "\<lbrace>invs and ct_active and st_tcb_at active thread and ex_nonz_cap_to thread\<rbrace>

--- a/proof/invariant-abstract/AARCH64/ArchTcb_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchTcb_AI.thy
@@ -367,7 +367,6 @@ lemma update_cap_valid[Tcb_AI_assms]:
                                      split: option.splits prod.splits)
   done
 
-
 crunch switch_to_thread
   for pred_tcb_at: "pred_tcb_at proj P t"
   (wp: crunch_wps simp: crunch_simps)

--- a/proof/invariant-abstract/AARCH64/ArchTcb_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchTcb_AI.thy
@@ -144,6 +144,10 @@ lemma finalise_cap_not_cte_wp_at[Tcb_AI_assms]:
          | simp add: deleting_irq_handler_def get_irq_slot_def x ball_ran_eq)+
     done
 
+crunch arch_post_set_flags, arch_prepare_set_domain
+  for typ_at[wp, Tcb_AI_assms]: "\<lambda>s. P (typ_at T p s)"
+  and invs[wp, Tcb_AI_assms]: "invs"
+
 
 lemma table_cap_ref_max_free_index_upd[simp,Tcb_AI_assms]:
   "table_cap_ref (max_free_index_update cap) = table_cap_ref cap"

--- a/proof/invariant-abstract/AARCH64/ArchUntyped_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchUntyped_AI.thy
@@ -362,7 +362,7 @@ lemma create_cap_valid_arch_state[wp, Untyped_AI_assms]:
   "\<lbrace>valid_arch_state and cte_wp_at (\<lambda>_. True) cref\<rbrace>
    create_cap tp sz p dev (cref,oref)
    \<lbrace>\<lambda>rv. valid_arch_state\<rbrace>"
-  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps create_cap_aobj_at)
+  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps create_cap_tcb create_cap_aobj_at)
 
 lemma set_cap_non_arch_valid_arch_state[Untyped_AI_assms]:
  "\<lbrace>\<lambda>s. valid_arch_state s \<and> cte_wp_at (\<lambda>_. \<not>is_arch_cap cap) ptr s\<rbrace>

--- a/proof/invariant-abstract/AARCH64/ArchVSpace_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchVSpace_AI.thy
@@ -289,7 +289,7 @@ lemma set_vcpu_valid_arch_state_hyp_live:
   apply (clarsimp simp: asid_pools_of_vcpu_None_upd_idem vmid_inv_def)
   apply (rule conjI)
    apply (clarsimp simp: cur_vcpu_2_def hyp_live_vcpu_tcb in_opt_pred split: option.splits)
-  apply (clarsimp simp: valid_global_arch_objs_def obj_at_def pts_of_vcpu_None_upd_idem)
+  apply (fastforce simp: valid_global_arch_objs_def obj_at_def pts_of_vcpu_None_upd_idem)
   done
 
 lemma set_vcpu_obj_at:
@@ -568,7 +568,7 @@ lemma valid_arch_state_arm_next_vmid[simp]:
   "valid_arch_state (s\<lparr>arch_state := arch_state s\<lparr>arm_next_vmid := next_vmid\<rparr>\<rparr>) =
    valid_arch_state s"
   unfolding valid_arch_state_def
-  by (clarsimp simp: valid_global_arch_objs_def vmid_inv_def)
+  by (fastforce simp: valid_global_arch_objs_def vmid_inv_def)
 
 lemma update_asid_pool_entry_vspace_objs_of:
   "\<lbrace>\<lambda>s. \<forall>pool_ptr ap entry. pool_for_asid asid s = Some pool_ptr \<longrightarrow>
@@ -720,6 +720,8 @@ lemma invalidate_vmid_entry_valid_vmid_table[wp]:
 crunch find_free_vmid
   for valid_global_tables[wp]: "valid_global_tables"
   and valid_vmid_table[wp]: valid_vmid_table
+  and arm_current_fpu_owner[wp]: "\<lambda>s. P (arm_current_fpu_owner (arch_state s))"
+  and valid_cur_fpu[wp]: valid_cur_fpu
 
 lemma find_free_vmid_valid_arch [wp]:
   "find_free_vmid \<lbrace>valid_arch_state\<rbrace>"
@@ -743,16 +745,6 @@ lemma valid_global_refs_vmid_table_upd[simp]:
 lemma valid_global_refs_next_vmid_upd[simp]:
   "valid_global_refs (s\<lparr>arch_state := arch_state s\<lparr>arm_next_vmid := x\<rparr>\<rparr>) = valid_global_refs s"
   unfolding valid_global_refs_def valid_refs_def global_refs_def
-  by simp
-
-lemma valid_machine_state_arm_vmid_table_upd[simp]:
-  "valid_machine_state (s\<lparr>arch_state := arch_state s\<lparr>arm_vmid_table := x\<rparr>\<rparr>) = valid_machine_state s"
-  unfolding valid_machine_state_def
-  by simp
-
-lemma valid_machine_state_arm_next_vmid_upd[simp]:
-  "valid_machine_state (s\<lparr>arch_state := arch_state s\<lparr>arm_next_vmid := x\<rparr>\<rparr>) = valid_machine_state s"
-  unfolding valid_machine_state_def
   by simp
 
 lemma vs_lookup_target_vspace_eq:
@@ -881,6 +873,7 @@ lemma invalidate_asid_entry_invs[wp]:
 
 crunch find_free_vmid, store_vmid
   for valid_asid_map[wp]: valid_asid_map
+  and valid_cur_fpu[wp]: valid_cur_fpu
 
 lemma find_free_vmid_invs[wp]:
   "find_free_vmid \<lbrace>invs\<rbrace>"
@@ -987,7 +980,7 @@ lemma set_vm_root_invs[wp]:
   by (wpsimp simp: if_distribR wp: get_cap_wp)
 
 crunch set_vm_root
-  for pred_tcb_at[wp]: "pred_tcb_at proj P t"
+  for pred_tcb_at[wp]: "\<lambda>s. Q (pred_tcb_at proj P t s)"
   (simp: crunch_simps)
 
 lemmas set_vm_root_typ_ats [wp] = abs_typ_at_lifts [OF set_vm_root_typ_at]
@@ -2421,7 +2414,7 @@ lemma set_asid_pool_valid_arch_state:
   set_asid_pool ap (pool(asid_low_bits_of asid \<mapsto> ape))
   \<lbrace>\<lambda>_. valid_arch_state\<rbrace>"
   unfolding valid_arch_state_def
-  by (wpsimp wp: set_asid_pool_vmid_inv|wps)+
+  by (wpsimp wp: set_asid_pool_vmid_inv | wps)+
 
 lemma set_asid_pool_invs_valid_asid_map[wp]:
   "\<lbrace>valid_asid_map and valid_asid_table and
@@ -2687,7 +2680,7 @@ lemma set_vcpu_valid_reply_masters[wp]:
   by (rule valid_reply_masters_cte_lift) wp
 
 lemma set_vcpu_pred_tcb_at[wp]:
-  "\<lbrace>pred_tcb_at proj P t\<rbrace> set_vcpu p v \<lbrace>\<lambda>rv. pred_tcb_at proj P t\<rbrace>"
+  "set_vcpu p v \<lbrace>\<lambda>s. Q (pred_tcb_at proj P t s)\<rbrace>"
   apply (simp add: set_vcpu_def set_object_def)
   including no_pre apply wp
   apply (rule hoare_strengthen_post [OF get_object_sp])
@@ -2834,8 +2827,13 @@ lemma set_vcpu_valid_arch_eq_hyp:
   apply (wp set_vcpu_wp)
   apply (clarsimp simp: vmid_inv_set_vcpu asid_pools_of_vcpu_None_upd_idem pts_of_vcpu_None_upd_idem
                         valid_global_arch_objs_def pt_at_eq_set_vcpu)
-  apply (clarsimp simp: cur_vcpu_def split: option.splits)
-  by (auto simp: obj_at_def  vcpu_tcb_refs_def opt_map_def in_opt_pred split: option.splits)
+   apply (clarsimp simp: cur_vcpu_def split: option.splits)
+   by (auto simp: obj_at_def vcpu_tcb_refs_def opt_map_def in_opt_pred split: option.splits)
+
+lemma set_vcpu_valid_cur_fpu[wp]:
+  "set_vcpu p v \<lbrace>valid_cur_fpu\<rbrace>"
+  apply (wp set_vcpu_wp)
+  by (fastforce simp: valid_cur_fpu_defs)
 
 lemma set_vcpu_invs_eq_hyp:
   "\<lbrace>obj_at (\<lambda>ko'. hyp_refs_of ko' = hyp_refs_of (ArchObj (VCPU v))) p
@@ -2845,6 +2843,18 @@ lemma set_vcpu_invs_eq_hyp:
    \<lbrace> \<lambda>_. invs \<rbrace>"
   unfolding invs_def valid_state_def
   by (wpsimp wp: set_vcpu_valid_pspace set_vcpu_valid_arch_eq_hyp)
+
+lemma set_vcpu_nonz_cap_to[wp]:
+  "\<lbrace>ex_nonz_cap_to t and vcpu_at p\<rbrace>
+   set_vcpu p vcpu
+   \<lbrace>\<lambda>_. ex_nonz_cap_to t\<rbrace>"
+  unfolding set_vcpu_def
+  by (wpsimp simp: obj_at_def)
+
+lemma vcpu_update_nonz_cap_to[wp]:
+  "vcpu_update p ap \<lbrace>ex_nonz_cap_to t\<rbrace>"
+  unfolding vcpu_update_def
+  by (wpsimp wp: get_vcpu_wp simp: in_omonad obj_at_def)
 
 (* FIXME: move both this and the original still in Retype_AI *)
 lemmas do_machine_op_bind =
@@ -2967,26 +2977,6 @@ lemma vcpu_disable_invs[wp]:
                       hoare_vcg_const_imp_lift hoare_vcg_all_lift hoare_vcg_imp_lift')
   done
 
-lemma valid_machine_state_arch_state_update [simp]:
-  "valid_machine_state (arch_state_update f s) = valid_machine_state s"
-  by (simp add: valid_machine_state_def)
-
-lemma arm_asid_table_current_vcpu_update[simp]:
-  "arm_asid_table ((arm_current_vcpu_update v) (arch_state s)) = arm_asid_table (arch_state s)"
-  by clarsimp
-
-lemma vmid_inv_current_vcpu_update[simp]:
-  "vmid_inv (s\<lparr>arch_state := arm_current_vcpu_update Map.empty (arch_state s)\<rparr>) = vmid_inv s"
-  by (clarsimp simp: vmid_inv_def)
-
-lemma valid_irq_node_arch_state_update [simp]:
-  "valid_irq_node (arch_state_update f s) = valid_irq_node s"
-  by (simp add: valid_irq_node_def)
-
-lemma valid_kernel_mappings_arch_state_update [simp]:
-  "valid_kernel_mappings (arch_state_update f s) = valid_kernel_mappings s"
-  by (simp add: valid_kernel_mappings_def)
-
 
 definition cur_vcpu_at where
   "cur_vcpu_at v s \<equiv> case v of None \<Rightarrow> True | Some (vp, _) \<Rightarrow> vcpu_at vp s \<and> obj_at hyp_live vp s"
@@ -3075,7 +3065,7 @@ lemma vcpu_switch_invs[wp]:
 crunch
   arm_context_switch, vcpu_update, vgic_update, vcpu_disable, vcpu_enable,
   vcpu_restore, vcpu_switch, set_vm_root
-  for pred_tcb_at[wp]: "pred_tcb_at proj P t"
+  for pred_tcb_at[wp]: "\<lambda>s. Q (pred_tcb_at proj P t s)"
   (simp: crunch_simps wp: crunch_wps mapM_x_wp)
 
 lemma set_vcpu_cte_wp_at[wp]:

--- a/proof/invariant-abstract/AARCH64/Machine_AI.thy
+++ b/proof/invariant-abstract/AARCH64/Machine_AI.thy
@@ -172,6 +172,10 @@ lemma no_irq_return[simp, wp]:
   unfolding no_irq_def
   by simp
 
+lemma no_irq_get[simp, wp]:
+  "no_irq get"
+  by (wpsimp simp: no_irq_def)
+
 lemma no_irq_gets[simp, wp]:
   "no_irq (gets f)"
   by (simp add: no_irq_def)
@@ -244,9 +248,10 @@ crunch_ignore (valid, empty_fail, no_fail)
     cleanCacheRange_RAM_impl
     cleanInvalidateCacheRange_RAM_impl
     configureTimer_impl
+    disableFpu_impl
     dsb_impl
     enableFpuEL01_impl
-    fpuThreadDeleteOp_impl
+    enableFpu_impl
     get_gic_vcpu_ctrl_lr_impl
     initL2Cache_impl
     initTimer_impl
@@ -255,7 +260,6 @@ crunch_ignore (valid, empty_fail, no_fail)
     invalidateTranslationASID_impl
     invalidateTranslationSingle_impl
     isb_impl
-    nativeThreadUsingFPU_impl
     plic_complete_claim_impl
     resetTimer_impl
     set_gic_vcpu_ctrl_apr_impl
@@ -267,7 +271,7 @@ crunch_ignore (valid, empty_fail, no_fail)
     setIRQTrigger_impl
     setSCTLR_impl
     setVSpaceRoot_impl
-    switchFpuOwner_impl
+    writeFpuState_impl
     writeVCPUHardwareReg_impl
     )
 
@@ -275,8 +279,8 @@ crunch_ignore (valid, empty_fail, no_fail)
    List obtained using:
    grep -oE "(\w+_impl)|(get\w+)" MachineOps.thy|sort|uniq|sed "s/_impl//;s/$/,/;s/^/  /"
    with the following manual interventions:
-   - remove false positives: get_def, gets_def, getFPUState, getRegister, getRestartPC
-   - add read_cntpct
+   - remove false positives: get_def, gets, gets_def, getFPUState, getRegister, getRestartPC
+   - add read_cntpct and readFpuState
    - remove final comma
    - getActiveIRQ does not preserve no_irq *)
 crunch
@@ -288,9 +292,11 @@ crunch
   cleanCacheRange_RAM,
   cleanInvalidateCacheRange_RAM,
   configureTimer,
+  disableFpu,
   dsb,
   enableFpuEL01,
-  fpuThreadDeleteOp,
+  enableFpu,
+  getDFSR,
   getESR,
   getFAR,
   get_gic_vcpu_ctrl_apr,
@@ -303,8 +309,8 @@ crunch
   get_gic_vcpu_ctrl_vmcr,
   get_gic_vcpu_ctrl_vtr,
   getHSR,
+  getIFSR,
   getMemoryRegions,
-  gets,
   getSCTLR,
   initL2Cache,
   initTimer,
@@ -313,7 +319,6 @@ crunch
   invalidateTranslationASID,
   invalidateTranslationSingle,
   isb,
-  nativeThreadUsingFPU,
   plic_complete_claim,
   resetTimer,
   set_gic_vcpu_ctrl_apr,
@@ -325,17 +330,18 @@ crunch
   setIRQTrigger,
   setSCTLR,
   setVSpaceRoot,
-  switchFpuOwner,
+  writeFpuState,
   readVCPUHardwareReg,
   writeVCPUHardwareReg,
-  read_cntpct
+  read_cntpct,
+  readFpuState
   for (no_fail) no_fail[intro!, wp, simp]
   and (empty_fail) empty_fail[intro!, wp, simp]
   and (no_irq) no_irq[intro!, wp, simp]
   and device_state_inv[wp]: "\<lambda>ms. P (device_state ms)"
   and irq_masks[wp]: "\<lambda>s. P (irq_masks s)"
   and underlying_memory_inv[wp]: "\<lambda>s. P (underlying_memory s)"
-  (wp: no_irq_bind ignore: empty_fail Nondet_Monad.bind)
+  (wp: no_irq_bind no_irq_modify ef_machine_rest_lift no_fail_machine_state_rest_T)
 
 crunch getFPUState, getRegister, getRestartPC, setNextPC, ackInterrupt, maskInterrupt
   for (no_fail) no_fail[intro!, wp, simp]

--- a/proof/invariant-abstract/ARM/ArchAcc_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchAcc_AI.thy
@@ -1698,6 +1698,13 @@ lemma set_asid_pool_iflive [wp]:
            simp: a_type_def live_def hyp_live_def)
 
 
+lemma set_asid_pool_nonz_cap_to[wp]:
+  "set_asid_pool p ap \<lbrace>ex_nonz_cap_to t\<rbrace>"
+  apply (simp add: set_asid_pool_def)
+  including unfold_objects
+  by (wpsimp wp: set_object_nonz_cap_to[THEN hoare_set_object_weaken_pre]
+           simp: a_type_def)
+
 lemma set_asid_pool_zombies [wp]:
   "\<lbrace>\<lambda>s. zombies_final s\<rbrace>
   set_asid_pool p ap
@@ -2070,6 +2077,10 @@ lemma mdb_cte_at_set_asid_pool[wp]:
   apply (simp only: imp_conv_disj)
   apply (wp hoare_vcg_disj_lift hoare_vcg_all_lift)
 done
+
+crunch set_asid_pool
+  for valid_cur_fpu[wp]: valid_cur_fpu
+  (wp: valid_cur_fpu_lift)
 
 lemma set_asid_pool_invs_unmap:
   "\<lbrace>invs and ko_at (ArchObj (ASIDPool ap)) p and

--- a/proof/invariant-abstract/ARM/ArchBCorres2_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchBCorres2_AI.thy
@@ -28,8 +28,9 @@ crunch invoke_untyped
   for (bcorres) bcorres[wp]: truncate_state
   (ignore: sequence_x)
 
-crunch set_mcpriority, set_priority,
-          arch_get_sanitise_register_info, arch_post_modify_registers
+crunch
+  set_mcpriority, set_priority, arch_get_sanitise_register_info, arch_post_modify_registers,
+  set_flags, arch_post_set_flags
   for (bcorres) bcorres[wp, BCorres2_AI_assms]: truncate_state
 
 lemma invoke_tcb_bcorres[wp]:
@@ -70,7 +71,7 @@ lemma make_arch_fault_msg_bcorres[wp,BCorres2_AI_assms]:
   "bcorres (make_arch_fault_msg a b) (make_arch_fault_msg a b)"
   by (cases a; simp ; wp)
 
-lemma  handle_arch_fault_reply_bcorres[wp,BCorres2_AI_assms]:
+lemma handle_arch_fault_reply_bcorres[wp,BCorres2_AI_assms]:
   "bcorres ( handle_arch_fault_reply a b c d) (handle_arch_fault_reply a b c d)"
   by (cases a; simp add: handle_arch_fault_reply_def; wp)
 
@@ -102,7 +103,7 @@ lemma decode_cnode_invocation[wp]: "bcorres (decode_cnode_invocation a b c d) (d
 crunch
   decode_set_ipc_buffer, decode_set_space, decode_set_priority,
   decode_set_mcpriority, decode_set_sched_params, decode_bind_notification,
-  decode_unbind_notification, decode_set_tls_base
+  decode_unbind_notification, decode_set_tls_base, decode_set_flags
   for (bcorres) bcorres[wp]: truncate_state
 
 lemma decode_tcb_configure_bcorres[wp]: "bcorres (decode_tcb_configure b (cap.ThreadCap c) d e)
@@ -110,7 +111,8 @@ lemma decode_tcb_configure_bcorres[wp]: "bcorres (decode_tcb_configure b (cap.Th
   apply (simp add: decode_tcb_configure_def | wp)+
   done
 
-lemma decode_tcb_invocation_bcorres[wp]:"bcorres (decode_tcb_invocation a b (cap.ThreadCap c) d e) (decode_tcb_invocation a b (cap.ThreadCap c) d e)"
+lemma decode_tcb_invocation_bcorres[wp]:
+  "bcorres (decode_tcb_invocation a b (cap.ThreadCap c) d e) (decode_tcb_invocation a b (cap.ThreadCap c) d e)"
   apply (simp add: decode_tcb_invocation_def)
   apply (wp | wpc | simp)+
   done

--- a/proof/invariant-abstract/ARM/ArchCNodeInv_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchCNodeInv_AI.thy
@@ -522,7 +522,7 @@ lemma cap_swap_valid_arch_state[wp, CNodeInv_AI_assms]:
   "\<lbrace>valid_arch_state and cte_wp_at (weak_derived c) a and cte_wp_at (weak_derived c') b\<rbrace>
    cap_swap c a c' b
    \<lbrace>\<lambda>_. valid_arch_state\<rbrace>"
-  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps cap_swap_aobj_at)
+  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps cap_swap_typ_ats cap_swap_aobj_at)
 
 end
 

--- a/proof/invariant-abstract/ARM/ArchCSpaceInv_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchCSpaceInv_AI.thy
@@ -32,7 +32,7 @@ lemmas unique_table_refs_no_cap_asidD
 
 lemma set_cap_valid_arch_state[wp]:
   "set_cap cap ptr \<lbrace> valid_arch_state \<rbrace>"
-  by (wp valid_arch_state_lift_aobj_at_no_caps set_cap.aobj_at)
+  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps set_cap_tcb set_cap.aobj_at)
 
 lemma replace_cap_invs:
   "\<lbrace>\<lambda>s. invs s \<and> cte_wp_at (replaceable s p cap) p s

--- a/proof/invariant-abstract/ARM/ArchCSpace_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchCSpace_AI.thy
@@ -521,7 +521,7 @@ lemma cap_insert_derived_valid_arch_state[CSpace_AI_assms]:
   "\<lbrace>valid_arch_state and (\<lambda>s. cte_wp_at (is_derived (cdt s) src cap) src s)\<rbrace>
    cap_insert cap src dest
    \<lbrace>\<lambda>rv. valid_arch_state \<rbrace>"
-  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps cap_insert_aobj_at cap_insert_aobj_at)
+  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps cap_insert_tcb cap_insert_aobj_at)
 
 lemma setup_reply_master_arch[CSpace_AI_assms]:
   "setup_reply_master t \<lbrace> valid_arch_state \<rbrace>"
@@ -556,7 +556,7 @@ lemma is_cap_simps':
 
 lemma cap_insert_simple_valid_arch_state[wp]:
   "cap_insert cap src dest \<lbrace> valid_arch_state\<rbrace>"
-  by (wp valid_arch_state_lift_aobj_at_no_caps cap_insert_aobj_at)+
+  by (wp valid_arch_state_lift_aobj_at_no_caps cap_insert_tcb cap_insert_aobj_at)+
 
 lemma cap_insert_simple_invs:
   "\<lbrace>invs and valid_cap cap and tcb_cap_valid cap dest and
@@ -570,7 +570,7 @@ lemma cap_insert_simple_invs:
   apply (simp add: invs_def valid_state_def valid_pspace_def)
   apply (rule hoare_pre)
    apply (wp cap_insert_simple_mdb cap_insert_iflive
-             cap_insert_zombies cap_insert_ifunsafe
+             cap_insert_zombies cap_insert_ifunsafe valid_cur_fpu_lift
              cap_insert_valid_global_refs cap_insert_idle
              valid_irq_node_typ cap_insert_simple_arch_caps_no_ap)
   apply (clarsimp simp: is_simple_cap_def cte_wp_at_caps_of_state)

--- a/proof/invariant-abstract/ARM/ArchDetSchedAux_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchDetSchedAux_AI.thy
@@ -86,9 +86,6 @@ lemma perform_asid_control_invocation_valid_sched:
 
 end
 
-lemmas tcb_sched_action_valid_idle_etcb
-    = ARM.tcb_sched_action_valid_idle_etcb
-
 global_interpretation DetSchedAux_AI?: DetSchedAux_AI
   proof goal_cases
   interpret Arch .

--- a/proof/invariant-abstract/ARM/ArchDetSchedDomainTime_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchDetSchedDomainTime_AI.thy
@@ -21,7 +21,8 @@ crunch
   handle_arch_fault_reply,
   arch_invoke_irq_control, handle_vm_fault, arch_get_sanitise_register_info,
   prepare_thread_delete, handle_hypervisor_fault, make_arch_fault_msg, init_arch_objects,
-  arch_post_modify_registers, arch_post_cap_deletion, arch_invoke_irq_handler
+  arch_post_modify_registers, arch_post_cap_deletion, arch_invoke_irq_handler,
+  arch_prepare_next_domain, arch_prepare_set_domain, arch_post_set_flags
   for domain_list_inv[wp, DetSchedDomainTime_AI_assms]: "\<lambda>s::det_state. P (domain_list s)"
   (wp: crunch_wps)
 
@@ -34,9 +35,11 @@ crunch
   handle_arch_fault_reply, init_arch_objects,
   arch_invoke_irq_control, handle_vm_fault, arch_get_sanitise_register_info,
   prepare_thread_delete, handle_hypervisor_fault,
-  arch_post_modify_registers, arch_post_cap_deletion, arch_invoke_irq_handler
+  arch_post_modify_registers, arch_post_cap_deletion, arch_invoke_irq_handler,
+  arch_prepare_set_domain, arch_post_set_flags
   for domain_time_inv[wp, DetSchedDomainTime_AI_assms]: "\<lambda>s::det_state. P (domain_time s)"
   (wp: crunch_wps)
+
 declare init_arch_objects_exst[DetSchedDomainTime_AI_assms]
         make_arch_fault_msg_inv[DetSchedDomainTime_AI_assms]
 

--- a/proof/invariant-abstract/ARM/ArchDetSchedSchedule_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchDetSchedSchedule_AI.thy
@@ -20,7 +20,8 @@ crunch
   for prepare_thread_delete_idle_thread[wp, DetSchedSchedule_AI_assms]: "\<lambda>(s:: det_ext state). P (idle_thread s)"
 
 crunch
-  switch_to_idle_thread, switch_to_thread, set_vm_root, arch_get_sanitise_register_info, arch_post_modify_registers
+  switch_to_idle_thread, switch_to_thread, set_vm_root, arch_get_sanitise_register_info,
+  arch_post_modify_registers, arch_prepare_next_domain
   for valid_queues[wp, DetSchedSchedule_AI_assms]: valid_queues
   (simp: crunch_simps ignore: set_tcb_queue tcb_sched_action clearExMonitor)
 
@@ -86,7 +87,9 @@ crunch arch_switch_to_thread, arch_get_sanitise_register_info, arch_post_modify_
   for valid_sched_action[wp, DetSchedSchedule_AI_assms]: valid_sched_action
   (simp: crunch_simps ignore: clearExMonitor)
 
-crunch arch_switch_to_thread, arch_get_sanitise_register_info, arch_post_modify_registers
+crunch
+  arch_switch_to_thread, arch_get_sanitise_register_info, arch_post_modify_registers,
+  arch_prepare_next_domain, arch_post_set_flags, arch_prepare_set_domain
   for valid_sched[wp, DetSchedSchedule_AI_assms]: valid_sched
   (simp: crunch_simps ignore: clearExMonitor)
 
@@ -114,13 +117,22 @@ crunch
   for valid_idle[wp, DetSchedSchedule_AI_assms]: "valid_idle"
   (wp: crunch_wps simp: crunch_simps)
 
-crunch arch_switch_to_idle_thread
+crunch arch_switch_to_idle_thread, arch_prepare_next_domain
   for etcb_at[wp, DetSchedSchedule_AI_assms]: "etcb_at P t"
 
 crunch
-  arch_switch_to_idle_thread, next_domain
+  arch_prepare_next_domain, arch_prepare_set_domain
   for scheduler_action[wp, DetSchedSchedule_AI_assms]: "\<lambda>s. P (scheduler_action s)"
   (simp: Let_def)
+
+crunch arch_prepare_next_domain
+  for ready_queues[wp, DetSchedSchedule_AI_assms]: "\<lambda>s. P (ready_queues s)"
+  and ct_in_q[wp, DetSchedSchedule_AI_assms]: ct_in_q
+  and valid_blocked[wp, DetSchedSchedule_AI_assms]: valid_blocked
+
+crunch arch_prepare_set_domain
+  for idle_thread[wp, DetSchedSchedule_AI_assms]: "\<lambda>s. P (idle_thread s)"
+  and valid_idle[wp, DetSchedSchedule_AI_assms]: valid_idle
 
 lemma set_vm_root_valid_blocked_ct_in_q [wp]:
   "\<lbrace>valid_blocked and ct_in_q\<rbrace> set_vm_root p \<lbrace>\<lambda>_. valid_blocked and ct_in_q\<rbrace>"
@@ -280,7 +292,7 @@ crunch arch_invoke_irq_control
   for valid_sched[wp, DetSchedSchedule_AI_assms]: "valid_sched"
 
 crunch
-  arch_activate_idle_thread, arch_switch_to_thread, arch_switch_to_idle_thread
+  arch_activate_idle_thread, arch_switch_to_thread, arch_switch_to_idle_thread, arch_prepare_next_domain
   for valid_list[wp, DetSchedSchedule_AI_assms]: "valid_list"
 
 crunch handle_arch_fault_reply, handle_vm_fault, arch_get_sanitise_register_info, arch_post_modify_registers

--- a/proof/invariant-abstract/ARM/ArchDetSchedSchedule_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchDetSchedSchedule_AI.thy
@@ -111,6 +111,7 @@ crunch set_vm_root
 
 crunch switch_to_thread
   for etcb_at[wp, DetSchedSchedule_AI_assms]: "etcb_at P t"
+  (wp: crunch_wps)
 
 crunch
   arch_switch_to_idle_thread

--- a/proof/invariant-abstract/ARM/ArchDeterministic_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchDeterministic_AI.thy
@@ -14,7 +14,7 @@ named_theorems Deterministic_AI_assms
 
 crunch
   cap_swap_for_delete,set_cap,finalise_cap,arch_get_sanitise_register_info,
-  arch_post_modify_registers
+  arch_post_modify_registers, arch_post_set_flags
   for valid_list[wp, Deterministic_AI_assms]: valid_list
   (wp: crunch_wps simp: unless_def crunch_simps)
 declare get_cap_inv[Deterministic_AI_assms]

--- a/proof/invariant-abstract/ARM/ArchDetype_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchDetype_AI.thy
@@ -205,6 +205,11 @@ lemma valid_arch_state_detype[detype_invs_proofs]:
   apply blast
   done
 
+lemma valid_cur_fpu[detype_invs_proofs]:
+  "valid_cur_fpu (detype (untyped_range cap) s)"
+  using valid_cur_fpu
+  by (clarsimp simp: valid_cur_fpu_def)
+
 lemma global_pts: (* ARCH SPECIFIC STATEMENT*)
   "\<And>p. \<lbrakk> p \<in> set (arm_global_pts (arch_state s)); p \<in> untyped_range cap \<rbrakk>  \<Longrightarrow> False"
   using valid_global_refsD [OF globals cap] by (simp add: cap_range_def global_refs_def)
@@ -540,7 +545,7 @@ sublocale detype_locale < detype_locale_gen_2
  proof goal_cases
   interpret detype_locale_arch ..
   case 1 show ?case
-  by (intro_locales; (unfold_locales; fact detype_invs_proofs)?)
+  by (intro_locales; unfold_locales; (fact detype_invs_proofs)?)
   qed
 
 context detype_locale begin

--- a/proof/invariant-abstract/ARM/ArchEmptyFail_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchEmptyFail_AI.thy
@@ -44,7 +44,7 @@ crunch handle_fault
 crunch
   decode_tcb_configure, decode_bind_notification, decode_unbind_notification,
   decode_set_priority, decode_set_mcpriority, decode_set_sched_params,
-  decode_set_tls_base
+  decode_set_tls_base, decode_set_flags
   for (empty_fail) empty_fail[wp]
   (simp: cap.splits arch_cap.splits split_def)
 
@@ -138,7 +138,7 @@ global_interpretation EmptyFail_AI_rec_del?: EmptyFail_AI_rec_del
 
 context Arch begin arch_global_naming
 crunch
-  cap_delete, choose_thread
+  cap_delete, choose_thread, arch_prepare_next_domain
   for (empty_fail) empty_fail[wp, EmptyFail_AI_assms]
 end
 

--- a/proof/invariant-abstract/ARM/ArchInvariants_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchInvariants_AI.thy
@@ -2310,6 +2310,7 @@ lemma valid_arch_arch_tcb_set_registers[simp]:
 lemma tcb_arch_ref_simps[simp]:
   "\<And>f. tcb_arch_ref (tcb_ipc_buffer_update f tcb) = tcb_arch_ref tcb"
   "\<And>f. tcb_arch_ref (tcb_mcpriority_update f tcb) = tcb_arch_ref tcb"
+  "\<And>f. tcb_arch_ref (tcb_flags_update f tcb) = tcb_arch_ref tcb"
   "\<And>f. tcb_arch_ref (tcb_ctable_update f tcb) = tcb_arch_ref tcb"
   "\<And>f. tcb_arch_ref (tcb_vtable_update f tcb) = tcb_arch_ref tcb"
   "\<And>f. tcb_arch_ref (tcb_reply_update f tcb) = tcb_arch_ref tcb"

--- a/proof/invariant-abstract/ARM/ArchInvariants_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchInvariants_AI.thy
@@ -747,6 +747,14 @@ definition
 where
   "hyp_live ko \<equiv> False"
 
+(* arch_tcb_live stub; there is no state in the arch specific part of TCBs on this platform that
+   marks a TCB as live *)
+definition arch_tcb_live :: "arch_tcb \<Rightarrow> bool" where
+  "arch_tcb_live arch_tcb \<equiv> False"
+
+definition valid_cur_fpu :: "'z::state_ext state \<Rightarrow> bool" where
+  "valid_cur_fpu \<equiv> \<top>"
+
 definition
   valid_arch_state :: "'z::state_ext state \<Rightarrow> bool"
 where
@@ -1325,6 +1333,9 @@ lemma valid_vspace_objs_update' [iff]:
   "valid_vspace_objs (f s) = valid_vspace_objs s"
   by (simp add: valid_vspace_objs_def)
 
+lemma valid_cur_fpu_update [iff]:
+  "valid_cur_fpu (f s) = valid_cur_fpu s"
+  by (auto simp: valid_cur_fpu_def)
 
 end
 
@@ -1361,6 +1372,10 @@ lemma valid_arch_state_lift:
   apply (rule hoare_lift_Pf[where f="\<lambda>s. arch_state s"])
    apply (wp arch typs hoare_vcg_conj_lift hoare_vcg_const_Ball_lift)+
   done
+
+lemma valid_cur_fpu_updates[simp]:
+  "\<And>f. valid_cur_fpu (arch_state_update f s) = valid_cur_fpu s"
+  by (auto simp: valid_cur_fpu_def)
 
 lemma aobj_at_default_arch_cap_valid:
   assumes "ty \<noteq> ASIDPoolObj"
@@ -2116,9 +2131,9 @@ lemma vs_lookup_2ConsD:
   apply (fastforce simp: vs_lookup1_def)
   done
 
-lemma global_refs_asid_table_update [iff]:
-  "global_refs (s\<lparr>arch_state := arm_asid_table_update f (arch_state s)\<rparr>) = global_refs s"
-  by (simp add: global_refs_def)
+lemma global_refs_updates[simp]:
+  "\<And>f. global_refs (s\<lparr>arch_state := arm_asid_table_update f (arch_state s)\<rparr>) = global_refs s"
+  by (auto simp: global_refs_def)
 
 lemma pspace_in_kernel_window_arch_update[simp]:
   "arm_kernel_vspace (f (arch_state s)) = arm_kernel_vspace (arch_state s)
@@ -2295,17 +2310,14 @@ lemma valid_tcb_arch_ref_lift:
   "tcb_arch_ref t = tcb_arch_ref t' \<Longrightarrow> valid_arch_tcb (tcb_arch t) = valid_arch_tcb (tcb_arch t')"
   by (simp add: valid_arch_tcb_def tcb_arch_ref_def)
 
-lemma valid_arch_tcb_context_update[simp]:
-  "valid_arch_tcb (tcb_context_update f t) = valid_arch_tcb t"
-  unfolding valid_arch_tcb_def obj_at_def by simp
+lemma valid_arch_tcb_simps[simp]:
+  "\<And>f. valid_arch_tcb (tcb_context_update f t) = valid_arch_tcb t"
+  by (simp add: valid_arch_tcb_def)+
 
-lemma valid_arch_arch_tcb_context_set[simp]:
-  "valid_arch_tcb (arch_tcb_context_set a t) = valid_arch_tcb t"
-  by (simp add: arch_tcb_context_set_def)
-
-lemma valid_arch_arch_tcb_set_registers[simp]:
-  "valid_arch_tcb (arch_tcb_set_registers a t) = valid_arch_tcb t"
-   by (simp add: arch_tcb_set_registers_def)
+lemma valid_arch_tcb_context_simps[simp]:
+  "\<And>a. valid_arch_tcb (arch_tcb_context_set a t) = valid_arch_tcb t"
+  "\<And>a. valid_arch_tcb (arch_tcb_set_registers a t) = valid_arch_tcb t"
+  by (simp add: arch_tcb_context_set_def arch_tcb_set_registers_def)+
 
 lemma tcb_arch_ref_simps[simp]:
   "\<And>f. tcb_arch_ref (tcb_ipc_buffer_update f tcb) = tcb_arch_ref tcb"
@@ -2346,6 +2358,15 @@ lemma hyp_live_tcb_simps[simp]:
   "\<And>f. hyp_live (TCB (tcb_priority_update f tcb)) = hyp_live (TCB tcb)"
   "\<And>f. hyp_live (TCB (tcb_time_slice_update f tcb)) = hyp_live (TCB tcb)"
   by (simp_all add: hyp_live_tcb_def)
+
+lemma arch_tcb_live_simps[simp]:
+  "\<And>f. arch_tcb_live (tcb_context_update f arch_tcb) = arch_tcb_live arch_tcb"
+  by (simp_all add: arch_tcb_live_def)
+
+lemma arch_tcb_live_context_simps[simp]:
+  "\<And>f. arch_tcb_live (arch_tcb_context_set f arch_tcb) = arch_tcb_live arch_tcb"
+  "\<And>f. arch_tcb_live (arch_tcb_set_registers f arch_tcb) = arch_tcb_live arch_tcb"
+  by (simp_all add: arch_tcb_context_set_def arch_tcb_set_registers_def)
 
 
 lemma valid_arch_tcb_pspaceI:

--- a/proof/invariant-abstract/ARM/ArchIpc_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchIpc_AI.thy
@@ -224,21 +224,17 @@ lemma copy_mrs_in_user_frame[wp, Ipc_AI_2_assms]:
   "\<lbrace>in_user_frame p\<rbrace> copy_mrs t buf t' buf' n \<lbrace>\<lambda>rv. in_user_frame p\<rbrace>"
   by (simp add: in_user_frame_def) (wp hoare_vcg_ex_lift)
 
-lemma as_user_getRestart_invs[wp]: "\<lbrace>P\<rbrace> as_user t getRestartPC \<lbrace>\<lambda>_. P\<rbrace>"
+lemma as_user_getRestart_inv[wp]:
+  "as_user t getRestartPC \<lbrace>P\<rbrace>"
   by (simp add: getRestartPC_def, rule user_getreg_inv)
 
-lemma make_arch_fault_msg_inv[wp]: "\<lbrace>P\<rbrace> make_arch_fault_msg f t \<lbrace>\<lambda>_. P\<rbrace>"
-  apply (cases f)
-  apply simp
-  apply wp
-  done
+lemma make_arch_fault_msg_inv[wp, Ipc_AI_2_assms]:
+  "make_arch_fault_msg ft t \<lbrace>P\<rbrace>"
+  by (cases ft; wpsimp)
 
-lemma make_fault_message_inv[wp, Ipc_AI_2_assms]:
-  "\<lbrace>P\<rbrace> make_fault_msg ft t \<lbrace>\<lambda>rv. P\<rbrace>"
-  apply (cases ft, simp_all split del: if_split)
-     apply (wp as_user_inv getRestartPC_inv mapM_wp'
-              | simp add: getRegister_def)+
-  done
+lemma make_fault_msg_inv[wp, Ipc_AI_2_assms]:
+  "make_fault_msg ft t \<lbrace>P\<rbrace>"
+  by (cases ft; wpsimp wp: as_user_inv getRestartPC_inv mapM_wp' split_del: if_split)
 
 lemma do_fault_transfer_invs[wp, Ipc_AI_2_assms]:
   "\<lbrace>invs and tcb_at receiver\<rbrace>
@@ -431,8 +427,6 @@ lemma transfer_caps_loop_valid_vspace_objs[wp, Ipc_AI_2_assms]:
         | assumption | simp split del: if_split)+
   done
 
-declare make_arch_fault_msg_inv[Ipc_AI_2_assms]
-
 lemma setup_caller_cap_aobj_at:
   "arch_obj_pred P' \<Longrightarrow>
   \<lbrace>\<lambda>s. P (obj_at P' pd s)\<rbrace> setup_caller_cap st rt grant \<lbrace>\<lambda>r s. P (obj_at P' pd s)\<rbrace>"
@@ -441,7 +435,7 @@ lemma setup_caller_cap_aobj_at:
 
 lemma setup_caller_cap_valid_arch[Ipc_AI_2_assms, wp]:
   "setup_caller_cap st rt grant \<lbrace>valid_arch_state\<rbrace>"
-  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps[rotated -1] setup_caller_cap_aobj_at)
+  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps[rotated -1] setup_caller_cap_tcb_at setup_caller_cap_aobj_at)
 
 lemma transfer_caps_loop_valid_arch[Ipc_AI_2_assms]:
   "\<And>slots caps ep buffer n mi.
@@ -450,7 +444,7 @@ lemma transfer_caps_loop_valid_arch[Ipc_AI_2_assms]:
          and transfer_caps_srcs caps\<rbrace>
       transfer_caps_loop ep buffer n caps slots mi
     \<lbrace>\<lambda>_. valid_arch_state\<rbrace>"
-  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps transfer_caps_loop_aobj_at)
+  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps transfer_caps_loop_typ_ats transfer_caps_loop_aobj_at)
 
 end
 
@@ -509,7 +503,7 @@ lemma do_ipc_transfer_valid_arch[Ipc_AI_3_assms]:
   "\<lbrace>valid_arch_state and valid_objs and valid_mdb \<rbrace>
    do_ipc_transfer s ep bg grt r
    \<lbrace>\<lambda>rv. valid_arch_state\<rbrace>"
-  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps do_ipc_transfer_aobj_at)
+  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps dit_tcb_at do_ipc_transfer_aobj_at)
 
 end
 

--- a/proof/invariant-abstract/ARM/ArchKHeap_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchKHeap_AI.thy
@@ -575,6 +575,18 @@ lemma valid_arch_state_lift_aobj_at:
 
 end
 
+\<comment> \<open>Intended for use inside Arch, as opposed to the interface lemma valid_cur_fpu_lift\<close>
+lemma valid_cur_fpu_lift_arch[wp]:
+  shows "f \<lbrace>valid_cur_fpu\<rbrace>"
+  by (wpsimp simp: valid_cur_fpu_def)
+
+\<comment> \<open>Interface lemma\<close>
+lemma valid_cur_fpu_lift:
+  assumes arch_tcb_at[wp]: "\<And>P P' p. f \<lbrace>\<lambda>s. P (arch_tcb_at P' p s)\<rbrace>"
+  assumes arch_state[wp]: "\<And>P. f \<lbrace>\<lambda>s. P (arch_state s)\<rbrace>"
+  shows "f \<lbrace>valid_cur_fpu\<rbrace>"
+  by (wpsimp wp: valid_cur_fpu_lift_arch)
+
 lemma equal_kernel_mappings_lift:
   assumes aobj_at:
     "\<And>P P' pd. vspace_obj_pred P' \<Longrightarrow> \<lbrace>\<lambda>s. P (obj_at P' pd s)\<rbrace> f \<lbrace>\<lambda>r s. P (obj_at P' pd s)\<rbrace>"
@@ -875,7 +887,7 @@ lemma default_arch_object_not_live[simp]: "\<not> live (ArchObj (default_arch_ob
                split: aobject_type.splits)
 
 lemma default_tcb_not_live[simp]: "\<not> live (TCB (default_tcb d))"
-  by (clarsimp simp: default_tcb_def default_arch_tcb_def live_def hyp_live_def)
+  by (clarsimp simp: default_tcb_def default_arch_tcb_def live_def hyp_live_def arch_tcb_live_def)
 
 lemma valid_arch_tcb_same_type:
   "\<lbrakk> valid_arch_tcb t s; valid_obj p k s; kheap s p = Some ko; a_type k = a_type ko \<rbrakk>

--- a/proof/invariant-abstract/ARM/ArchKernelInit_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchKernelInit_AI.thy
@@ -249,7 +249,6 @@ lemma cap_refs_respects_device_region_init[simp]:
 
 lemma invs_A:
   "invs init_A_st"
-
   apply (simp add: invs_def)
   apply (rule conjI)
    prefer 2
@@ -281,7 +280,8 @@ lemma invs_A:
    apply (rule conjI)
     apply (simp add:pspace_distinct_init_A)
    apply (rule conjI)
-    apply (clarsimp simp: if_live_then_nonz_cap_def obj_at_def state_defs live_def hyp_live_def)
+    apply (clarsimp simp: if_live_then_nonz_cap_def obj_at_def state_defs live_def hyp_live_def
+                          arch_tcb_live_def)
    apply (rule conjI)
     apply (clarsimp simp: zombies_final_def cte_wp_at_cases state_defs
                           tcb_cap_cases_def is_zombie_def)
@@ -327,6 +327,7 @@ lemma invs_A:
    apply (rule conjI)
     apply (simp add: valid_global_pts_def state_defs)
    apply (simp add: state_defs is_inv_def)
+  apply (rule conjI, clarsimp simp: valid_cur_fpu_def)
   apply (rule conjI)
    apply (clarsimp simp: valid_irq_node_def obj_at_def state_defs
                          is_cap_table_def wf_empty_bits

--- a/proof/invariant-abstract/ARM/ArchRetype_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchRetype_AI.thy
@@ -785,6 +785,10 @@ lemma valid_global_refs:
   apply (simp add: cte_retype cap_range_def)
   done
 
+lemma valid_cur_fpu':
+  "valid_cur_fpu s \<Longrightarrow> valid_cur_fpu s'"
+  by (clarsimp simp: valid_cur_fpu_def)
+
 lemma valid_arch_state:
   "valid_arch_state s \<Longrightarrow> valid_arch_state s'"
   by (clarsimp simp: valid_arch_state_def obj_at_pres
@@ -1195,7 +1199,7 @@ lemma post_retype_invs:
   by (clarsimp simp: invs_def post_retype_invs_def valid_state_def
                      unsafe_rep2 null_filter valid_idle
                      valid_reply_caps valid_reply_masters
-                     valid_global_refs valid_arch_state
+                     valid_global_refs valid_arch_state valid_cur_fpu'
                      valid_irq_node_def obj_at_pres
                      valid_arch_caps valid_global_objs
                      valid_vspace_objs' valid_irq_handlers

--- a/proof/invariant-abstract/ARM/ArchSchedule_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchSchedule_AI.thy
@@ -39,9 +39,9 @@ lemma clearExMonitor_invs [wp]:
   done
 
 lemma arch_stt_invs [wp,Schedule_AI_assms]:
-  "\<lbrace>invs\<rbrace> arch_switch_to_thread t' \<lbrace>\<lambda>_. invs\<rbrace>"
+  "\<lbrace>invs and ex_nonz_cap_to t\<rbrace> arch_switch_to_thread t \<lbrace>\<lambda>_. invs\<rbrace>"
   apply (simp add: arch_switch_to_thread_def)
-  apply wp
+  apply wpsimp
   done
 
 lemma arch_stt_tcb [wp,Schedule_AI_assms]:
@@ -102,7 +102,7 @@ lemma arch_stt_scheduler_action [wp, Schedule_AI_assms]:
 crunch arch_prepare_next_domain
   for ct[wp, Schedule_AI_assms]: "\<lambda>s. P (cur_thread s)"
   and activatable[wp, Schedule_AI_assms]: "ct_in_state activatable"
-  and pred_tcb_at[wp, Schedule_AI_assms]: "\<lambda>s. P (pred_tcb_at proj Q t s)"
+  and st_tcb_at[wp, Schedule_AI_assms]: "\<lambda>s. P (st_tcb_at Q t s)"
   and valid_idle[wp, Schedule_AI_assms]: valid_idle
   and invs[wp, Schedule_AI_assms]: invs
   (wp: crunch_wps ct_in_state_thread_state_lift)
@@ -117,7 +117,7 @@ interpretation Schedule_AI?: Schedule_AI
   proof goal_cases
   interpret Arch .
   case 1 show ?case
-  by (intro_locales; (unfold_locales; fact Schedule_AI_assms)?)
+  by (intro_locales; unfold_locales; (fact Schedule_AI_assms)?)
   qed
 
 end

--- a/proof/invariant-abstract/ARM/ArchSchedule_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchSchedule_AI.thy
@@ -99,6 +99,14 @@ lemma arch_stt_scheduler_action [wp, Schedule_AI_assms]:
   "\<lbrace>\<lambda>s. P (scheduler_action s)\<rbrace> arch_switch_to_thread t' \<lbrace>\<lambda>_ s. P (scheduler_action s)\<rbrace>"
   by (wpsimp simp: arch_switch_to_thread_def)
 
+crunch arch_prepare_next_domain
+  for ct[wp, Schedule_AI_assms]: "\<lambda>s. P (cur_thread s)"
+  and activatable[wp, Schedule_AI_assms]: "ct_in_state activatable"
+  and pred_tcb_at[wp, Schedule_AI_assms]: "\<lambda>s. P (pred_tcb_at proj Q t s)"
+  and valid_idle[wp, Schedule_AI_assms]: valid_idle
+  and invs[wp, Schedule_AI_assms]: invs
+  (wp: crunch_wps ct_in_state_thread_state_lift)
+
 lemma arch_stit_scheduler_action [wp, Schedule_AI_assms]:
   "\<lbrace>\<lambda>s. P (scheduler_action s)\<rbrace> arch_switch_to_idle_thread \<lbrace>\<lambda>_ s. P (scheduler_action s)\<rbrace>"
   by (wpsimp simp: arch_switch_to_idle_thread_def)

--- a/proof/invariant-abstract/ARM/ArchSyscall_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchSyscall_AI.thy
@@ -18,6 +18,9 @@ context Arch begin arch_global_naming
 named_theorems Syscall_AI_assms
 
 declare arch_get_sanitise_register_info_invs[Syscall_AI_assms]
+        arch_get_sanitise_register_info_ex_nonz_cap_to[Syscall_AI_assms]
+        make_fault_msg_inv[Syscall_AI_assms]
+
 crunch handle_arch_fault_reply, arch_get_sanitise_register_info
   for pred_tcb_at[wp,Syscall_AI_assms]: "pred_tcb_at proj P t"
 crunch handle_arch_fault_reply
@@ -34,9 +37,6 @@ crunch handle_arch_fault_reply, arch_get_sanitise_register_info
   for valid_objs[wp,Syscall_AI_assms]: "valid_objs"
 crunch handle_arch_fault_reply, arch_get_sanitise_register_info
   for cte_wp_at[wp,Syscall_AI_assms]: "\<lambda>s. P (cte_wp_at P' p s)"
-declare arch_get_sanitise_register_info_ex_nonz_cap_to[Syscall_AI_assms]
-        make_fault_message_inv[Syscall_AI_assms]
-
 
 crunch invoke_irq_control
   for typ_at[wp, Syscall_AI_assms]: "\<lambda>s. P (typ_at T p s)"

--- a/proof/invariant-abstract/ARM/ArchTcbAcc_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchTcbAcc_AI.thy
@@ -162,7 +162,7 @@ lemma tcb_context_update_aux: "arch_tcb_context_set (P (arch_tcb_context_get atc
 lemma thread_set_valid_arch_state[TcbAcc_AI_assms]:
   "(\<And>tcb. \<forall>(getF, v) \<in> ran tcb_cap_cases. getF (f tcb) = getF tcb)
    \<Longrightarrow> thread_set f t \<lbrace> valid_arch_state \<rbrace>"
-  by (wp valid_arch_state_lift_aobj_at_no_caps thread_set.aobj_at)
+  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps thread_set_tcb thread_set.aobj_at)
 
 end
 

--- a/proof/invariant-abstract/ARM/ArchTcb_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchTcb_AI.thy
@@ -370,7 +370,6 @@ lemma update_cap_valid[Tcb_AI_assms]:
                                      split: option.splits prod.splits bool.splits)
   done
 
-
 crunch switch_to_thread
   for pred_tcb_at: "pred_tcb_at proj P t"
   (wp: crunch_wps simp: crunch_simps)

--- a/proof/invariant-abstract/ARM/ArchTcb_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchTcb_AI.thy
@@ -162,6 +162,10 @@ lemma table_cap_ref_max_free_index_upd[simp,Tcb_AI_assms]:
   "table_cap_ref (max_free_index_update cap) = table_cap_ref cap"
   by (simp add: free_index_update_def table_cap_ref_def split: cap.splits)
 
+crunch arch_post_set_flags, arch_prepare_set_domain
+  for typ_at[wp, Tcb_AI_assms]: "\<lambda>s. P (typ_at T p s)"
+  and invs[wp, Tcb_AI_assms]: "invs"
+
 
 interpretation Tcb_AI_1? : Tcb_AI_1
   where state_ext_t = state_ext_t

--- a/proof/invariant-abstract/ARM/ArchUntyped_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchUntyped_AI.thy
@@ -561,7 +561,7 @@ lemma create_cap_valid_arch_state[wp, Untyped_AI_assms]:
   "\<lbrace>valid_arch_state and cte_wp_at (\<lambda>_. True) cref\<rbrace>
    create_cap tp sz p dev (cref,oref)
    \<lbrace>\<lambda>rv. valid_arch_state\<rbrace>"
-  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps create_cap_aobj_at)
+  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps create_cap_tcb create_cap_aobj_at)
 
 lemma set_cap_non_arch_valid_arch_state[Untyped_AI_assms]:
  "\<lbrace>\<lambda>s. valid_arch_state s \<and> cte_wp_at (\<lambda>_. \<not>is_arch_cap cap) ptr s\<rbrace>

--- a/proof/invariant-abstract/ARM/ArchVSpaceEntries_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchVSpaceEntries_AI.thy
@@ -1521,8 +1521,9 @@ lemma handle_invocation_valid_pdpt[wp]:
      (auto simp: ct_in_state_def elim: st_tcb_ex_cap)
 
 
-crunch handle_event, activate_thread, switch_to_thread,
-       switch_to_idle_thread, schedule_choose_new_thread
+crunch
+  handle_event, activate_thread, switch_to_thread, switch_to_idle_thread,
+  schedule_choose_new_thread, arch_prepare_next_domain
   for valid_pdpt[wp]: "valid_pdpt_objs"
   (simp: crunch_simps wp: crunch_wps OR_choice_weak_wp select_ext_weak_wp
       ignore: without_preemption getActiveIRQ resetTimer ackInterrupt

--- a/proof/invariant-abstract/ARM/ArchVSpace_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchVSpace_AI.thy
@@ -1713,7 +1713,7 @@ lemma svr_invs [wp]:
   done
 
 crunch set_vm_root
-  for pred_tcb_at[wp]: "pred_tcb_at proj P t"
+  for pred_tcb_at[wp]: "\<lambda>s. Q (pred_tcb_at proj P t s)"
   (simp: crunch_simps)
 
 lemmas set_vm_root_typ_ats [wp] = abs_typ_at_lifts [OF set_vm_root_typ_at]

--- a/proof/invariant-abstract/ARM_HYP/ArchDetSchedAux_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchDetSchedAux_AI.thy
@@ -156,9 +156,6 @@ crunch init_arch_objects
 
 end
 
-lemmas tcb_sched_action_valid_idle_etcb
-    = ARM_HYP.tcb_sched_action_valid_idle_etcb
-
 global_interpretation DetSchedAux_AI_det_ext?: DetSchedAux_AI_det_ext
   proof goal_cases
   interpret Arch .

--- a/proof/invariant-abstract/BCorres2_AI.thy
+++ b/proof/invariant-abstract/BCorres2_AI.thy
@@ -445,10 +445,12 @@ lemma get_before_assert_opt:
   apply (simp add: ext exec_get)
   done
 
-lemma s_bcorres_get_left:
+lemma s_bcorres_get_pre:
   "(s_bcorres_underlying t (get >>= f) g s)
     = (s_bcorres_underlying t (f s) g s)"
-  by (simp add: s_bcorres_underlying_def exec_get)
+  "(s_bcorres_underlying t f' (get >>= g') s)
+    = (s_bcorres_underlying t f' (g' (t s)) s)"
+  by (simp add: s_bcorres_underlying_def exec_get)+
 
 lemma get_outside_alternative:
   "alternative (get >>= f) g

--- a/proof/invariant-abstract/CNodeInv_AI.thy
+++ b/proof/invariant-abstract/CNodeInv_AI.thy
@@ -710,24 +710,6 @@ lemma cap_swap_fd_not_recursive:
    by (wpsimp wp: cap_swap_not_recursive get_cap_wp)
 
 
-lemma set_mrs_typ_at [wp]:
-  "\<lbrace>\<lambda>s. P (typ_at T p s)\<rbrace> set_mrs p' b m \<lbrace>\<lambda>rv s. P (typ_at T p s)\<rbrace>"
-  apply (simp add: set_mrs_def bind_assoc set_object_def get_object_def)
-  apply (cases b)
-   apply simp
-   apply wp
-   apply clarsimp
-   apply (drule get_tcb_SomeD)
-   apply (clarsimp simp: obj_at_def)
-  apply (clarsimp simp: zipWithM_x_mapM split_def
-             split del: if_split)
-  apply (wp mapM_wp')
-  apply clarsimp
-  apply (drule get_tcb_SomeD)
-  apply (clarsimp simp: obj_at_def)
-  done
-
-
 lemma cte_wp_and:
   "cte_wp_at (P and Q) c s = (cte_wp_at P c s \<and> cte_wp_at Q c s)"
   by (auto simp: cte_wp_at_def)
@@ -1918,6 +1900,9 @@ lemma cap_swap_aobj_at:
   "arch_obj_pred P' \<Longrightarrow>
   \<lbrace>\<lambda>s. P (obj_at P' pd s)\<rbrace> cap_swap c a c' b \<lbrace>\<lambda>r s. P (obj_at P' pd s)\<rbrace>"
   unfolding cap_swap_def set_cdt_def by (wpsimp wp: set_cap.aobj_at)
+
+crunch cap_swap
+  for valid_cur_fpu[wp]: valid_cur_fpu
 
 context CNodeInv_AI begin
 lemma cap_swap_cap_refs_respects_device_region[wp]:

--- a/proof/invariant-abstract/CSpaceInv_AI.thy
+++ b/proof/invariant-abstract/CSpaceInv_AI.thy
@@ -517,8 +517,8 @@ lemma set_cap_a_type_inv:
   done
 
 
-lemma set_cap_tcb:
-  "\<lbrace>tcb_at p'\<rbrace> set_cap cap  p \<lbrace>\<lambda>rv. tcb_at p'\<rbrace>"
+lemma set_cap_tcb[wp]:
+  "set_cap cap  p \<lbrace>\<lambda>s. P (tcb_at p' s)\<rbrace>"
   by (clarsimp simp: tcb_at_typ intro!: set_cap_typ_at)
 
 
@@ -604,7 +604,7 @@ lemma set_cap_cur [wp]:
   done
 
 lemma set_cap_pred_tcb [wp]:
- "\<lbrace>pred_tcb_at proj P t\<rbrace> set_cap c p \<lbrace>\<lambda>rv. pred_tcb_at proj P t\<rbrace>"
+ "set_cap c p \<lbrace>\<lambda>s. P' (pred_tcb_at proj P t s)\<rbrace>"
   apply (simp add: set_cap_def set_object_def split_def)
   apply (wp get_object_wp | wpc)+
   apply (auto simp: pred_tcb_at_def obj_at_def tcb_to_itcb_def)
@@ -1628,6 +1628,10 @@ lemma set_cap_valid_ioc[wp]:
   apply fastforce
   done
 
+crunch set_cap
+  for valid_cur_fpu[wp]: valid_cur_fpu
+  (wp: valid_cur_fpu_lift)
+
 lemma descendants_inc_minor:
   "\<lbrakk>descendants_inc m cs; mdb_cte_at (\<lambda>p. \<exists>c. cs p = Some c \<and> cap.NullCap \<noteq> c) m;
    \<forall>x\<in> dom cs. cap_class (the (cs' x)) = cap_class (the (cs x)) \<and> cap_range (the (cs' x)) = cap_range (the (cs x))\<rbrakk>
@@ -2005,7 +2009,7 @@ lemma set_untyped_cap_as_full_tcb_cap_valid:
     apply (case_tac "tcb_at (fst dest) s")
       apply clarsimp
       apply (intro conjI impI allI)
-      apply (drule use_valid[OF _ set_cap_pred_tcb],simp+)
+      apply (drule use_valid[OF _ set_cap_pred_tcb[where P'=id, simplified]],simp+)
         apply (clarsimp simp: valid_ipc_buffer_cap_def is_cap_simps)
         apply (fastforce simp: tcb_at_def obj_at_def is_tcb)
     apply (clarsimp simp: tcb_at_typ)
@@ -2027,7 +2031,7 @@ lemma cap_insert_objs [wp]:
   done
 
 crunch cap_insert, set_cdt
-  for pred_tcb_at[wp]: "pred_tcb_at proj P t"
+  for pred_tcb_at[wp]: "\<lambda>s. P' (pred_tcb_at proj P t s)"
   (wp: hoare_drop_imps)
 
 
@@ -2057,6 +2061,10 @@ lemma cap_insert_obj_at_other:
   apply (rule hoare_pre)
    apply (wp set_cap_obj_at_other get_cap_wp|simp split del: if_split)+
   done
+
+crunch cap_insert
+  for valid_cur_fpu[wp]: valid_cur_fpu
+  (wp: crunch_wps)
 
 lemma only_idle_tcb_update:
   "\<lbrakk>only_idle s; ko_at (TCB t) p s; tcb_state t = tcb_state t' \<or> \<not>idle (tcb_state t') \<rbrakk>

--- a/proof/invariant-abstract/CSpace_AI.thy
+++ b/proof/invariant-abstract/CSpace_AI.thy
@@ -3885,7 +3885,7 @@ lemma cap_insert_invs[wp]:
     \<lbrace>\<lambda>rv. invs :: 'state_ext state \<Rightarrow> bool\<rbrace>"
   apply (simp add: invs_def valid_state_def)
   apply (rule hoare_pre)
-   apply (wp cap_insert_valid_pspace cap_insert_ifunsafe cap_insert_idle
+   apply (wp cap_insert_valid_pspace cap_insert_ifunsafe cap_insert_idle valid_cur_fpu_lift
              valid_irq_node_typ cap_insert_valid_arch_caps cap_insert_derived_valid_arch_state)
   apply (auto simp: cte_wp_at_caps_of_state is_derived_cap_is_device
                         is_derived_cap_range valid_pspace_def)
@@ -3945,6 +3945,7 @@ lemma cap_swap_typ_at:
          |simp split del: if_split)+
   done
 
+lemmas cap_swap_typ_ats[wp] = abs_typ_at_lifts[OF cap_swap_typ_at]
 
 lemma cap_swap_valid_cap:
   "\<lbrace>valid_cap c\<rbrace> cap_swap cap x cap' y \<lbrace>\<lambda>_. valid_cap c\<rbrace>"
@@ -4275,7 +4276,7 @@ lemma no_reply_caps_for_thread:
 crunch setup_reply_master
   for tcb[wp]: "tcb_at t"
   and idle[wp]: "valid_idle"
-  (wp: set_cap_tcb simp: crunch_simps)
+  (simp: crunch_simps)
 
 lemma setup_reply_master_pspace[wp]:
   "\<lbrace>valid_pspace and tcb_at t\<rbrace> setup_reply_master t \<lbrace>\<lambda>rv. valid_pspace\<rbrace>"
@@ -4441,6 +4442,7 @@ lemma setup_reply_master_vms[wp]:
 
 crunch setup_reply_master
   for valid_irq_states[wp]: "valid_irq_states"
+  and pred_tcb_at[wp]: "\<lambda>s. P (pred_tcb_at proj P' p s)"
   (wp: crunch_wps simp: crunch_simps)
 
 
@@ -4452,7 +4454,7 @@ lemma setup_reply_master_invs[wp]:
       setup_reply_master t
     \<lbrace>\<lambda>rv. invs :: 'state_ext state \<Rightarrow> bool\<rbrace>"
   apply (simp add: invs_def valid_state_def)
-  apply (wp valid_irq_node_typ
+  apply (wp valid_irq_node_typ valid_cur_fpu_lift
                  | simp add: valid_pspace_def)+
   done
 

--- a/proof/invariant-abstract/DetSchedDomainTime_AI.thy
+++ b/proof/invariant-abstract/DetSchedDomainTime_AI.thy
@@ -91,6 +91,16 @@ locale DetSchedDomainTime_AI =
     "\<And>P i. arch_invoke_irq_handler i \<lbrace>\<lambda>s::det_state. P (domain_list s)\<rbrace>"
   assumes arch_invoke_irq_handler_domain_time_inv'[wp]:
     "\<And>P i. arch_invoke_irq_handler i \<lbrace>\<lambda>s::det_state. P (domain_time s)\<rbrace>"
+  assumes arch_prepare_next_domain_domain_list_inv'[wp]:
+    "\<And>P. arch_prepare_next_domain \<lbrace>\<lambda>s::det_state. P (domain_list s)\<rbrace>"
+  assumes arch_prepare_set_domain_domain_list_inv'[wp]:
+    "\<And>P t d. arch_prepare_set_domain t d \<lbrace>\<lambda>s::det_state. P (domain_list s)\<rbrace>"
+  assumes arch_post_set_flags_domain_list_inv'[wp]:
+    "\<And>P t fs. arch_post_set_flags t fs \<lbrace>\<lambda>s::det_state. P (domain_list s)\<rbrace>"
+  assumes arch_prepare_set_domain_domain_time_inv'[wp]:
+    "\<And>P t d. arch_prepare_set_domain t d \<lbrace>\<lambda>s::det_state. P (domain_time s)\<rbrace>"
+  assumes arch_post_set_flags_domain_time_inv'[wp]:
+    "\<And>P t fs. arch_post_set_flags t fs \<lbrace>\<lambda>s::det_state. P (domain_time s)\<rbrace>"
 
 crunch update_restart_pc
   for domain_list[wp]: "\<lambda>s. P (domain_list s)"

--- a/proof/invariant-abstract/DetSchedInvs_AI.thy
+++ b/proof/invariant-abstract/DetSchedInvs_AI.thy
@@ -274,6 +274,10 @@ lemma valid_sched_valid_queues[elim!]:
   "valid_sched s \<Longrightarrow> valid_queues s"
   by (clarsimp simp: valid_sched_def)
 
+lemma valid_sched_valid_blocked[elim!]:
+  "valid_sched s \<Longrightarrow> valid_blocked s"
+  by (clarsimp simp: valid_sched_def)
+
 lemma typ_at_st_tcb_at_lift:
   assumes typ_lift: "\<And>P T p. \<lbrace>\<lambda>s. P (typ_at T p s)\<rbrace> f \<lbrace>\<lambda>r s. P (typ_at T p s)\<rbrace>"
   assumes st_lift: "\<And>P. \<lbrace>st_tcb_at P t\<rbrace> f \<lbrace>\<lambda>_. st_tcb_at P t\<rbrace>"

--- a/proof/invariant-abstract/DetSchedSchedule_AI.thy
+++ b/proof/invariant-abstract/DetSchedSchedule_AI.thy
@@ -1586,6 +1586,25 @@ lemma thread_set_not_state_valid_sched:
    \<lbrace>valid_sched\<rbrace> thread_set f tptr \<lbrace>\<lambda>rv. valid_sched\<rbrace>"
   by (rule valid_sched_lift; (wpsimp wp: thread_set_no_change_tcb_state thread_set_etcbs)?)
 
+crunch arch_thread_set
+  for etcbs_of[wp]: "\<lambda>s. P (etcbs_of s)"
+  and valid_queues[wp]: valid_queues
+  and weak_valid_sched_action[wp]: weak_valid_sched_action
+  and valid_sched_action[wp]: valid_sched_action
+  and valid_sched[wp]: valid_sched
+  and valid_blocked[wp]: valid_blocked
+  (wp: set_object_wp valid_queues_lift weak_valid_sched_action_lift valid_sched_action_lift
+       valid_sched_lift valid_blocked_lift)
+
+lemma arch_thread_set_is_activatable[wp]:
+  "arch_thread_set f tptr \<lbrace>is_activatable t\<rbrace>"
+  by (wpsimp simp: is_activatable_def | wps)+
+
+lemma arch_thread_set_ct_in_q[wp]:
+  "arch_thread_set f tptr \<lbrace>ct_in_q\<rbrace>"
+  unfolding ct_in_q_def
+  by (wpsimp wp: hoare_vcg_imp_lift' | wps)+
+
 lemma unbind_notification_valid_sched[wp]:
   "\<lbrace>valid_sched\<rbrace> unbind_notification ntfnptr \<lbrace>\<lambda>rv. valid_sched\<rbrace>"
   apply (simp add: unbind_notification_def)

--- a/proof/invariant-abstract/DetSchedSchedule_AI.thy
+++ b/proof/invariant-abstract/DetSchedSchedule_AI.thy
@@ -938,12 +938,12 @@ lemma tcb_sched_action_dequeue_valid_sched_action_2_ct_upd:
   apply (clarsimp simp: etcb_at_def valid_sched_action_def split: option.split)
   done
 
-context DetSchedSchedule_AI begin
-
 lemma etcbs_of_arch_state[simp]:
   "get_tcb ref s = Some tcb \<Longrightarrow>
   etcbs_of' (\<lambda>r. if r = ref then Some (TCB (tcb_arch_update f tcb)) else kheap s r) = etcbs_of' (kheap s)"
   by (auto simp: etcbs_of_update_unrelated dest!: get_tcb_SomeD)
+
+context DetSchedSchedule_AI begin
 
 lemma as_user_valid_sched[wp]:
   "\<lbrace>valid_sched\<rbrace> as_user tptr f \<lbrace>\<lambda>rv. valid_sched\<rbrace>"
@@ -999,11 +999,11 @@ lemma tcb_sched_action_dequeue_ct_in_cur_domain':
   apply (simp add: etcb_at_def split: option.split)
   done
 
-context DetSchedSchedule_AI begin
-
 crunch as_user
   for ct_in_cur_domain_2[wp]: "\<lambda>s. ct_in_cur_domain_2 thread (idle_thread s) (scheduler_action s) (cur_domain s) (etcbs_of s)"
   (wp: set_object_wp)
+
+context DetSchedSchedule_AI begin
 
 lemma switch_to_thread_ct_in_cur_domain[wp]:
   "\<lbrace>\<lambda>s. ct_in_cur_domain_2 thread (idle_thread s) (scheduler_action s) (cur_domain s) (etcbs_of s)\<rbrace>
@@ -2127,11 +2127,6 @@ lemma restart_valid_sched[wp]:
   done
 
 end
-
-lemma etcbs_of_arch_state[simp]:
-  "get_tcb ref s = Some tcb \<Longrightarrow>
-  etcbs_of' (\<lambda>r. if r = ref then Some (TCB (tcb_arch_update f tcb)) else kheap s r) = etcbs_of' (kheap s)"
-  by (auto simp: etcbs_of_update_unrelated dest!: get_tcb_SomeD)
 
 lemma as_user_valid_sched[wp]:
   "\<lbrace>valid_sched\<rbrace> as_user tptr f \<lbrace>\<lambda>rv. valid_sched\<rbrace>"

--- a/proof/invariant-abstract/Deterministic_AI.thy
+++ b/proof/invariant-abstract/Deterministic_AI.thy
@@ -3865,6 +3865,8 @@ locale Deterministic_AI_1 =
     "\<And>t. \<lbrace>valid_list\<rbrace> arch_get_sanitise_register_info t \<lbrace>\<lambda>_. valid_list\<rbrace>"
   assumes arch_post_modify_registers_valid_list[wp]:
     "\<And>t ptr. \<lbrace>valid_list\<rbrace> arch_post_modify_registers t ptr \<lbrace>\<lambda>_. valid_list\<rbrace>"
+  assumes arch_post_set_flags_valid_list[wp]:
+    "\<And>t fs. arch_post_set_flags t fs \<lbrace>valid_list\<rbrace>"
 
 
 context Deterministic_AI_1 begin

--- a/proof/invariant-abstract/Detype_AI.thy
+++ b/proof/invariant-abstract/Detype_AI.thy
@@ -393,6 +393,9 @@ lemma valid_arch_caps: "valid_arch_caps s"
 lemma valid_arch_state: "valid_arch_state s" using invs
   by clarsimp
   (* moreover *)
+lemma valid_cur_fpu: "valid_cur_fpu s" using invs
+  by clarsimp
+  (* moreover *)
 lemma ut_mdb: "untyped_mdb (cdt s) (caps_of_state s)"
   using invs
   by (clarsimp dest!: invs_mdb simp add: valid_mdb_def)
@@ -461,6 +464,7 @@ locale detype_locale_gen_2 = detype_locale_gen_1 cap ptr s
   assumes detype_invs_assms:
     "valid_idle (detype (untyped_range cap) s)"
     "valid_arch_state (detype (untyped_range cap) s)"
+    "valid_cur_fpu (detype (untyped_range cap) s)"
     "valid_vspace_objs (detype (untyped_range cap) s)"
     "valid_arch_caps (detype (untyped_range cap) s)"
     "valid_kernel_mappings (detype (untyped_range cap) s)"

--- a/proof/invariant-abstract/EmptyFail_AI.thy
+++ b/proof/invariant-abstract/EmptyFail_AI.thy
@@ -331,6 +331,8 @@ locale EmptyFail_AI_schedule = EmptyFail_AI_cap_revoke state_ext_t
     "empty_fail (get_thread_state ref :: (thread_state, 'state_ext) s_monad)"
   assumes arch_switch_to_thread_empty_fail[wp]:
     "empty_fail (arch_switch_to_thread t :: (unit, 'state_ext) s_monad)"
+  assumes arch_prepare_next_domain_empty_fail[wp]:
+    "empty_fail (arch_prepare_next_domain :: (unit, 'state_ext) s_monad)"
 
 crunch set_scheduler_action, next_domain, reschedule_required
   for (empty_fail) empty_fail[wp]

--- a/proof/invariant-abstract/Finalise_AI.thy
+++ b/proof/invariant-abstract/Finalise_AI.thy
@@ -315,11 +315,6 @@ lemma (in mdb_empty_abs) no_mloop_n:
   by (simp add: no_mloop_def parency)
 
 
-lemma final_mdb_update[simp]:
-  "is_final_cap' cap (cdt_update f s) = is_final_cap' cap s"
-  by (clarsimp simp: is_final_cap'_def2)
-
-
 lemma no_cap_to_obj_with_diff_cdt_update[simp]:
   "no_cap_to_obj_with_diff_ref cap S (cdt_update f s)
         = no_cap_to_obj_with_diff_ref cap S s"

--- a/proof/invariant-abstract/InterruptAcc_AI.thy
+++ b/proof/invariant-abstract/InterruptAcc_AI.thy
@@ -41,6 +41,7 @@ definition all_invs_but_valid_irq_states_for where
   valid_reply_masters and
   valid_global_refs and
   valid_arch_state and
+  valid_cur_fpu and
   valid_irq_node and
   valid_irq_handlers and
   valid_irq_states_but irq and

--- a/proof/invariant-abstract/Invariants_AI.thy
+++ b/proof/invariant-abstract/Invariants_AI.thy
@@ -1825,7 +1825,7 @@ lemma valid_mdb_eqI:
   done
 
 lemma set_object_at_obj:
-  "\<lbrace> \<lambda>s. obj_at P p s \<and> (p = r \<longrightarrow> P obj) \<rbrace> set_object r obj \<lbrace> \<lambda>rv. obj_at P p \<rbrace>"
+  "\<lbrace> \<lambda>s. Q (obj_at P p s) \<and> (p = r \<longrightarrow> Q (P obj)) \<rbrace> set_object r obj \<lbrace> \<lambda>_ s. Q (obj_at P p s) \<rbrace>"
   by (clarsimp simp: valid_def in_monad obj_at_def set_object_def get_object_def)
 
 lemma set_object_at_obj1:
@@ -3209,6 +3209,13 @@ lemma ex_nonz_cap_to_simps[simp]:
   "\<And>f. ex_nonz_cap_to p (scheduler_action_update f s) = ex_nonz_cap_to p s"
   "\<And>f. ex_nonz_cap_to w (trans_state f s) = ex_nonz_cap_to w s"
   by (simp_all add: ex_nonz_cap_to_def)
+
+lemma is_final_cap_simps[simp]:
+  "\<And>f. is_final_cap' cap (cdt_update f s) = is_final_cap' cap s"
+  "\<And>f. is_final_cap' cap (machine_state_update f s) = is_final_cap' cap s"
+  "\<And>f. is_final_cap' cap (arch_state_update f s) = is_final_cap' cap s"
+  "\<And>f. is_final_cap' cap (trans_state f s) = is_final_cap' cap s"
+  by (clarsimp simp: is_final_cap'_def2)+
 
 lemma only_idle_lift_weak:
   assumes "\<And>Q P t. \<lbrace>\<lambda>s. Q (st_tcb_at P t s)\<rbrace> f \<lbrace>\<lambda>_ s. Q (st_tcb_at P t s)\<rbrace>"

--- a/proof/invariant-abstract/IpcCancel_AI.thy
+++ b/proof/invariant-abstract/IpcCancel_AI.thy
@@ -809,6 +809,7 @@ where
 crunch tcb_sched_action, possible_switch_to
   for valid_reply_caps[wp]: valid_reply_caps
   and valid_reply_masters[wp]: valid_reply_masters
+  and valid_cur_fpu[wp]: valid_cur_fpu
 
 lemma cancel_all_invs_helper:
   "\<lbrace>all_invs_but_sym_refs
@@ -979,6 +980,10 @@ lemma bound_tcb_bound_notification_at:
                     state_refs_of_def refs_of_rev
           simp del: refs_of_simps)
   done
+
+crunch set_bound_notification
+  for valid_cur_fpu[wp]: valid_cur_fpu
+  (wp: valid_cur_fpu_lift)
 
 lemma unbind_notification_invs:
   shows "\<lbrace>invs\<rbrace> unbind_notification t \<lbrace>\<lambda>rv. invs\<rbrace>"

--- a/proof/invariant-abstract/RISCV64/ArchDetSchedAux_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchDetSchedAux_AI.thy
@@ -156,9 +156,6 @@ crunch init_arch_objects
 
 end
 
-lemmas tcb_sched_action_valid_idle_etcb
-    = RISCV64.tcb_sched_action_valid_idle_etcb
-
 global_interpretation DetSchedAux_AI_det_ext?: DetSchedAux_AI_det_ext
   proof goal_cases
   interpret Arch .

--- a/proof/invariant-abstract/Retype_AI.thy
+++ b/proof/invariant-abstract/Retype_AI.thy
@@ -2170,11 +2170,6 @@ lemma ioc_more_swap[simp]: "
   done
 
 
-lemma is_final_cap'_more_update[simp]:
-  "is_final_cap' cap (trans_state f s) = is_final_cap' cap s"
-  by (simp add: is_final_cap'_def)
-
-
 lemma no_cap_to_obj_with_diff_ref_more_update[simp]:
   "no_cap_to_obj_with_diff_ref cap sl (trans_state f s) =
    no_cap_to_obj_with_diff_ref cap sl s"
@@ -2183,11 +2178,6 @@ lemma no_cap_to_obj_with_diff_ref_more_update[simp]:
 end
 
 (* FIXME: irq_state stuff moved from CNodeInv_AI, not clear it makes sense here. *)
-
-lemma cte_wp_at_irq_state_independent[intro!, simp]:
-  "is_final_cap' x (s\<lparr>machine_state := machine_state s\<lparr>irq_state := f (irq_state (machine_state s))\<rparr>\<rparr>)
-   = is_final_cap' x s"
-  by (simp add: is_final_cap'_def)
 
 
 lemma zombies_final_irq_state_independent[intro!, simp]:

--- a/proof/invariant-abstract/Retype_AI.thy
+++ b/proof/invariant-abstract/Retype_AI.thy
@@ -885,7 +885,7 @@ abbreviation(input)
        and valid_pspace and valid_mdb and valid_idle and only_idle
        and if_unsafe_then_cap and valid_reply_caps
        and valid_reply_masters and valid_global_refs and valid_arch_state
-       and valid_irq_node and valid_irq_handlers and valid_vspace_objs
+       and valid_cur_fpu and valid_irq_node and valid_irq_handlers and valid_vspace_objs
        and valid_irq_states and valid_global_objs
        and valid_arch_caps and valid_kernel_mappings
        and valid_asid_map and valid_global_vspace_mappings

--- a/proof/invariant-abstract/Schedule_AI.thy
+++ b/proof/invariant-abstract/Schedule_AI.thy
@@ -21,7 +21,7 @@ locale Schedule_AI =
     assumes dmo_mapM_storeWord_0_invs[wp]:
       "\<And>S. valid invs (do_machine_op (mapM (\<lambda>p. storeWord p 0) S)) (\<lambda>_. (invs :: 'a state \<Rightarrow> bool))"
     assumes arch_stt_invs [wp]:
-      "\<And>t'. \<lbrace>invs\<rbrace> arch_switch_to_thread t' \<lbrace>\<lambda>_. (invs :: 'a state \<Rightarrow> bool)\<rbrace>"
+      "\<And>t'. \<lbrace>invs and ex_nonz_cap_to t'\<rbrace> arch_switch_to_thread t' \<lbrace>\<lambda>_. (invs :: 'a state \<Rightarrow> bool)\<rbrace>"
     assumes arch_stt_tcb [wp]:
       "\<And>t'. \<lbrace>tcb_at t'\<rbrace> arch_switch_to_thread t' \<lbrace>\<lambda>_. (tcb_at t' :: 'a state \<Rightarrow> bool)\<rbrace>"
     assumes arch_stt_st_tcb_at:
@@ -38,8 +38,6 @@ locale Schedule_AI =
       "\<And>P. arch_prepare_next_domain \<lbrace>\<lambda>s :: 'a state. P (cur_thread s)\<rbrace>"
     assumes arch_prepare_next_domain_activatable[wp]:
       "arch_prepare_next_domain \<lbrace>ct_in_state activatable :: 'a state \<Rightarrow> bool\<rbrace>"
-    assumes arch_prepare_next_domain_pred_tcb_at[wp]:
-      "\<And>(proj :: itcb \<Rightarrow> 't) P Q t. arch_prepare_next_domain \<lbrace>\<lambda>s :: 'a state. P (pred_tcb_at proj Q t s)\<rbrace>"
     assumes arch_prepare_next_domain_st_tcb_at[wp]:
       "\<And>P Q t. arch_prepare_next_domain \<lbrace>\<lambda>s :: 'a state. P (st_tcb_at Q t s)\<rbrace>"
     assumes arch_prepare_next_domain_valid_idle[wp]:

--- a/proof/invariant-abstract/Schedule_AI.thy
+++ b/proof/invariant-abstract/Schedule_AI.thy
@@ -17,6 +17,7 @@ abbreviation
 
 locale Schedule_AI =
     fixes state_ext :: "('a::state_ext) itself"
+    fixes some_t :: "'t itself"
     assumes dmo_mapM_storeWord_0_invs[wp]:
       "\<And>S. valid invs (do_machine_op (mapM (\<lambda>p. storeWord p 0) S)) (\<lambda>_. (invs :: 'a state \<Rightarrow> bool))"
     assumes arch_stt_invs [wp]:
@@ -32,7 +33,19 @@ locale Schedule_AI =
     assumes arch_stit_scheduler_action[wp]:
       "\<And>t'. arch_switch_to_idle_thread \<lbrace>\<lambda>s::'a state. P (scheduler_action s)\<rbrace>"
     assumes stit_activatable:
-      "\<lbrace>invs\<rbrace> switch_to_idle_thread \<lbrace>\<lambda>rv . (ct_in_state activatable :: 'a state \<Rightarrow> bool)\<rbrace>"
+      "\<lbrace>invs\<rbrace> switch_to_idle_thread \<lbrace>\<lambda>rv. (ct_in_state activatable :: 'a state \<Rightarrow> bool)\<rbrace>"
+    assumes arch_prepare_next_domain_ct[wp]:
+      "\<And>P. arch_prepare_next_domain \<lbrace>\<lambda>s :: 'a state. P (cur_thread s)\<rbrace>"
+    assumes arch_prepare_next_domain_activatable[wp]:
+      "arch_prepare_next_domain \<lbrace>ct_in_state activatable :: 'a state \<Rightarrow> bool\<rbrace>"
+    assumes arch_prepare_next_domain_pred_tcb_at[wp]:
+      "\<And>(proj :: itcb \<Rightarrow> 't) P Q t. arch_prepare_next_domain \<lbrace>\<lambda>s :: 'a state. P (pred_tcb_at proj Q t s)\<rbrace>"
+    assumes arch_prepare_next_domain_st_tcb_at[wp]:
+      "\<And>P Q t. arch_prepare_next_domain \<lbrace>\<lambda>s :: 'a state. P (st_tcb_at Q t s)\<rbrace>"
+    assumes arch_prepare_next_domain_valid_idle[wp]:
+      "arch_prepare_next_domain \<lbrace>valid_idle :: 'a state \<Rightarrow> bool\<rbrace>"
+    assumes arch_prepare_next_domain_invs[wp]:
+      "arch_prepare_next_domain \<lbrace>invs :: 'a state \<Rightarrow> bool\<rbrace>"
 
 crunch schedule_switch_thread_fastfail
   for inv[wp]: P

--- a/proof/invariant-abstract/Syscall_AI.thy
+++ b/proof/invariant-abstract/Syscall_AI.thy
@@ -73,13 +73,14 @@ lemma cur_thread_update_invs:
                    state_refs_of_def cur_tcb_def)
 
 lemma switch_to_thread_invs[wp]:
-  "switch_to_thread tptr \<lbrace>invs\<rbrace>"
+  "\<lbrace>invs and ex_nonz_cap_to tptr\<rbrace> switch_to_thread tptr \<lbrace>\<lambda>_. invs\<rbrace>"
   by (wpsimp simp: switch_to_thread_def thread_get_def is_tcb
                wp: cur_thread_update_invs)
 
 lemma guarded_switch_to_invs[wp]:
   "guarded_switch_to thread \<lbrace>invs\<rbrace>"
-  by (wpsimp simp: guarded_switch_to_def wp: hoare_drop_imps)
+  apply (wpsimp simp: guarded_switch_to_def wp: gts_wp)
+  by (fastforce elim: st_tcb_ex_cap' simp: runnable_eq)
 
 lemma schedule_choose_new_thread_invs[wp]:
   "schedule_choose_new_thread \<lbrace>invs\<rbrace>"

--- a/proof/invariant-abstract/Syscall_AI.thy
+++ b/proof/invariant-abstract/Syscall_AI.thy
@@ -81,7 +81,7 @@ lemma guarded_switch_to_invs[wp]:
   "guarded_switch_to thread \<lbrace>invs\<rbrace>"
   by (wpsimp simp: guarded_switch_to_def wp: hoare_drop_imps)
 
-lemma schedule_choose_new_thread_valid_state_cur_tcb [wp]:
+lemma schedule_choose_new_thread_invs[wp]:
   "schedule_choose_new_thread \<lbrace>invs\<rbrace>"
   by (wpsimp simp: schedule_choose_new_thread_def choose_thread_def
                wp: hoare_drop_imps)

--- a/proof/invariant-abstract/TcbAcc_AI.thy
+++ b/proof/invariant-abstract/TcbAcc_AI.thy
@@ -121,8 +121,8 @@ lemma thread_set_tcb[wp]:
   by (simp add: thread_set_typ_at [where P="\<lambda>s. s"] tcb_at_typ)
 
 lemma thread_set_no_change_tcb_pred:
-  assumes x: "\<And>tcb. proj (tcb_to_itcb (f tcb))    = proj (tcb_to_itcb tcb)"
-  shows      "\<lbrace>pred_tcb_at proj P t\<rbrace> thread_set f t' \<lbrace>\<lambda>rv. pred_tcb_at proj P t\<rbrace>"
+  assumes x: "\<And>tcb. proj (tcb_to_itcb (f tcb)) = proj (tcb_to_itcb tcb)"
+  shows      "thread_set f t' \<lbrace>\<lambda>s. P (pred_tcb_at proj Q t s)\<rbrace>"
   apply (simp add: thread_set_def pred_tcb_at_def)
   apply wp
    apply (rule set_object_at_obj)
@@ -703,7 +703,7 @@ lemma as_user_ex_nonz_cap_to[wp]:
   by (wp ex_nonz_cap_to_pres)
 
 lemma as_user_pred_tcb_at [wp]:
-  "\<lbrace>pred_tcb_at proj P t\<rbrace> as_user t' m \<lbrace>\<lambda>rv. pred_tcb_at proj P t\<rbrace>"
+  "as_user t' m \<lbrace>\<lambda>s. P (pred_tcb_at proj Q t s)\<rbrace>"
   by (wp as_user_wp_thread_set_helper thread_set_no_change_tcb_pred
       | simp add: tcb_to_itcb_def)+
 

--- a/proof/invariant-abstract/Tcb_AI.thy
+++ b/proof/invariant-abstract/Tcb_AI.thy
@@ -41,6 +41,12 @@ locale Tcb_AI_1 =
   assumes arch_post_modify_registers_ex_nonz_cap_to[wp]:
   "\<And>c t a. \<lbrace>\<lambda>(s::'state_ext state). ex_nonz_cap_to a s\<rbrace> arch_post_modify_registers c t
        \<lbrace>\<lambda>b s. ex_nonz_cap_to a s\<rbrace>"
+  assumes arch_post_set_flags[wp]:
+  "\<And>t flags. arch_post_set_flags t flags \<lbrace>invs :: 'state_ext state \<Rightarrow> _\<rbrace>"
+  assumes arch_prepare_set_domain_invs[wp]:
+  "\<And>t d. arch_prepare_set_domain t d \<lbrace>invs :: 'state_ext state \<Rightarrow> _\<rbrace>"
+  assumes arch_prepare_set_domain_typ_at[wp]:
+  "\<And>t d P T p. arch_prepare_set_domain t d \<lbrace>\<lambda>s::'state_ext state. P (typ_at T p s)\<rbrace>"
   assumes finalise_cap_not_cte_wp_at:
   "\<And>P cap fin. P cap.NullCap \<Longrightarrow> \<lbrace>\<lambda>(s::'state_ext state). \<forall>cp \<in> ran (caps_of_state s). P cp\<rbrace>
                 finalise_cap cap fin \<lbrace>\<lambda>rv s. \<forall>cp \<in> ran (caps_of_state s). P cp\<rbrace>"
@@ -757,6 +763,7 @@ where
                                           and ex_nonz_cap_to ntfnptr
                                           and bound_tcb_at ((=) None) t) ))"
 | "tcb_inv_wf (SetTLSBase t tls_base) = (tcb_at t and ex_nonz_cap_to t)"
+| "tcb_inv_wf (SetFlags t clearFlags setFlags) = (tcb_at t and ex_nonz_cap_to t)"
 
 end
 
@@ -816,24 +823,64 @@ lemma bind_notification_invs:
                   split: thread_state.splits if_split_asm)
   done
 
+lemma update_flags_valid_tcb[simp]:
+  "valid_tcb p t s \<Longrightarrow> valid_tcb p (t\<lparr>tcb_flags := fs\<rparr>) s"
+  by (simp add: valid_tcb_def ran_tcb_cap_cases)
+
+lemma set_flags_valid_objs[wp]:
+  "\<lbrace>invs\<rbrace> set_flags t fs \<lbrace>\<lambda>rv. valid_objs\<rbrace>"
+  unfolding set_flags_def
+  apply (wp thread_set_cte_at thread_set_valid_objs')
+  apply (simp add: invs_valid_objs)
+  done
+
+crunch set_flags
+  for valid_cap[wp]: "valid_cap c"
+  and cte_at[wp]: "cte_at c"
+
+lemma set_flags_invs[wp]:
+  "\<lbrace>invs and tcb_at t\<rbrace> set_flags t fs \<lbrace>\<lambda>rv. invs\<rbrace>"
+  unfolding set_flags_def
+  by (wp thread_set_valid_objs''
+         thread_set_refs_trivial
+         thread_set_hyp_refs_trivial
+         thread_set_iflive_trivial
+         thread_set_mdb
+         thread_set_ifunsafe_trivial
+         thread_set_cur_tcb
+         thread_set_zombies_trivial
+         thread_set_valid_idle_trivial
+         thread_set_global_refs_triv
+         thread_set_valid_reply_caps_trivial
+         thread_set_valid_reply_masters_trivial
+         valid_irq_node_typ valid_irq_handlers_lift
+         thread_set_caps_of_state_trivial
+         thread_set_arch_caps_trivial
+         thread_set_only_idle
+         thread_set_cap_refs_in_kernel_window
+         thread_set_valid_ioc_trivial thread_set_valid_arch_state
+         thread_set_cap_refs_respects_device_region
+      | simp add: ran_tcb_cap_cases invs_def valid_state_def valid_pspace_def
+      | rule conjI | erule disjE)+
+
 lemma (in Tcb_AI) tcbinv_invs:
   "\<lbrace>(invs::('state_ext::state_ext) state\<Rightarrow>bool) and tcb_inv_wf ti\<rbrace>
      invoke_tcb ti
    \<lbrace>\<lambda>rv. invs\<rbrace>"
-  apply (case_tac ti, simp_all only:)
-         apply ((wp writereg_invs readreg_invs copyreg_invs tc_invs
-              | simp
-              | clarsimp simp: invs_def valid_state_def valid_pspace_def
-                        dest!: idle_no_ex_cap
-                        split: option.split
-              | rule conjI)+)[6]
-   apply (rename_tac option)
-   apply (case_tac option, simp_all)
-    apply (rule hoare_pre)
-     apply ((wp unbind_notification_invs get_simple_ko_wp | simp)+)[2]
-   apply (wp bind_notification_invs)
-   apply clarsimp
-  apply wpsimp
+  apply (case_tac ti; simp only:)
+          apply ((wp writereg_invs readreg_invs copyreg_invs tc_invs
+               | simp
+               | clarsimp simp: invs_def valid_state_def valid_pspace_def
+                         dest!: idle_no_ex_cap
+                         split: option.split
+               | rule conjI)+)[6]
+    apply (rename_tac option)
+    apply (case_tac option; simp)
+     apply (rule hoare_pre)
+      apply ((wp unbind_notification_invs get_simple_ko_wp | simp)+)[2]
+    apply (wp bind_notification_invs)
+    apply clarsimp
+   apply wpsimp+
   done
 
 
@@ -1161,14 +1208,15 @@ lemma derived_cap_cnode_valid:
 
 crunch  decode_unbind_notification
   for inv[wp]: P
-(simp: whenE_def)
 
 lemma decode_bind_notification_inv[wp]:
-  "\<lbrace>P\<rbrace> decode_bind_notification cap excaps \<lbrace>\<lambda>_. P\<rbrace>"
+  "decode_bind_notification cap excaps \<lbrace>P\<rbrace>"
   unfolding decode_bind_notification_def
-  by (wpsimp wp: get_simple_ko_wp gbn_wp
-             simp: whenE_def if_apply_def2
-             split_del: if_split)
+  by (wpsimp wp: get_simple_ko_wp gbn_wp)
+
+lemma decode_set_flags_inv[wp]:
+  "decode_set_flags args cap \<lbrace>P\<rbrace>"
+  by (wpsimp simp: decode_set_flags_def)
 
 lemma (in Tcb_AI) decode_tcb_inv_inv:
   "\<lbrace>P::'state_ext state \<Rightarrow> bool\<rbrace>
@@ -1215,6 +1263,12 @@ lemma decode_unbind_notification_wf:
   apply clarsimp
   done
 
+lemma decode_set_flags_wf[wp]:
+  "\<lbrace>invs and tcb_at t and ex_nonz_cap_to t\<rbrace>
+   decode_set_flags args (cap.ThreadCap t)
+   \<lbrace>tcb_inv_wf\<rbrace>,-"
+  by (wpsimp simp: decode_set_flags_def)
+
 lemma decode_tcb_inv_wf:
   "\<lbrace>invs and tcb_at t and ex_nonz_cap_to t
          and cte_at slot and ex_cte_cap_to slot
@@ -1235,35 +1289,11 @@ lemma decode_tcb_inv_wf:
   apply (clarsimp simp: real_cte_at_cte)
   apply (fastforce simp: real_cte_at_not_tcb_at)
   done
+
+crunch invoke_domain
+  for typ_at[wp]: "\<lambda>s::'state_ext state. P (typ_at T p s)"
+  and invs[wp]: "invs :: 'state_ext state \<Rightarrow> _"
 end
-
-lemma out_pred_tcb_at_preserved:
-  "\<lbrakk> \<And>tcb x. tcb_state (f x tcb) = tcb_state tcb \<rbrakk> \<Longrightarrow>
-   \<lbrace>st_tcb_at P t\<rbrace> option_update_thread t' f opt \<lbrace>\<lambda>rv. st_tcb_at P t\<rbrace>"
-  apply (cases opt, simp_all add: option_update_thread_def)
-  apply (rule thread_set_no_change_tcb_state)
-  apply simp
-  done
-
-lemma set_domain_invs[wp]:
-  "set_domain t d \<lbrace>invs\<rbrace>"
-  by (simp add: set_domain_def | wp)+
-
-lemma invoke_domain_invs:
-  "\<lbrace>invs\<rbrace>
-     invoke_domain t d
-   \<lbrace>\<lambda>rv. invs\<rbrace>"
-  by (simp add: invoke_domain_def | wp)+
-
-lemma set_domain_typ_at[wp]:
-  "set_domain t d \<lbrace>\<lambda>s. P (typ_at T p s)\<rbrace>"
-  by (simp add: set_domain_def | wp)+
-
-lemma invoke_domain_typ_at[wp]:
-  "\<lbrace>\<lambda>s. P (typ_at T p s)\<rbrace>
-     invoke_domain t d
-   \<lbrace>\<lambda>rv s. P (typ_at T p s)\<rbrace>"
-  by (simp add: invoke_domain_def | wp)+
 
 lemma decode_domain_inv_inv:
   "\<lbrace>P\<rbrace>

--- a/proof/invariant-abstract/Tcb_AI.thy
+++ b/proof/invariant-abstract/Tcb_AI.thy
@@ -185,6 +185,7 @@ lemma (in Tcb_AI_1) copyreg_invs:
 lemma out_invs_trivialT:
   assumes x: "\<And>tcb v. \<forall>(getF, setF)\<in>ran tcb_cap_cases. getF (fn v tcb) = getF tcb"
   assumes r:  "\<And>tcb v. tcb_arch_ref (fn v tcb) = tcb_arch_ref tcb" (* ARMHYP *)
+  assumes r': "\<And>tcb v. arch_tcb_live (tcb_arch (fn v tcb)) = arch_tcb_live (tcb_arch tcb)"
   assumes z: "\<And>tcb v. tcb_state  (fn v tcb) = tcb_state  tcb"
   assumes z': "\<And>tcb v. tcb_bound_notification (fn v tcb) = tcb_bound_notification tcb"
   assumes z'': "\<And>tcb v. tcb_iarch (fn v tcb) = tcb_iarch tcb"
@@ -197,8 +198,8 @@ lemma out_invs_trivialT:
                                                    | Some f \<Rightarrow> valid_fault f)"
   shows      "\<lbrace>invs\<rbrace> option_update_thread t fn v \<lbrace>\<lambda>rv. invs\<rbrace>"
   apply (case_tac v, simp_all add: option_update_thread_def)
-  apply (rule thread_set_invs_trivial [OF x z z' z'' w y a r])
-  apply (auto intro: r)
+  apply (rule thread_set_invs_trivial [OF x z z' z'' w y a r r'])
+  apply auto
   done
 
 lemmas out_invs_trivial = out_invs_trivialT [OF ball_tcb_cap_casesI]
@@ -613,7 +614,7 @@ lemma thread_set_tcb_ipc_buffer_cap_cleared_invs:
              thread_set_valid_reply_caps_trivial
              thread_set_valid_reply_masters_trivial
              valid_irq_node_typ valid_irq_handlers_lift
-             thread_set_caps_of_state_trivial thread_set_valid_arch_state
+             thread_set_caps_of_state_trivial thread_set_valid_arch_state thread_set_valid_cur_fpu
              thread_set_arch_caps_trivial thread_set_irq_node
              thread_set_only_idle
              thread_set_cap_refs_in_kernel_window
@@ -707,7 +708,7 @@ lemma set_mcpriority_invs[wp]:
              thread_set_arch_caps_trivial
              thread_set_only_idle
              thread_set_cap_refs_in_kernel_window
-             thread_set_valid_ioc_trivial thread_set_valid_arch_state
+             thread_set_valid_ioc_trivial thread_set_valid_arch_state thread_set_valid_cur_fpu
              thread_set_cap_refs_respects_device_region
               | simp add: ran_tcb_cap_cases invs_def valid_state_def valid_pspace_def
               | rule conjI | erule disjE)+
@@ -858,7 +859,7 @@ lemma set_flags_invs[wp]:
          thread_set_arch_caps_trivial
          thread_set_only_idle
          thread_set_cap_refs_in_kernel_window
-         thread_set_valid_ioc_trivial thread_set_valid_arch_state
+         thread_set_valid_ioc_trivial thread_set_valid_arch_state thread_set_valid_cur_fpu
          thread_set_cap_refs_respects_device_region
       | simp add: ran_tcb_cap_cases invs_def valid_state_def valid_pspace_def
       | rule conjI | erule disjE)+

--- a/proof/invariant-abstract/Untyped_AI.thy
+++ b/proof/invariant-abstract/Untyped_AI.thy
@@ -3087,6 +3087,9 @@ lemma create_cap_refs_respects_device:
   apply (fastforce simp: is_cap_simps)
   done
 
+crunch create_cap
+  for valid_cur_fpu[wp]: valid_cur_fpu
+
 lemma (in Untyped_AI_nonempty_table) create_cap_invs[wp]:
   "\<lbrace>invs
       and cte_wp_at (\<lambda>c. is_untyped_cap c \<and> cap_is_device (default_cap tp oref sz dev)  = cap_is_device c

--- a/proof/invariant-abstract/VSpacePre_AI.thy
+++ b/proof/invariant-abstract/VSpacePre_AI.thy
@@ -174,26 +174,4 @@ lemma set_cap_arch_obj:
   apply (clarsimp simp: obj_at_def cte_wp_at_cases)
   done
 
-lemma set_mrs_typ_at[wp]:
-  "\<lbrace>\<lambda>s. P (typ_at T p s)\<rbrace> set_mrs t buf mrs \<lbrace>\<lambda>rv s. P (typ_at T p s)\<rbrace>"
-  apply (simp add: set_mrs_def zipWithM_x_mapM split_def
-                   store_word_offs_def set_object_def get_object_def
-              cong: option.case_cong
-              split del: if_split)
-  apply (wp hoare_vcg_split_case_option)
-    apply (rule mapM_wp [where S=UNIV, simplified])
-    apply (wp | simp)+
-  apply (clarsimp simp: obj_at_def a_type_def
-                  dest!: get_tcb_SomeD)
-  done
-
-lemma set_mrs_tcb[wp]:
-  "\<lbrace> tcb_at t \<rbrace> set_mrs receiver recv_buf mrs \<lbrace>\<lambda>rv. tcb_at t \<rbrace>"
-  by (simp add: tcb_at_typ, wp)
-
-
-lemma set_mrs_ntfn_at[wp]:
-  "\<lbrace> ntfn_at p \<rbrace> set_mrs receiver recv_buf mrs \<lbrace>\<lambda>rv. ntfn_at p \<rbrace>"
-  by (simp add: ntfn_at_typ, wp)
-
 end

--- a/proof/invariant-abstract/X64/ArchDetSchedAux_AI.thy
+++ b/proof/invariant-abstract/X64/ArchDetSchedAux_AI.thy
@@ -157,9 +157,6 @@ crunch init_arch_objects
 
 end
 
-lemmas tcb_sched_action_valid_idle_etcb
-    = X64.tcb_sched_action_valid_idle_etcb
-
 global_interpretation DetSchedAux_AI_det_ext?: DetSchedAux_AI_det_ext
   proof goal_cases
   interpret Arch .

--- a/spec/abstract/AARCH64/ArchRetype_A.thy
+++ b/spec/abstract/AARCH64/ArchRetype_A.thy
@@ -57,7 +57,7 @@ definition empty_context :: user_context where
   "empty_context \<equiv> UserContext (FPUState (\<lambda>_. 0) 0 0) (\<lambda>_. 0)"
 
 definition init_arch_tcb :: arch_tcb where
-  "init_arch_tcb \<equiv> \<lparr> tcb_context = empty_context, tcb_vcpu = None \<rparr>"
+  "init_arch_tcb \<equiv> \<lparr> tcb_context = empty_context, tcb_vcpu = None, tcb_cur_fpu = False \<rparr>"
 
 end
 end

--- a/spec/abstract/AARCH64/Arch_Structs_A.thy
+++ b/spec/abstract/AARCH64/Arch_Structs_A.thy
@@ -365,17 +365,22 @@ section "Arch-specific TCB"
 
 qualify AARCH64_A (in Arch)
 
-text \<open> Arch-specific part of a TCB: this must have at least a field for user context. \<close>
+text \<open>
+  Arch-specific part of a TCB: this must have at least a field for user context.
+  @{text tcb_cur_fpu} is a ghost variable used to used to track within the tcb whether it is the
+  current fpu owner, so that we are able to determine whether a tcb is live without needing to look
+  at global state.\<close>
 record arch_tcb =
   tcb_context :: user_context
   tcb_vcpu    :: "obj_ref option"
+  tcb_cur_fpu :: bool
 
 end_qualify
 
 context Arch begin arch_global_naming (A)
 
 definition default_arch_tcb :: arch_tcb where
-  "default_arch_tcb \<equiv> \<lparr>tcb_context = new_context, tcb_vcpu = None\<rparr>"
+  "default_arch_tcb \<equiv> \<lparr>tcb_context = new_context, tcb_vcpu = None, tcb_cur_fpu = False\<rparr>"
 
 text \<open>
   Accessors for @{text "tcb_context"} inside @{text "arch_tcb"}. These are later used to

--- a/spec/abstract/AARCH64/FPU_A.thy
+++ b/spec/abstract/AARCH64/FPU_A.thy
@@ -25,6 +25,14 @@ definition load_fpu_state :: "obj_ref \<Rightarrow> (unit,'z::state_ext) s_monad
      do_machine_op (writeFpuState fpu_state)
    od"
 
+definition set_arm_current_fpu_owner :: "obj_ref option \<Rightarrow> (unit,'z::state_ext) s_monad" where
+  "set_arm_current_fpu_owner new_owner \<equiv> do
+     cur_fpu_owner \<leftarrow> gets (arm_current_fpu_owner \<circ> arch_state);
+     maybeM (arch_thread_set (tcb_cur_fpu_update \<bottom>)) cur_fpu_owner;
+     modify (\<lambda>s. s \<lparr>arch_state := arch_state s\<lparr>arm_current_fpu_owner := new_owner\<rparr>\<rparr>);
+     maybeM (arch_thread_set (tcb_cur_fpu_update \<top>)) new_owner
+   od"
+
 \<comment> \<open>FIXME FPU: maybe use an if instead of the case (depends on if wpc or if\_split is easier)\<close>
 definition switch_local_fpu_owner :: "obj_ref option \<Rightarrow> (unit,'z::state_ext) s_monad" where
   "switch_local_fpu_owner new_owner \<equiv> do
@@ -34,7 +42,7 @@ definition switch_local_fpu_owner :: "obj_ref option \<Rightarrow> (unit,'z::sta
      case new_owner of
        None \<Rightarrow> do_machine_op disableFpu
        | Some tcb_ptr \<Rightarrow> load_fpu_state tcb_ptr;
-     modify (\<lambda>s. s \<lparr>arch_state := arch_state s\<lparr>arm_current_fpu_owner := new_owner\<rparr>\<rparr>)
+     set_arm_current_fpu_owner new_owner
    od"
 
 definition fpu_release :: "obj_ref \<Rightarrow> (unit,'z::state_ext) s_monad" where

--- a/spec/abstract/X64/ArchRetype_A.thy
+++ b/spec/abstract/X64/ArchRetype_A.thy
@@ -38,7 +38,7 @@ definition
   "empty_context \<equiv> UserContext (\<lambda>_. 0) (\<lambda>_. 0)"
 
 definition init_arch_tcb :: arch_tcb where
-  "init_arch_tcb \<equiv> \<lparr> tcb_context = empty_context \<rparr>"
+  "init_arch_tcb \<equiv> \<lparr> tcb_context = empty_context, tcb_cur_fpu = False \<rparr>"
 
 end
 end

--- a/spec/abstract/X64/Arch_Structs_A.thy
+++ b/spec/abstract/X64/Arch_Structs_A.thy
@@ -406,9 +406,14 @@ section "Arch-specific TCB"
 
 qualify X64_A (in Arch)
 
-text \<open> Arch-specific part of a TCB: this must have at least a field for user context. \<close>
+text \<open>
+  Arch-specific part of a TCB: this must have at least a field for user context.
+  @{text tcb_cur_fpu} is a ghost variable used to used to track within the tcb whether it is the
+  current fpu owner, so that we are able to determine whether a tcb is live without needing to look
+  at global state.\<close>
 record arch_tcb =
   tcb_context :: user_context
+  tcb_cur_fpu :: bool
 
 end_qualify
 
@@ -416,7 +421,7 @@ context Arch begin arch_global_naming (A)
 
 definition
   default_arch_tcb :: arch_tcb where
-  "default_arch_tcb \<equiv> \<lparr>tcb_context = new_context\<rparr>"
+  "default_arch_tcb \<equiv> \<lparr>tcb_context = new_context, tcb_cur_fpu = False\<rparr>"
 
 text \<open> Accessors for @{text "tcb_context"} inside @{text "arch_tcb"}.
   These are later used to implement @{text as_user}, i.e.\ need to be

--- a/spec/abstract/X64/FPU_A.thy
+++ b/spec/abstract/X64/FPU_A.thy
@@ -25,6 +25,14 @@ definition load_fpu_state :: "obj_ref \<Rightarrow> (unit,'z::state_ext) s_monad
      do_machine_op (writeFpuState fpu_state)
    od"
 
+definition set_arm_current_fpu_owner :: "obj_ref option \<Rightarrow> (unit,'z::state_ext) s_monad" where
+  "set_arm_current_fpu_owner new_owner \<equiv> do
+     cur_fpu_owner \<leftarrow> gets (x64_current_fpu_owner \<circ> arch_state);
+     maybeM (arch_thread_set (tcb_cur_fpu_update \<bottom>)) cur_fpu_owner;
+     modify (\<lambda>s. s \<lparr>arch_state := arch_state s\<lparr>x64_current_fpu_owner := new_owner\<rparr>\<rparr>);
+     maybeM (arch_thread_set (tcb_cur_fpu_update \<top>)) new_owner
+   od"
+
 \<comment> \<open>FIXME FPU: maybe use an if instead of the case (depends on if wpc or if\_split is easier)\<close>
 definition switch_local_fpu_owner :: "obj_ref option \<Rightarrow> (unit,'z::state_ext) s_monad" where
   "switch_local_fpu_owner new_owner \<equiv> do
@@ -34,7 +42,7 @@ definition switch_local_fpu_owner :: "obj_ref option \<Rightarrow> (unit,'z::sta
      case new_owner of
        None \<Rightarrow> do_machine_op disableFpu
        | Some tcb_ptr \<Rightarrow> load_fpu_state tcb_ptr;
-     modify (\<lambda>s. s \<lparr>arch_state := arch_state s\<lparr>x64_current_fpu_owner := new_owner\<rparr>\<rparr>)
+     set_arm_current_fpu_owner new_owner
    od"
 
 definition fpu_release :: "obj_ref \<Rightarrow> (unit,'z::state_ext) s_monad" where


### PR DESCRIPTION
This updates the AInvs proofs for ARM and AARCH64 following the specification changes made in https://github.com/seL4/l4v/pull/819 that made FPU state more explicit and changed the kernel to use semi-lazy FPU switching. It additionally proves a new invariant about the FPU that we expect to be necessary for later stages of the functional correctness proofs and also updates Access for ARM.