### PR TITLE
refine: make ghost_relation_wrapper projections generic

### DIFF
--- a/proof/refine/AARCH64/ArchStateRelation.thy
+++ b/proof/refine/AARCH64/ArchStateRelation.thy
@@ -119,21 +119,23 @@ definition is_other_obj_relation_type :: "a_type \<Rightarrow> bool" where
     | _ \<Rightarrow> True"
 
 definition ghost_relation ::
-  "Structures_A.kheap \<Rightarrow> (machine_word \<rightharpoonup> vmpage_size) \<Rightarrow> (machine_word \<rightharpoonup> nat) \<Rightarrow> (machine_word \<rightharpoonup> pt_type) \<Rightarrow> bool" where
+  "kheap \<Rightarrow> (machine_word \<rightharpoonup> vmpage_size) \<Rightarrow> (machine_word \<rightharpoonup> nat) \<Rightarrow> (machine_word \<rightharpoonup> pt_type) \<Rightarrow> bool"
+  where
   "ghost_relation h ups cns pt_types \<equiv>
      (\<forall>a sz. (\<exists>dev. h a = Some (ArchObj (DataPage dev sz))) \<longleftrightarrow> ups a = Some sz) \<and>
      (\<forall>a n. (\<exists>cs. h a = Some (CNode n cs) \<and> well_formed_cnode_n n cs) \<longleftrightarrow> cns a = Some n) \<and>
      (\<forall>a pt_t. (\<exists>pt. h a = Some (ArchObj (PageTable pt)) \<and> pt_t = pt_type pt) \<longleftrightarrow> pt_types a = Some pt_t)"
 
