### PR TITLE
FPU: return new flag state after invokeSetFlags

### DIFF
--- a/lib/Word_Lib/More_Word.thy
+++ b/lib/Word_Lib/More_Word.thy
@@ -1534,6 +1534,10 @@ lemma nth_is_and_neq_0:
   "bit (x::'a::len word) n = (x AND 2 ^ n \<noteq> 0)"
   by (subst and_neq_0_is_nth; rule refl)
 
+lemma not_nth_is_and_eq_0:
+  "(\<not> bit (x::'a::len word) n) = (x AND 2 ^ n = 0)"
+  by (simp add: and_exp_eq_0_iff_not_bit)
+
 lemma max_word_not_less [simp]:
    "\<not> - 1 < x" for x :: \<open>'a::len word\<close>
   by (fact word_order.extremum_strict)

--- a/proof/crefine/AARCH64/Retype_C.thy
+++ b/proof/crefine/AARCH64/Retype_C.thy
@@ -3470,7 +3470,7 @@ proof -
        tcbSchedNext_C := tcb_Ptr 0, tcbSchedPrev_C := tcb_Ptr 0,
        tcbEPNext_C := tcb_Ptr 0, tcbEPPrev_C := tcb_Ptr 0,
        tcbBoundNotification_C := ntfn_Ptr 0,
-       flags_C := 0\<rparr>"
+       tcbFlags_C := 0\<rparr>"
 
   have fbtcb: "from_bytes (replicate (size_of TYPE(tcb_C)) 0) = ?tcb"
     apply (simp add: from_bytes_def)

--- a/proof/crefine/AARCH64/StateRelation_C.thy
+++ b/proof/crefine/AARCH64/StateRelation_C.thy
@@ -414,7 +414,7 @@ where
      \<and> option_to_ptr (tcbBoundNotification atcb) = tcbBoundNotification_C ctcb
      \<and> option_to_ctcb_ptr (tcbSchedPrev atcb) = tcbSchedPrev_C ctcb
      \<and> option_to_ctcb_ptr (tcbSchedNext atcb) = tcbSchedNext_C ctcb
-     \<and> tcbFlags atcb = flags_C ctcb"
+     \<and> tcbFlags atcb = tcbFlags_C ctcb"
 
 abbreviation
   "ep_queue_relation' \<equiv> tcb_queue_relation' tcbEPNext_C tcbEPPrev_C"

--- a/proof/crefine/AARCH64/Tcb_C.thy
+++ b/proof/crefine/AARCH64/Tcb_C.thy
@@ -4506,8 +4506,8 @@ lemma decodeSetTLSBase_ccorres:
   done
 
 lemma scast_seL4_TCBFlag_fpuDisabled[simp]:
-  "scast seL4_TCBFlag_fpuDisabled = tcbFlagToWord (ArchFlag FpuDisabled)"
-  by (clarsimp simp: seL4_TCBFlag_fpuDisabled_def tcbFlagToWord_def archTcbFlagToWord_def)
+  "scast seL4_TCBFlag_fpuDisabled = tcbFlagToWord FpuDisabled"
+  by (clarsimp simp: seL4_TCBFlag_fpuDisabled_def tcbFlagToWord_def)
 
 lemma invokeTCB_SetFlags_ccorres:
   notes hoare_weak_lift_imp [wp]

--- a/proof/crefine/AARCH64/Tcb_C.thy
+++ b/proof/crefine/AARCH64/Tcb_C.thy
@@ -4505,43 +4505,92 @@ lemma decodeSetTLSBase_ccorres:
   apply (auto simp: unat_eq_0 le_max_word_ucast_id)+
   done
 
-lemma scast_seL4_TCBFlag_fpuDisabled[simp]:
-  "scast seL4_TCBFlag_fpuDisabled = tcbFlagToWord FpuDisabled"
-  by (clarsimp simp: seL4_TCBFlag_fpuDisabled_def tcbFlagToWord_def)
-
 lemma invokeTCB_SetFlags_ccorres:
   notes hoare_weak_lift_imp [wp]
   shows
