### PR TITLE
More platform configs for CI

### DIFF
--- a/.github/workflows/proof-deploy.yml
+++ b/.github/workflows/proof-deploy.yml
@@ -55,12 +55,18 @@ jobs:
         num_domains: ['1', '']
         plat: ['']
         include:
+          - arch: ARM
+            plat: exynos4
+          - arch: ARM
+            plat: hikey
           - arch: ARM_HYP
             plat: exynos5
           - arch: AARCH64
             plat: zynqmp
           - arch: AARCH64
             plat: bcm2711
+          - arch: AARCH64
+            plat: imx8mm
     # test only most recent push:
     concurrency:
       group: l4v-regression-${{ github.ref }}-${{ strategy.job-index }}

--- a/.github/workflows/weekly-clean.yml
+++ b/.github/workflows/weekly-clean.yml
@@ -19,6 +19,53 @@ jobs:
       matrix:
         arch: [ARM, ARM_HYP, AARCH64, RISCV64, X64]
         num_domains: ['1', '7', '']
+        plat: ['']
+        include:
+          - arch: ARM
+            plat: exynos4
+          - arch: ARM
+            plat: exynos5410
+          - arch: ARM
+            plat: exynos5422
+          - arch: ARM
+            plat: hikey
+          - arch: ARM
+            plat: tk1
+          - arch: ARM
+            plat: zynq7000
+          - arch: ARM
+            plat: zynqmp
+
+          - arch: ARM_HYP
+            plat: exynos5410
+          - arch: ARM_HYP
+            plat: exynos5
+
+          - arch: AARCH64
+            plat: bcm2711
+          - arch: AARCH64
+            plat: hikey
+          - arch: AARCH64
+            plat: imx8mm
+          - arch: AARCH64
+            plat: imx8mq
+          - arch: AARCH64
+            plat: imx93
+          - arch: AARCH64
+            plat: maaxboard
+          - arch: AARCH64
+            plat: odroidc2
+          - arch: AARCH64
+            plat: odroidc4
+          - arch: AARCH64
+            plat: rockpro64
+          - arch: AARCH64
+            plat: tqma
+          - arch: AARCH64
+            plat: tx1
+          - arch: AARCH64
+            plat: zynqmp
+
     steps:
     - name: Proofs
       uses: seL4/ci-actions/aws-proofs@master


### PR DESCRIPTION
The first commit adds a broader spread of platforms to CI for every merge to cover GICv3 on AARCH64 and different IRQ and other platform values for ARM.

The second commit adds all supported platforms to the weekly test. This might be too many -- I'm not sure and we should watch cost as well. Ideas welcome.