### PR TITLE
refine: add IRQReserved to state relation

### DIFF
--- a/proof/refine/AARCH64/ArchMachine_R.thy
+++ b/proof/refine/AARCH64/ArchMachine_R.thy
@@ -69,5 +69,14 @@ lemma getActiveIRQ_le_maxIRQ:
   apply (simp add: irqs_masked'_def valid_irq_states'_def)
   done
 
+lemma doMachineOp_getActiveIRQ_non_kernel[wp]:
+  "\<lbrace>\<top>\<rbrace> doMachineOp (getActiveIRQ True)
+   \<lbrace>\<lambda>rv s. \<forall>irq. rv = Some irq \<longrightarrow> irq \<in> non_kernel_IRQs \<longrightarrow> P irq s\<rbrace>"
+  unfolding doMachineOp_def
+  apply wpsimp
+  apply (drule use_valid, rule getActiveIRQ_neq_non_kernel, rule TrueI)
+  apply clarsimp
+  done
+
 end
 end

--- a/proof/refine/AARCH64/Refine.thy
+++ b/proof/refine/AARCH64/Refine.thy
@@ -539,9 +539,8 @@ lemma kernel_corres':
                  activateThread
               od)"
   unfolding call_kernel_def
-  apply (corres corres: handleEvent_corres corres_machine_op
-                        maybeHandleInterrupt_corres
-                simp: irq_state_independent_def
+  apply (corres corres: handleEvent_corres corres_machine_op maybeHandleInterrupt_corres
+                  simp: irq_state_independent_def
          | corres_cases_both)+
         apply (wpsimp wp: handle_event_valid_sched)+
       apply (corres corres: schedule_corres activateThread_corres)

--- a/proof/refine/ARM/Interrupt_R.thy
+++ b/proof/refine/ARM/Interrupt_R.thy
@@ -770,6 +770,11 @@ lemma timerTick_corres:
 
 lemmas corres_eq_trivial = corres_Id[where f = h and g = h for h, simplified]
 
+(* FIXME arch-split: architectures with hypervisor support impose stronger guards *)
+lemma handle_reserved_irq_corres[corres]:
+  "corres dc einvs invs' (handle_reserved_irq irq) (handleReservedIRQ irq)"
+  unfolding handle_reserved_irq_def handleReservedIRQ_def by corres
+
 lemma handleInterrupt_corres:
   "corres dc
      (einvs) (invs' and (\<lambda>s. intStateIRQTable (ksInterruptState s) irq \<noteq> IRQInactive))
@@ -790,25 +795,26 @@ lemma handleInterrupt_corres:
       apply ((wp | simp)+)[4]
   apply (rule corres_gen_asm2)
   apply (case_tac st, simp_all add: irq_state_relation_def split: irqstate.split_asm)
-   apply (simp add: getSlotCap_def bind_assoc)
-   apply (rule corres_guard_imp)
-     apply (rule corres_split[OF getIRQSlot_corres])
-       apply simp
-       apply (rule corres_split[OF get_cap_corres,
-                                 where R="\<lambda>rv. einvs and valid_cap rv"
-                                  and R'="\<lambda>rv. invs' and valid_cap' (cteCap rv)"])
-         apply (rule corres_underlying_split[where r'=dc])
-            apply (case_tac xb, simp_all add: doMachineOp_return)[1]
-             apply (clarsimp simp add: when_def doMachineOp_return)
-             apply (rule corres_guard_imp, rule sendSignal_corres)
-              apply (clarsimp simp: valid_cap_def valid_cap'_def)+
-           apply (clarsimp simp: arch_mask_irq_signal_def maskIrqSignal_def)
-           apply (corres corres: corres_machine_op corres_eq_trivial intro: no_fail_ackInterrupt)
-          apply wpsimp+
-   apply fastforce
-  apply (corres corres: timerTick_corres corres_machine_op simp: bind_assoc)
-   apply fastforce
-  apply clarsimp
+    apply (simp add: getSlotCap_def bind_assoc)
+    apply (rule corres_guard_imp)
+      apply (rule corres_split[OF getIRQSlot_corres])
+        apply simp
+        apply (rule corres_split[OF get_cap_corres,
+                                  where R="\<lambda>rv. einvs and valid_cap rv"
+                                   and R'="\<lambda>rv. invs' and valid_cap' (cteCap rv)"])
+          apply (rule corres_underlying_split[where r'=dc])
+             apply (case_tac xb, simp_all add: doMachineOp_return)[1]
+              apply (clarsimp simp add: when_def doMachineOp_return)
+              apply (rule corres_guard_imp, rule sendSignal_corres)
+               apply (clarsimp simp: valid_cap_def valid_cap'_def)+
+            apply (clarsimp simp: arch_mask_irq_signal_def maskIrqSignal_def)
+            apply (corres corres: corres_machine_op corres_eq_trivial intro: no_fail_ackInterrupt)
+           apply wpsimp+
+    apply fastforce
+   apply (corres corres: timerTick_corres corres_machine_op simp: bind_assoc)
+    apply fastforce
+   apply clarsimp
+  apply (corres corres: corres_machine_op corres_eq_trivial)
   done
 
 lemma threadSet_ksDomainTime[wp]:
@@ -897,6 +903,7 @@ lemma dmo_ackInterrupt[wp]:
                            machine_rest_lift_def split_def | wp)+)[3]
   done
 
+(* FIXME arch-split: imposing a stronger precondition affects InfoFlow refinement *)
 lemma hint_invs[wp]:
   "\<lbrace>invs'\<rbrace> InterruptDecls_H.handleInterrupt irq \<lbrace>\<lambda>rv. invs'\<rbrace>"
   apply (simp add: Interrupt_H.handleInterrupt_def getSlotCap_def

--- a/proof/refine/ARM_HYP/ArchMachine_R.thy
+++ b/proof/refine/ARM_HYP/ArchMachine_R.thy
@@ -69,5 +69,14 @@ lemma getActiveIRQ_le_maxIRQ:
   apply (simp add: irqs_masked'_def valid_irq_states'_def)
   done
 
+lemma doMachineOp_getActiveIRQ_non_kernel[wp]:
+  "\<lbrace>\<top>\<rbrace> doMachineOp (getActiveIRQ True)
+   \<lbrace>\<lambda>rv s. \<forall>irq. rv = Some irq \<longrightarrow> irq \<in> non_kernel_IRQs \<longrightarrow> P irq s\<rbrace>"
+  unfolding doMachineOp_def
+  apply wpsimp
+  apply (drule use_valid, rule getActiveIRQ_neq_non_kernel, rule TrueI)
+  apply clarsimp
+  done
+
 end
 end

--- a/proof/refine/ARM_HYP/Interrupt_R.thy
+++ b/proof/refine/ARM_HYP/Interrupt_R.thy
@@ -1036,16 +1036,17 @@ lemma handle_reserved_irq_corres[corres]:
 
 lemma handleInterrupt_corres:
   "corres dc
-     einvs (invs' and (\<lambda>s. intStateIRQTable (ksInterruptState s) irq \<noteq> IRQInactive))
+     einvs (invs' and (\<lambda>s. intStateIRQTable (ksInterruptState s) irq \<noteq> IRQInactive)
+                  and (\<lambda>s. irq \<in> non_kernel_IRQs \<longrightarrow> sch_act_not (ksCurThread s) s))
      (handle_interrupt irq) (handleInterrupt irq)"
-  (is "corres dc _ ?P' ?f ?g")
+  (is "corres dc _ (invs' and _ and ?P') _ _")
   apply (simp add: handle_interrupt_def handleInterrupt_def)
   apply (rule conjI[rotated]; rule impI)
 
    apply (rule corres_guard_imp)
      apply (rule corres_split[OF getIRQState_corres,
                                where R="\<lambda>rv. einvs"
-                                 and R'="\<lambda>rv. invs' and (\<lambda>s. rv \<noteq> IRQInactive)"])
+                                 and R'="\<lambda>rv. invs' and ?P' and (\<lambda>s. rv \<noteq> IRQInactive)"])
        defer
        apply (wp getIRQState_prop getIRQState_inv do_machine_op_bind doMachineOp_bind | simp add: do_machine_op_bind doMachineOp_bind )+
    apply (rule corres_guard_imp)
@@ -1056,34 +1057,27 @@ lemma handleInterrupt_corres:
       apply ((wp | simp)+)[4]
 
   apply (rule corres_gen_asm2)
-  apply (case_tac st, simp_all add: irq_state_relation_def split: irqstate.split_asm)
-   apply (simp add: getSlotCap_def bind_assoc)
-   apply (rule corres_guard_imp)
-     apply (rule corres_split[OF getIRQSlot_corres])
-       apply simp
-       apply (rule corres_split[OF get_cap_corres,
-                                where R="\<lambda>rv. einvs and valid_cap rv"
-                                  and R'="\<lambda>rv. invs' and valid_cap' (cteCap rv)"])
-         apply (rule corres_underlying_split[where r'=dc])
-            apply (case_tac xb, simp_all add: doMachineOp_return)[1]
-             apply (clarsimp simp add: when_def doMachineOp_return)
-             apply (rule corres_guard_imp, rule sendSignal_corres)
-              apply (clarsimp simp: valid_cap_def valid_cap'_def arch_mask_irq_signal_def
-                                    maskIrqSignal_def do_machine_op_bind doMachineOp_bind)+
-           apply corres
-             apply (rule corres_machine_op, rule corres_eq_trivial; simp; rule no_fail_ackInterrupt no_fail_maskInterrupt)+
-            apply wpsimp+
-   apply fastforce
-  apply (rule corres_guard_imp)
-    apply (rule corres_split)
-       apply simp
-       apply (rule corres_split[OF timerTick_corres corres_machine_op])
-         apply (rule corres_eq_trivial, wpsimp+)
-      apply (rule corres_machine_op)
-      apply (rule corres_eq_trivial; simp)
-     apply wpsimp+
-   apply (clarsimp simp: invs_distinct invs_psp_aligned schact_is_rct_def)
-  apply clarsimp
+  apply (case_tac st, simp_all add: irq_state_relation_def bind_assoc split: irqstate.split_asm)
+    apply (simp add: getSlotCap_def bind_assoc)
+    apply (rule corres_guard_imp)
+      apply (rule corres_split[OF getIRQSlot_corres])
+        apply simp
+        apply (rule corres_split[OF get_cap_corres,
+                                 where R="\<lambda>rv. einvs and valid_cap rv"
+                                   and R'="\<lambda>rv. invs' and valid_cap' (cteCap rv)"])
+          apply (rule corres_underlying_split[where r'=dc])
+             apply (case_tac xb, simp_all add: doMachineOp_return)[1]
+              apply (clarsimp simp add: when_def doMachineOp_return)
+              apply (rule corres_guard_imp, rule sendSignal_corres)
+               apply (clarsimp simp: valid_cap_def valid_cap'_def arch_mask_irq_signal_def
+                                     maskIrqSignal_def do_machine_op_bind doMachineOp_bind)+
+            apply corres
+               apply (rule corres_machine_op, rule corres_eq_trivial; simp; rule no_fail_ackInterrupt no_fail_maskInterrupt)+
+             apply wpsimp+
+    apply fastforce
+   apply (corres corres: timerTick_corres corres_machine_op
+                   simp: invs_distinct invs_psp_aligned)
+  apply (corres corres: corres_machine_op)
   done
 
 lemma threadSet_ksDomainTime[wp]:

--- a/proof/refine/ARM_HYP/Refine.thy
+++ b/proof/refine/ARM_HYP/Refine.thy
@@ -535,7 +535,7 @@ lemma kernel_corres':
   apply (corres corres: handleEvent_corres corres_machine_op maybeHandleInterrupt_corres
                 simp: irq_state_independent_def
          | corres_cases_both)+
-        apply (wp handle_event_valid_sched)+
+        apply (wpsimp wp: handle_event_valid_sched)+
       apply (corres corres: schedule_corres activateThread_corres)
       apply (wpsimp wp: schedule_invs' hoare_vcg_if_lift2 dmo_getActiveIRQ_non_kernel
                         handle_spurious_irq_invs

--- a/proof/refine/ARM_HYP/Syscall_R.thy
+++ b/proof/refine/ARM_HYP/Syscall_R.thy
@@ -1785,17 +1785,21 @@ lemma contract_all_imp_strg:
   by blast
 
 lemma maybeHandleInterrupt_corres:
-  "corres dc einvs invs' (maybe_handle_interrupt in_kernel) (maybeHandleInterrupt in_kernel)"
+  "corres dc einvs (invs' and (\<lambda>s'. in_kernel \<or> sch_act_not (ksCurThread s') s'))
+          (maybe_handle_interrupt in_kernel) (maybeHandleInterrupt in_kernel)"
   unfolding maybe_handle_interrupt_def maybeHandleInterrupt_def
   apply (corres corres: corres_machine_op handleInterrupt_corres[@lift_corres_args]
                 simp: irq_state_independent_def
          | corres_cases_both)+
-     apply (wpsimp wp: hoare_drop_imp)
-    apply clarsimp
-    apply (strengthen contract_all_imp_strg[where P'=True, simplified])
-    apply (wpsimp wp: doMachineOp_getActiveIRQ_IRQ_active' hoare_vcg_all_lift)
-    apply (wpsimp wp: hoare_drop_imp)
-   apply clarsimp
+     apply (wpsimp wp: hoare_drop_imps)
+    apply (rule_tac Q'="\<lambda>rv s. (\<forall>irq. rv = Some irq \<longrightarrow> irq \<in> non_kernel_IRQs \<longrightarrow> sch_act_not (ksCurThread s) s)
+                             \<and> (\<forall>irq. rv = Some irq \<longrightarrow> intStateIRQTable (ksInterruptState s) irq \<noteq> IRQInactive)
+                             \<and> invs' s"
+                 in hoare_strengthen_post)
+     apply (rule hoare_pre_disj[where P="_ and K (in_kernel)" and P'="_ and K(\<not>in_kernel)"];
+            rule hoare_gen_asm; simp)
+      apply ((wp | wp hoare_vcg_all_lift doMachineOp_getActiveIRQ_IRQ_active'
+                 | simp | simp add: imp_conjR | wp hoare_drop_imps)+)
   apply (clarsimp simp: invs'_def valid_state'_def)
   done
 

--- a/proof/refine/RISCV64/Interrupt_R.thy
+++ b/proof/refine/RISCV64/Interrupt_R.thy
@@ -705,6 +705,11 @@ lemma timerTick_corres:
 
 lemmas corres_eq_trivial = corres_Id[where f = h and g = h for h, simplified]
 
+(* FIXME arch-split: architectures with hypervisor support impose stronger guards *)
+lemma handle_reserved_irq_corres[corres]:
+  "corres dc einvs invs' (handle_reserved_irq irq) (handleReservedIRQ irq)"
+  unfolding handle_reserved_irq_def handleReservedIRQ_def by corres
+
 lemma handleInterrupt_corres:
   "corres dc
      einvs
@@ -724,34 +729,35 @@ lemma handleInterrupt_corres:
 
   apply (rule corres_gen_asm2)
   apply (case_tac st, simp_all add: irq_state_relation_def split: irqstate.split_asm)
-   apply (simp add: getSlotCap_def bind_assoc)
+    apply (simp add: getSlotCap_def bind_assoc)
+    apply (rule corres_guard_imp)
+      apply (rule corres_split[OF getIRQSlot_corres])
+        apply simp
+        apply (rule corres_split[OF get_cap_corres,
+                                  where R="\<lambda>rv. einvs and valid_cap rv"
+                                   and R'="\<lambda>rv. invs' and valid_cap' (cteCap rv)"])
+          apply (rule corres_underlying_split[where r'=dc])
+             apply (case_tac xb, simp_all add: doMachineOp_return)[1]
+              apply (clarsimp simp add: when_def doMachineOp_return)
+              apply (rule corres_guard_imp, rule sendSignal_corres)
+               apply (clarsimp simp: valid_cap_def valid_cap'_def arch_mask_irq_signal_def
+                                     maskIrqSignal_def do_machine_op_bind doMachineOp_bind)+
+            apply (rule corres_machine_op, rule corres_eq_trivial;
+                    (simp add: no_fail_ackInterrupt)+)+
+           apply ((wp |simp)+)
+     apply clarsimp
+    apply fastforce
    apply (rule corres_guard_imp)
-     apply (rule corres_split[OF getIRQSlot_corres])
-       apply simp
-       apply (rule corres_split[OF get_cap_corres,
-                                 where R="\<lambda>rv. einvs and valid_cap rv"
-                                  and R'="\<lambda>rv. invs' and valid_cap' (cteCap rv)"])
-         apply (rule corres_underlying_split[where r'=dc])
-            apply (case_tac xb, simp_all add: doMachineOp_return)[1]
-             apply (clarsimp simp add: when_def doMachineOp_return)
-             apply (rule corres_guard_imp, rule sendSignal_corres)
-              apply (clarsimp simp: valid_cap_def valid_cap'_def arch_mask_irq_signal_def
-                                    maskIrqSignal_def do_machine_op_bind doMachineOp_bind)+
-           apply (rule corres_machine_op, rule corres_eq_trivial;
-                   (simp add: no_fail_ackInterrupt)+)+
-          apply ((wp |simp)+)
-    apply clarsimp
-   apply fastforce
-  apply (rule corres_guard_imp)
-    apply (rule corres_split)
-       apply simp
-       apply (rule corres_split[OF timerTick_corres corres_machine_op])
-         apply (rule corres_eq_trivial, wpsimp+)
-      apply (rule corres_machine_op)
-      apply (rule corres_eq_trivial, (simp add: no_fail_ackInterrupt)+)
-     apply wp+
-   apply (clarsimp simp: invs_distinct invs_psp_aligned schact_is_rct_def)
-  apply clarsimp
+     apply (rule corres_split)
+        apply simp
+        apply (rule corres_split[OF timerTick_corres corres_machine_op])
+          apply (rule corres_eq_trivial, wpsimp+)
+       apply (rule corres_machine_op)
+       apply (rule corres_eq_trivial, (simp add: no_fail_ackInterrupt)+)
+      apply wp+
+    apply (clarsimp simp: invs_distinct invs_psp_aligned schact_is_rct_def)
+   apply clarsimp
+  apply (corres corres: corres_machine_op corres_eq_trivial)
   done
 
 lemma threadSet_ksDomainTime[wp]:
@@ -829,6 +835,7 @@ lemma dmo_ackInterrupt[wp]:
                            machine_rest_lift_def split_def | wp)+)[3]
   done
 
+(* FIXME arch-split: imposing a stronger precondition affects InfoFlow refinement *)
 lemma hint_invs[wp]:
   "\<lbrace>invs'\<rbrace> handleInterrupt irq \<lbrace>\<lambda>rv. invs'\<rbrace>"
   apply (simp add: handleInterrupt_def getSlotCap_def

--- a/proof/refine/StateRelation.thy
+++ b/proof/refine/StateRelation.thy
@@ -263,6 +263,7 @@ definition irq_state_relation :: "irq_state \<Rightarrow> irqstate \<Rightarrow>
      (irq_state.IRQInactive, irqstate.IRQInactive) \<Rightarrow> True
    | (irq_state.IRQSignal, irqstate.IRQSignal) \<Rightarrow> True
    | (irq_state.IRQTimer, irqstate.IRQTimer) \<Rightarrow> True
+   | (irq_state.IRQReserved, irqstate.IRQReserved) \<Rightarrow> True
    | _ \<Rightarrow> False"
 
 definition interrupt_state_relation ::


### PR DESCRIPTION
Previously, `irq_state_relation` did not admit reserved IRQs. This was addressed in `ARM_HYP` but not standardised across other architectures, and subsequently overwritten during arch-split efforts. This PR addresses this issue.

We also tag the `ARM` and `RISCV64` variants of `hint_invs` with `FIXME arch-split`. Here, strengthening the precondition is required for an arch-split, but will impact the InfoFlow refinement proofs.