### PR TITLE
c-parser: add support for _Static_assert statements

### DIFF
--- a/tools/c-parser/Absyn-Serial.ML
+++ b/tools/c-parser/Absyn-Serial.ML
@@ -116,6 +116,7 @@ fun decl_serial (VarDecl (ty, s, cls, init, atts))
   | decl_serial (EnumDecl (so, xs)) = Nm ("EnumDecl",
         [opt_serial Q (node so), list_serial (pair_serial "EnumElt" (Q o node)
             (opt_serial expr_serial)) xs])
+  | decl_serial (StaticAssertion dets) = Nm ("StaticAssertion", [Q (node (#message dets)), expr_serial (#condition dets)])
 
 fun stmt_serial s = let
     fun os2s (SOME s) = "Some (" ^ s ^ ")"

--- a/tools/c-parser/Absyn-StmtDecl.ML
+++ b/tools/c-parser/Absyn-StmtDecl.ML
@@ -44,6 +44,7 @@ datatype declaration =
                        params : (expr ctype * string option) list,
                        specs : fnspec list}
        | EnumDecl of string option wrap * (string wrap * expr option) list
+       | StaticAssertion of { condition: expr, message: string wrap }
 
 type namedstringexp = string option * string * expr
 

--- a/tools/c-parser/StrictC.grm
+++ b/tools/c-parser/StrictC.grm
@@ -725,6 +725,7 @@ end
             struct_fields wrap * struct_id_decl wrap list
         | struct_declaration of struct_fields wrap * struct_id_decl wrap list
         | type_definition  of declaration
+        | static_assert_declaration of declaration wrap
         | elementary_type of expr ctype
         | integral_type of inttype wrap
         | type_name of expr ctype wrap
@@ -842,6 +843,7 @@ end
     | DONT_TRANSLATE
     | STRING_LITERAL of string
     | SPEC_BLOCKEND
+    | STATIC_ASSERT
     | GCC_ATTRIBUTE
     | YASM
     | YREGISTER
@@ -997,6 +999,13 @@ declaration
                  end) *)
 | declaration_specifiers init_declarator_list YSEMI
                 (make_declaration declaration_specifiers init_declarator_list)
+| static_assert_declaration ([static_assert_declaration])
+
+(* 6.7.10 and/or §A.2.2 ``static_assert-declaration: _Static_assert ( constant-expression , string-literal ) ;'' *)
+(* constant-expression is modelled as rexpression (c.f. "enumerator") *)
+static_assert_declaration
+: STATIC_ASSERT LPAREN rexpression YCOMMA cstring_literal RPAREN YSEMI
+                (wrap(StaticAssertion { condition = rexpression, message = cstring_literal }, eleft rexpression, eright rexpression))
 
 declaration_specifiers
 : storage_class_specifier
@@ -1187,6 +1196,8 @@ struct_declaration
                          left basetype, right struct_declarator_list),
                     sdecls)
                  end)
