### PR TITLE
Update other top level proofs for det_ext changes

### DIFF
--- a/proof/access-control/RISCV64/ArchAccess.thy
+++ b/proof/access-control/RISCV64/ArchAccess.thy
@@ -74,6 +74,11 @@ lemmas state_vrefs_upd =
   revokable_update.state_vrefs
   machine_state_update.state_vrefs
   more_update.state_vrefs
+  scheduler_action_update.state_vrefs
+  domain_index_update.state_vrefs
+  cur_domain_update.state_vrefs
+  domain_time_update.state_vrefs
+  ready_queues_update.state_vrefs
 
 end
 
@@ -152,6 +157,11 @@ lemmas integrity_asids_updates =
   interrupt_update.integrity_asids_update
   cur_thread_update.integrity_asids_update
   machine_state_update.integrity_asids_update
+  scheduler_action_update.integrity_asids_update
+  domain_index_update.integrity_asids_update
+  cur_domain_update.integrity_asids_update
+  domain_time_update.integrity_asids_update
+  ready_queues_update.integrity_asids_update
 
 lemma integrity_asids_cnode_update':
   "\<lbrakk> kheap st p = Some (CNode sz cs); integrity_asids aag subjects x a st (s\<lparr>kheap := rest\<rparr>) \<rbrakk>

--- a/proof/access-control/RISCV64/ArchArch_AC.thy
+++ b/proof/access-control/RISCV64/ArchArch_AC.thy
@@ -311,9 +311,8 @@ lemma store_pte_thread_bound_ntfns[wp]:
                  elim!: rsubst[where P=P, OF _ ext])
   done
 
-lemma store_pte_domains_of_state[wp]:
-  "store_pte p pte \<lbrace>\<lambda>s. P (domains_of_state s)\<rbrace>"
-  unfolding store_pte_def set_pt_def by (wpsimp wp: set_object_wp)
+crunch store_pte
+  for etcbs_of[wp]: "\<lambda>s. P (etcbs_of s)"
 
 lemma mapM_x_store_pte_caps_of_state[wp]:
   "mapM_x (swp store_pte InvalidPTE) slots \<lbrace>\<lambda>s. P (asid_table s)\<rbrace>"
@@ -775,14 +774,6 @@ lemma perform_page_table_invocation_pas_refined:
   apply (case_tac iv; clarsimp)
   done
 
-(* FIXME move to AInvs *)
-lemma store_pte_ekheap[wp]:
-  "store_pte p pte \<lbrace>\<lambda>s. P (ekheap s)\<rbrace>"
-  apply (simp add: store_pte_def set_pt_def)
-  apply (wp get_object_wp)
-  apply simp
-  done
-
 lemma set_asid_pool_thread_st_auth[wp]:
   "set_asid_pool p pool \<lbrace>\<lambda>s. P (thread_st_auth s)\<rbrace>"
   apply (simp add: set_asid_pool_def)
@@ -799,13 +790,6 @@ lemma set_asid_pool_thread_bound_ntfns[wp]:
   apply (clarsimp simp: thread_bound_ntfns_def obj_at_def get_tcb_def tcb_states_of_state_def
                  elim!: rsubst[where P=P, OF _ ext]
                  split: kernel_object.split_asm option.split)
-  done
-
-(* FIXME move to AInvs *)
-lemma set_asid_pool_ekheap[wp]:
-  "set_asid_pool p pool \<lbrace>\<lambda>s. P (ekheap s)\<rbrace>"
-  apply (simp add: set_asid_pool_def)
-  apply (wp get_object_wp | simp)+
   done
 
 crunch set_asid_pool
@@ -1898,19 +1882,19 @@ lemma decode_arch_invocation_authorised:
   apply auto
   done
 
