### PR TITLE
Fix task enabling FPU for itself

### DIFF
--- a/proof/crefine/AARCH64/Schedule_C.thy
+++ b/proof/crefine/AARCH64/Schedule_C.thy
@@ -145,29 +145,6 @@ lemma isRunnable_exs_valid[wp]:
   unfolding isRunnable_def getThreadState_def
   by (wpsimp wp: exs_getObject)
 
-lemma lazyFPURestore_ccorres:
-  "ccorres dc xfdc
-     (no_0_obj' and tcb_at' t)
-     (\<lbrace>\<acute>thread = tcb_ptr_to_ctcb_ptr t\<rbrace>) hs
-     (lazyFpuRestore t) (Call lazyFPURestore_'proc)"
-  apply (cinit lift: thread_')
-   apply (rule ccorres_pre_threadGet, rename_tac flags)
-   apply (rule ccorres_move_c_guard_tcb)
-   apply (rule ccorres_if_lhs)
-    apply (rule ccorres_cond_true)
-    apply (ctac add: disableFpu_ccorres)
-   apply (rule ccorres_cond_false)
-   apply (ctac add: nativeThreadUsingFPU_ccorres[where thread=t])
-     apply (rule ccorres_cond[where R=\<top>])
-       apply (clarsimp simp: to_bool_neq_0 split: if_split)
-      apply (ctac add: enableFpu_ccorres)
-     apply (ctac add: switchLocalFpuOwner_ccorres)
-    apply wpsimp
-   apply (vcg exspec=nativeThreadUsingFPU_modifies)
-  apply (clarsimp simp: isFlagSet_def typ_heap_simps' word_bw_comms ctcb_relation_def
-                        option_to_ctcb_ptr_def)
-  done
-
 crunch arch_switchToThread
   for no_0_obj'[wp]: no_0_obj'
   and tcb_at'[wp]: "tcb_at' t"

--- a/proof/crefine/X64/Schedule_C.thy
+++ b/proof/crefine/X64/Schedule_C.thy
@@ -104,29 +104,6 @@ lemma Arch_switchToThread_ccorres:
   apply clarsimp
   done
 
-lemma lazyFPURestore_ccorres:
-  "ccorres dc xfdc
-     (no_0_obj' and tcb_at' t)
-     (\<lbrace>\<acute>thread = tcb_ptr_to_ctcb_ptr t\<rbrace>) hs
-     (lazyFpuRestore t) (Call lazyFPURestore_'proc)"
-  apply (cinit lift: thread_')
-   apply (rule ccorres_pre_threadGet, rename_tac flags)
-   apply (rule ccorres_move_c_guard_tcb)
-   apply (rule ccorres_if_lhs)
-    apply (rule ccorres_cond_true)
-    apply (ctac add: disableFpu_ccorres)
-   apply (rule ccorres_cond_false)
-   apply (ctac add: nativeThreadUsingFPU_ccorres[where thread=t])
-     apply (rule ccorres_cond[where R=\<top>])
-       apply (clarsimp simp: to_bool_neq_0 split: if_split)
-      apply (ctac add: enableFpu_ccorres)
-     apply (ctac add: switchLocalFpuOwner_ccorres)
-    apply wpsimp
-   apply (vcg exspec=nativeThreadUsingFPU_modifies)
-  apply (clarsimp simp: isFlagSet_def typ_heap_simps' word_bw_comms ctcb_relation_def
-                        option_to_ctcb_ptr_def)
-  done
-
 crunch arch_switchToThread
   for no_0_obj'[wp]: no_0_obj'
   and tcb_at'[wp]: "tcb_at' t"

--- a/proof/crefine/X64/Tcb_C.thy
+++ b/proof/crefine/X64/Tcb_C.thy
@@ -4508,6 +4508,35 @@ lemma decodeSetTLSBase_ccorres:
   apply (auto simp: unat_eq_0 le_max_word_ucast_id)+
   done
 
+lemma lazyFPURestore_ccorres:
+  "ccorres dc xfdc
+     (no_0_obj' and tcb_at' t)
+     (\<lbrace>\<acute>thread = tcb_ptr_to_ctcb_ptr t\<rbrace>) hs
+     (lazyFpuRestore t) (Call lazyFPURestore_'proc)"
+  apply (cinit lift: thread_')
+   apply (rule ccorres_pre_threadGet, rename_tac flags)
+   apply (rule ccorres_move_c_guard_tcb)
+   apply (rule ccorres_if_lhs)
+    apply (rule ccorres_cond_true)
+    apply (ctac add: disableFpu_ccorres)
+   apply (rule ccorres_cond_false)
+   apply (ctac add: nativeThreadUsingFPU_ccorres[where thread=t])
+     apply (rule ccorres_cond[where R=\<top>])
+       apply (clarsimp simp: to_bool_neq_0 split: if_split)
+      apply (ctac add: enableFpu_ccorres)
+     apply (ctac add: switchLocalFpuOwner_ccorres)
+    apply wpsimp
+   apply (vcg exspec=nativeThreadUsingFPU_modifies)
+  apply (clarsimp simp: isFlagSet_def typ_heap_simps' word_bw_comms ctcb_relation_def
+                        option_to_ctcb_ptr_def)
+  done
+
+crunch lazyFpuRestore
+  for st_tcb_at'[wp]: "\<lambda>s. P (st_tcb_at' Q p s)"
+  and sch_act_wf[wp]: "\<lambda>s. sch_act_wf (ksSchedulerAction s) s"
+  and aligned'[wp]: "pspace_aligned'"
+  and distinct'[wp]: "pspace_distinct'"
+
 lemma invokeTCB_SetFlags_ccorres:
   notes hoare_weak_lift_imp [wp]
   shows
@@ -4533,12 +4562,16 @@ lemma invokeTCB_SetFlags_ccorres:
           apply (rule ball_tcb_cte_casesI, simp+)
          apply (clarsimp simp: ctcb_relation_def)
         apply ceqv
+       apply (rule ccorres_pre_getCurThread, rename_tac cur)
        apply (rule ccorres_split_nothrow_dc)
           apply (rule_tac R=\<top> and R'="\<lbrace>\<acute>flags = flags && ~~ clears || sets && tcbFlagMask\<rbrace>"
+                       in ccorres_cond_strong)
+            apply (clarsimp simp: isFlagSet_def word_bw_comms)
+           apply (ctac add: fpuRelease_ccorres)
+          apply (rule_tac R=\<top> and R'="\<lbrace>\<acute>cur_thread = tcb_ptr_to_ctcb_ptr cur\<rbrace>"
                        in ccorres_when_strong)
-           apply (clarsimp simp: isFlagSet_def word_bw_comms)
-          apply (ctac add: fpuRelease_ccorres)
-
+           apply clarsimp
+          apply (ctac add: lazyFPURestore_ccorres)
          apply (rule ccorres_Cond_rhs_Seq[rotated]; clarsimp)
           apply (simp add: replyOnRestart_def liftE_def bind_assoc)
           apply (rule getThreadState_ccorres_foo, rename_tac tstate)
@@ -4579,7 +4612,7 @@ lemma invokeTCB_SetFlags_ccorres:
          apply (vcg exspec=lookupIPCBuffer_modifies)
         apply (wpsimp wp: hoare_vcg_all_lift hoare_vcg_imp_lift')
        apply clarsimp
-       apply (vcg exspec=fpuRelease_modifies)
+       apply (vcg exspec=fpuRelease_modifies exspec=lazyFPURestore_modifies)
       apply (wpsimp wp: hoare_vcg_all_lift hoare_vcg_imp_lift' threadSet_pred_tcb_no_state
                         threadSet_sch_act weak_if_wp' | strengthen invs_valid_objs')+
      apply vcg

--- a/proof/invariant-abstract/AARCH64/ArchTcb_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchTcb_AI.thy
@@ -146,7 +146,14 @@ lemma finalise_cap_not_cte_wp_at[Tcb_AI_assms]:
 
 crunch arch_post_set_flags, arch_prepare_set_domain
   for typ_at[wp, Tcb_AI_assms]: "\<lambda>s. P (typ_at T p s)"
-  and invs[wp, Tcb_AI_assms]: "invs"
+
+crunch arch_prepare_set_domain
+  for invs[wp, Tcb_AI_assms]: "invs"
+
+lemma arch_post_set_flags_invs[wp, Tcb_AI_assms]:
+  "\<lbrace>invs and ex_nonz_cap_to t\<rbrace> arch_post_set_flags t flags \<lbrace>\<lambda>_. invs\<rbrace>"
+  unfolding arch_post_set_flags_def
+  by wpsimp
 
 lemmas vcpu_flush_typ_ats [wp] = abs_typ_at_lifts[OF vcpu_flush_typ_at]
 

--- a/proof/invariant-abstract/AARCH64/ArchVCPU_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchVCPU_AI.thy
@@ -830,11 +830,6 @@ crunch reply_from_kernel, receive_signal
   and valid_cur_vcpu[wp]: valid_cur_vcpu
   (wp: valid_cur_vcpu_lift_weak in_cur_domain_lift_weak simp: crunch_simps)
 
-lemma ct_in_cur_domain_active_resume_cur_thread:
-  "\<lbrakk>ct_in_cur_domain s; ct_active s; valid_idle s; scheduler_action s = resume_cur_thread\<rbrakk>
-   \<Longrightarrow> in_cur_domain (cur_thread s) s"
-  by (clarsimp simp: ct_in_cur_domain_def ct_in_state_def dest!: st_tcb_at_idle_thread)
-
 lemma handle_invocation_valid_cur_vcpu[wp]:
   "\<lbrace>valid_cur_vcpu and einvs and ct_active and (\<lambda>s. scheduler_action s = resume_cur_thread)\<rbrace>
    handle_invocation calling blocking

--- a/proof/invariant-abstract/ARM/ArchTcb_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchTcb_AI.thy
@@ -166,6 +166,11 @@ crunch arch_post_set_flags, arch_prepare_set_domain
   for typ_at[wp, Tcb_AI_assms]: "\<lambda>s. P (typ_at T p s)"
   and invs[wp, Tcb_AI_assms]: "invs"
 
+(* Interface asks for a weaker lemma due to other arches needing an extra precondition *)
+lemma arch_post_set_flags_invs'[Tcb_AI_assms]:
+  "\<lbrace>invs and ex_nonz_cap_to t\<rbrace> arch_post_set_flags t flags \<lbrace>\<lambda>_. invs\<rbrace>"
+  by wpsimp
+
 lemmas arch_prepare_set_domain_typ_ats[wp] = abs_typ_at_lifts[OF arch_prepare_set_domain_typ_at]
 
 crunch arch_prepare_set_domain
@@ -177,7 +182,7 @@ crunch arch_prepare_set_domain
 interpretation Tcb_AI_1? : Tcb_AI_1
   where state_ext_t = state_ext_t
   and is_cnode_or_valid_arch = is_cnode_or_valid_arch
-by (unfold_locales; fact Tcb_AI_assms)
+  by (unfold_locales; fact Tcb_AI_assms)
 
 
 lemma use_no_cap_to_obj_asid_strg: (* arch specific *)

--- a/proof/invariant-abstract/ARM_HYP/ArchTcb_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchTcb_AI.thy
@@ -164,6 +164,11 @@ crunch arch_post_set_flags, arch_prepare_set_domain
 
 lemmas vcpu_flush_typ_ats [wp] = abs_typ_at_lifts[OF vcpu_flush_typ_at]
 
+(* Interface asks for a weaker lemma due to other arches needing an extra precondition *)
+lemma arch_post_set_flags_invs'[Tcb_AI_assms]:
+  "\<lbrace>invs and ex_nonz_cap_to t\<rbrace> arch_post_set_flags t flags \<lbrace>\<lambda>_. invs\<rbrace>"
+  by wpsimp
+
 lemmas arch_prepare_set_domain_typ_ats[wp] = abs_typ_at_lifts[OF arch_prepare_set_domain_typ_at]
 
 crunch arch_prepare_set_domain
@@ -179,7 +184,7 @@ lemma table_cap_ref_max_free_index_upd[simp,Tcb_AI_assms]:
 interpretation Tcb_AI_1? : Tcb_AI_1
   where state_ext_t = state_ext_t
   and is_cnode_or_valid_arch = is_cnode_or_valid_arch
-by (unfold_locales; fact Tcb_AI_assms)
+  by (unfold_locales; fact Tcb_AI_assms)
 
 
 lemma use_no_cap_to_obj_asid_strg: (* arch specific *)

--- a/proof/invariant-abstract/ARM_HYP/ArchVCPU_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchVCPU_AI.thy
@@ -815,11 +815,6 @@ crunch reply_from_kernel, receive_signal
   and valid_cur_vcpu[wp]: valid_cur_vcpu
   (wp: valid_cur_vcpu_lift_weak in_cur_domain_lift_weak simp: crunch_simps)
 
-lemma ct_in_cur_domain_active_resume_cur_thread:
-  "\<lbrakk>ct_in_cur_domain s; ct_active s; valid_idle s; scheduler_action s = resume_cur_thread\<rbrakk>
-   \<Longrightarrow> in_cur_domain (cur_thread s) s"
-  by (clarsimp simp: ct_in_cur_domain_def ct_in_state_def dest!: st_tcb_at_idle_thread)
-
 lemma handle_invocation_valid_cur_vcpu[wp]:
   "\<lbrace>valid_cur_vcpu and einvs and ct_active and (\<lambda>s. scheduler_action s = resume_cur_thread)\<rbrace>
    handle_invocation calling blocking

--- a/proof/invariant-abstract/DetSchedInvs_AI.thy
+++ b/proof/invariant-abstract/DetSchedInvs_AI.thy
@@ -409,4 +409,9 @@ lemma valid_sched_lift:
             valid_sched_action_lift valid_blocked_lift a c d e f g h i hoare_vcg_conj_lift)
   done
 
+lemma ct_in_cur_domain_active_resume_cur_thread:
+  "\<lbrakk>ct_in_cur_domain s; ct_active s; valid_idle s; scheduler_action s = resume_cur_thread\<rbrakk>
+   \<Longrightarrow> in_cur_domain (cur_thread s) s"
+  by (clarsimp simp: ct_in_cur_domain_def ct_in_state_def dest!: st_tcb_at_idle_thread)
+
 end

--- a/proof/invariant-abstract/RISCV64/ArchTcb_AI.thy
+++ b/proof/invariant-abstract/RISCV64/ArchTcb_AI.thy
@@ -150,6 +150,11 @@ crunch arch_post_set_flags, arch_prepare_set_domain
   for typ_at[wp, Tcb_AI_assms]: "\<lambda>s. P (typ_at T p s)"
   and invs[wp, Tcb_AI_assms]: "invs"
 
+(* Interface asks for a weaker lemma due to other arches needing an extra precondition *)
+lemma arch_post_set_flags_invs'[Tcb_AI_assms]:
+  "\<lbrace>invs and ex_nonz_cap_to t\<rbrace> arch_post_set_flags t flags \<lbrace>\<lambda>_. invs\<rbrace>"
+  by wpsimp
+
 lemmas arch_prepare_set_domain_typ_ats[wp] = abs_typ_at_lifts[OF arch_prepare_set_domain_typ_at]
 
 crunch arch_prepare_set_domain

--- a/proof/invariant-abstract/TcbAcc_AI.thy
+++ b/proof/invariant-abstract/TcbAcc_AI.thy
@@ -512,6 +512,13 @@ lemma thread_set_cte_wp_at_trivial:
   by (auto simp: cte_wp_at_caps_of_state
           intro: thread_set_caps_of_state_trivial [OF x])
 
+lemma thread_set_ex_nonz_cap_to_trivial:
+  assumes x: "\<And>tcb. \<forall>(getF, v) \<in> ran tcb_cap_cases.
+                  getF (f tcb) = getF tcb"
+  shows "\<lbrace>\<lambda>s. Q (ex_nonz_cap_to p s)\<rbrace> thread_set f t \<lbrace>\<lambda>rv s. Q (ex_nonz_cap_to p s)\<rbrace>"
+  unfolding ex_nonz_cap_to_def
+  by (auto simp: cte_wp_at_caps_of_state
+          intro: thread_set_caps_of_state_trivial [OF x])
 
 lemma det_query_twice:
   assumes x: "\<And>P. \<lbrace>P\<rbrace> f \<lbrace>\<lambda>x. P\<rbrace>"

--- a/proof/invariant-abstract/Tcb_AI.thy
+++ b/proof/invariant-abstract/Tcb_AI.thy
@@ -41,8 +41,8 @@ locale Tcb_AI_1 =
   assumes arch_post_modify_registers_ex_nonz_cap_to[wp]:
   "\<And>c t a. \<lbrace>\<lambda>(s::'state_ext state). ex_nonz_cap_to a s\<rbrace> arch_post_modify_registers c t
        \<lbrace>\<lambda>b s. ex_nonz_cap_to a s\<rbrace>"
-  assumes arch_post_set_flags[wp]:
-  "\<And>t flags. arch_post_set_flags t flags \<lbrace>invs :: 'state_ext state \<Rightarrow> _\<rbrace>"
+  assumes arch_post_set_flags_invs[wp]:
+  "\<And>t flags. \<lbrace>invs and ex_nonz_cap_to t\<rbrace> arch_post_set_flags t flags \<lbrace>\<lambda>_. invs :: 'state_ext state \<Rightarrow> _\<rbrace>"
   assumes arch_prepare_set_domain_invs[wp]:
   "\<And>t d. arch_prepare_set_domain t d \<lbrace>invs :: 'state_ext state \<Rightarrow> _\<rbrace>"
   assumes arch_prepare_set_domain_typ_at[wp]:
@@ -838,6 +838,8 @@ lemma set_flags_valid_objs[wp]:
 crunch set_flags
   for valid_cap[wp]: "valid_cap c"
   and cte_at[wp]: "cte_at c"
+  and ex_nonz_cap_to[wp]: "ex_nonz_cap_to p"
+  (wp: thread_set_ex_nonz_cap_to_trivial simp: ball_tcb_cap_casesI)
 
 lemma set_flags_invs[wp]:
   "\<lbrace>invs and tcb_at t\<rbrace> set_flags t fs \<lbrace>\<lambda>rv. invs\<rbrace>"

--- a/proof/invariant-abstract/X64/ArchFPU_AI.thy
+++ b/proof/invariant-abstract/X64/ArchFPU_AI.thy
@@ -137,15 +137,6 @@ lemma schedule_cur_fpu_in_cur_domain[wp]:
 
 \<comment> \<open>handle_interrupt\<close>
 
-\<comment> \<open>FIXME: move\<close>
-lemma thread_set_no_change_etcb_at:
-  assumes x: "\<And>tcb. P (etcb_of (f tcb)) = P (etcb_of tcb)"
-  shows      "thread_set f t' \<lbrace>etcb_at P t\<rbrace>"
-  apply (simp add: thread_set_def set_object_def get_object_def)
-  apply wpsimp
-  apply (clarsimp simp: x get_tcb_def etcb_at_def etcbs_of'_def)
-  done
-
 crunch send_signal, set_extra_badge, handle_reserved_irq
   for etcb_at[wp]: "etcb_at P t"
   and cur_domain[wp]: "\<lambda>s. P (cur_domain s)"
@@ -236,6 +227,21 @@ lemma option_update_thread_no_etcb_change_cur_fpu_in_cur_domain:
   unfolding option_update_thread_def
   by (wpsimp wp: cur_fpu_in_cur_domain_lift_strong thread_set_no_change_etcb_at simp: x)
 
+lemma arch_post_set_flags_in_cur_domain[wp]:
+  "\<lbrace>cur_fpu_in_cur_domain and (\<lambda>s. in_cur_domain (cur_thread s) s)\<rbrace>
+   arch_post_set_flags t flags
+   \<lbrace>\<lambda>_. cur_fpu_in_cur_domain\<rbrace>"
+  unfolding arch_post_set_flags_def
+  by wpsimp
+
+lemma set_flags_in_cur_domain[wp]:
+  "set_flags param_a param_b \<lbrace>in_cur_domain t\<rbrace>"
+  unfolding set_flags_def in_cur_domain_def
+  by (wpsimp wp: thread_set_no_change_etcb_at | wps)+
+
+crunch set_flags
+  for cur_thread[wp]: "\<lambda>s. P (cur_thread s)"
+
 crunch invoke_tcb
   for cur_fpu_in_cur_domain[wp]: cur_fpu_in_cur_domain
   (wp: crunch_wps check_cap_inv thread_set_no_etcb_change_cur_fpu_in_cur_domain
@@ -255,8 +261,7 @@ crunch
   (wp: crunch_wps  simp: crunch_simps)
 
 lemma arch_perform_invocation_valid_cur_fpu[wp]:
-  "\<lbrace>cur_fpu_in_cur_domain and ct_in_cur_domain and cur_fpu and valid_arch_inv ai
-    and (\<lambda>s. scheduler_action s = resume_cur_thread)\<rbrace>
+  "\<lbrace>cur_fpu_in_cur_domain and valid_arch_inv ai\<rbrace>
    arch_perform_invocation ai
    \<lbrace>\<lambda>_. cur_fpu_in_cur_domain\<rbrace>"
   unfolding arch_perform_invocation_def
@@ -327,8 +332,8 @@ crunch
    simp: crunch_simps)
 
 lemma perform_invocation_valid_cur_fpu[wp]:
-  "\<lbrace>cur_fpu_in_cur_domain and ct_in_cur_domain and cur_fpu and valid_invocation iv
-    and (\<lambda>s. scheduler_action s = resume_cur_thread)\<rbrace>
+  "\<lbrace>cur_fpu_in_cur_domain and valid_invocation iv
+    and (\<lambda>s. in_cur_domain (cur_thread s) s)\<rbrace>
    perform_invocation blocking call iv
    \<lbrace>\<lambda>_. cur_fpu_in_cur_domain\<rbrace>"
   by (case_tac iv, simp_all; (solves wpsimp)?)
@@ -341,25 +346,25 @@ lemma set_thread_state_runnable_scheduler_action:
   by (clarsimp simp: pred_tcb_at_def obj_at_def)
 
 lemma handle_invocation_cur_fpu_in_cur_domain[wp]:
-  "\<lbrace>cur_fpu_in_cur_domain and invs and ct_in_cur_domain and ct_active
-    and (\<lambda>s. scheduler_action s = resume_cur_thread)\<rbrace>
+  "\<lbrace>cur_fpu_in_cur_domain and einvs and ct_active and (\<lambda>s. scheduler_action s = resume_cur_thread)\<rbrace>
    handle_invocation calling blocking
    \<lbrace>\<lambda>_. cur_fpu_in_cur_domain\<rbrace>"
   unfolding handle_invocation_def
   apply (wpsimp wp: syscall_valid)
           apply (wp gts_wp hoare_vcg_all_lift hoare_drop_imps
                     set_thread_state_runnable_scheduler_action
-                | simp add: split_def)+
+                 | simp add: split_def | wps)+
   apply (fastforce simp: invs_def valid_state_def valid_arch_state_def valid_pspace_def
-                         valid_tcb_state_def ct_in_state_def
-                  elim!: pred_tcb_weakenE)
+                         valid_tcb_state_def ct_in_state_def valid_sched_def
+                  elim!: pred_tcb_weakenE
+                 intro!: ct_in_cur_domain_active_resume_cur_thread)
   done
 
 crunch maybe_handle_interrupt
   for cur_fpu_in_cur_domain[wp]: cur_fpu_in_cur_domain
 
 lemma handle_event_cur_fpu_in_cur_domain[wp]:
-  "\<lbrace>cur_fpu_in_cur_domain and invs and ct_in_cur_domain and (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_active s)
+  "\<lbrace>cur_fpu_in_cur_domain and einvs and (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_active s)
     and (\<lambda>s. scheduler_action s = resume_cur_thread)\<rbrace>
    handle_event e
    \<lbrace>\<lambda>_. cur_fpu_in_cur_domain\<rbrace>"
@@ -371,7 +376,7 @@ crunch activate_thread
   for cur_fpu_in_cur_domain[wp]: cur_fpu_in_cur_domain
 
 lemma call_kernel_cur_fpu_in_cur_domain:
-  "\<lbrace>cur_fpu_in_cur_domain and invs and valid_sched and (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_active s)
+  "\<lbrace>cur_fpu_in_cur_domain and einvs and (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_active s)
     and (\<lambda>s. scheduler_action s = resume_cur_thread)\<rbrace>
    call_kernel e
    \<lbrace>\<lambda>_. cur_fpu_in_cur_domain\<rbrace>"
@@ -381,7 +386,6 @@ lemma call_kernel_cur_fpu_in_cur_domain:
      apply fastforce
     apply (wpsimp wp: getActiveIRQ_neq_non_kernel handle_event_valid_sched
            | strengthen invs_valid_objs invs_hyp_sym_refs)+
-  apply (clarsimp simp: valid_sched_def)
   done
 
 end

--- a/proof/invariant-abstract/X64/ArchTcb_AI.thy
+++ b/proof/invariant-abstract/X64/ArchTcb_AI.thy
@@ -164,7 +164,14 @@ lemma finalise_cap_not_cte_wp_at[Tcb_AI_assms]:
 
 crunch arch_post_set_flags, arch_prepare_set_domain
   for typ_at[wp, Tcb_AI_assms]: "\<lambda>s. P (typ_at T p s)"
-  and invs[wp, Tcb_AI_assms]: "invs"
+
+crunch arch_prepare_set_domain
+  for invs[wp, Tcb_AI_assms]: "invs"
+
+lemma arch_post_set_flags_invs[wp, Tcb_AI_assms]:
+  "\<lbrace>invs and ex_nonz_cap_to t\<rbrace> arch_post_set_flags t flags \<lbrace>\<lambda>_. invs\<rbrace>"
+  unfolding arch_post_set_flags_def
+  by wpsimp
 
 lemmas arch_prepare_set_domain_typ_ats[wp] = abs_typ_at_lifts[OF arch_prepare_set_domain_typ_at]
 

--- a/proof/refine/AARCH64/Tcb_R.thy
+++ b/proof/refine/AARCH64/Tcb_R.thy
@@ -1654,10 +1654,10 @@ lemma setSchedulerAction_invs'[wp]:
               need to unfold config_HAVE_FPU. *)
 lemma postSetFlags_corres[corres]:
   "flags = word_to_tcb_flags flags' \<Longrightarrow>
-   corres dc (pspace_aligned and pspace_distinct and valid_cur_fpu) \<top>
+   corres dc (cur_tcb and pspace_aligned and pspace_distinct and valid_cur_fpu) \<top>
      (arch_post_set_flags  t flags) (postSetFlags t flags')"
   unfolding arch_post_set_flags_def postSetFlags_def
-  by (corres term_simp: Kernel_Config.config_HAVE_FPU_def)
+  by (corres simp: Kernel_Config.config_HAVE_FPU_def cur_tcb_def)
 
 end
 
@@ -1673,6 +1673,7 @@ crunch set_flags
   for pspace_aligned[wp]: pspace_aligned
   and pspace_distinct[wp]: pspace_distinct
   and valid_cur_fpu[wp]: valid_cur_fpu
+  and cur_tcb[wp]: cur_tcb
 
 
 consts
@@ -1904,9 +1905,10 @@ lemma setFlags_invs'[wp]:
    \<lbrace>\<lambda>_. invs'\<rbrace>"
   by (wpsimp simp: setFlags_def wp: threadSet_flags_invs')
 
-crunch postSetFlags
-  for invs'[wp]: invs'
-  (ignore: threadSet)
+lemma postSetFlags_invs'[wp]:
+  "postSetFlags t flags \<lbrace>invs'\<rbrace>"
+  unfolding postSetFlags_def
+  by wpsimp
 
 lemma invokeSetFlags_invs'[wp]:
   "\<lbrace>invs' and tcb_inv_wf' (tcbinvocation.SetFlags tcb clears' sets')\<rbrace>

--- a/proof/refine/X64/Tcb_R.thy
+++ b/proof/refine/X64/Tcb_R.thy
@@ -1669,10 +1669,10 @@ lemma setSchedulerAction_invs'[wp]:
               need to unfold config_HAVE_FPU. *)
 lemma postSetFlags_corres[corres]:
   "flags = word_to_tcb_flags flags' \<Longrightarrow>
-   corres dc (pspace_aligned and pspace_distinct and valid_cur_fpu) \<top>
+   corres dc (cur_tcb and pspace_aligned and pspace_distinct and valid_cur_fpu) \<top>
      (arch_post_set_flags  t flags) (postSetFlags t flags')"
   unfolding arch_post_set_flags_def postSetFlags_def
-  by (corres term_simp: Kernel_Config.config_HAVE_FPU_def)
+  by (corres simp: Kernel_Config.config_HAVE_FPU_def cur_tcb_def)
 
 end
 
@@ -1688,6 +1688,7 @@ crunch set_flags
   for pspace_aligned[wp]: pspace_aligned
   and pspace_distinct[wp]: pspace_distinct
   and valid_cur_fpu[wp]: valid_cur_fpu
+  and cur_tcb[wp]: cur_tcb
 
 
 consts
@@ -1919,9 +1920,10 @@ lemma setFlags_invs'[wp]:
    \<lbrace>\<lambda>_. invs'\<rbrace>"
   by (wpsimp simp: setFlags_def wp: threadSet_flags_invs')
 
-crunch postSetFlags
-  for invs'[wp]: invs'
-  (ignore: threadSet)
+lemma postSetFlags_invs'[wp]:
+  "postSetFlags t flags \<lbrace>invs'\<rbrace>"
+  unfolding postSetFlags_def
+  by wpsimp
 
 lemma invokeSetFlags_invs'[wp]:
   "\<lbrace>invs' and tcb_inv_wf' (tcbinvocation.SetFlags tcb clears' sets')\<rbrace>

--- a/spec/abstract/AARCH64/ArchTcb_A.thy
+++ b/spec/abstract/AARCH64/ArchTcb_A.thy
@@ -28,8 +28,12 @@ definition arch_post_modify_registers :: "obj_ref \<Rightarrow> obj_ref \<Righta
 
 \<comment> \<open>The corresponding C code is not arch dependent and so is inline as part of invokeSetFlags\<close>
 definition arch_post_set_flags :: "obj_ref \<Rightarrow> tcb_flags \<Rightarrow> (unit, 'a::state_ext) s_monad" where
-  "arch_post_set_flags t flags \<equiv>
-     when (FpuDisabled \<in> flags) (fpu_release t)"
+  "arch_post_set_flags t flags \<equiv> do
+     cur \<leftarrow> gets cur_thread;
+     if FpuDisabled \<in> flags
+     then fpu_release t
+     else when (t = cur) (lazy_fpu_restore t)
+   od"
 
 end
 end

--- a/spec/abstract/X64/ArchTcb_A.thy
+++ b/spec/abstract/X64/ArchTcb_A.thy
@@ -48,8 +48,12 @@ where
 
 \<comment> \<open>The corresponding C code is not arch dependent and so is inline as part of invokeSetFlags\<close>
 definition arch_post_set_flags :: "obj_ref \<Rightarrow> tcb_flags \<Rightarrow> (unit, 'a::state_ext) s_monad" where
-  "arch_post_set_flags t flags \<equiv>
-     when (FpuDisabled \<in> flags) (fpu_release t)"
+  "arch_post_set_flags t flags \<equiv> do
+     cur \<leftarrow> gets cur_thread;
+     if FpuDisabled \<in> flags
+     then fpu_release t
+     else when (t = cur) (lazy_fpu_restore t)
+   od"
 
 (* As opposed to hyp-enabled architectures, we can keep this here as it does not cause circular
    function dependency. *)

--- a/spec/haskell/src/SEL4/Object/TCB/AARCH64.hs
+++ b/spec/haskell/src/SEL4/Object/TCB/AARCH64.hs
@@ -55,5 +55,8 @@ postModifyRegisters :: PPtr TCB -> PPtr TCB -> UserMonad ()
 postModifyRegisters _ _ = return ()
 
 postSetFlags :: PPtr TCB -> TcbFlags -> Kernel ()
-postSetFlags t flags =
-    when (isFlagSet FpuDisabled flags) (fpuRelease t)
+postSetFlags t flags = do
+    cur <- getCurThread
+    if (isFlagSet FpuDisabled flags)
+        then fpuRelease t
+        else when (t == cur) (lazyFpuRestore t)

--- a/spec/haskell/src/SEL4/Object/TCB/X64.lhs
+++ b/spec/haskell/src/SEL4/Object/TCB/X64.lhs
@@ -63,5 +63,8 @@ Here, cur = ksCurThread
 >     when (dest /= cur) $ setRegister (RegisterSet.Register ErrorRegister) 0
 
 > postSetFlags :: PPtr TCB -> TcbFlags -> Kernel ()
-> postSetFlags t flags =
->     when (isFlagSet FpuDisabled flags) (fpuRelease t)
+> postSetFlags t flags = do
+>     cur <- getCurThread
+>     if (isFlagSet FpuDisabled flags)
+>         then fpuRelease t
+>         else when (t == cur) (lazyFpuRestore t)


### PR DESCRIPTION
Restore the FPU immediately when setting the TCB flag to enabled if it is the current thread. Otherwise the FPU would stay disabled, as switch_to_thread would not be called.

Test with: https://github.com/seL4/seL4/pull/1574