### PR TITLE
Rename fpu_state to user_fpu_state in user contexts

### DIFF
--- a/proof/crefine/AARCH64/ADT_C.thy
+++ b/proof/crefine/AARCH64/ADT_C.thy
@@ -127,8 +127,8 @@ definition
 definition (in state_rel) to_user_context_C :: "user_context \<Rightarrow> user_context_C" where
   "to_user_context_C uc \<equiv>
      user_context_C (ARRAY r. user_regs uc (register_to_H (of_nat r))) 0
-                    (user_fpu_state_C (ARRAY r. fpuRegs (fpu_state uc) (of_nat r))
-                                      (fpuSr (fpu_state uc)) (fpuCr (fpu_state uc)))"
+                    (user_fpu_state_C (ARRAY r. fpuRegs (user_fpu_state uc) (of_nat r))
+                                      (fpuSr (user_fpu_state uc)) (fpuCr (user_fpu_state uc)))"
 
 (* FIXME ARMHYP is this useful in any other file? *)
 (* Note: depends on vcpuactive being false when vcpuptr is NULL! *)

--- a/proof/crefine/AARCH64/Fastpath_Equiv.thy
+++ b/proof/crefine/AARCH64/Fastpath_Equiv.thy
@@ -555,11 +555,6 @@ lemma zipWithM_setRegister_simple_modify_registers:
                         simpler_modify_def fun_upd_def[symmetric])
   done
 
-(* FIXME AARCH64 move to IsolatedThreadAction where existing setRegister_simple is commented out *)
-lemma setRegister_simple:
-  "setRegister r v = (\<lambda>con. ({((), UserContext (fpu_state con) ((user_regs con)(r := v)))}, False))"
-  by (simp add: setRegister_def simpler_modify_def)
-
 lemma no_fail_getObject_asidpool[wp]:
   "no_fail (asid_pool_at' pool_ptr) (getObject pool_ptr :: asidpool kernel)"
   (* FIXME AARCH64 no_fail_getObject_tcb and no_fail_getObject_vcpu don't need this at their locations

--- a/proof/crefine/AARCH64/StateRelation_C.thy
+++ b/proof/crefine/AARCH64/StateRelation_C.thy
@@ -280,7 +280,7 @@ definition
   ccontext_relation :: "user_context \<Rightarrow> user_context_C \<Rightarrow> bool"
 where
   "ccontext_relation uc_H uc_C \<equiv> cregs_relation (user_regs uc_H) (registers_C uc_C) \<and>
-                                 fpu_relation (fpu_state uc_H) (fpuState_C uc_C)"
+                                 fpu_relation (user_fpu_state uc_H) (fpuState_C uc_C)"
 
 primrec
   cthread_state_relation_lifted :: "Structures_H.thread_state \<Rightarrow>

--- a/proof/crefine/X64/ADT_C.thy
+++ b/proof/crefine/X64/ADT_C.thy
@@ -123,7 +123,7 @@ definition (in state_rel)
   to_user_context_C :: "user_context \<Rightarrow> user_context_C"
 where
   "to_user_context_C uc \<equiv>
-  user_context_C (user_fpu_state_C (ARRAY r. fpu_state uc (finite_index r)))
+  user_context_C (user_fpu_state_C (ARRAY r. user_fpu_state uc (finite_index r)))
                  (ARRAY r. user_regs uc (register_to_H (of_nat r)))"
 
 lemma (in kernel_m) ccontext_rel_to_C:

--- a/proof/crefine/X64/IsolatedThreadAction.thy
+++ b/proof/crefine/X64/IsolatedThreadAction.thy
@@ -26,7 +26,7 @@ where
  "put_tcb_state_regs_tcb tsr tcb \<equiv> case tsr of
      TCBStateRegs st regs \<Rightarrow>
         tcb \<lparr> tcbState := st,
-              tcbArch := atcbContextSet (UserContext (fpu_state (atcbContext (tcbArch tcb))) regs)
+              tcbArch := atcbContextSet (UserContext (user_fpu_state (atcbContext (tcbArch tcb))) regs)
                          (tcbArch tcb) \<rparr>"
 
 definition
@@ -60,7 +60,7 @@ definition
   od"
 
 lemma UserContextGet[simp]:
-  "UserContext (fpu_state (atcbContext t)) (user_regs (atcbContextGet t)) = atcbContextGet t"
+  "UserContext (user_fpu_state (atcbContext t)) (user_regs (atcbContextGet t)) = atcbContextGet t"
   by (cases t, simp add: atcbContextGet_def)
 
 lemma put_tcb_state_regs_twice[simp]:
@@ -172,7 +172,7 @@ lemma get_tcb_state_regs_ko_at':
 lemma put_tcb_state_regs_ko_at':
   "ko_at' ko p s \<Longrightarrow> put_tcb_state_regs tsr (ksPSpace s p)
        = Some (KOTCB (ko \<lparr> tcbState := tsrState tsr
-                         , tcbArch := atcbContextSet (UserContext (fpu_state (atcbContext (tcbArch ko))) (tsrContext tsr)) (tcbArch ko)\<rparr>))"
+                         , tcbArch := atcbContextSet (UserContext (user_fpu_state (atcbContext (tcbArch ko))) (tsrContext tsr)) (tcbArch ko)\<rparr>))"
   by (clarsimp simp: obj_at'_def projectKOs put_tcb_state_regs_def
                      put_tcb_state_regs_tcb_def
               split: tcb_state_regs.split)
