### PR TITLE
use mlton from Isabelle distribution

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -27,9 +27,6 @@ sudo apt-get install \
     rsync
 ```
 
-There is no package for the MLton compiler on Bullseye, so you will need to
-install it from the [MLton website](http://www.mlton.org).
-
 The Haskell Stack package is unavailable on Bullseye, so you will need to
 install it from the [Haskell Stack
 website](https://docs.haskellstack.org/en/stable/).
@@ -50,7 +47,7 @@ sudo apt-get install \
     ncurses-dev librsvg2-bin device-tree-compiler cmake \
     ninja-build curl zlib1g-dev texlive-fonts-recommended \
     texlive-latex-extra texlive-metapost texlive-bibtex-extra \
-    mlton-compiler haskell-stack repo
+    haskell-stack repo
 ```
 
 Continue with the [python setup step](#python) below.
@@ -64,7 +61,7 @@ To install the main dependencies and cross compilers, use the following steps:
 
 ```sh
 brew install git libxml2 ncurses librsvg dtc cmake ninja texlive rsync python ccache \
-     zstd haskell-stack mlton arm-none-eabi-gcc repo
+     zstd haskell-stack arm-none-eabi-gcc repo
 
 brew install --cask gcc-arm-embedded
 

--- a/tools/c-parser/README.md
+++ b/tools/c-parser/README.md
@@ -22,8 +22,8 @@ be allocated via `alloc`, because this library function does typically not yet
 exist in low-level code such as OS kernel implementation.
 
 To install, we recommend using one of the [releases] provided below and see the
-file INSTALL in the `src/c-parser` directory. You will need Isabelle and the
-[MLton compiler] for Standard ML.
+file INSTALL in the `src/c-parser` directory. You need the Isabelle release that
+corresponds to the StrictC parser release.
 
 To use:
 
@@ -41,7 +41,6 @@ for more information.
 [releases]: #releases
 [testfiles]: testfiles/
 [breakcontinue]: testfiles/breakcontinue.thy
-[MLton compiler]: http://mlton.org
 [AutoCorres]: https://trustworthy.systems/projects/OLD/autocorres/
 
 Documentation

--- a/tools/c-parser/globalmakevars
+++ b/tools/c-parser/globalmakevars
@@ -16,9 +16,10 @@ GLOB_PFX := $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
 CC ?= gcc
 
 SML_COMPILER ?= mlton
-#ifndef SML_COMPILER
-#SML_COMPILER := $(if $(shell which mlton),mlton,poly)
-#endif
+
+ifndef MLTON
+MLTON := $(shell $(GLOB_PFX)/../../isabelle/bin/isabelle getenv -b ISABELLE_MLTON)
+endif
 
 ifndef ML_HOME
 ML_HOME := $(shell $(GLOB_PFX)/../../isabelle/bin/isabelle getenv ML_HOME | perl -ne 'print (substr($$_,8))')

--- a/tools/c-parser/standalone-parser/Makefile
+++ b/tools/c-parser/standalone-parser/Makefile
@@ -71,47 +71,47 @@ AARCH64_MLB_PATH := -mlb-path-var 'L4V_ARCH AARCH64'
 X64_MLB_PATH := -mlb-path-var 'L4V_ARCH X64'
 RISCV64_MLB_PATH := -mlb-path-var 'L4V_ARCH RISCV64'
 
-PARSER_DEPS_ARM := $(shell mlton $(ARM_MLB_PATH) -stop f $(STP_PFX)/c-parser.mlb)
-PARSER_DEPS_ARM_HYP := $(shell mlton $(ARM_HYP_MLB_PATH) -stop f $(STP_PFX)/c-parser.mlb)
-PARSER_DEPS_AARCH64 := $(shell mlton $(AARCH64_MLB_PATH) -stop f $(STP_PFX)/c-parser.mlb)
-PARSER_DEPS_X64 := $(shell mlton $(X64_MLB_PATH) -stop f $(STP_PFX)/c-parser.mlb)
-PARSER_DEPS_RISCV64 := $(shell mlton $(RISCV64_MLB_PATH) -stop f $(STP_PFX)/c-parser.mlb)
+PARSER_DEPS_ARM := $(shell $(MLTON) $(ARM_MLB_PATH) -stop f $(STP_PFX)/c-parser.mlb)
+PARSER_DEPS_ARM_HYP := $(shell $(MLTON) $(ARM_HYP_MLB_PATH) -stop f $(STP_PFX)/c-parser.mlb)
+PARSER_DEPS_AARCH64 := $(shell $(MLTON) $(AARCH64_MLB_PATH) -stop f $(STP_PFX)/c-parser.mlb)
+PARSER_DEPS_X64 := $(shell $(MLTON) $(X64_MLB_PATH) -stop f $(STP_PFX)/c-parser.mlb)
+PARSER_DEPS_RISCV64 := $(shell $(MLTON) $(RISCV64_MLB_PATH) -stop f $(STP_PFX)/c-parser.mlb)
 
-TOKENIZER_DEPS_ARM := $(shell mlton $(ARM_MLB_PATH) -stop f $(STP_PFX)/tokenizer.mlb)
-TOKENIZER_DEPS_ARM_HYP := $(shell mlton $(ARM_HYP_MLB_PATH) -stop f $(STP_PFX)/tokenizer.mlb)
-TOKENIZER_DEPS_AARCH64 := $(shell mlton $(AARCH64_MLB_PATH) -stop f $(STP_PFX)/tokenizer.mlb)
-TOKENIZER_DEPS_X64 := $(shell mlton $(X64_MLB_PATH) -stop f $(STP_PFX)/tokenizer.mlb)
-TOKENIZER_DEPS_RISCV64 := $(shell mlton $(RISCV64_MLB_PATH) -stop f $(STP_PFX)/tokenizer.mlb)
+TOKENIZER_DEPS_ARM := $(shell $(MLTON) $(ARM_MLB_PATH) -stop f $(STP_PFX)/tokenizer.mlb)
+TOKENIZER_DEPS_ARM_HYP := $(shell $(MLTON) $(ARM_HYP_MLB_PATH) -stop f $(STP_PFX)/tokenizer.mlb)
+TOKENIZER_DEPS_AARCH64 := $(shell $(MLTON) $(AARCH64_MLB_PATH) -stop f $(STP_PFX)/tokenizer.mlb)
+TOKENIZER_DEPS_X64 := $(shell $(MLTON) $(X64_MLB_PATH) -stop f $(STP_PFX)/tokenizer.mlb)
+TOKENIZER_DEPS_RISCV64 := $(shell $(MLTON) $(RISCV64_MLB_PATH) -stop f $(STP_PFX)/tokenizer.mlb)
 
 $(STPARSER_ARM): $(PARSER_DEPS_ARM) | $(ARM_DIR)
-	mlton $(ARM_MLB_PATH) -output $@ $<
+	$(MLTON) $(ARM_MLB_PATH) -output $@ $<
 
 $(STPARSER_ARM_HYP): $(PARSER_DEPS_ARM_HYP) | $(ARM_HYP_DIR)
-	mlton $(ARM_HYP_MLB_PATH) -output $@ $<
+	$(MLTON) $(ARM_HYP_MLB_PATH) -output $@ $<
 
 $(STPARSER_AARCH64): $(PARSER_DEPS_AARCH64) | $(AARCH64_DIR)
-	mlton $(AARCH64_MLB_PATH) -output $@ $<
+	$(MLTON) $(AARCH64_MLB_PATH) -output $@ $<
 
 $(STPARSER_X64): $(PARSER_DEPS_X64) | $(X64_DIR)
-	mlton $(X64_MLB_PATH) -output $@ $<
+	$(MLTON) $(X64_MLB_PATH) -output $@ $<
 
 $(STPARSER_RISCV64): $(PARSER_DEPS_RISCV64) | $(RISCV64_DIR)
-	mlton $(RISCV64_MLB_PATH) -output $@ $<
+	$(MLTON) $(RISCV64_MLB_PATH) -output $@ $<
 
 $(TOKENIZER_ARM): $(TOKENIZER_DEPS_ARM) | $(ARM_DIR)
-	mlton $(ARM_MLB_PATH) -output $@ $<
+	$(MLTON) $(ARM_MLB_PATH) -output $@ $<
 
 $(TOKENIZER_ARM_HYP): $(TOKENIZER_DEPS_ARM_HYP) | $(ARM_HYP_DIR)
-	mlton $(ARM_HYP_MLB_PATH) -output $@ $<
+	$(MLTON) $(ARM_HYP_MLB_PATH) -output $@ $<
 
 $(TOKENIZER_AARCH64): $(TOKENIZER_DEPS_AARCH64) | $(AARCH64_DIR)
-	mlton $(AARCH64_MLB_PATH) -output $@ $<
+	$(MLTON) $(AARCH64_MLB_PATH) -output $@ $<
 
 $(TOKENIZER_X64): $(TOKENIZER_DEPS_X64) | $(X64_DIR)
-	mlton $(X64_MLB_PATH) -output $@ $<
+	$(MLTON) $(X64_MLB_PATH) -output $@ $<
 
 $(TOKENIZER_RISCV64): $(TOKENIZER_DEPS_RISCV64) | $(RISCV64_DIR)
-	mlton $(RISCV64_MLB_PATH) -output $@ $<
+	$(MLTON) $(RISCV64_MLB_PATH) -output $@ $<
 
 else ifeq ($(SML_COMPILER),poly)
 #

--- a/tools/c-parser/standalone-parser/README.md
+++ b/tools/c-parser/standalone-parser/README.md
@@ -13,14 +13,3 @@ verification C subset.
 
 Note that this is only the parser, not the Isabelle translation.
 Programs that pass the parse may still fail in translation.
-
-
-Dependencies
-------------
-
-This build works best with the `mlton` compiler, available from
-
-  http://mlton.org
-
-PolyML has worked as well in the past, but may require some additional
-setup for 64bit platforms.

--- a/tools/c-parser/tools/mllex/Makefile
+++ b/tools/c-parser/tools/mllex/Makefile
@@ -22,10 +22,10 @@ ifeq ($(SML_COMPILER),mlton)
 #
 # Compilation if the compiler is mlton
 #
-MLTON_DEPS := $(shell mlton -stop f $(MLLEX_PFX)/mllex.mlb)
+MLTON_DEPS := $(shell $(MLTON) -stop f $(MLLEX_PFX)/mllex.mlb)
 
 $(MLLEX): $(MLTON_DEPS)
-	mlton $<
+	$(MLTON) $<
 else ifeq ($(SML_COMPILER),poly)
 #
 # Compilation if the compiler is Poly/ML

--- a/tools/c-parser/tools/mlyacc/Makefile
+++ b/tools/c-parser/tools/mlyacc/Makefile
@@ -21,10 +21,10 @@ ifeq ($(SML_COMPILER),mlton)
 #
 # Compilation if the compiler is mlton
 #
-MLTON_DEPS := $(shell mlton -stop f $(MLYACC_PFX)/mlyacc.mlb)
+MLTON_DEPS := $(shell $(MLTON) -stop f $(MLYACC_PFX)/mlyacc.mlb)
 
 $(MLYACC_PFX)/mlyacc: $(MLTON_DEPS)
-	mlton $<
+	$(MLTON) $<
 
 else ifeq ($(SML_COMPILER),poly)
 #


### PR DESCRIPTION
Simplify installation and use the `mlton` included in the Isabelle distribution.

Needs to be merged after Isabelle2025 (#882), because before that the included `mlton` is too old to support Arm platforms.