-lemma authorised_arch_inv_sa_update:
+lemma authorised_arch_inv_sa_update[simp]:
   "authorised_arch_inv aag i (scheduler_action_update (\<lambda>_. act) s) =
    authorised_arch_inv aag i s"
   by (clarsimp simp: authorised_arch_inv_def authorised_page_inv_def authorised_slots_def
               split: arch_invocation.splits page_invocation.splits)
 
+crunch set_thread_state_act
+  for authorised_arch_inv[wp]: "authorised_arch_inv aag i"
+
 lemma set_thread_state_authorised_arch_inv[wp]:
   "set_thread_state ref ts \<lbrace>authorised_arch_inv aag i\<rbrace>"
   unfolding set_thread_state_def
-  apply (wpsimp wp: dxo_wp_weak)
-     apply (clarsimp simp: authorised_arch_inv_def authorised_page_inv_def authorised_slots_def
-                    split: arch_invocation.splits page_invocation.splits)
-    apply (wpsimp wp: set_object_wp)+
+  apply (wpsimp wp: set_object_wp)
   apply (clarsimp simp: authorised_arch_inv_def authorised_page_inv_def
                         authorised_slots_def vs_lookup_slot_def obind_def
                  split: arch_invocation.splits page_invocation.splits if_splits option.splits)

--- a/proof/access-control/RISCV64/ArchCNode_AC.thy
+++ b/proof/access-control/RISCV64/ArchCNode_AC.thy
@@ -131,15 +131,12 @@ lemma list_integ_lift[CNode_AC_assms]:
     "\<lbrace>list_integ (cdt_change_allowed aag {pasSubject aag} (cdt st) (tcb_states_of_state st)) st and Q\<rbrace>
      f
      \<lbrace>\<lambda>_. list_integ (cdt_change_allowed aag {pasSubject aag}  (cdt st) (tcb_states_of_state st)) st\<rbrace>"
-  assumes ekh: "\<And>P. f \<lbrace>\<lambda>s. P (ekheap s)\<rbrace>"
-  assumes rq: "\<And>P. f \<lbrace>\<lambda>s. P (ready_queues s)\<rbrace>"
   shows "\<lbrace>integrity aag X st and Q\<rbrace> f \<lbrace>\<lambda>_. integrity aag X st\<rbrace>"
   apply (rule hoare_pre)
    apply (unfold integrity_def[abs_def] integrity_asids_def)
    apply (simp only: integrity_cdt_list_as_list_integ)
-   apply (rule hoare_lift_Pf2[where f="ekheap"])
-    apply (simp add: tcb_states_of_state_def get_tcb_def)
-    apply (wp li[simplified tcb_states_of_state_def get_tcb_def] ekh rq)+
+   apply (simp add: tcb_states_of_state_def get_tcb_def)
+   apply (wp li[simplified tcb_states_of_state_def get_tcb_def])+
   apply (simp only: integrity_cdt_list_as_list_integ)
   apply (simp add: tcb_states_of_state_def get_tcb_def)
   done

--- a/proof/access-control/RISCV64/ArchFinalise_AC.thy
+++ b/proof/access-control/RISCV64/ArchFinalise_AC.thy
@@ -75,26 +75,26 @@ lemma delete_asid_pas_refined[wp]:
                  in hoare_strengthen_post[rotated])
      defer
      apply wpsimp+
