### PR TITLE
github: update to central workflows

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,4 +1,4 @@
-# Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+# Copyright 2025, Proofcraft Pty Ltd
 #
 # SPDX-License-Identifier: BSD-2-Clause
 
@@ -6,37 +6,11 @@
 
 name: PR
 
-on: [pull_request]
+on: [pull_request, workflow_dispatch]
 
 jobs:
-  gitlint:
-    name: Gitlint
-    runs-on: ubuntu-latest
-    steps:
-    - uses: seL4/ci-actions/gitlint@master
-      with:
-        token: ${{ secrets.READ_TOKEN }}
-
-  whitespace:
-    name: 'Trailing Whitespace'
-    runs-on: ubuntu-latest
-    steps:
-    - uses: seL4/ci-actions/git-diff-check@master
-      with:
-        token: ${{ secrets.READ_TOKEN }}
-
-  shell:
-    name: 'Portable Shell'
-    runs-on: ubuntu-latest
-    steps:
-    - uses: seL4/ci-actions/bashisms@master
-      with:
-        token: ${{ secrets.READ_TOKEN }}
-
-  style:
-    name: Style
-    runs-on: ubuntu-latest
-    steps:
-    - uses: seL4/ci-actions/style@master
-      with:
+  pr-checks:
+    name: Checks
+    uses: seL4/ci-actions/.github/workflows/pr.yml@master
+    secrets:
         token: ${{ secrets.READ_TOKEN }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,4 +1,4 @@
-# Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+# Copyright 2025, Proofcraft Pty Ltd
 #
 # SPDX-License-Identifier: BSD-2-Clause
 
@@ -9,27 +9,12 @@ on:
   push:
     branches:
       - master
-      - rt
-      - aarch64
   pull_request:
-  # for testing:
   workflow_dispatch:
 
 jobs:
-  check:
-    name: License Check
-    runs-on: ubuntu-latest
-    steps:
-    - uses: seL4/ci-actions/license-check@master
-      with:
-        token: ${{ secrets.READ_TOKEN }}
-
-  links:
-    name: Links
-    runs-on: ubuntu-latest
-    steps:
-      - uses: seL4/ci-actions/link-check@master
-        with:
-          token: ${{ secrets.READ_TOKEN }}
-          # produces 403 for link checkers now:
-          exclude_urls: ".*haskellstack.org.*"
+  checks:
+    name: Checks
+    uses: seL4/ci-actions/.github/workflows/push.yml@master
+    secrets:
+      token: ${{ secrets.READ_TOKEN }}

--- a/.linkcheck-ignore.yml
+++ b/.linkcheck-ignore.yml
@@ -1,0 +1,7 @@
+# Copyright 2025, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+urls:
+  - ".*haskellstack.org.*"
+  - https://doi.org/10.1145/1190215.1190234


### PR DESCRIPTION
Use GitHub workflow_call feature to reduce workflow duplication.

~~The central workflows in https://github.com/seL4/ci-actions/blob/master/.github/workflows/ don't support the `READ_TOKEN` bit yet, so we should hold off on merging until that is done.~~

~~I also still need to implement the ignore file format for the link checker.~~

~~Will set to non-draft when this is done.~~

Both features are implemented (https://github.com/seL4/ci-actions/pull/393 and https://github.com/seL4/ci-actions/pull/390), now ready for review.