### PR TITLE
Update AInvs and Access for other arches for explicit FPU changes

### DIFF
--- a/proof/access-control/RISCV64/ArchDomainSepInv.thy
+++ b/proof/access-control/RISCV64/ArchDomainSepInv.thy
@@ -13,7 +13,8 @@ context Arch begin global_naming RISCV64
 
 named_theorems DomainSepInv_assms
 
-crunch arch_post_cap_deletion, set_pt, set_asid_pool, prepare_thread_delete, init_arch_objects
+crunch
+  arch_post_cap_deletion, set_pt, set_asid_pool, prepare_thread_delete, init_arch_objects
   for domain_sep_inv[DomainSepInv_assms, wp]: "domain_sep_inv irqs st"
   (wp: domain_sep_inv_triv crunch_wps set_asid_pool_cte_wp_at set_pt_cte_wp_at)
 
@@ -30,6 +31,7 @@ crunch
   perform_pg_inv_get_addr, perform_pt_inv_map, perform_pt_inv_unmap,
   handle_hypervisor_fault, handle_arch_fault_reply, arch_mask_irq_signal,
   arch_switch_to_thread, arch_switch_to_idle_thread, arch_activate_idle_thread,
+  arch_prepare_set_domain, arch_prepare_next_domain, arch_post_set_flags,
   store_asid_pool_entry, copy_global_mappings
   for domain_sep_inv[DomainSepInv_assms, wp]: "domain_sep_inv irqs st"
   (wp: crunch_wps)

--- a/proof/access-control/RISCV64/ArchIpc_AC.thy
+++ b/proof/access-control/RISCV64/ArchIpc_AC.thy
@@ -12,11 +12,7 @@ context Arch begin global_naming RISCV64
 
 named_theorems Ipc_AC_assms
 
-lemma make_fault_message_inv[Ipc_AC_assms, wp]:
-  "make_fault_msg ft t \<lbrace>P\<rbrace>"
-  apply (cases ft, simp_all split del: if_split)
-  by (wp as_user_inv getRestartPC_inv mapM_wp' make_arch_fault_msg_inv | simp add: getRegister_def)+
-
+declare make_fault_msg_inv[Ipc_AC_assms]
 declare handle_arch_fault_reply_typ_at[Ipc_AC_assms]
 
 crunch cap_insert_ext

--- a/proof/access-control/RISCV64/ArchSyscall_AC.thy
+++ b/proof/access-control/RISCV64/ArchSyscall_AC.thy
@@ -151,7 +151,8 @@ crunch arch_post_cap_deletion
 crunch
   arch_post_modify_registers, arch_invoke_irq_control,
   arch_invoke_irq_handler, arch_perform_invocation, arch_mask_irq_signal,
-  handle_reserved_irq, handle_vm_fault, handle_hypervisor_fault, handle_arch_fault_reply
+  handle_reserved_irq, handle_vm_fault, handle_hypervisor_fault, handle_arch_fault_reply,
+  arch_prepare_set_domain, arch_post_set_flags, arch_prepare_next_domain
   for cur_thread[Syscall_AC_assms, wp]: "\<lambda>s. P (cur_thread s)"
   and idle_thread[Syscall_AC_assms, wp]: "\<lambda>s. P (idle_thread s)"
   and cur_domain[Syscall_AC_assms, wp]:  "\<lambda>s. P (cur_domain s)"
@@ -160,7 +161,15 @@ crunch
 \<comment> \<open>These aren't proved in the previous crunch, and hence need to be declared\<close>
 declare handle_arch_fault_reply_cur_thread[Syscall_AC_assms]
 declare handle_arch_fault_reply_it[Syscall_AC_assms]
+declare arch_prepare_set_domain_idle_thread[Syscall_AC_assms]
 declare init_arch_objects_inv[Syscall_AC_assms]
+
+crunch arch_prepare_next_domain
+  for pas_refined[Syscall_AC_assms, wp]: "pas_refined aag"
+  and integrity[Syscall_AC_assms, wp]: "integrity aag X st"
+  and ct_not_in_q[Syscall_AC_assms, wp]: ct_not_in_q
+  and valid_sched_action[Syscall_AC_assms, wp]: valid_sched_action
+  and ct_in_cur_domain[Syscall_AC_assms, wp]: ct_in_cur_domain
 
 end
 

--- a/proof/access-control/RISCV64/ArchTcb_AC.thy
+++ b/proof/access-control/RISCV64/ArchTcb_AC.thy
@@ -14,7 +14,7 @@ named_theorems Tcb_AC_assms
 
 declare arch_get_sanitise_register_info_inv[Tcb_AC_assms]
 
-crunch arch_post_modify_registers
+crunch arch_post_modify_registers, arch_post_set_flags
   for pas_refined[Tcb_AC_assms, wp]: "pas_refined aag"
 
 lemma arch_post_modify_registers_respects[Tcb_AC_assms]:
@@ -22,6 +22,12 @@ lemma arch_post_modify_registers_respects[Tcb_AC_assms]:
    arch_post_modify_registers cur t
    \<lbrace>\<lambda>_ s. integrity aag X st s\<rbrace>"
   by wpsimp
+
+lemma arch_post_set_flags_respects[Tcb_AC_assms]:
+  "\<lbrace>integrity aag X st and K (is_subject aag t)\<rbrace>
+   arch_post_set_flags t flags
+   \<lbrace>\<lambda>_ s. integrity aag X st s\<rbrace>"
+  by (wpsimp simp: arch_post_set_flags_def)
 
 lemma invoke_tcb_tc_respects_aag[Tcb_AC_assms]:
   "\<lbrace>integrity aag X st and pas_refined aag and einvs and simple_sched_action

--- a/proof/access-control/RISCV64/ExampleSystem.thy
+++ b/proof/access-control/RISCV64/ExampleSystem.thy
@@ -309,6 +309,7 @@ where
      tcb_priority           = undefined,
      tcb_time_slice         = undefined,
      tcb_domain             = 0,
+     tcb_flags              = undefined,
      tcb_arch               = \<lparr>tcb_context = undefined\<rparr> \<rparr>"
 
 
@@ -333,6 +334,7 @@ where
      tcb_priority           = undefined,
      tcb_time_slice         = undefined,
      tcb_domain             = 0,
+     tcb_flags              = undefined,
      tcb_arch               = \<lparr>tcb_context = undefined\<rparr>\<rparr>"
 
 definition
@@ -855,6 +857,7 @@ where
      tcb_priority           = undefined,
      tcb_time_slice         = undefined,
      tcb_domain             = 0,
+     tcb_flags              = undefined,
      tcb_arch               = \<lparr>tcb_context = undefined\<rparr>\<rparr>"
 
 
@@ -879,6 +882,7 @@ where
      tcb_priority           = undefined,
      tcb_time_slice         = undefined,
      tcb_domain             = 0,
+     tcb_flags              = undefined,
      tcb_arch               = \<lparr>tcb_context = undefined\<rparr>\<rparr>"
 
 (* the boolean in BlockedOnReceive is True if the object can receive but not send.

--- a/proof/invariant-abstract/AARCH64/ArchAcc_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchAcc_AI.thy
@@ -893,7 +893,7 @@ lemma set_pt_distinct [wp]:
 
 crunch store_pte
   for arch[wp]: "\<lambda>s. P (arch_state s)"
-  and "distinct"[wp]: pspace_distinct
+  and distinct[wp]: pspace_distinct
 
 lemma store_pt_asid_pools_of[wp]:
   "set_pt p pt \<lbrace>\<lambda>s. P (asid_pools_of s)\<rbrace>"

--- a/proof/invariant-abstract/AARCH64/ArchBits_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchBits_AI.thy
@@ -33,7 +33,7 @@ sublocale p_asid_table_current_vcpu_update:
   Arch_p_asid_table_update_eq "\<lambda>s. s\<lparr>arch_state := arm_current_vcpu_update f (arch_state s)\<rparr>"
   by (unfold_locales) auto
 
-sublocale p_asid_table_current_vcpu_update:
+sublocale p_asid_table_current_fpu_update:
   Arch_p_asid_table_update_eq "\<lambda>s. s\<lparr>arch_state := arm_current_fpu_owner_update f (arch_state s)\<rparr>"
   by (unfold_locales) auto
 

--- a/proof/invariant-abstract/AARCH64/ArchCSpace_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchCSpace_AI.thy
@@ -530,7 +530,7 @@ lemma cap_insert_simple_invs:
   apply (simp add: invs_def valid_state_def valid_pspace_def)
   apply (rule hoare_pre)
    apply (wp cap_insert_simple_mdb cap_insert_iflive
-             cap_insert_zombies cap_insert_ifunsafe valid_cur_fpu_lift
+             cap_insert_zombies cap_insert_ifunsafe
              cap_insert_valid_global_refs cap_insert_idle
              valid_irq_node_typ cap_insert_simple_arch_caps_no_ap)
   apply (clarsimp simp: is_simple_cap_def cte_wp_at_caps_of_state)

--- a/proof/invariant-abstract/AARCH64/ArchDetSchedSchedule_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchDetSchedSchedule_AI.thy
@@ -486,10 +486,6 @@ crunch arch_get_sanitise_register_info, arch_post_modify_registers
 crunch arch_get_sanitise_register_info, arch_post_modify_registers
   for scheduler_action[wp, DetSchedSchedule_AI_assms]: "\<lambda>s. P (scheduler_action s)"
 
-lemma make_arch_fault_msg_inv:
-  "make_arch_fault_msg f t \<lbrace>P\<rbrace>"
-  by (cases f; wpsimp)
-
 declare make_arch_fault_msg_inv[DetSchedSchedule_AI_assms]
 
 lemma arch_post_modify_registers_not_idle_thread[DetSchedSchedule_AI_assms]:

--- a/proof/invariant-abstract/AARCH64/ArchFinalise_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchFinalise_AI.thy
@@ -1249,38 +1249,37 @@ lemma finalise_cap_replaceable [Finalise_AI_assms]:
                          ran_tcb_cap_cases is_cap_simps
                          gen_obj_refs_subset vs_cap_ref_def
                          all_bool_eq)
-  apply (cases cap;
-           simp add: replaceable_def reachable_frame_cap_def is_arch_cap_def
-                split del: if_split;
-           ((wp suspend_unlive[unfolded o_def]
-                suspend_final_cap[where sl=sl]
-                prepare_thread_delete_unlive[unfolded o_def]
-                unbind_maybe_notification_not_bound
-                get_simple_ko_ko_at unbind_notification_valid_objs
-             | clarsimp simp: o_def dom_tcb_cap_cases_lt_ARCH
-                              ran_tcb_cap_cases is_cap_simps
-                              cap_range_def unat_of_bl_length
-                              can_fast_finalise_def
-                              gen_obj_refs_subset
-                              vs_cap_ref_def
-                              valid_ipc_buffer_cap_def
-                        dest!: tcb_cap_valid_NullCapD
-                        split: Structures_A.thread_state.split_asm
-             | simp cong: conj_cong
-             | simp cong: rev_conj_cong add: no_cap_to_obj_with_diff_ref_Null
-             | (strengthen tcb_cap_valid_imp_NullCap tcb_cap_valid_imp', wp)
-             | rule conjI
-             | erule cte_wp_at_weakenE tcb_cap_valid_imp'[rule_format, rotated -1]
-             | erule(1) no_cap_to_obj_with_diff_ref_finalI_ARCH
-             | (wp (once) hoare_drop_imps,
-                        wp (once) cancel_all_ipc_unlive[unfolded o_def]
-                       cancel_all_signals_unlive[unfolded o_def])
-             | ((wp (once) hoare_drop_imps)?,
-                (wp (once) hoare_drop_imps)?,
-                wp (once) deleting_irq_handler_empty)
-             | wpc
-             | simp add: valid_cap_simps is_nondevice_page_cap_simps)+))
-  done
+  by (cases cap;
+        simp add: replaceable_def reachable_frame_cap_def is_arch_cap_def
+             split del: if_split;
+        ((wp suspend_unlive[unfolded o_def]
+             suspend_final_cap[where sl=sl]
+             prepare_thread_delete_unlive[unfolded o_def]
+             unbind_maybe_notification_not_bound
+             get_simple_ko_ko_at unbind_notification_valid_objs
+          | clarsimp simp: o_def dom_tcb_cap_cases_lt_ARCH
+                           ran_tcb_cap_cases is_cap_simps
+                           cap_range_def unat_of_bl_length
+                           can_fast_finalise_def
+                           gen_obj_refs_subset
+                           vs_cap_ref_def
+                           valid_ipc_buffer_cap_def
+                     dest!: tcb_cap_valid_NullCapD
+                     split: Structures_A.thread_state.split_asm
+          | simp cong: conj_cong
+          | simp cong: rev_conj_cong add: no_cap_to_obj_with_diff_ref_Null
+          | (strengthen tcb_cap_valid_imp_NullCap tcb_cap_valid_imp', wp)
+          | rule conjI
+          | erule cte_wp_at_weakenE tcb_cap_valid_imp'[rule_format, rotated -1]
+          | erule(1) no_cap_to_obj_with_diff_ref_finalI_ARCH
+          | (wp (once) hoare_drop_imps,
+                     wp (once) cancel_all_ipc_unlive[unfolded o_def]
+                    cancel_all_signals_unlive[unfolded o_def])
+          | ((wp (once) hoare_drop_imps)?,
+             (wp (once) hoare_drop_imps)?,
+             wp (once) deleting_irq_handler_empty)
+          | wpc
+          | simp add: valid_cap_simps)+))
 
 lemma (* deleting_irq_handler_cte_preserved *)[Finalise_AI_assms]:
   assumes x: "\<And>cap. P cap \<Longrightarrow> \<not> can_fast_finalise cap"

--- a/proof/invariant-abstract/AARCH64/ArchTcbAcc_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchTcbAcc_AI.thy
@@ -183,7 +183,7 @@ lemma arch_thread_set_cur_fpu_False_if_live_then_nonz_cap[wp]:
 
 lemma arch_thread_set_if_live_then_nonz_cap_None[wp]:
   "arch_thread_set (tcb_vcpu_update Map.empty) t \<lbrace>if_live_then_nonz_cap\<rbrace>"
-  by (wpsimp wp: arch_thread_set_if_live_then_nonz_cap_unchanged simp: hyp_live_def )
+  by (wpsimp wp: arch_thread_set_if_live_then_nonz_cap_unchanged simp: hyp_live_def)
 
 lemmas arch_thread_set_cur_fpu_True_if_live_then_nonz_cap[wp]
   = arch_thread_set_if_live_then_nonz_cap'[where f="tcb_cur_fpu_update \<top>"]

--- a/proof/invariant-abstract/ARM/ArchCSpace_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchCSpace_AI.thy
@@ -570,7 +570,7 @@ lemma cap_insert_simple_invs:
   apply (simp add: invs_def valid_state_def valid_pspace_def)
   apply (rule hoare_pre)
    apply (wp cap_insert_simple_mdb cap_insert_iflive
-             cap_insert_zombies cap_insert_ifunsafe valid_cur_fpu_lift
+             cap_insert_zombies cap_insert_ifunsafe
              cap_insert_valid_global_refs cap_insert_idle
              valid_irq_node_typ cap_insert_simple_arch_caps_no_ap)
   apply (clarsimp simp: is_simple_cap_def cte_wp_at_caps_of_state)

--- a/proof/invariant-abstract/ARM/ArchDetSchedSchedule_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchDetSchedSchedule_AI.thy
@@ -305,6 +305,7 @@ crunch arch_get_sanitise_register_info, arch_post_modify_registers
   for ready_queues[wp, DetSchedSchedule_AI_assms]: "\<lambda>s. P (ready_queues s)"
 crunch arch_get_sanitise_register_info, arch_post_modify_registers
   for scheduler_action[wp, DetSchedSchedule_AI_assms]: "\<lambda>s. P (scheduler_action s)"
+
 declare make_arch_fault_msg_inv[DetSchedSchedule_AI_assms]
 
 lemma arch_post_modify_registers_not_idle_thread[DetSchedSchedule_AI_assms]:

--- a/proof/invariant-abstract/ARM/ArchFinalise_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchFinalise_AI.thy
@@ -537,38 +537,37 @@ lemma finalise_cap_replaceable [Finalise_AI_assms]:
                          o_def cap_range_def valid_arch_state_def
                          ran_tcb_cap_cases is_cap_simps
                          gen_obj_refs_subset vs_cap_ref_def)
-  apply (cases cap;
-           simp add: replaceable_def reachable_pg_cap_def is_arch_cap_def
-                split del: if_split;
-           ((wp suspend_unlive[unfolded o_def]
-                suspend_final_cap[where sl=sl]
-                prepare_thread_delete_unlive[unfolded o_def]
-                unbind_maybe_notification_not_bound
-                get_simple_ko_ko_at unbind_notification_valid_objs
-             | clarsimp simp: o_def dom_tcb_cap_cases_lt_ARCH
-                              ran_tcb_cap_cases is_cap_simps
-                              cap_range_def unat_of_bl_length
-                              can_fast_finalise_def
-                              gen_obj_refs_subset
-                              vs_cap_ref_def
-                              valid_ipc_buffer_cap_def
-                        dest!: tcb_cap_valid_NullCapD
-                        split: Structures_A.thread_state.split_asm
-             | simp cong: conj_cong
-             | simp cong: rev_conj_cong add: no_cap_to_obj_with_diff_ref_Null
-             | (strengthen tcb_cap_valid_imp_NullCap tcb_cap_valid_imp', wp)
-             | rule conjI
-             | erule cte_wp_at_weakenE tcb_cap_valid_imp'[rule_format, rotated -1]
-             | erule(1) no_cap_to_obj_with_diff_ref_finalI_ARCH
-             | (wp (once) hoare_drop_imps,
-                        wp (once) cancel_all_ipc_unlive[unfolded o_def]
-                       cancel_all_signals_unlive[unfolded o_def])
-             | ((wp (once) hoare_drop_imps)?,
-                (wp (once) hoare_drop_imps)?,
-                wp (once) deleting_irq_handler_empty)
-             | wpc
-             | simp add: valid_cap_simps is_nondevice_page_cap_simps)+))
-  done
+  by (cases cap;
+        simp add: replaceable_def reachable_pg_cap_def is_arch_cap_def
+             split del: if_split;
+        ((wp suspend_unlive[unfolded o_def]
+             suspend_final_cap[where sl=sl]
+             prepare_thread_delete_unlive[unfolded o_def]
+             unbind_maybe_notification_not_bound
+             get_simple_ko_ko_at unbind_notification_valid_objs
+          | clarsimp simp: o_def dom_tcb_cap_cases_lt_ARCH
+                           ran_tcb_cap_cases is_cap_simps
+                           cap_range_def unat_of_bl_length
+                           can_fast_finalise_def
+                           gen_obj_refs_subset
+                           vs_cap_ref_def
+                           valid_ipc_buffer_cap_def
+                     dest!: tcb_cap_valid_NullCapD
+                     split: Structures_A.thread_state.split_asm
+          | simp cong: conj_cong
+          | simp cong: rev_conj_cong add: no_cap_to_obj_with_diff_ref_Null
+          | (strengthen tcb_cap_valid_imp_NullCap tcb_cap_valid_imp', wp)
+          | rule conjI
+          | erule cte_wp_at_weakenE tcb_cap_valid_imp'[rule_format, rotated -1]
+          | erule(1) no_cap_to_obj_with_diff_ref_finalI_ARCH
+          | (wp (once) hoare_drop_imps,
+                     wp (once) cancel_all_ipc_unlive[unfolded o_def]
+                    cancel_all_signals_unlive[unfolded o_def])
+          | ((wp (once) hoare_drop_imps)?,
+             (wp (once) hoare_drop_imps)?,
+             wp (once) deleting_irq_handler_empty)
+          | wpc
+          | simp add: valid_cap_simps is_nondevice_page_cap_simps)+))
 
 lemma (* deleting_irq_handler_cte_preserved *)[Finalise_AI_assms]:
   assumes x: "\<And>cap. P cap \<Longrightarrow> \<not> can_fast_finalise cap"

--- a/proof/invariant-abstract/ARM_HYP/ArchAcc_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchAcc_AI.thy
@@ -1821,6 +1821,12 @@ lemma set_asid_pool_iflive [wp]:
   by (wpsimp wp: set_object_iflive[THEN hoare_set_object_weaken_pre]
            simp: a_type_def live_def hyp_live_def arch_live_def)
 
+lemma set_asid_pool_nonz_cap_to[wp]:
+  "set_asid_pool p ap \<lbrace>ex_nonz_cap_to t\<rbrace>"
+  apply (simp add: set_asid_pool_def)
+  including unfold_objects
+  by (wpsimp wp: set_object_nonz_cap_to[THEN hoare_set_object_weaken_pre]
+           simp: a_type_def)
 
 lemma set_asid_pool_zombies [wp]:
   "\<lbrace>\<lambda>s. zombies_final s\<rbrace>
@@ -2199,6 +2205,10 @@ lemma mdb_cte_at_set_asid_pool[wp]:
   apply (simp only: imp_conv_disj)
   apply (wp hoare_vcg_disj_lift hoare_vcg_all_lift)
 done
+
+crunch set_asid_pool
+  for valid_cur_fpu[wp]: valid_cur_fpu
+  (wp: valid_cur_fpu_lift)
 
 lemma set_asid_pool_invs_unmap:
   "\<lbrace>invs and ko_at (ArchObj (ASIDPool ap)) p and

--- a/proof/invariant-abstract/ARM_HYP/ArchBCorres2_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchBCorres2_AI.thy
@@ -28,8 +28,9 @@ crunch invoke_untyped
   for (bcorres) bcorres[wp]: truncate_state
   (ignore: sequence_x)
 
-crunch set_mcpriority, set_priority,
-          arch_get_sanitise_register_info, arch_post_modify_registers
+crunch
+  set_mcpriority, set_priority, arch_get_sanitise_register_info, arch_post_modify_registers,
+  set_flags, arch_post_set_flags
   for (bcorres) bcorres[BCorres2_AI_assms,wp]: truncate_state
 
 lemma invoke_tcb_bcorres[wp]:
@@ -68,7 +69,7 @@ lemma make_arch_fault_msg_bcorres[wp,BCorres2_AI_assms]:
   "bcorres (make_arch_fault_msg a b) (make_arch_fault_msg a b)"
   by (cases a; wpsimp)
 
-lemma  handle_arch_fault_reply_bcorres[wp,BCorres2_AI_assms]:
+lemma handle_arch_fault_reply_bcorres[wp,BCorres2_AI_assms]:
   "bcorres ( handle_arch_fault_reply a b c d) (handle_arch_fault_reply a b c d)"
   by (cases a; wpsimp simp: handle_arch_fault_reply_def)
 
@@ -101,7 +102,7 @@ lemma decode_cnode_invocation[wp]: "bcorres (decode_cnode_invocation a b c d) (d
 crunch
   decode_set_ipc_buffer, decode_set_space, decode_set_priority,
   decode_set_mcpriority, decode_set_sched_params, decode_bind_notification,
-  decode_unbind_notification, decode_set_tls_base
+  decode_unbind_notification, decode_set_tls_base, decode_set_flags
   for (bcorres) bcorres[wp]: truncate_state
 
 lemma decode_tcb_configure_bcorres[wp]: "bcorres (decode_tcb_configure b (cap.ThreadCap c) d e)
@@ -109,7 +110,8 @@ lemma decode_tcb_configure_bcorres[wp]: "bcorres (decode_tcb_configure b (cap.Th
   apply (simp add: decode_tcb_configure_def | wp)+
   done
 
-lemma decode_tcb_invocation_bcorres[wp]:"bcorres (decode_tcb_invocation a b (cap.ThreadCap c) d e) (decode_tcb_invocation a b (cap.ThreadCap c) d e)"
+lemma decode_tcb_invocation_bcorres[wp]:
+  "bcorres (decode_tcb_invocation a b (cap.ThreadCap c) d e) (decode_tcb_invocation a b (cap.ThreadCap c) d e)"
   apply (simp add: decode_tcb_invocation_def)
   apply (wp | wpc | simp)+
   done

--- a/proof/invariant-abstract/ARM_HYP/ArchCNodeInv_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchCNodeInv_AI.thy
@@ -538,7 +538,7 @@ lemma cap_swap_valid_arch_state[wp, CNodeInv_AI_assms]:
   "\<lbrace>valid_arch_state and cte_wp_at (weak_derived c) a and cte_wp_at (weak_derived c') b\<rbrace>
    cap_swap c a c' b
    \<lbrace>\<lambda>_. valid_arch_state\<rbrace>"
-  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps cap_swap_aobj_at)
+  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps cap_swap_typ_ats cap_swap_aobj_at)
 
 end
 

--- a/proof/invariant-abstract/ARM_HYP/ArchCSpaceInv_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchCSpaceInv_AI.thy
@@ -32,7 +32,7 @@ lemmas unique_table_refs_no_cap_asidD
 
 lemma set_cap_valid_arch_state[wp]:
   "set_cap cap ptr \<lbrace> valid_arch_state \<rbrace>"
-  by (wp valid_arch_state_lift_aobj_at_no_caps set_cap.aobj_at)
+  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps set_cap_tcb set_cap.aobj_at)
 
 lemma replace_cap_invs:
   "\<lbrace>\<lambda>s. invs s \<and> cte_wp_at (replaceable s p cap) p s

--- a/proof/invariant-abstract/ARM_HYP/ArchCSpace_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchCSpace_AI.thy
@@ -520,7 +520,7 @@ lemma cap_insert_derived_valid_arch_state[CSpace_AI_assms]:
   "\<lbrace>valid_arch_state and (\<lambda>s. cte_wp_at (is_derived (cdt s) src cap) src s)\<rbrace>
    cap_insert cap src dest
    \<lbrace>\<lambda>rv. valid_arch_state \<rbrace>"
-  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps cap_insert_aobj_at cap_insert_aobj_at)
+  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps cap_insert_tcb cap_insert_aobj_at)
 
 lemma setup_reply_master_arch[CSpace_AI_assms]:
   "setup_reply_master t \<lbrace> valid_arch_state \<rbrace>"