-  apply (clarsimp simp: pas_refined_def)
-  apply (intro conjI)
-    apply (clarsimp simp: state_objs_to_policy_def)
-    apply (subst (asm) caps_of_state_fun_upd[simplified fun_upd_def])
-     apply (clarsimp simp: obj_at_def)
-    apply (erule subsetD)
-    apply (clarsimp simp: auth_graph_map_def)
-    apply (rule exI, rule conjI, rule refl)+
-    apply (erule state_bits_to_policy_vrefs_subseteq)
-        apply clarsimp
-       apply (clarsimp simp: all_ext thread_st_auth_def tcb_states_of_state_def get_tcb_def obj_at_def)
-      apply (clarsimp simp: all_ext thread_bound_ntfns_def get_tcb_def obj_at_def)
+  apply (erule pas_refined_subsets_tcb_domain_map_wellformed)
+      apply (clarsimp simp: state_objs_to_policy_def)
+      apply (subst (asm) caps_of_state_fun_upd[simplified fun_upd_def])
+       apply (clarsimp simp: obj_at_def)
+      apply (erule state_bits_to_policy_vrefs_subseteq)
+          apply clarsimp
+         apply (clarsimp simp: all_ext thread_st_auth_def tcb_states_of_state_def get_tcb_def obj_at_def)
+        apply (clarsimp simp: all_ext thread_bound_ntfns_def get_tcb_def obj_at_def)
+       apply clarsimp
+      apply (rule allI[OF state_vrefs_clear_asid_pool]; simp)
      apply clarsimp