@@ -241,12 +241,12 @@ lemma mapM_getRegister_simple:
   done
 
 lemma setRegister_simple:
-  "setRegister r v = (\<lambda>con. ({((), UserContext (fpu_state con) ((user_regs con)(r := v)))}, False))"
+  "setRegister r v = (\<lambda>con. ({((), UserContext (user_fpu_state con) ((user_regs con)(r := v)))}, False))"
   by (simp add: setRegister_def simpler_modify_def)
 
 lemma zipWithM_setRegister_simple:
   "zipWithM_x setRegister rs vs
-      = (\<lambda>con. ({((), foldl (\<lambda>con (r, v). UserContext (fpu_state con) ((user_regs con)(r := v))) con (zip rs vs))}, False))"
+      = (\<lambda>con. ({((), foldl (\<lambda>con (r, v). UserContext (user_fpu_state con) ((user_regs con)(r := v))) con (zip rs vs))}, False))"
   apply (simp add: zipWithM_x_mapM_x)
   apply (induct ("zip rs vs"))
    apply (simp add: mapM_x_Nil return_def)
@@ -1100,8 +1100,8 @@ lemma partial_overwrite_fun_upd2:
   by (simp add: fun_eq_iff partial_overwrite_def split: if_split)
 
 lemma atcbContextSetSetGet_eq[simp]:
-  "atcbContextSet (UserContext (fpu_state (atcbContext
-     (atcbContextSet (UserContext (fpu_state (atcbContext t)) r) t)))
+  "atcbContextSet (UserContext (user_fpu_state (atcbContext
+     (atcbContextSet (UserContext (user_fpu_state (atcbContext t)) r) t)))
         (user_regs (atcbContextGet t))) t = t"
   by (cases t, simp add: atcbContextSet_def atcbContextGet_def)
 

--- a/proof/crefine/X64/StateRelation_C.thy
+++ b/proof/crefine/X64/StateRelation_C.thy
@@ -330,7 +330,7 @@ definition
   ccontext_relation :: "user_context \<Rightarrow> user_context_C \<Rightarrow> bool"
 where
   "ccontext_relation uc_H uc_C \<equiv> cregs_relation (user_regs uc_H) (registers_C uc_C) \<and>
-                                  fpu_relation (fpu_state uc_H) (fpuState_C uc_C)"
+                                  fpu_relation (user_fpu_state uc_H) (fpuState_C uc_C)"
 
 primrec
   cthread_state_relation_lifted :: "Structures_H.thread_state \<Rightarrow>

--- a/proof/refine/AARCH64/TcbAcc_R.thy
+++ b/proof/refine/AARCH64/TcbAcc_R.thy
@@ -4111,8 +4111,8 @@ proof -
 qed
 
 lemma UserContext_fold:
-  "UserContext (fpu_state s) (foldl (\<lambda>s (x, y). s(x := y)) (user_regs s) xs) =
-   foldl (\<lambda>s (r, v). UserContext (fpu_state s) ((user_regs s)(r := v))) s xs"
+  "UserContext (user_fpu_state s) (foldl (\<lambda>s (x, y). s(x := y)) (user_regs s) xs) =
+   foldl (\<lambda>s (r, v). UserContext (user_fpu_state s) ((user_regs s)(r := v))) s xs"
   apply (induct xs arbitrary: s; simp)
   apply (clarsimp split: prod.splits)
   apply (metis user_context.sel)
@@ -4126,7 +4126,7 @@ lemma setMRs_corres:
               (set_mrs t buf mrs) (setMRs t buf mrs')"
 proof -
   have setRegister_def2:
-    "setRegister = (\<lambda>r v.  modify (\<lambda>s. UserContext (fpu_state s) ((user_regs s)(r := v))))"
+    "setRegister = (\<lambda>r v.  modify (\<lambda>s. UserContext (user_fpu_state s) ((user_regs s)(r := v))))"
     by ((rule ext)+, simp add: setRegister_def)
 
   have S: "\<And>xs ys n m. m - n \<ge> length xs \<Longrightarrow> (zip xs (drop n (take m ys))) = zip xs (drop n ys)"

--- a/proof/refine/X64/Ipc_R.thy
+++ b/proof/refine/X64/Ipc_R.thy
@@ -1880,9 +1880,9 @@ crunch doIPCTransfer
    simp: split_def zipWithM_x_mapM)
 
 lemma sanitise_register_corres:
-  "foldl (\<lambda>s (a, b). UserContext (fpu_state s) ((user_regs s)(a := sanitise_register x a b))) s
+  "foldl (\<lambda>s (a, b). UserContext (user_fpu_state s) ((user_regs s)(a := sanitise_register x a b))) s
           (zip msg_template msg) =
-   foldl (\<lambda>s (a, b). UserContext (fpu_state s) ((user_regs s)(a := sanitiseRegister y a b))) s
+   foldl (\<lambda>s (a, b). UserContext (user_fpu_state s) ((user_regs s)(a := sanitiseRegister y a b))) s
           (zip msg_template msg)"
   apply (rule foldl_cong)
     apply simp

--- a/proof/refine/X64/TcbAcc_R.thy
+++ b/proof/refine/X64/TcbAcc_R.thy
@@ -4033,8 +4033,8 @@ proof -
 qed
 
 lemma UserContext_fold:
-  "UserContext (fpu_state s) (foldl (\<lambda>s (x, y). s(x := y)) (user_regs s) xs) =
-   foldl (\<lambda>s (r, v). UserContext (fpu_state s) ((user_regs s)(r := v))) s xs"
+  "UserContext (user_fpu_state s) (foldl (\<lambda>s (x, y). s(x := y)) (user_regs s) xs) =
+   foldl (\<lambda>s (r, v). UserContext (user_fpu_state s) ((user_regs s)(r := v))) s xs"
   apply (induct xs arbitrary: s; simp)
   apply (clarsimp split: prod.splits)
   by (metis user_context.sel(1) user_context.sel(2))
