### PR TITLE
access+infoflow: relax conditions

### DIFF
--- a/proof/access-control/ARM/ArchADT_AC.thy
+++ b/proof/access-control/ARM/ArchADT_AC.thy
@@ -216,7 +216,7 @@ global_interpretation ADT_AC_1?: ADT_AC_1
 proof goal_cases
   interpret Arch .
   case 1 show ?case
-    by (unfold_locales; fact ADT_AC_assms)
+    by (unfold_locales; (fact ADT_AC_assms)?)
 qed
 
 end

--- a/proof/access-control/ARM/ArchAccess_AC.thy
+++ b/proof/access-control/ARM/ArchAccess_AC.thy
@@ -64,7 +64,7 @@ global_interpretation Access_AC_1?: Access_AC_1
 proof goal_cases
   interpret Arch .
   case 1 show ?case
-    by (unfold_locales; fact Access_AC_assms)
+    by (unfold_locales; (fact Access_AC_assms)?)
 qed
 
 

--- a/proof/access-control/ARM/ArchArch_AC.thy
+++ b/proof/access-control/ARM/ArchArch_AC.thy
@@ -49,7 +49,7 @@ global_interpretation Arch_AC_1?: Arch_AC_1
 proof goal_cases
   interpret Arch .
   case 1 show ?case
-    by (unfold_locales; (fact Arch_AC_assms | wpsimp wp: Arch_AC_assms))
+    by (unfold_locales; (fact Arch_AC_assms | solves \<open>wp only: Arch_AC_assms; simp\<close>)?)
 qed
 
 

--- a/proof/access-control/ARM/ArchCNode_AC.thy
+++ b/proof/access-control/ARM/ArchCNode_AC.thy
@@ -134,7 +134,7 @@ global_interpretation CNode_AC_1?: CNode_AC_1
 proof goal_cases
   interpret Arch .
   case 1 show ?case
-    by (unfold_locales; (fact CNode_AC_assms | simp add: CNode_AC_assms | wpsimp))
+    by (unfold_locales; (fact CNode_AC_assms | solves \<open>wp only: CNode_AC_assms; simp\<close>)?)
 qed
 
 
@@ -161,7 +161,7 @@ global_interpretation CNode_AC_2?: CNode_AC_2
 proof goal_cases
   interpret Arch .
   case 1 show ?case
-    by (unfold_locales; fact CNode_AC_assms)
+    by (unfold_locales; (fact CNode_AC_assms)?)
 qed
 
 
@@ -199,7 +199,7 @@ global_interpretation CNode_AC_3?: CNode_AC_3
 proof goal_cases
   interpret Arch .
   case 1 show ?case
-    by (unfold_locales; fact CNode_AC_assms)
+    by (unfold_locales; (fact CNode_AC_assms)?)
 qed
 
 
@@ -307,7 +307,7 @@ global_interpretation CNode_AC_4?: CNode_AC_4
 proof goal_cases
   interpret Arch .
   case 1 show ?case
-    by (unfold_locales; fact CNode_AC_assms)
+    by (unfold_locales; (fact CNode_AC_assms)?)
 qed
 
 

--- a/proof/access-control/ARM/ArchFinalise_AC.thy
+++ b/proof/access-control/ARM/ArchFinalise_AC.thy
@@ -61,6 +61,12 @@ lemma arch_finalise_cap_respects[Finalise_AC_assms, wp]:
              intro: pas_refined_Control_into_is_subject_asid)
   done
 
+declare finalise_cap_replaceable[Finalise_AC_assms]
+declare finalise_cap_valid_list[Finalise_AC_assms]
+declare arch_finalise_cap_pas_refined[Finalise_AC_assms]
+declare prepare_thread_delete_st_tcb_at_halted[Finalise_AC_assms]
+declare prepare_thread_delete_pas_refined[Finalise_AC_assms]
+
 end
 
 
@@ -68,7 +74,7 @@ global_interpretation Finalise_AC_1?: Finalise_AC_1
 proof goal_cases
   interpret Arch .
   case 1 show ?case
-    by (unfold_locales; (fact Finalise_AC_assms | wpsimp wp: finalise_cap_replaceable))
+    by (unfold_locales; (fact Finalise_AC_assms | solves \<open>wp only: Finalise_AC_assms; simp\<close>)?)
 qed
 
 
@@ -123,7 +129,7 @@ global_interpretation Finalise_AC_2?: Finalise_AC_2
 proof goal_cases
   interpret Arch .
   case 1 show ?case
-    by (unfold_locales; fact Finalise_AC_assms)
+    by (unfold_locales; (fact Finalise_AC_assms)?)
 qed
 
 end

--- a/proof/access-control/ARM/ArchInterrupt_AC.thy
+++ b/proof/access-control/ARM/ArchInterrupt_AC.thy
@@ -21,8 +21,7 @@ definition arch_authorised_irq_ctl_inv ::
        (pasSubject aag, Control, pasIRQAbs aag irq) \<in> pasPolicy aag"
 
 lemma arch_invoke_irq_control_pas_refined[Interrupt_AC_assms]:
-  "\<lbrace>pas_refined aag and pspace_aligned and valid_vspace_objs and valid_arch_state
-                    and valid_mdb and arch_irq_control_inv_valid irq_ctl_inv
+  "\<lbrace>pas_refined aag and valid_mdb and arch_irq_control_inv_valid irq_ctl_inv
                     and K (arch_authorised_irq_ctl_inv aag irq_ctl_inv)\<rbrace>
    arch_invoke_irq_control irq_ctl_inv
    \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"

--- a/proof/access-control/ARM/ArchIpc_AC.thy
+++ b/proof/access-control/ARM/ArchIpc_AC.thy
@@ -63,10 +63,6 @@ lemma tcb_context_no_change[Ipc_AC_assms]:
   apply (auto simp: arch_tcb_context_set_def)
   done
 
-lemma transfer_caps_loop_valid_arch[Ipc_AC_assms]:
-  "transfer_caps_loop ep buffer n caps slots mi \<lbrace>valid_arch_state :: det_ext state \<Rightarrow> _\<rbrace>"
-  by (wp valid_arch_state_lift_aobj_at_no_caps transfer_caps_loop_aobj_at)
-
 end
 
 
@@ -74,7 +70,7 @@ global_interpretation Ipc_AC_1?: Ipc_AC_1
 proof goal_cases
   interpret Arch .
   case 1 show ?case
-    by (unfold_locales; fact Ipc_AC_assms)
+    by (unfold_locales; (fact Ipc_AC_assms)?)
 qed
 
 

--- a/proof/access-control/ARM/ArchRetype_AC.thy
+++ b/proof/access-control/ARM/ArchRetype_AC.thy
@@ -437,7 +437,7 @@ global_interpretation Retype_AC_1?: Retype_AC_1
 proof goal_cases
   interpret Arch .
   case 1 show ?case
-    by (unfold_locales; (fact Retype_AC_assms | wpsimp))
+    by (unfold_locales; (fact Retype_AC_assms | solves \<open>wp only: Retype_AC_assms; simp\<close>)?)
 qed
 
 

--- a/proof/access-control/ARM/ArchSyscall_AC.thy
+++ b/proof/access-control/ARM/ArchSyscall_AC.thy
@@ -179,7 +179,7 @@ global_interpretation Syscall_AC_1?: Syscall_AC_1
 proof goal_cases
   interpret Arch .
   case 1 show ?case
-    by (unfold_locales; (fact Syscall_AC_assms)?)
+    by (unfold_locales; (fact Syscall_AC_assms | solves \<open>wp only: Syscall_AC_assms; simp\<close>)?)
 qed
 
 end

--- a/proof/access-control/ARM/ArchTcb_AC.thy
+++ b/proof/access-control/ARM/ArchTcb_AC.thy
@@ -100,7 +100,7 @@ global_interpretation Tcb_AC_1?: Tcb_AC_1
 proof goal_cases
   interpret Arch .
   case 1 show ?case
-    by (unfold_locales; fact Tcb_AC_assms)
+    by (unfold_locales; (fact Tcb_AC_assms)?)
 qed
 
 end

--- a/proof/access-control/Arch_AC.thy
+++ b/proof/access-control/Arch_AC.thy
@@ -68,9 +68,7 @@ lemma mapM_set'':
   done
 
 lemma as_user_state_vrefs:
-  "\<lbrace>pspace_aligned and valid_vspace_objs and valid_arch_state and (\<lambda>s. P (state_vrefs s))\<rbrace>
-   as_user t f
-   \<lbrace>\<lambda>_ s :: det_ext state. P (state_vrefs s)\<rbrace>"
+  "as_user t f \<lbrace>\<lambda>s :: det_ext state. P (state_vrefs s)\<rbrace>"
   apply (simp add: as_user_def)
   apply (wpsimp wp: set_object_wp)
   apply (clarsimp simp: state_vrefs_tcb_upd obj_at_def is_obj_defs
@@ -79,9 +77,7 @@ lemma as_user_state_vrefs:
   done
 
 lemma as_user_pas_refined[wp]:
-  "\<lbrace>pspace_aligned and valid_vspace_objs and valid_arch_state and pas_refined aag\<rbrace>
-   as_user t f
-   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
+  "as_user t f \<lbrace>pas_refined aag\<rbrace>"
   apply (simp add: pas_refined_def state_objs_to_policy_def)
   apply (rule hoare_pre)
    apply wps
@@ -151,9 +147,7 @@ lemma is_subject_asid_into_loas:
 
 locale Arch_AC_1 =
   assumes set_mrs_state_vrefs[wp]:
-    "\<lbrace>pspace_aligned and valid_vspace_objs and valid_arch_state and (\<lambda>s. P (state_vrefs s))\<rbrace>
-     set_mrs thread buf msgs
-     \<lbrace>\<lambda>_ s :: det_ext state. P (state_vrefs s)\<rbrace>"
+    "set_mrs thread buf msgs \<lbrace>\<lambda>s :: det_ext state. P (state_vrefs s)\<rbrace>"
   and mul_add_word_size_lt_msg_align_bits_ofnat:
   "\<lbrakk> p < 2 ^ (msg_align_bits - word_size_bits); k < word_size \<rbrakk>
      \<Longrightarrow> of_nat p * of_nat word_size + k < (2 :: obj_ref) ^ msg_align_bits"
@@ -196,9 +190,7 @@ lemma store_word_offs_integrity_autarch:
   done
 
 lemma set_mrs_pas_refined[wp]:
-  "\<lbrace>pspace_aligned and valid_vspace_objs and valid_arch_state and pas_refined aag\<rbrace>
-   set_mrs thread buf msgs
-   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
+  "set_mrs thread buf msgs \<lbrace>pas_refined aag\<rbrace>"
   apply (simp add: pas_refined_def state_objs_to_policy_def)
   apply (rule hoare_pre)
    apply (wp | wps)+

--- a/proof/access-control/CNode_AC.thy
+++ b/proof/access-control/CNode_AC.thy
@@ -9,7 +9,7 @@ imports ArchAccess_AC
 begin
 
 (* Note: exporting the following diverges from AInvs interfaces where valid_arch_state is
-   permitted to depend on caps (due to supporting x64). If x64 access control is to go ahead,
+   permitted to depend on caps (due to supporting X64). If X64 access control is to go ahead,
    these will need more careful management. *)
 arch_requalify_facts
   set_cap_valid_arch_state
@@ -67,18 +67,14 @@ locale CNode_AC_1 =
        state_asids_to_policy_arch aag caps (as :: arch_state) vrefs \<subseteq> pasPolicy aag \<rbrakk>
        \<Longrightarrow> state_asids_to_policy_arch aag (caps(ptr \<mapsto> cap, ptr' \<mapsto> cap')) as vrefs \<subseteq> pasPolicy aag"
   and state_vrefs_tcb_upd:
-    "\<lbrakk> pspace_aligned s; valid_vspace_objs s; valid_arch_state s; tcb_at tptr s \<rbrakk>
-       \<Longrightarrow> state_vrefs (s\<lparr>kheap := (kheap s)(tptr \<mapsto> TCB tcb)\<rparr>) = state_vrefs s"
+    "tcb_at tptr s \<Longrightarrow> state_vrefs (s\<lparr>kheap := (kheap s)(tptr \<mapsto> TCB tcb)\<rparr>) = state_vrefs s"
   and state_vrefs_simple_type_upd:
-    "\<lbrakk> pspace_aligned s; valid_vspace_objs s; valid_arch_state s;
-       ko_at ko p s; is_simple_type ko; a_type ko = a_type (f (val :: 'b)) \<rbrakk>
+    "\<lbrakk> ko_at ko p s; is_simple_type ko; a_type ko = a_type (f (val :: 'b)) \<rbrakk>
        \<Longrightarrow> state_vrefs (s\<lparr>kheap := (kheap s)(p \<mapsto> f val)\<rparr>) = state_vrefs s"
   and a_type_arch_object_not_tcb[simp]:
     "a_type (ArchObj arch_kernel_obj) \<noteq> ATCB"
   and set_cap_state_vrefs:
-    "\<And>P. \<lbrace>pspace_aligned and valid_vspace_objs and valid_arch_state and (\<lambda>s. P (state_vrefs s))\<rbrace>
-          set_cap cap slot
-          \<lbrace>\<lambda>_ s :: det_ext state. P (state_vrefs s)\<rbrace>"
+    "\<And>P. set_cap cap slot \<lbrace>\<lambda>s :: det_ext state. P (state_vrefs s)\<rbrace>"
   and set_cdt_state_vrefs[wp]:
     "\<And>P. set_cdt t \<lbrace>\<lambda>s :: det_ext state. P (state_vrefs s)\<rbrace>"
   and set_cdt_state_asids_to_policy[wp]:
@@ -308,7 +304,7 @@ lemma sita_caps_update2:
 context CNode_AC_1 begin
 
 lemma set_cap_pas_refined:
-  "\<lbrace>pas_refined aag and pspace_aligned and valid_vspace_objs and valid_arch_state and
+  "\<lbrace>pas_refined aag and
     (\<lambda>s. (is_transferable_in ptr s \<and> (\<not> Option.is_none (cdt s ptr)))
           \<longrightarrow> is_transferable_cap cap \<or>
               abs_has_auth_to aag Control (fst $ the $ cdt s ptr) (fst ptr)) and
@@ -330,8 +326,7 @@ lemma set_cap_pas_refined:
   done
 
 lemma set_cap_pas_refined_not_transferable:
-  "\<lbrace>pas_refined aag and pspace_aligned and valid_vspace_objs and valid_arch_state
-                    and cte_wp_at (\<lambda>c. \<not>is_transferable (Some c)) ptr
+  "\<lbrace>pas_refined aag and cte_wp_at (\<lambda>c. \<not>is_transferable (Some c)) ptr
                     and K (aag_cap_auth aag (pasObjectAbs aag (fst ptr)) cap)\<rbrace>
    set_cap cap ptr
    \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
@@ -1025,7 +1020,7 @@ locale CNode_AC_3 = CNode_AC_2 +
 begin
 
 lemma cap_insert_pas_refined:
-  "\<lbrace>pas_refined aag and pspace_aligned and valid_vspace_objs and valid_arch_state and valid_mdb and
+  "\<lbrace>pas_refined aag and valid_mdb and
     (\<lambda>s. (is_transferable_in src_slot s \<and> (\<not> Option.is_none (cdt s src_slot)))
          \<longrightarrow> is_transferable_cap new_cap) and
     K (is_subject aag (fst dest_slot) \<and> is_subject aag (fst src_slot)
@@ -1049,7 +1044,7 @@ lemma cap_insert_pas_refined:
                  dest: aag_cdt_link_Control aag_cdt_link_DeleteDerived cap_auth_caps_of_state)
 
 lemma cap_insert_pas_refined':
-  "\<lbrace>pas_refined aag and pspace_aligned and valid_vspace_objs and valid_arch_state and valid_mdb and
+  "\<lbrace>pas_refined aag and valid_mdb and
     (\<lambda>s. cte_wp_at is_transferable_cap src_slot s \<longrightarrow> is_transferable_cap new_cap) and
     K (is_subject aag (fst dest_slot) \<and> is_subject aag (fst src_slot)
                                       \<and> pas_cap_cur_auth aag new_cap) \<rbrace>
@@ -1060,7 +1055,7 @@ lemma cap_insert_pas_refined':
                 simp: cte_wp_at_caps_of_state Option.is_none_def)
 
 lemma cap_insert_pas_refined_not_transferable:
-  "\<lbrace>pas_refined aag and pspace_aligned and valid_vspace_objs and valid_arch_state and valid_mdb
+  "\<lbrace>pas_refined aag and valid_mdb
                     and not cte_wp_at is_transferable_cap src_slot
                     and K (is_subject aag (fst dest_slot) \<and> is_subject aag (fst src_slot)
                                                           \<and> pas_cap_cur_auth aag new_cap) \<rbrace>
@@ -1069,7 +1064,7 @@ lemma cap_insert_pas_refined_not_transferable:
    by (wpsimp wp: cap_insert_pas_refined')
 
 lemma cap_insert_pas_refined_same_object_as:
-  "\<lbrace>pas_refined aag and pspace_aligned and valid_vspace_objs and valid_arch_state and valid_mdb
+  "\<lbrace>pas_refined aag and valid_mdb
                     and cte_wp_at (same_object_as new_cap) src_slot
                     and K (is_subject aag (fst dest_slot) \<and> is_subject aag (fst src_slot) \<and>
                            (\<not> is_master_reply_cap new_cap) \<and> pas_cap_cur_auth aag new_cap)\<rbrace>
@@ -1081,8 +1076,7 @@ lemma cap_insert_pas_refined_same_object_as:
                 elim: is_transferable_capE split: cap.splits)
 
 lemma cap_move_pas_refined[wp]:
-  "\<lbrace>pas_refined aag and pspace_aligned and valid_vspace_objs and valid_arch_state
-                    and valid_mdb and cte_wp_at (weak_derived new_cap) src_slot
+  "\<lbrace>pas_refined aag and valid_mdb and cte_wp_at (weak_derived new_cap) src_slot
                     and cte_wp_at ((=) NullCap) dest_slot
                     and K (is_subject aag (fst dest_slot) \<and> is_subject aag (fst src_slot)
                                                           \<and> pas_cap_cur_auth aag new_cap)\<rbrace>
@@ -1099,14 +1093,8 @@ lemma cap_move_pas_refined[wp]:
                 dest: invs_mdb pas_refined_mem[OF sta_cdt]
                       pas_refined_mem[OF sta_cdt_transferable])
 
-crunch set_original, set_cdt
-  for pspace_aligned[wp]: pspace_aligned
-  and valid_vspace_objs[wp]: valid_vspace_objs
-  and valid_arch_state[wp]: valid_arch_state
-
 lemma empty_slot_pas_refined[wp, wp_not_transferable]:
-  "\<lbrace>pas_refined aag and pspace_aligned and valid_vspace_objs and valid_arch_state
-                    and valid_mdb and K (is_subject aag (fst slot))\<rbrace>
+  "\<lbrace>pas_refined aag and valid_mdb and K (is_subject aag (fst slot))\<rbrace>
    empty_slot slot irqopt
    \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   apply (simp add: empty_slot_def post_cap_deletion_def)
@@ -1119,8 +1107,7 @@ lemma empty_slot_pas_refined[wp, wp_not_transferable]:
 
 
 lemma empty_slot_pas_refined_transferable[wp_transferable]:
-  "\<lbrace>pas_refined aag and pspace_aligned and valid_vspace_objs and valid_arch_state
-                    and valid_mdb and (\<lambda>s. is_transferable (caps_of_state s slot))\<rbrace>
+  "\<lbrace>pas_refined aag and valid_mdb and (\<lambda>s. is_transferable (caps_of_state s slot))\<rbrace>
    empty_slot slot irqopt
    \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   apply (simp add: empty_slot_def post_cap_deletion_def)
@@ -1177,8 +1164,8 @@ lemma cap_swap_pas_refined[wp]:
      apply (simp split: if_splits add: aag_wellformed_refl)
      by (erule subsetD;
          force simp: is_transferable_weak_derived intro!: sbta_cdt_transferable auth_graph_map_memI)+
-         apply (blast intro: state_bits_to_policy.intros auth_graph_map_memI)
-   by fastforce+
+  apply (blast intro: state_bits_to_policy.intros auth_graph_map_memI)
+  done
 
 lemma cap_swap_for_delete_pas_refined[wp]:
   "\<lbrace>pas_refined aag and invs and K (is_subject aag (fst slot) \<and> is_subject aag (fst slot'))\<rbrace>
@@ -1305,9 +1292,7 @@ lemma set_simple_ko_ekheap[wp]:
 context CNode_AC_3 begin
 
 lemma sts_st_vrefs[wp]:
-  "\<lbrace>pspace_aligned and valid_vspace_objs and valid_arch_state and (\<lambda>s. P (state_vrefs s))\<rbrace>
-   set_thread_state t st
-   \<lbrace>\<lambda>_ s :: det_ext state. P (state_vrefs s)\<rbrace>"
+  "set_thread_state t st \<lbrace>\<lambda>s :: det_ext state. P (state_vrefs s)\<rbrace>"
   apply (simp add: set_thread_state_def del: set_thread_state_ext_extended.dxo_eq)
   apply (wpsimp wp: set_object_wp dxo_wp_weak)
   apply (clarsimp simp: state_vrefs_tcb_upd obj_at_def is_obj_defs
@@ -1316,8 +1301,7 @@ lemma sts_st_vrefs[wp]:
   done
 
 lemma set_thread_state_pas_refined:
-  "\<lbrace>pas_refined aag and pspace_aligned and valid_vspace_objs and valid_arch_state and
-    K (\<forall>r \<in> tcb_st_to_auth st. abs_has_auth_to aag (snd r) t (fst r))\<rbrace>
+  "\<lbrace>pas_refined aag and K (\<forall>r \<in> tcb_st_to_auth st. abs_has_auth_to aag (snd r) t (fst r))\<rbrace>
    set_thread_state t st
    \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   apply (simp add: pas_refined_def state_objs_to_policy_def)
@@ -1330,17 +1314,14 @@ lemma set_thread_state_pas_refined:
   done
 
 lemma set_simple_ko_vrefs[wp]:
-  "\<lbrace>pspace_aligned and valid_vspace_objs and valid_arch_state and (\<lambda>s. P (state_vrefs s))\<rbrace>
-   set_simple_ko f ptr (val :: 'b)
-   \<lbrace>\<lambda>_ s :: det_ext state. P (state_vrefs s)\<rbrace>"
+  "set_simple_ko f ptr (val :: 'b) \<lbrace>\<lambda>s :: det_ext state. P (state_vrefs s)\<rbrace>"
   apply (simp add: set_simple_ko_def set_object_def)
   apply (wp get_object_wp)
   apply (fastforce simp: state_vrefs_simple_type_upd obj_at_def elim!: rsubst[where P=P, OF _ ext])
   done
 
 lemma set_simple_ko_pas_refined[wp]:
-  "\<lbrace>pas_refined aag and pspace_aligned and valid_vspace_objs and valid_arch_state\<rbrace>
-    set_simple_ko f ptr (ep :: 'b) \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
+  "set_simple_ko f ptr (ep :: 'b) \<lbrace>pas_refined aag\<rbrace>"
   apply (simp add: pas_refined_def state_objs_to_policy_def)
   apply (rule hoare_pre)
    apply (wp tcb_domain_map_wellformed_lift | wps)+
@@ -1348,9 +1329,7 @@ lemma set_simple_ko_pas_refined[wp]:
   done
 
 lemma thread_set_state_vrefs:
-  "\<lbrace>pspace_aligned and valid_vspace_objs and valid_arch_state and (\<lambda>s. P (state_vrefs s))\<rbrace>
-   thread_set f t
-   \<lbrace>\<lambda>_ s :: det_ext state. P (state_vrefs s)\<rbrace>"
+  "thread_set f t \<lbrace>\<lambda>s :: det_ext state. P (state_vrefs s)\<rbrace>"
   apply (simp add: thread_set_def)
   apply (wpsimp wp: set_object_wp)
   apply (clarsimp simp: state_vrefs_tcb_upd obj_at_def is_obj_defs
@@ -1387,8 +1366,7 @@ lemma thread_set_pas_refined_triv:
   assumes cps: "\<And>tcb. \<forall>(getF, v)\<in>ran tcb_cap_cases. getF (f tcb) = getF tcb"
        and st: "\<And>tcb. tcb_state (f tcb) = tcb_state tcb"
       and ntfn: "\<And>tcb. tcb_bound_notification (f tcb) = tcb_bound_notification tcb"
-     shows "\<lbrace>pas_refined aag and pspace_aligned and valid_vspace_objs and valid_arch_state\<rbrace>
-            thread_set f t \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
+     shows "thread_set f t \<lbrace>pas_refined aag\<rbrace>"
   by (wpsimp wp: tcb_domain_map_wellformed_lift thread_set_state_vrefs
            simp: pas_refined_def state_objs_to_policy_def
       | wps thread_set_caps_of_state_trivial[OF cps]

--- a/proof/access-control/Finalise_AC.thy
+++ b/proof/access-control/Finalise_AC.thy
@@ -23,9 +23,7 @@ NB: the @{term is_subject} assumption is not appropriate for some of
 locale Finalise_AC_1 =
   fixes aag :: "'a PAS"
   assumes sbn_st_vrefs:
-    "\<And>P. \<lbrace>(\<lambda>s.  P (state_vrefs s)) and pspace_aligned and valid_vspace_objs and valid_arch_state\<rbrace>
-          set_bound_notification ref ntfn
-          \<lbrace>\<lambda>_ s :: det_ext state. P (state_vrefs s)\<rbrace>"
+    "\<And>P. set_bound_notification ref ntfn \<lbrace>\<lambda>s :: det_ext state. P (state_vrefs s)\<rbrace>"
   and arch_finalise_cap_auth':
     "\<lbrace>pas_refined aag\<rbrace> arch_finalise_cap acap final \<lbrace>\<lambda>rv _. pas_cap_cur_auth aag (fst rv)\<rbrace>"
   and arch_finalise_cap_obj_refs:
@@ -47,13 +45,13 @@ locale Finalise_AC_1 =
      \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   and prepare_thread_delete_pas_refined[wp]:
     "prepare_thread_delete p \<lbrace>pas_refined aag\<rbrace>"
-  and prepare_thread_delete_respects[wp]:
-    "prepare_thread_delete p \<lbrace>integrity aag X st\<rbrace>"
+  and prepare_thread_delete_integrity_autarch[wp]:
+    "\<lbrace>integrity aag X st and K (is_subject aag p)\<rbrace> prepare_thread_delete p \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   and finalise_cap_replaceable:
     "\<lbrace>\<lambda>s :: det_ext state. s \<turnstile> cap \<and> x = is_final_cap' cap s \<and> valid_mdb s \<and>
                            cte_wp_at ((=) cap) sl s \<and> valid_objs s \<and> sym_refs (state_refs_of s) \<and>
                            (cap_irqs cap \<noteq> {} \<longrightarrow> if_unsafe_then_cap s \<and> valid_global_refs s) \<and>
-                           (is_arch_cap cap \<longrightarrow> pspace_aligned s \<and> valid_vspace_objs s \<and>
+                           (is_arch_cap cap \<longrightarrow> pspace_aligned s \<and> pspace_distinct s \<and> valid_vspace_objs s \<and>
                                                 valid_arch_state s \<and> valid_arch_caps s)\<rbrace>
      finalise_cap cap x
      \<lbrace>\<lambda>rv s. replaceable s sl (fst rv) cap\<rbrace>"
@@ -62,12 +60,6 @@ locale Finalise_AC_1 =
                                   and K (pas_cap_cur_auth aag (ArchObjectCap acap))\<rbrace>
      arch_finalise_cap acap final
      \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
-  and arch_post_cap_deletion[wp]:
-    "arch_post_cap_deletion acap \<lbrace>\<lambda>s :: det_ext state. pspace_aligned s\<rbrace>"
-  and arch_post_cap_deletion_valid_vspace_objs[wp]:
-    "arch_post_cap_deletion acap \<lbrace>\<lambda>s :: det_ext state. valid_vspace_objs s\<rbrace>"
-  and arch_post_cap_deletion_valid_arch_state[wp]:
-    "arch_post_cap_deletion acap \<lbrace>\<lambda>s :: det_ext state. valid_arch_state s\<rbrace>"
 begin
 
 lemma tcb_sched_action_dequeue_integrity':
@@ -250,7 +242,7 @@ crunch fast_finalise
 context Finalise_AC_1 begin
 
 lemma sbn_pas_refined[wp]:
-  "\<lbrace>pas_refined aag and pspace_aligned and valid_vspace_objs and valid_arch_state and
+  "\<lbrace>pas_refined aag and
     K (case ntfn of None \<Rightarrow> True
                   | Some ntfn' \<Rightarrow> \<forall>auth \<in> {Receive, Reset}. abs_has_auth_to aag auth t ntfn')\<rbrace>
    set_bound_notification t ntfn
@@ -264,51 +256,28 @@ lemma sbn_pas_refined[wp]:
            split: if_split_asm)
 
 lemma unbind_notification_pas_refined[wp]:
-  "\<lbrace>pas_refined aag and pspace_aligned and valid_vspace_objs and valid_arch_state\<rbrace>
-   unbind_notification tptr
-   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
+  "unbind_notification tptr \<lbrace>pas_refined aag\<rbrace>"
   apply (clarsimp simp: unbind_notification_def)
   apply (wp set_simple_ko_pas_refined hoare_drop_imps | wpc | simp)+
   done
 
 lemma unbind_maybe_notification_pas_refined[wp]:
-  "\<lbrace>pas_refined aag and pspace_aligned and valid_vspace_objs and valid_arch_state\<rbrace>
-   unbind_maybe_notification nptr \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
+  "unbind_maybe_notification nptr \<lbrace>pas_refined aag\<rbrace>"
   apply (clarsimp simp: unbind_maybe_notification_def)
   apply (wp set_simple_ko_pas_refined hoare_drop_imps | wpc | simp)+
   done
 
 lemma cancel_all_ipc_pas_refined[wp]:
-  "\<lbrace>pas_refined aag and pspace_aligned and valid_vspace_objs and valid_arch_state\<rbrace>
-   cancel_all_ipc epptr
-   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
+  "cancel_all_ipc epptr \<lbrace>pas_refined aag\<rbrace>"
   apply (clarsimp simp: cancel_all_ipc_def get_ep_queue_def cong: endpoint.case_cong)
-  apply (rule_tac Q'="\<lambda>_. pas_refined aag and pspace_aligned
-                                         and valid_vspace_objs
-                                         and valid_arch_state"
-               in hoare_strengthen_post)
-   apply (wpsimp wp: mapM_x_wp_inv set_thread_state_pas_refined get_simple_ko_wp)+
+  apply (wpsimp wp: mapM_x_wp_inv set_thread_state_pas_refined get_simple_ko_wp)+
   done
 
 lemma cancel_all_signals_pas_refined[wp]:
-  "\<lbrace>pas_refined aag and pspace_aligned and valid_vspace_objs and
-     valid_arch_state\<rbrace>
-   cancel_all_signals ntfnptr
-   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
+  "cancel_all_signals ntfnptr \<lbrace>pas_refined aag\<rbrace>"
   apply (clarsimp simp: cancel_all_signals_def cong: ntfn.case_cong)
-  apply (rule_tac Q'="\<lambda>_. pas_refined aag and pspace_aligned
-                                         and valid_vspace_objs
-                                         and valid_arch_state"
-               in hoare_strengthen_post)
-   apply (wpsimp wp: mapM_x_wp_inv set_thread_state_pas_refined get_simple_ko_wp)+
+  apply (wpsimp wp: mapM_x_wp_inv set_thread_state_pas_refined get_simple_ko_wp)+
   done
-
-crunch unbind_maybe_notification, cancel_all_ipc, cancel_all_signals,
-         fast_finalise, blocked_cancel_ipc, cap_move
-  for pspace_aligned[wp]: pspace_aligned
-  and valid_vspace_objs[wp]: valid_vspace_objs
-  and valid_arch_state[wp]: valid_arch_state
-  (ignore: cap_move_ext tcb_sched_action reschedule_required wp: dxo_wp_weak mapM_x_inv_wp)
 
 crunch cap_delete_one
   for pas_refined_transferable[wp_transferable]: "pas_refined aag"
@@ -367,12 +336,6 @@ lemma deleting_irq_handler_pas_refined[wp]:
   apply wp
   apply (fastforce simp: pas_refined_def irq_map_wellformed_aux_def)
   done
-
-crunch suspend
-  for pspace_aligned[wp]: "\<lambda>s :: det_ext state. pspace_aligned s"
-  and valid_vspace_objs[wp]: "\<lambda>s :: det_ext state. valid_vspace_objs s"
-  and valid_arch_state[wp]: "\<lambda>s :: det_ext state. valid_arch_state s"
-  (wp: dxo_wp_weak hoare_drop_imps simp: crunch_simps simp: tcb_cap_cases_def)
 
 crunch suspend
   for pas_refined[wp]: "pas_refined aag"
@@ -541,7 +504,6 @@ lemma reply_cancel_ipc_respects[wp]:
                       thread_set_not_state_valid_sched hoare_weak_lift_imp thread_set_cte_wp_at_trivial
                       thread_set_pas_refined
                 simp: ran_tcb_cap_cases)+
-  apply (strengthen invs_psp_aligned invs_vspace_objs invs_arch_state, clarsimp)
   apply (rule conjI)
    apply (fastforce simp: cte_wp_at_caps_of_state intro:is_transferable.intros
                    dest!: reply_cap_descends_from_master0)
@@ -594,7 +556,6 @@ lemma suspend_respects[wp]:
     apply (rule hoare_conjI)
      apply (wp hoare_drop_imps)+
     apply wpsimp+
-  apply fastforce
   done
 
 end
@@ -997,9 +958,7 @@ lemma set_eobject_integrity_autarch:
   done
 
 lemma cancel_badged_sends_pas_refined[wp]:
-  "\<lbrace>pas_refined aag and pspace_aligned and valid_vspace_objs and valid_arch_state\<rbrace>
-   cancel_badged_sends epptr badge
-   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
+  "cancel_badged_sends epptr badge \<lbrace>pas_refined aag\<rbrace>"
   unfolding cancel_badged_sends_def
   by (wpsimp simp: filterM_mapM wp: mapM_wp_inv set_thread_state_pas_refined get_simple_ko_wp)
 
@@ -1015,8 +974,7 @@ lemma thread_set_pas_refined_triv_idleT:
   and st: "\<And>tcb. P (tcb_state tcb) \<longrightarrow> tcb_state (f tcb) = tcb_state tcb"
   and ba: "\<And>tcb. Q (tcb_bound_notification tcb)
                   \<longrightarrow> tcb_bound_notification (f tcb) = tcb_bound_notification tcb"
-  shows "\<lbrace>pas_refined aag and pspace_aligned and valid_vspace_objs and valid_arch_state
-                          and idle_tcb_at (\<lambda>(st, ntfn, arch). P st \<and> Q ntfn \<and> R arch) t\<rbrace>
+  shows "\<lbrace>pas_refined aag and idle_tcb_at (\<lambda>(st, ntfn, arch). P st \<and> Q ntfn \<and> R arch) t\<rbrace>
          thread_set f t
          \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   apply (simp add: pas_refined_def state_objs_to_policy_def)
@@ -1026,10 +984,7 @@ lemma thread_set_pas_refined_triv_idleT:
    apply (wpsimp wp: set_object_wp)
   apply (clarsimp simp: pred_tcb_def2 fun_upd_def[symmetric]
                    del: subsetI)
-  apply (subst state_vrefs_tcb_upd, fastforce+)
-   apply (clarsimp simp: tcb_at_def)
-  apply (subst state_vrefs_tcb_upd, fastforce+)
-   apply (clarsimp simp: tcb_at_def)
+  apply (subst state_vrefs_tcb_upd, clarsimp simp: tcb_at_def)+
   apply (rule conjI)
    apply (erule_tac P="\<lambda> ts ba. auth_graph_map a (state_bits_to_policy cps ts ba cd vr) \<subseteq> ag"
                 for a cps cd vr ag in rsubst')

--- a/proof/access-control/Interrupt_AC.thy
+++ b/proof/access-control/Interrupt_AC.thy
@@ -30,8 +30,7 @@ lemma pas_refined_is_subject_irqD:
 locale Interrupt_AC_1 =
   fixes arch_authorised_irq_ctl_inv :: "'a PAS \<Rightarrow> arch_irq_control_invocation \<Rightarrow> bool"
   assumes arch_invoke_irq_control_pas_refined:
-    "\<lbrace>pas_refined (aag :: 'a PAS) and pspace_aligned and valid_vspace_objs and valid_arch_state
-                                  and valid_mdb and arch_irq_control_inv_valid irq_ctl_inv
+    "\<lbrace>pas_refined (aag :: 'a PAS) and valid_mdb and arch_irq_control_inv_valid irq_ctl_inv
                                   and K (arch_authorised_irq_ctl_inv aag irq_ctl_inv)\<rbrace>
      arch_invoke_irq_control irq_ctl_inv
      \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
@@ -59,8 +58,7 @@ definition authorised_irq_ctl_inv :: "'a PAS \<Rightarrow> Invocations_A.irq_con
      | ArchIRQControl acinv \<Rightarrow> arch_authorised_irq_ctl_inv aag acinv"
 
 lemma invoke_irq_control_pas_refined:
-  "\<lbrace>pas_refined aag and pspace_aligned and valid_vspace_objs and valid_arch_state
-                    and valid_mdb and irq_control_inv_valid irq_ctl_inv
+  "\<lbrace>pas_refined aag and valid_mdb and irq_control_inv_valid irq_ctl_inv
                     and K (authorised_irq_ctl_inv aag irq_ctl_inv)\<rbrace>
    invoke_irq_control irq_ctl_inv
    \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"

--- a/proof/access-control/RISCV64/ArchADT_AC.thy
+++ b/proof/access-control/RISCV64/ArchADT_AC.thy
@@ -118,7 +118,7 @@ global_interpretation ADT_AC_1?: ADT_AC_1
 proof goal_cases
   interpret Arch .
   case 1 show ?case
-    by (unfold_locales; fact ADT_AC_assms)
+    by (unfold_locales; (fact ADT_AC_assms)?)
 qed
 
 end

--- a/proof/access-control/RISCV64/ArchAccess_AC.thy
+++ b/proof/access-control/RISCV64/ArchAccess_AC.thy
@@ -55,7 +55,7 @@ global_interpretation Access_AC_1?: Access_AC_1
 proof goal_cases
   interpret Arch .
   case 1 show ?case
-    by (unfold_locales; fact Access_AC_assms)
+    by (unfold_locales; (fact Access_AC_assms)?)
 qed
 
 
@@ -159,7 +159,7 @@ global_interpretation Access_AC_3?: Access_AC_3
 proof goal_cases
   interpret Arch .
   case 1 show ?case
-    by (unfold_locales; fact Access_AC_assms)
+    by (unfold_locales; (fact Access_AC_assms)?)
 qed
 
 

--- a/proof/access-control/RISCV64/ArchArch_AC.thy
+++ b/proof/access-control/RISCV64/ArchArch_AC.thy
@@ -19,20 +19,13 @@ context Arch begin global_naming RISCV64
 named_theorems Arch_AC_assms
 
 lemma set_mrs_state_vrefs[Arch_AC_assms, wp]:
-  "\<lbrace>pspace_aligned and valid_vspace_objs and valid_arch_state and (\<lambda>s. P (state_vrefs s))\<rbrace>
-   set_mrs thread buf msgs
-   \<lbrace>\<lambda>_ s. P (state_vrefs s)\<rbrace>"
+  "set_mrs thread buf msgs \<lbrace>\<lambda>s. P (state_vrefs s)\<rbrace>"
   apply (simp add: set_mrs_def split_def set_object_def get_object_def split del: if_split)
   apply (wpsimp wp: gets_the_wp get_wp put_wp mapM_x_wp'
               simp: zipWithM_x_mapM_x split_def store_word_offs_def
          split_del: if_split)
-  apply (subst state_vrefs_eqI)
-        prefer 7
-        apply assumption
-       apply (clarsimp simp: opt_map_def)
-      apply (fastforce simp: opt_map_def aobj_of_def)
-     apply clarsimp
-    apply (auto simp: valid_arch_state_def)
+  apply (subst (asm) state_vrefs_tcb_upd[symmetric])
+   apply (auto simp: fun_upd_def get_tcb_def tcb_at_def)
   done
 
 lemma mul_add_word_size_lt_msg_align_bits_ofnat[Arch_AC_assms]:
@@ -55,7 +48,7 @@ global_interpretation Arch_AC_1?: Arch_AC_1
 proof goal_cases
   interpret Arch .
   case 1 show ?case
-    by (unfold_locales; fact Arch_AC_assms)
+    by (unfold_locales; (fact Arch_AC_assms)?)
 qed
 
 
@@ -503,11 +496,9 @@ lemma perform_pt_inv_unmap_pas_refined:
   \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   unfolding perform_pt_inv_unmap_def
   apply (wpsimp wp: set_cap_pas_refined get_cap_wp)
-       apply (strengthen invs_psp_aligned invs_vspace_objs invs_arch_state)
        apply wps
        apply (rule hoare_vcg_all_lift[OF hoare_vcg_imp_lift'[OF mapM_x_wp_inv]], wpsimp wp: mapM_x_wp_inv)
        apply (rule hoare_vcg_conj_lift[OF hoare_strengthen_post[OF mapM_x_swp_store_InvalidPTE_pas_refined]], assumption)
-       apply (rule hoare_vcg_conj_lift[OF hoare_strengthen_post[OF mapM_x_swp_store_pte_invs_unmap]], assumption)
        apply (wpsimp wp: pt_lookup_from_level_wrp store_pte_invs_unmap store_pte_pas_refined
                          mapM_x_wp_inv unmap_page_table_pas_refined
                          hoare_vcg_imp_lift' hoare_vcg_ball_lift hoare_vcg_all_lift)+

--- a/proof/access-control/RISCV64/ArchCNode_AC.thy
+++ b/proof/access-control/RISCV64/ArchCNode_AC.thy
@@ -56,29 +56,28 @@ lemma sata_update2[CNode_AC_assms]:
                  simp: cap_links_asid_slot_def label_owns_asid_slot_def
                 split: if_split_asm)
 
+lemma vs_lookup_table_eqI':
+  "\<lbrakk> asid_table s' (asid_high_bits_of asid) = asid_table s (asid_high_bits_of asid);
+     \<forall>pool_ptr. asid_table s' (asid_high_bits_of asid) = Some pool_ptr
+                \<longrightarrow> bot_level \<le> max_pt_level
+                \<longrightarrow> vspace_for_pool pool_ptr asid (asid_pools_of s') =
+                    vspace_for_pool pool_ptr asid (asid_pools_of s);
+     bot_level < max_pt_level \<longrightarrow> pts_of s' = pts_of s \<rbrakk>
+     \<Longrightarrow> vs_lookup_table bot_level asid vref s' = vs_lookup_table bot_level asid vref s"
+  by (auto simp: obind_def vs_lookup_table_def asid_pool_level_eq[symmetric]
+                 pool_for_asid_def vspace_for_pool_def
+          split: option.splits)
+
 lemma state_vrefs_eqI:
-  "\<lbrakk> \<forall>bot_level asid vref level p.
-       bot_level < level \<and> vs_lookup_table level asid vref s = Some (level, p)
-       \<longrightarrow> (if level \<le> max_pt_level
-            then pts_of s' p = pts_of s p
-            else asid_pools_of s' p = asid_pools_of s p);
-     aobjs_of s' = aobjs_of s; asid_table s' = asid_table s;
-     pspace_aligned s; valid_vspace_objs s; valid_asid_table s \<rbrakk>
-     \<Longrightarrow> state_vrefs (s' :: 'a :: state_ext state) = state_vrefs (s :: 'a :: state_ext state)"
-  apply (rule ext)
-  apply safe
-   apply (subst (asm) state_vrefs_def, clarsimp)
-   apply (fastforce intro: state_vrefsD elim: subst[OF vs_lookup_table_eqI,rotated -1])
-  apply (subst (asm) state_vrefs_def, clarsimp)
-  apply (rule state_vrefsD)
-     apply (subst vs_lookup_table_eqI; fastforce)
-    apply fastforce+
-  done
+  assumes "asid_table s' = asid_table s"
+  and "aobjs_of s' = aobjs_of s"
+  shows "state_vrefs s' = state_vrefs s"
+  apply (prop_tac "\<forall>level asid vref. vs_lookup_table level asid vref s = vs_lookup_table level asid vref s'")
+   apply (intro allI vs_lookup_table_eqI')
+  using assms by (auto simp: vspace_for_pool_def state_vrefs_def)
 
 lemma set_cap_state_vrefs[CNode_AC_assms, wp]:
-  "\<lbrace>pspace_aligned and valid_vspace_objs and valid_arch_state and (\<lambda>s. P (state_vrefs s))\<rbrace>
-   set_cap cap slot
-   \<lbrace>\<lambda>_ s :: det_ext state. P (state_vrefs s)\<rbrace>"
+  "set_cap cap slot \<lbrace>\<lambda>s :: det_ext state. P (state_vrefs s)\<rbrace>"
   apply (simp add: set_cap_def set_object_def)
   apply (wpsimp wp: get_object_wp)
   apply safe
@@ -100,14 +99,12 @@ crunch prepare_thread_delete, arch_finalise_cap
   (wp: crunch_wps hoare_vcg_if_lift2 simp: unless_def)
 
 lemma state_vrefs_tcb_upd[CNode_AC_assms]:
-  "\<lbrakk> pspace_aligned s; valid_vspace_objs s; valid_arch_state s; tcb_at t s \<rbrakk>
-     \<Longrightarrow> state_vrefs (s\<lparr>kheap := (kheap s)(t \<mapsto> TCB tcb)\<rparr>) = state_vrefs s"
+  "tcb_at t s \<Longrightarrow> state_vrefs (s\<lparr>kheap := (kheap s)(t \<mapsto> TCB tcb)\<rparr>) = state_vrefs s"
   apply (rule state_vrefs_eqI)
   by (fastforce simp: opt_map_def obj_at_def is_obj_defs valid_arch_state_def)+
 
 lemma state_vrefs_simple_type_upd[CNode_AC_assms]:
-  "\<lbrakk> pspace_aligned s; valid_vspace_objs s; valid_arch_state s;
-     ko_at ko ptr s; is_simple_type ko; a_type ko = a_type (f val) \<rbrakk>
+  "\<lbrakk> ko_at ko ptr s; is_simple_type ko; a_type ko = a_type (f val) \<rbrakk>
      \<Longrightarrow> state_vrefs (s\<lparr>kheap := (kheap s)(ptr \<mapsto> f val)\<rparr>) = state_vrefs s"
   apply (case_tac ko; case_tac "f val"; clarsimp)
   by (fastforce intro!: state_vrefs_eqI simp: opt_map_def obj_at_def is_obj_defs valid_arch_state_def)+
@@ -154,7 +151,7 @@ global_interpretation CNode_AC_1?: CNode_AC_1
 proof goal_cases
   interpret Arch .
   case 1 show ?case
-    by (unfold_locales; fact CNode_AC_assms)
+    by (unfold_locales; (fact CNode_AC_assms)?)
 qed
 
 
@@ -181,7 +178,7 @@ global_interpretation CNode_AC_2?: CNode_AC_2
 proof goal_cases
   interpret Arch .
   case 1 show ?case
-    by (unfold_locales; fact CNode_AC_assms)
+    by (unfold_locales; (fact CNode_AC_assms)?)
 qed
 
 
@@ -219,7 +216,7 @@ global_interpretation CNode_AC_3?: CNode_AC_3
 proof goal_cases
   interpret Arch .
   case 1 show ?case
-    by (unfold_locales; fact CNode_AC_assms)
+    by (unfold_locales; (fact CNode_AC_assms)?)
 qed
 
 

--- a/proof/access-control/RISCV64/ArchDomainSepInv.thy
+++ b/proof/access-control/RISCV64/ArchDomainSepInv.thy
@@ -25,19 +25,6 @@ lemma arch_finalise_cap_rv[DomainSepInv_assms]:
   "\<lbrace>\<lambda>_. P (NullCap,NullCap)\<rbrace> arch_finalise_cap c x \<lbrace>\<lambda>rv _. P rv\<rbrace>"
   unfolding arch_finalise_cap_def by wpsimp
 
-end
-
-
-global_interpretation DomainSepInv_1?: DomainSepInv_1
-proof goal_cases
-  interpret Arch .
-  case 1 show ?case
-    by (unfold_locales; (fact DomainSepInv_assms | wp init_arch_objects_inv))
-qed
-
-
-context Arch begin global_naming RISCV64
-
 crunch
   handle_reserved_irq, handle_vm_fault, perform_pg_inv_map, perform_pg_inv_unmap,
   perform_pg_inv_get_addr, perform_pt_inv_map, perform_pt_inv_unmap,
@@ -46,6 +33,30 @@ crunch
   store_asid_pool_entry, copy_global_mappings
   for domain_sep_inv[DomainSepInv_assms, wp]: "domain_sep_inv irqs st"
   (wp: crunch_wps)
+
+lemma arch_derive_cap_domain_sep_inv[DomainSepInv_assms, wp]:
+  "\<lbrace>\<top>\<rbrace> arch_derive_cap acap \<lbrace>\<lambda>rv _. domain_sep_inv_cap irqs rv\<rbrace>,-"
+  unfolding arch_derive_cap_def
+  by wpsimp
+
+lemma arch_post_modify_registers_domain_sep_inv[DomainSepInv_assms, wp]:
+  "arch_post_modify_registers cur t \<lbrace>domain_sep_inv irqs st\<rbrace>"
+  unfolding arch_post_modify_registers_def by wpsimp
+
+declare init_arch_objects_inv[DomainSepInv_assms]
+
+end
+
+
+global_interpretation DomainSepInv_1?: DomainSepInv_1
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case
+    by (unfold_locales; (fact DomainSepInv_assms)?)
+qed
+
+
+context Arch begin global_naming RISCV64
 
 lemma perform_page_invocation_domain_sep_inv:
   "\<lbrace>domain_sep_inv irqs st and valid_page_inv pgi\<rbrace>
@@ -112,15 +123,6 @@ lemma arch_invoke_irq_control_domain_sep_inv[DomainSepInv_assms]:
    apply (wpsimp wp: do_machine_op_domain_sep_inv simp: arch_irq_control_inv_valid_def)+
   done
 
-lemma arch_derive_cap_domain_sep_inv[DomainSepInv_assms, wp]:
-  "\<lbrace>\<top>\<rbrace> arch_derive_cap acap \<lbrace>\<lambda>rv _. domain_sep_inv_cap irqs rv\<rbrace>,-"
-  unfolding arch_derive_cap_def
-  by wpsimp
-
-lemma arch_post_modify_registers_domain_sep_inv[DomainSepInv_assms, wp]:
-  "arch_post_modify_registers cur t \<lbrace>domain_sep_inv irqs st\<rbrace>"
-  unfolding arch_post_modify_registers_def by wpsimp
-
 end
 
 
@@ -128,7 +130,7 @@ global_interpretation DomainSepInv_2?: DomainSepInv_2
 proof goal_cases
   interpret Arch .
   case 1 show ?case
-    by (unfold_locales; fact DomainSepInv_assms)
+    by (unfold_locales; (fact DomainSepInv_assms | solves \<open>wp only: DomainSepInv_assms; simp\<close>)?)
 qed
 
 end

--- a/proof/access-control/RISCV64/ArchFinalise_AC.thy
+++ b/proof/access-control/RISCV64/ArchFinalise_AC.thy
@@ -111,9 +111,7 @@ crunch prepare_thread_delete
   for respects[Finalise_AC_assms, wp]: "integrity aag X st"
 
 lemma sbn_st_vrefs[Finalise_AC_assms]:
-  "\<lbrace>(\<lambda>s. P (state_vrefs s)) and pspace_aligned and valid_vspace_objs and valid_arch_state\<rbrace>
-   set_bound_notification t st
-   \<lbrace>\<lambda>_ s. P (state_vrefs s)\<rbrace>"
+  "set_bound_notification t st \<lbrace>\<lambda>s. P (state_vrefs s)\<rbrace>"
   apply (simp add: set_bound_notification_def)
   apply (wpsimp wp: set_object_wp dxo_wp_weak)
   apply (subst state_vrefs_tcb_upd)
@@ -216,7 +214,7 @@ lemma delete_asid_respects:
   apply (clarsimp simp: pas_refined_refl obj_at_def asid_pool_integrity_def)
   done
 
-lemma arch_finalise_cap_respects[wp]:
+lemma arch_finalise_cap_respects[Finalise_AC_assms, wp]:
   "\<lbrace>integrity aag X st and invs and pas_refined aag and valid_cap (ArchObjectCap cap)
                        and K (pas_cap_cur_auth aag (ArchObjectCap cap))\<rbrace>
    arch_finalise_cap cap final
@@ -229,10 +227,11 @@ lemma arch_finalise_cap_respects[wp]:
              intro: pas_refined_Control_into_is_subject_asid)
   done
 
-crunch arch_post_cap_deletion
-  for pspace_aligned[Finalise_AC_assms, wp]: "\<lambda>s :: det_ext state. pspace_aligned s"
-  and valid_vspace_objs[Finalise_AC_assms, wp]: "\<lambda>s :: det_ext state. valid_vspace_objs s"
-  and valid_arch_state[Finalise_AC_assms, wp]: "\<lambda>s :: det_ext state. valid_arch_state s"
+declare prepare_thread_delete_st_tcb_at_halted[Finalise_AC_assms]
+declare finalise_cap_valid_list[Finalise_AC_assms]
+declare arch_finalise_cap_pas_refined[Finalise_AC_assms]
+declare prepare_thread_delete_pas_refined[Finalise_AC_assms]
+declare finalise_cap_replaceable[Finalise_AC_assms]
 
 end
 
@@ -241,7 +240,7 @@ global_interpretation Finalise_AC_1?: Finalise_AC_1
 proof goal_cases
   interpret Arch .
   case 1 show ?case
-    by (unfold_locales; (fact Finalise_AC_assms | wp finalise_cap_replaceable))
+    by (unfold_locales; (fact Finalise_AC_assms | solves \<open>wp only: Finalise_AC_assms; simp\<close>)?)
 qed
 
 
@@ -296,7 +295,7 @@ global_interpretation Finalise_AC_2?: Finalise_AC_2
 proof goal_cases
   interpret Arch .
   case 1 show ?case
-    by (unfold_locales; fact Finalise_AC_assms)
+    by (unfold_locales; (fact Finalise_AC_assms)?)
 qed
 
 end

--- a/proof/access-control/RISCV64/ArchInterrupt_AC.thy
+++ b/proof/access-control/RISCV64/ArchInterrupt_AC.thy
@@ -21,8 +21,7 @@ definition arch_authorised_irq_ctl_inv ::
        (pasSubject aag, Control, pasIRQAbs aag irq) \<in> pasPolicy aag"
 
 lemma arch_invoke_irq_control_pas_refined[Interrupt_AC_assms]:
-  "\<lbrace>pas_refined aag and pspace_aligned and valid_vspace_objs and valid_arch_state
-                    and valid_mdb and arch_irq_control_inv_valid irq_ctl_inv
+  "\<lbrace>pas_refined aag and valid_mdb and arch_irq_control_inv_valid irq_ctl_inv
                     and K (arch_authorised_irq_ctl_inv aag irq_ctl_inv)\<rbrace>
    arch_invoke_irq_control irq_ctl_inv
    \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"

--- a/proof/access-control/RISCV64/ArchIpc_AC.thy
+++ b/proof/access-control/RISCV64/ArchIpc_AC.thy
@@ -66,10 +66,6 @@ lemma tcb_context_no_change[Ipc_AC_assms]:
   apply (auto simp: arch_tcb_context_set_def)
   done
 
-lemma transfer_caps_loop_valid_arch[Ipc_AC_assms]:
-  "transfer_caps_loop ep buffer n caps slots mi \<lbrace>valid_arch_state :: det_ext state \<Rightarrow> _\<rbrace>"
-  by (wp valid_arch_state_lift_aobj_at_no_caps transfer_caps_loop_aobj_at)
-
 end
 
 
@@ -187,11 +183,6 @@ lemma auth_ipc_buffers_kheap_update[Ipc_AC_assms]:
 lemma auth_ipc_buffers_machine_state_update[Ipc_AC_assms, simp]:
   "auth_ipc_buffers (machine_state_update f s) = auth_ipc_buffers s"
   by (clarsimp simp: auth_ipc_buffers_def get_tcb_def)
-
-crunch handle_arch_fault_reply
-  for pspace_aligned[Ipc_AC_assms, wp]: "\<lambda>s :: det_ext state. pspace_aligned s"
-  and valid_vspace_objs[Ipc_AC_assms, wp]: "\<lambda>s :: det_ext state. valid_vspace_objs s"
-  and valid_arch_state[Ipc_AC_assms, wp]: "\<lambda>s :: det_ext state. valid_arch_state s"
 
 lemma cap_insert_ext_integrity_asids_in_ipc[Ipc_AC_assms, wp]:
   "cap_insert_ext src_parent src_slot dest_slot src_p dest_p

--- a/proof/access-control/RISCV64/ArchRetype_AC.thy
+++ b/proof/access-control/RISCV64/ArchRetype_AC.thy
@@ -368,6 +368,8 @@ lemma retype_region_integrity_asids[Retype_AC_assms]:
                     simp: image_def p_assoc_help power_sub)
   done
 
+declare init_arch_objects_inv[Retype_AC_assms]
+
 end
 
 
@@ -375,7 +377,7 @@ global_interpretation Retype_AC_1?: Retype_AC_1
 proof goal_cases
   interpret Arch .
   case 1 show ?case
-    by (unfold_locales; (fact Retype_AC_assms | wpsimp wp: init_arch_objects_inv)?)
+    by (unfold_locales; (fact Retype_AC_assms | solves \<open>wp only: Retype_AC_assms; simp\<close>)?)
 qed
 
 requalify_facts RISCV64.storeWord_respects

--- a/proof/access-control/RISCV64/ArchSyscall_AC.thy
+++ b/proof/access-control/RISCV64/ArchSyscall_AC.thy
@@ -160,6 +160,7 @@ crunch
 \<comment> \<open>These aren't proved in the previous crunch, and hence need to be declared\<close>
 declare handle_arch_fault_reply_cur_thread[Syscall_AC_assms]
 declare handle_arch_fault_reply_it[Syscall_AC_assms]
+declare init_arch_objects_inv[Syscall_AC_assms]
 
 end
 
@@ -168,7 +169,7 @@ global_interpretation Syscall_AC_1?: Syscall_AC_1
 proof goal_cases
   interpret Arch .
   case 1 show ?case
-    by (unfold_locales; (fact Syscall_AC_assms | wp init_arch_objects_inv))
+    by (unfold_locales; (fact Syscall_AC_assms | solves \<open>wp only: Syscall_AC_assms; simp\<close>)?)
 qed
 
 end

--- a/proof/access-control/RISCV64/ArchTcb_AC.thy
+++ b/proof/access-control/RISCV64/ArchTcb_AC.thy
@@ -104,7 +104,7 @@ global_interpretation Tcb_AC_1?: Tcb_AC_1
 proof goal_cases
   interpret Arch .
   case 1 show ?case
-    by (unfold_locales; fact Tcb_AC_assms)
+    by (unfold_locales; (fact Tcb_AC_assms)?)
 qed
 
 end

--- a/proof/access-control/Tcb_AC.thy
+++ b/proof/access-control/Tcb_AC.thy
@@ -96,8 +96,7 @@ lemma cdt_NullCap:
   by (rule ccontr) (force dest: mdb_cte_atD simp: valid_mdb_def2)
 
 lemma setup_reply_master_pas_refined:
-  "\<lbrace>pas_refined aag and pspace_aligned and valid_vspace_objs and valid_arch_state
-                    and valid_mdb and K (is_subject aag t)\<rbrace>
+  "\<lbrace>pas_refined aag and valid_mdb and K (is_subject aag t)\<rbrace>
    setup_reply_master t
    \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   apply (simp add: setup_reply_master_def)
@@ -108,7 +107,7 @@ crunch possible_switch_to
   for tcb_domain_map_wellformed[wp]: "tcb_domain_map_wellformed aag"
 
 crunch setup_reply_master
-  for pspace_aligned[wp]: pspace_aligned
+  for pas_refined[wp]: "pas_refined aag"
 
 lemma restart_pas_refined:
   "\<lbrace>pas_refined aag and invs and tcb_at t and K (is_subject aag t)\<rbrace>
@@ -116,8 +115,8 @@ lemma restart_pas_refined:
    \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   apply (simp add: restart_def get_thread_state_def)
   apply (wp set_thread_state_pas_refined setup_reply_master_pas_refined thread_get_wp'
-         | strengthen invs_mdb
-         | fastforce)+
+         | strengthen invs_mdb)+
+  apply fastforce
   done
 
 lemma option_update_thread_set_safe_lift:
@@ -177,7 +176,7 @@ lemma (in is_extended') cte_wp_at[wp]: "I (cte_wp_at P a)"
   by (rule lift_inv, simp)
 
 lemma checked_insert_pas_refined:
-  "\<lbrace>pas_refined aag and pspace_aligned and valid_vspace_objs and valid_arch_state and valid_mdb and
+  "\<lbrace>pas_refined aag and valid_mdb and
     K (\<not> is_master_reply_cap new_cap \<and> is_subject aag target \<and>
          is_subject aag (fst src_slot) \<and> pas_cap_cur_auth aag new_cap)\<rbrace>
    check_cap_at new_cap src_slot
@@ -340,8 +339,7 @@ lemma hoare_st_refl:
   done
 
 lemma bind_notification_pas_refined[wp]:
-  "\<lbrace>pas_refined aag and pspace_aligned and valid_vspace_objs and valid_arch_state and
-    K (\<forall>auth \<in> {Receive, Reset}. abs_has_auth_to aag auth t ntfn)\<rbrace>
+  "\<lbrace>pas_refined aag and K (\<forall>auth \<in> {Receive, Reset}. abs_has_auth_to aag auth t ntfn)\<rbrace>
    bind_notification t ntfn
    \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   apply (clarsimp simp: bind_notification_def)
@@ -357,13 +355,6 @@ lemma invoke_tcb_ntfn_control_pas_refined[wp]:
    apply (safe intro!: hoare_gen_asm)
    apply (wp | fastforce simp: authorised_tcb_inv_def)+
   done
-
-crunch suspend, restart
-  for pspace_aligned[wp]: "\<lambda>s :: det_ext state. pspace_aligned s"
-  and valid_vspace_objs[wp]: "\<lambda>s :: det_ext state. valid_vspace_objs s"
-  and valid_arch_state[wp]: "\<lambda>s :: det_ext state. valid_arch_state s"
-  (wp: dxo_wp_weak)
-
 
 context Tcb_AC_1 begin
 
@@ -382,11 +373,7 @@ lemma invoke_tcb_pas_refined:
    apply assumption
   apply (rule hoare_gen_asm)
   apply (cases ti, simp_all add: authorised_tcb_inv_def)
-        apply (wp ita_wps hoare_drop_imps
-                  hoare_strengthen_post[where Q'="\<lambda>_. pas_refined aag and pspace_aligned
-                                                                     and valid_vspace_objs
-                                                                     and valid_arch_state",
-                                        OF mapM_x_wp']
+        apply (wp ita_wps hoare_drop_imps mapM_x_wp'
               | simp add: emptyable_def if_apply_def2 authorised_tcb_inv_def
               | rule ball_tcb_cap_casesI
               | wpc

--- a/proof/infoflow/ARM/ArchADT_IF.thy
+++ b/proof/infoflow/ARM/ArchADT_IF.thy
@@ -363,6 +363,10 @@ crunch arch_invoke_irq_control
   for irq_state_of_state[ADT_IF_assms, wp]: "\<lambda>s. P (irq_state_of_state s)"
   (wp: dmo_wp crunch_wps simp: setIRQTrigger_def machine_op_lift_def machine_rest_lift_def)
 
+lemma handle_reserved_irq_non_kernel_IRQs[ADT_IF_assms]:
+  "\<lbrace>P and K (irq \<notin> non_kernel_IRQs)\<rbrace> handle_reserved_irq irq \<lbrace>\<lambda>_. P\<rbrace>"
+  by (wpsimp simp: handle_reserved_irq_def)
+
 end
 
 

--- a/proof/infoflow/ARM/ArchFinalise_IF.thy
+++ b/proof/infoflow/ARM/ArchFinalise_IF.thy
@@ -14,6 +14,7 @@ named_theorems Finalise_IF_assms
 
 crunch arch_post_cap_deletion
   for globals_equiv[Finalise_IF_assms, wp]: "globals_equiv st"
+  and valid_arch_state[Finalise_IF_assms,wp]: valid_arch_state
 
 lemma dmo_maskInterrupt_reads_respects[Finalise_IF_assms]:
   "reads_respects aag l \<top> (do_machine_op (maskInterrupt m irq))"

--- a/proof/infoflow/ARM/ArchIpc_IF.thy
+++ b/proof/infoflow/ARM/ArchIpc_IF.thy
@@ -275,6 +275,13 @@ lemma handle_arch_fault_reply_globals_equiv[Ipc_IF_assms]:
 crunch arch_get_sanitise_register_info, handle_arch_fault_reply
   for valid_global_objs[Ipc_IF_assms, wp]: "valid_global_objs"
 
+crunch handle_arch_fault_reply
+  for valid_arch_state[Ipc_IF_assms,wp]: "\<lambda>s :: det_state. valid_arch_state s"
+
+lemma transfer_caps_loop_valid_arch[Ipc_IF_assms]:
+  "transfer_caps_loop ep buffer n caps slots mi \<lbrace>valid_arch_state :: det_ext state \<Rightarrow> _\<rbrace>"
+  by (wp valid_arch_state_lift_aobj_at_no_caps transfer_caps_loop_aobj_at)
+
 end
 
 
@@ -331,8 +338,7 @@ lemma do_normal_transfer_reads_respects[Ipc_IF_assms]:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
   shows
   "reads_respects aag (l :: 'a subject_label)
-     (pas_refined aag and pspace_aligned and valid_vspace_objs and valid_arch_state
-                      and valid_mdb and valid_objs
+     (pas_refined aag and valid_mdb and valid_objs
                       and K (aag_can_read_or_affect aag l sender \<and>
                              ipc_buffer_has_read_auth aag (pasObjectAbs aag sender) sbuf \<and>
                              ipc_buffer_has_read_auth aag (pasObjectAbs aag receiver) rbuf \<and>

--- a/proof/infoflow/ARM/ArchTcb_IF.thy
+++ b/proof/infoflow/ARM/ArchTcb_IF.thy
@@ -190,7 +190,6 @@ lemma tc_reads_respects_f[Tcb_IF_assms]:
                       | simp add: emptyable_def tcb_cap_cases_def tcb_cap_valid_def
                                   tcb_at_st_tcb_at when_def
                       | strengthen use_no_cap_to_obj_asid_strg invs_mdb
-                                   invs_psp_aligned invs_vspace_objs invs_arch_state
                       | solves auto)+)[7]
           apply ((simp add: conj_comms, strengthen imp_consequent[where Q="x = None" for x]
                                       , simp cong: conj_cong)
@@ -220,7 +219,6 @@ lemma tc_reads_respects_f[Tcb_IF_assms]:
                  | wpc
                  | simp add: emptyable_def tcb_cap_cases_def tcb_cap_valid_def when_def st_tcb_at_triv
                  | strengthen use_no_cap_to_obj_asid_strg invs_mdb
-                              invs_psp_aligned invs_vspace_objs invs_arch_state
                  | wp (once) hoare_drop_imp)+
     apply (simp add: option_update_thread_def tcb_cap_cases_def
            | wp hoare_weak_lift_imp hoare_weak_lift_imp_conj thread_set_pas_refined

--- a/proof/infoflow/Arch_IF.thy
+++ b/proof/infoflow/Arch_IF.thy
@@ -8,7 +8,7 @@ theory Arch_IF
 imports ArchRetype_IF
 begin
 
-(* Note: exporting the following diverges from AInvs interfaces where valid_arch_state is
+(* FIXME IF: exporting the following diverges from AInvs interfaces where valid_arch_state is
    permitted to depend on caps (due to supporting x64). If x64 confidentiality is to go ahead,
    this will need more careful management. *)
 arch_requalify_facts

--- a/proof/infoflow/FinalCaps.thy
+++ b/proof/infoflow/FinalCaps.thy
@@ -1351,8 +1351,7 @@ lemma silc_inv_preserves_silc_dom_caps:
 context FinalCaps_1 begin
 
 lemma finalise_cap_silc_inv:
-  "\<lbrace>silc_inv aag st and pspace_aligned and valid_vspace_objs and valid_arch_state
-                    and valid_mdb and pas_refined aag and K (pas_cap_cur_auth aag cap)\<rbrace>
+  "\<lbrace>silc_inv aag st and valid_mdb and pas_refined aag and K (pas_cap_cur_auth aag cap)\<rbrace>
    finalise_cap cap final
    \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
   apply (case_tac cap)
@@ -1368,7 +1367,7 @@ lemma finalise_cap_silc_inv:
   done
 
 lemma finalise_cap_ret_is_silc:
-  "\<lbrace>silc_inv aag st and pspace_aligned and valid_vspace_objs and valid_arch_state and valid_mdb
+  "\<lbrace>silc_inv aag st and valid_mdb
                     and cte_wp_at ((=) cap) slot and pas_refined aag and K (pas_cap_cur_auth aag cap)\<rbrace>
    finalise_cap cap blah
    \<lbrace>\<lambda>rvb s. \<not> cap_points_to_label aag (fst rvb) (pasObjectAbs aag (fst slot))
@@ -2426,8 +2425,7 @@ lemma transfer_caps_silc_inv:
   done
 
 lemma do_normal_transfer_silc_inv:
-  "\<lbrace>silc_inv aag st and pspace_aligned and valid_vspace_objs and valid_arch_state
-                    and valid_objs and valid_mdb and pas_refined aag
+  "\<lbrace>silc_inv aag st and valid_objs and valid_mdb and pas_refined aag
                     and K (grant \<longrightarrow> is_subject aag sender \<and> is_subject aag receiver)\<rbrace>
    do_normal_transfer sender send_buffer ep badge grant receiver recv_buffer
    \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
@@ -2441,8 +2439,7 @@ lemma do_normal_transfer_silc_inv:
   done
 
 lemma do_ipc_transfer_silc_inv:
-  "\<lbrace>silc_inv aag st and pspace_aligned and valid_vspace_objs and valid_arch_state
-                    and valid_objs and valid_mdb and pas_refined aag
+  "\<lbrace>silc_inv aag st and valid_objs and valid_mdb and pas_refined aag
                     and K (grant \<longrightarrow> is_subject aag sender \<and> is_subject aag receiver)\<rbrace>
    do_ipc_transfer sender ep badge grant receiver
    \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"

--- a/proof/infoflow/Noninterference.thy
+++ b/proof/infoflow/Noninterference.thy
@@ -712,8 +712,6 @@ lemma kernel_entry_if_integrity:
     apply (wp thread_set_integrity_autarch thread_set_pas_refined guarded_pas_domain_lift
               thread_set_invs_trivial thread_set_not_state_valid_sched
            | simp add: tcb_cap_cases_def schact_is_rct_def arch_tcb_update_aux2)+
-    apply (wp (once) prop_of_two_valid[where f="ct_active" and g="cur_thread"])
-      apply (wp | simp)+
     apply (wp thread_set_tcb_context_update_wp)+
   apply (clarsimp simp: schact_is_rct_def)
   apply (rule conjI)
@@ -722,9 +720,8 @@ lemma kernel_entry_if_integrity:
    apply simp
    apply (subgoal_tac "kheap st (cur_thread st) \<noteq> None")
     apply clarsimp
-   apply (drule tcb_at_invs, clarsimp simp: tcb_at_def get_tcb_def
-                                     split: kernel_object.splits option.splits)
-  apply (clarsimp simp: invs_psp_aligned invs_vspace_objs invs_arch_state)
+   apply (drule tcb_at_invs)
+   apply (clarsimp simp: tcb_at_def get_tcb_def split: kernel_object.splits option.splits)
   apply (rule conjI)
    apply assumption
   apply (rule state.equality, simp_all)

--- a/proof/infoflow/RISCV64/ArchADT_IF.thy
+++ b/proof/infoflow/RISCV64/ArchADT_IF.thy
@@ -292,6 +292,10 @@ crunch arch_invoke_irq_control
   for irq_state_of_state[ADT_IF_assms, wp]: "\<lambda>s. P (irq_state_of_state s)"
   (wp: dmo_wp crunch_wps simp: setIRQTrigger_def machine_op_lift_def machine_rest_lift_def)
 
+lemma handle_reserved_irq_non_kernel_IRQs[ADT_IF_assms]:
+  "\<lbrace>P and K (irq \<notin> non_kernel_IRQs)\<rbrace> handle_reserved_irq irq \<lbrace>\<lambda>_. P\<rbrace>"
+  by (wpsimp simp: handle_reserved_irq_def)
+
 end
 
 

--- a/proof/infoflow/RISCV64/ArchFinalise_IF.thy
+++ b/proof/infoflow/RISCV64/ArchFinalise_IF.thy
@@ -14,6 +14,7 @@ named_theorems Finalise_IF_assms
 
 crunch arch_post_cap_deletion
   for globals_equiv[Finalise_IF_assms, wp]: "globals_equiv st"
+  and valid_arch_state[Finalise_IF_assms,wp]: valid_arch_state
 
 lemma dmo_maskInterrupt_reads_respects[Finalise_IF_assms]:
   "reads_respects aag l \<top> (do_machine_op (maskInterrupt m irq))"

--- a/proof/infoflow/RISCV64/ArchIpc_IF.thy
+++ b/proof/infoflow/RISCV64/ArchIpc_IF.thy
@@ -274,6 +274,13 @@ lemma handle_arch_fault_reply_globals_equiv[Ipc_IF_assms]:
 crunch arch_get_sanitise_register_info, handle_arch_fault_reply
   for valid_global_objs[Ipc_IF_assms, wp]: "valid_global_objs"
 
+crunch handle_arch_fault_reply
+  for valid_arch_state[Ipc_IF_assms,wp]: "\<lambda>s :: det_state. valid_arch_state s"
+
+lemma transfer_caps_loop_valid_arch[Ipc_IF_assms]:
+  "transfer_caps_loop ep buffer n caps slots mi \<lbrace>valid_arch_state :: det_ext state \<Rightarrow> _\<rbrace>"
+  by (wp valid_arch_state_lift_aobj_at_no_caps transfer_caps_loop_aobj_at)
+
 end
 
 
@@ -330,8 +337,7 @@ lemma do_normal_transfer_reads_respects[Ipc_IF_assms]:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
   shows
   "reads_respects aag (l :: 'a subject_label)
-     (pas_refined aag and pspace_aligned and valid_vspace_objs and valid_arch_state
-                      and valid_mdb and valid_objs
+     (pas_refined aag and valid_mdb and valid_objs
                       and K (aag_can_read_or_affect aag l sender \<and>
                              ipc_buffer_has_read_auth aag (pasObjectAbs aag sender) sbuf \<and>
                              ipc_buffer_has_read_auth aag (pasObjectAbs aag receiver) rbuf \<and>

--- a/proof/infoflow/RISCV64/ArchTcb_IF.thy
+++ b/proof/infoflow/RISCV64/ArchTcb_IF.thy
@@ -186,7 +186,6 @@ lemma tc_reads_respects_f[Tcb_IF_assms]:
                       | simp add: emptyable_def tcb_cap_cases_def tcb_cap_valid_def
                                   tcb_at_st_tcb_at when_def
                       | strengthen use_no_cap_to_obj_asid_strg invs_mdb
-                                   invs_psp_aligned invs_vspace_objs invs_arch_state
                       | solves auto)+)[7]
           apply ((simp add: conj_comms, strengthen imp_consequent[where Q="x = None" for x]
                                       , simp cong: conj_cong)
@@ -216,7 +215,6 @@ lemma tc_reads_respects_f[Tcb_IF_assms]:
                  | wpc
                  | simp add: emptyable_def tcb_cap_cases_def tcb_cap_valid_def when_def st_tcb_at_triv
                  | strengthen use_no_cap_to_obj_asid_strg invs_mdb
-                              invs_psp_aligned invs_vspace_objs invs_arch_state
                  | wp (once) hoare_drop_imp)+
     apply (simp add: option_update_thread_def tcb_cap_cases_def
            | wp hoare_weak_lift_imp hoare_weak_lift_imp_conj thread_set_pas_refined
@@ -232,7 +230,6 @@ lemma tc_reads_respects_f[Tcb_IF_assms]:
              thread_set_valid_arch_state
           | simp add: tcb_cap_cases_def | wpc | wp (once) hoare_drop_imp)+
   apply (clarsimp simp: authorised_tcb_inv_def authorised_tcb_inv_extra_def emptyable_def)
-  apply (clarsimp simp: invs_psp_aligned invs_vspace_objs invs_arch_state)
   apply (clarsimp cong: conj_cong)
   apply (intro conjI impI allI)
   (* slow *)

--- a/proof/infoflow/Retype_IF.thy
+++ b/proof/infoflow/Retype_IF.thy
@@ -207,6 +207,9 @@ lemma globals_equiv_is_original_cap_update[simp]:
   "globals_equiv s (s'\<lparr>is_original_cap := x\<rparr>) = globals_equiv s s'"
   by (fastforce simp: globals_equiv_def idle_equiv_def)
 
+crunch set_cdt
+  for valid_arch_state[wp]: "\<lambda>s. P (valid_arch_state s)"
+
 lemma create_cap_globals_equiv:
   "\<lbrace>globals_equiv s and valid_global_objs and valid_arch_state\<rbrace>
    create_cap type bits untyped dev slot

--- a/proof/infoflow/Syscall_IF.thy
+++ b/proof/infoflow/Syscall_IF.thy
@@ -89,6 +89,9 @@ lemma cap_revoke_globals_equiv:
   by (wp cap_delete_globals_equiv preemption_point_inv
       | fastforce simp: emptyable_def dest: reply_slot_not_descendant)+
 
+crunch cap_move
+  for valid_arch_state[wp]: "\<lambda>s :: det_ext state. valid_arch_state s"
+
 lemma invoke_cnode_globals_equiv:
   "\<lbrace>globals_equiv st and invs and valid_cnode_inv cinv\<rbrace>
    invoke_cnode cinv

--- a/proof/infoflow/Tcb_IF.thy
+++ b/proof/infoflow/Tcb_IF.thy
@@ -294,6 +294,10 @@ locale Tcb_IF_2 = Tcb_IF_1 +
              (invoke_tcb ti)"
 begin
 
+crunch suspend, restart
+  for valid_arch_state[wp]: "\<lambda>s :: det_state. valid_arch_state s"
+  (wp: dxo_wp_weak)
+
 lemma invoke_tcb_globals_equiv:
   "\<lbrace>invs and globals_equiv st and tcb_inv_wf ti\<rbrace>
    invoke_tcb ti
@@ -518,10 +522,7 @@ lemma invoke_tcb_reads_respects_f:
                  restart_silc_inv restart_pas_refined
               | simp split del: if_split add: det_setRegister det_setNextPC
               | strengthen invs_mdb
-              | (rule hoare_strengthen_post[where Q'="\<lambda>_. silc_inv aag st and pas_refined aag
-                                                                         and pspace_aligned
-                                                                         and valid_vspace_objs
-                                                                         and valid_arch_state",
+              | (rule hoare_strengthen_post[where Q'="\<lambda>_. silc_inv aag st and pas_refined aag",
                                             OF mapM_x_wp', rotated], fastforce)
               | wp mapM_x_wp')+
        apply (solves \<open>auto simp: authorised_tcb_inv_def det_getRestartPC det_getRegister


### PR DESCRIPTION
* Remove various instances of `pspace_aligned`, `valid_vspace_objs`, and `valid_asid_table`/`valid_arch_state` from preconditions
* Relax the `is_subject` predicate in various Syscall_AC lemmas
* Enforce explicit `wp` rules in locale interpretations