-    apply (rule allI[OF state_vrefs_clear_asid_pool]; simp)
+     apply (erule state_asids_to_policy_vrefs_subseteq)
+       apply (fastforce simp: obj_at_def caps_of_state_fun_upd[simplified fun_upd_def])
+      apply (rule allI[OF state_vrefs_clear_asid_pool]; fastforce)
+     apply fastforce
+    apply (fastforce simp: obj_at_def caps_of_state_fun_upd[simplified fun_upd_def])
+   apply (subst tcb_domain_map_wellformed_etcbs_of[where P="kheap_update f" for f])
+    apply (fastforce simp: etcbs_of'_def obj_at_def split: option.splits)
    apply clarsimp
-   apply (erule subsetD, erule state_asids_to_policy_vrefs_subseteq)
-     apply (fastforce simp: obj_at_def caps_of_state_fun_upd[simplified fun_upd_def])
-    apply (rule allI[OF state_vrefs_clear_asid_pool]; fastforce)
-   apply fastforce
-  apply (fastforce simp: obj_at_def caps_of_state_fun_upd[simplified fun_upd_def])
+  apply clarsimp
   done
 
 lemma arch_finalise_cap_pas_refined[wp]:

--- a/proof/access-control/RISCV64/ArchIpc_AC.thy
+++ b/proof/access-control/RISCV64/ArchIpc_AC.thy
@@ -21,6 +21,7 @@ declare handle_arch_fault_reply_typ_at[Ipc_AC_assms]
 
 crunch cap_insert_ext
   for integrity_asids[Ipc_AC_assms, wp]: "integrity_asids aag subjects x a st"
+  (ignore_del: cap_insert_ext) \<comment> \<open>FIXME: should these ext consts still be ignored in DetSched_AI files and beyond?\<close>
 
 lemma arch_derive_cap_auth_derived[Ipc_AC_assms]:
   "\<lbrace>\<top>\<rbrace> arch_derive_cap acap \<lbrace>\<lambda>rv _. rv \<noteq> NullCap \<longrightarrow> auth_derived rv (ArchObjectCap acap)\<rbrace>, -"
@@ -203,8 +204,6 @@ lemma list_integ_lift_in_ipc[Ipc_AC_assms]:
    "\<lbrace>list_integ (cdt_change_allowed aag {pasSubject aag} (cdt st) (tcb_states_of_state st)) st and Q\<rbrace>
     f
     \<lbrace>\<lambda>_. list_integ (cdt_change_allowed aag {pasSubject aag} (cdt st) (tcb_states_of_state st)) st\<rbrace>"
-  assumes ekh: "\<And>P. \<lbrace>\<lambda>s. P (ekheap s)\<rbrace> f \<lbrace>\<lambda>rv s. P (ekheap s)\<rbrace>"
-  assumes rq: "\<And>P. \<lbrace> \<lambda>s. P (ready_queues s) \<rbrace> f \<lbrace> \<lambda>rv s. P (ready_queues s) \<rbrace>"
   shows "\<lbrace>integrity_tcb_in_ipc aag X receiver epptr ctxt st and Q\<rbrace>
          f
          \<lbrace>\<lambda>_. integrity_tcb_in_ipc aag X receiver epptr ctxt st\<rbrace>"
@@ -212,9 +211,8 @@ lemma list_integ_lift_in_ipc[Ipc_AC_assms]:
   apply (simp del:split_paired_All)
   apply (rule hoare_pre)
    apply (simp only: integrity_cdt_list_as_list_integ)
-   apply (rule hoare_lift_Pf2[where f="ekheap"])
-    apply (simp add: tcb_states_of_state_def get_tcb_def)
-    apply (wp li[simplified tcb_states_of_state_def get_tcb_def] ekh rq)+
+   apply (simp add: tcb_states_of_state_def get_tcb_def)
+   apply (wp li[simplified tcb_states_of_state_def get_tcb_def])+
   apply (simp only: integrity_cdt_list_as_list_integ)
   apply (simp add: tcb_states_of_state_def get_tcb_def)
   apply (fastforce simp: opt_map_def)

--- a/proof/access-control/RISCV64/ArchTcb_AC.thy
+++ b/proof/access-control/RISCV64/ArchTcb_AC.thy
@@ -32,14 +32,12 @@ lemma invoke_tcb_tc_respects_aag[Tcb_AC_assms]:
   apply (rule hoare_gen_asm)+
   apply (subst invoke_tcb.simps)
   apply (subst option_update_thread_def)
-  apply (subst set_priority_extended.dxo_eq)
   apply (rule hoare_weaken_pre)
    apply (rule_tac P="case ep of Some v \<Rightarrow> length v = word_bits | _ \<Rightarrow> True"
                  in hoare_gen_asm)
    apply (simp only: split_def)
   apply (((simp add: conj_comms,
           strengthen imp_consequent[where Q="x = None" for x], simp cong: conj_cong)
-         | strengthen invs_psp_aligned invs_vspace_objs invs_arch_state
          | rule wp_split_const_if wp_split_const_if_R hoare_vcg_all_liftE_R
                 hoare_vcg_conj_elimE hoare_vcg_const_imp_liftE_R hoare_vcg_conj_liftE_R
          | wp restart_integrity_autarch set_mcpriority_integrity_autarch
@@ -79,7 +77,8 @@ lemma invoke_tcb_tc_respects_aag[Tcb_AC_assms]:
          | simp add: ran_tcb_cap_cases dom_tcb_cap_cases[simplified]
                      emptyable_def a_type_def partial_inv_def
          | wpc
-         | strengthen invs_mdb use_no_cap_to_obj_asid_strg
+         | strengthen invs_psp_aligned invs_vspace_objs invs_arch_state
+                      invs_mdb use_no_cap_to_obj_asid_strg
                       tcb_cap_always_valid_strg[where p="tcb_cnode_index 0"]
                       tcb_cap_always_valid_strg[where p="tcb_cnode_index (Suc 0)"]))+
   apply (clarsimp simp: authorised_tcb_inv_def)

--- a/proof/access-control/RISCV64/ExampleSystem.thy
+++ b/proof/access-control/RISCV64/ExampleSystem.thy
@@ -306,6 +306,9 @@ where
      tcb_fault              = undefined,
      tcb_bound_notification = None,
      tcb_mcpriority         = undefined,
+     tcb_priority           = undefined,
+     tcb_time_slice         = undefined,
+     tcb_domain             = 0,
      tcb_arch               = \<lparr>tcb_context = undefined\<rparr> \<rparr>"
 
 
@@ -327,6 +330,9 @@ where
      tcb_fault              = undefined,
      tcb_bound_notification = None,
      tcb_mcpriority         = undefined,
+     tcb_priority           = undefined,
+     tcb_time_slice         = undefined,
+     tcb_domain             = 0,
      tcb_arch               = \<lparr>tcb_context = undefined\<rparr>\<rparr>"
 
 definition
@@ -356,13 +362,6 @@ lemmas kh1_obj_def =
 
 definition exst1 :: "det_ext" where
   "exst1 \<equiv> \<lparr>work_units_completed_internal = undefined,
-             scheduler_action_internal = undefined,
-             ekheap_internal = \<lambda>x. None,
-             domain_list_internal = undefined,
-             domain_index_internal = undefined,
-             cur_domain_internal = undefined,
-             domain_time_internal = undefined,
-             ready_queues_internal = undefined,
              cdt_list_internal = undefined\<rparr>"
 
 definition
@@ -374,6 +373,12 @@ where
     is_original_cap = undefined,
     cur_thread = undefined,
     idle_thread = undefined,
+    scheduler_action = undefined,
+    domain_list = undefined,
+    domain_index = undefined,
+    cur_domain = undefined,
+    domain_time = undefined,
+    ready_queues = undefined,
     machine_state = undefined,
     interrupt_irq_node = (\<lambda>_. 10),
     interrupt_states = undefined,
@@ -445,10 +450,13 @@ where
          else if (asid_high_bits_of x = asid_high_bits_of asid1_0xBF9)
           then T1 else undefined)"
 