@@ -559,7 +559,7 @@ by (cases cap; simp)+
 
 lemma cap_insert_simple_valid_arch_state[wp]:
   "cap_insert cap src dest \<lbrace> valid_arch_state\<rbrace>"
-  by (wp valid_arch_state_lift_aobj_at_no_caps cap_insert_aobj_at)+
+  by (wp valid_arch_state_lift_aobj_at_no_caps cap_insert_tcb cap_insert_aobj_at)+
 
 lemma cap_insert_simple_invs:
   "\<lbrace>invs and valid_cap cap and tcb_cap_valid cap dest and

--- a/proof/invariant-abstract/ARM_HYP/ArchDetSchedDomainTime_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchDetSchedDomainTime_AI.thy
@@ -30,10 +30,11 @@ crunch
   arch_invoke_irq_control, arch_get_sanitise_register_info,
   prepare_thread_delete, handle_hypervisor_fault, make_arch_fault_msg, init_arch_objects,
   arch_post_modify_registers, arch_post_cap_deletion, handle_vm_fault,
-  arch_invoke_irq_handler
+  arch_invoke_irq_handler, arch_prepare_next_domain, arch_prepare_set_domain, arch_post_set_flags
   for domain_list_inv[wp, DetSchedDomainTime_AI_assms]: "\<lambda>s::det_state. P (domain_list s)"
   (simp: crunch_simps wp: mapM_wp' transfer_caps_loop_pres crunch_wps)
 declare init_arch_objects_exst[DetSchedDomainTime_AI_assms]
+        make_arch_fault_msg_inv[DetSchedDomainTime_AI_assms]
 
 crunch arch_finalise_cap, arch_get_sanitise_register_info
   for domain_time_inv[wp, DetSchedDomainTime_AI_assms]: "\<lambda>s. P (domain_time s)"
@@ -45,7 +46,8 @@ crunch
   arch_invoke_irq_control, arch_get_sanitise_register_info,
   prepare_thread_delete, handle_hypervisor_fault, handle_vm_fault,
   arch_post_modify_registers, arch_post_cap_deletion, make_arch_fault_msg,
-  arch_invoke_irq_handler, handle_reserved_irq, arch_mask_irq_signal
+  arch_invoke_irq_handler, handle_reserved_irq, arch_mask_irq_signal,
+  arch_prepare_next_domain, arch_prepare_set_domain, arch_post_set_flags
   for domain_time_inv[wp, DetSchedDomainTime_AI_assms]: "\<lambda>s::det_state. P (domain_time s)"
   (simp: crunch_simps wp: transfer_caps_loop_pres crunch_wps)
 

--- a/proof/invariant-abstract/ARM_HYP/ArchDeterministic_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchDeterministic_AI.thy
@@ -16,7 +16,8 @@ context Arch begin arch_global_naming
 named_theorems Deterministic_AI_assms
 
 crunch
- vcpu_save, vcpu_enable, vcpu_disable, vcpu_restore, arch_get_sanitise_register_info, arch_post_modify_registers
+  vcpu_save, vcpu_enable, vcpu_disable, vcpu_restore, arch_get_sanitise_register_info,
+  arch_post_modify_registers, arch_post_set_flags
   for valid_list[wp, Deterministic_AI_assms]: valid_list
   (wp: crunch_wps simp: unless_def crunch_simps)
 

--- a/proof/invariant-abstract/ARM_HYP/ArchDetype_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchDetype_AI.thy
@@ -194,7 +194,7 @@ lemma tcb_arch_detype[detype_invs_proofs]:
   apply rotate_tac (* do not pick typ_at *)
   apply (drule live_okE)
    apply (clarsimp simp: live_def hyp_live_def arch_live_def obj_at_def hyp_refs_of_def
-                         refs_of_a_def vcpu_tcb_refs_def
+                         refs_of_a_def vcpu_tcb_refs_def tcb_vcpu_refs_def
                   split: kernel_object.splits arch_kernel_obj.splits option.splits)
   apply clarsimp
   done
@@ -222,6 +222,11 @@ lemma valid_arch_state_detype[detype_invs_proofs]:
   apply (drule obj_at_hyp_live_strg)
   apply (clarsimp simp: live_okE)
   done
+
+lemma valid_cur_fpu[detype_invs_proofs]:
+  "valid_cur_fpu (detype (untyped_range cap) s)"
+  using valid_cur_fpu
+  by (clarsimp simp: valid_cur_fpu_def)
 
 lemma global_pts: (* ARCH SPECIFIC STATEMENT *)
   "\<And>p. \<lbrakk> p \<in> {}; p \<in> untyped_range cap \<rbrakk>  \<Longrightarrow> False"
@@ -403,7 +408,7 @@ sublocale detype_locale < detype_locale_gen_1
  proof goal_cases
   interpret detype_locale_arch ..
   case 1 show ?case
-  by (intro_locales; (unfold_locales; fact detype_invs_proofs)?)
+  by (intro_locales; unfold_locales; (fact detype_invs_proofs)?)
   qed
 
 
@@ -613,7 +618,7 @@ sublocale detype_locale < detype_locale_gen_2
  proof goal_cases
   interpret detype_locale_arch ..
   case 1 show ?case
-  by (intro_locales; (unfold_locales; fact detype_invs_proofs)?)
+  by (intro_locales; unfold_locales; (fact detype_invs_proofs)?)
   qed
 
 context detype_locale begin

--- a/proof/invariant-abstract/ARM_HYP/ArchEmptyFail_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchEmptyFail_AI.thy
@@ -45,7 +45,7 @@ crunch handle_fault
 crunch
   decode_tcb_configure, decode_bind_notification, decode_unbind_notification,
   decode_set_priority, decode_set_mcpriority, decode_set_sched_params,
-  decode_set_tls_base
+  decode_set_tls_base, decode_set_flags
   for (empty_fail) empty_fail[wp]
   (simp: cap.splits arch_cap.splits split_def)
 
@@ -160,7 +160,7 @@ global_interpretation EmptyFail_AI_rec_del?: EmptyFail_AI_rec_del
 
 context Arch begin arch_global_naming
 crunch
-  cap_delete, choose_thread
+  cap_delete, choose_thread, arch_prepare_next_domain
   for (empty_fail) empty_fail[wp, EmptyFail_AI_assms]
 end
 

--- a/proof/invariant-abstract/ARM_HYP/ArchFinalise_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchFinalise_AI.thy
@@ -975,7 +975,7 @@ lemma prepare_thread_delete_unlive[wp]:
   "\<lbrace>obj_at (Not \<circ> live0) ptr\<rbrace> prepare_thread_delete ptr \<lbrace>\<lambda>rv. obj_at (Not \<circ> live) ptr\<rbrace>"
   apply (rule_tac Q'="\<lambda>rv. obj_at (Not \<circ> live0) ptr and obj_at (Not \<circ> hyp_live) ptr" in hoare_strengthen_post)
   apply (wpsimp wp: hoare_vcg_conj_lift prepare_thread_delete_unlive_hyp prepare_thread_delete_unlive0)+
-  apply (clarsimp simp: obj_at_def, case_tac ko, simp_all add: is_tcb_def live_def)
+  apply (clarsimp simp: obj_at_def, case_tac ko, simp_all add: is_tcb_def live_def arch_tcb_live_def)
   done
 
 lemma arch_finalise_cap_replaceable:
@@ -1006,41 +1006,37 @@ lemma finalise_cap_replaceable [Finalise_AI_assms]:
                          ran_tcb_cap_cases is_cap_simps
                          gen_obj_refs_subset vs_cap_ref_def
                          all_bool_eq)
-  apply ((cases cap;
-      simp add: replaceable_def reachable_pg_cap_def
-                       split del: if_split;
-      rule hoare_pre),
-
-    (wp suspend_unlive[unfolded o_def]
-        suspend_final_cap[where sl=sl]
-        prepare_thread_delete_unlive[unfolded o_def]
-        unbind_maybe_notification_not_bound
-        get_simple_ko_ko_at
-        unbind_notification_valid_objs
-      | clarsimp simp: o_def dom_tcb_cap_cases_lt_ARCH
-                        ran_tcb_cap_cases is_cap_simps
-                        cap_range_def
-                        can_fast_finalise_def
-                        gen_obj_refs_subset
-                        vs_cap_ref_def
-                        valid_ipc_buffer_cap_def
-                 dest!: tcb_cap_valid_NullCapD
-                 split: Structures_A.thread_state.split_asm
-      | simp cong: conj_cong
-      | simp cong: rev_conj_cong add: no_cap_to_obj_with_diff_ref_Null
-      | (strengthen tcb_cap_valid_imp_NullCap tcb_cap_valid_imp', wp)
-      | rule conjI
-      | erule cte_wp_at_weakenE tcb_cap_valid_imp'[rule_format, rotated -1]
-      | erule(1) no_cap_to_obj_with_diff_ref_finalI_ARCH
-      | (wp (once) hoare_drop_imps,
-          wp (once) cancel_all_ipc_unlive[unfolded o_def]
-              cancel_all_signals_unlive[unfolded o_def])
-      | ((wp (once) hoare_drop_imps)?,
-         (wp (once) hoare_drop_imps)?,
-         wp (once) deleting_irq_handler_empty)
-      | wpc
-      | simp add: valid_cap_simps is_nondevice_page_cap_simps)+)
-  done
+  by (cases cap;
+        simp add: replaceable_def reachable_pg_cap_def is_arch_cap_def
+             split del: if_split;
+        ((wp suspend_unlive[unfolded o_def]
+             suspend_final_cap[where sl=sl]
+             prepare_thread_delete_unlive[unfolded o_def]
+             unbind_maybe_notification_not_bound
+             get_simple_ko_ko_at unbind_notification_valid_objs
+          | clarsimp simp: o_def dom_tcb_cap_cases_lt_ARCH
+                           ran_tcb_cap_cases is_cap_simps
+                           cap_range_def unat_of_bl_length
+                           can_fast_finalise_def
+                           gen_obj_refs_subset
+                           vs_cap_ref_def
+                           valid_ipc_buffer_cap_def
+                     dest!: tcb_cap_valid_NullCapD
+                     split: Structures_A.thread_state.split_asm
+          | simp cong: conj_cong
+          | simp cong: rev_conj_cong add: no_cap_to_obj_with_diff_ref_Null
+          | (strengthen tcb_cap_valid_imp_NullCap tcb_cap_valid_imp', wp)
+          | rule conjI
+          | erule cte_wp_at_weakenE tcb_cap_valid_imp'[rule_format, rotated -1]
+          | erule(1) no_cap_to_obj_with_diff_ref_finalI_ARCH
+          | (wp (once) hoare_drop_imps,
+                     wp (once) cancel_all_ipc_unlive[unfolded o_def]
+                    cancel_all_signals_unlive[unfolded o_def])
+          | ((wp (once) hoare_drop_imps)?,
+             (wp (once) hoare_drop_imps)?,
+             wp (once) deleting_irq_handler_empty)
+          | wpc
+          | simp add: valid_cap_simps is_nondevice_page_cap_simps)+))
 
 lemma (* deleting_irq_handler_cte_preserved *)[Finalise_AI_assms]:
   assumes x: "\<And>cap. P cap \<Longrightarrow> \<not> can_fast_finalise cap"

--- a/proof/invariant-abstract/ARM_HYP/ArchIpc_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchIpc_AI.thy
@@ -223,24 +223,17 @@ lemma copy_mrs_in_user_frame[wp, Ipc_AI_2_assms]:
   "\<lbrace>in_user_frame p\<rbrace> copy_mrs t buf t' buf' n \<lbrace>\<lambda>rv. in_user_frame p\<rbrace>"
   by (simp add: in_user_frame_def) (wp hoare_vcg_ex_lift)
 
-lemma as_user_getRestart_invs[wp]: "\<lbrace>P\<rbrace> as_user t getRestartPC \<lbrace>\<lambda>_. P\<rbrace>"
+lemma as_user_getRestart_inv[wp]:
+  "as_user t getRestartPC \<lbrace>P\<rbrace>"
   by (simp add: getRestartPC_def, rule user_getreg_inv)
 
-lemma make_arch_fault_msg_invs[wp, Ipc_AI_2_assms]: "make_arch_fault_msg f t \<lbrace>invs\<rbrace>"
-  apply (cases f)
-  apply simp_all
-  apply (wpsimp simp: do_machine_op_bind addressTranslateS1_def)
-  done
+lemma make_arch_fault_msg_inv[wp, Ipc_AI_2_assms]:
+  "make_arch_fault_msg ft t \<lbrace>P\<rbrace>"
+  by (cases ft; wpsimp)
 
-lemma make_fault_message_inv[wp, Ipc_AI_2_assms]:
-  "make_fault_msg ft t \<lbrace>invs\<rbrace>"
-  apply (cases ft, simp_all split del: if_split)
-     apply (wp as_user_inv getRestartPC_inv mapM_wp'
-              | simp add: getRegister_def)+
-  done
-
-crunch make_fault_msg
-  for tcb_at[wp]: "tcb_at t"
+lemma make_fault_msg_inv[wp, Ipc_AI_2_assms]:
+  "make_fault_msg ft t \<lbrace>P\<rbrace>"
+  by (cases ft; wpsimp wp: as_user_inv getRestartPC_inv mapM_wp' split_del: if_split)
 
 lemma do_fault_transfer_invs[wp, Ipc_AI_2_assms]:
   "\<lbrace>invs and tcb_at receiver\<rbrace>
@@ -523,7 +516,7 @@ lemma setup_caller_cap_aobj_at:
 
 lemma setup_caller_cap_valid_arch[Ipc_AI_2_assms, wp]:
   "setup_caller_cap st rt grant \<lbrace>valid_arch_state\<rbrace>"
-  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps[rotated -1] setup_caller_cap_aobj_at)
+  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps[rotated -1] setup_caller_cap_tcb_at setup_caller_cap_aobj_at)
 
 lemma transfer_caps_loop_valid_arch[Ipc_AI_2_assms]:
   "\<And>slots caps ep buffer n mi.
@@ -532,7 +525,7 @@ lemma transfer_caps_loop_valid_arch[Ipc_AI_2_assms]:
          and transfer_caps_srcs caps\<rbrace>
       transfer_caps_loop ep buffer n caps slots mi
     \<lbrace>\<lambda>_. valid_arch_state\<rbrace>"
-  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps transfer_caps_loop_aobj_at)
+  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps transfer_caps_loop_typ_ats transfer_caps_loop_aobj_at)
 
 end
 
@@ -599,7 +592,7 @@ lemma do_ipc_transfer_valid_arch[Ipc_AI_3_assms]:
   "\<lbrace>valid_arch_state and valid_objs and valid_mdb \<rbrace>
    do_ipc_transfer s ep bg grt r
    \<lbrace>\<lambda>rv. valid_arch_state\<rbrace>"
-  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps do_ipc_transfer_aobj_at)
+  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps dit_tcb_at do_ipc_transfer_aobj_at)
 
 end
 

--- a/proof/invariant-abstract/ARM_HYP/ArchKHeap_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchKHeap_AI.thy
@@ -490,6 +490,18 @@ lemma valid_arch_state_lift_aobj_at:
 
 end
 
+\<comment> \<open>Intended for use inside Arch, as opposed to the interface lemma valid_cur_fpu_lift\<close>
+lemma valid_cur_fpu_lift_arch[wp]:
+  shows "f \<lbrace>valid_cur_fpu\<rbrace>"
+  by (wpsimp simp: valid_cur_fpu_def)
+
+\<comment> \<open>Interface lemma\<close>
+lemma valid_cur_fpu_lift:
+  assumes arch_tcb_at[wp]: "\<And>P P' p. f \<lbrace>\<lambda>s. P (arch_tcb_at P' p s)\<rbrace>"
+  assumes arch_state[wp]: "\<And>P. f \<lbrace>\<lambda>s. P (arch_state s)\<rbrace>"
+  shows "f \<lbrace>valid_cur_fpu\<rbrace>"
+  by (wpsimp wp: valid_cur_fpu_lift_arch)
+
 lemma equal_kernel_mappings_lift:
   assumes vsobj_at:
     "\<And>P P' pd. vspace_obj_pred P' \<Longrightarrow> \<lbrace>\<lambda>s. P (obj_at P' pd s)\<rbrace> f \<lbrace>\<lambda>r s. P (obj_at P' pd s)\<rbrace>"
@@ -762,7 +774,7 @@ lemma default_arch_object_not_live[simp]: "\<not> live (ArchObj (default_arch_ob
                split: aobject_type.splits)
 
 lemma default_tcb_not_live[simp]: "\<not> live (TCB (default_tcb d))"
-  by (clarsimp simp: default_tcb_def default_arch_tcb_def live_def hyp_live_def)
+  by (clarsimp simp: default_tcb_def default_arch_tcb_def live_def hyp_live_def arch_tcb_live_def)
 
 lemma valid_arch_tcb_same_type:
   "\<lbrakk> valid_arch_tcb t s; valid_obj p k s; kheap s p = Some ko; a_type k = a_type ko \<rbrakk>

--- a/proof/invariant-abstract/ARM_HYP/ArchKernelInit_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchKernelInit_AI.thy
@@ -275,7 +275,7 @@ lemma invs_A:
     apply (simp add:pspace_distinct_init_A)
    apply (rule conjI)
     apply (clarsimp simp: if_live_then_nonz_cap_def ex_nonz_cap_to_def live_def hyp_live_def
-                          obj_at_def state_defs init_arch_tcb_def arch_live_def)
+                          obj_at_def state_defs init_arch_tcb_def arch_live_def arch_tcb_live_def)
    apply (rule conjI)
     apply (clarsimp simp: zombies_final_def cte_wp_at_cases state_defs
                           tcb_cap_cases_def is_zombie_def)
@@ -319,6 +319,7 @@ lemma invs_A:
    apply (rule conjI)
     apply (clarsimp simp: valid_arch_state_def obj_at_def state_defs a_type_def)
    apply (simp add: state_defs is_inv_def)
+  apply (rule conjI, clarsimp simp: valid_cur_fpu_def)
   apply (rule conjI)
    apply (clarsimp simp: valid_irq_node_def obj_at_def state_defs
                          is_cap_table_def wf_empty_bits

--- a/proof/invariant-abstract/ARM_HYP/ArchRetype_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchRetype_AI.thy
@@ -623,6 +623,10 @@ lemma valid_global_refs:
   apply (simp add: cte_retype cap_range_def)
   done
 
+lemma valid_cur_fpu':
+  "valid_cur_fpu s \<Longrightarrow> valid_cur_fpu s'"
+  by (clarsimp simp: valid_cur_fpu_def)
+
 lemma valid_arch_state:
   "valid_arch_state s \<Longrightarrow> valid_arch_state s'"
   by (clarsimp simp: valid_arch_state_def obj_at_pres
@@ -1040,7 +1044,7 @@ lemma post_retype_invs:
   by (clarsimp simp: invs_def post_retype_invs_def valid_state_def
                      unsafe_rep2 null_filter valid_idle
                      valid_reply_caps valid_reply_masters
-                     valid_global_refs valid_arch_state
+                     valid_global_refs valid_arch_state valid_cur_fpu'
                      valid_irq_node_def obj_at_pres
                      valid_arch_caps valid_global_objs_def
                      valid_vspace_objs' valid_irq_handlers

--- a/proof/invariant-abstract/ARM_HYP/ArchSchedule_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchSchedule_AI.thy
@@ -40,7 +40,7 @@ lemma clearExMonitor_invs [wp]:
   done
 
 lemma arch_stt_invs [wp,Schedule_AI_assms]:
-  "\<lbrace>invs\<rbrace> arch_switch_to_thread t' \<lbrace>\<lambda>_. invs\<rbrace>"
+  "\<lbrace>invs and ex_nonz_cap_to t\<rbrace> arch_switch_to_thread t \<lbrace>\<lambda>_. invs\<rbrace>"
   apply (wpsimp simp: arch_switch_to_thread_def)
   by (rule sym_refs_VCPU_hyp_live; fastforce)
 
@@ -112,6 +112,14 @@ lemma arch_stt_scheduler_action [wp, Schedule_AI_assms]:
   "\<lbrace>\<lambda>s. P (scheduler_action s)\<rbrace> arch_switch_to_thread t' \<lbrace>\<lambda>_ s. P (scheduler_action s)\<rbrace>"
   by (wpsimp simp: arch_switch_to_thread_def)
 
+crunch arch_prepare_next_domain
+  for ct[wp, Schedule_AI_assms]: "\<lambda>s. P (cur_thread s)"
+  and activatable[wp, Schedule_AI_assms]: "ct_in_state activatable"
+  and st_tcb_at[wp, Schedule_AI_assms]: "\<lambda>s. P (st_tcb_at Q t s)"
+  and valid_idle[wp, Schedule_AI_assms]: valid_idle
+  and invs[wp, Schedule_AI_assms]: invs
+  (wp: crunch_wps ct_in_state_thread_state_lift)
+
 lemma arch_stit_scheduler_action [wp, Schedule_AI_assms]:
   "\<lbrace>\<lambda>s. P (scheduler_action s)\<rbrace> arch_switch_to_idle_thread \<lbrace>\<lambda>_ s. P (scheduler_action s)\<rbrace>"
   by (wpsimp simp: arch_switch_to_idle_thread_def)
@@ -122,7 +130,7 @@ interpretation Schedule_AI?: Schedule_AI
   proof goal_cases
   interpret Arch .
   case 1 show ?case
-  by (intro_locales; (unfold_locales; fact Schedule_AI_assms)?)
+  by (intro_locales; unfold_locales; (fact Schedule_AI_assms)?)
   qed
 
 end

--- a/proof/invariant-abstract/ARM_HYP/ArchSyscall_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchSyscall_AI.thy
@@ -19,6 +19,8 @@ named_theorems Syscall_AI_assms
 
 declare arch_get_sanitise_register_info_invs[Syscall_AI_assms]
         arch_get_sanitise_register_info_ex_nonz_cap_to[Syscall_AI_assms]
+        make_fault_msg_inv[Syscall_AI_assms]
+
 crunch handle_arch_fault_reply, arch_get_sanitise_register_info
   for pred_tcb_at[wp,Syscall_AI_assms]: "pred_tcb_at proj P t"
 crunch handle_arch_fault_reply, arch_get_sanitise_register_info

--- a/proof/invariant-abstract/ARM_HYP/ArchTcbAcc_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchTcbAcc_AI.thy
@@ -164,7 +164,7 @@ lemma tcb_context_update_aux: "arch_tcb_context_set (P (arch_tcb_context_get atc
 lemma thread_set_valid_arch_state[TcbAcc_AI_assms]:
   "(\<And>tcb. \<forall>(getF, v) \<in> ran tcb_cap_cases. getF (f tcb) = getF tcb)
    \<Longrightarrow> thread_set f t \<lbrace> valid_arch_state \<rbrace>"
-  by (wp valid_arch_state_lift_aobj_at_no_caps thread_set.aobj_at)
+  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps thread_set_tcb thread_set.aobj_at)
 
 end
 
@@ -184,19 +184,10 @@ lemma arch_thread_set_valid_idle[wp]:
 
 lemma arch_thread_set_if_live_then_nonz_cap_None[wp]:
   "arch_thread_set (tcb_vcpu_update Map.empty) t \<lbrace>if_live_then_nonz_cap\<rbrace>"
-  by (wpsimp wp: arch_thread_set_if_live_then_nonz_cap' simp: hyp_live_def)
+  by (wpsimp wp: arch_thread_set_if_live_then_nonz_cap_unchanged simp: hyp_live_def)
 
-lemma arch_thread_set_if_live_then_nonz_cap_Some[wp]:
-  "\<lbrace>(ex_nonz_cap_to t or obj_at live t) and if_live_then_nonz_cap\<rbrace>
-   arch_thread_set (tcb_vcpu_update (\<lambda>_. Some vcp)) t
-   \<lbrace>\<lambda>rv. if_live_then_nonz_cap\<rbrace>"
-  apply (simp add: arch_thread_set_def)
-  apply (wp set_object_iflive)
-  apply (clarsimp simp: ex_nonz_cap_to_def if_live_then_nonz_cap_def
-                  dest!: get_tcb_SomeD)
-  apply (subst get_tcb_rev, assumption, subst option.sel)+
-  apply (clarsimp simp: obj_at_def tcb_cap_cases_def)
-  done
+lemmas arch_thread_set_if_live_then_nonz_cap_Some[wp]
+  = arch_thread_set_if_live_then_nonz_cap'[where f="tcb_vcpu_update (\<lambda>_. Some vcp)" for vcp]
 
 lemma arch_thread_set_valid_objs_vcpu_None[wp]:
   "arch_thread_set (tcb_vcpu_update Map.empty) t \<lbrace>valid_objs\<rbrace>"

--- a/proof/invariant-abstract/ARM_HYP/ArchTcb_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchTcb_AI.thy
@@ -158,6 +158,10 @@ lemma finalise_cap_not_cte_wp_at[Tcb_AI_assms]:
          | simp add: deleting_irq_handler_def get_irq_slot_def x ball_ran_eq)+
   done
 
+crunch arch_post_set_flags, arch_prepare_set_domain
+  for typ_at[wp, Tcb_AI_assms]: "\<lambda>s. P (typ_at T p s)"
+  and invs[wp, Tcb_AI_assms]: "invs"
+
 
 lemma table_cap_ref_max_free_index_upd[simp,Tcb_AI_assms]:
   "table_cap_ref (max_free_index_update cap) = table_cap_ref cap"
@@ -366,7 +370,6 @@ lemma update_cap_valid[Tcb_AI_assms]:
   apply (case_tac arch_cap, simp_all add: acap_rights_update_def
                                      split: option.splits prod.splits bool.splits)
   done
-
 
 crunch switch_to_thread
   for pred_tcb_at: "pred_tcb_at proj P t"

--- a/proof/invariant-abstract/ARM_HYP/ArchUntyped_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchUntyped_AI.thy
@@ -447,7 +447,7 @@ lemma create_cap_valid_arch_state[wp, Untyped_AI_assms]:
   "\<lbrace>valid_arch_state and cte_wp_at (\<lambda>_. True) cref\<rbrace>
    create_cap tp sz p dev (cref,oref)
    \<lbrace>\<lambda>rv. valid_arch_state\<rbrace>"
-  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps create_cap_aobj_at)
+  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps create_cap_tcb create_cap_aobj_at)
 
 lemma set_cap_non_arch_valid_arch_state[Untyped_AI_assms]:
  "\<lbrace>\<lambda>s. valid_arch_state s \<and> cte_wp_at (\<lambda>_. \<not>is_arch_cap cap) ptr s\<rbrace>