@@ -4047,7 +4047,7 @@ lemma setMRs_corres:
               (set_mrs t buf mrs) (setMRs t buf mrs')"
 proof -
   have setRegister_def2:
-    "setRegister = (\<lambda>r v.  modify (\<lambda>s. UserContext (fpu_state s) ((user_regs s)(r := v))))"
+    "setRegister = (\<lambda>r v.  modify (\<lambda>s. UserContext (user_fpu_state s) ((user_regs s)(r := v))))"
     by ((rule ext)+, simp add: setRegister_def)
 
   have S: "\<And>xs ys n m. m - n \<ge> length xs \<Longrightarrow> (zip xs (drop n (take m ys))) = zip xs (drop n ys)"

--- a/spec/abstract/AARCH64/Arch_Structs_A.thy
+++ b/spec/abstract/AARCH64/Arch_Structs_A.thy
@@ -398,7 +398,7 @@ text \<open>
 \<close>
 definition arch_tcb_set_registers :: "(register \<Rightarrow> machine_word) \<Rightarrow> arch_tcb \<Rightarrow> arch_tcb" where
   "arch_tcb_set_registers regs a_tcb \<equiv>
-    a_tcb \<lparr> tcb_context := UserContext (fpu_state (tcb_context a_tcb)) regs \<rparr>"
+    a_tcb \<lparr> tcb_context := UserContext (user_fpu_state (tcb_context a_tcb)) regs \<rparr>"
 
 definition arch_tcb_get_registers :: "arch_tcb \<Rightarrow> register \<Rightarrow> machine_word" where
   "arch_tcb_get_registers a_tcb \<equiv> user_regs (tcb_context a_tcb)"

--- a/spec/abstract/X64/Arch_Structs_A.thy
+++ b/spec/abstract/X64/Arch_Structs_A.thy
@@ -446,7 +446,7 @@ definition
   arch_tcb_set_registers :: "(register \<Rightarrow> machine_word) \<Rightarrow> arch_tcb \<Rightarrow> arch_tcb"
 where
   "arch_tcb_set_registers regs a_tcb \<equiv>
-    a_tcb \<lparr> tcb_context := UserContext (fpu_state (tcb_context a_tcb)) regs \<rparr>"
+    a_tcb \<lparr> tcb_context := UserContext (user_fpu_state (tcb_context a_tcb)) regs \<rparr>"
 
 definition
   arch_tcb_get_registers :: "arch_tcb \<Rightarrow> register \<Rightarrow> machine_word"

--- a/spec/haskell/src/SEL4/Machine/RegisterSet/AARCH64.hs
+++ b/spec/haskell/src/SEL4/Machine/RegisterSet/AARCH64.hs
@@ -123,7 +123,7 @@ data FPUState = FPUState { fpuRegs :: Array Int Data.Word.Word64
 -- machine words, indexed by register name for the user registers, plus the
 -- state of the FPU.
 data UserContext = UC { fromUC :: Array Register Word,
-                        fpuState :: FPUState }
+                        userFpuState :: FPUState }
   deriving Show
 
 -- A new user-level context is a list of values for the machine's registers.
@@ -140,9 +140,9 @@ newContext = UC ((funArray $ const 0)//initContext) newFPUState
 
 getRegister r = gets $ (! r) . fromUC
 
-setRegister r v = modify (\ uc -> UC (fromUC uc //[(r, v)]) (fpuState uc))
+setRegister r v = modify (\ uc -> UC (fromUC uc //[(r, v)]) (userFpuState uc))
 
 getFPUState :: State UserContext FPUState
-getFPUState = gets fpuState
+getFPUState = gets userFpuState
 
 setFPUState fc = modify (\ uc -> UC (fromUC uc) fc)

--- a/spec/haskell/src/SEL4/Machine/RegisterSet/X64.lhs
+++ b/spec/haskell/src/SEL4/Machine/RegisterSet/X64.lhs
@@ -87,7 +87,7 @@ with the convention that all unused entries map to 0.
 > type FPUState = Array Word Data.Word.Word8
 
 > data UserContext = UC { fromUC :: Array Register Word,
->                         fpuState :: FPUState }
+>                         userFpuState :: FPUState }
 >   deriving Show
 
 
@@ -103,9 +103,9 @@ Functions are provided to get and set a single register, or to get and set the F
 
 > getRegister r = gets $ (! r) . fromUC
 
-> setRegister r v = modify (\ uc -> UC (fromUC uc //[(r, v)]) (fpuState uc))
+> setRegister r v = modify (\ uc -> UC (fromUC uc //[(r, v)]) (userFpuState uc))
 
 > getFPUState :: State UserContext FPUState
-> getFPUState = gets fpuState
+> getFPUState = gets userFpuState
 
 > setFPUState fc = modify (\ uc -> UC (fromUC uc) fc)

--- a/spec/machine/AARCH64/MachineOps.thy
+++ b/spec/machine/AARCH64/MachineOps.thy
@@ -159,7 +159,7 @@ datatype fpu_state = FPUState (fpuRegs : "fpu_regs \<Rightarrow> 64 word")
                               (fpuSr : "32 word")
                               (fpuCr : "32 word")
 
-datatype user_context = UserContext (fpu_state : fpu_state) (user_regs : user_regs)
+datatype user_context = UserContext (user_fpu_state : fpu_state) (user_regs : user_regs)
 
 type_synonym 'a user_monad = "(user_context, 'a) nondet_monad"
 
@@ -167,10 +167,10 @@ definition getRegister :: "register \<Rightarrow> machine_word user_monad" where
   "getRegister r \<equiv> gets (\<lambda>s. user_regs s r)"
 
 definition modify_registers :: "(user_regs \<Rightarrow> user_regs) \<Rightarrow> user_context \<Rightarrow> user_context" where
-  "modify_registers f uc \<equiv> UserContext (fpu_state uc) (f (user_regs uc))"
+  "modify_registers f uc \<equiv> UserContext (user_fpu_state uc) (f (user_regs uc))"
 
 definition setRegister :: "register \<Rightarrow> machine_word \<Rightarrow> unit user_monad" where
-  "setRegister r v \<equiv> modify (\<lambda>s. UserContext (fpu_state s) ((user_regs s) (r := v)))"
+  "setRegister r v \<equiv> modify (\<lambda>s. UserContext (user_fpu_state s) ((user_regs s) (r := v)))"
 
 definition getRestartPC :: "machine_word user_monad" where
   "getRestartPC \<equiv> getRegister FaultIP"
@@ -182,7 +182,7 @@ definition setNextPC :: "machine_word \<Rightarrow> unit user_monad" where
 subsection "FPU-related"
 
 definition getFPUState :: "fpu_state user_monad" where
-  "getFPUState \<equiv> gets fpu_state"
+  "getFPUState \<equiv> gets user_fpu_state"
 
 definition setFPUState :: "fpu_state \<Rightarrow> unit user_monad" where
   "setFPUState fc \<equiv> modify (\<lambda>s. UserContext fc (user_regs s))"

--- a/spec/machine/X64/MachineOps.thy
+++ b/spec/machine/X64/MachineOps.thy
@@ -226,7 +226,7 @@ type_synonym fpu_state = "fpu_bytes \<Rightarrow> 8 word"
 
 type_synonym user_regs = "register \<Rightarrow> machine_word"
 
-datatype user_context = UserContext (fpu_state : fpu_state) (user_regs : user_regs)
+datatype user_context = UserContext (user_fpu_state : fpu_state) (user_regs : user_regs)
 
 type_synonym 'a user_monad = "(user_context, 'a) nondet_monad"
 
@@ -236,12 +236,12 @@ where
   "getRegister r \<equiv> gets (\<lambda>s. user_regs s r)"
 
 definition
-  "modify_registers f uc \<equiv> UserContext (fpu_state uc) (f (user_regs uc))"
+  "modify_registers f uc \<equiv> UserContext (user_fpu_state uc) (f (user_regs uc))"
 
 definition
   setRegister :: "register \<Rightarrow> machine_word \<Rightarrow> unit user_monad"
 where
-  "setRegister r v \<equiv> modify (\<lambda>s. UserContext (fpu_state s) ((user_regs s) (r := v)))"
+  "setRegister r v \<equiv> modify (\<lambda>s. UserContext (user_fpu_state s) ((user_regs s) (r := v)))"
 
 definition
   "getRestartPC \<equiv> getRegister FaultIP"
@@ -253,7 +253,7 @@ definition
 definition
   getFPUState :: "fpu_state user_monad"
 where
-  "getFPUState \<equiv> gets fpu_state"
+  "getFPUState \<equiv> gets user_fpu_state"
 
 definition
   setFPUState :: "fpu_state \<Rightarrow> unit user_monad"


### PR DESCRIPTION
On architectures with FPU support, user contexts have a `user_regs` field and an `fpu_state` field. This commit renames `fpu_state` to `user_fpu_state`.

Test with https://github.com/seL4/seL4/pull/1325