### PR TITLE
aarch64: updates for GICv3 split EOI mode

### DIFF
--- a/proof/crefine/AARCH64/Machine_C.thy
+++ b/proof/crefine/AARCH64/Machine_C.thy
@@ -62,6 +62,12 @@ assumes maskInterrupt_ccorres:
            (doMachineOp (maskInterrupt m irq))
            (Call maskInterrupt_'proc)"
 
+(* This function is only implemented on GICv3 configs, hence the precondition *)
+assumes deactivateInterrupt_ccorres:
+  "ccorres dc xfdc (\<lambda>_. config_ARM_GIC_V3) (\<lbrace>\<acute>irq = ucast irq\<rbrace>) []
+           (doMachineOp (deactivateInterrupt irq))
+           (Call deactivateInterrupt_'proc)"
+
 (* This is a simplification until complete FPU handling is added at a future date *)
 assumes fpuThreadDelete_ccorres:
   "ccorres dc xfdc (tcb_at' thread) (\<lbrace>\<acute>thread = tcb_ptr_to_ctcb_ptr thread\<rbrace>) hs

--- a/proof/invariant-abstract/AARCH64/ArchBCorres2_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchBCorres2_AI.thy
@@ -65,7 +65,7 @@ lemma invoke_irq_control_bcorres[wp]: "bcorres (invoke_irq_control a) (invoke_ir
   done
 
 lemma invoke_irq_handler_bcorres[wp]: "bcorres (invoke_irq_handler a) (invoke_irq_handler a)"
-  by (cases a; wpsimp)
+  by (cases a; (wpsimp | rule conjI)+)
 
 lemma make_arch_fault_msg_bcorres[wp,BCorres2_AI_assms]:
   "bcorres (make_arch_fault_msg a b) (make_arch_fault_msg a b)"

--- a/proof/invariant-abstract/AARCH64/ArchEmptyFail_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchEmptyFail_AI.thy
@@ -194,6 +194,11 @@ lemma vgic_maintenance_empty_fail[wp]: "empty_fail vgic_maintenance"
                    get_gic_vcpu_ctrl_misr_def
                    vgic_maintenance_def)
 
+lemma deactivateInterrupt_empty_fail[wp]:
+  "config_ARM_GIC_V3 \<Longrightarrow> empty_fail (deactivateInterrupt irq)"
+  unfolding deactivateInterrupt_def
+  by wpsimp
+
 crunch possible_switch_to, handle_event, activate_thread
   for (empty_fail) empty_fail[wp, EmptyFail_AI_assms]
   (simp: cap.splits arch_cap.splits split_def invocation_label.splits Let_def

--- a/spec/abstract/AARCH64/ArchInterrupt_A.thy
+++ b/spec/abstract/AARCH64/ArchInterrupt_A.thy
@@ -77,11 +77,15 @@ definition handle_reserved_irq :: "irq \<Rightarrow> (unit,'z::state_ext) s_mona
    od"
 
 fun arch_invoke_irq_handler :: "irq_handler_invocation \<Rightarrow> (unit,'z::state_ext) s_monad" where
-  "arch_invoke_irq_handler (ACKIrq irq) = (do_machine_op $ maskInterrupt False irq)"
+  "arch_invoke_irq_handler (ACKIrq irq) =
+     do_machine_op (if Kernel_Config.config_ARM_GIC_V3
+                    then deactivateInterrupt irq
+                    else maskInterrupt False irq)"
 | "arch_invoke_irq_handler _ = return ()"
 
 definition arch_mask_irq_signal :: "irq \<Rightarrow> (unit,'z::state_ext) s_monad" where
-  "arch_mask_irq_signal irq \<equiv> do_machine_op $ maskInterrupt True irq"
+  "arch_mask_irq_signal irq \<equiv>
+     when (\<not>Kernel_Config.config_ARM_GIC_V3) (do_machine_op $ maskInterrupt True irq)"
 
 end
 

--- a/spec/design/skel/AARCH64/Hardware_H.thy
+++ b/spec/design/skel/AARCH64/Hardware_H.thy
@@ -15,7 +15,7 @@ context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Machine/Hardware/AARCH64.hs Platform=Platform.AARCH64 CONTEXT AARCH64_H \
   NOT PT_Type plic_complete_claim getMemoryRegions getDeviceRegions getKernelDevices \
-  loadWord storeWord storeWordVM getActiveIRQ ackInterrupt maskInterrupt \
+  loadWord storeWord storeWordVM getActiveIRQ ackInterrupt maskInterrupt deactivateInterrupt \
   configureTimer resetTimer debugPrint getRestartPC setNextPC clearMemory \
   clearMemoryVM initMemory freeMemory setHardwareASID wordFromPDE wordFromPTE \
   VMFaultType HypFaultType VMPageSize pageBits pageBitsForSize toPAddr \

--- a/spec/haskell/src/SEL4/Machine/Hardware.lhs
+++ b/spec/haskell/src/SEL4/Machine/Hardware.lhs
@@ -66,7 +66,7 @@ Depending on the architecture, real physical addresses may be the same as the ad
 
 An interrupt request from an external device, or from the CPU's timer, is represented by the type "IRQ".
 
-> newtype IRQ = IRQ Arch.IRQ
+> newtype IRQ = IRQ { theIRQ :: Arch.IRQ }
 >     deriving (Enum, Bounded, Ord, Ix, Eq, Show)
 
 The maximum and minimum IRQ are given explicit constant names here. In Haskell, these are extracted from instantiation of IRQ into the Bounded class. In the formalisation, these constants are generated and defined in Kernel_Config.thy.

--- a/spec/haskell/src/SEL4/Machine/Hardware/AARCH64.hs
+++ b/spec/haskell/src/SEL4/Machine/Hardware/AARCH64.hs
@@ -382,6 +382,9 @@ maskInterrupt maskI irq = do
     cbptr <- ask
     liftIO $ Platform.maskInterrupt cbptr maskI irq
 
+deactivateInterrupt :: IRQ -> MachineMonad ()
+deactivateInterrupt irq = error "Unimplemented - GICv3 machine op"
+
 debugPrint :: String -> MachineMonad ()
 debugPrint str = liftIO $ putStrLn str
 

--- a/spec/machine/AARCH64/MachineOps.thy
+++ b/spec/machine/AARCH64/MachineOps.thy
@@ -92,8 +92,13 @@ definition debugPrint :: "unit list \<Rightarrow> unit machine_monad" where
 
 subsection \<open>Interrupt Controller\<close>
 
+(* Interface function for the Haskell IRQ wrapper type *)
 definition IRQ :: "irq \<Rightarrow> irq" where
   "IRQ \<equiv> id"
+
+(* Interface function for the Haskell IRQ wrapper type *)
+definition theIRQ :: "irq \<Rightarrow> irq" where
+  "theIRQ \<equiv> id"
 
 consts' setIRQTrigger_impl :: "irq \<Rightarrow> bool \<Rightarrow> unit machine_rest_monad"
 definition setIRQTrigger :: "irq \<Rightarrow> bool \<Rightarrow> unit machine_monad" where
@@ -130,6 +135,14 @@ definition ackInterrupt :: "irq \<Rightarrow> unit machine_monad" where
 
 definition setInterruptMode :: "irq \<Rightarrow> bool \<Rightarrow> bool \<Rightarrow> unit machine_monad" where
   "setInterruptMode \<equiv> \<lambda>irq levelTrigger polarityLow. return ()"
+
+text \<open>Only exists on GICv3 platforms. We model interrupt deactivation as unmasking
+  for the purposes of the interrupt oracle.\<close>
+definition deactivateInterrupt :: "irq \<Rightarrow> unit machine_monad" where
+  "deactivateInterrupt irq \<equiv> do
+     assert config_ARM_GIC_V3;
+     maskInterrupt False irq
+   od"
 
 
 subsection "User Monad and Registers"


### PR DESCRIPTION
Brings changes for split EOI (End Of Interrupt) mode from seL4/seL4#1183 into the verification.

Most of what changes in the seL4 pull request is underneath the machine interface and implements a different mechanism for masking/unmasking interrupts (using priority drop instead of actual masking/unmasking). For the purposes of the proof, what we want from the hardware remains the same: when deactivated, the interrupt will no longer fire.

Affects AARCH64 only.

Test with: seL4/seL4#1183