### PR TITLE
Simpl: suppress internal simpset warnings

### DIFF
--- a/tools/c-parser/Simpl/hoare.ML
+++ b/tools/c-parser/Simpl/hoare.ML
@@ -3513,7 +3513,8 @@ fun mk_hoare_tac hoare_tac finish_tac annotate_inv exnames
        SOME (Tids,mode,kind)
        => SELECT_GOAL
             (hoare_tac annotate_inv exnames strip_guards mode kind (is_state_space_var Tids)
-                   spec_sfx ctxt (finish_tac kind (is_state_space_var Tids))) i st
+                   spec_sfx (Context_Position.set_visible false ctxt)
+                   (finish_tac kind (is_state_space_var Tids))) i st
      | NONE => no_tac st
 
 fun vcg_tac spec_sfx strip_guards exnames ctxt i st =


### PR DESCRIPTION
Currently any vcg invocation produces a warning about a duplicate simp rule that is used internally. Set the context that is passed to the VCG tactic to internal so that such warnings about internal rules are suppressed.

This creates a diff to the AFP version of Simpl, but it's minimal and easy to maintain. I might try to upstream it at the next Isabelle update. 