-(* FIXME arch-split: provided only so that ghost_relation can be used within generic definition
+(* provided only so that ghost_relation can be used within generic definition
    of state_relation (since arch_state_relation doesn't have access to kheap, and
    gsPTTypes on AARCH64 isn't generic) *)
-definition ghost_relation_wrapper :: "det_state \<Rightarrow> kernel_state \<Rightarrow> bool" where
-  "ghost_relation_wrapper s s' \<equiv>
-     ghost_relation (kheap s) (gsUserPages s') (gsCNodes s') (gsPTTypes (ksArchState s'))"
+definition ghost_relation_wrapper_2 ::
+  "kheap \<Rightarrow> (machine_word \<rightharpoonup> vmpage_size) \<Rightarrow> (machine_word \<rightharpoonup> nat) \<Rightarrow> Arch.kernel_state \<Rightarrow> bool"
+  where
+  "ghost_relation_wrapper_2 h ups cns as \<equiv> ghost_relation h ups cns (gsPTTypes as)"
 
 (* inside Arch locale, we have no need for the wrapper *)
-lemmas [simp] = ghost_relation_wrapper_def
+lemmas ghost_relation_wrapper_def[simp] = ghost_relation_wrapper_2_def
 
 definition arch_state_relation :: "(arch_state \<times> AARCH64_H.kernel_state) set" where
   "arch_state_relation \<equiv> {(s, s') .

--- a/proof/refine/AARCH64/ArchStateRelationLemmas.thy
+++ b/proof/refine/AARCH64/ArchStateRelationLemmas.thy
@@ -159,11 +159,6 @@ lemma other_aobj_relation_aobj:
   unfolding other_aobj_relation_def is_ArchObj_def
   by (clarsimp split: Structures_A.kernel_object.splits)
 
-lemma ghost_relation_wrapper_machine_state_upd_id[StateRelation_R_assms,simp]:
-  "ghost_relation_wrapper (s\<lparr>machine_state := ss\<rparr>) (s'\<lparr>ksMachineState := ss'\<rparr>)
-   = ghost_relation_wrapper s s'"
-  by simp
-
 (* interface lemma, can't be used in locale assumptions due to free type variable *)
 lemma valid_arch_obj'_valid[wp]:
   assumes P: "\<And>P T p. \<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace> f \<lbrace>\<lambda>rv s. P (typ_at' T p s)\<rbrace>"
@@ -171,16 +166,6 @@ lemma valid_arch_obj'_valid[wp]:
   shows "\<lbrace>valid_arch_obj' ako\<rbrace> f \<lbrace>\<lambda>rv. valid_arch_obj' ako\<rbrace>"
   unfolding valid_arch_obj'_def
   by (case_tac ako; wpsimp)
-
-lemma ghost_relation_wrapper_ksPSpace_upd[simp, StateRelation_R_assms]:
-  "ghost_relation_wrapper s (s'\<lparr>ksPSpace := ps'\<rparr>) = ghost_relation_wrapper s s'"
-  by (clarsimp simp: ghost_relation_typ_at set_cap_a_type_inv)
-
-lemma ghost_relation_wrapper_abs_upd_simps[simp, StateRelation_R_assms]:
-  "\<And>f s s'. ghost_relation_wrapper (cdt_list_update f s) s' = ghost_relation_wrapper s s'"
-  "\<And>f s s'. ghost_relation_wrapper (cdt_update f s) s' = ghost_relation_wrapper s s'"
-  "\<And>f s s'. ghost_relation_wrapper (is_original_cap_update f s) s' = ghost_relation_wrapper s s'"
-  by simp_all
 
 end
 

--- a/proof/refine/AARCH64/ArchTcbAcc_R.thy
+++ b/proof/refine/AARCH64/ArchTcbAcc_R.thy
@@ -13,14 +13,6 @@ context Arch begin arch_global_naming
 
 named_theorems TcbAcc_R_assms
 
-lemma ghost_relation_wrapper_ksSchedulerAction_upd[TcbAcc_R_assms, simp]:
-  "ghost_relation_wrapper s (s'\<lparr>ksSchedulerAction := v\<rparr>) = ghost_relation_wrapper s s'"
-  by clarsimp
-
-lemma ghost_relation_wrapper_scheduler_action_upd[TcbAcc_R_assms, simp]:
-  "ghost_relation_wrapper (s\<lparr>scheduler_action := v\<rparr>) s' = ghost_relation_wrapper s s'"
-  by clarsimp
-
 (* FIXME: move & the versions in Machine_AI could use word_size_bits form instead of specific number *)
 lemma no_fail_loadWord_bits[TcbAcc_R_assms, wp]:
   "no_fail (\<lambda>_. is_aligned p word_size_bits) (loadWord p)"
@@ -219,14 +211,6 @@ lemma asUser_valid_tcbs'[wp]:
   apply (wpsimp wp: threadSet_valid_tcbs' hoare_drop_imps
               simp: valid_tcb'_def valid_arch_tcb'_def tcb_cte_cases_def objBits_simps')
   done
-
-lemma ghost_relation_wrapper_ksReadyQueuesL1Bitmap_upd[TcbAcc_R_assms, simp]:
-  "ghost_relation_wrapper s (s'\<lparr>ksReadyQueuesL1Bitmap := v\<rparr>) = ghost_relation_wrapper s s'"
-  by (clarsimp simp: ghost_relation_typ_at set_cap_a_type_inv)
-
-lemma ghost_relation_wrapper_ksReadyQueuesL2Bitmap_upd[TcbAcc_R_assms, simp]:
-  "ghost_relation_wrapper s (s'\<lparr>ksReadyQueuesL2Bitmap := v\<rparr>) = ghost_relation_wrapper s s'"
-  by (clarsimp simp: ghost_relation_typ_at set_cap_a_type_inv)
 
 lemmas addToBitmap_typ_ats[wp] = typ_at_lifts[OF addToBitmap_typ_at']
 lemmas removeFromBitmap_typ_ats[wp] = typ_at_lifts[OF removeFromBitmap_typ_at']
@@ -510,14 +494,6 @@ lemma asUser_setRegister_corres:
   apply (rule asUser_corres')
   apply (rule corres_modify'; simp)
   done
-
-lemma ghost_relation_wrapper_ksReadyQueues_upd[TcbAcc_R_2_assms, simp]:
-  "ghost_relation_wrapper s (s'\<lparr>ksReadyQueues := v\<rparr>) = ghost_relation_wrapper s s'"
-  by clarsimp
-
-lemma ghost_relation_wrapper_ready_queues_upd[TcbAcc_R_2_assms, simp]:
-  "ghost_relation_wrapper (s\<lparr>ready_queues := v\<rparr>) s' = ghost_relation_wrapper s s'"
-  by clarsimp
 
 lemma removeFromBitmap_bitmapQ_no_L1_orphans[TcbAcc_R_2_assms, wp]:
   "\<lbrace> bitmapQ_no_L1_orphans \<rbrace> removeFromBitmap d p \<lbrace>\<lambda>_. bitmapQ_no_L1_orphans \<rbrace>"

--- a/proof/refine/AARCH64/Untyped_R.thy
+++ b/proof/refine/AARCH64/Untyped_R.thy
@@ -3837,7 +3837,6 @@ lemma updateFreeIndex_corres:
          (cte_at' (cte_map src)
            and pspace_distinct' and pspace_aligned')
          (set_cap cap src) (updateFreeIndex (cte_map src) idx)"
-  supply AARCH64.ghost_relation_wrapper_def[simp] (* FIXME arch-split *)
   apply (rule corres_name_pre)
   apply (simp add: updateFreeIndex_def updateTrackedFreeIndex_def)
   apply (rule corres_guard_imp)

--- a/proof/refine/ARM/ArchStateRelation.thy
+++ b/proof/refine/ARM/ArchStateRelation.thy
@@ -136,21 +136,21 @@ definition
    | _ \<Rightarrow> True"
 
 definition ghost_relation ::
-  "Structures_A.kheap \<Rightarrow> (word32 \<rightharpoonup> vmpage_size) \<Rightarrow> (word32 \<rightharpoonup> nat) \<Rightarrow> bool" where
+  "kheap \<Rightarrow> (machine_word \<rightharpoonup> vmpage_size) \<Rightarrow> (machine_word \<rightharpoonup> nat) \<Rightarrow> bool" where
   "ghost_relation h ups cns \<equiv>
-   (\<forall>a sz. (\<exists>dev. h a = Some (ArchObj (DataPage dev sz))) \<longleftrightarrow> ups a = Some sz) \<and>
-   (\<forall>a n. (\<exists>cs. h a = Some (CNode n cs) \<and> well_formed_cnode_n n cs) \<longleftrightarrow>
-          cns a = Some n)"
+     (\<forall>a sz. (\<exists>dev. h a = Some (ArchObj (DataPage dev sz))) \<longleftrightarrow> ups a = Some sz) \<and>
+     (\<forall>a n. (\<exists>cs. h a = Some (CNode n cs) \<and> well_formed_cnode_n n cs) \<longleftrightarrow> cns a = Some n)"
 
-(* FIXME arch-split: provided only so that ghost_relation can be used within generic definition
+(* provided only so that ghost_relation can be used within generic definition
    of state_relation (since arch_state_relation doesn't have access to kheap, and
    gsPTTypes on AARCH64 isn't generic) *)
-definition ghost_relation_wrapper :: "det_state \<Rightarrow> kernel_state \<Rightarrow> bool" where
-  "ghost_relation_wrapper s s' \<equiv>
-     ghost_relation (kheap s) (gsUserPages s') (gsCNodes s')"
+definition ghost_relation_wrapper_2 ::
+  "kheap \<Rightarrow> (machine_word \<rightharpoonup> vmpage_size) \<Rightarrow> (machine_word \<rightharpoonup> nat) \<Rightarrow> Arch.kernel_state \<Rightarrow> bool"
+  where
+  "ghost_relation_wrapper_2 h ups cns as \<equiv> ghost_relation h ups cns"
 
 (* inside Arch locale, we have no need for the wrapper *)
-lemmas [simp] = ghost_relation_wrapper_def
+lemmas ghost_relation_wrapper_def[simp] = ghost_relation_wrapper_2_def
 
 definition arch_state_relation :: "(arch_state \<times> ARM_H.kernel_state) set" where
   "arch_state_relation \<equiv> {(s, s') .

--- a/proof/refine/ARM/ArchStateRelationLemmas.thy
+++ b/proof/refine/ARM/ArchStateRelationLemmas.thy
@@ -165,11 +165,6 @@ lemma other_aobj_relation_aobj:
   unfolding other_aobj_relation_def is_ArchObj_def
   by (clarsimp split: Structures_A.kernel_object.splits)
 
-lemma ghost_relation_wrapper_machine_state_upd_id[StateRelation_R_assms,simp]:
-  "ghost_relation_wrapper (s\<lparr>machine_state := ss\<rparr>) (s'\<lparr>ksMachineState := ss'\<rparr>)
-   = ghost_relation_wrapper s s'"
-  by simp
-
 (* interface lemma, can't be used in locale assumptions due to free type variable *)
 lemma valid_arch_obj'_valid[wp]:
   assumes P: "\<And>P T p. \<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace> f \<lbrace>\<lambda>rv s. P (typ_at' T p s)\<rbrace>"
@@ -177,16 +172,6 @@ lemma valid_arch_obj'_valid[wp]:
   shows "\<lbrace>valid_arch_obj' ako\<rbrace> f \<lbrace>\<lambda>rv. valid_arch_obj' ako\<rbrace>"
   unfolding valid_arch_obj'_def
   by (case_tac ako; wpsimp)
-
-lemma ghost_relation_wrapper_ksPSpace_upd[simp, StateRelation_R_assms]:
-  "ghost_relation_wrapper s (s'\<lparr>ksPSpace := ps'\<rparr>) = ghost_relation_wrapper s s'"
-  by (clarsimp simp: ghost_relation_typ_at set_cap_a_type_inv)
-
-lemma ghost_relation_wrapper_abs_upd_simps[simp, StateRelation_R_assms]:
-  "\<And>f s s'. ghost_relation_wrapper (cdt_list_update f s) s' = ghost_relation_wrapper s s'"
-  "\<And>f s s'. ghost_relation_wrapper (cdt_update f s) s' = ghost_relation_wrapper s s'"
-  "\<And>f s s'. ghost_relation_wrapper (is_original_cap_update f s) s' = ghost_relation_wrapper s s'"
-  by simp_all
 
 end
 

--- a/proof/refine/ARM/ArchTcbAcc_R.thy
+++ b/proof/refine/ARM/ArchTcbAcc_R.thy
@@ -13,14 +13,6 @@ context Arch begin arch_global_naming
 
 named_theorems TcbAcc_R_assms
 
-lemma ghost_relation_wrapper_ksSchedulerAction_upd[TcbAcc_R_assms, simp]:
-  "ghost_relation_wrapper s (s'\<lparr>ksSchedulerAction := v\<rparr>) = ghost_relation_wrapper s s'"
-  by clarsimp
-
-lemma ghost_relation_wrapper_scheduler_action_upd[TcbAcc_R_assms, simp]:
-  "ghost_relation_wrapper (s\<lparr>scheduler_action := v\<rparr>) s' = ghost_relation_wrapper s s'"
-  by clarsimp
-
 (* FIXME: move & the versions in Machine_AI could use word_size_bits form instead of specific number *)
 lemma no_fail_loadWord_bits[TcbAcc_R_assms, wp]:
   "no_fail (\<lambda>_. is_aligned p word_size_bits) (loadWord p)"
@@ -216,14 +208,6 @@ lemma asUser_valid_tcbs'[wp]:
   apply (wpsimp wp: threadSet_valid_tcbs' hoare_drop_imps
               simp: valid_tcb'_def valid_arch_tcb'_def tcb_cte_cases_def objBits_simps')
   done
-
-lemma ghost_relation_wrapper_ksReadyQueuesL1Bitmap_upd[TcbAcc_R_assms, simp]:
-  "ghost_relation_wrapper s (s'\<lparr>ksReadyQueuesL1Bitmap := v\<rparr>) = ghost_relation_wrapper s s'"
-  by (clarsimp simp: ghost_relation_typ_at set_cap_a_type_inv)
-
-lemma ghost_relation_wrapper_ksReadyQueuesL2Bitmap_upd[TcbAcc_R_assms, simp]:
-  "ghost_relation_wrapper s (s'\<lparr>ksReadyQueuesL2Bitmap := v\<rparr>) = ghost_relation_wrapper s s'"
-  by (clarsimp simp: ghost_relation_typ_at set_cap_a_type_inv)
 
 lemmas addToBitmap_typ_ats[wp] = typ_at_lifts[OF addToBitmap_typ_at']
 lemmas removeFromBitmap_typ_ats[wp] = typ_at_lifts[OF removeFromBitmap_typ_at']
@@ -507,14 +491,6 @@ lemma asUser_setRegister_corres:
   apply (rule asUser_corres')
   apply (rule corres_modify'; simp)
   done
-
-lemma ghost_relation_wrapper_ksReadyQueues_upd[TcbAcc_R_2_assms, simp]:
-  "ghost_relation_wrapper s (s'\<lparr>ksReadyQueues := v\<rparr>) = ghost_relation_wrapper s s'"
-  by clarsimp
-
-lemma ghost_relation_wrapper_ready_queues_upd[TcbAcc_R_2_assms, simp]:
-  "ghost_relation_wrapper (s\<lparr>ready_queues := v\<rparr>) s' = ghost_relation_wrapper s s'"
-  by clarsimp
 
 lemma removeFromBitmap_bitmapQ_no_L1_orphans[TcbAcc_R_2_assms, wp]:
   "\<lbrace> bitmapQ_no_L1_orphans \<rbrace> removeFromBitmap d p \<lbrace>\<lambda>_. bitmapQ_no_L1_orphans \<rbrace>"

--- a/proof/refine/ARM/Untyped_R.thy
+++ b/proof/refine/ARM/Untyped_R.thy
@@ -3809,7 +3809,6 @@ lemma updateFreeIndex_corres:
          (cte_at' (cte_map src)
            and pspace_distinct' and pspace_aligned')
          (set_cap cap src) (updateFreeIndex (cte_map src) idx)"
-  supply ARM.ghost_relation_wrapper_def[simp] (* FIXME arch-split *)
   apply (rule corres_name_pre)
   apply (simp add: updateFreeIndex_def updateTrackedFreeIndex_def)
   apply (rule corres_guard_imp)

--- a/proof/refine/ARM_HYP/ArchStateRelation.thy
+++ b/proof/refine/ARM_HYP/ArchStateRelation.thy
@@ -159,21 +159,21 @@ definition
    | _ \<Rightarrow> True"
 
 definition ghost_relation ::
-  "Structures_A.kheap \<Rightarrow> (word32 \<rightharpoonup> vmpage_size) \<Rightarrow> (word32 \<rightharpoonup> nat) \<Rightarrow> bool" where
+  "kheap \<Rightarrow> (machine_word \<rightharpoonup> vmpage_size) \<Rightarrow> (machine_word \<rightharpoonup> nat) \<Rightarrow> bool" where
   "ghost_relation h ups cns \<equiv>
-   (\<forall>a sz. (\<exists>dev. h a = Some (ArchObj (DataPage dev sz))) \<longleftrightarrow> ups a = Some sz) \<and>
-   (\<forall>a n. (\<exists>cs. h a = Some (CNode n cs) \<and> well_formed_cnode_n n cs) \<longleftrightarrow>
-          cns a = Some n)"
+     (\<forall>a sz. (\<exists>dev. h a = Some (ArchObj (DataPage dev sz))) \<longleftrightarrow> ups a = Some sz) \<and>
+     (\<forall>a n. (\<exists>cs. h a = Some (CNode n cs) \<and> well_formed_cnode_n n cs) \<longleftrightarrow> cns a = Some n)"
 
-(* FIXME arch-split: provided only so that ghost_relation can be used within generic definition
+(* provided only so that ghost_relation can be used within generic definition
    of state_relation (since arch_state_relation doesn't have access to kheap, and
    gsPTTypes on AARCH64 isn't generic) *)
-definition ghost_relation_wrapper :: "det_state \<Rightarrow> kernel_state \<Rightarrow> bool" where
-  "ghost_relation_wrapper s s' \<equiv>
-     ghost_relation (kheap s) (gsUserPages s') (gsCNodes s')"
+definition ghost_relation_wrapper_2 ::
+  "kheap \<Rightarrow> (machine_word \<rightharpoonup> vmpage_size) \<Rightarrow> (machine_word \<rightharpoonup> nat) \<Rightarrow> Arch.kernel_state \<Rightarrow> bool"
+  where
+  "ghost_relation_wrapper_2 h ups cns as \<equiv> ghost_relation h ups cns"
 
 (* inside Arch locale, we have no need for the wrapper *)
-lemmas [simp] = ghost_relation_wrapper_def
+lemmas ghost_relation_wrapper_def[simp] = ghost_relation_wrapper_2_def
 
 definition arch_state_relation :: "(arch_state \<times> ARM_HYP_H.kernel_state) set" where
   "arch_state_relation \<equiv> {(s, s') .

--- a/proof/refine/ARM_HYP/ArchStateRelationLemmas.thy
+++ b/proof/refine/ARM_HYP/ArchStateRelationLemmas.thy
@@ -161,27 +161,12 @@ lemma other_aobj_relation_aobj:
   unfolding other_aobj_relation_def is_ArchObj_def
   by (clarsimp split: Structures_A.kernel_object.splits)
 
-lemma ghost_relation_wrapper_machine_state_upd_id[StateRelation_R_assms,simp]:
-  "ghost_relation_wrapper (s\<lparr>machine_state := ss\<rparr>) (s'\<lparr>ksMachineState := ss'\<rparr>)
-   = ghost_relation_wrapper s s'"
-  by simp
-
 (* interface lemma, can't be used in locale assumptions due to free type variable *)
 lemma valid_arch_obj'_valid[wp]:
   assumes P: "\<And>P T p. \<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace> f \<lbrace>\<lambda>rv s. P (typ_at' T p s)\<rbrace>"
   notes [wp] = hoare_vcg_all_lift hoare_vcg_imp_lift hoare_vcg_const_Ball_lift typ_at_lifts[OF P]
   shows "\<lbrace>valid_arch_obj' ako\<rbrace> f \<lbrace>\<lambda>rv. valid_arch_obj' ako\<rbrace>"
   by (case_tac ako; wpsimp)
-
-lemma ghost_relation_wrapper_ksPSpace_upd[simp, StateRelation_R_assms]:
-  "ghost_relation_wrapper s (s'\<lparr>ksPSpace := ps'\<rparr>) = ghost_relation_wrapper s s'"
-  by (clarsimp simp: ghost_relation_typ_at set_cap_a_type_inv)
-
-lemma ghost_relation_wrapper_abs_upd_simps[simp, StateRelation_R_assms]:
-  "\<And>f s s'. ghost_relation_wrapper (cdt_list_update f s) s' = ghost_relation_wrapper s s'"
-  "\<And>f s s'. ghost_relation_wrapper (cdt_update f s) s' = ghost_relation_wrapper s s'"
-  "\<And>f s s'. ghost_relation_wrapper (is_original_cap_update f s) s' = ghost_relation_wrapper s s'"
-  by simp_all
 
 end
 

--- a/proof/refine/ARM_HYP/ArchTcbAcc_R.thy
+++ b/proof/refine/ARM_HYP/ArchTcbAcc_R.thy
@@ -13,14 +13,6 @@ context Arch begin arch_global_naming
 
 named_theorems TcbAcc_R_assms
 
-lemma ghost_relation_wrapper_ksSchedulerAction_upd[TcbAcc_R_assms, simp]:
-  "ghost_relation_wrapper s (s'\<lparr>ksSchedulerAction := v\<rparr>) = ghost_relation_wrapper s s'"
-  by clarsimp
-
-lemma ghost_relation_wrapper_scheduler_action_upd[TcbAcc_R_assms, simp]:
-  "ghost_relation_wrapper (s\<lparr>scheduler_action := v\<rparr>) s' = ghost_relation_wrapper s s'"
-  by clarsimp
-
 (* FIXME: move & the versions in Machine_AI could use word_size_bits form instead of specific number *)
 lemma no_fail_loadWord_bits[TcbAcc_R_assms, wp]:
   "no_fail (\<lambda>_. is_aligned p word_size_bits) (loadWord p)"
@@ -230,14 +222,6 @@ lemma asUser_valid_tcbs'[wp]:
   apply (wpsimp wp: threadSet_valid_tcbs' hoare_drop_imps
               simp: valid_tcb'_def valid_arch_tcb'_def tcb_cte_cases_def objBits_simps')
   done
-
-lemma ghost_relation_wrapper_ksReadyQueuesL1Bitmap_upd[TcbAcc_R_assms, simp]:
-  "ghost_relation_wrapper s (s'\<lparr>ksReadyQueuesL1Bitmap := v\<rparr>) = ghost_relation_wrapper s s'"
-  by (clarsimp simp: ghost_relation_typ_at set_cap_a_type_inv)
-
-lemma ghost_relation_wrapper_ksReadyQueuesL2Bitmap_upd[TcbAcc_R_assms, simp]:
-  "ghost_relation_wrapper s (s'\<lparr>ksReadyQueuesL2Bitmap := v\<rparr>) = ghost_relation_wrapper s s'"
-  by (clarsimp simp: ghost_relation_typ_at set_cap_a_type_inv)
 
 lemmas addToBitmap_typ_ats[wp] = typ_at_lifts[OF addToBitmap_typ_at']
 lemmas removeFromBitmap_typ_ats[wp] = typ_at_lifts[OF removeFromBitmap_typ_at']
@@ -522,14 +506,6 @@ lemma asUser_setRegister_corres:
   apply (rule asUser_corres')
   apply (rule corres_modify'; simp)
   done
-
-lemma ghost_relation_wrapper_ksReadyQueues_upd[TcbAcc_R_2_assms, simp]:
-  "ghost_relation_wrapper s (s'\<lparr>ksReadyQueues := v\<rparr>) = ghost_relation_wrapper s s'"
-  by clarsimp
-
-lemma ghost_relation_wrapper_ready_queues_upd[TcbAcc_R_2_assms, simp]:
-  "ghost_relation_wrapper (s\<lparr>ready_queues := v\<rparr>) s' = ghost_relation_wrapper s s'"
-  by clarsimp
 
 lemma removeFromBitmap_bitmapQ_no_L1_orphans[TcbAcc_R_2_assms, wp]:
   "\<lbrace> bitmapQ_no_L1_orphans \<rbrace> removeFromBitmap d p \<lbrace>\<lambda>_. bitmapQ_no_L1_orphans \<rbrace>"

--- a/proof/refine/ARM_HYP/Untyped_R.thy
+++ b/proof/refine/ARM_HYP/Untyped_R.thy
@@ -3871,7 +3871,6 @@ lemma updateFreeIndex_corres:
          (cte_at' (cte_map src)
            and pspace_distinct' and pspace_aligned')
          (set_cap cap src) (updateFreeIndex (cte_map src) idx)"
-  supply ARM_HYP.ghost_relation_wrapper_def[simp] (* FIXME arch-split *)
   apply (rule corres_name_pre)
   apply (simp add: updateFreeIndex_def updateTrackedFreeIndex_def)
   apply (rule corres_guard_imp)

--- a/proof/refine/CSpace1_R.thy
+++ b/proof/refine/CSpace1_R.thy
@@ -5177,7 +5177,7 @@ lemma cteInsert_corres:
             apply (thin_tac "ksIdleThread t = p" for p t)+
             apply (thin_tac "ksSchedulerAction t = p" for p t)+
             apply (rule conjI)
-             apply (erule (4) ghost_relation_wrapper_same_abs_set_cap)
+             apply (erule (1) ghost_relation_wrapper_same_abs_set_cap; rule refl)
             apply (rule conjI)
              defer
              apply(rule conjI)
@@ -5841,7 +5841,7 @@ lemma cteSwap_corres:
   apply (thin_tac "interrupt_state_relation n s s'" for n s s')+
   apply (thin_tac "(s,s') \<in> arch_state_relation" for s s')+
   apply (rule conjI)
-   apply (erule (5) ghost_relation_wrapper_set_cap_twice)
+   apply (erule (2) ghost_relation_wrapper_set_cap_twice; rule refl)
   apply (thin_tac "ksArchState t = p" for t p)+
   apply (thin_tac "gsCNodes t = p" for t p)+
   apply (thin_tac "gsUserPages t = p" for t p)+

--- a/proof/refine/CSpace_R.thy
+++ b/proof/refine/CSpace_R.thy
@@ -1085,7 +1085,7 @@ lemma cteMove_corres:
     apply fastforce
    apply fastforce
   apply (rule conjI)
-   apply (erule (5) ghost_relation_wrapper_set_cap_twice)
+   apply (erule (2) ghost_relation_wrapper_set_cap_twice; rule refl)
   apply (thin_tac "gsCNodes t = p" for t p)+
   apply (thin_tac "ksWorkUnitsCompleted t = p" for t p)+
   apply (thin_tac "cur_thread t = p" for t p)+
@@ -4258,7 +4258,7 @@ lemma (in CSpace_R_2) cteInsert_simple_corres:
             apply (drule (3) updateMDB_the_lot', simp only: no_0_modify_map, simp only:, elim conjE)
             apply clarsimp
             apply (rule conjI)
-             apply (erule (4) ghost_relation_wrapper_same_abs_set_cap)
+             apply (erule (1) ghost_relation_wrapper_same_abs_set_cap; rule refl)
             apply (thin_tac "gsCNodes t = p" for t p)+
             apply (thin_tac "ksMachineState t = p" for t p)+
             apply (thin_tac "ksCurThread t = p" for t p)+

--- a/proof/refine/RISCV64/ArchStateRelation.thy
+++ b/proof/refine/RISCV64/ArchStateRelation.thy
@@ -84,20 +84,21 @@ definition is_other_obj_relation_type :: "a_type \<Rightarrow> bool" where
     | _ \<Rightarrow> True"
 
 definition ghost_relation ::
-  "Structures_A.kheap \<Rightarrow> (machine_word \<rightharpoonup> vmpage_size) \<Rightarrow> (machine_word \<rightharpoonup> nat) \<Rightarrow> bool" where
+  "kheap \<Rightarrow> (machine_word \<rightharpoonup> vmpage_size) \<Rightarrow> (machine_word \<rightharpoonup> nat) \<Rightarrow> bool" where
   "ghost_relation h ups cns \<equiv>
      (\<forall>a sz. (\<exists>dev. h a = Some (ArchObj (DataPage dev sz))) \<longleftrightarrow> ups a = Some sz) \<and>
      (\<forall>a n. (\<exists>cs. h a = Some (CNode n cs) \<and> well_formed_cnode_n n cs) \<longleftrightarrow> cns a = Some n)"
 
-(* FIXME arch-split: provided only so that ghost_relation can be used within generic definition
+(* provided only so that ghost_relation can be used within generic definition
    of state_relation (since arch_state_relation doesn't have access to kheap, and
    gsPTTypes on AARCH64 isn't generic) *)
-definition ghost_relation_wrapper :: "det_state \<Rightarrow> kernel_state \<Rightarrow> bool" where
-  "ghost_relation_wrapper s s' \<equiv>
-     ghost_relation (kheap s) (gsUserPages s') (gsCNodes s')"
+definition ghost_relation_wrapper_2 ::
+  "kheap \<Rightarrow> (machine_word \<rightharpoonup> vmpage_size) \<Rightarrow> (machine_word \<rightharpoonup> nat) \<Rightarrow> Arch.kernel_state \<Rightarrow> bool"
+  where
+  "ghost_relation_wrapper_2 h ups cns as \<equiv> ghost_relation h ups cns"
 
 (* inside Arch locale, we have no need for the wrapper *)
-lemmas [simp] = ghost_relation_wrapper_def
+lemmas ghost_relation_wrapper_def[simp] = ghost_relation_wrapper_2_def
 
 definition arch_state_relation :: "(arch_state \<times> RISCV64_H.kernel_state) set" where
   "arch_state_relation \<equiv> {(s, s') .

--- a/proof/refine/RISCV64/ArchStateRelationLemmas.thy
+++ b/proof/refine/RISCV64/ArchStateRelationLemmas.thy
@@ -153,11 +153,6 @@ lemma other_aobj_relation_aobj:
   unfolding other_aobj_relation_def is_ArchObj_def
   by (clarsimp split: Structures_A.kernel_object.splits)
 
-lemma ghost_relation_wrapper_machine_state_upd_id[StateRelation_R_assms,simp]:
-  "ghost_relation_wrapper (s\<lparr>machine_state := ss\<rparr>) (s'\<lparr>ksMachineState := ss'\<rparr>)
-   = ghost_relation_wrapper s s'"
-  by simp
-
 (* interface lemma, can't be used in locale assumptions due to free type variable *)
 lemma valid_arch_obj'_valid[wp]:
   assumes P: "\<And>P T p. \<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace> f \<lbrace>\<lambda>rv s. P (typ_at' T p s)\<rbrace>"
@@ -165,16 +160,6 @@ lemma valid_arch_obj'_valid[wp]:
   shows "\<lbrace>valid_arch_obj' ako\<rbrace> f \<lbrace>\<lambda>rv. valid_arch_obj' ako\<rbrace>"
   unfolding valid_arch_obj'_def
   by (case_tac ako; wpsimp)
-
-lemma ghost_relation_wrapper_ksPSpace_upd[simp, StateRelation_R_assms]:
-  "ghost_relation_wrapper s (s'\<lparr>ksPSpace := ps'\<rparr>) = ghost_relation_wrapper s s'"
-  by (clarsimp simp: ghost_relation_typ_at set_cap_a_type_inv)
-
-lemma ghost_relation_wrapper_abs_upd_simps[simp, StateRelation_R_assms]:
-  "\<And>f s s'. ghost_relation_wrapper (cdt_list_update f s) s' = ghost_relation_wrapper s s'"
-  "\<And>f s s'. ghost_relation_wrapper (cdt_update f s) s' = ghost_relation_wrapper s s'"
-  "\<And>f s s'. ghost_relation_wrapper (is_original_cap_update f s) s' = ghost_relation_wrapper s s'"
-  by simp_all
 
 end
 

--- a/proof/refine/RISCV64/ArchTcbAcc_R.thy
+++ b/proof/refine/RISCV64/ArchTcbAcc_R.thy
@@ -13,14 +13,6 @@ context Arch begin arch_global_naming
 
 named_theorems TcbAcc_R_assms
 
-lemma ghost_relation_wrapper_ksSchedulerAction_upd[TcbAcc_R_assms, simp]:
-  "ghost_relation_wrapper s (s'\<lparr>ksSchedulerAction := v\<rparr>) = ghost_relation_wrapper s s'"
-  by clarsimp
-
-lemma ghost_relation_wrapper_scheduler_action_upd[TcbAcc_R_assms, simp]:
-  "ghost_relation_wrapper (s\<lparr>scheduler_action := v\<rparr>) s' = ghost_relation_wrapper s s'"
-  by clarsimp
-
 (* FIXME: move & the versions in Machine_AI could use word_size_bits form instead of specific number *)
 lemma no_fail_loadWord_bits[TcbAcc_R_assms, wp]:
   "no_fail (\<lambda>_. is_aligned p word_size_bits) (loadWord p)"
@@ -205,14 +197,6 @@ lemma asUser_valid_tcbs'[wp]:
   apply (wpsimp wp: threadSet_valid_tcbs' hoare_drop_imps
               simp: valid_tcb'_def valid_arch_tcb'_def tcb_cte_cases_def objBits_simps')
   done
-
-lemma ghost_relation_wrapper_ksReadyQueuesL1Bitmap_upd[TcbAcc_R_assms, simp]:
-  "ghost_relation_wrapper s (s'\<lparr>ksReadyQueuesL1Bitmap := v\<rparr>) = ghost_relation_wrapper s s'"
-  by (clarsimp simp: ghost_relation_typ_at set_cap_a_type_inv)
-
-lemma ghost_relation_wrapper_ksReadyQueuesL2Bitmap_upd[TcbAcc_R_assms, simp]:
-  "ghost_relation_wrapper s (s'\<lparr>ksReadyQueuesL2Bitmap := v\<rparr>) = ghost_relation_wrapper s s'"
-  by (clarsimp simp: ghost_relation_typ_at set_cap_a_type_inv)
 
 lemmas addToBitmap_typ_ats[wp] = typ_at_lifts[OF addToBitmap_typ_at']
 lemmas removeFromBitmap_typ_ats[wp] = typ_at_lifts[OF removeFromBitmap_typ_at']
@@ -495,14 +479,6 @@ lemma asUser_setRegister_corres:
   apply (rule asUser_corres')
   apply (rule corres_modify'; simp)
   done
-
-lemma ghost_relation_wrapper_ksReadyQueues_upd[TcbAcc_R_2_assms, simp]:
-  "ghost_relation_wrapper s (s'\<lparr>ksReadyQueues := v\<rparr>) = ghost_relation_wrapper s s'"
-  by clarsimp
-
-lemma ghost_relation_wrapper_ready_queues_upd[TcbAcc_R_2_assms, simp]:
-  "ghost_relation_wrapper (s\<lparr>ready_queues := v\<rparr>) s' = ghost_relation_wrapper s s'"
-  by clarsimp
 
 lemma removeFromBitmap_bitmapQ_no_L1_orphans[TcbAcc_R_2_assms, wp]:
   "\<lbrace> bitmapQ_no_L1_orphans \<rbrace> removeFromBitmap d p \<lbrace>\<lambda>_. bitmapQ_no_L1_orphans \<rbrace>"

--- a/proof/refine/RISCV64/Untyped_R.thy
+++ b/proof/refine/RISCV64/Untyped_R.thy
@@ -3833,7 +3833,6 @@ lemma updateFreeIndex_corres:
          (cte_at' (cte_map src)
            and pspace_distinct' and pspace_aligned')
          (set_cap cap src) (updateFreeIndex (cte_map src) idx)"
-  supply RISCV64.ghost_relation_wrapper_def[simp] (* FIXME arch-split *)
   apply (rule corres_name_pre)
   apply (simp add: updateFreeIndex_def updateTrackedFreeIndex_def)
   apply (rule corres_guard_imp)

--- a/proof/refine/TcbAcc_R.thy
+++ b/proof/refine/TcbAcc_R.thy
@@ -83,10 +83,6 @@ locale TcbAcc_R =
      \<lbrace>\<lambda>s. P (global_refs' s)\<rbrace> setObject t (v::tcb) \<lbrace>\<lambda>rv s. P (global_refs' s)\<rbrace>"
   assumes zobj_refs'_capRange:
     "\<And>s cap. s \<turnstile>' cap \<Longrightarrow> zobj_refs' cap \<subseteq> capRange cap"
-  assumes ghost_relation_wrapper_ksReadyQueuesL1Bitmap_upd[simp]:
-    "\<And>s s' v. ghost_relation_wrapper s (s'\<lparr>ksReadyQueuesL1Bitmap := v\<rparr>) = ghost_relation_wrapper s s'"
-  assumes ghost_relation_wrapper_ksReadyQueuesL2Bitmap_upd[simp]:
-    "\<And>s s' v. ghost_relation_wrapper s (s'\<lparr>ksReadyQueuesL2Bitmap := v\<rparr>) = ghost_relation_wrapper s s'"
   assumes pspace_relation_update_tcbs:
     "\<And>s s' x tcb tcb' otcb otcb'.
      \<lbrakk> pspace_relation s s'; s x = Some (TCB otcb); s' x = Some (KOTCB otcb');
@@ -107,10 +103,6 @@ locale TcbAcc_R =
      = (prioToL1Index p \<noteq> prioToL1Index p')"
   assumes prioToL1Index_size[simp]:
     "\<And>w. prioToL1Index w < l2BitmapSize"
-  assumes ghost_relation_wrapper_ksSchedulerAction_upd[simp]:
-    "\<And>s s' v. ghost_relation_wrapper s (s'\<lparr>ksSchedulerAction := v\<rparr>) = ghost_relation_wrapper s s'"
-  assumes ghost_relation_wrapper_scheduler_action_upd[simp]:
-    "\<And>s s' v. ghost_relation_wrapper (s\<lparr>scheduler_action := v\<rparr>) s' = ghost_relation_wrapper s s'"
   assumes pspace_dom_dom:
     "\<And>ps. dom ps \<subseteq> pspace_dom ps"
 
@@ -2060,10 +2052,6 @@ lemma in_ready_q_tcbQueued_eq:
 
 
 locale TcbAcc_R_2 = TcbAcc_R +
-  assumes ghost_relation_wrapper_ksReadyQueues_upd[simp]:
-    "\<And>s s' v. ghost_relation_wrapper s (s'\<lparr>ksReadyQueues := v\<rparr>) = ghost_relation_wrapper s s'"
-  assumes ghost_relation_wrapper_ready_queues_upd[simp]:
-    "\<And>s s' v. ghost_relation_wrapper (s\<lparr>ready_queues := v\<rparr>) s' = ghost_relation_wrapper s s'"
   assumes removeFromBitmap_valid_bitmapQ_except:
     "\<And>d p. removeFromBitmap d p \<lbrace>valid_bitmapQ_except d p \<rbrace>"
   assumes removeFromBitmap_bitmapQ_no_L2_orphans[wp]:
@@ -2211,9 +2199,6 @@ lemma tcbSchedEnqueue_corres:
   apply (clarsimp simp: state_relation_def)
   apply (intro hoare_vcg_conj_lift_pre_fix;
          (solves \<open>frule singleton_eqD, frule set_tcb_queue_projs_inv, wpsimp simp: swp_def\<close>)?)
-   (* generic ghost_state_wrapper won't work after set_tcb_queue_projs_inv *)
-   prefer 2
-   apply (solves \<open>drule singleton_eqD, wpsimp simp: set_tcb_queue_def, monad_eq\<close>)
 
   \<comment> \<open>ready_queues_relation\<close>
   apply (clarsimp simp: ready_queues_relation_def ready_queue_relation_def Let_def)
@@ -2655,9 +2640,6 @@ lemma tcbSchedDequeue_corres:
   apply (clarsimp simp: state_relation_def)
   apply (intro hoare_vcg_conj_lift_pre_fix;
          (solves \<open>frule singleton_eqD, frule set_tcb_queue_projs_inv, wpsimp simp: swp_def\<close>)?)
-   (* generic ghost_state_wrapper won't work after set_tcb_queue_projs_inv *)
-   prefer 2
-   apply (solves \<open>drule singleton_eqD, wpsimp simp: set_tcb_queue_def, monad_eq\<close>)
 
   \<comment> \<open>ready_queues_relation\<close>
   apply (clarsimp simp: ready_queues_relation_def ready_queue_relation_def Let_def)

--- a/proof/refine/X64/ArchStateRelation.thy
+++ b/proof/refine/X64/ArchStateRelation.thy
@@ -145,21 +145,21 @@ definition
      | _ \<Rightarrow> True"
 
 definition ghost_relation ::
-  "Structures_A.kheap \<Rightarrow> (machine_word \<rightharpoonup> vmpage_size) \<Rightarrow> (machine_word \<rightharpoonup> nat) \<Rightarrow> bool" where
+  "kheap \<Rightarrow> (machine_word \<rightharpoonup> vmpage_size) \<Rightarrow> (machine_word \<rightharpoonup> nat) \<Rightarrow> bool" where
   "ghost_relation h ups cns \<equiv>
-   (\<forall>a sz. (\<exists>dev. h a = Some (ArchObj (DataPage dev sz))) \<longleftrightarrow> ups a = Some sz) \<and>
-   (\<forall>a n. (\<exists>cs. h a = Some (CNode n cs) \<and> well_formed_cnode_n n cs) \<longleftrightarrow>
-          cns a = Some n)"
+     (\<forall>a sz. (\<exists>dev. h a = Some (ArchObj (DataPage dev sz))) \<longleftrightarrow> ups a = Some sz) \<and>
+     (\<forall>a n. (\<exists>cs. h a = Some (CNode n cs) \<and> well_formed_cnode_n n cs) \<longleftrightarrow> cns a = Some n)"
 
-(* FIXME arch-split: provided only so that ghost_relation can be used within generic definition
+(* provided only so that ghost_relation can be used within generic definition
    of state_relation (since arch_state_relation doesn't have access to kheap, and
    gsPTTypes on AARCH64 isn't generic) *)
-definition ghost_relation_wrapper :: "det_state \<Rightarrow> kernel_state \<Rightarrow> bool" where
-  "ghost_relation_wrapper s s' \<equiv>
-     ghost_relation (kheap s) (gsUserPages s') (gsCNodes s')"
+definition ghost_relation_wrapper_2 ::
+  "kheap \<Rightarrow> (machine_word \<rightharpoonup> vmpage_size) \<Rightarrow> (machine_word \<rightharpoonup> nat) \<Rightarrow> Arch.kernel_state \<Rightarrow> bool"
+  where
+  "ghost_relation_wrapper_2 h ups cns as \<equiv> ghost_relation h ups cns"
 
 (* inside Arch locale, we have no need for the wrapper *)
-lemmas [simp] = ghost_relation_wrapper_def
+lemmas ghost_relation_wrapper_def[simp] = ghost_relation_wrapper_2_def
 
 definition cr3_relation :: "X64_A.cr3 \<Rightarrow> cr3 \<Rightarrow> bool" where
   "cr3_relation c c' \<equiv> cr3_base_address c = cr3BaseAddress c' \<and> cr3_pcid c = cr3pcid c'"

--- a/proof/refine/X64/ArchStateRelationLemmas.thy
+++ b/proof/refine/X64/ArchStateRelationLemmas.thy
@@ -181,11 +181,6 @@ lemma other_aobj_relation_aobj:
   unfolding other_aobj_relation_def is_ArchObj_def
   by (clarsimp split: Structures_A.kernel_object.splits)
 
-lemma ghost_relation_wrapper_machine_state_upd_id[StateRelation_R_assms,simp]:
-  "ghost_relation_wrapper (s\<lparr>machine_state := ss\<rparr>) (s'\<lparr>ksMachineState := ss'\<rparr>)
-   = ghost_relation_wrapper s s'"
-  by simp
-
 (* interface lemma, can't be used in locale assumptions due to free type variable *)
 lemma valid_arch_obj'_valid[wp]:
   assumes P: "\<And>P T p. \<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace> f \<lbrace>\<lambda>rv s. P (typ_at' T p s)\<rbrace>"
@@ -193,16 +188,6 @@ lemma valid_arch_obj'_valid[wp]:
   shows "\<lbrace>valid_arch_obj' ako\<rbrace> f \<lbrace>\<lambda>rv. valid_arch_obj' ako\<rbrace>"
   unfolding valid_arch_obj'_def
   by (case_tac ako; wpsimp)
-
-lemma ghost_relation_wrapper_ksPSpace_upd[simp, StateRelation_R_assms]:
-  "ghost_relation_wrapper s (s'\<lparr>ksPSpace := ps'\<rparr>) = ghost_relation_wrapper s s'"
-  by (clarsimp simp: ghost_relation_typ_at set_cap_a_type_inv)
-
-lemma ghost_relation_wrapper_abs_upd_simps[simp, StateRelation_R_assms]:
-  "\<And>f s s'. ghost_relation_wrapper (cdt_list_update f s) s' = ghost_relation_wrapper s s'"
-  "\<And>f s s'. ghost_relation_wrapper (cdt_update f s) s' = ghost_relation_wrapper s s'"
-  "\<And>f s s'. ghost_relation_wrapper (is_original_cap_update f s) s' = ghost_relation_wrapper s s'"
-  by simp_all
 
 end
 

--- a/proof/refine/X64/ArchTcbAcc_R.thy
+++ b/proof/refine/X64/ArchTcbAcc_R.thy
@@ -13,14 +13,6 @@ context Arch begin arch_global_naming
 
 named_theorems TcbAcc_R_assms
 
-lemma ghost_relation_wrapper_ksSchedulerAction_upd[TcbAcc_R_assms, simp]:
-  "ghost_relation_wrapper s (s'\<lparr>ksSchedulerAction := v\<rparr>) = ghost_relation_wrapper s s'"
-  by clarsimp
-
-lemma ghost_relation_wrapper_scheduler_action_upd[TcbAcc_R_assms, simp]:
-  "ghost_relation_wrapper (s\<lparr>scheduler_action := v\<rparr>) s' = ghost_relation_wrapper s s'"
-  by clarsimp
-
 (* FIXME: move & the versions in Machine_AI could use word_size_bits form instead of specific number *)
 lemma no_fail_loadWord_bits[TcbAcc_R_assms, wp]:
   "no_fail (\<lambda>_. is_aligned p word_size_bits) (loadWord p)"
@@ -194,14 +186,6 @@ lemma asUser_valid_tcbs'[wp]:
   apply (wpsimp wp: threadSet_valid_tcbs' hoare_drop_imps
               simp: valid_tcb'_def valid_arch_tcb'_def tcb_cte_cases_def objBits_simps')
   done
-
-lemma ghost_relation_wrapper_ksReadyQueuesL1Bitmap_upd[TcbAcc_R_assms, simp]:
-  "ghost_relation_wrapper s (s'\<lparr>ksReadyQueuesL1Bitmap := v\<rparr>) = ghost_relation_wrapper s s'"
-  by (clarsimp simp: ghost_relation_typ_at set_cap_a_type_inv)
-
-lemma ghost_relation_wrapper_ksReadyQueuesL2Bitmap_upd[TcbAcc_R_assms, simp]:
-  "ghost_relation_wrapper s (s'\<lparr>ksReadyQueuesL2Bitmap := v\<rparr>) = ghost_relation_wrapper s s'"
-  by (clarsimp simp: ghost_relation_typ_at set_cap_a_type_inv)
 
 lemmas addToBitmap_typ_ats[wp] = typ_at_lifts[OF addToBitmap_typ_at']
 lemmas removeFromBitmap_typ_ats[wp] = typ_at_lifts[OF removeFromBitmap_typ_at']
@@ -485,14 +469,6 @@ lemma asUser_setRegister_corres:
   apply (rule asUser_corres')
   apply (rule corres_modify'; simp)
   done
-
-lemma ghost_relation_wrapper_ksReadyQueues_upd[TcbAcc_R_2_assms, simp]:
-  "ghost_relation_wrapper s (s'\<lparr>ksReadyQueues := v\<rparr>) = ghost_relation_wrapper s s'"
-  by clarsimp
-
-lemma ghost_relation_wrapper_ready_queues_upd[TcbAcc_R_2_assms, simp]:
-  "ghost_relation_wrapper (s\<lparr>ready_queues := v\<rparr>) s' = ghost_relation_wrapper s s'"
-  by clarsimp
 
 lemma removeFromBitmap_bitmapQ_no_L1_orphans[TcbAcc_R_2_assms, wp]:
   "\<lbrace> bitmapQ_no_L1_orphans \<rbrace> removeFromBitmap d p \<lbrace>\<lambda>_. bitmapQ_no_L1_orphans \<rbrace>"

--- a/proof/refine/X64/Untyped_R.thy
+++ b/proof/refine/X64/Untyped_R.thy
@@ -3916,7 +3916,6 @@ lemma updateFreeIndex_corres:
          (cte_at' (cte_map src)
            and pspace_distinct' and pspace_aligned')
          (set_cap cap src) (updateFreeIndex (cte_map src) idx)"
-  supply X64.ghost_relation_wrapper_def[simp] (* FIXME arch-split *)
   apply (rule corres_name_pre)
   apply (simp add: updateFreeIndex_def updateTrackedFreeIndex_def)
   apply (rule corres_guard_imp)


### PR DESCRIPTION
Use the `_2` approach to make a `ghost_relation_wrapper` abbreviation that exposes to generic proofs the fields that `ghost_relation` can depend on. This allows generic proofs to automatically simplify most appearances of `ghost_relation_wrapper` without additional lemmas.

Stats:  24 files changed, 49 insertions(+), 269 deletions(-)
Total: 220 lines removed