### PR TITLE
Update Refine and CRefine for other arches for explicit FPU changes

### DIFF
--- a/proof/crefine/AARCH64/ADT_C.thy
+++ b/proof/crefine/AARCH64/ADT_C.thy
@@ -1506,9 +1506,7 @@ lemma mk_gsUntypedZeroRanges_correct:
   done
 
 
-definition
-  cstate_to_H :: "globals \<Rightarrow> kernel_state"
-where
+definition cstate_to_H :: "globals \<Rightarrow> kernel_state" where
   "cstate_to_H s \<equiv>
    \<lparr>ksPSpace = cstate_to_pspace_H s,
     gsUserPages = fst (ghost'state_' s), gsCNodes = fst (snd (ghost'state_' s)),

--- a/proof/crefine/AARCH64/IsolatedThreadAction.thy
+++ b/proof/crefine/AARCH64/IsolatedThreadAction.thy
@@ -1646,12 +1646,9 @@ lemma typ_at_partial_overwrite_id2:
   "\<lbrakk> \<forall>x. tcb_at' (idx x) s \<rbrakk>
    \<Longrightarrow> typ_at' P p (ksPSpace_update (partial_overwrite idx f) s) = typ_at' P p s"
   apply (frule dom_partial_overwrite[where tsrs=f])
-  apply (simp add: typ_at'_def ko_wp_at'_def obj_at'_def ps_clear_def partial_overwrite_def
-                    split: if_split)
-  apply clarsimp
+  apply (clarsimp simp: typ_at'_def ko_wp_at'_def obj_at'_def ps_clear_def partial_overwrite_def)
   apply (drule_tac x=x in spec)
-  apply (clarsimp simp: put_tcb_state_regs_def objBits_simps
-                        project_inject)
+  apply (clarsimp simp: put_tcb_state_regs_def objBits_simps)
   done
 
 lemma tcb_at_partial_overwrite:
@@ -1708,7 +1705,7 @@ lemma threadSet_isolatable:
   assumes v: "\<And>tcb. get_tcb_state_regs_tcb (f tcb) = get_tcb_state_regs_tcb tcb"
   assumes y: "\<And>tsr tcb. f (put_tcb_state_regs_tcb tsr tcb) = put_tcb_state_regs_tcb tsr (f tcb)"
   shows "thread_actions_isolatable idx (threadSet f t)"
-  apply (clarsimp simp: threadSet_def )
+  apply (clarsimp simp: threadSet_def)
   apply (subst setObject_assert_modify;
          simp add: objBits_2n objBits_simps tcbBlockSizeBits_def)+
   apply (clarsimp simp: thread_actions_isolatable_def isolate_thread_actions_def split_def

--- a/proof/crefine/AARCH64/SR_lemmas_C.thy
+++ b/proof/crefine/AARCH64/SR_lemmas_C.thy
@@ -1211,7 +1211,6 @@ lemma rf_sr_upd_safe[simp]:
     "armHSCurVCPU_' (globals (g y)) = armHSCurVCPU_' (globals y)"
     "armHSVCPUActive_' (globals (g y)) = armHSVCPUActive_' (globals y)"
     "ksCurFPUOwner_' (globals (g y)) = ksCurFPUOwner_' (globals y)"
-    "phantom_machine_state_' (globals (g y)) = phantom_machine_state_' (globals y)"
   and    gs: "ghost'state_' (globals (g y)) = ghost'state_' (globals y)"
   and     wu:  "(ksWorkUnitsCompleted_' (globals (g y))) = (ksWorkUnitsCompleted_' (globals y))"
   shows "((a, (g y)) \<in> rf_sr) = ((a, y) \<in> rf_sr)"

--- a/proof/crefine/AARCH64/TcbAcc_C.thy
+++ b/proof/crefine/AARCH64/TcbAcc_C.thy
@@ -289,7 +289,7 @@ lemma ccorres_pre_getCurVCPU:
   apply (clarsimp simp: rf_sr_ksArchState_armHSCurVCPU)
   done
 
-lemma rf_sr_ksArchState_armHSCurFPU:
+lemma rf_sr_ksArchState_armKSCurFPUOwner:
   "(s, s') \<in> rf_sr \<Longrightarrow> cur_fpu_relation (armKSCurFPUOwner (ksArchState s)) (ksCurFPUOwner_' (globals s'))"
   by (clarsimp simp: rf_sr_def cstate_relation_def carch_state_relation_def Let_def)
 
@@ -313,7 +313,7 @@ lemma ccorres_pre_getCurFPUOwner:
      apply (rule cc)
     apply clarsimp
    apply assumption
-  apply (simp add: rf_sr_ksArchState_armHSCurFPU)
+  apply (simp add: rf_sr_ksArchState_armKSCurFPUOwner)
   done
 
 lemma getObject_tcb_wp':

--- a/proof/crefine/ARM/Finalise_C.thy
+++ b/proof/crefine/ARM/Finalise_C.thy
@@ -2128,7 +2128,7 @@ lemma ccap_relation_IRQHandler_mask:
   apply (simp add: c_valid_cap_def cap_irq_handler_cap_lift cl_valid_cap_def)
   done
 
-lemma prepare_thread_delete_ccorres:
+lemma prepareThreadDelete_ccorres:
   "ccorres dc xfdc \<top> UNIV []
    (prepareThreadDelete thread) (Call Arch_prepareThreadDelete_'proc)"
   unfolding prepareThreadDelete_def
@@ -2237,7 +2237,7 @@ lemma finaliseCap_ccorres:
     apply csymbr
     apply (ctac(no_vcg) add: unbindNotification_ccorres)
      apply (ctac(no_vcg) add: suspend_ccorres[OF cteDeleteOne_ccorres])
-     apply (ctac(no_vcg) add: prepare_thread_delete_ccorres)
+     apply (ctac(no_vcg) add: prepareThreadDelete_ccorres)
       apply (rule ccorres_from_vcg_throws[where P=\<top> and P'=UNIV])
       apply (rule allI, rule conseqPre, vcg)
       apply (clarsimp simp: word_sle_def return_def)

--- a/proof/crefine/ARM/Invoke_C.thy
+++ b/proof/crefine/ARM/Invoke_C.thy
@@ -92,9 +92,35 @@ lemma setDomain_ccorres:
                          invs'_def valid_state'_def valid_pspace'_def)
   done
 
+lemma prepareSetDomain_ccorres:
+  "ccorres dc xfdc
+      (invs' and tcb_at' t)
+      (\<lbrace>\<acute>tptr = tcb_ptr_to_ctcb_ptr t\<rbrace> \<inter> \<lbrace>\<acute>dom = ucast d\<rbrace>) []
+      (prepareSetDomain t d) (Call prepareSetDomain_'proc)"
+  apply (cinit lift: tptr_' dom_')
+   apply (rule ccorres_return_Skip)
+  apply clarsimp
+  done
+
 lemma active_runnable':
   "active' state \<Longrightarrow> runnable' state"
   by (fastforce simp: runnable'_def)
+
+lemma invokeDomainSetSet_ccorres:
+  "ccorres dc xfdc
+      (invs' and tcb_at' t and sch_act_simple
+             and (\<lambda>s. d \<le> maxDomain))
+      (\<lbrace>\<acute>tcb = tcb_ptr_to_ctcb_ptr t\<rbrace> \<inter> \<lbrace>\<acute>domain = ucast d\<rbrace>) []
+      (do x <- prepareSetDomain t d;
+               setDomain t d
+       od)
+      (Call invokeDomainSetSet_'proc)"
+  apply (cinit' lift: tcb_' domain_')
+   apply (simp add: liftE_def bind_assoc)
+   apply (ctac (no_vcg) add: prepareSetDomain_ccorres)
+    apply (ctac (no_vcg) add: setDomain_ccorres)
+   apply wpsimp+
+  done
 
 lemma decodeDomainInvocation_ccorres:
   notes Collect_const[simp del]
@@ -178,11 +204,12 @@ lemma decodeDomainInvocation_ccorres:
                                  performInvocation_def liftE_bindE bind_assoc)
        apply (ctac add: setThreadState_ccorres)
          apply csymbr
-         apply (ctac add: setDomain_ccorres)
+         apply (subst bind_assoc[symmetric])
+         apply (ctac add: invokeDomainSetSet_ccorres)
            apply (rule ccorres_alternative2)
            apply (ctac add: ccorres_return_CE)
           apply wp
-         apply (vcg exspec=setDomain_modifies)
+         apply (vcg exspec=invokeDomainSetSet_modifies)
         apply (wp sts_invs_minor')
        apply (vcg exspec=setThreadState_modifies)
       apply wp

--- a/proof/crefine/ARM/Machine_C.thy
+++ b/proof/crefine/ARM/Machine_C.thy
@@ -204,6 +204,7 @@ assumes invalidateLocalTLB_VAASID_spec:
 assumes cleanCacheRange_PoU_spec:
  "\<Gamma>\<turnstile>\<^bsub>/UNIV\<^esub> UNIV (Call cleanCacheRange_PoU_'proc) UNIV"
 
+
 (* The following are fastpath specific assumptions.
    We might want to move them somewhere else. *)
 

--- a/proof/crefine/ARM/Retype_C.thy
+++ b/proof/crefine/ARM/Retype_C.thy
@@ -2891,7 +2891,9 @@ proof -
        tcbFaultHandler_C := 0, tcbIPCBuffer_C := 0,
        tcbSchedNext_C := tcb_Ptr 0, tcbSchedPrev_C := tcb_Ptr 0,
        tcbEPNext_C := tcb_Ptr 0, tcbEPPrev_C := tcb_Ptr 0,
-       tcbBoundNotification_C := ntfn_Ptr 0\<rparr>"
+       tcbBoundNotification_C := ntfn_Ptr 0,
+       flags_C := 0\<rparr>"
+
   have fbtcb: "from_bytes (replicate (size_of TYPE(tcb_C)) 0) = ?tcb"
     apply (simp add: from_bytes_def)
     apply (simp add: typ_info_simps tcb_C_tag_def)

--- a/proof/crefine/ARM/SR_lemmas_C.thy
+++ b/proof/crefine/ARM/SR_lemmas_C.thy
@@ -299,12 +299,12 @@ lemma cmdbnode_relation_mdb_node_to_H [simp]:
 definition tcb_no_ctes_proj ::
   "tcb \<Rightarrow> Structures_H.thread_state \<times> machine_word \<times> machine_word \<times> arch_tcb \<times> bool \<times> word8
           \<times> word8 \<times> word8 \<times> nat \<times> fault option \<times> machine_word option
-          \<times> machine_word option \<times> machine_word option"
+          \<times> machine_word option \<times> machine_word option \<times> machine_word"
   where
   "tcb_no_ctes_proj t \<equiv>
      (tcbState t, tcbFaultHandler t, tcbIPCBuffer t, tcbArch t, tcbQueued t,
       tcbMCP t, tcbPriority t, tcbDomain t, tcbTimeSlice t, tcbFault t, tcbBoundNotification t,
-      tcbSchedNext t, tcbSchedPrev t)"
+      tcbSchedNext t, tcbSchedPrev t, tcbFlags t)"
 
 lemma tcb_cte_cases_proj_eq [simp]:
   "tcb_cte_cases p = Some (getF, setF) \<Longrightarrow>

--- a/proof/crefine/ARM/Schedule_C.thy
+++ b/proof/crefine/ARM/Schedule_C.thy
@@ -357,11 +357,20 @@ lemma nextDomain_ccorres:
   apply simp
   done
 
+lemma prepareNextDomain_ccorres:
+  "ccorres dc xfdc invs' UNIV [] prepareNextDomain (Call prepareNextDomain_'proc)"
+  apply cinit
+  apply (rule ccorres_return_Skip)
+  by clarsimp
+
 lemma scheduleChooseNewThread_ccorres:
   "ccorres dc xfdc
      (\<lambda>s. invs' s \<and> ksSchedulerAction s = ChooseNewThread) UNIV hs
      (do domainTime \<leftarrow> getDomainTime;
-         y \<leftarrow> when (domainTime = 0) nextDomain;
+         y \<leftarrow> when (domainTime = 0) (do
+             y <- prepareNextDomain;
+             nextDomain
+         od);
          chooseThread
       od)
      (Call scheduleChooseNewThread_'proc)"
@@ -370,12 +379,14 @@ lemma scheduleChooseNewThread_ccorres:
    apply (rule ccorres_split_nothrow)
        apply (rule_tac R="\<lambda>s. ksDomainTime s = domainTime" in ccorres_when)
         apply (fastforce simp: rf_sr_ksDomainTime)
-       apply (rule_tac xf'=xfdc in ccorres_call[OF nextDomain_ccorres] ; simp)
+       apply (ctac (no_vcg) add: prepareNextDomain_ccorres)
+        apply (rule ccorres_call[OF nextDomain_ccorres, where xf'=xfdc] ; simp)
+       apply wpsimp
       apply ceqv
      apply (ctac (no_vcg) add: chooseThread_ccorres)
     apply (wp nextDomain_invs_no_cicd')
    apply clarsimp
-   apply (vcg exspec=nextDomain_modifies)
+   apply (vcg exspec=nextDomain_modifies exspec=prepareNextDomain_modifies)
   apply (clarsimp simp: if_apply_def2 invs'_invs_no_cicd')
   done
 

--- a/proof/crefine/ARM/StateRelation_C.thy
+++ b/proof/crefine/ARM/StateRelation_C.thy
@@ -350,7 +350,8 @@ where
                   (lookup_fault_lift (tcbLookupFailure_C ctcb))
      \<and> option_to_ptr (tcbBoundNotification atcb) = tcbBoundNotification_C ctcb
      \<and> option_to_ctcb_ptr (tcbSchedPrev atcb) = tcbSchedPrev_C ctcb
-     \<and> option_to_ctcb_ptr (tcbSchedNext atcb) = tcbSchedNext_C ctcb"
+     \<and> option_to_ctcb_ptr (tcbSchedNext atcb) = tcbSchedNext_C ctcb
+     \<and> tcbFlags atcb = flags_C ctcb"
 
 abbreviation
   "ep_queue_relation' \<equiv> tcb_queue_relation' tcbEPNext_C tcbEPPrev_C"

--- a/proof/crefine/ARM_HYP/Invoke_C.thy
+++ b/proof/crefine/ARM_HYP/Invoke_C.thy
@@ -92,9 +92,35 @@ lemma setDomain_ccorres:
                          invs'_def valid_state'_def valid_pspace'_def)
   done
 
+lemma prepareSetDomain_ccorres:
+  "ccorres dc xfdc
+      (invs' and tcb_at' t)
+      (\<lbrace>\<acute>tptr = tcb_ptr_to_ctcb_ptr t\<rbrace> \<inter> \<lbrace>\<acute>dom = ucast d\<rbrace>) []
+      (prepareSetDomain t d) (Call prepareSetDomain_'proc)"
+  apply (cinit lift: tptr_' dom_')
+   apply (rule ccorres_return_Skip)
+  apply clarsimp
+  done
+
 lemma active_runnable':
   "active' state \<Longrightarrow> runnable' state"
   by (fastforce simp: runnable'_def)
+
+lemma invokeDomainSetSet_ccorres:
+  "ccorres dc xfdc
+      (invs' and tcb_at' t and sch_act_simple
+             and (\<lambda>s. d \<le> maxDomain))
+      (\<lbrace>\<acute>tcb = tcb_ptr_to_ctcb_ptr t\<rbrace> \<inter> \<lbrace>\<acute>domain = ucast d\<rbrace>) []
+      (do x <- prepareSetDomain t d;
+               setDomain t d
+       od)
+      (Call invokeDomainSetSet_'proc)"
+  apply (cinit' lift: tcb_' domain_')
+   apply (simp add: liftE_def bind_assoc)
+   apply (ctac (no_vcg) add: prepareSetDomain_ccorres)
+    apply (ctac (no_vcg) add: setDomain_ccorres)
+   apply wpsimp+
+  done
 
 lemma decodeDomainInvocation_ccorres:
   notes Collect_const[simp del]
@@ -178,11 +204,12 @@ lemma decodeDomainInvocation_ccorres:
                                  performInvocation_def liftE_bindE bind_assoc)
        apply (ctac add: setThreadState_ccorres)
          apply csymbr
-         apply (ctac add: setDomain_ccorres)
+         apply (subst bind_assoc[symmetric])
+         apply (ctac add: invokeDomainSetSet_ccorres)
            apply (rule ccorres_alternative2)
            apply (ctac add: ccorres_return_CE)
           apply wp
-         apply (vcg exspec=setDomain_modifies)
+         apply (vcg exspec=invokeDomainSetSet_modifies)
         apply (wp sts_invs_minor')
        apply (vcg exspec=setThreadState_modifies)
       apply wp

--- a/proof/crefine/ARM_HYP/IsolatedThreadAction.thy
+++ b/proof/crefine/ARM_HYP/IsolatedThreadAction.thy
@@ -14,11 +14,15 @@ context begin interpretation Arch . (*FIXME: arch-split*)
 datatype tcb_state_regs =
   TCBStateRegs (tsrState : thread_state) (tsrContext : "MachineTypes.register \<Rightarrow> machine_word")
 
+definition get_tcb_state_regs_tcb :: "tcb \<Rightarrow> tcb_state_regs" where
+  "get_tcb_state_regs_tcb tcb \<equiv> TCBStateRegs (tcbState tcb) ((user_regs \<circ> atcbContextGet \<circ> tcbArch) tcb)"
+
 definition
   get_tcb_state_regs :: "kernel_object option \<Rightarrow> tcb_state_regs"
 where
- "get_tcb_state_regs oko \<equiv> case oko of
-    Some (KOTCB tcb) \<Rightarrow> TCBStateRegs (tcbState tcb) ((user_regs o atcbContextGet o tcbArch) tcb)"
+ "get_tcb_state_regs oko \<equiv> case oko of Some (KOTCB tcb) \<Rightarrow> get_tcb_state_regs_tcb tcb"
+
+lemmas get_tcb_state_regs_defs = get_tcb_state_regs_def get_tcb_state_regs_tcb_def
 
 definition
   put_tcb_state_regs_tcb :: "tcb_state_regs \<Rightarrow> tcb \<Rightarrow> tcb"
@@ -35,6 +39,8 @@ where
  "put_tcb_state_regs tsr oko = Some (KOTCB (put_tcb_state_regs_tcb tsr
     (case oko of
        Some (KOTCB tcb) \<Rightarrow> tcb | _ \<Rightarrow> makeObject)))"
+
+lemmas put_tcb_state_regs_defs = put_tcb_state_regs_def put_tcb_state_regs_tcb_def
 
 definition
  "partial_overwrite idx tcbs ps \<equiv>
@@ -62,12 +68,11 @@ definition
 lemma put_tcb_state_regs_twice[simp]:
   "put_tcb_state_regs tsr (put_tcb_state_regs tsr' tcb)
     = put_tcb_state_regs tsr tcb"
-  apply (simp add: put_tcb_state_regs_def put_tcb_state_regs_tcb_def
-                   makeObject_tcb
+  apply (simp add: put_tcb_state_regs_defs makeObject_tcb newArchTCB_def
             split: tcb_state_regs.split option.split
                    Structures_H.kernel_object.split)
-  apply (intro all_tcbI impI allI)
-  apply simp
+  using atcbContextSet_def atcbContext_set_set
+  apply (intro all_tcbI impI allI conjI; simp)
   done
 
 lemma partial_overwrite_twice[simp]:
@@ -80,9 +85,8 @@ lemma get_tcb_state_regs_partial_overwrite[simp]:
    get_tcb_state_regs (partial_overwrite idx tcbs f (idx x))
       = tcbs x"
   apply (simp add: partial_overwrite_def)
-  apply (simp add: put_tcb_state_regs_def
-                   get_tcb_state_regs_def
-                   put_tcb_state_regs_tcb_def
+  apply (simp add: put_tcb_state_regs_defs
+                   get_tcb_state_regs_defs
             split: tcb_state_regs.split)
   done
 
@@ -156,14 +160,13 @@ lemma partial_overwrite_fun_upd:
 lemma get_tcb_state_regs_ko_at':
   "ko_at' ko p s \<Longrightarrow> get_tcb_state_regs (ksPSpace s p)
        = TCBStateRegs (tcbState ko) ((user_regs o atcbContextGet o tcbArch) ko)"
-  by (clarsimp simp: obj_at'_def projectKOs get_tcb_state_regs_def)
+  by (clarsimp simp: obj_at'_def get_tcb_state_regs_defs projectKOs)
 
 lemma put_tcb_state_regs_ko_at':
   "ko_at' ko p s \<Longrightarrow> put_tcb_state_regs tsr (ksPSpace s p)
        = Some (KOTCB (ko \<lparr> tcbState := tsrState tsr
                          , tcbArch := atcbContextSet (UserContext (tsrContext tsr)) (tcbArch ko)\<rparr>))"
-  by (clarsimp simp: obj_at'_def projectKOs put_tcb_state_regs_def
-                     put_tcb_state_regs_tcb_def
+  by (clarsimp simp: obj_at'_def put_tcb_state_regs_defs projectKOs
               split: tcb_state_regs.split)
 
 lemma partial_overwrite_get_tcb_state_regs:
@@ -174,8 +177,7 @@ lemma partial_overwrite_get_tcb_state_regs:
                       split: if_split)
   apply clarsimp
   apply (drule_tac x=xa in spec)
-  apply (clarsimp simp: obj_at'_def projectKOs put_tcb_state_regs_def
-                        get_tcb_state_regs_def put_tcb_state_regs_tcb_def)
+  apply (clarsimp simp: obj_at'_def put_tcb_state_regs_defs get_tcb_state_regs_defs projectKOs)
   apply (case_tac obj, simp)
   done
 
@@ -279,8 +281,7 @@ lemma map_to_ctes_partial_overwrite:
    apply (drule_tac x=xa in spec)
    apply (clarsimp simp: obj_at'_def projectKOs objBits_simps
                    cong: if_cong)
-   apply (simp add: put_tcb_state_regs_def put_tcb_state_regs_tcb_def
-                    objBits_simps
+   apply (simp add: put_tcb_state_regs_tcb_def objBits_simps
               cong: if_cong option.case_cong)
    apply (case_tac obj, simp split: tcb_state_regs.split if_split)
   apply simp
@@ -291,15 +292,14 @@ lemma map_to_ctes_partial_overwrite:
    apply (drule_tac x=xa in spec)
    apply (clarsimp simp: obj_at'_def projectKOs objBits_simps
                    cong: if_cong)
-   apply (simp add: put_tcb_state_regs_def put_tcb_state_regs_tcb_def
-                    objBits_simps'
+   apply (simp add: put_tcb_state_regs_tcb_def objBits_simps'
               cong: if_cong option.case_cong)
    apply (case_tac obj, simp split: tcb_state_regs.split if_split)
    apply (intro impI allI)
-   apply (subgoal_tac "x - idx xa = x && mask 9")
-    apply (clarsimp simp: tcb_cte_cases_def split: if_split)
+   apply (subgoal_tac "x - idx xa = x && mask tcbBlockSizeBits")
+    apply (clarsimp simp: tcb_cte_cases_def objBits_defs split: if_split)
    apply (drule_tac t = "idx xa" in sym)
-    apply simp
+    apply (simp add: objBits_defs)
   apply (simp cong: if_cong)
   done
 
@@ -673,7 +673,7 @@ lemma setVCPU_isolatable:
   apply (clarsimp simp: put_tcb_state_regs_tcb_def get_tcb_state_regs_def)
   apply (rename_tac p')
   apply (erule_tac x=p' in allE)
-  apply (clarsimp simp: obj_at'_def projectKOs atcbContextSet_def atcbContextGet_def split: tcb_state_regs.splits)
+  apply (clarsimp simp: obj_at'_def projectKOs get_tcb_state_regs_defs atcbContextSet_def atcbContextGet_def split: tcb_state_regs.splits)
   apply (rename_tac tcb)
   apply (case_tac tcb, simp)
   apply (rename_tac arch_tcb)
@@ -1166,8 +1166,8 @@ lemma oblivious_switchToThread_schact:
                    threadSet_def tcbSchedEnqueue_def unless_when asUser_def
                    getQueue_def setQueue_def storeWordUser_def setRegister_def
                    pointerInUserData_def isRunnable_def isStopped_def
-                   getThreadState_def tcbSchedDequeue_def tcbQueueRemove_def bitmap_fun_defs
-                   ksReadyQueues_asrt_def)
+                   getThreadState_def tcbSchedDequeue_def bitmap_fun_defs
+                   tcbQueueRemove_def ksReadyQueues_asrt_def)
   apply (safe intro!: oblivious_bind
          | simp_all add: ready_qs_runnable_def idleThreadNotQueued_def oblivious_setVMRoot_schact
                          oblivious_vcpuSwitch_schact)+
@@ -1377,8 +1377,7 @@ lemma setCTE_isolatable:
     apply (rule ext)
     apply (clarsimp simp: partial_overwrite_get_tcb_state_regs
                    split: if_split)
-    apply (clarsimp simp: projectKOs get_tcb_state_regs_def
-                          put_tcb_state_regs_def put_tcb_state_regs_tcb_def
+    apply (clarsimp simp: projectKOs get_tcb_state_regs_defs put_tcb_state_regs_defs
                           partial_overwrite_def
                    split: tcb_state_regs.split)
     apply (case_tac obj, simp add: projectKO_opt_tcb)
@@ -1460,8 +1459,7 @@ lemma isolate_thread_actions_threadSet_tcbState:
                 intro!: kernel_state.fold_congs[OF refl refl])
   apply (simp add: partial_overwrite_fun_upd
                    partial_overwrite_get_tcb_state_regs)
-  apply (clarsimp simp: put_tcb_state_regs_def put_tcb_state_regs_tcb_def
-                        projectKOs get_tcb_state_regs_def
+  apply (clarsimp simp: put_tcb_state_regs_defs projectKOs get_tcb_state_regs_defs
                  elim!: obj_atE')
   apply (case_tac ko)
   apply (simp add: projectKO_opt_tcb)
@@ -1490,7 +1488,7 @@ lemma switchToThread_rewrite:
        (switchToThread t)
        (do Arch.switchToThread t; setCurThread t od)"
   apply (simp add: switchToThread_def Thread_H.switchToThread_def)
-  apply (monadic_rewrite_l tcbSchedDequeue_rewrite, simp)
+  apply (monadic_rewrite_l tcbSchedDequeue_rewrite \<open>wpsimp simp: o_def\<close>, simp)
    (* strip LHS of getters and asserts until LHS and RHS are the same *)
    apply (repeat_unless \<open>rule monadic_rewrite_refl\<close> monadic_rewrite_symb_exec_l)
       apply wpsimp+
@@ -1520,16 +1518,11 @@ lemma threadGet_isolatable:
 
 lemma switchToThread_isolatable:
   "thread_actions_isolatable idx (Arch.switchToThread t)"
-  apply (simp add: switchToThread_def getTCB_threadGet
-                   storeWordUser_def stateAssert_def2)
+  apply (simp add: switchToThread_def getTCB_threadGet)
   apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
-               gets_isolatable setVMRoot_isolatable
-               thread_actions_isolatable_if
+               setVMRoot_isolatable
                doMachineOp_isolatable
                threadGet_isolatable [OF all_tcbI]
-               thread_actions_isolatable_returns
-               thread_actions_isolatable_fail
-               threadGet_vcpu_isolatable
                vcpuSwitch_isolatable)
         apply (wpsimp simp: put_tcb_state_regs_tcb_def atcbContextSet_def
                      split: tcb_state_regs.split)+
@@ -1646,8 +1639,8 @@ lemma set_register_isolate:
   apply (clarsimp simp: obj_at'_def projectKOs objBits_simps
                   cong: if_cong)
   apply (case_tac obj)
-  apply (simp add: projectKO_opt_tcb put_tcb_state_regs_def
-                   put_tcb_state_regs_tcb_def get_tcb_state_regs_def
+  apply (simp add: projectKO_opt_tcb put_tcb_state_regs_defs
+                   get_tcb_state_regs_defs
              cong: if_cong)
   done
 
@@ -1678,9 +1671,8 @@ lemma copy_register_isolate:
   apply (clarsimp simp: obj_at'_def projectKOs objBits_simps
                   cong: if_cong)
   apply (case_tac obj, case_tac obja)
-  apply (simp add: projectKO_opt_tcb put_tcb_state_regs_def
-                   put_tcb_state_regs_tcb_def get_tcb_state_regs_def
-                   atcbContextGet_def
+  apply (simp add: projectKO_opt_tcb put_tcb_state_regs_defs
+                   get_tcb_state_regs_defs atcbContextGet_def
              cong: if_cong)
   apply (auto simp: fun_eq_iff split: if_split)
   done

--- a/proof/crefine/ARM_HYP/Machine_C.thy
+++ b/proof/crefine/ARM_HYP/Machine_C.thy
@@ -351,6 +351,7 @@ assumes get_cntv_off_64_ccorres:
            (doMachineOp get_cntv_off_64)
            (Call get_cntv_off_64_'proc)"
 
+
 (* The following are fastpath specific assumptions.
    We might want to move them somewhere else. *)
 

--- a/proof/crefine/ARM_HYP/Recycle_C.thy
+++ b/proof/crefine/ARM_HYP/Recycle_C.thy
@@ -1200,7 +1200,7 @@ lemma coerce_memset_to_heap_update:
       = heap_update (tcb_Ptr x)
              (tcb_C.tcb_C (arch_tcb_C (user_context_C (FCP (\<lambda>x. 0))) NULL)
                           (thread_state_C (FCP (\<lambda>x. 0)))
-                          (NULL)
+                          0 NULL
                           (seL4_Fault_C (FCP (\<lambda>x. 0)))
                           (lookup_fault_C (FCP (\<lambda>x. 0)))
                             0 0 0 0 0 0 NULL NULL NULL NULL)"

--- a/proof/crefine/ARM_HYP/Retype_C.thy
+++ b/proof/crefine/ARM_HYP/Retype_C.thy
@@ -3392,7 +3392,9 @@ proof -
        tcbFaultHandler_C := 0, tcbIPCBuffer_C := 0,
        tcbSchedNext_C := tcb_Ptr 0, tcbSchedPrev_C := tcb_Ptr 0,
        tcbEPNext_C := tcb_Ptr 0, tcbEPPrev_C := tcb_Ptr 0,
-       tcbBoundNotification_C := ntfn_Ptr 0\<rparr>"
+       tcbBoundNotification_C := ntfn_Ptr 0,
+       flags_C := 0\<rparr>"
+
   have fbtcb: "from_bytes (replicate (size_of TYPE(tcb_C)) 0) = ?tcb"
     apply (simp add: from_bytes_def)
     apply (simp add: typ_info_simps tcb_C_tag_def)

--- a/proof/crefine/ARM_HYP/SR_lemmas_C.thy
+++ b/proof/crefine/ARM_HYP/SR_lemmas_C.thy
@@ -313,12 +313,12 @@ lemma cmdbnode_relation_mdb_node_to_H [simp]:
 definition tcb_no_ctes_proj ::
   "tcb \<Rightarrow> Structures_H.thread_state \<times> machine_word \<times> machine_word \<times> arch_tcb \<times> bool \<times> word8
           \<times> word8 \<times> word8 \<times> nat \<times> fault option \<times> machine_word option
-          \<times> machine_word option \<times> machine_word option"
+          \<times> machine_word option \<times> machine_word option \<times> machine_word"
   where
   "tcb_no_ctes_proj t \<equiv>
      (tcbState t, tcbFaultHandler t, tcbIPCBuffer t, tcbArch t, tcbQueued t,
       tcbMCP t, tcbPriority t, tcbDomain t, tcbTimeSlice t, tcbFault t, tcbBoundNotification t,
-      tcbSchedNext t, tcbSchedPrev t)"
+      tcbSchedNext t, tcbSchedPrev t, tcbFlags t)"
 
 lemma tcb_cte_cases_proj_eq [simp]:
   "tcb_cte_cases p = Some (getF, setF) \<Longrightarrow>

--- a/proof/crefine/ARM_HYP/Schedule_C.thy
+++ b/proof/crefine/ARM_HYP/Schedule_C.thy
@@ -399,11 +399,20 @@ lemma nextDomain_ccorres:
   apply simp
   done
 
+lemma prepareNextDomain_ccorres:
+  "ccorres dc xfdc invs' UNIV [] prepareNextDomain (Call prepareNextDomain_'proc)"
+  apply cinit
+  apply (rule ccorres_return_Skip)
+  by clarsimp
+
 lemma scheduleChooseNewThread_ccorres:
   "ccorres dc xfdc
      (\<lambda>s. invs' s \<and> ksSchedulerAction s = ChooseNewThread) UNIV hs
      (do domainTime \<leftarrow> getDomainTime;
-         y \<leftarrow> when (domainTime = 0) nextDomain;
+         y \<leftarrow> when (domainTime = 0) (do
+             y <- prepareNextDomain;
+             nextDomain
+         od);
          chooseThread
       od)
      (Call scheduleChooseNewThread_'proc)"
@@ -412,12 +421,14 @@ lemma scheduleChooseNewThread_ccorres:
    apply (rule ccorres_split_nothrow)
        apply (rule_tac R="\<lambda>s. ksDomainTime s = domainTime" in ccorres_when)
         apply (fastforce simp: rf_sr_ksDomainTime)
-       apply (rule_tac xf'=xfdc in ccorres_call[OF nextDomain_ccorres] ; simp)
+       apply (ctac (no_vcg) add: prepareNextDomain_ccorres)
+        apply (rule ccorres_call[OF nextDomain_ccorres, where xf'=xfdc] ; simp)
+       apply wpsimp
       apply ceqv
      apply (ctac (no_vcg) add: chooseThread_ccorres)
     apply (wp nextDomain_invs_no_cicd')
    apply clarsimp
-   apply (vcg exspec=nextDomain_modifies)
+   apply (vcg exspec=nextDomain_modifies exspec=prepareNextDomain_modifies)
   apply (clarsimp simp: if_apply_def2 invs'_invs_no_cicd')
   done
 

--- a/proof/crefine/ARM_HYP/StateRelation_C.thy
+++ b/proof/crefine/ARM_HYP/StateRelation_C.thy
@@ -389,7 +389,8 @@ where
                   (lookup_fault_lift (tcbLookupFailure_C ctcb))
      \<and> option_to_ptr (tcbBoundNotification atcb) = tcbBoundNotification_C ctcb
      \<and> option_to_ctcb_ptr (tcbSchedPrev atcb) = tcbSchedPrev_C ctcb
-     \<and> option_to_ctcb_ptr (tcbSchedNext atcb) = tcbSchedNext_C ctcb"
+     \<and> option_to_ctcb_ptr (tcbSchedNext atcb) = tcbSchedNext_C ctcb
+     \<and> tcbFlags atcb = flags_C ctcb"
 
 abbreviation
   "ep_queue_relation' \<equiv> tcb_queue_relation' tcbEPNext_C tcbEPPrev_C"

--- a/proof/crefine/ARM_HYP/Tcb_C.thy
+++ b/proof/crefine/ARM_HYP/Tcb_C.thy
@@ -4509,6 +4509,95 @@ lemma decodeSetTLSBase_ccorres:
   apply (auto simp: unat_eq_0 le_max_word_ucast_id)+
   done
 
+lemma invokeTCB_SetFlags_ccorres:
+  notes hoare_weak_lift_imp [wp]
+  shows
+  "ccorres (cintr \<currency> (\<lambda>rv rv'. rv = [])) (liftxf errstate id (K ()) ret__unsigned_long_')
+   (invs' and tcb_at' tcb)
+   (\<lbrace>\<acute>thread = tcb_ptr_to_ctcb_ptr tcb\<rbrace>
+    \<inter> \<lbrace>\<acute>clear = clears\<rbrace>
+    \<inter> \<lbrace>\<acute>set = sets\<rbrace>) []
+   (invokeTCB (SetFlags tcb clears sets))
+   (Call invokeSetFlags_'proc)"
+  apply (cinit lift: thread_' clear_' set_' simp: setFlags_def postSetFlags_def)
+   apply (simp add: liftE_def bind_assoc)
+   apply (rule ccorres_pre_threadGet, rename_tac flags)
+   \<comment> \<open>split off flags_' updates and threadSet\<close>
+   apply (rule ccorres_rhs_assoc2, rule ccorres_rhs_assoc2, rule ccorres_rhs_assoc2)
+   apply (rule ccorres_split_nothrow)
+       apply (rule_tac P="\<lambda>tcb. tcbFlags tcb = flags" in threadSet_ccorres_lemma2)
+        apply vcg
+       apply (clarsimp simp: tcb_at_h_t_valid[OF obj_tcb_at'])
+       apply (erule rf_sr_tcb_update_no_queue2[rotated],
+              (simp add: typ_heap_simps')+, simp_all?)[1]
+        apply (rule ball_tcb_cte_casesI, simp+)
+       apply (clarsimp simp: ctcb_relation_def)
+      apply ceqv
+     apply (rule ccorres_return_CE[folded return_returnOk]; simp)
+    apply (wpsimp simp: guard_is_UNIV_def)+
+   apply vcg
+  apply (clarsimp simp: obj_at'_def typ_heap_simps' ctcb_relation_def)
+  done
+
+lemma decodeSetFlags_ccorres:
+  "ccorres (intr_and_se_rel \<currency> dc) (liftxf errstate id (K ()) ret__unsigned_long_')
+       (invs' and sch_act_simple
+              and (\<lambda>s. ksCurThread s = thread) and ct_active' and K (isThreadCap cp)
+              and valid_cap' cp and (\<lambda>s. \<forall>x \<in> zobj_refs' cp. ex_nonz_cap_to' x s)
+              and sysargs_rel args buffer)
+       (\<lbrace>ccap_relation cp \<acute>cap\<rbrace>
+        \<inter> \<lbrace>unat \<acute>length___unsigned_long = length args\<rbrace>
+        \<inter> \<lbrace>\<acute>buffer = option_to_ptr buffer\<rbrace>) []
+     (decodeSetFlags args cp
+        >>= invocationCatch thread isBlocking isCall InvokeTCB)
+     (Call decodeSetFlags_'proc)"
+  apply (cinit' lift: cap_' length___unsigned_long_' buffer_'
+                simp: decodeSetFlags_def )
+   apply csymbr+
+   apply (rule ccorres_Cond_rhs_Seq)
+    apply (rule ccorres_from_vcg_split_throws[where P=\<top> and P'=UNIV])
+     apply vcg
+    apply (rule conseqPre, vcg)
+    apply (clarsimp simp: throwError_def invocationCatch_def fst_return
+                          intr_and_se_rel_def syscall_error_rel_def
+                          syscall_error_to_H_cases exception_defs
+                   split: list.split)
+    apply unat_arith
+   apply (clarsimp simp: linorder_not_less word_le_nat_alt)
+   apply (rule_tac P="\<lambda>a. ccorres rvr xf P P' hs a c" for rvr xf P P' hs c in ssubst,
+          rule bind_cong [OF _ refl], rule list_case_helper,
+          clarsimp)+
+   apply (rule ccorres_add_return,
+          ctac add: getSyscallArg_ccorres_foo'[where args=args and n=0 and buffer=buffer])
+     apply (rule ccorres_add_return,
+            ctac add: getSyscallArg_ccorres_foo'[where args=args and n=1 and buffer=buffer])
+       apply (simp add: invocationCatch_use_injection_handler
+                        bindE_assoc injection_handler_returnOk
+                        ccorres_invocationCatch_Inr performInvocation_def)
+       apply (ctac add: setThreadState_ccorres)
+         apply (ctac (no_vcg) add: invokeTCB_SetFlags_ccorres)
+           apply simp
+           apply (rule ccorres_alternative2)
+           apply (rule ccorres_return_CE, simp+)[1]
+          apply (rule ccorres_return_C_errorE, simp+)[1]
+         apply (wpsimp wp: sts_invs_minor')+
+       apply (vcg exspec=setThreadState_modifies)
+      apply wpsimp
+     apply (vcg exspec=getSyscallArg_modifies)
+    apply wpsimp
+   apply (vcg exspec=getSyscallArg_modifies)
+  apply (clarsimp simp: Collect_const_mem)
+  apply (rule conjI)
+   apply (clarsimp simp: ct_in_state'_def sysargs_rel_n_def n_msgRegisters_def)
+   apply (auto simp: valid_tcb_state'_def linorder_not_less word_le_nat_alt isCap_simps valid_cap'_def
+              elim!: pred_tcb'_weakenE)[1]
+  apply (simp only: cap_get_tag_isCap[symmetric], drule(1) cap_get_tag_to_H)
+  apply (clarsimp simp: rf_sr_ksCurThread word_sle_def cap_get_tag_isCap cap_get_tag_to_H word_less_nat_alt)
+  apply (subgoal_tac "args \<noteq> []")
+   apply (clarsimp simp: hd_conv_nth)
+  apply clarsimp
+  done
+
 lemma decodeTCBInvocation_ccorres:
   "interpret_excaps extraCaps' = excaps_map extraCaps \<Longrightarrow>
    ccorres (intr_and_se_rel \<currency> dc) (liftxf errstate id (K ()) ret__unsigned_long_')
@@ -4636,6 +4725,12 @@ lemma decodeTCBInvocation_ccorres:
    apply (rule ccorres_Cond_rhs)
     apply (simp add: gen_invocation_type_eq)
     apply (rule ccorres_add_returnOk, ctac(no_vcg) add: decodeSetTLSBase_ccorres)
+      apply (rule ccorres_return_CE, simp+)[1]
+     apply (rule ccorres_return_C_errorE, simp+)[1]
+    apply wp
+   apply (rule ccorres_Cond_rhs)
+    apply (simp add: gen_invocation_type_eq)
+    apply (rule ccorres_add_returnOk, ctac(no_vcg) add: decodeSetFlags_ccorres)
       apply (rule ccorres_return_CE, simp+)[1]
      apply (rule ccorres_return_C_errorE, simp+)[1]
     apply wp

--- a/proof/crefine/Move_C.thy
+++ b/proof/crefine/Move_C.thy
@@ -452,7 +452,7 @@ lemma tcbFault_submonad_args:
 lemma threadGet_stateAssert_gets:
   "threadGet ext t = do stateAssert (tcb_at' t) []; gets (thread_fetch ext t) od"
   apply (rule is_stateAssert_gets [OF _ _ empty_fail_threadGet no_fail_threadGet])
-  apply (wp threadGet_wp | clarsimp simp: obj_at'_def thread_fetch_def)+
+  apply (wp threadGet_wp | clarsimp simp: obj_at'_def thread_fetch_def projectKOs)+
   done
 
 lemma threadGet_tcbFault_submonad_fn:
@@ -490,7 +490,7 @@ lemma is_stateAssert_modify:
 lemma threadSet_stateAssert_modify:
   "threadSet f t = do stateAssert (tcb_at' t) []; modify (thread_replace (\<lambda>_. f) t ()) od"
   apply (rule is_stateAssert_modify [OF _ _ empty_fail_threadSet no_fail_threadSet])
-  apply (wp threadSet_wp | clarsimp simp: obj_at'_def thread_replace_def)+
+  apply (wp threadSet_wp | clarsimp simp: obj_at'_def thread_replace_def projectKOs)+
   done
 
 lemmas asUser_return = submonad.return [OF submonad_asUser]

--- a/proof/crefine/RISCV64/Invoke_C.thy
+++ b/proof/crefine/RISCV64/Invoke_C.thy
@@ -93,9 +93,35 @@ lemma setDomain_ccorres:
                          invs'_def valid_state'_def valid_pspace'_def)
   done
 
+lemma prepareSetDomain_ccorres:
+  "ccorres dc xfdc
+      (invs' and tcb_at' t)
+      (\<lbrace>\<acute>tptr = tcb_ptr_to_ctcb_ptr t\<rbrace> \<inter> \<lbrace>\<acute>dom = ucast d\<rbrace>) []
+      (prepareSetDomain t d) (Call prepareSetDomain_'proc)"
+  apply (cinit lift: tptr_' dom_')
+   apply (rule ccorres_return_Skip)
+  apply clarsimp
+  done
+
 lemma active_runnable':
   "active' state \<Longrightarrow> runnable' state"
   by (fastforce simp: runnable'_def)
+
+lemma invokeDomainSetSet_ccorres:
+  "ccorres dc xfdc
+      (invs' and tcb_at' t and sch_act_simple
+             and (\<lambda>s. d \<le> maxDomain))
+      (\<lbrace>\<acute>tcb = tcb_ptr_to_ctcb_ptr t\<rbrace> \<inter> \<lbrace>\<acute>domain = ucast d\<rbrace>) []
+      (do x <- prepareSetDomain t d;
+               setDomain t d
+       od)
+      (Call invokeDomainSetSet_'proc)"
+  apply (cinit' lift: tcb_' domain_')
+   apply (simp add: liftE_def bind_assoc)
+   apply (ctac (no_vcg) add: prepareSetDomain_ccorres)
+    apply (ctac (no_vcg) add: setDomain_ccorres)
+   apply wpsimp+
+  done
 
 lemma decodeDomainInvocation_ccorres:
   notes Collect_const[simp del]
@@ -179,11 +205,12 @@ lemma decodeDomainInvocation_ccorres:
                                  performInvocation_def liftE_bindE bind_assoc)
        apply (ctac add: setThreadState_ccorres)
          apply csymbr
-         apply (ctac add: setDomain_ccorres)
+         apply (subst bind_assoc[symmetric])
+         apply (ctac add: invokeDomainSetSet_ccorres)
            apply (rule ccorres_alternative2)
            apply (ctac add: ccorres_return_CE)
           apply wp
-         apply (vcg exspec=setDomain_modifies)
+         apply (vcg exspec=invokeDomainSetSet_modifies)
         apply (wp sts_invs_minor')
        apply (vcg exspec=setThreadState_modifies)
       apply wp

--- a/proof/crefine/RISCV64/IsolatedThreadAction.thy
+++ b/proof/crefine/RISCV64/IsolatedThreadAction.thy
@@ -15,11 +15,15 @@ context begin interpretation Arch .
 datatype tcb_state_regs =
   TCBStateRegs (tsrState : thread_state) (tsrContext : "MachineTypes.register \<Rightarrow> machine_word")
 
+definition get_tcb_state_regs_tcb :: "tcb \<Rightarrow> tcb_state_regs" where
+  "get_tcb_state_regs_tcb tcb \<equiv> TCBStateRegs (tcbState tcb) ((user_regs \<circ> atcbContextGet \<circ> tcbArch) tcb)"
+
 definition
   get_tcb_state_regs :: "kernel_object option \<Rightarrow> tcb_state_regs"
 where
- "get_tcb_state_regs oko \<equiv> case oko of
-    Some (KOTCB tcb) \<Rightarrow> TCBStateRegs (tcbState tcb) ((user_regs o atcbContextGet o tcbArch) tcb)"
+ "get_tcb_state_regs oko \<equiv> case oko of Some (KOTCB tcb) \<Rightarrow> get_tcb_state_regs_tcb tcb"
+
+lemmas get_tcb_state_regs_defs = get_tcb_state_regs_def get_tcb_state_regs_tcb_def
 
 definition
   put_tcb_state_regs_tcb :: "tcb_state_regs \<Rightarrow> tcb \<Rightarrow> tcb"
@@ -36,6 +40,8 @@ where
  "put_tcb_state_regs tsr oko = Some (KOTCB (put_tcb_state_regs_tcb tsr
     (case oko of
        Some (KOTCB tcb) \<Rightarrow> tcb | _ \<Rightarrow> makeObject)))"
+
+lemmas put_tcb_state_regs_defs = put_tcb_state_regs_def put_tcb_state_regs_tcb_def
 
 definition
  "partial_overwrite idx tcbs ps \<equiv>
@@ -67,13 +73,11 @@ lemma UserContextGet[simp]:
 lemma put_tcb_state_regs_twice[simp]:
   "put_tcb_state_regs tsr (put_tcb_state_regs tsr' tcb)
     = put_tcb_state_regs tsr tcb"
-  apply (simp add: put_tcb_state_regs_def put_tcb_state_regs_tcb_def
-                   makeObject_tcb newArchTCB_def
+  apply (simp add: put_tcb_state_regs_defs makeObject_tcb newArchTCB_def
             split: tcb_state_regs.split option.split
                    Structures_H.kernel_object.split)
-  apply (intro all_tcbI impI allI)
-   using atcbContextSet_def atcbContext_set_set
-   apply fastforce+
+  using atcbContextSet_def atcbContext_set_set
+  apply (intro all_tcbI impI allI conjI; simp)
   done
 
 lemma partial_overwrite_twice[simp]:
@@ -86,9 +90,8 @@ lemma get_tcb_state_regs_partial_overwrite[simp]:
    get_tcb_state_regs (partial_overwrite idx tcbs f (idx x))
       = tcbs x"
   apply (simp add: partial_overwrite_def)
-  apply (simp add: put_tcb_state_regs_def
-                   get_tcb_state_regs_def
-                   put_tcb_state_regs_tcb_def
+  apply (simp add: put_tcb_state_regs_defs
+                   get_tcb_state_regs_defs
             split: tcb_state_regs.split)
   done
 
@@ -166,14 +169,13 @@ context begin interpretation Arch . (*FIXME: arch-split*)
 lemma get_tcb_state_regs_ko_at':
   "ko_at' ko p s \<Longrightarrow> get_tcb_state_regs (ksPSpace s p)
        = TCBStateRegs (tcbState ko) ((user_regs o atcbContextGet o tcbArch) ko)"
-  by (clarsimp simp: obj_at'_def projectKOs get_tcb_state_regs_def)
+  by (clarsimp simp: obj_at'_def get_tcb_state_regs_defs projectKOs)
 
 lemma put_tcb_state_regs_ko_at':
   "ko_at' ko p s \<Longrightarrow> put_tcb_state_regs tsr (ksPSpace s p)
        = Some (KOTCB (ko \<lparr> tcbState := tsrState tsr
                          , tcbArch := atcbContextSet (UserContext (tsrContext tsr)) (tcbArch ko)\<rparr>))"
-  by (clarsimp simp: obj_at'_def projectKOs put_tcb_state_regs_def
-                     put_tcb_state_regs_tcb_def
+  by (clarsimp simp: obj_at'_def put_tcb_state_regs_defs projectKOs
               split: tcb_state_regs.split)
 
 lemma partial_overwrite_get_tcb_state_regs:
@@ -184,8 +186,7 @@ lemma partial_overwrite_get_tcb_state_regs:
                       split: if_split)
   apply clarsimp
   apply (drule_tac x=xa in spec)
-  apply (clarsimp simp: obj_at'_def projectKOs put_tcb_state_regs_def
-                        get_tcb_state_regs_def put_tcb_state_regs_tcb_def)
+  apply (clarsimp simp: obj_at'_def put_tcb_state_regs_defs get_tcb_state_regs_defs projectKOs)
   apply (case_tac obj, simp)
   done
 
@@ -274,10 +275,9 @@ lemma map_to_ctes_partial_overwrite:
   apply (case_tac "x \<in> range idx")
    apply (clarsimp simp: put_tcb_state_regs_def)
    apply (drule_tac x=xa in spec)
-   apply (clarsimp simp: obj_at'_def projectKOs objBits_simps'
+   apply (clarsimp simp: obj_at'_def objBits_simps'
                    cong: if_cong)
-   apply (simp add: put_tcb_state_regs_def put_tcb_state_regs_tcb_def
-                    objBits_simps'
+   apply (simp add: put_tcb_state_regs_tcb_def objBits_simps'
               cong: if_cong option.case_cong)
    apply (case_tac obj, simp split: tcb_state_regs.split if_split)
   apply simp
@@ -286,10 +286,9 @@ lemma map_to_ctes_partial_overwrite:
   apply (case_tac "x && ~~ mask (objBitsKO (KOTCB undefined)) \<in> range idx")
    apply (clarsimp simp: put_tcb_state_regs_def)
    apply (drule_tac x=xa in spec)
-   apply (clarsimp simp: obj_at'_def projectKOs objBits_simps'
+   apply (clarsimp simp: obj_at'_def objBits_simps'
                    cong: if_cong)
-   apply (simp add: put_tcb_state_regs_def put_tcb_state_regs_tcb_def
-                    objBits_simps'
+   apply (simp add: put_tcb_state_regs_tcb_def objBits_simps'
               cong: if_cong option.case_cong)
    apply (case_tac obj, simp split: tcb_state_regs.split if_split)
    apply (intro impI allI)
@@ -914,8 +913,8 @@ lemma oblivious_switchToThread_schact:
                    threadSet_def tcbSchedEnqueue_def unless_when asUser_def
                    getQueue_def setQueue_def storeWordUser_def setRegister_def
                    pointerInUserData_def isRunnable_def isStopped_def
-                   getThreadState_def tcbSchedDequeue_def tcbQueueRemove_def bitmap_fun_defs
-                   ksReadyQueues_asrt_def)
+                   getThreadState_def tcbSchedDequeue_def bitmap_fun_defs
+                   tcbQueueRemove_def ksReadyQueues_asrt_def)
   by (safe intro!: oblivious_bind
               | simp_all add: ready_qs_runnable_def idleThreadNotQueued_def
                               oblivious_setVMRoot_schact)+
@@ -1138,8 +1137,7 @@ lemma setCTE_isolatable:
     apply (rule ext)
     apply (clarsimp simp: partial_overwrite_get_tcb_state_regs
                    split: if_split)
-    apply (clarsimp simp: projectKOs get_tcb_state_regs_def
-                          put_tcb_state_regs_def put_tcb_state_regs_tcb_def
+    apply (clarsimp simp: projectKOs get_tcb_state_regs_defs put_tcb_state_regs_defs
                           partial_overwrite_def
                    split: tcb_state_regs.split)
     apply (case_tac obj, simp add: projectKO_opt_tcb)
@@ -1220,8 +1218,7 @@ lemma isolate_thread_actions_threadSet_tcbState:
                 intro!: kernel_state.fold_congs[OF refl refl])
   apply (simp add: partial_overwrite_fun_upd
                    partial_overwrite_get_tcb_state_regs)
-  apply (clarsimp simp: put_tcb_state_regs_def put_tcb_state_regs_tcb_def
-                        projectKOs get_tcb_state_regs_def
+  apply (clarsimp simp: put_tcb_state_regs_defs projectKOs get_tcb_state_regs_defs
                  elim!: obj_atE')
   apply (case_tac ko)
   apply (simp add: projectKO_opt_tcb)
@@ -1250,7 +1247,7 @@ lemma switchToThread_rewrite:
        (switchToThread t)
        (do Arch.switchToThread t; setCurThread t od)"
   apply (simp add: switchToThread_def Thread_H.switchToThread_def)
-  apply (monadic_rewrite_l tcbSchedDequeue_rewrite, simp)
+  apply (monadic_rewrite_l tcbSchedDequeue_rewrite \<open>wpsimp simp: o_def\<close>, simp)
    (* strip LHS of getters and asserts until LHS and RHS are the same *)
    apply (repeat_unless \<open>rule monadic_rewrite_refl\<close> monadic_rewrite_symb_exec_l)
       apply wpsimp+
@@ -1278,17 +1275,13 @@ lemma threadGet_isolatable:
   apply (simp add: projectKO_opt_tcb v split: if_split)
   done
 
- lemma switchToThread_isolatable:
+lemma switchToThread_isolatable:
   "thread_actions_isolatable idx (Arch.switchToThread t)"
-  apply (simp add: switchToThread_def
-                   storeWordUser_def stateAssert_def2)
+  apply (simp add: switchToThread_def)
   apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
-               gets_isolatable setVMRoot_isolatable
-               thread_actions_isolatable_if
+               setVMRoot_isolatable
                doMachineOp_isolatable
-               threadGet_isolatable [OF all_tcbI]
-               thread_actions_isolatable_returns
-               thread_actions_isolatable_fail)
+               threadGet_isolatable [OF all_tcbI])
   done
 
 lemma tcbQueued_put_tcb_state_regs_tcb:
@@ -1399,12 +1392,11 @@ lemma set_register_isolate:
                         partial_overwrite_fun_upd
                         partial_overwrite_get_tcb_state_regs)
   apply (drule_tac x=y in spec)
-  apply (clarsimp simp: obj_at'_def projectKOs objBits_simps
+  apply (clarsimp simp: obj_at'_def objBits_simps
                   cong: if_cong)
   apply (case_tac obj)
-  apply (simp add: projectKO_opt_tcb put_tcb_state_regs_def
-                   put_tcb_state_regs_tcb_def get_tcb_state_regs_def
-                   atcbContextGet_def
+  apply (simp add: projectKO_opt_tcb put_tcb_state_regs_defs
+                   get_tcb_state_regs_defs atcbContextGet_def
              cong: if_cong)
   done
 
@@ -1435,9 +1427,8 @@ lemma copy_register_isolate:
   apply (clarsimp simp: obj_at'_def projectKOs objBits_simps
                   cong: if_cong)
   apply (case_tac obj, case_tac obja)
-  apply (simp add: projectKO_opt_tcb put_tcb_state_regs_def
-                   put_tcb_state_regs_tcb_def get_tcb_state_regs_def
-                   atcbContextGet_def
+  apply (simp add: projectKO_opt_tcb put_tcb_state_regs_defs
+                   get_tcb_state_regs_defs atcbContextGet_def
              cong: if_cong)
   apply (auto simp: fun_eq_iff split: if_split)
   done

--- a/proof/crefine/RISCV64/Machine_C.thy
+++ b/proof/crefine/RISCV64/Machine_C.thy
@@ -81,6 +81,7 @@ assumes isIRQPending_ccorres:
 assumes getActiveIRQ_Normal:
   "\<Gamma> \<turnstile> \<langle>Call getActiveIRQ_'proc, Normal s\<rangle> \<Rightarrow> s' \<Longrightarrow> isNormal s'"
 
+
 (* The following are fastpath specific assumptions.
    We might want to move them somewhere else. *)
 

--- a/proof/crefine/RISCV64/Recycle_C.thy
+++ b/proof/crefine/RISCV64/Recycle_C.thy
@@ -1105,7 +1105,7 @@ lemma coerce_memset_to_heap_update:
       = heap_update (tcb_Ptr x)
              (tcb_C.tcb_C (arch_tcb_C (user_context_C (FCP (\<lambda>x. 0))))
                           (thread_state_C (FCP (\<lambda>x. 0)))
-                          (NULL)
+                          0 NULL
                           (seL4_Fault_C (FCP (\<lambda>x. 0)))
                           (lookup_fault_C (FCP (\<lambda>x. 0)))
                             0 0 0 0 0 0 NULL NULL NULL NULL)"

--- a/proof/crefine/RISCV64/Retype_C.thy
+++ b/proof/crefine/RISCV64/Retype_C.thy
@@ -3290,7 +3290,9 @@ proof -
        tcbFaultHandler_C := 0, tcbIPCBuffer_C := 0,
        tcbSchedNext_C := tcb_Ptr 0, tcbSchedPrev_C := tcb_Ptr 0,
        tcbEPNext_C := tcb_Ptr 0, tcbEPPrev_C := tcb_Ptr 0,
-       tcbBoundNotification_C := ntfn_Ptr 0\<rparr>"
+       tcbBoundNotification_C := ntfn_Ptr 0,
+       flags_C := 0\<rparr>"
+
   have fbtcb: "from_bytes (replicate (size_of TYPE(tcb_C)) 0) = ?tcb"
     apply (simp add: from_bytes_def)
     apply (simp add: typ_info_simps tcb_C_tag_def)

--- a/proof/crefine/RISCV64/SR_lemmas_C.thy
+++ b/proof/crefine/RISCV64/SR_lemmas_C.thy
@@ -307,12 +307,12 @@ lemma cmdbnode_relation_mdb_node_to_H [simp]:
 definition tcb_no_ctes_proj ::
   "tcb \<Rightarrow> Structures_H.thread_state \<times> machine_word \<times> machine_word \<times> arch_tcb \<times> bool \<times> word8
           \<times> word8 \<times> word8 \<times> nat \<times> fault option \<times> machine_word option
-          \<times> machine_word option \<times> machine_word option"
+          \<times> machine_word option \<times> machine_word option \<times> machine_word"
   where
   "tcb_no_ctes_proj t \<equiv>
      (tcbState t, tcbFaultHandler t, tcbIPCBuffer t, tcbArch t, tcbQueued t,
       tcbMCP t, tcbPriority t, tcbDomain t, tcbTimeSlice t, tcbFault t, tcbBoundNotification t,
-      tcbSchedNext t, tcbSchedPrev t)"
+      tcbSchedNext t, tcbSchedPrev t, tcbFlags t)"
 
 lemma tcb_cte_cases_proj_eq [simp]:
   "tcb_cte_cases p = Some (getF, setF) \<Longrightarrow>

--- a/proof/crefine/RISCV64/StateRelation_C.thy
+++ b/proof/crefine/RISCV64/StateRelation_C.thy
@@ -363,7 +363,8 @@ where
                   (lookup_fault_lift (tcbLookupFailure_C ctcb))
      \<and> option_to_ptr (tcbBoundNotification atcb) = tcbBoundNotification_C ctcb
      \<and> option_to_ctcb_ptr (tcbSchedPrev atcb) = tcbSchedPrev_C ctcb
-     \<and> option_to_ctcb_ptr (tcbSchedNext atcb) = tcbSchedNext_C ctcb"
+     \<and> option_to_ctcb_ptr (tcbSchedNext atcb) = tcbSchedNext_C ctcb
+     \<and> tcbFlags atcb = flags_C ctcb"
 
 abbreviation
   "ep_queue_relation' \<equiv> tcb_queue_relation' tcbEPNext_C tcbEPPrev_C"

--- a/proof/crefine/RISCV64/Tcb_C.thy
+++ b/proof/crefine/RISCV64/Tcb_C.thy
@@ -4508,6 +4508,95 @@ lemma decodeSetTLSBase_ccorres:
   apply (auto simp: unat_eq_0 le_max_word_ucast_id)+
   done
 
+lemma invokeTCB_SetFlags_ccorres:
+  notes hoare_weak_lift_imp [wp]
+  shows
+  "ccorres (cintr \<currency> (\<lambda>rv rv'. rv = [])) (liftxf errstate id (K ()) ret__unsigned_long_')
+   (invs' and tcb_at' tcb)
+   (\<lbrace>\<acute>thread = tcb_ptr_to_ctcb_ptr tcb\<rbrace>
+    \<inter> \<lbrace>\<acute>clear = clears\<rbrace>
+    \<inter> \<lbrace>\<acute>set = sets\<rbrace>) []
+   (invokeTCB (SetFlags tcb clears sets))
+   (Call invokeSetFlags_'proc)"
+  apply (cinit lift: thread_' clear_' set_' simp: setFlags_def postSetFlags_def)
+   apply (simp add: liftE_def bind_assoc)
+   apply (rule ccorres_pre_threadGet, rename_tac flags)
+   \<comment> \<open>split off flags_' updates and threadSet\<close>
+   apply (rule ccorres_rhs_assoc2, rule ccorres_rhs_assoc2, rule ccorres_rhs_assoc2)
+   apply (rule ccorres_split_nothrow)
+       apply (rule_tac P="\<lambda>tcb. tcbFlags tcb = flags" in threadSet_ccorres_lemma2)
+        apply vcg
+       apply (clarsimp simp: tcb_at_h_t_valid[OF obj_tcb_at'])
+       apply (erule rf_sr_tcb_update_no_queue2[rotated],
+              (simp add: typ_heap_simps')+, simp_all?)[1]
+        apply (rule ball_tcb_cte_casesI, simp+)
+       apply (clarsimp simp: ctcb_relation_def)
+      apply ceqv
+     apply (rule ccorres_return_CE[folded return_returnOk]; simp)
+    apply (wpsimp simp: guard_is_UNIV_def)+
+   apply vcg
+  apply (clarsimp simp: obj_at'_def typ_heap_simps' ctcb_relation_def)
+  done
+
+lemma decodeSetFlags_ccorres:
+  "ccorres (intr_and_se_rel \<currency> dc) (liftxf errstate id (K ()) ret__unsigned_long_')
+       (invs' and sch_act_simple
+              and (\<lambda>s. ksCurThread s = thread) and ct_active' and K (isThreadCap cp)
+              and valid_cap' cp and (\<lambda>s. \<forall>x \<in> zobj_refs' cp. ex_nonz_cap_to' x s)
+              and sysargs_rel args buffer)
+       (\<lbrace>ccap_relation cp \<acute>cap\<rbrace>
+        \<inter> \<lbrace>unat \<acute>length___unsigned_long = length args\<rbrace>
+        \<inter> \<lbrace>\<acute>buffer = option_to_ptr buffer\<rbrace>) []
+     (decodeSetFlags args cp
+        >>= invocationCatch thread isBlocking isCall InvokeTCB)
+     (Call decodeSetFlags_'proc)"
+  apply (cinit' lift: cap_' length___unsigned_long_' buffer_'
+                simp: decodeSetFlags_def )
+   apply csymbr+
+   apply (rule ccorres_Cond_rhs_Seq)
+    apply (rule ccorres_from_vcg_split_throws[where P=\<top> and P'=UNIV])
+     apply vcg
+    apply (rule conseqPre, vcg)
+    apply (clarsimp simp: throwError_def invocationCatch_def fst_return
+                          intr_and_se_rel_def syscall_error_rel_def
+                          syscall_error_to_H_cases exception_defs
+                   split: list.split)
+    apply unat_arith
+   apply (clarsimp simp: linorder_not_less word_le_nat_alt)
+   apply (rule_tac P="\<lambda>a. ccorres rvr xf P P' hs a c" for rvr xf P P' hs c in ssubst,
+          rule bind_cong [OF _ refl], rule list_case_helper,
+          clarsimp)+
+   apply (rule ccorres_add_return,
+          ctac add: getSyscallArg_ccorres_foo'[where args=args and n=0 and buffer=buffer])
+     apply (rule ccorres_add_return,
+            ctac add: getSyscallArg_ccorres_foo'[where args=args and n=1 and buffer=buffer])
+       apply (simp add: invocationCatch_use_injection_handler
+                        bindE_assoc injection_handler_returnOk
+                        ccorres_invocationCatch_Inr performInvocation_def)
+       apply (ctac add: setThreadState_ccorres)
+         apply (ctac (no_vcg) add: invokeTCB_SetFlags_ccorres)
+           apply simp
+           apply (rule ccorres_alternative2)
+           apply (rule ccorres_return_CE, simp+)[1]
+          apply (rule ccorres_return_C_errorE, simp+)[1]
+         apply (wpsimp wp: sts_invs_minor')+
+       apply (vcg exspec=setThreadState_modifies)
+      apply wpsimp
+     apply (vcg exspec=getSyscallArg_modifies)
+    apply wpsimp
+   apply (vcg exspec=getSyscallArg_modifies)
+  apply (clarsimp simp: Collect_const_mem)
+  apply (rule conjI)
+   apply (clarsimp simp: ct_in_state'_def sysargs_rel_n_def n_msgRegisters_def)
+   apply (auto simp: valid_tcb_state'_def linorder_not_less word_le_nat_alt isCap_simps valid_cap'_def
+              elim!: pred_tcb'_weakenE)[1]
+  apply (simp only: cap_get_tag_isCap[symmetric], drule(1) cap_get_tag_to_H)
+  apply (clarsimp simp: rf_sr_ksCurThread word_sle_def cap_get_tag_isCap cap_get_tag_to_H word_less_nat_alt)
+  apply (subgoal_tac "args \<noteq> []")
+   apply (clarsimp simp: hd_conv_nth)
+  apply clarsimp
+  done
+
 lemma decodeTCBInvocation_ccorres:
   "interpret_excaps extraCaps' = excaps_map extraCaps \<Longrightarrow>
    ccorres (intr_and_se_rel \<currency> dc) (liftxf errstate id (K ()) ret__unsigned_long_')
@@ -4635,6 +4724,12 @@ lemma decodeTCBInvocation_ccorres:
    apply (rule ccorres_Cond_rhs)
     apply (simp add: gen_invocation_type_eq)
     apply (rule ccorres_add_returnOk, ctac(no_vcg) add: decodeSetTLSBase_ccorres)
+      apply (rule ccorres_return_CE, simp+)[1]
+     apply (rule ccorres_return_C_errorE, simp+)[1]
+    apply wp
+   apply (rule ccorres_Cond_rhs)
+    apply (simp add: gen_invocation_type_eq)
+    apply (rule ccorres_add_returnOk, ctac(no_vcg) add: decodeSetFlags_ccorres)
       apply (rule ccorres_return_CE, simp+)[1]
      apply (rule ccorres_return_C_errorE, simp+)[1]
     apply wp

--- a/proof/crefine/X64/ArchMove_C.thy
+++ b/proof/crefine/X64/ArchMove_C.thy
@@ -96,13 +96,16 @@ lemma prio_ucast_shiftr_wordRadix_helper3:
 
 lemmas setEndpoint_obj_at_tcb' = setEndpoint_obj_at'_tcb
 
+crunch lazyFpuRestore
+  for tcbQueued[wp]: "obj_at' (\<lambda>tcb. P (tcbQueued tcb)) t'"
+
 (* FIXME: Move to Schedule_R.thy. Make Arch_switchToThread_obj_at a specialisation of this *)
 lemma Arch_switchToThread_obj_at_pre:
   "\<lbrace>obj_at' (Not \<circ> tcbQueued) t\<rbrace>
    Arch.switchToThread t
    \<lbrace>\<lambda>rv. obj_at' (Not \<circ> tcbQueued) t\<rbrace>"
-  apply (simp add: X64_H.switchToThread_def)
-  apply (wp asUser_obj_at_notQ doMachineOp_obj_at hoare_drop_imps|wpc)+
+  unfolding X64_H.switchToThread_def
+  apply (wpsimp wp: asUser_obj_at_notQ doMachineOp_obj_at hoare_drop_imps simp: comp_def)
   done
 
 crunch setThreadState
@@ -267,10 +270,6 @@ lemma setVMRoot_valid_arch_state':
          | strengthen valid_cr3'_makeCR3)+
   done
 
-crunch switchToThread
-  for valid_arch_state'[wp]: valid_arch_state'
-  (wp: crunch_wps simp: crunch_simps)
-
 lemma mab_gt_2 [simp]:
   "2 \<le> msg_align_bits" by (simp add: msg_align_bits)
 
@@ -297,7 +296,7 @@ lemma threadGet_tcbFault_loadWordUser_comm:
                           ps_clear_upd ps_clear_upd_None pointerInUserData_def
                    split: option.split kernel_object.split)
    apply (simp add: get_def empty_fail_def)
-  apply (simp add: ef_loadWord)
+  apply simp
   done
 
 lemma threadGet_tcbFault_storeWordUser_comm:
@@ -313,7 +312,7 @@ lemma threadGet_tcbFault_storeWordUser_comm:
                           ps_clear_upd ps_clear_upd_None pointerInUserData_def
                    split: option.split kernel_object.split)
    apply (simp add: get_def empty_fail_def)
-  apply (simp add: ef_storeWord)
+  apply simp
   done
 
 lemma asUser_getRegister_discarded:
@@ -462,7 +461,7 @@ lemma length_msgRegisters[simplified size_msgRegisters_def]:
 
 lemma empty_fail_loadWordUser[intro!, simp]:
   "empty_fail (loadWordUser x)"
-  by (fastforce simp: loadWordUser_def ef_loadWord ef_dmo')
+  by (fastforce simp: loadWordUser_def ef_dmo')
 
 lemma empty_fail_getMRs[iff]:
   "empty_fail (getMRs t buf mi)"

--- a/proof/crefine/X64/Arch_C.thy
+++ b/proof/crefine/X64/Arch_C.thy
@@ -119,7 +119,6 @@ lemma performPageTableInvocationUnmap_ccorres:
                              cap_page_table_cap_lift_def)
       apply simp
      apply (clarsimp simp: carch_state_relation_def cmachine_state_relation_def
-                           fpu_null_state_heap_update_tag_disj_simps
                            global_ioport_bitmap_heap_update_tag_disj_simps
                            cvariable_array_map_const_add_map_option[where f="tcb_no_ctes_proj"]
                     dest!: ksPSpace_update_eq_ExD)
@@ -182,7 +181,6 @@ lemma clearMemory_setObject_PDE_ccorres:
     subgoal by (simp add: cpde_relation_def Let_def pde_lift_def pde_get_tag_def pde_tag_defs
                    split: if_splits pde.split_asm)
    apply (simp add: carch_state_relation_def cmachine_state_relation_def
-                    fpu_null_state_heap_update_tag_disj_simps
                     global_ioport_bitmap_heap_update_tag_disj_simps
                     update_pde_map_tos)
   apply simp
@@ -261,7 +259,6 @@ lemma performPageDirectoryInvocationUnmap_ccorres:
                              cap_page_directory_cap_lift_def)
       apply simp
      apply (clarsimp simp: carch_state_relation_def cmachine_state_relation_def
-                           fpu_null_state_heap_update_tag_disj_simps
                            global_ioport_bitmap_heap_update_tag_disj_simps
                            cvariable_array_map_const_add_map_option[where f="tcb_no_ctes_proj"]
                     dest!: ksPSpace_update_eq_ExD)
@@ -324,7 +321,6 @@ lemma clearMemory_setObject_PDPTE_ccorres:
     subgoal by (simp add: cpdpte_relation_def Let_def pdpte_lift_def pdpte_get_tag_def pdpte_tag_defs
                    split: if_splits pdpte.split_asm)
    apply (simp add: carch_state_relation_def cmachine_state_relation_def
-                    fpu_null_state_heap_update_tag_disj_simps
                     global_ioport_bitmap_heap_update_tag_disj_simps
                     update_pdpte_map_tos)
   apply simp
@@ -403,7 +399,6 @@ lemma performPDPTInvocationUnmap_ccorres:
                              cap_pdpt_cap_lift_def)
       apply simp
      apply (clarsimp simp: carch_state_relation_def cmachine_state_relation_def
-                           fpu_null_state_heap_update_tag_disj_simps
                            global_ioport_bitmap_heap_update_tag_disj_simps
                            cvariable_array_map_const_add_map_option[where f="tcb_no_ctes_proj"]
                     dest!: ksPSpace_update_eq_ExD)
@@ -624,8 +619,7 @@ proof -
   thus ?thesis using rf empty kdr zro
     apply (simp add: rf_sr_def cstate_relation_def Let_def rl' tag_disj_via_td_name
                      ko_def[symmetric])
-    apply (simp add: carch_state_relation_def cmachine_state_relation_def
-                     fpu_null_state_relation_def)
+    apply (simp add: carch_state_relation_def cmachine_state_relation_def)
     apply (simp add: rl' cterl tag_disj_via_td_name h_t_valid_clift_Some_iff tcb_C_size)
     apply (clarsimp simp: hrs_htd_update ptr_retyps_htd_safe_neg szo szko
                           kernel_data_refs_domain_eq_rotate

--- a/proof/crefine/X64/CSpace_C.thy
+++ b/proof/crefine/X64/CSpace_C.thy
@@ -439,8 +439,7 @@ lemma ccorres_updateCap [corres]:
    apply (rule conjI)
     apply (erule (1) setCTE_tcb_case)
    by (auto simp: carch_state_relation_def cmachine_state_relation_def
-                  global_ioport_bitmap_heap_update_tag_disj_simps
-                  fpu_null_state_heap_update_tag_disj_simps)
+                  global_ioport_bitmap_heap_update_tag_disj_simps)
 
 lemma ccorres_updateMDB_const [corres]:
   fixes ptr :: "cstate \<Rightarrow> cte_C ptr" and val :: "cstate \<Rightarrow> mdb_node_C"
@@ -477,8 +476,7 @@ lemma ccorres_updateMDB_const [corres]:
    apply (rule conjI)
     apply (erule (1) setCTE_tcb_case)
    by (auto simp: carch_state_relation_def cmachine_state_relation_def
-                  global_ioport_bitmap_heap_update_tag_disj_simps
-                  fpu_null_state_heap_update_tag_disj_simps)
+                  global_ioport_bitmap_heap_update_tag_disj_simps)
 
 (* 64 == badgeBits *)
 lemma cap_lift_capNtfnBadge_mask_eq:
@@ -636,8 +634,7 @@ lemma ccorres_updateMDB_set_mdbNext [corres]:
    apply (rule conjI)
     apply (erule (1) setCTE_tcb_case)
    by (auto simp: carch_state_relation_def cmachine_state_relation_def
-                  global_ioport_bitmap_heap_update_tag_disj_simps
-                  fpu_null_state_heap_update_tag_disj_simps)
+                  global_ioport_bitmap_heap_update_tag_disj_simps)
 
 lemma ccorres_updateMDB_set_mdbPrev [corres]:
   "src=src' \<Longrightarrow>
@@ -679,7 +676,6 @@ lemma ccorres_updateMDB_set_mdbPrev [corres]:
     apply (simp add: cmdbnode_relation_def mask_def)
    apply (erule_tac t = s'a in ssubst)
    apply (simp add: carch_state_relation_def cmachine_state_relation_def
-                    fpu_null_state_heap_update_tag_disj_simps
                     global_ioport_bitmap_heap_update_tag_disj_simps)
    apply (erule (1) setCTE_tcb_case)
   by clarsimp
@@ -812,7 +808,6 @@ lemma update_freeIndex':
        apply (rule conjI)
         subgoal by (erule (1) setCTE_tcb_case)
        apply (clarsimp simp: carch_state_relation_def cmachine_state_relation_def
-                             fpu_null_state_heap_update_tag_disj_simps
                              global_ioport_bitmap_heap_update_tag_disj_simps
                              packed_heap_update_collapse_hrs)
       by (clarsimp simp: cte_wp_at_ctes_of)
@@ -1500,7 +1495,6 @@ lemma emptySlot_helper:
       prefer 2
       apply (erule_tac t = s' in ssubst)
       apply (simp add: carch_state_relation_def cmachine_state_relation_def
-                       fpu_null_state_heap_update_tag_disj_simps
                        cvariable_array_map_const_add_map_option[where f="tcb_no_ctes_proj"]
                        h_t_valid_clift_Some_iff typ_heap_simps'
                  cong: lifth_update)
@@ -1531,7 +1525,6 @@ lemma emptySlot_helper:
     prefer 2
     apply (erule_tac t = s' in ssubst)
     apply (simp add: carch_state_relation_def cmachine_state_relation_def
-                     fpu_null_state_heap_update_tag_disj_simps
                      cvariable_array_map_const_add_map_option[where f="tcb_no_ctes_proj"]
                      typ_heap_simps' h_t_valid_clift_Some_iff
                cong: lifth_update)
@@ -2394,8 +2387,7 @@ lemma setIOPortMask_ccorres:
                         monad_simps in_monad
                         hrs_mem_update h_val_heap_modify
                         clift_heap_modify_same tag_disj_via_td_name
-                        cpspace_relation_def carch_globals_def cmachine_state_relation_def
-                        fpu_null_state_relation_def)
+                        cpspace_relation_def carch_globals_def cmachine_state_relation_def)
   apply (match premises in H: \<open>cioport_bitmap_to_H _ = _\<close> and O: \<open>low_' s \<le> high_' s\<close> for s
            \<Rightarrow> \<open>match premises in _[thin]: _(multi) \<Rightarrow> \<open>insert O H\<close>\<close>)
   apply (clarsimp simp: cioport_bitmap_to_H_def wordRadix_def, rule ext, drule_tac x=port in fun_cong)

--- a/proof/crefine/X64/Detype_C.thy
+++ b/proof/crefine/X64/Detype_C.thy
@@ -1736,23 +1736,6 @@ proof -
   }
 
   moreover
-  {
-    assume "s' \<Turnstile>\<^sub>c fpu_state_Ptr (symbol_table ''x86KSnullFpuState'')"
-    moreover
-    have "ptr_span (fpu_state_Ptr (symbol_table ''x86KSnullFpuState''))
-             \<inter> {ptr..ptr + 2 ^ bits - 1} = {}"
-      using sr ptr_refs by (fastforce simp: rf_sr_def cstate_relation_def Let_def
-                                            carch_state_relation_def fpu_null_state_relation_def)
-    ultimately
-    have "hrs_htd (hrs_htd_update (typ_region_bytes ptr bits) (t_hrs_' (globals s')))
-            \<Turnstile>\<^sub>t fpu_state_Ptr (symbol_table ''x86KSnullFpuState'')"
-      using al wb
-      apply (cases "t_hrs_' (globals s')")
-      apply (simp add: hrs_htd_update_def hrs_htd_def h_t_valid_typ_region_bytes upto_intvl_eq)
-      done
-  }
-
-  moreover
   have h2ud_eq:
        "heap_to_user_data (?psu (ksPSpace s))
                           (?mmu (underlying_memory (ksMachineState s))) =
@@ -1936,8 +1919,7 @@ proof -
     using sr untyped_cap_rf_sr_ptr_bits_domain[OF cte invs sr]
     by (simp add: rf_sr_def cstate_relation_def Let_def clift
                   psu_restrict cpspace_relation_def global_ioport_bitmap_relation_def2
-                  carch_state_relation_def fpu_null_state_relation_def2
-                  cmachine_state_relation_def
+                  carch_state_relation_def cmachine_state_relation_def
                   hrs_htd_update htd_safe_typ_region_bytes
                   zero_ranges_are_zero_typ_region_bytes)
 

--- a/proof/crefine/X64/Invoke_C.thy
+++ b/proof/crefine/X64/Invoke_C.thy
@@ -92,9 +92,43 @@ lemma setDomain_ccorres:
                          invs'_def valid_state'_def valid_pspace'_def)
   done
 
+lemma prepareSetDomain_ccorres:
+  "ccorres dc xfdc
+      (invs' and tcb_at' t)
+      (\<lbrace>\<acute>tptr = tcb_ptr_to_ctcb_ptr t\<rbrace> \<inter> \<lbrace>\<acute>dom = ucast d\<rbrace>) []
+      (prepareSetDomain t d) (Call prepareSetDomain_'proc)"
+  apply (cinit lift: tptr_' dom_')
+   apply (rule ccorres_pre_curDomain)
+   apply (rule_tac C'="{s. curDom \<noteq> ucast d}"
+               and Q="\<lambda>s. curDom = ksCurDomain s"
+               and Q'=UNIV
+                in ccorres_rewrite_cond_sr)
+    apply (clarsimp simp: rf_sr_ksCurDomain)
+   apply (rule ccorres_when[where R=\<top>])
+    apply clarsimp
+   apply (ctac add: fpuRelease_ccorres)
+  apply clarsimp
+  done
+
 lemma active_runnable':
   "active' state \<Longrightarrow> runnable' state"
   by (fastforce simp: runnable'_def)
+
+lemma invokeDomainSetSet_ccorres:
+  "ccorres dc xfdc
+      (invs' and tcb_at' t and sch_act_simple
+             and (\<lambda>s. d \<le> maxDomain))
+      (\<lbrace>\<acute>tcb = tcb_ptr_to_ctcb_ptr t\<rbrace> \<inter> \<lbrace>\<acute>domain = ucast d\<rbrace>) []
+      (do x <- prepareSetDomain t d;
+               setDomain t d
+       od)
+      (Call invokeDomainSetSet_'proc)"
+  apply (cinit' lift: tcb_' domain_')
+   apply (simp add: liftE_def bind_assoc)
+   apply (ctac (no_vcg) add: prepareSetDomain_ccorres)
+    apply (ctac (no_vcg) add: setDomain_ccorres)
+   apply wpsimp+
+  done
 
 lemma decodeDomainInvocation_ccorres:
   notes Collect_const[simp del]
@@ -178,11 +212,12 @@ lemma decodeDomainInvocation_ccorres:
                                  performInvocation_def liftE_bindE bind_assoc)
        apply (ctac add: setThreadState_ccorres)
          apply csymbr
-         apply (ctac add: setDomain_ccorres)
+         apply (subst bind_assoc[symmetric])
+         apply (ctac add: invokeDomainSetSet_ccorres)
            apply (rule ccorres_alternative2)
            apply (ctac add: ccorres_return_CE)
           apply wp
-         apply (vcg exspec=setDomain_modifies)
+         apply (vcg exspec=invokeDomainSetSet_modifies)
         apply (wp sts_invs_minor')
        apply (vcg exspec=setThreadState_modifies)
       apply wp

--- a/proof/crefine/X64/IpcCancel_C.thy
+++ b/proof/crefine/X64/IpcCancel_C.thy
@@ -222,9 +222,7 @@ lemma cancelSignal_ccorres_helper:
          apply (simp add: cnotification_relation_def Let_def NtfnState_Idle_def)
          apply (simp add: carch_state_relation_def carch_globals_def)
         apply (clarsimp simp: carch_state_relation_def carch_globals_def
-                              typ_heap_simps' packed_heap_update_collapse_hrs
-                              fpu_null_state_heap_update_tag_disj_simps
-                       elim!: fpu_null_state_typ_heap_preservation)
+                              typ_heap_simps' packed_heap_update_collapse_hrs)
        apply (simp add: cmachine_state_relation_def)
       apply (simp add: h_t_valid_clift_Some_iff)
      apply (simp add: objBits_simps')
@@ -269,9 +267,7 @@ lemma cancelSignal_ccorres_helper:
          apply simp
         apply simp
        subgoal by (clarsimp simp: carch_state_relation_def carch_globals_def
-                                  fpu_null_state_heap_update_tag_disj_simps
-                                  global_ioport_bitmap_heap_update_tag_disj_simps
-                           elim!: fpu_null_state_typ_heap_preservation)
+                                  global_ioport_bitmap_heap_update_tag_disj_simps)
       subgoal by (simp add: cmachine_state_relation_def)
      subgoal by (simp add: h_t_valid_clift_Some_iff)
     subgoal by (simp add: objBits_simps')
@@ -2613,10 +2609,8 @@ lemma cancelIPC_ccorres_helper:
          apply (erule (1) map_to_ko_atI')
         apply (simp add: heap_to_user_data_def Let_def)
         subgoal by (clarsimp simp: carch_state_relation_def carch_globals_def
-                                   fpu_null_state_heap_update_tag_disj_simps
                                    global_ioport_bitmap_heap_update_tag_disj_simps
-                                   packed_heap_update_collapse_hrs
-                             elim!: fpu_null_state_typ_heap_preservation)
+                                   packed_heap_update_collapse_hrs)
        subgoal by (simp add: cmachine_state_relation_def)
       subgoal by (simp add: h_t_valid_clift_Some_iff)
      subgoal by (simp add: objBits_simps')
@@ -2675,10 +2669,8 @@ lemma cancelIPC_ccorres_helper:
         apply simp
         apply (erule (1) map_to_ko_atI')
        subgoal by (clarsimp simp: carch_state_relation_def carch_globals_def
-                                  fpu_null_state_heap_update_tag_disj_simps
                                   global_ioport_bitmap_heap_update_tag_disj_simps
-                                  packed_heap_update_collapse_hrs
-                            elim!: fpu_null_state_typ_heap_preservation)
+                                  packed_heap_update_collapse_hrs)
       subgoal by (simp add: cmachine_state_relation_def)
      subgoal by (simp add: h_t_valid_clift_Some_iff)
     subgoal by (simp add: objBits_simps')

--- a/proof/crefine/X64/Ipc_C.thy
+++ b/proof/crefine/X64/Ipc_C.thy
@@ -237,7 +237,7 @@ lemma asUser_loadWordUser_comm:
                            ps_clear_upd ps_clear_upd_None pointerInUserData_def
                     split: option.split kernel_object.split)
     apply simp
-   apply (simp add: ef_loadWord)
+   apply simp
   apply assumption
   done
 
@@ -253,7 +253,7 @@ lemma asUser_storeWordUser_comm:
                            ps_clear_upd ps_clear_upd_None pointerInUserData_def
                     split: option.split kernel_object.split)
     apply simp
-   apply (simp add: ef_storeWord)
+   apply simp
   apply assumption
   done
 
@@ -4463,9 +4463,7 @@ lemma sendIPC_dequeue_ccorres_helper:
            apply simp
           apply (erule (1) map_to_ko_atI')
          apply (clarsimp simp: carch_state_relation_def packed_heap_update_collapse_hrs
-                               fpu_null_state_heap_update_tag_disj_simps
-                               global_ioport_bitmap_heap_update_tag_disj_simps
-                        elim!: fpu_null_state_typ_heap_preservation)
+                               global_ioport_bitmap_heap_update_tag_disj_simps)
         apply (simp add: cmachine_state_relation_def)
        apply (simp add: h_t_valid_clift_Some_iff)
       apply (simp add: objBits_simps')
@@ -4510,9 +4508,7 @@ lemma sendIPC_dequeue_ccorres_helper:
           apply simp
          apply (erule (1) map_to_ko_atI')
         apply (clarsimp simp: carch_state_relation_def packed_heap_update_collapse_hrs
-                              fpu_null_state_heap_update_tag_disj_simps
-                              global_ioport_bitmap_heap_update_tag_disj_simps
-                       elim!: fpu_null_state_typ_heap_preservation)
+                              global_ioport_bitmap_heap_update_tag_disj_simps)
        apply (simp add: cmachine_state_relation_def)
       apply (simp add: h_t_valid_clift_Some_iff)
      apply (simp add: objBits_simps')
@@ -4853,9 +4849,7 @@ lemma sendIPC_enqueue_ccorres_helper:
           apply clarsimp
          apply (clarsimp simp: obj_at'_def projectKOs)
         apply (clarsimp simp: carch_state_relation_def packed_heap_update_collapse_hrs
-                              global_ioport_bitmap_heap_update_tag_disj_simps
-                              fpu_null_state_heap_update_tag_disj_simps
-                       elim!: fpu_null_state_typ_heap_preservation)
+                              global_ioport_bitmap_heap_update_tag_disj_simps)
        apply (simp add: cmachine_state_relation_def)
       apply (simp add: typ_heap_simps')
      apply (simp add: objBits_simps')
@@ -4904,9 +4898,7 @@ lemma sendIPC_enqueue_ccorres_helper:
          apply (clarsimp simp: objBitsKO_def)
         apply (clarsimp simp: obj_at'_def projectKOs)
        apply (clarsimp simp: carch_state_relation_def packed_heap_update_collapse_hrs
-                             global_ioport_bitmap_heap_update_tag_disj_simps
-                             fpu_null_state_heap_update_tag_disj_simps
-                      elim!: fpu_null_state_typ_heap_preservation)
+                             global_ioport_bitmap_heap_update_tag_disj_simps)
       apply (simp add: cmachine_state_relation_def)
      apply (simp add: h_t_valid_clift_Some_iff)
     apply (simp add: objBits_simps')
@@ -5271,9 +5263,7 @@ lemma receiveIPC_enqueue_ccorres_helper:
           apply (clarsimp simp: objBitsKO_def)
          apply (clarsimp simp: obj_at'_def projectKOs)
         apply (clarsimp simp: carch_state_relation_def packed_heap_update_collapse_hrs
-                              global_ioport_bitmap_heap_update_tag_disj_simps
-                              fpu_null_state_heap_update_tag_disj_simps
-                       elim!: fpu_null_state_typ_heap_preservation)
+                              global_ioport_bitmap_heap_update_tag_disj_simps)
        apply (simp add: cmachine_state_relation_def)
       apply (simp add: h_t_valid_clift_Some_iff)
      apply (simp add: objBits_simps')
@@ -5314,9 +5304,7 @@ lemma receiveIPC_enqueue_ccorres_helper:
          apply (clarsimp simp: objBitsKO_def)
         apply (clarsimp simp: obj_at'_def projectKOs)
        apply (clarsimp simp: carch_state_relation_def packed_heap_update_collapse_hrs
-                             global_ioport_bitmap_heap_update_tag_disj_simps
-                             fpu_null_state_heap_update_tag_disj_simps
-                      elim!: fpu_null_state_typ_heap_preservation)
+                             global_ioport_bitmap_heap_update_tag_disj_simps)
       apply (simp add: cmachine_state_relation_def)
      apply (simp add: typ_heap_simps')
     apply (simp add: objBits_simps')
@@ -5399,9 +5387,7 @@ lemma receiveIPC_dequeue_ccorres_helper:
           apply simp
          apply (erule (1) map_to_ko_atI')
         apply (clarsimp simp: carch_state_relation_def packed_heap_update_collapse_hrs
-                               global_ioport_bitmap_heap_update_tag_disj_simps
-                               fpu_null_state_heap_update_tag_disj_simps
-                        elim!: fpu_null_state_typ_heap_preservation)
+                               global_ioport_bitmap_heap_update_tag_disj_simps)
         apply (simp add: cmachine_state_relation_def)
        apply (simp add: typ_heap_simps')
       apply (simp add: objBits_simps')
@@ -5446,9 +5432,7 @@ lemma receiveIPC_dequeue_ccorres_helper:
           apply simp
          apply (erule (1) map_to_ko_atI')
         apply (clarsimp simp: carch_state_relation_def packed_heap_update_collapse_hrs
-                              global_ioport_bitmap_heap_update_tag_disj_simps
-                              fpu_null_state_heap_update_tag_disj_simps
-                       elim!: fpu_null_state_typ_heap_preservation)
+                              global_ioport_bitmap_heap_update_tag_disj_simps)
        apply (simp add: cmachine_state_relation_def)
       apply (simp add: typ_heap_simps')
      apply (simp add: objBits_simps')
@@ -5526,7 +5510,6 @@ lemma completeSignal_ccorres:
               apply (simp add: cnotification_relation_def Let_def NtfnState_Idle_def mask_def)
              apply simp
             apply (clarsimp simp: carch_state_relation_def
-                                  fpu_null_state_heap_update_tag_disj_simps
                                   global_ioport_bitmap_heap_update_tag_disj_simps)
            apply (simp add: cmachine_state_relation_def)
           apply (simp add: h_t_valid_clift_Some_iff)
@@ -5931,9 +5914,7 @@ lemma sendSignal_dequeue_ccorres_helper:
                             tcb_queue_relation'_def)
           apply simp
          apply (clarsimp simp: carch_state_relation_def packed_heap_update_collapse_hrs
-                               global_ioport_bitmap_heap_update_tag_disj_simps
-                               fpu_null_state_heap_update_tag_disj_simps
-                        elim!: fpu_null_state_typ_heap_preservation)
+                               global_ioport_bitmap_heap_update_tag_disj_simps)
         apply (simp add: cmachine_state_relation_def)
        apply (simp add: h_t_valid_clift_Some_iff)
       apply (simp add: objBits_simps')
@@ -5983,9 +5964,7 @@ lemma sendSignal_dequeue_ccorres_helper:
           apply (clarsimp split: if_split)
          apply simp
         apply (clarsimp simp: carch_state_relation_def
-                              global_ioport_bitmap_heap_update_tag_disj_simps
-                              fpu_null_state_heap_update_tag_disj_simps
-                       elim!: fpu_null_state_typ_heap_preservation)
+                              global_ioport_bitmap_heap_update_tag_disj_simps)
        apply (simp add: cmachine_state_relation_def)
       apply (simp add: h_t_valid_clift_Some_iff)
      apply (simp add: objBits_simps')
@@ -6015,7 +5994,6 @@ lemma ntfn_set_active_ccorres:
     apply (clarsimp simp: typ_heap_simps' rf_sr_def cstate_relation_def Let_def
                           cpspace_relation_def update_ntfn_map_tos
                           carch_state_relation_def packed_heap_update_collapse_hrs
-                          fpu_null_state_heap_update_tag_disj_simps
                           cmachine_state_relation_def)
     apply (rule cpspace_relation_ntfn_update_ntfn, assumption+)
      apply (simp add: cnotification_relation_def Let_def NtfnState_Active_def
@@ -6131,7 +6109,6 @@ lemma sendSignal_ccorres [corres]:
                              NtfnState_Active_def mask_def word_bw_comms)
            apply simp
           apply (clarsimp simp: carch_state_relation_def
-                                fpu_null_state_heap_update_tag_disj_simps
                                 global_ioport_bitmap_heap_update_tag_disj_simps)
          apply (simp add: cmachine_state_relation_def)
         apply (simp add: h_t_valid_clift_Some_iff)
@@ -6372,9 +6349,7 @@ lemma receiveSignal_enqueue_ccorres_helper:
             by clarsimp
          apply (simp add: isWaitingNtfn_def)
         apply (clarsimp simp: carch_state_relation_def packed_heap_update_collapse_hrs
-                              global_ioport_bitmap_heap_update_tag_disj_simps
-                              fpu_null_state_heap_update_tag_disj_simps
-                       elim!: fpu_null_state_typ_heap_preservation)
+                              global_ioport_bitmap_heap_update_tag_disj_simps)
        apply (simp add: cmachine_state_relation_def)
       apply (simp add: h_t_valid_clift_Some_iff)
      apply (simp add: objBits_simps')
@@ -6430,9 +6405,7 @@ lemma receiveSignal_enqueue_ccorres_helper:
            done
         apply (simp add: isWaitingNtfn_def)
        apply (clarsimp simp: carch_state_relation_def packed_heap_update_collapse_hrs
-                             global_ioport_bitmap_heap_update_tag_disj_simps
-                             fpu_null_state_heap_update_tag_disj_simps
-                      elim!: fpu_null_state_typ_heap_preservation)
+                             global_ioport_bitmap_heap_update_tag_disj_simps)
       apply (simp add: cmachine_state_relation_def)
      apply (simp add: h_t_valid_clift_Some_iff)
     apply (simp add: objBits_simps')
@@ -6533,8 +6506,7 @@ lemma receiveSignal_ccorres [corres]:
                apply (simp add: cnotification_relation_def Let_def
                                 NtfnState_Idle_def mask_def)
               apply simp
-             apply (simp add: carch_state_relation_def fpu_null_state_heap_update_tag_disj_simps
-                              global_ioport_bitmap_heap_update_tag_disj_simps)
+             apply (simp add: carch_state_relation_def global_ioport_bitmap_heap_update_tag_disj_simps)
             apply (simp add: cmachine_state_relation_def)
            apply (simp add: h_t_valid_clift_Some_iff)
           apply (simp add: objBits_simps')

--- a/proof/crefine/X64/IsolatedThreadAction.thy
+++ b/proof/crefine/X64/IsolatedThreadAction.thy
@@ -14,11 +14,15 @@ context begin interpretation Arch .
 datatype tcb_state_regs =
   TCBStateRegs (tsrState : thread_state) (tsrContext : "MachineTypes.register \<Rightarrow> machine_word")
 
+definition get_tcb_state_regs_tcb :: "tcb \<Rightarrow> tcb_state_regs" where
+  "get_tcb_state_regs_tcb tcb \<equiv> TCBStateRegs (tcbState tcb) ((user_regs \<circ> atcbContextGet \<circ> tcbArch) tcb)"
+
 definition
   get_tcb_state_regs :: "kernel_object option \<Rightarrow> tcb_state_regs"
 where
- "get_tcb_state_regs oko \<equiv> case oko of
-    Some (KOTCB tcb) \<Rightarrow> TCBStateRegs (tcbState tcb) ((user_regs o atcbContextGet o tcbArch) tcb)"
+ "get_tcb_state_regs oko \<equiv> case oko of Some (KOTCB tcb) \<Rightarrow> get_tcb_state_regs_tcb tcb"
+
+lemmas get_tcb_state_regs_defs = get_tcb_state_regs_def get_tcb_state_regs_tcb_def
 
 definition
   put_tcb_state_regs_tcb :: "tcb_state_regs \<Rightarrow> tcb \<Rightarrow> tcb"
@@ -35,6 +39,8 @@ where
  "put_tcb_state_regs tsr oko = Some (KOTCB (put_tcb_state_regs_tcb tsr
     (case oko of
        Some (KOTCB tcb) \<Rightarrow> tcb | _ \<Rightarrow> makeObject)))"
+
+lemmas put_tcb_state_regs_defs = put_tcb_state_regs_def put_tcb_state_regs_tcb_def
 
 definition
  "partial_overwrite idx tcbs ps \<equiv>
@@ -66,13 +72,11 @@ lemma UserContextGet[simp]:
 lemma put_tcb_state_regs_twice[simp]:
   "put_tcb_state_regs tsr (put_tcb_state_regs tsr' tcb)
     = put_tcb_state_regs tsr tcb"
-  apply (simp add: put_tcb_state_regs_def put_tcb_state_regs_tcb_def
-                   makeObject_tcb newArchTCB_def atcbContextSet_def
+  apply (simp add: put_tcb_state_regs_defs makeObject_tcb newArchTCB_def
             split: tcb_state_regs.split option.split
                    Structures_H.kernel_object.split)
-  apply (intro all_tcbI impI allI)
-   using atcbContextSet_def atcbContext_set_set
-   apply fastforce+
+  using atcbContextSet_def atcbContext_set_set
+  apply (intro all_tcbI impI allI conjI; simp)
   done
 
 lemma partial_overwrite_twice[simp]:
@@ -85,9 +89,8 @@ lemma get_tcb_state_regs_partial_overwrite[simp]:
    get_tcb_state_regs (partial_overwrite idx tcbs f (idx x))
       = tcbs x"
   apply (simp add: partial_overwrite_def)
-  apply (simp add: put_tcb_state_regs_def
-                   get_tcb_state_regs_def
-                   put_tcb_state_regs_tcb_def
+  apply (simp add: put_tcb_state_regs_defs
+                   get_tcb_state_regs_defs
             split: tcb_state_regs.split)
   done
 
@@ -167,14 +170,14 @@ context begin interpretation Arch . (*FIXME: arch-split*)
 lemma get_tcb_state_regs_ko_at':
   "ko_at' ko p s \<Longrightarrow> get_tcb_state_regs (ksPSpace s p)
        = TCBStateRegs (tcbState ko) ((user_regs o atcbContextGet o tcbArch) ko)"
-  by (clarsimp simp: obj_at'_def projectKOs get_tcb_state_regs_def)
+  by (clarsimp simp: obj_at'_def projectKOs get_tcb_state_regs_defs)
 
 lemma put_tcb_state_regs_ko_at':
   "ko_at' ko p s \<Longrightarrow> put_tcb_state_regs tsr (ksPSpace s p)
        = Some (KOTCB (ko \<lparr> tcbState := tsrState tsr
-                         , tcbArch := atcbContextSet (UserContext (user_fpu_state (atcbContext (tcbArch ko))) (tsrContext tsr)) (tcbArch ko)\<rparr>))"
-  by (clarsimp simp: obj_at'_def projectKOs put_tcb_state_regs_def
-                     put_tcb_state_regs_tcb_def
+                         , tcbArch := atcbContextSet (UserContext (user_fpu_state (atcbContext (tcbArch ko)))
+                                                                  (tsrContext tsr)) (tcbArch ko)\<rparr>))"
+  by (clarsimp simp: obj_at'_def projectKOs put_tcb_state_regs_defs
               split: tcb_state_regs.split)
 
 lemma partial_overwrite_get_tcb_state_regs:
@@ -185,8 +188,7 @@ lemma partial_overwrite_get_tcb_state_regs:
                       split: if_split)
   apply clarsimp
   apply (drule_tac x=xa in spec)
-  apply (clarsimp simp: obj_at'_def projectKOs put_tcb_state_regs_def
-                        get_tcb_state_regs_def put_tcb_state_regs_tcb_def)
+  apply (clarsimp simp: obj_at'_def projectKOs put_tcb_state_regs_defs get_tcb_state_regs_defs)
   apply (case_tac obj, simp)
   done
 
@@ -277,8 +279,7 @@ lemma map_to_ctes_partial_overwrite:
    apply (drule_tac x=xa in spec)
    apply (clarsimp simp: obj_at'_def projectKOs objBits_simps'
                    cong: if_cong)
-   apply (simp add: put_tcb_state_regs_def put_tcb_state_regs_tcb_def
-                    objBits_simps'
+   apply (simp add: put_tcb_state_regs_tcb_def objBits_simps'
               cong: if_cong option.case_cong)
    apply (case_tac obj, simp split: tcb_state_regs.split if_split)
   apply simp
@@ -289,8 +290,7 @@ lemma map_to_ctes_partial_overwrite:
    apply (drule_tac x=xa in spec)
    apply (clarsimp simp: obj_at'_def projectKOs objBits_simps'
                    cong: if_cong)
-   apply (simp add: put_tcb_state_regs_def put_tcb_state_regs_tcb_def
-                    objBits_simps'
+   apply (simp add: put_tcb_state_regs_tcb_def objBits_simps'
               cong: if_cong option.case_cong)
    apply (case_tac obj, simp split: tcb_state_regs.split if_split)
    apply (intro impI allI)
@@ -533,7 +533,7 @@ lemma thread_actions_isolatable_bind:
   apply (simp add: obj_at_partial_overwrite_If)
   done
 
-lemma thread_actions_isolatable_return:
+lemma thread_actions_isolatable_return[simp]:
   "thread_actions_isolatable idx (return v)"
   apply (clarsimp simp: thread_actions_isolatable_def
                         monadic_rewrite_def liftM_def
@@ -544,19 +544,22 @@ lemma thread_actions_isolatable_return:
                    ksPSpace_update_partial_id)
   done
 
-lemma thread_actions_isolatable_fail:
+lemma thread_actions_isolatable_fail[simp]:
   "thread_actions_isolatable idx fail"
   by (simp add: thread_actions_isolatable_def
                 isolate_thread_actions_def select_f_asserts
                 liftM_def bind_assoc getSchedulerAction_def
                 monadic_rewrite_def exec_gets)
 
-lemma thread_actions_isolatable_returns:
+lemma thread_actions_isolatable_assert[simp]:
+  "thread_actions_isolatable idx (assert P)"
+  by (auto simp: assert_def)
+
+lemma thread_actions_isolatable_returns[simp]:
   "thread_actions_isolatable idx (return v)"
   "thread_actions_isolatable idx (returnOk v)"
   "thread_actions_isolatable idx (throwError v)"
-  by (simp add: returnOk_def throwError_def
-                thread_actions_isolatable_return)+
+  by (simp add: returnOk_def throwError_def)+
 
 lemma thread_actions_isolatable_bindE:
   "\<lbrakk> thread_actions_isolatable idx f; \<And>x. thread_actions_isolatable idx (g x);
@@ -642,11 +645,12 @@ lemma modify_not_fail[simp]:
 lemma setObject_assert_modify:
   "\<lbrakk> updateObject v = updateObject_default v; (1::machine_word) < 2 ^ objBits v;
      \<And>ko v'. projectKO_opt ko = Some (v'::'a) \<Longrightarrow> objBitsKO ko = objBits v \<rbrakk> \<Longrightarrow>
-   setObject p (v::'a::pspace_storable) s = (do
-     assert (obj_at' (\<lambda>_::'a. True) p s);
+   setObject p (v::'a::pspace_storable) = (do
+     state_assert (obj_at' (\<lambda>_::'a. True) p);
      modify (ksPSpace_update (\<lambda>ps. ps(p \<mapsto> injectKOS v)))
-   od) s"
-  apply (clarsimp simp: assert_def setObject_modify split: if_split)
+   od)"
+  apply (rule ext)
+  apply (clarsimp simp: state_assert_def exec_get assert_def setObject_modify bind_assoc split: if_split)
   apply (clarsimp simp: setObject_def updateObject_default_def exec_gets split_def bind_assoc)
   apply (clarsimp simp: assert_opt_def assert_def alignCheck_assert projectKO_def
                  split: option.splits if_splits)
@@ -916,6 +920,20 @@ lemma oblivious_setVMRoot_schact:
                       split: if_split capability.split arch_capability.split option.split)+
 
 
+lemma oblivious_switchLocalFpuOwner_schact:
+  "oblivious (ksSchedulerAction_update f) (switchLocalFpuOwner new_owner)"
+  apply (simp add: switchLocalFpuOwner_def)
+  by (safe intro!: oblivious_bind
+      | simp_all add: fpuOwner_asrt_def saveFpuState_def loadFpuState_def asUser_def
+                      threadGet_def liftM_def threadSet_def
+               split: option.split)+
+
+lemma oblivious_lazyFpuRestore_schact:
+  "oblivious (ksSchedulerAction_update f) (lazyFpuRestore t)"
+  apply (simp add: lazyFpuRestore_def)
+  by (safe intro!: oblivious_bind
+      | simp_all add: threadGet_def liftM_def oblivious_switchLocalFpuOwner_schact)+
+
 lemma oblivious_switchToThread_schact:
   "oblivious (ksSchedulerAction_update f) (ThreadDecls_H.switchToThread t)"
   apply (simp add: Thread_H.switchToThread_def switchToThread_def bind_assoc
@@ -923,11 +941,11 @@ lemma oblivious_switchToThread_schact:
                    threadSet_def tcbSchedEnqueue_def unless_when asUser_def
                    getQueue_def setQueue_def storeWordUser_def setRegister_def
                    pointerInUserData_def isRunnable_def isStopped_def
-                   getThreadState_def tcbSchedDequeue_def tcbQueueRemove_def bitmap_fun_defs
-                   ksReadyQueues_asrt_def)
+                   getThreadState_def tcbSchedDequeue_def bitmap_fun_defs
+                   tcbQueueRemove_def ksReadyQueues_asrt_def)
   by (safe intro!: oblivious_bind
               | simp_all add: ready_qs_runnable_def idleThreadNotQueued_def
-                              oblivious_setVMRoot_schact)+
+                              oblivious_setVMRoot_schact oblivious_lazyFpuRestore_schact)+
 
 (* FIXME move *)
 lemma empty_fail_getCurThread[intro!, wp, simp]:
@@ -1128,8 +1146,7 @@ lemma setCTE_isolatable:
     apply (rule ext)
     apply (clarsimp simp: partial_overwrite_get_tcb_state_regs
                    split: if_split)
-    apply (clarsimp simp: projectKOs get_tcb_state_regs_def
-                          put_tcb_state_regs_def put_tcb_state_regs_tcb_def
+    apply (clarsimp simp: projectKOs get_tcb_state_regs_defs put_tcb_state_regs_defs
                           partial_overwrite_def
                    split: tcb_state_regs.split)
     apply (case_tac obj, simp add: projectKO_opt_tcb)
@@ -1211,8 +1228,7 @@ lemma isolate_thread_actions_threadSet_tcbState:
                 intro!: kernel_state.fold_congs[OF refl refl])
   apply (simp add: partial_overwrite_fun_upd
                    partial_overwrite_get_tcb_state_regs)
-  apply (clarsimp simp: put_tcb_state_regs_def put_tcb_state_regs_tcb_def
-                        projectKOs get_tcb_state_regs_def
+  apply (clarsimp simp: put_tcb_state_regs_defs get_tcb_state_regs_defs projectKOs
                  elim!: obj_atE')
   apply (case_tac ko)
   apply (simp add: projectKO_opt_tcb)
@@ -1241,7 +1257,7 @@ lemma switchToThread_rewrite:
        (switchToThread t)
        (do Arch.switchToThread t; setCurThread t od)"
   apply (simp add: switchToThread_def Thread_H.switchToThread_def)
-  apply (monadic_rewrite_l tcbSchedDequeue_rewrite, simp)
+  apply (monadic_rewrite_l tcbSchedDequeue_rewrite \<open>wpsimp simp: o_def\<close>, simp)
    (* strip LHS of getters and asserts until LHS and RHS are the same *)
    apply (repeat_unless \<open>rule monadic_rewrite_refl\<close> monadic_rewrite_symb_exec_l)
       apply wpsimp+
@@ -1263,23 +1279,177 @@ lemma threadGet_isolatable:
   apply (clarsimp simp: exec_gets exec_modify o_def
                         ksPSpace_update_partial_id in_monad)
   apply (erule obj_atE')
-  apply (clarsimp simp: projectKOs
-                        partial_overwrite_def put_tcb_state_regs_def
+  apply (clarsimp simp: projectKOs partial_overwrite_def put_tcb_state_regs_def
                   cong: if_cong)
   apply (simp add: projectKO_opt_tcb v split: if_split)
   done
 
- lemma switchToThread_isolatable:
-  "thread_actions_isolatable idx (Arch.switchToThread t)"
-  apply (simp add: switchToThread_def
-                   storeWordUser_def stateAssert_def2)
+lemma typ_at_partial_overwrite_id2:
+  "\<lbrakk> \<forall>x. tcb_at' (idx x) s \<rbrakk>
+   \<Longrightarrow> typ_at' P p (ksPSpace_update (partial_overwrite idx f) s) = typ_at' P p s"
+  apply (frule dom_partial_overwrite[where tsrs=f])
+  apply (clarsimp simp: typ_at'_def ko_wp_at'_def obj_at'_def ps_clear_def partial_overwrite_def projectKOs)
+  apply (drule_tac x=x in spec)
+  apply (clarsimp simp: put_tcb_state_regs_def objBits_simps)
+  done
+
+lemma tcb_at_partial_overwrite:
+  "\<forall>x. tcb_at' (idx x) s \<Longrightarrow>
+   tcb_at' p (ksPSpace_update (partial_overwrite idx f) s) = tcb_at' p s"
+  by (simp add: tcb_at_typ_at' typ_at_partial_overwrite_id2)
+
+
+definition asUserFPU :: "machine_word \<Rightarrow> (fpu_state \<Rightarrow> ('a \<times> fpu_state)) \<Rightarrow> 'a kernel" where
+  "asUserFPU tptr f \<equiv> do
+        fpu \<leftarrow> threadGet (user_fpu_state \<circ> atcbContextGet o tcbArch) tptr;
+        threadSet (\<lambda>tcb. tcb \<lparr> tcbArch := atcbContextSet (UserContext (snd (f fpu)) (user_regs (atcbContext (tcbArch tcb))))
+                                           (tcbArch tcb)\<rparr>) tptr;
+        return (fst (f fpu))
+   od"
+
+lemma asUser_asUserFPU_set:
+  "asUser t (setFPUState fc) = asUserFPU t (\<lambda>_. ((), fc))"
+  unfolding asUser_def asUserFPU_def setFPUState_def
+  apply (clarsimp simp: select_f_returns threadGet_stateAssert_gets bind_assoc exec_gets comp_def
+                intro!: ext bind_apply_cong[where f="stateAssert P L" for P L, OF refl]
+                 dest!: fst_stateAssertD)
+  apply (clarsimp simp: threadSet_det simpler_modify_def)
+  apply (rule kernel_state.unfold_congs; simp?)
+  apply (rule ext)
+  apply (clarsimp simp: obj_at'_def atcbContextSet_def thread_fetch_def atcbContextGet_def projectKOs)
+  done
+
+lemma asUser_asUserFPU_get:
+  "asUser t getFPUState = asUserFPU t (\<lambda>fc. (fc, fc))"
+  unfolding asUser_def asUserFPU_def getFPUState_def
+  apply (subst threadSet_stateAssert_modify)+
+  apply (clarsimp simp: select_f_returns threadGet_stateAssert_gets bind_assoc exec_gets comp_def
+                intro!: ext bind_apply_cong[where f="stateAssert P L" for P L, OF refl]
+                 dest!: fst_stateAssertD)
+  apply (clarsimp simp: simpler_modify_def return_def bind_def)
+  apply (clarsimp simp: obj_at'_def atcbContextSet_def thread_fetch_def atcbContextGet_def
+                        thread_replace_def projectKOs)
+  done
+
+lemma put_tcb_state_regs_tcb_twice[simp]:
+  "put_tcb_state_regs_tcb tsr (put_tcb_state_regs_tcb tsr' tcb) = put_tcb_state_regs_tcb tsr tcb"
+  apply (cases tcb)
+  apply (simp add: put_tcb_state_regs_tcb_def split: tcb_state_regs.split)
+  apply (fastforce simp: atcbContextSet_def)
+  done
+
+lemma put_tcb_state_regs_tcb_unchanged:
+  "get_tcb_state_regs_tcb tcb = tsr \<Longrightarrow> put_tcb_state_regs_tcb tsr tcb = tcb"
+  apply (cases tcb)
+  apply (clarsimp simp: put_tcb_state_regs_tcb_def get_tcb_state_regs_tcb_def)
+  done
+
+lemma threadSet_isolatable:
+  assumes v: "\<And>tcb. get_tcb_state_regs_tcb (f tcb) = get_tcb_state_regs_tcb tcb"
+  assumes y: "\<And>tsr tcb. f (put_tcb_state_regs_tcb tsr tcb) = put_tcb_state_regs_tcb tsr (f tcb)"
+  shows "thread_actions_isolatable idx (threadSet f t)"
+  apply (clarsimp simp: threadSet_def)
+  apply (subst setObject_assert_modify;
+         simp add: objBits_2n objBits_simps tcbBlockSizeBits_def projectKOs)+
+  apply (clarsimp simp: thread_actions_isolatable_def isolate_thread_actions_def split_def
+                        getObject_get_assert
+                        setObject_assert_modify objBits_2n objBits_simps tcbBlockSizeBits_def liftM_def
+                        state_assert_def
+                        bind_select_f_bind[symmetric]
+                        select_f_returns select_f_asserts bind_assoc)
+  apply (clarsimp simp: monadic_rewrite_def exec_gets
+                        getSchedulerAction_def)
+  apply (simp add: obj_at_partial_overwrite_If)
+  apply (rule bind_apply_cong[OF refl])
+  apply (clarsimp simp: exec_gets exec_get simpler_modify_def o_def
+                        ksPSpace_update_partial_id in_monad)
+  apply (erule obj_atE')
+  apply (rule kernel_state.unfold_congs; simp?)
+  apply (rule ext)
+  apply (clarsimp simp: projectKOs)
+  apply (intro impI conjI)
+   apply (clarsimp simp: partial_overwrite_def put_tcb_state_regs_def get_tcb_state_regs_def
+                         y put_tcb_state_regs_tcb_unchanged v)
+  apply (clarsimp simp: partial_overwrite_def put_tcb_state_regs_def get_tcb_state_regs_def)
+  apply (drule_tac x=xa in spec)
+  apply (clarsimp simp: obj_at'_def put_tcb_state_regs_tcb_unchanged projectKOs)
+  done
+
+lemma atcbContext_update_twice[simp]:
+  "atcbContext_update f (atcbContext_update f' v) = atcbContext_update (f \<circ> f') v"
+  by (cases v; clarsimp)
+
+lemma tcbArch_update_twice[simp]:
+  "tcbArch_update f (tcbArch_update f' v) = tcbArch_update (f \<circ> f') v"
+  by (cases v; clarsimp)
+
+lemma asUserFPU_isolatable:
+  "thread_actions_isolatable idx (asUserFPU t f)"
+  apply (simp add: asUserFPU_def)
   apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
-               gets_isolatable setVMRoot_isolatable
+               thread_actions_isolatable_returns
+               threadGet_isolatable threadSet_isolatable)
+        apply (wpsimp simp: put_tcb_state_regs_tcb_def get_tcb_state_regs_tcb_def atcbContextGet_def atcbContextSet_def
+                     split: tcb_state_regs.split)+
+      apply (case_tac tcb)
+      apply clarsimp
+     apply wpsimp+
+  done
+
+lemma saveFpuState_isolatable:
+  "thread_actions_isolatable idx (saveFpuState t)"
+  apply (simp add: saveFpuState_def asUser_asUserFPU_set)
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
+               doMachineOp_isolatable asUserFPU_isolatable
+         | wpsimp)+
+  done
+
+lemma asUserFPU_typ_at'[wp]:
+  "\<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace> asUserFPU t' f \<lbrace>\<lambda>rv s. P (typ_at' T p s)\<rbrace>"
+  by (simp add: asUserFPU_def bind_assoc split_def, wp select_f_inv)
+
+lemmas asUserFPU_typ_ats[wp] = typ_at_lifts [OF asUserFPU_typ_at']
+
+lemma loadFpuState_isolatable:
+  "thread_actions_isolatable idx (loadFpuState t)"
+  apply (simp add: loadFpuState_def asUser_asUserFPU_get)
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
+               doMachineOp_isolatable asUserFPU_isolatable
+         | wpsimp)+
+  done
+
+lemma switchLocalFpuOwner_isolatable:
+  "thread_actions_isolatable idx (switchLocalFpuOwner t)"
+  apply (simp add: switchLocalFpuOwner_def stateAssert_def2 fpuOwner_asrt_def case_option_If2
+              split del: if_split)
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
+               gets_isolatable
                thread_actions_isolatable_if
                doMachineOp_isolatable
+               saveFpuState_isolatable loadFpuState_isolatable modifyArchState_isolatable)
+        apply (wpsimp simp: none_top_def tcb_at_partial_overwrite
+                     split: option.split)+
+  done
+
+lemma lazyFpuRestore_isolatable:
+  "thread_actions_isolatable idx (lazyFpuRestore t)"
+  apply (simp add: lazyFpuRestore_def)
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
+               gets_isolatable thread_actions_isolatable_if doMachineOp_isolatable
+               threadGet_isolatable [OF all_tcbI] switchLocalFpuOwner_isolatable)
+        apply (wpsimp simp: put_tcb_state_regs_tcb_def
+                     split: tcb_state_regs.split)+
+  done
+
+lemma switchToThread_isolatable:
+  "thread_actions_isolatable idx (Arch.switchToThread t)"
+  apply (simp add: switchToThread_def)
+  apply (intro thread_actions_isolatable_bind[OF _ _ hoare_weaken_pre]
+               setVMRoot_isolatable
+               doMachineOp_isolatable
                threadGet_isolatable [OF all_tcbI]
-               thread_actions_isolatable_returns
-               thread_actions_isolatable_fail)
+               lazyFpuRestore_isolatable)
+   apply wpsimp+
   done
 
 lemma tcbQueued_put_tcb_state_regs_tcb:
@@ -1393,9 +1563,8 @@ lemma set_register_isolate:
   apply (clarsimp simp: obj_at'_def projectKOs objBits_simps
                   cong: if_cong)
   apply (case_tac obj)
-  apply (simp add: projectKO_opt_tcb put_tcb_state_regs_def
-                   put_tcb_state_regs_tcb_def get_tcb_state_regs_def
-                   atcbContextGet_def
+  apply (simp add: projectKO_opt_tcb put_tcb_state_regs_defs
+                   get_tcb_state_regs_defs atcbContextGet_def
              cong: if_cong)
   done
 
@@ -1426,9 +1595,8 @@ lemma copy_register_isolate:
   apply (clarsimp simp: obj_at'_def projectKOs objBits_simps
                   cong: if_cong)
   apply (case_tac obj, case_tac obja)
-  apply (simp add: projectKO_opt_tcb put_tcb_state_regs_def
-                   put_tcb_state_regs_tcb_def get_tcb_state_regs_def
-                   atcbContextGet_def
+  apply (simp add: projectKO_opt_tcb put_tcb_state_regs_defs
+                   get_tcb_state_regs_defs atcbContextGet_def
              cong: if_cong)
   apply (auto simp: fun_eq_iff split: if_split)
   done

--- a/proof/crefine/X64/Machine_C.thy
+++ b/proof/crefine/X64/Machine_C.thy
@@ -37,23 +37,6 @@ assumes ioapicMapPinToVector_ccorres:
      (doMachineOp (ioapicMapPinToVector ioapic pin level polarity vector))
      (Call ioapic_map_pin_to_vector_'proc)"
 
-(* FIXME: x64: Currently don't verify FPU lazy state switching (VER-951) *)
-assumes nativeThreadUsingFPU_ccorres:
-  "ccorres (\<lambda>rv rv'. rv' = from_bool rv) ret__unsigned_long_'
-     (tcb_at' thread)
-     (UNIV \<inter> \<lbrace>\<acute>thread = tcb_ptr_to_ctcb_ptr thread\<rbrace>)
-     []
-     (doMachineOp (nativeThreadUsingFPU thread))
-     (Call nativeThreadUsingFPU_'proc)"
-
-assumes switchFpuOwner_ccorres:
-  "ccorres dc xfdc \<top>
-     (UNIV \<inter> \<lbrace>\<acute>new_owner = Ptr new_owner\<rbrace>
-           \<inter> \<lbrace>\<acute>cpu = cpu\<rbrace>)
-     []
-     (doMachineOp (switchFpuOwner new_owner cpu))
-     (Call switchFpuOwner_'proc)"
-
 (* FIXME x64: double-check this, assumption is ccorres holds regardless of in_kernel *)
 (* FIXME x64: accessor function relation was complicated on ARM, testing if you don't
               need it to be that way *)
@@ -94,6 +77,26 @@ assumes invalidateLocalPageStructureCacheASID_ccorres:
   "ccorres dc xfdc \<top> (UNIV \<inter> \<lbrace>\<acute>root = vspace\<rbrace> \<inter> \<lbrace>\<acute>asid = asid\<rbrace>) []
            (doMachineOp (invalidateLocalPageStructureCacheASID vspace asid))
            (Call invalidateLocalPageStructureCacheASID_'proc)"
+
+
+(* FPU-related machine ops *)
+
+assumes saveFpuState_ccorres:
+  "ccorres dc xfdc (tcb_at' t) (\<lbrace>\<acute>thread = tcb_ptr_to_ctcb_ptr t \<rbrace>) []
+     (saveFpuState t) (Call saveFpuState_'proc)"
+
+assumes loadFpuState_ccorres:
+  "ccorres dc xfdc (tcb_at' t) (\<lbrace>\<acute>thread = tcb_ptr_to_ctcb_ptr t \<rbrace>) []
+     (loadFpuState t) (Call loadFpuState_'proc)"
+
+assumes enableFpu_ccorres:
+  "ccorres dc xfdc \<top> UNIV []
+     (doMachineOp enableFpu) (Call enableFpu_'proc)"
+
+assumes disableFpu_ccorres:
+  "ccorres dc xfdc \<top> UNIV []
+     (doMachineOp disableFpu) (Call disableFpu_'proc)"
+
 
 (* The following are fastpath specific assumptions.
    We might want to move them somewhere else. *)

--- a/proof/crefine/X64/PSpace_C.thy
+++ b/proof/crefine/X64/PSpace_C.thy
@@ -119,7 +119,6 @@ lemma storePTE_Basic_ccorres':
           erule ko_at_projectKO_opt, simp+)
   apply (simp add: cready_queues_relation_def
                    carch_state_relation_def
-                   fpu_null_state_heap_update_tag_disj_simps
                    cmachine_state_relation_def
                    Let_def typ_heap_simps
                    cteCaps_of_def update_pte_map_tos bit_simps)
@@ -166,7 +165,6 @@ lemma storePDE_Basic_ccorres':
           erule ko_at_projectKO_opt, simp+)
   apply (simp add: cready_queues_relation_def
                    carch_state_relation_def
-                   fpu_null_state_heap_update_tag_disj_simps
                    cmachine_state_relation_def
                    Let_def typ_heap_simps bit_simps
                    cteCaps_of_def update_pde_map_tos)
@@ -212,7 +210,6 @@ lemma storePDPTE_Basic_ccorres':
           erule ko_at_projectKO_opt, simp+)
   apply (simp add: cready_queues_relation_def
                    carch_state_relation_def
-                   fpu_null_state_heap_update_tag_disj_simps
                    cmachine_state_relation_def
                    Let_def typ_heap_simps
                    cteCaps_of_def update_pdpte_map_tos bit_simps)
@@ -259,7 +256,6 @@ lemma storePML4E_Basic_ccorres':
           erule ko_at_projectKO_opt, simp+)
   apply (simp add: cready_queues_relation_def
                    carch_state_relation_def
-                   fpu_null_state_heap_update_tag_disj_simps
                    cmachine_state_relation_def
                    Let_def typ_heap_simps bit_simps
                    cteCaps_of_def update_pml4e_map_tos)

--- a/proof/crefine/X64/Recycle_C.thy
+++ b/proof/crefine/X64/Recycle_C.thy
@@ -315,8 +315,7 @@ lemma clearMemory_PageCap_ccorres:
    apply (clarsimp simp: rf_sr_def cstate_relation_def Let_def)
    apply (clarsimp simp: cpspace_relation_def typ_heap_simps
                          clift_foldl_hrs_mem_update foldl_id
-                         carch_state_relation_def fpu_null_state_relation_def
-                         cmachine_state_relation_def
+                         carch_state_relation_def cmachine_state_relation_def
                          foldl_fun_upd_const[unfolded fun_upd_def]
                          power_user_page_foldl_zero_ranges
                          dom_heap_to_device_data)
@@ -681,7 +680,6 @@ lemma clearMemory_setObject_PTE_ccorres:
     apply (rule cmap_relation_updI, simp_all)[1]
     apply (simp add: cpte_relation_def Let_def pte_lift_def)
    apply (simp add: carch_state_relation_def cmachine_state_relation_def
-                    fpu_null_state_heap_update_tag_disj_simps
                     global_ioport_bitmap_heap_update_tag_disj_simps
                     update_pte_map_tos)
   apply simp
@@ -932,8 +930,7 @@ lemma cancelBadgedSends_ccorres:
           apply (rule setObject_eq; simp add: objBits_simps')[1]
          apply (clarsimp simp: rf_sr_def cstate_relation_def Let_def
                                carch_state_relation_def cmachine_state_relation_def
-                               packed_heap_update_collapse_hrs
-                               fpu_null_state_heap_update_tag_disj_simps)
+                               packed_heap_update_collapse_hrs)
          apply (clarsimp simp: cpspace_relation_def update_ep_map_tos typ_heap_simps')
          apply (erule(1) cpspace_relation_ep_update_ep2)
           apply (simp add: cendpoint_relation_def endpoint_state_defs)
@@ -973,7 +970,6 @@ lemma cancelBadgedSends_ccorres:
                apply (clarsimp simp: rf_sr_def cstate_relation_def Let_def
                                      packed_heap_update_collapse_hrs
                                      carch_state_relation_def
-                                     fpu_null_state_heap_update_tag_disj_simps
                                      cmachine_state_relation_def)
                apply (clarsimp simp: cpspace_relation_def typ_heap_simps'
                                      update_ep_map_tos)
@@ -987,7 +983,6 @@ lemma cancelBadgedSends_ccorres:
               apply (clarsimp simp: rf_sr_def cstate_relation_def Let_def
                                     packed_heap_update_collapse_hrs
                                     carch_state_relation_def
-                                    fpu_null_state_heap_update_tag_disj_simps
                                     cmachine_state_relation_def)
               apply (clarsimp simp: cpspace_relation_def typ_heap_simps'
                                     update_ep_map_tos)
@@ -1089,8 +1084,7 @@ lemma cancelBadgedSends_ccorres:
                     apply (clarsimp simp: image_iff)
                     apply (drule_tac x=p in spec)
                     subgoal by fastforce
-                   apply (clarsimp simp: carch_state_relation_def cmachine_state_relation_def
-                                  elim!: fpu_null_state_typ_heap_preservation)
+                   apply (clarsimp simp: carch_state_relation_def cmachine_state_relation_def)
                   apply (rule ccorres_symb_exec_r2)
                     apply (erule spec)
                    apply vcg
@@ -1205,7 +1199,7 @@ lemma coerce_memset_to_heap_update:
       = heap_update (tcb_Ptr x)
              (tcb_C.tcb_C (arch_tcb_C (user_context_C (user_fpu_state_C (FCP (\<lambda>x. 0))) (FCP (\<lambda>x. 0))))
                           (thread_state_C (FCP (\<lambda>x. 0)))
-                          (NULL)
+                          0 NULL
                           (seL4_Fault_C (FCP (\<lambda>x. 0)))
                           (lookup_fault_C (FCP (\<lambda>x. 0)))
                             0 0 0 0 0 0 NULL NULL NULL NULL)"
@@ -1302,7 +1296,6 @@ lemma updateFreeIndex_ccorres:
     apply (rule setCTE_tcb_case, assumption+)
    apply (case_tac s', clarsimp)
    subgoal by (simp add: carch_state_relation_def cmachine_state_relation_def
-                         fpu_null_state_heap_update_tag_disj_simps
                          global_ioport_bitmap_heap_update_tag_disj_simps)
 
   apply (clarsimp simp: isCap_simps)

--- a/proof/crefine/X64/Refine_C.thy
+++ b/proof/crefine/X64/Refine_C.thy
@@ -79,9 +79,9 @@ proof -
        apply (clarsimp simp: return_def)
       apply (wp schedule_sch_act_wf schedule_invs'
              | strengthen invs_valid_objs_strengthen invs_pspace_aligned' invs_pspace_distinct')+
-   apply (rule_tac Q'="\<lambda>rv s. invs' s \<and> (\<forall>x. rv = Some x \<longrightarrow> x \<le> X64.maxIRQ) \<and> rv \<noteq> Some 0x3FF" in hoare_post_imp)
+   apply (rule_tac Q'="\<lambda>rv s. invs' s \<and> (\<forall>x. rv = Some x \<longrightarrow> x \<le> X64.maxIRQ)" in hoare_post_imp)
     apply (clarsimp simp: non_kernel_IRQs_def)
-   apply (wp getActiveIRQ_le_maxIRQ getActiveIRQ_neq_Some0xFF | simp)+
+   apply (wp getActiveIRQ_le_maxIRQ  | simp)+
   apply (clarsimp simp: invs'_def valid_state'_def)
   done
 qed
@@ -253,7 +253,6 @@ lemma handleSyscall_ccorres:
                 apply (ctac (no_vcg) add: getActiveIRQ_ccorres)
                  apply (rule ccorres_Guard)?
                  apply (simp only: irqInvalid_def)?
-                 apply (rule_tac P="rv \<noteq> Some 0xFFFF" in ccorres_gen_asm)
                  apply (subst ccorres_seq_skip'[symmetric])
                  apply (rule ccorres_split_nothrow_novcg)
                      apply (rule_tac R=\<top> and xf=xfdc in ccorres_when)
@@ -264,11 +263,10 @@ lemma handleSyscall_ccorres:
                   apply wp
                  apply (simp add: guard_is_UNIV_def)
                 apply clarsimp
-                apply (rule_tac Q'="\<lambda>rv s. invs' s \<and>
-                 (\<forall>x. rv = Some x \<longrightarrow> x \<le> X64.maxIRQ) \<and> rv \<noteq> Some 0x3FF"
-                                             in hoare_post_imp)
+                apply (rule_tac Q'="\<lambda>rv s. invs' s \<and> (\<forall>x. rv = Some x \<longrightarrow> x \<le> X64.maxIRQ)"
+                             in hoare_post_imp)
                  apply (clarsimp simp: non_kernel_IRQs_def)
-                apply (wp getActiveIRQ_le_maxIRQ getActiveIRQ_neq_Some0xFF | simp)+
+                apply (wp getActiveIRQ_le_maxIRQ | simp)+
                apply (rule_tac Q'=" invs' " in hoare_post_impE_E_dc, wp)
                apply (simp add: invs'_def valid_state'_def)
               apply clarsimp
@@ -288,7 +286,6 @@ lemma handleSyscall_ccorres:
                apply (rule ccorres_cond_univ)
                apply (simp add: liftE_def bind_assoc irqInvalid_def)
                apply (ctac (no_vcg) add: getActiveIRQ_ccorres)
-                apply (rule_tac P="rv \<noteq> Some 0xFFFF" in ccorres_gen_asm)
                 apply (subst ccorres_seq_skip'[symmetric])
                 apply (rule ccorres_split_nothrow_novcg)
                     apply (rule ccorres_Guard)?
@@ -300,11 +297,10 @@ lemma handleSyscall_ccorres:
                  apply wp
                 apply (simp add: guard_is_UNIV_def)
                apply clarsimp
-               apply (rule_tac Q'="\<lambda>rv s. invs' s \<and>
-                (\<forall>x. rv = Some x \<longrightarrow> x \<le> X64.maxIRQ) \<and> rv \<noteq> Some 0x3FF"
-                                     in hoare_post_imp)
+               apply (rule_tac Q'="\<lambda>rv s. invs' s \<and> (\<forall>x. rv = Some x \<longrightarrow> x \<le> X64.maxIRQ)"
+                            in hoare_post_imp)
                 apply (clarsimp simp: non_kernel_IRQs_def)
-               apply (wp getActiveIRQ_le_maxIRQ getActiveIRQ_neq_Some0xFF | simp)+
+               apply (wp getActiveIRQ_le_maxIRQ | simp)+
               apply (rule_tac Q'=" invs' " in hoare_post_impE_E_dc, wp)
               apply (simp add: invs'_def valid_state'_def)
              apply clarsimp
@@ -323,25 +319,22 @@ lemma handleSyscall_ccorres:
               apply (rule ccorres_cond_univ)
               apply (simp add: liftE_def bind_assoc irqInvalid_def)
               apply (ctac (no_vcg) add: getActiveIRQ_ccorres)
-               apply (rule_tac P="rv \<noteq> Some 0xFFFF" in ccorres_gen_asm)
                apply (subst ccorres_seq_skip'[symmetric])
                apply (rule ccorres_split_nothrow_novcg)
                    apply (rule ccorres_Guard)?
                    apply (rule_tac R=\<top> and xf=xfdc in ccorres_when)
                     apply (case_tac rv, clarsimp)
                     apply (clarsimp simp: ucast_8_32_neq)
-                   apply clarsimp
                    apply (ctac (no_vcg) add: handleInterrupt_ccorres)
                   apply ceqv
                  apply (rule_tac ccorres_returnOk_skip[unfolded returnOk_def,simplified])
                 apply wp
                apply (simp add: guard_is_UNIV_def)
               apply clarsimp
-              apply (rule_tac Q'="\<lambda>rv s. invs' s \<and>
-               (\<forall>x. rv = Some x \<longrightarrow> x \<le> X64.maxIRQ) \<and> rv \<noteq> Some 0x3FF"
-                                        in hoare_post_imp)
+              apply (rule_tac Q'="\<lambda>rv s. invs' s \<and> (\<forall>x. rv = Some x \<longrightarrow> x \<le> X64.maxIRQ)"
+                           in hoare_post_imp)
                apply (clarsimp simp: non_kernel_IRQs_def)
-              apply (wp getActiveIRQ_le_maxIRQ getActiveIRQ_neq_Some0xFF | simp)+
+              apply (wp getActiveIRQ_le_maxIRQ | simp)+
              apply (rule_tac Q'=" invs' " in hoare_post_impE_E_dc, wp)
              apply (simp add: invs'_def valid_state'_def)
             apply clarsimp

--- a/proof/crefine/X64/Retype_C.thy
+++ b/proof/crefine/X64/Retype_C.thy
@@ -1543,7 +1543,7 @@ proof (intro impI allI)
   thus ?thesis using rf empty kdr rzo
   apply (simp add: rf_sr_def cstate_relation_def Let_def rl'
                    tag_disj_via_td_name)
-  apply (simp add: carch_state_relation_def fpu_null_state_relation_def cmachine_state_relation_def)
+  apply (simp add: carch_state_relation_def cmachine_state_relation_def)
   apply (simp add: rl' cterl tag_disj_via_td_name h_t_valid_clift_Some_iff)
   apply (clarsimp simp: hrs_htd_update ptr_retyps_htd_safe_neg szo
                         kernel_data_refs_domain_eq_rotate
@@ -1657,7 +1657,7 @@ proof (intro impI allI)
 
   thus ?thesis using rf empty kdr rzo
     apply (simp add: rf_sr_def cstate_relation_def Let_def rl' tag_disj_via_td_name)
-    apply (simp add: carch_state_relation_def fpu_null_state_relation_def cmachine_state_relation_def)
+    apply (simp add: carch_state_relation_def cmachine_state_relation_def)
     apply (simp add: rl' cterl tag_disj_via_td_name h_t_valid_clift_Some_iff )
     apply (clarsimp simp: hrs_htd_update ptr_retyps_htd_safe_neg szo
                           kernel_data_refs_domain_eq_rotate
@@ -1804,7 +1804,7 @@ proof (intro impI allI)
 
   thus ?thesis using rf empty kdr irq rzo
     apply (simp add: rf_sr_def cstate_relation_def Let_def rl' tag_disj_via_td_name)
-    apply (simp add: carch_state_relation_def fpu_null_state_relation_def cmachine_state_relation_def)
+    apply (simp add: carch_state_relation_def cmachine_state_relation_def)
     apply (simp add: rl' cterl tag_disj_via_td_name h_t_valid_clift_Some_iff)
     apply (clarsimp simp: hrs_htd_update ptr_retyps_htd_safe_neg szo
                           kernel_data_refs_domain_eq_rotate
@@ -2101,7 +2101,7 @@ proof (intro impI allI)
   ultimately
   show ?thesis using rf empty kernel_data_refs_disj rzo
     apply (simp add: rf_sr_def cstate_relation_def Let_def rl' tag_disj_via_td_name)
-    apply (simp add: carch_state_relation_def fpu_null_state_relation_def cmachine_state_relation_def)
+    apply (simp add: carch_state_relation_def cmachine_state_relation_def)
     apply (clarsimp simp add: rl' cterl tag_disj_via_td_name
       hrs_htd_update ht_rl foldr_upd_app_if [folded data_map_insert_def] rl projectKOs
       cvariable_array_ptr_retyps[OF szo]
@@ -2284,7 +2284,7 @@ proof (intro impI allI)
   ultimately
   show ?thesis using rf empty kernel_data_refs_disj rzo
     apply (simp add: rf_sr_def cstate_relation_def Let_def rl' tag_disj_via_td_name)
-    apply (simp add: carch_state_relation_def fpu_null_state_relation_def cmachine_state_relation_def)
+    apply (simp add: carch_state_relation_def cmachine_state_relation_def)
     apply (clarsimp simp add: rl' cterl tag_disj_via_td_name
       hrs_htd_update ht_rl foldr_upd_app_if [folded data_map_insert_def] rl projectKOs
       cvariable_array_ptr_retyps[OF szo]
@@ -2465,7 +2465,7 @@ proof (intro impI allI)
   ultimately
   show ?thesis using rf empty kernel_data_refs_disj rzo
     apply (simp add: rf_sr_def cstate_relation_def Let_def rl' tag_disj_via_td_name)
-    apply (simp add: carch_state_relation_def fpu_null_state_relation_def cmachine_state_relation_def)
+    apply (simp add: carch_state_relation_def cmachine_state_relation_def)
     apply (clarsimp simp add: rl' cterl tag_disj_via_td_name
       hrs_htd_update ht_rl foldr_upd_app_if [folded data_map_insert_def] rl projectKOs
       cvariable_array_ptr_retyps[OF szo]
@@ -2646,7 +2646,7 @@ proof (intro impI allI)
   ultimately
   show ?thesis using rf empty kernel_data_refs_disj rzo
     apply (simp add: rf_sr_def cstate_relation_def Let_def rl' tag_disj_via_td_name)
-    apply (simp add: carch_state_relation_def fpu_null_state_relation_def cmachine_state_relation_def)
+    apply (simp add: carch_state_relation_def cmachine_state_relation_def)
     apply (clarsimp simp add: rl' cterl tag_disj_via_td_name
       hrs_htd_update ht_rl foldr_upd_app_if [folded data_map_insert_def] rl projectKOs
       cvariable_array_ptr_retyps[OF szo]
@@ -2843,8 +2843,7 @@ lemma insertNewCap_ccorres_helper:
   apply (simp cong: lifth_update)
   apply (rule conjI)
    apply (erule (1) setCTE_tcb_case)
-  apply (simp add: carch_state_relation_def cmachine_state_relation_def
-                   fpu_null_state_heap_update_tag_disj_simps typ_heap_simps
+  apply (simp add: carch_state_relation_def cmachine_state_relation_def typ_heap_simps
                    cvariable_array_map_const_add_map_option[where f="tcb_no_ctes_proj"])
   done
 
@@ -3501,10 +3500,6 @@ lemmas field_tag_subs =
   field_tag_sub_trans[OF field_tag_sub']
   field_tag_sub'
 
-lemmas fpu_null_state_heap_update_field =
-  field_tag_subs[THEN disjoint_subset[where B=kernel_data_refs],
-                 THEN fpu_null_state_heap_update_span_disjoint]
-
 context
   fixes p:: "'a::mem_type ptr" and n :: nat
   assumes nkr: "{ptr_val p ..+ n * size_of TYPE('a)} \<inter> kernel_data_refs = {}"
@@ -3518,12 +3513,6 @@ lemma retyp_non_kernel_data_ref:
   apply (subst Int_commute)
   apply (rule disjoint_subset2[OF assms nkr])
   done
-
-lemma fpu_null_state_retyp_disjoint:
-  "fpu_null_state_relation (hrs_htd_update (ptr_retyps_gen n p foo) h) = fpu_null_state_relation h"
-  by (cases "ptr_span (fpu_state_Ptr (symbol_table ''x86KSnullFpuState'')) \<subseteq> kernel_data_refs";
-      clarsimp simp: fpu_null_state_relation_def lift_t_Some_iff hrs_htd_update
-                     retyp_non_kernel_data_ref)
 
 end
 
@@ -3885,7 +3874,9 @@ proof -
        tcbFaultHandler_C := 0, tcbIPCBuffer_C := 0,
        tcbSchedNext_C := tcb_Ptr 0, tcbSchedPrev_C := tcb_Ptr 0,
        tcbEPNext_C := tcb_Ptr 0, tcbEPPrev_C := tcb_Ptr 0,
-       tcbBoundNotification_C := ntfn_Ptr 0\<rparr>"
+       tcbBoundNotification_C := ntfn_Ptr 0,
+       tcb_C.flags_C := 0\<rparr>"
+
   have fbtcb: "from_bytes (replicate (size_of TYPE(tcb_C)) 0) = ?tcb"
     apply (simp add: from_bytes_def)
     apply (simp add: typ_info_simps tcb_C_tag_def)
@@ -4099,12 +4090,6 @@ proof -
                           htd_safe[simplified] kernel_data_refs_domain_eq_rotate)
     apply (simp add: heap_updates_def tcb_queue_update_other' hrs_htd_update
                      ptr_retyp_to_array[simplified] irq[simplified])
-    apply (match premises in H: \<open>fpu_null_state_relation _\<close> \<Rightarrow>
-             \<open>match premises in _[thin]: _ (multi) \<Rightarrow> \<open>insert H\<close>\<close>)
-    apply (simp add: fpu_null_state_heap_update_field p_nkr size_td_array
-                     fpu_null_state_retyp_disjoint
-                     disjoint_subset[OF _ kdr] disjoint_subset[OF _ p_nkr]
-                     intvl_start_le cte_C_size tcbBlockSizeBits_def)
     done
 qed
 
@@ -4256,8 +4241,7 @@ lemma rf_sr_rep0:
   shows "(\<sigma>, globals_update (t_hrs_'_update (hrs_mem_update (heap_update_list ptr (replicate sz 0)))) x) \<in> rf_sr"
   using sr
   by (clarsimp simp: rf_sr_def cstate_relation_def Let_def cpspace_relation_def
-                     carch_state_relation_def fpu_null_state_relation_def
-                     cmachine_state_relation_def hrs_mem_update
+                     carch_state_relation_def cmachine_state_relation_def hrs_mem_update
                      cslift_bytes_mem_update[OF empty, simplified] cte_C_size)
 
 (* FIXME: generalise *)
@@ -4756,7 +4740,7 @@ proof (intro impI allI)
 
   thus  ?thesis using rf empty kdr rzo
     apply (simp add: rf_sr_def cstate_relation_def Let_def rl' tag_disj_via_td_name )
-    apply (simp add: carch_state_relation_def fpu_null_state_relation_def cmachine_state_relation_def)
+    apply (simp add: carch_state_relation_def cmachine_state_relation_def)
     apply (simp add: tag_disj_via_td_name rl' tcb_C_size h_t_valid_clift_Some_iff)
     apply (clarsimp simp: hrs_htd_update szo'[symmetric])
     apply (simp add:szo hrs_htd_def p2dist objBits_simps ko_def ptr_retyps_htd_safe_neg
@@ -4815,8 +4799,7 @@ lemma copyGlobalMappings_ccorres:
                               carray_map_relation_upd_triv)
         subgoal by (erule (2) cmap_relation_updI; simp)
        subgoal by (clarsimp simp: carch_state_relation_def cmachine_state_relation_def
-                                  global_ioport_bitmap_heap_update_tag_disj_simps
-                                  fpu_null_state_heap_update_tag_disj_simps)
+                                  global_ioport_bitmap_heap_update_tag_disj_simps)
       apply simp
      apply (simp add: objBits_simps archObjSize_def)
     apply clarsimp
@@ -5152,14 +5135,13 @@ lemmas Mode_initContext_spec'' =
 lemma Arch_initContext_spec':
   shows
     "\<forall>s\<^sub>0. \<Gamma> \<turnstile>
-      {t. t = s\<^sub>0 \<and> t \<Turnstile>\<^sub>c context_' t \<and> s\<^sub>0 \<Turnstile>\<^sub>c fpu_state_Ptr (symbol_table ''x86KSnullFpuState'')}
+      {t. t = s\<^sub>0 \<and> t \<Turnstile>\<^sub>c context_' t}
         Call Arch_initContext_'proc
       {t. t = globals_update
                (t_hrs_'_update
                 (hrs_mem_update
                  (heap_update (fpu_state_Ptr &(context_' s\<^sub>0\<rightarrow>[''fpuState_C'']))
-                              (h_val (hrs_mem (t_hrs_' (globals s\<^sub>0)))
-                                     (fpu_state_Ptr (symbol_table ''x86KSnullFpuState''))) \<circ>
+                              (x86KSnullFpuState_' (globals s\<^sub>0)) \<circ>
                   heap_update (registers_Ptr &(context_' s\<^sub>0\<rightarrow>[''registers_C'']))
                               (array_updates (h_val (hrs_mem (t_hrs_' (globals s\<^sub>0)))
                                                     (registers_Ptr &(context_' s\<^sub>0\<rightarrow>[''registers_C''])))
@@ -5175,19 +5157,18 @@ lemma Arch_initContext_spec':
           | (vcg exspec=Mode_initContext_spec'',
              clarsimp simp: hrs_mem_update_compose h_val_id packed_heap_update_collapse o_def
                             array_updates_rev_app))+
-  apply (auto simp: h_val_heap_same_hrs_mem_update_typ_disj[OF h_t_valid_c_guard_field _ tag_disj_via_td_name]
-                    export_tag_adjust_ti typ_uinfo_t_def array_updates_rev
+  apply (auto simp: array_updates_rev
               cong: Kernel_C.globals.unfold_congs StateSpace.state.unfold_congs)
   done
 
 lemma rf_sr_fpu_null_relation:
-  "(s,s') \<in> rf_sr \<Longrightarrow> fpu_null_state_relation (t_hrs_' (globals s'))"
+  "(s,s') \<in> rf_sr \<Longrightarrow> fpu_null_state_relation (x86KSnullFpuState_' (globals s'))"
   by (simp add: rf_sr_def cstate_relation_def Let_def carch_state_relation_def)
 
 lemma ccorres_placeNewObject_tcb:
   "ccorresG rf_sr \<Gamma> dc xfdc
    (pspace_aligned' and pspace_distinct' and pspace_no_overlap' regionBase tcbBlockSizeBits
-      and (\<lambda>s. sym_refs (state_refs_of' s))
+      and (\<lambda>s. sym_refs (state_refs_of' s)) and valid_idle'
       and (\<lambda>s. 2 ^ tcbBlockSizeBits \<le> gsMaxObjectSize s)
       and ret_zero regionBase (2 ^ tcbBlockSizeBits)
       and K (regionBase \<noteq> 0 \<and> range_cover regionBase tcbBlockSizeBits tcbBlockSizeBits 1
@@ -5237,16 +5218,7 @@ lemma ccorres_placeNewObject_tcb:
      apply (erule disjoint_subset[rotated],
             simp add: intvl_start_le size_td_array cte_C_size objBits_defs)
     apply (clarsimp simp: hrs_htd_update)
-    apply (rule h_t_valid_field[rotated], simp+)+
-   apply (clarsimp simp: hrs_htd_update)
-   apply (subgoal_tac "{regionBase + 0x400 ..+ size_of TYPE(tcb_C)} \<subseteq> {regionBase ..+ 2 ^ tcbBlockSizeBits}")
-    apply (subgoal_tac "{regionBase ..+ 5*size_of TYPE(cte_C)} \<subseteq> {regionBase ..+ 2 ^ tcbBlockSizeBits}")
-     apply (intro h_t_valid_ptr_retyps_gen_disjoint
-                    [where n=1 and arr=False, unfolded ptr_retyps_gen_def, simplified];
-            clarsimp simp: rf_sr_def cstate_relation_def Let_def carch_state_relation_def
-                           fpu_null_state_relation_def2 objBits_defs
-                    elim!: disjoint_subset disjoint_subset2; blast)
-    apply (rule intvl_sub_offset intvl_start_le; clarsimp simp: objBits_defs cte_C_size)+
+    apply ((rule h_t_valid_field[rotated], simp+)+)[1]
   apply (rule bexI[OF _ placeNewObject_eq];
          clarsimp simp: hrs_htd_update word_bits_def no_fail_def objBitsKO_def
                         range_cover.aligned new_cap_addrs_def)
@@ -5256,7 +5228,7 @@ lemma ccorres_placeNewObject_tcb:
          clarsimp simp: ctcb_ptr_to_tcb_ptr_def objBitsKO_def range_cover.aligned)
     apply (frule region_actually_is_bytes; clarsimp simp: region_is_bytes'_def)
    apply (clarsimp simp: hrs_mem_def)
-  apply (frule rf_sr_fpu_null_relation; simp add: fpu_null_state_relation_def2)
+  apply (frule rf_sr_fpu_null_relation; simp add: fpu_null_state_relation_def)
   by (clarsimp simp: ctcb_offset_defs rf_sr_def ptr_retyps_gen_def heap_updates_def
                      hrs_mem_update_compose
                cong: Kernel_C.globals.unfold_congs StateSpace.state.unfold_congs
@@ -5586,7 +5558,7 @@ proof (intro impI allI)
 
   thus  ?thesis using rf empty kdr rzo
     apply (simp add: rf_sr_def cstate_relation_def Let_def rl' tag_disj_via_td_name )
-    apply (simp add: carch_state_relation_def fpu_null_state_relation_def cmachine_state_relation_def)
+    apply (simp add: carch_state_relation_def cmachine_state_relation_def)
     apply (simp add: tag_disj_via_td_name rl' tcb_C_size h_t_valid_clift_Some_iff)
     apply (clarsimp simp: hrs_htd_update szo'[symmetric] cvariable_array_ptr_retyps[OF szo] rb')
     apply (subst zero_ranges_ptr_retyps, simp_all only: szo'[symmetric] power_add, simp)
@@ -6159,8 +6131,7 @@ lemma threadSet_domain_ccorres [corres]:
    apply assumption
   apply clarsimp
   apply (clarsimp simp: rf_sr_def cstate_relation_def Let_def)
-  apply (clarsimp simp: cmachine_state_relation_def carch_state_relation_def cpspace_relation_def
-                        fpu_null_state_heap_update_tag_disj_simps)
+  apply (clarsimp simp: cmachine_state_relation_def carch_state_relation_def cpspace_relation_def)
   apply (clarsimp simp: update_tcb_map_tos typ_heap_simps')
   apply (simp add: map_to_ctes_upd_tcb_no_ctes map_to_tcbs_upd tcb_cte_cases_def cteSizeBits_def)
   apply (simp add: cep_relations_drop_fun_upd
@@ -7235,8 +7206,7 @@ lemma ccorres_typ_region_bytes_dummy:
                    objBitsT_simps word_bits_def zero_ranges_are_zero_typ_region_bytes
              cong: conj_cong)
   apply (rule conjI, rule htd_safe_typ_region_bytes, simp, blast)
-  by (clarsimp simp: global_ioport_bitmap_relation_def fpu_null_state_relation_def
-                     typ_bytes_cpspace_relation_clift_gptr
+  by (clarsimp simp: global_ioport_bitmap_relation_def typ_bytes_cpspace_relation_clift_gptr
                      cpspace_relation_def bit_simps word_bits_def invs_pspace_aligned')
 
 lemma region_is_typeless_cong:

--- a/proof/crefine/X64/SR_lemmas_C.thy
+++ b/proof/crefine/X64/SR_lemmas_C.thy
@@ -295,12 +295,12 @@ lemma cmdbnode_relation_mdb_node_to_H [simp]:
 definition tcb_no_ctes_proj ::
   "tcb \<Rightarrow> Structures_H.thread_state \<times> machine_word \<times> machine_word \<times> arch_tcb \<times> bool \<times> word8
           \<times> word8 \<times> word8 \<times> nat \<times> fault option \<times> machine_word option
-          \<times> machine_word option \<times> machine_word option"
+          \<times> machine_word option \<times> machine_word option \<times> machine_word"
   where
   "tcb_no_ctes_proj t \<equiv>
      (tcbState t, tcbFaultHandler t, tcbIPCBuffer t, tcbArch t, tcbQueued t,
       tcbMCP t, tcbPriority t, tcbDomain t, tcbTimeSlice t, tcbFault t, tcbBoundNotification t,
-      tcbSchedNext t, tcbSchedPrev t)"
+      tcbSchedNext t, tcbSchedPrev t, tcbFlags t)"
 
 lemma tcb_cte_cases_proj_eq [simp]:
   "tcb_cte_cases p = Some (getF, setF) \<Longrightarrow>
@@ -1075,7 +1075,9 @@ lemma cstate_relation_only_t_hrs:
   ksDomainTime_' s = ksDomainTime_' t;
   num_ioapics_' s = num_ioapics_' t;
   ioapic_nirqs_' s = ioapic_nirqs_' t;
-  x86KSIRQState_' s = x86KSIRQState_' t
+  x86KSIRQState_' s = x86KSIRQState_' t;
+  ksCurFPUOwner_' s = ksCurFPUOwner_' t;
+  x86KSnullFpuState_' s = x86KSnullFpuState_' t
   \<rbrakk>
   \<Longrightarrow> cstate_relation a s = cstate_relation a t"
   unfolding cstate_relation_def
@@ -1102,6 +1104,8 @@ lemma rf_sr_upd:
     "num_ioapics_' (globals x) = num_ioapics_' (globals y)"
     "ioapic_nirqs_' (globals x) = ioapic_nirqs_' (globals y)"
     "x86KSIRQState_' (globals x) = x86KSIRQState_' (globals y)"
+    "ksCurFPUOwner_' (globals x) = ksCurFPUOwner_' (globals y)"
+    "x86KSnullFpuState_' (globals x) = x86KSnullFpuState_' (globals y)"
   shows "((a, x) \<in> rf_sr) = ((a, y) \<in> rf_sr)"
   unfolding rf_sr_def using assms
   by simp (rule cstate_relation_only_t_hrs, auto)
@@ -1125,6 +1129,8 @@ lemma rf_sr_upd_safe[simp]:
     "num_ioapics_' (globals (g y)) = num_ioapics_' (globals y)"
     "ioapic_nirqs_' (globals (g y)) = ioapic_nirqs_' (globals y)"
     "x86KSIRQState_' (globals (g y)) = x86KSIRQState_' (globals y)"
+    "ksCurFPUOwner_' (globals (g y)) = ksCurFPUOwner_' (globals y)"
+    "x86KSnullFpuState_' (globals (g y)) = x86KSnullFpuState_' (globals y)"
   and    gs: "ghost'state_' (globals (g y)) = ghost'state_' (globals y)"
   and     wu:  "(ksWorkUnitsCompleted_' (globals (g y))) = (ksWorkUnitsCompleted_' (globals y))"
   shows "((a, (g y)) \<in> rf_sr) = ((a, y) \<in> rf_sr)"
@@ -2424,12 +2430,6 @@ lemma tcb_and_not_mask_canonical:
 lemmas tcb_ptr_sign_extend_canonical =
       tcb_and_not_mask_canonical[where n=0, simplified mask_def objBits_simps', simplified]
 
-lemma fpu_null_state_typ_heap_preservation:
-  assumes "fpu_null_state_relation s"
-  assumes "(clift t :: user_fpu_state_C typ_heap) = clift s"
-  shows "fpu_null_state_relation t"
-  using assms by (simp add: fpu_null_state_relation_def)
-
 (* FIXME: move up to TypHeap? *)
 lemma lift_t_Some_iff:
   "lift_t g hrs p = Some v \<longleftrightarrow> hrs_htd hrs, g \<Turnstile>\<^sub>t p \<and> h_val (hrs_mem hrs) p = v"
@@ -2464,14 +2464,6 @@ lemma global_ioport_bitmap_relation_def2:
         \<and> ptr_span (ioport_table_Ptr (symbol_table ''x86KSAllocatedIOPorts'')) \<subseteq> kernel_data_refs"
   by (clarsimp simp: global_ioport_bitmap_relation_def lift_t_Some_iff)
 
-lemma fpu_null_state_relation_def2:
-  "fpu_null_state_relation hrs \<equiv>
-    hrs_htd hrs \<Turnstile>\<^sub>t fpu_state_Ptr (symbol_table ''x86KSnullFpuState'')
-     \<and> h_val (hrs_mem hrs) (fpu_state_Ptr (symbol_table ''x86KSnullFpuState''))
-         = user_fpu_state_C (ARRAY i. FPUNullState (finite_index i))
-     \<and> ptr_span (fpu_state_Ptr (symbol_table ''x86KSnullFpuState'')) \<subseteq> kernel_data_refs"
-  by (clarsimp simp: fpu_null_state_relation_def lift_t_Some_iff)
-
 lemma global_ioport_bitmap_heap_update_tag_disj':
   fixes p :: "'a::mem_type ptr"
   assumes valid: "hrs_htd h, g \<Turnstile>\<^sub>t p"
@@ -2480,16 +2472,6 @@ lemma global_ioport_bitmap_heap_update_tag_disj':
   unfolding global_ioport_bitmap_relation_def
   using lift_t_heap_update_same[OF valid disj]
   by (clarsimp simp: global_ioport_bitmap_relation_def hrs_mem_update_def hrs_htd_def
-              split: prod.splits)
-
-lemma fpu_null_state_heap_update_tag_disj':
-  fixes p :: "'a::mem_type ptr"
-  assumes valid: "hrs_htd h, g \<Turnstile>\<^sub>t p"
-  assumes disj: "typ_uinfo_t TYPE(user_fpu_state_C) \<bottom>\<^sub>t typ_uinfo_t TYPE('a)"
-  shows "fpu_null_state_relation (hrs_mem_update (heap_update p v) h) = fpu_null_state_relation h"
-  unfolding fpu_null_state_relation_def
-  using lift_t_heap_update_same[OF valid disj]
-  by (clarsimp simp: fpu_null_state_relation_def hrs_mem_update_def hrs_htd_def
               split: prod.splits)
 
 lemma rf_sr_obj_update_helper:
@@ -2509,9 +2491,6 @@ lemmas h_t_valid_fields_clift =
 
 lemmas global_ioport_bitmap_heap_update_tag_disj_simps =
   h_t_valid_fields_clift[THEN global_ioport_bitmap_heap_update_tag_disj'[OF _ tag_disj_via_td_name]]
-
-lemmas fpu_null_state_heap_update_tag_disj_simps =
-  h_t_valid_fields_clift[THEN fpu_null_state_heap_update_tag_disj'[OF _ tag_disj_via_td_name]]
 
 lemma numDomains_sge_1_simp:
   "1 <s Kernel_C.numDomains \<longleftrightarrow> Suc 0 < Kernel_Config.numDomains"

--- a/proof/crefine/X64/Schedule_C.thy
+++ b/proof/crefine/X64/Schedule_C.thy
@@ -70,14 +70,29 @@ lemma switchToIdleThread_ccorres:
       apply (wpsimp simp: X64_H.switchToIdleThread_def wp: hoare_drop_imps)+
   done
 
+\<comment> \<open>The C and specifications differ in where the lazyFpuRestore is located within switchToThread; in
+   the specifications it is in ARCH.switchToThread while in the C it is directly in the generic
+   switchToThread. This difference is because the C treats FPUs being enabled as a generic feature,
+   while it is an architecture feature in the specifications.
+   To make things line up in switchToThread_ccorres we rewrite ARCH.switchToThread to have the
+   lazyFpuRestore outside of it.\<close>
+definition arch_switchToThread where
+  "arch_switchToThread tcb \<equiv> setVMRoot tcb"
+
+lemma arch_switchToThread_rewrite:
+  "X64_H.switchToThread tcb \<equiv> do
+     arch_switchToThread tcb;
+     lazyFpuRestore tcb
+   od"
+  by (clarsimp simp: X64_H.switchToThread_def arch_switchToThread_def bind_assoc)
+
 lemma Arch_switchToThread_ccorres:
   "ccorres dc xfdc
            (all_invs_but_ct_idle_or_in_cur_domain' and tcb_at' t)
            (UNIV \<inter> \<lbrace>\<acute>tcb = tcb_ptr_to_ctcb_ptr t\<rbrace>)
            []
-           (Arch.switchToThread t) (Call Arch_switchToThread_'proc)"
+           (arch_switchToThread t) (Call Arch_switchToThread_'proc)"
   apply (cinit lift: tcb_')
-   apply (unfold X64_H.switchToThread_def)[1]
    apply (rule ccorres_add_return2)
    apply (ctac (no_vcg) add: setVMRoot_ccorres)
     apply csymbr (* config_set(CONFIG_KERNEL_X86_IBPB_ON_CONTEXT_SWITCH) *)
@@ -88,6 +103,33 @@ lemma Arch_switchToThread_ccorres:
    apply wp
   apply clarsimp
   done
+
+lemma lazyFPURestore_ccorres:
+  "ccorres dc xfdc
+     (no_0_obj' and tcb_at' t)
+     (\<lbrace>\<acute>thread = tcb_ptr_to_ctcb_ptr t\<rbrace>) hs
+     (lazyFpuRestore t) (Call lazyFPURestore_'proc)"
+  apply (cinit lift: thread_')
+   apply (rule ccorres_pre_threadGet, rename_tac flags)
+   apply (rule ccorres_move_c_guard_tcb)
+   apply (rule ccorres_if_lhs)
+    apply (rule ccorres_cond_true)
+    apply (ctac add: disableFpu_ccorres)
+   apply (rule ccorres_cond_false)
+   apply (ctac add: nativeThreadUsingFPU_ccorres[where thread=t])
+     apply (rule ccorres_cond[where R=\<top>])
+       apply (clarsimp simp: to_bool_neq_0 split: if_split)
+      apply (ctac add: enableFpu_ccorres)
+     apply (ctac add: switchLocalFpuOwner_ccorres)
+    apply wpsimp
+   apply (vcg exspec=nativeThreadUsingFPU_modifies)
+  apply (clarsimp simp: isFlagSet_def typ_heap_simps' word_bw_comms ctcb_relation_def
+                        option_to_ctcb_ptr_def)
+  done
+
+crunch arch_switchToThread
+  for no_0_obj'[wp]: no_0_obj'
+  and tcb_at'[wp]: "tcb_at' t"
 
 (* FIXME: move *)
 lemma switchToThread_ccorres:
@@ -102,17 +144,27 @@ lemma switchToThread_ccorres:
   apply (rule ccorres_symb_exec_l'[OF _ _ assert_sp]; (solves wpsimp)?)
   apply (rule ccorres_stateAssert_fwd)+
   apply (cinit' lift: thread_')
-   apply (ctac (no_vcg) add: Arch_switchToThread_ccorres)
-    apply (ctac (no_vcg) add: tcbSchedDequeue_ccorres)
-     apply (simp add: setCurThread_def)
-     apply (rule ccorres_stateAssert)
-     apply (rule_tac P=\<top> and P'=UNIV in ccorres_from_vcg)
-     apply clarsimp
-     apply (rule conseqPre, vcg)
-     apply (clarsimp simp: setCurThread_def simpler_modify_def rf_sr_def cstate_relation_def
-                           Let_def carch_state_relation_def cmachine_state_relation_def)
-    apply (wpsimp wp: Arch_switchToThread_invs_no_cicd' hoare_drop_imps
-           | strengthen invs_no_cicd'_pspace_aligned' invs_no_cicd'_pspace_distinct')+
+   \<comment> \<open>Split off Arch_switchToThread and lazyFPURestore and rewrite Haskell to line up.
+       We do this locally in the ccorres step to avoid affecting the later wp proof.\<close>
+   apply (rule ccorres_rhs_assoc2)
+   apply (rule ccorres_split_nothrow)
+       apply (clarsimp simp: arch_switchToThread_rewrite)
+       apply (ctac (no_vcg) add: Arch_switchToThread_ccorres)
+        apply (rule ccorres_call[where xf'=xfdc], ctac (no_vcg) add: lazyFPURestore_ccorres; simp)
+       apply wpsimp
+      apply ceqv
+     apply (ctac (no_vcg) add: tcbSchedDequeue_ccorres)
+      apply (simp add: setCurThread_def)
+      apply (rule ccorres_stateAssert)
+      apply (rule_tac P=\<top> and P'=UNIV in ccorres_from_vcg)
+      apply clarsimp
+      apply (rule conseqPre, vcg)
+      apply (clarsimp simp: setCurThread_def simpler_modify_def rf_sr_def cstate_relation_def
+                            Let_def carch_state_relation_def cmachine_state_relation_def)
+     apply (wpsimp wp: Arch_switchToThread_invs_no_cicd'
+            | strengthen invs_no_cicd'_pspace_aligned' invs_no_cicd'_pspace_distinct')+
+   apply (vcg exspec=lazyFPURestore_modifies exspec=Arch_switchToThread_modifies)
+  apply (clarsimp simp: invs_cicd_no_0_obj')
   done
 
 lemma activateThread_ccorres:
@@ -402,11 +454,20 @@ lemma nextDomain_ccorres:
   apply simp
   done
 
+lemma prepareNextDomain_ccorres:
+  "ccorres dc xfdc invs' UNIV [] prepareNextDomain (Call prepareNextDomain_'proc)"
+  apply cinit
+  apply (ctac add: switchLocalFpuOwner_ccorres)
+  by (clarsimp simp: option_to_ctcb_ptr_def)
+
 lemma scheduleChooseNewThread_ccorres:
   "ccorres dc xfdc
      (\<lambda>s. invs' s \<and> ksSchedulerAction s = ChooseNewThread) UNIV hs
      (do domainTime \<leftarrow> getDomainTime;
-         y \<leftarrow> when (domainTime = 0) nextDomain;
+         y \<leftarrow> when (domainTime = 0) (do
+             y <- prepareNextDomain;
+             nextDomain
+         od);
          chooseThread
       od)
      (Call scheduleChooseNewThread_'proc)"
@@ -415,12 +476,14 @@ lemma scheduleChooseNewThread_ccorres:
    apply (rule ccorres_split_nothrow)
        apply (rule_tac R="\<lambda>s. ksDomainTime s = domainTime" in ccorres_when)
         apply (fastforce simp: rf_sr_ksDomainTime)
-       apply (rule_tac xf'=xfdc in ccorres_call[OF nextDomain_ccorres] ; simp)
+       apply (ctac (no_vcg) add: prepareNextDomain_ccorres)
+        apply (rule ccorres_call[OF nextDomain_ccorres, where xf'=xfdc] ; simp)
+       apply wpsimp
       apply ceqv
      apply (ctac (no_vcg) add: chooseThread_ccorres)
     apply (wp nextDomain_invs_no_cicd')
    apply clarsimp
-   apply (vcg exspec=nextDomain_modifies)
+   apply (vcg exspec=nextDomain_modifies exspec=prepareNextDomain_modifies)
   apply (clarsimp simp: if_apply_def2 invs'_invs_no_cicd')
   done
 
@@ -741,8 +804,7 @@ lemma threadSet_timeSlice_ccorres [corres]:
    apply assumption
   apply clarsimp
   apply (clarsimp simp: rf_sr_def cstate_relation_def Let_def)
-  apply (clarsimp simp: cmachine_state_relation_def carch_state_relation_def cpspace_relation_def
-                        fpu_null_state_heap_update_tag_disj_simps)
+  apply (clarsimp simp: cmachine_state_relation_def carch_state_relation_def cpspace_relation_def)
   apply (clarsimp simp: update_tcb_map_tos typ_heap_simps')
   apply (simp add: map_to_ctes_upd_tcb_no_ctes tcb_cte_cases_def tcb_cte_cases_neqs
                    map_to_tcbs_upd)

--- a/proof/crefine/X64/StateRelation_C.thy
+++ b/proof/crefine/X64/StateRelation_C.thy
@@ -174,12 +174,16 @@ where
            \<and> ptr_span (ioport_table_Ptr (symbol_table ''x86KSAllocatedIOPorts'')) \<subseteq> kernel_data_refs"
 
 definition
-  fpu_null_state_relation :: "heap_raw_state \<Rightarrow> bool"
+  fpu_null_state_relation :: "user_fpu_state_C \<Rightarrow> bool"
 where
-  "fpu_null_state_relation hrs \<equiv>
-    clift hrs (Ptr (symbol_table ''x86KSnullFpuState''))
-      = Some (user_fpu_state_C (ARRAY i. FPUNullState (finite_index i))) \<and>
-    ptr_span (fpu_state_Ptr (symbol_table ''x86KSnullFpuState'')) \<subseteq> kernel_data_refs"
+  "fpu_null_state_relation nullFpuState \<equiv>
+    nullFpuState = user_fpu_state_C (ARRAY i. FPUNullState (finite_index i))"
+
+definition cur_fpu_relation :: "machine_word option \<Rightarrow> tcb_C ptr \<Rightarrow> bool" where
+  "cur_fpu_relation akscurfpu cfpu \<equiv>
+     case akscurfpu of
+       Some acurfpu \<Rightarrow> cfpu = tcb_ptr_to_ctcb_ptr acurfpu \<and> cfpu \<noteq> NULL
+     | None \<Rightarrow> cfpu = NULL"
 
 definition
   carch_state_relation :: "Arch.kernel_state \<Rightarrow> globals \<Rightarrow> bool"
@@ -189,11 +193,12 @@ where
     array_relation ((=) \<circ> option_to_ptr) (2^asid_high_bits - 1) (x64KSASIDTable astate) (x86KSASIDTable_' cstate) \<and>
     ccr3_relation (x64KSCurrentUserCR3 astate) (x64KSCurrentUserCR3_' cstate) \<and>
     global_ioport_bitmap_relation (clift (t_hrs_' cstate)) (x64KSAllocatedIOPorts astate) \<and>
-    fpu_null_state_relation (t_hrs_' cstate) \<and>
+    fpu_null_state_relation (x86KSnullFpuState_' cstate) \<and>
     x64KSNumIOAPICs astate = UCAST (32 \<rightarrow> 64) (num_ioapics_' cstate) \<and>
     array_relation (=) (of_nat Kernel_Config.maxNumIOAPIC) (x64KSIOAPICnIRQs astate) (ioapic_nirqs_' cstate) \<and>
     array_relation x64_irq_state_relation maxIRQ (x64KSIRQState astate) (x86KSIRQState_' cstate) \<and>
-    carch_globals astate"
+    carch_globals astate \<and>
+    cur_fpu_relation (x64KSCurFPUOwner astate) (ksCurFPUOwner_' cstate)"
 
 end
 
@@ -206,6 +211,7 @@ where
   irq_masks s = irq_masks (phantom_machine_state_' s') \<and>
   irq_state s = irq_state (phantom_machine_state_' s') \<and>
   device_state s = device_state (phantom_machine_state_' s') \<and>
+  fpu_enabled s = fpu_enabled (phantom_machine_state_' s') \<and>
   \<comment> \<open>exclusive_state s = exclusive_state (phantom_machine_state_' s') \<and>\<close> \<comment> \<open>FIXME x64:this is needed for infoflow so we'll leave it commented\<close>
   machine_state_rest s = machine_state_rest (phantom_machine_state_' s')"
 
@@ -441,7 +447,8 @@ where
                   (lookup_fault_lift (tcbLookupFailure_C ctcb))
      \<and> option_to_ptr (tcbBoundNotification atcb) = tcbBoundNotification_C ctcb
      \<and> option_to_ctcb_ptr (tcbSchedPrev atcb) = tcbSchedPrev_C ctcb
-     \<and> option_to_ctcb_ptr (tcbSchedNext atcb) = tcbSchedNext_C ctcb"
+     \<and> option_to_ctcb_ptr (tcbSchedNext atcb) = tcbSchedNext_C ctcb
+     \<and> tcbFlags atcb = tcb_C.flags_C ctcb"
 
 abbreviation
   "ep_queue_relation' \<equiv> tcb_queue_relation' tcbEPNext_C tcbEPPrev_C"

--- a/proof/crefine/X64/StoreWord_C.thy
+++ b/proof/crefine/X64/StoreWord_C.thy
@@ -603,8 +603,7 @@ proof (intro allI impI)
 
   thus ?thesis using rf
     apply (simp add: rf_sr_def cstate_relation_def Let_def rl' tag_disj_via_td_name)
-    apply (simp add: carch_state_relation_def fpu_null_state_relation_def
-                     cmachine_state_relation_def carch_globals_def)
+    apply (simp add: carch_state_relation_def cmachine_state_relation_def carch_globals_def)
     apply (simp add: rl' tag_disj_via_td_name zr)
     done
 qed
@@ -924,8 +923,7 @@ proof (intro allI impI)
 
   thus ?thesis using rf
     apply (simp add: rf_sr_def cstate_relation_def Let_def rl' tag_disj_via_td_name)
-    apply (simp add: carch_state_relation_def fpu_null_state_relation_def
-                     cmachine_state_relation_def carch_globals_def)
+    apply (simp add: carch_state_relation_def cmachine_state_relation_def carch_globals_def)
     apply (simp add: rl' tag_disj_via_td_name zr)
     done
 qed

--- a/proof/crefine/X64/TcbAcc_C.thy
+++ b/proof/crefine/X64/TcbAcc_C.thy
@@ -251,6 +251,33 @@ lemma sanitiseRegister_spec:
   apply (case_tac r; simp add: C_register_defs sanitiseRegister_def sanitiseOrFlags_def sanitiseAndFlags_def) (* long *)
   by word_bitwise
 
+lemma rf_sr_ksArchState_x64KSCurFPUOwner:
+  "(s, s') \<in> rf_sr \<Longrightarrow> cur_fpu_relation (x64KSCurFPUOwner (ksArchState s)) (ksCurFPUOwner_' (globals s'))"
+  by (clarsimp simp: rf_sr_def cstate_relation_def carch_state_relation_def Let_def)
+
+lemma ccorres_pre_getCurFPUOwner:
+  assumes cc: "\<And>rv. ccorres r xf (P rv) (P' rv) hs (f rv) c"
+  shows
+    "ccorres r xf
+       (\<lambda>s. (\<forall>rv. (x64KSCurFPUOwner \<circ> ksArchState) s = rv \<longrightarrow> P rv s))
+       {s. \<forall>rv fpu'. ksCurFPUOwner_' (globals s) = fpu' \<and> cur_fpu_relation rv fpu' \<longrightarrow> s \<in> P' rv} hs
+       (gets (x64KSCurFPUOwner \<circ> ksArchState) >>= (\<lambda>rv. f rv)) c"
+  apply (rule ccorres_guard_imp)
+    apply (rule ccorres_symb_exec_l)
+       defer
+       apply wp[1]
+      apply (rule gets_sp)
+     apply (clarsimp simp: empty_fail_def simpler_gets_def)
+    apply assumption
+   apply clarsimp
+   defer
+   apply (rule ccorres_guard_imp)
+     apply (rule cc)
+    apply clarsimp
+   apply assumption
+  apply (simp add: rf_sr_ksArchState_x64KSCurFPUOwner)
+  done
+
 lemma getObject_tcb_wp':
   "\<lbrace>\<lambda>s. \<forall>t. ko_at' (t :: tcb) p s \<longrightarrow> Q t s\<rbrace> getObject p \<lbrace>Q\<rbrace>"
   by (clarsimp simp: getObject_def valid_def in_monad
@@ -277,6 +304,18 @@ lemma ccorres_pre_getObject_tcb:
            erule ko_at_projectKO_opt)
   apply simp
   done
+
+lemma armKSCurFPUOwner_update_ccorres:
+  "ccorres dc xfdc (\<lambda>_. cur_fpu_relation fpu fpu') UNIV hs
+     (modifyArchState (x64KSCurFPUOwner_update (\<lambda>_. fpu)))
+     (Basic (\<lambda>s. globals_update (ksCurFPUOwner_'_update (\<lambda>_. fpu')) s))"
+  apply (clarsimp simp: modifyArchState_def)
+  apply (rule ccorres_from_vcg)
+  apply (rule allI, rule conseqPre, vcg)
+  apply (clarsimp simp: bind_def simpler_gets_def simpler_modify_def)
+  apply (clarsimp simp: rf_sr_def cstate_relation_def Let_def)
+  by (clarsimp simp: carch_state_relation_def carch_globals_def cur_fpu_relation_def
+                     cmachine_state_relation_def)
 
 (* FIXME: MOVE, probably to CSpace_RAB  *)
 lemma ccorres_gen_asm2_state:

--- a/proof/crefine/X64/TcbQueue_C.thy
+++ b/proof/crefine/X64/TcbQueue_C.thy
@@ -1156,15 +1156,6 @@ lemma tcb_at'_non_kernel_data_ref:
 lemmas tcb_at'_non_kernel_data_ref'
   = tcb_at'_non_kernel_data_ref[OF invs'_pspace_domain_valid]
 
-(* FIXME: move. Wants to go in SR_lemmas_C, but dependencies make this hard. *)
-lemma fpu_null_state_heap_update_span_disjoint:
-  assumes "ptr_span p \<inter> kernel_data_refs = {}"
-  shows "fpu_null_state_relation (hrs_mem_update (heap_update p v) h) = fpu_null_state_relation h"
-  by (cases "ptr_span (fpu_state_Ptr (symbol_table ''x86KSnullFpuState'')) \<subseteq> kernel_data_refs";
-      clarsimp simp: fpu_null_state_relation_def lift_t_Some_iff hrs_mem_update
-                     h_val_update_regions_disjoint
-              dest!: disjoint_subset2[OF _ assms])
-
 (* FIXME: move near tag_disj_via_td_name *)
 lemma tag_not_less_via_td_name:
   assumes ta: "typ_name (typ_info_t TYPE('a)) \<noteq> pad_typ_name"
@@ -1399,10 +1390,6 @@ lemma fpu_state_preservation:
   apply (simp add: unat_eq_0)
   done
 
-lemma fpu_null_state_preservation:
-  shows "fpu_null_state_relation u = fpu_null_state_relation h"
-  by (simp add: fpu_null_state_relation_def fpu_state_preservation)
-
 end
 
 lemma rf_sr_tcb_update_no_queue:
@@ -1439,7 +1426,7 @@ lemma rf_sr_tcb_update_no_queue:
      apply (rule cnotification_relation_upd_tcb_no_queues, assumption+)
       subgoal by (clarsimp intro!: ext)
      subgoal by (clarsimp intro!: ext)
-   subgoal by (clarsimp simp: carch_state_relation_def fpu_null_state_preservation typ_heap_simps')
+   subgoal by (clarsimp simp: carch_state_relation_def typ_heap_simps')
   by (simp add: cmachine_state_relation_def)
 
 lemmas rf_sr_tcb_update_no_queue2 =
@@ -1493,8 +1480,7 @@ lemma rf_sr_tcb_update_not_in_queue:
      subgoal by blast
     apply (clarsimp simp: Let_def)
    apply (simp add: carch_state_relation_def)
-   subgoal by (clarsimp simp: fpu_null_state_heap_update_span_disjoint[OF tcb_at'_non_kernel_data_ref']
-                              global_ioport_bitmap_heap_update_tag_disj_simps obj_at'_def projectKOs)
+   subgoal by (clarsimp simp: global_ioport_bitmap_heap_update_tag_disj_simps obj_at'_def projectKOs)
   by (simp add: cmachine_state_relation_def)
 
 end

--- a/proof/crefine/X64/Tcb_C.thy
+++ b/proof/crefine/X64/Tcb_C.thy
@@ -1040,7 +1040,6 @@ lemma setupReplyMaster_ccorres:
          apply simp
         apply (simp add: cmachine_state_relation_def packed_heap_update_collapse_hrs
                          carch_state_relation_def carch_globals_def
-                         fpu_null_state_heap_update_tag_disj_simps
                          global_ioport_bitmap_heap_update_tag_disj_simps
                          cvariable_array_map_const_add_map_option[where f="tcb_no_ctes_proj"])
        apply (wp | simp)+
@@ -3824,8 +3823,7 @@ lemma bindNotification_ccorres:
                  apply ((clarsimp simp: option_to_ctcb_ptr_canonical[OF invs_pspace_canonical'])+)[3]
               apply (auto simp: option_to_ctcb_ptr_def objBits_simps'
                                 bindNTFN_alignment_junk)[1]
-             apply (simp add: carch_state_relation_def fpu_null_state_heap_update_tag_disj_simps
-                              global_ioport_bitmap_heap_update_tag_disj_simps)
+             apply (simp add: carch_state_relation_def global_ioport_bitmap_heap_update_tag_disj_simps)
             apply (simp add: cmachine_state_relation_def)
            apply (simp add: h_t_valid_clift_Some_iff)
           apply (simp add: objBits_simps')
@@ -4510,6 +4508,103 @@ lemma decodeSetTLSBase_ccorres:
   apply (auto simp: unat_eq_0 le_max_word_ucast_id)+
   done
 
+lemma scast_seL4_TCBFlag_fpuDisabled[simp]:
+  "scast seL4_TCBFlag_fpuDisabled = tcbFlagToWord (ArchFlag FpuDisabled)"
+  by (clarsimp simp: seL4_TCBFlag_fpuDisabled_def tcbFlagToWord_def archTcbFlagToWord_def)
+
+lemma invokeTCB_SetFlags_ccorres:
+  notes hoare_weak_lift_imp [wp]
+  shows
+  "ccorres (cintr \<currency> (\<lambda>rv rv'. rv = [])) (liftxf errstate id (K ()) ret__unsigned_long_')
+           (invs' and tcb_at' tcb)
+           (\<lbrace>\<acute>thread = tcb_ptr_to_ctcb_ptr tcb\<rbrace>
+            \<inter> \<lbrace>\<acute>clear = clears\<rbrace>
+            \<inter> \<lbrace>\<acute>set = sets\<rbrace>) []
+           (invokeTCB (SetFlags tcb clears sets))
+           (Call invokeSetFlags_'proc)"
+  apply (cinit lift: thread_' clear_' set_' simp: setFlags_def postSetFlags_def)
+   apply (simp add: liftE_def bind_assoc)
+   apply (rule ccorres_pre_threadGet, rename_tac flags)
+   \<comment> \<open>split off flags_' updates and threadSet\<close>
+   apply (rule ccorres_rhs_assoc2, rule ccorres_rhs_assoc2, rule ccorres_rhs_assoc2)
+   apply (rule ccorres_split_nothrow)
+       apply (rule_tac P="\<lambda>tcb. tcbFlags tcb = flags" in threadSet_ccorres_lemma2)
+        apply vcg
+       apply (clarsimp simp: tcb_at_h_t_valid[OF obj_tcb_at'])
+       apply (erule rf_sr_tcb_update_no_queue2[rotated],
+              (simp add: typ_heap_simps')+, simp_all?)[1]
+        apply (rule ball_tcb_cte_casesI, simp+)
+       apply (clarsimp simp: ctcb_relation_def)
+      apply ceqv
+     apply (rule ccorres_split_nothrow_novcg_dc)
+        apply (rule_tac R=\<top> and R'="{s. flags_' s = flags && ~~ clears || sets}" in ccorres_when_strong)
+         apply (clarsimp simp: isFlagSet_def word_bw_comms)
+        apply (ctac add: fpuRelease_ccorres)
+       apply (rule ccorres_return_CE[folded return_returnOk]; simp)
+      apply (wpsimp simp: guard_is_UNIV_def)+
+   apply vcg
+  apply (clarsimp simp: obj_at'_def typ_heap_simps' ctcb_relation_def)
+  done
+
+lemma decodeSetFlags_ccorres:
+  "ccorres (intr_and_se_rel \<currency> dc) (liftxf errstate id (K ()) ret__unsigned_long_')
+       (invs' and sch_act_simple
+              and (\<lambda>s. ksCurThread s = thread) and ct_active' and K (isThreadCap cp)
+              and valid_cap' cp and (\<lambda>s. \<forall>x \<in> zobj_refs' cp. ex_nonz_cap_to' x s)
+              and sysargs_rel args buffer)
+       (\<lbrace>ccap_relation cp \<acute>cap\<rbrace>
+        \<inter> \<lbrace>unat \<acute>length___unsigned_long = length args\<rbrace>
+        \<inter> \<lbrace>\<acute>buffer = option_to_ptr buffer\<rbrace>) []
+     (decodeSetFlags args cp
+        >>= invocationCatch thread isBlocking isCall InvokeTCB)
+     (Call decodeSetFlags_'proc)"
+  apply (cinit' lift: cap_' length___unsigned_long_' buffer_'
+                simp: decodeSetFlags_def )
+   apply csymbr+
+   apply (rule ccorres_Cond_rhs_Seq)
+    apply (rule ccorres_from_vcg_split_throws[where P=\<top> and P'=UNIV])
+     apply vcg
+    apply (rule conseqPre, vcg)
+    apply (clarsimp simp: throwError_def invocationCatch_def fst_return
+                          intr_and_se_rel_def syscall_error_rel_def
+                          syscall_error_to_H_cases exception_defs
+                   split: list.split)
+    apply unat_arith
+   apply (clarsimp simp: linorder_not_less word_le_nat_alt)
+   apply (rule_tac P="\<lambda>a. ccorres rvr xf P P' hs a c" for rvr xf P P' hs c in ssubst,
+          rule bind_cong [OF _ refl], rule list_case_helper,
+          clarsimp)+
+   apply (rule ccorres_add_return,
+          ctac add: getSyscallArg_ccorres_foo'[where args=args and n=0 and buffer=buffer])
+     apply (rule ccorres_add_return,
+            ctac add: getSyscallArg_ccorres_foo'[where args=args and n=1 and buffer=buffer])
+       apply (simp add: invocationCatch_use_injection_handler
+                        bindE_assoc injection_handler_returnOk
+                        ccorres_invocationCatch_Inr performInvocation_def)
+       apply (ctac add: setThreadState_ccorres)
+         apply (ctac (no_vcg) add: invokeTCB_SetFlags_ccorres)
+           apply simp
+           apply (rule ccorres_alternative2)
+           apply (rule ccorres_return_CE, simp+)[1]
+          apply (rule ccorres_return_C_errorE, simp+)[1]
+         apply (wpsimp wp: sts_invs_minor')+
+       apply (vcg exspec=setThreadState_modifies)
+      apply wpsimp
+     apply (vcg exspec=getSyscallArg_modifies)
+    apply wpsimp
+   apply (vcg exspec=getSyscallArg_modifies)
+  apply (clarsimp simp: Collect_const_mem)
+  apply (rule conjI)
+   apply (clarsimp simp: ct_in_state'_def sysargs_rel_n_def n_msgRegisters_def)
+   apply (auto simp: valid_tcb_state'_def linorder_not_less word_le_nat_alt isCap_simps valid_cap'_def
+              elim!: pred_tcb'_weakenE)[1]
+  apply (simp only: cap_get_tag_isCap[symmetric], drule(1) cap_get_tag_to_H)
+  apply (clarsimp simp: rf_sr_ksCurThread word_sle_def cap_get_tag_isCap cap_get_tag_to_H word_less_nat_alt)
+  apply (subgoal_tac "args \<noteq> []")
+   apply (clarsimp simp: hd_conv_nth)
+  apply clarsimp
+  done
+
 lemma decodeTCBInvocation_ccorres:
   "interpret_excaps extraCaps' = excaps_map extraCaps \<Longrightarrow>
    ccorres (intr_and_se_rel \<currency> dc) (liftxf errstate id (K ()) ret__unsigned_long_')
@@ -4637,6 +4732,12 @@ lemma decodeTCBInvocation_ccorres:
    apply (rule ccorres_Cond_rhs)
     apply (simp add: gen_invocation_type_eq)
     apply (rule ccorres_add_returnOk, ctac(no_vcg) add: decodeSetTLSBase_ccorres)
+      apply (rule ccorres_return_CE, simp+)[1]
+     apply (rule ccorres_return_C_errorE, simp+)[1]
+    apply wp
+   apply (rule ccorres_Cond_rhs)
+    apply (simp add: gen_invocation_type_eq)
+    apply (rule ccorres_add_returnOk, ctac(no_vcg) add: decodeSetFlags_ccorres)
       apply (rule ccorres_return_CE, simp+)[1]
      apply (rule ccorres_return_C_errorE, simp+)[1]
     apply wp

--- a/proof/crefine/X64/VSpace_C.thy
+++ b/proof/crefine/X64/VSpace_C.thy
@@ -1908,8 +1908,7 @@ lemma updateCap_frame_mapped_addr_ccorres:
     apply (erule (1) setCTE_tcb_case)
    subgoal by (simp add: carch_state_relation_def cmachine_state_relation_def
                          typ_heap_simps h_t_valid_clift_Some_iff
-                         cvariable_array_map_const_add_map_option[where f="tcb_no_ctes_proj"]
-                         fpu_null_state_heap_update_tag_disj_simps)
+                         cvariable_array_map_const_add_map_option[where f="tcb_no_ctes_proj"])
   apply (clarsimp simp: ccte_relation_def)
   apply (clarsimp simp: cte_lift_def)
   apply (simp split: option.splits)
@@ -2294,7 +2293,6 @@ lemma setObjectASID_Basic_ccorres:
           erule ko_at_projectKO_opt, simp+)
   apply (simp add: cready_queues_relation_def
                    carch_state_relation_def
-                   fpu_null_state_heap_update_tag_disj_simps
                    cmachine_state_relation_def
                    Let_def typ_heap_simps
                    update_asidpool_map_tos)
@@ -2383,7 +2381,6 @@ lemma performASIDPoolInvocation_ccorres:
             apply (erule (1) setCTE_tcb_case)
            apply (simp add: carch_state_relation_def cmachine_state_relation_def
                             cvariable_array_map_const_add_map_option[where f="tcb_no_ctes_proj"]
-                            fpu_null_state_heap_update_tag_disj_simps
                             global_ioport_bitmap_heap_update_tag_disj_simps
                             packed_heap_update_collapse_hrs)
           apply (clarsimp simp: cte_wp_at_ctes_of)

--- a/proof/invariant-abstract/AARCH64/ArchFinalise_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchFinalise_AI.thy
@@ -598,10 +598,6 @@ crunch dissociate_vcpu_tcb
   for cur_thread[wp]: "\<lambda>s. P (cur_thread s)"
   (wp: crunch_wps)
 
-lemma same_caps_tcb_arch_update[simp]:
-  "same_caps (TCB (tcb_arch_update f tcb)) = same_caps (TCB tcb)"
-  by (rule ext) (clarsimp simp: tcb_cap_cases_def)
-
 crunch dissociate_vcpu_tcb
   for cap_refs_respects_device_region[wp]: "cap_refs_respects_device_region"
   (wp: crunch_wps cap_refs_respects_device_region_dmo

--- a/proof/invariant-abstract/AARCH64/ArchVSpace_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchVSpace_AI.thy
@@ -2348,13 +2348,6 @@ lemma set_asid_pool_arch_objs_map:
   apply (fastforce simp: obj_at_def)
   done
 
-lemma caps_of_state_fun_upd:
-  "obj_at (same_caps val) p s \<Longrightarrow>
-   (caps_of_state (s\<lparr>kheap := (kheap s) (p \<mapsto> val)\<rparr>)) = caps_of_state s"
-  apply (drule caps_of_state_after_update)
-  apply (simp add: fun_upd_def)
-  done
-
 lemma set_asid_pool_valid_arch_caps_map:
   "\<lbrace>valid_arch_caps and valid_arch_state and valid_global_objs and valid_objs
     and valid_vspace_objs and pspace_aligned and

--- a/proof/invariant-abstract/ARM/ArchTcb_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchTcb_AI.thy
@@ -166,6 +166,13 @@ crunch arch_post_set_flags, arch_prepare_set_domain
   for typ_at[wp, Tcb_AI_assms]: "\<lambda>s. P (typ_at T p s)"
   and invs[wp, Tcb_AI_assms]: "invs"
 
+lemmas arch_prepare_set_domain_typ_ats[wp] = abs_typ_at_lifts[OF arch_prepare_set_domain_typ_at]
+
+crunch arch_prepare_set_domain
+  for pspace_aligned[wp]: pspace_aligned
+  and pspace_distinct[wp]: pspace_distinct
+  (wp: crunch_wps)
+
 
 interpretation Tcb_AI_1? : Tcb_AI_1
   where state_ext_t = state_ext_t

--- a/proof/invariant-abstract/ARM_HYP/ArchFinalise_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchFinalise_AI.thy
@@ -607,10 +607,6 @@ crunch dissociate_vcpu_tcb
   for cur_thread[wp]: "\<lambda>s. P (cur_thread s)"
   (wp: crunch_wps)
 
-lemma same_caps_tcb_arch_update[simp]:
-  "same_caps (TCB (tcb_arch_update f tcb)) = same_caps (TCB tcb)"
-  by (rule ext) (clarsimp simp: tcb_cap_cases_def)
-
 crunch dissociate_vcpu_tcb
   for cap_refs_respects_device_region[wp]: "cap_refs_respects_device_region"
   (wp: crunch_wps cap_refs_respects_device_region_dmo

--- a/proof/invariant-abstract/ARM_HYP/ArchTcb_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchTcb_AI.thy
@@ -162,6 +162,12 @@ crunch arch_post_set_flags, arch_prepare_set_domain
   for typ_at[wp, Tcb_AI_assms]: "\<lambda>s. P (typ_at T p s)"
   and invs[wp, Tcb_AI_assms]: "invs"
 
+lemmas arch_prepare_set_domain_typ_ats[wp] = abs_typ_at_lifts[OF arch_prepare_set_domain_typ_at]
+
+crunch arch_prepare_set_domain
+  for pspace_aligned[wp]: pspace_aligned
+  and pspace_distinct[wp]: pspace_distinct
+  (wp: crunch_wps)
 
 lemma table_cap_ref_max_free_index_upd[simp,Tcb_AI_assms]:
   "table_cap_ref (max_free_index_update cap) = table_cap_ref cap"

--- a/proof/invariant-abstract/KHeapPre_AI.thy
+++ b/proof/invariant-abstract/KHeapPre_AI.thy
@@ -34,6 +34,10 @@ lemma same_caps_more_simps[simp]:
  "same_caps (ArchObj ao) val        = (\<exists>ao'. val = ArchObj ao')"
  by (cases val, (fastforce simp: is_obj_defs)+)+
 
+lemma same_caps_tcb_arch_update[simp]:
+  "same_caps (TCB (tcb_arch_update f tcb)) = same_caps (TCB tcb)"
+  by (rule ext) (clarsimp simp: tcb_cap_cases_def)
+
 lemma dmo_return [simp]:
   "do_machine_op (return x) = return x"
   by (simp add: do_machine_op_def select_f_def return_def gets_def get_def

--- a/proof/invariant-abstract/KHeap_AI.thy
+++ b/proof/invariant-abstract/KHeap_AI.thy
@@ -692,6 +692,12 @@ lemma caps_of_state_after_update:
   by (simp add: caps_of_state_cte_wp_at cte_wp_at_after_update
           cong: if_cong)
 
+lemma caps_of_state_fun_upd:
+  "obj_at (same_caps val) p s \<Longrightarrow>
+   (caps_of_state (s\<lparr>kheap := (kheap s) (p \<mapsto> val)\<rparr>)) = caps_of_state s"
+  apply (drule caps_of_state_after_update)
+  apply (simp add: fun_upd_def)
+  done
 
 lemma elim_CNode_case:
   "\<lbrakk> (case x of CNode sz ct \<Rightarrow> False | _ \<Rightarrow> True) \<rbrakk>

--- a/proof/invariant-abstract/RISCV64/ArchFinalise_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchFinalise_AI.thy
@@ -361,10 +361,6 @@ lemma as_user_unlive0[wp]:
 lemma o_def_not: "obj_at (\<lambda>a. \<not> P a) t s =  obj_at (Not o P) t s"
   by (simp add: obj_at_def)
 
-lemma same_caps_tcb_arch_update[simp]:
-  "same_caps (TCB (tcb_arch_update f tcb)) = same_caps (TCB tcb)"
-  by (rule ext) (clarsimp simp: tcb_cap_cases_def)
-
 lemma as_user_valid_irq_node[wp]:
   "\<lbrace>valid_irq_node\<rbrace> as_user t f \<lbrace>\<lambda>_. valid_irq_node\<rbrace>"
   unfolding as_user_def

--- a/proof/invariant-abstract/RISCV64/ArchTcb_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchTcb_AI.thy
@@ -150,6 +150,12 @@ crunch arch_post_set_flags, arch_prepare_set_domain
   for typ_at[wp, Tcb_AI_assms]: "\<lambda>s. P (typ_at T p s)"
   and invs[wp, Tcb_AI_assms]: "invs"
 
+lemmas arch_prepare_set_domain_typ_ats[wp] = abs_typ_at_lifts[OF arch_prepare_set_domain_typ_at]
+
+crunch arch_prepare_set_domain
+  for pspace_aligned[wp]: pspace_aligned
+  and pspace_distinct[wp]: pspace_distinct
+  (wp: crunch_wps)
 
 lemma table_cap_ref_max_free_index_upd[simp,Tcb_AI_assms]:
   "table_cap_ref (max_free_index_update cap) = table_cap_ref cap"

--- a/proof/invariant-abstract/RISCV64/ArchVSpace_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchVSpace_AI.thy
@@ -1647,13 +1647,6 @@ lemma set_asid_pool_arch_objs_map:
   apply (fastforce simp: obj_at_def)
   done
 
-lemma caps_of_state_fun_upd:
-  "obj_at (same_caps val) p s \<Longrightarrow>
-   (caps_of_state (s\<lparr>kheap := (kheap s) (p \<mapsto> val)\<rparr>)) = caps_of_state s"
-  apply (drule caps_of_state_after_update)
-  apply (simp add: fun_upd_def)
-  done
-
 lemma set_asid_pool_valid_arch_caps_map:
   "\<lbrace>valid_arch_caps and valid_arch_state and valid_global_objs and valid_objs
     and valid_vspace_objs and pspace_aligned and

--- a/proof/invariant-abstract/TcbAcc_AI.thy
+++ b/proof/invariant-abstract/TcbAcc_AI.thy
@@ -2333,7 +2333,6 @@ lemma arch_thread_set_zombies_final[wp]:
   apply (subst get_tcb_rev)
    apply assumption
   apply simp
-  apply (subst get_tcb_rev, assumption, simp)+
   apply (clarsimp simp: obj_at_def tcb_cap_cases_def)
   done
 

--- a/proof/invariant-abstract/X64/ArchBCorres2_AI.thy
+++ b/proof/invariant-abstract/X64/ArchBCorres2_AI.thy
@@ -34,7 +34,7 @@ crunch set_mcpriority, set_priority, set_flags, arch_post_set_flags
 crunch arch_get_sanitise_register_info, arch_post_modify_registers
   for (bcorres) bcorres[wp, BCorres2_AI_assms]: truncate_state
 
-crunch updateIRQState
+crunch update_irq_state
   for (bcorres) bcorres[wp]: truncate_state
 
 lemma invoke_tcb_bcorres[wp]:

--- a/proof/invariant-abstract/X64/ArchDetSchedSchedule_AI.thy
+++ b/proof/invariant-abstract/X64/ArchDetSchedSchedule_AI.thy
@@ -119,7 +119,7 @@ crunch switch_to_thread
 
 crunch
   arch_switch_to_idle_thread
-  for valid_idle[wp, DetSchedSchedule_AI_assms]: "valid_idle :: det_ext state \<Rightarrow> bool"
+  for valid_idle[wp, DetSchedSchedule_AI_assms]: valid_idle
   (wp: crunch_wps simp: crunch_simps)
 
 crunch arch_switch_to_idle_thread, arch_prepare_next_domain

--- a/proof/invariant-abstract/X64/ArchInterrupt_AI.thy
+++ b/proof/invariant-abstract/X64/ArchInterrupt_AI.thy
@@ -257,11 +257,11 @@ qed
 crunch ioapicMapPinToVector
   for device_state_inv[wp]: "\<lambda>ms. P (device_state ms)"
 
-lemma updateIRQState_invs[wp]:
+lemma update_irq_state_invs[wp]:
   "\<lbrace>invs and K (irq \<le> maxIRQ)\<rbrace>
-   updateIRQState irq state
+   update_irq_state irq state
    \<lbrace>\<lambda>_. invs\<rbrace>"
-  apply (clarsimp simp: updateIRQState_def)
+  apply (clarsimp simp: update_irq_state_def)
   apply wp
   apply (clarsimp simp: invs_def valid_state_def valid_pspace_def valid_global_refs_def
                         global_refs_def valid_arch_state_def valid_vspace_objs_def
@@ -282,7 +282,7 @@ lemma dmo_ioapicMapPinToVector[wp]: "\<lbrace>invs\<rbrace> do_machine_op (ioapi
   apply(erule (1) use_valid[OF _ ioapicMapPinToVector_irq_masks])
   done
 
-crunch updateIRQState
+crunch update_irq_state
   for real_cte_at[wp]: "real_cte_at x"
   and cte_wp_at[wp]: "\<lambda>s. P (cte_wp_at Q slot s)"
   and cdt[wp]: "\<lambda>s. P (cdt s)"

--- a/proof/invariant-abstract/X64/ArchTcb_AI.thy
+++ b/proof/invariant-abstract/X64/ArchTcb_AI.thy
@@ -58,11 +58,6 @@ where
           \<and> (is_pml4_cap cap \<longrightarrow> cap_asid cap \<noteq> None)
           \<and> \<not> is_ioport_control_cap cap)"
 
-crunch arch_post_set_flags, arch_prepare_set_domain
-  for typ_at[wp, Tcb_AI_assms]: "\<lambda>s. P (typ_at T p s)"
-  and invs[wp, Tcb_AI_assms]: "invs"
-
-
 definition (* arch specific *)
   "vspace_asid cap \<equiv> case cap of
     ArchObjectCap (PageTableCap _ (Some (asid, _))) \<Rightarrow> Some asid

--- a/proof/invariant-abstract/X64/Machine_AI.thy
+++ b/proof/invariant-abstract/X64/Machine_AI.thy
@@ -311,7 +311,7 @@ crunch
   and underlying_memory_inv[wp]: "\<lambda>s. P (underlying_memory s)"
   (wp: no_irq_bind no_irq_modify ef_machine_rest_lift no_fail_machine_state_rest_T)
 
-crunch getFPUState, getRegister, getRestartPC, setNextPC, ackInterrupt, maskInterrupt, hwASIDInvalidate
+crunch getFPUState, getRegister, getRestartPC, setNextPC, ackInterrupt, maskInterrupt
   for (no_fail) no_fail[intro!, wp, simp]
   and (empty_fail) empty_fail[intro!, wp, simp]
 

--- a/proof/refine/AARCH64/Schedule_R.thy
+++ b/proof/refine/AARCH64/Schedule_R.thy
@@ -228,9 +228,7 @@ crunch writeFpuState, readFpuState
   for fpu_enabled[wp]: fpu_enabled
 
 crunch load_fpu_state, save_fpu_state
-  for pspace_aligned[wp]: pspace_aligned
-  and pspace_distinct[wp]: pspace_distinct
-  and valid_cur_fpu[wp]: valid_cur_fpu
+  for valid_cur_fpu[wp]: valid_cur_fpu
   and fpu_enabled[wp]: "\<lambda>s. fpu_enabled (machine_state s)"
   (wp: dmo_machine_state_lift)
 

--- a/proof/refine/AARCH64/StateRelation.thy
+++ b/proof/refine/AARCH64/StateRelation.thy
@@ -427,7 +427,7 @@ definition arch_state_relation :: "(arch_state \<times> AARCH64_H.kernel_state) 
          \<and> arm_kernel_vspace s = armKSKernelVSpace s'
          \<and> arm_current_vcpu s = armHSCurVCPU s'
          \<and> arm_gicvcpu_numlistregs s = armKSGICVCPUNumListRegs s'
-         \<and> arm_current_fpu_owner  s = armKSCurFPUOwner s'}"
+         \<and> arm_current_fpu_owner s = armKSCurFPUOwner s'}"
 
 definition rights_mask_map :: "rights set \<Rightarrow> Types_H.cap_rights" where
   "rights_mask_map \<equiv>

--- a/proof/refine/AARCH64/Syscall_R.thy
+++ b/proof/refine/AARCH64/Syscall_R.thy
@@ -472,9 +472,9 @@ lemma performInvocation_corres:
       apply (clarsimp simp: invoke_domain_def)
       apply (rule corres_guard_imp)
         apply (rule corres_split[OF prepareSetDomain_corres])
-        apply (rule corres_split[OF setDomain_corres])
-          apply (rule corres_trivial, simp)
-         apply wpsimp+
+          apply (rule corres_split[OF setDomain_corres])
+            apply (rule corres_trivial, simp)
+           apply wpsimp+
        apply ((clarsimp simp: invs_psp_aligned invs_distinct)+)[2]
      \<comment> \<open>CNodes\<close>
      apply clarsimp

--- a/proof/refine/ARM/ADT_H.thy
+++ b/proof/refine/ARM/ADT_H.thy
@@ -437,6 +437,7 @@ definition
       tcb_priority = tcbPriority tcb,
       tcb_time_slice = tcbTimeSlice tcb,
       tcb_domain = tcbDomain tcb,
+      tcb_flags = word_to_tcb_flags (tcbFlags tcb),
       tcb_arch = ArchTcbMap (tcbArch tcb)\<rparr>"
 
 definition

--- a/proof/refine/ARM/EmptyFail_H.thy
+++ b/proof/refine/ARM/EmptyFail_H.thy
@@ -259,7 +259,7 @@ lemma catchError_empty_fail[intro!, wp, simp]:
   by fastforce
 
 crunch
-  chooseThread, getDomainTime, nextDomain, isHighestPrio
+  chooseThread, getDomainTime, nextDomain, isHighestPrio, prepareNextDomain
   for (empty_fail) empty_fail[intro!, wp, simp]
   (wp: empty_fail_catch)
 

--- a/proof/refine/ARM/Finalise_R.thy
+++ b/proof/refine/ARM/Finalise_R.thy
@@ -2377,7 +2377,8 @@ lemma finaliseCap_True_invs[wp]:
   done
 
 crunch flushSpace
-  for invs'[wp]: "invs'" (ignore: doMachineOp)
+  for invs'[wp]: "invs'"
+  (ignore: doMachineOp)
 
 lemma invs_asid_update_strg':
   "invs' s \<and> tab = armKSASIDTable (ksArchState s) \<longrightarrow>

--- a/proof/refine/ARM/Init_R.thy
+++ b/proof/refine/ARM/Init_R.thy
@@ -28,9 +28,7 @@ context begin interpretation Arch . (*FIXME: arch-split*)
   system.
 *)
 
-definition zeroed_arch_abstract_state ::
-  arch_state
-  where
+definition zeroed_arch_abstract_state :: arch_state where
   "zeroed_arch_abstract_state \<equiv> \<lparr>
     arm_asid_table = Map.empty,
     arm_hwasid_table = Map.empty,
@@ -41,9 +39,7 @@ definition zeroed_arch_abstract_state ::
     arm_kernel_vspace = K ArmVSpaceUserRegion
   \<rparr>"
 
-definition zeroed_main_abstract_state ::
-  abstract_state
-  where
+definition zeroed_main_abstract_state :: abstract_state where
   "zeroed_main_abstract_state \<equiv> \<lparr>
     kheap = Map.empty,
     cdt = Map.empty,
@@ -62,28 +58,20 @@ definition zeroed_main_abstract_state ::
     arch_state = zeroed_arch_abstract_state
   \<rparr>"
 
-definition zeroed_extended_state ::
-  det_ext
-  where
+definition zeroed_extended_state :: det_ext where
   "zeroed_extended_state \<equiv> \<lparr>
     work_units_completed_internal = 0,
     cdt_list_internal = K []
   \<rparr>"
 
-definition zeroed_abstract_state ::
-  det_state
-  where
+definition zeroed_abstract_state :: det_state where
   "zeroed_abstract_state \<equiv> abstract_state.extend zeroed_main_abstract_state
                            (state.fields zeroed_extended_state)"
 
-definition zeroed_arch_intermediate_state ::
-  Arch.kernel_state
-  where
+definition zeroed_arch_intermediate_state :: Arch.kernel_state where
   "zeroed_arch_intermediate_state \<equiv> ARMKernelState Map.empty Map.empty 0 Map.empty 0 [] (K ArmVSpaceUserRegion)"
 
-definition zeroed_intermediate_state ::
-  global.kernel_state
-  where
+definition zeroed_intermediate_state :: global.kernel_state where
   "zeroed_intermediate_state \<equiv> \<lparr>
     ksPSpace = Map.empty,
     gsUserPages = Map.empty,

--- a/proof/refine/ARM/IpcCancel_R.thy
+++ b/proof/refine/ARM/IpcCancel_R.thy
@@ -1202,9 +1202,9 @@ lemma updateObject_ep_inv:
   by simp (rule updateObject_default_inv)
 
 lemma asUser_tcbQueued_inv[wp]:
-  "\<lbrace>obj_at' (\<lambda>tcb. P (tcbQueued tcb)) t'\<rbrace> asUser t m \<lbrace>\<lambda>_. obj_at' (\<lambda>tcb. P (tcbQueued tcb)) t'\<rbrace>"
+  "asUser t m \<lbrace>\<lambda>s. Q (obj_at' (\<lambda>tcb. P (tcbQueued tcb)) tcb_ptr s)\<rbrace>"
   apply (simp add: asUser_def tcb_in_cur_domain'_def threadGet_def)
-  apply (wp threadSet_obj_at'_strongish getObject_tcb_wp | wpc | simp | clarsimp simp: obj_at'_def)+
+  apply (wp threadSet_obj_at'_no_state getObject_tcb_wp | wpc | simp | clarsimp simp: obj_at'_def)+
   done
 
 context begin interpretation Arch . (* FIXME: arch-split *)
@@ -2248,8 +2248,8 @@ lemma suspend_unqueued:
 
 crunch prepareThreadDelete
   for unqueued: "obj_at' (Not \<circ> tcbQueued) t"
-crunch prepareThreadDelete
-  for inactive: "st_tcb_at' ((=) Inactive) t'"
+  and inactive: "st_tcb_at' ((=) Inactive) t'"
+  (simp: obj_at'_not_comp_fold)
 
 end
 end

--- a/proof/refine/ARM/PageTableDuplicates.thy
+++ b/proof/refine/ARM/PageTableDuplicates.thy
@@ -2086,7 +2086,7 @@ lemma tc_valid_duplicates':
                         tcbIPCBufferSlot_def)
   by (auto dest!: isCapDs isReplyCapD isValidVTableRootD simp: isCap_simps)
 
-crunch performTransfer, unbindNotification, bindNotification, setDomain
+crunch performTransfer, unbindNotification, bindNotification, setDomain, prepareSetDomain,postSetFlags, setFlags
   for valid_duplicates'[wp]: "(\<lambda>s. vs_valid_duplicates' (ksPSpace s))"
   (ignore: threadSet wp: setObject_ksInterrupt updateObject_default_inv
      simp: crunch_simps)

--- a/proof/refine/ARM/Refine.thy
+++ b/proof/refine/ARM/Refine.thy
@@ -201,8 +201,7 @@ assumes rel: "(s,s') \<in> state_relation"
 shows "absKState s' = abs_state s"
   using assms
   apply (intro state.equality, simp_all add: absKState_def abs_state_def)
-                 apply (rule absHeap_correct; clarsimp)
-                 apply (clarsimp elim!: state_relationE)
+                 apply (rule absHeap_correct; clarsimp elim!: state_relationE)
                 apply (rule absCDT_correct; clarsimp)
                apply (rule absIsOriginalCap_correct; clarsimp)
               apply (simp add: state_relation_def)
@@ -649,8 +648,8 @@ lemma entry_corres:
                  threadSet_invs_trivial threadSet_ct_running'
                  thread_set_not_state_valid_sched hoare_weak_lift_imp
                  hoare_vcg_disj_lift ct_in_state_thread_state_lift
-              | simp add: tcb_cap_cases_def ct_in_state'_def thread_set_no_change_tcb_state
-                          schact_is_rct_def
+                 thread_set_no_change_tcb_state
+              | simp add: tcb_cap_cases_def ct_in_state'_def schact_is_rct_def
               | (wps, wp threadSet_st_tcb_at2) )+
    apply (fastforce simp: invs_def cur_tcb_def)
   apply (clarsimp simp: ct_in_state'_def)

--- a/proof/refine/ARM/Retype_R.thy
+++ b/proof/refine/ARM/Retype_R.thy
@@ -2312,6 +2312,10 @@ lemma other_objs_default_relation:
                  split: Structures_A.apiobject_type.split_asm)
   done
 
+lemma word_to_tcb_flags_0[simp]:
+  "word_to_tcb_flags 0 = {}"
+  by (clarsimp simp: word_to_tcb_flags_def)
+
 lemma tcb_relation_retype:
   "obj_relation_retype (default_object Structures_A.TCBObject dev n d)
                        (KOTCB (tcbDomain_update (\<lambda>_. d) makeObject))"
@@ -3057,7 +3061,7 @@ proof (intro conjI impI)
        apply (rule_tac ptr="x + xa" in cte_wp_at_tcbI', assumption+)
         apply fastforce
        apply simp
-      apply (rename_tac thread_state mcp priority bool option nat cptr vptr bound tcbprev tcbnext user_context)
+      apply (rename_tac thread_state mcp priority bool option nat cptr vptr bound tcbprev tcbnext tcbflags tcbarch)
       apply (case_tac thread_state, simp_all add: valid_tcb_state'_def valid_bound_tcb'_def
                                                   valid_bound_ntfn'_def obj_at_disj' opt_tcb_at'_def
                                                   valid_arch_tcb'_def

--- a/proof/refine/ARM/Schedule_R.thy
+++ b/proof/refine/ARM/Schedule_R.thy
@@ -742,29 +742,8 @@ proof -
     by (rule lift_neg_pred_tcb_at' [OF ArchThreadDecls_H_ARM_H_switchToThread_typ_at' pos])
 qed
 
-
-crunch storeWordUser
-  for ksQ[wp]: "\<lambda>s. P (ksReadyQueues s p)"
-crunch setVMRoot
-  for ksQ[wp]: "\<lambda>s. P (ksReadyQueues s)"
-(wp: crunch_wps simp: crunch_simps)
-crunch storeWordUser
-  for ksIdleThread[wp]: "\<lambda>s. P (ksIdleThread s)"
-crunch asUser
-  for ksIdleThread[wp]: "\<lambda>s. P (ksIdleThread s)"
-(wp: crunch_wps simp: crunch_simps)
-crunch asUser
-  for ksQ[wp]: "\<lambda>s. P (ksReadyQueues s p)"
-(wp: crunch_wps simp: crunch_simps)
-
-lemma arch_switch_thread_ksQ[wp]:
-  "\<lbrace>\<lambda>s. P (ksReadyQueues s p)\<rbrace> Arch.switchToThread t \<lbrace>\<lambda>_ s. P (ksReadyQueues s p)\<rbrace>"
-  apply (simp add: ARM_H.switchToThread_def)
-  apply (wp)
-  done
-
 crunch storeWordUser, setVMRoot, asUser, storeWordUser, Arch.switchToThread
-  for ksQ[wp]: "\<lambda>s. P (ksReadyQueues s p)"
+  for ksQ[wp]: "\<lambda>s. P (ksReadyQueues s)"
   and ksIdleThread[wp]: "\<lambda>s. P (ksIdleThread s)"
   and sym_heap_sched_pointers[wp]: sym_heap_sched_pointers
   and valid_objs'[wp]: valid_objs'
@@ -1664,24 +1643,33 @@ lemma nextDomain_invs_no_cicd':
                         all_invs_but_ct_idle_or_in_cur_domain'_def)
   done
 
+lemma prepareNextDomain_corres[corres]:
+  "corres dc (pspace_aligned and pspace_distinct) \<top>
+             arch_prepare_next_domain prepareNextDomain"
+  by (clarsimp simp: arch_prepare_next_domain_def prepareNextDomain_def)
+
+crunch prepareNextDomain
+  for invs'[wp]: invs'
+  and nosch[wp]: "\<lambda>s. P (ksSchedulerAction s)"
+
 lemma scheduleChooseNewThread_fragment_corres:
   "corres dc (invs and valid_sched and (\<lambda>s. scheduler_action s = choose_new_thread)) (invs' and (\<lambda>s. ksSchedulerAction s = ChooseNewThread))
-     (do _ \<leftarrow> when (domainTime = 0) next_domain;
+     (do _ \<leftarrow> when (domainTime = 0) (do
+           _ \<leftarrow> arch_prepare_next_domain;
+           next_domain
+         od);
          choose_thread
       od)
-     (do _ \<leftarrow> when (domainTime = 0) nextDomain;
-          chooseThread
+     (do _ \<leftarrow> when (domainTime = 0) (do
+           _ \<leftarrow> prepareNextDomain;
+           nextDomain
+         od);
+         chooseThread
       od)"
-  apply (subst bind_dummy_ret_val)
-  apply (subst bind_dummy_ret_val)
-  apply (rule corres_guard_imp)
-    apply (rule corres_split)
-       apply (rule corres_when, simp)
-       apply (rule nextDomain_corres)
-      apply simp
-      apply (rule chooseThread_corres)
-     apply (wp nextDomain_invs_no_cicd')+
-   apply (clarsimp simp: valid_sched_def invs'_def valid_state'_def all_invs_but_ct_idle_or_in_cur_domain'_def)+
+  apply (subst bind_dummy_ret_val)+
+  apply (corres corres: nextDomain_corres chooseThread_corres
+                    wp: nextDomain_invs_no_cicd')
+   apply (auto simp: valid_sched_def invs'_def valid_state'_def all_invs_but_ct_idle_or_in_cur_domain'_def)
   done
 
 lemma scheduleSwitchThreadFastfail_corres:

--- a/proof/refine/ARM/StateRelation.thy
+++ b/proof/refine/ARM/StateRelation.thy
@@ -193,7 +193,8 @@ definition tcb_relation :: "Structures_A.tcb \<Rightarrow> Structures_H.tcb \<Ri
    \<and> tcb_mcpriority tcb = tcbMCP tcb'
    \<and> tcb_priority tcb = tcbPriority tcb'
    \<and> tcb_time_slice tcb = tcbTimeSlice tcb'
-   \<and> tcb_domain tcb = tcbDomain tcb'"
+   \<and> tcb_domain tcb = tcbDomain tcb'
+   \<and> tcb_flags tcb = word_to_tcb_flags (tcbFlags tcb')"
 
 \<comment> \<open>
   A pair of objects @{term "(obj, obj')"} should satisfy the following relation when, under further

--- a/proof/refine/ARM/SubMonad_R.thy
+++ b/proof/refine/ARM/SubMonad_R.thy
@@ -20,12 +20,21 @@ interpretation submonad_doMachineOp:
   submonad ksMachineState "(ksMachineState_update \<circ> K)" \<top> doMachineOp
   by (rule submonad_doMachineOp)
 
+lemma corres_machine_op':
+  assumes P: "corres_underlying Id False True r P P' x x'"
+  shows      "corres r (P \<circ> machine_state) (P' \<circ> ksMachineState) (do_machine_op x) (doMachineOp x')"
+  apply (rule corres_submonad3 [OF submonad_do_machine_op submonad_doMachineOp _ _ _ _ P])
+   apply (simp_all add: state_relation_def swp_def)
+  done
+
 lemma corres_machine_op:
   assumes P: "corres_underlying Id False True r \<top> \<top> x x'"
   shows      "corres r \<top> \<top> (do_machine_op x) (doMachineOp x')"
-  apply (rule corres_submonad [OF submonad_do_machine_op submonad_doMachineOp _ _ P])
-   apply (simp_all add: state_relation_def swp_def)
-  done
+  by (rule corres_machine_op'[OF P, simplified])
+
+lemmas corres_machine_op_Id = corres_machine_op[OF corres_Id]
+lemmas corres_machine_op_Id_dc[corres_term] = corres_machine_op_Id[where r="dc::unit \<Rightarrow> unit \<Rightarrow> bool"]
+lemmas corres_machine_op_Id_eq[corres_term] = corres_machine_op_Id[where r="(=)"]
 
 lemmas corresK_machine_op =
   corres_machine_op[atomized, THEN corresK_lift_rule, rule_format, corresK]

--- a/proof/refine/ARM/Syscall_R.thy
+++ b/proof/refine/ARM/Syscall_R.thy
@@ -463,9 +463,9 @@ lemma performInvocation_corres:
       apply (clarsimp simp: invoke_domain_def)
       apply (rule corres_guard_imp)
         apply (rule corres_split[OF prepareSetDomain_corres])
-        apply (rule corres_split[OF setDomain_corres])
-          apply (rule corres_trivial, simp)
-         apply wpsimp+
+          apply (rule corres_split[OF setDomain_corres])
+            apply (rule corres_trivial, simp)
+           apply wpsimp+
        apply (fastforce+)[2]
      \<comment> \<open>CNodes\<close>
      apply clarsimp

--- a/proof/refine/ARM/Syscall_R.thy
+++ b/proof/refine/ARM/Syscall_R.thy
@@ -339,6 +339,12 @@ lemma threadSet_tcbDomain_update_sch_act_wf[wp]:
    apply (auto simp: obj_at'_def)
   done
 
+lemma prepareSetDomain_corres[corres]:
+  "corres dc (pspace_aligned and pspace_distinct) \<top>
+     (arch_prepare_set_domain tptr new_dom) (prepareSetDomain tptr new_dom)"
+  unfolding prepareSetDomain_def arch_prepare_set_domain_def
+  by (corres corres: gcd_corres)
+
 lemma setDomain_corres:
   "corres dc
      (valid_sched and tcb_at tptr and pspace_aligned and pspace_distinct)
@@ -392,6 +398,11 @@ lemma setDomain_corres:
    apply (auto elim: valid_objs'_maxDomain valid_objs'_maxPriority pred_tcb'_weakenE
                simp: valid_sched_def valid_sched_action_def)
   done
+
+crunch prepareSetDomain
+  for invs'[wp]: invs'
+  and sch_act_simple[wp]: sch_act_simple
+  and tcb_at'[wp]: "tcb_at' p"
 
 lemma performInvocation_corres:
   "\<lbrakk> inv_relation i i'; call \<longrightarrow> block \<rbrakk> \<Longrightarrow>
@@ -448,12 +459,13 @@ lemma performInvocation_corres:
        apply (rule corres_guard_imp)
          apply (erule invokeTCB_corres)
         apply ((clarsimp dest!: schact_is_rct_simple)+)[2]
-       \<comment> \<open>domain cap\<close>
+      \<comment> \<open>domain cap\<close>
       apply (clarsimp simp: invoke_domain_def)
       apply (rule corres_guard_imp)
+        apply (rule corres_split[OF prepareSetDomain_corres])
         apply (rule corres_split[OF setDomain_corres])
           apply (rule corres_trivial, simp)
-         apply (wp)+
+         apply wpsimp+
        apply (fastforce+)[2]
      \<comment> \<open>CNodes\<close>
      apply clarsimp
@@ -485,7 +497,7 @@ lemma sendSignal_tcb_at'[wp]:
 lemmas checkCap_inv_typ_at'
   = checkCap_inv[where P="\<lambda>s. P (typ_at' T p s)" for P T p]
 
-crunch restart, bindNotification, performTransfer
+crunch restart, bindNotification, performTransfer, setFlags, postSetFlags
   for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
 
 lemma invokeTCB_typ_at'[wp]:
@@ -960,6 +972,12 @@ lemma setDomain_invs':
     apply (wp hoare_vcg_imp_lift)+
   apply (clarsimp simp:invs'_def valid_pspace'_def valid_state'_def)+
   done
+
+crunch prepareSetDomain
+  for ksCurThread[wp]: "\<lambda>s. P (ksCurThread s)"
+  and ct_in_state'[wp]: "ct_in_state' P"
+  and ksSchedulerAction[wp]: "\<lambda>s. P (ksSchedulerAction s)"
+  (wp: ct_in_state_thread_state_lift')
 
 lemma performInv_invs'[wp]:
   "\<lbrace>invs' and sch_act_simple and ct_active' and valid_invocation' i\<rbrace>

--- a/proof/refine/ARM/TcbAcc_R.thy
+++ b/proof/refine/ARM/TcbAcc_R.thy
@@ -455,7 +455,7 @@ lemma ball_tcb_cte_casesI:
   by (simp add: tcb_cte_cases_def tcb_cte_cases_neqs)
 
 lemma all_tcbI:
-  "\<lbrakk> \<And>a b c d e f g h i j k l m n p q r s. P (Thread a b c d e f g h i j k l m n p q r s) \<rbrakk>
+  "\<lbrakk> \<And>a b c d e f g h i j k l m n p q r s t. P (Thread a b c d e f g h i j k l m n p q r s t) \<rbrakk>
    \<Longrightarrow> \<forall>tcb. P tcb"
   by (rule allI, case_tac tcb, simp)
 
@@ -1136,13 +1136,12 @@ lemma threadSet_obj_at'_strongish[wp]:
      threadSet f t \<lbrace>\<lambda>rv. obj_at' P t'\<rbrace>"
   by (simp add: hoare_weaken_pre [OF threadSet_obj_at'_really_strongest])
 
-lemma threadSet_pred_tcb_no_state:
-  assumes "\<And>tcb. proj (tcb_to_itcb' (f tcb)) = proj (tcb_to_itcb' tcb)"
-  shows   "\<lbrace>\<lambda>s. P (pred_tcb_at' proj P' t' s)\<rbrace> threadSet f t \<lbrace>\<lambda>rv s. P (pred_tcb_at' proj P' t' s)\<rbrace>"
+lemma threadSet_obj_at'_no_state:
+  assumes "\<And>tcb. P' (f tcb) = P' tcb"
+  shows   "threadSet f t \<lbrace>\<lambda>s. P (obj_at' P' t' s)\<rbrace>"
 proof -
-  have pos: "\<And>P' t' t.
-            \<lbrace>pred_tcb_at' proj P' t'\<rbrace> threadSet f t \<lbrace>\<lambda>rv. pred_tcb_at' proj P' t'\<rbrace>"
-    apply (simp add: pred_tcb_at'_def)
+  have pos: "\<And>t' t.
+            \<lbrace>obj_at' P' t'\<rbrace> threadSet f t \<lbrace>\<lambda>rv. obj_at' P' t'\<rbrace>"
     apply (wp threadSet_obj_at'_strongish)
     apply clarsimp
     apply (erule obj_at'_weakenE)
@@ -1152,19 +1151,24 @@ proof -
   show ?thesis
     apply (rule_tac P=P in P_bool_lift)
      apply (rule pos)
-    apply (rule_tac Q'="\<lambda>_ s. \<not> tcb_at' t' s \<or> pred_tcb_at' proj (\<lambda>tcb. \<not> P' tcb) t' s"
+    apply (rule_tac Q'="\<lambda>_ s. \<not> tcb_at' t' s \<or> obj_at' (\<lambda>tcb. \<not> P' tcb) t' s"
              in hoare_post_imp)
      apply (erule disjE)
-      apply (clarsimp dest!: pred_tcb_at')
+      apply (clarsimp simp: obj_at'_def)
      apply (clarsimp)
-     apply (frule_tac P=P' and Q="\<lambda>tcb. \<not> P' tcb" in pred_tcb_at_conj')
-     apply (clarsimp)+
+     apply (frule_tac P=P' and Q="\<lambda>tcb. \<not> P' tcb" in obj_at_conj')
+      apply (clarsimp)+
     apply (wp hoare_convert_imp)
       apply (simp add: typ_at_tcb' [symmetric])
       apply (wp pos)+
-    apply (clarsimp simp: pred_tcb_at'_def not_obj_at' elim!: obj_at'_weakenE)
+    apply (clarsimp simp: not_obj_at' assms elim!: obj_at'_weakenE)
     done
 qed
+
+lemma threadSet_pred_tcb_no_state:
+  assumes "\<And>tcb. proj (tcb_to_itcb' (f tcb)) = proj (tcb_to_itcb' tcb)"
+  shows   "threadSet f t \<lbrace>\<lambda>s. P (pred_tcb_at' proj P' t' s)\<rbrace>"
+  by (wpsimp wp: threadSet_obj_at'_no_state simp: pred_tcb_at'_def assms)
 
 lemma threadSet_ct[wp]:
   "\<lbrace>\<lambda>s. P (ksCurThread s)\<rbrace> threadSet f t \<lbrace>\<lambda>rv s. P (ksCurThread s)\<rbrace>"
@@ -1708,6 +1712,12 @@ lemma asUser_tcbPriority_inv[wp]:
   apply (wp threadSet_obj_at'_strongish getObject_tcb_wp | wpc | simp | clarsimp simp: obj_at'_def)+
   done
 
+lemma asUser_tcbState_inv[wp]:
+  "\<lbrace>obj_at' (\<lambda>tcb. P (tcbState tcb)) t'\<rbrace> asUser t m \<lbrace>\<lambda>_. obj_at' (\<lambda>tcb. P (tcbState tcb)) t'\<rbrace>"
+  apply (simp add: asUser_def threadGet_def)
+  apply (wpsimp wp: getObject_tcb_wp simp: obj_at'_def)
+  done
+
 lemma asUser_sch_act_wf[wp]:
   "\<lbrace>\<lambda>s. sch_act_wf (ksSchedulerAction s) s\<rbrace>
     asUser t m \<lbrace>\<lambda>rv s. sch_act_wf (ksSchedulerAction s) s\<rbrace>"
@@ -1955,6 +1965,12 @@ lemma pspace_relation_update_concrete_tcb:
   "\<lbrakk>pspace_relation s s'; s ptr = Some (TCB tcb); s' ptr = Some (KOTCB otcb');
     tcb_relation tcb tcb'\<rbrakk>
    \<Longrightarrow> pspace_relation s (s'(ptr \<mapsto> KOTCB tcb'))"
+  by (fastforce dest: pspace_relation_update_tcbs simp: map_upd_triv)
+
+lemma pspace_relation_update_abstract_tcb:
+  "\<lbrakk>pspace_relation s s'; s ptr = Some (TCB tcb); s' ptr = Some (KOTCB otcb');
+    tcb_relation tcb' otcb'\<rbrakk>
+   \<Longrightarrow> pspace_relation (s(ptr \<mapsto> TCB tcb')) s'"
   by (fastforce dest: pspace_relation_update_tcbs simp: map_upd_triv)
 
 lemma threadSet_pspace_relation:

--- a/proof/refine/ARM/Tcb_R.thy
+++ b/proof/refine/ARM/Tcb_R.thy
@@ -1531,7 +1531,7 @@ proof -
                                    threadSet_valid_objs' thread_set_not_state_valid_sched
                                    thread_set_tcb_ipc_buffer_cap_cleared_invs thread_set_cte_wp_at_trivial
                                    thread_set_no_cap_to_trivial getThreadBufferSlot_dom_tcb_cte_cases
-                                   assertDerived_wp_weak threadSet_cap_to' out_pred_tcb_at_preserved
+                                   assertDerived_wp_weak threadSet_cap_to'
                                    checkCap_wp assertDerived_wp_weak cap_insert_objs'
                         | simp add: ran_tcb_cap_cases split_def U V
                                   emptyable_def
@@ -1567,7 +1567,7 @@ proof -
                                  threadSet_valid_objs' thread_set_not_state_valid_sched setP_invs'
                                  typ_at_lifts [OF setPriority_typ_at']
                                  typ_at_lifts [OF setMCPriority_typ_at']
-                                 threadSet_cap_to' out_pred_tcb_at_preserved assertDerived_wp
+                                 threadSet_cap_to' assertDerived_wp
                       del: cteInsert_invs
                    | simp add: ran_tcb_cap_cases split_def U V
                                emptyable_def
@@ -1671,6 +1671,49 @@ lemma setSchedulerAction_invs'[wp]:
 
 end
 
+lemma setFlags_corres[corres]:
+  "flags = word_to_tcb_flags flags' \<Longrightarrow>
+   corres dc (tcb_at t and pspace_aligned and pspace_distinct) \<top>
+         (set_flags t flags) (setFlags t flags')"
+  unfolding set_flags_def setFlags_def
+  apply (corres corres: threadset_corres)
+  by (clarsimp simp: tcb_relation_def inQ_def)+
+
+crunch set_flags
+  for pspace_aligned[wp]: pspace_aligned
+  and pspace_distinct[wp]: pspace_distinct
+
+context begin interpretation Arch . (*FIXME: arch-split*)
+
+lemma tcbFlagToWord_bit:
+  "(\<exists>n. tcbFlagToWord flag = bit n) \<or> tcbFlagToWord flag = 0"
+  by (auto simp: tcbFlagToWord_def archTcbFlagToWord_def split: tcb_flag.splits
+       simp del: bit_def)
+
+lemma word_to_tcb_flags_subtract:
+  "word_to_tcb_flags (flags && ~~ flags') = word_to_tcb_flags flags - word_to_tcb_flags flags'"
+  apply (clarsimp simp: word_to_tcb_flags_def intro!: set_eqI)
+  apply (cut_tac flag=x in tcbFlagToWord_bit)
+  apply (fastforce simp: word_eq_iff tcbFlagToWord_bit)
+  done
+
+lemma word_to_tcb_flags_union:
+  "word_to_tcb_flags (flags || flags') = word_to_tcb_flags flags \<union> word_to_tcb_flags flags'"
+  apply (clarsimp simp: word_to_tcb_flags_def intro!: set_eqI)
+  apply (cut_tac flag=x in tcbFlagToWord_bit)
+  apply (fastforce simp: word_eq_iff tcbFlagToWord_bit)
+  done
+
+lemmas word_to_tcb_flags_simps = word_to_tcb_flags_subtract word_to_tcb_flags_union
+
+lemma postSetFlags_corres[corres]:
+  "flags = word_to_tcb_flags flags' \<Longrightarrow>
+   corres dc (pspace_aligned and pspace_distinct) \<top>
+     (arch_post_set_flags  t flags) (postSetFlags t flags')"
+  by (clarsimp simp: arch_post_set_flags_def postSetFlags_def)
+
+end
+
 consts
   copyregsets_map :: "arch_copy_register_sets \<Rightarrow> Arch.copy_register_sets"
 
@@ -1702,6 +1745,10 @@ where
     = (x = tcbinvocation.NotificationControl t ntfnptr)"
 | "tcbinv_relation (tcb_invocation.SetTLSBase ref w) x
     = (x = tcbinvocation.SetTLSBase ref w)"
+| "tcbinv_relation (tcb_invocation.SetFlags ref clears sets) x
+    = (\<exists>clears' sets'.
+         clears = word_to_tcb_flags clears' \<and> sets = word_to_tcb_flags sets' \<and>
+         x = tcbinvocation.SetFlags ref clears' sets')"
 
 primrec
   tcb_inv_wf' :: "tcbinvocation \<Rightarrow> kernel_state \<Rightarrow> bool"
@@ -1741,6 +1788,8 @@ where
                                           and bound_tcb_at' ((=) None) t) )"
 | "tcb_inv_wf' (tcbinvocation.SetTLSBase ref w)
              = (tcb_at' ref and ex_nonz_cap_to' ref)"
+| "tcb_inv_wf' (tcbinvocation.SetFlags ref clears sets)
+             = (tcb_at' ref and ex_nonz_cap_to' ref)"
 
 lemma invokeTCB_corres:
  "tcbinv_relation ti ti' \<Longrightarrow>
@@ -1749,53 +1798,57 @@ lemma invokeTCB_corres:
          (invs' and sch_act_simple and tcb_inv_wf' ti')
          (invoke_tcb ti) (invokeTCB ti')"
   apply (case_tac ti, simp_all only: tcbinv_relation.simps valid_tcb_invocation_def)
-         apply (rule corres_guard_imp [OF invokeTCB_WriteRegisters_corres], simp+)[1]
-        apply (rule corres_guard_imp [OF invokeTCB_ReadRegisters_corres], simp+)[1]
-       apply (rule corres_guard_imp [OF invokeTCB_CopyRegisters_corres], simp+)[1]
-      apply (clarsimp simp del: invoke_tcb.simps)
-      apply (rename_tac word one t2 mcp t3 t4 t5 t6 t7 t8 t9 t10 t11)
-      apply (rule_tac F="is_aligned word 5" in corres_req)
-       apply (clarsimp simp add: is_aligned_weaken [OF tcb_aligned])
-      apply (rule corres_guard_imp [OF transferCaps_corres], clarsimp+)
-       apply (clarsimp simp: is_cnode_or_valid_arch_def
-                      split: option.split option.split_asm)
-      apply clarsimp
-      apply (auto split: option.split_asm simp: newroot_rel_def)[1]
+          apply (rule corres_guard_imp [OF invokeTCB_WriteRegisters_corres], simp+)[1]
+         apply (rule corres_guard_imp [OF invokeTCB_ReadRegisters_corres], simp+)[1]
+        apply (rule corres_guard_imp [OF invokeTCB_CopyRegisters_corres], simp+)[1]
+       apply (clarsimp simp del: invoke_tcb.simps)
+       apply (rename_tac word one t2 mcp t3 t4 t5 t6 t7 t8 t9 t10 t11)
+       apply (rule_tac F="is_aligned word 5" in corres_req)
+        apply (clarsimp simp add: is_aligned_weaken [OF tcb_aligned])
+       apply (rule corres_guard_imp [OF transferCaps_corres], clarsimp+)
+        apply (clarsimp simp: is_cnode_or_valid_arch_def
+                       split: option.split option.split_asm)
+       apply clarsimp
+       apply (auto split: option.split_asm simp: newroot_rel_def)[1]
+      apply (simp add: invokeTCB_def liftM_def[symmetric]
+                       o_def dc_def[symmetric])
+      apply (rule corres_guard_imp [OF suspend_corres], simp+)
      apply (simp add: invokeTCB_def liftM_def[symmetric]
                       o_def dc_def[symmetric])
-     apply (rule corres_guard_imp [OF suspend_corres], simp+)
-    apply (simp add: invokeTCB_def liftM_def[symmetric]
-                     o_def dc_def[symmetric])
-    apply (rule corres_guard_imp [OF restart_corres], simp+)
-   apply (simp add:invokeTCB_def)
-   apply (rename_tac option)
-   apply (case_tac option)
+     apply (rule corres_guard_imp [OF restart_corres], simp+)
+    apply (simp add:invokeTCB_def)
+    apply (rename_tac option)
+    apply (case_tac option)
+     apply simp
+     apply (rule corres_guard_imp)
+       apply (rule corres_split[OF unbindNotification_corres])
+         apply (rule corres_trivial, simp)
+        apply wp+
+      apply (clarsimp)
+     apply clarsimp
     apply simp
     apply (rule corres_guard_imp)
-      apply (rule corres_split[OF unbindNotification_corres])
+      apply (rule corres_split[OF bindNotification_corres])
         apply (rule corres_trivial, simp)
        apply wp+
-     apply (clarsimp)
-    apply clarsimp
-   apply simp
+     apply clarsimp
+     apply (clarsimp simp: obj_at_def is_ntfn)
+    apply (clarsimp simp: obj_at'_def projectKOs)
+   apply (simp add: invokeTCB_def tlsBaseRegister_def)
    apply (rule corres_guard_imp)
-     apply (rule corres_split[OF bindNotification_corres])
-       apply (rule corres_trivial, simp)
-      apply wp+
-    apply clarsimp
-    apply (clarsimp simp: obj_at_def is_ntfn)
-   apply (clarsimp simp: obj_at'_def projectKOs)
-  apply (simp add: invokeTCB_def tlsBaseRegister_def)
-  apply (rule corres_guard_imp)
-    apply (rule corres_split[OF TcbAcc_R.asUser_setRegister_corres])
-      apply (rule corres_split[OF Bits_R.getCurThread_corres])
-        apply (rule corres_split[OF Corres_UL.corres_when])
-            apply simp
-           apply (rule TcbAcc_R.rescheduleRequired_corres)
-          apply (rule corres_trivial, simp)
-         apply (wpsimp wp: hoare_drop_imp)+
-   apply (fastforce dest: valid_sched_valid_queues simp: valid_sched_weak_strg)
-  apply fastforce
+     apply (rule corres_split[OF TcbAcc_R.asUser_setRegister_corres])
+       apply (rule corres_split[OF Bits_R.getCurThread_corres])
+         apply (rule corres_split[OF Corres_UL.corres_when])
+             apply simp
+            apply (rule TcbAcc_R.rescheduleRequired_corres)
+           apply (rule corres_trivial, simp)
+          apply (wpsimp wp: hoare_drop_imp)+
+    apply (fastforce dest: valid_sched_valid_queues simp: valid_sched_weak_strg)
+   apply fastforce
+  apply (clarsimp simp: invokeTCB_def)
+  apply (corres corres: threadGet_corres[where r="\<lambda>flags flags'. flags = word_to_tcb_flags flags'"]
+             term_simp: tcb_relation_def word_to_tcb_flags_simps)
+   apply fastforce+
   done
 
 lemma tcbBoundNotification_caps_safe[simp]:
@@ -1866,23 +1919,37 @@ lemma setTLSBase_invs'[wp]:
    \<lbrace>\<lambda>rv. invs'\<rbrace>"
   by (wpsimp simp: invokeTCB_def)
 
+lemma threadSet_flags_invs[wp]:
+  "threadSet (tcbFlags_update f) t \<lbrace>invs'\<rbrace>"
+  by (wpsimp wp: threadSet_invs_trivial)
+
+crunch setFlags, postSetFlags
+  for invs'[wp]: invs'
+  (ignore: threadSet)
+
+lemma invokeSetFlags_invs'[wp]:
+  "\<lbrace>invs' and tcb_inv_wf' (tcbinvocation.SetFlags tcb clears' sets')\<rbrace>
+   invokeTCB (tcbinvocation.SetFlags tcb clears' sets')
+   \<lbrace>\<lambda>rv. invs'\<rbrace>"
+  by (wpsimp simp: invokeTCB_def)
+
 lemma tcbinv_invs':
   "\<lbrace>invs' and sch_act_simple and ct_in_state' runnable' and tcb_inv_wf' ti\<rbrace>
      invokeTCB ti
    \<lbrace>\<lambda>rv. invs'\<rbrace>"
   apply (case_tac ti, simp_all only:)
+          apply (simp add: invokeTCB_def)
+          apply wp
+          apply (clarsimp simp: invs'_def valid_state'_def
+                          dest!: global'_no_ex_cap)
          apply (simp add: invokeTCB_def)
-         apply wp
+         apply (wp restart_invs')
          apply (clarsimp simp: invs'_def valid_state'_def
                          dest!: global'_no_ex_cap)
-        apply (simp add: invokeTCB_def)
-        apply (wp restart_invs')
-        apply (clarsimp simp: invs'_def valid_state'_def
-                        dest!: global'_no_ex_cap)
-       apply (wp tc_invs')
-       apply (clarsimp split: option.split dest!: isCapDs)
-      apply (wp writereg_invs' readreg_invs' copyreg_invs' tcbntfn_invs'
-             | simp)+
+        apply (wp tc_invs')
+        apply (clarsimp split: option.split dest!: isCapDs)
+       apply (wp writereg_invs' readreg_invs' copyreg_invs' tcbntfn_invs'
+              | simp)+
   done
 
 declare assertDerived_wp [wp]
@@ -2583,6 +2650,13 @@ lemma decodeSetTLSBase_corres:
   by (clarsimp simp: decode_set_tls_base_def decodeSetTLSBase_def returnOk_def
                split: list.split)
 
+lemma decodeSetFlags_corres:
+  "corres (ser \<oplus> tcbinv_relation) (tcb_at t) (tcb_at' t)
+          (decode_set_flags w (cap.ThreadCap t))
+          (decodeSetFlags w (capability.ThreadCap t))"
+  by (clarsimp simp: decode_set_flags_def decodeSetFlags_def returnOk_def
+               split: list.split)
+
 lemma decodeTCBInvocation_corres:
  "\<lbrakk> c = Structures_A.ThreadCap t; cap_relation c c';
       list_all2 (\<lambda>(c, sl) (c', sl'). cap_relation c c' \<and> sl' = cte_map sl) extras extras';
@@ -2610,7 +2684,8 @@ lemma decodeTCBInvocation_corres:
              corres_guard_imp[OF decodeSetSpace_corres]
              corres_guard_imp[OF decodeBindNotification_corres]
              corres_guard_imp[OF decodeUnbindNotification_corres]
-             corres_guard_imp[OF decodeSetTLSBase_corres],
+             corres_guard_imp[OF decodeSetTLSBase_corres]
+             corres_guard_imp[OF decodeSetFlags_corres],
          simp_all add: valid_cap_simps valid_cap_simps' invs_def valid_state_def
                        valid_pspace_def valid_sched_def)
   apply (auto simp: list_all2_map1 list_all2_map2
@@ -2661,6 +2736,12 @@ lemma decodeSetTLSBase_wf:
   apply (simp add: decodeSetTLSBase_def
              cong: list.case_cong)
   by wpsimp
+
+lemma decodeSetFlags_wf[wp]:
+  "\<lbrace>invs' and tcb_at' t and ex_nonz_cap_to' t\<rbrace>
+   decodeSetFlags w (capability.ThreadCap t)
+   \<lbrace>tcb_inv_wf'\<rbrace>,-"
+  by (wpsimp simp: decodeSetFlags_def)
 
 lemma decodeTCBInv_wf:
   "\<lbrace>invs' and tcb_at' t and cte_at' slot and ex_nonz_cap_to' t

--- a/proof/refine/ARM/Untyped_R.thy
+++ b/proof/refine/ARM/Untyped_R.thy
@@ -4365,7 +4365,7 @@ crunch doMachineOp
   (simp: crunch_simps ct_in_state'_def)
 
 crunch doMachineOp
-  for st_tcb_at'[wp]: "st_tcb_at' P p"
+  for st_tcb_at'[wp]: "\<lambda>s. P (st_tcb_at' P' p s)"
   (simp: crunch_simps ct_in_state'_def)
 
 lemma ex_cte_cap_wp_to_irq_state_independent_H[simp]:

--- a/proof/refine/ARM/orphanage/Orphanage.thy
+++ b/proof/refine/ARM/orphanage/Orphanage.thy
@@ -754,25 +754,13 @@ lemma ThreadDecls_H_switchToThread_ct [wp]:
   apply (wp | clarsimp)+
   done
 
-crunch nextDomain
+crunch nextDomain, prepareNextDomain
   for no_orphans[wp]: no_orphans
-(wp: no_orphans_lift simp: Let_def)
-
-crunch nextDomain
-  for tcbQueued[wp]: "\<lambda>s. Q (obj_at' (\<lambda>tcb. P (tcbQueued tcb)) tcb_ptr s)"
-(simp: Let_def)
-
-crunch nextDomain
-  for st_tcb_at'[wp]: "\<lambda>s. P (st_tcb_at' P' p s)"
-(simp: Let_def)
-
-crunch nextDomain
-  for ct'[wp]: "\<lambda>s. P (ksCurThread s)"
-(simp: Let_def)
-
-crunch nextDomain
-  for sch_act_not[wp]: "sch_act_not t"
-(simp: Let_def)
+  and tcbQueued[wp]: "\<lambda>s. Q (obj_at' (\<lambda>tcb. P (tcbQueued tcb)) tcb_ptr s)"
+  and st_tcb_at'[wp]: "\<lambda>s. P (st_tcb_at' P' p s)"
+  and ct'[wp]: "\<lambda>s. P (ksCurThread s)"
+  and sch_act_not[wp]: "sch_act_not t"
+  (wp: no_orphans_lift simp: Let_def)
 
 lemma all_invs_but_ct_idle_or_in_cur_domain'_strg:
   "invs' s \<longrightarrow> all_invs_but_ct_idle_or_in_cur_domain' s"
@@ -830,16 +818,11 @@ lemma scheduleChooseNewThread_no_orphans:
    scheduleChooseNewThread
    \<lbrace>\<lambda>_. no_orphans\<rbrace>"
   unfolding scheduleChooseNewThread_def
-     apply (wp add: ssa_no_orphans hoare_vcg_all_lift)
-         apply (wp hoare_disjI1 chooseThread_nosch)+
-    apply (wp nextDomain_invs_no_cicd' hoare_vcg_imp_lift
-               hoare_lift_Pf2 [OF tcbQueued_all_queued_tcb_ptrs_lift[OF nextDomain_tcbQueued]
-                                  nextDomain_ct']
-               hoare_lift_Pf2 [OF st_tcb_at'_is_active_tcb_ptr_lift[OF nextDomain_st_tcb_at']
-                                  nextDomain_ct']
-               hoare_vcg_all_lift getDomainTime_wp)[2]
-   apply (wpsimp simp: if_apply_def2 invs'_invs_no_cicd all_queued_tcb_ptrs_def
-                       is_active_tcb_ptr_runnable')+
+  apply (wpsimp wp: ssa_no_orphans hoare_vcg_all_lift hoare_vcg_imp_lift' chooseThread_nosch
+                    hoare_disjI1 nextDomain_invs_no_cicd' tcbQueued_all_queued_tcb_ptrs_lift
+                    st_tcb_at'_is_active_tcb_ptr_lift
+         | wps)+
+  apply (clarsimp simp: invs'_invs_no_cicd is_active_tcb_ptr_runnable')
   done
 
 lemma setSchedulerAction_tcbQueued[wp]:
@@ -916,37 +899,32 @@ proof -
   supply if_weak_cong[cong]
   apply (wp, wpc)
        \<comment> \<open>action = ResumeCurrentThread\<close>
-       apply (wp)[1]
+       apply wp
       \<comment> \<open>action = ChooseNewThread\<close>
       apply (clarsimp simp: when_def scheduleChooseNewThread_def)
       apply (wp ssa_no_orphans hoare_vcg_all_lift)
           apply (wp hoare_disjI1 chooseThread_nosch)
-         apply (wp nextDomain_invs_no_cicd' hoare_vcg_imp_lift
-                   hoare_lift_Pf2 [OF tcbQueued_all_queued_tcb_ptrs_lift
-                                      [OF nextDomain_tcbQueued]
-                                      nextDomain_ct']
-                   hoare_lift_Pf2 [OF st_tcb_at'_is_active_tcb_ptr_lift
-                                    [OF nextDomain_st_tcb_at']
-                                    nextDomain_ct']
-                   hoare_vcg_all_lift getDomainTime_wp)[2]
-        apply wpsimp
+         apply ((wpsimp wp: nextDomain_invs_no_cicd' hoare_vcg_imp_lift'
+                            st_tcb_at'_is_active_tcb_ptr_lift
+                            tcbQueued_all_queued_tcb_ptrs_lift hoare_vcg_all_lift getDomainTime_wp
+                 | wps)+)[2]
        apply ((wp tcbSchedEnqueue_no_orphans tcbSchedEnqueue_all_queued_tcb_ptrs'
                   hoare_drop_imp
                | clarsimp simp: all_queued_tcb_ptrs_def
                | strengthen all_invs_but_ct_idle_or_in_cur_domain'_strg
-               | rule hoare_lift_Pf2[where f=ksCurThread])+)[1]
+               | wps)+)[1]
       apply wpsimp
-    \<comment> \<open>action = SwitchToThread candidate\<close>
-    apply clarsimp
-    apply (rename_tac candidate)
-   apply (wpsimp wp: do_switch_to abort_switch_to_enq abort_switch_to_app)
-          (* isHighestPrio *)
-          apply (wp hoare_drop_imps)
-         apply (wp add: tcbSchedEnqueue_no_orphans)+
-    apply (clarsimp simp: conj_comms cong: conj_cong imp_cong split del: if_split)
-    apply (wp hoare_vcg_imp_lift'
-           | strengthen not_pred_tcb_at'_strengthen)+
-      apply (wps | wpsimp wp: tcbSchedEnqueue_all_queued_tcb_ptrs')+
+     \<comment> \<open>action = SwitchToThread candidate\<close>
+     apply clarsimp
+     apply (rename_tac candidate)
+     apply (wpsimp wp: do_switch_to abort_switch_to_enq abort_switch_to_app)
+            (* isHighestPrio *)
+            apply (wp hoare_drop_imps)
+           apply (wp add: tcbSchedEnqueue_no_orphans)+
+      apply (clarsimp simp: conj_comms cong: conj_cong imp_cong split del: if_split)
+      apply (wp hoare_vcg_imp_lift'
+             | strengthen not_pred_tcb_at'_strengthen)+
+       apply (wps | wpsimp wp: tcbSchedEnqueue_all_queued_tcb_ptrs')+
   apply (fastforce simp: is_active_tcb_ptr_runnable' all_invs_but_ct_idle_or_in_cur_domain'_strg
                          invs_switchToThread_runnable')
   done
@@ -1631,7 +1609,7 @@ lemma restart_no_orphans [wp]:
   apply auto
   done
 
-lemma readreg_no_orphans:
+lemma readreg_no_orphans[wp]:
   "\<lbrace> \<lambda>s. no_orphans s \<and> invs' s \<and> sch_act_simple s \<and> tcb_at' src s \<rbrace>
      invokeTCB (tcbinvocation.ReadRegisters src susp n arch)
    \<lbrace> \<lambda>rv s. no_orphans s \<rbrace>"
@@ -1639,7 +1617,7 @@ lemma readreg_no_orphans:
   apply (wp | clarsimp)+
   done
 
-lemma writereg_no_orphans:
+lemma writereg_no_orphans[wp]:
   "\<lbrace> \<lambda>s. no_orphans s \<and> invs' s \<and> sch_act_simple s
        \<and> tcb_at' dest s \<and> ex_nonz_cap_to' dest s\<rbrace>
      invokeTCB (tcbinvocation.WriteRegisters dest resume values arch)
@@ -1650,7 +1628,7 @@ lemma writereg_no_orphans:
   by (wp hoare_vcg_if_lift hoare_vcg_conj_lift restart_invs' hoare_weak_lift_imp
        | strengthen | clarsimp simp: invs'_def valid_state'_def dest!: global'_no_ex_cap)+
 
-lemma copyreg_no_orphans:
+lemma copyreg_no_orphans[wp]:
   "\<lbrace> \<lambda>s. no_orphans s \<and> invs' s \<and> sch_act_simple s \<and> tcb_at' src s
          \<and> tcb_at' dest s \<and> ex_nonz_cap_to' src s \<and> ex_nonz_cap_to' dest s \<rbrace>
      invokeTCB (tcbinvocation.CopyRegisters dest src susp resume frames ints arch)
@@ -1667,7 +1645,7 @@ lemma copyreg_no_orphans:
   apply (fastforce simp: invs'_def valid_state'_def dest!: global'_no_ex_cap)
   done
 
-lemma settlsbase_no_orphans:
+lemma settlsbase_no_orphans[wp]:
   "\<lbrace> \<lambda>s. no_orphans s \<and> invs' s \<rbrace>
      invokeTCB (tcbinvocation.SetTLSBase src dest)
    \<lbrace> \<lambda>rv s. no_orphans s \<rbrace>"
@@ -1761,21 +1739,20 @@ lemma bindNotification_no_orphans[wp]:
   unfolding bindNotification_def
   by wp
 
+crunch setFlags, postSetFlags
+  for no_orphans[wp]: no_orphans
+
 lemma invokeTCB_no_orphans [wp]:
   "\<lbrace> \<lambda>s. no_orphans s \<and> invs' s \<and> sch_act_simple s \<and> tcb_inv_wf' tinv s \<rbrace>
    invokeTCB tinv
    \<lbrace> \<lambda>rv s. no_orphans s \<rbrace>"
-  apply (case_tac tinv, simp_all)
-       apply (clarsimp simp: invokeTCB_def)
-       apply (wp, clarsimp)
-      apply (clarsimp simp: invokeTCB_def)
-      apply (wp, clarsimp)
-     apply (wp tc_no_orphans)
-     apply (clarsimp split: option.splits simp: msg_align_bits elim!:is_aligned_weaken)
-     apply (rename_tac option)
-     apply (case_tac option)
-      apply ((wp | simp add: invokeTCB_def)+)[2]
-    apply (wp writereg_no_orphans readreg_no_orphans copyreg_no_orphans settlsbase_no_orphans | clarsimp)+
+  apply (case_tac tinv; simp; (solves wpsimp)?)
+      apply (wpsimp simp: invokeTCB_def)
+     apply (wpsimp simp: invokeTCB_def)
+    apply (wp tc_no_orphans)
+    apply (clarsimp split: option.splits simp: msg_align_bits elim!:is_aligned_weaken)
+   apply (wpsimp simp: invokeTCB_def)
+  apply (wpsimp simp: invokeTCB_def)
   done
 
 lemma invokeCNode_no_orphans [wp]:
@@ -1939,6 +1916,10 @@ lemma setDomain_no_orphans [wp]:
 
 crunch invokeIRQHandler
   for no_orphans[wp]: no_orphans
+
+crunch prepareSetDomain
+  for no_orphans[wp]: no_orphans
+  and cur_tcb'[wp]: cur_tcb'
 
 lemma performInvocation_no_orphans [wp]:
   "\<lbrace> \<lambda>s. no_orphans s \<and> invs' s \<and> valid_invocation' i s \<and> ct_active' s \<and> sch_act_simple s \<rbrace>

--- a/proof/refine/ARM_HYP/ADT_H.thy
+++ b/proof/refine/ARM_HYP/ADT_H.thy
@@ -310,6 +310,7 @@ definition
       tcb_priority = tcbPriority tcb,
       tcb_time_slice = tcbTimeSlice tcb,
       tcb_domain = tcbDomain tcb,
+      tcb_flags = word_to_tcb_flags (tcbFlags tcb),
       tcb_arch = ArchTcbMap (tcbArch tcb)\<rparr>"
 
 definition

--- a/proof/refine/ARM_HYP/EmptyFail_H.thy
+++ b/proof/refine/ARM_HYP/EmptyFail_H.thy
@@ -270,7 +270,7 @@ lemma catchError_empty_fail[intro!, wp, simp]:
   by fastforce
 
 crunch
-  chooseThread, getDomainTime, nextDomain, isHighestPrio
+  chooseThread, getDomainTime, nextDomain, isHighestPrio, prepareNextDomain
   for (empty_fail) empty_fail[intro!, wp, simp]
   (wp: empty_fail_catch)
 

--- a/proof/refine/ARM_HYP/Finalise_R.thy
+++ b/proof/refine/ARM_HYP/Finalise_R.thy
@@ -2383,7 +2383,8 @@ lemma finaliseCap_True_invs[wp]:
   done
 
 crunch flushSpace
-  for invs'[wp]: "invs'" (ignore: doMachineOp)
+  for invs'[wp]: "invs'"
+  (ignore: doMachineOp)
 
 lemma invs_asid_update_strg':
   "invs' s \<and> tab = armKSASIDTable (ksArchState s) \<longrightarrow>

--- a/proof/refine/ARM_HYP/Init_R.thy
+++ b/proof/refine/ARM_HYP/Init_R.thy
@@ -28,9 +28,7 @@ context begin interpretation Arch . (*FIXME: arch-split*)
   system.
 *)
 
-definition zeroed_arch_abstract_state ::
-  arch_state
-  where
+definition zeroed_arch_abstract_state :: arch_state where
   "zeroed_arch_abstract_state \<equiv> \<lparr>
     arm_asid_table = Map.empty,
     arm_hwasid_table = Map.empty,
@@ -42,9 +40,7 @@ definition zeroed_arch_abstract_state ::
     arm_us_global_pd =0
    \<rparr>"
 
-definition zeroed_main_abstract_state ::
-  abstract_state
-  where
+definition zeroed_main_abstract_state :: abstract_state where
   "zeroed_main_abstract_state \<equiv> \<lparr>
     kheap = Map.empty,
     cdt = Map.empty,
@@ -63,28 +59,20 @@ definition zeroed_main_abstract_state ::
     arch_state = zeroed_arch_abstract_state
   \<rparr>"
 
-definition zeroed_extended_state ::
-  det_ext
-  where
+definition zeroed_extended_state :: det_ext where
   "zeroed_extended_state \<equiv> \<lparr>
     work_units_completed_internal = 0,
     cdt_list_internal = K []
   \<rparr>"
 
-definition zeroed_abstract_state ::
-  det_state
-  where
+definition zeroed_abstract_state :: det_state where
   "zeroed_abstract_state \<equiv> abstract_state.extend zeroed_main_abstract_state
                            (state.fields zeroed_extended_state)"
 
-definition zeroed_arch_intermediate_state ::
-  Arch.kernel_state
-  where
+definition zeroed_arch_intermediate_state :: Arch.kernel_state where
   "zeroed_arch_intermediate_state \<equiv> ARMKernelState Map.empty Map.empty 0 Map.empty None 0 0 (K ArmVSpaceUserRegion)"
 
-definition zeroed_intermediate_state ::
-  global.kernel_state
-  where
+definition zeroed_intermediate_state :: global.kernel_state where
   "zeroed_intermediate_state \<equiv> \<lparr>
     ksPSpace = Map.empty,
     gsUserPages = Map.empty,

--- a/proof/refine/ARM_HYP/IpcCancel_R.thy
+++ b/proof/refine/ARM_HYP/IpcCancel_R.thy
@@ -1204,9 +1204,9 @@ lemma updateObject_ep_inv:
   by simp (rule updateObject_default_inv)
 
 lemma asUser_tcbQueued_inv[wp]:
-  "\<lbrace>obj_at' (\<lambda>tcb. P (tcbQueued tcb)) t'\<rbrace> asUser t m \<lbrace>\<lambda>_. obj_at' (\<lambda>tcb. P (tcbQueued tcb)) t'\<rbrace>"
+  "asUser t m \<lbrace>\<lambda>s. Q (obj_at' (\<lambda>tcb. P (tcbQueued tcb)) tcb_ptr s)\<rbrace>"
   apply (simp add: asUser_def tcb_in_cur_domain'_def threadGet_def)
-  apply (wp threadSet_obj_at'_strongish getObject_tcb_wp | wpc | simp | clarsimp simp: obj_at'_def)+
+  apply (wp threadSet_obj_at'_no_state getObject_tcb_wp | wpc | simp | clarsimp simp: obj_at'_def)+
   done
 
 context begin interpretation Arch .
@@ -2421,8 +2421,8 @@ crunch dissociateVCPUTCB
 
 crunch prepareThreadDelete
   for unqueued: "obj_at' (Not \<circ> tcbQueued) t"
-crunch prepareThreadDelete
-  for inactive: "st_tcb_at' ((=) Inactive) t'"
+  and inactive: "st_tcb_at' ((=) Inactive) t'"
+  (simp: obj_at'_not_comp_fold)
 
 end
 end

--- a/proof/refine/ARM_HYP/Ipc_R.thy
+++ b/proof/refine/ARM_HYP/Ipc_R.thy
@@ -1663,9 +1663,6 @@ lemma makeFaultMessage_tcb_at'[wp]:
                  simp: getRegister_def makeArchFaultMessage_def)+
   done
 
-crunch make_fault_msg
-  for in_user_frame[wp]: "in_user_frame p"
-
 lemma makeFaultMessage_valid_ipc_buffer_ptr'[wp]:
   "makeFaultMessage ft t \<lbrace>valid_ipc_buffer_ptr' p\<rbrace>"
   apply (cases ft, simp_all add: makeFaultMessage_def)

--- a/proof/refine/ARM_HYP/PageTableDuplicates.thy
+++ b/proof/refine/ARM_HYP/PageTableDuplicates.thy
@@ -2016,7 +2016,7 @@ lemma tc_valid_duplicates':
                simp: isCap_simps)
   done
 
-crunch performTransfer, unbindNotification, bindNotification, setDomain
+crunch performTransfer, unbindNotification, bindNotification, setDomain, prepareSetDomain,postSetFlags, setFlags
   for valid_duplicates'[wp]: "(\<lambda>s. vs_valid_duplicates' (ksPSpace s))"
   (ignore: threadSet wp: setObject_ksInterrupt updateObject_default_inv
      simp: crunch_simps)

--- a/proof/refine/ARM_HYP/Refine.thy
+++ b/proof/refine/ARM_HYP/Refine.thy
@@ -201,8 +201,7 @@ assumes rel: "(s,s') \<in> state_relation"
 shows "absKState s' = abs_state s"
   using assms
   apply (intro state.equality, simp_all add: absKState_def abs_state_def)
-                 apply (rule absHeap_correct; clarsimp)
-                 apply (clarsimp elim!: state_relationE)
+                 apply (rule absHeap_correct; clarsimp elim!: state_relationE)
                 apply (rule absCDT_correct; clarsimp)
                apply (rule absIsOriginalCap_correct; clarsimp)
               apply (simp add: state_relation_def)
@@ -659,16 +658,14 @@ lemma entry_corres:
          apply (rule hoare_strengthen_post, rule akernel_invs_det_ext,
                 simp add: invs_def valid_state_def valid_pspace_def cur_tcb_def)
         apply (rule hoare_strengthen_post, rule ckernel_invs, simp add: invs'_def cur_tcb'_def)
-       apply ((wp thread_set_invs_trivial
-                  thread_set_not_state_valid_sched hoare_weak_lift_imp
-                  hoare_vcg_disj_lift ct_in_state_thread_state_lift
-               | simp add: tcb_cap_cases_def thread_set_no_change_tcb_state schact_is_rct_def)+)[1]
-      apply (simp add: pred_conj_def cong: conj_cong)
-      apply (wp threadSet_invs_trivial threadSet_ct_running'
-                 hoare_weak_lift_imp hoare_vcg_disj_lift
-              | simp add: ct_in_state'_def atcbContextSet_def
-              | (wps, wp threadSet_st_tcb_at2))+
-   apply (fastforce simp: invs_def cur_tcb_def)
+       apply (wp thread_set_invs_trivial
+                 threadSet_invs_trivial threadSet_ct_running'
+                 thread_set_not_state_valid_sched hoare_weak_lift_imp
+                 hoare_vcg_disj_lift ct_in_state_thread_state_lift
+                 thread_set_no_change_tcb_state
+              | simp add: tcb_cap_cases_def ct_in_state'_def schact_is_rct_def
+              | (wps, wp threadSet_st_tcb_at2) )+
+   apply (clarsimp simp: invs_def cur_tcb_def valid_state_def valid_pspace_def)
   apply (clarsimp simp: ct_in_state'_def)
   done
 

--- a/proof/refine/ARM_HYP/Retype_R.thy
+++ b/proof/refine/ARM_HYP/Retype_R.thy
@@ -2333,6 +2333,10 @@ lemma other_objs_default_relation:
                  split: Structures_A.apiobject_type.split_asm)
   done
 
+lemma word_to_tcb_flags_0[simp]:
+  "word_to_tcb_flags 0 = {}"
+  by (clarsimp simp: word_to_tcb_flags_def)
+
 lemma tcb_relation_retype:
   "obj_relation_retype (default_object Structures_A.TCBObject dev n d)
                        (KOTCB (tcbDomain_update (\<lambda>_. d) makeObject))"
@@ -3051,7 +3055,7 @@ proof (intro conjI impI)
        apply (rule_tac ptr="x + xa" in cte_wp_at_tcbI', assumption+)
         apply fastforce
        apply simp
-      apply (rename_tac thread_state mcp priority bool option nat cptr vptr bound tcbprev tcbnext user_context)
+      apply (rename_tac thread_state mcp priority bool option nat cptr vptr bound tcbprev tcbnext tcbflags tcbarch)
       apply (case_tac thread_state, simp_all add: valid_tcb_state'_def valid_bound_tcb'_def
                                                   valid_bound_ntfn'_def obj_at_disj' opt_tcb_at'_def
                                            split: option.splits)[4]

--- a/proof/refine/ARM_HYP/Schedule_R.thy
+++ b/proof/refine/ARM_HYP/Schedule_R.thy
@@ -824,12 +824,11 @@ proof -
 qed
 
 crunch storeWordUser, setVMRoot, asUser, storeWordUser, Arch.switchToThread
-  for ksQ[wp]: "\<lambda>s. P (ksReadyQueues s p)"
+  for ksQ[wp]: "\<lambda>s. P (ksReadyQueues s)"
   and ksIdleThread[wp]: "\<lambda>s. P (ksIdleThread s)"
   and sym_heap_sched_pointers[wp]: sym_heap_sched_pointers
   and valid_objs'[wp]: valid_objs'
-  (wp: crunch_wps threadSet_sched_pointers getObject_tcb_wp getASID_wp
-   simp: crunch_simps obj_at'_def)
+  (wp: crunch_wps threadSet_sched_pointers simp: crunch_simps)
 
 crunch arch_switch_to_thread, arch_switch_to_idle_thread
   for pspace_aligned[wp]: pspace_aligned
@@ -837,7 +836,7 @@ crunch arch_switch_to_thread, arch_switch_to_idle_thread
   and ready_qs_distinct[wp]: ready_qs_distinct
   and valid_idle_new[wp]: valid_idle
   and ready_queues[wp]: "\<lambda>s. P (ready_queues s)"
-  (wp: ready_qs_distinct_lift simp: crunch_simps)
+  (wp: ready_qs_distinct_lift)
 
 lemma valid_queues_in_correct_ready_q[elim!]:
   "valid_queues s \<Longrightarrow> in_correct_ready_q s"
@@ -1858,24 +1857,33 @@ lemma nextDomain_invs_no_cicd':
                         all_invs_but_ct_idle_or_in_cur_domain'_def)
   done
 
+lemma prepareNextDomain_corres[corres]:
+  "corres dc (pspace_aligned and pspace_distinct) \<top>
+             arch_prepare_next_domain prepareNextDomain"
+  by (clarsimp simp: arch_prepare_next_domain_def prepareNextDomain_def)
+
+crunch prepareNextDomain
+  for invs'[wp]: invs'
+  and nosch[wp]: "\<lambda>s. P (ksSchedulerAction s)"
+
 lemma scheduleChooseNewThread_fragment_corres:
   "corres dc (invs and valid_sched and (\<lambda>s. scheduler_action s = choose_new_thread)) (invs' and (\<lambda>s. ksSchedulerAction s = ChooseNewThread))
-     (do _ \<leftarrow> when (domainTime = 0) next_domain;
+     (do _ \<leftarrow> when (domainTime = 0) (do
+           _ \<leftarrow> arch_prepare_next_domain;
+           next_domain
+         od);
          choose_thread
       od)
-     (do _ \<leftarrow> when (domainTime = 0) nextDomain;
-          chooseThread
+     (do _ \<leftarrow> when (domainTime = 0) (do
+           _ \<leftarrow> prepareNextDomain;
+           nextDomain
+         od);
+         chooseThread
       od)"
-  apply (subst bind_dummy_ret_val)
-  apply (subst bind_dummy_ret_val)
-  apply (rule corres_guard_imp)
-    apply (rule corres_split)
-       apply (rule corres_when, simp)
-       apply (rule nextDomain_corres)
-      apply simp
-      apply (rule chooseThread_corres)
-     apply (wp nextDomain_invs_no_cicd')+
-   apply (clarsimp simp: valid_sched_def invs'_def valid_state'_def all_invs_but_ct_idle_or_in_cur_domain'_def)+
+  apply (subst bind_dummy_ret_val)+
+  apply (corres corres: nextDomain_corres chooseThread_corres
+                    wp: nextDomain_invs_no_cicd')
+   apply (auto simp: valid_sched_def invs'_def valid_state'_def all_invs_but_ct_idle_or_in_cur_domain'_def)
   done
 
 lemma scheduleSwitchThreadFastfail_corres:

--- a/proof/refine/ARM_HYP/StateRelation.thy
+++ b/proof/refine/ARM_HYP/StateRelation.thy
@@ -213,7 +213,8 @@ definition tcb_relation :: "Structures_A.tcb \<Rightarrow> Structures_H.tcb \<Ri
    \<and> tcb_mcpriority tcb = tcbMCP tcb'
    \<and> tcb_priority tcb = tcbPriority tcb'
    \<and> tcb_time_slice tcb = tcbTimeSlice tcb'
-   \<and> tcb_domain tcb = tcbDomain tcb'"
+   \<and> tcb_domain tcb = tcbDomain tcb'
+   \<and> tcb_flags tcb = word_to_tcb_flags (tcbFlags tcb')"
 
 \<comment> \<open>
   A pair of objects @{term "(obj, obj')"} should satisfy the following relation when, under further

--- a/proof/refine/ARM_HYP/SubMonad_R.thy
+++ b/proof/refine/ARM_HYP/SubMonad_R.thy
@@ -20,12 +20,21 @@ interpretation submonad_doMachineOp:
   submonad ksMachineState "(ksMachineState_update \<circ> K)" \<top> doMachineOp
   by (rule submonad_doMachineOp)
 
+lemma corres_machine_op':
+  assumes P: "corres_underlying Id False True r P P' x x'"
+  shows      "corres r (P \<circ> machine_state) (P' \<circ> ksMachineState) (do_machine_op x) (doMachineOp x')"
+  apply (rule corres_submonad3 [OF submonad_do_machine_op submonad_doMachineOp _ _ _ _ P])
+   apply (simp_all add: state_relation_def swp_def)
+  done
+
 lemma corres_machine_op:
   assumes P: "corres_underlying Id False True r \<top> \<top> x x'"
   shows      "corres r \<top> \<top> (do_machine_op x) (doMachineOp x')"
-  apply (rule corres_submonad [OF submonad_do_machine_op submonad_doMachineOp _ _ P])
-   apply (simp_all add: state_relation_def swp_def)
-  done
+  by (rule corres_machine_op'[OF P, simplified])
+
+lemmas corres_machine_op_Id = corres_machine_op[OF corres_Id]
+lemmas corres_machine_op_Id_dc[corres_term] = corres_machine_op_Id[where r="dc::unit \<Rightarrow> unit \<Rightarrow> bool"]
+lemmas corres_machine_op_Id_eq[corres_term] = corres_machine_op_Id[where r="(=)"]
 
 lemmas corresK_machine_op =
   corres_machine_op[atomized, THEN corresK_lift_rule, rule_format, corresK]

--- a/proof/refine/ARM_HYP/Syscall_R.thy
+++ b/proof/refine/ARM_HYP/Syscall_R.thy
@@ -349,6 +349,12 @@ lemma threadSet_tcbDomain_update_sch_act_wf[wp]:
    apply (auto simp: obj_at'_def)
   done
 
+lemma prepareSetDomain_corres[corres]:
+  "corres dc (pspace_aligned and pspace_distinct) \<top>
+     (arch_prepare_set_domain tptr new_dom) (prepareSetDomain tptr new_dom)"
+  unfolding prepareSetDomain_def arch_prepare_set_domain_def
+  by (corres corres: gcd_corres)
+
 lemma setDomain_corres:
   "corres dc
      (valid_sched and tcb_at tptr and pspace_aligned and pspace_distinct)
@@ -402,6 +408,11 @@ lemma setDomain_corres:
    apply (auto elim: valid_objs'_maxDomain valid_objs'_maxPriority pred_tcb'_weakenE
                simp: valid_sched_def valid_sched_action_def)
   done
+
+crunch prepareSetDomain
+  for invs'[wp]: invs'
+  and sch_act_simple[wp]: sch_act_simple
+  and tcb_at'[wp]: "tcb_at' p"
 
 lemma performInvocation_corres:
   "\<lbrakk> inv_relation i i'; call \<longrightarrow> block \<rbrakk> \<Longrightarrow>
@@ -458,12 +469,13 @@ lemma performInvocation_corres:
        apply (rule corres_guard_imp)
          apply (erule invokeTCB_corres)
         apply ((clarsimp dest!: schact_is_rct_simple)+)[2]
-       \<comment> \<open>domain cap\<close>
+      \<comment> \<open>domain cap\<close>
       apply (clarsimp simp: invoke_domain_def)
       apply (rule corres_guard_imp)
-        apply (rule corres_split[OF setDomain_corres])
-          apply (rule corres_trivial, simp)
-         apply (wp)+
+        apply (rule corres_split[OF prepareSetDomain_corres])
+          apply (rule corres_split[OF setDomain_corres])
+            apply (rule corres_trivial, simp)
+           apply wpsimp+
        apply ((clarsimp simp: invs_psp_aligned invs_distinct)+)[2]
      \<comment> \<open>CNodes\<close>
      apply clarsimp
@@ -495,7 +507,7 @@ lemma sendSignal_tcb_at'[wp]:
 lemmas checkCap_inv_typ_at'
   = checkCap_inv[where P="\<lambda>s. P (typ_at' T p s)" for P T p]
 
-crunch restart, bindNotification, performTransfer
+crunch restart, bindNotification, performTransfer, setFlags, postSetFlags
   for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
 
 lemma invokeTCB_typ_at'[wp]:
@@ -982,6 +994,12 @@ lemma setDomain_invs':
     apply (wp hoare_vcg_imp_lift)+
   apply (clarsimp simp:invs'_def valid_pspace'_def valid_state'_def)+
   done
+
+crunch prepareSetDomain
+  for ksCurThread[wp]: "\<lambda>s. P (ksCurThread s)"
+  and ct_in_state'[wp]: "ct_in_state' P"
+  and ksSchedulerAction[wp]: "\<lambda>s. P (ksSchedulerAction s)"
+  (wp: ct_in_state_thread_state_lift')
 
 lemma performInv_invs'[wp]:
   "\<lbrace>invs' and sch_act_simple and ct_active' and valid_invocation' i\<rbrace>

--- a/proof/refine/ARM_HYP/Tcb_R.thy
+++ b/proof/refine/ARM_HYP/Tcb_R.thy
@@ -1531,7 +1531,7 @@ proof -
                                    threadSet_valid_objs' thread_set_not_state_valid_sched
                                    thread_set_tcb_ipc_buffer_cap_cleared_invs thread_set_cte_wp_at_trivial
                                    thread_set_no_cap_to_trivial getThreadBufferSlot_dom_tcb_cte_cases
-                                   assertDerived_wp_weak threadSet_cap_to' out_pred_tcb_at_preserved
+                                   assertDerived_wp_weak threadSet_cap_to'
                                    checkCap_wp assertDerived_wp_weak cap_insert_objs'
                         | simp add: ran_tcb_cap_cases split_def U V
                                   emptyable_def
@@ -1567,7 +1567,7 @@ proof -
                                  threadSet_valid_objs' thread_set_not_state_valid_sched setP_invs'
                                  typ_at_lifts [OF setPriority_typ_at']
                                  typ_at_lifts [OF setMCPriority_typ_at']
-                                 threadSet_cap_to' out_pred_tcb_at_preserved assertDerived_wp
+                                 threadSet_cap_to' assertDerived_wp
                       del: cteInsert_invs
                    | simp add: ran_tcb_cap_cases split_def U V
                                emptyable_def
@@ -1676,6 +1676,49 @@ lemma setSchedulerAction_invs'[wp]:
 
 end
 
+lemma setFlags_corres[corres]:
+  "flags = word_to_tcb_flags flags' \<Longrightarrow>
+   corres dc (tcb_at t and pspace_aligned and pspace_distinct) \<top>
+         (set_flags t flags) (setFlags t flags')"
+  unfolding set_flags_def setFlags_def
+  apply (corres corres: threadset_corres)
+  by (clarsimp simp: tcb_relation_def inQ_def)+
+
+crunch set_flags
+  for pspace_aligned[wp]: pspace_aligned
+  and pspace_distinct[wp]: pspace_distinct
+
+context begin interpretation Arch . (*FIXME: arch-split*)
+
+lemma tcbFlagToWord_bit:
+  "(\<exists>n. tcbFlagToWord flag = bit n) \<or> tcbFlagToWord flag = 0"
+  by (auto simp: tcbFlagToWord_def archTcbFlagToWord_def split: tcb_flag.splits
+       simp del: bit_def)
+
+lemma word_to_tcb_flags_subtract:
+  "word_to_tcb_flags (flags && ~~ flags') = word_to_tcb_flags flags - word_to_tcb_flags flags'"
+  apply (clarsimp simp: word_to_tcb_flags_def intro!: set_eqI)
+  apply (cut_tac flag=x in tcbFlagToWord_bit)
+  apply (fastforce simp: word_eq_iff tcbFlagToWord_bit)
+  done
+
+lemma word_to_tcb_flags_union:
+  "word_to_tcb_flags (flags || flags') = word_to_tcb_flags flags \<union> word_to_tcb_flags flags'"
+  apply (clarsimp simp: word_to_tcb_flags_def intro!: set_eqI)
+  apply (cut_tac flag=x in tcbFlagToWord_bit)
+  apply (fastforce simp: word_eq_iff tcbFlagToWord_bit)
+  done
+
+lemmas word_to_tcb_flags_simps = word_to_tcb_flags_subtract word_to_tcb_flags_union
+
+lemma postSetFlags_corres[corres]:
+  "flags = word_to_tcb_flags flags' \<Longrightarrow>
+   corres dc (pspace_aligned and pspace_distinct) \<top>
+     (arch_post_set_flags  t flags) (postSetFlags t flags')"
+  by (clarsimp simp: arch_post_set_flags_def postSetFlags_def)
+
+end
+
 consts
   copyregsets_map :: "arch_copy_register_sets \<Rightarrow> Arch.copy_register_sets"
 
@@ -1707,6 +1750,10 @@ where
     = (x = tcbinvocation.NotificationControl t ntfnptr)"
 | "tcbinv_relation (tcb_invocation.SetTLSBase ref w) x
     = (x = tcbinvocation.SetTLSBase ref w)"
+| "tcbinv_relation (tcb_invocation.SetFlags ref clears sets) x
+    = (\<exists>clears' sets'.
+         clears = word_to_tcb_flags clears' \<and> sets = word_to_tcb_flags sets' \<and>
+         x = tcbinvocation.SetFlags ref clears' sets')"
 
 primrec
   tcb_inv_wf' :: "tcbinvocation \<Rightarrow> kernel_state \<Rightarrow> bool"
@@ -1746,6 +1793,8 @@ where
                                           and bound_tcb_at' ((=) None) t) )"
 | "tcb_inv_wf' (tcbinvocation.SetTLSBase ref w)
              = (tcb_at' ref and ex_nonz_cap_to' ref)"
+| "tcb_inv_wf' (tcbinvocation.SetFlags ref clears sets)
+             = (tcb_at' ref and ex_nonz_cap_to' ref)"
 
 lemma invokeTCB_corres:
  "tcbinv_relation ti ti' \<Longrightarrow>
@@ -1754,54 +1803,58 @@ lemma invokeTCB_corres:
          (invs' and sch_act_simple and tcb_inv_wf' ti')
          (invoke_tcb ti) (invokeTCB ti')"
   apply (case_tac ti, simp_all only: tcbinv_relation.simps valid_tcb_invocation_def)
-         apply (rule corres_guard_imp [OF invokeTCB_WriteRegisters_corres], simp+)[1]
-        apply (rule corres_guard_imp [OF invokeTCB_ReadRegisters_corres], simp+)[1]
-       apply (rule corres_guard_imp [OF invokeTCB_CopyRegisters_corres], simp+)[1]
-      apply (clarsimp simp del: invoke_tcb.simps)
-      apply (rename_tac word one t2 mcp t3 t4 t5 t6 t7 t8 t9 t10 t11)
-      apply (rule_tac F="is_aligned word 5" in corres_req)
-       apply (clarsimp simp add: is_aligned_weaken [OF tcb_aligned])
-      apply (rule corres_guard_imp [OF transferCaps_corres], clarsimp+)
+          apply (rule corres_guard_imp [OF invokeTCB_WriteRegisters_corres], simp+)[1]
+         apply (rule corres_guard_imp [OF invokeTCB_ReadRegisters_corres], simp+)[1]
+        apply (rule corres_guard_imp [OF invokeTCB_CopyRegisters_corres], simp+)[1]
+       apply (clarsimp simp del: invoke_tcb.simps)
+       apply (rename_tac word one t2 mcp t3 t4 t5 t6 t7 t8 t9 t10 t11)
+       apply (rule_tac F="is_aligned word 5" in corres_req)
+        apply (clarsimp simp add: is_aligned_weaken [OF tcb_aligned])
+       apply (rule corres_guard_imp [OF transferCaps_corres], clarsimp+)
        subgoal
        by (clarsimp simp: is_cnode_or_valid_arch_def
                    split: option.split option.split_asm)
-      apply clarsimp
-      apply (auto split: option.split_asm simp: newroot_rel_def)[1]
+       apply clarsimp
+       apply (auto split: option.split_asm simp: newroot_rel_def)[1]
+      apply (simp add: invokeTCB_def liftM_def[symmetric]
+                       o_def dc_def[symmetric])
+      apply (rule corres_guard_imp [OF suspend_corres], simp+)
      apply (simp add: invokeTCB_def liftM_def[symmetric]
                       o_def dc_def[symmetric])
-     apply (rule corres_guard_imp [OF suspend_corres], simp+)
-    apply (simp add: invokeTCB_def liftM_def[symmetric]
-                     o_def dc_def[symmetric])
-    apply (rule corres_guard_imp [OF restart_corres], simp+)
-   apply (simp add: invokeTCB_def)
-   apply (rename_tac option)
-   apply (case_tac option)
+     apply (rule corres_guard_imp [OF restart_corres], simp+)
+    apply (simp add: invokeTCB_def)
+    apply (rename_tac option)
+    apply (case_tac option)
+     apply simp
+     apply (rule corres_guard_imp)
+       apply (rule corres_split[OF unbindNotification_corres])
+         apply (rule corres_trivial, simp)
+        apply wp+
+      apply clarsimp
+     apply clarsimp
     apply simp
     apply (rule corres_guard_imp)
-      apply (rule corres_split[OF unbindNotification_corres])
+      apply (rule corres_split[OF bindNotification_corres])
         apply (rule corres_trivial, simp)
        apply wp+
      apply clarsimp
-    apply clarsimp
-   apply simp
+     apply (clarsimp simp: obj_at_def is_ntfn)
+    apply (clarsimp simp: obj_at'_def projectKOs)
+   apply (simp add: invokeTCB_def tlsBaseRegister_def)
    apply (rule corres_guard_imp)
-     apply (rule corres_split[OF bindNotification_corres])
-       apply (rule corres_trivial, simp)
-      apply wp+
-    apply clarsimp
-    apply (clarsimp simp: obj_at_def is_ntfn)
-   apply (clarsimp simp: obj_at'_def projectKOs)
-  apply (simp add: invokeTCB_def tlsBaseRegister_def)
-  apply (rule corres_guard_imp)
-    apply (rule corres_split[OF TcbAcc_R.asUser_setRegister_corres])
-      apply (rule corres_split[OF Bits_R.getCurThread_corres])
-        apply (rule corres_split[OF Corres_UL.corres_when])
-            apply simp
-           apply (rule TcbAcc_R.rescheduleRequired_corres)
-          apply (rule corres_trivial, simp)
-         apply (wpsimp wp: hoare_drop_imp)+
-   apply (fastforce dest: valid_sched_valid_queues simp: valid_sched_weak_strg)
-  apply fastforce
+     apply (rule corres_split[OF TcbAcc_R.asUser_setRegister_corres])
+       apply (rule corres_split[OF Bits_R.getCurThread_corres])
+         apply (rule corres_split[OF Corres_UL.corres_when])
+             apply simp
+            apply (rule TcbAcc_R.rescheduleRequired_corres)
+           apply (rule corres_trivial, simp)
+          apply (wpsimp wp: hoare_drop_imp)+
+    apply (fastforce dest: valid_sched_valid_queues simp: valid_sched_weak_strg)
+   apply fastforce
+  apply (clarsimp simp: invokeTCB_def)
+  apply (corres corres: threadGet_corres[where r="\<lambda>flags flags'. flags = word_to_tcb_flags flags'"]
+             term_simp: tcb_relation_def word_to_tcb_flags_simps)
+   apply fastforce+
   done
 
 lemma tcbBoundNotification_caps_safe[simp]:
@@ -1872,23 +1925,37 @@ lemma setTLSBase_invs'[wp]:
    \<lbrace>\<lambda>rv. invs'\<rbrace>"
   by (wpsimp simp: invokeTCB_def)
 
+lemma threadSet_flags_invs[wp]:
+  "threadSet (tcbFlags_update f) t \<lbrace>invs'\<rbrace>"
+  by (wpsimp wp: threadSet_invs_trivial)
+
+crunch setFlags, postSetFlags
+  for invs'[wp]: invs'
+  (ignore: threadSet)
+
+lemma invokeSetFlags_invs'[wp]:
+  "\<lbrace>invs' and tcb_inv_wf' (tcbinvocation.SetFlags tcb clears' sets')\<rbrace>
+   invokeTCB (tcbinvocation.SetFlags tcb clears' sets')
+   \<lbrace>\<lambda>rv. invs'\<rbrace>"
+  by (wpsimp simp: invokeTCB_def)
+
 lemma tcbinv_invs':
   "\<lbrace>invs' and sch_act_simple and ct_in_state' runnable' and tcb_inv_wf' ti\<rbrace>
      invokeTCB ti
    \<lbrace>\<lambda>rv. invs'\<rbrace>"
   apply (case_tac ti, simp_all only:)
+          apply (simp add: invokeTCB_def)
+          apply wp
+          apply (clarsimp simp: invs'_def valid_state'_def
+                          dest!: global'_no_ex_cap)
          apply (simp add: invokeTCB_def)
-         apply wp
+         apply (wp restart_invs')
          apply (clarsimp simp: invs'_def valid_state'_def
                          dest!: global'_no_ex_cap)
-        apply (simp add: invokeTCB_def)
-        apply (wp restart_invs')
-        apply (clarsimp simp: invs'_def valid_state'_def
-                        dest!: global'_no_ex_cap)
-       apply (wp tc_invs')
-       apply (clarsimp split: option.split dest!: isCapDs)
-      apply (wp writereg_invs' readreg_invs' copyreg_invs' tcbntfn_invs'
-             | simp)+
+        apply (wp tc_invs')
+        apply (clarsimp split: option.split dest!: isCapDs)
+       apply (wp writereg_invs' readreg_invs' copyreg_invs' tcbntfn_invs'
+              | simp)+
   done
 
 declare assertDerived_wp [wp]
@@ -2602,6 +2669,13 @@ lemma decodeSetTLSBase_corres:
   by (clarsimp simp: decode_set_tls_base_def decodeSetTLSBase_def returnOk_def
                split: list.split)
 
+lemma decodeSetFlags_corres:
+  "corres (ser \<oplus> tcbinv_relation) (tcb_at t) (tcb_at' t)
+          (decode_set_flags w (cap.ThreadCap t))
+          (decodeSetFlags w (capability.ThreadCap t))"
+  by (clarsimp simp: decode_set_flags_def decodeSetFlags_def returnOk_def
+               split: list.split)
+
 lemma decodeTCBInvocation_corres:
  "\<lbrakk> c = Structures_A.ThreadCap t; cap_relation c c';
       list_all2 (\<lambda>(c, sl) (c', sl'). cap_relation c c' \<and> sl' = cte_map sl) extras extras';
@@ -2629,7 +2703,8 @@ lemma decodeTCBInvocation_corres:
              corres_guard_imp[OF decodeSetSpace_corres]
              corres_guard_imp[OF decodeBindNotification_corres]
              corres_guard_imp[OF decodeUnbindNotification_corres]
-             corres_guard_imp[OF decodeSetTLSBase_corres],
+             corres_guard_imp[OF decodeSetTLSBase_corres]
+             corres_guard_imp[OF decodeSetFlags_corres],
          simp_all add: valid_cap_simps valid_cap_simps' invs_def valid_state_def valid_sched_def)
   apply (auto simp: list_all2_map1 list_all2_map2
              elim!: list_all2_mono)
@@ -2679,6 +2754,12 @@ lemma decodeSetTLSBase_wf:
   apply (simp add: decodeSetTLSBase_def
              cong: list.case_cong)
   by wpsimp
+
+lemma decodeSetFlags_wf[wp]:
+  "\<lbrace>invs' and tcb_at' t and ex_nonz_cap_to' t\<rbrace>
+   decodeSetFlags w (capability.ThreadCap t)
+   \<lbrace>tcb_inv_wf'\<rbrace>,-"
+  by (wpsimp simp: decodeSetFlags_def)
 
 lemma decodeTCBInv_wf:
   "\<lbrace>invs' and tcb_at' t and cte_at' slot and ex_nonz_cap_to' t

--- a/proof/refine/ARM_HYP/Untyped_R.thy
+++ b/proof/refine/ARM_HYP/Untyped_R.thy
@@ -4421,7 +4421,7 @@ crunch doMachineOp
   (simp: crunch_simps ct_in_state'_def)
 
 crunch doMachineOp
-  for st_tcb_at'[wp]: "st_tcb_at' P p"
+  for st_tcb_at'[wp]: "\<lambda>s. P (st_tcb_at' P' p s)"
   (simp: crunch_simps ct_in_state'_def)
 
 lemma ex_cte_cap_wp_to_irq_state_independent_H[simp]:

--- a/proof/refine/RISCV64/ADT_H.thy
+++ b/proof/refine/RISCV64/ADT_H.thy
@@ -253,6 +253,7 @@ definition
       tcb_priority = tcbPriority tcb,
       tcb_time_slice = tcbTimeSlice tcb,
       tcb_domain = tcbDomain tcb,
+      tcb_flags = word_to_tcb_flags (tcbFlags tcb),
       tcb_arch = ArchTcbMap (tcbArch tcb)\<rparr>"
 
 definition

--- a/proof/refine/RISCV64/EmptyFail_H.thy
+++ b/proof/refine/RISCV64/EmptyFail_H.thy
@@ -264,7 +264,7 @@ lemma catchError_empty_fail[intro!, wp, simp]:
   by fastforce
 
 crunch
-  chooseThread, getDomainTime, nextDomain, isHighestPrio
+  chooseThread, getDomainTime, nextDomain, isHighestPrio, prepareNextDomain
   for (empty_fail) empty_fail[intro!, wp, simp]
   (wp: empty_fail_catch)
 

--- a/proof/refine/RISCV64/Init_R.thy
+++ b/proof/refine/RISCV64/Init_R.thy
@@ -28,18 +28,14 @@ context begin interpretation Arch . (*FIXME: arch-split*)
   system.
 *)
 
-definition zeroed_arch_abstract_state ::
-  arch_state
-  where
+definition zeroed_arch_abstract_state :: arch_state where
   "zeroed_arch_abstract_state \<equiv> \<lparr>
     riscv_asid_table    = Map.empty,
     riscv_global_pts    = K {},
     riscv_kernel_vspace = K RISCVVSpaceUserRegion
   \<rparr>"
 
-definition zeroed_main_abstract_state ::
-  abstract_state
-  where
+definition zeroed_main_abstract_state :: abstract_state where
   "zeroed_main_abstract_state \<equiv> \<lparr>
     kheap = Map.empty,
     cdt = Map.empty,
@@ -58,28 +54,20 @@ definition zeroed_main_abstract_state ::
     arch_state = zeroed_arch_abstract_state
   \<rparr>"
 
-definition zeroed_extended_state ::
-  det_ext
-  where
+definition zeroed_extended_state :: det_ext where
   "zeroed_extended_state \<equiv> \<lparr>
     work_units_completed_internal = 0,
     cdt_list_internal = K []
   \<rparr>"
 
-definition zeroed_abstract_state ::
-  det_state
-  where
+definition zeroed_abstract_state :: det_state where
   "zeroed_abstract_state \<equiv> abstract_state.extend zeroed_main_abstract_state
                            (state.fields zeroed_extended_state)"
 
-definition zeroed_arch_intermediate_state ::
-  Arch.kernel_state
-  where
+definition zeroed_arch_intermediate_state :: Arch.kernel_state where
   "zeroed_arch_intermediate_state \<equiv> RISCVKernelState Map.empty (K []) (K RISCVVSpaceUserRegion)"
 
-definition zeroed_intermediate_state ::
-  global.kernel_state
-  where
+definition zeroed_intermediate_state :: global.kernel_state where
   "zeroed_intermediate_state \<equiv> \<lparr>
     ksPSpace = Map.empty,
     gsUserPages = Map.empty,

--- a/proof/refine/RISCV64/IpcCancel_R.thy
+++ b/proof/refine/RISCV64/IpcCancel_R.thy
@@ -1172,9 +1172,9 @@ lemma updateObject_ep_inv:
   by simp (rule updateObject_default_inv)
 
 lemma asUser_tcbQueued_inv[wp]:
-  "\<lbrace>obj_at' (\<lambda>tcb. P (tcbQueued tcb)) t'\<rbrace> asUser t m \<lbrace>\<lambda>_. obj_at' (\<lambda>tcb. P (tcbQueued tcb)) t'\<rbrace>"
+  "asUser t m \<lbrace>\<lambda>s. Q (obj_at' (\<lambda>tcb. P (tcbQueued tcb)) tcb_ptr s)\<rbrace>"
   apply (simp add: asUser_def tcb_in_cur_domain'_def threadGet_def)
-  apply (wp threadSet_obj_at'_strongish getObject_tcb_wp | wpc | simp | clarsimp simp: obj_at'_def)+
+  apply (wp threadSet_obj_at'_no_state getObject_tcb_wp | wpc | simp | clarsimp simp: obj_at'_def)+
   done
 
 context begin interpretation Arch .
@@ -2185,9 +2185,9 @@ lemma suspend_unqueued:
   by (wpsimp simp: comp_def wp: tcbSchedDequeue_not_tcbQueued)
 
 crunch prepareThreadDelete
-  for unqueued: "obj_at' (\<lambda>a. \<not> tcbQueued a) t"
-crunch prepareThreadDelete
-  for inactive: "st_tcb_at' ((=) Inactive) t'"
+  for unqueued: "obj_at' (Not \<circ> tcbQueued) t"
+  and inactive: "st_tcb_at' ((=) Inactive) t'"
+  (simp: obj_at'_not_comp_fold)
 
 end
 end

--- a/proof/refine/RISCV64/Ipc_R.thy
+++ b/proof/refine/RISCV64/Ipc_R.thy
@@ -1632,13 +1632,6 @@ lemmas threadget_fault_corres =
                               and f = tcb_fault and f' = tcbFault,
                             simplified tcb_relation_def, simplified]
 
-lemma make_fault_msg_in_user_frame[wp]:
-  "make_fault_msg f t \<lbrace>in_user_frame p\<rbrace>"
-  supply if_split[split del]
-  apply (cases f; wpsimp)
-  apply (rename_tac af; case_tac af; wpsimp)
-  done
-
 lemma doFaultTransfer_corres:
   "corres dc
     (obj_at (\<lambda>ko. \<exists>tcb ft. ko = TCB tcb \<and> tcb_fault tcb = Some ft) sender

--- a/proof/refine/RISCV64/Refine.thy
+++ b/proof/refine/RISCV64/Refine.thy
@@ -195,8 +195,7 @@ lemma absKState_correct:
   shows "absKState s' = abs_state s"
   using assms
   apply (intro state.equality, simp_all add: absKState_def abs_state_def)
-                 apply (rule absHeap_correct; clarsimp)
-                 apply (clarsimp elim!: state_relationE)
+                 apply (rule absHeap_correct; clarsimp elim!: state_relationE)
                 apply (rule absCDT_correct; clarsimp)
                apply (rule absIsOriginalCap_correct; clarsimp)
               apply (simp add: state_relation_def)
@@ -645,8 +644,8 @@ lemma entry_corres:
                  threadSet_invs_trivial threadSet_ct_running'
                  thread_set_not_state_valid_sched hoare_weak_lift_imp
                  hoare_vcg_disj_lift ct_in_state_thread_state_lift
-              | simp add: tcb_cap_cases_def ct_in_state'_def thread_set_no_change_tcb_state
-                          schact_is_rct_def
+                 thread_set_no_change_tcb_state
+              | simp add: tcb_cap_cases_def ct_in_state'_def schact_is_rct_def
               | (wps, wp threadSet_st_tcb_at2) )+
    apply (clarsimp simp: invs_def cur_tcb_def valid_state_def valid_pspace_def)
   apply (clarsimp simp: ct_in_state'_def)

--- a/proof/refine/RISCV64/Retype_R.thy
+++ b/proof/refine/RISCV64/Retype_R.thy
@@ -2279,6 +2279,10 @@ lemma other_objs_default_relation:
                  split: Structures_A.apiobject_type.split_asm)
   done
 
+lemma word_to_tcb_flags_0[simp]:
+  "word_to_tcb_flags 0 = {}"
+  by (clarsimp simp: word_to_tcb_flags_def)
+
 lemma tcb_relation_retype:
   "obj_relation_retype (default_object Structures_A.TCBObject dev n d)
                        (KOTCB (tcbDomain_update (\<lambda>_. d) makeObject))"
@@ -3009,7 +3013,7 @@ proof (intro conjI impI)
        apply (rule_tac ptr="x + xa" in cte_wp_at_tcbI', assumption+)
         apply fastforce
        apply simp
-      apply (rename_tac thread_state mcp priority bool option nat cptr vptr bound tcbprev tcbnext user_context)
+      apply (rename_tac thread_state mcp priority bool option nat cptr vptr bound tcbprev tcbnext tcbflags tcbarch)
       apply (case_tac thread_state, simp_all add: valid_tcb_state'_def valid_bound_tcb'_def
                                                   valid_bound_ntfn'_def obj_at_disj' opt_tcb_at'_def
                                            split: option.splits)[4]

--- a/proof/refine/RISCV64/Schedule_R.thy
+++ b/proof/refine/RISCV64/Schedule_R.thy
@@ -742,7 +742,7 @@ proof -
 qed
 
 crunch storeWordUser, setVMRoot, asUser, storeWordUser, Arch.switchToThread
-  for ksQ[wp]: "\<lambda>s. P (ksReadyQueues s p)"
+  for ksQ[wp]: "\<lambda>s. P (ksReadyQueues s)"
   and ksIdleThread[wp]: "\<lambda>s. P (ksIdleThread s)"
   and sym_heap_sched_pointers[wp]: sym_heap_sched_pointers
   and valid_objs'[wp]: valid_objs'
@@ -1724,24 +1724,33 @@ lemma nextDomain_invs_no_cicd':
                         all_invs_but_ct_idle_or_in_cur_domain'_def)
   done
 
+lemma prepareNextDomain_corres[corres]:
+  "corres dc (pspace_aligned and pspace_distinct) \<top>
+             arch_prepare_next_domain prepareNextDomain"
+  by (clarsimp simp: arch_prepare_next_domain_def prepareNextDomain_def)
+
+crunch prepareNextDomain
+  for invs'[wp]: invs'
+  and nosch[wp]: "\<lambda>s. P (ksSchedulerAction s)"
+
 lemma scheduleChooseNewThread_fragment_corres:
   "corres dc (invs and valid_sched and (\<lambda>s. scheduler_action s = choose_new_thread)) (invs' and (\<lambda>s. ksSchedulerAction s = ChooseNewThread))
-     (do _ \<leftarrow> when (domainTime = 0) next_domain;
+     (do _ \<leftarrow> when (domainTime = 0) (do
+           _ \<leftarrow> arch_prepare_next_domain;
+           next_domain
+         od);
          choose_thread
       od)
-     (do _ \<leftarrow> when (domainTime = 0) nextDomain;
-          chooseThread
+     (do _ \<leftarrow> when (domainTime = 0) (do
+           _ \<leftarrow> prepareNextDomain;
+           nextDomain
+         od);
+         chooseThread
       od)"
-  apply (subst bind_dummy_ret_val)
-  apply (subst bind_dummy_ret_val)
-  apply (rule corres_guard_imp)
-    apply (rule corres_split)
-       apply (rule corres_when, simp)
-       apply (rule nextDomain_corres)
-      apply simp
-      apply (rule chooseThread_corres)
-     apply (wp nextDomain_invs_no_cicd')+
-   apply (clarsimp simp: valid_sched_def invs'_def valid_state'_def all_invs_but_ct_idle_or_in_cur_domain'_def)+
+  apply (subst bind_dummy_ret_val)+
+  apply (corres corres: nextDomain_corres chooseThread_corres
+                    wp: nextDomain_invs_no_cicd')
+   apply (auto simp: valid_sched_def invs'_def valid_state'_def all_invs_but_ct_idle_or_in_cur_domain'_def)
   done
 
 lemma scheduleSwitchThreadFastfail_corres:

--- a/proof/refine/RISCV64/StateRelation.thy
+++ b/proof/refine/RISCV64/StateRelation.thy
@@ -156,7 +156,8 @@ definition tcb_relation :: "Structures_A.tcb \<Rightarrow> Structures_H.tcb \<Ri
    \<and> tcb_mcpriority tcb = tcbMCP tcb'
    \<and> tcb_priority tcb = tcbPriority tcb'
    \<and> tcb_time_slice tcb = tcbTimeSlice tcb'
-   \<and> tcb_domain tcb = tcbDomain tcb'"
+   \<and> tcb_domain tcb = tcbDomain tcb'
+   \<and> tcb_flags tcb = word_to_tcb_flags (tcbFlags tcb')"
 
 \<comment> \<open>
   A pair of objects @{term "(obj, obj')"} should satisfy the following relation when, under further

--- a/proof/refine/RISCV64/SubMonad_R.thy
+++ b/proof/refine/RISCV64/SubMonad_R.thy
@@ -20,16 +20,21 @@ interpretation submonad_doMachineOp:
   submonad ksMachineState "(ksMachineState_update \<circ> K)" \<top> doMachineOp
   by (rule submonad_doMachineOp)
 
-lemma corres_machine_op:
-  assumes P: "corres_underlying Id False True r \<top> \<top> x x'"
-  shows      "corres r \<top> \<top> (do_machine_op x) (doMachineOp x')"
-  apply (rule corres_submonad [OF submonad_do_machine_op submonad_doMachineOp _ _ P])
+lemma corres_machine_op':
+  assumes P: "corres_underlying Id False True r P P' x x'"
+  shows      "corres r (P \<circ> machine_state) (P' \<circ> ksMachineState) (do_machine_op x) (doMachineOp x')"
+  apply (rule corres_submonad3 [OF submonad_do_machine_op submonad_doMachineOp _ _ _ _ P])
    apply (simp_all add: state_relation_def swp_def)
   done
 
+lemma corres_machine_op:
+  assumes P: "corres_underlying Id False True r \<top> \<top> x x'"
+  shows      "corres r \<top> \<top> (do_machine_op x) (doMachineOp x')"
+  by (rule corres_machine_op'[OF P, simplified])
+
 lemmas corres_machine_op_Id = corres_machine_op[OF corres_Id]
-lemmas corres_machine_op_Id_eq[corres_term] = corres_machine_op_Id[where r="(=)"]
 lemmas corres_machine_op_Id_dc[corres_term] = corres_machine_op_Id[where r="dc::unit \<Rightarrow> unit \<Rightarrow> bool"]
+lemmas corres_machine_op_Id_eq[corres_term] = corres_machine_op_Id[where r="(=)"]
 
 lemma doMachineOp_mapM:
   assumes "\<And>x. empty_fail (m x)"

--- a/proof/refine/RISCV64/Syscall_R.thy
+++ b/proof/refine/RISCV64/Syscall_R.thy
@@ -348,6 +348,12 @@ lemma threadSet_tcbDomain_update_sch_act_wf[wp]:
    apply (auto simp: obj_at'_def)
   done
 
+lemma prepareSetDomain_corres[corres]:
+  "corres dc (pspace_aligned and pspace_distinct) \<top>
+     (arch_prepare_set_domain tptr new_dom) (prepareSetDomain tptr new_dom)"
+  unfolding prepareSetDomain_def arch_prepare_set_domain_def
+  by (corres corres: gcd_corres)
+
 lemma setDomain_corres:
   "corres dc
      (valid_sched and tcb_at tptr and pspace_aligned and pspace_distinct)
@@ -401,6 +407,11 @@ lemma setDomain_corres:
    apply (auto elim: valid_objs'_maxDomain valid_objs'_maxPriority pred_tcb'_weakenE
                simp: valid_sched_def valid_sched_action_def)
   done
+
+crunch prepareSetDomain
+  for invs'[wp]: invs'
+  and sch_act_simple[wp]: sch_act_simple
+  and tcb_at'[wp]: "tcb_at' p"
 
 lemma performInvocation_corres:
   "\<lbrakk> inv_relation i i'; call \<longrightarrow> block \<rbrakk> \<Longrightarrow>
@@ -459,9 +470,10 @@ lemma performInvocation_corres:
       \<comment> \<open>domain cap\<close>
       apply (clarsimp simp: invoke_domain_def)
       apply (rule corres_guard_imp)
-        apply (rule corres_split[OF setDomain_corres])
-          apply (rule corres_trivial, simp)
-         apply (wp)+
+        apply (rule corres_split[OF prepareSetDomain_corres])
+          apply (rule corres_split[OF setDomain_corres])
+            apply (rule corres_trivial, simp)
+           apply wpsimp+
        apply ((clarsimp simp: invs_psp_aligned invs_distinct)+)[2]
      \<comment> \<open>CNodes\<close>
      apply clarsimp
@@ -493,7 +505,7 @@ lemma sendSignal_tcb_at'[wp]:
 lemmas checkCap_inv_typ_at'
   = checkCap_inv[where P="\<lambda>s. P (typ_at' T p s)" for P T p]
 
-crunch restart, bindNotification, performTransfer
+crunch restart, bindNotification, performTransfer, setFlags, postSetFlags
   for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
 
 lemma invokeTCB_typ_at'[wp]:
@@ -963,6 +975,12 @@ lemma setDomain_invs':
     apply (wp hoare_vcg_imp_lift)+
   apply (clarsimp simp:invs'_def valid_pspace'_def valid_state'_def)+
   done
+
+crunch prepareSetDomain
+  for ksCurThread[wp]: "\<lambda>s. P (ksCurThread s)"
+  and ct_in_state'[wp]: "ct_in_state' P"
+  and ksSchedulerAction[wp]: "\<lambda>s. P (ksSchedulerAction s)"
+  (wp: ct_in_state_thread_state_lift')
 
 lemma performInv_invs'[wp]:
   "\<lbrace>invs' and sch_act_simple and ct_active' and valid_invocation' i\<rbrace>

--- a/proof/refine/RISCV64/TcbAcc_R.thy
+++ b/proof/refine/RISCV64/TcbAcc_R.thy
@@ -459,7 +459,7 @@ lemma ball_tcb_cte_casesI:
   by (simp add: tcb_cte_cases_def cteSizeBits_def)
 
 lemma all_tcbI:
-  "\<lbrakk> \<And>a b c d e f g h i j k l m n p q r s. P (Thread a b c d e f g h i j k l m n p q r s) \<rbrakk>
+  "\<lbrakk> \<And>a b c d e f g h i j k l m n p q r s t. P (Thread a b c d e f g h i j k l m n p q r s t) \<rbrakk>
    \<Longrightarrow> \<forall>tcb. P tcb"
   by (rule allI, case_tac tcb, simp)
 
@@ -1124,13 +1124,12 @@ lemma threadSet_obj_at'_strongish[wp]:
      threadSet f t \<lbrace>\<lambda>rv. obj_at' P t'\<rbrace>"
   by (simp add: hoare_weaken_pre [OF threadSet_obj_at'_really_strongest])
 
-lemma threadSet_pred_tcb_no_state:
-  assumes "\<And>tcb. proj (tcb_to_itcb' (f tcb)) = proj (tcb_to_itcb' tcb)"
-  shows   "\<lbrace>\<lambda>s. P (pred_tcb_at' proj P' t' s)\<rbrace> threadSet f t \<lbrace>\<lambda>rv s. P (pred_tcb_at' proj P' t' s)\<rbrace>"
+lemma threadSet_obj_at'_no_state:
+  assumes "\<And>tcb. P' (f tcb) = P' tcb"
+  shows   "threadSet f t \<lbrace>\<lambda>s. P (obj_at' P' t' s)\<rbrace>"
 proof -
-  have pos: "\<And>P' t' t.
-            \<lbrace>pred_tcb_at' proj P' t'\<rbrace> threadSet f t \<lbrace>\<lambda>rv. pred_tcb_at' proj P' t'\<rbrace>"
-    apply (simp add: pred_tcb_at'_def)
+  have pos: "\<And>t' t.
+            \<lbrace>obj_at' P' t'\<rbrace> threadSet f t \<lbrace>\<lambda>rv. obj_at' P' t'\<rbrace>"
     apply (wp threadSet_obj_at'_strongish)
     apply clarsimp
     apply (erule obj_at'_weakenE)
@@ -1140,19 +1139,24 @@ proof -
   show ?thesis
     apply (rule_tac P=P in P_bool_lift)
      apply (rule pos)
-    apply (rule_tac Q'="\<lambda>_ s. \<not> tcb_at' t' s \<or> pred_tcb_at' proj (\<lambda>tcb. \<not> P' tcb) t' s"
+    apply (rule_tac Q'="\<lambda>_ s. \<not> tcb_at' t' s \<or> obj_at' (\<lambda>tcb. \<not> P' tcb) t' s"
              in hoare_post_imp)
      apply (erule disjE)
-      apply (clarsimp dest!: pred_tcb_at')
+      apply (clarsimp simp: obj_at'_def)
      apply (clarsimp)
-     apply (frule_tac P=P' and Q="\<lambda>tcb. \<not> P' tcb" in pred_tcb_at_conj')
-     apply (clarsimp)+
+     apply (frule_tac P=P' and Q="\<lambda>tcb. \<not> P' tcb" in obj_at_conj')
+      apply (clarsimp)+
     apply (wp hoare_convert_imp)
       apply (simp add: typ_at_tcb' [symmetric])
       apply (wp pos)+
-    apply (clarsimp simp: pred_tcb_at'_def not_obj_at' elim!: obj_at'_weakenE)
+    apply (clarsimp simp: not_obj_at' assms elim!: obj_at'_weakenE)
     done
 qed
+
+lemma threadSet_pred_tcb_no_state:
+  assumes "\<And>tcb. proj (tcb_to_itcb' (f tcb)) = proj (tcb_to_itcb' tcb)"
+  shows   "threadSet f t \<lbrace>\<lambda>s. P (pred_tcb_at' proj P' t' s)\<rbrace>"
+  by (wpsimp wp: threadSet_obj_at'_no_state simp: pred_tcb_at'_def assms)
 
 lemma threadSet_ct[wp]:
   "\<lbrace>\<lambda>s. P (ksCurThread s)\<rbrace> threadSet f t \<lbrace>\<lambda>rv s. P (ksCurThread s)\<rbrace>"
@@ -1698,6 +1702,12 @@ lemma asUser_tcbPriority_inv[wp]:
   apply (wp threadSet_obj_at'_strongish getObject_tcb_wp | wpc | simp | clarsimp simp: obj_at'_def)+
   done
 
+lemma asUser_tcbState_inv[wp]:
+  "\<lbrace>obj_at' (\<lambda>tcb. P (tcbState tcb)) t'\<rbrace> asUser t m \<lbrace>\<lambda>_. obj_at' (\<lambda>tcb. P (tcbState tcb)) t'\<rbrace>"
+  apply (simp add: asUser_def threadGet_def)
+  apply (wpsimp wp: getObject_tcb_wp simp: obj_at'_def)
+  done
+
 lemma asUser_sch_act_wf[wp]:
   "\<lbrace>\<lambda>s. sch_act_wf (ksSchedulerAction s) s\<rbrace>
     asUser t m \<lbrace>\<lambda>rv s. sch_act_wf (ksSchedulerAction s) s\<rbrace>"
@@ -1949,6 +1959,12 @@ lemma pspace_relation_update_concrete_tcb:
   "\<lbrakk>pspace_relation s s'; s ptr = Some (TCB tcb); s' ptr = Some (KOTCB otcb');
     tcb_relation tcb tcb'\<rbrakk>
    \<Longrightarrow> pspace_relation s (s'(ptr \<mapsto> KOTCB tcb'))"
+  by (fastforce dest: pspace_relation_update_tcbs simp: map_upd_triv)
+
+lemma pspace_relation_update_abstract_tcb:
+  "\<lbrakk>pspace_relation s s'; s ptr = Some (TCB tcb); s' ptr = Some (KOTCB otcb');
+    tcb_relation tcb' otcb'\<rbrakk>
+   \<Longrightarrow> pspace_relation (s(ptr \<mapsto> TCB tcb')) s'"
   by (fastforce dest: pspace_relation_update_tcbs simp: map_upd_triv)
 
 lemma threadSet_pspace_relation:

--- a/proof/refine/RISCV64/Tcb_R.thy
+++ b/proof/refine/RISCV64/Tcb_R.thy
@@ -1512,7 +1512,7 @@ proof -
                                    threadSet_valid_objs' thread_set_not_state_valid_sched
                                    thread_set_tcb_ipc_buffer_cap_cleared_invs thread_set_cte_wp_at_trivial
                                    thread_set_no_cap_to_trivial getThreadBufferSlot_dom_tcb_cte_cases
-                                   assertDerived_wp_weak threadSet_cap_to' out_pred_tcb_at_preserved
+                                   assertDerived_wp_weak threadSet_cap_to'
                                    checkCap_wp assertDerived_wp_weak cap_insert_objs'
                         | simp add: ran_tcb_cap_cases split_def U V
                                   emptyable_def
@@ -1547,7 +1547,7 @@ proof -
                                  threadSet_valid_objs' thread_set_not_state_valid_sched setP_invs'
                                  typ_at_lifts [OF setPriority_typ_at']
                                  typ_at_lifts [OF setMCPriority_typ_at']
-                                 threadSet_cap_to' out_pred_tcb_at_preserved assertDerived_wp
+                                 threadSet_cap_to' assertDerived_wp
                       del: cteInsert_invs
                    | simp add: ran_tcb_cap_cases split_def U V
                                emptyable_def
@@ -1652,6 +1652,49 @@ lemma setSchedulerAction_invs'[wp]:
 
 end
 
+lemma setFlags_corres[corres]:
+  "flags = word_to_tcb_flags flags' \<Longrightarrow>
+   corres dc (tcb_at t and pspace_aligned and pspace_distinct) \<top>
+         (set_flags t flags) (setFlags t flags')"
+  unfolding set_flags_def setFlags_def
+  apply (corres corres: threadset_corres)
+  by (clarsimp simp: tcb_relation_def inQ_def)+
+
+crunch set_flags
+  for pspace_aligned[wp]: pspace_aligned
+  and pspace_distinct[wp]: pspace_distinct
+
+context begin interpretation Arch . (*FIXME: arch-split*)
+
+lemma tcbFlagToWord_bit:
+  "(\<exists>n. tcbFlagToWord flag = bit n) \<or> tcbFlagToWord flag = 0"
+  by (auto simp: tcbFlagToWord_def archTcbFlagToWord_def split: tcb_flag.splits
+       simp del: bit_def)
+
+lemma word_to_tcb_flags_subtract:
+  "word_to_tcb_flags (flags && ~~ flags') = word_to_tcb_flags flags - word_to_tcb_flags flags'"
+  apply (clarsimp simp: word_to_tcb_flags_def intro!: set_eqI)
+  apply (cut_tac flag=x in tcbFlagToWord_bit)
+  apply (fastforce simp: word_eq_iff tcbFlagToWord_bit)
+  done
+
+lemma word_to_tcb_flags_union:
+  "word_to_tcb_flags (flags || flags') = word_to_tcb_flags flags \<union> word_to_tcb_flags flags'"
+  apply (clarsimp simp: word_to_tcb_flags_def intro!: set_eqI)
+  apply (cut_tac flag=x in tcbFlagToWord_bit)
+  apply (fastforce simp: word_eq_iff tcbFlagToWord_bit)
+  done
+
+lemmas word_to_tcb_flags_simps = word_to_tcb_flags_subtract word_to_tcb_flags_union
+
+lemma postSetFlags_corres[corres]:
+  "flags = word_to_tcb_flags flags' \<Longrightarrow>
+   corres dc (pspace_aligned and pspace_distinct) \<top>
+     (arch_post_set_flags  t flags) (postSetFlags t flags')"
+  by (clarsimp simp: arch_post_set_flags_def postSetFlags_def)
+
+end
+
 consts
   copyregsets_map :: "arch_copy_register_sets \<Rightarrow> Arch.copy_register_sets"
 
@@ -1683,6 +1726,10 @@ where
     = (x = tcbinvocation.NotificationControl t ntfnptr)"
 | "tcbinv_relation (tcb_invocation.SetTLSBase ref w) x
     = (x = tcbinvocation.SetTLSBase ref w)"
+| "tcbinv_relation (tcb_invocation.SetFlags ref clears sets) x
+    = (\<exists>clears' sets'.
+         clears = word_to_tcb_flags clears' \<and> sets = word_to_tcb_flags sets' \<and>
+         x = tcbinvocation.SetFlags ref clears' sets')"
 
 primrec
   tcb_inv_wf' :: "tcbinvocation \<Rightarrow> kernel_state \<Rightarrow> bool"
@@ -1722,6 +1769,8 @@ where
                                           and bound_tcb_at' ((=) None) t) )"
 | "tcb_inv_wf' (tcbinvocation.SetTLSBase ref w)
              = (tcb_at' ref and ex_nonz_cap_to' ref)"
+| "tcb_inv_wf' (tcbinvocation.SetFlags ref clears sets)
+             = (tcb_at' ref and ex_nonz_cap_to' ref)"
 
 lemma invokeTCB_corres:
  "tcbinv_relation ti ti' \<Longrightarrow>
@@ -1730,53 +1779,57 @@ lemma invokeTCB_corres:
          (invs' and sch_act_simple and tcb_inv_wf' ti')
          (invoke_tcb ti) (invokeTCB ti')"
   apply (case_tac ti, simp_all only: tcbinv_relation.simps valid_tcb_invocation_def)
-         apply (rule corres_guard_imp [OF invokeTCB_WriteRegisters_corres], simp+)[1]
-        apply (rule corres_guard_imp [OF invokeTCB_ReadRegisters_corres], simp+)[1]
-       apply (rule corres_guard_imp [OF invokeTCB_CopyRegisters_corres], simp+)[1]
-      apply (clarsimp simp del: invoke_tcb.simps)
-      apply (rename_tac word one t2 mcp t3 t4 t5 t6 t7 t8 t9 t10 t11)
-      apply (rule_tac F="is_aligned word 5" in corres_req)
-       apply (clarsimp simp add: is_aligned_weaken [OF tcb_aligned])
-      apply (rule corres_guard_imp [OF transferCaps_corres], clarsimp+)
-       apply (clarsimp simp: is_cnode_or_valid_arch_def
-                      split: option.split option.split_asm)
-      apply clarsimp
-      apply (auto split: option.split_asm simp: newroot_rel_def)[1]
+          apply (rule corres_guard_imp [OF invokeTCB_WriteRegisters_corres], simp+)[1]
+         apply (rule corres_guard_imp [OF invokeTCB_ReadRegisters_corres], simp+)[1]
+        apply (rule corres_guard_imp [OF invokeTCB_CopyRegisters_corres], simp+)[1]
+       apply (clarsimp simp del: invoke_tcb.simps)
+       apply (rename_tac word one t2 mcp t3 t4 t5 t6 t7 t8 t9 t10 t11)
+       apply (rule_tac F="is_aligned word 5" in corres_req)
+        apply (clarsimp simp add: is_aligned_weaken [OF tcb_aligned])
+       apply (rule corres_guard_imp [OF transferCaps_corres], clarsimp+)
+        apply (clarsimp simp: is_cnode_or_valid_arch_def
+                       split: option.split option.split_asm)
+       apply clarsimp
+       apply (auto split: option.split_asm simp: newroot_rel_def)[1]
+      apply (simp add: invokeTCB_def liftM_def[symmetric]
+                       o_def dc_def[symmetric])
+      apply (rule corres_guard_imp [OF suspend_corres], simp+)
      apply (simp add: invokeTCB_def liftM_def[symmetric]
                       o_def dc_def[symmetric])
-     apply (rule corres_guard_imp [OF suspend_corres], simp+)
-    apply (simp add: invokeTCB_def liftM_def[symmetric]
-                     o_def dc_def[symmetric])
-    apply (rule corres_guard_imp [OF restart_corres], simp+)
-   apply (simp add:invokeTCB_def)
-   apply (rename_tac option)
-   apply (case_tac option)
+     apply (rule corres_guard_imp [OF restart_corres], simp+)
+    apply (simp add:invokeTCB_def)
+    apply (rename_tac option)
+    apply (case_tac option)
+     apply simp
+     apply (rule corres_guard_imp)
+       apply (rule corres_split[OF unbindNotification_corres])
+         apply (rule corres_trivial, simp)
+        apply wp+
+      apply (clarsimp)
+     apply clarsimp
     apply simp
     apply (rule corres_guard_imp)
-      apply (rule corres_split[OF unbindNotification_corres])
+      apply (rule corres_split[OF bindNotification_corres])
         apply (rule corres_trivial, simp)
        apply wp+
-     apply (clarsimp)
-    apply clarsimp
-   apply simp
+     apply clarsimp
+     apply (clarsimp simp: obj_at_def is_ntfn)
+    apply (clarsimp simp: obj_at'_def)
+   apply (simp add: invokeTCB_def tlsBaseRegister_def)
    apply (rule corres_guard_imp)
-     apply (rule corres_split[OF bindNotification_corres])
-       apply (rule corres_trivial, simp)
-      apply wp+
-    apply clarsimp
-    apply (clarsimp simp: obj_at_def is_ntfn)
-   apply (clarsimp simp: obj_at'_def)
-  apply (simp add: invokeTCB_def tlsBaseRegister_def)
-  apply (rule corres_guard_imp)
-    apply (rule corres_split[OF TcbAcc_R.asUser_setRegister_corres])
-      apply (rule corres_split[OF Bits_R.getCurThread_corres])
-        apply (rule corres_split[OF Corres_UL.corres_when])
-            apply simp
-           apply (rule TcbAcc_R.rescheduleRequired_corres)
-          apply (rule corres_trivial, simp)
-         apply (wpsimp wp: hoare_drop_imp)+
-   apply (fastforce dest: valid_sched_valid_queues simp: valid_sched_weak_strg)
-  apply fastforce
+     apply (rule corres_split[OF TcbAcc_R.asUser_setRegister_corres])
+       apply (rule corres_split[OF Bits_R.getCurThread_corres])
+         apply (rule corres_split[OF Corres_UL.corres_when])
+             apply simp
+            apply (rule TcbAcc_R.rescheduleRequired_corres)
+           apply (rule corres_trivial, simp)
+          apply (wpsimp wp: hoare_drop_imp)+
+    apply (fastforce dest: valid_sched_valid_queues simp: valid_sched_weak_strg)
+   apply fastforce
+  apply (clarsimp simp: invokeTCB_def)
+  apply (corres corres: threadGet_corres[where r="\<lambda>flags flags'. flags = word_to_tcb_flags flags'"]
+             term_simp: tcb_relation_def word_to_tcb_flags_simps)
+   apply fastforce+
   done
 
 lemma tcbBoundNotification_caps_safe[simp]:
@@ -1847,23 +1900,37 @@ lemma setTLSBase_invs'[wp]:
    \<lbrace>\<lambda>rv. invs'\<rbrace>"
   by (wpsimp simp: invokeTCB_def)
 
+lemma threadSet_flags_invs[wp]:
+  "threadSet (tcbFlags_update f) t \<lbrace>invs'\<rbrace>"
+  by (wpsimp wp: threadSet_invs_trivial)
+
+crunch setFlags, postSetFlags
+  for invs'[wp]: invs'
+  (ignore: threadSet)
+
+lemma invokeSetFlags_invs'[wp]:
+  "\<lbrace>invs' and tcb_inv_wf' (tcbinvocation.SetFlags tcb clears' sets')\<rbrace>
+   invokeTCB (tcbinvocation.SetFlags tcb clears' sets')
+   \<lbrace>\<lambda>rv. invs'\<rbrace>"
+  by (wpsimp simp: invokeTCB_def)
+
 lemma tcbinv_invs':
   "\<lbrace>invs' and sch_act_simple and ct_in_state' runnable' and tcb_inv_wf' ti\<rbrace>
      invokeTCB ti
    \<lbrace>\<lambda>rv. invs'\<rbrace>"
   apply (case_tac ti, simp_all only:)
+          apply (simp add: invokeTCB_def)
+          apply wp
+          apply (clarsimp simp: invs'_def valid_state'_def
+                          dest!: global'_no_ex_cap)
          apply (simp add: invokeTCB_def)
-         apply wp
+         apply (wp restart_invs')
          apply (clarsimp simp: invs'_def valid_state'_def
                          dest!: global'_no_ex_cap)
-        apply (simp add: invokeTCB_def)
-        apply (wp restart_invs')
-        apply (clarsimp simp: invs'_def valid_state'_def
-                        dest!: global'_no_ex_cap)
-       apply (wp tc_invs')
-       apply (clarsimp split: option.split dest!: isCapDs)
-      apply (wp writereg_invs' readreg_invs' copyreg_invs' tcbntfn_invs'
-             | simp)+
+        apply (wp tc_invs')
+        apply (clarsimp split: option.split dest!: isCapDs)
+       apply (wp writereg_invs' readreg_invs' copyreg_invs' tcbntfn_invs'
+              | simp)+
   done
 
 declare assertDerived_wp [wp]
@@ -2568,6 +2635,13 @@ lemma decodeSetTLSBase_corres:
   by (clarsimp simp: decode_set_tls_base_def decodeSetTLSBase_def returnOk_def
                split: list.split)
 
+lemma decodeSetFlags_corres:
+  "corres (ser \<oplus> tcbinv_relation) (tcb_at t) (tcb_at' t)
+          (decode_set_flags w (cap.ThreadCap t))
+          (decodeSetFlags w (capability.ThreadCap t))"
+  by (clarsimp simp: decode_set_flags_def decodeSetFlags_def returnOk_def
+               split: list.split)
+
 lemma decodeTCBInvocation_corres:
  "\<lbrakk> c = Structures_A.ThreadCap t; cap_relation c c';
       list_all2 (\<lambda>(c, sl) (c', sl'). cap_relation c c' \<and> sl' = cte_map sl) extras extras';
@@ -2595,7 +2669,8 @@ lemma decodeTCBInvocation_corres:
              corres_guard_imp[OF decodeSetSpace_corres]
              corres_guard_imp[OF decodeBindNotification_corres]
              corres_guard_imp[OF decodeUnbindNotification_corres]
-             corres_guard_imp[OF decodeSetTLSBase_corres],
+             corres_guard_imp[OF decodeSetTLSBase_corres]
+             corres_guard_imp[OF decodeSetFlags_corres],
          simp_all add: valid_cap_simps valid_cap_simps' invs_def valid_state_def
                        valid_pspace_def valid_sched_def)
   apply (auto simp: list_all2_map1 list_all2_map2
@@ -2646,6 +2721,12 @@ lemma decodeSetTLSBase_wf:
   apply (simp add: decodeSetTLSBase_def
              cong: list.case_cong)
   by wpsimp
+
+lemma decodeSetFlags_wf[wp]:
+  "\<lbrace>invs' and tcb_at' t and ex_nonz_cap_to' t\<rbrace>
+   decodeSetFlags w (capability.ThreadCap t)
+   \<lbrace>tcb_inv_wf'\<rbrace>,-"
+  by (wpsimp simp: decodeSetFlags_def)
 
 lemma decodeTCBInv_wf:
   "\<lbrace>invs' and tcb_at' t and cte_at' slot and ex_nonz_cap_to' t

--- a/proof/refine/RISCV64/Untyped_R.thy
+++ b/proof/refine/RISCV64/Untyped_R.thy
@@ -4398,7 +4398,7 @@ crunch doMachineOp
   (simp: crunch_simps ct_in_state'_def)
 
 crunch doMachineOp
-  for st_tcb_at'[wp]: "st_tcb_at' P p"
+  for st_tcb_at'[wp]: "\<lambda>s. P (st_tcb_at' P' p s)"
   (simp: crunch_simps ct_in_state'_def)
 
 lemma ex_cte_cap_wp_to_irq_state_independent_H[simp]:

--- a/proof/refine/RISCV64/orphanage/Orphanage.thy
+++ b/proof/refine/RISCV64/orphanage/Orphanage.thy
@@ -734,25 +734,13 @@ lemma ThreadDecls_H_switchToThread_ct [wp]:
   apply (wp | clarsimp)+
   done
 
-crunch nextDomain
+crunch nextDomain, prepareNextDomain
   for no_orphans[wp]: no_orphans
-(wp: no_orphans_lift simp: Let_def)
-
-crunch nextDomain
-  for tcbQueued[wp]: "\<lambda>s. Q (obj_at' (\<lambda>tcb. P (tcbQueued tcb)) tcb_ptr s)"
-(simp: Let_def)
-
-crunch nextDomain
-  for st_tcb_at'[wp]: "\<lambda>s. P (st_tcb_at' P' p s)"
-(simp: Let_def)
-
-crunch nextDomain
-  for ct'[wp]: "\<lambda>s. P (ksCurThread s)"
-(simp: Let_def)
-
-crunch nextDomain
-  for sch_act_not[wp]: "sch_act_not t"
-(simp: Let_def)
+  and tcbQueued[wp]: "\<lambda>s. Q (obj_at' (\<lambda>tcb. P (tcbQueued tcb)) tcb_ptr s)"
+  and st_tcb_at'[wp]: "\<lambda>s. P (st_tcb_at' P' p s)"
+  and ct'[wp]: "\<lambda>s. P (ksCurThread s)"
+  and sch_act_not[wp]: "sch_act_not t"
+  (wp: no_orphans_lift simp: Let_def)
 
 lemma all_invs_but_ct_idle_or_in_cur_domain'_strg:
   "invs' s \<longrightarrow> all_invs_but_ct_idle_or_in_cur_domain' s"
@@ -818,16 +806,11 @@ lemma scheduleChooseNewThread_no_orphans:
    scheduleChooseNewThread
    \<lbrace>\<lambda>_. no_orphans\<rbrace>"
   unfolding scheduleChooseNewThread_def
-     apply (wp add: ssa_no_orphans hoare_vcg_all_lift)
-         apply (wp hoare_disjI1 chooseThread_nosch)+
-    apply (wp nextDomain_invs_no_cicd' hoare_vcg_imp_lift
-               hoare_lift_Pf2 [OF tcbQueued_all_queued_tcb_ptrs_lift[OF nextDomain_tcbQueued]
-                                  nextDomain_ct']
-               hoare_lift_Pf2 [OF st_tcb_at'_is_active_tcb_ptr_lift[OF nextDomain_st_tcb_at']
-                                  nextDomain_ct']
-               hoare_vcg_all_lift getDomainTime_wp)[2]
-   apply (wpsimp simp: if_apply_def2 invs'_invs_no_cicd all_queued_tcb_ptrs_def
-                       is_active_tcb_ptr_runnable')+
+  apply (wpsimp wp: ssa_no_orphans hoare_vcg_all_lift hoare_vcg_imp_lift' chooseThread_nosch
+                    hoare_disjI1 nextDomain_invs_no_cicd' tcbQueued_all_queued_tcb_ptrs_lift
+                    st_tcb_at'_is_active_tcb_ptr_lift
+         | wps)+
+  apply (clarsimp simp: invs'_invs_no_cicd is_active_tcb_ptr_runnable')
   done
 
 lemma setSchedulerAction_tcbQueued[wp]:
@@ -904,20 +887,15 @@ proof -
     unfolding schedule_def
     apply (wp, wpc)
          \<comment> \<open>action = ResumeCurrentThread\<close>
-         apply (wp)[1]
+         apply wp
         \<comment> \<open>action = ChooseNewThread\<close>
         apply (clarsimp simp: when_def scheduleChooseNewThread_def)
         apply (wp ssa_no_orphans hoare_vcg_all_lift)
             apply (wp hoare_disjI1 chooseThread_nosch)
-           apply (wp nextDomain_invs_no_cicd' hoare_vcg_imp_lift
-                     hoare_lift_Pf2 [OF tcbQueued_all_queued_tcb_ptrs_lift
-                                      [OF nextDomain_tcbQueued]
-                                      nextDomain_ct']
-                     hoare_lift_Pf2 [OF st_tcb_at'_is_active_tcb_ptr_lift
-                                      [OF nextDomain_st_tcb_at']
-                                      nextDomain_ct']
-                     hoare_vcg_all_lift getDomainTime_wp)[2]
-          apply wpsimp
+           apply ((wpsimp wp: nextDomain_invs_no_cicd' hoare_vcg_imp_lift'
+                              st_tcb_at'_is_active_tcb_ptr_lift
+                              tcbQueued_all_queued_tcb_ptrs_lift hoare_vcg_all_lift getDomainTime_wp
+                   | wps)+)[2]
          apply ((wp tcbSchedEnqueue_no_orphans tcbSchedEnqueue_all_queued_tcb_ptrs'
                     hoare_drop_imp
                  | clarsimp simp: all_queued_tcb_ptrs_def
@@ -934,7 +912,7 @@ proof -
         apply (clarsimp simp: conj_comms cong: conj_cong imp_cong split del: if_split)
         apply (wp hoare_vcg_imp_lift'
                | strengthen not_pred_tcb_at'_strengthen)+
-        apply (wps | wpsimp wp: tcbSchedEnqueue_all_queued_tcb_ptrs')+
+         apply (wps | wpsimp wp: tcbSchedEnqueue_all_queued_tcb_ptrs')+
     apply (fastforce simp: is_active_tcb_ptr_runnable' all_invs_but_ct_idle_or_in_cur_domain'_strg
                            invs_switchToThread_runnable')
     done
@@ -1584,7 +1562,7 @@ lemma restart_no_orphans [wp]:
   apply auto
   done
 
-lemma readreg_no_orphans:
+lemma readreg_no_orphans[wp]:
   "\<lbrace> \<lambda>s. no_orphans s \<and> invs' s \<and> sch_act_simple s \<and> tcb_at' src s \<rbrace>
      invokeTCB (tcbinvocation.ReadRegisters src susp n arch)
    \<lbrace> \<lambda>rv s. no_orphans s \<rbrace>"
@@ -1592,7 +1570,7 @@ lemma readreg_no_orphans:
   apply (wp | clarsimp)+
   done
 
-lemma writereg_no_orphans:
+lemma writereg_no_orphans[wp]:
   "\<lbrace>\<lambda>s. no_orphans s \<and> invs' s \<and> sch_act_simple s \<and> tcb_at' dest s \<and> ex_nonz_cap_to' dest s\<rbrace>
    invokeTCB (tcbinvocation.WriteRegisters dest resume values arch)
    \<lbrace>\<lambda>_. no_orphans\<rbrace>"
@@ -1600,7 +1578,7 @@ lemma writereg_no_orphans:
   by (wpsimp wp: hoare_vcg_if_lift hoare_vcg_conj_lift restart_invs' hoare_weak_lift_imp
       | clarsimp simp: invs'_def valid_state'_def dest!: global'_no_ex_cap )+
 
-lemma copyreg_no_orphans:
+lemma copyreg_no_orphans[wp]:
   "\<lbrace> \<lambda>s. no_orphans s \<and> invs' s \<and> sch_act_simple s \<and> tcb_at' src s
          \<and> tcb_at' dest s \<and> ex_nonz_cap_to' src s \<and> ex_nonz_cap_to' dest s \<rbrace>
      invokeTCB (tcbinvocation.CopyRegisters dest src susp resume frames ints arch)
@@ -1614,7 +1592,7 @@ lemma copyreg_no_orphans:
   apply (fastforce simp: invs'_def valid_state'_def dest!: global'_no_ex_cap)
   done
 
-lemma settlsbase_no_orphans:
+lemma settlsbase_no_orphans[wp]:
   "\<lbrace> \<lambda>s. no_orphans s \<and> invs' s \<rbrace>
      invokeTCB (tcbinvocation.SetTLSBase src dest)
    \<lbrace> \<lambda>rv s. no_orphans s \<rbrace>"
@@ -1709,21 +1687,20 @@ lemma bindNotification_no_orphans[wp]:
   unfolding bindNotification_def
   by wp
 
+crunch setFlags, postSetFlags
+  for no_orphans[wp]: no_orphans
+
 lemma invokeTCB_no_orphans [wp]:
   "\<lbrace> \<lambda>s. no_orphans s \<and> invs' s \<and> sch_act_simple s \<and> tcb_inv_wf' tinv s \<rbrace>
    invokeTCB tinv
    \<lbrace> \<lambda>rv s. no_orphans s \<rbrace>"
-  apply (case_tac tinv, simp_all)
-       apply (clarsimp simp: invokeTCB_def)
-       apply (wp, clarsimp)
-      apply (clarsimp simp: invokeTCB_def)
-      apply (wp, clarsimp)
-     apply (wp tc_no_orphans)
-     apply (clarsimp split: option.splits simp: msg_align_bits elim!:is_aligned_weaken)
-     apply (rename_tac option)
-     apply (case_tac option)
-      apply ((wp | simp add: invokeTCB_def)+)[2]
-    apply (wp writereg_no_orphans readreg_no_orphans copyreg_no_orphans settlsbase_no_orphans | clarsimp)+
+  apply (case_tac tinv; simp; (solves wpsimp)?)
+      apply (wpsimp simp: invokeTCB_def)
+     apply (wpsimp simp: invokeTCB_def)
+    apply (wp tc_no_orphans)
+    apply (clarsimp split: option.splits simp: msg_align_bits elim!:is_aligned_weaken)
+   apply (wpsimp simp: invokeTCB_def)
+  apply (wpsimp simp: invokeTCB_def)
   done
 
 lemma invokeCNode_no_orphans [wp]:
@@ -1875,6 +1852,10 @@ lemma setDomain_no_orphans [wp]:
          | clarsimp simp: st_tcb_at_neg2 not_obj_at')+
   apply (fastforce simp: tcb_at_typ_at'  is_active_tcb_ptr_runnable')
   done
+
+crunch prepareSetDomain
+  for no_orphans[wp]: no_orphans
+  and cur_tcb'[wp]: cur_tcb'
 
 lemma performInvocation_no_orphans [wp]:
   "\<lbrace> \<lambda>s. no_orphans s \<and> invs' s \<and> valid_invocation' i s \<and> ct_active' s \<and> sch_act_simple s \<rbrace>

--- a/proof/refine/X64/ADT_H.thy
+++ b/proof/refine/X64/ADT_H.thy
@@ -510,15 +510,16 @@ lemma FaultMap_fault_map[simp]:
   done
 
 definition
-  "ArchTcbMap atcb \<equiv>
-    \<lparr> tcb_context =  atcbContext atcb \<rparr>"
+  "ArchTcbMap atcb is_cur_fpu_owner \<equiv>
+    \<lparr> tcb_context = atcbContext atcb, tcb_cur_fpu = is_cur_fpu_owner \<rparr>"
 
 lemma arch_tcb_relation_imp_ArchTcnMap:
-  "\<lbrakk> arch_tcb_relation atcb atcb'\<rbrakk> \<Longrightarrow> ArchTcbMap atcb' = atcb"
+  "\<lbrakk> arch_tcb_relation atcb atcb'; tcb_cur_fpu atcb = is_cur_fpu_owner\<rbrakk>
+   \<Longrightarrow> ArchTcbMap atcb' is_cur_fpu_owner = atcb"
   by (clarsimp simp: arch_tcb_relation_def ArchTcbMap_def)
 
 definition
-  "TcbMap tcb \<equiv>
+  "TcbMap tcb is_cur_fpu_owner \<equiv>
      \<lparr>tcb_ctable = CapabilityMap (cteCap (tcbCTable tcb)),
       tcb_vtable = CapabilityMap (cteCap (tcbVTable tcb)),
       tcb_reply = CapabilityMap (cteCap (tcbReply tcb)),
@@ -533,27 +534,27 @@ definition
       tcb_priority = tcbPriority tcb,
       tcb_time_slice = tcbTimeSlice tcb,
       tcb_domain = tcbDomain tcb,
-      tcb_arch = ArchTcbMap (tcbArch tcb)\<rparr>"
+      tcb_flags = word_to_tcb_flags (tcbFlags tcb),
+      tcb_arch = ArchTcbMap (tcbArch tcb) is_cur_fpu_owner\<rparr>"
 
 definition
- "absCNode sz h a \<equiv> CNode sz (%bl.
-  if length bl = sz
+ "absCNode sz h a \<equiv> CNode sz (\<lambda>bl.
+    if length bl = sz
     then Some (CapabilityMap (case (h (a + of_bl bl * 2^cteSizeBits)) of
                                 Some (KOCTE cte) \<Rightarrow> cteCap cte))
-  else None)"
+    else None)"
 
-definition
-  absHeap :: "(machine_word \<rightharpoonup> vmpage_size) \<Rightarrow> (machine_word \<rightharpoonup> nat) \<Rightarrow>
-              (machine_word \<rightharpoonup> Structures_H.kernel_object) \<Rightarrow> Structures_A.kheap"
-  where
-  "absHeap ups cns h \<equiv> \<lambda>x.
+definition absHeap ::
+  "(machine_word \<rightharpoonup> vmpage_size) \<Rightarrow> (machine_word \<rightharpoonup> nat) \<Rightarrow>
+     (machine_word \<rightharpoonup> Structures_H.kernel_object) \<Rightarrow> machine_word option \<Rightarrow> Structures_A.kheap" where
+  "absHeap ups cns h cur_fpu_owner \<equiv> \<lambda>x.
      case h x of
        Some (KOEndpoint ep) \<Rightarrow> Some (Endpoint (EndpointMap ep))
      | Some (KONotification ntfn) \<Rightarrow> Some (Notification (AEndpointMap ntfn))
      | Some KOKernelData \<Rightarrow> undefined \<comment> \<open>forbidden by pspace_relation\<close>
      | Some KOUserData \<Rightarrow> map_option (ArchObj \<circ> DataPage False) (ups x)
      | Some KOUserDataDevice \<Rightarrow> map_option (ArchObj \<circ> DataPage True) (ups x)
-     | Some (KOTCB tcb) \<Rightarrow> Some (TCB (TcbMap tcb))
+     | Some (KOTCB tcb) \<Rightarrow> Some (TCB (TcbMap tcb (cur_fpu_owner = Some x)))
      | Some (KOCTE cte) \<Rightarrow> map_option (%sz. absCNode sz h x) (cns x)
      | Some (KOArch ako) \<Rightarrow> map_option ArchObj (absHeapArch h x ako)
      | None \<Rightarrow> None"
@@ -661,10 +662,12 @@ lemma absHeap_correct:
   assumes pspace_aligned:  "pspace_aligned s"
   assumes pspace_distinct: "pspace_distinct s"
   assumes valid_objs:      "valid_objs s"
+  assumes valid_cur_fpu:   "valid_cur_fpu s"
   assumes pspace_relation: "pspace_relation (kheap s) (ksPSpace s')"
   assumes ghost_relation:  "ghost_relation (kheap s) (gsUserPages s') (gsCNodes s')"
+  assumes arch_state_relation: "(arch_state s, ksArchState s') \<in> arch_state_relation"
 shows
-  "absHeap (gsUserPages s') (gsCNodes s') (ksPSpace s') = kheap s"
+  "absHeap (gsUserPages s') (gsCNodes s') (ksPSpace s') (x64KSCurFPUOwner (ksArchState s')) = kheap s"
 proof -
   from ghost_relation
   have gsUserPages:
@@ -839,9 +842,12 @@ proof -
                        split: option.splits)
       using valid_objs[simplified valid_objs_def Ball_def dom_def fun_app_def]
       apply (erule_tac x=y in allE)
+      using arch_state_relation valid_cur_fpu[simplified valid_cur_fpu_def]
+      apply (erule_tac x=y in allE)
       apply (clarsimp simp add: cap_relation_imp_CapabilityMap valid_obj_def
                                 valid_tcb_def ran_tcb_cap_cases valid_cap_def2
-                                arch_tcb_relation_imp_ArchTcnMap)
+                                arch_tcb_relation_imp_ArchTcnMap arch_state_relation_def
+                                is_tcb_cur_fpu_def obj_at_def)
      apply (simp add: absCNode_def cte_map_def)
      apply (erule pspace_dom_relatedE[OF _ pspace_relation])
      apply (case_tac ko, simp_all add: other_obj_relation_def
@@ -1903,7 +1909,9 @@ where
 
 definition
   "absArchState s' \<equiv>
-   case s' of X64KernelState asid_tbl gpm gpdpts gpds gpts ccr3 kvspace kports num_ioapics ioapics_nirqs irq_states \<Rightarrow>
+   case s' of
+     X64KernelState asid_tbl gpm gpdpts gpds gpts ccr3 kvspace kports num_ioapics ioapics_nirqs
+                    irq_states current_fpu_owner \<Rightarrow>
      \<lparr>x64_asid_table = asid_tbl \<circ> ucast, x64_global_pml4 = gpm,
       x64_kernel_vspace = kvspace, x64_global_pts = gpts,
       x64_global_pdpts = gpdpts, x64_global_pds = gpds,
@@ -1911,7 +1919,8 @@ definition
       x64_allocated_io_ports = kports,
       x64_num_ioapics = num_ioapics,
       x64_ioapic_nirqs = ioapics_nirqs,
-      x64_irq_state = x64irqstate_to_abstract \<circ> irq_states\<rparr>"
+      x64_irq_state = x64irqstate_to_abstract \<circ> irq_states,
+      x64_current_fpu_owner = current_fpu_owner\<rparr>"
 
 lemma cr3_expand_unexpand[simp]: "cr3 (cr3_base_address a) (cr3_pcid a) = a"
   by (cases a, simp)
@@ -1961,7 +1970,7 @@ lemma absExst_correct:
 
 definition
   "absKState s \<equiv>
-   \<lparr>kheap = absHeap (gsUserPages s) (gsCNodes s) (ksPSpace s),
+   \<lparr>kheap = absHeap (gsUserPages s) (gsCNodes s) (ksPSpace s) (x64KSCurFPUOwner (ksArchState s)),
     cdt = absCDT (cteMap (gsCNodes s)) (ctes_of s),
     is_original_cap = absIsOriginalCap (cteMap (gsCNodes s)) (ksPSpace s),
     cur_thread = ksCurThread s, idle_thread = ksIdleThread s,
@@ -1976,11 +1985,6 @@ definition
     interrupt_states = absInterruptStates (ksInterruptState s),
     arch_state = absArchState (ksArchState s),
     exst = absExst s\<rparr>"
-
-(* TODO: move *)
-lemma invs_valid_ioc[elim!]: "invs s \<Longrightarrow> valid_ioc s"
-  by (clarsimp simp add: invs_def valid_state_def)
-
 
 
 definition

--- a/proof/refine/X64/CNodeInv_R.thy
+++ b/proof/refine/X64/CNodeInv_R.thy
@@ -622,11 +622,14 @@ lemma unbindNotification_ctes_of_thread:
    \<lbrace>\<lambda>rv s. \<exists>node. ctes_of s x = Some (CTE (ThreadCap t) node)\<rbrace>"
   by wp
 
+crunch fpuRelease
+  for ctes_of[wp]: "\<lambda>s. P (ctes_of s)"
+
 lemma prepareThreadDelete_ctes_of_thread:
   "\<lbrace>\<lambda>s. \<exists>node. ctes_of s x = Some (CTE (ThreadCap t) node)\<rbrace>
      prepareThreadDelete t
    \<lbrace>\<lambda>rv s. \<exists>node. ctes_of s x = Some (CTE (ThreadCap t) node)\<rbrace>"
-  by (wpsimp simp: prepareThreadDelete_def fpuThreadDelete_def)
+  by (wpsimp simp: prepareThreadDelete_def)
 
 lemma suspend_not_recursive_ctes:
   "\<lbrace>\<lambda>s. P (not_recursive_ctes s)\<rbrace>
@@ -653,7 +656,7 @@ lemma prepareThreadDelete_not_recursive_ctes:
   "\<lbrace>\<lambda>s. P (not_recursive_ctes s)\<rbrace>
      prepareThreadDelete t
    \<lbrace>\<lambda>rv s. P (not_recursive_ctes s)\<rbrace>"
-  by (wpsimp simp: prepareThreadDelete_def fpuThreadDelete_def not_recursive_ctes_def cteCaps_of_def)
+  by (wpsimp simp: prepareThreadDelete_def not_recursive_ctes_def cteCaps_of_def)
 
 definition
   finaliseSlot_recset :: "((machine_word \<times> bool \<times> kernel_state) \<times> (machine_word \<times> bool \<times> kernel_state)) set"
@@ -9011,7 +9014,6 @@ crunch finaliseCap
   (wp: crunch_wps unless_wp getASID_wp no_irq
        no_irq_writeCR3 no_irq_invalidateASID
        no_irq_invalidateLocalPageStructureCacheASID
-       no_irq_switchFpuOwner no_irq_nativeThreadUsingFPU
    simp: crunch_simps o_def)
 
 lemma finaliseSlot_IRQInactive':

--- a/proof/refine/X64/Detype_R.thy
+++ b/proof/refine/X64/Detype_R.thy
@@ -1788,7 +1788,7 @@ proof -
   apply (rule hoare_pre)
    apply (rule_tac P'="is_aligned ptr bits \<and> 3 \<le> bits \<and> bits \<le> word_bits" in hoare_grab_asm)
    apply (clarsimp simp add: deleteObjects_def2)
-   apply (simp add: freeMemory_def bind_assoc doMachineOp_bind ef_storeWord)
+   apply (simp add: freeMemory_def bind_assoc doMachineOp_bind)
    apply (simp add: bind_assoc[where f="\<lambda>_. modify f" for f, symmetric])
    apply (simp add: mapM_x_storeWord_step[simplified word_size_bits_def]
                     doMachineOp_modify modify_modify)

--- a/proof/refine/X64/EmptyFail_H.thy
+++ b/proof/refine/X64/EmptyFail_H.thy
@@ -264,7 +264,7 @@ lemma catchError_empty_fail[intro!, wp, simp]:
   by fastforce
 
 crunch
-  chooseThread, getDomainTime, nextDomain, isHighestPrio
+  chooseThread, getDomainTime, nextDomain, isHighestPrio, prepareNextDomain
   for (empty_fail) empty_fail[intro!, wp, simp]
   (wp: empty_fail_catch)
 

--- a/proof/refine/X64/Init_R.thy
+++ b/proof/refine/X64/Init_R.thy
@@ -28,9 +28,7 @@ context begin interpretation Arch . (*FIXME: arch-split*)
   system.
 *)
 
-definition zeroed_arch_abstract_state ::
-  arch_state
-  where
+definition zeroed_arch_abstract_state :: arch_state where
   "zeroed_arch_abstract_state \<equiv> \<lparr>
     x64_asid_table         = Map.empty,
     x64_global_pml4        = 0,
@@ -42,11 +40,10 @@ definition zeroed_arch_abstract_state ::
     x64_allocated_io_ports = \<bottom>,
     x64_num_ioapics        = 0,
     x64_ioapic_nirqs       = K 0,
-    x64_irq_state          = K IRQFree\<rparr>"
+    x64_irq_state          = K IRQFree,
+    x64_current_fpu_owner = None\<rparr>"
 
-definition zeroed_main_abstract_state ::
-  abstract_state
-  where
+definition zeroed_main_abstract_state :: abstract_state where
   "zeroed_main_abstract_state \<equiv> \<lparr>
     kheap = Map.empty,
     cdt = Map.empty,
@@ -65,29 +62,21 @@ definition zeroed_main_abstract_state ::
     arch_state = zeroed_arch_abstract_state
   \<rparr>"
 
-definition zeroed_extended_state ::
-  det_ext
-  where
+definition zeroed_extended_state :: det_ext where
   "zeroed_extended_state \<equiv> \<lparr>
     work_units_completed_internal = 0,
     cdt_list_internal = K []
   \<rparr>"
 
-definition zeroed_abstract_state ::
-  det_state
-  where
+definition zeroed_abstract_state :: det_state where
   "zeroed_abstract_state \<equiv> abstract_state.extend zeroed_main_abstract_state
                            (state.fields zeroed_extended_state)"
 
-definition zeroed_arch_intermediate_state ::
-  Arch.kernel_state
-  where
+definition zeroed_arch_intermediate_state :: Arch.kernel_state where
   "zeroed_arch_intermediate_state \<equiv> X64KernelState Map.empty 0 [] [] [] (CR3 0 0)
-     (K X64VSpaceUserRegion) \<bottom> 0 (K 0) (K X64IRQFree)"
+     (K X64VSpaceUserRegion) \<bottom> 0 (K 0) (K X64IRQFree) None"
 
-definition zeroed_intermediate_state ::
-  global.kernel_state
-  where
+definition zeroed_intermediate_state :: global.kernel_state where
   "zeroed_intermediate_state \<equiv> \<lparr>
     ksPSpace = Map.empty,
     gsUserPages = Map.empty,

--- a/proof/refine/X64/InterruptAcc_R.thy
+++ b/proof/refine/X64/InterruptAcc_R.thy
@@ -36,7 +36,6 @@ lemma setIRQState_corres:
         apply (clarsimp simp: interrupt_state_relation_def)
        apply (rule corres_machine_op)
        apply (rule corres_Id | simp)+
-       apply (rule no_fail_maskInterrupt)
       apply (wp | simp)+
   apply (clarsimp simp: irq_state_relation_def
                  split: irq_state.split_asm irqstate.split_asm)

--- a/proof/refine/X64/Interrupt_R.thy
+++ b/proof/refine/X64/Interrupt_R.thy
@@ -380,7 +380,6 @@ lemma invokeIRQHandler_corres:
   apply (cases i, simp_all add: Interrupt_H.invokeIRQHandler_def invokeIRQHandler_def)
     apply (rule corres_guard_imp, rule corres_machine_op)
       apply (rule corres_Id, simp_all)
-    apply (rule no_fail_maskInterrupt)
    apply (rename_tac word cap prod)
    apply clarsimp
    apply (rule corres_guard_imp)
@@ -477,16 +476,16 @@ method do_machine_op_corres
 lemma updateIRQState_corres[wp]:
   "state = x64irqstate_to_abstract state' \<Longrightarrow>
      corres dc \<top> \<top>
-       (X64_A.updateIRQState irq state)
-       (X64_H.updateIRQState irq state')"
-  apply (clarsimp simp: X64_A.updateIRQState_def X64_H.updateIRQState_def)
+       (update_irq_state irq state)
+       (updateIRQState irq state')"
+  apply (clarsimp simp: update_irq_state_def updateIRQState_def)
   apply (rule corres_guard_imp)
     apply (rule corres_split[OF corres_gets_x64_irq_state])
       apply (rule corres_modify[where P=\<top> and P'=\<top>])
       apply (auto simp: state_relation_def arch_state_relation_def x64_irq_relation_def)
   done
 
-crunch X64_H.updateIRQState
+crunch updateIRQState
   for pspace_distinct'[wp]: "pspace_distinct'"
   and pspace_aligned'[wp]: "pspace_aligned'"
   and cte_wp_at'[wp]: "cte_wp_at' a b"
@@ -601,9 +600,9 @@ lemma setIRQState_issued[wp]:
 
 lemma updateIRQState_invs'[wp]:
   "\<lbrace>invs' and K (irq \<le> maxIRQ)\<rbrace>
-   X64_H.updateIRQState irq state
+   updateIRQState irq state
    \<lbrace>\<lambda>_. invs'\<rbrace>"
-  apply (clarsimp simp: X64_H.updateIRQState_def)
+  apply (clarsimp simp: updateIRQState_def)
   apply wp
   apply (fastforce simp: invs'_def valid_state'_def cur_tcb'_def
                          valid_idle'_def valid_irq_node'_def

--- a/proof/refine/X64/IpcCancel_R.thy
+++ b/proof/refine/X64/IpcCancel_R.thy
@@ -1185,9 +1185,9 @@ lemma updateObject_ep_inv:
   by simp (rule updateObject_default_inv)
 
 lemma asUser_tcbQueued_inv[wp]:
-  "\<lbrace>obj_at' (\<lambda>tcb. P (tcbQueued tcb)) t'\<rbrace> asUser t m \<lbrace>\<lambda>_. obj_at' (\<lambda>tcb. P (tcbQueued tcb)) t'\<rbrace>"
+  "asUser t m \<lbrace>\<lambda>s. Q (obj_at' (\<lambda>tcb. P (tcbQueued tcb)) tcb_ptr s)\<rbrace>"
   apply (simp add: asUser_def tcb_in_cur_domain'_def threadGet_def)
-  apply (wp threadSet_obj_at'_strongish getObject_tcb_wp | wpc | simp | clarsimp simp: obj_at'_def)+
+  apply (wp threadSet_obj_at'_no_state getObject_tcb_wp | wpc | simp | clarsimp simp: obj_at'_def)+
   done
 
 crunch asUser
@@ -1276,39 +1276,28 @@ lemma (in delete_one) suspend_corres:
   apply simp
   done
 
-lemma no_fail_switchFpuOwner[wp]:
-  "no_fail \<top> (X64.switchFpuOwner thread cpu)"
-  by (simp add: X64.switchFpuOwner_def X64.no_fail_machine_op_lift)
+context begin interpretation Arch .
 
-lemma no_fail_nativeThreadUsingFPU[wp]:
-  "no_fail (\<top> and \<top>) (X64.nativeThreadUsingFPU thread)"
-  supply Collect_const[simp del]
-  apply (simp only: X64.nativeThreadUsingFPU_def)
-  apply (wpsimp wp: X64.no_fail_machine_op_lift)
+lemma tcb_ko_at':
+  "tcb_at' t s \<Longrightarrow> \<exists>t'::tcb. ko_at' t' t s"
+  by (clarsimp simp: obj_at'_def)
+
+lemma fpuRelease_corres[corres]:
+  "t' = t \<Longrightarrow>
+   corres dc (pspace_aligned and pspace_distinct and valid_cur_fpu) \<top> (fpu_release t) (fpuRelease t')"
+  by (corres simp: fpu_release_def fpuRelease_def)
+
+lemma prepareThreadDelete_corres[corres]:
+  "t' = t \<Longrightarrow>
+   corres dc (invs and tcb_at t) no_0_obj'
+          (prepare_thread_delete t) (prepareThreadDelete t')"
+  apply (simp add: prepare_thread_delete_def prepareThreadDelete_def)
+  apply corres
+   apply fastforce
+  apply (clarsimp simp: tcb_ko_at')
   done
 
-lemma (in delete_one) prepareThreadDelete_corres:
-  "corres dc (tcb_at t) (tcb_at' t)
-        (prepare_thread_delete t) (ArchRetypeDecls_H.X64_H.prepareThreadDelete t)"
-  apply (simp add: ArchVSpace_A.X64_A.prepare_thread_delete_def ArchRetype_H.X64_H.prepareThreadDelete_def
-                   ArchVSpace_A.X64_A.fpu_thread_delete_def ArchRetype_H.X64_H.fpuThreadDelete_def
-                   X64_H.fromPPtr_def)
-  apply (rule corres_guard_imp)
-    apply (rule corres_split[where r'="(=)"])
-       apply (rule corres_machine_op)
-       apply (rule corres_Id, rule refl, simp)
-       apply wpsimp
-      apply clarsimp
-      apply (rule corres_when)
-       apply clarsimp
-      apply (rule corres_machine_op)
-      apply (rule corres_Id, rule refl, simp)
-      apply wpsimp
-     apply clarsimp
-     apply wpsimp
-    apply wpsimp
-   apply auto
-  done
+end
 
 lemma no_refs_simple_strg':
   "st_tcb_at' simple' t s' \<and> P {} \<longrightarrow> st_tcb_at' (\<lambda>st. P (tcb_st_refs_of' st)) t s'"
@@ -2303,9 +2292,15 @@ lemma suspend_unqueued:
   unfolding suspend_def
   by (wpsimp simp: comp_def wp: tcbSchedDequeue_not_tcbQueued)
 
+lemma asUser_tcbQueued[wp]:
+  "asUser t' f \<lbrace>\<lambda>s. Q (obj_at' (P \<circ> tcbQueued) t s)\<rbrace>"
+  unfolding asUser_def threadGet_stateAssert_gets_asUser
+  by (wpsimp wp: threadSet_obj_at'_no_state simp: asUser_fetch_def obj_at'_def)
+
 crunch prepareThreadDelete
-  for unqueued: "obj_at' (\<lambda>a. \<not> tcbQueued a) t"
+  for unqueued: "obj_at' (Not \<circ> tcbQueued) t"
   and inactive: "st_tcb_at' ((=) Inactive) t'"
+  (simp: obj_at'_not_comp_fold)
 
 end
 end

--- a/proof/refine/X64/Machine_R.thy
+++ b/proof/refine/X64/Machine_R.thy
@@ -79,15 +79,5 @@ lemma getActiveIRQ_le_maxIRQ:
   apply (simp add: irqs_masked'_def valid_irq_states'_def)
   done
 
-(* FIXME: follows already from getActiveIRQ_le_maxIRQ *)
-lemma getActiveIRQ_neq_Some0xFF:
-  "\<lbrace>\<top>\<rbrace> doMachineOp (getActiveIRQ in_kernel) \<lbrace>\<lambda>rv s. rv \<noteq> Some 0x3FF\<rbrace>"
-  apply (simp add: doMachineOp_def split_def)
-  apply wp
-  apply clarsimp
-  apply (drule use_valid, rule getActiveIRQ_neq_Some0xFF')
-   apply auto
-  done
-
 end
 end

--- a/proof/refine/X64/Refine.thy
+++ b/proof/refine/X64/Refine.thy
@@ -201,8 +201,7 @@ assumes rel: "(s,s') \<in> state_relation"
 shows "absKState s' = abs_state s"
   using assms
   apply (intro state.equality, simp_all add: absKState_def abs_state_def)
-                 apply (rule absHeap_correct; clarsimp)
-                 apply (clarsimp elim!: state_relationE)
+                 apply (rule absHeap_correct; clarsimp elim!: state_relationE)
                 apply (rule absCDT_correct; clarsimp)
                apply (rule absIsOriginalCap_correct; clarsimp)
               apply (simp add: state_relation_def)
@@ -448,7 +447,6 @@ lemma kernelEntry_invs':
   apply (wp ckernel_invs callKernel_domain_time_left
             threadSet_invs_trivial threadSet_ct_running'
             TcbAcc_R.dmo_invs' hoare_weak_lift_imp
-            doMachineOp_sch_act_simple
             callKernel_domain_time_left
          | clarsimp simp: user_memory_update_def no_irq_def tcb_at_invs'
                           valid_domain_list'_def)+
@@ -635,16 +633,17 @@ lemma entry_corres:
             apply (simp add: tcb_relation_def arch_tcb_relation_def
                              arch_tcb_context_get_def atcbContextGet_def)
            apply wp+
-         apply (rule hoare_strengthen_post, rule akernel_invs_det_ext, fastforce simp: invs_def cur_tcb_def)
+         apply (rule hoare_strengthen_post, rule akernel_invs_det_ext,
+                simp add: invs_def valid_state_def valid_pspace_def cur_tcb_def)
         apply (rule hoare_strengthen_post, rule ckernel_invs, simp add: invs'_def cur_tcb'_def)
        apply (wp thread_set_invs_trivial
                  threadSet_invs_trivial threadSet_ct_running'
                  thread_set_not_state_valid_sched hoare_weak_lift_imp
                  hoare_vcg_disj_lift ct_in_state_thread_state_lift
-              | simp add: tcb_cap_cases_def ct_in_state'_def thread_set_no_change_tcb_state
-                          schact_is_rct_def
-              | (wps, wp threadSet_st_tcb_at2))+
-   apply (fastforce simp: invs_def cur_tcb_def)
+                 thread_set_no_change_tcb_state
+              | simp add: tcb_cap_cases_def ct_in_state'_def schact_is_rct_def
+              | (wps, wp threadSet_st_tcb_at2) )+
+   apply (clarsimp simp: invs_def cur_tcb_def valid_state_def valid_pspace_def)
   apply (clarsimp simp: ct_in_state'_def)
   done
 

--- a/proof/refine/X64/Retype_R.thy
+++ b/proof/refine/X64/Retype_R.thy
@@ -2330,6 +2330,10 @@ lemma other_objs_default_relation:
                  split: Structures_A.apiobject_type.split_asm)
   done
 
+lemma word_to_tcb_flags_0[simp]:
+  "word_to_tcb_flags 0 = {}"
+  by (clarsimp simp: word_to_tcb_flags_def)
+
 lemma tcb_relation_retype:
   "obj_relation_retype (default_object Structures_A.TCBObject dev n d)
                        (KOTCB (tcbDomain_update (\<lambda>_. d) makeObject))"
@@ -3118,7 +3122,7 @@ proof (intro conjI impI)
        apply (rule_tac ptr="x + xa" in cte_wp_at_tcbI', assumption+)
         apply fastforce
        apply simp
-      apply (rename_tac thread_state mcp priority bool option nat cptr vptr bound tcbprev tcbnext user_context)
+      apply (rename_tac thread_state mcp priority bool option nat cptr vptr bound tcbprev tcbnext tcbflags tcbarch)
       apply (case_tac thread_state, simp_all add: valid_tcb_state'_def valid_bound_tcb'_def
                                                   valid_bound_ntfn'_def obj_at_disj' none_top_def
                                                   valid_arch_tcb'_def

--- a/proof/refine/X64/Schedule_R.thy
+++ b/proof/refine/X64/Schedule_R.thy
@@ -61,18 +61,125 @@ lemmas findM_awesome = findM_awesome' [OF _ _ _ suffix_order.refl]
 (* Levity: added (20090721 10:56:29) *)
 declare objBitsT_koTypeOf [simp]
 
+lemma gets_x64KSCurFPUOwner_corres[corres]:
+  "corres (=) \<top> \<top>
+          (gets (x64_current_fpu_owner \<circ> arch_state)) (gets (x64KSCurFPUOwner \<circ> ksArchState))"
+  by (simp add: state_relation_def arch_state_relation_def)
+
+crunch setFPUState
+  for (no_fail) no_fail[wp]
+
+lemma saveFpuState_corres[corres]:
+  "corres dc (tcb_at t and pspace_aligned and pspace_distinct and (fpu_enabled \<circ> machine_state)) \<top>
+             (save_fpu_state t) (saveFpuState t)"
+  unfolding save_fpu_state_def saveFpuState_def
+  apply (corres corres: corres_machine_op' asUser_corres')
+  by (simp add: state_relation_def)
+
+crunch asUser
+  for ksMachineState[wp]: "\<lambda>s. P (ksMachineState s)"
+  (wp: crunch_wps)
+
+lemma loadFpuState_corres[corres]:
+  "corres dc (tcb_at t and pspace_aligned and pspace_distinct and (fpu_enabled \<circ> machine_state)) \<top>
+             (load_fpu_state t) (loadFpuState t)"
+  unfolding load_fpu_state_def loadFpuState_def
+  apply (corres corres: corres_machine_op' asUser_corres' simp: o_def)
+  by (simp add: state_relation_def)
+
+lemma set_tcb_cur_fpu_noop:
+  "corres dc (pspace_aligned and pspace_distinct and tcb_at t) \<top>
+             (arch_thread_set (tcb_cur_fpu_update f) t) (return ())"
+  unfolding arch_thread_set_def thread_set_def
+  apply (rule corres_cross_over_guard[OF tcb_at_cross]; fastforce?)
+  apply (clarsimp simp: corres_underlying_def return_def set_object_def get_object_def in_monad Bex_def
+                        obj_at_def obj_at'_def is_tcb get_tcb_rev)
+  apply (clarsimp simp: state_relation_def projectKOs)
+  apply safe
+     apply (frule (2) pspace_relation_tcb_relation)
+     apply (clarsimp simp: pspace_relation_update_abstract_tcb tcb_relation_def arch_tcb_relation_def)
+    apply (clarsimp simp: ghost_relation_of_heap)
+   apply (clarsimp simp: swp_def cte_wp_at_after_update' obj_at_def simp del: same_caps_simps)
+  apply (clarsimp simp: caps_of_state_fun_upd obj_at_def simp del: same_caps_simps)
+  done
+
+lemma set_x64_current_fpu_owner_corres[corres]:
+  "corres dc (pspace_aligned and pspace_distinct and valid_cur_fpu and none_top tcb_at new_owner) \<top>
+             (set_x64_current_fpu_owner new_owner) (modifyArchState (x64KSCurFPUOwner_update (\<lambda>_. new_owner)))"
+  unfolding set_x64_current_fpu_owner_def modifyArchState_def maybeM_def
+  apply corres_pre
+  apply (rule corres_underlying_gets_pre_lhs)
+  apply (rule corres_add_noop_rhs)
+  apply (corres_split; clarsimp?)
+       apply (corres_cases; corres corres: set_tcb_cur_fpu_noop)
+      apply (rule corres_add_noop_rhs2)
+      apply (rule corres_split)
+         apply (corres corres: corres_modify_tivial) \<comment> \<open>FIXME: typo in rule name\<close>
+         apply (clarsimp simp: state_relation_def arch_state_relation_def)
+        apply (corres_cases; corres corres: set_tcb_cur_fpu_noop)
+       apply (wpsimp wp: hoare_vcg_all_lift hoare_vcg_imp_lift)+
+   apply (auto simp: current_fpu_owner_Some_tcb_at)
+  done
+
+lemma enableFpu_fpu_enabled[wp]:
+  "\<lbrace>\<top>\<rbrace> enableFpu \<lbrace>\<lambda>_. fpu_enabled\<rbrace>"
+  by (wpsimp simp: enableFpu_def)
+
+crunch writeFpuState, readFpuState
+  for fpu_enabled[wp]: fpu_enabled
+
+crunch load_fpu_state, save_fpu_state
+  for valid_cur_fpu[wp]: valid_cur_fpu
+  and fpu_enabled[wp]: "\<lambda>s. fpu_enabled (machine_state s)"
+  (wp: dmo_machine_state_lift)
+
+defs fpuOwner_asrt_def:
+  "fpuOwner_asrt \<equiv> \<lambda>s'. opt_tcb_at' (x64KSCurFPUOwner (ksArchState s')) s'"
+
+lemma fpuOwner_asrt_cross:
+  "\<lbrakk>(s, s') \<in> state_relation; valid_cur_fpu s; pspace_aligned s; pspace_distinct s\<rbrakk> \<Longrightarrow> fpuOwner_asrt s'"
+  by (fastforce simp: state_relation_def arch_state_relation_def fpuOwner_asrt_def
+              intro!: tcb_at_cross current_fpu_owner_Some_tcb_at)
+
+lemma switchLocalFpuOwner_corres[corres]:
+  "corres dc (pspace_aligned and pspace_distinct and valid_cur_fpu and none_top tcb_at new_owner) \<top>
+             (switch_local_fpu_owner new_owner) (switchLocalFpuOwner new_owner)"
+  unfolding switch_local_fpu_owner_def switchLocalFpuOwner_def maybeM_def
+  apply (corres corres: corres_stateAssert_r | corres_cases | clarsimp)+
+         apply (wpsimp wp: hoare_vcg_all_lift hoare_vcg_imp_lift' dmo_machine_state_lift)+
+   apply (auto simp: current_fpu_owner_Some_tcb_at fpuOwner_asrt_cross)
+  done
+
+lemma isFlagSet_set:
+  "isFlagSet flag flags = (flag \<in> word_to_tcb_flags flags)"
+  by (clarsimp simp: isFlagSet_def word_to_tcb_flags_def)
+
+lemma lazyFpuRestore_corres[corres]:
+  "corres dc (pspace_aligned and pspace_distinct and valid_cur_fpu and tcb_at t) \<top>
+             (lazy_fpu_restore t) (lazyFpuRestore t)"
+  unfolding lazy_fpu_restore_def lazyFpuRestore_def
+  by (corres corres: threadGet_corres[where r="\<lambda>flags flags'. flags = word_to_tcb_flags flags'"]
+          term_simp: tcb_relation_def isFlagSet_set
+                 wp: hoare_drop_imps)
+
+crunch set_vm_root
+  for x64_current_fpu_owner[wp]: "\<lambda>s. P (x64_current_fpu_owner (arch_state s))"
+  and valid_cur_fpu[wp]: valid_cur_fpu
+  and aligned[wp]: pspace_aligned
+  and distinct[wp]: pspace_distinct
+  (simp: crunch_simps wp: crunch_wps valid_cur_fpu_lift_arch)
+
 lemma arch_switchToThread_corres:
   "corres dc (valid_arch_state and valid_objs and valid_asid_map
               and valid_vspace_objs and pspace_aligned and pspace_distinct
               and valid_vs_lookup and valid_global_objs
               and unique_table_refs o caps_of_state
-              and st_tcb_at runnable t)
+              and valid_cur_fpu and tcb_at t)
              (valid_arch_state' and valid_pspace' and st_tcb_at' runnable' t)
              (arch_switch_to_thread t) (Arch.switchToThread t)"
   apply (simp add: arch_switch_to_thread_def X64_H.switchToThread_def)
-  apply (rule corres_guard_imp)
-    apply (rule setVMRoot_corres[OF refl])
-   apply (clarsimp simp: st_tcb_at_tcb_at)
+  apply (corres corres: getObject_TCB_corres
+                term_simp: tcb_relation_def arch_tcb_relation_def)
   apply (clarsimp simp: valid_pspace'_def)
   done
 
@@ -672,61 +779,38 @@ lemma setCurThread_corres:
   apply (simp add: state_relation_def swp_def)
   done
 
-lemma arch_switch_thread_tcb_at' [wp]: "\<lbrace>tcb_at' t\<rbrace> Arch.switchToThread t \<lbrace>\<lambda>_. tcb_at' t\<rbrace>"
-  by (unfold X64_H.switchToThread_def, wp typ_at_lift_tcb')
+crunch setVMRoot, lazyFpuRestore
+  for pred_tcb_at'[wp]: "pred_tcb_at' proj P t'"
+  (simp: crunch_simps wp: crunch_wps)
 
-crunch "switchToThread"
+crunch switchToThread
   for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
 
 lemma Arch_switchToThread_pred_tcb'[wp]:
-  "\<lbrace>\<lambda>s. P (pred_tcb_at' proj P' t' s)\<rbrace>
-   Arch.switchToThread t \<lbrace>\<lambda>rv s. P (pred_tcb_at' proj P' t' s)\<rbrace>"
+  "Arch.switchToThread t \<lbrace>\<lambda>s. P (pred_tcb_at' proj P' t' s)\<rbrace>"
 proof -
-  have pos: "\<And>P t t'. \<lbrace>pred_tcb_at' proj P t'\<rbrace> Arch.switchToThread t \<lbrace>\<lambda>rv. pred_tcb_at' proj P t'\<rbrace>"
-    apply (simp add:  pred_tcb_at'_def X64_H.switchToThread_def)
-     apply (rule setVMRoot_obj_at)
-    done
+  have pos: "\<And>P t t'. Arch.switchToThread t \<lbrace>pred_tcb_at' proj P t'\<rbrace>"
+    by (wpsimp simp: X64_H.switchToThread_def)
   show ?thesis
     apply (rule P_bool_lift [OF pos])
     by (rule lift_neg_pred_tcb_at' [OF ArchThreadDecls_H_X64_H_switchToThread_typ_at' pos])
 qed
 
-
-crunch storeWordUser
-  for ksQ[wp]: "\<lambda>s. P (ksReadyQueues s p)"
-crunch setVMRoot
-  for ksQ[wp]: "\<lambda>s. P (ksReadyQueues s)"
-(wp: crunch_wps simp: crunch_simps)
-crunch storeWordUser
-  for ksIdleThread[wp]: "\<lambda>s. P (ksIdleThread s)"
-crunch asUser
-  for ksIdleThread[wp]: "\<lambda>s. P (ksIdleThread s)"
-(wp: crunch_wps simp: crunch_simps)
-crunch asUser
-  for ksQ[wp]: "\<lambda>s. P (ksReadyQueues s p)"
-(wp: crunch_wps simp: crunch_simps)
-
-lemma arch_switch_thread_ksQ[wp]:
-  "\<lbrace>\<lambda>s. P (ksReadyQueues s p)\<rbrace> Arch.switchToThread t \<lbrace>\<lambda>_ s. P (ksReadyQueues s p)\<rbrace>"
-  apply (simp add: X64_H.switchToThread_def)
-  apply (wp)
-  done
-
 crunch storeWordUser, setVMRoot, asUser, storeWordUser, Arch.switchToThread
-  for ksIdleThread[wp]: "\<lambda>s. P (ksIdleThread s)"
+  for ksQ[wp]: "\<lambda>s. P (ksReadyQueues s)"
+  and ksIdleThread[wp]: "\<lambda>s. P (ksIdleThread s)"
   and sym_heap_sched_pointers[wp]: sym_heap_sched_pointers
   and valid_objs'[wp]: valid_objs'
-  (wp: crunch_wps threadSet_sched_pointers simp: crunch_simps)
+  (wp: crunch_wps threadSet_sched_pointers getObject_tcb_wp getASID_wp
+   simp: crunch_simps obj_at'_def)
 
 crunch arch_switch_to_thread, arch_switch_to_idle_thread
   for pspace_aligned[wp]: pspace_aligned
   and pspace_distinct[wp]: pspace_distinct
-  and ready_qs_distinct[wp]: ready_qs_distinct
   and ready_queues[wp]: "\<lambda>s. P (ready_queues s)"
-  (wp: ready_qs_distinct_lift simp: crunch_simps)
-
-crunch arch_switch_to_thread, arch_switch_to_idle_thread
-  for valid_idle[wp]: "\<lambda>s::det_ext state. valid_idle s"
+  and ready_qs_distinct[wp]: ready_qs_distinct
+  and valid_idle[wp]: valid_idle
+  (wp: ready_qs_distinct_lift crunch_wps simp: crunch_simps)
 
 lemma valid_queues_in_correct_ready_q[elim!]:
   "valid_queues s \<Longrightarrow> in_correct_ready_q s"
@@ -741,7 +825,7 @@ lemma switchToThread_corres:
                 and valid_vspace_objs and pspace_aligned and pspace_distinct
                 and valid_vs_lookup and valid_global_objs
                 and unique_table_refs o caps_of_state
-                and st_tcb_at runnable t and valid_queues and valid_idle)
+                and st_tcb_at runnable t and valid_queues and valid_idle and valid_cur_fpu)
              (no_0_obj' and sym_heap_sched_pointers and valid_pspace' and valid_arch_state')
              (switch_to_thread t) (switchToThread t)"
   apply (rule_tac Q'="st_tcb_at' runnable' t" in corres_cross_add_guard)
@@ -869,6 +953,28 @@ lemma setCurThread_invs_idle_thread:
   by (rule hoare_pre, rule setCurThread_invs_no_cicd'_idle_thread)
      (clarsimp simp: invs'_to_invs_no_cicd'_def all_invs_but_ct_idle_or_in_cur_domain'_def)
 
+lemma x64KSCurFPUOwner_invs'[wp]:
+  "modifyArchState (x64KSCurFPUOwner_update f) \<lbrace>invs'\<rbrace>"
+  apply (wpsimp simp: modifyArchState_def)
+  by (clarsimp simp: invs'_def valid_state'_def valid_machine_state'_def
+                     ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def
+                     valid_arch_state'_def valid_global_refs'_def global_refs'_def
+              split: option.split)
+
+crunch loadFpuState, saveFpuState
+  for invs'[wp]: invs'
+  (ignore: doMachineOp)
+
+lemma switchLocalFpuOwner_invs[wp]:
+  "\<lbrace>invs' and opt_tcb_at' newOwner\<rbrace> switchLocalFpuOwner newOwner \<lbrace>\<lambda>_. invs'\<rbrace>"
+  unfolding switchLocalFpuOwner_def
+  by (wpsimp wp: hoare_vcg_all_lift hoare_vcg_imp_lift' typ_at_lifts simp: fpuOwner_asrt_def)
+
+lemma lazyFpuRestore_invs[wp]:
+  "\<lbrace>invs' and tcb_at' t\<rbrace> lazyFpuRestore t \<lbrace>\<lambda>_. invs'\<rbrace>"
+  unfolding lazyFpuRestore_def
+  by (wpsimp wp: threadGet_wp)
+
 lemma Arch_switchToThread_invs[wp]:
   "\<lbrace>invs' and tcb_at' t\<rbrace> Arch.switchToThread t \<lbrace>\<lambda>rv. invs'\<rbrace>"
   apply (simp add: X64_H.switchToThread_def)
@@ -877,19 +983,12 @@ lemma Arch_switchToThread_invs[wp]:
 
 crunch "Arch.switchToThread"
   for ksCurDomain[wp]: "\<lambda>s. P (ksCurDomain s)"
-(simp: crunch_simps)
+  (simp: crunch_simps)
 
-lemma Arch_swichToThread_tcbDomain_triv[wp]:
-  "\<lbrace> obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t' \<rbrace> Arch.switchToThread t \<lbrace> \<lambda>_. obj_at'  (\<lambda>tcb. P (tcbDomain tcb)) t' \<rbrace>"
-  apply (clarsimp simp: X64_H.switchToThread_def storeWordUser_def)
-  apply (wp hoare_drop_imp | simp)+
-  done
-
-lemma Arch_swichToThread_tcbPriority_triv[wp]:
-  "\<lbrace> obj_at' (\<lambda>tcb. P (tcbPriority tcb)) t' \<rbrace> Arch.switchToThread t \<lbrace> \<lambda>_. obj_at'  (\<lambda>tcb. P (tcbPriority tcb)) t' \<rbrace>"
-  apply (clarsimp simp: X64_H.switchToThread_def storeWordUser_def)
-  apply (wp hoare_drop_imp | simp)+
-  done
+crunch Arch.switchToThread
+  for tcbDomain[wp]: "obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'"
+  and tcbState[wp]: "obj_at' (\<lambda>tcb. P (tcbState tcb)) t'"
+  and tcbPriority[wp]: "obj_at' (\<lambda>tcb. P (tcbPriority tcb)) t'"
 
 lemma Arch_switchToThread_tcb_in_cur_domain'[wp]:
   "\<lbrace>tcb_in_cur_domain' t'\<rbrace> Arch.switchToThread t \<lbrace>\<lambda>_. tcb_in_cur_domain' t' \<rbrace>"
@@ -907,12 +1006,10 @@ lemma tcbSchedDequeue_not_tcbQueued:
   apply (clarsimp simp: obj_at'_def)
   done
 
-lemma Arch_switchToThread_obj_at[wp]:
-  "\<lbrace>obj_at' (P \<circ> tcbState) t\<rbrace>
-   Arch.switchToThread t
-   \<lbrace>\<lambda>rv. obj_at' (P \<circ> tcbState) t\<rbrace>"
-  apply (simp add: X64_H.switchToThread_def )
-  apply (rule setVMRoot_obj_at)
+lemma asUser_obj_at[wp]:
+  "asUser t' f \<lbrace>\<lambda>s. P' (obj_at' (P \<circ> tcbState) t s)\<rbrace>"
+  apply (wpsimp simp: asUser_def threadGet_stateAssert_gets_asUser wp: threadSet_obj_at'_no_state)
+  apply (simp add: obj_at'_def)
   done
 
 declare doMachineOp_obj_at[wp]
@@ -992,6 +1089,60 @@ lemma asUser_utr[wp]:
   apply (simp add: o_def)
   done
 
+lemma threadSet_invs_no_cicd'_trivialT:
+  assumes
+    "\<forall>tcb. \<forall>(getF,setF) \<in> ran tcb_cte_cases. getF (F tcb) = getF tcb"
+    "\<forall>tcb. tcbState (F tcb) = tcbState tcb \<and> tcbDomain (F tcb) = tcbDomain tcb"
+    "\<forall>tcb. is_aligned (tcbIPCBuffer tcb) msg_align_bits \<longrightarrow> is_aligned (tcbIPCBuffer (F tcb)) msg_align_bits"
+    "\<forall>tcb. tcbBoundNotification (F tcb) = tcbBoundNotification tcb"
+    "\<forall>tcb. tcbSchedPrev (F tcb) = tcbSchedPrev tcb"
+    "\<forall>tcb. tcbSchedNext (F tcb) = tcbSchedNext tcb"
+    "\<forall>tcb. tcbQueued (F tcb) = tcbQueued tcb"
+    "\<forall>tcb. tcbDomain tcb \<le> maxDomain \<longrightarrow> tcbDomain (F tcb) \<le> maxDomain"
+    "\<forall>tcb. tcbPriority tcb \<le> maxPriority \<longrightarrow> tcbPriority (F tcb) \<le> maxPriority"
+    "\<forall>tcb. tcbMCP tcb \<le> maxPriority \<longrightarrow> tcbMCP (F tcb) \<le> maxPriority"
+  shows "threadSet F t \<lbrace>invs_no_cicd'\<rbrace>"
+  apply (simp add: invs_no_cicd'_def valid_state'_def)
+  apply (wp threadSet_valid_pspace'T
+            threadSet_sch_actT_P[where P=False, simplified]
+            threadSet_state_refs_of'T[where f'=id]
+            threadSet_iflive'T
+            threadSet_ifunsafe'T
+            threadSet_idle'T
+            threadSet_global_refsT
+            irqs_masked_lift
+            valid_irq_node_lift
+            valid_irq_handlers_lift''
+            threadSet_ctes_ofT
+            threadSet_not_inQ
+            threadSet_ct_idle_or_in_cur_domain'
+            threadSet_valid_dom_schedule' threadSet_sched_pointers threadSet_valid_sched_pointers
+            threadSet_cur
+            untyped_ranges_zero_lift
+         | clarsimp simp: assms cteCaps_of_def valid_arch_tcb'_def | rule refl)+
+  by (auto simp: o_def)
+
+lemmas threadSet_invs_no_cicd'_trivial =
+    threadSet_invs_no_cicd'_trivialT [OF all_tcbI all_tcbI all_tcbI all_tcbI, OF ball_tcb_cte_casesI]
+
+lemma asUser_invs_no_cicd'[wp]:
+  "\<lbrace>invs_no_cicd'\<rbrace> asUser t m \<lbrace>\<lambda>rv. invs_no_cicd'\<rbrace>"
+  apply (simp add: asUser_def split_def)
+  apply (wp hoare_drop_imps | simp)+
+  apply (wp threadSet_invs_no_cicd'_trivial hoare_drop_imps | simp)+
+  done
+
+lemma x64KSCurFPUOwner_invs_no_cicd'[wp]:
+  "modifyArchState (x64KSCurFPUOwner_update f) \<lbrace>invs_no_cicd'\<rbrace>"
+  apply (wpsimp simp: modifyArchState_def)
+  by (clarsimp simp: all_invs_but_ct_idle_or_in_cur_domain'_def valid_machine_state'_def
+                     valid_arch_state'_def valid_global_refs'_def global_refs'_def
+              split: option.split)
+
+crunch lazyFpuRestore
+  for invs_no_cicd'[wp]: invs_no_cicd'
+  (ignore: doMachineOp modifyArchState)
+
 lemma Arch_switchToThread_invs_no_cicd':
   "\<lbrace>invs_no_cicd'\<rbrace> Arch.switchToThread t \<lbrace>\<lambda>rv. invs_no_cicd'\<rbrace>"
   apply (simp add: X64_H.switchToThread_def)
@@ -1038,7 +1189,7 @@ lemma switchToThread_ct_in_state[wp]:
 proof -
   show ?thesis
     apply (simp add: Thread_H.switchToThread_def tcbSchedEnqueue_def unless_def)
-    apply (wp setCurThread_ct_in_state Arch_switchToThread_obj_at
+    apply (wp setCurThread_ct_in_state
          | simp add: o_def cong: if_cong)+
     done
 qed
@@ -1381,7 +1532,7 @@ lemma guarded_switch_to_corres:
                 and valid_vs_lookup and valid_global_objs
                 and unique_table_refs o caps_of_state
                 and st_tcb_at runnable t
-                and valid_queues and valid_idle)
+                and valid_queues and valid_idle and valid_cur_fpu)
              (valid_arch_state' and valid_pspace' and sym_heap_sched_pointers
                 and st_tcb_at' runnable' t and cur_tcb')
              (guarded_switch_to t) (switchToThread t)"
@@ -1651,24 +1802,34 @@ lemma nextDomain_invs_no_cicd':
                         all_invs_but_ct_idle_or_in_cur_domain'_def)
   done
 
+lemma prepareNextDomain_corres[corres]:
+  "corres dc (pspace_aligned and pspace_distinct and valid_cur_fpu) \<top>
+             arch_prepare_next_domain prepareNextDomain"
+  apply (clarsimp simp: arch_prepare_next_domain_def prepareNextDomain_def)
+  by (corres corres: switchLocalFpuOwner_corres)
+
+crunch prepareNextDomain
+  for invs'[wp]: invs'
+  and nosch[wp]: "\<lambda>s. P (ksSchedulerAction s)"
+
 lemma scheduleChooseNewThread_fragment_corres:
   "corres dc (invs and valid_sched and (\<lambda>s. scheduler_action s = choose_new_thread)) (invs' and (\<lambda>s. ksSchedulerAction s = ChooseNewThread))
-     (do _ \<leftarrow> when (domainTime = 0) next_domain;
+     (do _ \<leftarrow> when (domainTime = 0) (do
+           _ \<leftarrow> arch_prepare_next_domain;
+           next_domain
+         od);
          choose_thread
       od)
-     (do _ \<leftarrow> when (domainTime = 0) nextDomain;
-          chooseThread
+     (do _ \<leftarrow> when (domainTime = 0) (do
+           _ \<leftarrow> prepareNextDomain;
+           nextDomain
+         od);
+         chooseThread
       od)"
-  apply (subst bind_dummy_ret_val)
-  apply (subst bind_dummy_ret_val)
-  apply (rule corres_guard_imp)
-    apply (rule corres_split)
-       apply (rule corres_when, simp)
-       apply (rule nextDomain_corres)
-      apply simp
-      apply (rule chooseThread_corres)
-     apply (wp nextDomain_invs_no_cicd')+
-   apply (clarsimp simp: valid_sched_def invs'_def valid_state'_def all_invs_but_ct_idle_or_in_cur_domain'_def)+
+  apply (subst bind_dummy_ret_val)+
+  apply (corres corres: nextDomain_corres chooseThread_corres
+                    wp: nextDomain_invs_no_cicd')
+   apply (auto simp: valid_sched_def invs'_def valid_state'_def all_invs_but_ct_idle_or_in_cur_domain'_def)
   done
 
 lemma scheduleSwitchThreadFastfail_corres:
@@ -2181,6 +2342,9 @@ lemma setCurThread_nosch:
   apply wp
   apply simp
   done
+
+crunch lazyFpuRestore
+  for nosch[wp]: "\<lambda>s. P (ksSchedulerAction s)"
 
 lemma stt_nosch:
   "\<lbrace>\<lambda>s. P (ksSchedulerAction s)\<rbrace>

--- a/proof/refine/X64/StateRelation.thy
+++ b/proof/refine/X64/StateRelation.thy
@@ -197,7 +197,8 @@ definition tcb_relation :: "Structures_A.tcb \<Rightarrow> Structures_H.tcb \<Ri
    \<and> tcb_mcpriority tcb = tcbMCP tcb'
    \<and> tcb_priority tcb = tcbPriority tcb'
    \<and> tcb_time_slice tcb = tcbTimeSlice tcb'
-   \<and> tcb_domain tcb = tcbDomain tcb'"
+   \<and> tcb_domain tcb = tcbDomain tcb'
+   \<and> tcb_flags tcb = word_to_tcb_flags (tcbFlags tcb')"
 
 
 \<comment> \<open>
@@ -543,7 +544,8 @@ where
        \<and> x64_allocated_io_ports s = x64KSAllocatedIOPorts s'
        \<and> x64_num_ioapics s = x64KSNumIOAPICs s'
        \<and> x64_ioapic_nirqs s = x64KSIOAPICnIRQs s'
-       \<and> x64_irq_relation (x64_irq_state s) (x64KSIRQState s')}"
+       \<and> x64_irq_relation (x64_irq_state s) (x64KSIRQState s')
+       \<and> x64_current_fpu_owner s = x64KSCurFPUOwner s'}"
 
 definition
   rights_mask_map :: "rights set \<Rightarrow> Types_H.cap_rights"

--- a/proof/refine/X64/SubMonad_R.thy
+++ b/proof/refine/X64/SubMonad_R.thy
@@ -20,12 +20,21 @@ interpretation submonad_doMachineOp:
   submonad ksMachineState "(ksMachineState_update \<circ> K)" \<top> doMachineOp
   by (rule submonad_doMachineOp)
 
+lemma corres_machine_op':
+  assumes P: "corres_underlying Id False True r P P' x x'"
+  shows      "corres r (P \<circ> machine_state) (P' \<circ> ksMachineState) (do_machine_op x) (doMachineOp x')"
+  apply (rule corres_submonad3 [OF submonad_do_machine_op submonad_doMachineOp _ _ _ _ P])
+   apply (simp_all add: state_relation_def swp_def)
+  done
+
 lemma corres_machine_op:
   assumes P: "corres_underlying Id False True r \<top> \<top> x x'"
   shows      "corres r \<top> \<top> (do_machine_op x) (doMachineOp x')"
-  apply (rule corres_submonad [OF submonad_do_machine_op submonad_doMachineOp _ _ P])
-   apply (simp_all add: state_relation_def swp_def)
-  done
+  by (rule corres_machine_op'[OF P, simplified])
+
+lemmas corres_machine_op_Id = corres_machine_op[OF corres_Id]
+lemmas corres_machine_op_Id_dc[corres_term] = corres_machine_op_Id[where r="dc::unit \<Rightarrow> unit \<Rightarrow> bool"]
+lemmas corres_machine_op_Id_eq[corres_term] = corres_machine_op_Id[where r="(=)"]
 
 lemma doMachineOp_mapM:
   assumes "\<And>x. empty_fail (m x)"

--- a/proof/refine/X64/Syscall_R.thy
+++ b/proof/refine/X64/Syscall_R.thy
@@ -348,6 +348,12 @@ lemma threadSet_tcbDomain_update_sch_act_wf[wp]:
    apply (auto simp: obj_at'_def)
   done
 
+lemma prepareSetDomain_corres[corres]:
+  "corres dc (pspace_aligned and pspace_distinct and valid_cur_fpu) \<top>
+     (arch_prepare_set_domain tptr new_dom) (prepareSetDomain tptr new_dom)"
+  unfolding prepareSetDomain_def arch_prepare_set_domain_def
+  by (corres corres: gcd_corres)
+
 lemma setDomain_corres:
   "corres dc
      (valid_sched and pspace_aligned and pspace_distinct and tcb_at tptr)
@@ -401,6 +407,11 @@ lemma setDomain_corres:
    apply (auto elim: valid_objs'_maxDomain valid_objs'_maxPriority pred_tcb'_weakenE
                simp: valid_sched_def valid_sched_action_def)
   done
+
+crunch prepareSetDomain
+  for invs'[wp]: invs'
+  and sch_act_simple[wp]: sch_act_simple
+  and tcb_at'[wp]: "tcb_at' p"
 
 lemma performInvocation_corres:
   "\<lbrakk> inv_relation i i'; call \<longrightarrow> block \<rbrakk> \<Longrightarrow>
@@ -457,12 +468,13 @@ lemma performInvocation_corres:
        apply (rule corres_guard_imp)
          apply (erule invokeTCB_corres)
         apply ((clarsimp dest!: schact_is_rct_simple)+)[2]
-       \<comment> \<open>domain cap\<close>
+      \<comment> \<open>domain cap\<close>
       apply (clarsimp simp: invoke_domain_def)
       apply (rule corres_guard_imp)
-        apply (rule corres_split[OF setDomain_corres])
-          apply (rule corres_trivial, simp)
-         apply (wp)+
+        apply (rule corres_split[OF prepareSetDomain_corres])
+          apply (rule corres_split[OF setDomain_corres])
+            apply (rule corres_trivial, simp)
+           apply wpsimp+
        apply (fastforce+)[2]
      \<comment> \<open>CNodes\<close>
      apply clarsimp
@@ -494,7 +506,7 @@ lemma sendSignal_tcb_at'[wp]:
 lemmas checkCap_inv_typ_at'
   = checkCap_inv[where P="\<lambda>s. P (typ_at' T p s)" for P T p]
 
-crunch restart, bindNotification, performTransfer
+crunch restart, bindNotification, performTransfer, setFlags, postSetFlags
   for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
 
 lemma invokeTCB_typ_at'[wp]:
@@ -961,6 +973,12 @@ lemma setDomain_invs':
     apply (wp hoare_vcg_imp_lift)+
   apply (clarsimp simp:invs'_def valid_pspace'_def valid_state'_def)+
   done
+
+crunch prepareSetDomain
+  for ksCurThread[wp]: "\<lambda>s. P (ksCurThread s)"
+  and ct_in_state'[wp]: "ct_in_state' P"
+  and ksSchedulerAction[wp]: "\<lambda>s. P (ksSchedulerAction s)"
+  (wp: ct_in_state_thread_state_lift')
 
 lemma performInv_invs'[wp]:
   "\<lbrace>invs' and sch_act_simple and ct_active' and valid_invocation' i\<rbrace>

--- a/proof/refine/X64/TcbAcc_R.thy
+++ b/proof/refine/X64/TcbAcc_R.thy
@@ -429,7 +429,7 @@ lemma ball_tcb_cte_casesI:
   by (simp add: tcb_cte_cases_def cteSizeBits_def)
 
 lemma all_tcbI:
-  "\<lbrakk> \<And>a b c d e f g h i j k l m n p q r s. P (Thread a b c d e f g h i j k l m n p q r s) \<rbrakk>
+  "\<lbrakk> \<And>a b c d e f g h i j k l m n p q r s t. P (Thread a b c d e f g h i j k l m n p q r s t) \<rbrakk>
    \<Longrightarrow> \<forall>tcb. P tcb"
   by (rule allI, case_tac tcb, simp)
 
@@ -1090,13 +1090,12 @@ lemma threadSet_obj_at'_strongish[wp]:
      threadSet f t \<lbrace>\<lambda>rv. obj_at' P t'\<rbrace>"
   by (simp add: hoare_weaken_pre [OF threadSet_obj_at'_really_strongest])
 
-lemma threadSet_pred_tcb_no_state:
-  assumes "\<And>tcb. proj (tcb_to_itcb' (f tcb)) = proj (tcb_to_itcb' tcb)"
-  shows   "\<lbrace>\<lambda>s. P (pred_tcb_at' proj P' t' s)\<rbrace> threadSet f t \<lbrace>\<lambda>rv s. P (pred_tcb_at' proj P' t' s)\<rbrace>"
+lemma threadSet_obj_at'_no_state:
+  assumes "\<And>tcb. P' (f tcb) = P' tcb"
+  shows   "threadSet f t \<lbrace>\<lambda>s. P (obj_at' P' t' s)\<rbrace>"
 proof -
-  have pos: "\<And>P' t' t.
-            \<lbrace>pred_tcb_at' proj P' t'\<rbrace> threadSet f t \<lbrace>\<lambda>rv. pred_tcb_at' proj P' t'\<rbrace>"
-    apply (simp add: pred_tcb_at'_def)
+  have pos: "\<And>t' t.
+            \<lbrace>obj_at' P' t'\<rbrace> threadSet f t \<lbrace>\<lambda>rv. obj_at' P' t'\<rbrace>"
     apply (wp threadSet_obj_at'_strongish)
     apply clarsimp
     apply (erule obj_at'_weakenE)
@@ -1106,19 +1105,24 @@ proof -
   show ?thesis
     apply (rule_tac P=P in P_bool_lift)
      apply (rule pos)
-    apply (rule_tac Q'="\<lambda>_ s. \<not> tcb_at' t' s \<or> pred_tcb_at' proj (\<lambda>tcb. \<not> P' tcb) t' s"
+    apply (rule_tac Q'="\<lambda>_ s. \<not> tcb_at' t' s \<or> obj_at' (\<lambda>tcb. \<not> P' tcb) t' s"
              in hoare_post_imp)
      apply (erule disjE)
-      apply (clarsimp dest!: pred_tcb_at')
+      apply (clarsimp simp: obj_at'_def)
      apply (clarsimp)
-     apply (frule_tac P=P' and Q="\<lambda>tcb. \<not> P' tcb" in pred_tcb_at_conj')
-     apply (clarsimp)+
+     apply (frule_tac P=P' and Q="\<lambda>tcb. \<not> P' tcb" in obj_at_conj')
+      apply (clarsimp)+
     apply (wp hoare_convert_imp)
       apply (simp add: typ_at_tcb' [symmetric])
       apply (wp pos)+
-    apply (clarsimp simp: pred_tcb_at'_def not_obj_at' elim!: obj_at'_weakenE)
+    apply (clarsimp simp: not_obj_at' assms elim!: obj_at'_weakenE)
     done
 qed
+
+lemma threadSet_pred_tcb_no_state:
+  assumes "\<And>tcb. proj (tcb_to_itcb' (f tcb)) = proj (tcb_to_itcb' tcb)"
+  shows   "threadSet f t \<lbrace>\<lambda>s. P (pred_tcb_at' proj P' t' s)\<rbrace>"
+  by (wpsimp wp: threadSet_obj_at'_no_state simp: pred_tcb_at'_def assms)
 
 lemma threadSet_ct[wp]:
   "\<lbrace>\<lambda>s. P (ksCurThread s)\<rbrace> threadSet f t \<lbrace>\<lambda>rv s. P (ksCurThread s)\<rbrace>"
@@ -1663,6 +1667,12 @@ lemma asUser_tcbPriority_inv[wp]:
   apply (wp threadSet_obj_at'_strongish getObject_tcb_wp | wpc | simp | clarsimp simp: obj_at'_def)+
   done
 
+lemma asUser_tcbState_inv[wp]:
+  "\<lbrace>obj_at' (\<lambda>tcb. P (tcbState tcb)) t'\<rbrace> asUser t m \<lbrace>\<lambda>_. obj_at' (\<lambda>tcb. P (tcbState tcb)) t'\<rbrace>"
+  apply (simp add: asUser_def threadGet_def)
+  apply (wpsimp wp: getObject_tcb_wp simp: obj_at'_def)
+  done
+
 lemma asUser_sch_act_wf[wp]:
   "\<lbrace>\<lambda>s. sch_act_wf (ksSchedulerAction s) s\<rbrace>
     asUser t m \<lbrace>\<lambda>rv s. sch_act_wf (ksSchedulerAction s) s\<rbrace>"
@@ -1915,6 +1925,12 @@ lemma pspace_relation_update_concrete_tcb:
   "\<lbrakk>pspace_relation s s'; s ptr = Some (TCB tcb); s' ptr = Some (KOTCB otcb');
     tcb_relation tcb tcb'\<rbrakk>
    \<Longrightarrow> pspace_relation s (s'(ptr \<mapsto> KOTCB tcb'))"
+  by (fastforce dest: pspace_relation_update_tcbs simp: map_upd_triv)
+
+lemma pspace_relation_update_abstract_tcb:
+  "\<lbrakk>pspace_relation s s'; s ptr = Some (TCB tcb); s' ptr = Some (KOTCB otcb');
+    tcb_relation tcb' otcb'\<rbrakk>
+   \<Longrightarrow> pspace_relation (s(ptr \<mapsto> TCB tcb')) s'"
   by (fastforce dest: pspace_relation_update_tcbs simp: map_upd_triv)
 
 lemma threadSet_pspace_relation:
@@ -3956,7 +3972,7 @@ lemma getMRs_corres:
   apply (rule corres_guard_imp)
     apply (rule corres_split[OF T])
       apply (simp only: option.simps return_bind fun_app_def
-                        load_word_offs_def doMachineOp_mapM ef_loadWord)
+                        load_word_offs_def doMachineOp_mapM)
       apply (rule corres_split_eqr)
          apply (simp only: mapM_map_simp msgMaxLength_def msgLengthBits_def
                            msg_max_length_def o_def upto_enum_word)

--- a/proof/refine/X64/Tcb_R.thy
+++ b/proof/refine/X64/Tcb_R.thy
@@ -346,9 +346,8 @@ lemma invokeTCB_WriteRegisters_corres:
                                  mask_def user_vtop_def
                            cong: if_cong)
           apply simp
-         apply (wpsimp wp: no_fail_mapM no_fail_setRegister)
-            apply (clarsimp simp: sanitiseOrFlags_def sanitiseAndFlags_def)
-            apply ((safe)[1], (wp no_fail_setRegister | simp)+)
+         apply (rule no_fail_pre, wp no_fail_mapM)
+          apply (clarsimp, (wp no_fail_setRegister | simp)+)
         apply (rule corres_split_nor[OF asUser_postModifyRegisters_corres[simplified]])
           apply (rule corres_split_nor[OF corres_when[OF refl restart_corres]])
             apply (rule corres_split_nor[OF corres_when[OF refl rescheduleRequired_corres]])
@@ -1190,6 +1189,10 @@ lemma assertDerived_wp_weak:
   apply (wpsimp simp: assertDerived_def)
   done
 
+crunch fpu_release
+  for pspace_alinged[wp]: "pspace_aligned"
+  and pspace_distinct[wp]: "pspace_distinct"
+
 crunch cap_delete
   for pspace_aligned[wp]: "pspace_aligned :: det_state \<Rightarrow> _"
   and pspace_distinct[wp]: "pspace_distinct :: det_state \<Rightarrow> _"
@@ -1539,7 +1542,7 @@ proof -
                                    threadSet_valid_objs' thread_set_not_state_valid_sched
                                    thread_set_tcb_ipc_buffer_cap_cleared_invs thread_set_cte_wp_at_trivial
                                    thread_set_no_cap_to_trivial getThreadBufferSlot_dom_tcb_cte_cases
-                                   assertDerived_wp_weak threadSet_cap_to' out_pred_tcb_at_preserved
+                                   assertDerived_wp_weak threadSet_cap_to'
                                    checkCap_wp assertDerived_wp_weak cap_insert_objs'
                         | simp add: ran_tcb_cap_cases split_def U V
                                   emptyable_def
@@ -1575,7 +1578,7 @@ proof -
                                  threadSet_valid_objs' thread_set_not_state_valid_sched setP_invs'
                                  typ_at_lifts [OF setPriority_typ_at']
                                  typ_at_lifts [OF setMCPriority_typ_at']
-                                 threadSet_cap_to' out_pred_tcb_at_preserved assertDerived_wp
+                                 threadSet_cap_to' assertDerived_wp
                       del: cteInsert_invs
                    | simp add: ran_tcb_cap_cases split_def U V
                                emptyable_def
@@ -1680,6 +1683,51 @@ lemma setSchedulerAction_invs'[wp]:
 
 end
 
+lemma setFlags_corres[corres]:
+  "flags = word_to_tcb_flags flags' \<Longrightarrow>
+   corres dc (tcb_at t and pspace_aligned and pspace_distinct) \<top>
+         (set_flags t flags) (setFlags t flags')"
+  unfolding set_flags_def setFlags_def
+  apply (corres corres: threadset_corres)
+  by (clarsimp simp: tcb_relation_def inQ_def)+
+
+crunch set_flags
+  for pspace_aligned[wp]: pspace_aligned
+  and pspace_distinct[wp]: pspace_distinct
+  and valid_cur_fpu[wp]: valid_cur_fpu
+
+context begin interpretation Arch . (*FIXME: arch-split*)
+
+lemma tcbFlagToWord_bit:
+  "\<exists>n. tcbFlagToWord flag = bit n"
+  by (auto simp: tcbFlagToWord_def archTcbFlagToWord_def split: tcb_flag.splits arch_tcb_flag.splits
+       simp del: bit_def)
+
+lemma word_to_tcb_flags_subtract:
+  "word_to_tcb_flags (flags && ~~ flags') = word_to_tcb_flags flags - word_to_tcb_flags flags'"
+  apply (clarsimp simp: word_to_tcb_flags_def intro!: set_eqI)
+  apply (cut_tac flag=x in tcbFlagToWord_bit)
+  apply (fastforce simp: word_eq_iff tcbFlagToWord_bit)
+  done
+
+lemma word_to_tcb_flags_union:
+  "word_to_tcb_flags (flags || flags') = word_to_tcb_flags flags \<union> word_to_tcb_flags flags'"
+  apply (clarsimp simp: word_to_tcb_flags_def intro!: set_eqI)
+  apply (cut_tac flag=x in tcbFlagToWord_bit)
+  apply (fastforce simp: word_eq_iff tcbFlagToWord_bit)
+  done
+
+lemmas word_to_tcb_flags_simps = word_to_tcb_flags_subtract word_to_tcb_flags_union
+
+lemma postSetFlags_corres[corres]:
+  "flags = word_to_tcb_flags flags' \<Longrightarrow>
+   corres dc (pspace_aligned and pspace_distinct and valid_cur_fpu) \<top>
+     (arch_post_set_flags  t flags) (postSetFlags t flags')"
+  unfolding arch_post_set_flags_def postSetFlags_def
+  by (corres term_simp: isFlagSet_set)
+
+end
+
 consts
   copyregsets_map :: "arch_copy_register_sets \<Rightarrow> Arch.copy_register_sets"
 
@@ -1711,6 +1759,10 @@ where
     = (x = tcbinvocation.NotificationControl t ntfnptr)"
 | "tcbinv_relation (tcb_invocation.SetTLSBase ref w) x
     = (x = tcbinvocation.SetTLSBase ref w)"
+| "tcbinv_relation (tcb_invocation.SetFlags ref clears sets) x
+    = (\<exists>clears' sets'.
+         clears = word_to_tcb_flags clears' \<and> sets = word_to_tcb_flags sets' \<and>
+         x = tcbinvocation.SetFlags ref clears' sets')"
 
 primrec
   tcb_inv_wf' :: "tcbinvocation \<Rightarrow> kernel_state \<Rightarrow> bool"
@@ -1750,6 +1802,8 @@ where
                                           and bound_tcb_at' ((=) None) t) )"
 | "tcb_inv_wf' (tcbinvocation.SetTLSBase ref w)
              = (tcb_at' ref and ex_nonz_cap_to' ref)"
+| "tcb_inv_wf' (tcbinvocation.SetFlags ref clears sets)
+             = (tcb_at' ref and ex_nonz_cap_to' ref)"
 
 lemma invokeTCB_corres:
  "tcbinv_relation ti ti' \<Longrightarrow>
@@ -1758,53 +1812,57 @@ lemma invokeTCB_corres:
          (invs' and sch_act_simple and tcb_inv_wf' ti')
          (invoke_tcb ti) (invokeTCB ti')"
   apply (case_tac ti, simp_all only: tcbinv_relation.simps valid_tcb_invocation_def)
-         apply (rule corres_guard_imp [OF invokeTCB_WriteRegisters_corres], simp+)[1]
-        apply (rule corres_guard_imp [OF invokeTCB_ReadRegisters_corres], simp+)[1]
-       apply (rule corres_guard_imp [OF invokeTCB_CopyRegisters_corres], simp+)[1]
-      apply (clarsimp simp del: invoke_tcb.simps)
-      apply (rename_tac word one t2 mcp t3 t4 t5 t6 t7 t8 t9 t10 t11)
-      apply (rule_tac F="is_aligned word 5" in corres_req)
-       apply (clarsimp simp add: is_aligned_weaken [OF tcb_aligned])
-      apply (rule corres_guard_imp [OF transferCaps_corres], clarsimp+)
-       apply (clarsimp simp: is_cnode_or_valid_arch_def
-                      split: option.split option.split_asm)
-      apply clarsimp
-      apply (auto split: option.split_asm simp: newroot_rel_def)[1]
+          apply (rule corres_guard_imp [OF invokeTCB_WriteRegisters_corres], simp+)[1]
+         apply (rule corres_guard_imp [OF invokeTCB_ReadRegisters_corres], simp+)[1]
+        apply (rule corres_guard_imp [OF invokeTCB_CopyRegisters_corres], simp+)[1]
+       apply (clarsimp simp del: invoke_tcb.simps)
+       apply (rename_tac word one t2 mcp t3 t4 t5 t6 t7 t8 t9 t10 t11)
+       apply (rule_tac F="is_aligned word 5" in corres_req)
+        apply (clarsimp simp add: is_aligned_weaken [OF tcb_aligned])
+       apply (rule corres_guard_imp [OF transferCaps_corres], clarsimp+)
+        apply (clarsimp simp: is_cnode_or_valid_arch_def
+                       split: option.split option.split_asm)
+       apply clarsimp
+       apply (auto split: option.split_asm simp: newroot_rel_def)[1]
+      apply (simp add: invokeTCB_def liftM_def[symmetric]
+                       o_def dc_def[symmetric])
+      apply (rule corres_guard_imp [OF suspend_corres], simp+)
      apply (simp add: invokeTCB_def liftM_def[symmetric]
                       o_def dc_def[symmetric])
-     apply (rule corres_guard_imp [OF suspend_corres], simp+)
-    apply (simp add: invokeTCB_def liftM_def[symmetric]
-                     o_def dc_def[symmetric])
-    apply (rule corres_guard_imp [OF restart_corres], simp+)
-   apply (simp add:invokeTCB_def)
-   apply (rename_tac option)
-   apply (case_tac option)
+     apply (rule corres_guard_imp [OF restart_corres], simp+)
+    apply (simp add:invokeTCB_def)
+    apply (rename_tac option)
+    apply (case_tac option)
+     apply simp
+     apply (rule corres_guard_imp)
+       apply (rule corres_split[OF unbindNotification_corres])
+         apply (rule corres_trivial, simp)
+        apply wp+
+      apply (clarsimp)
+     apply clarsimp
     apply simp
     apply (rule corres_guard_imp)
-      apply (rule corres_split[OF unbindNotification_corres])
+      apply (rule corres_split[OF bindNotification_corres])
         apply (rule corres_trivial, simp)
        apply wp+
-     apply (clarsimp)
-    apply clarsimp
-   apply simp
+     apply clarsimp
+     apply (clarsimp simp: obj_at_def is_ntfn)
+    apply (clarsimp simp: obj_at'_def projectKOs)
+   apply (simp add: invokeTCB_def tlsBaseRegister_def)
    apply (rule corres_guard_imp)
-     apply (rule corres_split[OF bindNotification_corres])
-       apply (rule corres_trivial, simp)
-      apply wp+
-    apply clarsimp
-    apply (clarsimp simp: obj_at_def is_ntfn)
-   apply (clarsimp simp: obj_at'_def projectKOs)
-  apply (simp add: invokeTCB_def tlsBaseRegister_def)
-  apply (rule corres_guard_imp)
-    apply (rule corres_split[OF TcbAcc_R.asUser_setRegister_corres])
-      apply (rule corres_split[OF Bits_R.getCurThread_corres])
-        apply (rule corres_split[OF Corres_UL.corres_when])
-            apply simp
-           apply (rule TcbAcc_R.rescheduleRequired_corres)
-          apply (rule corres_trivial, simp)
-         apply (wpsimp wp: hoare_drop_imp)+
-   apply (fastforce dest: valid_sched_valid_queues simp: valid_sched_weak_strg)
-  apply fastforce
+     apply (rule corres_split[OF TcbAcc_R.asUser_setRegister_corres])
+       apply (rule corres_split[OF Bits_R.getCurThread_corres])
+         apply (rule corres_split[OF Corres_UL.corres_when])
+             apply simp
+            apply (rule TcbAcc_R.rescheduleRequired_corres)
+           apply (rule corres_trivial, simp)
+          apply (wpsimp wp: hoare_drop_imp)+
+    apply (fastforce dest: valid_sched_valid_queues simp: valid_sched_weak_strg)
+   apply fastforce
+  apply (clarsimp simp: invokeTCB_def)
+  apply (corres corres: threadGet_corres[where r="\<lambda>flags flags'. flags = word_to_tcb_flags flags'"]
+             term_simp: tcb_relation_def word_to_tcb_flags_simps)
+   apply fastforce+
   done
 
 lemma tcbBoundNotification_caps_safe[simp]:
@@ -1875,23 +1933,37 @@ lemma setTLSBase_invs'[wp]:
    \<lbrace>\<lambda>rv. invs'\<rbrace>"
   by (wpsimp simp: invokeTCB_def)
 
+lemma threadSet_flags_invs[wp]:
+  "threadSet (tcbFlags_update f) t \<lbrace>invs'\<rbrace>"
+  by (wpsimp wp: threadSet_invs_trivial)
+
+crunch setFlags, postSetFlags
+  for invs'[wp]: invs'
+  (ignore: threadSet)
+
+lemma invokeSetFlags_invs'[wp]:
+  "\<lbrace>invs' and tcb_inv_wf' (tcbinvocation.SetFlags tcb clears' sets')\<rbrace>
+   invokeTCB (tcbinvocation.SetFlags tcb clears' sets')
+   \<lbrace>\<lambda>rv. invs'\<rbrace>"
+  by (wpsimp simp: invokeTCB_def)
+
 lemma tcbinv_invs':
   "\<lbrace>invs' and sch_act_simple and ct_in_state' runnable' and tcb_inv_wf' ti\<rbrace>
      invokeTCB ti
    \<lbrace>\<lambda>rv. invs'\<rbrace>"
   apply (case_tac ti, simp_all only:)
+          apply (simp add: invokeTCB_def)
+          apply wp
+          apply (clarsimp simp: invs'_def valid_state'_def
+                          dest!: global'_no_ex_cap)
          apply (simp add: invokeTCB_def)
-         apply wp
+         apply (wp restart_invs')
          apply (clarsimp simp: invs'_def valid_state'_def
                          dest!: global'_no_ex_cap)
-        apply (simp add: invokeTCB_def)
-        apply (wp restart_invs')
-        apply (clarsimp simp: invs'_def valid_state'_def
-                        dest!: global'_no_ex_cap)
-       apply (wp tc_invs')
-       apply (clarsimp split: option.split dest!: isCapDs)
-      apply (wp writereg_invs' readreg_invs' copyreg_invs' tcbntfn_invs'
-             | simp)+
+        apply (wp tc_invs')
+        apply (clarsimp split: option.split dest!: isCapDs)
+       apply (wp writereg_invs' readreg_invs' copyreg_invs' tcbntfn_invs'
+              | simp)+
   done
 
 declare assertDerived_wp [wp]
@@ -2605,6 +2677,13 @@ lemma decodeSetTLSBase_corres:
   by (clarsimp simp: decode_set_tls_base_def decodeSetTLSBase_def returnOk_def
                split: list.split)
 
+lemma decodeSetFlags_corres:
+  "corres (ser \<oplus> tcbinv_relation) (tcb_at t) (tcb_at' t)
+          (decode_set_flags w (cap.ThreadCap t))
+          (decodeSetFlags w (capability.ThreadCap t))"
+  by (clarsimp simp: decode_set_flags_def decodeSetFlags_def returnOk_def
+               split: list.split)
+
 lemma decodeTCBInvocation_corres:
  "\<lbrakk> c = Structures_A.ThreadCap t; cap_relation c c';
       list_all2 (\<lambda>(c, sl) (c', sl'). cap_relation c c' \<and> sl' = cte_map sl) extras extras';
@@ -2632,7 +2711,8 @@ lemma decodeTCBInvocation_corres:
              corres_guard_imp[OF decodeSetSpace_corres]
              corres_guard_imp[OF decodeBindNotification_corres]
              corres_guard_imp[OF decodeUnbindNotification_corres]
-             corres_guard_imp[OF decodeSetTLSBase_corres],
+             corres_guard_imp[OF decodeSetTLSBase_corres]
+             corres_guard_imp[OF decodeSetFlags_corres],
          simp_all add: valid_cap_simps valid_cap_simps' invs_def valid_sched_def)
   apply (auto simp: list_all2_map1 list_all2_map2 valid_state_def
              elim!: list_all2_mono)
@@ -2682,6 +2762,12 @@ lemma decodeSetTLSBase_wf:
   apply (simp add: decodeSetTLSBase_def
              cong: list.case_cong)
   by wpsimp
+
+lemma decodeSetFlags_wf[wp]:
+  "\<lbrace>invs' and tcb_at' t and ex_nonz_cap_to' t\<rbrace>
+   decodeSetFlags w (capability.ThreadCap t)
+   \<lbrace>tcb_inv_wf'\<rbrace>,-"
+  by (wpsimp simp: decodeSetFlags_def)
 
 lemma decodeTCBInv_wf:
   "\<lbrace>invs' and tcb_at' t and cte_at' slot and ex_nonz_cap_to' t

--- a/proof/refine/X64/Untyped_R.thy
+++ b/proof/refine/X64/Untyped_R.thy
@@ -4488,7 +4488,7 @@ crunch doMachineOp
   (simp: crunch_simps ct_in_state'_def)
 
 crunch doMachineOp
-  for st_tcb_at'[wp]: "st_tcb_at' P p"
+  for st_tcb_at'[wp]: "\<lambda>s. P (st_tcb_at' P' p s)"
   (simp: crunch_simps ct_in_state'_def)
 
 lemma ex_cte_cap_wp_to_irq_state_independent_H[simp]:

--- a/spec/abstract/X64/Arch_A.thy
+++ b/spec/abstract/X64/Arch_A.thy
@@ -19,8 +19,8 @@ context Arch begin arch_global_naming (A)
 definition "page_bits \<equiv> pageBits"
 
 definition
-  updateIRQState :: "irq \<Rightarrow> X64IRQState \<Rightarrow> ('a abstract_state_scheme, unit) nondet_monad" where
-  "updateIRQState irq irqState \<equiv> do
+  update_irq_state :: "irq \<Rightarrow> X64IRQState \<Rightarrow> ('a abstract_state_scheme, unit) nondet_monad" where
+  "update_irq_state irq irqState \<equiv> do
      irq_states \<leftarrow> gets (x64_irq_state o arch_state);
      modify (\<lambda>s. s \<lparr>arch_state := (arch_state s) \<lparr>x64_irq_state := irq_states (irq := irqState)\<rparr>\<rparr>)
   od"
@@ -31,13 +31,13 @@ definition
     IssueIRQHandlerIOAPIC irq dest src ioapic pin level polarity vector \<Rightarrow> without_preemption (do
       do_machine_op $ ioapicMapPinToVector ioapic pin level polarity vector;
       irq_state \<leftarrow> return $ IRQIOAPIC (ioapic && mask 5) (pin && mask 5) (level && 1) (polarity && 1) True;
-      updateIRQState irq irq_state;
+      update_irq_state irq irq_state;
       set_irq_state IRQSignal (IRQ irq);
       cap_insert (IRQHandlerCap (IRQ irq)) src dest
     od) |
     IssueIRQHandlerMSI irq dest src bus dev func handle \<Rightarrow> without_preemption (do
       irq_state \<leftarrow> return $ IRQMSI (bus && mask 8) (dev && mask 5) (func && mask 3) (handle && mask 32);
-      updateIRQState irq irq_state;
+      update_irq_state irq irq_state;
       set_irq_state IRQSignal (IRQ irq);
       cap_insert (IRQHandlerCap (IRQ irq)) src dest
     od)

--- a/spec/haskell/src/SEL4/Object/Structures/ARM.lhs
+++ b/spec/haskell/src/SEL4/Object/Structures/ARM.lhs
@@ -139,7 +139,7 @@ present on all platforms is stored here.
 > type ArchTcbFlag = ()
 
 > archTcbFlagToWord :: ArchTcbFlag -> Word
-> archTcbFlagToWord _ = error "ARM does not have any arch specific flags"
+> archTcbFlagToWord _ = 0 -- ARM does not have any arch specific flags but we make this 0 so that some proofs are easier
 
 \subsection{ASID Pools}
 

--- a/spec/haskell/src/SEL4/Object/Structures/RISCV64.hs
+++ b/spec/haskell/src/SEL4/Object/Structures/RISCV64.hs
@@ -76,7 +76,7 @@ atcbContextGet = atcbContext
 type ArchTcbFlag = ()
 
 archTcbFlagToWord :: ArchTcbFlag -> Word
-archTcbFlagToWord _ = error "ARM does not have any arch specific flags"
+archTcbFlagToWord _ = 0 -- RISCV64 does not have any arch specific flags but we make this 0 so that some proofs are easier
 
 {- ASID Pools -}
 

--- a/spec/machine/X64/MachineOps.thy
+++ b/spec/machine/X64/MachineOps.thy
@@ -360,11 +360,6 @@ where
 "numIODomainIDBits \<equiv> undefined"
 *)
 
-definition
-  hwASIDInvalidate :: "word64 \<Rightarrow> machine_word \<Rightarrow> unit machine_monad"
-where
-  "hwASIDInvalidate \<equiv> invalidateASID"
-
 consts'
   getFaultAddress_val :: "machine_state \<Rightarrow> machine_word"
 definition


### PR DESCRIPTION
This extends the changes made in https://github.com/seL4/l4v/pull/873 for the remaining architectures. Changes to X64 were generally more extensive due to its proofs needing to be made consistent with the more recent AARCH64 proofs that were being copied.

Test with https://github.com/seL4/seL4/pull/1325