--- a/proof/invariant-abstract/ARM_HYP/ArchVSpaceEntries_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchVSpaceEntries_AI.thy
@@ -1520,8 +1520,9 @@ lemma handle_invocation_valid_pdpt[wp]:
      (auto simp: ct_in_state_def elim: st_tcb_ex_cap)
 
 
-crunch handle_event, activate_thread, switch_to_thread,
-       switch_to_idle_thread, schedule_choose_new_thread
+crunch
+  handle_event, activate_thread, switch_to_thread, switch_to_idle_thread,
+  schedule_choose_new_thread, arch_prepare_next_domain
   for valid_pdpt[wp]: "valid_pdpt_objs"
   (simp: crunch_simps wp: crunch_wps OR_choice_weak_wp select_ext_weak_wp
       ignore: without_preemption getActiveIRQ resetTimer ackInterrupt

--- a/proof/invariant-abstract/ARM_HYP/ArchVSpace_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchVSpace_AI.thy
@@ -2327,7 +2327,7 @@ lemma set_vcpu_valid_reply_masters[wp]:
   by (rule valid_reply_masters_cte_lift) wp
 
 lemma set_vcpu_pred_tcb_at[wp]:
-  "\<lbrace>pred_tcb_at proj P t\<rbrace> set_vcpu p v \<lbrace>\<lambda>rv. pred_tcb_at proj P t\<rbrace>"
+  "set_vcpu p v \<lbrace>\<lambda>s. Q (pred_tcb_at proj P t s)\<rbrace>"
   apply (simp add: set_vcpu_def set_object_def)
   including no_pre apply wp
   apply (rule hoare_strengthen_post [OF get_object_sp])
@@ -2460,8 +2460,8 @@ lemma set_vcpu_valid_pspace:
   apply (wpsimp simp: valid_pspace_def pred_conj_def
                   wp: set_vcpu_if_live_then_nonz_cap_full set_vcpu_sym_refs_refs_hyp)
   apply (clarsimp simp: obj_at_def live_def)
-  apply (clarsimp simp: arch_live_def hyp_refs_of_def refs_of_a_def vcpu_tcb_refs_def hyp_live_def
-                 split: kernel_object.splits arch_kernel_obj.splits option.splits)
+  apply (auto simp: arch_live_def hyp_refs_of_def vcpu_tcb_refs_def hyp_live_def
+              split: kernel_object.splits arch_kernel_obj.splits option.splits)
   done
 
 
@@ -2764,7 +2764,7 @@ lemma svr_invs [wp]:
 crunch
   arm_context_switch, vcpu_update, vgic_update, vcpu_disable, vcpu_enable,
   vcpu_restore, vcpu_switch, set_vm_root
-  for pred_tcb_at[wp]: "pred_tcb_at proj P t"
+  for pred_tcb_at[wp]: "\<lambda>s. Q (pred_tcb_at proj P t s)"
   (simp: crunch_simps wp: crunch_wps mapM_x_wp)
 
 lemmas set_vm_root_typ_ats [wp] = abs_typ_at_lifts [OF set_vm_root_typ_at]

--- a/proof/invariant-abstract/KHeap_AI.thy
+++ b/proof/invariant-abstract/KHeap_AI.thy
@@ -1453,10 +1453,10 @@ lemma set_aobject_valid_mdb[wp]:
   done
 
 lemma set_aobject_pred_tcb_at[wp]:
-  "set_object ptr (ArchObj obj) \<lbrace>pred_tcb_at proj P t\<rbrace>"
+  "set_object ptr (ArchObj obj) \<lbrace>\<lambda>s. Q (pred_tcb_at proj P t s)\<rbrace>"
   apply (simp add: set_object_def)
   apply (wp get_object_wp)
-  apply (clarsimp simp: pred_tcb_at_def obj_at_def a_type_def)
+  apply (clarsimp simp: pred_tcb_at_def obj_at_def a_type_def split: kernel_object.splits)
   done
 
 lemma set_aobject_cur_tcb [wp]:

--- a/proof/invariant-abstract/RISCV64/ArchAcc_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchAcc_AI.thy
@@ -789,7 +789,7 @@ lemma set_pt_distinct [wp]:
 
 crunch store_pte
   for arch[wp]: "\<lambda>s. P (arch_state s)"
-  and "distinct"[wp]: pspace_distinct
+  and distinct[wp]: pspace_distinct
 
 lemma store_pt_asid_pools_of[wp]:
   "set_pt p pt \<lbrace>\<lambda>s. P (asid_pools_of s)\<rbrace>"
@@ -1559,6 +1559,13 @@ lemma set_asid_pool_iflive [wp]:
   done
 
 
+lemma set_asid_pool_nonz_cap_to[wp]:
+  "set_asid_pool p ap \<lbrace>ex_nonz_cap_to t\<rbrace>"
+  apply (simp add: set_asid_pool_def)
+  including unfold_objects
+  by (wpsimp wp: set_object_nonz_cap_to[THEN hoare_set_object_weaken_pre]
+           simp: a_type_def)
+
 lemma set_asid_pool_zombies [wp]:
   "\<lbrace>\<lambda>s. zombies_final s\<rbrace>
   set_asid_pool p ap
@@ -2067,6 +2074,10 @@ lemma mdb_cte_at_set_asid_pool[wp]:
   apply (simp only: imp_conv_disj)
   apply (wp hoare_vcg_disj_lift hoare_vcg_all_lift)
 done
+
+crunch set_asid_pool
+  for valid_cur_fpu[wp]: valid_cur_fpu
+  (wp: valid_cur_fpu_lift)
 
 lemma set_asid_pool_invs_unmap:
   "\<lbrace>invs and ko_at (ArchObj (ASIDPool ap)) p and (\<lambda>s. \<exists>a. asid_table s a = Some p) and

--- a/proof/invariant-abstract/RISCV64/ArchBCorres2_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchBCorres2_AI.thy
@@ -28,10 +28,9 @@ crunch invoke_untyped
   for (bcorres) bcorres[wp]: truncate_state
   (ignore: sequence_x)
 
-crunch set_mcpriority, set_priority
-  for (bcorres) bcorres[wp]: truncate_state
-
-crunch arch_get_sanitise_register_info, arch_post_modify_registers
+crunch
+  set_mcpriority, set_priority, arch_get_sanitise_register_info, arch_post_modify_registers,
+  set_flags, arch_post_set_flags
   for (bcorres) bcorres[wp, BCorres2_AI_assms]: truncate_state
 
 lemma invoke_tcb_bcorres[wp]:
@@ -70,7 +69,7 @@ lemma make_arch_fault_msg_bcorres[wp,BCorres2_AI_assms]:
   "bcorres (make_arch_fault_msg a b) (make_arch_fault_msg a b)"
   by (cases a; simp ; wp)
 
-lemma  handle_arch_fault_reply_bcorres[wp,BCorres2_AI_assms]:
+lemma handle_arch_fault_reply_bcorres[wp,BCorres2_AI_assms]:
   "bcorres ( handle_arch_fault_reply a b c d) (handle_arch_fault_reply a b c d)"
   by (cases a; simp add: handle_arch_fault_reply_def; wp)
 
@@ -103,7 +102,7 @@ lemma decode_cnode_invocation[wp]: "bcorres (decode_cnode_invocation a b c d) (d
 crunch
   decode_set_ipc_buffer, decode_set_space, decode_set_priority,
   decode_set_mcpriority, decode_set_sched_params, decode_bind_notification,
-  decode_unbind_notification, decode_set_tls_base
+  decode_unbind_notification, decode_set_tls_base, decode_set_flags
   for (bcorres) bcorres[wp]: truncate_state
 
 lemma decode_tcb_configure_bcorres[wp]:

--- a/proof/invariant-abstract/RISCV64/ArchCNodeInv_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchCNodeInv_AI.thy
@@ -526,7 +526,7 @@ lemma cap_swap_valid_arch_state[wp, CNodeInv_AI_assms]:
   "\<lbrace>valid_arch_state and cte_wp_at (weak_derived c) a and cte_wp_at (weak_derived c') b\<rbrace>
    cap_swap c a c' b
    \<lbrace>\<lambda>_. valid_arch_state\<rbrace>"
-  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps cap_swap_aobj_at)
+  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps cap_swap_typ_ats cap_swap_aobj_at)
 
 end
 

--- a/proof/invariant-abstract/RISCV64/ArchCSpaceInv_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchCSpaceInv_AI.thy
@@ -16,7 +16,7 @@ context Arch begin arch_global_naming
 
 lemma set_cap_valid_arch_state[wp]:
   "set_cap cap ptr \<lbrace> valid_arch_state \<rbrace>"
-  by (wp valid_arch_state_lift_aobj_at_no_caps set_cap.aobj_at)
+  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps set_cap_tcb set_cap.aobj_at)
 
 lemma replace_cap_invs:
   "\<lbrace>\<lambda>s. invs s \<and> cte_wp_at (replaceable s p cap) p s

--- a/proof/invariant-abstract/RISCV64/ArchCSpace_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchCSpace_AI.thy
@@ -481,7 +481,7 @@ lemma cap_insert_derived_valid_arch_state[CSpace_AI_assms]:
   "\<lbrace>valid_arch_state and (\<lambda>s. cte_wp_at (is_derived (cdt s) src cap) src s)\<rbrace>
    cap_insert cap src dest
    \<lbrace>\<lambda>rv. valid_arch_state \<rbrace>"
-  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps cap_insert_aobj_at cap_insert_aobj_at)
+  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps cap_insert_tcb cap_insert_aobj_at)
 
 lemma setup_reply_master_arch[CSpace_AI_assms]:
   "setup_reply_master t \<lbrace> valid_arch_state \<rbrace>"
@@ -516,7 +516,7 @@ lemma is_cap_simps':
 
 lemma cap_insert_simple_valid_arch_state[wp]:
   "cap_insert cap src dest \<lbrace> valid_arch_state\<rbrace>"
-  by (wp valid_arch_state_lift_aobj_at_no_caps cap_insert_aobj_at)+
+  by (wp valid_arch_state_lift_aobj_at_no_caps cap_insert_tcb cap_insert_aobj_at)+
 
 lemma cap_insert_simple_invs:
   "\<lbrace>invs and valid_cap cap and tcb_cap_valid cap dest and

--- a/proof/invariant-abstract/RISCV64/ArchDetSchedDomainTime_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchDetSchedDomainTime_AI.thy
@@ -22,7 +22,7 @@ crunch
   arch_invoke_irq_control, arch_get_sanitise_register_info,
   prepare_thread_delete, handle_hypervisor_fault, make_arch_fault_msg, init_arch_objects,
   arch_post_modify_registers, arch_post_cap_deletion, handle_vm_fault,
-  arch_invoke_irq_handler
+  arch_invoke_irq_handler, arch_prepare_next_domain, arch_prepare_set_domain, arch_post_set_flags
   for domain_list_inv[wp, DetSchedDomainTime_AI_assms]: "\<lambda>s::det_state. P (domain_list s)"
   (simp: crunch_simps)
 
@@ -36,7 +36,7 @@ crunch
   arch_invoke_irq_control, arch_get_sanitise_register_info,
   prepare_thread_delete, handle_hypervisor_fault, handle_vm_fault,
   arch_post_modify_registers, arch_post_cap_deletion, make_arch_fault_msg,
-  arch_invoke_irq_handler
+  arch_invoke_irq_handler, arch_prepare_next_domain, arch_prepare_set_domain, arch_post_set_flags
   for domain_time_inv[wp, DetSchedDomainTime_AI_assms]: "\<lambda>s::det_state. P (domain_time s)"
   (simp: crunch_simps)
 
@@ -44,6 +44,7 @@ crunch do_machine_op
   for exst[wp]: "\<lambda>s. P (exst s)"
 
 declare init_arch_objects_exst[DetSchedDomainTime_AI_assms]
+        make_arch_fault_msg_inv[DetSchedDomainTime_AI_assms]
 
 end
 

--- a/proof/invariant-abstract/RISCV64/ArchDetSchedSchedule_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchDetSchedSchedule_AI.thy
@@ -17,7 +17,8 @@ crunch
   for prepare_thread_delete_idle_thread[wp, DetSchedSchedule_AI_assms]: "\<lambda>(s:: det_ext state). P (idle_thread s)"
 
 crunch
-  switch_to_idle_thread, switch_to_thread, set_vm_root, arch_get_sanitise_register_info, arch_post_modify_registers
+  switch_to_idle_thread, switch_to_thread, set_vm_root, arch_get_sanitise_register_info,
+  arch_post_modify_registers, arch_prepare_next_domain
   for valid_queues[wp, DetSchedSchedule_AI_assms]: valid_queues
   (simp: crunch_simps ignore: set_tcb_queue tcb_sched_action)
 
@@ -83,7 +84,9 @@ crunch arch_switch_to_thread, arch_get_sanitise_register_info, arch_post_modify_
   for valid_sched_action[wp, DetSchedSchedule_AI_assms]: valid_sched_action
   (simp: crunch_simps)
 
-crunch arch_switch_to_thread, arch_get_sanitise_register_info, arch_post_modify_registers
+crunch
+  arch_switch_to_thread, arch_get_sanitise_register_info, arch_post_modify_registers,
+  arch_prepare_next_domain, arch_post_set_flags, arch_prepare_set_domain
   for valid_sched[wp, DetSchedSchedule_AI_assms]: valid_sched
   (simp: crunch_simps)
 
@@ -105,19 +108,29 @@ crunch set_vm_root
 
 crunch switch_to_thread
   for etcb_at[wp, DetSchedSchedule_AI_assms]: "etcb_at P t"
+  (wp: crunch_wps)
 
 crunch
   arch_switch_to_idle_thread
   for valid_idle[wp, DetSchedSchedule_AI_assms]: "valid_idle"
   (wp: crunch_wps simp: crunch_simps)
 
-crunch arch_switch_to_idle_thread
+crunch arch_switch_to_idle_thread, arch_prepare_next_domain
   for etcb_at[wp, DetSchedSchedule_AI_assms]: "etcb_at P t"
 
 crunch
-  arch_switch_to_idle_thread, next_domain
+  arch_prepare_next_domain, arch_prepare_set_domain
   for scheduler_action[wp, DetSchedSchedule_AI_assms]: "\<lambda>s. P (scheduler_action s)"
   (simp: Let_def)
+
+crunch arch_prepare_next_domain
+  for ready_queues[wp, DetSchedSchedule_AI_assms]: "\<lambda>s. P (ready_queues s)"
+  and ct_in_q[wp, DetSchedSchedule_AI_assms]: ct_in_q
+  and valid_blocked[wp, DetSchedSchedule_AI_assms]: valid_blocked
+
+crunch arch_prepare_set_domain
+  for idle_thread[wp, DetSchedSchedule_AI_assms]: "\<lambda>s. P (idle_thread s)"
+  and valid_idle[wp, DetSchedSchedule_AI_assms]: valid_idle
 
 lemma set_vm_root_valid_blocked_ct_in_q [wp]:
   "\<lbrace>valid_blocked and ct_in_q\<rbrace> set_vm_root p \<lbrace>\<lambda>_. valid_blocked and ct_in_q\<rbrace>"
@@ -270,7 +283,7 @@ crunch arch_invoke_irq_control
   for valid_sched[wp, DetSchedSchedule_AI_assms]: "valid_sched"
 
 crunch
-  arch_activate_idle_thread, arch_switch_to_thread, arch_switch_to_idle_thread
+  arch_activate_idle_thread, arch_switch_to_thread, arch_switch_to_idle_thread, arch_prepare_next_domain
   for valid_list[wp, DetSchedSchedule_AI_assms]: "valid_list"
 
 crunch
@@ -284,10 +297,6 @@ crunch arch_get_sanitise_register_info, arch_post_modify_registers
   for ready_queues[wp, DetSchedSchedule_AI_assms]: "\<lambda>s. P (ready_queues s)"
 crunch arch_get_sanitise_register_info, arch_post_modify_registers
   for scheduler_action[wp, DetSchedSchedule_AI_assms]: "\<lambda>s. P (scheduler_action s)"
-
-lemma make_arch_fault_msg_inv:
-  "make_arch_fault_msg f t \<lbrace>P\<rbrace>"
-  by (cases f) wpsimp
 
 declare make_arch_fault_msg_inv[DetSchedSchedule_AI_assms]
 

--- a/proof/invariant-abstract/RISCV64/ArchDeterministic_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchDeterministic_AI.thy
@@ -14,7 +14,7 @@ named_theorems Deterministic_AI_assms
 
 crunch
   cap_swap_for_delete,set_cap,finalise_cap,arch_get_sanitise_register_info,
-  arch_post_modify_registers
+  arch_post_modify_registers, arch_post_set_flags
   for valid_list[wp, Deterministic_AI_assms]: valid_list
   (wp: crunch_wps simp: unless_def crunch_simps)
 declare get_cap_inv[Deterministic_AI_assms]

--- a/proof/invariant-abstract/RISCV64/ArchDetype_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchDetype_AI.thy
@@ -289,6 +289,11 @@ lemma valid_arch_state_detype[detype_invs_proofs]:
   unfolding valid_arch_state_def pred_conj_def
   by (simp only: valid_asid_table valid_global_arch_objs valid_global_tables) simp
 
+lemma valid_cur_fpu[detype_invs_proofs]:
+  "valid_cur_fpu (detype (untyped_range cap) s)"
+  using valid_cur_fpu
+  by (clarsimp simp: valid_cur_fpu_def)
+
 lemma vs_lookup_asid_pool_level:
   assumes lookup: "vs_lookup_table level asid vref s = Some (level, p)" "vref \<in> user_region"
   assumes ap: "asid_pools_of s p = Some ap"
@@ -585,7 +590,7 @@ sublocale detype_locale < detype_locale_gen_2
  proof goal_cases
   interpret detype_locale_arch ..
   case 1 show ?case
-  by (intro_locales; (unfold_locales; fact detype_invs_proofs)?)
+  by (intro_locales; unfold_locales; (fact detype_invs_proofs)?)
   qed
 
 context detype_locale begin

--- a/proof/invariant-abstract/RISCV64/ArchEmptyFail_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchEmptyFail_AI.thy
@@ -39,7 +39,7 @@ crunch handle_fault
 crunch
   decode_tcb_configure, decode_bind_notification, decode_unbind_notification,
   decode_set_priority, decode_set_mcpriority, decode_set_sched_params,
-  decode_set_tls_base
+  decode_set_tls_base, decode_set_flags
   for (empty_fail) empty_fail[wp]
   (simp: cap.splits arch_cap.splits split_def)
 
@@ -147,7 +147,7 @@ global_interpretation EmptyFail_AI_rec_del?: EmptyFail_AI_rec_del
 
 context Arch begin arch_global_naming
 crunch
-  cap_delete, choose_thread
+  cap_delete, choose_thread, arch_prepare_next_domain
   for (empty_fail) empty_fail[wp, EmptyFail_AI_assms]
 end
 

--- a/proof/invariant-abstract/RISCV64/ArchFinalise_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchFinalise_AI.thy
@@ -649,7 +649,7 @@ lemma prepare_thread_delete_unlive[wp]:
   apply (rule_tac Q'="\<lambda>rv. obj_at (Not \<circ> live0) ptr and obj_at (Not \<circ> hyp_live) ptr" in hoare_strengthen_post)
   apply (wpsimp wp: hoare_vcg_conj_lift prepare_thread_delete_unlive_hyp prepare_thread_delete_unlive0)
    apply (clarsimp simp: obj_at_def)
-  apply (clarsimp simp: obj_at_def, case_tac ko, simp_all add: is_tcb_def live_def)
+  apply (clarsimp simp: obj_at_def, case_tac ko, simp_all add: is_tcb_def live_def arch_tcb_live_def)
   done
 
 lemma finalise_cap_replaceable [Finalise_AI_assms]:
@@ -670,38 +670,37 @@ lemma finalise_cap_replaceable [Finalise_AI_assms]:
                          ran_tcb_cap_cases is_cap_simps
                          gen_obj_refs_subset vs_cap_ref_def
                          all_bool_eq)
