### PR TITLE
arm-hyp+aarch64 haskell+crefine: fix saved-when-disabled registers

### DIFF
--- a/proof/crefine/AARCH64/Arch_C.thy
+++ b/proof/crefine/AARCH64/Arch_C.thy
@@ -3369,12 +3369,17 @@ lemma vcpu_reg_saved_when_disabled_spec:
   "\<forall>s. \<Gamma> \<turnstile> {s}
            Call vcpu_reg_saved_when_disabled_'proc
            \<lbrace> \<acute>ret__unsigned_long = from_bool (\<^bsup>s\<^esup>field \<in> {scast seL4_VCPUReg_SCTLR,
+                                                          scast seL4_VCPUReg_CNTV_CVAL,
+                                                          scast seL4_VCPUReg_CNTVOFF,
+                                                          scast seL4_VCPUReg_CNTKCTL_EL1,
                                                           scast seL4_VCPUReg_CNTV_CTL,
                                                           scast seL4_VCPUReg_CPACR}) \<rbrace>"
   by vcg clarsimp
 
 lemma vcpuRegSavedWhenDisabled_spec[simp]:
-  "vcpuRegSavedWhenDisabled reg = (reg = VCPURegSCTLR \<or> reg = VCPURegCNTV_CTL \<or> reg = VCPURegCPACR)"
+  "vcpuRegSavedWhenDisabled reg = (reg = VCPURegSCTLR \<or> reg = VCPURegCNTV_CVAL \<or>
+                                   reg = VCPURegCNTVOFF \<or> reg = VCPURegCNTKCTL_EL1 \<or>
+                                   reg = VCPURegCNTV_CTL \<or> reg = VCPURegCPACR)"
   by (simp add: vcpuRegSavedWhenDisabled_def split: vcpureg.splits)
 
 lemma writeVCPUReg_ccorres:
@@ -3400,7 +3405,8 @@ lemma writeVCPUReg_ccorres:
     apply clarsimp
     apply (rename_tac curvcpuactive)
     apply csymbr
-    apply (rule_tac C'="{s. (reg = VCPURegSCTLR \<or> reg = VCPURegCNTV_CTL \<or> reg = VCPURegCPACR) \<and> \<not>curvcpuactive }"
+    apply (rule_tac C'="{s. (reg = VCPURegSCTLR \<or> reg = VCPURegCNTV_CVAL \<or> reg = VCPURegCNTVOFF \<or>
+                             reg = VCPURegCNTKCTL_EL1 \<or> reg = VCPURegCNTV_CTL \<or> reg = VCPURegCPACR) \<and> \<not>curvcpuactive }"
                             and Q="\<lambda>s. (armHSCurVCPU \<circ> ksArchState) s = Some (vcpuptr, curvcpuactive)"
                             and Q'=UNIV in ccorres_rewrite_cond_sr)
      subgoal by (clarsimp dest!: rf_sr_ksArchState_armHSCurVCPU
@@ -3444,7 +3450,8 @@ lemma readVCPUReg_ccorres:
     apply clarsimp
     apply (rename_tac curvcpuactive)
     apply csymbr
-    apply (rule_tac C'="{s. (reg = VCPURegSCTLR \<or> reg = VCPURegCNTV_CTL \<or> reg = VCPURegCPACR) \<and> \<not>curvcpuactive }"
+    apply (rule_tac C'="{s. (reg = VCPURegSCTLR \<or> reg = VCPURegCNTV_CVAL \<or> reg = VCPURegCNTVOFF \<or>
+                             reg = VCPURegCNTKCTL_EL1 \<or> reg = VCPURegCNTV_CTL \<or> reg = VCPURegCPACR) \<and> \<not>curvcpuactive }"
                             and Q="\<lambda>s. (armHSCurVCPU \<circ> ksArchState) s = Some (vcpuptr, curvcpuactive)"
                             and Q'=UNIV in ccorres_rewrite_cond_sr)
      subgoal by (clarsimp dest!: rf_sr_ksArchState_armHSCurVCPU

--- a/spec/haskell/src/SEL4/Machine/RegisterSet/AARCH64.hs
+++ b/spec/haskell/src/SEL4/Machine/RegisterSet/AARCH64.hs
@@ -102,6 +102,9 @@ vcpuRegNum = fromEnum (maxBound :: VCPUReg)
 vcpuRegSavedWhenDisabled :: VCPUReg -> Bool
 vcpuRegSavedWhenDisabled VCPURegSCTLR = True
 vcpuRegSavedWhenDisabled VCPURegCNTV_CTL = True
+vcpuRegSavedWhenDisabled VCPURegCNTV_CVAL = True
+vcpuRegSavedWhenDisabled VCPURegCNTVOFF = True
+vcpuRegSavedWhenDisabled VCPURegCNTKCTL_EL1 = True
 vcpuRegSavedWhenDisabled VCPURegCPACR = True
 vcpuRegSavedWhenDisabled _ = False
 

--- a/spec/haskell/src/SEL4/Machine/RegisterSet/ARM.lhs
+++ b/spec/haskell/src/SEL4/Machine/RegisterSet/ARM.lhs
@@ -99,6 +99,11 @@ This module defines the ARM register set.
 
 > vcpuRegSavedWhenDisabled :: VCPUReg -> Bool
 > vcpuRegSavedWhenDisabled VCPURegSCTLR = True
+> vcpuRegSavedWhenDisabled VCPURegCNTV_CTL  = True
+> vcpuRegSavedWhenDisabled VCPURegCNTV_CVALhigh = True
+> vcpuRegSavedWhenDisabled VCPURegCNTV_CVALlow = True
+> vcpuRegSavedWhenDisabled VCPURegCNTVOFFhigh = True
+> vcpuRegSavedWhenDisabled VCPURegCNTVOFFlow = True
 > vcpuRegSavedWhenDisabled _ = False
 
 #endif


### PR DESCRIPTION
Mark additional registers as being saved when a VCPU is disabled

Test with seL4/seL4#1384