### PR TITLE
refine+crefine: make valid_arch_obj' stateless

### DIFF
--- a/proof/crefine/ARM/ADT_C.thy
+++ b/proof/crefine/ARM/ADT_C.thy
@@ -1233,16 +1233,6 @@ lemma ksPSpace_eq_imp_valid_tcb'_eq:
                  valid_tcb'_def valid_tcb_state'_def valid_bound_ntfn'_def valid_arch_tcb'_def
           split: thread_state.splits option.splits)
 
-lemma ksPSpace_eq_imp_valid_arch_obj'_eq:
-  assumes ksPSpace: "ksPSpace s' = ksPSpace s"
-  shows "valid_arch_obj' ao s' = valid_arch_obj' ao s"
-  apply (case_tac ao, simp)
-   apply (rename_tac pte)
-   apply (case_tac pte, simp_all add: valid_mapping'_def)
-  apply (rename_tac pde)
-  apply (case_tac pde, simp_all add: valid_mapping'_def)
-  done
-
 lemma ksPSpace_eq_imp_valid_objs'_eq:
   assumes ksPSpace: "ksPSpace s' = ksPSpace s"
   shows "valid_objs' s' = valid_objs' s"
@@ -1251,7 +1241,6 @@ lemma ksPSpace_eq_imp_valid_objs'_eq:
                      ksPSpace_eq_imp_obj_at'_eq[OF ksPSpace]
                      ksPSpace_eq_imp_valid_tcb'_eq[OF ksPSpace]
                      ksPSpace_eq_imp_valid_cap'_eq[OF ksPSpace]
-                     ksPSpace_eq_imp_valid_arch_obj'_eq[OF ksPSpace]
                      valid_ntfn'_def valid_cte'_def valid_bound_tcb'_def
               split: kernel_object.splits endpoint.splits ntfn.splits option.splits)
 

--- a/proof/crefine/ARM/ArchMove_C.thy
+++ b/proof/crefine/ARM/ArchMove_C.thy
@@ -120,10 +120,9 @@ where
     0 \<notin> ran pool \<and> (\<forall>x \<in> ran pool. is_aligned x pdBits))"
 
 lemma valid_eq_wf_asid_pool'[simp]:
-  "valid_asid_pool' pool = (\<lambda>s. wf_asid_pool' pool)"
+  "valid_asid_pool' pool = wf_asid_pool' pool"
   by (case_tac pool) simp
 declare valid_asid_pool'.simps[simp del]
-(*<<<*)
 
 lemma valid_untyped':
   notes usableUntypedRange.simps[simp del]

--- a/proof/crefine/ARM_HYP/ADT_C.thy
+++ b/proof/crefine/ARM_HYP/ADT_C.thy
@@ -1025,8 +1025,8 @@ lemma memattr_from_cacheable_inject[simp]:
 
 lemma cpspace_pde_relation_unique:
   assumes "cpspace_pde_relation ah ch" "cpspace_pde_relation ah' ch"