+definition Sys1DomainMap :: "Sys1Labels agent_domain_map" where
+  "Sys1DomainMap \<equiv> (\<lambda>_. {}) (0 := {UT1, T1})"
+
 definition Sys1PAS :: "Sys1Labels PAS" where
   "Sys1PAS \<equiv> \<lparr> pasObjectAbs = Sys1AgentMap, pasASIDAbs = Sys1ASIDMap, pasIRQAbs = (\<lambda>_. IRQ1),
                pasPolicy = Sys1AuthGraph, pasSubject = UT1, pasMayActivate = True,
-               pasMayEditReadyQueues = True, pasMaySendIrqs = True, pasDomainAbs = undefined \<rparr>"
+               pasMayEditReadyQueues = True, pasMaySendIrqs = True, pasDomainAbs = Sys1DomainMap \<rparr>"
 
 subsubsection \<open>Proof of pas_refined for Sys1\<close>
 
@@ -539,15 +547,21 @@ lemma thread_bound_ntfns_1:
 
 declare AllowSend_def[simp] AllowRecv_def[simp]
 
-lemma domains_of_state_s1[simp]:
-  "domains_of_state s1 = {}"
-  apply (rule equalityI)
-   apply (rule subsetI)
-   apply clarsimp
-   apply (erule domains_of_state_aux.induct)
-   apply (simp add: s1_def exst1_def)
-  apply simp
-  done
+lemma etcbs_of_s1:
+  "etcbs_of s1 = [0xC07 \<mapsto> etcb_of (un_TCB obj1_0xC07), 0xC08 \<mapsto> etcb_of (un_TCB obj1_0xC08)]"
+  by (fastforce simp: etcbs_of'_def s1_def kh1_def kh1_obj_def)
+
+lemma domains_of_state_s1:
+  "domains_of_state s1 = {(0xC07, 0), (0xC08, 0)}"
+   by (fastforce simp: etcbs_of_s1 kh1_obj_def
+                 elim: domains_of_state_aux.cases
+                split: if_split_asm
+               intro!: domtcbs)
+
+lemma tcb_domain_map_wellformed_s1:
+  "tcb_domain_map_wellformed Sys1PAS s1"
+  by (clarsimp simp: tcb_domain_map_wellformed_aux_def Sys1PAS_def domains_of_state_s1
+                        Sys1AgentMap_simps Sys1DomainMap_def)
 
 lemma vs_refs_aux_empty_pt[simp]:
   "vs_refs_aux lvl (PageTable empty_pt) = {}"
@@ -566,7 +580,7 @@ lemma "pas_refined Sys1PAS s1"
   apply (intro conjI)
        subgoal by (simp add: Sys1_wellformed)
       subgoal by (simp add: irq_map_wellformed_aux_def s1_def Sys1AgentMap_simps Sys1PAS_def)
-     subgoal by (simp add: tcb_domain_map_wellformed_aux_def)
+     subgoal by (simp add: tcb_domain_map_wellformed_s1)
     apply (clarsimp simp: auth_graph_map_def Sys1PAS_def state_objs_to_policy_def)+
     apply (erule state_bits_to_policy.cases, simp_all, clarsimp)
           apply (drule s1_caps_of_state, clarsimp)
@@ -838,6 +852,9 @@ where
      tcb_fault              = undefined,
      tcb_bound_notification = None,
      tcb_mcpriority         = undefined,
+     tcb_priority           = undefined,
+     tcb_time_slice         = undefined,
+     tcb_domain             = 0,
      tcb_arch               = \<lparr>tcb_context = undefined\<rparr>\<rparr>"
 
 
@@ -859,6 +876,9 @@ where
      tcb_fault              = undefined,
      tcb_bound_notification = None,
      tcb_mcpriority         = undefined,
+     tcb_priority           = undefined,
+     tcb_time_slice         = undefined,
+     tcb_domain             = 0,
      tcb_arch               = \<lparr>tcb_context = undefined\<rparr>\<rparr>"
 
 (* the boolean in BlockedOnReceive is True if the object can receive but not send.
@@ -891,6 +911,12 @@ where
     is_original_cap = undefined,
     cur_thread = undefined,
     idle_thread = undefined,
+    scheduler_action = undefined,
+    domain_list = undefined,
+    domain_index = undefined,
+    cur_domain = undefined,
+    domain_time = undefined,
+    ready_queues = undefined,
     machine_state = undefined,
     interrupt_irq_node = (\<lambda>_. 9001),
     interrupt_states = undefined,
@@ -947,10 +973,14 @@ where
      (asid2_0xBF7 := UT2,
       asid2_0xBF9 := T2 )"
 
+definition Sys2DomainMap :: "Sys2Labels agent_domain_map" where
+  "Sys2DomainMap \<equiv> (\<lambda>_. {}) (0 := {UT2, T2})"
+
 definition Sys2PAS :: "Sys2Labels PAS" where
   "Sys2PAS \<equiv> \<lparr> pasObjectAbs = Sys2AgentMap, pasASIDAbs = Sys2ASIDMap,
               pasIRQAbs = (\<lambda>_. IRQ2),
-              pasPolicy = Sys2AuthGraph, pasSubject = UT2, pasMayActivate = True, pasMayEditReadyQueues = True, pasMaySendIrqs = True, pasDomainAbs = undefined \<rparr>"
+              pasPolicy = Sys2AuthGraph, pasSubject = UT2, pasMayActivate = True, pasMayEditReadyQueues = True,
+              pasMaySendIrqs = True, pasDomainAbs = Sys2DomainMap \<rparr>"
 
 
 
@@ -1029,15 +1059,21 @@ lemma Sys2AgentMap_simps:
   "Sys2AgentMap 9001 = IRQ2"
   by (simp_all add: Sys2AgentMap_def)
 
-lemma domains_of_state_s2[simp]:
-  "domains_of_state s2 = {}"
-  apply (rule equalityI)
-   apply (rule subsetI)
-   apply clarsimp
-   apply (erule domains_of_state_aux.induct)
-   apply (simp add: s2_def exst1_def)
-  apply simp
-  done
+lemma etcbs_of_s2:
+  "etcbs_of s2 = [0xC07 \<mapsto> etcb_of (un_TCB obj2_0xC07), 0xC08 \<mapsto> etcb_of (un_TCB obj2_0xC08)]"
+  by (fastforce simp: etcbs_of'_def s2_def kh2_def kh2_obj_def)
+
+lemma domains_of_state_s2:
+  "domains_of_state s2 = {(0xC07, 0), (0xC08, 0)}"
+   by (fastforce simp: etcbs_of_s2 kh2_obj_def
+                 elim: domains_of_state_aux.cases
+                split: if_split_asm
+               intro!: domtcbs)
+
+lemma tcb_domain_map_wellformed_s2:
+  "tcb_domain_map_wellformed Sys2PAS s2"
+  by (clarsimp simp: tcb_domain_map_wellformed_aux_def Sys2PAS_def domains_of_state_s2
+                        Sys2AgentMap_simps Sys2DomainMap_def)
 
 lemma thread_bound_ntfns_2[simp]:
   "thread_bound_ntfns s2 = Map.empty"
@@ -1050,13 +1086,14 @@ lemma thread_bound_ntfns_2[simp]:
 lemma "pas_refined Sys2PAS s2"
   apply (clarsimp simp: pas_refined_def)
   apply (intro conjI)
-      apply (simp add: Sys2_wellformed)
-     apply (simp add: Sys2PAS_def s2_def Sys2AgentMap_def
-                      irq_map_wellformed_aux_def)
+       apply (simp add: Sys2_wellformed)
+      apply (simp add: Sys2PAS_def s2_def Sys2AgentMap_def
+                       irq_map_wellformed_aux_def)
+     apply (clarsimp simp: tcb_domain_map_wellformed_s2)
     apply (clarsimp simp: auth_graph_map_def
                           Sys2PAS_def
                           state_objs_to_policy_def
-                          state_bits_to_policy_def tcb_domain_map_wellformed_aux_def)+
+                          state_bits_to_policy_def)
     apply (erule state_bits_to_policyp.cases, simp_all)
          apply (drule s2_caps_of_state, clarsimp)
          apply (elim disjE, simp_all add: cap_auth_conferred_def

--- a/proof/bisim/Separation.thy
+++ b/proof/bisim/Separation.thy
@@ -158,4 +158,18 @@ lemma separate_state_get_tcbD:
   apply (simp add: tcb_at_def separate_tcb_def caps_of_state_tcb_cap_cases dom_tcb_cap_cases)
   done
 
+lemma separate_state_simps[simp]:
+  "\<And>f. separate_state (trans_state f s) = separate_state s"
+  "\<And>f. separate_state (cdt_update f s) = separate_state s"
+  "\<And>f. separate_state (is_original_cap_update f s) = separate_state s"
+  "\<And>f. separate_state (domain_index_update f s) = separate_state s"
+  "\<And>f. separate_state (cur_domain_update f s) = separate_state s"
+  "\<And>f. separate_state (domain_time_update f s) = separate_state s"
+  "\<And>f. separate_state (arch_state_update f s) = separate_state s"
+  "\<And>f. separate_state (machine_state_update f s) = separate_state s"
+  "\<And>f. separate_state (cur_thread_update f s) = separate_state s"
+  "\<And>f. separate_state (ready_queues_update f s) = separate_state s"
+  "\<And>f. separate_state (scheduler_action_update f s) = separate_state s"
+  by (simp add: separate_state_def)+
+
 end

--- a/proof/drefine/Refine_D.thy
+++ b/proof/drefine/Refine_D.thy
@@ -18,13 +18,11 @@ text \<open>
   Toplevel @{text dcorres} theorem.
 \<close>
 
-lemma valid_etcbs_sched: "valid_sched s \<longrightarrow> valid_etcbs s" by (fastforce simp: valid_sched_def)
-
 lemma handle_event_invs_and_valid_sched:
   "\<lbrace>invs and valid_sched and (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_active s)
       and (\<lambda>s. scheduler_action s = resume_cur_thread)\<rbrace> Syscall_A.handle_event e
-  \<lbrace>\<lambda>rv. invs and valid_sched\<rbrace>"
-  by ((wp he_invs handle_event_valid_sched), clarsimp)
+  \<lbrace>\<lambda>rv. invs and valid_sched :: det_state \<Rightarrow> _\<rbrace>"
+  by (wpsimp wp: he_invs handle_event_valid_sched)
 
 lemma dcorres_call_kernel:
   "dcorres dc \<top>
@@ -42,7 +40,7 @@ lemma dcorres_call_kernel:
             apply simp
             apply (rule schedule_dcorres)
            apply (rule activate_thread_corres[unfolded fun_app_def])
-          apply (wp schedule_valid_sched | strengthen valid_etcbs_sched)+
+          apply (wp schedule_valid_sched)+
         apply (simp add: handle_pending_interrupts_def)
         apply (rule corres_split[OF get_active_irq_corres])
           apply (clarsimp simp: when_def split: option.splits)
@@ -50,8 +48,8 @@ lemma dcorres_call_kernel:
          apply ((wp | simp)+)[3]
       apply (rule hoare_post_impE_E_dc, rule handle_event_invs_and_valid_sched)
       apply (clarsimp simp: invs_def valid_state_def)
-      apply (simp add: conj_comms if_apply_def2 non_kernel_IRQs_def
-             | wp | strengthen valid_etcbs_sched valid_idle_invs_strg)+
+     apply (simp add: conj_comms if_apply_def2 non_kernel_IRQs_def
+            | wp | strengthen valid_idle_invs_strg)+
     apply (rule valid_validE2)
       apply (rule hoare_vcg_conj_lift)
        apply (rule he_invs)

--- a/proof/drefine/StateTranslationProofs_DR.thy
+++ b/proof/drefine/StateTranslationProofs_DR.thy
@@ -205,14 +205,14 @@ lemma transform_objects_update_kheap_same_caps:
   (if ptr = idle_thread s then
          transform_objects (update_kheap kh s)
   else
-         (transform_objects (update_kheap kh s))(ptr \<mapsto> transform_object (machine_state s) ptr (ekheap s ptr) ko'))"
+         (transform_objects (update_kheap kh s))(ptr \<mapsto> transform_object (machine_state s) ptr ko'))"
   unfolding transform_objects_def
   apply (rule ext)
   apply (simp add: map_option_case restrict_map_def map_add_def )
   done
 
 lemma transform_objects_update_same:
-  "\<lbrakk> kheap s ptr = Some ko; transform_object (machine_state s) ptr (ekheap s ptr) ko = ko'; ptr \<noteq> idle_thread s \<rbrakk>
+  "\<lbrakk> kheap s ptr = Some ko; transform_object (machine_state s) ptr ko = ko'; ptr \<noteq> idle_thread s \<rbrakk>
   \<Longrightarrow> (transform_objects s)(ptr \<mapsto> ko') = transform_objects s"
   unfolding transform_objects_def
   by (rule ext) (simp)

--- a/spec/sep-abstract/Syscall_SA.thy
+++ b/spec/sep-abstract/Syscall_SA.thy
@@ -115,9 +115,9 @@ definition
   handle_yield :: "(unit,'z::state_ext) s_monad" where
   "handle_yield \<equiv> do
      thread \<leftarrow> gets cur_thread;
-     do_extended_op (tcb_sched_action (tcb_sched_dequeue) thread);
-     do_extended_op (tcb_sched_action (tcb_sched_append) thread);
-     do_extended_op reschedule_required
+     tcb_sched_action (tcb_sched_dequeue) thread;
+     tcb_sched_action (tcb_sched_append) thread;
+     reschedule_required
    od"
 
 definition
@@ -244,7 +244,7 @@ text \<open>
 \<close>
 
 definition
-  call_kernel :: "event \<Rightarrow> (unit,'z::state_ext_sched) s_monad" where
+  call_kernel :: "event \<Rightarrow> (unit,'z::state_ext) s_monad" where
   "call_kernel ev \<equiv> do
        handle_event ev <handle>
            (\<lambda>_. without_preemption $ do


### PR DESCRIPTION
This follows on from https://github.com/seL4/l4v/pull/824 and https://github.com/seL4/l4v/pull/880. All proofs except for Infoflow should now be working.