-  apply (cases cap;
-           simp add: replaceable_def reachable_frame_cap_def is_arch_cap_def
-                split del: if_split;
-           ((wp suspend_unlive[unfolded o_def]
-                suspend_final_cap[where sl=sl]
-                prepare_thread_delete_unlive[unfolded o_def]
-                unbind_maybe_notification_not_bound
-                get_simple_ko_ko_at unbind_notification_valid_objs
-             | clarsimp simp: o_def dom_tcb_cap_cases_lt_ARCH
-                              ran_tcb_cap_cases is_cap_simps
-                              cap_range_def unat_of_bl_length
-                              can_fast_finalise_def
-                              gen_obj_refs_subset
-                              vs_cap_ref_def
-                              valid_ipc_buffer_cap_def
-                        dest!: tcb_cap_valid_NullCapD
-                        split: Structures_A.thread_state.split_asm
-             | simp cong: conj_cong
-             | simp cong: rev_conj_cong add: no_cap_to_obj_with_diff_ref_Null
-             | (strengthen tcb_cap_valid_imp_NullCap tcb_cap_valid_imp', wp)
-             | rule conjI
-             | erule cte_wp_at_weakenE tcb_cap_valid_imp'[rule_format, rotated -1]
-             | erule(1) no_cap_to_obj_with_diff_ref_finalI_ARCH
-             | (wp (once) hoare_drop_imps,
-                        wp (once) cancel_all_ipc_unlive[unfolded o_def]
-                       cancel_all_signals_unlive[unfolded o_def])
-             | ((wp (once) hoare_drop_imps)?,
-                (wp (once) hoare_drop_imps)?,
-                wp (once) deleting_irq_handler_empty)
-             | wpc
-             | simp add: valid_cap_simps is_nondevice_page_cap_simps)+))
-  done
+  by (cases cap;
+        simp add: replaceable_def reachable_frame_cap_def is_arch_cap_def
+             split del: if_split;
+        ((wp suspend_unlive[unfolded o_def]
+             suspend_final_cap[where sl=sl]
+             prepare_thread_delete_unlive[unfolded o_def]
+             unbind_maybe_notification_not_bound
+             get_simple_ko_ko_at unbind_notification_valid_objs
+          | clarsimp simp: o_def dom_tcb_cap_cases_lt_ARCH
+                           ran_tcb_cap_cases is_cap_simps
+                           cap_range_def unat_of_bl_length
+                           can_fast_finalise_def
+                           gen_obj_refs_subset
+                           vs_cap_ref_def
+                           valid_ipc_buffer_cap_def
+                     dest!: tcb_cap_valid_NullCapD
+                     split: Structures_A.thread_state.split_asm
+          | simp cong: conj_cong
+          | simp cong: rev_conj_cong add: no_cap_to_obj_with_diff_ref_Null
+          | (strengthen tcb_cap_valid_imp_NullCap tcb_cap_valid_imp', wp)
+          | rule conjI
+          | erule cte_wp_at_weakenE tcb_cap_valid_imp'[rule_format, rotated -1]
+          | erule(1) no_cap_to_obj_with_diff_ref_finalI_ARCH
+          | (wp (once) hoare_drop_imps,
+                     wp (once) cancel_all_ipc_unlive[unfolded o_def]
+                    cancel_all_signals_unlive[unfolded o_def])
+          | ((wp (once) hoare_drop_imps)?,
+             (wp (once) hoare_drop_imps)?,
+             wp (once) deleting_irq_handler_empty)
+          | wpc
+          | simp add: valid_cap_simps)+))
 
 lemma (* deleting_irq_handler_cte_preserved *)[Finalise_AI_assms]:
   assumes x: "\<And>cap. P cap \<Longrightarrow> \<not> can_fast_finalise cap"

--- a/proof/invariant-abstract/RISCV64/ArchInvariants_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchInvariants_AI.thy
@@ -670,6 +670,14 @@ definition
 
 declare cap_asid_arch_def[abs_def, simp]
 
+(* arch_tcb_live stub; there is no state in the arch specific part of TCBs on this platform that
+   marks a TCB as live *)
+definition arch_tcb_live :: "arch_tcb \<Rightarrow> bool" where
+  "arch_tcb_live arch_tcb \<equiv> False"
+
+definition valid_cur_fpu :: "'z::state_ext state \<Rightarrow> bool" where
+  "valid_cur_fpu \<equiv> \<top>"
+
 definition
   "cap_asid = arch_cap_fun_lift cap_asid_arch None"
 
@@ -882,9 +890,9 @@ lemma addrFromPPtr_ptrFromPAddr_id[simp]:
   "addrFromPPtr (ptrFromPAddr x) = x"
   by (simp add: addrFromPPtr_def ptrFromPAddr_def)
 
-lemma global_refs_asid_table_update [iff]:
-  "global_refs (s\<lparr>arch_state := riscv_asid_table_update f (arch_state s)\<rparr>) = global_refs s"
-  by (simp add: global_refs_def)
+lemma global_refs_updates[simp]:
+  "\<And>f. global_refs (s\<lparr>arch_state := riscv_asid_table_update f (arch_state s)\<rparr>) = global_refs s"
+  by (auto simp: global_refs_def)
 
 lemma pspace_in_kernel_window_arch_update[simp]:
   "riscv_kernel_vspace (f (arch_state s)) = riscv_kernel_vspace (arch_state s)
@@ -1182,6 +1190,7 @@ lemma valid_tcb_arch_ref_lift:
 lemma tcb_arch_ref_simps[simp]:
   "\<And>f. tcb_arch_ref (tcb_ipc_buffer_update f tcb) = tcb_arch_ref tcb"
   "\<And>f. tcb_arch_ref (tcb_mcpriority_update f tcb) = tcb_arch_ref tcb"
+  "\<And>f. tcb_arch_ref (tcb_flags_update f tcb) = tcb_arch_ref tcb"
   "\<And>f. tcb_arch_ref (tcb_ctable_update f tcb) = tcb_arch_ref tcb"
   "\<And>f. tcb_arch_ref (tcb_vtable_update f tcb) = tcb_arch_ref tcb"
   "\<And>f. tcb_arch_ref (tcb_reply_update f tcb) = tcb_arch_ref tcb"
@@ -1217,6 +1226,15 @@ lemma hyp_live_tcb_simps[simp]:
   "\<And>f. hyp_live (TCB (tcb_priority_update f tcb)) = hyp_live (TCB tcb)"
   "\<And>f. hyp_live (TCB (tcb_time_slice_update f tcb)) = hyp_live (TCB tcb)"
   by (simp_all add: hyp_live_tcb_def)
+
+lemma arch_tcb_live_simps[simp]:
+  "\<And>f. arch_tcb_live (tcb_context_update f arch_tcb) = arch_tcb_live arch_tcb"
+  by (simp_all add: arch_tcb_live_def)
+
+lemma arch_tcb_live_context_simps[simp]:
+  "\<And>f. arch_tcb_live (arch_tcb_context_set f arch_tcb) = arch_tcb_live arch_tcb"
+  "\<And>f. arch_tcb_live (arch_tcb_set_registers f arch_tcb) = arch_tcb_live arch_tcb"
+  by (simp_all add: arch_tcb_context_set_def arch_tcb_set_registers_def)
 
 lemma wellformed_arch_typ:
   "(\<And>T p. f \<lbrace>typ_at T p\<rbrace>) \<Longrightarrow> f \<lbrace>arch_valid_obj ao\<rbrace>"
@@ -1260,17 +1278,14 @@ lemma valid_arch_cap_ref_pspaceI[elim]:
   unfolding valid_arch_cap_ref_def
   by (auto intro: obj_at_pspaceI split: arch_cap.split)
 
-lemma valid_arch_tcb_context_update[simp]:
-  "valid_arch_tcb (tcb_context_update f t) = valid_arch_tcb t"
-  unfolding valid_arch_tcb_def obj_at_def by simp
+lemma valid_arch_tcb_simps[simp]:
+  "\<And>f. valid_arch_tcb (tcb_context_update f t) = valid_arch_tcb t"
+  by (simp add: valid_arch_tcb_def)+
 
-lemma valid_arch_arch_tcb_context_set[simp]:
-  "valid_arch_tcb (arch_tcb_context_set a t) = valid_arch_tcb t"
-  by (simp add: arch_tcb_context_set_def)
-
-lemma valid_arch_arch_tcb_set_registers[simp]:
-  "valid_arch_tcb (arch_tcb_set_registers a t) = valid_arch_tcb t"
-  by (simp add: arch_tcb_set_registers_def)
+lemma valid_arch_tcb_context_simps[simp]:
+  "\<And>a. valid_arch_tcb (arch_tcb_context_set a t) = valid_arch_tcb t"
+  "\<And>a. valid_arch_tcb (arch_tcb_set_registers a t) = valid_arch_tcb t"
+  by (simp add: arch_tcb_context_set_def arch_tcb_set_registers_def)+
 
 lemma valid_arch_tcb_typ_at:
   "\<lbrakk> valid_arch_tcb t s; \<And>T p. typ_at T p s \<Longrightarrow> typ_at T p s' \<rbrakk> \<Longrightarrow> valid_arch_tcb t s'"
@@ -1589,7 +1604,6 @@ lemma valid_global_vspace_mappings_kwD:
 lemma valid_global_vspace_mappings_aligned[simp]:
   "valid_global_vspace_mappings s \<Longrightarrow> is_aligned (global_pt s) pt_bits"
   by (simp add: valid_global_vspace_mappings_def Let_def)
-
 
 lemma vspace_for_asid_SomeD:
   "vspace_for_asid asid s = Some pt_ptr
@@ -2434,6 +2448,10 @@ lemma valid_arch_state_lift:
   shows "f \<lbrace>valid_arch_state\<rbrace>"
   by (rule valid_arch_state_lift_arch; wp)
 
+lemma valid_cur_fpu_updates[simp]:
+  "\<And>f. valid_cur_fpu (arch_state_update f s) = valid_cur_fpu s"
+  by (auto simp: valid_cur_fpu_def)
+
 lemma asid_high_bits_of_and_mask[simp]:
   "asid_high_bits_of (asid && ~~ mask asid_low_bits || ucast (asid_low::asid_low_index)) =
    asid_high_bits_of asid"
@@ -2805,6 +2823,10 @@ lemma has_kernel_mappings_update [iff]:
 lemma equal_kernel_mappings_update [iff]:
   "equal_kernel_mappings (f s) = equal_kernel_mappings s"
   by (simp add: equal_kernel_mappings_def pspace)
+
+lemma valid_cur_fpu_update [iff]:
+  "valid_cur_fpu (f s) = valid_cur_fpu s"
+  by (auto simp: valid_cur_fpu_def)
 
 end
 

--- a/proof/invariant-abstract/RISCV64/ArchIpc_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchIpc_AI.thy
@@ -218,21 +218,17 @@ lemma copy_mrs_in_user_frame[wp, Ipc_AI_2_assms]:
   "\<lbrace>in_user_frame p\<rbrace> copy_mrs t buf t' buf' n \<lbrace>\<lambda>rv. in_user_frame p\<rbrace>"
   by (simp add: in_user_frame_def) (wp hoare_vcg_ex_lift)
 
-lemma as_user_getRestart_invs[wp]: "\<lbrace>P\<rbrace> as_user t getRestartPC \<lbrace>\<lambda>_. P\<rbrace>"
+lemma as_user_getRestart_inv[wp]:
+  "as_user t getRestartPC \<lbrace>P\<rbrace>"
   by (simp add: getRestartPC_def, rule user_getreg_inv)
 
-lemma make_arch_fault_msg_invs[wp, Ipc_AI_2_assms]: "make_arch_fault_msg f t \<lbrace>invs\<rbrace>"
-  by (cases f; wpsimp)
+lemma make_arch_fault_msg_inv[wp, Ipc_AI_2_assms]:
+  "make_arch_fault_msg ft t \<lbrace>P\<rbrace>"
+  by (cases ft; wpsimp)
 
-lemma make_fault_message_inv[wp, Ipc_AI_2_assms]:
-  "make_fault_msg ft t \<lbrace>invs\<rbrace>"
-  apply (cases ft, simp_all split del: if_split)
-     apply (wp as_user_inv getRestartPC_inv mapM_wp'
-              | simp add: getRegister_def)+
-  done
-
-crunch make_fault_msg
-  for tcb_at[wp]: "tcb_at t"
+lemma make_fault_msg_inv[wp, Ipc_AI_2_assms]:
+  "make_fault_msg ft t \<lbrace>P\<rbrace>"
+  by (cases ft; wpsimp wp: as_user_inv getRestartPC_inv mapM_wp' split_del: if_split)
 
 lemma do_fault_transfer_invs[wp, Ipc_AI_2_assms]:
   "\<lbrace>invs and tcb_at receiver\<rbrace>
@@ -496,7 +492,7 @@ lemma setup_caller_cap_aobj_at:
 
 lemma setup_caller_cap_valid_arch[Ipc_AI_2_assms, wp]:
   "setup_caller_cap st rt grant \<lbrace>valid_arch_state\<rbrace>"
-  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps[rotated -1] setup_caller_cap_aobj_at)
+  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps[rotated -1] setup_caller_cap_tcb_at setup_caller_cap_aobj_at)
 
 lemma transfer_caps_loop_valid_arch[Ipc_AI_2_assms]:
   "\<And>slots caps ep buffer n mi.
@@ -505,7 +501,7 @@ lemma transfer_caps_loop_valid_arch[Ipc_AI_2_assms]:
          and transfer_caps_srcs caps\<rbrace>
       transfer_caps_loop ep buffer n caps slots mi
     \<lbrace>\<lambda>_. valid_arch_state\<rbrace>"
-  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps transfer_caps_loop_aobj_at)
+  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps transfer_caps_loop_typ_ats transfer_caps_loop_aobj_at)
 
 end
 
@@ -570,7 +566,7 @@ lemma do_ipc_transfer_valid_arch[Ipc_AI_3_assms]:
   "\<lbrace>valid_arch_state and valid_objs and valid_mdb \<rbrace>
    do_ipc_transfer s ep bg grt r
    \<lbrace>\<lambda>rv. valid_arch_state\<rbrace>"
-  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps do_ipc_transfer_aobj_at)
+  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps dit_tcb_at do_ipc_transfer_aobj_at)
 
 end
 

--- a/proof/invariant-abstract/RISCV64/ArchKHeap_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchKHeap_AI.thy
@@ -603,6 +603,18 @@ lemma valid_arch_state_lift_aobj_at:
 end
 end
 
+\<comment> \<open>Intended for use inside Arch, as opposed to the interface lemma valid_cur_fpu_lift\<close>
+lemma valid_cur_fpu_lift_arch[wp]:
+  shows "f \<lbrace>valid_cur_fpu\<rbrace>"
+  by (wpsimp simp: valid_cur_fpu_def)
+
+\<comment> \<open>Interface lemma\<close>
+lemma valid_cur_fpu_lift:
+  assumes arch_tcb_at[wp]: "\<And>P P' p. f \<lbrace>\<lambda>s. P (arch_tcb_at P' p s)\<rbrace>"
+  assumes arch_state[wp]: "\<And>P. f \<lbrace>\<lambda>s. P (arch_state s)\<rbrace>"
+  shows "f \<lbrace>valid_cur_fpu\<rbrace>"
+  by (wpsimp wp: valid_cur_fpu_lift_arch)
+
 lemma equal_kernel_mappings_lift:
   assumes aobj_at: "\<And>P P' pd. vspace_obj_pred P' \<Longrightarrow> f \<lbrace>\<lambda>s. P (obj_at P' pd s)\<rbrace>"
   assumes [wp]: "\<And>P. f \<lbrace>\<lambda>s. P (arch_state s)\<rbrace>"
@@ -790,7 +802,7 @@ lemma default_arch_object_not_live[simp]: "\<not> live (ArchObj (default_arch_ob
                split: aobject_type.splits)
 
 lemma default_tcb_not_live[simp]: "\<not> live (TCB (default_tcb d))"
-  by (clarsimp simp: default_tcb_def default_arch_tcb_def live_def hyp_live_def)
+  by (clarsimp simp: default_tcb_def default_arch_tcb_def live_def hyp_live_def arch_tcb_live_def)
 
 lemma valid_arch_tcb_same_type:
   "\<lbrakk> valid_arch_tcb t s; valid_obj p k s; kheap s p = Some ko; a_type k = a_type ko \<rbrakk>

--- a/proof/invariant-abstract/RISCV64/ArchKernelInit_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchKernelInit_AI.thy
@@ -561,7 +561,8 @@ lemma invs_A:
     apply auto[1]
    apply (simp add: pspace_aligned_init_A pspace_distinct_init_A)
    apply (rule conjI)
-    apply (clarsimp simp: if_live_then_nonz_cap_def obj_at_def state_defs live_def hyp_live_def)
+    apply (clarsimp simp: if_live_then_nonz_cap_def obj_at_def state_defs live_def hyp_live_def
+                          arch_tcb_live_def)
    apply (rule conjI)
     apply (clarsimp simp: zombies_final_def cte_wp_at_cases state_defs
                           tcb_cap_cases_def is_zombie_def)
@@ -599,6 +600,7 @@ lemma invs_A:
    apply (rule conjI)
     apply (clarsimp simp: valid_asid_table_def state_defs)
    apply (simp add: valid_arch_state_def state_defs obj_at_def a_type_def)
+  apply (rule conjI, clarsimp simp: valid_cur_fpu_def)
   apply (rule conjI)
    apply (clarsimp simp: valid_irq_node_def obj_at_def state_defs
                          is_cap_table_def wf_empty_bits

--- a/proof/invariant-abstract/RISCV64/ArchRetype_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchRetype_AI.thy
@@ -476,6 +476,10 @@ lemma valid_global_tables:
   apply (drule pts_of', fastforce simp: vm_kernel_only_def pte_rights_of_def)
   done
 
+lemma valid_cur_fpu':
+  "valid_cur_fpu s \<Longrightarrow> valid_cur_fpu s'"
+  by (clarsimp simp: valid_cur_fpu_def)
+
 lemma valid_arch_state:
   "valid_arch_state s \<Longrightarrow> valid_arch_state s'"
   apply (simp add: valid_arch_state_def valid_asid_table valid_global_arch_objs valid_global_tables
@@ -905,7 +909,7 @@ lemma post_retype_invs:
   apply (clarsimp simp: invs_def post_retype_invs_def valid_state_def
                      unsafe_rep2 null_filter valid_idle
                      valid_reply_caps valid_reply_masters
-                     valid_global_refs valid_arch_state
+                     valid_global_refs valid_arch_state valid_cur_fpu'
                      valid_irq_node_def obj_at_pres
                      valid_arch_caps valid_global_objs_def
                      valid_vspace_objs' valid_irq_handlers

--- a/proof/invariant-abstract/RISCV64/ArchSchedule_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchSchedule_AI.thy
@@ -28,9 +28,9 @@ lemma dmo_mapM_storeWord_0_invs[wp,Schedule_AI_assms]:
   by (simp add: upto.simps word_bits_def)
 
 lemma arch_stt_invs [wp,Schedule_AI_assms]:
-  "\<lbrace>invs\<rbrace> arch_switch_to_thread t' \<lbrace>\<lambda>_. invs\<rbrace>"
+  "\<lbrace>invs and ex_nonz_cap_to t\<rbrace> arch_switch_to_thread t \<lbrace>\<lambda>_. invs\<rbrace>"
   apply (simp add: arch_switch_to_thread_def)
-  apply wp
+  apply wpsimp
   done
 
 lemma arch_stt_tcb [wp,Schedule_AI_assms]:
@@ -88,6 +88,14 @@ lemma arch_stt_scheduler_action [wp, Schedule_AI_assms]:
   "\<lbrace>\<lambda>s. P (scheduler_action s)\<rbrace> arch_switch_to_thread t' \<lbrace>\<lambda>_ s. P (scheduler_action s)\<rbrace>"
   by (wpsimp simp: arch_switch_to_thread_def)
 
+crunch arch_prepare_next_domain
+  for ct[wp, Schedule_AI_assms]: "\<lambda>s. P (cur_thread s)"
+  and activatable[wp, Schedule_AI_assms]: "ct_in_state activatable"
+  and st_tcb_at[wp, Schedule_AI_assms]: "\<lambda>s. P (st_tcb_at Q t s)"
+  and valid_idle[wp, Schedule_AI_assms]: valid_idle
+  and invs[wp, Schedule_AI_assms]: invs
+  (wp: crunch_wps ct_in_state_thread_state_lift)
+
 lemma arch_stit_scheduler_action [wp, Schedule_AI_assms]:
   "\<lbrace>\<lambda>s. P (scheduler_action s)\<rbrace> arch_switch_to_idle_thread \<lbrace>\<lambda>_ s. P (scheduler_action s)\<rbrace>"
   by (wpsimp simp: arch_switch_to_idle_thread_def)
@@ -98,7 +106,7 @@ interpretation Schedule_AI?: Schedule_AI
   proof goal_cases
   interpret Arch .
   case 1 show ?case
-  by (intro_locales; (unfold_locales; fact Schedule_AI_assms)?)
+  by (intro_locales; unfold_locales; (fact Schedule_AI_assms)?)
   qed
 
 end

--- a/proof/invariant-abstract/RISCV64/ArchSyscall_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchSyscall_AI.thy
@@ -18,6 +18,9 @@ context Arch begin arch_global_naming
 named_theorems Syscall_AI_assms
 
 declare arch_get_sanitise_register_info_invs[Syscall_AI_assms]
+        arch_get_sanitise_register_info_ex_nonz_cap_to[Syscall_AI_assms]
+        make_fault_msg_inv[Syscall_AI_assms]
+
 crunch handle_arch_fault_reply, arch_get_sanitise_register_info
   for pred_tcb_at[wp,Syscall_AI_assms]: "pred_tcb_at proj P t"
 crunch handle_arch_fault_reply
@@ -85,8 +88,6 @@ lemma hvmf_active [Syscall_AI_assms]:
 lemma hvmf_ex_cap[wp, Syscall_AI_assms]:
   "\<lbrace>ex_nonz_cap_to p\<rbrace> handle_vm_fault t b \<lbrace>\<lambda>rv. ex_nonz_cap_to p\<rbrace>"
   unfolding handle_vm_fault_def by (cases b; wpsimp)
-
-declare arch_get_sanitise_register_info_ex_nonz_cap_to[Syscall_AI_assms]
 
 lemma hh_invs[wp, Syscall_AI_assms]:
   "\<lbrace>invs and ct_active and st_tcb_at active thread and ex_nonz_cap_to_thread\<rbrace>

--- a/proof/invariant-abstract/RISCV64/ArchTcbAcc_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchTcbAcc_AI.thy
@@ -159,7 +159,7 @@ lemma tcb_context_update_aux: "arch_tcb_context_set (P (arch_tcb_context_get atc
 lemma thread_set_valid_arch_state[TcbAcc_AI_assms]:
   "(\<And>tcb. \<forall>(getF, v) \<in> ran tcb_cap_cases. getF (f tcb) = getF tcb)
    \<Longrightarrow> thread_set f t \<lbrace> valid_arch_state \<rbrace>"
-  by (wp valid_arch_state_lift_aobj_at_no_caps thread_set.aobj_at)
+  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps thread_set_tcb thread_set.aobj_at)
 
 end
 

--- a/proof/invariant-abstract/RISCV64/ArchTcb_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchTcb_AI.thy
@@ -146,6 +146,10 @@ lemma finalise_cap_not_cte_wp_at[Tcb_AI_assms]:
          | simp add: deleting_irq_handler_def get_irq_slot_def x ball_ran_eq)+
     done
 
+crunch arch_post_set_flags, arch_prepare_set_domain
+  for typ_at[wp, Tcb_AI_assms]: "\<lambda>s. P (typ_at T p s)"
+  and invs[wp, Tcb_AI_assms]: "invs"
+
 
 lemma table_cap_ref_max_free_index_upd[simp,Tcb_AI_assms]:
   "table_cap_ref (max_free_index_update cap) = table_cap_ref cap"
@@ -366,7 +370,6 @@ lemma update_cap_valid[Tcb_AI_assms]:
   apply (case_tac arch_cap, simp_all add: acap_rights_update_def Let_def
                                      split: option.splits prod.splits)
   done
-
 
 crunch switch_to_thread
   for pred_tcb_at: "pred_tcb_at proj P t"

--- a/proof/invariant-abstract/RISCV64/ArchUntyped_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchUntyped_AI.thy
@@ -361,7 +361,7 @@ lemma create_cap_valid_arch_state[wp, Untyped_AI_assms]:
   "\<lbrace>valid_arch_state and cte_wp_at (\<lambda>_. True) cref\<rbrace>
    create_cap tp sz p dev (cref,oref)
    \<lbrace>\<lambda>rv. valid_arch_state\<rbrace>"
-  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps create_cap_aobj_at)
+  by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps create_cap_tcb create_cap_aobj_at)
 
 lemma set_cap_non_arch_valid_arch_state[Untyped_AI_assms]:
  "\<lbrace>\<lambda>s. valid_arch_state s \<and> cte_wp_at (\<lambda>_. \<not>is_arch_cap cap) ptr s\<rbrace>

--- a/proof/invariant-abstract/RISCV64/ArchVSpaceEntries_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchVSpaceEntries_AI.thy
@@ -318,7 +318,7 @@ lemma handle_invocation_valid_vspace_objs'[wp]:
 crunch activate_thread,switch_to_thread, handle_hypervisor_fault,
        switch_to_idle_thread, handle_call, handle_recv, handle_reply,
        handle_send, handle_yield, handle_interrupt,
-       schedule_choose_new_thread
+       schedule_choose_new_thread, arch_prepare_next_domain
   for valid_vspace_objs'[wp]: "valid_vspace_objs'"
   (simp: crunch_simps wp: crunch_wps OR_choice_weak_wp select_ext_weak_wp
       ignore: without_preemption getActiveIRQ resetTimer ackInterrupt

--- a/proof/invariant-abstract/RISCV64/ArchVSpace_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchVSpace_AI.thy
@@ -297,7 +297,7 @@ lemma set_vm_root_invs[wp]:
   by (wpsimp simp: if_distribR wp: get_cap_wp)
 
 crunch set_vm_root
-  for pred_tcb_at[wp]: "pred_tcb_at proj P t"
+  for pred_tcb_at[wp]: "\<lambda>s. Q (pred_tcb_at proj P t s)"
   (simp: crunch_simps)
 
 lemmas set_vm_root_typ_ats [wp] = abs_typ_at_lifts [OF set_vm_root_typ_at]

--- a/proof/invariant-abstract/X64/ArchBCorres2_AI.thy
+++ b/proof/invariant-abstract/X64/ArchBCorres2_AI.thy
@@ -28,7 +28,7 @@ crunch invoke_untyped
   for (bcorres) bcorres[wp]: truncate_state
   (ignore: sequence_x)
 
-crunch set_mcpriority, set_priority
+crunch set_mcpriority, set_priority, set_flags, arch_post_set_flags
   for (bcorres) bcorres[wp]: truncate_state
 
 crunch arch_get_sanitise_register_info, arch_post_modify_registers
@@ -72,7 +72,7 @@ lemma make_arch_fault_msg_bcorres[wp,BCorres2_AI_assms]:
   "bcorres (make_arch_fault_msg a b) (make_arch_fault_msg a b)"
   by (cases a; simp ; wp)
 
-lemma  handle_arch_fault_reply_bcorres[wp,BCorres2_AI_assms]:
+lemma handle_arch_fault_reply_bcorres[wp,BCorres2_AI_assms]:
   "bcorres ( handle_arch_fault_reply a b c d) (handle_arch_fault_reply a b c d)"
   by (cases a; simp add: handle_arch_fault_reply_def; wp)
 
@@ -105,7 +105,7 @@ lemma decode_cnode_invocation[wp]: "bcorres (decode_cnode_invocation a b c d) (d
 crunch
   decode_set_ipc_buffer, decode_set_space, decode_set_priority,
   decode_set_mcpriority, decode_set_sched_params, decode_bind_notification,
-  decode_unbind_notification, decode_set_tls_base
+  decode_unbind_notification, decode_set_tls_base, decode_set_flags
   for (bcorres) bcorres[wp]: truncate_state
 
 lemma decode_tcb_configure_bcorres[wp]: "bcorres (decode_tcb_configure b (cap.ThreadCap c) d e)

--- a/proof/invariant-abstract/X64/ArchBits_AI.thy
+++ b/proof/invariant-abstract/X64/ArchBits_AI.thy
@@ -10,6 +10,14 @@ begin
 
 context Arch begin arch_global_naming
 
+(* arch-specific interpretations of update locales: *)
+
+(* FIXME: do this for other x64 arch_state fields *)
+sublocale p_asid_table_current_fpu_update:
+  Arch_p_asid_table_update_eq "\<lambda>s. s\<lparr>arch_state := x64_current_fpu_owner_update f (arch_state s)\<rparr>"
+  by (unfold_locales) (auto simp: second_level_tables_def)
+
+
 lemma invs_valid_ioports[elim!]:
   "invs s \<Longrightarrow> valid_ioports s"
   by (simp add: invs_def valid_state_def valid_arch_state_def)

--- a/proof/invariant-abstract/X64/ArchCSpace_AI.thy
+++ b/proof/invariant-abstract/X64/ArchCSpace_AI.thy
@@ -752,13 +752,16 @@ lemma set_ioport_mask_invs:
                         valid_irq_node_def valid_irq_states_def valid_machine_state_def valid_arch_caps_def
                          valid_global_objs_def valid_asid_map_def valid_kernel_mappings_def
                         second_level_tables_def)
-  apply (clarsimp simp: valid_ioports_def all_ioports_issued_def)
-  apply (drule_tac x=cap in bspec, assumption)
-  apply (clarsimp simp: subset_eq issued_ioports_def clearable_ioport_range_def)
-  apply (case_tac b; simp)
-  apply (erule ranE)
-  apply (drule_tac x=cap in bspec, fastforce simp: ran_def)
-  by auto
+  apply (rule conjI)
+   apply (clarsimp simp: valid_ioports_def all_ioports_issued_def)
+   apply (drule_tac x=cap in bspec, assumption)
+   apply (clarsimp simp: subset_eq issued_ioports_def clearable_ioport_range_def)
+   apply (case_tac b; simp)
+   apply (erule ranE)
+   apply (drule_tac x=cap in bspec, fastforce simp: ran_def)
+   apply fastforce
+  apply (clarsimp simp: valid_cur_fpu_defs)
+  done
 
 definition
   "arch_post_cap_delete_pre \<equiv> clearable_ioport_range"

--- a/proof/invariant-abstract/X64/ArchCrunchSetup_AI.thy
+++ b/proof/invariant-abstract/X64/ArchCrunchSetup_AI.thy
@@ -12,7 +12,7 @@ begin
 context Arch begin arch_global_naming
 
 