-  "ccorres (cintr \<currency> (\<lambda>rv rv'. rv = [])) (liftxf errstate id (K ()) ret__unsigned_long_')
-   (invs' and tcb_at' tcb)
-   (\<lbrace>\<acute>thread = tcb_ptr_to_ctcb_ptr tcb\<rbrace>
-    \<inter> \<lbrace>\<acute>clear = clears\<rbrace>
-    \<inter> \<lbrace>\<acute>set = sets\<rbrace>) []
-   (invokeTCB (SetFlags tcb clears sets))
-   (Call invokeSetFlags_'proc)"
-  apply (cinit lift: thread_' clear_' set_' simp: setFlags_def postSetFlags_def)
-   apply (simp add: liftE_def bind_assoc)
-   apply (rule ccorres_pre_threadGet, rename_tac flags)
-   \<comment> \<open>split off flags_' updates and threadSet\<close>
-   apply (rule ccorres_rhs_assoc2, rule ccorres_rhs_assoc2, rule ccorres_rhs_assoc2)
-   apply (rule ccorres_split_nothrow)
-       apply (rule_tac P="\<lambda>tcb. tcbFlags tcb = flags" in threadSet_ccorres_lemma2)
-        apply vcg
-       apply (clarsimp simp: tcb_at_h_t_valid[OF obj_tcb_at'])
-       apply (erule rf_sr_tcb_update_no_queue2[rotated],
-              (simp add: typ_heap_simps')+, simp_all?)[1]
-        apply (rule ball_tcb_cte_casesI, simp+)
-       apply (clarsimp simp: ctcb_relation_def)
-      apply ceqv
-     apply (rule ccorres_split_nothrow_novcg_dc)
-        apply (rule_tac R=\<top> and R'="{s. flags_' s = flags && ~~ clears || sets}" in ccorres_when_strong)
-         apply (clarsimp simp: isFlagSet_def word_bw_comms)
-        apply (ctac add: fpuRelease_ccorres)
-       apply (rule ccorres_return_CE[folded return_returnOk]; simp)
-      apply (wpsimp simp: guard_is_UNIV_def)+
-   apply vcg
-  apply (clarsimp simp: obj_at'_def typ_heap_simps' ctcb_relation_def)
-  done
+  "ccorres dc xfdc
+     (invs' and (\<lambda>s. ksCurThread s = thread) and ct_in_state' ((=) Restart))
+     (\<lbrace>\<acute>thread = tcb_ptr_to_ctcb_ptr tcb\<rbrace> \<inter> \<lbrace>\<acute>clear = clears\<rbrace> \<inter> \<lbrace>\<acute>set = sets\<rbrace> \<inter> \<lbrace>\<acute>call = from_bool isCall\<rbrace>) []
+     (do reply \<leftarrow> invokeSetFlags tcb clears sets;
+         replyOnRestart thread [reply] isCall od)
+     (Call invokeSetFlags_'proc)"
+  apply (cinit' lift: thread_' clear_' set_' call_' simp: invokeSetFlags_def setFlags_def postSetFlags_def)
+   apply (clarsimp simp: liftE_liftE bind_bindE_assoc bindE_assoc bind_assoc simp del: Collect_const
+                 intro!: ccorres_liftE')
+   apply (rule ccorres_symb_exec_r)
+     apply (rule ccorres_pre_threadGet, rename_tac flags)
+     \<comment> \<open>split off flags_' updates and threadSet\<close>
+     apply (rule ccorres_rhs_assoc2, rule ccorres_rhs_assoc2, rule ccorres_rhs_assoc2)
+     apply (rule ccorres_split_nothrow)
+         apply (rule_tac P="\<lambda>tcb. tcbFlags tcb = flags" in threadSet_ccorres_lemma2)
+          apply vcg
+         apply (clarsimp simp: tcb_at_h_t_valid[OF obj_tcb_at'])
+         apply (erule rf_sr_tcb_update_no_queue2[rotated],
+                (simp add: typ_heap_simps')+, simp_all?)[1]
+          apply (rule ball_tcb_cte_casesI, simp+)
+         apply (clarsimp simp: ctcb_relation_def)
+        apply ceqv
+       apply (rule ccorres_split_nothrow_dc)
+          apply (rule_tac R=\<top> and R'="\<lbrace>\<acute>flags = flags && ~~ clears || sets && tcbFlagMask\<rbrace>"
+                       in ccorres_when_strong)
+           apply (clarsimp simp: isFlagSet_def word_bw_comms)
+          apply (ctac add: fpuRelease_ccorres)
+
+         apply (rule ccorres_Cond_rhs_Seq[rotated]; clarsimp)
+          apply (simp add: replyOnRestart_def liftE_def bind_assoc)
+          apply (rule getThreadState_ccorres_foo, rename_tac tstate)
+          apply (rule_tac P="tstate = Restart" in ccorres_gen_asm)
+          apply clarsimp
+          apply (ctac (no_vcg) add: setThreadState_ccorres)
+         apply (rule ccorres_rhs_assoc)+
+         apply (clarsimp simp: replyOnRestart_def liftE_def bind_assoc)
+         apply (rule getThreadState_ccorres_foo, rename_tac tstate)
+         apply (rule_tac P="tstate = Restart" in ccorres_gen_asm)
+         apply (clarsimp simp: bind_assoc)
+         apply (simp add: replyFromKernel_def bind_assoc)
+         apply (ctac add: lookupIPCBuffer_ccorres)
+           apply (ctac add: setRegister_ccorres)
+             apply (simp add: setMRs_single)
+             apply (ctac add: setMR_as_setRegister_ccorres[where offset=0])
+               apply clarsimp
+               apply csymbr
+               apply (simp only: setMessageInfo_def bind_assoc)
+               apply ctac
+                 apply simp
+                 apply (ctac add: setRegister_ccorres)
+                   apply (ctac add: setThreadState_ccorres)
+                  apply wpsimp
+                 apply (vcg exspec=setRegister_modifies)
+                apply wpsimp
+               apply clarsimp
+               apply vcg
+              apply wpsimp
+             apply (clarsimp simp: msgInfoRegister_def AARCH64.msgInfoRegister_def
+                                   Kernel_C.msgInfoRegister_def)
+             apply (vcg exspec=setMR_modifies)
+            apply wpsimp
+           apply clarsimp
+           apply (vcg exspec=setRegister_modifies)
+          apply wpsimp
+         apply clarsimp
+         apply (vcg exspec=lookupIPCBuffer_modifies)
+        apply (wpsimp wp: hoare_vcg_all_lift hoare_vcg_imp_lift')
+       apply clarsimp
+       apply (vcg exspec=fpuRelease_modifies)
+      apply (wpsimp wp: hoare_vcg_all_lift hoare_vcg_imp_lift' threadSet_pred_tcb_no_state
+                        threadSet_sch_act weak_if_wp' | strengthen invs_valid_objs')+
+     apply vcg
+    apply clarsimp
+    apply vcg
+   apply (rule conseqPre, vcg, clarsimp)
+  apply (clarsimp simp: invs_no_0_obj' tcb_at_invs' invs_valid_objs' invs_sch_act_wf'
+                        rf_sr_ksCurThread msgRegisters_unfold
+                        seL4_MessageInfo_lift_def message_info_to_H_def
+                        obj_at'_def typ_heap_simps' ctcb_relation_def)
+  by (auto dest: invs_valid_objs' elim!: valid_objsE'
+           simp: AARCH64.badgeRegister_def badgeRegister_def C_register_defs fromPAddr_def
+                 ThreadState_defs pred_tcb_at'_def obj_at'_def ct_in_state'_def typ_heap_simps'
+                 mask_2pm1 valid_obj'_def valid_tcb'_def word_ao_dist word_bw_assocs word_bw_lcs)
 
 lemma decodeSetFlags_ccorres:
   "ccorres (intr_and_se_rel \<currency> dc) (liftxf errstate id (K ()) ret__unsigned_long_')
@@ -4551,11 +4600,12 @@ lemma decodeSetFlags_ccorres:
               and sysargs_rel args buffer)
        (\<lbrace>ccap_relation cp \<acute>cap\<rbrace>
         \<inter> \<lbrace>unat \<acute>length___unsigned_long = length args\<rbrace>
-        \<inter> \<lbrace>\<acute>buffer = option_to_ptr buffer\<rbrace>) []
+        \<inter> \<lbrace>\<acute>buffer = option_to_ptr buffer\<rbrace>
+        \<inter> \<lbrace>\<acute>call = from_bool isCall\<rbrace>) []
      (decodeSetFlags args cp
         >>= invocationCatch thread isBlocking isCall InvokeTCB)
      (Call decodeSetFlags_'proc)"
-  apply (cinit' lift: cap_' length___unsigned_long_' buffer_'
+  apply (cinit' lift: cap_' length___unsigned_long_' buffer_' call_'
                 simp: decodeSetFlags_def )
    apply csymbr+
    apply (rule ccorres_Cond_rhs_Seq)
@@ -4579,12 +4629,18 @@ lemma decodeSetFlags_ccorres:
                         bindE_assoc injection_handler_returnOk
                         ccorres_invocationCatch_Inr performInvocation_def)
        apply (ctac add: setThreadState_ccorres)
+         apply (rule ccorres_nondet_refinement)
+          apply (rule is_nondet_refinement_bindE)
+           apply (rule is_nondet_refinement_refl)
+          apply (simp split: if_split, rule conjI[rotated])
+           apply (rule impI, rule is_nondet_refinement_refl)
+          apply (rule impI, rule is_nondet_refinement_alternative1)
+         apply (clarsimp simp: invokeTCB_def liftE_bindE bind_assoc liftE_left)
+         apply (rule ccorres_add_returnOk)
+         apply (rule ccorres_liftE_Seq)
          apply (ctac (no_vcg) add: invokeTCB_SetFlags_ccorres)
-           apply simp
-           apply (rule ccorres_alternative2)
-           apply (rule ccorres_return_CE, simp+)[1]
-          apply (rule ccorres_return_C_errorE, simp+)[1]
-         apply (wpsimp wp: sts_invs_minor')+
+          apply (rule ccorres_return_CE, simp+)[1]
+         apply (wpsimp wp: sts_invs_minor' ct_in_state'_set)+
        apply (vcg exspec=setThreadState_modifies)
       apply wpsimp
      apply (vcg exspec=getSyscallArg_modifies)

--- a/proof/crefine/AARCH64/VSpace_C.thy
+++ b/proof/crefine/AARCH64/VSpace_C.thy
@@ -1581,8 +1581,8 @@ lemma msgRegisters_ccorres:
   apply (simp add: Arrays.update_def n_msgRegisters_def nth_Cons' split: if_split)
   done
 
-(* usually when we call setMR directly, we mean to only set a registers, which will
-   fit in actual registers *)
+(* usually when we call setMR directly, we mean to only set a single message register
+   which will fit in actual registers *)
 lemma setMR_as_setRegister_ccorres:
   "ccorres (\<lambda>rv rv'. rv' = of_nat offset + 1) ret__unsigned_'
       (tcb_at' thread and K (TCB_H.msgRegisters ! offset = reg \<and> offset < length msgRegisters))
@@ -1592,8 +1592,8 @@ lemma setMR_as_setRegister_ccorres:
     (asUser thread (setRegister reg val))
     (Call setMR_'proc)"
   apply (rule ccorres_grab_asm)
-  apply (cinit' lift:  reg___unsigned_long_' offset_' receiver_')
-   apply (clarsimp simp: n_msgRegisters_def length_of_msgRegisters)
+  apply (cinit' lift: reg___unsigned_long_' offset_' receiver_')
+   apply (clarsimp simp: length_msgRegisters)
    apply (rule ccorres_cond_false)
    apply (rule ccorres_move_const_guards)
    apply (rule ccorres_add_return2)
@@ -1603,9 +1603,9 @@ lemma setMR_as_setRegister_ccorres:
      apply (clarsimp simp: return_def)
     apply (rule hoare_TrueI[of \<top>])
    apply (vcg exspec=setRegister_modifies)
-  apply (clarsimp simp: n_msgRegisters_def length_of_msgRegisters not_le conj_commute)
+  apply (clarsimp simp: length_msgRegisters n_msgRegisters_def not_le conj_commute)
   apply (subst msgRegisters_ccorres[symmetric])
-   apply (clarsimp simp: n_msgRegisters_def length_of_msgRegisters unat_of_nat_eq)
+   apply (clarsimp simp: n_msgRegisters_def unat_of_nat_eq)
   apply (clarsimp simp: word_less_nat_alt word_le_nat_alt unat_of_nat_eq not_le[symmetric])
   done
 

--- a/proof/crefine/AARCH64/Wellformed_C.thy
+++ b/proof/crefine/AARCH64/Wellformed_C.thy
@@ -435,6 +435,7 @@ lemma ptr_val_tcb_ptr_mask2:
   apply (simp add: is_aligned_add_helper ctcb_offset_defs objBits_simps')
   done
 
+
 section \<open>Domains\<close>
 
 text \<open>
@@ -542,6 +543,7 @@ lemma num_tcb_queues_calculation:
   "num_tcb_queues = numDomains * numPriorities"
   unfolding num_tcb_queues_val by eval
 
+
 text \<open>maxIRQ interface\<close>
 
 (* Main lemma to use when one encounters Kernel_C.maxIRQ *)
@@ -636,6 +638,19 @@ lemma max_armKSGICVCPUNumListRegs_msb:
 lemma max_armKSGICVCPUNumListRegs_word_bits:
   "max_armKSGICVCPUNumListRegs \<le> word_bits"
   by (simp add: max_armKSGICVCPUNumListRegs_val word_bits_def)
+
+
+text \<open>TCBFlags interface\<close>
+
+lemma scast_seL4_TCBFlag_simps[simp]:
+  "scast seL4_TCBFlag_NoFlag = 0"
+  "scast seL4_TCBFlag_fpuDisabled = tcbFlagToWord FpuDisabled"
+  by (clarsimp simp: seL4_TCBFlag_fpuDisabled_def seL4_TCBFlag_NoFlag_def tcbFlagToWord_def)+
+
+(* config_HAVE_FPU has to be unfolded here to match the implicit enum value from the preprocessor. *)
+lemma scast_seL4_TCBFlag_MASK_tcbFlagMask[simp]:
+  "scast seL4_TCBFlag_MASK = tcbFlagMask"
+  by (clarsimp simp: seL4_TCBFlag_MASK_def tcbFlagMask_def Kernel_Config.config_HAVE_FPU_def tcbFlagToWord_def)
 
 (* end of Kernel_Config interface section *)
 

--- a/proof/crefine/ARM/Arch_C.thy
+++ b/proof/crefine/ARM/Arch_C.thy
@@ -1890,34 +1890,6 @@ lemma setMRs_single:
   apply (clarsimp simp: msgRegisters_unfold sequence_x_def)
   done
 
-(* usually when we call setMR directly, we mean to only set a single message register
-   which will fit in actual registers *)
-lemma setMR_as_setRegister_ccorres:
-  "ccorres (\<lambda>rv rv'. rv' = of_nat offset + 1) ret__unsigned_'
-      (tcb_at' thread and K (TCB_H.msgRegisters ! offset = reg \<and> offset < length msgRegisters))
-      (UNIV \<inter> \<lbrace>\<acute>reg = val\<rbrace>
-            \<inter> \<lbrace>\<acute>offset = of_nat offset\<rbrace>
-            \<inter> \<lbrace>\<acute>receiver = tcb_ptr_to_ctcb_ptr thread\<rbrace>) hs
-    (asUser thread (setRegister reg val))
-    (Call setMR_'proc)"
-  apply (rule ccorres_grab_asm)
-  apply (cinit' lift:  reg_' offset_' receiver_')
-   apply (clarsimp simp: length_msgRegisters)
-   apply (rule ccorres_cond_false)
-   apply (rule ccorres_move_const_guards)
-   apply (rule ccorres_add_return2)
-   apply (ctac add: setRegister_ccorres)
-     apply (rule ccorres_from_vcg_throws[where P'=UNIV and P=\<top>])
-     apply (rule allI, rule conseqPre, vcg)
-     apply (clarsimp simp: return_def)
-    apply (rule hoare_TrueI[of \<top>])
-   apply (vcg exspec=setRegister_modifies)
-  apply (clarsimp simp: length_msgRegisters n_msgRegisters_def not_le conj_commute)
-  apply (subst msgRegisters_ccorres[symmetric])
-   apply (clarsimp simp: n_msgRegisters_def unat_of_nat_eq)
-  apply (clarsimp simp: word_less_nat_alt word_le_nat_alt unat_of_nat_eq not_le[symmetric])
-  done
-
 lemma performPageGetAddress_ccorres:
   notes Collect_const[simp del]
   shows

--- a/proof/crefine/ARM/Retype_C.thy
+++ b/proof/crefine/ARM/Retype_C.thy
@@ -2892,7 +2892,7 @@ proof -
        tcbSchedNext_C := tcb_Ptr 0, tcbSchedPrev_C := tcb_Ptr 0,
        tcbEPNext_C := tcb_Ptr 0, tcbEPPrev_C := tcb_Ptr 0,
        tcbBoundNotification_C := ntfn_Ptr 0,
-       flags_C := 0\<rparr>"
+       tcbFlags_C := 0\<rparr>"
 
   have fbtcb: "from_bytes (replicate (size_of TYPE(tcb_C)) 0) = ?tcb"
     apply (simp add: from_bytes_def)

--- a/proof/crefine/ARM/StateRelation_C.thy
+++ b/proof/crefine/ARM/StateRelation_C.thy
@@ -351,7 +351,7 @@ where
      \<and> option_to_ptr (tcbBoundNotification atcb) = tcbBoundNotification_C ctcb
      \<and> option_to_ctcb_ptr (tcbSchedPrev atcb) = tcbSchedPrev_C ctcb
      \<and> option_to_ctcb_ptr (tcbSchedNext atcb) = tcbSchedNext_C ctcb
-     \<and> tcbFlags atcb = flags_C ctcb"
+     \<and> tcbFlags atcb = tcbFlags_C ctcb"
 
 abbreviation
   "ep_queue_relation' \<equiv> tcb_queue_relation' tcbEPNext_C tcbEPPrev_C"

--- a/proof/crefine/ARM/SyscallArgs_C.thy
+++ b/proof/crefine/ARM/SyscallArgs_C.thy
@@ -582,14 +582,6 @@ lemma no_fail_getMRs:
   apply (rule det_wp_getMRs)
   done
 
-lemma msgRegisters_ccorres:
-  "n < unat n_msgRegisters \<Longrightarrow>
-  register_from_H (ARM_H.msgRegisters ! n) = (index msgRegistersC n)"
-  apply (simp add: msgRegistersC_def msgRegisters_unfold fupdate_def)
-  apply (simp add: Arrays.update_def n_msgRegisters_def fcp_beta nth_Cons' split: if_split)
-  done
-
-
 lemma asUser_cur_obj_at':
   assumes f: "\<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>"
   shows "\<lbrace>\<lambda>s. obj_at' (\<lambda>tcb. P (atcbContextGet (tcbArch tcb))) (ksCurThread s) s \<and> t = ksCurThread s\<rbrace>

--- a/proof/crefine/ARM/TcbAcc_C.thy
+++ b/proof/crefine/ARM/TcbAcc_C.thy
@@ -225,6 +225,17 @@ lemma ccorres_pre_getObject_tcb:
   apply simp
   done
 
+lemma setMRs_single:
+  "setMRs thread buffer [val] = do
+     _ \<leftarrow> asUser thread (setRegister register.R2 val);
+     return 1
+   od"
+  apply (clarsimp simp: setMRs_def length_msgRegisters zipWithM_x_def zipWith_def split: option.splits)
+  apply (subst zip_commute, subst zip_singleton)
+   apply (simp add: length_msgRegisters size_msgRegisters_def length_0_conv[symmetric])
+  apply (clarsimp simp: msgRegisters_unfold sequence_x_def)
+  done
+
 end
 
 end

--- a/proof/crefine/ARM/Tcb_C.thy
+++ b/proof/crefine/ARM/Tcb_C.thy
@@ -4421,32 +4421,82 @@ lemma decodeSetTLSBase_ccorres:
 lemma invokeTCB_SetFlags_ccorres:
   notes hoare_weak_lift_imp [wp]
   shows
-  "ccorres (cintr \<currency> (\<lambda>rv rv'. rv = [])) (liftxf errstate id (K ()) ret__unsigned_long_')
-   (invs' and tcb_at' tcb)
-   (\<lbrace>\<acute>thread = tcb_ptr_to_ctcb_ptr tcb\<rbrace>
-    \<inter> \<lbrace>\<acute>clear = clears\<rbrace>
-    \<inter> \<lbrace>\<acute>set = sets\<rbrace>) []
-   (invokeTCB (SetFlags tcb clears sets))
-   (Call invokeSetFlags_'proc)"
-  apply (cinit lift: thread_' clear_' set_' simp: setFlags_def postSetFlags_def)
-   apply (simp add: liftE_def bind_assoc)
-   apply (rule ccorres_pre_threadGet, rename_tac flags)
-   \<comment> \<open>split off flags_' updates and threadSet\<close>
-   apply (rule ccorres_rhs_assoc2, rule ccorres_rhs_assoc2, rule ccorres_rhs_assoc2)
-   apply (rule ccorres_split_nothrow)
-       apply (rule_tac P="\<lambda>tcb. tcbFlags tcb = flags" in threadSet_ccorres_lemma2)
-        apply vcg
-       apply (clarsimp simp: tcb_at_h_t_valid[OF obj_tcb_at'])
-       apply (erule rf_sr_tcb_update_no_queue2[rotated],
-              (simp add: typ_heap_simps')+, simp_all?)[1]
-        apply (rule ball_tcb_cte_casesI, simp+)
-       apply (clarsimp simp: ctcb_relation_def)
-      apply ceqv
-     apply (rule ccorres_return_CE[folded return_returnOk]; simp)
-    apply (wpsimp simp: guard_is_UNIV_def)+
-   apply vcg
-  apply (clarsimp simp: obj_at'_def typ_heap_simps' ctcb_relation_def)
-  done
+  "ccorres dc xfdc
+     (invs' and (\<lambda>s. ksCurThread s = thread) and ct_in_state' ((=) Restart))
+     (\<lbrace>\<acute>thread = tcb_ptr_to_ctcb_ptr tcb\<rbrace> \<inter> \<lbrace>\<acute>clear = clears\<rbrace> \<inter> \<lbrace>\<acute>set = sets\<rbrace> \<inter> \<lbrace>\<acute>call = from_bool isCall\<rbrace>) []
+     (do reply \<leftarrow> invokeSetFlags tcb clears sets;
+         replyOnRestart thread [reply] isCall od)
+     (Call invokeSetFlags_'proc)"
+  apply (cinit' lift: thread_' clear_' set_' call_' simp: invokeSetFlags_def setFlags_def postSetFlags_def)
+   apply (clarsimp simp: liftE_liftE bind_bindE_assoc bindE_assoc bind_assoc simp del: Collect_const
+                 intro!: ccorres_liftE')
+   apply (rule ccorres_symb_exec_r)
+     apply (rule ccorres_pre_threadGet, rename_tac flags)
+     \<comment> \<open>split off flags_' updates and threadSet\<close>
+     apply (rule ccorres_rhs_assoc2, rule ccorres_rhs_assoc2, rule ccorres_rhs_assoc2)
+     apply (rule ccorres_split_nothrow)
+         apply (rule_tac P="\<lambda>tcb. tcbFlags tcb = flags" in threadSet_ccorres_lemma2)
+          apply vcg
+         apply (clarsimp simp: tcb_at_h_t_valid[OF obj_tcb_at'])
+         apply (erule rf_sr_tcb_update_no_queue2[rotated],
+                (simp add: typ_heap_simps')+, simp_all?)[1]
+          apply (rule ball_tcb_cte_casesI, simp+)
+         apply (clarsimp simp: ctcb_relation_def)
+        apply ceqv
+
+       apply (rule ccorres_Cond_rhs_Seq[rotated]; clarsimp)
+        apply (simp add: replyOnRestart_def liftE_def bind_assoc)
+        apply (rule getThreadState_ccorres_foo, rename_tac tstate)
+        apply (rule_tac P="tstate = Restart" in ccorres_gen_asm)
+        apply clarsimp
+        apply (ctac (no_vcg) add: setThreadState_ccorres)
+       apply (rule ccorres_rhs_assoc)+
+       apply (clarsimp simp: replyOnRestart_def liftE_def bind_assoc)
+       apply (rule getThreadState_ccorres_foo, rename_tac tstate)
+       apply (rule_tac P="tstate = Restart" in ccorres_gen_asm)
+       apply (clarsimp simp: bind_assoc)
+       apply (simp add: replyFromKernel_def bind_assoc)
+       apply (ctac add: lookupIPCBuffer_ccorres)
+         apply (ctac add: setRegister_ccorres)
+           apply (simp add: setMRs_single)
+           apply (ctac add: setMR_as_setRegister_ccorres[where offset=0])
+             apply clarsimp
+             apply csymbr
+             apply (simp only: setMessageInfo_def bind_assoc)
+             apply ctac
+               apply simp
+               apply (ctac add: setRegister_ccorres)
+                 apply (ctac add: setThreadState_ccorres)
+                apply wpsimp
+               apply (vcg exspec=setRegister_modifies)
+              apply wpsimp
+             apply clarsimp
+             apply vcg
+            apply wpsimp
+           apply (clarsimp simp: msgInfoRegister_def ARM.msgInfoRegister_def
+                                 Kernel_C.msgInfoRegister_def)
+           apply (vcg exspec=setMR_modifies)
+          apply wpsimp
+         apply clarsimp
+         apply (vcg exspec=setRegister_modifies)
+        apply wpsimp
+       apply clarsimp
+       apply (vcg exspec=lookupIPCBuffer_modifies)
+      apply (wpsimp wp: hoare_vcg_all_lift hoare_vcg_imp_lift' threadSet_pred_tcb_no_state
+                        threadSet_sch_act weak_if_wp' | strengthen invs_valid_objs')+
+     apply vcg
+    apply clarsimp
+    apply vcg
+   apply (rule conseqPre, vcg, clarsimp)
+  apply (clarsimp simp: invs_no_0_obj' tcb_at_invs' invs_valid_objs' invs_sch_act_wf'
+                        rf_sr_ksCurThread msgRegisters_unfold
+                        seL4_MessageInfo_lift_def message_info_to_H_def
+                        obj_at'_def typ_heap_simps' ctcb_relation_def)
+  by (auto dest: invs_valid_objs' elim!: valid_objsE'
+           simp: ARM.badgeRegister_def badgeRegister_def Kernel_C.badgeRegister_def
+                 fromPAddr_def ThreadState_defs C_register_defs projectKOs
+                 pred_tcb_at'_def obj_at'_def ct_in_state'_def typ_heap_simps' mask_2pm1
+                 valid_obj'_def valid_tcb'_def word_ao_dist word_bw_assocs word_bw_lcs)
 
 lemma decodeSetFlags_ccorres:
   "ccorres (intr_and_se_rel \<currency> dc) (liftxf errstate id (K ()) ret__unsigned_long_')
@@ -4456,11 +4506,12 @@ lemma decodeSetFlags_ccorres:
               and sysargs_rel args buffer)
        (\<lbrace>ccap_relation cp \<acute>cap\<rbrace>
         \<inter> \<lbrace>unat \<acute>length___unsigned_long = length args\<rbrace>
-        \<inter> \<lbrace>\<acute>buffer = option_to_ptr buffer\<rbrace>) []
+        \<inter> \<lbrace>\<acute>buffer = option_to_ptr buffer\<rbrace>
+        \<inter> \<lbrace>\<acute>call = from_bool isCall\<rbrace>) []
      (decodeSetFlags args cp
         >>= invocationCatch thread isBlocking isCall InvokeTCB)
      (Call decodeSetFlags_'proc)"
-  apply (cinit' lift: cap_' length___unsigned_long_' buffer_'
+  apply (cinit' lift: cap_' length___unsigned_long_' buffer_' call_'
                 simp: decodeSetFlags_def )
    apply csymbr+
    apply (rule ccorres_Cond_rhs_Seq)
@@ -4484,12 +4535,18 @@ lemma decodeSetFlags_ccorres:
                         bindE_assoc injection_handler_returnOk
                         ccorres_invocationCatch_Inr performInvocation_def)
        apply (ctac add: setThreadState_ccorres)
+         apply (rule ccorres_nondet_refinement)
+          apply (rule is_nondet_refinement_bindE)
+           apply (rule is_nondet_refinement_refl)
+          apply (simp split: if_split, rule conjI[rotated])
+           apply (rule impI, rule is_nondet_refinement_refl)
+          apply (rule impI, rule is_nondet_refinement_alternative1)
+         apply (clarsimp simp: invokeTCB_def liftE_bindE bind_assoc liftE_left)
+         apply (rule ccorres_add_returnOk)
+         apply (rule ccorres_liftE_Seq)
          apply (ctac (no_vcg) add: invokeTCB_SetFlags_ccorres)
-           apply simp
-           apply (rule ccorres_alternative2)
-           apply (rule ccorres_return_CE, simp+)[1]
-          apply (rule ccorres_return_C_errorE, simp+)[1]
-         apply (wpsimp wp: sts_invs_minor')+
+          apply (rule ccorres_return_CE, simp+)[1]
+         apply (wpsimp wp: sts_invs_minor' ct_in_state'_set)+
        apply (vcg exspec=setThreadState_modifies)
       apply wpsimp
      apply (vcg exspec=getSyscallArg_modifies)

--- a/proof/crefine/ARM/VSpace_C.thy
+++ b/proof/crefine/ARM/VSpace_C.thy
@@ -1713,6 +1713,41 @@ lemma setRegister_ccorres:
   apply (auto intro: typ_heap_simps elim: obj_at'_weakenE)
   done
 
+lemma msgRegisters_ccorres:
+  "n < unat n_msgRegisters \<Longrightarrow>
+  register_from_H (ARM_H.msgRegisters ! n) = (index kernel_all_substitute.msgRegisters n)"
+  apply (simp add: kernel_all_substitute.msgRegisters_def msgRegisters_unfold fupdate_def)
+  apply (simp add: Arrays.update_def n_msgRegisters_def nth_Cons' split: if_split)
+  done
+
+(* usually when we call setMR directly, we mean to only set a single message register
+   which will fit in actual registers *)
+lemma setMR_as_setRegister_ccorres:
+  "ccorres (\<lambda>rv rv'. rv' = of_nat offset + 1) ret__unsigned_'
+      (tcb_at' thread and K (TCB_H.msgRegisters ! offset = reg \<and> offset < length msgRegisters))
+      (\<lbrace>\<acute>reg___unsigned_long = val\<rbrace>
+       \<inter> \<lbrace>\<acute>offset = of_nat offset\<rbrace>
+       \<inter> \<lbrace>\<acute>receiver = tcb_ptr_to_ctcb_ptr thread\<rbrace>) hs
+    (asUser thread (setRegister reg val))
+    (Call setMR_'proc)"
+  apply (rule ccorres_grab_asm)
+  apply (cinit' lift: reg___unsigned_long_' offset_' receiver_')
+   apply (clarsimp simp: length_msgRegisters)
+   apply (rule ccorres_cond_false)
+   apply (rule ccorres_move_const_guards)
+   apply (rule ccorres_add_return2)
+   apply (ctac add: setRegister_ccorres)
+     apply (rule ccorres_from_vcg_throws[where P'=UNIV and P=\<top>])
+     apply (rule allI, rule conseqPre, vcg)
+     apply (clarsimp simp: return_def)
+    apply (rule hoare_TrueI[of \<top>])
+   apply (vcg exspec=setRegister_modifies)
+  apply (clarsimp simp: length_msgRegisters n_msgRegisters_def not_le conj_commute)
+  apply (subst msgRegisters_ccorres[symmetric])
+   apply (clarsimp simp: n_msgRegisters_def unat_of_nat_eq)
+  apply (clarsimp simp: word_less_nat_alt word_le_nat_alt unat_of_nat_eq not_le[symmetric])
+  done
+
 lemma wordFromMessageInfo_spec:
   defines "mil s \<equiv> seL4_MessageInfo_lift \<^bsup>s\<^esup>mi"
   shows "\<forall>s. \<Gamma> \<turnstile> {s} Call wordFromMessageInfo_'proc

--- a/proof/crefine/ARM/Wellformed_C.thy
+++ b/proof/crefine/ARM/Wellformed_C.thy
@@ -366,6 +366,7 @@ lemma ptr_val_tcb_ptr_mask2:
   apply (simp add: is_aligned_add_helper ctcb_offset_defs objBits_simps')
   done
 
+
 section \<open>Domains\<close>
 
 text \<open>
@@ -473,6 +474,7 @@ lemma num_tcb_queues_calculation:
   "num_tcb_queues = numDomains * numPriorities"
   unfolding num_tcb_queues_val by eval
 
+
 text \<open>maxIRQ interface\<close>
 
 (* Main lemma to use when one encounters Kernel_C.maxIRQ *)
@@ -550,7 +552,24 @@ lemma shiftr_cacheLineBits_less_mask_word_bits:
   using shiftr_less_max_mask[where n=cacheLineBits and x=x] cacheLineBits_sanity
   by (simp add: word_bits_def)
 
+
+text \<open>TCBFlags interface\<close>
+
+lemma scast_seL4_TCBFlag_simps[simp]:
+  "scast seL4_TCBFlag_NoFlag = 0"
+  "scast seL4_TCBFlag_fpuDisabled = tcbFlagToWord FpuDisabled"
+  by (clarsimp simp: seL4_TCBFlag_fpuDisabled_def seL4_TCBFlag_NoFlag_def tcbFlagToWord_def)+
+
+(* config_HAVE_FPU has to be unfolded here to match the implicit enum value from the preprocessor. *)
+lemma scast_seL4_TCBFlag_MASK_tcbFlagMask[simp]:
+  "scast seL4_TCBFlag_MASK = tcbFlagMask"
+  by (clarsimp simp: seL4_TCBFlag_MASK_def tcbFlagMask_def Kernel_Config.config_HAVE_FPU_def tcbFlagToWord_def)
+
 (* end of Kernel_Config interface section *)
+
+
+(* Input abbreviations for API object types *)
+(* disambiguates names *)
 
 abbreviation(input)
   NotificationObject :: sword32

--- a/proof/crefine/ARM_HYP/Retype_C.thy
+++ b/proof/crefine/ARM_HYP/Retype_C.thy
@@ -3393,7 +3393,7 @@ proof -
        tcbSchedNext_C := tcb_Ptr 0, tcbSchedPrev_C := tcb_Ptr 0,
        tcbEPNext_C := tcb_Ptr 0, tcbEPPrev_C := tcb_Ptr 0,
        tcbBoundNotification_C := ntfn_Ptr 0,
-       flags_C := 0\<rparr>"
+       tcbFlags_C := 0\<rparr>"
 
   have fbtcb: "from_bytes (replicate (size_of TYPE(tcb_C)) 0) = ?tcb"
     apply (simp add: from_bytes_def)

--- a/proof/crefine/ARM_HYP/StateRelation_C.thy
+++ b/proof/crefine/ARM_HYP/StateRelation_C.thy
@@ -390,7 +390,7 @@ where
      \<and> option_to_ptr (tcbBoundNotification atcb) = tcbBoundNotification_C ctcb
      \<and> option_to_ctcb_ptr (tcbSchedPrev atcb) = tcbSchedPrev_C ctcb
      \<and> option_to_ctcb_ptr (tcbSchedNext atcb) = tcbSchedNext_C ctcb
-     \<and> tcbFlags atcb = flags_C ctcb"
+     \<and> tcbFlags atcb = tcbFlags_C ctcb"
 
 abbreviation
   "ep_queue_relation' \<equiv> tcb_queue_relation' tcbEPNext_C tcbEPPrev_C"

--- a/proof/crefine/ARM_HYP/Tcb_C.thy
+++ b/proof/crefine/ARM_HYP/Tcb_C.thy
@@ -4512,32 +4512,82 @@ lemma decodeSetTLSBase_ccorres:
 lemma invokeTCB_SetFlags_ccorres:
   notes hoare_weak_lift_imp [wp]
   shows
-  "ccorres (cintr \<currency> (\<lambda>rv rv'. rv = [])) (liftxf errstate id (K ()) ret__unsigned_long_')
-   (invs' and tcb_at' tcb)
-   (\<lbrace>\<acute>thread = tcb_ptr_to_ctcb_ptr tcb\<rbrace>
-    \<inter> \<lbrace>\<acute>clear = clears\<rbrace>
-    \<inter> \<lbrace>\<acute>set = sets\<rbrace>) []
-   (invokeTCB (SetFlags tcb clears sets))
-   (Call invokeSetFlags_'proc)"
-  apply (cinit lift: thread_' clear_' set_' simp: setFlags_def postSetFlags_def)
-   apply (simp add: liftE_def bind_assoc)
-   apply (rule ccorres_pre_threadGet, rename_tac flags)
-   \<comment> \<open>split off flags_' updates and threadSet\<close>
-   apply (rule ccorres_rhs_assoc2, rule ccorres_rhs_assoc2, rule ccorres_rhs_assoc2)
-   apply (rule ccorres_split_nothrow)
-       apply (rule_tac P="\<lambda>tcb. tcbFlags tcb = flags" in threadSet_ccorres_lemma2)
-        apply vcg
-       apply (clarsimp simp: tcb_at_h_t_valid[OF obj_tcb_at'])
-       apply (erule rf_sr_tcb_update_no_queue2[rotated],
-              (simp add: typ_heap_simps')+, simp_all?)[1]
-        apply (rule ball_tcb_cte_casesI, simp+)
-       apply (clarsimp simp: ctcb_relation_def)
-      apply ceqv
-     apply (rule ccorres_return_CE[folded return_returnOk]; simp)
-    apply (wpsimp simp: guard_is_UNIV_def)+
-   apply vcg
-  apply (clarsimp simp: obj_at'_def typ_heap_simps' ctcb_relation_def)
-  done
+  "ccorres dc xfdc
+     (invs' and (\<lambda>s. ksCurThread s = thread) and ct_in_state' ((=) Restart))
+     (\<lbrace>\<acute>thread = tcb_ptr_to_ctcb_ptr tcb\<rbrace> \<inter> \<lbrace>\<acute>clear = clears\<rbrace> \<inter> \<lbrace>\<acute>set = sets\<rbrace> \<inter> \<lbrace>\<acute>call = from_bool isCall\<rbrace>) []
+     (do reply \<leftarrow> invokeSetFlags tcb clears sets;
+         replyOnRestart thread [reply] isCall od)
+     (Call invokeSetFlags_'proc)"
+  apply (cinit' lift: thread_' clear_' set_' call_' simp: invokeSetFlags_def setFlags_def postSetFlags_def)
+   apply (clarsimp simp: liftE_liftE bind_bindE_assoc bindE_assoc bind_assoc simp del: Collect_const
+                 intro!: ccorres_liftE')
+   apply (rule ccorres_symb_exec_r)
+     apply (rule ccorres_pre_threadGet, rename_tac flags)
+     \<comment> \<open>split off flags_' updates and threadSet\<close>
+     apply (rule ccorres_rhs_assoc2, rule ccorres_rhs_assoc2, rule ccorres_rhs_assoc2)
+     apply (rule ccorres_split_nothrow)
+         apply (rule_tac P="\<lambda>tcb. tcbFlags tcb = flags" in threadSet_ccorres_lemma2)
+          apply vcg
+         apply (clarsimp simp: tcb_at_h_t_valid[OF obj_tcb_at'])
+         apply (erule rf_sr_tcb_update_no_queue2[rotated],
+                (simp add: typ_heap_simps')+, simp_all?)[1]
+          apply (rule ball_tcb_cte_casesI, simp+)
+         apply (clarsimp simp: ctcb_relation_def)
+        apply ceqv
+
+       apply (rule ccorres_Cond_rhs_Seq[rotated]; clarsimp)
+        apply (simp add: replyOnRestart_def liftE_def bind_assoc)
+        apply (rule getThreadState_ccorres_foo, rename_tac tstate)
+        apply (rule_tac P="tstate = Restart" in ccorres_gen_asm)
+        apply clarsimp
+        apply (ctac (no_vcg) add: setThreadState_ccorres)
+       apply (rule ccorres_rhs_assoc)+
+       apply (clarsimp simp: replyOnRestart_def liftE_def bind_assoc)
+       apply (rule getThreadState_ccorres_foo, rename_tac tstate)
+       apply (rule_tac P="tstate = Restart" in ccorres_gen_asm)
+       apply (clarsimp simp: bind_assoc)
+       apply (simp add: replyFromKernel_def bind_assoc)
+       apply (ctac add: lookupIPCBuffer_ccorres)
+         apply (ctac add: setRegister_ccorres)
+           apply (simp add: setMRs_single)
+           apply (ctac add: setMR_as_setRegister_ccorres[where offset=0])
+             apply clarsimp
+             apply csymbr
+             apply (simp only: setMessageInfo_def bind_assoc)
+             apply ctac
+               apply simp
+               apply (ctac add: setRegister_ccorres)
+                 apply (ctac add: setThreadState_ccorres)
+                apply wpsimp
+               apply (vcg exspec=setRegister_modifies)
+              apply wpsimp
+             apply clarsimp
+             apply vcg
+            apply wpsimp
+           apply (clarsimp simp: msgInfoRegister_def ARM_HYP.msgInfoRegister_def
+                                 Kernel_C.msgInfoRegister_def)
+           apply (vcg exspec=setMR_modifies)
+          apply wpsimp
+         apply clarsimp
+         apply (vcg exspec=setRegister_modifies)
+        apply wpsimp
+       apply clarsimp
+       apply (vcg exspec=lookupIPCBuffer_modifies)
+      apply (wpsimp wp: hoare_vcg_all_lift hoare_vcg_imp_lift' threadSet_pred_tcb_no_state
+                        threadSet_sch_act weak_if_wp' | strengthen invs_valid_objs')+
+     apply vcg
+    apply clarsimp
+    apply vcg
+   apply (rule conseqPre, vcg, clarsimp)
+  apply (clarsimp simp: invs_no_0_obj' tcb_at_invs' invs_valid_objs' invs_sch_act_wf'
+                        rf_sr_ksCurThread msgRegisters_unfold
+                        seL4_MessageInfo_lift_def message_info_to_H_def
+                        obj_at'_def typ_heap_simps' ctcb_relation_def)
+  by (auto dest: invs_valid_objs' elim!: valid_objsE'
+           simp: ARM_HYP.badgeRegister_def badgeRegister_def Kernel_C.badgeRegister_def
+                 fromPAddr_def ThreadState_defs C_register_defs projectKOs
+                 pred_tcb_at'_def obj_at'_def ct_in_state'_def typ_heap_simps' mask_2pm1
+                 valid_obj'_def valid_tcb'_def word_ao_dist word_bw_assocs word_bw_lcs)
 
 lemma decodeSetFlags_ccorres:
   "ccorres (intr_and_se_rel \<currency> dc) (liftxf errstate id (K ()) ret__unsigned_long_')
@@ -4547,11 +4597,12 @@ lemma decodeSetFlags_ccorres:
               and sysargs_rel args buffer)
        (\<lbrace>ccap_relation cp \<acute>cap\<rbrace>
         \<inter> \<lbrace>unat \<acute>length___unsigned_long = length args\<rbrace>
-        \<inter> \<lbrace>\<acute>buffer = option_to_ptr buffer\<rbrace>) []
+        \<inter> \<lbrace>\<acute>buffer = option_to_ptr buffer\<rbrace>
+        \<inter> \<lbrace>\<acute>call = from_bool isCall\<rbrace>) []
      (decodeSetFlags args cp
         >>= invocationCatch thread isBlocking isCall InvokeTCB)
      (Call decodeSetFlags_'proc)"
-  apply (cinit' lift: cap_' length___unsigned_long_' buffer_'
+  apply (cinit' lift: cap_' length___unsigned_long_' buffer_' call_'
                 simp: decodeSetFlags_def )
    apply csymbr+
    apply (rule ccorres_Cond_rhs_Seq)
@@ -4575,12 +4626,18 @@ lemma decodeSetFlags_ccorres:
                         bindE_assoc injection_handler_returnOk
                         ccorres_invocationCatch_Inr performInvocation_def)
        apply (ctac add: setThreadState_ccorres)
+         apply (rule ccorres_nondet_refinement)
+          apply (rule is_nondet_refinement_bindE)
+           apply (rule is_nondet_refinement_refl)
+          apply (simp split: if_split, rule conjI[rotated])
+           apply (rule impI, rule is_nondet_refinement_refl)
+          apply (rule impI, rule is_nondet_refinement_alternative1)
+         apply (clarsimp simp: invokeTCB_def liftE_bindE bind_assoc liftE_left)
+         apply (rule ccorres_add_returnOk)
+         apply (rule ccorres_liftE_Seq)
          apply (ctac (no_vcg) add: invokeTCB_SetFlags_ccorres)
-           apply simp
-           apply (rule ccorres_alternative2)
-           apply (rule ccorres_return_CE, simp+)[1]
-          apply (rule ccorres_return_C_errorE, simp+)[1]
-         apply (wpsimp wp: sts_invs_minor')+
+          apply (rule ccorres_return_CE, simp+)[1]
+         apply (wpsimp wp: sts_invs_minor' ct_in_state'_set)+
        apply (vcg exspec=setThreadState_modifies)
       apply wpsimp
      apply (vcg exspec=getSyscallArg_modifies)

--- a/proof/crefine/ARM_HYP/VSpace_C.thy
+++ b/proof/crefine/ARM_HYP/VSpace_C.thy
@@ -2838,19 +2838,19 @@ lemma msgRegisters_ccorres:
   apply (simp add: Arrays.update_def n_msgRegisters_def fcp_beta nth_Cons' split: if_split)
   done
 
-(* usually when we call setMR directly, we mean to only set a registers, which will
-   fit in actual registers *)
+(* usually when we call setMR directly, we mean to only set a single message register
+   which will fit in actual registers *)
 lemma setMR_as_setRegister_ccorres:
   "ccorres (\<lambda>rv rv'. rv' = of_nat offset + 1) ret__unsigned_'
       (tcb_at' thread and K (TCB_H.msgRegisters ! offset = reg \<and> offset < length msgRegisters))
-      (UNIV \<inter> \<lbrace>\<acute>reg = val\<rbrace>
-            \<inter> \<lbrace>\<acute>offset = of_nat offset\<rbrace>
-            \<inter> \<lbrace>\<acute>receiver = tcb_ptr_to_ctcb_ptr thread\<rbrace>) hs
+      (\<lbrace>\<acute>reg___unsigned_long = val\<rbrace>
+       \<inter> \<lbrace>\<acute>offset = of_nat offset\<rbrace>
+       \<inter> \<lbrace>\<acute>receiver = tcb_ptr_to_ctcb_ptr thread\<rbrace>) hs
     (asUser thread (setRegister reg val))
     (Call setMR_'proc)"
   apply (rule ccorres_grab_asm)
-  apply (cinit' lift:  reg_' offset_' receiver_')
-   apply (clarsimp simp: n_msgRegisters_def length_of_msgRegisters)
+  apply (cinit' lift: reg___unsigned_long_' offset_' receiver_')
+   apply (clarsimp simp: length_msgRegisters)
    apply (rule ccorres_cond_false)
    apply (rule ccorres_move_const_guards)
    apply (rule ccorres_add_return2)
@@ -2860,9 +2860,9 @@ lemma setMR_as_setRegister_ccorres:
      apply (clarsimp simp: return_def)
     apply (rule hoare_TrueI[of \<top>])
    apply (vcg exspec=setRegister_modifies)
-  apply (clarsimp simp: n_msgRegisters_def length_of_msgRegisters not_le conj_commute)
+  apply (clarsimp simp: length_msgRegisters n_msgRegisters_def not_le conj_commute)
   apply (subst msgRegisters_ccorres[symmetric])
-   apply (clarsimp simp: n_msgRegisters_def length_of_msgRegisters unat_of_nat_eq)
+   apply (clarsimp simp: n_msgRegisters_def unat_of_nat_eq)
   apply (clarsimp simp: word_less_nat_alt word_le_nat_alt unat_of_nat_eq not_le[symmetric])
   done
 

--- a/proof/crefine/ARM_HYP/Wellformed_C.thy
+++ b/proof/crefine/ARM_HYP/Wellformed_C.thy
@@ -401,6 +401,7 @@ lemma ptr_val_tcb_ptr_mask2:
   apply (simp add: is_aligned_add_helper ctcb_offset_defs objBits_simps')
   done
 
+
 section \<open>Domains\<close>
 
 text \<open>
@@ -507,6 +508,7 @@ value_type num_tcb_queues = "numDomains * numPriorities"
 lemma num_tcb_queues_calculation:
   "num_tcb_queues = numDomains * numPriorities"
   unfolding num_tcb_queues_val by eval
+
 
 text \<open>maxIRQ interface\<close>
 
@@ -620,6 +622,19 @@ schematic_goal hcrVCPU_val:
   "hcrVCPU = ?val"
   by (simp add: hcrVCPU_def hcrCommon_def hcrTWE_def hcrTWI_def
                 Kernel_Config.config_DISABLE_WFI_WFE_TRAPS_def)
+
+
+text \<open>TCBFlags interface\<close>
+
+lemma scast_seL4_TCBFlag_simps[simp]:
+  "scast seL4_TCBFlag_NoFlag = 0"
+  "scast seL4_TCBFlag_fpuDisabled = tcbFlagToWord FpuDisabled"
+  by (clarsimp simp: seL4_TCBFlag_fpuDisabled_def seL4_TCBFlag_NoFlag_def tcbFlagToWord_def)+
+
+(* config_HAVE_FPU has to be unfolded here to match the implicit enum value from the preprocessor. *)
+lemma scast_seL4_TCBFlag_MASK_tcbFlagMask[simp]:
+  "scast seL4_TCBFlag_MASK = tcbFlagMask"
+  by (clarsimp simp: seL4_TCBFlag_MASK_def tcbFlagMask_def Kernel_Config.config_HAVE_FPU_def tcbFlagToWord_def)
 
 (* end of Kernel_Config interface section *)
 

--- a/proof/crefine/RISCV64/Retype_C.thy
+++ b/proof/crefine/RISCV64/Retype_C.thy
@@ -3291,7 +3291,7 @@ proof -
        tcbSchedNext_C := tcb_Ptr 0, tcbSchedPrev_C := tcb_Ptr 0,
        tcbEPNext_C := tcb_Ptr 0, tcbEPPrev_C := tcb_Ptr 0,
        tcbBoundNotification_C := ntfn_Ptr 0,
-       flags_C := 0\<rparr>"
+       tcbFlags_C := 0\<rparr>"
 
   have fbtcb: "from_bytes (replicate (size_of TYPE(tcb_C)) 0) = ?tcb"
     apply (simp add: from_bytes_def)

--- a/proof/crefine/RISCV64/StateRelation_C.thy
+++ b/proof/crefine/RISCV64/StateRelation_C.thy
@@ -364,7 +364,7 @@ where
      \<and> option_to_ptr (tcbBoundNotification atcb) = tcbBoundNotification_C ctcb
      \<and> option_to_ctcb_ptr (tcbSchedPrev atcb) = tcbSchedPrev_C ctcb
      \<and> option_to_ctcb_ptr (tcbSchedNext atcb) = tcbSchedNext_C ctcb
-     \<and> tcbFlags atcb = flags_C ctcb"
+     \<and> tcbFlags atcb = tcbFlags_C ctcb"
 
 abbreviation
   "ep_queue_relation' \<equiv> tcb_queue_relation' tcbEPNext_C tcbEPPrev_C"

--- a/proof/crefine/RISCV64/VSpace_C.thy
+++ b/proof/crefine/RISCV64/VSpace_C.thy
@@ -1032,19 +1032,19 @@ lemma msgRegisters_ccorres:
   apply (simp add: Arrays.update_def n_msgRegisters_def nth_Cons' split: if_split)
   done
 
-(* usually when we call setMR directly, we mean to only set a registers, which will
-   fit in actual registers *)
+(* usually when we call setMR directly, we mean to only set a single message register
+   which will fit in actual registers *)
 lemma setMR_as_setRegister_ccorres:
   "ccorres (\<lambda>rv rv'. rv' = of_nat offset + 1) ret__unsigned_'
       (tcb_at' thread and K (TCB_H.msgRegisters ! offset = reg \<and> offset < length msgRegisters))
-      (UNIV \<inter> \<lbrace>\<acute>reg___unsigned_long = val\<rbrace>
-            \<inter> \<lbrace>\<acute>offset = of_nat offset\<rbrace>
-            \<inter> \<lbrace>\<acute>receiver = tcb_ptr_to_ctcb_ptr thread\<rbrace>) hs
+      (\<lbrace>\<acute>reg___unsigned_long = val\<rbrace>
+       \<inter> \<lbrace>\<acute>offset = of_nat offset\<rbrace>
+       \<inter> \<lbrace>\<acute>receiver = tcb_ptr_to_ctcb_ptr thread\<rbrace>) hs
     (asUser thread (setRegister reg val))
     (Call setMR_'proc)"
   apply (rule ccorres_grab_asm)
-  apply (cinit' lift:  reg___unsigned_long_' offset_' receiver_')
-   apply (clarsimp simp: n_msgRegisters_def length_of_msgRegisters)
+  apply (cinit' lift: reg___unsigned_long_' offset_' receiver_')
+   apply (clarsimp simp: length_msgRegisters)
    apply (rule ccorres_cond_false)
    apply (rule ccorres_move_const_guards)
    apply (rule ccorres_add_return2)
@@ -1054,9 +1054,9 @@ lemma setMR_as_setRegister_ccorres:
      apply (clarsimp simp: return_def)
     apply (rule hoare_TrueI[of \<top>])
    apply (vcg exspec=setRegister_modifies)
-  apply (clarsimp simp: n_msgRegisters_def length_of_msgRegisters not_le conj_commute)
+  apply (clarsimp simp: length_msgRegisters n_msgRegisters_def not_le conj_commute)
   apply (subst msgRegisters_ccorres[symmetric])
-   apply (clarsimp simp: n_msgRegisters_def length_of_msgRegisters unat_of_nat_eq)
+   apply (clarsimp simp: n_msgRegisters_def unat_of_nat_eq)
   apply (clarsimp simp: word_less_nat_alt word_le_nat_alt unat_of_nat_eq not_le[symmetric])
   done
 

--- a/proof/crefine/RISCV64/Wellformed_C.thy
+++ b/proof/crefine/RISCV64/Wellformed_C.thy
@@ -369,6 +369,7 @@ lemma ptr_val_tcb_ptr_mask2:
   apply (simp add: is_aligned_add_helper ctcb_offset_defs objBits_simps')
   done
 
+
 section \<open>Domains\<close>
 
 text \<open>
@@ -476,12 +477,29 @@ lemma num_tcb_queues_calculation:
   "num_tcb_queues = numDomains * numPriorities"
   unfolding num_tcb_queues_val by eval
 
+
 text \<open>maxIRQ interface\<close>
 
 declare Kernel_C.maxIRQ_def[code]
 
 (* FIXME: compute maxIRQ for kernel config instead *)
 value_type irq_array_size = "Suc (unat Kernel_C.maxIRQ)"
+
+
+text \<open>TCBFlags interface\<close>
+
+lemma scast_seL4_TCBFlag_simps[simp]:
+  "scast seL4_TCBFlag_NoFlag = 0"
+  "scast seL4_TCBFlag_fpuDisabled = tcbFlagToWord FpuDisabled"
+  by (clarsimp simp: seL4_TCBFlag_fpuDisabled_def seL4_TCBFlag_NoFlag_def tcbFlagToWord_def)+
+
+(* config_HAVE_FPU has to be unfolded here to match the implicit enum value from the preprocessor. *)
+lemma scast_seL4_TCBFlag_MASK_tcbFlagMask[simp]:
+  "scast seL4_TCBFlag_MASK = tcbFlagMask"
+  by (clarsimp simp: seL4_TCBFlag_MASK_def tcbFlagMask_def Kernel_Config.config_HAVE_FPU_def tcbFlagToWord_def)
+
+ (* end of Kernel_Config interface section *)
+
 
 (* Input abbreviations for API object types *)
 (* disambiguates names *)

--- a/proof/crefine/X64/Retype_C.thy
+++ b/proof/crefine/X64/Retype_C.thy
@@ -3875,7 +3875,7 @@ proof -
        tcbSchedNext_C := tcb_Ptr 0, tcbSchedPrev_C := tcb_Ptr 0,
        tcbEPNext_C := tcb_Ptr 0, tcbEPPrev_C := tcb_Ptr 0,
        tcbBoundNotification_C := ntfn_Ptr 0,
-       tcb_C.flags_C := 0\<rparr>"
+       tcbFlags_C := 0\<rparr>"
 
   have fbtcb: "from_bytes (replicate (size_of TYPE(tcb_C)) 0) = ?tcb"
     apply (simp add: from_bytes_def)

--- a/proof/crefine/X64/StateRelation_C.thy
+++ b/proof/crefine/X64/StateRelation_C.thy
@@ -448,7 +448,7 @@ where
      \<and> option_to_ptr (tcbBoundNotification atcb) = tcbBoundNotification_C ctcb
      \<and> option_to_ctcb_ptr (tcbSchedPrev atcb) = tcbSchedPrev_C ctcb
      \<and> option_to_ctcb_ptr (tcbSchedNext atcb) = tcbSchedNext_C ctcb
-     \<and> tcbFlags atcb = tcb_C.flags_C ctcb"
+     \<and> tcbFlags atcb = tcbFlags_C ctcb"
 
 abbreviation
   "ep_queue_relation' \<equiv> tcb_queue_relation' tcbEPNext_C tcbEPPrev_C"

--- a/proof/crefine/X64/Tcb_C.thy
+++ b/proof/crefine/X64/Tcb_C.thy
@@ -4509,8 +4509,8 @@ lemma decodeSetTLSBase_ccorres:
   done
 
 lemma scast_seL4_TCBFlag_fpuDisabled[simp]:
-  "scast seL4_TCBFlag_fpuDisabled = tcbFlagToWord (ArchFlag FpuDisabled)"
-  by (clarsimp simp: seL4_TCBFlag_fpuDisabled_def tcbFlagToWord_def archTcbFlagToWord_def)
+  "scast seL4_TCBFlag_fpuDisabled = tcbFlagToWord FpuDisabled"
+  by (clarsimp simp: seL4_TCBFlag_fpuDisabled_def tcbFlagToWord_def)
 
 lemma invokeTCB_SetFlags_ccorres:
   notes hoare_weak_lift_imp [wp]

--- a/proof/crefine/X64/Tcb_C.thy
+++ b/proof/crefine/X64/Tcb_C.thy
@@ -4508,43 +4508,93 @@ lemma decodeSetTLSBase_ccorres:
   apply (auto simp: unat_eq_0 le_max_word_ucast_id)+
   done
 
-lemma scast_seL4_TCBFlag_fpuDisabled[simp]:
-  "scast seL4_TCBFlag_fpuDisabled = tcbFlagToWord FpuDisabled"
-  by (clarsimp simp: seL4_TCBFlag_fpuDisabled_def tcbFlagToWord_def)
-
 lemma invokeTCB_SetFlags_ccorres:
   notes hoare_weak_lift_imp [wp]
   shows
-  "ccorres (cintr \<currency> (\<lambda>rv rv'. rv = [])) (liftxf errstate id (K ()) ret__unsigned_long_')
-           (invs' and tcb_at' tcb)
-           (\<lbrace>\<acute>thread = tcb_ptr_to_ctcb_ptr tcb\<rbrace>
-            \<inter> \<lbrace>\<acute>clear = clears\<rbrace>
-            \<inter> \<lbrace>\<acute>set = sets\<rbrace>) []
-           (invokeTCB (SetFlags tcb clears sets))
-           (Call invokeSetFlags_'proc)"
-  apply (cinit lift: thread_' clear_' set_' simp: setFlags_def postSetFlags_def)
-   apply (simp add: liftE_def bind_assoc)
-   apply (rule ccorres_pre_threadGet, rename_tac flags)
-   \<comment> \<open>split off flags_' updates and threadSet\<close>
-   apply (rule ccorres_rhs_assoc2, rule ccorres_rhs_assoc2, rule ccorres_rhs_assoc2)
-   apply (rule ccorres_split_nothrow)
-       apply (rule_tac P="\<lambda>tcb. tcbFlags tcb = flags" in threadSet_ccorres_lemma2)
-        apply vcg
-       apply (clarsimp simp: tcb_at_h_t_valid[OF obj_tcb_at'])
-       apply (erule rf_sr_tcb_update_no_queue2[rotated],
-              (simp add: typ_heap_simps')+, simp_all?)[1]
-        apply (rule ball_tcb_cte_casesI, simp+)
-       apply (clarsimp simp: ctcb_relation_def)
-      apply ceqv
-     apply (rule ccorres_split_nothrow_novcg_dc)
-        apply (rule_tac R=\<top> and R'="{s. flags_' s = flags && ~~ clears || sets}" in ccorres_when_strong)
-         apply (clarsimp simp: isFlagSet_def word_bw_comms)
-        apply (ctac add: fpuRelease_ccorres)
-       apply (rule ccorres_return_CE[folded return_returnOk]; simp)
-      apply (wpsimp simp: guard_is_UNIV_def)+
-   apply vcg
-  apply (clarsimp simp: obj_at'_def typ_heap_simps' ctcb_relation_def)
-  done
+  "ccorres dc xfdc
+     (invs' and (\<lambda>s. ksCurThread s = thread) and ct_in_state' ((=) Restart))
+     (\<lbrace>\<acute>thread = tcb_ptr_to_ctcb_ptr tcb\<rbrace> \<inter> \<lbrace>\<acute>clear = clears\<rbrace> \<inter> \<lbrace>\<acute>set = sets\<rbrace> \<inter> \<lbrace>\<acute>call = from_bool isCall\<rbrace>) []
+     (do reply \<leftarrow> invokeSetFlags tcb clears sets;
+         replyOnRestart thread [reply] isCall od)
+     (Call invokeSetFlags_'proc)"
+  apply (cinit' lift: thread_' clear_' set_' call_' simp: invokeSetFlags_def setFlags_def postSetFlags_def)
+   apply (clarsimp simp: liftE_liftE bind_bindE_assoc bindE_assoc bind_assoc simp del: Collect_const
+                 intro!: ccorres_liftE')
+   apply (rule ccorres_symb_exec_r)
+     apply (rule ccorres_pre_threadGet, rename_tac flags)
+     \<comment> \<open>split off flags_' updates and threadSet\<close>
+     apply (rule ccorres_rhs_assoc2, rule ccorres_rhs_assoc2, rule ccorres_rhs_assoc2)
+     apply (rule ccorres_split_nothrow)
+         apply (rule_tac P="\<lambda>tcb. tcbFlags tcb = flags" in threadSet_ccorres_lemma2)
+          apply vcg
+         apply (clarsimp simp: tcb_at_h_t_valid[OF obj_tcb_at'])
+         apply (erule rf_sr_tcb_update_no_queue2[rotated],
+                (simp add: typ_heap_simps')+, simp_all?)[1]
+          apply (rule ball_tcb_cte_casesI, simp+)
+         apply (clarsimp simp: ctcb_relation_def)
+        apply ceqv
+       apply (rule ccorres_split_nothrow_dc)
+          apply (rule_tac R=\<top> and R'="\<lbrace>\<acute>flags = flags && ~~ clears || sets && tcbFlagMask\<rbrace>"
+                       in ccorres_when_strong)
+           apply (clarsimp simp: isFlagSet_def word_bw_comms)
+          apply (ctac add: fpuRelease_ccorres)
+
+         apply (rule ccorres_Cond_rhs_Seq[rotated]; clarsimp)
+          apply (simp add: replyOnRestart_def liftE_def bind_assoc)
+          apply (rule getThreadState_ccorres_foo, rename_tac tstate)
+          apply (rule_tac P="tstate = Restart" in ccorres_gen_asm)
+          apply clarsimp
+          apply (ctac (no_vcg) add: setThreadState_ccorres)
+         apply (rule ccorres_rhs_assoc)+
+         apply (clarsimp simp: replyOnRestart_def liftE_def bind_assoc)
+         apply (rule getThreadState_ccorres_foo, rename_tac tstate)
+         apply (rule_tac P="tstate = Restart" in ccorres_gen_asm)
+         apply (clarsimp simp: bind_assoc)
+         apply (simp add: replyFromKernel_def bind_assoc)
+         apply (ctac add: lookupIPCBuffer_ccorres)
+           apply (ctac add: setRegister_ccorres)
+             apply (simp add: setMRs_single)
+             apply (ctac add: setMR_as_setRegister_ccorres[where offset=0])
+               apply clarsimp
+               apply csymbr
+               apply (simp only: setMessageInfo_def bind_assoc)
+               apply ctac
+                 apply simp
+                 apply (ctac add: setRegister_ccorres)
+                   apply (ctac add: setThreadState_ccorres)
+                  apply wpsimp
+                 apply (vcg exspec=setRegister_modifies)
+                apply wpsimp
+               apply clarsimp
+               apply vcg
+              apply wpsimp
+             apply (clarsimp simp: msgInfoRegister_def X64.msgInfoRegister_def
+                                   Kernel_C.msgInfoRegister_def)
+             apply (vcg exspec=setMR_modifies)
+            apply wpsimp
+           apply clarsimp
+           apply (vcg exspec=setRegister_modifies)
+          apply wpsimp
+         apply clarsimp
+         apply (vcg exspec=lookupIPCBuffer_modifies)
+        apply (wpsimp wp: hoare_vcg_all_lift hoare_vcg_imp_lift')
+       apply clarsimp
+       apply (vcg exspec=fpuRelease_modifies)
+      apply (wpsimp wp: hoare_vcg_all_lift hoare_vcg_imp_lift' threadSet_pred_tcb_no_state
+                        threadSet_sch_act weak_if_wp' | strengthen invs_valid_objs')+
+     apply vcg
+    apply clarsimp
+    apply vcg
+   apply (rule conseqPre, vcg, clarsimp)
+  apply (clarsimp simp: invs_no_0_obj' tcb_at_invs' invs_valid_objs' invs_sch_act_wf'
+                        rf_sr_ksCurThread msgRegisters_unfold
+                        seL4_MessageInfo_lift_def message_info_to_H_def
+                        obj_at'_def typ_heap_simps' ctcb_relation_def)
+  by (auto dest: invs_valid_objs' elim!: valid_objsE'
+           simp: X64.badgeRegister_def badgeRegister_def Kernel_C.badgeRegister_def X64.capRegister_def
+                 fromPAddr_def ThreadState_defs C_register_defs projectKOs
+                 pred_tcb_at'_def obj_at'_def ct_in_state'_def typ_heap_simps' mask_2pm1
+                 valid_obj'_def valid_tcb'_def word_ao_dist word_bw_assocs word_bw_lcs)
 
 lemma decodeSetFlags_ccorres:
   "ccorres (intr_and_se_rel \<currency> dc) (liftxf errstate id (K ()) ret__unsigned_long_')
@@ -4554,11 +4604,12 @@ lemma decodeSetFlags_ccorres:
               and sysargs_rel args buffer)
        (\<lbrace>ccap_relation cp \<acute>cap\<rbrace>
         \<inter> \<lbrace>unat \<acute>length___unsigned_long = length args\<rbrace>
-        \<inter> \<lbrace>\<acute>buffer = option_to_ptr buffer\<rbrace>) []
+        \<inter> \<lbrace>\<acute>buffer = option_to_ptr buffer\<rbrace>
+        \<inter> \<lbrace>\<acute>call = from_bool isCall\<rbrace>) []
      (decodeSetFlags args cp
         >>= invocationCatch thread isBlocking isCall InvokeTCB)
      (Call decodeSetFlags_'proc)"
-  apply (cinit' lift: cap_' length___unsigned_long_' buffer_'
+  apply (cinit' lift: cap_' length___unsigned_long_' buffer_' call_'
                 simp: decodeSetFlags_def )
    apply csymbr+
    apply (rule ccorres_Cond_rhs_Seq)
@@ -4582,12 +4633,18 @@ lemma decodeSetFlags_ccorres:
                         bindE_assoc injection_handler_returnOk
                         ccorres_invocationCatch_Inr performInvocation_def)
        apply (ctac add: setThreadState_ccorres)
+         apply (rule ccorres_nondet_refinement)
+          apply (rule is_nondet_refinement_bindE)
+           apply (rule is_nondet_refinement_refl)
+          apply (simp split: if_split, rule conjI[rotated])
+           apply (rule impI, rule is_nondet_refinement_refl)
+          apply (rule impI, rule is_nondet_refinement_alternative1)
+         apply (clarsimp simp: invokeTCB_def liftE_bindE bind_assoc liftE_left)
+         apply (rule ccorres_add_returnOk)
+         apply (rule ccorres_liftE_Seq)
          apply (ctac (no_vcg) add: invokeTCB_SetFlags_ccorres)
-           apply simp
-           apply (rule ccorres_alternative2)
-           apply (rule ccorres_return_CE, simp+)[1]
-          apply (rule ccorres_return_C_errorE, simp+)[1]
-         apply (wpsimp wp: sts_invs_minor')+
+          apply (rule ccorres_return_CE, simp+)[1]
+         apply (wpsimp wp: sts_invs_minor' ct_in_state'_set)+
        apply (vcg exspec=setThreadState_modifies)
       apply wpsimp
      apply (vcg exspec=getSyscallArg_modifies)

--- a/proof/crefine/X64/VSpace_C.thy
+++ b/proof/crefine/X64/VSpace_C.thy
@@ -1358,19 +1358,19 @@ lemma msgRegisters_ccorres:
   apply (simp add: Arrays.update_def n_msgRegisters_def fcp_beta nth_Cons' split: if_split)
   done
 
-(* usually when we call setMR directly, we mean to only set a registers, which will
-   fit in actual registers *)
+(* usually when we call setMR directly, we mean to only set a single message register
+   which will fit in actual registers *)
 lemma setMR_as_setRegister_ccorres:
   "ccorres (\<lambda>rv rv'. rv' = of_nat offset + 1) ret__unsigned_'
       (tcb_at' thread and K (TCB_H.msgRegisters ! offset = reg \<and> offset < length msgRegisters))
-      (UNIV \<inter> \<lbrace>\<acute>reg___unsigned_long = val\<rbrace>
-            \<inter> \<lbrace>\<acute>offset = of_nat offset\<rbrace>
-            \<inter> \<lbrace>\<acute>receiver = tcb_ptr_to_ctcb_ptr thread\<rbrace>) hs
+      (\<lbrace>\<acute>reg___unsigned_long = val\<rbrace>
+       \<inter> \<lbrace>\<acute>offset = of_nat offset\<rbrace>
+       \<inter> \<lbrace>\<acute>receiver = tcb_ptr_to_ctcb_ptr thread\<rbrace>) hs
     (asUser thread (setRegister reg val))
     (Call setMR_'proc)"
   apply (rule ccorres_grab_asm)
-  apply (cinit' lift:  reg___unsigned_long_' offset_' receiver_')
-   apply (clarsimp simp: n_msgRegisters_def length_of_msgRegisters)
+  apply (cinit' lift: reg___unsigned_long_' offset_' receiver_')
+   apply (clarsimp simp: length_msgRegisters)
    apply (rule ccorres_cond_false)
    apply (rule ccorres_move_const_guards)
    apply (rule ccorres_add_return2)
@@ -1380,9 +1380,9 @@ lemma setMR_as_setRegister_ccorres:
      apply (clarsimp simp: return_def)
     apply (rule hoare_TrueI[of \<top>])
    apply (vcg exspec=setRegister_modifies)
-  apply (clarsimp simp: n_msgRegisters_def length_of_msgRegisters not_le conj_commute)
+  apply (clarsimp simp: length_msgRegisters n_msgRegisters_def not_le conj_commute)
   apply (subst msgRegisters_ccorres[symmetric])
-   apply (clarsimp simp: n_msgRegisters_def length_of_msgRegisters unat_of_nat_eq)
+   apply (clarsimp simp: n_msgRegisters_def unat_of_nat_eq)
   apply (clarsimp simp: word_less_nat_alt word_le_nat_alt unat_of_nat_eq not_le[symmetric])
   done
 

--- a/proof/crefine/X64/Wellformed_C.thy
+++ b/proof/crefine/X64/Wellformed_C.thy
@@ -412,6 +412,7 @@ lemma ptr_val_tcb_ptr_mask2:
   apply (simp add: is_aligned_add_helper ctcb_offset_defs objBits_simps')
   done
 
+
 section \<open>Domains\<close>
 
 text \<open>
@@ -519,12 +520,29 @@ lemma num_tcb_queues_calculation:
   "num_tcb_queues = numDomains * numPriorities"
   unfolding num_tcb_queues_val by eval
 
+
 text \<open>maxIRQ interface\<close>
 
 declare Kernel_C.maxIRQ_def[code]
 
 (* FIXME: would be more uniform to have a maxIRQ in Kernel_Config for X64 as well *)
 value_type irq_array_size = "Suc (unat Kernel_C.maxIRQ)"
+
+
+text \<open>TCBFlags interface\<close>
+
+lemma scast_seL4_TCBFlag_simps[simp]:
+  "scast seL4_TCBFlag_NoFlag = 0"
+  "scast seL4_TCBFlag_fpuDisabled = tcbFlagToWord FpuDisabled"
+  by (clarsimp simp: seL4_TCBFlag_fpuDisabled_def seL4_TCBFlag_NoFlag_def tcbFlagToWord_def)+
+
+(* config_HAVE_FPU has to be unfolded here to match the implicit enum value from the preprocessor. *)
+lemma scast_seL4_TCBFlag_MASK_tcbFlagMask[simp]:
+  "scast seL4_TCBFlag_MASK = tcbFlagMask"
+  by (clarsimp simp: seL4_TCBFlag_MASK_def tcbFlagMask_def Kernel_Config.config_HAVE_FPU_def tcbFlagToWord_def)
+
+(* end of Kernel_Config interface section *)
+
 
 (* Input abbreviations for API object types *)
 (* disambiguates names *)

--- a/proof/refine/AARCH64/IpcCancel_R.thy
+++ b/proof/refine/AARCH64/IpcCancel_R.thy
@@ -2369,6 +2369,11 @@ lemma archThreadGet_wp:
   unfolding archThreadGet_def
   by (wpsimp wp: getObject_tcb_wp simp: obj_at'_def)
 
+crunch fpuRelease
+  for st_tcb_at'[wp]: "\<lambda>s. Q (st_tcb_at' P t s)"
+  and valid_objs'[wp]: valid_objs'
+  and sch_act_wf[wp]: "\<lambda>s. sch_act_wf (ksSchedulerAction s) s"
+
 crunch prepareThreadDelete
   for unqueued: "obj_at' (Not \<circ> tcbQueued) t"
   and inactive: "st_tcb_at' ((=) Inactive) t'"

--- a/proof/refine/AARCH64/Retype_R.thy
+++ b/proof/refine/AARCH64/Retype_R.thy
@@ -107,13 +107,13 @@ lemma valid_obj_makeObject_cte [simp]:
 
 lemma valid_obj_makeObject_tcb [simp]:
   "valid_obj' (KOTCB makeObject) s"
-  unfolding valid_obj'_def valid_tcb'_def  valid_tcb_state'_def valid_arch_tcb'_def
+  unfolding valid_obj'_def valid_tcb'_def valid_tcb_state'_def valid_arch_tcb'_def
   by (clarsimp simp: makeObject_tcb makeObject_cte tcb_cte_cases_def minBound_word newArchTCB_def
                      cteSizeBits_def)
 
 lemma valid_obj_makeObject_tcb_tcbDomain_update [simp]:
   "d \<le> maxDomain \<Longrightarrow> valid_obj' (KOTCB (tcbDomain_update (\<lambda>_. d) makeObject)) s"
-  unfolding valid_obj'_def valid_tcb'_def  valid_tcb_state'_def valid_arch_tcb'_def
+  unfolding valid_obj'_def valid_tcb'_def valid_tcb_state'_def valid_arch_tcb'_def
   by (clarsimp simp: makeObject_tcb makeObject_cte objBits_simps' newArchTCB_def
                      tcb_cte_cases_def maxDomain_def maxPriority_def numPriorities_def minBound_word)
 

--- a/proof/refine/AARCH64/Schedule_R.thy
+++ b/proof/refine/AARCH64/Schedule_R.thy
@@ -249,16 +249,14 @@ lemma switchLocalFpuOwner_corres[corres]:
    apply (auto simp: current_fpu_owner_Some_tcb_at fpuOwner_asrt_cross)
   done
 
-lemma isFlagSet_set:
-  "isFlagSet flag flags = (flag \<in> word_to_tcb_flags flags)"
-  by (clarsimp simp: isFlagSet_def word_to_tcb_flags_def)
-
+(* FIXME FPU: when the FPU being enabled is properly configurable for the proofs then this should
+              have config_HAVE_FPU as a precondition instead of being unfolded. *)
 lemma lazyFpuRestore_corres[corres]:
   "corres dc (pspace_aligned and pspace_distinct and valid_cur_fpu and tcb_at t) \<top>
              (lazy_fpu_restore t) (lazyFpuRestore t)"
   unfolding lazy_fpu_restore_def lazyFpuRestore_def
   by (corres corres: threadGet_corres[where r="\<lambda>flags flags'. flags = word_to_tcb_flags flags'"]
-          term_simp: tcb_relation_def isFlagSet_set
+          term_simp: tcb_relation_def Kernel_Config.config_HAVE_FPU_def
                  wp: hoare_drop_imps)
 
 crunch set_vm_root, vcpu_switch
@@ -1308,6 +1306,7 @@ lemma threadSet_invs_no_cicd'_trivialT:
     "\<forall>tcb. tcbDomain tcb \<le> maxDomain \<longrightarrow> tcbDomain (F tcb) \<le> maxDomain"
     "\<forall>tcb. tcbPriority tcb \<le> maxPriority \<longrightarrow> tcbPriority (F tcb) \<le> maxPriority"
     "\<forall>tcb. tcbMCP tcb \<le> maxPriority \<longrightarrow> tcbMCP (F tcb) \<le> maxPriority"
+    "\<forall>tcb. tcbFlags tcb && ~~ tcbFlagMask = 0 \<longrightarrow> tcbFlags (F tcb) && ~~ tcbFlagMask = 0"
     "\<forall>tcb. atcbVCPUPtr (tcbArch (F tcb)) = atcbVCPUPtr (tcbArch tcb)"
   shows "threadSet F t \<lbrace>invs_no_cicd'\<rbrace>"
   apply (simp add: invs_no_cicd'_def valid_state'_def)

--- a/proof/refine/AARCH64/Syscall_R.thy
+++ b/proof/refine/AARCH64/Syscall_R.thy
@@ -514,7 +514,7 @@ lemma invokeTCB_typ_at'[wp]:
      invokeTCB tinv
    \<lbrace>\<lambda>rv s. P (typ_at' T p s)\<rbrace>"
   apply (cases tinv,
-         simp_all add: invokeTCB_def
+         simp_all add: invokeTCB_def invokeSetFlags_def
                        getThreadBufferSlot_def locateSlot_conv
             split del: if_split)
    apply (simp only: cases_simp if_cancel simp_thms conj_comms pred_conj_def

--- a/proof/refine/AARCH64/TcbAcc_R.thy
+++ b/proof/refine/AARCH64/TcbAcc_R.thy
@@ -810,6 +810,7 @@ lemma threadSet_valid_pspace'T_P:
   assumes u: "\<forall>tcb. tcbDomain tcb \<le> maxDomain \<longrightarrow> tcbDomain (F tcb) \<le> maxDomain"
   assumes w: "\<forall>tcb. tcbPriority tcb \<le> maxPriority \<longrightarrow> tcbPriority (F tcb) \<le> maxPriority"
   assumes w': "\<forall>tcb. tcbMCP tcb \<le> maxPriority \<longrightarrow> tcbMCP (F tcb) \<le> maxPriority"
+  assumes f: "\<forall>tcb. tcbFlags tcb && ~~ tcbFlagMask = 0 \<longrightarrow> tcbFlags (F tcb) && ~~ tcbFlagMask = 0"
   assumes v': "\<forall>tcb s. valid_arch_tcb' (tcbArch tcb) s \<longrightarrow> valid_arch_tcb' (tcbArch (F tcb)) s"
   shows
   "\<lbrace>valid_pspace' and (\<lambda>s. P \<longrightarrow> st_tcb_at' Q t s \<and> bound_tcb_at' Q' t s
@@ -824,7 +825,7 @@ lemma threadSet_valid_pspace'T_P:
   apply (erule(1) valid_objsE')
   apply (clarsimp simp add: valid_obj'_def valid_tcb'_def
                             bspec_split [OF spec [OF x]] z
-                            split_paired_Ball y u w v w' v' p n)
+                            split_paired_Ball y u w v w' v' p n f)
   done
 
 lemmas threadSet_valid_pspace'T =
@@ -1377,6 +1378,7 @@ lemma threadSet_invs_trivialT:
     "\<forall>tcb. tcbDomain (F tcb) = tcbDomain tcb"
     "\<forall>tcb. tcbPriority (F tcb) = tcbPriority tcb"
     "\<forall>tcb. tcbMCP tcb \<le> maxPriority \<longrightarrow> tcbMCP (F tcb) \<le> maxPriority"
+    "\<forall>tcb. tcbFlags tcb && ~~ tcbFlagMask = 0 \<longrightarrow> tcbFlags (F tcb) && ~~ tcbFlagMask = 0"
     "\<forall>tcb. atcbVCPUPtr (tcbArch (F tcb)) = atcbVCPUPtr (tcbArch tcb)"
   shows "threadSet F t \<lbrace>invs'\<rbrace>"
   apply (simp add: invs'_def valid_state'_def split del: if_split)

--- a/proof/refine/AARCH64/Tcb_R.thy
+++ b/proof/refine/AARCH64/Tcb_R.thy
@@ -1657,6 +1657,13 @@ lemma setSchedulerAction_invs'[wp]:
   apply (simp add: ct_idle_or_in_cur_domain'_def)
   done
 
+lemma postSetFlags_corres[corres]:
+  "flags = word_to_tcb_flags flags' \<Longrightarrow>
+   corres dc (pspace_aligned and pspace_distinct and valid_cur_fpu) \<top>
+     (arch_post_set_flags  t flags) (postSetFlags t flags')"
+  unfolding arch_post_set_flags_def postSetFlags_def
+  by (corres term_simp: isFlagSet_set)
+
 end
 
 lemma setFlags_corres[corres]:
@@ -1672,12 +1679,9 @@ crunch set_flags
   and pspace_distinct[wp]: pspace_distinct
   and valid_cur_fpu[wp]: valid_cur_fpu
 
-context begin interpretation Arch . (*FIXME: arch-split*)
-
 lemma tcbFlagToWord_bit:
   "\<exists>n. tcbFlagToWord flag = bit n"
-  by (auto simp: tcbFlagToWord_def archTcbFlagToWord_def split: tcb_flag.splits arch_tcb_flag.splits
-       simp del: bit_def)
+  by (auto simp: tcbFlagToWord_def split: tcb_flag.splits simp del: bit_def)
 
 lemma word_to_tcb_flags_subtract:
   "word_to_tcb_flags (flags && ~~ flags') = word_to_tcb_flags flags - word_to_tcb_flags flags'"
@@ -1694,15 +1698,6 @@ lemma word_to_tcb_flags_union:
   done
 
 lemmas word_to_tcb_flags_simps = word_to_tcb_flags_subtract word_to_tcb_flags_union
-
-lemma postSetFlags_corres[corres]:
-  "flags = word_to_tcb_flags flags' \<Longrightarrow>
-   corres dc (pspace_aligned and pspace_distinct and valid_cur_fpu) \<top>
-     (arch_post_set_flags  t flags) (postSetFlags t flags')"
-  unfolding arch_post_set_flags_def postSetFlags_def
-  by (corres term_simp: isFlagSet_set)
-
-end
 
 consts
   copyregsets_map :: "arch_copy_register_sets \<Rightarrow> Arch.copy_register_sets"

--- a/proof/refine/AARCH64/Tcb_R.thy
+++ b/proof/refine/AARCH64/Tcb_R.thy
@@ -1105,6 +1105,7 @@ lemma threadSet_invs_trivialT2:
     "\<forall>tcb. tcbDomain tcb \<le> maxDomain \<longrightarrow> tcbDomain (F tcb) \<le> maxDomain"
     "\<forall>tcb. tcbPriority tcb \<le> maxPriority \<longrightarrow> tcbPriority (F tcb) \<le> maxPriority"
     "\<forall>tcb. tcbMCP tcb \<le> maxPriority \<longrightarrow> tcbMCP (F tcb) \<le> maxPriority"
+    "\<forall>tcb. tcbFlags tcb && ~~ tcbFlagMask = 0 \<longrightarrow> tcbFlags (F tcb) && ~~ tcbFlagMask = 0"
     "\<forall>tcb. atcbVCPUPtr (tcbArch (F tcb)) = atcbVCPUPtr (tcbArch tcb)"
   shows
   "\<lbrace>\<lambda>s. invs' s \<and> (\<forall>tcb. is_aligned (tcbIPCBuffer (F tcb)) msg_align_bits)\<rbrace>
@@ -1657,12 +1658,14 @@ lemma setSchedulerAction_invs'[wp]:
   apply (simp add: ct_idle_or_in_cur_domain'_def)
   done
 
+(* FIXME FPU: when the FPU being enabled is properly configurable for the proofs then this shouldn't
+              need to unfold config_HAVE_FPU. *)
 lemma postSetFlags_corres[corres]:
   "flags = word_to_tcb_flags flags' \<Longrightarrow>
    corres dc (pspace_aligned and pspace_distinct and valid_cur_fpu) \<top>
      (arch_post_set_flags  t flags) (postSetFlags t flags')"
   unfolding arch_post_set_flags_def postSetFlags_def
-  by (corres term_simp: isFlagSet_set)
+  by (corres term_simp: Kernel_Config.config_HAVE_FPU_def)
 
 end
 
@@ -1679,25 +1682,6 @@ crunch set_flags
   and pspace_distinct[wp]: pspace_distinct
   and valid_cur_fpu[wp]: valid_cur_fpu
 
-lemma tcbFlagToWord_bit:
-  "\<exists>n. tcbFlagToWord flag = bit n"
-  by (auto simp: tcbFlagToWord_def split: tcb_flag.splits simp del: bit_def)
-
-lemma word_to_tcb_flags_subtract:
-  "word_to_tcb_flags (flags && ~~ flags') = word_to_tcb_flags flags - word_to_tcb_flags flags'"
-  apply (clarsimp simp: word_to_tcb_flags_def intro!: set_eqI)
-  apply (cut_tac flag=x in tcbFlagToWord_bit)
-  apply (fastforce simp: word_eq_iff tcbFlagToWord_bit)
-  done
-
-lemma word_to_tcb_flags_union:
-  "word_to_tcb_flags (flags || flags') = word_to_tcb_flags flags \<union> word_to_tcb_flags flags'"
-  apply (clarsimp simp: word_to_tcb_flags_def intro!: set_eqI)
-  apply (cut_tac flag=x in tcbFlagToWord_bit)
-  apply (fastforce simp: word_eq_iff tcbFlagToWord_bit)
-  done
-
-lemmas word_to_tcb_flags_simps = word_to_tcb_flags_subtract word_to_tcb_flags_union
 
 consts
   copyregsets_map :: "arch_copy_register_sets \<Rightarrow> Arch.copy_register_sets"
@@ -1776,6 +1760,15 @@ where
 | "tcb_inv_wf' (tcbinvocation.SetFlags ref clears sets)
              = (tcb_at' ref and ex_nonz_cap_to' ref)"
 
+lemma invokeSetFlags_helper:
+  "flags = word_to_tcb_flags flags' \<Longrightarrow>
+   corres (=) \<top> (K (flags' && ~~ tcbFlagMask = 0))
+     (return [tcb_flags_to_word (flags - word_to_tcb_flags clears' \<union> word_to_tcb_flags sets')])
+     (return [flags' && ~~ clears' || sets' && tcbFlagMask])"
+  by (fastforce simp: mask_eq_x_eq_0[symmetric] word_to_tcb_flags_simps[symmetric]
+                      word_to_tcb_flags_and_not[symmetric] tcb_flags_to_word_id word_bw_comms
+                      word_ao_dist2 word_bw_assocs[symmetric])
+
 lemma invokeTCB_corres:
  "tcbinv_relation ti ti' \<Longrightarrow>
   corres (dc \<oplus> (=))
@@ -1830,10 +1823,13 @@ lemma invokeTCB_corres:
           apply (wpsimp wp: hoare_drop_imp)+
     apply (fastforce dest: valid_sched_valid_queues simp: valid_sched_weak_strg)
    apply fastforce
-  apply (clarsimp simp: invokeTCB_def)
+  apply (clarsimp simp: invokeTCB_def invokeSetFlags_def bind_assoc)
   apply (corres corres: threadGet_corres[where r="\<lambda>flags flags'. flags = word_to_tcb_flags flags'"]
-             term_simp: tcb_relation_def word_to_tcb_flags_simps)
-   apply fastforce+
+                        invokeSetFlags_helper
+             term_simp: tcb_relation_def word_to_tcb_flags_simps Diff_Int_distrib Diff_Int
+                    wp: threadGet_wp)
+   apply fastforce
+  apply (fastforce dest: tcb_ko_at_valid_objs_valid_tcb' simp: valid_tcb'_def)
   done
 
 lemma tcbBoundNotification_caps_safe[simp]:
@@ -1904,11 +1900,19 @@ lemma setTLSBase_invs'[wp]:
    \<lbrace>\<lambda>rv. invs'\<rbrace>"
   by (wpsimp simp: invokeTCB_def)
 
-lemma threadSet_flags_invs[wp]:
-  "threadSet (tcbFlags_update f) t \<lbrace>invs'\<rbrace>"
-  by (wpsimp wp: threadSet_invs_trivial)
+lemma threadSet_flags_invs'[wp]:
+  "\<lbrace>invs' and K (\<forall>flags. flags && ~~ tcbFlagMask = 0 \<longrightarrow> f flags && ~~ tcbFlagMask = 0)\<rbrace>
+   threadSet (tcbFlags_update f) t
+   \<lbrace>\<lambda>_. invs'\<rbrace>"
+  by (rule hoare_gen_asm) (wpsimp wp: threadSet_invs_trivial)
 
-crunch setFlags, postSetFlags
+lemma setFlags_invs'[wp]:
+  "\<lbrace>invs' and K (flags && ~~ tcbFlagMask = 0)\<rbrace>
+   setFlags t flags
+   \<lbrace>\<lambda>_. invs'\<rbrace>"
+  by (wpsimp simp: setFlags_def wp: threadSet_flags_invs')
+
+crunch postSetFlags
   for invs'[wp]: invs'
   (ignore: threadSet)
 
@@ -1916,7 +1920,11 @@ lemma invokeSetFlags_invs'[wp]:
   "\<lbrace>invs' and tcb_inv_wf' (tcbinvocation.SetFlags tcb clears' sets')\<rbrace>
    invokeTCB (tcbinvocation.SetFlags tcb clears' sets')
    \<lbrace>\<lambda>rv. invs'\<rbrace>"
-  by (wpsimp simp: invokeTCB_def)
+  unfolding invokeTCB_def invokeSetFlags_def
+  apply (wpsimp wp: threadGet_wp)
+  apply (fastforce dest: tcb_ko_at_valid_objs_valid_tcb'
+                   simp: valid_tcb'_def word_ao_dist word_bw_assocs word_bw_lcs)+
+  done
 
 lemma tcbinv_invs':
   "\<lbrace>invs' and sch_act_simple and ct_in_state' runnable' and tcb_inv_wf' ti\<rbrace>

--- a/proof/refine/AARCH64/orphanage/Orphanage.thy
+++ b/proof/refine/AARCH64/orphanage/Orphanage.thy
@@ -1693,7 +1693,7 @@ lemma invokeTCB_no_orphans [wp]:
     apply (wp tc_no_orphans)
     apply (clarsimp split: option.splits simp: msg_align_bits elim!:is_aligned_weaken)
    apply (wpsimp simp: invokeTCB_def)
-  apply (wpsimp simp: invokeTCB_def)
+  apply (wpsimp simp: invokeTCB_def invokeSetFlags_def)
   done
 
 lemma invokeCNode_no_orphans [wp]:

--- a/proof/refine/ARM/PageTableDuplicates.thy
+++ b/proof/refine/ARM/PageTableDuplicates.thy
@@ -2109,7 +2109,7 @@ lemma invokeTCB_valid_duplicates'[wp]:
      apply (clarsimp split:option.splits)
      apply (rename_tac option)
      apply (case_tac option, simp_all)
-    apply (simp add:invokeTCB_def | wp mapM_x_wp' | intro impI conjI | wpc)+
+    apply (simp add:invokeTCB_def invokeSetFlags_def | wp mapM_x_wp' | intro impI conjI | wpc)+
   done
 
 lemma performInvocation_valid_duplicates'[wp]:

--- a/proof/refine/ARM/Retype_R.thy
+++ b/proof/refine/ARM/Retype_R.thy
@@ -105,13 +105,13 @@ lemma valid_obj_makeObject_cte [simp]:
 
 lemma valid_obj_makeObject_tcb [simp]:
   "valid_obj' (KOTCB makeObject) s"
-  unfolding valid_obj'_def valid_tcb'_def  valid_tcb_state'_def
+  unfolding valid_obj'_def valid_tcb'_def valid_tcb_state'_def
   by (clarsimp simp: makeObject_tcb makeObject_cte tcb_cte_cases_def minBound_word newArchTCB_def
                      cteSizeBits_def valid_arch_tcb'_def)
 
 lemma valid_obj_makeObject_tcb_tcbDomain_update [simp]:
   "d \<le> maxDomain \<Longrightarrow> valid_obj' (KOTCB (tcbDomain_update (\<lambda>_. d) makeObject)) s"
-  unfolding valid_obj'_def valid_tcb'_def  valid_tcb_state'_def valid_arch_tcb'_def
+  unfolding valid_obj'_def valid_tcb'_def valid_tcb_state'_def valid_arch_tcb'_def
   by (clarsimp simp: makeObject_tcb makeObject_cte objBits_simps' newArchTCB_def
                      tcb_cte_cases_def maxDomain_def maxPriority_def numPriorities_def minBound_word)
 

--- a/proof/refine/ARM/Syscall_R.thy
+++ b/proof/refine/ARM/Syscall_R.thy
@@ -505,7 +505,7 @@ lemma invokeTCB_typ_at'[wp]:
      invokeTCB tinv
    \<lbrace>\<lambda>rv s. P (typ_at' T p s)\<rbrace>"
   apply (cases tinv,
-         simp_all add: invokeTCB_def
+         simp_all add: invokeTCB_def invokeSetFlags_def
                        getThreadBufferSlot_def locateSlot_conv
             split del: if_split)
    apply (simp only: cases_simp if_cancel simp_thms conj_comms pred_conj_def

--- a/proof/refine/ARM/TcbAcc_R.thy
+++ b/proof/refine/ARM/TcbAcc_R.thy
@@ -813,6 +813,7 @@ lemma threadSet_valid_pspace'T_P:
   assumes u: "\<forall>tcb. tcbDomain tcb \<le> maxDomain \<longrightarrow> tcbDomain (F tcb) \<le> maxDomain"
   assumes w: "\<forall>tcb. tcbPriority tcb \<le> maxPriority \<longrightarrow> tcbPriority (F tcb) \<le> maxPriority"
   assumes w': "\<forall>tcb. tcbMCP tcb \<le> maxPriority \<longrightarrow> tcbMCP (F tcb) \<le> maxPriority"
+  assumes f: "\<forall>tcb. tcbFlags tcb && ~~ tcbFlagMask = 0 \<longrightarrow> tcbFlags (F tcb) && ~~ tcbFlagMask = 0"
   shows
   "\<lbrace>valid_pspace' and (\<lambda>s. P \<longrightarrow> st_tcb_at' Q t s \<and> bound_tcb_at' Q' t s
                                  \<and> obj_at' (\<lambda>tcb. Q'' (tcbSchedPrev tcb)) t s
@@ -826,7 +827,7 @@ lemma threadSet_valid_pspace'T_P:
   apply (erule(1) valid_objsE')
   apply (clarsimp simp add: valid_obj'_def valid_tcb'_def
                             bspec_split [OF spec [OF x]] z
-                            split_paired_Ball y u w v w' p n)
+                            split_paired_Ball y u w v w' p n f)
   apply (simp add: valid_arch_tcb'_def) (* FIXME arch-split: non-hyp only *)
   done
 
@@ -1377,6 +1378,7 @@ lemma threadSet_invs_trivialT:
     "\<forall>tcb. tcbDomain (F tcb) = tcbDomain tcb"
     "\<forall>tcb. tcbPriority (F tcb) = tcbPriority tcb"
     "\<forall>tcb. tcbMCP tcb \<le> maxPriority \<longrightarrow> tcbMCP (F tcb) \<le> maxPriority"
+    "\<forall>tcb. tcbFlags tcb && ~~ tcbFlagMask = 0 \<longrightarrow> tcbFlags (F tcb) && ~~ tcbFlagMask = 0"
   shows "threadSet F t \<lbrace>invs'\<rbrace>"
   apply (simp add: invs'_def valid_state'_def split del: if_split)
   apply (wp threadSet_valid_pspace'T

--- a/proof/refine/ARM/Tcb_R.thy
+++ b/proof/refine/ARM/Tcb_R.thy
@@ -1136,6 +1136,7 @@ lemma threadSet_invs_trivialT2:
     "\<forall>tcb. tcbDomain tcb \<le> maxDomain \<longrightarrow> tcbDomain (F tcb) \<le> maxDomain"
     "\<forall>tcb. tcbPriority tcb \<le> maxPriority \<longrightarrow> tcbPriority (F tcb) \<le> maxPriority"
     "\<forall>tcb. tcbMCP tcb \<le> maxPriority \<longrightarrow> tcbMCP (F tcb) \<le> maxPriority"
+    "\<forall>tcb. tcbFlags tcb && ~~ tcbFlagMask = 0 \<longrightarrow> tcbFlags (F tcb) && ~~ tcbFlagMask = 0"
   shows
   "\<lbrace>\<lambda>s. invs' s \<and> (\<forall>tcb. is_aligned (tcbIPCBuffer (F tcb)) msg_align_bits)\<rbrace>
    threadSet F t
@@ -1689,25 +1690,6 @@ crunch set_flags
   for pspace_aligned[wp]: pspace_aligned
   and pspace_distinct[wp]: pspace_distinct
 
-lemma tcbFlagToWord_bit:
-  "(\<exists>n. tcbFlagToWord flag = bit n) \<or> tcbFlagToWord flag = 0"
-  by (auto simp: tcbFlagToWord_def split: tcb_flag.splits simp del: bit_def)
-
-lemma word_to_tcb_flags_subtract:
-  "word_to_tcb_flags (flags && ~~ flags') = word_to_tcb_flags flags - word_to_tcb_flags flags'"
-  apply (clarsimp simp: word_to_tcb_flags_def intro!: set_eqI)
-  apply (cut_tac flag=x in tcbFlagToWord_bit)
-  apply (fastforce simp: word_eq_iff tcbFlagToWord_bit)
-  done
-
-lemma word_to_tcb_flags_union:
-  "word_to_tcb_flags (flags || flags') = word_to_tcb_flags flags \<union> word_to_tcb_flags flags'"
-  apply (clarsimp simp: word_to_tcb_flags_def intro!: set_eqI)
-  apply (cut_tac flag=x in tcbFlagToWord_bit)
-  apply (fastforce simp: word_eq_iff tcbFlagToWord_bit)
-  done
-
-lemmas word_to_tcb_flags_simps = word_to_tcb_flags_subtract word_to_tcb_flags_union
 
 consts
   copyregsets_map :: "arch_copy_register_sets \<Rightarrow> Arch.copy_register_sets"
@@ -1786,6 +1768,15 @@ where
 | "tcb_inv_wf' (tcbinvocation.SetFlags ref clears sets)
              = (tcb_at' ref and ex_nonz_cap_to' ref)"
 
+lemma invokeSetFlags_helper:
+  "flags = word_to_tcb_flags flags' \<Longrightarrow>
+   corres (=) \<top> (K (flags' && ~~ tcbFlagMask = 0))
+     (return [tcb_flags_to_word (flags - word_to_tcb_flags clears' \<union> word_to_tcb_flags sets')])
+     (return [flags' && ~~ clears' || sets' && tcbFlagMask])"
+  by (fastforce simp: mask_eq_x_eq_0[symmetric] word_to_tcb_flags_simps[symmetric]
+                      word_to_tcb_flags_and_not[symmetric] tcb_flags_to_word_id word_bw_comms
+                      word_ao_dist2 word_bw_assocs[symmetric])
+
 lemma invokeTCB_corres:
  "tcbinv_relation ti ti' \<Longrightarrow>
   corres (dc \<oplus> (=))
@@ -1840,10 +1831,13 @@ lemma invokeTCB_corres:
           apply (wpsimp wp: hoare_drop_imp)+
     apply (fastforce dest: valid_sched_valid_queues simp: valid_sched_weak_strg)
    apply fastforce
-  apply (clarsimp simp: invokeTCB_def)
+  apply (clarsimp simp: invokeTCB_def invokeSetFlags_def bind_assoc)
   apply (corres corres: threadGet_corres[where r="\<lambda>flags flags'. flags = word_to_tcb_flags flags'"]
-             term_simp: tcb_relation_def word_to_tcb_flags_simps)
-   apply fastforce+
+                        invokeSetFlags_helper
+             term_simp: tcb_relation_def word_to_tcb_flags_simps Diff_Int_distrib Diff_Int
+                    wp: threadGet_wp)
+   apply fastforce
+  apply (fastforce dest: tcb_ko_at_valid_objs_valid_tcb' simp: valid_tcb'_def)
   done
 
 lemma tcbBoundNotification_caps_safe[simp]:
@@ -1914,11 +1908,19 @@ lemma setTLSBase_invs'[wp]:
    \<lbrace>\<lambda>rv. invs'\<rbrace>"
   by (wpsimp simp: invokeTCB_def)
 
-lemma threadSet_flags_invs[wp]:
-  "threadSet (tcbFlags_update f) t \<lbrace>invs'\<rbrace>"
-  by (wpsimp wp: threadSet_invs_trivial)
+lemma threadSet_flags_invs'[wp]:
+  "\<lbrace>invs' and K (\<forall>flags. flags && ~~ tcbFlagMask = 0 \<longrightarrow> f flags && ~~ tcbFlagMask = 0)\<rbrace>
+   threadSet (tcbFlags_update f) t
+   \<lbrace>\<lambda>_. invs'\<rbrace>"
+  by (rule hoare_gen_asm) (wpsimp wp: threadSet_invs_trivial)
 
-crunch setFlags, postSetFlags
+lemma setFlags_invs'[wp]:
+  "\<lbrace>invs' and K (flags && ~~ tcbFlagMask = 0)\<rbrace>
+   setFlags t flags
+   \<lbrace>\<lambda>_. invs'\<rbrace>"
+  by (wpsimp simp: setFlags_def wp: threadSet_flags_invs')
+
+crunch postSetFlags
   for invs'[wp]: invs'
   (ignore: threadSet)
 
@@ -1926,7 +1928,11 @@ lemma invokeSetFlags_invs'[wp]:
   "\<lbrace>invs' and tcb_inv_wf' (tcbinvocation.SetFlags tcb clears' sets')\<rbrace>
    invokeTCB (tcbinvocation.SetFlags tcb clears' sets')
    \<lbrace>\<lambda>rv. invs'\<rbrace>"
-  by (wpsimp simp: invokeTCB_def)
+  unfolding invokeTCB_def invokeSetFlags_def
+  apply (wpsimp wp: threadGet_wp)
+  apply (fastforce dest: tcb_ko_at_valid_objs_valid_tcb'
+                   simp: valid_tcb'_def word_ao_dist word_bw_assocs word_bw_lcs)+
+  done
 
 lemma tcbinv_invs':
   "\<lbrace>invs' and sch_act_simple and ct_in_state' runnable' and tcb_inv_wf' ti\<rbrace>

--- a/proof/refine/ARM/Tcb_R.thy
+++ b/proof/refine/ARM/Tcb_R.thy
@@ -1669,6 +1669,12 @@ lemma setSchedulerAction_invs'[wp]:
   apply (simp add: ct_idle_or_in_cur_domain'_def)
   done
 
+lemma postSetFlags_corres[corres]:
+  "flags = word_to_tcb_flags flags' \<Longrightarrow>
+   corres dc (pspace_aligned and pspace_distinct) \<top>
+     (arch_post_set_flags  t flags) (postSetFlags t flags')"
+  by (clarsimp simp: arch_post_set_flags_def postSetFlags_def)
+
 end
 
 lemma setFlags_corres[corres]:
@@ -1683,12 +1689,9 @@ crunch set_flags
   for pspace_aligned[wp]: pspace_aligned
   and pspace_distinct[wp]: pspace_distinct
 
-context begin interpretation Arch . (*FIXME: arch-split*)
-
 lemma tcbFlagToWord_bit:
   "(\<exists>n. tcbFlagToWord flag = bit n) \<or> tcbFlagToWord flag = 0"
-  by (auto simp: tcbFlagToWord_def archTcbFlagToWord_def split: tcb_flag.splits
-       simp del: bit_def)
+  by (auto simp: tcbFlagToWord_def split: tcb_flag.splits simp del: bit_def)
 
 lemma word_to_tcb_flags_subtract:
   "word_to_tcb_flags (flags && ~~ flags') = word_to_tcb_flags flags - word_to_tcb_flags flags'"
@@ -1705,14 +1708,6 @@ lemma word_to_tcb_flags_union:
   done
 
 lemmas word_to_tcb_flags_simps = word_to_tcb_flags_subtract word_to_tcb_flags_union
-
-lemma postSetFlags_corres[corres]:
-  "flags = word_to_tcb_flags flags' \<Longrightarrow>
-   corres dc (pspace_aligned and pspace_distinct) \<top>
-     (arch_post_set_flags  t flags) (postSetFlags t flags')"
-  by (clarsimp simp: arch_post_set_flags_def postSetFlags_def)
-
-end
 
 consts
   copyregsets_map :: "arch_copy_register_sets \<Rightarrow> Arch.copy_register_sets"

--- a/proof/refine/ARM/orphanage/Orphanage.thy
+++ b/proof/refine/ARM/orphanage/Orphanage.thy
@@ -1752,7 +1752,7 @@ lemma invokeTCB_no_orphans [wp]:
     apply (wp tc_no_orphans)
     apply (clarsimp split: option.splits simp: msg_align_bits elim!:is_aligned_weaken)
    apply (wpsimp simp: invokeTCB_def)
-  apply (wpsimp simp: invokeTCB_def)
+  apply (wpsimp simp: invokeTCB_def invokeSetFlags_def)
   done
 
 lemma invokeCNode_no_orphans [wp]:

--- a/proof/refine/ARM_HYP/PageTableDuplicates.thy
+++ b/proof/refine/ARM_HYP/PageTableDuplicates.thy
@@ -2039,7 +2039,7 @@ lemma invokeTCB_valid_duplicates'[wp]:
      apply (clarsimp split:option.splits)
      apply (rename_tac option)
      apply (case_tac option, simp_all)
-    apply (simp add:invokeTCB_def | wp mapM_x_wp' | intro impI conjI | wpc)+
+    apply (simp add:invokeTCB_def invokeSetFlags_def | wp mapM_x_wp' | intro impI conjI | wpc)+
   done
 
 lemma performInvocation_valid_duplicates'[wp]:

--- a/proof/refine/ARM_HYP/Syscall_R.thy
+++ b/proof/refine/ARM_HYP/Syscall_R.thy
@@ -515,7 +515,7 @@ lemma invokeTCB_typ_at'[wp]:
      invokeTCB tinv
    \<lbrace>\<lambda>rv s. P (typ_at' T p s)\<rbrace>"
   apply (cases tinv,
-         simp_all add: invokeTCB_def
+         simp_all add: invokeTCB_def invokeSetFlags_def
                        getThreadBufferSlot_def locateSlot_conv
             split del: if_split)
    apply (simp only: cases_simp if_cancel simp_thms conj_comms pred_conj_def

--- a/proof/refine/ARM_HYP/TcbAcc_R.thy
+++ b/proof/refine/ARM_HYP/TcbAcc_R.thy
@@ -816,6 +816,7 @@ lemma threadSet_valid_pspace'T_P:
   assumes u: "\<forall>tcb. tcbDomain tcb \<le> maxDomain \<longrightarrow> tcbDomain (F tcb) \<le> maxDomain"
   assumes w: "\<forall>tcb. tcbPriority tcb \<le> maxPriority \<longrightarrow> tcbPriority (F tcb) \<le> maxPriority"
   assumes w': "\<forall>tcb. tcbMCP tcb \<le> maxPriority \<longrightarrow> tcbMCP (F tcb) \<le> maxPriority"
+  assumes f: "\<forall>tcb. tcbFlags tcb && ~~ tcbFlagMask = 0 \<longrightarrow> tcbFlags (F tcb) && ~~ tcbFlagMask = 0"
   assumes v': "\<forall>tcb s. valid_arch_tcb' (tcbArch tcb) s \<longrightarrow> valid_arch_tcb' (tcbArch (F tcb)) s"
   shows
   "\<lbrace>valid_pspace' and (\<lambda>s. P \<longrightarrow> st_tcb_at' Q t s \<and> bound_tcb_at' Q' t s
@@ -830,7 +831,7 @@ lemma threadSet_valid_pspace'T_P:
   apply (erule(1) valid_objsE')
   apply (clarsimp simp add: valid_obj'_def valid_tcb'_def
                             bspec_split [OF spec [OF x]] z
-                            split_paired_Ball y u w v w' v' p n)
+                            split_paired_Ball y u w v w' v' p n f)
   done
 
 lemmas threadSet_valid_pspace'T =
@@ -1390,6 +1391,7 @@ lemma threadSet_invs_trivialT:
     "\<forall>tcb. tcbDomain (F tcb) = tcbDomain tcb"
     "\<forall>tcb. tcbPriority (F tcb) = tcbPriority tcb"
     "\<forall>tcb. tcbMCP tcb \<le> maxPriority \<longrightarrow> tcbMCP (F tcb) \<le> maxPriority"
+    "\<forall>tcb. tcbFlags tcb && ~~ tcbFlagMask = 0 \<longrightarrow> tcbFlags (F tcb) && ~~ tcbFlagMask = 0"
     "\<forall>tcb. atcbVCPUPtr (tcbArch (F tcb)) = atcbVCPUPtr (tcbArch tcb)"
   shows "threadSet F t \<lbrace>invs'\<rbrace>"
   apply (simp add: invs'_def valid_state'_def split del: if_split)

--- a/proof/refine/ARM_HYP/Tcb_R.thy
+++ b/proof/refine/ARM_HYP/Tcb_R.thy
@@ -1139,6 +1139,7 @@ lemma threadSet_invs_trivialT2:
     "\<forall>tcb. tcbDomain tcb \<le> maxDomain \<longrightarrow> tcbDomain (F tcb) \<le> maxDomain"
     "\<forall>tcb. tcbPriority tcb \<le> maxPriority \<longrightarrow> tcbPriority (F tcb) \<le> maxPriority"
     "\<forall>tcb. tcbMCP tcb \<le> maxPriority \<longrightarrow> tcbMCP (F tcb) \<le> maxPriority"
+    "\<forall>tcb. tcbFlags tcb && ~~ tcbFlagMask = 0 \<longrightarrow> tcbFlags (F tcb) && ~~ tcbFlagMask = 0"
     "\<forall>tcb. atcbVCPUPtr (tcbArch (F tcb)) = atcbVCPUPtr (tcbArch tcb)"
   shows
   "\<lbrace>\<lambda>s. invs' s \<and> (\<forall>tcb. is_aligned (tcbIPCBuffer (F tcb)) msg_align_bits)\<rbrace>
@@ -1694,25 +1695,6 @@ crunch set_flags
   for pspace_aligned[wp]: pspace_aligned
   and pspace_distinct[wp]: pspace_distinct
 
-lemma tcbFlagToWord_bit:
-  "(\<exists>n. tcbFlagToWord flag = bit n) \<or> tcbFlagToWord flag = 0"
-  by (auto simp: tcbFlagToWord_def split: tcb_flag.splits simp del: bit_def)
-
-lemma word_to_tcb_flags_subtract:
-  "word_to_tcb_flags (flags && ~~ flags') = word_to_tcb_flags flags - word_to_tcb_flags flags'"
-  apply (clarsimp simp: word_to_tcb_flags_def intro!: set_eqI)
-  apply (cut_tac flag=x in tcbFlagToWord_bit)
-  apply (fastforce simp: word_eq_iff tcbFlagToWord_bit)
-  done
-
-lemma word_to_tcb_flags_union:
-  "word_to_tcb_flags (flags || flags') = word_to_tcb_flags flags \<union> word_to_tcb_flags flags'"
-  apply (clarsimp simp: word_to_tcb_flags_def intro!: set_eqI)
-  apply (cut_tac flag=x in tcbFlagToWord_bit)
-  apply (fastforce simp: word_eq_iff tcbFlagToWord_bit)
-  done
-
-lemmas word_to_tcb_flags_simps = word_to_tcb_flags_subtract word_to_tcb_flags_union
 
 consts
   copyregsets_map :: "arch_copy_register_sets \<Rightarrow> Arch.copy_register_sets"
@@ -1791,6 +1773,15 @@ where
 | "tcb_inv_wf' (tcbinvocation.SetFlags ref clears sets)
              = (tcb_at' ref and ex_nonz_cap_to' ref)"
 
+lemma invokeSetFlags_helper:
+  "flags = word_to_tcb_flags flags' \<Longrightarrow>
+   corres (=) \<top> (K (flags' && ~~ tcbFlagMask = 0))
+     (return [tcb_flags_to_word (flags - word_to_tcb_flags clears' \<union> word_to_tcb_flags sets')])
+     (return [flags' && ~~ clears' || sets' && tcbFlagMask])"
+  by (fastforce simp: mask_eq_x_eq_0[symmetric] word_to_tcb_flags_simps[symmetric]
+                      word_to_tcb_flags_and_not[symmetric] tcb_flags_to_word_id word_bw_comms
+                      word_ao_dist2 word_bw_assocs[symmetric])
+
 lemma invokeTCB_corres:
  "tcbinv_relation ti ti' \<Longrightarrow>
   corres (dc \<oplus> (=))
@@ -1846,10 +1837,13 @@ lemma invokeTCB_corres:
           apply (wpsimp wp: hoare_drop_imp)+
     apply (fastforce dest: valid_sched_valid_queues simp: valid_sched_weak_strg)
    apply fastforce
-  apply (clarsimp simp: invokeTCB_def)
+  apply (clarsimp simp: invokeTCB_def invokeSetFlags_def bind_assoc)
   apply (corres corres: threadGet_corres[where r="\<lambda>flags flags'. flags = word_to_tcb_flags flags'"]
-             term_simp: tcb_relation_def word_to_tcb_flags_simps)
-   apply fastforce+
+                        invokeSetFlags_helper
+             term_simp: tcb_relation_def word_to_tcb_flags_simps Diff_Int_distrib Diff_Int
+                    wp: threadGet_wp)
+   apply fastforce
+  apply (fastforce dest: tcb_ko_at_valid_objs_valid_tcb' simp: valid_tcb'_def)
   done
 
 lemma tcbBoundNotification_caps_safe[simp]:
@@ -1920,11 +1914,19 @@ lemma setTLSBase_invs'[wp]:
    \<lbrace>\<lambda>rv. invs'\<rbrace>"
   by (wpsimp simp: invokeTCB_def)
 
-lemma threadSet_flags_invs[wp]:
-  "threadSet (tcbFlags_update f) t \<lbrace>invs'\<rbrace>"
-  by (wpsimp wp: threadSet_invs_trivial)
+lemma threadSet_flags_invs'[wp]:
+  "\<lbrace>invs' and K (\<forall>flags. flags && ~~ tcbFlagMask = 0 \<longrightarrow> f flags && ~~ tcbFlagMask = 0)\<rbrace>
+   threadSet (tcbFlags_update f) t
+   \<lbrace>\<lambda>_. invs'\<rbrace>"
+  by (rule hoare_gen_asm) (wpsimp wp: threadSet_invs_trivial)
 
-crunch setFlags, postSetFlags
+lemma setFlags_invs'[wp]:
+  "\<lbrace>invs' and K (flags && ~~ tcbFlagMask = 0)\<rbrace>
+   setFlags t flags
+   \<lbrace>\<lambda>_. invs'\<rbrace>"
+  by (wpsimp simp: setFlags_def wp: threadSet_flags_invs')
+
+crunch postSetFlags
   for invs'[wp]: invs'
   (ignore: threadSet)
 
@@ -1932,7 +1934,11 @@ lemma invokeSetFlags_invs'[wp]:
   "\<lbrace>invs' and tcb_inv_wf' (tcbinvocation.SetFlags tcb clears' sets')\<rbrace>
    invokeTCB (tcbinvocation.SetFlags tcb clears' sets')
    \<lbrace>\<lambda>rv. invs'\<rbrace>"
-  by (wpsimp simp: invokeTCB_def)
+  unfolding invokeTCB_def invokeSetFlags_def
+  apply (wpsimp wp: threadGet_wp)
+  apply (fastforce dest: tcb_ko_at_valid_objs_valid_tcb'
+                   simp: valid_tcb'_def word_ao_dist word_bw_assocs word_bw_lcs)+
+  done
 
 lemma tcbinv_invs':
   "\<lbrace>invs' and sch_act_simple and ct_in_state' runnable' and tcb_inv_wf' ti\<rbrace>

--- a/proof/refine/ARM_HYP/Tcb_R.thy
+++ b/proof/refine/ARM_HYP/Tcb_R.thy
@@ -1674,6 +1674,12 @@ lemma setSchedulerAction_invs'[wp]:
   apply (simp add: ct_idle_or_in_cur_domain'_def)
   done
 
+lemma postSetFlags_corres[corres]:
+  "flags = word_to_tcb_flags flags' \<Longrightarrow>
+   corres dc (pspace_aligned and pspace_distinct) \<top>
+     (arch_post_set_flags  t flags) (postSetFlags t flags')"
+  by (clarsimp simp: arch_post_set_flags_def postSetFlags_def)
+
 end
 
 lemma setFlags_corres[corres]:
@@ -1688,12 +1694,9 @@ crunch set_flags
   for pspace_aligned[wp]: pspace_aligned
   and pspace_distinct[wp]: pspace_distinct
 
-context begin interpretation Arch . (*FIXME: arch-split*)
-
 lemma tcbFlagToWord_bit:
   "(\<exists>n. tcbFlagToWord flag = bit n) \<or> tcbFlagToWord flag = 0"
-  by (auto simp: tcbFlagToWord_def archTcbFlagToWord_def split: tcb_flag.splits
-       simp del: bit_def)
+  by (auto simp: tcbFlagToWord_def split: tcb_flag.splits simp del: bit_def)
 
 lemma word_to_tcb_flags_subtract:
   "word_to_tcb_flags (flags && ~~ flags') = word_to_tcb_flags flags - word_to_tcb_flags flags'"
@@ -1710,14 +1713,6 @@ lemma word_to_tcb_flags_union:
   done
 
 lemmas word_to_tcb_flags_simps = word_to_tcb_flags_subtract word_to_tcb_flags_union
-
-lemma postSetFlags_corres[corres]:
-  "flags = word_to_tcb_flags flags' \<Longrightarrow>
-   corres dc (pspace_aligned and pspace_distinct) \<top>
-     (arch_post_set_flags  t flags) (postSetFlags t flags')"
-  by (clarsimp simp: arch_post_set_flags_def postSetFlags_def)
-
-end
 
 consts
   copyregsets_map :: "arch_copy_register_sets \<Rightarrow> Arch.copy_register_sets"

--- a/proof/refine/InvariantsPre_H.thy
+++ b/proof/refine/InvariantsPre_H.thy
@@ -14,7 +14,7 @@ imports
   LevityCatch
   "AInvs.ArchDetSchedSchedule_AI"
   "Lib.Heap_List"
-  Move_R
+  TcbFlags_R
 begin
 
 section \<open>Locale Setup for kernel_state Field Update Identities\<close>

--- a/proof/refine/Invariants_H.thy
+++ b/proof/refine/Invariants_H.thy
@@ -360,6 +360,7 @@ definition valid_tcb' :: "tcb \<Rightarrow> kernel_state \<Rightarrow> bool" whe
                   \<and> tcbMCP t \<le> maxPriority
                   \<and> opt_tcb_at' (tcbSchedPrev t) s
                   \<and> opt_tcb_at' (tcbSchedNext t) s
+                  \<and> tcbFlags t && ~~ tcbFlagMask = 0
                   \<and> valid_arch_tcb' (tcbArch t) s"
 
 definition valid_ep' :: "Structures_H.endpoint \<Rightarrow> kernel_state \<Rightarrow> bool" where

--- a/proof/refine/RISCV64/Schedule_R.thy
+++ b/proof/refine/RISCV64/Schedule_R.thy
@@ -1034,6 +1034,7 @@ lemma threadSet_invs_no_cicd'_trivialT:
     "\<forall>tcb. tcbDomain tcb \<le> maxDomain \<longrightarrow> tcbDomain (F tcb) \<le> maxDomain"
     "\<forall>tcb. tcbPriority tcb \<le> maxPriority \<longrightarrow> tcbPriority (F tcb) \<le> maxPriority"
     "\<forall>tcb. tcbMCP tcb \<le> maxPriority \<longrightarrow> tcbMCP (F tcb) \<le> maxPriority"
+    "\<forall>tcb. tcbFlags tcb && ~~ tcbFlagMask = 0 \<longrightarrow> tcbFlags (F tcb) && ~~ tcbFlagMask = 0"
   shows
   "threadSet F t \<lbrace>invs_no_cicd'\<rbrace>"
   apply (simp add: invs_no_cicd'_def valid_state'_def)

--- a/proof/refine/RISCV64/Syscall_R.thy
+++ b/proof/refine/RISCV64/Syscall_R.thy
@@ -513,7 +513,7 @@ lemma invokeTCB_typ_at'[wp]:
      invokeTCB tinv
    \<lbrace>\<lambda>rv s. P (typ_at' T p s)\<rbrace>"
   apply (cases tinv,
-         simp_all add: invokeTCB_def
+         simp_all add: invokeTCB_def invokeSetFlags_def
                        getThreadBufferSlot_def locateSlot_conv
             split del: if_split)
    apply (simp only: cases_simp if_cancel simp_thms conj_comms pred_conj_def

--- a/proof/refine/RISCV64/TcbAcc_R.thy
+++ b/proof/refine/RISCV64/TcbAcc_R.thy
@@ -806,6 +806,7 @@ lemma threadSet_valid_pspace'T_P:
   assumes u: "\<forall>tcb. tcbDomain tcb \<le> maxDomain \<longrightarrow> tcbDomain (F tcb) \<le> maxDomain"
   assumes w: "\<forall>tcb. tcbPriority tcb \<le> maxPriority \<longrightarrow> tcbPriority (F tcb) \<le> maxPriority"
   assumes w': "\<forall>tcb. tcbMCP tcb \<le> maxPriority \<longrightarrow> tcbMCP (F tcb) \<le> maxPriority"
+  assumes f: "\<forall>tcb. tcbFlags tcb && ~~ tcbFlagMask = 0 \<longrightarrow> tcbFlags (F tcb) && ~~ tcbFlagMask = 0"
   shows
   "\<lbrace>valid_pspace' and (\<lambda>s. P \<longrightarrow> st_tcb_at' Q t s \<and> bound_tcb_at' Q' t s
                                  \<and> obj_at' (\<lambda>tcb. Q'' (tcbSchedPrev tcb)) t s
@@ -819,7 +820,7 @@ lemma threadSet_valid_pspace'T_P:
   apply (erule(1) valid_objsE')
   apply (clarsimp simp add: valid_obj'_def valid_tcb'_def
                             bspec_split [OF spec [OF x]] z
-                            split_paired_Ball y u w v w' p n)
+                            split_paired_Ball y u w v w' p n f)
   apply (simp add: valid_arch_tcb'_def) (* FIXME arch-split: non-hyp only *)
   done
 
@@ -1363,6 +1364,7 @@ lemma threadSet_invs_trivialT:
     "\<forall>tcb. tcbDomain (F tcb) = tcbDomain tcb"
     "\<forall>tcb. tcbPriority (F tcb) = tcbPriority tcb"
     "\<forall>tcb. tcbMCP tcb \<le> maxPriority \<longrightarrow> tcbMCP (F tcb) \<le> maxPriority"
+    "\<forall>tcb. tcbFlags tcb && ~~ tcbFlagMask = 0 \<longrightarrow> tcbFlags (F tcb) && ~~ tcbFlagMask = 0"
   shows "threadSet F t \<lbrace>invs'\<rbrace>"
   apply (simp add: invs'_def valid_state'_def split del: if_split)
   apply (wp threadSet_valid_pspace'T

--- a/proof/refine/RISCV64/Tcb_R.thy
+++ b/proof/refine/RISCV64/Tcb_R.thy
@@ -1650,6 +1650,12 @@ lemma setSchedulerAction_invs'[wp]:
   apply (simp add: ct_idle_or_in_cur_domain'_def)
   done
 
+lemma postSetFlags_corres[corres]:
+  "flags = word_to_tcb_flags flags' \<Longrightarrow>
+   corres dc (pspace_aligned and pspace_distinct) \<top>
+     (arch_post_set_flags  t flags) (postSetFlags t flags')"
+  by (clarsimp simp: arch_post_set_flags_def postSetFlags_def)
+
 end
 
 lemma setFlags_corres[corres]:
@@ -1664,12 +1670,9 @@ crunch set_flags
   for pspace_aligned[wp]: pspace_aligned
   and pspace_distinct[wp]: pspace_distinct
 
-context begin interpretation Arch . (*FIXME: arch-split*)
-
 lemma tcbFlagToWord_bit:
   "(\<exists>n. tcbFlagToWord flag = bit n) \<or> tcbFlagToWord flag = 0"
-  by (auto simp: tcbFlagToWord_def archTcbFlagToWord_def split: tcb_flag.splits
-       simp del: bit_def)
+  by (auto simp: tcbFlagToWord_def split: tcb_flag.splits simp del: bit_def)
 
 lemma word_to_tcb_flags_subtract:
   "word_to_tcb_flags (flags && ~~ flags') = word_to_tcb_flags flags - word_to_tcb_flags flags'"
@@ -1686,14 +1689,6 @@ lemma word_to_tcb_flags_union:
   done
 
 lemmas word_to_tcb_flags_simps = word_to_tcb_flags_subtract word_to_tcb_flags_union
-
-lemma postSetFlags_corres[corres]:
-  "flags = word_to_tcb_flags flags' \<Longrightarrow>
-   corres dc (pspace_aligned and pspace_distinct) \<top>
-     (arch_post_set_flags  t flags) (postSetFlags t flags')"
-  by (clarsimp simp: arch_post_set_flags_def postSetFlags_def)
-
-end
 
 consts
   copyregsets_map :: "arch_copy_register_sets \<Rightarrow> Arch.copy_register_sets"

--- a/proof/refine/RISCV64/orphanage/Orphanage.thy
+++ b/proof/refine/RISCV64/orphanage/Orphanage.thy
@@ -1700,7 +1700,7 @@ lemma invokeTCB_no_orphans [wp]:
     apply (wp tc_no_orphans)
     apply (clarsimp split: option.splits simp: msg_align_bits elim!:is_aligned_weaken)
    apply (wpsimp simp: invokeTCB_def)
-  apply (wpsimp simp: invokeTCB_def)
+  apply (wpsimp simp: invokeTCB_def invokeSetFlags_def)
   done
 
 lemma invokeCNode_no_orphans [wp]:

--- a/proof/refine/TcbFlags_R.thy
+++ b/proof/refine/TcbFlags_R.thy
@@ -1,0 +1,90 @@
+(*
+ * Copyright 2025, Proofcraft Pty Ltd
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+(* Lemmas connecting how the design and abstract specifications represent TCB flags.
+   That is, bitwise with a word in the design spec and as a set in the abstract spec. *)
+
+theory TcbFlags_R
+imports BaseRefine.Include Move_R
+begin
+
+lemma ex_tcbFlagToWord_bit:
+  "\<exists>n<word_bits. tcbFlagToWord flag = bit n"
+  by (auto simp: tcbFlagToWord_def ex_nat_less_eq word_bits_conv split: tcb_flag.splits simp del: bit_def)
+
+lemma ex_tcbFlagToWord:
+  "tcbFlagMask !! n \<Longrightarrow> \<exists>flag. tcbFlagToWord flag = bit n"
+  by (auto simp: tcbFlagToWord_def tcbFlagMask_def split: tcb_flag.splits if_splits)
+
+lemma tcbFlagToWord_and_tcbFlagMask_eq:
+  "flag \<in> word_to_tcb_flags tcbFlagMask \<Longrightarrow> tcbFlagToWord flag && tcbFlagMask = tcbFlagToWord flag"
+  by (cut_tac flag=flag in ex_tcbFlagToWord_bit) (fastforce simp: word_to_tcb_flags_def word_eq_iff)
+
+lemma word_to_tcb_flags_not:
+  "word_to_tcb_flags (~~ flags) = word_to_tcb_flags tcbFlagMask - word_to_tcb_flags flags"
+  apply (clarsimp simp: word_to_tcb_flags_def intro!: set_eqI)
+  apply (cut_tac flag=x in ex_tcbFlagToWord_bit)
+  apply (fastforce simp: word_eq_iff)
+  done
+
+lemma word_to_tcb_flags_or:
+  "word_to_tcb_flags (flags || flags') = word_to_tcb_flags flags \<union> word_to_tcb_flags flags'"
+  apply (clarsimp simp: word_to_tcb_flags_def intro!: set_eqI)
+  apply (cut_tac flag=x in ex_tcbFlagToWord_bit)
+  apply (fastforce simp: word_eq_iff)
+  done
+
+lemma word_to_tcb_flags_and:
+  "word_to_tcb_flags (flags && flags') = word_to_tcb_flags flags \<inter> word_to_tcb_flags flags'"
+  apply (clarsimp simp: word_to_tcb_flags_def intro!: set_eqI)
+  apply (cut_tac flag=x in ex_tcbFlagToWord_bit)
+  apply (fastforce simp: word_eq_iff)
+  done
+
+lemmas word_to_tcb_flags_simps = word_to_tcb_flags_not word_to_tcb_flags_or word_to_tcb_flags_and
+
+lemma word_to_tcb_flags_and_not:
+  "flags && tcbFlagMask = flags
+   \<Longrightarrow> word_to_tcb_flags (flags && ~~ flags') = word_to_tcb_flags flags - word_to_tcb_flags flags'"
+  apply (clarsimp simp: word_to_tcb_flags_def intro!: set_eqI)
+  apply (cut_tac flag=x in ex_tcbFlagToWord_bit)
+  apply (fastforce simp: word_eq_iff)
+  done
+
+lemma word_to_tcb_flags_tcbFlagMask[simp]:
+  "word_to_tcb_flags flags \<inter> word_to_tcb_flags tcbFlagMask = word_to_tcb_flags flags"
+  apply (clarsimp simp: word_to_tcb_flags_def intro!: set_eqI)
+  apply (cut_tac flag=x in ex_tcbFlagToWord_bit)
+  apply (fastforce simp: word_eq_iff)
+  done
+
+lemma tcb_flags_to_word_id:
+  "tcb_flags_to_word (word_to_tcb_flags w) = w && tcbFlagMask"
+  unfolding tcb_flags_to_word_def word_to_tcb_flags_def
+  apply (rule the_equality; clarsimp simp: Collect_eq word_bw_lcs)
+  apply (rule ccontr)
+  apply (subst (asm) all_not_ex)
+  apply (erule FalseI)
+  apply (subst (asm) word_eq_iff)+
+  apply clarsimp
+  apply (prop_tac "tcbFlagMask !! n")
+   apply fastforce
+  apply (frule ex_tcbFlagToWord)
+  apply clarsimp
+  apply (rule_tac x=flag in exI)
+  apply (clarsimp simp: not_nth_is_and_eq_0[symmetric] word_bw_assocs[symmetric] word_bw_comms)
+  done
+
+lemma isFlagSet_in_word_to_tcb_flags[simp]:
+  "flag \<in> word_to_tcb_flags tcbFlagMask \<Longrightarrow> isFlagSet flag flags = (flag \<in> word_to_tcb_flags flags)"
+  by (drule tcbFlagToWord_and_tcbFlagMask_eq)
+     (clarsimp simp: isFlagSet_def word_to_tcb_flags_def word_bw_lcs intro!: eq_eqI word_bw_comms)
+
+lemma FpuDisabled_in_tcbFlagMask[simp]:
+  "config_HAVE_FPU \<Longrightarrow> FpuDisabled \<in> word_to_tcb_flags tcbFlagMask"
+  by (clarsimp simp: word_to_tcb_flags_def tcbFlagToWord_def tcbFlagMask_def)
+
+end

--- a/proof/refine/X64/ArchStateRelation.thy
+++ b/proof/refine/X64/ArchStateRelation.thy
@@ -186,7 +186,7 @@ definition arch_state_relation :: "(arch_state \<times> X64_H.kernel_state) set"
        \<and> x64_allocated_io_ports s = x64KSAllocatedIOPorts s'
        \<and> x64_num_ioapics s = x64KSNumIOAPICs s'
        \<and> x64_ioapic_nirqs s = x64KSIOAPICnIRQs s'
-       \<and> x64_irq_relation (x64_irq_state s) (x64KSIRQState s')}
+       \<and> x64_irq_relation (x64_irq_state s) (x64KSIRQState s')
        \<and> x64_current_fpu_owner s = x64KSCurFPUOwner s'}"
 
 end

--- a/proof/refine/X64/IpcCancel_R.thy
+++ b/proof/refine/X64/IpcCancel_R.thy
@@ -2299,6 +2299,13 @@ lemma asUser_tcbQueued[wp]:
   unfolding asUser_def threadGet_stateAssert_gets_asUser
   by (wpsimp wp: threadSet_obj_at'_no_state simp: asUser_fetch_def obj_at'_def)
 
+lemmas asUser_st_tcb_at'[wp] = asUser_obj_at[folded st_tcb_at'_def]
+
+crunch fpuRelease
+  for st_tcb_at'[wp]: "\<lambda>s. Q (st_tcb_at' P t s)"
+  and valid_objs'[wp]: valid_objs'
+  and sch_act_wf[wp]: "\<lambda>s. sch_act_wf (ksSchedulerAction s) s"
+
 crunch prepareThreadDelete
   for unqueued: "obj_at' (Not \<circ> tcbQueued) t"
   and inactive: "st_tcb_at' ((=) Inactive) t'"

--- a/proof/refine/X64/Retype_R.thy
+++ b/proof/refine/X64/Retype_R.thy
@@ -108,13 +108,13 @@ lemma valid_obj_makeObject_cte [simp]:
 
 lemma valid_obj_makeObject_tcb [simp]:
   "valid_obj' (KOTCB makeObject) s"
-  unfolding valid_obj'_def valid_tcb'_def  valid_tcb_state'_def
+  unfolding valid_obj'_def valid_tcb'_def valid_tcb_state'_def
   by (clarsimp simp: makeObject_tcb makeObject_cte tcb_cte_cases_def minBound_word newArchTCB_def
                      cteSizeBits_def valid_arch_tcb'_def)
 
 lemma valid_obj_makeObject_tcb_tcbDomain_update [simp]:
   "d \<le> maxDomain \<Longrightarrow> valid_obj' (KOTCB (tcbDomain_update (\<lambda>_. d) makeObject)) s"
-  unfolding valid_obj'_def valid_tcb'_def  valid_tcb_state'_def valid_arch_tcb'_def
+  unfolding valid_obj'_def valid_tcb'_def valid_tcb_state'_def valid_arch_tcb'_def
   by (clarsimp simp: makeObject_tcb makeObject_cte objBits_simps' newArchTCB_def
                      tcb_cte_cases_def maxDomain_def maxPriority_def numPriorities_def minBound_word)
 

--- a/proof/refine/X64/Syscall_R.thy
+++ b/proof/refine/X64/Syscall_R.thy
@@ -514,7 +514,7 @@ lemma invokeTCB_typ_at'[wp]:
      invokeTCB tinv
    \<lbrace>\<lambda>rv s. P (typ_at' T p s)\<rbrace>"
   apply (cases tinv,
-         simp_all add: invokeTCB_def
+         simp_all add: invokeTCB_def invokeSetFlags_def
                        getThreadBufferSlot_def locateSlot_conv
             split del: if_split)
    apply (simp only: cases_simp if_cancel simp_thms conj_comms pred_conj_def

--- a/proof/refine/X64/TcbAcc_R.thy
+++ b/proof/refine/X64/TcbAcc_R.thy
@@ -770,6 +770,7 @@ lemma threadSet_valid_pspace'T_P:
   assumes u: "\<forall>tcb. tcbDomain tcb \<le> maxDomain \<longrightarrow> tcbDomain (F tcb) \<le> maxDomain"
   assumes w: "\<forall>tcb. tcbPriority tcb \<le> maxPriority \<longrightarrow> tcbPriority (F tcb) \<le> maxPriority"
   assumes w': "\<forall>tcb. tcbMCP tcb \<le> maxPriority \<longrightarrow> tcbMCP (F tcb) \<le> maxPriority"
+  assumes f: "\<forall>tcb. tcbFlags tcb && ~~ tcbFlagMask = 0 \<longrightarrow> tcbFlags (F tcb) && ~~ tcbFlagMask = 0"
   shows
   "\<lbrace>valid_pspace' and (\<lambda>s. P \<longrightarrow> st_tcb_at' Q t s \<and> bound_tcb_at' Q' t s
                                  \<and> obj_at' (\<lambda>tcb. Q'' (tcbSchedPrev tcb)) t s
@@ -783,7 +784,7 @@ lemma threadSet_valid_pspace'T_P:
   apply (erule(1) valid_objsE')
   apply (clarsimp simp add: valid_obj'_def valid_tcb'_def
                             bspec_split [OF spec [OF x]] z
-                            split_paired_Ball y u w v w' p n)
+                            split_paired_Ball y u w v w' p n f)
   apply (simp add: valid_arch_tcb'_def) (* FIXME arch-split: non-hyp only *)
   done
 
@@ -1331,6 +1332,7 @@ lemma threadSet_invs_trivialT:
     "\<forall>tcb. tcbDomain (F tcb) = tcbDomain tcb"
     "\<forall>tcb. tcbPriority (F tcb) = tcbPriority tcb"
     "\<forall>tcb. tcbMCP tcb \<le> maxPriority \<longrightarrow> tcbMCP (F tcb) \<le> maxPriority"
+    "\<forall>tcb. tcbFlags tcb && ~~ tcbFlagMask = 0 \<longrightarrow> tcbFlags (F tcb) && ~~ tcbFlagMask = 0"
   shows "threadSet F t \<lbrace>invs'\<rbrace>"
   apply (simp add: invs'_def valid_state'_def split del: if_split)
   apply (wp threadSet_valid_pspace'T

--- a/proof/refine/X64/Tcb_R.thy
+++ b/proof/refine/X64/Tcb_R.thy
@@ -1681,6 +1681,13 @@ lemma setSchedulerAction_invs'[wp]:
   apply (simp add: ct_idle_or_in_cur_domain'_def)
   done
 
+lemma postSetFlags_corres[corres]:
+  "flags = word_to_tcb_flags flags' \<Longrightarrow>
+   corres dc (pspace_aligned and pspace_distinct and valid_cur_fpu) \<top>
+     (arch_post_set_flags  t flags) (postSetFlags t flags')"
+  unfolding arch_post_set_flags_def postSetFlags_def
+  by (corres term_simp: isFlagSet_set)
+
 end
 
 lemma setFlags_corres[corres]:
@@ -1696,12 +1703,9 @@ crunch set_flags
   and pspace_distinct[wp]: pspace_distinct
   and valid_cur_fpu[wp]: valid_cur_fpu
 
-context begin interpretation Arch . (*FIXME: arch-split*)
-
 lemma tcbFlagToWord_bit:
   "\<exists>n. tcbFlagToWord flag = bit n"
-  by (auto simp: tcbFlagToWord_def archTcbFlagToWord_def split: tcb_flag.splits arch_tcb_flag.splits
-       simp del: bit_def)
+  by (auto simp: tcbFlagToWord_def split: tcb_flag.splits simp del: bit_def)
 
 lemma word_to_tcb_flags_subtract:
   "word_to_tcb_flags (flags && ~~ flags') = word_to_tcb_flags flags - word_to_tcb_flags flags'"
@@ -1718,15 +1722,6 @@ lemma word_to_tcb_flags_union:
   done
 
 lemmas word_to_tcb_flags_simps = word_to_tcb_flags_subtract word_to_tcb_flags_union
-
-lemma postSetFlags_corres[corres]:
-  "flags = word_to_tcb_flags flags' \<Longrightarrow>
-   corres dc (pspace_aligned and pspace_distinct and valid_cur_fpu) \<top>
-     (arch_post_set_flags  t flags) (postSetFlags t flags')"
-  unfolding arch_post_set_flags_def postSetFlags_def
-  by (corres term_simp: isFlagSet_set)
-
-end
 
 consts
   copyregsets_map :: "arch_copy_register_sets \<Rightarrow> Arch.copy_register_sets"

--- a/proof/refine/X64/Tcb_R.thy
+++ b/proof/refine/X64/Tcb_R.thy
@@ -1109,6 +1109,7 @@ lemma threadSet_invs_trivialT2:
     "\<forall>tcb. tcbDomain tcb \<le> maxDomain \<longrightarrow> tcbDomain (F tcb) \<le> maxDomain"
     "\<forall>tcb. tcbPriority tcb \<le> maxPriority \<longrightarrow> tcbPriority (F tcb) \<le> maxPriority"
     "\<forall>tcb. tcbMCP tcb \<le> maxPriority \<longrightarrow> tcbMCP (F tcb) \<le> maxPriority"
+    "\<forall>tcb. tcbFlags tcb && ~~ tcbFlagMask = 0 \<longrightarrow> tcbFlags (F tcb) && ~~ tcbFlagMask = 0"
   shows
     "\<lbrace>\<lambda>s. invs' s \<and> (\<forall>tcb. is_aligned (tcbIPCBuffer (F tcb)) msg_align_bits)\<rbrace>
      threadSet F t
@@ -1681,12 +1682,14 @@ lemma setSchedulerAction_invs'[wp]:
   apply (simp add: ct_idle_or_in_cur_domain'_def)
   done
 
+(* FIXME FPU: when the FPU being enabled is properly configurable for the proofs then this shouldn't
+              need to unfold config_HAVE_FPU. *)
 lemma postSetFlags_corres[corres]:
   "flags = word_to_tcb_flags flags' \<Longrightarrow>
    corres dc (pspace_aligned and pspace_distinct and valid_cur_fpu) \<top>
      (arch_post_set_flags  t flags) (postSetFlags t flags')"
   unfolding arch_post_set_flags_def postSetFlags_def
-  by (corres term_simp: isFlagSet_set)
+  by (corres term_simp: Kernel_Config.config_HAVE_FPU_def)
 
 end
 
@@ -1703,25 +1706,6 @@ crunch set_flags
   and pspace_distinct[wp]: pspace_distinct
   and valid_cur_fpu[wp]: valid_cur_fpu
 
-lemma tcbFlagToWord_bit:
-  "\<exists>n. tcbFlagToWord flag = bit n"
-  by (auto simp: tcbFlagToWord_def split: tcb_flag.splits simp del: bit_def)
-
-lemma word_to_tcb_flags_subtract:
-  "word_to_tcb_flags (flags && ~~ flags') = word_to_tcb_flags flags - word_to_tcb_flags flags'"
-  apply (clarsimp simp: word_to_tcb_flags_def intro!: set_eqI)
-  apply (cut_tac flag=x in tcbFlagToWord_bit)
-  apply (fastforce simp: word_eq_iff tcbFlagToWord_bit)
-  done
-
-lemma word_to_tcb_flags_union:
-  "word_to_tcb_flags (flags || flags') = word_to_tcb_flags flags \<union> word_to_tcb_flags flags'"
-  apply (clarsimp simp: word_to_tcb_flags_def intro!: set_eqI)
-  apply (cut_tac flag=x in tcbFlagToWord_bit)
-  apply (fastforce simp: word_eq_iff tcbFlagToWord_bit)
-  done
-
-lemmas word_to_tcb_flags_simps = word_to_tcb_flags_subtract word_to_tcb_flags_union
 
 consts
   copyregsets_map :: "arch_copy_register_sets \<Rightarrow> Arch.copy_register_sets"
@@ -1800,6 +1784,15 @@ where
 | "tcb_inv_wf' (tcbinvocation.SetFlags ref clears sets)
              = (tcb_at' ref and ex_nonz_cap_to' ref)"
 
+lemma invokeSetFlags_helper:
+  "flags = word_to_tcb_flags flags' \<Longrightarrow>
+   corres (=) \<top> (K (flags' && ~~ tcbFlagMask = 0))
+     (return [tcb_flags_to_word (flags - word_to_tcb_flags clears' \<union> word_to_tcb_flags sets')])
+     (return [flags' && ~~ clears' || sets' && tcbFlagMask])"
+  by (fastforce simp: mask_eq_x_eq_0[symmetric] word_to_tcb_flags_simps[symmetric]
+                      word_to_tcb_flags_and_not[symmetric] tcb_flags_to_word_id word_bw_comms
+                      word_ao_dist2 word_bw_assocs[symmetric])
+
 lemma invokeTCB_corres:
  "tcbinv_relation ti ti' \<Longrightarrow>
   corres (dc \<oplus> (=))
@@ -1854,10 +1847,13 @@ lemma invokeTCB_corres:
           apply (wpsimp wp: hoare_drop_imp)+
     apply (fastforce dest: valid_sched_valid_queues simp: valid_sched_weak_strg)
    apply fastforce
-  apply (clarsimp simp: invokeTCB_def)
+  apply (clarsimp simp: invokeTCB_def invokeSetFlags_def bind_assoc)
   apply (corres corres: threadGet_corres[where r="\<lambda>flags flags'. flags = word_to_tcb_flags flags'"]
-             term_simp: tcb_relation_def word_to_tcb_flags_simps)
-   apply fastforce+
+                        invokeSetFlags_helper
+             term_simp: tcb_relation_def word_to_tcb_flags_simps Diff_Int_distrib Diff_Int
+                    wp: threadGet_wp)
+   apply fastforce
+  apply (fastforce dest: tcb_ko_at_valid_objs_valid_tcb' simp: valid_tcb'_def)
   done
 
 lemma tcbBoundNotification_caps_safe[simp]:
@@ -1928,11 +1924,19 @@ lemma setTLSBase_invs'[wp]:
    \<lbrace>\<lambda>rv. invs'\<rbrace>"
   by (wpsimp simp: invokeTCB_def)
 
-lemma threadSet_flags_invs[wp]:
-  "threadSet (tcbFlags_update f) t \<lbrace>invs'\<rbrace>"
-  by (wpsimp wp: threadSet_invs_trivial)
+lemma threadSet_flags_invs'[wp]:
+  "\<lbrace>invs' and K (\<forall>flags. flags && ~~ tcbFlagMask = 0 \<longrightarrow> f flags && ~~ tcbFlagMask = 0)\<rbrace>
+   threadSet (tcbFlags_update f) t
+   \<lbrace>\<lambda>_. invs'\<rbrace>"
+  by (rule hoare_gen_asm) (wpsimp wp: threadSet_invs_trivial)
 
-crunch setFlags, postSetFlags
+lemma setFlags_invs'[wp]:
+  "\<lbrace>invs' and K (flags && ~~ tcbFlagMask = 0)\<rbrace>
+   setFlags t flags
+   \<lbrace>\<lambda>_. invs'\<rbrace>"
+  by (wpsimp simp: setFlags_def wp: threadSet_flags_invs')
+
+crunch postSetFlags
   for invs'[wp]: invs'
   (ignore: threadSet)
 
@@ -1940,7 +1944,11 @@ lemma invokeSetFlags_invs'[wp]:
   "\<lbrace>invs' and tcb_inv_wf' (tcbinvocation.SetFlags tcb clears' sets')\<rbrace>
    invokeTCB (tcbinvocation.SetFlags tcb clears' sets')
    \<lbrace>\<lambda>rv. invs'\<rbrace>"
-  by (wpsimp simp: invokeTCB_def)
+  unfolding invokeTCB_def invokeSetFlags_def
+  apply (wpsimp wp: threadGet_wp)
+  apply (fastforce dest: tcb_ko_at_valid_objs_valid_tcb'
+                   simp: valid_tcb'_def word_ao_dist word_bw_assocs word_bw_lcs)+
+  done
 
 lemma tcbinv_invs':
   "\<lbrace>invs' and sch_act_simple and ct_in_state' runnable' and tcb_inv_wf' ti\<rbrace>

--- a/spec/abstract/AARCH64/ArchTcb_A.thy
+++ b/spec/abstract/AARCH64/ArchTcb_A.thy
@@ -29,7 +29,7 @@ definition arch_post_modify_registers :: "obj_ref \<Rightarrow> obj_ref \<Righta
 \<comment> \<open>The corresponding C code is not arch dependent and so is inline as part of invokeSetFlags\<close>
 definition arch_post_set_flags :: "obj_ref \<Rightarrow> tcb_flags \<Rightarrow> (unit, 'a::state_ext) s_monad" where
   "arch_post_set_flags t flags \<equiv>
-     when (ArchFlag FpuDisabled \<in> flags) (fpu_release t)"
+     when (FpuDisabled \<in> flags) (fpu_release t)"
 
 definition arch_prepare_set_domain :: "obj_ref \<Rightarrow> domain \<Rightarrow> (unit, 'a::state_ext) s_monad" where
   "arch_prepare_set_domain t new_dom \<equiv> do

--- a/spec/abstract/AARCH64/FPU_A.thy
+++ b/spec/abstract/AARCH64/FPU_A.thy
@@ -54,7 +54,7 @@ definition fpu_release :: "obj_ref \<Rightarrow> (unit,'z::state_ext) s_monad" w
 definition lazy_fpu_restore :: "obj_ref \<Rightarrow> (unit,'z::state_ext) s_monad" where
   "lazy_fpu_restore thread_ptr \<equiv> do
      flags \<leftarrow> thread_get tcb_flags thread_ptr;
-     if ArchFlag FpuDisabled \<in> flags
+     if FpuDisabled \<in> flags
      then do_machine_op disableFpu
      else do
        cur_fpu_owner \<leftarrow> gets (arm_current_fpu_owner \<circ> arch_state);

--- a/spec/abstract/Structures_A.thy
+++ b/spec/abstract/Structures_A.thy
@@ -372,8 +372,14 @@ type_synonym domain = word8
 
 type_synonym tcb_flags = "tcb_flag set"
 
+text \<open>
+  The set of TCB flags may be larger than the set of configured flags (e.g. FpuDisabled is only
+  used when FPU is configured), hence we only convert flags in `tcbFlagMask`. \<close>
 definition word_to_tcb_flags :: "machine_word \<Rightarrow> tcb_flags" where
-  "word_to_tcb_flags w \<equiv> {flag. tcbFlagToWord flag && w \<noteq> 0}"
+  "word_to_tcb_flags w \<equiv> {flag. w && tcbFlagToWord flag && tcbFlagMask \<noteq> 0}"
+
+definition tcb_flags_to_word :: "tcb_flags \<Rightarrow> machine_word" where
+  "tcb_flags_to_word flags \<equiv> THE w. word_to_tcb_flags w = flags \<and> w && ~~ tcbFlagMask = 0"
 
 record tcb =
  tcb_ctable        :: cap

--- a/spec/abstract/Tcb_A.thy
+++ b/spec/abstract/Tcb_A.thy
@@ -259,7 +259,7 @@ where
     new_flags \<leftarrow> return $ flags - clearFlags \<union> setFlags;
     set_flags tcb new_flags;
     arch_post_set_flags tcb new_flags;
-    return []
+    return [tcb_flags_to_word new_flags]
   od)"
 
 definition

--- a/spec/abstract/X64/ArchTcb_A.thy
+++ b/spec/abstract/X64/ArchTcb_A.thy
@@ -49,7 +49,7 @@ where
 \<comment> \<open>The corresponding C code is not arch dependent and so is inline as part of invokeSetFlags\<close>
 definition arch_post_set_flags :: "obj_ref \<Rightarrow> tcb_flags \<Rightarrow> (unit, 'a::state_ext) s_monad" where
   "arch_post_set_flags t flags \<equiv>
-     when (ArchFlag FpuDisabled \<in> flags) (fpu_release t)"
+     when (FpuDisabled \<in> flags) (fpu_release t)"
 
 definition arch_prepare_set_domain :: "obj_ref \<Rightarrow> domain \<Rightarrow> (unit, 'a::state_ext) s_monad" where
   "arch_prepare_set_domain t new_dom \<equiv> do

--- a/spec/abstract/X64/FPU_A.thy
+++ b/spec/abstract/X64/FPU_A.thy
@@ -54,7 +54,7 @@ definition fpu_release :: "obj_ref \<Rightarrow> (unit,'z::state_ext) s_monad" w
 definition lazy_fpu_restore :: "obj_ref \<Rightarrow> (unit,'z::state_ext) s_monad" where
   "lazy_fpu_restore thread_ptr \<equiv> do
      flags \<leftarrow> thread_get tcb_flags thread_ptr;
-     if ArchFlag FpuDisabled \<in> flags
+     if FpuDisabled \<in> flags
      then do_machine_op disableFpu
      else do
        cur_fpu_owner \<leftarrow> gets (x64_current_fpu_owner \<circ> arch_state);

--- a/spec/cspec/c/gen-config-thy.py
+++ b/spec/cspec/c/gen-config-thy.py
@@ -130,7 +130,7 @@ known_config_keys = {
     'CONFIG_EXPORT_PTMR_USER': (bool, None),
     'CONFIG_EXPORT_VTMR_USER': (bool, None),
     'CONFIG_VTIMER_UPDATE_VOFFSET': (bool, None),
-    'CONFIG_HAVE_FPU': (bool, None),
+    'CONFIG_HAVE_FPU': (bool, 'config_HAVE_FPU'),
     'CONFIG_PADDR_USER_DEVICE_TOP': (word, None),
     'CONFIG_ROOT_CNODE_SIZE_BITS': (nat, None),
     'CONFIG_TIMER_TICK_MS': (word, None),

--- a/spec/design/skel/AARCH64/ArchStructures_H.thy
+++ b/spec/design/skel/AARCH64/ArchStructures_H.thy
@@ -18,11 +18,11 @@ context Arch begin arch_global_naming (H)
 #INCLUDE_SETTINGS keep_constructor=arch_tcb
 
 #INCLUDE_HASKELL SEL4/Object/Structures/AARCH64.hs CONTEXT AARCH64_H decls_only \
-  NOT VPPIEventIRQ VirtTimer ArchTcbFlag archTcbFlagToWord
+  NOT VPPIEventIRQ VirtTimer
 #INCLUDE_HASKELL SEL4/Object/Structures/AARCH64.hs CONTEXT AARCH64_H instanceproofs \
   NOT VPPIEventIRQ VirtTimer
 #INCLUDE_HASKELL SEL4/Object/Structures/AARCH64.hs CONTEXT AARCH64_H bodies_only \
-  NOT makeVCPUObject archTcbFlagToWord
+  NOT makeVCPUObject
 
 (* we define makeVCPUObject_def manually because we want a total function vgicLR *)
 defs makeVCPUObject_def:

--- a/spec/design/skel/AARCH64/Arch_Structs_B.thy
+++ b/spec/design/skel/AARCH64/Arch_Structs_B.thy
@@ -21,8 +21,6 @@ context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/API/Invocation/AARCH64.hs CONTEXT AARCH64_H ONLY FlushType
 
-#INCLUDE_HASKELL SEL4/Object/Structures/AARCH64.hs CONTEXT AARCH64_H ONLY ArchTcbFlag archTcbFlagToWord
-
 end
 
 end

--- a/spec/design/skel/ARM/ArchStructures_H.thy
+++ b/spec/design/skel/ARM/ArchStructures_H.thy
@@ -15,11 +15,9 @@ context Arch begin arch_global_naming (H)
 #INCLUDE_SETTINGS keep_constructor=asidpool
 #INCLUDE_SETTINGS keep_constructor=arch_tcb
 
-#INCLUDE_HASKELL SEL4/Object/Structures/ARM.lhs CONTEXT ARM_H decls_only \
-  NOT ArchTcbFlag archTcbFlagToWord
+#INCLUDE_HASKELL SEL4/Object/Structures/ARM.lhs CONTEXT ARM_H decls_only
 #INCLUDE_HASKELL SEL4/Object/Structures/ARM.lhs CONTEXT ARM_H instanceproofs
-#INCLUDE_HASKELL SEL4/Object/Structures/ARM.lhs CONTEXT ARM_H bodies_only \
-  NOT archTcbFlagToWord
+#INCLUDE_HASKELL SEL4/Object/Structures/ARM.lhs CONTEXT ARM_H bodies_only
 
 datatype arch_kernel_object_type =
     PDET

--- a/spec/design/skel/ARM/Arch_Structs_B.thy
+++ b/spec/design/skel/ARM/Arch_Structs_B.thy
@@ -19,7 +19,5 @@ context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Model/StateData/ARM.lhs CONTEXT ARM_H ONLY ArmVSpaceRegionUse
 
-#INCLUDE_HASKELL SEL4/Object/Structures/ARM.lhs CONTEXT ARM_H ONLY ArchTcbFlag archTcbFlagToWord
-
 end
 end

--- a/spec/design/skel/ARM_HYP/ArchStructures_H.thy
+++ b/spec/design/skel/ARM_HYP/ArchStructures_H.thy
@@ -15,11 +15,9 @@ context Arch begin arch_global_naming (H)
 #INCLUDE_SETTINGS keep_constructor=asidpool
 #INCLUDE_SETTINGS keep_constructor=arch_tcb
 
-#INCLUDE_HASKELL SEL4/Object/Structures/ARM.lhs CONTEXT ARM_HYP_H decls_only NOT VPPIEventIRQ VirtTimer \
-  NOT ArchTcbFlag archTcbFlagToWord
+#INCLUDE_HASKELL SEL4/Object/Structures/ARM.lhs CONTEXT ARM_HYP_H decls_only NOT VPPIEventIRQ VirtTimer
 #INCLUDE_HASKELL SEL4/Object/Structures/ARM.lhs CONTEXT ARM_HYP_H instanceproofs NOT VPPIEventIRQ VirtTimer
-#INCLUDE_HASKELL SEL4/Object/Structures/ARM.lhs CONTEXT ARM_HYP_H bodies_only NOT makeVCPUObject \
-  NOT archTcbFlagToWord
+#INCLUDE_HASKELL SEL4/Object/Structures/ARM.lhs CONTEXT ARM_HYP_H bodies_only NOT makeVCPUObject
 
 (* we define makeVCPUObject_def manually because we want a total function vgicLR *)
 defs makeVCPUObject_def:

--- a/spec/design/skel/ARM_HYP/Arch_Structs_B.thy
+++ b/spec/design/skel/ARM_HYP/Arch_Structs_B.thy
@@ -18,7 +18,5 @@ context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Model/StateData/ARM.lhs CONTEXT ARM_HYP_H ONLY ArmVSpaceRegionUse
 
-#INCLUDE_HASKELL SEL4/Object/Structures/ARM.lhs CONTEXT ARM_HYP_H ONLY ArchTcbFlag archTcbFlagToWord
-
 end
 end

--- a/spec/design/skel/RISCV64/ArchStructures_H.thy
+++ b/spec/design/skel/RISCV64/ArchStructures_H.thy
@@ -16,11 +16,9 @@ context Arch begin arch_global_naming (H)
 #INCLUDE_SETTINGS keep_constructor=asidpool
 #INCLUDE_SETTINGS keep_constructor=arch_tcb
 
-#INCLUDE_HASKELL SEL4/Object/Structures/RISCV64.hs CONTEXT RISCV64_H decls_only \
-  NOT ArchTcbFlag archTcbFlagToWord
+#INCLUDE_HASKELL SEL4/Object/Structures/RISCV64.hs CONTEXT RISCV64_H decls_only
 #INCLUDE_HASKELL SEL4/Object/Structures/RISCV64.hs CONTEXT RISCV64_H instanceproofs
-#INCLUDE_HASKELL SEL4/Object/Structures/RISCV64.hs CONTEXT RISCV64_H bodies_only \
-  NOT archTcbFlagToWord
+#INCLUDE_HASKELL SEL4/Object/Structures/RISCV64.hs CONTEXT RISCV64_H bodies_only
 
 datatype arch_kernel_object_type =
     PTET

--- a/spec/design/skel/RISCV64/Arch_Structs_B.thy
+++ b/spec/design/skel/RISCV64/Arch_Structs_B.thy
@@ -19,8 +19,6 @@ context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Model/StateData/RISCV64.hs CONTEXT RISCV64_H ONLY RISCVVSpaceRegionUse
 
-#INCLUDE_HASKELL SEL4/Object/Structures/RISCV64.hs CONTEXT RISCV64_H ONLY ArchTcbFlag archTcbFlagToWord
-
 end
 
 end

--- a/spec/design/skel/Structs_B.thy
+++ b/spec/design/skel/Structs_B.thy
@@ -13,6 +13,6 @@ imports Arch_Structs_B
 begin
 
 #INCLUDE_SETTINGS keep_constructor = tcb_flag
-#INCLUDE_HASKELL SEL4/Object/Structures.lhs ONLY TcbFlag tcbFlagToWord
+#INCLUDE_HASKELL SEL4/Object/Structures.lhs ONLY TcbFlag tcbFlagToWord tcbFlagMask
 
 end

--- a/spec/design/skel/Structs_B.thy
+++ b/spec/design/skel/Structs_B.thy
@@ -12,12 +12,6 @@ theory Structs_B
 imports Arch_Structs_B
 begin
 
-arch_requalify_types (H)
-  arch_tcb_flag
-
-arch_requalify_consts (H)
-  archTcbFlagToWord
-
 #INCLUDE_SETTINGS keep_constructor = tcb_flag
 #INCLUDE_HASKELL SEL4/Object/Structures.lhs ONLY TcbFlag tcbFlagToWord
 

--- a/spec/design/skel/Structures_H.thy
+++ b/spec/design/skel/Structures_H.thy
@@ -35,8 +35,8 @@ arch_requalify_consts (H)
   atcbContextGet
   atcbContextSet
 
-#INCLUDE_HASKELL SEL4/Object/Structures.lhs decls_only NOT isNullCap isUntypedCap isIRQControlCap isReplyCap isDomainCap isNotificationCap TcbFlag tcbFlagToWord
-#INCLUDE_HASKELL SEL4/Object/Structures.lhs bodies_only NOT kernelObjectTypeName isNullCap isUntypedCap isIRQControlCap isReplyCap isDomainCap isNotificationCap tcbFlagToWord
+#INCLUDE_HASKELL SEL4/Object/Structures.lhs decls_only NOT isNullCap isUntypedCap isIRQControlCap isReplyCap isDomainCap isNotificationCap TcbFlag tcbFlagToWord tcbFlagMask
+#INCLUDE_HASKELL SEL4/Object/Structures.lhs bodies_only NOT kernelObjectTypeName isNullCap isUntypedCap isIRQControlCap isReplyCap isDomainCap isNotificationCap tcbFlagToWord tcbFlagMask
 
 
 end

--- a/spec/design/skel/X64/ArchStructures_H.thy
+++ b/spec/design/skel/X64/ArchStructures_H.thy
@@ -16,11 +16,9 @@ context Arch begin arch_global_naming (H)
 #INCLUDE_SETTINGS keep_constructor=asidpool
 #INCLUDE_SETTINGS keep_constructor=arch_tcb
 
-#INCLUDE_HASKELL SEL4/Object/Structures/X64.lhs CONTEXT X64_H decls_only \
-  NOT ArchTcbFlag archTcbFlagToWord
+#INCLUDE_HASKELL SEL4/Object/Structures/X64.lhs CONTEXT X64_H decls_only
 #INCLUDE_HASKELL SEL4/Object/Structures/X64.lhs CONTEXT X64_H instanceproofs
-#INCLUDE_HASKELL SEL4/Object/Structures/X64.lhs CONTEXT X64_H bodies_only \
-  NOT archTcbFlagToWord
+#INCLUDE_HASKELL SEL4/Object/Structures/X64.lhs CONTEXT X64_H bodies_only
 
 datatype arch_kernel_object_type =
     PDET

--- a/spec/design/skel/X64/Arch_Structs_B.thy
+++ b/spec/design/skel/X64/Arch_Structs_B.thy
@@ -18,8 +18,6 @@ context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Model/StateData/X64.lhs CONTEXT X64_H ONLY X64VSpaceRegionUse
 
-#INCLUDE_HASKELL SEL4/Object/Structures/X64.lhs CONTEXT X64_H ONLY ArchTcbFlag archTcbFlagToWord
-
 end (* context X64 *)
 
 end

--- a/spec/haskell/src/SEL4/Machine/Hardware.lhs
+++ b/spec/haskell/src/SEL4/Machine/Hardware.lhs
@@ -216,3 +216,9 @@ The constant "nullPointer" is a physical pointer guaranteed to be invalid.
 > nullPointer :: PPtr a
 > nullPointer = PPtr 0
 
+\subsection{Config parameters}
+
+Whether the FPU is enabled or not.
+
+> config_HAVE_FPU :: Bool
+> config_HAVE_FPU = error "generated from CMake config"

--- a/spec/haskell/src/SEL4/Object/FPU/AARCH64.hs
+++ b/spec/haskell/src/SEL4/Object/FPU/AARCH64.hs
@@ -53,7 +53,7 @@ fpuRelease tcbPtr = do
 lazyFpuRestore :: PPtr TCB -> Kernel ()
 lazyFpuRestore tcbPtr = do
     flags <- threadGet tcbFlags tcbPtr
-    if (isFlagSet (ArchFlag FpuDisabled) flags)
+    if (isFlagSet FpuDisabled flags)
       then doMachineOp disableFpu
       else do
           curFpuOwner <- gets (armKSCurFPUOwner . ksArchState)

--- a/spec/haskell/src/SEL4/Object/FPU/X64.hs
+++ b/spec/haskell/src/SEL4/Object/FPU/X64.hs
@@ -53,7 +53,7 @@ fpuRelease tcbPtr = do
 lazyFpuRestore :: PPtr TCB -> Kernel ()
 lazyFpuRestore tcbPtr = do
     flags <- threadGet tcbFlags tcbPtr
-    if (isFlagSet (ArchFlag FpuDisabled) flags)
+    if (isFlagSet FpuDisabled flags)
       then doMachineOp disableFpu
       else do
           curFpuOwner <- gets (x64KSCurFPUOwner . ksArchState)

--- a/spec/haskell/src/SEL4/Object/Structures.lhs
+++ b/spec/haskell/src/SEL4/Object/Structures.lhs
@@ -499,10 +499,10 @@ Various operations on the free index of an Untyped cap.
 
 \subsubsection{TCB Flags}
 
-> data TcbFlag = ArchFlag ArchTcbFlag
+> data TcbFlag = FpuDisabled
 
 > tcbFlagToWord :: TcbFlag -> Word
-> tcbFlagToWord (ArchFlag archFlag) = archTcbFlagToWord archFlag
+> tcbFlagToWord (FpuDisabled) = bit 0
 
 Sets of TCB flags are bitwise OR'd and represented as a word.
 

--- a/spec/haskell/src/SEL4/Object/Structures.lhs
+++ b/spec/haskell/src/SEL4/Object/Structures.lhs
@@ -513,3 +513,6 @@ Sets of TCB flags are bitwise OR'd and represented as a word.
 
 > isFlagSet :: TcbFlag -> TcbFlags -> Bool
 > isFlagSet flag flags = tcbFlagToWord flag .&. flags /= 0
+
+> tcbFlagMask :: Word
+> tcbFlagMask = if config_HAVE_FPU then tcbFlagToWord FpuDisabled else 0

--- a/spec/haskell/src/SEL4/Object/Structures/AARCH64.hs
+++ b/spec/haskell/src/SEL4/Object/Structures/AARCH64.hs
@@ -70,11 +70,6 @@ atcbContextSet uc atcb = atcb { atcbContext = uc }
 atcbContextGet :: ArchTCB -> UserContext
 atcbContextGet = atcbContext
 
-data ArchTcbFlag = FpuDisabled
-
-archTcbFlagToWord :: ArchTcbFlag -> Word
-archTcbFlagToWord (FpuDisabled) = bit 0
-
 
 {- ASID Pools -}
 

--- a/spec/haskell/src/SEL4/Object/Structures/ARM.lhs
+++ b/spec/haskell/src/SEL4/Object/Structures/ARM.lhs
@@ -136,10 +136,6 @@ present on all platforms is stored here.
 > atcbContextGet :: ArchTCB -> UserContext
 > atcbContextGet = atcbContext
 
-> type ArchTcbFlag = ()
-
-> archTcbFlagToWord :: ArchTcbFlag -> Word
-> archTcbFlagToWord _ = 0 -- ARM does not have any arch specific flags but we make this 0 so that some proofs are easier
 
 \subsection{ASID Pools}
 

--- a/spec/haskell/src/SEL4/Object/Structures/RISCV64.hs
+++ b/spec/haskell/src/SEL4/Object/Structures/RISCV64.hs
@@ -73,10 +73,6 @@ atcbContextSet uc atcb = atcb { atcbContext = uc }
 atcbContextGet :: ArchTCB -> UserContext
 atcbContextGet = atcbContext
 
-type ArchTcbFlag = ()
-
-archTcbFlagToWord :: ArchTcbFlag -> Word
-archTcbFlagToWord _ = 0 -- RISCV64 does not have any arch specific flags but we make this 0 so that some proofs are easier
 
 {- ASID Pools -}
 

--- a/spec/haskell/src/SEL4/Object/Structures/X64.lhs
+++ b/spec/haskell/src/SEL4/Object/Structures/X64.lhs
@@ -121,10 +121,6 @@ present on all platforms is stored here.
 > atcbContextGet :: ArchTCB -> UserContext
 > atcbContextGet = atcbContext
 
-> data ArchTcbFlag = FpuDisabled
-
-> archTcbFlagToWord :: ArchTcbFlag -> Word
-> archTcbFlagToWord (FpuDisabled) = bit 0
 
 \subsection{ASID Pools}
 

--- a/spec/haskell/src/SEL4/Object/TCB.lhs
+++ b/spec/haskell/src/SEL4/Object/TCB.lhs
@@ -556,11 +556,16 @@ Modifying the current thread may require rescheduling because modified registers
 
 > invokeTCB (SetFlags tcb flagsClear flagsSet) =
 >   withoutPreemption $ do
+>     newFlags <- invokeSetFlags tcb flagsClear flagsSet
+>     return [newFlags]
+
+> invokeSetFlags :: PPtr TCB -> Word -> Word -> Kernel Word
+> invokeSetFlags tcb flagsClear flagsSet = do
 >     flags <- threadGet tcbFlags tcb
->     let newFlags = (flags .&. complement flagsClear) .|. flagsSet
+>     let newFlags = (flags .&. complement flagsClear) .|. (flagsSet .&. tcbFlagMask)
 >     setFlags tcb newFlags
 >     Arch.postSetFlags tcb newFlags
->     return []
+>     return newFlags
 
 \subsection{Decoding Domain Invocations}
 

--- a/spec/haskell/src/SEL4/Object/TCB/AARCH64.hs
+++ b/spec/haskell/src/SEL4/Object/TCB/AARCH64.hs
@@ -56,7 +56,7 @@ postModifyRegisters _ _ = return ()
 
 postSetFlags :: PPtr TCB -> TcbFlags -> Kernel ()
 postSetFlags t flags =
-    when (isFlagSet (ArchFlag FpuDisabled) flags) (fpuRelease t)
+    when (isFlagSet FpuDisabled flags) (fpuRelease t)
 
 -- Save and clear FPU state before setting the domain of a TCB, to ensure that
 -- we do not later write to cross-domain state.

--- a/spec/haskell/src/SEL4/Object/TCB/X64.lhs
+++ b/spec/haskell/src/SEL4/Object/TCB/X64.lhs
@@ -64,7 +64,7 @@ Here, cur = ksCurThread
 
 > postSetFlags :: PPtr TCB -> TcbFlags -> Kernel ()
 > postSetFlags t flags =
->     when (isFlagSet (ArchFlag FpuDisabled) flags) (fpuRelease t)
+>     when (isFlagSet FpuDisabled flags) (fpuRelease t)
 
 Save and clear FPU state before setting the domain of a TCB, to ensure that
 we do not later write to cross-domain state.


### PR DESCRIPTION
This modifies the specifications and updates the proofs to match a change made to the C code. When setting a TCB's flags the invocation now returns the new flag state. As part of this the type of the flags in the specifications had to be modified to be the same on all architectures, to match the C.

Test with https://github.com/seL4/seL4/pull/1325