### PR TITLE
github: fix weekly tests

### DIFF
--- a/.github/workflows/weekly-clean.yml
+++ b/.github/workflows/weekly-clean.yml
@@ -81,13 +81,13 @@ jobs:
     - name: Upload kernel builds
       uses: actions/upload-artifact@v4
       with:
-        name: kernel-builds-${{ matrix.num_domains }}-${{ matrix.arch }}
+        name: kernel-builds-${{ matrix.num_domains }}-${{ matrix.arch }}-${{ matrix.plat }}
         path: artifacts/kernel-builds
         if-no-files-found: ignore
     - name: Upload logs
       uses: actions/upload-artifact@v4
       with:
-        name: logs-${{ matrix.num_domains }}-${{ matrix.arch }}
+        name: logs-${{ matrix.num_domains }}-${{ matrix.arch }}-${{ matrix.plat }}
         path: logs.tar.xz
 
   binary-verification:

--- a/.github/workflows/weekly-clean.yml
+++ b/.github/workflows/weekly-clean.yml
@@ -18,9 +18,12 @@ jobs:
       fail-fast: false
       matrix:
         arch: [ARM, ARM_HYP, AARCH64, RISCV64, X64]
-        num_domains: ['1', '7', '']
+        num_domains: ['1', '']
         plat: ['']
         include:
+          - arch: ARM
+            num_domains: '7'
+
           - arch: ARM
             plat: exynos4
           - arch: ARM


### PR DESCRIPTION
Currently the weekly tests are broken, failing on:

- artifact upload (duplicate file names for different platforms in the same architecture). Fixed in first commit.
- out of VM quota (too many concurrent tests). Fixed in second commit by reducing test load slightly.