-crunch_ignore (add: debugPrint clearMemory invalidateTLB initL2Cache)
+crunch_ignore (add: debugPrint clearMemory)
 
 end
 

--- a/proof/invariant-abstract/X64/ArchDetSchedDomainTime_AI.thy
+++ b/proof/invariant-abstract/X64/ArchDetSchedDomainTime_AI.thy
@@ -28,7 +28,8 @@ crunch
   arch_invoke_irq_control, handle_vm_fault, arch_post_modify_registers,
   prepare_thread_delete, handle_hypervisor_fault, arch_post_cap_deletion,
   make_arch_fault_msg, arch_get_sanitise_register_info, handle_reserved_irq,
-  arch_invoke_irq_handler, arch_mask_irq_signal
+  arch_invoke_irq_handler, arch_mask_irq_signal, arch_prepare_next_domain, arch_prepare_set_domain,
+  arch_post_set_flags
   for domain_list_inv[wp, DetSchedDomainTime_AI_assms]: "\<lambda>s::det_state. P (domain_list s)"
   (wp: crunch_wps)
 
@@ -42,12 +43,12 @@ crunch
   arch_invoke_irq_control, handle_vm_fault, arch_post_modify_registers,
   prepare_thread_delete, handle_hypervisor_fault, arch_post_cap_deletion,
   arch_get_sanitise_register_info, handle_reserved_irq, arch_invoke_irq_handler,
-  arch_mask_irq_signal
+  arch_mask_irq_signal, arch_prepare_set_domain, arch_post_set_flags
   for domain_time_inv[wp, DetSchedDomainTime_AI_assms]: "\<lambda>s::det_state. P (domain_time s)"
   (wp: crunch_wps)
 
 declare init_arch_objects_exst[DetSchedDomainTime_AI_assms]
-        make_arch_fault_msg_invs[DetSchedDomainTime_AI_assms]
+        make_arch_fault_msg_inv[DetSchedDomainTime_AI_assms]
 
 end
 

--- a/proof/invariant-abstract/X64/ArchDetSchedSchedule_AI.thy
+++ b/proof/invariant-abstract/X64/ArchDetSchedSchedule_AI.thy
@@ -17,14 +17,15 @@ crunch
   for prepare_thread_delete_idel_thread[wp, DetSchedSchedule_AI_assms]: "\<lambda>(s:: det_ext state). P (idle_thread s)"
 
 crunch
-  switch_to_idle_thread, switch_to_thread, arch_get_sanitise_register_info, arch_post_modify_registers
+  switch_to_idle_thread, switch_to_thread, arch_get_sanitise_register_info, arch_post_modify_registers,
+  arch_prepare_next_domain
   for valid_queues[wp, DetSchedSchedule_AI_assms]: valid_queues
-  (simp: crunch_simps ignore: set_tcb_queue tcb_sched_action )
+  (simp: crunch_simps wp: crunch_wps ignore: tcb_sched_action )
 
 crunch
   switch_to_idle_thread, switch_to_thread, arch_get_sanitise_register_info, arch_post_modify_registers
   for weak_valid_sched_action[wp, DetSchedSchedule_AI_assms]: "weak_valid_sched_action"
-  (simp: crunch_simps)
+  (simp: crunch_simps wp: crunch_wps)
 
 crunch set_vm_root
   for ready_queues[wp]: "\<lambda>s. P (ready_queues s)"
@@ -74,26 +75,32 @@ lemma switch_to_idle_thread_ct_in_cur_domain [wp, DetSchedSchedule_AI_assms]:
 crunch
   arch_switch_to_thread, arch_get_sanitise_register_info
   for ct_not_in_q[wp, DetSchedSchedule_AI_assms]: ct_not_in_q
-  (simp: crunch_simps ignore: )
+  (simp: crunch_simps wp: crunch_wps)
 
 crunch
   arch_switch_to_thread, arch_get_sanitise_register_info
   for is_activatable[wp, DetSchedSchedule_AI_assms]: "is_activatable t"
-  (simp: crunch_simps ignore: )
+  (simp: crunch_simps wp: crunch_wps)
 
 crunch
   arch_switch_to_thread, arch_get_sanitise_register_info, arch_post_modify_registers
   for valid_sched_action[wp, DetSchedSchedule_AI_assms]: valid_sched_action
-  (simp: crunch_simps ignore: )
+  (simp: crunch_simps wp: crunch_wps)
 
 crunch
-  arch_switch_to_thread, arch_get_sanitise_register_info, arch_post_modify_registers
+  arch_switch_to_thread, arch_get_sanitise_register_info, arch_post_modify_registers,
+  arch_prepare_next_domain, arch_post_set_flags, arch_prepare_set_domain
   for valid_sched[wp, DetSchedSchedule_AI_assms]: valid_sched
-  (simp: crunch_simps ignore: )
+  (simp: crunch_simps wp: crunch_wps)
 
 crunch set_vm_root
   for exst[wp]: "\<lambda>s. P (exst s)"
   (wp: crunch_wps whenE_wp simp: crunch_simps)
+
+lemma arch_thread_set_ct_in_cur_domain_2[wp]:
+  "arch_thread_set f tptr \<lbrace>\<lambda>s. ct_in_cur_domain_2 thread (idle_thread s) (scheduler_action s) (cur_domain s) (etcbs_of s)\<rbrace>"
+  apply (simp add: arch_thread_set_def set_object_def get_object_def)
+  by wpsimp
 
 crunch arch_switch_to_thread
   for ct_in_cur_domain_2[wp, DetSchedSchedule_AI_assms]: "\<lambda>s. ct_in_cur_domain_2 thread (idle_thread s) (scheduler_action s) (cur_domain s) (etcbs_of s)"
@@ -115,23 +122,40 @@ crunch
   for valid_idle[wp, DetSchedSchedule_AI_assms]: "valid_idle :: det_ext state \<Rightarrow> bool"
   (wp: crunch_wps simp: crunch_simps)
 
-crunch arch_switch_to_idle_thread
+crunch arch_switch_to_idle_thread, arch_prepare_next_domain
   for etcb_at[wp, DetSchedSchedule_AI_assms]: "etcb_at P t"
 
 crunch
-  arch_switch_to_idle_thread, next_domain
+  arch_prepare_next_domain, arch_prepare_set_domain
   for scheduler_action[wp, DetSchedSchedule_AI_assms]: "\<lambda>s. P (scheduler_action s)"
   (simp: Let_def)
+
+lemma as_user_ct_in_q[wp]:
+  "as_user t f \<lbrace>ct_in_q\<rbrace>"
+  unfolding ct_in_q_def
+  by (wpsimp wp: hoare_vcg_imp_lift | wps)+
+
+crunch arch_prepare_next_domain
+  for ready_queues[wp, DetSchedSchedule_AI_assms]: "\<lambda>s. P (ready_queues s)"
+  and ct_in_q[wp, DetSchedSchedule_AI_assms]: ct_in_q
+  and valid_blocked[wp, DetSchedSchedule_AI_assms]: valid_blocked
+  (wp: crunch_wps)
+
+crunch arch_prepare_set_domain
+  for idle_thread[wp, DetSchedSchedule_AI_assms]: "\<lambda>s. P (idle_thread s)"
+  and valid_idle[wp, DetSchedSchedule_AI_assms]: valid_idle
 
 lemma set_vm_root_valid_blocked_ct_in_q [wp]:
   "\<lbrace>valid_blocked and ct_in_q\<rbrace> set_vm_root p \<lbrace>\<lambda>_. valid_blocked and ct_in_q\<rbrace>"
   by (wp | wpc | auto)+
 
+crunch lazy_fpu_restore
+  for valid_blocked[wp]: valid_blocked
+  and ct_in_q[wp]: ct_in_q
+
 lemma arch_switch_to_thread_valid_blocked [wp, DetSchedSchedule_AI_assms]:
   "\<lbrace>valid_blocked and ct_in_q\<rbrace> arch_switch_to_thread thread \<lbrace>\<lambda>_. valid_blocked and ct_in_q\<rbrace>"
-  apply (simp add: arch_switch_to_thread_def)
-  apply wp
-  done
+  by (wpsimp simp: arch_switch_to_thread_def)
 
 lemma switch_to_idle_thread_ct_not_queued [wp, DetSchedSchedule_AI_assms]:
   "\<lbrace>valid_queues and valid_idle\<rbrace>
@@ -312,21 +336,21 @@ crunch arch_invoke_irq_control
   for valid_sched[wp, DetSchedSchedule_AI_assms]: "valid_sched"
 
 crunch
-  arch_activate_idle_thread, arch_switch_to_thread, arch_switch_to_idle_thread
+  arch_activate_idle_thread, arch_switch_to_thread, arch_switch_to_idle_thread, arch_prepare_next_domain
   for valid_list[wp, DetSchedSchedule_AI_assms]: "valid_list"
 
 crunch
   handle_arch_fault_reply, handle_vm_fault, arch_get_sanitise_register_info, arch_post_modify_registers
   for cur_tcb[wp, DetSchedSchedule_AI_assms]: cur_tcb
 
-crunch make_arch_fault_msg, arch_get_sanitise_register_info, arch_post_modify_registers
+crunch arch_get_sanitise_register_info, arch_post_modify_registers
   for not_cur_thread[wp, DetSchedSchedule_AI_assms]: "not_cur_thread t'"
-crunch make_arch_fault_msg
-  for valid_sched[wp, DetSchedSchedule_AI_assms]: valid_sched
-crunch make_arch_fault_msg, arch_get_sanitise_register_info, arch_post_modify_registers
+crunch arch_get_sanitise_register_info, arch_post_modify_registers
   for ready_queues[wp, DetSchedSchedule_AI_assms]: "\<lambda>s. P (ready_queues s)"
-crunch make_arch_fault_msg, arch_get_sanitise_register_info, arch_post_modify_registers
+crunch arch_get_sanitise_register_info, arch_post_modify_registers
   for scheduler_action[wp, DetSchedSchedule_AI_assms]: "\<lambda>s. P (scheduler_action s)"
+
+declare make_arch_fault_msg_inv[DetSchedSchedule_AI_assms]
 
 lemma arch_post_modify_registers_not_idle_thread[DetSchedSchedule_AI_assms]:
   "\<lbrace>\<lambda>s::det_ext state. t \<noteq> idle_thread s\<rbrace> arch_post_modify_registers c t \<lbrace>\<lambda>_ s. t \<noteq> idle_thread s\<rbrace>"

--- a/proof/invariant-abstract/X64/ArchDeterministic_AI.thy
+++ b/proof/invariant-abstract/X64/ArchDeterministic_AI.thy
@@ -21,7 +21,7 @@ crunch set_object
 
 crunch
   cap_swap_for_delete,set_cap,finalise_cap,arch_get_sanitise_register_info,
-  arch_post_modify_registers, arch_invoke_irq_handler
+  arch_post_modify_registers, arch_invoke_irq_handler, arch_post_set_flags
   for valid_list[wp, Deterministic_AI_assms]: valid_list
   (wp: crunch_wps simp: unless_def crunch_simps)
 declare get_cap_inv[Deterministic_AI_assms]

--- a/proof/invariant-abstract/X64/ArchDetype_AI.thy
+++ b/proof/invariant-abstract/X64/ArchDetype_AI.thy
@@ -82,7 +82,7 @@ next
 qed
 
 lemma empty_fail_freeMemory [Detype_AI_assms]: "empty_fail (freeMemory ptr bits)"
-  by (fastforce simp: freeMemory_def mapM_x_mapM ef_storeWord)
+  by (fastforce simp: freeMemory_def mapM_x_mapM)
 
 
 lemma region_in_kernel_window_detype[simp]:
@@ -211,6 +211,11 @@ lemma valid_arch_state_detype[detype_invs_proofs]:
   apply (simp add: cap_range_def)
   apply blast
   done
+
+lemma valid_cur_fpu[detype_invs_proofs]:
+  "valid_cur_fpu (detype (untyped_range cap) s)"
+  using valid_cur_fpu
+  by (auto simp: valid_cur_fpu_def is_tcb_cur_fpu_def live_def arch_tcb_live_def arch_state_det elim!: live_okE)
 
 lemma global_pdpts:
   "\<And>p. \<lbrakk> p \<in> set (x64_global_pdpts (arch_state s)); p \<in> untyped_range cap \<rbrakk>  \<Longrightarrow> False"
@@ -547,7 +552,7 @@ sublocale detype_locale < detype_locale_gen_2
  proof goal_cases
   interpret detype_locale_arch ..
   case 1 show ?case
-  by (intro_locales; (unfold_locales; fact detype_invs_proofs)?)
+  by (intro_locales; unfold_locales; (fact detype_invs_proofs)?)
   qed
 
 context detype_locale begin
@@ -569,7 +574,7 @@ lemma (in Arch) delete_objects_invs[wp]:
     invs and ct_active\<rbrace>
     delete_objects ptr bits \<lbrace>\<lambda>_. invs\<rbrace>"
   apply (simp add: delete_objects_def)
-  apply (simp add: freeMemory_def word_size_def bind_assoc ef_storeWord)
+  apply (simp add: freeMemory_def word_size_def bind_assoc)
    apply (rule hoare_pre)
    apply (rule_tac P'="is_aligned ptr bits \<and> word_size_bits \<le> bits \<and> bits \<le> word_bits"
                 in hoare_grab_asm)

--- a/proof/invariant-abstract/X64/ArchEmptyFail_AI.thy
+++ b/proof/invariant-abstract/X64/ArchEmptyFail_AI.thy
@@ -12,18 +12,12 @@ context Arch begin arch_global_naming
 
 named_theorems EmptyFail_AI_assms
 
-crunch_ignore (empty_fail)
-  (add: invalidateTLBEntry_impl invalidateTranslationSingleASID_impl
-        invalidateASID_impl ioapicMapPinToVector_impl
-        in8_impl in16_impl in32_impl out8_impl out16_impl out32_impl)
-
-lemma invalidateLocalPageStructureCacheASID_ef[simp,wp]:
-  "empty_fail (invalidateLocalPageStructureCacheASID vs asid)"
-  by (simp add: invalidateLocalPageStructureCacheASID_def)
-
 crunch
-  loadWord, load_word_offs, storeWord, getRestartPC, get_mrs, invalidate_page_structure_cache_asid
+  load_word_offs, get_mrs, invalidate_page_structure_cache_asid
   for (empty_fail) empty_fail[wp, EmptyFail_AI_assms]
+
+(* FIXME: remove from locale *)
+declare loadWord_empty_fail[EmptyFail_AI_assms]
 
 end
 
@@ -56,7 +50,7 @@ lemma port_in_empty_fail[simp, intro!]:
 crunch
   decode_tcb_configure, decode_bind_notification, decode_unbind_notification,
   decode_set_priority, decode_set_mcpriority, decode_set_sched_params,
-  decode_set_tls_base
+  decode_set_tls_base, decode_set_flags
   for (empty_fail) empty_fail[wp]
   (simp: cap.splits arch_cap.splits split_def)
 
@@ -154,11 +148,7 @@ crunch maskInterrupt, empty_slot,
   (simp: Let_def catch_def split_def OR_choiceE_def mk_ef_def option.splits endpoint.splits
          notification.splits thread_state.splits sum.splits cap.splits arch_cap.splits
          kernel_object.splits vmpage_size.splits pde.splits bool.splits list.splits
-         set_object_def
-   ignore: nativeThreadUsingFPU_impl switchFpuOwner_impl)
-
-crunch setRegister, setNextPC
-  for (empty_fail) empty_fail[wp, EmptyFail_AI_assms]
+         set_object_def)
 
 end
 
@@ -170,7 +160,7 @@ global_interpretation EmptyFail_AI_rec_del?: EmptyFail_AI_rec_del
 
 context Arch begin arch_global_naming
 crunch
-  cap_delete, choose_thread
+  cap_delete, choose_thread, arch_prepare_next_domain
   for (empty_fail) empty_fail[wp, EmptyFail_AI_assms]
 end
 
@@ -189,8 +179,7 @@ crunch possible_switch_to, handle_event, activate_thread
          bool.splits apiobject_type.splits aobject_type.splits notification.splits
          thread_state.splits endpoint.splits catch_def sum.splits cnode_invocation.splits
          page_table_invocation.splits page_invocation.splits asid_control_invocation.splits
-         asid_pool_invocation.splits arch_invocation.splits irq_state.splits syscall.splits
-   ignore: resetTimer_impl)
+         asid_pool_invocation.splits arch_invocation.splits irq_state.splits syscall.splits)
 end
 
 global_interpretation EmptyFail_AI_call_kernel?: EmptyFail_AI_call_kernel

--- a/proof/invariant-abstract/X64/ArchFinalise_AI.thy
+++ b/proof/invariant-abstract/X64/ArchFinalise_AI.thy
@@ -78,7 +78,7 @@ lemma invs_x64_asid_table_unmap:
                     valid_vs_lookup_unmap_strg valid_arch_state_unmap_strg)
   apply (simp add: valid_irq_node_def valid_kernel_mappings_def
                    valid_global_objs_arch_update valid_asid_map_def)
-  apply (simp add: valid_table_caps_def valid_machine_state_def second_level_tables_def)
+  apply (simp add: valid_table_caps_def valid_machine_state_def second_level_tables_def valid_cur_fpu_defs)
   done
 
 lemma delete_asid_pool_invs[wp]:
@@ -315,8 +315,14 @@ lemma (* unbind_notification_final *) [wp,Finalise_AI_assms]:
        | wpc | simp add: tcb_cap_cases_def)+
   done
 
+lemma as_user_final[wp]:
+  "as_user t f \<lbrace>is_final_cap' cap\<rbrace>"
+  by (wpsimp wp: as_user_wp_thread_set_helper thread_set_final_cap
+           simp: ran_tcb_cap_cases)
+
 crunch prepare_thread_delete
   for is_final_cap'[wp]: "is_final_cap' cap"
+  (wp: crunch_wps)
 
 lemma (* finalise_cap_cases1 *)[Finalise_AI_assms]:
   "\<lbrace>\<lambda>s. final \<longrightarrow> is_final_cap' cap s
@@ -356,41 +362,12 @@ crunch arch_finalise_cap, prepare_thread_delete
 
 crunch prepare_thread_delete
   for valid_cap[wp]: "valid_cap cap"
-crunch prepare_thread_delete
-  for tcb_at[wp]: "tcb_at p"
-crunch prepare_thread_delete
-  for cte_wp_at[wp, Finalise_AI_assms]: "\<lambda>s. P (cte_wp_at P' p s)"
-crunch prepare_thread_delete
-  for irq_node[wp, Finalise_AI_assms]: "\<lambda>s. P (interrupt_irq_node s)"
-crunch prepare_thread_delete
-  for caps_of_state[wp, Finalise_AI_assms]: "\<lambda>s. P (caps_of_state s)"
-
-crunch nativeThreadUsingFPU, switchFpuOwner
-  for device_state_inv[wp]: "\<lambda>ms. P (device_state ms)"
-
-lemma dmo_nativeThreadUsingFPU[wp]: "\<lbrace>invs\<rbrace> do_machine_op (nativeThreadUsingFPU thread) \<lbrace>\<lambda>y. invs\<rbrace>"
-  apply (wp dmo_invs)
-  apply safe
-   apply (drule_tac Q="\<lambda>_ m'. underlying_memory m' p = underlying_memory m p"
-          in use_valid)
-     apply ((clarsimp simp: nativeThreadUsingFPU_def machine_op_lift_def
-                            machine_rest_lift_def split_def | wp)+)[3]
-  apply (erule (1) use_valid[OF _ nativeThreadUsingFPU_irq_masks])
-  done
-
-lemma dmo_switchFpuOwner[wp]: "\<lbrace>invs\<rbrace> do_machine_op (switchFpuOwner thread cpu) \<lbrace>\<lambda>y. invs\<rbrace>"
-  apply (wp dmo_invs)
-  apply safe
-   apply (drule_tac Q="\<lambda>_ m'. underlying_memory m' p = underlying_memory m p"
-          in use_valid)
-     apply ((clarsimp simp: switchFpuOwner_def machine_op_lift_def
-                            machine_rest_lift_def split_def | wp)+)[3]
-  apply (erule (1) use_valid[OF _ switchFpuOwner_irq_masks])
-  done
-
-crunch prepare_thread_delete
-  for invs[wp]: invs
-  (ignore: do_machine_op)
+  and tcb_at[wp]: "tcb_at p"
+  and cte_wp_at[wp, Finalise_AI_assms]: "\<lambda>s. P (cte_wp_at P' p s)"
+  and irq_node[wp, Finalise_AI_assms]: "\<lambda>s. P (interrupt_irq_node s)"
+  and caps_of_state[wp, Finalise_AI_assms]: "\<lambda>s. P (caps_of_state s)"
+  and invs[wp]: invs
+  (wp: crunch_wps simp: crunch_simps)
 
 lemma (* finalise_cap_new_valid_cap *)[wp,Finalise_AI_assms]:
   "\<lbrace>valid_cap cap\<rbrace> finalise_cap cap x \<lbrace>\<lambda>rv. valid_cap (fst rv)\<rbrace>"
@@ -511,37 +488,122 @@ lemma (* suspend_no_cap_to_obj_ref *)[wp,Finalise_AI_assms]:
                  dest!: obj_ref_none_no_asid[rule_format])
   done
 