+(* per the C11 spec this should be allowed but let's not for simplicity *)
+(* | static_assert_declaration () *)
 
 struct_declarator_list :
    struct_declarator (wrap ([node struct_declarator], left struct_declarator,

--- a/tools/c-parser/StrictC.lex
+++ b/tools/c-parser/StrictC.lex
@@ -388,6 +388,8 @@ attr_start = "__attribute__"{ws}*"((";
      (tok(Tokens.YRETURN,source,yypos,yypos+size yytext-1));
 <INITIAL,TDEF,TS,TSS,TSI>"sizeof" =>
      (tok(Tokens.YSIZEOF,source,yypos,yypos+size yytext-1));
+<INITIAL,TDEF,TS,TSS,TSI>"_Static_assert" =>
+     (tok(Tokens.STATIC_ASSERT,source,yypos,yypos+size yytext-1));
 <INITIAL,TS,TSS,TSI>"enum" =>
      (tok(Tokens.YENUM,source,yypos,yypos+size yytext-1));
 <INITIAL,TDEF,TS,TSS,TSI>"__attribute__" =>

--- a/tools/c-parser/program_analysis.ML
+++ b/tools/c-parser/program_analysis.ML
@@ -1681,6 +1681,9 @@ in
       (puredecl d, pop_scope (set_proto_params fname (List.rev pm_vis0) e))
     end
   | EnumDecl eninfo => (puredecl d, process_enumdecl eninfo e)
+  (* nothing to be done *)
+  (* XXX: like process_enumdecl, use const_eval on the condition to check it? *)
+  | StaticAssertion {...} => (puredecl d, e)
 end
 
 type asm_stmt_elements = (string * bool * expr option * expr list)

--- a/tools/c-parser/standalone-parser/main.sml
+++ b/tools/c-parser/standalone-parser/main.sml
@@ -359,6 +359,7 @@ in
                                              NONE => "anonymous"
                                            | SOME s => s)^
                         " enum"
+  | StaticAssertion {message,...} => "static assertion "^node message
 end
 
 fun print_fnslocs cse ast = let
@@ -383,6 +384,7 @@ fun print_ast cse ast = let
         VarDecl (_, s, _, _, _) => "VarDecl: " ^ node s
       | StructDecl (s, _) => "StructDecl: " ^ node s
       | ExtFnDecl exfn => "ExtFnDecl: " ^ node (#name exfn)
+      | StaticAssertion {message, ...} => "StaticAssertion: " ^ node message
       | EnumDecl (soptw, _) =>
           case node soptw of
             SOME s => "EnumDecl: "  ^ s

--- a/tools/c-parser/syntax_transforms.ML
+++ b/tools/c-parser/syntax_transforms.ML
@@ -245,6 +245,12 @@ fun remove_decl_typedefs env d =
     in
       (SOME (EnumDecl (sw, map ecmap ecs)), env)
     end
+  | StaticAssertion {condition, message} => let
+    in
+      (SOME (StaticAssertion { condition = (remove_expr_typedefs env) condition,
+                               message = message }),
+       env)
+    end
 
 val bogus = SourcePos.bogus
 

--- a/tools/c-parser/testfiles/static_assert.c
+++ b/tools/c-parser/testfiles/static_assert.c
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2025, UNSW
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+_Static_assert(2 + 3 == 5, "Hello");
+
+// struct hello {
+//   _Static_assert(4 + 4 == 8, "Goodbye");
+// }

--- a/tools/c-parser/testfiles/static_assert.thy
+++ b/tools/c-parser/testfiles/static_assert.thy
@@ -1,0 +1,18 @@
+(*
+ * Copyright 2025, UNSW
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ *)
+
+theory static_assert
+imports "CParser.CTranslation"
+begin
+
+external_file "static_assert.c"
+install_C_file "static_assert.c"
+
+context static_assert
+begin
+
+end
+end


### PR DESCRIPTION
The kernel AST now produces statements like:

    ##StaticAssertion: long_is_32bits
    StaticAssertion [
      "long_is_32bits"
      BinOp [
        "=="
        SizeofTy [
          Unsigned [
            "long"
          ],
        ],
        Constant [
          NUMCONST [
            "4"
            ""
            "DEC"
          ],
        ],
      ],
    ],

This should allow the horrible array size hack to be removed from the kernel source code, i.e. [include/assert.h](
https://github.com/seL4/seL4/blob/13.0.0/include/assert.h#L45-L69).

---

Was this necessary? No
Was this interesting? Yes
Was this fun? Uhhh well I want to do more of it

---

It doesn't seem like any of the kernel proofs actually proved anything against the static asserts, so this should be fine. (I ran the proofs locally after making all the static assertions false and they still succeeded, so I think only the compiler checks these).

---

I've no idea how to write an appropriate test, aside from that it parses.

I also have [a similar one for offsetof](https://github.com/seL4/l4v/compare/master...midnightveil:seL4-l4v:julia/offsetof?expand=1), but I don't want to trigger the CI builds unnecessarily by making another PR (for the moment, at least).