-  assumes "\<forall>x \<in> ran (map_to_pdes ah). valid_pde' x s"
-  assumes "\<forall>x \<in> ran (map_to_pdes ah'). valid_pde' x s'"
+  assumes "\<forall>x \<in> ran (map_to_pdes ah). valid_pde' x"
+  assumes "\<forall>x \<in> ran (map_to_pdes ah'). valid_pde' x"
   shows   "map_to_pdes ah' = map_to_pdes ah"
   apply (rule cmap_relation_unique'[OF inj_Ptr _ assms])
   apply (simp add: cpde_relation_def Let_def split: pde.splits bool.splits)
@@ -1034,8 +1034,8 @@ lemma cpspace_pde_relation_unique:
 
 lemma cpspace_pte_relation_unique:
   assumes "cpspace_pte_relation ah ch" "cpspace_pte_relation ah' ch"
-  assumes "\<forall>x \<in> ran (map_to_ptes ah). valid_pte' x s"
-  assumes "\<forall>x \<in> ran (map_to_ptes ah'). valid_pte' x s'"
+  assumes "\<forall>x \<in> ran (map_to_ptes ah). valid_pte' x"
+  assumes "\<forall>x \<in> ran (map_to_ptes ah'). valid_pte' x"
   shows   "map_to_ptes ah' = map_to_ptes ah"
   apply (rule cmap_relation_unique'[OF inj_Ptr _ assms])
   apply (simp add: cpte_relation_def Let_def split: pte.splits bool.splits)
@@ -1260,7 +1260,7 @@ lemma map_to_cnes_eq:
   done
 
 lemma valid_objs'_valid_pde'_ran:
-  "valid_objs' s \<Longrightarrow> \<forall>x\<in>ran (map_to_pdes (ksPSpace s)). valid_pde' x s"
+  "valid_objs' s \<Longrightarrow> \<forall>x\<in>ran (map_to_pdes (ksPSpace s)). valid_pde' x"
   apply (clarsimp simp: valid_objs'_def ran_def)
   apply (case_tac "ksPSpace s a", simp+)
   apply (rename_tac y, drule_tac x=y in spec)
@@ -1270,7 +1270,7 @@ lemma valid_objs'_valid_pde'_ran:
   done
 
 lemma valid_objs'_valid_pte'_ran:
-  "valid_objs' s \<Longrightarrow> \<forall>x\<in>ran (map_to_ptes (ksPSpace s)). valid_pte' x s"
+  "valid_objs' s \<Longrightarrow> \<forall>x\<in>ran (map_to_ptes (ksPSpace s)). valid_pte' x"
   apply (clarsimp simp: valid_objs'_def ran_def)
   apply (case_tac "ksPSpace s a", simp+)
   apply (rename_tac y, drule_tac x=y in spec)
@@ -1287,7 +1287,6 @@ lemma valid_objs'_aligned_vcpuTCB:
   apply (case_tac y; clarsimp simp: projectKOs)
   apply (erule impE, fastforce)
   apply (clarsimp simp: valid_obj'_def valid_vcpu'_def split: option.splits)
-  apply (clarsimp simp: typ_at_tcb' obj_at'_def projectKOs objBits_simps)
   done
 
 lemma cpspace_relation_unique:
@@ -1384,23 +1383,6 @@ lemma ksPSpace_eq_imp_valid_tcb'_eq:
                  valid_tcb'_def valid_tcb_state'_def valid_bound_ntfn'_def valid_arch_tcb'_def
           split: thread_state.splits option.splits)
 
-lemma ksPSpace_eq_imp_valid_vcpu'_eq:
-  assumes ksPSpace: "ksPSpace s' = ksPSpace s"
-  shows "valid_vcpu' vcpu s' = valid_vcpu' vcpu s"
-  by (auto simp: valid_vcpu'_def ksPSpace_eq_imp_typ_at'_eq[OF ksPSpace] split: option.splits)
-
-lemma ksPSpace_eq_imp_valid_arch_obj'_eq:
-  assumes ksPSpace: "ksPSpace s' = ksPSpace s"
-  shows "valid_arch_obj' ao s' = valid_arch_obj' ao s"
-  apply (case_tac ao, simp)
-    apply (rename_tac pte)
-    apply (case_tac pte, simp_all add: valid_mapping'_def)
-   apply (rename_tac pde)
-   apply (case_tac pde, simp_all add: valid_mapping'_def)
-  apply (rename_tac vcpu)
-  apply (rule ksPSpace_eq_imp_valid_vcpu'_eq[OF ksPSpace])
-  done
-
 lemma ksPSpace_eq_imp_valid_objs'_eq:
   assumes ksPSpace: "ksPSpace s' = ksPSpace s"
   shows "valid_objs' s' = valid_objs' s"
@@ -1409,7 +1391,6 @@ lemma ksPSpace_eq_imp_valid_objs'_eq:
                      ksPSpace_eq_imp_obj_at'_eq[OF ksPSpace]
                      ksPSpace_eq_imp_valid_tcb'_eq[OF ksPSpace]
                      ksPSpace_eq_imp_valid_cap'_eq[OF ksPSpace]
-                     ksPSpace_eq_imp_valid_arch_obj'_eq[OF ksPSpace]
                      valid_ntfn'_def valid_cte'_def valid_bound_tcb'_def
               split: kernel_object.splits endpoint.splits ntfn.splits option.splits)
 

--- a/proof/crefine/ARM_HYP/ArchMove_C.thy
+++ b/proof/crefine/ARM_HYP/ArchMove_C.thy
@@ -241,8 +241,8 @@ lemma le_mask_asid_bits_helper:
   apply (clarsimp simp: asid_bits_def asid_low_bits_def asid_high_bits_def nth_shiftl)
   done
 
-lemma valid_objs_valid_pte': "\<lbrakk> valid_objs' s ; ko_at' (ko :: pte) p s \<rbrakk> \<Longrightarrow> valid_pte' ko s"
-  by (fastforce simp add: obj_at'_def ran_def valid_obj'_def projectKOs valid_objs'_def)
+lemma valid_objs_valid_pte': "\<lbrakk> valid_objs' s ; ko_at' (ko :: pte) p s \<rbrakk> \<Longrightarrow> valid_pte' ko"
+  by (fastforce simp add: obj_at'_def ran_def valid_obj'_def valid_objs'_def)
 
 lemma is_aligned_pageBitsForSize_minimum:
   "\<lbrakk> is_aligned p (pageBitsForSize sz) ; n \<le> pageBits \<rbrakk> \<Longrightarrow> is_aligned p n"
@@ -314,7 +314,7 @@ where
     0 \<notin> ran pool \<and> (\<forall>x \<in> ran pool. is_aligned x pdBits))"
 
 lemma valid_eq_wf_asid_pool'[simp]:
-  "valid_asid_pool' pool = (\<lambda>s. wf_asid_pool' pool)"
+  "valid_asid_pool' pool = wf_asid_pool' pool"
   by (case_tac pool) simp
 declare valid_asid_pool'.simps[simp del]
 (*<<<*)

--- a/proof/crefine/ARM_HYP/Arch_C.thy
+++ b/proof/crefine/ARM_HYP/Arch_C.thy
@@ -2520,7 +2520,7 @@ lemma resolveVAddr_ccorres:
       apply ceqv
      apply (rule ccorres_pre_getObject_pte)
      apply (rule_tac P="page_table_at' (ptrFromPAddr word1)" in ccorres_cross_over_guard)
-     apply (rule_tac P = "\<lambda>s. valid_pte' rv s"
+     apply (rule_tac P = "\<lambda>_. valid_pte' rv"
                  and P'="{s. \<exists>v. cslift s (pte_Ptr (lookup_pt_slot_no_fail (ptrFromPAddr word1) vaddr)) = Some v
                                     \<and> cpte_relation rv v
                                     \<and> array_assertion (pte_Ptr (ptrFromPAddr word1))

--- a/proof/crefine/ARM_HYP/Wellformed_C.thy
+++ b/proof/crefine/ARM_HYP/Wellformed_C.thy
@@ -746,6 +746,25 @@ lemma
   "(scast ThreadState_IdleThreadState :: machine_word) && mask 4 = scast ThreadState_IdleThreadState"
   by (simp add: ThreadState_defs mask_def)+
 
+lemma aligned_tcb_ctcb_not_NULL:
+  assumes "is_aligned p tcbBlockSizeBits"
+  shows "tcb_ptr_to_ctcb_ptr p \<noteq> NULL"
+proof
+  assume "tcb_ptr_to_ctcb_ptr p = NULL"
+  hence "p + ctcb_offset = 0"
+     by (simp add: tcb_ptr_to_ctcb_ptr_def)
+  moreover
+  from `is_aligned p tcbBlockSizeBits`
+  have "p + ctcb_offset = p || ctcb_offset"
+    by (rule word_and_or_mask_aligned) (simp add: ctcb_offset_defs objBits_defs mask_def)
+  moreover
+  have "ctcb_offset !! ctcb_size_bits"
+    by (simp add: ctcb_offset_defs objBits_defs)
+  ultimately
+  show False
+    by (simp add: bang_eq)
+qed
+
 end
 
 end

--- a/proof/crefine/X64/ADT_C.thy
+++ b/proof/crefine/X64/ADT_C.thy
@@ -992,8 +992,8 @@ lemma super_writeable_rights_inj:
 
 lemma cpspace_pml4e_relation_unique:
   assumes "cpspace_pml4e_relation ah ch" "cpspace_pml4e_relation ah' ch"
-  assumes "\<forall>x \<in> ran (map_to_pml4es ah). valid_pml4e' x s"
-  assumes "\<forall>x \<in> ran (map_to_pml4es ah'). valid_pml4e' x s'"
+  assumes "\<forall>x \<in> ran (map_to_pml4es ah). valid_pml4e' x"
+  assumes "\<forall>x \<in> ran (map_to_pml4es ah'). valid_pml4e' x"
   shows   "map_to_pml4es ah' = map_to_pml4es ah"
   apply (rule cmap_relation_unique'[OF inj_Ptr _ assms])
   apply (auto simp: cpml4e_relation_def Let_def split: pml4e.splits bool.splits
@@ -1002,8 +1002,8 @@ lemma cpspace_pml4e_relation_unique:
 
 lemma cpspace_pdpte_relation_unique:
   assumes "cpspace_pdpte_relation ah ch" "cpspace_pdpte_relation ah' ch"
-  assumes "\<forall>x \<in> ran (map_to_pdptes ah). valid_pdpte' x s"
-  assumes "\<forall>x \<in> ran (map_to_pdptes ah'). valid_pdpte' x s'"
+  assumes "\<forall>x \<in> ran (map_to_pdptes ah). valid_pdpte' x"
+  assumes "\<forall>x \<in> ran (map_to_pdptes ah'). valid_pdpte' x"
   shows   "map_to_pdptes ah' = map_to_pdptes ah"
   apply (rule cmap_relation_unique'[OF inj_Ptr _ assms])
   apply (auto simp: cpdpte_relation_def Let_def split: pdpte.splits bool.splits
@@ -1012,8 +1012,8 @@ lemma cpspace_pdpte_relation_unique:
 
 lemma cpspace_pde_relation_unique:
   assumes "cpspace_pde_relation ah ch" "cpspace_pde_relation ah' ch"
-  assumes "\<forall>x \<in> ran (map_to_pdes ah). valid_pde' x s"
-  assumes "\<forall>x \<in> ran (map_to_pdes ah'). valid_pde' x s'"
+  assumes "\<forall>x \<in> ran (map_to_pdes ah). valid_pde' x"
+  assumes "\<forall>x \<in> ran (map_to_pdes ah'). valid_pde' x"
   shows   "map_to_pdes ah' = map_to_pdes ah"
   apply (rule cmap_relation_unique'[OF inj_Ptr _ assms])
   apply (auto simp: cpde_relation_def Let_def split: pde.splits bool.splits
@@ -1022,8 +1022,8 @@ lemma cpspace_pde_relation_unique:
 
 lemma cpspace_pte_relation_unique:
   assumes "cpspace_pte_relation ah ch" "cpspace_pte_relation ah' ch"
-  assumes "\<forall>x \<in> ran (map_to_ptes ah). valid_pte' x s"
-  assumes "\<forall>x \<in> ran (map_to_ptes ah'). valid_pte' x s'"
+  assumes "\<forall>x \<in> ran (map_to_ptes ah). valid_pte' x"
+  assumes "\<forall>x \<in> ran (map_to_ptes ah'). valid_pte' x"
   shows   "map_to_ptes ah' = map_to_ptes ah"
   apply (rule cmap_relation_unique'[OF inj_Ptr _ assms])
   apply (auto simp: cpte_relation_def Let_def split: pte.splits bool.splits
@@ -1223,7 +1223,7 @@ lemma map_to_cnes_eq:
   done
 
 lemma valid_objs'_valid_pml4'_ran:
-  "valid_objs' s \<Longrightarrow> \<forall>x\<in>ran (map_to_pml4es (ksPSpace s)). valid_pml4e' x s"
+  "valid_objs' s \<Longrightarrow> \<forall>x\<in>ran (map_to_pml4es (ksPSpace s)). valid_pml4e' x"
   apply (clarsimp simp: valid_objs'_def ran_def)
   apply (case_tac "ksPSpace s a", simp+)
   apply (rename_tac y, drule_tac x=y in spec)
@@ -1233,7 +1233,7 @@ lemma valid_objs'_valid_pml4'_ran:
   done
 
 lemma valid_objs'_valid_pdpt'_ran:
-  "valid_objs' s \<Longrightarrow> \<forall>x\<in>ran (map_to_pdptes (ksPSpace s)). valid_pdpte' x s"
+  "valid_objs' s \<Longrightarrow> \<forall>x\<in>ran (map_to_pdptes (ksPSpace s)). valid_pdpte' x"
   apply (clarsimp simp: valid_objs'_def ran_def)
   apply (case_tac "ksPSpace s a", simp+)
   apply (rename_tac y, drule_tac x=y in spec)
@@ -1243,7 +1243,7 @@ lemma valid_objs'_valid_pdpt'_ran:
   done
 
 lemma valid_objs'_valid_pde'_ran:
-  "valid_objs' s \<Longrightarrow> \<forall>x\<in>ran (map_to_pdes (ksPSpace s)). valid_pde' x s"
+  "valid_objs' s \<Longrightarrow> \<forall>x\<in>ran (map_to_pdes (ksPSpace s)). valid_pde' x"
   apply (clarsimp simp: valid_objs'_def ran_def)
   apply (case_tac "ksPSpace s a", simp+)
   apply (rename_tac y, drule_tac x=y in spec)
@@ -1253,7 +1253,7 @@ lemma valid_objs'_valid_pde'_ran:
   done
 
 lemma valid_objs'_valid_pte'_ran:
-  "valid_objs' s \<Longrightarrow> \<forall>x\<in>ran (map_to_ptes (ksPSpace s)). valid_pte' x s"
+  "valid_objs' s \<Longrightarrow> \<forall>x\<in>ran (map_to_ptes (ksPSpace s)). valid_pte' x"
   apply (clarsimp simp: valid_objs'_def ran_def)
   apply (case_tac "ksPSpace s a", simp+)
   apply (rename_tac y, drule_tac x=y in spec)
@@ -1359,13 +1359,6 @@ lemma ksPSpace_eq_imp_valid_tcb'_eq:
                  valid_tcb'_def valid_tcb_state'_def valid_bound_ntfn'_def valid_arch_tcb'_def
           split: thread_state.splits option.splits)
 
-lemma ksPSpace_eq_imp_valid_arch_obj'_eq:
-  assumes ksPSpace: "ksPSpace s' = ksPSpace s"
-  shows "valid_arch_obj' ao s' = valid_arch_obj' ao s"
-  apply (case_tac ao, simp)
-     apply (rename_tac obj, case_tac obj; simp add: valid_mapping'_def)+
-  done
-
 lemma ksPSpace_eq_imp_valid_objs'_eq:
   assumes ksPSpace: "ksPSpace s' = ksPSpace s"
   shows "valid_objs' s' = valid_objs' s"
@@ -1374,7 +1367,6 @@ lemma ksPSpace_eq_imp_valid_objs'_eq:
                      ksPSpace_eq_imp_obj_at'_eq[OF ksPSpace]
                      ksPSpace_eq_imp_valid_tcb'_eq[OF ksPSpace]
                      ksPSpace_eq_imp_valid_cap'_eq[OF ksPSpace]
-                     ksPSpace_eq_imp_valid_arch_obj'_eq[OF ksPSpace]
                      valid_ntfn'_def valid_cte'_def valid_bound_tcb'_def
               split: kernel_object.splits endpoint.splits ntfn.splits option.splits)
 

--- a/proof/crefine/X64/ArchMove_C.thy
+++ b/proof/crefine/X64/ArchMove_C.thy
@@ -371,7 +371,7 @@ lemma is_aligned_pageBitsForSize_minimum:
   apply (erule is_aligned_weaken, simp)+
   done
 
-lemma valid_objs_valid_pte': "\<lbrakk> valid_objs' s ; ko_at' (ko :: pte) p s \<rbrakk> \<Longrightarrow> valid_pte' ko s"
+lemma valid_objs_valid_pte': "\<lbrakk> valid_objs' s ; ko_at' (ko :: pte) p s \<rbrakk> \<Longrightarrow> valid_pte' ko"
   by (fastforce simp add: obj_at'_def ran_def valid_obj'_def projectKOs valid_objs'_def)
 
 lemma obj_at_kernel_mappings':
@@ -388,7 +388,7 @@ where
     0 \<notin> ran pool \<and> (\<forall>x \<in> ran pool. is_aligned x pml4_bits))"
 
 lemma valid_eq_wf_asid_pool'[simp]:
-  "valid_asid_pool' pool = (\<lambda>s. wf_asid_pool' pool)"
+  "valid_asid_pool' pool = wf_asid_pool' pool"
   by (case_tac pool) simp
 
 declare valid_asid_pool'.simps[simp del]

--- a/proof/refine/AARCH64/ArchInvsDefs_H.thy
+++ b/proof/refine/AARCH64/ArchInvsDefs_H.thy
@@ -186,8 +186,8 @@ definition valid_vcpu' :: "vcpu \<Rightarrow> bool" where
 definition ppn_bounded :: "pte \<Rightarrow> bool" where
   "ppn_bounded pte \<equiv> case pte of PageTablePTE ppn \<Rightarrow> canonical_address ppn | _ \<Rightarrow> True"
 
-definition valid_arch_obj' :: "arch_kernel_object \<Rightarrow> kernel_state \<Rightarrow> bool" where
-  "valid_arch_obj' ako _ \<equiv> case ako of
+definition valid_arch_obj' :: "arch_kernel_object \<Rightarrow> bool" where
+  "valid_arch_obj' ako \<equiv> case ako of
      KOPTE pte \<Rightarrow> ppn_bounded pte
    | KOVCPU vcpu \<Rightarrow> valid_vcpu' vcpu
    | _ \<Rightarrow> True"

--- a/proof/refine/AARCH64/ArchInvsLemmas_H.thy
+++ b/proof/refine/AARCH64/ArchInvsLemmas_H.thy
@@ -44,12 +44,6 @@ lemma valid_cap'_pspaceI[Invariants_H_pspaceI_assms]:
             simp: vspace_table_at'_defs valid_arch_cap'_def valid_arch_cap_ref'_def
            split: arch_capability.split zombie_type.split option.splits)
 
-(* FIXME arch-split: required since valid_arch_obj' takes state due to other arches *)
-lemma valid_arch_obj'_pspaceI:
-  "\<lbrakk>valid_arch_obj' obj s; ksPSpace s = ksPSpace s'\<rbrakk> \<Longrightarrow> valid_arch_obj' obj s'"
-  unfolding valid_arch_obj'_def
-  by simp
-
 lemma valid_obj'_pspaceI[Invariants_H_pspaceI_assms]:
   "valid_obj' obj s \<Longrightarrow> ksPSpace s = ksPSpace s' \<Longrightarrow> valid_obj' obj s'"
   unfolding valid_obj'_def
@@ -59,7 +53,7 @@ lemma valid_obj'_pspaceI[Invariants_H_pspaceI_assms]:
                  valid_bound_ntfn'_def valid_arch_tcb'_def
            split: Structures_H.endpoint.splits Structures_H.notification.splits
                   Structures_H.thread_state.splits ntfn.splits option.splits
-           intro: obj_at'_pspaceI valid_cap'_pspaceI typ_at'_pspaceI valid_arch_obj'_pspaceI)
+           intro: obj_at'_pspaceI valid_cap'_pspaceI typ_at'_pspaceI)
 
 lemma tcb_space_clear[Invariants_H_pspaceI_assms]:
   "\<lbrakk> tcb_cte_cases (y - x) = Some (getF, setF);

--- a/proof/refine/AARCH64/ArchStateRelationLemmas.thy
+++ b/proof/refine/AARCH64/ArchStateRelationLemmas.thy
@@ -159,14 +159,6 @@ lemma other_aobj_relation_aobj:
   unfolding other_aobj_relation_def is_ArchObj_def
   by (clarsimp split: Structures_A.kernel_object.splits)
 
-(* interface lemma, can't be used in locale assumptions due to free type variable *)
-lemma valid_arch_obj'_valid[wp]:
-  assumes P: "\<And>P T p. \<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace> f \<lbrace>\<lambda>rv s. P (typ_at' T p s)\<rbrace>"
-  notes [wp] = hoare_vcg_all_lift hoare_vcg_imp_lift hoare_vcg_const_Ball_lift typ_at_lifts[OF P]
-  shows "\<lbrace>valid_arch_obj' ako\<rbrace> f \<lbrace>\<lambda>rv. valid_arch_obj' ako\<rbrace>"
-  unfolding valid_arch_obj'_def
-  by (case_tac ako; wpsimp)
-
 lemma msgLabelBits_msg_label_bits[StateRelation_R_assms]:
   "msgLabelBits = msg_label_bits"
   by (simp add: msgLabelBits_def)

--- a/proof/refine/AARCH64/Retype_R.thy
+++ b/proof/refine/AARCH64/Retype_R.thy
@@ -2940,12 +2940,6 @@ lemma valid_untyped'_helper:
   done
 qed
 
-(* FIXME arch-split: workaround for stateless valid_arch_obj' *)
-lemma valid_arch_obj'_state_inv[simp]:
-  "valid_arch_obj' ako s \<Longrightarrow> valid_arch_obj' ako s'"
-  unfolding valid_arch_obj'_def
-  by simp
-
 definition caps_overlap_reserved' :: "machine_word set \<Rightarrow> kernel_state \<Rightarrow> bool"
 where
  "caps_overlap_reserved' S s \<equiv> \<forall>cte \<in> ran (ctes_of s).

--- a/proof/refine/ARM/ArchArchAcc_R.thy
+++ b/proof/refine/ARM/ArchArchAcc_R.thy
@@ -1089,8 +1089,8 @@ lemma pte_relation'_Invalid_inv [simp]:
 
 definition
   "valid_slots' m \<equiv> case m of
-    Inl (pte, xs) \<Rightarrow> \<lambda>s. valid_pte' pte s
-  | Inr (pde, xs) \<Rightarrow> \<lambda>s. valid_pde' pde s"
+    Inl (pte, xs) \<Rightarrow> \<lambda>s. valid_pte' pte
+  | Inr (pde, xs) \<Rightarrow> \<lambda>s. valid_pde' pde"
 
 lemma createMappingEntries_valid_slots' [wp]:
   "\<lbrace>valid_objs' and
@@ -1324,7 +1324,7 @@ lemma storePDE_ctes [wp]:
 
 
 lemma storePDE_valid_objs [wp]:
-  "\<lbrace>valid_objs' and valid_pde' pde\<rbrace> storePDE p pde \<lbrace>\<lambda>_. valid_objs'\<rbrace>"
+  "\<lbrace>valid_objs' and K (valid_pde' pde)\<rbrace> storePDE p pde \<lbrace>\<lambda>_. valid_objs'\<rbrace>"
   apply (simp add: storePDE_def doMachineOp_def split_def)
   apply (rule hoare_pre)
    apply (wp hoare_drop_imps|wpc|simp)+

--- a/proof/refine/ARM/ArchInvsDefs_H.thy
+++ b/proof/refine/ARM/ArchInvsDefs_H.thy
@@ -138,27 +138,27 @@ lemmas [simp] = arch_valid_irq_def
 definition valid_arch_tcb' :: "Structures_H.arch_tcb \<Rightarrow> kernel_state \<Rightarrow> bool" where
   "valid_arch_tcb' \<equiv> \<lambda>t. \<top>"
 
-definition valid_mapping' :: "word32 \<Rightarrow> vmpage_size \<Rightarrow> kernel_state \<Rightarrow> bool" where
- "valid_mapping' x sz s \<equiv> is_aligned x (pageBitsForSize sz)
-                          \<and> ptrFromPAddr x \<noteq> 0"
+definition valid_mapping' :: "word32 \<Rightarrow> vmpage_size \<Rightarrow> bool" where
+ "valid_mapping' x sz \<equiv> is_aligned x (pageBitsForSize sz)
+                        \<and> ptrFromPAddr x \<noteq> 0"
 
-primrec valid_pte' :: "ARM_H.pte \<Rightarrow> kernel_state \<Rightarrow> bool" where
-  "valid_pte' (InvalidPTE) = \<top>"
+primrec valid_pte' :: "ARM_H.pte \<Rightarrow> bool" where
+  "valid_pte' (InvalidPTE) = True"
 | "valid_pte' (LargePagePTE ptr _ _ _ _) = (valid_mapping' ptr ARMLargePage)"
 | "valid_pte' (SmallPagePTE ptr _ _ _ _) = (valid_mapping' ptr ARMSmallPage)"
 
-primrec valid_pde' :: "ARM_H.pde \<Rightarrow> kernel_state \<Rightarrow> bool" where
- "valid_pde' (InvalidPDE) = \<top>"
+primrec valid_pde' :: "ARM_H.pde \<Rightarrow> bool" where
+ "valid_pde' (InvalidPDE) = True"
 | "valid_pde' (SectionPDE ptr _ _ _ _ _ _) = (valid_mapping' ptr ARMSection)"
 | "valid_pde' (SuperSectionPDE ptr _ _ _ _ _) = (valid_mapping' ptr ARMSuperSection)"
-| "valid_pde' (PageTablePDE ptr _ _) = (\<lambda>_. is_aligned ptr ptBits)"
+| "valid_pde' (PageTablePDE ptr _ _) = is_aligned ptr ptBits"
 
-primrec valid_asid_pool' :: "asidpool \<Rightarrow> kernel_state \<Rightarrow> bool" where
+primrec valid_asid_pool' :: "asidpool \<Rightarrow> bool" where
  "valid_asid_pool' (ASIDPool pool)
-     = (\<lambda>s. dom pool \<subseteq> {0 .. 2^asid_low_bits - 1}
-            \<and> 0 \<notin> ran pool \<and> (\<forall>x \<in> ran pool. is_aligned x pdBits))"
+     = (dom pool \<subseteq> {0 .. 2^asid_low_bits - 1}
+        \<and> 0 \<notin> ran pool \<and> (\<forall>x \<in> ran pool. is_aligned x pdBits))"
 
-primrec valid_arch_obj' :: "arch_kernel_object \<Rightarrow> kernel_state \<Rightarrow> bool" where
+primrec valid_arch_obj' :: "arch_kernel_object \<Rightarrow> bool" where
   "valid_arch_obj' (KOASIDPool pool) = valid_asid_pool' pool"
 | "valid_arch_obj' (KOPDE pde) = valid_pde' pde"
 | "valid_arch_obj' (KOPTE pte) = valid_pte' pte"

--- a/proof/refine/ARM/ArchInvsLemmas_H.thy
+++ b/proof/refine/ARM/ArchInvsLemmas_H.thy
@@ -45,21 +45,6 @@ lemma valid_cap'_pspaceI[Invariants_H_pspaceI_assms]:
             simp: vspace_table_at'_defs valid_arch_cap'_def
            split: arch_capability.split zombie_type.split option.splits)+
 
-(* FIXME arch-split: required since valid_arch_obj' takes state due to other arches *)
-lemma valid_arch_obj'_pspaceI:
-  "\<lbrakk>valid_arch_obj' obj s; ksPSpace s = ksPSpace s'\<rbrakk> \<Longrightarrow> valid_arch_obj' obj s'"
-  apply (cases obj; simp)
-    apply (rename_tac asidpool)
-    apply (case_tac asidpool,
-           auto simp: page_directory_at'_def intro: typ_at'_pspaceI[rotated])[1]
-   apply (rename_tac pte)
-   apply (case_tac pte; simp add: valid_mapping'_def)
-  apply (rename_tac pde)
-  apply (case_tac pde;
-         auto simp: page_table_at'_def valid_mapping'_def
-             intro: typ_at'_pspaceI[rotated])
-  done
-
 lemma valid_obj'_pspaceI[Invariants_H_pspaceI_assms]:
   "valid_obj' obj s \<Longrightarrow> ksPSpace s = ksPSpace s' \<Longrightarrow> valid_obj' obj s'"
   unfolding valid_obj'_def
@@ -69,7 +54,7 @@ lemma valid_obj'_pspaceI[Invariants_H_pspaceI_assms]:
                  valid_bound_ntfn'_def valid_arch_tcb'_def
            split: Structures_H.endpoint.splits Structures_H.notification.splits
                   Structures_H.thread_state.splits ntfn.splits option.splits
-           intro: obj_at'_pspaceI valid_cap'_pspaceI typ_at'_pspaceI valid_arch_obj'_pspaceI)
+           intro: obj_at'_pspaceI valid_cap'_pspaceI typ_at'_pspaceI)
 
 lemma tcb_space_clear[Invariants_H_pspaceI_assms]:
   "\<lbrakk> tcb_cte_cases (y - x) = Some (getF, setF);
@@ -374,30 +359,13 @@ lemma valid_arch_tcb_lift':
   shows "\<lbrace>\<lambda>s. valid_arch_tcb' tcb s\<rbrace> f \<lbrace>\<lambda>rv s. valid_arch_tcb' tcb s\<rbrace>"
   by (clarsimp simp add: valid_arch_tcb'_def, wp)
 
-lemma valid_pde_lift':
-  assumes x: "\<And>T p. \<lbrace>typ_at' T p\<rbrace> f \<lbrace>\<lambda>rv. typ_at' T p\<rbrace>"
-  shows "\<lbrace>\<lambda>s. valid_pde' pde s\<rbrace> f \<lbrace>\<lambda>rv s. valid_pde' pde s\<rbrace>"
-  by (cases pde) (simp add: valid_mapping'_def|wp x typ_at_lift_page_table_at')+
-
-lemma valid_pte_lift':
-  assumes x: "\<And>T p. \<lbrace>typ_at' T p\<rbrace> f \<lbrace>\<lambda>rv. typ_at' T p\<rbrace>"
-  shows "\<lbrace>\<lambda>s. valid_pte' pte s\<rbrace> f \<lbrace>\<lambda>rv s. valid_pte' pte s\<rbrace>"
-  by (cases pte) (simp add: valid_mapping'_def|wp x typ_at_lift_page_directory_at')+
-
-lemma valid_asid_pool_lift':
-  assumes x: "\<And>T p. \<lbrace>typ_at' T p\<rbrace> f \<lbrace>\<lambda>rv. typ_at' T p\<rbrace>"
-  shows "\<lbrace>\<lambda>s. valid_asid_pool' ap s\<rbrace> f \<lbrace>\<lambda>rv s. valid_asid_pool' ap s\<rbrace>"
-  by (cases ap) (simp|wp x typ_at_lift_page_directory_at' hoare_vcg_const_Ball_lift)+
-
 lemmas typ_at_lifts =
            typ_at_lift_tcb' typ_at_lift_ep' typ_at_lift_ntfn' typ_at_lift_cte' typ_at_lift_cte_at'
            typ_at_lift_valid_untyped' typ_at_lift_valid_cap' valid_bound_tcb_lift
            typ_at_lift_page_table_at'
            typ_at_lift_page_directory_at'
            typ_at_lift_asid_at'
-           valid_pde_lift'
-           valid_pte_lift'
-           valid_asid_pool_lift'
+           valid_arch_tcb_lift'
 
 lemmas bit_simps' = pteBits_def pdeBits_def asidHighBits_def asid_low_bits_def word_size_bits_def
                     asid_high_bits_def bit_simps

--- a/proof/refine/ARM/ArchStateRelationLemmas.thy
+++ b/proof/refine/ARM/ArchStateRelationLemmas.thy
@@ -165,14 +165,6 @@ lemma other_aobj_relation_aobj:
   unfolding other_aobj_relation_def is_ArchObj_def
   by (clarsimp split: Structures_A.kernel_object.splits)
 
-(* interface lemma, can't be used in locale assumptions due to free type variable *)
-lemma valid_arch_obj'_valid[wp]:
-  assumes P: "\<And>P T p. \<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace> f \<lbrace>\<lambda>rv s. P (typ_at' T p s)\<rbrace>"
-  notes [wp] = hoare_vcg_all_lift hoare_vcg_imp_lift hoare_vcg_const_Ball_lift typ_at_lifts[OF P]
-  shows "\<lbrace>valid_arch_obj' ako\<rbrace> f \<lbrace>\<lambda>rv. valid_arch_obj' ako\<rbrace>"
-  unfolding valid_arch_obj'_def
-  by (case_tac ako; wpsimp)
-
 lemma msgLabelBits_msg_label_bits[StateRelation_R_assms]:
   "msgLabelBits = msg_label_bits"
   by (simp add: msgLabelBits_def)

--- a/proof/refine/ARM/Detype_R.thy
+++ b/proof/refine/ARM/Detype_R.thy
@@ -1131,14 +1131,6 @@ lemma valid_obj':
    apply (clarsimp simp: ko_wp_at'_def objBits_simps' cte_level_bits_def[symmetric])
    apply (erule(2) cte_wp_at_cteI')
    apply simp
-  apply (rename_tac arch_kernel_object)
-  apply (case_tac "arch_kernel_object", simp_all)
-    apply (rename_tac asidpool)
-    apply (case_tac asidpool, clarsimp simp: page_directory_at'_def)
-   apply (rename_tac pte)
-   apply (case_tac pte, simp_all add: valid_mapping'_def)
-  apply(rename_tac pde)
-  apply (case_tac pde, simp_all add: valid_mapping'_def)
   done
 
 lemma tcbSchedNexts_of_pspace':

--- a/proof/refine/ARM/Finalise_R.thy
+++ b/proof/refine/ARM/Finalise_R.thy
@@ -2497,15 +2497,6 @@ lemma deleteASIDPool_invs[wp]:
               | simp)+
   done
 
-lemma invalidateASIDEntry_valid_ap' [wp]:
-  "\<lbrace>valid_asid_pool' p\<rbrace> invalidateASIDEntry asid \<lbrace>\<lambda>r. valid_asid_pool' p\<rbrace>"
-  apply (simp add: invalidateASIDEntry_def invalidateASID_def
-                   invalidateHWASIDEntry_def bind_assoc)
-  apply (wp loadHWASID_wp | simp)+
-  apply (case_tac p)
-  apply (clarsimp simp del: fun_upd_apply)
-  done
-
 lemmas flushSpace_typ_ats' [wp] = typ_at_lifts [OF flushSpace_typ_at']
 
 lemma deleteASID_invs'[wp]:

--- a/proof/refine/ARM/Retype_R.thy
+++ b/proof/refine/ARM/Retype_R.thy
@@ -3079,17 +3079,6 @@ proof (intro conjI impI)
      apply (erule valid_cap[unfolded foldr_upd_app_if[folded data_map_insert_def]])
      apply (erule(2) cte_wp_at_cteI'[unfolded cte_level_bits_def])
      apply simp
-    apply (rename_tac arch_kernel_object)
-    apply (case_tac arch_kernel_object; simp)
-      apply (rename_tac asidpool)
-      apply (case_tac asidpool, clarsimp simp: page_directory_at'_def
-                                               typ_at_to_obj_at_arches
-                                               obj_at_disj')
-     apply (rename_tac pte)
-     apply (case_tac pte; simp add: valid_mapping'_def)
-    apply (rename_tac pde)
-    apply (case_tac pde; simp add: valid_mapping'_def page_table_at'_def
-                                   typ_at_to_obj_at_arches obj_at_disj')
     done
   have not_0: "0 \<notin> set (new_cap_addrs (2 ^ gbits * n) ptr val)"
     using p_0
@@ -3168,7 +3157,7 @@ lemma createObjects_valid_pspace_untyped':
   done
 
 lemma getObject_valid_pde'[wp]:
-  "\<lbrace>valid_objs'\<rbrace> getObject x \<lbrace>valid_pde'\<rbrace>"
+  "\<lbrace>valid_objs'\<rbrace> getObject x \<lbrace>\<lambda>rv _. valid_pde' rv\<rbrace>"
   apply (rule hoare_chain)
     apply (rule hoare_vcg_conj_lift)
      apply (rule getObject_ko_at, simp)
@@ -3176,7 +3165,7 @@ lemma getObject_valid_pde'[wp]:
     apply (rule getObject_inv[where P=valid_objs'])
     apply (simp add: loadObject_default_inv)
    apply simp
-  apply (clarsimp simp: projectKOs valid_obj'_def dest!: obj_at_valid_objs')
+  apply (clarsimp simp: valid_obj'_def dest!: obj_at_valid_objs')
   done
 
 crunch copyGlobalMappings
@@ -3795,7 +3784,7 @@ lemma copyGlobalMappings_ko_wp_at:
      apply (simp add: objBits_simps archObjSize_def)
     apply (simp add: pdeBits_def)
    apply (simp cong: if_cong split del: if_split)
-   apply (wp getObject_inv loadObject_default_inv | simp split del: if_split)+
+   apply (wp (trace) getObject_inv loadObject_default_inv | simp split del: if_split)+
    apply (clarsimp simp: obj_at'_def ko_wp_at'_def projectKOs)
   apply (wp | simp)+
   done

--- a/proof/refine/ARM_HYP/ArchArchAcc_R.thy
+++ b/proof/refine/ARM_HYP/ArchArchAcc_R.thy
@@ -1282,8 +1282,8 @@ fun pde_vmsz_aligned' where
 
 definition
   "valid_slots' m \<equiv> case m of
-    Inl (pte, xs) \<Rightarrow> \<lambda>s. valid_pte' pte s \<and> pte_vmsz_aligned' pte
-  | Inr (pde, xs) \<Rightarrow> \<lambda>s. valid_pde' pde s \<and> pde_vmsz_aligned' pde"
+    Inl (pte, xs) \<Rightarrow> \<lambda>s. valid_pte' pte \<and> pte_vmsz_aligned' pte
+  | Inr (pde, xs) \<Rightarrow> \<lambda>s. valid_pde' pde \<and> pde_vmsz_aligned' pde"
 
 lemma createMappingEntries_valid_slots' [wp]:
   "\<lbrace>valid_objs' and
@@ -1566,7 +1566,7 @@ lemma storePDE_ctes [wp]:
 
 
 lemma storePDE_valid_objs [wp]:
-  "\<lbrace>valid_objs' and valid_pde' pde\<rbrace> storePDE p pde \<lbrace>\<lambda>_. valid_objs'\<rbrace>"
+  "\<lbrace>valid_objs' and K (valid_pde' pde) \<rbrace> storePDE p pde \<lbrace>\<lambda>_. valid_objs'\<rbrace>"
   apply (simp add: storePDE_def doMachineOp_def split_def)
   apply (rule hoare_pre)
    apply (wp hoare_drop_imps|wpc|simp)+

--- a/proof/refine/ARM_HYP/ArchStateRelationLemmas.thy
+++ b/proof/refine/ARM_HYP/ArchStateRelationLemmas.thy
@@ -161,13 +161,6 @@ lemma other_aobj_relation_aobj:
   unfolding other_aobj_relation_def is_ArchObj_def
   by (clarsimp split: Structures_A.kernel_object.splits)
 
-(* interface lemma, can't be used in locale assumptions due to free type variable *)
-lemma valid_arch_obj'_valid[wp]:
-  assumes P: "\<And>P T p. \<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace> f \<lbrace>\<lambda>rv s. P (typ_at' T p s)\<rbrace>"
-  notes [wp] = hoare_vcg_all_lift hoare_vcg_imp_lift hoare_vcg_const_Ball_lift typ_at_lifts[OF P]
-  shows "\<lbrace>valid_arch_obj' ako\<rbrace> f \<lbrace>\<lambda>rv. valid_arch_obj' ako\<rbrace>"
-  by (case_tac ako; wpsimp)
-
 lemma msgLabelBits_msg_label_bits[StateRelation_R_assms]:
   "msgLabelBits = msg_label_bits"
   by (simp add: msgLabelBits_def)

--- a/proof/refine/ARM_HYP/Arch_R.thy
+++ b/proof/refine/ARM_HYP/Arch_R.thy
@@ -2292,8 +2292,7 @@ lemma assoc_invs':
   apply (rule conjI)
    apply (clarsimp simp: typ_at_to_obj_at_arches obj_at'_def)
   apply (rule conjI)
-   apply (clarsimp simp: typ_at_tcb' obj_at'_def)
-
+   apply (fastforce dest!: obj_at_aligned' simp add: objBits_def objBits_simps')
   supply fun_upd_apply[simp]
   apply (clarsimp simp: hyp_live'_def arch_live'_def)
   apply (rule_tac rfs'="state_hyp_refs_of' s" in delta_sym_refs, assumption)

--- a/proof/refine/ARM_HYP/Detype_R.thy
+++ b/proof/refine/ARM_HYP/Detype_R.thy
@@ -1186,21 +1186,6 @@ lemma valid_obj':
    apply (clarsimp simp: ko_wp_at'_def objBits_simps' cte_level_bits_def[symmetric])
    apply (erule(2) cte_wp_at_cteI')
    apply simp
-  apply (rename_tac arch_kernel_object)
-  apply (case_tac "arch_kernel_object", simp_all)
-    apply (rename_tac asidpool)
-    apply (case_tac asidpool, clarsimp)
-   apply (rename_tac pte)
-   apply (case_tac pte, simp_all add: valid_mapping'_def)
-  apply(rename_tac pde)
-  apply (case_tac pde, simp_all add: valid_mapping'_def)
-  (* vcpu case *)
-  using sym_hyp_refs
-  apply (clarsimp simp add: valid_vcpu'_def split: option.split_asm)
-  apply (drule (2) sym_refs_VCPU_hyp_live')
-  apply (drule live_notRange, clarsimp simp: live'_def)
-   apply (case_tac ko; simp)
-  apply clarsimp
   done
 
 lemma tcbSchedNexts_of_pspace':

--- a/proof/refine/ARM_HYP/Finalise_R.thy
+++ b/proof/refine/ARM_HYP/Finalise_R.thy
@@ -2526,15 +2526,6 @@ lemma deleteASIDPool_invs[wp]:
               | simp)+
   done
 
-lemma invalidateASIDEntry_valid_ap' [wp]:
-  "\<lbrace>valid_asid_pool' p\<rbrace> invalidateASIDEntry asid \<lbrace>\<lambda>r. valid_asid_pool' p\<rbrace>"
-  apply (simp add: invalidateASIDEntry_def invalidateASID_def
-                   invalidateHWASIDEntry_def bind_assoc)
-  apply (wp loadHWASID_wp | simp)+
-  apply (case_tac p)
-  apply (clarsimp simp del: fun_upd_apply)
-  done
-
 lemmas flushSpace_typ_ats' [wp] = typ_at_lifts [OF flushSpace_typ_at']
 
 lemma deleteASID_invs'[wp]:

--- a/proof/refine/ARM_HYP/Retype_R.thy
+++ b/proof/refine/ARM_HYP/Retype_R.thy
@@ -3073,21 +3073,6 @@ proof (intro conjI impI)
      apply (erule valid_cap[unfolded foldr_upd_app_if[folded data_map_insert_def]])
      apply (erule(2) cte_wp_at_cteI'[unfolded cte_level_bits_def])
      apply simp
-    apply (rename_tac arch_kernel_object)
-    apply (case_tac arch_kernel_object; simp)
-      apply (rename_tac asidpool)
-      apply (case_tac asidpool, clarsimp simp: page_directory_at'_def
-                                               typ_at_to_obj_at_arches
-                                               obj_at_disj')
-     apply (rename_tac pte)
-     apply (case_tac pte; simp add: valid_mapping'_def)
-    apply (rename_tac pde)
-    apply (case_tac pde; simp add: valid_mapping'_def page_table_at'_def
-                                   typ_at_to_obj_at_arches obj_at_disj')
-   apply (rename_tac vcpu)
-   apply (case_tac "vcpuTCBPtr vcpu";
-          clarsimp simp: valid_vcpu'_def typ_at_to_obj_at'[where 'a=tcb, simplified]
-                         typ_at_to_obj_at_arches obj_at_disj')
    done
   have not_0: "0 \<notin> set (new_cap_addrs (2 ^ gbits * n) ptr val)"
     using p_0

--- a/proof/refine/Invariants_H.thy
+++ b/proof/refine/Invariants_H.thy
@@ -392,7 +392,7 @@ definition valid_obj' :: "Structures_H.kernel_object \<Rightarrow> kernel_state 
   | KOUserDataDevice \<Rightarrow> True
   | KOTCB tcb \<Rightarrow> valid_tcb' tcb s
   | KOCTE cte \<Rightarrow> valid_cte' cte s
-  | KOArch ako \<Rightarrow> valid_arch_obj' ako s"
+  | KOArch ako \<Rightarrow> valid_arch_obj' ako"
 
 definition
   pspace_aligned' :: "kernel_state \<Rightarrow> bool"

--- a/proof/refine/KHeap_R.thy
+++ b/proof/refine/KHeap_R.thy
@@ -11,11 +11,6 @@ imports
   ArchMachine_R
 begin
 
-arch_requalify_facts
-  valid_arch_obj'_valid
-
-lemmas [wp] = valid_arch_obj'_valid
-
 translations
   (type) "'a kernel" <=(type) "kernel_state \<Rightarrow> ('a \<times> kernel_state) set \<times> bool"
 
@@ -1730,8 +1725,7 @@ lemma typ_at'_valid_obj'_lift:
                      valid_bound_ntfn'_def;
            wpsimp wp: hoare_case_option_wp hoare_case_option_wp2 valid_arch_tcb_lift' P;
            (clarsimp split: option.splits)?)
-   apply (wpsimp simp: valid_cte'_def)
-  apply (rule valid_arch_obj'_valid[OF P])
+   apply (wpsimp simp: valid_cte'_def)+
   done
 
 lemmas setObject_valid_obj = typ_at'_valid_obj'_lift [OF setObject_typ_at']

--- a/proof/refine/RISCV64/ArchInvsDefs_H.thy
+++ b/proof/refine/RISCV64/ArchInvsDefs_H.thy
@@ -142,8 +142,8 @@ definition is_device_frame_cap' :: "capability \<Rightarrow> bool" where
 definition valid_arch_tcb' :: "Structures_H.arch_tcb \<Rightarrow> kernel_state \<Rightarrow> bool" where
   "valid_arch_tcb' \<equiv> \<lambda>t. \<top>"
 
-definition valid_arch_obj' :: "arch_kernel_object \<Rightarrow> kernel_state \<Rightarrow> bool" where
-  "valid_arch_obj' ako _ \<equiv> case ako of
+definition valid_arch_obj' :: "arch_kernel_object \<Rightarrow> bool" where
+  "valid_arch_obj' ako \<equiv> case ako of
      _ \<Rightarrow> True"
 
 primrec

--- a/proof/refine/RISCV64/ArchInvsLemmas_H.thy
+++ b/proof/refine/RISCV64/ArchInvsLemmas_H.thy
@@ -44,12 +44,6 @@ lemma valid_cap'_pspaceI[Invariants_H_pspaceI_assms]:
             simp: vspace_table_at'_defs valid_arch_cap'_def valid_arch_cap_ref'_def
            split: arch_capability.split zombie_type.split option.splits)
 
-(* FIXME arch-split: required since valid_arch_obj' takes state due to other arches *)
-lemma valid_arch_obj'_pspaceI:
-  "\<lbrakk>valid_arch_obj' obj s; ksPSpace s = ksPSpace s'\<rbrakk> \<Longrightarrow> valid_arch_obj' obj s'"
-  unfolding valid_arch_obj'_def
-  by simp
-
 lemma valid_obj'_pspaceI[Invariants_H_pspaceI_assms]:
   "valid_obj' obj s \<Longrightarrow> ksPSpace s = ksPSpace s' \<Longrightarrow> valid_obj' obj s'"
   unfolding valid_obj'_def
@@ -59,7 +53,7 @@ lemma valid_obj'_pspaceI[Invariants_H_pspaceI_assms]:
                  valid_bound_ntfn'_def valid_arch_tcb'_def
            split: Structures_H.endpoint.splits Structures_H.notification.splits
                   Structures_H.thread_state.splits ntfn.splits option.splits
-           intro: obj_at'_pspaceI valid_cap'_pspaceI typ_at'_pspaceI valid_arch_obj'_pspaceI)
+           intro: obj_at'_pspaceI valid_cap'_pspaceI typ_at'_pspaceI)
 
 lemma tcb_space_clear[Invariants_H_pspaceI_assms]:
   "\<lbrakk> tcb_cte_cases (y - x) = Some (getF, setF);

--- a/proof/refine/RISCV64/ArchStateRelationLemmas.thy
+++ b/proof/refine/RISCV64/ArchStateRelationLemmas.thy
@@ -153,14 +153,6 @@ lemma other_aobj_relation_aobj:
   unfolding other_aobj_relation_def is_ArchObj_def
   by (clarsimp split: Structures_A.kernel_object.splits)
 
-(* interface lemma, can't be used in locale assumptions due to free type variable *)
-lemma valid_arch_obj'_valid[wp]:
-  assumes P: "\<And>P T p. \<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace> f \<lbrace>\<lambda>rv s. P (typ_at' T p s)\<rbrace>"
-  notes [wp] = hoare_vcg_all_lift hoare_vcg_imp_lift hoare_vcg_const_Ball_lift typ_at_lifts[OF P]
-  shows "\<lbrace>valid_arch_obj' ako\<rbrace> f \<lbrace>\<lambda>rv. valid_arch_obj' ako\<rbrace>"
-  unfolding valid_arch_obj'_def
-  by (case_tac ako; wpsimp)
-
 lemma msgLabelBits_msg_label_bits[StateRelation_R_assms]:
   "msgLabelBits = msg_label_bits"
   by (simp add: msgLabelBits_def)

--- a/proof/refine/X64/ArchArchAcc_R.thy
+++ b/proof/refine/X64/ArchArchAcc_R.thy
@@ -1682,9 +1682,9 @@ lemma pml4e_relation'_Invalid_inv [simp]:
 
 definition
   "valid_slots' m \<equiv> case m of
-    (VMPTE pte, p) \<Rightarrow> \<lambda>s. valid_pte' pte s
-  | (VMPDE pde, p) \<Rightarrow> \<lambda>s. valid_pde' pde s
-  | (VMPDPTE pdpte, p) \<Rightarrow> \<lambda>s. valid_pdpte' pdpte s"
+    (VMPTE pte, p) \<Rightarrow> \<lambda>s. valid_pte' pte
+  | (VMPDE pde, p) \<Rightarrow> \<lambda>s. valid_pde' pde
+  | (VMPDPTE pdpte, p) \<Rightarrow> \<lambda>s. valid_pdpte' pdpte"
 
 lemma createMappingEntries_valid_slots' [wp]:
   "\<lbrace>valid_objs' and
@@ -2015,7 +2015,7 @@ lemma storePML4E_ctes [wp]:
   done
 
 lemma storePML4E_valid_objs [wp]:
-  "\<lbrace>valid_objs' and valid_pml4e' pml4e\<rbrace> storePML4E p pml4e \<lbrace>\<lambda>_. valid_objs'\<rbrace>"
+  "\<lbrace>valid_objs' and K (valid_pml4e' pml4e)\<rbrace> storePML4E p pml4e \<lbrace>\<lambda>_. valid_objs'\<rbrace>"
   apply (simp add: storePML4E_def doMachineOp_def split_def)
   apply (rule hoare_pre)
    apply (wp hoare_drop_imps|wpc|simp)+
@@ -2027,7 +2027,7 @@ lemma storePML4E_valid_objs [wp]:
   done
 
 lemma storePDPTE_valid_objs [wp]:
-  "\<lbrace>valid_objs' and valid_pdpte' pdpte\<rbrace> storePDPTE p pdpte \<lbrace>\<lambda>_. valid_objs'\<rbrace>"
+  "\<lbrace>valid_objs' and K (valid_pdpte' pdpte)\<rbrace> storePDPTE p pdpte \<lbrace>\<lambda>_. valid_objs'\<rbrace>"
   apply (simp add: storePDPTE_def doMachineOp_def split_def)
   apply (rule hoare_pre)
    apply (wp hoare_drop_imps|wpc|simp)+
@@ -2039,7 +2039,7 @@ lemma storePDPTE_valid_objs [wp]:
   done
 
 lemma storePDE_valid_objs [wp]:
-  "\<lbrace>valid_objs' and valid_pde' pde\<rbrace> storePDE p pde \<lbrace>\<lambda>_. valid_objs'\<rbrace>"
+  "\<lbrace>valid_objs' and K (valid_pde' pde)\<rbrace> storePDE p pde \<lbrace>\<lambda>_. valid_objs'\<rbrace>"
   apply (simp add: storePDE_def doMachineOp_def split_def)
   apply (rule hoare_pre)
    apply (wp hoare_drop_imps|wpc|simp)+

--- a/proof/refine/X64/ArchInvsDefs_H.thy
+++ b/proof/refine/X64/ArchInvsDefs_H.thy
@@ -150,34 +150,33 @@ lemmas [simp] = arch_valid_irq_def
 definition valid_arch_tcb' :: "Structures_H.arch_tcb \<Rightarrow> kernel_state \<Rightarrow> bool" where
   "valid_arch_tcb' \<equiv> \<lambda>t. \<top>"
 
-definition valid_mapping' :: "machine_word \<Rightarrow> vmpage_size \<Rightarrow> kernel_state \<Rightarrow> bool" where
- "valid_mapping' x sz s \<equiv> is_aligned x (pageBitsForSize sz)
-                            \<and> ptrFromPAddr x \<noteq> 0"
+definition valid_mapping' :: "machine_word \<Rightarrow> vmpage_size \<Rightarrow> bool" where
+ "valid_mapping' x sz \<equiv> is_aligned x (pageBitsForSize sz) \<and> ptrFromPAddr x \<noteq> 0"
 
-primrec valid_pte' :: "X64_H.pte \<Rightarrow> kernel_state \<Rightarrow> bool" where
-  "valid_pte' (InvalidPTE) = \<top>"
-| "valid_pte' (SmallPagePTE ptr _ _ _ _ _ _ _ _) = (valid_mapping' ptr X64SmallPage)"
+primrec valid_pte' :: "X64_H.pte \<Rightarrow> bool" where
+  "valid_pte' (InvalidPTE) = True"
+| "valid_pte' (SmallPagePTE ptr _ _ _ _ _ _ _ _) = valid_mapping' ptr X64SmallPage"
 
-primrec valid_pde' :: "X64_H.pde \<Rightarrow> kernel_state \<Rightarrow> bool" where
- "valid_pde' (InvalidPDE) = \<top>"
+primrec valid_pde' :: "X64_H.pde \<Rightarrow> bool" where
+ "valid_pde' (InvalidPDE) = True"
 | "valid_pde' (LargePagePDE ptr _ _ _ _ _ _ _ _) = (valid_mapping' ptr X64LargePage)"
-| "valid_pde' (PageTablePDE ptr _ _ _ _ _) = (\<lambda>_. is_aligned ptr ptBits)"
+| "valid_pde' (PageTablePDE ptr _ _ _ _ _) = is_aligned ptr ptBits"
 
-primrec valid_pdpte' :: "X64_H.pdpte \<Rightarrow> kernel_state \<Rightarrow> bool" where
- "valid_pdpte' (InvalidPDPTE) = \<top>"
+primrec valid_pdpte' :: "X64_H.pdpte \<Rightarrow> bool" where
+ "valid_pdpte' (InvalidPDPTE) = True"
 | "valid_pdpte' (HugePagePDPTE ptr _ _ _ _ _ _ _ _) = (valid_mapping' ptr X64HugePage)"
-| "valid_pdpte' (PageDirectoryPDPTE ptr _ _ _ _ _) = (\<lambda>_. is_aligned ptr pdBits)"
+| "valid_pdpte' (PageDirectoryPDPTE ptr _ _ _ _ _) = is_aligned ptr pdBits"
 
-primrec valid_pml4e' :: "X64_H.pml4e \<Rightarrow> kernel_state \<Rightarrow> bool" where
- "valid_pml4e' (InvalidPML4E) = \<top>"
-| "valid_pml4e' (PDPointerTablePML4E ptr _ _ _ _ _) = (\<lambda>_. is_aligned ptr pdptBits)"
+primrec valid_pml4e' :: "X64_H.pml4e \<Rightarrow> bool" where
+ "valid_pml4e' (InvalidPML4E) = True"
+| "valid_pml4e' (PDPointerTablePML4E ptr _ _ _ _ _) = is_aligned ptr pdptBits"
 
-primrec valid_asid_pool' :: "asidpool \<Rightarrow> kernel_state \<Rightarrow> bool" where
+primrec valid_asid_pool' :: "asidpool \<Rightarrow> bool" where
  "valid_asid_pool' (ASIDPool pool)
-     = (\<lambda>s. dom pool \<subseteq> {0 .. 2^asid_low_bits - 1}
-           \<and> 0 \<notin> ran pool \<and> (\<forall>x \<in> ran pool. is_aligned x pml4Bits))"
+     = (dom pool \<subseteq> {0 .. 2^asid_low_bits - 1}
+        \<and> 0 \<notin> ran pool \<and> (\<forall>x \<in> ran pool. is_aligned x pml4Bits))"
 
-primrec valid_arch_obj' :: "arch_kernel_object \<Rightarrow> kernel_state \<Rightarrow> bool" where
+primrec valid_arch_obj' :: "arch_kernel_object \<Rightarrow> bool" where
   "valid_arch_obj' (KOASIDPool pool) = valid_asid_pool' pool"
 | "valid_arch_obj' (KOPDE pde) = valid_pde' pde"
 | "valid_arch_obj' (KOPTE pte) = valid_pte' pte"

--- a/proof/refine/X64/ArchInvsLemmas_H.thy
+++ b/proof/refine/X64/ArchInvsLemmas_H.thy
@@ -40,34 +40,17 @@ lemma valid_cap'_pspaceI[Invariants_H_pspaceI_assms]:
             simp: vspace_table_at'_defs valid_arch_cap'_def
            split: arch_capability.split zombie_type.split option.splits)+
 
-lemma valid_arch_obj'_pspaceI:
-  "valid_arch_obj' obj s \<Longrightarrow> ksPSpace s = ksPSpace s' \<Longrightarrow> valid_arch_obj' obj s'"
-  apply (cases obj; simp)
-    apply (rename_tac asidpool)
-    apply (case_tac asidpool,
-           auto simp: page_directory_at'_def intro: typ_at'_pspaceI[rotated])[1]
-   apply (rename_tac pte)
-   apply (case_tac pte; simp add: valid_mapping'_def)
-  apply (rename_tac pde)
-  apply (case_tac pde;
-         auto simp: page_table_at'_def valid_mapping'_def
-             intro: typ_at'_pspaceI[rotated])
-   apply (rename_tac pdpte)
-   apply (case_tac pdpte; auto simp: valid_mapping'_def)
-  apply (rename_tac pml4e)
-  apply (case_tac pml4e; auto simp: valid_mapping'_def)
-  done
-
 lemma valid_obj'_pspaceI[Invariants_H_pspaceI_assms]:
   "valid_obj' obj s \<Longrightarrow> ksPSpace s = ksPSpace s' \<Longrightarrow> valid_obj' obj s'"
   unfolding valid_obj'_def
+  supply no_0_obj_at'[rule del] (* avoid weak elim rule warning *)
   by (cases obj)
      (auto simp: valid_ep'_def valid_ntfn'_def valid_tcb'_def valid_cte'_def
                  valid_tcb_state'_def valid_bound_tcb'_def
                  valid_bound_ntfn'_def valid_arch_tcb'_def
            split: Structures_H.endpoint.splits Structures_H.notification.splits
                   Structures_H.thread_state.splits ntfn.splits option.splits
-           intro: obj_at'_pspaceI valid_cap'_pspaceI typ_at'_pspaceI valid_arch_obj'_pspaceI)
+           intro: obj_at'_pspaceI valid_cap'_pspaceI)
 
 lemma tcb_space_clear[Invariants_H_pspaceI_assms]:
   "\<lbrakk> tcb_cte_cases (y - x) = Some (getF, setF);
@@ -468,31 +451,6 @@ lemma valid_arch_tcb_lift':
   shows "\<lbrace>\<lambda>s. valid_arch_tcb' tcb s\<rbrace> f \<lbrace>\<lambda>rv s. valid_arch_tcb' tcb s\<rbrace>"
   by (clarsimp simp add: valid_arch_tcb'_def, wp)
 
-lemma valid_pde_lift':
-  assumes x: "\<And>T p. \<lbrace>typ_at' T p\<rbrace> f \<lbrace>\<lambda>rv. typ_at' T p\<rbrace>"
-  shows "\<lbrace>\<lambda>s. valid_pde' pde s\<rbrace> f \<lbrace>\<lambda>rv s. valid_pde' pde s\<rbrace>"
-  by (cases pde) (simp add: valid_mapping'_def|wp x typ_at_lift_page_table_at')+
-
-lemma valid_pte_lift':
-  assumes x: "\<And>T p. \<lbrace>typ_at' T p\<rbrace> f \<lbrace>\<lambda>rv. typ_at' T p\<rbrace>"
-  shows "\<lbrace>\<lambda>s. valid_pte' pte s\<rbrace> f \<lbrace>\<lambda>rv s. valid_pte' pte s\<rbrace>"
-  by (cases pte) (simp add: valid_mapping'_def|wp x typ_at_lift_page_directory_at')+
-
-lemma valid_pdpte_lift':
-  assumes x: "\<And>T p. \<lbrace>typ_at' T p\<rbrace> f \<lbrace>\<lambda>rv. typ_at' T p\<rbrace>"
-  shows "\<lbrace>\<lambda>s. valid_pdpte' pdpte s\<rbrace> f \<lbrace>\<lambda>rv s. valid_pdpte' pdpte s\<rbrace>"
-  by (cases pdpte) (simp add: valid_mapping'_def|wp x typ_at_lift_pd_pointer_table_at')+
-
-lemma valid_pml4e_lift':
-  assumes x: "\<And>T p. \<lbrace>typ_at' T p\<rbrace> f \<lbrace>\<lambda>rv. typ_at' T p\<rbrace>"
-  shows "\<lbrace>\<lambda>s. valid_pml4e' pml4e s\<rbrace> f \<lbrace>\<lambda>rv s. valid_pml4e' pml4e s\<rbrace>"
-  by (cases pml4e) (simp add: valid_mapping'_def|wp x typ_at_lift_page_map_l4_at')+
-
-lemma valid_asid_pool_lift':
-  assumes x: "\<And>T p. \<lbrace>typ_at' T p\<rbrace> f \<lbrace>\<lambda>rv. typ_at' T p\<rbrace>"
-  shows "\<lbrace>\<lambda>s. valid_asid_pool' ap s\<rbrace> f \<lbrace>\<lambda>rv s. valid_asid_pool' ap s\<rbrace>"
-  by (cases ap) (simp|wp x typ_at_lift_page_directory_at' hoare_vcg_const_Ball_lift)+
-
 lemmas typ_at_lifts =
          typ_at_lift_tcb' typ_at_lift_ep' typ_at_lift_ntfn' typ_at_lift_cte' typ_at_lift_cte_at'
          typ_at_lift_valid_untyped' typ_at_lift_valid_cap' valid_bound_tcb_lift
@@ -501,11 +459,7 @@ lemmas typ_at_lifts =
          typ_at_lift_page_map_l4_at'
          typ_at_lift_pd_pointer_table_at'
          typ_at_lift_asid_at'
-         valid_pde_lift'
-         valid_pte_lift'
-         valid_pdpte_lift'
-         valid_pml4e_lift'
-         valid_asid_pool_lift'
+         valid_arch_tcb_lift'
 
 (* FIXME arch-split: X64: this probably needs more to be useful *)
 lemmas bit_simps' = asidHighBits_def asid_low_bits_def

--- a/proof/refine/X64/ArchStateRelationLemmas.thy
+++ b/proof/refine/X64/ArchStateRelationLemmas.thy
@@ -181,14 +181,6 @@ lemma other_aobj_relation_aobj:
   unfolding other_aobj_relation_def is_ArchObj_def
   by (clarsimp split: Structures_A.kernel_object.splits)
 
-(* interface lemma, can't be used in locale assumptions due to free type variable *)
-lemma valid_arch_obj'_valid[wp]:
-  assumes P: "\<And>P T p. \<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace> f \<lbrace>\<lambda>rv s. P (typ_at' T p s)\<rbrace>"
-  notes [wp] = hoare_vcg_all_lift hoare_vcg_imp_lift hoare_vcg_const_Ball_lift typ_at_lifts[OF P]
-  shows "\<lbrace>valid_arch_obj' ako\<rbrace> f \<lbrace>\<lambda>rv. valid_arch_obj' ako\<rbrace>"
-  unfolding valid_arch_obj'_def
-  by (case_tac ako; wpsimp)
-
 lemma msgLabelBits_msg_label_bits[StateRelation_R_assms]:
   "msgLabelBits = msg_label_bits"
   by (simp add: msgLabelBits_def)

--- a/proof/refine/X64/ArchVSpace_R.thy
+++ b/proof/refine/X64/ArchVSpace_R.thy
@@ -965,7 +965,8 @@ definition
      PageTableMap cap slot pde pdeSlot vspace \<Rightarrow>
      cte_wp_at' (is_arch_update' cap) slot and
      valid_cap' cap and
-     valid_pde' pde and K (case cap of ArchObjectCap (PageTableCap _ (Some (asid, vs))) \<Rightarrow> True | _ \<Rightarrow> False)
+     K (valid_pde' pde) and
+     K (case cap of ArchObjectCap (PageTableCap _ (Some (asid, vs))) \<Rightarrow> True | _ \<Rightarrow> False)
    | PageTableUnmap cap slot \<Rightarrow> cte_wp_at' (is_arch_update' (ArchObjectCap cap)) slot
                                  and valid_cap' (ArchObjectCap cap)
                                  and K (isPageTableCap cap)"
@@ -1150,7 +1151,8 @@ definition
      PageDirectoryMap cap slot pdpte pdptSlot vspace \<Rightarrow>
      cte_wp_at' (is_arch_update' cap) slot and
      valid_cap' cap and
-     valid_pdpte' pdpte and K (case cap of ArchObjectCap (PageDirectoryCap _ (Some (asid, vs))) \<Rightarrow> True | _ \<Rightarrow> False)
+     K (valid_pdpte' pdpte) and
+     K (case cap of ArchObjectCap (PageDirectoryCap _ (Some (asid, vs))) \<Rightarrow> True | _ \<Rightarrow> False)
    | PageDirectoryUnmap cap slot \<Rightarrow> cte_wp_at' (is_arch_update' (ArchObjectCap cap)) slot
                                  and valid_cap' (ArchObjectCap cap)
                                  and K (isPageDirectoryCap cap)"
@@ -1279,7 +1281,8 @@ definition
      PDPTMap cap slot pml4e pml4Slot vspace \<Rightarrow>
      cte_wp_at' (is_arch_update' cap) slot and
      valid_cap' cap and
-     valid_pml4e' pml4e and K (case cap of ArchObjectCap (PDPointerTableCap _ (Some (asid, vs))) \<Rightarrow> True | _ \<Rightarrow> False)
+     K (valid_pml4e' pml4e) and
+     K (case cap of ArchObjectCap (PDPointerTableCap _ (Some (asid, vs))) \<Rightarrow> True | _ \<Rightarrow> False)
    | PDPTUnmap cap slot \<Rightarrow> cte_wp_at' (is_arch_update' (ArchObjectCap cap)) slot
                                  and valid_cap' (ArchObjectCap cap)
                                  and K (isPDPointerTableCap cap)"
@@ -1993,7 +1996,7 @@ lemma storePML4E_tcbs_of'[wp]:
   by setObject_easy_cases
 
 lemma storePDE_invs[wp]:
-  "\<lbrace>invs' and valid_pde' pde\<rbrace>
+  "\<lbrace>invs' and K (valid_pde' pde)\<rbrace>
       storePDE p pde
    \<lbrace>\<lambda>_. invs'\<rbrace>"
   apply (simp add: invs'_def valid_state'_def valid_pspace'_def)
@@ -2008,7 +2011,7 @@ lemma storePDE_invs[wp]:
   done
 
 lemma storePDPTE_invs[wp]:
-  "\<lbrace>invs' and valid_pdpte' pde\<rbrace>
+  "\<lbrace>invs' and K (valid_pdpte' pde)\<rbrace>
       storePDPTE p pde
    \<lbrace>\<lambda>_. invs'\<rbrace>"
   apply (simp add: invs'_def valid_state'_def valid_pspace'_def)
@@ -2023,7 +2026,7 @@ lemma storePDPTE_invs[wp]:
   done
 
 lemma storePML4E_invs[wp]:
-  "\<lbrace>invs' and valid_pml4e' pde\<rbrace>
+  "\<lbrace>invs' and K (valid_pml4e' pde)\<rbrace>
       storePML4E p pde
    \<lbrace>\<lambda>_. invs'\<rbrace>"
   apply (simp add: invs'_def valid_state'_def valid_pspace'_def)
@@ -2107,7 +2110,7 @@ lemma storePTE_irq_states' [wp]:
   done
 
 lemma storePTE_valid_objs [wp]:
-  "\<lbrace>valid_objs' and valid_pte' pte\<rbrace> storePTE p pte \<lbrace>\<lambda>_. valid_objs'\<rbrace>"
+  "\<lbrace>valid_objs' and K (valid_pte' pte)\<rbrace> storePTE p pte \<lbrace>\<lambda>_. valid_objs'\<rbrace>"
   apply (simp add: storePTE_def doMachineOp_def split_def)
   apply (rule hoare_pre)
    apply (wp hoare_drop_imps|wpc|simp)+
@@ -2176,7 +2179,7 @@ lemma storePTE_ct_idle_or_in_cur_domain'[wp]:
   by (wp ct_idle_or_in_cur_domain'_lift hoare_vcg_disj_lift)
 
 lemma storePTE_invs [wp]:
-  "\<lbrace>invs' and valid_pte' pte\<rbrace> storePTE p pte \<lbrace>\<lambda>_. invs'\<rbrace>"
+  "\<lbrace>invs' and K (valid_pte' pte)\<rbrace> storePTE p pte \<lbrace>\<lambda>_. invs'\<rbrace>"
   apply (simp add: invs'_def valid_state'_def valid_pspace'_def)
   apply (rule hoare_pre)
    apply (wp sch_act_wf_lift valid_global_refs_lift' irqs_masked_lift
@@ -2188,7 +2191,7 @@ lemma storePTE_invs [wp]:
   done
 
 lemma setASIDPool_valid_objs [wp]:
-  "\<lbrace>valid_objs' and valid_asid_pool' ap\<rbrace> setObject p (ap::asidpool) \<lbrace>\<lambda>_. valid_objs'\<rbrace>"
+  "\<lbrace>valid_objs' and K (valid_asid_pool' ap)\<rbrace> setObject p (ap::asidpool) \<lbrace>\<lambda>_. valid_objs'\<rbrace>"
   apply (rule hoare_pre)
    apply (rule setObject_valid_objs')
    prefer 2
@@ -2339,7 +2342,7 @@ lemma setObject_asidpool_tcbs_of'[wp]:
   by setObject_easy_cases
 
 lemma setASIDPool_invs [wp]:
-  "\<lbrace>invs' and valid_asid_pool' ap\<rbrace> setObject p (ap::asidpool) \<lbrace>\<lambda>_. invs'\<rbrace>"
+  "\<lbrace>invs' and K (valid_asid_pool' ap)\<rbrace> setObject p (ap::asidpool) \<lbrace>\<lambda>_. invs'\<rbrace>"
   apply (simp add: invs'_def valid_state'_def valid_pspace'_def)
   apply (rule hoare_pre)
    apply (wp sch_act_wf_lift valid_global_refs_lift' irqs_masked_lift
@@ -2381,7 +2384,7 @@ lemma perform_pti_invs [wp]:
                          is_arch_update'_def isCap_simps valid_cap'_def
                          capAligned_def)
   apply (rule hoare_pre)
-   apply (wpsimp wp: arch_update_updateCap_invs valid_pde_lift' hoare_vcg_all_lift hoare_vcg_ex_lift
+   apply (wpsimp wp: arch_update_updateCap_invs hoare_vcg_all_lift hoare_vcg_ex_lift
              | wp (once) hoare_drop_imps)+
   apply (clarsimp simp: cte_wp_at_ctes_of valid_pti'_def)
   done
@@ -2400,7 +2403,7 @@ lemma perform_pdi_invs [wp]:
                          is_arch_update'_def isCap_simps valid_cap'_def
                          capAligned_def)
   apply (rule hoare_pre)
-   apply (wpsimp wp: arch_update_updateCap_invs valid_pdpte_lift' hoare_vcg_all_lift hoare_vcg_ex_lift
+   apply (wpsimp wp: arch_update_updateCap_invs hoare_vcg_all_lift hoare_vcg_ex_lift
              | wp (once) hoare_drop_imps)+
   apply (clarsimp simp: cte_wp_at_ctes_of valid_pdi'_def)
   done
@@ -2442,8 +2445,6 @@ lemma unmapPage_invs' [wp]:
 
 crunch pteCheckIfMapped, pdeCheckIfMapped
   for invs'[wp]: "invs'"
-  and valid_pte'[wp]: "valid_pte' pte"
-  and valid_pde'[wp]: "valid_pde' pde"
 
 lemma perform_page_invs [wp]:
   notes no_irq[wp]

--- a/proof/refine/X64/Arch_R.thy
+++ b/proof/refine/X64/Arch_R.thy
@@ -1545,7 +1545,7 @@ lemma valid_slots_lift':
   apply (clarsimp simp: valid_slots'_def)
   apply (case_tac x, clarsimp split: vmpage_entry.splits)
   apply safe
-   apply (rule hoare_pre, wp hoare_vcg_const_Ball_lift t valid_pde_lift' valid_pte_lift' valid_pdpte_lift', simp)+
+   apply (rule hoare_pre, wp hoare_vcg_const_Ball_lift t, simp)+
   done
 
 lemma sts_valid_arch_inv':

--- a/proof/refine/X64/Detype_R.thy
+++ b/proof/refine/X64/Detype_R.thy
@@ -1136,18 +1136,6 @@ lemma valid_obj':
    apply (clarsimp simp: ko_wp_at'_def objBits_simps' cte_level_bits_def[symmetric])
    apply (erule(2) cte_wp_at_cteI')
    apply simp
-  apply (rename_tac arch_kernel_object)
-  apply (case_tac "arch_kernel_object", simp_all)
-      apply (rename_tac asidpool)
-      apply (case_tac asidpool, clarsimp simp: page_directory_at'_def)
-     apply (rename_tac pte)
-     apply (case_tac pte, simp_all add: valid_mapping'_def)
-    apply (rename_tac pde)
-    apply (case_tac pde, simp_all add: valid_mapping'_def)
-   apply (rename_tac pdpte)
-   apply (case_tac pdpte, simp_all add: valid_mapping'_def)
-  apply (rename_tac pml4e)
-  apply (case_tac pml4e, simp_all add: valid_mapping'_def)
   done
 
 lemma tcbSchedNexts_of_pspace':

--- a/proof/refine/X64/Finalise_R.thy
+++ b/proof/refine/X64/Finalise_R.thy
@@ -2492,11 +2492,6 @@ lemma deleteASIDPool_invs[wp]:
               | simp)+
   done
 
-lemma hwASIDInvalidate_valid_ap' [wp]:
-  "\<lbrace>valid_asid_pool' p\<rbrace> hwASIDInvalidate asid vs \<lbrace>\<lambda>r. valid_asid_pool' p\<rbrace>"
-  apply (simp add: hwASIDInvalidate_def)
-  by wp
-
 lemma deleteASID_invs'[wp]:
   "\<lbrace>invs'\<rbrace> deleteASID asid pd \<lbrace>\<lambda>rv. invs'\<rbrace>"
   supply inj_ASIDPool[simp del]

--- a/proof/refine/X64/Retype_R.thy
+++ b/proof/refine/X64/Retype_R.thy
@@ -3130,15 +3130,6 @@ proof (intro conjI impI)
      apply (erule valid_cap[unfolded foldr_upd_app_if[folded data_map_insert_def]])
      apply (erule(2) cte_wp_at_cteI'[unfolded cte_level_bits_def])
      apply simp
-    apply (rename_tac arch_kernel_object)
-    apply (case_tac arch_kernel_object; simp)
-      apply (rename_tac asidpool)
-      apply (case_tac asidpool, clarsimp simp: page_directory_at'_def
-                                               typ_at_to_obj_at_arches
-                                               obj_at_disj')
-     apply (rename_tac vspace_table_entry;
-            case_tac vspace_table_entry;
-            simp add: valid_mapping'_def)+
     done
   have not_0: "0 \<notin> set (new_cap_addrs (2 ^ gbits * n) ptr val)"
     using p_0
@@ -3220,7 +3211,7 @@ lemma createObjects_valid_pspace_untyped':
   done
 
 lemma getObject_valid_pml4e'[wp]:
-  "\<lbrace>valid_objs'\<rbrace> getObject x \<lbrace>valid_pml4e'\<rbrace>"
+  "\<lbrace>valid_objs'\<rbrace> getObject x \<lbrace>\<lambda>rv _. valid_pml4e' rv\<rbrace>"
   apply (rule hoare_chain)
     apply (rule hoare_vcg_conj_lift)
      apply (rule getObject_ko_at, simp)
@@ -3228,7 +3219,7 @@ lemma getObject_valid_pml4e'[wp]:
     apply (rule getObject_inv[where P=valid_objs'])
     apply (simp add: loadObject_default_inv)
    apply simp
-  apply (clarsimp simp: projectKOs valid_obj'_def dest!: obj_at_valid_objs')
+  apply (clarsimp simp: valid_obj'_def dest!: obj_at_valid_objs')
   done
 
 crunch copyGlobalMappings


### PR DESCRIPTION
Due to ARM_HYP, all architectures were conforming to an interface which required valid_arch_obj' to depend on state. It turns out that this is not necessary. Remove the dependency on state and clean up.

I need this one for arch-splitting Retype_R, due to some assumptions in the interface. Also, this inconsistency was annoying in general.

43 files changed, 195 insertions(+), 523 deletions(-)
Total: 328 lines deleted (i.e. very minor cleanup)