-lemma suspend_unlive':
-  "\<lbrace>bound_tcb_at ((=) None) t and valid_mdb and valid_objs and tcb_at t \<rbrace>
-      suspend t
-   \<lbrace>\<lambda>rv. obj_at (Not \<circ> live) t\<rbrace>"
-  apply (simp add: suspend_def set_thread_state_def set_object_def get_object_def)
-  supply hoare_vcg_if_split[wp_split del] if_split[split del]
-  apply (wp | simp only: obj_at_exst_update)+
-     apply (simp add: obj_at_def live_def hyp_live_def)
-     apply (rule_tac Q'="\<lambda>_. bound_tcb_at ((=) None) t" in hoare_strengthen_post)
-      supply hoare_vcg_if_split[wp_split]
-      apply wp
-     apply (auto simp: pred_tcb_def2)[1]
-    apply (simp flip: if_split)
-    apply wpsimp+
-  done
+lemma as_user_unlive_hyp[wp]:
+  "\<lbrace>obj_at (Not \<circ> hyp_live) vr\<rbrace> as_user t f \<lbrace>\<lambda>_. obj_at (Not \<circ> hyp_live) vr\<rbrace>"
+  unfolding as_user_def
+  by (wpsimp wp: set_object_wp)
+     (clarsimp simp: obj_at_def hyp_live_def get_tcb_Some_ko_at arch_tcb_context_set_def)
 
-crunch fpu_thread_delete
-  for obj_at[wp]: "\<lambda>s. P' (obj_at P p s)"
-  (wp: whenE_wp simp: crunch_simps)
+lemma as_user_unlive0[wp]:
+  "\<lbrace>obj_at (Not \<circ> live0) vr\<rbrace> as_user t f \<lbrace>\<lambda>_. obj_at (Not \<circ> live0) vr\<rbrace>"
+  unfolding as_user_def
+  apply (wpsimp wp: set_object_wp)
+  by (clarsimp simp: obj_at_def arch_tcb_context_set_def dest!: get_tcb_SomeD)
 
-lemma (* fpu_thread_delete_no_cap_to_obj_ref *)[wp,Finalise_AI_assms]:
+lemma o_def_not:
+  "obj_at (\<lambda>a. \<not> P a) t s =  obj_at (Not o P) t s"
+  by (simp add: obj_at_def)
+
+lemma prepare_thread_delete_no_cap_to_obj_ref[wp]:
   "\<lbrace>no_cap_to_obj_with_diff_ref cap S\<rbrace>
-     fpu_thread_delete thread
+     prepare_thread_delete t
    \<lbrace>\<lambda>rv. no_cap_to_obj_with_diff_ref cap S\<rbrace>"
+  unfolding prepare_thread_delete_def
   by (wpsimp simp: no_cap_to_obj_with_diff_ref_def cte_wp_at_caps_of_state)
 
+crunch fpu_release
+  for unlive[wp]: "obj_at (Not \<circ> live0) ptr"
+  and unlive_hyp[wp]: "obj_at (Not \<circ> hyp_live) ptr"
+  (simp: o_def_not wp: crunch_wps ignore: arch_thread_set)
+
+lemma prepare_thread_delete_unlive_hyp:
+  "\<lbrace>obj_at \<top> ptr\<rbrace> prepare_thread_delete ptr \<lbrace>\<lambda>rv. obj_at (Not \<circ> hyp_live) ptr\<rbrace>"
+  apply (simp add: prepare_thread_delete_def)
+  apply (wpsimp wp: hoare_vcg_imp_lift' arch_thread_get_wp)
+  apply (clarsimp simp: obj_at_def hyp_live_def)
+  done
+
+crunch prepare_thread_delete
+  for unlive0: "obj_at (Not \<circ> live0) t"
+
+\<comment> \<open>arch_tcb_live' is used locally as a predicate that can be passed to obj_at\<close>
+definition arch_tcb_live' :: "kernel_object \<Rightarrow> bool" where
+  "arch_tcb_live' ko \<equiv> case ko of
+     TCB tcb \<Rightarrow> arch_tcb_live (tcb_arch tcb)
+   |  _ \<Rightarrow> False"
+
+lemmas arch_tcb_live'_defs = arch_tcb_live'_def arch_tcb_live_def
+
+lemma as_user_arch_tcb_live'[wp]:
+  "as_user t f \<lbrace>obj_at (Not \<circ> arch_tcb_live') t'\<rbrace>"
+  unfolding as_user_def
+  apply (wpsimp wp: set_object_wp)
+  by (clarsimp simp: obj_at_def arch_tcb_live'_def dest!: get_tcb_SomeD)
+
+lemma arch_thread_set_unlive_arch_tcb[wp]:
+  "\<lbrace>\<lambda>s. vr \<noteq> t \<longrightarrow> obj_at (Not \<circ> arch_tcb_live') vr s\<rbrace>
+   arch_thread_set (tcb_cur_fpu_update \<bottom>) t
+   \<lbrace>\<lambda>_. obj_at (Not \<circ> arch_tcb_live') vr\<rbrace>"
+  apply (wpsimp simp: arch_thread_set_def wp: set_object_wp)
+  apply (clarsimp simp: obj_at_def arch_tcb_live'_defs)
+  done
+
+lemma set_x64_current_fpu_owner_None_unlive_arch_tcb[wp]:
+  "\<lbrace>\<lambda>s. x64_current_fpu_owner (arch_state s) = Some t\<rbrace>
+   set_x64_current_fpu_owner None
+   \<lbrace>\<lambda>_. obj_at (Not \<circ> arch_tcb_live') t\<rbrace>"
+  unfolding set_x64_current_fpu_owner_def
+  by wpsimp
+
+crunch save_fpu_state
+  for unlive_arch_tcb[wp]: "obj_at (Not \<circ> arch_tcb_live') ptr"
+  and x64_current_fpu_owner[wp]: "\<lambda>s. P (x64_current_fpu_owner (arch_state s))"
+  (simp: o_def_not)
+
+lemma switch_local_fpu_owner_None_unlive_arch_tcb[wp]:
+  "\<lbrace>\<lambda>s. x64_current_fpu_owner (arch_state s) = Some t\<rbrace>
+   switch_local_fpu_owner None
+   \<lbrace>\<lambda>_. obj_at (Not \<circ> arch_tcb_live') t\<rbrace>"
+  unfolding switch_local_fpu_owner_def
+  by wpsimp
+
+lemma fpu_release_unlive_arch_tcb[wp]:
+  "\<lbrace>valid_cur_fpu and tcb_at t\<rbrace>
+   fpu_release t
+   \<lbrace>\<lambda>_. obj_at (Not \<circ> arch_tcb_live') t\<rbrace>"
+  unfolding fpu_release_def
+  by (wpsimp simp: valid_cur_fpu_defs arch_tcb_live'_defs is_tcb)
+
+lemma prepare_thread_delete_unlive_arch_tcb:
+  "\<lbrace>valid_cur_fpu and tcb_at ptr\<rbrace> prepare_thread_delete ptr \<lbrace>\<lambda>rv. obj_at (Not \<circ> arch_tcb_live') ptr\<rbrace>"
+  apply (simp add: prepare_thread_delete_def)
+  by wpsimp
+
+lemma prepare_thread_delete_unlive[wp]:
+  "\<lbrace>valid_cur_fpu and tcb_at ptr and obj_at (Not \<circ> live0) ptr\<rbrace>
+   prepare_thread_delete ptr
+   \<lbrace>\<lambda>rv. obj_at (Not \<circ> live) ptr\<rbrace>"
+  apply (rule_tac Q'="\<lambda>rv. obj_at (Not \<circ> live0) ptr and obj_at (Not \<circ> hyp_live) ptr and obj_at (Not \<circ> arch_tcb_live') ptr"
+               in hoare_strengthen_post)
+  apply (wpsimp wp: hoare_vcg_conj_lift prepare_thread_delete_unlive_hyp prepare_thread_delete_unlive0 prepare_thread_delete_unlive_arch_tcb)
+   apply (clarsimp simp: obj_at_def)
+  apply (clarsimp simp: obj_at_def, case_tac ko, simp_all add: is_tcb_def live_def arch_tcb_live'_def)
+  done
+
+crunch set_ioport_mask
+  for valid_cur_fpu[wp]: valid_cur_fpu
+  (wp: valid_cur_fpu_lift_arch)
+
+crunch suspend, unbind_notification
+  for valid_cur_fpu[wp]: valid_cur_fpu
+  (wp: crunch_wps  simp: crunch_simps)
+
 lemma finalise_cap_replaceable [Finalise_AI_assms]:
-  "\<lbrace>\<lambda>s. s \<turnstile> cap \<and> x = is_final_cap' cap s \<and> valid_mdb s
+  "\<lbrace>\<lambda>s. s \<turnstile> cap \<and> x = is_final_cap' cap s \<and> valid_mdb s \<and> valid_cur_fpu s
         \<and> cte_wp_at ((=) cap) sl s \<and> valid_objs s \<and> sym_refs (state_refs_of s)
         \<and> (cap_irqs cap \<noteq> {} \<longrightarrow> if_unsafe_then_cap s \<and> valid_global_refs s)
         \<and> (is_arch_cap cap \<longrightarrow> pspace_aligned s \<and>
+                               pspace_distinct s \<and>
                                valid_vspace_objs s \<and>
                                valid_arch_state s \<and>
                                valid_arch_caps s)\<rbrace>
@@ -549,46 +611,43 @@ lemma finalise_cap_replaceable [Finalise_AI_assms]:
    \<lbrace>\<lambda>rv s. replaceable s sl (fst rv) cap\<rbrace>"
   apply (cases "is_arch_cap cap")
    apply (clarsimp simp: is_cap_simps)
-   apply wp
+   apply (wp arch_finalise_cap_replaceable)
    apply (clarsimp simp: replaceable_def reachable_pg_cap_def
-            o_def cap_range_def valid_arch_state_def
-            ran_tcb_cap_cases is_cap_simps
-            gen_obj_refs_subset vs_cap_ref_def
-            all_bool_eq)
-  apply ((cases cap;
-      simp add: replaceable_def reachable_pg_cap_def
-                       split del: if_split;
-      rule hoare_pre),
-
-    (wp suspend_unlive'[unfolded o_def]
-        suspend_final_cap[where sl=sl]
-        unbind_maybe_notification_not_bound
-        get_simple_ko_ko_at hoare_vcg_conj_lift
-        unbind_notification_valid_objs
-      | clarsimp simp: o_def dom_tcb_cap_cases_lt_ARCH
-                        ran_tcb_cap_cases is_cap_simps
-                        cap_range_def prepare_thread_delete_def
-                        can_fast_finalise_def
-                        gen_obj_refs_subset
-                        vs_cap_ref_def unat_of_bl_length
-                        valid_ipc_buffer_cap_def
-                 dest!: tcb_cap_valid_NullCapD
-                 split: Structures_A.thread_state.split_asm
-      | simp cong: conj_cong
-      | simp cong: rev_conj_cong add: no_cap_to_obj_with_diff_ref_Null
-      | (strengthen tcb_cap_valid_imp_NullCap tcb_cap_valid_imp', wp)
-      | rule conjI
-      | erule cte_wp_at_weakenE tcb_cap_valid_imp'[rule_format, rotated -1]
-      | erule(1) no_cap_to_obj_with_diff_ref_finalI_ARCH
-      | (wp (once) hoare_drop_imps,
-          wp (once) cancel_all_ipc_unlive[unfolded o_def]
-              cancel_all_signals_unlive[unfolded o_def])
-      | ((wp (once) hoare_drop_imps)?,
-         (wp (once) hoare_drop_imps)?,
-         wp (once) deleting_irq_handler_empty)
-      | wpc
-      | simp add: valid_cap_simps is_nondevice_page_cap_simps)+)
-  done
+                         o_def cap_range_def valid_arch_state_def
+                         ran_tcb_cap_cases is_cap_simps
+                         gen_obj_refs_subset vs_cap_ref_def
+                         all_bool_eq)
+  by (cases cap;
+        simp add: replaceable_def reachable_pg_cap_def is_arch_cap_def
+             split del: if_split;
+        ((wp suspend_unlive[unfolded o_def]
+             suspend_final_cap[where sl=sl]
+             prepare_thread_delete_unlive[unfolded o_def]
+             unbind_maybe_notification_not_bound
+             get_simple_ko_ko_at unbind_notification_valid_objs
+          | clarsimp simp: o_def dom_tcb_cap_cases_lt_ARCH
+                           ran_tcb_cap_cases is_cap_simps
+                           cap_range_def unat_of_bl_length
+                           can_fast_finalise_def
+                           gen_obj_refs_subset
+                           vs_cap_ref_def
+                           valid_ipc_buffer_cap_def
+                     dest!: tcb_cap_valid_NullCapD
+                     split: Structures_A.thread_state.split_asm
+          | simp cong: conj_cong
+          | simp cong: rev_conj_cong add: no_cap_to_obj_with_diff_ref_Null
+          | (strengthen tcb_cap_valid_imp_NullCap tcb_cap_valid_imp', wp)
+          | rule conjI
+          | erule cte_wp_at_weakenE tcb_cap_valid_imp'[rule_format, rotated -1]
+          | erule(1) no_cap_to_obj_with_diff_ref_finalI_ARCH
+          | (wp (once) hoare_drop_imps,
+                     wp (once) cancel_all_ipc_unlive[unfolded o_def]
+                    cancel_all_signals_unlive[unfolded o_def])
+          | ((wp (once) hoare_drop_imps)?,
+             (wp (once) hoare_drop_imps)?,
+             wp (once) deleting_irq_handler_empty)
+          | wpc
+          | simp add: valid_cap_simps)+))
 
 lemma (* deleting_irq_handler_cte_preserved *)[Finalise_AI_assms]:
   assumes x: "\<And>cap. P cap \<Longrightarrow> \<not> can_fast_finalise cap"
@@ -626,7 +685,7 @@ context Arch begin arch_global_naming
 
 lemma fast_finalise_replaceable[wp]:
   "\<lbrace>\<lambda>s. s \<turnstile> cap \<and> x = is_final_cap' cap s
-     \<and> cte_wp_at ((=) cap) sl s \<and> valid_asid_table (x64_asid_table (arch_state s)) s
+     \<and> cte_wp_at ((=) cap) sl s \<and> valid_asid_table (x64_asid_table (arch_state s)) s \<and> valid_cur_fpu s
      \<and> valid_mdb s \<and> valid_objs s \<and> sym_refs (state_refs_of s)\<rbrace>
      fast_finalise cap x
    \<lbrace>\<lambda>rv s. cte_wp_at (replaceable s sl cap.NullCap) sl s\<rbrace>"
@@ -667,7 +726,8 @@ lemma flush_table_irq_node: "\<lbrace>\<lambda>s. P (interrupt_irq_node s)\<rbra
   apply (wp mapM_x_wp' | wpc | simp | rule hoare_pre)+
   done
 
-lemma flush_table_pred_tcb_at: "\<lbrace>\<lambda>s. pred_tcb_at proj P t s\<rbrace> flush_table a b c d \<lbrace>\<lambda>_ s. pred_tcb_at proj P t s\<rbrace>"
+lemma flush_table_pred_tcb_at:
+  "flush_table a b c d \<lbrace>\<lambda>s. Q (pred_tcb_at proj P t s)\<rbrace>"
   apply (simp add: flush_table_def)
   apply (wp mapM_x_wp' | wpc | simp | rule hoare_pre)+
   done
@@ -677,7 +737,7 @@ crunch arch_finalise_cap
   (wp: crunch_wps simp: crunch_simps)
 
 crunch arch_finalise_cap
-  for pred_tcb_at[wp]: "pred_tcb_at proj P t"
+  for pred_tcb_at[wp]: "\<lambda>s. Q (pred_tcb_at proj P t s)"
   (simp: crunch_simps set_arch_obj_simps wp: crunch_wps set_aobject_pred_tcb_at
    ignore: set_object)
 
@@ -1406,6 +1466,10 @@ lemma valid_global_objs_table [simp]:
 lemma valid_kernel_mappings [iff]:
   "valid_kernel_mappings (s\<lparr>arch_state := arch_state s\<lparr>x64_asid_table := x64_asid_table'\<rparr>\<rparr>) = valid_kernel_mappings s"
   by (simp add: valid_kernel_mappings_def second_level_tables_def)
+
+lemma valid_cur_fpu_table[simp]:
+  "valid_cur_fpu (s\<lparr>arch_state := arch_state s\<lparr>x64_asid_table := x64_asid_table'\<rparr>\<rparr>) = valid_cur_fpu s"
+  by (clarsimp simp: valid_cur_fpu_defs)
 
 lemma vs_asid_refs_updateD:
   "(ref', p') \<in> vs_asid_refs (table (x \<mapsto> p))

--- a/proof/invariant-abstract/X64/ArchInterrupt_AI.thy
+++ b/proof/invariant-abstract/X64/ArchInterrupt_AI.thy
@@ -269,13 +269,8 @@ lemma updateIRQState_invs[wp]:
                         vs_lookup_pages1_def valid_table_caps_def empty_table_def second_level_tables_def
                         valid_global_objs_def valid_kernel_mappings_def valid_asid_map_def
                         valid_x64_irq_state_def valid_ioports_def all_ioports_issued_def
-                        issued_ioports_def word_not_le[symmetric])
+                        issued_ioports_def word_not_le[symmetric] valid_cur_fpu_def is_tcb_cur_fpu_def)
   done
-
-lemma no_irq_ioapicMapPinToVector: "no_irq (ioapicMapPinToVector a b c d e)"
-  by (wp no_irq | clarsimp simp: no_irq_def ioapicMapPinToVector_def)+
-
-lemmas ioapicMapPinToVector_irq_masks = no_irq[OF no_irq_ioapicMapPinToVector]
 
 lemma dmo_ioapicMapPinToVector[wp]: "\<lbrace>invs\<rbrace> do_machine_op (ioapicMapPinToVector irq b c d e) \<lbrace>\<lambda>y. invs\<rbrace>"
   apply (wp dmo_invs)

--- a/proof/invariant-abstract/X64/ArchIpc_AI.thy
+++ b/proof/invariant-abstract/X64/ArchIpc_AI.thy
@@ -224,22 +224,17 @@ lemma copy_mrs_in_user_frame[wp, Ipc_AI_2_assms]:
   "\<lbrace>in_user_frame p\<rbrace> copy_mrs t buf t' buf' n \<lbrace>\<lambda>rv. in_user_frame p\<rbrace>"
   by (simp add: in_user_frame_def) (wp hoare_vcg_ex_lift)
 
-lemma as_user_getRestart_invs[wp]: "\<lbrace>P\<rbrace> as_user t getRestartPC \<lbrace>\<lambda>_. P\<rbrace>"
-  apply (simp add: getRestartPC_def ; rule user_getreg_inv)
-  done
+lemma as_user_getRestart_inv[wp]:
+  "as_user t getRestartPC \<lbrace>P\<rbrace>"
+  by (simp add: getRestartPC_def, rule user_getreg_inv)
 
-lemma make_arch_fault_msg_invs[wp]: "\<lbrace>P\<rbrace> make_arch_fault_msg f t \<lbrace>\<lambda>_. P\<rbrace>"
-  apply (cases f)
-  apply simp
-  apply wp
-  done
+lemma make_arch_fault_msg_inv[wp, Ipc_AI_2_assms]:
+  "make_arch_fault_msg ft t \<lbrace>P\<rbrace>"
+  by (cases ft; wpsimp)
 
-lemma make_fault_message_inv[wp, Ipc_AI_2_assms]:
-  "\<lbrace>P\<rbrace> make_fault_msg ft t \<lbrace>\<lambda>rv. P\<rbrace>"
-  apply (cases ft, simp_all split del: if_split)
-     apply (wp as_user_inv getRestartPC_inv mapM_wp'
-              | simp add: getRegister_def)+
-  done
+lemma make_fault_msg_inv[wp, Ipc_AI_2_assms]:
+  "make_fault_msg ft t \<lbrace>P\<rbrace>"
+  by (cases ft; wpsimp wp: as_user_inv getRestartPC_inv mapM_wp' split_del: if_split)
 
 lemma do_fault_transfer_invs[wp, Ipc_AI_2_assms]:
   "\<lbrace>invs and tcb_at receiver\<rbrace>
@@ -418,7 +413,6 @@ lemma transfer_caps_loop_valid_vspace_objs[wp, Ipc_AI_2_assms]:
         | assumption | simp split del: if_split)+
   done
 
-declare make_arch_fault_msg_invs[Ipc_AI_2_assms]
 crunch handle_arch_fault_reply, arch_get_sanitise_register_info
   for typ_at[Ipc_AI_2_assms]: "P (typ_at T p s)"
 

--- a/proof/invariant-abstract/X64/ArchKHeap_AI.thy
+++ b/proof/invariant-abstract/X64/ArchKHeap_AI.thy
@@ -568,6 +568,34 @@ lemma valid_arch_state_lift_aobj_at:
 end
 end
 
+\<comment> \<open>FIXME arch-split: if tcb_at and related terms were moved to InvariantsPre_AI then this lemma
+                     could go in ArchInvariants_AI.\<close>
+lemma current_fpu_owner_Some_tcb_at:
+  "\<lbrakk>x64_current_fpu_owner (arch_state s) = Some p; valid_cur_fpu s\<rbrakk> \<Longrightarrow> tcb_at p s"
+  by (auto simp: valid_cur_fpu_defs is_tcb)
+
+\<comment> \<open>FIXME arch-split: is_tcb_cur_fpu can't be defined like this because arch_tcb_at isn't defined
+                     until Invariants_AI.\<close>
+lemma is_tcb_cur_fpu_def2:
+  "is_tcb_cur_fpu \<equiv> arch_tcb_at itcb_cur_fpu"
+  by (clarsimp simp: is_tcb_cur_fpu_def pred_tcb_at_def)
+
+\<comment> \<open>Intended for use inside Arch, as opposed to the interface lemma valid_cur_fpu_lift\<close>
+lemma valid_cur_fpu_lift_arch:
+  assumes arch_tcb_at[wp]: "\<And>P p. f \<lbrace>\<lambda>s. P (arch_tcb_at itcb_cur_fpu p s)\<rbrace>"
+  assumes fpu_owner[wp]: "\<And>P. f \<lbrace>\<lambda>s. P (x64_current_fpu_owner (arch_state s))\<rbrace>"
+  shows "f \<lbrace>valid_cur_fpu\<rbrace>"
+  unfolding valid_cur_fpu_def
+  apply (rule hoare_lift_Pf[where f="\<lambda>s. x64_current_fpu_owner (arch_state s)", rotated], rule fpu_owner)
+  by (wpsimp wp: hoare_vcg_all_lift simp: is_tcb_cur_fpu_def2)
+
+\<comment> \<open>Interface lemma\<close>
+lemma valid_cur_fpu_lift:
+  assumes arch_tcb_at[wp]: "\<And>P P' p. f \<lbrace>\<lambda>s. P (arch_tcb_at P' p s)\<rbrace>"
+  assumes arch_state[wp]: "\<And>P. f \<lbrace>\<lambda>s. P (arch_state s)\<rbrace>"
+  shows "f \<lbrace>valid_cur_fpu\<rbrace>"
+  by (wpsimp wp: valid_cur_fpu_lift_arch)
+
 lemma equal_kernel_mappings_lift:
   assumes aobj_at:
     "\<And>P P' pd. vspace_obj_pred P' \<Longrightarrow> \<lbrace>\<lambda>s. P (obj_at P' pd s)\<rbrace> f \<lbrace>\<lambda>r s. P (obj_at P' pd s)\<rbrace>"
@@ -923,7 +951,7 @@ lemma default_arch_object_not_live[simp]: "\<not> live (ArchObj (default_arch_ob
                split: aobject_type.splits)
 
 lemma default_tcb_not_live[simp]: "\<not> live (TCB (default_tcb d))"
-  by (clarsimp simp: default_tcb_def default_arch_tcb_def live_def hyp_live_def)
+  by (clarsimp simp: default_tcb_def default_arch_tcb_def live_def hyp_live_def arch_tcb_live_def)
 
 lemma valid_arch_tcb_same_type:
   "\<lbrakk> valid_arch_tcb t s; valid_obj p k s; kheap s p = Some ko; a_type k = a_type ko \<rbrakk>

--- a/proof/invariant-abstract/X64/ArchKernelInit_AI.thy
+++ b/proof/invariant-abstract/X64/ArchKernelInit_AI.thy
@@ -219,6 +219,10 @@ lemma cap_refs_respects_device_region_init[simp]:
    apply (clarsimp simp: cte_wp_at_caps_of_state cap_range_respects_device_region_def)
    done
 
+lemma tcb_cur_fpu_init_arch_tcb_False[simp]:
+  "tcb_cur_fpu init_arch_tcb = False"
+  by (simp add: init_arch_tcb_def)
+
 lemma kernel_mapping_slot: "0x1FF \<in> kernel_mapping_slots"
   by (auto simp: kernel_mapping_slots_def pptr_base_def pptrBase_def bit_simps)
 
@@ -264,14 +268,13 @@ lemma invs_A:
     apply (clarsimp simp: valid_cs_def word_bits_def cte_level_bits_def
                           init_irq_ptrs_all_ineqs valid_tcb_def
                    split: if_split_asm)
-     apply (clarsimp simp: vmsz_aligned_def is_aligned_addrFromPPtr_n table_size is_aligned_shift
-                           pageBits_def ptTranslationBits_def)
+    apply (clarsimp simp: vmsz_aligned_def is_aligned_addrFromPPtr_n table_size is_aligned_shift
+                          pageBits_def ptTranslationBits_def)
    apply (simp add: pspace_aligned_init_A pspace_distinct_init_A)
-   apply (rule conjI)
-    apply (clarsimp simp: if_live_then_nonz_cap_def obj_at_def state_defs live_def hyp_live_def)
-   apply (rule conjI)
-    apply (clarsimp simp: zombies_final_def cte_wp_at_cases state_defs
-                          tcb_cap_cases_def is_zombie_def)
+   apply (clarsimp simp: if_live_then_nonz_cap_def obj_at_def state_defs live_def hyp_live_def
+                         arch_live_def arch_tcb_live_def)
+   apply (clarsimp simp: zombies_final_def cte_wp_at_cases state_defs ex_nonz_cap_to_def
+                         tcb_cap_cases_def is_zombie_def)
    apply (clarsimp simp: sym_refs_def state_refs_of_def state_defs state_hyp_refs_of_def)
   apply (rule conjI)
    apply (clarsimp simp: valid_mdb_def init_cdt_def no_mloop_def
@@ -300,7 +303,7 @@ lemma invs_A:
                          caps_of_state_init_A_st_Null is_master_reply_cap_to_def
                          valid_reply_masters_def valid_global_refs_def
                          valid_refs_def[unfolded cte_wp_at_caps_of_state])
-  apply (clarsimp, (thin_tac "_")+) (* use new proven assumptions, then drop them *)
+   apply (clarsimp, (thin_tac "_")+) (* use new proven assumptions, then drop them *)
    apply (rule conjI)
     apply (clarsimp simp: valid_arch_state_def)
     apply (rule conjI)
@@ -314,6 +317,7 @@ lemma invs_A:
     apply (clarsimp simp: valid_ioports_def caps_of_state_init_A_st_Null all_ioports_issued_def ran_def
                           issued_ioports_def ioports_no_overlap_def
                     cong: rev_conj_cong)
+  apply (rule conjI, clarsimp simp: valid_cur_fpu_def is_tcb_cur_fpu_def obj_at_def state_defs)
   apply (rule conjI)
    apply (clarsimp simp: valid_irq_node_def obj_at_def state_defs
                          is_cap_table_def wf_empty_bits

--- a/proof/invariant-abstract/X64/ArchSchedule_AI.thy
+++ b/proof/invariant-abstract/X64/ArchSchedule_AI.thy
@@ -14,7 +14,7 @@ named_theorems Schedule_AI_assms
 
 lemma dmo_mapM_storeWord_0_invs[wp,Schedule_AI_assms]:
   "valid invs (do_machine_op (mapM (\<lambda>p. storeWord p 0) S)) (\<lambda>_. invs)"
-  apply (simp add: dom_mapM ef_storeWord)
+  apply (simp add: dom_mapM)
   apply (rule mapM_UNIV_wp)
   apply (simp add: do_machine_op_def split_def)
   apply wp
@@ -28,17 +28,97 @@ lemma dmo_mapM_storeWord_0_invs[wp,Schedule_AI_assms]:
   apply (simp add: upto0_7_def word_bits_def split: if_splits)
   done
 
-lemma arch_stt_invs [wp,Schedule_AI_assms]:
-  "\<lbrace>invs\<rbrace> arch_switch_to_thread t' \<lbrace>\<lambda>_. invs\<rbrace>"
-  apply (simp add: arch_switch_to_thread_def)
-  apply wp
+lemma set_x64_current_fpu_owner_valid_cur_fpu[wp]:
+  "set_x64_current_fpu_owner new_owner \<lbrace>valid_cur_fpu\<rbrace>"
+  unfolding set_x64_current_fpu_owner_def
+  apply (wp arch_thread_set_wp)
+  by (auto simp: valid_cur_fpu_defs valid_cur_fpu_is_tcb_cur_fpu_unique'[simplified valid_cur_fpu_defs])
+
+lemma set_x64_current_fpu_owner_valid_pspace[wp]:
+  "\<lbrace>valid_pspace and none_top ex_nonz_cap_to t\<rbrace>
+   set_x64_current_fpu_owner t
+   \<lbrace>\<lambda>_. valid_pspace\<rbrace>"
+  unfolding set_x64_current_fpu_owner_def valid_pspace_def
+  apply (wpsimp wp: hoare_vcg_all_lift hoare_vcg_imp_lift' hoare_disjI1)
+  by fastforce
+
+crunch set_x64_current_fpu_owner
+  for valid_mdb[wp]: valid_mdb
+  and valid_ioc[wp]: valid_ioc
+  and valid_idle[wp]: valid_idle
+  and only_idle[wp]: only_idle
+  and if_unsafe_then_cap[wp]: if_unsafe_then_cap
+  and valid_reply_caps[wp]: valid_reply_caps
+  and valid_reply_masters[wp]: valid_reply_masters
+  and valid_global_refs[wp]: valid_global_refs
+  and valid_arch_state[wp]: valid_arch_state
+  and valid_irq_node[wp]: valid_irq_node
+  and valid_irq_handlers[wp]: valid_irq_handlers
+  and valid_machine_state[wp]: valid_machine_state
+  and valid_irq_states[wp]: valid_irq_states
+  and valid_vspace_objs[wp]: valid_vspace_objs
+  and valid_arch_caps[wp]: valid_arch_caps
+  and valid_global_objs[wp]: valid_global_objs
+  and valid_kernel_mappings[wp]: valid_kernel_mappings
+  and equal_kernel_mappings[wp]: equal_kernel_mappings
+  and valid_asid_map[wp]: valid_asid_map
+  and valid_global_vspace_mappings[wp]: valid_global_vspace_mappings
+  and pspace_in_kernel_window[wp]: pspace_in_kernel_window
+  and cap_refs_in_kernel_window[wp]: cap_refs_in_kernel_window
+  and pspace_respects_device_region[wp]: pspace_respects_device_region
+  and cap_refs_respects_device_region[wp]: cap_refs_respects_device_region
+  and cur_tcb[wp]: cur_tcb
+  (wp: crunch_wps)
+
+lemma set_x64_current_fpu_owner_invs[wp]:
+  "\<lbrace>invs and none_top tcb_at t and none_top ex_nonz_cap_to t\<rbrace>
+   set_x64_current_fpu_owner t
+   \<lbrace>\<lambda>_. invs\<rbrace>"
+  by (wpsimp simp: invs_def valid_state_def)
+
+crunch save_fpu_state, load_fpu_state
+  for invs[wp]: invs
+  and typ_at[wp]: "\<lambda>s. P (typ_at T p s)"
+  and ex_nonz_cap_to[wp]: "ex_nonz_cap_to t"
+  (wp: dmo_invs_lift)
+
+lemmas save_fpu_state_typ_ats[wp] = abs_typ_at_lifts[OF save_fpu_state_typ_at]
+lemmas load_fpu_state_typ_ats[wp] = abs_typ_at_lifts[OF load_fpu_state_typ_at]
+
+lemma switch_local_fpu_owner_invs:
+  "\<lbrace>invs and none_top tcb_at t and none_top ex_nonz_cap_to t\<rbrace> switch_local_fpu_owner t \<lbrace>\<lambda>_. invs\<rbrace>"
+  unfolding switch_local_fpu_owner_def
+  apply (wpsimp wp: dmo_invs_lift hoare_vcg_imp_lift' hoare_disjI1
+         | wpsimp wp: hoare_vcg_all_lift)+
+  by fastforce
+
+crunch lazy_fpu_restore
+  for typ_at[wp]: "\<lambda>s. P (typ_at T p s)"
+  and scheduler_action[wp]: "\<lambda>s. P (scheduler_action s)"
+  and st_tcb_at[wp]: "\<lambda>s. P (st_tcb_at Q t s)"
+  (wp: dmo_invs_lift crunch_wps)
+
+lemma lazy_fpu_restore_invs[wp]:
+  "\<lbrace>invs and none_top ex_nonz_cap_to (Some t)\<rbrace>
+   lazy_fpu_restore t
+   \<lbrace>\<lambda>_. invs\<rbrace>"
+  unfolding lazy_fpu_restore_def
+  apply (wpsimp wp: dmo_invs_lift switch_local_fpu_owner_invs thread_get_wp')
+  apply (clarsimp simp: obj_at_def is_tcb)
   done
 
+crunch set_vm_root
+  for ex_nonz_cap_to[wp]: "ex_nonz_cap_to t"
+  (wp: crunch_wps simp: crunch_simps)
+
+lemma arch_stt_invs [wp,Schedule_AI_assms]:
+  "\<lbrace>invs and ex_nonz_cap_to t\<rbrace> arch_switch_to_thread t \<lbrace>\<lambda>_. invs\<rbrace>"
+  unfolding arch_switch_to_thread_def
+  by wpsimp
+
 lemma arch_stt_tcb [wp,Schedule_AI_assms]:
-  "\<lbrace>tcb_at t'\<rbrace> arch_switch_to_thread t' \<lbrace>\<lambda>_. tcb_at t'\<rbrace>"
-  apply (simp add: arch_switch_to_thread_def)
-  apply (wp)
-  done
+  "arch_switch_to_thread t' \<lbrace>tcb_at t'\<rbrace>"
+  by (wpsimp simp: arch_switch_to_thread_def wp: tcb_at_typ_at)
 
 lemma arch_stt_st_tcb_at[Schedule_AI_assms]:
   "arch_switch_to_thread t \<lbrace>st_tcb_at Q t\<rbrace>"
@@ -53,10 +133,6 @@ lemma arch_stit_tcb_at[wp]:
   apply (simp add: arch_switch_to_idle_thread_def )
   apply wp
   done
-
-crunch set_vm_root
-  for st_tcb_at[wp]: "st_tcb_at P t"
-  (wp: crunch_wps simp: crunch_simps)
 
 lemma idle_strg:
   "thread = idle_thread s \<and> invs s \<Longrightarrow> invs (s\<lparr>cur_thread := thread\<rparr>)"
@@ -93,6 +169,14 @@ lemma arch_stt_scheduler_action [wp, Schedule_AI_assms]:
   "\<lbrace>\<lambda>s. P (scheduler_action s)\<rbrace> arch_switch_to_thread t' \<lbrace>\<lambda>_ s. P (scheduler_action s)\<rbrace>"
   by (wpsimp simp: arch_switch_to_thread_def)
 
+crunch arch_prepare_next_domain
+  for ct[wp, Schedule_AI_assms]: "\<lambda>s. P (cur_thread s)"
+  and activatable[wp, Schedule_AI_assms]: "ct_in_state activatable"
+  and st_tcb_at[wp, Schedule_AI_assms]: "\<lambda>s. P (st_tcb_at Q t s)"
+  and valid_idle[wp, Schedule_AI_assms]: valid_idle
+  and invs[wp, Schedule_AI_assms]: invs
+  (wp: crunch_wps ct_in_state_thread_state_lift)
+
 lemma arch_stit_scheduler_action [wp, Schedule_AI_assms]:
   "\<lbrace>\<lambda>s. P (scheduler_action s)\<rbrace> arch_switch_to_idle_thread \<lbrace>\<lambda>_ s. P (scheduler_action s)\<rbrace>"
   by (wpsimp simp: arch_switch_to_idle_thread_def)
@@ -103,7 +187,7 @@ interpretation Schedule_AI?: Schedule_AI
   proof goal_cases
   interpret Arch .
   case 1 show ?case
-  by (intro_locales; (unfold_locales; fact Schedule_AI_assms)?)
+  by (intro_locales; unfold_locales; (fact Schedule_AI_assms)?)
   qed
 
 end

--- a/proof/invariant-abstract/X64/ArchSyscall_AI.thy
+++ b/proof/invariant-abstract/X64/ArchSyscall_AI.thy
@@ -18,6 +18,9 @@ context Arch begin arch_global_naming
 named_theorems Syscall_AI_assms
 
 declare arch_get_sanitise_register_info_invs[Syscall_AI_assms]
+        arch_get_sanitise_register_info_ex_nonz_cap_to[Syscall_AI_assms]
+        make_fault_msg_inv[Syscall_AI_assms]
+
 crunch handle_arch_fault_reply, arch_get_sanitise_register_info
   for pred_tcb_at[wp,Syscall_AI_assms]: "pred_tcb_at proj P t"
 crunch handle_arch_fault_reply
@@ -28,7 +31,7 @@ crunch handle_arch_fault_reply, arch_get_sanitise_register_info
   for it[wp,Syscall_AI_assms]: "\<lambda>s. P (idle_thread s)"
 crunch handle_arch_fault_reply, arch_get_sanitise_register_info
   for caps[wp,Syscall_AI_assms]: "\<lambda>s. P (caps_of_state s)"
-crunch handle_arch_fault_reply, make_fault_msg, arch_get_sanitise_register_info
+crunch handle_arch_fault_reply, arch_get_sanitise_register_info
   for cur_thread[wp,Syscall_AI_assms]: "\<lambda>s. P (cur_thread s)"
 crunch handle_arch_fault_reply, arch_get_sanitise_register_info
   for valid_objs[wp,Syscall_AI_assms]: "valid_objs"
@@ -103,23 +106,6 @@ lemma hvmf_ex_cap[wp, Syscall_AI_assms]:
   apply (cases b, simp_all)
    apply (wp | simp)+
   done
-
-
-crunch handle_arch_fault_reply
-  for pred_tcb_at[wp,Syscall_AI_assms]: "pred_tcb_at proj P t"
-crunch handle_arch_fault_reply
-  for invs[wp,Syscall_AI_assms]: "invs"
-declare arch_get_sanitise_register_info_ex_nonz_cap_to[Syscall_AI_assms]
-crunch handle_arch_fault_reply
-  for it[wp,Syscall_AI_assms]: "\<lambda>s. P (idle_thread s)"
-crunch handle_arch_fault_reply
-  for caps[wp,Syscall_AI_assms]: "\<lambda>s. P (caps_of_state s)"
-declare make_fault_message_inv[Syscall_AI_assms]
-crunch handle_arch_fault_reply
-  for valid_objs[wp,Syscall_AI_assms]: "valid_objs"
-crunch handle_arch_fault_reply
-  for cte_wp_at[wp,Syscall_AI_assms]: "\<lambda>s. P (cte_wp_at P' p s)"
-
 
 lemma hh_invs[wp, Syscall_AI_assms]:
   "\<lbrace>invs and ct_active and st_tcb_at active thread and ex_nonz_cap_to_thread\<rbrace>

--- a/proof/invariant-abstract/X64/ArchTcb_AI.thy
+++ b/proof/invariant-abstract/X64/ArchTcb_AI.thy
@@ -58,6 +58,10 @@ where
           \<and> (is_pml4_cap cap \<longrightarrow> cap_asid cap \<noteq> None)
           \<and> \<not> is_ioport_control_cap cap)"
 
+crunch arch_post_set_flags, arch_prepare_set_domain
+  for typ_at[wp, Tcb_AI_assms]: "\<lambda>s. P (typ_at T p s)"
+  and invs[wp, Tcb_AI_assms]: "invs"
+
 
 definition (* arch specific *)
   "vspace_asid cap \<equiv> case cap of
@@ -163,6 +167,16 @@ lemma finalise_cap_not_cte_wp_at[Tcb_AI_assms]:
          | simp add: deleting_irq_handler_def get_irq_slot_def x ball_ran_eq)+
     done
 
+crunch arch_post_set_flags, arch_prepare_set_domain
+  for typ_at[wp, Tcb_AI_assms]: "\<lambda>s. P (typ_at T p s)"
+  and invs[wp, Tcb_AI_assms]: "invs"
+
+lemmas arch_prepare_set_domain_typ_ats[wp] = abs_typ_at_lifts[OF arch_prepare_set_domain_typ_at]
+
+crunch arch_prepare_set_domain
+  for pspace_aligned[wp]: pspace_aligned
+  and pspace_distinct[wp]: pspace_distinct
+  (wp: crunch_wps)
 
 lemma table_cap_ref_max_free_index_upd[simp,Tcb_AI_assms]:
   "table_cap_ref (max_free_index_update cap) = table_cap_ref cap"
@@ -363,7 +377,6 @@ lemma update_cap_valid[Tcb_AI_assms]:
   apply (case_tac arch_cap, simp_all add: acap_rights_update_def Let_def
                                      split: option.splits prod.splits)
   done
-
 
 crunch switch_to_thread
   for pred_tcb_at: "pred_tcb_at proj P t"

--- a/proof/invariant-abstract/X64/ArchVSpaceEntries_AI.thy
+++ b/proof/invariant-abstract/X64/ArchVSpaceEntries_AI.thy
@@ -715,7 +715,7 @@ lemma handle_invocation_valid_vspace_objs'[wp]:
 crunch activate_thread,switch_to_thread, handle_hypervisor_fault,
        switch_to_idle_thread, handle_call, handle_recv, handle_reply,
        handle_send, handle_yield, handle_interrupt,
-       schedule_choose_new_thread
+       schedule_choose_new_thread, arch_prepare_next_domain
   for valid_vspace_objs'[wp]: "valid_vspace_objs'"
   (simp: crunch_simps wp: crunch_wps OR_choice_weak_wp select_ext_weak_wp
       ignore: without_preemption getActiveIRQ resetTimer ackInterrupt

--- a/proof/invariant-abstract/X64/ArchVSpace_AI.thy
+++ b/proof/invariant-abstract/X64/ArchVSpace_AI.thy
@@ -14,21 +14,6 @@ begin
 
 context Arch begin arch_global_naming
 
-(* FIXME: should go in Machine_AI, but needs dmo_invs from KHeap_AI. *)
-lemmas machine_op_lift_irq_masks = no_irq[OF no_irq_machine_op_lift]
-
-lemma machine_op_lift_underlying_memory:
-  "\<lbrace>\<lambda>m'. underlying_memory m' p = um\<rbrace> machine_op_lift m \<lbrace>\<lambda>_ m'. underlying_memory m' p = um\<rbrace>"
-  by (wpsimp simp: machine_op_lift_def machine_rest_lift_def split_def)
-
-lemma do_machine_op_lift_invs:
-  "\<lbrace>invs\<rbrace> do_machine_op (machine_op_lift m) \<lbrace>\<lambda>_. invs\<rbrace>"
-  apply (wp dmo_invs)
-  apply safe
-   apply (drule use_valid[OF _ machine_op_lift_underlying_memory]; fastforce)
-  apply (erule (1) use_valid[OF _ machine_op_lift_irq_masks])
-  done
-
 abbreviation "canonicalise x \<equiv> (scast ((ucast x) :: 48 word)) :: 64 word"
 
 lemma pptr_base_shift_cast_le:
@@ -179,13 +164,6 @@ lemma find_vspace_for_asid_vspace_at_asid [wp]:
 
 crunch do_machine_op
   for valid_vs_lookup[wp]: "valid_vs_lookup"
-
-
-lemma invalidateTLB_underlying_memory:
-  "\<lbrace>\<lambda>m'. underlying_memory m' p = um\<rbrace>
-   invalidateTLB
-   \<lbrace>\<lambda>_ m'. underlying_memory m' p = um\<rbrace>"
-  by (simp add: invalidateTLB_def machine_op_lift_underlying_memory)
 
 
 lemma vspace_at_asid_arch_up':
@@ -351,27 +329,11 @@ crunch hw_asid_invalidate
   for valid_vs_lookup[wp]: "valid_vs_lookup"
 
 crunch hw_asid_invalidate
-  for arm_asid_table_inv[wp]: "\<lambda>s. P (x64_asid_table (arch_state s))"
-
-lemma invalidateASID_underlying_memory:
-  "\<lbrace>\<lambda>m'. underlying_memory m' p = um\<rbrace>
-   invalidateASID a b
-   \<lbrace>\<lambda>_ m'. underlying_memory m' p = um\<rbrace>"
-  by (simp add: invalidateASID_def invalidateASID_def machine_op_lift_underlying_memory)
-
-(* FIXME x64: move to Machine_AI *)
-lemma no_irq_invalidateASID: "no_irq (invalidateASID a b)"
-  by (clarsimp simp: invalidateASID_def invalidateASID_def)
-
-lemmas invalidateASID_irq_masks = no_irq[OF no_irq_invalidateASID]
-
-crunch invalidateASID
-  for device_state_inv[wp]: "\<lambda>ms. P (device_state ms)"
-  (ignore: ignore_failure)
+  for x64_asid_table_inv[wp]: "\<lambda>s. P (x64_asid_table (arch_state s))"
 
 lemma dmo_invalidateASID_invs[wp]:
   "\<lbrace>invs\<rbrace> do_machine_op (invalidateASID a b) \<lbrace>\<lambda>_. invs\<rbrace>"
-  by (simp add: invalidateASID_def do_machine_op_lift_invs)
+  by (simp add: invalidateASID_def dmo_machine_op_lift_invs)
 
 lemma hw_asid_invalidate_invs[wp]: "\<lbrace>invs\<rbrace> hw_asid_invalidate asid vspace \<lbrace>\<lambda>_. invs\<rbrace>"
   by (wpsimp simp: hw_asid_invalidate_def)
@@ -852,17 +814,14 @@ definition
   and K (0 < asid \<and> asid_wf asid)
   and ([VSRef (ucast (asid_high_bits_of asid)) None] \<rhd> p)"
 
-crunch ackInterrupt, writeCR3
-  for device_state_inv[wp]: "\<lambda>ms. P (device_state ms)"
-
 
 lemma dmo_ackInterrupt[wp]: "\<lbrace>invs\<rbrace> do_machine_op (ackInterrupt irq) \<lbrace>\<lambda>y. invs\<rbrace>"
-  by (simp add: ackInterrupt_def do_machine_op_lift_invs)
+  by (simp add: ackInterrupt_def dmo_machine_op_lift_invs)
 
 lemmas writeCR3_irq_masks = no_irq[OF no_irq_writeCR3]
 
 lemma dmo_writeCR3[wp]: "\<lbrace>invs\<rbrace> do_machine_op (writeCR3 vs asid) \<lbrace>\<lambda>rv. invs\<rbrace>"
-  by (simp add: writeCR3_def do_machine_op_lift_invs)
+  by (simp add: writeCR3_def dmo_machine_op_lift_invs)
 
 crunch get_current_cr3
   for inv[wp]: P
@@ -883,6 +842,7 @@ lemma arch_state_update_invs:
   assumes "pspace_in_kernel_window s \<Longrightarrow> pspace_in_kernel_window (arch_state_update f s)"
   assumes "cap_refs_in_kernel_window s \<Longrightarrow> cap_refs_in_kernel_window (arch_state_update f s)"
   assumes "valid_ioports s \<Longrightarrow> valid_ioports (arch_state_update f s)"
+  assumes "valid_cur_fpu s \<Longrightarrow> valid_cur_fpu (arch_state_update f s)"
   shows "invs (arch_state_update f s)"
   using assms by (simp add: invs_def valid_state_def valid_irq_node_def valid_irq_states_def
                             valid_machine_state_def valid_arch_caps_def valid_asid_map_def
@@ -899,7 +859,7 @@ lemma set_current_cr3_invs[wp]:
   "\<lbrace>invs and K (valid_cr3 c)\<rbrace> set_current_cr3 c \<lbrace>\<lambda>rv. invs\<rbrace>"
   apply (wpsimp simp: set_current_cr3_def; erule arch_state_update_invs)
   by (auto simp: valid_global_refs_def global_refs_def valid_arch_state_def valid_table_caps_def
-                 valid_global_objs_def valid_kernel_mappings_def second_level_tables_def)
+                 valid_global_objs_def valid_kernel_mappings_def second_level_tables_def valid_cur_fpu_defs)
 
 lemma valid_cr3_make_cr3:
   "asid_wf asid \<Longrightarrow> valid_cr3 (make_cr3 addr asid)"
@@ -934,11 +894,8 @@ lemma svr_invs [wp]:
   apply (simp add: valid_cap_def)
   done
 
-crunch set_current_vspace_root
-  for pred_tcb_at[wp]: "pred_tcb_at proj P t"
-
-crunch set_vm_root
-  for pred_tcb_at[wp]: "pred_tcb_at proj P t"
+crunch set_current_vspace_root, set_vm_root
+  for pred_tcb_at[wp]: "\<lambda>s. Q (pred_tcb_at proj P t s)"
   (simp: crunch_simps)
 
 crunch get_current_cr3, set_vm_root
@@ -1585,28 +1542,13 @@ lemma arch_update_cap_invs_unmap_pd_pointer_table:
   apply fastforce
   done
 
-lemma invalidateTLBEntry_underlying_memory:
-  "\<lbrace>\<lambda>m'. underlying_memory m' p = um\<rbrace>
-   invalidateTLBEntry a
-   \<lbrace>\<lambda>_ m'. underlying_memory m' p = um\<rbrace>"
-  by (simp add: invalidateTLBEntry_def machine_op_lift_underlying_memory)
-
-lemmas invalidateTLBEntry_irq_masks = no_irq[OF no_irq_invalidateTLBEntry]
-
-crunch invalidateTLBEntry
-  for device_state_inv[wp]: "\<lambda>ms. P (device_state ms)"
-  (ignore: ignore_failure)
-
 lemma dmo_invalidateTLBEntry_invs[wp]:
   "\<lbrace>invs\<rbrace> do_machine_op (invalidateTLBEntry a) \<lbrace>\<lambda>_. invs\<rbrace>"
-  by (simp add: invalidateTLBEntry_def do_machine_op_lift_invs)
-
-crunch invalidateTranslationSingleASID
-  for device_state[wp]: "\<lambda>ms. P (device_state ms)"
+  by (simp add: invalidateTLBEntry_def dmo_machine_op_lift_invs)
 
 lemma invalidatePageStructureCache_invs[wp]:
   "\<lbrace>invs\<rbrace> do_machine_op (invalidateTranslationSingleASID a b)\<lbrace>\<lambda>_. invs\<rbrace>"
-  by (simp add: invalidateTranslationSingleASID_def do_machine_op_lift_invs)
+  by (simp add: invalidateTranslationSingleASID_def dmo_machine_op_lift_invs)
 
 lemma flush_table_invs[wp]:
   "\<lbrace>invs\<rbrace> flush_table pm vaddr pt vspace \<lbrace>\<lambda>rv. invs\<rbrace>"
@@ -1649,7 +1591,7 @@ lemma not_in_global_refs_vs_lookup:
 
 lemma flush_all_invs[wp]:
   "\<lbrace>invs\<rbrace> flush_all vspace asid \<lbrace>\<lambda>_. invs\<rbrace>"
-  by (simp add: flush_all_def invalidateASID_def do_machine_op_lift_invs)
+  by (simp add: flush_all_def invalidateASID_def dmo_machine_op_lift_invs)
 
 lemma valid_asid_table_inverse_injD:
   "\<lbrakk>(a,b) \<in> vs_asid_refs (x64_asid_table (arch_state s)); (a,c) \<in> vs_asid_refs (x64_asid_table (arch_state s))\<rbrakk>
@@ -2518,7 +2460,7 @@ lemma vs_lookup1_archD:
 
 lemma dmo_invalidateLocalPageStructureCacheASID[wp]:
   "\<lbrace>invs\<rbrace> do_machine_op (invalidateLocalPageStructureCacheASID vs asid) \<lbrace>\<lambda>rv. invs\<rbrace>"
-  by (simp add: invalidateLocalPageStructureCacheASID_def do_machine_op_lift_invs)
+  by (simp add: invalidateLocalPageStructureCacheASID_def dmo_machine_op_lift_invs)
 
 lemma invalidate_page_structure_cache_asid_invs[wp]:
   "\<lbrace>invs\<rbrace> invalidate_page_structure_cache_asid vs asid \<lbrace>\<lambda>rv. invs\<rbrace>"
@@ -3841,13 +3783,13 @@ lemma dmo_in32[wp]: "\<lbrace>invs\<rbrace> do_machine_op (in32 irq) \<lbrace>\<
   done
 
 lemma dmo_out8[wp]: "\<lbrace>invs\<rbrace> do_machine_op (out8 irq b) \<lbrace>\<lambda>y. invs\<rbrace>"
-  by (clarsimp simp: out8_def do_machine_op_lift_invs)
+  by (clarsimp simp: out8_def dmo_machine_op_lift_invs)
 
 lemma dmo_out16[wp]: "\<lbrace>invs\<rbrace> do_machine_op (out16 irq b) \<lbrace>\<lambda>y. invs\<rbrace>"
-  by (clarsimp simp: out16_def do_machine_op_lift_invs)
+  by (clarsimp simp: out16_def dmo_machine_op_lift_invs)
 
 lemma dmo_out32[wp]: "\<lbrace>invs\<rbrace> do_machine_op (out32 irq b) \<lbrace>\<lambda>y. invs\<rbrace>"
-  by (clarsimp simp: out32_def do_machine_op_lift_invs)
+  by (clarsimp simp: out32_def dmo_machine_op_lift_invs)
 
 lemma perform_io_port_invocation_invs[wp]:
   "\<lbrace>invs\<rbrace> perform_io_port_invocation iopinv \<lbrace>\<lambda>rv. invs\<rbrace>"

--- a/proof/invariant-abstract/X64/Machine_AI.thy
+++ b/proof/invariant-abstract/X64/Machine_AI.thy
@@ -1,4 +1,5 @@
 (*
+ * Copyright 2025, Proofcraft Pty Ltd
  * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only
@@ -12,6 +13,7 @@ theory Machine_AI
 imports Bits_AI
 begin
 
+text \<open>Crunch setup\<close>
 
 definition
   "no_irq f \<equiv> \<forall>P. \<lbrace>\<lambda>s. P (irq_masks s)\<rbrace> f \<lbrace>\<lambda>_ s. P (irq_masks s)\<rbrace>"
@@ -69,94 +71,56 @@ crunch_ignore (no_irq) (add:
 
 context Arch begin arch_global_naming
 
+text \<open>Deterministic\<close>
+
 lemma det_getRegister: "det (getRegister x)"
   by (simp add: getRegister_def)
 
 lemma det_setRegister: "det (setRegister x w)"
   by (simp add: setRegister_def det_def modify_def get_def put_def bind_def)
 
-
 lemma det_getRestartPC: "det getRestartPC"
   by (simp add: getRestartPC_def det_getRegister)
-
 
 lemma det_setNextPC: "det (setNextPC p)"
   by (simp add: setNextPC_def det_setRegister)
 
-(* FIXME empty_fail: make all empty_fail [intro!, wp], and non-conditional ones [simp] *)
-lemma ef_loadWord: "empty_fail (loadWord x)"
-  by (fastforce simp: loadWord_def)
+text \<open>Failure on empty result\<close>
 
+crunch loadWord, storeWord, machine_op_lift
+  for (empty_fail) empty_fail[intro!, wp, simp]
+  (ignore: Nondet_Monad.bind mapM_x simp: machine_op_lift_def empty_fail_cond)
 
-lemma ef_storeWord: "empty_fail (storeWord x y)"
-  by (fastforce simp: storeWord_def)
+lemmas ef_machine_op_lift = machine_op_lift_empty_fail \<comment> \<open>required for generic interface\<close>
 
+text \<open>Does not affect state\<close>
 
-lemma no_fail_getRestartPC: "no_fail \<top> getRestartPC"
+definition "irq_state_independent P \<equiv> \<forall>f s. P s \<longrightarrow> P (irq_state_update f s)"
+
+lemma getActiveIRQ_inv[wp]:
+  "\<lbrakk>irq_state_independent P\<rbrakk> \<Longrightarrow> getActiveIRQ in_kernel \<lbrace>P\<rbrace>"
+  apply (simp add: getActiveIRQ_def)
+  apply wp
+  apply (simp add: irq_state_independent_def)
+  done
+
+lemma loadWord_inv[wp]: "loadWord x \<lbrace>P\<rbrace>"
+  by (wpsimp simp: loadWord_def)
+
+lemma getRestartPC_inv: "getRestartPC \<lbrace>P\<rbrace>"
   by (simp add: getRestartPC_def getRegister_def)
 
+text \<open>Does not set failure flag\<close>
 
-lemma no_fail_loadWord [wp]: "no_fail (\<lambda>_. is_aligned p 3) (loadWord p)"
-  apply (simp add: loadWord_def is_aligned_mask [symmetric])
-  apply (rule no_fail_pre)
-   apply wp
-  apply simp
-  done
-
+lemma no_fail_loadWord[wp]: "no_fail (\<lambda>_. is_aligned p 3) (loadWord p)"
+  by (wpsimp simp: loadWord_def is_aligned_mask [symmetric])
 
 lemma no_fail_storeWord: "no_fail (\<lambda>_. is_aligned p 3) (storeWord p w)"
-  apply (simp add: storeWord_def is_aligned_mask [symmetric])
-  apply (rule no_fail_pre)
-   apply (wp)
-  apply simp
-  done
-
+  by (wpsimp simp: storeWord_def is_aligned_mask [symmetric])
 
 lemma no_fail_machine_op_lift [simp]:
   "no_fail \<top> (machine_op_lift f)"
   by (simp add: machine_op_lift_def)
-
-
-lemma ef_machine_op_lift [simp]:
-  "empty_fail (machine_op_lift f)"
-  by (simp add: machine_op_lift_def)
-
-
-
-lemma no_fail_setNextPC: "no_fail \<top> (setNextPC pc)"
-  by (simp add: setNextPC_def setRegister_def)
-
-
-lemma no_fail_initL2Cache: "no_fail \<top> initL2Cache"
-  by (simp add: initL2Cache_def)
-
-lemma no_fail_resetTimer[wp]: "no_fail \<top> resetTimer"
-  by (simp add: resetTimer_def)
-
-
-lemma loadWord_inv: "\<lbrace>P\<rbrace> loadWord x \<lbrace>\<lambda>x. P\<rbrace>"
-  apply (simp add: loadWord_def)
-  apply wp
-  apply simp
-  done
-
-
-lemma getRestartPC_inv: "\<lbrace>P\<rbrace> getRestartPC \<lbrace>\<lambda>rv. P\<rbrace>"
-  by (simp add: getRestartPC_def getRegister_def)
-
-
-
-lemma no_fail_clearMemory[simp, wp]:
-  "no_fail (\<lambda>_. is_aligned p 3) (clearMemory p b)"
-  apply (simp add: clearMemory_def mapM_x_mapM)
-  apply (rule no_fail_pre)
-   apply (wp no_fail_mapM' no_fail_storeWord )
-  apply (clarsimp simp: upto_enum_step_def)
-  apply (erule aligned_add_aligned)
-   apply (simp add: word_size_def)
-   apply (rule is_aligned_mult_triv2 [where n = 3, simplified])
-  apply simp
-  done
 
 lemma no_fail_freeMemory[simp, wp]:
   "no_fail (\<lambda>_. is_aligned p 3) (freeMemory p b)"
@@ -170,7 +134,6 @@ lemma no_fail_freeMemory[simp, wp]:
   apply simp
   done
 
-
 lemma no_fail_getActiveIRQ[wp]:
   "no_fail \<top> (getActiveIRQ in_kernel)"
   apply (simp add: getActiveIRQ_def)
@@ -179,23 +142,12 @@ lemma no_fail_getActiveIRQ[wp]:
   apply simp
   done
 
-definition "irq_state_independent P \<equiv> \<forall>f s. P s \<longrightarrow> P (irq_state_update f s)"
+text \<open>Does not affect IRQ masks - low-level properties of @{term no_irq}\<close>
 
-lemma getActiveIRQ_inv [wp]:
-  "\<lbrakk>irq_state_independent P\<rbrakk> \<Longrightarrow> \<lbrace>P\<rbrace> getActiveIRQ in_kernel \<lbrace>\<lambda>rv. P\<rbrace>"
-  apply (simp add: getActiveIRQ_def)
-  apply wp
-  apply (simp add: irq_state_independent_def)
-  done
-
-lemma no_fail_ackInterrupt[wp]: "no_fail \<top> (ackInterrupt irq)"
-  by (simp add: ackInterrupt_def)
-
-
-lemma no_fail_maskInterrupt[wp]: "no_fail \<top> (maskInterrupt irq bool)"
-  by (simp add: maskInterrupt_def)
-
-
+lemma no_irq_bind[wp]:
+  "\<lbrakk> no_irq f; \<And>rv. no_irq (g rv) \<rbrakk> \<Longrightarrow> no_irq (f >>= g)"
+  unfolding no_irq_def
+  by (wpsimp, blast+)
 
 lemma no_irq_use:
   "\<lbrakk> no_irq f; (rv,s') \<in> fst (f s) \<rbrakk> \<Longrightarrow> irq_masks s' = irq_masks s"
@@ -204,12 +156,9 @@ lemma no_irq_use:
   apply fastforce
   done
 
-lemma no_irq_machine_rest_lift:
+lemma no_irq_machine_rest_lift[simp, wp]:
   "no_irq (machine_rest_lift f)"
-  apply (clarsimp simp: no_irq_def machine_rest_lift_def split_def)
-  apply wp
-  apply simp
-  done
+  by (wpsimp simp: no_irq_def machine_rest_lift_def split_def)
 
 crunch machine_op_lift
   for (no_irq) no_irq[wp, simp]
@@ -218,90 +167,40 @@ lemma no_irq:
   "no_irq f \<Longrightarrow> \<lbrace>\<lambda>s. P (irq_masks s)\<rbrace> f \<lbrace>\<lambda>_ s. P (irq_masks s)\<rbrace>"
   by (simp add: no_irq_def)
 
-lemma no_irq_invalidateTLB: "no_irq  invalidateTLB"
-  by (simp add: invalidateTLB_def)
+lemma no_irq_return[simp, wp]:
+  "no_irq (return v)"
+  unfolding no_irq_def
+  by simp
 
-lemma no_irq_initL2Cache: "no_irq  initL2Cache"
-  by (simp add: initL2Cache_def)
+lemma no_irq_get[simp, wp]:
+  "no_irq get"
+  by (wpsimp simp: no_irq_def)
 
-lemma no_irq_gets [simp]:
+lemma no_irq_gets[simp, wp]:
   "no_irq (gets f)"
   by (simp add: no_irq_def)
 
-
-lemma no_irq_resetTimer: "no_irq resetTimer"
-  by (simp add: resetTimer_def)
-
-
-lemma no_irq_debugPrint: "no_irq (debugPrint $ xs)"
-  by (simp add: no_irq_def)
-
-context notes no_irq[wp] begin
-
-lemma no_irq_ackInterrupt: "no_irq (ackInterrupt irq)"
-  by (wp | clarsimp simp: no_irq_def ackInterrupt_def)+
-
-lemma no_irq_writeCR3: "no_irq (writeCR3 vs asid)"
-  by (wp | clarsimp simp: no_irq_def writeCR3_def)+
-
-lemma no_irq_loadWord: "no_irq (loadWord x)"
-  apply (clarsimp simp: no_irq_def)
-  apply (rule loadWord_inv)
-  done
-
-
-lemma no_irq_getActiveIRQ: "no_irq (getActiveIRQ in_kernel)"
-  apply (clarsimp simp: no_irq_def)
-  apply (rule getActiveIRQ_inv)
-  apply (simp add: irq_state_independent_def)
-  done
-
-
 lemma no_irq_mapM:
   "(\<And>x. x \<in> set xs \<Longrightarrow> no_irq (f x)) \<Longrightarrow> no_irq (mapM f xs)"
-  apply (subst no_irq_def)
-  apply clarify
-  apply (rule mapM_wp)
-   prefer 2
-   apply (rule order_refl)
-  apply (wp; simp)
+  apply (simp (no_asm) add: no_irq_def)
+  apply (clarsimp intro!: mapM_wp[OF _ order_refl])
+  apply (wpsimp wp: no_irq)
   done
-
 
 lemma no_irq_mapM_x:
   "(\<And>x. x \<in> set xs \<Longrightarrow> no_irq (f x)) \<Longrightarrow> no_irq (mapM_x f xs)"
-  apply (subst no_irq_def)
-  apply clarify
-  apply (rule mapM_x_wp)
-   prefer 2
-   apply (rule order_refl)
-  apply (wp; simp)
+  apply (simp (no_asm) add: no_irq_def)
+  apply (clarsimp intro!: mapM_x_wp[OF _ order_refl])
+  apply (wpsimp wp: no_irq)
   done
-
 
 lemma no_irq_swp:
   "no_irq (f y x) \<Longrightarrow> no_irq (swp f x y)"
   by (simp add: swp_def)
 
-
-lemma no_irq_seq [wp]:
-  "\<lbrakk> no_irq f; \<And>x. no_irq (g x) \<rbrakk> \<Longrightarrow> no_irq (f >>= g)"
-  apply (subst no_irq_def)
-  apply clarsimp
-  apply (rule bind_wp)
-  apply (wp|simp)+
-  done
-
-lemma no_irq_return [simp, wp]: "no_irq (return v)"
-  unfolding no_irq_def return_def
-  by (rule allI, simp add: valid_def)
-
-
 lemma no_irq_fail [simp, wp]: "no_irq fail"
   unfolding no_irq_def fail_def
   by (rule allI, simp add: valid_def)
-
-
 
 lemma no_irq_assert [simp, wp]: "no_irq (assert P)"
   unfolding assert_def by simp
@@ -313,82 +212,175 @@ lemma no_irq_modify:
   apply (clarsimp simp: in_monad)
   done
 
-lemma no_irq_invalidateTLBEntry: "no_irq (invalidateTLBEntry a)"
-  by (clarsimp simp: invalidateTLBEntry_def)
-
-lemma no_irq_storeWord: "no_irq (storeWord w p)"
-  apply (simp add: storeWord_def)
-  apply (wp no_irq_modify)
-  apply simp
-  done
-
-lemma no_irq_when:
+lemma no_irq_when[simp, wp]:
   "\<lbrakk>P \<Longrightarrow> no_irq f\<rbrakk> \<Longrightarrow> no_irq (when P f)"
   by (simp add: when_def)
 
-lemma no_irq_clearMemory: "no_irq (clearMemory a b)"
-  apply (simp add: clearMemory_def)
-  apply (wp no_irq_mapM_x no_irq_storeWord)
+text \<open>Architecture-specific @{term no_irq} preservations\<close>
+
+lemma no_irq_loadWord: "no_irq (loadWord x)"
+  by (wpsimp simp: no_irq_def wp: loadWord_inv)
+
+lemma no_irq_getActiveIRQ: "no_irq (getActiveIRQ in_kernel)"
+  by (wpsimp simp: no_irq_def irq_state_independent_def wp: getActiveIRQ_inv)
+
+lemma no_irq_storeWord: "no_irq (storeWord w p)"
+  by (wpsimp simp: storeWord_def wp: no_irq_modify)
+
+crunch ackInterrupt
+  for (no_irq) no_irq[intro!, wp, simp]
+
+text \<open>Wide-angle crunch proofs over architecture-specific machine operations for
+  @{term no_fail}, @{term empty_fail} and @{term no_irq}}}\<close>
+
+(* Most of the basic machine ops in MachineOps.thy use abstract _impl constants which should never
+   be expanded.
+   Note: this was generated by running the following, and should likely be updated the same way:
+   grep -o "\w\+_impl" MachineOps.thy|sort|uniq|sed "s/^/    /"
+   *)
+crunch_ignore (valid, empty_fail, no_fail)
+  (add:
+    configureTimer_impl
+    disableFpu_impl
+    enableFpu_impl
+    getDeviceRegions_impl
+    getKernelDevices_impl
+    in16_impl
+    in32_impl
+    in8_impl
+    initL2Cache_impl
+    initTimer_impl
+    invalidateASID_impl
+    invalidateLocalPageStructureCacheASID_impl
+    invalidateTLBEntry_impl
+    invalidateTLB_impl
+    invalidateTranslationSingleASID_impl
+    ioapicMapPinToVector_impl
+    mfence_impl
+    out16_impl
+    out32_impl
+    out8_impl
+    resetTimer_impl
+    writeCR3_impl
+    writeFpuState_impl
+    )
+
+(* Crunches for machine ops without concrete implementations (using _impl or _val).
+   List obtained using:
+   grep -oE "(\w+_impl)|(get\w+)" MachineOps.thy|sort|uniq|sed "s/_impl//;s/$/,/;s/^/  /"
+   with the following manual interventions:
+   - remove false positives: get_def, gets, gets_def, getFPUState, getRegister, getRestartPC,
+                             getDeviceRegions_val, getFaultAddress_val, getKernelDevices_val
+   - add read_cntpct and readFpuState
+   - remove final comma
+   - getActiveIRQ does not preserve no_irq *)
+crunch
+  configureTimer,
+  disableFpu,
+  enableFpu,
+  getDeviceRegions,
+  getDeviceRegions,
+  getFaultAddress,
+  getKernelDevices,
+  getKernelDevices,
+  getMemoryRegions,
+  in16,
+  in32,
+  in8,
+  initL2Cache,
+  initTimer,
+  invalidateASID,
+  invalidateLocalPageStructureCacheASID,
+  invalidateTLBEntry,
+  invalidateTLB,
+  invalidateTranslationSingleASID,
+  ioapicMapPinToVector,
+  mfence,
+  out16,
+  out32,
+  out8,
+  resetTimer,
+  writeCR3,
+  writeFpuState,
+  readFpuState
+  for (no_fail) no_fail[intro!, wp, simp]
+  and (empty_fail) empty_fail[intro!, wp, simp]
+  and (no_irq) no_irq[intro!, wp, simp]
+  and device_state_inv[wp]: "\<lambda>ms. P (device_state ms)"
+  and irq_masks[wp]: "\<lambda>s. P (irq_masks s)"
+  and underlying_memory_inv[wp]: "\<lambda>s. P (underlying_memory s)"
+  (wp: no_irq_bind no_irq_modify ef_machine_rest_lift no_fail_machine_state_rest_T)
+
+crunch getFPUState, getRegister, getRestartPC, setNextPC, ackInterrupt, maskInterrupt, hwASIDInvalidate
+  for (no_fail) no_fail[intro!, wp, simp]
+  and (empty_fail) empty_fail[intro!, wp, simp]
+
+crunch ackInterrupt, maskInterrupt
+  for device_state_inv[wp]: "\<lambda>ms. P (device_state ms)"
+  and underlying_memory_inv[wp]: "\<lambda>s. P (underlying_memory s)"
+
+crunch ackInterrupt
+  for irq_masks[wp]: "\<lambda>s. P (irq_masks s)"
+
+text \<open>Lifting rules\<close>
+
+lemma dmo_machine_state_lift:
+  "\<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace> \<Longrightarrow> \<lbrace>\<lambda>s. P (machine_state s)\<rbrace> do_machine_op f \<lbrace>\<lambda>rv s. Q rv (machine_state s)\<rbrace>"
+  unfolding do_machine_op_def by wpsimp (erule use_valid; assumption)
+
+crunch do_machine_op
+  for user_frame[wp]: "\<lambda>s. P (in_user_frame p s)"
+
+lemma dmo_valid_machine_state[wp]:
+  assumes "\<And>P. f \<lbrace>\<lambda>s. P (underlying_memory s)\<rbrace>"
+  shows "do_machine_op f \<lbrace>valid_machine_state\<rbrace>"
+  unfolding valid_machine_state_def
+  by (wpsimp wp: hoare_vcg_all_lift hoare_vcg_disj_lift dmo_machine_state_lift assms)
+
+lemma dmo_valid_irq_states[wp]:
+  "(\<And>P. f \<lbrace>\<lambda>s. P (irq_masks s)\<rbrace>) \<Longrightarrow> do_machine_op f \<lbrace>valid_irq_states\<rbrace>"
+  unfolding valid_irq_states_def do_machine_op_def
+  by (wpsimp, erule use_valid; assumption)
+
+text \<open>Ops that require machine-ops rules derived above\<close>
+
+\<comment> \<open>These can't be placed into the sections above, as they require the derivation of the machine op
+   properties, and those in turn rely on items in specific sections above. There are unlikely to be
+   many definitions like this in MachineOps.thy\<close>
+
+crunch clearMemory
+  for (empty_fail) empty_fail[intro!, wp, simp]
+
+lemma no_fail_clearMemory[unfolded word_size_bits_def, simp, wp]:
+  "no_fail (\<lambda>_. is_aligned p word_size_bits) (clearMemory p b)"
+  apply (simp add: clearMemory_def word_size_bits_def mapM_x_mapM)
+  apply (rule no_fail_pre)
+   apply (wp no_fail_mapM' no_fail_storeWord )
+  apply (clarsimp simp: upto_enum_step_def)
+  apply (erule aligned_add_aligned)
+   apply (simp add: word_size_def)
+   apply (rule is_aligned_mult_triv2 [where n = 3, simplified])
+  apply simp
   done
 
-lemma no_irq_in8: "no_irq (in8 irq)"
-  by (wp | clarsimp simp: in8_def)+
+lemma no_irq_clearMemory: "no_irq (clearMemory a b)"
+  by (wpsimp simp: clearMemory_def no_irq_mapM_x no_irq_storeWord)
 
-lemma no_irq_in16: "no_irq (in16 irq)"
-  by (wp | clarsimp simp: in16_def)+
-
-lemma no_irq_in32: "no_irq (in32 irq)"
-  by (wp | clarsimp simp: in32_def)+
-
-lemma no_irq_out8: "no_irq (out8 irq b)"
-  by (wp | clarsimp simp: out8_def)+
-
-lemma no_irq_out16: "no_irq (out16 irq b)"
-  by (wp | clarsimp simp: out16_def)+
-
-lemma no_irq_out32: "no_irq (out32 irq b)"
-  by (wp | clarsimp simp: out32_def)+
-
-lemma no_irq_invalidateLocalPageStructureCacheASID:
-  "no_irq (invalidateLocalPageStructureCacheASID vspace asid)"
-  by (wpsimp simp: invalidateLocalPageStructureCacheASID_def)
-
-lemmas invalidateLocalPageStructureCacheASID_irq_masks =
-  no_irq[OF no_irq_invalidateLocalPageStructureCacheASID]
-
-lemma no_irq_nativeThreadUsingFPU: "no_irq (nativeThreadUsingFPU thread)"
-  by (wp | clarsimp simp: nativeThreadUsingFPU_def)+
-
-lemma no_irq_switchFpuOwner: "no_irq (switchFpuOwner thread cpu)"
-  by (wp | clarsimp simp: switchFpuOwner_def)+
-
-lemmas nativeThreadUsingFPU_irq_masks = no_irq[OF no_irq_nativeThreadUsingFPU]
-lemmas switchFpuOwner_irq_masks = no_irq[OF no_irq_switchFpuOwner]
+text \<open>Misc WP rules\<close>
 
 lemma getActiveIRQ_le_maxIRQ':
   "\<lbrace>\<lambda>s. \<forall>irq > maxIRQ. irq_masks s irq\<rbrace>
     getActiveIRQ in_kernel
    \<lbrace>\<lambda>rv s. \<forall>x. rv = Some x \<longrightarrow> x \<le> maxIRQ\<rbrace>"
   apply (simp add: getActiveIRQ_def)
-  apply wp
-  apply clarsimp
+  apply wpsimp
   apply (rule ccontr)
   apply (simp add: linorder_not_le)
   done
 
-(* FIXME: follows already from getActiveIRQ_le_maxIRQ *)
-lemma getActiveIRQ_neq_Some0xFF':
-  "\<lbrace>\<top>\<rbrace> getActiveIRQ in_kernel \<lbrace>\<lambda>rv s. rv \<noteq> Some 0x3FF\<rbrace>"
-  apply (simp add: getActiveIRQ_def)
-  apply wpsimp
-  done
-
 lemma getActiveIRQ_neq_non_kernel:
   "\<lbrace>\<top>\<rbrace> getActiveIRQ True \<lbrace>\<lambda>rv s. rv \<notin> Some ` non_kernel_IRQs \<rbrace>"
-  apply (simp add: getActiveIRQ_def)
-  apply wp
-  apply auto
-  done
+  by (wpsimp simp: getActiveIRQ_def)
 
 lemma dmo_getActiveIRQ_non_kernel[wp]:
   "\<lbrace>\<top>\<rbrace> do_machine_op (getActiveIRQ True)
@@ -399,59 +391,10 @@ lemma dmo_getActiveIRQ_non_kernel[wp]:
   apply clarsimp
   done
 
-lemma empty_fail_invalidateTLB: "empty_fail  invalidateTLB"
-  by (simp add: invalidateTLB_def)
+lemma dmo_gets_inv[wp]:
+  "do_machine_op (gets f) \<lbrace>P\<rbrace>"
+  unfolding do_machine_op_def by (wpsimp simp: simpler_gets_def)
 
-lemma empty_fail_initL2Cache: "empty_fail  initL2Cache"
-  by (simp add: initL2Cache_def)
-
-lemma empty_fail_clearMemory [simp, intro!]:
-  "\<And>a b. empty_fail (clearMemory a b)"
-  by (fastforce simp: clearMemory_def mapM_x_mapM ef_storeWord)
-
-lemma getFaultAddress_ef[simp,wp]: "empty_fail getFaultAddress"
-  by (simp add: getFaultAddress_def)
-
-lemma ioapicMapPinToVector_ef[simp,wp]: "empty_fail (ioapicMapPinToVector a b c d e)"
-  by (simp add: ioapicMapPinToVector_def)
-
-lemma invalidateTLBEntry_ef[simp,wp]: "empty_fail (invalidateTLBEntry b)"
-  by (simp add: invalidateTLBEntry_def)
-
-lemma invalidateASID_ef[simp,wp]: "empty_fail (invalidateASID a b)"
-  by (simp add: invalidateASID_def)
-
-lemma invalidateTranslationSingleASID_ef[simp,wp]: "empty_fail (invalidateTranslationSingleASID a b)"
-  by (simp add: invalidateTranslationSingleASID_def)
-
-lemma hwASIDInvalidate_ef[simp,wp]: "empty_fail (hwASIDInvalidate b a)"
-  by (simp add: hwASIDInvalidate_def)
-
-lemma updateIRQState_ef[simp,wp]: "empty_fail (updateIRQState b c)"
-  by (fastforce simp: updateIRQState_def)
-
-lemma writeCR3_ef[simp,wp]: "empty_fail (writeCR3 a b)"
-  by (simp add: writeCR3_def)
-
-lemma in8_ef[simp,wp]: "empty_fail (in8 port)"
-  by (fastforce simp: in8_def)
-
-lemma in16_ef[simp,wp]: "empty_fail (in16 port)"
-  by (fastforce simp: in16_def)
-
-lemma in32_ef[simp,wp]: "empty_fail (in32 port)"
-  by (fastforce simp: in32_def)
-
-lemma out8_ef[simp,wp]: "empty_fail (out8 port dat)"
-  by (simp add: out8_def)
-
-lemma out16_ef[simp,wp]: "empty_fail (out16 port dat)"
-  by (simp add: out16_def)
-
-lemma out32_ef[simp,wp]: "empty_fail (out32 port dat)"
-  by (simp add: out32_def)
-
-end
 end
 
 end

--- a/spec/abstract/X64/FPU_A.thy
+++ b/spec/abstract/X64/FPU_A.thy
@@ -25,8 +25,8 @@ definition load_fpu_state :: "obj_ref \<Rightarrow> (unit,'z::state_ext) s_monad
      do_machine_op (writeFpuState fpu_state)
    od"
 
-definition set_arm_current_fpu_owner :: "obj_ref option \<Rightarrow> (unit,'z::state_ext) s_monad" where
-  "set_arm_current_fpu_owner new_owner \<equiv> do
+definition set_x64_current_fpu_owner :: "obj_ref option \<Rightarrow> (unit,'z::state_ext) s_monad" where
+  "set_x64_current_fpu_owner new_owner \<equiv> do
      cur_fpu_owner \<leftarrow> gets (x64_current_fpu_owner \<circ> arch_state);
      maybeM (arch_thread_set (tcb_cur_fpu_update \<bottom>)) cur_fpu_owner;
      modify (\<lambda>s. s \<lparr>arch_state := arch_state s\<lparr>x64_current_fpu_owner := new_owner\<rparr>\<rparr>);
@@ -42,7 +42,7 @@ definition switch_local_fpu_owner :: "obj_ref option \<Rightarrow> (unit,'z::sta
      case new_owner of
        None \<Rightarrow> do_machine_op disableFpu
        | Some tcb_ptr \<Rightarrow> load_fpu_state tcb_ptr;
-     set_arm_current_fpu_owner new_owner
+     set_x64_current_fpu_owner new_owner
    od"
 
 definition fpu_release :: "obj_ref \<Rightarrow> (unit,'z::state_ext) s_monad" where


### PR DESCRIPTION
This extends the changes made in https://github.com/seL4/l4v/pull/850 for the remaining architectures. Changes to X64 were  more extensive due to its proofs needing to be made consistent with the more recent AARCH64 proofs that were being copied.