### PR TITLE
Update other arches for det_ext changes

### DIFF
--- a/proof/crefine/ARM/Arch_C.thy
+++ b/proof/crefine/ARM/Arch_C.thy
@@ -246,7 +246,7 @@ proof -
      simplified, OF empty[folded szko] szo[symmetric], unfolded szko]
 
   have szb: "pageBits < word_bits" by simp
-  have mko: "\<And>dev. makeObjectKO dev (Inl (KOArch (KOASIDPool f))) = Some ko"
+  have mko: "\<And>dev d f. makeObjectKO dev d (Inl (KOArch (KOASIDPool f))) = Some ko"
     by (simp add: ko_def makeObjectKO_def)
 
 

--- a/proof/crefine/ARM/Refine_C.thy
+++ b/proof/crefine/ARM/Refine_C.thy
@@ -636,18 +636,17 @@ lemma threadSet_all_invs_triv':
   unfolding all_invs'_def
   apply (rule hoare_pre)
    apply (rule wp_from_corres_unit)
-     apply (rule threadset_corresT [where f="tcb_arch_update (arch_tcb_context_set f)"])
+      apply (rule threadset_corresT [where f="tcb_arch_update (arch_tcb_context_set f)"]; simp?)
         apply (simp add: tcb_relation_def arch_tcb_context_set_def
                          atcbContextSet_def arch_tcb_relation_def)
        apply (simp add: tcb_cap_cases_def)
       apply (simp add: tcb_cte_cases_def tcb_cte_cases_neqs)
-     apply (simp add: exst_same_def)
-    apply (wp thread_set_invs_trivial thread_set_ct_running thread_set_not_state_valid_sched
-              threadSet_invs_trivial threadSet_ct_running' hoare_weak_lift_imp
-              thread_set_ct_in_state
-           | simp add: tcb_cap_cases_def tcb_arch_ref_def exst_same_def
-           | rule threadSet_ct_in_state'
-           | wp (once) hoare_vcg_disj_lift)+
+     apply (wp thread_set_invs_trivial thread_set_not_state_valid_sched
+               threadSet_invs_trivial threadSet_ct_running' hoare_weak_lift_imp
+               thread_set_ct_in_state
+            | simp add: tcb_cap_cases_def tcb_arch_ref_def
+            | rule threadSet_ct_in_state'
+            | wp (once) hoare_vcg_disj_lift)+
   apply clarsimp
   apply (rule exI, rule conjI, assumption)
   apply (clarsimp simp: invs_def valid_state_def valid_pspace_def invs'_def cur_tcb_def cur_tcb'_def)

--- a/proof/crefine/ARM/Retype_C.thy
+++ b/proof/crefine/ARM/Retype_C.thy
@@ -901,7 +901,7 @@ lemma retype_ctes_helper:
   and      al: "is_aligned ptr (objBitsKO ko)"
   and      sz: "objBitsKO ko \<le> sz"
   and     szb: "sz < word_bits"
-  and     mko: "makeObjectKO dev tp = Some ko"
+  and     mko: "makeObjectKO dev d tp = Some ko"
   and      rc: "range_cover ptr sz (objBitsKO ko) n"
   shows  "map_to_ctes (\<lambda>xa. if xa \<in> set (new_cap_addrs n ptr ko) then Some ko else ksPSpace s xa) =
    (\<lambda>x. if tp = Inr (APIObjectType ArchTypes_H.apiobject_type.CapTableObject) \<and> x \<in> set (new_cap_addrs n ptr ko) \<or>
@@ -1160,7 +1160,7 @@ proof (intro impI allI)
     by (clarsimp simp:range_cover_def[where 'a=32, folded word_bits_def])+
 
   (* obj specific *)
-  have mko: "\<And>dev. makeObjectKO dev (Inr (APIObjectType ArchTypes_H.apiobject_type.EndpointObject)) = Some ko"
+  have mko: "\<And>dev d. makeObjectKO dev d (Inr (APIObjectType ArchTypes_H.apiobject_type.EndpointObject)) = Some ko"
     by (simp add: ko_def makeObjectKO_def)
 
   have relrl:
@@ -1274,7 +1274,7 @@ proof (intro impI allI)
     by (clarsimp simp:range_cover_def[where 'a=32, folded word_bits_def])+
 
   (* obj specific *)
-  have mko: "\<And> dev. makeObjectKO dev (Inr (APIObjectType ArchTypes_H.apiobject_type.NotificationObject)) = Some ko" by (simp add: ko_def makeObjectKO_def)
+  have mko: "\<And> dev d. makeObjectKO dev d (Inr (APIObjectType ArchTypes_H.apiobject_type.NotificationObject)) = Some ko" by (simp add: ko_def makeObjectKO_def)
 
   have relrl:
     "cnotification_relation (cslift x) makeObject (from_bytes (replicate (size_of TYPE(notification_C)) 0))"
@@ -1426,7 +1426,7 @@ proof (intro impI allI)
     by (clarsimp simp:range_cover_def[where 'a=32, folded word_bits_def])+
 
   (* obj specific *)
-  have mko: "\<And>dev. makeObjectKO dev (Inr (APIObjectType  ArchTypes_H.apiobject_type.CapTableObject)) = Some ko"
+  have mko: "\<And>dev d. makeObjectKO dev d (Inr (APIObjectType  ArchTypes_H.apiobject_type.CapTableObject)) = Some ko"
     by (simp add: ko_def makeObjectKO_def)
 
   note relrl = ccte_relation_makeObject
@@ -1631,7 +1631,8 @@ proof (intro impI allI)
           Int_atLeastAtMost atLeastatMost_empty_iff split_paired_Ex
 
   (* obj specific *)
-  have mko: "\<And>dev. makeObjectKO dev (Inr ARM_H.PageTableObject) = Some ko" by (simp add: ko_def makeObjectKO_def)
+  have mko: "\<And>dev d. makeObjectKO dev d (Inr ARM_H.PageTableObject) = Some ko"
+    by (simp add: ko_def makeObjectKO_def)
 
   have relrl:
     "cpte_relation makeObject (from_bytes (replicate (size_of TYPE(pte_C)) 0))"
@@ -1804,7 +1805,7 @@ proof (intro impI allI)
     by (clarsimp simp:range_cover_def[where 'a=32, folded word_bits_def])+
 
   (* obj specific *)
-  have mko: "\<And>dev. makeObjectKO dev (Inr ARM_H.PageDirectoryObject) = Some ko"
+  have mko: "\<And>dev d. makeObjectKO dev d (Inr ARM_H.PageDirectoryObject) = Some ko"
     by (simp add: ko_def makeObjectKO_def)
 
   note blah[simp del] =  atLeastAtMost_iff atLeastatMost_subset_iff atLeastLessThan_iff
@@ -2592,11 +2593,11 @@ lemmas ptr_retyp_htd_safe_neg' = ptr_retyp_htd_safe_neg[OF _ _ subset_refl]
 
 lemma cnc_tcb_helper:
   fixes p :: "tcb_C ptr"
-  defines "kotcb \<equiv> (KOTCB (makeObject :: tcb))"
+    and d :: domain
+  defines "kotcb \<equiv> KOTCB (tcbDomain_update (\<lambda>_. d) (makeObject :: tcb))"
   assumes rfsr: "(\<sigma>\<lparr>ksPSpace := ks\<rparr>, x) \<in> rf_sr"
   and      al: "is_aligned (ctcb_ptr_to_tcb_ptr p) (objBitsKO kotcb)"
   and ptr0: "ctcb_ptr_to_tcb_ptr p \<noteq> 0"
-  and ptrlb: "2^ctcb_size_bits \<le> ptr_val p"
   and pal: "pspace_aligned' (\<sigma>\<lparr>ksPSpace := ks\<rparr>)"
   and pno: "pspace_no_overlap' (ctcb_ptr_to_tcb_ptr p) (objBitsKO kotcb) (\<sigma>\<lparr>ksPSpace := ks\<rparr>)"
   and pds: "pspace_distinct' (\<sigma>\<lparr>ksPSpace := ks\<rparr>)"
@@ -2606,20 +2607,21 @@ lemma cnc_tcb_helper:
   and empty: "region_is_bytes (ctcb_ptr_to_tcb_ptr p) (2 ^ tcbBlockSizeBits) x"
   and rep0:  "heap_list (fst (t_hrs_' (globals x))) (2 ^ tcbBlockSizeBits) (ctcb_ptr_to_tcb_ptr p) = replicate (2 ^ tcbBlockSizeBits) 0"
   and kdr: "{ctcb_ptr_to_tcb_ptr p..+2 ^ tcbBlockSizeBits} \<inter> kernel_data_refs = {}"
+  and domrel: "ucast d = d'"
   shows "(\<sigma>\<lparr>ksPSpace := ks(ctcb_ptr_to_tcb_ptr p \<mapsto> kotcb)\<rparr>,
      globals_update
       (t_hrs_'_update
-        (\<lambda>a. hrs_mem_update (heap_update (Ptr &(p\<rightarrow>[''tcbTimeSlice_C'']) :: machine_word ptr) (5 :: machine_word))
+        (\<lambda>a. hrs_mem_update (heap_update (Ptr &(p\<rightarrow>[''tcbDomain_C''])) (d' :: machine_word))
+(hrs_mem_update (heap_update (Ptr &(p\<rightarrow>[''tcbTimeSlice_C'']) :: machine_word ptr) (5 :: machine_word))
               (hrs_mem_update
                 (heap_update ((Ptr &((Ptr &((Ptr &(p\<rightarrow>[''tcbArch_C'']) :: arch_tcb_C ptr)\<rightarrow>[''tcbContext_C''])
                      :: user_context_C ptr)\<rightarrow>[''registers_C''])) :: (word32[20]) ptr)
                   (Arrays.update (h_val (hrs_mem a) ((Ptr &((Ptr &((Ptr &(p\<rightarrow>[''tcbArch_C'']) :: arch_tcb_C ptr)\<rightarrow>[''tcbContext_C''])
                        :: user_context_C ptr)\<rightarrow>[''registers_C''])) :: (word32[20]) ptr)) (unat Kernel_C.CPSR) (0x150 :: word32)))
                    (hrs_htd_update (\<lambda>xa. ptr_retyps_gen 1 (Ptr (ctcb_ptr_to_tcb_ptr p) :: (cte_C[5]) ptr) False
-                       (ptr_retyps_gen 1 p False xa)) a)))) x)
+                       (ptr_retyps_gen 1 p False xa)) a))))) x)
              \<in> rf_sr"
   (is "(\<sigma>\<lparr>ksPSpace := ?ks\<rparr>, globals_update ?gs' x) \<in> rf_sr")
-
 proof -
   define ko where "ko \<equiv> (KOCTE (makeObject :: cte))"
   let ?ptr = "cte_Ptr (ctcb_ptr_to_tcb_ptr p)"
@@ -2744,7 +2746,7 @@ proof -
                     \<lparr>tcbContext_C := tcbContext_C (tcbArch_C (from_bytes (replicate (size_of TYPE(tcb_C)) 0)))
                      \<lparr>registers_C :=
                         Arrays.update (registers_C (tcbContext_C (tcbArch_C (from_bytes (replicate (size_of TYPE(tcb_C)) 0))))) (unat Kernel_C.CPSR)
-                         0x150\<rparr>\<rparr>, tcbTimeSlice_C := 5\<rparr>)"
+                         0x150\<rparr>\<rparr>, tcbDomain_C := d', tcbTimeSlice_C := 5\<rparr>)"
 
   have "ptr_retyp p (snd (t_hrs_' (globals x))) \<Turnstile>\<^sub>t p" using cgp
     by (rule ptr_retyp_h_t_valid)
@@ -2792,7 +2794,7 @@ proof -
 
   have rl:
     "(\<forall>v :: 'a :: pre_storable. projectKO_opt kotcb \<noteq> Some v) \<Longrightarrow>
-    (projectKO_opt \<circ>\<^sub>m (ks(ctcb_ptr_to_tcb_ptr p \<mapsto> KOTCB makeObject)) :: word32 \<Rightarrow> 'a option)
+    (projectKO_opt \<circ>\<^sub>m (ks(ctcb_ptr_to_tcb_ptr p \<mapsto> KOTCB (tcbDomain_update (\<lambda>_. d) makeObject))) :: word32 \<Rightarrow> 'a option)
     = projectKO_opt \<circ>\<^sub>m ks" using pno al
     apply -
     apply (drule(2) projectKO_opt_retyp_other'[OF _ _ pal])
@@ -2805,8 +2807,9 @@ proof -
     apply (clarsimp simp: projectKOs map_comp_def split: if_split)
     done
 
-  have mko: "\<And>dev. makeObjectKO dev (Inr (APIObjectType ArchTypes_H.apiobject_type.TCBObject)) = Some kotcb"
+  have mko: "\<And>dev. makeObjectKO dev d (Inr (APIObjectType ArchTypes_H.apiobject_type.TCBObject)) = Some kotcb"
     by (simp add: makeObjectKO_def kotcb_def)
+
   note hacky_cte = retype_ctes_helper [where sz = "objBitsKO kotcb" and ko = kotcb and ptr = "ctcb_ptr_to_tcb_ptr p",
     OF pal pds pno al _ _ mko, simplified new_cap_addrs_def, simplified]
 
@@ -2849,7 +2852,7 @@ proof -
       done
   qed
 
-  ultimately have rl_cte: "(map_to_ctes (ks(ctcb_ptr_to_tcb_ptr p \<mapsto> KOTCB makeObject)) :: word32 \<Rightarrow> cte option)
+  ultimately have rl_cte: "(map_to_ctes (ks(ctcb_ptr_to_tcb_ptr p \<mapsto> KOTCB (tcbDomain_update (\<lambda>_. d) makeObject))) :: word32 \<Rightarrow> cte option)
     = (\<lambda>x. if x \<in> ptr_val ` (CTypesDefs.ptr_add (cte_Ptr (ctcb_ptr_to_tcb_ptr p)) \<circ> of_nat) ` {k. k < 5}
          then Some (CTE NullCap nullMDBNode)
          else map_to_ctes ks x)"
@@ -2906,21 +2909,22 @@ proof -
     done
 
   have tcb_rel:
-    "ctcb_relation makeObject ?new_tcb"
+    "ctcb_relation (tcbDomain_update (\<lambda>_. d) makeObject) ?new_tcb"
     unfolding ctcb_relation_def makeObject_tcb
     apply (simp add: fbtcb minBound_word)
     apply (intro conjI)
-          apply (simp add: cthread_state_relation_def thread_state_lift_def
-                           eval_nat_numeral ThreadState_Inactive_def)
-         apply (clarsimp simp: ccontext_relation_def carch_tcb_relation_def)
-         (* C regs relation *)
-         apply (clarsimp simp: cregs_relation_def)
-         subgoal for r
-           by (case_tac r;
-               simp add: "StrictC'_register_defs" eval_nat_numeral atcbContext_def atcbContextGet_def
-                         newArchTCB_def newContext_def initContext_def take_bit_Suc
-                    del: unsigned_numeral)
-        apply (simp add: thread_state_lift_def index_foldr_update atcbContextGet_def)
+           apply (simp add: cthread_state_relation_def thread_state_lift_def
+                            eval_nat_numeral ThreadState_Inactive_def)
+          apply (clarsimp simp: ccontext_relation_def carch_tcb_relation_def)
+          (* C regs relation *)
+          apply (clarsimp simp: cregs_relation_def)
+          subgoal for r
+            by (case_tac r;
+                simp add: "StrictC'_register_defs" eval_nat_numeral atcbContext_def atcbContextGet_def
+                          newArchTCB_def newContext_def initContext_def take_bit_Suc
+                     del: unsigned_numeral)
+         apply (simp add: thread_state_lift_def index_foldr_update atcbContextGet_def)
+        apply (fastforce intro: domrel)
        apply (simp add: Kernel_Config.timeSlice_def)
       apply (simp add: cfault_rel_def seL4_Fault_lift_def seL4_Fault_get_tag_def Let_def
                        lookup_fault_lift_def lookup_fault_get_tag_def lookup_fault_invalid_root_def
@@ -3045,6 +3049,7 @@ proof -
      apply (erule cmap_relation_retype2)
      apply (simp add:ccte_relation_nullCap nullMDBNode_def nullPointer_def)
     \<comment> \<open>tcb\<close>
+     apply (clarsimp simp: map_comp_update)
      apply (erule cmap_relation_updI2 [where dest = "ctcb_ptr_to_tcb_ptr p" and f = "tcb_ptr_to_ctcb_ptr", simplified])
      apply (rule map_comp_simps)
      apply (rule pks)
@@ -3390,7 +3395,7 @@ proof (intro impI allI)
     by (clarsimp dest!: is_aligned_weaken range_cover.aligned)
 
   (* This is a hack *)
-  have mko: "\<And>dev. makeObjectKO False (Inr object_type.SmallPageObject) = Some ko"
+  have mko: "\<And>dev d. makeObjectKO False d (Inr object_type.SmallPageObject) = Some ko"
     by (simp add: makeObjectKO_def ko_def)
 
   from sz have "2 \<le> sz" by (simp add: objBits_simps pageBits_def ko_def)
@@ -3975,16 +3980,22 @@ lemma ccorres_placeNewObject_tcb:
       and ret_zero regionBase (2 ^ tcbBlockSizeBits)
       and K (regionBase \<noteq> 0 \<and> range_cover regionBase tcbBlockSizeBits tcbBlockSizeBits 1
       \<and>  {regionBase..+2^tcbBlockSizeBits} \<inter> kernel_data_refs = {}))
-   ({s. region_actually_is_zero_bytes regionBase (2^tcbBlockSizeBits) s})
-    hs
-   (placeNewObject regionBase (makeObject :: tcb) 0)
+   ({s. region_actually_is_zero_bytes regionBase (2^tcbBlockSizeBits) s
+        \<and> ksCurDomain_' (globals s) = ucast d}) hs
+   (placeNewObject regionBase (tcbDomain_update (\<lambda>_. d) makeObject) 0)
    (\<acute>tcb :== tcb_Ptr (regionBase + 0x100);;
         (global_htd_update (\<lambda>s. ptr_retyp (Ptr (ptr_val (tcb_' s) - ctcb_offset) :: (cte_C[5]) ptr)
             \<circ> ptr_retyp (tcb_' s)));;
         (Guard C_Guard \<lbrace>hrs_htd \<acute>t_hrs \<Turnstile>\<^sub>t \<acute>tcb\<rbrace>
-           (call (\<lambda>s. s\<lparr>context_' := Ptr &((Ptr &(tcb_' s\<rightarrow>[''tcbArch_C'']) :: arch_tcb_C ptr)\<rightarrow>[''tcbContext_C''])\<rparr>) Arch_initContext_'proc (\<lambda>s t. s\<lparr>globals := globals t\<rparr>) (\<lambda>s' s''. Basic (\<lambda>s. s))));;
+           (call (\<lambda>s. s\<lparr>context_' := Ptr &((Ptr &(tcb_' s\<rightarrow>[''tcbArch_C'']) :: arch_tcb_C ptr)\<rightarrow>[''tcbContext_C''])\<rparr>)
+                 Arch_initContext_'proc (\<lambda>s t. s\<lparr>globals := globals t\<rparr>) (\<lambda>s' s''. Basic (\<lambda>s. s))));;
         (Guard C_Guard \<lbrace>hrs_htd \<acute>t_hrs \<Turnstile>\<^sub>t \<acute>tcb\<rbrace>
-           (Basic (\<lambda>s. globals_update (t_hrs_'_update (hrs_mem_update (heap_update (Ptr &((tcb_' s)\<rightarrow>[''tcbTimeSlice_C''])) (5::word32)))) s))))"
+           (Basic (\<lambda>s. globals_update (t_hrs_'_update (hrs_mem_update (heap_update (Ptr &((tcb_' s)\<rightarrow>[''tcbTimeSlice_C''])) (5::word32)))) s)));;
+        (Guard C_Guard {s. s \<Turnstile>\<^sub>c tcb_' s}
+          (Basic (\<lambda>s. globals_update
+                       (t_hrs_'_update
+                        (hrs_mem_update (heap_update (Ptr &(tcb_' s\<rightarrow>[''tcbDomain_C'']))
+                                        (ksCurDomain_' (globals s) :: machine_word)))) s))))"
   apply -
   apply (rule ccorres_from_vcg_nofail)
   apply clarsimp
@@ -4018,28 +4029,26 @@ lemma ccorres_placeNewObject_tcb:
    apply (clarsimp simp: hrs_htd_update)
    apply (rule bexI [OF _ placeNewObject_eq])
       apply (clarsimp simp: split_def new_cap_addrs_def)
-      apply (cut_tac \<sigma>=\<sigma> and x=x
-                   and ks="ksPSpace \<sigma>" and p="tcb_Ptr (regionBase + 0x100)" in cnc_tcb_helper)
-                    apply clarsimp
-                   apply (clarsimp simp: ctcb_ptr_to_tcb_ptr_def ctcb_offset_defs
-                                         objBitsKO_def range_cover.aligned)
-                  apply (clarsimp simp: ctcb_ptr_to_tcb_ptr_def ctcb_offset_defs objBitsKO_def)
-                 apply (simp add:olen_add_eqv[symmetric] ctcb_size_bits_def)
-                 apply (erule is_aligned_no_wrap'[OF range_cover.aligned])
-                 apply (simp add: objBits_defs)
+      apply (cut_tac \<sigma>=\<sigma> and x=x and ks="ksPSpace \<sigma>" and p="tcb_Ptr (regionBase + 0x100)"
+                 and d=d and d'="ucast d"
+               in cnc_tcb_helper)
+                   apply clarsimp
+                  apply (clarsimp simp: ctcb_ptr_to_tcb_ptr_def ctcb_offset_defs
+                                        objBitsKO_def range_cover.aligned)
+                 apply (clarsimp simp: ctcb_ptr_to_tcb_ptr_def ctcb_offset_defs objBitsKO_def)
                 apply simp
-               apply clarsimp
-              apply (clarsimp simp: ctcb_ptr_to_tcb_ptr_def ctcb_offset_defs objBitsKO_def)
-             apply (clarsimp)
-            apply simp
-           apply clarsimp
-          apply (clarsimp simp: objBits_simps ctcb_ptr_to_tcb_ptr_def ctcb_offset_defs)
-         apply (frule region_actually_is_bytes)
-         apply (clarsimp simp: region_is_bytes'_def ctcb_ptr_to_tcb_ptr_def ctcb_offset_defs split_def
-                               hrs_mem_update_def hrs_htd_def)
-        apply (clarsimp simp: ctcb_ptr_to_tcb_ptr_def ctcb_offset_defs hrs_mem_update_def split_def)
-        apply (simp add: hrs_mem_def)
-       apply (simp add: ctcb_ptr_to_tcb_ptr_def ctcb_offset_defs)
+               apply (clarsimp simp: ctcb_ptr_to_tcb_ptr_def ctcb_offset_defs objBitsKO_def)
+              apply (clarsimp)
+             apply simp
+            apply clarsimp
+           apply (clarsimp simp: objBits_simps ctcb_ptr_to_tcb_ptr_def ctcb_offset_defs)
+          apply (frule region_actually_is_bytes)
+          apply (clarsimp simp: region_is_bytes'_def ctcb_ptr_to_tcb_ptr_def ctcb_offset_defs split_def
+                                hrs_mem_update_def hrs_htd_def)
+         apply (clarsimp simp: ctcb_ptr_to_tcb_ptr_def ctcb_offset_defs hrs_mem_update_def split_def)
+         apply (simp add: hrs_mem_def)
+        apply (simp add: ctcb_ptr_to_tcb_ptr_def ctcb_offset_defs)
+       apply clarsimp
       apply (clarsimp simp: ctcb_ptr_to_tcb_ptr_def ctcb_offset_defs hrs_mem_update_def split_def)
       apply (clarsimp simp: rf_sr_def ptr_retyps_gen_def cong: Kernel_C.globals.unfold_congs
                             StateSpace.state.unfold_congs kernel_state.unfold_congs)
@@ -4203,7 +4212,7 @@ proof (intro impI allI)
       by (simp add:word_bits_def objBits_simps ko_def pageBits_def)
 
   (* This is a hack *)
-  have mko: "\<And>dev. makeObjectKO True (Inr object_type.SmallPageObject) = Some ko"
+  have mko: "\<And>dev d. makeObjectKO True d (Inr object_type.SmallPageObject) = Some ko"
     by (simp add: makeObjectKO_def ko_def)
 
   from sz have "2 \<le> sz" by (simp add: objBits_simps pageBits_def ko_def)
@@ -5064,19 +5073,15 @@ proof -
           apply (rule ccorres_symb_exec_r)
             apply (ccorres_remove_UNIV_guard)
             apply (simp add: hrs_htd_update)
-            apply (ctac (c_lines 4) add: ccorres_placeNewObject_tcb[simplified])
+            apply (rule ccorres_pre_curDomain)
+            apply (ctac (c_lines 5) add: ccorres_placeNewObject_tcb[simplified])
               apply simp
-              apply (rule ccorres_pre_curDomain)
-              apply ctac
-                apply (rule ccorres_symb_exec_r)
-                  apply (rule ccorres_return_C, simp, simp, simp)
-                 apply vcg
-                apply (rule conseqPre, vcg, clarsimp)
-               apply wp
-              apply vcg
-             apply (simp add: obj_at'_real_def)
-             apply (wp placeNewObject_ko_wp_at')
-            apply vcg
+              apply (rule ccorres_symb_exec_r)
+                apply (rule ccorres_return_C, simp, simp, simp)
+               apply vcg
+              apply (rule conseqPre, vcg, clarsimp)
+             apply wp
+            apply (vcg exspec=Arch_initContext_modifies)
            apply clarsimp
            apply vcg
           apply (clarsimp simp: CPSR_def)

--- a/proof/crefine/ARM_HYP/Arch_C.thy
+++ b/proof/crefine/ARM_HYP/Arch_C.thy
@@ -267,7 +267,7 @@ proof -
      simplified, OF empty[folded szko] szo[symmetric], unfolded szko]
 
   have szb: "pageBits < word_bits" by simp
-  have mko: "\<And>dev. makeObjectKO dev (Inl (KOArch (KOASIDPool f))) = Some ko"
+  have mko: "\<And>dev d f. makeObjectKO dev d (Inl (KOArch (KOASIDPool f))) = Some ko"
     by (simp add: ko_def makeObjectKO_def)
 
 

--- a/proof/crefine/ARM_HYP/Refine_C.thy
+++ b/proof/crefine/ARM_HYP/Refine_C.thy
@@ -647,9 +647,9 @@ lemma callKernel_withFastpath_corres_C:
   apply (auto elim!: pred_tcb'_weakenE cnode_caps_gsCNodes_from_sr[rotated])
   done
 
-lemma tcb_arch_ref_context_set_id [simp]:
-  "tcb_arch_ref (tcb_arch_update (arch_tcb_context_set f) tcb) = tcb_arch_ref tcb"
-  unfolding tcb_arch_ref_def arch_tcb_context_set_def
+lemma tcb_vcpu_context_set_id[simp]:
+  "tcb_vcpu (arch_tcb_context_set f (tcb_arch tcb)) = tcb_vcpu (tcb_arch tcb)"
+  unfolding arch_tcb_context_set_def
   by simp
 
 lemma threadSet_all_invs_triv':
@@ -658,25 +658,24 @@ lemma threadSet_all_invs_triv':
   unfolding all_invs'_def
   apply (rule hoare_pre)
    apply (rule wp_from_corres_unit)
-     apply (rule threadset_corresT [where f="tcb_arch_update (arch_tcb_context_set f)"])
-            apply (simp add: tcb_relation_def arch_tcb_context_set_def
-                            atcbContextSet_def arch_tcb_relation_def)
-           apply (simp add: tcb_cap_cases_def)
-          apply (simp add: tcb_cte_cases_def tcb_cte_cases_neqs)
-         apply fastforce
-        apply fastforce
-       apply fastforce
-     apply (simp add: exst_same_def)
-    apply (wp thread_set_invs_trivial thread_set_ct_running thread_set_not_state_valid_sched
-              threadSet_invs_trivial threadSet_ct_running' hoare_weak_lift_imp
-              thread_set_ct_in_state
-           | simp add: tcb_cap_cases_def
-           | rule threadSet_ct_in_state'
-           | wp (once) hoare_vcg_disj_lift)+
+      apply (rule threadset_corresT [where f="tcb_arch_update (arch_tcb_context_set f)"]; simp?)
+        apply (simp add: tcb_relation_def arch_tcb_context_set_def
+                         atcbContextSet_def arch_tcb_relation_def)
+       apply (simp add: tcb_cap_cases_def)
+      apply (simp add: tcb_cte_cases_def cteSizeBits_def)
+     apply (wp thread_set_invs_trivial thread_set_not_state_valid_sched
+               threadSet_invs_trivial threadSet_ct_running' hoare_weak_lift_imp
+               thread_set_ct_in_state
+            | simp add: tcb_cap_cases_def tcb_arch_ref_def
+            | rule threadSet_ct_in_state'
+            | wp (once) hoare_vcg_disj_lift)+
   apply clarsimp
+  apply (rename_tac s s')
   apply (rule exI, rule conjI, assumption)
-  apply (clarsimp simp: invs_def valid_state_def valid_pspace_def invs'_def cur_tcb_def)
-  apply (simp add: state_relation_def)
+  apply (prop_tac "invs s'")
+   apply (clarsimp simp: invs_def)
+  apply (clarsimp simp: invs_psp_aligned invs_distinct)
+  apply (clarsimp simp: invs_def cur_tcb_def cur_tcb'_def state_relation_def)
   done
 
 lemma getContext_corres:

--- a/proof/crefine/RISCV64/Arch_C.thy
+++ b/proof/crefine/RISCV64/Arch_C.thy
@@ -250,7 +250,7 @@ proof -
      simplified, OF empty[folded szko] szo[symmetric], unfolded szko]
 
   have szb: "pageBits < word_bits" by simp
-  have mko: "\<And>dev. makeObjectKO dev (Inl (KOArch (KOASIDPool f))) = Some ko"
+  have mko: "\<And>dev d f. makeObjectKO dev d (Inl (KOArch (KOASIDPool f))) = Some ko"
     by (simp add: ko_def makeObjectKO_def)
 
 

--- a/proof/crefine/RISCV64/Refine_C.thy
+++ b/proof/crefine/RISCV64/Refine_C.thy
@@ -635,18 +635,17 @@ lemma threadSet_all_invs_triv':
   unfolding all_invs'_def
   apply (rule hoare_pre)
    apply (rule wp_from_corres_unit)
-     apply (rule threadset_corresT [where f="tcb_arch_update (arch_tcb_context_set f)"])
+      apply (rule threadset_corresT [where f="tcb_arch_update (arch_tcb_context_set f)"]; simp?)
         apply (simp add: tcb_relation_def arch_tcb_context_set_def
                          atcbContextSet_def arch_tcb_relation_def)
        apply (simp add: tcb_cap_cases_def)
       apply (simp add: tcb_cte_cases_def cteSizeBits_def)
-     apply (simp add: exst_same_def)
-    apply (wp thread_set_invs_trivial thread_set_ct_running thread_set_not_state_valid_sched
-              threadSet_invs_trivial threadSet_ct_running' hoare_weak_lift_imp
-              thread_set_ct_in_state
-           | simp add: tcb_cap_cases_def tcb_arch_ref_def exst_same_def
-           | rule threadSet_ct_in_state'
-           | wp (once) hoare_vcg_disj_lift)+
+     apply (wp thread_set_invs_trivial thread_set_not_state_valid_sched
+               threadSet_invs_trivial threadSet_ct_running' hoare_weak_lift_imp
+               thread_set_ct_in_state
+            | simp add: tcb_cap_cases_def tcb_arch_ref_def
+            | rule threadSet_ct_in_state'
+            | wp (once) hoare_vcg_disj_lift)+
   apply clarsimp
   apply (rename_tac s s')
   apply (rule exI, rule conjI, assumption)

--- a/proof/crefine/RISCV64/Retype_C.thy
+++ b/proof/crefine/RISCV64/Retype_C.thy
@@ -1195,7 +1195,7 @@ lemma retype_ctes_helper:
   and      al: "is_aligned ptr (objBitsKO ko)"
   and      sz: "objBitsKO ko \<le> sz"
   and     szb: "sz < word_bits"
-  and     mko: "makeObjectKO dev tp' = Some ko"
+  and     mko: "makeObjectKO dev d tp' = Some ko"
   and      rc: "range_cover ptr sz (objBitsKO ko) n"
   shows  "map_to_ctes (\<lambda>xa. if xa \<in> set (new_cap_addrs n ptr ko) then Some ko else ksPSpace s xa) =
    (\<lambda>x. if tp' = Inr (APIObjectType ArchTypes_H.apiobject_type.CapTableObject) \<and> x \<in> set (new_cap_addrs n ptr ko) \<or>
@@ -1476,7 +1476,7 @@ proof (intro impI allI)
     by (clarsimp simp:range_cover_def[where 'a=machine_word_len, folded word_bits_def])+
 
   (* obj specific *)
-  have mko: "\<And>dev. makeObjectKO dev (Inr (APIObjectType ArchTypes_H.apiobject_type.EndpointObject)) = Some ko"
+  have mko: "\<And>dev d. makeObjectKO dev d (Inr (APIObjectType ArchTypes_H.apiobject_type.EndpointObject)) = Some ko"
     by (simp add: ko_def makeObjectKO_def)
 
   have relrl:
@@ -1590,7 +1590,7 @@ proof (intro impI allI)
     by (clarsimp simp:range_cover_def[where 'a=machine_word_len, folded word_bits_def])+
 
   (* obj specific *)
-  have mko: "\<And> dev. makeObjectKO dev (Inr (APIObjectType ArchTypes_H.apiobject_type.NotificationObject)) = Some ko" by (simp add: ko_def makeObjectKO_def)
+  have mko: "\<And> dev d. makeObjectKO dev d (Inr (APIObjectType ArchTypes_H.apiobject_type.NotificationObject)) = Some ko" by (simp add: ko_def makeObjectKO_def)
 
   have relrl:
     "cnotification_relation (cslift x) makeObject (from_bytes (replicate (size_of TYPE(notification_C)) 0))"
@@ -1742,7 +1742,7 @@ proof (intro impI allI)
     by (clarsimp simp:range_cover_def[where 'a=machine_word_len, folded word_bits_def])+
 
   (* obj specific *)
-  have mko: "\<And>dev. makeObjectKO dev (Inr (APIObjectType  ArchTypes_H.apiobject_type.CapTableObject)) = Some ko"
+  have mko: "\<And>dev d. makeObjectKO dev d (Inr (APIObjectType  ArchTypes_H.apiobject_type.CapTableObject)) = Some ko"
     by (simp add: ko_def makeObjectKO_def)
 
   note relrl = ccte_relation_makeObject
@@ -1976,7 +1976,7 @@ proof (intro impI allI)
           Int_atLeastAtMost atLeastatMost_empty_iff split_paired_Ex
 
   (* obj specific *)
-  have mko: "\<And>dev. makeObjectKO dev (Inr RISCV64_H.PageTableObject) = Some ko" by (simp add: ko_def makeObjectKO_def)
+  have mko: "\<And>dev d. makeObjectKO dev d (Inr RISCV64_H.PageTableObject) = Some ko" by (simp add: ko_def makeObjectKO_def)
 
   have relrl:
     "cpte_relation makeObject (from_bytes (replicate (size_of TYPE(pte_C)) 0))"
@@ -2946,7 +2946,8 @@ end
 
 lemma cnc_tcb_helper:
   fixes p :: "tcb_C ptr"
-  defines "kotcb \<equiv> (KOTCB (makeObject :: tcb))"
+    and d :: domain
+  defines "kotcb \<equiv> KOTCB (tcbDomain_update (\<lambda>_. d) (makeObject :: tcb))"
   assumes rfsr: "(\<sigma>\<lparr>ksPSpace := ks\<rparr>, x) \<in> rf_sr"
   assumes al: "is_aligned (ctcb_ptr_to_tcb_ptr p) (objBitsKO kotcb)"
   assumes ptr0: "ctcb_ptr_to_tcb_ptr p \<noteq> 0"
@@ -2959,6 +2960,7 @@ lemma cnc_tcb_helper:
   assumes empty: "region_is_bytes (ctcb_ptr_to_tcb_ptr p) (2 ^ tcbBlockSizeBits) x"
   assumes rep0: "heap_list (fst (t_hrs_' (globals x))) (2 ^ tcbBlockSizeBits) (ctcb_ptr_to_tcb_ptr p) = replicate (2 ^ tcbBlockSizeBits) 0"
   assumes kdr: "{ctcb_ptr_to_tcb_ptr p..+2 ^ tcbBlockSizeBits} \<inter> kernel_data_refs = {}"
+  assumes domrel: "ucast d = d'"
   shows "(\<sigma>\<lparr>ksPSpace := ks(ctcb_ptr_to_tcb_ptr p \<mapsto> kotcb)\<rparr>,
             globals_update
               (t_hrs_'_update
@@ -2967,7 +2969,8 @@ lemma cnc_tcb_helper:
                                      [heap_update (registers_of_tcb_Ptr p)
                                                   (array_updates (h_val (hrs_mem hrs) (registers_of_tcb_Ptr p))
                                                                  initContext_registers),
-                                      heap_update (machine_word_Ptr &(p\<rightarrow>[''tcbTimeSlice_C''])) 5])
+                                      heap_update (machine_word_Ptr &(p\<rightarrow>[''tcbTimeSlice_C''])) 5,
+                                      heap_update (machine_word_Ptr &(p\<rightarrow>[''tcbDomain_C''])) (d' :: machine_word)])
                        )) x)
            \<in> rf_sr"
   (is "(\<sigma>\<lparr>ksPSpace := ?ks\<rparr>, globals_update ?gs' x) \<in> rf_sr")
@@ -3139,7 +3142,8 @@ proof -
                          \<lparr>registers_C := array_updates (registers_C (tcbContext_C ?tcbArch_C))
                                                        initContext_registers
                             \<rparr>\<rparr>,
-                        tcbTimeSlice_C := 5\<rparr>)"
+                        tcbTimeSlice_C := 5,
+                        tcbDomain_C := d'\<rparr>)"
 
   have tdisj':
     "\<And>y. hrs_htd (t_hrs_' (globals x)) \<Turnstile>\<^sub>t y \<Longrightarrow> ptr_span p \<inter> ptr_span y \<noteq> {} \<Longrightarrow> y = p"
@@ -3190,7 +3194,7 @@ proof -
 
   have rl:
     "(\<forall>v :: 'a :: pre_storable. projectKO_opt kotcb \<noteq> Some v) \<Longrightarrow>
-    (projectKO_opt \<circ>\<^sub>m (ks(ctcb_ptr_to_tcb_ptr p \<mapsto> KOTCB makeObject)) :: machine_word \<Rightarrow> 'a option)
+    (projectKO_opt \<circ>\<^sub>m (ks(ctcb_ptr_to_tcb_ptr p \<mapsto> KOTCB (tcbDomain_update (\<lambda>_. d) makeObject))) :: machine_word \<Rightarrow> 'a option)
     = projectKO_opt \<circ>\<^sub>m ks" using pno al
     apply -
     apply (drule(2) projectKO_opt_retyp_other'[OF _ _ pal])
@@ -3203,8 +3207,9 @@ proof -
     apply (clarsimp simp: projectKOs map_comp_def split: if_split)
     done
 
-  have mko: "\<And>dev. makeObjectKO dev (Inr (APIObjectType ArchTypes_H.apiobject_type.TCBObject)) = Some kotcb"
+  have mko: "\<And>dev. makeObjectKO dev d (Inr (APIObjectType ArchTypes_H.apiobject_type.TCBObject)) = Some kotcb"
     by (simp add: makeObjectKO_def kotcb_def)
+
   note hacky_cte = retype_ctes_helper [where sz = "objBitsKO kotcb" and ko = kotcb and ptr = "ctcb_ptr_to_tcb_ptr p",
     OF pal pds pno al _ _ mko, simplified new_cap_addrs_def, simplified]
 
@@ -3245,7 +3250,7 @@ proof -
       done
   qed
 
-  ultimately have rl_cte: "(map_to_ctes (ks(ctcb_ptr_to_tcb_ptr p \<mapsto> KOTCB makeObject)) :: machine_word \<Rightarrow> cte option)
+  ultimately have rl_cte: "(map_to_ctes (ks(ctcb_ptr_to_tcb_ptr p \<mapsto> KOTCB (tcbDomain_update (\<lambda>_. d) makeObject))) :: machine_word \<Rightarrow> cte option)
     = (\<lambda>x. if x \<in> ptr_val ` (CTypesDefs.ptr_add (cte_Ptr (ctcb_ptr_to_tcb_ptr p)) \<circ> of_nat) ` {k. k < 5}
          then Some (CTE NullCap nullMDBNode)
          else map_to_ctes ks x)"
@@ -3303,18 +3308,20 @@ proof -
     done
 
   have tcb_rel:
-    "ctcb_relation makeObject ?new_tcb"
+    "ctcb_relation (tcbDomain_update (\<lambda>_. d) makeObject) ?new_tcb"
     unfolding ctcb_relation_def makeObject_tcb heap_updates_defs initContext_registers_def
     apply (simp add: fbtcb minBound_word)
     apply (intro conjI)
-         apply (simp add: cthread_state_relation_def thread_state_lift_def
-                          eval_nat_numeral ThreadState_defs)
-        apply (clarsimp simp: ccontext_relation_def newContext_def2 carch_tcb_relation_def
-                              newArchTCB_def cregs_relation_def atcbContextGet_def)
-        apply (case_tac r; simp add: C_register_defs index_foldr_update
-                                     atcbContext_def newArchTCB_def newContext_def
-                                     initContext_def)
-       apply (simp add: thread_state_lift_def index_foldr_update atcbContextGet_def)
+          apply (simp add: cthread_state_relation_def thread_state_lift_def
+                           eval_nat_numeral ThreadState_defs)
+         apply (clarsimp simp: ccontext_relation_def newContext_def2 carch_tcb_relation_def
+                               newArchTCB_def cregs_relation_def atcbContextGet_def
+                               index_foldr_update)
+         apply (case_tac r; simp add: C_register_defs index_foldr_update
+                                      atcbContext_def newArchTCB_def newContext_def
+                                      initContext_def)
+        apply (simp add: thread_state_lift_def index_foldr_update atcbContextGet_def)
+       apply (fastforce intro: domrel)
       apply (simp add: Kernel_Config.timeSlice_def)
      apply (simp add: cfault_rel_def seL4_Fault_lift_def seL4_Fault_get_tag_def Let_def
                       lookup_fault_lift_def lookup_fault_get_tag_def lookup_fault_invalid_root_def
@@ -3447,6 +3454,7 @@ proof -
      apply (erule cmap_relation_retype2)
      apply (simp add:ccte_relation_nullCap nullMDBNode_def nullPointer_def)
     \<comment> \<open>tcb\<close>
+     apply (clarsimp simp: map_comp_update)
      apply (erule cmap_relation_updI2 [where dest = "ctcb_ptr_to_tcb_ptr p" and f = "tcb_ptr_to_ctcb_ptr", simplified])
      apply (rule map_comp_simps)
      apply (rule pks)
@@ -3938,7 +3946,7 @@ proof (intro impI allI)
     by (clarsimp dest!: is_aligned_weaken range_cover.aligned)
 
   (* This is a hack *)
-  have mko: "\<And>dev. makeObjectKO False (Inr object_type.SmallPageObject) = Some ko"
+  have mko: "\<And>dev d. makeObjectKO False d (Inr object_type.SmallPageObject) = Some ko"
     by (simp add: makeObjectKO_def ko_def)
 
   from sz have "3 \<le> sz" by (simp add: objBits_simps pageBits_def ko_def)
@@ -4490,16 +4498,22 @@ lemma ccorres_placeNewObject_tcb:
       and ret_zero regionBase (2 ^ tcbBlockSizeBits)
       and K (regionBase \<noteq> 0 \<and> range_cover regionBase tcbBlockSizeBits tcbBlockSizeBits 1
       \<and>  {regionBase..+2^tcbBlockSizeBits} \<inter> kernel_data_refs = {}))
-   ({s. region_actually_is_zero_bytes regionBase (2^tcbBlockSizeBits) s})
-    hs
-   (placeNewObject regionBase (makeObject :: tcb) 0)
+   ({s. region_actually_is_zero_bytes regionBase (2^tcbBlockSizeBits) s
+        \<and> ksCurDomain_' (globals s) = ucast d}) hs
+   (placeNewObject regionBase (tcbDomain_update (\<lambda>_. d) makeObject) 0)
    (\<acute>tcb :== tcb_Ptr (regionBase + 0x200);;
         (global_htd_update (\<lambda>s. ptr_retyp (Ptr (ptr_val (tcb_' s) - ctcb_offset) :: (cte_C[5]) ptr)
             \<circ> ptr_retyp (tcb_' s)));;
         (Guard C_Guard \<lbrace>hrs_htd \<acute>t_hrs \<Turnstile>\<^sub>t \<acute>tcb\<rbrace>
-           (call (\<lambda>s. s\<lparr>context_' := Ptr &((Ptr &(tcb_' s\<rightarrow>[''tcbArch_C'']) :: arch_tcb_C ptr)\<rightarrow>[''tcbContext_C''])\<rparr>) Arch_initContext_'proc (\<lambda>s t. s\<lparr>globals := globals t\<rparr>) (\<lambda>s' s''. Basic (\<lambda>s. s))));;
+           (call (\<lambda>s. s\<lparr>context_' := Ptr &((Ptr &(tcb_' s\<rightarrow>[''tcbArch_C'']) :: arch_tcb_C ptr)\<rightarrow>[''tcbContext_C''])\<rparr>)
+                 Arch_initContext_'proc (\<lambda>s t. s\<lparr>globals := globals t\<rparr>) (\<lambda>s' s''. Basic (\<lambda>s. s))));;
         (Guard C_Guard \<lbrace>hrs_htd \<acute>t_hrs \<Turnstile>\<^sub>t \<acute>tcb\<rbrace>
-           (Basic (\<lambda>s. globals_update (t_hrs_'_update (hrs_mem_update (heap_update (Ptr &((tcb_' s)\<rightarrow>[''tcbTimeSlice_C''])) (5::machine_word)))) s))))"
+           (Basic (\<lambda>s. globals_update (t_hrs_'_update (hrs_mem_update (heap_update (Ptr &((tcb_' s)\<rightarrow>[''tcbTimeSlice_C''])) (5::machine_word)))) s)));;
+        (Guard C_Guard {s. s \<Turnstile>\<^sub>c tcb_' s}
+          (Basic (\<lambda>s. globals_update
+                       (t_hrs_'_update
+                        (hrs_mem_update (heap_update (Ptr &(tcb_' s\<rightarrow>[''tcbDomain_C'']))
+                                        (ksCurDomain_' (globals s) :: machine_word)))) s))))"
 proof -
   let ?offs = "0x200" \<comment> \<open>2 ^ (tcbBlockSizeBits - 1)\<close>
 
@@ -4539,6 +4553,7 @@ proof -
          clarsimp simp: hrs_htd_update word_bits_def no_fail_def objBitsKO_def
                         range_cover.aligned new_cap_addrs_def tcbBlockSizeBits_def)
   apply (cut_tac \<sigma>=\<sigma> and x=x and ks="ksPSpace \<sigma>" and p="tcb_Ptr (regionBase + ctcb_offset)"
+             and d=d and d'="ucast d"
            in cnc_tcb_helper;
          clarsimp simp: ctcb_ptr_to_tcb_ptr_def objBitsKO_def range_cover.aligned tcbBlockSizeBits_def)
     apply (frule region_actually_is_bytes; clarsimp simp: region_is_bytes'_def)
@@ -4651,7 +4666,7 @@ proof (intro impI allI)
       by (simp add:word_bits_def objBits_simps ko_def pageBits_def)
 
   (* This is a hack *)
-  have mko: "\<And>dev. makeObjectKO True (Inr object_type.SmallPageObject) = Some ko"
+  have mko: "\<And>dev d. makeObjectKO True d (Inr object_type.SmallPageObject) = Some ko"
     by (simp add: makeObjectKO_def ko_def)
 
   from sz have "3 \<le> sz" by (simp add: objBits_simps pageBits_def ko_def)
@@ -5293,18 +5308,14 @@ proof -
           apply (rule ccorres_symb_exec_r)
             apply (ccorres_remove_UNIV_guard)
             apply (simp add: hrs_htd_update)
-            apply (ctac (c_lines 4) add: ccorres_placeNewObject_tcb[simplified])
+            apply (rule ccorres_pre_curDomain)
+            apply (ctac (c_lines 5) add: ccorres_placeNewObject_tcb[simplified])
               apply simp
-              apply (rule ccorres_pre_curDomain)
-              apply ctac
-                apply (rule ccorres_symb_exec_r)
-                  apply (rule ccorres_return_C, simp, simp, simp)
-                 apply vcg
-                apply (rule conseqPre, vcg, clarsimp)
-               apply wp
-              apply vcg
-             apply (simp add: obj_at'_real_def)
-             apply (wp placeNewObject_ko_wp_at')
+              apply (rule ccorres_symb_exec_r)
+                apply (rule ccorres_return_C, simp, simp, simp)
+               apply vcg
+              apply (rule conseqPre, vcg, clarsimp)
+             apply wp
             apply (vcg exspec=Arch_initContext_modifies)
            apply clarsimp
            apply vcg

--- a/proof/crefine/X64/Arch_C.thy
+++ b/proof/crefine/X64/Arch_C.thy
@@ -562,7 +562,7 @@ proof -
      simplified, OF empty[folded szko] szo[symmetric], unfolded szko]
 
   have szb: "pageBits < word_bits" by simp
-  have mko: "\<And>dev. makeObjectKO dev (Inl (KOArch (KOASIDPool f))) = Some ko"
+  have mko: "\<And>dev d f. makeObjectKO dev d (Inl (KOArch (KOASIDPool f))) = Some ko"
     by (simp add: ko_def makeObjectKO_def)
 
 

--- a/proof/crefine/X64/Refine_C.thy
+++ b/proof/crefine/X64/Refine_C.thy
@@ -638,18 +638,17 @@ lemma threadSet_all_invs_triv':
   unfolding all_invs'_def
   apply (rule hoare_pre)
    apply (rule wp_from_corres_unit)
-     apply (rule threadset_corresT [where f="tcb_arch_update (arch_tcb_context_set f)"])
+      apply (rule threadset_corresT [where f="tcb_arch_update (arch_tcb_context_set f)"]; simp?)
         apply (simp add: tcb_relation_def arch_tcb_context_set_def
                          atcbContextSet_def arch_tcb_relation_def)
        apply (simp add: tcb_cap_cases_def)
       apply (simp add: tcb_cte_cases_def tcb_cte_cases_neqs)
-     apply (simp add: exst_same_def)
-    apply (wp thread_set_invs_trivial thread_set_ct_running thread_set_not_state_valid_sched
-              threadSet_invs_trivial threadSet_ct_running' hoare_weak_lift_imp
-              thread_set_ct_in_state
-           | simp add: tcb_cap_cases_def tcb_arch_ref_def exst_same_def
-           | rule threadSet_ct_in_state'
-           | wp (once) hoare_vcg_disj_lift)+
+     apply (wp thread_set_invs_trivial thread_set_not_state_valid_sched
+               threadSet_invs_trivial threadSet_ct_running' hoare_weak_lift_imp
+               thread_set_ct_in_state
+            | simp add: tcb_cap_cases_def tcb_arch_ref_def
+            | rule threadSet_ct_in_state'
+            | wp (once) hoare_vcg_disj_lift)+
   apply clarsimp
   apply (rule exI, rule conjI, assumption)
   apply (clarsimp simp: invs_def invs'_def cur_tcb_def cur_tcb'_def invs_psp_aligned invs_distinct)

--- a/proof/crefine/X64/Retype_C.thy
+++ b/proof/crefine/X64/Retype_C.thy
@@ -1195,7 +1195,7 @@ lemma retype_ctes_helper:
   and      al: "is_aligned ptr (objBitsKO ko)"
   and      sz: "objBitsKO ko \<le> sz"
   and     szb: "sz < word_bits"
-  and     mko: "makeObjectKO dev tp = Some ko"
+  and     mko: "makeObjectKO dev d tp = Some ko"
   and      rc: "range_cover ptr sz (objBitsKO ko) n"
   shows  "map_to_ctes (\<lambda>xa. if xa \<in> set (new_cap_addrs n ptr ko) then Some ko else ksPSpace s xa) =
    (\<lambda>x. if tp = Inr (APIObjectType ArchTypes_H.apiobject_type.CapTableObject) \<and> x \<in> set (new_cap_addrs n ptr ko) \<or>
@@ -1480,7 +1480,7 @@ proof (intro impI allI)
     by (clarsimp simp:range_cover_def[where 'a=machine_word_len, folded word_bits_def])+
 
   (* obj specific *)
-  have mko: "\<And>dev. makeObjectKO dev (Inr (APIObjectType ArchTypes_H.apiobject_type.EndpointObject)) = Some ko"
+  have mko: "\<And>dev d. makeObjectKO dev d (Inr (APIObjectType ArchTypes_H.apiobject_type.EndpointObject)) = Some ko"
     by (simp add: ko_def makeObjectKO_def)
 
   have relrl:
@@ -1594,7 +1594,7 @@ proof (intro impI allI)
     by (clarsimp simp:range_cover_def[where 'a=machine_word_len, folded word_bits_def])+
 
   (* obj specific *)
-  have mko: "\<And> dev. makeObjectKO dev (Inr (APIObjectType ArchTypes_H.apiobject_type.NotificationObject)) = Some ko" by (simp add: ko_def makeObjectKO_def)
+  have mko: "\<And> dev d. makeObjectKO dev d (Inr (APIObjectType ArchTypes_H.apiobject_type.NotificationObject)) = Some ko" by (simp add: ko_def makeObjectKO_def)
 
   have relrl:
     "cnotification_relation (cslift x) makeObject (from_bytes (replicate (size_of TYPE(notification_C)) 0))"
@@ -1746,7 +1746,7 @@ proof (intro impI allI)
     by (clarsimp simp:range_cover_def[where 'a=machine_word_len, folded word_bits_def])+
 
   (* obj specific *)
-  have mko: "\<And>dev. makeObjectKO dev (Inr (APIObjectType  ArchTypes_H.apiobject_type.CapTableObject)) = Some ko"
+  have mko: "\<And>dev d. makeObjectKO dev d (Inr (APIObjectType  ArchTypes_H.apiobject_type.CapTableObject)) = Some ko"
     by (simp add: ko_def makeObjectKO_def)
 
   note relrl = ccte_relation_makeObject
@@ -1980,7 +1980,7 @@ proof (intro impI allI)
           Int_atLeastAtMost atLeastatMost_empty_iff split_paired_Ex
 
   (* obj specific *)
-  have mko: "\<And>dev. makeObjectKO dev (Inr X64_H.PageTableObject) = Some ko" by (simp add: ko_def makeObjectKO_def)
+  have mko: "\<And>dev d. makeObjectKO dev d (Inr X64_H.PageTableObject) = Some ko" by (simp add: ko_def makeObjectKO_def)
 
   have relrl:
     "cpte_relation makeObject (from_bytes (replicate (size_of TYPE(pte_C)) 0))"
@@ -2162,7 +2162,7 @@ proof (intro impI allI)
           Int_atLeastAtMost atLeastatMost_empty_iff split_paired_Ex
 
   (* obj specific *)
-  have mko: "\<And>dev. makeObjectKO dev (Inr X64_H.PageDirectoryObject) = Some ko" by (simp add: ko_def makeObjectKO_def)
+  have mko: "\<And>dev d. makeObjectKO dev d (Inr X64_H.PageDirectoryObject) = Some ko" by (simp add: ko_def makeObjectKO_def)
 
   have relrl:
     "cpde_relation makeObject (from_bytes (replicate (size_of TYPE(pde_C)) 0))"
@@ -2343,7 +2343,7 @@ proof (intro impI allI)
           Int_atLeastAtMost atLeastatMost_empty_iff split_paired_Ex
 
   (* obj specific *)
-  have mko: "\<And>dev. makeObjectKO dev (Inr X64_H.PDPointerTableObject) = Some ko" by (simp add: ko_def makeObjectKO_def)
+  have mko: "\<And>dev d. makeObjectKO dev d (Inr X64_H.PDPointerTableObject) = Some ko" by (simp add: ko_def makeObjectKO_def)
 
   have relrl:
     "cpdpte_relation makeObject (from_bytes (replicate (size_of TYPE(pdpte_C)) 0))"
@@ -2525,7 +2525,7 @@ proof (intro impI allI)
           Int_atLeastAtMost atLeastatMost_empty_iff split_paired_Ex
 
   (* obj specific *)
-  have mko: "\<And>dev. makeObjectKO dev (Inr X64_H.PML4Object) = Some ko" by (simp add: ko_def makeObjectKO_def)
+  have mko: "\<And>dev d. makeObjectKO dev d (Inr X64_H.PML4Object) = Some ko" by (simp add: ko_def makeObjectKO_def)
 
   have relrl:
     "cpml4e_relation makeObject (from_bytes (replicate (size_of TYPE(pml4e_C)) 0))"
@@ -3529,7 +3529,8 @@ end
 
 lemma cnc_tcb_helper:
   fixes p :: "tcb_C ptr"
-  defines "kotcb \<equiv> (KOTCB (makeObject :: tcb))"
+    and d :: domain
+  defines "kotcb \<equiv> KOTCB (tcbDomain_update (\<lambda>_. d) (makeObject :: tcb))"
   assumes rfsr: "(\<sigma>\<lparr>ksPSpace := ks\<rparr>, x) \<in> rf_sr"
   assumes al: "is_aligned (ctcb_ptr_to_tcb_ptr p) (objBitsKO kotcb)"
   assumes ptr0: "ctcb_ptr_to_tcb_ptr p \<noteq> 0"
@@ -3542,6 +3543,7 @@ lemma cnc_tcb_helper:
   assumes empty: "region_is_bytes (ctcb_ptr_to_tcb_ptr p) (2 ^ tcbBlockSizeBits) x"
   assumes rep0: "heap_list (fst (t_hrs_' (globals x))) (2 ^ tcbBlockSizeBits) (ctcb_ptr_to_tcb_ptr p) = replicate (2 ^ tcbBlockSizeBits) 0"
   assumes kdr: "{ctcb_ptr_to_tcb_ptr p..+2 ^ tcbBlockSizeBits} \<inter> kernel_data_refs = {}"
+  assumes domrel: "ucast d = d'"
   shows "(\<sigma>\<lparr>ksPSpace := ks(ctcb_ptr_to_tcb_ptr p \<mapsto> kotcb)\<rparr>,
             globals_update
               (t_hrs_'_update
@@ -3552,7 +3554,8 @@ lemma cnc_tcb_helper:
                                                                  initContext_registers),
                                       heap_update (fpu_state_of_tcb_Ptr p)
                                                   (user_fpu_state_C (ARRAY i. FPUNullState (finite_index i))),
-                                      heap_update (machine_word_Ptr &(p\<rightarrow>[''tcbTimeSlice_C''])) 5])
+                                      heap_update (machine_word_Ptr &(p\<rightarrow>[''tcbTimeSlice_C''])) 5,
+                                      heap_update (machine_word_Ptr &(p\<rightarrow>[''tcbDomain_C''])) (d' :: machine_word)])
                        )) x)
            \<in> rf_sr"
   (is "(\<sigma>\<lparr>ksPSpace := ?ks\<rparr>, globals_update ?gs' x) \<in> rf_sr")
@@ -3725,7 +3728,8 @@ proof -
                                                        initContext_registers,
                           fpuState_C := fpuState_C (tcbContext_C ?tcbArch_C)
                             \<lparr>state_C := ARRAY i. FPUNullState (finite_index i)\<rparr>\<rparr>\<rparr>,
-                        tcbTimeSlice_C := 5\<rparr>)"
+                        tcbTimeSlice_C := 5,
+                        tcbDomain_C := d'\<rparr>)"
 
   have tdisj':
     "\<And>y. hrs_htd (t_hrs_' (globals x)) \<Turnstile>\<^sub>t y \<Longrightarrow> ptr_span p \<inter> ptr_span y \<noteq> {} \<Longrightarrow> y = p"
@@ -3781,7 +3785,7 @@ proof -
 
   have rl:
     "(\<forall>v :: 'a :: pre_storable. projectKO_opt kotcb \<noteq> Some v) \<Longrightarrow>
-    (projectKO_opt \<circ>\<^sub>m (ks(ctcb_ptr_to_tcb_ptr p \<mapsto> KOTCB makeObject)) :: machine_word \<Rightarrow> 'a option)
+    (projectKO_opt \<circ>\<^sub>m (ks(ctcb_ptr_to_tcb_ptr p \<mapsto> KOTCB (tcbDomain_update (\<lambda>_. d) makeObject))) :: machine_word \<Rightarrow> 'a option)
     = projectKO_opt \<circ>\<^sub>m ks" using pno al
     apply -
     apply (drule(2) projectKO_opt_retyp_other'[OF _ _ pal])
@@ -3794,8 +3798,9 @@ proof -
     apply (clarsimp simp: projectKOs map_comp_def split: if_split)
     done
 
-  have mko: "\<And>dev. makeObjectKO dev (Inr (APIObjectType ArchTypes_H.apiobject_type.TCBObject)) = Some kotcb"
+  have mko: "\<And>dev. makeObjectKO dev d (Inr (APIObjectType ArchTypes_H.apiobject_type.TCBObject)) = Some kotcb"
     by (simp add: makeObjectKO_def kotcb_def)
+
   note hacky_cte = retype_ctes_helper [where sz = "objBitsKO kotcb" and ko = kotcb and ptr = "ctcb_ptr_to_tcb_ptr p",
     OF pal pds pno al _ _ mko, simplified new_cap_addrs_def, simplified]
 
@@ -3836,7 +3841,7 @@ proof -
       done
   qed
 
-  ultimately have rl_cte: "(map_to_ctes (ks(ctcb_ptr_to_tcb_ptr p \<mapsto> KOTCB makeObject)) :: machine_word \<Rightarrow> cte option)
+  ultimately have rl_cte: "(map_to_ctes (ks(ctcb_ptr_to_tcb_ptr p \<mapsto> KOTCB (tcbDomain_update (\<lambda>_. d) makeObject))) :: machine_word \<Rightarrow> cte option)
     = (\<lambda>x. if x \<in> ptr_val ` (CTypesDefs.ptr_add (cte_Ptr (ctcb_ptr_to_tcb_ptr p)) \<circ> of_nat) ` {k. k < 5}
          then Some (CTE NullCap nullMDBNode)
          else map_to_ctes ks x)"
@@ -3898,18 +3903,20 @@ proof -
     done
 
   have tcb_rel:
-    "ctcb_relation makeObject ?new_tcb"
+    "ctcb_relation (tcbDomain_update (\<lambda>_. d) makeObject) ?new_tcb"
     unfolding ctcb_relation_def makeObject_tcb heap_updates_defs initContext_registers_def
     apply (simp add: fbtcb minBound_word)
     apply (intro conjI)
-         apply (simp add: cthread_state_relation_def thread_state_lift_def
-                          eval_nat_numeral ThreadState_defs)
-        apply (clarsimp simp: ccontext_relation_def newContext_def2 carch_tcb_relation_def
-                              newArchTCB_def cregs_relation_def atcbContextGet_def fpu_relation_def)
-        apply (case_tac r; simp add: C_register_defs index_foldr_update
-                                     atcbContext_def newArchTCB_def newContext_def
-                                     initContext_def)
-       apply (simp add: thread_state_lift_def index_foldr_update atcbContextGet_def)
+          apply (simp add: cthread_state_relation_def thread_state_lift_def
+                           eval_nat_numeral ThreadState_defs)
+         apply (clarsimp simp: ccontext_relation_def newContext_def2 carch_tcb_relation_def
+                               newArchTCB_def fpu_relation_def cregs_relation_def atcbContextGet_def
+                               index_foldr_update)
+         apply (case_tac r; simp add: C_register_defs index_foldr_update
+                                      atcbContext_def newArchTCB_def newContext_def
+                                      initContext_def)
+        apply (simp add: thread_state_lift_def index_foldr_update atcbContextGet_def)
+       apply (fastforce intro: domrel)
       apply (simp add: Kernel_Config.timeSlice_def)
      apply (simp add: cfault_rel_def seL4_Fault_lift_def seL4_Fault_get_tag_def Let_def
                       lookup_fault_lift_def lookup_fault_get_tag_def lookup_fault_invalid_root_def
@@ -4042,6 +4049,7 @@ proof -
      apply (erule cmap_relation_retype2)
      apply (simp add:ccte_relation_nullCap nullMDBNode_def nullPointer_def)
     \<comment> \<open>tcb\<close>
+     apply (clarsimp simp: map_comp_update)
      apply (erule cmap_relation_updI2 [where dest = "ctcb_ptr_to_tcb_ptr p" and f = "tcb_ptr_to_ctcb_ptr", simplified])
      apply (rule map_comp_simps)
      apply (rule pks)
@@ -4540,7 +4548,7 @@ proof (intro impI allI)
     by (clarsimp dest!: is_aligned_weaken range_cover.aligned)
 
   (* This is a hack *)
-  have mko: "\<And>dev. makeObjectKO False (Inr object_type.SmallPageObject) = Some ko"
+  have mko: "\<And>dev d. makeObjectKO False d (Inr object_type.SmallPageObject) = Some ko"
     by (simp add: makeObjectKO_def ko_def)
 
   from sz have "3 \<le> sz" by (simp add: objBits_simps pageBits_def ko_def)
@@ -5184,16 +5192,22 @@ lemma ccorres_placeNewObject_tcb:
       and ret_zero regionBase (2 ^ tcbBlockSizeBits)
       and K (regionBase \<noteq> 0 \<and> range_cover regionBase tcbBlockSizeBits tcbBlockSizeBits 1
       \<and>  {regionBase..+2^tcbBlockSizeBits} \<inter> kernel_data_refs = {}))
-   ({s. region_actually_is_zero_bytes regionBase (2^tcbBlockSizeBits) s})
-    hs
-   (placeNewObject regionBase (makeObject :: tcb) 0)
+   ({s. region_actually_is_zero_bytes regionBase (2^tcbBlockSizeBits) s
+        \<and> ksCurDomain_' (globals s) = ucast d}) hs
+   (placeNewObject regionBase (tcbDomain_update (\<lambda>_. d) makeObject) 0)
    (\<acute>tcb :== tcb_Ptr (regionBase + 0x400);;
         (global_htd_update (\<lambda>s. ptr_retyp (Ptr (ptr_val (tcb_' s) - ctcb_offset) :: (cte_C[5]) ptr)
             \<circ> ptr_retyp (tcb_' s)));;
         (Guard C_Guard \<lbrace>hrs_htd \<acute>t_hrs \<Turnstile>\<^sub>t \<acute>tcb\<rbrace>
-           (call (\<lambda>s. s\<lparr>context_' := Ptr &((Ptr &(tcb_' s\<rightarrow>[''tcbArch_C'']) :: arch_tcb_C ptr)\<rightarrow>[''tcbContext_C''])\<rparr>) Arch_initContext_'proc (\<lambda>s t. s\<lparr>globals := globals t\<rparr>) (\<lambda>s' s''. Basic (\<lambda>s. s))));;
+           (call (\<lambda>s. s\<lparr>context_' := Ptr &((Ptr &(tcb_' s\<rightarrow>[''tcbArch_C'']) :: arch_tcb_C ptr)\<rightarrow>[''tcbContext_C''])\<rparr>)
+                 Arch_initContext_'proc (\<lambda>s t. s\<lparr>globals := globals t\<rparr>) (\<lambda>s' s''. Basic (\<lambda>s. s))));;
         (Guard C_Guard \<lbrace>hrs_htd \<acute>t_hrs \<Turnstile>\<^sub>t \<acute>tcb\<rbrace>
-           (Basic (\<lambda>s. globals_update (t_hrs_'_update (hrs_mem_update (heap_update (Ptr &((tcb_' s)\<rightarrow>[''tcbTimeSlice_C''])) (5::machine_word)))) s))))"
+           (Basic (\<lambda>s. globals_update (t_hrs_'_update (hrs_mem_update (heap_update (Ptr &((tcb_' s)\<rightarrow>[''tcbTimeSlice_C''])) (5::machine_word)))) s)));;
+        (Guard C_Guard {s. s \<Turnstile>\<^sub>c tcb_' s}
+          (Basic (\<lambda>s. globals_update
+                       (t_hrs_'_update
+                        (hrs_mem_update (heap_update (Ptr &(tcb_' s\<rightarrow>[''tcbDomain_C'']))
+                                        (ksCurDomain_' (globals s) :: machine_word)))) s))))"
   apply (simp add: placeNewObject_eq)
   apply (rule ccorres_from_vcg_nofail)
   apply clarsimp
@@ -5237,6 +5251,7 @@ lemma ccorres_placeNewObject_tcb:
          clarsimp simp: hrs_htd_update word_bits_def no_fail_def objBitsKO_def
                         range_cover.aligned new_cap_addrs_def)
   apply (cut_tac \<sigma>=\<sigma> and x=x and ks="ksPSpace \<sigma>" and p="tcb_Ptr (regionBase + ctcb_offset)"
+             and d=d and d'="ucast d"
            in cnc_tcb_helper;
          clarsimp simp: ctcb_ptr_to_tcb_ptr_def objBitsKO_def range_cover.aligned)
     apply (frule region_actually_is_bytes; clarsimp simp: region_is_bytes'_def)
@@ -5483,7 +5498,7 @@ proof (intro impI allI)
       by (simp add:word_bits_def objBits_simps ko_def pageBits_def)
 
   (* This is a hack *)
-  have mko: "\<And>dev. makeObjectKO True (Inr object_type.SmallPageObject) = Some ko"
+  have mko: "\<And>dev d. makeObjectKO True d (Inr object_type.SmallPageObject) = Some ko"
     by (simp add: makeObjectKO_def ko_def)
 
   from sz have "3 \<le> sz" by (simp add: objBits_simps pageBits_def ko_def)
@@ -6261,18 +6276,14 @@ proof -
           apply (rule ccorres_symb_exec_r)
             apply (ccorres_remove_UNIV_guard)
             apply (simp add: hrs_htd_update)
-            apply (ctac (c_lines 4) add: ccorres_placeNewObject_tcb[simplified])
+            apply (rule ccorres_pre_curDomain)
+            apply (ctac (c_lines 5) add: ccorres_placeNewObject_tcb[simplified])
               apply simp
-              apply (rule ccorres_pre_curDomain)
-              apply ctac
-                apply (rule ccorres_symb_exec_r)
-                  apply (rule ccorres_return_C, simp, simp, simp)
-                 apply vcg
-                apply (rule conseqPre, vcg, clarsimp)
-               apply wp
-              apply vcg
-             apply (simp add: obj_at'_real_def)
-             apply (wp placeNewObject_ko_wp_at')
+              apply (rule ccorres_symb_exec_r)
+                apply (rule ccorres_return_C, simp, simp, simp)
+               apply vcg
+              apply (rule conseqPre, vcg, clarsimp)
+             apply wp
             apply (vcg exspec=Arch_initContext_modifies)
            apply clarsimp
            apply vcg

--- a/proof/invariant-abstract/AARCH64/ArchKHeap_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchKHeap_AI.thy
@@ -977,17 +977,17 @@ lemma state_hyp_refs_of_ntfn_update: "\<And>s ep val. typ_at ANTFN ep s \<Longri
   done
 
 lemma state_hyp_refs_of_tcb_bound_ntfn_update:
-       "kheap s t = Some (TCB tcb) \<Longrightarrow>
-          state_hyp_refs_of (s\<lparr>kheap := (kheap s)(t \<mapsto> TCB (tcb\<lparr>tcb_bound_notification := ntfn\<rparr>))\<rparr>)
-            = state_hyp_refs_of s"
+  "kheap s t = Some (TCB tcb) \<Longrightarrow>
+   state_hyp_refs_of (s\<lparr>kheap := (kheap s)(t \<mapsto> TCB (tcb\<lparr>tcb_bound_notification := ntfn\<rparr>))\<rparr>)
+   = state_hyp_refs_of s"
   apply (rule all_ext)
   apply (clarsimp simp add: state_hyp_refs_of_def obj_at_def split: option.splits)
   done
 
 lemma state_hyp_refs_of_tcb_state_update:
-       "kheap s t = Some (TCB tcb) \<Longrightarrow>
-          state_hyp_refs_of (s\<lparr>kheap := (kheap s)(t \<mapsto> TCB (tcb\<lparr>tcb_state := ts\<rparr>))\<rparr>)
-            = state_hyp_refs_of s"
+  "kheap s t = Some (TCB tcb) \<Longrightarrow>
+   state_hyp_refs_of (s\<lparr>kheap := (kheap s)(t \<mapsto> TCB (tcb\<lparr>tcb_state := ts\<rparr>))\<rparr>)
+   = state_hyp_refs_of s"
   apply (rule all_ext)
   apply (clarsimp simp add: state_hyp_refs_of_def obj_at_def split: option.splits)
   done
@@ -995,7 +995,7 @@ lemma state_hyp_refs_of_tcb_state_update:
 lemma state_hyp_refs_of_tcb_domain_update:
   "kheap s t = Some (TCB tcb) \<Longrightarrow>
    state_hyp_refs_of (s\<lparr>kheap := (kheap s)(t \<mapsto> TCB (tcb\<lparr>tcb_domain := d\<rparr>))\<rparr>)
-     = state_hyp_refs_of s"
+   = state_hyp_refs_of s"
   apply (rule all_ext)
   apply (clarsimp simp add: state_hyp_refs_of_def obj_at_def split: option.splits)
   done
@@ -1003,7 +1003,7 @@ lemma state_hyp_refs_of_tcb_domain_update:
 lemma state_hyp_refs_of_tcb_priority_update:
   "kheap s t = Some (TCB tcb) \<Longrightarrow>
    state_hyp_refs_of (s\<lparr>kheap := (kheap s)(t \<mapsto> TCB (tcb\<lparr>tcb_priority := p\<rparr>))\<rparr>)
-     = state_hyp_refs_of s"
+   = state_hyp_refs_of s"
   apply (rule all_ext)
   apply (clarsimp simp add: state_hyp_refs_of_def obj_at_def split: option.splits)
   done
@@ -1011,7 +1011,7 @@ lemma state_hyp_refs_of_tcb_priority_update:
 lemma state_hyp_refs_of_tcb_time_slice_update:
   "kheap s t = Some (TCB tcb) \<Longrightarrow>
    state_hyp_refs_of (s\<lparr>kheap := (kheap s)(t \<mapsto> TCB (tcb\<lparr>tcb_time_slice := ts\<rparr>))\<rparr>)
-     = state_hyp_refs_of s"
+   = state_hyp_refs_of s"
   apply (rule all_ext)
   apply (clarsimp simp add: state_hyp_refs_of_def obj_at_def split: option.splits)
   done

--- a/proof/invariant-abstract/ARM/ArchKHeap_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchKHeap_AI.thy
@@ -824,17 +824,17 @@ lemma state_hyp_refs_of_ntfn_update: "\<And>s ep val. typ_at ANTFN ep s \<Longri
   done
 
 lemma state_hyp_refs_of_tcb_bound_ntfn_update:
-       "kheap s t = Some (TCB tcb) \<Longrightarrow>
-          state_hyp_refs_of (s\<lparr>kheap := (kheap s)(t \<mapsto> TCB (tcb\<lparr>tcb_bound_notification := ntfn\<rparr>))\<rparr>)
-            = state_hyp_refs_of s"
+  "kheap s t = Some (TCB tcb) \<Longrightarrow>
+   state_hyp_refs_of (s\<lparr>kheap := (kheap s)(t \<mapsto> TCB (tcb\<lparr>tcb_bound_notification := ntfn\<rparr>))\<rparr>)
+   = state_hyp_refs_of s"
   apply (rule all_ext)
   apply (clarsimp simp add: ARM.state_hyp_refs_of_def obj_at_def split: option.splits)
   done
 
 lemma state_hyp_refs_of_tcb_state_update:
-       "kheap s t = Some (TCB tcb) \<Longrightarrow>
-          state_hyp_refs_of (s\<lparr>kheap := (kheap s)(t \<mapsto> TCB (tcb\<lparr>tcb_state := ts\<rparr>))\<rparr>)
-            = state_hyp_refs_of s"
+  "kheap s t = Some (TCB tcb) \<Longrightarrow>
+   state_hyp_refs_of (s\<lparr>kheap := (kheap s)(t \<mapsto> TCB (tcb\<lparr>tcb_state := ts\<rparr>))\<rparr>)
+   = state_hyp_refs_of s"
   apply (rule all_ext)
   apply (clarsimp simp add: ARM.state_hyp_refs_of_def obj_at_def split: option.splits)
   done
@@ -842,7 +842,7 @@ lemma state_hyp_refs_of_tcb_state_update:
 lemma state_hyp_refs_of_tcb_domain_update:
   "kheap s t = Some (TCB tcb) \<Longrightarrow>
    state_hyp_refs_of (s\<lparr>kheap := (kheap s)(t \<mapsto> TCB (tcb\<lparr>tcb_domain := d\<rparr>))\<rparr>)
-     = state_hyp_refs_of s"
+   = state_hyp_refs_of s"
   apply (rule all_ext)
   apply (clarsimp simp add: state_hyp_refs_of_def obj_at_def split: option.splits)
   done
@@ -850,7 +850,7 @@ lemma state_hyp_refs_of_tcb_domain_update:
 lemma state_hyp_refs_of_tcb_priority_update:
   "kheap s t = Some (TCB tcb) \<Longrightarrow>
    state_hyp_refs_of (s\<lparr>kheap := (kheap s)(t \<mapsto> TCB (tcb\<lparr>tcb_priority := p\<rparr>))\<rparr>)
-     = state_hyp_refs_of s"
+   = state_hyp_refs_of s"
   apply (rule all_ext)
   apply (clarsimp simp add: state_hyp_refs_of_def obj_at_def split: option.splits)
   done
@@ -858,7 +858,7 @@ lemma state_hyp_refs_of_tcb_priority_update:
 lemma state_hyp_refs_of_tcb_time_slice_update:
   "kheap s t = Some (TCB tcb) \<Longrightarrow>
    state_hyp_refs_of (s\<lparr>kheap := (kheap s)(t \<mapsto> TCB (tcb\<lparr>tcb_time_slice := ts\<rparr>))\<rparr>)
-     = state_hyp_refs_of s"
+   = state_hyp_refs_of s"
   apply (rule all_ext)
   apply (clarsimp simp add: state_hyp_refs_of_def obj_at_def split: option.splits)
   done

--- a/proof/invariant-abstract/ARM_HYP/ArchBCorres2_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchBCorres2_AI.thy
@@ -15,11 +15,11 @@ named_theorems BCorres2_AI_assms
 
 crunch invoke_cnode
   for (bcorres) bcorres[wp, BCorres2_AI_assms]: truncate_state
-  (simp: swp_def ignore: clearMemory without_preemption filterM ethread_set)
+  (simp: swp_def ignore: clearMemory without_preemption filterM)
 
 crunch create_cap,init_arch_objects,retype_region,delete_objects
   for (bcorres) bcorres[wp]: truncate_state
-  (ignore: freeMemory clearMemory retype_region_ext)
+  (ignore: freeMemory clearMemory)
 
 crunch set_extra_badge,derive_cap
   for (bcorres) bcorres[wp]: truncate_state (ignore: storeWord)
@@ -28,7 +28,7 @@ crunch invoke_untyped
   for (bcorres) bcorres[wp]: truncate_state
   (ignore: sequence_x)
 
-crunch set_mcpriority,
+crunch set_mcpriority, set_priority,
           arch_get_sanitise_register_info, arch_post_modify_registers
   for (bcorres) bcorres[BCorres2_AI_assms,wp]: truncate_state
 
@@ -72,10 +72,6 @@ lemma  handle_arch_fault_reply_bcorres[wp,BCorres2_AI_assms]:
   "bcorres ( handle_arch_fault_reply a b c d) (handle_arch_fault_reply a b c d)"
   by (cases a; wpsimp simp: handle_arch_fault_reply_def)
 
-crunch
-    arch_switch_to_thread,arch_switch_to_idle_thread
-  for (bcorres) bcorres[wp, BCorres2_AI_assms]: truncate_state
-
 end
 
 interpretation BCorres2_AI?: BCorres2_AI
@@ -84,19 +80,13 @@ interpretation BCorres2_AI?: BCorres2_AI
   case 1 show ?case by (unfold_locales; (fact BCorres2_AI_assms)?)
   qed
 
-lemmas schedule_bcorres[wp] = schedule_bcorres1[OF BCorres2_AI_axioms]
-
 context Arch begin arch_global_naming
 
-crunch send_signal,arch_perform_invocation
+crunch send_ipc,send_signal,do_reply_transfer,arch_perform_invocation,invoke_domain
   for (bcorres) bcorres[wp]: truncate_state
-
-crunch send_ipc
-  for (bcorres) bcorres[wp]: truncate_state
-  (simp: ignore: getRegister mapME cap_fault_on_failure)
-
-crunch do_reply_transfer
-  for (bcorres) bcorres[wp]: truncate_state
+  (simp: gets_the_def swp_def
+   ignore: freeMemory clearMemory loadWord cap_fault_on_failure
+           storeWord lookup_error_on_failure getRestartPC getRegister mapME)
 
 lemma perform_invocation_bcorres[wp]: "bcorres (perform_invocation a b c) (perform_invocation a b c)"
   apply (cases c)
@@ -161,33 +151,14 @@ lemma vppi_event_bcorres[wp]:
 lemma handle_reserved_irq_bcorres[wp]: "bcorres (handle_reserved_irq a) (handle_reserved_irq a)"
   unfolding handle_reserved_irq_def by wpsimp
 
-lemma handle_hypervisor_fault_bcorres[wp]: "bcorres (handle_hypervisor_fault a b) (handle_hypervisor_fault a b)"
-  apply (cases b)
-  apply (simp | wp)+
-  done
+crunch handle_hypervisor_fault, timer_tick
+  for (bcorres) bcorres[wp]: truncate_state
 
 lemma handle_event_bcorres[wp]: "bcorres (handle_event e) (handle_event e)"
   apply (cases e)
   apply (simp add: handle_send_def handle_call_def handle_recv_def handle_reply_def handle_yield_def
                    handle_interrupt_def handle_reserved_irq_def Let_def arch_mask_irq_signal_def
          | intro impI conjI allI | wp | wpc)+
-  done
-
-crunch guarded_switch_to,switch_to_idle_thread
-  for (bcorres) bcorres[wp]: truncate_state (ignore: storeWord clearExMonitor)
-
-lemma choose_switch_or_idle:
-  "((), s') \<in> fst (choose_thread s) \<Longrightarrow>
-       (\<exists>word. ((),s') \<in> fst (guarded_switch_to word s)) \<or>
-       ((),s') \<in> fst (switch_to_idle_thread s)"
-  apply (simp add: choose_thread_def)
-  apply (clarsimp simp add: switch_to_idle_thread_def bind_def gets_def
-                   arch_switch_to_idle_thread_def in_monad
-                   return_def get_def modify_def put_def
-                    get_thread_state_def
-                   thread_get_def
-                   split: if_split_asm)
-  apply force
   done
 
 end

--- a/proof/invariant-abstract/ARM_HYP/ArchDetSchedAux_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchDetSchedAux_AI.thy
@@ -13,93 +13,43 @@ context Arch begin arch_global_naming
 
 named_theorems DetSchedAux_AI_assms
 
+lemma set_pd_etcbs[wp]:
+  "set_pd p pd \<lbrace>\<lambda>s. P (etcbs_of s)\<rbrace>"
+  unfolding set_pd_def
+  apply (wpsimp wp: set_object_wp_strong)
+  by (auto elim!: rsubst[where P=P] simp: etcbs_of'_def obj_at_def a_type_def
+           split: kernel_object.splits)
+
 crunch init_arch_objects
   for exst[wp]: "\<lambda>s. P (exst s)"
-  and ct[wp]: "\<lambda>s. P (cur_thread s)"
-  and valid_etcbs[wp, DetSchedAux_AI_assms]: valid_etcbs
-  (wp: crunch_wps unless_wp)
+  and etcbs_of[wp, DetSchedAux_AI_assms]: "\<lambda>s. P (etcbs_of s)"
+  and ready_queues[wp, DetSchedAux_AI_assms]: "\<lambda>s. P (ready_queues s)"
+  and idle_thread[wp, DetSchedAux_AI_assms]: "\<lambda>s. P (idle_thread s)"
+  and schedact[wp, DetSchedAux_AI_assms]: "\<lambda>s. P (scheduler_action s)"
+  and cur_domain[wp, DetSchedAux_AI_assms]: "\<lambda>s. P (cur_domain s)"
+  (wp: crunch_wps)
 
-crunch invoke_untyped
-  for ct[wp, DetSchedAux_AI_assms]: "\<lambda>s. P (cur_thread s)"
-  (wp: crunch_wps dxo_wp_weak preemption_point_inv mapME_x_inv_wp
-   simp: crunch_simps do_machine_op_def detype_def mapM_x_defsym unless_def
-   ignore: freeMemory retype_region_ext)
-crunch invoke_untyped
-  for ready_queues[wp, DetSchedAux_AI_assms]: "\<lambda>s. P (ready_queues s)"
-  (wp: crunch_wps mapME_x_inv_wp preemption_point_inv'
-   simp: detype_def detype_ext_def crunch_simps
-         wrap_ext_det_ext_ext_def mapM_x_defsym
-   ignore: freeMemory)
-crunch invoke_untyped
-  for scheduler_action[wp, DetSchedAux_AI_assms]: "\<lambda>s. P (scheduler_action s)"
-  (wp: crunch_wps mapME_x_inv_wp preemption_point_inv'
-   simp: detype_def detype_ext_def crunch_simps
-         wrap_ext_det_ext_ext_def mapM_x_defsym
-   ignore: freeMemory)
-crunch invoke_untyped
-  for cur_domain[wp, DetSchedAux_AI_assms]: "\<lambda>s. P (cur_domain s)"
-  (wp: crunch_wps mapME_x_inv_wp preemption_point_inv'
-   simp: detype_def detype_ext_def crunch_simps
-         wrap_ext_det_ext_ext_def mapM_x_defsym
-   ignore: freeMemory)
-crunch invoke_untyped
-  for idle_thread[wp, DetSchedAux_AI_assms]: "\<lambda>s. P (idle_thread s)"
-  (wp: crunch_wps mapME_x_inv_wp preemption_point_inv dxo_wp_weak
-   simp: detype_def detype_ext_def crunch_simps
-         wrap_ext_det_ext_ext_def mapM_x_defsym
-   ignore: freeMemory retype_region_ext)
+crunch init_arch_objects
+  for valid_queues[wp]: valid_queues
+  and valid_sched_action[wp]: valid_sched_action
+  and valid_sched[wp]: valid_sched
+  (wp: valid_queues_lift valid_sched_action_lift valid_sched_lift)
 
 lemma tcb_sched_action_valid_idle_etcb:
-  "\<lbrace>valid_idle_etcb\<rbrace>
-     tcb_sched_action foo thread
-   \<lbrace>\<lambda>_. valid_idle_etcb\<rbrace>"
-  apply (rule valid_idle_etcb_lift)
-  apply (simp add: tcb_sched_action_def set_tcb_queue_def)
-  apply (wp | simp)+
-  done
-
-lemma delete_objects_etcb_at[wp, DetSchedAux_AI_assms]:
-  "\<lbrace>\<lambda>s::det_ext state. etcb_at P t s\<rbrace> delete_objects a b \<lbrace>\<lambda>r s. etcb_at P t s\<rbrace>"
-  apply (simp add: delete_objects_def)
-  apply (wp)
-  apply (simp add: detype_def detype_ext_def wrap_ext_det_ext_ext_def etcb_at_def|wp)+
-  done
-
-crunch reset_untyped_cap
-  for etcb_at[wp]: "etcb_at P t"
-  (wp: preemption_point_inv' mapME_x_inv_wp crunch_wps
-    simp: unless_def)
-
-crunch reset_untyped_cap
-  for valid_etcbs[wp]: "valid_etcbs"
-  (wp: preemption_point_inv' mapME_x_inv_wp crunch_wps
-    simp: unless_def)
-
-lemma invoke_untyped_etcb_at [DetSchedAux_AI_assms]:
-  "\<lbrace>(\<lambda>s :: det_ext state. etcb_at P t s) and valid_etcbs\<rbrace> invoke_untyped ui \<lbrace>\<lambda>r s. st_tcb_at (Not o inactive) t s \<longrightarrow> etcb_at P t s\<rbrace>"
-  apply (cases ui)
-  apply (simp add: mapM_x_def[symmetric] invoke_untyped_def whenE_def
-           split del: if_split)
-  apply (rule hoare_pre)
-   apply (wp retype_region_etcb_at mapM_x_wp'
-             create_cap_no_pred_tcb_at typ_at_pred_tcb_at_lift
-             hoare_convert_imp[OF create_cap_no_pred_tcb_at]
-             hoare_convert_imp[OF _ init_arch_objects_exst]
-      | simp
-      | (wp (once) hoare_drop_impE_E))+
-  done
-
+  "tcb_sched_action foo thread \<lbrace>valid_idle_etcb\<rbrace>"
+  by (rule valid_idle_etcb_lift)
+     (wpsimp simp: tcb_sched_action_def set_tcb_queue_def)
 
 crunch init_arch_objects
   for valid_blocked[wp, DetSchedAux_AI_assms]: valid_blocked
-  (wp: valid_blocked_lift set_cap_typ_at)
+  (wp: valid_blocked_lift)
 
-lemma perform_asid_control_etcb_at:"\<lbrace>(\<lambda>s. etcb_at P t s) and valid_etcbs\<rbrace>
-          perform_asid_control_invocation aci
-          \<lbrace>\<lambda>r s. st_tcb_at (Not \<circ> inactive) t s \<longrightarrow> etcb_at P t s\<rbrace>"
+lemma perform_asid_control_etcb_at:
+  "\<lbrace>etcb_at P t\<rbrace>
+   perform_asid_control_invocation aci
+   \<lbrace>\<lambda>r s. st_tcb_at (Not \<circ> inactive) t s \<longrightarrow> etcb_at P t s\<rbrace>"
   apply (simp add: perform_asid_control_invocation_def)
-  apply (rule hoare_pre)
-   apply ( wp | wpc | simp)+
+  apply wpsimp
        apply (wp hoare_imp_lift_something typ_at_pred_tcb_at_lift)[1]
       apply (rule hoare_drop_imps)
       apply (wp retype_region_etcb_at)+
@@ -107,25 +57,12 @@ lemma perform_asid_control_etcb_at:"\<lbrace>(\<lambda>s. etcb_at P t s) and val
   done
 
 crunch perform_asid_control_invocation
-  for ct[wp]: "\<lambda>s. P (cur_thread s)"
-
-crunch perform_asid_control_invocation
   for idle_thread[wp]: "\<lambda>s. P (idle_thread s)"
-
-crunch perform_asid_control_invocation
-  for valid_etcbs[wp]: valid_etcbs (wp: hoare_weak_lift_imp)
-
-crunch perform_asid_control_invocation
-  for valid_blocked[wp]: valid_blocked (wp: hoare_weak_lift_imp)
-
-crunch perform_asid_control_invocation
-  for schedact[wp]: "\<lambda>s :: det_ext state. P (scheduler_action s)" (wp: crunch_wps simp: detype_def detype_ext_def wrap_ext_det_ext_ext_def cap_insert_ext_def ignore: freeMemory)
-
-crunch perform_asid_control_invocation
-  for rqueues[wp]: "\<lambda>s :: det_ext state. P (ready_queues s)" (wp: crunch_wps simp: detype_def detype_ext_def wrap_ext_det_ext_ext_def cap_insert_ext_def ignore: freeMemory)
-
-crunch perform_asid_control_invocation
-  for cur_domain[wp]: "\<lambda>s :: det_ext state. P (cur_domain s)" (wp: crunch_wps simp: detype_def detype_ext_def wrap_ext_det_ext_ext_def cap_insert_ext_def ignore: freeMemory)
+  and valid_blocked[wp]: valid_blocked
+  and schedact[wp]: "\<lambda>s. P (scheduler_action s)"
+  and ready_queues[wp]: "\<lambda>s. P (ready_queues s)"
+  and cur_domain[wp]: "\<lambda>s. P (cur_domain s)"
+  (wp: hoare_weak_lift_imp simp: detype_def)
 
 lemma perform_asid_control_invocation_valid_sched:
   "\<lbrace>ct_active and invs and valid_aci aci and valid_sched and valid_idle\<rbrace>
@@ -145,25 +82,10 @@ lemma perform_asid_control_invocation_valid_sched:
   apply simp
   done
 
-crunch init_arch_objects
-  for valid_queues[wp]: valid_queues (wp: valid_queues_lift)
-
-crunch init_arch_objects
-  for valid_sched_action[wp]: valid_sched_action (wp: valid_sched_action_lift)
-
-crunch init_arch_objects
-  for valid_sched[wp]: valid_sched (wp: valid_sched_lift)
-
 end
 
 lemmas tcb_sched_action_valid_idle_etcb
     = ARM_HYP.tcb_sched_action_valid_idle_etcb
-
-global_interpretation DetSchedAux_AI_det_ext?: DetSchedAux_AI_det_ext
-  proof goal_cases
-  interpret Arch .
-  case 1 show ?case by (unfold_locales; (fact DetSchedAux_AI_assms | wp)?)
-  qed
 
 global_interpretation DetSchedAux_AI?: DetSchedAux_AI
   proof goal_cases

--- a/proof/invariant-abstract/ARM_HYP/ArchDetype_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchDetype_AI.thy
@@ -502,14 +502,12 @@ proof -
 qed
 
 lemma in_user_frame_eq:
-  notes blah[simp del] =  atLeastAtMost_iff
-          atLeastatMost_subset_iff atLeastLessThan_iff
-          Int_atLeastAtMost atLeastatMost_empty_iff split_paired_Ex
-          order_class.Icc_eq_Icc
-     and  p2pm1[simp] = p2pm1_to_mask
-  shows  "p \<notin> untyped_range cap \<Longrightarrow> in_user_frame p
-              (trans_state (\<lambda>_. detype_ext (untyped_range cap) (exst s)) s
-               \<lparr>kheap := \<lambda>x. if x \<in> untyped_range cap then None else kheap s x\<rparr>)
+  notes [simp del] = atLeastAtMost_iff atLeastatMost_subset_iff atLeastLessThan_iff
+                     Int_atLeastAtMost atLeastatMost_empty_iff split_paired_Ex
+                     order_class.Icc_eq_Icc
+    and [simp] = p2pm1_to_mask
+  shows "p \<notin> untyped_range cap \<Longrightarrow>
+         in_user_frame p (s \<lparr>kheap := \<lambda>x. if x \<in> untyped_range cap then None else kheap s x\<rparr>)
          = in_user_frame p s"
     using cap_is_valid untyped
     apply (clarsimp simp: in_user_frame_def)
@@ -544,9 +542,7 @@ lemma in_device_frame_eq:
           order_class.Icc_eq_Icc
      and  p2pm1[simp] = p2pm1_to_mask
   shows "p \<notin> untyped_range cap
-       \<Longrightarrow> in_device_frame p
-              (trans_state (\<lambda>_. detype_ext (untyped_range cap) (exst s)) s
-               \<lparr>kheap := \<lambda>x. if x \<in> untyped_range cap then None else kheap s x\<rparr>)
+       \<Longrightarrow> in_device_frame p (s \<lparr>kheap := \<lambda>x. if x \<in> untyped_range cap then None else kheap s x\<rparr>)
          = in_device_frame p s"
     using untyped cap_is_valid
     apply (clarsimp simp: in_device_frame_def)

--- a/proof/invariant-abstract/ARM_HYP/ArchEmptyFail_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchEmptyFail_AI.thy
@@ -164,18 +164,6 @@ crunch
   for (empty_fail) empty_fail[wp, EmptyFail_AI_assms]
 end
 
-global_interpretation EmptyFail_AI_schedule_unit?: EmptyFail_AI_schedule_unit
-  proof goal_cases
-  interpret Arch .
-  case 1 show ?case by (unfold_locales; (fact EmptyFail_AI_assms)?)
-  qed
-
-global_interpretation EmptyFail_AI_schedule_det?: EmptyFail_AI_schedule_det
-  proof goal_cases
-  interpret Arch .
-  case 1 show ?case by (unfold_locales; (fact EmptyFail_AI_assms)?)
-  qed
-
 global_interpretation EmptyFail_AI_schedule?: EmptyFail_AI_schedule
   proof goal_cases
   interpret Arch .
@@ -195,11 +183,7 @@ lemma deactivateInterrupt_empty_fail[wp]:
   unfolding deactivateInterrupt_def
   by wpsimp
 
-crunch possible_switch_to
-  for (empty_fail) empty_fail[wp, EmptyFail_AI_assms]
-  (ignore_del: possible_switch_to)
-
-crunch handle_event, activate_thread
+crunch possible_switch_to, handle_event, activate_thread
   for (empty_fail) empty_fail[wp, EmptyFail_AI_assms]
   (simp: cap.splits arch_cap.splits split_def invocation_label.splits Let_def
          kernel_object.splits arch_kernel_obj.splits option.splits pde.splits pte.splits
@@ -210,18 +194,6 @@ crunch handle_event, activate_thread
          flush_type.splits page_directory_invocation.splits
    ignore: resetTimer_impl ackInterrupt_impl addressTranslateS1_impl)
 end
-
-global_interpretation EmptyFail_AI_call_kernel_unit?: EmptyFail_AI_call_kernel_unit
-  proof goal_cases
-  interpret Arch .
-  case 1 show ?case by (unfold_locales; (fact EmptyFail_AI_assms)?)
-  qed
-
-global_interpretation EmptyFail_AI_call_kernel_det?: EmptyFail_AI_call_kernel_det
-  proof goal_cases
-  interpret Arch .
-  case 1 show ?case by (unfold_locales; (fact EmptyFail_AI_assms)?)
-  qed
 
 global_interpretation EmptyFail_AI_call_kernel?: EmptyFail_AI_call_kernel
   proof goal_cases

--- a/proof/invariant-abstract/ARM_HYP/ArchInterrupt_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchInterrupt_AI.thy
@@ -261,6 +261,14 @@ lemma handle_reserved_irq_invs[wp]:
   "\<lbrace>invs\<rbrace> handle_reserved_irq irq \<lbrace>\<lambda>_. invs\<rbrace>"
   unfolding handle_reserved_irq_def by (wpsimp simp: non_kernel_IRQs_def)
 
+crunch timer_tick
+  for invs[wp]: invs
+  (wp: thread_set_invs_trivial[OF ball_tcb_cap_casesI])
+
+crunch timer_tick
+  for invs[wp]: invs
+  (wp: thread_set_invs_trivial[OF ball_tcb_cap_casesI])
+
 lemma (* handle_interrupt_invs *) [Interrupt_AI_assms]:
   "\<lbrace>invs\<rbrace> handle_interrupt irq \<lbrace>\<lambda>_. invs\<rbrace>"
   apply (simp add: handle_interrupt_def)

--- a/proof/invariant-abstract/ARM_HYP/ArchInvariants_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchInvariants_AI.thy
@@ -2411,84 +2411,47 @@ lemma valid_arch_arch_tcb_context_set[simp]:
   "valid_arch_tcb (arch_tcb_context_set a t) = valid_arch_tcb t"
   by (simp add: arch_tcb_context_set_def)
 
-lemma tcb_arch_ref_context_update:
-  "tcb_arch_ref (t\<lparr>tcb_arch := (arch_tcb_context_set a (tcb_arch t))\<rparr>) = tcb_arch_ref t"
-  by (simp add: tcb_arch_ref_def arch_tcb_context_set_def)
-
-lemma tcb_arch_ref_set_registers:
-  "tcb_arch_ref (tcb\<lparr>tcb_arch := arch_tcb_set_registers regs (tcb_arch tcb)\<rparr>) = tcb_arch_ref tcb"
-  by (simp add: tcb_arch_ref_def arch_tcb_context_set_def arch_tcb_set_registers_def)
-
 lemma valid_arch_arch_tcb_set_registers[simp]:
   "valid_arch_tcb (arch_tcb_set_registers a t) = valid_arch_tcb t"
    by (simp add: arch_tcb_set_registers_def)
 
-lemma tcb_arch_ref_ipc_buffer_update: "\<And>tcb.
-       tcb_arch_ref (tcb_ipc_buffer_update f tcb) = tcb_arch_ref tcb"
-  by (simp add: tcb_arch_ref_def)
-
-lemma tcb_arch_ref_mcpriority_update: "\<And>tcb.
-       tcb_arch_ref (tcb_mcpriority_update f tcb) = tcb_arch_ref tcb"
-  by (simp add: tcb_arch_ref_def)
-
-lemma tcb_arch_ref_ctable_update: "\<And>tcb.
-       tcb_arch_ref (tcb_ctable_update f tcb) = tcb_arch_ref tcb"
-  by (simp add: tcb_arch_ref_def)
-
-lemma tcb_arch_ref_vtable_update: "\<And>tcb.
-       tcb_arch_ref (tcb_vtable_update f tcb) = tcb_arch_ref tcb"
-  by (simp add: tcb_arch_ref_def)
-
-lemma tcb_arch_ref_reply_update: "\<And>tcb.
-       tcb_arch_ref (tcb_reply_update f tcb) = tcb_arch_ref tcb"
-  by (simp add: tcb_arch_ref_def)
-
-lemma tcb_arch_ref_caller_update: "\<And>tcb.
-       tcb_arch_ref (tcb_caller_update f tcb) = tcb_arch_ref tcb"
-  by (simp add: tcb_arch_ref_def)
-
-lemma tcb_arch_ref_ipcframe_update: "\<And>tcb.
-       tcb_arch_ref (tcb_ipcframe_update f tcb) = tcb_arch_ref tcb"
-  by (simp add: tcb_arch_ref_def)
-
-lemma tcb_arch_ref_state_update: "\<And>tcb.
-       tcb_arch_ref (tcb_state_update f tcb) = tcb_arch_ref tcb"
-  by (simp add: tcb_arch_ref_def)
-
-lemma tcb_arch_ref_fault_handler_update: "\<And>tcb.
-       tcb_arch_ref (tcb_fault_handler_update f tcb) = tcb_arch_ref tcb"
-  by (simp add: tcb_arch_ref_def)
-
-lemma tcb_arch_ref_fault_update: "\<And>tcb.
-       tcb_arch_ref (tcb_fault_update f tcb) = tcb_arch_ref tcb"
-  by (simp add: tcb_arch_ref_def)
-
-lemma tcb_arch_ref_bound_notification_update: "\<And>tcb.
-       tcb_arch_ref (tcb_bound_notification_update f tcb) = tcb_arch_ref tcb"
-  by (simp add: tcb_arch_ref_def)
-
-
-lemmas tcb_arch_ref_simps[simp] = tcb_arch_ref_ipc_buffer_update tcb_arch_ref_mcpriority_update
-  tcb_arch_ref_ctable_update tcb_arch_ref_vtable_update tcb_arch_ref_reply_update
-  tcb_arch_ref_caller_update tcb_arch_ref_ipcframe_update tcb_arch_ref_state_update
-  tcb_arch_ref_fault_handler_update tcb_arch_ref_fault_update tcb_arch_ref_bound_notification_update
-  tcb_arch_ref_context_update tcb_arch_ref_set_registers
+lemma tcb_arch_ref_simps[simp]:
+  "\<And>f. tcb_arch_ref (tcb_ipc_buffer_update f tcb) = tcb_arch_ref tcb"
+  "\<And>f. tcb_arch_ref (tcb_mcpriority_update f tcb) = tcb_arch_ref tcb"
+  "\<And>f. tcb_arch_ref (tcb_ctable_update f tcb) = tcb_arch_ref tcb"
+  "\<And>f. tcb_arch_ref (tcb_vtable_update f tcb) = tcb_arch_ref tcb"
+  "\<And>f. tcb_arch_ref (tcb_reply_update f tcb) = tcb_arch_ref tcb"
+  "\<And>f. tcb_arch_ref (tcb_caller_update f tcb) = tcb_arch_ref tcb"
+  "\<And>f. tcb_arch_ref (tcb_ipcframe_update f tcb) = tcb_arch_ref tcb"
+  "\<And>f. tcb_arch_ref (tcb_state_update f tcb) = tcb_arch_ref tcb"
+  "\<And>f. tcb_arch_ref (tcb_fault_handler_update f tcb) = tcb_arch_ref tcb"
+  "\<And>f. tcb_arch_ref (tcb_fault_update f tcb) = tcb_arch_ref tcb"
+  "\<And>f. tcb_arch_ref (tcb_bound_notification_update f tcb) = tcb_arch_ref tcb"
+  "\<And>f. tcb_arch_ref (tcb_domain_update f tcb) = tcb_arch_ref tcb"
+  "\<And>f. tcb_arch_ref (tcb_priority_update f tcb) = tcb_arch_ref tcb"
+  "\<And>f. tcb_arch_ref (tcb_time_slice_update f tcb) = tcb_arch_ref tcb"
+  "tcb_arch_ref (t\<lparr>tcb_arch := (arch_tcb_context_set a (tcb_arch t))\<rparr>) = tcb_arch_ref t"
+  "tcb_arch_ref (tcb\<lparr>tcb_arch := arch_tcb_set_registers regs (tcb_arch tcb)\<rparr>) = tcb_arch_ref tcb"
+  by (auto simp: tcb_arch_ref_def arch_tcb_set_registers_def arch_tcb_context_set_def)
 
 lemma hyp_live_tcb_def: "hyp_live (TCB tcb) = bound (tcb_arch_ref tcb)"
   by (clarsimp simp: hyp_live_def tcb_arch_ref_def)
 
 lemma hyp_live_tcb_simps[simp]:
-"\<And>tcb f. hyp_live (TCB (tcb_ipc_buffer_update f tcb)) = hyp_live (TCB tcb)"
-"\<And>tcb f. hyp_live (TCB (tcb_mcpriority_update f tcb)) = hyp_live (TCB tcb)"
-"\<And>tcb f. hyp_live (TCB (tcb_ctable_update f tcb)) = hyp_live (TCB tcb)"
-"\<And>tcb f. hyp_live (TCB (tcb_vtable_update f tcb)) = hyp_live (TCB tcb)"
-"\<And>tcb f. hyp_live (TCB (tcb_reply_update f tcb)) = hyp_live (TCB tcb)"
-"\<And>tcb f. hyp_live (TCB (tcb_caller_update f tcb)) = hyp_live (TCB tcb)"
-"\<And>tcb f. hyp_live (TCB (tcb_ipcframe_update f tcb)) = hyp_live (TCB tcb)"
-"\<And>tcb f. hyp_live (TCB (tcb_state_update f tcb)) = hyp_live (TCB tcb)"
-"\<And>tcb f. hyp_live (TCB (tcb_fault_handler_update f tcb)) = hyp_live (TCB tcb)"
-"\<And>tcb f. hyp_live (TCB (tcb_fault_update f tcb)) = hyp_live (TCB tcb)"
-"\<And>tcb f. hyp_live (TCB (tcb_bound_notification_update f tcb)) = hyp_live (TCB tcb)"
+  "\<And>f. hyp_live (TCB (tcb_ipc_buffer_update f tcb)) = hyp_live (TCB tcb)"
+  "\<And>f. hyp_live (TCB (tcb_mcpriority_update f tcb)) = hyp_live (TCB tcb)"
+  "\<And>f. hyp_live (TCB (tcb_ctable_update f tcb)) = hyp_live (TCB tcb)"
+  "\<And>f. hyp_live (TCB (tcb_vtable_update f tcb)) = hyp_live (TCB tcb)"
+  "\<And>f. hyp_live (TCB (tcb_reply_update f tcb)) = hyp_live (TCB tcb)"
+  "\<And>f. hyp_live (TCB (tcb_caller_update f tcb)) = hyp_live (TCB tcb)"
+  "\<And>f. hyp_live (TCB (tcb_ipcframe_update f tcb)) = hyp_live (TCB tcb)"
+  "\<And>f. hyp_live (TCB (tcb_state_update f tcb)) = hyp_live (TCB tcb)"
+  "\<And>f. hyp_live (TCB (tcb_fault_handler_update f tcb)) = hyp_live (TCB tcb)"
+  "\<And>f. hyp_live (TCB (tcb_fault_update f tcb)) = hyp_live (TCB tcb)"
+  "\<And>f. hyp_live (TCB (tcb_bound_notification_update f tcb)) = hyp_live (TCB tcb)"
+  "\<And>f. hyp_live (TCB (tcb_domain_update f tcb)) = hyp_live (TCB tcb)"
+  "\<And>f. hyp_live (TCB (tcb_priority_update f tcb)) = hyp_live (TCB tcb)"
+  "\<And>f. hyp_live (TCB (tcb_time_slice_update f tcb)) = hyp_live (TCB tcb)"
   by (simp_all add: hyp_live_tcb_def)
 
 

--- a/proof/invariant-abstract/ARM_HYP/ArchKHeap_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchKHeap_AI.thy
@@ -697,17 +697,17 @@ lemma state_hyp_refs_of_ntfn_update: "\<And>s ep val. typ_at ANTFN ep s \<Longri
   done
 
 lemma state_hyp_refs_of_tcb_bound_ntfn_update:
-       "kheap s t = Some (TCB tcb) \<Longrightarrow>
-          state_hyp_refs_of (s\<lparr>kheap := (kheap s)(t \<mapsto> TCB (tcb\<lparr>tcb_bound_notification := ntfn\<rparr>))\<rparr>)
-            = state_hyp_refs_of s"
+  "kheap s t = Some (TCB tcb) \<Longrightarrow>
+   state_hyp_refs_of (s\<lparr>kheap := (kheap s)(t \<mapsto> TCB (tcb\<lparr>tcb_bound_notification := ntfn\<rparr>))\<rparr>)
+   = state_hyp_refs_of s"
   apply (rule all_ext)
   apply (clarsimp simp add: ARM_HYP.state_hyp_refs_of_def obj_at_def split: option.splits)
   done
 
 lemma state_hyp_refs_of_tcb_state_update:
-       "kheap s t = Some (TCB tcb) \<Longrightarrow>
-          state_hyp_refs_of (s\<lparr>kheap := (kheap s)(t \<mapsto> TCB (tcb\<lparr>tcb_state := ts\<rparr>))\<rparr>)
-            = state_hyp_refs_of s"
+  "kheap s t = Some (TCB tcb) \<Longrightarrow>
+   state_hyp_refs_of (s\<lparr>kheap := (kheap s)(t \<mapsto> TCB (tcb\<lparr>tcb_state := ts\<rparr>))\<rparr>)
+   = state_hyp_refs_of s"
   apply (rule all_ext)
   apply (clarsimp simp add: ARM_HYP.state_hyp_refs_of_def obj_at_def split: option.splits)
   done
@@ -715,7 +715,7 @@ lemma state_hyp_refs_of_tcb_state_update:
 lemma state_hyp_refs_of_tcb_domain_update:
   "kheap s t = Some (TCB tcb) \<Longrightarrow>
    state_hyp_refs_of (s\<lparr>kheap := (kheap s)(t \<mapsto> TCB (tcb\<lparr>tcb_domain := d\<rparr>))\<rparr>)
-     = state_hyp_refs_of s"
+   = state_hyp_refs_of s"
   apply (rule all_ext)
   apply (clarsimp simp add: state_hyp_refs_of_def obj_at_def split: option.splits)
   done
@@ -723,7 +723,7 @@ lemma state_hyp_refs_of_tcb_domain_update:
 lemma state_hyp_refs_of_tcb_priority_update:
   "kheap s t = Some (TCB tcb) \<Longrightarrow>
    state_hyp_refs_of (s\<lparr>kheap := (kheap s)(t \<mapsto> TCB (tcb\<lparr>tcb_priority := p\<rparr>))\<rparr>)
-     = state_hyp_refs_of s"
+   = state_hyp_refs_of s"
   apply (rule all_ext)
   apply (clarsimp simp add: state_hyp_refs_of_def obj_at_def split: option.splits)
   done
@@ -731,7 +731,7 @@ lemma state_hyp_refs_of_tcb_priority_update:
 lemma state_hyp_refs_of_tcb_time_slice_update:
   "kheap s t = Some (TCB tcb) \<Longrightarrow>
    state_hyp_refs_of (s\<lparr>kheap := (kheap s)(t \<mapsto> TCB (tcb\<lparr>tcb_time_slice := ts\<rparr>))\<rparr>)
-     = state_hyp_refs_of s"
+   = state_hyp_refs_of s"
   apply (rule all_ext)
   apply (clarsimp simp add: state_hyp_refs_of_def obj_at_def split: option.splits)
   done

--- a/proof/invariant-abstract/ARM_HYP/ArchSchedule_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchSchedule_AI.thy
@@ -49,8 +49,8 @@ lemma arch_stt_tcb [wp,Schedule_AI_assms]:
   "\<lbrace>tcb_at t'\<rbrace> arch_switch_to_thread t' \<lbrace>\<lambda>_. tcb_at t'\<rbrace>"
   by (wpsimp simp: arch_switch_to_thread_def wp: tcb_at_typ_at)
 
-lemma arch_stt_runnable[Schedule_AI_assms]:
-  "\<lbrace>st_tcb_at runnable t\<rbrace> arch_switch_to_thread t \<lbrace>\<lambda>r. st_tcb_at runnable t\<rbrace>"
+lemma arch_stt_st_tcb_at[Schedule_AI_assms]:
+  "arch_switch_to_thread t \<lbrace>st_tcb_at Q t\<rbrace>"
   by (wpsimp simp: arch_switch_to_thread_def)
 
 lemma idle_strg:
@@ -104,28 +104,19 @@ lemma stit_activatable[Schedule_AI_assms]:
                  elim!: pred_tcb_weaken_strongerE)
   done
 
-lemma stt_invs [wp,Schedule_AI_assms]:
-  "\<lbrace>invs\<rbrace> switch_to_thread t' \<lbrace>\<lambda>_. invs\<rbrace>"
-  apply (simp add: switch_to_thread_def)
-  apply wp
-     apply (simp add: trans_state_update[symmetric] del: trans_state_update)
-    apply (rule_tac Q'="\<lambda>_. invs and tcb_at t'" in hoare_strengthen_post, wp)
-    apply (clarsimp simp: invs_def valid_state_def valid_idle_def
-                          valid_irq_node_def valid_machine_state_def)
-    apply (fastforce simp: cur_tcb_def obj_at_def
-                     elim: valid_pspace_eqI ifunsafe_pspaceI)
-   apply wp+
-  apply clarsimp
-  apply (simp add: is_tcb_def)
-  done
-end
+crunch set_vm_root, vcpu_switch
+  for scheduler_action[wp]: "\<lambda>s. P (scheduler_action s)"
+  (wp: crunch_wps simp: crunch_simps)
 
-interpretation Schedule_AI_U?: Schedule_AI_U
-  proof goal_cases
-  interpret Arch .
-  case 1 show ?case
-  by (intro_locales; (unfold_locales; fact Schedule_AI_assms)?)
-  qed
+lemma arch_stt_scheduler_action [wp, Schedule_AI_assms]:
+  "\<lbrace>\<lambda>s. P (scheduler_action s)\<rbrace> arch_switch_to_thread t' \<lbrace>\<lambda>_ s. P (scheduler_action s)\<rbrace>"
+  by (wpsimp simp: arch_switch_to_thread_def)
+
+lemma arch_stit_scheduler_action [wp, Schedule_AI_assms]:
+  "\<lbrace>\<lambda>s. P (scheduler_action s)\<rbrace> arch_switch_to_idle_thread \<lbrace>\<lambda>_ s. P (scheduler_action s)\<rbrace>"
+  by (wpsimp simp: arch_switch_to_idle_thread_def)
+
+end
 
 interpretation Schedule_AI?: Schedule_AI
   proof goal_cases

--- a/proof/invariant-abstract/ARM_HYP/ArchUntyped_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchUntyped_AI.thy
@@ -153,7 +153,7 @@ lemma retype_ret_valid_caps_captable[Untyped_AI_assms]:
    \<and> range_cover ptr sz (obj_bits_api CapTableObject us) n \<and> ptr \<noteq> 0
        \<rbrakk>
          \<Longrightarrow> \<forall>y\<in>{0..<n}. s
-                \<lparr>kheap := foldr (\<lambda>p kh. kh(p \<mapsto> default_object CapTableObject dev us)) (map (\<lambda>p. ptr_add ptr (p * 2 ^ obj_bits_api CapTableObject us)) [0..<n])
+                \<lparr>kheap := foldr (\<lambda>p kh. kh(p \<mapsto> default_object CapTableObject dev us (cur_domain s))) (map (\<lambda>p. ptr_add ptr (p * 2 ^ obj_bits_api CapTableObject us)) [0..<n])
                            (kheap s)\<rparr> \<turnstile> CNodeCap (ptr_add ptr (y * 2 ^ obj_bits_api CapTableObject us)) us []"
 by ((clarsimp simp:valid_cap_def default_object_def cap_aligned_def
         cte_level_bits_def slot_bits_def is_obj_defs well_formed_cnode_n_def empty_cnode_def
@@ -166,13 +166,14 @@ lemma retype_ret_valid_caps_aobj[Untyped_AI_assms]:
   \<lbrakk>pspace_no_overlap_range_cover ptr sz s \<and> x6 \<noteq> ASIDPoolObj \<and>
   range_cover ptr sz (obj_bits_api (ArchObject x6) us) n \<and> ptr \<noteq> 0\<rbrakk>
             \<Longrightarrow> \<forall>y\<in>{0..<n}. s
-                   \<lparr>kheap := foldr (\<lambda>p kh. kh(p \<mapsto> default_object (ArchObject x6) dev us)) (map (\<lambda>p. ptr_add ptr (p * 2 ^ obj_bits_api (ArchObject x6) us)) [0..<n])
-                              (kheap s)\<rparr> \<turnstile> ArchObjectCap (ARM_HYP_A.arch_default_cap x6 (ptr_add ptr (y * 2 ^ obj_bits_api (ArchObject x6) us)) us dev)"
+                   \<lparr>kheap := foldr (\<lambda>p kh. kh(p \<mapsto> default_object (ArchObject x6) dev us (cur_domain s))) (map (\<lambda>p. ptr_add ptr (p * 2 ^ obj_bits_api (ArchObject x6) us)) [0..<n])
+                              (kheap s)\<rparr> \<turnstile> ArchObjectCap (arch_default_cap x6 (ptr_add ptr (y * 2 ^ obj_bits_api (ArchObject x6) us)) us dev)"
   apply (rename_tac aobject_type us n)
   apply (case_tac aobject_type)
-by (clarsimp simp:valid_cap_def default_object_def cap_aligned_def
-        cte_level_bits_def slot_bits_def is_obj_defs well_formed_cnode_n_def empty_cnode_def
-        dom_def arch_default_cap_def ptr_add_def | intro conjI obj_at_foldr_intro
+  by (clarsimp simp: valid_cap_def default_object_def cap_aligned_def
+                     cte_level_bits_def is_obj_defs well_formed_cnode_n_def empty_cnode_def
+                     dom_def arch_default_cap_def ptr_add_def
+      | intro conjI obj_at_foldr_intro
         imageI valid_vm_rights_def
       | rule is_aligned_add_multI[OF _ le_refl]
       | fastforce simp:range_cover_def obj_bits_api_def
@@ -404,9 +405,8 @@ lemma nonempty_table_caps_of[Untyped_AI_assms]:
 
 
 lemma nonempty_default[simp, Untyped_AI_assms]:
-  "tp \<noteq> Untyped \<Longrightarrow> \<not> nonempty_table S (default_object tp dev us)"
-  apply (case_tac tp, simp_all add: default_object_def nonempty_table_def
-                                    a_type_def)
+  "tp \<noteq> Untyped \<Longrightarrow> \<not> nonempty_table S (default_object tp dev us d)"
+  apply (case_tac tp, simp_all add: default_object_def nonempty_table_def a_type_def)
   apply (rename_tac aobject_type)
   apply (case_tac aobject_type, simp_all add: default_arch_object_def)
    apply (simp_all add: empty_table_def pde_ref_def valid_pde_mappings_def)

--- a/proof/invariant-abstract/ARM_HYP/ArchVSpaceEntries_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchVSpaceEntries_AI.thy
@@ -553,14 +553,10 @@ lemma invoke_cnode_valid_pdpt_objs[wp]:
    apply (wp get_cap_wp | wpc | simp split del: if_split)+
   done
 
-crunch invoke_tcb
+crunch invoke_tcb, invoke_domain
   for valid_pdpt_objs[wp]: "valid_pdpt_objs"
   (wp: check_cap_inv crunch_wps simp: crunch_simps
        ignore: check_cap_at)
-
-lemma invoke_domain_valid_pdpt_objs[wp]:
-  "\<lbrace>valid_pdpt_objs\<rbrace> invoke_domain t d \<lbrace>\<lambda>rv. valid_pdpt_objs\<rbrace>"
-  by (simp add: invoke_domain_def | wp)+
 
 crunch set_extra_badge, transfer_caps_loop
   for valid_pdpt_objs[wp]: "valid_pdpt_objs"
@@ -1497,11 +1493,11 @@ lemma invocation_duplicates_valid_exst_update[simp]:
   apply (clarsimp simp add: invocation_duplicates_valid_def pti_duplicates_valid_def page_inv_duplicates_valid_def page_inv_entries_safe_def split: sum.splits invocation.splits arch_invocation.splits kernel_object.splits page_table_invocation.splits page_invocation.splits)+
   done
 
-
 lemma set_thread_state_duplicates_valid[wp]:
   "\<lbrace>invocation_duplicates_valid i\<rbrace> set_thread_state t st \<lbrace>\<lambda>rv. invocation_duplicates_valid i\<rbrace>"
-  apply (simp add: set_thread_state_def set_object_def get_object_def)
-  apply (wp|simp)+
+  apply (simp add: set_thread_state_def set_thread_state_act_def set_scheduler_action_def
+                   get_thread_state_def thread_get_def set_object_def get_object_def)
+  apply wpsimp
   apply (clarsimp simp: invocation_duplicates_valid_def pti_duplicates_valid_def
                         page_inv_duplicates_valid_def page_inv_entries_safe_def
                         Let_def
@@ -1510,7 +1506,7 @@ lemma set_thread_state_duplicates_valid[wp]:
                         page_table_invocation.split
                         page_invocation.split sum.split
                         )
-  apply (auto simp add: obj_at_def page_inv_entries_safe_def)
+   apply (auto simp add: obj_at_def page_inv_entries_safe_def)
   done
 
 lemma handle_invocation_valid_pdpt[wp]:
@@ -1524,22 +1520,21 @@ lemma handle_invocation_valid_pdpt[wp]:
      (auto simp: ct_in_state_def elim: st_tcb_ex_cap)
 
 
-crunch handle_event, activate_thread,switch_to_thread,
-       switch_to_idle_thread
+crunch handle_event, activate_thread, switch_to_thread,
+       switch_to_idle_thread, schedule_choose_new_thread
   for valid_pdpt[wp]: "valid_pdpt_objs"
   (simp: crunch_simps wp: crunch_wps OR_choice_weak_wp select_ext_weak_wp
       ignore: without_preemption getActiveIRQ resetTimer ackInterrupt
               getFAR getDFSR getIFSR OR_choice set_scheduler_action
               clearExMonitor)
 
-lemma schedule_valid_pdpt[wp]: "\<lbrace>valid_pdpt_objs\<rbrace> schedule :: (unit,unit) s_monad \<lbrace>\<lambda>_. valid_pdpt_objs\<rbrace>"
-  apply (simp add: schedule_def allActiveTCBs_def)
-  apply wpsimp
-  done
+lemma schedule_valid_pdpt[wp]:
+  "schedule \<lbrace>valid_pdpt_objs\<rbrace>"
+  unfolding schedule_def by (wpsimp wp: hoare_drop_imps)
 
 lemma call_kernel_valid_pdpt[wp]:
   "\<lbrace>invs and (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_running s) and valid_pdpt_objs\<rbrace>
-      (call_kernel e) :: (unit,unit) s_monad
+   call_kernel e
    \<lbrace>\<lambda>_. valid_pdpt_objs\<rbrace>"
   apply (cases e, simp_all add: call_kernel_def)
       apply (rule hoare_pre)

--- a/proof/invariant-abstract/ARM_HYP/ArchVSpace_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchVSpace_AI.thy
@@ -5992,7 +5992,7 @@ lemma perform_asid_pool_invs [wp]:
 
 lemma valid_vspace_obj_default:
   assumes tyunt: "ty \<noteq> Structures_A.apiobject_type.Untyped"
-  shows "ArchObj ao = default_object ty dev us \<Longrightarrow> valid_vspace_obj ao s'"
+  shows "ArchObj ao = default_object ty dev us d \<Longrightarrow> valid_vspace_obj ao s'"
   apply (cases ty, simp_all add: default_object_def tyunt)
   apply (simp add: valid_vspace_obj_default')
   done

--- a/proof/invariant-abstract/RISCV64/ArchArch_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchArch_AI.thy
@@ -919,6 +919,9 @@ lemma invoke_arch_invs[wp]:
   apply (wp|simp)+
   done
 
+crunch set_thread_state_act
+  for aobjs_of[wp]: "\<lambda>s. P (aobjs_of s)"
+
 lemma sts_aobjs_of[wp]:
   "set_thread_state t st \<lbrace>\<lambda>s. P (aobjs_of s)\<rbrace>"
   unfolding set_thread_state_def

--- a/proof/invariant-abstract/RISCV64/ArchBCorres2_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchBCorres2_AI.thy
@@ -15,11 +15,11 @@ named_theorems BCorres2_AI_assms
 
 crunch invoke_cnode
   for (bcorres) bcorres[wp, BCorres2_AI_assms]: truncate_state
-  (simp: swp_def ignore: clearMemory without_preemption filterM ethread_set)
+  (simp: swp_def ignore: clearMemory without_preemption filterM)
 
 crunch create_cap,init_arch_objects,retype_region,delete_objects
   for (bcorres) bcorres[wp]: truncate_state
-  (ignore: freeMemory clearMemory retype_region_ext)
+  (ignore: freeMemory clearMemory)
 
 crunch set_extra_badge,derive_cap
   for (bcorres) bcorres[wp]: truncate_state (ignore: storeWord)
@@ -28,7 +28,7 @@ crunch invoke_untyped
   for (bcorres) bcorres[wp]: truncate_state
   (ignore: sequence_x)
 
-crunch set_mcpriority
+crunch set_mcpriority, set_priority
   for (bcorres) bcorres[wp]: truncate_state
 
 crunch arch_get_sanitise_register_info, arch_post_modify_registers
@@ -74,10 +74,6 @@ lemma  handle_arch_fault_reply_bcorres[wp,BCorres2_AI_assms]:
   "bcorres ( handle_arch_fault_reply a b c d) (handle_arch_fault_reply a b c d)"
   by (cases a; simp add: handle_arch_fault_reply_def; wp)
 
-crunch
-    arch_switch_to_thread,arch_switch_to_idle_thread
-  for (bcorres) bcorres[wp, BCorres2_AI_assms]: truncate_state
-
 end
 
 interpretation BCorres2_AI?: BCorres2_AI
@@ -86,11 +82,9 @@ interpretation BCorres2_AI?: BCorres2_AI
   case 1 show ?case by (unfold_locales; (fact BCorres2_AI_assms)?)
   qed
 
-lemmas schedule_bcorres[wp] = schedule_bcorres1[OF BCorres2_AI_axioms]
-
 context Arch begin arch_global_naming
 
-crunch send_ipc,send_signal,do_reply_transfer,arch_perform_invocation
+crunch send_ipc,send_signal,do_reply_transfer,arch_perform_invocation,invoke_domain
   for (bcorres) bcorres[wp]: truncate_state
   (simp: gets_the_def swp_def
    ignore: freeMemory clearMemory loadWord cap_fault_on_failure
@@ -139,32 +133,14 @@ crunch receive_ipc,receive_signal,delete_caller_cap
 lemma handle_vm_fault_bcorres[wp]: "bcorres (handle_vm_fault a b) (handle_vm_fault a b)"
   unfolding handle_vm_fault_def by (cases b; wpsimp)
 
-lemma handle_hypervisor_fault_bcorres[wp]: "bcorres (handle_hypervisor_fault a b) (handle_hypervisor_fault a b)"
-  by (cases b) wpsimp
-
+crunch handle_hypervisor_fault, timer_tick
+  for (bcorres) bcorres[wp]: truncate_state
 
 lemma handle_event_bcorres[wp]: "bcorres (handle_event e) (handle_event e)"
   apply (cases e)
   apply (simp add: handle_send_def handle_call_def handle_recv_def handle_reply_def handle_yield_def
                    handle_interrupt_def Let_def handle_reserved_irq_def arch_mask_irq_signal_def
          | intro impI conjI allI | wp | wpc)+
-  done
-
-crunch guarded_switch_to,switch_to_idle_thread
-  for (bcorres) bcorres[wp]: truncate_state (ignore: storeWord)
-
-lemma choose_switch_or_idle:
-  "((), s') \<in> fst (choose_thread s) \<Longrightarrow>
-       (\<exists>word. ((),s') \<in> fst (guarded_switch_to word s)) \<or>
-       ((),s') \<in> fst (switch_to_idle_thread s)"
-  apply (simp add: choose_thread_def)
-  apply (clarsimp simp add: switch_to_idle_thread_def bind_def gets_def
-                   arch_switch_to_idle_thread_def in_monad
-                   return_def get_def modify_def put_def
-                    get_thread_state_def
-                   thread_get_def
-                   split: if_split_asm)
-  apply force
   done
 
 end

--- a/proof/invariant-abstract/RISCV64/ArchDetSchedAux_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchDetSchedAux_AI.thy
@@ -14,92 +14,31 @@ named_theorems DetSchedAux_AI_assms
 
 crunch init_arch_objects
   for exst[wp]: "\<lambda>s. P (exst s)"
-  and ct[wp]: "\<lambda>s. P (cur_thread s)"
-  and valid_etcbs[wp, DetSchedAux_AI_assms]: valid_etcbs
-  (wp: crunch_wps unless_wp valid_etcbs_lift)
-
-crunch invoke_untyped
-  for ct[wp, DetSchedAux_AI_assms]: "\<lambda>s. P (cur_thread s)"
-  (wp: crunch_wps dxo_wp_weak preemption_point_inv mapME_x_inv_wp
-   simp: crunch_simps do_machine_op_def detype_def mapM_x_defsym unless_def
-   ignore: freeMemory retype_region_ext)
-crunch invoke_untyped
-  for ready_queues[wp, DetSchedAux_AI_assms]: "\<lambda>s. P (ready_queues s)"
-  (wp: crunch_wps mapME_x_inv_wp preemption_point_inv'
-   simp: detype_def detype_ext_def crunch_simps
-          wrap_ext_det_ext_ext_def mapM_x_defsym
-   ignore: freeMemory)
-crunch invoke_untyped
-  for scheduler_action[wp, DetSchedAux_AI_assms]: "\<lambda>s. P (scheduler_action s)"
-  (wp: crunch_wps mapME_x_inv_wp preemption_point_inv'
-   simp: detype_def detype_ext_def crunch_simps
-         wrap_ext_det_ext_ext_def mapM_x_defsym
-   ignore: freeMemory)
-crunch invoke_untyped
-  for cur_domain[wp, DetSchedAux_AI_assms]: "\<lambda>s. P (cur_domain s)"
-  (wp: crunch_wps mapME_x_inv_wp preemption_point_inv'
-   simp: detype_def detype_ext_def crunch_simps
-         wrap_ext_det_ext_ext_def mapM_x_defsym
-   ignore: freeMemory)
-crunch invoke_untyped
-  for idle_thread[wp, DetSchedAux_AI_assms]: "\<lambda>s. P (idle_thread s)"
-  (wp: crunch_wps mapME_x_inv_wp preemption_point_inv dxo_wp_weak
-   simp: detype_def detype_ext_def crunch_simps
-         wrap_ext_det_ext_ext_def mapM_x_defsym
-   ignore: freeMemory retype_region_ext)
+  and valid_queues[wp]: valid_queues
+  and valid_sched_action[wp]: valid_sched_action
+  and valid_sched[wp]: valid_sched
+  and etcbs_of[wp, DetSchedAux_AI_assms]: "\<lambda>s. P (etcbs_of s)"
+  and ready_queues[wp, DetSchedAux_AI_assms]: "\<lambda>s. P (ready_queues s)"
+  and idle_thread[wp, DetSchedAux_AI_assms]: "\<lambda>s. P (idle_thread s)"
+  and schedact[wp, DetSchedAux_AI_assms]: "\<lambda>s. P (scheduler_action s)"
+  and cur_domain[wp, DetSchedAux_AI_assms]: "\<lambda>s. P (cur_domain s)"
+  (wp: mapM_x_wp')
 
 lemma tcb_sched_action_valid_idle_etcb:
-  "\<lbrace>valid_idle_etcb\<rbrace>
-     tcb_sched_action foo thread
-   \<lbrace>\<lambda>_. valid_idle_etcb\<rbrace>"
-  apply (rule valid_idle_etcb_lift)
-  apply (simp add: tcb_sched_action_def set_tcb_queue_def)
-  apply (wp | simp)+
-  done
-
-crunch do_machine_op
-  for ekheap[wp]: "\<lambda>s. P (ekheap s)"
-
-lemma delete_objects_etcb_at[wp, DetSchedAux_AI_assms]:
-  "\<lbrace>\<lambda>s::det_ext state. etcb_at P t s\<rbrace> delete_objects a b \<lbrace>\<lambda>r s. etcb_at P t s\<rbrace>"
-  apply (simp add: delete_objects_def)
-  apply (simp add: detype_def detype_ext_def wrap_ext_det_ext_ext_def etcb_at_def|wp)+
-  done
-
-crunch reset_untyped_cap
-  for etcb_at[wp]: "etcb_at P t"
-  (wp: preemption_point_inv' mapME_x_inv_wp crunch_wps
-    simp: unless_def)
-
-crunch reset_untyped_cap
-  for valid_etcbs[wp]: "valid_etcbs"
-  (wp: preemption_point_inv' mapME_x_inv_wp crunch_wps
-    simp: unless_def)
-
-lemma invoke_untyped_etcb_at [DetSchedAux_AI_assms]:
-  "\<lbrace>(\<lambda>s :: det_ext state. etcb_at P t s) and valid_etcbs\<rbrace> invoke_untyped ui \<lbrace>\<lambda>r s. st_tcb_at (Not o inactive) t s \<longrightarrow> etcb_at P t s\<rbrace>"
-  apply (cases ui)
-  apply (simp add: mapM_x_def[symmetric] invoke_untyped_def whenE_def
-           split del: if_split)
-  apply (wp retype_region_etcb_at mapM_x_wp'
-            create_cap_no_pred_tcb_at typ_at_pred_tcb_at_lift
-            hoare_convert_imp[OF create_cap_no_pred_tcb_at]
-            hoare_convert_imp[OF _ init_arch_objects_exst]
-      | simp
-      | (wp (once) hoare_drop_impE_E))+
-  done
-
+  "tcb_sched_action foo thread \<lbrace>valid_idle_etcb\<rbrace>"
+  by (rule valid_idle_etcb_lift)
+     (wpsimp simp: tcb_sched_action_def set_tcb_queue_def)
 
 crunch init_arch_objects
   for valid_blocked[wp, DetSchedAux_AI_assms]: valid_blocked
-  (wp: valid_blocked_lift set_cap_typ_at)
+  (wp: valid_blocked_lift)
 
-lemma perform_asid_control_etcb_at:"\<lbrace>(\<lambda>s. etcb_at P t s) and valid_etcbs\<rbrace>
-          perform_asid_control_invocation aci
-          \<lbrace>\<lambda>r s. st_tcb_at (Not \<circ> inactive) t s \<longrightarrow> etcb_at P t s\<rbrace>"
+lemma perform_asid_control_etcb_at:
+  "\<lbrace>etcb_at P t\<rbrace>
+   perform_asid_control_invocation aci
+   \<lbrace>\<lambda>r s. st_tcb_at (Not \<circ> inactive) t s \<longrightarrow> etcb_at P t s\<rbrace>"
   apply (simp add: perform_asid_control_invocation_def)
-  apply (rule hoare_pre)
-   apply (wp | wpc | simp)+
+  apply wpsimp
        apply (wp hoare_imp_lift_something typ_at_pred_tcb_at_lift)[1]
       apply (rule hoare_drop_imps)
       apply (wp retype_region_etcb_at)+
@@ -107,25 +46,15 @@ lemma perform_asid_control_etcb_at:"\<lbrace>(\<lambda>s. etcb_at P t s) and val
   done
 
 crunch perform_asid_control_invocation
-  for ct[wp]: "\<lambda>s. P (cur_thread s)"
-
-crunch perform_asid_control_invocation
   for idle_thread[wp]: "\<lambda>s. P (idle_thread s)"
+  and valid_blocked[wp]: valid_blocked
+  and schedact[wp]: "\<lambda>s. P (scheduler_action s)"
+  and ready_queues[wp]: "\<lambda>s. P (ready_queues s)"
+  and cur_domain[wp]: "\<lambda>s. P (cur_domain s)"
+  (wp: hoare_weak_lift_imp simp: detype_def)
 
 crunch perform_asid_control_invocation
-  for valid_etcbs[wp]: valid_etcbs (wp: hoare_weak_lift_imp)
-
-crunch perform_asid_control_invocation
-  for valid_blocked[wp]: valid_blocked (wp: hoare_weak_lift_imp)
-
-crunch perform_asid_control_invocation
-  for schedact[wp]: "\<lambda>s :: det_ext state. P (scheduler_action s)" (wp: crunch_wps simp: detype_def detype_ext_def wrap_ext_det_ext_ext_def cap_insert_ext_def ignore: freeMemory)
-
-crunch perform_asid_control_invocation
-  for rqueues[wp]: "\<lambda>s :: det_ext state. P (ready_queues s)" (wp: crunch_wps simp: detype_def detype_ext_def wrap_ext_det_ext_ext_def cap_insert_ext_def ignore: freeMemory)
-
-crunch perform_asid_control_invocation
-  for cur_domain[wp]: "\<lambda>s :: det_ext state. P (cur_domain s)" (wp: crunch_wps simp: detype_def detype_ext_def wrap_ext_det_ext_ext_def cap_insert_ext_def ignore: freeMemory)
+  for ct[wp]: "\<lambda>s. P (cur_thread s)"
 
 lemma perform_asid_control_invocation_valid_sched:
   "\<lbrace>ct_active and invs and valid_aci aci and valid_sched and valid_idle\<rbrace>
@@ -145,25 +74,10 @@ lemma perform_asid_control_invocation_valid_sched:
   apply simp
   done
 
-crunch init_arch_objects
-  for valid_queues[wp]: valid_queues (wp: valid_queues_lift)
-
-crunch init_arch_objects
-  for valid_sched_action[wp]: valid_sched_action (wp: valid_sched_action_lift)
-
-crunch init_arch_objects
-  for valid_sched[wp]: valid_sched (wp: valid_sched_lift)
-
 end
 
 lemmas tcb_sched_action_valid_idle_etcb
     = RISCV64.tcb_sched_action_valid_idle_etcb
-
-global_interpretation DetSchedAux_AI_det_ext?: DetSchedAux_AI_det_ext
-  proof goal_cases
-  interpret Arch .
-  case 1 show ?case by (unfold_locales; (fact DetSchedAux_AI_assms)?)
-  qed
 
 global_interpretation DetSchedAux_AI?: DetSchedAux_AI
   proof goal_cases

--- a/proof/invariant-abstract/RISCV64/ArchDetSchedDomainTime_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchDetSchedDomainTime_AI.thy
@@ -20,10 +20,10 @@ crunch
   arch_activate_idle_thread, arch_switch_to_thread, arch_switch_to_idle_thread,
   handle_arch_fault_reply,
   arch_invoke_irq_control, arch_get_sanitise_register_info,
-  prepare_thread_delete, handle_hypervisor_fault, make_arch_fault_msg,
+  prepare_thread_delete, handle_hypervisor_fault, make_arch_fault_msg, init_arch_objects,
   arch_post_modify_registers, arch_post_cap_deletion, handle_vm_fault,
   arch_invoke_irq_handler
-  for domain_list_inv[wp, DetSchedDomainTime_AI_assms]: "\<lambda>s. P (domain_list s)"
+  for domain_list_inv[wp, DetSchedDomainTime_AI_assms]: "\<lambda>s::det_state. P (domain_list s)"
   (simp: crunch_simps)
 
 crunch arch_finalise_cap
@@ -37,7 +37,7 @@ crunch
   prepare_thread_delete, handle_hypervisor_fault, handle_vm_fault,
   arch_post_modify_registers, arch_post_cap_deletion, make_arch_fault_msg,
   arch_invoke_irq_handler
-  for domain_time_inv[wp, DetSchedDomainTime_AI_assms]: "\<lambda>s. P (domain_time s)"
+  for domain_time_inv[wp, DetSchedDomainTime_AI_assms]: "\<lambda>s::det_state. P (domain_time s)"
   (simp: crunch_simps)
 
 crunch do_machine_op
@@ -56,11 +56,11 @@ global_interpretation DetSchedDomainTime_AI?: DetSchedDomainTime_AI
 context Arch begin arch_global_naming
 
 crunch arch_perform_invocation
-  for domain_time_inv[wp, DetSchedDomainTime_AI_assms]: "\<lambda>s. P (domain_time s)"
+  for domain_time_inv[wp, DetSchedDomainTime_AI_assms]: "\<lambda>s::det_state. P (domain_time s)"
   (wp: crunch_wps check_cap_inv)
 
 crunch arch_perform_invocation
-  for domain_list_inv[wp, DetSchedDomainTime_AI_assms]: "\<lambda>s. P (domain_list s)"
+  for domain_list_inv[wp, DetSchedDomainTime_AI_assms]: "\<lambda>s::det_state. P (domain_list s)"
   (wp: crunch_wps check_cap_inv)
 
 lemma timer_tick_valid_domain_time:
@@ -69,7 +69,7 @@ lemma timer_tick_valid_domain_time:
    \<lbrace>\<lambda>x s. domain_time s = 0 \<longrightarrow> scheduler_action s = choose_new_thread\<rbrace>" (is "\<lbrace> ?dtnot0 \<rbrace> _ \<lbrace> _ \<rbrace>")
   unfolding timer_tick_def
   supply if_split[split del]
-  supply ethread_get_wp[wp del]
+  supply thread_get_wp[wp del]
   supply if_apply_def2[simp]
   apply (wpsimp
            wp: reschedule_required_valid_domain_time hoare_vcg_const_imp_lift gts_wp
@@ -77,9 +77,12 @@ lemma timer_tick_valid_domain_time:
                   postcondition once we hit thread_set_time_slice *)
                hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and Q="\<lambda>_ s. domain_time s = 0 \<longrightarrow> X s"
                                 and f="thread_set_time_slice t ts" for X t ts]
-               hoare_drop_imp[where f="ethread_get t f" for t f])
+               hoare_drop_imp[where f="thread_get t f" for t f])
   apply fastforce
   done
+
+crunch do_machine_op
+  for domain_time_sched[wp]: "\<lambda>s. P (domain_time s) (scheduler_action s)"
 
 lemma handle_interrupt_valid_domain_time [DetSchedDomainTime_AI_assms]:
   "\<lbrace>\<lambda>s :: det_ext state. 0 < domain_time s \<rbrace>

--- a/proof/invariant-abstract/RISCV64/ArchDetSchedSchedule_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchDetSchedSchedule_AI.thy
@@ -17,11 +17,6 @@ crunch
   for prepare_thread_delete_idle_thread[wp, DetSchedSchedule_AI_assms]: "\<lambda>(s:: det_ext state). P (idle_thread s)"
 
 crunch
-  arch_switch_to_idle_thread, arch_switch_to_thread, arch_get_sanitise_register_info, arch_post_modify_registers
-  for valid_etcbs[wp, DetSchedSchedule_AI_assms]: valid_etcbs
-  (simp: crunch_simps)
-
-crunch
   switch_to_idle_thread, switch_to_thread, set_vm_root, arch_get_sanitise_register_info, arch_post_modify_registers
   for valid_queues[wp, DetSchedSchedule_AI_assms]: valid_queues
   (simp: crunch_simps ignore: set_tcb_queue tcb_sched_action)
@@ -32,11 +27,9 @@ crunch
   (simp: crunch_simps)
 
 crunch set_vm_root
-  for ct_not_in_q[wp]: "ct_not_in_q"
-  (wp: crunch_wps simp: crunch_simps)
-
-crunch set_vm_root
-  for ct_not_in_q'[wp]: "\<lambda>s. ct_not_in_q_2 (ready_queues s) (scheduler_action s) t"
+  for ready_queues[wp]: "\<lambda>s. P (ready_queues s)"
+  and ct_not_in_q[wp]: "ct_not_in_q"
+  and ct_not_in_q'[wp]: "\<lambda>s. ct_not_in_q_2 (ready_queues s) (scheduler_action s) t"
   (wp: crunch_wps simp: crunch_simps)
 
 lemma switch_to_idle_thread_ct_not_in_q [wp, DetSchedSchedule_AI_assms]:
@@ -51,7 +44,7 @@ lemma switch_to_idle_thread_ct_not_in_q [wp, DetSchedSchedule_AI_assms]:
 
 crunch set_vm_root
   for valid_sched_action'[wp]: "\<lambda>s. valid_sched_action_2 (scheduler_action s)
-                                                 (ekheap s) (kheap s) thread (cur_domain s)"
+                                                 (etcbs_of s) (kheap s) thread (cur_domain s)"
   (wp: crunch_wps simp: crunch_simps)
 
 lemma switch_to_idle_thread_valid_sched_action [wp, DetSchedSchedule_AI_assms]:
@@ -68,7 +61,7 @@ lemma switch_to_idle_thread_valid_sched_action [wp, DetSchedSchedule_AI_assms]:
 
 crunch set_vm_root
   for ct_in_cur_domain'[wp]: "\<lambda>s. ct_in_cur_domain_2 t (idle_thread s)
-                                                   (scheduler_action s) (cur_domain s) (ekheap s)"
+                                                   (scheduler_action s) (cur_domain s) (etcbs_of s)"
   (wp: crunch_wps simp: crunch_simps)
 
 lemma switch_to_idle_thread_ct_in_cur_domain [wp, DetSchedSchedule_AI_assms]:
@@ -99,7 +92,7 @@ crunch set_vm_root
   (wp: crunch_wps whenE_wp simp: crunch_simps)
 
 crunch arch_switch_to_thread
-  for ct_in_cur_domain_2[wp, DetSchedSchedule_AI_assms]: "\<lambda>s. ct_in_cur_domain_2 thread (idle_thread s) (scheduler_action s) (cur_domain s) (ekheap s)"
+  for ct_in_cur_domain_2[wp, DetSchedSchedule_AI_assms]: "\<lambda>s. ct_in_cur_domain_2 thread (idle_thread s) (scheduler_action s) (cur_domain s) (etcbs_of s)"
   (simp: crunch_simps wp: assert_inv)
 
 crunch set_vm_root
@@ -142,7 +135,7 @@ lemma arch_switch_to_thread_valid_blocked [wp, DetSchedSchedule_AI_assms]:
   by (wpsimp simp: arch_switch_to_thread_def)
 
 lemma switch_to_idle_thread_ct_not_queued [wp, DetSchedSchedule_AI_assms]:
-  "\<lbrace>valid_queues and valid_etcbs and valid_idle\<rbrace>
+  "\<lbrace>valid_queues and valid_idle\<rbrace>
      switch_to_idle_thread
    \<lbrace>\<lambda>rv s. not_queued (cur_thread s) s\<rbrace>"
   apply (simp add: switch_to_idle_thread_def arch_switch_to_idle_thread_def
@@ -187,13 +180,19 @@ lemma switch_to_idle_thread_cur_thread_idle_thread [wp, DetSchedSchedule_AI_assm
   "\<lbrace>\<top>\<rbrace> switch_to_idle_thread \<lbrace>\<lambda>_ s. cur_thread s = idle_thread s\<rbrace>"
   by (wp | simp add:switch_to_idle_thread_def arch_switch_to_idle_thread_def)+
 
-lemma set_pt_valid_etcbs[wp]:
-  "\<lbrace>valid_etcbs\<rbrace> set_pt ptr pt \<lbrace>\<lambda>rv. valid_etcbs\<rbrace>"
-  by (wp hoare_drop_imps valid_etcbs_lift | simp add: set_pt_def)+
+lemma set_pt_etcbs[wp]:
+  "set_pt ptr pt \<lbrace>\<lambda>s. P (etcbs_of s)\<rbrace>"
+  unfolding set_pt_def
+  apply (wpsimp wp: set_object_wp get_object_wp)
+  apply (auto elim!: rsubst[where P=P] simp: obj_at_def etcbs_of'_def split: kernel_object.splits)
+  done
 
-lemma set_asid_pool_valid_etcbs[wp]:
-  "\<lbrace>valid_etcbs\<rbrace> set_asid_pool ptr pool \<lbrace>\<lambda>rv. valid_etcbs\<rbrace>"
-  by (wp hoare_drop_imps valid_etcbs_lift | simp add: set_asid_pool_def)+
+lemma set_asid_pool_etcbs_of[wp]:
+  "set_asid_pool ptr pool \<lbrace>\<lambda>s. P (etcbs_of s)\<rbrace>"
+  unfolding set_asid_pool_def
+  apply (wpsimp wp: set_object_wp_strong)
+  by (auto elim!: rsubst[where P=P] simp: etcbs_of'_def obj_at_def a_type_def
+           split: kernel_object.splits)
 
 lemma set_pt_valid_sched[wp]:
   "\<lbrace>valid_sched\<rbrace> set_pt ptr pt \<lbrace>\<lambda>rv. valid_sched\<rbrace>"
@@ -208,12 +207,6 @@ crunch
   for ct_not_in_q[wp, DetSchedSchedule_AI_assms]: ct_not_in_q
   (wp: crunch_wps hoare_drop_imps unless_wp select_inv mapM_wp
        subset_refl if_fun_split simp: crunch_simps ignore: tcb_sched_action)
-
-crunch
-  arch_finalise_cap, prepare_thread_delete
-  for valid_etcbs[wp, DetSchedSchedule_AI_assms]: valid_etcbs
-  (wp: hoare_drop_imps unless_wp select_inv mapM_x_wp mapM_wp subset_refl
-       if_fun_split simp: crunch_simps ignore: set_object thread_set)
 
 crunch
   arch_finalise_cap, prepare_thread_delete
@@ -304,11 +297,9 @@ lemma arch_post_modify_registers_not_idle_thread[DetSchedSchedule_AI_assms]:
 
 crunch arch_post_cap_deletion
   for valid_sched[wp, DetSchedSchedule_AI_assms]: valid_sched
-  and valid_etcbs[wp, DetSchedSchedule_AI_assms]: valid_etcbs
   and ct_not_in_q[wp, DetSchedSchedule_AI_assms]: ct_not_in_q
   and simple_sched_action[wp, DetSchedSchedule_AI_assms]: simple_sched_action
   and not_cur_thread[wp, DetSchedSchedule_AI_assms]: "not_cur_thread t"
-  and is_etcb_at[wp, DetSchedSchedule_AI_assms]: "is_etcb_at t"
   and not_queued[wp, DetSchedSchedule_AI_assms]: "not_queued t"
   and sched_act_not[wp, DetSchedSchedule_AI_assms]: "scheduler_act_not t"
   and weak_valid_sched_action[wp, DetSchedSchedule_AI_assms]: weak_valid_sched_action
@@ -322,6 +313,14 @@ crunch
   arch_finalise_cap
   for arch_finalise_cap[wp, DetSchedSchedule_AI_assms]: "\<lambda>(s:: det_ext state). P (idle_thread s)"
   (wp: crunch_wps simp: if_fun_split)
+
+crunch arch_switch_to_thread
+  for etcbs_of[wp, DetSchedSchedule_AI_assms]: "\<lambda>s. P (etcbs_of s)"
+  and cur_domain[wp, DetSchedSchedule_AI_assms]: "\<lambda>s. P (cur_domain s)"
+
+crunch arch_switch_to_thread
+  for etcbs_of[wp, DetSchedSchedule_AI_assms]: "\<lambda>s. P (etcbs_of s)"
+  and cur_domain[wp, DetSchedSchedule_AI_assms]: "\<lambda>s. P (cur_domain s)"
 
 end
 

--- a/proof/invariant-abstract/RISCV64/ArchDetype_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchDetype_AI.thy
@@ -495,9 +495,8 @@ lemma in_user_frame_eq:
                      Int_atLeastAtMost atLeastatMost_empty_iff split_paired_Ex
                      order_class.Icc_eq_Icc
     and [simp] = p2pm1_to_mask
-  shows "p \<notin> untyped_range cap \<Longrightarrow> in_user_frame p
-              (trans_state (\<lambda>_. detype_ext (untyped_range cap) (exst s)) s
-               \<lparr>kheap := \<lambda>x. if x \<in> untyped_range cap then None else kheap s x\<rparr>)
+  shows "p \<notin> untyped_range cap \<Longrightarrow>
+         in_user_frame p (s \<lparr>kheap := \<lambda>x. if x \<in> untyped_range cap then None else kheap s x\<rparr>)
          = in_user_frame p s"
     using cap_is_valid untyped
     apply (cases cap; simp add: in_user_frame_def valid_untyped_def valid_cap_def obj_at_def)
@@ -523,9 +522,7 @@ lemma in_device_frame_eq:
           order_class.Icc_eq_Icc
      and  p2pm1[simp] = p2pm1_to_mask
   shows "p \<notin> untyped_range cap
-       \<Longrightarrow> in_device_frame p
-              (trans_state (\<lambda>_. detype_ext (untyped_range cap) (exst s)) s
-               \<lparr>kheap := \<lambda>x. if x \<in> untyped_range cap then None else kheap s x\<rparr>)
+       \<Longrightarrow> in_device_frame p (s \<lparr>kheap := \<lambda>x. if x \<in> untyped_range cap then None else kheap s x\<rparr>)
          = in_device_frame p s"
     using cap_is_valid untyped
     unfolding in_device_frame_def

--- a/proof/invariant-abstract/RISCV64/ArchEmptyFail_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchEmptyFail_AI.thy
@@ -151,18 +151,6 @@ crunch
   for (empty_fail) empty_fail[wp, EmptyFail_AI_assms]
 end
 
-global_interpretation EmptyFail_AI_schedule_unit?: EmptyFail_AI_schedule_unit
-  proof goal_cases
-  interpret Arch .
-  case 1 show ?case by (unfold_locales; (fact EmptyFail_AI_assms)?)
-  qed
-
-global_interpretation EmptyFail_AI_schedule_det?: EmptyFail_AI_schedule_det
-  proof goal_cases
-  interpret Arch .
-  case 1 show ?case by (unfold_locales; (fact EmptyFail_AI_assms)?)
-  qed
-
 global_interpretation EmptyFail_AI_schedule?: EmptyFail_AI_schedule
   proof goal_cases
   interpret Arch .
@@ -186,22 +174,9 @@ crunch possible_switch_to, handle_event, activate_thread
          bool.splits apiobject_type.splits aobject_type.splits notification.splits
          thread_state.splits endpoint.splits catch_def sum.splits cnode_invocation.splits
          page_table_invocation.splits page_invocation.splits asid_control_invocation.splits
-         asid_pool_invocation.splits arch_invocation.splits irq_state.splits syscall.splits
-   ignore_del: possible_switch_to)
+         asid_pool_invocation.splits arch_invocation.splits irq_state.splits syscall.splits)
 
 end
-
-global_interpretation EmptyFail_AI_call_kernel_unit?: EmptyFail_AI_call_kernel_unit
-  proof goal_cases
-  interpret Arch .
-  case 1 show ?case by (unfold_locales; (fact EmptyFail_AI_assms)?)
-  qed
-
-global_interpretation EmptyFail_AI_call_kernel_det?: EmptyFail_AI_call_kernel_det
-  proof goal_cases
-  interpret Arch .
-  case 1 show ?case by (unfold_locales; (fact EmptyFail_AI_assms)?)
-  qed
 
 global_interpretation EmptyFail_AI_call_kernel?: EmptyFail_AI_call_kernel
   proof goal_cases

--- a/proof/invariant-abstract/RISCV64/ArchInterrupt_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchInterrupt_AI.thy
@@ -236,6 +236,14 @@ lemma handle_reserved_irq_invs[wp]:
   "\<lbrace>invs\<rbrace> handle_reserved_irq irq \<lbrace>\<lambda>_. invs\<rbrace>"
   unfolding handle_reserved_irq_def by (wpsimp simp: non_kernel_IRQs_def)
 
+crunch timer_tick
+  for invs[wp]: invs
+  (wp: thread_set_invs_trivial[OF ball_tcb_cap_casesI])
+
+crunch timer_tick
+  for invs[wp]: invs
+  (wp: thread_set_invs_trivial[OF ball_tcb_cap_casesI])
+
 lemma (* handle_interrupt_invs *) [Interrupt_AI_assms]:
   "\<lbrace>invs\<rbrace> handle_interrupt irq \<lbrace>\<lambda>_. invs\<rbrace>"
   apply (simp add: handle_interrupt_def)

--- a/proof/invariant-abstract/RISCV64/ArchInvariants_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchInvariants_AI.thy
@@ -1191,6 +1191,9 @@ lemma tcb_arch_ref_simps[simp]:
   "\<And>f. tcb_arch_ref (tcb_fault_handler_update f tcb) = tcb_arch_ref tcb"
   "\<And>f. tcb_arch_ref (tcb_fault_update f tcb) = tcb_arch_ref tcb"
   "\<And>f. tcb_arch_ref (tcb_bound_notification_update f tcb) = tcb_arch_ref tcb"
+  "\<And>f. tcb_arch_ref (tcb_domain_update f tcb) = tcb_arch_ref tcb"
+  "\<And>f. tcb_arch_ref (tcb_priority_update f tcb) = tcb_arch_ref tcb"
+  "\<And>f. tcb_arch_ref (tcb_time_slice_update f tcb) = tcb_arch_ref tcb"
   "tcb_arch_ref (t\<lparr>tcb_arch := (arch_tcb_context_set a (tcb_arch t))\<rparr>) = tcb_arch_ref t"
   "tcb_arch_ref (tcb\<lparr>tcb_arch := arch_tcb_set_registers regs (tcb_arch tcb)\<rparr>) = tcb_arch_ref tcb"
   by (auto simp: tcb_arch_ref_def)
@@ -1210,6 +1213,9 @@ lemma hyp_live_tcb_simps[simp]:
   "\<And>f. hyp_live (TCB (tcb_fault_handler_update f tcb)) = hyp_live (TCB tcb)"
   "\<And>f. hyp_live (TCB (tcb_fault_update f tcb)) = hyp_live (TCB tcb)"
   "\<And>f. hyp_live (TCB (tcb_bound_notification_update f tcb)) = hyp_live (TCB tcb)"
+  "\<And>f. hyp_live (TCB (tcb_domain_update f tcb)) = hyp_live (TCB tcb)"
+  "\<And>f. hyp_live (TCB (tcb_priority_update f tcb)) = hyp_live (TCB tcb)"
+  "\<And>f. hyp_live (TCB (tcb_time_slice_update f tcb)) = hyp_live (TCB tcb)"
   by (simp_all add: hyp_live_tcb_def)
 
 lemma wellformed_arch_typ:

--- a/proof/invariant-abstract/RISCV64/ArchKHeap_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchKHeap_AI.thy
@@ -718,7 +718,7 @@ lemma pspace_respects_region_cong[cong]:
 
 definition "obj_is_device tp dev \<equiv>
   case tp of Untyped \<Rightarrow> dev
-    | _ \<Rightarrow>(case (default_object tp dev 0) of (ArchObj (DataPage dev _)) \<Rightarrow> dev
+    | _ \<Rightarrow>(case default_object tp dev 0 0 of (ArchObj (DataPage dev _)) \<Rightarrow> dev
           | _ \<Rightarrow> False)"
 
 lemma cap_is_device_obj_is_device[simp]:
@@ -761,11 +761,35 @@ lemma state_hyp_refs_of_tcb_state_update:
   apply (clarsimp simp add: state_hyp_refs_of_def obj_at_def split: option.splits)
   done
 
+lemma state_hyp_refs_of_tcb_domain_update:
+  "kheap s t = Some (TCB tcb) \<Longrightarrow>
+   state_hyp_refs_of (s\<lparr>kheap := (kheap s)(t \<mapsto> TCB (tcb\<lparr>tcb_domain := d\<rparr>))\<rparr>)
+     = state_hyp_refs_of s"
+  apply (rule all_ext)
+  apply (clarsimp simp add: state_hyp_refs_of_def obj_at_def split: option.splits)
+  done
+
+lemma state_hyp_refs_of_tcb_priority_update:
+  "kheap s t = Some (TCB tcb) \<Longrightarrow>
+   state_hyp_refs_of (s\<lparr>kheap := (kheap s)(t \<mapsto> TCB (tcb\<lparr>tcb_priority := p\<rparr>))\<rparr>)
+     = state_hyp_refs_of s"
+  apply (rule all_ext)
+  apply (clarsimp simp add: state_hyp_refs_of_def obj_at_def split: option.splits)
+  done
+
+lemma state_hyp_refs_of_tcb_time_slice_update:
+  "kheap s t = Some (TCB tcb) \<Longrightarrow>
+   state_hyp_refs_of (s\<lparr>kheap := (kheap s)(t \<mapsto> TCB (tcb\<lparr>tcb_time_slice := ts\<rparr>))\<rparr>)
+     = state_hyp_refs_of s"
+  apply (rule all_ext)
+  apply (clarsimp simp add: state_hyp_refs_of_def obj_at_def split: option.splits)
+  done
+
 lemma default_arch_object_not_live[simp]: "\<not> live (ArchObj (default_arch_object aty dev us))"
   by (clarsimp simp: default_arch_object_def live_def hyp_live_def arch_live_def
                split: aobject_type.splits)
 
-lemma default_tcb_not_live[simp]: "\<not> live (TCB default_tcb)"
+lemma default_tcb_not_live[simp]: "\<not> live (TCB (default_tcb d))"
   by (clarsimp simp: default_tcb_def default_arch_tcb_def live_def hyp_live_def)
 
 lemma valid_arch_tcb_same_type:

--- a/proof/invariant-abstract/RISCV64/ArchKHeap_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchKHeap_AI.thy
@@ -746,17 +746,17 @@ lemma state_hyp_refs_of_ntfn_update: "\<And>s ep val. typ_at ANTFN ep s \<Longri
   done
 
 lemma state_hyp_refs_of_tcb_bound_ntfn_update:
-       "kheap s t = Some (TCB tcb) \<Longrightarrow>
-          state_hyp_refs_of (s\<lparr>kheap := (kheap s)(t \<mapsto> TCB (tcb\<lparr>tcb_bound_notification := ntfn\<rparr>))\<rparr>)
-            = state_hyp_refs_of s"
+   "kheap s t = Some (TCB tcb) \<Longrightarrow>
+    state_hyp_refs_of (s\<lparr>kheap := (kheap s)(t \<mapsto> TCB (tcb\<lparr>tcb_bound_notification := ntfn\<rparr>))\<rparr>)
+    = state_hyp_refs_of s"
   apply (rule all_ext)
   apply (clarsimp simp add: state_hyp_refs_of_def obj_at_def split: option.splits)
   done
 
 lemma state_hyp_refs_of_tcb_state_update:
-       "kheap s t = Some (TCB tcb) \<Longrightarrow>
-          state_hyp_refs_of (s\<lparr>kheap := (kheap s)(t \<mapsto> TCB (tcb\<lparr>tcb_state := ts\<rparr>))\<rparr>)
-            = state_hyp_refs_of s"
+   "kheap s t = Some (TCB tcb) \<Longrightarrow>
+    state_hyp_refs_of (s\<lparr>kheap := (kheap s)(t \<mapsto> TCB (tcb\<lparr>tcb_state := ts\<rparr>))\<rparr>)
+    = state_hyp_refs_of s"
   apply (rule all_ext)
   apply (clarsimp simp add: state_hyp_refs_of_def obj_at_def split: option.splits)
   done
@@ -764,7 +764,7 @@ lemma state_hyp_refs_of_tcb_state_update:
 lemma state_hyp_refs_of_tcb_domain_update:
   "kheap s t = Some (TCB tcb) \<Longrightarrow>
    state_hyp_refs_of (s\<lparr>kheap := (kheap s)(t \<mapsto> TCB (tcb\<lparr>tcb_domain := d\<rparr>))\<rparr>)
-     = state_hyp_refs_of s"
+   = state_hyp_refs_of s"
   apply (rule all_ext)
   apply (clarsimp simp add: state_hyp_refs_of_def obj_at_def split: option.splits)
   done
@@ -772,7 +772,7 @@ lemma state_hyp_refs_of_tcb_domain_update:
 lemma state_hyp_refs_of_tcb_priority_update:
   "kheap s t = Some (TCB tcb) \<Longrightarrow>
    state_hyp_refs_of (s\<lparr>kheap := (kheap s)(t \<mapsto> TCB (tcb\<lparr>tcb_priority := p\<rparr>))\<rparr>)
-     = state_hyp_refs_of s"
+   = state_hyp_refs_of s"
   apply (rule all_ext)
   apply (clarsimp simp add: state_hyp_refs_of_def obj_at_def split: option.splits)
   done
@@ -780,7 +780,7 @@ lemma state_hyp_refs_of_tcb_priority_update:
 lemma state_hyp_refs_of_tcb_time_slice_update:
   "kheap s t = Some (TCB tcb) \<Longrightarrow>
    state_hyp_refs_of (s\<lparr>kheap := (kheap s)(t \<mapsto> TCB (tcb\<lparr>tcb_time_slice := ts\<rparr>))\<rparr>)
-     = state_hyp_refs_of s"
+   = state_hyp_refs_of s"
   apply (rule all_ext)
   apply (clarsimp simp add: state_hyp_refs_of_def obj_at_def split: option.splits)
   done

--- a/proof/invariant-abstract/RISCV64/ArchUntyped_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchUntyped_AI.thy
@@ -153,7 +153,7 @@ lemma retype_ret_valid_caps_captable[Untyped_AI_assms]:
       \<and> range_cover ptr sz (obj_bits_api CapTableObject us) n \<and> ptr \<noteq> 0
        \<rbrakk>
          \<Longrightarrow> \<forall>y\<in>{0..<n}. s
-                \<lparr>kheap := foldr (\<lambda>p kh. kh(p \<mapsto> default_object CapTableObject dev us)) (map (\<lambda>p. ptr_add ptr (p * 2 ^ obj_bits_api CapTableObject us)) [0..<n])
+                \<lparr>kheap := foldr (\<lambda>p kh. kh(p \<mapsto> default_object CapTableObject dev us (cur_domain s))) (map (\<lambda>p. ptr_add ptr (p * 2 ^ obj_bits_api CapTableObject us)) [0..<n])
                            (kheap s)\<rparr> \<turnstile> CNodeCap (ptr_add ptr (y * 2 ^ obj_bits_api CapTableObject us)) us []"
 by ((clarsimp simp:valid_cap_def default_object_def cap_aligned_def
         cte_level_bits_def is_obj_defs well_formed_cnode_n_def empty_cnode_def
@@ -166,7 +166,7 @@ lemma retype_ret_valid_caps_aobj[Untyped_AI_assms]:
   \<lbrakk>pspace_no_overlap_range_cover ptr sz s \<and> x6 \<noteq> ASIDPoolObj \<and>
   range_cover ptr sz (obj_bits_api (ArchObject x6) us) n \<and> ptr \<noteq> 0\<rbrakk>
             \<Longrightarrow> \<forall>y\<in>{0..<n}. s
-                   \<lparr>kheap := foldr (\<lambda>p kh. kh(p \<mapsto> default_object (ArchObject x6) dev us)) (map (\<lambda>p. ptr_add ptr (p * 2 ^ obj_bits_api (ArchObject x6) us)) [0..<n])
+                   \<lparr>kheap := foldr (\<lambda>p kh. kh(p \<mapsto> default_object (ArchObject x6) dev us (cur_domain s))) (map (\<lambda>p. ptr_add ptr (p * 2 ^ obj_bits_api (ArchObject x6) us)) [0..<n])
                               (kheap s)\<rparr> \<turnstile> ArchObjectCap (arch_default_cap x6 (ptr_add ptr (y * 2 ^ obj_bits_api (ArchObject x6) us)) us dev)"
   apply (rename_tac aobject_type us n)
   apply (case_tac aobject_type)
@@ -334,7 +334,7 @@ lemma nonempty_table_caps_of[Untyped_AI_assms]:
 
 
 lemma nonempty_default[simp, Untyped_AI_assms]:
-  "tp \<noteq> Untyped \<Longrightarrow> \<not> nonempty_table S (default_object tp dev us)"
+  "tp \<noteq> Untyped \<Longrightarrow> \<not> nonempty_table S (default_object tp dev us d)"
   apply (case_tac tp, simp_all add: default_object_def nonempty_table_def a_type_def)
   apply (rename_tac aobject_type)
   apply (case_tac aobject_type; simp add: default_arch_object_def)

--- a/proof/invariant-abstract/RISCV64/ArchVSpaceEntries_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchVSpaceEntries_AI.thy
@@ -156,14 +156,10 @@ lemma invoke_cnode_valid_vspace_objs'[wp]:
    apply (wp get_cap_wp | wpc | simp split del: if_split)+
   done
 
-crunch invoke_tcb
+crunch invoke_tcb, invoke_domain
   for valid_vspace_objs'[wp]: "valid_vspace_objs'"
   (wp: check_cap_inv crunch_wps simp: crunch_simps
        ignore: check_cap_at)
-
-lemma invoke_domain_valid_vspace_objs'[wp]:
-  "\<lbrace>valid_vspace_objs'\<rbrace> invoke_domain t d \<lbrace>\<lambda>rv. valid_vspace_objs'\<rbrace>"
-  by (simp add: invoke_domain_def | wp)+
 
 crunch set_extra_badge, transfer_caps_loop
   for valid_vspace_objs'[wp]: "valid_vspace_objs'"
@@ -321,7 +317,8 @@ lemma handle_invocation_valid_vspace_objs'[wp]:
 
 crunch activate_thread,switch_to_thread, handle_hypervisor_fault,
        switch_to_idle_thread, handle_call, handle_recv, handle_reply,
-       handle_send, handle_yield, handle_interrupt
+       handle_send, handle_yield, handle_interrupt,
+       schedule_choose_new_thread
   for valid_vspace_objs'[wp]: "valid_vspace_objs'"
   (simp: crunch_simps wp: crunch_wps OR_choice_weak_wp select_ext_weak_wp
       ignore: without_preemption getActiveIRQ resetTimer ackInterrupt
@@ -332,14 +329,12 @@ lemma handle_event_valid_vspace_objs'[wp]:
   by (case_tac e; simp) (wpsimp simp: Let_def handle_vm_fault_def | wp (once) hoare_drop_imps)+
 
 lemma schedule_valid_vspace_objs'[wp]:
-  "\<lbrace>valid_vspace_objs'\<rbrace> schedule :: (unit,unit) s_monad \<lbrace>\<lambda>_. valid_vspace_objs'\<rbrace>"
-  apply (simp add: schedule_def allActiveTCBs_def)
-  apply wpsimp
-  done
+  "schedule \<lbrace>valid_vspace_objs'\<rbrace>"
+  unfolding schedule_def by (wpsimp wp: hoare_drop_imps)
 
 lemma call_kernel_valid_vspace_objs'[wp]:
   "\<lbrace>invs and (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_running s) and valid_vspace_objs'\<rbrace>
-      (call_kernel e) :: (unit,unit) s_monad
+   call_kernel e
    \<lbrace>\<lambda>_. valid_vspace_objs'\<rbrace>"
   apply (cases e, simp_all add: call_kernel_def)
       apply (rule hoare_pre)

--- a/proof/invariant-abstract/RISCV64/ArchVSpace_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchVSpace_AI.thy
@@ -1962,7 +1962,7 @@ lemma invs_aligned_pdD:
 
 lemma valid_vspace_obj_default:
   assumes tyunt: "ty \<noteq> Structures_A.apiobject_type.Untyped"
-  shows "ArchObj ao = default_object ty dev us \<Longrightarrow> valid_vspace_obj level ao s'"
+  shows "ArchObj ao = default_object ty dev us d \<Longrightarrow> valid_vspace_obj level ao s'"
   by (cases ty; simp add: default_object_def tyunt)
 
 end

--- a/proof/invariant-abstract/X64/ArchDetSchedAux_AI.thy
+++ b/proof/invariant-abstract/X64/ArchDetSchedAux_AI.thy
@@ -12,95 +12,42 @@ context Arch begin arch_global_naming
 
 named_theorems DetSchedAux_AI_assms
 
-crunch set_object, init_arch_objects
-  for exst[wp]: "\<lambda>s. P (exst s)" (wp: crunch_wps unless_wp)
-crunch init_arch_objects
-  for ct[wp]: "\<lambda>s. P (cur_thread s)" (wp: crunch_wps unless_wp)
-crunch init_arch_objects
-  for valid_etcbs[wp, DetSchedAux_AI_assms]: valid_etcbs (wp: valid_etcbs_lift)
+lemma set_arch_obj_etcbs[wp]:
+  "set_object ptr (ArchObj aobj) \<lbrace>\<lambda>s. P (etcbs_of s)\<rbrace>"
+  apply (wpsimp wp: set_object_wp_strong)
+  by (auto elim!: rsubst[where P=P] simp: etcbs_of'_def obj_at_def a_type_def
+           split: kernel_object.splits)
 
-crunch invoke_untyped
-  for ct[wp, DetSchedAux_AI_assms]: "\<lambda>s. P (cur_thread s)"
-  (wp: crunch_wps dxo_wp_weak preemption_point_inv mapME_x_inv_wp
-    simp: crunch_simps do_machine_op_def detype_def mapM_x_defsym unless_def
-    ignore: freeMemory ignore: retype_region_ext)
-crunch invoke_untyped
-  for ready_queues[wp, DetSchedAux_AI_assms]: "\<lambda>s. P (ready_queues s)"
-  (wp: crunch_wps mapME_x_inv_wp preemption_point_inv'
-    simp: detype_def detype_ext_def crunch_simps
-          wrap_ext_det_ext_ext_def mapM_x_defsym
-  ignore: freeMemory)
-crunch invoke_untyped
-  for scheduler_action[wp, DetSchedAux_AI_assms]: "\<lambda>s. P (scheduler_action s)"
-  (wp: crunch_wps mapME_x_inv_wp preemption_point_inv'
-      simp: detype_def detype_ext_def crunch_simps
-            wrap_ext_det_ext_ext_def mapM_x_defsym
-    ignore: freeMemory)
-crunch invoke_untyped
-  for cur_domain[wp, DetSchedAux_AI_assms]: "\<lambda>s. P (cur_domain s)"
-  (wp: crunch_wps mapME_x_inv_wp preemption_point_inv'
-      simp: detype_def detype_ext_def crunch_simps
-            wrap_ext_det_ext_ext_def mapM_x_defsym
-    ignore: freeMemory)
-crunch invoke_untyped
-  for idle_thread[wp, DetSchedAux_AI_assms]: "\<lambda>s. P (idle_thread s)"
-  (wp: crunch_wps mapME_x_inv_wp preemption_point_inv dxo_wp_weak
-      simp: detype_def detype_ext_def crunch_simps
-            wrap_ext_det_ext_ext_def mapM_x_defsym
-    ignore: freeMemory retype_region_ext)
+crunch init_arch_objects
+  for exst[wp]: "\<lambda>s. P (exst s)"
+  and etcbs_of[wp, DetSchedAux_AI_assms]: "\<lambda>s. P (etcbs_of s)"
+  and ready_queues[wp, DetSchedAux_AI_assms]: "\<lambda>s. P (ready_queues s)"
+  and idle_thread[wp, DetSchedAux_AI_assms]: "\<lambda>s. P (idle_thread s)"
+  and schedact[wp, DetSchedAux_AI_assms]: "\<lambda>s. P (scheduler_action s)"
+  and cur_domain[wp, DetSchedAux_AI_assms]: "\<lambda>s. P (cur_domain s)"
+  (wp: crunch_wps simp: set_arch_obj_simps)
+
+crunch init_arch_objects
+  for valid_queues[wp]: valid_queues
+  and valid_sched_action[wp]: valid_sched_action
+  and valid_sched[wp]: valid_sched
+  (wp: valid_queues_lift valid_sched_action_lift valid_sched_lift)
 
 lemma tcb_sched_action_valid_idle_etcb:
-  "\<lbrace>valid_idle_etcb\<rbrace>
-     tcb_sched_action foo thread
-   \<lbrace>\<lambda>_. valid_idle_etcb\<rbrace>"
-  apply (rule valid_idle_etcb_lift)
-  apply (simp add: tcb_sched_action_def set_tcb_queue_def)
-  apply (wp | simp)+
-  done
-
-crunch do_machine_op
-  for ekheap[wp]: "\<lambda>s. P (ekheap s)"
-
-lemma delete_objects_etcb_at[wp, DetSchedAux_AI_assms]:
-  "\<lbrace>\<lambda>s::det_ext state. etcb_at P t s\<rbrace> delete_objects a b \<lbrace>\<lambda>r s. etcb_at P t s\<rbrace>"
-  apply (simp add: delete_objects_def)
-  apply (simp add: detype_def detype_ext_def wrap_ext_det_ext_ext_def etcb_at_def|wp)+
-  done
-
-crunch reset_untyped_cap
-  for etcb_at[wp]: "etcb_at P t"
-  (wp: preemption_point_inv' mapME_x_inv_wp crunch_wps
-    simp: unless_def)
-
-crunch reset_untyped_cap
-  for valid_etcbs[wp]: "valid_etcbs"
-  (wp: preemption_point_inv' mapME_x_inv_wp crunch_wps
-    simp: unless_def)
-
-lemma invoke_untyped_etcb_at [DetSchedAux_AI_assms]:
-  "\<lbrace>(\<lambda>s :: det_ext state. etcb_at P t s) and valid_etcbs\<rbrace> invoke_untyped ui \<lbrace>\<lambda>r s. st_tcb_at (Not o inactive) t s \<longrightarrow> etcb_at P t s\<rbrace>"
-  apply (cases ui)
-  apply (simp add: mapM_x_def[symmetric] invoke_untyped_def whenE_def
-           split del: if_split)
-  apply (wp retype_region_etcb_at mapM_x_wp'
-            create_cap_no_pred_tcb_at typ_at_pred_tcb_at_lift
-            hoare_convert_imp[OF create_cap_no_pred_tcb_at]
-            hoare_convert_imp[OF _ init_arch_objects_exst]
-      | simp
-      | (wp (once) hoare_drop_impE_E))+
-  done
-
+  "tcb_sched_action foo thread \<lbrace>valid_idle_etcb\<rbrace>"
+  by (rule valid_idle_etcb_lift)
+     (wpsimp simp: tcb_sched_action_def set_tcb_queue_def)
 
 crunch init_arch_objects
   for valid_blocked[wp, DetSchedAux_AI_assms]: valid_blocked
   (wp: valid_blocked_lift set_cap_typ_at)
 
-lemma perform_asid_control_etcb_at:"\<lbrace>(\<lambda>s. etcb_at P t s) and valid_etcbs\<rbrace>
-          perform_asid_control_invocation aci
-          \<lbrace>\<lambda>r s. st_tcb_at (Not \<circ> inactive) t s \<longrightarrow> etcb_at P t s\<rbrace>"
+lemma perform_asid_control_etcb_at:
+  "\<lbrace>etcb_at P t\<rbrace>
+   perform_asid_control_invocation aci
+   \<lbrace>\<lambda>r s. st_tcb_at (Not \<circ> inactive) t s \<longrightarrow> etcb_at P t s\<rbrace>"
   apply (simp add: perform_asid_control_invocation_def)
-  apply (rule hoare_pre)
-   apply (wp | wpc | simp)+
+  apply wpsimp
        apply (wp hoare_imp_lift_something typ_at_pred_tcb_at_lift)[1]
       apply (rule hoare_drop_imps)
       apply (wp retype_region_etcb_at)+
@@ -108,25 +55,15 @@ lemma perform_asid_control_etcb_at:"\<lbrace>(\<lambda>s. etcb_at P t s) and val
   done
 
 crunch perform_asid_control_invocation
-  for ct[wp]: "\<lambda>s. P (cur_thread s)"
-
-crunch perform_asid_control_invocation
   for idle_thread[wp]: "\<lambda>s. P (idle_thread s)"
+  and valid_blocked[wp]: valid_blocked
+  and schedact[wp]: "\<lambda>s. P (scheduler_action s)"
+  and ready_queues[wp]: "\<lambda>s. P (ready_queues s)"
+  and cur_domain[wp]: "\<lambda>s. P (cur_domain s)"
+  (wp: hoare_weak_lift_imp simp: detype_def)
 
 crunch perform_asid_control_invocation
-  for valid_etcbs[wp]: valid_etcbs (wp: hoare_weak_lift_imp)
-
-crunch perform_asid_control_invocation
-  for valid_blocked[wp]: valid_blocked (wp: hoare_weak_lift_imp)
-
-crunch perform_asid_control_invocation
-  for schedact[wp]: "\<lambda>s :: det_ext state. P (scheduler_action s)" (wp: crunch_wps simp: detype_def detype_ext_def wrap_ext_det_ext_ext_def cap_insert_ext_def ignore: freeMemory)
-
-crunch perform_asid_control_invocation
-  for rqueues[wp]: "\<lambda>s :: det_ext state. P (ready_queues s)" (wp: crunch_wps simp: detype_def detype_ext_def wrap_ext_det_ext_ext_def cap_insert_ext_def ignore: freeMemory)
-
-crunch perform_asid_control_invocation
-  for cur_domain[wp]: "\<lambda>s :: det_ext state. P (cur_domain s)" (wp: crunch_wps simp: detype_def detype_ext_def wrap_ext_det_ext_ext_def cap_insert_ext_def ignore: freeMemory)
+  for ct[wp]: "\<lambda>s. P (cur_thread s)"
 
 lemma perform_asid_control_invocation_valid_sched:
   "\<lbrace>ct_active and invs and valid_aci aci and valid_sched and valid_idle\<rbrace>
@@ -146,25 +83,10 @@ lemma perform_asid_control_invocation_valid_sched:
   apply simp
   done
 
-crunch init_arch_objects
-  for valid_queues[wp]: valid_queues (wp: valid_queues_lift)
-
-crunch init_arch_objects
-  for valid_sched_action[wp]: valid_sched_action (wp: valid_sched_action_lift)
-
-crunch init_arch_objects
-  for valid_sched[wp]: valid_sched (wp: valid_sched_lift)
-
 end
 
 lemmas tcb_sched_action_valid_idle_etcb
     = X64.tcb_sched_action_valid_idle_etcb
-
-global_interpretation DetSchedAux_AI_det_ext?: DetSchedAux_AI_det_ext
-  proof goal_cases
-  interpret Arch .
-  case 1 show ?case by (unfold_locales; (fact DetSchedAux_AI_assms)?)
-  qed
 
 global_interpretation DetSchedAux_AI?: DetSchedAux_AI
   proof goal_cases

--- a/proof/invariant-abstract/X64/ArchDetSchedDomainTime_AI.thy
+++ b/proof/invariant-abstract/X64/ArchDetSchedDomainTime_AI.thy
@@ -24,12 +24,13 @@ crunch arch_finalise_cap
 
 crunch
   arch_activate_idle_thread, arch_switch_to_thread, arch_switch_to_idle_thread,
-  handle_arch_fault_reply,
+  handle_arch_fault_reply, init_arch_objects,
   arch_invoke_irq_control, handle_vm_fault, arch_post_modify_registers,
   prepare_thread_delete, handle_hypervisor_fault, arch_post_cap_deletion,
   make_arch_fault_msg, arch_get_sanitise_register_info, handle_reserved_irq,
   arch_invoke_irq_handler, arch_mask_irq_signal
-  for domain_list_inv[wp, DetSchedDomainTime_AI_assms]: "\<lambda>s. P (domain_list s)"
+  for domain_list_inv[wp, DetSchedDomainTime_AI_assms]: "\<lambda>s::det_state. P (domain_list s)"
+  (wp: crunch_wps)
 
 crunch arch_finalise_cap
   for domain_time_inv[wp, DetSchedDomainTime_AI_assms]: "\<lambda>s. P (domain_time s)"
@@ -42,7 +43,8 @@ crunch
   prepare_thread_delete, handle_hypervisor_fault, arch_post_cap_deletion,
   arch_get_sanitise_register_info, handle_reserved_irq, arch_invoke_irq_handler,
   arch_mask_irq_signal
-  for domain_time_inv[wp, DetSchedDomainTime_AI_assms]: "\<lambda>s. P (domain_time s)"
+  for domain_time_inv[wp, DetSchedDomainTime_AI_assms]: "\<lambda>s::det_state. P (domain_time s)"
+  (wp: crunch_wps)
 
 declare init_arch_objects_exst[DetSchedDomainTime_AI_assms]
         make_arch_fault_msg_invs[DetSchedDomainTime_AI_assms]
@@ -58,17 +60,11 @@ global_interpretation DetSchedDomainTime_AI?: DetSchedDomainTime_AI
 context Arch begin arch_global_naming
 
 crunch arch_perform_invocation
-  for domain_list_inv[wp, DetSchedDomainTime_AI_assms]: "\<lambda>s. P (domain_list s)"
+  for domain_list_inv[wp, DetSchedDomainTime_AI_assms]: "\<lambda>s::det_state. P (domain_list s)"
   (wp: crunch_wps check_cap_inv)
 
-crunch arch_mask_irq_signal
-  for domain_time_inv[wp, DetSchedDomainTime_AI_assms]: "\<lambda>s. P (domain_time s)"
-
-crunch arch_mask_irq_signal
-  for domain_list_inv[wp, DetSchedDomainTime_AI_assms]: "\<lambda>s. P (domain_list s)"
-
 crunch arch_perform_invocation
-  for domain_time_inv[wp, DetSchedDomainTime_AI_assms]: "\<lambda>s. P (domain_time s)"
+  for domain_time_inv[wp, DetSchedDomainTime_AI_assms]: "\<lambda>s::det_state. P (domain_time s)"
   (wp: crunch_wps check_cap_inv)
 
 crunch do_machine_op
@@ -83,7 +79,7 @@ lemma timer_tick_valid_domain_time:
    \<lbrace>\<lambda>x s. domain_time s = 0 \<longrightarrow> scheduler_action s = choose_new_thread\<rbrace>" (is "\<lbrace> ?dtnot0 \<rbrace> _ \<lbrace> _ \<rbrace>")
   unfolding timer_tick_def
   supply if_split[split del]
-  supply ethread_get_wp[wp del]
+  supply thread_get_wp[wp del]
   supply if_apply_def2[simp]
   apply (wpsimp
            wp: reschedule_required_valid_domain_time hoare_vcg_const_imp_lift gts_wp
@@ -91,9 +87,12 @@ lemma timer_tick_valid_domain_time:
                   postcondition once we hit thread_set_time_slice *)
                hoare_post_imp[where Q'="\<lambda>_. ?dtnot0" and Q="\<lambda>_ s. domain_time s = 0 \<longrightarrow> X s"
                                 and f="thread_set_time_slice t ts" for X t ts]
-               hoare_drop_imp[where f="ethread_get t f" for t f])
+               hoare_drop_imp[where f="thread_get t f" for t f])
   apply fastforce
   done
+
+crunch do_machine_op
+  for domain_time_sched[wp]: "\<lambda>s. P (domain_time s) (scheduler_action s)"
 
 lemma handle_interrupt_valid_domain_time [DetSchedDomainTime_AI_assms]:
   "\<lbrace>\<lambda>s :: det_ext state. 0 < domain_time s \<rbrace>

--- a/proof/invariant-abstract/X64/ArchDetype_AI.thy
+++ b/proof/invariant-abstract/X64/ArchDetype_AI.thy
@@ -457,9 +457,8 @@ lemma in_user_frame_eq:
                      Int_atLeastAtMost atLeastatMost_empty_iff split_paired_Ex
                      order_class.Icc_eq_Icc
     and [simp] = p2pm1_to_mask
-  shows "p \<notin> untyped_range cap \<Longrightarrow> in_user_frame p
-              (trans_state (\<lambda>_. detype_ext (untyped_range cap) (exst s)) s
-               \<lparr>kheap := \<lambda>x. if x \<in> untyped_range cap then None else kheap s x\<rparr>)
+  shows "p \<notin> untyped_range cap \<Longrightarrow>
+         in_user_frame p (s \<lparr>kheap := \<lambda>x. if x \<in> untyped_range cap then None else kheap s x\<rparr>)
          = in_user_frame p s"
     using cap_is_valid untyped
     apply (cases cap; simp add: in_user_frame_def valid_untyped_def valid_cap_def obj_at_def)
@@ -485,9 +484,7 @@ lemma in_device_frame_eq:
           order_class.Icc_eq_Icc
      and  p2pm1[simp] = p2pm1_to_mask
   shows "p \<notin> untyped_range cap
-       \<Longrightarrow> in_device_frame p
-              (trans_state (\<lambda>_. detype_ext (untyped_range cap) (exst s)) s
-               \<lparr>kheap := \<lambda>x. if x \<in> untyped_range cap then None else kheap s x\<rparr>)
+       \<Longrightarrow> in_device_frame p (s \<lparr>kheap := \<lambda>x. if x \<in> untyped_range cap then None else kheap s x\<rparr>)
          = in_device_frame p s"
     using cap_is_valid untyped
     unfolding in_device_frame_def

--- a/proof/invariant-abstract/X64/ArchEmptyFail_AI.thy
+++ b/proof/invariant-abstract/X64/ArchEmptyFail_AI.thy
@@ -174,18 +174,6 @@ crunch
   for (empty_fail) empty_fail[wp, EmptyFail_AI_assms]
 end
 
-global_interpretation EmptyFail_AI_schedule_unit?: EmptyFail_AI_schedule_unit
-  proof goal_cases
-  interpret Arch .
-  case 1 show ?case by (unfold_locales; (fact EmptyFail_AI_assms)?)
-  qed
-
-global_interpretation EmptyFail_AI_schedule_det?: EmptyFail_AI_schedule_det
-  proof goal_cases
-  interpret Arch .
-  case 1 show ?case by (unfold_locales; (fact EmptyFail_AI_assms)?)
-  qed
-
 global_interpretation EmptyFail_AI_schedule?: EmptyFail_AI_schedule
   proof goal_cases
   interpret Arch .
@@ -194,11 +182,7 @@ global_interpretation EmptyFail_AI_schedule?: EmptyFail_AI_schedule
 
 context Arch begin arch_global_naming
 
-crunch possible_switch_to
-  for (empty_fail) empty_fail[wp,EmptyFail_AI_assms]
-  (ignore_del: possible_switch_to)
-
-crunch handle_event, activate_thread
+crunch possible_switch_to, handle_event, activate_thread
   for (empty_fail) empty_fail[wp, EmptyFail_AI_assms]
   (simp: cap.splits arch_cap.splits split_def invocation_label.splits Let_def
          kernel_object.splits arch_kernel_obj.splits option.splits pde.splits pte.splits
@@ -206,21 +190,8 @@ crunch handle_event, activate_thread
          thread_state.splits endpoint.splits catch_def sum.splits cnode_invocation.splits
          page_table_invocation.splits page_invocation.splits asid_control_invocation.splits
          asid_pool_invocation.splits arch_invocation.splits irq_state.splits syscall.splits
-         page_directory_invocation.splits set_object_def
    ignore: resetTimer_impl)
 end
-
-global_interpretation EmptyFail_AI_call_kernel_unit?: EmptyFail_AI_call_kernel_unit
-  proof goal_cases
-  interpret Arch .
-  case 1 show ?case by (unfold_locales; (fact EmptyFail_AI_assms)?)
-  qed
-
-global_interpretation EmptyFail_AI_call_kernel_det?: EmptyFail_AI_call_kernel_det
-  proof goal_cases
-  interpret Arch .
-  case 1 show ?case by (unfold_locales; (fact EmptyFail_AI_assms)?)
-  qed
 
 global_interpretation EmptyFail_AI_call_kernel?: EmptyFail_AI_call_kernel
   proof goal_cases

--- a/proof/invariant-abstract/X64/ArchInterrupt_AI.thy
+++ b/proof/invariant-abstract/X64/ArchInterrupt_AI.thy
@@ -352,6 +352,14 @@ lemma empty_fail_maskInterrupt_ARCH[Interrupt_AI_assms]:
   "empty_fail (maskInterrupt f irq)"
   by (wp | simp add: maskInterrupt_def)+
 
+crunch timer_tick
+  for invs[wp]: invs
+  (wp: thread_set_invs_trivial[OF ball_tcb_cap_casesI])
+
+crunch timer_tick
+  for invs[wp]: invs
+  (wp: thread_set_invs_trivial[OF ball_tcb_cap_casesI])
+
 lemma (* handle_interrupt_invs *) [Interrupt_AI_assms]:
   "\<lbrace>invs\<rbrace> handle_interrupt irq \<lbrace>\<lambda>_. invs\<rbrace>"
   apply (simp add: handle_interrupt_def  )

--- a/proof/invariant-abstract/X64/ArchInvariants_AI.thy
+++ b/proof/invariant-abstract/X64/ArchInvariants_AI.thy
@@ -3251,84 +3251,47 @@ lemma valid_arch_arch_tcb_context_set[simp]:
   "valid_arch_tcb (arch_tcb_context_set a t) = valid_arch_tcb t"
   by (simp add: arch_tcb_context_set_def)
 
-lemma tcb_arch_ref_context_update:
-  "tcb_arch_ref (t\<lparr>tcb_arch := (arch_tcb_context_set a (tcb_arch t))\<rparr>) = tcb_arch_ref t"
-  by (simp add: tcb_arch_ref_def arch_tcb_context_set_def)
-
-lemma tcb_arch_ref_set_registers:
-  "tcb_arch_ref (tcb\<lparr>tcb_arch := arch_tcb_set_registers regs (tcb_arch tcb)\<rparr>) = tcb_arch_ref tcb"
-  by (simp add: tcb_arch_ref_def arch_tcb_set_registers_def)
-
 lemma valid_arch_arch_tcb_set_registers[simp]:
   "valid_arch_tcb (arch_tcb_set_registers a t) = valid_arch_tcb t"
   by (simp add: arch_tcb_set_registers_def)
 
-lemma tcb_arch_ref_ipc_buffer_update: "\<And>tcb.
-       tcb_arch_ref (tcb_ipc_buffer_update f tcb) = tcb_arch_ref tcb"
-  by (simp add: tcb_arch_ref_def)
-
-lemma tcb_arch_ref_mcpriority_update: "\<And>tcb.
-       tcb_arch_ref (tcb_mcpriority_update f tcb) = tcb_arch_ref tcb"
-  by (simp add: tcb_arch_ref_def)
-
-lemma tcb_arch_ref_ctable_update: "\<And>tcb.
-       tcb_arch_ref (tcb_ctable_update f tcb) = tcb_arch_ref tcb"
-  by (simp add: tcb_arch_ref_def)
-
-lemma tcb_arch_ref_vtable_update: "\<And>tcb.
-       tcb_arch_ref (tcb_vtable_update f tcb) = tcb_arch_ref tcb"
-  by (simp add: tcb_arch_ref_def)
-
-lemma tcb_arch_ref_reply_update: "\<And>tcb.
-       tcb_arch_ref (tcb_reply_update f tcb) = tcb_arch_ref tcb"
-  by (simp add: tcb_arch_ref_def)
-
-lemma tcb_arch_ref_caller_update: "\<And>tcb.
-       tcb_arch_ref (tcb_caller_update f tcb) = tcb_arch_ref tcb"
-  by (simp add: tcb_arch_ref_def)
-
-lemma tcb_arch_ref_ipcframe_update: "\<And>tcb.
-       tcb_arch_ref (tcb_ipcframe_update f tcb) = tcb_arch_ref tcb"
-  by (simp add: tcb_arch_ref_def)
-
-lemma tcb_arch_ref_state_update: "\<And>tcb.
-       tcb_arch_ref (tcb_state_update f tcb) = tcb_arch_ref tcb"
-  by (simp add: tcb_arch_ref_def)
-
-lemma tcb_arch_ref_fault_handler_update: "\<And>tcb.
-       tcb_arch_ref (tcb_fault_handler_update f tcb) = tcb_arch_ref tcb"
-  by (simp add: tcb_arch_ref_def)
-
-lemma tcb_arch_ref_fault_update: "\<And>tcb.
-       tcb_arch_ref (tcb_fault_update f tcb) = tcb_arch_ref tcb"
-  by (simp add: tcb_arch_ref_def)
-
-lemma tcb_arch_ref_bound_notification_update: "\<And>tcb.
-       tcb_arch_ref (tcb_bound_notification_update f tcb) = tcb_arch_ref tcb"
-  by (simp add: tcb_arch_ref_def)
-
-
-lemmas tcb_arch_ref_simps[simp] = tcb_arch_ref_ipc_buffer_update tcb_arch_ref_mcpriority_update
-  tcb_arch_ref_ctable_update tcb_arch_ref_vtable_update tcb_arch_ref_reply_update
-  tcb_arch_ref_caller_update tcb_arch_ref_ipcframe_update tcb_arch_ref_state_update
-  tcb_arch_ref_fault_handler_update tcb_arch_ref_fault_update tcb_arch_ref_bound_notification_update
-  tcb_arch_ref_context_update tcb_arch_ref_set_registers
+lemma tcb_arch_ref_simps[simp]:
+  "\<And>f. tcb_arch_ref (tcb_ipc_buffer_update f tcb) = tcb_arch_ref tcb"
+  "\<And>f. tcb_arch_ref (tcb_mcpriority_update f tcb) = tcb_arch_ref tcb"
+  "\<And>f. tcb_arch_ref (tcb_ctable_update f tcb) = tcb_arch_ref tcb"
+  "\<And>f. tcb_arch_ref (tcb_vtable_update f tcb) = tcb_arch_ref tcb"
+  "\<And>f. tcb_arch_ref (tcb_reply_update f tcb) = tcb_arch_ref tcb"
+  "\<And>f. tcb_arch_ref (tcb_caller_update f tcb) = tcb_arch_ref tcb"
+  "\<And>f. tcb_arch_ref (tcb_ipcframe_update f tcb) = tcb_arch_ref tcb"
+  "\<And>f. tcb_arch_ref (tcb_state_update f tcb) = tcb_arch_ref tcb"
+  "\<And>f. tcb_arch_ref (tcb_fault_handler_update f tcb) = tcb_arch_ref tcb"
+  "\<And>f. tcb_arch_ref (tcb_fault_update f tcb) = tcb_arch_ref tcb"
+  "\<And>f. tcb_arch_ref (tcb_bound_notification_update f tcb) = tcb_arch_ref tcb"
+  "\<And>f. tcb_arch_ref (tcb_domain_update f tcb) = tcb_arch_ref tcb"
+  "\<And>f. tcb_arch_ref (tcb_priority_update f tcb) = tcb_arch_ref tcb"
+  "\<And>f. tcb_arch_ref (tcb_time_slice_update f tcb) = tcb_arch_ref tcb"
+  "tcb_arch_ref (t\<lparr>tcb_arch := (arch_tcb_context_set a (tcb_arch t))\<rparr>) = tcb_arch_ref t"
+  "tcb_arch_ref (tcb\<lparr>tcb_arch := arch_tcb_set_registers regs (tcb_arch tcb)\<rparr>) = tcb_arch_ref tcb"
+  by (auto simp: tcb_arch_ref_def arch_tcb_set_registers_def arch_tcb_context_set_def)
 
 lemma hyp_live_tcb_def: "hyp_live (TCB tcb) = bound (tcb_arch_ref tcb)"
   by (clarsimp simp: hyp_live_def tcb_arch_ref_def)
 
 lemma hyp_live_tcb_simps[simp]:
-"\<And>tcb f. hyp_live (TCB (tcb_ipc_buffer_update f tcb)) = hyp_live (TCB tcb)"
-"\<And>tcb f. hyp_live (TCB (tcb_mcpriority_update f tcb)) = hyp_live (TCB tcb)"
-"\<And>tcb f. hyp_live (TCB (tcb_ctable_update f tcb)) = hyp_live (TCB tcb)"
-"\<And>tcb f. hyp_live (TCB (tcb_vtable_update f tcb)) = hyp_live (TCB tcb)"
-"\<And>tcb f. hyp_live (TCB (tcb_reply_update f tcb)) = hyp_live (TCB tcb)"
-"\<And>tcb f. hyp_live (TCB (tcb_caller_update f tcb)) = hyp_live (TCB tcb)"
-"\<And>tcb f. hyp_live (TCB (tcb_ipcframe_update f tcb)) = hyp_live (TCB tcb)"
-"\<And>tcb f. hyp_live (TCB (tcb_state_update f tcb)) = hyp_live (TCB tcb)"
-"\<And>tcb f. hyp_live (TCB (tcb_fault_handler_update f tcb)) = hyp_live (TCB tcb)"
-"\<And>tcb f. hyp_live (TCB (tcb_fault_update f tcb)) = hyp_live (TCB tcb)"
-"\<And>tcb f. hyp_live (TCB (tcb_bound_notification_update f tcb)) = hyp_live (TCB tcb)"
+  "\<And>f. hyp_live (TCB (tcb_ipc_buffer_update f tcb)) = hyp_live (TCB tcb)"
+  "\<And>f. hyp_live (TCB (tcb_mcpriority_update f tcb)) = hyp_live (TCB tcb)"
+  "\<And>f. hyp_live (TCB (tcb_ctable_update f tcb)) = hyp_live (TCB tcb)"
+  "\<And>f. hyp_live (TCB (tcb_vtable_update f tcb)) = hyp_live (TCB tcb)"
+  "\<And>f. hyp_live (TCB (tcb_reply_update f tcb)) = hyp_live (TCB tcb)"
+  "\<And>f. hyp_live (TCB (tcb_caller_update f tcb)) = hyp_live (TCB tcb)"
+  "\<And>f. hyp_live (TCB (tcb_ipcframe_update f tcb)) = hyp_live (TCB tcb)"
+  "\<And>f. hyp_live (TCB (tcb_state_update f tcb)) = hyp_live (TCB tcb)"
+  "\<And>f. hyp_live (TCB (tcb_fault_handler_update f tcb)) = hyp_live (TCB tcb)"
+  "\<And>f. hyp_live (TCB (tcb_fault_update f tcb)) = hyp_live (TCB tcb)"
+  "\<And>f. hyp_live (TCB (tcb_bound_notification_update f tcb)) = hyp_live (TCB tcb)"
+  "\<And>f. hyp_live (TCB (tcb_domain_update f tcb)) = hyp_live (TCB tcb)"
+  "\<And>f. hyp_live (TCB (tcb_priority_update f tcb)) = hyp_live (TCB tcb)"
+  "\<And>f. hyp_live (TCB (tcb_time_slice_update f tcb)) = hyp_live (TCB tcb)"
   by (simp_all add: hyp_live_tcb_def)
 
 

--- a/proof/invariant-abstract/X64/ArchKHeap_AI.thy
+++ b/proof/invariant-abstract/X64/ArchKHeap_AI.thy
@@ -844,7 +844,7 @@ lemma pspace_respects_region_cong[cong]:
 
 definition "obj_is_device tp dev \<equiv>
   case tp of Untyped \<Rightarrow> dev
-    | _ \<Rightarrow>(case (default_object tp dev 0) of (ArchObj (DataPage dev _)) \<Rightarrow> dev
+    | _ \<Rightarrow>(case default_object tp dev 0 0 of (ArchObj (DataPage dev _)) \<Rightarrow> dev
           | _ \<Rightarrow> False)"
 
 lemma cap_is_device_obj_is_device[simp]:
@@ -887,6 +887,30 @@ lemma state_hyp_refs_of_tcb_state_update:
   apply (clarsimp simp add: state_hyp_refs_of_def obj_at_def split: option.splits)
   done
 
+lemma state_hyp_refs_of_tcb_domain_update:
+  "kheap s t = Some (TCB tcb) \<Longrightarrow>
+   state_hyp_refs_of (s\<lparr>kheap := (kheap s)(t \<mapsto> TCB (tcb\<lparr>tcb_domain := d\<rparr>))\<rparr>)
+     = state_hyp_refs_of s"
+  apply (rule all_ext)
+  apply (clarsimp simp add: state_hyp_refs_of_def obj_at_def split: option.splits)
+  done
+
+lemma state_hyp_refs_of_tcb_priority_update:
+  "kheap s t = Some (TCB tcb) \<Longrightarrow>
+   state_hyp_refs_of (s\<lparr>kheap := (kheap s)(t \<mapsto> TCB (tcb\<lparr>tcb_priority := p\<rparr>))\<rparr>)
+     = state_hyp_refs_of s"
+  apply (rule all_ext)
+  apply (clarsimp simp add: state_hyp_refs_of_def obj_at_def split: option.splits)
+  done
+
+lemma state_hyp_refs_of_tcb_time_slice_update:
+  "kheap s t = Some (TCB tcb) \<Longrightarrow>
+   state_hyp_refs_of (s\<lparr>kheap := (kheap s)(t \<mapsto> TCB (tcb\<lparr>tcb_time_slice := ts\<rparr>))\<rparr>)
+     = state_hyp_refs_of s"
+  apply (rule all_ext)
+  apply (clarsimp simp add: state_hyp_refs_of_def obj_at_def split: option.splits)
+  done
+
 lemma arch_valid_obj_same_type:
   "\<lbrakk> arch_valid_obj ao s; kheap s p = Some ko; a_type k = a_type ko \<rbrakk>
    \<Longrightarrow> arch_valid_obj ao (s\<lparr>kheap := (kheap s)(p \<mapsto> k)\<rparr>)"
@@ -894,11 +918,11 @@ lemma arch_valid_obj_same_type:
          clarsimp simp: typ_at_same_type)
 
 
-lemma default_arch_object_not_live: "\<not> live (ArchObj (default_arch_object aty dev us))"
+lemma default_arch_object_not_live[simp]: "\<not> live (ArchObj (default_arch_object aty dev us))"
   by (clarsimp simp: default_arch_object_def live_def hyp_live_def arch_live_def
                split: aobject_type.splits)
 
-lemma default_tcb_not_live: "\<not> live (TCB default_tcb)"
+lemma default_tcb_not_live[simp]: "\<not> live (TCB (default_tcb d))"
   by (clarsimp simp: default_tcb_def default_arch_tcb_def live_def hyp_live_def)
 
 lemma valid_arch_tcb_same_type:

--- a/proof/invariant-abstract/X64/ArchKHeap_AI.thy
+++ b/proof/invariant-abstract/X64/ArchKHeap_AI.thy
@@ -872,17 +872,17 @@ lemma state_hyp_refs_of_ntfn_update: "\<And>s ep val. typ_at ANTFN ep s \<Longri
   done
 
 lemma state_hyp_refs_of_tcb_bound_ntfn_update:
-       "kheap s t = Some (TCB tcb) \<Longrightarrow>
-          state_hyp_refs_of (s\<lparr>kheap := (kheap s)(t \<mapsto> TCB (tcb\<lparr>tcb_bound_notification := ntfn\<rparr>))\<rparr>)
-            = state_hyp_refs_of s"
+  "kheap s t = Some (TCB tcb) \<Longrightarrow>
+   state_hyp_refs_of (s\<lparr>kheap := (kheap s)(t \<mapsto> TCB (tcb\<lparr>tcb_bound_notification := ntfn\<rparr>))\<rparr>)
+   = state_hyp_refs_of s"
   apply (rule all_ext)
   apply (clarsimp simp add: state_hyp_refs_of_def obj_at_def split: option.splits)
   done
 
 lemma state_hyp_refs_of_tcb_state_update:
-       "kheap s t = Some (TCB tcb) \<Longrightarrow>
-          state_hyp_refs_of (s\<lparr>kheap := (kheap s)(t \<mapsto> TCB (tcb\<lparr>tcb_state := ts\<rparr>))\<rparr>)
-            = state_hyp_refs_of s"
+  "kheap s t = Some (TCB tcb) \<Longrightarrow>
+   state_hyp_refs_of (s\<lparr>kheap := (kheap s)(t \<mapsto> TCB (tcb\<lparr>tcb_state := ts\<rparr>))\<rparr>)
+   = state_hyp_refs_of s"
   apply (rule all_ext)
   apply (clarsimp simp add: state_hyp_refs_of_def obj_at_def split: option.splits)
   done
@@ -890,7 +890,7 @@ lemma state_hyp_refs_of_tcb_state_update:
 lemma state_hyp_refs_of_tcb_domain_update:
   "kheap s t = Some (TCB tcb) \<Longrightarrow>
    state_hyp_refs_of (s\<lparr>kheap := (kheap s)(t \<mapsto> TCB (tcb\<lparr>tcb_domain := d\<rparr>))\<rparr>)
-     = state_hyp_refs_of s"
+   = state_hyp_refs_of s"
   apply (rule all_ext)
   apply (clarsimp simp add: state_hyp_refs_of_def obj_at_def split: option.splits)
   done
@@ -898,7 +898,7 @@ lemma state_hyp_refs_of_tcb_domain_update:
 lemma state_hyp_refs_of_tcb_priority_update:
   "kheap s t = Some (TCB tcb) \<Longrightarrow>
    state_hyp_refs_of (s\<lparr>kheap := (kheap s)(t \<mapsto> TCB (tcb\<lparr>tcb_priority := p\<rparr>))\<rparr>)
-     = state_hyp_refs_of s"
+   = state_hyp_refs_of s"
   apply (rule all_ext)
   apply (clarsimp simp add: state_hyp_refs_of_def obj_at_def split: option.splits)
   done
@@ -906,7 +906,7 @@ lemma state_hyp_refs_of_tcb_priority_update:
 lemma state_hyp_refs_of_tcb_time_slice_update:
   "kheap s t = Some (TCB tcb) \<Longrightarrow>
    state_hyp_refs_of (s\<lparr>kheap := (kheap s)(t \<mapsto> TCB (tcb\<lparr>tcb_time_slice := ts\<rparr>))\<rparr>)
-     = state_hyp_refs_of s"
+   = state_hyp_refs_of s"
   apply (rule all_ext)
   apply (clarsimp simp add: state_hyp_refs_of_def obj_at_def split: option.splits)
   done

--- a/proof/invariant-abstract/X64/ArchRetype_AI.thy
+++ b/proof/invariant-abstract/X64/ArchRetype_AI.thy
@@ -54,31 +54,16 @@ lemma retype_region_ret_folded [Retype_AI_assms]:
    apply (simp add:retype_addrs_def)
   done
 
-lemmas [wp] =  unless_wp
-
 (* These also prove facts about copy_global_mappings *)
 crunch init_arch_objects
-  for pspace_aligned[wp]: "pspace_aligned"
-  (ignore: clearMemory wp: crunch_wps simp: crunch_simps unless_def)
-crunch init_arch_objects
-  for pspace_distinct[wp]: "pspace_distinct"
-  (ignore: clearMemory set_object set_pml4
-       wp: crunch_wps set_object_distinct
-     simp: crunch_simps unless_def set_arch_obj_simps)
-crunch init_arch_objects
-  for mdb_inv[wp]: "\<lambda>s. P (cdt s)"
-  (ignore: clearMemory set_pml4 wp: crunch_wps simp: crunch_simps unless_def set_arch_obj_simps)
-crunch init_arch_objects
-  for valid_mdb[wp]: "valid_mdb"
-  (ignore: clearMemory set_pml4 wp: crunch_wps simp: crunch_simps unless_def set_arch_obj_simps)
-crunch init_arch_objects
-  for cte_wp_at[wp]: "\<lambda>s. P (cte_wp_at P' p s)"
-  (ignore: clearMemory set_pml4
-       wp: crunch_wps set_aobject_cte_wp_at
-     simp: crunch_simps unless_def set_arch_obj_simps)
-crunch init_arch_objects
-  for typ_at[wp]: "\<lambda>s. P (typ_at T p s)"
-  (ignore: clearMemory wp: crunch_wps simp: crunch_simps unless_def)
+  for pspace_aligned[wp]:  "pspace_aligned"
+  and pspace_distinct[wp]: "pspace_distinct"
+  and mdb_inv[wp]: "\<lambda>s. P (cdt s)"
+  and valid_mdb[wp]: "valid_mdb"
+  and cte_wp_at[wp]: "\<lambda>s. P (cte_wp_at P' p s)"
+  and typ_at[wp]: "\<lambda>s. P (typ_at T p s)"
+  and cur_thread[wp]: "\<lambda>s. P (cur_thread s)"
+  (ignore: clearMemory set_pml4 wp: crunch_wps set_aobject_cte_wp_at simp: set_arch_obj_simps)
 
 lemma mdb_cte_at_store_pml4e[wp]:
   "\<lbrace>\<lambda>s. mdb_cte_at (swp (cte_wp_at ((\<noteq>) cap.NullCap)) s) (cdt s)\<rbrace>
@@ -615,7 +600,7 @@ lemma valid_untyped_helper [Retype_AI_assms]:
   and     cn   : "caps_no_overlap ptr sz s"
   and     vp   : "valid_pspace s"
   shows "valid_cap c
-           (s\<lparr>kheap := \<lambda>x. if x \<in> set (retype_addrs ptr ty n us) then Some (default_object ty dev us) else kheap s x\<rparr>)"
+           (s\<lparr>kheap := \<lambda>x. if x \<in> set (retype_addrs ptr ty n us) then Some (default_object ty dev us (cur_domain s)) else kheap s x\<rparr>)"
   (is "valid_cap c ?ns")
   proof -
   have obj_at_pres: "\<And>P x. obj_at P x s \<Longrightarrow> obj_at P x ?ns"
@@ -623,7 +608,7 @@ lemma valid_untyped_helper [Retype_AI_assms]:
    (erule pspace_no_overlapC [OF pn _ _ cover vp])
   note blah[simp del] = atLeastAtMost_iff atLeastatMost_subset_iff atLeastLessThan_iff
         Int_atLeastAtMost atLeastatMost_empty_iff
-  have cover':"range_cover ptr sz (obj_bits (default_object ty dev us)) n"
+  have cover':"range_cover ptr sz (obj_bits (default_object ty dev us (cur_domain s))) n"
     using cover tyunt
     by (clarsimp simp: obj_bits_dev_irr)
 
@@ -708,30 +693,28 @@ lemma valid_cap:
   proof -
   note blah[simp del] = atLeastAtMost_iff atLeastatMost_subset_iff atLeastLessThan_iff
         Int_atLeastAtMost atLeastatMost_empty_iff
-  have cover':"range_cover ptr sz (obj_bits (default_object ty dev us)) n"
+  have cover':"range_cover ptr sz (obj_bits (default_object ty dev us (cur_domain s))) n"
     using cover tyunt
     by (clarsimp simp: obj_bits_dev_irr)
   show ?thesis
   using cap
   apply (case_tac cap)
     unfolding valid_cap_def
-    apply (simp_all add: valid_cap_def obj_at_pres cte_at_pres
-                              split: option.split_asm arch_cap.split_asm
-                                     option.splits)
+             apply (simp_all add: valid_cap_def obj_at_pres cte_at_pres
+                           split: option.split_asm arch_cap.split_asm option.splits)
      apply (clarsimp simp add: valid_untyped_def ps_def s'_def)
      apply (intro conjI)
-       apply clarsimp
-       apply (drule disjoint_subset [OF retype_addrs_obj_range_subset [OF _ cover' tyunt]])
-        apply (simp add: Int_ac p_assoc_help[symmetric])
-       apply simp
       apply clarsimp
+      apply (drule disjoint_subset [OF retype_addrs_obj_range_subset [OF _ cover' tyunt]])
+       apply (simp add: Int_ac p_assoc_help[symmetric])
+      apply fastforce
+     apply clarsimp
      apply (drule disjoint_subset [OF retype_addrs_obj_range_subset [OF _ cover' tyunt]])
       apply (simp add: Int_ac p_assoc_help[symmetric])
-     apply simp
-     using cover tyunt
-     apply (simp add: obj_bits_api_def2 split: Structures_A.apiobject_type.splits)
-     apply clarsimp+
-    apply (fastforce elim!: obj_at_pres)+
+     apply fastforce
+    using cover tyunt
+    apply (simp add: obj_bits_api_def2 split: Structures_A.apiobject_type.splits)
+        apply (fastforce elim!: obj_at_pres)+
   done
   qed
 
@@ -742,13 +725,13 @@ lemma valid_global_refs:
   done
 
 lemma vs_refs_default [simp]:
-  "vs_refs (default_object ty dev us) = {}"
+  "vs_refs (default_object ty dev us d) = {}"
   by (simp add: default_object_def default_arch_object_def tyunt vs_refs_def
                 o_def pml4e_ref_def pdpte_ref_def pde_ref_def graph_of_def
          split: Structures_A.apiobject_type.splits aobject_type.splits)
 
 lemma vs_refs_pages_default [simp]:
-  "vs_refs_pages (default_object ty dev us) = {}"
+  "vs_refs_pages (default_object ty dev us d) = {}"
   by (simp add: default_object_def default_arch_object_def tyunt vs_refs_pages_def
                 o_def pml4e_ref_pages_def pdpte_ref_pages_def graph_of_def
          split: Structures_A.apiobject_type.splits aobject_type.splits)
@@ -802,10 +785,10 @@ proof
   fix p ao
   assume p: "(\<exists>\<rhd> p) s'"
   assume "ko_at (ArchObj ao) p s'"
-  hence "ko_at (ArchObj ao) p s \<or> ArchObj ao = default_object ty dev us"
+  hence "ko_at (ArchObj ao) p s \<or> ArchObj ao = default_object ty dev us (cur_domain s)"
     by (simp add: ps_def obj_at_def s'_def split: if_split_asm)
   moreover
-  { assume "ArchObj ao = default_object ty dev us" with tyunt
+  { assume "ArchObj ao = default_object ty dev us (cur_domain s)" with tyunt
     have "valid_vspace_obj ao s'" by (rule valid_vspace_obj_default)
   }
   moreover
@@ -957,7 +940,7 @@ lemma pspace_respects_device_regionD:
 
 
 lemma default_obj_dev:
-  "\<lbrakk>ty \<noteq> Untyped;default_object ty dev us = ArchObj (DataPage dev' sz)\<rbrakk> \<Longrightarrow> dev = dev'"
+  "\<lbrakk>ty \<noteq> Untyped;default_object ty dev us d = ArchObj (DataPage dev' sz)\<rbrakk> \<Longrightarrow> dev = dev'"
   by (clarsimp simp: default_object_def default_arch_object_def
               split: apiobject_type.split_asm aobject_type.split_asm)
 
@@ -1100,7 +1083,7 @@ lemma pspace_respects_device_region:
   apply (rule pspace_respects_device_regionI)
      apply (clarsimp simp add: pspace_respects_device_region_def s'_def ps_def
                         split: if_split_asm )
-      apply (drule retype_addrs_obj_range_subset[OF _ _ tyunt])
+      apply (drule retype_addrs_obj_range_subset[OF _ _ tyunt, where d'="cur_domain s"])
        using cover tyunt
        apply (simp add: obj_bits_api_def3 split: if_splits)
       apply (frule default_obj_dev[OF tyunt],simp)
@@ -1114,7 +1097,7 @@ lemma pspace_respects_device_region:
      apply fastforce
     apply (clarsimp simp add: pspace_respects_device_region_def s'_def ps_def
                        split: if_split_asm )
-     apply (drule retype_addrs_obj_range_subset[OF _ _ tyunt])
+     apply (drule retype_addrs_obj_range_subset[OF _ _ tyunt, where d'="cur_domain s"])
       using cover tyunt
       apply (simp add: obj_bits_api_def4 split: if_splits)
      apply (frule default_obj_dev[OF tyunt],simp)

--- a/proof/invariant-abstract/X64/ArchSchedule_AI.thy
+++ b/proof/invariant-abstract/X64/ArchSchedule_AI.thy
@@ -40,11 +40,9 @@ lemma arch_stt_tcb [wp,Schedule_AI_assms]:
   apply (wp)
   done
 
-lemma arch_stt_runnable[Schedule_AI_assms]:
-  "\<lbrace>st_tcb_at runnable t\<rbrace> arch_switch_to_thread t \<lbrace>\<lambda>r . st_tcb_at runnable t\<rbrace>"
-  apply (simp add: arch_switch_to_thread_def)
-  apply wp
-  done
+lemma arch_stt_st_tcb_at[Schedule_AI_assms]:
+  "arch_switch_to_thread t \<lbrace>st_tcb_at Q t\<rbrace>"
+  by (wpsimp simp: arch_switch_to_thread_def)
 
 lemma arch_stit_invs[wp, Schedule_AI_assms]:
   "\<lbrace>invs\<rbrace> arch_switch_to_idle_thread \<lbrace>\<lambda>r. invs\<rbrace>"
@@ -60,8 +58,15 @@ crunch set_vm_root
   for st_tcb_at[wp]: "st_tcb_at P t"
   (wp: crunch_wps simp: crunch_simps)
 
+lemma idle_strg:
+  "thread = idle_thread s \<and> invs s \<Longrightarrow> invs (s\<lparr>cur_thread := thread\<rparr>)"
+  by (clarsimp simp: invs_def valid_state_def valid_idle_def cur_tcb_def
+                     pred_tcb_at_def valid_machine_state_def obj_at_def is_tcb_def)
+
 crunch set_vm_root
   for ct[wp]: "\<lambda>s. P (cur_thread s)"
+  and it[wp]: "\<lambda>s. P (idle_thread s)"
+  and scheduler_action[wp]: "\<lambda>s. P (scheduler_action s)"
   (wp: crunch_wps simp: crunch_simps)
 
 lemma arch_stit_activatable[wp, Schedule_AI_assms]:
@@ -71,10 +76,9 @@ lemma arch_stit_activatable[wp, Schedule_AI_assms]:
   done
 
 lemma stit_invs [wp,Schedule_AI_assms]:
-  "\<lbrace>invs\<rbrace> switch_to_idle_thread \<lbrace>\<lambda>rv. invs\<rbrace>"
-  apply (simp add: switch_to_idle_thread_def)
-  apply (wp sct_invs)
-  apply (clarsimp simp: invs_def valid_state_def valid_idle_def pred_tcb_at_tcb_at)
+  "switch_to_idle_thread \<lbrace>invs\<rbrace>"
+  apply (simp add: switch_to_idle_thread_def arch_switch_to_idle_thread_def)
+  apply (wpsimp|strengthen idle_strg)+
   done
 
 lemma stit_activatable[Schedule_AI_assms]:
@@ -85,28 +89,15 @@ lemma stit_activatable[Schedule_AI_assms]:
                  elim!: pred_tcb_weaken_strongerE)
   done
 
-lemma stt_invs [wp,Schedule_AI_assms]:
-  "\<lbrace>invs\<rbrace> switch_to_thread t' \<lbrace>\<lambda>_. invs\<rbrace>"
-  apply (simp add: switch_to_thread_def)
-  apply wp
-     apply (simp add: trans_state_update[symmetric] del: trans_state_update)
-    apply (rule_tac Q'="\<lambda>_. invs and tcb_at t'" in hoare_strengthen_post, wp)
-    apply (clarsimp simp: invs_def valid_state_def valid_idle_def
-                          valid_irq_node_def valid_machine_state_def)
-    apply (fastforce simp: cur_tcb_def obj_at_def
-                     elim: valid_pspace_eqI ifunsafe_pspaceI)
-   apply wp+
-  apply clarsimp
-  apply (simp add: is_tcb_def)
-  done
-end
+lemma arch_stt_scheduler_action [wp, Schedule_AI_assms]:
+  "\<lbrace>\<lambda>s. P (scheduler_action s)\<rbrace> arch_switch_to_thread t' \<lbrace>\<lambda>_ s. P (scheduler_action s)\<rbrace>"
+  by (wpsimp simp: arch_switch_to_thread_def)
 
-interpretation Schedule_AI_U?: Schedule_AI_U
-  proof goal_cases
-  interpret Arch .
-  case 1 show ?case
-  by (intro_locales; (unfold_locales; fact Schedule_AI_assms)?)
-  qed
+lemma arch_stit_scheduler_action [wp, Schedule_AI_assms]:
+  "\<lbrace>\<lambda>s. P (scheduler_action s)\<rbrace> arch_switch_to_idle_thread \<lbrace>\<lambda>_ s. P (scheduler_action s)\<rbrace>"
+  by (wpsimp simp: arch_switch_to_idle_thread_def)
+
+end
 
 interpretation Schedule_AI?: Schedule_AI
   proof goal_cases

--- a/proof/invariant-abstract/X64/ArchUntyped_AI.thy
+++ b/proof/invariant-abstract/X64/ArchUntyped_AI.thy
@@ -153,7 +153,7 @@ lemma retype_ret_valid_caps_captable[Untyped_AI_assms]:
       \<and> range_cover ptr sz (obj_bits_api CapTableObject us) n \<and> ptr \<noteq> 0
        \<rbrakk>
          \<Longrightarrow> \<forall>y\<in>{0..<n}. s
-                \<lparr>kheap := foldr (\<lambda>p kh. kh(p \<mapsto> default_object CapTableObject dev us)) (map (\<lambda>p. ptr_add ptr (p * 2 ^ obj_bits_api CapTableObject us)) [0..<n])
+                \<lparr>kheap := foldr (\<lambda>p kh. kh(p \<mapsto> default_object CapTableObject dev us (cur_domain s))) (map (\<lambda>p. ptr_add ptr (p * 2 ^ obj_bits_api CapTableObject us)) [0..<n])
                            (kheap s)\<rparr> \<turnstile> CNodeCap (ptr_add ptr (y * 2 ^ obj_bits_api CapTableObject us)) us []"
 by ((clarsimp simp:valid_cap_def default_object_def cap_aligned_def
         cte_level_bits_def is_obj_defs well_formed_cnode_n_def empty_cnode_def
@@ -166,7 +166,7 @@ lemma retype_ret_valid_caps_aobj[Untyped_AI_assms]:
   \<lbrakk>pspace_no_overlap_range_cover ptr sz s \<and> x6 \<noteq> ASIDPoolObj \<and>
   range_cover ptr sz (obj_bits_api (ArchObject x6) us) n \<and> ptr \<noteq> 0\<rbrakk>
             \<Longrightarrow> \<forall>y\<in>{0..<n}. s
-                   \<lparr>kheap := foldr (\<lambda>p kh. kh(p \<mapsto> default_object (ArchObject x6) dev us)) (map (\<lambda>p. ptr_add ptr (p * 2 ^ obj_bits_api (ArchObject x6) us)) [0..<n])
+                   \<lparr>kheap := foldr (\<lambda>p kh. kh(p \<mapsto> default_object (ArchObject x6) dev us (cur_domain s))) (map (\<lambda>p. ptr_add ptr (p * 2 ^ obj_bits_api (ArchObject x6) us)) [0..<n])
                               (kheap s)\<rparr> \<turnstile> ArchObjectCap (arch_default_cap x6 (ptr_add ptr (y * 2 ^ obj_bits_api (ArchObject x6) us)) us dev)"
   apply (rename_tac aobject_type us n)
   apply (case_tac aobject_type)
@@ -566,9 +566,8 @@ lemma nonempty_table_caps_of[Untyped_AI_assms]:
 
 
 lemma nonempty_default[simp, Untyped_AI_assms]:
-  "tp \<noteq> Untyped \<Longrightarrow> \<not> nonempty_table S (default_object tp dev us)"
-  apply (case_tac tp, simp_all add: default_object_def nonempty_table_def
-                                    a_type_def)
+  "tp \<noteq> Untyped \<Longrightarrow> \<not> nonempty_table S (default_object tp dev us d)"
+  apply (case_tac tp, simp_all add: default_object_def nonempty_table_def a_type_def)
   apply (rename_tac aobject_type)
   apply (case_tac aobject_type, simp_all add: default_arch_object_def)
    apply (simp_all add: empty_table_def pde_ref_def)

--- a/proof/invariant-abstract/X64/ArchVSpace_AI.thy
+++ b/proof/invariant-abstract/X64/ArchVSpace_AI.thy
@@ -3909,7 +3909,7 @@ end
 
 lemma valid_vspace_obj_default:
   assumes tyunt: "ty \<noteq> Structures_A.apiobject_type.Untyped"
-  shows "ArchObj ao = default_object ty dev us \<Longrightarrow> valid_vspace_obj ao s'"
+  shows "ArchObj ao = default_object ty dev us d \<Longrightarrow> valid_vspace_obj ao s'"
   apply (cases ty, simp_all add: default_object_def tyunt)
   apply (simp add: valid_vspace_obj_default')
   done

--- a/proof/refine/AARCH64/Untyped_R.thy
+++ b/proof/refine/AARCH64/Untyped_R.thy
@@ -2999,7 +2999,7 @@ lemma createNewCaps_range_helper:
             apply (wpsimp simp: curDomain_def)
            apply (clarsimp simp: APIType_capBits_def word_bits_def objBits_simps ptr_add_def o_def)
            apply (fastforce simp: objBitsKO_def objBits_def)
-           \<comment>\<open>other APIObjectType\<close>
+          \<comment>\<open>other APIObjectType\<close>
           apply ((rule hoare_pre, wp createObjects_ret2,
                   clarsimp simp: APIType_capBits_def word_bits_def objBits_simps ptr_add_def o_def,
                   fastforce simp: objBitsKO_def objBits_def)+)[3]

--- a/proof/refine/ARM/ADT_H.thy
+++ b/proof/refine/ARM/ADT_H.thy
@@ -434,6 +434,9 @@ definition
       tcb_fault = map_option FaultMap (tcbFault tcb),
       tcb_bound_notification = tcbBoundNotification tcb,
       tcb_mcpriority = tcbMCP tcb,
+      tcb_priority = tcbPriority tcb,
+      tcb_time_slice = tcbTimeSlice tcb,
+      tcb_domain = tcbDomain tcb,
       tcb_arch = ArchTcbMap (tcbArch tcb)\<rparr>"
 
 definition
@@ -909,55 +912,6 @@ proof -
     apply (clarsimp simp add: pde_relation_def split: if_split_asm)
     done
 qed
-
-definition
-  "EtcbMap tcb \<equiv>
-     \<lparr>tcb_priority = tcbPriority tcb,
-      time_slice = tcbTimeSlice tcb,
-      tcb_domain = tcbDomain tcb\<rparr>"
-
-definition
-  absEkheap :: "(word32 \<rightharpoonup> Structures_H.kernel_object) \<Rightarrow> obj_ref \<Rightarrow> etcb option"
-  where
-  "absEkheap h \<equiv> \<lambda>x.
-     case h x of
-       Some (KOTCB tcb) \<Rightarrow> Some (EtcbMap tcb)
-     | _ \<Rightarrow> None"
-
-lemma absEkheap_correct:
-assumes pspace_relation: "pspace_relation (kheap s) (ksPSpace s')"
-assumes ekheap_relation: "ekheap_relation (ekheap s) (ksPSpace s')"
-assumes vetcbs: "valid_etcbs s"
-shows
-  "absEkheap (ksPSpace s') = ekheap s"
-  apply (rule ext)
-  apply (clarsimp simp: absEkheap_def split: option.splits Structures_H.kernel_object.splits)
-  apply (subgoal_tac "\<forall>x. (\<exists>tcb. kheap s x = Some (TCB tcb)) =
-                          (\<exists>tcb'. ksPSpace s' x = Some (KOTCB tcb'))")
-   using vetcbs ekheap_relation
-   apply (clarsimp simp: valid_etcbs_def is_etcb_at_def dom_def ekheap_relation_def st_tcb_at_def obj_at_def)
-   apply (erule_tac x=x in allE)+
-   apply (rule conjI, force)
-   apply clarsimp
-   apply (rule conjI, clarsimp simp: EtcbMap_def etcb_relation_def)+
-   apply clarsimp
-  using pspace_relation
-  apply (clarsimp simp add: pspace_relation_def pspace_dom_def UNION_eq
-                              dom_def Collect_eq)
-  apply (rule iffI)
-   apply (erule_tac x=x in allE)+
-   apply (case_tac "ksPSpace s' x", clarsimp)
-    apply (erule_tac x=x in allE, clarsimp)
-   apply clarsimp
-   apply (case_tac a, simp_all add: tcb_relation_cut_def other_obj_relation_def)
-  apply (insert pspace_relation)
-  apply (clarsimp simp: obj_at'_def projectKOs)
-  apply (erule(1) pspace_dom_relatedE)
-  apply (erule(1) obj_relation_cutsE)
-  apply (clarsimp simp: other_obj_relation_def
-                 split: Structures_A.kernel_object.split_asm  if_split_asm
-                        ARM_A.arch_kernel_obj.split_asm)+
-  done
 
 text \<open>The following function can be used to reverse cte_map.\<close>
 definition
@@ -1796,13 +1750,6 @@ lemma absSchedulerAction_correct:
 definition
   "absExst s \<equiv>
      \<lparr>work_units_completed_internal = ksWorkUnitsCompleted s,
-      scheduler_action_internal = absSchedulerAction (ksSchedulerAction s),
-      ekheap_internal = absEkheap (ksPSpace s),
-      domain_list_internal = ksDomSchedule s,
-      domain_index_internal = ksDomScheduleIdx s,
-      cur_domain_internal = ksCurDomain s,
-      domain_time_internal = ksDomainTime s,
-      ready_queues_internal = (\<lambda>d p. heap_walk (tcbSchedNexts_of s) (tcbQueueHead (ksReadyQueues s (d, p))) []),
       cdt_list_internal = absCDTList (cteMap (gsCNodes s)) (ctes_of s)\<rparr>"
 
 lemma absExst_correct:
@@ -1810,16 +1757,12 @@ lemma absExst_correct:
   assumes rel: "(s, s') \<in> state_relation"
   shows "absExst s' = exst s"
   apply (rule det_ext.equality)
-           using rel invs invs'
-           apply (simp_all add: absExst_def absSchedulerAction_correct absEkheap_correct
-                                absCDTList_correct[THEN fun_cong] state_relation_def invs_def
-                                valid_state_def ready_queues_relation_def ready_queue_relation_def
-                                invs'_def valid_state'_def
-                                valid_pspace_def valid_sched_def valid_pspace'_def curry_def
-                                fun_eq_iff)
-   apply (fastforce simp: absEkheap_correct)
-  apply (fastforce simp: list_queue_relation_def Let_def dest: heap_ls_is_walk)
-  done
+      using rel invs invs'
+      apply (simp_all add: absExst_def absSchedulerAction_correct
+                           absCDTList_correct[THEN fun_cong] state_relation_def invs_def valid_state_def
+                           ready_queues_relation_def invs'_def valid_state'_def
+                           valid_pspace_def valid_sched_def valid_pspace'_def curry_def fun_eq_iff)
+      done
 
 
 definition
@@ -1828,6 +1771,12 @@ definition
     cdt = absCDT (cteMap (gsCNodes s)) (ctes_of s),
     is_original_cap = absIsOriginalCap (cteMap (gsCNodes s)) (ksPSpace s),
     cur_thread = ksCurThread s, idle_thread = ksIdleThread s,
+    scheduler_action = absSchedulerAction (ksSchedulerAction s),
+    domain_list = ksDomSchedule s,
+    domain_index = ksDomScheduleIdx s,
+    cur_domain = ksCurDomain s,
+    domain_time = ksDomainTime s,
+    ready_queues = (\<lambda>d p. heap_walk (tcbSchedNexts_of s) (tcbQueueHead (ksReadyQueues s (d, p))) []),
     machine_state = observable_memory (ksMachineState s) (user_mem' s),
     interrupt_irq_node = absInterruptIRQNode (ksInterruptState s),
     interrupt_states = absInterruptStates (ksInterruptState s),

--- a/proof/refine/ARM/ArchAcc_R.thy
+++ b/proof/refine/ARM/ArchAcc_R.thy
@@ -188,7 +188,7 @@ crunch getIRQSlot
 
 lemma setObject_ASIDPool_corres [corres]:
   "p = p' \<Longrightarrow> a = inv ASIDPool a' o ucast \<Longrightarrow>
-  corres dc (asid_pool_at p and valid_etcbs) (asid_pool_at' p')
+  corres dc (asid_pool_at p) (asid_pool_at' p')
             (set_asid_pool p a) (setObject p' a')"
   apply (simp add: set_asid_pool_def)
   apply (corresKsimp search: setObject_other_corres[where P="\<lambda>_. True"]
@@ -200,7 +200,7 @@ lemma setObject_ASIDPool_corres [corres]:
 
 lemma setObject_ASIDPool_corres':
   "a = inv ASIDPool a' o ucast \<Longrightarrow>
-  corres dc (asid_pool_at p and valid_etcbs) (pspace_aligned' and pspace_distinct')
+  corres dc (asid_pool_at p) (pspace_aligned' and pspace_distinct')
             (set_asid_pool p a) (setObject p a')"
   apply (rule stronger_corres_guard_imp[OF setObject_ASIDPool_corres])
    apply auto
@@ -685,8 +685,7 @@ lemma get_master_pte_corres':
 \<comment> \<open>setObject_other_corres unfortunately doesn't work here\<close>
 lemma setObject_PD_corres [@lift_corres_args, corres]:
   "pde_relation_aligned (p>>2) pde pde' \<Longrightarrow>
-         corres dc  (ko_at (ArchObj (PageDirectory pd)) (p && ~~ mask pd_bits)
-                     and pspace_aligned and valid_etcbs)
+         corres dc  (ko_at (ArchObj (PageDirectory pd)) (p && ~~ mask pd_bits) and pspace_aligned)
                     (pde_at' p)
           (set_pd (p && ~~ mask pd_bits) (pd(ucast (p && mask pd_bits >> 2) := pde)))
           (setObject p pde')"
@@ -745,13 +744,6 @@ lemma setObject_PD_corres [@lift_corres_args, corres]:
     apply (simp split: if_split_asm)
    apply (simp add: other_obj_relation_def
                split: Structures_A.kernel_object.splits arch_kernel_obj.splits)
-  apply (rule conjI)
-   apply (clarsimp simp: ekheap_relation_def pspace_relation_def)
-   apply (drule(1) ekheap_kheap_dom)
-   apply clarsimp
-   apply (drule_tac x=p in bspec, erule domI)
-   apply (simp add: tcb_relation_cut_def
-             split: Structures_A.kernel_object.splits)
   apply (extract_conjunct \<open>match conclusion in "ghost_relation _ _ _" \<Rightarrow> -\<close>)
    apply (clarsimp simp add: ghost_relation_def)
    apply (erule_tac x="p && ~~ mask pd_bits" in allE)+
@@ -767,8 +759,7 @@ lemma setObject_PD_corres [@lift_corres_args, corres]:
 
 lemma setObject_PT_corres [@lift_corres_args, corres]:
   "pte_relation_aligned (p >> 2) pte pte' \<Longrightarrow>
-         corres dc  (ko_at (ArchObj (PageTable pt)) (p && ~~ mask pt_bits)
-                     and pspace_aligned and valid_etcbs)
+         corres dc  (ko_at (ArchObj (PageTable pt)) (p && ~~ mask pt_bits) and pspace_aligned)
                     (pte_at' p)
           (set_pt (p && ~~ mask pt_bits) (pt(ucast (p && mask pt_bits >> 2) := pte)))
           (setObject p pte')"
@@ -825,13 +816,6 @@ lemma setObject_PT_corres [@lift_corres_args, corres]:
     apply (simp split: if_split_asm)
    apply (simp add: other_obj_relation_def
                split: Structures_A.kernel_object.splits arch_kernel_obj.splits)
-  apply (rule conjI)
-   apply (clarsimp simp: ekheap_relation_def pspace_relation_def)
-   apply (drule(1) ekheap_kheap_dom)
-   apply clarsimp
-   apply (drule_tac x=p in bspec, erule domI)
-   apply (simp add: tcb_relation_cut_def
-             split: Structures_A.kernel_object.splits)
   apply (extract_conjunct \<open>match conclusion in "ghost_relation _ _ _" \<Rightarrow> -\<close>)
    apply (clarsimp simp add: ghost_relation_def)
    apply (erule_tac x="p && ~~ mask pt_bits" in allE)+
@@ -848,7 +832,7 @@ lemma setObject_PT_corres [@lift_corres_args, corres]:
 
 lemma storePDE_corres [@lift_corres_args, corres]:
   "pde_relation_aligned (p >> 2) pde pde' \<Longrightarrow>
-  corres dc (pde_at p and pspace_aligned and valid_etcbs) (pde_at' p) (store_pde p pde) (storePDE p pde')"
+  corres dc (pde_at p and pspace_aligned) (pde_at' p) (store_pde p pde) (storePDE p pde')"
   apply (simp add: store_pde_def storePDE_def)
   apply (rule corres_symb_exec_l)
      apply (erule setObject_PD_corres[OF _ refl])
@@ -867,7 +851,7 @@ lemma storePDE_corres [@lift_corres_args, corres]:
 lemma storePDE_corres':
   "pde_relation_aligned (p >> 2) pde pde' \<Longrightarrow>
   corres dc
-     (pde_at p and pspace_aligned and valid_etcbs) (pspace_aligned' and pspace_distinct')
+     (pde_at p and pspace_aligned) (pspace_aligned' and pspace_distinct')
      (store_pde p pde) (storePDE p pde')"
   apply (rule stronger_corres_guard_imp, rule storePDE_corres)
    apply auto
@@ -875,7 +859,7 @@ lemma storePDE_corres':
 
 lemma storePTE_corres [@lift_corres_args, corres]:
   "pte_relation_aligned (p>>2) pte pte' \<Longrightarrow>
-  corres dc (pte_at p and pspace_aligned and valid_etcbs) (pte_at' p) (store_pte p pte) (storePTE p pte')"
+  corres dc (pte_at p and pspace_aligned) (pte_at' p) (store_pte p pte) (storePTE p pte')"
   apply (simp add: store_pte_def storePTE_def)
   apply (rule corres_symb_exec_l)
      apply (erule setObject_PT_corres[OF _ refl])
@@ -893,7 +877,7 @@ lemma storePTE_corres [@lift_corres_args, corres]:
 
 lemma storePTE_corres':
   "pte_relation_aligned (p >> 2) pte pte' \<Longrightarrow>
-  corres dc (pte_at p and pspace_aligned and valid_etcbs)
+  corres dc (pte_at p and pspace_aligned)
             (pspace_aligned' and pspace_distinct')
             (store_pte p pte) (storePTE p pte')"
   apply (rule stronger_corres_guard_imp, rule storePTE_corres)

--- a/proof/refine/ARM/ArchInvsLemmas_H.thy
+++ b/proof/refine/ARM/ArchInvsLemmas_H.thy
@@ -471,4 +471,24 @@ lemma valid_pspaceI'[intro]:
 
 end
 
+context Arch begin
+
+lemma objBits_less_word_bits:
+  "objBits v < word_bits"
+  unfolding objBits_simps'
+  apply (case_tac "injectKO v"; simp)
+  by (simp add: pageBits_def pteBits_def pdeBits_def objBits_simps word_bits_def
+         split: arch_kernel_object.split)+
+
+lemma objBits_pos_power2[simp]:
+  assumes "objBits v < word_bits"
+  shows "(1::machine_word) < (2::machine_word) ^ objBits v"
+  unfolding objBits_simps'
+  apply (insert assms)
+  apply (case_tac "injectKO v"; simp)
+  by (simp add: pageBits_def pteBits_def pdeBits_def objBits_simps
+         split: arch_kernel_object.split)+
+
+end
+
 end

--- a/proof/refine/ARM/ArchMove_R.thy
+++ b/proof/refine/ARM/ArchMove_R.thy
@@ -17,13 +17,4 @@ lemmas cte_index_repair_sym = cte_index_repair[symmetric]
 
 lemmas of_nat_inj32 = of_nat_inj[where 'a=32, folded word_bits_def]
 
-context begin
-interpretation Arch .
-
-(* Move to Deterministic_AI*)
-crunch copy_global_mappings
-  for valid_etcbs[wp]: valid_etcbs (wp: mapM_x_wp')
-
-end
-
 end

--- a/proof/refine/ARM/Arch_R.thy
+++ b/proof/refine/ARM/Arch_R.thy
@@ -90,24 +90,6 @@ lemma createObject_typ_at':
   apply (clarsimp simp: is_aligned_no_overflow_mask)
   done
 
-lemma retype_region2_ext_retype_region_ArchObject:
-  "retype_region ptr n us (ArchObject x)=
-  retype_region2 ptr n us (ArchObject x)"
-  apply (rule ext)
-  apply (simp add:retype_region_def retype_region2_def bind_assoc
-    retype_region2_ext_def retype_region_ext_def default_ext_def)
-  apply (rule ext)
-  apply (intro monad_eq_split_tail ext)+
-     apply simp
-    apply simp
-   apply (simp add:gets_def get_def bind_def return_def simpler_modify_def )
-   apply (rule_tac x = xc in fun_cong)
-   apply (rule_tac f = do_extended_op in arg_cong)
-   apply (rule ext)
-   apply simp
-  apply simp
-  done
-
 lemma set_cap_device_and_range_aligned:
   "is_aligned ptr sz \<Longrightarrow> \<lbrace>\<lambda>_. True\<rbrace>
     set_cap
@@ -161,7 +143,6 @@ lemma performASIDControlInvocation_corres:
             apply (clarsimp simp:is_cap_simps)
            apply (simp add: free_index_of_def)
           apply (rule corres_split)
-             apply (simp add: retype_region2_ext_retype_region_ArchObject )
              apply (rule corres_retype [where ty="Inl (KOArch (KOASIDPool F))",
                                         unfolded APIType_map2_def makeObjectKO_def,
                                         THEN createObjects_corres',simplified,
@@ -312,8 +293,8 @@ lemma performASIDControlInvocation_corres:
    apply (rule conjI, rule pspace_no_overlap_subset,
          rule pspace_no_overlap_detype[OF caps_of_state_valid])
         apply (simp add:invs_psp_aligned invs_valid_objs is_aligned_neg_mask_eq)+
-   apply (clarsimp simp: detype_def clear_um_def detype_ext_def valid_sched_def valid_etcbs_def
-            st_tcb_at_kh_def obj_at_kh_def st_tcb_at_def obj_at_def is_etcb_at_def)
+   apply (clarsimp simp: detype_def clear_um_def valid_sched_def
+                         st_tcb_at_kh_def obj_at_kh_def st_tcb_at_def obj_at_def)
   apply (simp add: detype_def clear_um_def)
   apply (drule_tac x = "cte_map (p', slot')" in pspace_relation_cte_wp_atI[OF state_relation_pspace_relation])
     apply (simp add:invs_valid_objs)+

--- a/proof/refine/ARM/CSpace1_R.thy
+++ b/proof/refine/ARM/CSpace1_R.thy
@@ -1723,41 +1723,34 @@ proof -
     done
 qed
 
-definition pspace_relations where
-  "pspace_relations ekh kh kh' \<equiv> pspace_relation kh kh' \<and> ekheap_relation ekh kh'"
-
 lemma set_cap_not_quite_corres_prequel:
   assumes cr:
-  "pspace_relations (ekheap s) (kheap s) (ksPSpace s')"
+  "pspace_relation (kheap s) (ksPSpace s')"
   "(x,t') \<in> fst (setCTE p' c' s')"
   "valid_objs s" "pspace_aligned s" "pspace_distinct s" "cte_at p s"
   "pspace_aligned' s'" "pspace_distinct' s'"
   assumes c: "cap_relation c (cteCap c')"
   assumes p: "p' = cte_map p"
   shows "\<exists>t. ((),t) \<in> fst (set_cap c p s) \<and>
-             pspace_relations (ekheap t) (kheap t) (ksPSpace t')"
+             pspace_relation (kheap t) (ksPSpace t')"
   using cr
   apply (clarsimp simp: setCTE_def setObject_def in_monad split_def)
   apply (drule(1) updateObject_cte_is_tcb_or_cte[OF _ refl, rotated])
   apply (elim disjE exE conjE)
-   apply (clarsimp simp: lookupAround2_char1 pspace_relations_def)
+   apply (clarsimp simp: lookupAround2_char1)
    apply (frule(5) cte_map_pulls_tcb_to_abstract[OF p])
     apply (simp add: domI)
    apply (frule tcb_cases_related2)
    apply (clarsimp simp: set_cap_def2 split_def bind_def get_object_def
                          simpler_gets_def assert_def fail_def return_def
                          set_object_def get_def put_def)
-   apply (rule conjI)
-    apply (erule(2) pspace_relation_update_tcbs)
-    apply (simp add: c)
-   apply (clarsimp simp: ekheap_relation_def pspace_relation_def)
-   apply (drule bspec, erule domI)
-   apply (clarsimp simp: etcb_relation_def tcb_cte_cases_def split: if_split_asm)
-  apply (clarsimp simp: pspace_relations_def)
+   apply (erule(2) pspace_relation_update_tcbs)
+   apply (simp add: c)
+  apply clarsimp
   apply (frule(5) cte_map_pulls_cte_to_abstract[OF p])
   apply (clarsimp simp: set_cap_def split_def bind_def get_object_def
-                        simpler_gets_def assert_def fail_def return_def
-                        set_object_def get_def put_def domI a_type_def[split_simps kernel_object.split arch_kernel_obj.split])
+                        simpler_gets_def assert_def a_type_def fail_def return_def
+                        set_object_def get_def put_def domI)
   apply (erule(1) valid_objsE)
   apply (clarsimp simp: valid_obj_def valid_cs_def valid_cs_size_def exI)
   apply (intro conjI impI)
@@ -1775,9 +1768,6 @@ lemma set_cap_not_quite_corres_prequel:
      apply (simp add: cte_at_cases domI well_formed_cnode_invsI[OF cr(3)])
     apply clarsimp
    apply (simp add: c)
-  apply (clarsimp simp: ekheap_relation_def pspace_relation_def)
-  apply (drule bspec, erule domI)
-  apply (clarsimp simp: etcb_relation_def tcb_cte_cases_def split: if_split_asm)
   apply (simp add: wf_cs_insert)
   done
 
@@ -1790,7 +1780,7 @@ lemma setCTE_pspace_only:
 
 lemma set_cap_not_quite_corres:
   assumes cr:
-  "pspace_relations (ekheap s) (kheap s) (ksPSpace s')"
+  "pspace_relation (kheap s) (ksPSpace s')"
   "cur_thread s = ksCurThread s'"
   "idle_thread s = ksIdleThread s'"
   "machine_state s = ksMachineState s'"
@@ -1807,10 +1797,9 @@ lemma set_cap_not_quite_corres:
   assumes c: "cap_relation c c'"
   assumes p: "p' = cte_map p"
   shows "\<exists>t. ((),t) \<in> fst (set_cap c p s) \<and>
-             pspace_relations (ekheap t) (kheap t) (ksPSpace t') \<and>
+             pspace_relation (kheap t) (ksPSpace t') \<and>
              cdt t = cdt s \<and>
              cdt_list t = cdt_list s \<and>
-             ekheap t = ekheap s \<and>
              scheduler_action t = scheduler_action s \<and>
              ready_queues t = ready_queues s \<and>
              is_original_cap t = is_original_cap s \<and>
@@ -2313,10 +2302,6 @@ lemma capClass_ztc_relation:
        cap_relation c c' \<rbrakk> \<Longrightarrow> capClass c' = PhysicalClass"
   by (auto simp: is_cap_simps)
 
-lemma pspace_relationsD:
-  "\<lbrakk>pspace_relation kh kh'; ekheap_relation ekh kh'\<rbrakk> \<Longrightarrow> pspace_relations ekh kh kh'"
-  by (simp add: pspace_relations_def)
-
 lemma updateCap_corres:
   "\<lbrakk>cap_relation cap cap';
     is_zombie cap \<or> is_cnode_cap cap \<or> is_thread_cap cap \<rbrakk>
@@ -2338,14 +2323,13 @@ lemma updateCap_corres:
     apply fastforce
    apply (clarsimp simp: cte_wp_at_ctes_of)
   apply (clarsimp simp add: state_relation_def)
-  apply (drule(1) pspace_relationsD)
   apply (frule (3) set_cap_not_quite_corres; fastforce?)
    apply (erule cte_wp_at_weakenE, rule TrueI)
   apply clarsimp
   apply (rule bexI)
    prefer 2
    apply simp
-  apply (clarsimp simp: in_set_cap_cte_at_swp pspace_relations_def)
+  apply (clarsimp simp: in_set_cap_cte_at_swp)
   apply (drule updateCap_stuff)
   apply simp
   apply (extract_conjunct \<open>match conclusion in "ghost_relation _ _ _" \<Rightarrow> -\<close>)
@@ -2467,24 +2451,6 @@ lemma updateMDB_pspace_relation:
   apply fastforce
   done
 
-lemma updateMDB_ekheap_relation:
-  assumes "(x, s'') \<in> fst (updateMDB p f s')"
-  assumes "ekheap_relation (ekheap s) (ksPSpace s')"
-  shows "ekheap_relation (ekheap s) (ksPSpace s'')" using assms
-  apply (clarsimp simp: updateMDB_def Let_def setCTE_def setObject_def in_monad ekheap_relation_def etcb_relation_def split_def split: if_split_asm)
-  apply (drule(1) updateObject_cte_is_tcb_or_cte[OF _ refl, rotated])
-  apply (drule_tac P="(=) s'" in use_valid [OF _ getCTE_sp], rule refl)
-  apply (drule bspec, erule domI)
-  apply (clarsimp simp: tcb_cte_cases_def lookupAround2_char1 split: if_split_asm)
-  done
-
-lemma updateMDB_pspace_relations:
-  assumes "(x, s'') \<in> fst (updateMDB p f s')"
-  assumes "pspace_relations (ekheap s) (kheap s) (ksPSpace s')"
-  assumes "pspace_aligned' s'" "pspace_distinct' s'"
-  shows "pspace_relations (ekheap s) (kheap s) (ksPSpace s'')" using assms
-  by (simp add: pspace_relations_def updateMDB_pspace_relation updateMDB_ekheap_relation)
-
 lemma updateMDB_ctes_of:
   assumes "(x, s') \<in> fst (updateMDB p f s)"
   assumes "no_0 (ctes_of s)"
@@ -2529,7 +2495,7 @@ crunch updateMDB
 
 lemma updateMDB_the_lot:
   assumes "(x, s'') \<in> fst (updateMDB p f s')"
-  assumes "pspace_relations (ekheap s) (kheap s) (ksPSpace s')"
+  assumes "pspace_relation (kheap s) (ksPSpace s')"
   assumes "pspace_aligned' s'" "pspace_distinct' s'" "no_0 (ctes_of s')"
   shows "ctes_of s'' = modify_map (ctes_of s') p (cteMDBNode_update f) \<and>
          ksMachineState s'' = ksMachineState s' \<and>
@@ -2542,7 +2508,7 @@ lemma updateMDB_the_lot:
          ksArchState s'' = ksArchState s' \<and>
          gsUserPages s'' = gsUserPages s' \<and>
          gsCNodes s'' = gsCNodes s' \<and>
-         pspace_relations (ekheap s) (kheap s) (ksPSpace s'') \<and>
+         pspace_relation (kheap s) (ksPSpace s'') \<and>
          pspace_aligned' s'' \<and> pspace_distinct' s'' \<and>
          no_0 (ctes_of s'') \<and>
          ksDomScheduleIdx s'' = ksDomScheduleIdx s' \<and>
@@ -2554,7 +2520,7 @@ lemma updateMDB_the_lot:
          (\<forall>domain priority.
             (inQ domain priority |< tcbs_of' s'') = (inQ domain priority |< tcbs_of' s'))"
 using assms
-  apply (simp add: updateMDB_eqs updateMDB_pspace_relations split del: if_split)
+  apply (simp add: updateMDB_eqs updateMDB_pspace_relation split del: if_split)
   apply (frule (1) updateMDB_ctes_of)
   apply clarsimp
   apply (rule conjI)
@@ -3768,7 +3734,6 @@ lemma setCTE_UntypedCap_corres:
    apply (clarsimp simp: cte_wp_at_ctes_of)
   apply clarsimp
   apply (clarsimp simp add: state_relation_def split_def)
-  apply (drule (1) pspace_relationsD)
   apply (frule_tac c = "cap.UntypedCap dev r bits idx"
                 in set_cap_not_quite_corres_prequel)
          apply assumption+
@@ -3779,8 +3744,6 @@ lemma setCTE_UntypedCap_corres:
   apply (rule bexI)
    prefer 2
    apply assumption
-  apply (clarsimp simp: pspace_relations_def)
-  apply (subst conj_assoc[symmetric])
   apply clarsimp
   apply (rule conjI)
    apply (frule setCTE_pspace_only)
@@ -3792,7 +3755,7 @@ lemma setCTE_UntypedCap_corres:
    apply (rule use_valid[OF _ setCTE_tcbSchedNexts_of], assumption)
    apply (rule use_valid[OF _ setCTE_ksReadyQueues], assumption)
    apply (rule use_valid[OF _ setCTE_inQ_opt_pred], assumption)
-   apply (rule use_valid[OF _ set_cap_exst], assumption)
+   apply (rule use_valid[OF _ set_cap_rqueues], assumption)
    apply clarsimp
   apply (rule conjI)
    apply (frule setCTE_pspace_only)
@@ -5056,8 +5019,8 @@ crunch set_untyped_cap_as_full
 
 lemma updateMDB_the_lot':
   assumes "(x, s'') \<in> fst (updateMDB p f s')"
-  assumes "pspace_relations (ekheap sa) (kheap s) (ksPSpace s')"
-  assumes "pspace_aligned' s'" "pspace_distinct' s'" "no_0 (ctes_of s')" "ekheap s = ekheap sa"
+  assumes "pspace_relation (kheap s) (ksPSpace s')"
+  assumes "pspace_aligned' s'" "pspace_distinct' s'" "no_0 (ctes_of s')"
   shows "ctes_of s'' = modify_map (ctes_of s') p (cteMDBNode_update f) \<and>
          ksMachineState s'' = ksMachineState s' \<and>
          ksWorkUnitsCompleted s'' = ksWorkUnitsCompleted s' \<and>
@@ -5069,7 +5032,7 @@ lemma updateMDB_the_lot':
          ksArchState s'' = ksArchState s' \<and>
          gsUserPages s'' = gsUserPages s' \<and>
          gsCNodes s'' = gsCNodes s' \<and>
-         pspace_relations (ekheap s) (kheap s) (ksPSpace s'') \<and>
+         pspace_relation (kheap s) (ksPSpace s'') \<and>
          pspace_aligned' s'' \<and> pspace_distinct' s'' \<and>
          no_0 (ctes_of s'') \<and>
          ksDomScheduleIdx s'' = ksDomScheduleIdx s' \<and>
@@ -5082,7 +5045,7 @@ lemma updateMDB_the_lot':
             (inQ domain priority |< tcbs_of' s'') = (inQ domain priority |< tcbs_of' s'))"
   apply (rule updateMDB_the_lot)
       using assms
-      apply (fastforce simp: pspace_relations_def)+
+      apply fastforce+
    done
 
 lemma cte_map_inj_eq':
@@ -5159,7 +5122,6 @@ lemma cteInsert_corres:
                apply (simp+)[3]
             apply (clarsimp simp: corres_underlying_def state_relation_def
                                   in_monad valid_mdb'_def valid_mdb_ctes_def)
-            apply (drule (1) pspace_relationsD)
             apply (drule (18) set_cap_not_quite_corres)
              apply (rule refl)
             apply (elim conjE exE)
@@ -5198,7 +5160,6 @@ lemma cteInsert_corres:
             apply (thin_tac "ksCurThread t = p" for p t)+
             apply (thin_tac "ksIdleThread t = p" for p t)+
             apply (thin_tac "ksSchedulerAction t = p" for p t)+
-            apply (clarsimp simp: pspace_relations_def)
 
             apply (rule conjI)
              apply (clarsimp simp: ghost_relation_typ_at set_cap_a_type_inv data_at_def)
@@ -6635,7 +6596,6 @@ lemma cteSwap_corres:
   apply (clarsimp simp: corres_underlying_def in_monad
                         state_relation_def)
   apply (clarsimp simp: valid_mdb'_def)
-  apply (drule(1) pspace_relationsD)
   apply (drule (12) set_cap_not_quite_corres)
       apply (erule cte_wp_at_weakenE, rule TrueI)
      apply assumption+
@@ -6671,20 +6631,19 @@ lemma cteSwap_corres:
   apply (simp cong: option.case_cong)
   apply (drule updateCap_stuff, elim conjE, erule(1) impE)
   apply (drule (2) updateMDB_the_lot')
-     apply (erule (1) impE, assumption)
-    apply (fastforce simp only: no_0_modify_map)
-   apply assumption
+    apply (erule (1) impE, assumption)
+   apply (fastforce simp only: no_0_modify_map)
   apply (elim conjE TrueE, simp only:)
-  apply (drule (2) updateMDB_the_lot', fastforce, simp only: no_0_modify_map, assumption)
+  apply (drule (2) updateMDB_the_lot', fastforce, simp only: no_0_modify_map)
   apply (drule in_getCTE, elim conjE, simp only:)
-  apply (drule (2) updateMDB_the_lot', fastforce, simp only: no_0_modify_map, assumption)
+  apply (drule (2) updateMDB_the_lot', fastforce, simp only: no_0_modify_map)
   apply (elim conjE TrueE, simp only:)
-  apply (drule (2) updateMDB_the_lot', fastforce, simp only: no_0_modify_map, assumption)
+  apply (drule (2) updateMDB_the_lot', fastforce, simp only: no_0_modify_map)
   apply (elim conjE TrueE, simp only:)
-  apply (drule (2) updateMDB_the_lot', fastforce, simp only: no_0_modify_map, assumption)
+  apply (drule (2) updateMDB_the_lot', fastforce, simp only: no_0_modify_map)
   apply (elim conjE TrueE, simp only:)
-  apply (drule (2) updateMDB_the_lot', fastforce, simp only: no_0_modify_map, assumption)
-  apply (simp only: pspace_relations_def refl)
+  apply (drule (2) updateMDB_the_lot', fastforce, simp only: no_0_modify_map)
+  apply (simp only: refl)
   apply (rule conjI, rule TrueI)+
   apply (thin_tac "ksMachineState t = p" for t p)+
   apply (thin_tac "ksCurThread t = p" for t p)+
@@ -6735,7 +6694,6 @@ lemma cteSwap_corres:
   apply (thin_tac "domain_index t = p" for t p)+
   apply (thin_tac "domain_list t = p" for t p)+
   apply (thin_tac "domain_time t = p" for t p)+
-  apply (thin_tac "ekheap t = p" for t p)+
   apply (thin_tac "scheduler_action t = p" for t p)+
   apply (thin_tac "ksArchState t = p" for t p)+
   apply (thin_tac "gsCNodes t = p" for t p)+
@@ -6744,7 +6702,6 @@ lemma cteSwap_corres:
   apply (thin_tac "ksIdleThread t = p" for t p)+
   apply (thin_tac "gsUserPages t = p" for t p)+
   apply (thin_tac "pspace_relation s s'" for s s')+
-  apply (thin_tac "ekheap_relation e p" for e p)+
   apply (thin_tac "interrupt_state_relation n s s'" for n s s')+
   apply (thin_tac "(s,s') \<in> arch_state_relation" for s s')+
   apply(subst conj_assoc[symmetric])

--- a/proof/refine/ARM/CSpace_R.thy
+++ b/proof/refine/ARM/CSpace_R.thy
@@ -693,8 +693,7 @@ lemma next_slot_eq2:
 
 lemma set_cap_not_quite_corres':
   assumes cr:
-  "pspace_relations (ekheap (a)) (kheap s) (ksPSpace s')"
-  "ekheap (s)      = ekheap (a)"
+  "pspace_relation (kheap s) (ksPSpace s')"
   "cur_thread s    = ksCurThread s'"
   "idle_thread s   = ksIdleThread s'"
   "machine_state s = ksMachineState s'"
@@ -711,10 +710,9 @@ lemma set_cap_not_quite_corres':
   assumes c: "cap_relation c c'"
   assumes p: "p' = cte_map p"
   shows "\<exists>t. ((),t) \<in> fst (set_cap c p s) \<and>
-             pspace_relations (ekheap t) (kheap t) (ksPSpace t') \<and>
+             pspace_relation (kheap t) (ksPSpace t') \<and>
              cdt t              = cdt s \<and>
              cdt_list t         = cdt_list (s) \<and>
-             ekheap t           = ekheap (s) \<and>
              scheduler_action t = scheduler_action (s) \<and>
              ready_queues t     = ready_queues (s) \<and>
              is_original_cap t  = is_original_cap s \<and>
@@ -731,7 +729,7 @@ lemma set_cap_not_quite_corres':
              domain_time t   = ksDomainTime t'"
   apply (rule set_cap_not_quite_corres)
                 using cr
-                apply (fastforce simp: c p pspace_relations_def)+
+                apply (fastforce simp: c p)+
                 done
 context begin interpretation Arch . (*FIXME: arch-split*)
 lemma cteMove_corres:
@@ -802,7 +800,6 @@ lemma cteMove_corres:
      apply fastforce
     apply fastforce
    apply fastforce
-   apply (drule (1) pspace_relationsD)
    apply (drule_tac p=ptr' in set_cap_not_quite_corres, assumption+)
             apply fastforce
            apply fastforce
@@ -862,7 +859,7 @@ lemma cteMove_corres:
   apply (frule(1) use_valid [OF _ updateCap_no_0])
   apply (frule(2) use_valid [OF _ updateCap_no_0, OF _ use_valid [OF _ updateCap_no_0]])
   apply (elim conjE)
-  apply (drule (5) updateMDB_the_lot', elim conjE)
+  apply (drule (4) updateMDB_the_lot', elim conjE)
   apply (drule (4) updateMDB_the_lot, elim conjE)
   apply (drule (4) updateMDB_the_lot, elim conjE)
   apply (drule (4) updateMDB_the_lot, elim conjE)
@@ -892,7 +889,6 @@ lemma cteMove_corres:
      apply fastforce
     apply fastforce
    apply fastforce
-  apply (clarsimp simp: pspace_relations_def)
   apply (rule conjI)
    apply (clarsimp simp: ghost_relation_typ_at set_cap_a_type_inv data_at_def)
   apply (thin_tac "gsCNodes t = p" for t p)+
@@ -919,7 +915,6 @@ lemma cteMove_corres:
   apply (thin_tac "ksDomainTime t = p" for t p)+
   apply (thin_tac "ksDomSchedule t = p" for t p)+
   apply (thin_tac "ctes_of t = p" for t p)+
-  apply (thin_tac "ekheap_relation t p" for t p)+
   apply (thin_tac "pspace_relation t p" for t p)+
   apply (thin_tac "interrupt_state_relation s t p" for s t p)+
   apply (thin_tac "ghost_relation s t p" for s t p)+
@@ -3535,7 +3530,7 @@ lemma deriveCap_untyped_derived:
 
 lemma setCTE_corres:
   "cap_relation cap (cteCap cte) \<Longrightarrow>
-   corres_underlying {(s, s'). pspace_relations (ekheap (s)) (kheap s) (ksPSpace s')} False True dc
+   corres_underlying {(s, s'). pspace_relation (kheap s) (ksPSpace s')} False True dc
       (pspace_distinct and pspace_aligned and valid_objs and cte_at p)
       (pspace_aligned' and pspace_distinct' and cte_at' (cte_map p))
       (set_cap cap p)
@@ -3580,7 +3575,7 @@ lemma ghost_relation_of_heap:
   done
 
 lemma corres_caps_decomposition:
-  assumes x: "corres_underlying {(s, s'). pspace_relations (ekheap (s)) (kheap s) (ksPSpace s')} False True r P P' f g"
+  assumes x: "corres_underlying {(s, s'). pspace_relation (kheap s) (ksPSpace s')} False True r P P' f g"
   assumes u: "\<And>P. \<lbrace>\<lambda>s. P (new_caps s)\<rbrace> f \<lbrace>\<lambda>rv s. P (caps_of_state s)\<rbrace>"
              "\<And>P. \<lbrace>\<lambda>s. P (new_mdb s)\<rbrace> f \<lbrace>\<lambda>rv s. P (cdt s)\<rbrace>"
              "\<And>P. \<lbrace>\<lambda>s. P (new_list s)\<rbrace> f \<lbrace>\<lambda>rv s. P (cdt_list (s))\<rbrace>"
@@ -3690,14 +3685,11 @@ proof -
   note abs_irq_together = abs_irq_together'[simplified]
   show ?thesis
     unfolding state_relation_def swp_cte_at
-    apply (subst conj_assoc[symmetric])
-    apply (subst pspace_relations_def[symmetric])
     apply (rule corres_underlying_decomposition [OF x])
      apply (simp add: ghost_relation_of_heap)
-     apply (wp hoare_vcg_conj_lift mdb_wp rvk_wp list_wp u abs_irq_together)+
-    apply (intro z[simplified o_def] conjI
-           | simp add: state_relation_def pspace_relations_def swp_cte_at
-           | (clarsimp, drule (1) z(6), simp add: state_relation_def))+
+     apply (wpsimp wp: hoare_vcg_conj_lift mdb_wp rvk_wp list_wp u abs_irq_together)+
+    apply (intro z[simplified o_def] conjI | simp add: state_relation_def swp_cte_at
+          | (drule (1) z(6), simp add: state_relation_def swp_cte_at))+
     done
 qed
 
@@ -3709,7 +3701,7 @@ lemma getCTE_symb_exec_r:
   done
 
 lemma updateMDB_symb_exec_r:
-  "corres_underlying {(s, s'). pspace_relations (ekheap s) (kheap s) (ksPSpace s')} False nf' dc
+  "corres_underlying {(s, s'). pspace_relation (kheap s) (ksPSpace s')} False nf' dc
         \<top> (pspace_aligned' and pspace_distinct' and (no_0 \<circ> ctes_of) and (\<lambda>s. p \<noteq> 0 \<longrightarrow> cte_at' p s))
         (return ()) (updateMDB p m)"
   using no_fail_updateMDB [of p m]
@@ -3760,45 +3752,20 @@ lemma revokable_relation_simp:
       \<Longrightarrow> mdbRevocable node = is_original_cap s p"
   by (cases p, clarsimp simp: state_relation_def revokable_relation_def)
 
-lemma setCTE_gsUserPages[wp]:
-  "\<lbrace>\<lambda>s. P (gsUserPages s)\<rbrace> setCTE p v \<lbrace>\<lambda>rv s. P (gsUserPages s)\<rbrace>"
-  apply (simp add: setCTE_def setObject_def split_def)
-  apply (wp updateObject_cte_inv crunch_wps | simp)+
-  done
-
-lemma setCTE_gsCNodes[wp]:
-  "\<lbrace>\<lambda>s. P (gsCNodes s)\<rbrace> setCTE p v \<lbrace>\<lambda>rv s. P (gsCNodes s)\<rbrace>"
-  apply (simp add: setCTE_def setObject_def split_def)
-  apply (wp updateObject_cte_inv crunch_wps | simp)+
-  done
+crunch setCTE
+  for gsUserPages[wp]: "\<lambda>s. P (gsUserPages s)"
+  and gsCNodes[wp]: "\<lambda>s. P (gsCNodes s)"
+  and domain_time[wp]: "\<lambda>s. P (ksDomainTime s)"
+  and work_units_completed[wp]: "\<lambda>s. P (ksWorkUnitsCompleted s)"
+  (simp: setObject_def wp: updateObject_cte_inv)
 
 lemma set_original_symb_exec_l':
-  "corres_underlying {(s, s'). f (ekheap s) (kheap s) s'} False nf' dc P P' (set_original p b) (return x)"
+  "corres_underlying {(s, s'). f (kheap s) s'} False nf' dc P P' (set_original p b) (return x)"
   by (simp add: corres_underlying_def return_def set_original_def in_monad Bex_def)
 
-lemma setCTE_schedule_index[wp]:
-  "\<lbrace>\<lambda>s. P (ksDomScheduleIdx s)\<rbrace> setCTE p v \<lbrace>\<lambda>rv s. P (ksDomScheduleIdx s)\<rbrace>"
-  apply (simp add: setCTE_def setObject_def split_def)
-  apply (wp updateObject_cte_inv crunch_wps | simp)+
-  done
-
-lemma setCTE_schedule[wp]:
-  "\<lbrace>\<lambda>s. P (ksDomSchedule s)\<rbrace> setCTE p v \<lbrace>\<lambda>rv s. P (ksDomSchedule s)\<rbrace>"
-  apply (simp add: setCTE_def setObject_def split_def)
-  apply (wp updateObject_cte_inv crunch_wps | simp)+
-  done
-
-lemma setCTE_domain_time[wp]:
-  "\<lbrace>\<lambda>s. P (ksDomainTime s)\<rbrace> setCTE p v \<lbrace>\<lambda>rv s. P (ksDomainTime s)\<rbrace>"
-  apply (simp add: setCTE_def setObject_def split_def)
-  apply (wp updateObject_cte_inv crunch_wps | simp)+
-  done
-
-lemma setCTE_work_units_completed[wp]:
-  "\<lbrace>\<lambda>s. P (ksWorkUnitsCompleted s)\<rbrace> setCTE p v \<lbrace>\<lambda>_ s. P (ksWorkUnitsCompleted s)\<rbrace>"
-  apply (simp add: setCTE_def setObject_def split_def)
-  apply (wp updateObject_cte_inv crunch_wps | simp)+
-  done
+crunch set_cap
+  for domain_index[wp]: "\<lambda>s. P (domain_index s)"
+  (wp: set_object_wp)
 
 lemma create_reply_master_corres:
   "\<lbrakk> sl' = cte_map sl ; AllowGrant \<in> rights \<rbrakk> \<Longrightarrow>
@@ -4788,7 +4755,6 @@ lemma cteInsert_simple_corres:
                apply (simp+)[3]
             apply (clarsimp simp: corres_underlying_def state_relation_def
                                   in_monad valid_mdb'_def valid_mdb_ctes_def)
-            apply (drule (1) pspace_relationsD)
             apply (drule (18) set_cap_not_quite_corres)
              apply (rule refl)
             apply (elim conjE exE)
@@ -4815,7 +4781,7 @@ lemma cteInsert_simple_corres:
             apply (drule (3) updateMDB_the_lot', simp only: no_0_modify_map, simp only:, elim conjE)
             apply (drule (3) updateMDB_the_lot', simp only: no_0_modify_map, simp only:, elim conjE)
             apply (drule (3) updateMDB_the_lot', simp only: no_0_modify_map, simp only:, elim conjE)
-            apply (clarsimp simp: pspace_relations_def)
+            apply clarsimp
             apply (thin_tac "gsCNodes t = p" for t p)+
             apply (thin_tac "ksMachineState t = p" for t p)+
             apply (thin_tac "ksCurThread t = p" for t p)+
@@ -4840,7 +4806,6 @@ lemma cteInsert_simple_corres:
             apply (thin_tac "ksDomainTime t = p" for t p)+
             apply (thin_tac "ksDomSchedule t = p" for t p)+
             apply (thin_tac "ctes_of t = p" for t p)+
-            apply (thin_tac "ekheap_relation t p" for t p)+
             apply (thin_tac "pspace_relation t p" for t p)+
             apply (thin_tac "interrupt_state_relation s t p" for s t p)+
             apply (thin_tac "sched_act_relation t p" for t p)+
@@ -5996,7 +5961,7 @@ lemma setCTE_set_cap_ready_queues_relation_valid_corres:
   shows "ready_queues_relation t t'"
   apply (clarsimp simp: ready_queues_relation_def)
   apply (insert pre)
-  apply (rule use_valid[OF step_abs set_cap_exst])
+  apply (rule use_valid[OF step_abs set_cap_rqueues])
   apply (rule use_valid[OF step_conc setCTE_ksReadyQueues])
   apply (rule use_valid[OF step_conc setCTE_tcbSchedNexts_of])
   apply (rule use_valid[OF step_conc setCTE_tcbSchedPrevs_of])
@@ -6022,7 +5987,6 @@ lemma updateCap_same_master:
         apply (clarsimp simp: cte_wp_at_ctes_of)
        apply clarsimp
        apply (clarsimp simp add: state_relation_def)
-       apply (drule (1) pspace_relationsD)
        apply (frule (4) set_cap_not_quite_corres_prequel)
             apply (erule cte_wp_at_weakenE, rule TrueI)
            apply assumption
@@ -6033,7 +5997,7 @@ lemma updateCap_same_master:
        apply (rule bexI)
         prefer 2
         apply assumption
-       apply (clarsimp simp: pspace_relations_def)
+       apply clarsimp
        apply (subst conj_assoc[symmetric])
        apply (extract_conjunct \<open>match conclusion in "ready_queues_relation a b" for a b \<Rightarrow> -\<close>)
         subgoal by (erule setCTE_set_cap_ready_queues_relation_valid_corres; assumption)

--- a/proof/refine/ARM/Detype_R.thy
+++ b/proof/refine/ARM/Detype_R.thy
@@ -836,11 +836,6 @@ lemma corres_machine_op:
    apply (simp_all add: state_relation_def swp_def)
   done
 
-lemma ekheap_relation_detype:
-  "ekheap_relation ekh kh \<Longrightarrow>
-   ekheap_relation (\<lambda>x. if P x then None else (ekh x)) (\<lambda>x. if P x then None else (kh x))"
-  by (fastforce simp add: ekheap_relation_def split: if_split_asm)
-
 lemma cap_table_at_gsCNodes_eq:
   "(s, s') \<in> state_relation
     \<Longrightarrow> (gsCNodes s' ptr = Some bits) = cap_table_at bits ptr s"
@@ -945,11 +940,11 @@ lemma detype_ready_queues_relation:
          tcb_of' |>
          tcbSchedPrev)
         (\<lambda>d p. inQ d p |< ((\<lambda>x. if lower \<le> x \<and> x \<le> upper then None else ksPSpace s' x) |> tcb_of'))"
-  apply (clarsimp simp: detype_ext_def ready_queues_relation_def Let_def)
+  apply (clarsimp simp: ready_queues_relation_def Let_def)
   apply (frule (1) detype_tcbSchedNexts_of[where S="{lower..upper}"]; simp)
   apply (frule (1) detype_tcbSchedPrevs_of[where S="{lower..upper}"]; simp)
   apply (frule (1) detype_inQ[where S="{lower..upper}"]; simp)
-  apply (fastforce simp add: detype_def detype_ext_def)
+  apply (fastforce simp add: detype_def)
   done
 
 lemma deleteObjects_corres:
@@ -980,11 +975,11 @@ lemma deleteObjects_corres:
    apply (rule_tac ptr=ptr and idx=idx and d=d in delete_locale.deletionIsSafe_delete_locale_holds)
    apply (clarsimp simp: delete_locale_def)
    apply (intro conjI)
-    apply (fastforce simp: sch_act_simple_def state_relation_def schact_is_rct_def)
+    apply (fastforce simp: sch_act_simple_def schact_is_rct_def state_relation_def)
    apply (rule_tac cap="cap.UntypedCap d base magnitude idx" and ptr="(a,b)" and s=s
                 in detype_locale'.deletionIsSafe,
           simp_all add: detype_locale'_def detype_locale_def invs_valid_pspace)[1]
-   apply (simp add:valid_cap_simps)
+   apply (simp add: valid_cap_simps)
   apply (simp add: bind_assoc[symmetric])
   apply (rule corres_stateAssert_implied2)
      defer
@@ -1024,30 +1019,29 @@ lemma deleteObjects_corres:
     apply (simp add: valid_pspace'_def)
     apply (rule state_relation_null_filterE, assumption,
            simp_all add: pspace_aligned'_cut pspace_distinct'_cut)[1]
-            apply (simp add: detype_def, rule state.equality; simp add: detype_ext_def)
-           apply (intro exI, fastforce)
-          apply (rule ext, clarsimp simp add: null_filter_def)
-          apply (rule sym, rule ccontr, clarsimp)
-          apply (drule(4) cte_map_not_null_outside')
-           apply (fastforce simp add: cte_wp_at_caps_of_state)
-          apply simp
-         apply (rule ext, clarsimp simp: null_filter'_def map_to_ctes_delete[simplified field_simps])
+           apply (simp add: detype_def)
+          apply (intro exI, fastforce)
+         apply (rule ext, clarsimp simp add: null_filter_def)
          apply (rule sym, rule ccontr, clarsimp)
-         apply (frule(2) pspace_relation_cte_wp_atI[OF state_relation_pspace_relation])
-         apply (elim exE)
-         apply (frule(4) cte_map_not_null_outside')
-          apply (rule cte_wp_at_weakenE, erule conjunct1)
-          apply (case_tac y, clarsimp)
-          apply (clarsimp simp: valid_mdb'_def valid_mdb_ctes_def valid_nullcaps_def)
-         apply clarsimp
-         apply (frule_tac cref="(aa, ba)" in cte_map_untyped_range,
-                erule cte_wp_at_weakenE[OF _ TrueI], assumption+)
+         apply (drule(4) cte_map_not_null_outside')
+          apply (fastforce simp add: cte_wp_at_caps_of_state)
          apply simp
-        apply (rule detype_pspace_relation[simplified],
-               simp_all add: state_relation_pspace_relation valid_pspace_def)[1]
-         apply (simp add: valid_cap'_def capAligned_def)
-        apply (clarsimp simp: valid_cap_def, assumption)
-       apply (fastforce simp add: detype_def detype_ext_def intro!: ekheap_relation_detype)
+        apply (rule ext, clarsimp simp: null_filter'_def map_to_ctes_delete[simplified field_simps])
+        apply (rule sym, rule ccontr, clarsimp)
+        apply (frule(2) pspace_relation_cte_wp_atI[OF state_relation_pspace_relation])
+        apply (elim exE)
+        apply (frule(4) cte_map_not_null_outside')
+         apply (rule cte_wp_at_weakenE, erule conjunct1)
+         apply (case_tac y, clarsimp)
+         apply (clarsimp simp: valid_mdb'_def valid_mdb_ctes_def valid_nullcaps_def)
+        apply clarsimp
+        apply (frule_tac cref="(aa, ba)" in cte_map_untyped_range,
+               erule cte_wp_at_weakenE[OF _ TrueI], assumption+)
+        apply simp
+       apply (rule detype_pspace_relation[simplified],
+              simp_all add: state_relation_pspace_relation valid_pspace_def)[1]
+        apply (simp add: valid_cap'_def capAligned_def)
+       apply (clarsimp simp: valid_cap_def, assumption)
       apply (rule detype_ready_queues_relation; blast?)
        apply (clarsimp simp: deletionIsSafe_delete_locale_def)
       apply (frule state_relation_ready_queues_relation)
@@ -3540,23 +3534,19 @@ lemma createObject_setCTE_commute:
                        cteSizeBits_def)
             \<comment> \<open>Untyped\<close>
             apply (simp add: monad_commute_guard_imp[OF return_commute])
-           \<comment> \<open>TCB, EP, NTFN\<close>
+           \<comment> \<open>TCB\<close>
            apply (rule monad_commute_guard_imp[OF commute_commute])
-            apply (rule monad_commute_split[OF monad_commute_split])
-                apply (rule monad_commute_split[OF commute_commute[OF return_commute]])
-                 apply (rule setCTE_modify_tcbDomain_commute)
-                apply wp
-               apply (rule curDomain_commute)
-               apply wp+
-             apply (rule setCTE_placeNewObject_commute)
-            apply (wp  placeNewObject_tcb_at' placeNewObject_cte_wp_at'
-              placeNewObject_pspace_distinct'
-              placeNewObject_pspace_aligned'
-              | clarsimp simp: objBits_simps')+
-           apply (rule monad_commute_guard_imp[OF commute_commute]
-            ,rule monad_commute_split[OF commute_commute[OF return_commute]]
-            ,rule setCTE_placeNewObject_commute
-            ,(wp|clarsimp simp: objBits_simps')+)+
+            apply (rule monad_commute_split[OF monad_commute_split[OF commute_commute]])
+                apply (rule return_commute)
+               apply (rule setCTE_placeNewObject_commute)
+              apply wp
+             apply (rule curDomain_commute)
+             apply (wpsimp simp: objBits_simps')+
+          \<comment> \<open>EP, NTFN\<close>
+          apply (rule monad_commute_guard_imp[OF commute_commute],
+                 rule monad_commute_split[OF commute_commute[OF return_commute]],
+                 rule setCTE_placeNewObject_commute,
+                 (wpsimp simp: objBits_simps')+)+
         \<comment> \<open>CNode\<close>
         apply (rule monad_commute_guard_imp[OF commute_commute])
          apply (rule monad_commute_split)+
@@ -4990,6 +4980,34 @@ lemma createTCBs_tcb_at':
   apply (simp add: objBits_simps shiftl_t2n)
   done
 
+lemma curDomain_createObjects'_comm:
+  "do x \<leftarrow> createObjects' ptr n obj us;
+      y \<leftarrow> curDomain;
+      m x y
+   od =
+   do y \<leftarrow> curDomain;
+      x \<leftarrow> createObjects' ptr n obj us;
+      m x y
+   od"
+  apply (rule ext)
+  apply (case_tac x)
+  by (auto simp: createObjects'_def split_def bind_assoc return_def unless_def
+                 when_def simpler_gets_def alignError_def fail_def assert_def
+                 bind_def curDomain_def modify_def get_def put_def
+          split: option.splits)
+
+lemma curDomain_twice_simp:
+  "do x \<leftarrow> curDomain;
+      y \<leftarrow> curDomain;
+      m x y
+   od =
+   do x \<leftarrow> curDomain;
+      m x x
+   od"
+  apply (rule ext)
+  apply (case_tac x)
+  by (auto simp: simpler_gets_def bind_def curDomain_def)
+
 lemma createNewCaps_Cons:
   assumes cover:"range_cover ptr sz (Types_H.getObjectSize ty us) (Suc (Suc n))"
   and "valid_pspace' s" "valid_arch_state' s"
@@ -5088,91 +5106,42 @@ proof -
               apiGetObjectSize_def shiftl_t2n field_simps
               shiftL_nat mapM_x_def sequence_x_def append
               fromIntegral_def integral_inv[unfolded Fun.comp_def])
-           \<comment> \<open>TCB, EP, NTFN\<close>
-           apply (simp add: bind_assoc
-                      ARM_H.getObjectSize_def
-                      sequence_def Retype_H.createObject_def
-                      ARM_H.toAPIType_def
-                      createObjects_def ARM_H.createObject_def
-                      Arch_createNewCaps_def comp_def
-                      apiGetObjectSize_def shiftl_t2n field_simps
-                      shiftL_nat append mapM_x_append2
-                      fromIntegral_def integral_inv[unfolded Fun.comp_def])+
-           apply (subst monad_eq)
-            apply (rule createObjects_Cons)
-                 apply (simp add: field_simps shiftl_t2n bind_assoc pageBits_def
-                               objBits_simps placeNewObject_def2)+
-           apply (rule_tac Q = "\<lambda>r s. pspace_aligned' s \<and>
-               pspace_distinct' s \<and>
-               pspace_no_overlap' (ptr + (2^tcbBlockSizeBits + of_nat n * 2^tcbBlockSizeBits)) (objBitsKO (KOTCB makeObject)) s \<and>
-               range_cover (ptr + 2^tcbBlockSizeBits) sz
-               (objBitsKO (KOTCB makeObject)) (Suc n)
-               \<and> (\<forall>x\<in>set [0.e.of_nat n]. tcb_at' (ptr + x * 2^tcbBlockSizeBits) s)"
-               in monad_eq_split2)
-              apply simp
-             apply (subst monad_commute_simple[symmetric])
-               apply (rule commute_commute[OF curDomain_commute])
-               apply (wpsimp+)[2]
-             apply (rule_tac Q = "\<lambda>r s. r = (ksCurDomain s) \<and>
-               pspace_aligned' s \<and>
-               pspace_distinct' s \<and>
-               pspace_no_overlap' (ptr + (2^tcbBlockSizeBits + of_nat n * 2^tcbBlockSizeBits)) (objBitsKO (KOTCB makeObject)) s \<and>
-               range_cover (ptr + 2^tcbBlockSizeBits) sz
-               (objBitsKO (KOTCB makeObject)) (Suc n)
-               \<and> (\<forall>x\<in>set [0.e.of_nat n]. tcb_at' (ptr + x * 2^tcbBlockSizeBits) s)
-             " in  monad_eq_split)
-               apply (subst monad_commute_simple[symmetric])
-                 apply (rule createObjects_setDomains_commute)
-                apply (clarsimp simp:objBits_simps)
-                apply (rule conj_impI)
-                 apply (erule aligned_add_aligned)
-                  apply (rule aligned_add_aligned[where n = tcbBlockSizeBits])
-                    apply (simp add:is_aligned_def objBits_defs)
-                   apply (cut_tac is_aligned_shift[where m = tcbBlockSizeBits and k = "of_nat n",
-                     unfolded shiftl_t2n,simplified])
-                   apply (simp add:field_simps)+
-                apply (erule range_cover_full)
-                apply (simp add: word_bits_conv objBits_defs)
-               apply (rule_tac Q = "\<lambda>x s. (ksCurDomain s) = ra" in monad_eq_split2)
-                  apply simp
-                 apply (rule_tac Q = "\<lambda>x s. (ksCurDomain s) = ra" in monad_eq_split)
-                   apply (subst rewrite_step[where f = curDomain and
-                     P ="\<lambda>s. ksCurDomain s = ra" and f' = "return ra"])
-                     apply (simp add:curDomain_def bind_def gets_def get_def)
-                    apply simp
-                   apply (simp add:mapM_x_singleton)
-                  apply wp
-                 apply simp
-                apply (wp mapM_x_wp')
-               apply simp
-              apply (simp add:curDomain_def,wp)
-             apply simp
-            apply (wp createObjects'_psp_aligned[where sz = sz]
-              createObjects'_psp_distinct[where sz = sz])
-            apply (rule hoare_vcg_conj_lift)
-             apply (rule hoare_post_imp[OF _ createObjects'_pspace_no_overlap
-                [unfolded shiftl_t2n,where gz = tcbBlockSizeBits and sz = sz,simplified]])
-              apply (simp add:objBits_simps field_simps)
-             apply (simp add: objBits_simps)
-            apply (wp createTCBs_tcb_at')
-           apply (clarsimp simp:objBits_simps word_bits_def field_simps)
-           apply (frule range_cover_le[where n = "Suc n"],simp+)
-           apply (drule range_cover_offset[where p = 1,rotated])
-            apply simp
-           apply (simp add: objBits_defs)
-          apply (((simp add:
-                      ARM_H.getObjectSize_def
-                      mapM_def sequence_def Retype_H.createObject_def
-                      ARM_H.toAPIType_def
-                      createObjects_def ARM_H.createObject_def
-                      Arch_createNewCaps_def comp_def
-                      apiGetObjectSize_def shiftl_t2n field_simps
-                      shiftL_nat mapM_x_def sequence_x_def append
-                      fromIntegral_def integral_inv[unfolded Fun.comp_def])+
-                   , subst monad_eq, rule createObjects_Cons
-                   , (simp add: field_simps shiftl_t2n bind_assoc pageBits_def
-                               objBits_simps' placeNewObject_def2)+)+)[2]
+           \<comment> \<open>TCB\<close>
+           apply (simp add: bind_assoc ARM_H.getObjectSize_def
+                            mapM_def sequence_def Retype_H.createObject_def
+                            ARM_H.toAPIType_def objBitsKO_def
+                            createObjects_def ARM_H.createObject_def
+                            Arch_createNewCaps_def comp_def append
+                            apiGetObjectSize_def shiftl_t2n field_simps
+                            shiftL_nat fromIntegral_def integral_inv[unfolded Fun.comp_def])
+           apply (subst curDomain_createObjects'_comm)
+           apply (subst curDomain_twice_simp)
+           apply (simp add: monad_eq_simp_state)
+           apply (intro conjI; clarsimp simp: in_monad)
+             apply ((fastforce simp: curDomain_def simpler_gets_def return_def placeNewObject_def2
+                                     field_simps shiftl_t2n bind_assoc objBits_simps in_monad
+                                     createObjects_Cons[where
+                                       val="KOTCB (tcbDomain_update (\<lambda>_. ksCurDomain s) makeObject)"
+                                       and s=s, simplified objBitsKO_def])+)[2]
+           apply ((clarsimp simp: curDomain_def simpler_gets_def return_def split_def bind_def
+                                 field_simps shiftl_t2n bind_assoc objBits_simps placeNewObject_def2
+                                 createObjects_Cons[where
+                                   val="KOTCB (tcbDomain_update (\<lambda>_. ksCurDomain s) makeObject)"
+                                   and s=s, simplified objBitsKO_def])+)[1]
+          \<comment> \<open>EP, NTFN\<close>
+          apply (((simp add: ARM_H.getObjectSize_def
+                             mapM_def sequence_def Retype_H.createObject_def
+                             ARM_H.toAPIType_def
+                             createObjects_def ARM_H.createObject_def
+                             Arch_createNewCaps_def comp_def
+                             apiGetObjectSize_def shiftl_t2n field_simps
+                             shiftL_nat mapM_x_def sequence_x_def append
+                             fromIntegral_def integral_inv[unfolded Fun.comp_def])+,
+                   subst monad_eq, rule createObjects_Cons,
+                   (simp add: field_simps shiftl_t2n bind_assoc pageBits_def
+                              objBits_simps' placeNewObject_def2)+)+)[2]
         \<comment> \<open>CNode\<close>
+        apply (in_case "CapTableObject")
         apply (simp add: cteSizeBits_def pageBits_def tcbBlockSizeBits_def
                       epSizeBits_def ntfnSizeBits_def pdBits_def bind_assoc
                       ARM_H.getObjectSize_def
@@ -5668,35 +5637,19 @@ lemma createObject_pspace_no_overlap':
    apply wpc
     apply (wp ArchCreateObject_pspace_no_overlap')
    apply wpc
-       apply wp
-      apply (simp add:placeNewObject_def2)
-      apply (wp doMachineOp_psp_no_overlap createObjects'_pspace_no_overlap2
-        | simp add: placeNewObject_def2 curDomain_def word_shiftl_add_distrib
-        field_simps)+
-      apply (simp add:add.assoc[symmetric])
-      apply (wp createObjects'_pspace_no_overlap2
-        [where n =0 and sz = sz,simplified])
-     apply (simp add:placeNewObject_def2)
-     apply (wp doMachineOp_psp_no_overlap createObjects'_pspace_no_overlap2
-        | simp add: placeNewObject_def2 word_shiftl_add_distrib
-        field_simps)+
-     apply (simp add:add.assoc[symmetric])
-     apply (wp createObjects'_pspace_no_overlap2
-        [where n =0 and sz = sz,simplified])
-    apply (simp add:placeNewObject_def2)
-    apply (wp doMachineOp_psp_no_overlap createObjects'_pspace_no_overlap2
-      | simp add: placeNewObject_def2 word_shiftl_add_distrib
-      field_simps)+
-    apply (simp add:add.assoc[symmetric])
-    apply (wp createObjects'_pspace_no_overlap2
-      [where n =0 and sz = sz,simplified])
-   apply (simp add:placeNewObject_def2)
-   apply (wp doMachineOp_psp_no_overlap createObjects'_pspace_no_overlap2
-     | simp add: placeNewObject_def2 word_shiftl_add_distrib
-     field_simps)+
-   apply (simp add:add.assoc[symmetric])
-   apply (wp createObjects'_pspace_no_overlap2
-     [where n =0 and sz = sz,simplified])
+         apply wp
+        \<comment> \<open>TCB\<close>
+        apply (wp createObjects'_pspace_no_overlap2[where n =0 and sz = sz,simplified]
+               | simp add: curDomain_def placeNewObject_def2 word_shiftl_add_distrib field_simps)+
+         apply (simp add:add.assoc[symmetric])
+         apply (wp createObjects'_pspace_no_overlap2[where n =0 and sz = sz,simplified])
+        apply (wpsimp simp: curDomain_def)
+       \<comment> \<open>other objects\<close>
+       apply ((wp createObjects'_pspace_no_overlap2
+               | simp add: placeNewObject_def2 word_shiftl_add_distrib field_simps)+,
+              simp add:add.assoc[symmetric],
+              wp createObjects'_pspace_no_overlap2[where n =0 and sz = sz,simplified])+
+   \<comment> \<open>Cleanup\<close>
   apply clarsimp
   apply (frule(1) range_cover_no_0[where p = n])
    apply simp
@@ -5714,10 +5667,9 @@ lemma createObject_pspace_no_overlap':
    apply (simp add:shiftl_t2n field_simps)
   apply (frule range_cover_offset[rotated,where p = n])
    apply simp+
-  apply (auto simp: word_shiftl_add_distrib field_simps shiftl_t2n elim: range_cover_le,
-    auto simp add: APIType_capBits_def fromAPIType_def objBits_def
-        dest!: to_from_apiTypeD)
-  done
+  by (auto simp: word_shiftl_add_distrib field_simps shiftl_t2n elim: range_cover_le)
+     (auto simp: APIType_capBits_def fromAPIType_def objBits_def objBits_simps
+          dest!: to_from_apiTypeD)
 
 lemma createObject_pspace_aligned_distinct':
   "\<lbrace>pspace_aligned' and K (is_aligned ptr (APIType_capBits ty us))

--- a/proof/refine/ARM/Finalise_R.thy
+++ b/proof/refine/ARM/Finalise_R.thy
@@ -1588,7 +1588,7 @@ lemma emptySlot_corres:
   apply (simp add: put_def)
   apply (simp add: exec_gets exec_get exec_put del: fun_upd_apply | subst bind_def)+
   apply (clarsimp simp: state_relation_def)
-  apply (drule updateMDB_the_lot, fastforce simp: pspace_relations_def, fastforce, fastforce)
+  apply (drule updateMDB_the_lot, fastforce simp: pspace_relation_def, fastforce, fastforce)
    apply (clarsimp simp: invs'_def valid_state'_def valid_pspace'_def
                          valid_mdb'_def valid_mdb_ctes_def)
   apply (elim conjE)
@@ -1617,7 +1617,7 @@ lemma emptySlot_corres:
   apply clarsimp
   apply (drule updateCap_stuff, elim conjE, erule (1) impE)
   apply clarsimp
-  apply (drule updateMDB_the_lot, force simp: pspace_relations_def, assumption+, simp)
+  apply (drule updateMDB_the_lot, force simp: pspace_relation_def, assumption+, simp)
   apply (rule bexI)
    prefer 2
    apply (simp only: trans_state_update[symmetric])
@@ -1645,7 +1645,7 @@ lemma emptySlot_corres:
    apply (rule mdb_ptr_axioms.intro)
    subgoal by simp
   apply (clarsimp simp: ghost_relation_typ_at set_cap_a_type_inv)
-  apply (simp add: pspace_relations_def)
+  apply (simp add: pspace_relation_def)
   apply (rule conjI)
    apply (clarsimp simp: data_at_def ghost_relation_typ_at set_cap_a_type_inv)
   apply (rule conjI)
@@ -3329,8 +3329,7 @@ context begin interpretation Arch . (*FIXME: arch-split*)
 lemma arch_finaliseCap_corres:
   "\<lbrakk> final_matters' (ArchObjectCap cap') \<Longrightarrow> final = final'; acap_relation cap cap' \<rbrakk>
      \<Longrightarrow> corres (\<lambda>r r'. cap_relation (fst r) (fst r') \<and> cap_relation (snd r) (snd r'))
-           (\<lambda>s. invs s \<and> valid_etcbs s
-                       \<and> s \<turnstile> cap.ArchObjectCap cap
+           (\<lambda>s. invs s \<and> s \<turnstile> cap.ArchObjectCap cap
                        \<and> (final_matters (cap.ArchObjectCap cap)
                             \<longrightarrow> final = is_final_cap' (cap.ArchObjectCap cap) s)
                        \<and> cte_wp_at ((=) (cap.ArchObjectCap cap)) sl s)
@@ -3596,9 +3595,6 @@ lemmas invalidateTLBByASID_typ_ats[wp] = typ_at_lifts [OF invalidateTLBByASID_ty
 
 crunch invalidateTLBByASID
   for cteCaps_of: "\<lambda>s. P (cteCaps_of s)"
-
-crunch invalidate_tlb_by_asid
-  for valid_etcbs[wp]: valid_etcbs
 
 lemma cteCaps_of_ctes_of_lift:
   "(\<And>P. \<lbrace>\<lambda>s. P (ctes_of s)\<rbrace> f \<lbrace>\<lambda>_ s. P (ctes_of s)\<rbrace>) \<Longrightarrow> \<lbrace>\<lambda>s. P (cteCaps_of s) \<rbrace> f \<lbrace>\<lambda>_ s. P (cteCaps_of s)\<rbrace>"

--- a/proof/refine/ARM/Init_R.thy
+++ b/proof/refine/ARM/Init_R.thy
@@ -50,6 +50,12 @@ definition zeroed_main_abstract_state ::
     is_original_cap = (K True),
     cur_thread = 0,
     idle_thread = 0,
+    scheduler_action = resume_cur_thread,
+    domain_list = [],
+    domain_index = 0,
+    cur_domain = 0,
+    domain_time = 0,
+    ready_queues = (\<lambda>_ _. []),
     machine_state = init_machine_state,
     interrupt_irq_node = (\<lambda>irq. ucast irq << cte_level_bits),
     interrupt_states = (K irq_state.IRQInactive),
@@ -61,13 +67,6 @@ definition zeroed_extended_state ::
   where
   "zeroed_extended_state \<equiv> \<lparr>
     work_units_completed_internal = 0,
-    scheduler_action_internal = resume_cur_thread,
-    ekheap_internal = K None,
-    domain_list_internal = [],
-    domain_index_internal = 0,
-    cur_domain_internal = 0,
-    domain_time_internal = 0,
-    ready_queues_internal = (\<lambda>_ _. []),
     cdt_list_internal = K []
   \<rparr>"
 
@@ -116,8 +115,7 @@ lemma non_empty_refine_state_relation:
   "(zeroed_abstract_state, zeroed_intermediate_state) \<in> state_relation"
   apply (clarsimp simp: state_relation_def zeroed_state_defs state.defs)
   apply (intro conjI)
-          apply (clarsimp simp: pspace_relation_def pspace_dom_def)
-         apply (clarsimp simp: ekheap_relation_def)
+         apply (clarsimp simp: pspace_relation_def pspace_dom_def)
         apply (clarsimp simp: ready_queues_relation_def ready_queue_relation_def queue_end_valid_def
                               opt_pred_def list_queue_relation_def tcbQueueEmpty_def
                               prev_queue_head_def)

--- a/proof/refine/ARM/Interrupt_R.thy
+++ b/proof/refine/ARM/Interrupt_R.thy
@@ -637,9 +637,8 @@ lemma getIRQState_prop:
 
 lemma decDomainTime_corres:
   "corres dc \<top> \<top> dec_domain_time decDomainTime"
-  apply (simp add:dec_domain_time_def corres_underlying_def
-    decDomainTime_def simpler_modify_def)
-  apply (clarsimp simp:state_relation_def)
+  apply (simp add:dec_domain_time_def corres_underlying_def decDomainTime_def simpler_modify_def)
+  apply (clarsimp simp: state_relation_def cdt_relation_def)
   done
 
 lemma thread_state_case_if:
@@ -673,24 +672,24 @@ lemma timerTick_corres:
           apply (rule corres_split[where r' = dc])
              apply (rule corres_if[where Q = \<top> and Q' = \<top>])
                apply (case_tac state,simp_all)[1]
-              apply (rule_tac r'="(=)" in corres_split[OF ethreadget_corres])
-                 apply (simp add:etcb_relation_def)
+              apply (rule_tac r'="(=)" in corres_split[OF threadGet_corres])
+                 apply (simp add: tcb_relation_def)
                 apply (rename_tac ts ts')
                 apply (rule_tac R="1 < ts" in corres_cases)
                  apply (simp)
                  apply (unfold thread_set_time_slice_def)
-                 apply (rule ethread_set_corres, simp+)
-                 apply (clarsimp simp: etcb_relation_def)
+                 apply (rule threadset_corres; simp add: tcb_relation_def inQ_def)
                 apply simp
-                apply (rule corres_split[OF ethread_set_corres])
-                         apply (simp add: sch_act_wf_weak etcb_relation_def pred_conj_def)+
+                apply (rule corres_split[OF threadset_corres])
+                                apply (simp add: sch_act_wf_weak tcb_relation_def pred_conj_def inQ_def)+
                   apply (rule corres_split[OF tcbSchedAppend_corres], simp)
                     apply (rule rescheduleRequired_corres)
                    apply wp
                   apply ((wpsimp wp: tcbSchedAppend_sym_heap_sched_pointers
                                      tcbSchedAppend_valid_objs'
                           | strengthen valid_objs'_valid_tcbs')+)[1]
-                 apply ((wp thread_set_time_slice_valid_queues
+                 apply ((wpsimp wp: thread_set_valid_queues thread_set_no_change_tcb_state
+                                    thread_set_weak_valid_sched_action
                          | strengthen valid_queues_in_correct_ready_q
                                       valid_queues_ready_qs_distinct)+)[1]
                 apply ((wpsimp wp: threadSet_sched_pointers threadSet_valid_sched_pointers
@@ -710,10 +709,10 @@ lemma timerTick_corres:
                              threadSet_pred_tcb_at_state threadSet_weak_sch_act_wf
                              rescheduleRequired_weak_sch_act_wf)+
               apply (strengthen valid_queues_in_correct_ready_q valid_queues_ready_qs_distinct)
-              apply (wpsimp wp: thread_set_time_slice_valid_queues)
-             apply ((wpsimp wp: thread_set_time_slice_valid_queues
+              apply (wpsimp wp: thread_set_valid_queues thread_set_weak_valid_sched_action)
+             apply ((wpsimp wp: thread_set_valid_queues
                      | strengthen valid_queues_in_correct_ready_q valid_queues_ready_qs_distinct)+)[1]
-            apply wpsimp
+            apply (wpsimp wp: thread_get_wp)
            apply wpsimp
           apply ((wpsimp wp: threadSet_sched_pointers threadSet_valid_sched_pointers
                              threadSet_valid_objs'
@@ -721,11 +720,8 @@ lemma timerTick_corres:
                   | wp (once) hoare_drop_imp)+)[1]
          apply (wpsimp wp: gts_wp gts_wp')+
      apply (clarsimp simp: cur_tcb_def)
-     apply (frule valid_sched_valid_etcbs)
-     apply (frule (1) tcb_at_is_etcb_at)
      apply (frule valid_sched_valid_queues)
      apply (fastforce simp: pred_tcb_at_def obj_at_def valid_sched_weak_strg)
-    apply (clarsimp simp: etcb_at_def split: option.splits)
     apply fastforce
    apply (fastforce simp: valid_state'_def ct_not_inQ_def)
   apply fastforce

--- a/proof/refine/ARM/IpcCancel_R.thy
+++ b/proof/refine/ARM/IpcCancel_R.thy
@@ -537,7 +537,7 @@ lemma (in delete_one) cancelIPC_ReplyCap_corres:
           apply (simp add: tcb_relation_def fault_rel_optionation_def)
          apply (simp add: tcb_cap_cases_def)
         apply (simp add: tcb_cte_cases_def tcb_cte_cases_neqs)
-       apply (simp add: exst_same_def)
+       apply (simp add: inQ_def)
       apply (fastforce simp: st_tcb_at_tcb_at)
      apply clarsimp
     defer
@@ -1227,17 +1227,21 @@ crunch asUser
 
 crunch set_thread_state
   for in_correct_ready_q[wp]: in_correct_ready_q
-  (ignore_del: set_thread_state_ext)
+  (wp: set_object_wp)
 
-crunch set_thread_state_ext
+crunch set_thread_state_act
   for ready_qs_distinct[wp]: ready_qs_distinct
-  (wp: crunch_wps ignore_del: set_thread_state_ext)
+  (wp: crunch_wps)
 
 lemma set_thread_state_ready_qs_distinct[wp]:
   "set_thread_state ref ts \<lbrace>ready_qs_distinct\<rbrace>"
   unfolding set_thread_state_def
   apply (wpsimp wp: set_object_wp)
   by (clarsimp simp: ready_qs_distinct_def)
+
+crunch as_user
+  for in_correct_ready_q[wp]: in_correct_ready_q
+  (wp: set_object_wp)
 
 lemma as_user_ready_qs_distinct[wp]:
   "as_user tptr f \<lbrace>ready_qs_distinct\<rbrace>"
@@ -1394,7 +1398,7 @@ lemma sts_sch_act_not_ct[wp]:
 text \<open>Cancelling all IPC in an endpoint or notification object\<close>
 
 lemma ep_cancel_corres_helper:
-  "corres dc ((\<lambda>s. \<forall>t \<in> set list. tcb_at t s) and valid_etcbs and valid_queues
+  "corres dc ((\<lambda>s. \<forall>t \<in> set list. tcb_at t s) and valid_queues
                                               and pspace_aligned and pspace_distinct)
              (valid_objs' and sym_heap_sched_pointers and valid_sched_pointers)
           (mapM_x (\<lambda>t. do
@@ -1431,7 +1435,7 @@ lemma ep_cancel_corres_helper:
 crunch set_simple_ko
   for ready_qs_distinct[wp]: ready_qs_distinct
   and in_correct_ready_q[wp]: in_correct_ready_q
-  (rule: ready_qs_distinct_lift wp: crunch_wps)
+  (wp: ready_qs_distinct_lift in_correct_ready_q_lift)
 
 lemma ep_cancel_corres:
   "corres dc (invs and valid_sched and ep_at ep) (invs' and ep_at' ep)
@@ -1440,7 +1444,7 @@ proof -
   have P:
     "\<And>list.
      corres dc (\<lambda>s. (\<forall>t \<in> set list. tcb_at t s) \<and> valid_pspace s \<and> ep_at ep s
-                        \<and> valid_etcbs s \<and> weak_valid_sched_action s \<and> valid_queues s)
+                        \<and> weak_valid_sched_action s \<and> valid_queues s)
                (\<lambda>s. (\<forall>t \<in> set list. tcb_at' t s) \<and> valid_pspace' s
                          \<and> ep_at' ep s \<and> weak_sch_act_wf (ksSchedulerAction s) s
                          \<and> valid_objs' s \<and> sym_heap_sched_pointers s \<and> valid_sched_pointers s)
@@ -2179,7 +2183,7 @@ lemma cancelBadgedSends_corres:
                                                            and pspace_distinct'"]])
          apply (rule_tac S="(=)"
                      and Q="\<lambda>xs s. (\<forall>x \<in> set xs. (epptr, TCBBlockedSend) \<in> state_refs_of s x) \<and>
-                                   distinct xs \<and> valid_etcbs s \<and>
+                                   distinct xs \<and>
                                    in_correct_ready_q s \<and> ready_qs_distinct s \<and>
                                    pspace_aligned s \<and> pspace_distinct s"
                     and Q'="\<lambda>_ s. valid_objs' s \<and> sym_heap_sched_pointers s \<and> valid_sched_pointers s
@@ -2203,7 +2207,7 @@ lemma cancelBadgedSends_corres:
                       | strengthen valid_objs'_valid_tcbs')+
             apply (clarsimp simp: valid_tcb_state_def tcb_at_def st_tcb_def2
                                   st_tcb_at_refs_of_rev
-                           dest!: state_refs_of_elemD elim!: tcb_at_is_etcb_at[rotated])
+                           dest!: state_refs_of_elemD)
             apply (simp add: valid_tcb_state'_def)
           apply (wp hoare_vcg_const_Ball_lift gts_wp | clarsimp)+
             apply (wp hoare_vcg_imp_lift sts_st_tcb' sts_valid_objs'

--- a/proof/refine/ARM/Ipc_R.thy
+++ b/proof/refine/ARM/Ipc_R.thy
@@ -2175,9 +2175,8 @@ lemma doReplyTransfer_corres:
                apply simp
               apply (rule corres_split)
                  apply (rule threadset_corresT;
-                        clarsimp simp add: tcb_relation_def fault_rel_optionation_def
-                                           tcb_cap_cases_def tcb_cte_cases_def tcb_cte_cases_neqs
-                                           exst_same_def)
+                        clarsimp simp add: tcb_relation_def fault_rel_optionation_def cteSizeBits_def
+                                           tcb_cap_cases_def tcb_cte_cases_def inQ_def)
                 apply (rule_tac Q="valid_sched and cur_tcb and tcb_at receiver and pspace_aligned and pspace_distinct"
                             and Q'="tcb_at' receiver and cur_tcb'
                                       and (\<lambda>s. weak_sch_act_wf (ksSchedulerAction s) s)
@@ -3374,7 +3373,7 @@ lemma sendFaultIPC_corres:
            apply (rule corres_if2 [OF refl])
             apply (simp add: dc_def[symmetric])
             apply (rule corres_split[OF threadset_corres sendIPC_corres], simp_all)[1]
-               apply (simp add: tcb_relation_def fault_rel_optionation_def exst_same_def)+
+               apply (simp add: tcb_relation_def fault_rel_optionation_def inQ_def)+
              apply (wp thread_set_invs_trivial thread_set_no_change_tcb_state
                        thread_set_typ_at ep_at_typ_at ex_nonz_cap_to_pres
                        thread_set_cte_wp_at_trivial thread_set_not_state_valid_sched

--- a/proof/refine/ARM/KHeap_R.thy
+++ b/proof/refine/ARM/KHeap_R.thy
@@ -952,17 +952,6 @@ lemma obj_relation_cut_same_type:
                     ARM_A.arch_kernel_obj.split_asm)
   done
 
-definition exst_same :: "Structures_H.tcb \<Rightarrow> Structures_H.tcb \<Rightarrow> bool"
-where
-  "exst_same tcb tcb' \<equiv> tcbPriority tcb = tcbPriority tcb'
-                      \<and> tcbTimeSlice tcb = tcbTimeSlice tcb'
-                      \<and> tcbDomain tcb = tcbDomain tcb'"
-
-fun exst_same' :: "Structures_H.kernel_object \<Rightarrow> Structures_H.kernel_object \<Rightarrow> bool"
-where
-  "exst_same' (KOTCB tcb) (KOTCB tcb') = exst_same tcb tcb'" |
-  "exst_same' _ _ = True"
-
 lemma tcbs_of'_non_tcb_update:
   "\<lbrakk>typ_at' (koTypeOf ko) ptr s'; koTypeOf ko \<noteq> TCBT\<rbrakk>
    \<Longrightarrow> tcbs_of' (s'\<lparr>ksPSpace := (ksPSpace s')(ptr \<mapsto> ko)\<rparr>) = tcbs_of' s'"
@@ -980,7 +969,6 @@ lemma setObject_other_corres:
                \<Longrightarrow> map_to_ctes ((ksPSpace s) (ptr \<mapsto> injectKO ob')) = map_to_ctes (ksPSpace s)"
   assumes t: "is_other_obj_relation_type (a_type ob)"
   assumes b: "\<And>ko. P ko \<Longrightarrow> objBits ko = objBits ob'"
-  assumes e: "\<And>ko. P ko \<Longrightarrow> exst_same' (injectKO ko) (injectKO ob')"
   assumes P: "\<And>(v::'a::pspace_storable). (1 :: word32) < 2 ^ (objBits v)"
   shows      "other_obj_relation ob (injectKO (ob' :: 'a :: pspace_storable)) \<Longrightarrow>
   corres dc (obj_at (\<lambda>ko. a_type ko = a_type ob) ptr and obj_at (same_caps ob) ptr)
@@ -1031,21 +1019,6 @@ lemma setObject_other_corres:
    apply (insert t)
    apply ((erule disjE
           | clarsimp simp: is_other_obj_relation_type is_other_obj_relation_type_def a_type_def)+)[1]
-  apply (extract_conjunct \<open>match conclusion in "ekheap_relation _ _" \<Rightarrow> -\<close>)
-   apply (simp only: ekheap_relation_def)
-   apply (rule ballI, drule(1) bspec)
-   apply (drule domD)
-   apply (insert e)
-   apply atomize
-   apply (clarsimp simp: obj_at'_def)
-   apply (erule_tac x=obj in allE)
-   apply (clarsimp simp: projectKO_eq project_inject)
-   apply (case_tac ob;
-          simp_all add: a_type_def other_obj_relation_def etcb_relation_def
-                        is_other_obj_relation_type t exst_same_def)
-     apply (clarsimp simp: is_other_obj_relation_type t exst_same_def
-                    split: Structures_A.kernel_object.splits Structures_H.kernel_object.splits
-                           arch_kernel_obj.splits)+
   \<comment> \<open>ready_queues_relation\<close>
   apply (prop_tac "koTypeOf (injectKO ob') \<noteq> TCBT")
    subgoal

--- a/proof/refine/ARM/PageTableDuplicates.thy
+++ b/proof/refine/ARM/PageTableDuplicates.thy
@@ -1049,7 +1049,7 @@ lemma createObject_valid_duplicates'[wp]:
            | wpc | simp add: alignError_def split del: if_split)+
      apply (rule copyGlobalMappings_valid_duplicates')
     apply ((wp unless_wp[where P="d"] unless_wp[where P'=\<top>] | wpc
-            | simp add: alignError_def placeNewObject_def
+            | simp add: alignError_def placeNewObject_def curDomain_def
                         placeNewObject'_def split_def split del: if_split)+)[2]
   apply (intro conjI impI)
              apply clarsimp+

--- a/proof/refine/ARM/Refine.thy
+++ b/proof/refine/ARM/Refine.thy
@@ -201,18 +201,27 @@ assumes rel: "(s,s') \<in> state_relation"
 shows "absKState s' = abs_state s"
   using assms
   apply (intro state.equality, simp_all add: absKState_def abs_state_def)
-           apply (rule absHeap_correct, clarsimp+)
-           apply (clarsimp elim!: state_relationE)
-          apply (rule absCDT_correct, clarsimp+)
-         apply (rule absIsOriginalCap_correct, clarsimp+)
+                 apply (rule absHeap_correct; clarsimp)
+                 apply (clarsimp elim!: state_relationE)
+                apply (rule absCDT_correct; clarsimp)
+               apply (rule absIsOriginalCap_correct; clarsimp)
+              apply (simp add: state_relation_def)
+             apply (simp add: state_relation_def)
+            apply (clarsimp simp: state_relation_def)
+            apply (rule absSchedulerAction_correct, simp add: state_relation_def)
+           apply (simp add: state_relation_def)
+          apply (simp add: state_relation_def)
+         apply (simp add: state_relation_def)
         apply (simp add: state_relation_def)
-       apply (simp add: state_relation_def)
+       apply (simp add: state_relation_def ready_queues_relation_def ready_queue_relation_def Let_def
+                        list_queue_relation_def)
+       apply (fastforce dest: heap_ls_is_walk)
       apply (clarsimp simp:  user_mem_relation invs_def invs'_def)
       apply (simp add: state_relation_def)
      apply (rule absInterruptIRQNode_correct, simp add: state_relation_def)
     apply (rule absInterruptStates_correct, simp add: state_relation_def)
    apply (rule absArchState_correct, simp)
-  apply (rule absExst_correct, simp+)
+  apply (rule absExst_correct; simp)
   done
 
 text \<open>The top-level invariance\<close>
@@ -223,19 +232,19 @@ lemma set_thread_state_sched_act:
   \<lbrace>\<lambda>rs s. P (scheduler_action (s::det_state))\<rbrace>"
   apply (simp add: set_thread_state_def)
   apply wp
-    apply (simp add: set_thread_state_ext_def)
-    apply wp
-       apply (rule hoare_pre_cont)
-      apply (rule_tac Q'="\<lambda>rv. (\<lambda>s. runnable ts) and (\<lambda>s. P (scheduler_action s))"
-              in hoare_strengthen_post)
-       apply wp
-      apply force
-     apply (wp gts_st_tcb_at)+
-     apply (rule_tac Q'="\<lambda>rv. st_tcb_at ((=) state) thread and (\<lambda>s. runnable state) and (\<lambda>s. P (scheduler_action s))" in hoare_strengthen_post)
+     apply (simp add: set_thread_state_act_def)
+     apply wp
+        apply (rule hoare_pre_cont)
+       apply (rule_tac Q'="\<lambda>rv. (\<lambda>s. runnable ts) and (\<lambda>s. P (scheduler_action s))"
+               in hoare_strengthen_post)
+        apply wp
+       apply force
+      apply (wp gts_st_tcb_at)+
+    apply (rule_tac Q'="\<lambda>rv. st_tcb_at ((=) state) thread and (\<lambda>s. runnable state) and (\<lambda>s. P (scheduler_action s))" in hoare_strengthen_post)
      apply (simp add: st_tcb_at_def)
      apply (wp obj_set_prop_at)+
     apply (force simp: st_tcb_at_def obj_at_def)
-  apply wp
+   apply wp
   apply clarsimp
   done
 
@@ -277,7 +286,7 @@ lemma kernel_entry_invs:
    apply clarsimp
   apply (simp add: kernel_entry_def)
   apply (wp akernel_invs_det_ext call_kernel_valid_sched thread_set_invs_trivial
-            thread_set_ct_running thread_set_not_state_valid_sched
+            thread_set_not_state_valid_sched
             hoare_vcg_disj_lift ct_in_state_thread_state_lift thread_set_no_change_tcb_state
             call_kernel_domain_time_inv_det_ext call_kernel_domain_list_inv_det_ext
             hoare_weak_lift_imp
@@ -335,11 +344,12 @@ lemmas valid_list_inits[simp] = valid_list_init[simplified]
 lemma valid_sched_init[simp]:
   "valid_sched init_A_st"
   apply (simp add: valid_sched_def init_A_st_def ext_init_def)
-  apply (clarsimp simp: valid_etcbs_def init_kheap_def st_tcb_at_kh_def obj_at_kh_def
-                    obj_at_def is_etcb_at_def idle_thread_ptr_def init_globals_frame_def
+  apply (clarsimp simp: init_kheap_def st_tcb_at_kh_def obj_at_kh_def
+                    obj_at_def idle_thread_ptr_def init_globals_frame_def
                     init_global_pd_def valid_queues_2_def ct_not_in_q_def not_queued_def
                     valid_sched_action_def is_activatable_def
-                    ct_in_cur_domain_2_def valid_blocked_2_def valid_idle_etcb_def etcb_at'_def default_etcb_def)
+                    ct_in_cur_domain_2_def valid_blocked_2_def valid_idle_etcb_def
+                    etcb_at'_def etcbs_of'_def)
   done
 
 lemma valid_domain_list_init[simp]:
@@ -441,27 +451,6 @@ lemma kernelEntry_invs':
                           valid_domain_list'_def)+
   done
 
-lemma absKState_correct':
-  "\<lbrakk>einvs s; invs' s'; (s,s') \<in> state_relation\<rbrakk>
-   \<Longrightarrow> absKState s' = abs_state s"
-  apply (intro state.equality, simp_all add: absKState_def abs_state_def)
-           apply (rule absHeap_correct)
-               apply (clarsimp simp: valid_state_def valid_pspace_def)+
-           apply (clarsimp dest!: state_relationD)
-          apply (rule absCDT_correct)
-                apply (clarsimp simp: valid_state_def valid_pspace_def
-                                      valid_state'_def valid_pspace'_def)+
-         apply (rule absIsOriginalCap_correct, clarsimp+)
-        apply (simp add: state_relation_def)
-       apply (simp add: state_relation_def)
-      apply (clarsimp simp: user_mem_relation invs_def invs'_def)
-      apply (simp add: state_relation_def)
-     apply (rule absInterruptIRQNode_correct, simp add: state_relation_def)
-    apply (rule absInterruptStates_correct, simp add: state_relation_def)
-   apply (erule absArchState_correct)
-  apply (rule absExst_correct, simp, assumption+)
-  done
-
 lemma ptable_lift_abs_state[simp]:
   "ptable_lift t (abs_state s) = ptable_lift t s"
   by (simp add: ptable_lift_def abs_state_def)
@@ -479,7 +468,7 @@ lemma ptable_rights_imp_UserData:
   shows "pointerInUserData y s' \<or> pointerInDeviceData y s'"
 proof -
   from invs invs' rel have [simp]: "absKState s' = abs_state s"
-    by - (rule absKState_correct', simp_all)
+    by - (rule absKState_correct, simp_all)
   from invs have valid: "valid_state s" by auto
   from invs' have valid': "valid_state' s'" by auto
   have "in_user_frame y s \<or> in_device_frame y s "
@@ -644,11 +633,10 @@ lemma entry_corres:
       apply (rule corres_split)
          apply simp
          apply (rule threadset_corresT; simp?)
-            apply (simp add: tcb_relation_def arch_tcb_relation_def
-                             arch_tcb_context_set_def atcbContextSet_def)
-           apply (clarsimp simp: tcb_cap_cases_def)
-          apply (clarsimp simp: tcb_cte_cases_def tcb_cte_cases_neqs)
-         apply (simp add: exst_same_def)
+           apply (simp add: tcb_relation_def arch_tcb_relation_def
+                            arch_tcb_context_set_def atcbContextSet_def)
+          apply (clarsimp simp: tcb_cap_cases_def)
+         apply (clarsimp simp: tcb_cte_cases_def tcb_cte_cases_neqs)
         apply (rule corres_split[OF kernel_corres])
           apply (rule corres_split_eqr[OF getCurThread_corres])
             apply (rule threadGet_corres)
@@ -657,7 +645,7 @@ lemma entry_corres:
            apply wp+
          apply (rule hoare_strengthen_post, rule akernel_invs_det_ext, fastforce simp: invs_def cur_tcb_def)
         apply (rule hoare_strengthen_post, rule ckernel_invs, simp add: invs'_def cur_tcb'_def)
-       apply (wp thread_set_invs_trivial thread_set_ct_running
+       apply (wp thread_set_invs_trivial
                  threadSet_invs_trivial threadSet_ct_running'
                  thread_set_not_state_valid_sched hoare_weak_lift_imp
                  hoare_vcg_disj_lift ct_in_state_thread_state_lift

--- a/proof/refine/ARM/Retype_R.thy
+++ b/proof/refine/ARM/Retype_R.thy
@@ -76,12 +76,12 @@ where
     | PageDirectoryObject \<Rightarrow> 14"
 
 definition
-  makeObjectKO :: "bool \<Rightarrow> (kernel_object + ARM_H.object_type) \<rightharpoonup> kernel_object"
+  makeObjectKO :: "bool \<Rightarrow> domain \<Rightarrow> (kernel_object + ARM_H.object_type) \<rightharpoonup> kernel_object"
 where
-  "makeObjectKO dev ty \<equiv> case ty of
+  "makeObjectKO dev d ty \<equiv> case ty of
       Inl KOUserData \<Rightarrow> Some KOUserData
     | Inl (KOArch (KOASIDPool _)) \<Rightarrow> Some (KOArch (KOASIDPool makeObject))
-    | Inr (APIObjectType ArchTypes_H.TCBObject) \<Rightarrow> Some (KOTCB makeObject)
+    | Inr (APIObjectType ArchTypes_H.TCBObject) \<Rightarrow> Some (KOTCB (tcbDomain_update (\<lambda>_. d) makeObject))
     | Inr (APIObjectType ArchTypes_H.EndpointObject) \<Rightarrow> Some (KOEndpoint makeObject)
     | Inr (APIObjectType ArchTypes_H.NotificationObject) \<Rightarrow> Some (KONotification makeObject)
     | Inr (APIObjectType ArchTypes_H.CapTableObject) \<Rightarrow> Some (KOCTE makeObject)
@@ -108,6 +108,12 @@ lemma valid_obj_makeObject_tcb [simp]:
   unfolding valid_obj'_def valid_tcb'_def  valid_tcb_state'_def
   by (clarsimp simp: makeObject_tcb makeObject_cte tcb_cte_cases_def minBound_word newArchTCB_def
                      cteSizeBits_def valid_arch_tcb'_def)
+
+lemma valid_obj_makeObject_tcb_tcbDomain_update [simp]:
+  "d \<le> maxDomain \<Longrightarrow> valid_obj' (KOTCB (tcbDomain_update (\<lambda>_. d) makeObject)) s"
+  unfolding valid_obj'_def valid_tcb'_def  valid_tcb_state'_def valid_arch_tcb'_def
+  by (clarsimp simp: makeObject_tcb makeObject_cte objBits_simps' newArchTCB_def
+                     tcb_cte_cases_def maxDomain_def maxPriority_def numPriorities_def minBound_word)
 
 lemma valid_obj_makeObject_endpoint [simp]:
   "valid_obj' (KOEndpoint makeObject) s"
@@ -297,14 +303,13 @@ lemma cte_at_next_slot'':
 
 
 lemma state_relation_null_filterE:
-  "\<lbrakk> (s, s') \<in> state_relation; t = kheap_update f (ekheap_update ef s);
+  "\<lbrakk> (s, s') \<in> state_relation; t = kheap_update f s;
      \<exists>f' g' h'.
      t' = s'\<lparr>ksPSpace := f' (ksPSpace s'), gsUserPages := g' (gsUserPages s'),
              gsCNodes := h' (gsCNodes s')\<rparr>;
      null_filter (caps_of_state t) = null_filter (caps_of_state s);
      null_filter' (ctes_of t') = null_filter' (ctes_of s');
-     pspace_relation (kheap t) (ksPSpace t');
-     ekheap_relation (ekheap t) (ksPSpace t'); ready_queues_relation t t';
+     pspace_relation (kheap t) (ksPSpace t'); ready_queues_relation t t';
      ghost_relation (kheap t) (gsUserPages t') (gsCNodes t'); valid_list s;
      pspace_aligned' s'; pspace_distinct' s'; valid_objs s; valid_mdb s;
      pspace_aligned' t'; pspace_distinct' t';
@@ -322,12 +327,11 @@ lemma state_relation_null_filterE:
     apply (case_tac "cdt s (a, b)")
      apply (subst mdb_cte_at_no_descendants, assumption)
       apply (simp add: cte_wp_at_caps_of_state swp_def)
-     apply (cut_tac s="kheap_update f (ekheap_update ef s)"  and
+     apply (cut_tac s="kheap_update f s"  and
                     s'="s'\<lparr>ksPSpace := f' (ksPSpace s'),
                            gsUserPages := g' (gsUserPages s'),
                            gsCNodes := h' (gsCNodes s')\<rparr>"
             in pspace_relation_ctes_ofI, simp_all)[1]
-      apply (simp add: trans_state_update[symmetric] del: trans_state_update)
       apply (erule caps_of_state_cteD)
      apply (clarsimp simp: descendants_of'_def)
      apply (case_tac cte)
@@ -431,12 +435,12 @@ lemma foldr_update_obj_at':
   done
 
 lemma makeObjectKO_eq:
-  assumes x: "makeObjectKO dev tp = Some v"
+  assumes x: "makeObjectKO dev d tp = Some v"
   shows
   "(v = KOCTE cte) =
        (tp = Inr (APIObjectType ArchTypes_H.CapTableObject) \<and> cte = makeObject)"
   "(v = KOTCB tcb) =
-       (tp = Inr (APIObjectType ArchTypes_H.TCBObject) \<and> tcb = makeObject)"
+       (tp = Inr (APIObjectType ArchTypes_H.TCBObject) \<and> tcb = (tcbDomain_update (\<lambda>_. d) makeObject))"
   using x
   by (simp add: makeObjectKO_def eq_commute
          split: apiobject_type.split_asm sum.split_asm kernel_object.split_asm
@@ -491,7 +495,7 @@ lemma ps_clearD:
   done
 
 lemma cte_wp_at_retype':
-  assumes ko: "makeObjectKO dev tp = Some obj"
+  assumes ko: "makeObjectKO dev d tp = Some obj"
       and pv: "pspace_aligned' s" "pspace_distinct' s"
      and pv': "pspace_aligned' (ksPSpace_update (\<lambda>x xa. if xa \<in> set addrs then Some obj else ksPSpace s xa) s)"
               "pspace_distinct' (ksPSpace_update (\<lambda>x xa. if xa \<in> set addrs then Some obj else ksPSpace s xa) s)"
@@ -510,27 +514,28 @@ lemma cte_wp_at_retype':
     apply (subgoal_tac "(\<exists>P :: cte \<Rightarrow> bool. obj_at' P p ?s')
                           \<longrightarrow> (\<not> (\<exists>P :: tcb \<Rightarrow> bool. obj_at' P (p && ~~ mask tcbBlockSizeBits) ?s'))")
      apply (simp only: cte_wp_at_obj_cases_mask foldr_update_obj_at'[OF pv pv' al])
-     apply (simp    add: projectKOs the_ctes_makeObject
-                         makeObjectKO_eq [OF ko]
-                         makeObject_cte dom_def
+     apply (simp    add: projectKOs the_ctes_makeObject makeObjectKO_eq [OF ko] makeObject_cte
               split del: if_split
                    cong: if_cong)
      apply (insert al ko)
-     apply (simp, safe, simp_all)
-      apply fastforce
-     apply fastforce
+     apply simp
+     apply (safe; simp)
+              apply ((fastforce simp: makeObjectKO_def makeObject_cte makeObject_tcb tcb_cte_cases_def
+                               split: if_split_asm)+)[10]
     apply (clarsimp elim!: obj_atE' simp: projectKOs objBits_simps)
     apply (drule ps_clearD[where y=p and n=tcbBlockSizeBits])
        apply simp
       apply (rule order_trans_rules(17))
        apply (clarsimp cong: if_cong)
       apply (rule word_and_le2)
-     apply (rule word_neg_and_le[simplified field_simps])
-    apply (clarsimp elim!: obj_atE' simp: pn)+
+     apply (simp add: word_neg_and_le[simplified field_simps])
+    apply simp
+   apply (clarsimp elim!: obj_atE' simp: pn)
+  apply (clarsimp elim!: obj_atE' simp: pn)
   done
 
 lemma ctes_of_retype:
-  assumes ko: "makeObjectKO dev tp = Some obj"
+  assumes ko: "makeObjectKO dev d tp = Some obj"
       and pv: "pspace_aligned' s" "pspace_distinct' s"
      and pv': "pspace_aligned' (ksPSpace_update (\<lambda>x xa. if xa \<in> set addrs then Some obj else ksPSpace s xa) s)"
               "pspace_distinct' (ksPSpace_update (\<lambda>x xa. if xa \<in> set addrs then Some obj else ksPSpace s xa) s)"
@@ -559,7 +564,7 @@ lemma None_ctes_of_cte_at:
   by (fastforce simp add: cte_wp_at_ctes_of)
 
 lemma null_filter_ctes_retype:
-  assumes ko: "makeObjectKO dev tp = Some obj"
+  assumes ko: "makeObjectKO dev d tp = Some obj"
       and pv: "pspace_aligned' s" "pspace_distinct' s"
      and pv': "pspace_aligned' (ksPSpace_update (\<lambda>x xa. if xa \<in> set addrs then Some obj else ksPSpace s xa) s)"
               "pspace_distinct' (ksPSpace_update (\<lambda>x xa. if xa \<in> set addrs then Some obj else ksPSpace s xa) s)"
@@ -590,7 +595,8 @@ lemma null_filter_ctes_retype:
    apply (insert ko[symmetric], simp add: makeObjectKO_def objBits_simps)
    apply clarsimp
    apply (subst(asm) subtract_mask[symmetric],
-          erule_tac v="if x \<in> set addrs then KOTCB makeObject else KOCTE cte"
+          erule_tac v="if x \<in> set addrs then KOTCB (tcbDomain_update (\<lambda>_. d) makeObject)
+                                        else KOCTE cte"
                 in tcb_space_clear)
        apply (simp add: is_aligned_mask word_bw_assocs)
       apply assumption
@@ -718,13 +724,13 @@ lemma obj_relation_retype_leD:
   by (simp add: obj_relation_retype_def)
 
 lemma obj_relation_retype_default_leD:
-  "\<lbrakk> obj_relation_retype (default_object (APIType_map2 ty) dev us) ko;
+  "\<lbrakk> obj_relation_retype (default_object (APIType_map2 ty) dev us d) ko;
        ty \<noteq> Inr (APIObjectType ArchTypes_H.Untyped) \<rbrakk>
       \<Longrightarrow> objBitsKO ko \<le> obj_bits_api (APIType_map2 ty) us"
   by (simp add: obj_relation_retype_def objBits_def obj_bits_dev_irr)
 
 lemma makeObjectKO_Untyped:
-  "makeObjectKO dev ty = Some v \<Longrightarrow> ty \<noteq> Inr (APIObjectType ArchTypes_H.Untyped)"
+  "makeObjectKO dev d ty = Some v \<Longrightarrow> ty \<noteq> Inr (APIObjectType ArchTypes_H.Untyped)"
   by (clarsimp simp: makeObjectKO_def)
 
 lemma obj_relation_cuts_trivial:
@@ -748,10 +754,10 @@ lemma obj_relation_cuts_trivial:
 lemma obj_relation_retype_addrs_eq:
   assumes not_unt:"ty \<noteq> Inr (APIObjectType ArchTypes_H.Untyped)"
   assumes  amp: "m = 2^ ((obj_bits_api (APIType_map2 ty) us) - (objBitsKO ko)) * n"
-  assumes  orr: "obj_relation_retype (default_object (APIType_map2 ty) dev us) ko"
+  assumes  orr: "obj_relation_retype (default_object (APIType_map2 ty) dev us d) ko"
   shows  "\<lbrakk> range_cover ptr sz (obj_bits_api (APIType_map2 ty) us) n \<rbrakk> \<Longrightarrow>
    (\<Union>x \<in> set (retype_addrs ptr (APIType_map2 ty) n us).
-            fst ` obj_relation_cuts (default_object (APIType_map2 ty) dev us) x)
+            fst ` obj_relation_cuts (default_object (APIType_map2 ty) dev us d) x)
       = set (new_cap_addrs m ptr ko)"
   apply (rule set_eqI, rule iffI)
    apply (clarsimp simp: retype_addrs_def)
@@ -811,7 +817,7 @@ lemma obj_relation_retype_addrs_eq:
 done
 
 lemma objBits_le_obj_bits_api:
-  "makeObjectKO dev ty = Some ko \<Longrightarrow>
+  "makeObjectKO dev d ty = Some ko \<Longrightarrow>
    objBitsKO ko \<le> obj_bits_api (APIType_map2 ty) us"
   apply (case_tac ty)
     apply (auto simp: default_arch_object_def pageBits_def archObjSize_def pteBits_def pdeBits_def
@@ -839,12 +845,12 @@ lemma retype_pspace_relation:
       and vs': "pspace_aligned' s'" "pspace_distinct' s'"
       and  pn: "pspace_no_overlap_range_cover ptr sz s"
       and pn': "pspace_no_overlap' ptr sz s'"
-      and  ko: "makeObjectKO dev ty = Some ko"
+      and  ko: "makeObjectKO dev d ty = Some ko"
       and cover: "range_cover ptr sz (obj_bits_api (APIType_map2 ty) us) n"
-      and orr: "obj_relation_retype (default_object (APIType_map2 ty) dev us) ko"
+      and orr: "obj_relation_retype (default_object (APIType_map2 ty) dev us d) ko"
       and num_r: "m = 2 ^ (obj_bits_api (APIType_map2 ty) us - objBitsKO ko) * n"
   shows
-  "pspace_relation (foldr (\<lambda>p ps. ps(p \<mapsto> default_object (APIType_map2 ty) dev us))
+  "pspace_relation (foldr (\<lambda>p ps. ps(p \<mapsto> default_object (APIType_map2 ty) dev us d))
                               (retype_addrs ptr (APIType_map2 ty) n us) (kheap s))
             (foldr (\<lambda>addr. data_map_insert addr ko) (new_cap_addrs m ptr ko) (ksPSpace s'))"
   (is "pspace_relation ?ps ?ps'")
@@ -863,7 +869,7 @@ proof
     "set (retype_addrs ptr (APIType_map2 ty) n us) \<inter> dom (kheap s) = {}"
     by auto
 
-  note pdom = pspace_dom_upd [OF dom_Int_ra, where ko="default_object (APIType_map2 ty) dev us"]
+  note pdom = pspace_dom_upd [OF dom_Int_ra, where ko="default_object (APIType_map2 ty) dev us d"]
 
   have pdom': "dom ?ps' = dom (ksPSpace s') \<union> set (new_cap_addrs m ptr ko)"
     by (clarsimp simp add: foldr_upd_app_if[folded data_map_insert_def]
@@ -934,79 +940,6 @@ lemma foldr_upd_app_if': "foldr (\<lambda>p ps. ps(p := f p)) as g = (\<lambda>x
   apply (rule ext)
   apply simp
   done
-
-lemma etcb_rel_makeObject: "etcb_relation default_etcb makeObject"
-  apply (simp add: etcb_relation_def default_etcb_def)
-  apply (simp add: makeObject_tcb default_priority_def default_domain_def)
-  done
-
-
-lemma ekh_at_tcb_at: "valid_etcbs_2 ekh kh \<Longrightarrow> ekh x = Some y  \<Longrightarrow> \<exists>tcb. kh x = Some (TCB tcb)"
-  apply (simp add: valid_etcbs_2_def
-                   st_tcb_at_kh_def obj_at_kh_def
-                   is_etcb_at'_def obj_at_def)
-  apply force
-  done
-
-lemma default_etcb_default_domain_futz [simp]:
-  "default_etcb\<lparr>tcb_domain := default_domain\<rparr> = default_etcb"
-unfolding default_etcb_def by simp
-
-lemma retype_ekheap_relation:
-  assumes  sr: "ekheap_relation (ekheap s) (ksPSpace s')"
-      and  sr': "pspace_relation (kheap s) (ksPSpace s')"
-      and  vs: "valid_pspace s" "valid_mdb s"
-      and et: "valid_etcbs s"
-      and vs': "pspace_aligned' s'" "pspace_distinct' s'"
-      and  pn: "pspace_no_overlap_range_cover ptr sz s"
-      and pn': "pspace_no_overlap' ptr sz s'"
-      and  ko: "makeObjectKO dev ty = Some ko"
-      and cover: "range_cover ptr sz (obj_bits_api (APIType_map2 ty) us) n"
-      and orr: "obj_relation_retype (default_object (APIType_map2 ty) dev us) ko"
-      and num_r: "m = 2 ^ (obj_bits_api (APIType_map2 ty) us - objBitsKO ko) * n"
-  shows
-  "ekheap_relation (foldr (\<lambda>p ps. ps(p := default_ext (APIType_map2 ty) default_domain))
-                              (retype_addrs ptr (APIType_map2 ty) n us) (ekheap s))
-            (foldr (\<lambda>addr. data_map_insert addr ko) (new_cap_addrs m ptr ko) (ksPSpace s'))"
-  (is "ekheap_relation ?ps ?ps'")
-  proof -
-  have not_unt: "ty \<noteq> Inr (APIObjectType ArchTypes_H.Untyped)"
-     by (rule makeObjectKO_Untyped[OF ko])
-  show ?thesis
-    apply (case_tac "ty \<noteq> Inr (APIObjectType apiobject_type.TCBObject)")
-     apply (insert ko)
-     apply (cut_tac retype_pspace_relation[OF sr' vs vs' pn pn' ko cover orr num_r])
-     apply (simp add: foldr_upd_app_if' foldr_upd_app_if[folded data_map_insert_def])
-     apply (simp add: obj_relation_retype_addrs_eq[OF not_unt num_r orr cover,symmetric])
-     apply (insert sr)
-     apply (clarsimp simp add: ekheap_relation_def
-                      pspace_relation_def default_ext_def cong: if_cong
-                      split: if_split_asm)
-      subgoal by (clarsimp simp add: makeObjectKO_def APIType_map2_def cong: if_cong
-                              split: sum.splits Structures_H.kernel_object.splits
-                                     arch_kernel_object.splits ARM_H.object_type.splits apiobject_type.splits)
-
-     apply (frule ekh_at_tcb_at[OF et])
-     apply (intro impI conjI)
-      apply clarsimp
-      apply (drule_tac x=a in bspec,force)
-      apply (clarsimp simp add: tcb_relation_cut_def split: if_split_asm)
-       apply (case_tac ko,simp_all)
-       apply (clarsimp simp add: makeObjectKO_def cong: if_cong split: sum.splits Structures_H.kernel_object.splits
-                                 arch_kernel_object.splits ARM_H.object_type.splits
-                                 apiobject_type.splits if_split_asm)
-      apply (drule_tac x=xa in bspec,simp)
-      subgoal by force
-     subgoal by force
-    apply (simp add: foldr_upd_app_if' foldr_upd_app_if[folded data_map_insert_def])
-    apply (simp add: obj_relation_retype_addrs_eq[OF not_unt num_r orr cover,symmetric])
-    apply (clarsimp simp add: APIType_map2_def default_ext_def ekheap_relation_def
-           default_object_def makeObjectKO_def etcb_rel_makeObject
-           cong: if_cong
-           split: if_split_asm)
-    apply force
-  done
-qed
 
 lemma pspace_no_overlapD':
   "\<lbrakk> ksPSpace s x = Some ko; pspace_no_overlap' p bits s \<rbrakk>
@@ -1198,7 +1131,7 @@ lemma retype_ksPSpace_dom_same:
   fixes x v
   assumes   vs': "pspace_aligned' s'" "pspace_distinct' s'"
   assumes   pn': "pspace_no_overlap' ptr sz s'"
-  assumes    ko: "makeObjectKO dev ty = Some ko"
+  assumes    ko: "makeObjectKO dev d ty = Some ko"
   assumes cover: "range_cover ptr sz (obj_bits_api (APIType_map2 ty) us) n"
   assumes num_r: "m = 2 ^ (obj_bits_api (APIType_map2 ty) us - objBitsKO ko) * n"
   shows
@@ -1237,7 +1170,7 @@ qed
 lemma retype_tcbSchedPrevs_of:
   assumes   vs': "pspace_aligned' s'" "pspace_distinct' s'"
   assumes   pn': "pspace_no_overlap' ptr sz s'"
-  assumes    ko: "makeObjectKO dev ty = Some ko"
+  assumes    ko: "makeObjectKO dev d ty = Some ko"
   assumes cover: "range_cover ptr sz (obj_bits_api (APIType_map2 ty) us) n"
   assumes num_r: "m = 2 ^ (obj_bits_api (APIType_map2 ty) us - objBitsKO ko) * n"
   shows
@@ -1263,7 +1196,7 @@ qed
 lemma retype_tcbSchedNexts_of:
   assumes   vs': "pspace_aligned' s'" "pspace_distinct' s'"
   assumes   pn': "pspace_no_overlap' ptr sz s'"
-  assumes    ko: "makeObjectKO dev ty = Some ko"
+  assumes    ko: "makeObjectKO dev d ty = Some ko"
   assumes cover: "range_cover ptr sz (obj_bits_api (APIType_map2 ty) us) n"
   assumes num_r: "m = 2 ^ (obj_bits_api (APIType_map2 ty) us - objBitsKO ko) * n"
   shows
@@ -1289,7 +1222,7 @@ qed
 lemma retype_inQ:
   assumes   vs': "pspace_aligned' s'" "pspace_distinct' s'"
   assumes   pn': "pspace_no_overlap' ptr sz s'"
-  assumes    ko: "makeObjectKO dev ty = Some ko"
+  assumes    ko: "makeObjectKO dev d ty = Some ko"
   assumes cover: "range_cover ptr sz (obj_bits_api (APIType_map2 ty) us) n"
   assumes num_r: "m = 2 ^ (obj_bits_api (APIType_map2 ty) us - objBitsKO ko) * n"
   shows
@@ -1318,12 +1251,12 @@ lemma retype_ready_queues_relation:
   assumes  rlqr: "ready_queues_relation s s'"
   assumes   vs': "pspace_aligned' s'" "pspace_distinct' s'"
   assumes   pn': "pspace_no_overlap' ptr sz s'"
-  assumes    ko: "makeObjectKO dev ty = Some ko"
+  assumes    ko: "makeObjectKO dev d ty = Some ko"
   assumes cover: "range_cover ptr sz (obj_bits_api (APIType_map2 ty) us) n"
   assumes num_r: "m = 2 ^ (obj_bits_api (APIType_map2 ty) us - objBitsKO ko) * n"
   shows
     "ready_queues_relation
-       (s \<lparr>kheap := foldr (\<lambda>p. data_map_insert p (default_object (APIType_map2 ty) dev us))
+       (s \<lparr>kheap := foldr (\<lambda>p. data_map_insert p (default_object (APIType_map2 ty) dev us d))
                                              (retype_addrs ptr (APIType_map2 ty) n us) (kheap s)\<rparr>)
        (s'\<lparr>ksPSpace := foldr (\<lambda>addr. data_map_insert addr ko) (new_cap_addrs m ptr ko) (ksPSpace s')\<rparr>)"
   using rlqr
@@ -1336,31 +1269,28 @@ lemma retype_state_relation:
   notes data_map_insert_def[simp del]
   assumes  sr:   "(s, s') \<in> state_relation"
       and  vs:   "valid_pspace s" "valid_mdb s"
-      and  et:   "valid_etcbs s" "valid_list s"
+      and  et:   "valid_list s"
       and vs':   "pspace_aligned' s'" "pspace_distinct' s'"
       and  pn:   "pspace_no_overlap_range_cover ptr sz s"
       and pn':   "pspace_no_overlap' ptr sz s'"
       and cover: "range_cover ptr sz (obj_bits_api (APIType_map2 ty) us) n"
-      and  ko:   "makeObjectKO dev ty = Some ko"
+      and  ko:   "makeObjectKO dev d ty = Some ko"
       and api:   "obj_bits_api (APIType_map2 ty) us \<le> sz"
-      and orr:   "obj_relation_retype (default_object (APIType_map2 ty) dev us) ko"
+      and orr:   "obj_relation_retype (default_object (APIType_map2 ty) dev us d) ko"
       and num_r: "m = 2 ^ (obj_bits_api (APIType_map2 ty) us - objBitsKO ko) * n"
   shows
-  "(ekheap_update
-              (\<lambda>_. foldr (\<lambda>p ekh a. if a = p then default_ext (APIType_map2 ty) default_domain else ekh a)
-                    (retype_addrs ptr (APIType_map2 ty) n us) (ekheap s))
-            s
-           \<lparr>kheap :=
-              foldr (\<lambda>p. data_map_insert p (default_object (APIType_map2 ty) dev us))
+  "(s \<lparr>kheap :=
+              foldr (\<lambda>p. data_map_insert p (default_object (APIType_map2 ty) dev us d))
                (retype_addrs ptr (APIType_map2 ty) n us) (kheap s)\<rparr>,
            update_gs (APIType_map2 ty) us (set (retype_addrs ptr (APIType_map2 ty) n us))
             (s'\<lparr>ksPSpace :=
                   foldr (\<lambda>addr. data_map_insert addr ko) (new_cap_addrs m ptr ko)
                    (ksPSpace s')\<rparr>))
           \<in> state_relation"
-  (is "(ekheap_update (\<lambda>_. ?eps) s\<lparr>kheap := ?ps\<rparr>, update_gs _ _ _ (s'\<lparr>ksPSpace := ?ps'\<rparr>))
+  (is "(s\<lparr>kheap := ?ps\<rparr>, update_gs _ _ _ (s'\<lparr>ksPSpace := ?ps'\<rparr>))
        \<in> state_relation")
-  proof (rule state_relation_null_filterE[OF sr refl _ _ _ _ _ _ _ _ vs'], simp_all add: trans_state_update[symmetric] del: trans_state_update)
+  proof (rule state_relation_null_filterE[OF sr refl _ _ _ _ _ _ _ vs'],
+         simp_all add: trans_state_update[symmetric] del: trans_state_update)
 
   have cover':"range_cover ptr sz (objBitsKO ko) m"
     by (rule range_cover_rel[OF cover objBits_le_obj_bits_api[OF ko] num_r])
@@ -1425,12 +1355,6 @@ lemma retype_state_relation:
   thus "pspace_relation ?ps ?ps'"
     by (rule retype_pspace_relation [OF _ vs vs' pn pn' ko cover orr num_r,
         folded data_map_insert_def])
-
-  have "ekheap_relation (ekheap (s)) (ksPSpace s')"
-  using sr by (simp add: state_relation_def)
-
-  thus "ekheap_relation ?eps ?ps'"
-    by (fold fun_upd_apply) (rule retype_ekheap_relation[OF _ pspr vs et(1) vs' pn pn' ko cover orr num_r])
 
   have pn2: "\<forall>a\<in>set ?al. kheap s a = None"
     by (rule ccontr) (clarsimp simp: pspace_no_overlapD1[OF pn _ cover vs(1)])
@@ -1578,210 +1502,6 @@ lemma objBitsKO_gt_0: "0 < objBitsKO ko"
     apply (simp_all add:archObjSize_def pageBits_def pteBits_def pdeBits_def)
   done
 
-lemma kheap_ekheap_double_gets:
-  "(\<And>rv erv rv'. \<lbrakk>pspace_relation rv rv'; ekheap_relation erv rv'\<rbrakk>
-                 \<Longrightarrow> corres r (R rv erv) (R' rv') (b rv erv) (d rv')) \<Longrightarrow>
-   corres r (\<lambda>s. R (kheap s) (ekheap s) s) (\<lambda>s. R' (ksPSpace s) s)
-          (do x \<leftarrow> gets kheap; xa \<leftarrow> gets ekheap; b x xa od) (gets ksPSpace >>= d)"
-  apply (rule corres_symb_exec_l)
-     apply (rule corres_guard_imp)
-       apply (rule_tac r'= "\<lambda>erv rv'. ekheap_relation erv rv' \<and> pspace_relation x rv'"
-               in corres_split)
-          apply (subst corres_gets[where P="\<lambda>s. x = kheap s" and P'=\<top>])
-          apply clarsimp
-          apply (simp add: state_relation_def)
-         apply clarsimp
-         apply assumption
-        apply (wp gets_exs_valid | simp)+
-  done
-
-(*
-
-Split out the extended operation that sets the etcb domains.
-
-This allows the existing corres proofs in this file to more-or-less go
-through as they stand.
-
-A more principled fix would be to change the abstract spec and
-generalise init_arch_objects to initialise other object types.
-
-*)
-
-definition retype_region2_ext :: "obj_ref list \<Rightarrow> Structures_A.apiobject_type \<Rightarrow> unit det_ext_monad" where
-  "retype_region2_ext ptrs type \<equiv> modify (\<lambda>s. ekheap_update (foldr (\<lambda>p ekh. (ekh(p := default_ext type default_domain))) ptrs) s)"
-
-crunch retype_region2_ext
-  for all_but_exst[wp]: "all_but_exst P"
-crunch retype_region2_ext
-  for (empty_fail) empty_fail[wp]
-
-end
-
-interpretation retype_region2_ext_extended: is_extended "retype_region2_ext ptrs type"
-  by (unfold_locales; wp)
-
-context begin interpretation Arch . (*FIXME: arch-split*)
-
-definition
- "retype_region2_extra_ext ptrs type \<equiv>
-     when (type = Structures_A.TCBObject) (do
-       cdom \<leftarrow> gets cur_domain;
-       mapM_x (ethread_set (\<lambda>tcb. tcb\<lparr>tcb_domain := cdom\<rparr>)) ptrs
-      od)"
-
-crunch retype_region2_extra_ext
-  for all_but_exst[wp]: "all_but_exst P" (wp: mapM_x_wp)
-crunch retype_region2_extra_ext
-  for (empty_fail) empty_fail[wp] (wp: mapM_x_wp)
-
-end
-
-interpretation retype_region2_extra_ext_extended: is_extended "retype_region2_extra_ext ptrs type"
-  by (unfold_locales; wp)
-
-context begin interpretation Arch . (*FIXME: arch-split*)
-
-definition
-  retype_region2 :: "obj_ref \<Rightarrow> nat \<Rightarrow> nat \<Rightarrow> Structures_A.apiobject_type \<Rightarrow> bool \<Rightarrow> (obj_ref list,'z::state_ext) s_monad"
-where
-  "retype_region2 ptr numObjects o_bits type dev \<equiv> do
-    obj_size \<leftarrow> return $ 2 ^ obj_bits_api type o_bits;
-    ptrs \<leftarrow> return $ map (\<lambda>p. ptr_add ptr (p * obj_size)) [0..< numObjects];
-    when (type \<noteq> Structures_A.Untyped) (do
-      kh \<leftarrow> gets kheap;
-      kh' \<leftarrow> return $ foldr (\<lambda>p kh. kh(p \<mapsto> default_object type dev o_bits)) ptrs kh;
-      do_extended_op (retype_region2_ext ptrs type);
-      modify $ kheap_update (K kh')
-    od);
-    return $ ptrs
-  od"
-
-lemma retype_region_ext_modify_kheap_futz:
-  "(retype_region2_extra_ext ptrs type :: (unit, det_ext) s_monad) >>= (\<lambda>_. modify (kheap_update f))
- = (modify (kheap_update f) >>= (\<lambda>_. retype_region2_extra_ext ptrs type))"
-  apply (clarsimp simp: retype_region_ext_def retype_region2_ext_def retype_region2_extra_ext_def when_def bind_assoc)
-  apply (subst oblivious_modify_swap)
-   defer
-   apply (simp add: bind_assoc)
-  apply (rule oblivious_bind)
-  apply simp
-  apply (rule oblivious_mapM_x)
-  apply (clarsimp simp: ethread_set_def set_eobject_def)
-  apply (rule oblivious_bind)
-   apply (simp add: gets_the_def)
-   apply (rule oblivious_bind)
-    apply (clarsimp simp: get_etcb_def)
-    apply simp
-   apply (simp add: modify_def[symmetric])
-done
-
-lemmas retype_region_ext_modify_kheap_futz' =
-  fun_cong[OF arg_cong[where f=Nondet_Monad.bind,
-           OF retype_region_ext_modify_kheap_futz[symmetric]], simplified bind_assoc]
-
-lemma foldr_upd_app_if_eta_futz:
-  "foldr (\<lambda>p ps. ps(p \<mapsto> f p)) as = (\<lambda>g x. if x \<in> set as then Some (f x) else g x)"
-apply (rule ext)
-apply (rule foldr_upd_app_if)
-done
-
-lemma modify_ekheap_update_comp_futz:
-  "modify (ekheap_update (f \<circ> g)) = modify (ekheap_update g) >>= (K (modify (ekheap_update f)))"
-by (simp add: o_def modify_def bind_def gets_def get_def put_def)
-
-lemma mapM_x_modify_futz:
-  assumes "\<forall>ptr\<in>set ptrs. ekheap s ptr \<noteq> None"
-  shows "mapM_x (ethread_set F) (rev ptrs) s
-       = modify (ekheap_update (foldr (\<lambda>p ekh. ekh(p := Some (F (the (ekh p))))) ptrs)) s" (is "?lhs ptrs s = ?rhs ptrs s")
-using assms
-proof(induct ptrs arbitrary: s)
-  case Nil thus ?case by (simp add: mapM_x_Nil return_def simpler_modify_def)
-next
-  case (Cons ptr ptrs s)
-  have "?rhs (ptr # ptrs) s
-      = (do modify (ekheap_update (foldr (\<lambda>p ekh. ekh(p \<mapsto> F (the (ekh p)))) ptrs));
-            modify (ekheap_update (\<lambda>ekh. ekh(ptr \<mapsto> F (the (ekh ptr)))))
-        od) s"
-    by (simp only: foldr_Cons modify_ekheap_update_comp_futz) simp
-  also have "... = (do ?lhs ptrs;
-                      modify (ekheap_update (\<lambda>ekh. ekh(ptr \<mapsto> F (the (ekh ptr)))))
-                    od) s"
-    apply (rule monad_eq_split_tail)
-     apply simp
-    apply (rule Cons.hyps[symmetric])
-    using Cons.prems
-    apply force
-    done
-  also have "... = ?lhs (ptr # ptrs) s"
-    apply (simp add: mapM_x_append mapM_x_singleton)
-    apply (rule monad_eq_split2[OF refl, where
-                 P="\<lambda>s. \<forall>ptr\<in>set (ptr # ptrs). ekheap s ptr \<noteq> None"
-             and Q="\<lambda>_ s. ekheap s ptr \<noteq> None"])
-      apply (simp add: ethread_set_def
-                       assert_opt_def get_etcb_def gets_the_def gets_def get_def modify_def put_def set_eobject_def
-                       bind_def fail_def return_def split_def
-                split: option.splits)
-     apply ((wp mapM_x_wp[OF _ subset_refl] | simp add: ethread_set_def set_eobject_def)+)[1]
-    using Cons.prems
-    apply force
-    done
-  finally show ?case by (rule sym)
-qed
-
-lemma awkward_fold_futz:
-  "fold (\<lambda>p ekh. ekh(p \<mapsto> the (ekh p)\<lparr>tcb_domain := cur_domain s\<rparr>)) ptrs ekh
- = (\<lambda>x. if x \<in> set ptrs then Some ((the (ekh x))\<lparr>tcb_domain := cur_domain s\<rparr>) else ekh x)"
-by (induct ptrs arbitrary: ekh) (simp_all add: fun_eq_iff)
-
-lemma retype_region2_ext_retype_region_ext_futz:
-  "retype_region2_ext ptrs type >>= (\<lambda>_. retype_region2_extra_ext ptrs type)
- = retype_region_ext ptrs type"
-proof(cases type)
-  case TCBObject
-  have complete_futz:
-    "\<And>F x. modify (ekheap_update (\<lambda>_. F (cur_domain x) (ekheap x))) x = modify (ekheap_update (\<lambda>ekh. F (cur_domain x) ekh)) x"
-    by (simp add: modify_def get_def get_etcb_def put_def bind_def return_def)
-  have second_futz:
-  "\<And>f G.
-   do modify (ekheap_update f);
-      cdom \<leftarrow> gets (\<lambda>s. cur_domain s);
-      G cdom
-   od =
-   do cdom \<leftarrow> gets (\<lambda>s. cur_domain s);
-      modify (ekheap_update f);
-      G cdom
-   od"
-    by (simp add: bind_def gets_def get_def return_def simpler_modify_def)
-  from TCBObject show ?thesis
-    apply (clarsimp simp: retype_region_ext_def retype_region2_ext_def retype_region2_extra_ext_def when_def bind_assoc)
-    apply (clarsimp simp: exec_gets fun_eq_iff)
-    apply (subst complete_futz)
-    apply (simp add: second_futz[simplified] exec_gets)
-    apply (simp add: default_ext_def exec_modify)
-    apply (subst mapM_x_modify_futz[where ptrs="rev ptrs", simplified])
-     apply (simp add: foldr_upd_app_if_eta_futz)
-    apply (simp add: modify_def exec_get put_def o_def)
-    apply (simp add: foldr_upd_app_if_eta_futz foldr_conv_fold awkward_fold_futz)
-    apply (simp cong: if_cong)
-    done
-qed (auto simp: fun_eq_iff retype_region_ext_def retype_region2_ext_def retype_region2_extra_ext_def
-                put_def gets_def get_def bind_def return_def mk_ef_def modify_def foldr_upd_app_if' when_def default_ext_def)
-
-lemma retype_region2_ext_retype_region:
-  "(retype_region ptr numObjects o_bits type dev :: (obj_ref list, det_ext) s_monad)
- = (do ptrs \<leftarrow> retype_region2 ptr numObjects o_bits type dev;
-       retype_region2_extra_ext ptrs type;
-       return ptrs
-    od)"
-apply (clarsimp simp: retype_region_def retype_region2_def when_def bind_assoc)
- apply safe
- defer
- apply (simp add: retype_region2_extra_ext_def)
-apply (subst retype_region_ext_modify_kheap_futz'[simplified bind_assoc])
-apply (subst retype_region2_ext_retype_region_ext_futz[symmetric])
-apply (simp add: bind_assoc)
-done
-
 lemma getObject_tcb_gets:
   "getObject addr >>= (\<lambda>x::tcb. gets proj >>= (\<lambda>y. G x y))
  = gets proj >>= (\<lambda>y. getObject addr >>= (\<lambda>x. G x y))"
@@ -1824,37 +1544,26 @@ next
     done
 qed
 
-(*
-
-The existing proof continues below.
-
-*)
-
-lemma modify_ekheap_update_ekheap:
-  "modify (\<lambda>s. ekheap_update f s) = do s \<leftarrow> gets ekheap; modify (\<lambda>s'. s'\<lparr>ekheap := f s\<rparr>) od"
-by (simp add: modify_def gets_def get_def put_def bind_def return_def split_def fun_eq_iff)
-
 lemma corres_retype':
   assumes    not_zero: "n \<noteq> 0"
   and         aligned: "is_aligned ptr (objBitsKO ko + gbits)"
-  and    obj_bits_api: "obj_bits_api (APIType_map2 ty) us =
-                        objBitsKO ko + gbits"
-  and           check: "(sz < obj_bits_api (APIType_map2 ty)  us)
-                           = (sz < objBitsKO ko + gbits)"
+  and    obj_bits_api: "obj_bits_api (APIType_map2 ty) us = objBitsKO ko + gbits"
+  and           check: "(sz < obj_bits_api (APIType_map2 ty) us) = (sz < objBitsKO ko + gbits)"
   and             usv: "APIType_map2 ty = Structures_A.CapTableObject \<Longrightarrow> 0 < us"
-  and              ko: "makeObjectKO dev ty = Some ko"
+  and              ko: "makeObjectKO dev d ty = Some ko"
   and             orr: "obj_bits_api (APIType_map2 ty) us \<le> sz \<Longrightarrow>
-                        obj_relation_retype
-                          (default_object (APIType_map2 ty) dev us) ko"
+                        obj_relation_retype (default_object (APIType_map2 ty) dev us d) ko"
   and           cover: "range_cover ptr sz (obj_bits_api (APIType_map2 ty) us) n"
   shows "corres (\<lambda>rv rv'. rv' = g rv)
-  (\<lambda>s. valid_pspace s \<and> pspace_no_overlap_range_cover ptr sz s
-     \<and> valid_mdb s \<and> valid_etcbs s \<and> valid_list s)
-  (\<lambda>s. pspace_aligned' s \<and> pspace_distinct' s \<and> pspace_no_overlap' ptr sz s)
-  (retype_region2 ptr n us (APIType_map2 ty) dev)
-  (do addrs \<leftarrow> createObjects ptr n ko gbits;
-      _ \<leftarrow> modify (update_gs (APIType_map2 ty) us (set addrs));
-      return (g addrs) od)"
+                (\<lambda>s. valid_pspace s \<and> pspace_no_overlap_range_cover ptr sz s
+                     \<and> valid_mdb s \<and> valid_list s)
+                (\<lambda>s. pspace_aligned' s \<and> pspace_distinct' s \<and> pspace_no_overlap' ptr sz s
+                      \<and> (ty = Inr (APIObjectType TCBObject) \<longrightarrow> d = ksCurDomain s))
+                (retype_region ptr n us (APIType_map2 ty) dev)
+                (do addrs \<leftarrow> createObjects ptr n ko gbits;
+                    _ \<leftarrow> modify (update_gs (APIType_map2 ty) us (set addrs));
+                    return (g addrs)
+                 od)"
   (is "corres ?r ?P ?P' ?C ?A")
 proof -
   note data_map_insert_def[simp del]
@@ -1932,7 +1641,7 @@ proof -
   have al': "is_aligned ptr (obj_bits_api (APIType_map2 ty) us)"
      by (simp add: obj_bits_api ko)
   show ?thesis
-  apply (simp add: when_def retype_region2_def createObjects'_def
+  apply (simp add: when_def retype_region_def createObjects'_def
                    createObjects_def aligned obj_bits_api[symmetric]
                    ko[symmetric] al' shiftl_t2n data_map_insert_def[symmetric]
                    is_aligned_mask[symmetric] split_def unless_def
@@ -1940,80 +1649,90 @@ proof -
         split del: if_split)
   apply (subst retype_addrs_fold)+
   apply (subst if_P)
-   using ko
-   apply (clarsimp simp: makeObjectKO_def)
-  apply (simp add: bind_assoc retype_region2_ext_def)
-  apply (rule corres_guard_imp)
-    apply (subst modify_ekheap_update_ekheap)
-    apply (simp only: bind_assoc)
-    apply (rule kheap_ekheap_double_gets)
-    apply (rule corres_symb_exec_r)
-       apply (simp add: not_less modify_modify bind_assoc[symmetric]
-                          obj_bits_api[symmetric] shiftl_t2n upto_enum_red'
+    using ko
+    apply (clarsimp simp: makeObjectKO_def)
+   apply (simp add: bind_assoc)
+   apply (rule corres_guard_imp)
+     apply (rule_tac r'=pspace_relation in corres_underlying_split)
+        apply (clarsimp dest!: state_relation_pspace_relation)
+       apply (simp add: gets_def)
+       apply (rule corres_symb_exec_l[rotated])
+          apply (rule exs_valid_get)
+         apply (rule get_sp)
+        apply (simp add: get_def no_fail_def)
+       apply (rule corres_symb_exec_r)
+          apply (simp add: not_less modify_modify bind_assoc[symmetric]
+                           obj_bits_api[symmetric] shiftl_t2n upto_enum_red'
                            range_cover.unat_of_nat_n[OF cover])
-       apply (rule corres_split_nor[OF _ corres_trivial])
-          apply (rename_tac x eps ps)
-          apply (rule_tac P="\<lambda>s. x = kheap s \<and> eps = ekheap (s) \<and> ?P s" and
-                          P'="\<lambda>s. ps = ksPSpace s \<and> ?P' s" in corres_modify)
-          apply (simp add: set_retype_addrs_fold new_caps_adds_fold)
-          apply (erule retype_state_relation[OF _ _ _ _ _ _ _ _ _ cover _ _ orr],
-                 simp_all add: ko not_zero obj_bits_api
-                               bound[simplified obj_bits_api ko])[1]
-         apply (clarsimp simp: retype_addrs_fold[symmetric] ptr_add_def upto_enum_red' not_zero'
-                               range_cover.unat_of_nat_n[OF cover] word_le_sub1
-                         simp del: word_of_nat_eq_0_iff)
-         apply (rule_tac f=g in arg_cong)
-         apply clarsimp
-        apply wp+
-      apply (clarsimp split: option.splits)
-      apply (intro conjI impI)
-       apply (clarsimp|wp)+
-     apply (clarsimp split: option.splits)
-     apply wpsimp
-    apply (clarsimp split: option.splits)
-    apply (intro conjI impI)
-     apply wp
-    apply (clarsimp simp:lookupAround2_char1)
-    apply wp
-    apply (clarsimp simp: obj_bits_api ko)
-    apply (drule(1) pspace_no_overlap_disjoint')
-    apply (rule_tac x1 = a in ccontr[OF in_empty_interE])
-      apply simp
-     apply (clarsimp simp: not_less shiftL_nat)
-     apply (erule order_trans)
-     apply (subst p_assoc_help)
-     apply (subst word_plus_and_or_coroll2[symmetric,where w = "mask sz"])
-     apply (subst add.commute)
-     apply (subst add.assoc)
-     apply (rule word_plus_mono_right)
-      using cover
-      apply -
-      apply (rule iffD2[OF word_le_nat_alt])
-      apply (subst word_of_nat_minus)
-       using not_zero
-       apply simp
-      apply (rule le_trans[OF unat_plus_gt])
-      apply simp
-      apply (subst unat_minus_one)
-       apply (subst mult.commute)
-       apply (rule word_power_nonzero_32)
-         apply (rule of_nat_less_pow_32[OF n_estimate])
-         apply (simp add:word_bits_def objBitsKO_gt_0 ko)
-        apply (simp add:range_cover_def obj_bits_api ko word_bits_def)
-       apply (cut_tac not_zero',clarsimp simp:ko)
-      apply(clarsimp simp:field_simps ko)
-      apply (subst unat_sub[OF word_1_le_power])
-       apply (simp add:range_cover_def)
-      apply (subst diff_add_assoc[symmetric])
-       apply (cut_tac unat_of_nat_n',simp add:ko)
-      apply (clarsimp simp: obj_bits_api ko)
-      apply (rule diff_le_mono)
-      apply (frule range_cover.range_cover_compare_bound)
-      apply (cut_tac obj_bits_api unat_of_nat_shift')
-      apply (clarsimp simp:add.commute range_cover_def ko)
-     apply (rule is_aligned_no_wrap'[OF is_aligned_neg_mask,OF le_refl ])
-     apply (simp add:range_cover_def domI)+
-  done
+          apply (rule corres_guard_imp)
+            apply (rule corres_split_nor[OF _ corres_trivial])
+               apply (rename_tac ps ps' sa)
+               apply (rule_tac P="\<lambda>s. ps = kheap s \<and> sa = s \<and> ?P s" and
+                               P'="\<lambda>s. ps' = ksPSpace s \<and> ?P' s" in corres_modify)
+               apply(frule curdomain_relation[THEN sym])
+               apply (simp add: set_retype_addrs_fold new_caps_adds_fold)
+               apply (drule retype_state_relation[OF _ _ _ _ _ _ _ _ cover _ _ orr],
+                      simp_all add: ko not_zero obj_bits_api
+                                    bound[simplified obj_bits_api ko])[1]
+               apply (cases ty; simp; rename_tac tp; case_tac tp;
+                      clarsimp simp: default_object_def APIType_map2_def
+                              split: arch_kernel_object.splits apiobject_type.splits)
+              apply (clarsimp simp: retype_addrs_fold[symmetric] ptr_add_def upto_enum_red' not_zero'
+                                    range_cover.unat_of_nat_n[OF cover] word_le_sub1)
+              apply (rule_tac f=g in arg_cong)
+              apply clarsimp
+             apply wpsimp+
+           apply simp+
+         apply (clarsimp split: option.splits)
+         apply (intro conjI impI)
+          apply (clarsimp|wp)+
+        apply (clarsimp split: option.splits)
+        apply wpsimp
+       apply (clarsimp split: option.splits)
+       apply (intro conjI impI)
+        apply wp
+       apply (clarsimp simp:lookupAround2_char1)
+       apply wp
+       apply (clarsimp simp: obj_bits_api ko)
+       apply (drule(1) pspace_no_overlap_disjoint')
+       apply (rule_tac x1 = a in ccontr[OF in_empty_interE])
+         apply simp
+        apply (clarsimp simp: not_less shiftL_nat)
+        apply (erule order_trans)
+        apply (subst p_assoc_help)
+        apply (subst word_plus_and_or_coroll2[symmetric,where w = "mask sz"])
+        apply (subst add.commute)
+        apply (subst add.assoc)
+        apply (rule word_plus_mono_right)
+         using cover
+         apply -
+         apply (rule iffD2[OF word_le_nat_alt])
+         apply (subst word_of_nat_minus)
+          using not_zero
+          apply simp
+         apply (rule le_trans[OF unat_plus_gt])
+         apply simp
+         apply (subst unat_minus_one)
+          apply (subst mult.commute)
+          apply (rule word_power_nonzero_32)
+            apply (rule of_nat_less_pow_32[OF n_estimate])
+            apply (simp add:word_bits_def objBitsKO_gt_0 ko)
+           apply (simp add:range_cover_def obj_bits_api ko word_bits_def)
+          apply (cut_tac not_zero',clarsimp simp:ko)
+         apply(clarsimp simp:field_simps ko)
+         apply (subst unat_sub[OF word_1_le_power])
+          apply (simp add:range_cover_def)
+         apply (subst diff_add_assoc[symmetric])
+          apply (cut_tac unat_of_nat_n',simp add:ko)
+         apply (clarsimp simp: obj_bits_api ko)
+         apply (rule diff_le_mono)
+         apply (frule range_cover.range_cover_compare_bound)
+         apply (cut_tac obj_bits_api unat_of_nat_shift')
+         apply (clarsimp simp:add.commute range_cover_def ko)
+        apply (rule is_aligned_no_wrap'[OF is_aligned_neg_mask,OF le_refl ])
+        apply (simp add:range_cover_def domI)+
+      apply wpsimp+
+   done
 qed
 
 lemma createObjects_corres':
@@ -2484,15 +2203,16 @@ proof -
                              fromIntegral_def toInteger_nat fromInteger_nat APIType_capBits_def curDomain_def
                       split: ARM_H.object_type.splits)
         apply (wp mapM_x_wp' hoare_vcg_const_Ball_lift)+
-        apply (rule hoare_post_imp)
-         prefer 2
-         apply (rule createObjects_obj_at [where 'a = "tcb",OF _ not_0])
-          using cover
-          apply (clarsimp simp: ARM_H.toAPIType_def APIType_capBits_def objBits_simps
-                         split: ARM_H.object_type.splits)
-         apply (simp add: projectKOs)
-        apply (clarsimp simp: valid_cap'_def objBits_simps)
-        apply (fastforce intro: capAligned_tcbI)
+         apply (rule hoare_post_imp)
+          prefer 2
+          apply (rule createObjects_obj_at [where 'a = "tcb",OF _ not_0])
+           using cover
+           apply (clarsimp simp: ARM_H.toAPIType_def APIType_capBits_def objBits_simps
+                          split: ARM_H.object_type.splits)
+           apply (simp add: projectKOs)+
+         apply (clarsimp simp: valid_cap'_def objBits_simps)
+         apply (fastforce intro: capAligned_tcbI)
+        apply wp
         done
     next
       case EndpointObject with Some cover ct show ?thesis
@@ -2573,7 +2293,7 @@ lemma other_objs_default_relation:
   "\<lbrakk> case ty of Structures_A.EndpointObject \<Rightarrow> ko = injectKO (makeObject :: endpoint)
              | Structures_A.NotificationObject \<Rightarrow> ko = injectKO (makeObject :: Structures_H.notification)
              | _ \<Rightarrow> False \<rbrakk> \<Longrightarrow>
-    obj_relation_retype (default_object ty dev n) ko"
+    obj_relation_retype (default_object ty dev n d) ko"
   apply (rule obj_relation_retype_other_obj)
    apply (clarsimp simp: default_object_def
                          is_other_obj_relation_type_def
@@ -2593,15 +2313,17 @@ lemma other_objs_default_relation:
   done
 
 lemma tcb_relation_retype:
-  "obj_relation_retype (default_object Structures_A.TCBObject dev n) (KOTCB makeObject)"
-  by (clarsimp simp: default_object_def obj_relation_retype_def tcb_relation_def default_tcb_def
+  "obj_relation_retype (default_object Structures_A.TCBObject dev n d)
+                       (KOTCB (tcbDomain_update (\<lambda>_. d) makeObject))"
+  by (clarsimp simp: tcb_relation_cut_def default_object_def obj_relation_retype_def
+                     tcb_relation_def default_tcb_def
                      makeObject_tcb makeObject_cte new_context_def newContext_def
-                     fault_rel_optionation_def initContext_def default_arch_tcb_def newArchTCB_def
-                     arch_tcb_relation_def objBits_simps' tcb_relation_cut_def)
+                     fault_rel_optionation_def initContext_def default_priority_def
+                     default_arch_tcb_def newArchTCB_def arch_tcb_relation_def objBits_simps')
 
 lemma captable_relation_retype:
   "n < word_bits \<Longrightarrow>
-   obj_relation_retype (default_object Structures_A.CapTableObject dev n) (KOCTE makeObject)"
+   obj_relation_retype (default_object Structures_A.CapTableObject dev n d) (KOCTE makeObject)"
   apply (clarsimp simp: obj_relation_retype_def default_object_def
                         wf_empty_bits objBits_simps'
                         dom_empty_cnode ex_with_length cte_level_bits_def)
@@ -2619,7 +2341,7 @@ lemma captable_relation_retype:
   done
 
 lemma pagetable_relation_retype:
-  "obj_relation_retype (default_object (ArchObject PageTableObj) dev n)
+  "obj_relation_retype (default_object (ArchObject PageTableObj) dev n d)
                        (KOArch (KOPTE makeObject))"
   apply (simp add: default_object_def default_arch_object_def
                    makeObject_pte obj_relation_retype_def
@@ -2633,7 +2355,7 @@ lemma pagetable_relation_retype:
   done
 
 lemma pagedirectory_relation_retype:
-  "obj_relation_retype (default_object (ArchObject PageDirectoryObj) dev n)
+  "obj_relation_retype (default_object (ArchObject PageDirectoryObj) dev n d)
                        (KOArch (KOPDE makeObject))"
   apply (simp add: default_object_def default_arch_object_def
                    makeObject_pde obj_relation_retype_def
@@ -2650,20 +2372,21 @@ lemmas makeObjectKO_simps = makeObjectKO_def[split_simps ARM_H.object_type.split
  apiobject_type.split sum.split kernel_object.split ]
 
 lemma corres_retype:
-  assumes         not_zero: "n \<noteq> 0"
+  assumes    not_zero: "n \<noteq> 0"
   and         aligned: "is_aligned ptr (objBitsKO ko + gbits)"
   and    obj_bits_api: "obj_bits_api (APIType_map2 ty) us = objBitsKO ko + gbits"
   and              tp: "APIType_map2 ty \<in> no_gs_types"
-  and              ko: "makeObjectKO dev ty = Some ko"
+  and              ko: "makeObjectKO dev d ty = Some ko"
   and             orr: "obj_bits_api (APIType_map2 ty) us \<le> sz \<Longrightarrow>
-                        obj_relation_retype (default_object (APIType_map2 ty) dev us) ko"
+                        obj_relation_retype (default_object (APIType_map2 ty) dev us d) ko"
   and           cover: "range_cover ptr sz (obj_bits_api (APIType_map2 ty) us) n"
   shows "corres (=)
   (\<lambda>s. valid_pspace s \<and> pspace_no_overlap_range_cover ptr sz s
-     \<and> valid_mdb s \<and> valid_etcbs s \<and> valid_list s)
+     \<and> valid_mdb s \<and> valid_list s)
   (\<lambda>s. pspace_aligned' s \<and> pspace_distinct' s \<and> pspace_no_overlap' ptr sz s
-       \<and> (\<exists>val. ko = injectKO val))
-  (retype_region2 ptr n us (APIType_map2 ty) dev) (createObjects ptr n ko gbits)"
+       \<and> (\<exists>val. ko = injectKO val)
+       \<and> (ty = Inr (APIObjectType TCBObject) \<longrightarrow> d = ksCurDomain s))
+  (retype_region ptr n us (APIType_map2 ty) dev) (createObjects ptr n ko gbits)"
   apply (rule corres_guard_imp)
     apply (rule_tac F = "(\<exists>val. ko = injectKO val)" in corres_gen_asm2)
     apply (erule exE)
@@ -2695,7 +2418,7 @@ lemma pde_relation_aligned_eq:
   done
 
 lemma copyGlobalMappings_corres:
-  "corres dc (valid_arch_state and valid_etcbs and pspace_aligned and page_directory_at pd)
+  "corres dc (valid_arch_state and pspace_aligned and page_directory_at pd)
              (valid_arch_state' and page_directory_at' pd)
           (copy_global_mappings pd)
           (copyGlobalMappings pd)"
@@ -2710,8 +2433,7 @@ lemma copyGlobalMappings_corres:
       apply (simp add: liftM_def[symmetric])
       apply (rule_tac S="(=)" and r'=dc
                   and Q="\<lambda>xs s. \<forall>x \<in> set xs. pde_at (global_pd + (x << 2)) s
-                                             \<and> pde_at (pd + (x << 2)) s \<and> pspace_aligned s \<and>
-                                             valid_etcbs s"
+                                             \<and> pde_at (pd + (x << 2)) s \<and> pspace_aligned s"
                   and Q'="\<lambda>xs s. \<forall>x \<in> set xs. pde_at' (global_pd + (x << 2)) s
                                              \<and> pde_at' (pd + (x << 2)) s"
                          in corres_mapM_list_all2, (simp add: pdeBits_def)+)
@@ -3209,7 +2931,8 @@ where
   (isUntypedCap (cteCap cte) \<longrightarrow> usableUntypedRange (cteCap cte) \<inter> S = {})"
 
 lemma createObjects_valid_pspace':
-  assumes  mko: "makeObjectKO dev ty = Some val"
+  assumes  mko: "makeObjectKO dev d ty = Some val"
+  and    max_d: "ty = Inr (APIObjectType TCBObject) \<longrightarrow> d \<le> maxDomain"
   and    not_0: "n \<noteq> 0"
   and    cover: "range_cover ptr sz (objBitsKO val + gbits) n"
   shows "\<lbrace>\<lambda>s. pspace_no_overlap' ptr sz s \<and> valid_pspace' s \<and> caps_no_overlap'' ptr sz s
@@ -3306,7 +3029,7 @@ proof (intro conjI impI)
                    elim!: ranE
                    split: if_split_asm)
      apply (insert sym[OF mko])[1]
-     apply (clarsimp simp: makeObjectKO_def
+     apply (clarsimp simp: makeObjectKO_def max_d
                     split: bool.split_asm sum.split_asm
                            ARM_H.object_type.split_asm
                            apiobject_type.split_asm
@@ -3424,13 +3147,14 @@ abbreviation
  "injectKOS \<equiv> (injectKO :: ('a :: pspace_storable) \<Rightarrow> kernel_object)"
 
 lemma createObjects_valid_pspace_untyped':
-  assumes  mko: "makeObjectKO dev ty = Some val"
+  assumes  mko: "makeObjectKO dev d ty = Some val"
+  and    max_d: "ty = Inr (APIObjectType TCBObject) \<longrightarrow> d \<le> maxDomain"
   and    not_0: "n \<noteq> 0"
   and    cover: "range_cover ptr sz (objBitsKO val + gbits) n"
   shows "\<lbrace>\<lambda>s. pspace_no_overlap' ptr sz s \<and> valid_pspace' s \<and> caps_no_overlap'' ptr sz s \<and> ptr \<noteq> 0
             \<and> caps_overlap_reserved' {ptr .. ptr + of_nat (n * 2^gbits * 2 ^ objBitsKO val ) - 1} s \<rbrace>
   createObjects' ptr n val gbits \<lbrace>\<lambda>r. valid_pspace'\<rbrace>"
-  apply (wp createObjects_valid_pspace' [OF mko not_0 cover])
+  apply (wp createObjects_valid_pspace' [OF mko max_d not_0 cover])
   apply simp
   done
 
@@ -3645,24 +3369,20 @@ lemma createNewCaps_cte_wp_at2:
      createNewCaps ty ptr n objsz dev
    \<lbrace>\<lambda>rv s. P (cte_wp_at' P' p s)\<rbrace>"
   including classic_wp_pre
-  apply (simp add: createNewCaps_def createObjects_def ARM_H.toAPIType_def
-           split del: if_split)
-  apply (case_tac ty; simp add: createNewCaps_def createObjects_def Arch_createNewCaps_def
-                           split del: if_split cong: if_cong)
+  unfolding createNewCaps_def Arch_createNewCaps_def createObjects_def ARM_H.toAPIType_def
+  apply (case_tac ty; simp split del: if_split cong: if_cong)
         apply (rename_tac apiobject_type)
         apply (case_tac apiobject_type; simp split del: if_split)
-            apply (rule hoare_pre, wp, simp add:createObjects_def)
-           apply ((wp createObjects_orig_cte_wp_at2'[where sz = sz]
-                     mapM_x_wp' threadSet_cte_wp_at2')+
+            apply (rule hoare_pre, wp, simp add: createObjects_def)
+           apply ((wp createObjects_orig_cte_wp_at2'[where sz = sz] mapM_x_wp')
                    | assumption
-                   | clarsimp simp: APIType_capBits_def
-                                    projectKOs projectKO_opts_defs
-                                    makeObject_tcb tcb_cte_cases_def tcb_cte_cases_neqs
-                                    pageBits_def archObjSize_def ptBits_def
-                                    pdBits_def createObjects_def curDomain_def
-                                    Let_def objBits_if_dev
+                   | clarsimp simp: APIType_capBits_def projectKOs projectKO_opts_defs
+                                    makeObject_tcb tcb_cte_cases_def cteSizeBits_def
+                                    pageBits_def archObjSize_def ptBits_def pteBits_def
+                                    pdBits_def pdeBits_def createObjects_def curDomain_def
+                                    objBits_if_dev
                          split del: if_split
-                   | simp add: objBits_simps pteBits_def pdeBits_def)+
+                   | simp add: objBits_simps field_simps mult_2_right)+
   done
 
 lemma createObjects_orig_obj_at':
@@ -4138,9 +3858,8 @@ lemma createNewCaps_ko_wp_atQ':
                    \<longrightarrow> (\<forall>pde_y :: pde. P' (injectKO pde_y)))
        and K (\<forall>d (tcb_x :: tcb). \<not>tcbQueued tcb_x \<and> tcbState tcb_x = Inactive
                    \<longrightarrow> P' (injectKO (tcb_x \<lparr> tcbDomain := d \<rparr>)) = P' (injectKO tcb_x))
-       and K (\<forall>v. makeObjectKO d (Inr ty) = Some v
-                 \<longrightarrow> P' v \<longrightarrow> P True)\<rbrace>
-     createNewCaps ty ptr n us d
+       and (\<lambda>s. (\<forall>v. makeObjectKO dev (ksCurDomain s) (Inr ty) = Some v \<longrightarrow> P' v \<longrightarrow> P True))\<rbrace>
+     createNewCaps ty ptr n us dev
    \<lbrace>\<lambda>rv s. P (ko_wp_at' P' p s)\<rbrace>"
   apply (rule hoare_name_pre_state)
   apply (clarsimp simp: createNewCaps_def ARM_H.toAPIType_def
@@ -4159,7 +3878,7 @@ lemma createNewCaps_ko_wp_atQ':
                                objBits_def pageBits_def pdBits_def ptBits_def curDomain_def
                                pteBits_def pdeBits_def
                           split del: if_split
-                   | split if_split_asm[where Q=d]
+                   | split if_split_asm[where Q=dev]
                    | intro conjI impI | fastforce)+)
   done
 
@@ -4290,7 +4009,7 @@ lemma createNewCaps_idle'[wp]:
         apply (rename_tac apiobject_type)
         apply (case_tac apiobject_type, simp_all split del: if_split)[1]
             apply wpsimp
-           apply (wpsimp wp: mapM_x_wp' createObjects_idle' threadSet_idle'
+           apply (wpsimp wp: mapM_x_wp' createObjects_idle'
                   | simp add: projectKO_opt_tcb projectKO_opt_cte
                               makeObject_cte makeObject_tcb archObjSize_def
                               tcb_cte_cases_def objBitsKO_def APIType_capBits_def
@@ -4613,16 +4332,15 @@ lemma createNewCaps_sched_queues:
      createNewCaps ty ptr n us dev
      \<lbrace>\<lambda>_ s. P (tcbSchedNexts_of s) (tcbSchedPrevs_of s)\<rbrace>"
   unfolding createNewCaps_def
-  apply (clarsimp simp: ARM_H.toAPIType_def
-             split del: if_split)
+  apply (clarsimp simp: ARM_H.toAPIType_def split del: if_split)
   apply (cases ty; simp add: createNewCaps_def Arch_createNewCaps_def
                         split del: if_split)
         apply (rename_tac apiobject_type)
         apply (case_tac apiobject_type; simp split del: if_split)
-            apply (rule hoare_pre, wp, simp)
+            apply (wp, simp)
            apply (insert cover not_0)
            apply (wpsimp wp: mapM_x_wp' createObjects_sched_queues
-                       simp: curDomain_def)
+                       simp: curDomain_def createObjects_def)
            by (wpsimp wp: mapM_x_wp' createObjects_sched_queues[simplified o_def]
                           threadSet_sched_pointers
                | simp add: objBitsKO_def APIType_capBits_def valid_pspace'_def makeObject_tcb
@@ -4672,9 +4390,12 @@ lemma mapM_x_threadSet_valid_pspace:
 lemma createNewCaps_valid_pspace:
   assumes  not_0: "n \<noteq> 0"
   and      cover: "range_cover ptr sz (APIType_capBits ty us) n"
-  shows "\<lbrace>\<lambda>s. pspace_no_overlap' ptr sz s \<and> valid_pspace' s
-  \<and> caps_no_overlap'' ptr sz s \<and> ptr \<noteq> 0 \<and> caps_overlap_reserved' {ptr..ptr + of_nat n * 2^(APIType_capBits ty us) - 1} s \<and> ksCurDomain s \<le> maxDomain\<rbrace>
-  createNewCaps ty ptr n us dev \<lbrace>\<lambda>r. valid_pspace'\<rbrace>"
+  shows
+  "\<lbrace>\<lambda>s. pspace_no_overlap' ptr sz s \<and> valid_pspace' s
+     \<and> caps_no_overlap'' ptr sz s \<and> ptr \<noteq> 0 \<and> caps_overlap_reserved' {ptr..ptr + of_nat n * 2^(APIType_capBits ty us) - 1} s
+     \<and> ksCurDomain s \<le> maxDomain\<rbrace>
+   createNewCaps ty ptr n us dev
+   \<lbrace>\<lambda>r. valid_pspace'\<rbrace>"
   unfolding createNewCaps_def Arch_createNewCaps_def
   using valid_obj_makeObject_rules
   apply (clarsimp simp: ARM_H.toAPIType_def
@@ -4684,15 +4405,19 @@ lemma createNewCaps_valid_pspace:
         apply (case_tac apiobject_type, simp_all split del: if_split)
             apply (rule hoare_pre, wp, clarsimp)
            apply (insert cover)
-           apply (wp createObjects_valid_pspace_untyped' [OF _ not_0 , where ty="Inr ty" and sz = sz]
-                     mapM_x_threadSet_valid_pspace mapM_x_wp'
-                 | simp add: makeObjectKO_def archObjSize_def APIType_capBits_def
-                             objBits_simps pageBits_def pdBits_def ptBits_def not_0
-                             createObjects_def curDomain_def
-                             pteBits_def pdeBits_def
-                 | intro conjI impI
-                 | simp add: power_add field_simps)+
-done
+           (* for TCBObject, we need to know a bit more about tcbDomain *)
+           apply (simp add: curDomain_def)
+           apply (rule bind_wp[OF _ gets_sp])
+           apply (clarsimp simp: createObjects_def)
+           apply (rule hoare_assume_pre)
+           by (wp createObjects_valid_pspace_untyped' [OF _ _ not_0 , where ty="Inr ty" and sz = sz]
+                  mapM_x_threadSet_valid_pspace mapM_x_wp'
+               | simp add: makeObjectKO_def APIType_capBits_def
+                           objBits_simps pageBits_def pdBits_def ptBits_def not_0
+                           createObjects_def curDomain_def
+                           pteBits_def pdeBits_def
+               | intro conjI impI
+               | simp add: power_add field_simps)+
 
 lemma copyGlobalMappings_inv[wp]:
   "\<lbrace>\<lambda>s. P (ksMachineState s)\<rbrace>
@@ -4916,7 +4641,7 @@ crunch createNewCaps
   (wp: mapM_x_wp' simp: crunch_simps)
 
 lemma createObjects_null_filter':
-  "\<lbrace>\<lambda>s. P (null_filter' (ctes_of s)) \<and> makeObjectKO dev ty = Some val \<and>
+  "\<lbrace>\<lambda>s. P (null_filter' (ctes_of s)) \<and> makeObjectKO dev d ty = Some val \<and>
         range_cover ptr sz (objBitsKO val + gbits) n \<and> n \<noteq> 0 \<and>
         pspace_aligned' s \<and> pspace_distinct' s \<and> pspace_no_overlap' ptr sz s\<rbrace>
    createObjects' ptr n val gbits
@@ -5307,7 +5032,7 @@ crunch createObjects
   (simp: unless_def)
 
 lemma createObjects_untyped_ranges_zero':
-  assumes moKO: "makeObjectKO dev ty = Some val"
+  assumes moKO: "makeObjectKO dev d ty = Some val"
   shows
   "\<lbrace>ct_active' and valid_pspace' and pspace_no_overlap' ptr sz
        and untyped_ranges_zero'
@@ -5339,9 +5064,10 @@ lemma sym_refs_empty[simp]:
   by simp
 
 lemma createObjects_no_cte_invs:
-  assumes moKO: "makeObjectKO dev ty = Some val"
+  assumes moKO: "makeObjectKO dev d ty = Some val"
   assumes no_cte: "\<And>c. projectKO_opt val \<noteq> Some (c::cte)"
   assumes no_tcb: "\<And>t. projectKO_opt val \<noteq> Some (t::tcb)"
+  and     mdom: "ty = Inr (APIObjectType ArchTypes_H.apiobject_type.TCBObject) \<longrightarrow> d \<le> maxDomain"
   shows
   "\<lbrace>\<lambda>s. range_cover ptr sz ((objBitsKO val) + gbits) n \<and> n \<noteq> 0 \<and> invs' s \<and> ct_active' s
         \<and> pspace_no_overlap' ptr sz s \<and> ptr \<noteq> 0
@@ -5431,23 +5157,21 @@ qed
 lemma corres_retype_update_gsI:
   assumes not_zero: "n \<noteq> 0"
   and      aligned: "is_aligned ptr (objBitsKO ko + gbits)"
-  and obj_bits_api: "obj_bits_api (APIType_map2 ty) us =
-                     objBitsKO ko + gbits"
-  and        check: "sz < obj_bits_api (APIType_map2 ty) us \<longleftrightarrow>
-                     sz < objBitsKO ko + gbits"
+  and obj_bits_api: "obj_bits_api (APIType_map2 ty) us = objBitsKO ko + gbits"
+  and        check: "sz < obj_bits_api (APIType_map2 ty) us \<longleftrightarrow> sz < objBitsKO ko + gbits"
   and          usv: "APIType_map2 ty = Structures_A.CapTableObject \<Longrightarrow> 0 < us"
-  and           ko: "makeObjectKO dev ty = Some ko"
+  and           ko: "makeObjectKO dev d ty = Some ko"
   and          orr: "obj_bits_api (APIType_map2 ty) us \<le> sz \<Longrightarrow>
-                     obj_relation_retype
-                       (default_object (APIType_map2 ty) dev us) ko"
+                     obj_relation_retype (default_object (APIType_map2 ty) dev us d) ko"
   and        cover: "range_cover ptr sz (obj_bits_api (APIType_map2 ty) us) n"
   and            f: "f = update_gs (APIType_map2 ty) us"
   shows "corres (\<lambda>rv rv'. rv' = g rv)
          (\<lambda>s. valid_pspace s \<and> pspace_no_overlap_range_cover ptr sz s
-            \<and> valid_mdb s \<and> valid_etcbs s \<and> valid_list s)
+            \<and> valid_mdb s \<and> valid_list s)
          (\<lambda>s. pspace_aligned' s \<and> pspace_distinct' s \<and>
-              pspace_no_overlap' ptr sz s)
-         (retype_region2 ptr n us (APIType_map2 ty) dev)
+              pspace_no_overlap' ptr sz s \<and>
+              (ty = Inr (APIObjectType TCBObject) \<longrightarrow> d = ksCurDomain s))
+         (retype_region ptr n us (APIType_map2 ty) dev)
          (do addrs \<leftarrow> createObjects ptr n ko gbits;
              _ \<leftarrow> modify (f (set addrs));
              return (g addrs)
@@ -5458,70 +5182,13 @@ lemma corres_retype_update_gsI:
 lemma gcd_corres: "corres (=) \<top> \<top> (gets cur_domain) curDomain"
   by (simp add: curDomain_def state_relation_def)
 
-lemma retype_region2_extra_ext_mapM_x_corres:
-  shows "corres dc
-           (valid_etcbs and (\<lambda>s. \<forall>addr\<in>set addrs. tcb_at addr s))
-           (\<lambda>s. \<forall>addr\<in>set addrs. obj_at' (Not \<circ> tcbQueued) addr s)
-           (retype_region2_extra_ext addrs Structures_A.apiobject_type.TCBObject)
-           (mapM_x (\<lambda>addr. do cdom \<leftarrow> curDomain;
-                              threadSet (tcbDomain_update (\<lambda>_. cdom)) addr
-                           od)
-             addrs)"
-  apply (rule corres_guard_imp)
-    apply (simp add: retype_region2_extra_ext_def curDomain_mapM_x_futz[symmetric] when_def)
-    apply (rule corres_split_eqr[OF gcd_corres])
-      apply (rule_tac S="Id \<inter> {(x, y). x \<in> set addrs}"
-                  and P="\<lambda>s. (\<forall>t \<in> set addrs. tcb_at t s) \<and> valid_etcbs s"
-                  and P'="\<lambda>s. \<forall>t \<in> set addrs. obj_at' (Not \<circ> tcbQueued) t s"
-                   in corres_mapM_x)
-          apply simp
-          apply (rule corres_guard_imp)
-            apply (rule ethread_set_corres, simp_all add: etcb_relation_def non_exst_same_def)[1]
-            apply (case_tac tcb')
-            apply simp
-           apply fastforce
-          apply (fastforce simp: obj_at'_def)
-         apply (wp hoare_vcg_ball_lift | simp)+
-        apply (clarsimp simp: obj_at'_def)
-       apply fastforce
-      apply auto[1]
-     apply (wp | simp add: curDomain_def)+
-  done
-
-lemma retype_region2_extra_ext_trivial:
-  "ty \<noteq> APIType_map2 (Inr (APIObjectType apiobject_type.TCBObject))
-      \<Longrightarrow> retype_region2_extra_ext ptrs ty = return ()"
-by (simp add: retype_region2_extra_ext_def when_def APIType_map2_def)
-
-lemma retype_region2_ext_retype_region_ArchObject_PageDirectoryObj:
-  "retype_region ptr n us (APIType_map2 (Inr PageDirectoryObject)) dev =
-  (retype_region2 ptr n us (APIType_map2 (Inr PageDirectoryObject)) dev :: obj_ref list det_ext_monad)"
-by (simp add: retype_region2_ext_retype_region retype_region2_extra_ext_def when_def APIType_map2_def)
-
-lemma retype_region2_valid_etcbs[wp]:"\<lbrace>valid_etcbs\<rbrace> retype_region2 a b c d dev \<lbrace>\<lambda>_. valid_etcbs\<rbrace>"
-  apply (simp add: retype_region2_def)
-  apply (simp add: retype_region2_ext_def bind_assoc)
-  apply wp
-  apply (clarsimp simp del: fun_upd_apply)
-  apply (blast intro: valid_etcb_fold_update)
-  done
-
-lemma retype_region2_obj_at:
-  assumes tytcb: "ty = Structures_A.apiobject_type.TCBObject"
-  shows "\<lbrace>\<top>\<rbrace> retype_region2 ptr n us ty dev \<lbrace>\<lambda>rv s. \<forall>x \<in> set rv. tcb_at x s\<rbrace>"
-  using tytcb unfolding retype_region2_def
-  apply (simp only: return_bind bind_return foldr_upd_app_if fun_app_def K_bind_def)
-  apply (wp dxo_wp_weak | simp)+
-  apply (auto simp: obj_at_def default_object_def is_tcb_def)
-  done
-
-lemma createObjects_Not_tcbQueued:
+lemma createObjects_tcb_at':
   "\<lbrakk>range_cover ptr sz (objBitsKO (injectKOS (makeObject::tcb))) n; n \<noteq> 0\<rbrakk> \<Longrightarrow>
    \<lbrace>\<lambda>s. pspace_no_overlap' ptr sz s \<and> pspace_aligned' s \<and> pspace_distinct' s\<rbrace>
    createObjects ptr n (KOTCB makeObject) 0
-   \<lbrace>\<lambda>ptrs s. \<forall>addr\<in>set ptrs. obj_at' (Not \<circ> tcbQueued) addr s\<rbrace>"
+   \<lbrace>\<lambda>ptrs s. \<forall>addr\<in>set ptrs. tcb_at' addr s\<rbrace>"
   apply (rule hoare_strengthen_post[OF createObjects_ko_at_strg[where val = "(makeObject :: tcb)"]])
-  apply (auto simp: obj_at'_def projectKOs project_inject objBitsKO_def objBits_def makeObject_tcb)
+  apply (auto simp: obj_at'_def project_inject objBitsKO_def objBits_def makeObject_tcb)
   done
 
 lemma data_page_relation_retype:
@@ -5553,7 +5220,7 @@ lemma regroup_createObjects_dmo_userPages:
 lemma corres_retype_region_createNewCaps:
   "corres ((\<lambda>r r'. length r = length r' \<and> list_all2 cap_relation r r')
                \<circ> map (\<lambda>ref. default_cap (APIType_map2 (Inr ty)) ref us dev))
-            (\<lambda>s. valid_pspace s \<and> valid_mdb s \<and> valid_etcbs s \<and> valid_list s \<and> valid_arch_state s
+            (\<lambda>s. valid_pspace s \<and> valid_mdb s \<and> valid_list s \<and> valid_arch_state s
                    \<and> caps_no_overlap y sz s \<and> pspace_no_overlap_range_cover y sz s
                    \<and> caps_overlap_reserved {y..y + of_nat n * 2 ^ (obj_bits_api (APIType_map2 (Inr ty)) us) - 1} s
                    \<and> (\<exists>slot. cte_wp_at (\<lambda>c. up_aligned_area y sz \<subseteq> cap_range c \<and> cap_is_device c = dev) slot s)
@@ -5565,12 +5232,9 @@ lemma corres_retype_region_createNewCaps:
                 init_arch_objects (APIType_map2 (Inr ty)) dev y n us x;
                 return x od)
             (createNewCaps ty y n us dev)"
-  apply (rule_tac F="range_cover y sz
-                       (obj_bits_api (APIType_map2 (Inr ty)) us) n \<and>
-                     n \<noteq> 0 \<and>
-                     (APIType_map2 (Inr ty) = Structures_A.CapTableObject
-                       \<longrightarrow> 0 < us)"
-            in corres_req, simp)
+  apply (rule_tac F="range_cover y sz (obj_bits_api (APIType_map2 (Inr ty)) us) n
+                      \<and> n \<noteq> 0 \<and> (APIType_map2 (Inr ty) = Structures_A.CapTableObject \<longrightarrow> 0 < us)"
+           in corres_req, simp)
   apply (clarsimp simp add: createNewCaps_def toAPIType_def
                  split del: if_split cong: if_cong)
   apply (subst init_arch_objects_APIType_map2)
@@ -5595,79 +5259,60 @@ lemma corres_retype_region_createNewCaps:
                 apply simp
                apply (clarsimp simp: range_cover_def)
                apply (arith+)[4]
-           \<comment> \<open>TCB, EP, NTFN\<close>
-           apply (simp_all add: retype_region2_ext_retype_region bind_cong[OF curDomain_mapM_x_futz refl, unfolded bind_assoc]
-                     split del: if_split)[9] (* not PageDirectoryObject *)
+           \<comment> \<open>TCB\<close>
+           apply (simp_all add: curDomain_def split del: if_split)
+           apply (rule corres_underlying_gets_pre_rhs[rotated])
+            apply (rule gets_sp)
            apply (rule corres_guard_imp)
+             apply (rule corres_bind_return)
              apply (rule corres_split_eqr)
                 apply (rule corres_retype[where 'a = tcb],
                        simp_all add: obj_bits_api_def objBits_simps' pageBits_def
-                                    APIType_map2_def makeObjectKO_def
-                                    tcb_relation_retype)[1]
-                apply (fastforce simp: range_cover_def)
-               apply (rule corres_split_nor)
-                  apply (simp add: APIType_map2_def)
-                  apply (rule retype_region2_extra_ext_mapM_x_corres)
-                 apply (rule corres_trivial, simp)
-                 apply (clarsimp simp: list_all2_same list_all2_map1 list_all2_map2
-                objBits_simps APIType_map2_def)
-                apply wp
-               apply wp
-              apply ((wp retype_region2_obj_at | simp add: APIType_map2_def)+)[1]
-             apply ((wp createObjects_Not_tcbQueued[where sz=sz] | simp add: APIType_map2_def objBits_simps' obj_bits_api_def)+)[1]
+                                     APIType_map2_def makeObjectKO_def)[1]
+                 apply (fastforce simp: range_cover_def)
+                apply (simp add: tcb_relation_retype)
+               apply (rule corres_returnTT, simp)
+               apply (clarsimp simp: list_all2_same list_all2_map1 list_all2_map2
+                                     objBits_simps APIType_map2_def)
+              apply ((wp | simp add: APIType_map2_def)+)[1]
+             apply ((wp createObjects_tcb_at'[where sz=sz] | simp add: APIType_map2_def objBits_simps' obj_bits_api_def)+)[1]
             apply simp
            apply simp
-          apply (subst retype_region2_extra_ext_trivial)
-           apply (simp add: APIType_map2_def)
-          apply (simp add: liftM_def[symmetric] split del: if_split)
-          apply (rule corres_rel_imp)
-           apply (rule corres_guard_imp)
-             apply (rule corres_retype[where 'a = endpoint],
-                    simp_all add: obj_bits_api_def objBits_simps' pageBits_def
-                                  APIType_map2_def makeObjectKO_def
-                                  other_objs_default_relation)[1]
-             apply (fastforce simp: range_cover_def)
-            apply simp
-           apply simp
-          apply (clarsimp simp: list_all2_same list_all2_map1 list_all2_map2
-                                objBits_simps APIType_map2_def)
-         apply (subst retype_region2_extra_ext_trivial)
-          apply (simp add: APIType_map2_def)
+         \<comment> \<open>EP, NTFN\<close>
          apply (simp add: liftM_def[symmetric] split del: if_split)
          apply (rule corres_rel_imp)
           apply (rule corres_guard_imp)
-            apply (rule corres_retype[where 'a = notification],
+            apply (rule corres_retype[where 'a = endpoint],
                    simp_all add: obj_bits_api_def objBits_simps' pageBits_def
                                  APIType_map2_def makeObjectKO_def
                                  other_objs_default_relation)[1]
-            apply (fastforce simp: range_cover_def)
-           apply simp
-          apply simp
-         apply (clarsimp simp: list_all2_same list_all2_map1 list_all2_map2
-                               objBits_simps APIType_map2_def)
+            apply ((simp add: range_cover_def APIType_map2_def
+                              list_all2_same list_all2_map1 list_all2_map2)+)[4]
+        apply (simp add: liftM_def[symmetric] split del: if_split)
+        apply (rule corres_rel_imp)
+         apply (rule corres_guard_imp)
+           apply (rule corres_retype[where 'a = notification],
+                  simp_all add: obj_bits_api_def objBits_simps' pageBits_def
+                                APIType_map2_def makeObjectKO_def
+                                other_objs_default_relation)[1]
+           apply ((simp add: range_cover_def APIType_map2_def
+                             list_all2_same list_all2_map1 list_all2_map2)+)[4]
         \<comment> \<open>CapTable\<close>
-        apply (subst retype_region2_extra_ext_trivial)
-         apply (simp add: APIType_map2_def)
+        apply (find_goal \<open>match premises in "_ = ArchTypes_H.apiobject_type.CapTableObject" \<Rightarrow> \<open>-\<close>\<close>)
         apply (subst bind_assoc_return_reverse[of "createObjects y n (KOCTE makeObject) us"])
-        apply (subst liftM_def
-               [of "map (\<lambda>addr. capability.CNodeCap addr us 0 0)", symmetric])
+        apply (subst liftM_def[of "map (\<lambda>addr. capability.CNodeCap addr us 0 0)", symmetric])
         apply simp
         apply (rule corres_rel_imp)
          apply (rule corres_guard_imp)
            apply (rule corres_retype_update_gsI,
-                 simp_all add: obj_bits_api_def objBits_simps' pageBits_def
-                               APIType_map2_def makeObjectKO_def slot_bits_def
-                               field_simps ext)[1]
-            apply (simp add: range_cover_def)
-           apply (rule captable_relation_retype,simp add: range_cover_def word_bits_def)
-          apply simp
-         apply simp
-        apply (clarsimp simp: list_all2_same list_all2_map1 list_all2_map2
-                              objBits_simps allRights_def APIType_map2_def
-                   split del: if_split)
+                  simp_all add: obj_bits_api_def objBits_simps' pageBits_def
+                                APIType_map2_def makeObjectKO_def slot_bits_def
+                                field_simps ext)[1]
+              apply ((clarsimp simp : range_cover_def APIType_map2_def word_bits_def
+                                       list_all2_same list_all2_map1 list_all2_map2
+                     | rule captable_relation_retype)+)[5]
        \<comment> \<open>SmallPageObject\<close>
-       apply (subst retype_region2_extra_ext_trivial)
-        apply (simp add: APIType_map2_def)
+       apply (in_case \<open>SmallPageObject\<close>)
        apply (simp add: corres_liftM2_simp[unfolded liftM_def] split del: if_split)
        apply (simp add: init_arch_objects_def split del: if_split)
        apply (subst regroup_createObjects_dmo_userPages)
@@ -5692,8 +5337,7 @@ lemma corres_retype_region_createNewCaps:
                               list_all2_map1 list_all2_map2 list_all2_same)
             apply ((wpsimp split_del: if_split)+)[6]
        \<comment> \<open>LargePageObject\<close>
-      apply (subst retype_region2_extra_ext_trivial)
-       apply (simp add: APIType_map2_def)
+      apply (in_case \<open>LargePageObject\<close>)
       apply (simp add: corres_liftM2_simp[unfolded liftM_def] split del: if_split)
       apply (simp add: init_arch_objects_def split del: if_split)
       apply (subst regroup_createObjects_dmo_userPages)
@@ -5718,8 +5362,7 @@ lemma corres_retype_region_createNewCaps:
                              list_all2_map1 list_all2_map2 list_all2_same)
            apply ((wpsimp split_del: if_split)+)[6]
      \<comment> \<open>SectionObject\<close>
-     apply (subst retype_region2_extra_ext_trivial)
-      apply (simp add: APIType_map2_def)
+     apply (in_case \<open>SectionObject\<close>)
      apply (simp add: corres_liftM2_simp[unfolded liftM_def] split del: if_split)
      apply (simp add: init_arch_objects_def split del: if_split)
      apply (subst regroup_createObjects_dmo_userPages)
@@ -5744,8 +5387,7 @@ lemma corres_retype_region_createNewCaps:
                             list_all2_map1 list_all2_map2 list_all2_same)
           apply ((wpsimp split_del: if_split)+)[6]
     \<comment> \<open>SuperSectionObject\<close>
-    apply (subst retype_region2_extra_ext_trivial)
-     apply (simp add: APIType_map2_def)
+    apply (in_case \<open>SuperSectionObject\<close>)
     apply (simp add: corres_liftM2_simp[unfolded liftM_def] split del: if_split)
     apply (simp add: init_arch_objects_def split del: if_split)
     apply (subst regroup_createObjects_dmo_userPages)
@@ -5769,9 +5411,8 @@ lemma corres_retype_region_createNewCaps:
           apply (simp add: APIType_map2_def arch_default_cap_def vm_read_write_def vmrights_map_def
                            list_all2_map1 list_all2_map2 list_all2_same)
          apply ((wpsimp split_del: if_split)+)[6]
-   \<comment> \<open>PageTable\<close>
-   apply (subst retype_region2_extra_ext_trivial)
-    apply (simp add: APIType_map2_def)
+   \<comment> \<open>PageTableObject\<close>
+   apply (in_case \<open>PageTableObject\<close>)
    apply (simp add: corres_liftM2_simp[unfolded liftM_def])
    apply (simp add: init_arch_objects_def bind_assoc split del: if_split)
    apply (rule corres_guard_imp)
@@ -5794,18 +5435,17 @@ lemma corres_retype_region_createNewCaps:
           apply (clarsimp simp: list_all2_map1 list_all2_map2 list_all2_same
                                 APIType_map2_def arch_default_cap_def)
          apply ((wpsimp split_del: if_split)+)[6]
-  \<comment> \<open>PageDirectory\<close>
+  \<comment> \<open>PageDirectoryObject\<close>
+  apply (in_case \<open>PageDirectoryObject\<close>)
   apply (simp add: bind_assoc)
   apply (rule corres_guard_imp)
     apply (rule corres_split_eqr)
-       apply (rule corres_retype[where ty = "Inr PageDirectoryObject" and 'a = pde
-                    , simplified, folded retype_region2_ext_retype_region_ArchObject_PageDirectoryObj],
+       apply (rule corres_retype[where ty = "Inr PageDirectoryObject" and 'a = pde],
               simp_all add: APIType_map2_def obj_bits_api_def
                             default_arch_object_def objBits_simps
-                            archObjSize_def pdBits_def pageBits_def
+                            pdBits_def pageBits_def
                             pteBits_def pdeBits_def
                             makeObjectKO_def)[1]
-supply [[goals_limit=30]]
         apply (simp add: range_cover_def)+
        apply (rule pagedirectory_relation_retype)
       apply (rename_tac pds)
@@ -5813,7 +5453,7 @@ supply [[goals_limit=30]]
                        vs_apiobj_size_def pdBits_eq
                   split del: if_split)
          apply (rule corres_split)
-         apply (rule_tac P="valid_arch_state and valid_etcbs and pspace_aligned and
+         apply (rule_tac P="valid_arch_state and pspace_aligned and
                             (\<lambda>s. \<forall>pd \<in> set pds. typ_at (AArch APageDirectory) pd s)" and
                          P'="valid_arch_state' and (\<lambda>s. \<forall>pd \<in> set pds. page_directory_at' pd s)"
                          in corres_mapM_x')

--- a/proof/refine/ARM/Schedule_R.thy
+++ b/proof/refine/ARM/Schedule_R.thy
@@ -93,7 +93,7 @@ lemma schedule_choose_new_thread_sched_act_rct[wp]:
 lemma tcbSchedAppend_corres:
   "tcb_ptr = tcbPtr \<Longrightarrow>
    corres dc
-     (in_correct_ready_q and ready_qs_distinct and valid_etcbs and st_tcb_at runnable tcb_ptr
+     (in_correct_ready_q and ready_qs_distinct and st_tcb_at runnable tcb_ptr
       and pspace_aligned and pspace_distinct)
      (sym_heap_sched_pointers and valid_sched_pointers and valid_tcbs')
      (tcb_sched_action tcb_sched_append tcb_ptr) (tcbSchedAppend tcbPtr)"
@@ -109,9 +109,9 @@ lemma tcbSchedAppend_corres:
    apply (fastforce dest: pspace_distinct_cross)
   apply (clarsimp simp: tcb_sched_action_def tcb_sched_append_def get_tcb_queue_def
                         tcbSchedAppend_def getQueue_def unless_def when_def)
-  apply (rule corres_symb_exec_l[OF _ _ ethread_get_sp]; (solves wpsimp)?)
+  apply (rule corres_symb_exec_l[OF _ _ thread_get_sp]; (solves wpsimp)?)
   apply (rename_tac domain)
-  apply (rule corres_symb_exec_l[OF _ _ ethread_get_sp]; (solves wpsimp)?)
+  apply (rule corres_symb_exec_l[OF _ _ thread_get_sp]; (solves wpsimp)?)
   apply (rename_tac priority)
   apply (rule corres_symb_exec_l[OF _ _ gets_sp]; (solves wpsimp)?)
   apply (rule corres_stateAssert_ignore)
@@ -123,12 +123,11 @@ lemma tcbSchedAppend_corres:
   apply (rule corres_symb_exec_r[OF _ threadGet_sp]; (solves wpsimp)?)
   apply (subst if_distrib[where f="set_tcb_queue domain prio" for domain prio])
   apply (rule corres_if_strong')
-    apply (frule state_relation_ready_queues_relation)
-    apply (frule in_ready_q_tcbQueued_eq[where t=tcbPtr])
     subgoal
-      by (fastforce dest: tcb_at_ekheap_dom pred_tcb_at_tcb_at
-                    simp: obj_at'_def projectKOs opt_pred_def opt_map_def obj_at_def is_tcb_def
-                          in_correct_ready_q_def etcb_at_def is_etcb_at_def)
+      by (fastforce dest!: state_relation_ready_queues_relation
+                           in_ready_q_tcbQueued_eq[where t=tcbPtr]
+                     simp: obj_at'_def projectKOs opt_pred_def opt_map_def in_correct_ready_q_def
+                           obj_at_def etcb_at_def etcbs_of'_def)
    apply (find_goal \<open>match conclusion in "corres _ _ _ _ (return ())" \<Rightarrow> \<open>-\<close>\<close>)
    apply (rule monadic_rewrite_corres_l[where P=P and Q=P for P, simplified])
     apply (clarsimp simp: set_tcb_queue_def)
@@ -176,16 +175,15 @@ lemma tcbSchedAppend_corres:
   apply (drule set_tcb_queue_new_state)
   apply (wpsimp wp: threadSet_wp simp: setQueue_def tcbQueueAppend_def)
   apply normalise_obj_at'
-  apply (frule (1) tcb_at_is_etcb_at)
-  apply (clarsimp simp: obj_at_def is_etcb_at_def etcb_at_def)
-  apply (rename_tac s d p s' tcb' tcb etcb)
-  apply (frule_tac t=tcbPtr in ekheap_relation_tcb_domain_priority)
+  apply (clarsimp simp: obj_at_def)
+  apply (rename_tac s d p s' tcb' tcb)
+  apply (frule_tac t=tcbPtr in pspace_relation_tcb_domain_priority)
     apply (force simp: obj_at_def)
    apply (force simp: obj_at'_def projectKOs)
   apply (clarsimp split: if_splits)
   apply (cut_tac ts="ready_queues s d p" in list_queue_relation_nil)
    apply (force dest!: spec simp: list_queue_relation_def)
-  apply (cut_tac ts="ready_queues s (tcb_domain etcb) (tcb_priority etcb)"
+  apply (cut_tac ts="ready_queues s (tcb_domain tcb) (tcb_priority tcb)"
               in obj_at'_tcbQueueEnd_ksReadyQueues)
       apply fast
      apply fast
@@ -195,8 +193,8 @@ lemma tcbSchedAppend_corres:
    apply (force dest!: spec simp: list_queue_relation_def)
   apply (clarsimp simp: list_queue_relation_def)
 
-  apply (case_tac "d \<noteq> tcb_domain etcb \<or> p \<noteq> tcb_priority etcb")
-   apply (cut_tac d=d and d'="tcb_domain etcb" and p=p and p'="tcb_priority etcb"
+  apply (case_tac "d \<noteq> tcb_domain tcb \<or> p \<noteq> tcb_priority tcb")
+   apply (cut_tac d=d and d'="tcb_domain tcb" and p=p and p'="tcb_priority tcb"
                in ready_queues_disjoint)
       apply force
      apply fastforce
@@ -220,14 +218,14 @@ lemma tcbSchedAppend_corres:
     apply (clarsimp simp: fun_upd_apply split: if_splits)
 
    \<comment> \<open>the ready queue was not originally empty\<close>
-   apply (clarsimp simp: etcb_at_def obj_at'_def)
-   apply (prop_tac "the (tcbQueueEnd (ksReadyQueues s' (tcb_domain etcb, tcb_priority etcb)))
+   apply (clarsimp simp: obj_at'_def)
+   apply (prop_tac "the (tcbQueueEnd (ksReadyQueues s' (tcb_domain tcb, tcb_priority tcb)))
                     \<notin> set (ready_queues s d p)")
     apply (erule orthD2)
-    apply (drule_tac x="tcb_domain etcb" in spec)
-    apply (drule_tac x="tcb_priority etcb" in spec)
+    apply (drule_tac x="tcb_domain tcb" in spec)
+    apply (drule_tac x="tcb_priority tcb" in spec)
     apply clarsimp
-    apply (drule_tac x="the (tcbQueueEnd (ksReadyQueues s' (tcb_domain etcb, tcb_priority etcb)))"
+    apply (drule_tac x="the (tcbQueueEnd (ksReadyQueues s' (tcb_domain tcb, tcb_priority tcb)))"
                  in spec)
     subgoal by (auto simp: in_opt_pred opt_map_red projectKOs)
    apply (intro conjI impI allI)
@@ -244,7 +242,7 @@ lemma tcbSchedAppend_corres:
       apply (case_tac "ready_queues s d p"; force simp: tcbQueueEmpty_def)
      apply (case_tac "t = tcbPtr")
       apply (clarsimp simp: projectKOs inQ_def fun_upd_apply split: if_splits)
-     apply (case_tac "t = the (tcbQueueEnd (ksReadyQueues s' (tcb_domain etcb, tcb_priority etcb)))")
+     apply (case_tac "t = the (tcbQueueEnd (ksReadyQueues s' (tcb_domain tcb, tcb_priority tcb)))")
       apply (clarsimp simp: projectKOs inQ_def opt_pred_def fun_upd_apply)
      apply (clarsimp simp: inQ_def in_opt_pred opt_map_def fun_upd_apply)
     apply (clarsimp simp: fun_upd_apply split: if_splits)
@@ -252,9 +250,9 @@ lemma tcbSchedAppend_corres:
 
   \<comment> \<open>d = tcb_domain tcb \<and> p = tcb_priority tcb\<close>
   apply clarsimp
-  apply (drule_tac x="tcb_domain etcb" in spec)
-  apply (drule_tac x="tcb_priority etcb" in spec)
-  apply (cut_tac ts="ready_queues s (tcb_domain etcb) (tcb_priority etcb)"
+  apply (drule_tac x="tcb_domain tcb" in spec)
+  apply (drule_tac x="tcb_priority tcb" in spec)
+  apply (cut_tac ts="ready_queues s (tcb_domain tcb) (tcb_priority tcb)"
               in tcbQueueHead_iff_tcbQueueEnd)
    apply (force simp: list_queue_relation_def)
   apply (frule valid_tcbs'_maxDomain[where t=tcbPtr], simp add: obj_at'_def projectKOs)
@@ -689,7 +687,7 @@ defs idleThreadNotQueued_def:
   "idleThreadNotQueued s \<equiv> obj_at' (Not \<circ> tcbQueued) (ksIdleThread s) s"
 
 lemma idle_thread_not_queued:
-  "\<lbrakk>valid_idle s; valid_queues s; valid_etcbs s\<rbrakk>
+  "\<lbrakk>valid_idle s; valid_queues s\<rbrakk>
    \<Longrightarrow> \<not> (\<exists>d p. idle_thread s \<in> set (ready_queues s d p))"
   apply (clarsimp simp: valid_queues_def)
   apply (drule_tac x=d in spec)
@@ -697,7 +695,7 @@ lemma idle_thread_not_queued:
   apply clarsimp
   apply (drule_tac x="idle_thread s" in bspec)
    apply fastforce
-  apply (clarsimp simp: valid_idle_def pred_tcb_at_def obj_at_def valid_etcbs_def)
+  apply (clarsimp simp: valid_idle_def pred_tcb_at_def obj_at_def)
   done
 
 lemma valid_idle_tcb_at:
@@ -705,12 +703,12 @@ lemma valid_idle_tcb_at:
   by (clarsimp simp: valid_idle_def pred_tcb_at_def obj_at_def is_tcb_def)
 
 lemma setCurThread_corres:
-  "corres dc (valid_idle and valid_queues and valid_etcbs and pspace_aligned and pspace_distinct) \<top>
+  "corres dc (valid_idle and valid_queues and pspace_aligned and pspace_distinct) \<top>
      (modify (cur_thread_update (\<lambda>_. t))) (setCurThread t)"
   apply (clarsimp simp: setCurThread_def)
   apply (rule corres_stateAssert_add_assertion[rotated])
    apply (clarsimp simp: idleThreadNotQueued_def)
-   apply (frule (2) idle_thread_not_queued)
+   apply (frule (1) idle_thread_not_queued)
    apply (frule state_relation_pspace_relation)
    apply (frule state_relation_ready_queues_relation)
    apply (frule state_relation_idle_thread)
@@ -777,6 +775,7 @@ crunch arch_switch_to_thread, arch_switch_to_idle_thread
   and pspace_distinct[wp]: pspace_distinct
   and ready_qs_distinct[wp]: ready_qs_distinct
   and valid_idle[wp]: valid_idle
+  and ready_queues[wp]: "\<lambda>s. P (ready_queues s)"
   (wp: ready_qs_distinct_lift)
 
 lemma valid_queues_in_correct_ready_q[elim!]:
@@ -792,7 +791,7 @@ lemma switchToThread_corres:
                 and valid_vspace_objs and pspace_aligned and pspace_distinct
                 and valid_vs_lookup and valid_global_objs
                 and unique_table_refs o caps_of_state
-                and st_tcb_at runnable t and valid_etcbs
+                and st_tcb_at runnable t
                 and valid_queues and valid_idle)
              (no_0_obj' and sym_heap_sched_pointers and valid_objs' and valid_arch_state')
              (switch_to_thread t) (switchToThread t)"
@@ -813,7 +812,7 @@ lemma switchToThread_corres:
     apply (rule corres_guard_imp)
       apply (rule corres_split[OF arch_switchToThread_corres])
         apply (rule corres_split[OF tcbSchedDequeue_corres setCurThread_corres])
-          apply (wpsimp simp: is_tcb_def)+
+          apply (wpsimp simp: is_tcb_def wp: in_correct_ready_q_lift)+
      apply (fastforce intro!: st_tcb_at_tcb_at)
     apply wpsimp
    apply wpsimp
@@ -836,7 +835,7 @@ lemma arch_switchToIdleThread_corres:
 
 lemma switchToIdleThread_corres:
   "corres dc
-     (invs and valid_queues and valid_etcbs)
+     (invs and valid_queues)
      invs_no_cicd'
      switch_to_idle_thread switchToIdleThread"
   apply (simp add: switch_to_idle_thread_def Thread_H.switchToIdleThread_def)
@@ -1425,7 +1424,7 @@ lemma guarded_switch_to_corres:
                 and valid_vspace_objs and pspace_aligned and pspace_distinct
                 and valid_vs_lookup and valid_global_objs
                 and unique_table_refs o caps_of_state
-                and st_tcb_at runnable t and valid_etcbs and valid_queues and valid_idle)
+                and st_tcb_at runnable t and valid_queues and valid_idle)
              (valid_arch_state' and no_0_obj' and sym_heap_sched_pointers and valid_objs')
              (guarded_switch_to t) (switchToThread t)"
   apply (simp add: guarded_switch_to_def)
@@ -1633,25 +1632,27 @@ lemma schact_bind_inside: "do x \<leftarrow> f; (case act of resume_cur_thread \
   apply (case_tac act,simp_all)
   done
 
-interpretation tcb_sched_action_extended: is_extended' "tcb_sched_action f a"
-  by (unfold_locales)
-
 lemma getDomainTime_corres:
   "corres (=) \<top> \<top> (gets domain_time) getDomainTime"
   by (simp add: getDomainTime_def state_relation_def)
 
+lemma reset_work_units_equiv:
+  "do_extended_op (modify (work_units_completed_update (\<lambda>_. 0)))
+   = (modify (work_units_completed_update (\<lambda>_. 0)))"
+  by (clarsimp simp: reset_work_units_def[symmetric])
+
 lemma nextDomain_corres:
   "corres dc \<top> \<top> next_domain nextDomain"
-  apply (simp add: next_domain_def nextDomain_def)
+  apply (clarsimp simp: next_domain_def nextDomain_def reset_work_units_equiv modify_modify)
   apply (rule corres_modify)
-  apply (simp add: state_relation_def Let_def dschLength_def dschDomain_def)
+  apply (simp add: state_relation_def Let_def dschLength_def dschDomain_def cdt_relation_def)
   done
 
 lemma next_domain_valid_sched[wp]:
   "\<lbrace> valid_sched and (\<lambda>s. scheduler_action s  = choose_new_thread)\<rbrace> next_domain \<lbrace> \<lambda>_. valid_sched \<rbrace>"
   apply (simp add: next_domain_def Let_def)
-  apply (wp, simp add: valid_sched_def valid_sched_action_2_def ct_not_in_q_2_def)
-  apply (simp add:valid_blocked_2_def)
+  apply (wpsimp wp: dxo_wp_weak)
+  apply (clarsimp simp: valid_sched_def)
   done
 
 lemma nextDomain_invs_no_cicd':
@@ -1685,7 +1686,7 @@ lemma scheduleChooseNewThread_fragment_corres:
 
 lemma scheduleSwitchThreadFastfail_corres:
   "\<lbrakk> ct \<noteq> it \<longrightarrow> (tp = tp' \<and> cp = cp') ; ct = ct' ; it = it' \<rbrakk> \<Longrightarrow>
-   corres ((=)) (is_etcb_at ct) (tcb_at' ct)
+   corres ((=)) (is_tcb_at ct) (tcb_at' ct)
      (schedule_switch_thread_fastfail ct it cp tp)
      (scheduleSwitchThreadFastfail ct' it' cp' tp')"
   by (clarsimp simp: schedule_switch_thread_fastfail_def scheduleSwitchThreadFastfail_def)
@@ -1724,9 +1725,6 @@ lemma isHighestPrio_corres:
          apply (wpsimp simp: if_apply_def2 wp: hoare_drop_imps ksReadyQueuesL1Bitmap_return_wp)+
   done
 
-crunch set_scheduler_action
-  for valid_idle_etcb[wp]: valid_idle_etcb
-
 crunch isHighestPrio
   for inv[wp]: P
 crunch curDomain
@@ -1759,13 +1757,13 @@ lemma scheduleChooseNewThread_corres:
 crunch guarded_switch_to
   for static_inv[wp]: "\<lambda>_. P"
 
-lemma ethread_get_when_corres:
-  assumes x: "\<And>etcb tcb'. etcb_relation etcb tcb' \<Longrightarrow> r (f etcb) (f' tcb')"
-  shows      "corres (\<lambda>rv rv'. b \<longrightarrow> r rv rv') (is_etcb_at t) (tcb_at' t)
-                (ethread_get_when b f t) (threadGet f' t)"
-  apply (clarsimp simp: ethread_get_when_def)
+lemma thread_get_when_corres:
+  assumes x: "\<And>tcb tcb'. tcb_relation tcb tcb' \<Longrightarrow> r (f tcb) (f' tcb')"
+  shows      "corres (\<lambda>rv rv'. b \<longrightarrow> r rv rv') (tcb_at t and pspace_aligned and pspace_distinct) (tcb_at' t)
+                ((if b then thread_get f t else return 0)) (threadGet f' t)"
+  apply clarsimp
   apply (rule conjI; clarsimp)
-  apply (rule corres_guard_imp, rule ethreadget_corres; simp add: x)
+  apply (rule corres_guard_imp, rule threadGet_corres; simp add: x)
   apply (clarsimp simp: threadGet_def)
   apply (rule corres_noop)
   apply wpsimp+
@@ -1774,31 +1772,29 @@ lemma ethread_get_when_corres:
 lemma tcb_sched_enqueue_in_correct_ready_q[wp]:
   "tcb_sched_action tcb_sched_enqueue t \<lbrace>in_correct_ready_q\<rbrace> "
   unfolding tcb_sched_action_def tcb_sched_enqueue_def set_tcb_queue_def
-  apply wpsimp
-  apply (clarsimp simp: in_correct_ready_q_def obj_at_def etcb_at_def is_etcb_at_def
-                 split: option.splits)
+  apply (wpsimp wp: thread_get_wp')
+  apply (clarsimp simp: in_correct_ready_q_def obj_at_def etcb_at_def is_etcb_at_def etcbs_of'_def)
   done
 
 lemma tcb_sched_append_in_correct_ready_q[wp]:
   "tcb_sched_action tcb_sched_append tcb_ptr \<lbrace>in_correct_ready_q\<rbrace> "
   unfolding tcb_sched_action_def tcb_sched_append_def
-  apply wpsimp
-  apply (clarsimp simp: in_correct_ready_q_def obj_at_def etcb_at_def is_etcb_at_def
-                 split: option.splits)
+  apply (wpsimp wp: thread_get_wp')
+  apply (clarsimp simp: in_correct_ready_q_def obj_at_def etcb_at_def is_etcb_at_def etcbs_of'_def)
   done
 
 lemma tcb_sched_enqueue_ready_qs_distinct[wp]:
   "tcb_sched_action tcb_sched_enqueue t \<lbrace>ready_qs_distinct\<rbrace> "
   unfolding tcb_sched_action_def set_tcb_queue_def
   apply (wpsimp wp: thread_get_wp')
-  apply (clarsimp simp: ready_qs_distinct_def etcb_at_def is_etcb_at_def split: option.splits)
+  apply (clarsimp simp: ready_qs_distinct_def etcb_at_def is_etcb_at_def)
   done
 
 lemma tcb_sched_append_ready_qs_distinct[wp]:
   "tcb_sched_action tcb_sched_append t \<lbrace>ready_qs_distinct\<rbrace> "
   unfolding tcb_sched_action_def tcb_sched_append_def set_tcb_queue_def
   apply (wpsimp wp: thread_get_wp')
-  apply (clarsimp simp: ready_qs_distinct_def etcb_at_def is_etcb_at_def split: option.splits)
+  apply (clarsimp simp: ready_qs_distinct_def etcb_at_def is_etcb_at_def)
   done
 
 crunch set_scheduler_action
@@ -1811,9 +1807,11 @@ crunch reschedule_required
   and ready_qs_distinct[wp]: ready_qs_distinct
   (ignore: tcb_sched_action wp: crunch_wps ignore_del: reschedule_required)
 
+crunch tcb_sched_action
+  for valid_vs_lookup[wp]: valid_vs_lookup
+
 lemma schedule_corres:
   "corres dc (invs and valid_sched and valid_list) invs' (Schedule_A.schedule) ThreadDecls_H.schedule"
-  supply ethread_get_wp[wp del]
   supply tcbSchedEnqueue_invs'[wp del]
   supply tcbSchedEnqueue_invs'_not_ResumeCurrentThread[wp del]
   supply setSchedulerAction_direct[wp]
@@ -1851,12 +1849,12 @@ lemma schedule_corres:
             apply (rule corres_split[OF getIdleThread_corres], rename_tac it it')
               apply (rule_tac F="was_running \<longrightarrow> ct \<noteq> it" in corres_gen_asm)
               apply (rule corres_split)
-                 apply (rule ethreadget_corres[where r="(=)"])
-                 apply (clarsimp simp: etcb_relation_def)
+                 apply (rule threadGet_corres[where r="(=)"])
+                 apply (clarsimp simp: tcb_relation_def)
                 apply (rename_tac tp tp')
                 apply (rule corres_split)
-                   apply (rule ethread_get_when_corres[where r="(=)"])
-                   apply (clarsimp simp: etcb_relation_def)
+                   apply (rule thread_get_when_corres[where r="(=)"])
+                   apply (clarsimp simp: tcb_relation_def)
                   apply (rename_tac cp cp')
                   apply (rule corres_split)
                      apply (rule scheduleSwitchThreadFastfail_corres; simp)
@@ -1918,7 +1916,7 @@ lemma schedule_corres:
    apply clarsimp
 
    subgoal for s
-     apply (clarsimp split: Deterministic_A.scheduler_action.splits
+     apply (clarsimp split: Structures_A.scheduler_action.splits
                      simp: invs_psp_aligned invs_distinct invs_valid_objs invs_arch_state
                            invs_vspace_objs[simplified] tcb_at_invs)
      apply (rule conjI, clarsimp)
@@ -1930,15 +1928,14 @@ lemma schedule_corres:
       subgoal for candidate
         apply (clarsimp simp: valid_sched_def invs_def valid_state_def cur_tcb_def
                                valid_arch_caps_def valid_sched_action_def
-                               weak_valid_sched_action_def tcb_at_is_etcb_at
-                               tcb_at_is_etcb_at[OF st_tcb_at_tcb_at[rotated]]
+                               weak_valid_sched_action_def
                                valid_blocked_except_def valid_blocked_def)
         apply (fastforce simp add: pred_tcb_at_def obj_at_def is_tcb valid_idle_def)
         done
      (* choose new thread case *)
      apply (intro impI conjI allI tcb_at_invs
-            | fastforce simp: invs_def cur_tcb_def valid_etcbs_def
-                              valid_sched_def  st_tcb_at_def obj_at_def valid_state_def
+            | fastforce simp: invs_def cur_tcb_def
+                              valid_sched_def st_tcb_at_def obj_at_def valid_state_def
                               weak_valid_sched_action_def not_cur_thread_def)+
      done
 
@@ -2289,7 +2286,7 @@ crunch setThreadState, setBoundNotification
 
 lemma possibleSwitchTo_corres:
   "corres dc
-     (valid_etcbs and weak_valid_sched_action and cur_tcb and st_tcb_at runnable t
+     (weak_valid_sched_action and cur_tcb and st_tcb_at runnable t
       and in_correct_ready_q and ready_qs_distinct and pspace_aligned and pspace_distinct)
      ((\<lambda>s. weak_sch_act_wf (ksSchedulerAction s) s)
       and sym_heap_sched_pointers and valid_sched_pointers and valid_objs')
@@ -2298,7 +2295,6 @@ lemma possibleSwitchTo_corres:
    apply (fastforce dest: pspace_aligned_cross)
   apply (rule_tac Q'=pspace_distinct' in corres_cross_add_guard)
    apply (fastforce dest: pspace_distinct_cross)
-  supply ethread_get_wp[wp del]
   apply (rule corres_cross_over_guard[where P'=Q and Q="tcb_at' t and Q" for Q])
    apply (clarsimp simp: state_relation_def)
    apply (rule tcb_at_cross, erule st_tcb_at_tcb_at; assumption)
@@ -2306,8 +2302,8 @@ lemma possibleSwitchTo_corres:
   apply (rule corres_guard_imp)
     apply (rule corres_split[OF curDomain_corres], simp)
       apply (rule corres_split)
-         apply (rule ethreadget_corres[where r="(=)"])
-         apply (clarsimp simp: etcb_relation_def)
+         apply (rule threadGet_corres[where r="(=)"])
+         apply (clarsimp simp: tcb_relation_def)
         apply (rule corres_split[OF getSchedulerAction_corres])
           apply (rule corres_if, simp)
            apply (rule tcbSchedEnqueue_corres, simp)
@@ -2317,14 +2313,9 @@ lemma possibleSwitchTo_corres:
              apply (rule tcbSchedEnqueue_corres, simp)
             apply (wp reschedule_required_valid_queues | strengthen valid_objs'_valid_tcbs')+
           apply (rule setSchedulerAction_corres, simp)
-         apply (wpsimp simp: if_apply_def2
-                       wp: hoare_drop_imp[where f="ethread_get a b" for a b])+
-      apply (wp hoare_drop_imps)[1]
-     apply wp+
-   apply (clarsimp simp: valid_sched_def invs_def valid_state_def cur_tcb_def st_tcb_at_tcb_at
-                          valid_sched_action_def weak_valid_sched_action_def
-                          tcb_at_is_etcb_at[OF st_tcb_at_tcb_at[rotated]])
-  apply (fastforce simp: tcb_at_is_etcb_at)
+         apply (wpsimp wp: hoare_drop_imps)+
+   apply (clarsimp simp: st_tcb_at_tcb_at)
+  apply fastforce
   done
 
 end

--- a/proof/refine/ARM/StateRelation.thy
+++ b/proof/refine/ARM/StateRelation.thy
@@ -173,28 +173,27 @@ where
 | "thread_state_relation (Structures_A.BlockedOnNotification oref) ts'
      = (ts' = Structures_H.BlockedOnNotification oref)"
 
-definition
-  arch_tcb_relation :: "Structures_A.arch_tcb \<Rightarrow> Structures_H.arch_tcb \<Rightarrow> bool"
-where
- "arch_tcb_relation \<equiv> \<lambda>atcb atcb'.
-   tcb_context atcb = atcbContext atcb'"
+definition arch_tcb_relation :: "Structures_A.arch_tcb \<Rightarrow> Structures_H.arch_tcb \<Rightarrow> bool" where
+  "arch_tcb_relation \<equiv>
+     \<lambda>atcb atcb'. tcb_context atcb = atcbContext atcb'"
 
-definition
-  tcb_relation :: "Structures_A.tcb \<Rightarrow> Structures_H.tcb \<Rightarrow> bool"
-where
- "tcb_relation \<equiv> \<lambda>tcb tcb'.
-    tcb_fault_handler tcb = to_bl (tcbFaultHandler tcb')
-  \<and> tcb_ipc_buffer tcb = tcbIPCBuffer tcb'
-  \<and> arch_tcb_relation (tcb_arch tcb) (tcbArch tcb')
-  \<and> thread_state_relation (tcb_state tcb) (tcbState tcb')
-  \<and> fault_rel_optionation (tcb_fault tcb) (tcbFault tcb')
-  \<and> cap_relation (tcb_ctable tcb) (cteCap (tcbCTable tcb'))
-  \<and> cap_relation (tcb_vtable tcb) (cteCap (tcbVTable tcb'))
-  \<and> cap_relation (tcb_reply tcb) (cteCap (tcbReply tcb'))
-  \<and> cap_relation (tcb_caller tcb) (cteCap (tcbCaller tcb'))
-  \<and> cap_relation (tcb_ipcframe tcb) (cteCap (tcbIPCBufferFrame tcb'))
-  \<and> tcb_bound_notification tcb = tcbBoundNotification tcb'
-  \<and> tcb_mcpriority tcb = tcbMCP tcb'"
+definition tcb_relation :: "Structures_A.tcb \<Rightarrow> Structures_H.tcb \<Rightarrow> bool" where
+  "tcb_relation \<equiv> \<lambda>tcb tcb'.
+     tcb_fault_handler tcb = to_bl (tcbFaultHandler tcb')
+   \<and> tcb_ipc_buffer tcb = tcbIPCBuffer tcb'
+   \<and> arch_tcb_relation (tcb_arch tcb) (tcbArch tcb')
+   \<and> thread_state_relation (tcb_state tcb) (tcbState tcb')
+   \<and> fault_rel_optionation (tcb_fault tcb) (tcbFault tcb')
+   \<and> cap_relation (tcb_ctable tcb) (cteCap (tcbCTable tcb'))
+   \<and> cap_relation (tcb_vtable tcb) (cteCap (tcbVTable tcb'))
+   \<and> cap_relation (tcb_reply tcb) (cteCap (tcbReply tcb'))
+   \<and> cap_relation (tcb_caller tcb) (cteCap (tcbCaller tcb'))
+   \<and> cap_relation (tcb_ipcframe tcb) (cteCap (tcbIPCBufferFrame tcb'))
+   \<and> tcb_bound_notification tcb = tcbBoundNotification tcb'
+   \<and> tcb_mcpriority tcb = tcbMCP tcb'
+   \<and> tcb_priority tcb = tcbPriority tcb'
+   \<and> tcb_time_slice tcb = tcbTimeSlice tcb'
+   \<and> tcb_domain tcb = tcbDomain tcb'"
 
 \<comment> \<open>
   A pair of objects @{term "(obj, obj')"} should satisfy the following relation when, under further
@@ -389,22 +388,8 @@ where
   (\<forall>x \<in> dom ab. \<forall>(y, P) \<in> obj_relation_cuts (the (ab x)) x.
        P (the (ab x)) (the (con y)))"
 
-definition etcb_relation :: "etcb \<Rightarrow> Structures_H.tcb \<Rightarrow> bool"
-where
- "etcb_relation \<equiv> \<lambda>etcb tcb'.
-    tcb_priority etcb = tcbPriority tcb'
-  \<and> tcb_time_slice etcb = tcbTimeSlice tcb'
-  \<and> tcb_domain etcb = tcbDomain tcb'"
-
-definition
- ekheap_relation :: "(obj_ref \<Rightarrow> etcb option) \<Rightarrow> (word32 \<rightharpoonup> Structures_H.kernel_object) \<Rightarrow> bool"
-where
- "ekheap_relation ab con \<equiv>
-    \<forall>x \<in> dom ab. \<exists>tcb'. con x = Some (KOTCB tcb') \<and> etcb_relation (the (ab x)) tcb'"
-
-primrec
-  sched_act_relation :: "Deterministic_A.scheduler_action \<Rightarrow> Structures_H.scheduler_action \<Rightarrow> bool"
-where
+primrec sched_act_relation :: "Structures_A.scheduler_action \<Rightarrow> scheduler_action \<Rightarrow> bool"
+  where
   "sched_act_relation resume_cur_thread a' = (a' = ResumeCurrentThread)" |
   "sched_act_relation choose_new_thread a' = (a' = ChooseNewThread)" |
   "sched_act_relation (switch_thread x) a' = (a' = SwitchToThread x)"
@@ -431,8 +416,8 @@ lemma list_queue_relation_nil:
   by (fastforce dest: heap_path_head simp: tcbQueueEmpty_def list_queue_relation_def)
 
 definition ready_queue_relation ::
-  "Deterministic_A.domain \<Rightarrow> Structures_A.priority
-   \<Rightarrow> Deterministic_A.ready_queue \<Rightarrow> ready_queue
+  "Structures_A.domain \<Rightarrow> Structures_A.priority
+   \<Rightarrow> Structures_A.ready_queue \<Rightarrow> ready_queue
    \<Rightarrow> (obj_ref \<rightharpoonup> obj_ref) \<Rightarrow> (obj_ref \<rightharpoonup> obj_ref)
    \<Rightarrow> (obj_ref \<Rightarrow> bool) \<Rightarrow> bool"
   where
@@ -442,7 +427,7 @@ definition ready_queue_relation ::
      \<and> (d > maxDomain \<or> p > maxPriority \<longrightarrow> tcbQueueEmpty q')"
 
 definition ready_queues_relation_2 ::
-  "(Deterministic_A.domain \<Rightarrow> Structures_A.priority \<Rightarrow> Deterministic_A.ready_queue)
+  "(Structures_A.domain \<Rightarrow> Structures_A.priority \<Rightarrow> Structures_A.ready_queue)
    \<Rightarrow> (domain \<times> priority \<Rightarrow> ready_queue)
    \<Rightarrow> (obj_ref \<rightharpoonup> obj_ref) \<Rightarrow> (obj_ref \<rightharpoonup> obj_ref)
    \<Rightarrow> (domain \<Rightarrow> priority \<Rightarrow> obj_ref \<Rightarrow> bool) \<Rightarrow> bool"
@@ -622,7 +607,6 @@ definition
 where
  "state_relation \<equiv> {(s, s').
          pspace_relation (kheap s) (ksPSpace s')
-       \<and> ekheap_relation (ekheap s) (ksPSpace s')
        \<and> sched_act_relation (scheduler_action s) (ksSchedulerAction s')
        \<and> ready_queues_relation s s'
        \<and> ghost_relation (kheap s) (gsUserPages s') (gsCNodes s')
@@ -654,10 +638,6 @@ lemma state_relation_pspace_relation[elim!]:
   "(s,s') \<in> state_relation \<Longrightarrow> pspace_relation (kheap s) (ksPSpace s')"
   by (simp add: state_relation_def)
 
-lemma state_relation_ekheap_relation[elim!]:
-  "(s,s') \<in> state_relation \<Longrightarrow> ekheap_relation (ekheap s) (ksPSpace s')"
-  by (simp add: state_relation_def)
-
 lemma state_relation_sched_act_relation[elim!]:
   "(s,s') \<in> state_relation \<Longrightarrow> sched_act_relation (scheduler_action s) (ksSchedulerAction s')"
   by (clarsimp simp: state_relation_def)
@@ -673,7 +653,6 @@ lemma state_relation_idle_thread[elim!]:
 lemma state_relationD:
   assumes sr:  "(s, s') \<in> state_relation"
   shows "pspace_relation (kheap s) (ksPSpace s') \<and>
-  ekheap_relation (ekheap s) (ksPSpace s') \<and>
   sched_act_relation (scheduler_action s) (ksSchedulerAction s') \<and>
   ready_queues_relation s s' \<and>
   ghost_relation (kheap s) (gsUserPages s') (gsCNodes s') \<and>
@@ -695,7 +674,6 @@ lemma state_relationD:
 lemma state_relationE [elim?]:
   assumes sr:  "(s, s') \<in> state_relation"
   and rl: "\<lbrakk>pspace_relation (kheap s) (ksPSpace s');
-  ekheap_relation (ekheap s) (ksPSpace s');
   sched_act_relation (scheduler_action s) (ksSchedulerAction s');
   ready_queues_relation s s';
   ghost_relation (kheap s) (gsUserPages s') (gsCNodes s');
@@ -749,11 +727,6 @@ lemma pspace_relation_absD:
   apply (rule rev_bexI, erule domI)
   apply (simp add: image_def rev_bexI)
   done
-
-lemma ekheap_relation_absD:
-  "\<lbrakk> ab x = Some y; ekheap_relation ab con \<rbrakk>
-      \<Longrightarrow> \<exists>tcb'. con x = Some (KOTCB tcb') \<and> etcb_relation y tcb'"
-  by (force simp add: ekheap_relation_def)
 
 lemma in_related_pspace_dom:
   "\<lbrakk> s' x = Some y; pspace_relation s s' \<rbrakk> \<Longrightarrow> x \<in> pspace_dom s"

--- a/proof/refine/ARM/Syscall_R.thy
+++ b/proof/refine/ARM/Syscall_R.thy
@@ -341,7 +341,7 @@ lemma threadSet_tcbDomain_update_sch_act_wf[wp]:
 
 lemma setDomain_corres:
   "corres dc
-     (valid_etcbs and valid_sched and tcb_at tptr and pspace_aligned and pspace_distinct)
+     (valid_sched and tcb_at tptr and pspace_aligned and pspace_distinct)
      (invs' and sch_act_simple and tcb_at' tptr and (\<lambda>s. new_dom \<le> maxDomain))
      (set_domain tptr new_dom) (setDomain tptr new_dom)"
   apply (rule corres_gen_asm2)
@@ -350,8 +350,8 @@ lemma setDomain_corres:
     apply (rule corres_split[OF getCurThread_corres])
       apply (rule corres_split[OF tcbSchedDequeue_corres], simp)
         apply (rule corres_split)
-           apply (rule ethread_set_corres; simp)
-           apply (clarsimp simp: etcb_relation_def)
+           apply (rule threadSet_not_queued_corres;
+                  simp add: tcb_relation_def tcb_cap_cases_def tcb_cte_cases_def cteSizeBits_def)
           apply (rule corres_split[OF isRunnable_corres])
             apply simp
             apply (rule corres_split)
@@ -364,9 +364,9 @@ lemma setDomain_corres:
             apply ((wpsimp wp: hoare_drop_imps | strengthen valid_objs'_valid_tcbs')+)[1]
            apply (wpsimp wp: gts_wp)
           apply wpsimp
-         apply ((wpsimp wp: hoare_vcg_imp_lift' ethread_set_not_queued_valid_queues hoare_vcg_all_lift
-                 | strengthen valid_objs'_valid_tcbs' valid_queues_in_correct_ready_q
-                              valid_queues_ready_qs_distinct)+)[1]
+         apply (wpsimp wp: hoare_vcg_imp_lift' hoare_vcg_all_lift
+                           thread_set_in_correct_ready_q_not_queued thread_set_no_change_tcb_state
+                           thread_set_no_change_tcb_state_converse thread_set_weak_valid_sched_action)
         apply (rule_tac Q'="\<lambda>_. valid_objs' and sym_heap_sched_pointers and valid_sched_pointers
                                and pspace_aligned' and pspace_distinct'
                                and (\<lambda>s. sch_act_wf (ksSchedulerAction s) s) and tcb_at' tptr"
@@ -375,7 +375,7 @@ lemma setDomain_corres:
         apply (wpsimp wp: threadSet_valid_objs' threadSet_sched_pointers
                           threadSet_valid_sched_pointers)+
        apply (rule_tac Q'="\<lambda>_ s. valid_queues s \<and> not_queued tptr s
-                                \<and> pspace_aligned s \<and> pspace_distinct s \<and> valid_etcbs s
+                                \<and> pspace_aligned s \<and> pspace_distinct s
                                 \<and> weak_valid_sched_action s"
                     in hoare_post_imp)
         apply (fastforce simp: pred_tcb_at_def obj_at_def)
@@ -389,10 +389,7 @@ lemma setDomain_corres:
        apply (clarsimp simp: tcb_cte_cases_def cteSizeBits_def)
        apply fastforce
       apply (wp hoare_vcg_all_lift tcbSchedDequeue_not_queued)+
-   apply clarsimp
-   apply (frule tcb_at_is_etcb_at)
-    apply simp+
-   apply (auto elim: tcb_at_is_etcb_at valid_objs'_maxDomain valid_objs'_maxPriority pred_tcb'_weakenE
+   apply (auto elim: valid_objs'_maxDomain valid_objs'_maxPriority pred_tcb'_weakenE
                simp: valid_sched_def valid_sched_action_def)
   done
 
@@ -1603,8 +1600,7 @@ lemma handleYield_corres:
                 | strengthen valid_objs'_valid_tcbs' valid_queues_in_correct_ready_q
                   valid_queues_ready_qs_distinct)+
    apply (simp add: invs_def valid_sched_def valid_sched_action_def cur_tcb_def
-                    tcb_at_is_etcb_at valid_state_def valid_pspace_def ct_in_state_def
-                    runnable_eq_active)
+                    valid_state_def valid_pspace_def ct_in_state_def runnable_eq_active)
   apply (fastforce simp: invs'_def valid_state'_def ct_in_state'_def sch_act_wf_weak cur_tcb'_def
                         valid_pspace_valid_objs' valid_objs'_maxDomain tcb_in_cur_domain'_def)
   done
@@ -1852,10 +1848,6 @@ lemma handleReply_nonz_cap_to_ct:
 
 crunch handleFaultReply
   for ksQ[wp]: "\<lambda>s. P (ksReadyQueues s p)"
-
-crunch possible_switch_to, handle_recv
-  for valid_etcbs[wp]: "valid_etcbs"
-  (wp: crunch_wps simp: crunch_simps)
 
 lemma handleReply_handleRecv_corres:
   "corres dc (einvs and ct_running)

--- a/proof/refine/ARM/TcbAcc_R.thy
+++ b/proof/refine/ARM/TcbAcc_R.thy
@@ -335,29 +335,27 @@ lemma setObject_update_TCB_corres':
   assumes tables': "\<forall>(getF, v) \<in> ran tcb_cte_cases. getF new_tcb' = getF tcb'"
   assumes sched_pointers: "tcbSchedPrev new_tcb' = tcbSchedPrev tcb'"
                           "tcbSchedNext new_tcb' = tcbSchedNext tcb'"
-  assumes flag: "tcbQueued new_tcb' = tcbQueued tcb'"
+  assumes flag: "\<And>d p. inQ d p new_tcb' = inQ d p tcb'"
   assumes r: "r () ()"
-  assumes exst: "exst_same tcb' new_tcb'"
   shows
     "corres r
        (ko_at (TCB tcb) ptr) (ko_at' tcb' ptr)
        (set_object ptr (TCB new_tcb)) (setObject ptr new_tcb')"
-  apply (rule_tac F="tcb_relation tcb tcb' \<and> exst_same tcb' new_tcb'" in corres_req)
+  apply (rule_tac F="tcb_relation tcb tcb'" in corres_req)
    apply (clarsimp simp: state_relation_def obj_at_def obj_at'_def)
    apply (frule(1) pspace_relation_absD)
-   apply (clarsimp simp: tcb_relation_cut_def exst projectKOs)
+   apply (clarsimp simp: tcb_relation_cut_def projectKOs)
   apply (rule corres_no_failI)
-   apply (rule no_fail_pre)
-    apply wp
+   apply wp
    apply (clarsimp simp: obj_at'_def)
   apply (unfold set_object_def setObject_def)
   apply (clarsimp simp: in_monad split_def bind_def gets_def get_def Bex_def
                         put_def return_def modify_def get_object_def projectKOs obj_at_def
-                        updateObject_default_def in_magnitude_check obj_at'_def)
-  apply (rename_tac s s' t')
-  apply (prop_tac "t' = s'")
-   apply (clarsimp simp: magnitudeCheck_def in_monad split: option.splits)
-  apply (drule singleton_in_magnitude_check)
+                        updateObject_default_def in_magnitude_check objBits_less_word_bits)
+  apply (rename_tac s s' ko)
+  apply (prop_tac "ko = tcb'")
+   apply (clarsimp simp: obj_at'_def projectKOs project_inject)
+  apply (clarsimp simp: state_relation_def)
   apply (prop_tac "map_to_ctes ((ksPSpace s') (ptr \<mapsto> injectKO new_tcb'))
                    = map_to_ctes (ksPSpace s')")
    apply (frule_tac tcb=new_tcb' and tcb=tcb' in map_to_ctes_upd_tcb)
@@ -365,73 +363,57 @@ lemma setObject_update_TCB_corres':
     apply (clarsimp simp: objBits_simps ps_clear_def3 field_simps objBits_defs mask_def)
    apply (insert tables')[1]
    apply (rule ext)
-   apply (clarsimp split: if_splits)
-   apply blast
+   subgoal by auto
   apply (prop_tac "obj_at (same_caps (TCB new_tcb)) ptr s")
    using tables
    apply (fastforce simp: obj_at_def)
-  apply (clarsimp simp: caps_of_state_after_update cte_wp_at_after_update swp_def
+  apply (clarsimp simp: caps_of_state_after_update cte_wp_at_after_update swp_def fun_upd_def
                         obj_at_def assms)
-  apply (clarsimp simp add: state_relation_def)
   apply (subst conj_assoc[symmetric])
   apply (extract_conjunct \<open>match conclusion in "ghost_relation _ _ _" \<Rightarrow> -\<close>)
-   apply (clarsimp simp add: ghost_relation_def)
+   apply (clarsimp simp: ghost_relation_def)
    apply (erule_tac x=ptr in allE)+
    apply clarsimp
-  apply (simp only: pspace_relation_def pspace_dom_update dom_fun_upd2 simp_thms)
-  apply (elim conjE)
-  apply (frule bspec, erule domI)
-  apply clarsimp
-  apply (rule conjI)
+  apply (extract_conjunct \<open>match conclusion in "pspace_relation _ _" \<Rightarrow> -\<close>)
+   apply (fold fun_upd_def)
    apply (simp only: pspace_relation_def simp_thms
                      pspace_dom_update[where x="kernel_object.TCB _"
                                          and v="kernel_object.TCB _",
                                        simplified a_type_def, simplified])
-  apply (rule conjI)
    using assms
    apply (simp only: dom_fun_upd2 simp_thms)
+   apply (elim conjE)
    apply (frule bspec, erule domI)
    apply (rule ballI, drule(1) bspec)
    apply (drule domD)
-   apply (clarsimp simp: tcb_relation_cut_def split: if_split_asm kernel_object.split_asm)
+   apply (clarsimp simp: project_inject tcb_relation_cut_def
+                  split: if_split_asm kernel_object.split_asm)
    apply (rename_tac aa ba)
    apply (drule_tac x="(aa, ba)" in bspec, simp)
    apply clarsimp
    apply (frule_tac ko'="kernel_object.TCB tcb" and x'=ptr in obj_relation_cut_same_type)
       apply (simp add: tcb_relation_cut_def)+
    apply clarsimp
-  apply (extract_conjunct \<open>match conclusion in "ekheap_relation _ _" \<Rightarrow> -\<close>)
-   apply (simp only: ekheap_relation_def)
-   apply (rule ballI, drule (1) bspec)
-   apply (insert exst)
-   apply (clarsimp simp: etcb_relation_def exst_same_def)
-  apply (extract_conjunct \<open>match conclusion in "ready_queues_relation_2 _ _ _ _ _" \<Rightarrow> -\<close>)
-   apply (insert sched_pointers flag exst)
-   apply (clarsimp simp: ready_queues_relation_def Let_def)
-   apply (prop_tac "(tcbSchedNexts_of s')(ptr := tcbSchedNext new_tcb') = tcbSchedNexts_of s'")
-    apply (fastforce simp: opt_map_def)
-   apply (prop_tac "(tcbSchedPrevs_of s')(ptr := tcbSchedPrev new_tcb') = tcbSchedPrevs_of s'")
-    apply (fastforce simp: opt_map_def)
-   apply (clarsimp simp: ready_queue_relation_def opt_pred_def opt_map_def exst_same_def
-                         inQ_def projectKOs
-                  split: option.splits)
-   apply (metis (mono_tags, opaque_lifting))
-  apply (clarsimp simp: fun_upd_def caps_of_state_after_update cte_wp_at_after_update swp_def
-                        obj_at_def)
-  done
+  apply (insert sched_pointers flag)
+  apply (clarsimp simp: ready_queues_relation_def Let_def)
+  apply (prop_tac "(tcbSchedNexts_of s')(ptr := tcbSchedNext new_tcb') = tcbSchedNexts_of s'")
+   apply (fastforce simp: opt_map_def)
+  apply (prop_tac "(tcbSchedPrevs_of s')(ptr := tcbSchedPrev new_tcb') = tcbSchedPrevs_of s'")
+   apply (fastforce simp: opt_map_def)
+  by (clarsimp simp: ready_queue_relation_def opt_pred_def opt_map_def split: option.splits)
 
 lemma setObject_update_TCB_corres:
   "\<lbrakk>tcb_relation tcb tcb' \<Longrightarrow> tcb_relation new_tcb new_tcb';
      \<forall>(getF, v) \<in> ran tcb_cap_cases. getF new_tcb = getF tcb;
      \<forall>(getF, v) \<in> ran tcb_cte_cases. getF new_tcb' = getF tcb';
      tcbSchedPrev new_tcb' = tcbSchedPrev tcb'; tcbSchedNext new_tcb' = tcbSchedNext tcb';
-     tcbQueued new_tcb' = tcbQueued tcb'; exst_same tcb' new_tcb';
+     \<And>d p. inQ d p new_tcb' = inQ d p tcb';
      r () ()\<rbrakk> \<Longrightarrow>
    corres r
      (\<lambda>s. get_tcb ptr s = Some tcb) (\<lambda>s'. (tcb', s') \<in> fst (getObject ptr s'))
      (set_object ptr (TCB new_tcb)) (setObject ptr new_tcb')"
   apply (rule corres_guard_imp)
-    apply (erule (7) setObject_update_TCB_corres')
+    apply (erule (4) setObject_update_TCB_corres'; fastforce)
    apply (clarsimp simp: getObject_def in_monad split_def obj_at'_def projectKOs
                          loadObject_default_def objBits_simps' in_magnitude_check)+
   done
@@ -485,8 +467,7 @@ lemma threadset_corresT:
                  getF (f' tcb) = getF tcb"
   assumes sched_pointers: "\<And>tcb. tcbSchedPrev (f' tcb) = tcbSchedPrev tcb"
                           "\<And>tcb. tcbSchedNext (f' tcb) = tcbSchedNext tcb"
-  assumes flag: "\<And>tcb. tcbQueued (f' tcb) = tcbQueued tcb"
-  assumes e: "\<And>tcb'. exst_same tcb' (f' tcb')"
+  assumes flag: "\<And>d p tcb'. inQ d p (f' tcb') = inQ d p tcb'"
   shows      "corres dc (tcb_at t and pspace_aligned and pspace_distinct)
                         \<top>
                         (thread_set f t) (threadSet f' t)"
@@ -494,15 +475,14 @@ lemma threadset_corresT:
   apply (rule corres_guard_imp)
     apply (rule corres_split[OF getObject_TCB_corres])
       apply (rule setObject_update_TCB_corres')
-             apply (erule x)
-            apply (rule y)
-           apply (clarsimp simp: bspec_split [OF spec [OF z]])
-           apply fastforce
-          apply (rule sched_pointers)
+            apply (erule x)
+           apply (rule y)
+          apply (clarsimp simp: bspec_split [OF spec [OF z]])
+          apply fastforce
          apply (rule sched_pointers)
-        apply (rule flag)
-       apply simp
-      apply (rule e)
+        apply (rule sched_pointers)
+       apply (rule flag)
+      apply simp
      apply wp+
    apply (clarsimp simp add: tcb_at_def obj_at_def)
    apply (drule get_tcb_SomeD)
@@ -532,8 +512,7 @@ lemma threadSet_corres_noopT:
                  getF (fn tcb) = getF tcb"
   assumes s: "\<forall>tcb'. tcbSchedPrev (fn tcb') = tcbSchedPrev tcb'"
              "\<forall>tcb'. tcbSchedNext (fn tcb') = tcbSchedNext tcb'"
-  assumes f: "\<And>tcb'. tcbQueued (fn tcb') = tcbQueued tcb'"
-  assumes e: "\<And>tcb'. exst_same tcb' (fn tcb')"
+  assumes f: "\<And>d p tcb'. inQ d p (fn tcb') = inQ d p tcb'"
   shows      "corres dc (tcb_at t and pspace_aligned and pspace_distinct) \<top>
                         (return v) (threadSet fn t)"
 proof -
@@ -551,13 +530,12 @@ proof -
        defer
        apply (subst bind_return [symmetric],
               rule corres_underlying_split [OF threadset_corresT])
-                apply (simp add: x)
-               apply simp
-              apply (rule y)
-             apply (fastforce simp: s)
+               apply (simp add: x)
+              apply simp
+             apply (rule y)
             apply (fastforce simp: s)
-           apply (fastforce simp: f)
-          apply (rule e)
+           apply (fastforce simp: s)
+          apply (fastforce simp: f)
          apply (rule corres_noop [where P=\<top> and P'=\<top>])
           apply simp
          apply (rule no_fail_pre, wpsimp+)[1]
@@ -577,19 +555,17 @@ lemma threadSet_corres_noop_splitT:
   assumes w: "\<lbrace>P'\<rbrace> threadSet fn t \<lbrace>\<lambda>x. Q'\<rbrace>"
   assumes s: "\<forall>tcb'. tcbSchedPrev (fn tcb') = tcbSchedPrev tcb'"
              "\<forall>tcb'. tcbSchedNext (fn tcb') = tcbSchedNext tcb'"
-  assumes f: "\<And>tcb'. tcbQueued (fn tcb') = tcbQueued tcb'"
-  assumes e: "\<And>tcb'. exst_same tcb' (fn tcb')"
+  assumes f: "\<And>d p tcb'. inQ d p (fn tcb') = inQ d p tcb'"
   shows      "corres r (tcb_at t and pspace_aligned and pspace_distinct and P) P'
                            m (threadSet fn t >>= (\<lambda>rv. m'))"
   apply (rule corres_guard_imp)
     apply (subst return_bind[symmetric])
     apply (rule corres_split_nor[OF threadSet_corres_noopT])
-            apply (simp add: x)
-           apply (rule y)
-          apply (fastforce simp: s)
+           apply (simp add: x)
+          apply (rule y)
          apply (fastforce simp: s)
-        apply (fastforce simp: f)
-       apply (rule e)
+        apply (fastforce simp: s)
+       apply (fastforce simp: f)
       apply (rule z)
      apply (wp w)+
    apply simp
@@ -1555,7 +1531,7 @@ proof -
                      (set_object add (TCB (tcb \<lparr> tcb_arch := arch_tcb_context_set con (tcb_arch tcb) \<rparr>)))
                      (setObject add (tcb' \<lparr> tcbArch := atcbContextSet con' (tcbArch tcb') \<rparr>))"
     by (rule setObject_update_TCB_corres [OF L2],
-        (simp add: tcb_cte_cases_def tcb_cap_cases_def cteSizeBits_def exst_same_def)+)
+        (simp add: tcb_cte_cases_def tcb_cap_cases_def cteSizeBits_def)+)
   have L4: "\<And>con con'. con = con' \<Longrightarrow>
             corres (\<lambda>(irv, nc) (irv', nc'). r irv irv' \<and> nc = nc')
                    \<top> \<top> (select_f (f con)) (select_f (g con'))"
@@ -1898,41 +1874,6 @@ lemma threadGet_obj_at':
   "\<lbrace>obj_at' (\<lambda>t. P (f t) t) t\<rbrace> threadGet f t \<lbrace>\<lambda>rv. obj_at' (P rv) t\<rbrace>"
   by (simp add: threadGet_def o_def | wp getObject_obj_at_tcb)+
 
-lemma corres_get_etcb:
-  "corres (etcb_relation) (is_etcb_at t) (tcb_at' t)
-                    (gets_the (get_etcb t)) (getObject t)"
-  apply (rule corres_no_failI)
-   apply wp
-  apply (clarsimp simp add: get_etcb_def gets_the_def gets_def
-                            get_def assert_opt_def bind_def
-                            return_def fail_def
-                            split: option.splits
-                            )
-  apply (frule in_inv_by_hoareD [OF getObject_inv_tcb])
-  apply (clarsimp simp add: is_etcb_at_def obj_at'_def projectKO_def
-                            projectKO_opt_tcb split_def
-                            getObject_def loadObject_default_def in_monad)
-  apply (case_tac bb)
-        apply (simp_all add: fail_def return_def)
-  apply (clarsimp simp add: state_relation_def ekheap_relation_def)
-  apply (drule bspec)
-   apply clarsimp
-   apply blast
-  apply (clarsimp simp add: other_obj_relation_def lookupAround2_known1)
-  done
-
-
-lemma ethreadget_corres:
-  assumes x: "\<And>etcb tcb'. etcb_relation etcb tcb' \<Longrightarrow> r (f etcb) (f' tcb')"
-  shows      "corres r (is_etcb_at t) (tcb_at' t) (ethread_get f t) (threadGet f' t)"
-  apply (simp add: ethread_get_def threadGet_def)
-  apply (fold liftM_def)
-  apply simp
-  apply (rule corres_rel_imp)
-   apply (rule corres_get_etcb)
-  apply (simp add: x)
-  done
-
 lemma getQueue_corres:
   "corres (\<lambda>ls q. (ls = [] \<longleftrightarrow> tcbQueueEmpty q) \<and> (ls \<noteq> [] \<longrightarrow> tcbQueueHead q = Some (hd ls))
                   \<and> queue_end_valid ls q)
@@ -1983,13 +1924,14 @@ crunch removeFromBitmap
 lemmas addToBitmap_typ_ats [wp] = typ_at_lifts [OF addToBitmap_typ_at']
 lemmas removeFromBitmap_typ_ats [wp] = typ_at_lifts [OF removeFromBitmap_typ_at']
 
-lemma ekheap_relation_tcb_domain_priority:
-  "\<lbrakk>ekheap_relation (ekheap s) (ksPSpace s'); ekheap s t = Some (tcb);
+lemma pspace_relation_tcb_domain_priority:
+  "\<lbrakk>pspace_relation (kheap s) (ksPSpace s'); kheap s t = Some (TCB tcb);
     ksPSpace s' t = Some (KOTCB tcb')\<rbrakk>
    \<Longrightarrow> tcbDomain tcb' = tcb_domain tcb \<and> tcbPriority tcb' = tcb_priority tcb"
-  apply (clarsimp simp: ekheap_relation_def)
-  apply (drule_tac x=t in bspec, blast)
-  apply (clarsimp simp: other_obj_relation_def etcb_relation_def)
+  apply (clarsimp simp: pspace_relation_def)
+  apply (drule_tac x=t in bspec)
+   apply (fastforce simp: obj_at_def)
+  apply (clarsimp simp: obj_at_def obj_at'_def tcb_relation_cut_def tcb_relation_def)
   done
 
 lemma no_fail_thread_get[wp]:
@@ -2036,85 +1978,16 @@ lemma threadSet_pspace_relation:
   apply (fastforce dest!: tcb_rel)
   done
 
-lemma ekheap_relation_update_tcbs:
-  "\<lbrakk> ekheap_relation (ekheap s) (ksPSpace s'); ekheap s x = Some oetcb;
-     ksPSpace s' x = Some (KOTCB otcb'); etcb_relation etcb tcb' \<rbrakk>
-   \<Longrightarrow> ekheap_relation ((ekheap s)(x \<mapsto> etcb)) ((ksPSpace s')(x \<mapsto> KOTCB tcb'))"
-  by (simp add: ekheap_relation_def)
-
-lemma ekheap_relation_update_concrete_tcb:
-  "\<lbrakk>ekheap_relation (ekheap s) (ksPSpace s'); ekheap s ptr = Some etcb;
-    ksPSpace s' ptr = Some (KOTCB otcb');
-    etcb_relation etcb tcb'\<rbrakk>
-   \<Longrightarrow> ekheap_relation (ekheap s) ((ksPSpace s')(ptr \<mapsto> KOTCB tcb'))"
-  by (fastforce dest: ekheap_relation_update_tcbs simp: map_upd_triv)
-
-lemma ekheap_relation_etcb_relation:
-  "\<lbrakk>ekheap_relation (ekheap s) (ksPSpace s'); ekheap s ptr = Some etcb;
-    ksPSpace s' ptr = Some (KOTCB tcb')\<rbrakk>
-   \<Longrightarrow> etcb_relation etcb tcb'"
-  apply (clarsimp simp: ekheap_relation_def)
-  apply (drule_tac x=ptr in bspec)
-   apply (fastforce simp: obj_at_def)
-  apply (clarsimp simp: obj_at_def obj_at'_def)
-  done
-
-lemma threadSet_ekheap_relation:
-  fixes s :: det_state
-  assumes etcb_rel: "(\<And>etcb tcb'. etcb_relation etcb tcb' \<Longrightarrow> etcb_relation etcb (F tcb'))"
-  shows
-    "\<lbrace>\<lambda>s'. ekheap_relation (ekheap s) (ksPSpace s') \<and> pspace_relation (kheap s) (ksPSpace s')
-           \<and> valid_etcbs s\<rbrace>
-     threadSet F tcbPtr
-     \<lbrace>\<lambda>_ s'. ekheap_relation (ekheap s) (ksPSpace s')\<rbrace>"
-  supply fun_upd_apply[simp del]
-  unfolding threadSet_def setObject_def updateObject_default_def
-  apply (wpsimp wp: getObject_tcb_wp simp: updateObject_default_def)
-  apply (frule tcb_at'_cross)
-   apply (fastforce simp: obj_at'_def)
-  apply normalise_obj_at'
-  apply (frule (1) tcb_at_is_etcb_at)
-  apply (clarsimp simp: obj_at_def is_tcb_def is_etcb_at_def)
-  apply (rename_tac ko, case_tac ko; clarsimp)
-  apply (rule ekheap_relation_update_concrete_tcb)
-     apply fastforce
-    apply fastforce
-   apply (fastforce simp: obj_at'_def projectKOs)
-  apply (frule (1) ekheap_relation_etcb_relation)
-   apply (fastforce simp: obj_at'_def projectKOs)
-  apply (fastforce dest!: etcb_rel)
-  done
-
 lemma tcbQueued_update_pspace_relation[wp]:
   fixes s :: det_state
   shows "threadSet (tcbQueued_update f) tcbPtr \<lbrace>\<lambda>s'. pspace_relation (kheap s) (ksPSpace s')\<rbrace>"
   by (wpsimp wp: threadSet_pspace_relation simp: tcb_relation_def)
-
-lemma tcbQueued_update_ekheap_relation[wp]:
-  fixes s :: det_state
-  shows
-    "\<lbrace>\<lambda>s'. ekheap_relation (ekheap s) (ksPSpace s') \<and> pspace_relation (kheap s) (ksPSpace s')
-           \<and> valid_etcbs s\<rbrace>
-     threadSet (tcbQueued_update f) tcbPtr
-     \<lbrace>\<lambda>_ s'. ekheap_relation (ekheap s) (ksPSpace s')\<rbrace>"
-  by (wpsimp wp: threadSet_ekheap_relation simp: etcb_relation_def)
 
 lemma tcbQueueRemove_pspace_relation[wp]:
   fixes s :: det_state
   shows "tcbQueueRemove queue tcbPtr \<lbrace>\<lambda>s'. pspace_relation (kheap s) (ksPSpace s')\<rbrace>"
   unfolding tcbQueueRemove_def
   by (wpsimp wp: threadSet_pspace_relation hoare_drop_imps simp: tcb_relation_def)
-
-lemma tcbQueueRemove_ekheap_relation[wp]:
-  fixes s :: det_state
-  shows
-    "\<lbrace>\<lambda>s'. ekheap_relation (ekheap s) (ksPSpace s') \<and> pspace_relation (kheap s) (ksPSpace s')
-           \<and> valid_etcbs s\<rbrace>
-     tcbQueueRemove queue tcbPtr
-     \<lbrace>\<lambda>_ s'. ekheap_relation (ekheap s) (ksPSpace s')\<rbrace>"
-  unfolding tcbQueueRemove_def
-  by (wpsimp wp: threadSet_ekheap_relation threadSet_pspace_relation hoare_drop_imps
-           simp: tcb_relation_def etcb_relation_def)
 
 lemma threadSet_ghost_relation[wp]:
   "threadSet f tcbPtr \<lbrace>\<lambda>s'. ghost_relation (kheap s) (gsUserPages s') (gsCNodes s')\<rbrace>"
@@ -2153,7 +2026,7 @@ lemma set_tcb_queue_projs:
    \<lbrace>\<lambda>s. P (kheap s) (cdt s) (is_original_cap s) (cur_thread s) (idle_thread s) (scheduler_action s)
           (domain_list s) (domain_index s) (cur_domain s) (domain_time s) (machine_state s)
           (interrupt_irq_node s) (interrupt_states s) (arch_state s) (caps_of_state s)
-          (work_units_completed s) (cdt_list s) (ekheap s)\<rbrace>"
+          (work_units_completed s) (cdt_list s)\<rbrace>"
   by (wpsimp simp: set_tcb_queue_def)
 
 lemma set_tcb_queue_cte_at:
@@ -2166,7 +2039,6 @@ lemma set_tcb_queue_cte_at:
 lemma set_tcb_queue_projs_inv:
   "fst (set_tcb_queue d p queue s) = {(r, s')} \<Longrightarrow>
    kheap s = kheap s'
-   \<and> ekheap s = ekheap s'
    \<and> cdt s = cdt s'
    \<and> is_original_cap s = is_original_cap s'
    \<and> cur_thread s = cur_thread s'
@@ -2199,50 +2071,17 @@ lemma tcbQueuePrepend_pspace_relation[wp]:
   unfolding tcbQueuePrepend_def
   by (wpsimp wp: threadSet_pspace_relation simp: tcb_relation_def)
 
-lemma tcbQueuePrepend_ekheap_relation[wp]:
-  fixes s :: det_state
-  shows
-    "\<lbrace>\<lambda>s'. ekheap_relation (ekheap s) (ksPSpace s') \<and> pspace_relation (kheap s) (ksPSpace s')
-           \<and> valid_etcbs s\<rbrace>
-     tcbQueuePrepend queue tcbPtr
-     \<lbrace>\<lambda>_ s'. ekheap_relation (ekheap s) (ksPSpace s')\<rbrace>"
-  unfolding tcbQueuePrepend_def
-  by (wpsimp wp: threadSet_pspace_relation threadSet_ekheap_relation
-           simp: tcb_relation_def etcb_relation_def)
-
 lemma tcbQueueAppend_pspace_relation[wp]:
   fixes s :: det_state
   shows "tcbQueueAppend queue tcbPtr \<lbrace>\<lambda>s'. pspace_relation (kheap s) (ksPSpace s')\<rbrace>"
   unfolding tcbQueueAppend_def
   by (wpsimp wp: threadSet_pspace_relation simp: tcb_relation_def)
 
-lemma tcbQueueAppend_ekheap_relation[wp]:
-  fixes s :: det_state
-  shows
-    "\<lbrace>\<lambda>s'. ekheap_relation (ekheap s) (ksPSpace s') \<and> pspace_relation (kheap s) (ksPSpace s')
-           \<and> valid_etcbs s\<rbrace>
-     tcbQueueAppend queue tcbPtr
-     \<lbrace>\<lambda>_ s'. ekheap_relation (ekheap s) (ksPSpace s')\<rbrace>"
-  unfolding tcbQueueAppend_def
-  by (wpsimp wp: threadSet_pspace_relation threadSet_ekheap_relation
-           simp: tcb_relation_def etcb_relation_def)
-
 lemma tcbQueueInsert_pspace_relation[wp]:
   fixes s :: det_state
   shows "tcbQueueInsert tcbPtr afterPtr \<lbrace>\<lambda>s'. pspace_relation (kheap s) (ksPSpace s')\<rbrace>"
   unfolding tcbQueueInsert_def
   by (wpsimp wp: threadSet_pspace_relation hoare_drop_imps simp: tcb_relation_def)
-
-lemma tcbQueueInsert_ekheap_relation[wp]:
-  fixes s :: det_state
-  shows
-    "\<lbrace>\<lambda>s'. ekheap_relation (ekheap s) (ksPSpace s') \<and> pspace_relation (kheap s) (ksPSpace s')
-           \<and> valid_etcbs s\<rbrace>
-     tcbQueueInsert tcbPtr afterPtr
-     \<lbrace>\<lambda>_ s'. ekheap_relation (ekheap s) (ksPSpace s')\<rbrace>"
-  unfolding tcbQueueInsert_def
-  by (wpsimp wp: threadSet_pspace_relation threadSet_ekheap_relation hoare_drop_imps
-           simp: tcb_relation_def etcb_relation_def)
 
 lemma removeFromBitmap_pspace_relation[wp]:
   fixes s :: det_state
@@ -2323,22 +2162,22 @@ lemma threadSet_ready_queues_relation:
 definition in_correct_ready_q_2 where
   "in_correct_ready_q_2 queues ekh \<equiv>
      \<forall>d p. \<forall>t \<in> set (queues d p). is_etcb_at' t ekh
-                                  \<and> etcb_at' (\<lambda>t. tcb_priority t = p \<and> tcb_domain t = d) t ekh"
+                                  \<and> etcb_at' (\<lambda>t. etcb_priority t = p \<and> etcb_domain t = d) t ekh"
 
-abbreviation in_correct_ready_q :: "det_ext state \<Rightarrow> bool" where
-  "in_correct_ready_q s \<equiv> in_correct_ready_q_2 (ready_queues s) (ekheap s)"
+abbreviation in_correct_ready_q :: "'z state \<Rightarrow> bool" where
+  "in_correct_ready_q s \<equiv> in_correct_ready_q_2 (ready_queues s) (etcbs_of s)"
 
 lemmas in_correct_ready_q_def = in_correct_ready_q_2_def
 
 lemma in_correct_ready_q_lift:
-  assumes c: "\<And>P. \<lbrace>\<lambda>s. P (ekheap s)\<rbrace> f \<lbrace>\<lambda>rv s. P (ekheap s)\<rbrace>"
+  assumes c: "\<And>P. f \<lbrace>\<lambda>s. P (etcbs_of s)\<rbrace>"
   assumes r: "\<And>P. f \<lbrace>\<lambda>s. P (ready_queues s)\<rbrace>"
   shows "f \<lbrace>in_correct_ready_q\<rbrace>"
   apply (rule hoare_pre)
    apply (wps assms | wpsimp)+
   done
 
-definition ready_qs_distinct :: "det_ext state \<Rightarrow> bool" where
+definition ready_qs_distinct :: "'z state \<Rightarrow> bool" where
   "ready_qs_distinct s \<equiv> \<forall>d p. distinct (ready_queues s d p)"
 
 lemma ready_qs_distinct_lift:
@@ -2439,28 +2278,6 @@ lemma thread_get_exs_valid[wp]:
   by (clarsimp simp: thread_get_def get_tcb_def gets_the_def gets_def return_def get_def
                      exs_valid_def tcb_at_def bind_def)
 
-lemma ethread_get_sp:
-  "\<lbrace>P\<rbrace> ethread_get f ptr
-   \<lbrace>\<lambda>rv. etcb_at (\<lambda>tcb. f tcb = rv) ptr and P\<rbrace>"
-  apply wpsimp
-  apply (clarsimp simp: etcb_at_def split: option.splits)
-  done
-
-lemma ethread_get_exs_valid[wp]:
-  "\<lbrakk>tcb_at tcb_ptr s; valid_etcbs s\<rbrakk> \<Longrightarrow> \<lbrace>(=) s\<rbrace> ethread_get f tcb_ptr \<exists>\<lbrace>\<lambda>_. (=) s\<rbrace>"
-  apply (frule (1) tcb_at_is_etcb_at)
-  apply (clarsimp simp: ethread_get_def get_etcb_def gets_the_def gets_def return_def get_def
-                        is_etcb_at_def exs_valid_def bind_def)
-  done
-
-lemma no_fail_ethread_get[wp]:
-  "no_fail (tcb_at tcb_ptr and valid_etcbs) (ethread_get f tcb_ptr)"
-  unfolding ethread_get_def
-  apply wpsimp
-  apply (frule (1) tcb_at_is_etcb_at)
-  apply (clarsimp simp: is_etcb_at_def get_etcb_def)
-  done
-
 lemma threadGet_sp:
   "\<lbrace>P\<rbrace> threadGet f ptr \<lbrace>\<lambda>rv s. \<exists>tcb :: tcb. ko_at' tcb ptr s \<and> f tcb = rv \<and> P s\<rbrace>"
   unfolding threadGet_def setObject_def
@@ -2487,7 +2304,7 @@ lemma in_ready_q_tcbQueued_eq:
 lemma tcbSchedEnqueue_corres:
   "tcb_ptr = tcbPtr \<Longrightarrow>
    corres dc
-     (in_correct_ready_q and ready_qs_distinct and valid_etcbs and st_tcb_at runnable tcb_ptr
+     (in_correct_ready_q and ready_qs_distinct and st_tcb_at runnable tcb_ptr
       and pspace_aligned and pspace_distinct)
      (sym_heap_sched_pointers and valid_sched_pointers and valid_tcbs')
      (tcb_sched_action tcb_sched_enqueue tcb_ptr) (tcbSchedEnqueue tcbPtr)"
@@ -2503,9 +2320,9 @@ lemma tcbSchedEnqueue_corres:
    apply (fastforce dest: pspace_distinct_cross)
   apply (clarsimp simp: tcb_sched_action_def tcb_sched_enqueue_def get_tcb_queue_def
                         tcbSchedEnqueue_def getQueue_def unless_def when_def)
-  apply (rule corres_symb_exec_l[OF _ _ ethread_get_sp]; (solves wpsimp)?)
+  apply (rule corres_symb_exec_l[OF _ _ thread_get_sp]; (solves wpsimp)?)
   apply (rename_tac domain)
-  apply (rule corres_symb_exec_l[OF _ _ ethread_get_sp]; (solves wpsimp)?)
+  apply (rule corres_symb_exec_l[OF _ _ thread_get_sp]; (solves wpsimp)?)
   apply (rename_tac priority)
   apply (rule corres_symb_exec_l[OF _ _ gets_sp]; (solves wpsimp)?)
   apply (rule corres_stateAssert_ignore)
@@ -2517,12 +2334,11 @@ lemma tcbSchedEnqueue_corres:
   apply (rule corres_symb_exec_r[OF _ threadGet_sp]; (solves wpsimp)?)
   apply (subst if_distrib[where f="set_tcb_queue domain prio" for domain prio])
   apply (rule corres_if_strong')
-    apply (frule state_relation_ready_queues_relation)
-    apply (frule in_ready_q_tcbQueued_eq[where t=tcbPtr])
     subgoal
-      by (fastforce dest: tcb_at_ekheap_dom pred_tcb_at_tcb_at
-                    simp: obj_at'_def opt_pred_def opt_map_def obj_at_def is_tcb_def
-                          in_correct_ready_q_def etcb_at_def is_etcb_at_def projectKOs)
+      by (fastforce dest!: state_relation_ready_queues_relation
+                           in_ready_q_tcbQueued_eq[where t=tcbPtr]
+                     simp: obj_at'_def opt_pred_def opt_map_def in_correct_ready_q_def
+                           obj_at_def etcb_at_def etcbs_of'_def projectKOs)
    apply (find_goal \<open>match conclusion in "corres _ _ _ _ (return ())" \<Rightarrow> \<open>-\<close>\<close>)
    apply (rule monadic_rewrite_corres_l[where P=P and Q=P for P, simplified])
     apply (clarsimp simp: set_tcb_queue_def)
@@ -2569,19 +2385,18 @@ lemma tcbSchedEnqueue_corres:
   apply (drule set_tcb_queue_new_state)
   apply (wpsimp wp: threadSet_wp getObject_tcb_wp simp: setQueue_def tcbQueuePrepend_def)
   apply normalise_obj_at'
-  apply (frule (1) tcb_at_is_etcb_at)
-  apply (clarsimp simp: obj_at_def is_etcb_at_def etcb_at_def)
-  apply (rename_tac s d p s' tcb' tcb etcb)
-  apply (frule_tac t=tcbPtr in ekheap_relation_tcb_domain_priority)
+  apply (clarsimp simp: obj_at_def)
+  apply (rename_tac s d p s' tcb' tcb)
+  apply (frule_tac t=tcbPtr in pspace_relation_tcb_domain_priority)
     apply (force simp: obj_at_def)
    apply (force simp: obj_at'_def projectKOs)
   apply (clarsimp split: if_splits)
   apply (cut_tac ts="ready_queues s d p" in list_queue_relation_nil)
    apply (force dest!: spec simp: list_queue_relation_def)
-  apply (cut_tac ts="ready_queues s (tcb_domain etcb) (tcb_priority etcb)"
+  apply (cut_tac ts="ready_queues s (tcb_domain tcb) (tcb_priority tcb)"
               in list_queue_relation_nil)
    apply (force dest!: spec simp: list_queue_relation_def)
-  apply (cut_tac ts="ready_queues s (tcb_domain etcb) (tcb_priority etcb)" and s'=s'
+  apply (cut_tac ts="ready_queues s (tcb_domain tcb) (tcb_priority tcb)" and s'=s'
               in obj_at'_tcbQueueEnd_ksReadyQueues)
       apply fast
      apply auto[1]
@@ -2590,14 +2405,14 @@ lemma tcbSchedEnqueue_corres:
   apply (cut_tac xs="ready_queues s d p" and st="tcbQueueHead (ksReadyQueues s' (d, p))"
               in heap_path_head')
    apply (auto dest: spec simp: list_queue_relation_def tcbQueueEmpty_def)[1]
-  apply (cut_tac xs="ready_queues s (tcb_domain etcb) (tcb_priority etcb)"
-             and st="tcbQueueHead (ksReadyQueues s' (tcb_domain etcb, tcb_priority etcb))"
+  apply (cut_tac xs="ready_queues s (tcb_domain tcb) (tcb_priority tcb)"
+             and st="tcbQueueHead (ksReadyQueues s' (tcb_domain tcb, tcb_priority tcb))"
               in heap_path_head')
    apply (auto dest: spec simp: list_queue_relation_def tcbQueueEmpty_def)[1]
   apply (clarsimp simp: list_queue_relation_def)
 
-  apply (case_tac "\<not> (d = tcb_domain etcb \<and> p = tcb_priority etcb)")
-   apply (cut_tac d=d and d'="tcb_domain etcb" and p=p and p'="tcb_priority etcb"
+  apply (case_tac "\<not> (d = tcb_domain tcb \<and> p = tcb_priority tcb)")
+   apply (cut_tac d=d and d'="tcb_domain tcb" and p=p and p'="tcb_priority tcb"
                in ready_queues_disjoint)
       apply force
      apply fastforce
@@ -2621,8 +2436,8 @@ lemma tcbSchedEnqueue_corres:
     apply (clarsimp simp: fun_upd_apply split: if_splits)
 
    \<comment> \<open>the ready queue was not originally empty\<close>
-   apply (clarsimp simp: etcb_at_def obj_at'_def)
-   apply (prop_tac "the (tcbQueueHead (ksReadyQueues s' (tcb_domain etcb, tcb_priority etcb)))
+   apply (clarsimp simp: obj_at'_def)
+   apply (prop_tac "the (tcbQueueHead (ksReadyQueues s' (tcb_domain tcb, tcb_priority tcb)))
                     \<notin> set (ready_queues s d p)")
     apply (erule orthD2)
     apply (clarsimp simp: tcbQueueEmpty_def)
@@ -2640,7 +2455,7 @@ lemma tcbSchedEnqueue_corres:
       apply (case_tac "ready_queues s d p"; force simp: tcbQueueEmpty_def)
      apply (case_tac "t = tcbPtr")
       apply (clarsimp simp: inQ_def fun_upd_apply obj_at'_def projectKOs split: if_splits)
-     apply (case_tac "t = the (tcbQueueHead (ksReadyQueues s' (tcb_domain etcb, tcb_priority etcb)))")
+     apply (case_tac "t = the (tcbQueueHead (ksReadyQueues s' (tcb_domain tcb, tcb_priority tcb)))")
       apply (clarsimp simp: inQ_def opt_pred_def opt_map_def obj_at'_def projectKOs fun_upd_apply
                      split: option.splits)
       apply metis
@@ -2648,11 +2463,11 @@ lemma tcbSchedEnqueue_corres:
     apply (clarsimp simp: fun_upd_apply split: if_splits)
    apply (clarsimp simp: fun_upd_apply split: if_splits)
 
-  \<comment> \<open>d = tcb_domain etcb \<and> p = tcb_priority etcb\<close>
+  \<comment> \<open>d = tcb_domain tcb \<and> p = tcb_priority tcb\<close>
   apply clarsimp
-  apply (drule_tac x="tcb_domain etcb" in spec)
-  apply (drule_tac x="tcb_priority etcb" in spec)
-  apply (cut_tac ts="ready_queues s (tcb_domain etcb) (tcb_priority etcb)"
+  apply (drule_tac x="tcb_domain tcb" in spec)
+  apply (drule_tac x="tcb_priority tcb" in spec)
+  apply (cut_tac ts="ready_queues s (tcb_domain tcb) (tcb_priority tcb)"
               in tcbQueueHead_iff_tcbQueueEnd)
    apply (force simp: list_queue_relation_def)
   apply (frule valid_tcbs'_maxDomain[where t=tcbPtr], simp add: obj_at'_def projectKOs)
@@ -2698,7 +2513,7 @@ lemma setSchedulerAction_corres:
   apply (simp add: setSchedulerAction_def set_scheduler_action_def)
   apply (rule corres_no_failI)
    apply wp
-  apply (clarsimp simp: in_monad simpler_modify_def state_relation_def)
+  apply (clarsimp simp: in_monad simpler_modify_def state_relation_def swp_def)
   done
 
 lemma getSchedulerAction_corres:
@@ -2709,7 +2524,7 @@ lemma getSchedulerAction_corres:
 
 lemma rescheduleRequired_corres:
   "corres dc
-     (weak_valid_sched_action and in_correct_ready_q and ready_qs_distinct and valid_etcbs
+     (weak_valid_sched_action and in_correct_ready_q and ready_qs_distinct
       and pspace_aligned and pspace_distinct)
      (sym_heap_sched_pointers and valid_sched_pointers and valid_tcbs')
      (reschedule_required) rescheduleRequired"
@@ -2727,8 +2542,8 @@ lemma rescheduleRequired_corres:
         apply (rule setSchedulerAction_corres)
         apply simp
        apply (wp | wpc | simp)+
-   apply (force dest: st_tcb_weakenE simp: in_monad weak_valid_sched_action_def valid_etcbs_def st_tcb_at_def obj_at_def is_tcb
-               split: Deterministic_A.scheduler_action.split)
+   apply (force dest: st_tcb_weakenE simp: in_monad weak_valid_sched_action_def st_tcb_at_def obj_at_def is_tcb
+               split: Structures_A.scheduler_action.split)
   apply (clarsimp split: scheduler_action.splits)
   done
 
@@ -2902,8 +2717,8 @@ definition tcb_queue_remove :: "'a \<Rightarrow> 'a list \<Rightarrow> 'a list" 
 
 definition tcb_sched_dequeue' :: "obj_ref \<Rightarrow> unit det_ext_monad" where
   "tcb_sched_dequeue' tcb_ptr \<equiv> do
-     d \<leftarrow> ethread_get tcb_domain tcb_ptr;
-     prio \<leftarrow> ethread_get tcb_priority tcb_ptr;
+     d \<leftarrow> thread_get tcb_domain tcb_ptr;
+     prio \<leftarrow> thread_get tcb_priority tcb_ptr;
      queue \<leftarrow> get_tcb_queue d prio;
      when (tcb_ptr \<in> set queue) $ set_tcb_queue d prio (tcb_queue_remove tcb_ptr queue)
    od"
@@ -2921,7 +2736,7 @@ lemma filter_tcb_queue_remove:
   done
 
 lemma tcb_sched_dequeue_monadic_rewrite:
-  "monadic_rewrite False True (is_etcb_at t and (\<lambda>s. \<forall>d p. distinct (ready_queues s d p)))
+  "monadic_rewrite False True (tcb_at t and (\<lambda>s. \<forall>d p. distinct (ready_queues s d p)))
      (tcb_sched_action tcb_sched_dequeue t) (tcb_sched_dequeue' t)"
   supply if_split[split del]
   apply (clarsimp simp: tcb_sched_dequeue'_def tcb_sched_dequeue_def tcb_sched_action_def
@@ -2934,9 +2749,9 @@ lemma tcb_sched_dequeue_monadic_rewrite:
       apply (metis (mono_tags, lifting) filter_cong)
      apply (rule monadic_rewrite_modify_noop)
     apply (wpsimp wp: thread_get_wp)+
-  apply (clarsimp simp: etcb_at_def split: option.splits)
-  apply (prop_tac "(\<lambda>d' p. if d' = tcb_domain x2 \<and> p = tcb_priority x2
-                           then filter (\<lambda>x. x \<noteq> t) (ready_queues s (tcb_domain x2) (tcb_priority x2))
+  apply (clarsimp simp: tcb_at_def)
+  apply (prop_tac "(\<lambda>d' p. if d' = tcb_domain tcb \<and> p = tcb_priority tcb
+                           then filter ((\<noteq>) t) (ready_queues s (tcb_domain tcb) (tcb_priority tcb))
                            else ready_queues s d' p)
                    = ready_queues s")
    apply (subst filter_True)
@@ -2969,7 +2784,7 @@ lemma in_queue_not_head_or_not_tail_length_gt_1:
 lemma tcbSchedDequeue_corres:
   "tcb_ptr = tcbPtr \<Longrightarrow>
    corres dc
-     (in_correct_ready_q and ready_qs_distinct and valid_etcbs and tcb_at tcb_ptr
+     (in_correct_ready_q and ready_qs_distinct and tcb_at tcb_ptr
       and pspace_aligned and pspace_distinct)
      (sym_heap_sched_pointers and valid_objs')
      (tcb_sched_action tcb_sched_dequeue tcb_ptr) (tcbSchedDequeue tcbPtr)"
@@ -2983,22 +2798,22 @@ lemma tcbSchedDequeue_corres:
    apply (fastforce dest: pspace_distinct_cross)
   apply (rule monadic_rewrite_corres_l[where P=P and Q=P for P, simplified])
    apply (rule monadic_rewrite_guard_imp[OF tcb_sched_dequeue_monadic_rewrite])
-   apply (fastforce dest: tcb_at_is_etcb_at simp: in_correct_ready_q_def ready_qs_distinct_def)
+   apply (fastforce simp: in_correct_ready_q_def ready_qs_distinct_def)
   apply (clarsimp simp: tcb_sched_dequeue'_def get_tcb_queue_def tcbSchedDequeue_def getQueue_def
                         unless_def when_def)
-  apply (rule corres_symb_exec_l[OF _ _ ethread_get_sp]; wpsimp?)
+  apply (rule corres_symb_exec_l[OF _ _ thread_get_sp]; wpsimp?)
   apply (rename_tac dom)
-  apply (rule corres_symb_exec_l[OF _ _ ethread_get_sp]; wpsimp?)
+  apply (rule corres_symb_exec_l[OF _ _ thread_get_sp]; wpsimp?)
   apply (rename_tac prio)
   apply (rule corres_symb_exec_l[OF _ _ gets_sp]; (solves wpsimp)?)
   apply (rule corres_stateAssert_ignore)
    apply (fastforce intro: ksReadyQueues_asrt_cross)
   apply (rule corres_symb_exec_r[OF _ threadGet_sp]; (solves wpsimp)?)
   apply (rule corres_if_strong'; fastforce?)
-    apply (frule state_relation_ready_queues_relation)
-    apply (frule in_ready_q_tcbQueued_eq[where t=tcbPtr])
-    apply (fastforce simp: obj_at'_def projectKOs opt_pred_def opt_map_def obj_at_def is_tcb_def
-                           in_correct_ready_q_def etcb_at_def is_etcb_at_def)
+   apply (fastforce dest!: state_relation_ready_queues_relation
+                           in_ready_q_tcbQueued_eq[where t=tcbPtr]
+                     simp: obj_at'_def opt_pred_def opt_map_def in_correct_ready_q_def
+                           obj_at_def etcb_at_def etcbs_of'_def projectKOs)
   apply (rule corres_symb_exec_r[OF _ threadGet_sp]; wpsimp?)
   apply (rule corres_symb_exec_r[OF _ threadGet_sp]; wpsimp?)
   apply (rule corres_symb_exec_r[OF _ gets_sp]; wpsimp?)
@@ -3020,24 +2835,23 @@ lemma tcbSchedDequeue_corres:
   apply (wpsimp wp: threadSet_wp getObject_tcb_wp
               simp: setQueue_def tcbQueueRemove_def
          split_del: if_split)
-  apply (frule (1) tcb_at_is_etcb_at)
-  apply (clarsimp simp: obj_at_def is_etcb_at_def etcb_at_def)
+  apply (clarsimp simp: obj_at_def)
   apply normalise_obj_at'
-  apply (rename_tac s d p s' tcb' tcb etcb)
-  apply (frule_tac t=tcbPtr in ekheap_relation_tcb_domain_priority)
+  apply (rename_tac s d p s' tcb' tcb)
+  apply (frule_tac t=tcbPtr in pspace_relation_tcb_domain_priority)
     apply (force simp: obj_at_def)
    apply (force simp: obj_at'_def projectKOs)
 
-  apply (case_tac "d \<noteq> tcb_domain etcb \<or> p \<noteq> tcb_priority etcb")
+  apply (case_tac "d \<noteq> tcb_domain tcb \<or> p \<noteq> tcb_priority tcb")
    apply clarsimp
-   apply (cut_tac p=tcbPtr and ls="ready_queues s (tcb_domain etcb) (tcb_priority etcb)"
+   apply (cut_tac p=tcbPtr and ls="ready_queues s (tcb_domain tcb) (tcb_priority tcb)"
                in list_queue_relation_neighbour_in_set)
       apply (fastforce dest!: spec)
      apply fastforce
     apply fastforce
    apply (cut_tac xs="ready_queues s d p" in heap_path_head')
     apply (force dest!: spec simp: ready_queues_relation_def Let_def list_queue_relation_def)
-   apply (cut_tac d=d and d'="tcb_domain etcb" and p=p and p'="tcb_priority etcb"
+   apply (cut_tac d=d and d'="tcb_domain tcb" and p=p and p'="tcb_priority tcb"
                in ready_queues_disjoint)
       apply force
      apply fastforce
@@ -3061,7 +2875,7 @@ lemma tcbSchedDequeue_corres:
      apply (clarsimp simp: fun_upd_apply)
     apply (clarsimp simp: fun_upd_apply)
 
-   apply (clarsimp simp: etcb_at_def obj_at'_def projectKOs)
+   apply (clarsimp simp: obj_at'_def projectKOs)
    apply (intro conjI; clarsimp)
 
     \<comment> \<open>tcbPtr is the head of the ready queue\<close>
@@ -3107,8 +2921,8 @@ lemma tcbSchedDequeue_corres:
 
   \<comment> \<open>d = tcb_domain tcb \<and> p = tcb_priority tcb\<close>
   apply clarsimp
-  apply (drule_tac x="tcb_domain etcb" in spec)
-  apply (drule_tac x="tcb_priority etcb" in spec)
+  apply (drule_tac x="tcb_domain tcb" in spec)
+  apply (drule_tac x="tcb_priority tcb" in spec)
   apply (clarsimp simp: list_queue_relation_def)
   apply (frule heap_path_head')
   apply (frule heap_ls_distinct)
@@ -3121,7 +2935,7 @@ lemma tcbSchedDequeue_corres:
      apply (simp add: fun_upd_apply tcb_queue_remove_def queue_end_valid_def heap_ls_unique
                       heap_path_last_end)
     apply (simp add: fun_upd_apply prev_queue_head_def)
-   apply (case_tac "ready_queues s (tcb_domain etcb) (tcb_priority etcb)";
+   apply (case_tac "ready_queues s (tcb_domain tcb) (tcb_priority tcb)";
           clarsimp simp: tcb_queue_remove_def inQ_def opt_pred_def fun_upd_apply)
   apply (intro conjI; clarsimp)
 
@@ -3140,7 +2954,7 @@ lemma tcbSchedDequeue_corres:
       apply (clarsimp simp: opt_map_red opt_map_upd_triv fun_upd_apply projectKOs)
      apply (clarsimp simp: queue_end_valid_def fun_upd_apply last_tl)
     apply (clarsimp simp: prev_queue_head_def fun_upd_apply projectKOs)
-   apply (case_tac "ready_queues s (tcb_domain etcb) (tcb_priority etcb)";
+   apply (case_tac "ready_queues s (tcb_domain tcb) (tcb_priority tcb)";
           clarsimp simp: inQ_def opt_pred_def opt_map_def fun_upd_apply projectKOs
                   split: option.splits)
   apply (intro conjI; clarsimp)
@@ -3221,11 +3035,11 @@ lemma setThreadState_corres:
           (set_thread_state t ts) (setThreadState ts' t)"
   (is "?tsr \<Longrightarrow> corres dc ?Pre ?Pre' ?sts ?sts'")
   apply (simp add: set_thread_state_def setThreadState_def)
-  apply (simp add: set_thread_state_ext_def[abs_def])
+  apply (simp add: set_thread_state_act_def[abs_def])
   apply (subst bind_assoc[symmetric], subst thread_set_def[simplified, symmetric])
   apply (rule corres_guard_imp)
     apply (rule corres_split[where r'=dc])
-       apply (rule threadset_corres, (simp add: tcb_relation_def exst_same_def)+)
+       apply (rule threadset_corres, (simp add: tcb_relation_def inQ_def)+)
       apply (subst thread_get_test[where test="runnable"])
       apply (rule corres_split[OF thread_get_isRunnable_corres])
         apply (rule corres_split[OF getCurThread_corres])
@@ -3246,7 +3060,7 @@ lemma setBoundNotification_corres:
           (set_bound_notification t ntfn) (setBoundNotification ntfn t)"
   apply (simp add: set_bound_notification_def setBoundNotification_def)
   apply (subst thread_set_def[simplified, symmetric])
-  apply (rule threadset_corres, simp_all add:tcb_relation_def exst_same_def)
+  apply (rule threadset_corres, simp_all add:tcb_relation_def inQ_def)
   done
 
 crunch rescheduleRequired, tcbSchedDequeue, setThreadState, setBoundNotification
@@ -5893,154 +5707,6 @@ lemma asUser_irq_handlers':
   apply (simp add: asUser_def split_def)
   apply (wpsimp wp: threadSet_irq_handlers' [OF all_tcbI, OF ball_tcb_cte_casesI] select_f_inv)
   done
-
-(* the brave can try to move this up to near setObject_update_TCB_corres' *)
-
-definition non_exst_same :: "Structures_H.tcb \<Rightarrow> Structures_H.tcb \<Rightarrow> bool"
-where
-  "non_exst_same tcb tcb' \<equiv> \<exists>d p ts. tcb' = tcb\<lparr>tcbDomain := d, tcbPriority := p, tcbTimeSlice := ts\<rparr>"
-
-fun non_exst_same' :: "Structures_H.kernel_object \<Rightarrow> Structures_H.kernel_object \<Rightarrow> bool"
-where
-  "non_exst_same' (KOTCB tcb) (KOTCB tcb') = non_exst_same tcb tcb'" |
-  "non_exst_same' _ _ = True"
-
-lemma non_exst_same_prio_upd[simp]:
-  "non_exst_same tcb (tcbPriority_update f tcb)"
-  by (cases tcb, simp add: non_exst_same_def)
-
-lemma non_exst_same_timeSlice_upd[simp]:
-  "non_exst_same tcb (tcbTimeSlice_update f tcb)"
-  by (cases tcb, simp add: non_exst_same_def)
-
-lemma non_exst_same_domain_upd[simp]:
-  "non_exst_same tcb (tcbDomain_update f tcb)"
-  by (cases tcb, simp add: non_exst_same_def)
-
-lemma set_eobject_corres':
-  assumes e: "etcb_relation etcb tcb'"
-  assumes z: "\<And>s. obj_at' P ptr s
-               \<Longrightarrow> map_to_ctes ((ksPSpace s) (ptr \<mapsto> KOTCB tcb')) = map_to_ctes (ksPSpace s)"
-  shows
-    "corres dc
-       (tcb_at ptr and is_etcb_at ptr)
-       (obj_at' (\<lambda>ko. non_exst_same ko tcb') ptr and obj_at' P ptr
-        and obj_at' (\<lambda>tcb. (tcbDomain tcb \<noteq> tcbDomain tcb' \<or> tcbPriority tcb \<noteq> tcbPriority tcb')
-                            \<longrightarrow> \<not> tcbQueued tcb) ptr)
-       (set_eobject ptr etcb) (setObject ptr tcb')"
-  apply (rule corres_no_failI)
-   apply (rule no_fail_pre)
-    apply wp
-   apply (clarsimp simp: obj_at'_def)
-  apply (unfold set_eobject_def setObject_def)
-  apply (clarsimp simp: in_monad split_def bind_def gets_def get_def Bex_def
-                        put_def return_def modify_def get_object_def projectKOs
-                        updateObject_default_def in_magnitude_check objBits_simps')
-  apply (clarsimp simp add: state_relation_def z)
-  apply (clarsimp simp add: obj_at_def is_etcb_at_def)
-  apply (simp only: pspace_relation_def dom_fun_upd2 simp_thms)
-  apply (elim conjE)
-  apply (frule bspec, erule domI)
-  apply (rule conjI)
-   apply (rule ballI, drule(1) bspec)
-   apply (drule domD)
-   apply (clarsimp simp: is_other_obj_relation_type)
-   apply (drule(1) bspec)
-   apply (clarsimp simp: non_exst_same_def)
-   apply (case_tac bb; simp)
-     apply (clarsimp simp: obj_at'_def other_obj_relation_def tcb_relation_cut_def cte_relation_def
-                           tcb_relation_def projectKOs
-                    split: if_split_asm)+
-   apply (clarsimp simp: aobj_relation_cuts_def split: ARM_A.arch_kernel_obj.splits)
-   apply (rename_tac arch_kernel_obj obj d p ts)
-   apply (case_tac arch_kernel_obj; simp)
-     apply (clarsimp simp: pte_relation_def pde_relation_def is_tcb_def
-                    split: if_split_asm)+
-  apply (extract_conjunct \<open>match conclusion in "ekheap_relation _ _" \<Rightarrow> -\<close>)
-   apply (simp only: ekheap_relation_def dom_fun_upd2 simp_thms)
-   apply (frule bspec, erule domI)
-   apply (rule ballI, drule(1) bspec)
-   apply (drule domD)
-   apply (clarsimp simp: obj_at'_def)
-   apply (insert e)
-   apply (clarsimp simp: other_obj_relation_def etcb_relation_def is_other_obj_relation_type
-                  split: Structures_A.kernel_object.splits kernel_object.splits arch_kernel_obj.splits)
-   apply (frule in_ready_q_tcbQueued_eq[where t=ptr])
-  apply (rename_tac s' conctcb' abstcb exttcb)
-  apply (clarsimp simp: ready_queues_relation_def Let_def)
-  apply (prop_tac "(tcbSchedNexts_of s')(ptr := tcbSchedNext tcb') = tcbSchedNexts_of s'")
-   apply (fastforce simp: opt_map_def obj_at'_def projectKOs non_exst_same_def split: option.splits)
-  apply (prop_tac "(tcbSchedPrevs_of s')(ptr := tcbSchedPrev tcb') = tcbSchedPrevs_of s'")
-   apply (fastforce simp: opt_map_def obj_at'_def projectKOs non_exst_same_def split: option.splits)
-  apply (clarsimp simp: ready_queue_relation_def opt_map_def opt_pred_def obj_at'_def projectKOs
-                        inQ_def non_exst_same_def
-                 split: option.splits)
-  apply metis
-  done
-
-lemma set_eobject_corres:
-  assumes tcbs: "non_exst_same tcb' tcbu'"
-  assumes e: "etcb_relation etcb tcb' \<Longrightarrow> etcb_relation etcbu tcbu'"
-  assumes tables': "\<forall>(getF, v) \<in> ran tcb_cte_cases. getF tcbu' = getF tcb'"
-  assumes r: "r () ()"
-  shows
-    "corres r
-       (tcb_at add and (\<lambda>s. ekheap s add = Some etcb))
-       (ko_at' tcb' add
-        and obj_at' (\<lambda>tcb. (tcbDomain tcb \<noteq> tcbDomain tcbu' \<or> tcbPriority tcb \<noteq> tcbPriority tcbu')
-                           \<longrightarrow> \<not> tcbQueued tcb) add)
-       (set_eobject add etcbu) (setObject add tcbu')"
-  apply (rule_tac F="non_exst_same tcb' tcbu' \<and> etcb_relation etcbu tcbu'" in corres_req)
-   apply (clarsimp simp: state_relation_def obj_at_def obj_at'_def)
-   apply (frule(1) pspace_relation_absD)
-   apply (clarsimp simp: projectKOs other_obj_relation_def ekheap_relation_def e tcbs)
-   apply (drule bspec, erule domI)
-   apply (clarsimp simp: e)
-  apply (erule conjE)
-  apply (rule corres_guard_imp)
-    apply (rule corres_rel_imp)
-     apply (rule set_eobject_corres'[where P="(=) tcb'"])
-      apply simp
-     defer
-    apply (simp add: r)
-   apply (fastforce simp: is_etcb_at_def elim!: obj_at_weakenE)
-   apply (subst(asm) eq_commute)
-   apply (clarsimp simp: obj_at'_def)
-  apply (clarsimp simp: projectKOs obj_at'_def objBits_simps)
-  apply (subst map_to_ctes_upd_tcb, assumption+)
-   apply (simp add: ps_clear_def3 field_simps objBits_defs mask_def)
-  apply (subst if_not_P)
-   apply (fastforce dest: bspec [OF tables', OF ranI])
-  apply simp
-  done
-
-lemma ethread_set_corresT:
-  assumes x: "\<And>tcb'. non_exst_same tcb' (f' tcb')"
-  assumes z: "\<forall>tcb. \<forall>(getF, setF) \<in> ran tcb_cte_cases. getF (f' tcb) = getF tcb"
-  assumes e: "\<And>etcb tcb'. etcb_relation etcb tcb' \<Longrightarrow> etcb_relation (f etcb) (f' tcb')"
-  shows
-    "corres dc
-       (tcb_at t and valid_etcbs)
-       (tcb_at' t
-        and obj_at' (\<lambda>tcb. (tcbDomain tcb \<noteq> tcbDomain (f' tcb)
-                             \<or> tcbPriority tcb \<noteq> tcbPriority (f' tcb))
-                           \<longrightarrow> \<not> tcbQueued tcb) t)
-       (ethread_set f t) (threadSet f' t)"
-  apply (simp add: ethread_set_def threadSet_def bind_assoc)
-  apply (rule corres_guard_imp)
-    apply (rule corres_split[OF corres_get_etcb set_eobject_corres])
-         apply (rule x)
-        apply (erule e)
-       apply (simp add: z)+
-     apply (wp getObject_tcb_wp)+
-   apply clarsimp
-   apply (simp add: valid_etcbs_def tcb_at_st_tcb_at[symmetric])
-   apply (force simp: tcb_at_def get_etcb_def obj_at_def)
-  apply (clarsimp simp: obj_at'_def)
-  done
-
-lemmas ethread_set_corres =
-    ethread_set_corresT [OF _ all_tcbI, OF _ ball_tcb_cte_casesI]
 
 lemma archTcbUpdate_aux2: "(\<lambda>tcb. tcb\<lparr> tcbArch := f (tcbArch tcb)\<rparr>) = tcbArch_update f"
   by (rule ext, case_tac tcb, simp)

--- a/proof/refine/ARM/Untyped_R.thy
+++ b/proof/refine/ARM/Untyped_R.thy
@@ -1330,7 +1330,7 @@ lemma in_getCTE2:
 declare wrap_ext_op_det_ext_ext_def[simp]
 
 lemma do_ext_op_update_cdt_list_symb_exec_l':
-  "corres_underlying {(s::det_state, s'). f (kheap s) (ekheap s) s'} nf nf' dc P P' (create_cap_ext p z a) (return x)"
+  "corres_underlying {(s::det_state, s'). f (kheap s) s'} nf nf' dc P P' (create_cap_ext p z a) (return x)"
   apply (simp add: corres_underlying_def create_cap_ext_def
   update_cdt_list_def set_cdt_list_def bind_def put_def get_def gets_def return_def)
   done
@@ -1366,16 +1366,13 @@ lemma set_cdt_symb_exec_l:
   by (simp add: corres_underlying_def return_def set_cdt_def in_monad Bex_def)
 
 crunch create_cap_ext
-  for domain_index[wp]: "\<lambda>s. P (domain_index s)"
-  and domain_list[wp]: "\<lambda>s. P (domain_list s)"
-  and domain_time[wp]: "\<lambda>s. P (domain_time s)"
-  and work_units_completed[wp]: "\<lambda>s. P (work_units_completed s)"
+  for work_units_completed[wp]: "\<lambda>s. P (work_units_completed s)"
   (ignore_del: create_cap_ext)
 
 context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma updateNewFreeIndex_noop_psp_corres:
-  "corres_underlying {(s, s'). pspace_relations (ekheap s) (kheap s) (ksPSpace s')} False True
+  "corres_underlying {(s, s'). pspace_relation (kheap s) (ksPSpace s')} False True
     dc \<top> (cte_at' slot)
     (return ()) (updateNewFreeIndex slot)"
   apply (simp add: updateNewFreeIndex_def)
@@ -1386,6 +1383,10 @@ lemma updateNewFreeIndex_noop_psp_corres:
       apply (wp getCTE_wp' | wpc
         | simp add: updateTrackedFreeIndex_def getSlotCap_def)+
   done
+
+crunch set_cap, set_cdt
+  for domain_index[wp]: "\<lambda>s. P (domain_index s)"
+  (wp: crunch_wps)
 
 crunch updateMDB, updateNewFreeIndex, setCTE
   for rdyq_projs[wp]:
@@ -2957,39 +2958,32 @@ lemma createNewCaps_range_helper:
   apply (frule range_cover.range_cover_n_less)
   apply (frule range_cover.unat_of_nat_n)
   apply (cases tp, simp_all split del: if_split)
-          apply (rename_tac apiobject_type)
-          apply (case_tac apiobject_type, simp_all split del: if_split)
-              apply (rule hoare_pre, wp)
-              apply (frule range_cover_not_zero[rotated -1],simp)
-              apply (clarsimp simp: APIType_capBits_def objBits_simps archObjSize_def ptr_add_def o_def)
-              apply (subst upto_enum_red')
-               apply unat_arith
-              apply (clarsimp simp: o_def fromIntegral_def toInteger_nat fromInteger_nat)
-              apply fastforce
-             apply (rule hoare_pre,wp createObjects_ret2)
-             apply (clarsimp simp: APIType_capBits_def word_bits_def
-                objBits_simps archObjSize_def ptr_add_def o_def)
-             apply (fastforce simp: objBitsKO_def objBits_def)
-            apply (rule hoare_pre,wp createObjects_ret2)
-            apply (clarsimp simp: APIType_capBits_def word_bits_def
-                                  objBits_simps archObjSize_def ptr_add_def o_def)
-            apply (fastforce simp: objBitsKO_def  objBits_def)
-           apply (rule hoare_pre,wp createObjects_ret2)
-           apply (clarsimp simp:  APIType_capBits_def word_bits_def
-              objBits_simps archObjSize_def ptr_add_def o_def)
-           apply (fastforce simp: objBitsKO_def  objBits_def)
-          apply (rule hoare_pre,wp createObjects_ret2)
-          apply (clarsimp simp: APIType_capBits_def word_bits_def
-             objBits_simps archObjSize_def ptr_add_def o_def)
-          apply (fastforce simp: objBitsKO_def  objBits_def)
-        apply (wp createObjects_ret2
-          | clarsimp simp: APIType_capBits_def objBits_if_dev archObjSize_def
-                        word_bits_def pdBits_def pageBits_def ptBits_def
-                        pteBits_def pdeBits_def
-                        split del: if_split
-          | simp add: objBits_simps
-          | (rule exI, fastforce))+
-  done
+        apply (rename_tac apiobject_type)
+        apply (case_tac apiobject_type, simp_all split del: if_split)
+            \<comment>\<open>Untyped\<close>
+            apply (rule hoare_pre, wp)
+            apply (frule range_cover_not_zero[rotated -1],simp)
+            apply (clarsimp simp: APIType_capBits_def objBits_simps ptr_add_def o_def)
+            apply (subst upto_enum_red')
+             apply unat_arith
+            apply (clarsimp simp: o_def fromIntegral_def toInteger_nat fromInteger_nat)
+            apply fastforce
+           \<comment>\<open>TCB\<close>
+           apply (rule hoare_pre, wp createObjects_ret2)
+            apply (wpsimp simp: curDomain_def)
+           apply (clarsimp simp: APIType_capBits_def word_bits_def objBits_simps ptr_add_def o_def)
+           apply (fastforce simp: objBitsKO_def objBits_def)
+           \<comment>\<open>other APIObjectType\<close>
+          apply ((rule hoare_pre, wp createObjects_ret2,
+                  clarsimp simp: APIType_capBits_def word_bits_def objBits_simps ptr_add_def o_def,
+                  fastforce simp: objBitsKO_def objBits_def)+)[3]
+       \<comment>\<open>Arch objects\<close>
+       by (wp createObjects_ret2
+           | clarsimp simp: APIType_capBits_def objBits_if_dev word_bits_def pdBits_def pageBits_def
+                            ptBits_def pteBits_def pdeBits_def
+                 split del: if_split
+           | simp add: objBits_simps
+           | (rule exI, fastforce))+
 
 lemma createNewCaps_range_helper2:
   "\<lbrace>\<lambda>s. range_cover ptr sz (APIType_capBits tp us) n \<and> 0 < n\<rbrace>
@@ -4010,9 +4004,6 @@ end
 
 context begin interpretation Arch . (*FIXME: arch-split*)
 
-lemma valid_sched_etcbs[elim!]: "valid_sched_2 queues ekh sa cdom kh ct it \<Longrightarrow> valid_etcbs_2 ekh kh"
-  by (simp add: valid_sched_def)
-
 crunch deleteObjects
   for ksIdleThread[wp]: "\<lambda>s. P (ksIdleThread s)"
   (simp: crunch_simps wp: hoare_drop_imps unless_wp ignore: freeMemory)
@@ -4926,7 +4917,7 @@ lemma inv_untyped_corres':
                 invs_valid_pspace invs_arch_state invs_psp_aligned
                 invs_distinct)
          apply (clarsimp simp:conj_comms ball_conj_distrib ex_in_conv)
-         apply (rule validE_R_validE, rule_tac Q'="\<lambda>_ s. valid_etcbs s \<and> valid_list s \<and> invs s \<and> ct_active s
+         apply (rule validE_R_validE, rule_tac Q'="\<lambda>_ s. valid_list s \<and> invs s \<and> ct_active s
           \<and> valid_untyped_inv_wcap ui
             (Some (cap.UntypedCap dev (ptr && ~~ mask sz) sz (if reset then 0 else idx))) s
           \<and> (reset \<longrightarrow> pspace_no_overlap {ptr && ~~ mask sz..(ptr && ~~ mask sz) + 2 ^ sz - 1} s)
@@ -5014,7 +5005,7 @@ lemma inv_untyped_corres':
       apply (clarsimp simp only: pred_conj_def invs ui if_apply_def2)
       apply (strengthen vui)
       apply (cut_tac vui invs invs')
-      apply (clarsimp simp: cte_wp_at_caps_of_state valid_sched_etcbs schact_is_rct_def)
+      apply (clarsimp simp: cte_wp_at_caps_of_state schact_is_rct_def)
      apply (cut_tac vui' invs')
      apply (clarsimp simp: ui cte_wp_at_ctes_of if_apply_def2 ui')
      done

--- a/proof/refine/ARM/Untyped_R.thy
+++ b/proof/refine/ARM/Untyped_R.thy
@@ -2973,7 +2973,7 @@ lemma createNewCaps_range_helper:
             apply (wpsimp simp: curDomain_def)
            apply (clarsimp simp: APIType_capBits_def word_bits_def objBits_simps ptr_add_def o_def)
            apply (fastforce simp: objBitsKO_def objBits_def)
-           \<comment>\<open>other APIObjectType\<close>
+          \<comment>\<open>other APIObjectType\<close>
           apply ((rule hoare_pre, wp createObjects_ret2,
                   clarsimp simp: APIType_capBits_def word_bits_def objBits_simps ptr_add_def o_def,
                   fastforce simp: objBitsKO_def objBits_def)+)[3]

--- a/proof/refine/ARM/VSpace_R.thy
+++ b/proof/refine/ARM/VSpace_R.thy
@@ -836,7 +836,7 @@ crunch deleteASID
 
 lemma deleteASID_corres:
   "corres dc
-          (invs and valid_etcbs and K (asid \<le> mask asid_bits \<and> asid \<noteq> 0))
+          (invs and K (asid \<le> mask asid_bits \<and> asid \<noteq> 0))
           (pspace_aligned' and pspace_distinct' and no_0_obj'
               and valid_arch_state' and cur_tcb')
           (delete_asid asid pd) (deleteASID asid pd)"
@@ -847,7 +847,7 @@ lemma deleteASID_corres:
       apply (rule_tac P="\<lambda>s. asid_high_bits_of asid \<in> dom (asidTable o ucast) \<longrightarrow>
                              asid_pool_at (the ((asidTable o ucast) (asid_high_bits_of asid))) s" and
                       P'="pspace_aligned' and pspace_distinct'" and
-                      Q="invs and valid_etcbs and K (asid \<le> mask asid_bits \<and> asid \<noteq> 0) and
+                      Q="invs and K (asid \<le> mask asid_bits \<and> asid \<noteq> 0) and
                          (\<lambda>s. arm_asid_table (arch_state s) = asidTable \<circ> ucast)" in
                       corres_split)
          apply (simp add: dom_def)
@@ -855,8 +855,7 @@ lemma deleteASID_corres:
         apply (rule corres_when, simp add: mask_asid_low_bits_ucast_ucast)
         apply (rule corres_split[OF flushSpace_corres[where pd=pd]])
           apply (rule corres_split[OF invalidateASIDEntry_corres[where pd=pd]])
-            apply (rule_tac P="asid_pool_at (the (asidTable (ucast (asid_high_bits_of asid))))
-                               and valid_etcbs"
+            apply (rule_tac P="asid_pool_at (the (asidTable (ucast (asid_high_bits_of asid))))"
                         and P'="pspace_aligned' and pspace_distinct'"
                          in corres_split)
                apply (simp del: fun_upd_apply)
@@ -1411,7 +1410,7 @@ lemma storePDE_InvalidPDE_valid_arch_state'[wp]:
 
 lemma unmapPageTable_corres:
   "corres dc
-          (invs and valid_etcbs and page_table_at pt and
+          (invs and page_table_at pt and
            K (0 < asid \<and> is_aligned vptr 20 \<and> asid \<le> mask asid_bits))
           (valid_arch_state' and pspace_aligned' and pspace_distinct'
             and no_0_obj' and cur_tcb' and valid_objs')
@@ -1525,7 +1524,7 @@ lemma store_pte_pd_at_asid[wp]:
   done
 
 lemma unmapPage_corres:
-  "corres dc (invs and valid_etcbs and
+  "corres dc (invs and
               K (valid_unmap sz (asid,vptr) \<and> vptr < kernel_base \<and> asid \<le> mask asid_bits))
              (valid_objs' and valid_arch_state' and pspace_aligned' and
               pspace_distinct' and no_0_obj' and cur_tcb')
@@ -1545,7 +1544,7 @@ lemma unmapPage_corres:
                               and (\<exists>\<rhd> (lookup_pd_slot pd vptr && ~~ mask pd_bits))
                               and valid_arch_state and valid_vspace_objs
                               and equal_kernel_mappings
-                              and pspace_aligned and valid_global_objs and valid_etcbs and
+                              and pspace_aligned and valid_global_objs and
                               K (valid_unmap sz (asid,vptr) )" and
                            P'="pspace_aligned' and pspace_distinct'" in corres_inst)
            apply clarsimp
@@ -1584,7 +1583,7 @@ lemma unmapPage_corres:
                            apply simp
                           apply simp
                          apply clarsimp
-                         apply (rule_tac P="(\<lambda>s. \<forall>x\<in>set [0, 4 .e. 0x3C]. pte_at (x + pa) s) and pspace_aligned and valid_etcbs"
+                         apply (rule_tac P="(\<lambda>s. \<forall>x\<in>set [0, 4 .e. 0x3C]. pte_at (x + pa) s) and pspace_aligned"
                                      and P'="pspace_aligned' and pspace_distinct'"
                                       in corres_guard_imp)
                            apply (rule storePTE_corres',  simp add:pte_relation_aligned_def)
@@ -1627,7 +1626,7 @@ lemma unmapPage_corres:
                              in corres_gen_asm)
                apply (simp add: is_aligned_mask[symmetric])
                apply (rule corres_split)
-                  apply (rule_tac P="page_directory_at pd and pspace_aligned and valid_etcbs
+                  apply (rule_tac P="page_directory_at pd and pspace_aligned
                                         and K (valid_unmap sz (asid, vptr))"
                               in corres_mapM [where r=dc], simp, simp)
                       prefer 5
@@ -1904,7 +1903,7 @@ crunch unmapPage
 
 lemma corres_store_pde_with_invalid_tail:
   "\<forall>slot \<in>set ys. \<not> is_aligned (slot >> 2) (pde_align' ab)
-  \<Longrightarrow>corres dc ((\<lambda>s. \<forall>y\<in> set ys. pde_at y s) and pspace_aligned and valid_etcbs)
+  \<Longrightarrow>corres dc ((\<lambda>s. \<forall>y\<in> set ys. pde_at y s) and pspace_aligned)
            (pspace_aligned' and pspace_distinct')
            (mapM (swp store_pde ARM_A.pde.InvalidPDE) ys)
            (mapM (swp storePDE ab) ys)"
@@ -1927,7 +1926,7 @@ lemma corres_store_pde_with_invalid_tail:
 
 lemma corres_store_pte_with_invalid_tail:
   "\<forall>slot\<in> set ys. \<not> is_aligned (slot >> 2) (pte_align' aa)
-  \<Longrightarrow> corres dc ((\<lambda>s. \<forall>y\<in>set ys. pte_at y s) and pspace_aligned and valid_etcbs)
+  \<Longrightarrow> corres dc ((\<lambda>s. \<forall>y\<in>set ys. pte_at y s) and pspace_aligned)
                 (pspace_aligned' and pspace_distinct')
              (mapM (swp store_pte ARM_A.pte.InvalidPTE) ys)
              (mapM (swp storePTE aa) ys)"
@@ -2127,7 +2126,7 @@ lemma same_refs_vs_cap_ref_eq:
 
 lemma performPageInvocation_corres:
   assumes "page_invocation_map pgi pgi'"
-  shows "corres (=) (invs and valid_etcbs and valid_page_inv pgi)
+  shows "corres (=) (invs and valid_page_inv pgi)
             (invs' and valid_page_inv' pgi' and (\<lambda>s. vs_valid_duplicates' (ksPSpace s)))
             (perform_page_invocation pgi) (performPageInvocation pgi')"
 proof -
@@ -2144,7 +2143,7 @@ proof -
                            page_invocation_map_def)
      apply (rule corres_guard_imp)
        apply (rule_tac R="\<lambda>_. invs and (valid_page_map_inv word cap (a,b) sum)
-                              and valid_etcbs and (\<lambda>s. caps_of_state s (a,b) = Some cap)"
+                              and (\<lambda>s. caps_of_state s (a,b) = Some cap)"
          and R'="\<lambda>_. invs' and valid_slots' m' and pspace_aligned' and valid_slots_duplicated' m'
          and pspace_distinct' and (\<lambda>s. vs_valid_duplicates' (ksPSpace s))" in corres_split)
           apply (erule updateCap_same_master)
@@ -2370,7 +2369,7 @@ definition
                                  and K (isPageTableCap cap)"
 
 lemma clear_page_table_corres:
-  "corres dc (pspace_aligned and page_table_at p and valid_etcbs)
+  "corres dc (pspace_aligned and page_table_at p)
              (pspace_aligned' and pspace_distinct')
     (mapM_x (swp store_pte ARM_A.InvalidPTE)
        [p , p + 4 .e. p + 2 ^ ptBits - 1])
@@ -2388,7 +2387,7 @@ lemma clear_page_table_corres:
                    mapM_x_mapM liftM_def[symmetric])
   apply (rule corres_guard_imp,
          rule_tac r'=dc and S="(=)"
-               and Q="\<lambda>xs s. \<forall>x \<in> set xs. pte_at x s \<and> pspace_aligned s \<and> valid_etcbs s"
+               and Q="\<lambda>xs s. \<forall>x \<in> set xs. pte_at x s \<and> pspace_aligned s"
                and Q'="\<lambda>xs. pspace_aligned' and pspace_distinct'"
                 in corres_mapM_list_all2, simp_all)
       apply (rule corres_guard_imp, rule storePTE_corres')
@@ -2409,7 +2408,7 @@ lemmas unmapPageTable_typ_ats[wp] = typ_at_lifts[OF unmapPageTable_typ_at']
 lemma performPageTableInvocation_corres:
   "page_table_invocation_map pti pti' \<Longrightarrow>
    corres dc
-          (invs and valid_etcbs and valid_pti pti)
+          (invs and valid_pti pti)
           (invs' and valid_pti' pti')
           (perform_page_table_invocation pti)
           (performPageTableInvocation pti')"
@@ -2489,7 +2488,7 @@ definition
 lemma performASIDPoolInvocation_corres:
   "ap' = asid_pool_invocation_map ap \<Longrightarrow>
   corres dc
-          (valid_objs and pspace_aligned and pspace_distinct and valid_apinv ap and valid_etcbs)
+          (valid_objs and pspace_aligned and pspace_distinct and valid_apinv ap)
           (pspace_aligned' and pspace_distinct' and valid_apinv' ap')
           (perform_asid_pool_invocation ap)
           (performASIDPoolInvocation ap')"
@@ -2501,7 +2500,7 @@ lemma performASIDPoolInvocation_corres:
        apply simp
       apply (rule_tac F="\<exists>p asid. rv = Structures_A.ArchObjectCap (ARM_A.PageDirectoryCap p asid)" in corres_gen_asm)
       apply clarsimp
-      apply (rule_tac Q="valid_objs and pspace_aligned and pspace_distinct and asid_pool_at word2 and valid_etcbs and
+      apply (rule_tac Q="valid_objs and pspace_aligned and pspace_distinct and asid_pool_at word2 and
                          cte_wp_at (\<lambda>c. cap_master_cap c =
                                         cap_master_cap (cap.ArchObjectCap (arch_cap.PageDirectoryCap p asid))) (a,b)"
                       in corres_split)

--- a/proof/refine/ARM_HYP/ADT_H.thy
+++ b/proof/refine/ARM_HYP/ADT_H.thy
@@ -307,6 +307,9 @@ definition
       tcb_fault = map_option FaultMap (tcbFault tcb),
       tcb_bound_notification = tcbBoundNotification tcb,
       tcb_mcpriority = tcbMCP tcb,
+      tcb_priority = tcbPriority tcb,
+      tcb_time_slice = tcbTimeSlice tcb,
+      tcb_domain = tcbDomain tcb,
       tcb_arch = ArchTcbMap (tcbArch tcb)\<rparr>"
 
 definition
@@ -764,55 +767,6 @@ proof -
     apply (clarsimp simp: vcpu_relation_def split: vcpu.splits)
     done
 qed
-
-definition
-  "EtcbMap tcb \<equiv>
-     \<lparr>tcb_priority = tcbPriority tcb,
-      time_slice = tcbTimeSlice tcb,
-      tcb_domain = tcbDomain tcb\<rparr>"
-
-definition
-  absEkheap :: "(word32 \<rightharpoonup> Structures_H.kernel_object) \<Rightarrow> obj_ref \<Rightarrow> etcb option"
-  where
-  "absEkheap h \<equiv> \<lambda>x.
-     case h x of
-       Some (KOTCB tcb) \<Rightarrow> Some (EtcbMap tcb)
-     | _ \<Rightarrow> None"
-
-lemma absEkheap_correct:
-assumes pspace_relation: "pspace_relation (kheap s) (ksPSpace s')"
-assumes ekheap_relation: "ekheap_relation (ekheap s) (ksPSpace s')"
-assumes vetcbs: "valid_etcbs s"
-shows
-  "absEkheap (ksPSpace s') = ekheap s"
-  apply (rule ext)
-  apply (clarsimp simp: absEkheap_def split: option.splits Structures_H.kernel_object.splits)
-  apply (subgoal_tac "\<forall>x. (\<exists>tcb. kheap s x = Some (TCB tcb)) =
-                          (\<exists>tcb'. ksPSpace s' x = Some (KOTCB tcb'))")
-   using vetcbs ekheap_relation
-   apply (clarsimp simp: valid_etcbs_def is_etcb_at_def dom_def ekheap_relation_def st_tcb_at_def obj_at_def)
-   apply (erule_tac x=x in allE)+
-   apply (rule conjI, force)
-   apply clarsimp
-   apply (rule conjI, clarsimp simp: EtcbMap_def etcb_relation_def)+
-   apply clarsimp
-  using pspace_relation
-  apply (clarsimp simp add: pspace_relation_def pspace_dom_def UNION_eq
-                              dom_def Collect_eq)
-  apply (rule iffI)
-   apply (erule_tac x=x in allE)+
-   apply (case_tac "ksPSpace s' x", clarsimp)
-    apply (erule_tac x=x in allE, clarsimp)
-   apply clarsimp
-   apply (case_tac a, simp_all add: tcb_relation_cut_def other_obj_relation_def)
-  apply (insert pspace_relation)
-  apply (clarsimp simp: obj_at'_def projectKOs)
-  apply (erule(1) pspace_dom_relatedE)
-  apply (erule(1) obj_relation_cutsE)
-  apply (clarsimp simp: other_obj_relation_def
-                 split: Structures_A.kernel_object.split_asm  if_split_asm
-                        ARM_HYP_A.arch_kernel_obj.split_asm)+
-  done
 
 text \<open>The following function can be used to reverse cte_map.\<close>
 definition
@@ -1632,13 +1586,6 @@ lemma absSchedulerAction_correct:
 definition
   "absExst s \<equiv>
      \<lparr>work_units_completed_internal = ksWorkUnitsCompleted s,
-      scheduler_action_internal = absSchedulerAction (ksSchedulerAction s),
-      ekheap_internal = absEkheap (ksPSpace s),
-      domain_list_internal = ksDomSchedule s,
-      domain_index_internal = ksDomScheduleIdx s,
-      cur_domain_internal = ksCurDomain s,
-      domain_time_internal = ksDomainTime s,
-      ready_queues_internal = (\<lambda>d p. heap_walk (tcbSchedNexts_of s) (tcbQueueHead (ksReadyQueues s (d, p))) []),
       cdt_list_internal = absCDTList (cteMap (gsCNodes s)) (ctes_of s)\<rparr>"
 
 lemma absExst_correct:
@@ -1646,16 +1593,12 @@ lemma absExst_correct:
   assumes rel: "(s, s') \<in> state_relation"
   shows "absExst s' = exst s"
   apply (rule det_ext.equality)
-           using rel invs invs'
-           apply (simp_all add: absExst_def absSchedulerAction_correct absEkheap_correct
-                                absCDTList_correct[THEN fun_cong] state_relation_def invs_def
-                                valid_state_def ready_queues_relation_def ready_queue_relation_def
-                                invs'_def valid_state'_def
-                                valid_pspace_def valid_sched_def valid_pspace'_def curry_def
-                                fun_eq_iff)
-   apply (fastforce simp: absEkheap_correct)
-  apply (fastforce simp: list_queue_relation_def Let_def dest: heap_ls_is_walk)
-  done
+      using rel invs invs'
+      apply (simp_all add: absExst_def absSchedulerAction_correct
+                           absCDTList_correct[THEN fun_cong] state_relation_def invs_def valid_state_def
+                           ready_queues_relation_def invs'_def valid_state'_def
+                           valid_pspace_def valid_sched_def valid_pspace'_def curry_def fun_eq_iff)
+      done
 
 
 definition
@@ -1664,6 +1607,12 @@ definition
     cdt = absCDT (cteMap (gsCNodes s)) (ctes_of s),
     is_original_cap = absIsOriginalCap (cteMap (gsCNodes s)) (ksPSpace s),
     cur_thread = ksCurThread s, idle_thread = ksIdleThread s,
+    scheduler_action = absSchedulerAction (ksSchedulerAction s),
+    domain_list = ksDomSchedule s,
+    domain_index = ksDomScheduleIdx s,
+    cur_domain = ksCurDomain s,
+    domain_time = ksDomainTime s,
+    ready_queues = (\<lambda>d p. heap_walk (tcbSchedNexts_of s) (tcbQueueHead (ksReadyQueues s (d, p))) []),
     machine_state = observable_memory (ksMachineState s) (user_mem' s),
     interrupt_irq_node = absInterruptIRQNode (ksInterruptState s),
     interrupt_states = absInterruptStates (ksInterruptState s),

--- a/proof/refine/ARM_HYP/ArchAcc_R.thy
+++ b/proof/refine/ARM_HYP/ArchAcc_R.thy
@@ -231,7 +231,7 @@ crunch getIRQSlot
 
 lemma setObject_ASIDPool_corres [corres]:
   "a = inv ASIDPool a' o ucast \<Longrightarrow>
-  corres dc (asid_pool_at p and valid_etcbs) (asid_pool_at' p)
+  corres dc (asid_pool_at p) (asid_pool_at' p)
             (set_asid_pool p a) (setObject p a')"
   apply (simp add: set_asid_pool_def)
   apply (corresKsimp search: setObject_other_corres[where P="\<lambda>_. True"]
@@ -243,7 +243,7 @@ lemma setObject_ASIDPool_corres [corres]:
 
 lemma setObject_ASIDPool_corres':
   "a = inv ASIDPool a' o ucast \<Longrightarrow>
-  corres dc (asid_pool_at p and valid_etcbs) (pspace_aligned' and pspace_distinct')
+  corres dc (asid_pool_at p) (pspace_aligned' and pspace_distinct')
             (set_asid_pool p a) (setObject p a')"
   apply (rule stronger_corres_guard_imp[OF setObject_ASIDPool_corres])
    apply auto
@@ -873,7 +873,7 @@ lemma get_master_pte_corres':
 lemma setObject_PD_corres [corres]:
   "pde_relation_aligned (p>>pde_bits) pde pde' \<Longrightarrow>
          corres dc  (ko_at (ArchObj (PageDirectory pd)) (p && ~~ mask pd_bits)
-                     and pspace_aligned and valid_etcbs)
+                     and pspace_aligned)
                     (pde_at' p)
           (set_pd (p && ~~ mask pd_bits) (pd(ucast (p && mask pd_bits >> pde_bits) := pde)))
           (setObject p pde')"
@@ -916,9 +916,9 @@ lemma setObject_PD_corres [corres]:
    apply (drule bspec, assumption)
    apply clarsimp
    apply (erule (1) obj_relation_cutsE)
+        apply simp
        apply simp
-      apply simp
-     apply clarsimp
+      apply clarsimp
      apply (frule (1) pspace_alignedD)
      apply (drule_tac p=x in pspace_alignedD, assumption)
      apply simp
@@ -933,13 +933,6 @@ lemma setObject_PD_corres [corres]:
     apply (simp split: if_split_asm)
    apply (simp add: other_obj_relation_def
                split: Structures_A.kernel_object.splits arch_kernel_obj.splits)
-  apply (rule conjI)
-   apply (clarsimp simp: ekheap_relation_def pspace_relation_def)
-   apply (drule(1) ekheap_kheap_dom)
-   apply clarsimp
-   apply (drule_tac x=p in bspec, erule domI)
-   apply (simp add: tcb_relation_cut_def
-           split: Structures_A.kernel_object.splits)
   apply (extract_conjunct \<open>match conclusion in "ghost_relation _ _ _" \<Rightarrow> -\<close>)
    apply (clarsimp simp add: ghost_relation_def)
    apply (erule_tac x="p && ~~ mask pd_bits" in allE)+
@@ -956,7 +949,7 @@ lemma setObject_PD_corres [corres]:
 lemma setObject_PT_corres [corres]:
   "pte_relation_aligned (p >> pte_bits) pte pte' \<Longrightarrow>
          corres dc  (ko_at (ArchObj (PageTable pt)) (p && ~~ mask pt_bits)
-                     and pspace_aligned and valid_etcbs)
+                     and pspace_aligned)
                     (pte_at' p)
           (set_pt (p && ~~ mask pt_bits) (pt(ucast (p && mask pt_bits >> pte_bits) := pte)))
           (setObject p pte')"
@@ -996,8 +989,8 @@ lemma setObject_PT_corres [corres]:
    apply (drule bspec, assumption)
    apply clarsimp
    apply (erule (1) obj_relation_cutsE)
-       apply simp
-      apply clarsimp
+        apply simp
+       apply clarsimp
       apply (frule (1) pspace_alignedD)
       apply (drule_tac p=x in pspace_alignedD, assumption)
       apply simp
@@ -1013,12 +1006,6 @@ lemma setObject_PT_corres [corres]:
     apply (simp split: if_split_asm)
    apply (simp add: other_obj_relation_def
                split: Structures_A.kernel_object.splits arch_kernel_obj.splits)
-  apply (rule conjI)
-   apply (clarsimp simp: ekheap_relation_def pspace_relation_def)
-   apply (drule(1) ekheap_kheap_dom)
-   apply clarsimp
-   apply (drule_tac x=p in bspec, erule domI)
-   apply (simp add: tcb_relation_cut_def split: Structures_A.kernel_object.splits)
   apply (extract_conjunct \<open>match conclusion in "ghost_relation _ _ _" \<Rightarrow> -\<close>)
    apply (clarsimp simp add: ghost_relation_def)
    apply (erule_tac x="p && ~~ mask pt_bits" in allE)+
@@ -1037,7 +1024,7 @@ lemma wordsFromPDEis2: "\<exists>a b . wordsFromPDE pde = [a , b]"
 
 lemma storePDE_corres [corres]:
   "pde_relation_aligned (p >> pde_bits) pde pde' \<Longrightarrow>
-  corres dc (pde_at p and pspace_aligned and valid_etcbs) (pde_at' p) (store_pde p pde) (storePDE p pde')"
+  corres dc (pde_at p and pspace_aligned) (pde_at' p) (store_pde p pde) (storePDE p pde')"
   apply (simp add: store_pde_def storePDE_def)
   apply (insert wordsFromPDEis2[of pde'])
   apply (clarsimp simp: tailM_def headM_def)
@@ -1058,7 +1045,7 @@ lemma storePDE_corres [corres]:
 lemma storePDE_corres':
   "pde_relation_aligned (p >> pde_bits) pde pde' \<Longrightarrow>
   corres dc
-     (pde_at p and pspace_aligned and valid_etcbs) (pspace_aligned' and pspace_distinct')
+     (pde_at p and pspace_aligned) (pspace_aligned' and pspace_distinct')
      (store_pde p pde) (storePDE p pde')"
   apply (rule stronger_corres_guard_imp, rule storePDE_corres)
    apply auto
@@ -1069,7 +1056,7 @@ lemma wordsFromPTEis2: "\<exists>a b . wordsFromPTE pte = [a , b]"
 
 lemma storePTE_corres [corres]:
   "pte_relation_aligned (p>>pte_bits) pte pte' \<Longrightarrow>
-  corres dc (pte_at p and pspace_aligned and valid_etcbs) (pte_at' p) (store_pte p pte) (storePTE p pte')"
+  corres dc (pte_at p and pspace_aligned) (pte_at' p) (store_pte p pte) (storePTE p pte')"
   apply (simp add: store_pte_def storePTE_def)
   apply (insert wordsFromPTEis2[of pte'])
   apply (clarsimp simp: tailM_def headM_def)
@@ -1089,7 +1076,7 @@ lemma storePTE_corres [corres]:
 
 lemma storePTE_corres':
   "pte_relation_aligned (p >> pte_bits) pte pte' \<Longrightarrow>
-  corres dc (pte_at p and pspace_aligned and valid_etcbs)
+  corres dc (pte_at p and pspace_aligned)
             (pspace_aligned' and pspace_distinct')
             (store_pte p pte) (storePTE p pte')"
   apply (rule stronger_corres_guard_imp, rule storePTE_corres)
@@ -1265,7 +1252,7 @@ crunch copyGlobalMappings
 lemmas copyGlobalMappings_typ_ats[wp] = typ_at_lifts [OF copyGlobalMappings_typ_at']
 
 lemma copy_global_mappings_corres [corres]:
-  "corres dc (page_directory_at pd and pspace_aligned and valid_arch_state and valid_etcbs)
+  "corres dc (page_directory_at pd and pspace_aligned and valid_arch_state)
              (page_directory_at' pd and valid_arch_state')
           (copy_global_mappings pd) (copyGlobalMappings pd)"
   apply (simp add: copy_global_mappings_def copyGlobalMappings_def)

--- a/proof/refine/ARM_HYP/ArchInvsLemmas_H.thy
+++ b/proof/refine/ARM_HYP/ArchInvsLemmas_H.thy
@@ -591,4 +591,24 @@ interpretation Arch .
 instance by intro_classes auto
 end
 
+context Arch begin
+
+lemma objBits_less_word_bits:
+  "objBits v < word_bits"
+  unfolding objBits_simps'
+  apply (case_tac "injectKO v"; simp)
+  by (simp add: pageBits_def pte_bits_def pde_bits_def word_bits_def
+         split: arch_kernel_object.split)+
+
+lemma objBits_pos_power2[simp]:
+  assumes "objBits v < word_bits"
+  shows "(1::machine_word) < (2::machine_word) ^ objBits v"
+  unfolding objBits_simps'
+  apply (insert assms)
+  apply (case_tac "injectKO v"; simp)
+  by (simp add: pageBits_def pte_bits_def pde_bits_def
+         split: arch_kernel_object.splits)+
+
+end
+
 end

--- a/proof/refine/ARM_HYP/ArchMove_R.thy
+++ b/proof/refine/ARM_HYP/ArchMove_R.thy
@@ -22,10 +22,6 @@ method prefer_next = tactic \<open>SUBGOAL (K (prefer_tac 2)) 1\<close>
 
 context begin interpretation Arch .
 
-(* Move to Deterministic_AI*)
-crunch copy_global_mappings
-  for valid_etcbs[wp]: valid_etcbs (wp: mapM_x_wp')
-
 (* Move to Machine_AI *)
 lemma no_fail_writeContextIDAndPD[wp]: "no_fail \<top> (writeContextIDAndPD a w)"
   by (simp add: writeContextIDAndPD_def)

--- a/proof/refine/ARM_HYP/Arch_R.thy
+++ b/proof/refine/ARM_HYP/Arch_R.thy
@@ -90,24 +90,6 @@ lemma createObject_typ_at':
   apply (clarsimp simp: is_aligned_no_overflow_mask)
   done
 
-lemma retype_region2_ext_retype_region_ArchObject:
-  "retype_region ptr n us (ArchObject x)=
-  retype_region2 ptr n us (ArchObject x)"
-  apply (rule ext)
-  apply (simp add:retype_region_def retype_region2_def bind_assoc
-    retype_region2_ext_def retype_region_ext_def default_ext_def)
-  apply (rule ext)
-  apply (intro monad_eq_split_tail ext)+
-     apply simp
-    apply simp
-   apply (simp add:gets_def get_def bind_def return_def simpler_modify_def )
-   apply (rule_tac x = xc in fun_cong)
-   apply (rule_tac f = do_extended_op in arg_cong)
-   apply (rule ext)
-   apply simp
-  apply simp
-  done
-
 lemma set_cap_device_and_range_aligned:
   "is_aligned ptr sz \<Longrightarrow> \<lbrace>\<lambda>_. True\<rbrace>
     set_cap
@@ -161,7 +143,6 @@ lemma performASIDControlInvocation_corres:
             apply (clarsimp simp:is_cap_simps)
            apply (simp add: free_index_of_def)
           apply (rule corres_split)
-             apply (simp add: retype_region2_ext_retype_region_ArchObject )
              apply (rule corres_retype [where ty="Inl (KOArch (KOASIDPool F))",
                                         unfolded APIType_map2_def makeObjectKO_def,
                                         THEN createObjects_corres',simplified,
@@ -313,8 +294,8 @@ lemma performASIDControlInvocation_corres:
    apply (rule conjI, rule pspace_no_overlap_subset,
          rule pspace_no_overlap_detype[OF caps_of_state_valid])
         apply (simp add:invs_psp_aligned invs_valid_objs is_aligned_neg_mask_eq)+
-   apply (clarsimp simp: detype_def clear_um_def detype_ext_def valid_sched_def valid_etcbs_def
-            st_tcb_at_kh_def obj_at_kh_def st_tcb_at_def obj_at_def is_etcb_at_def)
+   apply (clarsimp simp: detype_def clear_um_def valid_sched_def
+                         st_tcb_at_kh_def obj_at_kh_def st_tcb_at_def obj_at_def)
   apply (simp add: detype_def clear_um_def)
   apply (drule_tac x = "cte_map (p', slot')" in pspace_relation_cte_wp_atI[OF state_relation_pspace_relation])
     apply (simp add:invs_valid_objs)+

--- a/proof/refine/ARM_HYP/CSpace_R.thy
+++ b/proof/refine/ARM_HYP/CSpace_R.thy
@@ -693,8 +693,7 @@ lemma next_slot_eq2:
 
 lemma set_cap_not_quite_corres':
   assumes cr:
-  "pspace_relations (ekheap (a)) (kheap s) (ksPSpace s')"
-  "ekheap (s)      = ekheap (a)"
+  "pspace_relation (kheap s) (ksPSpace s')"
   "cur_thread s    = ksCurThread s'"
   "idle_thread s   = ksIdleThread s'"
   "machine_state s = ksMachineState s'"
@@ -711,10 +710,9 @@ lemma set_cap_not_quite_corres':
   assumes c: "cap_relation c c'"
   assumes p: "p' = cte_map p"
   shows "\<exists>t. ((),t) \<in> fst (set_cap c p s) \<and>
-             pspace_relations (ekheap t) (kheap t) (ksPSpace t') \<and>
+             pspace_relation (kheap t) (ksPSpace t') \<and>
              cdt t              = cdt s \<and>
              cdt_list t         = cdt_list (s) \<and>
-             ekheap t           = ekheap (s) \<and>
              scheduler_action t = scheduler_action (s) \<and>
              ready_queues t     = ready_queues (s) \<and>
              is_original_cap t  = is_original_cap s \<and>
@@ -731,7 +729,7 @@ lemma set_cap_not_quite_corres':
              domain_time t   = ksDomainTime t'"
   apply (rule set_cap_not_quite_corres)
                 using cr
-                apply (fastforce simp: c p pspace_relations_def)+
+                apply (fastforce simp: c p)+
                 done
 context begin interpretation Arch . (*FIXME: arch-split*)
 lemma cteMove_corres:
@@ -802,7 +800,6 @@ lemma cteMove_corres:
      apply fastforce
     apply fastforce
    apply fastforce
-   apply (drule (1) pspace_relationsD)
    apply (drule_tac p=ptr' in set_cap_not_quite_corres, assumption+)
             apply fastforce
            apply fastforce
@@ -862,7 +859,7 @@ lemma cteMove_corres:
   apply (frule(1) use_valid [OF _ updateCap_no_0])
   apply (frule(2) use_valid [OF _ updateCap_no_0, OF _ use_valid [OF _ updateCap_no_0]])
   apply (elim conjE)
-  apply (drule (5) updateMDB_the_lot', elim conjE)
+  apply (drule (4) updateMDB_the_lot', elim conjE)
   apply (drule (4) updateMDB_the_lot, elim conjE)
   apply (drule (4) updateMDB_the_lot, elim conjE)
   apply (drule (4) updateMDB_the_lot, elim conjE)
@@ -892,7 +889,6 @@ lemma cteMove_corres:
      apply fastforce
     apply fastforce
    apply fastforce
-  apply (clarsimp simp: pspace_relations_def)
   apply (rule conjI)
    subgoal by (clarsimp simp: ghost_relation_typ_at set_cap_a_type_inv data_at_def)
   apply (thin_tac "gsCNodes t = p" for t p)+
@@ -919,7 +915,6 @@ lemma cteMove_corres:
   apply (thin_tac "ksDomainTime t = p" for t p)+
   apply (thin_tac "ksDomSchedule t = p" for t p)+
   apply (thin_tac "ctes_of t = p" for t p)+
-  apply (thin_tac "ekheap_relation t p" for t p)+
   apply (thin_tac "pspace_relation t p" for t p)+
   apply (thin_tac "interrupt_state_relation s t p" for s t p)+
   apply (thin_tac "ghost_relation s t p" for s t p)+
@@ -3583,7 +3578,7 @@ lemma deriveCap_untyped_derived:
 
 lemma setCTE_corres:
   "cap_relation cap (cteCap cte) \<Longrightarrow>
-   corres_underlying {(s, s'). pspace_relations (ekheap (s)) (kheap s) (ksPSpace s')} False True dc
+   corres_underlying {(s, s'). pspace_relation (kheap s) (ksPSpace s')} False True dc
       (pspace_distinct and pspace_aligned and valid_objs and cte_at p)
       (pspace_aligned' and pspace_distinct' and cte_at' (cte_map p))
       (set_cap cap p)
@@ -3628,7 +3623,7 @@ lemma ghost_relation_of_heap:
   done
 
 lemma corres_caps_decomposition:
-  assumes x: "corres_underlying {(s, s'). pspace_relations (ekheap (s)) (kheap s) (ksPSpace s')} False True r P P' f g"
+  assumes x: "corres_underlying {(s, s'). pspace_relation (kheap s) (ksPSpace s')} False True r P P' f g"
   assumes u: "\<And>P. \<lbrace>\<lambda>s. P (new_caps s)\<rbrace> f \<lbrace>\<lambda>rv s. P (caps_of_state s)\<rbrace>"
              "\<And>P. \<lbrace>\<lambda>s. P (new_mdb s)\<rbrace> f \<lbrace>\<lambda>rv s. P (cdt s)\<rbrace>"
              "\<And>P. \<lbrace>\<lambda>s. P (new_list s)\<rbrace> f \<lbrace>\<lambda>rv s. P (cdt_list (s))\<rbrace>"
@@ -3738,13 +3733,11 @@ proof -
   note abs_irq_together = abs_irq_together'[simplified]
   show ?thesis
     unfolding state_relation_def swp_cte_at
-    apply (subst conj_assoc[symmetric])
-    apply (subst pspace_relations_def[symmetric])
     apply (rule corres_underlying_decomposition [OF x])
      apply (simp add: ghost_relation_of_heap)
      apply (wpsimp wp: hoare_vcg_conj_lift mdb_wp rvk_wp list_wp u abs_irq_together)+
-    apply (intro z[simplified o_def] conjI | simp add: state_relation_def pspace_relations_def swp_cte_at
-          | (clarsimp, drule (1) z(6), simp add: state_relation_def pspace_relations_def swp_cte_at))+
+    apply (intro z[simplified o_def] conjI | simp add: state_relation_def swp_cte_at
+           | (drule (1) z(6), simp add: state_relation_def swp_cte_at))+
     done
 qed
 
@@ -3756,7 +3749,7 @@ lemma getCTE_symb_exec_r:
   done
 
 lemma updateMDB_symb_exec_r:
-  "corres_underlying {(s, s'). pspace_relations (ekheap s) (kheap s) (ksPSpace s')} False nf' dc
+  "corres_underlying {(s, s'). pspace_relation (kheap s) (ksPSpace s')} False nf' dc
         \<top> (pspace_aligned' and pspace_distinct' and (no_0 \<circ> ctes_of) and (\<lambda>s. p \<noteq> 0 \<longrightarrow> cte_at' p s))
         (return ()) (updateMDB p m)"
   using no_fail_updateMDB [of p m]
@@ -3807,45 +3800,20 @@ lemma revokable_relation_simp:
       \<Longrightarrow> mdbRevocable node = is_original_cap s p"
   by (cases p, clarsimp simp: state_relation_def revokable_relation_def)
 
-lemma setCTE_gsUserPages[wp]:
-  "\<lbrace>\<lambda>s. P (gsUserPages s)\<rbrace> setCTE p v \<lbrace>\<lambda>rv s. P (gsUserPages s)\<rbrace>"
-  apply (simp add: setCTE_def setObject_def split_def)
-  apply (wp updateObject_cte_inv crunch_wps | simp)+
-  done
-
-lemma setCTE_gsCNodes[wp]:
-  "\<lbrace>\<lambda>s. P (gsCNodes s)\<rbrace> setCTE p v \<lbrace>\<lambda>rv s. P (gsCNodes s)\<rbrace>"
-  apply (simp add: setCTE_def setObject_def split_def)
-  apply (wp updateObject_cte_inv crunch_wps | simp)+
-  done
+crunch setCTE
+  for gsUserPages[wp]: "\<lambda>s. P (gsUserPages s)"
+  and gsCNodes[wp]: "\<lambda>s. P (gsCNodes s)"
+  and domain_time[wp]: "\<lambda>s. P (ksDomainTime s)"
+  and work_units_completed[wp]: "\<lambda>s. P (ksWorkUnitsCompleted s)"
+  (simp: setObject_def wp: updateObject_cte_inv)
 
 lemma set_original_symb_exec_l':
-  "corres_underlying {(s, s'). f (ekheap s) (kheap s) s'} False nf' dc P P' (set_original p b) (return x)"
+  "corres_underlying {(s, s'). f (kheap s) s'} False nf' dc P P' (set_original p b) (return x)"
   by (simp add: corres_underlying_def return_def set_original_def in_monad Bex_def)
 
-lemma setCTE_schedule_index[wp]:
-  "\<lbrace>\<lambda>s. P (ksDomScheduleIdx s)\<rbrace> setCTE p v \<lbrace>\<lambda>rv s. P (ksDomScheduleIdx s)\<rbrace>"
-  apply (simp add: setCTE_def setObject_def split_def)
-  apply (wp updateObject_cte_inv crunch_wps | simp)+
-  done
-
-lemma setCTE_schedule[wp]:
-  "\<lbrace>\<lambda>s. P (ksDomSchedule s)\<rbrace> setCTE p v \<lbrace>\<lambda>rv s. P (ksDomSchedule s)\<rbrace>"
-  apply (simp add: setCTE_def setObject_def split_def)
-  apply (wp updateObject_cte_inv crunch_wps | simp)+
-  done
-
-lemma setCTE_domain_time[wp]:
-  "\<lbrace>\<lambda>s. P (ksDomainTime s)\<rbrace> setCTE p v \<lbrace>\<lambda>rv s. P (ksDomainTime s)\<rbrace>"
-  apply (simp add: setCTE_def setObject_def split_def)
-  apply (wp updateObject_cte_inv crunch_wps | simp)+
-  done
-
-lemma setCTE_work_units_completed[wp]:
-  "\<lbrace>\<lambda>s. P (ksWorkUnitsCompleted s)\<rbrace> setCTE p v \<lbrace>\<lambda>_ s. P (ksWorkUnitsCompleted s)\<rbrace>"
-  apply (simp add: setCTE_def setObject_def split_def)
-  apply (wp updateObject_cte_inv crunch_wps | simp)+
-  done
+crunch set_cap
+  for domain_index[wp]: "\<lambda>s. P (domain_index s)"
+  (wp: set_object_wp)
 
 lemma create_reply_master_corres:
   "\<lbrakk> sl' = cte_map sl ; AllowGrant \<in> rights \<rbrakk> \<Longrightarrow>
@@ -4840,7 +4808,6 @@ lemma cteInsert_simple_corres:
                apply (simp+)[3]
             apply (clarsimp simp: corres_underlying_def state_relation_def
                                   in_monad valid_mdb'_def valid_mdb_ctes_def)
-            apply (drule (1) pspace_relationsD)
             apply (drule (18) set_cap_not_quite_corres)
              apply (rule refl)
             apply (elim conjE exE)
@@ -4867,7 +4834,7 @@ lemma cteInsert_simple_corres:
             apply (drule (3) updateMDB_the_lot', simp only: no_0_modify_map, simp only:, elim conjE)
             apply (drule (3) updateMDB_the_lot', simp only: no_0_modify_map, simp only:, elim conjE)
             apply (drule (3) updateMDB_the_lot', simp only: no_0_modify_map, simp only:, elim conjE)
-            apply (clarsimp simp: pspace_relations_def)
+            apply clarsimp
             apply (thin_tac "gsCNodes t = p" for t p)+
             apply (thin_tac "ksMachineState t = p" for t p)+
             apply (thin_tac "ksCurThread t = p" for t p)+
@@ -4892,7 +4859,6 @@ lemma cteInsert_simple_corres:
             apply (thin_tac "ksDomainTime t = p" for t p)+
             apply (thin_tac "ksDomSchedule t = p" for t p)+
             apply (thin_tac "ctes_of t = p" for t p)+
-            apply (thin_tac "ekheap_relation t p" for t p)+
             apply (thin_tac "pspace_relation t p" for t p)+
             apply (thin_tac "interrupt_state_relation s t p" for s t p)+
             apply (thin_tac "sched_act_relation t p" for t p)+
@@ -6063,7 +6029,7 @@ lemma setCTE_set_cap_ready_queues_relation_valid_corres:
   shows "ready_queues_relation t t'"
   apply (clarsimp simp: ready_queues_relation_def)
   apply (insert pre)
-  apply (rule use_valid[OF step_abs set_cap_exst])
+  apply (rule use_valid[OF step_abs set_cap_rqueues])
   apply (rule use_valid[OF step_conc setCTE_ksReadyQueues])
   apply (rule use_valid[OF step_conc setCTE_tcbSchedNexts_of])
   apply (rule use_valid[OF step_conc setCTE_tcbSchedPrevs_of])
@@ -6089,7 +6055,6 @@ lemma updateCap_same_master:
         apply (clarsimp simp: cte_wp_at_ctes_of)
        apply clarsimp
        apply (clarsimp simp add: state_relation_def)
-       apply (drule (1) pspace_relationsD)
        apply (frule (4) set_cap_not_quite_corres_prequel)
             apply (erule cte_wp_at_weakenE, rule TrueI)
            apply assumption
@@ -6100,7 +6065,7 @@ lemma updateCap_same_master:
        apply (rule bexI)
         prefer 2
         apply assumption
-       apply (clarsimp simp: pspace_relations_def)
+       apply clarsimp
        apply (subst conj_assoc[symmetric])
        apply (extract_conjunct \<open>match conclusion in "ready_queues_relation a b" for a b \<Rightarrow> -\<close>)
         subgoal by (erule setCTE_set_cap_ready_queues_relation_valid_corres; assumption)

--- a/proof/refine/ARM_HYP/Detype_R.thy
+++ b/proof/refine/ARM_HYP/Detype_R.thy
@@ -889,11 +889,6 @@ lemma corres_machine_op:
    apply (simp_all add: state_relation_def swp_def)
   done
 
-lemma ekheap_relation_detype:
-  "ekheap_relation ekh kh \<Longrightarrow>
-   ekheap_relation (\<lambda>x. if P x then None else (ekh x)) (\<lambda>x. if P x then None else (kh x))"
-  by (fastforce simp add: ekheap_relation_def split: if_split_asm)
-
 lemma cap_table_at_gsCNodes_eq:
   "(s, s') \<in> state_relation
     \<Longrightarrow> (gsCNodes s' ptr = Some bits) = cap_table_at bits ptr s"
@@ -994,11 +989,11 @@ lemma detype_ready_queues_relation:
          tcb_of' |>
          tcbSchedPrev)
         (\<lambda>d p. inQ d p |< ((\<lambda>x. if lower \<le> x \<and> x \<le> upper then None else ksPSpace s' x) |> tcb_of'))"
-  apply (clarsimp simp: detype_ext_def ready_queues_relation_def Let_def)
+  apply (clarsimp simp: ready_queues_relation_def Let_def)
   apply (frule (1) detype_tcbSchedNexts_of[where S="{lower..upper}"]; simp)
   apply (frule (1) detype_tcbSchedPrevs_of[where S="{lower..upper}"]; simp)
   apply (frule (1) detype_inQ[where S="{lower..upper}"]; simp)
-  apply (fastforce simp add: detype_def detype_ext_def wrap_ext_det_ext_ext_def)
+  apply (fastforce simp add: detype_def)
   done
 
 lemma deleteObjects_corres:
@@ -1073,33 +1068,29 @@ lemma deleteObjects_corres:
     apply (simp add: valid_pspace'_def)
     apply (rule state_relation_null_filterE, assumption,
            simp_all add: pspace_aligned'_cut pspace_distinct'_cut)[1]
-            apply (simp add: detype_def, rule state.equality; simp add: detype_ext_def)
-           apply (intro exI, fastforce)
-          apply (rule ext, clarsimp simp add: null_filter_def)
-          apply (rule sym, rule ccontr, clarsimp)
-          apply (drule(4) cte_map_not_null_outside')
-           apply (fastforce simp add: cte_wp_at_caps_of_state)
-          apply simp
-         apply (rule ext, clarsimp simp add: null_filter'_def
-                            map_to_ctes_delete[simplified field_simps])
+           apply (simp add: detype_def)
+          apply (intro exI, fastforce)
+         apply (rule ext, clarsimp simp add: null_filter_def)
          apply (rule sym, rule ccontr, clarsimp)
-         apply (frule(2) pspace_relation_cte_wp_atI
-                         [OF state_relation_pspace_relation])
-         apply (elim exE)
-         apply (frule(4) cte_map_not_null_outside')
-          apply (rule cte_wp_at_weakenE, erule conjunct1)
-          apply (case_tac y, clarsimp)
-          apply (clarsimp simp: valid_mdb'_def valid_mdb_ctes_def
-                                valid_nullcaps_def)
-         apply clarsimp
-         apply (frule_tac cref="(aa, ba)" in cte_map_untyped_range,
-                erule cte_wp_at_weakenE[OF _ TrueI], assumption+)
+         apply (drule(4) cte_map_not_null_outside')
+          apply (fastforce simp add: cte_wp_at_caps_of_state)
          apply simp
-        apply (rule detype_pspace_relation[simplified],
-               simp_all add: state_relation_pspace_relation valid_pspace_def)[1]
-         apply (simp add: valid_cap'_def capAligned_def)
-        apply (clarsimp simp: valid_cap_def, assumption)
-       apply (fastforce simp add: detype_def detype_ext_def intro!: ekheap_relation_detype)
+        apply (rule ext, clarsimp simp: null_filter'_def map_to_ctes_delete[simplified field_simps])
+        apply (rule sym, rule ccontr, clarsimp)
+        apply (frule(2) pspace_relation_cte_wp_atI[OF state_relation_pspace_relation])
+        apply (elim exE)
+        apply (frule(4) cte_map_not_null_outside')
+         apply (rule cte_wp_at_weakenE, erule conjunct1)
+         apply (case_tac y, clarsimp)
+         apply (clarsimp simp: valid_mdb'_def valid_mdb_ctes_def valid_nullcaps_def)
+        apply clarsimp
+        apply (frule_tac cref="(aa, ba)" in cte_map_untyped_range,
+               erule cte_wp_at_weakenE[OF _ TrueI], assumption+)
+        apply simp
+       apply (rule detype_pspace_relation[simplified],
+              simp_all add: state_relation_pspace_relation valid_pspace_def)[1]
+        apply (simp add: valid_cap'_def capAligned_def)
+       apply (clarsimp simp: valid_cap_def, assumption)
       apply (rule detype_ready_queues_relation; blast?)
        apply (clarsimp simp: deletionIsSafe_delete_locale_def)
       apply (erule state_relation_ready_queues_relation)
@@ -3503,23 +3494,19 @@ lemma createObject_setCTE_commute:
                        cteSizeBits_def)
             \<comment> \<open>Untyped\<close>
             apply (simp add: monad_commute_guard_imp[OF return_commute])
-           \<comment> \<open>TCB, EP, NTFN\<close>
+           \<comment> \<open>TCB\<close>
            apply (rule monad_commute_guard_imp[OF commute_commute])
-            apply (rule monad_commute_split[OF monad_commute_split])
-                apply (rule monad_commute_split[OF commute_commute[OF return_commute]])
-                 apply (rule setCTE_modify_tcbDomain_commute)
-                apply wp
-               apply (rule curDomain_commute)
-               apply wp+
-             apply (rule setCTE_placeNewObject_commute)
-            apply (wp  placeNewObject_tcb_at' placeNewObject_cte_wp_at'
-              placeNewObject_pspace_distinct'
-              placeNewObject_pspace_aligned'
-              | clarsimp simp: objBits_simps')+
-           apply (rule monad_commute_guard_imp[OF commute_commute]
-            ,rule monad_commute_split[OF commute_commute[OF return_commute]]
-            ,rule setCTE_placeNewObject_commute
-            ,(wp|clarsimp simp: objBits_simps')+)+
+            apply (rule monad_commute_split[OF monad_commute_split[OF commute_commute]])
+                apply (rule return_commute)
+               apply (rule setCTE_placeNewObject_commute)
+              apply wp
+             apply (rule curDomain_commute)
+             apply (wpsimp simp: objBits_simps')+
+          \<comment> \<open>EP, NTFN\<close>
+          apply (rule monad_commute_guard_imp[OF commute_commute],
+                 rule monad_commute_split[OF commute_commute[OF return_commute]],
+                 rule setCTE_placeNewObject_commute,
+                 (wpsimp simp: objBits_simps')+)+
         \<comment> \<open>CNode\<close>
         apply (rule monad_commute_guard_imp[OF commute_commute])
          apply (rule monad_commute_split)+
@@ -4864,6 +4851,34 @@ lemma mapM_x_copyGlobalMappings_noop:
   apply (simp add: mapM_x_Cons copyGlobalMappings_def)
   done
 
+lemma curDomain_createObjects'_comm:
+  "do x \<leftarrow> createObjects' ptr n obj us;
+      y \<leftarrow> curDomain;
+      m x y
+   od =
+   do y \<leftarrow> curDomain;
+      x \<leftarrow> createObjects' ptr n obj us;
+      m x y
+   od"
+  apply (rule ext)
+  apply (case_tac x)
+  by (auto simp: createObjects'_def split_def bind_assoc return_def unless_def
+                 when_def simpler_gets_def alignError_def fail_def assert_def
+                 bind_def curDomain_def modify_def get_def put_def
+          split: option.splits)
+
+lemma curDomain_twice_simp:
+  "do x \<leftarrow> curDomain;
+      y \<leftarrow> curDomain;
+      m x y
+   od =
+   do x \<leftarrow> curDomain;
+      m x x
+   od"
+  apply (rule ext)
+  apply (case_tac x)
+  by (auto simp: simpler_gets_def bind_def curDomain_def)
+
 lemma createNewCaps_Cons:
   assumes cover:"range_cover ptr sz (Types_H.getObjectSize ty us) (Suc (Suc n))"
   and "valid_pspace' s" "valid_arch_state' s"
@@ -4946,12 +4961,11 @@ proof -
    apply (erule range_cover.sz(1)[where 'a=32, folded word_bits_def])
   apply (simp add: createNewCaps_def)
   apply (case_tac ty)
-        apply (simp add: ARM_HYP_H.toAPIType_def
-                         Arch_createNewCaps_def)
-        apply (rename_tac apiobject_type)
-        apply (case_tac apiobject_type)
-            apply (simp_all add: bind_assoc ARM_HYP_H.toAPIType_def
-                                 )
+         apply (simp add: ARM_HYP_H.toAPIType_def
+                          Arch_createNewCaps_def)
+         apply (rename_tac apiobject_type)
+         apply (case_tac apiobject_type)
+             apply (simp_all add: bind_assoc ARM_HYP_H.toAPIType_def)
             \<comment> \<open>Untyped\<close>
             apply (simp add:
               bind_assoc ARM_HYP_H.getObjectSize_def
@@ -4962,134 +4976,83 @@ proof -
               apiGetObjectSize_def shiftl_t2n field_simps
               shiftL_nat mapM_x_def sequence_x_def append
               fromIntegral_def integral_inv[unfolded Fun.comp_def])
-           \<comment> \<open>TCB, EP, NTFN\<close>
-           apply (simp add:
-                      bind_assoc
-                      ARM_HYP_H.getObjectSize_def
-                      sequence_def Retype_H.createObject_def
-                      ARM_HYP_H.toAPIType_def
-                      createObjects_def ARM_HYP_H.createObject_def
-                      Arch_createNewCaps_def comp_def
-                      apiGetObjectSize_def shiftl_t2n field_simps
-                      shiftL_nat append mapM_x_append2
-                      fromIntegral_def integral_inv[unfolded Fun.comp_def])+
-           apply (subst monad_eq)
-            apply (rule createObjects_Cons)
-                 apply (simp add: field_simps shiftl_t2n bind_assoc pageBits_def
-                               objBits_simps placeNewObject_def2)+
-           apply (rule_tac Q = "\<lambda>r s. pspace_aligned' s \<and>
-               pspace_distinct' s \<and>
-               pspace_no_overlap' (ptr + (2^tcbBlockSizeBits + of_nat n * 2^tcbBlockSizeBits)) (objBitsKO (KOTCB makeObject)) s \<and>
-               range_cover (ptr + 2^tcbBlockSizeBits) sz
-               (objBitsKO (KOTCB makeObject)) (Suc n)
-               \<and> (\<forall>x\<in>set [0.e.of_nat n]. tcb_at' (ptr + x * 2^tcbBlockSizeBits) s)"
-               in monad_eq_split2)
-              apply simp
-             apply (subst monad_commute_simple[symmetric])
-              apply (rule commute_commute[OF curDomain_commute])
-              apply (wpsimp+)[2]
-             apply (rule_tac Q = "\<lambda>r s. r = (ksCurDomain s) \<and>
-               pspace_aligned' s \<and>
-               pspace_distinct' s \<and>
-               pspace_no_overlap' (ptr + (2^tcbBlockSizeBits + of_nat n * 2^tcbBlockSizeBits)) (objBitsKO (KOTCB makeObject)) s \<and>
-               range_cover (ptr + 2^tcbBlockSizeBits) sz
-               (objBitsKO (KOTCB makeObject)) (Suc n)
-               \<and> (\<forall>x\<in>set [0.e.of_nat n]. tcb_at' (ptr + x * 2^tcbBlockSizeBits) s)
-             " in  monad_eq_split)
-               apply (subst monad_commute_simple[symmetric])
-                 apply (rule createObjects_setDomains_commute)
-                apply (clarsimp simp: objBits_simps)
-                apply (rule conj_impI)
-                 apply (erule aligned_add_aligned)
-                  apply (rule aligned_add_aligned[where n = tcbBlockSizeBits])
-                    apply (simp add:is_aligned_def objBits_defs)
-                   apply (cut_tac is_aligned_shift[where m = tcbBlockSizeBits and k = "of_nat n",
-                     unfolded shiftl_t2n,simplified])
-                   apply (simp add:field_simps)+
-                apply (erule range_cover_full)
-                apply (simp add: word_bits_conv objBits_defs)
-               apply (rule_tac Q = "\<lambda>x s. (ksCurDomain s) = ra" in monad_eq_split2)
-                  apply simp
-                 apply (rule_tac Q = "\<lambda>x s. (ksCurDomain s) = ra" in monad_eq_split)
-                   apply (subst rewrite_step[where f = curDomain and
-                     P ="\<lambda>s. ksCurDomain s = ra" and f' = "return ra"])
-                     apply (simp add:curDomain_def bind_def gets_def get_def)
-                    apply simp
-                   apply (simp add:mapM_x_singleton)
-                  apply wp
-                 apply simp
-                apply (wp mapM_x_wp')
-               apply simp
-              apply (simp add:curDomain_def,wp)
-             apply simp
-            apply (wp createObjects'_psp_aligned[where sz = sz]
-              createObjects'_psp_distinct[where sz = sz])
-            apply (rule hoare_vcg_conj_lift)
-             apply (rule hoare_post_imp[OF _ createObjects'_pspace_no_overlap
-                [unfolded shiftl_t2n,where gz = tcbBlockSizeBits and sz = sz,simplified]])
-              apply (simp add:objBits_simps' field_simps)
-             apply (simp add: objBits_simps)
-            apply (wp createTCBs_tcb_at'[where sz = sz])
-           apply (clarsimp simp: objBits_simps word_bits_def field_simps)
-           apply (frule range_cover_le[where n = "Suc n"],simp+)
-           apply (drule range_cover_offset[where p = 1,rotated])
-            apply simp
-           apply (simp add: objBits_defs)
-          apply (((simp add: bind_assoc
-                      ARM_HYP_H.getObjectSize_def
-                      mapM_def sequence_def Retype_H.createObject_def
-                      ARM_HYP_H.toAPIType_def
-                      createObjects_def ARM_HYP_H.createObject_def
-                      Arch_createNewCaps_def comp_def
-                      apiGetObjectSize_def shiftl_t2n field_simps
-                      shiftL_nat mapM_x_def sequence_x_def append
-                      fromIntegral_def integral_inv[unfolded Fun.comp_def])+
-                   , subst monad_eq, rule createObjects_Cons
-                   , (simp add: field_simps shiftl_t2n bind_assoc pageBits_def
+            \<comment> \<open>TCB\<close>
+            apply (simp add: bind_assoc ARM_HYP_H.getObjectSize_def
+                             mapM_def sequence_def Retype_H.createObject_def
+                             ARM_HYP_H.toAPIType_def objBitsKO_def
+                             createObjects_def ARM_HYP_H.createObject_def
+                             Arch_createNewCaps_def comp_def append
+                             apiGetObjectSize_def shiftl_t2n field_simps
+                             shiftL_nat fromIntegral_def integral_inv[unfolded Fun.comp_def])
+            apply (subst curDomain_createObjects'_comm)
+            apply (subst curDomain_twice_simp)
+            apply (simp add: monad_eq_simp_state)
+            apply (intro conjI; clarsimp simp: in_monad)
+              apply ((fastforce simp: curDomain_def simpler_gets_def return_def placeNewObject_def2
+                                      field_simps shiftl_t2n bind_assoc objBits_simps in_monad
+                                      createObjects_Cons[where
+                                        val="KOTCB (tcbDomain_update (\<lambda>_. ksCurDomain s) makeObject)"
+                                        and s=s, simplified objBitsKO_def])+)[2]
+            apply ((clarsimp simp: curDomain_def simpler_gets_def return_def split_def bind_def
+                                  field_simps shiftl_t2n bind_assoc objBits_simps placeNewObject_def2
+                                  createObjects_Cons[where
+                                    val="KOTCB (tcbDomain_update (\<lambda>_. ksCurDomain s) makeObject)"
+                                    and s=s, simplified objBitsKO_def])+)[1]
+           \<comment> \<open>EP, NTFN\<close>
+           apply (((simp add: ARM_HYP_H.getObjectSize_def
+                              mapM_def sequence_def Retype_H.createObject_def
+                              ARM_HYP_H.toAPIType_def
+                              createObjects_def ARM_HYP_H.createObject_def
+                              Arch_createNewCaps_def comp_def
+                              apiGetObjectSize_def shiftl_t2n field_simps
+                              shiftL_nat mapM_x_def sequence_x_def append
+                              fromIntegral_def integral_inv[unfolded Fun.comp_def])+,
+                    subst monad_eq, rule createObjects_Cons,
+                    (simp add: field_simps shiftl_t2n bind_assoc pageBits_def
                                objBits_simps' placeNewObject_def2)+)+)[2]
-        \<comment> \<open>CNode\<close>
-        apply (simp add: cteSizeBits_def pageBits_def tcbBlockSizeBits_def
-                      epSizeBits_def ntfnSizeBits_def pdBits_def bind_assoc
-                      ARM_HYP_H.getObjectSize_def
-                      mapM_def sequence_def Retype_H.createObject_def
-                      ARM_HYP_H.toAPIType_def
-                      createObjects_def ARM_HYP_H.createObject_def
-                      Arch_createNewCaps_def comp_def
-                      apiGetObjectSize_def shiftl_t2n field_simps
-                      shiftL_nat mapM_x_def sequence_x_def append
-                      fromIntegral_def integral_inv[unfolded Fun.comp_def])+
-        apply (subst monad_eq, rule createObjects_Cons)
-              apply (simp add: field_simps shiftl_t2n bind_assoc pageBits_def
-                               objBits_simps' placeNewObject_def2)+
-        apply (subst gsCNodes_update gsCNodes_upd_createObjects'_comm)+
-        apply (simp add: modify_modify_bind)
-        apply (rule fun_cong[where x=s])
-        apply (rule arg_cong_bind[OF refl ext])+
-        apply (rule arg_cong_bind[OF _ refl])
-        apply (rule arg_cong[where f=modify, OF ext], simp)
-        apply (rule arg_cong2[where f=gsCNodes_update, OF ext refl])
-        apply (rule ext)
-        apply simp
+         \<comment> \<open>CNode\<close>
+         apply (simp add: cteSizeBits_def pageBits_def tcbBlockSizeBits_def
+                       epSizeBits_def ntfnSizeBits_def pdBits_def bind_assoc
+                       ARM_HYP_H.getObjectSize_def
+                       mapM_def sequence_def Retype_H.createObject_def
+                       ARM_HYP_H.toAPIType_def
+                       createObjects_def ARM_HYP_H.createObject_def
+                       Arch_createNewCaps_def comp_def
+                       apiGetObjectSize_def shiftl_t2n field_simps
+                       shiftL_nat mapM_x_def sequence_x_def append
+                       fromIntegral_def integral_inv[unfolded Fun.comp_def])+
+         apply (subst monad_eq, rule createObjects_Cons)
+               apply (simp add: field_simps shiftl_t2n bind_assoc pageBits_def
+                                objBits_simps' placeNewObject_def2)+
+         apply (subst gsCNodes_update gsCNodes_upd_createObjects'_comm)+
+         apply (simp add: modify_modify_bind)
+         apply (rule fun_cong[where x=s])
+         apply (rule arg_cong_bind[OF refl ext])+
+         apply (rule arg_cong_bind[OF _ refl])
+         apply (rule arg_cong[where f=modify, OF ext], simp)
+         apply (rule arg_cong2[where f=gsCNodes_update, OF ext refl])
+         apply (rule ext)
+         apply simp
 
-       \<comment> \<open>SmallPageObject\<close>
-       apply (simp add: Arch_createNewCaps_def
-                        Retype_H.createObject_def createObjects_def bind_assoc toAPIType_def
-                        ARM_HYP_H.createObject_def placeNewDataObject_def)
-       apply (intro conjI impI)
-        (* device *)
-        apply (subst monad_eq, rule createObjects_Cons)
-             apply (simp_all add: field_simps shiftl_t2n pageBits_def
-                                  getObjectSize_def objBits_simps)[6]
-        apply (simp add: bind_assoc placeNewObject_def2 objBits_simps getObjectSize_def
-                         pageBits_def add.commute append)
+        \<comment> \<open>SmallPageObject\<close>
+        apply (simp add: Arch_createNewCaps_def
+                         Retype_H.createObject_def createObjects_def bind_assoc toAPIType_def
+                         ARM_HYP_H.createObject_def placeNewDataObject_def)
+        apply (intro conjI impI)
+         (* device *)
+         apply (subst monad_eq, rule createObjects_Cons)
+               apply (simp_all add: field_simps shiftl_t2n pageBits_def
+                                    getObjectSize_def objBits_simps)[6]
+         apply (simp add: bind_assoc placeNewObject_def2 objBits_simps getObjectSize_def
+                          pageBits_def add.commute append)
          apply ((subst gsUserPages_update gsCNodes_update
                        gsUserPages_upd_createObjects'_comm
                        monad_commute_simple'[OF dmo'_gsUserPages_upd_map_commute]
                  | simp add: modify_modify_bind o_def)+)[1]
         (* not device *)
         apply (subst monad_eq, rule createObjects_Cons)
-             apply (simp_all add: field_simps shiftl_t2n pageBits_def
-                                  getObjectSize_def objBits_simps)[6]
+              apply (simp_all add: field_simps shiftl_t2n pageBits_def
+                                   getObjectSize_def objBits_simps)[6]
         apply (simp add: bind_assoc placeNewObject_def2 objBits_simps getObjectSize_def
                          pageBits_def add.commute append mapM_x_append mapM_x_singleton)
         apply (subst gsUserPages_update gsCNodes_update
@@ -5097,16 +5060,42 @@ proof -
                      monad_commute_simple'[OF map_dmo'_createObjects'_comm]
                      monad_commute_simple'[OF dmo'_gsUserPages_upd_map_commute]
                | simp add: modify_modify_bind o_def)+
-      \<comment> \<open>LargePageObject\<close>
+       \<comment> \<open>LargePageObject\<close>
+       apply (simp add: Arch_createNewCaps_def Retype_H.createObject_def createObjects_def bind_assoc
+                        ARM_HYP_H.toAPIType_def ARM_HYP_H.createObject_def placeNewDataObject_def)
+       apply (intro conjI impI)
+        (* device *)
+        apply (subst monad_eq, rule createObjects_Cons)
+              apply (simp_all add: field_simps shiftl_t2n pageBits_def
+                                   getObjectSize_def objBits_simps)[6]
+        apply (simp add: bind_assoc placeNewObject_def2 objBits_simps getObjectSize_def
+                         pageBits_def add.commute append)
+        apply ((subst gsUserPages_update gsCNodes_update
+                      gsUserPages_upd_createObjects'_comm
+                      monad_commute_simple'[OF dmo'_gsUserPages_upd_map_commute]
+                | simp add: modify_modify_bind o_def)+)[1]
+       (* not device *)
+       apply (subst monad_eq, rule createObjects_Cons)
+             apply (simp_all add: field_simps shiftl_t2n pageBits_def
+                                  ARM_HYP_H.getObjectSize_def objBits_simps)[6]
+       apply (simp add: bind_assoc placeNewObject_def2 objBits_simps
+                         ARM_HYP_H.getObjectSize_def
+                        pageBits_def add.commute append mapM_x_append mapM_x_singleton)
+      apply (subst gsUserPages_update gsCNodes_update
+                   gsUserPages_upd_createObjects'_comm
+                   monad_commute_simple'[OF map_dmo'_createObjects'_comm]
+                   monad_commute_simple'[OF dmo'_gsUserPages_upd_map_commute]
+             | simp add: modify_modify_bind o_def)+
+      \<comment> \<open>SectionObject\<close>
       apply (simp add: Arch_createNewCaps_def Retype_H.createObject_def createObjects_def bind_assoc
-                       ARM_HYP_H.toAPIType_def ARM_HYP_H.createObject_def placeNewDataObject_def)
+                       toAPIType_def ARM_HYP_H.createObject_def placeNewDataObject_def)
       apply (intro conjI impI)
        (* device *)
        apply (subst monad_eq, rule createObjects_Cons)
-            apply (simp_all add: field_simps shiftl_t2n pageBits_def
-                                 getObjectSize_def objBits_simps)[6]
-       apply (simp add: bind_assoc placeNewObject_def2 objBits_simps getObjectSize_def
-                        pageBits_def add.commute append)
+             apply (simp_all add: field_simps shiftl_t2n pageBits_def
+                                  getObjectSize_def objBits_simps)[6]
+       apply (simp add: bind_assoc placeNewObject_def2 objBits_simps
+                        getObjectSize_def pageBits_def add.commute append)
        apply ((subst gsUserPages_update gsCNodes_update
                      gsUserPages_upd_createObjects'_comm
                      monad_commute_simple'[OF dmo'_gsUserPages_upd_map_commute]
@@ -5115,22 +5104,21 @@ proof -
       apply (subst monad_eq, rule createObjects_Cons)
             apply (simp_all add: field_simps shiftl_t2n pageBits_def
                                  ARM_HYP_H.getObjectSize_def objBits_simps)[6]
-      apply (simp add: bind_assoc placeNewObject_def2 objBits_simps
-                        ARM_HYP_H.getObjectSize_def
+      apply (simp add: bind_assoc placeNewObject_def2 objBits_simps ARM_HYP_H.getObjectSize_def
                        pageBits_def add.commute append mapM_x_append mapM_x_singleton)
-      apply (subst gsUserPages_update gsCNodes_update
-                   gsUserPages_upd_createObjects'_comm
-                   monad_commute_simple'[OF map_dmo'_createObjects'_comm]
-                   monad_commute_simple'[OF dmo'_gsUserPages_upd_map_commute]
-             | simp add: modify_modify_bind o_def)+
-     \<comment> \<open>SectionObject\<close>
+     apply (subst gsUserPages_update gsCNodes_update
+                  gsUserPages_upd_createObjects'_comm
+                  monad_commute_simple'[OF map_dmo'_createObjects'_comm]
+                  monad_commute_simple'[OF dmo'_gsUserPages_upd_map_commute]
+            | simp add: modify_modify_bind o_def)+
+     \<comment> \<open>SuperSectionObject\<close>
      apply (simp add: Arch_createNewCaps_def Retype_H.createObject_def createObjects_def bind_assoc
                       toAPIType_def ARM_HYP_H.createObject_def placeNewDataObject_def)
      apply (intro conjI impI)
       (* device *)
       apply (subst monad_eq, rule createObjects_Cons)
-           apply (simp_all add: field_simps shiftl_t2n pageBits_def
-                                getObjectSize_def objBits_simps)[6]
+            apply (simp_all add: field_simps shiftl_t2n pageBits_def
+                                 getObjectSize_def objBits_simps)[6]
       apply (simp add: bind_assoc placeNewObject_def2 objBits_simps
                        getObjectSize_def pageBits_def add.commute append)
       apply ((subst gsUserPages_update gsCNodes_update
@@ -5141,33 +5129,8 @@ proof -
      apply (subst monad_eq, rule createObjects_Cons)
            apply (simp_all add: field_simps shiftl_t2n pageBits_def
                                 ARM_HYP_H.getObjectSize_def objBits_simps)[6]
-     apply (simp add: bind_assoc placeNewObject_def2 objBits_simps ARM_HYP_H.getObjectSize_def
-                      pageBits_def add.commute append mapM_x_append mapM_x_singleton)
-     apply (subst gsUserPages_update gsCNodes_update
-                  gsUserPages_upd_createObjects'_comm
-                  monad_commute_simple'[OF map_dmo'_createObjects'_comm]
-                  monad_commute_simple'[OF dmo'_gsUserPages_upd_map_commute]
-            | simp add: modify_modify_bind o_def)+
-    \<comment> \<open>SuperSectionObject\<close>
-    apply (simp add: Arch_createNewCaps_def Retype_H.createObject_def createObjects_def bind_assoc
-                     toAPIType_def ARM_HYP_H.createObject_def placeNewDataObject_def)
-    apply (intro conjI impI)
-     (* device *)
-     apply (subst monad_eq, rule createObjects_Cons)
-          apply (simp_all add: field_simps shiftl_t2n pageBits_def
-                               getObjectSize_def objBits_simps)[6]
-     apply (simp add: bind_assoc placeNewObject_def2 objBits_simps
-                      getObjectSize_def pageBits_def add.commute append)
-     apply ((subst gsUserPages_update gsCNodes_update
-                   gsUserPages_upd_createObjects'_comm
-                   monad_commute_simple'[OF dmo'_gsUserPages_upd_map_commute]
-             | simp add: modify_modify_bind o_def)+)[1]
-    (* not device *)
-    apply (subst monad_eq, rule createObjects_Cons)
-          apply (simp_all add: field_simps shiftl_t2n pageBits_def
-                               ARM_HYP_H.getObjectSize_def objBits_simps)[6]
-    apply (simp add: bind_assoc placeNewObject_def2 objBits_simps pageBits_def
-                     ARM_HYP_H.getObjectSize_def add.commute append mapM_x_append mapM_x_singleton)
+     apply (simp add: bind_assoc placeNewObject_def2 objBits_simps pageBits_def
+                      ARM_HYP_H.getObjectSize_def add.commute append mapM_x_append mapM_x_singleton)
     apply (subst gsUserPages_update gsCNodes_update
                  gsUserPages_upd_createObjects'_comm
                  monad_commute_simple'[OF map_dmo'_createObjects'_comm]
@@ -5491,35 +5454,19 @@ lemma createObject_pspace_no_overlap':
    apply wpc
     apply (wp ArchCreateObject_pspace_no_overlap')
    apply wpc
-       apply wp
-      apply (simp add:placeNewObject_def2)
-      apply (wp doMachineOp_psp_no_overlap createObjects'_pspace_no_overlap2
-        | simp add: placeNewObject_def2 curDomain_def word_shiftl_add_distrib
-        field_simps)+
-      apply (simp add:add.assoc[symmetric])
-      apply (wp createObjects'_pspace_no_overlap2
-        [where n =0 and sz = sz,simplified])
-     apply (simp add:placeNewObject_def2)
-     apply (wp doMachineOp_psp_no_overlap createObjects'_pspace_no_overlap2
-        | simp add: placeNewObject_def2 word_shiftl_add_distrib
-        field_simps)+
-     apply (simp add:add.assoc[symmetric])
-     apply (wp createObjects'_pspace_no_overlap2
-        [where n =0 and sz = sz,simplified])
-    apply (simp add:placeNewObject_def2)
-    apply (wp doMachineOp_psp_no_overlap createObjects'_pspace_no_overlap2
-      | simp add: placeNewObject_def2 word_shiftl_add_distrib
-      field_simps)+
-    apply (simp add:add.assoc[symmetric])
-    apply (wp createObjects'_pspace_no_overlap2
-      [where n =0 and sz = sz,simplified])
-   apply (simp add:placeNewObject_def2)
-   apply (wp doMachineOp_psp_no_overlap createObjects'_pspace_no_overlap2
-     | simp add: placeNewObject_def2 word_shiftl_add_distrib
-     field_simps)+
-   apply (simp add:add.assoc[symmetric])
-   apply (wp createObjects'_pspace_no_overlap2
-     [where n =0 and sz = sz,simplified])
+         apply wp
+        \<comment> \<open>TCB\<close>
+        apply (wp createObjects'_pspace_no_overlap2[where n =0 and sz = sz,simplified]
+               | simp add: curDomain_def placeNewObject_def2 word_shiftl_add_distrib field_simps)+
+         apply (simp add:add.assoc[symmetric])
+         apply (wp createObjects'_pspace_no_overlap2[where n =0 and sz = sz,simplified])
+        apply (wpsimp simp: curDomain_def)
+       \<comment> \<open>other objects\<close>
+       apply ((wp createObjects'_pspace_no_overlap2
+               | simp add: placeNewObject_def2 word_shiftl_add_distrib field_simps)+,
+              simp add:add.assoc[symmetric],
+              wp createObjects'_pspace_no_overlap2[where n =0 and sz = sz,simplified])+
+   \<comment> \<open>Cleanup\<close>
   apply clarsimp
   apply (frule(1) range_cover_no_0[where p = n])
    apply simp
@@ -5537,10 +5484,9 @@ lemma createObject_pspace_no_overlap':
    apply (simp add:shiftl_t2n field_simps)
   apply (frule range_cover_offset[rotated,where p = n])
    apply simp+
-  apply (auto simp: word_shiftl_add_distrib field_simps shiftl_t2n elim: range_cover_le,
-    auto simp add: APIType_capBits_def fromAPIType_def objBits_def
-        dest!: to_from_apiTypeD)
-  done
+  by (auto simp: word_shiftl_add_distrib field_simps shiftl_t2n elim: range_cover_le)
+     (auto simp: APIType_capBits_def fromAPIType_def objBits_def objBits_simps
+          dest!: to_from_apiTypeD)
 
 lemma createObject_pspace_aligned_distinct':
   "\<lbrace>pspace_aligned' and K (is_aligned ptr (APIType_capBits ty us))

--- a/proof/refine/ARM_HYP/Finalise_R.thy
+++ b/proof/refine/ARM_HYP/Finalise_R.thy
@@ -1598,7 +1598,7 @@ lemma emptySlot_corres:
   apply (simp add: put_def)
   apply (simp add: exec_gets exec_get exec_put del: fun_upd_apply | subst bind_def)+
   apply (clarsimp simp: state_relation_def)
-  apply (drule updateMDB_the_lot, fastforce simp: pspace_relations_def, fastforce, fastforce)
+  apply (drule updateMDB_the_lot, fastforce simp: pspace_relation_def, fastforce, fastforce)
    apply (clarsimp simp: invs'_def valid_state'_def valid_pspace'_def
                          valid_mdb'_def valid_mdb_ctes_def)
   apply (elim conjE)
@@ -1627,7 +1627,7 @@ lemma emptySlot_corres:
   apply clarsimp
   apply (drule updateCap_stuff, elim conjE, erule (1) impE)
   apply clarsimp
-  apply (drule updateMDB_the_lot, force simp: pspace_relations_def, assumption+, simp)
+  apply (drule updateMDB_the_lot, force simp: pspace_relation_def, assumption+, simp)
   apply (rule bexI)
    prefer 2
    apply (simp only: trans_state_update[symmetric])
@@ -1655,7 +1655,7 @@ lemma emptySlot_corres:
    apply (rule mdb_ptr_axioms.intro)
    subgoal by simp
   apply (clarsimp simp: ghost_relation_typ_at set_cap_a_type_inv)
-  apply (simp add: pspace_relations_def)
+  apply (simp add: pspace_relation_def)
   apply (rule conjI)
    apply (clarsimp simp: data_at_def ghost_relation_typ_at set_cap_a_type_inv)
   apply (rule conjI)
@@ -3849,8 +3849,7 @@ lemma vcpuFinalise_corres [corres]:
 lemma arch_finaliseCap_corres:
   "\<lbrakk> final_matters' (ArchObjectCap cap') \<Longrightarrow> final = final'; acap_relation cap cap' \<rbrakk>
      \<Longrightarrow> corres (\<lambda>r r'. cap_relation (fst r) (fst r') \<and> cap_relation (snd r) (snd r'))
-           (\<lambda>s. invs s \<and> valid_etcbs s
-                       \<and> s \<turnstile> cap.ArchObjectCap cap
+           (\<lambda>s. invs s \<and> s \<turnstile> cap.ArchObjectCap cap
                        \<and> (final_matters (cap.ArchObjectCap cap)
                             \<longrightarrow> final = is_final_cap' (cap.ArchObjectCap cap) s)
                        \<and> cte_wp_at ((=) (cap.ArchObjectCap cap)) sl s)
@@ -4204,9 +4203,6 @@ lemma isFinal_lift:
 
 crunch invalidateTLBByASID
   for cteCaps_of: "\<lambda>s. P (cteCaps_of s)"
-
-crunch invalidate_tlb_by_asid
-  for valid_etcbs[wp]: valid_etcbs
 
 lemma cteCaps_of_ctes_of_lift:
   "(\<And>P. \<lbrace>\<lambda>s. P (ctes_of s)\<rbrace> f \<lbrace>\<lambda>_ s. P (ctes_of s)\<rbrace>) \<Longrightarrow> \<lbrace>\<lambda>s. P (cteCaps_of s) \<rbrace> f \<lbrace>\<lambda>_ s. P (cteCaps_of s)\<rbrace>"

--- a/proof/refine/ARM_HYP/Init_R.thy
+++ b/proof/refine/ARM_HYP/Init_R.thy
@@ -51,6 +51,12 @@ definition zeroed_main_abstract_state ::
     is_original_cap = (K True),
     cur_thread = 0,
     idle_thread = 0,
+    scheduler_action = resume_cur_thread,
+    domain_list = [],
+    domain_index = 0,
+    cur_domain = 0,
+    domain_time = 0,
+    ready_queues = (\<lambda>_ _. []),
     machine_state = init_machine_state,
     interrupt_irq_node = (\<lambda>irq. ucast irq << cte_level_bits),
     interrupt_states = (K irq_state.IRQInactive),
@@ -62,13 +68,6 @@ definition zeroed_extended_state ::
   where
   "zeroed_extended_state \<equiv> \<lparr>
     work_units_completed_internal = 0,
-    scheduler_action_internal = resume_cur_thread,
-    ekheap_internal = K None,
-    domain_list_internal = [],
-    domain_index_internal = 0,
-    cur_domain_internal = 0,
-    domain_time_internal = 0,
-    ready_queues_internal = (\<lambda>_ _. []),
     cdt_list_internal = K []
   \<rparr>"
 
@@ -117,8 +116,7 @@ lemma non_empty_refine_state_relation:
   "(zeroed_abstract_state, zeroed_intermediate_state) \<in> state_relation"
   apply (clarsimp simp: state_relation_def zeroed_state_defs state.defs)
   apply (intro conjI)
-          apply (clarsimp simp: pspace_relation_def pspace_dom_def)
-         apply (clarsimp simp: ekheap_relation_def)
+         apply (clarsimp simp: pspace_relation_def pspace_dom_def)
         apply (clarsimp simp: ready_queues_relation_def ready_queue_relation_def queue_end_valid_def
                               opt_pred_def list_queue_relation_def tcbQueueEmpty_def
                               prev_queue_head_def)

--- a/proof/refine/ARM_HYP/Interrupt_R.thy
+++ b/proof/refine/ARM_HYP/Interrupt_R.thy
@@ -621,9 +621,8 @@ lemma getIRQState_prop:
 
 lemma decDomainTime_corres:
   "corres dc \<top> \<top> dec_domain_time decDomainTime"
-  apply (simp add:dec_domain_time_def corres_underlying_def
-    decDomainTime_def simpler_modify_def)
-  apply (clarsimp simp:state_relation_def)
+  apply (simp add:dec_domain_time_def corres_underlying_def decDomainTime_def simpler_modify_def)
+  apply (clarsimp simp: state_relation_def cdt_relation_def)
   done
 
 lemma thread_state_case_if:
@@ -657,24 +656,24 @@ lemma timerTick_corres:
           apply (rule corres_split[where r' = dc])
              apply (rule corres_if[where Q = \<top> and Q' = \<top>])
                apply (case_tac state,simp_all)[1]
-              apply (rule_tac r'="(=)" in corres_split[OF ethreadget_corres])
-                 apply (simp add:etcb_relation_def)
+              apply (rule_tac r'="(=)" in corres_split[OF threadGet_corres])
+                 apply (simp add: tcb_relation_def)
                 apply (rename_tac ts ts')
                 apply (rule_tac R="1 < ts" in corres_cases)
                  apply (simp)
                  apply (unfold thread_set_time_slice_def)
-                 apply (rule ethread_set_corres, simp+)
-                 apply (clarsimp simp: etcb_relation_def)
+                 apply (rule threadset_corres; simp add: tcb_relation_def inQ_def)
                 apply simp
-                apply (rule corres_split[OF ethread_set_corres])
-                         apply (simp add: sch_act_wf_weak etcb_relation_def pred_conj_def)+
+                apply (rule corres_split[OF threadset_corres])
+                                apply (simp add: sch_act_wf_weak tcb_relation_def pred_conj_def inQ_def)+
                   apply (rule corres_split[OF tcbSchedAppend_corres], simp)
                     apply (rule rescheduleRequired_corres)
                    apply wp
                   apply ((wpsimp wp: tcbSchedAppend_sym_heap_sched_pointers
                                      tcbSchedAppend_valid_objs'
                           | strengthen valid_objs'_valid_tcbs')+)[1]
-                 apply ((wp thread_set_time_slice_valid_queues
+                 apply ((wpsimp wp: thread_set_valid_queues thread_set_no_change_tcb_state
+                                    thread_set_weak_valid_sched_action
                          | strengthen valid_queues_in_correct_ready_q
                                       valid_queues_ready_qs_distinct)+)[1]
                 apply ((wpsimp wp: threadSet_sched_pointers threadSet_valid_sched_pointers
@@ -694,10 +693,10 @@ lemma timerTick_corres:
                              threadSet_pred_tcb_at_state threadSet_weak_sch_act_wf
                              rescheduleRequired_weak_sch_act_wf)+
               apply (strengthen valid_queues_in_correct_ready_q valid_queues_ready_qs_distinct)
-              apply (wpsimp wp: thread_set_time_slice_valid_queues)
-             apply ((wpsimp wp: thread_set_time_slice_valid_queues
+              apply (wpsimp wp: thread_set_valid_queues thread_set_weak_valid_sched_action)
+             apply ((wpsimp wp: thread_set_valid_queues
                      | strengthen valid_queues_in_correct_ready_q valid_queues_ready_qs_distinct)+)[1]
-            apply wpsimp
+            apply (wpsimp wp: thread_get_wp)
            apply wpsimp
           apply ((wpsimp wp: threadSet_sched_pointers threadSet_valid_sched_pointers
                              threadSet_valid_objs'
@@ -705,11 +704,8 @@ lemma timerTick_corres:
                   | wp (once) hoare_drop_imp)+)[1]
          apply (wpsimp wp: gts_wp gts_wp')+
      apply (clarsimp simp: cur_tcb_def)
-     apply (frule valid_sched_valid_etcbs)
-     apply (frule (1) tcb_at_is_etcb_at)
      apply (frule valid_sched_valid_queues)
      apply (fastforce simp: pred_tcb_at_def obj_at_def valid_sched_weak_strg)
-    apply (clarsimp simp: etcb_at_def split: option.splits)
     apply fastforce
    apply (fastforce simp: valid_state'_def ct_not_inQ_def)
   apply fastforce

--- a/proof/refine/ARM_HYP/IpcCancel_R.thy
+++ b/proof/refine/ARM_HYP/IpcCancel_R.thy
@@ -538,7 +538,7 @@ lemma (in delete_one) cancelIPC_ReplyCap_corres:
           apply (simp add: tcb_relation_def fault_rel_optionation_def)
          apply (simp add: tcb_cap_cases_def)
         apply (simp add: tcb_cte_cases_def tcb_cte_cases_neqs)
-       apply (simp add: exst_same_def)
+       apply (simp add: inQ_def)
       apply (fastforce simp: st_tcb_at_tcb_at)
      apply clarsimp
     defer
@@ -1224,17 +1224,21 @@ crunch asUser
 
 crunch set_thread_state
   for in_correct_ready_q[wp]: in_correct_ready_q
-  (wp: crunch_wps ignore_del: set_thread_state_ext)
+  (wp: set_object_wp)
 
-crunch set_thread_state_ext
+crunch set_thread_state_act
   for ready_qs_distinct[wp]: ready_qs_distinct
-  (wp: crunch_wps ignore_del: set_thread_state_ext)
+  (wp: crunch_wps)
 
 lemma set_thread_state_ready_qs_distinct[wp]:
   "set_thread_state ref ts \<lbrace>ready_qs_distinct\<rbrace>"
   unfolding set_thread_state_def
   apply (wpsimp wp: set_object_wp)
   by (clarsimp simp: ready_qs_distinct_def)
+
+crunch as_user
+  for in_correct_ready_q[wp]: in_correct_ready_q
+  (wp: set_object_wp)
 
 lemma as_user_ready_qs_distinct[wp]:
   "as_user tptr f \<lbrace>ready_qs_distinct\<rbrace>"
@@ -1331,8 +1335,7 @@ lemma archThreadSet_corres:
   apply (simp add: arch_thread_set_def archThreadSet_def)
   apply (corresK corres: getObject_TCB_corres setObject_update_TCB_corres')
   apply wpsimp+
-  apply (auto simp add: tcb_relation_def tcb_cap_cases_def tcb_cte_cases_def exst_same_def
-                        tcb_cte_cases_neqs)+
+  apply (auto simp: tcb_relation_def tcb_cap_cases_def tcb_cte_cases_def tcb_cte_cases_neqs)+
   done
 
 lemma archThreadSet_VCPU_None_corres[corres]:
@@ -1539,7 +1542,7 @@ lemma sts_sch_act_not_ct[wp]:
 text \<open>Cancelling all IPC in an endpoint or notification object\<close>
 
 lemma ep_cancel_corres_helper:
-  "corres dc ((\<lambda>s. \<forall>t \<in> set list. tcb_at t s) and valid_etcbs and valid_queues
+  "corres dc ((\<lambda>s. \<forall>t \<in> set list. tcb_at t s) and valid_queues
                                               and pspace_aligned and pspace_distinct)
              (valid_objs' and sym_heap_sched_pointers and valid_sched_pointers)
           (mapM_x (\<lambda>t. do
@@ -1576,7 +1579,7 @@ lemma ep_cancel_corres_helper:
 crunch set_simple_ko
   for ready_qs_distinct[wp]: ready_qs_distinct
   and in_correct_ready_q[wp]: in_correct_ready_q
-  (rule: ready_qs_distinct_lift wp: crunch_wps)
+  (wp: ready_qs_distinct_lift in_correct_ready_q_lift)
 
 lemma ep_cancel_corres:
   "corres dc (invs and valid_sched and ep_at ep) (invs' and ep_at' ep)
@@ -1585,7 +1588,7 @@ proof -
   have P:
     "\<And>list.
      corres dc (\<lambda>s. (\<forall>t \<in> set list. tcb_at t s) \<and> valid_pspace s \<and> ep_at ep s
-                        \<and> valid_etcbs s \<and> weak_valid_sched_action s \<and> valid_queues s)
+                        \<and> weak_valid_sched_action s \<and> valid_queues s)
                (\<lambda>s. (\<forall>t \<in> set list. tcb_at' t s) \<and> valid_pspace' s
                          \<and> ep_at' ep s \<and> weak_sch_act_wf (ksSchedulerAction s) s
                          \<and> valid_objs' s \<and> sym_heap_sched_pointers s \<and> valid_sched_pointers s)
@@ -2313,7 +2316,7 @@ lemma cancelBadgedSends_corres:
                                                            and pspace_distinct'"]])
          apply (rule_tac S="(=)"
                      and Q="\<lambda>xs s. (\<forall>x \<in> set xs. (epptr, TCBBlockedSend) \<in> state_refs_of s x) \<and>
-                                   distinct xs \<and> valid_etcbs s \<and>
+                                   distinct xs \<and>
                                    in_correct_ready_q s \<and> ready_qs_distinct s \<and>
                                    pspace_aligned s \<and> pspace_distinct s"
                     and Q'="\<lambda>_ s. valid_objs' s \<and> sym_heap_sched_pointers s \<and> valid_sched_pointers s
@@ -2337,7 +2340,7 @@ lemma cancelBadgedSends_corres:
                       | strengthen valid_objs'_valid_tcbs')+
             apply (clarsimp simp: valid_tcb_state_def tcb_at_def st_tcb_def2
                                   st_tcb_at_refs_of_rev
-                           dest!: state_refs_of_elemD elim!: tcb_at_is_etcb_at[rotated])
+                           dest!: state_refs_of_elemD)
            apply (simp add: valid_tcb_state'_def)
           apply (wp hoare_vcg_const_Ball_lift gts_wp | clarsimp)+
             apply (wp hoare_vcg_imp_lift sts_st_tcb' sts_valid_objs'

--- a/proof/refine/ARM_HYP/Ipc_R.thy
+++ b/proof/refine/ARM_HYP/Ipc_R.thy
@@ -2306,9 +2306,8 @@ lemma doReplyTransfer_corres:
                apply simp
               apply (rule corres_split)
                  apply (rule threadset_corresT;
-                        clarsimp simp add: tcb_relation_def fault_rel_optionation_def
-                                           tcb_cap_cases_def tcb_cte_cases_def tcb_cte_cases_neqs
-                                           exst_same_def)
+                        clarsimp simp add: tcb_relation_def fault_rel_optionation_def cteSizeBits_def
+                                           tcb_cap_cases_def tcb_cte_cases_def inQ_def)
                 apply (rule_tac Q="valid_sched and cur_tcb and tcb_at receiver and pspace_aligned and pspace_distinct"
                             and Q'="tcb_at' receiver and cur_tcb'
                                       and (\<lambda>s. weak_sch_act_wf (ksSchedulerAction s) s)
@@ -3515,7 +3514,7 @@ lemma sendFaultIPC_corres:
            apply (rule corres_if2 [OF refl])
             apply (simp add: dc_def[symmetric])
             apply (rule corres_split[OF threadset_corres sendIPC_corres], simp_all)[1]
-               apply (simp add: tcb_relation_def fault_rel_optionation_def exst_same_def)+
+               apply (simp add: tcb_relation_def fault_rel_optionation_def inQ_def)+
              apply (wp thread_set_invs_trivial thread_set_no_change_tcb_state
                        thread_set_typ_at ep_at_typ_at ex_nonz_cap_to_pres
                        thread_set_cte_wp_at_trivial thread_set_not_state_valid_sched

--- a/proof/refine/ARM_HYP/KHeap_R.thy
+++ b/proof/refine/ARM_HYP/KHeap_R.thy
@@ -1043,17 +1043,6 @@ lemma obj_relation_cut_same_type:
                     ARM_HYP_A.arch_kernel_obj.split_asm arch_kernel_object.split_asm)
   done
 
-definition exst_same :: "Structures_H.tcb \<Rightarrow> Structures_H.tcb \<Rightarrow> bool"
-where
-  "exst_same tcb tcb' \<equiv> tcbPriority tcb = tcbPriority tcb'
-                      \<and> tcbTimeSlice tcb = tcbTimeSlice tcb'
-                      \<and> tcbDomain tcb = tcbDomain tcb'"
-
-fun exst_same' :: "Structures_H.kernel_object \<Rightarrow> Structures_H.kernel_object \<Rightarrow> bool"
-where
-  "exst_same' (KOTCB tcb) (KOTCB tcb') = exst_same tcb tcb'" |
-  "exst_same' _ _ = True"
-
 lemma tcbs_of'_non_tcb_update:
   "\<lbrakk>typ_at' (koTypeOf ko) ptr s'; koTypeOf ko \<noteq> TCBT\<rbrakk>
    \<Longrightarrow> tcbs_of' (s'\<lparr>ksPSpace := (ksPSpace s')(ptr \<mapsto> ko)\<rparr>) = tcbs_of' s'"
@@ -1071,7 +1060,6 @@ lemma setObject_other_corres:
                \<Longrightarrow> map_to_ctes ((ksPSpace s) (ptr \<mapsto> injectKO ob')) = map_to_ctes (ksPSpace s)"
   assumes t: "is_other_obj_relation_type (a_type ob)"
   assumes b: "\<And>ko. P ko \<Longrightarrow> objBits ko = objBits ob'"
-  assumes e: "\<And>ko. P ko \<Longrightarrow> exst_same' (injectKO ko) (injectKO ob')"
   assumes P: "\<And>v::'a::pspace_storable. (1 :: machine_word) < 2 ^ objBits v"
   shows      "other_obj_relation ob (injectKO (ob' :: 'a :: pspace_storable)) \<Longrightarrow>
   corres dc (obj_at (\<lambda>ko. a_type ko = a_type ob) ptr and obj_at (same_caps ob) ptr)
@@ -1122,21 +1110,6 @@ lemma setObject_other_corres:
    apply (insert t)
    apply ((erule disjE
           | clarsimp simp: is_other_obj_relation_type is_other_obj_relation_type_def a_type_def)+)[1]
-  apply (extract_conjunct \<open>match conclusion in "ekheap_relation _ _" \<Rightarrow> -\<close>)
-   apply (simp only: ekheap_relation_def)
-   apply (rule ballI, drule(1) bspec)
-   apply (drule domD)
-   apply (insert e)
-   apply atomize
-   apply (clarsimp simp: obj_at'_def)
-   apply (erule_tac x=obj in allE)
-   apply (clarsimp simp: projectKO_eq project_inject)
-   apply (case_tac ob;
-          simp_all add: a_type_def other_obj_relation_def etcb_relation_def
-                        is_other_obj_relation_type t exst_same_def)[1]
-     apply (clarsimp simp: is_other_obj_relation_type t exst_same_def
-                    split: Structures_A.kernel_object.splits Structures_H.kernel_object.splits
-                           arch_kernel_obj.splits)+
   \<comment> \<open>ready_queues_relation\<close>
   apply (prop_tac "koTypeOf (injectKO ob') \<noteq> TCBT")
    subgoal

--- a/proof/refine/ARM_HYP/PageTableDuplicates.thy
+++ b/proof/refine/ARM_HYP/PageTableDuplicates.thy
@@ -647,7 +647,7 @@ lemma createObject_valid_duplicates'[wp]:
   apply (simp add:createObject_def)
   apply (rule hoare_pre)
   apply (wpc | wp| simp add: ARM_HYP_H.createObject_def split del: if_split)+
-         apply (simp add: placeNewObject_def placeNewDataObject_def
+         apply (simp add: placeNewObject_def placeNewDataObject_def curDomain_def
                           placeNewObject'_def split_def copyGlobalMappings_def
                      split del: if_split
            | wp unless_wp[where P="d"] unless_wp[where P'=\<top>]

--- a/proof/refine/ARM_HYP/Refine.thy
+++ b/proof/refine/ARM_HYP/Refine.thy
@@ -201,18 +201,27 @@ assumes rel: "(s,s') \<in> state_relation"
 shows "absKState s' = abs_state s"
   using assms
   apply (intro state.equality, simp_all add: absKState_def abs_state_def)
-           apply (rule absHeap_correct, clarsimp+)
-           apply (clarsimp elim!: state_relationE)
-          apply (rule absCDT_correct, clarsimp+)
-         apply (rule absIsOriginalCap_correct, clarsimp+)
+                 apply (rule absHeap_correct; clarsimp)
+                 apply (clarsimp elim!: state_relationE)
+                apply (rule absCDT_correct; clarsimp)
+               apply (rule absIsOriginalCap_correct; clarsimp)
+              apply (simp add: state_relation_def)
+             apply (simp add: state_relation_def)
+            apply (clarsimp simp: state_relation_def)
+            apply (rule absSchedulerAction_correct, simp add: state_relation_def)
+           apply (simp add: state_relation_def)
+          apply (simp add: state_relation_def)
+         apply (simp add: state_relation_def)
         apply (simp add: state_relation_def)
-       apply (simp add: state_relation_def)
+       apply (simp add: state_relation_def ready_queues_relation_def ready_queue_relation_def Let_def
+                        list_queue_relation_def)
+       apply (fastforce dest: heap_ls_is_walk)
       apply (clarsimp simp:  user_mem_relation invs_def invs'_def)
       apply (simp add: state_relation_def)
      apply (rule absInterruptIRQNode_correct, simp add: state_relation_def)
     apply (rule absInterruptStates_correct, simp add: state_relation_def)
    apply (rule absArchState_correct, simp)
-  apply (rule absExst_correct, simp+)
+  apply (rule absExst_correct; simp)
   done
 
 text \<open>The top-level invariance\<close>
@@ -223,19 +232,19 @@ lemma set_thread_state_sched_act:
   \<lbrace>\<lambda>rs s. P (scheduler_action (s::det_state))\<rbrace>"
   apply (simp add: set_thread_state_def)
   apply wp
-    apply (simp add: set_thread_state_ext_def)
-    apply wp
-       apply (rule hoare_pre_cont)
-      apply (rule_tac Q'="\<lambda>rv. (\<lambda>s. runnable ts) and (\<lambda>s. P (scheduler_action s))"
-              in hoare_strengthen_post)
-       apply wp
-      apply force
-     apply (wp gts_st_tcb_at)+
-     apply (rule_tac Q'="\<lambda>rv. st_tcb_at ((=) state) thread and (\<lambda>s. runnable state) and (\<lambda>s. P (scheduler_action s))" in hoare_strengthen_post)
+     apply (simp add: set_thread_state_act_def)
+     apply wp
+        apply (rule hoare_pre_cont)
+       apply (rule_tac Q'="\<lambda>rv. (\<lambda>s. runnable ts) and (\<lambda>s. P (scheduler_action s))"
+               in hoare_strengthen_post)
+        apply wp
+       apply force
+      apply (wp gts_st_tcb_at)+
+    apply (rule_tac Q'="\<lambda>rv. st_tcb_at ((=) state) thread and (\<lambda>s. runnable state) and (\<lambda>s. P (scheduler_action s))" in hoare_strengthen_post)
      apply (simp add: st_tcb_at_def)
      apply (wp obj_set_prop_at)+
     apply (force simp: st_tcb_at_def obj_at_def)
-  apply wp
+   apply wp
   apply clarsimp
   done
 
@@ -277,7 +286,7 @@ lemma kernel_entry_invs:
    apply clarsimp
   apply (simp add: kernel_entry_def)
   apply (wp akernel_invs_det_ext call_kernel_valid_sched thread_set_invs_trivial
-            thread_set_ct_running thread_set_not_state_valid_sched
+            thread_set_not_state_valid_sched
             hoare_vcg_disj_lift ct_in_state_thread_state_lift thread_set_no_change_tcb_state
             call_kernel_domain_time_inv_det_ext call_kernel_domain_list_inv_det_ext
             hoare_weak_lift_imp
@@ -335,11 +344,12 @@ lemmas valid_list_inits[simp] = valid_list_init[simplified]
 lemma valid_sched_init[simp]:
   "valid_sched init_A_st"
   apply (simp add: valid_sched_def init_A_st_def ext_init_def)
-  apply (clarsimp simp: valid_etcbs_def init_kheap_def st_tcb_at_kh_def obj_at_kh_def
-                    obj_at_def is_etcb_at_def idle_thread_ptr_def init_globals_frame_def
+  apply (clarsimp simp: init_kheap_def st_tcb_at_kh_def obj_at_kh_def
+                    obj_at_def idle_thread_ptr_def init_globals_frame_def
                     valid_queues_2_def ct_not_in_q_def not_queued_def
                     valid_sched_action_def is_activatable_def us_global_pd_ptr_def
-                    ct_in_cur_domain_2_def valid_blocked_2_def valid_idle_etcb_def etcb_at'_def default_etcb_def)
+                    ct_in_cur_domain_2_def valid_blocked_2_def valid_idle_etcb_def
+                    etcb_at'_def etcbs_of'_def)
   done
 
 lemma valid_domain_list_init[simp]:
@@ -442,27 +452,6 @@ lemma kernelEntry_invs':
                           valid_domain_list'_def)+
   done
 
-lemma absKState_correct':
-  "\<lbrakk>einvs s; invs' s'; (s,s') \<in> state_relation\<rbrakk>
-   \<Longrightarrow> absKState s' = abs_state s"
-  apply (intro state.equality, simp_all add: absKState_def abs_state_def)
-           apply (rule absHeap_correct)
-               apply (clarsimp simp: valid_state_def valid_pspace_def)+
-           apply (clarsimp dest!: state_relationD)
-          apply (rule absCDT_correct)
-                apply (clarsimp simp: valid_state_def valid_pspace_def
-                                      valid_state'_def valid_pspace'_def)+
-         apply (rule absIsOriginalCap_correct, clarsimp+)
-        apply (simp add: state_relation_def)
-       apply (simp add: state_relation_def)
-      apply (clarsimp simp: user_mem_relation invs_def invs'_def)
-      apply (simp add: state_relation_def)
-     apply (rule absInterruptIRQNode_correct, simp add: state_relation_def)
-    apply (rule absInterruptStates_correct, simp add: state_relation_def)
-   apply (erule absArchState_correct)
-  apply (rule absExst_correct, simp, assumption+)
-  done
-
 lemma ptable_lift_abs_state[simp]:
   "ptable_lift t (abs_state s) = ptable_lift t s"
   by (simp add: ptable_lift_def abs_state_def)
@@ -480,7 +469,7 @@ lemma ptable_rights_imp_UserData:
   shows "pointerInUserData y s' \<or> pointerInDeviceData y s'"
 proof -
   from invs invs' rel have [simp]: "absKState s' = abs_state s"
-    by - (rule absKState_correct', simp_all)
+    by - (rule absKState_correct, simp_all)
   from invs have valid: "valid_state s" by auto
   from invs' have valid': "valid_state' s'" by auto
   have "in_user_frame y s \<or> in_device_frame y s "
@@ -657,11 +646,10 @@ lemma entry_corres:
       apply (rule corres_split)
          apply simp
          apply (rule threadset_corresT; simp?)
-            apply (simp add: tcb_relation_def arch_tcb_relation_def
-                             arch_tcb_context_set_def atcbContextSet_def)
-           apply (clarsimp simp: tcb_cap_cases_def)
-          apply (clarsimp simp: tcb_cte_cases_def tcb_cte_cases_neqs)
-         apply (simp add: exst_same_def)
+           apply (simp add: tcb_relation_def arch_tcb_relation_def
+                            arch_tcb_context_set_def atcbContextSet_def)
+          apply (clarsimp simp: tcb_cap_cases_def)
+         apply (clarsimp simp: tcb_cte_cases_def tcb_cte_cases_neqs)
         apply (rule corres_split[OF kernel_corres])
           apply (rule corres_split_eqr[OF getCurThread_corres])
             apply (rule threadGet_corres)
@@ -671,7 +659,7 @@ lemma entry_corres:
          apply (rule hoare_strengthen_post, rule akernel_invs_det_ext,
                 simp add: invs_def valid_state_def valid_pspace_def cur_tcb_def)
         apply (rule hoare_strengthen_post, rule ckernel_invs, simp add: invs'_def cur_tcb'_def)
-       apply ((wp thread_set_invs_trivial thread_set_ct_running
+       apply ((wp thread_set_invs_trivial
                   thread_set_not_state_valid_sched hoare_weak_lift_imp
                   hoare_vcg_disj_lift ct_in_state_thread_state_lift
                | simp add: tcb_cap_cases_def thread_set_no_change_tcb_state schact_is_rct_def)+)[1]

--- a/proof/refine/ARM_HYP/Retype_R.thy
+++ b/proof/refine/ARM_HYP/Retype_R.thy
@@ -79,14 +79,14 @@ where
     | VCPUObject \<Rightarrow> vcpu_bits"
 
 definition
-  makeObjectKO :: "bool \<Rightarrow> (kernel_object + ARM_HYP_H.object_type) \<rightharpoonup> kernel_object"
+  makeObjectKO :: "bool \<Rightarrow> domain \<Rightarrow> (kernel_object + ARM_HYP_H.object_type) \<rightharpoonup> kernel_object"
 where
-  "makeObjectKO dev ty \<equiv> case ty of
+  "makeObjectKO dev d ty \<equiv> case ty of
       Inl KOUserData \<Rightarrow> Some KOUserData
     | Inl (KOArch (KOASIDPool _)) \<Rightarrow> Some (KOArch (KOASIDPool makeObject))
     | Inl (KOArch (KOVCPU _)) \<Rightarrow> Some (KOArch (KOVCPU makeObject)) \<comment> \<open>inl or inr?\<close>
     | Inr VCPUObject \<Rightarrow> Some (KOArch (KOVCPU makeObject)) \<comment> \<open>inl or inr?\<close>
-    | Inr (APIObjectType ArchTypes_H.TCBObject) \<Rightarrow> Some (KOTCB makeObject)
+    | Inr (APIObjectType ArchTypes_H.TCBObject) \<Rightarrow> Some (KOTCB (tcbDomain_update (\<lambda>_. d) makeObject))
     | Inr (APIObjectType ArchTypes_H.EndpointObject) \<Rightarrow> Some (KOEndpoint makeObject)
     | Inr (APIObjectType ArchTypes_H.NotificationObject) \<Rightarrow> Some (KONotification makeObject)
     | Inr (APIObjectType ArchTypes_H.CapTableObject) \<Rightarrow> Some (KOCTE makeObject)
@@ -113,6 +113,12 @@ lemma valid_obj_makeObject_tcb [simp]:
   unfolding valid_obj'_def valid_tcb'_def  valid_tcb_state'_def valid_arch_tcb'_def
   by (clarsimp simp: makeObject_tcb makeObject_cte tcb_cte_cases_def minBound_word newArchTCB_def
                      cteSizeBits_def valid_arch_tcb'_def)
+
+lemma valid_obj_makeObject_tcb_tcbDomain_update [simp]:
+  "d \<le> maxDomain \<Longrightarrow> valid_obj' (KOTCB (tcbDomain_update (\<lambda>_. d) makeObject)) s"
+  unfolding valid_obj'_def valid_tcb'_def  valid_tcb_state'_def valid_arch_tcb'_def
+  by (clarsimp simp: makeObject_tcb makeObject_cte objBits_simps' newArchTCB_def
+                     tcb_cte_cases_def maxDomain_def maxPriority_def numPriorities_def minBound_word)
 
 lemma valid_obj_makeObject_endpoint [simp]:
   "valid_obj' (KOEndpoint makeObject) s"
@@ -307,14 +313,13 @@ lemma cte_at_next_slot'':
 
 
 lemma state_relation_null_filterE:
-  "\<lbrakk> (s, s') \<in> state_relation; t = kheap_update f (ekheap_update ef s);
+  "\<lbrakk> (s, s') \<in> state_relation; t = kheap_update f s;
      \<exists>f' g' h'.
      t' = s'\<lparr>ksPSpace := f' (ksPSpace s'), gsUserPages := g' (gsUserPages s'),
              gsCNodes := h' (gsCNodes s')\<rparr>;
      null_filter (caps_of_state t) = null_filter (caps_of_state s);
      null_filter' (ctes_of t') = null_filter' (ctes_of s');
-     pspace_relation (kheap t) (ksPSpace t');
-     ekheap_relation (ekheap t) (ksPSpace t'); ready_queues_relation t t';
+     pspace_relation (kheap t) (ksPSpace t'); ready_queues_relation t t';
      ghost_relation (kheap t) (gsUserPages t') (gsCNodes t'); valid_list s;
      pspace_aligned' s'; pspace_distinct' s'; valid_objs s; valid_mdb s;
      pspace_aligned' t'; pspace_distinct' t';
@@ -332,12 +337,11 @@ lemma state_relation_null_filterE:
     apply (case_tac "cdt s (a, b)")
      apply (subst mdb_cte_at_no_descendants, assumption)
       apply (simp add: cte_wp_at_caps_of_state swp_def)
-     apply (cut_tac s="kheap_update f (ekheap_update ef s)"  and
+     apply (cut_tac s="kheap_update f s"  and
                     s'="s'\<lparr>ksPSpace := f' (ksPSpace s'),
                            gsUserPages := g' (gsUserPages s'),
                            gsCNodes := h' (gsCNodes s')\<rparr>"
             in pspace_relation_ctes_ofI, simp_all)[1]
-      apply (simp add: trans_state_update[symmetric] del: trans_state_update)
       apply (erule caps_of_state_cteD)
      apply (clarsimp simp: descendants_of'_def)
      apply (case_tac cte)
@@ -441,12 +445,12 @@ lemma foldr_update_obj_at':
   done
 
 lemma makeObjectKO_eq:
-  assumes x: "makeObjectKO dev tp = Some v"
+  assumes x: "makeObjectKO dev d tp = Some v"
   shows
   "(v = KOCTE cte) =
        (tp = Inr (APIObjectType ArchTypes_H.CapTableObject) \<and> cte = makeObject)"
   "(v = KOTCB tcb) =
-       (tp = Inr (APIObjectType ArchTypes_H.TCBObject) \<and> tcb = makeObject)"
+       (tp = Inr (APIObjectType ArchTypes_H.TCBObject) \<and> tcb = (tcbDomain_update (\<lambda>_. d) makeObject))"
   using x
   by (simp add: makeObjectKO_def eq_commute
          split: apiobject_type.split_asm sum.split_asm kernel_object.split_asm
@@ -501,7 +505,7 @@ lemma ps_clearD:
   done
 
 lemma cte_wp_at_retype':
-  assumes ko: "makeObjectKO dev tp = Some obj"
+  assumes ko: "makeObjectKO dev d tp = Some obj"
       and pv: "pspace_aligned' s" "pspace_distinct' s"
      and pv': "pspace_aligned' (ksPSpace_update (\<lambda>x xa. if xa \<in> set addrs then Some obj else ksPSpace s xa) s)"
               "pspace_distinct' (ksPSpace_update (\<lambda>x xa. if xa \<in> set addrs then Some obj else ksPSpace s xa) s)"
@@ -520,29 +524,28 @@ lemma cte_wp_at_retype':
     apply (subgoal_tac "(\<exists>P :: cte \<Rightarrow> bool. obj_at' P p ?s')
                           \<longrightarrow> (\<not> (\<exists>P :: tcb \<Rightarrow> bool. obj_at' P (p && ~~ mask tcbBlockSizeBits) ?s'))")
      apply (simp only: cte_wp_at_obj_cases_mask foldr_update_obj_at'[OF pv pv' al])
-     apply (simp    add: projectKOs the_ctes_makeObject
-                         makeObjectKO_eq [OF ko]
-                         makeObject_cte dom_def
+     apply (simp    add: projectKOs the_ctes_makeObject makeObjectKO_eq [OF ko] makeObject_cte
               split del: if_split
                    cong: if_cong)
      apply (insert al ko)
-     apply (simp, safe, simp_all)
-      apply fastforce
-     apply fastforce
+     apply simp
+     apply (safe; simp)
+              apply ((fastforce simp: makeObjectKO_def makeObject_cte makeObject_tcb tcb_cte_cases_def
+                               split: if_split_asm)+)[10]
     apply (clarsimp elim!: obj_atE' simp: projectKOs objBits_simps)
     apply (drule ps_clearD[where y=p and n=tcbBlockSizeBits])
        apply simp
       apply (rule order_trans_rules(17))
        apply (clarsimp cong: if_cong)
       apply (rule word_and_le2)
-     apply (simp add: word_le_mask_out_plus_2sz)
+     apply (simp add: word_neg_and_le[simplified field_simps])
     apply simp
    apply (clarsimp elim!: obj_atE' simp: pn)
   apply (clarsimp elim!: obj_atE' simp: pn)
   done
 
 lemma ctes_of_retype:
-  assumes ko: "makeObjectKO dev tp = Some obj"
+  assumes ko: "makeObjectKO dev d tp = Some obj"
       and pv: "pspace_aligned' s" "pspace_distinct' s"
      and pv': "pspace_aligned' (ksPSpace_update (\<lambda>x xa. if xa \<in> set addrs then Some obj else ksPSpace s xa) s)"
               "pspace_distinct' (ksPSpace_update (\<lambda>x xa. if xa \<in> set addrs then Some obj else ksPSpace s xa) s)"
@@ -571,7 +574,7 @@ lemma None_ctes_of_cte_at:
   by (fastforce simp add: cte_wp_at_ctes_of)
 
 lemma null_filter_ctes_retype:
-  assumes ko: "makeObjectKO dev tp = Some obj"
+  assumes ko: "makeObjectKO dev d tp = Some obj"
       and pv: "pspace_aligned' s" "pspace_distinct' s"
      and pv': "pspace_aligned' (ksPSpace_update (\<lambda>x xa. if xa \<in> set addrs then Some obj else ksPSpace s xa) s)"
               "pspace_distinct' (ksPSpace_update (\<lambda>x xa. if xa \<in> set addrs then Some obj else ksPSpace s xa) s)"
@@ -602,7 +605,8 @@ lemma null_filter_ctes_retype:
    apply (insert ko[symmetric], simp add: makeObjectKO_def objBits_simps)
    apply clarsimp
    apply (subst(asm) subtract_mask[symmetric],
-          erule_tac v="if x \<in> set addrs then KOTCB makeObject else KOCTE cte"
+          erule_tac v="if x \<in> set addrs then KOTCB (tcbDomain_update (\<lambda>_. d) makeObject)
+                                        else KOCTE cte"
                 in tcb_space_clear)
        apply (simp add: is_aligned_mask word_bw_assocs)
       apply assumption
@@ -730,13 +734,13 @@ lemma obj_relation_retype_leD:
   by (simp add: obj_relation_retype_def)
 
 lemma obj_relation_retype_default_leD:
-  "\<lbrakk> obj_relation_retype (default_object (APIType_map2 ty) dev us) ko;
+  "\<lbrakk> obj_relation_retype (default_object (APIType_map2 ty) dev us d) ko;
        ty \<noteq> Inr (APIObjectType ArchTypes_H.Untyped) \<rbrakk>
       \<Longrightarrow> objBitsKO ko \<le> obj_bits_api (APIType_map2 ty) us"
   by (simp add: obj_relation_retype_def objBits_def obj_bits_dev_irr)
 
 lemma makeObjectKO_Untyped:
-  "makeObjectKO dev ty = Some v \<Longrightarrow> ty \<noteq> Inr (APIObjectType ArchTypes_H.Untyped)"
+  "makeObjectKO dev d ty = Some v \<Longrightarrow> ty \<noteq> Inr (APIObjectType ArchTypes_H.Untyped)"
   by (clarsimp simp: makeObjectKO_def)
 
 lemma obj_relation_cuts_trivial:
@@ -760,10 +764,10 @@ lemma obj_relation_cuts_trivial:
 lemma obj_relation_retype_addrs_eq:
   assumes not_unt:"ty \<noteq> Inr (APIObjectType ArchTypes_H.Untyped)"
   assumes  amp: "m = 2^ ((obj_bits_api (APIType_map2 ty) us) - (objBitsKO ko)) * n"
-  assumes  orr: "obj_relation_retype (default_object (APIType_map2 ty) dev us) ko"
+  assumes  orr: "obj_relation_retype (default_object (APIType_map2 ty) dev us d) ko"
   shows  "\<lbrakk> range_cover ptr sz (obj_bits_api (APIType_map2 ty) us) n \<rbrakk> \<Longrightarrow>
    (\<Union>x \<in> set (retype_addrs ptr (APIType_map2 ty) n us).
-            fst ` obj_relation_cuts (default_object (APIType_map2 ty) dev us) x)
+            fst ` obj_relation_cuts (default_object (APIType_map2 ty) dev us d) x)
       = set (new_cap_addrs m ptr ko)"
   apply (rule set_eqI, rule iffI)
    apply (clarsimp simp: retype_addrs_def)
@@ -823,7 +827,7 @@ lemma obj_relation_retype_addrs_eq:
 done
 
 lemma objBits_le_obj_bits_api:
-  "makeObjectKO dev ty = Some ko \<Longrightarrow>
+  "makeObjectKO dev d ty = Some ko \<Longrightarrow>
    objBitsKO ko \<le> obj_bits_api (APIType_map2 ty) us"
   apply (case_tac ty)
     apply (auto simp: default_arch_object_def vspace_bits_defs vcpu_bits_def archObjSize_def
@@ -852,12 +856,12 @@ lemma retype_pspace_relation:
       and vs': "pspace_aligned' s'" "pspace_distinct' s'"
       and  pn: "pspace_no_overlap_range_cover ptr sz s"
       and pn': "pspace_no_overlap' ptr sz s'"
-      and  ko: "makeObjectKO dev ty = Some ko"
+      and  ko: "makeObjectKO dev d ty = Some ko"
       and cover: "range_cover ptr sz (obj_bits_api (APIType_map2 ty) us) n"
-      and orr: "obj_relation_retype (default_object (APIType_map2 ty) dev us) ko"
+      and orr: "obj_relation_retype (default_object (APIType_map2 ty) dev us d) ko"
       and num_r: "m = 2 ^ (obj_bits_api (APIType_map2 ty) us - objBitsKO ko) * n"
   shows
-  "pspace_relation (foldr (\<lambda>p ps. ps(p \<mapsto> default_object (APIType_map2 ty) dev us))
+  "pspace_relation (foldr (\<lambda>p ps. ps(p \<mapsto> default_object (APIType_map2 ty) dev us d))
                               (retype_addrs ptr (APIType_map2 ty) n us) (kheap s))
             (foldr (\<lambda>addr. data_map_insert addr ko) (new_cap_addrs m ptr ko) (ksPSpace s'))"
   (is "pspace_relation ?ps ?ps'")
@@ -876,7 +880,7 @@ proof
     "set (retype_addrs ptr (APIType_map2 ty) n us) \<inter> dom (kheap s) = {}"
     by auto
 
-  note pdom = pspace_dom_upd [OF dom_Int_ra, where ko="default_object (APIType_map2 ty) dev us"]
+  note pdom = pspace_dom_upd [OF dom_Int_ra, where ko="default_object (APIType_map2 ty) dev us d"]
 
   have pdom': "dom ?ps' = dom (ksPSpace s') \<union> set (new_cap_addrs m ptr ko)"
     by (clarsimp simp add: foldr_upd_app_if[folded data_map_insert_def]
@@ -947,79 +951,6 @@ lemma foldr_upd_app_if': "foldr (\<lambda>p ps. ps(p := f p)) as g = (\<lambda>x
   apply (rule ext)
   apply simp
   done
-
-lemma etcb_rel_makeObject: "etcb_relation default_etcb makeObject"
-  apply (simp add: etcb_relation_def default_etcb_def)
-  apply (simp add: makeObject_tcb default_priority_def default_domain_def)
-  done
-
-
-lemma ekh_at_tcb_at: "valid_etcbs_2 ekh kh \<Longrightarrow> ekh x = Some y  \<Longrightarrow> \<exists>tcb. kh x = Some (TCB tcb)"
-  apply (simp add: valid_etcbs_2_def
-                   st_tcb_at_kh_def obj_at_kh_def
-                   is_etcb_at'_def obj_at_def)
-  apply force
-  done
-
-lemma default_etcb_default_domain_futz [simp]:
-  "default_etcb\<lparr>tcb_domain := default_domain\<rparr> = default_etcb"
-unfolding default_etcb_def by simp
-
-lemma retype_ekheap_relation:
-  assumes  sr: "ekheap_relation (ekheap s) (ksPSpace s')"
-      and  sr': "pspace_relation (kheap s) (ksPSpace s')"
-      and  vs: "valid_pspace s" "valid_mdb s"
-      and et: "valid_etcbs s"
-      and vs': "pspace_aligned' s'" "pspace_distinct' s'"
-      and  pn: "pspace_no_overlap_range_cover ptr sz s"
-      and pn': "pspace_no_overlap' ptr sz s'"
-      and  ko: "makeObjectKO dev ty = Some ko"
-      and cover: "range_cover ptr sz (obj_bits_api (APIType_map2 ty) us) n"
-      and orr: "obj_relation_retype (default_object (APIType_map2 ty) dev us) ko"
-      and num_r: "m = 2 ^ (obj_bits_api (APIType_map2 ty) us - objBitsKO ko) * n"
-  shows
-  "ekheap_relation (foldr (\<lambda>p ps. ps(p := default_ext (APIType_map2 ty) default_domain))
-                              (retype_addrs ptr (APIType_map2 ty) n us) (ekheap s))
-            (foldr (\<lambda>addr. data_map_insert addr ko) (new_cap_addrs m ptr ko) (ksPSpace s'))"
-  (is "ekheap_relation ?ps ?ps'")
-  proof -
-  have not_unt: "ty \<noteq> Inr (APIObjectType ArchTypes_H.Untyped)"
-     by (rule makeObjectKO_Untyped[OF ko])
-  show ?thesis
-    apply (case_tac "ty \<noteq> Inr (APIObjectType apiobject_type.TCBObject)")
-     apply (insert ko)
-     apply (cut_tac retype_pspace_relation[OF sr' vs vs' pn pn' ko cover orr num_r])
-     apply (simp add: foldr_upd_app_if' foldr_upd_app_if[folded data_map_insert_def])
-     apply (simp add: obj_relation_retype_addrs_eq[OF not_unt num_r orr cover,symmetric])
-     apply (insert sr)
-     apply (clarsimp simp add: ekheap_relation_def
-                      pspace_relation_def default_ext_def cong: if_cong
-                      split: if_split_asm)
-      subgoal by (clarsimp simp add: makeObjectKO_def APIType_map2_def cong: if_cong
-                              split: sum.splits Structures_H.kernel_object.splits
-                                     arch_kernel_object.splits ARM_HYP_H.object_type.splits apiobject_type.splits)
-
-     apply (frule ekh_at_tcb_at[OF et])
-     apply (intro impI conjI)
-      apply clarsimp
-      apply (drule_tac x=a in bspec,force)
-      apply (clarsimp simp: tcb_relation_cut_def split: if_split_asm)
-       apply (case_tac ko,simp_all)
-       apply (clarsimp simp add: makeObjectKO_def cong: if_cong split: sum.splits Structures_H.kernel_object.splits
-                                 arch_kernel_object.splits ARM_HYP_H.object_type.splits
-                                 apiobject_type.splits if_split_asm)
-      apply (drule_tac x=xa in bspec,simp)
-      subgoal by force
-     subgoal by force
-    apply (simp add: foldr_upd_app_if' foldr_upd_app_if[folded data_map_insert_def])
-    apply (simp add: obj_relation_retype_addrs_eq[OF not_unt num_r orr cover,symmetric])
-    apply (clarsimp simp add: APIType_map2_def default_ext_def ekheap_relation_def
-           default_object_def makeObjectKO_def etcb_rel_makeObject
-           cong: if_cong
-           split: if_split_asm)
-    apply force
-  done
-qed
 
 lemma pspace_no_overlapD':
   "\<lbrakk> ksPSpace s x = Some ko; pspace_no_overlap' p bits s \<rbrakk>
@@ -1211,7 +1142,7 @@ lemma retype_ksPSpace_dom_same:
   fixes x v
   assumes   vs': "pspace_aligned' s'" "pspace_distinct' s'"
   assumes   pn': "pspace_no_overlap' ptr sz s'"
-  assumes    ko: "makeObjectKO dev ty = Some ko"
+  assumes    ko: "makeObjectKO dev d ty = Some ko"
   assumes cover: "range_cover ptr sz (obj_bits_api (APIType_map2 ty) us) n"
   assumes num_r: "m = 2 ^ (obj_bits_api (APIType_map2 ty) us - objBitsKO ko) * n"
   shows
@@ -1250,7 +1181,7 @@ qed
 lemma retype_tcbSchedPrevs_of:
   assumes   vs': "pspace_aligned' s'" "pspace_distinct' s'"
   assumes   pn': "pspace_no_overlap' ptr sz s'"
-  assumes    ko: "makeObjectKO dev ty = Some ko"
+  assumes    ko: "makeObjectKO dev d ty = Some ko"
   assumes cover: "range_cover ptr sz (obj_bits_api (APIType_map2 ty) us) n"
   assumes num_r: "m = 2 ^ (obj_bits_api (APIType_map2 ty) us - objBitsKO ko) * n"
   shows
@@ -1276,7 +1207,7 @@ qed
 lemma retype_tcbSchedNexts_of:
   assumes   vs': "pspace_aligned' s'" "pspace_distinct' s'"
   assumes   pn': "pspace_no_overlap' ptr sz s'"
-  assumes    ko: "makeObjectKO dev ty = Some ko"
+  assumes    ko: "makeObjectKO dev d ty = Some ko"
   assumes cover: "range_cover ptr sz (obj_bits_api (APIType_map2 ty) us) n"
   assumes num_r: "m = 2 ^ (obj_bits_api (APIType_map2 ty) us - objBitsKO ko) * n"
   shows
@@ -1302,7 +1233,7 @@ qed
 lemma retype_inQ:
   assumes   vs': "pspace_aligned' s'" "pspace_distinct' s'"
   assumes   pn': "pspace_no_overlap' ptr sz s'"
-  assumes    ko: "makeObjectKO dev ty = Some ko"
+  assumes    ko: "makeObjectKO dev d ty = Some ko"
   assumes cover: "range_cover ptr sz (obj_bits_api (APIType_map2 ty) us) n"
   assumes num_r: "m = 2 ^ (obj_bits_api (APIType_map2 ty) us - objBitsKO ko) * n"
   shows
@@ -1331,12 +1262,12 @@ lemma retype_ready_queues_relation:
   assumes  rlqr: "ready_queues_relation s s'"
   assumes   vs': "pspace_aligned' s'" "pspace_distinct' s'"
   assumes   pn': "pspace_no_overlap' ptr sz s'"
-  assumes    ko: "makeObjectKO dev ty = Some ko"
+  assumes    ko: "makeObjectKO dev d ty = Some ko"
   assumes cover: "range_cover ptr sz (obj_bits_api (APIType_map2 ty) us) n"
   assumes num_r: "m = 2 ^ (obj_bits_api (APIType_map2 ty) us - objBitsKO ko) * n"
   shows
     "ready_queues_relation
-       (s \<lparr>kheap := foldr (\<lambda>p. data_map_insert p (default_object (APIType_map2 ty) dev us))
+       (s \<lparr>kheap := foldr (\<lambda>p. data_map_insert p (default_object (APIType_map2 ty) dev us d))
                                              (retype_addrs ptr (APIType_map2 ty) n us) (kheap s)\<rparr>)
        (s'\<lparr>ksPSpace := foldr (\<lambda>addr. data_map_insert addr ko) (new_cap_addrs m ptr ko) (ksPSpace s')\<rparr>)"
   using rlqr
@@ -1349,31 +1280,28 @@ lemma retype_state_relation:
   notes data_map_insert_def[simp del]
   assumes  sr:   "(s, s') \<in> state_relation"
       and  vs:   "valid_pspace s" "valid_mdb s"
-      and  et:   "valid_etcbs s" "valid_list s"
+      and  et:   "valid_list s"
       and vs':   "pspace_aligned' s'" "pspace_distinct' s'"
       and  pn:   "pspace_no_overlap_range_cover ptr sz s"
       and pn':   "pspace_no_overlap' ptr sz s'"
       and cover: "range_cover ptr sz (obj_bits_api (APIType_map2 ty) us) n"
-      and  ko:   "makeObjectKO dev ty = Some ko"
+      and  ko:   "makeObjectKO dev d ty = Some ko"
       and api:   "obj_bits_api (APIType_map2 ty) us \<le> sz"
-      and orr:   "obj_relation_retype (default_object (APIType_map2 ty) dev us) ko"
+      and orr:   "obj_relation_retype (default_object (APIType_map2 ty) dev us d) ko"
       and num_r: "m = 2 ^ (obj_bits_api (APIType_map2 ty) us - objBitsKO ko) * n"
   shows
-  "(ekheap_update
-              (\<lambda>_. foldr (\<lambda>p ekh a. if a = p then default_ext (APIType_map2 ty) default_domain else ekh a)
-                    (retype_addrs ptr (APIType_map2 ty) n us) (ekheap s))
-            s
-           \<lparr>kheap :=
-              foldr (\<lambda>p. data_map_insert p (default_object (APIType_map2 ty) dev us))
+  "(s \<lparr>kheap :=
+              foldr (\<lambda>p. data_map_insert p (default_object (APIType_map2 ty) dev us d))
                (retype_addrs ptr (APIType_map2 ty) n us) (kheap s)\<rparr>,
            update_gs (APIType_map2 ty) us (set (retype_addrs ptr (APIType_map2 ty) n us))
             (s'\<lparr>ksPSpace :=
                   foldr (\<lambda>addr. data_map_insert addr ko) (new_cap_addrs m ptr ko)
                    (ksPSpace s')\<rparr>))
           \<in> state_relation"
-  (is "(ekheap_update (\<lambda>_. ?eps) s\<lparr>kheap := ?ps\<rparr>, update_gs _ _ _ (s'\<lparr>ksPSpace := ?ps'\<rparr>))
+  (is "(s\<lparr>kheap := ?ps\<rparr>, update_gs _ _ _ (s'\<lparr>ksPSpace := ?ps'\<rparr>))
        \<in> state_relation")
-  proof (rule state_relation_null_filterE[OF sr refl _ _ _ _ _ _ _ _ vs'], simp_all add: trans_state_update[symmetric] del: trans_state_update)
+  proof (rule state_relation_null_filterE[OF sr refl _ _ _ _ _ _ _ vs'],
+         simp_all add: trans_state_update[symmetric] del: trans_state_update)
 
   have cover':"range_cover ptr sz (objBitsKO ko) m"
     by (rule range_cover_rel[OF cover objBits_le_obj_bits_api[OF ko] num_r])
@@ -1438,12 +1366,6 @@ lemma retype_state_relation:
   thus "pspace_relation ?ps ?ps'"
     by (rule retype_pspace_relation [OF _ vs vs' pn pn' ko cover orr num_r,
         folded data_map_insert_def])
-
-  have "ekheap_relation (ekheap (s)) (ksPSpace s')"
-  using sr by (simp add: state_relation_def)
-
-  thus "ekheap_relation ?eps ?ps'"
-    by (fold fun_upd_apply) (rule retype_ekheap_relation[OF _ pspr vs et(1) vs' pn pn' ko cover orr num_r])
 
   have pn2: "\<forall>a\<in>set ?al. kheap s a = None"
     by (rule ccontr) (clarsimp simp: pspace_no_overlapD1[OF pn _ cover vs(1)])
@@ -1591,210 +1513,6 @@ lemma objBitsKO_gt_0: "0 < objBitsKO ko"
     apply (simp_all add:archObjSize_def vcpu_bits_def vspace_bits_defs)
   done
 
-lemma kheap_ekheap_double_gets:
-  "(\<And>rv erv rv'. \<lbrakk>pspace_relation rv rv'; ekheap_relation erv rv'\<rbrakk>
-                 \<Longrightarrow> corres r (R rv erv) (R' rv') (b rv erv) (d rv')) \<Longrightarrow>
-   corres r (\<lambda>s. R (kheap s) (ekheap s) s) (\<lambda>s. R' (ksPSpace s) s)
-          (do x \<leftarrow> gets kheap; xa \<leftarrow> gets ekheap; b x xa od) (gets ksPSpace >>= d)"
-  apply (rule corres_symb_exec_l)
-     apply (rule corres_guard_imp)
-       apply (rule_tac r'= "\<lambda>erv rv'. ekheap_relation erv rv' \<and> pspace_relation x rv'"
-               in corres_split)
-          apply (subst corres_gets[where P="\<lambda>s. x = kheap s" and P'=\<top>])
-          apply clarsimp
-          apply (simp add: state_relation_def)
-         apply clarsimp
-         apply assumption
-        apply (wp gets_exs_valid | simp)+
-  done
-
-(*
-
-Split out the extended operation that sets the etcb domains.
-
-This allows the existing corres proofs in this file to more-or-less go
-through as they stand.
-
-A more principled fix would be to change the abstract spec and
-generalise init_arch_objects to initialise other object types.
-
-*)
-
-definition retype_region2_ext :: "obj_ref list \<Rightarrow> Structures_A.apiobject_type \<Rightarrow> unit det_ext_monad" where
-  "retype_region2_ext ptrs type \<equiv> modify (\<lambda>s. ekheap_update (foldr (\<lambda>p ekh. (ekh(p := default_ext type default_domain))) ptrs) s)"
-
-crunch retype_region2_ext
-  for all_but_exst[wp]: "all_but_exst P"
-crunch retype_region2_ext
-  for (empty_fail) empty_fail[wp]
-
-end
-
-interpretation retype_region2_ext_extended: is_extended "retype_region2_ext ptrs type"
-  by (unfold_locales; wp)
-
-context begin interpretation Arch . (*FIXME: arch-split*)
-
-definition
- "retype_region2_extra_ext ptrs type \<equiv>
-     when (type = Structures_A.TCBObject) (do
-       cdom \<leftarrow> gets cur_domain;
-       mapM_x (ethread_set (\<lambda>tcb. tcb\<lparr>tcb_domain := cdom\<rparr>)) ptrs
-      od)"
-
-crunch retype_region2_extra_ext
-  for all_but_exst[wp]: "all_but_exst P" (wp: mapM_x_wp)
-crunch retype_region2_extra_ext
-  for (empty_fail) empty_fail[wp] (wp: mapM_x_wp)
-
-end
-
-interpretation retype_region2_extra_ext_extended: is_extended "retype_region2_extra_ext ptrs type"
-  by (unfold_locales; wp)
-
-context begin interpretation Arch . (*FIXME: arch-split*)
-
-definition
-  retype_region2 :: "obj_ref \<Rightarrow> nat \<Rightarrow> nat \<Rightarrow> Structures_A.apiobject_type \<Rightarrow> bool \<Rightarrow> (obj_ref list,'z::state_ext) s_monad"
-where
-  "retype_region2 ptr numObjects o_bits type dev \<equiv> do
-    obj_size \<leftarrow> return $ 2 ^ obj_bits_api type o_bits;
-    ptrs \<leftarrow> return $ map (\<lambda>p. ptr_add ptr (p * obj_size)) [0..< numObjects];
-    when (type \<noteq> Structures_A.Untyped) (do
-      kh \<leftarrow> gets kheap;
-      kh' \<leftarrow> return $ foldr (\<lambda>p kh. kh(p \<mapsto> default_object type dev o_bits)) ptrs kh;
-      do_extended_op (retype_region2_ext ptrs type);
-      modify $ kheap_update (K kh')
-    od);
-    return $ ptrs
-  od"
-
-lemma retype_region_ext_modify_kheap_futz:
-  "(retype_region2_extra_ext ptrs type :: (unit, det_ext) s_monad) >>= (\<lambda>_. modify (kheap_update f))
- = (modify (kheap_update f) >>= (\<lambda>_. retype_region2_extra_ext ptrs type))"
-  apply (clarsimp simp: retype_region_ext_def retype_region2_ext_def retype_region2_extra_ext_def when_def bind_assoc)
-  apply (subst oblivious_modify_swap)
-   defer
-   apply (simp add: bind_assoc)
-  apply (rule oblivious_bind)
-  apply simp
-  apply (rule oblivious_mapM_x)
-  apply (clarsimp simp: ethread_set_def set_eobject_def)
-  apply (rule oblivious_bind)
-   apply (simp add: gets_the_def)
-   apply (rule oblivious_bind)
-    apply (clarsimp simp: get_etcb_def)
-    apply simp
-   apply (simp add: modify_def[symmetric])
-done
-
-lemmas retype_region_ext_modify_kheap_futz' =
-  fun_cong[OF arg_cong[where f=Nondet_Monad.bind,
-           OF retype_region_ext_modify_kheap_futz[symmetric]], simplified bind_assoc]
-
-lemma foldr_upd_app_if_eta_futz:
-  "foldr (\<lambda>p ps. ps(p \<mapsto> f p)) as = (\<lambda>g x. if x \<in> set as then Some (f x) else g x)"
-apply (rule ext)
-apply (rule foldr_upd_app_if)
-done
-
-lemma modify_ekheap_update_comp_futz:
-  "modify (ekheap_update (f \<circ> g)) = modify (ekheap_update g) >>= (K (modify (ekheap_update f)))"
-by (simp add: o_def modify_def bind_def gets_def get_def put_def)
-
-lemma mapM_x_modify_futz:
-  assumes "\<forall>ptr\<in>set ptrs. ekheap s ptr \<noteq> None"
-  shows "mapM_x (ethread_set F) (rev ptrs) s
-       = modify (ekheap_update (foldr (\<lambda>p ekh. ekh(p := Some (F (the (ekh p))))) ptrs)) s" (is "?lhs ptrs s = ?rhs ptrs s")
-using assms
-proof(induct ptrs arbitrary: s)
-  case Nil thus ?case by (simp add: mapM_x_Nil return_def simpler_modify_def)
-next
-  case (Cons ptr ptrs s)
-  have "?rhs (ptr # ptrs) s
-      = (do modify (ekheap_update (foldr (\<lambda>p ekh. ekh(p \<mapsto> F (the (ekh p)))) ptrs));
-            modify (ekheap_update (\<lambda>ekh. ekh(ptr \<mapsto> F (the (ekh ptr)))))
-        od) s"
-    by (simp only: foldr_Cons modify_ekheap_update_comp_futz) simp
-  also have "... = (do ?lhs ptrs;
-                      modify (ekheap_update (\<lambda>ekh. ekh(ptr \<mapsto> F (the (ekh ptr)))))
-                    od) s"
-    apply (rule monad_eq_split_tail)
-     apply simp
-    apply (rule Cons.hyps[symmetric])
-    using Cons.prems
-    apply force
-    done
-  also have "... = ?lhs (ptr # ptrs) s"
-    apply (simp add: mapM_x_append mapM_x_singleton)
-    apply (rule monad_eq_split2[OF refl, where
-                 P="\<lambda>s. \<forall>ptr\<in>set (ptr # ptrs). ekheap s ptr \<noteq> None"
-             and Q="\<lambda>_ s. ekheap s ptr \<noteq> None"])
-      apply (simp add: ethread_set_def
-                       assert_opt_def get_etcb_def gets_the_def gets_def get_def modify_def put_def set_eobject_def
-                       bind_def fail_def return_def split_def
-                split: option.splits)
-     apply ((wp mapM_x_wp[OF _ subset_refl] | simp add: ethread_set_def set_eobject_def)+)[1]
-    using Cons.prems
-    apply force
-    done
-  finally show ?case by (rule sym)
-qed
-
-lemma awkward_fold_futz:
-  "fold (\<lambda>p ekh. ekh(p \<mapsto> the (ekh p)\<lparr>tcb_domain := cur_domain s\<rparr>)) ptrs ekh
- = (\<lambda>x. if x \<in> set ptrs then Some ((the (ekh x))\<lparr>tcb_domain := cur_domain s\<rparr>) else ekh x)"
-by (induct ptrs arbitrary: ekh) (simp_all add: fun_eq_iff)
-
-lemma retype_region2_ext_retype_region_ext_futz:
-  "retype_region2_ext ptrs type >>= (\<lambda>_. retype_region2_extra_ext ptrs type)
- = retype_region_ext ptrs type"
-proof(cases type)
-  case TCBObject
-  have complete_futz:
-    "\<And>F x. modify (ekheap_update (\<lambda>_. F (cur_domain x) (ekheap x))) x = modify (ekheap_update (\<lambda>ekh. F (cur_domain x) ekh)) x"
-    by (simp add: modify_def get_def get_etcb_def put_def bind_def return_def)
-  have second_futz:
-  "\<And>f G.
-   do modify (ekheap_update f);
-      cdom \<leftarrow> gets (\<lambda>s. cur_domain s);
-      G cdom
-   od =
-   do cdom \<leftarrow> gets (\<lambda>s. cur_domain s);
-      modify (ekheap_update f);
-      G cdom
-   od"
-    by (simp add: bind_def gets_def get_def return_def simpler_modify_def)
-  from TCBObject show ?thesis
-    apply (clarsimp simp: retype_region_ext_def retype_region2_ext_def retype_region2_extra_ext_def when_def bind_assoc)
-    apply (clarsimp simp: exec_gets fun_eq_iff)
-    apply (subst complete_futz)
-    apply (simp add: second_futz[simplified] exec_gets)
-    apply (simp add: default_ext_def exec_modify)
-    apply (subst mapM_x_modify_futz[where ptrs="rev ptrs", simplified])
-     apply (simp add: foldr_upd_app_if_eta_futz)
-    apply (simp add: modify_def exec_get put_def o_def)
-    apply (simp add: foldr_upd_app_if_eta_futz foldr_conv_fold awkward_fold_futz)
-    apply (simp cong: if_cong)
-    done
-qed (auto simp: fun_eq_iff retype_region_ext_def retype_region2_ext_def retype_region2_extra_ext_def
-                put_def gets_def get_def bind_def return_def mk_ef_def modify_def foldr_upd_app_if' when_def default_ext_def)
-
-lemma retype_region2_ext_retype_region:
-  "(retype_region ptr numObjects o_bits type dev :: (obj_ref list, det_ext) s_monad)
- = (do ptrs \<leftarrow> retype_region2 ptr numObjects o_bits type dev;
-       retype_region2_extra_ext ptrs type;
-       return ptrs
-    od)"
-apply (clarsimp simp: retype_region_def retype_region2_def when_def bind_assoc)
- apply safe
- defer
- apply (simp add: retype_region2_extra_ext_def)
-apply (subst retype_region_ext_modify_kheap_futz'[simplified bind_assoc])
-apply (subst retype_region2_ext_retype_region_ext_futz[symmetric])
-apply (simp add: bind_assoc)
-done
-
 lemma getObject_tcb_gets:
   "getObject addr >>= (\<lambda>x::tcb. gets proj >>= (\<lambda>y. G x y))
  = gets proj >>= (\<lambda>y. getObject addr >>= (\<lambda>x. G x y))"
@@ -1837,37 +1555,26 @@ next
     done
 qed
 
-(*
-
-The existing proof continues below.
-
-*)
-
-lemma modify_ekheap_update_ekheap:
-  "modify (\<lambda>s. ekheap_update f s) = do s \<leftarrow> gets ekheap; modify (\<lambda>s'. s'\<lparr>ekheap := f s\<rparr>) od"
-by (simp add: modify_def gets_def get_def put_def bind_def return_def split_def fun_eq_iff)
-
 lemma corres_retype':
   assumes    not_zero: "n \<noteq> 0"
   and         aligned: "is_aligned ptr (objBitsKO ko + gbits)"
-  and    obj_bits_api: "obj_bits_api (APIType_map2 ty) us =
-                        objBitsKO ko + gbits"
-  and           check: "(sz < obj_bits_api (APIType_map2 ty)  us)
-                           = (sz < objBitsKO ko + gbits)"
+  and    obj_bits_api: "obj_bits_api (APIType_map2 ty) us = objBitsKO ko + gbits"
+  and           check: "(sz < obj_bits_api (APIType_map2 ty) us) = (sz < objBitsKO ko + gbits)"
   and             usv: "APIType_map2 ty = Structures_A.CapTableObject \<Longrightarrow> 0 < us"
-  and              ko: "makeObjectKO dev ty = Some ko"
+  and              ko: "makeObjectKO dev d ty = Some ko"
   and             orr: "obj_bits_api (APIType_map2 ty) us \<le> sz \<Longrightarrow>
-                        obj_relation_retype
-                          (default_object (APIType_map2 ty) dev us) ko"
+                        obj_relation_retype (default_object (APIType_map2 ty) dev us d) ko"
   and           cover: "range_cover ptr sz (obj_bits_api (APIType_map2 ty) us) n"
   shows "corres (\<lambda>rv rv'. rv' = g rv)
-  (\<lambda>s. valid_pspace s \<and> pspace_no_overlap_range_cover ptr sz s
-     \<and> valid_mdb s \<and> valid_etcbs s \<and> valid_list s)
-  (\<lambda>s. pspace_aligned' s \<and> pspace_distinct' s \<and> pspace_no_overlap' ptr sz s)
-  (retype_region2 ptr n us (APIType_map2 ty) dev)
-  (do addrs \<leftarrow> createObjects ptr n ko gbits;
-      _ \<leftarrow> modify (update_gs (APIType_map2 ty) us (set addrs));
-      return (g addrs) od)"
+                (\<lambda>s. valid_pspace s \<and> pspace_no_overlap_range_cover ptr sz s
+                     \<and> valid_mdb s \<and> valid_list s)
+                (\<lambda>s. pspace_aligned' s \<and> pspace_distinct' s \<and> pspace_no_overlap' ptr sz s
+                      \<and> (ty = Inr (APIObjectType TCBObject) \<longrightarrow> d = ksCurDomain s))
+                (retype_region ptr n us (APIType_map2 ty) dev)
+                (do addrs \<leftarrow> createObjects ptr n ko gbits;
+                    _ \<leftarrow> modify (update_gs (APIType_map2 ty) us (set addrs));
+                    return (g addrs)
+                 od)"
   (is "corres ?r ?P ?P' ?C ?A")
 proof -
   note data_map_insert_def[simp del]
@@ -1945,7 +1652,7 @@ proof -
   have al': "is_aligned ptr (obj_bits_api (APIType_map2 ty) us)"
      by (simp add: obj_bits_api ko)
   show ?thesis
-  apply (simp add: when_def retype_region2_def createObjects'_def
+  apply (simp add: when_def retype_region_def createObjects'_def
                    createObjects_def aligned obj_bits_api[symmetric]
                    ko[symmetric] al' shiftl_t2n data_map_insert_def[symmetric]
                    is_aligned_mask[symmetric] split_def unless_def
@@ -1953,80 +1660,90 @@ proof -
         split del: if_split)
   apply (subst retype_addrs_fold)+
   apply (subst if_P)
-   using ko
-   apply (clarsimp simp: makeObjectKO_def)
-  apply (simp add: bind_assoc retype_region2_ext_def)
-  apply (rule corres_guard_imp)
-    apply (subst modify_ekheap_update_ekheap)
-    apply (simp only: bind_assoc)
-    apply (rule kheap_ekheap_double_gets)
-    apply (rule corres_symb_exec_r)
-       apply (simp add: not_less modify_modify bind_assoc[symmetric]
-                          obj_bits_api[symmetric] shiftl_t2n upto_enum_red'
+    using ko
+    apply (clarsimp simp: makeObjectKO_def)
+   apply (simp add: bind_assoc)
+   apply (rule corres_guard_imp)
+     apply (rule_tac r'=pspace_relation in corres_underlying_split)
+        apply (clarsimp dest!: state_relation_pspace_relation)
+       apply (simp add: gets_def)
+       apply (rule corres_symb_exec_l[rotated])
+          apply (rule exs_valid_get)
+         apply (rule get_sp)
+        apply (simp add: get_def no_fail_def)
+       apply (rule corres_symb_exec_r)
+          apply (simp add: not_less modify_modify bind_assoc[symmetric]
+                           obj_bits_api[symmetric] shiftl_t2n upto_enum_red'
                            range_cover.unat_of_nat_n[OF cover])
-       apply (rule corres_split_nor[OF _ corres_trivial])
-          apply (rename_tac x eps ps)
-          apply (rule_tac P="\<lambda>s. x = kheap s \<and> eps = ekheap (s) \<and> ?P s" and
-                          P'="\<lambda>s. ps = ksPSpace s \<and> ?P' s" in corres_modify)
-          apply (simp add: set_retype_addrs_fold new_caps_adds_fold)
-          apply (erule retype_state_relation[OF _ _ _ _ _ _ _ _ _ cover _ _ orr],
-                 simp_all add: ko not_zero obj_bits_api
-                               bound[simplified obj_bits_api ko])[1]
-         apply (clarsimp simp: retype_addrs_fold[symmetric] ptr_add_def upto_enum_red' not_zero'
-                               range_cover.unat_of_nat_n[OF cover] word_le_sub1
-                         simp del: word_of_nat_eq_0_iff)
-         apply (rule_tac f=g in arg_cong)
-         apply clarsimp
-        apply wp+
-      apply (clarsimp split: option.splits)
-      apply (intro conjI impI)
-       apply (clarsimp|wp)+
-     apply (clarsimp split: option.splits)
-     apply wpsimp
-    apply (clarsimp split: option.splits)
-    apply (intro conjI impI)
-     apply wp
-    apply (clarsimp simp:lookupAround2_char1)
-    apply wp
-    apply (clarsimp simp: obj_bits_api ko)
-    apply (drule(1) pspace_no_overlap_disjoint')
-    apply (rule_tac x1 = a in ccontr[OF in_empty_interE])
-      apply simp
-     apply (clarsimp simp: not_less shiftL_nat)
-     apply (erule order_trans)
-     apply (subst p_assoc_help)
-     apply (subst word_plus_and_or_coroll2[symmetric,where w = "mask sz"])
-     apply (subst add.commute)
-     apply (subst add.assoc)
-     apply (rule word_plus_mono_right)
-      using cover
-      apply -
-      apply (rule iffD2[OF word_le_nat_alt])
-      apply (subst word_of_nat_minus)
-       using not_zero
-       apply simp
-      apply (rule le_trans[OF unat_plus_gt])
-      apply simp
-      apply (subst unat_minus_one)
-       apply (subst mult.commute)
-       apply (rule word_power_nonzero_32)
-         apply (rule of_nat_less_pow_32[OF n_estimate])
-         apply (simp add:word_bits_def objBitsKO_gt_0 ko)
-        apply (simp add:range_cover_def obj_bits_api ko word_bits_def)
-       apply (cut_tac not_zero',clarsimp simp:ko)
-      apply(clarsimp simp:field_simps ko)
-      apply (subst unat_sub[OF word_1_le_power])
-       apply (simp add:range_cover_def)
-      apply (subst diff_add_assoc[symmetric])
-       apply (cut_tac unat_of_nat_n',simp add:ko)
-      apply (clarsimp simp: obj_bits_api ko)
-      apply (rule diff_le_mono)
-      apply (frule range_cover.range_cover_compare_bound)
-      apply (cut_tac obj_bits_api unat_of_nat_shift')
-      apply (clarsimp simp:add.commute range_cover_def ko)
-     apply (rule is_aligned_no_wrap'[OF is_aligned_neg_mask,OF le_refl ])
-     apply (simp add:range_cover_def domI)+
-  done
+          apply (rule corres_guard_imp)
+            apply (rule corres_split_nor[OF _ corres_trivial])
+               apply (rename_tac ps ps' sa)
+               apply (rule_tac P="\<lambda>s. ps = kheap s \<and> sa = s \<and> ?P s" and
+                               P'="\<lambda>s. ps' = ksPSpace s \<and> ?P' s" in corres_modify)
+               apply(frule curdomain_relation[THEN sym])
+               apply (simp add: set_retype_addrs_fold new_caps_adds_fold)
+               apply (drule retype_state_relation[OF _ _ _ _ _ _ _ _ cover _ _ orr],
+                      simp_all add: ko not_zero obj_bits_api
+                                    bound[simplified obj_bits_api ko])[1]
+               apply (cases ty; simp; rename_tac tp; case_tac tp;
+                      clarsimp simp: default_object_def APIType_map2_def
+                              split: arch_kernel_object.splits apiobject_type.splits)
+              apply (clarsimp simp: retype_addrs_fold[symmetric] ptr_add_def upto_enum_red' not_zero'
+                                    range_cover.unat_of_nat_n[OF cover] word_le_sub1)
+              apply (rule_tac f=g in arg_cong)
+              apply clarsimp
+             apply wpsimp+
+           apply simp+
+         apply (clarsimp split: option.splits)
+         apply (intro conjI impI)
+          apply (clarsimp|wp)+
+        apply (clarsimp split: option.splits)
+        apply wpsimp
+       apply (clarsimp split: option.splits)
+       apply (intro conjI impI)
+        apply wp
+       apply (clarsimp simp:lookupAround2_char1)
+       apply wp
+       apply (clarsimp simp: obj_bits_api ko)
+       apply (drule(1) pspace_no_overlap_disjoint')
+       apply (rule_tac x1 = a in ccontr[OF in_empty_interE])
+         apply simp
+        apply (clarsimp simp: not_less shiftL_nat)
+        apply (erule order_trans)
+        apply (subst p_assoc_help)
+        apply (subst word_plus_and_or_coroll2[symmetric,where w = "mask sz"])
+        apply (subst add.commute)
+        apply (subst add.assoc)
+        apply (rule word_plus_mono_right)
+         using cover
+         apply -
+         apply (rule iffD2[OF word_le_nat_alt])
+         apply (subst word_of_nat_minus)
+          using not_zero
+          apply simp
+         apply (rule le_trans[OF unat_plus_gt])
+         apply simp
+         apply (subst unat_minus_one)
+          apply (subst mult.commute)
+          apply (rule word_power_nonzero_32)
+            apply (rule of_nat_less_pow_32[OF n_estimate])
+            apply (simp add:word_bits_def objBitsKO_gt_0 ko)
+           apply (simp add:range_cover_def obj_bits_api ko word_bits_def)
+          apply (cut_tac not_zero',clarsimp simp:ko)
+         apply(clarsimp simp:field_simps ko)
+         apply (subst unat_sub[OF word_1_le_power])
+          apply (simp add:range_cover_def)
+         apply (subst diff_add_assoc[symmetric])
+          apply (cut_tac unat_of_nat_n',simp add:ko)
+         apply (clarsimp simp: obj_bits_api ko)
+         apply (rule diff_le_mono)
+         apply (frule range_cover.range_cover_compare_bound)
+         apply (cut_tac obj_bits_api unat_of_nat_shift')
+         apply (clarsimp simp:add.commute range_cover_def ko)
+        apply (rule is_aligned_no_wrap'[OF is_aligned_neg_mask,OF le_refl ])
+        apply (simp add:range_cover_def domI)+
+      apply wpsimp+
+   done
 qed
 
 lemma createObjects_corres':
@@ -2506,15 +2223,16 @@ proof -
                              fromIntegral_def toInteger_nat fromInteger_nat APIType_capBits_def curDomain_def
                       split: ARM_HYP_H.object_type.splits)
         apply (wp mapM_x_wp' hoare_vcg_const_Ball_lift)+
-        apply (rule hoare_post_imp)
-         prefer 2
-         apply (rule createObjects_obj_at [where 'a = "tcb",OF _ not_0])
-          using cover
-          apply (clarsimp simp: ARM_HYP_H.toAPIType_def APIType_capBits_def objBits_simps
-                         split: ARM_HYP_H.object_type.splits)
-         apply (simp add: projectKOs)
-        apply (clarsimp simp: valid_cap'_def objBits_simps)
-        apply (fastforce intro: capAligned_tcbI)
+         apply (rule hoare_post_imp)
+          prefer 2
+          apply (rule createObjects_obj_at [where 'a = "tcb",OF _ not_0])
+           using cover
+           apply (clarsimp simp: ARM_HYP_H.toAPIType_def APIType_capBits_def objBits_simps
+                          split: ARM_HYP_H.object_type.splits)
+           apply simp+
+         apply (clarsimp simp: valid_cap'_def objBits_simps)
+         apply (fastforce intro: capAligned_tcbI)
+        apply wp
         done
     next
       case EndpointObject with Some cover ct show ?thesis
@@ -2596,7 +2314,7 @@ lemma other_objs_default_relation:
   "\<lbrakk> case ty of Structures_A.EndpointObject \<Rightarrow> ko = injectKO (makeObject :: endpoint)
              | Structures_A.NotificationObject \<Rightarrow> ko = injectKO (makeObject :: Structures_H.notification)
              | _ \<Rightarrow> False \<rbrakk> \<Longrightarrow>
-    obj_relation_retype (default_object ty dev n) ko"
+    obj_relation_retype (default_object ty dev n d) ko"
   apply (rule obj_relation_retype_other_obj)
    apply (clarsimp simp: default_object_def
                          is_other_obj_relation_type_def
@@ -2616,15 +2334,17 @@ lemma other_objs_default_relation:
   done
 
 lemma tcb_relation_retype:
-  "obj_relation_retype (default_object Structures_A.TCBObject dev n) (KOTCB makeObject)"
-  by (clarsimp simp: default_object_def obj_relation_retype_def tcb_relation_def default_tcb_def
-                     makeObject_tcb makeObject_cte new_context_def newContext_def tcb_relation_cut_def
+  "obj_relation_retype (default_object Structures_A.TCBObject dev n d)
+                       (KOTCB (tcbDomain_update (\<lambda>_. d) makeObject))"
+  by (clarsimp simp: tcb_relation_cut_def default_object_def obj_relation_retype_def
+                     tcb_relation_def default_tcb_def
+                     makeObject_tcb makeObject_cte new_context_def newContext_def
                      fault_rel_optionation_def initContext_def default_priority_def
                      default_arch_tcb_def newArchTCB_def arch_tcb_relation_def objBits_simps')
 
 lemma captable_relation_retype:
   "n < word_bits \<Longrightarrow>
-   obj_relation_retype (default_object Structures_A.CapTableObject dev n) (KOCTE makeObject)"
+   obj_relation_retype (default_object Structures_A.CapTableObject dev n d) (KOCTE makeObject)"
   apply (clarsimp simp: obj_relation_retype_def default_object_def
                         wf_empty_bits objBits_simps'
                         dom_empty_cnode ex_with_length cte_level_bits_def)
@@ -2642,7 +2362,7 @@ lemma captable_relation_retype:
   done
 
 lemma pagetable_relation_retype:
-  "obj_relation_retype (default_object (ArchObject PageTableObj) dev n)
+  "obj_relation_retype (default_object (ArchObject PageTableObj) dev n d)
                        (KOArch (KOPTE makeObject))"
   apply (simp add: default_object_def default_arch_object_def
                    makeObject_pte obj_relation_retype_def
@@ -2656,7 +2376,7 @@ lemma pagetable_relation_retype:
   done
 
 lemma pagedirectory_relation_retype:
-  "obj_relation_retype (default_object (ArchObject PageDirectoryObj) dev n)
+  "obj_relation_retype (default_object (ArchObject PageDirectoryObj) dev n d)
                        (KOArch (KOPDE makeObject))"
   apply (simp add: default_object_def default_arch_object_def
                    makeObject_pde obj_relation_retype_def
@@ -2673,20 +2393,21 @@ lemmas makeObjectKO_simps = makeObjectKO_def[split_simps ARM_HYP_H.object_type.s
  apiobject_type.split sum.split kernel_object.split ]
 
 lemma corres_retype:
-  assumes         not_zero: "n \<noteq> 0"
+  assumes    not_zero: "n \<noteq> 0"
   and         aligned: "is_aligned ptr (objBitsKO ko + gbits)"
   and    obj_bits_api: "obj_bits_api (APIType_map2 ty) us = objBitsKO ko + gbits"
   and              tp: "APIType_map2 ty \<in> no_gs_types"
-  and              ko: "makeObjectKO dev ty = Some ko"
+  and              ko: "makeObjectKO dev d ty = Some ko"
   and             orr: "obj_bits_api (APIType_map2 ty) us \<le> sz \<Longrightarrow>
-                        obj_relation_retype (default_object (APIType_map2 ty) dev us) ko"
+                        obj_relation_retype (default_object (APIType_map2 ty) dev us d) ko"
   and           cover: "range_cover ptr sz (obj_bits_api (APIType_map2 ty) us) n"
   shows "corres (=)
   (\<lambda>s. valid_pspace s \<and> pspace_no_overlap_range_cover ptr sz s
-     \<and> valid_mdb s \<and> valid_etcbs s \<and> valid_list s)
+     \<and> valid_mdb s \<and> valid_list s)
   (\<lambda>s. pspace_aligned' s \<and> pspace_distinct' s \<and> pspace_no_overlap' ptr sz s
-       \<and> (\<exists>val. ko = injectKO val))
-  (retype_region2 ptr n us (APIType_map2 ty) dev) (createObjects ptr n ko gbits)"
+       \<and> (\<exists>val. ko = injectKO val)
+       \<and> (ty = Inr (APIObjectType TCBObject) \<longrightarrow> d = ksCurDomain s))
+  (retype_region ptr n us (APIType_map2 ty) dev) (createObjects ptr n ko gbits)"
   apply (rule corres_guard_imp)
     apply (rule_tac F = "(\<exists>val. ko = injectKO val)" in corres_gen_asm2)
     apply (erule exE)
@@ -2708,7 +2429,7 @@ lemma init_arch_objects_APIType_map2:
   done
 
 lemma copyGlobalMappings_corres:
-  "corres dc (valid_arch_state and valid_etcbs and pspace_aligned and page_directory_at pd)
+  "corres dc (valid_arch_state and pspace_aligned and page_directory_at pd)
              (valid_arch_state' and page_directory_at' pd)
           (copy_global_mappings pd)
           (copyGlobalMappings pd)"
@@ -3204,7 +2925,8 @@ where
   (isUntypedCap (cteCap cte) \<longrightarrow> usableUntypedRange (cteCap cte) \<inter> S = {})"
 
 lemma createObjects_valid_pspace':
-  assumes  mko: "makeObjectKO dev ty = Some val"
+  assumes  mko: "makeObjectKO dev d ty = Some val"
+  and    max_d: "ty = Inr (APIObjectType TCBObject) \<longrightarrow> d \<le> maxDomain"
   and    not_0: "n \<noteq> 0"
   and    cover: "range_cover ptr sz (objBitsKO val + gbits) n"
   shows "\<lbrace>\<lambda>s. pspace_no_overlap' ptr sz s \<and> valid_pspace' s \<and> caps_no_overlap'' ptr sz s
@@ -3301,7 +3023,7 @@ proof (intro conjI impI)
                    elim!: ranE
                    split: if_split_asm)
      apply (insert sym[OF mko])[1]
-     apply (clarsimp simp: makeObjectKO_def
+     apply (clarsimp simp: makeObjectKO_def max_d
                     split: bool.split_asm sum.split_asm
                            ARM_HYP_H.object_type.split_asm
                            apiobject_type.split_asm
@@ -3420,13 +3142,14 @@ proof (intro conjI impI)
 qed
 
 lemma createObjects_valid_pspace_untyped':
-  assumes  mko: "makeObjectKO dev ty = Some val"
+  assumes  mko: "makeObjectKO dev d ty = Some val"
+  and    max_d: "ty = Inr (APIObjectType TCBObject) \<longrightarrow> d \<le> maxDomain"
   and    not_0: "n \<noteq> 0"
   and    cover: "range_cover ptr sz (objBitsKO val + gbits) n"
   shows "\<lbrace>\<lambda>s. pspace_no_overlap' ptr sz s \<and> valid_pspace' s \<and> caps_no_overlap'' ptr sz s \<and> ptr \<noteq> 0
             \<and> caps_overlap_reserved' {ptr .. ptr + of_nat (n * 2^gbits * 2 ^ objBitsKO val ) - 1} s \<rbrace>
   createObjects' ptr n val gbits \<lbrace>\<lambda>r. valid_pspace'\<rbrace>"
-  apply (wp createObjects_valid_pspace' [OF mko not_0 cover])
+  apply (wp createObjects_valid_pspace' [OF mko max_d not_0 cover])
   apply simp
   done
 
@@ -3629,24 +3352,19 @@ lemma createNewCaps_cte_wp_at2:
      createNewCaps ty ptr n objsz dev
    \<lbrace>\<lambda>rv s. P (cte_wp_at' P' p s)\<rbrace>"
   including classic_wp_pre
-  apply (simp add: createNewCaps_def createObjects_def ARM_HYP_H.toAPIType_def
-           split del: if_split)
-  apply (case_tac ty; simp add: createNewCaps_def createObjects_def Arch_createNewCaps_def
-                           split del: if_split cong: if_cong)
+  unfolding createNewCaps_def Arch_createNewCaps_def createObjects_def ARM_HYP_H.toAPIType_def
+  apply (case_tac ty; simp split del: if_split cong: if_cong)
         apply (rename_tac apiobject_type)
         apply (case_tac apiobject_type; simp split del: if_split)
-            apply (rule hoare_pre, wp, simp add:createObjects_def)
-           apply ((wp createObjects_orig_cte_wp_at2'[where sz = sz]
-                     mapM_x_wp' threadSet_cte_wp_at2')+
+            apply (rule hoare_pre, wp, simp add: createObjects_def)
+           apply ((wp createObjects_orig_cte_wp_at2'[where sz = sz] mapM_x_wp')
                    | assumption
-                   | clarsimp simp: APIType_capBits_def
-                                    projectKOs projectKO_opts_defs
-                                    makeObject_tcb tcb_cte_cases_def tcb_cte_cases_neqs
-                                    archObjSize_def vspace_bits_defs
-                                    createObjects_def curDomain_def
-                                    Let_def objBits_if_dev
+                   | clarsimp simp: APIType_capBits_def projectKOs projectKO_opts_defs
+                                    makeObject_tcb tcb_cte_cases_def cteSizeBits_def
+                                    archObjSize_def vspace_bits_defs createObjects_def curDomain_def
+                                    objBits_if_dev
                          split del: if_split
-                   | simp add: objBits_simps)+
+                   | simp add: objBits_simps field_simps mult_2_right)+
   done
 
 lemma createObjects_orig_obj_at':
@@ -4207,9 +3925,8 @@ lemma createNewCaps_ko_wp_atQ':
                    \<longrightarrow> (\<forall>pde_y :: pde. P' (injectKO pde_y)))
        and K (\<forall>d (tcb_x :: tcb). \<not>tcbQueued tcb_x \<and> tcbState tcb_x = Inactive
                    \<longrightarrow> P' (injectKO (tcb_x \<lparr> tcbDomain := d \<rparr>)) = P' (injectKO tcb_x))
-       and K (\<forall>v. makeObjectKO d (Inr ty) = Some v
-                 \<longrightarrow> P' v \<longrightarrow> P True)\<rbrace>
-     createNewCaps ty ptr n us d
+       and (\<lambda>s. (\<forall>v. makeObjectKO dev (ksCurDomain s) (Inr ty) = Some v \<longrightarrow> P' v \<longrightarrow> P True))\<rbrace>
+     createNewCaps ty ptr n us dev
    \<lbrace>\<lambda>rv s. P (ko_wp_at' P' p s)\<rbrace>"
   apply (rule hoare_name_pre_state)
   apply (clarsimp simp: createNewCaps_def ARM_HYP_H.toAPIType_def
@@ -4361,21 +4078,21 @@ lemma createNewCaps_idle'[wp]:
              split del: if_split)
   apply (cases ty, simp_all add: Arch_createNewCaps_def
                       split del: if_split)
-         apply (rename_tac apiobject_type)
-         apply (case_tac apiobject_type, simp_all split del: if_split)[1]
-             apply wpsimp
-            (* The following step does not use wpsimp to avoid clarsimp_no_cond, which for some reason
-               leads to a failed proof state. If this could be fixed then the inclusion of
-               classic_wp_pre could also be removed. *)
-            including classic_wp_pre
-            apply (wp mapM_x_wp' createObjects_idle' threadSet_idle'
-                   | simp add: projectKO_opt_tcb projectKO_opt_cte
-                               makeObject_cte makeObject_tcb archObjSize_def
-                               tcb_cte_cases_def objBitsKO_def APIType_capBits_def
-                               vspace_bits_defs objBits_def
-                               createObjects_def tcb_cte_cases_neqs
-                   | intro conjI impI
-                   | clarsimp simp: curDomain_def)+
+        apply (rename_tac apiobject_type)
+        apply (case_tac apiobject_type, simp_all split del: if_split)[1]
+            apply wpsimp
+           (* The following step does not use wpsimp to avoid clarsimp_no_cond, which for some reason
+              leads to a failed proof state. If this could be fixed then the inclusion of
+              classic_wp_pre could also be removed. *)
+           including classic_wp_pre
+           apply (wp mapM_x_wp' createObjects_idle'
+                  | clarsimp simp: curDomain_def
+                  | simp add: projectKO_opt_tcb projectKO_opt_cte mult_2
+                              makeObject_cte makeObject_tcb archObjSize_def
+                              tcb_cte_cases_def objBitsKO_def APIType_capBits_def
+                              vspace_bits_defs objBits_def createObjects_def cteSizeBits_def
+                  | simp add: field_simps
+                  | intro conjI impI)+
   done
 
 crunch createNewCaps
@@ -4700,9 +4417,12 @@ lemma mapM_x_threadSet_valid_pspace:
 lemma createNewCaps_valid_pspace:
   assumes  not_0: "n \<noteq> 0"
   and      cover: "range_cover ptr sz (APIType_capBits ty us) n"
-  shows "\<lbrace>\<lambda>s. pspace_no_overlap' ptr sz s \<and> valid_pspace' s
-  \<and> caps_no_overlap'' ptr sz s \<and> ptr \<noteq> 0 \<and> caps_overlap_reserved' {ptr..ptr + of_nat n * 2^(APIType_capBits ty us) - 1} s \<and> ksCurDomain s \<le> maxDomain\<rbrace>
-  createNewCaps ty ptr n us dev \<lbrace>\<lambda>r. valid_pspace'\<rbrace>"
+  shows
+  "\<lbrace>\<lambda>s. pspace_no_overlap' ptr sz s \<and> valid_pspace' s
+     \<and> caps_no_overlap'' ptr sz s \<and> ptr \<noteq> 0 \<and> caps_overlap_reserved' {ptr..ptr + of_nat n * 2^(APIType_capBits ty us) - 1} s
+     \<and> ksCurDomain s \<le> maxDomain\<rbrace>
+   createNewCaps ty ptr n us dev
+   \<lbrace>\<lambda>r. valid_pspace'\<rbrace>"
   unfolding createNewCaps_def Arch_createNewCaps_def
   using valid_obj_makeObject_rules
   apply (clarsimp simp: ARM_HYP_H.toAPIType_def
@@ -4712,14 +4432,17 @@ lemma createNewCaps_valid_pspace:
         apply (case_tac apiobject_type, simp_all split del: if_split)
             apply (rule hoare_pre, wp, clarsimp)
            apply (insert cover)
-           apply (wp createObjects_valid_pspace_untyped' [OF _ not_0 , where ty="Inr ty" and sz = sz]
-                     mapM_x_threadSet_valid_pspace mapM_x_wp'
-                 | simp add: makeObjectKO_def archObjSize_def APIType_capBits_def
-                             objBits_simps vspace_bits_defs not_0
-                             createObjects_def curDomain_def
-                 | intro conjI impI
-                 | simp add: power_add field_simps)+
-  done
+           (* for TCBObject, we need to know a bit more about tcbDomain *)
+           apply (simp add: curDomain_def)
+           apply (rule bind_wp[OF _ gets_sp])
+           apply (clarsimp simp: createObjects_def)
+           apply (rule hoare_assume_pre)
+           by (wp createObjects_valid_pspace_untyped' [OF _ _ not_0 , where ty="Inr ty" and sz = sz]
+                  mapM_x_threadSet_valid_pspace mapM_x_wp'
+               | simp add: makeObjectKO_def APIType_capBits_def
+                           objBits_simps vspace_bits_defs not_0 createObjects_def
+               | intro conjI impI
+               | simp add: power_add field_simps)+
 
 lemma copyGlobalMappings_inv[wp]:
   "\<lbrace>\<lambda>s. P (ksMachineState s)\<rbrace>
@@ -4942,7 +4665,7 @@ crunch createNewCaps
   (wp: mapM_x_wp' simp: crunch_simps)
 
 lemma createObjects_null_filter':
-  "\<lbrace>\<lambda>s. P (null_filter' (ctes_of s)) \<and> makeObjectKO dev ty = Some val \<and>
+  "\<lbrace>\<lambda>s. P (null_filter' (ctes_of s)) \<and> makeObjectKO dev d ty = Some val \<and>
         range_cover ptr sz (objBitsKO val + gbits) n \<and> n \<noteq> 0 \<and>
         pspace_aligned' s \<and> pspace_distinct' s \<and> pspace_no_overlap' ptr sz s\<rbrace>
    createObjects' ptr n val gbits
@@ -5358,7 +5081,7 @@ crunch createObjects
   (simp: unless_def)
 
 lemma createObjects_untyped_ranges_zero':
-  assumes moKO: "makeObjectKO dev ty = Some val"
+  assumes moKO: "makeObjectKO dev d ty = Some val"
   shows
   "\<lbrace>ct_active' and valid_pspace' and pspace_no_overlap' ptr sz
        and untyped_ranges_zero'
@@ -5384,9 +5107,10 @@ lemma createObjects_untyped_ranges_zero':
   done
 
 lemma createObjects_no_cte_invs:
-  assumes moKO: "makeObjectKO dev ty = Some val"
+  assumes moKO: "makeObjectKO dev d ty = Some val"
   assumes no_cte: "\<And>c. projectKO_opt val \<noteq> Some (c::cte)"
   assumes no_tcb: "\<And>t. projectKO_opt val \<noteq> Some (t::tcb)"
+  and     mdom: "ty = Inr (APIObjectType ArchTypes_H.apiobject_type.TCBObject) \<longrightarrow> d \<le> maxDomain"
   shows
   "\<lbrace>\<lambda>s. range_cover ptr sz ((objBitsKO val) + gbits) n \<and> n \<noteq> 0 \<and> invs' s \<and> ct_active' s
         \<and> pspace_no_overlap' ptr sz s \<and> ptr \<noteq> 0
@@ -5467,23 +5191,21 @@ qed
 lemma corres_retype_update_gsI:
   assumes not_zero: "n \<noteq> 0"
   and      aligned: "is_aligned ptr (objBitsKO ko + gbits)"
-  and obj_bits_api: "obj_bits_api (APIType_map2 ty) us =
-                     objBitsKO ko + gbits"
-  and        check: "sz < obj_bits_api (APIType_map2 ty) us \<longleftrightarrow>
-                     sz < objBitsKO ko + gbits"
+  and obj_bits_api: "obj_bits_api (APIType_map2 ty) us = objBitsKO ko + gbits"
+  and        check: "sz < obj_bits_api (APIType_map2 ty) us \<longleftrightarrow> sz < objBitsKO ko + gbits"
   and          usv: "APIType_map2 ty = Structures_A.CapTableObject \<Longrightarrow> 0 < us"
-  and           ko: "makeObjectKO dev ty = Some ko"
+  and           ko: "makeObjectKO dev d ty = Some ko"
   and          orr: "obj_bits_api (APIType_map2 ty) us \<le> sz \<Longrightarrow>
-                     obj_relation_retype
-                       (default_object (APIType_map2 ty) dev us) ko"
+                     obj_relation_retype (default_object (APIType_map2 ty) dev us d) ko"
   and        cover: "range_cover ptr sz (obj_bits_api (APIType_map2 ty) us) n"
   and            f: "f = update_gs (APIType_map2 ty) us"
   shows "corres (\<lambda>rv rv'. rv' = g rv)
          (\<lambda>s. valid_pspace s \<and> pspace_no_overlap_range_cover ptr sz s
-            \<and> valid_mdb s \<and> valid_etcbs s \<and> valid_list s)
+            \<and> valid_mdb s \<and> valid_list s)
          (\<lambda>s. pspace_aligned' s \<and> pspace_distinct' s \<and>
-              pspace_no_overlap' ptr sz s)
-         (retype_region2 ptr n us (APIType_map2 ty) dev)
+              pspace_no_overlap' ptr sz s \<and>
+              (ty = Inr (APIObjectType TCBObject) \<longrightarrow> d = ksCurDomain s))
+         (retype_region ptr n us (APIType_map2 ty) dev)
          (do addrs \<leftarrow> createObjects ptr n ko gbits;
              _ \<leftarrow> modify (f (set addrs));
              return (g addrs)
@@ -5494,70 +5216,13 @@ lemma corres_retype_update_gsI:
 lemma gcd_corres: "corres (=) \<top> \<top> (gets cur_domain) curDomain"
   by (simp add: curDomain_def state_relation_def)
 
-lemma retype_region2_extra_ext_mapM_x_corres:
-  shows "corres dc
-           (valid_etcbs and (\<lambda>s. \<forall>addr\<in>set addrs. tcb_at addr s))
-           (\<lambda>s. \<forall>addr\<in>set addrs. obj_at' (Not \<circ> tcbQueued) addr s)
-           (retype_region2_extra_ext addrs Structures_A.apiobject_type.TCBObject)
-           (mapM_x (\<lambda>addr. do cdom \<leftarrow> curDomain;
-                              threadSet (tcbDomain_update (\<lambda>_. cdom)) addr
-                           od)
-             addrs)"
-  apply (rule corres_guard_imp)
-    apply (simp add: retype_region2_extra_ext_def curDomain_mapM_x_futz[symmetric] when_def)
-    apply (rule corres_split_eqr[OF gcd_corres])
-      apply (rule_tac S="Id \<inter> {(x, y). x \<in> set addrs}"
-                  and P="\<lambda>s. (\<forall>t \<in> set addrs. tcb_at t s) \<and> valid_etcbs s"
-                  and P'="\<lambda>s. \<forall>t \<in> set addrs. obj_at' (Not \<circ> tcbQueued) t s"
-                   in corres_mapM_x)
-          apply simp
-          apply (rule corres_guard_imp)
-            apply (rule ethread_set_corres, simp_all add: etcb_relation_def non_exst_same_def)[1]
-            apply (case_tac tcb')
-            apply simp
-           apply fastforce
-          apply (fastforce simp: obj_at'_def)
-         apply (wp hoare_vcg_ball_lift | simp)+
-        apply (clarsimp simp: obj_at'_def)
-       apply fastforce
-      apply auto[1]
-     apply (wp | simp add: curDomain_def)+
-  done
-
-lemma retype_region2_extra_ext_trivial:
-  "ty \<noteq> APIType_map2 (Inr (APIObjectType apiobject_type.TCBObject))
-      \<Longrightarrow> retype_region2_extra_ext ptrs ty = return ()"
-by (simp add: retype_region2_extra_ext_def when_def APIType_map2_def)
-
-lemma retype_region2_ext_retype_region_ArchObject_PageDirectoryObj:
-  "retype_region ptr n us (APIType_map2 (Inr PageDirectoryObject)) dev =
-  (retype_region2 ptr n us (APIType_map2 (Inr PageDirectoryObject)) dev :: obj_ref list det_ext_monad)"
-by (simp add: retype_region2_ext_retype_region retype_region2_extra_ext_def when_def APIType_map2_def)
-
-lemma retype_region2_valid_etcbs[wp]:"\<lbrace>valid_etcbs\<rbrace> retype_region2 a b c d dev \<lbrace>\<lambda>_. valid_etcbs\<rbrace>"
-  apply (simp add: retype_region2_def)
-  apply (simp add: retype_region2_ext_def bind_assoc)
-  apply wp
-  apply (clarsimp simp del: fun_upd_apply)
-  apply (blast intro: valid_etcb_fold_update)
-  done
-
-lemma retype_region2_obj_at:
-  assumes tytcb: "ty = Structures_A.apiobject_type.TCBObject"
-  shows "\<lbrace>\<top>\<rbrace> retype_region2 ptr n us ty dev \<lbrace>\<lambda>rv s. \<forall>x \<in> set rv. tcb_at x s\<rbrace>"
-  using tytcb unfolding retype_region2_def
-  apply (simp only: return_bind bind_return foldr_upd_app_if fun_app_def K_bind_def)
-  apply (wp dxo_wp_weak | simp)+
-  apply (auto simp: obj_at_def default_object_def is_tcb_def)
-  done
-
-lemma createObjects_Not_tcbQueued:
+lemma createObjects_tcb_at':
   "\<lbrakk>range_cover ptr sz (objBitsKO (injectKOS (makeObject::tcb))) n; n \<noteq> 0\<rbrakk> \<Longrightarrow>
    \<lbrace>\<lambda>s. pspace_no_overlap' ptr sz s \<and> pspace_aligned' s \<and> pspace_distinct' s\<rbrace>
    createObjects ptr n (KOTCB makeObject) 0
-   \<lbrace>\<lambda>ptrs s. \<forall>addr\<in>set ptrs. obj_at' (Not \<circ> tcbQueued) addr s\<rbrace>"
+   \<lbrace>\<lambda>ptrs s. \<forall>addr\<in>set ptrs. tcb_at' addr s\<rbrace>"
   apply (rule hoare_strengthen_post[OF createObjects_ko_at_strg[where val = "(makeObject :: tcb)"]])
-  apply (auto simp: obj_at'_def projectKOs project_inject objBitsKO_def objBits_def makeObject_tcb)
+  apply (auto simp: obj_at'_def project_inject objBitsKO_def objBits_def makeObject_tcb)
   done
 
 lemma data_page_relation_retype:
@@ -5594,7 +5259,7 @@ lemma regroup_createObjects_dmo_userPages:
 lemma corres_retype_region_createNewCaps:
   "corres ((\<lambda>r r'. length r = length r' \<and> list_all2 cap_relation r r')
                \<circ> map (\<lambda>ref. default_cap (APIType_map2 (Inr ty)) ref us dev))
-            (\<lambda>s. valid_pspace s \<and> valid_mdb s \<and> valid_etcbs s \<and> valid_list s \<and> valid_arch_state s
+            (\<lambda>s. valid_pspace s \<and> valid_mdb s \<and> valid_list s \<and> valid_arch_state s
                    \<and> caps_no_overlap y sz s \<and> pspace_no_overlap_range_cover y sz s
                    \<and> caps_overlap_reserved {y..y + of_nat n * 2 ^ (obj_bits_api (APIType_map2 (Inr ty)) us) - 1} s
                    \<and> (\<exists>slot. cte_wp_at (\<lambda>c. up_aligned_area y sz \<subseteq> cap_range c \<and> cap_is_device c = dev) slot s)
@@ -5606,110 +5271,87 @@ lemma corres_retype_region_createNewCaps:
                 init_arch_objects (APIType_map2 (Inr ty)) dev y n us x;
                 return x od)
             (createNewCaps ty y n us dev)"
-  apply (rule_tac F="range_cover y sz
-                       (obj_bits_api (APIType_map2 (Inr ty)) us) n \<and>
-                     n \<noteq> 0 \<and>
-                     (APIType_map2 (Inr ty) = Structures_A.CapTableObject
-                       \<longrightarrow> 0 < us)"
-            in corres_req, simp)
+  apply (rule_tac F="range_cover y sz (obj_bits_api (APIType_map2 (Inr ty)) us) n
+                      \<and> n \<noteq> 0 \<and> (APIType_map2 (Inr ty) = Structures_A.CapTableObject \<longrightarrow> 0 < us)"
+           in corres_req, simp)
   apply (clarsimp simp add: createNewCaps_def toAPIType_def
                  split del: if_split cong: if_cong)
   apply (subst init_arch_objects_APIType_map2)
   apply (cases ty, simp_all add: Arch_createNewCaps_def
                       split del: if_split)
-        apply (rename_tac apiobject_type)
-        apply (case_tac apiobject_type, simp_all split del: if_split)
-            \<comment> \<open>Untyped\<close>
-            apply (simp     add: retype_region_def obj_bits_api_def
-                                 APIType_map2_def
-                      split del: if_split
-                           cong: if_cong)
-            apply (subst upto_enum_red')
-             apply (drule range_cover_not_zero[rotated])
-              apply simp
-             apply unat_arith
-            apply (clarsimp simp: list_all2_same enum_word_def  range_cover.unat_of_nat_n
-                                  list_all2_map1 list_all2_map2
-                                  ptr_add_def fromIntegral_def toInteger_nat fromInteger_nat)
-            apply (subst unat_of_nat_minus_1)
-              apply (rule le_less_trans[OF range_cover.range_cover_n_le(2) power_strict_increasing])
-                apply simp
-               apply (clarsimp simp: range_cover_def)
-               apply (arith+)[4]
-           \<comment> \<open>TCB, EP, NTFN\<close>
-           defer 10
-           apply (simp_all add: retype_region2_ext_retype_region bind_cong[OF curDomain_mapM_x_futz refl, unfolded bind_assoc]
-                     split del: if_split)[10] (* not PageDirectoryObject *)
-           apply (rule corres_guard_imp)
-             apply (rule corres_split_eqr)
-                apply (rule corres_retype[where 'a = tcb],
-                       simp_all add: obj_bits_api_def objBits_simps' pageBits_def
-                                    APIType_map2_def makeObjectKO_def
-                                    tcb_relation_retype)[1]
-                apply (fastforce simp: range_cover_def)
-               apply (rule corres_split_nor)
-                  apply (simp add: APIType_map2_def)
-                  apply (rule retype_region2_extra_ext_mapM_x_corres)
-                 apply (rule corres_trivial, simp)
-                 apply (clarsimp simp: list_all2_same list_all2_map1 list_all2_map2
-                objBits_simps APIType_map2_def)
-                apply wp
-               apply wp
-              apply ((wp retype_region2_obj_at | simp add: APIType_map2_def)+)[1]
-             apply ((wp createObjects_Not_tcbQueued[where sz=sz] | simp add: APIType_map2_def objBits_simps' obj_bits_api_def)+)[1]
+         apply (rename_tac apiobject_type)
+         apply (case_tac apiobject_type, simp_all split del: if_split)
+             \<comment> \<open>Untyped\<close>
+             apply (simp     add: retype_region_def obj_bits_api_def
+                                  APIType_map2_def
+                       split del: if_split
+                            cong: if_cong)
+             apply (subst upto_enum_red')
+              apply (drule range_cover_not_zero[rotated])
+               apply simp
+              apply unat_arith
+             apply (clarsimp simp: list_all2_same enum_word_def  range_cover.unat_of_nat_n
+                                   list_all2_map1 list_all2_map2
+                                   ptr_add_def fromIntegral_def toInteger_nat fromInteger_nat)
+             apply (subst unat_of_nat_minus_1)
+               apply (rule le_less_trans[OF range_cover.range_cover_n_le(2) power_strict_increasing])
+                 apply simp
+                apply (clarsimp simp: range_cover_def)
+                apply (arith+)[4]
+            \<comment> \<open>TCB\<close>
+            apply (simp_all add: curDomain_def split del: if_split)
+            apply (rule corres_underlying_gets_pre_rhs[rotated])
+             apply (rule gets_sp)
+            apply (rule corres_guard_imp)
+              apply (rule corres_bind_return)
+              apply (rule corres_split_eqr)
+                 apply (rule corres_retype[where 'a = tcb],
+                        simp_all add: obj_bits_api_def objBits_simps' pageBits_def
+                                      APIType_map2_def makeObjectKO_def)[1]
+                  apply (fastforce simp: range_cover_def)
+                 apply (simp add: tcb_relation_retype)
+                apply (rule corres_returnTT, simp)
+                apply (clarsimp simp: list_all2_same list_all2_map1 list_all2_map2
+                                      objBits_simps APIType_map2_def)
+               apply ((wp | simp add: APIType_map2_def)+)[1]
+              apply ((wp createObjects_tcb_at'[where sz=sz] | simp add: APIType_map2_def objBits_simps' obj_bits_api_def)+)[1]
+             apply simp
             apply simp
-           apply simp
-          apply (subst retype_region2_extra_ext_trivial)
-           apply (simp add: APIType_map2_def)
+           \<comment> \<open>EP, NTFN\<close>
+           apply (simp add: liftM_def[symmetric] split del: if_split)
+           apply (rule corres_rel_imp)
+            apply (rule corres_guard_imp)
+              apply (rule corres_retype[where 'a = endpoint],
+                     simp_all add: obj_bits_api_def objBits_simps' pageBits_def
+                                   APIType_map2_def makeObjectKO_def
+                                   other_objs_default_relation)[1]
+              apply ((simp add: range_cover_def APIType_map2_def
+                                list_all2_same list_all2_map1 list_all2_map2)+)[4]
           apply (simp add: liftM_def[symmetric] split del: if_split)
           apply (rule corres_rel_imp)
            apply (rule corres_guard_imp)
-             apply (rule corres_retype[where 'a = endpoint],
+             apply (rule corres_retype[where 'a = notification],
                     simp_all add: obj_bits_api_def objBits_simps' pageBits_def
                                   APIType_map2_def makeObjectKO_def
                                   other_objs_default_relation)[1]
-             apply (fastforce simp: range_cover_def)
-            apply simp
-           apply simp
-          apply (clarsimp simp: list_all2_same list_all2_map1 list_all2_map2
-                                objBits_simps APIType_map2_def)
-         apply (subst retype_region2_extra_ext_trivial)
-          apply (simp add: APIType_map2_def)
-         apply (simp add: liftM_def[symmetric] split del: if_split)
+             apply ((simp add: range_cover_def APIType_map2_def
+                               list_all2_same list_all2_map1 list_all2_map2)+)[4]
+         \<comment> \<open>CapTable\<close>
+         apply (find_goal \<open>match premises in "_ = ArchTypes_H.apiobject_type.CapTableObject" \<Rightarrow> \<open>-\<close>\<close>)
+         apply (subst bind_assoc_return_reverse[of "createObjects y n (KOCTE makeObject) us"])
+         apply (subst liftM_def [of "map (\<lambda>addr. capability.CNodeCap addr us 0 0)", symmetric])
+         apply simp
          apply (rule corres_rel_imp)
           apply (rule corres_guard_imp)
-            apply (rule corres_retype[where 'a = notification],
+            apply (rule corres_retype_update_gsI,
                    simp_all add: obj_bits_api_def objBits_simps' pageBits_def
-                                 APIType_map2_def makeObjectKO_def
-                                 other_objs_default_relation)[1]
-            apply (fastforce simp: range_cover_def)
-           apply simp
-          apply simp
-         apply (clarsimp simp: list_all2_same list_all2_map1 list_all2_map2
-                               objBits_simps APIType_map2_def)
-        \<comment> \<open>CapTable\<close>
-        apply (subst retype_region2_extra_ext_trivial)
-         apply (simp add: APIType_map2_def)
-        apply (subst bind_assoc_return_reverse[of "createObjects y n (KOCTE makeObject) us"])
-        apply (subst liftM_def
-               [of "map (\<lambda>addr. capability.CNodeCap addr us 0 0)", symmetric])
-        apply simp
-        apply (rule corres_rel_imp)
-         apply (rule corres_guard_imp)
-           apply (rule corres_retype_update_gsI,
-                 simp_all add: obj_bits_api_def objBits_simps' pageBits_def
-                               APIType_map2_def makeObjectKO_def slot_bits_def
-                               field_simps ext)[1]
-            apply (simp add: range_cover_def)
-           apply (rule captable_relation_retype,simp add: range_cover_def word_bits_def)
-          apply simp
-         apply simp
-        apply (clarsimp simp: list_all2_same list_all2_map1 list_all2_map2
-                              objBits_simps allRights_def APIType_map2_def
-                   split del: if_split)
+                                 APIType_map2_def makeObjectKO_def slot_bits_def
+                                 field_simps ext)[1]
+             apply ((clarsimp simp : range_cover_def APIType_map2_def word_bits_def
+                                      list_all2_same list_all2_map1 list_all2_map2
+                    | rule captable_relation_retype)+)[5]
         \<comment> \<open>SmallPageObject\<close>
-        apply (subst retype_region2_extra_ext_trivial)
-         apply (simp add: APIType_map2_def)
+        apply (in_case \<open>SmallPageObject\<close>)
         apply (simp add: corres_liftM2_simp[unfolded liftM_def] split del: if_split)
         apply (simp add: init_arch_objects_def split del: if_split)
         apply (subst regroup_createObjects_dmo_userPages)
@@ -5734,8 +5376,6 @@ lemma corres_retype_region_createNewCaps:
                                list_all2_map1 list_all2_map2 list_all2_same)
              apply ((wpsimp split_del: if_split)+)[6]
        \<comment> \<open>LargePageObject\<close>
-       apply (subst retype_region2_extra_ext_trivial)
-        apply (simp add: APIType_map2_def)
        apply (simp add: corres_liftM2_simp[unfolded liftM_def] split del: if_split)
        apply (simp add: init_arch_objects_def split del: if_split)
        apply (subst regroup_createObjects_dmo_userPages)
@@ -5760,8 +5400,6 @@ lemma corres_retype_region_createNewCaps:
                               list_all2_map1 list_all2_map2 list_all2_same)
             apply ((wpsimp split_del: if_split)+)[6]
       \<comment> \<open>SectionObject\<close>
-      apply (subst retype_region2_extra_ext_trivial)
-       apply (simp add: APIType_map2_def)
       apply (simp add: corres_liftM2_simp[unfolded liftM_def] split del: if_split)
       apply (simp add: init_arch_objects_def split del: if_split)
       apply (subst regroup_createObjects_dmo_userPages)
@@ -5786,8 +5424,6 @@ lemma corres_retype_region_createNewCaps:
                              list_all2_map1 list_all2_map2 list_all2_same)
            apply ((wpsimp split_del: if_split)+)[6]
      \<comment> \<open>SuperSectionObject\<close>
-     apply (subst retype_region2_extra_ext_trivial)
-      apply (simp add: APIType_map2_def)
      apply (simp add: corres_liftM2_simp[unfolded liftM_def] split del: if_split)
      apply (simp add: init_arch_objects_def split del: if_split)
      apply (subst regroup_createObjects_dmo_userPages)
@@ -5812,8 +5448,6 @@ lemma corres_retype_region_createNewCaps:
                             list_all2_map1 list_all2_map2 list_all2_same)
           apply ((wpsimp split_del: if_split)+)[6]
     \<comment> \<open>PageTable\<close>
-    apply (subst retype_region2_extra_ext_trivial)
-     apply (simp add: APIType_map2_def)
     apply (simp add: corres_liftM2_simp[unfolded liftM_def])
     apply (simp add: init_arch_objects_def  split del: if_split)
     apply (rule corres_guard_imp)
@@ -5835,16 +5469,13 @@ lemma corres_retype_region_createNewCaps:
           apply (clarsimp simp: list_all2_map1 list_all2_map2 list_all2_same
                                 APIType_map2_def arch_default_cap_def)
          apply ((wpsimp split_del: if_split)+)[6]
-   defer
    \<comment> \<open>PageDirectory\<close>
    apply (simp only: bind_assoc)
    apply (rule corres_guard_imp)
      apply (rule corres_split_eqr)
-        apply (rule corres_retype[where ty = "Inr PageDirectoryObject" and 'a = pde
-                     , simplified, folded retype_region2_ext_retype_region_ArchObject_PageDirectoryObj],
+        apply (rule corres_retype[where ty = "Inr PageDirectoryObject" and 'a = pde, simplified],
                simp_all add: APIType_map2_def obj_bits_api_def
-                             default_arch_object_def objBits_simps
-                             archObjSize_def vspace_bits_defs
+                             default_arch_object_def objBits_simps vspace_bits_defs
                              makeObjectKO_def)[1]
          apply (simp add: range_cover_def)+
         apply (rule pagedirectory_relation_retype)
@@ -5854,7 +5485,7 @@ lemma corres_retype_region_createNewCaps:
           apply (simp add: mapM_x_mapM)
           apply (rule corres_underlying_split[where r' = dc])
              apply (rule_tac Q="\<lambda>xs s. (\<forall>x \<in> set xs. page_directory_at x s)
-                                    \<and> valid_arch_state s \<and> pspace_aligned s \<and> valid_etcbs s"
+                                    \<and> valid_arch_state s \<and> pspace_aligned s"
                           and Q'="\<lambda>xs s. (\<forall>x \<in> set xs. page_directory_at' x s) \<and> valid_arch_state' s"
                           in corres_mapM_list_all2[where r'=dc and S="(=)"])
                   apply simp+
@@ -5923,8 +5554,6 @@ lemma corres_retype_region_createNewCaps:
                       vspace_bits_defs fromIntegral_def toInteger_nat fromInteger_nat
                       makeObject_pde projectKOs)[2]
   \<comment> \<open>VCPUObject\<close>
-  apply (subst retype_region2_extra_ext_trivial)
-   apply (simp add: APIType_map2_def)
   apply (simp add: corres_liftM2_simp[unfolded liftM_def] split del: if_split)
   apply (rule corres_rel_imp)
    apply (simp add: init_arch_objects_APIType_map2_VCPU_noop split del: if_split)

--- a/proof/refine/ARM_HYP/Schedule_R.thy
+++ b/proof/refine/ARM_HYP/Schedule_R.thy
@@ -174,7 +174,7 @@ lemma schedule_choose_new_thread_sched_act_rct[wp]:
 lemma tcbSchedAppend_corres:
   "tcb_ptr = tcbPtr \<Longrightarrow>
    corres dc
-     (in_correct_ready_q and ready_qs_distinct and valid_etcbs and st_tcb_at runnable tcb_ptr
+     (in_correct_ready_q and ready_qs_distinct and st_tcb_at runnable tcb_ptr
       and pspace_aligned and pspace_distinct)
      (sym_heap_sched_pointers and valid_sched_pointers and valid_tcbs')
      (tcb_sched_action tcb_sched_append tcb_ptr) (tcbSchedAppend tcbPtr)"
@@ -191,9 +191,9 @@ lemma tcbSchedAppend_corres:
    apply (fastforce dest: pspace_distinct_cross)
   apply (clarsimp simp: tcb_sched_action_def tcb_sched_append_def get_tcb_queue_def
                         tcbSchedAppend_def getQueue_def unless_def when_def)
-  apply (rule corres_symb_exec_l[OF _ _ ethread_get_sp]; (solves wpsimp)?)
+  apply (rule corres_symb_exec_l[OF _ _ thread_get_sp]; (solves wpsimp)?)
   apply (rename_tac domain)
-  apply (rule corres_symb_exec_l[OF _ _ ethread_get_sp]; (solves wpsimp)?)
+  apply (rule corres_symb_exec_l[OF _ _ thread_get_sp]; (solves wpsimp)?)
   apply (rename_tac priority)
   apply (rule corres_symb_exec_l[OF _ _ gets_sp]; (solves wpsimp)?)
   apply (rule corres_stateAssert_ignore)
@@ -205,12 +205,11 @@ lemma tcbSchedAppend_corres:
   apply (rule corres_symb_exec_r[OF _ threadGet_sp]; (solves wpsimp)?)
   apply (subst if_distrib[where f="set_tcb_queue domain prio" for domain prio])
   apply (rule corres_if_strong')
-    apply (frule state_relation_ready_queues_relation)
-    apply (frule in_ready_q_tcbQueued_eq[where t=tcbPtr])
     subgoal
-      by (fastforce dest: tcb_at_ekheap_dom pred_tcb_at_tcb_at
-                    simp: obj_at'_def opt_pred_def opt_map_def obj_at_def is_tcb_def
-                          in_correct_ready_q_def etcb_at_def is_etcb_at_def)
+      by (fastforce dest!: state_relation_ready_queues_relation
+                           in_ready_q_tcbQueued_eq[where t=tcbPtr]
+                     simp: obj_at'_def opt_pred_def opt_map_def in_correct_ready_q_def
+                           obj_at_def etcb_at_def etcbs_of'_def)
    apply (find_goal \<open>match conclusion in "corres _ _ _ _ (return ())" \<Rightarrow> \<open>-\<close>\<close>)
    apply (rule monadic_rewrite_corres_l[where P=P and Q=P for P, simplified])
     apply (clarsimp simp: set_tcb_queue_def)
@@ -258,16 +257,15 @@ lemma tcbSchedAppend_corres:
   apply (drule set_tcb_queue_new_state)
   apply (wpsimp wp: threadSet_wp simp: setQueue_def tcbQueueAppend_def)
   apply normalise_obj_at'
-  apply (frule (1) tcb_at_is_etcb_at)
-  apply (clarsimp simp: obj_at_def is_etcb_at_def etcb_at_def)
-  apply (rename_tac s d p s' tcb' tcb etcb)
-  apply (frule_tac t=tcbPtr in ekheap_relation_tcb_domain_priority)
+  apply (clarsimp simp: obj_at_def)
+  apply (rename_tac s d p s' tcb' tcb)
+  apply (frule_tac t=tcbPtr in pspace_relation_tcb_domain_priority)
     apply (force simp: obj_at_def)
    apply (force simp: obj_at'_def)
   apply (clarsimp split: if_splits)
   apply (cut_tac ts="ready_queues s d p" in list_queue_relation_nil)
    apply (force dest!: spec simp: list_queue_relation_def)
-  apply (cut_tac ts="ready_queues s (tcb_domain etcb) (tcb_priority etcb)"
+  apply (cut_tac ts="ready_queues s (tcb_domain tcb) (tcb_priority tcb)"
               in obj_at'_tcbQueueEnd_ksReadyQueues)
       apply fast
      apply fast
@@ -277,8 +275,8 @@ lemma tcbSchedAppend_corres:
    apply (force dest!: spec simp: list_queue_relation_def)
   apply (clarsimp simp: list_queue_relation_def)
 
-  apply (case_tac "d \<noteq> tcb_domain etcb \<or> p \<noteq> tcb_priority etcb")
-   apply (cut_tac d=d and d'="tcb_domain etcb" and p=p and p'="tcb_priority etcb"
+  apply (case_tac "d \<noteq> tcb_domain tcb \<or> p \<noteq> tcb_priority tcb")
+   apply (cut_tac d=d and d'="tcb_domain tcb" and p=p and p'="tcb_priority tcb"
                in ready_queues_disjoint)
       apply force
      apply fastforce
@@ -302,14 +300,14 @@ lemma tcbSchedAppend_corres:
     apply (clarsimp simp: fun_upd_apply split: if_splits)
 
    \<comment> \<open>the ready queue was not originally empty\<close>
-   apply (clarsimp simp: etcb_at_def obj_at'_def)
-   apply (prop_tac "the (tcbQueueEnd (ksReadyQueues s' (tcb_domain etcb, tcb_priority etcb)))
+   apply (clarsimp simp: obj_at'_def)
+   apply (prop_tac "the (tcbQueueEnd (ksReadyQueues s' (tcb_domain tcb, tcb_priority tcb)))
                     \<notin> set (ready_queues s d p)")
     apply (erule orthD2)
-    apply (drule_tac x="tcb_domain etcb" in spec)
-    apply (drule_tac x="tcb_priority etcb" in spec)
+    apply (drule_tac x="tcb_domain tcb" in spec)
+    apply (drule_tac x="tcb_priority tcb" in spec)
     apply clarsimp
-    apply (drule_tac x="the (tcbQueueEnd (ksReadyQueues s' (tcb_domain etcb, tcb_priority etcb)))"
+    apply (drule_tac x="the (tcbQueueEnd (ksReadyQueues s' (tcb_domain tcb, tcb_priority tcb)))"
                  in spec)
     subgoal by (auto simp: in_opt_pred opt_map_red)
    apply (intro conjI impI allI)
@@ -326,7 +324,7 @@ lemma tcbSchedAppend_corres:
       apply (case_tac "ready_queues s d p"; force simp: tcbQueueEmpty_def)
      apply (case_tac "t = tcbPtr")
       apply (clarsimp simp: inQ_def fun_upd_apply split: if_splits)
-     apply (case_tac "t = the (tcbQueueEnd (ksReadyQueues s' (tcb_domain etcb, tcb_priority etcb)))")
+     apply (case_tac "t = the (tcbQueueEnd (ksReadyQueues s' (tcb_domain tcb, tcb_priority tcb)))")
       apply (clarsimp simp: inQ_def opt_pred_def fun_upd_apply)
      apply (clarsimp simp: inQ_def in_opt_pred opt_map_def fun_upd_apply)
     apply (clarsimp simp: fun_upd_apply split: if_splits)
@@ -334,9 +332,9 @@ lemma tcbSchedAppend_corres:
 
   \<comment> \<open>d = tcb_domain tcb \<and> p = tcb_priority tcb\<close>
   apply clarsimp
-  apply (drule_tac x="tcb_domain etcb" in spec)
-  apply (drule_tac x="tcb_priority etcb" in spec)
-  apply (cut_tac ts="ready_queues s (tcb_domain etcb) (tcb_priority etcb)"
+  apply (drule_tac x="tcb_domain tcb" in spec)
+  apply (drule_tac x="tcb_priority tcb" in spec)
+  apply (cut_tac ts="ready_queues s (tcb_domain tcb) (tcb_priority tcb)"
               in tcbQueueHead_iff_tcbQueueEnd)
    apply (force simp: list_queue_relation_def)
   apply (frule valid_tcbs'_maxDomain[where t=tcbPtr], simp add: obj_at'_def)
@@ -773,7 +771,7 @@ defs idleThreadNotQueued_def:
   "idleThreadNotQueued s \<equiv> obj_at' (Not \<circ> tcbQueued) (ksIdleThread s) s"
 
 lemma idle_thread_not_queued:
-  "\<lbrakk>valid_idle s; valid_queues s; valid_etcbs s\<rbrakk>
+  "\<lbrakk>valid_idle s; valid_queues s\<rbrakk>
    \<Longrightarrow> \<not> (\<exists>d p. idle_thread s \<in> set (ready_queues s d p))"
   apply (clarsimp simp: valid_queues_def)
   apply (drule_tac x=d in spec)
@@ -781,7 +779,7 @@ lemma idle_thread_not_queued:
   apply clarsimp
   apply (drule_tac x="idle_thread s" in bspec)
    apply fastforce
-  apply (clarsimp simp: valid_idle_def pred_tcb_at_def obj_at_def valid_etcbs_def)
+  apply (clarsimp simp: valid_idle_def pred_tcb_at_def obj_at_def)
   done
 
 lemma valid_idle_tcb_at:
@@ -789,13 +787,13 @@ lemma valid_idle_tcb_at:
   by (clarsimp simp: valid_idle_def pred_tcb_at_def obj_at_def is_tcb_def)
 
 lemma setCurThread_corres:
-  "corres dc (valid_idle and valid_queues and valid_etcbs and pspace_aligned and pspace_distinct) \<top>
+  "corres dc (valid_idle and valid_queues and pspace_aligned and pspace_distinct) \<top>
      (modify (cur_thread_update (\<lambda>_. t))) (setCurThread t)"
   supply projectKOs[simp]
   apply (clarsimp simp: setCurThread_def)
   apply (rule corres_stateAssert_add_assertion[rotated])
    apply (clarsimp simp: idleThreadNotQueued_def)
-   apply (frule (2) idle_thread_not_queued)
+   apply (frule (1) idle_thread_not_queued)
    apply (frule state_relation_pspace_relation)
    apply (frule state_relation_ready_queues_relation)
    apply (frule state_relation_idle_thread)
@@ -838,6 +836,7 @@ crunch arch_switch_to_thread, arch_switch_to_idle_thread
   and pspace_distinct[wp]: pspace_distinct
   and ready_qs_distinct[wp]: ready_qs_distinct
   and valid_idle_new[wp]: valid_idle
+  and ready_queues[wp]: "\<lambda>s. P (ready_queues s)"
   (wp: ready_qs_distinct_lift simp: crunch_simps)
 
 lemma valid_queues_in_correct_ready_q[elim!]:
@@ -853,7 +852,7 @@ lemma switchToThread_corres:
                 and valid_vspace_objs and pspace_aligned and pspace_distinct
                 and valid_vs_lookup and valid_global_objs
                 and unique_table_refs o caps_of_state
-                and st_tcb_at runnable t and valid_etcbs and (\<lambda>s. sym_refs (state_hyp_refs_of s))
+                and st_tcb_at runnable t and (\<lambda>s. sym_refs (state_hyp_refs_of s))
                 and valid_queues and valid_idle)
              (valid_arch_state' and no_0_obj' and sym_heap_sched_pointers and valid_objs'
               and (\<lambda>s. sym_refs (state_hyp_refs_of' s)))
@@ -875,7 +874,7 @@ lemma switchToThread_corres:
     apply (rule corres_guard_imp)
       apply (rule corres_split[OF arch_switchToThread_corres])
         apply (rule corres_split[OF tcbSchedDequeue_corres setCurThread_corres])
-          apply (wpsimp simp: is_tcb_def)+
+          apply (wpsimp simp: is_tcb_def wp: in_correct_ready_q_lift)+
      apply (fastforce intro!: st_tcb_at_tcb_at)
     apply wpsimp
    apply wpsimp
@@ -936,7 +935,7 @@ lemma arch_switchToIdleThread_corres:
 
 lemma switchToIdleThread_corres:
   "corres dc
-     (invs and valid_queues and valid_etcbs)
+     (invs and valid_queues)
      invs_no_cicd'
      switch_to_idle_thread switchToIdleThread"
   apply (simp add: switch_to_idle_thread_def Thread_H.switchToIdleThread_def)
@@ -1589,7 +1588,7 @@ lemma guarded_switch_to_corres:
                 and valid_vspace_objs and pspace_aligned and pspace_distinct
                 and valid_vs_lookup
                 and unique_table_refs o caps_of_state
-                and st_tcb_at runnable t and valid_etcbs and valid_queues and valid_idle and (\<lambda>s. sym_refs (state_hyp_refs_of s)))
+                and st_tcb_at runnable t and valid_queues and valid_idle and (\<lambda>s. sym_refs (state_hyp_refs_of s)))
              (valid_arch_state' and valid_pspace' and sym_heap_sched_pointers
               and (\<lambda>s. sym_refs (state_hyp_refs_of' s)))
              (guarded_switch_to t) (switchToThread t)"
@@ -1827,25 +1826,27 @@ lemma schact_bind_inside: "do x \<leftarrow> f; (case act of resume_cur_thread \
   apply (case_tac act,simp_all)
   done
 
-interpretation tcb_sched_action_extended: is_extended' "tcb_sched_action f a"
-  by (unfold_locales)
-
 lemma getDomainTime_corres:
   "corres (=) \<top> \<top> (gets domain_time) getDomainTime"
   by (simp add: getDomainTime_def state_relation_def)
 
+lemma reset_work_units_equiv:
+  "do_extended_op (modify (work_units_completed_update (\<lambda>_. 0)))
+   = (modify (work_units_completed_update (\<lambda>_. 0)))"
+  by (clarsimp simp: reset_work_units_def[symmetric])
+
 lemma nextDomain_corres:
   "corres dc \<top> \<top> next_domain nextDomain"
-  apply (simp add: next_domain_def nextDomain_def)
+  apply (clarsimp simp: next_domain_def nextDomain_def reset_work_units_equiv modify_modify)
   apply (rule corres_modify)
-  apply (simp add: state_relation_def Let_def dschLength_def dschDomain_def)
+  apply (simp add: state_relation_def Let_def dschLength_def dschDomain_def cdt_relation_def)
   done
 
 lemma next_domain_valid_sched[wp]:
   "\<lbrace> valid_sched and (\<lambda>s. scheduler_action s  = choose_new_thread)\<rbrace> next_domain \<lbrace> \<lambda>_. valid_sched \<rbrace>"
   apply (simp add: next_domain_def Let_def)
-  apply (wp, simp add: valid_sched_def valid_sched_action_2_def ct_not_in_q_2_def)
-  apply (simp add:valid_blocked_2_def)
+  apply (wpsimp wp: dxo_wp_weak)
+  apply (clarsimp simp: valid_sched_def)
   done
 
 lemma nextDomain_invs_no_cicd':
@@ -1879,7 +1880,7 @@ lemma scheduleChooseNewThread_fragment_corres:
 
 lemma scheduleSwitchThreadFastfail_corres:
   "\<lbrakk> ct \<noteq> it \<longrightarrow> (tp = tp' \<and> cp = cp') ; ct = ct' ; it = it' \<rbrakk> \<Longrightarrow>
-   corres ((=)) (is_etcb_at ct) (tcb_at' ct)
+   corres ((=)) (is_tcb_at ct) (tcb_at' ct)
      (schedule_switch_thread_fastfail ct it cp tp)
      (scheduleSwitchThreadFastfail ct' it' cp' tp')"
   by (clarsimp simp: schedule_switch_thread_fastfail_def scheduleSwitchThreadFastfail_def)
@@ -1918,9 +1919,6 @@ lemma isHighestPrio_corres:
          apply (wpsimp simp: if_apply_def2 wp: hoare_drop_imps ksReadyQueuesL1Bitmap_return_wp)+
   done
 
-crunch set_scheduler_action
-  for valid_idle_etcb[wp]: valid_idle_etcb
-
 crunch isHighestPrio
   for inv[wp]: P
 crunch curDomain
@@ -1953,13 +1951,13 @@ lemma scheduleChooseNewThread_corres:
 crunch guarded_switch_to
   for static_inv[wp]: "\<lambda>_. P"
 
-lemma ethread_get_when_corres:
-  assumes x: "\<And>etcb tcb'. etcb_relation etcb tcb' \<Longrightarrow> r (f etcb) (f' tcb')"
-  shows      "corres (\<lambda>rv rv'. b \<longrightarrow> r rv rv') (is_etcb_at t) (tcb_at' t)
-                (ethread_get_when b f t) (threadGet f' t)"
-  apply (clarsimp simp: ethread_get_when_def)
+lemma thread_get_when_corres:
+  assumes x: "\<And>tcb tcb'. tcb_relation tcb tcb' \<Longrightarrow> r (f tcb) (f' tcb')"
+  shows      "corres (\<lambda>rv rv'. b \<longrightarrow> r rv rv') (tcb_at t and pspace_aligned and pspace_distinct) (tcb_at' t)
+                ((if b then thread_get f t else return 0)) (threadGet f' t)"
+  apply clarsimp
   apply (rule conjI; clarsimp)
-  apply (rule corres_guard_imp, rule ethreadget_corres; simp add: x)
+  apply (rule corres_guard_imp, rule threadGet_corres; simp add: x)
   apply (clarsimp simp: threadGet_def)
   apply (rule corres_noop)
   apply wpsimp+
@@ -1972,31 +1970,29 @@ lemma tcb_sched_action_sym_refs_state_hyp_refs_of[wp]:
 lemma tcb_sched_enqueue_in_correct_ready_q[wp]:
   "tcb_sched_action tcb_sched_enqueue t \<lbrace>in_correct_ready_q\<rbrace> "
   unfolding tcb_sched_action_def tcb_sched_enqueue_def set_tcb_queue_def
-  apply wpsimp
-  apply (clarsimp simp: in_correct_ready_q_def obj_at_def etcb_at_def is_etcb_at_def
-                 split: option.splits)
+  apply (wpsimp wp: thread_get_wp')
+  apply (clarsimp simp: in_correct_ready_q_def obj_at_def etcb_at_def is_etcb_at_def etcbs_of'_def)
   done
 
 lemma tcb_sched_append_in_correct_ready_q[wp]:
   "tcb_sched_action tcb_sched_append tcb_ptr \<lbrace>in_correct_ready_q\<rbrace> "
   unfolding tcb_sched_action_def tcb_sched_append_def
-  apply wpsimp
-  apply (clarsimp simp: in_correct_ready_q_def obj_at_def etcb_at_def is_etcb_at_def
-                 split: option.splits)
+  apply (wpsimp wp: thread_get_wp')
+  apply (clarsimp simp: in_correct_ready_q_def obj_at_def etcb_at_def is_etcb_at_def etcbs_of'_def)
   done
 
 lemma tcb_sched_enqueue_ready_qs_distinct[wp]:
   "tcb_sched_action tcb_sched_enqueue t \<lbrace>ready_qs_distinct\<rbrace> "
   unfolding tcb_sched_action_def set_tcb_queue_def
   apply (wpsimp wp: thread_get_wp')
-  apply (clarsimp simp: ready_qs_distinct_def etcb_at_def is_etcb_at_def split: option.splits)
+  apply (clarsimp simp: ready_qs_distinct_def etcb_at_def is_etcb_at_def)
   done
 
 lemma tcb_sched_append_ready_qs_distinct[wp]:
   "tcb_sched_action tcb_sched_append t \<lbrace>ready_qs_distinct\<rbrace> "
   unfolding tcb_sched_action_def tcb_sched_append_def set_tcb_queue_def
   apply (wpsimp wp: thread_get_wp')
-  apply (clarsimp simp: ready_qs_distinct_def etcb_at_def is_etcb_at_def split: option.splits)
+  apply (clarsimp simp: ready_qs_distinct_def etcb_at_def is_etcb_at_def)
   done
 
 crunch set_scheduler_action
@@ -2009,9 +2005,11 @@ crunch reschedule_required
   and ready_qs_distinct[wp]: ready_qs_distinct
   (ignore: tcb_sched_action wp: crunch_wps ignore_del: reschedule_required)
 
+crunch tcb_sched_action
+  for valid_vs_lookup[wp]: valid_vs_lookup
+
 lemma schedule_corres:
   "corres dc (invs and valid_sched and valid_list) invs' (Schedule_A.schedule) ThreadDecls_H.schedule"
-  supply ethread_get_wp[wp del]
   supply tcbSchedEnqueue_invs'[wp del]
   supply tcbSchedEnqueue_invs'_not_ResumeCurrentThread[wp del]
   supply setSchedulerAction_direct[wp]
@@ -2048,11 +2046,11 @@ lemma schedule_corres:
              apply (rule tcbSchedEnqueue_corres, simp)
             apply (rule corres_split[OF getIdleThread_corres], rename_tac it it')
               apply (rule_tac F="was_running \<longrightarrow> ct \<noteq> it" in corres_gen_asm)
-              apply (rule corres_split[OF ethreadget_corres[where r="(=)"]])
-                 apply (simp add: etcb_relation_def)
+              apply (rule corres_split[OF threadGet_corres[where r="(=)"]])
+                 apply (simp add: tcb_relation_def)
                 apply (rename_tac tp tp')
-                apply (rule corres_split[OF ethread_get_when_corres[where r="(=)"]])
-                   apply (simp add: etcb_relation_def)
+                apply (rule corres_split[OF thread_get_when_corres[where r="(=)"]])
+                   apply (simp add: tcb_relation_def)
                   apply (rename_tac cp cp')
                   apply (rule corres_split)
                      apply (rule scheduleSwitchThreadFastfail_corres; simp)
@@ -2116,7 +2114,7 @@ lemma schedule_corres:
    apply clarsimp
 
    subgoal for s
-     apply (clarsimp split: Deterministic_A.scheduler_action.splits
+     apply (clarsimp split: Structures_A.scheduler_action.splits
                      simp: invs_psp_aligned invs_distinct invs_valid_objs invs_arch_state
                            invs_vspace_objs[simplified] tcb_at_invs)
      apply (rule conjI, clarsimp)
@@ -2128,15 +2126,14 @@ lemma schedule_corres:
       subgoal for candidate
         apply (clarsimp simp: valid_sched_def invs_def valid_state_def cur_tcb_def
                               valid_arch_caps_def valid_sched_action_def
-                              weak_valid_sched_action_def tcb_at_is_etcb_at
-                              tcb_at_is_etcb_at[OF st_tcb_at_tcb_at[rotated]]
+                              weak_valid_sched_action_def
                               valid_blocked_except_def valid_blocked_def invs_hyp_sym_refs)
         apply (fastforce simp: pred_tcb_at_def obj_at_def is_tcb valid_idle_def)
         done
      (* choose new thread case *)
      apply (intro impI conjI allI tcb_at_invs
-            | fastforce simp: invs_def cur_tcb_def valid_etcbs_def
-                              valid_sched_def  st_tcb_at_def obj_at_def valid_state_def
+            | fastforce simp: invs_def cur_tcb_def
+                              valid_sched_def st_tcb_at_def obj_at_def valid_state_def
                               weak_valid_sched_action_def not_cur_thread_def)+
      done
 
@@ -2488,7 +2485,7 @@ lemma sbn_sch_act_sane:
 
 lemma possibleSwitchTo_corres:
   "corres dc
-     (valid_etcbs and weak_valid_sched_action and cur_tcb and st_tcb_at runnable t
+     (weak_valid_sched_action and cur_tcb and st_tcb_at runnable t
       and in_correct_ready_q and ready_qs_distinct and pspace_aligned and pspace_distinct)
      ((\<lambda>s. weak_sch_act_wf (ksSchedulerAction s) s)
       and sym_heap_sched_pointers and valid_sched_pointers and valid_objs')
@@ -2497,7 +2494,6 @@ lemma possibleSwitchTo_corres:
    apply (fastforce dest: pspace_aligned_cross)
   apply (rule_tac Q'=pspace_distinct' in corres_cross_add_guard)
    apply (fastforce dest: pspace_distinct_cross)
-  supply ethread_get_wp[wp del]
   apply (rule corres_cross_over_guard[where P'=Q and Q="tcb_at' t and Q" for Q])
    apply (clarsimp simp: state_relation_def)
    apply (rule tcb_at_cross, erule st_tcb_at_tcb_at; assumption)
@@ -2505,8 +2501,8 @@ lemma possibleSwitchTo_corres:
   apply (rule corres_guard_imp)
     apply (rule corres_split[OF curDomain_corres], simp)
       apply (rule corres_split)
-         apply (rule ethreadget_corres[where r="(=)"])
-         apply (clarsimp simp: etcb_relation_def)
+         apply (rule threadGet_corres[where r="(=)"])
+         apply (clarsimp simp: tcb_relation_def)
         apply (rule corres_split[OF getSchedulerAction_corres])
           apply (rule corres_if, simp)
            apply (rule tcbSchedEnqueue_corres, simp)
@@ -2516,14 +2512,9 @@ lemma possibleSwitchTo_corres:
              apply (rule tcbSchedEnqueue_corres, simp)
             apply (wp reschedule_required_valid_queues | strengthen valid_objs'_valid_tcbs')+
           apply (rule setSchedulerAction_corres, simp)
-         apply (wpsimp simp: if_apply_def2
-                       wp: hoare_drop_imp[where f="ethread_get a b" for a b])+
-      apply (wp hoare_drop_imps)[1]
-     apply wp+
-   apply (clarsimp simp: valid_sched_def invs_def valid_state_def cur_tcb_def st_tcb_at_tcb_at
-                          valid_sched_action_def weak_valid_sched_action_def
-                          tcb_at_is_etcb_at[OF st_tcb_at_tcb_at[rotated]])
-  apply (fastforce simp: tcb_at_is_etcb_at)
+         apply (wpsimp wp: hoare_drop_imps)+
+   apply (clarsimp simp: st_tcb_at_tcb_at)
+  apply fastforce
   done
 
 end

--- a/proof/refine/ARM_HYP/StateRelation.thy
+++ b/proof/refine/ARM_HYP/StateRelation.thy
@@ -193,28 +193,27 @@ where
 | "thread_state_relation (Structures_A.BlockedOnNotification oref) ts'
      = (ts' = Structures_H.BlockedOnNotification oref)"
 
-definition
-  arch_tcb_relation :: "Structures_A.arch_tcb \<Rightarrow> Structures_H.arch_tcb \<Rightarrow> bool"
-where
- "arch_tcb_relation \<equiv> \<lambda>atcb atcb'.
-   tcb_context atcb = atcbContext atcb' \<and> tcb_vcpu atcb = atcbVCPUPtr atcb'"
+definition arch_tcb_relation :: "Structures_A.arch_tcb \<Rightarrow> Structures_H.arch_tcb \<Rightarrow> bool" where
+  "arch_tcb_relation \<equiv>
+     \<lambda>atcb atcb'. tcb_context atcb = atcbContext atcb' \<and> tcb_vcpu atcb = atcbVCPUPtr atcb'"
 
-definition
-  tcb_relation :: "Structures_A.tcb \<Rightarrow> Structures_H.tcb \<Rightarrow> bool"
-where
- "tcb_relation \<equiv> \<lambda>tcb tcb'.
-    tcb_fault_handler tcb = to_bl (tcbFaultHandler tcb')
-  \<and> tcb_ipc_buffer tcb = tcbIPCBuffer tcb'
-  \<and> arch_tcb_relation (tcb_arch tcb) (tcbArch tcb')
-  \<and> thread_state_relation (tcb_state tcb) (tcbState tcb')
-  \<and> fault_rel_optionation (tcb_fault tcb) (tcbFault tcb')
-  \<and> cap_relation (tcb_ctable tcb) (cteCap (tcbCTable tcb'))
-  \<and> cap_relation (tcb_vtable tcb) (cteCap (tcbVTable tcb'))
-  \<and> cap_relation (tcb_reply tcb) (cteCap (tcbReply tcb'))
-  \<and> cap_relation (tcb_caller tcb) (cteCap (tcbCaller tcb'))
-  \<and> cap_relation (tcb_ipcframe tcb) (cteCap (tcbIPCBufferFrame tcb'))
-  \<and> tcb_bound_notification tcb = tcbBoundNotification tcb'
-  \<and> tcb_mcpriority tcb = tcbMCP tcb'"
+definition tcb_relation :: "Structures_A.tcb \<Rightarrow> Structures_H.tcb \<Rightarrow> bool" where
+  "tcb_relation \<equiv> \<lambda>tcb tcb'.
+     tcb_fault_handler tcb = to_bl (tcbFaultHandler tcb')
+   \<and> tcb_ipc_buffer tcb = tcbIPCBuffer tcb'
+   \<and> arch_tcb_relation (tcb_arch tcb) (tcbArch tcb')
+   \<and> thread_state_relation (tcb_state tcb) (tcbState tcb')
+   \<and> fault_rel_optionation (tcb_fault tcb) (tcbFault tcb')
+   \<and> cap_relation (tcb_ctable tcb) (cteCap (tcbCTable tcb'))
+   \<and> cap_relation (tcb_vtable tcb) (cteCap (tcbVTable tcb'))
+   \<and> cap_relation (tcb_reply tcb) (cteCap (tcbReply tcb'))
+   \<and> cap_relation (tcb_caller tcb) (cteCap (tcbCaller tcb'))
+   \<and> cap_relation (tcb_ipcframe tcb) (cteCap (tcbIPCBufferFrame tcb'))
+   \<and> tcb_bound_notification tcb = tcbBoundNotification tcb'
+   \<and> tcb_mcpriority tcb = tcbMCP tcb'
+   \<and> tcb_priority tcb = tcbPriority tcb'
+   \<and> tcb_time_slice tcb = tcbTimeSlice tcb'
+   \<and> tcb_domain tcb = tcbDomain tcb'"
 
 \<comment> \<open>
   A pair of objects @{term "(obj, obj')"} should satisfy the following relation when, under further
@@ -413,22 +412,8 @@ where
   (\<forall>x \<in> dom ab. \<forall>(y, P) \<in> obj_relation_cuts (the (ab x)) x.
        P (the (ab x)) (the (con y)))"
 
-definition etcb_relation :: "etcb \<Rightarrow> Structures_H.tcb \<Rightarrow> bool"
-where
- "etcb_relation \<equiv> \<lambda>etcb tcb'.
-    tcb_priority etcb = tcbPriority tcb'
-  \<and> tcb_time_slice etcb = tcbTimeSlice tcb'
-  \<and> tcb_domain etcb = tcbDomain tcb'"
-
-definition
- ekheap_relation :: "(obj_ref \<Rightarrow> etcb option) \<Rightarrow> (word32 \<rightharpoonup> Structures_H.kernel_object) \<Rightarrow> bool"
-where
- "ekheap_relation ab con \<equiv>
-    \<forall>x \<in> dom ab. \<exists>tcb'. con x = Some (KOTCB tcb') \<and> etcb_relation (the (ab x)) tcb'"
-
-primrec
-  sched_act_relation :: "Deterministic_A.scheduler_action \<Rightarrow> Structures_H.scheduler_action \<Rightarrow> bool"
-where
+primrec sched_act_relation :: "Structures_A.scheduler_action \<Rightarrow> scheduler_action \<Rightarrow> bool"
+  where
   "sched_act_relation resume_cur_thread a' = (a' = ResumeCurrentThread)" |
   "sched_act_relation choose_new_thread a' = (a' = ChooseNewThread)" |
   "sched_act_relation (switch_thread x) a' = (a' = SwitchToThread x)"
@@ -455,8 +440,8 @@ lemma list_queue_relation_nil:
   by (fastforce dest: heap_path_head simp: tcbQueueEmpty_def list_queue_relation_def)
 
 definition ready_queue_relation ::
-  "Deterministic_A.domain \<Rightarrow> Structures_A.priority
-   \<Rightarrow> Deterministic_A.ready_queue \<Rightarrow> ready_queue
+  "Structures_A.domain \<Rightarrow> Structures_A.priority
+   \<Rightarrow> Structures_A.ready_queue \<Rightarrow> ready_queue
    \<Rightarrow> (obj_ref \<rightharpoonup> obj_ref) \<Rightarrow> (obj_ref \<rightharpoonup> obj_ref)
    \<Rightarrow> (obj_ref \<Rightarrow> bool) \<Rightarrow> bool"
   where
@@ -466,7 +451,7 @@ definition ready_queue_relation ::
      \<and> (d > maxDomain \<or> p > maxPriority \<longrightarrow> tcbQueueEmpty q')"
 
 definition ready_queues_relation_2 ::
-  "(Deterministic_A.domain \<Rightarrow> Structures_A.priority \<Rightarrow> Deterministic_A.ready_queue)
+  "(Structures_A.domain \<Rightarrow> Structures_A.priority \<Rightarrow> Structures_A.ready_queue)
    \<Rightarrow> (domain \<times> priority \<Rightarrow> ready_queue)
    \<Rightarrow> (obj_ref \<rightharpoonup> obj_ref) \<Rightarrow> (obj_ref \<rightharpoonup> obj_ref)
    \<Rightarrow> (domain \<Rightarrow> priority \<Rightarrow> obj_ref \<Rightarrow> bool) \<Rightarrow> bool"
@@ -645,7 +630,6 @@ definition
 where
  "state_relation \<equiv> {(s, s').
          pspace_relation (kheap s) (ksPSpace s')
-       \<and> ekheap_relation (ekheap s) (ksPSpace s')
        \<and> sched_act_relation (scheduler_action s) (ksSchedulerAction s')
        \<and> ready_queues_relation s s'
        \<and> ghost_relation (kheap s) (gsUserPages s') (gsCNodes s')
@@ -677,10 +661,6 @@ lemma state_relation_pspace_relation[elim!]:
   "(s,s') \<in> state_relation \<Longrightarrow> pspace_relation (kheap s) (ksPSpace s')"
   by (simp add: state_relation_def)
 
-lemma state_relation_ekheap_relation[elim!]:
-  "(s,s') \<in> state_relation \<Longrightarrow> ekheap_relation (ekheap s) (ksPSpace s')"
-  by (simp add: state_relation_def)
-
 lemma state_relation_sched_act_relation[elim!]:
   "(s,s') \<in> state_relation \<Longrightarrow> sched_act_relation (scheduler_action s) (ksSchedulerAction s')"
   by (clarsimp simp: state_relation_def)
@@ -696,7 +676,6 @@ lemma state_relation_idle_thread[elim!]:
 lemma state_relationD:
   assumes sr:  "(s, s') \<in> state_relation"
   shows "pspace_relation (kheap s) (ksPSpace s') \<and>
-  ekheap_relation (ekheap s) (ksPSpace s') \<and>
   sched_act_relation (scheduler_action s) (ksSchedulerAction s') \<and>
   ready_queues_relation s s' \<and>
   ghost_relation (kheap s) (gsUserPages s') (gsCNodes s') \<and>
@@ -718,7 +697,6 @@ lemma state_relationD:
 lemma state_relationE [elim?]:
   assumes sr:  "(s, s') \<in> state_relation"
   and rl: "\<lbrakk>pspace_relation (kheap s) (ksPSpace s');
-  ekheap_relation (ekheap s) (ksPSpace s');
   sched_act_relation (scheduler_action s) (ksSchedulerAction s');
   ready_queues_relation s s';
   ghost_relation (kheap s) (gsUserPages s') (gsCNodes s');
@@ -772,11 +750,6 @@ lemma pspace_relation_absD:
   apply (rule rev_bexI, erule domI)
   apply (simp add: image_def rev_bexI)
   done
-
-lemma ekheap_relation_absD:
-  "\<lbrakk> ab x = Some y; ekheap_relation ab con \<rbrakk>
-      \<Longrightarrow> \<exists>tcb'. con x = Some (KOTCB tcb') \<and> etcb_relation y tcb'"
-  by (force simp add: ekheap_relation_def)
 
 lemma in_related_pspace_dom:
   "\<lbrakk> s' x = Some y; pspace_relation s s' \<rbrakk> \<Longrightarrow> x \<in> pspace_dom s"

--- a/proof/refine/ARM_HYP/Syscall_R.thy
+++ b/proof/refine/ARM_HYP/Syscall_R.thy
@@ -351,7 +351,7 @@ lemma threadSet_tcbDomain_update_sch_act_wf[wp]:
 
 lemma setDomain_corres:
   "corres dc
-     (valid_etcbs and valid_sched and tcb_at tptr and pspace_aligned and pspace_distinct)
+     (valid_sched and tcb_at tptr and pspace_aligned and pspace_distinct)
      (invs' and sch_act_simple and tcb_at' tptr and (\<lambda>s. new_dom \<le> maxDomain))
      (set_domain tptr new_dom) (setDomain tptr new_dom)"
   apply (rule corres_gen_asm2)
@@ -360,8 +360,8 @@ lemma setDomain_corres:
     apply (rule corres_split[OF getCurThread_corres])
       apply (rule corres_split[OF tcbSchedDequeue_corres], simp)
         apply (rule corres_split)
-           apply (rule ethread_set_corres; simp)
-           apply (clarsimp simp: etcb_relation_def)
+           apply (rule threadSet_not_queued_corres;
+                  simp add: tcb_relation_def tcb_cap_cases_def tcb_cte_cases_def cteSizeBits_def)
           apply (rule corres_split[OF isRunnable_corres])
             apply simp
             apply (rule corres_split)
@@ -374,9 +374,9 @@ lemma setDomain_corres:
             apply ((wpsimp wp: hoare_drop_imps | strengthen valid_objs'_valid_tcbs')+)[1]
            apply (wpsimp wp: gts_wp)
           apply wpsimp
-         apply ((wpsimp wp: hoare_vcg_imp_lift' ethread_set_not_queued_valid_queues hoare_vcg_all_lift
-                 | strengthen valid_objs'_valid_tcbs' valid_queues_in_correct_ready_q
-                              valid_queues_ready_qs_distinct)+)[1]
+         apply (wpsimp wp: hoare_vcg_imp_lift' hoare_vcg_all_lift
+                           thread_set_in_correct_ready_q_not_queued thread_set_no_change_tcb_state
+                           thread_set_no_change_tcb_state_converse thread_set_weak_valid_sched_action)
         apply (rule_tac Q'="\<lambda>_. valid_objs' and sym_heap_sched_pointers and valid_sched_pointers
                                and pspace_aligned' and pspace_distinct'
                                and (\<lambda>s. sch_act_wf (ksSchedulerAction s) s) and tcb_at' tptr"
@@ -385,7 +385,7 @@ lemma setDomain_corres:
         apply (wpsimp wp: threadSet_valid_objs' threadSet_sched_pointers
                           threadSet_valid_sched_pointers)+
        apply (rule_tac Q'="\<lambda>_ s. valid_queues s \<and> not_queued tptr s
-                                \<and> pspace_aligned s \<and> pspace_distinct s \<and> valid_etcbs s
+                                \<and> pspace_aligned s \<and> pspace_distinct s
                                 \<and> weak_valid_sched_action s"
                     in hoare_post_imp)
         apply (fastforce simp: pred_tcb_at_def obj_at_def)
@@ -399,10 +399,7 @@ lemma setDomain_corres:
        apply (clarsimp simp: tcb_cte_cases_def cteSizeBits_def)
        apply fastforce
       apply (wp hoare_vcg_all_lift tcbSchedDequeue_not_queued)+
-   apply clarsimp
-   apply (frule tcb_at_is_etcb_at)
-    apply simp+
-   apply (auto elim: tcb_at_is_etcb_at valid_objs'_maxDomain valid_objs'_maxPriority pred_tcb'_weakenE
+   apply (auto elim: valid_objs'_maxDomain valid_objs'_maxPriority pred_tcb'_weakenE
                simp: valid_sched_def valid_sched_action_def)
   done
 
@@ -1627,8 +1624,7 @@ lemma handleYield_corres:
                 | strengthen valid_objs'_valid_tcbs' valid_queues_in_correct_ready_q
                   valid_queues_ready_qs_distinct)+
    apply (simp add: invs_def valid_sched_def valid_sched_action_def cur_tcb_def
-                    tcb_at_is_etcb_at valid_state_def valid_pspace_def ct_in_state_def
-                    runnable_eq_active)
+                    valid_state_def valid_pspace_def ct_in_state_def runnable_eq_active)
   apply (fastforce simp: invs'_def valid_state'_def ct_in_state'_def sch_act_wf_weak cur_tcb'_def
                         valid_pspace_valid_objs' valid_objs'_maxDomain tcb_in_cur_domain'_def)
   done
@@ -1861,12 +1857,6 @@ lemma handleReply_nonz_cap_to_ct:
 
 crunch handleFaultReply
   for ksQ[wp]: "\<lambda>s. P (ksReadyQueues s p)"
-
-crunch possible_switch_to
-  for valid_etcbs[wp]: "valid_etcbs"
-crunch handle_recv
-  for valid_etcbs[wp]: "valid_etcbs"
-  (wp: crunch_wps simp: crunch_simps)
 
 lemma handleReply_handleRecv_corres:
   "corres dc (einvs and ct_running)

--- a/proof/refine/ARM_HYP/TcbAcc_R.thy
+++ b/proof/refine/ARM_HYP/TcbAcc_R.thy
@@ -337,29 +337,27 @@ lemma setObject_update_TCB_corres':
   assumes tables': "\<forall>(getF, v) \<in> ran tcb_cte_cases. getF new_tcb' = getF tcb'"
   assumes sched_pointers: "tcbSchedPrev new_tcb' = tcbSchedPrev tcb'"
                           "tcbSchedNext new_tcb' = tcbSchedNext tcb'"
-  assumes flag: "tcbQueued new_tcb' = tcbQueued tcb'"
+  assumes flag: "\<And>d p. inQ d p new_tcb' = inQ d p tcb'"
   assumes r: "r () ()"
-  assumes exst: "exst_same tcb' new_tcb'"
   shows
     "corres r
        (ko_at (TCB tcb) ptr) (ko_at' tcb' ptr)
        (set_object ptr (TCB new_tcb)) (setObject ptr new_tcb')"
-  apply (rule_tac F="tcb_relation tcb tcb' \<and> exst_same tcb' new_tcb'" in corres_req)
+  apply (rule_tac F="tcb_relation tcb tcb'" in corres_req)
    apply (clarsimp simp: state_relation_def obj_at_def obj_at'_def)
    apply (frule(1) pspace_relation_absD)
-   apply (clarsimp simp: projectKOs tcb_relation_cut_def exst)
+   apply (clarsimp simp: projectKOs tcb_relation_cut_def)
   apply (rule corres_no_failI)
-   apply (rule no_fail_pre)
-    apply wp
+   apply wp
    apply (clarsimp simp: obj_at'_def)
   apply (unfold set_object_def setObject_def)
   apply (clarsimp simp: in_monad split_def bind_def gets_def get_def Bex_def
                         put_def return_def modify_def get_object_def projectKOs obj_at_def
-                        updateObject_default_def in_magnitude_check obj_at'_def)
-  apply (rename_tac s s' t')
-  apply (prop_tac "t' = s'")
-   apply (clarsimp simp: magnitudeCheck_def in_monad split: option.splits)
-  apply (drule singleton_in_magnitude_check)
+                        updateObject_default_def in_magnitude_check objBits_less_word_bits)
+  apply (rename_tac s s' ko)
+  apply (prop_tac "ko = tcb'")
+   apply (clarsimp simp: obj_at'_def projectKOs project_inject)
+  apply (clarsimp simp: state_relation_def)
   apply (prop_tac "map_to_ctes ((ksPSpace s') (ptr \<mapsto> injectKO new_tcb'))
                    = map_to_ctes (ksPSpace s')")
    apply (frule_tac tcb=new_tcb' and tcb=tcb' in map_to_ctes_upd_tcb)
@@ -367,75 +365,59 @@ lemma setObject_update_TCB_corres':
     apply (clarsimp simp: objBits_simps ps_clear_def3 field_simps objBits_defs mask_def)
    apply (insert tables')[1]
    apply (rule ext)
-   apply (clarsimp split: if_splits)
-   apply blast
+   subgoal by auto
   apply (prop_tac "obj_at (same_caps (TCB new_tcb)) ptr s")
    using tables
    apply (fastforce simp: obj_at_def)
-  apply (clarsimp simp: caps_of_state_after_update cte_wp_at_after_update swp_def
+  apply (clarsimp simp: caps_of_state_after_update cte_wp_at_after_update swp_def fun_upd_def
                         obj_at_def assms)
-  apply (clarsimp simp add: state_relation_def)
   apply (subst conj_assoc[symmetric])
   apply (extract_conjunct \<open>match conclusion in "ghost_relation _ _ _" \<Rightarrow> -\<close>)
-   apply (clarsimp simp add: ghost_relation_def)
+   apply (clarsimp simp: ghost_relation_def)
    apply (erule_tac x=ptr in allE)+
    apply clarsimp
-  apply (simp only: pspace_relation_def pspace_dom_update dom_fun_upd2 simp_thms)
-  apply (elim conjE)
-  apply (frule bspec, erule domI)
-  apply clarsimp
-  apply (rule conjI)
+  apply (extract_conjunct \<open>match conclusion in "pspace_relation _ _" \<Rightarrow> -\<close>)
+   apply (fold fun_upd_def)
    apply (simp only: pspace_relation_def simp_thms
                      pspace_dom_update[where x="kernel_object.TCB _"
                                          and v="kernel_object.TCB _",
                                        simplified a_type_def, simplified])
-  apply (rule conjI)
    using assms
    apply (simp only: dom_fun_upd2 simp_thms)
+   apply (elim conjE)
    apply (frule bspec, erule domI)
    apply (rule ballI, drule(1) bspec)
    apply (drule domD)
-   apply (clarsimp simp: tcb_relation_cut_def project_inject split: if_split_asm kernel_object.split_asm)
+   apply (clarsimp simp: project_inject tcb_relation_cut_def
+                  split: if_split_asm kernel_object.split_asm)
    apply (rename_tac aa ba)
    apply (drule_tac x="(aa, ba)" in bspec, simp)
    apply clarsimp
    apply (frule_tac ko'="kernel_object.TCB tcb" and x'=ptr in obj_relation_cut_same_type)
       apply (simp add: tcb_relation_cut_def)+
    apply clarsimp
-  apply (extract_conjunct \<open>match conclusion in "ekheap_relation _ _" \<Rightarrow> -\<close>)
-   apply (simp only: ekheap_relation_def)
-   apply (rule ballI, drule (1) bspec)
-   apply (insert exst)
-   apply (clarsimp simp: etcb_relation_def exst_same_def)
-  apply (extract_conjunct \<open>match conclusion in "ready_queues_relation_2 _ _ _ _ _" \<Rightarrow> -\<close>)
-   apply (insert sched_pointers flag exst)
-   apply (clarsimp simp: ready_queues_relation_def Let_def)
-   apply (prop_tac "(tcbSchedNexts_of s')(ptr := tcbSchedNext new_tcb') = tcbSchedNexts_of s'")
-    apply (fastforce simp: opt_map_def)
-   apply (prop_tac "(tcbSchedPrevs_of s')(ptr := tcbSchedPrev new_tcb') = tcbSchedPrevs_of s'")
-    apply (fastforce simp: opt_map_def)
-   apply (clarsimp simp: ready_queue_relation_def opt_pred_def opt_map_def exst_same_def
-                         inQ_def projectKOs
-                  split: option.splits)
-   apply (metis (mono_tags, opaque_lifting))
-  apply (clarsimp simp: fun_upd_def caps_of_state_after_update cte_wp_at_after_update swp_def
-                        obj_at_def)
-  done
+  apply (insert sched_pointers flag)
+  apply (clarsimp simp: ready_queues_relation_def Let_def)
+  apply (prop_tac "(tcbSchedNexts_of s')(ptr := tcbSchedNext new_tcb') = tcbSchedNexts_of s'")
+   apply (fastforce simp: opt_map_def)
+  apply (prop_tac "(tcbSchedPrevs_of s')(ptr := tcbSchedPrev new_tcb') = tcbSchedPrevs_of s'")
+   apply (fastforce simp: opt_map_def)
+  by (clarsimp simp: ready_queue_relation_def opt_pred_def opt_map_def split: option.splits)
 
 lemma setObject_update_TCB_corres:
   "\<lbrakk>tcb_relation tcb tcb' \<Longrightarrow> tcb_relation new_tcb new_tcb';
      \<forall>(getF, v) \<in> ran tcb_cap_cases. getF new_tcb = getF tcb;
      \<forall>(getF, v) \<in> ran tcb_cte_cases. getF new_tcb' = getF tcb';
      tcbSchedPrev new_tcb' = tcbSchedPrev tcb'; tcbSchedNext new_tcb' = tcbSchedNext tcb';
-     tcbQueued new_tcb' = tcbQueued tcb'; exst_same tcb' new_tcb';
+     \<And>d p. inQ d p new_tcb' = inQ d p tcb';
      r () ()\<rbrakk> \<Longrightarrow>
    corres r
      (\<lambda>s. get_tcb ptr s = Some tcb) (\<lambda>s'. (tcb', s') \<in> fst (getObject ptr s'))
      (set_object ptr (TCB new_tcb)) (setObject ptr new_tcb')"
   apply (rule corres_guard_imp)
-    apply (erule (7) setObject_update_TCB_corres')
-   apply (clarsimp simp: getObject_def in_monad split_def obj_at'_def
-                         loadObject_default_def objBits_simps' in_magnitude_check projectKOs)+
+    apply (erule (4) setObject_update_TCB_corres'; fastforce)
+   apply (clarsimp simp: getObject_def in_monad split_def obj_at'_def projectKOs
+                         loadObject_default_def objBits_simps' in_magnitude_check)+
   done
 
 lemma getObject_TCB_corres:
@@ -487,8 +469,7 @@ lemma threadset_corresT:
                  getF (f' tcb) = getF tcb"
   assumes sched_pointers: "\<And>tcb. tcbSchedPrev (f' tcb) = tcbSchedPrev tcb"
                           "\<And>tcb. tcbSchedNext (f' tcb) = tcbSchedNext tcb"
-  assumes flag: "\<And>tcb. tcbQueued (f' tcb) = tcbQueued tcb"
-  assumes e: "\<And>tcb'. exst_same tcb' (f' tcb')"
+  assumes flag: "\<And>d p tcb'. inQ d p (f' tcb') = inQ d p tcb'"
   shows      "corres dc (tcb_at t and pspace_aligned and pspace_distinct)
                         \<top>
                         (thread_set f t) (threadSet f' t)"
@@ -496,15 +477,14 @@ lemma threadset_corresT:
   apply (rule corres_guard_imp)
     apply (rule corres_split[OF getObject_TCB_corres])
       apply (rule setObject_update_TCB_corres')
-             apply (erule x)
-            apply (rule y)
-           apply (clarsimp simp: bspec_split [OF spec [OF z]])
-           apply fastforce
-          apply (rule sched_pointers)
+            apply (erule x)
+           apply (rule y)
+          apply (clarsimp simp: bspec_split [OF spec [OF z]])
+          apply fastforce
          apply (rule sched_pointers)
-        apply (rule flag)
-       apply simp
-      apply (rule e)
+        apply (rule sched_pointers)
+       apply (rule flag)
+      apply simp
      apply wp+
    apply (clarsimp simp add: tcb_at_def obj_at_def)
    apply (drule get_tcb_SomeD)
@@ -534,8 +514,7 @@ lemma threadSet_corres_noopT:
                  getF (fn tcb) = getF tcb"
   assumes s: "\<forall>tcb'. tcbSchedPrev (fn tcb') = tcbSchedPrev tcb'"
              "\<forall>tcb'. tcbSchedNext (fn tcb') = tcbSchedNext tcb'"
-  assumes f: "\<And>tcb'. tcbQueued (fn tcb') = tcbQueued tcb'"
-  assumes e: "\<And>tcb'. exst_same tcb' (fn tcb')"
+  assumes f: "\<And>d p tcb'. inQ d p (fn tcb') = inQ d p tcb'"
   shows      "corres dc (tcb_at t and pspace_aligned and pspace_distinct) \<top>
                         (return v) (threadSet fn t)"
 proof -
@@ -553,13 +532,12 @@ proof -
        defer
        apply (subst bind_return [symmetric],
               rule corres_underlying_split [OF threadset_corresT])
-                apply (simp add: x)
-               apply simp
-              apply (rule y)
-             apply (fastforce simp: s)
+               apply (simp add: x)
+              apply simp
+             apply (rule y)
             apply (fastforce simp: s)
-           apply (fastforce simp: f)
-          apply (rule e)
+           apply (fastforce simp: s)
+          apply (fastforce simp: f)
          apply (rule corres_noop [where P=\<top> and P'=\<top>])
           apply wpsimp+
     done
@@ -577,19 +555,17 @@ lemma threadSet_corres_noop_splitT:
   assumes w: "\<lbrace>P'\<rbrace> threadSet fn t \<lbrace>\<lambda>x. Q'\<rbrace>"
   assumes s: "\<forall>tcb'. tcbSchedPrev (fn tcb') = tcbSchedPrev tcb'"
              "\<forall>tcb'. tcbSchedNext (fn tcb') = tcbSchedNext tcb'"
-  assumes f: "\<And>tcb'. tcbQueued (fn tcb') = tcbQueued tcb'"
-  assumes e: "\<And>tcb'. exst_same tcb' (fn tcb')"
+  assumes f: "\<And>d p tcb'. inQ d p (fn tcb') = inQ d p tcb'"
   shows      "corres r (tcb_at t and pspace_aligned and pspace_distinct and P) P'
                            m (threadSet fn t >>= (\<lambda>rv. m'))"
   apply (rule corres_guard_imp)
     apply (subst return_bind[symmetric])
     apply (rule corres_split_nor[OF threadSet_corres_noopT])
-            apply (simp add: x)
-           apply (rule y)
-          apply (fastforce simp: s)
+           apply (simp add: x)
+          apply (rule y)
          apply (fastforce simp: s)
-        apply (fastforce simp: f)
-       apply (rule e)
+        apply (fastforce simp: s)
+       apply (fastforce simp: f)
       apply (rule z)
      apply (wp w)+
    apply simp
@@ -1574,7 +1550,7 @@ lemma asUser_corres':
                      (set_object add (TCB (tcb \<lparr> tcb_arch := arch_tcb_context_set con (tcb_arch tcb) \<rparr>)))
                      (setObject add (tcb' \<lparr> tcbArch := atcbContextSet con' (tcbArch tcb') \<rparr>))"
     by (rule setObject_update_TCB_corres [OF L2],
-        (simp add: tcb_cte_cases_def tcb_cte_cases_neqs tcb_cap_cases_def exst_same_def)+)
+        (simp add: tcb_cte_cases_def tcb_cte_cases_neqs tcb_cap_cases_def)+)
   have L4: "\<And>con con'. con = con' \<Longrightarrow>
             corres (\<lambda>(irv, nc) (irv', nc'). r irv irv' \<and> nc = nc')
                    \<top> \<top> (select_f (f con)) (select_f (g con'))"
@@ -1944,41 +1920,6 @@ lemma fun_if_triv[simp]:
   "(\<lambda>x. if x = y then f y else f x) = f"
   by (force)
 
-lemma corres_get_etcb:
-  "corres (etcb_relation) (is_etcb_at t) (tcb_at' t)
-                    (gets_the (get_etcb t)) (getObject t)"
-  apply (rule corres_no_failI)
-   apply wp
-  apply (clarsimp simp add: get_etcb_def gets_the_def gets_def
-                            get_def assert_opt_def bind_def
-                            return_def fail_def
-                            split: option.splits
-                            )
-  apply (frule in_inv_by_hoareD [OF getObject_inv_tcb])
-  apply (clarsimp simp add: is_etcb_at_def obj_at'_def projectKO_def
-                            projectKO_opt_tcb split_def
-                            getObject_def loadObject_default_def in_monad)
-  apply (case_tac bb)
-        apply (simp_all add: fail_def return_def)
-  apply (clarsimp simp add: state_relation_def ekheap_relation_def)
-  apply (drule bspec)
-   apply clarsimp
-   apply blast
-  apply (clarsimp simp add: other_obj_relation_def lookupAround2_known1)
-  done
-
-
-lemma ethreadget_corres:
-  assumes x: "\<And>etcb tcb'. etcb_relation etcb tcb' \<Longrightarrow> r (f etcb) (f' tcb')"
-  shows      "corres r (is_etcb_at t) (tcb_at' t) (ethread_get f t) (threadGet f' t)"
-  apply (simp add: ethread_get_def threadGet_def)
-  apply (fold liftM_def)
-  apply simp
-  apply (rule corres_rel_imp)
-   apply (rule corres_get_etcb)
-  apply (simp add: x)
-  done
-
 lemma getQueue_corres:
   "corres (\<lambda>ls q. (ls = [] \<longleftrightarrow> tcbQueueEmpty q) \<and> (ls \<noteq> [] \<longrightarrow> tcbQueueHead q = Some (hd ls))
                   \<and> queue_end_valid ls q)
@@ -2029,13 +1970,14 @@ crunch removeFromBitmap
 lemmas addToBitmap_typ_ats [wp] = typ_at_lifts [OF addToBitmap_typ_at']
 lemmas removeFromBitmap_typ_ats [wp] = typ_at_lifts [OF removeFromBitmap_typ_at']
 
-lemma ekheap_relation_tcb_domain_priority:
-  "\<lbrakk>ekheap_relation (ekheap s) (ksPSpace s'); ekheap s t = Some (tcb);
+lemma pspace_relation_tcb_domain_priority:
+  "\<lbrakk>pspace_relation (kheap s) (ksPSpace s'); kheap s t = Some (TCB tcb);
     ksPSpace s' t = Some (KOTCB tcb')\<rbrakk>
    \<Longrightarrow> tcbDomain tcb' = tcb_domain tcb \<and> tcbPriority tcb' = tcb_priority tcb"
-  apply (clarsimp simp: ekheap_relation_def)
-  apply (drule_tac x=t in bspec, blast)
-  apply (clarsimp simp: other_obj_relation_def etcb_relation_def)
+  apply (clarsimp simp: pspace_relation_def)
+  apply (drule_tac x=t in bspec)
+   apply (fastforce simp: obj_at_def)
+  apply (clarsimp simp: obj_at_def obj_at'_def tcb_relation_cut_def tcb_relation_def)
   done
 
 lemma no_fail_thread_get[wp]:
@@ -2082,85 +2024,16 @@ lemma threadSet_pspace_relation:
   apply (fastforce dest!: tcb_rel)
   done
 
-lemma ekheap_relation_update_tcbs:
-  "\<lbrakk> ekheap_relation (ekheap s) (ksPSpace s'); ekheap s x = Some oetcb;
-     ksPSpace s' x = Some (KOTCB otcb'); etcb_relation etcb tcb' \<rbrakk>
-   \<Longrightarrow> ekheap_relation ((ekheap s)(x \<mapsto> etcb)) ((ksPSpace s')(x \<mapsto> KOTCB tcb'))"
-  by (simp add: ekheap_relation_def)
-
-lemma ekheap_relation_update_concrete_tcb:
-  "\<lbrakk>ekheap_relation (ekheap s) (ksPSpace s'); ekheap s ptr = Some etcb;
-    ksPSpace s' ptr = Some (KOTCB otcb');
-    etcb_relation etcb tcb'\<rbrakk>
-   \<Longrightarrow> ekheap_relation (ekheap s) ((ksPSpace s')(ptr \<mapsto> KOTCB tcb'))"
-  by (fastforce dest: ekheap_relation_update_tcbs simp: map_upd_triv)
-
-lemma ekheap_relation_etcb_relation:
-  "\<lbrakk>ekheap_relation (ekheap s) (ksPSpace s'); ekheap s ptr = Some etcb;
-    ksPSpace s' ptr = Some (KOTCB tcb')\<rbrakk>
-   \<Longrightarrow> etcb_relation etcb tcb'"
-  apply (clarsimp simp: ekheap_relation_def)
-  apply (drule_tac x=ptr in bspec)
-   apply (fastforce simp: obj_at_def)
-  apply (clarsimp simp: obj_at_def obj_at'_def)
-  done
-
-lemma threadSet_ekheap_relation:
-  fixes s :: det_state
-  assumes etcb_rel: "(\<And>etcb tcb'. etcb_relation etcb tcb' \<Longrightarrow> etcb_relation etcb (F tcb'))"
-  shows
-    "\<lbrace>\<lambda>s'. ekheap_relation (ekheap s) (ksPSpace s') \<and> pspace_relation (kheap s) (ksPSpace s')
-           \<and> valid_etcbs s\<rbrace>
-     threadSet F tcbPtr
-     \<lbrace>\<lambda>_ s'. ekheap_relation (ekheap s) (ksPSpace s')\<rbrace>"
-  supply fun_upd_apply[simp del]
-  unfolding threadSet_def setObject_def updateObject_default_def
-  apply (wpsimp wp: getObject_tcb_wp simp: updateObject_default_def)
-  apply (frule tcb_at'_cross)
-   apply (fastforce simp: obj_at'_def)
-  apply normalise_obj_at'
-  apply (frule (1) tcb_at_is_etcb_at)
-  apply (clarsimp simp: obj_at_def is_tcb_def is_etcb_at_def)
-  apply (rename_tac ko, case_tac ko; clarsimp)
-  apply (rule ekheap_relation_update_concrete_tcb)
-     apply fastforce
-    apply fastforce
-   apply (fastforce simp: obj_at'_def projectKOs)
-  apply (frule (1) ekheap_relation_etcb_relation)
-   apply (fastforce simp: obj_at'_def projectKOs)
-  apply (fastforce dest!: etcb_rel)
-  done
-
 lemma tcbQueued_update_pspace_relation[wp]:
   fixes s :: det_state
   shows "threadSet (tcbQueued_update f) tcbPtr \<lbrace>\<lambda>s'. pspace_relation (kheap s) (ksPSpace s')\<rbrace>"
   by (wpsimp wp: threadSet_pspace_relation simp: tcb_relation_def)
-
-lemma tcbQueued_update_ekheap_relation[wp]:
-  fixes s :: det_state
-  shows
-    "\<lbrace>\<lambda>s'. ekheap_relation (ekheap s) (ksPSpace s') \<and> pspace_relation (kheap s) (ksPSpace s')
-           \<and> valid_etcbs s\<rbrace>
-     threadSet (tcbQueued_update f) tcbPtr
-     \<lbrace>\<lambda>_ s'. ekheap_relation (ekheap s) (ksPSpace s')\<rbrace>"
-  by (wpsimp wp: threadSet_ekheap_relation simp: etcb_relation_def)
 
 lemma tcbQueueRemove_pspace_relation[wp]:
   fixes s :: det_state
   shows "tcbQueueRemove queue tcbPtr \<lbrace>\<lambda>s'. pspace_relation (kheap s) (ksPSpace s')\<rbrace>"
   unfolding tcbQueueRemove_def
   by (wpsimp wp: threadSet_pspace_relation hoare_drop_imps simp: tcb_relation_def)
-
-lemma tcbQueueRemove_ekheap_relation[wp]:
-  fixes s :: det_state
-  shows
-    "\<lbrace>\<lambda>s'. ekheap_relation (ekheap s) (ksPSpace s') \<and> pspace_relation (kheap s) (ksPSpace s')
-           \<and> valid_etcbs s\<rbrace>
-     tcbQueueRemove queue tcbPtr
-     \<lbrace>\<lambda>_ s'. ekheap_relation (ekheap s) (ksPSpace s')\<rbrace>"
-  unfolding tcbQueueRemove_def
-  by (wpsimp wp: threadSet_ekheap_relation threadSet_pspace_relation hoare_drop_imps
-           simp: tcb_relation_def etcb_relation_def)
 
 lemma threadSet_ghost_relation[wp]:
   "threadSet f tcbPtr \<lbrace>\<lambda>s'. ghost_relation (kheap s) (gsUserPages s') (gsCNodes s')\<rbrace>"
@@ -2199,7 +2072,7 @@ lemma set_tcb_queue_projs:
    \<lbrace>\<lambda>s. P (kheap s) (cdt s) (is_original_cap s) (cur_thread s) (idle_thread s) (scheduler_action s)
           (domain_list s) (domain_index s) (cur_domain s) (domain_time s) (machine_state s)
           (interrupt_irq_node s) (interrupt_states s) (arch_state s) (caps_of_state s)
-          (work_units_completed s) (cdt_list s) (ekheap s)\<rbrace>"
+          (work_units_completed s) (cdt_list s)\<rbrace>"
   by (wpsimp simp: set_tcb_queue_def)
 
 lemma set_tcb_queue_cte_at:
@@ -2212,7 +2085,6 @@ lemma set_tcb_queue_cte_at:
 lemma set_tcb_queue_projs_inv:
   "fst (set_tcb_queue d p queue s) = {(r, s')} \<Longrightarrow>
    kheap s = kheap s'
-   \<and> ekheap s = ekheap s'
    \<and> cdt s = cdt s'
    \<and> is_original_cap s = is_original_cap s'
    \<and> cur_thread s = cur_thread s'
@@ -2245,50 +2117,17 @@ lemma tcbQueuePrepend_pspace_relation[wp]:
   unfolding tcbQueuePrepend_def
   by (wpsimp wp: threadSet_pspace_relation simp: tcb_relation_def)
 
-lemma tcbQueuePrepend_ekheap_relation[wp]:
-  fixes s :: det_state
-  shows
-    "\<lbrace>\<lambda>s'. ekheap_relation (ekheap s) (ksPSpace s') \<and> pspace_relation (kheap s) (ksPSpace s')
-           \<and> valid_etcbs s\<rbrace>
-     tcbQueuePrepend queue tcbPtr
-     \<lbrace>\<lambda>_ s'. ekheap_relation (ekheap s) (ksPSpace s')\<rbrace>"
-  unfolding tcbQueuePrepend_def
-  by (wpsimp wp: threadSet_pspace_relation threadSet_ekheap_relation
-           simp: tcb_relation_def etcb_relation_def)
-
 lemma tcbQueueAppend_pspace_relation[wp]:
   fixes s :: det_state
   shows "tcbQueueAppend queue tcbPtr \<lbrace>\<lambda>s'. pspace_relation (kheap s) (ksPSpace s')\<rbrace>"
   unfolding tcbQueueAppend_def
   by (wpsimp wp: threadSet_pspace_relation simp: tcb_relation_def)
 
-lemma tcbQueueAppend_ekheap_relation[wp]:
-  fixes s :: det_state
-  shows
-    "\<lbrace>\<lambda>s'. ekheap_relation (ekheap s) (ksPSpace s') \<and> pspace_relation (kheap s) (ksPSpace s')
-           \<and> valid_etcbs s\<rbrace>
-     tcbQueueAppend queue tcbPtr
-     \<lbrace>\<lambda>_ s'. ekheap_relation (ekheap s) (ksPSpace s')\<rbrace>"
-  unfolding tcbQueueAppend_def
-  by (wpsimp wp: threadSet_pspace_relation threadSet_ekheap_relation
-           simp: tcb_relation_def etcb_relation_def)
-
 lemma tcbQueueInsert_pspace_relation[wp]:
   fixes s :: det_state
   shows "tcbQueueInsert tcbPtr afterPtr \<lbrace>\<lambda>s'. pspace_relation (kheap s) (ksPSpace s')\<rbrace>"
   unfolding tcbQueueInsert_def
   by (wpsimp wp: threadSet_pspace_relation hoare_drop_imps simp: tcb_relation_def)
-
-lemma tcbQueueInsert_ekheap_relation[wp]:
-  fixes s :: det_state
-  shows
-    "\<lbrace>\<lambda>s'. ekheap_relation (ekheap s) (ksPSpace s') \<and> pspace_relation (kheap s) (ksPSpace s')
-           \<and> valid_etcbs s\<rbrace>
-     tcbQueueInsert tcbPtr afterPtr
-     \<lbrace>\<lambda>_ s'. ekheap_relation (ekheap s) (ksPSpace s')\<rbrace>"
-  unfolding tcbQueueInsert_def
-  by (wpsimp wp: threadSet_pspace_relation threadSet_ekheap_relation hoare_drop_imps
-           simp: tcb_relation_def etcb_relation_def)
 
 lemma removeFromBitmap_pspace_relation[wp]:
   fixes s :: det_state
@@ -2370,22 +2209,22 @@ lemma threadSet_ready_queues_relation:
 definition in_correct_ready_q_2 where
   "in_correct_ready_q_2 queues ekh \<equiv>
      \<forall>d p. \<forall>t \<in> set (queues d p). is_etcb_at' t ekh
-                                  \<and> etcb_at' (\<lambda>t. tcb_priority t = p \<and> tcb_domain t = d) t ekh"
+                                  \<and> etcb_at' (\<lambda>t. etcb_priority t = p \<and> etcb_domain t = d) t ekh"
 
-abbreviation in_correct_ready_q :: "det_ext state \<Rightarrow> bool" where
-  "in_correct_ready_q s \<equiv> in_correct_ready_q_2 (ready_queues s) (ekheap s)"
+abbreviation in_correct_ready_q :: "'z state \<Rightarrow> bool" where
+  "in_correct_ready_q s \<equiv> in_correct_ready_q_2 (ready_queues s) (etcbs_of s)"
 
 lemmas in_correct_ready_q_def = in_correct_ready_q_2_def
 
 lemma in_correct_ready_q_lift:
-  assumes c: "\<And>P. \<lbrace>\<lambda>s. P (ekheap s)\<rbrace> f \<lbrace>\<lambda>rv s. P (ekheap s)\<rbrace>"
+  assumes c: "\<And>P. f \<lbrace>\<lambda>s. P (etcbs_of s)\<rbrace>"
   assumes r: "\<And>P. f \<lbrace>\<lambda>s. P (ready_queues s)\<rbrace>"
   shows "f \<lbrace>in_correct_ready_q\<rbrace>"
   apply (rule hoare_pre)
    apply (wps assms | wpsimp)+
   done
 
-definition ready_qs_distinct :: "det_ext state \<Rightarrow> bool" where
+definition ready_qs_distinct :: "'z state \<Rightarrow> bool" where
   "ready_qs_distinct s \<equiv> \<forall>d p. distinct (ready_queues s d p)"
 
 lemma ready_qs_distinct_lift:
@@ -2482,28 +2321,6 @@ lemma thread_get_exs_valid[wp]:
   by (clarsimp simp: thread_get_def get_tcb_def gets_the_def gets_def return_def get_def
                      exs_valid_def tcb_at_def bind_def)
 
-lemma ethread_get_sp:
-  "\<lbrace>P\<rbrace> ethread_get f ptr
-   \<lbrace>\<lambda>rv. etcb_at (\<lambda>tcb. f tcb = rv) ptr and P\<rbrace>"
-  apply wpsimp
-  apply (clarsimp simp: etcb_at_def split: option.splits)
-  done
-
-lemma ethread_get_exs_valid[wp]:
-  "\<lbrakk>tcb_at tcb_ptr s; valid_etcbs s\<rbrakk> \<Longrightarrow> \<lbrace>(=) s\<rbrace> ethread_get f tcb_ptr \<exists>\<lbrace>\<lambda>_. (=) s\<rbrace>"
-  apply (frule (1) tcb_at_is_etcb_at)
-  apply (clarsimp simp: ethread_get_def get_etcb_def gets_the_def gets_def return_def get_def
-                        is_etcb_at_def exs_valid_def bind_def)
-  done
-
-lemma no_fail_ethread_get[wp]:
-  "no_fail (tcb_at tcb_ptr and valid_etcbs) (ethread_get f tcb_ptr)"
-  unfolding ethread_get_def
-  apply wpsimp
-  apply (frule (1) tcb_at_is_etcb_at)
-  apply (clarsimp simp: is_etcb_at_def get_etcb_def)
-  done
-
 lemma threadGet_sp:
   "\<lbrace>P\<rbrace> threadGet f ptr \<lbrace>\<lambda>rv s. \<exists>tcb :: tcb. ko_at' tcb ptr s \<and> f tcb = rv \<and> P s\<rbrace>"
   unfolding threadGet_def setObject_def
@@ -2530,7 +2347,7 @@ lemma in_ready_q_tcbQueued_eq:
 lemma tcbSchedEnqueue_corres:
   "tcb_ptr = tcbPtr \<Longrightarrow>
    corres dc
-     (in_correct_ready_q and ready_qs_distinct and valid_etcbs and st_tcb_at runnable tcb_ptr
+     (in_correct_ready_q and ready_qs_distinct and st_tcb_at runnable tcb_ptr
       and pspace_aligned and pspace_distinct)
      (sym_heap_sched_pointers and valid_sched_pointers and valid_tcbs')
      (tcb_sched_action tcb_sched_enqueue tcb_ptr) (tcbSchedEnqueue tcbPtr)"
@@ -2547,9 +2364,9 @@ lemma tcbSchedEnqueue_corres:
    apply (fastforce dest: pspace_distinct_cross)
   apply (clarsimp simp: tcb_sched_action_def tcb_sched_enqueue_def get_tcb_queue_def
                         tcbSchedEnqueue_def getQueue_def unless_def when_def)
-  apply (rule corres_symb_exec_l[OF _ _ ethread_get_sp]; (solves wpsimp)?)
+  apply (rule corres_symb_exec_l[OF _ _ thread_get_sp]; (solves wpsimp)?)
   apply (rename_tac domain)
-  apply (rule corres_symb_exec_l[OF _ _ ethread_get_sp]; (solves wpsimp)?)
+  apply (rule corres_symb_exec_l[OF _ _ thread_get_sp]; (solves wpsimp)?)
   apply (rename_tac priority)
   apply (rule corres_symb_exec_l[OF _ _ gets_sp]; (solves wpsimp)?)
   apply (rule corres_stateAssert_ignore)
@@ -2561,12 +2378,11 @@ lemma tcbSchedEnqueue_corres:
   apply (rule corres_symb_exec_r[OF _ threadGet_sp]; (solves wpsimp)?)
   apply (subst if_distrib[where f="set_tcb_queue domain prio" for domain prio])
   apply (rule corres_if_strong')
-    apply (frule state_relation_ready_queues_relation)
-    apply (frule in_ready_q_tcbQueued_eq[where t=tcbPtr])
     subgoal
-      by (fastforce dest: tcb_at_ekheap_dom pred_tcb_at_tcb_at
-                    simp: obj_at'_def opt_pred_def opt_map_def obj_at_def is_tcb_def
-                          in_correct_ready_q_def etcb_at_def is_etcb_at_def)
+      by (fastforce dest!: state_relation_ready_queues_relation
+                           in_ready_q_tcbQueued_eq[where t=tcbPtr]
+                     simp: obj_at'_def opt_pred_def opt_map_def in_correct_ready_q_def
+                           obj_at_def etcb_at_def etcbs_of'_def)
    apply (find_goal \<open>match conclusion in "corres _ _ _ _ (return ())" \<Rightarrow> \<open>-\<close>\<close>)
    apply (rule monadic_rewrite_corres_l[where P=P and Q=P for P, simplified])
     apply (clarsimp simp: set_tcb_queue_def)
@@ -2613,19 +2429,18 @@ lemma tcbSchedEnqueue_corres:
   apply (drule set_tcb_queue_new_state)
   apply (wpsimp wp: threadSet_wp getObject_tcb_wp simp: setQueue_def tcbQueuePrepend_def)
   apply normalise_obj_at'
-  apply (frule (1) tcb_at_is_etcb_at)
-  apply (clarsimp simp: obj_at_def is_etcb_at_def etcb_at_def)
-  apply (rename_tac s d p s' tcb' tcb etcb)
-  apply (frule_tac t=tcbPtr in ekheap_relation_tcb_domain_priority)
+  apply (clarsimp simp: obj_at_def)
+  apply (rename_tac s d p s' tcb' tcb)
+  apply (frule_tac t=tcbPtr in pspace_relation_tcb_domain_priority)
     apply (force simp: obj_at_def)
    apply (force simp: obj_at'_def)
   apply (clarsimp split: if_splits)
   apply (cut_tac ts="ready_queues s d p" in list_queue_relation_nil)
    apply (force dest!: spec simp: list_queue_relation_def)
-  apply (cut_tac ts="ready_queues s (tcb_domain etcb) (tcb_priority etcb)"
+  apply (cut_tac ts="ready_queues s (tcb_domain tcb) (tcb_priority tcb)"
               in list_queue_relation_nil)
    apply (force dest!: spec simp: list_queue_relation_def)
-  apply (cut_tac ts="ready_queues s (tcb_domain etcb) (tcb_priority etcb)" and s'=s'
+  apply (cut_tac ts="ready_queues s (tcb_domain tcb) (tcb_priority tcb)" and s'=s'
               in obj_at'_tcbQueueEnd_ksReadyQueues)
       apply fast
      apply auto[1]
@@ -2634,14 +2449,14 @@ lemma tcbSchedEnqueue_corres:
   apply (cut_tac xs="ready_queues s d p" and st="tcbQueueHead (ksReadyQueues s' (d, p))"
               in heap_path_head')
    apply (auto dest: spec simp: list_queue_relation_def tcbQueueEmpty_def)[1]
-  apply (cut_tac xs="ready_queues s (tcb_domain etcb) (tcb_priority etcb)"
-             and st="tcbQueueHead (ksReadyQueues s' (tcb_domain etcb, tcb_priority etcb))"
+  apply (cut_tac xs="ready_queues s (tcb_domain tcb) (tcb_priority tcb)"
+             and st="tcbQueueHead (ksReadyQueues s' (tcb_domain tcb, tcb_priority tcb))"
               in heap_path_head')
    apply (auto dest: spec simp: list_queue_relation_def tcbQueueEmpty_def)[1]
   apply (clarsimp simp: list_queue_relation_def)
 
-  apply (case_tac "\<not> (d = tcb_domain etcb \<and> p = tcb_priority etcb)")
-   apply (cut_tac d=d and d'="tcb_domain etcb" and p=p and p'="tcb_priority etcb"
+  apply (case_tac "\<not> (d = tcb_domain tcb \<and> p = tcb_priority tcb)")
+   apply (cut_tac d=d and d'="tcb_domain tcb" and p=p and p'="tcb_priority tcb"
                in ready_queues_disjoint)
       apply force
      apply fastforce
@@ -2665,8 +2480,8 @@ lemma tcbSchedEnqueue_corres:
     apply (clarsimp simp: fun_upd_apply split: if_splits)
 
    \<comment> \<open>the ready queue was not originally empty\<close>
-   apply (clarsimp simp: etcb_at_def obj_at'_def)
-   apply (prop_tac "the (tcbQueueHead (ksReadyQueues s' (tcb_domain etcb, tcb_priority etcb)))
+   apply (clarsimp simp: obj_at'_def)
+   apply (prop_tac "the (tcbQueueHead (ksReadyQueues s' (tcb_domain tcb, tcb_priority tcb)))
                     \<notin> set (ready_queues s d p)")
     apply (erule orthD2)
     apply (clarsimp simp: tcbQueueEmpty_def)
@@ -2684,7 +2499,7 @@ lemma tcbSchedEnqueue_corres:
       apply (case_tac "ready_queues s d p"; force simp: tcbQueueEmpty_def)
      apply (case_tac "t = tcbPtr")
       apply (clarsimp simp: inQ_def fun_upd_apply obj_at'_def split: if_splits)
-     apply (case_tac "t = the (tcbQueueHead (ksReadyQueues s' (tcb_domain etcb, tcb_priority etcb)))")
+     apply (case_tac "t = the (tcbQueueHead (ksReadyQueues s' (tcb_domain tcb, tcb_priority tcb)))")
       apply (clarsimp simp: inQ_def opt_pred_def opt_map_def obj_at'_def fun_upd_apply
                      split: option.splits)
       apply metis
@@ -2692,11 +2507,11 @@ lemma tcbSchedEnqueue_corres:
     apply (clarsimp simp: fun_upd_apply split: if_splits)
    apply (clarsimp simp: fun_upd_apply split: if_splits)
 
-  \<comment> \<open>d = tcb_domain etcb \<and> p = tcb_priority etcb\<close>
+  \<comment> \<open>d = tcb_domain tcb \<and> p = tcb_priority tcb\<close>
   apply clarsimp
-  apply (drule_tac x="tcb_domain etcb" in spec)
-  apply (drule_tac x="tcb_priority etcb" in spec)
-  apply (cut_tac ts="ready_queues s (tcb_domain etcb) (tcb_priority etcb)"
+  apply (drule_tac x="tcb_domain tcb" in spec)
+  apply (drule_tac x="tcb_priority tcb" in spec)
+  apply (cut_tac ts="ready_queues s (tcb_domain tcb) (tcb_priority tcb)"
               in tcbQueueHead_iff_tcbQueueEnd)
    apply (force simp: list_queue_relation_def)
   apply (frule valid_tcbs'_maxDomain[where t=tcbPtr], simp add: obj_at'_def)
@@ -2741,7 +2556,7 @@ lemma setSchedulerAction_corres:
   apply (simp add: setSchedulerAction_def set_scheduler_action_def)
   apply (rule corres_no_failI)
    apply wp
-  apply (clarsimp simp: in_monad simpler_modify_def state_relation_def)
+  apply (clarsimp simp: in_monad simpler_modify_def state_relation_def swp_def)
   done
 
 lemma getSchedulerAction_corres:
@@ -2752,7 +2567,7 @@ lemma getSchedulerAction_corres:
 
 lemma rescheduleRequired_corres:
   "corres dc
-     (weak_valid_sched_action and in_correct_ready_q and ready_qs_distinct and valid_etcbs
+     (weak_valid_sched_action and in_correct_ready_q and ready_qs_distinct
       and pspace_aligned and pspace_distinct)
      (sym_heap_sched_pointers and valid_sched_pointers and valid_tcbs')
      (reschedule_required) rescheduleRequired"
@@ -2770,8 +2585,8 @@ lemma rescheduleRequired_corres:
         apply (rule setSchedulerAction_corres)
         apply simp
        apply (wp | wpc | simp)+
-   apply (force dest: st_tcb_weakenE simp: in_monad weak_valid_sched_action_def valid_etcbs_def st_tcb_at_def obj_at_def is_tcb
-               split: Deterministic_A.scheduler_action.split)
+   apply (force dest: st_tcb_weakenE simp: in_monad weak_valid_sched_action_def st_tcb_at_def obj_at_def is_tcb
+               split: Structures_A.scheduler_action.split)
   apply (clarsimp split: scheduler_action.splits)
   done
 
@@ -2945,8 +2760,8 @@ definition tcb_queue_remove :: "'a \<Rightarrow> 'a list \<Rightarrow> 'a list" 
 
 definition tcb_sched_dequeue' :: "obj_ref \<Rightarrow> unit det_ext_monad" where
   "tcb_sched_dequeue' tcb_ptr \<equiv> do
-     d \<leftarrow> ethread_get tcb_domain tcb_ptr;
-     prio \<leftarrow> ethread_get tcb_priority tcb_ptr;
+     d \<leftarrow> thread_get tcb_domain tcb_ptr;
+     prio \<leftarrow> thread_get tcb_priority tcb_ptr;
      queue \<leftarrow> get_tcb_queue d prio;
      when (tcb_ptr \<in> set queue) $ set_tcb_queue d prio (tcb_queue_remove tcb_ptr queue)
    od"
@@ -2964,7 +2779,7 @@ lemma filter_tcb_queue_remove:
   done
 
 lemma tcb_sched_dequeue_monadic_rewrite:
-  "monadic_rewrite False True (is_etcb_at t and (\<lambda>s. \<forall>d p. distinct (ready_queues s d p)))
+  "monadic_rewrite False True (tcb_at t and (\<lambda>s. \<forall>d p. distinct (ready_queues s d p)))
      (tcb_sched_action tcb_sched_dequeue t) (tcb_sched_dequeue' t)"
   supply if_split[split del]
   apply (clarsimp simp: tcb_sched_dequeue'_def tcb_sched_dequeue_def tcb_sched_action_def
@@ -2977,9 +2792,9 @@ lemma tcb_sched_dequeue_monadic_rewrite:
       apply (metis (mono_tags, lifting) filter_cong)
      apply (rule monadic_rewrite_modify_noop)
     apply (wpsimp wp: thread_get_wp)+
-  apply (clarsimp simp: etcb_at_def split: option.splits)
-  apply (prop_tac "(\<lambda>d' p. if d' = tcb_domain x2 \<and> p = tcb_priority x2
-                           then filter (\<lambda>x. x \<noteq> t) (ready_queues s (tcb_domain x2) (tcb_priority x2))
+  apply (clarsimp simp: tcb_at_def)
+  apply (prop_tac "(\<lambda>d' p. if d' = tcb_domain tcb \<and> p = tcb_priority tcb
+                           then filter ((\<noteq>) t) (ready_queues s (tcb_domain tcb) (tcb_priority tcb))
                            else ready_queues s d' p)
                    = ready_queues s")
    apply (subst filter_True)
@@ -3012,7 +2827,7 @@ lemma in_queue_not_head_or_not_tail_length_gt_1:
 lemma tcbSchedDequeue_corres:
   "tcb_ptr = tcbPtr \<Longrightarrow>
    corres dc
-     (in_correct_ready_q and ready_qs_distinct and valid_etcbs and tcb_at tcb_ptr
+     (in_correct_ready_q and ready_qs_distinct and tcb_at tcb_ptr
       and pspace_aligned and pspace_distinct)
      (sym_heap_sched_pointers and valid_objs')
      (tcb_sched_action tcb_sched_dequeue tcb_ptr) (tcbSchedDequeue tcbPtr)"
@@ -3027,22 +2842,22 @@ lemma tcbSchedDequeue_corres:
    apply (fastforce dest: pspace_distinct_cross)
   apply (rule monadic_rewrite_corres_l[where P=P and Q=P for P, simplified])
    apply (rule monadic_rewrite_guard_imp[OF tcb_sched_dequeue_monadic_rewrite])
-   apply (fastforce dest: tcb_at_is_etcb_at simp: in_correct_ready_q_def ready_qs_distinct_def)
+   apply (fastforce simp: in_correct_ready_q_def ready_qs_distinct_def)
   apply (clarsimp simp: tcb_sched_dequeue'_def get_tcb_queue_def tcbSchedDequeue_def  getQueue_def
                         unless_def when_def)
-  apply (rule corres_symb_exec_l[OF _ _ ethread_get_sp]; wpsimp?)
+  apply (rule corres_symb_exec_l[OF _ _ thread_get_sp]; wpsimp?)
   apply (rename_tac dom)
-  apply (rule corres_symb_exec_l[OF _ _ ethread_get_sp]; wpsimp?)
+  apply (rule corres_symb_exec_l[OF _ _ thread_get_sp]; wpsimp?)
   apply (rename_tac prio)
   apply (rule corres_symb_exec_l[OF _ _ gets_sp]; (solves wpsimp)?)
   apply (rule corres_stateAssert_ignore)
    apply (fastforce intro: ksReadyQueues_asrt_cross)
   apply (rule corres_symb_exec_r[OF _ threadGet_sp]; (solves wpsimp)?)
   apply (rule corres_if_strong'; fastforce?)
-    apply (frule state_relation_ready_queues_relation)
-    apply (frule in_ready_q_tcbQueued_eq[where t=tcbPtr])
-    apply (fastforce simp: obj_at'_def opt_pred_def opt_map_def obj_at_def is_tcb_def
-                           in_correct_ready_q_def etcb_at_def is_etcb_at_def)
+   apply (fastforce dest!: state_relation_ready_queues_relation
+                           in_ready_q_tcbQueued_eq[where t=tcbPtr]
+                     simp: obj_at'_def opt_pred_def opt_map_def in_correct_ready_q_def
+                           obj_at_def etcb_at_def etcbs_of'_def)
   apply (rule corres_symb_exec_r[OF _ threadGet_sp]; wpsimp?)
   apply (rule corres_symb_exec_r[OF _ threadGet_sp]; wpsimp?)
   apply (rule corres_symb_exec_r[OF _ gets_sp]; wpsimp?)
@@ -3064,24 +2879,23 @@ lemma tcbSchedDequeue_corres:
   apply (wpsimp wp: threadSet_wp getObject_tcb_wp
               simp: setQueue_def tcbQueueRemove_def
          split_del: if_split)
-  apply (frule (1) tcb_at_is_etcb_at)
-  apply (clarsimp simp: obj_at_def is_etcb_at_def etcb_at_def)
+  apply (clarsimp simp: obj_at_def)
   apply normalise_obj_at'
-  apply (rename_tac s d p s' tcb' tcb etcb)
-  apply (frule_tac t=tcbPtr in ekheap_relation_tcb_domain_priority)
+  apply (rename_tac s d p s' tcb' tcb)
+  apply (frule_tac t=tcbPtr in pspace_relation_tcb_domain_priority)
     apply (force simp: obj_at_def)
    apply (force simp: obj_at'_def)
 
-  apply (case_tac "d \<noteq> tcb_domain etcb \<or> p \<noteq> tcb_priority etcb")
+  apply (case_tac "d \<noteq> tcb_domain tcb \<or> p \<noteq> tcb_priority tcb")
    apply clarsimp
-   apply (cut_tac p=tcbPtr and ls="ready_queues s (tcb_domain etcb) (tcb_priority etcb)"
+   apply (cut_tac p=tcbPtr and ls="ready_queues s (tcb_domain tcb) (tcb_priority tcb)"
                in list_queue_relation_neighbour_in_set)
       apply (fastforce dest!: spec)
      apply fastforce
     apply fastforce
    apply (cut_tac xs="ready_queues s d p" in heap_path_head')
     apply (force dest!: spec simp: ready_queues_relation_def Let_def list_queue_relation_def)
-   apply (cut_tac d=d and d'="tcb_domain etcb" and p=p and p'="tcb_priority etcb"
+   apply (cut_tac d=d and d'="tcb_domain tcb" and p=p and p'="tcb_priority tcb"
                in ready_queues_disjoint)
       apply force
      apply fastforce
@@ -3105,7 +2919,7 @@ lemma tcbSchedDequeue_corres:
      apply (clarsimp simp: fun_upd_apply)
     apply (clarsimp simp: fun_upd_apply)
 
-   apply (clarsimp simp: etcb_at_def obj_at'_def)
+   apply (clarsimp simp: obj_at'_def)
    apply (intro conjI; clarsimp)
 
     \<comment> \<open>tcbPtr is the head of the ready queue\<close>
@@ -3151,8 +2965,8 @@ lemma tcbSchedDequeue_corres:
 
   \<comment> \<open>d = tcb_domain tcb \<and> p = tcb_priority tcb\<close>
   apply clarsimp
-  apply (drule_tac x="tcb_domain etcb" in spec)
-  apply (drule_tac x="tcb_priority etcb" in spec)
+  apply (drule_tac x="tcb_domain tcb" in spec)
+  apply (drule_tac x="tcb_priority tcb" in spec)
   apply (clarsimp simp: list_queue_relation_def)
   apply (frule heap_path_head')
   apply (frule heap_ls_distinct)
@@ -3165,7 +2979,7 @@ lemma tcbSchedDequeue_corres:
      apply (simp add: fun_upd_apply tcb_queue_remove_def queue_end_valid_def heap_ls_unique
                       heap_path_last_end)
     apply (simp add: fun_upd_apply prev_queue_head_def)
-   apply (case_tac "ready_queues s (tcb_domain etcb) (tcb_priority etcb)";
+   apply (case_tac "ready_queues s (tcb_domain tcb) (tcb_priority tcb)";
           clarsimp simp: tcb_queue_remove_def inQ_def opt_pred_def fun_upd_apply)
   apply (intro conjI; clarsimp)
 
@@ -3184,7 +2998,7 @@ lemma tcbSchedDequeue_corres:
       apply (clarsimp simp: opt_map_red opt_map_upd_triv fun_upd_apply)
      apply (clarsimp simp: queue_end_valid_def fun_upd_apply last_tl)
     apply (clarsimp simp: prev_queue_head_def fun_upd_apply)
-   apply (case_tac "ready_queues s (tcb_domain etcb) (tcb_priority etcb)";
+   apply (case_tac "ready_queues s (tcb_domain tcb) (tcb_priority tcb)";
           clarsimp simp: inQ_def opt_pred_def opt_map_def fun_upd_apply split: option.splits)
   apply (intro conjI; clarsimp)
 
@@ -3263,11 +3077,11 @@ lemma setThreadState_corres:
           (set_thread_state t ts) (setThreadState ts' t)"
   (is "?tsr \<Longrightarrow> corres dc ?Pre ?Pre' ?sts ?sts'")
   apply (simp add: set_thread_state_def setThreadState_def)
-  apply (simp add: set_thread_state_ext_def[abs_def])
+  apply (simp add: set_thread_state_act_def[abs_def])
   apply (subst bind_assoc[symmetric], subst thread_set_def[simplified, symmetric])
   apply (rule corres_guard_imp)
     apply (rule corres_split[where r'=dc])
-       apply (rule threadset_corres, (simp add: tcb_relation_def exst_same_def)+)
+       apply (rule threadset_corres, (simp add: tcb_relation_def inQ_def)+)
       apply (subst thread_get_test[where test="runnable"])
       apply (rule corres_split[OF thread_get_isRunnable_corres])
         apply (rule corres_split[OF getCurThread_corres])
@@ -3288,7 +3102,7 @@ lemma setBoundNotification_corres:
           (set_bound_notification t ntfn) (setBoundNotification ntfn t)"
   apply (simp add: set_bound_notification_def setBoundNotification_def)
   apply (subst thread_set_def[simplified, symmetric])
-  apply (rule threadset_corres, simp_all add:tcb_relation_def exst_same_def)
+  apply (rule threadset_corres, simp_all add:tcb_relation_def inQ_def)
   done
 
 crunch rescheduleRequired, tcbSchedDequeue, setThreadState, setBoundNotification
@@ -6018,154 +5832,6 @@ lemma asUser_irq_handlers':
   apply (simp add: asUser_def split_def)
   apply (wpsimp wp: threadSet_irq_handlers' [OF all_tcbI, OF ball_tcb_cte_casesI] select_f_inv)
   done
-
-(* the brave can try to move this up to near setObject_update_TCB_corres' *)
-
-definition non_exst_same :: "Structures_H.tcb \<Rightarrow> Structures_H.tcb \<Rightarrow> bool"
-where
-  "non_exst_same tcb tcb' \<equiv> \<exists>d p ts. tcb' = tcb\<lparr>tcbDomain := d, tcbPriority := p, tcbTimeSlice := ts\<rparr>"
-
-fun non_exst_same' :: "Structures_H.kernel_object \<Rightarrow> Structures_H.kernel_object \<Rightarrow> bool"
-where
-  "non_exst_same' (KOTCB tcb) (KOTCB tcb') = non_exst_same tcb tcb'" |
-  "non_exst_same' _ _ = True"
-
-lemma non_exst_same_prio_upd[simp]:
-  "non_exst_same tcb (tcbPriority_update f tcb)"
-  by (cases tcb, simp add: non_exst_same_def)
-
-lemma non_exst_same_timeSlice_upd[simp]:
-  "non_exst_same tcb (tcbTimeSlice_update f tcb)"
-  by (cases tcb, simp add: non_exst_same_def)
-
-lemma non_exst_same_domain_upd[simp]:
-  "non_exst_same tcb (tcbDomain_update f tcb)"
-  by (cases tcb, simp add: non_exst_same_def)
-
-lemma set_eobject_corres':
-  assumes e: "etcb_relation etcb tcb'"
-  assumes z: "\<And>s. obj_at' P ptr s
-               \<Longrightarrow> map_to_ctes ((ksPSpace s) (ptr \<mapsto> KOTCB tcb')) = map_to_ctes (ksPSpace s)"
-  shows
-    "corres dc
-       (tcb_at ptr and is_etcb_at ptr)
-       (obj_at' (\<lambda>ko. non_exst_same ko tcb') ptr and obj_at' P ptr
-        and obj_at' (\<lambda>tcb. (tcbDomain tcb \<noteq> tcbDomain tcb' \<or> tcbPriority tcb \<noteq> tcbPriority tcb')
-                            \<longrightarrow> \<not> tcbQueued tcb) ptr)
-       (set_eobject ptr etcb) (setObject ptr tcb')"
-  apply (rule corres_no_failI)
-   apply (rule no_fail_pre)
-    apply wp
-   apply (clarsimp simp: obj_at'_def)
-  apply (unfold set_eobject_def setObject_def)
-  apply (clarsimp simp: in_monad split_def bind_def gets_def get_def Bex_def
-                        put_def return_def modify_def get_object_def projectKOs
-                        updateObject_default_def in_magnitude_check objBits_simps')
-  apply (clarsimp simp add: state_relation_def z)
-  apply (clarsimp simp add: obj_at_def is_etcb_at_def)
-  apply (simp only: pspace_relation_def dom_fun_upd2 simp_thms)
-  apply (elim conjE)
-  apply (frule bspec, erule domI)
-  apply (rule conjI)
-   apply (rule ballI, drule(1) bspec)
-   apply (drule domD)
-   apply (clarsimp simp: is_other_obj_relation_type)
-   apply (drule(1) bspec)
-   apply (clarsimp simp: non_exst_same_def)
-   apply (case_tac bb; simp)
-     apply (clarsimp simp: obj_at'_def other_obj_relation_def tcb_relation_cut_def cte_relation_def
-                           tcb_relation_def projectKOs
-                    split: if_split_asm)+
-   apply (clarsimp simp: aobj_relation_cuts_def split: ARM_HYP_A.arch_kernel_obj.splits)
-   apply (rename_tac arch_kernel_obj obj d p ts)
-   apply (case_tac arch_kernel_obj; simp)
-     apply (clarsimp simp: pte_relation_def pde_relation_def is_tcb_def
-                    split: if_split_asm)+
-  apply (extract_conjunct \<open>match conclusion in "ekheap_relation _ _" \<Rightarrow> -\<close>)
-   apply (simp only: ekheap_relation_def dom_fun_upd2 simp_thms)
-   apply (frule bspec, erule domI)
-   apply (rule ballI, drule(1) bspec)
-   apply (drule domD)
-   apply (clarsimp simp: obj_at'_def)
-   apply (insert e)
-   apply (clarsimp simp: other_obj_relation_def etcb_relation_def is_other_obj_relation_type
-                  split: Structures_A.kernel_object.splits kernel_object.splits arch_kernel_obj.splits)
-   apply (frule in_ready_q_tcbQueued_eq[where t=ptr])
-  apply (rename_tac s' conctcb' abstcb exttcb)
-  apply (clarsimp simp: ready_queues_relation_def Let_def)
-  apply (prop_tac "(tcbSchedNexts_of s')(ptr := tcbSchedNext tcb') = tcbSchedNexts_of s'")
-   apply (fastforce simp: opt_map_def obj_at'_def projectKOs non_exst_same_def split: option.splits)
-  apply (prop_tac "(tcbSchedPrevs_of s')(ptr := tcbSchedPrev tcb') = tcbSchedPrevs_of s'")
-   apply (fastforce simp: opt_map_def obj_at'_def projectKOs non_exst_same_def split: option.splits)
-  apply (clarsimp simp: ready_queue_relation_def opt_map_def opt_pred_def obj_at'_def  projectKOs
-                        inQ_def non_exst_same_def
-                 split: option.splits)
-  apply metis
-  done
-
-lemma set_eobject_corres:
-  assumes tcbs: "non_exst_same tcb' tcbu'"
-  assumes e: "etcb_relation etcb tcb' \<Longrightarrow> etcb_relation etcbu tcbu'"
-  assumes tables': "\<forall>(getF, v) \<in> ran tcb_cte_cases. getF tcbu' = getF tcb'"
-  assumes r: "r () ()"
-  shows
-    "corres r
-       (tcb_at add and (\<lambda>s. ekheap s add = Some etcb))
-       (ko_at' tcb' add
-        and obj_at' (\<lambda>tcb. (tcbDomain tcb \<noteq> tcbDomain tcbu' \<or> tcbPriority tcb \<noteq> tcbPriority tcbu')
-                           \<longrightarrow> \<not> tcbQueued tcb) add)
-       (set_eobject add etcbu) (setObject add tcbu')"
-  apply (rule_tac F="non_exst_same tcb' tcbu' \<and> etcb_relation etcbu tcbu'" in corres_req)
-   apply (clarsimp simp: state_relation_def obj_at_def obj_at'_def)
-   apply (frule(1) pspace_relation_absD)
-   apply (clarsimp simp: projectKOs other_obj_relation_def ekheap_relation_def e tcbs)
-   apply (drule bspec, erule domI)
-   apply (clarsimp simp: e)
-  apply (erule conjE)
-  apply (rule corres_guard_imp)
-    apply (rule corres_rel_imp)
-     apply (rule set_eobject_corres'[where P="(=) tcb'"])
-      apply simp
-     defer
-    apply (simp add: r)
-   apply (fastforce simp: is_etcb_at_def elim!: obj_at_weakenE)
-   apply (subst(asm) eq_commute)
-   apply (clarsimp simp: obj_at'_def)
-  apply (clarsimp simp: projectKOs obj_at'_def objBits_simps)
-  apply (subst map_to_ctes_upd_tcb, assumption+)
-   apply (simp add: ps_clear_def3 field_simps objBits_defs mask_def)
-  apply (subst if_not_P)
-   apply (fastforce dest: bspec [OF tables', OF ranI])
-  apply simp
-  done
-
-lemma ethread_set_corresT:
-  assumes x: "\<And>tcb'. non_exst_same tcb' (f' tcb')"
-  assumes z: "\<forall>tcb. \<forall>(getF, setF) \<in> ran tcb_cte_cases. getF (f' tcb) = getF tcb"
-  assumes e: "\<And>etcb tcb'. etcb_relation etcb tcb' \<Longrightarrow> etcb_relation (f etcb) (f' tcb')"
-  shows
-    "corres dc
-       (tcb_at t and valid_etcbs)
-       (tcb_at' t
-        and obj_at' (\<lambda>tcb. (tcbDomain tcb \<noteq> tcbDomain (f' tcb)
-                             \<or> tcbPriority tcb \<noteq> tcbPriority (f' tcb))
-                           \<longrightarrow> \<not> tcbQueued tcb) t)
-       (ethread_set f t) (threadSet f' t)"
-  apply (simp add: ethread_set_def threadSet_def bind_assoc)
-  apply (rule corres_guard_imp)
-    apply (rule corres_split[OF corres_get_etcb set_eobject_corres])
-         apply (rule x)
-        apply (erule e)
-       apply (simp add: z)+
-     apply (wp getObject_tcb_wp)+
-   apply clarsimp
-   apply (simp add: valid_etcbs_def tcb_at_st_tcb_at[symmetric])
-   apply (force simp: tcb_at_def get_etcb_def obj_at_def)
-  apply (clarsimp simp: obj_at'_def)
-  done
-
-lemmas ethread_set_corres =
-    ethread_set_corresT [OF _ all_tcbI, OF _ ball_tcb_cte_casesI]
 
 end
 end

--- a/proof/refine/ARM_HYP/Tcb_R.thy
+++ b/proof/refine/ARM_HYP/Tcb_R.thy
@@ -229,7 +229,7 @@ lemma restart_corres:
         apply (clarsimp simp: invs'_def valid_state'_def sch_act_wf_weak valid_pspace'_def
                               valid_tcb_state'_def)
        apply wp+
-   apply (simp add: valid_sched_def invs_def tcb_at_is_etcb_at invs_psp_aligned invs_distinct)
+   apply (simp add: valid_sched_def invs_def invs_psp_aligned invs_distinct)
   apply clarsimp
   done
 
@@ -311,9 +311,6 @@ crunch asUser
 crunch getSanitiseRegisterInfo
   for invs'[wp]: invs'
 
-lemma einvs_valid_etcbs: "einvs s \<longrightarrow> valid_etcbs s"
-  by (clarsimp simp: valid_sched_def)
-
 lemma asUser_postModifyRegisters_corres:
   "corres dc \<top> (tcb_at' t)
      (arch_post_modify_registers ct t)
@@ -354,7 +351,7 @@ lemma invokeTCB_WriteRegisters_corres:
                   apply simp
                  apply (wp+)[2]
              apply ((wp hoare_weak_lift_imp restart_invs'
-                     | strengthen valid_sched_weak_strg einvs_valid_etcbs
+                     | strengthen valid_sched_weak_strg
                                   invs_weak_sch_act_wf
                                   valid_queues_in_correct_ready_q valid_queues_ready_qs_distinct
                                   valid_sched_valid_queues valid_objs'_valid_tcbs' invs_valid_objs'
@@ -596,9 +593,63 @@ crunch tcbSchedDequeue
 crunch tcbSchedDequeue
   for st_tcb_at'[wp]: "\<lambda>s. P (st_tcb_at' st tcbPtr s)"
 
+lemma thread_set_ready_qs_distinct[wp]:
+  "thread_set f tcb_ptr \<lbrace>ready_qs_distinct\<rbrace>"
+  apply (wpsimp wp: thread_set_wp)
+  by (clarsimp simp: ready_qs_distinct_def)
+
+lemma thread_set_in_correct_ready_q_not_queued:
+  "\<lbrace>in_correct_ready_q and not_queued t\<rbrace>
+   thread_set f t
+   \<lbrace>\<lambda>_. in_correct_ready_q\<rbrace>"
+  unfolding thread_set_priority_def
+  apply (wpsimp wp: thread_set_wp)
+  apply (clarsimp simp: in_correct_ready_q_def not_queued_def is_etcb_at'_def etcb_at_def etcbs_of'_def)
+  done
+
+lemma tcb_sched_dequeue_in_correct_ready_q[wp]:
+  "tcb_sched_action tcb_sched_dequeue t \<lbrace>in_correct_ready_q\<rbrace> "
+  unfolding tcb_sched_action_def set_tcb_queue_def
+  apply (wpsimp wp: thread_get_wp')
+  apply (clarsimp simp: in_correct_ready_q_def tcb_sched_dequeue_def)
+  done
+
+lemma tcb_sched_dequeue_ready_qs_distinct[wp]:
+  "tcb_sched_action tcb_sched_dequeue t \<lbrace>ready_qs_distinct\<rbrace> "
+  unfolding tcb_sched_action_def set_tcb_queue_def
+  apply (wpsimp wp: thread_get_wp')
+  apply (clarsimp simp: ready_qs_distinct_def tcb_sched_dequeue_def)
+  done
+
+\<comment> \<open>For updating the domain and the priority fields of a TCB that is not in a ready queue\<close>
+lemma threadSet_not_queued_corres:
+  "\<lbrakk>\<And>tcb tcb'. tcb_relation tcb tcb' \<Longrightarrow> tcb_relation (f tcb) (F tcb');
+    \<And>tcb'. tcbSchedNext (F tcb') = tcbSchedNext tcb';
+    \<And>tcb'. tcbSchedPrev (F tcb') = tcbSchedPrev tcb';
+    \<And>tcb'. tcbQueued (F tcb') = tcbQueued tcb';
+    \<And>tcb. \<forall>(getF, v) \<in> ran tcb_cap_cases. getF (f tcb) = getF tcb;
+    \<And>tcb'. \<forall>(getF, v)\<in>ran tcb_cte_cases. getF (F tcb') = getF tcb'\<rbrakk>
+   \<Longrightarrow> corres dc (tcb_at t and not_queued t and pspace_aligned and pspace_distinct) \<top>
+         (thread_set f t) (threadSet F t)"
+  apply (rule_tac Q'="tcb_at' t" in corres_cross_add_guard)
+   apply (fastforce dest!: state_relationD elim!: tcb_at_cross)
+  apply (simp add: thread_set_def threadSet_def)
+  apply (rule corres_symb_exec_l[OF _ _ gets_the_sp]; wpsimp simp: tcb_at_def)
+  apply (rule corres_symb_exec_r[OF _ getObject_tcb_sp]; wpsimp?)
+  apply (rename_tac tcb tcb')
+  apply (rule stronger_corres_guard_imp)
+    apply (rule_tac F="\<not> tcbQueued tcb'" in corres_gen_asm)
+    apply (rule_tac tcb=tcb and tcb'=tcb' in setObject_update_TCB_corres';
+           fastforce simp: inQ_def)
+   apply (frule state_relation_ready_queues_relation)
+   apply (frule in_ready_q_tcbQueued_eq[where t=t])
+   apply (clarsimp simp: opt_pred_def opt_map_def obj_at'_def not_queued_def projectKOs)
+  apply clarsimp
+  done
+
 lemma sp_corres2:
   "corres dc
-     (valid_etcbs and weak_valid_sched_action and cur_tcb and tcb_at t
+     (weak_valid_sched_action and cur_tcb and tcb_at t
       and valid_queues and pspace_aligned and pspace_distinct)
      (tcb_at' t and (\<lambda>s. weak_sch_act_wf (ksSchedulerAction s) s)
       and valid_objs' and (\<lambda>_. x \<le> maxPriority) and sym_heap_sched_pointers and valid_sched_pointers)
@@ -606,8 +657,9 @@ lemma sp_corres2:
   apply (simp add: setPriority_def set_priority_def thread_set_priority_def)
   apply (rule stronger_corres_guard_imp)
     apply (rule corres_split[OF tcbSchedDequeue_corres], simp)
-      apply (rule corres_split[OF ethread_set_corres], simp_all)[1]
-         apply (simp add: etcb_relation_def)
+      apply (rule corres_split[OF threadSet_not_queued_corres];
+                           simp add: tcb_relation_def tcb_cap_cases_def tcb_cte_cases_def
+                                     cteSizeBits_def)
         apply (rule corres_split[OF isRunnable_corres])
           apply (erule corres_when)
           apply(rule corres_split[OF getCurThread_corres])
@@ -617,19 +669,19 @@ lemma sp_corres2:
            apply ((clarsimp
                    | wp hoare_weak_lift_imp hoare_vcg_if_lift hoare_wp_combs gts_wp
                         isRunnable_wp)+)[4]
-       apply (wp hoare_vcg_imp_lift' hoare_vcg_if_lift hoare_vcg_all_lift
-                 ethread_set_not_queued_valid_queues
-              | strengthen valid_queues_in_correct_ready_q valid_queues_ready_qs_distinct)+
+       apply (wpsimp wp: hoare_vcg_imp_lift' hoare_vcg_if_lift hoare_vcg_all_lift
+                         thread_set_in_correct_ready_q_not_queued thread_set_no_change_tcb_state
+                         thread_set_no_change_tcb_state_converse thread_set_weak_valid_sched_action)+
       apply ((wp hoare_vcg_imp_lift' hoare_vcg_all_lift
                  isRunnable_wp threadSet_pred_tcb_no_state
                  threadSet_valid_objs_tcbPriority_update threadSet_sched_pointers
                  threadSet_valid_sched_pointers tcb_dequeue_not_queued tcbSchedDequeue_not_queued
                  threadSet_weak_sch_act_wf
-              | simp add: etcb_relation_def
+              | simp add: tcb_relation_def
               | strengthen valid_objs'_valid_tcbs'
                 obj_at'_weakenE[where P="Not \<circ> tcbQueued"]
               | wps)+)
-   apply (force simp: valid_etcbs_def tcb_at_st_tcb_at[symmetric] state_relation_def
+   apply (force simp: tcb_at_st_tcb_at[symmetric] state_relation_def
                 dest: pspace_relation_tcb_at intro: st_tcb_at_opeqI)
   apply clarsimp
   done
@@ -652,7 +704,7 @@ lemma setMCPriority_corres:
     apply (clarsimp simp: setMCPriority_def set_mcpriority_def)
     apply (rule threadset_corresT)
   by (clarsimp simp: tcb_relation_def tcb_cap_cases_tcb_mcpriority
-                     tcb_cte_cases_def cteSizeBits_def exst_same_def)+
+                     tcb_cte_cases_def cteSizeBits_def inQ_def)+
 
 definition
  "out_rel fn fn' v v' \<equiv>
@@ -666,8 +718,7 @@ lemma out_corresT:
   assumes y: "\<And>v. \<forall>tcb. \<forall>(getF, setF)\<in>ran tcb_cte_cases. getF (fn' v tcb) = getF tcb"
   assumes sched_pointers: "\<And>tcb v. tcbSchedPrev (fn' v tcb) = tcbSchedPrev tcb"
                           "\<And>tcb v. tcbSchedNext (fn' v tcb) = tcbSchedNext tcb"
-  assumes flag: "\<And>tcb v. tcbQueued (fn' v tcb) = tcbQueued tcb"
-  assumes e: "\<And>tcb v. exst_same tcb (fn' v tcb)"
+  assumes flag: "\<And>d p tcb' v. inQ d p (fn' v tcb') = inQ d p tcb'"
   shows
   "out_rel fn fn' v v' \<Longrightarrow>
      corres dc (tcb_at t and pspace_aligned and pspace_distinct)
@@ -675,7 +726,7 @@ lemma out_corresT:
        (option_update_thread t fn v)
        (case_option (return ()) (\<lambda>x. threadSet (fn' x) t) v')"
   apply (case_tac v, simp_all add: out_rel_def option_update_thread_def)
-  apply (clarsimp simp: threadset_corresT [OF _ x y sched_pointers flag e])
+  apply (clarsimp simp: threadset_corresT [OF _ x y sched_pointers flag])
   done
 
 lemmas out_corres = out_corresT [OF _ all_tcbI, OF ball_tcb_cap_casesI ball_tcb_cte_casesI]
@@ -1037,14 +1088,14 @@ lemma thread_set_ipc_weak_valid_sched_action:
   apply (simp | intro impI | elim exE conjE)+
   apply (frule get_tcb_SomeD)
   apply (erule ssubst)
-  apply (clarsimp simp add: weak_valid_sched_action_def valid_etcbs_2_def st_tcb_at_kh_def
-              get_tcb_def obj_at_kh_def obj_at_def is_etcb_at'_def valid_sched_def valid_sched_action_def)
+  apply (clarsimp simp: weak_valid_sched_action_def st_tcb_at_kh_def obj_at_kh_def valid_sched_def
+                        valid_sched_action_def)
   done
 
 lemma threadcontrol_corres_helper3:
   "\<lbrace>einvs and simple_sched_action\<rbrace>
    check_cap_at cap p (check_cap_at (cap.ThreadCap cap') slot (cap_insert cap p (t, tcb_cnode_index 4)))
-   \<lbrace>\<lambda>_ s. weak_valid_sched_action s \<and> in_correct_ready_q s \<and> ready_qs_distinct s \<and> valid_etcbs s
+   \<lbrace>\<lambda>_ s. weak_valid_sched_action s \<and> in_correct_ready_q s \<and> ready_qs_distinct s
           \<and> pspace_aligned s \<and> pspace_distinct s\<rbrace>"
    apply (wpsimp
           | strengthen valid_sched_valid_queues valid_queues_in_correct_ready_q
@@ -1198,7 +1249,7 @@ proof -
                (option_map to_bl v))
                (case v of None \<Rightarrow> return ()
                  | Some x \<Rightarrow> threadSet (tcbFaultHandler_update (%_. x)) t)"
-    apply (rule out_corres, simp_all add: exst_same_def)
+    apply (rule out_corres, simp_all add: inQ_def)
     apply (case_tac v, simp_all add: out_rel_def)
     apply (safe, case_tac tcb', simp add: tcb_relation_def split: option.split)
     done
@@ -1208,7 +1259,7 @@ proof -
                (option_update_thread t (tcb_ipc_buffer_update o (%x _. x)) v)
                (case v of None \<Rightarrow> return ()
                  | Some x \<Rightarrow> threadSet (tcbIPCBuffer_update (%_. x)) t)"
-    apply (rule out_corres, simp_all add: exst_same_def)
+    apply (rule out_corres, simp_all )
     apply (case_tac v, simp_all add: out_rel_def)
     apply (safe, case_tac tcb', simp add: tcb_relation_def)
     done
@@ -1337,20 +1388,19 @@ proof -
             apply (rule cteDelete_corres)
            apply (rule_tac F="is_aligned aa msg_align_bits" in corres_gen_asm2)
            apply (rule corres_split_nor)
-              apply (rule threadset_corres,
-                      (simp add: tcb_relation_def), (simp add: exst_same_def)+)[1]
+              apply (rule threadset_corres; simp add: tcb_relation_def)
              apply (rule corres_split[OF getCurThread_corres], clarsimp)
                apply (rule corres_when[OF refl rescheduleRequired_corres])
               apply (wpsimp wp: gct_wp)+
             apply (strengthen valid_queues_ready_qs_distinct)
             apply (wpsimp wp: thread_set_ipc_weak_valid_sched_action thread_set_valid_queues
-                              hoare_drop_imp)
+                              hoare_drop_imp in_correct_ready_q_lift thread_set_etcbs)
            apply clarsimp
            apply (strengthen valid_objs'_valid_tcbs' invs_valid_objs')+
            apply (wpsimp wp: threadSet_sched_pointers threadSet_valid_sched_pointers hoare_drop_imp
                              threadSet_invs_tcbIPCBuffer_update)
           apply (clarsimp simp: pred_conj_def)
-          apply (strengthen einvs_valid_etcbs valid_queues_in_correct_ready_q
+          apply (strengthen valid_queues_in_correct_ready_q
                             valid_sched_valid_queues invs_psp_aligned invs_distinct)+
           apply wp
          apply (clarsimp simp: pred_conj_def)
@@ -1365,8 +1415,7 @@ proof -
           apply (rule_tac F="is_aligned aa msg_align_bits" in corres_gen_asm)
           apply (rule_tac F="isArchObjectCap ac" in corres_gen_asm2)
           apply (rule corres_split_nor)
-             apply (rule threadset_corres,
-                   simp add: tcb_relation_def, (simp add: exst_same_def)+)
+             apply (rule threadset_corres; simp add: tcb_relation_def)
             apply (rule corres_split_nor)
                apply (erule checkCapAt_cteInsert_corres)
               apply (rule corres_split[OF getCurThread_corres], clarsimp)
@@ -1751,7 +1800,7 @@ lemma invokeTCB_corres:
            apply (rule TcbAcc_R.rescheduleRequired_corres)
           apply (rule corres_trivial, simp)
          apply (wpsimp wp: hoare_drop_imp)+
-   apply (fastforce dest: valid_sched_valid_queues simp: valid_sched_weak_strg einvs_valid_etcbs)
+   apply (fastforce dest: valid_sched_valid_queues simp: valid_sched_weak_strg)
   apply fastforce
   done
 
@@ -1977,7 +2026,7 @@ lemma decodeSetPriority_corres:
   "\<lbrakk> cap_relation cap cap'; is_thread_cap cap;
      list_all2 (\<lambda>(c, sl) (c', sl'). cap_relation c c' \<and> sl' = cte_map sl) extras extras' \<rbrakk> \<Longrightarrow>
    corres (ser \<oplus> tcbinv_relation)
-       (cur_tcb and valid_etcbs and (pspace_aligned and pspace_distinct and (\<lambda>s. \<forall>x \<in> set extras. s \<turnstile> (fst x))))
+       (cur_tcb and (pspace_aligned and pspace_distinct and (\<lambda>s. \<forall>x \<in> set extras. s \<turnstile> (fst x))))
        (invs' and (\<lambda>s. \<forall>x \<in> set extras'. s \<turnstile>' (fst x)))
        (decode_set_priority args cap slot extras)
        (decodeSetPriority args cap' extras')"
@@ -1995,7 +2044,7 @@ lemma decodeSetMCPriority_corres:
   "\<lbrakk> cap_relation cap cap'; is_thread_cap cap;
      list_all2 (\<lambda>(c, sl) (c', sl'). cap_relation c c' \<and> sl' = cte_map sl) extras extras' \<rbrakk> \<Longrightarrow>
    corres (ser \<oplus> tcbinv_relation)
-       (cur_tcb and valid_etcbs and (pspace_aligned and pspace_distinct and (\<lambda>s. \<forall>x \<in> set extras. s \<turnstile> (fst x))))
+       (cur_tcb and (pspace_aligned and pspace_distinct and (\<lambda>s. \<forall>x \<in> set extras. s \<turnstile> (fst x))))
        (invs' and (\<lambda>s. \<forall>x \<in> set extras'. s \<turnstile>' (fst x)))
        (decode_set_mcpriority args cap slot extras)
        (decodeSetMCPriority args cap' extras')"
@@ -2103,7 +2152,7 @@ lemma decodeSetSchedParams_corres:
   "\<lbrakk> cap_relation cap cap'; is_thread_cap cap;
      list_all2 (\<lambda>(c, sl) (c', sl'). cap_relation c c' \<and> sl' = cte_map sl) extras extras' \<rbrakk> \<Longrightarrow>
    corres (ser \<oplus> tcbinv_relation)
-       (cur_tcb and valid_etcbs and
+       (cur_tcb and
          (pspace_aligned and pspace_distinct and (\<lambda>s. \<forall>x \<in> set extras. s \<turnstile> (fst x))))
        (invs' and (\<lambda>s. \<forall>x \<in> set extras'. s \<turnstile>' (fst x)))
        (decode_set_sched_params args cap slot extras)

--- a/proof/refine/ARM_HYP/Untyped_R.thy
+++ b/proof/refine/ARM_HYP/Untyped_R.thy
@@ -1345,7 +1345,7 @@ lemma in_getCTE2:
 declare wrap_ext_op_det_ext_ext_def[simp]
 
 lemma do_ext_op_update_cdt_list_symb_exec_l':
-  "corres_underlying {(s::det_state, s'). f (kheap s) (ekheap s) s'} nf nf' dc P P' (create_cap_ext p z a) (return x)"
+  "corres_underlying {(s::det_state, s'). f (kheap s) s'} nf nf' dc P P' (create_cap_ext p z a) (return x)"
   apply (simp add: corres_underlying_def create_cap_ext_def
   update_cdt_list_def set_cdt_list_def bind_def put_def get_def gets_def return_def)
   done
@@ -1388,16 +1388,13 @@ lemma set_cdt_symb_exec_l:
   by (simp add: corres_underlying_def return_def set_cdt_def in_monad Bex_def)
 
 crunch create_cap_ext
-  for domain_index[wp]: "\<lambda>s. P (domain_index s)"
-  and domain_list[wp]: "\<lambda>s. P (domain_list s)"
-  and domain_time[wp]: "\<lambda>s. P (domain_time s)"
-  and work_units_completed[wp]: "\<lambda>s. P (work_units_completed s)"
+  for work_units_completed[wp]: "\<lambda>s. P (work_units_completed s)"
   (ignore_del: create_cap_ext)
 
 context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma updateNewFreeIndex_noop_psp_corres:
-  "corres_underlying {(s, s'). pspace_relations (ekheap s) (kheap s) (ksPSpace s')} False True
+  "corres_underlying {(s, s'). pspace_relation (kheap s) (ksPSpace s')} False True
     dc \<top> (cte_at' slot)
     (return ()) (updateNewFreeIndex slot)"
   apply (simp add: updateNewFreeIndex_def)
@@ -1408,6 +1405,10 @@ lemma updateNewFreeIndex_noop_psp_corres:
       apply (wp getCTE_wp' | wpc
         | simp add: updateTrackedFreeIndex_def getSlotCap_def)+
   done
+
+crunch set_cap, set_cdt
+  for domain_index[wp]: "\<lambda>s. P (domain_index s)"
+  (wp: crunch_wps)
 
 crunch updateMDB, updateNewFreeIndex, setCTE
   for rdyq_projs[wp]:
@@ -3016,38 +3017,31 @@ lemma createNewCaps_range_helper:
   apply (frule range_cover.range_cover_n_less)
   apply (frule range_cover.unat_of_nat_n)
   apply (cases tp, simp_all split del: if_split)
-          apply (rename_tac apiobject_type)
-          apply (case_tac apiobject_type, simp_all split del: if_split)
-              apply (rule hoare_pre, wp)
-              apply (frule range_cover_not_zero[rotated -1],simp)
-              apply (clarsimp simp: APIType_capBits_def objBits_simps archObjSize_def ptr_add_def o_def)
-              apply (subst upto_enum_red')
-               apply unat_arith
-              apply (clarsimp simp: o_def fromIntegral_def toInteger_nat fromInteger_nat)
-              apply fastforce
-             apply (rule hoare_pre,wp createObjects_ret2)
-             apply (clarsimp simp: APIType_capBits_def word_bits_def
-                objBits_simps archObjSize_def ptr_add_def o_def)
-             apply (fastforce simp: objBitsKO_def objBits_def)
-            apply (rule hoare_pre,wp createObjects_ret2)
-            apply (clarsimp simp: APIType_capBits_def word_bits_def
-                                  objBits_simps archObjSize_def ptr_add_def o_def)
-            apply (fastforce simp: objBitsKO_def  objBits_def)
-           apply (rule hoare_pre,wp createObjects_ret2)
-           apply (clarsimp simp:  APIType_capBits_def word_bits_def
-              objBits_simps archObjSize_def ptr_add_def o_def)
-           apply (fastforce simp: objBitsKO_def  objBits_def)
-          apply (rule hoare_pre,wp createObjects_ret2)
-          apply (clarsimp simp: APIType_capBits_def word_bits_def
-             objBits_simps archObjSize_def ptr_add_def o_def)
-          apply (fastforce simp: objBitsKO_def  objBits_def)
-        apply (wp createObjects_ret2
-          | clarsimp simp: APIType_capBits_def objBits_if_dev archObjSize_def
-                        word_bits_def vspace_bits_defs vcpu_bits_def
-                        split del: if_split
-          | simp add: objBits_simps
-          | (rule exI, fastforce))+
-  done
+         apply (rename_tac apiobject_type)
+         apply (case_tac apiobject_type, simp_all split del: if_split)
+             \<comment>\<open>Untyped\<close>
+             apply (rule hoare_pre, wp)
+             apply (frule range_cover_not_zero[rotated -1],simp)
+             apply (clarsimp simp: APIType_capBits_def objBits_simps ptr_add_def o_def)
+             apply (subst upto_enum_red')
+              apply unat_arith
+             apply (clarsimp simp: o_def fromIntegral_def toInteger_nat fromInteger_nat)
+             apply fastforce
+            \<comment>\<open>TCB\<close>
+            apply (rule hoare_pre, wp createObjects_ret2)
+             apply (wpsimp simp: curDomain_def)
+            apply (clarsimp simp: APIType_capBits_def word_bits_def objBits_simps ptr_add_def o_def)
+            apply (fastforce simp: objBitsKO_def objBits_def)
+          \<comment>\<open>other APIObjectType\<close>
+          apply ((rule hoare_pre, wp createObjects_ret2,
+                  clarsimp simp: APIType_capBits_def word_bits_def objBits_simps ptr_add_def o_def,
+                  fastforce simp: objBitsKO_def objBits_def)+)[3]
+        \<comment>\<open>Arch objects\<close>
+        by (wp createObjects_ret2
+            | clarsimp simp: APIType_capBits_def objBits_if_dev word_bits_def vspace_bits_defs vcpu_bits_def
+                  split del: if_split
+            | simp add: objBits_simps
+            | (rule exI, fastforce))+
 
 lemma createNewCaps_range_helper2:
   "\<lbrace>\<lambda>s. range_cover ptr sz (APIType_capBits tp us) n \<and> 0 < n\<rbrace>
@@ -4066,9 +4060,6 @@ end
 
 context begin interpretation Arch . (*FIXME: arch-split*)
 
-lemma valid_sched_etcbs[elim!]: "valid_sched_2 queues ekh sa cdom kh ct it \<Longrightarrow> valid_etcbs_2 ekh kh"
-  by (simp add: valid_sched_def)
-
 crunch deleteObjects
   for ksIdleThread[wp]: "\<lambda>s. P (ksIdleThread s)"
   (simp: crunch_simps wp: hoare_drop_imps unless_wp ignore: freeMemory)
@@ -4985,7 +4976,7 @@ lemma inv_untyped_corres':
                 invs_distinct)
          apply (clarsimp simp:conj_comms ball_conj_distrib ex_in_conv)
          apply ((rule validE_R_validE)?,
-            rule_tac Q'="\<lambda>_ s. valid_etcbs s \<and> valid_list s \<and> invs s \<and> ct_active s
+            rule_tac Q'="\<lambda>_ s. valid_list s \<and> invs s \<and> ct_active s
           \<and> valid_untyped_inv_wcap ui
             (Some (cap.UntypedCap dev (ptr && ~~ mask sz) sz (if reset then 0 else idx))) s
           \<and> (reset \<longrightarrow> pspace_no_overlap {ptr && ~~ mask sz..(ptr && ~~ mask sz) + 2 ^ sz - 1} s)
@@ -5073,7 +5064,7 @@ lemma inv_untyped_corres':
       apply (clarsimp simp only: pred_conj_def invs ui)
       apply (strengthen vui)
       apply (cut_tac vui invs invs')
-      apply (clarsimp simp: cte_wp_at_caps_of_state valid_sched_etcbs schact_is_rct_def)
+      apply (clarsimp simp: cte_wp_at_caps_of_state schact_is_rct_def)
      apply (cut_tac vui' invs')
      apply (clarsimp simp: ui cte_wp_at_ctes_of if_apply_def2 ui')
      done

--- a/proof/refine/ARM_HYP/VSpace_R.thy
+++ b/proof/refine/ARM_HYP/VSpace_R.thy
@@ -779,12 +779,11 @@ lemma setObject_VCPU_corres:
   apply (simp add: set_vcpu_def)
   apply (rule corres_guard_imp)
     apply (rule setObject_other_corres [where P="\<lambda>ko::vcpu. True"], simp)
-         apply (clarsimp simp: obj_at'_def projectKOs)
-         apply (erule map_to_ctes_upd_other, simp, simp)
-        apply (simp add: a_type_def is_other_obj_relation_type_def)
-       apply (simp add: objBits_simps archObjSize_def)
-      apply simp
-     apply (simp add: objBits_simps archObjSize_def vcpu_bits_def pageBits_def)
+        apply (clarsimp simp: obj_at'_def projectKOs)
+        apply (erule map_to_ctes_upd_other, simp, simp)
+       apply (simp add: a_type_def is_other_obj_relation_type_def)
+      apply (simp add: objBits_simps)
+     apply (simp add: objBits_simps vcpu_bits_def pageBits_def)
     apply (simp add: other_obj_relation_def asid_pool_relation_def)
    apply (clarsimp simp: typ_at_to_obj_at'[symmetric] obj_at_def exs_valid_def
                          assert_def a_type_def return_def fail_def)
@@ -1387,7 +1386,7 @@ crunch deleteASID
 
 lemma deleteASID_corres:
   "corres dc
-          (invs and valid_etcbs and K (asid \<le> mask asid_bits \<and> asid \<noteq> 0))
+          (invs and K (asid \<le> mask asid_bits \<and> asid \<noteq> 0))
           (pspace_aligned' and pspace_distinct' and no_0_obj'
               and valid_arch_state' and cur_tcb')
           (delete_asid asid pd) (deleteASID asid pd)"
@@ -1399,7 +1398,7 @@ lemma deleteASID_corres:
       apply (rule_tac P="\<lambda>s. asid_high_bits_of asid \<in> dom (asidTable o ucast) \<longrightarrow>
                              asid_pool_at (the ((asidTable o ucast) (asid_high_bits_of asid))) s" and
                       P'="pspace_aligned' and pspace_distinct'" and
-                      Q="invs and valid_etcbs and K (asid \<le> mask asid_bits \<and> asid \<noteq> 0) and
+                      Q="invs and K (asid \<le> mask asid_bits \<and> asid \<noteq> 0) and
                          (\<lambda>s. arm_asid_table (arch_state s) = asidTable \<circ> ucast)" in
                       corres_split)
          apply (simp add: dom_def)
@@ -1407,8 +1406,7 @@ lemma deleteASID_corres:
         apply (rule corres_when, simp add: mask_asid_low_bits_ucast_ucast)
         apply (rule corres_split[OF flushSpace_corres[where pd=pd]])
           apply (rule corres_split[OF invalidateASIDEntry_corres[where pd=pd]])
-            apply (rule_tac P="asid_pool_at (the (asidTable (ucast (asid_high_bits_of asid))))
-                               and valid_etcbs"
+            apply (rule_tac P="asid_pool_at (the (asidTable (ucast (asid_high_bits_of asid))))"
                         and P'="pspace_aligned' and pspace_distinct'"
                          in corres_split)
                apply (simp del: fun_upd_apply)
@@ -2037,7 +2035,7 @@ lemma storePDE_InvalidPDE_valid_arch_state'[wp]:
 
 lemma unmapPageTable_corres:
   "corres dc
-          (invs and valid_etcbs and page_table_at pt and
+          (invs and page_table_at pt and
            K (0 < asid \<and> is_aligned vptr 21 \<and> asid \<le> mask asid_bits))
           (valid_arch_state' and pspace_aligned' and pspace_distinct'
             and no_0_obj' and cur_tcb' and valid_objs')
@@ -2191,7 +2189,7 @@ lemma is_aligned_dvd_k: "\<lbrakk>  2 ^ m  * (k :: nat) = 2 ^ n  ; is_aligned p 
   done
 
 lemma unmapPage_corres:
-  "corres dc (invs and valid_etcbs and
+  "corres dc (invs and
               K (valid_unmap sz (asid,vptr) \<and> vptr < kernel_base \<and> asid \<le> mask asid_bits))
              (valid_objs' and valid_arch_state' and pspace_aligned' and
               pspace_distinct' and no_0_obj' and cur_tcb')
@@ -2208,7 +2206,7 @@ lemma unmapPage_corres:
                                and (\<exists>\<rhd> (lookup_pd_slot pd vptr && ~~ mask pd_bits))
                                and valid_arch_state and valid_vspace_objs
                                and equal_kernel_mappings
-                               and pspace_aligned and valid_etcbs and
+                               and pspace_aligned and
                                K (valid_unmap sz (asid,vptr) )" and
                             P'="pspace_aligned' and pspace_distinct'" in corres_inst)
             apply clarsimp
@@ -2248,7 +2246,7 @@ lemma unmapPage_corres:
                            apply simp
                           apply simp
                          apply clarsimp
-                         apply (rule_tac P="(\<lambda>s. \<forall>x\<in>set largePagePTEOffsets. pte_at (x + pa) s) and pspace_aligned and valid_etcbs"
+                         apply (rule_tac P="(\<lambda>s. \<forall>x\<in>set largePagePTEOffsets. pte_at (x + pa) s) and pspace_aligned"
                                         and P'="pspace_aligned' and pspace_distinct'"
                                         in corres_guard_imp)
                            apply (rule storePTE_corres',  simp add:pte_relation_aligned_def)
@@ -2294,7 +2292,7 @@ lemma unmapPage_corres:
                               in corres_gen_asm)
                 apply (simp add: is_aligned_mask[symmetric])
                 apply (rule corres_split)
-                   apply (rule_tac P="page_directory_at pd and pspace_aligned and valid_etcbs
+                   apply (rule_tac P="page_directory_at pd and pspace_aligned
                                          and K (valid_unmap sz (asid, vptr))"
                                in corres_mapM [where r=dc], simp, simp)
                        prefer 5
@@ -2613,7 +2611,7 @@ lemma triple_set_zip_eq:
 
 lemma corres_store_pde_with_invalid_tail:
   "\<lbrakk> \<forall>slot \<in>set ys. \<not> is_aligned (slot >> pde_bits) (pde_align' ab); length ys < 2^word_bits \<rbrakk>
-  \<Longrightarrow>corres dc ((\<lambda>s. \<forall>y\<in> set ys. pde_at y s) and pspace_aligned and valid_etcbs)
+  \<Longrightarrow>corres dc ((\<lambda>s. \<forall>y\<in> set ys. pde_at y s) and pspace_aligned)
            (pspace_aligned' and pspace_distinct')
            (mapM (swp store_pde ARM_HYP_A.pde.InvalidPDE) ys)
            (mapM (\<lambda>(slot, i). storePDE slot (addPDEOffset ab i)) (zip ys [1.e.of_nat (length ys)]))"
@@ -2637,7 +2635,7 @@ lemma corres_store_pde_with_invalid_tail:
 
 lemma corres_store_pte_with_invalid_tail:
   "\<lbrakk> \<forall>slot\<in> set ys. \<not> is_aligned (slot >> pte_bits) (pte_align' aa); length ys < 2^word_bits\<rbrakk>
-  \<Longrightarrow> corres dc ((\<lambda>s. \<forall>y\<in>set ys. pte_at y s) and pspace_aligned and valid_etcbs)
+  \<Longrightarrow> corres dc ((\<lambda>s. \<forall>y\<in>set ys. pte_at y s) and pspace_aligned)
                 (pspace_aligned' and pspace_distinct')
              (mapM (swp store_pte ARM_HYP_A.pte.InvalidPTE) ys)
              (mapM (\<lambda>(slot, i). storePTE slot (addPTEOffset aa i)) (zip ys [1.e.of_nat (length ys)]))"
@@ -2847,7 +2845,7 @@ lemma valid_slots_duplicated'_length_Inr:
 
 lemma performPageInvocation_corres:
   assumes "page_invocation_map pgi pgi'"
-  shows "corres (=) (invs and valid_etcbs and valid_page_inv pgi)
+  shows "corres (=) (invs and valid_page_inv pgi)
             (invs' and valid_page_inv' pgi' and (\<lambda>s. vs_valid_duplicates' (ksPSpace s)))
             (perform_page_invocation pgi) (performPageInvocation pgi')"
 proof -
@@ -2861,7 +2859,7 @@ proof -
      \<comment> \<open>PageMap\<close>
      apply (clarsimp simp: perform_page_invocation_def performPageInvocation_def page_invocation_map_def)
      apply (rule corres_guard_imp)
-       apply (rule_tac R="\<lambda>_. invs and (valid_page_map_inv word cap (a,b) sum) and valid_etcbs
+       apply (rule_tac R="\<lambda>_. invs and (valid_page_map_inv word cap (a,b) sum)
                           and (\<lambda>s. caps_of_state s (a,b) = Some cap)"
                 and R'="\<lambda>_. invs' and valid_slots' m' and pspace_aligned' and valid_slots_duplicated' m'
                         and pspace_distinct' and (\<lambda>s. vs_valid_duplicates' (ksPSpace s))" in corres_split)
@@ -3103,7 +3101,7 @@ definition
                                  and K (isPageTableCap cap)"
 
 lemma clear_page_table_corres:
-  "corres dc (pspace_aligned and page_table_at p and valid_etcbs)
+  "corres dc (pspace_aligned and page_table_at p)
              (pspace_aligned' and pspace_distinct')
     (mapM_x (swp store_pte ARM_HYP_A.InvalidPTE)
        [p , p + 8 .e. p + 2 ^ ptBits - 1])
@@ -3121,7 +3119,7 @@ lemma clear_page_table_corres:
                    mapM_x_mapM liftM_def[symmetric])
   apply (rule corres_guard_imp,
          rule_tac r'=dc and S="(=)"
-               and Q="\<lambda>xs s. \<forall>x \<in> set xs. pte_at x s \<and> pspace_aligned s \<and> valid_etcbs s"
+               and Q="\<lambda>xs s. \<forall>x \<in> set xs. pte_at x s \<and> pspace_aligned s"
                and Q'="\<lambda>xs. pspace_aligned' and pspace_distinct'"
                 in corres_mapM_list_all2, simp_all)
       apply (rule corres_guard_imp, rule storePTE_corres')
@@ -3141,7 +3139,7 @@ lemmas unmapPageTable_typ_ats[wp] = typ_at_lifts[OF unmapPageTable_typ_at']
 lemma performPageTableInvocation_corres:
   "page_table_invocation_map pti pti' \<Longrightarrow>
    corres dc
-          (invs and valid_etcbs and valid_pti pti)
+          (invs and valid_pti pti)
           (invs' and valid_pti' pti')
           (perform_page_table_invocation pti)
           (performPageTableInvocation pti')"
@@ -3229,7 +3227,7 @@ definition (* ARMHYP: need review *)
 lemma performASIDPoolInvocation_corres:
   "ap' = asid_pool_invocation_map ap \<Longrightarrow>
   corres dc
-          (valid_objs and pspace_aligned and pspace_distinct and valid_apinv ap and valid_etcbs)
+          (valid_objs and pspace_aligned and pspace_distinct and valid_apinv ap)
           (pspace_aligned' and pspace_distinct' and valid_apinv' ap')
           (perform_asid_pool_invocation ap)
           (performASIDPoolInvocation ap')"
@@ -3241,7 +3239,7 @@ lemma performASIDPoolInvocation_corres:
        apply simp
       apply (rule_tac F="\<exists>p asid. rv = Structures_A.ArchObjectCap (ARM_HYP_A.PageDirectoryCap p asid)" in corres_gen_asm)
       apply clarsimp
-      apply (rule_tac Q="valid_objs and pspace_aligned and pspace_distinct and asid_pool_at word2 and valid_etcbs and
+      apply (rule_tac Q="valid_objs and pspace_aligned and pspace_distinct and asid_pool_at word2 and
                          cte_wp_at (\<lambda>c. cap_master_cap c =
                                         cap_master_cap (cap.ArchObjectCap (arch_cap.PageDirectoryCap p asid))) (a,b)"
                       in corres_split)

--- a/proof/refine/RISCV64/ADT_H.thy
+++ b/proof/refine/RISCV64/ADT_H.thy
@@ -250,6 +250,9 @@ definition
       tcb_fault = map_option FaultMap (tcbFault tcb),
       tcb_bound_notification = tcbBoundNotification tcb,
       tcb_mcpriority = tcbMCP tcb,
+      tcb_priority = tcbPriority tcb,
+      tcb_time_slice = tcbTimeSlice tcb,
+      tcb_domain = tcbDomain tcb,
       tcb_arch = ArchTcbMap (tcbArch tcb)\<rparr>"
 
 definition
@@ -711,53 +714,6 @@ proof -
     apply (clarsimp split: if_splits)
     done
 qed
-
-definition
-  "EtcbMap tcb \<equiv>
-     \<lparr>tcb_priority = tcbPriority tcb,
-      time_slice = tcbTimeSlice tcb,
-      tcb_domain = tcbDomain tcb\<rparr>"
-
-definition absEkheap ::
-  "(machine_word \<rightharpoonup> Structures_H.kernel_object) \<Rightarrow> obj_ref \<Rightarrow> etcb option" where
-  "absEkheap h \<equiv> \<lambda>x.
-     case h x of
-       Some (KOTCB tcb) \<Rightarrow> Some (EtcbMap tcb)
-     | _ \<Rightarrow> None"
-
-lemma absEkheap_correct:
-  assumes pspace_relation: "pspace_relation (kheap s) (ksPSpace s')"
-  assumes ekheap_relation: "ekheap_relation (ekheap s) (ksPSpace s')"
-  assumes vetcbs: "valid_etcbs s"
-  shows "absEkheap (ksPSpace s') = ekheap s"
-  apply (rule ext)
-  apply (clarsimp simp: absEkheap_def split: option.splits Structures_H.kernel_object.splits)
-  apply (subgoal_tac "\<forall>x. (\<exists>tcb. kheap s x = Some (TCB tcb)) =
-                          (\<exists>tcb'. ksPSpace s' x = Some (KOTCB tcb'))")
-   using vetcbs ekheap_relation
-   apply (clarsimp simp: valid_etcbs_def is_etcb_at_def dom_def ekheap_relation_def st_tcb_at_def obj_at_def)
-   apply (erule_tac x=x in allE)+
-   apply (rule conjI, force)
-   apply clarsimp
-   apply (rule conjI, clarsimp simp: EtcbMap_def etcb_relation_def)+
-   apply clarsimp
-  using pspace_relation
-  apply (clarsimp simp add: pspace_relation_def pspace_dom_def UNION_eq
-                              dom_def Collect_eq)
-  apply (rule iffI)
-   apply (erule_tac x=x in allE)+
-   apply (case_tac "ksPSpace s' x", clarsimp)
-    apply (erule_tac x=x in allE, clarsimp)
-   apply clarsimp
-   apply (case_tac a, simp_all add: tcb_relation_cut_def other_obj_relation_def)
-  apply (insert pspace_relation)
-  apply (clarsimp simp: obj_at'_def)
-  apply (erule(1) pspace_dom_relatedE)
-  apply (erule(1) obj_relation_cutsE)
-     apply (clarsimp simp: other_obj_relation_def
-                    split: Structures_A.kernel_object.split_asm  if_split_asm
-                           RISCV64_A.arch_kernel_obj.split_asm)+
-  done
 
 text \<open>The following function can be used to reverse cte_map.\<close>
 definition
@@ -1518,13 +1474,6 @@ lemma absSchedulerAction_correct:
 definition
   "absExst s \<equiv>
      \<lparr>work_units_completed_internal = ksWorkUnitsCompleted s,
-      scheduler_action_internal = absSchedulerAction (ksSchedulerAction s),
-      ekheap_internal = absEkheap (ksPSpace s),
-      domain_list_internal = ksDomSchedule s,
-      domain_index_internal = ksDomScheduleIdx s,
-      cur_domain_internal = ksCurDomain s,
-      domain_time_internal = ksDomainTime s,
-      ready_queues_internal = (\<lambda>d p. heap_walk (tcbSchedNexts_of s) (tcbQueueHead (ksReadyQueues s (d, p))) []),
       cdt_list_internal = absCDTList (cteMap (gsCNodes s)) (ctes_of s)\<rparr>"
 
 lemma absExst_correct:
@@ -1532,16 +1481,12 @@ lemma absExst_correct:
   assumes rel: "(s, s') \<in> state_relation"
   shows "absExst s' = exst s"
   apply (rule det_ext.equality)
-           using rel invs invs'
-           apply (simp_all add: absExst_def absSchedulerAction_correct absEkheap_correct
-                                absCDTList_correct[THEN fun_cong] state_relation_def invs_def
-                                valid_state_def ready_queues_relation_def ready_queue_relation_def
-                                invs'_def valid_state'_def
-                                valid_pspace_def valid_sched_def valid_pspace'_def curry_def
-                                fun_eq_iff)
-   apply (fastforce simp: absEkheap_correct)
-  apply (fastforce simp: list_queue_relation_def Let_def dest: heap_ls_is_walk)
-  done
+      using rel invs invs'
+      apply (simp_all add: absExst_def absSchedulerAction_correct
+                           absCDTList_correct[THEN fun_cong] state_relation_def invs_def valid_state_def
+                           ready_queues_relation_def invs'_def valid_state'_def
+                           valid_pspace_def valid_sched_def valid_pspace'_def curry_def fun_eq_iff)
+      done
 
 
 definition
@@ -1550,6 +1495,12 @@ definition
     cdt = absCDT (cteMap (gsCNodes s)) (ctes_of s),
     is_original_cap = absIsOriginalCap (cteMap (gsCNodes s)) (ksPSpace s),
     cur_thread = ksCurThread s, idle_thread = ksIdleThread s,
+    scheduler_action = absSchedulerAction (ksSchedulerAction s),
+    domain_list = ksDomSchedule s,
+    domain_index = ksDomScheduleIdx s,
+    cur_domain = ksCurDomain s,
+    domain_time = ksDomainTime s,
+    ready_queues = (\<lambda>d p. heap_walk (tcbSchedNexts_of s) (tcbQueueHead (ksReadyQueues s (d, p))) []),
     machine_state = observable_memory (ksMachineState s) (user_mem' s),
     interrupt_irq_node = absInterruptIRQNode (ksInterruptState s),
     interrupt_states = absInterruptStates (ksInterruptState s),

--- a/proof/refine/RISCV64/ArchAcc_R.thy
+++ b/proof/refine/RISCV64/ArchAcc_R.thy
@@ -444,11 +444,6 @@ lemma setObject_PT_corres:
      apply ((simp split: if_split_asm)+)[2]
    apply (simp add: other_obj_relation_def
                split: Structures_A.kernel_object.splits arch_kernel_obj.splits)
-  apply (rule conjI)
-   apply (clarsimp simp: ekheap_relation_def pspace_relation_def)
-   apply (drule_tac x=p in bspec, erule domI)
-   apply (simp add: other_obj_relation_def
-           split: Structures_A.kernel_object.splits)
   apply (extract_conjunct \<open>match conclusion in "ghost_relation _ _ _" \<Rightarrow> -\<close>)
    apply (clarsimp simp add: ghost_relation_def)
    apply (erule_tac x="p && ~~ mask pt_bits" in allE)+

--- a/proof/refine/RISCV64/ArchInvsLemmas_H.thy
+++ b/proof/refine/RISCV64/ArchInvsLemmas_H.thy
@@ -443,4 +443,24 @@ lemma objBitsT_koTypeOf:
 
 end
 
+context Arch begin
+
+lemma objBits_less_word_bits:
+  "objBits v < word_bits"
+  unfolding objBits_simps'
+  apply (case_tac "injectKO v"; simp)
+  by (simp add: pageBits_def pteBits_def objBits_simps word_bits_def
+         split: arch_kernel_object.split)+
+
+lemma objBits_pos_power2[simp]:
+  assumes "objBits v < word_bits"
+  shows "(1::machine_word) < (2::machine_word) ^ objBits v"
+  unfolding objBits_simps'
+  apply (insert assms)
+  apply (case_tac "injectKO v"; simp)
+  by (simp add: pageBits_def pteBits_def objBits_simps
+         split: arch_kernel_object.split)+
+
+end
+
 end

--- a/proof/refine/RISCV64/ArchMove_R.thy
+++ b/proof/refine/RISCV64/ArchMove_R.thy
@@ -24,10 +24,6 @@ context Arch begin arch_global_naming
 definition ppn_len :: nat where
   "ppn_len \<equiv> LENGTH(pte_ppn_len)"
 
-(* Move to Deterministic_AI *)
-crunch copy_global_mappings
-  for valid_etcbs[wp]: valid_etcbs (wp: mapM_x_wp')
-
 lemma get_pt_mapM_x_lower:
   assumes g: "\<And>P pt x. \<lbrace> \<lambda>s. P (kheap s pt_ptr) \<rbrace> g pt x \<lbrace> \<lambda>_ s. P (kheap s pt_ptr) \<rbrace>"
   assumes y: "ys \<noteq> []"

--- a/proof/refine/RISCV64/Arch_R.thy
+++ b/proof/refine/RISCV64/Arch_R.thy
@@ -95,24 +95,6 @@ lemma createObject_typ_at':
   apply (clarsimp simp: is_aligned_no_overflow_mask)
   done
 
-lemma retype_region2_ext_retype_region_ArchObject:
-  "retype_region ptr n us (ArchObject x)=
-  retype_region2 ptr n us (ArchObject x)"
-  apply (rule ext)
-  apply (simp add: retype_region_def retype_region2_def bind_assoc
-                   retype_region2_ext_def retype_region_ext_def default_ext_def)
-  apply (rule ext)
-  apply (intro monad_eq_split_tail ext)+
-     apply simp
-    apply simp
-   apply (simp add:gets_def get_def bind_def return_def simpler_modify_def )
-   apply (rule_tac x = xc in fun_cong)
-   apply (rule_tac f = do_extended_op in arg_cong)
-   apply (rule ext)
-   apply simp
-  apply simp
-  done
-
 lemma set_cap_device_and_range_aligned:
   "is_aligned ptr sz \<Longrightarrow> \<lbrace>\<lambda>_. True\<rbrace>
     set_cap
@@ -165,7 +147,6 @@ lemma performASIDControlInvocation_corres:
             apply (clarsimp simp:is_cap_simps)
            apply (simp add: free_index_of_def)
           apply (rule corres_split)
-             apply (simp add: retype_region2_ext_retype_region_ArchObject )
              apply (rule corres_retype [where ty="Inl (KOArch (KOASIDPool F))" for F,
                                         unfolded APIType_map2_def makeObjectKO_def,
                                         THEN createObjects_corres',simplified,
@@ -314,8 +295,8 @@ lemma performASIDControlInvocation_corres:
    apply (rule conjI, rule pspace_no_overlap_subset,
          rule pspace_no_overlap_detype[OF caps_of_state_valid])
         apply (simp add:invs_psp_aligned invs_valid_objs is_aligned_neg_mask_eq)+
-   apply (clarsimp simp: detype_def clear_um_def detype_ext_def valid_sched_def valid_etcbs_def
-            st_tcb_at_kh_def obj_at_kh_def st_tcb_at_def obj_at_def is_etcb_at_def)
+   apply (clarsimp simp: detype_def clear_um_def valid_sched_def
+                         st_tcb_at_kh_def obj_at_kh_def st_tcb_at_def obj_at_def)
   apply (simp add: detype_def clear_um_def)
   apply (drule_tac x = "cte_map (p', slot')" in pspace_relation_cte_wp_atI[OF state_relation_pspace_relation])
     apply (simp add:invs_valid_objs)+

--- a/proof/refine/RISCV64/CSpace1_R.thy
+++ b/proof/refine/RISCV64/CSpace1_R.thy
@@ -1755,37 +1755,30 @@ proof -
     done
 qed
 
-definition pspace_relations where
-  "pspace_relations ekh kh kh' \<equiv> pspace_relation kh kh' \<and> ekheap_relation ekh kh'"
-
 lemma set_cap_not_quite_corres_prequel:
   assumes cr:
-  "pspace_relations (ekheap s) (kheap s) (ksPSpace s')"
+  "pspace_relation (kheap s) (ksPSpace s')"
   "(x,t') \<in> fst (setCTE p' c' s')"
   "valid_objs s" "pspace_aligned s" "pspace_distinct s" "cte_at p s"
   "pspace_aligned' s'" "pspace_distinct' s'"
   assumes c: "cap_relation c (cteCap c')"
   assumes p: "p' = cte_map p"
   shows "\<exists>t. ((),t) \<in> fst (set_cap c p s) \<and>
-             pspace_relations (ekheap t) (kheap t) (ksPSpace t')"
+             pspace_relation (kheap t) (ksPSpace t')"
   using cr
   apply (clarsimp simp: setCTE_def setObject_def in_monad split_def)
   apply (drule(1) updateObject_cte_is_tcb_or_cte[OF _ refl, rotated])
   apply (elim disjE exE conjE)
-   apply (clarsimp simp: lookupAround2_char1 pspace_relations_def)
+   apply (clarsimp simp: lookupAround2_char1)
    apply (frule(5) cte_map_pulls_tcb_to_abstract[OF p])
     apply (simp add: domI)
    apply (frule tcb_cases_related2)
    apply (clarsimp simp: set_cap_def2 split_def bind_def get_object_def
                          simpler_gets_def assert_def fail_def return_def
                          set_object_def get_def put_def)
-   apply (rule conjI)
-    apply (erule(2) pspace_relation_update_tcbs)
-    apply (simp add: c)
-   apply (clarsimp simp: ekheap_relation_def pspace_relation_def)
-   apply (drule bspec, erule domI)
-   apply (clarsimp simp: etcb_relation_def tcb_cte_cases_def split: if_split_asm)
-  apply (clarsimp simp: pspace_relations_def)
+   apply (erule(2) pspace_relation_update_tcbs)
+   apply (simp add: c)
+  apply clarsimp
   apply (frule(5) cte_map_pulls_cte_to_abstract[OF p])
   apply (clarsimp simp: set_cap_def split_def bind_def get_object_def
                         simpler_gets_def assert_def a_type_def fail_def return_def
@@ -1793,24 +1786,20 @@ lemma set_cap_not_quite_corres_prequel:
   apply (erule(1) valid_objsE)
   apply (clarsimp simp: valid_obj_def valid_cs_def valid_cs_size_def exI)
   apply (rule conjI, clarsimp)
-   apply (rule conjI)
-    apply (erule(1) pspace_relation_update_ctes[where cap=c])
-     apply clarsimp
-     apply (intro conjI impI)
-      apply (rule ext, clarsimp simp add: domI p)
-      apply (drule cte_map_inj_eq [OF _ _ cr(6) cr(3-5)])
-       apply (simp add: cte_at_cases domI)
-      apply (simp add: prod_eq_iff)
-     apply (insert p)[1]
-     apply (clarsimp split: option.split Structures_A.kernel_object.split
-                    intro!: ext)
+   apply (erule(1) pspace_relation_update_ctes[where cap=c])
+    apply clarsimp
+    apply (intro conjI impI)
+     apply (rule ext, clarsimp simp add: domI p)
      apply (drule cte_map_inj_eq [OF _ _ cr(6) cr(3-5)])
-      apply (simp add: cte_at_cases domI well_formed_cnode_invsI[OF cr(3)])
-     apply clarsimp
-    apply (simp add: c)
-   apply (clarsimp simp: ekheap_relation_def pspace_relation_def)
-   apply (drule bspec, erule domI)
-   apply (clarsimp simp: etcb_relation_def tcb_cte_cases_def split: if_split_asm)
+      apply (simp add: cte_at_cases domI)
+     apply (simp add: prod_eq_iff)
+    apply (insert p)[1]
+    apply (clarsimp split: option.split Structures_A.kernel_object.split
+                   intro!: ext)
+    apply (drule cte_map_inj_eq [OF _ _ cr(6) cr(3-5)])
+     apply (simp add: cte_at_cases domI well_formed_cnode_invsI[OF cr(3)])
+    apply clarsimp
+   apply (simp add: c)
   apply (simp add: wf_cs_insert)
   done
 
@@ -1823,7 +1812,7 @@ lemma setCTE_pspace_only:
 
 lemma set_cap_not_quite_corres:
   assumes cr:
-  "pspace_relations (ekheap s) (kheap s) (ksPSpace s')"
+  "pspace_relation (kheap s) (ksPSpace s')"
   "cur_thread s = ksCurThread s'"
   "idle_thread s = ksIdleThread s'"
   "machine_state s = ksMachineState s'"
@@ -1840,10 +1829,9 @@ lemma set_cap_not_quite_corres:
   assumes c: "cap_relation c c'"
   assumes p: "p' = cte_map p"
   shows "\<exists>t. ((),t) \<in> fst (set_cap c p s) \<and>
-             pspace_relations (ekheap t) (kheap t) (ksPSpace t') \<and>
+             pspace_relation (kheap t) (ksPSpace t') \<and>
              cdt t = cdt s \<and>
              cdt_list t = cdt_list s \<and>
-             ekheap t = ekheap s \<and>
              scheduler_action t = scheduler_action s \<and>
              ready_queues t = ready_queues s \<and>
              is_original_cap t = is_original_cap s \<and>
@@ -2468,10 +2456,6 @@ lemma capClass_ztc_relation:
        cap_relation c c' \<rbrakk> \<Longrightarrow> capClass c' = PhysicalClass"
   by (auto simp: is_cap_simps)
 
-lemma pspace_relationsD:
-  "\<lbrakk>pspace_relation kh kh'; ekheap_relation ekh kh'\<rbrakk> \<Longrightarrow> pspace_relations ekh kh kh'"
-  by (simp add: pspace_relations_def)
-
 lemma updateCap_corres:
   "\<lbrakk>cap_relation cap cap';
     is_zombie cap \<or> is_cnode_cap cap \<or> is_thread_cap cap \<rbrakk>
@@ -2493,14 +2477,13 @@ lemma updateCap_corres:
     apply fastforce
    apply (clarsimp simp: cte_wp_at_ctes_of)
   apply (clarsimp simp add: state_relation_def)
-  apply (drule(1) pspace_relationsD)
   apply (frule (3) set_cap_not_quite_corres; fastforce?)
    apply (erule cte_wp_at_weakenE, rule TrueI)
   apply clarsimp
   apply (rule bexI)
    prefer 2
    apply simp
-  apply (clarsimp simp: in_set_cap_cte_at_swp pspace_relations_def)
+  apply (clarsimp simp: in_set_cap_cte_at_swp)
   apply (drule updateCap_stuff)
   apply simp
   apply (extract_conjunct \<open>match conclusion in "ghost_relation _ _ _" \<Rightarrow> -\<close>)
@@ -2622,24 +2605,6 @@ lemma updateMDB_pspace_relation:
   apply fastforce
   done
 
-lemma updateMDB_ekheap_relation:
-  assumes "(x, s'') \<in> fst (updateMDB p f s')"
-  assumes "ekheap_relation (ekheap s) (ksPSpace s')"
-  shows "ekheap_relation (ekheap s) (ksPSpace s'')" using assms
-  apply (clarsimp simp: updateMDB_def Let_def setCTE_def setObject_def in_monad ekheap_relation_def etcb_relation_def split_def split: if_split_asm)
-  apply (drule(1) updateObject_cte_is_tcb_or_cte[OF _ refl, rotated])
-  apply (drule_tac P="(=) s'" in use_valid [OF _ getCTE_sp], rule refl)
-  apply (drule bspec, erule domI)
-  apply (clarsimp simp: tcb_cte_cases_def lookupAround2_char1 split: if_split_asm)
-  done
-
-lemma updateMDB_pspace_relations:
-  assumes "(x, s'') \<in> fst (updateMDB p f s')"
-  assumes "pspace_relations (ekheap s) (kheap s) (ksPSpace s')"
-  assumes "pspace_aligned' s'" "pspace_distinct' s'"
-  shows "pspace_relations (ekheap s) (kheap s) (ksPSpace s'')" using assms
-  by (simp add: pspace_relations_def updateMDB_pspace_relation updateMDB_ekheap_relation)
-
 lemma updateMDB_ctes_of:
   assumes "(x, s') \<in> fst (updateMDB p f s)"
   assumes "no_0 (ctes_of s)"
@@ -2684,7 +2649,7 @@ crunch updateMDB
 
 lemma updateMDB_the_lot:
   assumes "(x, s'') \<in> fst (updateMDB p f s')"
-  assumes "pspace_relations (ekheap s) (kheap s) (ksPSpace s')"
+  assumes "pspace_relation (kheap s) (ksPSpace s')"
   assumes "pspace_aligned' s'" "pspace_distinct' s'" "no_0 (ctes_of s')"
   shows "ctes_of s'' = modify_map (ctes_of s') p (cteMDBNode_update f) \<and>
          ksMachineState s'' = ksMachineState s' \<and>
@@ -2697,7 +2662,7 @@ lemma updateMDB_the_lot:
          ksArchState s'' = ksArchState s' \<and>
          gsUserPages s'' = gsUserPages s' \<and>
          gsCNodes s'' = gsCNodes s' \<and>
-         pspace_relations (ekheap s) (kheap s) (ksPSpace s'') \<and>
+         pspace_relation (kheap s) (ksPSpace s'') \<and>
          pspace_aligned' s'' \<and> pspace_distinct' s'' \<and>
          no_0 (ctes_of s'') \<and>
          ksDomScheduleIdx s'' = ksDomScheduleIdx s' \<and>
@@ -2709,7 +2674,7 @@ lemma updateMDB_the_lot:
          (\<forall>domain priority.
             (inQ domain priority |< tcbs_of' s'') = (inQ domain priority |< tcbs_of' s'))"
 using assms
-  apply (simp add: updateMDB_eqs updateMDB_pspace_relations split del: if_split)
+  apply (simp add: updateMDB_eqs updateMDB_pspace_relation split del: if_split)
   apply (frule (1) updateMDB_ctes_of)
   apply clarsimp
   apply (rule conjI)
@@ -3899,7 +3864,6 @@ lemma setCTE_UntypedCap_corres:
    apply (clarsimp simp: cte_wp_at_ctes_of)
   apply clarsimp
   apply (clarsimp simp add: state_relation_def split_def)
-  apply (drule (1) pspace_relationsD)
   apply (frule_tac c = "cap.UntypedCap dev r bits idx"
                 in set_cap_not_quite_corres_prequel)
          apply assumption+
@@ -3910,8 +3874,6 @@ lemma setCTE_UntypedCap_corres:
   apply (rule bexI)
    prefer 2
    apply assumption
-  apply (clarsimp simp: pspace_relations_def)
-  apply (subst conj_assoc[symmetric])
   apply clarsimp
   apply (rule conjI)
    apply (frule setCTE_pspace_only)
@@ -3923,7 +3885,7 @@ lemma setCTE_UntypedCap_corres:
    apply (rule use_valid[OF _ setCTE_tcbSchedNexts_of], assumption)
    apply (rule use_valid[OF _ setCTE_ksReadyQueues], assumption)
    apply (rule use_valid[OF _ setCTE_inQ_opt_pred], assumption)
-   apply (rule use_valid[OF _ set_cap_exst], assumption)
+   apply (rule use_valid[OF _ set_cap_rqueues], assumption)
    apply clarsimp
   apply (rule conjI)
    apply (frule setCTE_pspace_only)
@@ -5186,8 +5148,8 @@ crunch set_untyped_cap_as_full
 
 lemma updateMDB_the_lot':
   assumes "(x, s'') \<in> fst (updateMDB p f s')"
-  assumes "pspace_relations (ekheap sa) (kheap s) (ksPSpace s')"
-  assumes "pspace_aligned' s'" "pspace_distinct' s'" "no_0 (ctes_of s')" "ekheap s = ekheap sa"
+  assumes "pspace_relation (kheap s) (ksPSpace s')"
+  assumes "pspace_aligned' s'" "pspace_distinct' s'" "no_0 (ctes_of s')"
   shows "ctes_of s'' = modify_map (ctes_of s') p (cteMDBNode_update f) \<and>
          ksMachineState s'' = ksMachineState s' \<and>
          ksWorkUnitsCompleted s'' = ksWorkUnitsCompleted s' \<and>
@@ -5199,7 +5161,7 @@ lemma updateMDB_the_lot':
          ksArchState s'' = ksArchState s' \<and>
          gsUserPages s'' = gsUserPages s' \<and>
          gsCNodes s'' = gsCNodes s' \<and>
-         pspace_relations (ekheap s) (kheap s) (ksPSpace s'') \<and>
+         pspace_relation (kheap s) (ksPSpace s'') \<and>
          pspace_aligned' s'' \<and> pspace_distinct' s'' \<and>
          no_0 (ctes_of s'') \<and>
          ksDomScheduleIdx s'' = ksDomScheduleIdx s' \<and>
@@ -5212,7 +5174,7 @@ lemma updateMDB_the_lot':
             (inQ domain priority |< tcbs_of' s'') = (inQ domain priority |< tcbs_of' s'))"
   apply (rule updateMDB_the_lot)
       using assms
-      apply (fastforce simp: pspace_relations_def)+
+      apply fastforce+
    done
 
 lemma cte_map_inj_eq':
@@ -5289,7 +5251,6 @@ lemma cteInsert_corres:
                apply (simp+)[3]
             apply (clarsimp simp: corres_underlying_def state_relation_def
                                   in_monad valid_mdb'_def valid_mdb_ctes_def)
-            apply (drule (1) pspace_relationsD)
             apply (drule (18) set_cap_not_quite_corres)
              apply (rule refl)
             apply (elim conjE exE)
@@ -5328,7 +5289,6 @@ lemma cteInsert_corres:
             apply (thin_tac "ksCurThread t = p" for p t)+
             apply (thin_tac "ksIdleThread t = p" for p t)+
             apply (thin_tac "ksSchedulerAction t = p" for p t)+
-            apply (clarsimp simp: pspace_relations_def)
 
             apply (rule conjI)
              apply (clarsimp simp: ghost_relation_typ_at set_cap_a_type_inv data_at_def)
@@ -6768,7 +6728,6 @@ lemma cteSwap_corres:
   apply (clarsimp simp: corres_underlying_def in_monad
                         state_relation_def)
   apply (clarsimp simp: valid_mdb'_def)
-  apply (drule(1) pspace_relationsD)
   apply (drule (12) set_cap_not_quite_corres)
       apply (erule cte_wp_at_weakenE, rule TrueI)
      apply assumption+
@@ -6804,20 +6763,19 @@ lemma cteSwap_corres:
   apply (simp cong: option.case_cong)
   apply (drule updateCap_stuff, elim conjE, erule(1) impE)
   apply (drule (2) updateMDB_the_lot')
-     apply (erule (1) impE, assumption)
-    apply (fastforce simp only: no_0_modify_map)
-   apply assumption
+    apply (erule (1) impE, assumption)
+   apply (fastforce simp only: no_0_modify_map)
   apply (elim conjE TrueE, simp only:)
-  apply (drule (2) updateMDB_the_lot', fastforce, simp only: no_0_modify_map, assumption)
+  apply (drule (2) updateMDB_the_lot', fastforce, simp only: no_0_modify_map)
   apply (drule in_getCTE, elim conjE, simp only:)
-  apply (drule (2) updateMDB_the_lot', fastforce, simp only: no_0_modify_map, assumption)
+  apply (drule (2) updateMDB_the_lot', fastforce, simp only: no_0_modify_map)
   apply (elim conjE TrueE, simp only:)
-  apply (drule (2) updateMDB_the_lot', fastforce, simp only: no_0_modify_map, assumption)
+  apply (drule (2) updateMDB_the_lot', fastforce, simp only: no_0_modify_map)
   apply (elim conjE TrueE, simp only:)
-  apply (drule (2) updateMDB_the_lot', fastforce, simp only: no_0_modify_map, assumption)
+  apply (drule (2) updateMDB_the_lot', fastforce, simp only: no_0_modify_map)
   apply (elim conjE TrueE, simp only:)
-  apply (drule (2) updateMDB_the_lot', fastforce, simp only: no_0_modify_map, assumption)
-  apply (simp only: pspace_relations_def refl)
+  apply (drule (2) updateMDB_the_lot', fastforce, simp only: no_0_modify_map)
+  apply (simp only: refl)
   apply (rule conjI, rule TrueI)+
   apply (thin_tac "ksMachineState t = p" for t p)+
   apply (thin_tac "ksCurThread t = p" for t p)+
@@ -6866,7 +6824,6 @@ lemma cteSwap_corres:
   apply (thin_tac "domain_index t = p" for t p)+
   apply (thin_tac "domain_list t = p" for t p)+
   apply (thin_tac "domain_time t = p" for t p)+
-  apply (thin_tac "ekheap t = p" for t p)+
   apply (thin_tac "scheduler_action t = p" for t p)+
   apply (thin_tac "ksArchState t = p" for t p)+
   apply (thin_tac "gsCNodes t = p" for t p)+
@@ -6875,7 +6832,6 @@ lemma cteSwap_corres:
   apply (thin_tac "ksIdleThread t = p" for t p)+
   apply (thin_tac "gsUserPages t = p" for t p)+
   apply (thin_tac "pspace_relation s s'" for s s')+
-  apply (thin_tac "ekheap_relation e p" for e p)+
   apply (thin_tac "interrupt_state_relation n s s'" for n s s')+
   apply (thin_tac "(s,s') \<in> arch_state_relation" for s s')+
   apply (rule conjI)

--- a/proof/refine/RISCV64/Detype_R.thy
+++ b/proof/refine/RISCV64/Detype_R.thy
@@ -786,11 +786,6 @@ lemma corres_machine_op:
    apply (simp_all add: state_relation_def swp_def)
   done
 
-lemma ekheap_relation_detype:
-  "ekheap_relation ekh kh \<Longrightarrow>
-   ekheap_relation (\<lambda>x. if P x then None else (ekh x)) (\<lambda>x. if P x then None else (kh x))"
-  by (fastforce simp add: ekheap_relation_def split: if_split_asm)
-
 lemma cap_table_at_gsCNodes_eq:
   "(s, s') \<in> state_relation
     \<Longrightarrow> (gsCNodes s' ptr = Some bits) = cap_table_at bits ptr s"
@@ -892,11 +887,11 @@ lemma detype_ready_queues_relation:
          tcb_of' |>
          tcbSchedPrev)
         (\<lambda>d p. inQ d p |< ((\<lambda>x. if lower \<le> x \<and> x \<le> upper then None else ksPSpace s' x) |> tcb_of'))"
-  apply (clarsimp simp: detype_ext_def ready_queues_relation_def Let_def)
+  apply (clarsimp simp: ready_queues_relation_def Let_def)
   apply (frule (1) detype_tcbSchedNexts_of[where S="{lower..upper}"]; simp)
   apply (frule (1) detype_tcbSchedPrevs_of[where S="{lower..upper}"]; simp)
   apply (frule (1) detype_inQ[where S="{lower..upper}"]; simp)
-  apply (fastforce simp add: detype_def detype_ext_def)
+  apply (fastforce simp add: detype_def)
   done
 
 lemma deleteObjects_corres:
@@ -957,31 +952,30 @@ lemma deleteObjects_corres:
     apply (simp add: valid_pspace'_def)
     apply (rule state_relation_null_filterE, assumption,
            simp_all add: pspace_aligned'_cut pspace_distinct'_cut)[1]
-            apply (simp add: detype_def, rule state.equality; simp add: detype_ext_def)
-           apply (intro exI, fastforce)
-          apply (rule ext, clarsimp simp add: null_filter_def)
-          apply (rule sym, rule ccontr, clarsimp)
-          apply (drule(4) cte_map_not_null_outside')
-           apply (fastforce simp add: cte_wp_at_caps_of_state)
-          apply simp
-         apply (rule ext, clarsimp simp: null_filter'_def map_to_ctes_delete)
+           apply (simp add: detype_def)
+          apply (intro exI, fastforce)
+         apply (rule ext, clarsimp simp add: null_filter_def)
          apply (rule sym, rule ccontr, clarsimp)
-         apply (frule(2) pspace_relation_cte_wp_atI[OF state_relation_pspace_relation])
-         apply (elim exE)
-         apply (frule (4) cte_map_not_null_outside')
-          apply (rule cte_wp_at_weakenE, erule conjunct1)
-          apply (case_tac y, clarsimp)
-          apply (clarsimp simp: valid_mdb'_def valid_mdb_ctes_def valid_nullcaps_def)
-         apply clarsimp
-         apply (frule_tac cref="(aa, ba)" in cte_map_untyped_range,
-                erule cte_wp_at_weakenE[OF _ TrueI], assumption+)
-         apply (simp add: add_mask_fold)
+         apply (drule(4) cte_map_not_null_outside')
+          apply (fastforce simp add: cte_wp_at_caps_of_state)
+         apply simp
+        apply (rule ext, clarsimp simp: null_filter'_def map_to_ctes_delete)
+        apply (rule sym, rule ccontr, clarsimp)
+        apply (frule(2) pspace_relation_cte_wp_atI[OF state_relation_pspace_relation])
+        apply (elim exE)
+        apply (frule (4) cte_map_not_null_outside')
+         apply (rule cte_wp_at_weakenE, erule conjunct1)
+         apply (case_tac y, clarsimp)
+         apply (clarsimp simp: valid_mdb'_def valid_mdb_ctes_def valid_nullcaps_def)
+        apply clarsimp
+        apply (frule_tac cref="(aa, ba)" in cte_map_untyped_range,
+               erule cte_wp_at_weakenE[OF _ TrueI], assumption+)
         apply (simp add: add_mask_fold)
-        apply (rule detype_pspace_relation[simplified],
-               simp_all add: state_relation_pspace_relation valid_pspace_def)[1]
-         apply (simp add: valid_cap'_def capAligned_def)
-        apply (clarsimp simp: valid_cap_def, assumption)
-       apply (fastforce simp: detype_def detype_ext_def add_mask_fold intro!: ekheap_relation_detype)
+       apply (simp add: add_mask_fold)
+       apply (rule detype_pspace_relation[simplified],
+              simp_all add: state_relation_pspace_relation valid_pspace_def)[1]
+        apply (simp add: valid_cap'_def capAligned_def)
+       apply (clarsimp simp: valid_cap_def, assumption)
       apply (simp add: add_mask_fold)
       apply (rule detype_ready_queues_relation; blast?)
        apply (clarsimp simp: deletionIsSafe_delete_locale_def)
@@ -3061,23 +3055,19 @@ lemma createObject_setCTE_commute:
                        cteSizeBits_def)
             \<comment> \<open>Untyped\<close>
             apply (simp add: monad_commute_guard_imp[OF return_commute])
-           \<comment> \<open>TCB, EP, NTFN\<close>
+           \<comment> \<open>TCB\<close>
            apply (rule monad_commute_guard_imp[OF commute_commute])
-            apply (rule monad_commute_split[OF monad_commute_split])
-                apply (rule monad_commute_split[OF commute_commute[OF return_commute]])
-                 apply (rule setCTE_modify_tcbDomain_commute)
-                apply wp
-               apply (rule curDomain_commute)
-               apply wp+
-             apply (rule setCTE_placeNewObject_commute)
-            apply (wp  placeNewObject_tcb_at' placeNewObject_cte_wp_at'
-              placeNewObject_pspace_distinct'
-              placeNewObject_pspace_aligned'
-              | clarsimp simp: objBits_simps')+
-           apply (rule monad_commute_guard_imp[OF commute_commute]
-            ,rule monad_commute_split[OF commute_commute[OF return_commute]]
-            ,rule setCTE_placeNewObject_commute
-            ,(wp|clarsimp simp: objBits_simps')+)+
+            apply (rule monad_commute_split[OF monad_commute_split[OF commute_commute]])
+                apply (rule return_commute)
+               apply (rule setCTE_placeNewObject_commute)
+              apply wp
+             apply (rule curDomain_commute)
+             apply (wpsimp simp: objBits_simps')+
+          \<comment> \<open>EP, NTFN\<close>
+          apply (rule monad_commute_guard_imp[OF commute_commute],
+                 rule monad_commute_split[OF commute_commute[OF return_commute]],
+                 rule setCTE_placeNewObject_commute,
+                 (wpsimp simp: objBits_simps')+)+
         \<comment> \<open>CNode\<close>
         apply (rule monad_commute_guard_imp[OF commute_commute])
          apply (rule monad_commute_split)+
@@ -4296,6 +4286,34 @@ lemma createTCBs_tcb_at':
   apply (simp add: objBits_simps shiftl_t2n)
   done
 
+lemma curDomain_createObjects'_comm:
+  "do x \<leftarrow> createObjects' ptr n obj us;
+      y \<leftarrow> curDomain;
+      m x y
+   od =
+   do y \<leftarrow> curDomain;
+      x \<leftarrow> createObjects' ptr n obj us;
+      m x y
+   od"
+  apply (rule ext)
+  apply (case_tac x)
+  by (auto simp: createObjects'_def split_def bind_assoc return_def unless_def
+                 when_def simpler_gets_def alignError_def fail_def assert_def
+                 bind_def curDomain_def modify_def get_def put_def
+          split: option.splits)
+
+lemma curDomain_twice_simp:
+  "do x \<leftarrow> curDomain;
+      y \<leftarrow> curDomain;
+      m x y
+   od =
+   do x \<leftarrow> curDomain;
+      m x x
+   od"
+  apply (rule ext)
+  apply (case_tac x)
+  by (auto simp: simpler_gets_def bind_def curDomain_def)
+
 lemma createNewCaps_Cons:
   assumes cover:"range_cover ptr sz (Types_H.getObjectSize ty us) (Suc (Suc n))"
   and "valid_pspace' s" "valid_arch_state' s"
@@ -4382,8 +4400,7 @@ proof -
                          Arch_createNewCaps_def)
         apply (rename_tac apiobject_type)
         apply (case_tac apiobject_type)
-            apply (simp_all add: bind_assoc RISCV64_H.toAPIType_def
-                                 )
+            apply (simp_all add: bind_assoc RISCV64_H.toAPIType_def)
             \<comment> \<open>Untyped\<close>
             apply (simp add:
               bind_assoc RISCV64_H.getObjectSize_def
@@ -4394,90 +4411,40 @@ proof -
               apiGetObjectSize_def shiftl_t2n field_simps
               shiftL_nat mapM_x_def sequence_x_def append
               fromIntegral_def integral_inv[unfolded Fun.comp_def])
-           \<comment> \<open>TCB, EP, NTFN\<close>
-           apply (simp add: bind_assoc
-                      RISCV64_H.getObjectSize_def
-                      sequence_def Retype_H.createObject_def
-                      RISCV64_H.toAPIType_def
-                      createObjects_def RISCV64_H.createObject_def
-                      Arch_createNewCaps_def comp_def
-                      apiGetObjectSize_def shiftl_t2n field_simps
-                      shiftL_nat append mapM_x_append2
-                      fromIntegral_def integral_inv[unfolded Fun.comp_def])+
-           apply (subst monad_eq)
-            apply (rule createObjects_Cons)
-                 apply (simp add: field_simps shiftl_t2n bind_assoc pageBits_def
-                               objBits_simps placeNewObject_def2)+
-           apply (rule_tac Q = "\<lambda>r s. pspace_aligned' s \<and>
-               pspace_distinct' s \<and>
-               pspace_no_overlap' (ptr + (2^tcbBlockSizeBits + of_nat n * 2^tcbBlockSizeBits)) (objBitsKO (KOTCB makeObject)) s \<and>
-               range_cover (ptr + 2^tcbBlockSizeBits) sz
-               (objBitsKO (KOTCB makeObject)) (Suc n)
-               \<and> (\<forall>x\<in>set [0.e.of_nat n]. tcb_at' (ptr + x * 2^tcbBlockSizeBits) s)"
-               in monad_eq_split2)
-              apply simp
-             apply (subst monad_commute_simple[symmetric])
-               apply (rule commute_commute[OF curDomain_commute])
-               apply wpsimp+
-             apply (rule_tac Q = "\<lambda>r s. r = (ksCurDomain s) \<and>
-               pspace_aligned' s \<and>
-               pspace_distinct' s \<and>
-               pspace_no_overlap' (ptr + (2^tcbBlockSizeBits + of_nat n * 2^tcbBlockSizeBits)) (objBitsKO (KOTCB makeObject)) s \<and>
-               range_cover (ptr + 2^tcbBlockSizeBits) sz
-               (objBitsKO (KOTCB makeObject)) (Suc n)
-               \<and> (\<forall>x\<in>set [0.e.of_nat n]. tcb_at' (ptr + x * 2^tcbBlockSizeBits) s)
-             " in  monad_eq_split)
-               apply (subst monad_commute_simple[symmetric])
-                 apply (rule createObjects_setDomains_commute)
-                apply (clarsimp simp:objBits_simps)
-                apply (rule conj_impI)
-                 apply (erule aligned_add_aligned)
-                  apply (rule aligned_add_aligned[where n = tcbBlockSizeBits])
-                    apply (simp add:is_aligned_def objBits_defs)
-                   apply (cut_tac is_aligned_shift[where m = tcbBlockSizeBits and k = "of_nat n",
-                     unfolded shiftl_t2n,simplified])
-                   apply (simp add:field_simps)+
-                apply (erule range_cover_full)
-                apply (simp add: word_bits_conv objBits_defs)
-               apply (rule_tac Q = "\<lambda>x s. (ksCurDomain s) = r" in monad_eq_split2)
-                  apply simp
-                 apply (rule_tac Q = "\<lambda>x s. (ksCurDomain s) = r" in monad_eq_split)
-                   apply (subst rewrite_step[where f = curDomain and
-                     P ="\<lambda>s. ksCurDomain s = r" and f' = "return r"])
-                     apply (simp add:curDomain_def bind_def gets_def get_def)
-                    apply simp
-                   apply (simp add:mapM_x_singleton)
-                  apply wp
-                 apply simp
-                apply (wp mapM_x_wp')
-               apply simp
-              apply (simp add:curDomain_def,wp)
-             apply simp
-            apply (wp createObjects'_psp_aligned[where sz = sz]
-              createObjects'_psp_distinct[where sz = sz])
-            apply (rule hoare_vcg_conj_lift)
-             apply (rule hoare_post_imp[OF _ createObjects'_pspace_no_overlap
-                [unfolded shiftl_t2n,where gz = tcbBlockSizeBits and sz = sz,simplified]])
-              apply (simp add:objBits_simps field_simps)
-             apply (simp add: objBits_simps)
-            apply (wp createTCBs_tcb_at'[where sz = sz])
-           apply (clarsimp simp:objBits_simps word_bits_def field_simps)
-           apply (frule range_cover_le[where n = "Suc n"],simp+)
-           apply (drule range_cover_offset[where p = 1,rotated])
-            apply simp
-           apply (simp add: objBits_defs)
-          apply (((simp add: bind_assoc
-                      RISCV64_H.getObjectSize_def
-                      mapM_def sequence_def Retype_H.createObject_def
-                      RISCV64_H.toAPIType_def
-                      createObjects_def RISCV64_H.createObject_def
-                      Arch_createNewCaps_def comp_def
-                      apiGetObjectSize_def shiftl_t2n field_simps
-                      shiftL_nat mapM_x_def sequence_x_def append
-                      fromIntegral_def integral_inv[unfolded Fun.comp_def])+
-                   , subst monad_eq, rule createObjects_Cons
-                   , (simp add: field_simps shiftl_t2n bind_assoc pageBits_def
-                               objBits_simps placeNewObject_def2)+)+)[2]
+           \<comment> \<open>TCB\<close>
+           apply (simp add: bind_assoc RISCV64_H.getObjectSize_def
+                            mapM_def sequence_def Retype_H.createObject_def
+                            RISCV64_H.toAPIType_def objBitsKO_def
+                            createObjects_def RISCV64_H.createObject_def
+                            Arch_createNewCaps_def comp_def append
+                            apiGetObjectSize_def shiftl_t2n field_simps
+                            shiftL_nat fromIntegral_def integral_inv[unfolded Fun.comp_def])
+           apply (subst curDomain_createObjects'_comm)
+           apply (subst curDomain_twice_simp)
+           apply (simp add: monad_eq_simp_state)
+           apply (intro conjI; clarsimp simp: in_monad)
+             apply ((fastforce simp: curDomain_def simpler_gets_def return_def placeNewObject_def2
+                                     field_simps shiftl_t2n bind_assoc objBits_simps in_monad
+                                     createObjects_Cons[where
+                                       val="KOTCB (tcbDomain_update (\<lambda>_. ksCurDomain s) makeObject)"
+                                       and s=s, simplified objBitsKO_def])+)[2]
+           apply ((clarsimp simp: curDomain_def simpler_gets_def return_def split_def bind_def
+                                 field_simps shiftl_t2n bind_assoc objBits_simps placeNewObject_def2
+                                 createObjects_Cons[where
+                                   val="KOTCB (tcbDomain_update (\<lambda>_. ksCurDomain s) makeObject)"
+                                   and s=s, simplified objBitsKO_def])+)[1]
+          \<comment> \<open>EP, NTFN\<close>
+          apply (((simp add: RISCV64_H.getObjectSize_def
+                             mapM_def sequence_def Retype_H.createObject_def
+                             RISCV64_H.toAPIType_def
+                             createObjects_def RISCV64_H.createObject_def
+                             Arch_createNewCaps_def comp_def
+                             apiGetObjectSize_def shiftl_t2n field_simps
+                             shiftL_nat mapM_x_def sequence_x_def append
+                             fromIntegral_def integral_inv[unfolded Fun.comp_def])+,
+                   subst monad_eq, rule createObjects_Cons,
+                   (simp add: field_simps shiftl_t2n bind_assoc pageBits_def
+                              objBits_simps' placeNewObject_def2)+)+)[2]
         \<comment> \<open>CNode\<close>
         apply (simp add: bind_assoc
                       RISCV64_H.getObjectSize_def
@@ -4586,7 +4553,7 @@ proof -
     apply (simp add:bind_assoc placeNewObject_def2)
     apply (simp add: field_simps bit_simps
           getObjectSize_def placeNewObject_def2 objBits_simps append)
-  done
+    done
 qed
 
 lemma createObject_def2:
@@ -4877,35 +4844,19 @@ lemma createObject_pspace_no_overlap':
    apply wpc
     apply (wp ArchCreateObject_pspace_no_overlap')
    apply wpc
-       apply wp
-      apply (simp add:placeNewObject_def2)
-      apply (wp doMachineOp_psp_no_overlap createObjects'_pspace_no_overlap2
-        | simp add: placeNewObject_def2 curDomain_def word_shiftl_add_distrib
-        field_simps)+
-      apply (simp add:add.assoc[symmetric])
-      apply (wp createObjects'_pspace_no_overlap2
-        [where n =0 and sz = sz,simplified])
-     apply (simp add:placeNewObject_def2)
-     apply (wp doMachineOp_psp_no_overlap createObjects'_pspace_no_overlap2
-        | simp add: placeNewObject_def2 word_shiftl_add_distrib
-        field_simps)+
-     apply (simp add:add.assoc[symmetric])
-     apply (wp createObjects'_pspace_no_overlap2
-        [where n =0 and sz = sz,simplified])
-    apply (simp add:placeNewObject_def2)
-    apply (wp doMachineOp_psp_no_overlap createObjects'_pspace_no_overlap2
-      | simp add: placeNewObject_def2 word_shiftl_add_distrib
-      field_simps)+
-    apply (simp add:add.assoc[symmetric])
-    apply (wp createObjects'_pspace_no_overlap2
-      [where n =0 and sz = sz,simplified])
-   apply (simp add:placeNewObject_def2)
-   apply (wp doMachineOp_psp_no_overlap createObjects'_pspace_no_overlap2
-     | simp add: placeNewObject_def2 word_shiftl_add_distrib
-     field_simps)+
-   apply (simp add:add.assoc[symmetric])
-   apply (wp createObjects'_pspace_no_overlap2
-     [where n =0 and sz = sz,simplified])
+         apply wp
+        \<comment> \<open>TCB\<close>
+        apply (wp createObjects'_pspace_no_overlap2[where n =0 and sz = sz,simplified]
+               | simp add: curDomain_def placeNewObject_def2 word_shiftl_add_distrib field_simps)+
+         apply (simp add:add.assoc[symmetric])
+         apply (wp createObjects'_pspace_no_overlap2[where n =0 and sz = sz,simplified])
+        apply (wpsimp simp: curDomain_def)
+       \<comment> \<open>other objects\<close>
+       apply ((wp createObjects'_pspace_no_overlap2
+               | simp add: placeNewObject_def2 word_shiftl_add_distrib field_simps)+,
+              simp add:add.assoc[symmetric],
+              wp createObjects'_pspace_no_overlap2[where n =0 and sz = sz,simplified])+
+   \<comment> \<open>Cleanup\<close>
   apply clarsimp
   apply (frule(1) range_cover_no_0[where p = n])
    apply simp
@@ -4923,10 +4874,9 @@ lemma createObject_pspace_no_overlap':
    apply (simp add:shiftl_t2n field_simps)
   apply (frule range_cover_offset[rotated,where p = n])
    apply simp+
-  apply (auto simp: word_shiftl_add_distrib field_simps shiftl_t2n elim: range_cover_le,
-    auto simp add: APIType_capBits_def fromAPIType_def objBits_def
-        dest!: to_from_apiTypeD)
-  done
+  by (auto simp: word_shiftl_add_distrib field_simps shiftl_t2n elim: range_cover_le)
+     (auto simp: APIType_capBits_def fromAPIType_def objBits_def objBits_simps
+          dest!: to_from_apiTypeD)
 
 lemma createObject_pspace_aligned_distinct':
   "\<lbrace>pspace_aligned' and K (is_aligned ptr (APIType_capBits ty us))

--- a/proof/refine/RISCV64/Finalise_R.thy
+++ b/proof/refine/RISCV64/Finalise_R.thy
@@ -1633,7 +1633,7 @@ lemma emptySlot_corres:
   apply (simp add: put_def)
   apply (simp add: exec_gets exec_get exec_put del: fun_upd_apply | subst bind_def)+
   apply (clarsimp simp: state_relation_def)
-  apply (drule updateMDB_the_lot, fastforce simp: pspace_relations_def, fastforce, fastforce)
+  apply (drule updateMDB_the_lot, fastforce simp: pspace_relation_def, fastforce, fastforce)
    apply (clarsimp simp: invs'_def valid_state'_def valid_pspace'_def
                          valid_mdb'_def valid_mdb_ctes_def)
   apply (elim conjE)
@@ -1662,7 +1662,7 @@ lemma emptySlot_corres:
   apply clarsimp
   apply (drule updateCap_stuff, elim conjE, erule (1) impE)
   apply clarsimp
-  apply (drule updateMDB_the_lot, force simp: pspace_relations_def, assumption+, simp)
+  apply (drule updateMDB_the_lot, force simp: pspace_relation_def, assumption+, simp)
   apply (rule bexI)
    prefer 2
    apply (simp only: trans_state_update[symmetric])
@@ -1690,7 +1690,7 @@ lemma emptySlot_corres:
    apply (rule mdb_ptr_axioms.intro)
    subgoal by simp
   apply (clarsimp simp: ghost_relation_typ_at set_cap_a_type_inv)
-  apply (simp add: pspace_relations_def)
+  apply (simp add: pspace_relation_def)
   apply (rule conjI)
    apply (clarsimp simp: data_at_def ghost_relation_typ_at set_cap_a_type_inv)
   apply (rule conjI)
@@ -3334,8 +3334,7 @@ context begin interpretation Arch . (*FIXME: arch-split*)
 lemma arch_finaliseCap_corres:
   "\<lbrakk> final_matters' (ArchObjectCap cap') \<Longrightarrow> final = final'; acap_relation cap cap' \<rbrakk>
      \<Longrightarrow> corres (\<lambda>r r'. cap_relation (fst r) (fst r') \<and> cap_relation (snd r) (snd r'))
-           (\<lambda>s. invs s \<and> valid_etcbs s
-                       \<and> s \<turnstile> cap.ArchObjectCap cap
+           (\<lambda>s. invs s \<and> s \<turnstile> cap.ArchObjectCap cap
                        \<and> (final_matters (cap.ArchObjectCap cap)
                             \<longrightarrow> final = is_final_cap' (cap.ArchObjectCap cap) s)
                        \<and> cte_wp_at ((=) (cap.ArchObjectCap cap)) sl s)

--- a/proof/refine/RISCV64/Init_R.thy
+++ b/proof/refine/RISCV64/Init_R.thy
@@ -46,6 +46,12 @@ definition zeroed_main_abstract_state ::
     is_original_cap = \<top>,
     cur_thread = 0,
     idle_thread = 0,
+    scheduler_action = resume_cur_thread,
+    domain_list = [],
+    domain_index = 0,
+    cur_domain = 0,
+    domain_time = 0,
+    ready_queues = (\<lambda>_ _. []),
     machine_state = init_machine_state,
     interrupt_irq_node = (\<lambda>irq. ucast irq << cte_level_bits),
     interrupt_states = (K irq_state.IRQInactive),
@@ -57,13 +63,6 @@ definition zeroed_extended_state ::
   where
   "zeroed_extended_state \<equiv> \<lparr>
     work_units_completed_internal = 0,
-    scheduler_action_internal = resume_cur_thread,
-    ekheap_internal = Map.empty,
-    domain_list_internal = [],
-    domain_index_internal = 0,
-    cur_domain_internal = 0,
-    domain_time_internal = 0,
-    ready_queues_internal = (\<lambda>_ _. []),
     cdt_list_internal = K []
   \<rparr>"
 
@@ -112,8 +111,7 @@ lemma non_empty_refine_state_relation:
   "(zeroed_abstract_state, zeroed_intermediate_state) \<in> state_relation"
   apply (clarsimp simp: state_relation_def zeroed_state_defs state.defs)
   apply (intro conjI)
-          apply (clarsimp simp: pspace_relation_def pspace_dom_def)
-         apply (clarsimp simp: ekheap_relation_def)
+         apply (clarsimp simp: pspace_relation_def pspace_dom_def)
         apply (clarsimp simp: ready_queues_relation_def ready_queue_relation_def queue_end_valid_def
                               opt_pred_def list_queue_relation_def tcbQueueEmpty_def
                               prev_queue_head_def)

--- a/proof/refine/RISCV64/Interrupt_R.thy
+++ b/proof/refine/RISCV64/Interrupt_R.thy
@@ -614,7 +614,7 @@ lemma getIRQState_prop:
 lemma decDomainTime_corres:
   "corres dc \<top> \<top> dec_domain_time decDomainTime"
   apply (simp add:dec_domain_time_def corres_underlying_def decDomainTime_def simpler_modify_def)
-  apply (clarsimp simp:state_relation_def)
+  apply (clarsimp simp: state_relation_def cdt_relation_def)
   done
 
 lemma thread_state_case_if:
@@ -648,24 +648,24 @@ lemma timerTick_corres:
           apply (rule corres_split[where r' = dc])
              apply (rule corres_if[where Q = \<top> and Q' = \<top>])
                apply (case_tac state,simp_all)[1]
-              apply (rule_tac r'="(=)" in corres_split[OF ethreadget_corres])
-                 apply (simp add:etcb_relation_def)
+              apply (rule_tac r'="(=)" in corres_split[OF threadGet_corres])
+                 apply (simp add: tcb_relation_def)
                 apply (rename_tac ts ts')
                 apply (rule_tac R="1 < ts" in corres_cases)
                  apply (simp)
                  apply (unfold thread_set_time_slice_def)
-                 apply (rule ethread_set_corres, simp+)
-                 apply (clarsimp simp: etcb_relation_def)
+                 apply (rule threadset_corres; simp add: tcb_relation_def inQ_def)
                 apply simp
-                apply (rule corres_split[OF ethread_set_corres])
-                         apply (simp add: sch_act_wf_weak etcb_relation_def pred_conj_def)+
+                apply (rule corres_split[OF threadset_corres])
+                                apply (simp add: sch_act_wf_weak tcb_relation_def pred_conj_def inQ_def)+
                   apply (rule corres_split[OF tcbSchedAppend_corres], simp)
                     apply (rule rescheduleRequired_corres)
                    apply wp
                   apply ((wpsimp wp: tcbSchedAppend_sym_heap_sched_pointers
                                      tcbSchedAppend_valid_objs'
                           | strengthen valid_objs'_valid_tcbs')+)[1]
-                 apply ((wp thread_set_time_slice_valid_queues
+                 apply ((wpsimp wp: thread_set_valid_queues thread_set_no_change_tcb_state
+                                    thread_set_weak_valid_sched_action
                          | strengthen valid_queues_in_correct_ready_q
                                       valid_queues_ready_qs_distinct)+)[1]
                 apply ((wpsimp wp: threadSet_sched_pointers threadSet_valid_sched_pointers
@@ -685,10 +685,10 @@ lemma timerTick_corres:
                              threadSet_pred_tcb_at_state threadSet_weak_sch_act_wf
                              rescheduleRequired_weak_sch_act_wf)+
               apply (strengthen valid_queues_in_correct_ready_q valid_queues_ready_qs_distinct)
-              apply (wpsimp wp: thread_set_time_slice_valid_queues)
-             apply ((wpsimp wp: thread_set_time_slice_valid_queues
+              apply (wpsimp wp: thread_set_valid_queues thread_set_weak_valid_sched_action)
+             apply ((wpsimp wp: thread_set_valid_queues
                      | strengthen valid_queues_in_correct_ready_q valid_queues_ready_qs_distinct)+)[1]
-            apply wpsimp
+            apply (wpsimp wp: thread_get_wp)
            apply wpsimp
           apply ((wpsimp wp: threadSet_sched_pointers threadSet_valid_sched_pointers
                              threadSet_valid_objs'
@@ -696,11 +696,8 @@ lemma timerTick_corres:
                   | wp (once) hoare_drop_imp)+)[1]
          apply (wpsimp wp: gts_wp gts_wp')+
      apply (clarsimp simp: cur_tcb_def)
-     apply (frule valid_sched_valid_etcbs)
-     apply (frule (1) tcb_at_is_etcb_at)
      apply (frule valid_sched_valid_queues)
      apply (fastforce simp: pred_tcb_at_def obj_at_def valid_sched_weak_strg)
-    apply (clarsimp simp: etcb_at_def split: option.splits)
     apply fastforce
    apply (fastforce simp: valid_state'_def ct_not_inQ_def)
   apply fastforce

--- a/proof/refine/RISCV64/IpcCancel_R.thy
+++ b/proof/refine/RISCV64/IpcCancel_R.thy
@@ -524,7 +524,7 @@ lemma (in delete_one) cancelIPC_ReplyCap_corres:
           apply (simp add: tcb_relation_def fault_rel_optionation_def)
          apply (simp add: tcb_cap_cases_def)
         apply (simp add: tcb_cte_cases_def cteSizeBits_def)
-       apply (simp add: exst_same_def)
+       apply (simp add: inQ_def)
       apply (fastforce simp: st_tcb_at_tcb_at)
      apply clarsimp
     defer
@@ -1192,9 +1192,9 @@ crunch asUser
 
 crunch set_thread_state
   for in_correct_ready_q[wp]: in_correct_ready_q
-  (wp: crunch_wps)
+  (wp: set_object_wp)
 
-crunch set_thread_state_ext
+crunch set_thread_state_act
   for ready_qs_distinct[wp]: ready_qs_distinct
   (wp: crunch_wps)
 
@@ -1203,6 +1203,10 @@ lemma set_thread_state_ready_qs_distinct[wp]:
   unfolding set_thread_state_def
   apply (wpsimp wp: set_object_wp)
   by (clarsimp simp: ready_qs_distinct_def)
+
+crunch as_user
+  for in_correct_ready_q[wp]: in_correct_ready_q
+  (wp: set_object_wp)
 
 lemma as_user_ready_qs_distinct[wp]:
   "as_user tptr f \<lbrace>ready_qs_distinct\<rbrace>"
@@ -1355,7 +1359,7 @@ lemma sts_sch_act_not_ct[wp]:
 text \<open>Cancelling all IPC in an endpoint or notification object\<close>
 
 lemma ep_cancel_corres_helper:
-  "corres dc ((\<lambda>s. \<forall>t \<in> set list. tcb_at t s) and valid_etcbs and valid_queues
+  "corres dc ((\<lambda>s. \<forall>t \<in> set list. tcb_at t s) and valid_queues
                                               and pspace_aligned and pspace_distinct)
              (valid_objs' and sym_heap_sched_pointers and valid_sched_pointers)
           (mapM_x (\<lambda>t. do
@@ -1392,7 +1396,7 @@ lemma ep_cancel_corres_helper:
 crunch set_simple_ko
   for ready_qs_distinct[wp]: ready_qs_distinct
   and in_correct_ready_q[wp]: in_correct_ready_q
-  (rule: ready_qs_distinct_lift wp: crunch_wps)
+  (wp: ready_qs_distinct_lift in_correct_ready_q_lift)
 
 lemma ep_cancel_corres:
   "corres dc (invs and valid_sched and ep_at ep) (invs' and ep_at' ep)
@@ -1401,7 +1405,7 @@ proof -
   have P:
     "\<And>list.
      corres dc (\<lambda>s. (\<forall>t \<in> set list. tcb_at t s) \<and> valid_pspace s \<and> ep_at ep s
-                        \<and> valid_etcbs s \<and> weak_valid_sched_action s \<and> valid_queues s)
+                        \<and> weak_valid_sched_action s \<and> valid_queues s)
                (\<lambda>s. (\<forall>t \<in> set list. tcb_at' t s) \<and> valid_pspace' s
                          \<and> ep_at' ep s \<and> weak_sch_act_wf (ksSchedulerAction s) s
                          \<and> valid_objs' s \<and> sym_heap_sched_pointers s \<and> valid_sched_pointers s)
@@ -2117,7 +2121,7 @@ lemma cancelBadgedSends_corres:
                                                            and pspace_distinct'"]])
          apply (rule_tac S="(=)"
                      and Q="\<lambda>xs s. (\<forall>x \<in> set xs. (epptr, TCBBlockedSend) \<in> state_refs_of s x) \<and>
-                                   distinct xs \<and> valid_etcbs s \<and>
+                                   distinct xs \<and>
                                    in_correct_ready_q s \<and> ready_qs_distinct s \<and>
                                    pspace_aligned s \<and> pspace_distinct s"
                     and Q'="\<lambda>_ s. valid_objs' s \<and> sym_heap_sched_pointers s \<and> valid_sched_pointers s
@@ -2141,7 +2145,7 @@ lemma cancelBadgedSends_corres:
                       | strengthen valid_objs'_valid_tcbs')+
             apply (clarsimp simp: valid_tcb_state_def tcb_at_def st_tcb_def2
                                   st_tcb_at_refs_of_rev
-                           dest!: state_refs_of_elemD elim!: tcb_at_is_etcb_at[rotated])
+                           dest!: state_refs_of_elemD)
             apply (simp add: valid_tcb_state'_def)
           apply (wp hoare_vcg_const_Ball_lift gts_wp | clarsimp)+
             apply (wp hoare_vcg_imp_lift sts_st_tcb' sts_valid_objs'

--- a/proof/refine/RISCV64/Ipc_R.thy
+++ b/proof/refine/RISCV64/Ipc_R.thy
@@ -2238,7 +2238,7 @@ lemma doReplyTransfer_corres:
               apply (rule corres_split)
                  apply (rule threadset_corresT;
                         clarsimp simp add: tcb_relation_def fault_rel_optionation_def cteSizeBits_def
-                                           tcb_cap_cases_def tcb_cte_cases_def exst_same_def)
+                                           tcb_cap_cases_def tcb_cte_cases_def inQ_def)
                 apply (rule_tac Q="valid_sched and cur_tcb and tcb_at receiver and pspace_aligned and pspace_distinct"
                             and Q'="tcb_at' receiver and cur_tcb'
                                       and (\<lambda>s. weak_sch_act_wf (ksSchedulerAction s) s)
@@ -3441,7 +3441,7 @@ lemma sendFaultIPC_corres:
            apply (rule corres_if2 [OF refl])
             apply (simp add: dc_def[symmetric])
             apply (rule corres_split[OF threadset_corres sendIPC_corres], simp_all)[1]
-               apply (simp add: tcb_relation_def fault_rel_optionation_def exst_same_def)+
+               apply (simp add: tcb_relation_def fault_rel_optionation_def inQ_def)+
              apply (wp thread_set_invs_trivial thread_set_no_change_tcb_state
                        thread_set_typ_at ep_at_typ_at ex_nonz_cap_to_pres
                        thread_set_cte_wp_at_trivial thread_set_not_state_valid_sched

--- a/proof/refine/RISCV64/KHeap_R.thy
+++ b/proof/refine/RISCV64/KHeap_R.thy
@@ -973,17 +973,6 @@ lemma obj_relation_cut_same_type:
                     arch_kernel_obj.split_asm)
   done
 
-definition exst_same :: "Structures_H.tcb \<Rightarrow> Structures_H.tcb \<Rightarrow> bool"
-where
-  "exst_same tcb tcb' \<equiv> tcbPriority tcb = tcbPriority tcb'
-                      \<and> tcbTimeSlice tcb = tcbTimeSlice tcb'
-                      \<and> tcbDomain tcb = tcbDomain tcb'"
-
-fun exst_same' :: "Structures_H.kernel_object \<Rightarrow> Structures_H.kernel_object \<Rightarrow> bool"
-where
-  "exst_same' (KOTCB tcb) (KOTCB tcb') = exst_same tcb tcb'" |
-  "exst_same' _ _ = True"
-
 lemma tcbs_of'_non_tcb_update:
   "\<lbrakk>typ_at' (koTypeOf ko) ptr s'; koTypeOf ko \<noteq> TCBT\<rbrakk>
    \<Longrightarrow> tcbs_of' (s'\<lparr>ksPSpace := (ksPSpace s')(ptr \<mapsto> ko)\<rparr>) = tcbs_of' s'"
@@ -1001,7 +990,6 @@ lemma setObject_other_corres:
                \<Longrightarrow> map_to_ctes ((ksPSpace s) (ptr \<mapsto> injectKO ob')) = map_to_ctes (ksPSpace s)"
   assumes t: "is_other_obj_relation_type (a_type ob)"
   assumes b: "\<And>ko. P ko \<Longrightarrow> objBits ko = objBits ob'"
-  assumes e: "\<And>ko. P ko \<Longrightarrow> exst_same' (injectKO ko) (injectKO ob')"
   assumes P: "\<And>(v::'a::pspace_storable). (1 :: machine_word) < 2 ^ (objBits v)"
   shows      "other_obj_relation ob (injectKO (ob' :: 'a :: pspace_storable)) \<Longrightarrow>
   corres dc (obj_at (\<lambda>ko. a_type ko = a_type ob) ptr and obj_at (same_caps ob) ptr)
@@ -1052,21 +1040,6 @@ lemma setObject_other_corres:
    apply (insert t)
    apply ((erule disjE
           | clarsimp simp: is_other_obj_relation_type is_other_obj_relation_type_def a_type_def)+)[1]
-  apply (extract_conjunct \<open>match conclusion in "ekheap_relation _ _" \<Rightarrow> -\<close>)
-   apply (simp only: ekheap_relation_def)
-   apply (rule ballI, drule(1) bspec)
-   apply (drule domD)
-   apply (insert e)
-   apply atomize
-   apply (clarsimp simp: obj_at'_def)
-   apply (erule_tac x=obj in allE)
-   apply (clarsimp simp: projectKO_eq project_inject)
-   apply (case_tac ob;
-          simp_all add: a_type_def other_obj_relation_def etcb_relation_def
-                        is_other_obj_relation_type t exst_same_def)
-     apply (clarsimp simp: is_other_obj_relation_type t exst_same_def
-                    split: Structures_A.kernel_object.splits Structures_H.kernel_object.splits
-                           arch_kernel_obj.splits)+
   \<comment> \<open>ready_queues_relation\<close>
   apply (prop_tac "koTypeOf (injectKO ob') \<noteq> TCBT")
    subgoal

--- a/proof/refine/RISCV64/Schedule_R.thy
+++ b/proof/refine/RISCV64/Schedule_R.thy
@@ -88,7 +88,7 @@ lemma schedule_choose_new_thread_sched_act_rct[wp]:
 lemma tcbSchedAppend_corres:
   "tcb_ptr = tcbPtr \<Longrightarrow>
    corres dc
-     (in_correct_ready_q and ready_qs_distinct and valid_etcbs and st_tcb_at runnable tcb_ptr
+     (in_correct_ready_q and ready_qs_distinct and st_tcb_at runnable tcb_ptr
       and pspace_aligned and pspace_distinct)
      (sym_heap_sched_pointers and valid_sched_pointers and valid_tcbs')
      (tcb_sched_action tcb_sched_append tcb_ptr) (tcbSchedAppend tcbPtr)"
@@ -104,9 +104,9 @@ lemma tcbSchedAppend_corres:
    apply (fastforce dest: pspace_distinct_cross)
   apply (clarsimp simp: tcb_sched_action_def tcb_sched_append_def get_tcb_queue_def
                         tcbSchedAppend_def getQueue_def unless_def when_def)
-  apply (rule corres_symb_exec_l[OF _ _ ethread_get_sp]; (solves wpsimp)?)
+  apply (rule corres_symb_exec_l[OF _ _ thread_get_sp]; (solves wpsimp)?)
   apply (rename_tac domain)
-  apply (rule corres_symb_exec_l[OF _ _ ethread_get_sp]; (solves wpsimp)?)
+  apply (rule corres_symb_exec_l[OF _ _ thread_get_sp]; (solves wpsimp)?)
   apply (rename_tac priority)
   apply (rule corres_symb_exec_l[OF _ _ gets_sp]; (solves wpsimp)?)
   apply (rule corres_stateAssert_ignore)
@@ -118,12 +118,11 @@ lemma tcbSchedAppend_corres:
   apply (rule corres_symb_exec_r[OF _ threadGet_sp]; (solves wpsimp)?)
   apply (subst if_distrib[where f="set_tcb_queue domain prio" for domain prio])
   apply (rule corres_if_strong')
-    apply (frule state_relation_ready_queues_relation)
-    apply (frule in_ready_q_tcbQueued_eq[where t=tcbPtr])
     subgoal
-      by (fastforce dest: tcb_at_ekheap_dom pred_tcb_at_tcb_at
-                    simp: obj_at'_def opt_pred_def opt_map_def obj_at_def is_tcb_def
-                          in_correct_ready_q_def etcb_at_def is_etcb_at_def)
+      by (fastforce dest!: state_relation_ready_queues_relation
+                           in_ready_q_tcbQueued_eq[where t=tcbPtr]
+                     simp: obj_at'_def opt_pred_def opt_map_def in_correct_ready_q_def
+                           obj_at_def etcb_at_def etcbs_of'_def)
    apply (find_goal \<open>match conclusion in "corres _ _ _ _ (return ())" \<Rightarrow> \<open>-\<close>\<close>)
    apply (rule monadic_rewrite_corres_l[where P=P and Q=P for P, simplified])
     apply (clarsimp simp: set_tcb_queue_def)
@@ -171,16 +170,15 @@ lemma tcbSchedAppend_corres:
   apply (drule set_tcb_queue_new_state)
   apply (wpsimp wp: threadSet_wp simp: setQueue_def tcbQueueAppend_def)
   apply normalise_obj_at'
-  apply (frule (1) tcb_at_is_etcb_at)
-  apply (clarsimp simp: obj_at_def is_etcb_at_def etcb_at_def)
-  apply (rename_tac s d p s' tcb' tcb etcb)
-  apply (frule_tac t=tcbPtr in ekheap_relation_tcb_domain_priority)
+  apply (clarsimp simp: obj_at_def)
+  apply (rename_tac s d p s' tcb' tcb)
+  apply (frule_tac t=tcbPtr in pspace_relation_tcb_domain_priority)
     apply (force simp: obj_at_def)
    apply (force simp: obj_at'_def)
   apply (clarsimp split: if_splits)
   apply (cut_tac ts="ready_queues s d p" in list_queue_relation_nil)
    apply (force dest!: spec simp: list_queue_relation_def)
-  apply (cut_tac ts="ready_queues s (tcb_domain etcb) (tcb_priority etcb)"
+  apply (cut_tac ts="ready_queues s (tcb_domain tcb) (tcb_priority tcb)"
               in obj_at'_tcbQueueEnd_ksReadyQueues)
       apply fast
      apply fast
@@ -190,8 +188,8 @@ lemma tcbSchedAppend_corres:
    apply (force dest!: spec simp: list_queue_relation_def)
   apply (clarsimp simp: list_queue_relation_def)
 
-  apply (case_tac "d \<noteq> tcb_domain etcb \<or> p \<noteq> tcb_priority etcb")
-   apply (cut_tac d=d and d'="tcb_domain etcb" and p=p and p'="tcb_priority etcb"
+  apply (case_tac "d \<noteq> tcb_domain tcb \<or> p \<noteq> tcb_priority tcb")
+   apply (cut_tac d=d and d'="tcb_domain tcb" and p=p and p'="tcb_priority tcb"
                in ready_queues_disjoint)
       apply force
      apply fastforce
@@ -215,14 +213,14 @@ lemma tcbSchedAppend_corres:
     apply (clarsimp simp: fun_upd_apply split: if_splits)
 
    \<comment> \<open>the ready queue was not originally empty\<close>
-   apply (clarsimp simp: etcb_at_def obj_at'_def)
-   apply (prop_tac "the (tcbQueueEnd (ksReadyQueues s' (tcb_domain etcb, tcb_priority etcb)))
+   apply (clarsimp simp: obj_at'_def)
+   apply (prop_tac "the (tcbQueueEnd (ksReadyQueues s' (tcb_domain tcb, tcb_priority tcb)))
                     \<notin> set (ready_queues s d p)")
     apply (erule orthD2)
-    apply (drule_tac x="tcb_domain etcb" in spec)
-    apply (drule_tac x="tcb_priority etcb" in spec)
+    apply (drule_tac x="tcb_domain tcb" in spec)
+    apply (drule_tac x="tcb_priority tcb" in spec)
     apply clarsimp
-    apply (drule_tac x="the (tcbQueueEnd (ksReadyQueues s' (tcb_domain etcb, tcb_priority etcb)))"
+    apply (drule_tac x="the (tcbQueueEnd (ksReadyQueues s' (tcb_domain tcb, tcb_priority tcb)))"
                  in spec)
     subgoal by (auto simp: in_opt_pred opt_map_red)
    apply (intro conjI impI allI)
@@ -239,7 +237,7 @@ lemma tcbSchedAppend_corres:
       apply (case_tac "ready_queues s d p"; force simp: tcbQueueEmpty_def)
      apply (case_tac "t = tcbPtr")
       apply (clarsimp simp: inQ_def fun_upd_apply split: if_splits)
-     apply (case_tac "t = the (tcbQueueEnd (ksReadyQueues s' (tcb_domain etcb, tcb_priority etcb)))")
+     apply (case_tac "t = the (tcbQueueEnd (ksReadyQueues s' (tcb_domain tcb, tcb_priority tcb)))")
       apply (clarsimp simp: inQ_def opt_pred_def fun_upd_apply)
      apply (clarsimp simp: inQ_def in_opt_pred opt_map_def fun_upd_apply)
     apply (clarsimp simp: fun_upd_apply split: if_splits)
@@ -247,9 +245,9 @@ lemma tcbSchedAppend_corres:
 
   \<comment> \<open>d = tcb_domain tcb \<and> p = tcb_priority tcb\<close>
   apply clarsimp
-  apply (drule_tac x="tcb_domain etcb" in spec)
-  apply (drule_tac x="tcb_priority etcb" in spec)
-  apply (cut_tac ts="ready_queues s (tcb_domain etcb) (tcb_priority etcb)"
+  apply (drule_tac x="tcb_domain tcb" in spec)
+  apply (drule_tac x="tcb_priority tcb" in spec)
+  apply (cut_tac ts="ready_queues s (tcb_domain tcb) (tcb_priority tcb)"
               in tcbQueueHead_iff_tcbQueueEnd)
    apply (force simp: list_queue_relation_def)
   apply (frule valid_tcbs'_maxDomain[where t=tcbPtr], simp add: obj_at'_def)
@@ -690,7 +688,7 @@ defs idleThreadNotQueued_def:
   "idleThreadNotQueued s \<equiv> obj_at' (Not \<circ> tcbQueued) (ksIdleThread s) s"
 
 lemma idle_thread_not_queued:
-  "\<lbrakk>valid_idle s; valid_queues s; valid_etcbs s\<rbrakk>
+  "\<lbrakk>valid_idle s; valid_queues s\<rbrakk>
    \<Longrightarrow> \<not> (\<exists>d p. idle_thread s \<in> set (ready_queues s d p))"
   apply (clarsimp simp: valid_queues_def)
   apply (drule_tac x=d in spec)
@@ -698,7 +696,7 @@ lemma idle_thread_not_queued:
   apply clarsimp
   apply (drule_tac x="idle_thread s" in bspec)
    apply fastforce
-  apply (clarsimp simp: valid_idle_def pred_tcb_at_def obj_at_def valid_etcbs_def)
+  apply (clarsimp simp: valid_idle_def pred_tcb_at_def obj_at_def)
   done
 
 lemma valid_idle_tcb_at:
@@ -706,12 +704,12 @@ lemma valid_idle_tcb_at:
   by (clarsimp simp: valid_idle_def pred_tcb_at_def obj_at_def is_tcb_def)
 
 lemma setCurThread_corres:
-  "corres dc (valid_idle and valid_queues and valid_etcbs and pspace_aligned and pspace_distinct) \<top>
+  "corres dc (valid_idle and valid_queues and pspace_aligned and pspace_distinct) \<top>
      (modify (cur_thread_update (\<lambda>_. t))) (setCurThread t)"
   apply (clarsimp simp: setCurThread_def)
   apply (rule corres_stateAssert_add_assertion[rotated])
    apply (clarsimp simp: idleThreadNotQueued_def)
-   apply (frule (2) idle_thread_not_queued)
+   apply (frule (1) idle_thread_not_queued)
    apply (frule state_relation_pspace_relation)
    apply (frule state_relation_ready_queues_relation)
    apply (frule state_relation_idle_thread)
@@ -755,6 +753,7 @@ crunch arch_switch_to_thread, arch_switch_to_idle_thread
   and pspace_distinct[wp]: pspace_distinct
   and ready_qs_distinct[wp]: ready_qs_distinct
   and valid_idle[wp]: valid_idle
+  and ready_queues[wp]: "\<lambda>s. P (ready_queues s)"
   (wp: ready_qs_distinct_lift)
 
 lemma valid_queues_in_correct_ready_q[elim!]:
@@ -770,7 +769,7 @@ lemma switchToThread_corres:
                 and valid_vspace_objs and pspace_aligned and pspace_distinct
                 and valid_vs_lookup and valid_global_objs
                 and unique_table_refs
-                and st_tcb_at runnable t and valid_etcbs and valid_queues and valid_idle)
+                and st_tcb_at runnable t and valid_queues and valid_idle)
              (no_0_obj' and sym_heap_sched_pointers and valid_objs')
              (switch_to_thread t) (switchToThread t)"
   apply (rule_tac Q'="st_tcb_at' runnable' t" in corres_cross_add_guard)
@@ -790,7 +789,7 @@ lemma switchToThread_corres:
     apply (rule corres_guard_imp)
       apply (rule corres_split[OF arch_switchToThread_corres])
         apply (rule corres_split[OF tcbSchedDequeue_corres setCurThread_corres])
-          apply (wpsimp simp: is_tcb_def)+
+          apply (wpsimp simp: is_tcb_def wp: in_correct_ready_q_lift)+
      apply (fastforce intro!: st_tcb_at_tcb_at)
     apply wpsimp
    apply wpsimp
@@ -814,7 +813,7 @@ lemma arch_switchToIdleThread_corres:
 
 lemma switchToIdleThread_corres:
   "corres dc
-     (invs and valid_queues and valid_etcbs)
+     (invs and valid_queues)
      invs_no_cicd'
      switch_to_idle_thread switchToIdleThread"
   apply (simp add: switch_to_idle_thread_def Thread_H.switchToIdleThread_def)
@@ -1456,7 +1455,7 @@ lemma guarded_switch_to_corres:
                 and valid_vspace_objs and pspace_aligned and pspace_distinct
                 and valid_vs_lookup and valid_global_objs
                 and unique_table_refs
-                and st_tcb_at runnable t and valid_etcbs and valid_queues and valid_idle)
+                and st_tcb_at runnable t and valid_queues and valid_idle)
              (no_0_obj' and sym_heap_sched_pointers and valid_objs')
              (guarded_switch_to t) (switchToThread t)"
   apply (simp add: guarded_switch_to_def)
@@ -1693,25 +1692,27 @@ lemma schact_bind_inside: "do x \<leftarrow> f; (case act of resume_cur_thread \
   apply (case_tac act,simp_all)
   done
 
-interpretation tcb_sched_action_extended: is_extended' "tcb_sched_action f a"
-  by (unfold_locales)
-
 lemma getDomainTime_corres:
   "corres (=) \<top> \<top> (gets domain_time) getDomainTime"
   by (simp add: getDomainTime_def state_relation_def)
 
+lemma reset_work_units_equiv:
+  "do_extended_op (modify (work_units_completed_update (\<lambda>_. 0)))
+   = (modify (work_units_completed_update (\<lambda>_. 0)))"
+  by (clarsimp simp: reset_work_units_def[symmetric])
+
 lemma nextDomain_corres:
   "corres dc \<top> \<top> next_domain nextDomain"
-  apply (simp add: next_domain_def nextDomain_def)
+  apply (clarsimp simp: next_domain_def nextDomain_def reset_work_units_equiv modify_modify)
   apply (rule corres_modify)
-  apply (simp add: state_relation_def Let_def dschLength_def dschDomain_def)
+  apply (simp add: state_relation_def Let_def dschLength_def dschDomain_def cdt_relation_def)
   done
 
 lemma next_domain_valid_sched[wp]:
   "\<lbrace> valid_sched and (\<lambda>s. scheduler_action s  = choose_new_thread)\<rbrace> next_domain \<lbrace> \<lambda>_. valid_sched \<rbrace>"
   apply (simp add: next_domain_def Let_def)
-  apply (wp, simp add: valid_sched_def valid_sched_action_2_def ct_not_in_q_2_def)
-  apply (simp add:valid_blocked_2_def)
+  apply (wpsimp wp: dxo_wp_weak)
+  apply (clarsimp simp: valid_sched_def)
   done
 
 lemma nextDomain_invs_no_cicd':
@@ -1745,7 +1746,7 @@ lemma scheduleChooseNewThread_fragment_corres:
 
 lemma scheduleSwitchThreadFastfail_corres:
   "\<lbrakk> ct \<noteq> it \<longrightarrow> (tp = tp' \<and> cp = cp') ; ct = ct' ; it = it' \<rbrakk> \<Longrightarrow>
-   corres ((=)) (is_etcb_at ct) (tcb_at' ct)
+   corres ((=)) (is_tcb_at ct) (tcb_at' ct)
      (schedule_switch_thread_fastfail ct it cp tp)
      (scheduleSwitchThreadFastfail ct' it' cp' tp')"
   by (clarsimp simp: schedule_switch_thread_fastfail_def scheduleSwitchThreadFastfail_def)
@@ -1784,9 +1785,6 @@ lemma isHighestPrio_corres:
          apply (wpsimp simp: if_apply_def2 wp: hoare_drop_imps ksReadyQueuesL1Bitmap_return_wp)+
   done
 
-crunch set_scheduler_action
-  for valid_idle_etcb[wp]: valid_idle_etcb
-
 crunch isHighestPrio
   for inv[wp]: P
 crunch curDomain
@@ -1814,13 +1812,13 @@ lemma scheduleChooseNewThread_corres:
    apply auto
   done
 
-lemma ethread_get_when_corres:
-  assumes x: "\<And>etcb tcb'. etcb_relation etcb tcb' \<Longrightarrow> r (f etcb) (f' tcb')"
-  shows      "corres (\<lambda>rv rv'. b \<longrightarrow> r rv rv') (is_etcb_at t) (tcb_at' t)
-                (ethread_get_when b f t) (threadGet f' t)"
-  apply (clarsimp simp: ethread_get_when_def)
+lemma thread_get_when_corres:
+  assumes x: "\<And>tcb tcb'. tcb_relation tcb tcb' \<Longrightarrow> r (f tcb) (f' tcb')"
+  shows      "corres (\<lambda>rv rv'. b \<longrightarrow> r rv rv') (tcb_at t and pspace_aligned and pspace_distinct) (tcb_at' t)
+                ((if b then thread_get f t else return 0)) (threadGet f' t)"
+  apply clarsimp
   apply (rule conjI; clarsimp)
-  apply (rule corres_guard_imp, rule ethreadget_corres; simp add: x)
+  apply (rule corres_guard_imp, rule threadGet_corres; simp add: x)
   apply (clarsimp simp: threadGet_def)
   apply (rule corres_noop)
   apply wpsimp+
@@ -1829,31 +1827,29 @@ lemma ethread_get_when_corres:
 lemma tcb_sched_enqueue_in_correct_ready_q[wp]:
   "tcb_sched_action tcb_sched_enqueue t \<lbrace>in_correct_ready_q\<rbrace> "
   unfolding tcb_sched_action_def tcb_sched_enqueue_def set_tcb_queue_def
-  apply wpsimp
-  apply (clarsimp simp: in_correct_ready_q_def obj_at_def etcb_at_def is_etcb_at_def
-                 split: option.splits)
+  apply (wpsimp wp: thread_get_wp')
+  apply (clarsimp simp: in_correct_ready_q_def obj_at_def etcb_at_def is_etcb_at_def etcbs_of'_def)
   done
 
 lemma tcb_sched_append_in_correct_ready_q[wp]:
   "tcb_sched_action tcb_sched_append tcb_ptr \<lbrace>in_correct_ready_q\<rbrace> "
   unfolding tcb_sched_action_def tcb_sched_append_def
-  apply wpsimp
-  apply (clarsimp simp: in_correct_ready_q_def obj_at_def etcb_at_def is_etcb_at_def
-                 split: option.splits)
+  apply (wpsimp wp: thread_get_wp')
+  apply (clarsimp simp: in_correct_ready_q_def obj_at_def etcb_at_def is_etcb_at_def etcbs_of'_def)
   done
 
 lemma tcb_sched_enqueue_ready_qs_distinct[wp]:
   "tcb_sched_action tcb_sched_enqueue t \<lbrace>ready_qs_distinct\<rbrace> "
   unfolding tcb_sched_action_def set_tcb_queue_def
   apply (wpsimp wp: thread_get_wp')
-  apply (clarsimp simp: ready_qs_distinct_def etcb_at_def is_etcb_at_def split: option.splits)
+  apply (clarsimp simp: ready_qs_distinct_def etcb_at_def is_etcb_at_def)
   done
 
 lemma tcb_sched_append_ready_qs_distinct[wp]:
   "tcb_sched_action tcb_sched_append t \<lbrace>ready_qs_distinct\<rbrace> "
   unfolding tcb_sched_action_def tcb_sched_append_def set_tcb_queue_def
   apply (wpsimp wp: thread_get_wp')
-  apply (clarsimp simp: ready_qs_distinct_def etcb_at_def is_etcb_at_def split: option.splits)
+  apply (clarsimp simp: ready_qs_distinct_def etcb_at_def is_etcb_at_def)
   done
 
 crunch set_scheduler_action
@@ -1866,9 +1862,11 @@ crunch reschedule_required
   and ready_qs_distinct[wp]: ready_qs_distinct
   (ignore: tcb_sched_action wp: crunch_wps)
 
+crunch tcb_sched_action
+  for valid_vs_lookup[wp]: valid_vs_lookup
+
 lemma schedule_corres:
   "corres dc (invs and valid_sched and valid_list) invs' (Schedule_A.schedule) ThreadDecls_H.schedule"
-  supply ethread_get_wp[wp del]
   supply ssa_wp[wp del]
   supply tcbSchedEnqueue_invs'[wp del]
   supply tcbSchedEnqueue_invs'_not_ResumeCurrentThread[wp del]
@@ -1907,12 +1905,12 @@ lemma schedule_corres:
             apply (rule corres_split[OF getIdleThread_corres], rename_tac it it')
               apply (rule_tac F="was_running \<longrightarrow> ct \<noteq> it" in corres_gen_asm)
               apply (rule corres_split)
-                 apply (rule ethreadget_corres[where r="(=)"])
-                 apply (clarsimp simp: etcb_relation_def)
+                 apply (rule threadGet_corres[where r="(=)"])
+                 apply (clarsimp simp: tcb_relation_def)
                 apply (rename_tac tp tp')
                 apply (rule corres_split)
-                   apply (rule ethread_get_when_corres[where r="(=)"])
-                   apply (clarsimp simp: etcb_relation_def)
+                   apply (rule thread_get_when_corres[where r="(=)"])
+                   apply (clarsimp simp: tcb_relation_def)
                   apply (rename_tac cp cp')
                   apply (rule corres_split)
                      apply (rule scheduleSwitchThreadFastfail_corres; simp)
@@ -1974,7 +1972,7 @@ lemma schedule_corres:
    apply clarsimp
 
    subgoal for s
-     apply (clarsimp split: Deterministic_A.scheduler_action.splits
+     apply (clarsimp split: Structures_A.scheduler_action.splits
                      simp: invs_psp_aligned invs_distinct invs_valid_objs invs_arch_state
                            invs_vspace_objs[simplified] tcb_at_invs)
      apply (rule conjI, clarsimp)
@@ -1986,15 +1984,14 @@ lemma schedule_corres:
       subgoal for candidate
         apply (clarsimp simp: valid_sched_def invs_def valid_state_def cur_tcb_def
                                valid_arch_caps_def valid_sched_action_def
-                               weak_valid_sched_action_def tcb_at_is_etcb_at
-                               tcb_at_is_etcb_at[OF st_tcb_at_tcb_at[rotated]]
+                               weak_valid_sched_action_def
                                valid_blocked_except_def valid_blocked_def)
         apply (fastforce simp add: pred_tcb_at_def obj_at_def is_tcb valid_idle_def)
         done
      (* choose new thread case *)
      apply (intro impI conjI allI tcb_at_invs
-            | fastforce simp: invs_def cur_tcb_def valid_etcbs_def
-                              valid_sched_def  st_tcb_at_def obj_at_def valid_state_def
+            | fastforce simp: invs_def cur_tcb_def
+                              valid_sched_def st_tcb_at_def obj_at_def valid_state_def
                               weak_valid_sched_action_def not_cur_thread_def)+
      done
 
@@ -2345,7 +2342,7 @@ lemma sbn_sch_act_sane:
 
 lemma possibleSwitchTo_corres:
   "corres dc
-     (valid_etcbs and weak_valid_sched_action and cur_tcb and st_tcb_at runnable t
+     (weak_valid_sched_action and cur_tcb and st_tcb_at runnable t
       and in_correct_ready_q and ready_qs_distinct and pspace_aligned and pspace_distinct)
      ((\<lambda>s. weak_sch_act_wf (ksSchedulerAction s) s)
       and sym_heap_sched_pointers and valid_sched_pointers and valid_objs')
@@ -2354,7 +2351,6 @@ lemma possibleSwitchTo_corres:
    apply (fastforce dest: pspace_aligned_cross)
   apply (rule_tac Q'=pspace_distinct' in corres_cross_add_guard)
    apply (fastforce dest: pspace_distinct_cross)
-  supply ethread_get_wp[wp del]
   apply (rule corres_cross_over_guard[where P'=Q and Q="tcb_at' t and Q" for Q])
    apply (clarsimp simp: state_relation_def)
    apply (rule tcb_at_cross, erule st_tcb_at_tcb_at; assumption)
@@ -2362,8 +2358,8 @@ lemma possibleSwitchTo_corres:
   apply (rule corres_guard_imp)
     apply (rule corres_split[OF curDomain_corres], simp)
       apply (rule corres_split)
-         apply (rule ethreadget_corres[where r="(=)"])
-         apply (clarsimp simp: etcb_relation_def)
+         apply (rule threadGet_corres[where r="(=)"])
+         apply (clarsimp simp: tcb_relation_def)
         apply (rule corres_split[OF getSchedulerAction_corres])
           apply (rule corres_if, simp)
            apply (rule tcbSchedEnqueue_corres, simp)
@@ -2373,14 +2369,9 @@ lemma possibleSwitchTo_corres:
              apply (rule tcbSchedEnqueue_corres, simp)
             apply (wp reschedule_required_valid_queues | strengthen valid_objs'_valid_tcbs')+
           apply (rule setSchedulerAction_corres, simp)
-         apply (wpsimp simp: if_apply_def2
-                       wp: hoare_drop_imp[where f="ethread_get a b" for a b])+
-      apply (wp hoare_drop_imps)[1]
-     apply wp+
-   apply (clarsimp simp: valid_sched_def invs_def valid_state_def cur_tcb_def st_tcb_at_tcb_at
-                          valid_sched_action_def weak_valid_sched_action_def
-                          tcb_at_is_etcb_at[OF st_tcb_at_tcb_at[rotated]])
-  apply (fastforce simp: tcb_at_is_etcb_at)
+         apply (wpsimp wp: hoare_drop_imps)+
+   apply (clarsimp simp: st_tcb_at_tcb_at)
+  apply fastforce
   done
 
 end

--- a/proof/refine/RISCV64/StateRelation.thy
+++ b/proof/refine/RISCV64/StateRelation.thy
@@ -153,7 +153,10 @@ definition tcb_relation :: "Structures_A.tcb \<Rightarrow> Structures_H.tcb \<Ri
    \<and> cap_relation (tcb_caller tcb) (cteCap (tcbCaller tcb'))
    \<and> cap_relation (tcb_ipcframe tcb) (cteCap (tcbIPCBufferFrame tcb'))
    \<and> tcb_bound_notification tcb = tcbBoundNotification tcb'
-   \<and> tcb_mcpriority tcb = tcbMCP tcb'"
+   \<and> tcb_mcpriority tcb = tcbMCP tcb'
+   \<and> tcb_priority tcb = tcbPriority tcb'
+   \<and> tcb_time_slice tcb = tcbTimeSlice tcb'
+   \<and> tcb_domain tcb = tcbDomain tcb'"
 
 \<comment> \<open>
   A pair of objects @{term "(obj, obj')"} should satisfy the following relation when, under further
@@ -281,18 +284,7 @@ definition pspace_relation ::
      (pspace_dom ab = dom con) \<and>
      (\<forall>x \<in> dom ab. \<forall>(y, P) \<in> obj_relation_cuts (the (ab x)) x. P (the (ab x)) (the (con y)))"
 
-definition etcb_relation :: "etcb \<Rightarrow> Structures_H.tcb \<Rightarrow> bool" where
-  "etcb_relation \<equiv> \<lambda>etcb tcb'.
-     tcb_priority etcb = tcbPriority tcb'
-     \<and> tcb_time_slice etcb = tcbTimeSlice tcb'
-     \<and> tcb_domain etcb = tcbDomain tcb'"
-
-definition ekheap_relation ::
-  "(obj_ref \<Rightarrow> etcb option) \<Rightarrow> (machine_word \<rightharpoonup> Structures_H.kernel_object) \<Rightarrow> bool" where
-  "ekheap_relation ab con \<equiv>
-     \<forall>x \<in> dom ab. \<exists>tcb'. con x = Some (KOTCB tcb') \<and> etcb_relation (the (ab x)) tcb'"
-
-primrec sched_act_relation :: "Deterministic_A.scheduler_action \<Rightarrow> scheduler_action \<Rightarrow> bool"
+primrec sched_act_relation :: "Structures_A.scheduler_action \<Rightarrow> scheduler_action \<Rightarrow> bool"
   where
   "sched_act_relation resume_cur_thread a' = (a' = ResumeCurrentThread)" |
   "sched_act_relation choose_new_thread a' = (a' = ChooseNewThread)" |
@@ -320,8 +312,8 @@ lemma list_queue_relation_nil:
   by (fastforce dest: heap_path_head simp: tcbQueueEmpty_def list_queue_relation_def)
 
 definition ready_queue_relation ::
-  "Deterministic_A.domain \<Rightarrow> Structures_A.priority
-   \<Rightarrow> Deterministic_A.ready_queue \<Rightarrow> ready_queue
+  "Structures_A.domain \<Rightarrow> Structures_A.priority
+   \<Rightarrow> Structures_A.ready_queue \<Rightarrow> ready_queue
    \<Rightarrow> (obj_ref \<rightharpoonup> obj_ref) \<Rightarrow> (obj_ref \<rightharpoonup> obj_ref)
    \<Rightarrow> (obj_ref \<Rightarrow> bool) \<Rightarrow> bool"
   where
@@ -331,7 +323,7 @@ definition ready_queue_relation ::
      \<and> (d > maxDomain \<or> p > maxPriority \<longrightarrow> tcbQueueEmpty q')"
 
 definition ready_queues_relation_2 ::
-  "(Deterministic_A.domain \<Rightarrow> Structures_A.priority \<Rightarrow> Deterministic_A.ready_queue)
+  "(Structures_A.domain \<Rightarrow> Structures_A.priority \<Rightarrow> Structures_A.ready_queue)
    \<Rightarrow> (domain \<times> priority \<Rightarrow> ready_queue)
    \<Rightarrow> (obj_ref \<rightharpoonup> obj_ref) \<Rightarrow> (obj_ref \<rightharpoonup> obj_ref)
    \<Rightarrow> (domain \<Rightarrow> priority \<Rightarrow> obj_ref \<Rightarrow> bool) \<Rightarrow> bool"
@@ -479,7 +471,6 @@ definition APIType_map :: "Structures_A.apiobject_type \<Rightarrow> RISCV64_H.o
 definition state_relation :: "(det_state \<times> kernel_state) set" where
   "state_relation \<equiv> {(s, s').
          pspace_relation (kheap s) (ksPSpace s')
-       \<and> ekheap_relation (ekheap s) (ksPSpace s')
        \<and> sched_act_relation (scheduler_action s) (ksSchedulerAction s')
        \<and> ready_queues_relation s s'
        \<and> ghost_relation (kheap s) (gsUserPages s') (gsCNodes s')
@@ -511,10 +502,6 @@ lemma state_relation_pspace_relation[elim!]:
   "(s,s') \<in> state_relation \<Longrightarrow> pspace_relation (kheap s) (ksPSpace s')"
   by (simp add: state_relation_def)
 
-lemma state_relation_ekheap_relation[elim!]:
-  "(s,s') \<in> state_relation \<Longrightarrow> ekheap_relation (ekheap s) (ksPSpace s')"
-  by (simp add: state_relation_def)
-
 lemma state_relation_sched_act_relation[elim!]:
   "(s,s') \<in> state_relation \<Longrightarrow> sched_act_relation (scheduler_action s) (ksSchedulerAction s')"
   by (clarsimp simp: state_relation_def)
@@ -530,7 +517,6 @@ lemma state_relation_idle_thread[elim!]:
 lemma state_relationD:
   "(s, s') \<in> state_relation \<Longrightarrow>
    pspace_relation (kheap s) (ksPSpace s') \<and>
-   ekheap_relation (ekheap s) (ksPSpace s') \<and>
    sched_act_relation (scheduler_action s) (ksSchedulerAction s') \<and>
    ready_queues_relation s s' \<and>
    ghost_relation (kheap s) (gsUserPages s') (gsCNodes s') \<and>
@@ -552,7 +538,6 @@ lemma state_relationD:
 lemma state_relationE [elim?]:
   assumes sr:  "(s, s') \<in> state_relation"
   and rl: "\<lbrakk> pspace_relation (kheap s) (ksPSpace s');
-             ekheap_relation (ekheap s) (ksPSpace s');
              sched_act_relation (scheduler_action s) (ksSchedulerAction s');
              ready_queues_relation s s';
              ghost_relation (kheap s) (gsUserPages s') (gsCNodes s');
@@ -600,11 +585,6 @@ lemma pspace_relation_absD:
   apply (simp (no_asm) add: pspace_dom_def)
   apply (fastforce simp: image_def intro: rev_bexI)
   done
-
-lemma ekheap_relation_absD:
-  "\<lbrakk> ab x = Some y; ekheap_relation ab con \<rbrakk> \<Longrightarrow>
-   \<exists>tcb'. con x = Some (KOTCB tcb') \<and> etcb_relation y tcb'"
-  by (force simp add: ekheap_relation_def)
 
 lemma in_related_pspace_dom:
   "\<lbrakk> s' x = Some y; pspace_relation s s' \<rbrakk> \<Longrightarrow> x \<in> pspace_dom s"

--- a/proof/refine/RISCV64/Syscall_R.thy
+++ b/proof/refine/RISCV64/Syscall_R.thy
@@ -350,7 +350,7 @@ lemma threadSet_tcbDomain_update_sch_act_wf[wp]:
 
 lemma setDomain_corres:
   "corres dc
-     (valid_etcbs and valid_sched and tcb_at tptr and pspace_aligned and pspace_distinct)
+     (valid_sched and tcb_at tptr and pspace_aligned and pspace_distinct)
      (invs' and sch_act_simple and tcb_at' tptr and (\<lambda>s. new_dom \<le> maxDomain))
      (set_domain tptr new_dom) (setDomain tptr new_dom)"
   apply (rule corres_gen_asm2)
@@ -359,8 +359,8 @@ lemma setDomain_corres:
     apply (rule corres_split[OF getCurThread_corres])
       apply (rule corres_split[OF tcbSchedDequeue_corres], simp)
         apply (rule corres_split)
-           apply (rule ethread_set_corres; simp)
-           apply (clarsimp simp: etcb_relation_def)
+           apply (rule threadSet_not_queued_corres;
+                  simp add: tcb_relation_def tcb_cap_cases_def tcb_cte_cases_def cteSizeBits_def)
           apply (rule corres_split[OF isRunnable_corres])
             apply simp
             apply (rule corres_split)
@@ -373,9 +373,9 @@ lemma setDomain_corres:
             apply ((wpsimp wp: hoare_drop_imps | strengthen valid_objs'_valid_tcbs')+)[1]
            apply (wpsimp wp: gts_wp)
           apply wpsimp
-         apply ((wpsimp wp: hoare_vcg_imp_lift' ethread_set_not_queued_valid_queues hoare_vcg_all_lift
-                 | strengthen valid_objs'_valid_tcbs' valid_queues_in_correct_ready_q
-                              valid_queues_ready_qs_distinct)+)[1]
+         apply (wpsimp wp: hoare_vcg_imp_lift' hoare_vcg_all_lift
+                           thread_set_in_correct_ready_q_not_queued thread_set_no_change_tcb_state
+                           thread_set_no_change_tcb_state_converse thread_set_weak_valid_sched_action)
         apply (rule_tac Q'="\<lambda>_. valid_objs' and sym_heap_sched_pointers and valid_sched_pointers
                                and pspace_aligned' and pspace_distinct'
                                and (\<lambda>s. sch_act_wf (ksSchedulerAction s) s) and tcb_at' tptr"
@@ -384,7 +384,7 @@ lemma setDomain_corres:
         apply (wpsimp wp: threadSet_valid_objs' threadSet_sched_pointers
                           threadSet_valid_sched_pointers)+
        apply (rule_tac Q'="\<lambda>_ s. valid_queues s \<and> not_queued tptr s
-                                \<and> pspace_aligned s \<and> pspace_distinct s \<and> valid_etcbs s
+                                \<and> pspace_aligned s \<and> pspace_distinct s
                                 \<and> weak_valid_sched_action s"
                     in hoare_post_imp)
         apply (fastforce simp: pred_tcb_at_def obj_at_def)
@@ -398,10 +398,7 @@ lemma setDomain_corres:
        apply (clarsimp simp: tcb_cte_cases_def cteSizeBits_def)
        apply fastforce
       apply (wp hoare_vcg_all_lift tcbSchedDequeue_not_queued)+
-   apply clarsimp
-   apply (frule tcb_at_is_etcb_at)
-    apply simp+
-   apply (auto elim: tcb_at_is_etcb_at valid_objs'_maxDomain valid_objs'_maxPriority pred_tcb'_weakenE
+   apply (auto elim: valid_objs'_maxDomain valid_objs'_maxPriority pred_tcb'_weakenE
                simp: valid_sched_def valid_sched_action_def)
   done
 
@@ -1569,8 +1566,7 @@ lemma handleYield_corres:
                 | strengthen valid_objs'_valid_tcbs' valid_queues_in_correct_ready_q
                   valid_queues_ready_qs_distinct)+
    apply (simp add: invs_def valid_sched_def valid_sched_action_def cur_tcb_def
-                    tcb_at_is_etcb_at valid_state_def valid_pspace_def ct_in_state_def
-                    runnable_eq_active)
+                    valid_state_def valid_pspace_def ct_in_state_def runnable_eq_active)
   apply (fastforce simp: invs'_def valid_state'_def ct_in_state'_def sch_act_wf_weak cur_tcb'_def
                         valid_pspace_valid_objs' valid_objs'_maxDomain tcb_in_cur_domain'_def)
   done
@@ -1811,10 +1807,6 @@ lemma handleReply_nonz_cap_to_ct:
 
 crunch handleFaultReply
   for ksQ[wp]: "\<lambda>s. P (ksReadyQueues s p)"
-
-crunch handle_recv
-  for valid_etcbs[wp]: "valid_etcbs"
-  (wp: crunch_wps simp: crunch_simps)
 
 lemma handleReply_handleRecv_corres:
   "corres dc (einvs and ct_running)

--- a/proof/refine/RISCV64/TcbAcc_R.thy
+++ b/proof/refine/RISCV64/TcbAcc_R.thy
@@ -339,29 +339,27 @@ lemma setObject_update_TCB_corres':
   assumes tables': "\<forall>(getF, v) \<in> ran tcb_cte_cases. getF new_tcb' = getF tcb'"
   assumes sched_pointers: "tcbSchedPrev new_tcb' = tcbSchedPrev tcb'"
                           "tcbSchedNext new_tcb' = tcbSchedNext tcb'"
-  assumes flag: "tcbQueued new_tcb' = tcbQueued tcb'"
+  assumes flag: "\<And>d p. inQ d p new_tcb' = inQ d p tcb'"
   assumes r: "r () ()"
-  assumes exst: "exst_same tcb' new_tcb'"
   shows
     "corres r
        (ko_at (TCB tcb) ptr) (ko_at' tcb' ptr)
        (set_object ptr (TCB new_tcb)) (setObject ptr new_tcb')"
-  apply (rule_tac F="tcb_relation tcb tcb' \<and> exst_same tcb' new_tcb'" in corres_req)
+  apply (rule_tac F="tcb_relation tcb tcb'" in corres_req)
    apply (clarsimp simp: state_relation_def obj_at_def obj_at'_def)
    apply (frule(1) pspace_relation_absD)
-   apply (clarsimp simp: tcb_relation_cut_def exst)
+   apply (clarsimp simp: tcb_relation_cut_def)
   apply (rule corres_no_failI)
-   apply (rule no_fail_pre)
-    apply wp
+   apply wp
    apply (clarsimp simp: obj_at'_def)
   apply (unfold set_object_def setObject_def)
   apply (clarsimp simp: in_monad split_def bind_def gets_def get_def Bex_def
-                        put_def return_def modify_def get_object_def projectKOs obj_at_def
-                        updateObject_default_def in_magnitude_check obj_at'_def)
-  apply (rename_tac s s' t')
-  apply (prop_tac "t' = s'")
-   apply (clarsimp simp: magnitudeCheck_def in_monad split: option.splits)
-  apply (drule singleton_in_magnitude_check)
+                        put_def return_def modify_def get_object_def obj_at_def
+                        updateObject_default_def in_magnitude_check objBits_less_word_bits)
+  apply (rename_tac s s' ko)
+  apply (prop_tac "ko = tcb'")
+   apply (clarsimp simp: obj_at'_def project_inject)
+  apply (clarsimp simp: state_relation_def)
   apply (prop_tac "map_to_ctes ((ksPSpace s') (ptr \<mapsto> injectKO new_tcb'))
                    = map_to_ctes (ksPSpace s')")
    apply (frule_tac tcb=new_tcb' and tcb=tcb' in map_to_ctes_upd_tcb)
@@ -369,72 +367,57 @@ lemma setObject_update_TCB_corres':
     apply (clarsimp simp: objBits_simps ps_clear_def3 field_simps objBits_defs mask_def)
    apply (insert tables')[1]
    apply (rule ext)
-   apply (clarsimp split: if_splits)
-   apply blast
+   subgoal by auto
   apply (prop_tac "obj_at (same_caps (TCB new_tcb)) ptr s")
    using tables
    apply (fastforce simp: obj_at_def)
-  apply (clarsimp simp: caps_of_state_after_update cte_wp_at_after_update swp_def
+  apply (clarsimp simp: caps_of_state_after_update cte_wp_at_after_update swp_def fun_upd_def
                         obj_at_def assms)
-  apply (clarsimp simp add: state_relation_def)
   apply (subst conj_assoc[symmetric])
   apply (extract_conjunct \<open>match conclusion in "ghost_relation _ _ _" \<Rightarrow> -\<close>)
-   apply (clarsimp simp add: ghost_relation_def)
+   apply (clarsimp simp: ghost_relation_def)
    apply (erule_tac x=ptr in allE)+
    apply clarsimp
-  apply (simp only: pspace_relation_def pspace_dom_update dom_fun_upd2 simp_thms)
-  apply (elim conjE)
-  apply (frule bspec, erule domI)
-  apply clarsimp
-  apply (rule conjI)
+  apply (extract_conjunct \<open>match conclusion in "pspace_relation _ _" \<Rightarrow> -\<close>)
+   apply (fold fun_upd_def)
    apply (simp only: pspace_relation_def simp_thms
                      pspace_dom_update[where x="kernel_object.TCB _"
                                          and v="kernel_object.TCB _",
                                        simplified a_type_def, simplified])
-  apply (rule conjI)
    using assms
    apply (simp only: dom_fun_upd2 simp_thms)
+   apply (elim conjE)
    apply (frule bspec, erule domI)
    apply (rule ballI, drule(1) bspec)
    apply (drule domD)
-   apply (clarsimp simp: tcb_relation_cut_def split: if_split_asm kernel_object.split_asm)
+   apply (clarsimp simp: project_inject tcb_relation_cut_def
+                  split: if_split_asm kernel_object.split_asm)
    apply (rename_tac aa ba)
    apply (drule_tac x="(aa, ba)" in bspec, simp)
    apply clarsimp
    apply (frule_tac ko'="kernel_object.TCB tcb" and x'=ptr in obj_relation_cut_same_type)
       apply (simp add: tcb_relation_cut_def)+
    apply clarsimp
-  apply (extract_conjunct \<open>match conclusion in "ekheap_relation _ _" \<Rightarrow> -\<close>)
-   apply (simp only: ekheap_relation_def)
-   apply (rule ballI, drule (1) bspec)
-   apply (insert exst)
-   apply (clarsimp simp: etcb_relation_def exst_same_def)
-  apply (extract_conjunct \<open>match conclusion in "ready_queues_relation_2 _ _ _ _ _" \<Rightarrow> -\<close>)
-   apply (insert sched_pointers flag exst)
-   apply (clarsimp simp: ready_queues_relation_def Let_def)
-   apply (prop_tac "(tcbSchedNexts_of s')(ptr := tcbSchedNext new_tcb') = tcbSchedNexts_of s'")
-    apply (fastforce simp: opt_map_def)
-   apply (prop_tac "(tcbSchedPrevs_of s')(ptr := tcbSchedPrev new_tcb') = tcbSchedPrevs_of s'")
-    apply (fastforce simp: opt_map_def)
-   apply (clarsimp simp: ready_queue_relation_def opt_pred_def opt_map_def exst_same_def inQ_def
-                  split: option.splits)
-   apply (metis (mono_tags, opaque_lifting))
-  apply (clarsimp simp: fun_upd_def caps_of_state_after_update cte_wp_at_after_update swp_def
-                        obj_at_def)
-  done
+  apply (insert sched_pointers flag)
+  apply (clarsimp simp: ready_queues_relation_def Let_def)
+  apply (prop_tac "(tcbSchedNexts_of s')(ptr := tcbSchedNext new_tcb') = tcbSchedNexts_of s'")
+   apply (fastforce simp: opt_map_def)
+  apply (prop_tac "(tcbSchedPrevs_of s')(ptr := tcbSchedPrev new_tcb') = tcbSchedPrevs_of s'")
+   apply (fastforce simp: opt_map_def)
+  by (clarsimp simp: ready_queue_relation_def opt_pred_def opt_map_def split: option.splits)
 
 lemma setObject_update_TCB_corres:
   "\<lbrakk>tcb_relation tcb tcb' \<Longrightarrow> tcb_relation new_tcb new_tcb';
      \<forall>(getF, v) \<in> ran tcb_cap_cases. getF new_tcb = getF tcb;
      \<forall>(getF, v) \<in> ran tcb_cte_cases. getF new_tcb' = getF tcb';
      tcbSchedPrev new_tcb' = tcbSchedPrev tcb'; tcbSchedNext new_tcb' = tcbSchedNext tcb';
-     tcbQueued new_tcb' = tcbQueued tcb'; exst_same tcb' new_tcb';
+     \<And>d p. inQ d p new_tcb' = inQ d p tcb';
      r () ()\<rbrakk> \<Longrightarrow>
    corres r
      (\<lambda>s. get_tcb ptr s = Some tcb) (\<lambda>s'. (tcb', s') \<in> fst (getObject ptr s'))
      (set_object ptr (TCB new_tcb)) (setObject ptr new_tcb')"
   apply (rule corres_guard_imp)
-    apply (erule (7) setObject_update_TCB_corres')
+    apply (erule (4) setObject_update_TCB_corres')
    apply (clarsimp simp: getObject_def in_monad split_def obj_at'_def
                          loadObject_default_def objBits_simps' in_magnitude_check)+
   done
@@ -488,8 +471,7 @@ lemma threadset_corresT:
                  getF (f' tcb) = getF tcb"
   assumes sched_pointers: "\<And>tcb. tcbSchedPrev (f' tcb) = tcbSchedPrev tcb"
                           "\<And>tcb. tcbSchedNext (f' tcb) = tcbSchedNext tcb"
-  assumes flag: "\<And>tcb. tcbQueued (f' tcb) = tcbQueued tcb"
-  assumes e: "\<And>tcb'. exst_same tcb' (f' tcb')"
+  assumes flag: "\<And>d p tcb'. inQ d p (f' tcb') = inQ d p tcb'"
   shows      "corres dc (tcb_at t and pspace_aligned and pspace_distinct)
                         \<top>
                         (thread_set f t) (threadSet f' t)"
@@ -497,15 +479,14 @@ lemma threadset_corresT:
   apply (rule corres_guard_imp)
     apply (rule corres_split[OF getObject_TCB_corres])
       apply (rule setObject_update_TCB_corres')
-             apply (erule x)
-            apply (rule y)
-           apply (clarsimp simp: bspec_split [OF spec [OF z]])
-           apply fastforce
-          apply (rule sched_pointers)
+            apply (erule x)
+           apply (rule y)
+          apply (clarsimp simp: bspec_split [OF spec [OF z]])
+          apply fastforce
          apply (rule sched_pointers)
-        apply (rule flag)
-       apply simp
-      apply (rule e)
+        apply (rule sched_pointers)
+       apply (rule flag)
+      apply simp
      apply wp+
    apply (clarsimp simp add: tcb_at_def obj_at_def)
    apply (drule get_tcb_SomeD)
@@ -535,8 +516,7 @@ lemma threadSet_corres_noopT:
                  getF (fn tcb) = getF tcb"
   assumes s: "\<forall>tcb'. tcbSchedPrev (fn tcb') = tcbSchedPrev tcb'"
              "\<forall>tcb'. tcbSchedNext (fn tcb') = tcbSchedNext tcb'"
-  assumes f: "\<And>tcb'. tcbQueued (fn tcb') = tcbQueued tcb'"
-  assumes e: "\<And>tcb'. exst_same tcb' (fn tcb')"
+  assumes f: "\<And>d p tcb'. inQ d p (fn tcb') = inQ d p tcb'"
   shows      "corres dc (tcb_at t and pspace_aligned and pspace_distinct) \<top>
                         (return v) (threadSet fn t)"
 proof -
@@ -554,13 +534,12 @@ proof -
        defer
        apply (subst bind_return [symmetric],
               rule corres_underlying_split [OF threadset_corresT])
-                apply (simp add: x)
-               apply simp
-              apply (rule y)
-             apply (fastforce simp: s)
+               apply (simp add: x)
+              apply simp
+             apply (rule y)
             apply (fastforce simp: s)
-           apply (fastforce simp: f)
-          apply (rule e)
+           apply (fastforce simp: s)
+          apply (fastforce simp: f)
          apply (rule corres_noop [where P=\<top> and P'=\<top>])
           apply simp
          apply (rule no_fail_pre, wpsimp+)[1]
@@ -580,19 +559,17 @@ lemma threadSet_corres_noop_splitT:
   assumes w: "\<lbrace>P'\<rbrace> threadSet fn t \<lbrace>\<lambda>x. Q'\<rbrace>"
   assumes s: "\<forall>tcb'. tcbSchedPrev (fn tcb') = tcbSchedPrev tcb'"
              "\<forall>tcb'. tcbSchedNext (fn tcb') = tcbSchedNext tcb'"
-  assumes f: "\<And>tcb'. tcbQueued (fn tcb') = tcbQueued tcb'"
-  assumes e: "\<And>tcb'. exst_same tcb' (fn tcb')"
+  assumes f: "\<And>d p tcb'. inQ d p (fn tcb') = inQ d p tcb'"
   shows      "corres r (tcb_at t and pspace_aligned and pspace_distinct and P) P'
                            m (threadSet fn t >>= (\<lambda>rv. m'))"
   apply (rule corres_guard_imp)
     apply (subst return_bind[symmetric])
     apply (rule corres_split_nor[OF threadSet_corres_noopT])
-            apply (simp add: x)
-           apply (rule y)
-          apply (fastforce simp: s)
+           apply (simp add: x)
+          apply (rule y)
          apply (fastforce simp: s)
-        apply (fastforce simp: f)
-       apply (rule e)
+        apply (fastforce simp: s)
+       apply (fastforce simp: f)
       apply (rule z)
      apply (wp w)+
    apply simp
@@ -1540,7 +1517,7 @@ proof -
                      (set_object add (TCB (tcb \<lparr> tcb_arch := arch_tcb_context_set con (tcb_arch tcb) \<rparr>)))
                      (setObject add (tcb' \<lparr> tcbArch := atcbContextSet con' (tcbArch tcb') \<rparr>))"
     by (rule setObject_update_TCB_corres [OF L2],
-        (simp add: tcb_cte_cases_def tcb_cap_cases_def cteSizeBits_def exst_same_def)+)
+        (simp add: tcb_cte_cases_def tcb_cap_cases_def cteSizeBits_def)+)
   have L4: "\<And>con con'. con = con' \<Longrightarrow>
             corres (\<lambda>(irv, nc) (irv', nc'). r irv irv' \<and> nc = nc')
                    \<top> \<top> (select_f (f con)) (select_f (g con'))"
@@ -1891,41 +1868,6 @@ lemma fun_if_triv[simp]:
   "(\<lambda>x. if x = y then f y else f x) = f"
   by (force)
 
-lemma corres_get_etcb:
-  "corres (etcb_relation) (is_etcb_at t) (tcb_at' t)
-                    (gets_the (get_etcb t)) (getObject t)"
-  apply (rule corres_no_failI)
-   apply wp
-  apply (clarsimp simp add: get_etcb_def gets_the_def gets_def
-                            get_def assert_opt_def bind_def
-                            return_def fail_def
-                            split: option.splits
-                            )
-  apply (frule in_inv_by_hoareD [OF getObject_inv_tcb])
-  apply (clarsimp simp add: is_etcb_at_def obj_at'_def projectKO_def
-                            projectKO_opt_tcb split_def
-                            getObject_def loadObject_default_def in_monad)
-  apply (case_tac bb)
-        apply (simp_all add: fail_def return_def)
-  apply (clarsimp simp add: state_relation_def ekheap_relation_def)
-  apply (drule bspec)
-   apply clarsimp
-   apply blast
-  apply (clarsimp simp add: other_obj_relation_def lookupAround2_known1)
-  done
-
-
-lemma ethreadget_corres:
-  assumes x: "\<And>etcb tcb'. etcb_relation etcb tcb' \<Longrightarrow> r (f etcb) (f' tcb')"
-  shows      "corres r (is_etcb_at t) (tcb_at' t) (ethread_get f t) (threadGet f' t)"
-  apply (simp add: ethread_get_def threadGet_def)
-  apply (fold liftM_def)
-  apply simp
-  apply (rule corres_rel_imp)
-   apply (rule corres_get_etcb)
-  apply (simp add: x)
-  done
-
 lemma getQueue_corres:
   "corres (\<lambda>ls q. (ls = [] \<longleftrightarrow> tcbQueueEmpty q) \<and> (ls \<noteq> [] \<longrightarrow> tcbQueueHead q = Some (hd ls))
                   \<and> queue_end_valid ls q)
@@ -1976,13 +1918,14 @@ crunch removeFromBitmap
 lemmas addToBitmap_typ_ats [wp] = typ_at_lifts [OF addToBitmap_typ_at']
 lemmas removeFromBitmap_typ_ats [wp] = typ_at_lifts [OF removeFromBitmap_typ_at']
 
-lemma ekheap_relation_tcb_domain_priority:
-  "\<lbrakk>ekheap_relation (ekheap s) (ksPSpace s'); ekheap s t = Some (tcb);
+lemma pspace_relation_tcb_domain_priority:
+  "\<lbrakk>pspace_relation (kheap s) (ksPSpace s'); kheap s t = Some (TCB tcb);
     ksPSpace s' t = Some (KOTCB tcb')\<rbrakk>
    \<Longrightarrow> tcbDomain tcb' = tcb_domain tcb \<and> tcbPriority tcb' = tcb_priority tcb"
-  apply (clarsimp simp: ekheap_relation_def)
-  apply (drule_tac x=t in bspec, blast)
-  apply (clarsimp simp: other_obj_relation_def etcb_relation_def)
+  apply (clarsimp simp: pspace_relation_def)
+  apply (drule_tac x=t in bspec)
+   apply (fastforce simp: obj_at_def)
+  apply (clarsimp simp: obj_at_def obj_at'_def tcb_relation_cut_def tcb_relation_def)
   done
 
 lemma no_fail_thread_get[wp]:
@@ -2029,85 +1972,16 @@ lemma threadSet_pspace_relation:
   apply (fastforce dest!: tcb_rel)
   done
 
-lemma ekheap_relation_update_tcbs:
-  "\<lbrakk> ekheap_relation (ekheap s) (ksPSpace s'); ekheap s x = Some oetcb;
-     ksPSpace s' x = Some (KOTCB otcb'); etcb_relation etcb tcb' \<rbrakk>
-   \<Longrightarrow> ekheap_relation ((ekheap s)(x \<mapsto> etcb)) ((ksPSpace s')(x \<mapsto> KOTCB tcb'))"
-  by (simp add: ekheap_relation_def)
-
-lemma ekheap_relation_update_concrete_tcb:
-  "\<lbrakk>ekheap_relation (ekheap s) (ksPSpace s'); ekheap s ptr = Some etcb;
-    ksPSpace s' ptr = Some (KOTCB otcb');
-    etcb_relation etcb tcb'\<rbrakk>
-   \<Longrightarrow> ekheap_relation (ekheap s) ((ksPSpace s')(ptr \<mapsto> KOTCB tcb'))"
-  by (fastforce dest: ekheap_relation_update_tcbs simp: map_upd_triv)
-
-lemma ekheap_relation_etcb_relation:
-  "\<lbrakk>ekheap_relation (ekheap s) (ksPSpace s'); ekheap s ptr = Some etcb;
-    ksPSpace s' ptr = Some (KOTCB tcb')\<rbrakk>
-   \<Longrightarrow> etcb_relation etcb tcb'"
-  apply (clarsimp simp: ekheap_relation_def)
-  apply (drule_tac x=ptr in bspec)
-   apply (fastforce simp: obj_at_def)
-  apply (clarsimp simp: obj_at_def obj_at'_def)
-  done
-
-lemma threadSet_ekheap_relation:
-  fixes s :: det_state
-  assumes etcb_rel: "(\<And>etcb tcb'. etcb_relation etcb tcb' \<Longrightarrow> etcb_relation etcb (F tcb'))"
-  shows
-    "\<lbrace>\<lambda>s'. ekheap_relation (ekheap s) (ksPSpace s') \<and> pspace_relation (kheap s) (ksPSpace s')
-           \<and> valid_etcbs s\<rbrace>
-     threadSet F tcbPtr
-     \<lbrace>\<lambda>_ s'. ekheap_relation (ekheap s) (ksPSpace s')\<rbrace>"
-  supply fun_upd_apply[simp del]
-  unfolding threadSet_def setObject_def updateObject_default_def
-  apply (wpsimp wp: getObject_tcb_wp simp: updateObject_default_def)
-  apply (frule tcb_at'_cross)
-   apply (fastforce simp: obj_at'_def)
-  apply normalise_obj_at'
-  apply (frule (1) tcb_at_is_etcb_at)
-  apply (clarsimp simp: obj_at_def is_tcb_def is_etcb_at_def)
-  apply (rename_tac ko, case_tac ko; clarsimp)
-  apply (rule ekheap_relation_update_concrete_tcb)
-     apply fastforce
-    apply fastforce
-   apply (fastforce simp: obj_at'_def)
-  apply (frule (1) ekheap_relation_etcb_relation)
-   apply (fastforce simp: obj_at'_def)
-  apply (fastforce dest!: etcb_rel)
-  done
-
 lemma tcbQueued_update_pspace_relation[wp]:
   fixes s :: det_state
   shows "threadSet (tcbQueued_update f) tcbPtr \<lbrace>\<lambda>s'. pspace_relation (kheap s) (ksPSpace s')\<rbrace>"
   by (wpsimp wp: threadSet_pspace_relation simp: tcb_relation_def)
-
-lemma tcbQueued_update_ekheap_relation[wp]:
-  fixes s :: det_state
-  shows
-    "\<lbrace>\<lambda>s'. ekheap_relation (ekheap s) (ksPSpace s') \<and> pspace_relation (kheap s) (ksPSpace s')
-           \<and> valid_etcbs s\<rbrace>
-     threadSet (tcbQueued_update f) tcbPtr
-     \<lbrace>\<lambda>_ s'. ekheap_relation (ekheap s) (ksPSpace s')\<rbrace>"
-  by (wpsimp wp: threadSet_ekheap_relation simp: etcb_relation_def)
 
 lemma tcbQueueRemove_pspace_relation[wp]:
   fixes s :: det_state
   shows "tcbQueueRemove queue tcbPtr \<lbrace>\<lambda>s'. pspace_relation (kheap s) (ksPSpace s')\<rbrace>"
   unfolding tcbQueueRemove_def
   by (wpsimp wp: threadSet_pspace_relation hoare_drop_imps simp: tcb_relation_def)
-
-lemma tcbQueueRemove_ekheap_relation[wp]:
-  fixes s :: det_state
-  shows
-    "\<lbrace>\<lambda>s'. ekheap_relation (ekheap s) (ksPSpace s') \<and> pspace_relation (kheap s) (ksPSpace s')
-           \<and> valid_etcbs s\<rbrace>
-     tcbQueueRemove queue tcbPtr
-     \<lbrace>\<lambda>_ s'. ekheap_relation (ekheap s) (ksPSpace s')\<rbrace>"
-  unfolding tcbQueueRemove_def
-  by (wpsimp wp: threadSet_ekheap_relation threadSet_pspace_relation hoare_drop_imps
-           simp: tcb_relation_def etcb_relation_def)
 
 lemma threadSet_ghost_relation[wp]:
   "threadSet f tcbPtr \<lbrace>\<lambda>s'. ghost_relation (kheap s) (gsUserPages s') (gsCNodes s')\<rbrace>"
@@ -2146,7 +2020,7 @@ lemma set_tcb_queue_projs:
    \<lbrace>\<lambda>s. P (kheap s) (cdt s) (is_original_cap s) (cur_thread s) (idle_thread s) (scheduler_action s)
           (domain_list s) (domain_index s) (cur_domain s) (domain_time s) (machine_state s)
           (interrupt_irq_node s) (interrupt_states s) (arch_state s) (caps_of_state s)
-          (work_units_completed s) (cdt_list s) (ekheap s)\<rbrace>"
+          (work_units_completed s) (cdt_list s)\<rbrace>"
   by (wpsimp simp: set_tcb_queue_def)
 
 lemma set_tcb_queue_cte_at:
@@ -2159,7 +2033,6 @@ lemma set_tcb_queue_cte_at:
 lemma set_tcb_queue_projs_inv:
   "fst (set_tcb_queue d p queue s) = {(r, s')} \<Longrightarrow>
    kheap s = kheap s'
-   \<and> ekheap s = ekheap s'
    \<and> cdt s = cdt s'
    \<and> is_original_cap s = is_original_cap s'
    \<and> cur_thread s = cur_thread s'
@@ -2192,50 +2065,17 @@ lemma tcbQueuePrepend_pspace_relation[wp]:
   unfolding tcbQueuePrepend_def
   by (wpsimp wp: threadSet_pspace_relation simp: tcb_relation_def)
 
-lemma tcbQueuePrepend_ekheap_relation[wp]:
-  fixes s :: det_state
-  shows
-    "\<lbrace>\<lambda>s'. ekheap_relation (ekheap s) (ksPSpace s') \<and> pspace_relation (kheap s) (ksPSpace s')
-           \<and> valid_etcbs s\<rbrace>
-     tcbQueuePrepend queue tcbPtr
-     \<lbrace>\<lambda>_ s'. ekheap_relation (ekheap s) (ksPSpace s')\<rbrace>"
-  unfolding tcbQueuePrepend_def
-  by (wpsimp wp: threadSet_pspace_relation threadSet_ekheap_relation
-           simp: tcb_relation_def etcb_relation_def)
-
 lemma tcbQueueAppend_pspace_relation[wp]:
   fixes s :: det_state
   shows "tcbQueueAppend queue tcbPtr \<lbrace>\<lambda>s'. pspace_relation (kheap s) (ksPSpace s')\<rbrace>"
   unfolding tcbQueueAppend_def
   by (wpsimp wp: threadSet_pspace_relation simp: tcb_relation_def)
 
-lemma tcbQueueAppend_ekheap_relation[wp]:
-  fixes s :: det_state
-  shows
-    "\<lbrace>\<lambda>s'. ekheap_relation (ekheap s) (ksPSpace s') \<and> pspace_relation (kheap s) (ksPSpace s')
-           \<and> valid_etcbs s\<rbrace>
-     tcbQueueAppend queue tcbPtr
-     \<lbrace>\<lambda>_ s'. ekheap_relation (ekheap s) (ksPSpace s')\<rbrace>"
-  unfolding tcbQueueAppend_def
-  by (wpsimp wp: threadSet_pspace_relation threadSet_ekheap_relation
-           simp: tcb_relation_def etcb_relation_def)
-
 lemma tcbQueueInsert_pspace_relation[wp]:
   fixes s :: det_state
   shows "tcbQueueInsert tcbPtr afterPtr \<lbrace>\<lambda>s'. pspace_relation (kheap s) (ksPSpace s')\<rbrace>"
   unfolding tcbQueueInsert_def
   by (wpsimp wp: threadSet_pspace_relation hoare_drop_imps simp: tcb_relation_def)
-
-lemma tcbQueueInsert_ekheap_relation[wp]:
-  fixes s :: det_state
-  shows
-    "\<lbrace>\<lambda>s'. ekheap_relation (ekheap s) (ksPSpace s') \<and> pspace_relation (kheap s) (ksPSpace s')
-           \<and> valid_etcbs s\<rbrace>
-     tcbQueueInsert tcbPtr afterPtr
-     \<lbrace>\<lambda>_ s'. ekheap_relation (ekheap s) (ksPSpace s')\<rbrace>"
-  unfolding tcbQueueInsert_def
-  by (wpsimp wp: threadSet_pspace_relation threadSet_ekheap_relation hoare_drop_imps
-           simp: tcb_relation_def etcb_relation_def)
 
 lemma removeFromBitmap_pspace_relation[wp]:
   fixes s :: det_state
@@ -2318,22 +2158,22 @@ lemma threadSet_ready_queues_relation:
 definition in_correct_ready_q_2 where
   "in_correct_ready_q_2 queues ekh \<equiv>
      \<forall>d p. \<forall>t \<in> set (queues d p). is_etcb_at' t ekh
-                                  \<and> etcb_at' (\<lambda>t. tcb_priority t = p \<and> tcb_domain t = d) t ekh"
+                                  \<and> etcb_at' (\<lambda>t. etcb_priority t = p \<and> etcb_domain t = d) t ekh"
 
-abbreviation in_correct_ready_q :: "det_ext state \<Rightarrow> bool" where
-  "in_correct_ready_q s \<equiv> in_correct_ready_q_2 (ready_queues s) (ekheap s)"
+abbreviation in_correct_ready_q :: "'z state \<Rightarrow> bool" where
+  "in_correct_ready_q s \<equiv> in_correct_ready_q_2 (ready_queues s) (etcbs_of s)"
 
 lemmas in_correct_ready_q_def = in_correct_ready_q_2_def
 
 lemma in_correct_ready_q_lift:
-  assumes c: "\<And>P. \<lbrace>\<lambda>s. P (ekheap s)\<rbrace> f \<lbrace>\<lambda>rv s. P (ekheap s)\<rbrace>"
+  assumes c: "\<And>P. f \<lbrace>\<lambda>s. P (etcbs_of s)\<rbrace>"
   assumes r: "\<And>P. f \<lbrace>\<lambda>s. P (ready_queues s)\<rbrace>"
   shows "f \<lbrace>in_correct_ready_q\<rbrace>"
   apply (rule hoare_pre)
    apply (wps assms | wpsimp)+
   done
 
-definition ready_qs_distinct :: "det_ext state \<Rightarrow> bool" where
+definition ready_qs_distinct :: "'z state \<Rightarrow> bool" where
   "ready_qs_distinct s \<equiv> \<forall>d p. distinct (ready_queues s d p)"
 
 lemma ready_qs_distinct_lift:
@@ -2430,28 +2270,6 @@ lemma thread_get_exs_valid[wp]:
   by (clarsimp simp: thread_get_def get_tcb_def gets_the_def gets_def return_def get_def
                      exs_valid_def tcb_at_def bind_def)
 
-lemma ethread_get_sp:
-  "\<lbrace>P\<rbrace> ethread_get f ptr
-   \<lbrace>\<lambda>rv. etcb_at (\<lambda>tcb. f tcb = rv) ptr and P\<rbrace>"
-  apply wpsimp
-  apply (clarsimp simp: etcb_at_def split: option.splits)
-  done
-
-lemma ethread_get_exs_valid[wp]:
-  "\<lbrakk>tcb_at tcb_ptr s; valid_etcbs s\<rbrakk> \<Longrightarrow> \<lbrace>(=) s\<rbrace> ethread_get f tcb_ptr \<exists>\<lbrace>\<lambda>_. (=) s\<rbrace>"
-  apply (frule (1) tcb_at_is_etcb_at)
-  apply (clarsimp simp: ethread_get_def get_etcb_def gets_the_def gets_def return_def get_def
-                        is_etcb_at_def exs_valid_def bind_def)
-  done
-
-lemma no_fail_ethread_get[wp]:
-  "no_fail (tcb_at tcb_ptr and valid_etcbs) (ethread_get f tcb_ptr)"
-  unfolding ethread_get_def
-  apply wpsimp
-  apply (frule (1) tcb_at_is_etcb_at)
-  apply (clarsimp simp: is_etcb_at_def get_etcb_def)
-  done
-
 lemma threadGet_sp:
   "\<lbrace>P\<rbrace> threadGet f ptr \<lbrace>\<lambda>rv s. \<exists>tcb :: tcb. ko_at' tcb ptr s \<and> f tcb = rv \<and> P s\<rbrace>"
   unfolding threadGet_def setObject_def
@@ -2478,7 +2296,7 @@ lemma in_ready_q_tcbQueued_eq:
 lemma tcbSchedEnqueue_corres:
   "tcb_ptr = tcbPtr \<Longrightarrow>
    corres dc
-     (in_correct_ready_q and ready_qs_distinct and valid_etcbs and st_tcb_at runnable tcb_ptr
+     (in_correct_ready_q and ready_qs_distinct and st_tcb_at runnable tcb_ptr
       and pspace_aligned and pspace_distinct)
      (sym_heap_sched_pointers and valid_sched_pointers and valid_tcbs')
      (tcb_sched_action tcb_sched_enqueue tcb_ptr) (tcbSchedEnqueue tcbPtr)"
@@ -2494,9 +2312,9 @@ lemma tcbSchedEnqueue_corres:
    apply (fastforce dest: pspace_distinct_cross)
   apply (clarsimp simp: tcb_sched_action_def tcb_sched_enqueue_def get_tcb_queue_def
                         tcbSchedEnqueue_def getQueue_def unless_def when_def)
-  apply (rule corres_symb_exec_l[OF _ _ ethread_get_sp]; (solves wpsimp)?)
+  apply (rule corres_symb_exec_l[OF _ _ thread_get_sp]; (solves wpsimp)?)
   apply (rename_tac domain)
-  apply (rule corres_symb_exec_l[OF _ _ ethread_get_sp]; (solves wpsimp)?)
+  apply (rule corres_symb_exec_l[OF _ _ thread_get_sp]; (solves wpsimp)?)
   apply (rename_tac priority)
   apply (rule corres_symb_exec_l[OF _ _ gets_sp]; (solves wpsimp)?)
   apply (rule corres_stateAssert_ignore)
@@ -2508,12 +2326,11 @@ lemma tcbSchedEnqueue_corres:
   apply (rule corres_symb_exec_r[OF _ threadGet_sp]; (solves wpsimp)?)
   apply (subst if_distrib[where f="set_tcb_queue domain prio" for domain prio])
   apply (rule corres_if_strong')
-    apply (frule state_relation_ready_queues_relation)
-    apply (frule in_ready_q_tcbQueued_eq[where t=tcbPtr])
     subgoal
-      by (fastforce dest: tcb_at_ekheap_dom pred_tcb_at_tcb_at
-                    simp: obj_at'_def opt_pred_def opt_map_def obj_at_def is_tcb_def
-                          in_correct_ready_q_def etcb_at_def is_etcb_at_def)
+      by (fastforce dest!: state_relation_ready_queues_relation
+                           in_ready_q_tcbQueued_eq[where t=tcbPtr]
+                     simp: obj_at'_def opt_pred_def opt_map_def in_correct_ready_q_def
+                           obj_at_def etcb_at_def etcbs_of'_def)
    apply (find_goal \<open>match conclusion in "corres _ _ _ _ (return ())" \<Rightarrow> \<open>-\<close>\<close>)
    apply (rule monadic_rewrite_corres_l[where P=P and Q=P for P, simplified])
     apply (clarsimp simp: set_tcb_queue_def)
@@ -2560,19 +2377,18 @@ lemma tcbSchedEnqueue_corres:
   apply (drule set_tcb_queue_new_state)
   apply (wpsimp wp: threadSet_wp getObject_tcb_wp simp: setQueue_def tcbQueuePrepend_def)
   apply normalise_obj_at'
-  apply (frule (1) tcb_at_is_etcb_at)
-  apply (clarsimp simp: obj_at_def is_etcb_at_def etcb_at_def)
-  apply (rename_tac s d p s' tcb' tcb etcb)
-  apply (frule_tac t=tcbPtr in ekheap_relation_tcb_domain_priority)
+  apply (clarsimp simp: obj_at_def)
+  apply (rename_tac s d p s' tcb' tcb)
+  apply (frule_tac t=tcbPtr in pspace_relation_tcb_domain_priority)
     apply (force simp: obj_at_def)
    apply (force simp: obj_at'_def)
   apply (clarsimp split: if_splits)
   apply (cut_tac ts="ready_queues s d p" in list_queue_relation_nil)
    apply (force dest!: spec simp: list_queue_relation_def)
-  apply (cut_tac ts="ready_queues s (tcb_domain etcb) (tcb_priority etcb)"
+  apply (cut_tac ts="ready_queues s (tcb_domain tcb) (tcb_priority tcb)"
               in list_queue_relation_nil)
    apply (force dest!: spec simp: list_queue_relation_def)
-  apply (cut_tac ts="ready_queues s (tcb_domain etcb) (tcb_priority etcb)" and s'=s'
+  apply (cut_tac ts="ready_queues s (tcb_domain tcb) (tcb_priority tcb)" and s'=s'
               in obj_at'_tcbQueueEnd_ksReadyQueues)
       apply fast
      apply auto[1]
@@ -2581,14 +2397,14 @@ lemma tcbSchedEnqueue_corres:
   apply (cut_tac xs="ready_queues s d p" and st="tcbQueueHead (ksReadyQueues s' (d, p))"
               in heap_path_head')
    apply (auto dest: spec simp: list_queue_relation_def tcbQueueEmpty_def)[1]
-  apply (cut_tac xs="ready_queues s (tcb_domain etcb) (tcb_priority etcb)"
-             and st="tcbQueueHead (ksReadyQueues s' (tcb_domain etcb, tcb_priority etcb))"
+  apply (cut_tac xs="ready_queues s (tcb_domain tcb) (tcb_priority tcb)"
+             and st="tcbQueueHead (ksReadyQueues s' (tcb_domain tcb, tcb_priority tcb))"
               in heap_path_head')
    apply (auto dest: spec simp: list_queue_relation_def tcbQueueEmpty_def)[1]
   apply (clarsimp simp: list_queue_relation_def)
 
-  apply (case_tac "\<not> (d = tcb_domain etcb \<and> p = tcb_priority etcb)")
-   apply (cut_tac d=d and d'="tcb_domain etcb" and p=p and p'="tcb_priority etcb"
+  apply (case_tac "\<not> (d = tcb_domain tcb \<and> p = tcb_priority tcb)")
+   apply (cut_tac d=d and d'="tcb_domain tcb" and p=p and p'="tcb_priority tcb"
                in ready_queues_disjoint)
       apply force
      apply fastforce
@@ -2612,8 +2428,8 @@ lemma tcbSchedEnqueue_corres:
     apply (clarsimp simp: fun_upd_apply split: if_splits)
 
    \<comment> \<open>the ready queue was not originally empty\<close>
-   apply (clarsimp simp: etcb_at_def obj_at'_def)
-   apply (prop_tac "the (tcbQueueHead (ksReadyQueues s' (tcb_domain etcb, tcb_priority etcb)))
+   apply (clarsimp simp: obj_at'_def)
+   apply (prop_tac "the (tcbQueueHead (ksReadyQueues s' (tcb_domain tcb, tcb_priority tcb)))
                     \<notin> set (ready_queues s d p)")
     apply (erule orthD2)
     apply (clarsimp simp: tcbQueueEmpty_def)
@@ -2631,7 +2447,7 @@ lemma tcbSchedEnqueue_corres:
       apply (case_tac "ready_queues s d p"; force simp: tcbQueueEmpty_def)
      apply (case_tac "t = tcbPtr")
       apply (clarsimp simp: inQ_def fun_upd_apply obj_at'_def split: if_splits)
-     apply (case_tac "t = the (tcbQueueHead (ksReadyQueues s' (tcb_domain etcb, tcb_priority etcb)))")
+     apply (case_tac "t = the (tcbQueueHead (ksReadyQueues s' (tcb_domain tcb, tcb_priority tcb)))")
       apply (clarsimp simp: inQ_def opt_pred_def opt_map_def obj_at'_def fun_upd_apply
                      split: option.splits)
       apply metis
@@ -2639,11 +2455,11 @@ lemma tcbSchedEnqueue_corres:
     apply (clarsimp simp: fun_upd_apply split: if_splits)
    apply (clarsimp simp: fun_upd_apply split: if_splits)
 
-  \<comment> \<open>d = tcb_domain etcb \<and> p = tcb_priority etcb\<close>
+  \<comment> \<open>d = tcb_domain tcb \<and> p = tcb_priority tcb\<close>
   apply clarsimp
-  apply (drule_tac x="tcb_domain etcb" in spec)
-  apply (drule_tac x="tcb_priority etcb" in spec)
-  apply (cut_tac ts="ready_queues s (tcb_domain etcb) (tcb_priority etcb)"
+  apply (drule_tac x="tcb_domain tcb" in spec)
+  apply (drule_tac x="tcb_priority tcb" in spec)
+  apply (cut_tac ts="ready_queues s (tcb_domain tcb) (tcb_priority tcb)"
               in tcbQueueHead_iff_tcbQueueEnd)
    apply (force simp: list_queue_relation_def)
   apply (frule valid_tcbs'_maxDomain[where t=tcbPtr], simp add: obj_at'_def)
@@ -2688,7 +2504,7 @@ lemma setSchedulerAction_corres:
   apply (simp add: setSchedulerAction_def set_scheduler_action_def)
   apply (rule corres_no_failI)
    apply wp
-  apply (clarsimp simp: in_monad simpler_modify_def state_relation_def)
+  apply (clarsimp simp: in_monad simpler_modify_def state_relation_def swp_def)
   done
 
 lemma getSchedulerAction_corres:
@@ -2699,7 +2515,7 @@ lemma getSchedulerAction_corres:
 
 lemma rescheduleRequired_corres:
   "corres dc
-     (weak_valid_sched_action and in_correct_ready_q and ready_qs_distinct and valid_etcbs
+     (weak_valid_sched_action and in_correct_ready_q and ready_qs_distinct
       and pspace_aligned and pspace_distinct)
      (sym_heap_sched_pointers and valid_sched_pointers and valid_tcbs')
      (reschedule_required) rescheduleRequired"
@@ -2717,8 +2533,8 @@ lemma rescheduleRequired_corres:
         apply (rule setSchedulerAction_corres)
         apply simp
        apply (wp | wpc | simp)+
-   apply (force dest: st_tcb_weakenE simp: in_monad weak_valid_sched_action_def valid_etcbs_def st_tcb_at_def obj_at_def is_tcb
-               split: Deterministic_A.scheduler_action.split)
+   apply (force dest: st_tcb_weakenE simp: in_monad weak_valid_sched_action_def st_tcb_at_def obj_at_def is_tcb
+               split: Structures_A.scheduler_action.split)
   apply (clarsimp split: scheduler_action.splits)
   done
 
@@ -2891,8 +2707,8 @@ definition tcb_queue_remove :: "'a \<Rightarrow> 'a list \<Rightarrow> 'a list" 
 
 definition tcb_sched_dequeue' :: "obj_ref \<Rightarrow> unit det_ext_monad" where
   "tcb_sched_dequeue' tcb_ptr \<equiv> do
-     d \<leftarrow> ethread_get tcb_domain tcb_ptr;
-     prio \<leftarrow> ethread_get tcb_priority tcb_ptr;
+     d \<leftarrow> thread_get tcb_domain tcb_ptr;
+     prio \<leftarrow> thread_get tcb_priority tcb_ptr;
      queue \<leftarrow> get_tcb_queue d prio;
      when (tcb_ptr \<in> set queue) $ set_tcb_queue d prio (tcb_queue_remove tcb_ptr queue)
    od"
@@ -2910,7 +2726,7 @@ lemma filter_tcb_queue_remove:
   done
 
 lemma tcb_sched_dequeue_monadic_rewrite:
-  "monadic_rewrite False True (is_etcb_at t and (\<lambda>s. \<forall>d p. distinct (ready_queues s d p)))
+  "monadic_rewrite False True (tcb_at t and (\<lambda>s. \<forall>d p. distinct (ready_queues s d p)))
      (tcb_sched_action tcb_sched_dequeue t) (tcb_sched_dequeue' t)"
   supply if_split[split del]
   apply (clarsimp simp: tcb_sched_dequeue'_def tcb_sched_dequeue_def tcb_sched_action_def
@@ -2923,9 +2739,9 @@ lemma tcb_sched_dequeue_monadic_rewrite:
       apply (metis (mono_tags, lifting) filter_cong)
      apply (rule monadic_rewrite_modify_noop)
     apply (wpsimp wp: thread_get_wp)+
-  apply (clarsimp simp: etcb_at_def split: option.splits)
-  apply (prop_tac "(\<lambda>d' p. if d' = tcb_domain x2 \<and> p = tcb_priority x2
-                           then filter (\<lambda>x. x \<noteq> t) (ready_queues s (tcb_domain x2) (tcb_priority x2))
+  apply (clarsimp simp: tcb_at_def)
+  apply (prop_tac "(\<lambda>d' p. if d' = tcb_domain tcb \<and> p = tcb_priority tcb
+                           then filter ((\<noteq>) t) (ready_queues s (tcb_domain tcb) (tcb_priority tcb))
                            else ready_queues s d' p)
                    = ready_queues s")
    apply (subst filter_True)
@@ -2958,7 +2774,7 @@ lemma in_queue_not_head_or_not_tail_length_gt_1:
 lemma tcbSchedDequeue_corres:
   "tcb_ptr = tcbPtr \<Longrightarrow>
    corres dc
-     (in_correct_ready_q and ready_qs_distinct and valid_etcbs and tcb_at tcb_ptr
+     (in_correct_ready_q and ready_qs_distinct and tcb_at tcb_ptr
       and pspace_aligned and pspace_distinct)
      (sym_heap_sched_pointers and valid_objs')
      (tcb_sched_action tcb_sched_dequeue tcb_ptr) (tcbSchedDequeue tcbPtr)"
@@ -2972,22 +2788,22 @@ lemma tcbSchedDequeue_corres:
    apply (fastforce dest: pspace_distinct_cross)
   apply (rule monadic_rewrite_corres_l[where P=P and Q=P for P, simplified])
    apply (rule monadic_rewrite_guard_imp[OF tcb_sched_dequeue_monadic_rewrite])
-   apply (fastforce dest: tcb_at_is_etcb_at simp: in_correct_ready_q_def ready_qs_distinct_def)
+   apply (fastforce simp: in_correct_ready_q_def ready_qs_distinct_def)
   apply (clarsimp simp: tcb_sched_dequeue'_def get_tcb_queue_def tcbSchedDequeue_def  getQueue_def
                         unless_def when_def)
-  apply (rule corres_symb_exec_l[OF _ _ ethread_get_sp]; wpsimp?)
+  apply (rule corres_symb_exec_l[OF _ _ thread_get_sp]; wpsimp?)
   apply (rename_tac dom)
-  apply (rule corres_symb_exec_l[OF _ _ ethread_get_sp]; wpsimp?)
+  apply (rule corres_symb_exec_l[OF _ _ thread_get_sp]; wpsimp?)
   apply (rename_tac prio)
   apply (rule corres_symb_exec_l[OF _ _ gets_sp]; (solves wpsimp)?)
   apply (rule corres_stateAssert_ignore)
    apply (fastforce intro: ksReadyQueues_asrt_cross)
   apply (rule corres_symb_exec_r[OF _ threadGet_sp]; (solves wpsimp)?)
   apply (rule corres_if_strong'; fastforce?)
-    apply (frule state_relation_ready_queues_relation)
-    apply (frule in_ready_q_tcbQueued_eq[where t=tcbPtr])
-    apply (fastforce simp: obj_at'_def opt_pred_def opt_map_def obj_at_def is_tcb_def
-                           in_correct_ready_q_def etcb_at_def is_etcb_at_def)
+   apply (fastforce dest!: state_relation_ready_queues_relation
+                           in_ready_q_tcbQueued_eq[where t=tcbPtr]
+                     simp: obj_at'_def opt_pred_def opt_map_def in_correct_ready_q_def
+                           obj_at_def etcb_at_def etcbs_of'_def)
   apply (rule corres_symb_exec_r[OF _ threadGet_sp]; wpsimp?)
   apply (rule corres_symb_exec_r[OF _ threadGet_sp]; wpsimp?)
   apply (rule corres_symb_exec_r[OF _ gets_sp]; wpsimp?)
@@ -3009,24 +2825,23 @@ lemma tcbSchedDequeue_corres:
   apply (wpsimp wp: threadSet_wp getObject_tcb_wp
               simp: setQueue_def tcbQueueRemove_def
          split_del: if_split)
-  apply (frule (1) tcb_at_is_etcb_at)
-  apply (clarsimp simp: obj_at_def is_etcb_at_def etcb_at_def)
+  apply (clarsimp simp: obj_at_def)
   apply normalise_obj_at'
-  apply (rename_tac s d p s' tcb' tcb etcb)
-  apply (frule_tac t=tcbPtr in ekheap_relation_tcb_domain_priority)
+  apply (rename_tac s d p s' tcb' tcb)
+  apply (frule_tac t=tcbPtr in pspace_relation_tcb_domain_priority)
     apply (force simp: obj_at_def)
    apply (force simp: obj_at'_def)
 
-  apply (case_tac "d \<noteq> tcb_domain etcb \<or> p \<noteq> tcb_priority etcb")
+  apply (case_tac "d \<noteq> tcb_domain tcb \<or> p \<noteq> tcb_priority tcb")
    apply clarsimp
-   apply (cut_tac p=tcbPtr and ls="ready_queues s (tcb_domain etcb) (tcb_priority etcb)"
+   apply (cut_tac p=tcbPtr and ls="ready_queues s (tcb_domain tcb) (tcb_priority tcb)"
                in list_queue_relation_neighbour_in_set)
       apply (fastforce dest!: spec)
      apply fastforce
     apply fastforce
    apply (cut_tac xs="ready_queues s d p" in heap_path_head')
     apply (force dest!: spec simp: ready_queues_relation_def Let_def list_queue_relation_def)
-   apply (cut_tac d=d and d'="tcb_domain etcb" and p=p and p'="tcb_priority etcb"
+   apply (cut_tac d=d and d'="tcb_domain tcb" and p=p and p'="tcb_priority tcb"
                in ready_queues_disjoint)
       apply force
      apply fastforce
@@ -3050,7 +2865,7 @@ lemma tcbSchedDequeue_corres:
      apply (clarsimp simp: fun_upd_apply)
     apply (clarsimp simp: fun_upd_apply)
 
-   apply (clarsimp simp: etcb_at_def obj_at'_def)
+   apply (clarsimp simp: obj_at'_def)
    apply (intro conjI; clarsimp)
 
     \<comment> \<open>tcbPtr is the head of the ready queue\<close>
@@ -3096,8 +2911,8 @@ lemma tcbSchedDequeue_corres:
 
   \<comment> \<open>d = tcb_domain tcb \<and> p = tcb_priority tcb\<close>
   apply clarsimp
-  apply (drule_tac x="tcb_domain etcb" in spec)
-  apply (drule_tac x="tcb_priority etcb" in spec)
+  apply (drule_tac x="tcb_domain tcb" in spec)
+  apply (drule_tac x="tcb_priority tcb" in spec)
   apply (clarsimp simp: list_queue_relation_def)
   apply (frule heap_path_head')
   apply (frule heap_ls_distinct)
@@ -3110,7 +2925,7 @@ lemma tcbSchedDequeue_corres:
      apply (simp add: fun_upd_apply tcb_queue_remove_def queue_end_valid_def heap_ls_unique
                       heap_path_last_end)
     apply (simp add: fun_upd_apply prev_queue_head_def)
-   apply (case_tac "ready_queues s (tcb_domain etcb) (tcb_priority etcb)";
+   apply (case_tac "ready_queues s (tcb_domain tcb) (tcb_priority tcb)";
           clarsimp simp: tcb_queue_remove_def inQ_def opt_pred_def fun_upd_apply)
   apply (intro conjI; clarsimp)
 
@@ -3129,7 +2944,7 @@ lemma tcbSchedDequeue_corres:
       apply (clarsimp simp: opt_map_red opt_map_upd_triv fun_upd_apply)
      apply (clarsimp simp: queue_end_valid_def fun_upd_apply last_tl)
     apply (clarsimp simp: prev_queue_head_def fun_upd_apply)
-   apply (case_tac "ready_queues s (tcb_domain etcb) (tcb_priority etcb)";
+   apply (case_tac "ready_queues s (tcb_domain tcb) (tcb_priority tcb)";
           clarsimp simp: inQ_def opt_pred_def opt_map_def fun_upd_apply split: option.splits)
   apply (intro conjI; clarsimp)
 
@@ -3208,11 +3023,11 @@ lemma setThreadState_corres:
           (set_thread_state t ts) (setThreadState ts' t)"
   (is "?tsr \<Longrightarrow> corres dc ?Pre ?Pre' ?sts ?sts'")
   apply (simp add: set_thread_state_def setThreadState_def)
-  apply (simp add: set_thread_state_ext_def[abs_def])
+  apply (simp add: set_thread_state_act_def[abs_def])
   apply (subst bind_assoc[symmetric], subst thread_set_def[simplified, symmetric])
   apply (rule corres_guard_imp)
     apply (rule corres_split[where r'=dc])
-       apply (rule threadset_corres, (simp add: tcb_relation_def exst_same_def)+)
+       apply (rule threadset_corres, (simp add: tcb_relation_def inQ_def)+)
       apply (subst thread_get_test[where test="runnable"])
       apply (rule corres_split[OF thread_get_isRunnable_corres])
         apply (rule corres_split[OF getCurThread_corres])
@@ -3233,7 +3048,7 @@ lemma setBoundNotification_corres:
           (set_bound_notification t ntfn) (setBoundNotification ntfn t)"
   apply (simp add: set_bound_notification_def setBoundNotification_def)
   apply (subst thread_set_def[simplified, symmetric])
-  apply (rule threadset_corres, simp_all add:tcb_relation_def exst_same_def)
+  apply (rule threadset_corres, simp_all add:tcb_relation_def inQ_def)
   done
 
 crunch rescheduleRequired, tcbSchedDequeue, setThreadState, setBoundNotification
@@ -5925,154 +5740,6 @@ lemma asUser_irq_handlers':
   apply (simp add: asUser_def split_def)
   apply (wpsimp wp: threadSet_irq_handlers' [OF all_tcbI, OF ball_tcb_cte_casesI] select_f_inv)
   done
-
-(* the brave can try to move this up to near setObject_update_TCB_corres' *)
-
-definition non_exst_same :: "Structures_H.tcb \<Rightarrow> Structures_H.tcb \<Rightarrow> bool"
-where
-  "non_exst_same tcb tcb' \<equiv> \<exists>d p ts. tcb' = tcb\<lparr>tcbDomain := d, tcbPriority := p, tcbTimeSlice := ts\<rparr>"
-
-fun non_exst_same' :: "Structures_H.kernel_object \<Rightarrow> Structures_H.kernel_object \<Rightarrow> bool"
-where
-  "non_exst_same' (KOTCB tcb) (KOTCB tcb') = non_exst_same tcb tcb'" |
-  "non_exst_same' _ _ = True"
-
-lemma non_exst_same_prio_upd[simp]:
-  "non_exst_same tcb (tcbPriority_update f tcb)"
-  by (cases tcb, simp add: non_exst_same_def)
-
-lemma non_exst_same_timeSlice_upd[simp]:
-  "non_exst_same tcb (tcbTimeSlice_update f tcb)"
-  by (cases tcb, simp add: non_exst_same_def)
-
-lemma non_exst_same_domain_upd[simp]:
-  "non_exst_same tcb (tcbDomain_update f tcb)"
-  by (cases tcb, simp add: non_exst_same_def)
-
-lemma set_eobject_corres':
-  assumes e: "etcb_relation etcb tcb'"
-  assumes z: "\<And>s. obj_at' P ptr s
-               \<Longrightarrow> map_to_ctes ((ksPSpace s) (ptr \<mapsto> KOTCB tcb')) = map_to_ctes (ksPSpace s)"
-  shows
-    "corres dc
-       (tcb_at ptr and is_etcb_at ptr)
-       (obj_at' (\<lambda>ko. non_exst_same ko tcb') ptr and obj_at' P ptr
-        and obj_at' (\<lambda>tcb. (tcbDomain tcb \<noteq> tcbDomain tcb' \<or> tcbPriority tcb \<noteq> tcbPriority tcb')
-                            \<longrightarrow> \<not> tcbQueued tcb) ptr)
-       (set_eobject ptr etcb) (setObject ptr tcb')"
-  apply (rule corres_no_failI)
-   apply (rule no_fail_pre)
-    apply wp
-   apply (clarsimp simp: obj_at'_def)
-  apply (unfold set_eobject_def setObject_def)
-  apply (clarsimp simp: in_monad split_def bind_def gets_def get_def Bex_def
-                        put_def return_def modify_def get_object_def
-                        updateObject_default_def in_magnitude_check objBits_simps')
-  apply (clarsimp simp add: state_relation_def z)
-  apply (clarsimp simp add: obj_at_def is_etcb_at_def)
-  apply (simp only: pspace_relation_def dom_fun_upd2 simp_thms)
-  apply (elim conjE)
-  apply (frule bspec, erule domI)
-  apply (rule conjI)
-   apply (rule ballI, drule(1) bspec)
-   apply (drule domD)
-   apply (clarsimp simp: is_other_obj_relation_type)
-   apply (drule(1) bspec)
-   apply (clarsimp simp: non_exst_same_def)
-   apply (case_tac bb; simp)
-     apply (clarsimp simp: obj_at'_def other_obj_relation_def tcb_relation_cut_def cte_relation_def
-                           tcb_relation_def
-                     split: if_split_asm)+
-   apply (clarsimp simp: aobj_relation_cuts_def split: RISCV64_A.arch_kernel_obj.splits)
-   apply (rename_tac arch_kernel_obj obj d p ts)
-   apply (case_tac arch_kernel_obj; simp)
-     apply (clarsimp simp: pte_relation_def is_tcb_def
-                    split: if_split_asm)+
-  apply (extract_conjunct \<open>match conclusion in "ekheap_relation _ _" \<Rightarrow> -\<close>)
-   apply (simp only: ekheap_relation_def dom_fun_upd2 simp_thms)
-   apply (frule bspec, erule domI)
-   apply (rule ballI, drule(1) bspec)
-   apply (drule domD)
-   apply (clarsimp simp: obj_at'_def)
-   apply (insert e)
-   apply (clarsimp simp: other_obj_relation_def etcb_relation_def is_other_obj_relation_type
-                  split: Structures_A.kernel_object.splits kernel_object.splits arch_kernel_obj.splits)
-   apply (frule in_ready_q_tcbQueued_eq[where t=ptr])
-  apply (rename_tac s' conctcb' abstcb exttcb)
-  apply (clarsimp simp: ready_queues_relation_def Let_def)
-  apply (prop_tac "(tcbSchedNexts_of s')(ptr := tcbSchedNext tcb') = tcbSchedNexts_of s'")
-   apply (fastforce simp: opt_map_def obj_at'_def non_exst_same_def split: option.splits)
-  apply (prop_tac "(tcbSchedPrevs_of s')(ptr := tcbSchedPrev tcb') = tcbSchedPrevs_of s'")
-   apply (fastforce simp: opt_map_def obj_at'_def non_exst_same_def split: option.splits)
-  apply (clarsimp simp: ready_queue_relation_def opt_map_def opt_pred_def obj_at'_def inQ_def
-                        non_exst_same_def
-                 split: option.splits)
-  apply metis
-  done
-
-lemma set_eobject_corres:
-  assumes tcbs: "non_exst_same tcb' tcbu'"
-  assumes e: "etcb_relation etcb tcb' \<Longrightarrow> etcb_relation etcbu tcbu'"
-  assumes tables': "\<forall>(getF, v) \<in> ran tcb_cte_cases. getF tcbu' = getF tcb'"
-  assumes r: "r () ()"
-  shows
-    "corres r
-       (tcb_at add and (\<lambda>s. ekheap s add = Some etcb))
-       (ko_at' tcb' add
-        and obj_at' (\<lambda>tcb. (tcbDomain tcb \<noteq> tcbDomain tcbu' \<or> tcbPriority tcb \<noteq> tcbPriority tcbu')
-                           \<longrightarrow> \<not> tcbQueued tcb) add)
-       (set_eobject add etcbu) (setObject add tcbu')"
-  apply (rule_tac F="non_exst_same tcb' tcbu' \<and> etcb_relation etcbu tcbu'" in corres_req)
-   apply (clarsimp simp: state_relation_def obj_at_def obj_at'_def)
-   apply (frule(1) pspace_relation_absD)
-   apply (clarsimp simp: other_obj_relation_def ekheap_relation_def e tcbs)
-   apply (drule bspec, erule domI)
-   apply (clarsimp simp: e)
-  apply (erule conjE)
-  apply (rule corres_guard_imp)
-    apply (rule corres_rel_imp)
-     apply (rule set_eobject_corres'[where P="(=) tcb'"])
-      apply simp
-     defer
-    apply (simp add: r)
-   apply (fastforce simp: is_etcb_at_def elim!: obj_at_weakenE)
-   apply (subst(asm) eq_commute)
-   apply (clarsimp simp: obj_at'_def)
-  apply (clarsimp simp: obj_at'_def objBits_simps)
-  apply (subst map_to_ctes_upd_tcb, assumption+)
-   apply (simp add: ps_clear_def3 field_simps objBits_defs mask_def)
-  apply (subst if_not_P)
-   apply (fastforce dest: bspec [OF tables', OF ranI])
-  apply simp
-  done
-
-lemma ethread_set_corresT:
-  assumes x: "\<And>tcb'. non_exst_same tcb' (f' tcb')"
-  assumes z: "\<forall>tcb. \<forall>(getF, setF) \<in> ran tcb_cte_cases. getF (f' tcb) = getF tcb"
-  assumes e: "\<And>etcb tcb'. etcb_relation etcb tcb' \<Longrightarrow> etcb_relation (f etcb) (f' tcb')"
-  shows
-    "corres dc
-       (tcb_at t and valid_etcbs)
-       (tcb_at' t
-        and obj_at' (\<lambda>tcb. (tcbDomain tcb \<noteq> tcbDomain (f' tcb)
-                             \<or> tcbPriority tcb \<noteq> tcbPriority (f' tcb))
-                           \<longrightarrow> \<not> tcbQueued tcb) t)
-       (ethread_set f t) (threadSet f' t)"
-  apply (simp add: ethread_set_def threadSet_def bind_assoc)
-  apply (rule corres_guard_imp)
-    apply (rule corres_split[OF corres_get_etcb set_eobject_corres])
-         apply (rule x)
-        apply (erule e)
-       apply (simp add: z)+
-     apply (wp getObject_tcb_wp)+
-   apply clarsimp
-   apply (simp add: valid_etcbs_def tcb_at_st_tcb_at[symmetric])
-   apply (force simp: tcb_at_def get_etcb_def obj_at_def)
-  apply (clarsimp simp: obj_at'_def)
-  done
-
-lemmas ethread_set_corres =
-    ethread_set_corresT [OF _ all_tcbI, OF _ ball_tcb_cte_casesI]
 
 lemma archTcbUpdate_aux2: "(\<lambda>tcb. tcb\<lparr> tcbArch := f (tcbArch tcb)\<rparr>) = tcbArch_update f"
   by (rule ext, case_tac tcb, simp)

--- a/proof/refine/RISCV64/Tcb_R.thy
+++ b/proof/refine/RISCV64/Tcb_R.thy
@@ -219,7 +219,7 @@ lemma restart_corres:
         apply (clarsimp simp: invs'_def valid_state'_def sch_act_wf_weak valid_pspace'_def
                               valid_tcb_state'_def)
        apply wp+
-   apply (simp add: valid_sched_def invs_def tcb_at_is_etcb_at invs_psp_aligned invs_distinct)
+   apply (simp add: valid_sched_def invs_def invs_psp_aligned invs_distinct)
   apply clarsimp
   done
 
@@ -338,7 +338,7 @@ lemma invokeTCB_WriteRegisters_corres:
               apply simp
              apply (wp+)[2]
            apply ((wp hoare_weak_lift_imp restart_invs'
-                   | strengthen valid_sched_weak_strg einvs_valid_etcbs
+                   | strengthen valid_sched_weak_strg
                                 invs_weak_sch_act_wf
                                 valid_queues_in_correct_ready_q valid_queues_ready_qs_distinct
                                 valid_sched_valid_queues valid_objs'_valid_tcbs' invs_valid_objs'
@@ -578,9 +578,63 @@ crunch tcbSchedDequeue
 crunch tcbSchedDequeue
   for st_tcb_at'[wp]: "\<lambda>s. P (st_tcb_at' st tcbPtr s)"
 
+lemma thread_set_ready_qs_distinct[wp]:
+  "thread_set f tcb_ptr \<lbrace>ready_qs_distinct\<rbrace>"
+  apply (wpsimp wp: thread_set_wp)
+  by (clarsimp simp: ready_qs_distinct_def)
+
+lemma thread_set_in_correct_ready_q_not_queued:
+  "\<lbrace>in_correct_ready_q and not_queued t\<rbrace>
+   thread_set f t
+   \<lbrace>\<lambda>_. in_correct_ready_q\<rbrace>"
+  unfolding thread_set_priority_def
+  apply (wpsimp wp: thread_set_wp)
+  apply (clarsimp simp: in_correct_ready_q_def not_queued_def is_etcb_at'_def etcb_at_def etcbs_of'_def)
+  done
+
+lemma tcb_sched_dequeue_in_correct_ready_q[wp]:
+  "tcb_sched_action tcb_sched_dequeue t \<lbrace>in_correct_ready_q\<rbrace> "
+  unfolding tcb_sched_action_def set_tcb_queue_def
+  apply (wpsimp wp: thread_get_wp')
+  apply (clarsimp simp: in_correct_ready_q_def tcb_sched_dequeue_def)
+  done
+
+lemma tcb_sched_dequeue_ready_qs_distinct[wp]:
+  "tcb_sched_action tcb_sched_dequeue t \<lbrace>ready_qs_distinct\<rbrace> "
+  unfolding tcb_sched_action_def set_tcb_queue_def
+  apply (wpsimp wp: thread_get_wp')
+  apply (clarsimp simp: ready_qs_distinct_def tcb_sched_dequeue_def)
+  done
+
+\<comment> \<open>For updating the domain and the priority fields of a TCB that is not in a ready queue\<close>
+lemma threadSet_not_queued_corres:
+  "\<lbrakk>\<And>tcb tcb'. tcb_relation tcb tcb' \<Longrightarrow> tcb_relation (f tcb) (F tcb');
+    \<And>tcb'. tcbSchedNext (F tcb') = tcbSchedNext tcb';
+    \<And>tcb'. tcbSchedPrev (F tcb') = tcbSchedPrev tcb';
+    \<And>tcb'. tcbQueued (F tcb') = tcbQueued tcb';
+    \<And>tcb. \<forall>(getF, v) \<in> ran tcb_cap_cases. getF (f tcb) = getF tcb;
+    \<And>tcb'. \<forall>(getF, v)\<in>ran tcb_cte_cases. getF (F tcb') = getF tcb'\<rbrakk>
+   \<Longrightarrow> corres dc (tcb_at t and not_queued t and pspace_aligned and pspace_distinct) \<top>
+         (thread_set f t) (threadSet F t)"
+  apply (rule_tac Q'="tcb_at' t" in corres_cross_add_guard)
+   apply (fastforce dest!: state_relationD elim!: tcb_at_cross)
+  apply (simp add: thread_set_def threadSet_def)
+  apply (rule corres_symb_exec_l[OF _ _ gets_the_sp]; wpsimp simp: tcb_at_def)
+  apply (rule corres_symb_exec_r[OF _ getObject_tcb_sp]; wpsimp?)
+  apply (rename_tac tcb tcb')
+  apply (rule stronger_corres_guard_imp)
+    apply (rule_tac F="\<not> tcbQueued tcb'" in corres_gen_asm)
+    apply (rule_tac tcb=tcb and tcb'=tcb' in setObject_update_TCB_corres';
+           fastforce simp: inQ_def)
+   apply (frule state_relation_ready_queues_relation)
+   apply (frule in_ready_q_tcbQueued_eq[where t=t])
+   apply (clarsimp simp: opt_pred_def opt_map_def obj_at'_def not_queued_def)
+  apply clarsimp
+  done
+
 lemma sp_corres2:
   "corres dc
-     (valid_etcbs and weak_valid_sched_action and cur_tcb and tcb_at t
+     (weak_valid_sched_action and cur_tcb and tcb_at t
       and valid_queues and pspace_aligned and pspace_distinct)
      (tcb_at' t and (\<lambda>s. weak_sch_act_wf (ksSchedulerAction s) s)
       and valid_objs' and (\<lambda>_. x \<le> maxPriority) and sym_heap_sched_pointers and valid_sched_pointers)
@@ -588,8 +642,9 @@ lemma sp_corres2:
   apply (simp add: setPriority_def set_priority_def thread_set_priority_def)
   apply (rule stronger_corres_guard_imp)
     apply (rule corres_split[OF tcbSchedDequeue_corres], simp)
-      apply (rule corres_split[OF ethread_set_corres], simp_all)[1]
-         apply (simp add: etcb_relation_def)
+      apply (rule corres_split[OF threadSet_not_queued_corres];
+                           simp add: tcb_relation_def tcb_cap_cases_def tcb_cte_cases_def
+                                     cteSizeBits_def)
         apply (rule corres_split[OF isRunnable_corres])
           apply (erule corres_when)
           apply(rule corres_split[OF getCurThread_corres])
@@ -599,19 +654,19 @@ lemma sp_corres2:
            apply ((clarsimp
                    | wp hoare_weak_lift_imp hoare_vcg_if_lift hoare_wp_combs gts_wp
                         isRunnable_wp)+)[4]
-       apply (wp hoare_vcg_imp_lift' hoare_vcg_if_lift hoare_vcg_all_lift
-                 ethread_set_not_queued_valid_queues
-              | strengthen valid_queues_in_correct_ready_q valid_queues_ready_qs_distinct)+
+       apply (wpsimp wp: hoare_vcg_imp_lift' hoare_vcg_if_lift hoare_vcg_all_lift
+                         thread_set_in_correct_ready_q_not_queued thread_set_no_change_tcb_state
+                         thread_set_no_change_tcb_state_converse thread_set_weak_valid_sched_action)+
       apply ((wp hoare_vcg_imp_lift' hoare_vcg_all_lift
                  isRunnable_wp threadSet_pred_tcb_no_state
                  threadSet_valid_objs_tcbPriority_update threadSet_sched_pointers
                  threadSet_valid_sched_pointers tcb_dequeue_not_queued tcbSchedDequeue_not_queued
                  threadSet_weak_sch_act_wf
-              | simp add: etcb_relation_def
+              | simp add: tcb_relation_def
               | strengthen valid_objs'_valid_tcbs'
                 obj_at'_weakenE[where P="Not \<circ> tcbQueued"]
               | wps)+)
-   apply (force simp: valid_etcbs_def tcb_at_st_tcb_at[symmetric] state_relation_def
+   apply (force simp: tcb_at_st_tcb_at[symmetric] state_relation_def
                 dest: pspace_relation_tcb_at intro: st_tcb_at_opeqI)
   apply clarsimp
   done
@@ -634,7 +689,7 @@ lemma setMCPriority_corres:
     apply (clarsimp simp: setMCPriority_def set_mcpriority_def)
     apply (rule threadset_corresT)
   by (clarsimp simp: tcb_relation_def tcb_cap_cases_tcb_mcpriority
-                     tcb_cte_cases_def cteSizeBits_def exst_same_def)+
+                     tcb_cte_cases_def cteSizeBits_def inQ_def)+
 
 definition
  "out_rel fn fn' v v' \<equiv>
@@ -648,8 +703,7 @@ lemma out_corresT:
   assumes y: "\<And>v. \<forall>tcb. \<forall>(getF, setF)\<in>ran tcb_cte_cases. getF (fn' v tcb) = getF tcb"
   assumes sched_pointers: "\<And>tcb v. tcbSchedPrev (fn' v tcb) = tcbSchedPrev tcb"
                           "\<And>tcb v. tcbSchedNext (fn' v tcb) = tcbSchedNext tcb"
-  assumes flag: "\<And>tcb v. tcbQueued (fn' v tcb) = tcbQueued tcb"
-  assumes e: "\<And>tcb v. exst_same tcb (fn' v tcb)"
+  assumes flag: "\<And>d p tcb' v. inQ d p (fn' v tcb') = inQ d p tcb'"
   shows
   "out_rel fn fn' v v' \<Longrightarrow>
      corres dc (tcb_at t and pspace_aligned and pspace_distinct)
@@ -657,7 +711,7 @@ lemma out_corresT:
        (option_update_thread t fn v)
        (case_option (return ()) (\<lambda>x. threadSet (fn' x) t) v')"
   apply (case_tac v, simp_all add: out_rel_def option_update_thread_def)
-  apply (clarsimp simp: threadset_corresT [OF _ x y sched_pointers flag e])
+  apply (clarsimp simp: threadset_corresT [OF _ x y sched_pointers flag])
   done
 
 lemmas out_corres = out_corresT [OF _ all_tcbI, OF ball_tcb_cap_casesI ball_tcb_cte_casesI]
@@ -984,14 +1038,14 @@ lemma thread_set_ipc_weak_valid_sched_action:
   apply (simp | intro impI | elim exE conjE)+
   apply (frule get_tcb_SomeD)
   apply (erule ssubst)
-  apply (clarsimp simp add: weak_valid_sched_action_def valid_etcbs_2_def st_tcb_at_kh_def
-              get_tcb_def obj_at_kh_def obj_at_def is_etcb_at'_def valid_sched_def valid_sched_action_def)
+  apply (clarsimp simp: weak_valid_sched_action_def st_tcb_at_kh_def obj_at_kh_def valid_sched_def
+                        valid_sched_action_def)
   done
 
 lemma threadcontrol_corres_helper3:
   "\<lbrace>einvs and simple_sched_action\<rbrace>
    check_cap_at cap p (check_cap_at (cap.ThreadCap cap') slot (cap_insert cap p (t, tcb_cnode_index 4)))
-   \<lbrace>\<lambda>_ s. weak_valid_sched_action s \<and> in_correct_ready_q s \<and> ready_qs_distinct s \<and> valid_etcbs s
+   \<lbrace>\<lambda>_ s. weak_valid_sched_action s \<and> in_correct_ready_q s \<and> ready_qs_distinct s
           \<and> pspace_aligned s \<and> pspace_distinct s\<rbrace>"
    apply (wpsimp
           | strengthen valid_sched_valid_queues valid_queues_in_correct_ready_q
@@ -1175,7 +1229,7 @@ proof -
                (option_map to_bl v))
                (case v of None \<Rightarrow> return ()
                  | Some x \<Rightarrow> threadSet (tcbFaultHandler_update (%_. x)) t)"
-    apply (rule out_corres, simp_all add: exst_same_def)
+    apply (rule out_corres, simp_all add: inQ_def)
     apply (case_tac v, simp_all add: out_rel_def)
     apply (safe, case_tac tcb', simp add: tcb_relation_def split: option.split)
     done
@@ -1185,7 +1239,7 @@ proof -
                (option_update_thread t (tcb_ipc_buffer_update o (%x _. x)) v)
                (case v of None \<Rightarrow> return ()
                  | Some x \<Rightarrow> threadSet (tcbIPCBuffer_update (%_. x)) t)"
-    apply (rule out_corres, simp_all add: exst_same_def)
+    apply (rule out_corres, simp_all )
     apply (case_tac v, simp_all add: out_rel_def)
     apply (safe, case_tac tcb', simp add: tcb_relation_def)
     done
@@ -1315,20 +1369,19 @@ proof -
             apply (rule cteDelete_corres)
            apply (rule_tac F="is_aligned aa msg_align_bits" in corres_gen_asm2)
            apply (rule corres_split_nor)
-              apply (rule threadset_corres,
-                      (simp add: tcb_relation_def), (simp add: exst_same_def)+)[1]
+              apply (rule threadset_corres; simp add: tcb_relation_def)
              apply (rule corres_split[OF getCurThread_corres], clarsimp)
                apply (rule corres_when[OF refl rescheduleRequired_corres])
               apply (wpsimp wp: gct_wp)+
             apply (strengthen valid_queues_ready_qs_distinct)
             apply (wpsimp wp: thread_set_ipc_weak_valid_sched_action thread_set_valid_queues
-                              hoare_drop_imp)
+                              hoare_drop_imp in_correct_ready_q_lift thread_set_etcbs)
            apply clarsimp
            apply (strengthen valid_objs'_valid_tcbs' invs_valid_objs')+
            apply (wpsimp wp: threadSet_sched_pointers threadSet_valid_sched_pointers hoare_drop_imp
                              threadSet_invs_tcbIPCBuffer_update)
           apply (clarsimp simp: pred_conj_def)
-          apply (strengthen einvs_valid_etcbs valid_queues_in_correct_ready_q
+          apply (strengthen valid_queues_in_correct_ready_q
                             valid_sched_valid_queues)+
           apply wp
          apply (clarsimp simp: pred_conj_def)
@@ -1344,8 +1397,7 @@ proof -
                         in corres_gen_asm)
           apply (rule_tac F="isArchObjectCap ac" in corres_gen_asm2)
           apply (rule corres_split_nor)
-             apply (rule threadset_corres,
-                    simp add: tcb_relation_def, (simp add: exst_same_def)+)
+             apply (rule threadset_corres; simp add: tcb_relation_def)
             apply (rule corres_split)
                apply (erule checkCapAt_cteInsert_corres)
               apply (rule corres_split[OF getCurThread_corres], clarsimp)
@@ -1723,7 +1775,7 @@ lemma invokeTCB_corres:
            apply (rule TcbAcc_R.rescheduleRequired_corres)
           apply (rule corres_trivial, simp)
          apply (wpsimp wp: hoare_drop_imp)+
-   apply (fastforce dest: valid_sched_valid_queues simp: valid_sched_weak_strg einvs_valid_etcbs)
+   apply (fastforce dest: valid_sched_valid_queues simp: valid_sched_weak_strg)
   apply fastforce
   done
 
@@ -1949,7 +2001,7 @@ lemma decodeSetPriority_corres:
   "\<lbrakk> cap_relation cap cap'; is_thread_cap cap;
      list_all2 (\<lambda>(c, sl) (c', sl'). cap_relation c c' \<and> sl' = cte_map sl) extras extras' \<rbrakk> \<Longrightarrow>
    corres (ser \<oplus> tcbinv_relation)
-       (cur_tcb and valid_etcbs and (pspace_aligned and pspace_distinct and (\<lambda>s. \<forall>x \<in> set extras. s \<turnstile> (fst x))))
+       (cur_tcb and (pspace_aligned and pspace_distinct and (\<lambda>s. \<forall>x \<in> set extras. s \<turnstile> (fst x))))
        (invs' and (\<lambda>s. \<forall>x \<in> set extras'. s \<turnstile>' (fst x)))
        (decode_set_priority args cap slot extras)
        (decodeSetPriority args cap' extras')"
@@ -1967,7 +2019,7 @@ lemma decodeSetMCPriority_corres:
   "\<lbrakk> cap_relation cap cap'; is_thread_cap cap;
      list_all2 (\<lambda>(c, sl) (c', sl'). cap_relation c c' \<and> sl' = cte_map sl) extras extras' \<rbrakk> \<Longrightarrow>
    corres (ser \<oplus> tcbinv_relation)
-       (cur_tcb and valid_etcbs and (pspace_aligned and pspace_distinct and (\<lambda>s. \<forall>x \<in> set extras. s \<turnstile> (fst x))))
+       (cur_tcb and (pspace_aligned and pspace_distinct and (\<lambda>s. \<forall>x \<in> set extras. s \<turnstile> (fst x))))
        (invs' and (\<lambda>s. \<forall>x \<in> set extras'. s \<turnstile>' (fst x)))
        (decode_set_mcpriority args cap slot extras)
        (decodeSetMCPriority args cap' extras')"
@@ -2073,7 +2125,7 @@ lemma decodeSetSchedParams_corres:
   "\<lbrakk> cap_relation cap cap'; is_thread_cap cap;
      list_all2 (\<lambda>(c, sl) (c', sl'). cap_relation c c' \<and> sl' = cte_map sl) extras extras' \<rbrakk> \<Longrightarrow>
    corres (ser \<oplus> tcbinv_relation)
-       (cur_tcb and valid_etcbs and
+       (cur_tcb and
          (pspace_aligned and pspace_distinct and (\<lambda>s. \<forall>x \<in> set extras. s \<turnstile> (fst x))))
        (invs' and (\<lambda>s. \<forall>x \<in> set extras'. s \<turnstile>' (fst x)))
        (decode_set_sched_params args cap slot extras)

--- a/proof/refine/X64/ADT_H.thy
+++ b/proof/refine/X64/ADT_H.thy
@@ -530,6 +530,9 @@ definition
       tcb_fault = map_option FaultMap (tcbFault tcb),
       tcb_bound_notification = tcbBoundNotification tcb,
       tcb_mcpriority = tcbMCP tcb,
+      tcb_priority = tcbPriority tcb,
+      tcb_time_slice = tcbTimeSlice tcb,
+      tcb_domain = tcbDomain tcb,
       tcb_arch = ArchTcbMap (tcbArch tcb)\<rparr>"
 
 definition
@@ -1093,55 +1096,6 @@ proof -
     apply (clarsimp split: if_split_asm)+
     done
 qed
-
-definition
-  "EtcbMap tcb \<equiv>
-     \<lparr>tcb_priority = tcbPriority tcb,
-      time_slice = tcbTimeSlice tcb,
-      tcb_domain = tcbDomain tcb\<rparr>"
-
-definition
-  absEkheap :: "(machine_word \<rightharpoonup> Structures_H.kernel_object) \<Rightarrow> obj_ref \<Rightarrow> etcb option"
-  where
-  "absEkheap h \<equiv> \<lambda>x.
-     case h x of
-       Some (KOTCB tcb) \<Rightarrow> Some (EtcbMap tcb)
-     | _ \<Rightarrow> None"
-
-lemma absEkheap_correct:
-assumes pspace_relation: "pspace_relation (kheap s) (ksPSpace s')"
-assumes ekheap_relation: "ekheap_relation (ekheap s) (ksPSpace s')"
-assumes vetcbs: "valid_etcbs s"
-shows
-  "absEkheap (ksPSpace s') = ekheap s"
-  apply (rule ext)
-  apply (clarsimp simp: absEkheap_def split: option.splits Structures_H.kernel_object.splits)
-  apply (subgoal_tac "\<forall>x. (\<exists>tcb. kheap s x = Some (TCB tcb)) =
-                          (\<exists>tcb'. ksPSpace s' x = Some (KOTCB tcb'))")
-   using vetcbs ekheap_relation
-   apply (clarsimp simp: valid_etcbs_def is_etcb_at_def dom_def ekheap_relation_def st_tcb_at_def obj_at_def)
-   apply (erule_tac x=x in allE)+
-   apply (rule conjI, force)
-   apply clarsimp
-   apply (rule conjI, clarsimp simp: EtcbMap_def etcb_relation_def)+
-   apply clarsimp
-  using pspace_relation
-  apply (clarsimp simp add: pspace_relation_def pspace_dom_def UNION_eq dom_def Collect_eq)
-  apply (rule iffI)
-   apply (erule_tac x=x in allE)+
-   apply (case_tac "ksPSpace s' x", clarsimp)
-    apply (erule_tac x=x in allE, clarsimp)
-   apply (rename_tac ko)
-   apply clarsimp
-   apply (case_tac ko; simp add: other_obj_relation_def tcb_relation_cut_def)
-  apply (insert pspace_relation)
-  apply (clarsimp simp: obj_at'_def projectKOs)
-  apply (erule(1) pspace_dom_relatedE)
-  apply (erule(1) obj_relation_cutsE)
-  apply (clarsimp simp: other_obj_relation_def
-                 split: Structures_A.kernel_object.split_asm  if_split_asm
-                        X64_A.arch_kernel_obj.split_asm)+
-  done
 
 text \<open>The following function can be used to reverse cte_map.\<close>
 definition
@@ -1990,13 +1944,6 @@ lemma absSchedulerAction_correct:
 definition
   "absExst s \<equiv>
      \<lparr>work_units_completed_internal = ksWorkUnitsCompleted s,
-      scheduler_action_internal = absSchedulerAction (ksSchedulerAction s),
-      ekheap_internal = absEkheap (ksPSpace s),
-      domain_list_internal = ksDomSchedule s,
-      domain_index_internal = ksDomScheduleIdx s,
-      cur_domain_internal = ksCurDomain s,
-      domain_time_internal = ksDomainTime s,
-      ready_queues_internal = (\<lambda>d p. heap_walk (tcbSchedNexts_of s) (tcbQueueHead (ksReadyQueues s (d, p))) []),
       cdt_list_internal = absCDTList (cteMap (gsCNodes s)) (ctes_of s)\<rparr>"
 
 lemma absExst_correct:
@@ -2004,16 +1951,12 @@ lemma absExst_correct:
   assumes rel: "(s, s') \<in> state_relation"
   shows "absExst s' = exst s"
   apply (rule det_ext.equality)
-           using rel invs invs'
-           apply (simp_all add: absExst_def absSchedulerAction_correct absEkheap_correct
-                                absCDTList_correct[THEN fun_cong] state_relation_def invs_def
-                                valid_state_def ready_queues_relation_def ready_queue_relation_def
-                                invs'_def valid_state'_def
-                                valid_pspace_def valid_sched_def valid_pspace'_def curry_def
-                                fun_eq_iff)
-   apply (fastforce simp: absEkheap_correct)
-  apply (fastforce simp: list_queue_relation_def Let_def dest: heap_ls_is_walk)
-  done
+      using rel invs invs'
+      apply (simp_all add: absExst_def absSchedulerAction_correct
+                           absCDTList_correct[THEN fun_cong] state_relation_def invs_def valid_state_def
+                           ready_queues_relation_def invs'_def valid_state'_def
+                           valid_pspace_def valid_sched_def valid_pspace'_def curry_def fun_eq_iff)
+      done
 
 
 definition
@@ -2022,6 +1965,12 @@ definition
     cdt = absCDT (cteMap (gsCNodes s)) (ctes_of s),
     is_original_cap = absIsOriginalCap (cteMap (gsCNodes s)) (ksPSpace s),
     cur_thread = ksCurThread s, idle_thread = ksIdleThread s,
+    scheduler_action = absSchedulerAction (ksSchedulerAction s),
+    domain_list = ksDomSchedule s,
+    domain_index = ksDomScheduleIdx s,
+    cur_domain = ksCurDomain s,
+    domain_time = ksDomainTime s,
+    ready_queues = (\<lambda>d p. heap_walk (tcbSchedNexts_of s) (tcbQueueHead (ksReadyQueues s (d, p))) []),
     machine_state = observable_memory (ksMachineState s) (user_mem' s),
     interrupt_irq_node = absInterruptIRQNode (ksInterruptState s),
     interrupt_states = absInterruptStates (ksInterruptState s),

--- a/proof/refine/X64/ArchAcc_R.thy
+++ b/proof/refine/X64/ArchAcc_R.thy
@@ -173,21 +173,19 @@ crunch getIRQSlot
 
 lemma setObject_ASIDPool_corres:
   "a = inv ASIDPool a' o ucast \<Longrightarrow>
-  corres dc (asid_pool_at p and valid_etcbs) (asid_pool_at' p)
+  corres dc (asid_pool_at p) (asid_pool_at' p)
             (set_asid_pool p a) (setObject p a')"
   apply (simp add: set_asid_pool_def)
   apply (rule corres_guard_imp)
     apply (rule setObject_other_corres [where P="\<lambda>ko::asidpool. True"])
-          apply simp
-         apply (clarsimp simp: obj_at'_def projectKOs)
-         apply (erule map_to_ctes_upd_other, simp, simp)
-        apply (simp add: a_type_def is_other_obj_relation_type_def)
-       apply (simp add: objBits_simps archObjSize_def)
-      apply simp
-     apply (simp add: objBits_simps archObjSize_def pageBits_def)
+         apply simp
+        apply (clarsimp simp: obj_at'_def projectKOs)
+        apply (erule map_to_ctes_upd_other, simp, simp)
+       apply (simp add: a_type_def is_other_obj_relation_type_def)
+      apply (simp add: objBits_simps)
+     apply (simp add: objBits_simps pageBits_def)
     apply (simp add: other_obj_relation_def asid_pool_relation_def)
    apply (simp add: typ_at'_def obj_at'_def ko_wp_at'_def projectKOs)
-   apply clarsimp
    apply (rename_tac arch_kernel_object)
    apply (case_tac arch_kernel_object; simp)
    apply (clarsimp simp: obj_at_def exs_valid_def assert_def a_type_def return_def fail_def)
@@ -197,7 +195,7 @@ lemma setObject_ASIDPool_corres:
 
 lemma setObject_ASIDPool_corres':
   "a = inv ASIDPool a' o ucast \<Longrightarrow>
-  corres dc (asid_pool_at p and valid_etcbs) (pspace_aligned' and pspace_distinct')
+  corres dc (asid_pool_at p) (pspace_aligned' and pspace_distinct')
             (set_asid_pool p a) (setObject p a')"
   apply (rule stronger_corres_guard_imp,
          erule setObject_ASIDPool_corres)
@@ -524,7 +522,7 @@ lemma get_pml4e_corres':
 lemma setObject_PD_corres:
   "pde_relation' pde pde' \<Longrightarrow>
          corres dc  (ko_at (ArchObj (PageDirectory pd)) (p && ~~ mask pd_bits)
-                     and pspace_aligned and valid_etcbs)
+                     and pspace_aligned)
                     (pde_at' p)
           (set_pd (p && ~~ mask pd_bits) (pd(ucast (p && mask pd_bits >> word_size_bits) := pde)))
           (setObject p pde')"
@@ -582,13 +580,6 @@ lemma setObject_PD_corres:
        apply ((simp split: if_split_asm)+)[4]
    apply (simp add: other_obj_relation_def
                split: Structures_A.kernel_object.splits arch_kernel_obj.splits)
-  apply (rule conjI)
-   apply (clarsimp simp: ekheap_relation_def pspace_relation_def)
-   apply (drule(1) ekheap_kheap_dom)
-   apply clarsimp
-   apply (drule_tac x=p in bspec, erule domI)
-   apply (simp add: other_obj_relation_def tcb_relation_cut_def
-           split: Structures_A.kernel_object.splits)
   apply (extract_conjunct \<open>match conclusion in "ready_queues_relation_2 _ _ _ _ _" \<Rightarrow> -\<close>)
    apply (prop_tac "typ_at' (koTypeOf (injectKO pde')) p b")
     apply (simp add: typ_at'_def ko_wp_at'_def)
@@ -613,7 +604,7 @@ lemma more_pt_inner_beauty:
 lemma setObject_PT_corres:
   "pte_relation' pte pte' \<Longrightarrow>
          corres dc  (ko_at (ArchObj (PageTable pt)) (p && ~~ mask pt_bits)
-                     and pspace_aligned and valid_etcbs)
+                     and pspace_aligned)
                     (pte_at' p)
           (set_pt (p && ~~ mask pt_bits) (pt(ucast (p && mask pt_bits >> word_size_bits) := pte)))
           (setObject p pte')"
@@ -671,13 +662,6 @@ lemma setObject_PT_corres:
         apply ((simp split: if_split_asm)+)[5]
    apply (simp add: other_obj_relation_def
                split: Structures_A.kernel_object.splits arch_kernel_obj.splits)
-  apply (rule conjI)
-   apply (clarsimp simp: ekheap_relation_def pspace_relation_def)
-   apply (drule(1) ekheap_kheap_dom)
-   apply clarsimp
-   apply (drule_tac x=p in bspec, erule domI)
-   apply (simp add: other_obj_relation_def tcb_relation_cut_def
-               split: Structures_A.kernel_object.splits)
   apply (extract_conjunct \<open>match conclusion in "ghost_relation _ _ _" \<Rightarrow> -\<close>)
    apply (clarsimp simp add: ghost_relation_def)
    apply (erule_tac x="p && ~~ mask pt_bits" in allE)+
@@ -702,7 +686,7 @@ lemma more_pdpt_inner_beauty:
 lemma setObject_PDPT_corres:
   "pdpte_relation' pdpte pdpte' \<Longrightarrow>
          corres dc  (ko_at (ArchObj (PDPointerTable pt)) (p && ~~ mask pdpt_bits)
-                     and pspace_aligned and valid_etcbs)
+                     and pspace_aligned)
                     (pdpte_at' p)
           (set_pdpt (p && ~~ mask pdpt_bits) (pt(ucast (p && mask pdpt_bits >> word_size_bits) := pdpte)))
           (setObject p pdpte')"
@@ -761,13 +745,6 @@ lemma setObject_PDPT_corres:
       apply ((simp split: if_split_asm)+)[5]
    apply (simp add: other_obj_relation_def
                split: Structures_A.kernel_object.splits arch_kernel_obj.splits)
-  apply (rule conjI)
-   apply (clarsimp simp: ekheap_relation_def pspace_relation_def)
-   apply (drule(1) ekheap_kheap_dom)
-   apply clarsimp
-   apply (drule_tac x=p in bspec, erule domI)
-   apply (simp add: other_obj_relation_def tcb_relation_cut_def
-               split: Structures_A.kernel_object.splits)
   apply (extract_conjunct \<open>match conclusion in "ready_queues_relation_2 _ _ _ _ _" \<Rightarrow> -\<close>)
    apply (prop_tac "typ_at' (koTypeOf (injectKO pdpte')) p b")
     apply (simp add: typ_at'_def ko_wp_at'_def)
@@ -792,7 +769,7 @@ lemma more_pml4_inner_beauty:
 lemma setObject_PML4_corres:
   "pml4e_relation' pml4e pml4e' \<Longrightarrow>
          corres dc  (ko_at (ArchObj (PageMapL4 pt)) (p && ~~ mask pml4_bits)
-                     and pspace_aligned and valid_etcbs)
+                     and pspace_aligned)
                     (pml4e_at' p)
           (set_pml4 (p && ~~ mask pml4_bits) (pt(ucast (p && mask pml4_bits >> word_size_bits) := pml4e)))
           (setObject p pml4e')"
@@ -852,13 +829,6 @@ lemma setObject_PML4_corres:
      apply ((simp split: if_split_asm)+)[2]
    apply (simp add: other_obj_relation_def
                split: Structures_A.kernel_object.splits arch_kernel_obj.splits)
-  apply (rule conjI)
-   apply (clarsimp simp: ekheap_relation_def pspace_relation_def)
-   apply (drule(1) ekheap_kheap_dom)
-   apply clarsimp
-   apply (drule_tac x=p in bspec, erule domI)
-   apply (simp add: other_obj_relation_def tcb_relation_cut_def
-               split: Structures_A.kernel_object.splits)
   apply (extract_conjunct \<open>match conclusion in "ready_queues_relation_2 _ _ _ _ _" \<Rightarrow> -\<close>)
    apply (prop_tac "typ_at' (koTypeOf (injectKO pml4e')) p b")
     apply (simp add: typ_at'_def ko_wp_at'_def)
@@ -874,7 +844,7 @@ lemma setObject_PML4_corres:
 
 lemma store_pml4e_corres [corres]:
   assumes "p' = p" "pml4e_relation' pml4e pml4e'"
-  shows "corres dc (pml4e_at p and pspace_aligned and valid_etcbs) (pml4e_at' p')
+  shows "corres dc (pml4e_at p and pspace_aligned) (pml4e_at' p')
                    (store_pml4e p pml4e) (storePML4E p' pml4e')"
   using assms
   apply (simp add: store_pml4e_def storePML4E_def)
@@ -894,7 +864,7 @@ lemma store_pml4e_corres [corres]:
 
 lemma store_pml4e_corres':
   assumes "p' = p" "pml4e_relation' pml4e pml4e'"
-  shows "corres dc (pml4e_at p and pspace_aligned and valid_etcbs) (pspace_aligned' and pspace_distinct')
+  shows "corres dc (pml4e_at p and pspace_aligned) (pspace_aligned' and pspace_distinct')
                    (store_pml4e p pml4e) (storePML4E p' pml4e')"
   using assms apply -
   apply (rule stronger_corres_guard_imp, erule (1) store_pml4e_corres)
@@ -903,7 +873,7 @@ lemma store_pml4e_corres':
 
 lemma storePDPTE_corres:
   "pdpte_relation' pdpte pdpte' \<Longrightarrow>
-  corres dc (pdpte_at p and pspace_aligned and valid_etcbs) (pdpte_at' p) (store_pdpte p pdpte) (storePDPTE p pdpte')"
+  corres dc (pdpte_at p and pspace_aligned) (pdpte_at' p) (store_pdpte p pdpte) (storePDPTE p pdpte')"
   apply (simp add: store_pdpte_def storePDPTE_def)
   apply (rule corres_symb_exec_l)
      apply (erule setObject_PDPT_corres)
@@ -922,7 +892,7 @@ lemma storePDPTE_corres:
 lemma storePDPTE_corres':
   "pdpte_relation' pdpte pdpte' \<Longrightarrow>
   corres dc
-     (pdpte_at p and pspace_aligned and valid_etcbs) (pspace_aligned' and pspace_distinct')
+     (pdpte_at p and pspace_aligned) (pspace_aligned' and pspace_distinct')
      (store_pdpte p pdpte) (storePDPTE p pdpte')"
   apply (rule stronger_corres_guard_imp,
          erule storePDPTE_corres)
@@ -931,7 +901,7 @@ lemma storePDPTE_corres':
 
 lemma storePDE_corres:
   "pde_relation' pde pde' \<Longrightarrow>
-  corres dc (pde_at p and pspace_aligned and valid_etcbs) (pde_at' p) (store_pde p pde) (storePDE p pde')"
+  corres dc (pde_at p and pspace_aligned) (pde_at' p) (store_pde p pde) (storePDE p pde')"
   apply (simp add: store_pde_def storePDE_def)
   apply (rule corres_symb_exec_l)
      apply (erule setObject_PD_corres)
@@ -950,7 +920,7 @@ lemma storePDE_corres:
 lemma storePDE_corres':
   "pde_relation' pde pde' \<Longrightarrow>
   corres dc
-     (pde_at p and pspace_aligned and valid_etcbs) (pspace_aligned' and pspace_distinct')
+     (pde_at p and pspace_aligned) (pspace_aligned' and pspace_distinct')
      (store_pde p pde) (storePDE p pde')"
   apply (rule stronger_corres_guard_imp,
          erule storePDE_corres)
@@ -959,7 +929,7 @@ lemma storePDE_corres':
 
 lemma storePTE_corres:
   "pte_relation' pte pte' \<Longrightarrow>
-  corres dc (pte_at p and pspace_aligned and valid_etcbs) (pte_at' p) (store_pte p pte) (storePTE p pte')"
+  corres dc (pte_at p and pspace_aligned) (pte_at' p) (store_pte p pte) (storePTE p pte')"
   apply (simp add: store_pte_def storePTE_def)
   apply (rule corres_symb_exec_l)
      apply (erule setObject_PT_corres)
@@ -977,7 +947,7 @@ lemma storePTE_corres:
 
 lemma storePTE_corres':
   "pte_relation' pte pte' \<Longrightarrow>
-  corres dc (pte_at p and pspace_aligned and valid_etcbs)
+  corres dc (pte_at p and pspace_aligned)
             (pspace_aligned' and pspace_distinct')
             (store_pte p pte) (storePTE p pte')"
   apply (rule stronger_corres_guard_imp,
@@ -1420,7 +1390,7 @@ lemma corres_gets_global_pml4 [corres]:
   by (simp add: state_relation_def arch_state_relation_def)
 
 lemma copy_global_mappings_corres [@lift_corres_args, corres]:
-  "corres dc (valid_arch_state and valid_etcbs and pspace_aligned and page_map_l4_at pm)
+  "corres dc (valid_arch_state and pspace_aligned and page_map_l4_at pm)
                    (valid_arch_state' and page_map_l4_at' pm)
                 (copy_global_mappings pm)
                 (copyGlobalMappings pm)" (is "corres _ ?apre _ _ _")

--- a/proof/refine/X64/ArchInvsLemmas_H.thy
+++ b/proof/refine/X64/ArchInvsLemmas_H.thy
@@ -534,4 +534,24 @@ lemma objBitsT_koTypeOf:
 
 end
 
+context Arch begin
+
+lemma objBits_less_word_bits:
+  "objBits v < word_bits"
+  unfolding objBits_simps'
+  apply (case_tac "injectKO v"; simp)
+  by (simp add: pageBits_def objBits_simps word_bits_def
+         split: arch_kernel_object.split)+
+
+lemma objBits_pos_power2[simp]:
+  assumes "objBits v < word_bits"
+  shows "(1::machine_word) < (2::machine_word) ^ objBits v"
+  unfolding objBits_simps'
+  apply (insert assms)
+  apply (case_tac "injectKO v"; simp)
+  by (simp add: pageBits_def objBits_simps
+         split: arch_kernel_object.split)+
+
+end
+
 end

--- a/proof/refine/X64/ArchMove_R.thy
+++ b/proof/refine/X64/ArchMove_R.thy
@@ -74,10 +74,6 @@ lemma no_irq_ioapicMapPinToVector[wp]:
   "no_irq (ioapicMapPinToVector a b c d e)"
   by (simp add: ioapicMapPinToVector_def)
 
-(* Move to Deterministic_AI*)
-crunch copy_global_mappings
-  for valid_etcbs[wp]: valid_etcbs (wp: mapM_x_wp')
-
 (* Move to no_gs_types_simps in ArchRetype_AI *)
 lemma no_gs_types_simps' [simp]:
   "ArchObject PDPTObj \<in> no_gs_types"

--- a/proof/refine/X64/Arch_R.thy
+++ b/proof/refine/X64/Arch_R.thy
@@ -92,24 +92,6 @@ lemma createObject_typ_at':
   apply (clarsimp simp: is_aligned_no_overflow_mask)
   done
 
-lemma retype_region2_ext_retype_region_ArchObject:
-  "retype_region ptr n us (ArchObject x)=
-  retype_region2 ptr n us (ArchObject x)"
-  apply (rule ext)
-  apply (simp add:retype_region_def retype_region2_def bind_assoc
-    retype_region2_ext_def retype_region_ext_def default_ext_def)
-  apply (rule ext)
-  apply (intro monad_eq_split_tail ext)+
-     apply simp
-    apply simp
-   apply (simp add:gets_def get_def bind_def return_def simpler_modify_def )
-   apply (rule_tac x = xc in fun_cong)
-   apply (rule_tac f = do_extended_op in arg_cong)
-   apply (rule ext)
-   apply simp
-  apply simp
-  done
-
 lemma set_cap_device_and_range_aligned:
   "is_aligned ptr sz \<Longrightarrow> \<lbrace>\<lambda>_. True\<rbrace>
     set_cap
@@ -164,7 +146,6 @@ lemma performASIDControlInvocation_corres:
             apply (clarsimp simp:is_cap_simps)
            apply (simp add: free_index_of_def)
           apply (rule corres_split)
-             apply (simp add: retype_region2_ext_retype_region_ArchObject )
              apply (rule corres_retype [where ty="Inl (KOArch (KOASIDPool F))" for F,
                                         unfolded APIType_map2_def makeObjectKO_def,
                                         THEN createObjects_corres',simplified,
@@ -319,8 +300,8 @@ lemma performASIDControlInvocation_corres:
    apply (rule conjI, rule pspace_no_overlap_subset,
          rule pspace_no_overlap_detype[OF caps_of_state_valid])
         apply (simp add:invs_psp_aligned invs_valid_objs is_aligned_neg_mask_eq)+
-   apply (clarsimp simp: detype_def clear_um_def detype_ext_def valid_sched_def valid_etcbs_def
-            st_tcb_at_kh_def obj_at_kh_def st_tcb_at_def obj_at_def is_etcb_at_def)
+   apply (clarsimp simp: detype_def clear_um_def valid_sched_def
+                         st_tcb_at_kh_def obj_at_kh_def st_tcb_at_def obj_at_def)
   apply (simp add: detype_def clear_um_def)
   apply (drule_tac x = "cte_map (p', slot')" in pspace_relation_cte_wp_atI[OF state_relation_pspace_relation])
     apply (simp add:invs_valid_objs)+

--- a/proof/refine/X64/CSpace1_R.thy
+++ b/proof/refine/X64/CSpace1_R.thy
@@ -1769,37 +1769,30 @@ proof -
     done
 qed
 
-definition pspace_relations where
-  "pspace_relations ekh kh kh' \<equiv> pspace_relation kh kh' \<and> ekheap_relation ekh kh'"
-
 lemma set_cap_not_quite_corres_prequel:
   assumes cr:
-  "pspace_relations (ekheap s) (kheap s) (ksPSpace s')"
+  "pspace_relation (kheap s) (ksPSpace s')"
   "(x,t') \<in> fst (setCTE p' c' s')"
   "valid_objs s" "pspace_aligned s" "pspace_distinct s" "cte_at p s"
   "pspace_aligned' s'" "pspace_distinct' s'"
   assumes c: "cap_relation c (cteCap c')"
   assumes p: "p' = cte_map p"
   shows "\<exists>t. ((),t) \<in> fst (set_cap c p s) \<and>
-             pspace_relations (ekheap t) (kheap t) (ksPSpace t')"
+             pspace_relation (kheap t) (ksPSpace t')"
   using cr
   apply (clarsimp simp: setCTE_def setObject_def in_monad split_def)
   apply (drule(1) updateObject_cte_is_tcb_or_cte[OF _ refl, rotated])
   apply (elim disjE exE conjE)
-   apply (clarsimp simp: lookupAround2_char1 pspace_relations_def)
+   apply (clarsimp simp: lookupAround2_char1)
    apply (frule(5) cte_map_pulls_tcb_to_abstract[OF p])
     apply (simp add: domI)
    apply (frule tcb_cases_related2)
    apply (clarsimp simp: set_cap_def2 split_def bind_def get_object_def
                          simpler_gets_def assert_def fail_def return_def
                          set_object_def get_def put_def)
-   apply (rule conjI)
-    apply (erule(2) pspace_relation_update_tcbs)
-    apply (simp add: c)
-   apply (clarsimp simp: ekheap_relation_def pspace_relation_def)
-   apply (drule bspec, erule domI)
-   apply (clarsimp simp: etcb_relation_def tcb_cte_cases_def split: if_split_asm)
-  apply (clarsimp simp: pspace_relations_def)
+   apply (erule(2) pspace_relation_update_tcbs)
+   apply (simp add: c)
+  apply clarsimp
   apply (frule(5) cte_map_pulls_cte_to_abstract[OF p])
   apply (clarsimp simp: set_cap_def split_def bind_def get_object_def
                         simpler_gets_def assert_def a_type_def fail_def return_def
@@ -1807,24 +1800,20 @@ lemma set_cap_not_quite_corres_prequel:
   apply (erule(1) valid_objsE)
   apply (clarsimp simp: valid_obj_def valid_cs_def valid_cs_size_def exI)
   apply (rule conjI, clarsimp)
-   apply (rule conjI)
-    apply (erule(1) pspace_relation_update_ctes[where cap=c])
-     apply clarsimp
-     apply (intro conjI impI)
-      apply (rule ext, clarsimp simp add: domI p)
-      apply (drule cte_map_inj_eq [OF _ _ cr(6) cr(3-5)])
-       apply (simp add: cte_at_cases domI)
-      apply (simp add: prod_eq_iff)
-     apply (insert p)[1]
-     apply (clarsimp split: option.split Structures_A.kernel_object.split
-                    intro!: ext)
+   apply (erule(1) pspace_relation_update_ctes[where cap=c])
+    apply clarsimp
+    apply (intro conjI impI)
+     apply (rule ext, clarsimp simp add: domI p)
      apply (drule cte_map_inj_eq [OF _ _ cr(6) cr(3-5)])
-      apply (simp add: cte_at_cases domI well_formed_cnode_invsI[OF cr(3)])
-     apply clarsimp
-    apply (simp add: c)
-   apply (clarsimp simp: ekheap_relation_def pspace_relation_def)
-   apply (drule bspec, erule domI)
-   apply (clarsimp simp: etcb_relation_def tcb_cte_cases_def split: if_split_asm)
+      apply (simp add: cte_at_cases domI)
+     apply (simp add: prod_eq_iff)
+    apply (insert p)[1]
+    apply (clarsimp split: option.split Structures_A.kernel_object.split
+                   intro!: ext)
+    apply (drule cte_map_inj_eq [OF _ _ cr(6) cr(3-5)])
+     apply (simp add: cte_at_cases domI well_formed_cnode_invsI[OF cr(3)])
+    apply clarsimp
+   apply (simp add: c)
   apply (simp add: wf_cs_insert)
   done
 
@@ -1837,7 +1826,7 @@ lemma setCTE_pspace_only:
 
 lemma set_cap_not_quite_corres:
   assumes cr:
-  "pspace_relations (ekheap s) (kheap s) (ksPSpace s')"
+  "pspace_relation (kheap s) (ksPSpace s')"
   "cur_thread s = ksCurThread s'"
   "idle_thread s = ksIdleThread s'"
   "machine_state s = ksMachineState s'"
@@ -1854,10 +1843,9 @@ lemma set_cap_not_quite_corres:
   assumes c: "cap_relation c c'"
   assumes p: "p' = cte_map p"
   shows "\<exists>t. ((),t) \<in> fst (set_cap c p s) \<and>
-             pspace_relations (ekheap t) (kheap t) (ksPSpace t') \<and>
+             pspace_relation (kheap t) (ksPSpace t') \<and>
              cdt t = cdt s \<and>
              cdt_list t = cdt_list s \<and>
-             ekheap t = ekheap s \<and>
              scheduler_action t = scheduler_action s \<and>
              ready_queues t = ready_queues s \<and>
              is_original_cap t = is_original_cap s \<and>
@@ -2489,10 +2477,6 @@ lemma capClass_ztc_relation:
        cap_relation c c' \<rbrakk> \<Longrightarrow> capClass c' = PhysicalClass"
   by (auto simp: is_cap_simps)
 
-lemma pspace_relationsD:
-  "\<lbrakk>pspace_relation kh kh'; ekheap_relation ekh kh'\<rbrakk> \<Longrightarrow> pspace_relations ekh kh kh'"
-  by (simp add: pspace_relations_def)
-
 lemma updateCap_corres:
   "\<lbrakk>cap_relation cap cap';
     is_zombie cap \<or> is_cnode_cap cap \<or> is_thread_cap cap \<rbrakk>
@@ -2514,14 +2498,13 @@ lemma updateCap_corres:
     apply fastforce
    apply (clarsimp simp: cte_wp_at_ctes_of)
   apply (clarsimp simp add: state_relation_def)
-  apply (drule(1) pspace_relationsD)
   apply (frule (3) set_cap_not_quite_corres; fastforce?)
    apply (erule cte_wp_at_weakenE, rule TrueI)
   apply clarsimp
   apply (rule bexI)
    prefer 2
    apply simp
-  apply (clarsimp simp: in_set_cap_cte_at_swp pspace_relations_def)
+  apply (clarsimp simp: in_set_cap_cte_at_swp)
   apply (drule updateCap_stuff)
   apply simp
   apply (extract_conjunct \<open>match conclusion in "ghost_relation _ _ _" \<Rightarrow> -\<close>)
@@ -2638,23 +2621,6 @@ lemma updateMDB_pspace_relation:
   apply fastforce
   done
 
-lemma updateMDB_ekheap_relation:
-  assumes "(x, s'') \<in> fst (updateMDB p f s')"
-  assumes "ekheap_relation (ekheap s) (ksPSpace s')"
-  shows "ekheap_relation (ekheap s) (ksPSpace s'')" using assms
-  apply (clarsimp simp: updateMDB_def Let_def setCTE_def setObject_def in_monad ekheap_relation_def etcb_relation_def split_def split: if_split_asm)
-  apply (drule(1) updateObject_cte_is_tcb_or_cte[OF _ refl, rotated])
-  apply (drule_tac P="(=) s'" in use_valid [OF _ getCTE_sp], rule refl)
-  apply (drule bspec, erule domI)
-  by (clarsimp simp: tcb_cte_cases_def lookupAround2_char1 split: if_split_asm)
-
-lemma updateMDB_pspace_relations:
-  assumes "(x, s'') \<in> fst (updateMDB p f s')"
-  assumes "pspace_relations (ekheap s) (kheap s) (ksPSpace s')"
-  assumes "pspace_aligned' s'" "pspace_distinct' s'"
-  shows "pspace_relations (ekheap s) (kheap s) (ksPSpace s'')" using assms
-  by (simp add: pspace_relations_def updateMDB_pspace_relation updateMDB_ekheap_relation)
-
 lemma updateMDB_ctes_of:
   assumes "(x, s') \<in> fst (updateMDB p f s)"
   assumes "no_0 (ctes_of s)"
@@ -2699,7 +2665,7 @@ crunch updateMDB
 
 lemma updateMDB_the_lot:
   assumes "(x, s'') \<in> fst (updateMDB p f s')"
-  assumes "pspace_relations (ekheap s) (kheap s) (ksPSpace s')"
+  assumes "pspace_relation (kheap s) (ksPSpace s')"
   assumes "pspace_aligned' s'" "pspace_distinct' s'" "no_0 (ctes_of s')"
   shows "ctes_of s'' = modify_map (ctes_of s') p (cteMDBNode_update f) \<and>
          ksMachineState s'' = ksMachineState s' \<and>
@@ -2712,7 +2678,7 @@ lemma updateMDB_the_lot:
          ksArchState s'' = ksArchState s' \<and>
          gsUserPages s'' = gsUserPages s' \<and>
          gsCNodes s'' = gsCNodes s' \<and>
-         pspace_relations (ekheap s) (kheap s) (ksPSpace s'') \<and>
+         pspace_relation (kheap s) (ksPSpace s'') \<and>
          pspace_aligned' s'' \<and> pspace_distinct' s'' \<and>
          no_0 (ctes_of s'') \<and>
          ksDomScheduleIdx s'' = ksDomScheduleIdx s' \<and>
@@ -2724,7 +2690,7 @@ lemma updateMDB_the_lot:
          (\<forall>domain priority.
             (inQ domain priority |< tcbs_of' s'') = (inQ domain priority |< tcbs_of' s'))"
 using assms
-  apply (simp add: updateMDB_eqs updateMDB_pspace_relations split del: if_split)
+  apply (simp add: updateMDB_eqs updateMDB_pspace_relation split del: if_split)
   apply (frule (1) updateMDB_ctes_of)
   apply clarsimp
   apply (rule conjI)
@@ -3951,7 +3917,6 @@ lemma setCTE_UntypedCap_corres:
    apply (clarsimp simp: cte_wp_at_ctes_of)
   apply clarsimp
   apply (clarsimp simp add: state_relation_def split_def)
-  apply (drule (1) pspace_relationsD)
   apply (frule_tac c = "cap.UntypedCap dev r bits idx"
                 in set_cap_not_quite_corres_prequel)
          apply assumption+
@@ -3962,8 +3927,6 @@ lemma setCTE_UntypedCap_corres:
   apply (rule bexI)
    prefer 2
    apply assumption
-  apply (clarsimp simp: pspace_relations_def)
-  apply (subst conj_assoc[symmetric])
   apply clarsimp
   apply (rule conjI)
    apply (frule setCTE_pspace_only)
@@ -3975,7 +3938,7 @@ lemma setCTE_UntypedCap_corres:
    apply (rule use_valid[OF _ setCTE_tcbSchedNexts_of], assumption)
    apply (rule use_valid[OF _ setCTE_ksReadyQueues], assumption)
    apply (rule use_valid[OF _ setCTE_inQ_opt_pred], assumption)
-   apply (rule use_valid[OF _ set_cap_exst], assumption)
+   apply (rule use_valid[OF _ set_cap_rqueues], assumption)
    apply clarsimp
   apply (rule conjI)
    apply (frule setCTE_pspace_only)
@@ -5245,8 +5208,8 @@ crunch set_untyped_cap_as_full
 
 lemma updateMDB_the_lot':
   assumes "(x, s'') \<in> fst (updateMDB p f s')"
-  assumes "pspace_relations (ekheap sa) (kheap s) (ksPSpace s')"
-  assumes "pspace_aligned' s'" "pspace_distinct' s'" "no_0 (ctes_of s')" "ekheap s = ekheap sa"
+  assumes "pspace_relation (kheap s) (ksPSpace s')"
+  assumes "pspace_aligned' s'" "pspace_distinct' s'" "no_0 (ctes_of s')"
   shows "ctes_of s'' = modify_map (ctes_of s') p (cteMDBNode_update f) \<and>
          ksMachineState s'' = ksMachineState s' \<and>
          ksWorkUnitsCompleted s'' = ksWorkUnitsCompleted s' \<and>
@@ -5258,7 +5221,7 @@ lemma updateMDB_the_lot':
          ksArchState s'' = ksArchState s' \<and>
          gsUserPages s'' = gsUserPages s' \<and>
          gsCNodes s'' = gsCNodes s' \<and>
-         pspace_relations (ekheap s) (kheap s) (ksPSpace s'') \<and>
+         pspace_relation (kheap s) (ksPSpace s'') \<and>
          pspace_aligned' s'' \<and> pspace_distinct' s'' \<and>
          no_0 (ctes_of s'') \<and>
          ksDomScheduleIdx s'' = ksDomScheduleIdx s' \<and>
@@ -5271,7 +5234,7 @@ lemma updateMDB_the_lot':
             (inQ domain priority |< tcbs_of' s'') = (inQ domain priority |< tcbs_of' s'))"
   apply (rule updateMDB_the_lot)
       using assms
-      apply (fastforce simp: pspace_relations_def)+
+      apply fastforce+
    done
 
 lemma cte_map_inj_eq':
@@ -5379,7 +5342,6 @@ lemma cteInsert_corres:
                apply (simp+)[3]
             apply (clarsimp simp: corres_underlying_def state_relation_def
                                   in_monad valid_mdb'_def valid_mdb_ctes_def)
-            apply (drule (1) pspace_relationsD)
             apply (drule (18) set_cap_not_quite_corres)
              apply (rule refl)
             apply (elim conjE exE)
@@ -5417,7 +5379,6 @@ lemma cteInsert_corres:
             apply (thin_tac "ksCurThread t = p" for p t)+
             apply (thin_tac "ksIdleThread t = p" for p t)+
             apply (thin_tac "ksSchedulerAction t = p" for p t)+
-            apply (clarsimp simp: pspace_relations_def)
             apply (rule conjI)
              subgoal by (simp only: simp_thms ghost_relation_typ_at set_cap_a_type_inv data_at_def)
             apply (thin_tac "ready_queues t = p" for t p)+
@@ -5431,7 +5392,6 @@ lemma cteInsert_corres:
             apply (thin_tac "domain_index t = p" for t p)+
             apply (thin_tac "domain_list t = p" for t p)+
             apply (thin_tac "domain_time t = p" for t p)+
-            apply (thin_tac "ekheap t = p" for t p)+
             apply (thin_tac "scheduler_action t = p" for t p)+
             apply (thin_tac "ksArchState t = p" for t p)+
             apply (thin_tac "gsCNodes t = p" for t p)+
@@ -5439,7 +5399,6 @@ lemma cteInsert_corres:
             apply (thin_tac "ksInterruptState t = p" for t p)+
             apply (thin_tac "gsUserPages t = p" for t p)+
             apply (thin_tac "pspace_relation s s'" for s s')+
-            apply (thin_tac "ekheap_relation e p" for e p)+
             apply (thin_tac "interrupt_state_relation n s s'" for n s s')+
             apply (thin_tac "sched_act_relation s s'" for s s')+
             apply (thin_tac "ready_queues_relation s s'" for s s')+
@@ -6858,7 +6817,6 @@ lemma cteSwap_corres:
   apply (clarsimp simp: corres_underlying_def in_monad
                         state_relation_def)
   apply (clarsimp simp: valid_mdb'_def)
-  apply (drule(1) pspace_relationsD)
   apply (drule (12) set_cap_not_quite_corres)
       apply (erule cte_wp_at_weakenE, rule TrueI)
      apply assumption+
@@ -6894,20 +6852,19 @@ lemma cteSwap_corres:
   apply (simp cong: option.case_cong)
   apply (drule updateCap_stuff, elim conjE, erule(1) impE)
   apply (drule (2) updateMDB_the_lot')
-     apply (erule (1) impE, assumption)
-    apply (fastforce simp only: no_0_modify_map)
-   apply assumption
+    apply (erule (1) impE, assumption)
+   apply (fastforce simp only: no_0_modify_map)
   apply (elim conjE TrueE, simp only:)
-  apply (drule (2) updateMDB_the_lot', fastforce, simp only: no_0_modify_map, assumption)
+  apply (drule (2) updateMDB_the_lot', fastforce, simp only: no_0_modify_map)
   apply (drule in_getCTE, elim conjE, simp only:)
-  apply (drule (2) updateMDB_the_lot', fastforce, simp only: no_0_modify_map, assumption)
+  apply (drule (2) updateMDB_the_lot', fastforce, simp only: no_0_modify_map)
   apply (elim conjE TrueE, simp only:)
-  apply (drule (2) updateMDB_the_lot', fastforce, simp only: no_0_modify_map, assumption)
+  apply (drule (2) updateMDB_the_lot', fastforce, simp only: no_0_modify_map)
   apply (elim conjE TrueE, simp only:)
-  apply (drule (2) updateMDB_the_lot', fastforce, simp only: no_0_modify_map, assumption)
+  apply (drule (2) updateMDB_the_lot', fastforce, simp only: no_0_modify_map)
   apply (elim conjE TrueE, simp only:)
-  apply (drule (2) updateMDB_the_lot', fastforce, simp only: no_0_modify_map, assumption)
-  apply (simp only: pspace_relations_def refl)
+  apply (drule (2) updateMDB_the_lot', fastforce, simp only: no_0_modify_map)
+  apply (simp only: refl)
   apply (rule conjI, rule TrueI)+
   apply (thin_tac "ksMachineState t = p" for t p)+
   apply (thin_tac "ksCurThread t = p" for t p)+
@@ -6926,7 +6883,6 @@ lemma cteSwap_corres:
   apply (thin_tac "domain_index t = p" for t p)+
   apply (thin_tac "domain_list t = p" for t p)+
   apply (thin_tac "domain_time t = p" for t p)+
-  apply (thin_tac "ekheap t = p" for t p)+
   apply (thin_tac "scheduler_action t = p" for t p)+
   apply (thin_tac "ksArchState t = p" for t p)+
   apply (thin_tac "gsCNodes t = p" for t p)+
@@ -6934,7 +6890,6 @@ lemma cteSwap_corres:
   apply (thin_tac "ksInterruptState t = p" for t p)+
   apply (thin_tac "ksIdleThread t = p" for t p)+
   apply (thin_tac "gsUserPages t = p" for t p)+
-  apply (thin_tac "ekheap_relation e p" for e p)+
   apply (thin_tac "interrupt_state_relation n s s'" for n s s')+
   apply (thin_tac "(s,s') \<in> arch_state_relation" for s s')+
   apply (thin_tac "sched_act_relation s s'" for s s')+
@@ -6969,7 +6924,6 @@ lemma cteSwap_corres:
   apply (thin_tac "ksInterruptState t = p" for t p)+
   apply (thin_tac "ksIdleThread t = p" for t p)+
   apply (thin_tac "gsUserPages t = p" for t p)+
-  apply (thin_tac "ekheap_relation e p" for e p)+
   apply (thin_tac "ksMachineState t = p" for t p)+
   apply (thin_tac "ksCurThread t = p" for t p)+
   apply (thin_tac "ksReadyQueues t = p" for t p)+

--- a/proof/refine/X64/CSpace_R.thy
+++ b/proof/refine/X64/CSpace_R.thy
@@ -693,8 +693,7 @@ lemma next_slot_eq2:
 
 lemma set_cap_not_quite_corres':
   assumes cr:
-  "pspace_relations (ekheap (a)) (kheap s) (ksPSpace s')"
-  "ekheap (s)      = ekheap (a)"
+  "pspace_relation (kheap s) (ksPSpace s')"
   "cur_thread s    = ksCurThread s'"
   "idle_thread s   = ksIdleThread s'"
   "machine_state s = ksMachineState s'"
@@ -711,10 +710,9 @@ lemma set_cap_not_quite_corres':
   assumes c: "cap_relation c c'"
   assumes p: "p' = cte_map p"
   shows "\<exists>t. ((),t) \<in> fst (set_cap c p s) \<and>
-             pspace_relations (ekheap t) (kheap t) (ksPSpace t') \<and>
+             pspace_relation (kheap t) (ksPSpace t') \<and>
              cdt t              = cdt s \<and>
              cdt_list t         = cdt_list (s) \<and>
-             ekheap t           = ekheap (s) \<and>
              scheduler_action t = scheduler_action (s) \<and>
              ready_queues t     = ready_queues (s) \<and>
              is_original_cap t  = is_original_cap s \<and>
@@ -731,7 +729,7 @@ lemma set_cap_not_quite_corres':
              domain_time t   = ksDomainTime t'"
   apply (rule set_cap_not_quite_corres)
                 using cr
-                apply (fastforce simp: c p pspace_relations_def)+
+                apply (fastforce simp: c p)+
                 done
 
 context begin interpretation Arch . (*FIXME: arch-split*)
@@ -803,7 +801,6 @@ lemma cteMove_corres:
      apply fastforce
     apply fastforce
    apply fastforce
-   apply (drule (1) pspace_relationsD)
    apply (drule_tac p=ptr' in set_cap_not_quite_corres, assumption+)
             apply fastforce
            apply fastforce
@@ -863,7 +860,7 @@ lemma cteMove_corres:
   apply (frule(1) use_valid [OF _ updateCap_no_0])
   apply (frule(2) use_valid [OF _ updateCap_no_0, OF _ use_valid [OF _ updateCap_no_0]])
   apply (elim conjE)
-  apply (drule (5) updateMDB_the_lot', elim conjE)
+  apply (drule (4) updateMDB_the_lot', elim conjE)
   apply (drule (4) updateMDB_the_lot, elim conjE)
   apply (drule (4) updateMDB_the_lot, elim conjE)
   apply (drule (4) updateMDB_the_lot, elim conjE)
@@ -893,7 +890,6 @@ lemma cteMove_corres:
      apply fastforce
     apply fastforce
    apply fastforce
-  apply (clarsimp simp: pspace_relations_def)
   apply (rule conjI)
    subgoal by (clarsimp simp: ghost_relation_typ_at set_cap_a_type_inv data_at_def)
   apply (thin_tac "gsCNodes t = p" for t p)+
@@ -920,7 +916,6 @@ lemma cteMove_corres:
   apply (thin_tac "ksDomainTime t = p" for t p)+
   apply (thin_tac "ksDomSchedule t = p" for t p)+
   apply (thin_tac "ctes_of t = p" for t p)+
-  apply (thin_tac "ekheap_relation t p" for t p)+
   apply (thin_tac "pspace_relation t p" for t p)+
   apply (thin_tac "interrupt_state_relation s t p" for s t p)+
   apply (thin_tac "ghost_relation s t p" for s t p)+
@@ -3567,7 +3562,7 @@ lemma deriveCap_untyped_derived:
 
 lemma setCTE_corres:
   "cap_relation cap (cteCap cte) \<Longrightarrow>
-   corres_underlying {(s, s'). pspace_relations (ekheap (s)) (kheap s) (ksPSpace s')} False True dc
+   corres_underlying {(s, s'). pspace_relation (kheap s) (ksPSpace s')} False True dc
       (pspace_distinct and pspace_aligned and valid_objs and cte_at p)
       (pspace_aligned' and pspace_distinct' and cte_at' (cte_map p))
       (set_cap cap p)
@@ -3612,7 +3607,7 @@ lemma ghost_relation_of_heap:
   done
 
 lemma corres_caps_decomposition:
-  assumes x: "corres_underlying {(s, s'). pspace_relations (ekheap (s)) (kheap s) (ksPSpace s')} False True r P P' f g"
+  assumes x: "corres_underlying {(s, s'). pspace_relation (kheap s) (ksPSpace s')} False True r P P' f g"
   assumes u: "\<And>P. \<lbrace>\<lambda>s. P (new_caps s)\<rbrace> f \<lbrace>\<lambda>rv s. P (caps_of_state s)\<rbrace>"
              "\<And>P. \<lbrace>\<lambda>s. P (new_mdb s)\<rbrace> f \<lbrace>\<lambda>rv s. P (cdt s)\<rbrace>"
              "\<And>P. \<lbrace>\<lambda>s. P (new_list s)\<rbrace> f \<lbrace>\<lambda>rv s. P (cdt_list (s))\<rbrace>"
@@ -3722,14 +3717,11 @@ proof -
   note abs_irq_together = abs_irq_together'[simplified]
   show ?thesis
     unfolding state_relation_def swp_cte_at
-    apply (subst conj_assoc[symmetric])
-    apply (subst pspace_relations_def[symmetric])
     apply (rule corres_underlying_decomposition [OF x])
      apply (simp add: ghost_relation_of_heap)
-     apply (wp hoare_vcg_conj_lift mdb_wp rvk_wp list_wp u abs_irq_together)+
-    apply (intro z[simplified o_def] conjI
-           | simp add: state_relation_def pspace_relations_def swp_cte_at
-           | (clarsimp, drule (1) z(6), simp add: state_relation_def))+
+     apply (wpsimp wp: hoare_vcg_conj_lift mdb_wp rvk_wp list_wp u abs_irq_together)+
+    apply (intro z[simplified o_def] conjI | simp add: state_relation_def swp_cte_at
+          | (drule (1) z(6), simp add: state_relation_def swp_cte_at))+
     done
 qed
 
@@ -3741,7 +3733,7 @@ lemma getCTE_symb_exec_r:
   done
 
 lemma updateMDB_symb_exec_r:
-  "corres_underlying {(s, s'). pspace_relations (ekheap s) (kheap s) (ksPSpace s')} False nf' dc
+  "corres_underlying {(s, s'). pspace_relation (kheap s) (ksPSpace s')} False nf' dc
         \<top> (pspace_aligned' and pspace_distinct' and (no_0 \<circ> ctes_of) and (\<lambda>s. p \<noteq> 0 \<longrightarrow> cte_at' p s))
         (return ()) (updateMDB p m)"
   using no_fail_updateMDB [of p m]
@@ -3792,45 +3784,20 @@ lemma revokable_relation_simp:
       \<Longrightarrow> mdbRevocable node = is_original_cap s p"
   by (cases p, clarsimp simp: state_relation_def revokable_relation_def)
 
-lemma setCTE_gsUserPages[wp]:
-  "\<lbrace>\<lambda>s. P (gsUserPages s)\<rbrace> setCTE p v \<lbrace>\<lambda>rv s. P (gsUserPages s)\<rbrace>"
-  apply (simp add: setCTE_def setObject_def split_def)
-  apply (wp updateObject_cte_inv crunch_wps | simp)+
-  done
-
-lemma setCTE_gsCNodes[wp]:
-  "\<lbrace>\<lambda>s. P (gsCNodes s)\<rbrace> setCTE p v \<lbrace>\<lambda>rv s. P (gsCNodes s)\<rbrace>"
-  apply (simp add: setCTE_def setObject_def split_def)
-  apply (wp updateObject_cte_inv crunch_wps | simp)+
-  done
+crunch setCTE
+  for gsUserPages[wp]: "\<lambda>s. P (gsUserPages s)"
+  and gsCNodes[wp]: "\<lambda>s. P (gsCNodes s)"
+  and domain_time[wp]: "\<lambda>s. P (ksDomainTime s)"
+  and work_units_completed[wp]: "\<lambda>s. P (ksWorkUnitsCompleted s)"
+  (simp: setObject_def wp: updateObject_cte_inv)
 
 lemma set_original_symb_exec_l':
-  "corres_underlying {(s, s'). f (ekheap s) (kheap s) s'} False nf' dc P P' (set_original p b) (return x)"
+  "corres_underlying {(s, s'). f (kheap s) s'} False nf' dc P P' (set_original p b) (return x)"
   by (simp add: corres_underlying_def return_def set_original_def in_monad Bex_def)
 
-lemma setCTE_schedule_index[wp]:
-  "\<lbrace>\<lambda>s. P (ksDomScheduleIdx s)\<rbrace> setCTE p v \<lbrace>\<lambda>rv s. P (ksDomScheduleIdx s)\<rbrace>"
-  apply (simp add: setCTE_def setObject_def split_def)
-  apply (wp updateObject_cte_inv crunch_wps | simp)+
-  done
-
-lemma setCTE_schedule[wp]:
-  "\<lbrace>\<lambda>s. P (ksDomSchedule s)\<rbrace> setCTE p v \<lbrace>\<lambda>rv s. P (ksDomSchedule s)\<rbrace>"
-  apply (simp add: setCTE_def setObject_def split_def)
-  apply (wp updateObject_cte_inv crunch_wps | simp)+
-  done
-
-lemma setCTE_domain_time[wp]:
-  "\<lbrace>\<lambda>s. P (ksDomainTime s)\<rbrace> setCTE p v \<lbrace>\<lambda>rv s. P (ksDomainTime s)\<rbrace>"
-  apply (simp add: setCTE_def setObject_def split_def)
-  apply (wp updateObject_cte_inv crunch_wps | simp)+
-  done
-
-lemma setCTE_work_units_completed[wp]:
-  "\<lbrace>\<lambda>s. P (ksWorkUnitsCompleted s)\<rbrace> setCTE p v \<lbrace>\<lambda>_ s. P (ksWorkUnitsCompleted s)\<rbrace>"
-  apply (simp add: setCTE_def setObject_def split_def)
-  apply (wp updateObject_cte_inv crunch_wps | simp)+
-  done
+crunch set_cap
+  for domain_index[wp]: "\<lambda>s. P (domain_index s)"
+  (wp: set_object_wp)
 
 lemma create_reply_master_corres:
   "\<lbrakk> sl' = cte_map sl ; AllowGrant \<in> rights \<rbrakk> \<Longrightarrow>
@@ -4854,7 +4821,6 @@ lemma cteInsert_simple_corres:
                apply (simp+)[3]
             apply (clarsimp simp: corres_underlying_def state_relation_def
                                   in_monad valid_mdb'_def valid_mdb_ctes_def)
-            apply (drule (1) pspace_relationsD)
             apply (drule (18) set_cap_not_quite_corres)
              apply (rule refl)
             apply (elim conjE exE)
@@ -4881,7 +4847,7 @@ lemma cteInsert_simple_corres:
             apply (drule (3) updateMDB_the_lot', simp only: no_0_modify_map, simp only:, elim conjE)
             apply (drule (3) updateMDB_the_lot', simp only: no_0_modify_map, simp only:, elim conjE)
             apply (drule (3) updateMDB_the_lot', simp only: no_0_modify_map, simp only:, elim conjE)
-            apply (clarsimp simp: pspace_relations_def)
+            apply clarsimp
             apply (thin_tac "gsCNodes t = p" for t p)+
             apply (thin_tac "ksMachineState t = p" for t p)+
             apply (thin_tac "ksCurThread t = p" for t p)+
@@ -4906,7 +4872,6 @@ lemma cteInsert_simple_corres:
             apply (thin_tac "ksDomainTime t = p" for t p)+
             apply (thin_tac "ksDomSchedule t = p" for t p)+
             apply (thin_tac "ctes_of t = p" for t p)+
-            apply (thin_tac "ekheap_relation t p" for t p)+
             apply (thin_tac "pspace_relation t p" for t p)+
             apply (thin_tac "interrupt_state_relation s t p" for s t p)+
             apply (thin_tac "sched_act_relation t p" for t p)+
@@ -6122,7 +6087,7 @@ lemma setCTE_set_cap_ready_queues_relation_valid_corres:
   shows "ready_queues_relation t t'"
   apply (clarsimp simp: ready_queues_relation_def)
   apply (insert pre)
-  apply (rule use_valid[OF step_abs set_cap_exst])
+  apply (rule use_valid[OF step_abs set_cap_rqueues])
   apply (rule use_valid[OF step_conc setCTE_ksReadyQueues])
   apply (rule use_valid[OF step_conc setCTE_tcbSchedNexts_of])
   apply (rule use_valid[OF step_conc setCTE_tcbSchedPrevs_of])
@@ -6148,7 +6113,6 @@ lemma updateCap_same_master:
         apply (clarsimp simp: cte_wp_at_ctes_of)
        apply clarsimp
        apply (clarsimp simp add: state_relation_def)
-       apply (drule (1) pspace_relationsD)
        apply (frule (4) set_cap_not_quite_corres_prequel)
             apply (erule cte_wp_at_weakenE, rule TrueI)
            apply assumption
@@ -6159,7 +6123,7 @@ lemma updateCap_same_master:
        apply (rule bexI)
         prefer 2
         apply assumption
-       apply (clarsimp simp: pspace_relations_def)
+       apply clarsimp
        apply (subst conj_assoc[symmetric])
        apply (extract_conjunct \<open>match conclusion in "ready_queues_relation a b" for a b \<Rightarrow> -\<close>)
         subgoal by (erule setCTE_set_cap_ready_queues_relation_valid_corres; assumption)

--- a/proof/refine/X64/Detype_R.thy
+++ b/proof/refine/X64/Detype_R.thy
@@ -852,11 +852,6 @@ lemma corres_machine_op:
    apply (simp_all add: state_relation_def swp_def)
   done
 
-lemma ekheap_relation_detype:
-  "ekheap_relation ekh kh \<Longrightarrow>
-   ekheap_relation (\<lambda>x. if P x then None else (ekh x)) (\<lambda>x. if P x then None else (kh x))"
-  by (fastforce simp add: ekheap_relation_def split: if_split_asm)
-
 lemma cap_table_at_gsCNodes_eq:
   "(s, s') \<in> state_relation
     \<Longrightarrow> (gsCNodes s' ptr = Some bits) = cap_table_at bits ptr s"
@@ -959,11 +954,11 @@ lemma detype_ready_queues_relation:
          tcb_of' |>
          tcbSchedPrev)
         (\<lambda>d p. inQ d p |< ((\<lambda>x. if lower \<le> x \<and> x \<le> upper then None else ksPSpace s' x) |> tcb_of'))"
-  apply (clarsimp simp: detype_ext_def ready_queues_relation_def Let_def)
+  apply (clarsimp simp: ready_queues_relation_def Let_def)
   apply (frule (1) detype_tcbSchedNexts_of[where S="{lower..upper}"]; simp)
   apply (frule (1) detype_tcbSchedPrevs_of[where S="{lower..upper}"]; simp)
   apply (frule (1) detype_inQ[where S="{lower..upper}"]; simp)
-  apply (fastforce simp add: detype_def detype_ext_def)
+  apply (fastforce simp add: detype_def)
   done
 
 lemma deleteObjects_corres:
@@ -1025,33 +1020,32 @@ lemma deleteObjects_corres:
     apply (simp add: valid_pspace'_def)
     apply (rule state_relation_null_filterE, assumption,
            simp_all add: pspace_aligned'_cut pspace_distinct'_cut)[1]
-            apply (simp add: detype_def, rule state.equality; simp add: detype_ext_def)
-           apply (intro exI, fastforce)
-          apply (rule ext, clarsimp simp add: null_filter_def)
-          apply (rule sym, rule ccontr, clarsimp)
-          apply (drule(4) cte_map_not_null_outside')
-           apply (fastforce simp add: cte_wp_at_caps_of_state)
-          apply simp
-         apply (rule ext, clarsimp simp add: null_filter'_def
-                            map_to_ctes_delete[simplified field_simps])
+           apply (simp add: detype_def)
+          apply (intro exI, fastforce)
+         apply (rule ext, clarsimp simp add: null_filter_def)
          apply (rule sym, rule ccontr, clarsimp)
-         apply (frule(2) pspace_relation_cte_wp_atI
-                         [OF state_relation_pspace_relation])
-         apply (elim exE)
-         apply (frule(4) cte_map_not_null_outside')
-          apply (rule cte_wp_at_weakenE, erule conjunct1)
-          apply (case_tac y, clarsimp)
-          apply (clarsimp simp: valid_mdb'_def valid_mdb_ctes_def
-                                valid_nullcaps_def)
-         apply clarsimp
-         apply (frule_tac cref="(aa, ba)" in cte_map_untyped_range,
-                erule cte_wp_at_weakenE[OF _ TrueI], assumption+)
+         apply (drule(4) cte_map_not_null_outside')
+          apply (fastforce simp add: cte_wp_at_caps_of_state)
          apply simp
-        apply (rule detype_pspace_relation[simplified],
-               simp_all add: state_relation_pspace_relation valid_pspace_def)[1]
-         apply (simp add: valid_cap'_def capAligned_def)
-        apply (clarsimp simp: valid_cap_def, assumption)
-       apply (fastforce simp add: detype_def detype_ext_def intro!: ekheap_relation_detype)
+        apply (rule ext, clarsimp simp add: null_filter'_def
+                           map_to_ctes_delete[simplified field_simps])
+        apply (rule sym, rule ccontr, clarsimp)
+        apply (frule(2) pspace_relation_cte_wp_atI
+                        [OF state_relation_pspace_relation])
+        apply (elim exE)
+        apply (frule(4) cte_map_not_null_outside')
+         apply (rule cte_wp_at_weakenE, erule conjunct1)
+         apply (case_tac y, clarsimp)
+         apply (clarsimp simp: valid_mdb'_def valid_mdb_ctes_def
+                               valid_nullcaps_def)
+        apply clarsimp
+        apply (frule_tac cref="(aa, ba)" in cte_map_untyped_range,
+               erule cte_wp_at_weakenE[OF _ TrueI], assumption+)
+        apply simp
+       apply (rule detype_pspace_relation[simplified],
+              simp_all add: state_relation_pspace_relation valid_pspace_def)[1]
+        apply (simp add: valid_cap'_def capAligned_def)
+       apply (clarsimp simp: valid_cap_def, assumption)
       apply (rule detype_ready_queues_relation; blast?)
        apply (clarsimp simp: deletionIsSafe_delete_locale_def)
       apply (frule state_relation_ready_queues_relation)
@@ -3742,23 +3736,19 @@ lemma createObject_setCTE_commute:
                        cteSizeBits_def)
             \<comment> \<open>Untyped\<close>
             apply (simp add: monad_commute_guard_imp[OF return_commute])
-           \<comment> \<open>TCB, EP, NTFN\<close>
+           \<comment> \<open>TCB\<close>
            apply (rule monad_commute_guard_imp[OF commute_commute])
-            apply (rule monad_commute_split[OF monad_commute_split])
-                apply (rule monad_commute_split[OF commute_commute[OF return_commute]])
-                 apply (rule setCTE_modify_tcbDomain_commute)
-                apply wp
-               apply (rule curDomain_commute)
-               apply wp+
-             apply (rule setCTE_placeNewObject_commute)
-            apply (wp  placeNewObject_tcb_at' placeNewObject_cte_wp_at'
-              placeNewObject_pspace_distinct'
-              placeNewObject_pspace_aligned'
-              | clarsimp simp: objBits_simps')+
-           apply (rule monad_commute_guard_imp[OF commute_commute]
-            ,rule monad_commute_split[OF commute_commute[OF return_commute]]
-            ,rule setCTE_placeNewObject_commute
-            ,(wp|clarsimp simp: objBits_simps')+)+
+            apply (rule monad_commute_split[OF monad_commute_split[OF commute_commute]])
+                apply (rule return_commute)
+               apply (rule setCTE_placeNewObject_commute)
+              apply wp
+             apply (rule curDomain_commute)
+             apply (wpsimp simp: objBits_simps')+
+          \<comment> \<open>EP, NTFN\<close>
+          apply (rule monad_commute_guard_imp[OF commute_commute],
+                 rule monad_commute_split[OF commute_commute[OF return_commute]],
+                 rule setCTE_placeNewObject_commute,
+                 (wpsimp simp: objBits_simps')+)+
         \<comment> \<open>CNode\<close>
         apply (rule monad_commute_guard_imp[OF commute_commute])
          apply (rule monad_commute_split)+
@@ -5066,6 +5056,34 @@ lemma createTCBs_tcb_at':
   apply (simp add: objBits_simps shiftl_t2n)
   done
 
+lemma curDomain_createObjects'_comm:
+  "do x \<leftarrow> createObjects' ptr n obj us;
+      y \<leftarrow> curDomain;
+      m x y
+   od =
+   do y \<leftarrow> curDomain;
+      x \<leftarrow> createObjects' ptr n obj us;
+      m x y
+   od"
+  apply (rule ext)
+  apply (case_tac x)
+  by (auto simp: createObjects'_def split_def bind_assoc return_def unless_def
+                 when_def simpler_gets_def alignError_def fail_def assert_def
+                 bind_def curDomain_def modify_def get_def put_def
+          split: option.splits)
+
+lemma curDomain_twice_simp:
+  "do x \<leftarrow> curDomain;
+      y \<leftarrow> curDomain;
+      m x y
+   od =
+   do x \<leftarrow> curDomain;
+      m x x
+   od"
+  apply (rule ext)
+  apply (case_tac x)
+  by (auto simp: simpler_gets_def bind_def curDomain_def)
+
 lemma createNewCaps_Cons:
   assumes cover:"range_cover ptr sz (Types_H.getObjectSize ty us) (Suc (Suc n))"
   and "valid_pspace' s" "valid_arch_state' s"
@@ -5148,150 +5166,99 @@ proof -
    apply (erule range_cover.sz(1)[where 'a=machine_word_len, folded word_bits_def])
   apply (simp add: createNewCaps_def)
   apply (case_tac ty)
-        apply (simp add: X64_H.toAPIType_def
-                         Arch_createNewCaps_def)
-        apply (rename_tac apiobject_type)
-        apply (case_tac apiobject_type)
-            apply (simp_all add: bind_assoc X64_H.toAPIType_def
-                                 )
-            \<comment> \<open>Untyped\<close>
-            apply (simp add:
-              bind_assoc X64_H.getObjectSize_def
-              mapM_def sequence_def Retype_H.createObject_def
-              X64_H.toAPIType_def
-              createObjects_def X64_H.createObject_def
-              Arch_createNewCaps_def comp_def
-              apiGetObjectSize_def shiftl_t2n field_simps
-              shiftL_nat mapM_x_def sequence_x_def append
-              fromIntegral_def integral_inv[unfolded Fun.comp_def])
-           \<comment> \<open>TCB, EP, NTFN\<close>
-           apply (simp add: bind_assoc
-                      X64_H.getObjectSize_def
-                      sequence_def Retype_H.createObject_def
-                      X64_H.toAPIType_def
-                      createObjects_def X64_H.createObject_def
-                      Arch_createNewCaps_def comp_def
-                      apiGetObjectSize_def shiftl_t2n field_simps
-                      shiftL_nat append mapM_x_append2
-                      fromIntegral_def integral_inv[unfolded Fun.comp_def])+
-           apply (subst monad_eq)
-            apply (rule createObjects_Cons)
-                 apply (simp add: field_simps shiftl_t2n bind_assoc pageBits_def
-                               objBits_simps placeNewObject_def2)+
-           apply (rule_tac Q = "\<lambda>r s. pspace_aligned' s \<and>
-               pspace_distinct' s \<and>
-               pspace_no_overlap' (ptr + (2^tcbBlockSizeBits + of_nat n * 2^tcbBlockSizeBits)) (objBitsKO (KOTCB makeObject)) s \<and>
-               range_cover (ptr + 2^tcbBlockSizeBits) sz
-               (objBitsKO (KOTCB makeObject)) (Suc n)
-               \<and> (\<forall>x\<in>set [0.e.of_nat n]. tcb_at' (ptr + x * 2^tcbBlockSizeBits) s)"
-               in monad_eq_split2)
-              apply simp
-             apply (subst monad_commute_simple[symmetric])
-              apply (rule commute_commute[OF curDomain_commute])
-              apply wpsimp+
-             apply (rule_tac Q = "\<lambda>r s. r = (ksCurDomain s) \<and>
-               pspace_aligned' s \<and>
-               pspace_distinct' s \<and>
-               pspace_no_overlap' (ptr + (2^tcbBlockSizeBits + of_nat n * 2^tcbBlockSizeBits)) (objBitsKO (KOTCB makeObject)) s \<and>
-               range_cover (ptr + 2^tcbBlockSizeBits) sz
-               (objBitsKO (KOTCB makeObject)) (Suc n)
-               \<and> (\<forall>x\<in>set [0.e.of_nat n]. tcb_at' (ptr + x * 2^tcbBlockSizeBits) s)
-             " in  monad_eq_split)
-               apply (subst monad_commute_simple[symmetric])
-                 apply (rule createObjects_setDomains_commute)
-                apply (clarsimp simp:objBits_simps)
-                apply (rule conj_impI)
-                 apply (erule aligned_add_aligned)
-                  apply (rule aligned_add_aligned[where n = tcbBlockSizeBits])
-                    apply (simp add:is_aligned_def objBits_defs)
-                   apply (cut_tac is_aligned_shift[where m = tcbBlockSizeBits and k = "of_nat n",
-                     unfolded shiftl_t2n,simplified])
-                   apply (simp add:field_simps)+
-                apply (erule range_cover_full)
-                apply (simp add: word_bits_conv objBits_defs)
-               apply (rule_tac Q = "\<lambda>x s. (ksCurDomain s) = r" in monad_eq_split2)
-                  apply simp
-                 apply (rule_tac Q = "\<lambda>x s. (ksCurDomain s) = r" in monad_eq_split)
-                   apply (subst rewrite_step[where f = curDomain and
-                     P ="\<lambda>s. ksCurDomain s = r" and f' = "return r"])
-                     apply (simp add:curDomain_def bind_def gets_def get_def)
-                    apply simp
-                   apply (simp add:mapM_x_singleton)
-                  apply wp
-                 apply simp
-                apply (wp mapM_x_wp')
-               apply simp
-              apply (simp add:curDomain_def,wp)
-             apply simp
-            apply (wp createObjects'_psp_aligned[where sz = sz]
-              createObjects'_psp_distinct[where sz = sz])
-            apply (rule hoare_vcg_conj_lift)
-             apply (rule hoare_post_imp[OF _ createObjects'_pspace_no_overlap
-                [unfolded shiftl_t2n,where gz = tcbBlockSizeBits and sz = sz,simplified]])
-              apply (simp add:objBits_simps field_simps)
-             apply (simp add: objBits_simps)
-            apply (wp createTCBs_tcb_at'[where sz = sz])
-           apply (clarsimp simp:objBits_simps word_bits_def field_simps)
-           apply (frule range_cover_le[where n = "Suc n"],simp+)
-           apply (drule range_cover_offset[where p = 1,rotated])
-            apply simp
-           apply (simp add: objBits_defs)
-          apply (((simp add: bind_assoc
-                      X64_H.getObjectSize_def
-                      mapM_def sequence_def Retype_H.createObject_def
-                      X64_H.toAPIType_def
-                      createObjects_def X64_H.createObject_def
-                      Arch_createNewCaps_def comp_def
-                      apiGetObjectSize_def shiftl_t2n field_simps
-                      shiftL_nat mapM_x_def sequence_x_def append
-                      fromIntegral_def integral_inv[unfolded Fun.comp_def])+
-                   , subst monad_eq, rule createObjects_Cons
-                   , (simp add: field_simps shiftl_t2n bind_assoc pageBits_def
-                               objBits_simps placeNewObject_def2)+)+)[2]
-        \<comment> \<open>CNode\<close>
-        apply (simp add: bind_assoc
-                      X64_H.getObjectSize_def
-                      mapM_def sequence_def Retype_H.createObject_def
-                      X64_H.toAPIType_def
-                      createObjects_def X64_H.createObject_def
-                      Arch_createNewCaps_def comp_def
-                      apiGetObjectSize_def shiftl_t2n field_simps
-                      shiftL_nat mapM_x_def sequence_x_def append
-                      fromIntegral_def integral_inv[unfolded Fun.comp_def])+
-        apply (subst monad_eq, rule createObjects_Cons)
-              apply (simp add: field_simps shiftl_t2n bind_assoc pageBits_def
-                               objBits_simps placeNewObject_def2)+
-        apply (subst gsCNodes_update gsCNodes_upd_createObjects'_comm)+
-        apply (simp add: modify_modify_bind)
-        apply (rule fun_cong[where x=s])
-        apply (rule arg_cong_bind1)+
-        apply (rule arg_cong_bind[OF _ refl])
-        apply (rule arg_cong[where f=modify, OF ext], simp)
-        apply (rule arg_cong2[where f=gsCNodes_update, OF ext refl])
-        apply (rule ext)
-        apply simp
+         apply (simp add: X64_H.toAPIType_def
+                          Arch_createNewCaps_def)
+         apply (rename_tac apiobject_type)
+         apply (case_tac apiobject_type)
+             apply (simp_all add: bind_assoc X64_H.toAPIType_def)
+             \<comment> \<open>Untyped\<close>
+             apply (simp add:
+               bind_assoc X64_H.getObjectSize_def
+               mapM_def sequence_def Retype_H.createObject_def
+               X64_H.toAPIType_def
+               createObjects_def X64_H.createObject_def
+               Arch_createNewCaps_def comp_def
+               apiGetObjectSize_def shiftl_t2n field_simps
+               shiftL_nat mapM_x_def sequence_x_def append
+               fromIntegral_def integral_inv[unfolded Fun.comp_def])
+            \<comment> \<open>TCB\<close>
+            apply (simp add: bind_assoc X64_H.getObjectSize_def
+                             mapM_def sequence_def Retype_H.createObject_def
+                             X64_H.toAPIType_def objBitsKO_def
+                             createObjects_def X64_H.createObject_def
+                             Arch_createNewCaps_def comp_def append
+                             apiGetObjectSize_def shiftl_t2n field_simps
+                             shiftL_nat fromIntegral_def integral_inv[unfolded Fun.comp_def])
+            apply (subst curDomain_createObjects'_comm)
+            apply (subst curDomain_twice_simp)
+            apply (simp add: monad_eq_simp_state)
+            apply (intro conjI; clarsimp simp: in_monad)
+              apply ((fastforce simp: curDomain_def simpler_gets_def return_def placeNewObject_def2
+                                      field_simps shiftl_t2n bind_assoc objBits_simps in_monad
+                                      createObjects_Cons[where
+                                        val="KOTCB (tcbDomain_update (\<lambda>_. ksCurDomain s) makeObject)"
+                                        and s=s, simplified objBitsKO_def])+)[2]
+            apply ((clarsimp simp: curDomain_def simpler_gets_def return_def split_def bind_def
+                                  field_simps shiftl_t2n bind_assoc objBits_simps placeNewObject_def2
+                                  createObjects_Cons[where
+                                    val="KOTCB (tcbDomain_update (\<lambda>_. ksCurDomain s) makeObject)"
+                                    and s=s, simplified objBitsKO_def])+)[1]
+           \<comment> \<open>EP, NTFN\<close>
+           apply (((simp add: X64_H.getObjectSize_def
+                              mapM_def sequence_def Retype_H.createObject_def
+                              X64_H.toAPIType_def
+                              createObjects_def X64_H.createObject_def
+                              Arch_createNewCaps_def comp_def
+                              apiGetObjectSize_def shiftl_t2n field_simps
+                              shiftL_nat mapM_x_def sequence_x_def append
+                              fromIntegral_def integral_inv[unfolded Fun.comp_def])+,
+                    subst monad_eq, rule createObjects_Cons,
+                    (simp add: field_simps shiftl_t2n bind_assoc pageBits_def
+                               objBits_simps' placeNewObject_def2)+)+)[2]
+         \<comment> \<open>CNode\<close>
+         apply (simp add: bind_assoc
+                       X64_H.getObjectSize_def
+                       mapM_def sequence_def Retype_H.createObject_def
+                       X64_H.toAPIType_def
+                       createObjects_def X64_H.createObject_def
+                       Arch_createNewCaps_def comp_def
+                       apiGetObjectSize_def shiftl_t2n field_simps
+                       shiftL_nat mapM_x_def sequence_x_def append
+                       fromIntegral_def integral_inv[unfolded Fun.comp_def])+
+         apply (subst monad_eq, rule createObjects_Cons)
+               apply (simp add: field_simps shiftl_t2n bind_assoc pageBits_def
+                                objBits_simps placeNewObject_def2)+
+         apply (subst gsCNodes_update gsCNodes_upd_createObjects'_comm)+
+         apply (simp add: modify_modify_bind)
+         apply (rule fun_cong[where x=s])
+         apply (rule arg_cong_bind1)+
+         apply (rule arg_cong_bind[OF _ refl])
+         apply (rule arg_cong[where f=modify, OF ext], simp)
+         apply (rule arg_cong2[where f=gsCNodes_update, OF ext refl])
+         apply (rule ext)
+         apply simp
 
-       \<comment> \<open>SmallPageObject\<close>
-       apply (simp add: Arch_createNewCaps_def
-                        Retype_H.createObject_def createObjects_def bind_assoc
-                        X64_H.toAPIType_def X64_H.toAPIType_def
-                        X64_H.createObject_def placeNewDataObject_def)
-       apply (intro conjI impI)
+        \<comment> \<open>SmallPageObject\<close>
+        apply (simp add: Arch_createNewCaps_def
+                         Retype_H.createObject_def createObjects_def bind_assoc
+                         X64_H.toAPIType_def X64_H.toAPIType_def
+                         X64_H.createObject_def placeNewDataObject_def)
+        apply (intro conjI impI)
+         apply (subst monad_eq, rule createObjects_Cons)
+               apply (simp_all add: field_simps shiftl_t2n pageBits_def
+                          getObjectSize_def X64_H.getObjectSize_def
+                          objBits_simps)[6]
+         apply (simp add: bind_assoc placeNewObject_def2 objBits_simps
+                          getObjectSize_def X64_H.getObjectSize_def bit_simps
+                          pageBits_def add.commute append)
+         apply ((subst gsUserPages_update gsCNodes_update
+                     gsUserPages_upd_createObjects'_comm
+                     dmo'_createObjects'_comm dmo'_gsUserPages_upd_comm
+                    | simp add: modify_modify_bind o_def)+)[1]
         apply (subst monad_eq, rule createObjects_Cons)
-             apply (simp_all add: field_simps shiftl_t2n pageBits_def
-                        getObjectSize_def X64_H.getObjectSize_def
-                        objBits_simps)[6]
-        apply (simp add: bind_assoc placeNewObject_def2 objBits_simps
-                         getObjectSize_def X64_H.getObjectSize_def bit_simps
-                         pageBits_def add.commute append)
-        apply ((subst gsUserPages_update gsCNodes_update
-                    gsUserPages_upd_createObjects'_comm
-                    dmo'_createObjects'_comm dmo'_gsUserPages_upd_comm
-                   | simp add: modify_modify_bind o_def)+)[1]
-        apply (subst monad_eq, rule createObjects_Cons)
-             apply (simp_all add: field_simps shiftl_t2n pageBits_def
-                        getObjectSize_def X64_H.getObjectSize_def
-                        objBits_simps)[6]
+              apply (simp_all add: field_simps shiftl_t2n pageBits_def
+                         getObjectSize_def X64_H.getObjectSize_def
+                         objBits_simps)[6]
         apply (simp add: bind_assoc placeNewObject_def2 objBits_simps
                          getObjectSize_def X64_H.getObjectSize_def
                          pageBits_def add.commute append)
@@ -5299,83 +5266,83 @@ proof -
                     gsUserPages_upd_createObjects'_comm
                     dmo'_createObjects'_comm dmo'_gsUserPages_upd_comm
                    | simp add: modify_modify_bind o_def)+
-      \<comment> \<open>LargePageObject\<close>
-      apply (simp add: Arch_createNewCaps_def
-                       Retype_H.createObject_def createObjects_def bind_assoc
-                       X64_H.toAPIType_def X64_H.toAPIType_def
-                       X64_H.createObject_def placeNewDataObject_def)
-      apply (intro conjI impI)
+       \<comment> \<open>LargePageObject\<close>
+       apply (simp add: Arch_createNewCaps_def
+                        Retype_H.createObject_def createObjects_def bind_assoc
+                        X64_H.toAPIType_def X64_H.toAPIType_def
+                        X64_H.createObject_def placeNewDataObject_def)
+       apply (intro conjI impI)
+        apply (subst monad_eq, rule createObjects_Cons)
+              apply (simp_all add: field_simps shiftl_t2n pageBits_def bit_simps
+                         getObjectSize_def X64_H.getObjectSize_def
+                         objBits_simps)[6]
+        apply (simp add: bind_assoc placeNewObject_def2 objBits_simps bit_simps
+                         getObjectSize_def X64_H.getObjectSize_def
+                         pageBits_def add.commute append)
+        apply ((subst gsUserPages_update gsCNodes_update
+                    gsUserPages_upd_createObjects'_comm
+                    dmo'_createObjects'_comm dmo'_gsUserPages_upd_comm
+                   | simp add: modify_modify_bind o_def)+)[1]
        apply (subst monad_eq, rule createObjects_Cons)
-            apply (simp_all add: field_simps shiftl_t2n pageBits_def bit_simps
-                       getObjectSize_def X64_H.getObjectSize_def
-                       objBits_simps)[6]
-       apply (simp add: bind_assoc placeNewObject_def2 objBits_simps bit_simps
-                        getObjectSize_def X64_H.getObjectSize_def
+             apply (simp_all add: field_simps shiftl_t2n pageBits_def
+                        X64_H.getObjectSize_def objBits_simps)[6]
+       apply (simp add: bind_assoc placeNewObject_def2 objBits_simps
+                         X64_H.getObjectSize_def
                         pageBits_def add.commute append)
-       apply ((subst gsUserPages_update gsCNodes_update
-                   gsUserPages_upd_createObjects'_comm
-                   dmo'_createObjects'_comm dmo'_gsUserPages_upd_comm
-                  | simp add: modify_modify_bind o_def)+)[1]
-      apply (subst monad_eq, rule createObjects_Cons)
-            apply (simp_all add: field_simps shiftl_t2n pageBits_def
-                       X64_H.getObjectSize_def objBits_simps)[6]
-      apply (simp add: bind_assoc placeNewObject_def2 objBits_simps
-                        X64_H.getObjectSize_def
-                       pageBits_def add.commute append)
       apply (subst gsUserPages_update gsCNodes_update
                    gsUserPages_upd_createObjects'_comm
                    dmo'_createObjects'_comm dmo'_gsUserPages_upd_comm
              | simp add: modify_modify_bind o_def)+
-     \<comment> \<open>HugePageObject\<close>
-     apply (simp add: Arch_createNewCaps_def
-                      Retype_H.createObject_def createObjects_def bind_assoc
-                      toAPIType_def X64_H.toAPIType_def
-                      X64_H.createObject_def placeNewDataObject_def)
-     apply (intro conjI impI)
+      \<comment> \<open>HugePageObject\<close>
+      apply (simp add: Arch_createNewCaps_def
+                       Retype_H.createObject_def createObjects_def bind_assoc
+                       toAPIType_def X64_H.toAPIType_def
+                       X64_H.createObject_def placeNewDataObject_def)
+      apply (intro conjI impI)
+       apply (subst monad_eq, rule createObjects_Cons)
+             apply (simp_all add: field_simps shiftl_t2n pageBits_def
+                        getObjectSize_def X64_H.getObjectSize_def
+                        objBits_simps)[6]
+       apply (simp add: bind_assoc placeNewObject_def2 objBits_simps bit_simps
+                        getObjectSize_def X64_H.getObjectSize_def
+                        pageBits_def add.commute append)
+       apply ((subst gsUserPages_update gsCNodes_update
+                     gsUserPages_upd_createObjects'_comm
+                     dmo'_createObjects'_comm dmo'_gsUserPages_upd_comm
+               | simp add: modify_modify_bind o_def)+)[1]
       apply (subst monad_eq, rule createObjects_Cons)
-           apply (simp_all add: field_simps shiftl_t2n pageBits_def
-                      getObjectSize_def X64_H.getObjectSize_def
-                      objBits_simps)[6]
-      apply (simp add: bind_assoc placeNewObject_def2 objBits_simps bit_simps
-                       getObjectSize_def X64_H.getObjectSize_def
+            apply (simp_all add: field_simps shiftl_t2n pageBits_def
+                       X64_H.getObjectSize_def objBits_simps)[6]
+      apply (simp add: bind_assoc placeNewObject_def2 objBits_simps
+                        X64_H.getObjectSize_def bit_simps
                        pageBits_def add.commute append)
-      apply ((subst gsUserPages_update gsCNodes_update
-                    gsUserPages_upd_createObjects'_comm
-                    dmo'_createObjects'_comm dmo'_gsUserPages_upd_comm
-              | simp add: modify_modify_bind o_def)+)[1]
-     apply (subst monad_eq, rule createObjects_Cons)
-           apply (simp_all add: field_simps shiftl_t2n pageBits_def
-                      X64_H.getObjectSize_def objBits_simps)[6]
-     apply (simp add: bind_assoc placeNewObject_def2 objBits_simps
-                       X64_H.getObjectSize_def bit_simps
-                      pageBits_def add.commute append)
      apply (subst gsUserPages_update gsCNodes_update
                   gsUserPages_upd_createObjects'_comm
                   dmo'_createObjects'_comm dmo'_gsUserPages_upd_comm
             | simp add: modify_modify_bind o_def)+
-   \<comment> \<open>PageTableObject\<close>
-   apply (simp add:Arch_createNewCaps_def Retype_H.createObject_def
-           createObjects_def bind_assoc X64_H.toAPIType_def
-           X64_H.createObject_def)
-         apply (subst monad_eq,rule createObjects_Cons)
-             apply ((simp add: field_simps shiftl_t2n pageBits_def archObjSize_def
-               getObjectSize_def X64_H.getObjectSize_def bit_simps
-               objBits_simps ptBits_def)+)[6]
-         apply (simp add:bind_assoc placeNewObject_def2)
+     \<comment> \<open>PageTableObject\<close>
+     apply (simp add:Arch_createNewCaps_def Retype_H.createObject_def
+             createObjects_def bind_assoc X64_H.toAPIType_def
+             X64_H.createObject_def)
+     apply (subst monad_eq,rule createObjects_Cons)
+           apply ((simp add: field_simps shiftl_t2n pageBits_def archObjSize_def
+             getObjectSize_def X64_H.getObjectSize_def bit_simps
+             objBits_simps ptBits_def)+)[6]
+     apply (simp add:bind_assoc placeNewObject_def2)
          apply (simp add: pageBits_def field_simps bit_simps
                getObjectSize_def  ptBits_def archObjSize_def
                X64_H.getObjectSize_def placeNewObject_def2
                objBits_simps append)
 
-   \<comment> \<open>PageDirectoryObject\<close>
-   apply (simp add:Arch_createNewCaps_def Retype_H.createObject_def
-           createObjects_def bind_assoc X64_H.toAPIType_def
-           X64_H.createObject_def)
-         apply (subst monad_eq,rule createObjects_Cons)
-             apply ((simp add: field_simps shiftl_t2n pageBits_def archObjSize_def
-               getObjectSize_def X64_H.getObjectSize_def bit_simps
-               objBits_simps ptBits_def)+)[6]
-         apply (simp add:bind_assoc placeNewObject_def2)
+    \<comment> \<open>PageDirectoryObject\<close>
+    apply (simp add:Arch_createNewCaps_def Retype_H.createObject_def
+            createObjects_def bind_assoc X64_H.toAPIType_def
+            X64_H.createObject_def)
+    apply (subst monad_eq,rule createObjects_Cons)
+          apply ((simp add: field_simps shiftl_t2n pageBits_def archObjSize_def
+            getObjectSize_def X64_H.getObjectSize_def bit_simps
+            objBits_simps ptBits_def)+)[6]
+    apply (simp add:bind_assoc placeNewObject_def2)
          apply (simp add: pageBits_def field_simps bit_simps
                getObjectSize_def  ptBits_def archObjSize_def
                X64_H.getObjectSize_def placeNewObject_def2
@@ -5385,120 +5352,120 @@ proof -
    apply (simp add:Arch_createNewCaps_def Retype_H.createObject_def
            createObjects_def bind_assoc X64_H.toAPIType_def
            X64_H.createObject_def)
-         apply (subst monad_eq,rule createObjects_Cons)
-             apply ((simp add: field_simps shiftl_t2n pageBits_def archObjSize_def
-               getObjectSize_def X64_H.getObjectSize_def bit_simps
-               objBits_simps ptBits_def)+)[6]
-         apply (simp add:bind_assoc placeNewObject_def2)
+   apply (subst monad_eq,rule createObjects_Cons)
+         apply ((simp add: field_simps shiftl_t2n pageBits_def archObjSize_def
+           getObjectSize_def X64_H.getObjectSize_def bit_simps
+           objBits_simps ptBits_def)+)[6]
+   apply (simp add:bind_assoc placeNewObject_def2)
          apply (simp add: pageBits_def field_simps bit_simps
                getObjectSize_def  ptBits_def archObjSize_def
                X64_H.getObjectSize_def placeNewObject_def2
                objBits_simps append)
-    \<comment> \<open>PML4Object\<close>
-         apply (simp add:Arch_createNewCaps_def Retype_H.createObject_def
-           createObjects_def bind_assoc X64_H.toAPIType_def
-           X64_H.createObject_def)
-         apply (subgoal_tac "distinct (map (\<lambda>n. ptr + (n << 12)) [0.e.((of_nat n)::machine_word)])")
-         prefer 2
-          apply (clarsimp simp: objBits_simps archObjSize_def pdBits_def pageBits_def bit_simps
-                                X64_H.getObjectSize_def)
-          apply (subst upto_enum_word)
-          apply (clarsimp simp:distinct_map)
-          apply (frule range_cover.range_cover_n_le)
-          apply (frule range_cover.range_cover_n_less)
-          apply (rule conjI)
-           apply (clarsimp simp:inj_on_def)
-           apply (rule ccontr)
-           apply (erule_tac bnd = "2^(word_bits - 12)" in shift_distinct_helper[rotated 3])
-                apply simp
-               apply (simp add:word_bits_def)
-              apply (erule less_le_trans[OF word_of_nat_less])
-              apply (simp add: word_of_nat_le word_bits_def)
-              apply (erule less_le_trans[OF word_of_nat_less])
-              apply (simp add:word_of_nat_le word_bits_def)
-            apply (frule range_cover.unat_of_nat_n[OF range_cover_le[where n = n]])
-             apply simp
-            apply (rule ccontr)
-            apply simp
-            apply (drule of_nat_inj64[THEN iffD1,rotated -1])
-             apply (simp_all add: word_bits_def)[3]
-           apply (clarsimp)
-           apply (erule_tac bnd = "2^(word_bits - 12)" in shift_distinct_helper[rotated 3])
-                apply simp
-               apply (simp add:word_bits_def)
-             apply (simp add:word_of_nat_less word_bits_def)
-             apply (erule less_le_trans[OF word_of_nat_less])
-             apply (simp add:word_of_nat_le word_bits_def)
-           apply (rule ccontr)
-           apply (frule range_cover.unat_of_nat_n[OF range_cover_le[where n = n]])
-            apply simp
-           apply simp
-           apply (drule of_nat_inj64[THEN iffD1,rotated -1])
-            apply (simp_all add: word_bits_def)[3]
-         apply (subst monad_eq,rule createObjects_Cons)
-               apply ((simp add: field_simps shiftl_t2n pageBits_def archObjSize_def
-                 X64_H.getObjectSize_def pdBits_def bit_simps
-                 objBits_simps ptBits_def)+)[6]
-         apply (simp add:objBits_simps archObjSize_def bit_simps X64_H.getObjectSize_def)
-         apply (simp add:bind_assoc)
-         apply (simp add: placeNewObject_def2[where val = "makeObject::X64_H.pml4e",simplified,symmetric])
-         apply (rule_tac Q = "\<lambda>r s. valid_arch_state' s \<and>
-           (\<forall>x\<le>of_nat n. page_map_l4_at' (ptr + (x << 12)) s) \<and> Q s" for Q in monad_eq_split)
-           apply (rule sym)
-           apply (subst monad_commute_simple)
-           apply (rule commute_commute)
-           apply (rule mapM_x_commute[where f=id])
-           apply (rule placeNewObject_copyGlobalMapping_commute)
-              apply (wp copyGlobalMappings_pspace_no_overlap' mapM_x_wp'| clarsimp)+
-            apply (clarsimp simp:objBits_simps archObjSize_def bit_simps word_bits_conv)
-            apply assumption (* resolve assumption , yuck *)
-           apply (simp add:append mapM_x_append bind_assoc)
-           apply (rule monad_eq_split[where Q = "\<lambda> r s.  pspace_aligned' s \<and> pspace_distinct' s
-             \<and> valid_arch_state' s \<and> (\<forall>r \<le> of_nat n. page_map_l4_at' (ptr + (r << 12)) s)
-             \<and>  page_map_l4_at' (ptr + ((1 + of_nat n) << 12)) s"])
-           apply (rule monad_eq_split[where Q = "\<lambda> r s.  pspace_aligned' s \<and> pspace_distinct' s
-             \<and> valid_arch_state' s \<and> (\<forall>r \<le> of_nat n. page_map_l4_at' (ptr + (r << 12)) s)
-             \<and>  page_map_l4_at' (ptr + ((1 + of_nat n) << 12)) s"])
-      apply (simp add: mapM_x_singleton)
-      apply (subst add.commute[where b=ptr])+
+  \<comment> \<open>PML4Object\<close>
+  apply (simp add:Arch_createNewCaps_def Retype_H.createObject_def
+    createObjects_def bind_assoc X64_H.toAPIType_def
+    X64_H.createObject_def)
+  apply (subgoal_tac "distinct (map (\<lambda>n. ptr + (n << 12)) [0.e.((of_nat n)::machine_word)])")
+   prefer 2
+   apply (clarsimp simp: objBits_simps archObjSize_def pdBits_def pageBits_def bit_simps
+                         X64_H.getObjectSize_def)
+   apply (subst upto_enum_word)
+   apply (clarsimp simp:distinct_map)
+   apply (frule range_cover.range_cover_n_le)
+   apply (frule range_cover.range_cover_n_less)
+   apply (rule conjI)
+    apply (clarsimp simp:inj_on_def)
+    apply (rule ccontr)
+    apply (erule_tac bnd = "2^(word_bits - 12)" in shift_distinct_helper[rotated 3])
+        apply simp
+       apply (simp add:word_bits_def)
+      apply (erule less_le_trans[OF word_of_nat_less])
+      apply (simp add: word_of_nat_le word_bits_def)
+     apply (erule less_le_trans[OF word_of_nat_less])
+     apply (simp add:word_of_nat_le word_bits_def)
+    apply (frule range_cover.unat_of_nat_n[OF range_cover_le[where n = n]])
+     apply simp
+    apply (rule ccontr)
+    apply simp
+    apply (drule of_nat_inj64[THEN iffD1,rotated -1])
+      apply (simp_all add: word_bits_def)[3]
+   apply (clarsimp)
+   apply (erule_tac bnd = "2^(word_bits - 12)" in shift_distinct_helper[rotated 3])
+       apply simp
+      apply (simp add:word_bits_def)
+     apply (simp add:word_of_nat_less word_bits_def)
+    apply (erule less_le_trans[OF word_of_nat_less])
+    apply (simp add:word_of_nat_le word_bits_def)
+   apply (rule ccontr)
+   apply (frule range_cover.unat_of_nat_n[OF range_cover_le[where n = n]])
+    apply simp
+   apply simp
+   apply (drule of_nat_inj64[THEN iffD1,rotated -1])
+     apply (simp_all add: word_bits_def)[3]
+  apply (subst monad_eq,rule createObjects_Cons)
+        apply ((simp add: field_simps shiftl_t2n pageBits_def archObjSize_def
+          X64_H.getObjectSize_def pdBits_def bit_simps
+          objBits_simps ptBits_def)+)[6]
+  apply (simp add:objBits_simps archObjSize_def bit_simps X64_H.getObjectSize_def)
+  apply (simp add:bind_assoc)
+  apply (simp add: placeNewObject_def2[where val = "makeObject::X64_H.pml4e",simplified,symmetric])
+  apply (rule_tac Q = "\<lambda>r s. valid_arch_state' s \<and>
+    (\<forall>x\<le>of_nat n. page_map_l4_at' (ptr + (x << 12)) s) \<and> Q s" for Q in monad_eq_split)
+    apply (rule sym)
+    apply (subst monad_commute_simple)
+      apply (rule commute_commute)
+      apply (rule mapM_x_commute[where f=id])
+       apply (rule placeNewObject_copyGlobalMapping_commute)
+      apply (wp copyGlobalMappings_pspace_no_overlap' mapM_x_wp'| clarsimp)+
+     apply (clarsimp simp:objBits_simps archObjSize_def bit_simps word_bits_conv)
+     apply assumption (* resolve assumption , yuck *)
+    apply (simp add:append mapM_x_append bind_assoc)
+    apply (rule monad_eq_split[where Q = "\<lambda> r s.  pspace_aligned' s \<and> pspace_distinct' s
+      \<and> valid_arch_state' s \<and> (\<forall>r \<le> of_nat n. page_map_l4_at' (ptr + (r << 12)) s)
+      \<and>  page_map_l4_at' (ptr + ((1 + of_nat n) << 12)) s"])
+      apply (rule monad_eq_split[where Q = "\<lambda> r s.  pspace_aligned' s \<and> pspace_distinct' s
+        \<and> valid_arch_state' s \<and> (\<forall>r \<le> of_nat n. page_map_l4_at' (ptr + (r << 12)) s)
+        \<and>  page_map_l4_at' (ptr + ((1 + of_nat n) << 12)) s"])
+        apply (simp add: mapM_x_singleton)
+        apply (subst add.commute[where b=ptr])+
+        apply simp
+       apply (wp mapM_x_wp')
+       apply (rule hoare_pre)
+        apply (clarsimp simp: page_map_l4_at'_def)
+        apply (wp hoare_vcg_all_lift hoare_vcg_imp_lift)
+       apply ((clarsimp simp: page_map_l4_at'_def)+)[2]
+     apply (wp placeNewObject_pspace_aligned' placeNewObject_pspace_distinct')
+     apply (simp add: placeNewObject_def2 field_simps)
+     apply (rule hoare_vcg_conj_lift)
+      apply (rule createObjects'_wp_subst)
+      apply (wp createObjects_valid_arch[where sz=12])
+     apply (rule hoare_vcg_conj_lift)
+      apply (clarsimp simp: page_map_l4_at'_def )
+      apply (wp hoare_vcg_all_lift hoare_vcg_imp_lift createObjects'_typ_at[where sz=12])
+     apply (rule hoare_strengthen_post[OF createObjects'_page_map_l4_at'[where sz=12, simplified ptTranslationBits_def]])
+     apply simp
+    apply (clarsimp simp: objBits_simps page_map_l4_at'_def field_simps archObjSize_def word_bits_conv bit_simps
+      range_cover_full aligned_add_aligned range_cover.aligned is_aligned_shiftl_self )
+   apply (frule pspace_no_overlap'_le2[where ptr'="(ptr + (1 + of_nat n << 12))"])
+     apply (subst shiftl_t2n, subst mult.commute, subst suc_of_nat)
+     apply (rule order_trans[OF range_cover_bound, where n1="1+n"])
+       apply (erule range_cover_le, simp)
       apply simp
-     apply (wp mapM_x_wp')
-     apply (rule hoare_pre)
-      apply (clarsimp simp: page_map_l4_at'_def)
-      apply (wp hoare_vcg_all_lift hoare_vcg_imp_lift)
-     apply ((clarsimp simp: page_map_l4_at'_def)+)[2]
-   apply (wp placeNewObject_pspace_aligned' placeNewObject_pspace_distinct')
-   apply (simp add: placeNewObject_def2 field_simps)
+     apply (rule word_sub_1_le)
+     apply (drule(1) range_cover_no_0[where p="n+1"])
+      apply simp
+     apply simp
+    apply (erule(1) range_cover_tail_mask)
    apply (rule hoare_vcg_conj_lift)
     apply (rule createObjects'_wp_subst)
-    apply (wp createObjects_valid_arch[where sz=12])
-   apply (rule hoare_vcg_conj_lift)
-    apply (clarsimp simp: page_map_l4_at'_def )
-    apply (wp hoare_vcg_all_lift hoare_vcg_imp_lift createObjects'_typ_at[where sz=12])
-   apply (rule hoare_strengthen_post[OF createObjects'_page_map_l4_at'[where sz=12, simplified ptTranslationBits_def]])
-   apply simp
-  apply (clarsimp simp: objBits_simps page_map_l4_at'_def field_simps archObjSize_def word_bits_conv bit_simps
-    range_cover_full aligned_add_aligned range_cover.aligned is_aligned_shiftl_self )
-  apply (frule pspace_no_overlap'_le2[where ptr'="(ptr + (1 + of_nat n << 12))"])
-   apply (subst shiftl_t2n, subst mult.commute, subst suc_of_nat)
-   apply (rule order_trans[OF range_cover_bound, where n1="1+n"])
-     apply (erule range_cover_le, simp)
-    apply simp
-   apply (rule word_sub_1_le)
-   apply (drule(1) range_cover_no_0[where p="n+1"])
-    apply simp
-   apply simp
-  apply (erule(1) range_cover_tail_mask)
-  apply (rule hoare_vcg_conj_lift)
-  apply (rule createObjects'_wp_subst)
-  apply (wp createObjects_valid_arch[where sz=sz])
-  apply (wp createObjects'_page_map_l4_at'[where sz=sz, unfolded ptTranslationBits_def]
-    createObjects'_psp_aligned[where sz=sz]
-    createObjects'_psp_distinct[where sz=sz] hoare_vcg_imp_lift
-    createObjects'_pspace_no_overlap[where sz=sz]
-  | simp add: objBits_simps archObjSize_def field_simps)+
+    apply (wp createObjects_valid_arch[where sz=sz])
+   apply (wp createObjects'_page_map_l4_at'[where sz=sz, unfolded ptTranslationBits_def]
+     createObjects'_psp_aligned[where sz=sz]
+     createObjects'_psp_distinct[where sz=sz] hoare_vcg_imp_lift
+     createObjects'_pspace_no_overlap[where sz=sz]
+   | simp add: objBits_simps archObjSize_def field_simps)+
   apply (drule range_cover_le[where n="Suc n"])
-  apply simp
+   apply simp
   apply (clarsimp simp: word_bits_def valid_pspace'_def bit_simps)
   apply (clarsimp simp: aligned_add_aligned[OF range_cover.aligned] is_aligned_shiftl_self word_bits_def)+
   done
@@ -5796,35 +5763,19 @@ lemma createObject_pspace_no_overlap':
    apply wpc
     apply (wp ArchCreateObject_pspace_no_overlap')
    apply wpc
-       apply wp
-      apply (simp add:placeNewObject_def2)
-      apply (wp doMachineOp_psp_no_overlap createObjects'_pspace_no_overlap2
-        | simp add: placeNewObject_def2 curDomain_def word_shiftl_add_distrib
-        field_simps)+
-      apply (simp add:add.assoc[symmetric])
-      apply (wp createObjects'_pspace_no_overlap2
-        [where n =0 and sz = sz,simplified])
-     apply (simp add:placeNewObject_def2)
-     apply (wp doMachineOp_psp_no_overlap createObjects'_pspace_no_overlap2
-        | simp add: placeNewObject_def2 word_shiftl_add_distrib
-        field_simps)+
-     apply (simp add:add.assoc[symmetric])
-     apply (wp createObjects'_pspace_no_overlap2
-        [where n =0 and sz = sz,simplified])
-    apply (simp add:placeNewObject_def2)
-    apply (wp doMachineOp_psp_no_overlap createObjects'_pspace_no_overlap2
-      | simp add: placeNewObject_def2 word_shiftl_add_distrib
-      field_simps)+
-    apply (simp add:add.assoc[symmetric])
-    apply (wp createObjects'_pspace_no_overlap2
-      [where n =0 and sz = sz,simplified])
-   apply (simp add:placeNewObject_def2)
-   apply (wp doMachineOp_psp_no_overlap createObjects'_pspace_no_overlap2
-     | simp add: placeNewObject_def2 word_shiftl_add_distrib
-     field_simps)+
-   apply (simp add:add.assoc[symmetric])
-   apply (wp createObjects'_pspace_no_overlap2
-     [where n =0 and sz = sz,simplified])
+         apply wp
+        \<comment> \<open>TCB\<close>
+        apply (wp createObjects'_pspace_no_overlap2[where n =0 and sz = sz,simplified]
+               | simp add: curDomain_def placeNewObject_def2 word_shiftl_add_distrib field_simps)+
+         apply (simp add:add.assoc[symmetric])
+         apply (wp createObjects'_pspace_no_overlap2[where n =0 and sz = sz,simplified])
+        apply (wpsimp simp: curDomain_def)
+       \<comment> \<open>other objects\<close>
+       apply ((wp createObjects'_pspace_no_overlap2
+               | simp add: placeNewObject_def2 word_shiftl_add_distrib field_simps)+,
+              simp add:add.assoc[symmetric],
+              wp createObjects'_pspace_no_overlap2[where n =0 and sz = sz,simplified])+
+   \<comment> \<open>Cleanup\<close>
   apply clarsimp
   apply (frule(1) range_cover_no_0[where p = n])
    apply simp
@@ -5842,10 +5793,9 @@ lemma createObject_pspace_no_overlap':
    apply (simp add:shiftl_t2n field_simps)
   apply (frule range_cover_offset[rotated,where p = n])
    apply simp+
-  apply (auto simp: word_shiftl_add_distrib field_simps shiftl_t2n elim: range_cover_le,
-    auto simp add: APIType_capBits_def fromAPIType_def objBits_def
-        dest!: to_from_apiTypeD)
-  done
+  by (auto simp: word_shiftl_add_distrib field_simps shiftl_t2n elim: range_cover_le)
+     (auto simp: APIType_capBits_def fromAPIType_def objBits_def objBits_simps
+          dest!: to_from_apiTypeD)
 
 lemma createObject_pspace_aligned_distinct':
   "\<lbrace>pspace_aligned' and K (is_aligned ptr (APIType_capBits ty us))

--- a/proof/refine/X64/Finalise_R.thy
+++ b/proof/refine/X64/Finalise_R.thy
@@ -1671,7 +1671,7 @@ lemma emptySlot_corres:
   apply (simp add: put_def)
   apply (simp add: exec_gets exec_get exec_put del: fun_upd_apply | subst bind_def)+
   apply (clarsimp simp: state_relation_def)
-  apply (drule updateMDB_the_lot, fastforce simp: pspace_relations_def, fastforce, fastforce)
+  apply (drule updateMDB_the_lot, fastforce simp: pspace_relation_def, fastforce, fastforce)
    apply (clarsimp simp: invs'_def valid_state'_def valid_pspace'_def
                          valid_mdb'_def valid_mdb_ctes_def)
   apply (elim conjE)
@@ -1700,7 +1700,7 @@ lemma emptySlot_corres:
   apply clarsimp
   apply (drule updateCap_stuff, elim conjE, erule (1) impE)
   apply clarsimp
-  apply (drule updateMDB_the_lot, force simp: pspace_relations_def, assumption+, simp)
+  apply (drule updateMDB_the_lot, force simp: pspace_relation_def, assumption+, simp)
   apply (rule bexI)
    prefer 2
    apply (simp only: trans_state_update[symmetric])
@@ -1728,7 +1728,7 @@ lemma emptySlot_corres:
    apply (rule mdb_ptr_axioms.intro)
    subgoal by simp
   apply (clarsimp simp: ghost_relation_typ_at set_cap_a_type_inv)
-  apply (simp add: pspace_relations_def)
+  apply (simp add: pspace_relation_def)
   apply (rule conjI)
    apply (clarsimp simp: data_at_def ghost_relation_typ_at set_cap_a_type_inv)
   apply (rule conjI)
@@ -3425,8 +3425,7 @@ context begin interpretation Arch . (*FIXME: arch-split*)
 lemma arch_finaliseCap_corres:
   "\<lbrakk> final_matters' (ArchObjectCap cap') \<Longrightarrow> final = final'; acap_relation cap cap' \<rbrakk>
      \<Longrightarrow> corres (\<lambda>r r'. cap_relation (fst r) (fst r') \<and> cap_relation (snd r) (snd r'))
-           (\<lambda>s. invs s \<and> valid_etcbs s
-                       \<and> s \<turnstile> cap.ArchObjectCap cap
+           (\<lambda>s. invs s \<and> s \<turnstile> cap.ArchObjectCap cap
                        \<and> (final_matters (cap.ArchObjectCap cap)
                             \<longrightarrow> final = is_final_cap' (cap.ArchObjectCap cap) s)
                        \<and> cte_wp_at ((=) (cap.ArchObjectCap cap)) sl s)

--- a/proof/refine/X64/Init_R.thy
+++ b/proof/refine/X64/Init_R.thy
@@ -53,6 +53,12 @@ definition zeroed_main_abstract_state ::
     is_original_cap = \<top>,
     cur_thread = 0,
     idle_thread = 0,
+    scheduler_action = resume_cur_thread,
+    domain_list = [],
+    domain_index = 0,
+    cur_domain = 0,
+    domain_time = 0,
+    ready_queues = (\<lambda>_ _. []),
     machine_state = init_machine_state,
     interrupt_irq_node = (\<lambda>irq. ucast irq << cte_level_bits),
     interrupt_states = (K irq_state.IRQInactive),
@@ -64,13 +70,6 @@ definition zeroed_extended_state ::
   where
   "zeroed_extended_state \<equiv> \<lparr>
     work_units_completed_internal = 0,
-    scheduler_action_internal = resume_cur_thread,
-    ekheap_internal = Map.empty,
-    domain_list_internal = [],
-    domain_index_internal = 0,
-    cur_domain_internal = 0,
-    domain_time_internal = 0,
-    ready_queues_internal = (\<lambda>_ _. []),
     cdt_list_internal = K []
   \<rparr>"
 
@@ -120,8 +119,7 @@ lemma non_empty_refine_state_relation:
   "(zeroed_abstract_state, zeroed_intermediate_state) \<in> state_relation"
   apply (clarsimp simp: state_relation_def zeroed_state_defs state.defs)
   apply (intro conjI)
-          apply (clarsimp simp: pspace_relation_def pspace_dom_def)
-         apply (clarsimp simp: ekheap_relation_def)
+         apply (clarsimp simp: pspace_relation_def pspace_dom_def)
         apply (clarsimp simp: ready_queues_relation_def ready_queue_relation_def queue_end_valid_def
                               opt_pred_def list_queue_relation_def tcbQueueEmpty_def
                               prev_queue_head_def)

--- a/proof/refine/X64/Interrupt_R.thy
+++ b/proof/refine/X64/Interrupt_R.thy
@@ -678,9 +678,8 @@ lemma getIRQState_prop:
 
 lemma decDomainTime_corres:
   "corres dc \<top> \<top> dec_domain_time decDomainTime"
-  apply (simp add:dec_domain_time_def corres_underlying_def
-    decDomainTime_def simpler_modify_def)
-  apply (clarsimp simp:state_relation_def)
+  apply (simp add:dec_domain_time_def corres_underlying_def decDomainTime_def simpler_modify_def)
+  apply (clarsimp simp: state_relation_def cdt_relation_def)
   done
 
 lemma thread_state_case_if:
@@ -701,7 +700,6 @@ lemma timerTick_corres:
   "corres dc (cur_tcb and valid_sched and pspace_aligned and pspace_distinct)
              invs'
              timer_tick timerTick"
-  supply if_weak_cong[cong]
   apply (simp add: timerTick_def timer_tick_def)
   apply (simp add: thread_state_case_if threadState_case_if)
   apply (rule_tac Q="cur_tcb and valid_sched and pspace_aligned and pspace_distinct"
@@ -715,26 +713,24 @@ lemma timerTick_corres:
           apply (rule corres_split[where r' = dc ])
              apply (rule corres_if[where Q = \<top> and Q' = \<top>])
                apply (case_tac state,simp_all)[1]
-              apply (simp add: Let_def)
-              apply (rule_tac r'="(=)" in corres_split[OF ethreadget_corres])
-                 apply (simp add:etcb_relation_def)
+              apply (rule_tac r'="(=)" in corres_split[OF threadGet_corres])
+                 apply (simp add: tcb_relation_def)
                 apply (rename_tac ts ts')
                 apply (rule_tac R="1 < ts" in corres_cases)
                  apply (simp)
                  apply (unfold thread_set_time_slice_def)
-                 apply (rule ethread_set_corres, simp+)
-                 apply (clarsimp simp: etcb_relation_def)
+                 apply (rule threadset_corres; simp add: tcb_relation_def inQ_def)
                 apply simp
-                apply (rule corres_split)
-                   apply (rule ethread_set_corres; simp)
-                   apply (simp add: etcb_relation_def)
+                apply (rule corres_split[OF threadset_corres])
+                                apply (simp add: sch_act_wf_weak tcb_relation_def pred_conj_def inQ_def)+
                   apply (rule corres_split[OF tcbSchedAppend_corres], simp)
                     apply (rule rescheduleRequired_corres)
                    apply wp
                   apply ((wpsimp wp: tcbSchedAppend_sym_heap_sched_pointers
                                      tcbSchedAppend_valid_objs'
                           | strengthen valid_objs'_valid_tcbs')+)[1]
-                 apply ((wp thread_set_time_slice_valid_queues
+                 apply ((wpsimp wp: thread_set_valid_queues thread_set_no_change_tcb_state
+                                    thread_set_weak_valid_sched_action
                          | strengthen valid_queues_in_correct_ready_q
                                       valid_queues_ready_qs_distinct)+)[1]
                 apply ((wpsimp wp: threadSet_sched_pointers threadSet_valid_sched_pointers
@@ -755,10 +751,10 @@ lemma timerTick_corres:
                              rescheduleRequired_weak_sch_act_wf
                          split_del: if_split)+
               apply (strengthen valid_queues_in_correct_ready_q valid_queues_ready_qs_distinct)
-              apply (wpsimp wp: thread_set_time_slice_valid_queues)
-             apply ((wpsimp wp: thread_set_time_slice_valid_queues
+              apply (wpsimp wp: thread_set_valid_queues thread_set_weak_valid_sched_action)
+             apply ((wpsimp wp: thread_set_valid_queues
                      | strengthen valid_queues_in_correct_ready_q valid_queues_ready_qs_distinct)+)[1]
-            apply wpsimp
+            apply (wpsimp wp: thread_get_wp)
            apply wpsimp
           apply ((wpsimp wp: threadSet_sched_pointers threadSet_valid_sched_pointers
                              threadSet_valid_objs'
@@ -766,11 +762,8 @@ lemma timerTick_corres:
                   | wp (once) hoare_drop_imp)+)[1]
          apply (wpsimp wp: gts_wp gts_wp')+
      apply (clarsimp simp: cur_tcb_def)
-     apply (frule valid_sched_valid_etcbs)
-     apply (frule (1) tcb_at_is_etcb_at)
      apply (frule valid_sched_valid_queues)
      apply (fastforce simp: pred_tcb_at_def obj_at_def valid_sched_weak_strg)
-    apply (clarsimp simp: etcb_at_def split: option.splits)
     apply fastforce
    apply (fastforce simp: valid_state'_def ct_not_inQ_def)
   apply fastforce

--- a/proof/refine/X64/Ipc_R.thy
+++ b/proof/refine/X64/Ipc_R.thy
@@ -2247,9 +2247,8 @@ lemma doReplyTransfer_corres:
                apply simp
               apply (rule corres_split)
                  apply (rule threadset_corresT;
-                        clarsimp simp add: tcb_relation_def fault_rel_optionation_def
-                                           tcb_cap_cases_def tcb_cte_cases_def tcb_cte_cases_neqs
-                                           exst_same_def)
+                        clarsimp simp add: tcb_relation_def fault_rel_optionation_def cteSizeBits_def
+                                           tcb_cap_cases_def tcb_cte_cases_def inQ_def)
                 apply (rule_tac P="valid_sched and cur_tcb and tcb_at receiver
                                    and pspace_aligned and pspace_distinct"
                             and P'="tcb_at' receiver and cur_tcb'
@@ -3429,7 +3428,7 @@ lemma sendFaultIPC_corres:
            apply (rule corres_if2 [OF refl])
             apply (simp add: dc_def[symmetric])
             apply (rule corres_split[OF threadset_corres sendIPC_corres], simp_all)[1]
-               apply (simp add: tcb_relation_def fault_rel_optionation_def exst_same_def)+
+               apply (simp add: tcb_relation_def fault_rel_optionation_def inQ_def)+
              apply (wp thread_set_invs_trivial thread_set_no_change_tcb_state
                        thread_set_typ_at ep_at_typ_at ex_nonz_cap_to_pres
                        thread_set_cte_wp_at_trivial thread_set_not_state_valid_sched

--- a/proof/refine/X64/Refine.thy
+++ b/proof/refine/X64/Refine.thy
@@ -201,18 +201,27 @@ assumes rel: "(s,s') \<in> state_relation"
 shows "absKState s' = abs_state s"
   using assms
   apply (intro state.equality, simp_all add: absKState_def abs_state_def)
-           apply (rule absHeap_correct, clarsimp+)
-           apply (clarsimp elim!: state_relationE)
-          apply (rule absCDT_correct, clarsimp+)
-         apply (rule absIsOriginalCap_correct, clarsimp+)
+                 apply (rule absHeap_correct; clarsimp)
+                 apply (clarsimp elim!: state_relationE)
+                apply (rule absCDT_correct; clarsimp)
+               apply (rule absIsOriginalCap_correct; clarsimp)
+              apply (simp add: state_relation_def)
+             apply (simp add: state_relation_def)
+            apply (clarsimp simp: state_relation_def)
+            apply (rule absSchedulerAction_correct, simp add: state_relation_def)
+           apply (simp add: state_relation_def)
+          apply (simp add: state_relation_def)
+         apply (simp add: state_relation_def)
         apply (simp add: state_relation_def)
-       apply (simp add: state_relation_def)
+       apply (simp add: state_relation_def ready_queues_relation_def ready_queue_relation_def Let_def
+                        list_queue_relation_def)
+       apply (fastforce dest: heap_ls_is_walk)
       apply (clarsimp simp:  user_mem_relation invs_def invs'_def)
       apply (simp add: state_relation_def)
      apply (rule absInterruptIRQNode_correct, simp add: state_relation_def)
     apply (rule absInterruptStates_correct, simp add: state_relation_def)
    apply (rule absArchState_correct, simp)
-  apply (rule absExst_correct, simp+)
+  apply (rule absExst_correct; simp)
   done
 
 text \<open>The top-level invariance\<close>
@@ -223,19 +232,19 @@ lemma set_thread_state_sched_act:
   \<lbrace>\<lambda>rs s. P (scheduler_action (s::det_state))\<rbrace>"
   apply (simp add: set_thread_state_def)
   apply wp
-    apply (simp add: set_thread_state_ext_def)
-    apply wp
-       apply (rule hoare_pre_cont)
-      apply (rule_tac Q'="\<lambda>rv. (\<lambda>s. runnable ts) and (\<lambda>s. P (scheduler_action s))"
-              in hoare_strengthen_post)
-       apply wp
-      apply force
-     apply (wp gts_st_tcb_at)+
-     apply (rule_tac Q'="\<lambda>rv. st_tcb_at ((=) state) thread and (\<lambda>s. runnable state) and (\<lambda>s. P (scheduler_action s))" in hoare_strengthen_post)
+     apply (simp add: set_thread_state_act_def)
+     apply wp
+        apply (rule hoare_pre_cont)
+       apply (rule_tac Q'="\<lambda>rv. (\<lambda>s. runnable ts) and (\<lambda>s. P (scheduler_action s))"
+               in hoare_strengthen_post)
+        apply wp
+       apply force
+      apply (wp gts_st_tcb_at)+
+    apply (rule_tac Q'="\<lambda>rv. st_tcb_at ((=) state) thread and (\<lambda>s. runnable state) and (\<lambda>s. P (scheduler_action s))" in hoare_strengthen_post)
      apply (simp add: st_tcb_at_def)
      apply (wp obj_set_prop_at)+
     apply (force simp: st_tcb_at_def obj_at_def)
-  apply wp
+   apply wp
   apply clarsimp
   done
 
@@ -277,7 +286,7 @@ lemma kernel_entry_invs:
    apply clarsimp
   apply (simp add: kernel_entry_def)
   apply (wp akernel_invs_det_ext call_kernel_valid_sched thread_set_invs_trivial
-            thread_set_ct_running thread_set_not_state_valid_sched
+            thread_set_not_state_valid_sched
             hoare_vcg_disj_lift ct_in_state_thread_state_lift thread_set_no_change_tcb_state
             call_kernel_domain_time_inv_det_ext call_kernel_domain_list_inv_det_ext
             hoare_weak_lift_imp
@@ -335,11 +344,12 @@ lemmas valid_list_inits[simp] = valid_list_init[simplified]
 lemma valid_sched_init[simp]:
   "valid_sched init_A_st"
   apply (simp add: valid_sched_def init_A_st_def ext_init_def)
-  apply (clarsimp simp: valid_etcbs_def init_kheap_def st_tcb_at_kh_def obj_at_kh_def
-                    obj_at_def is_etcb_at_def idle_thread_ptr_def init_global_pml4_def
+  apply (clarsimp simp: init_kheap_def st_tcb_at_kh_def obj_at_kh_def
+                    obj_at_def idle_thread_ptr_def init_global_pml4_def
                     init_global_pd_def valid_queues_2_def ct_not_in_q_def not_queued_def
                     valid_sched_action_def is_activatable_def init_global_pdpt_def
-                    ct_in_cur_domain_2_def valid_blocked_2_def valid_idle_etcb_def etcb_at'_def default_etcb_def)
+                    ct_in_cur_domain_2_def valid_blocked_2_def valid_idle_etcb_def
+                    etcb_at'_def etcbs_of'_def)
   done
 
 lemma valid_domain_list_init[simp]:
@@ -444,27 +454,6 @@ lemma kernelEntry_invs':
                           valid_domain_list'_def)+
   done
 
-lemma absKState_correct':
-  "\<lbrakk>einvs s; invs' s'; (s,s') \<in> state_relation\<rbrakk>
-   \<Longrightarrow> absKState s' = abs_state s"
-  apply (intro state.equality, simp_all add: absKState_def abs_state_def)
-           apply (rule absHeap_correct)
-               apply (clarsimp simp: valid_state_def valid_pspace_def)+
-           apply (clarsimp dest!: state_relationD)
-          apply (rule absCDT_correct)
-                apply (clarsimp simp: valid_state_def valid_pspace_def
-                                      valid_state'_def valid_pspace'_def)+
-         apply (rule absIsOriginalCap_correct, clarsimp+)
-        apply (simp add: state_relation_def)
-       apply (simp add: state_relation_def)
-      apply (clarsimp simp: user_mem_relation invs_def invs'_def)
-      apply (simp add: state_relation_def)
-     apply (rule absInterruptIRQNode_correct, simp add: state_relation_def)
-    apply (rule absInterruptStates_correct, simp add: state_relation_def)
-   apply (erule absArchState_correct)
-  apply (rule absExst_correct, simp, assumption+)
-  done
-
 lemma ptable_lift_abs_state[simp]:
   "ptable_lift t (abs_state s) = ptable_lift t s"
   by (simp add: ptable_lift_def abs_state_def)
@@ -482,7 +471,7 @@ lemma ptable_rights_imp_UserData:
   shows "pointerInUserData y s' \<or> pointerInDeviceData y s'"
 proof -
   from invs invs' rel have [simp]: "absKState s' = abs_state s"
-    by - (rule absKState_correct', simp_all)
+    by - (rule absKState_correct, simp_all)
   from invs have valid: "valid_state s" by auto
   from invs' have valid': "valid_state' s'" by auto
   have "in_user_frame y s \<or> in_device_frame y s "
@@ -635,12 +624,11 @@ lemma entry_corres:
     apply (rule corres_split[OF getCurThread_corres])
       apply (rule corres_split)
          apply simp
-         apply (rule threadset_corresT; simp)
-            apply (simp add: tcb_relation_def arch_tcb_relation_def
-                             arch_tcb_context_set_def atcbContextSet_def)
-           apply (clarsimp simp: tcb_cap_cases_def)
-          apply (clarsimp simp: tcb_cte_cases_def tcb_cte_cases_neqs)
-         apply (simp add: exst_same_def)
+         apply (rule threadset_corresT; simp?)
+           apply (simp add: tcb_relation_def arch_tcb_relation_def
+                            arch_tcb_context_set_def atcbContextSet_def)
+          apply (clarsimp simp: tcb_cap_cases_def cteSizeBits_def)
+         apply (clarsimp simp: tcb_cte_cases_def cteSizeBits_def)
         apply (rule corres_split[OF kernel_corres])
           apply (rule corres_split_eqr[OF getCurThread_corres])
             apply (rule threadGet_corres)
@@ -649,7 +637,7 @@ lemma entry_corres:
            apply wp+
          apply (rule hoare_strengthen_post, rule akernel_invs_det_ext, fastforce simp: invs_def cur_tcb_def)
         apply (rule hoare_strengthen_post, rule ckernel_invs, simp add: invs'_def cur_tcb'_def)
-       apply (wp thread_set_invs_trivial thread_set_ct_running
+       apply (wp thread_set_invs_trivial
                  threadSet_invs_trivial threadSet_ct_running'
                  thread_set_not_state_valid_sched hoare_weak_lift_imp
                  hoare_vcg_disj_lift ct_in_state_thread_state_lift

--- a/proof/refine/X64/Retype_R.thy
+++ b/proof/refine/X64/Retype_R.thy
@@ -78,12 +78,12 @@ where
     | PML4Object \<Rightarrow> 12"
 
 definition
-  makeObjectKO :: "bool \<Rightarrow> (kernel_object + X64_H.object_type) \<rightharpoonup> kernel_object"
+  makeObjectKO :: "bool \<Rightarrow> domain \<Rightarrow> (kernel_object + X64_H.object_type) \<rightharpoonup> kernel_object"
 where
-  "makeObjectKO dev ty \<equiv> case ty of
+  "makeObjectKO dev d ty \<equiv> case ty of
       Inl KOUserData \<Rightarrow> Some KOUserData
     | Inl (KOArch (KOASIDPool _)) \<Rightarrow> Some (KOArch (KOASIDPool makeObject))
-    | Inr (APIObjectType ArchTypes_H.TCBObject) \<Rightarrow> Some (KOTCB makeObject)
+    | Inr (APIObjectType ArchTypes_H.TCBObject) \<Rightarrow> Some (KOTCB (tcbDomain_update (\<lambda>_. d) makeObject))
     | Inr (APIObjectType ArchTypes_H.EndpointObject) \<Rightarrow> Some (KOEndpoint makeObject)
     | Inr (APIObjectType ArchTypes_H.NotificationObject) \<Rightarrow> Some (KONotification makeObject)
     | Inr (APIObjectType ArchTypes_H.CapTableObject) \<Rightarrow> Some (KOCTE makeObject)
@@ -111,6 +111,12 @@ lemma valid_obj_makeObject_tcb [simp]:
   unfolding valid_obj'_def valid_tcb'_def  valid_tcb_state'_def
   by (clarsimp simp: makeObject_tcb makeObject_cte tcb_cte_cases_def minBound_word newArchTCB_def
                      cteSizeBits_def valid_arch_tcb'_def)
+
+lemma valid_obj_makeObject_tcb_tcbDomain_update [simp]:
+  "d \<le> maxDomain \<Longrightarrow> valid_obj' (KOTCB (tcbDomain_update (\<lambda>_. d) makeObject)) s"
+  unfolding valid_obj'_def valid_tcb'_def  valid_tcb_state'_def valid_arch_tcb'_def
+  by (clarsimp simp: makeObject_tcb makeObject_cte objBits_simps' newArchTCB_def
+                     tcb_cte_cases_def maxDomain_def maxPriority_def numPriorities_def minBound_word)
 
 lemma valid_obj_makeObject_endpoint [simp]:
   "valid_obj' (KOEndpoint makeObject) s"
@@ -309,14 +315,13 @@ lemma cte_at_next_slot'':
 
 
 lemma state_relation_null_filterE:
-  "\<lbrakk> (s, s') \<in> state_relation; t = kheap_update f (ekheap_update ef s);
+  "\<lbrakk> (s, s') \<in> state_relation; t = kheap_update f s;
      \<exists>f' g' h'.
      t' = s'\<lparr>ksPSpace := f' (ksPSpace s'), gsUserPages := g' (gsUserPages s'),
              gsCNodes := h' (gsCNodes s')\<rparr>;
      null_filter (caps_of_state t) = null_filter (caps_of_state s);
      null_filter' (ctes_of t') = null_filter' (ctes_of s');
-     pspace_relation (kheap t) (ksPSpace t');
-     ekheap_relation (ekheap t) (ksPSpace t'); ready_queues_relation t t';
+     pspace_relation (kheap t) (ksPSpace t'); ready_queues_relation t t';
      ghost_relation (kheap t) (gsUserPages t') (gsCNodes t'); valid_list s;
      pspace_aligned' s'; pspace_distinct' s'; valid_objs s; valid_mdb s;
      pspace_aligned' t'; pspace_distinct' t';
@@ -334,12 +339,11 @@ lemma state_relation_null_filterE:
     apply (case_tac "cdt s (a, b)")
      apply (subst mdb_cte_at_no_descendants, assumption)
       apply (simp add: cte_wp_at_caps_of_state swp_def)
-     apply (cut_tac s="kheap_update f (ekheap_update ef s)"  and
+     apply (cut_tac s="kheap_update f s"  and
                     s'="s'\<lparr>ksPSpace := f' (ksPSpace s'),
                            gsUserPages := g' (gsUserPages s'),
                            gsCNodes := h' (gsCNodes s')\<rparr>"
             in pspace_relation_ctes_ofI, simp_all)[1]
-      apply (simp add: trans_state_update[symmetric] del: trans_state_update)
       apply (erule caps_of_state_cteD)
      apply (clarsimp simp: descendants_of'_def)
      apply (case_tac cte)
@@ -443,12 +447,12 @@ lemma foldr_update_obj_at':
   done
 
 lemma makeObjectKO_eq:
-  assumes x: "makeObjectKO dev tp = Some v"
+  assumes x: "makeObjectKO dev d tp = Some v"
   shows
   "(v = KOCTE cte) =
        (tp = Inr (APIObjectType ArchTypes_H.CapTableObject) \<and> cte = makeObject)"
   "(v = KOTCB tcb) =
-       (tp = Inr (APIObjectType ArchTypes_H.TCBObject) \<and> tcb = makeObject)"
+       (tp = Inr (APIObjectType ArchTypes_H.TCBObject) \<and> tcb = (tcbDomain_update (\<lambda>_. d) makeObject))"
   using x
   by (simp add: makeObjectKO_def eq_commute
          split: apiobject_type.split_asm sum.split_asm kernel_object.split_asm
@@ -503,7 +507,7 @@ lemma ps_clearD:
   done
 
 lemma cte_wp_at_retype':
-  assumes ko: "makeObjectKO dev tp = Some obj"
+  assumes ko: "makeObjectKO dev d tp = Some obj"
       and pv: "pspace_aligned' s" "pspace_distinct' s"
      and pv': "pspace_aligned' (ksPSpace_update (\<lambda>x xa. if xa \<in> set addrs then Some obj else ksPSpace s xa) s)"
               "pspace_distinct' (ksPSpace_update (\<lambda>x xa. if xa \<in> set addrs then Some obj else ksPSpace s xa) s)"
@@ -522,15 +526,14 @@ lemma cte_wp_at_retype':
     apply (subgoal_tac "(\<exists>P :: cte \<Rightarrow> bool. obj_at' P p ?s')
                           \<longrightarrow> (\<not> (\<exists>P :: tcb \<Rightarrow> bool. obj_at' P (p && ~~ mask tcbBlockSizeBits) ?s'))")
      apply (simp only: cte_wp_at_obj_cases_mask foldr_update_obj_at'[OF pv pv' al])
-     apply (simp    add: projectKOs the_ctes_makeObject
-                         makeObjectKO_eq [OF ko]
-                         makeObject_cte dom_def
+     apply (simp    add: projectKOs the_ctes_makeObject makeObjectKO_eq [OF ko] makeObject_cte
               split del: if_split
                    cong: if_cong)
      apply (insert al ko)
-     apply (simp, safe, simp_all)
-      apply fastforce
-     apply fastforce
+     apply simp
+     apply (safe; simp)
+              apply ((fastforce simp: makeObjectKO_def makeObject_cte makeObject_tcb tcb_cte_cases_def
+                               split: if_split_asm)+)[10]
     apply (clarsimp elim!: obj_atE' simp: projectKOs objBits_simps)
     apply (drule ps_clearD[where y=p and n=tcbBlockSizeBits])
        apply simp
@@ -544,7 +547,7 @@ lemma cte_wp_at_retype':
   done
 
 lemma ctes_of_retype:
-  assumes ko: "makeObjectKO dev tp = Some obj"
+  assumes ko: "makeObjectKO dev d tp = Some obj"
       and pv: "pspace_aligned' s" "pspace_distinct' s"
      and pv': "pspace_aligned' (ksPSpace_update (\<lambda>x xa. if xa \<in> set addrs then Some obj else ksPSpace s xa) s)"
               "pspace_distinct' (ksPSpace_update (\<lambda>x xa. if xa \<in> set addrs then Some obj else ksPSpace s xa) s)"
@@ -573,7 +576,7 @@ lemma None_ctes_of_cte_at:
   by (fastforce simp add: cte_wp_at_ctes_of)
 
 lemma null_filter_ctes_retype:
-  assumes ko: "makeObjectKO dev tp = Some obj"
+  assumes ko: "makeObjectKO dev d tp = Some obj"
       and pv: "pspace_aligned' s" "pspace_distinct' s"
      and pv': "pspace_aligned' (ksPSpace_update (\<lambda>x xa. if xa \<in> set addrs then Some obj else ksPSpace s xa) s)"
               "pspace_distinct' (ksPSpace_update (\<lambda>x xa. if xa \<in> set addrs then Some obj else ksPSpace s xa) s)"
@@ -604,7 +607,8 @@ lemma null_filter_ctes_retype:
    apply (insert ko[symmetric], simp add: makeObjectKO_def objBits_simps)
    apply clarsimp
    apply (subst(asm) subtract_mask[symmetric],
-          erule_tac v="if x \<in> set addrs then KOTCB makeObject else KOCTE cte"
+          erule_tac v="if x \<in> set addrs then KOTCB (tcbDomain_update (\<lambda>_. d) makeObject)
+                                        else KOCTE cte"
                 in tcb_space_clear)
        apply (simp add: is_aligned_mask word_bw_assocs)
       apply assumption
@@ -732,13 +736,13 @@ lemma obj_relation_retype_leD:
   by (simp add: obj_relation_retype_def)
 
 lemma obj_relation_retype_default_leD:
-  "\<lbrakk> obj_relation_retype (default_object (APIType_map2 ty) dev us) ko;
+  "\<lbrakk> obj_relation_retype (default_object (APIType_map2 ty) dev us d) ko;
        ty \<noteq> Inr (APIObjectType ArchTypes_H.Untyped) \<rbrakk>
       \<Longrightarrow> objBitsKO ko \<le> obj_bits_api (APIType_map2 ty) us"
   by (simp add: obj_relation_retype_def objBits_def obj_bits_dev_irr)
 
 lemma makeObjectKO_Untyped:
-  "makeObjectKO dev ty = Some v \<Longrightarrow> ty \<noteq> Inr (APIObjectType ArchTypes_H.Untyped)"
+  "makeObjectKO dev d ty = Some v \<Longrightarrow> ty \<noteq> Inr (APIObjectType ArchTypes_H.Untyped)"
   by (clarsimp simp: makeObjectKO_def)
 
 lemma obj_relation_cuts_trivial:
@@ -761,10 +765,10 @@ lemma obj_relation_cuts_trivial:
 lemma obj_relation_retype_addrs_eq:
   assumes not_unt:"ty \<noteq> Inr (APIObjectType ArchTypes_H.Untyped)"
   assumes  amp: "m = 2^ ((obj_bits_api (APIType_map2 ty) us) - (objBitsKO ko)) * n"
-  assumes  orr: "obj_relation_retype (default_object (APIType_map2 ty) dev us) ko"
+  assumes  orr: "obj_relation_retype (default_object (APIType_map2 ty) dev us d) ko"
   shows  "\<lbrakk> range_cover ptr sz (obj_bits_api (APIType_map2 ty) us) n \<rbrakk> \<Longrightarrow>
    (\<Union>x \<in> set (retype_addrs ptr (APIType_map2 ty) n us).
-            fst ` obj_relation_cuts (default_object (APIType_map2 ty) dev us) x)
+            fst ` obj_relation_cuts (default_object (APIType_map2 ty) dev us d) x)
       = set (new_cap_addrs m ptr ko)"
   apply (rule set_eqI, rule iffI)
    apply (clarsimp simp: retype_addrs_def)
@@ -824,7 +828,7 @@ lemma obj_relation_retype_addrs_eq:
 done
 
 lemma objBits_le_obj_bits_api:
-  "makeObjectKO dev ty = Some ko \<Longrightarrow>
+  "makeObjectKO dev d ty = Some ko \<Longrightarrow>
    objBitsKO ko \<le> obj_bits_api (APIType_map2 ty) us"
   apply (case_tac ty)
     apply (auto simp: default_arch_object_def archObjSize_def bit_simps
@@ -853,12 +857,12 @@ lemma retype_pspace_relation:
       and vs': "pspace_aligned' s'" "pspace_distinct' s'"
       and  pn: "pspace_no_overlap_range_cover ptr sz s"
       and pn': "pspace_no_overlap' ptr sz s'"
-      and  ko: "makeObjectKO dev ty = Some ko"
+      and  ko: "makeObjectKO dev d ty = Some ko"
       and cover: "range_cover ptr sz (obj_bits_api (APIType_map2 ty) us) n"
-      and orr: "obj_relation_retype (default_object (APIType_map2 ty) dev us) ko"
+      and orr: "obj_relation_retype (default_object (APIType_map2 ty) dev us d) ko"
       and num_r: "m = 2 ^ (obj_bits_api (APIType_map2 ty) us - objBitsKO ko) * n"
   shows
-  "pspace_relation (foldr (\<lambda>p ps. ps(p \<mapsto> default_object (APIType_map2 ty) dev us))
+  "pspace_relation (foldr (\<lambda>p ps. ps(p \<mapsto> default_object (APIType_map2 ty) dev us d))
                               (retype_addrs ptr (APIType_map2 ty) n us) (kheap s))
             (foldr (\<lambda>addr. data_map_insert addr ko) (new_cap_addrs m ptr ko) (ksPSpace s'))"
   (is "pspace_relation ?ps ?ps'")
@@ -877,7 +881,7 @@ proof
     "set (retype_addrs ptr (APIType_map2 ty) n us) \<inter> dom (kheap s) = {}"
     by auto
 
-  note pdom = pspace_dom_upd [OF dom_Int_ra, where ko="default_object (APIType_map2 ty) dev us"]
+  note pdom = pspace_dom_upd [OF dom_Int_ra, where ko="default_object (APIType_map2 ty) dev us d"]
 
   have pdom': "dom ?ps' = dom (ksPSpace s') \<union> set (new_cap_addrs m ptr ko)"
     by (clarsimp simp add: foldr_upd_app_if[folded data_map_insert_def]
@@ -948,79 +952,6 @@ lemma foldr_upd_app_if': "foldr (\<lambda>p ps. ps(p := f p)) as g = (\<lambda>x
   apply (rule ext)
   apply simp
   done
-
-lemma etcb_rel_makeObject: "etcb_relation default_etcb makeObject"
-  apply (simp add: etcb_relation_def default_etcb_def)
-  apply (simp add: makeObject_tcb default_priority_def default_domain_def)
-  done
-
-
-lemma ekh_at_tcb_at: "valid_etcbs_2 ekh kh \<Longrightarrow> ekh x = Some y  \<Longrightarrow> \<exists>tcb. kh x = Some (TCB tcb)"
-  apply (simp add: valid_etcbs_2_def
-                   st_tcb_at_kh_def obj_at_kh_def
-                   is_etcb_at'_def obj_at_def)
-  apply force
-  done
-
-lemma default_etcb_default_domain_futz [simp]:
-  "default_etcb\<lparr>tcb_domain := default_domain\<rparr> = default_etcb"
-unfolding default_etcb_def by simp
-
-lemma retype_ekheap_relation:
-  assumes  sr: "ekheap_relation (ekheap s) (ksPSpace s')"
-      and  sr': "pspace_relation (kheap s) (ksPSpace s')"
-      and  vs: "valid_pspace s" "valid_mdb s"
-      and et: "valid_etcbs s"
-      and vs': "pspace_aligned' s'" "pspace_distinct' s'"
-      and  pn: "pspace_no_overlap_range_cover ptr sz s"
-      and pn': "pspace_no_overlap' ptr sz s'"
-      and  ko: "makeObjectKO dev ty = Some ko"
-      and cover: "range_cover ptr sz (obj_bits_api (APIType_map2 ty) us) n"
-      and orr: "obj_relation_retype (default_object (APIType_map2 ty) dev us) ko"
-      and num_r: "m = 2 ^ (obj_bits_api (APIType_map2 ty) us - objBitsKO ko) * n"
-  shows
-  "ekheap_relation (foldr (\<lambda>p ps. ps(p := default_ext (APIType_map2 ty) default_domain))
-                              (retype_addrs ptr (APIType_map2 ty) n us) (ekheap s))
-            (foldr (\<lambda>addr. data_map_insert addr ko) (new_cap_addrs m ptr ko) (ksPSpace s'))"
-  (is "ekheap_relation ?ps ?ps'")
-  proof -
-  have not_unt: "ty \<noteq> Inr (APIObjectType ArchTypes_H.Untyped)"
-     by (rule makeObjectKO_Untyped[OF ko])
-  show ?thesis
-    apply (case_tac "ty \<noteq> Inr (APIObjectType apiobject_type.TCBObject)")
-     apply (insert ko)
-     apply (cut_tac retype_pspace_relation[OF sr' vs vs' pn pn' ko cover orr num_r])
-     apply (simp add: foldr_upd_app_if' foldr_upd_app_if[folded data_map_insert_def])
-     apply (simp add: obj_relation_retype_addrs_eq[OF not_unt num_r orr cover,symmetric])
-     apply (insert sr)
-     apply (clarsimp simp add: ekheap_relation_def
-                      pspace_relation_def default_ext_def cong: if_cong
-                      split: if_split_asm)
-      subgoal by (clarsimp simp add: makeObjectKO_def APIType_map2_def cong: if_cong
-                              split: sum.splits Structures_H.kernel_object.splits
-                                     arch_kernel_object.splits X64_H.object_type.splits apiobject_type.splits)
-
-     apply (frule ekh_at_tcb_at[OF et])
-     apply (intro impI conjI)
-      apply clarsimp
-      apply (drule_tac x=a in bspec,force)
-      apply (clarsimp simp add: tcb_relation_cut_def split: if_split_asm)
-       apply (case_tac ko,simp_all)
-       apply (clarsimp simp add: makeObjectKO_def cong: if_cong split: sum.splits Structures_H.kernel_object.splits
-                                 arch_kernel_object.splits X64_H.object_type.splits
-                                 apiobject_type.splits if_split_asm)
-      apply (drule_tac x=xa in bspec,simp)
-      subgoal by force
-     subgoal by force
-    apply (simp add: foldr_upd_app_if' foldr_upd_app_if[folded data_map_insert_def])
-    apply (simp add: obj_relation_retype_addrs_eq[OF not_unt num_r orr cover,symmetric])
-    apply (clarsimp simp add: APIType_map2_def default_ext_def ekheap_relation_def
-           default_object_def makeObjectKO_def etcb_rel_makeObject
-           cong: if_cong
-           split: if_split_asm)
-    apply force
-  done
-qed
 
 lemma pspace_no_overlapD':
   "\<lbrakk> ksPSpace s x = Some ko; pspace_no_overlap' p bits s \<rbrakk>
@@ -1196,7 +1127,7 @@ lemma retype_ksPSpace_dom_same:
   fixes x v
   assumes   vs': "pspace_aligned' s'" "pspace_distinct' s'"
   assumes   pn': "pspace_no_overlap' ptr sz s'"
-  assumes    ko: "makeObjectKO dev ty = Some ko"
+  assumes    ko: "makeObjectKO dev d ty = Some ko"
   assumes cover: "range_cover ptr sz (obj_bits_api (APIType_map2 ty) us) n"
   assumes num_r: "m = 2 ^ (obj_bits_api (APIType_map2 ty) us - objBitsKO ko) * n"
   shows
@@ -1235,7 +1166,7 @@ qed
 lemma retype_tcbSchedPrevs_of:
   assumes   vs': "pspace_aligned' s'" "pspace_distinct' s'"
   assumes   pn': "pspace_no_overlap' ptr sz s'"
-  assumes    ko: "makeObjectKO dev ty = Some ko"
+  assumes    ko: "makeObjectKO dev d ty = Some ko"
   assumes cover: "range_cover ptr sz (obj_bits_api (APIType_map2 ty) us) n"
   assumes num_r: "m = 2 ^ (obj_bits_api (APIType_map2 ty) us - objBitsKO ko) * n"
   shows
@@ -1261,7 +1192,7 @@ qed
 lemma retype_tcbSchedNexts_of:
   assumes   vs': "pspace_aligned' s'" "pspace_distinct' s'"
   assumes   pn': "pspace_no_overlap' ptr sz s'"
-  assumes    ko: "makeObjectKO dev ty = Some ko"
+  assumes    ko: "makeObjectKO dev d ty = Some ko"
   assumes cover: "range_cover ptr sz (obj_bits_api (APIType_map2 ty) us) n"
   assumes num_r: "m = 2 ^ (obj_bits_api (APIType_map2 ty) us - objBitsKO ko) * n"
   shows
@@ -1287,7 +1218,7 @@ qed
 lemma retype_inQ:
   assumes   vs': "pspace_aligned' s'" "pspace_distinct' s'"
   assumes   pn': "pspace_no_overlap' ptr sz s'"
-  assumes    ko: "makeObjectKO dev ty = Some ko"
+  assumes    ko: "makeObjectKO dev d ty = Some ko"
   assumes cover: "range_cover ptr sz (obj_bits_api (APIType_map2 ty) us) n"
   assumes num_r: "m = 2 ^ (obj_bits_api (APIType_map2 ty) us - objBitsKO ko) * n"
   shows
@@ -1316,12 +1247,12 @@ lemma retype_ready_queues_relation:
   assumes  rlqr: "ready_queues_relation s s'"
   assumes   vs': "pspace_aligned' s'" "pspace_distinct' s'"
   assumes   pn': "pspace_no_overlap' ptr sz s'"
-  assumes    ko: "makeObjectKO dev ty = Some ko"
+  assumes    ko: "makeObjectKO dev d ty = Some ko"
   assumes cover: "range_cover ptr sz (obj_bits_api (APIType_map2 ty) us) n"
   assumes num_r: "m = 2 ^ (obj_bits_api (APIType_map2 ty) us - objBitsKO ko) * n"
   shows
     "ready_queues_relation
-       (s \<lparr>kheap := foldr (\<lambda>p. data_map_insert p (default_object (APIType_map2 ty) dev us))
+       (s \<lparr>kheap := foldr (\<lambda>p. data_map_insert p (default_object (APIType_map2 ty) dev us d))
                                              (retype_addrs ptr (APIType_map2 ty) n us) (kheap s)\<rparr>)
        (s'\<lparr>ksPSpace := foldr (\<lambda>addr. data_map_insert addr ko) (new_cap_addrs m ptr ko) (ksPSpace s')\<rparr>)"
   using rlqr
@@ -1339,31 +1270,28 @@ lemma retype_state_relation:
   notes data_map_insert_def[simp del]
   assumes  sr:   "(s, s') \<in> state_relation"
       and  vs:   "valid_pspace s" "valid_mdb s"
-      and  et:   "valid_etcbs s" "valid_list s"
+      and  et:   "valid_list s"
       and vs':   "pspace_aligned' s'" "pspace_distinct' s'"
       and  pn:   "pspace_no_overlap_range_cover ptr sz s"
       and pn':   "pspace_no_overlap' ptr sz s'"
       and cover: "range_cover ptr sz (obj_bits_api (APIType_map2 ty) us) n"
-      and  ko:   "makeObjectKO dev ty = Some ko"
+      and  ko:   "makeObjectKO dev d ty = Some ko"
       and api:   "obj_bits_api (APIType_map2 ty) us \<le> sz"
-      and orr:   "obj_relation_retype (default_object (APIType_map2 ty) dev us) ko"
+      and orr:   "obj_relation_retype (default_object (APIType_map2 ty) dev us d) ko"
       and num_r: "m = 2 ^ (obj_bits_api (APIType_map2 ty) us - objBitsKO ko) * n"
   shows
-  "(ekheap_update
-              (\<lambda>_. foldr (\<lambda>p ekh a. if a = p then default_ext (APIType_map2 ty) default_domain else ekh a)
-                    (retype_addrs ptr (APIType_map2 ty) n us) (ekheap s))
-            s
-           \<lparr>kheap :=
-              foldr (\<lambda>p. data_map_insert p (default_object (APIType_map2 ty) dev us))
+  "(s \<lparr>kheap :=
+              foldr (\<lambda>p. data_map_insert p (default_object (APIType_map2 ty) dev us d))
                (retype_addrs ptr (APIType_map2 ty) n us) (kheap s)\<rparr>,
            update_gs (APIType_map2 ty) us (set (retype_addrs ptr (APIType_map2 ty) n us))
             (s'\<lparr>ksPSpace :=
                   foldr (\<lambda>addr. data_map_insert addr ko) (new_cap_addrs m ptr ko)
                    (ksPSpace s')\<rparr>))
           \<in> state_relation"
-  (is "(ekheap_update (\<lambda>_. ?eps) s\<lparr>kheap := ?ps\<rparr>, update_gs _ _ _ (s'\<lparr>ksPSpace := ?ps'\<rparr>))
+  (is "(s\<lparr>kheap := ?ps\<rparr>, update_gs _ _ _ (s'\<lparr>ksPSpace := ?ps'\<rparr>))
        \<in> state_relation")
-  proof (rule state_relation_null_filterE[OF sr refl _ _ _ _ _ _ _ _ vs'], simp_all add: trans_state_update[symmetric] del: trans_state_update)
+  proof (rule state_relation_null_filterE[OF sr refl _ _ _ _ _ _ _ vs'],
+         simp_all add: trans_state_update[symmetric] del: trans_state_update)
 
   have cover':"range_cover ptr sz (objBitsKO ko) m"
     by (rule range_cover_rel[OF cover objBits_le_obj_bits_api[OF ko] num_r])
@@ -1428,12 +1356,6 @@ lemma retype_state_relation:
   thus "pspace_relation ?ps ?ps'"
     by (rule retype_pspace_relation [OF _ vs vs' pn pn' ko cover orr num_r,
         folded data_map_insert_def])
-
-  have "ekheap_relation (ekheap (s)) (ksPSpace s')"
-  using sr by (simp add: state_relation_def)
-
-  thus "ekheap_relation ?eps ?ps'"
-    by (fold fun_upd_apply) (rule retype_ekheap_relation[OF _ pspr vs et(1) vs' pn pn' ko cover orr num_r])
 
   have pn2: "\<forall>a\<in>set ?al. kheap s a = None"
     by (rule ccontr) (clarsimp simp: pspace_no_overlapD1[OF pn _ cover vs(1)])
@@ -1579,208 +1501,6 @@ lemma objBitsKO_gt_0: "0 < objBitsKO ko"
     apply (simp_all add:archObjSize_def pageBits_def)
   done
 
-lemma kheap_ekheap_double_gets:
-  "(\<And>rv erv rv'. \<lbrakk>pspace_relation rv rv'; ekheap_relation erv rv'\<rbrakk>
-                 \<Longrightarrow> corres r (R rv erv) (R' rv') (b rv erv) (d rv')) \<Longrightarrow>
-   corres r (\<lambda>s. R (kheap s) (ekheap s) s) (\<lambda>s. R' (ksPSpace s) s)
-          (do x \<leftarrow> gets kheap; xa \<leftarrow> gets ekheap; b x xa od) (gets ksPSpace >>= d)"
-  apply (rule corres_symb_exec_l)
-     apply (rule corres_guard_imp)
-       apply (rule_tac r'= "\<lambda>erv rv'. ekheap_relation erv rv' \<and> pspace_relation x rv'"
-               in corres_split)
-          apply (subst corres_gets[where P="\<lambda>s. x = kheap s" and P'=\<top>])
-          apply clarsimp
-          apply (simp add: state_relation_def)
-         apply clarsimp
-         apply assumption
-        apply (wp gets_exs_valid | simp)+
-  done
-
-(*
-
-Split out the extended operation that sets the etcb domains.
-
-This allows the existing corres proofs in this file to more-or-less go
-through as they stand.
-
-A more principled fix would be to change the abstract spec and
-generalise init_arch_objects to initialise other object types.
-
-*)
-
-definition retype_region2_ext :: "obj_ref list \<Rightarrow> Structures_A.apiobject_type \<Rightarrow> unit det_ext_monad" where
-  "retype_region2_ext ptrs type \<equiv> modify (\<lambda>s. ekheap_update (foldr (\<lambda>p ekh. (ekh(p := default_ext type default_domain))) ptrs) s)"
-
-crunch retype_region2_ext
-  for all_but_exst[wp]: "all_but_exst P"
-crunch retype_region2_ext
-  for (empty_fail) empty_fail[wp]
-
-end
-
-interpretation retype_region2_ext_extended: is_extended "retype_region2_ext ptrs type"
-  by (unfold_locales; wp)
-
-context begin interpretation Arch . (*FIXME: arch-split*)
-
-definition
- "retype_region2_extra_ext ptrs type \<equiv>
-     when (type = Structures_A.TCBObject) (do
-       cdom \<leftarrow> gets cur_domain;
-       mapM_x (ethread_set (\<lambda>tcb. tcb\<lparr>tcb_domain := cdom\<rparr>)) ptrs
-      od)"
-
-crunch retype_region2_extra_ext
-  for all_but_exst[wp]: "all_but_exst P" (wp: mapM_x_wp)
-crunch retype_region2_extra_ext
-  for (empty_fail) empty_fail[wp] (wp: mapM_x_wp)
-
-end
-
-interpretation retype_region2_extra_ext_extended: is_extended "retype_region2_extra_ext ptrs type"
-  by (unfold_locales; wp)
-
-context begin interpretation Arch . (*FIXME: arch-split*)
-
-definition
-  retype_region2 :: "obj_ref \<Rightarrow> nat \<Rightarrow> nat \<Rightarrow> Structures_A.apiobject_type \<Rightarrow> bool \<Rightarrow> (obj_ref list,'z::state_ext) s_monad"
-where
-  "retype_region2 ptr numObjects o_bits type dev \<equiv> do
-    obj_size \<leftarrow> return $ 2 ^ obj_bits_api type o_bits;
-    ptrs \<leftarrow> return $ map (\<lambda>p. ptr_add ptr (p * obj_size)) [0..< numObjects];
-    when (type \<noteq> Structures_A.Untyped) (do
-      kh \<leftarrow> gets kheap;
-      kh' \<leftarrow> return $ foldr (\<lambda>p kh. kh(p \<mapsto> default_object type dev o_bits)) ptrs kh;
-      do_extended_op (retype_region2_ext ptrs type);
-      modify $ kheap_update (K kh')
-    od);
-    return $ ptrs
-  od"
-
-lemma retype_region_ext_modify_kheap_futz:
-  "(retype_region2_extra_ext ptrs type :: (unit, det_ext) s_monad) >>= (\<lambda>_. modify (kheap_update f))
- = (modify (kheap_update f) >>= (\<lambda>_. retype_region2_extra_ext ptrs type))"
-  apply (clarsimp simp: retype_region_ext_def retype_region2_ext_def retype_region2_extra_ext_def when_def bind_assoc)
-  apply (subst oblivious_modify_swap)
-   defer
-   apply (simp add: bind_assoc)
-  apply (rule oblivious_bind)
-  apply simp
-  apply (rule oblivious_mapM_x)
-  apply (clarsimp simp: ethread_set_def set_eobject_def)
-  apply (rule oblivious_bind)
-   apply (simp add: gets_the_def)
-   apply (rule oblivious_bind)
-    apply (clarsimp simp: get_etcb_def)
-    apply simp
-   apply (simp add: modify_def[symmetric])
-done
-
-lemmas retype_region_ext_modify_kheap_futz' = fun_cong[OF arg_cong[where f=Nondet_Monad.bind, OF retype_region_ext_modify_kheap_futz[symmetric]], simplified bind_assoc]
-
-lemma foldr_upd_app_if_eta_futz:
-  "foldr (\<lambda>p ps. ps(p \<mapsto> f p)) as = (\<lambda>g x. if x \<in> set as then Some (f x) else g x)"
-apply (rule ext)
-apply (rule foldr_upd_app_if)
-done
-
-lemma modify_ekheap_update_comp_futz:
-  "modify (ekheap_update (f \<circ> g)) = modify (ekheap_update g) >>= (K (modify (ekheap_update f)))"
-by (simp add: o_def modify_def bind_def gets_def get_def put_def)
-
-lemma mapM_x_modify_futz:
-  assumes "\<forall>ptr\<in>set ptrs. ekheap s ptr \<noteq> None"
-  shows "mapM_x (ethread_set F) (rev ptrs) s
-       = modify (ekheap_update (foldr (\<lambda>p ekh. ekh(p := Some (F (the (ekh p))))) ptrs)) s" (is "?lhs ptrs s = ?rhs ptrs s")
-using assms
-proof(induct ptrs arbitrary: s)
-  case Nil thus ?case by (simp add: mapM_x_Nil return_def simpler_modify_def)
-next
-  case (Cons ptr ptrs s)
-  have "?rhs (ptr # ptrs) s
-      = (do modify (ekheap_update (foldr (\<lambda>p ekh. ekh(p \<mapsto> F (the (ekh p)))) ptrs));
-            modify (ekheap_update (\<lambda>ekh. ekh(ptr \<mapsto> F (the (ekh ptr)))))
-        od) s"
-    by (simp only: foldr_Cons modify_ekheap_update_comp_futz) simp
-  also have "... = (do ?lhs ptrs;
-                      modify (ekheap_update (\<lambda>ekh. ekh(ptr \<mapsto> F (the (ekh ptr)))))
-                    od) s"
-    apply (rule monad_eq_split_tail)
-     apply simp
-    apply (rule Cons.hyps[symmetric])
-    using Cons.prems
-    apply force
-    done
-  also have "... = ?lhs (ptr # ptrs) s"
-    apply (simp add: mapM_x_append mapM_x_singleton)
-    apply (rule monad_eq_split2[OF refl, where
-                 P="\<lambda>s. \<forall>ptr\<in>set (ptr # ptrs). ekheap s ptr \<noteq> None"
-             and Q="\<lambda>_ s. ekheap s ptr \<noteq> None"])
-      apply (simp add: ethread_set_def
-                       assert_opt_def get_etcb_def gets_the_def gets_def get_def modify_def put_def set_eobject_def
-                       bind_def fail_def return_def split_def
-                split: option.splits)
-     apply ((wp mapM_x_wp[OF _ subset_refl] | simp add: ethread_set_def set_eobject_def)+)[1]
-    using Cons.prems
-    apply force
-    done
-  finally show ?case by (rule sym)
-qed
-
-lemma awkward_fold_futz:
-  "fold (\<lambda>p ekh. ekh(p \<mapsto> the (ekh p)\<lparr>tcb_domain := cur_domain s\<rparr>)) ptrs ekh
- = (\<lambda>x. if x \<in> set ptrs then Some ((the (ekh x))\<lparr>tcb_domain := cur_domain s\<rparr>) else ekh x)"
-by (induct ptrs arbitrary: ekh) (simp_all add: fun_eq_iff)
-
-lemma retype_region2_ext_retype_region_ext_futz:
-  "retype_region2_ext ptrs type >>= (\<lambda>_. retype_region2_extra_ext ptrs type)
- = retype_region_ext ptrs type"
-proof(cases type)
-  case TCBObject
-  have complete_futz:
-    "\<And>F x. modify (ekheap_update (\<lambda>_. F (cur_domain x) (ekheap x))) x = modify (ekheap_update (\<lambda>ekh. F (cur_domain x) ekh)) x"
-    by (simp add: modify_def get_def get_etcb_def put_def bind_def return_def)
-  have second_futz:
-  "\<And>f G.
-   do modify (ekheap_update f);
-      cdom \<leftarrow> gets (\<lambda>s. cur_domain s);
-      G cdom
-   od =
-   do cdom \<leftarrow> gets (\<lambda>s. cur_domain s);
-      modify (ekheap_update f);
-      G cdom
-   od"
-    by (simp add: bind_def gets_def get_def return_def simpler_modify_def)
-  from TCBObject show ?thesis
-    apply (clarsimp simp: retype_region_ext_def retype_region2_ext_def retype_region2_extra_ext_def when_def bind_assoc)
-    apply (clarsimp simp: exec_gets fun_eq_iff)
-    apply (subst complete_futz)
-    apply (simp add: second_futz[simplified] exec_gets)
-    apply (simp add: default_ext_def exec_modify)
-    apply (subst mapM_x_modify_futz[where ptrs="rev ptrs", simplified])
-     apply (simp add: foldr_upd_app_if_eta_futz)
-    apply (simp add: modify_def exec_get put_def o_def)
-    apply (simp add: foldr_upd_app_if_eta_futz foldr_conv_fold awkward_fold_futz)
-    apply (simp cong: if_cong)
-    done
-qed (auto simp: fun_eq_iff retype_region_ext_def retype_region2_ext_def retype_region2_extra_ext_def
-                put_def gets_def get_def bind_def return_def mk_ef_def modify_def foldr_upd_app_if' when_def default_ext_def)
-
-lemma retype_region2_ext_retype_region:
-  "(retype_region ptr numObjects o_bits type dev :: (obj_ref list, det_ext) s_monad)
- = (do ptrs \<leftarrow> retype_region2 ptr numObjects o_bits type dev;
-       retype_region2_extra_ext ptrs type;
-       return ptrs
-    od)"
-apply (clarsimp simp: retype_region_def retype_region2_def when_def bind_assoc)
- apply safe
- defer
- apply (simp add: retype_region2_extra_ext_def)
-apply (subst retype_region_ext_modify_kheap_futz'[simplified bind_assoc])
-apply (subst retype_region2_ext_retype_region_ext_futz[symmetric])
-apply (simp add: bind_assoc)
-done
-
 lemma getObject_tcb_gets:
   "getObject addr >>= (\<lambda>x::tcb. gets proj >>= (\<lambda>y. G x y))
  = gets proj >>= (\<lambda>y. getObject addr >>= (\<lambda>x. G x y))"
@@ -1823,37 +1543,26 @@ next
     done
 qed
 
-(*
-
-The existing proof continues below.
-
-*)
-
-lemma modify_ekheap_update_ekheap:
-  "modify (\<lambda>s. ekheap_update f s) = do s \<leftarrow> gets ekheap; modify (\<lambda>s'. s'\<lparr>ekheap := f s\<rparr>) od"
-by (simp add: modify_def gets_def get_def put_def bind_def return_def split_def fun_eq_iff)
-
 lemma corres_retype':
   assumes    not_zero: "n \<noteq> 0"
   and         aligned: "is_aligned ptr (objBitsKO ko + gbits)"
-  and    obj_bits_api: "obj_bits_api (APIType_map2 ty) us =
-                        objBitsKO ko + gbits"
-  and           check: "(sz < obj_bits_api (APIType_map2 ty)  us)
-                           = (sz < objBitsKO ko + gbits)"
+  and    obj_bits_api: "obj_bits_api (APIType_map2 ty) us = objBitsKO ko + gbits"
+  and           check: "(sz < obj_bits_api (APIType_map2 ty) us) = (sz < objBitsKO ko + gbits)"
   and             usv: "APIType_map2 ty = Structures_A.CapTableObject \<Longrightarrow> 0 < us"
-  and              ko: "makeObjectKO dev ty = Some ko"
+  and              ko: "makeObjectKO dev d ty = Some ko"
   and             orr: "obj_bits_api (APIType_map2 ty) us \<le> sz \<Longrightarrow>
-                        obj_relation_retype
-                          (default_object (APIType_map2 ty) dev us) ko"
+                        obj_relation_retype (default_object (APIType_map2 ty) dev us d) ko"
   and           cover: "range_cover ptr sz (obj_bits_api (APIType_map2 ty) us) n"
   shows "corres (\<lambda>rv rv'. rv' = g rv)
-  (\<lambda>s. valid_pspace s \<and> pspace_no_overlap_range_cover ptr sz s
-     \<and> valid_mdb s \<and> valid_etcbs s \<and> valid_list s)
-  (\<lambda>s. pspace_aligned' s \<and> pspace_distinct' s \<and> pspace_no_overlap' ptr sz s)
-  (retype_region2 ptr n us (APIType_map2 ty) dev)
-  (do addrs \<leftarrow> createObjects ptr n ko gbits;
-      _ \<leftarrow> modify (update_gs (APIType_map2 ty) us (set addrs));
-      return (g addrs) od)"
+                (\<lambda>s. valid_pspace s \<and> pspace_no_overlap_range_cover ptr sz s
+                     \<and> valid_mdb s \<and> valid_list s)
+                (\<lambda>s. pspace_aligned' s \<and> pspace_distinct' s \<and> pspace_no_overlap' ptr sz s
+                      \<and> (ty = Inr (APIObjectType TCBObject) \<longrightarrow> d = ksCurDomain s))
+                (retype_region ptr n us (APIType_map2 ty) dev)
+                (do addrs \<leftarrow> createObjects ptr n ko gbits;
+                    _ \<leftarrow> modify (update_gs (APIType_map2 ty) us (set addrs));
+                    return (g addrs)
+                 od)"
   (is "corres ?r ?P ?P' ?C ?A")
 proof -
   note data_map_insert_def[simp del]
@@ -1931,7 +1640,7 @@ proof -
   have al': "is_aligned ptr (obj_bits_api (APIType_map2 ty) us)"
      by (simp add: obj_bits_api ko)
   show ?thesis
-  apply (simp add: when_def retype_region2_def createObjects'_def
+  apply (simp add: when_def retype_region_def createObjects'_def
                    createObjects_def aligned obj_bits_api[symmetric]
                    ko[symmetric] al' shiftl_t2n data_map_insert_def[symmetric]
                    is_aligned_mask[symmetric] split_def unless_def
@@ -1939,80 +1648,90 @@ proof -
         split del: if_split)
   apply (subst retype_addrs_fold)+
   apply (subst if_P)
-   using ko
-   apply (clarsimp simp: makeObjectKO_def)
-  apply (simp add: bind_assoc retype_region2_ext_def)
-  apply (rule corres_guard_imp)
-    apply (subst modify_ekheap_update_ekheap)
-    apply (simp only: bind_assoc)
-    apply (rule kheap_ekheap_double_gets)
-    apply (rule corres_symb_exec_r)
-       apply (simp add: not_less modify_modify bind_assoc[symmetric]
-                          obj_bits_api[symmetric] shiftl_t2n upto_enum_red'
+    using ko
+    apply (clarsimp simp: makeObjectKO_def)
+   apply (simp add: bind_assoc)
+   apply (rule corres_guard_imp)
+     apply (rule_tac r'=pspace_relation in corres_underlying_split)
+        apply (clarsimp dest!: state_relation_pspace_relation)
+       apply (simp add: gets_def)
+       apply (rule corres_symb_exec_l[rotated])
+          apply (rule exs_valid_get)
+         apply (rule get_sp)
+        apply (simp add: get_def no_fail_def)
+       apply (rule corres_symb_exec_r)
+          apply (simp add: not_less modify_modify bind_assoc[symmetric]
+                           obj_bits_api[symmetric] shiftl_t2n upto_enum_red'
                            range_cover.unat_of_nat_n[OF cover])
-       apply (rule corres_split_nor[OF _ corres_trivial])
-          apply (rename_tac x eps ps)
-          apply (rule_tac P="\<lambda>s. x = kheap s \<and> eps = ekheap (s) \<and> ?P s" and
-                          P'="\<lambda>s. ps = ksPSpace s \<and> ?P' s" in corres_modify)
-          apply (simp add: set_retype_addrs_fold new_caps_adds_fold)
-          apply (erule retype_state_relation[OF _ _ _ _ _ _ _ _ _ cover _ _ orr],
-                 simp_all add: ko not_zero obj_bits_api
-                               bound[simplified obj_bits_api ko])[1]
-         apply (clarsimp simp: retype_addrs_fold[symmetric] ptr_add_def upto_enum_red' not_zero'
-                               range_cover.unat_of_nat_n[OF cover] word_le_sub1
-                         simp del: word_of_nat_eq_0_iff)
-         apply (rule_tac f=g in arg_cong)
-         apply clarsimp
-        apply wp+
-      apply (clarsimp split: option.splits)
-      apply (intro conjI impI)
-       apply (clarsimp|wp)+
-     apply (clarsimp split: option.splits)
-     apply wpsimp
-    apply (clarsimp split: option.splits)
-    apply (intro conjI impI)
-     apply wp
-    apply (clarsimp simp:lookupAround2_char1)
-    apply wp
-    apply (clarsimp simp: obj_bits_api ko)
-    apply (drule(1) pspace_no_overlap_disjoint')
-    apply (rule_tac x1 = a in ccontr[OF in_empty_interE])
-      apply simp
-     apply (clarsimp simp: not_less shiftL_nat)
-     apply (erule order_trans)
-     apply (subst p_assoc_help)
-     apply (subst word_plus_and_or_coroll2[symmetric,where w = "mask sz"])
-     apply (subst add.commute)
-     apply (subst add.assoc)
-     apply (rule word_plus_mono_right)
-      using cover
-      apply -
-      apply (rule iffD2[OF word_le_nat_alt])
-      apply (subst word_of_nat_minus)
-       using not_zero
-       apply simp
-      apply (rule le_trans[OF unat_plus_gt])
-      apply simp
-      apply (subst unat_minus_one)
-       apply (subst mult.commute)
-       apply (rule word_power_nonzero_64)
-         apply (rule of_nat_less_pow_64[OF n_estimate])
-         apply (simp add:word_bits_def objBitsKO_gt_0 ko)
-        apply (simp add:range_cover_def obj_bits_api ko word_bits_def)
-       apply (cut_tac not_zero',clarsimp simp:ko)
-      apply(clarsimp simp:field_simps ko)
-      apply (subst unat_sub[OF word_1_le_power])
-       apply (simp add:range_cover_def)
-      apply (subst diff_add_assoc[symmetric])
-       apply (cut_tac unat_of_nat_n',simp add:ko)
-      apply (clarsimp simp: obj_bits_api ko)
-      apply (rule diff_le_mono)
-      apply (frule range_cover.range_cover_compare_bound)
-      apply (cut_tac obj_bits_api unat_of_nat_shift')
-      apply (clarsimp simp:add.commute range_cover_def ko)
-     apply (rule is_aligned_no_wrap'[OF is_aligned_neg_mask,OF le_refl ])
-     apply (simp add:range_cover_def domI)+
-  done
+          apply (rule corres_guard_imp)
+            apply (rule corres_split_nor[OF _ corres_trivial])
+               apply (rename_tac ps ps' sa)
+               apply (rule_tac P="\<lambda>s. ps = kheap s \<and> sa = s \<and> ?P s" and
+                               P'="\<lambda>s. ps' = ksPSpace s \<and> ?P' s" in corres_modify)
+               apply(frule curdomain_relation[THEN sym])
+               apply (simp add: set_retype_addrs_fold new_caps_adds_fold)
+               apply (drule retype_state_relation[OF _ _ _ _ _ _ _ _ cover _ _ orr],
+                      simp_all add: ko not_zero obj_bits_api
+                                    bound[simplified obj_bits_api ko])[1]
+               apply (cases ty; simp; rename_tac tp; case_tac tp;
+                      clarsimp simp: default_object_def APIType_map2_def
+                              split: arch_kernel_object.splits apiobject_type.splits)
+              apply (clarsimp simp: retype_addrs_fold[symmetric] ptr_add_def upto_enum_red' not_zero'
+                                    range_cover.unat_of_nat_n[OF cover] word_le_sub1)
+              apply (rule_tac f=g in arg_cong)
+              apply clarsimp
+             apply wpsimp+
+           apply simp+
+         apply (clarsimp split: option.splits)
+         apply (intro conjI impI)
+          apply (clarsimp|wp)+
+        apply (clarsimp split: option.splits)
+        apply wpsimp
+       apply (clarsimp split: option.splits)
+       apply (intro conjI impI)
+        apply wp
+       apply (clarsimp simp:lookupAround2_char1)
+       apply wp
+       apply (clarsimp simp: obj_bits_api ko)
+       apply (drule(1) pspace_no_overlap_disjoint')
+       apply (rule_tac x1 = a in ccontr[OF in_empty_interE])
+         apply simp
+        apply (clarsimp simp: not_less shiftL_nat)
+        apply (erule order_trans)
+        apply (subst p_assoc_help)
+        apply (subst word_plus_and_or_coroll2[symmetric,where w = "mask sz"])
+        apply (subst add.commute)
+        apply (subst add.assoc)
+        apply (rule word_plus_mono_right)
+         using cover
+         apply -
+         apply (rule iffD2[OF word_le_nat_alt])
+         apply (subst word_of_nat_minus)
+          using not_zero
+          apply simp
+         apply (rule le_trans[OF unat_plus_gt])
+         apply simp
+         apply (subst unat_minus_one)
+          apply (subst mult.commute)
+          apply (rule word_power_nonzero_64)
+            apply (rule of_nat_less_pow_64[OF n_estimate])
+            apply (simp add:word_bits_def objBitsKO_gt_0 ko)
+           apply (simp add:range_cover_def obj_bits_api ko word_bits_def)
+          apply (cut_tac not_zero',clarsimp simp:ko)
+         apply(clarsimp simp:field_simps ko)
+         apply (subst unat_sub[OF word_1_le_power])
+          apply (simp add:range_cover_def)
+         apply (subst diff_add_assoc[symmetric])
+          apply (cut_tac unat_of_nat_n',simp add:ko)
+         apply (clarsimp simp: obj_bits_api ko)
+         apply (rule diff_le_mono)
+         apply (frule range_cover.range_cover_compare_bound)
+         apply (cut_tac obj_bits_api unat_of_nat_shift')
+         apply (clarsimp simp:add.commute range_cover_def ko)
+        apply (rule is_aligned_no_wrap'[OF is_aligned_neg_mask,OF le_refl ])
+        apply (simp add:range_cover_def domI)+
+      apply wpsimp+
+   done
 qed
 
 lemma createObjects_corres':
@@ -2502,15 +2221,16 @@ proof -
                              fromIntegral_def toInteger_nat fromInteger_nat APIType_capBits_def curDomain_def
                       split: X64_H.object_type.splits)
         apply (wp mapM_x_wp' hoare_vcg_const_Ball_lift)+
-        apply (rule hoare_post_imp)
-         prefer 2
-         apply (rule createObjects_obj_at [where 'a = "tcb",OF _ not_0])
-          using cover
-          apply (clarsimp simp: X64_H.toAPIType_def APIType_capBits_def objBits_simps
-                         split: X64_H.object_type.splits)
-         apply (simp add: projectKOs)
-        apply (clarsimp simp: valid_cap'_def objBits_simps)
-        apply (fastforce intro: capAligned_tcbI)
+         apply (rule hoare_post_imp)
+          prefer 2
+          apply (rule createObjects_obj_at [where 'a = "tcb",OF _ not_0])
+           using cover
+           apply (clarsimp simp: X64_H.toAPIType_def APIType_capBits_def objBits_simps
+                          split: X64_H.object_type.splits)
+           apply (simp add: projectKOs)+
+         apply (clarsimp simp: valid_cap'_def objBits_simps)
+         apply (fastforce intro: capAligned_tcbI)
+        apply wp
         done
     next
       case EndpointObject with Some cover ct show ?thesis
@@ -2591,7 +2311,7 @@ lemma other_objs_default_relation:
   "\<lbrakk> case ty of Structures_A.EndpointObject \<Rightarrow> ko = injectKO (makeObject :: endpoint)
              | Structures_A.NotificationObject \<Rightarrow> ko = injectKO (makeObject :: Structures_H.notification)
              | _ \<Rightarrow> False \<rbrakk> \<Longrightarrow>
-    obj_relation_retype (default_object ty dev n) ko"
+    obj_relation_retype (default_object ty dev n d) ko"
   apply (rule obj_relation_retype_other_obj)
    apply (clarsimp simp: default_object_def
                          is_other_obj_relation_type_def
@@ -2611,15 +2331,17 @@ lemma other_objs_default_relation:
   done
 
 lemma tcb_relation_retype:
-  "obj_relation_retype (default_object Structures_A.TCBObject dev n) (KOTCB makeObject)"
-  by (clarsimp simp: default_object_def obj_relation_retype_def tcb_relation_def default_tcb_def
+  "obj_relation_retype (default_object Structures_A.TCBObject dev n d)
+                       (KOTCB (tcbDomain_update (\<lambda>_. d) makeObject))"
+  by (clarsimp simp: tcb_relation_cut_def default_object_def obj_relation_retype_def
+                     tcb_relation_def default_tcb_def
                      makeObject_tcb makeObject_cte new_context_def newContext_def
-                     fault_rel_optionation_def initContext_def default_arch_tcb_def newArchTCB_def
-                     arch_tcb_relation_def objBits_simps' tcb_relation_cut_def)
+                     fault_rel_optionation_def initContext_def default_priority_def
+                     default_arch_tcb_def newArchTCB_def arch_tcb_relation_def objBits_simps')
 
 lemma captable_relation_retype:
   "n < word_bits \<Longrightarrow>
-   obj_relation_retype (default_object Structures_A.CapTableObject dev n) (KOCTE makeObject)"
+   obj_relation_retype (default_object Structures_A.CapTableObject dev n d) (KOCTE makeObject)"
   apply (clarsimp simp: obj_relation_retype_def default_object_def
                         wf_empty_bits objBits_simps'
                         dom_empty_cnode ex_with_length cte_level_bits_def)
@@ -2637,7 +2359,7 @@ lemma captable_relation_retype:
   done
 
 lemma pagetable_relation_retype:
-  "obj_relation_retype (default_object (ArchObject PageTableObj) dev n)
+  "obj_relation_retype (default_object (ArchObject PageTableObj) dev n d)
                        (KOArch (KOPTE makeObject))"
   apply (simp add: default_object_def default_arch_object_def
                    makeObject_pte obj_relation_retype_def
@@ -2651,7 +2373,7 @@ lemma pagetable_relation_retype:
   done
 
 lemma pagedirectory_relation_retype:
-  "obj_relation_retype (default_object (ArchObject PageDirectoryObj) dev n)
+  "obj_relation_retype (default_object (ArchObject PageDirectoryObj) dev n d)
                        (KOArch (KOPDE makeObject))"
   apply (simp add: default_object_def default_arch_object_def
                    makeObject_pde obj_relation_retype_def
@@ -2665,7 +2387,7 @@ lemma pagedirectory_relation_retype:
   done
 
 lemma pdpt_relation_retype:
-  "obj_relation_retype (default_object (ArchObject PDPTObj) dev n)
+  "obj_relation_retype (default_object (ArchObject PDPTObj) dev n d)
                        (KOArch (KOPDPTE makeObject))"
   apply (simp add: default_object_def default_arch_object_def
                    makeObject_pdpte obj_relation_retype_def
@@ -2679,7 +2401,7 @@ lemma pdpt_relation_retype:
   done
 
 lemma pml4_relation_retype:
-  "obj_relation_retype (default_object (ArchObject PML4Obj) dev n)
+  "obj_relation_retype (default_object (ArchObject PML4Obj) dev n d)
                        (KOArch (KOPML4E makeObject))"
   apply (simp add: default_object_def default_arch_object_def
                    makeObject_pml4e obj_relation_retype_def
@@ -2696,20 +2418,21 @@ lemmas makeObjectKO_simps = makeObjectKO_def[split_simps X64_H.object_type.split
  apiobject_type.split sum.split kernel_object.split ]
 
 lemma corres_retype:
-  assumes         not_zero: "n \<noteq> 0"
+  assumes    not_zero: "n \<noteq> 0"
   and         aligned: "is_aligned ptr (objBitsKO ko + gbits)"
   and    obj_bits_api: "obj_bits_api (APIType_map2 ty) us = objBitsKO ko + gbits"
   and              tp: "APIType_map2 ty \<in> no_gs_types"
-  and              ko: "makeObjectKO dev ty = Some ko"
+  and              ko: "makeObjectKO dev d ty = Some ko"
   and             orr: "obj_bits_api (APIType_map2 ty) us \<le> sz \<Longrightarrow>
-                        obj_relation_retype (default_object (APIType_map2 ty) dev us) ko"
+                        obj_relation_retype (default_object (APIType_map2 ty) dev us d) ko"
   and           cover: "range_cover ptr sz (obj_bits_api (APIType_map2 ty) us) n"
   shows "corres (=)
   (\<lambda>s. valid_pspace s \<and> pspace_no_overlap_range_cover ptr sz s
-     \<and> valid_mdb s \<and> valid_etcbs s \<and> valid_list s)
+     \<and> valid_mdb s \<and> valid_list s)
   (\<lambda>s. pspace_aligned' s \<and> pspace_distinct' s \<and> pspace_no_overlap' ptr sz s
-       \<and> (\<exists>val. ko = injectKO val))
-  (retype_region2 ptr n us (APIType_map2 ty) dev) (createObjects ptr n ko gbits)"
+       \<and> (\<exists>val. ko = injectKO val)
+       \<and> (ty = Inr (APIObjectType TCBObject) \<longrightarrow> d = ksCurDomain s))
+  (retype_region ptr n us (APIType_map2 ty) dev) (createObjects ptr n ko gbits)"
   apply (rule corres_guard_imp)
     apply (rule_tac F = "(\<exists>val. ko = injectKO val)" in corres_gen_asm2)
     apply (erule exE)
@@ -3256,7 +2979,8 @@ proof -
 qed
 
 lemma createObjects_valid_pspace':
-  assumes  mko: "makeObjectKO dev ty = Some val"
+  assumes  mko: "makeObjectKO dev d ty = Some val"
+  and    max_d: "ty = Inr (APIObjectType TCBObject) \<longrightarrow> d \<le> maxDomain"
   and    not_0: "n \<noteq> 0"
   and    cover: "range_cover ptr sz (objBitsKO val + gbits) n"
   and    sz_limit: "sz \<le> maxUntypedSizeBits"
@@ -3366,7 +3090,7 @@ proof (intro conjI impI)
                    elim!: ranE
                    split: if_split_asm)
      apply (insert sym[OF mko])[1]
-     apply (clarsimp simp: makeObjectKO_def
+     apply (clarsimp simp: makeObjectKO_def max_d
                     split: bool.split_asm sum.split_asm
                            X64_H.object_type.split_asm
                            apiobject_type.split_asm
@@ -3482,7 +3206,8 @@ abbreviation
  "injectKOS \<equiv> (injectKO :: ('a :: pspace_storable) \<Rightarrow> kernel_object)"
 
 lemma createObjects_valid_pspace_untyped':
-  assumes  mko: "makeObjectKO dev ty = Some val"
+  assumes  mko: "makeObjectKO dev d ty = Some val"
+  and    max_d: "ty = Inr (APIObjectType TCBObject) \<longrightarrow> d \<le> maxDomain"
   and    not_0: "n \<noteq> 0"
   and    cover: "range_cover ptr sz (objBitsKO val + gbits) n"
   and    sz_limit: "sz \<le> maxUntypedSizeBits"
@@ -3491,7 +3216,7 @@ lemma createObjects_valid_pspace_untyped':
   shows "\<lbrace>\<lambda>s. pspace_no_overlap' ptr sz s \<and> valid_pspace' s \<and> caps_no_overlap'' ptr sz s \<and> ptr \<noteq> 0
             \<and> caps_overlap_reserved' {ptr .. ptr + of_nat (n * 2^gbits * 2 ^ objBitsKO val ) - 1} s \<rbrace>
   createObjects' ptr n val gbits \<lbrace>\<lambda>r. valid_pspace'\<rbrace>"
-  apply (wp createObjects_valid_pspace' [OF mko not_0 cover sz_limit ptr_cn ptr_km])
+  apply (wp createObjects_valid_pspace' [OF mko max_d not_0 cover sz_limit ptr_cn ptr_km])
   apply simp
   done
 
@@ -3713,15 +3438,12 @@ lemma createNewCaps_cte_wp_at2:
      createNewCaps ty ptr n objsz dev
    \<lbrace>\<lambda>rv s. P (cte_wp_at' P' p s)\<rbrace>"
   including classic_wp_pre
-  apply (simp add: createNewCaps_def createObjects_def X64_H.toAPIType_def
-           split del: if_split)
-  apply (case_tac ty; simp add: createNewCaps_def createObjects_def Arch_createNewCaps_def
-                           split del: if_split cong: if_cong)
+  unfolding createNewCaps_def Arch_createNewCaps_def createObjects_def X64_H.toAPIType_def
+  apply (case_tac ty; simp split del: if_split cong: if_cong)
         apply (rename_tac apiobject_type)
         apply (case_tac apiobject_type; simp split del: if_split)
-            apply (rule hoare_pre, wp, simp add:createObjects_def)
-           apply ((wp createObjects_orig_cte_wp_at2'[where sz = sz]
-                     mapM_x_wp' threadSet_cte_wp_at2')+
+            apply (rule hoare_pre, wp, simp add: createObjects_def)
+           apply ((wp createObjects_orig_cte_wp_at2'[where sz = sz] mapM_x_wp')
                    | assumption
                    | clarsimp simp: APIType_capBits_def projectKO_opts_defs
                                     makeObject_tcb tcb_cte_cases_def cteSizeBits_def
@@ -4234,10 +3956,9 @@ lemma createNewCaps_ko_wp_atQ':
                    \<longrightarrow> (\<forall>pml4e_y :: pml4e. P' (injectKO pml4e_y)))
        and K (\<forall>d (tcb_x :: tcb). \<not>tcbQueued tcb_x \<and> tcbState tcb_x = Inactive
                    \<longrightarrow> P' (injectKO (tcb_x \<lparr> tcbDomain := d \<rparr>)) = P' (injectKO tcb_x))
-       and K (\<forall>v. makeObjectKO d (Inr ty) = Some v
-                   \<longrightarrow> P' v \<longrightarrow> P True)\<rbrace>
-     createNewCaps ty ptr n us d
-   \<lbrace>\<lambda>rv s. P (ko_wp_at' P' p s)\<rbrace>"
+       and (\<lambda>s. \<forall>v. makeObjectKO dev (ksCurDomain s) (Inr ty) = Some v \<longrightarrow> P' v \<longrightarrow> P True)\<rbrace>
+     createNewCaps ty ptr n us dev
+   \<lbrace>\<lambda>_ s. P (ko_wp_at' P' p s)\<rbrace>"
   apply (rule hoare_name_pre_state)
   apply (clarsimp simp: createNewCaps_def X64_H.toAPIType_def
              split del: if_split)
@@ -4396,7 +4117,7 @@ lemma createNewCaps_idle'[wp]:
          apply (rename_tac apiobject_type)
          apply (case_tac apiobject_type, simp_all split del: if_split)[1]
              apply wpsimp
-            apply (wpsimp wp: mapM_x_wp' createObjects_idle' threadSet_idle'
+            apply (wpsimp wp: mapM_x_wp' createObjects_idle'
                    | simp add: projectKO_opt_tcb projectKO_opt_cte
                                makeObject_cte makeObject_tcb archObjSize_def
                                tcb_cte_cases_def objBitsKO_def APIType_capBits_def
@@ -4620,22 +4341,20 @@ lemma createNewCaps_sched_queues:
      createNewCaps ty ptr n us dev
      \<lbrace>\<lambda>_ s. P (tcbSchedNexts_of s) (tcbSchedPrevs_of s)\<rbrace>"
   unfolding createNewCaps_def
-  apply (clarsimp simp: X64_H.toAPIType_def
-             split del: if_split)
+  apply (clarsimp simp: X64_H.toAPIType_def split del: if_split)
   apply (cases ty; simp add: createNewCaps_def Arch_createNewCaps_def
                         split del: if_split)
         apply (rename_tac apiobject_type)
         apply (case_tac apiobject_type; simp split del: if_split)
-            apply (rule hoare_pre, wp, simp)
+            apply (wp, simp)
            apply (insert cover not_0)
-           apply (wpsimp wp: mapM_x_wp' createObjects_sched_queues
-                       simp: curDomain_def)
-           by (wpsimp wp: mapM_x_wp' createObjects_sched_queues[simplified o_def]
-                          threadSet_sched_pointers
-               | simp add: objBitsKO_def APIType_capBits_def valid_pspace'_def makeObject_tcb
-                           objBits_def archObjSize_def createObjects_def
-                           bit_simps
-               | intro conjI impI)+
+           apply (wpsimp wp: mapM_x_wp' createObjects_sched_queues threadSet_sched_pointers
+                         simp: curDomain_def createObjects_def)
+           apply (simp add: valid_pspace'_def objBits_simps APIType_capBits_def makeObject_tcb)
+          by (wpsimp wp: mapM_x_wp' createObjects_sched_queues threadSet_sched_pointers
+                     simp: createObjects_def valid_pspace'_def objBits_simps APIType_capBits_def
+                     split_del: if_split,
+              fastforce simp add: mult_2 add_ac bit_simps)+
 
 lemma createObjects_valid_sched_pointers:
   "\<lbrace>\<lambda>s. valid_sched_pointers s
@@ -4683,11 +4402,14 @@ lemma createNewCaps_valid_pspace:
   and      sz_limit: "sz \<le> maxUntypedSizeBits"
   and      ptr_cn: "canonical_address (ptr && ~~ mask sz)"
   and      ptr_km: "ptr && ~~ mask sz \<in> kernel_mappings"
-  shows "\<lbrace>\<lambda>s. pspace_no_overlap' ptr sz s \<and> valid_pspace' s
-  \<and> caps_no_overlap'' ptr sz s \<and> ptr \<noteq> 0 \<and> caps_overlap_reserved' {ptr..ptr + of_nat n * 2^(APIType_capBits ty us) - 1} s \<and> ksCurDomain s \<le> maxDomain\<rbrace>
-  createNewCaps ty ptr n us dev \<lbrace>\<lambda>r. valid_pspace'\<rbrace>"
+  shows
+  "\<lbrace>\<lambda>s. pspace_no_overlap' ptr sz s \<and> valid_pspace' s
+     \<and> caps_no_overlap'' ptr sz s \<and> ptr \<noteq> 0 \<and> caps_overlap_reserved' {ptr..ptr + of_nat n * 2^(APIType_capBits ty us) - 1} s
+     \<and> ksCurDomain s \<le> maxDomain\<rbrace>
+   createNewCaps ty ptr n us dev
+   \<lbrace>\<lambda>r. valid_pspace'\<rbrace>"
   unfolding createNewCaps_def Arch_createNewCaps_def
-  using valid_obj_makeObject_rules ptr_cn sz_limit ptr_km
+  using valid_obj_makeObject_rules sz_limit ptr_cn ptr_km
   apply (clarsimp simp: X64_H.toAPIType_def
              split del: if_split cong: option.case_cong)
   apply (cases ty, simp_all split del: if_split)
@@ -4695,13 +4417,18 @@ lemma createNewCaps_valid_pspace:
         apply (case_tac apiobject_type, simp_all split del: if_split)
             apply (rule hoare_pre, wp, clarsimp)
            apply (insert cover)
-           apply (wp createObjects_valid_pspace_untyped' [OF _ not_0 , where ty="Inr ty" and sz = sz]
-                     mapM_x_threadSet_valid_pspace mapM_x_wp'
-                 | simp add: makeObjectKO_def archObjSize_def APIType_capBits_def
-                             objBits_simps not_0 createObjects_def curDomain_def bit_simps
-                 | intro conjI impI
-                 | simp add: power_add field_simps)+
-  done
+           (* for TCBObject, we need to know a bit more about tcbDomain *)
+           apply (simp add: curDomain_def)
+           apply (rule bind_wp[OF _ gets_sp])
+           apply (clarsimp simp: createObjects_def)
+           apply (rule hoare_assume_pre)
+           by (wp createObjects_valid_pspace_untyped' [OF _ _ not_0 , where ty="Inr ty" and sz = sz]
+                  mapM_x_threadSet_valid_pspace mapM_x_wp'
+               | simp add: makeObjectKO_def APIType_capBits_def
+                           objBits_simps not_0 createObjects_def curDomain_def
+               | intro conjI impI
+               | simp add: power_add field_simps mult_2_right
+               | simp add: bit_simps)+
 
 lemma copyGlobalMappings_inv[wp]:
   "\<lbrace>\<lambda>s. P (ksMachineState s)\<rbrace>
@@ -4917,7 +4644,7 @@ crunch createNewCaps
   (wp: mapM_x_wp' simp: crunch_simps)
 
 lemma createObjects_null_filter':
-  "\<lbrace>\<lambda>s. P (null_filter' (ctes_of s)) \<and> makeObjectKO dev ty = Some val \<and>
+  "\<lbrace>\<lambda>s. P (null_filter' (ctes_of s)) \<and> makeObjectKO dev d ty = Some val \<and>
         range_cover ptr sz (objBitsKO val + gbits) n \<and> n \<noteq> 0 \<and>
         pspace_aligned' s \<and> pspace_distinct' s \<and> pspace_no_overlap' ptr sz s\<rbrace>
    createObjects' ptr n val gbits
@@ -5338,7 +5065,7 @@ crunch createObjects
   (simp: unless_def)
 
 lemma createObjects_untyped_ranges_zero':
-  assumes moKO: "makeObjectKO dev ty = Some val"
+  assumes moKO: "makeObjectKO dev d ty = Some val"
   shows
   "\<lbrace>ct_active' and valid_pspace' and pspace_no_overlap' ptr sz
        and untyped_ranges_zero'
@@ -5370,9 +5097,10 @@ lemma sym_refs_empty[simp]:
   by simp
 
 lemma createObjects_no_cte_invs:
-  assumes moKO: "makeObjectKO dev ty = Some val"
+  assumes moKO: "makeObjectKO dev d ty = Some val"
   assumes no_cte: "\<And>c. projectKO_opt val \<noteq> Some (c::cte)"
   assumes no_tcb: "\<And>t. projectKO_opt val \<noteq> Some (t::tcb)"
+  and     mdom: "ty = Inr (APIObjectType ArchTypes_H.apiobject_type.TCBObject) \<longrightarrow> d \<le> maxDomain"
   shows
   "\<lbrace>\<lambda>s. range_cover ptr sz ((objBitsKO val) + gbits) n \<and> n \<noteq> 0
         \<and> sz \<le> maxUntypedSizeBits \<and> canonical_address (ptr && ~~ mask sz)
@@ -5457,23 +5185,21 @@ qed
 lemma corres_retype_update_gsI:
   assumes not_zero: "n \<noteq> 0"
   and      aligned: "is_aligned ptr (objBitsKO ko + gbits)"
-  and obj_bits_api: "obj_bits_api (APIType_map2 ty) us =
-                     objBitsKO ko + gbits"
-  and        check: "sz < obj_bits_api (APIType_map2 ty) us \<longleftrightarrow>
-                     sz < objBitsKO ko + gbits"
+  and obj_bits_api: "obj_bits_api (APIType_map2 ty) us = objBitsKO ko + gbits"
+  and        check: "sz < obj_bits_api (APIType_map2 ty) us \<longleftrightarrow> sz < objBitsKO ko + gbits"
   and          usv: "APIType_map2 ty = Structures_A.CapTableObject \<Longrightarrow> 0 < us"
-  and           ko: "makeObjectKO dev ty = Some ko"
+  and           ko: "makeObjectKO dev d ty = Some ko"
   and          orr: "obj_bits_api (APIType_map2 ty) us \<le> sz \<Longrightarrow>
-                     obj_relation_retype
-                       (default_object (APIType_map2 ty) dev us) ko"
+                     obj_relation_retype (default_object (APIType_map2 ty) dev us d) ko"
   and        cover: "range_cover ptr sz (obj_bits_api (APIType_map2 ty) us) n"
   and            f: "f = update_gs (APIType_map2 ty) us"
   shows "corres (\<lambda>rv rv'. rv' = g rv)
          (\<lambda>s. valid_pspace s \<and> pspace_no_overlap_range_cover ptr sz s
-            \<and> valid_mdb s \<and> valid_etcbs s \<and> valid_list s)
+            \<and> valid_mdb s \<and> valid_list s)
          (\<lambda>s. pspace_aligned' s \<and> pspace_distinct' s \<and>
-              pspace_no_overlap' ptr sz s)
-         (retype_region2 ptr n us (APIType_map2 ty) dev)
+              pspace_no_overlap' ptr sz s \<and>
+              (ty = Inr (APIObjectType TCBObject) \<longrightarrow> d = ksCurDomain s))
+         (retype_region ptr n us (APIType_map2 ty) dev)
          (do addrs \<leftarrow> createObjects ptr n ko gbits;
              _ \<leftarrow> modify (f (set addrs));
              return (g addrs)
@@ -5484,71 +5210,13 @@ lemma corres_retype_update_gsI:
 lemma gcd_corres: "corres (=) \<top> \<top> (gets cur_domain) curDomain"
   by (simp add: curDomain_def state_relation_def)
 
-lemma retype_region2_extra_ext_mapM_x_corres:
-  shows "corres dc
-           (valid_etcbs and (\<lambda>s. \<forall>addr\<in>set addrs. tcb_at addr s))
-           (\<lambda>s. \<forall>addr\<in>set addrs. obj_at' (Not \<circ> tcbQueued) addr s)
-           (retype_region2_extra_ext addrs Structures_A.apiobject_type.TCBObject)
-           (mapM_x (\<lambda>addr. do cdom \<leftarrow> curDomain;
-                              threadSet (tcbDomain_update (\<lambda>_. cdom)) addr
-                           od)
-             addrs)"
-  apply (rule corres_guard_imp)
-    apply (simp add: retype_region2_extra_ext_def curDomain_mapM_x_futz[symmetric] when_def)
-    apply (rule corres_split_eqr[OF gcd_corres])
-      apply (rule_tac S="Id \<inter> {(x, y). x \<in> set addrs}"
-                  and P="\<lambda>s. (\<forall>t \<in> set addrs. tcb_at t s) \<and> valid_etcbs s"
-                  and P'="\<lambda>s. \<forall>t \<in> set addrs. obj_at' (Not \<circ> tcbQueued) t s"
-                   in corres_mapM_x)
-          apply simp
-          apply (rule corres_guard_imp)
-            apply (rule ethread_set_corres, simp_all add: etcb_relation_def non_exst_same_def)[1]
-            apply (case_tac tcb')
-            apply simp
-           apply fastforce
-          apply (fastforce simp: obj_at'_def)
-         apply (wp hoare_vcg_ball_lift | simp)+
-        apply (clarsimp simp: obj_at'_def)
-       apply fastforce
-      apply auto[1]
-     apply (wp | simp add: curDomain_def)+
-  done
-
-lemma retype_region2_extra_ext_trivial:
-  "ty \<noteq> APIType_map2 (Inr (APIObjectType apiobject_type.TCBObject))
-      \<Longrightarrow> retype_region2_extra_ext ptrs ty = return ()"
-by (simp add: retype_region2_extra_ext_def when_def APIType_map2_def)
-
-lemma retype_region2_retype_region_PML4Obj:
-  "retype_region ptr n us (APIType_map2 (Inr PML4Object)) dev =
-  (retype_region2 ptr n us (APIType_map2 (Inr PML4Object)) dev :: obj_ref list det_ext_monad)"
-  by (simp add: retype_region2_ext_retype_region retype_region2_extra_ext_def when_def
-                APIType_map2_def)
-
-lemma retype_region2_valid_etcbs[wp]:"\<lbrace>valid_etcbs\<rbrace> retype_region2 a b c d dev \<lbrace>\<lambda>_. valid_etcbs\<rbrace>"
-  apply (simp add: retype_region2_def)
-  apply (simp add: retype_region2_ext_def bind_assoc)
-  apply wp
-  apply (clarsimp simp del: fun_upd_apply)
-  apply (blast intro: valid_etcb_fold_update)
-  done
-
-lemma retype_region2_obj_at:
-  assumes tytcb: "ty = Structures_A.apiobject_type.TCBObject"
-  shows "\<lbrace>\<top>\<rbrace> retype_region2 ptr n us ty dev \<lbrace>\<lambda>rv s. \<forall>x \<in> set rv. tcb_at x s\<rbrace>"
-  using tytcb unfolding retype_region2_def
-  apply (simp only: return_bind bind_return foldr_upd_app_if fun_app_def K_bind_def)
-  apply (wp dxo_wp_weak | simp)+
-  apply (auto simp: obj_at_def default_object_def is_tcb_def)
-  done
-
-lemma createObjects_Not_tcbQueued:
+lemma createObjects_tcb_at':
   "\<lbrakk>range_cover ptr sz (objBitsKO (injectKOS (makeObject::tcb))) n; n \<noteq> 0\<rbrakk> \<Longrightarrow>
    \<lbrace>\<lambda>s. pspace_no_overlap' ptr sz s \<and> pspace_aligned' s \<and> pspace_distinct' s\<rbrace>
    createObjects ptr n (KOTCB makeObject) 0
-   \<lbrace>\<lambda>ptrs s. \<forall>addr\<in>set ptrs. obj_at' (Not \<circ> tcbQueued) addr s\<rbrace>"
+   \<lbrace>\<lambda>ptrs s. \<forall>addr\<in>set ptrs. tcb_at' addr s\<rbrace>"
   apply (rule hoare_strengthen_post[OF createObjects_ko_at_strg[where val = "(makeObject :: tcb)"]])
-  apply (auto simp: obj_at'_def projectKOs project_inject objBitsKO_def objBits_def makeObject_tcb)
+  apply (auto simp: obj_at'_def project_inject objBitsKO_def objBits_def makeObject_tcb)
   done
 
 lemma init_arch_objects_APIType_map2_noop:
@@ -5610,7 +5278,7 @@ lemma createObjects_pml4_at:
 lemma corres_retype_region_createNewCaps:
   "corres ((\<lambda>r r'. length r = length r' \<and> list_all2 cap_relation r r')
                \<circ> map (\<lambda>ref. default_cap (APIType_map2 (Inr ty)) ref us dev))
-            (\<lambda>s. valid_pspace s \<and> valid_mdb s \<and> valid_etcbs s \<and> valid_list s \<and> valid_arch_state s
+            (\<lambda>s. valid_pspace s \<and> valid_mdb s \<and> valid_list s \<and> valid_arch_state s
                    \<and> caps_no_overlap y sz s \<and> pspace_no_overlap_range_cover y sz s
                    \<and> caps_overlap_reserved {y..y + of_nat n * 2 ^ (obj_bits_api (APIType_map2 (Inr ty)) us) - 1} s
                    \<and> (\<exists>slot. cte_wp_at (\<lambda>c. up_aligned_area y sz \<subseteq> cap_range c \<and> cap_is_device c = dev) slot s)
@@ -5645,60 +5313,45 @@ lemma corres_retype_region_createNewCaps:
                  apply simp
                 apply (clarsimp simp: range_cover_def)
                 apply (arith+)[4]
-            \<comment> \<open>TCB, EP, NTFN\<close>
-            apply (simp_all add: retype_region2_ext_retype_region
-                                 bind_cong[OF curDomain_mapM_x_futz refl, unfolded bind_assoc]
-                            split del: if_split)[10] (* not PML4Object *)
+            \<comment> \<open>TCB\<close>
+            apply (simp_all add: curDomain_def split del: if_split)
+            apply (rule corres_underlying_gets_pre_rhs[rotated])
+             apply (rule gets_sp)
             apply (rule corres_guard_imp)
+              apply (rule corres_bind_return)
               apply (rule corres_split_eqr)
                  apply (rule corres_retype[where 'a = tcb],
                         simp_all add: obj_bits_api_def objBits_simps' pageBits_def
-                                      APIType_map2_def makeObjectKO_def
-                                      tcb_relation_retype)[1]
-                 apply (fastforce simp: range_cover_def)
-                apply (simp add: tcb_relation_retype)
-                apply (rule corres_split_nor)
-                   apply (simp add: APIType_map2_def)
-                   apply (rule retype_region2_extra_ext_mapM_x_corres)
-                  apply (rule corres_trivial, simp)
-                  apply (clarsimp simp: list_all2_same list_all2_map1 list_all2_map2
-                                        objBits_simps APIType_map2_def)
-                 apply wp
-                apply wp
-               apply ((wp retype_region2_obj_at | simp add: APIType_map2_def)+)[1]
-              apply ((wp createObjects_Not_tcbQueued[where sz=sz]
-                      | simp add: APIType_map2_def objBits_simps' obj_bits_api_def)+)[1]
+                                      APIType_map2_def makeObjectKO_def)[1]
+                  apply (fastforce simp: range_cover_def)
+                 apply (simp add: tcb_relation_retype)
+                apply (rule corres_returnTT, simp)
+                apply (clarsimp simp: list_all2_same list_all2_map1 list_all2_map2
+                                      objBits_simps APIType_map2_def)
+               apply ((wp | simp add: APIType_map2_def)+)[1]
+              apply ((wp createObjects_tcb_at'[where sz=sz] | simp add: APIType_map2_def objBits_simps' obj_bits_api_def)+)[1]
              apply simp
             apply simp
-           apply (subst retype_region2_extra_ext_trivial)
-            apply (simp add: APIType_map2_def)
+           \<comment> \<open>EP, NTFN\<close>
            apply (simp add: liftM_def[symmetric] split del: if_split)
            apply (rule corres_rel_imp)
             apply (rule corres_guard_imp)
               apply (rule corres_retype[where 'a = endpoint],
-                     simp_all add: obj_bits_api_def objBits_simps' pageBits_def APIType_map2_def
-                                   makeObjectKO_def other_objs_default_relation)[1]
-              apply (fastforce simp: range_cover_def)
-             apply simp
-            apply simp
-           apply (clarsimp simp: list_all2_same list_all2_map1 list_all2_map2 objBits_simps
-                                 APIType_map2_def)
-          apply (subst retype_region2_extra_ext_trivial)
-           apply (simp add: APIType_map2_def)
+                     simp_all add: obj_bits_api_def objBits_simps' pageBits_def
+                                   APIType_map2_def makeObjectKO_def
+                                   other_objs_default_relation)[1]
+              apply ((simp add: range_cover_def APIType_map2_def
+                                list_all2_same list_all2_map1 list_all2_map2)+)[4]
           apply (simp add: liftM_def[symmetric] split del: if_split)
           apply (rule corres_rel_imp)
            apply (rule corres_guard_imp)
              apply (rule corres_retype[where 'a = notification],
-                    simp_all add: obj_bits_api_def objBits_simps' pageBits_def APIType_map2_def
-                                  makeObjectKO_def other_objs_default_relation)[1]
-             apply (fastforce simp: range_cover_def)
-            apply simp
-           apply simp
-          apply (clarsimp simp: list_all2_same list_all2_map1 list_all2_map2 objBits_simps
-                                APIType_map2_def)
+                    simp_all add: obj_bits_api_def objBits_simps' pageBits_def
+                                  APIType_map2_def makeObjectKO_def
+                                  other_objs_default_relation)[1]
+           apply ((simp add: range_cover_def APIType_map2_def
+                             list_all2_same list_all2_map1 list_all2_map2)+)[4]
          \<comment> \<open>CapTable\<close>
-         apply (subst retype_region2_extra_ext_trivial)
-          apply (simp add: APIType_map2_def)
          apply (subst bind_assoc_return_reverse[of "createObjects y n (KOCTE makeObject) us"])
          apply (subst liftM_def[of "map (\<lambda>addr. capability.CNodeCap addr us 0 0)", symmetric])
          apply simp
@@ -5715,8 +5368,6 @@ lemma corres_retype_region_createNewCaps:
                                allRights_def APIType_map2_def
                          split del: if_split)
         \<comment> \<open>SmallPageObject\<close>
-        apply (subst retype_region2_extra_ext_trivial)
-         apply (simp add: APIType_map2_def)
         apply (simp add: corres_liftM2_simp[unfolded liftM_def] split del: if_split)
         apply (rule corres_rel_imp)
          apply (simp add: init_arch_objects_APIType_map2_noop split del: if_split)
@@ -5731,8 +5382,6 @@ lemma corres_retype_region_createNewCaps:
         apply (simp add: APIType_map2_def arch_default_cap_def vm_read_write_def vmrights_map_def
                          list_all2_map1 list_all2_map2 list_all2_same)
        \<comment> \<open>LargePageObject\<close>
-       apply (subst retype_region2_extra_ext_trivial)
-        apply (simp add: APIType_map2_def)
        apply (simp add: corres_liftM2_simp[unfolded liftM_def] split del: if_split)
        apply (rule corres_rel_imp)
         apply (simp add: init_arch_objects_APIType_map2_noop split del: if_split)
@@ -5747,8 +5396,6 @@ lemma corres_retype_region_createNewCaps:
        apply (simp add: APIType_map2_def arch_default_cap_def vm_read_write_def vmrights_map_def
                         list_all2_map1 list_all2_map2 list_all2_same)
       \<comment> \<open>HugePageObject\<close>
-      apply (subst retype_region2_extra_ext_trivial)
-       apply (simp add: APIType_map2_def)
       apply (simp add: corres_liftM2_simp[unfolded liftM_def] split del: if_split)
       apply (rule corres_rel_imp)
        apply (simp add: init_arch_objects_APIType_map2_noop split del: if_split)
@@ -5763,8 +5410,6 @@ lemma corres_retype_region_createNewCaps:
       apply (simp add: APIType_map2_def arch_default_cap_def vm_read_write_def vmrights_map_def
                        list_all2_map1 list_all2_map2 list_all2_same)
      \<comment> \<open>PageTable\<close>
-     apply (subst retype_region2_extra_ext_trivial)
-      apply (simp add: APIType_map2_def)
      apply (simp_all add: corres_liftM2_simp[unfolded liftM_def])
      apply (rule corres_guard_imp)
        apply (simp add: init_arch_objects_APIType_map2_noop)
@@ -5778,9 +5423,6 @@ lemma corres_retype_region_createNewCaps:
                              APIType_map2_def arch_default_cap_def)
       apply fastforce+
     \<comment> \<open>PageDirectory\<close>
-    apply (subst retype_region2_extra_ext_trivial)
-     apply (simp add: APIType_map2_def)
-    apply (simp_all add: corres_liftM2_simp[unfolded liftM_def])
     apply (rule corres_guard_imp)
       apply (simp add: init_arch_objects_APIType_map2_noop)
       apply (rule corres_rel_imp)
@@ -5793,9 +5435,6 @@ lemma corres_retype_region_createNewCaps:
                             APIType_map2_def arch_default_cap_def)
      apply fastforce+
    \<comment> \<open>PDPT\<close>
-   apply (subst retype_region2_extra_ext_trivial)
-    apply (simp add: APIType_map2_def)
-   apply (simp_all add: corres_liftM2_simp[unfolded liftM_def])
    apply (rule corres_guard_imp)
      apply (simp add: init_arch_objects_APIType_map2_noop)
      apply (rule corres_rel_imp)
@@ -5808,10 +5447,8 @@ lemma corres_retype_region_createNewCaps:
                            APIType_map2_def arch_default_cap_def)
     apply fastforce+
   \<comment> \<open>PML4\<close>
-  apply (corresKsimp corres: corres_retype[where ty="Inr PML4Object" and 'a=pml4e and sz=sz,
-                                          simplified, folded retype_region2_retype_region_PML4Obj]
-                   corresK: corresK_mapM_x_list_all2[where I="\<lambda>xs s. valid_arch_state s \<and> pspace_aligned s
-                                                             \<and> valid_etcbs s \<and>
+  apply (corresKsimp corres: corres_retype[where ty="Inr PML4Object" and 'a=pml4e and sz=sz]
+                   corresK: corresK_mapM_x_list_all2[where I="\<lambda>xs s. valid_arch_state s \<and> pspace_aligned s \<and>
                                                             (\<forall>x \<in> set xs. page_map_l4_at x s)"
                                              and I'="\<lambda>xs s. valid_arch_state' s \<and>
                                                              (\<forall>x \<in> set xs. page_map_l4_at' x s)"

--- a/proof/refine/X64/StateRelation.thy
+++ b/proof/refine/X64/StateRelation.thy
@@ -177,28 +177,27 @@ where
 | "thread_state_relation (Structures_A.BlockedOnNotification oref) ts'
      = (ts' = Structures_H.BlockedOnNotification oref)"
 
-definition
-  arch_tcb_relation :: "Structures_A.arch_tcb \<Rightarrow> Structures_H.arch_tcb \<Rightarrow> bool"
-where
- "arch_tcb_relation \<equiv> \<lambda>atcb atcb'.
-   tcb_context atcb = atcbContext atcb'"
+definition arch_tcb_relation :: "Structures_A.arch_tcb \<Rightarrow> Structures_H.arch_tcb \<Rightarrow> bool" where
+  "arch_tcb_relation \<equiv>
+     \<lambda>atcb atcb'. tcb_context atcb = atcbContext atcb'"
 
-definition
-  tcb_relation :: "Structures_A.tcb \<Rightarrow> Structures_H.tcb \<Rightarrow> bool"
-where
- "tcb_relation \<equiv> \<lambda>tcb tcb'.
-    tcb_fault_handler tcb = to_bl (tcbFaultHandler tcb')
-  \<and> tcb_ipc_buffer tcb = tcbIPCBuffer tcb'
-  \<and> arch_tcb_relation (tcb_arch tcb) (tcbArch tcb')
-  \<and> thread_state_relation (tcb_state tcb) (tcbState tcb')
-  \<and> fault_rel_optionation (tcb_fault tcb) (tcbFault tcb')
-  \<and> cap_relation (tcb_ctable tcb) (cteCap (tcbCTable tcb'))
-  \<and> cap_relation (tcb_vtable tcb) (cteCap (tcbVTable tcb'))
-  \<and> cap_relation (tcb_reply tcb) (cteCap (tcbReply tcb'))
-  \<and> cap_relation (tcb_caller tcb) (cteCap (tcbCaller tcb'))
-  \<and> cap_relation (tcb_ipcframe tcb) (cteCap (tcbIPCBufferFrame tcb'))
-  \<and> tcb_bound_notification tcb = tcbBoundNotification tcb'
-  \<and> tcb_mcpriority tcb = tcbMCP tcb'"
+definition tcb_relation :: "Structures_A.tcb \<Rightarrow> Structures_H.tcb \<Rightarrow> bool" where
+  "tcb_relation \<equiv> \<lambda>tcb tcb'.
+     tcb_fault_handler tcb = to_bl (tcbFaultHandler tcb')
+   \<and> tcb_ipc_buffer tcb = tcbIPCBuffer tcb'
+   \<and> arch_tcb_relation (tcb_arch tcb) (tcbArch tcb')
+   \<and> thread_state_relation (tcb_state tcb) (tcbState tcb')
+   \<and> fault_rel_optionation (tcb_fault tcb) (tcbFault tcb')
+   \<and> cap_relation (tcb_ctable tcb) (cteCap (tcbCTable tcb'))
+   \<and> cap_relation (tcb_vtable tcb) (cteCap (tcbVTable tcb'))
+   \<and> cap_relation (tcb_reply tcb) (cteCap (tcbReply tcb'))
+   \<and> cap_relation (tcb_caller tcb) (cteCap (tcbCaller tcb'))
+   \<and> cap_relation (tcb_ipcframe tcb) (cteCap (tcbIPCBufferFrame tcb'))
+   \<and> tcb_bound_notification tcb = tcbBoundNotification tcb'
+   \<and> tcb_mcpriority tcb = tcbMCP tcb'
+   \<and> tcb_priority tcb = tcbPriority tcb'
+   \<and> tcb_time_slice tcb = tcbTimeSlice tcb'
+   \<and> tcb_domain tcb = tcbDomain tcb'"
 
 
 \<comment> \<open>
@@ -407,22 +406,9 @@ where
   (\<forall>x \<in> dom ab. \<forall>(y, P) \<in> obj_relation_cuts (the (ab x)) x.
        P (the (ab x)) (the (con y)))"
 
-definition etcb_relation :: "etcb \<Rightarrow> Structures_H.tcb \<Rightarrow> bool"
-where
- "etcb_relation \<equiv> \<lambda>etcb tcb'.
-    tcb_priority etcb = tcbPriority tcb'
-  \<and> tcb_time_slice etcb = tcbTimeSlice tcb'
-  \<and> tcb_domain etcb = tcbDomain tcb'"
-
-definition
- ekheap_relation :: "(obj_ref \<Rightarrow> etcb option) \<Rightarrow> (machine_word \<rightharpoonup> Structures_H.kernel_object) \<Rightarrow> bool"
-where
- "ekheap_relation ab con \<equiv>
-    \<forall>x \<in> dom ab. \<exists>tcb'. con x = Some (KOTCB tcb') \<and> etcb_relation (the (ab x)) tcb'"
-
 primrec
-  sched_act_relation :: "Deterministic_A.scheduler_action \<Rightarrow> Structures_H.scheduler_action \<Rightarrow> bool"
-where
+  sched_act_relation :: "Structures_A.scheduler_action \<Rightarrow> Structures_H.scheduler_action \<Rightarrow> bool"
+  where
   "sched_act_relation resume_cur_thread a' = (a' = ResumeCurrentThread)" |
   "sched_act_relation choose_new_thread a' = (a' = ChooseNewThread)" |
   "sched_act_relation (switch_thread x) a' = (a' = SwitchToThread x)"
@@ -449,8 +435,8 @@ lemma list_queue_relation_nil:
   by (fastforce dest: heap_path_head simp: tcbQueueEmpty_def list_queue_relation_def)
 
 definition ready_queue_relation ::
-  "Deterministic_A.domain \<Rightarrow> Structures_A.priority
-   \<Rightarrow> Deterministic_A.ready_queue \<Rightarrow> ready_queue
+  "Structures_A.domain \<Rightarrow> Structures_A.priority
+   \<Rightarrow> Structures_A.ready_queue \<Rightarrow> ready_queue
    \<Rightarrow> (obj_ref \<rightharpoonup> obj_ref) \<Rightarrow> (obj_ref \<rightharpoonup> obj_ref)
    \<Rightarrow> (obj_ref \<Rightarrow> bool) \<Rightarrow> bool"
   where
@@ -460,7 +446,7 @@ definition ready_queue_relation ::
      \<and> (d > maxDomain \<or> p > maxPriority \<longrightarrow> tcbQueueEmpty q')"
 
 definition ready_queues_relation_2 ::
-  "(Deterministic_A.domain \<Rightarrow> Structures_A.priority \<Rightarrow> Deterministic_A.ready_queue)
+  "(Structures_A.domain \<Rightarrow> Structures_A.priority \<Rightarrow> Structures_A.ready_queue)
    \<Rightarrow> (domain \<times> priority \<Rightarrow> ready_queue)
    \<Rightarrow> (obj_ref \<rightharpoonup> obj_ref) \<Rightarrow> (obj_ref \<rightharpoonup> obj_ref)
    \<Rightarrow> (domain \<Rightarrow> priority \<Rightarrow> obj_ref \<Rightarrow> bool) \<Rightarrow> bool"
@@ -670,7 +656,6 @@ definition
 where
  "state_relation \<equiv> {(s, s').
          pspace_relation (kheap s) (ksPSpace s')
-       \<and> ekheap_relation (ekheap s) (ksPSpace s')
        \<and> sched_act_relation (scheduler_action s) (ksSchedulerAction s')
        \<and> ready_queues_relation s s'
        \<and> ghost_relation (kheap s) (gsUserPages s') (gsCNodes s')
@@ -702,10 +687,6 @@ lemma state_relation_pspace_relation[elim!]:
   "(s,s') \<in> state_relation \<Longrightarrow> pspace_relation (kheap s) (ksPSpace s')"
   by (simp add: state_relation_def)
 
-lemma state_relation_ekheap_relation[elim!]:
-  "(s,s') \<in> state_relation \<Longrightarrow> ekheap_relation (ekheap s) (ksPSpace s')"
-  by (simp add: state_relation_def)
-
 lemma state_relation_sched_act_relation[elim!]:
   "(s,s') \<in> state_relation \<Longrightarrow> sched_act_relation (scheduler_action s) (ksSchedulerAction s')"
   by (clarsimp simp: state_relation_def)
@@ -721,7 +702,6 @@ lemma state_relation_idle_thread[elim!]:
 lemma state_relationD:
   assumes sr:  "(s, s') \<in> state_relation"
   shows "pspace_relation (kheap s) (ksPSpace s') \<and>
-  ekheap_relation (ekheap s) (ksPSpace s') \<and>
   sched_act_relation (scheduler_action s) (ksSchedulerAction s') \<and>
   ready_queues_relation s s' \<and>
   ghost_relation (kheap s) (gsUserPages s') (gsCNodes s') \<and>
@@ -743,7 +723,6 @@ lemma state_relationD:
 lemma state_relationE [elim?]:
   assumes sr:  "(s, s') \<in> state_relation"
   and rl: "\<lbrakk>pspace_relation (kheap s) (ksPSpace s');
-  ekheap_relation (ekheap s) (ksPSpace s');
   sched_act_relation (scheduler_action s) (ksSchedulerAction s');
   ready_queues_relation s s';
   ghost_relation (kheap s) (gsUserPages s') (gsCNodes s');
@@ -799,11 +778,6 @@ lemma pspace_relation_absD:
   apply (rule rev_bexI, erule domI)
   apply (simp add: image_def rev_bexI)
   done
-
-lemma ekheap_relation_absD:
-  "\<lbrakk> ab x = Some y; ekheap_relation ab con \<rbrakk>
-      \<Longrightarrow> \<exists>tcb'. con x = Some (KOTCB tcb') \<and> etcb_relation y tcb'"
-  by (force simp add: ekheap_relation_def)
 
 lemma in_related_pspace_dom:
   "\<lbrakk> s' x = Some y; pspace_relation s s' \<rbrakk> \<Longrightarrow> x \<in> pspace_dom s"

--- a/proof/refine/X64/Syscall_R.thy
+++ b/proof/refine/X64/Syscall_R.thy
@@ -350,7 +350,7 @@ lemma threadSet_tcbDomain_update_sch_act_wf[wp]:
 
 lemma setDomain_corres:
   "corres dc
-     (valid_etcbs and valid_sched and pspace_aligned and pspace_distinct and tcb_at tptr)
+     (valid_sched and pspace_aligned and pspace_distinct and tcb_at tptr)
      (invs' and sch_act_simple and tcb_at' tptr and (\<lambda>s. new_dom \<le> maxDomain))
      (set_domain tptr new_dom) (setDomain tptr new_dom)"
   apply (rule corres_gen_asm2)
@@ -359,8 +359,8 @@ lemma setDomain_corres:
     apply (rule corres_split[OF getCurThread_corres])
       apply (rule corres_split[OF tcbSchedDequeue_corres], simp)
         apply (rule corres_split)
-           apply (rule ethread_set_corres; simp)
-           apply (clarsimp simp: etcb_relation_def)
+           apply (rule threadSet_not_queued_corres;
+                  simp add: tcb_relation_def tcb_cap_cases_def tcb_cte_cases_def cteSizeBits_def)
           apply (rule corres_split[OF isRunnable_corres])
             apply simp
             apply (rule corres_split)
@@ -373,9 +373,9 @@ lemma setDomain_corres:
             apply ((wpsimp wp: hoare_drop_imps | strengthen valid_objs'_valid_tcbs')+)[1]
            apply (wpsimp wp: gts_wp)
           apply wpsimp
-         apply ((wpsimp wp: hoare_vcg_imp_lift' ethread_set_not_queued_valid_queues hoare_vcg_all_lift
-                 | strengthen valid_objs'_valid_tcbs' valid_queues_in_correct_ready_q
-                              valid_queues_ready_qs_distinct)+)[1]
+         apply (wpsimp wp: hoare_vcg_imp_lift' hoare_vcg_all_lift
+                           thread_set_in_correct_ready_q_not_queued thread_set_no_change_tcb_state
+                           thread_set_no_change_tcb_state_converse thread_set_weak_valid_sched_action)
         apply (rule_tac Q'="\<lambda>_. valid_objs' and sym_heap_sched_pointers and valid_sched_pointers
                                and pspace_aligned' and pspace_distinct'
                                and (\<lambda>s. sch_act_wf (ksSchedulerAction s) s) and tcb_at' tptr"
@@ -384,7 +384,7 @@ lemma setDomain_corres:
         apply (wpsimp wp: threadSet_valid_objs' threadSet_sched_pointers
                           threadSet_valid_sched_pointers)+
        apply (rule_tac Q'="\<lambda>_ s. valid_queues s \<and> not_queued tptr s
-                                \<and> pspace_aligned s \<and> pspace_distinct s \<and> valid_etcbs s
+                                \<and> pspace_aligned s \<and> pspace_distinct s
                                 \<and> weak_valid_sched_action s"
                     in hoare_post_imp)
         apply (fastforce simp: pred_tcb_at_def obj_at_def)
@@ -398,10 +398,7 @@ lemma setDomain_corres:
        apply (clarsimp simp: tcb_cte_cases_def cteSizeBits_def)
        apply fastforce
       apply (wp hoare_vcg_all_lift tcbSchedDequeue_not_queued)+
-   apply clarsimp
-   apply (frule tcb_at_is_etcb_at)
-    apply simp+
-   apply (auto elim: tcb_at_is_etcb_at valid_objs'_maxDomain valid_objs'_maxPriority pred_tcb'_weakenE
+   apply (auto elim: valid_objs'_maxDomain valid_objs'_maxPriority pred_tcb'_weakenE
                simp: valid_sched_def valid_sched_action_def)
   done
 
@@ -1575,8 +1572,7 @@ lemma handleYield_corres:
                 | strengthen valid_objs'_valid_tcbs' valid_queues_in_correct_ready_q
                   valid_queues_ready_qs_distinct)+
    apply (fastforce simp: invs_def valid_sched_def valid_sched_action_def
-                          tcb_at_is_etcb_at valid_state_def valid_pspace_def ct_in_state_def
-                          runnable_eq_active)
+                          valid_state_def valid_pspace_def ct_in_state_def runnable_eq_active)
   apply (fastforce simp: invs'_def valid_state'_def ct_in_state'_def sch_act_wf_weak cur_tcb'_def
                          valid_pspace_valid_objs' valid_objs'_maxDomain tcb_in_cur_domain'_def)
   done
@@ -1816,10 +1812,6 @@ lemma handleReply_nonz_cap_to_ct:
 
 crunch handleFaultReply
   for ksQ[wp]: "\<lambda>s. P (ksReadyQueues s p)"
-
-crunch handle_recv
-  for valid_etcbs[wp]: "valid_etcbs"
-  (wp: crunch_wps simp: crunch_simps)
 
 lemma handleReply_handleRecv_corres:
   "corres dc (einvs and ct_running)

--- a/proof/refine/X64/TcbAcc_R.thy
+++ b/proof/refine/X64/TcbAcc_R.thy
@@ -309,28 +309,27 @@ lemma setObject_update_TCB_corres':
   assumes tables': "\<forall>(getF, v) \<in> ran tcb_cte_cases. getF new_tcb' = getF tcb'"
   assumes sched_pointers: "tcbSchedPrev new_tcb' = tcbSchedPrev tcb'"
                           "tcbSchedNext new_tcb' = tcbSchedNext tcb'"
-  assumes flag: "tcbQueued new_tcb' = tcbQueued tcb'"
+  assumes flag: "\<And>d p. inQ d p new_tcb' = inQ d p tcb'"
   assumes r: "r () ()"
-  assumes exst: "exst_same tcb' new_tcb'"
-  shows "corres r (ko_at (TCB tcb) ptr) (ko_at' tcb' ptr)
-                  (set_object ptr (TCB new_tcb)) (setObject ptr new_tcb')"
-  apply (rule_tac F="tcb_relation tcb tcb' \<and> exst_same tcb' new_tcb'" in corres_req)
+  shows
+    "corres r
+       (ko_at (TCB tcb) ptr) (ko_at' tcb' ptr)
+       (set_object ptr (TCB new_tcb)) (setObject ptr new_tcb')"
+  apply (rule_tac F="tcb_relation tcb tcb'" in corres_req)
    apply (clarsimp simp: state_relation_def obj_at_def obj_at'_def)
    apply (frule(1) pspace_relation_absD)
-   apply (clarsimp simp: tcb_relation_cut_def exst)
-   apply (clarsimp simp: projectKOs tcb_relation_cut_def exst)
+   apply (clarsimp simp: projectKOs tcb_relation_cut_def)
   apply (rule corres_no_failI)
-   apply (rule no_fail_pre)
-    apply wp
+   apply wp
    apply (clarsimp simp: obj_at'_def)
   apply (unfold set_object_def setObject_def)
   apply (clarsimp simp: in_monad split_def bind_def gets_def get_def Bex_def
                         put_def return_def modify_def get_object_def projectKOs obj_at_def
-                        updateObject_default_def in_magnitude_check obj_at'_def)
-  apply (rename_tac s s' t')
-  apply (prop_tac "t' = s'")
-   apply (clarsimp simp: magnitudeCheck_def in_monad split: option.splits)
-  apply (drule singleton_in_magnitude_check)
+                        updateObject_default_def in_magnitude_check objBits_less_word_bits)
+  apply (rename_tac s s' ko)
+  apply (prop_tac "ko = tcb'")
+   apply (clarsimp simp: obj_at'_def projectKOs project_inject)
+  apply (clarsimp simp: state_relation_def)
   apply (prop_tac "map_to_ctes ((ksPSpace s') (ptr \<mapsto> injectKO new_tcb'))
                    = map_to_ctes (ksPSpace s')")
    apply (frule_tac tcb=new_tcb' and tcb=tcb' in map_to_ctes_upd_tcb)
@@ -338,72 +337,57 @@ lemma setObject_update_TCB_corres':
     apply (clarsimp simp: objBits_simps ps_clear_def3 field_simps objBits_defs mask_def)
    apply (insert tables')[1]
    apply (rule ext)
-   apply (clarsimp split: if_splits)
-   apply blast
+   subgoal by auto
   apply (prop_tac "obj_at (same_caps (TCB new_tcb)) ptr s")
    using tables
    apply (fastforce simp: obj_at_def)
-  apply (clarsimp simp: caps_of_state_after_update cte_wp_at_after_update swp_def
+  apply (clarsimp simp: caps_of_state_after_update cte_wp_at_after_update swp_def fun_upd_def
                         obj_at_def assms)
-  apply (clarsimp simp add: state_relation_def)
   apply (subst conj_assoc[symmetric])
   apply (extract_conjunct \<open>match conclusion in "ghost_relation _ _ _" \<Rightarrow> -\<close>)
    apply (clarsimp simp add: ghost_relation_def)
    apply (erule_tac x=ptr in allE)+
    apply clarsimp
-  apply (simp only: pspace_relation_def pspace_dom_update dom_fun_upd2 simp_thms)
-  apply (elim conjE)
-  apply (frule bspec, erule domI)
-  apply clarsimp
-  apply (rule conjI)
+  apply (extract_conjunct \<open>match conclusion in "pspace_relation _ _" \<Rightarrow> -\<close>)
+   apply (fold fun_upd_def)
    apply (simp only: pspace_relation_def simp_thms
                      pspace_dom_update[where x="kernel_object.TCB _"
                                          and v="kernel_object.TCB _",
                                        simplified a_type_def, simplified])
-  apply (rule conjI)
    using assms
    apply (simp only: dom_fun_upd2 simp_thms)
+   apply (elim conjE)
    apply (frule bspec, erule domI)
    apply (rule ballI, drule(1) bspec)
    apply (drule domD)
-   apply (clarsimp simp: tcb_relation_cut_def split: if_split_asm kernel_object.split_asm)
+   apply (clarsimp simp: project_inject tcb_relation_cut_def
+                  split: if_split_asm kernel_object.split_asm)
    apply (rename_tac aa ba)
    apply (drule_tac x="(aa, ba)" in bspec, simp)
    apply clarsimp
    apply (frule_tac ko'="kernel_object.TCB tcb" and x'=ptr in obj_relation_cut_same_type)
       apply (simp add: tcb_relation_cut_def)+
    apply clarsimp
-  apply (extract_conjunct \<open>match conclusion in "ekheap_relation _ _" \<Rightarrow> -\<close>)
-   apply (simp only: ekheap_relation_def)
-   apply (rule ballI, drule (1) bspec)
-   apply (insert exst)
-   apply (clarsimp simp: etcb_relation_def exst_same_def)
-  apply (extract_conjunct \<open>match conclusion in "ready_queues_relation_2 _ _ _ _ _" \<Rightarrow> -\<close>)
-   apply (insert sched_pointers flag exst)
-   apply (clarsimp simp: ready_queues_relation_def Let_def)
-   apply (prop_tac "(tcbSchedNexts_of s')(ptr := tcbSchedNext new_tcb') = tcbSchedNexts_of s'")
-    apply (fastforce simp: opt_map_def)
-   apply (prop_tac "(tcbSchedPrevs_of s')(ptr := tcbSchedPrev new_tcb') = tcbSchedPrevs_of s'")
-    apply (fastforce simp: opt_map_def)
-   apply (clarsimp simp: ready_queue_relation_def opt_pred_def opt_map_def exst_same_def inQ_def
-                  split: option.splits)
-   apply (metis (no_types, lifting) tcb_of'_TCB)
-  apply (clarsimp simp: fun_upd_def caps_of_state_after_update cte_wp_at_after_update swp_def
-                        obj_at_def)
-  done
+  apply (insert sched_pointers flag)
+  apply (clarsimp simp: ready_queues_relation_def Let_def)
+  apply (prop_tac "(tcbSchedNexts_of s')(ptr := tcbSchedNext new_tcb') = tcbSchedNexts_of s'")
+   apply (fastforce simp: opt_map_def)
+  apply (prop_tac "(tcbSchedPrevs_of s')(ptr := tcbSchedPrev new_tcb') = tcbSchedPrevs_of s'")
+   apply (fastforce simp: opt_map_def)
+  by (clarsimp simp: ready_queue_relation_def opt_pred_def opt_map_def split: option.splits)
 
 lemma setObject_update_TCB_corres:
   "\<lbrakk>tcb_relation tcb tcb' \<Longrightarrow> tcb_relation new_tcb new_tcb';
      \<forall>(getF, v) \<in> ran tcb_cap_cases. getF new_tcb = getF tcb;
      \<forall>(getF, v) \<in> ran tcb_cte_cases. getF new_tcb' = getF tcb';
      tcbSchedPrev new_tcb' = tcbSchedPrev tcb'; tcbSchedNext new_tcb' = tcbSchedNext tcb';
-     tcbQueued new_tcb' = tcbQueued tcb'; exst_same tcb' new_tcb';
+     \<And>d p. inQ d p new_tcb' = inQ d p tcb';
      r () ()\<rbrakk> \<Longrightarrow>
    corres r
      (\<lambda>s. get_tcb ptr s = Some tcb) (\<lambda>s'. (tcb', s') \<in> fst (getObject ptr s'))
      (set_object ptr (TCB new_tcb)) (setObject ptr new_tcb')"
   apply (rule corres_guard_imp)
-    apply (erule (7) setObject_update_TCB_corres')
+    apply (erule (4) setObject_update_TCB_corres')
    apply (clarsimp simp: getObject_def in_monad split_def obj_at'_def projectKOs
                          loadObject_default_def objBits_simps' in_magnitude_check)+
   done
@@ -457,23 +441,21 @@ lemma threadset_corresT:
                  getF (f' tcb) = getF tcb"
   assumes sched_pointers: "\<And>tcb. tcbSchedPrev (f' tcb) = tcbSchedPrev tcb"
                           "\<And>tcb. tcbSchedNext (f' tcb) = tcbSchedNext tcb"
-  assumes flag: "\<And>tcb. tcbQueued (f' tcb) = tcbQueued tcb"
-  assumes e: "\<And>tcb'. exst_same tcb' (f' tcb')"
+  assumes flag: "\<And>d p tcb'. inQ d p (f' tcb') = inQ d p tcb'"
   shows      "corres dc (tcb_at t and pspace_aligned and pspace_distinct) \<top>
                      (thread_set f t) (threadSet f' t)"
   apply (simp add: thread_set_def threadSet_def)
   apply (rule corres_guard_imp)
     apply (rule corres_split[OF getObject_TCB_corres])
       apply (rule setObject_update_TCB_corres')
-             apply (erule x)
-            apply (rule y)
-           apply (clarsimp simp: bspec_split [OF spec [OF z]])
-           apply fastforce
-          apply (rule sched_pointers)
+            apply (erule x)
+           apply (rule y)
+          apply (clarsimp simp: bspec_split [OF spec [OF z]])
+          apply fastforce
          apply (rule sched_pointers)
-        apply (rule flag)
-       apply simp
-      apply (rule e)
+        apply (rule sched_pointers)
+       apply (rule flag)
+      apply simp
      apply wp+
    apply (clarsimp simp add: tcb_at_def obj_at_def)
    apply (drule get_tcb_SomeD)
@@ -493,8 +475,7 @@ lemma threadSet_corres_noopT:
                  getF (fn tcb) = getF tcb"
   assumes s: "\<forall>tcb'. tcbSchedPrev (fn tcb') = tcbSchedPrev tcb'"
              "\<forall>tcb'. tcbSchedNext (fn tcb') = tcbSchedNext tcb'"
-  assumes f: "\<And>tcb'. tcbQueued (fn tcb') = tcbQueued tcb'"
-  assumes e: "\<And>tcb'. exst_same tcb' (fn tcb')"
+  assumes f: "\<And>d p tcb'. inQ d p (fn tcb') = inQ d p tcb'"
   shows      "corres dc (tcb_at t and pspace_aligned and pspace_distinct) \<top>
                         (return v) (threadSet fn t)"
 proof -
@@ -512,13 +493,12 @@ proof -
        defer
        apply (subst bind_return [symmetric],
               rule corres_underlying_split [OF threadset_corresT])
-                apply (simp add: x)
-               apply simp
-              apply (rule y)
-             apply (fastforce simp: s)
+               apply (simp add: x)
+              apply simp
+             apply (rule y)
             apply (fastforce simp: s)
-           apply (fastforce simp: f)
-          apply (rule e)
+           apply (fastforce simp: s)
+          apply (fastforce simp: f)
          apply (rule corres_noop [where P=\<top> and P'=\<top>])
           apply wpsimp+
     done
@@ -536,19 +516,17 @@ lemma threadSet_corres_noop_splitT:
   assumes w: "\<lbrace>P'\<rbrace> threadSet fn t \<lbrace>\<lambda>x. Q'\<rbrace>"
   assumes s: "\<forall>tcb'. tcbSchedPrev (fn tcb') = tcbSchedPrev tcb'"
              "\<forall>tcb'. tcbSchedNext (fn tcb') = tcbSchedNext tcb'"
-  assumes f: "\<And>tcb'. tcbQueued (fn tcb') = tcbQueued tcb'"
-  assumes e: "\<And>tcb'. exst_same tcb' (fn tcb')"
+  assumes f: "\<And>d p tcb'. inQ d p (fn tcb') = inQ d p tcb'"
   shows      "corres r (tcb_at t and pspace_aligned and pspace_distinct and P) P'
                      m (threadSet fn t >>= (\<lambda>rv. m'))"
   apply (rule corres_guard_imp)
     apply (subst return_bind[symmetric])
     apply (rule corres_split_nor[OF threadSet_corres_noopT])
-            apply (simp add: x)
-           apply (rule y)
-          apply (fastforce simp: s)
+           apply (simp add: x)
+          apply (rule y)
          apply (fastforce simp: s)
-        apply (fastforce simp: f)
-       apply (rule e)
+        apply (fastforce simp: s)
+       apply (fastforce simp: f)
       apply (rule z)
      apply (wp w)+
    apply simp
@@ -1505,7 +1483,7 @@ lemma asUser_corres':
                      (set_object add (TCB (tcb \<lparr> tcb_arch := arch_tcb_context_set con (tcb_arch tcb) \<rparr>)))
                      (setObject add (tcb' \<lparr> tcbArch := atcbContextSet con' (tcbArch tcb') \<rparr>))"
     by (rule setObject_update_TCB_corres [OF L2],
-        (simp add: tcb_cte_cases_def tcb_cap_cases_def cteSizeBits_def exst_same_def)+)
+        (simp add: tcb_cte_cases_def tcb_cap_cases_def cteSizeBits_def)+)
   have L4: "\<And>con con'. con = con' \<Longrightarrow>
             corres (\<lambda>(irv, nc) (irv', nc'). r irv irv' \<and> nc = nc')
                    \<top> \<top> (select_f (f con)) (select_f (g con'))"
@@ -1856,41 +1834,6 @@ lemma fun_if_triv[simp]:
   "(\<lambda>x. if x = y then f y else f x) = f"
   by (force)
 
-lemma corres_get_etcb:
-  "corres (etcb_relation) (is_etcb_at t) (tcb_at' t)
-                    (gets_the (get_etcb t)) (getObject t)"
-  apply (rule corres_no_failI)
-   apply wp
-  apply (clarsimp simp add: get_etcb_def gets_the_def gets_def
-                            get_def assert_opt_def bind_def
-                            return_def fail_def
-                            split: option.splits
-                            )
-  apply (frule in_inv_by_hoareD [OF getObject_inv_tcb])
-  apply (clarsimp simp add: is_etcb_at_def obj_at'_def projectKO_def
-                            projectKO_opt_tcb split_def
-                            getObject_def loadObject_default_def in_monad)
-  apply (case_tac bb)
-        apply (simp_all add: fail_def return_def)
-  apply (clarsimp simp add: state_relation_def ekheap_relation_def)
-  apply (drule bspec)
-   apply clarsimp
-   apply blast
-  apply (clarsimp simp add: other_obj_relation_def lookupAround2_known1)
-  done
-
-
-lemma ethreadget_corres:
-  assumes x: "\<And>etcb tcb'. etcb_relation etcb tcb' \<Longrightarrow> r (f etcb) (f' tcb')"
-  shows      "corres r (is_etcb_at t) (tcb_at' t) (ethread_get f t) (threadGet f' t)"
-  apply (simp add: ethread_get_def threadGet_def)
-  apply (fold liftM_def)
-  apply simp
-  apply (rule corres_rel_imp)
-   apply (rule corres_get_etcb)
-  apply (simp add: x)
-  done
-
 lemma getQueue_corres:
   "corres (\<lambda>ls q. (ls = [] \<longleftrightarrow> tcbQueueEmpty q) \<and> (ls \<noteq> [] \<longrightarrow> tcbQueueHead q = Some (hd ls))
                   \<and> queue_end_valid ls q)
@@ -1941,13 +1884,14 @@ crunch removeFromBitmap
 lemmas addToBitmap_typ_ats [wp] = typ_at_lifts [OF addToBitmap_typ_at']
 lemmas removeFromBitmap_typ_ats [wp] = typ_at_lifts [OF removeFromBitmap_typ_at']
 
-lemma ekheap_relation_tcb_domain_priority:
-  "\<lbrakk>ekheap_relation (ekheap s) (ksPSpace s'); ekheap s t = Some (tcb);
+lemma pspace_relation_tcb_domain_priority:
+  "\<lbrakk>pspace_relation (kheap s) (ksPSpace s'); kheap s t = Some (TCB tcb);
     ksPSpace s' t = Some (KOTCB tcb')\<rbrakk>
    \<Longrightarrow> tcbDomain tcb' = tcb_domain tcb \<and> tcbPriority tcb' = tcb_priority tcb"
-  apply (clarsimp simp: ekheap_relation_def)
-  apply (drule_tac x=t in bspec, blast)
-  apply (clarsimp simp: other_obj_relation_def etcb_relation_def)
+  apply (clarsimp simp: pspace_relation_def)
+  apply (drule_tac x=t in bspec)
+   apply (fastforce simp: obj_at_def)
+  apply (clarsimp simp: obj_at_def obj_at'_def tcb_relation_cut_def tcb_relation_def)
   done
 
 lemma no_fail_thread_get[wp]:
@@ -1994,85 +1938,16 @@ lemma threadSet_pspace_relation:
   apply (fastforce dest!: tcb_rel)
   done
 
-lemma ekheap_relation_update_tcbs:
-  "\<lbrakk> ekheap_relation (ekheap s) (ksPSpace s'); ekheap s x = Some oetcb;
-     ksPSpace s' x = Some (KOTCB otcb'); etcb_relation etcb tcb' \<rbrakk>
-   \<Longrightarrow> ekheap_relation ((ekheap s)(x \<mapsto> etcb)) ((ksPSpace s')(x \<mapsto> KOTCB tcb'))"
-  by (simp add: ekheap_relation_def)
-
-lemma ekheap_relation_update_concrete_tcb:
-  "\<lbrakk>ekheap_relation (ekheap s) (ksPSpace s'); ekheap s ptr = Some etcb;
-    ksPSpace s' ptr = Some (KOTCB otcb');
-    etcb_relation etcb tcb'\<rbrakk>
-   \<Longrightarrow> ekheap_relation (ekheap s) ((ksPSpace s')(ptr \<mapsto> KOTCB tcb'))"
-  by (fastforce dest: ekheap_relation_update_tcbs simp: map_upd_triv)
-
-lemma ekheap_relation_etcb_relation:
-  "\<lbrakk>ekheap_relation (ekheap s) (ksPSpace s'); ekheap s ptr = Some etcb;
-    ksPSpace s' ptr = Some (KOTCB tcb')\<rbrakk>
-   \<Longrightarrow> etcb_relation etcb tcb'"
-  apply (clarsimp simp: ekheap_relation_def)
-  apply (drule_tac x=ptr in bspec)
-   apply (fastforce simp: obj_at_def)
-  apply (clarsimp simp: obj_at_def obj_at'_def)
-  done
-
-lemma threadSet_ekheap_relation:
-  fixes s :: det_state
-  assumes etcb_rel: "(\<And>etcb tcb'. etcb_relation etcb tcb' \<Longrightarrow> etcb_relation etcb (F tcb'))"
-  shows
-    "\<lbrace>\<lambda>s'. ekheap_relation (ekheap s) (ksPSpace s') \<and> pspace_relation (kheap s) (ksPSpace s')
-           \<and> valid_etcbs s\<rbrace>
-     threadSet F tcbPtr
-     \<lbrace>\<lambda>_ s'. ekheap_relation (ekheap s) (ksPSpace s')\<rbrace>"
-  supply fun_upd_apply[simp del]
-  unfolding threadSet_def setObject_def updateObject_default_def
-  apply (wpsimp wp: getObject_tcb_wp simp: updateObject_default_def)
-  apply (frule tcb_at'_cross)
-   apply (fastforce simp: obj_at'_def)
-  apply normalise_obj_at'
-  apply (frule (1) tcb_at_is_etcb_at)
-  apply (clarsimp simp: obj_at_def is_tcb_def is_etcb_at_def)
-  apply (rename_tac ko, case_tac ko; clarsimp)
-  apply (rule ekheap_relation_update_concrete_tcb)
-     apply fastforce
-    apply fastforce
-   apply (fastforce simp: obj_at'_def projectKOs)
-  apply (frule (1) ekheap_relation_etcb_relation)
-   apply (fastforce simp: obj_at'_def projectKOs)
-  apply (fastforce dest!: etcb_rel)
-  done
-
 lemma tcbQueued_update_pspace_relation[wp]:
   fixes s :: det_state
   shows "threadSet (tcbQueued_update f) tcbPtr \<lbrace>\<lambda>s'. pspace_relation (kheap s) (ksPSpace s')\<rbrace>"
   by (wpsimp wp: threadSet_pspace_relation simp: tcb_relation_def)
-
-lemma tcbQueued_update_ekheap_relation[wp]:
-  fixes s :: det_state
-  shows
-    "\<lbrace>\<lambda>s'. ekheap_relation (ekheap s) (ksPSpace s') \<and> pspace_relation (kheap s) (ksPSpace s')
-           \<and> valid_etcbs s\<rbrace>
-     threadSet (tcbQueued_update f) tcbPtr
-     \<lbrace>\<lambda>_ s'. ekheap_relation (ekheap s) (ksPSpace s')\<rbrace>"
-  by (wpsimp wp: threadSet_ekheap_relation simp: etcb_relation_def)
 
 lemma tcbQueueRemove_pspace_relation[wp]:
   fixes s :: det_state
   shows "tcbQueueRemove queue tcbPtr \<lbrace>\<lambda>s'. pspace_relation (kheap s) (ksPSpace s')\<rbrace>"
   unfolding tcbQueueRemove_def
   by (wpsimp wp: threadSet_pspace_relation hoare_drop_imps simp: tcb_relation_def)
-
-lemma tcbQueueRemove_ekheap_relation[wp]:
-  fixes s :: det_state
-  shows
-    "\<lbrace>\<lambda>s'. ekheap_relation (ekheap s) (ksPSpace s') \<and> pspace_relation (kheap s) (ksPSpace s')
-           \<and> valid_etcbs s\<rbrace>
-     tcbQueueRemove queue tcbPtr
-     \<lbrace>\<lambda>_ s'. ekheap_relation (ekheap s) (ksPSpace s')\<rbrace>"
-  unfolding tcbQueueRemove_def
-  by (wpsimp wp: threadSet_ekheap_relation threadSet_pspace_relation hoare_drop_imps
-           simp: tcb_relation_def etcb_relation_def)
 
 lemma threadSet_ghost_relation[wp]:
   "threadSet f tcbPtr \<lbrace>\<lambda>s'. ghost_relation (kheap s) (gsUserPages s') (gsCNodes s')\<rbrace>"
@@ -2111,7 +1986,7 @@ lemma set_tcb_queue_projs:
    \<lbrace>\<lambda>s. P (kheap s) (cdt s) (is_original_cap s) (cur_thread s) (idle_thread s) (scheduler_action s)
           (domain_list s) (domain_index s) (cur_domain s) (domain_time s) (machine_state s)
           (interrupt_irq_node s) (interrupt_states s) (arch_state s) (caps_of_state s)
-          (work_units_completed s) (cdt_list s) (ekheap s)\<rbrace>"
+          (work_units_completed s) (cdt_list s)\<rbrace>"
   by (wpsimp simp: set_tcb_queue_def)
 
 lemma set_tcb_queue_cte_at:
@@ -2124,7 +1999,6 @@ lemma set_tcb_queue_cte_at:
 lemma set_tcb_queue_projs_inv:
   "fst (set_tcb_queue d p queue s) = {(r, s')} \<Longrightarrow>
    kheap s = kheap s'
-   \<and> ekheap s = ekheap s'
    \<and> cdt s = cdt s'
    \<and> is_original_cap s = is_original_cap s'
    \<and> cur_thread s = cur_thread s'
@@ -2157,50 +2031,17 @@ lemma tcbQueuePrepend_pspace_relation[wp]:
   unfolding tcbQueuePrepend_def
   by (wpsimp wp: threadSet_pspace_relation simp: tcb_relation_def)
 
-lemma tcbQueuePrepend_ekheap_relation[wp]:
-  fixes s :: det_state
-  shows
-    "\<lbrace>\<lambda>s'. ekheap_relation (ekheap s) (ksPSpace s') \<and> pspace_relation (kheap s) (ksPSpace s')
-           \<and> valid_etcbs s\<rbrace>
-     tcbQueuePrepend queue tcbPtr
-     \<lbrace>\<lambda>_ s'. ekheap_relation (ekheap s) (ksPSpace s')\<rbrace>"
-  unfolding tcbQueuePrepend_def
-  by (wpsimp wp: threadSet_pspace_relation threadSet_ekheap_relation
-           simp: tcb_relation_def etcb_relation_def)
-
 lemma tcbQueueAppend_pspace_relation[wp]:
   fixes s :: det_state
   shows "tcbQueueAppend queue tcbPtr \<lbrace>\<lambda>s'. pspace_relation (kheap s) (ksPSpace s')\<rbrace>"
   unfolding tcbQueueAppend_def
   by (wpsimp wp: threadSet_pspace_relation simp: tcb_relation_def)
 
-lemma tcbQueueAppend_ekheap_relation[wp]:
-  fixes s :: det_state
-  shows
-    "\<lbrace>\<lambda>s'. ekheap_relation (ekheap s) (ksPSpace s') \<and> pspace_relation (kheap s) (ksPSpace s')
-           \<and> valid_etcbs s\<rbrace>
-     tcbQueueAppend queue tcbPtr
-     \<lbrace>\<lambda>_ s'. ekheap_relation (ekheap s) (ksPSpace s')\<rbrace>"
-  unfolding tcbQueueAppend_def
-  by (wpsimp wp: threadSet_pspace_relation threadSet_ekheap_relation
-           simp: tcb_relation_def etcb_relation_def)
-
 lemma tcbQueueInsert_pspace_relation[wp]:
   fixes s :: det_state
   shows "tcbQueueInsert tcbPtr afterPtr \<lbrace>\<lambda>s'. pspace_relation (kheap s) (ksPSpace s')\<rbrace>"
   unfolding tcbQueueInsert_def
   by (wpsimp wp: threadSet_pspace_relation hoare_drop_imps simp: tcb_relation_def)
-
-lemma tcbQueueInsert_ekheap_relation[wp]:
-  fixes s :: det_state
-  shows
-    "\<lbrace>\<lambda>s'. ekheap_relation (ekheap s) (ksPSpace s') \<and> pspace_relation (kheap s) (ksPSpace s')
-           \<and> valid_etcbs s\<rbrace>
-     tcbQueueInsert tcbPtr afterPtr
-     \<lbrace>\<lambda>_ s'. ekheap_relation (ekheap s) (ksPSpace s')\<rbrace>"
-  unfolding tcbQueueInsert_def
-  by (wpsimp wp: threadSet_pspace_relation threadSet_ekheap_relation hoare_drop_imps
-           simp: tcb_relation_def etcb_relation_def)
 
 lemma removeFromBitmap_pspace_relation[wp]:
   fixes s :: det_state
@@ -2283,22 +2124,22 @@ lemma threadSet_ready_queues_relation:
 definition in_correct_ready_q_2 where
   "in_correct_ready_q_2 queues ekh \<equiv>
      \<forall>d p. \<forall>t \<in> set (queues d p). is_etcb_at' t ekh
-                                  \<and> etcb_at' (\<lambda>t. tcb_priority t = p \<and> tcb_domain t = d) t ekh"
+                                  \<and> etcb_at' (\<lambda>t. etcb_priority t = p \<and> etcb_domain t = d) t ekh"
 
-abbreviation in_correct_ready_q :: "det_ext state \<Rightarrow> bool" where
-  "in_correct_ready_q s \<equiv> in_correct_ready_q_2 (ready_queues s) (ekheap s)"
+abbreviation in_correct_ready_q :: "'z state \<Rightarrow> bool" where
+  "in_correct_ready_q s \<equiv> in_correct_ready_q_2 (ready_queues s) (etcbs_of s)"
 
 lemmas in_correct_ready_q_def = in_correct_ready_q_2_def
 
 lemma in_correct_ready_q_lift:
-  assumes c: "\<And>P. \<lbrace>\<lambda>s. P (ekheap s)\<rbrace> f \<lbrace>\<lambda>rv s. P (ekheap s)\<rbrace>"
+  assumes c: "\<And>P. f \<lbrace>\<lambda>s. P (etcbs_of s)\<rbrace>"
   assumes r: "\<And>P. f \<lbrace>\<lambda>s. P (ready_queues s)\<rbrace>"
   shows "f \<lbrace>in_correct_ready_q\<rbrace>"
   apply (rule hoare_pre)
    apply (wps assms | wpsimp)+
   done
 
-definition ready_qs_distinct :: "det_ext state \<Rightarrow> bool" where
+definition ready_qs_distinct :: "'z state \<Rightarrow> bool" where
   "ready_qs_distinct s \<equiv> \<forall>d p. distinct (ready_queues s d p)"
 
 lemma ready_qs_distinct_lift:
@@ -2395,28 +2236,6 @@ lemma thread_get_exs_valid[wp]:
   by (clarsimp simp: thread_get_def get_tcb_def gets_the_def gets_def return_def get_def
                      exs_valid_def tcb_at_def bind_def)
 
-lemma ethread_get_sp:
-  "\<lbrace>P\<rbrace> ethread_get f ptr
-   \<lbrace>\<lambda>rv. etcb_at (\<lambda>tcb. f tcb = rv) ptr and P\<rbrace>"
-  apply wpsimp
-  apply (clarsimp simp: etcb_at_def split: option.splits)
-  done
-
-lemma ethread_get_exs_valid[wp]:
-  "\<lbrakk>tcb_at tcb_ptr s; valid_etcbs s\<rbrakk> \<Longrightarrow> \<lbrace>(=) s\<rbrace> ethread_get f tcb_ptr \<exists>\<lbrace>\<lambda>_. (=) s\<rbrace>"
-  apply (frule (1) tcb_at_is_etcb_at)
-  apply (clarsimp simp: ethread_get_def get_etcb_def gets_the_def gets_def return_def get_def
-                        is_etcb_at_def exs_valid_def bind_def)
-  done
-
-lemma no_fail_ethread_get[wp]:
-  "no_fail (tcb_at tcb_ptr and valid_etcbs) (ethread_get f tcb_ptr)"
-  unfolding ethread_get_def
-  apply wpsimp
-  apply (frule (1) tcb_at_is_etcb_at)
-  apply (clarsimp simp: is_etcb_at_def get_etcb_def)
-  done
-
 lemma threadGet_sp:
   "\<lbrace>P\<rbrace> threadGet f ptr \<lbrace>\<lambda>rv s. \<exists>tcb :: tcb. ko_at' tcb ptr s \<and> f tcb = rv \<and> P s\<rbrace>"
   unfolding threadGet_def setObject_def
@@ -2443,7 +2262,7 @@ lemma in_ready_q_tcbQueued_eq:
 lemma tcbSchedEnqueue_corres:
   "tcb_ptr = tcbPtr \<Longrightarrow>
    corres dc
-     (in_correct_ready_q and ready_qs_distinct and valid_etcbs and st_tcb_at runnable tcb_ptr
+     (in_correct_ready_q and ready_qs_distinct and st_tcb_at runnable tcb_ptr
       and pspace_aligned and pspace_distinct)
      (sym_heap_sched_pointers and valid_sched_pointers and valid_tcbs')
      (tcb_sched_action tcb_sched_enqueue tcb_ptr) (tcbSchedEnqueue tcbPtr)"
@@ -2459,9 +2278,9 @@ lemma tcbSchedEnqueue_corres:
    apply (fastforce dest: pspace_distinct_cross)
   apply (clarsimp simp: tcb_sched_action_def tcb_sched_enqueue_def get_tcb_queue_def
                         tcbSchedEnqueue_def getQueue_def unless_def when_def)
-  apply (rule corres_symb_exec_l[OF _ _ ethread_get_sp]; (solves wpsimp)?)
+  apply (rule corres_symb_exec_l[OF _ _ thread_get_sp]; (solves wpsimp)?)
   apply (rename_tac domain)
-  apply (rule corres_symb_exec_l[OF _ _ ethread_get_sp]; (solves wpsimp)?)
+  apply (rule corres_symb_exec_l[OF _ _ thread_get_sp]; (solves wpsimp)?)
   apply (rename_tac priority)
   apply (rule corres_symb_exec_l[OF _ _ gets_sp]; (solves wpsimp)?)
   apply (rule corres_stateAssert_ignore)
@@ -2473,12 +2292,11 @@ lemma tcbSchedEnqueue_corres:
   apply (rule corres_symb_exec_r[OF _ threadGet_sp]; (solves wpsimp)?)
   apply (subst if_distrib[where f="set_tcb_queue domain prio" for domain prio])
   apply (rule corres_if_strong')
-    apply (frule state_relation_ready_queues_relation)
-    apply (frule in_ready_q_tcbQueued_eq[where t=tcbPtr])
     subgoal
-      by (fastforce dest: tcb_at_ekheap_dom pred_tcb_at_tcb_at
-                    simp: obj_at'_def opt_pred_def opt_map_def obj_at_def is_tcb_def
-                          in_correct_ready_q_def etcb_at_def is_etcb_at_def projectKOs)
+      by (fastforce dest!: state_relation_ready_queues_relation
+                           in_ready_q_tcbQueued_eq[where t=tcbPtr]
+                     simp: obj_at'_def opt_pred_def opt_map_def in_correct_ready_q_def
+                           obj_at_def etcb_at_def etcbs_of'_def projectKOs)
    apply (find_goal \<open>match conclusion in "corres _ _ _ _ (return ())" \<Rightarrow> \<open>-\<close>\<close>)
    apply (rule monadic_rewrite_corres_l[where P=P and Q=P for P, simplified])
     apply (clarsimp simp: set_tcb_queue_def)
@@ -2525,19 +2343,18 @@ lemma tcbSchedEnqueue_corres:
   apply (drule set_tcb_queue_new_state)
   apply (wpsimp wp: threadSet_wp getObject_tcb_wp simp: setQueue_def tcbQueuePrepend_def)
   apply normalise_obj_at'
-  apply (frule (1) tcb_at_is_etcb_at)
-  apply (clarsimp simp: obj_at_def is_etcb_at_def etcb_at_def)
-  apply (rename_tac s d p s' tcb' tcb etcb)
-  apply (frule_tac t=tcbPtr in ekheap_relation_tcb_domain_priority)
+  apply (clarsimp simp: obj_at_def)
+  apply (rename_tac s d p s' tcb' tcb)
+  apply (frule_tac t=tcbPtr in pspace_relation_tcb_domain_priority)
     apply (force simp: obj_at_def)
    apply (force simp: obj_at'_def projectKOs)
   apply (clarsimp split: if_splits)
   apply (cut_tac ts="ready_queues s d p" in list_queue_relation_nil)
    apply (force dest!: spec simp: list_queue_relation_def)
-  apply (cut_tac ts="ready_queues s (tcb_domain etcb) (tcb_priority etcb)"
+  apply (cut_tac ts="ready_queues s (tcb_domain tcb) (tcb_priority tcb)"
               in list_queue_relation_nil)
    apply (force dest!: spec simp: list_queue_relation_def)
-  apply (cut_tac ts="ready_queues s (tcb_domain etcb) (tcb_priority etcb)" and s'=s'
+  apply (cut_tac ts="ready_queues s (tcb_domain tcb) (tcb_priority tcb)" and s'=s'
               in obj_at'_tcbQueueEnd_ksReadyQueues)
       apply fast
      apply auto[1]
@@ -2546,14 +2363,14 @@ lemma tcbSchedEnqueue_corres:
   apply (cut_tac xs="ready_queues s d p" and st="tcbQueueHead (ksReadyQueues s' (d, p))"
               in heap_path_head')
    apply (auto dest: spec simp: list_queue_relation_def tcbQueueEmpty_def)[1]
-  apply (cut_tac xs="ready_queues s (tcb_domain etcb) (tcb_priority etcb)"
-             and st="tcbQueueHead (ksReadyQueues s' (tcb_domain etcb, tcb_priority etcb))"
+  apply (cut_tac xs="ready_queues s (tcb_domain tcb) (tcb_priority tcb)"
+             and st="tcbQueueHead (ksReadyQueues s' (tcb_domain tcb, tcb_priority tcb))"
               in heap_path_head')
    apply (auto dest: spec simp: list_queue_relation_def tcbQueueEmpty_def)[1]
   apply (clarsimp simp: list_queue_relation_def)
 
-  apply (case_tac "\<not> (d = tcb_domain etcb \<and> p = tcb_priority etcb)")
-   apply (cut_tac d=d and d'="tcb_domain etcb" and p=p and p'="tcb_priority etcb"
+  apply (case_tac "\<not> (d = tcb_domain tcb \<and> p = tcb_priority tcb)")
+   apply (cut_tac d=d and d'="tcb_domain tcb" and p=p and p'="tcb_priority tcb"
                in ready_queues_disjoint)
       apply force
      apply fastforce
@@ -2577,8 +2394,8 @@ lemma tcbSchedEnqueue_corres:
     apply (clarsimp simp: fun_upd_apply split: if_splits)
 
    \<comment> \<open>the ready queue was not originally empty\<close>
-   apply (clarsimp simp: etcb_at_def obj_at'_def)
-   apply (prop_tac "the (tcbQueueHead (ksReadyQueues s' (tcb_domain etcb, tcb_priority etcb)))
+   apply (clarsimp simp: obj_at'_def)
+   apply (prop_tac "the (tcbQueueHead (ksReadyQueues s' (tcb_domain tcb, tcb_priority tcb)))
                     \<notin> set (ready_queues s d p)")
     apply (erule orthD2)
     apply (clarsimp simp: tcbQueueEmpty_def)
@@ -2596,7 +2413,7 @@ lemma tcbSchedEnqueue_corres:
       apply (case_tac "ready_queues s d p"; force simp: tcbQueueEmpty_def)
      apply (case_tac "t = tcbPtr")
       apply (clarsimp simp: inQ_def fun_upd_apply obj_at'_def projectKOs split: if_splits)
-     apply (case_tac "t = the (tcbQueueHead (ksReadyQueues s' (tcb_domain etcb, tcb_priority etcb)))")
+     apply (case_tac "t = the (tcbQueueHead (ksReadyQueues s' (tcb_domain tcb, tcb_priority tcb)))")
       apply (clarsimp simp: inQ_def opt_pred_def opt_map_def obj_at'_def fun_upd_apply projectKOs
                      split: option.splits)
       apply metis
@@ -2604,11 +2421,11 @@ lemma tcbSchedEnqueue_corres:
     apply (clarsimp simp: fun_upd_apply split: if_splits)
    apply (clarsimp simp: fun_upd_apply split: if_splits)
 
-  \<comment> \<open>d = tcb_domain etcb \<and> p = tcb_priority etcb\<close>
+  \<comment> \<open>d = tcb_domain tcb \<and> p = tcb_priority tcb\<close>
   apply clarsimp
-  apply (drule_tac x="tcb_domain etcb" in spec)
-  apply (drule_tac x="tcb_priority etcb" in spec)
-  apply (cut_tac ts="ready_queues s (tcb_domain etcb) (tcb_priority etcb)"
+  apply (drule_tac x="tcb_domain tcb" in spec)
+  apply (drule_tac x="tcb_priority tcb" in spec)
+  apply (cut_tac ts="ready_queues s (tcb_domain tcb) (tcb_priority tcb)"
               in tcbQueueHead_iff_tcbQueueEnd)
    apply (force simp: list_queue_relation_def)
   apply (frule valid_tcbs'_maxDomain[where t=tcbPtr], simp add: obj_at'_def projectKOs)
@@ -2653,7 +2470,7 @@ lemma setSchedulerAction_corres:
   apply (simp add: setSchedulerAction_def set_scheduler_action_def)
   apply (rule corres_no_failI)
    apply wp
-  apply (clarsimp simp: in_monad simpler_modify_def state_relation_def)
+  apply (clarsimp simp: in_monad simpler_modify_def state_relation_def swp_def)
   done
 
 lemma getSchedulerAction_corres:
@@ -2664,7 +2481,7 @@ lemma getSchedulerAction_corres:
 
 lemma rescheduleRequired_corres:
   "corres dc
-     (weak_valid_sched_action and in_correct_ready_q and ready_qs_distinct and valid_etcbs
+     (weak_valid_sched_action and in_correct_ready_q and ready_qs_distinct
       and pspace_aligned and pspace_distinct)
      (sym_heap_sched_pointers and valid_sched_pointers and valid_tcbs'
       and pspace_aligned' and pspace_distinct')
@@ -2683,8 +2500,8 @@ lemma rescheduleRequired_corres:
         apply (rule setSchedulerAction_corres)
         apply simp
        apply (wp | wpc | simp)+
-   apply (force dest: st_tcb_weakenE simp: in_monad weak_valid_sched_action_def valid_etcbs_def
-               split: Deterministic_A.scheduler_action.split)
+   apply (force dest: st_tcb_weakenE simp: in_monad weak_valid_sched_action_def
+               split: Structures_A.scheduler_action.split)
   apply simp
   apply (clarsimp simp: weak_sch_act_wf_def pred_tcb_at' split: scheduler_action.splits)
   done
@@ -2851,8 +2668,8 @@ definition tcb_queue_remove :: "'a \<Rightarrow> 'a list \<Rightarrow> 'a list" 
 
 definition tcb_sched_dequeue' :: "obj_ref \<Rightarrow> unit det_ext_monad" where
   "tcb_sched_dequeue' tcb_ptr \<equiv> do
-     d \<leftarrow> ethread_get tcb_domain tcb_ptr;
-     prio \<leftarrow> ethread_get tcb_priority tcb_ptr;
+     d \<leftarrow> thread_get tcb_domain tcb_ptr;
+     prio \<leftarrow> thread_get tcb_priority tcb_ptr;
      queue \<leftarrow> get_tcb_queue d prio;
      when (tcb_ptr \<in> set queue) $ set_tcb_queue d prio (tcb_queue_remove tcb_ptr queue)
    od"
@@ -2870,7 +2687,7 @@ lemma filter_tcb_queue_remove:
   done
 
 lemma tcb_sched_dequeue_monadic_rewrite:
-  "monadic_rewrite False True (is_etcb_at t and (\<lambda>s. \<forall>d p. distinct (ready_queues s d p)))
+  "monadic_rewrite False True (tcb_at t and (\<lambda>s. \<forall>d p. distinct (ready_queues s d p)))
      (tcb_sched_action tcb_sched_dequeue t) (tcb_sched_dequeue' t)"
   supply if_split[split del]
   apply (clarsimp simp: tcb_sched_dequeue'_def tcb_sched_dequeue_def tcb_sched_action_def
@@ -2883,9 +2700,9 @@ lemma tcb_sched_dequeue_monadic_rewrite:
       apply (metis (mono_tags, lifting) filter_cong)
      apply (rule monadic_rewrite_modify_noop)
     apply (wpsimp wp: thread_get_wp)+
-  apply (clarsimp simp: etcb_at_def split: option.splits)
-  apply (prop_tac "(\<lambda>d' p. if d' = tcb_domain x2 \<and> p = tcb_priority x2
-                           then filter (\<lambda>x. x \<noteq> t) (ready_queues s (tcb_domain x2) (tcb_priority x2))
+  apply (clarsimp simp: tcb_at_def)
+  apply (prop_tac "(\<lambda>d' p. if d' = tcb_domain tcb \<and> p = tcb_priority tcb
+                           then filter ((\<noteq>) t) (ready_queues s (tcb_domain tcb) (tcb_priority tcb))
                            else ready_queues s d' p)
                    = ready_queues s")
    apply (subst filter_True)
@@ -2918,7 +2735,7 @@ lemma in_queue_not_head_or_not_tail_length_gt_1:
 lemma tcbSchedDequeue_corres:
   "tcb_ptr = tcbPtr \<Longrightarrow>
    corres dc
-     (in_correct_ready_q and ready_qs_distinct and valid_etcbs and tcb_at tcb_ptr
+     (in_correct_ready_q and ready_qs_distinct and tcb_at tcb_ptr
       and pspace_aligned and pspace_distinct)
      (sym_heap_sched_pointers and valid_objs')
      (tcb_sched_action tcb_sched_dequeue tcb_ptr) (tcbSchedDequeue tcbPtr)"
@@ -2932,22 +2749,22 @@ lemma tcbSchedDequeue_corres:
    apply (fastforce dest: pspace_distinct_cross)
   apply (rule monadic_rewrite_corres_l[where P=P and Q=P for P, simplified])
    apply (rule monadic_rewrite_guard_imp[OF tcb_sched_dequeue_monadic_rewrite])
-   apply (fastforce dest: tcb_at_is_etcb_at simp: in_correct_ready_q_def ready_qs_distinct_def)
+   apply (fastforce simp: in_correct_ready_q_def ready_qs_distinct_def)
   apply (clarsimp simp: tcb_sched_dequeue'_def get_tcb_queue_def tcbSchedDequeue_def  getQueue_def
                         unless_def when_def)
-  apply (rule corres_symb_exec_l[OF _ _ ethread_get_sp]; wpsimp?)
+  apply (rule corres_symb_exec_l[OF _ _ thread_get_sp]; wpsimp?)
   apply (rename_tac dom)
-  apply (rule corres_symb_exec_l[OF _ _ ethread_get_sp]; wpsimp?)
+  apply (rule corres_symb_exec_l[OF _ _ thread_get_sp]; wpsimp?)
   apply (rename_tac prio)
   apply (rule corres_symb_exec_l[OF _ _ gets_sp]; (solves wpsimp)?)
   apply (rule corres_stateAssert_ignore)
    apply (fastforce intro: ksReadyQueues_asrt_cross)
   apply (rule corres_symb_exec_r[OF _ threadGet_sp]; (solves wpsimp)?)
   apply (rule corres_if_strong'; fastforce?)
-    apply (frule state_relation_ready_queues_relation)
-    apply (frule in_ready_q_tcbQueued_eq[where t=tcbPtr])
-    apply (fastforce simp: obj_at'_def opt_pred_def opt_map_def obj_at_def is_tcb_def
-                           in_correct_ready_q_def etcb_at_def is_etcb_at_def)
+   apply (fastforce dest!: state_relation_ready_queues_relation
+                           in_ready_q_tcbQueued_eq[where t=tcbPtr]
+                     simp: obj_at'_def opt_pred_def opt_map_def in_correct_ready_q_def
+                           obj_at_def etcb_at_def etcbs_of'_def)
   apply (rule corres_symb_exec_r[OF _ threadGet_sp]; wpsimp?)
   apply (rule corres_symb_exec_r[OF _ threadGet_sp]; wpsimp?)
   apply (rule corres_symb_exec_r[OF _ gets_sp]; wpsimp?)
@@ -2969,24 +2786,23 @@ lemma tcbSchedDequeue_corres:
   apply (wpsimp wp: threadSet_wp getObject_tcb_wp
               simp: setQueue_def tcbQueueRemove_def
          split_del: if_split)
-  apply (frule (1) tcb_at_is_etcb_at)
-  apply (clarsimp simp: obj_at_def is_etcb_at_def etcb_at_def)
+  apply (clarsimp simp: obj_at_def)
   apply normalise_obj_at'
-  apply (rename_tac s d p s' tcb' tcb etcb)
-  apply (frule_tac t=tcbPtr in ekheap_relation_tcb_domain_priority)
+  apply (rename_tac s d p s' tcb' tcb)
+  apply (frule_tac t=tcbPtr in pspace_relation_tcb_domain_priority)
     apply (force simp: obj_at_def)
    apply (force simp: obj_at'_def)
 
-  apply (case_tac "d \<noteq> tcb_domain etcb \<or> p \<noteq> tcb_priority etcb")
+  apply (case_tac "d \<noteq> tcb_domain tcb \<or> p \<noteq> tcb_priority tcb")
    apply clarsimp
-   apply (cut_tac p=tcbPtr and ls="ready_queues s (tcb_domain etcb) (tcb_priority etcb)"
+   apply (cut_tac p=tcbPtr and ls="ready_queues s (tcb_domain tcb) (tcb_priority tcb)"
                in list_queue_relation_neighbour_in_set)
       apply (fastforce dest!: spec)
      apply fastforce
     apply fastforce
    apply (cut_tac xs="ready_queues s d p" in heap_path_head')
     apply (force dest!: spec simp: ready_queues_relation_def Let_def list_queue_relation_def)
-   apply (cut_tac d=d and d'="tcb_domain etcb" and p=p and p'="tcb_priority etcb"
+   apply (cut_tac d=d and d'="tcb_domain tcb" and p=p and p'="tcb_priority tcb"
                in ready_queues_disjoint)
       apply force
      apply fastforce
@@ -3010,7 +2826,7 @@ lemma tcbSchedDequeue_corres:
      apply (clarsimp simp: fun_upd_apply)
     apply (clarsimp simp: fun_upd_apply)
 
-   apply (clarsimp simp: etcb_at_def obj_at'_def)
+   apply (clarsimp simp: obj_at'_def)
    apply (intro conjI; clarsimp)
 
     \<comment> \<open>tcbPtr is the head of the ready queue\<close>
@@ -3056,8 +2872,8 @@ lemma tcbSchedDequeue_corres:
 
   \<comment> \<open>d = tcb_domain tcb \<and> p = tcb_priority tcb\<close>
   apply clarsimp
-  apply (drule_tac x="tcb_domain etcb" in spec)
-  apply (drule_tac x="tcb_priority etcb" in spec)
+  apply (drule_tac x="tcb_domain tcb" in spec)
+  apply (drule_tac x="tcb_priority tcb" in spec)
   apply (clarsimp simp: list_queue_relation_def)
   apply (frule heap_path_head')
   apply (frule heap_ls_distinct)
@@ -3070,7 +2886,7 @@ lemma tcbSchedDequeue_corres:
      apply (simp add: fun_upd_apply tcb_queue_remove_def queue_end_valid_def heap_ls_unique
                       heap_path_last_end)
     apply (simp add: fun_upd_apply prev_queue_head_def)
-   apply (case_tac "ready_queues s (tcb_domain etcb) (tcb_priority etcb)";
+   apply (case_tac "ready_queues s (tcb_domain tcb) (tcb_priority tcb)";
           clarsimp simp: tcb_queue_remove_def inQ_def opt_pred_def fun_upd_apply)
   apply (intro conjI; clarsimp)
 
@@ -3089,7 +2905,7 @@ lemma tcbSchedDequeue_corres:
       apply (clarsimp simp: opt_map_red opt_map_upd_triv fun_upd_apply)
      apply (clarsimp simp: queue_end_valid_def fun_upd_apply last_tl)
     apply (clarsimp simp: prev_queue_head_def fun_upd_apply)
-   apply (case_tac "ready_queues s (tcb_domain etcb) (tcb_priority etcb)";
+   apply (case_tac "ready_queues s (tcb_domain tcb) (tcb_priority tcb)";
           clarsimp simp: inQ_def opt_pred_def opt_map_def fun_upd_apply split: option.splits)
   apply (intro conjI; clarsimp)
 
@@ -3168,11 +2984,11 @@ lemma setThreadState_corres:
           (set_thread_state t ts) (setThreadState ts' t)"
   (is "?tsr \<Longrightarrow> corres dc ?Pre ?Pre' ?sts ?sts'")
   apply (simp add: set_thread_state_def setThreadState_def)
-  apply (simp add: set_thread_state_ext_def[abs_def])
+  apply (simp add: set_thread_state_act_def[abs_def])
   apply (subst bind_assoc[symmetric], subst thread_set_def[simplified, symmetric])
   apply (rule corres_guard_imp)
     apply (rule corres_split[where r'=dc])
-       apply (rule threadset_corres, (simp add: tcb_relation_def exst_same_def)+)
+       apply (rule threadset_corres, (simp add: tcb_relation_def inQ_def)+)
       apply (subst thread_get_test[where test="runnable"])
       apply (rule corres_split[OF thread_get_isRunnable_corres])
         apply (rule corres_split[OF getCurThread_corres])
@@ -3193,7 +3009,7 @@ lemma setBoundNotification_corres:
           (set_bound_notification t ntfn) (setBoundNotification ntfn t)"
   apply (simp add: set_bound_notification_def setBoundNotification_def)
   apply (subst thread_set_def[simplified, symmetric])
-  apply (rule threadset_corres, simp_all add:tcb_relation_def exst_same_def)
+  apply (rule threadset_corres, simp_all add:tcb_relation_def inQ_def)
   done
 
 crunch rescheduleRequired, tcbSchedDequeue, setThreadState, setBoundNotification
@@ -5903,155 +5719,6 @@ lemma asUser_irq_handlers':
   apply (simp add: asUser_def split_def)
   apply (wpsimp wp: threadSet_irq_handlers' [OF all_tcbI, OF ball_tcb_cte_casesI] select_f_inv)
   done
-
-(* the brave can try to move this up to near setObject_update_TCB_corres' *)
-
-definition non_exst_same :: "Structures_H.tcb \<Rightarrow> Structures_H.tcb \<Rightarrow> bool"
-where
-  "non_exst_same tcb tcb' \<equiv> \<exists>d p ts. tcb' = tcb\<lparr>tcbDomain := d, tcbPriority := p, tcbTimeSlice := ts\<rparr>"
-
-fun non_exst_same' :: "Structures_H.kernel_object \<Rightarrow> Structures_H.kernel_object \<Rightarrow> bool"
-where
-  "non_exst_same' (KOTCB tcb) (KOTCB tcb') = non_exst_same tcb tcb'" |
-  "non_exst_same' _ _ = True"
-
-lemma non_exst_same_prio_upd[simp]:
-  "non_exst_same tcb (tcbPriority_update f tcb)"
-  by (cases tcb, simp add: non_exst_same_def)
-
-lemma non_exst_same_timeSlice_upd[simp]:
-  "non_exst_same tcb (tcbTimeSlice_update f tcb)"
-  by (cases tcb, simp add: non_exst_same_def)
-
-lemma non_exst_same_domain_upd[simp]:
-  "non_exst_same tcb (tcbDomain_update f tcb)"
-  by (cases tcb, simp add: non_exst_same_def)
-
-lemma set_eobject_corres':
-  assumes e: "etcb_relation etcb tcb'"
-  assumes z: "\<And>s. obj_at' P ptr s
-               \<Longrightarrow> map_to_ctes ((ksPSpace s) (ptr \<mapsto> KOTCB tcb')) = map_to_ctes (ksPSpace s)"
-  shows
-    "corres dc
-       (tcb_at ptr and is_etcb_at ptr)
-       (obj_at' (\<lambda>ko. non_exst_same ko tcb') ptr and obj_at' P ptr
-        and obj_at' (\<lambda>tcb. (tcbDomain tcb \<noteq> tcbDomain tcb' \<or> tcbPriority tcb \<noteq> tcbPriority tcb')
-                            \<longrightarrow> \<not> tcbQueued tcb) ptr)
-       (set_eobject ptr etcb) (setObject ptr tcb')"
-  apply (rule corres_no_failI)
-   apply (rule no_fail_pre)
-    apply wp
-   apply (clarsimp simp: obj_at'_def)
-  apply (unfold set_eobject_def setObject_def)
-  apply (clarsimp simp: in_monad split_def bind_def gets_def get_def Bex_def
-                        put_def return_def modify_def get_object_def projectKOs
-                        updateObject_default_def in_magnitude_check objBits_simps')
-  apply (clarsimp simp add: state_relation_def z)
-  apply (clarsimp simp add: obj_at_def is_etcb_at_def)
-  apply (simp only: pspace_relation_def dom_fun_upd2 simp_thms)
-  apply (elim conjE)
-  apply (frule bspec, erule domI)
-  apply (rule conjI)
-   apply (rule ballI, drule(1) bspec)
-   apply (drule domD)
-   apply (clarsimp simp: is_other_obj_relation_type)
-   apply (drule(1) bspec)
-   apply (clarsimp simp: non_exst_same_def)
-   apply (case_tac bb; simp)
-     apply (clarsimp simp: obj_at'_def other_obj_relation_def tcb_relation_cut_def cte_relation_def
-                           tcb_relation_def projectKOs
-                     split: if_split_asm)+
-   apply (clarsimp simp: aobj_relation_cuts_def split: X64_A.arch_kernel_obj.splits)
-   apply (rename_tac arch_kernel_obj obj d p ts)
-   apply (case_tac arch_kernel_obj; simp)
-     apply (clarsimp simp: pte_relation_def pde_relation_def pdpte_relation_def pml4e_relation_def
-                           is_tcb_def
-                    split: if_split_asm)+
-  apply (extract_conjunct \<open>match conclusion in "ekheap_relation _ _" \<Rightarrow> -\<close>)
-   apply (simp only: ekheap_relation_def dom_fun_upd2 simp_thms)
-   apply (frule bspec, erule domI)
-   apply (rule ballI, drule(1) bspec)
-   apply (drule domD)
-   apply (clarsimp simp: obj_at'_def)
-   apply (insert e)
-   apply (clarsimp simp: other_obj_relation_def etcb_relation_def is_other_obj_relation_type
-                  split: Structures_A.kernel_object.splits kernel_object.splits arch_kernel_obj.splits)
-   apply (frule in_ready_q_tcbQueued_eq[where t=ptr])
-  apply (rename_tac s' conctcb' abstcb exttcb)
-  apply (clarsimp simp: ready_queues_relation_def Let_def)
-  apply (prop_tac "(tcbSchedNexts_of s')(ptr := tcbSchedNext tcb') = tcbSchedNexts_of s'")
-   apply (fastforce simp: opt_map_def obj_at'_def non_exst_same_def projectKOs split: option.splits)
-  apply (prop_tac "(tcbSchedPrevs_of s')(ptr := tcbSchedPrev tcb') = tcbSchedPrevs_of s'")
-   apply (fastforce simp: opt_map_def obj_at'_def non_exst_same_def projectKOs split: option.splits)
-  apply (clarsimp simp: ready_queue_relation_def opt_map_def opt_pred_def obj_at'_def inQ_def
-                        non_exst_same_def projectKOs
-                 split: option.splits)
-  apply metis
-  done
-
-lemma set_eobject_corres:
-  assumes tcbs: "non_exst_same tcb' tcbu'"
-  assumes e: "etcb_relation etcb tcb' \<Longrightarrow> etcb_relation etcbu tcbu'"
-  assumes tables': "\<forall>(getF, v) \<in> ran tcb_cte_cases. getF tcbu' = getF tcb'"
-  assumes r: "r () ()"
-  shows
-    "corres r
-       (tcb_at add and (\<lambda>s. ekheap s add = Some etcb))
-       (ko_at' tcb' add
-        and obj_at' (\<lambda>tcb. (tcbDomain tcb \<noteq> tcbDomain tcbu' \<or> tcbPriority tcb \<noteq> tcbPriority tcbu')
-                           \<longrightarrow> \<not> tcbQueued tcb) add)
-       (set_eobject add etcbu) (setObject add tcbu')"
-  apply (rule_tac F="non_exst_same tcb' tcbu' \<and> etcb_relation etcbu tcbu'" in corres_req)
-   apply (clarsimp simp: state_relation_def obj_at_def obj_at'_def)
-   apply (frule(1) pspace_relation_absD)
-   apply (clarsimp simp: projectKOs other_obj_relation_def ekheap_relation_def e tcbs)
-   apply (drule bspec, erule domI)
-   apply (clarsimp simp: e)
-  apply (erule conjE)
-  apply (rule corres_guard_imp)
-    apply (rule corres_rel_imp)
-     apply (rule set_eobject_corres'[where P="(=) tcb'"])
-      apply simp
-     defer
-    apply (simp add: r)
-   apply (fastforce simp: is_etcb_at_def elim!: obj_at_weakenE)
-   apply (subst(asm) eq_commute)
-   apply (clarsimp simp: obj_at'_def)
-  apply (clarsimp simp: projectKOs obj_at'_def objBits_simps)
-  apply (subst map_to_ctes_upd_tcb, assumption+)
-   apply (simp add: ps_clear_def3 field_simps objBits_defs mask_def)
-  apply (subst if_not_P)
-   apply (fastforce dest: bspec [OF tables', OF ranI])
-  apply simp
-  done
-
-lemma ethread_set_corresT:
-  assumes x: "\<And>tcb'. non_exst_same tcb' (f' tcb')"
-  assumes z: "\<forall>tcb. \<forall>(getF, setF) \<in> ran tcb_cte_cases. getF (f' tcb) = getF tcb"
-  assumes e: "\<And>etcb tcb'. etcb_relation etcb tcb' \<Longrightarrow> etcb_relation (f etcb) (f' tcb')"
-  shows
-    "corres dc
-       (tcb_at t and valid_etcbs)
-       (tcb_at' t
-        and obj_at' (\<lambda>tcb. (tcbDomain tcb \<noteq> tcbDomain (f' tcb)
-                             \<or> tcbPriority tcb \<noteq> tcbPriority (f' tcb))
-                           \<longrightarrow> \<not> tcbQueued tcb) t)
-       (ethread_set f t) (threadSet f' t)"
-  apply (simp add: ethread_set_def threadSet_def bind_assoc)
-  apply (rule corres_guard_imp)
-    apply (rule corres_split[OF corres_get_etcb set_eobject_corres])
-         apply (rule x)
-        apply (erule e)
-       apply (simp add: z)+
-     apply (wp getObject_tcb_wp)+
-   apply clarsimp
-   apply (simp add: valid_etcbs_def tcb_at_st_tcb_at[symmetric])
-   apply (force simp: tcb_at_def get_etcb_def obj_at_def)
-  apply (clarsimp simp: obj_at'_def)
-  done
-
-lemmas ethread_set_corres =
-    ethread_set_corresT [OF _ all_tcbI, OF _ ball_tcb_cte_casesI]
 
 end
 end

--- a/proof/refine/X64/Tcb_R.thy
+++ b/proof/refine/X64/Tcb_R.thy
@@ -228,7 +228,7 @@ lemma restart_corres:
         apply (clarsimp simp: invs'_def valid_state'_def sch_act_wf_weak valid_pspace'_def
                               valid_tcb_state'_def)
        apply wp+
-   apply (fastforce simp: valid_sched_def invs_def tcb_at_is_etcb_at)
+   apply (fastforce simp: valid_sched_def invs_def)
   apply (clarsimp simp add: invs'_def valid_state'_def sch_act_wf_weak)
   done
 
@@ -305,9 +305,6 @@ lemma invokeTCB_ReadRegisters_corres:
   apply (clarsimp simp: invs'_def valid_state'_def dest!: global'_no_ex_cap)
   done
 
-lemma einvs_valid_etcbs: "einvs s \<longrightarrow> valid_etcbs s"
-  by (clarsimp simp: valid_sched_def)
-
 lemma asUser_postModifyRegisters_corres:
   "corres dc (tcb_at t and pspace_aligned and pspace_distinct) (tcb_at' ct)
      (arch_post_modify_registers ct t)
@@ -359,7 +356,7 @@ lemma invokeTCB_WriteRegisters_corres:
               apply simp
              apply (wp+)[2]
            apply ((wp hoare_weak_lift_imp restart_invs'
-                   | strengthen valid_sched_weak_strg einvs_valid_etcbs
+                   | strengthen valid_sched_weak_strg
                                 invs_weak_sch_act_wf
                                 valid_queues_in_correct_ready_q valid_queues_ready_qs_distinct
                                 valid_sched_valid_queues valid_objs'_valid_tcbs' invs_valid_objs'
@@ -599,9 +596,63 @@ lemma tcbSchedDequeue_ct_in_state'[wp]:
   apply (rule hoare_lift_Pf [where f=ksCurThread]; wp)
   done
 
+lemma thread_set_ready_qs_distinct[wp]:
+  "thread_set f tcb_ptr \<lbrace>ready_qs_distinct\<rbrace>"
+  apply (wpsimp wp: thread_set_wp)
+  by (clarsimp simp: ready_qs_distinct_def)
+
+lemma thread_set_in_correct_ready_q_not_queued:
+  "\<lbrace>in_correct_ready_q and not_queued t\<rbrace>
+   thread_set f t
+   \<lbrace>\<lambda>_. in_correct_ready_q\<rbrace>"
+  unfolding thread_set_priority_def
+  apply (wpsimp wp: thread_set_wp)
+  apply (clarsimp simp: in_correct_ready_q_def not_queued_def is_etcb_at'_def etcb_at_def etcbs_of'_def)
+  done
+
+lemma tcb_sched_dequeue_in_correct_ready_q[wp]:
+  "tcb_sched_action tcb_sched_dequeue t \<lbrace>in_correct_ready_q\<rbrace> "
+  unfolding tcb_sched_action_def set_tcb_queue_def
+  apply (wpsimp wp: thread_get_wp')
+  apply (clarsimp simp: in_correct_ready_q_def tcb_sched_dequeue_def)
+  done
+
+lemma tcb_sched_dequeue_ready_qs_distinct[wp]:
+  "tcb_sched_action tcb_sched_dequeue t \<lbrace>ready_qs_distinct\<rbrace> "
+  unfolding tcb_sched_action_def set_tcb_queue_def
+  apply (wpsimp wp: thread_get_wp')
+  apply (clarsimp simp: ready_qs_distinct_def tcb_sched_dequeue_def)
+  done
+
+\<comment> \<open>For updating the domain and the priority fields of a TCB that is not in a ready queue\<close>
+lemma threadSet_not_queued_corres:
+  "\<lbrakk>\<And>tcb tcb'. tcb_relation tcb tcb' \<Longrightarrow> tcb_relation (f tcb) (F tcb');
+    \<And>tcb'. tcbSchedNext (F tcb') = tcbSchedNext tcb';
+    \<And>tcb'. tcbSchedPrev (F tcb') = tcbSchedPrev tcb';
+    \<And>tcb'. tcbQueued (F tcb') = tcbQueued tcb';
+    \<And>tcb. \<forall>(getF, v) \<in> ran tcb_cap_cases. getF (f tcb) = getF tcb;
+    \<And>tcb'. \<forall>(getF, v)\<in>ran tcb_cte_cases. getF (F tcb') = getF tcb'\<rbrakk>
+   \<Longrightarrow> corres dc (tcb_at t and not_queued t and pspace_aligned and pspace_distinct) \<top>
+         (thread_set f t) (threadSet F t)"
+  apply (rule_tac Q'="tcb_at' t" in corres_cross_add_guard)
+   apply (fastforce dest!: state_relationD elim!: tcb_at_cross)
+  apply (simp add: thread_set_def threadSet_def)
+  apply (rule corres_symb_exec_l[OF _ _ gets_the_sp]; wpsimp simp: tcb_at_def)
+  apply (rule corres_symb_exec_r[OF _ getObject_tcb_sp]; wpsimp?)
+  apply (rename_tac tcb tcb')
+  apply (rule stronger_corres_guard_imp)
+    apply (rule_tac F="\<not> tcbQueued tcb'" in corres_gen_asm)
+    apply (rule_tac tcb=tcb and tcb'=tcb' in setObject_update_TCB_corres';
+           fastforce simp: inQ_def)
+   apply (frule state_relation_ready_queues_relation)
+   apply (frule in_ready_q_tcbQueued_eq[where t=t])
+   apply (clarsimp simp: opt_pred_def opt_map_def obj_at'_def not_queued_def projectKOs)
+  apply clarsimp
+  done
+
 lemma sp_corres2:
   "corres dc
-     (valid_etcbs and weak_valid_sched_action and cur_tcb and tcb_at t
+     (weak_valid_sched_action and cur_tcb and tcb_at t
       and valid_queues and pspace_aligned and pspace_distinct)
      (tcb_at' t and (\<lambda>s. weak_sch_act_wf (ksSchedulerAction s) s)
       and valid_objs' and (\<lambda>_. x \<le> maxPriority)
@@ -610,8 +661,9 @@ lemma sp_corres2:
   apply (simp add: setPriority_def set_priority_def thread_set_priority_def)
   apply (rule stronger_corres_guard_imp)
     apply (rule corres_split[OF tcbSchedDequeue_corres], simp)
-      apply (rule corres_split[OF ethread_set_corres], simp_all)[1]
-         apply (simp add: etcb_relation_def)
+      apply (rule corres_split[OF threadSet_not_queued_corres];
+                           simp add: tcb_relation_def tcb_cap_cases_def tcb_cte_cases_def
+                                     cteSizeBits_def)
         apply (rule corres_split[OF isRunnable_corres])
           apply (erule corres_when)
           apply(rule corres_split[OF getCurThread_corres])
@@ -621,19 +673,19 @@ lemma sp_corres2:
            apply ((clarsimp
                    | wp hoare_weak_lift_imp hoare_vcg_if_lift hoare_wp_combs gts_wp
                         isRunnable_wp)+)[4]
-       apply (wp hoare_vcg_imp_lift' hoare_vcg_if_lift hoare_vcg_all_lift
-                 ethread_set_not_queued_valid_queues
-              | strengthen valid_queues_in_correct_ready_q valid_queues_ready_qs_distinct)+
+       apply (wpsimp wp: hoare_vcg_imp_lift' hoare_vcg_if_lift hoare_vcg_all_lift
+                         thread_set_in_correct_ready_q_not_queued thread_set_no_change_tcb_state
+                         thread_set_no_change_tcb_state_converse thread_set_weak_valid_sched_action)+
       apply ((wp hoare_vcg_imp_lift' hoare_vcg_all_lift
                  isRunnable_wp threadSet_pred_tcb_no_state
                  threadSet_valid_objs_tcbPriority_update threadSet_sched_pointers
                  threadSet_valid_sched_pointers tcb_dequeue_not_queued tcbSchedDequeue_not_queued
                  threadSet_weak_sch_act_wf
-              | simp add: etcb_relation_def
+              | simp add: tcb_relation_def
               | strengthen valid_objs'_valid_tcbs'
                 obj_at'_weakenE[where P="Not \<circ> tcbQueued"]
               | wps)+)
-   apply (force simp: valid_etcbs_def tcb_at_st_tcb_at[symmetric] state_relation_def
+   apply (force simp: tcb_at_st_tcb_at[symmetric] state_relation_def
                 dest: pspace_relation_tcb_at intro: st_tcb_at_opeqI)
   apply clarsimp
   done
@@ -654,7 +706,7 @@ lemma setMCPriority_corres:
     apply (clarsimp simp: setMCPriority_def set_mcpriority_def)
     apply (rule threadset_corresT)
        by (clarsimp simp: tcb_relation_def tcb_cap_cases_tcb_mcpriority
-                          tcb_cte_cases_def tcb_cte_cases_neqs exst_same_def)+
+                          tcb_cte_cases_def tcb_cte_cases_neqs inQ_def)+
 
 definition
  "out_rel fn fn' v v' \<equiv>
@@ -668,15 +720,14 @@ lemma out_corresT:
   assumes y: "\<And>v. \<forall>tcb. \<forall>(getF, setF)\<in>ran tcb_cte_cases. getF (fn' v tcb) = getF tcb"
   assumes sched_pointers: "\<And>tcb v. tcbSchedPrev (fn' v tcb) = tcbSchedPrev tcb"
                           "\<And>tcb v. tcbSchedNext (fn' v tcb) = tcbSchedNext tcb"
-  assumes flag: "\<And>tcb v. tcbQueued (fn' v tcb) = tcbQueued tcb"
-  assumes e: "\<And>tcb v. exst_same tcb (fn' v tcb)"
+  assumes flag: "\<And>d p tcb' v. inQ d p (fn' v tcb') = inQ d p tcb'"
   shows
   "out_rel fn fn' v v' \<Longrightarrow>
      corres dc (tcb_at t and pspace_aligned and pspace_distinct) \<top>
        (option_update_thread t fn v)
        (case_option (return ()) (\<lambda>x. threadSet (fn' x) t) v')"
   apply (case_tac v, simp_all add: out_rel_def option_update_thread_def)
-  apply (clarsimp simp: threadset_corresT [OF _ x y sched_pointers flag e])
+  apply (clarsimp simp: threadset_corresT [OF _ x y sched_pointers flag])
   done
 
 lemmas out_corres = out_corresT [OF _ all_tcbI, OF ball_tcb_cap_casesI ball_tcb_cte_casesI]
@@ -1002,26 +1053,24 @@ definition valid_tcb_invocation :: "tcbinvocation \<Rightarrow> bool" where
         ThreadControl _ _ _ mcp p _ _ _ \<Rightarrow> valid_option_prio p \<and> valid_option_prio mcp
       | _                           \<Rightarrow> True"
 
-lemma threadcontrol_corres_helper1:
-  "\<lbrace>einvs and simple_sched_action\<rbrace>
+lemma thread_set_ipc_weak_valid_sched_action:
+  "\<lbrace> einvs and simple_sched_action\<rbrace>
    thread_set (tcb_ipc_buffer_update f) a
-   \<lbrace>\<lambda>_. weak_valid_sched_action and valid_etcbs\<rbrace>"
+   \<lbrace>\<lambda>x. weak_valid_sched_action\<rbrace>"
   apply (rule hoare_pre)
    apply (simp add: thread_set_def)
    apply (wp set_object_wp)
   apply (simp | intro impI | elim exE conjE)+
   apply (frule get_tcb_SomeD)
   apply (erule ssubst)
-  apply (clarsimp simp add: weak_valid_sched_action_def valid_etcbs_2_def st_tcb_at_kh_def
-              get_tcb_def obj_at_kh_def obj_at_def is_etcb_at'_def valid_sched_def valid_sched_action_def)
-  apply (erule_tac x=a in allE)+
-  apply (clarsimp simp: is_tcb_def)
+  apply (clarsimp simp: weak_valid_sched_action_def st_tcb_at_kh_def obj_at_kh_def valid_sched_def
+                        valid_sched_action_def)
   done
 
 lemma threadcontrol_corres_helper3:
   "\<lbrace>einvs and simple_sched_action\<rbrace>
    check_cap_at cap p (check_cap_at (cap.ThreadCap cap') slot (cap_insert cap p tcb_slot))
-   \<lbrace>\<lambda>_ s. weak_valid_sched_action s \<and> in_correct_ready_q s \<and> ready_qs_distinct s \<and> valid_etcbs s
+   \<lbrace>\<lambda>_ s. weak_valid_sched_action s \<and> in_correct_ready_q s \<and> ready_qs_distinct s
           \<and> pspace_aligned s \<and> pspace_distinct s\<rbrace>"
    apply (wpsimp
           | strengthen valid_sched_valid_queues valid_queues_in_correct_ready_q
@@ -1141,25 +1190,6 @@ lemma assertDerived_wp_weak:
   apply (wpsimp simp: assertDerived_def)
   done
 
-lemma thread_set_ipc_weak_valid_sched_action:
-  "\<lbrace> einvs and simple_sched_action\<rbrace>
-   thread_set (tcb_ipc_buffer_update f) a
-   \<lbrace>\<lambda>x. weak_valid_sched_action\<rbrace>"
-  apply (rule hoare_pre)
-   apply (simp add: thread_set_def)
-   apply (wp set_object_wp)
-  apply (simp | intro impI | elim exE conjE)+
-  apply (frule get_tcb_SomeD)
-  apply (erule ssubst)
-  apply (clarsimp simp add: weak_valid_sched_action_def valid_etcbs_2_def st_tcb_at_kh_def
-              get_tcb_def obj_at_kh_def obj_at_def is_etcb_at'_def valid_sched_def valid_sched_action_def)
-  done
-
-crunch cap_insert
-  for in_correct_ready_q[wp]: in_correct_ready_q
-  and ready_qs_distinct[wp]: ready_qs_distinct
-  (wp: crunch_wps ready_qs_distinct_lift)
-
 crunch cap_delete
   for pspace_aligned[wp]: "pspace_aligned :: det_state \<Rightarrow> _"
   and pspace_distinct[wp]: "pspace_distinct :: det_state \<Rightarrow> _"
@@ -1226,7 +1256,7 @@ proof -
                (option_map to_bl v))
                (case v of None \<Rightarrow> return ()
                  | Some x \<Rightarrow> threadSet (tcbFaultHandler_update (%_. x)) t)"
-    apply (rule out_corres, simp_all add: exst_same_def)
+    apply (rule out_corres, simp_all add: inQ_def)
     apply (case_tac v, simp_all add: out_rel_def)
     apply (safe, case_tac tcb', simp add: tcb_relation_def split: option.split)
     done
@@ -1236,7 +1266,7 @@ proof -
                (option_update_thread t (tcb_ipc_buffer_update o (%x _. x)) v)
                (case v of None \<Rightarrow> return ()
                  | Some x \<Rightarrow> threadSet (tcbIPCBuffer_update (%_. x)) t)"
-    apply (rule out_corres, simp_all add: exst_same_def)
+    apply (rule out_corres, simp_all )
     apply (case_tac v, simp_all add: out_rel_def)
     apply (safe, case_tac tcb', simp add: tcb_relation_def)
     done
@@ -1365,20 +1395,19 @@ proof -
             apply (rule cteDelete_corres)
            apply (rule_tac F="is_aligned aa msg_align_bits" in corres_gen_asm2)
            apply (rule corres_split_nor)
-              apply (rule threadset_corres,
-                      (simp add: tcb_relation_def), (simp add: exst_same_def)+)[1]
+              apply (rule threadset_corres; simp add: tcb_relation_def)
              apply (rule corres_split[OF getCurThread_corres], clarsimp)
                apply (rule corres_when[OF refl rescheduleRequired_corres])
               apply (wpsimp wp: gct_wp)+
             apply (strengthen valid_queues_ready_qs_distinct)
             apply (wpsimp wp: thread_set_ipc_weak_valid_sched_action thread_set_valid_queues
-                              hoare_drop_imp)
+                              hoare_drop_imp in_correct_ready_q_lift thread_set_etcbs)
            apply clarsimp
            apply (strengthen valid_objs'_valid_tcbs' invs_valid_objs')+
            apply (wpsimp wp: threadSet_sched_pointers threadSet_valid_sched_pointers hoare_drop_imp
                              threadSet_invs_tcbIPCBuffer_update)
           apply (clarsimp simp: pred_conj_def)
-          apply (strengthen einvs_valid_etcbs valid_queues_in_correct_ready_q
+          apply (strengthen valid_queues_in_correct_ready_q
                             valid_sched_valid_queues)+
           apply wp
          apply (clarsimp simp: pred_conj_def)
@@ -1394,8 +1423,7 @@ proof -
                         in corres_gen_asm)
           apply (rule_tac F="isArchObjectCap ac" in corres_gen_asm2)
           apply (rule corres_split_nor)
-             apply (rule threadset_corres,
-                    simp add: tcb_relation_def, (simp add: exst_same_def)+)
+             apply (rule threadset_corres; simp add: tcb_relation_def)
             apply (rule corres_split)
                apply (erule checkCapAt_cteInsert_corres)
               apply (rule corres_split[OF getCurThread_corres], clarsimp)
@@ -1775,7 +1803,7 @@ lemma invokeTCB_corres:
            apply (rule TcbAcc_R.rescheduleRequired_corres)
           apply (rule corres_trivial, simp)
          apply (wpsimp wp: hoare_drop_imp)+
-   apply (fastforce dest: valid_sched_valid_queues simp: valid_sched_weak_strg einvs_valid_etcbs)
+   apply (fastforce dest: valid_sched_valid_queues simp: valid_sched_weak_strg)
   apply fastforce
   done
 
@@ -2001,7 +2029,7 @@ lemma decodeSetPriority_corres:
   "\<lbrakk> cap_relation cap cap'; is_thread_cap cap;
      list_all2 (\<lambda>(c, sl) (c', sl'). cap_relation c c' \<and> sl' = cte_map sl) extras extras' \<rbrakk> \<Longrightarrow>
    corres (ser \<oplus> tcbinv_relation)
-       (cur_tcb and valid_etcbs and
+       (cur_tcb and
         (pspace_aligned and pspace_distinct and (\<lambda>s. \<forall>x \<in> set extras. s \<turnstile> fst x)))
        (invs' and (\<lambda>s. \<forall>x \<in> set extras'. s \<turnstile>' fst x))
        (decode_set_priority args cap slot extras)
@@ -2021,7 +2049,7 @@ lemma decodeSetMCPriority_corres:
   "\<lbrakk> cap_relation cap cap'; is_thread_cap cap;
      list_all2 (\<lambda>(c, sl) (c', sl'). cap_relation c c' \<and> sl' = cte_map sl) extras extras' \<rbrakk> \<Longrightarrow>
    corres (ser \<oplus> tcbinv_relation)
-       (cur_tcb and valid_etcbs and
+       (cur_tcb and
         (pspace_aligned and pspace_distinct and (\<lambda>s. \<forall>x \<in> set extras. s \<turnstile> fst x)))
        (invs' and (\<lambda>s. \<forall>x \<in> set extras'. s \<turnstile>' fst x))
        (decode_set_mcpriority args cap slot extras)
@@ -2131,7 +2159,7 @@ lemma decodeSetSchedParams_corres:
   "\<lbrakk> cap_relation cap cap'; is_thread_cap cap;
      list_all2 (\<lambda>(c, sl) (c', sl'). cap_relation c c' \<and> sl' = cte_map sl) extras extras' \<rbrakk> \<Longrightarrow>
    corres (ser \<oplus> tcbinv_relation)
-       (cur_tcb and valid_etcbs and
+       (cur_tcb and
         (pspace_aligned and pspace_distinct and (\<lambda>s. \<forall>x \<in> set extras. s \<turnstile> fst x)))
        (invs' and (\<lambda>s. \<forall>x \<in> set extras'. s \<turnstile>' fst x))
        (decode_set_sched_params args cap slot extras)

--- a/proof/refine/X64/Untyped_R.thy
+++ b/proof/refine/X64/Untyped_R.thy
@@ -1371,7 +1371,7 @@ lemma in_getCTE2:
 declare wrap_ext_op_det_ext_ext_def[simp]
 
 lemma do_ext_op_update_cdt_list_symb_exec_l':
-  "corres_underlying {(s::det_state, s'). f (kheap s) (ekheap s) s'} nf nf' dc P P' (create_cap_ext p z a) (return x)"
+  "corres_underlying {(s::det_state, s'). f (kheap s) s'} nf nf' dc P P' (create_cap_ext p z a) (return x)"
   apply (simp add: corres_underlying_def create_cap_ext_def
   update_cdt_list_def set_cdt_list_def bind_def put_def get_def gets_def return_def)
   done
@@ -1409,16 +1409,13 @@ lemma set_cdt_symb_exec_l:
   by (simp add: corres_underlying_def return_def set_cdt_def in_monad Bex_def)
 
 crunch create_cap_ext
-  for domain_index[wp]: "\<lambda>s. P (domain_index s)"
-  and domain_list[wp]: "\<lambda>s. P (domain_list s)"
-  and domain_time[wp]: "\<lambda>s. P (domain_time s)"
-  and work_units_completed[wp]: "\<lambda>s. P (work_units_completed s)"
+  for work_units_completed[wp]: "\<lambda>s. P (work_units_completed s)"
   (ignore_del: create_cap_ext)
 
 context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma updateNewFreeIndex_noop_psp_corres:
-  "corres_underlying {(s, s'). pspace_relations (ekheap s) (kheap s) (ksPSpace s')} False True
+  "corres_underlying {(s, s'). pspace_relation (kheap s) (ksPSpace s')} False True
     dc \<top> (cte_at' slot)
     (return ()) (updateNewFreeIndex slot)"
   apply (simp add: updateNewFreeIndex_def)
@@ -1429,6 +1426,10 @@ lemma updateNewFreeIndex_noop_psp_corres:
       apply (wp getCTE_wp' | wpc
         | simp add: updateTrackedFreeIndex_def getSlotCap_def)+
   done
+
+crunch set_cap, set_cdt
+  for domain_index[wp]: "\<lambda>s. P (domain_index s)"
+  (wp: crunch_wps)
 
 crunch updateMDB, updateNewFreeIndex, setCTE
   for rdyq_projs[wp]:
@@ -3061,38 +3062,31 @@ lemma createNewCaps_range_helper:
   apply (frule range_cover.range_cover_n_less)
   apply (frule range_cover.unat_of_nat_n)
   apply (cases tp, simp_all split del: if_split)
-          apply (rename_tac apiobject_type)
-          apply (case_tac apiobject_type, simp_all split del: if_split)
-              apply (rule hoare_pre, wp)
-              apply (frule range_cover_not_zero[rotated -1],simp)
-              apply (clarsimp simp: APIType_capBits_def objBits_simps archObjSize_def ptr_add_def o_def)
-              apply (subst upto_enum_red')
-               apply unat_arith
-              apply (clarsimp simp: o_def fromIntegral_def toInteger_nat fromInteger_nat)
-              apply fastforce
-             apply (rule hoare_pre,wp createObjects_ret2)
-             apply (clarsimp simp: APIType_capBits_def word_bits_def bit_simps
-                objBits_simps archObjSize_def ptr_add_def o_def)
-             apply (fastforce simp: objBitsKO_def objBits_def)
-            apply (rule hoare_pre,wp createObjects_ret2)
-            apply (clarsimp simp: APIType_capBits_def word_bits_def
-                                  objBits_simps archObjSize_def ptr_add_def o_def)
-            apply (fastforce simp: objBitsKO_def  objBits_def)
-           apply (rule hoare_pre,wp createObjects_ret2)
-           apply (clarsimp simp:  APIType_capBits_def word_bits_def
-              objBits_simps archObjSize_def ptr_add_def o_def)
-           apply (fastforce simp: objBitsKO_def  objBits_def)
-          apply (rule hoare_pre,wp createObjects_ret2)
-          apply (clarsimp simp: APIType_capBits_def word_bits_def
-             objBits_simps archObjSize_def ptr_add_def o_def)
-          apply (fastforce simp: objBitsKO_def  objBits_def)
-        apply (wp createObjects_ret2
-          | clarsimp simp: APIType_capBits_def objBits_if_dev archObjSize_def
-                        word_bits_def  bit_simps
-                        split del: if_split
-          | simp add: objBits_simps
-          | (rule exI, (fastforce simp: bit_simps)))+
-  done
+         apply (rename_tac apiobject_type)
+         apply (case_tac apiobject_type, simp_all split del: if_split)
+             \<comment>\<open>Untyped\<close>
+             apply (rule hoare_pre, wp)
+             apply (frule range_cover_not_zero[rotated -1],simp)
+             apply (clarsimp simp: APIType_capBits_def objBits_simps ptr_add_def o_def)
+             apply (subst upto_enum_red')
+              apply unat_arith
+             apply (clarsimp simp: o_def fromIntegral_def toInteger_nat fromInteger_nat)
+             apply fastforce
+            \<comment>\<open>TCB\<close>
+            apply (rule hoare_pre, wp createObjects_ret2)
+             apply (wpsimp simp: curDomain_def)
+            apply (clarsimp simp: APIType_capBits_def word_bits_def objBits_simps ptr_add_def o_def)
+            apply (fastforce simp: objBitsKO_def objBits_def)
+            \<comment>\<open>other APIObjectType\<close>
+           apply ((rule hoare_pre, wp createObjects_ret2,
+                   clarsimp simp: APIType_capBits_def word_bits_def objBits_simps ptr_add_def o_def,
+                   fastforce simp: objBitsKO_def objBits_def)+)[3]
+        \<comment>\<open>Arch objects\<close>
+        by (wp createObjects_ret2
+            | clarsimp simp: APIType_capBits_def objBits_if_dev word_bits_def
+                  split del: if_split
+            | simp add: objBits_simps
+            | (rule exI, (fastforce simp: bit_simps)))+
 
 lemma createNewCaps_range_helper2:
   "\<lbrace>\<lambda>s. range_cover ptr sz (APIType_capBits tp us) n \<and> 0 < n\<rbrace>
@@ -4135,9 +4129,6 @@ end
 
 context begin interpretation Arch . (*FIXME: arch-split*)
 
-lemma valid_sched_etcbs[elim!]: "valid_sched_2 queues ekh sa cdom kh ct it \<Longrightarrow> valid_etcbs_2 ekh kh"
-  by (simp add: valid_sched_def)
-
 crunch deleteObjects
   for ksIdleThread[wp]: "\<lambda>s. P (ksIdleThread s)"
   (simp: crunch_simps wp: hoare_drop_imps unless_wp ignore: freeMemory)
@@ -5062,7 +5053,7 @@ lemma inv_untyped_corres':
                 invs_distinct)
          apply (clarsimp simp:conj_comms ball_conj_distrib ex_in_conv)
          apply ((rule validE_R_validE)?,
-          rule_tac Q'="\<lambda>_ s. valid_etcbs s \<and> valid_list s \<and> invs s \<and> ct_active s
+          rule_tac Q'="\<lambda>_ s. valid_list s \<and> invs s \<and> ct_active s
           \<and> valid_untyped_inv_wcap ui
             (Some (cap.UntypedCap dev (ptr && ~~ mask sz) sz (if reset then 0 else idx))) s
           \<and> (reset \<longrightarrow> pspace_no_overlap {ptr && ~~ mask sz..(ptr && ~~ mask sz) + 2 ^ sz - 1} s)
@@ -5150,7 +5141,7 @@ lemma inv_untyped_corres':
       apply (clarsimp simp only: pred_conj_def invs ui)
       apply (strengthen vui)
       apply (cut_tac vui invs invs')
-      apply (clarsimp simp: cte_wp_at_caps_of_state valid_sched_etcbs schact_is_rct_def)
+      apply (clarsimp simp: cte_wp_at_caps_of_state schact_is_rct_def)
      apply (cut_tac vui' invs')
      apply (clarsimp simp: ui cte_wp_at_ctes_of if_apply_def2 ui')
      done

--- a/proof/refine/X64/Untyped_R.thy
+++ b/proof/refine/X64/Untyped_R.thy
@@ -3077,7 +3077,7 @@ lemma createNewCaps_range_helper:
              apply (wpsimp simp: curDomain_def)
             apply (clarsimp simp: APIType_capBits_def word_bits_def objBits_simps ptr_add_def o_def)
             apply (fastforce simp: objBitsKO_def objBits_def)
-            \<comment>\<open>other APIObjectType\<close>
+           \<comment>\<open>other APIObjectType\<close>
            apply ((rule hoare_pre, wp createObjects_ret2,
                    clarsimp simp: APIType_capBits_def word_bits_def objBits_simps ptr_add_def o_def,
                    fastforce simp: objBitsKO_def objBits_def)+)[3]


### PR DESCRIPTION
This extends the changes made in https://github.com/seL4/l4v/pull/824 for the functional correctness proofs for all architectures.