### PR TITLE
arch-split Finalise_R

### DIFF
--- a/proof/crefine/AARCH64/Fastpath_Equiv.thy
+++ b/proof/crefine/AARCH64/Fastpath_Equiv.thy
@@ -33,9 +33,13 @@ lemma getEndpoint_obj_at':
 
 lemmas setEndpoint_obj_at_tcb' = setEndpoint_obj_at'_tcb
 
+context notes if_cong[cong] begin
+
 crunch tcbSchedEnqueue
   for tcbContext[wp]: "obj_at' (\<lambda>tcb. P ((atcbContextGet o tcbArch) tcb)) t"
   (simp: tcbQueuePrepend_def)
+
+end
 
 lemma setCTE_tcbContext:
   "\<lbrace>obj_at' (\<lambda>tcb. P ((atcbContextGet o tcbArch) tcb)) t\<rbrace>
@@ -1082,9 +1086,13 @@ crunch emptySlot, asUser
   for gsCNodes[wp]: "\<lambda>s. P (gsCNodes s)"
   (wp: crunch_wps)
 
+context notes if_cong[cong] begin (* FIXME arch-split: WTF *)
+
 crunch possibleSwitchTo
   for tcbContext[wp]: "obj_at' (\<lambda>tcb. P ( (atcbContextGet o tcbArch) tcb)) t"
   (wp: crunch_wps simp_del: comp_apply)
+
+end
 
 crunch doFaultTransfer
   for only_cnode_caps[wp]: "\<lambda>s. P (only_cnode_caps (ctes_of s))"
@@ -1415,9 +1423,13 @@ lemma valid_objs_ntfn_at_tcbBoundNotification:
   apply clarsimp
   done
 
+context notes if_cong[cong] begin
+
 crunch setThreadState
   for bound_tcb_at'_Q[wp]: "\<lambda>s. Q (bound_tcb_at' P t s)"
   (wp: threadSet_pred_tcb_no_state crunch_wps simp: unless_def)
+
+end
 
 lemmas emptySlot_pred_tcb_at'_Q[wp] = lift_neg_pred_tcb_at'[OF emptySlot_typ_at' emptySlot_pred_tcb_at']
 

--- a/proof/crefine/AARCH64/Fastpath_Equiv.thy
+++ b/proof/crefine/AARCH64/Fastpath_Equiv.thy
@@ -33,13 +33,9 @@ lemma getEndpoint_obj_at':
 
 lemmas setEndpoint_obj_at_tcb' = setEndpoint_obj_at'_tcb
 
-context notes if_cong[cong] begin
-
 crunch tcbSchedEnqueue
   for tcbContext[wp]: "obj_at' (\<lambda>tcb. P ((atcbContextGet o tcbArch) tcb)) t"
-  (simp: tcbQueuePrepend_def)
-
-end
+  (simp: tcbQueuePrepend_def cong: if_cong)
 
 lemma setCTE_tcbContext:
   "\<lbrace>obj_at' (\<lambda>tcb. P ((atcbContextGet o tcbArch) tcb)) t\<rbrace>
@@ -481,13 +477,10 @@ lemma setCTE_obj_at'_tcbIPCBuffer:
   unfolding setCTE_def
   by (rule setObject_cte_obj_at_tcb', simp+)
 
-context
-notes if_cong[cong]
-begin
 crunch cteInsert, asUser
   for obj_at'_tcbIPCBuffer[wp]: "obj_at' (\<lambda>tcb. P (tcbIPCBuffer tcb)) t"
-  (wp: setCTE_obj_at'_queued crunch_wps threadSet_obj_at'_really_strongest)
-end
+  (wp: setCTE_obj_at'_queued crunch_wps threadSet_obj_at'_really_strongest
+   cong: if_cong)
 
 crunch cteInsert, threadSet, asUser, emptySlot
   for ksReadyQueuesL1Bitmap_inv[wp]: "\<lambda>s. P (ksReadyQueuesL1Bitmap s)"
@@ -1086,13 +1079,9 @@ crunch emptySlot, asUser
   for gsCNodes[wp]: "\<lambda>s. P (gsCNodes s)"
   (wp: crunch_wps)
 
-context notes if_cong[cong] begin (* FIXME arch-split: WTF *)
-
 crunch possibleSwitchTo
   for tcbContext[wp]: "obj_at' (\<lambda>tcb. P ( (atcbContextGet o tcbArch) tcb)) t"
-  (wp: crunch_wps simp_del: comp_apply)
-
-end
+  (wp: crunch_wps simp_del: comp_apply cong: if_cong)
 
 crunch doFaultTransfer
   for only_cnode_caps[wp]: "\<lambda>s. P (only_cnode_caps (ctes_of s))"
@@ -1423,13 +1412,9 @@ lemma valid_objs_ntfn_at_tcbBoundNotification:
   apply clarsimp
   done
 
-context notes if_cong[cong] begin
-
 crunch setThreadState
   for bound_tcb_at'_Q[wp]: "\<lambda>s. Q (bound_tcb_at' P t s)"
-  (wp: threadSet_pred_tcb_no_state crunch_wps simp: unless_def)
-
-end
+  (wp: threadSet_pred_tcb_no_state crunch_wps simp: unless_def cong: if_cong)
 
 lemmas emptySlot_pred_tcb_at'_Q[wp] = lift_neg_pred_tcb_at'[OF emptySlot_typ_at' emptySlot_pred_tcb_at']
 
@@ -1483,18 +1468,16 @@ crunch rescheduleRequired
   for obj_at'_tcbIPCBuffer[wp]: "obj_at' (\<lambda>tcb. P (tcbIPCBuffer tcb)) t"
   (wp: crunch_wps tcbSchedEnqueue_tcbIPCBuffer simp: rescheduleRequired_def)
 
-context
-notes if_cong[cong]
-begin
 crunch setThreadState
   for obj_at'_tcbIPCBuffer[wp]: "obj_at' (\<lambda>tcb. P (tcbIPCBuffer tcb)) t"
-  (wp: crunch_wps threadSet_obj_at'_really_strongest)
+  (wp: crunch_wps threadSet_obj_at'_really_strongest
+   cong: if_cong)
 
 crunch handleFault
   for obj_at'_tcbIPCBuffer[wp]: "obj_at' (\<lambda>tcb. P (tcbIPCBuffer tcb)) t"
   (wp: crunch_wps constOnFailure_wp tcbSchedEnqueue_tcbIPCBuffer threadSet_obj_at'_really_strongest
-   simp: zipWithM_x_mapM)
-end
+   simp: zipWithM_x_mapM
+   cong: if_cong)
 
 crunch emptySlot
   for obj_at'_tcbIPCBuffer[wp]: "obj_at' (\<lambda>tcb. P (tcbIPCBuffer tcb)) t"

--- a/proof/crefine/AARCH64/Finalise_C.thy
+++ b/proof/crefine/AARCH64/Finalise_C.thy
@@ -792,7 +792,7 @@ lemma doUnbindNotification_ccorres:
     (UNIV \<inter> {s. ntfnPtr_' s = ntfn_Ptr ntfnptr} \<inter> {s. tcbptr_' s = tcb_ptr_to_ctcb_ptr tcb}) []
    (do ntfn \<leftarrow> getNotification ntfnptr; doUnbindNotification ntfnptr ntfn tcb od)
    (Call doUnbindNotification_'proc)"
-  apply (cinit' lift: ntfnPtr_' tcbptr_')
+  apply (cinit' lift: ntfnPtr_' tcbptr_' simp: doUnbindNotification_def)
    apply (rule ccorres_symb_exec_l [OF _ get_ntfn_inv' _ empty_fail_getNotification])
     apply (rule_tac P="invs' and ko_at' ntfn ntfnptr" and P'=UNIV
              in ccorres_split_nothrow_novcg)
@@ -841,7 +841,7 @@ lemma doUnbindNotification_ccorres':
     (UNIV \<inter> {s. ntfnPtr_' s = ntfn_Ptr ntfnptr} \<inter> {s. tcbptr_' s = tcb_ptr_to_ctcb_ptr tcb}) []
    (doUnbindNotification ntfnptr ntfn tcb)
    (Call doUnbindNotification_'proc)"
-  apply (cinit' lift: ntfnPtr_' tcbptr_')
+  apply (cinit' lift: ntfnPtr_' tcbptr_' simp: doUnbindNotification_def)
     apply (rule_tac P="invs' and ko_at' ntfn ntfnptr" and P'=UNIV
                 in ccorres_split_nothrow_novcg)
         apply (rule ccorres_from_vcg[where rrel=dc and xf=xfdc])

--- a/proof/crefine/AARCH64/Ipc_C.thy
+++ b/proof/crefine/AARCH64/Ipc_C.thy
@@ -4097,18 +4097,16 @@ lemma handleFaultReply_ccorres [corres]:
   apply (fastforce simp: seL4_Faults seL4_Arch_Faults)
   done
 
-context
-notes if_cong[cong]
-begin
 crunch emptySlot, tcbSchedEnqueue, rescheduleRequired
   for tcbFault: "obj_at' (\<lambda>tcb. P (tcbFault tcb)) t"
   (wp: threadSet_obj_at'_strongish crunch_wps
-    simp: crunch_simps unless_def)
+   simp: crunch_simps unless_def
+   cong: if_cong)
 
 crunch setThreadState, cancelAllIPC, cancelAllSignals
   for tcbFault: "obj_at' (\<lambda>tcb. P (tcbFault tcb)) t"
-  (wp: threadSet_obj_at'_strongish crunch_wps)
-end
+  (wp: threadSet_obj_at'_strongish crunch_wps
+   cong: if_cong)
 
 lemma sbn_tcbFault:
   "\<lbrace>obj_at' (\<lambda>tcb. P (tcbFault tcb)) t\<rbrace>

--- a/proof/crefine/AARCH64/IsolatedThreadAction.thy
+++ b/proof/crefine/AARCH64/IsolatedThreadAction.thy
@@ -266,7 +266,7 @@ lemma map_to_ctes_partial_overwrite:
   "\<forall>x. tcb_at' (idx x) s \<Longrightarrow>
    map_to_ctes (partial_overwrite idx tsrs (ksPSpace s))
      = ctes_of s"
-  supply if_split[split del]
+  supply if_split[split del] if_cong[cong]
   apply (rule ext)
   apply (frule dom_partial_overwrite[where tsrs=tsrs])
   apply (simp add: map_to_ctes_def partial_overwrite_def
@@ -1279,7 +1279,8 @@ lemma oblivious_switchToThread_schact:
                    getQueue_def setQueue_def storeWordUser_def setRegister_def
                    pointerInUserData_def isRunnable_def isStopped_def
                    getThreadState_def tcbSchedDequeue_def bitmap_fun_defs
-                   tcbQueueRemove_def ksReadyQueues_asrt_def)
+                   tcbQueueRemove_def ksReadyQueues_asrt_def
+              cong: if_cong)
   by (safe intro!: oblivious_bind
               | simp_all add: ready_qs_runnable_def idleThreadNotQueued_def
                               oblivious_setVMRoot_schact oblivious_vcpuSwitch_schact
@@ -1324,9 +1325,13 @@ lemma tcbSchedEnqueue_tcbPriority[wp]:
   apply (wp | simp cong: if_cong)+
   done
 
+context notes if_cong[cong] begin
+
 crunch cteDeleteOne
   for obj_at_prio[wp]: "obj_at' (\<lambda>tcb. P (tcbPriority tcb)) t"
   (wp: crunch_wps setEndpoint_obj_at'_tcb setNotification_tcb simp: crunch_simps unless_def)
+
+end
 
 lemma setThreadState_no_sch_change:
   "\<lbrace>\<lambda>s. P (ksSchedulerAction s) \<and> (runnable' st \<or> t \<noteq> ksCurThread s)\<rbrace>

--- a/proof/crefine/AARCH64/IsolatedThreadAction.thy
+++ b/proof/crefine/AARCH64/IsolatedThreadAction.thy
@@ -1325,13 +1325,9 @@ lemma tcbSchedEnqueue_tcbPriority[wp]:
   apply (wp | simp cong: if_cong)+
   done
 
-context notes if_cong[cong] begin
-
 crunch cteDeleteOne
   for obj_at_prio[wp]: "obj_at' (\<lambda>tcb. P (tcbPriority tcb)) t"
-  (wp: crunch_wps setEndpoint_obj_at'_tcb setNotification_tcb simp: crunch_simps unless_def)
-
-end
+  (wp: crunch_wps setEndpoint_obj_at'_tcb setNotification_tcb simp: crunch_simps unless_def cong: if_cong)
 
 lemma setThreadState_no_sch_change:
   "\<lbrace>\<lambda>s. P (ksSchedulerAction s) \<and> (runnable' st \<or> t \<noteq> ksCurThread s)\<rbrace>

--- a/proof/crefine/ARM/Fastpath_Equiv.thy
+++ b/proof/crefine/ARM/Fastpath_Equiv.thy
@@ -33,13 +33,9 @@ lemma getEndpoint_obj_at':
 
 lemmas setEndpoint_obj_at_tcb' = setEndpoint_obj_at'_tcb
 
-context notes if_cong[cong] begin
-
 crunch tcbSchedEnqueue
   for tcbContext[wp]: "obj_at' (\<lambda>tcb. P ((atcbContextGet o tcbArch) tcb)) t"
-  (simp: tcbQueuePrepend_def)
-
-end
+  (simp: tcbQueuePrepend_def cong: if_cong)
 
 lemma setCTE_tcbContext:
   "\<lbrace>obj_at' (\<lambda>tcb. P ((atcbContextGet o tcbArch) tcb)) t\<rbrace>
@@ -483,13 +479,10 @@ lemma setCTE_obj_at'_tcbIPCBuffer:
   unfolding setCTE_def
   by (rule setObject_cte_obj_at_tcb', simp+)
 
-context
-notes if_cong[cong]
-begin
 crunch cteInsert, asUser
   for obj_at'_tcbIPCBuffer[wp]: "obj_at' (\<lambda>tcb. P (tcbIPCBuffer tcb)) t"
-  (wp: setCTE_obj_at'_queued crunch_wps threadSet_obj_at'_really_strongest)
-end
+  (wp: setCTE_obj_at'_queued crunch_wps threadSet_obj_at'_really_strongest
+   cong: if_cong)
 
 crunch cteInsert, threadSet, asUser, emptySlot
   for ksReadyQueuesL1Bitmap_inv[wp]: "\<lambda>s. P (ksReadyQueuesL1Bitmap s)"
@@ -1317,13 +1310,9 @@ lemma valid_objs_ntfn_at_tcbBoundNotification:
   apply clarsimp
   done
 
-context notes if_cong[cong] begin
-
 crunch setThreadState
   for bound_tcb_at'_Q[wp]: "\<lambda>s. Q (bound_tcb_at' P t s)"
-  (wp: threadSet_pred_tcb_no_state crunch_wps simp: unless_def)
-
-end
+  (wp: threadSet_pred_tcb_no_state crunch_wps simp: unless_def cong: if_cong)
 
 lemmas emptySlot_pred_tcb_at'_Q[wp] = lift_neg_pred_tcb_at'[OF emptySlot_typ_at' emptySlot_pred_tcb_at']
 
@@ -1377,18 +1366,16 @@ crunch rescheduleRequired
   for obj_at'_tcbIPCBuffer[wp]: "obj_at' (\<lambda>tcb. P (tcbIPCBuffer tcb)) t"
   (wp: crunch_wps tcbSchedEnqueue_tcbIPCBuffer simp: rescheduleRequired_def)
 
-context
-notes if_cong[cong]
-begin
 crunch setThreadState
   for obj_at'_tcbIPCBuffer[wp]: "obj_at' (\<lambda>tcb. P (tcbIPCBuffer tcb)) t"
-  (wp: crunch_wps threadSet_obj_at'_really_strongest)
+  (wp: crunch_wps threadSet_obj_at'_really_strongest
+   cong: if_cong)
 
 crunch handleFault
   for obj_at'_tcbIPCBuffer[wp]: "obj_at' (\<lambda>tcb. P (tcbIPCBuffer tcb)) t"
   (wp: crunch_wps constOnFailure_wp tcbSchedEnqueue_tcbIPCBuffer threadSet_obj_at'_really_strongest
-   simp: zipWithM_x_mapM)
-end
+   simp: zipWithM_x_mapM
+   cong: if_cong)
 
 crunch emptySlot
   for obj_at'_tcbIPCBuffer[wp]: "obj_at' (\<lambda>tcb. P (tcbIPCBuffer tcb)) t"

--- a/proof/crefine/ARM/Fastpath_Equiv.thy
+++ b/proof/crefine/ARM/Fastpath_Equiv.thy
@@ -33,9 +33,13 @@ lemma getEndpoint_obj_at':
 
 lemmas setEndpoint_obj_at_tcb' = setEndpoint_obj_at'_tcb
 
+context notes if_cong[cong] begin
+
 crunch tcbSchedEnqueue
   for tcbContext[wp]: "obj_at' (\<lambda>tcb. P ((atcbContextGet o tcbArch) tcb)) t"
   (simp: tcbQueuePrepend_def)
+
+end
 
 lemma setCTE_tcbContext:
   "\<lbrace>obj_at' (\<lambda>tcb. P ((atcbContextGet o tcbArch) tcb)) t\<rbrace>
@@ -1313,9 +1317,13 @@ lemma valid_objs_ntfn_at_tcbBoundNotification:
   apply clarsimp
   done
 
+context notes if_cong[cong] begin
+
 crunch setThreadState
   for bound_tcb_at'_Q[wp]: "\<lambda>s. Q (bound_tcb_at' P t s)"
   (wp: threadSet_pred_tcb_no_state crunch_wps simp: unless_def)
+
+end
 
 lemmas emptySlot_pred_tcb_at'_Q[wp] = lift_neg_pred_tcb_at'[OF emptySlot_typ_at' emptySlot_pred_tcb_at']
 

--- a/proof/crefine/ARM/Finalise_C.thy
+++ b/proof/crefine/ARM/Finalise_C.thy
@@ -756,7 +756,7 @@ lemma doUnbindNotification_ccorres:
     (UNIV \<inter> {s. ntfnPtr_' s = ntfn_Ptr ntfnptr} \<inter> {s. tcbptr_' s = tcb_ptr_to_ctcb_ptr tcb}) []
    (do ntfn \<leftarrow> getNotification ntfnptr; doUnbindNotification ntfnptr ntfn tcb od)
    (Call doUnbindNotification_'proc)"
-  apply (cinit' lift: ntfnPtr_' tcbptr_')
+  apply (cinit' lift: ntfnPtr_' tcbptr_' simp: doUnbindNotification_def)
    apply (rule ccorres_symb_exec_l [OF _ get_ntfn_inv' _ empty_fail_getNotification])
     apply (rule_tac P="invs' and ko_at' ntfn ntfnptr" and P'=UNIV
              in ccorres_split_nothrow_novcg)
@@ -805,7 +805,7 @@ lemma doUnbindNotification_ccorres':
     (UNIV \<inter> {s. ntfnPtr_' s = ntfn_Ptr ntfnptr} \<inter> {s. tcbptr_' s = tcb_ptr_to_ctcb_ptr tcb}) []
    (doUnbindNotification ntfnptr ntfn tcb)
    (Call doUnbindNotification_'proc)"
-  apply (cinit' lift: ntfnPtr_' tcbptr_')
+  apply (cinit' lift: ntfnPtr_' tcbptr_' simp: doUnbindNotification_def)
     apply (rule_tac P="invs' and ko_at' ntfn ntfnptr" and P'=UNIV
                 in ccorres_split_nothrow_novcg)
         apply (rule ccorres_from_vcg[where rrel=dc and xf=xfdc])

--- a/proof/crefine/ARM/Ipc_C.thy
+++ b/proof/crefine/ARM/Ipc_C.thy
@@ -3809,18 +3809,16 @@ lemma handleFaultReply_ccorres [corres]:
   apply (fastforce simp: seL4_Faults seL4_Arch_Faults)
   done
 
-context
-notes if_cong[cong]
-begin
 crunch emptySlot, tcbSchedEnqueue, rescheduleRequired
   for tcbFault: "obj_at' (\<lambda>tcb. P (tcbFault tcb)) t"
   (wp: threadSet_obj_at'_strongish crunch_wps
-    simp: crunch_simps unless_def)
+   simp: crunch_simps unless_def
+   cong: if_cong)
 
 crunch setThreadState, cancelAllIPC, cancelAllSignals
   for tcbFault: "obj_at' (\<lambda>tcb. P (tcbFault tcb)) t"
-  (wp: threadSet_obj_at'_strongish crunch_wps)
-end
+  (wp: threadSet_obj_at'_strongish crunch_wps
+   cong: if_cong)
 
 lemma sbn_tcbFault:
   "\<lbrace>obj_at' (\<lambda>tcb. P (tcbFault tcb)) t\<rbrace>

--- a/proof/crefine/ARM/IsolatedThreadAction.thy
+++ b/proof/crefine/ARM/IsolatedThreadAction.thy
@@ -275,6 +275,7 @@ lemma map_to_ctes_partial_overwrite:
    map_to_ctes (partial_overwrite idx tsrs (ksPSpace s))
      = ctes_of s"
   supply if_split[split del]
+  supply if_cong[cong]
   apply (rule ext)
   apply (frule dom_partial_overwrite[where tsrs=tsrs])
   apply (simp add: map_to_ctes_def partial_overwrite_def
@@ -880,7 +881,8 @@ lemma oblivious_switchToThread_schact:
                    getQueue_def setQueue_def storeWordUser_def setRegister_def
                    pointerInUserData_def isRunnable_def isStopped_def
                    getThreadState_def tcbSchedDequeue_def bitmap_fun_defs
-                   tcbQueueRemove_def ksReadyQueues_asrt_def)
+                   tcbQueueRemove_def ksReadyQueues_asrt_def
+              cong: if_cong)
   by (safe intro!: oblivious_bind
               | simp_all add: ready_qs_runnable_def idleThreadNotQueued_def
                               oblivious_setVMRoot_schact)+
@@ -914,7 +916,7 @@ lemma tcbSchedEnqueue_tcbPriority[wp]:
 crunch cteDeleteOne
   for obj_at_prio[wp]: "obj_at' (\<lambda>tcb. P (tcbPriority tcb)) t"
   (wp: crunch_wps setEndpoint_obj_at'_tcb setNotification_tcb
-   simp: crunch_simps unless_def setBoundNotification_def)
+   simp: crunch_simps unless_def setBoundNotification_def doUnbindNotification_def)
 
 context
 notes if_cong[cong]

--- a/proof/crefine/ARM/IsolatedThreadAction.thy
+++ b/proof/crefine/ARM/IsolatedThreadAction.thy
@@ -918,12 +918,9 @@ crunch cteDeleteOne
   (wp: crunch_wps setEndpoint_obj_at'_tcb setNotification_tcb
    simp: crunch_simps unless_def setBoundNotification_def doUnbindNotification_def)
 
-context
-notes if_cong[cong]
-begin
 crunch rescheduleRequired
   for obj_at_dom[wp]: "obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t"
-end
+  (cong: if_cong)
 
 lemma setThreadState_no_sch_change:
   "\<lbrace>\<lambda>s. P (ksSchedulerAction s) \<and> (runnable' st \<or> t \<noteq> ksCurThread s)\<rbrace>

--- a/proof/crefine/ARM_HYP/Fastpath_Equiv.thy
+++ b/proof/crefine/ARM_HYP/Fastpath_Equiv.thy
@@ -33,13 +33,9 @@ lemma getEndpoint_obj_at':
 
 lemmas setEndpoint_obj_at_tcb' = setEndpoint_obj_at'_tcb
 
-context notes if_cong[cong] begin
-
 crunch tcbSchedEnqueue
   for tcbContext[wp]: "obj_at' (\<lambda>tcb. P ((atcbContextGet o tcbArch) tcb)) t"
-  (simp: tcbQueuePrepend_def)
-
-end
+  (simp: tcbQueuePrepend_def cong: if_cong)
 
 lemma setCTE_tcbContext:
   "\<lbrace>obj_at' (\<lambda>tcb. P ((atcbContextGet o tcbArch) tcb)) t\<rbrace>
@@ -483,13 +479,10 @@ lemma setCTE_obj_at'_tcbIPCBuffer:
   unfolding setCTE_def
   by (rule setObject_cte_obj_at_tcb', simp+)
 
-context
-notes if_cong[cong]
-begin
 crunch cteInsert, asUser
   for obj_at'_tcbIPCBuffer[wp]: "obj_at' (\<lambda>tcb. P (tcbIPCBuffer tcb)) t"
-  (wp: setCTE_obj_at'_queued crunch_wps threadSet_obj_at'_really_strongest)
-end
+  (wp: setCTE_obj_at'_queued crunch_wps threadSet_obj_at'_really_strongest
+   cong: if_cong)
 
 crunch cteInsert, threadSet, asUser, emptySlot
   for ksReadyQueuesL1Bitmap_inv[wp]: "\<lambda>s. P (ksReadyQueuesL1Bitmap s)"
@@ -1320,13 +1313,9 @@ lemma valid_objs_ntfn_at_tcbBoundNotification:
   apply clarsimp
   done
 
-context notes if_cong[cong] begin
-
 crunch setThreadState
   for bound_tcb_at'_Q[wp]: "\<lambda>s. Q (bound_tcb_at' P t s)"
-  (wp: threadSet_pred_tcb_no_state crunch_wps simp: unless_def)
-
-end
+  (wp: threadSet_pred_tcb_no_state crunch_wps simp: unless_def cong: if_cong)
 
 lemmas emptySlot_pred_tcb_at'_Q[wp] = lift_neg_pred_tcb_at'[OF emptySlot_typ_at' emptySlot_pred_tcb_at']
 
@@ -1380,18 +1369,16 @@ crunch rescheduleRequired
   for obj_at'_tcbIPCBuffer[wp]: "obj_at' (\<lambda>tcb. P (tcbIPCBuffer tcb)) t"
   (wp: crunch_wps tcbSchedEnqueue_tcbIPCBuffer simp: rescheduleRequired_def)
 
-context
-notes if_cong[cong]
-begin
 crunch setThreadState
   for obj_at'_tcbIPCBuffer[wp]: "obj_at' (\<lambda>tcb. P (tcbIPCBuffer tcb)) t"
-  (wp: crunch_wps threadSet_obj_at'_really_strongest)
+  (wp: crunch_wps threadSet_obj_at'_really_strongest
+   cong: if_cong)
 
 crunch handleFault
   for obj_at'_tcbIPCBuffer[wp]: "obj_at' (\<lambda>tcb. P (tcbIPCBuffer tcb)) t"
   (wp: crunch_wps constOnFailure_wp tcbSchedEnqueue_tcbIPCBuffer threadSet_obj_at'_really_strongest
-   simp: zipWithM_x_mapM)
-end
+   simp: zipWithM_x_mapM
+   cong: if_cong)
 
 crunch emptySlot
   for obj_at'_tcbIPCBuffer[wp]: "obj_at' (\<lambda>tcb. P (tcbIPCBuffer tcb)) t"

--- a/proof/crefine/ARM_HYP/Fastpath_Equiv.thy
+++ b/proof/crefine/ARM_HYP/Fastpath_Equiv.thy
@@ -33,9 +33,13 @@ lemma getEndpoint_obj_at':
 
 lemmas setEndpoint_obj_at_tcb' = setEndpoint_obj_at'_tcb
 
+context notes if_cong[cong] begin
+
 crunch tcbSchedEnqueue
   for tcbContext[wp]: "obj_at' (\<lambda>tcb. P ((atcbContextGet o tcbArch) tcb)) t"
   (simp: tcbQueuePrepend_def)
+
+end
 
 lemma setCTE_tcbContext:
   "\<lbrace>obj_at' (\<lambda>tcb. P ((atcbContextGet o tcbArch) tcb)) t\<rbrace>
@@ -1316,9 +1320,13 @@ lemma valid_objs_ntfn_at_tcbBoundNotification:
   apply clarsimp
   done
 
+context notes if_cong[cong] begin
+
 crunch setThreadState
   for bound_tcb_at'_Q[wp]: "\<lambda>s. Q (bound_tcb_at' P t s)"
   (wp: threadSet_pred_tcb_no_state crunch_wps simp: unless_def)
+
+end
 
 lemmas emptySlot_pred_tcb_at'_Q[wp] = lift_neg_pred_tcb_at'[OF emptySlot_typ_at' emptySlot_pred_tcb_at']
 

--- a/proof/crefine/ARM_HYP/Finalise_C.thy
+++ b/proof/crefine/ARM_HYP/Finalise_C.thy
@@ -789,7 +789,7 @@ lemma doUnbindNotification_ccorres:
     (UNIV \<inter> {s. ntfnPtr_' s = ntfn_Ptr ntfnptr} \<inter> {s. tcbptr_' s = tcb_ptr_to_ctcb_ptr tcb}) []
    (do ntfn \<leftarrow> getNotification ntfnptr; doUnbindNotification ntfnptr ntfn tcb od)
    (Call doUnbindNotification_'proc)"
-  apply (cinit' lift: ntfnPtr_' tcbptr_')
+  apply (cinit' lift: ntfnPtr_' tcbptr_' simp: doUnbindNotification_def)
    apply (rule ccorres_symb_exec_l [OF _ get_ntfn_inv' _ empty_fail_getNotification])
     apply (rule_tac P="invs' and ko_at' ntfn ntfnptr" and P'=UNIV
              in ccorres_split_nothrow_novcg)
@@ -838,7 +838,7 @@ lemma doUnbindNotification_ccorres':
     (UNIV \<inter> {s. ntfnPtr_' s = ntfn_Ptr ntfnptr} \<inter> {s. tcbptr_' s = tcb_ptr_to_ctcb_ptr tcb}) []
    (doUnbindNotification ntfnptr ntfn tcb)
    (Call doUnbindNotification_'proc)"
-  apply (cinit' lift: ntfnPtr_' tcbptr_')
+  apply (cinit' lift: ntfnPtr_' tcbptr_' simp: doUnbindNotification_def)
     apply (rule_tac P="invs' and ko_at' ntfn ntfnptr" and P'=UNIV
                 in ccorres_split_nothrow_novcg)
         apply (rule ccorres_from_vcg[where rrel=dc and xf=xfdc])

--- a/proof/crefine/ARM_HYP/Ipc_C.thy
+++ b/proof/crefine/ARM_HYP/Ipc_C.thy
@@ -4336,20 +4336,16 @@ lemma handleFaultReply_ccorres [corres]:
   apply (fastforce simp: seL4_Faults seL4_Arch_Faults)
   done
 
-context
-notes if_cong[cong]
-begin
-
 crunch emptySlot, tcbSchedEnqueue, rescheduleRequired
   for tcbFault: "obj_at' (\<lambda>tcb. P (tcbFault tcb)) t"
   (wp: threadSet_obj_at'_strongish crunch_wps
-    simp: crunch_simps unless_def)
+   simp: crunch_simps unless_def
+   cong: if_cong)
 
 crunch setThreadState, cancelAllIPC, cancelAllSignals
   for tcbFault: "obj_at' (\<lambda>tcb. P (tcbFault tcb)) t"
-  (wp: threadSet_obj_at'_strongish crunch_wps)
-
-end
+  (wp: threadSet_obj_at'_strongish crunch_wps
+   cong: if_cong)
 
 lemma sbn_tcbFault:
   "\<lbrace>obj_at' (\<lambda>tcb. P (tcbFault tcb)) t\<rbrace>

--- a/proof/crefine/ARM_HYP/IsolatedThreadAction.thy
+++ b/proof/crefine/ARM_HYP/IsolatedThreadAction.thy
@@ -272,6 +272,7 @@ lemma map_to_ctes_partial_overwrite:
    map_to_ctes (partial_overwrite idx tsrs (ksPSpace s))
      = ctes_of s"
   supply if_split[split del]
+  supply if_cong[cong]
   apply (rule ext)
   apply (frule dom_partial_overwrite[where tsrs=tsrs])
   apply (simp add: map_to_ctes_def partial_overwrite_def
@@ -1167,7 +1168,8 @@ lemma oblivious_switchToThread_schact:
                    getQueue_def setQueue_def storeWordUser_def setRegister_def
                    pointerInUserData_def isRunnable_def isStopped_def
                    getThreadState_def tcbSchedDequeue_def bitmap_fun_defs
-                   tcbQueueRemove_def ksReadyQueues_asrt_def)
+                   tcbQueueRemove_def ksReadyQueues_asrt_def
+              cong: if_cong)
   apply (safe intro!: oblivious_bind
          | simp_all add: ready_qs_runnable_def idleThreadNotQueued_def oblivious_setVMRoot_schact
                          oblivious_vcpuSwitch_schact)+
@@ -1202,7 +1204,7 @@ lemma tcbSchedEnqueue_tcbPriority[wp]:
 crunch cteDeleteOne
   for obj_at_prio[wp]: "obj_at' (\<lambda>tcb. P (tcbPriority tcb)) t"
   (wp: crunch_wps setEndpoint_obj_at'_tcb setNotification_tcb
-   simp: crunch_simps unless_def setBoundNotification_def)
+   simp: crunch_simps unless_def setBoundNotification_def doUnbindNotification_def)
 
 lemma setThreadState_no_sch_change:
   "\<lbrace>\<lambda>s. P (ksSchedulerAction s) \<and> (runnable' st \<or> t \<noteq> ksCurThread s)\<rbrace>

--- a/proof/crefine/RISCV64/ArchMove_C.thy
+++ b/proof/crefine/RISCV64/ArchMove_C.thy
@@ -291,12 +291,9 @@ lemma asUser_getRegister_discarded:
                         return_def fail_def stateAssert_def)
   done
 
-context notes if_cong[cong] begin
-
 crunch setThreadState
   for pspace_canonical'[wp]: pspace_canonical'
-
-end
+  (cong: if_cong)
 
 lemma obj_at_kernel_mappings':
   "\<lbrakk>pspace_in_kernel_mappings' s; obj_at' P p s\<rbrakk>

--- a/proof/crefine/RISCV64/ArchMove_C.thy
+++ b/proof/crefine/RISCV64/ArchMove_C.thy
@@ -291,8 +291,12 @@ lemma asUser_getRegister_discarded:
                         return_def fail_def stateAssert_def)
   done
 
+context notes if_cong[cong] begin
+
 crunch setThreadState
   for pspace_canonical'[wp]: pspace_canonical'
+
+end
 
 lemma obj_at_kernel_mappings':
   "\<lbrakk>pspace_in_kernel_mappings' s; obj_at' P p s\<rbrakk>

--- a/proof/crefine/RISCV64/Delete_C.thy
+++ b/proof/crefine/RISCV64/Delete_C.thy
@@ -894,6 +894,7 @@ lemma finaliseSlot_ccorres:
          apply (clarsimp simp: cte_wp_at_ctes_of)
          apply (erule disjE[where P="F \<and> G" for F G])
           apply (clarsimp simp: capRemovable_def cte_wp_at_ctes_of cap_has_cleanup'_def
+                                arch_cap_has_cleanup'_def
                          split: option.split capability.splits)
           apply (auto dest!: ctes_of_valid'
                        simp: valid_cap'_def Kernel_C.maxIRQ_def RISCV64.maxIRQ_def

--- a/proof/crefine/RISCV64/Finalise_C.thy
+++ b/proof/crefine/RISCV64/Finalise_C.thy
@@ -809,7 +809,7 @@ lemma doUnbindNotification_ccorres:
     (UNIV \<inter> {s. ntfnPtr_' s = ntfn_Ptr ntfnptr} \<inter> {s. tcbptr_' s = tcb_ptr_to_ctcb_ptr tcb}) []
    (do ntfn \<leftarrow> getNotification ntfnptr; doUnbindNotification ntfnptr ntfn tcb od)
    (Call doUnbindNotification_'proc)"
-  apply (cinit' lift: ntfnPtr_' tcbptr_')
+  apply (cinit' lift: ntfnPtr_' tcbptr_' simp: doUnbindNotification_def)
    apply (rule ccorres_symb_exec_l [OF _ get_ntfn_inv' _ empty_fail_getNotification])
     apply (rule_tac P="invs' and ko_at' ntfn ntfnptr" and P'=UNIV
              in ccorres_split_nothrow_novcg)
@@ -858,7 +858,7 @@ lemma doUnbindNotification_ccorres':
     (UNIV \<inter> {s. ntfnPtr_' s = ntfn_Ptr ntfnptr} \<inter> {s. tcbptr_' s = tcb_ptr_to_ctcb_ptr tcb}) []
    (doUnbindNotification ntfnptr ntfn tcb)
    (Call doUnbindNotification_'proc)"
-  apply (cinit' lift: ntfnPtr_' tcbptr_')
+  apply (cinit' lift: ntfnPtr_' tcbptr_' simp: doUnbindNotification_def)
     apply (rule_tac P="invs' and ko_at' ntfn ntfnptr" and P'=UNIV
                 in ccorres_split_nothrow_novcg)
         apply (rule ccorres_from_vcg[where rrel=dc and xf=xfdc])

--- a/proof/crefine/RISCV64/Ipc_C.thy
+++ b/proof/crefine/RISCV64/Ipc_C.thy
@@ -4045,18 +4045,16 @@ lemma handleFaultReply_ccorres [corres]:
   apply (fastforce simp: seL4_Faults seL4_Arch_Faults)
   done
 
-context
-notes if_cong[cong]
-begin
 crunch emptySlot, tcbSchedEnqueue, rescheduleRequired
   for tcbFault: "obj_at' (\<lambda>tcb. P (tcbFault tcb)) t"
   (wp: threadSet_obj_at'_strongish crunch_wps
-    simp: crunch_simps unless_def)
+   simp: crunch_simps unless_def
+   cong: if_cong)
 
 crunch setThreadState, cancelAllIPC, cancelAllSignals
   for tcbFault: "obj_at' (\<lambda>tcb. P (tcbFault tcb)) t"
-  (wp: threadSet_obj_at'_strongish crunch_wps)
-end
+  (wp: threadSet_obj_at'_strongish crunch_wps
+   cong: if_cong)
 
 lemma sbn_tcbFault:
   "\<lbrace>obj_at' (\<lambda>tcb. P (tcbFault tcb)) t\<rbrace>

--- a/proof/crefine/RISCV64/IsolatedThreadAction.thy
+++ b/proof/crefine/RISCV64/IsolatedThreadAction.thy
@@ -955,13 +955,9 @@ lemma tcbSchedEnqueue_tcbPriority[wp]:
   apply (wp | simp cong: if_cong)+
   done
 
-context notes if_cong[cong] begin
-
 crunch cteDeleteOne
   for obj_at_prio[wp]: "obj_at' (\<lambda>tcb. P (tcbPriority tcb)) t"
-  (wp: crunch_wps setEndpoint_obj_at'_tcb setNotification_tcb simp: crunch_simps unless_def)
-
-end
+  (wp: crunch_wps setEndpoint_obj_at'_tcb setNotification_tcb simp: crunch_simps unless_def cong: if_cong)
 
 lemma setThreadState_no_sch_change:
   "\<lbrace>\<lambda>s. P (ksSchedulerAction s) \<and> (runnable' st \<or> t \<noteq> ksCurThread s)\<rbrace>

--- a/proof/crefine/RISCV64/IsolatedThreadAction.thy
+++ b/proof/crefine/RISCV64/IsolatedThreadAction.thy
@@ -268,6 +268,7 @@ lemma map_to_ctes_partial_overwrite:
    map_to_ctes (partial_overwrite idx tsrs (ksPSpace s))
      = ctes_of s"
   supply if_split[split del]
+  supply if_cong[cong]
   apply (rule ext)
   apply (frule dom_partial_overwrite[where tsrs=tsrs])
   apply (simp add: map_to_ctes_def partial_overwrite_def
@@ -909,7 +910,8 @@ lemma oblivious_switchToThread_schact:
                    getQueue_def setQueue_def storeWordUser_def setRegister_def
                    pointerInUserData_def isRunnable_def isStopped_def
                    getThreadState_def tcbSchedDequeue_def bitmap_fun_defs
-                   tcbQueueRemove_def ksReadyQueues_asrt_def)
+                   tcbQueueRemove_def ksReadyQueues_asrt_def
+              cong: if_cong[cong])
   by (safe intro!: oblivious_bind
               | simp_all add: ready_qs_runnable_def idleThreadNotQueued_def
                               oblivious_setVMRoot_schact)+
@@ -953,9 +955,13 @@ lemma tcbSchedEnqueue_tcbPriority[wp]:
   apply (wp | simp cong: if_cong)+
   done
 
+context notes if_cong[cong] begin
+
 crunch cteDeleteOne
   for obj_at_prio[wp]: "obj_at' (\<lambda>tcb. P (tcbPriority tcb)) t"
   (wp: crunch_wps setEndpoint_obj_at'_tcb setNotification_tcb simp: crunch_simps unless_def)
+
+end
 
 lemma setThreadState_no_sch_change:
   "\<lbrace>\<lambda>s. P (ksSchedulerAction s) \<and> (runnable' st \<or> t \<noteq> ksCurThread s)\<rbrace>

--- a/proof/crefine/X64/ArchMove_C.thy
+++ b/proof/crefine/X64/ArchMove_C.thy
@@ -108,12 +108,9 @@ lemma Arch_switchToThread_obj_at_pre:
   apply (wpsimp wp: asUser_obj_at_notQ doMachineOp_obj_at hoare_drop_imps simp: comp_def)
   done
 
-context notes if_cong[cong] begin
-
 crunch setThreadState
   for pspace_canonical'[wp]: pspace_canonical'
-
-end
+  (cong: if_cong)
 
 lemma word_shift_by_3:
   "x * 8 = (x::'a::len word) << 3"

--- a/proof/crefine/X64/ArchMove_C.thy
+++ b/proof/crefine/X64/ArchMove_C.thy
@@ -108,8 +108,12 @@ lemma Arch_switchToThread_obj_at_pre:
   apply (wpsimp wp: asUser_obj_at_notQ doMachineOp_obj_at hoare_drop_imps simp: comp_def)
   done
 
+context notes if_cong[cong] begin
+
 crunch setThreadState
   for pspace_canonical'[wp]: pspace_canonical'
+
+end
 
 lemma word_shift_by_3:
   "x * 8 = (x::'a::len word) << 3"

--- a/proof/crefine/X64/Finalise_C.thy
+++ b/proof/crefine/X64/Finalise_C.thy
@@ -791,7 +791,7 @@ lemma doUnbindNotification_ccorres:
     (UNIV \<inter> {s. ntfnPtr_' s = ntfn_Ptr ntfnptr} \<inter> {s. tcbptr_' s = tcb_ptr_to_ctcb_ptr tcb}) []
    (do ntfn \<leftarrow> getNotification ntfnptr; doUnbindNotification ntfnptr ntfn tcb od)
    (Call doUnbindNotification_'proc)"
-  apply (cinit' lift: ntfnPtr_' tcbptr_')
+  apply (cinit' lift: ntfnPtr_' tcbptr_' simp: doUnbindNotification_def)
    apply (rule ccorres_symb_exec_l [OF _ get_ntfn_inv' _ empty_fail_getNotification])
     apply (rule_tac P="invs' and ko_at' ntfn ntfnptr" and P'=UNIV
              in ccorres_split_nothrow_novcg)
@@ -841,7 +841,7 @@ lemma doUnbindNotification_ccorres':
     (UNIV \<inter> {s. ntfnPtr_' s = ntfn_Ptr ntfnptr} \<inter> {s. tcbptr_' s = tcb_ptr_to_ctcb_ptr tcb}) []
    (doUnbindNotification ntfnptr ntfn tcb)
    (Call doUnbindNotification_'proc)"
-  apply (cinit' lift: ntfnPtr_' tcbptr_')
+  apply (cinit' lift: ntfnPtr_' tcbptr_' simp: doUnbindNotification_def)
     apply (rule_tac P="invs' and ko_at' ntfn ntfnptr" and P'=UNIV
                 in ccorres_split_nothrow_novcg)
         apply (rule ccorres_from_vcg[where rrel=dc and xf=xfdc])

--- a/proof/crefine/X64/Ipc_C.thy
+++ b/proof/crefine/X64/Ipc_C.thy
@@ -4053,18 +4053,16 @@ lemma handleFaultReply_ccorres [corres]:
   apply (fastforce simp: seL4_Faults seL4_Arch_Faults)
   done
 
-context
-notes if_cong[cong]
-begin
 crunch emptySlot, tcbSchedEnqueue, rescheduleRequired
   for tcbFault: "obj_at' (\<lambda>tcb. P (tcbFault tcb)) t"
   (wp: threadSet_obj_at'_strongish crunch_wps
-    simp: crunch_simps unless_def)
+   simp: crunch_simps unless_def
+   cong: if_cong)
 
 crunch setThreadState, cancelAllIPC, cancelAllSignals
   for tcbFault: "obj_at' (\<lambda>tcb. P (tcbFault tcb)) t"
-  (wp: threadSet_obj_at'_strongish crunch_wps)
-end
+  (wp: threadSet_obj_at'_strongish crunch_wps
+   cong: if_cong)
 
 lemma sbn_tcbFault:
   "\<lbrace>obj_at' (\<lambda>tcb. P (tcbFault tcb)) t\<rbrace>

--- a/proof/crefine/X64/IsolatedThreadAction.thy
+++ b/proof/crefine/X64/IsolatedThreadAction.thy
@@ -961,13 +961,9 @@ lemma activateThread_simple_rewrite:
 
 end
 
-context notes if_cong[cong] begin
-
 crunch setBoundNotification, cteDeleteOne
   for obj_at_prio[wp]: "obj_at' (\<lambda>tcb. P (tcbPriority tcb)) t"
-  (wp: crunch_wps simp: crunch_simps)
-
-end
+  (wp: crunch_wps simp: crunch_simps cong: if_cong)
 
 lemma setThreadState_no_sch_change:
   "\<lbrace>\<lambda>s. P (ksSchedulerAction s) \<and> (runnable' st \<or> t \<noteq> ksCurThread s)\<rbrace>

--- a/proof/crefine/X64/IsolatedThreadAction.thy
+++ b/proof/crefine/X64/IsolatedThreadAction.thy
@@ -269,7 +269,7 @@ lemma map_to_ctes_partial_overwrite:
   "\<forall>x. tcb_at' (idx x) s \<Longrightarrow>
    map_to_ctes (partial_overwrite idx tsrs (ksPSpace s))
      = ctes_of s"
-  supply if_split[split del]
+  supply if_split[split del] if_cong[cong]
   apply (rule ext)
   apply (frule dom_partial_overwrite[where tsrs=tsrs])
   apply (simp add: map_to_ctes_def partial_overwrite_def
@@ -937,7 +937,8 @@ lemma oblivious_switchToThread_schact:
                    getQueue_def setQueue_def storeWordUser_def setRegister_def
                    pointerInUserData_def isRunnable_def isStopped_def
                    getThreadState_def tcbSchedDequeue_def bitmap_fun_defs
-                   tcbQueueRemove_def ksReadyQueues_asrt_def)
+                   tcbQueueRemove_def ksReadyQueues_asrt_def
+              cong: if_cong)
   by (safe intro!: oblivious_bind
               | simp_all add: ready_qs_runnable_def idleThreadNotQueued_def
                               oblivious_setVMRoot_schact oblivious_lazyFpuRestore_schact)+
@@ -960,9 +961,13 @@ lemma activateThread_simple_rewrite:
 
 end
 
+context notes if_cong[cong] begin
+
 crunch setBoundNotification, cteDeleteOne
   for obj_at_prio[wp]: "obj_at' (\<lambda>tcb. P (tcbPriority tcb)) t"
   (wp: crunch_wps simp: crunch_simps)
+
+end
 
 lemma setThreadState_no_sch_change:
   "\<lbrace>\<lambda>s. P (ksSchedulerAction s) \<and> (runnable' st \<or> t \<noteq> ksCurThread s)\<rbrace>

--- a/proof/refine/AARCH64/ArchCSpace1_R.thy
+++ b/proof/refine/AARCH64/ArchCSpace1_R.thy
@@ -793,6 +793,28 @@ lemma valid_badges_def2[CSpace1_R_assms]:
   apply (auto simp: isCap_simps valid_arch_badges_SMC)
   done
 
+(* FIXME arch-split: theoretically, valid_badges_def3 could be an interface lemma, but:
+   unordered_valid_arch_badges is on AARCH64 only, and this rule is always used with
+   unordered_valid_arch_badges_def, which defeats any attempt at using it generically  *)
+lemma valid_badges_def3:
+  "valid_badges m =
+   (\<forall>p p' cap node cap' node'.
+      m p = Some (CTE cap node) \<longrightarrow>
+      m p' = Some (CTE cap' node') \<longrightarrow>
+      m \<turnstile> p \<leadsto> p' \<longrightarrow>
+      (capMasterCap cap = capMasterCap cap' \<longrightarrow> capBadge cap \<noteq> None \<longrightarrow>
+       capBadge cap \<noteq> capBadge cap' \<longrightarrow> capBadge cap' \<noteq> Some 0 \<longrightarrow> mdbFirstBadged node') \<and>
+      unordered_valid_arch_badges cap cap' node')"
+  apply (simp add: valid_badges_def2)
+  apply (rule iffI; clarsimp simp: valid_arch_badges_implies_unordered)
+  apply (simp add: valid_arch_badges_def)
+  apply (rule conjI; clarsimp)
+   (* SGISignalCap *)
+   apply (fastforce simp: unordered_valid_arch_badges_def)
+  (* SMCCap *)
+  apply (fastforce simp: isCap_simps)
+  done
+
 lemma capRange_SMC[simp]:
   "capRange (ArchObjectCap (SMCCap smc_badge)) = {}"
   by (simp add: capRange_def)

--- a/proof/refine/AARCH64/ArchFinalise_R.thy
+++ b/proof/refine/AARCH64/ArchFinalise_R.thy
@@ -1099,13 +1099,9 @@ lemma archThreadSet_tcbSchedPrevNext[wp]:
   apply auto
   done
 
-context notes if_cong[cong] begin
-
 crunch asUser
   for tcbSchedPrevNext[wp]: "obj_at' (\<lambda>tcb. P (tcbSchedNext tcb) (tcbSchedPrev tcb)) t"
-  (wp: threadGet_wp)
-
-end
+  (wp: threadGet_wp cong: if_cong)
 
 crunch prepareThreadDelete
   for tcbSchedPrevNext[wp]: "obj_at' (\<lambda>tcb. P (tcbSchedNext tcb) (tcbSchedPrev tcb)) t"
@@ -1383,14 +1379,11 @@ crunch dissociateVCPUTCB, unmapPageTable
   (wp: crunch_wps getVCPU_wp getObject_inv hoare_vcg_all_lift hoare_vcg_if_lift3
    simp: loadObject_default_def updateObject_default_def)
 
-context notes if_cong[cong] begin
-
 crunch Arch_finaliseCap
   for nosch[wp]: "\<lambda>s. P (ksSchedulerAction s)"
   (wp: crunch_wps getObject_inv simp: loadObject_default_def updateObject_default_def
-   rule: AARCH64_H.finaliseCap_def)
-
-end
+   rule: AARCH64_H.finaliseCap_def
+   cong: if_cong)
 
 crunch vcpuFinalise, deletingIRQHandler, finaliseCap
   for sch_act_simple[wp]: sch_act_simple

--- a/proof/refine/AARCH64/ArchFinalise_R.thy
+++ b/proof/refine/AARCH64/ArchFinalise_R.thy
@@ -5,11 +5,9 @@
  * SPDX-License-Identifier: GPL-2.0-only
  *)
 
-theory Finalise_R
+theory ArchFinalise_R
 imports
-  ArchIpcCancel_R
-  InterruptAcc_R
-  ArchRetype_R
+  Finalise_R
 begin
 
 context begin interpretation Arch . (*FIXME: arch-split*)

--- a/proof/refine/AARCH64/ArchFinalise_R.thy
+++ b/proof/refine/AARCH64/ArchFinalise_R.thy
@@ -10,502 +10,81 @@ imports
   Finalise_R
 begin
 
-context begin interpretation Arch . (*FIXME: arch-split*)
+context Arch begin arch_global_naming
 
-declare doUnbindNotification_def[simp]
+named_theorems Finalise_R_assms
 
 lemma isArchSGISignalCap_NullCap[simp]:
   "\<not>isArchSGISignalCap NullCap"
   by (simp add: isCap_simps)
 
-text \<open>Properties about empty_slot/emptySlot\<close>
-
-lemma case_Null_If:
-  "(case c of NullCap \<Rightarrow> a | _ \<Rightarrow> b) = (if c = NullCap then a else b)"
-  by (case_tac c, simp_all)
-
-crunch emptySlot
-  for aligned'[wp]: pspace_aligned'
-  and distinct'[wp]: pspace_distinct'
-  and pspace_canonical'[wp]: pspace_canonical'
-  (simp: case_Null_If)
-
-lemma updateCap_cte_wp_at_cases:
-  "\<lbrace>\<lambda>s. (ptr = ptr' \<longrightarrow> cte_wp_at' (P \<circ> cteCap_update (K cap)) ptr' s) \<and> (ptr \<noteq> ptr' \<longrightarrow> cte_wp_at' P ptr' s)\<rbrace>
-     updateCap ptr cap
-   \<lbrace>\<lambda>rv. cte_wp_at' P ptr'\<rbrace>"
-  apply (clarsimp simp: valid_def)
-  apply (drule updateCap_stuff)
-  apply (clarsimp simp: cte_wp_at_ctes_of modify_map_def)
-  done
-
-crunch postCapDeletion, updateTrackedFreeIndex
-  for cte_wp_at'[wp]: "cte_wp_at' P p"
-
-lemma updateFreeIndex_cte_wp_at:
-  "\<lbrace>\<lambda>s. cte_at' p s \<and> P (cte_wp_at' (if p = p' then P'
-      o (cteCap_update (capFreeIndex_update (K idx))) else P') p' s)\<rbrace>
-    updateFreeIndex p idx
-  \<lbrace>\<lambda>rv s. P (cte_wp_at' P' p' s)\<rbrace>"
-  apply (simp add: updateFreeIndex_def updateTrackedFreeIndex_def
-        split del: if_split)
-  apply (rule hoare_pre)
-   apply (wp updateCap_cte_wp_at' getSlotCap_wp)
-  apply (clarsimp simp: cte_wp_at_ctes_of)
-  apply (cases "p' = p", simp_all)
-  apply (case_tac cte, simp)
-  done
-
-lemma emptySlot_cte_wp_cap_other:
-  "\<lbrace>(\<lambda>s. cte_wp_at' (\<lambda>c. P (cteCap c)) p s) and K (p \<noteq> p')\<rbrace>
-  emptySlot p' opt
-  \<lbrace>\<lambda>rv s. cte_wp_at' (\<lambda>c. P (cteCap c)) p s\<rbrace>"
-  apply (rule hoare_gen_asm)
-  apply (simp add: emptySlot_def clearUntypedFreeIndex_def getSlotCap_def)
-  apply (rule hoare_pre)
-   apply (wp updateMDB_weak_cte_wp_at updateCap_cte_wp_at_cases
-             updateFreeIndex_cte_wp_at getCTE_wp' hoare_vcg_all_lift
-              | simp add:  | wpc
-              | wp (once) hoare_drop_imps)+
-  done
+lemma arch_postCapDeletion_ksArchState_lift[Finalise_R_assms]:
+  "\<lbrakk>\<And>s as. P (s\<lparr>ksArchState := as\<rparr>) = P s\<rbrakk> \<Longrightarrow> Arch.postCapDeletion ac \<lbrace>P\<rbrace>"
+  unfolding postCapDeletion_def
+  by wpsimp
 
 lemmas clearUntypedFreeIndex_typ_ats[wp] = typ_at_lifts[OF clearUntypedFreeIndex_typ_at']
 
-crunch postCapDeletion
-  for tcb_at'[wp]: "tcb_at' t"
-crunch emptySlot
-  for ct[wp]: "\<lambda>s. P (ksCurThread s)"
-crunch clearUntypedFreeIndex
-  for cur_tcb'[wp]: "cur_tcb'"
-  (wp: cur_tcb_lift)
+crunch setIRQState
+  for umm[Finalise_R_assms, wp]: "\<lambda>s. P (underlying_memory (ksMachineState s))"
+  (wp: dmo_lift')
 
-crunch emptySlot
-  for ksRQ[wp]: "\<lambda>s. P (ksReadyQueues s)"
-crunch emptySlot
-  for ksRQL1[wp]: "\<lambda>s. P (ksReadyQueuesL1Bitmap s)"
-crunch emptySlot
-  for ksRQL2[wp]: "\<lambda>s. P (ksReadyQueuesL2Bitmap s)"
-crunch postCapDeletion
-  for obj_at'[wp]: "obj_at' P p"
+(* better crunch names for Arch.postCapDeletion *)
+abbreviation (input)
+  "Arch_postCapDeletion \<equiv> Arch.postCapDeletion"
 
-crunch clearUntypedFreeIndex
-  for inQ[wp]: "\<lambda>s. P (obj_at' (inQ d p) t s)"
-crunch clearUntypedFreeIndex
-  for tcbDomain[wp]: "obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t"
-crunch clearUntypedFreeIndex
-  for tcbPriority[wp]: "obj_at' (\<lambda>tcb. P (tcbPriority tcb)) t"
+crunch Arch_postCapDeletion
+  for valid_global_refs[wp]: valid_global_refs'
+  and valid_arch_state'[wp]: valid_arch_state'
+  (rule: AARCH64_H.postCapDeletion_def)
 
-crunch emptySlot
-  for nosch[wp]: "\<lambda>s. P (ksSchedulerAction s)"
-crunch emptySlot
-  for ksCurDomain[wp]: "\<lambda>s. P (ksCurDomain s)"
+lemma arch_postCapDeletion_corres[Finalise_R_assms]:
+  "acap_relation cap cap' \<Longrightarrow> corres dc \<top> \<top> (arch_post_cap_deletion cap) (AARCH64_H.postCapDeletion cap')"
+  by (clarsimp simp: arch_post_cap_deletion_def AARCH64_H.postCapDeletion_def)
 
-lemma emptySlot_sch_act_wf [wp]:
-  "\<lbrace>\<lambda>s. sch_act_wf (ksSchedulerAction s) s\<rbrace>
-  emptySlot sl opt
-  \<lbrace>\<lambda>rv s. sch_act_wf (ksSchedulerAction s) s\<rbrace>"
-  apply (simp add: emptySlot_def case_Null_If)
-  apply (wp sch_act_wf_lift tcb_in_cur_domain'_lift | wpcw | simp)+
-  done
+(* better crunch names for Arch.finaliseCap *)
+abbreviation (input)
+  "Arch_finaliseCap \<equiv> Arch.finaliseCap"
 
-lemma updateCap_valid_objs' [wp]:
-  "\<lbrace>valid_objs' and valid_cap' cap\<rbrace>
-  updateCap ptr cap \<lbrace>\<lambda>r. valid_objs'\<rbrace>"
-  unfolding updateCap_def
-  by (wp setCTE_valid_objs getCTE_wp) (clarsimp dest!: cte_at_cte_wp_atD)
+crunch Arch_finaliseCap, prepareThreadDelete
+  for typ_at'[Finalise_R_assms, wp]: "\<lambda>s. P (typ_at' T p s)"
+  and aligned'[Finalise_R_assms, wp]: "pspace_aligned'"
+  and distinct'[Finalise_R_assms, wp]: "pspace_distinct'"
+  (wp: crunch_wps getObject_inv loadObject_default_inv
+   simp: crunch_simps unless_def o_def
+   ignore_del: setObject
+   rule: AARCH64_H.finaliseCap_def)
 
-lemma updateFreeIndex_valid_objs' [wp]:
-  "\<lbrace>valid_objs'\<rbrace> clearUntypedFreeIndex ptr \<lbrace>\<lambda>r. valid_objs'\<rbrace>"
-  apply (simp add: clearUntypedFreeIndex_def getSlotCap_def)
-  apply (wp getCTE_wp' | wpc | simp add: updateTrackedFreeIndex_def)+
-  done
+crunch prepareThreadDelete, Arch_finaliseCap
+  for it'[Finalise_R_assms, wp]: "\<lambda>s. P (ksIdleThread s)"
+  (wp: hoare_drop_imps
+   simp: crunch_simps updateObject_default_def
+   rule: AARCH64_H.finaliseCap_def)
 
-crunch emptySlot
-  for valid_objs'[wp]: "valid_objs'"
+definition
+  arch_final_matters' :: "arch_capability \<Rightarrow> bool" where
+ "arch_final_matters' acap \<equiv> case acap of
+    FrameCap ref rghts sz d mapdata \<Rightarrow> False
+  | ASIDControlCap \<Rightarrow> False
+  | SMCCap _ \<Rightarrow> False
+  | SGISignalCap _ _ \<Rightarrow> False
+  | _ \<Rightarrow> True"
 
-crunch setInterruptState
-  for state_refs_of'[wp]: "\<lambda>s. P (state_refs_of' s)"
-  (simp: state_refs_of'_pspaceI)
-crunch emptySlot
-  for state_refs_of'[wp]: "\<lambda>s. P (state_refs_of' s)"
-  (wp: crunch_wps)
-crunch setInterruptState
-  for state_hyp_refs_of'[wp]: "\<lambda>s. P (state_hyp_refs_of' s)"
-  (simp: state_hyp_refs_of'_pspaceI)
-crunch emptySlot
-  for state_hyp_refs_of'[wp]: "\<lambda>s. P (state_hyp_refs_of' s)"
-  (wp: crunch_wps)
+definition arch_cap_has_cleanup' :: "arch_capability \<Rightarrow> bool" where
+  "arch_cap_has_cleanup' _ \<equiv> False"
 
-lemma mdb_chunked2D:
-  "\<lbrakk> mdb_chunked m; m \<turnstile> p \<leadsto> p'; m \<turnstile> p' \<leadsto> p'';
-     m p = Some (CTE cap nd); m p'' = Some (CTE cap'' nd'');
-     sameRegionAs cap cap''; p \<noteq> p''; mdb_chunked_arch_assms cap \<rbrakk>
-     \<Longrightarrow> \<exists>cap' nd'. m p' = Some (CTE cap' nd') \<and> sameRegionAs cap cap'"
-  apply (subgoal_tac "\<exists>cap' nd'. m p' = Some (CTE cap' nd')")
-   apply (clarsimp simp add: mdb_chunked_def)
-   apply (drule spec[where x=p])
-   apply (drule spec[where x=p''])
-   apply clarsimp
-   apply (drule mp, erule trancl_into_trancl2)
-    apply (erule trancl.intros(1))
-   apply (simp add: is_chunk_def)
-   apply (drule spec, drule mp, erule trancl.intros(1))
-   apply (drule mp, rule trancl_into_rtrancl)
-    apply (erule trancl.intros(1))
-   apply clarsimp
-  apply (clarsimp simp: mdb_next_unfold)
-  apply (case_tac z, simp)
-  done
+definition
+  "post_cap_delete_pre' cap sl cs \<equiv> case cap of
+     IRQHandlerCap irq \<Rightarrow> irq \<le> maxIRQ \<and> (\<forall>sl'. sl \<noteq> sl' \<longrightarrow> cs sl' \<noteq> Some cap)
+   | _ \<Rightarrow> False"
 
-lemma nullPointer_eq_0_simp[simp]: (* FIXME: move to nullPointer_0_simp in Retype_R *)
-  "(0 = nullPointer) = True"
-  by (simp add: nullPointer_def)+
+end (* Arch *)
 
-lemma no_0_no_0_lhs_trancl [simp]:
-  "no_0 m \<Longrightarrow> \<not> m \<turnstile> 0 \<leadsto>\<^sup>+ x"
-  by (rule, drule tranclD, clarsimp simp: next_unfold')
+arch_requalify_consts
+  arch_final_matters'
+  arch_cap_has_cleanup'
 
-lemma no_0_no_0_lhs_rtrancl [simp]:
-  "\<lbrakk> no_0 m; x \<noteq> 0 \<rbrakk> \<Longrightarrow> \<not> m \<turnstile> 0 \<leadsto>\<^sup>* x"
-  by (clarsimp dest!: rtranclD)
-
-lemma valid_badges_def3: (* FIXME arch-split: interface; used in mdb_empty below and CNodeInv_R *)
-  "valid_badges m =
-   (\<forall>p p' cap node cap' node'.
-      m p = Some (CTE cap node) \<longrightarrow>
-      m p' = Some (CTE cap' node') \<longrightarrow>
-      m \<turnstile> p \<leadsto> p' \<longrightarrow>
-      (capMasterCap cap = capMasterCap cap' \<longrightarrow> capBadge cap \<noteq> None \<longrightarrow>
-       capBadge cap \<noteq> capBadge cap' \<longrightarrow> capBadge cap' \<noteq> Some 0 \<longrightarrow> mdbFirstBadged node') \<and>
-      unordered_valid_arch_badges cap cap' node')"
-  apply (simp add: valid_badges_def2)
-  apply (rule iffI; clarsimp simp: valid_arch_badges_implies_unordered)
-  apply (simp add: valid_arch_badges_def)
-  apply (rule conjI; clarsimp)
-   (* SGISignalCap *)
-   apply (fastforce simp: unordered_valid_arch_badges_def)
-  (* SMCCap *)
-  apply (fastforce simp: isCap_simps)
-  done
-
-end
-
-locale mdb_empty =
-  mdb_ptr?: mdb_ptr m _ _ slot s_cap s_node
-    for m slot s_cap s_node +
-
-  fixes n
-  defines "n \<equiv>
-           modify_map
-             (modify_map
-               (modify_map
-                 (modify_map m (mdbPrev s_node)
-                   (cteMDBNode_update (mdbNext_update (%_. (mdbNext s_node)))))
-                 (mdbNext s_node)
-                 (cteMDBNode_update
-                   (\<lambda>mdb. mdbFirstBadged_update (%_. (mdbFirstBadged mdb \<or> mdbFirstBadged s_node))
-                           (mdbPrev_update (%_. (mdbPrev s_node)) mdb))))
-               slot (cteCap_update (%_. capability.NullCap)))
-              slot (cteMDBNode_update (const nullMDBNode))"
-begin
-
-interpretation Arch . (*FIXME: arch-split*)
-
-lemmas m_slot_prev = m_p_prev
-lemmas m_slot_next = m_p_next
-lemmas prev_slot_next = prev_p_next
-lemmas next_slot_prev = next_p_prev
-
-lemma n_revokable:
-  "n p = Some (CTE cap node) \<Longrightarrow>
-  (\<exists>cap' node'. m p = Some (CTE cap' node') \<and>
-              (if p = slot
-               then \<not> mdbRevocable node
-               else mdbRevocable node = mdbRevocable node'))"
-  by (auto simp add: n_def modify_map_if nullMDBNode_def split: if_split_asm)
-
-lemma m_revokable:
-  "m p = Some (CTE cap node) \<Longrightarrow>
-  (\<exists>cap' node'. n p = Some (CTE cap' node') \<and>
-              (if p = slot
-               then \<not> mdbRevocable node'
-               else mdbRevocable node' = mdbRevocable node))"
-  apply (clarsimp simp add: n_def modify_map_if nullMDBNode_def split: if_split_asm)
-  apply (cases "p=slot", simp)
-  apply (cases "p=mdbNext s_node", simp)
-   apply (cases "p=mdbPrev s_node", simp)
-   apply clarsimp
-  apply simp
-  apply (cases "p=mdbPrev s_node", simp)
-  apply simp
-  done
-
-lemma no_0_n:
-  "no_0 n"
-  using no_0 by (simp add: n_def)
-
-lemma n_next:
-  "n p = Some (CTE cap node) \<Longrightarrow>
-  (\<exists>cap' node'. m p = Some (CTE cap' node') \<and>
-              (if p = slot
-               then mdbNext node = 0
-               else if p = mdbPrev s_node
-               then mdbNext node = mdbNext s_node
-               else mdbNext node = mdbNext node'))"
-  apply (subgoal_tac "p \<noteq> 0")
-   prefer 2
-   apply (insert no_0_n)[1]
-   apply clarsimp
-  apply (cases "p = slot")
-   apply (clarsimp simp: n_def modify_map_if initMDBNode_def split: if_split_asm)
-  apply (cases "p = mdbPrev s_node")
-   apply (auto simp: n_def modify_map_if initMDBNode_def split: if_split_asm)
-  done
-
-lemma n_prev:
-  "n p = Some (CTE cap node) \<Longrightarrow>
-  (\<exists>cap' node'. m p = Some (CTE cap' node') \<and>
-              (if p = slot
-               then mdbPrev node = 0
-               else if p = mdbNext s_node
-               then mdbPrev node = mdbPrev s_node
-               else mdbPrev node = mdbPrev node'))"
-  apply (subgoal_tac "p \<noteq> 0")
-   prefer 2
-   apply (insert no_0_n)[1]
-   apply clarsimp
-  apply (cases "p = slot")
-   apply (clarsimp simp: n_def modify_map_if initMDBNode_def split: if_split_asm)
-  apply (cases "p = mdbNext s_node")
-   apply (auto simp: n_def modify_map_if initMDBNode_def split: if_split_asm)
-  done
-
-lemma n_cap:
-  "n p = Some (CTE cap node) \<Longrightarrow>
-  \<exists>cap' node'. m p = Some (CTE cap' node') \<and>
-              (if p = slot
-               then cap = NullCap
-               else cap' = cap)"
-  apply (clarsimp simp: n_def modify_map_if initMDBNode_def split: if_split_asm)
-   apply (cases node)
-   apply auto
-  done
-
-lemma m_cap:
-  "m p = Some (CTE cap node) \<Longrightarrow>
-  \<exists>cap' node'. n p = Some (CTE cap' node') \<and>
-              (if p = slot
-               then cap' = NullCap
-               else cap' = cap)"
-  apply (clarsimp simp: n_def modify_map_cases initMDBNode_def)
-  apply (cases node)
-  apply clarsimp
-  apply (cases "p=slot", simp)
-  apply clarsimp
-  apply (cases "mdbNext s_node = p", simp)
-   apply fastforce
-  apply simp
-  apply (cases "mdbPrev s_node = p", simp)
-  apply fastforce
-  done
-
-lemma n_badged:
-  "n p = Some (CTE cap node) \<Longrightarrow>
-  \<exists>cap' node'. m p = Some (CTE cap' node') \<and>
-              (if p = slot
-               then \<not> mdbFirstBadged node
-               else if p = mdbNext s_node
-               then mdbFirstBadged node = (mdbFirstBadged node' \<or> mdbFirstBadged s_node)
-               else mdbFirstBadged node = mdbFirstBadged node')"
-  apply (subgoal_tac "p \<noteq> 0")
-   prefer 2
-   apply (insert no_0_n)[1]
-   apply clarsimp
-  apply (cases "p = slot")
-   apply (clarsimp simp: n_def modify_map_if initMDBNode_def split: if_split_asm)
-  apply (cases "p = mdbNext s_node")
-   apply (auto simp: n_def modify_map_if nullMDBNode_def split: if_split_asm)
-  done
-
-lemma m_badged:
-  "m p = Some (CTE cap node) \<Longrightarrow>
-  \<exists>cap' node'. n p = Some (CTE cap' node') \<and>
-              (if p = slot
-               then \<not> mdbFirstBadged node'
-               else if p = mdbNext s_node
-               then mdbFirstBadged node' = (mdbFirstBadged node \<or> mdbFirstBadged s_node)
-               else mdbFirstBadged node' = mdbFirstBadged node)"
-  apply (subgoal_tac "p \<noteq> 0")
-   prefer 2
-   apply (insert no_0_n)[1]
-   apply clarsimp
-  apply (cases "p = slot")
-   apply (clarsimp simp: n_def modify_map_if nullMDBNode_def split: if_split_asm)
-  apply (cases "p = mdbNext s_node")
-   apply (clarsimp simp: n_def modify_map_if nullMDBNode_def split: if_split_asm)
-  apply clarsimp
-  apply (cases "p = mdbPrev s_node")
-   apply (auto simp: n_def modify_map_if initMDBNode_def  split: if_split_asm)
-  done
-
-lemmas slot = m_p
-
-lemma m_next:
-  "m p = Some (CTE cap node) \<Longrightarrow>
-  \<exists>cap' node'. n p = Some (CTE cap' node') \<and>
-              (if p = slot
-               then mdbNext node' = 0
-               else if p = mdbPrev s_node
-               then mdbNext node' = mdbNext s_node
-               else mdbNext node' = mdbNext node)"
-  apply (subgoal_tac "p \<noteq> 0")
-   prefer 2
-   apply clarsimp
-  apply (cases "p = slot")
-   apply (clarsimp simp: n_def modify_map_if)
-  apply (cases "p = mdbPrev s_node")
-   apply (simp add: n_def modify_map_if)
-  apply simp
-  apply (simp add: n_def modify_map_if)
-  apply (cases "mdbNext s_node = p")
-   apply fastforce
-  apply fastforce
-  done
-
-lemma m_prev:
-  "m p = Some (CTE cap node) \<Longrightarrow>
-  \<exists>cap' node'. n p = Some (CTE cap' node') \<and>
-              (if p = slot
-               then mdbPrev node' = 0
-               else if p = mdbNext s_node
-               then mdbPrev node' = mdbPrev s_node
-               else mdbPrev node' = mdbPrev node)"
-  apply (subgoal_tac "p \<noteq> 0")
-   prefer 2
-   apply clarsimp
-  apply (cases "p = slot")
-   apply (clarsimp simp: n_def modify_map_if)
-  apply (cases "p = mdbPrev s_node")
-   apply (simp add: n_def modify_map_if)
-  apply simp
-  apply (simp add: n_def modify_map_if)
-  apply (cases "mdbNext s_node = p")
-   apply fastforce
-  apply fastforce
-  done
-
-lemma n_nextD:
-  "n \<turnstile> p \<leadsto> p' \<Longrightarrow>
-  if p = slot then p' = 0
-  else if p = mdbPrev s_node
-  then m \<turnstile> p \<leadsto> slot \<and> p' = mdbNext s_node
-  else m \<turnstile> p \<leadsto> p'"
-  apply (clarsimp simp: mdb_next_unfold split del: if_split cong: if_cong)
-  apply (case_tac z)
-  apply (clarsimp split del: if_split)
-  apply (drule n_next)
-  apply (elim exE conjE)
-  apply (simp split: if_split_asm)
-  apply (frule dlist_prevD [OF m_slot_prev])
-  apply (clarsimp simp: mdb_next_unfold)
-  done
-
-lemma n_next_eq:
-  "n \<turnstile> p \<leadsto> p' =
-  (if p = slot then p' = 0
-  else if p = mdbPrev s_node
-  then m \<turnstile> p \<leadsto> slot \<and> p' = mdbNext s_node
-  else m \<turnstile> p \<leadsto> p')"
-  apply (rule iffI)
-   apply (erule n_nextD)
-  apply (clarsimp simp: mdb_next_unfold split: if_split_asm)
-    apply (simp add: n_def modify_map_if slot)
-   apply hypsubst_thin
-   apply (case_tac z)
-   apply simp
-   apply (drule m_next)
-   apply clarsimp
-  apply (case_tac z)
-  apply simp
-  apply (drule m_next)
-  apply clarsimp
-  done
-
-lemma n_prev_eq:
-  "n \<turnstile> p \<leftarrow> p' =
-  (if p' = slot then p = 0
-  else if p' = mdbNext s_node
-  then m \<turnstile> slot \<leftarrow> p' \<and> p = mdbPrev s_node
-  else m \<turnstile> p \<leftarrow> p')"
-  apply (rule iffI)
-   apply (clarsimp simp: mdb_prev_def split del: if_split cong: if_cong)
-   apply (case_tac z)
-   apply (clarsimp split del: if_split)
-   apply (drule n_prev)
-   apply (elim exE conjE)
-   apply (simp split: if_split_asm)
-   apply (frule dlist_nextD [OF m_slot_next])
-   apply (clarsimp simp: mdb_prev_def)
-  apply (clarsimp simp: mdb_prev_def split: if_split_asm)
-    apply (simp add: n_def modify_map_if slot)
-   apply hypsubst_thin
-   apply (case_tac z)
-   apply clarsimp
-   apply (drule m_prev)
-   apply clarsimp
-  apply (case_tac z)
-  apply simp
-  apply (drule m_prev)
-  apply clarsimp
-  done
-
-lemma valid_dlist_n:
-  "valid_dlist n" using dlist
-  apply (clarsimp simp: valid_dlist_def2 [OF no_0_n])
-  apply (simp add: n_next_eq n_prev_eq m_slot_next m_slot_prev cong: if_cong)
-  apply (rule conjI, clarsimp)
-   apply (rule conjI, clarsimp simp: next_slot_prev prev_slot_next)
-   apply (fastforce dest!: dlist_prev_src_unique)
-  apply clarsimp
-  apply (rule conjI, clarsimp)
-   apply (clarsimp simp: valid_dlist_def2 [OF no_0])
-   apply (case_tac "mdbNext s_node = 0")
-    apply simp
-    apply (subgoal_tac "m \<turnstile> slot \<leadsto> c'")
-     prefer 2
-     apply fastforce
-    apply (clarsimp simp: mdb_next_unfold slot)
-   apply (frule next_slot_prev)
-   apply (drule (1) dlist_prev_src_unique, simp)
-   apply simp
-  apply clarsimp
-  apply (rule conjI, clarsimp)
-   apply (fastforce dest: dlist_next_src_unique)
-  apply clarsimp
-  apply (rule conjI, clarsimp)
-   apply (clarsimp simp: valid_dlist_def2 [OF no_0])
-   apply (clarsimp simp: mdb_prev_def slot)
-  apply (clarsimp simp: valid_dlist_def2 [OF no_0])
-  done
-
-lemma caps_contained_n:
-  "caps_contained' n"
-  using valid
-  apply (clarsimp simp: valid_mdb_ctes_def caps_contained'_def)
-  apply (drule n_cap)+
-  apply (clarsimp split: if_split_asm)
-  apply (erule disjE, clarsimp)
-  apply clarsimp
-  apply fastforce
-  done
-
-lemma chunked:
-  "mdb_chunked m"
-  using valid ..
-
-lemma valid_badges:
-  "valid_badges m"
-  using valid ..
+context Arch_mdb_empty begin
 
 lemma valid_badges_n:
   "valid_badges n"
@@ -513,6 +92,7 @@ proof -
   from valid_badges
   show ?thesis
     supply if_cong[cong]
+    supply to_slot_eq[simp del]
     apply (simp add: valid_badges_def3)
     apply clarsimp
     apply (rule conjI)
@@ -580,14 +160,6 @@ proof -
     done
 qed
 
-lemma to_slot_eq [simp]:
-  "m \<turnstile> p \<leadsto> slot = (p = mdbPrev s_node \<and> p \<noteq> 0)"
-  apply (rule iffI)
-   apply (frule dlist_nextD0, simp)
-   apply (clarsimp simp: mdb_prev_def slot mdb_next_unfold)
-  apply (clarsimp intro!: prev_slot_next)
-  done
-
 lemma n_parent_of:
   "\<lbrakk> n \<turnstile> p parentOf p'; p \<noteq> slot; p' \<noteq> slot \<rbrakk> \<Longrightarrow> m \<turnstile> p parentOf p'"
   supply if_cong[cong]
@@ -641,30 +213,6 @@ lemma m_parent_of_next:
   apply (rule conjI, fastforce simp: isCap_simps)
   apply (rule conjI, fastforce simp: isCap_simps)
   by (rule conjI; fastforce simp: isCap_simps) (* slow *)
-
-lemma n_mdbNext:
-  "\<lbrakk> n (mdbNext s_node) = Some (CTE cap node); mdbPrev s_node \<noteq> 0 \<rbrakk> \<Longrightarrow>
-  \<exists>node'. m (mdbNext s_node) = Some (CTE cap node') \<and>
-          mdbNext node = mdbNext node' \<and>
-          mdbPrev node = mdbPrev s_node \<and>
-          mdbRevocable node = mdbRevocable node' \<and>
-          (mdbFirstBadged node = mdbFirstBadged node' \<or> mdbFirstBadged s_node)"
-  apply (clarsimp simp: n_def modify_map_def)
-  apply (case_tac z)
-  apply clarsimp
-  done
-
-lemma n_mdbPrev:
-  "\<lbrakk> n (mdbPrev s_node) = Some (CTE cap node); mdbNext s_node \<noteq> 0 \<rbrakk> \<Longrightarrow>
-    \<exists>node'. m (mdbPrev s_node) = Some (CTE cap node') \<and>
-          mdbNext node = mdbNext s_node \<and>
-          mdbPrev node = mdbPrev node' \<and>
-          mdbRevocable node = mdbRevocable node' \<and>
-          (mdbFirstBadged node = mdbFirstBadged node')"
-  apply (clarsimp simp: n_def modify_map_def)
-  apply (case_tac z)
-  apply clarsimp
-  done
 
 lemma parency_n:
   assumes "n \<turnstile> p \<rightarrow> p'"
@@ -848,578 +396,50 @@ next
     done
 qed
 
-lemma parency_m:
-  assumes "m \<turnstile> p \<rightarrow> p'"
-  shows "p \<noteq> slot \<longrightarrow> (if p' \<noteq> slot then n \<turnstile> p \<rightarrow> p' else m \<turnstile> p \<rightarrow> mdbNext s_node \<longrightarrow> n \<turnstile> p \<rightarrow> mdbNext s_node)"
-using assms
-proof induct
-  case (direct_parent c)
-  thus ?case
-    apply clarsimp
-    apply (rule conjI)
-     apply clarsimp
-     apply (rule subtree.direct_parent)
-       apply (simp add: n_next_eq)
-       apply clarsimp
-       apply (subgoal_tac "mdbPrev s_node \<noteq> 0")
-        prefer 2
-        apply (clarsimp simp: mdb_next_unfold)
-       apply (drule prev_slot_next)
-       apply (clarsimp simp: mdb_next_unfold)
-      apply assumption
-     apply (erule m_parent_of, simp, simp)
-      apply clarsimp
-     apply clarsimp
-     apply (drule dlist_next_src_unique)
-       apply fastforce
-      apply clarsimp
-     apply simp
-    apply clarsimp
-    apply (rule subtree.direct_parent)
-      apply (simp add: n_next_eq)
-     apply (drule subtree_parent)
-     apply (clarsimp simp: parentOf_def)
-    apply (drule subtree_parent)
-    apply (erule (1) m_parent_of_next)
-     apply clarsimp
-    apply clarsimp
-    done
-next
-  case (trans_parent c c')
-  thus ?case
-    apply clarsimp
-    apply (rule conjI)
-     apply clarsimp
-     apply (cases "c=slot")
-      apply simp
-      apply (erule impE)
-       apply (erule subtree.trans_parent)
-         apply fastforce
-        apply (clarsimp simp: slot mdb_next_unfold)
-       apply (clarsimp simp: slot mdb_next_unfold)
-      apply (clarsimp simp: slot mdb_next_unfold)
-     apply clarsimp
-     apply (erule subtree.trans_parent)
-       apply (simp add: n_next_eq)
-       apply clarsimp
-       apply (subgoal_tac "mdbPrev s_node \<noteq> 0")
-        prefer 2
-        apply (clarsimp simp: mdb_next_unfold)
-       apply (drule prev_slot_next)
-       apply (clarsimp simp: mdb_next_unfold)
-      apply assumption
-     apply (erule m_parent_of, simp, simp)
-      apply clarsimp
-      apply (drule subtree_mdb_next)
-      apply (drule trancl_trans)
-       apply (erule r_into_trancl)
-      apply simp
-     apply clarsimp
-     apply (drule dlist_next_src_unique)
-       apply fastforce
-      apply clarsimp
-     apply simp
-    apply clarsimp
-    apply (erule subtree.trans_parent)
-      apply (simp add: n_next_eq)
-     apply clarsimp
-    apply (rule m_parent_of_next, erule subtree_parent, assumption, assumption)
-    apply clarsimp
-    done
+end (* Arch_mdb_empty *)
+
+context mdb_empty begin
+
+lemmas gen_arch_assms =
+  Arch_mdb_empty.valid_badges_n
+  Arch_mdb_empty.parency_n
+  Arch_mdb_empty.m_parent_of
+  Arch_mdb_empty.m_parent_of_next
+
+(* extract arch-dependent assumptions of mdb_empty_gen proved in Arch_mdb_empty
+   (faster than interpreting Arch) *)
+lemmas gen_assms = gen_arch_assms[unfolded Arch_mdb_empty_def, OF mdb_empty_axioms]
+
+sublocale mdb_empty_gen
+  by (unfold_locales)
+     (blast intro!: gen_assms)+
+
+(* re-bind names *)
+lemmas vmdb_n = vmdb_n
+lemmas descendants = descendants
+
+end (* mdb_empty *)
+
+interpretation Finalise_R?: Finalise_R arch_final_matters' arch_cap_has_cleanup'
+proof goal_cases
+  interpret Arch  .
+  case 1 show ?case by (intro_locales; (unfold_locales; (fact Finalise_R_assms)?)?)
 qed
 
-lemma parency:
-  "n \<turnstile> p \<rightarrow> p' = (p \<noteq> slot \<and> p' \<noteq> slot \<and> m \<turnstile> p \<rightarrow> p')"
-  by (auto dest!: parency_n parency_m)
+context Arch begin arch_global_naming
 
-lemma descendants:
-  "descendants_of' p n =
-  (if p = slot then {} else descendants_of' p m - {slot})"
-  by (auto simp add: parency descendants_of'_def)
+named_theorems Finalise_R_2_assms
 
-lemma n_tranclD:
-  "n \<turnstile> p \<leadsto>\<^sup>+ p' \<Longrightarrow> m \<turnstile> p \<leadsto>\<^sup>+ p' \<and> p' \<noteq> slot"
-  apply (erule trancl_induct)
-   apply (clarsimp simp add: n_next_eq split: if_split_asm)
-     apply (rule mdb_chain_0D)
-      apply (rule chain)
-     apply (clarsimp simp: slot)
-    apply (blast intro: trancl_trans prev_slot_next)
-   apply fastforce
-  apply (clarsimp simp: n_next_eq split: if_split_asm)
-   apply (erule trancl_trans)
-   apply (blast intro: trancl_trans prev_slot_next)
-  apply (fastforce intro: trancl_trans)
-  done
-
-lemma m_tranclD:
-  "m \<turnstile> p \<leadsto>\<^sup>+ p' \<Longrightarrow>
-  if p = slot then n \<turnstile> mdbNext s_node \<leadsto>\<^sup>* p'
-  else if p' = slot then n \<turnstile> p \<leadsto>\<^sup>+ mdbNext s_node
-  else n \<turnstile> p \<leadsto>\<^sup>+ p'"
-  using no_0_n
-  apply -
-  apply (erule trancl_induct)
-   apply clarsimp
-   apply (rule conjI)
-    apply clarsimp
-    apply (rule r_into_trancl)
-    apply (clarsimp simp: n_next_eq)
-   apply clarsimp
-   apply (rule conjI)
-    apply (insert m_slot_next)[1]
-    apply (clarsimp simp: mdb_next_unfold)
-   apply clarsimp
-   apply (rule r_into_trancl)
-   apply (clarsimp simp: n_next_eq)
-   apply (rule context_conjI)
-    apply (clarsimp simp: mdb_next_unfold)
-   apply (drule prev_slot_next)
-   apply (clarsimp simp: mdb_next_unfold)
-  apply clarsimp
-  apply (rule conjI)
-   apply clarsimp
-   apply (rule conjI)
-    apply clarsimp
-    apply (drule prev_slot_next)
-    apply (drule trancl_trans, erule r_into_trancl)
-    apply simp
-   apply clarsimp
-   apply (erule trancl_trans)
-   apply (rule r_into_trancl)
-   apply (simp add: n_next_eq)
-  apply clarsimp
-  apply (rule conjI)
-   apply clarsimp
-   apply (erule rtrancl_trans)
-   apply (rule r_into_rtrancl)
-   apply (simp add: n_next_eq)
-   apply (rule conjI)
-    apply clarsimp
-    apply (rule context_conjI)
-     apply (clarsimp simp: mdb_next_unfold)
-    apply (drule prev_slot_next)
-    apply (clarsimp simp: mdb_next_unfold)
-   apply clarsimp
-  apply clarsimp
-  apply (simp split: if_split_asm)
-   apply (clarsimp simp: mdb_next_unfold slot)
-  apply (erule trancl_trans)
-  apply (rule r_into_trancl)
-  apply (clarsimp simp add: n_next_eq)
-  apply (rule context_conjI)
-   apply (clarsimp simp: mdb_next_unfold)
-  apply (drule prev_slot_next)
-  apply (clarsimp simp: mdb_next_unfold)
-  done
-
-lemma n_trancl_eq:
-  "n \<turnstile> p \<leadsto>\<^sup>+ p' = (m \<turnstile> p \<leadsto>\<^sup>+ p' \<and> (p = slot \<longrightarrow> p' = 0) \<and> p' \<noteq> slot)"
-  using no_0_n
-  apply -
-  apply (rule iffI)
-   apply (frule n_tranclD)
-   apply clarsimp
-   apply (drule tranclD)
-   apply (clarsimp simp: n_next_eq)
-   apply (simp add: rtrancl_eq_or_trancl)
-  apply clarsimp
-  apply (drule m_tranclD)
-  apply (simp split: if_split_asm)
-  apply (rule r_into_trancl)
-  apply (simp add: n_next_eq)
-  done
-
-lemma n_rtrancl_eq:
-  "n \<turnstile> p \<leadsto>\<^sup>* p' =
-  (m \<turnstile> p \<leadsto>\<^sup>* p' \<and>
-   (p = slot \<longrightarrow> p' = 0 \<or> p' = slot) \<and>
-   (p' = slot \<longrightarrow> p = slot))"
-  by (auto simp: rtrancl_eq_or_trancl n_trancl_eq)
-
-lemma mdb_chain_0_n:
-  "mdb_chain_0 n"
-  using chain
-  apply (clarsimp simp: mdb_chain_0_def)
-  apply (drule bspec)
-   apply (fastforce simp: n_def modify_map_if split: if_split_asm)
-  apply (simp add: n_trancl_eq)
-  done
-
-lemma mdb_chunked_n:
-  "mdb_chunked n"
-  using chunked
-  apply (clarsimp simp: mdb_chunked_def)
-  apply (drule n_cap)+
-  apply (clarsimp split: if_split_asm)
-  apply (case_tac "p=slot", clarsimp)
-  apply clarsimp
-  apply (erule_tac x=p in allE)
-  apply (erule_tac x=p' in allE)
-  apply (clarsimp simp: is_chunk_def)
-  apply (simp add: n_trancl_eq n_rtrancl_eq)
-  apply (rule conjI)
-   apply clarsimp
-   apply (erule_tac x=p'' in allE)
-   apply clarsimp
-   apply (drule_tac p=p'' in m_cap)
-   apply clarsimp
-  apply clarsimp
-  apply (erule_tac x=p'' in allE)
-  apply clarsimp
-  apply (drule_tac p=p'' in m_cap)
-  apply clarsimp
-  done
-
-lemma untyped_mdb_n:
-  "untyped_mdb' n"
-  using untyped_mdb
-  apply (simp add: untyped_mdb'_def descendants_of'_def parency)
-  apply clarsimp
-  apply (drule n_cap)+
-  apply (clarsimp split: if_split_asm)
-  apply (case_tac "p=slot", simp)
-  apply clarsimp
-  done
-
-lemma untyped_inc_n:
-  "untyped_inc' n"
-  using untyped_inc
-  apply (simp add: untyped_inc'_def descendants_of'_def parency)
-  apply clarsimp
-  apply (drule n_cap)+
-  apply (clarsimp split: if_split_asm)
-  apply (case_tac "p=slot", simp)
-  apply clarsimp
-  apply (erule_tac x=p in allE)
-  apply (erule_tac x=p' in allE)
-  apply simp
-  done
-
-lemmas vn_prev [dest!] = valid_nullcaps_prev [OF _ slot no_0 dlist nullcaps]
-lemmas vn_next [dest!] = valid_nullcaps_next [OF _ slot no_0 dlist nullcaps]
-
-lemma nullcaps_n: "valid_nullcaps n"
-proof -
-  from valid have "valid_nullcaps m" ..
-  thus ?thesis
-    apply (clarsimp simp: valid_nullcaps_def nullMDBNode_def nullPointer_def)
-    apply (frule n_cap)
-    apply (frule n_next)
-    apply (frule n_badged)
-    apply (frule n_revokable)
-    apply (drule n_prev)
-    apply (case_tac n)
-    apply (insert slot)
-    apply (fastforce split: if_split_asm)
-    done
-qed
-
-lemma ut_rev_n: "ut_revocable' n"
-  apply(insert valid)
-  apply(clarsimp simp: ut_revocable'_def)
-  apply(frule n_cap)
-  apply(drule n_revokable)
-  apply(clarsimp simp: isCap_simps split: if_split_asm)
-  apply(simp add: valid_mdb_ctes_def ut_revocable'_def)
-  done
-
-lemma class_links_n: "class_links n"
-  using valid slot
-  apply (clarsimp simp: valid_mdb_ctes_def class_links_def)
-  apply (case_tac cte, case_tac cte')
-  apply (drule n_nextD)
-  apply (clarsimp simp: split: if_split_asm)
-    apply (simp add: no_0_n)
-   apply (drule n_cap)+
-   apply clarsimp
-   apply (frule spec[where x=slot],
-          drule spec[where x="mdbNext s_node"],
-          simp, simp add: m_slot_next)
-   apply (drule spec[where x="mdbPrev s_node"],
-          drule spec[where x=slot], simp)
-  apply (drule n_cap)+
-  apply clarsimp
-  apply (fastforce split: if_split_asm)
-  done
-
-lemma distinct_zombies_m: "distinct_zombies m"
-  using valid by (simp add: valid_mdb_ctes_def)
-
-lemma distinct_zombies_n[simp]:
-  "distinct_zombies n"
-  using distinct_zombies_m
-  apply (simp add: n_def distinct_zombies_nonCTE_modify_map)
-  apply (subst modify_map_apply[where p=slot])
-   apply (simp add: modify_map_def slot)
-  apply simp
-  apply (rule distinct_zombies_sameMasterE)
-    apply (simp add: distinct_zombies_nonCTE_modify_map)
-   apply (simp add: modify_map_def slot)
-  apply simp
-  done
-
-lemma irq_control_n [simp]: "irq_control n"
-  using slot
-  apply (clarsimp simp: irq_control_def)
-  apply (frule n_revokable)
-  apply (drule n_cap)
-  apply (clarsimp split: if_split_asm)
-  apply (frule irq_revocable, rule irq_control)
-  apply clarsimp
-  apply (drule n_cap)
-  apply (clarsimp simp: if_split_asm)
-  apply (erule (1) irq_controlD, rule irq_control)
-  done
-
-lemma reply_masters_rvk_fb_m: "reply_masters_rvk_fb m"
-  using valid by auto
-
-lemma reply_masters_rvk_fb_n [simp]: "reply_masters_rvk_fb n"
-  using reply_masters_rvk_fb_m
-  apply (simp add: reply_masters_rvk_fb_def n_def
-                   ball_ran_modify_map_eq
-                   modify_map_comp[symmetric])
-  apply (subst ball_ran_modify_map_eq)
-   apply (frule bspec, rule ranI, rule slot)
-   apply (simp add: nullMDBNode_def isCap_simps modify_map_def
-                    slot)
-  apply (subst ball_ran_modify_map_eq)
-   apply (clarsimp simp add: modify_map_def)
-   apply fastforce
-  apply (simp add: ball_ran_modify_map_eq)
-  done
-
-lemma vmdb_n: "valid_mdb_ctes n"
-  by (simp add: valid_mdb_ctes_def valid_dlist_n
-                no_0_n mdb_chain_0_n valid_badges_n
-                caps_contained_n mdb_chunked_n
-                untyped_mdb_n untyped_inc_n
-                nullcaps_n ut_rev_n class_links_n)
-
-end
-
-context begin interpretation Arch .
-crunch postCapDeletion, clearUntypedFreeIndex
-  for ctes_of[wp]: "\<lambda>s. P (ctes_of s)"
-
-lemma emptySlot_mdb [wp]:
-  "\<lbrace>valid_mdb'\<rbrace>
-  emptySlot sl opt
-  \<lbrace>\<lambda>_. valid_mdb'\<rbrace>"
-  unfolding emptySlot_def
-  apply (simp only: case_Null_If valid_mdb'_def)
-  apply (wp updateCap_ctes_of_wp getCTE_wp'
-            opt_return_pres_lift | simp add: cte_wp_at_ctes_of)+
-  apply (clarsimp)
-  apply (case_tac cte)
-  apply (rename_tac cap node)
-  apply (simp)
-  apply (subgoal_tac "mdb_empty (ctes_of s) sl cap node")
-   prefer 2
-   apply (rule mdb_empty.intro)
-   apply (rule mdb_ptr.intro)
-    apply (rule vmdb.intro)
-    apply (simp add: valid_mdb_ctes_def)
-   apply (rule mdb_ptr_axioms.intro)
-   apply (simp add: cte_wp_at_ctes_of)
-  apply (rule conjI, clarsimp simp: valid_mdb_ctes_def)
-  apply (erule mdb_empty.vmdb_n[unfolded const_def])
-  done
-end
-
-lemma if_live_then_nonz_cap'_def2:
-  "if_live_then_nonz_cap' =
-   (\<lambda>s. \<forall>ptr. ko_wp_at' live' ptr s \<longrightarrow>
-              (\<exists>p zr. (option_map zobj_refs' o cteCaps_of s) p = Some zr \<and> ptr \<in> zr))"
-  by (fastforce simp: if_live_then_nonz_cap'_def ex_nonz_cap_to'_def cte_wp_at_ctes_of
-                      cteCaps_of_def)
-
-lemma updateMDB_ko_wp_at_live[wp]:
-  "\<lbrace>\<lambda>s. P (ko_wp_at' live' p' s)\<rbrace>
-      updateMDB p m
-   \<lbrace>\<lambda>rv s. P (ko_wp_at' live' p' s)\<rbrace>"
-  unfolding updateMDB_def Let_def
-  apply (rule hoare_pre, wp)
-  apply simp
-  done
-
-lemma updateCap_ko_wp_at_live[wp]:
-  "\<lbrace>\<lambda>s. P (ko_wp_at' live' p' s)\<rbrace>
-      updateCap p cap
-   \<lbrace>\<lambda>rv s. P (ko_wp_at' live' p' s)\<rbrace>"
-  unfolding updateCap_def
-  by wp
-
-primrec
-  threadCapRefs :: "capability \<Rightarrow> machine_word set"
-where
-  "threadCapRefs (ThreadCap r)                  = {r}"
-| "threadCapRefs (ReplyCap t m x)               = {}"
-| "threadCapRefs NullCap                        = {}"
-| "threadCapRefs (UntypedCap d r n i)           = {}"
-| "threadCapRefs (EndpointCap r badge x y z t)  = {}"
-| "threadCapRefs (NotificationCap r badge x y)  = {}"
-| "threadCapRefs (CNodeCap r b g gsz)           = {}"
-| "threadCapRefs (Zombie r b n)                 = {}"
-| "threadCapRefs (ArchObjectCap ac)             = {}"
-| "threadCapRefs (IRQHandlerCap irq)            = {}"
-| "threadCapRefs (IRQControlCap)                = {}"
-| "threadCapRefs (DomainCap)                    = {}"
-
-definition
-  "isFinal cap p m \<equiv>
-  \<not>isUntypedCap cap \<and>
-  (\<forall>p' c. m p' = Some c \<longrightarrow>
-          p \<noteq> p' \<longrightarrow> \<not>isUntypedCap c \<longrightarrow>
-          \<not> sameObjectAs cap c)"
-
-lemma not_FinalE:
-  "\<lbrakk> \<not> isFinal cap sl cps; isUntypedCap cap \<Longrightarrow> P;
-     \<And>p c. \<lbrakk> cps p = Some c; p \<noteq> sl; \<not> isUntypedCap c; sameObjectAs cap c \<rbrakk> \<Longrightarrow> P
-    \<rbrakk> \<Longrightarrow> P"
-  by (fastforce simp: isFinal_def)
-
-definition
- "removeable' sl \<equiv> \<lambda>s cap.
-    (\<exists>p. p \<noteq> sl \<and> cte_wp_at' (\<lambda>cte. capMasterCap (cteCap cte) = capMasterCap cap) p s)
-    \<or> ((\<forall>p \<in> cte_refs' cap (irq_node' s). p \<noteq> sl \<longrightarrow> cte_wp_at' (\<lambda>cte. cteCap cte = NullCap) p s)
-         \<and> (\<forall>p \<in> zobj_refs' cap. ko_wp_at' (Not \<circ> live') p s))"
-
-lemma not_Final_removeable:
-  "\<not> isFinal cap sl (cteCaps_of s)
-    \<Longrightarrow> removeable' sl s cap"
+lemma not_Final_removeable[Finalise_R_2_assms]:
+  "\<not> isFinal cap sl (cteCaps_of s) \<Longrightarrow> removeable' sl s cap"
   apply (erule not_FinalE)
    apply (clarsimp simp: removeable'_def gen_isCap_simps)
   apply (clarsimp simp: cteCaps_of_def AARCH64.sameObjectAs_def2 removeable'_def
-                        cte_wp_at_ctes_of) (* FIXME arch-split *)
+                        cte_wp_at_ctes_of)
   apply fastforce
   done
 
-context begin interpretation Arch .
-crunch postCapDeletion
-  for ko_wp_at'[wp]: "\<lambda>s. P (ko_wp_at' P' p s)"
-crunch postCapDeletion
-  for cteCaps_of[wp]: "\<lambda>s. P (cteCaps_of s)"
-  (simp: cteCaps_of_def o_def)
-end
-
-crunch clearUntypedFreeIndex
-  for ko_at_live[wp]: "\<lambda>s. P (ko_wp_at' live' ptr s)"
-
-lemma clearUntypedFreeIndex_cteCaps_of[wp]:
-  "\<lbrace>\<lambda>s. P (cteCaps_of s)\<rbrace>
-       clearUntypedFreeIndex sl \<lbrace>\<lambda>y s. P (cteCaps_of s)\<rbrace>"
-  by (simp add: cteCaps_of_def, wp)
-
-lemma emptySlot_iflive'[wp]:
-  "\<lbrace>\<lambda>s. if_live_then_nonz_cap' s \<and> cte_wp_at' (\<lambda>cte. removeable' sl s (cteCap cte)) sl s\<rbrace>
-     emptySlot sl opt
-   \<lbrace>\<lambda>rv. if_live_then_nonz_cap'\<rbrace>"
-  apply (simp add: emptySlot_def case_Null_If if_live_then_nonz_cap'_def2
-              del: comp_apply)
-  apply (rule hoare_pre)
-   apply (wp hoare_vcg_all_lift hoare_vcg_disj_lift
-             getCTE_wp opt_return_pres_lift
-             clearUntypedFreeIndex_ctes_of
-             clearUntypedFreeIndex_cteCaps_of
-             hoare_vcg_ex_lift
-             | wp (once) hoare_vcg_imp_lift
-             | simp add: cte_wp_at_ctes_of del: comp_apply)+
-  apply (clarsimp simp: modify_map_same imp_conjR[symmetric])
-  apply (drule spec, drule(1) mp)
-  apply (clarsimp simp: cte_wp_at_ctes_of modify_map_def split: if_split_asm)
-  apply (case_tac "p \<noteq> sl")
-   apply blast
-  apply (simp add: removeable'_def cteCaps_of_def)
-  apply (erule disjE)
-   apply (clarsimp simp: cte_wp_at_ctes_of modify_map_def
-                  dest!: capMaster_same_refs)
-   apply fastforce
-  apply clarsimp
-  apply (drule(1) bspec)
-  apply (clarsimp simp: ko_wp_at'_def)
-  done
-
-lemma setIRQState_irq_node'[wp]:
-  "\<lbrace>\<lambda>s. P (irq_node' s)\<rbrace> setIRQState state irq \<lbrace>\<lambda>_ s. P (irq_node' s)\<rbrace>"
-  apply (simp add: setIRQState_def setInterruptState_def getInterruptState_def)
-  apply wp
-  apply simp
-  done
-
-context begin interpretation Arch .
-crunch emptySlot
-  for irq_node'[wp]: "\<lambda>s. P (irq_node' s)"
-end
-
-lemma emptySlot_ifunsafe'[wp]:
-  "\<lbrace>\<lambda>s. if_unsafe_then_cap' s \<and> cte_wp_at' (\<lambda>cte. removeable' sl s (cteCap cte)) sl s\<rbrace>
-     emptySlot sl opt
-   \<lbrace>\<lambda>rv. if_unsafe_then_cap'\<rbrace>"
-  apply (simp add: ifunsafe'_def3)
-  apply (rule hoare_pre, rule hoare_use_eq_irq_node'[OF emptySlot_irq_node'])
-   apply (simp add: emptySlot_def case_Null_If)
-   apply (wp opt_return_pres_lift | simp add: o_def)+
-   apply (wp getCTE_cteCap_wp clearUntypedFreeIndex_cteCaps_of)+
-  apply (clarsimp simp: tree_cte_cteCap_eq[unfolded o_def]
-                        modify_map_same
-                        modify_map_comp[symmetric]
-                 split: option.split_asm if_split_asm
-                 dest!: modify_map_K_D)
-  apply (clarsimp simp: modify_map_def)
-  apply (drule_tac x=cref in spec, clarsimp)
-  apply (case_tac "cref' \<noteq> sl")
-   apply (rule_tac x=cref' in exI)
-   apply (clarsimp simp: modify_map_def)
-  apply (simp add: removeable'_def)
-  apply (erule disjE)
-   apply (clarsimp simp: modify_map_def)
-   apply (subst(asm) tree_cte_cteCap_eq[unfolded o_def])
-   apply (clarsimp split: option.split_asm dest!: capMaster_same_refs)
-   apply fastforce
-  apply clarsimp
-  apply (drule(1) bspec)
-  apply (clarsimp simp: cte_wp_at_ctes_of cteCaps_of_def)
-  done
-
-lemmas ctes_of_valid'[elim] = ctes_of_valid_cap''[where r=cte for cte]
-
-crunch setInterruptState
-  for valid_idle'[wp]: "valid_idle'"
-  (simp: valid_idle'_def)
-
-context begin interpretation Arch .
-crunch emptySlot
-  for valid_idle'[wp]: "valid_idle'"
-crunch deletedIRQHandler, getSlotCap, clearUntypedFreeIndex, updateMDB, getCTE, updateCap
-  for ksArch[wp]: "\<lambda>s. P (ksArchState s)"
-crunch emptySlot
-  for ksIdle[wp]: "\<lambda>s. P (ksIdleThread s)"
-crunch emptySlot
-  for gsMaxObjectSize[wp]: "\<lambda>s. P (gsMaxObjectSize s)"
-end
-
-lemma emptySlot_cteCaps_of:
-  "\<lbrace>\<lambda>s. P ((cteCaps_of s)(p \<mapsto> NullCap))\<rbrace>
-     emptySlot p opt
-   \<lbrace>\<lambda>rv s. P (cteCaps_of s)\<rbrace>"
-  apply (simp add: emptySlot_def case_Null_If)
-  apply (wp opt_return_pres_lift getCTE_cteCap_wp
-            clearUntypedFreeIndex_cteCaps_of)
-  apply (clarsimp simp: cteCaps_of_def cte_wp_at_ctes_of)
-  apply (auto elim!: rsubst[where P=P]
-               simp: modify_map_def fun_upd_def[symmetric] o_def
-                     fun_upd_idem cteCaps_of_def
-              split: option.splits)
-  done
-
-context begin interpretation Arch .
-
-crunch deletedIRQHandler
-  for cteCaps_of[wp]: "\<lambda>s. P (cteCaps_of s)"
-
-lemma deletedIRQHandler_valid_global_refs[wp]:
+lemma deletedIRQHandler_valid_global_refs[Finalise_R_2_assms, wp]:
   "\<lbrace>valid_global_refs'\<rbrace> deletedIRQHandler irq \<lbrace>\<lambda>rv. valid_global_refs'\<rbrace>"
   apply (clarsimp simp: valid_global_refs'_def global_refs'_def)
   apply (rule hoare_pre)
@@ -1433,7 +453,7 @@ lemma deletedIRQHandler_valid_global_refs[wp]:
   apply (clarsimp simp: valid_refs'_cteCaps valid_cap_sizes_cteCaps ball_ran_eq)
   done
 
-lemma clearUntypedFreeIndex_valid_global_refs[wp]:
+lemma clearUntypedFreeIndex_valid_global_refs[Finalise_R_2_assms, wp]:
   "\<lbrace>valid_global_refs'\<rbrace> clearUntypedFreeIndex irq \<lbrace>\<lambda>rv. valid_global_refs'\<rbrace>"
   apply (clarsimp simp: valid_global_refs'_def global_refs'_def)
   apply (rule hoare_pre)
@@ -1447,549 +467,44 @@ lemma clearUntypedFreeIndex_valid_global_refs[wp]:
   apply (clarsimp simp: valid_refs'_cteCaps valid_cap_sizes_cteCaps ball_ran_eq)
   done
 
-crunch global.postCapDeletion
-  for valid_global_refs[wp]: "valid_global_refs'"
-
-lemma emptySlot_valid_global_refs[wp]:
-  "\<lbrace>valid_global_refs' and cte_at' sl\<rbrace> emptySlot sl opt \<lbrace>\<lambda>rv. valid_global_refs'\<rbrace>"
-  apply (clarsimp simp: emptySlot_def)
-  apply (wpsimp wp: getCTE_wp hoare_drop_imps hoare_vcg_ex_lift simp: cte_wp_at_ctes_of)
-  apply (clarsimp simp: valid_global_refs'_def global_refs'_def)
-  apply (frule(1) cte_at_valid_cap_sizes_0)
-  apply (clarsimp simp: valid_refs'_cteCaps valid_cap_sizes_cteCaps ball_ran_eq)
-  done
-end
-
-lemmas doMachineOp_irq_handlers[wp]
-    = valid_irq_handlers_lift'' [OF doMachineOp_ctes doMachineOp_ksInterruptState]
-
-lemma deletedIRQHandler_irq_handlers'[wp]:
-  "\<lbrace>\<lambda>s. valid_irq_handlers' s \<and> (IRQHandlerCap irq \<notin> ran (cteCaps_of s))\<rbrace>
-       deletedIRQHandler irq
-   \<lbrace>\<lambda>rv. valid_irq_handlers'\<rbrace>"
-  apply (simp add: deletedIRQHandler_def setIRQState_def setInterruptState_def getInterruptState_def)
-  apply wp
-  apply (clarsimp simp: valid_irq_handlers'_def irq_issued'_def ran_def cteCaps_of_def)
-  done
-
-context begin interpretation Arch .
-
-lemma postCapDeletion_irq_handlers'[wp]:
-  "\<lbrace>\<lambda>s. valid_irq_handlers' s \<and> (cap \<noteq> NullCap \<longrightarrow> cap \<notin> ran (cteCaps_of s))\<rbrace>
-       postCapDeletion cap
-   \<lbrace>\<lambda>rv. valid_irq_handlers'\<rbrace>"
-  by (wpsimp simp: Retype_H.postCapDeletion_def AARCH64_H.postCapDeletion_def)
-
-definition
-  "post_cap_delete_pre' cap sl cs \<equiv> case cap of
-     IRQHandlerCap irq \<Rightarrow> irq \<le> maxIRQ \<and> (\<forall>sl'. sl \<noteq> sl' \<longrightarrow> cs sl' \<noteq> Some cap)
-   | _ \<Rightarrow> False"
-
-end
-
-crunch clearUntypedFreeIndex
-  for ksInterruptState[wp]: "\<lambda>s. P (ksInterruptState s)"
-
-lemma emptySlot_valid_irq_handlers'[wp]:
-  "\<lbrace>\<lambda>s. valid_irq_handlers' s
-          \<and> (\<forall>sl'. info \<noteq> NullCap \<longrightarrow> sl' \<noteq> sl \<longrightarrow> cteCaps_of s sl' \<noteq> Some info)\<rbrace>
-     emptySlot sl info
-   \<lbrace>\<lambda>rv. valid_irq_handlers'\<rbrace>"
-  apply (simp add: emptySlot_def case_Null_If)
-  apply (wp | wpc)+
-        apply (unfold valid_irq_handlers'_def irq_issued'_def)
-        apply (wp getCTE_cteCap_wp clearUntypedFreeIndex_cteCaps_of
-          | wps clearUntypedFreeIndex_ksInterruptState)+
-  apply (clarsimp simp: cteCaps_of_def cte_wp_at_ctes_of ran_def modify_map_def
-                 split: option.split)
-  apply auto
-  done
-
-context begin interpretation Arch .
-crunch emptySlot
-  for irq_states'[wp]: valid_irq_states'
-
-crunch emptySlot
-  for no_0_obj'[wp]: no_0_obj'
- (wp: crunch_wps)
-
-lemma deletedIRQHandler_irqs_masked'[wp]:
-  "\<lbrace>irqs_masked'\<rbrace> deletedIRQHandler irq \<lbrace>\<lambda>_. irqs_masked'\<rbrace>"
-  apply (simp add: deletedIRQHandler_def setIRQState_def getInterruptState_def setInterruptState_def)
-  apply (wp dmo_maskInterrupt)
-  apply (simp add: irqs_masked'_def)
-  done
-
-crunch emptySlot
-  for irqs_masked'[wp]: "irqs_masked'"
-
-lemma setIRQState_umm:
- "\<lbrace>\<lambda>s. P (underlying_memory (ksMachineState s))\<rbrace>
-   setIRQState irqState irq
-  \<lbrace>\<lambda>_ s. P (underlying_memory (ksMachineState s))\<rbrace>"
-  by (simp add: setIRQState_def maskInterrupt_def
-                setInterruptState_def getInterruptState_def
-      | wp dmo_lift')+
-
-crunch emptySlot
-  for umm[wp]: "\<lambda>s. P (underlying_memory (ksMachineState s))"
-  (wp: setIRQState_umm)
-
-lemma emptySlot_vms'[wp]:
-  "\<lbrace>valid_machine_state'\<rbrace> emptySlot slot irq \<lbrace>\<lambda>_. valid_machine_state'\<rbrace>"
-  by (simp add: valid_machine_state'_def pointerInUserData_def pointerInDeviceData_def)
-     (wp hoare_vcg_all_lift hoare_vcg_disj_lift)
-
-crunch emptySlot
-  for pspace_domain_valid[wp]: "pspace_domain_valid"
-
-crunch emptySlot
-  for ksDomSchedule[wp]: "\<lambda>s. P (ksDomSchedule s)"
-crunch emptySlot
-  for ksDomScheduleIdx[wp]: "\<lambda>s. P (ksDomScheduleIdx s)"
-
-lemma deletedIRQHandler_ct_not_inQ[wp]:
-  "\<lbrace>ct_not_inQ\<rbrace> deletedIRQHandler irq \<lbrace>\<lambda>_. ct_not_inQ\<rbrace>"
-  apply (rule ct_not_inQ_lift [OF deletedIRQHandler_nosch])
-  apply (rule hoare_weaken_pre)
-   apply (wps deletedIRQHandler_ct)
-   apply (simp add: deletedIRQHandler_def setIRQState_def)
-   apply (wp)
-  apply (simp add: comp_def)
-  done
-
-crunch emptySlot
-  for ct_not_inQ[wp]: "ct_not_inQ"
-
-crunch emptySlot
-  for tcbDomain[wp]: "obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t"
-
-lemma emptySlot_ct_idle_or_in_cur_domain'[wp]:
-  "\<lbrace>ct_idle_or_in_cur_domain'\<rbrace> emptySlot sl opt \<lbrace>\<lambda>_. ct_idle_or_in_cur_domain'\<rbrace>"
-  by (wp ct_idle_or_in_cur_domain'_lift2 tcb_in_cur_domain'_lift | simp)+
-
-crunch postCapDeletion
-  for gsUntypedZeroRanges[wp]: "\<lambda>s. P (gsUntypedZeroRanges s)"
-  (wp: crunch_wps simp: crunch_simps)
-
-lemma untypedZeroRange_modify_map_isUntypedCap:
-  "m sl = Some v \<Longrightarrow> \<not> isUntypedCap v \<Longrightarrow> \<not> isUntypedCap (f v)
-    \<Longrightarrow> (untypedZeroRange \<circ>\<^sub>m modify_map m sl f) = (untypedZeroRange \<circ>\<^sub>m m)"
-  by (simp add: modify_map_def map_comp_def fun_eq_iff untypedZeroRange_def)
-
-lemma emptySlot_untyped_ranges[wp]:
-  "\<lbrace>untyped_ranges_zero' and valid_objs' and valid_mdb'\<rbrace>
-     emptySlot sl opt \<lbrace>\<lambda>rv. untyped_ranges_zero'\<rbrace>"
-  apply (simp add: emptySlot_def case_Null_If)
-  apply (rule hoare_pre)
-   apply (rule bind_wp)
-    apply (rule untyped_ranges_zero_lift)
-     apply (wp getCTE_cteCap_wp clearUntypedFreeIndex_cteCaps_of
-       | wpc | simp add: clearUntypedFreeIndex_def updateTrackedFreeIndex_def
-                         getSlotCap_def
-                  split: option.split)+
-  apply (clarsimp simp: modify_map_comp[symmetric] modify_map_same)
-  apply (case_tac "\<not> isUntypedCap (the (cteCaps_of s sl))")
-   apply (case_tac "the (cteCaps_of s sl)",
-     simp_all add: untyped_ranges_zero_inv_def
-                   untypedZeroRange_modify_map_isUntypedCap isCap_simps)[1]
-  apply (clarsimp simp: isCap_simps untypedZeroRange_def modify_map_def)
-  apply (strengthen untyped_ranges_zero_fun_upd[mk_strg I E])
-  apply simp
-  apply (simp add: untypedZeroRange_def isCap_simps)
-  done
-
-crunch emptySlot
-  for valid_arch'[wp]: valid_arch_state'
-  (wp: crunch_wps)
-
-crunch deletedIRQHandler, updateMDB, updateCap, clearUntypedFreeIndex
-  for valid_arch'[wp]: valid_arch_state'
-  (wp: valid_arch_state_lift' crunch_wps)
-
-crunch global.postCapDeletion
-  for valid_arch'[wp]: valid_arch_state'
-
-crunch emptySlot
-  for valid_bitmaps[wp]: valid_bitmaps
-  and tcbQueued_opt_pred[wp]: "\<lambda>s. P (tcbQueued |< tcbs_of' s)"
-  and valid_sched_pointers[wp]: valid_sched_pointers
-  and sched_projs[wp]: "\<lambda>s. P (tcbSchedNexts_of s) (tcbSchedPrevs_of s)"
-  and ksDomScheduleIdx[wp]: "\<lambda>s. P (ksDomScheduleIdx s)"
-  and ksDomScheduleStart[wp]: "\<lambda>s. P (ksDomScheduleStart s)"
-  (wp: valid_bitmaps_lift)
-
-lemma emptySlot_invs'[wp]:
-  "\<lbrace>\<lambda>s. invs' s \<and> cte_wp_at' (\<lambda>cte. removeable' sl s (cteCap cte)) sl s
-            \<and> (info \<noteq> NullCap \<longrightarrow> post_cap_delete_pre' info sl (cteCaps_of s) )\<rbrace>
-     emptySlot sl info
-   \<lbrace>\<lambda>rv. invs'\<rbrace>"
-  apply (simp add: invs'_def valid_state'_def valid_pspace'_def)
-  apply (wp valid_irq_node_lift cur_tcb_lift valid_dom_schedule'_lift)
-  apply (clarsimp simp: cte_wp_at_ctes_of post_cap_delete_pre'_def cteCaps_of_def
-                 split: capability.split_asm arch_capability.split_asm)
-  by auto
-
-lemma deletedIRQHandler_corres:
-  "corres dc \<top> \<top>
-    (deleted_irq_handler irq)
-    (deletedIRQHandler irq)"
-  apply (simp add: deleted_irq_handler_def deletedIRQHandler_def)
-  apply (rule setIRQState_corres)
-  apply (simp add: irq_state_relation_def)
-  done
-
-lemma arch_postCapDeletion_corres:
-  "acap_relation cap cap' \<Longrightarrow> corres dc \<top> \<top> (arch_post_cap_deletion cap) (AARCH64_H.postCapDeletion cap')"
-  by (clarsimp simp: arch_post_cap_deletion_def AARCH64_H.postCapDeletion_def)
-
-lemma postCapDeletion_corres:
-  "cap_relation cap cap' \<Longrightarrow> corres dc \<top> \<top> (post_cap_deletion cap) (postCapDeletion cap')"
-  apply (cases cap; clarsimp simp: post_cap_deletion_def Retype_H.postCapDeletion_def)
-   apply (corresKsimp corres: deletedIRQHandler_corres)
-  by (corresKsimp corres: arch_postCapDeletion_corres)
-
-lemma set_cap_trans_state:
-  "((),s') \<in> fst (set_cap c p s) \<Longrightarrow> ((),trans_state f s') \<in> fst (set_cap c p (trans_state f s))"
-  apply (cases p)
-  apply (clarsimp simp add: set_cap_def in_monad set_object_def get_object_def)
-  apply (case_tac y)
-      apply (auto simp add: in_monad set_object_def well_formed_cnode_n_def split: if_split_asm)
-  done
-
-lemma clearUntypedFreeIndex_noop_corres:
-  "corres dc \<top> (cte_at' (cte_map slot))
-    (return ()) (clearUntypedFreeIndex (cte_map slot))"
-  apply (simp add: clearUntypedFreeIndex_def)
-  apply (rule corres_guard_imp)
-    apply (rule corres_bind_return2)
-    apply (rule corres_symb_exec_r_conj[where P'="cte_at' (cte_map slot)"])
-       apply (rule corres_trivial, simp)
-      apply (wp getCTE_wp' | wpc
-        | simp add: updateTrackedFreeIndex_def getSlotCap_def)+
-     apply (clarsimp simp: state_relation_def)
-    apply (rule no_fail_pre)
-     apply (wp no_fail_getSlotCap getCTE_wp'
-       | wpc | simp add: updateTrackedFreeIndex_def getSlotCap_def)+
-  done
-
-lemma clearUntypedFreeIndex_valid_pspace'[wp]:
-  "\<lbrace>valid_pspace'\<rbrace> clearUntypedFreeIndex slot \<lbrace>\<lambda>rv. valid_pspace'\<rbrace>"
-  apply (simp add: valid_pspace'_def)
-  apply (rule hoare_pre)
-   apply (wp | simp add: valid_mdb'_def)+
-  done
-
-lemma emptySlot_corres:
-  "cap_relation info info' \<Longrightarrow> corres dc (einvs and cte_at slot) (invs' and cte_at' (cte_map slot))
-             (empty_slot slot info) (emptySlot (cte_map slot) info')"
-  unfolding emptySlot_def empty_slot_def
-  apply (simp add: case_Null_If)
-  apply (rule corres_guard_imp)
-    apply (rule corres_split_noop_rhs[OF clearUntypedFreeIndex_noop_corres])
-     apply (rule_tac R="\<lambda>cap. einvs and cte_wp_at ((=) cap) slot" and
-                     R'="\<lambda>cte. valid_pspace' and cte_wp_at' ((=) cte) (cte_map slot)" in
-                     corres_split[OF get_cap_corres])
-       defer
-       apply (wp get_cap_wp getCTE_wp')+
-     apply (simp add: cte_wp_at_ctes_of)
-     apply (wp hoare_vcg_imp_lift' clearUntypedFreeIndex_valid_pspace')
-    apply fastforce
-   apply (fastforce simp: cte_wp_at_ctes_of)
-  apply simp
-  apply (rule conjI, clarsimp)
-   defer
-  apply clarsimp
-  apply (rule conjI, clarsimp)
-  apply clarsimp
-  apply (simp only: bind_assoc[symmetric])
-  apply (rule corres_underlying_split[where r'=dc, OF _ postCapDeletion_corres])
-    defer
-    apply wpsimp+
-  apply (rule corres_no_failI)
-   apply (rule no_fail_pre, wp hoare_weak_lift_imp)
-   apply (clarsimp simp: cte_wp_at_ctes_of valid_pspace'_def)
-   apply (clarsimp simp: valid_mdb'_def valid_mdb_ctes_def)
-   apply (rule conjI, clarsimp)
-    apply (erule (2) valid_dlistEp)
-    apply simp
-   apply clarsimp
-   apply (erule (2) valid_dlistEn)
-   apply simp
-  apply (clarsimp simp: in_monad bind_assoc exec_gets)
-  apply (subgoal_tac "mdb_empty_abs a")
-   prefer 2
-   apply (rule mdb_empty_abs.intro)
-   apply (rule vmdb_abs.intro)
-   apply fastforce
-  apply (frule mdb_empty_abs'.intro)
-  apply (simp add: mdb_empty_abs'.empty_slot_ext_det_def2 update_cdt_list_def set_cdt_list_def exec_gets set_cdt_def bind_assoc exec_get exec_put set_original_def modify_def del: fun_upd_apply | subst bind_def, simp, simp add: mdb_empty_abs'.empty_slot_ext_det_def2)+
-  apply (simp add: put_def)
-  apply (simp add: exec_gets exec_get exec_put del: fun_upd_apply | subst bind_def)+
-  apply (clarsimp simp: state_relation_def)
-  apply (drule updateMDB_the_lot, fastforce simp: pspace_relation_def, fastforce, fastforce)
-   apply (clarsimp simp: invs'_def valid_state'_def valid_pspace'_def
-                         valid_mdb'_def valid_mdb_ctes_def)
-  apply (elim conjE)
-  apply (drule (4) updateMDB_the_lot, elim conjE)
-  apply clarsimp
-  apply (drule_tac s'=s''a and c=cap.NullCap in set_cap_not_quite_corres)
-                      subgoal by simp
-                     subgoal by simp
-                    subgoal by simp
-                   subgoal by simp
-                  subgoal by fastforce
-                 subgoal by fastforce
-                subgoal by fastforce
-               subgoal by fastforce
-              subgoal by fastforce
-             apply fastforce
-            subgoal by fastforce
-           subgoal by fastforce
-          subgoal by fastforce
-         apply (erule cte_wp_at_weakenE, rule TrueI)
-        apply assumption
-       subgoal by simp
-      subgoal by simp
-     subgoal by simp
-    subgoal by simp
-   apply (rule refl)
-  apply clarsimp
-  apply (drule updateCap_stuff, elim conjE, erule (1) impE)
-  apply clarsimp
-  apply (drule updateMDB_the_lot, force simp: pspace_relation_def, assumption+, simp)
-  apply (rule bexI)
-   prefer 2
-   apply (simp only: trans_state_update[symmetric])
-   apply (rule set_cap_trans_state)
-   apply (rule set_cap_revokable_update)
-   apply (erule set_cap_cdt_update)
-  apply clarsimp
-  apply (thin_tac "ctes_of t = s" for t s)+
-  apply (thin_tac "ksMachineState t = p" for t p)+
-  apply (thin_tac "ksCurThread t = p" for t p)+
-  apply (thin_tac "ksReadyQueues t = p" for t p)+
-  apply (thin_tac "ksSchedulerAction t = p" for t p)+
-  apply (clarsimp simp: cte_wp_at_ctes_of)
-  apply (case_tac rv')
-  apply (rename_tac s_cap s_node)
-  apply (subgoal_tac "cte_at slot a")
-   prefer 2
-   apply (fastforce elim: cte_wp_at_weakenE)
-  apply (subgoal_tac "mdb_empty (ctes_of b) (cte_map slot) s_cap s_node")
-   prefer 2
-   apply (rule mdb_empty.intro)
-   apply (rule mdb_ptr.intro)
-    apply (rule vmdb.intro)
-    subgoal by (simp add: invs'_def valid_state'_def valid_pspace'_def valid_mdb'_def)
-   apply (rule mdb_ptr_axioms.intro)
-   subgoal by simp
-  apply (clarsimp simp: ghost_relation_typ_at set_cap_a_type_inv)
-  apply (simp add: pspace_relation_def)
-  apply (rule conjI)
-   apply (clarsimp simp: data_at_def ghost_relation_typ_at set_cap_a_type_inv)
-  apply (rule conjI)
-   prefer 2
-   apply (rule conjI)
-    apply (clarsimp simp: cdt_list_relation_def)
-    apply(frule invs_valid_pspace, frule invs_mdb)
-    apply(subgoal_tac "no_mloop (cdt a) \<and> finite_depth (cdt a)")
-     prefer 2
-     subgoal by(simp add: finite_depth valid_mdb_def)
-    apply(subgoal_tac "valid_mdb_ctes (ctes_of b)")
-     prefer 2
-     subgoal by(simp add: mdb_empty_def mdb_ptr_def vmdb_def)
-    apply(clarsimp simp: valid_pspace_def)
-
-    apply(case_tac "cdt a slot")
-     apply(simp add: next_slot_eq[OF mdb_empty_abs'.next_slot_no_parent])
-     apply(case_tac "next_slot (aa, bb) (cdt_list a) (cdt a)")
-      subgoal by (simp)
-     apply(clarsimp)
-     apply(frule(1) mdb_empty.n_next)
-     apply(clarsimp)
-     apply(erule_tac x=aa in allE, erule_tac x=bb in allE)
-     apply(simp split: if_split_asm)
-      apply(drule cte_map_inj_eq)
-           apply(drule cte_at_next_slot)
-             apply(assumption)+
-      apply(simp)
-     apply(subgoal_tac "(ab, bc) = slot")
-      prefer 2
-      apply(drule_tac cte="CTE s_cap s_node" in valid_mdbD2')
-        subgoal by (clarsimp simp: valid_mdb_ctes_def no_0_def)
-       subgoal by (clarsimp simp: invs'_def valid_state'_def valid_pspace'_def)
-      apply(clarsimp)
-      apply(rule cte_map_inj_eq)
-           apply(assumption)
-          apply(drule(3) cte_at_next_slot', assumption)
-         apply(assumption)+
-     apply(simp)
-     apply(drule_tac p="(aa, bb)" in no_parent_not_next_slot)
-        apply(assumption)+
-     apply(clarsimp)
-
-    apply(simp add: next_slot_eq[OF mdb_empty_abs'.next_slot] split del: if_split)
-    apply(case_tac "next_slot (aa, bb) (cdt_list a) (cdt a)")
-     subgoal by (simp)
-    apply(case_tac "(aa, bb) = slot", simp)
-    apply(case_tac "next_slot (aa, bb) (cdt_list a) (cdt a) = Some slot")
-     apply(simp)
-     apply(case_tac "next_slot ac (cdt_list a) (cdt a)", simp)
-     apply(simp)
-     apply(frule(1) mdb_empty.n_next)
-     apply(clarsimp)
-     apply(erule_tac x=aa in allE', erule_tac x=bb in allE)
-     apply(erule_tac x=ac in allE, erule_tac x=bd in allE)
-     apply(clarsimp split: if_split_asm)
-      apply(drule(1) no_self_loop_next)
-      apply(simp)
-     apply(drule_tac cte="CTE cap' node'" in valid_mdbD1')
-       apply(fastforce simp: valid_mdb_ctes_def no_0_def)
-      subgoal by (simp add: valid_mdb'_def)
-     apply(clarsimp)
-    apply(simp)
-    apply(frule(1) mdb_empty.n_next)
-    apply(erule_tac x=aa in allE, erule_tac x=bb in allE)
-    apply(clarsimp split: if_split_asm)
-     apply(drule(1) no_self_loop_prev)
-     apply(clarsimp)
-     apply(drule_tac cte="CTE s_cap s_node" in valid_mdbD2')
-       apply(clarsimp simp: valid_mdb_ctes_def no_0_def)
-      apply clarify
-     apply(clarsimp)
-     apply(drule cte_map_inj_eq)
-          apply(drule(3) cte_at_next_slot')
-          apply(assumption)+
-     apply(simp)
-    apply(erule disjE)
-     apply(drule cte_map_inj_eq)
-          apply(drule(3) cte_at_next_slot)
-          apply(assumption)+
-     apply(simp)
-    subgoal by (simp)
-   apply (simp add: revokable_relation_def)
-   apply (clarsimp simp: in_set_cap_cte_at)
-   apply (rule conjI)
-    apply clarsimp
-    apply (drule(1) mdb_empty.n_revokable)
-    subgoal by clarsimp
-   apply clarsimp
-   apply (drule (1) mdb_empty.n_revokable)
-   apply (subgoal_tac "null_filter (caps_of_state a) (aa,bb) \<noteq> None")
-    prefer 2
-    apply (drule set_cap_caps_of_state_monad)
-    subgoal by (force simp: null_filter_def)
-   apply clarsimp
-   apply (subgoal_tac "cte_at (aa, bb) a")
-    prefer 2
-    apply (drule null_filter_caps_of_stateD, erule cte_wp_cte_at)
-   apply (drule (2) cte_map_inj_ps, fastforce)
-   subgoal by simp
-  apply (clarsimp simp add: cdt_relation_def)
-  apply (subst mdb_empty_abs.descendants, assumption)
-  apply (subst mdb_empty.descendants, assumption)
-  apply clarsimp
-  apply (frule_tac p="(aa, bb)" in in_set_cap_cte_at)
-  apply clarsimp
-  apply (frule (2) cte_map_inj_ps, fastforce)
-  apply simp
-  apply (case_tac "slot \<in> descendants_of (aa,bb) (cdt a)")
-   apply (subst inj_on_image_set_diff)
-      apply (rule inj_on_descendants_cte_map)
-         apply fastforce
-        apply fastforce
-       apply fastforce
-      apply fastforce
-     apply fastforce
-    subgoal by simp
-   subgoal by simp
-  apply simp
-  apply (subgoal_tac "cte_map slot \<notin> descendants_of' (cte_map (aa,bb)) (ctes_of b)")
-   subgoal by simp
-  apply (erule_tac x=aa in allE, erule allE, erule (1) impE)
-  apply (drule_tac s="cte_map ` u" for u in sym)
-  apply clarsimp
-  apply (drule cte_map_inj_eq, assumption)
-      apply (erule descendants_of_cte_at, fastforce)
-     apply fastforce
-    apply fastforce
-   apply fastforce
-  apply simp
-  done
-
-
-
-text \<open>Some facts about is_final_cap/isFinalCapability\<close>
-
-lemma isFinalCapability_inv:
-  "\<lbrace>P\<rbrace> isFinalCapability cap \<lbrace>\<lambda>_. P\<rbrace>"
-  apply (simp add: isFinalCapability_def Let_def
-              split del: if_split cong: if_cong)
-  apply (rule hoare_pre, wp)
-   apply (rule hoare_post_imp[where Q'="\<lambda>s. P"], simp)
-   apply wp
-  apply simp
-  done
-
-definition
-  final_matters' :: "capability \<Rightarrow> bool"
-where
- "final_matters' cap \<equiv> case cap of
-    EndpointCap ref bdg s r g gr \<Rightarrow> True
-  | NotificationCap ref bdg s r \<Rightarrow> True
-  | ThreadCap ref \<Rightarrow> True
-  | CNodeCap ref bits gd gs \<Rightarrow> True
-  | Zombie ptr zb n \<Rightarrow> True
-  | IRQHandlerCap irq \<Rightarrow> True
-  | ArchObjectCap acap \<Rightarrow> (case acap of
-      FrameCap ref rghts sz d mapdata \<Rightarrow> False
-    | ASIDControlCap \<Rightarrow> False
-    | SMCCap _ \<Rightarrow> False
-    | SGISignalCap _ _ \<Rightarrow> False
-    | _ \<Rightarrow> True)
-  | _ \<Rightarrow> False"
-
 lemma final_matters_Master:
   "final_matters' (capMasterCap cap) = final_matters' cap"
   by (simp add: capMasterCap_def arch_capMasterCap_def split: capability.split arch_capability.split,
-      simp add: final_matters'_def)
+      simp add: final_matters'_def arch_final_matters'_def)
 
 lemma final_matters_sameRegion_sameObject:
   "final_matters' cap \<Longrightarrow> sameRegionAs cap cap' = sameObjectAs cap cap'"
   apply (rule iffI)
    apply (erule sameRegionAsE)
       apply (simp add: sameObjectAs_def3)
-      apply (clarsimp simp: isCap_simps sameObjectAs_sameRegionAs final_matters'_def
-        split:capability.splits arch_capability.splits)+
+      apply (clarsimp simp: isCap_simps sameObjectAs_sameRegionAs
+                            final_matters'_def arch_final_matters'_def
+                      split: capability.splits arch_capability.splits)+
   done
 
 lemma final_matters_sameRegion_sameObject2:
   "\<lbrakk> final_matters' cap'; \<not> isUntypedCap cap; \<not> isIRQHandlerCap cap' \<rbrakk>
-     \<Longrightarrow> sameRegionAs cap cap' = sameObjectAs cap cap'"
+   \<Longrightarrow> sameRegionAs cap cap' = sameObjectAs cap cap'"
   apply (rule iffI)
    apply (erule sameRegionAsE)
        apply (simp add: sameObjectAs_def3)
-       apply (fastforce simp: isCap_simps final_matters'_def)
+       apply (fastforce simp: isCap_simps final_matters'_def arch_final_matters'_def)
       apply simp
-     apply (clarsimp simp: final_matters'_def isCap_simps)
-    apply (clarsimp simp: final_matters'_def isCap_simps)
-   apply (clarsimp simp: final_matters'_def isCap_simps)
+     apply (clarsimp simp: final_matters'_def arch_final_matters'_def isCap_simps)+
   apply (erule sameObjectAs_sameRegionAs)
   done
 
 lemma final_matters_mdb_chunked_arch_assms:
   "final_matters' cap \<Longrightarrow> mdb_chunked_arch_assms cap"
-  by (clarsimp simp: mdb_chunked_arch_assms_def isCap_simps final_matters'_def)
+  by (clarsimp simp: mdb_chunked_arch_assms_def isCap_simps
+                     final_matters'_def arch_final_matters'_def)
 
-lemma notFinal_prev_or_next:
+lemma notFinal_prev_or_next[Finalise_R_2_assms]:
   "\<lbrakk> \<not> isFinal cap x (cteCaps_of s); mdb_chunked (ctes_of s);
-      valid_dlist (ctes_of s); no_0 (ctes_of s);
-      ctes_of s x = Some (CTE cap node); final_matters' cap \<rbrakk>
-     \<Longrightarrow> (\<exists>cap' node'. ctes_of s (mdbPrev node) = Some (CTE cap' node')
-              \<and> sameObjectAs cap cap')
-      \<or> (\<exists>cap' node'. ctes_of s (mdbNext node) = Some (CTE cap' node')
-              \<and> sameObjectAs cap cap')"
+     valid_dlist (ctes_of s); no_0 (ctes_of s);
+     ctes_of s x = Some (CTE cap node); final_matters' cap \<rbrakk>
+   \<Longrightarrow> (\<exists>cap' node'. ctes_of s (mdbPrev node) = Some (CTE cap' node') \<and> sameObjectAs cap cap')
+      \<or> (\<exists>cap' node'. ctes_of s (mdbNext node) = Some (CTE cap' node') \<and> sameObjectAs cap cap')"
   apply (erule not_FinalE)
    apply (clarsimp simp: isCap_simps final_matters'_def)
   apply (frule final_matters_mdb_chunked_arch_assms)
@@ -2031,91 +546,20 @@ lemma notFinal_prev_or_next:
   apply (clarsimp simp: sameObjectAs_def3 simp del: isArchFrameCap_capMasterCap)
   done
 
-lemma isFinal:
-  "\<lbrace>\<lambda>s. valid_mdb' s \<and> cte_wp_at' ((=) cte) x s
-          \<and> final_matters' (cteCap cte)
-          \<and> Q (isFinal (cteCap cte) x (cteCaps_of s)) s\<rbrace>
-    isFinalCapability cte
-   \<lbrace>Q\<rbrace>"
-  unfolding isFinalCapability_def
-  apply (cases cte)
-  apply (rename_tac cap node)
-  apply (unfold Let_def)
-  apply (simp only: if_False)
-  apply (wp getCTE_wp')
-  apply (cases "mdbPrev (cteMDBNode cte) = nullPointer")
-   apply simp
-   apply (clarsimp simp: valid_mdb_ctes_def valid_mdb'_def
-                         cte_wp_at_ctes_of)
-   apply (rule conjI, clarsimp simp: nullPointer_def)
-    apply (erule rsubst[where P="\<lambda>x. Q x s" for s], simp)
-    apply (rule classical)
-    apply (drule(5) notFinal_prev_or_next)
-    apply clarsimp
-   apply (clarsimp simp: nullPointer_def)
-   apply (erule rsubst[where P="\<lambda>x. Q x s" for s])
-   apply (rule sym, rule iffI)
-    apply (rule classical)
-    apply (drule(5) notFinal_prev_or_next)
-    apply clarsimp
-   apply clarsimp
-   apply (clarsimp simp: cte_wp_at_ctes_of cteCaps_of_def)
-   apply (case_tac cte)
-   apply clarsimp
-   apply (clarsimp simp add: isFinal_def)
-   apply (erule_tac x="mdbNext node" in allE)
-   apply simp
-   apply (erule impE)
-    apply (clarsimp simp: valid_mdb'_def valid_mdb_ctes_def)
-    apply (drule (1) mdb_chain_0_no_loops)
-    apply simp
-   apply (clarsimp simp: sameObjectAs_def3 isCap_simps)
-  apply simp
-  apply (clarsimp simp: cte_wp_at_ctes_of
-                        valid_mdb_ctes_def valid_mdb'_def)
-  apply (case_tac cte)
-  apply clarsimp
-  apply (rule conjI)
-   apply clarsimp
-   apply (erule rsubst[where P="\<lambda>x. Q x s" for s])
-   apply clarsimp
-   apply (clarsimp simp: isFinal_def cteCaps_of_def)
-   apply (erule_tac x="mdbPrev node" in allE)
-   apply simp
-   apply (erule impE)
-    apply clarsimp
-    apply (drule (1) mdb_chain_0_no_loops)
-    apply (subgoal_tac "ctes_of s (mdbNext node) = Some (CTE cap node)")
-     apply clarsimp
-    apply (erule (1) valid_dlistEp)
-     apply clarsimp
-    apply (case_tac cte')
-    apply clarsimp
-   apply (clarsimp simp add: sameObjectAs_def3 isCap_simps)
-  apply clarsimp
-  apply (rule conjI)
-   apply clarsimp
-   apply (erule rsubst[where P="\<lambda>x. Q x s" for s], simp)
-   apply (rule classical, drule(5) notFinal_prev_or_next)
-   apply (clarsimp simp: sameObjectAs_sym nullPointer_def)
-  apply (clarsimp simp: nullPointer_def)
-  apply (erule rsubst[where P="\<lambda>x. Q x s" for s])
-  apply (rule sym, rule iffI)
-   apply (rule classical, drule(5) notFinal_prev_or_next)
-   apply (clarsimp simp: sameObjectAs_sym)
-   apply auto[1]
-  apply (clarsimp simp: isFinal_def cteCaps_of_def)
-  apply (case_tac cte)
-  apply (erule_tac x="mdbNext node" in allE)
-  apply simp
-  apply (erule impE)
-   apply clarsimp
-   apply (drule (1) mdb_chain_0_no_loops)
-   apply simp
-  apply clarsimp
-  apply (clarsimp simp: isCap_simps sameObjectAs_def3)
-  done
-end
+lemma sameObjectAs_not_Untyped[Finalise_R_2_assms]:
+  "\<lbrakk> global.sameObjectAs cap cap'; \<not> isUntypedCap cap \<rbrakk>
+   \<Longrightarrow> \<not> isUntypedCap cap'"
+  by (clarsimp simp: gen_isCap_simps sameObjectAs_def3)
+
+lemma sameObjectAs_not_Untyped'[Finalise_R_2_assms]:
+  "\<lbrakk> global.sameObjectAs cap cap'; \<not> isUntypedCap cap' \<rbrakk>
+   \<Longrightarrow> global.sameObjectAs cap' cap"
+  by (clarsimp simp: isCap_simps sameObjectAs_def3)
+
+end (* Arch *)
+
+(* only two arch-specific lemmas in vmdb;
+   save processing time by not creating an extra Arch_vmdb locale, directly requalify instead *)
 
 lemma (in vmdb) isFinal_no_subtree:
   "\<lbrakk> m \<turnstile> sl \<rightarrow> p; isFinal cap sl (option_map cteCap o m);
@@ -2125,19 +569,9 @@ lemma (in vmdb) isFinal_no_subtree:
    apply (clarsimp simp: isFinal_def parentOf_def mdb_next_unfold cteCaps_of_def)
    apply (erule_tac x="mdbNext n" in allE)
    apply simp
-   apply (clarsimp simp: AARCH64.isMDBParentOf_CTE final_matters_sameRegion_sameObject) (* FIXME arch-split *)
-   apply (clarsimp simp: gen_isCap_simps AARCH64.sameObjectAs_def3) (* FIXME arch-split *)
+   apply (clarsimp simp: AARCH64.isMDBParentOf_CTE AARCH64.final_matters_sameRegion_sameObject)
+   apply (clarsimp simp: gen_isCap_simps AARCH64.sameObjectAs_def3)
   apply clarsimp
-  done
-
-lemma isFinal_no_descendants:
-  "\<lbrakk> isFinal cap sl (cteCaps_of s); ctes_of s sl = Some (CTE cap n);
-      valid_mdb' s; final_matters' cap \<rbrakk>
-  \<Longrightarrow> descendants_of' sl (ctes_of s) = {}"
-  apply (clarsimp simp add: descendants_of'_def cteCaps_of_def)
-  apply (erule(3) vmdb.isFinal_no_subtree[rotated])
-  apply unfold_locales[1]
-  apply (simp add: valid_mdb'_def)
   done
 
 lemma (in vmdb) isFinal_untypedParent:
@@ -2162,362 +596,29 @@ lemma (in vmdb) isFinal_untypedParent:
   apply clarsimp
   apply (drule isMDBParent_sameRegion)
   apply simp
-  apply (frule final_matters_mdb_chunked_arch_assms)
+  apply (frule AARCH64.final_matters_mdb_chunked_arch_assms)
   apply (rule classical, simp)
-  apply (simp add: final_matters_sameRegion_sameObject2
+  apply (simp add: AARCH64.final_matters_sameRegion_sameObject2
                    sameObjectAs_sym)
   done
 
-context begin interpretation Arch . (*FIXME: arch-split*)
+context Arch begin arch_global_naming
 
-lemma no_fail_isFinalCapability [wp]:
-  "no_fail (valid_mdb' and cte_wp_at' ((=) cte) p) (isFinalCapability cte)"
-  apply (simp add: isFinalCapability_def)
-  apply (clarsimp simp: Let_def split del: if_split)
-  apply (rule no_fail_pre, wp getCTE_wp')
-  apply (clarsimp simp: valid_mdb'_def valid_mdb_ctes_def cte_wp_at_ctes_of nullPointer_def)
-  apply (rule conjI)
-   apply clarsimp
-   apply (erule (2) valid_dlistEp)
-   apply simp
-  apply clarsimp
-  apply (rule conjI)
-   apply (erule (2) valid_dlistEn)
-   apply simp
-  apply clarsimp
-  apply (rule valid_dlistEn, assumption+)
-  apply (erule (2) valid_dlistEp)
-  apply simp
+lemma isFinal_no_descendants:
+  "\<lbrakk> isFinal cap sl (cteCaps_of s); ctes_of s sl = Some (CTE cap n);
+      valid_mdb' s; final_matters' cap \<rbrakk>
+  \<Longrightarrow> descendants_of' sl (ctes_of s) = {}"
+  apply (clarsimp simp add: descendants_of'_def cteCaps_of_def)
+  apply (erule(3) vmdb.isFinal_no_subtree[rotated])
+  apply unfold_locales[1]
+  apply (simp add: valid_mdb'_def)
   done
 
-lemma corres_gets_lift:
-  assumes inv: "\<And>P. \<lbrace>P\<rbrace> g \<lbrace>\<lambda>_. P\<rbrace>"
-  assumes res: "\<lbrace>Q'\<rbrace> g \<lbrace>\<lambda>r s. r = g' s\<rbrace>"
-  assumes Q: "\<And>s. Q s \<Longrightarrow> Q' s"
-  assumes nf: "no_fail Q g"
-  shows "corres r P Q f (gets g') \<Longrightarrow> corres r P Q f g"
-  apply (clarsimp simp add: corres_underlying_def simpler_gets_def)
-  apply (drule (1) bspec)
-  apply (rule conjI)
-   apply clarsimp
-   apply (rule bexI)
-    prefer 2
-    apply assumption
-   apply simp
-   apply (frule in_inv_by_hoareD [OF inv])
-   apply simp
-   apply (drule use_valid, rule res)
-    apply (erule Q)
-   apply simp
-  apply (insert nf)
-  apply (clarsimp simp: no_fail_def)
-  done
+lemmas cancelAllIPC_typs[wp] = typ_at_lifts[OF cancelAllIPC_typ_at']
+lemmas cancelAllSignals_typs[wp] = typ_at_lifts[OF cancelAllSignals_typ_at']
+lemmas suspend_typs[wp] = typ_at_lifts[OF suspend_typ_at']
 
-lemma obj_refs_Master:
-  "\<lbrakk> cap_relation cap cap'; P cap \<rbrakk>
-      \<Longrightarrow> obj_refs cap =
-           (if capClass (capMasterCap cap') = PhysicalClass
-                  \<and> \<not> isUntypedCap (capMasterCap cap')
-            then {capUntypedPtr (capMasterCap cap')} else {})"
-  by (clarsimp simp: isCap_simps
-              split: cap_relation_split_asm arch_cap.split_asm)
-
-lemma isFinalCapability_corres':
-  "final_matters' (cteCap cte) \<Longrightarrow>
-   corres (=) (invs and cte_wp_at ((=) cap) ptr)
-               (invs' and cte_wp_at' ((=) cte) (cte_map ptr))
-       (is_final_cap cap) (isFinalCapability cte)"
-  apply (rule corres_gets_lift)
-      apply (rule isFinalCapability_inv)
-     apply (rule isFinal[where x="cte_map ptr"])
-    apply clarsimp
-    apply (rule conjI, clarsimp)
-    apply (rule refl)
-   apply (rule no_fail_pre, wp, fastforce)
-  apply (simp add: is_final_cap_def)
-  apply (clarsimp simp: cte_wp_at_ctes_of cteCaps_of_def state_relation_def)
-  apply (frule (1) pspace_relation_ctes_ofI)
-    apply fastforce
-   apply fastforce
-  apply clarsimp
-  apply (rule iffI)
-   apply (simp add: is_final_cap'_def2 isFinal_def)
-   apply clarsimp
-   apply (subgoal_tac "obj_refs cap \<noteq> {} \<or> cap_irqs cap \<noteq> {} \<or> arch_gen_refs cap \<noteq> {}")
-    prefer 2
-    apply (erule_tac x=a in allE)
-    apply (erule_tac x=b in allE)
-    apply (clarsimp simp: cte_wp_at_def gen_obj_refs_Int)
-   apply (subgoal_tac "ptr = (a,b)")
-    prefer 2
-    apply (erule_tac x="fst ptr" in allE)
-    apply (erule_tac x="snd ptr" in allE)
-    apply (clarsimp simp: cte_wp_at_def gen_obj_refs_Int)
-   apply clarsimp
-   apply (rule context_conjI)
-    apply (clarsimp simp: isCap_simps)
-    apply (cases cap, auto)[1]
-   apply clarsimp
-   apply (drule_tac x=p' in pspace_relation_cte_wp_atI, assumption)
-    apply fastforce
-   apply clarsimp
-   apply (erule_tac x=aa in allE)
-   apply (erule_tac x=ba in allE)
-   apply (clarsimp simp: cte_wp_at_caps_of_state)
-   apply (clarsimp simp: sameObjectAs_def3 obj_refs_Master cap_irqs_relation_Master
-                         arch_gen_refs_relation_Master gen_obj_refs_Int
-                   cong: if_cong
-                  split: capability.split_asm)
-  apply (clarsimp simp: isFinal_def is_final_cap'_def3)
-  apply (rule_tac x="fst ptr" in exI)
-  apply (rule_tac x="snd ptr" in exI)
-  apply (rule conjI)
-   apply (clarsimp simp: cte_wp_at_def final_matters'_def
-                         gen_obj_refs_Int
-                  split: cap_relation_split_asm arch_cap.split_asm)
-  apply clarsimp
-  apply (drule_tac p="(a,b)" in cte_wp_at_norm)
-  apply clarsimp
-  apply (frule_tac slot="(a,b)" in pspace_relation_ctes_ofI, assumption)
-    apply fastforce
-   apply fastforce
-  apply clarsimp
-  apply (frule_tac p="(a,b)" in cte_wp_valid_cap, fastforce)
-  apply (erule_tac x="cte_map (a,b)" in allE)
-  apply simp
-  apply (erule impCE, simp, drule cte_map_inj_eq)
-        apply (erule cte_wp_at_weakenE, rule TrueI)
-       apply (erule cte_wp_at_weakenE, rule TrueI)
-      apply fastforce
-     apply fastforce
-    apply (erule invs_distinct)
-   apply simp
-  apply (frule_tac p=ptr in cte_wp_valid_cap, fastforce)
-  apply (clarsimp simp: cte_wp_at_def gen_obj_refs_Int)
-  apply (rule conjI)
-   apply (rule classical)
-   apply (frule(1) zombies_finalD2[OF _ _ _ invs_zombies],
-          simp?, clarsimp, assumption+)
-   subgoal by (clarsimp simp: sameObjectAs_def3 isCap_simps valid_cap_def valid_arch_cap_def
-                              valid_arch_cap_ref_def obj_at_def is_obj_defs a_type_def
-                              final_matters'_def
-                        split: cap.split_asm arch_cap.split_asm option.split_asm if_split_asm,
-               simp_all add: is_cap_defs)
-  apply (rule classical)
-  apply (clarsimp simp: cap_irqs_def cap_irq_opt_def sameObjectAs_def3 isCap_simps
-                 split: cap.split_asm)
-  done
-
-lemma isFinalCapability_corres:
-  "corres (\<lambda>rv rv'. final_matters' (cteCap cte) \<longrightarrow> rv = rv')
-          (invs and cte_wp_at ((=) cap) ptr)
-          (invs' and cte_wp_at' ((=) cte) (cte_map ptr))
-       (is_final_cap cap) (isFinalCapability cte)"
-  apply (cases "final_matters' (cteCap cte)")
-   apply simp
-   apply (erule isFinalCapability_corres')
-  apply (subst bind_return[symmetric],
-         rule corres_symb_exec_r)
-     apply (rule corres_no_failI)
-      apply wp
-     apply (clarsimp simp: in_monad is_final_cap_def simpler_gets_def)
-    apply (wp isFinalCapability_inv)+
-  apply fastforce
-  done
-
-text \<open>Facts about finalise_cap/finaliseCap and
-        cap_delete_one/cteDelete in no particular order\<close>
-
-
-definition
-  finaliseCapTrue_standin_simple_def:
-  "finaliseCapTrue_standin cap fin \<equiv> finaliseCap cap fin True"
-
-context
-begin
-
-declare if_cong [cong]
-
-lemmas finaliseCapTrue_standin_def
-    = finaliseCapTrue_standin_simple_def
-        [unfolded finaliseCap_def, simplified]
-
-lemmas cteDeleteOne_def'
-    = eq_reflection [OF cteDeleteOne_def]
-lemmas cteDeleteOne_def
-    = cteDeleteOne_def'[folded finaliseCapTrue_standin_simple_def]
-
-crunch cteDeleteOne, suspend, prepareThreadDelete
-  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  (wp: crunch_wps getObject_inv loadObject_default_inv
-   simp: crunch_simps unless_def o_def
-   ignore_del: setObject)
-
-end
-
-lemmas cancelAllIPC_typs[wp] = typ_at_lifts [OF cancelAllIPC_typ_at']
-lemmas cancelAllSignals_typs[wp] = typ_at_lifts [OF cancelAllSignals_typ_at']
-lemmas suspend_typs[wp] = typ_at_lifts [OF suspend_typ_at']
-
-definition
-  cap_has_cleanup' :: "capability \<Rightarrow> bool"
-where
-  "cap_has_cleanup' cap \<equiv> case cap of
-     IRQHandlerCap _ \<Rightarrow> True
-   | ArchObjectCap acap \<Rightarrow> False
-   | _ \<Rightarrow> False"
-
-lemmas cap_has_cleanup'_simps[simp] = cap_has_cleanup'_def[split_simps capability.split]
-
-lemma finaliseCap_cases[wp]:
-  "\<lbrace>\<top>\<rbrace>
-     finaliseCap cap final flag
-   \<lbrace>\<lambda>rv s. fst rv = NullCap \<and> (snd rv \<noteq> NullCap \<longrightarrow> final \<and> cap_has_cleanup' cap \<and> snd rv = cap)
-     \<or>
-       isZombie (fst rv) \<and> final \<and> \<not> flag \<and> snd rv = NullCap
-        \<and> capUntypedPtr (fst rv) = capUntypedPtr cap
-        \<and> (isThreadCap cap \<or> isCNodeCap cap \<or> isZombie cap)\<rbrace>"
-  apply (simp add: finaliseCap_def AARCH64_H.finaliseCap_def Let_def
-                   getThreadCSpaceRoot
-             cong: if_cong split del: if_split)
-  apply (rule hoare_pre)
-   apply ((wp | simp add: isCap_simps split del: if_split
-              | wpc
-              | simp only: valid_NullCap fst_conv snd_conv)+)[1]
-  apply (simp only: simp_thms fst_conv snd_conv option.simps if_cancel
-                    o_def)
-  apply (intro allI impI conjI TrueI)
-  apply (auto simp add: isCap_simps cap_has_cleanup'_def)
-  done
-
-crunch finaliseCap
-  for aligned'[wp]: "pspace_aligned'"
-  (simp: crunch_simps assertE_def unless_def o_def
-     wp: getObject_inv loadObject_default_inv crunch_wps)
-
-crunch finaliseCap
-  for distinct'[wp]: "pspace_distinct'"
-  (simp: crunch_simps assertE_def unless_def o_def
-     wp: getObject_inv loadObject_default_inv crunch_wps)
-
-crunch finaliseCap
-  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  (simp: crunch_simps assertE_def
-     wp: getObject_inv loadObject_default_inv crunch_wps)
 lemmas finaliseCap_typ_ats[wp] = typ_at_lifts[OF finaliseCap_typ_at']
-
-lemma unmapPageTable_it'[wp]:
-  "unmapPageTable asid vaddr pt \<lbrace>\<lambda>s. P (ksIdleThread s)\<rbrace>"
-  unfolding unmapPageTable_def by wpsimp
-
-crunch finaliseCap
-  for it'[wp]: "\<lambda>s. P (ksIdleThread s)"
-  (wp: mapM_x_wp_inv mapM_wp' hoare_drop_imps getObject_inv loadObject_default_inv
-   simp: crunch_simps updateObject_default_def o_def)
-
-lemma ntfn_q_refs_of'_mult:
-  "ntfn_q_refs_of' ntfn = (case ntfn of Structures_H.WaitingNtfn q \<Rightarrow> set q | _ \<Rightarrow> {}) \<times> {NTFNSignal}"
-  by (cases ntfn, simp_all)
-
-lemma tcb_st_not_Bound:
-  "(p, NTFNBound) \<notin> tcb_st_refs_of' ts"
-  "(p, TCBBound) \<notin> tcb_st_refs_of' ts"
-  by (auto simp: tcb_st_refs_of'_def split: Structures_H.thread_state.split)
-
-crunch setBoundNotification
-  for valid_bitmaps[wp]: valid_bitmaps
-  and tcbSchedNexts_of[wp]: "\<lambda>s. P (tcbSchedNexts_of s)"
-  and tcbSchedPrevs_of[wp]: "\<lambda>s. P (tcbSchedPrevs_of s)"
-  and tcbQueued[wp]: "\<lambda>s. P (tcbQueued |< tcbs_of' s)"
-  and valid_sched_pointers[wp]: valid_sched_pointers
-  (wp: valid_bitmaps_lift)
-
-lemma unbindNotification_invs[wp]:
-  "\<lbrace>invs'\<rbrace> unbindNotification tcb \<lbrace>\<lambda>rv. invs'\<rbrace>"
-  apply (simp add: unbindNotification_def invs'_def valid_state'_def)
-  apply (rule bind_wp[OF _ gbn_sp'])
-  apply (case_tac ntfnPtr, clarsimp, wp, clarsimp)
-  apply clarsimp
-  apply (rule bind_wp[OF _ get_ntfn_sp'])
-  apply (rule hoare_pre)
-  apply (wp sbn'_valid_pspace'_inv sbn_sch_act' valid_irq_node_lift valid_dom_schedule'_lift
-            irqs_masked_lift setBoundNotification_ct_not_inQ sym_heap_sched_pointers_lift
-            untyped_ranges_zero_lift | clarsimp simp: cteCaps_of_def o_def)+
-  apply (rule conjI)
-   apply (clarsimp elim!: obj_atE'
-                   dest!: pred_tcb_at')
-  apply (clarsimp simp: pred_tcb_at' conj_comms)
-  apply (frule bound_tcb_ex_cap'', clarsimp+)
-  apply (frule(1) sym_refs_bound_tcb_atD')
-  apply (frule(1) sym_refs_obj_atD')
-  apply (clarsimp simp: refs_of_rev')
-  apply normalise_obj_at'
-  apply (subst delta_sym_refs, assumption)
-    apply (auto split: if_split_asm)[1]
-   apply (auto simp: tcb_st_not_Bound ntfn_q_refs_of'_mult split: if_split_asm)[1]
-  apply (frule obj_at_valid_objs', clarsimp+)
-  apply (simp add: valid_ntfn'_def valid_obj'_def live'_def
-            split: ntfn.splits)
-  apply (erule if_live_then_nonz_capE')
-  apply (clarsimp simp: obj_at'_def ko_wp_at'_def live'_def)
-  done
-
-lemma ntfn_bound_tcb_at':
-  "\<lbrakk>sym_refs (state_refs_of' s); valid_objs' s; ko_at' ntfn ntfnptr s;
-    ntfnBoundTCB ntfn = Some tcbptr; P (Some ntfnptr)\<rbrakk>
-  \<Longrightarrow> bound_tcb_at' P tcbptr s"
-  apply (drule_tac x=ntfnptr in sym_refsD[rotated])
-   apply (clarsimp simp: obj_at'_def)
-   apply (fastforce simp: state_refs_of'_def)
-  apply (auto simp: pred_tcb_at'_def obj_at'_def valid_obj'_def valid_ntfn'_def
-                    state_refs_of'_def refs_of_rev'
-          simp del: refs_of_simps
-             split: option.splits if_split_asm)
-  done
-
-
-lemma unbindMaybeNotification_invs[wp]:
-  "\<lbrace>invs'\<rbrace> unbindMaybeNotification ntfnptr \<lbrace>\<lambda>rv. invs'\<rbrace>"
-  apply (simp add: unbindMaybeNotification_def invs'_def valid_state'_def)
-  apply (rule bind_wp[OF _ get_ntfn_sp'])
-  apply (rule hoare_pre)
-   apply (wp sbn'_valid_pspace'_inv sbn_sch_act' sym_heap_sched_pointers_lift valid_irq_node_lift
-             irqs_masked_lift valid_dom_schedule'_lift setBoundNotification_ct_not_inQ
-             untyped_ranges_zero_lift
-             | wpc | clarsimp simp: cteCaps_of_def o_def)+
-  apply safe[1]
-           defer 3
-           defer 7
-           apply (fold_subgoals (prefix))[8]
-           subgoal premises prems using prems
-              by (auto simp: pred_tcb_at' valid_pspace'_def valid_obj'_def valid_ntfn'_def
-                             ko_wp_at'_def live'_def
-                      elim!: obj_atE' valid_objsE' if_live_then_nonz_capE'
-                      split: option.splits ntfn.splits)
-   apply (rule delta_sym_refs, assumption)
-    apply (fold_subgoals (prefix))[2]
-    subgoal premises prems using prems by (fastforce simp: symreftype_inverse' ntfn_q_refs_of'_def
-                    split: ntfn.splits if_split_asm
-                     dest!: ko_at_state_refs_ofD')+
-  apply (rule delta_sym_refs, assumption)
-   apply (clarsimp split: if_split_asm)
-   apply (frule ko_at_state_refs_ofD', simp)
-  apply (clarsimp split: if_split_asm)
-   apply (frule_tac P="(=) (Some ntfnptr)" in ntfn_bound_tcb_at', simp_all add: valid_pspace'_def)[1]
-   subgoal by (fastforce simp: ntfn_q_refs_of'_def state_refs_of'_def tcb_ntfn_is_bound'_def
-                          tcb_st_refs_of'_def
-                   dest!: bound_tcb_at_state_refs_ofD'
-                   split: ntfn.splits thread_state.splits)
-  apply (frule ko_at_state_refs_ofD', simp)
-  done
-
-(* Ugh, required to be able to split out the abstract invs *)
-lemma finaliseCap_True_invs[wp]:
-  "\<lbrace>invs'\<rbrace> finaliseCap cap final True \<lbrace>\<lambda>rv. invs'\<rbrace>"
-  apply (simp add: finaliseCap_def Let_def)
-  apply safe
-    apply (wp irqs_masked_lift| simp | wpc)+
-  done
 
 lemma invalidateASIDEntry_invs'[wp]:
   "invalidateASIDEntry asid \<lbrace>invs'\<rbrace>"
@@ -2555,7 +656,7 @@ lemma deleteASID_invs'[wp]:
   unfolding deleteASID_def
   by (wpsimp wp: getASID_wp hoare_drop_imps simp: getPoolPtr_def)
 
-lemmas archThreadSet_typ_ats[wp] = typ_at_lifts [OF archThreadSet_typ_at']
+lemmas archThreadSet_typ_ats[wp] = typ_at_lifts[OF archThreadSet_typ_at']
 
 lemma archThreadSet_valid_objs'[wp]:
   "\<lbrace>valid_objs' and (\<lambda>s. \<forall>tcb. ko_at' tcb t s \<longrightarrow> valid_arch_tcb' (f (tcbArch tcb)) s)\<rbrace>
@@ -2606,45 +707,23 @@ lemma archThreadSet_inQ[wp]:
 
 crunch archThreadSet
   for ct[wp]: "\<lambda>s. P (ksCurThread s)"
-  (wp: setObject_ct_inv)
-
-crunch archThreadSet
-  for sched[wp]: "\<lambda>s. P (ksSchedulerAction s)"
-  (wp: setObject_sa_unchanged)
-
-crunch archThreadSet
-  for L1[wp]: "\<lambda>s. P (ksReadyQueuesL1Bitmap s)"
-  (wp: setObject_sa_unchanged)
-
-crunch archThreadSet
-  for L2[wp]: "\<lambda>s. P (ksReadyQueuesL2Bitmap s)"
-  (wp: setObject_sa_unchanged)
-
-crunch archThreadSet
-  for ksArch[wp]: "\<lambda>s. P (ksArchState s)"
-
-crunch archThreadSet
-  for ksDomSchedule[wp]: "\<lambda>s. P (ksDomSchedule s)"
-  (wp: setObject_ksDomSchedule_inv)
+  and sched[wp]: "\<lambda>s. P (ksSchedulerAction s)"
+  and L1[wp]: "\<lambda>s. P (ksReadyQueuesL1Bitmap s)"
+  and L2[wp]: "\<lambda>s. P (ksReadyQueuesL2Bitmap s)"
+  and ksArch[wp]: "\<lambda>s. P (ksArchState s)"
+  and ksDomSchedule[wp]: "\<lambda>s. P (ksDomSchedule s)"
+  and pspace_canonical'[wp]: pspace_canonical'
+  and gsMaxObjectSize[wp]: "\<lambda>s. P (gsMaxObjectSize s)"
+  and ksInterruptState[wp]: "\<lambda>s. P (ksInterruptState s)"
+  (wp: setObject_ct_inv setObject_sa_unchanged setObject_ksDomSchedule_inv)
 
 crunch archThreadSet
   for ksDomScheduleIdx[wp]: "\<lambda>s. P (ksDomScheduleIdx s)"
   and ksDomScheduleStart[wp]: "\<lambda>s. P (ksDomScheduleStart s)"
   (simp: setObject_def wp: updateObject_default_inv)
 
-lemma setObject_tcb_ksInterruptState[wp]:
-  "setObject t (v :: tcb) \<lbrace>\<lambda>s. P (ksInterruptState s)\<rbrace>"
-  by (wpsimp simp: setObject_def wp: updateObject_default_inv)
-
-lemma setObject_tcb_gsMaxObjectSize[wp]:
-  "setObject t (v :: tcb) \<lbrace>\<lambda>s. P (gsMaxObjectSize s)\<rbrace>"
-  by (wpsimp simp: setObject_def wp: updateObject_default_inv)
-
 crunch archThreadSet
-  for pspace_canonical'[wp]: pspace_canonical'
-  and gsMaxObjectSize[wp]: "\<lambda>s. P (gsMaxObjectSize s)"
-  and ksInterruptState[wp]: "\<lambda>s. P (ksInterruptState s)"
-  and ksMachineState[wp]: "\<lambda>s. P (ksMachineState s)"
+  for ksMachineState[wp]: "\<lambda>s. P (ksMachineState s)"
   (wp: setObject_ksMachine updateObject_default_inv)
 
 lemma archThreadSet_state_refs_of'[wp]:
@@ -2726,10 +805,6 @@ lemma archThreadSet_obj_at'_pte[wp]:
 crunch archThreadSet
   for pspace_domain_valid[wp]: pspace_domain_valid
 
-lemma setObject_tcb_gsUntypedZeroRanges[wp]:
-  "setObject ptr (tcb::tcb) \<lbrace>\<lambda>s. P (gsUntypedZeroRanges s)\<rbrace>"
-  by (wpsimp wp: updateObject_default_inv simp: setObject_def)
-
 crunch archThreadSet
   for gsUntypedZeroRanges[wp]: "\<lambda>s. P (gsUntypedZeroRanges s)"
 
@@ -2741,17 +816,6 @@ lemma archThreadSet_tcb_at'[wp]:
   "\<lbrace>\<top>\<rbrace> archThreadSet f t \<lbrace>\<lambda>_. tcb_at' t\<rbrace>"
   unfolding archThreadSet_def
   by (wpsimp wp: getObject_tcb_wp simp: obj_at'_def)
-
-lemma setObject_tcb_tcbs_of'[wp]:
-  "\<lbrace>\<lambda>s. P ((tcbs_of' s) (t \<mapsto> tcb))\<rbrace>
-   setObject t tcb
-   \<lbrace>\<lambda>_ s. P (tcbs_of' s)\<rbrace>"
-  unfolding setObject_def
-  apply (wpsimp simp: updateObject_default_def)
-  apply (erule rsubst[where P=P])
-  apply (rule ext)
-  apply (clarsimp simp: opt_map_def split: option.splits)
-  done
 
 lemma archThreadSet_tcbSchedPrevs_of[wp]:
   "archThreadSet f t \<lbrace>\<lambda>s. P (tcbSchedPrevs_of s)\<rbrace>"
@@ -2843,10 +907,6 @@ lemma vcpuInvalidateActive_obj_at'[wp]:
   "vcpuInvalidateActive \<lbrace>\<lambda>s. P (obj_at' P' p s)\<rbrace>"
   unfolding vcpuInvalidateActive_def modifyArchState_def by wpsimp
 
-lemma when_assert_eq:
-  "(when P $ haskell_fail xs) = assert (\<not>P)"
-  by (simp add: assert_def when_def)
-
 lemma dissociateVCPUTCB_invs'[wp]:
   "dissociateVCPUTCB vcpu tcb \<lbrace>invs'\<rbrace>"
   unfolding dissociateVCPUTCB_def setVCPU_archThreadSet_None_eq when_assert_eq
@@ -2865,7 +925,7 @@ lemma dissociateVCPUTCB_invs'[wp]:
 lemma vcpuFinalise_invs'[wp]: "vcpuFinalise vcpu \<lbrace>invs'\<rbrace>"
   unfolding vcpuFinalise_def by wpsimp
 
-lemma arch_finaliseCap_invs[wp]:
+lemma arch_finaliseCap_invs[Finalise_R_2_assms, wp]:
   "\<lbrace>invs' and valid_cap' (ArchObjectCap cap)\<rbrace> Arch.finaliseCap cap fin \<lbrace>\<lambda>rv. invs'\<rbrace>"
   unfolding AARCH64_H.finaliseCap_def Let_def by wpsimp
 
@@ -2935,271 +995,16 @@ lemma arch_finaliseCap_removeable[wp]:
    \<lbrace>\<lambda>rv s. isNullCap (fst rv) \<and> removeable' slot s (ArchObjectCap cap) \<and> isNullCap (snd rv)\<rbrace>"
   unfolding AARCH64_H.finaliseCap_def
   apply (wpsimp wp: hoare_vcg_op_lift simp: removeable'_def isCap_simps cte_wp_at_ctes_of)
-  apply (fastforce simp: final_matters'_def isFinal_def cte_wp_at_ctes_of cteCaps_of_def
-                         sameObjectAs_def3)
+  apply (fastforce simp: final_matters'_def arch_final_matters'_def isFinal_def cte_wp_at_ctes_of
+                         cteCaps_of_def sameObjectAs_def3)
   done
-
-lemma isZombie_Null:
-  "\<not> isZombie NullCap"
-  by (simp add: isCap_simps)
-
-lemma prepares_delete_helper'':
-  assumes x: "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv. ko_wp_at' (Not \<circ> live') p\<rbrace>"
-  shows      "\<lbrace>P and K ((\<forall>x. cte_refs' cap x = {})
-                          \<and> zobj_refs' cap = {p}
-                          \<and> threadCapRefs cap = {})\<rbrace>
-                 f \<lbrace>\<lambda>rv s. removeable' sl s cap\<rbrace>"
-  apply (rule hoare_gen_asm)
-  apply (rule hoare_strengthen_post [OF x])
-  apply (clarsimp simp: removeable'_def)
-  done
-
-crunch finaliseCapTrue_standin, unbindNotification
-  for ctes_of[wp]: "\<lambda>s. P (ctes_of s)"
-  (wp: crunch_wps getObject_inv loadObject_default_inv simp: crunch_simps)
-
-lemma cteDeleteOne_cteCaps_of:
-  "\<lbrace>\<lambda>s. (cte_wp_at' (\<lambda>cte. \<exists>final. finaliseCap (cteCap cte) final True \<noteq> fail) p s \<longrightarrow>
-          P ((cteCaps_of s)(p \<mapsto> NullCap)))\<rbrace>
-     cteDeleteOne p
-   \<lbrace>\<lambda>rv s. P (cteCaps_of s)\<rbrace>"
-  apply (simp add: cteDeleteOne_def unless_def split_def)
-  apply (rule bind_wp [OF _ getCTE_sp])
-  apply (case_tac "\<forall>final. finaliseCap (cteCap cte) final True = fail")
-   apply (simp add: finaliseCapTrue_standin_simple_def)
-   apply wp
-   apply (clarsimp simp: cte_wp_at_ctes_of cteCaps_of_def
-                         finaliseCap_def isCap_simps)
-   apply (drule_tac x=s in fun_cong)
-   apply (simp add: return_def fail_def)
-  apply (wp emptySlot_cteCaps_of)
-    apply (simp add: cteCaps_of_def)
-    apply (wp (once) hoare_drop_imps)
-    apply (wp isFinalCapability_inv getCTE_wp')+
-  apply (clarsimp simp: cteCaps_of_def cte_wp_at_ctes_of)
-  apply (auto simp: fun_upd_idem fun_upd_def[symmetric] o_def)
-  done
-
-lemma cteDeleteOne_isFinal:
-  "\<lbrace>\<lambda>s. isFinal cap slot (cteCaps_of s)\<rbrace>
-     cteDeleteOne p
-   \<lbrace>\<lambda>rv s. isFinal cap slot (cteCaps_of s)\<rbrace>"
-  apply (wp cteDeleteOne_cteCaps_of)
-  apply (clarsimp simp: isFinal_def sameObjectAs_def2)
-  done
-
-lemmas setEndpoint_cteCaps_of[wp] = cteCaps_of_ctes_of_lift [OF set_ep_ctes_of]
-lemmas setNotification_cteCaps_of[wp] = cteCaps_of_ctes_of_lift [OF set_ntfn_ctes_of]
-lemmas threadSet_cteCaps_of = cteCaps_of_ctes_of_lift [OF threadSet_ctes_of]
 
 crunch archThreadSet, vcpuUpdate, dissociateVCPUTCB
   for isFinal: "\<lambda>s. isFinal cap slot (cteCaps_of s)"
   (wp: cteCaps_of_ctes_of_lift)
 
-crunch suspend, prepareThreadDelete
+crunch prepareThreadDelete
   for isFinal: "\<lambda>s. isFinal cap slot (cteCaps_of s)"
-  (ignore: threadSet
-       wp: threadSet_cteCaps_of crunch_wps
-     simp: crunch_simps unless_def o_def)
-
-lemma isThreadCap_threadCapRefs_tcbptr:
-  "isThreadCap cap \<Longrightarrow> threadCapRefs cap = {capTCBPtr cap}"
-  by (clarsimp simp: isCap_simps)
-
-lemma isArchObjectCap_Cap_capCap:
-  "isArchObjectCap cap \<Longrightarrow> ArchObjectCap (capCap cap) = cap"
-  by (clarsimp simp: isCap_simps)
-
-lemma cteDeleteOne_deletes[wp]:
-  "\<lbrace>\<top>\<rbrace> cteDeleteOne p \<lbrace>\<lambda>rv s. cte_wp_at' (\<lambda>c. cteCap c = NullCap) p s\<rbrace>"
-  apply (subst tree_cte_cteCap_eq[unfolded o_def])
-  apply (wp cteDeleteOne_cteCaps_of)
-  apply clarsimp
-  done
-
-crunch finaliseCap
-  for irq_node'[wp]: "\<lambda>s. P (irq_node' s)"
-  (wp: crunch_wps getObject_inv loadObject_default_inv
-       updateObject_default_inv setObject_ksInterrupt
-   simp: crunch_simps o_def)
-
-lemma deletingIRQHandler_removeable':
-  "\<lbrace>invs' and (\<lambda>s. isFinal (IRQHandlerCap irq) slot (cteCaps_of s))
-          and K (cap = IRQHandlerCap irq)\<rbrace>
-     deletingIRQHandler irq
-   \<lbrace>\<lambda>rv s. removeable' slot s cap\<rbrace>"
-  apply (rule hoare_gen_asm)
-  apply (simp add: deletingIRQHandler_def getIRQSlot_def locateSlot_conv
-                   getInterruptState_def getSlotCap_def)
-  apply (simp add: removeable'_def tree_cte_cteCap_eq[unfolded o_def])
-  apply (subst tree_cte_cteCap_eq[unfolded o_def])+
-  apply (wp hoare_use_eq_irq_node' [OF cteDeleteOne_irq_node' cteDeleteOne_cteCaps_of]
-            getCTE_wp')
-  apply (clarsimp simp: cte_level_bits_def ucast_nat_def shiftl_t2n mult_ac cteSizeBits_def
-                  split: option.split_asm)
-  done
-
-lemma finaliseCap_cte_refs:
-  "\<lbrace>\<lambda>s. s \<turnstile>' cap\<rbrace>
-     finaliseCap cap final flag
-   \<lbrace>\<lambda>rv s. fst rv \<noteq> NullCap \<longrightarrow> cte_refs' (fst rv) = cte_refs' cap\<rbrace>"
-  apply (simp  add: finaliseCap_def Let_def getThreadCSpaceRoot
-                    AARCH64_H.finaliseCap_def
-             cong: if_cong split del: if_split)
-  apply (rule hoare_pre)
-   apply (wp | wpc | simp only: o_def)+
-  apply (frule valid_capAligned)
-  apply (cases cap, simp_all add: isCap_simps)
-   apply (clarsimp simp: tcb_cte_cases_def word_count_from_top objBits_defs)
-  apply clarsimp
-  apply (rule ext, simp)
-  apply (rule image_cong [OF _ refl])
-  apply (fastforce simp: mask_def capAligned_def objBits_simps shiftL_nat)
-  done
-
-lemma deletingIRQHandler_final:
-  "\<lbrace>\<lambda>s. isFinal cap slot (cteCaps_of s)
-             \<and> (\<forall>final. finaliseCap cap final True = fail)\<rbrace>
-     deletingIRQHandler irq
-   \<lbrace>\<lambda>rv s. isFinal cap slot (cteCaps_of s)\<rbrace>"
-  apply (simp add: deletingIRQHandler_def isFinal_def getIRQSlot_def
-                   getInterruptState_def locateSlot_conv getSlotCap_def)
-  apply (wp cteDeleteOne_cteCaps_of getCTE_wp')
-  apply (auto simp: sameObjectAs_def3)
-  done
-
-declare suspend_unqueued [wp]
-
-lemma unbindNotification_valid_objs'_helper:
-  "valid_tcb' tcb s \<longrightarrow> valid_tcb' (tcbBoundNotification_update (\<lambda>_. None) tcb) s "
-  by (clarsimp simp: valid_bound_ntfn'_def valid_tcb'_def tcb_cte_cases_def cteSizeBits_def
-                  split: option.splits ntfn.splits)
-
-lemma unbindNotification_valid_objs'_helper':
-  "valid_ntfn' tcb s \<longrightarrow> valid_ntfn' (ntfnBoundTCB_update (\<lambda>_. None) tcb) s "
-  by (clarsimp simp: valid_bound_tcb'_def valid_ntfn'_def
-                  split: option.splits ntfn.splits)
-
-lemmas setNotification_valid_tcb' = typ_at'_valid_tcb'_lift [OF setNotification_typ_at']
-
-lemma unbindNotification_valid_objs'[wp]:
-  "\<lbrace>valid_objs'\<rbrace>
-     unbindNotification t
-   \<lbrace>\<lambda>rv. valid_objs'\<rbrace>"
-  apply (simp add: unbindNotification_def)
-  apply (rule hoare_pre)
-  apply (wp threadSet_valid_objs' gbn_wp' set_ntfn_valid_objs' hoare_vcg_all_lift
-            setNotification_valid_tcb' getNotification_wp
-        | wpc | clarsimp simp: setBoundNotification_def unbindNotification_valid_objs'_helper)+
-  apply (clarsimp elim!: obj_atE')
-  apply (rule valid_objsE', assumption+)
-  apply (clarsimp simp: valid_obj'_def unbindNotification_valid_objs'_helper')
-  done
-
-lemma unbindMaybeNotification_valid_objs'[wp]:
-  "\<lbrace>valid_objs'\<rbrace>
-     unbindMaybeNotification t
-   \<lbrace>\<lambda>rv. valid_objs'\<rbrace>"
-  apply (simp add: unbindMaybeNotification_def)
-  apply (rule bind_wp[OF _ get_ntfn_sp'])
-  apply (rule hoare_pre)
-  apply (wp threadSet_valid_objs' gbn_wp' set_ntfn_valid_objs' hoare_vcg_all_lift
-            setNotification_valid_tcb' getNotification_wp
-        | wpc | clarsimp simp: setBoundNotification_def unbindNotification_valid_objs'_helper)+
-  apply (clarsimp elim!: obj_atE')
-  apply (rule valid_objsE', assumption+)
-  apply (clarsimp simp: valid_obj'_def unbindNotification_valid_objs'_helper')
-  done
-
-lemma unbindMaybeNotification_sch_act_wf[wp]:
-  "\<lbrace>\<lambda>s. sch_act_wf (ksSchedulerAction s) s\<rbrace> unbindMaybeNotification t
-  \<lbrace>\<lambda>rv s. sch_act_wf (ksSchedulerAction s) s\<rbrace>"
-  apply (simp add: unbindMaybeNotification_def)
-  apply (rule hoare_pre)
-  apply (wp sbn_sch_act' | wpc | simp)+
-  done
-
-lemma valid_cong:
-  "\<lbrakk> \<And>s. P s = P' s; \<And>s. P' s \<Longrightarrow> f s = f' s;
-        \<And>rv s' s. \<lbrakk> (rv, s') \<in> fst (f' s); P' s \<rbrakk> \<Longrightarrow> Q rv s' = Q' rv s' \<rbrakk>
-    \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace> = \<lbrace>P'\<rbrace> f' \<lbrace>Q'\<rbrace>"
-  by (clarsimp simp add: valid_def, blast)
-
-lemma sym_refs_ntfn_bound_eq: "sym_refs (state_refs_of' s)
-    \<Longrightarrow> obj_at' (\<lambda>ntfn. ntfnBoundTCB ntfn = Some t) x s
-    = bound_tcb_at' (\<lambda>st. st = Some x) t s"
-  apply (rule iffI)
-   apply (drule (1) sym_refs_obj_atD')
-   apply (clarsimp simp: pred_tcb_at'_def obj_at'_def ko_wp_at'_def refs_of_rev')
-  apply (drule(1) sym_refs_bound_tcb_atD')
-  apply (clarsimp simp: obj_at'_def ko_wp_at'_def refs_of_rev')
-  done
-
-lemma unbindMaybeNotification_obj_at'_bound:
-  "\<lbrace>\<top>\<rbrace>
-     unbindMaybeNotification r
-   \<lbrace>\<lambda>_ s. obj_at' (\<lambda>ntfn. ntfnBoundTCB ntfn = None) r s\<rbrace>"
-  apply (simp add: unbindMaybeNotification_def)
-  apply (rule bind_wp[OF _ get_ntfn_sp'])
-  apply (rule hoare_pre)
-   apply (wp obj_at_setObject2
-        | wpc
-        | simp add: setBoundNotification_def threadSet_def updateObject_default_def in_monad)+
-  apply (simp add: setNotification_def obj_at'_real_def cong: valid_cong)
-   apply (wp setObject_ko_wp_at, (simp add: objBits_simps')+)
-  apply (clarsimp simp: obj_at'_def ko_wp_at'_def)
-  done
-
-crunch unbindNotification, unbindMaybeNotification
-  for isFinal[wp]: "\<lambda>s. isFinal cap slot (cteCaps_of s)"
-  (wp: sts_bound_tcb_at' threadSet_cteCaps_of crunch_wps getObject_inv
-       loadObject_default_inv
-   ignore: threadSet
-   simp: setBoundNotification_def)
-
-crunch cancelSignal, cancelAllIPC
-  for bound_tcb_at'[wp]: "bound_tcb_at' P t"
-  (wp: sts_bound_tcb_at' threadSet_cteCaps_of crunch_wps getObject_inv
-       loadObject_default_inv
-   ignore: threadSet)
-
-lemma finaliseCapTrue_standin_bound_tcb_at':
-  "\<lbrace>\<lambda>s. bound_tcb_at' P t s \<and> (\<exists>tt b r. cap = ReplyCap tt b r) \<rbrace>
-     finaliseCapTrue_standin cap final
-   \<lbrace>\<lambda>_. bound_tcb_at' P t\<rbrace>"
-  apply (case_tac cap, simp_all add:finaliseCapTrue_standin_def)
-  apply (clarsimp simp: isNotificationCap_def)
-  apply (wp, clarsimp)
-  done
-
-lemma capDeleteOne_bound_tcb_at':
-  "\<lbrace>bound_tcb_at' P tptr and cte_wp_at' (isReplyCap \<circ> cteCap) callerCap\<rbrace>
-      cteDeleteOne callerCap \<lbrace>\<lambda>rv. bound_tcb_at' P tptr\<rbrace>"
-  apply (simp add: cteDeleteOne_def unless_def)
-  apply (rule hoare_pre)
-   apply (wp finaliseCapTrue_standin_bound_tcb_at' hoare_vcg_all_lift
-            hoare_vcg_if_lift2 getCTE_cteCap_wp
-        | wpc | simp | wp (once) hoare_drop_imp)+
-  apply (clarsimp simp:  cteCaps_of_def isReplyCap_def cte_wp_at_ctes_of
-                 split: option.splits)
-  apply (case_tac "cteCap cte", simp_all)
-  done
-
-lemma cancelIPC_bound_tcb_at'[wp]:
-  "\<lbrace>bound_tcb_at' P tptr\<rbrace> cancelIPC t \<lbrace>\<lambda>rv. bound_tcb_at' P tptr\<rbrace>"
-  apply (simp add: cancelIPC_def Let_def)
-  apply (rule bind_wp[OF _ gts_sp'])
-  apply (case_tac "state", simp_all)
-         defer 2
-         apply (rule hoare_pre)
-          apply ((wp sts_bound_tcb_at' getEndpoint_wp | wpc | simp)+)[8]
-  apply (simp add: getThreadReplySlot_def locateSlot_conv liftM_def)
-  apply (rule hoare_pre)
-   apply (wp capDeleteOne_bound_tcb_at' getCTE_ctes_of)
-   apply (rule_tac Q'="\<lambda>_. bound_tcb_at' P tptr" in hoare_post_imp)
-   apply (clarsimp simp: capHasProperty_def cte_wp_at_ctes_of)
-   apply (wp threadSet_pred_tcb_no_state | simp)+
-  done
 
 lemma archThreadSet_bound_tcb_at'[wp]:
   "archThreadSet f t \<lbrace>bound_tcb_at' P t'\<rbrace>"
@@ -3207,41 +1012,13 @@ lemma archThreadSet_bound_tcb_at'[wp]:
   apply (wpsimp wp: setObject_tcb_strongest getObject_tcb_wp simp: pred_tcb_at'_def)
   by (auto simp: obj_at'_def objBits_simps)
 
-lemmas asUser_bound_obj_at'[wp] = asUser_pred_tcb_at' [of itcbBoundNotification]
-
 lemmas setObject_vcpu_pred_tcb_at'[wp] =
   setObject_vcpu_obj_at'_no_vcpu [of _ "\<lambda>ko. tst (pr (tcb_to_itcb' ko))" for tst pr, folded pred_tcb_at'_def]
 
-crunch dissociateVCPUTCB, vgicUpdateLR
+crunch dissociateVCPUTCB, vgicUpdateLR, prepareThreadDelete
   for bound_tcb_at'[wp]: "bound_tcb_at' P t"
   (wp: sts_bound_tcb_at' getVCPU_wp crunch_wps hoare_vcg_all_lift hoare_vcg_if_lift3
    ignore: archThreadSet)
-
-crunch suspend, prepareThreadDelete
-  for bound_tcb_at'[wp]: "bound_tcb_at' P t"
-  (wp: sts_bound_tcb_at' cancelIPC_bound_tcb_at'
-   ignore: threadSet)
-
-lemma unbindNotification_bound_tcb_at':
-  "\<lbrace>\<lambda>_. True\<rbrace> unbindNotification t \<lbrace>\<lambda>rv. bound_tcb_at' ((=) None) t\<rbrace>"
-  apply (simp add: unbindNotification_def)
-  apply (wp setBoundNotification_bound_tcb gbn_wp' | wpc | simp)+
-  done
-
-crunch unbindNotification, unbindMaybeNotification
-  for weak_sch_act_wf[wp]: "\<lambda>s. weak_sch_act_wf (ksSchedulerAction s) s"
-
-lemma unbindNotification_tcb_at'[wp]:
-  "\<lbrace>tcb_at' t'\<rbrace> unbindNotification t \<lbrace>\<lambda>rv. tcb_at' t'\<rbrace>"
-  apply (simp add: unbindNotification_def)
-  apply (wp gbn_wp' | wpc | simp)+
-  done
-
-lemma unbindMaybeNotification_tcb_at'[wp]:
-  "\<lbrace>tcb_at' t'\<rbrace> unbindMaybeNotification t \<lbrace>\<lambda>rv. tcb_at' t'\<rbrace>"
-  apply (simp add: unbindMaybeNotification_def)
-  apply (wp gbn_wp' | wpc | simp)+
-  done
 
 lemma dissociateVCPUTCB_cte_wp_at'[wp]:
   "dissociateVCPUTCB v t \<lbrace>cte_wp_at' P p\<rbrace>"
@@ -3249,10 +1026,17 @@ lemma dissociateVCPUTCB_cte_wp_at'[wp]:
 
 lemmas dissociateVCPUTCB_typ_ats'[wp] = typ_at_lifts[OF dissociateVCPUTCB_typ_at']
 
+crunch Arch.finaliseCap, prepareThreadDelete
+  for irq_node'[Finalise_R_2_assms, wp]: "\<lambda>s. P (irq_node' s)"
+  (wp: crunch_wps getObject_inv loadObject_default_inv
+       updateObject_default_inv setObject_ksInterrupt
+   simp: crunch_simps o_def)
+
+lemmas Arch_finaliseCap_irq_node'[Finalise_R_2_assms] = ArchRetypeDecls_H_AARCH64_H_finaliseCap_irq_node'
+
 crunch prepareThreadDelete
-  for cte_wp_at'[wp]: "cte_wp_at' P p"
-crunch prepareThreadDelete
-  for valid_cap'[wp]: "valid_cap' cap"
+  for cte_wp_at'[Finalise_R_2_assms, wp]: "cte_wp_at' P p"
+  and valid_cap'[Finalise_R_2_assms, wp]: "valid_cap' cap"
 
 lemma unset_vcpu_hyp_unlive[wp]:
   "\<lbrace>\<top>\<rbrace> archThreadSet (atcbVCPUPtr_update Map.empty) t \<lbrace>\<lambda>_. ko_wp_at' (Not \<circ> hyp_live') t\<rbrace>"
@@ -3304,49 +1088,8 @@ lemma prepareThreadDelete_hyp_unlive[wp]:
   done
 
 crunch prepareThreadDelete
-  for invs[wp]: "invs'"
-  (ignore: doMachineOp)
-
-end
-
-lemma tcbQueueRemove_tcbSchedNext_tcbSchedPrev_None_obj_at':
-  "\<lbrace>\<lambda>s. \<exists>ts. list_queue_relation ts q (tcbSchedNexts_of s) (tcbSchedPrevs_of s)\<rbrace>
-   tcbQueueRemove q t
-   \<lbrace>\<lambda>_ s. obj_at' (\<lambda>tcb. tcbSchedNext tcb = None \<and> tcbSchedPrev tcb = None) t s\<rbrace>"
-  apply (clarsimp simp: tcbQueueRemove_def)
-  apply (wpsimp wp: threadSet_wp getTCB_wp)
-  by (fastforce dest!: heap_ls_last_None
-                 simp: list_queue_relation_def prev_queue_head_def queue_end_valid_def
-                       obj_at'_def opt_map_def ps_clear_def AARCH64.objBits_simps
-                split: if_splits)
-
-lemma tcbSchedDequeue_tcbSchedNext_tcbSchedPrev_None_obj_at':
-  "\<lbrace>valid_sched_pointers\<rbrace>
-   tcbSchedDequeue t
-   \<lbrace>\<lambda>_ s. obj_at' (\<lambda>tcb. tcbSchedNext tcb = None \<and> tcbSchedPrev tcb = None) t s\<rbrace>"
-  unfolding tcbSchedDequeue_def
-  by (wpsimp wp: tcbQueueRemove_tcbSchedNext_tcbSchedPrev_None_obj_at' threadGet_wp)
-     (fastforce simp: ready_queue_relation_def ksReadyQueues_asrt_def obj_at'_def
-                      valid_sched_pointers_def opt_pred_def opt_map_def
-               split: option.splits)
-
-crunch updateRestartPC, cancelIPC
-  for valid_sched_pointers[wp]: valid_sched_pointers
-  (simp: crunch_simps wp: crunch_wps)
-
-lemma setThreadState_tcbSchedNext_tcbSchedPrev_None_obj_at'[wp]:
-  "setThreadState ref ts \<lbrace>\<lambda>s. obj_at' (\<lambda>tcb. tcbSchedNext tcb = None \<and> tcbSchedPrev tcb = None) t s\<rbrace>"
-  unfolding setThreadState_def
-  apply (wpsimp wp: threadSet_wp getTCB_wp)
-  apply (fastforce simp: obj_at'_def gen_objBits_simps)
-  done
-
-lemma suspend_tcbSchedNext_tcbSchedPrev_None:
-  "\<lbrace>invs'\<rbrace> suspend t \<lbrace>\<lambda>_ s. obj_at' (\<lambda>tcb. tcbSchedNext tcb = None \<and> tcbSchedPrev tcb = None) t s\<rbrace>"
-  unfolding suspend_def
-  by (wpsimp wp: hoare_drop_imps tcbSchedDequeue_tcbSchedNext_tcbSchedPrev_None_obj_at')
-
-context begin interpretation Arch . (*FIXME: arch-split*)
+  for invs[Finalise_R_2_assms, wp]: "invs'"
+  (ignore: doMachineOp simp: crunch_simps)
 
 lemma archThreadSet_tcbSchedPrevNext[wp]:
   "archThreadSet f t' \<lbrace>obj_at' (\<lambda>tcb. P (tcbSchedNext tcb) (tcbSchedPrev tcb)) t\<rbrace>"
@@ -3356,12 +1099,85 @@ lemma archThreadSet_tcbSchedPrevNext[wp]:
   apply auto
   done
 
+context notes if_cong[cong] begin
+
+crunch asUser
+  for tcbSchedPrevNext[wp]: "obj_at' (\<lambda>tcb. P (tcbSchedNext tcb) (tcbSchedPrev tcb)) t"
+  (wp: threadGet_wp)
+
+end
+
 crunch prepareThreadDelete
   for tcbSchedPrevNext[wp]: "obj_at' (\<lambda>tcb. P (tcbSchedNext tcb) (tcbSchedPrev tcb)) t"
   (wp: threadGet_wp getVCPU_wp archThreadGet_wp crunch_wps simp: crunch_simps)
 
-end
+crunch deleteASIDPool
+  for cte_wp_at'[wp]: "cte_wp_at' P p"
+  (simp: crunch_simps assertE_def
+   wp: crunch_wps getObject_inv loadObject_default_inv)
 
+lemma deleteASID_cte_wp_at'[wp]:
+  "\<lbrace>cte_wp_at' P p\<rbrace> deleteASID param_a param_b \<lbrace>\<lambda>_. cte_wp_at' P p\<rbrace>"
+  apply (simp add: deleteASID_def
+              cong: option.case_cong)
+  apply (wp setObject_cte_wp_at'[where Q="\<top>"] getObject_inv
+            loadObject_default_inv setVMRoot_cte_wp_at'
+          | clarsimp simp: updateObject_default_def in_monad
+          | rule equals0I
+          | wpc)+
+  done
+
+crunch vcpuFinalise
+  for cte_wp_at'[wp]: "cte_wp_at' P p"
+  (wp: crunch_wps getObject_inv loadObject_default_inv)
+
+lemma arch_finaliseCap_cte_wp_at[Finalise_R_2_assms, wp]:
+  "\<lbrace>cte_wp_at' P p\<rbrace> Arch.finaliseCap cap fin \<lbrace>\<lambda>rv. cte_wp_at' P p\<rbrace>"
+  apply (simp add: AARCH64_H.finaliseCap_def)
+  apply (wpsimp wp: unmapPage_cte_wp_at')
+  done
+
+lemma finaliseCap_valid_cap[Finalise_R_2_assms, wp]:
+  "\<lbrace>\<top>\<rbrace> Arch.finaliseCap cap final \<lbrace>\<lambda>rv. valid_cap' (fst rv)\<rbrace>"
+  by (wpsimp simp: AARCH64_H.finaliseCap_def)
+
+lemma finaliseCap_cases[wp]:
+  "\<lbrace>\<top>\<rbrace>
+   finaliseCap cap final flag
+   \<lbrace>\<lambda>rv s. fst rv = NullCap \<and> (snd rv \<noteq> NullCap \<longrightarrow> final \<and> cap_has_cleanup' cap \<and> snd rv = cap)
+           \<or> isZombie (fst rv) \<and> final \<and> \<not> flag \<and> snd rv = NullCap
+             \<and> capUntypedPtr (fst rv) = capUntypedPtr cap
+             \<and> (isThreadCap cap \<or> isCNodeCap cap \<or> isZombie cap)\<rbrace>"
+  apply (simp add: finaliseCap_def AARCH64_H.finaliseCap_def Let_def
+                   getThreadCSpaceRoot
+             cong: if_cong split del: if_split)
+  apply (rule hoare_pre)
+   apply ((wp | simp add: gen_isCap_simps split del: if_split
+              | wpc
+              | simp only: valid_NullCap fst_conv snd_conv)+)[1]
+  apply (simp only: simp_thms fst_conv snd_conv option.simps if_cancel
+                    o_def)
+  apply (intro allI impI conjI TrueI)
+  apply (auto simp add: gen_isCap_simps cap_has_cleanup'_def)
+  done
+
+lemmas [Finalise_R_2_assms] =
+  cancelAllIPC_cte_wp_at' cancelAllSignals_cte_wp_at' unbindMaybeNotification_cte_wp_at'
+  prepareThreadDelete_cte_wp_at' unbindNotification_cte_wp_at'
+  Arch_postCapDeletion_valid_global_refs Arch_postCapDeletion_valid_arch_state'
+  mdb_empty.vmdb_n mdb_empty.descendants not_Final_removeable
+
+end (* Arch *)
+
+interpretation Finalise_R_2?: Finalise_R_2 arch_final_matters' arch_cap_has_cleanup'
+proof goal_cases
+  interpret Arch  .
+  case 1 show ?case by (intro_locales; (unfold_locales; (fact Finalise_R_2_assms)?)?)
+qed
+
+(* this is the only arch-specific lemma in delete_one_conc_pre so far;
+   save processing time by not creating an extra Arch_delete_one_conc_pre locale
+   by directly requalifying instead *)
 lemma (in delete_one_conc_pre) finaliseCap_replaceable:
   "\<lbrace>\<lambda>s. invs' s \<and> cte_wp_at' (\<lambda>cte. cteCap cte = cap) slot s
        \<and> (final_matters' cap \<longrightarrow> (final = isFinal cap slot (cteCaps_of s)))
@@ -3383,13 +1199,15 @@ lemma (in delete_one_conc_pre) finaliseCap_replaceable:
                      \<and> bound_tcb_at' ((=) None) p s
                      \<and> ko_wp_at' (Not \<circ> hyp_live') p s
                      \<and> obj_at' (\<lambda>tcb. tcbSchedNext tcb = None \<and> tcbSchedPrev tcb = None) p s))\<rbrace>"
+  supply [wp] = AARCH64.prepareThreadDelete_bound_tcb_at' AARCH64.prepareThreadDelete_hyp_unlive
+                AARCH64.prepareThreadDelete_tcbSchedPrevNext
   apply (simp add: finaliseCap_def Let_def getThreadCSpaceRoot
              cong: if_cong split del: if_split)
   apply (rule hoare_pre)
    apply (wp prepares_delete_helper'' [OF cancelAllIPC_unlive]
              prepares_delete_helper'' [OF cancelAllSignals_unlive]
-             suspend_isFinal AARCH64.prepareThreadDelete_unqueued (* FIXME arch-split: interface *)
-             AARCH64.prepareThreadDelete_inactive prepareThreadDelete_isFinal
+             suspend_isFinal AARCH64.prepareThreadDelete_unqueued
+             AARCH64.prepareThreadDelete_inactive AARCH64.prepareThreadDelete_isFinal
              suspend_makes_inactive
              deletingIRQHandler_removeable'
              deletingIRQHandler_final[where slot=slot ]
@@ -3400,14 +1218,14 @@ lemma (in delete_one_conc_pre) finaliseCap_replaceable:
              suspend_tcbSchedNext_tcbSchedPrev_None
            | simp add: isZombie_Null isThreadCap_threadCapRefs_tcbptr
                        isArchObjectCap_Cap_capCap
-           | (rule hoare_strengthen_post [OF arch_finaliseCap_removeable[where slot=slot]],
+           | (rule hoare_strengthen_post[OF AARCH64.arch_finaliseCap_removeable[where slot=slot]],
                   clarsimp simp: gen_isCap_simps)
            | wpc)+
   apply clarsimp
   apply (frule cte_wp_at_valid_objs_valid_cap', clarsimp+)
   apply (case_tac "cteCap cte",
          simp_all add: gen_isCap_simps capRange_def cap_has_cleanup'_def
-                       final_matters'_def AARCH64.objBits_simps
+                       final_matters'_def gen_objBits_simps
                        not_Final_removeable finaliseCap_def,
          simp_all add: removeable'_def)
      (* thread *)
@@ -3418,418 +1236,144 @@ lemma (in delete_one_conc_pre) finaliseCap_replaceable:
     apply (clarsimp simp: obj_at'_def | rule conjI)+
   done
 
-lemma cteDeleteOne_cte_wp_at_preserved:
-  assumes x: "\<And>cap final. P cap \<Longrightarrow> finaliseCap cap final True = fail"
-  shows "\<lbrace>\<lambda>s. cte_wp_at' (\<lambda>cte. P (cteCap cte)) p s\<rbrace>
-           cteDeleteOne ptr
-         \<lbrace>\<lambda>rv s. cte_wp_at' (\<lambda>cte. P (cteCap cte)) p s\<rbrace>"
-  apply (simp add: tree_cte_cteCap_eq[unfolded o_def])
-  apply (rule hoare_pre, wp cteDeleteOne_cteCaps_of)
-  apply (clarsimp simp: cteCaps_of_def cte_wp_at_ctes_of x)
-  done
+context Arch begin arch_global_naming
 
-crunch cancelSignal
-  for ctes_of[wp]: "\<lambda>s. P (ctes_of s)"
-  (simp: crunch_simps wp: crunch_wps)
+named_theorems Finalise_R_3_assms
 
-lemma cancelIPC_cteCaps_of:
-  "\<lbrace>\<lambda>s. (\<forall>p. cte_wp_at' (\<lambda>cte. \<exists>final. finaliseCap (cteCap cte) final True \<noteq> fail) p s \<longrightarrow>
-          P ((cteCaps_of s)(p \<mapsto> NullCap))) \<and>
-     P (cteCaps_of s)\<rbrace>
-     cancelIPC t
-   \<lbrace>\<lambda>rv s. P (cteCaps_of s)\<rbrace>"
-  apply (simp add: cancelIPC_def Let_def capHasProperty_def
-                   getThreadReplySlot_def locateSlot_conv)
-  apply (rule hoare_pre)
-   apply (wp cteDeleteOne_cteCaps_of getCTE_wp' | wpcw
-          | simp add: cte_wp_at_ctes_of
-          | wp (once) hoare_drop_imps cteCaps_of_ctes_of_lift)+
-          apply (wp hoare_convert_imp hoare_vcg_all_lift
-                    threadSet_ctes_of threadSet_cteCaps_of
-                 | clarsimp)+
-         apply (wp cteDeleteOne_cteCaps_of getCTE_wp' | wpcw | simp
-                | wp (once) hoare_drop_imps cteCaps_of_ctes_of_lift)+
-  apply (clarsimp simp: cte_wp_at_ctes_of cteCaps_of_def)
-  apply (drule_tac x="mdbNext (cteMDBNode x)" in spec)
-  apply clarsimp
-  apply (auto simp: o_def map_option_case fun_upd_def[symmetric])
-  done
-
-lemma cancelIPC_cte_wp_at':
-  assumes x: "\<And>cap final. P cap \<Longrightarrow> finaliseCap cap final True = fail"
-  shows "\<lbrace>\<lambda>s. cte_wp_at' (\<lambda>cte. P (cteCap cte)) p s\<rbrace>
-           cancelIPC t
-         \<lbrace>\<lambda>rv s. cte_wp_at' (\<lambda>cte. P (cteCap cte)) p s\<rbrace>"
-  apply (simp add: tree_cte_cteCap_eq[unfolded o_def])
-  apply (rule hoare_pre, wp cancelIPC_cteCaps_of)
-  apply (clarsimp simp: cteCaps_of_def cte_wp_at_ctes_of x)
-  done
-
-crunch tcbSchedDequeue
-  for cte_wp_at'[wp]: "cte_wp_at' P p"
-  (wp: crunch_wps)
-
-lemma suspend_cte_wp_at':
-  assumes x: "\<And>cap final. P cap \<Longrightarrow> finaliseCap cap final True = fail"
-  shows "\<lbrace>cte_wp_at' (\<lambda>cte. P (cteCap cte)) p\<rbrace>
-           suspend t
-         \<lbrace>\<lambda>rv. cte_wp_at' (\<lambda>cte. P (cteCap cte)) p\<rbrace>"
-  apply (simp add: suspend_def updateRestartPC_def)
-  apply (rule hoare_pre)
-   apply (wp threadSet_cte_wp_at' cancelIPC_cte_wp_at'
-             | simp add: x)+
-  done
-
-context begin interpretation Arch . (*FIXME: arch-split*)
-
-crunch deleteASIDPool
-  for cte_wp_at'[wp]: "cte_wp_at' P p"
-  (simp: crunch_simps assertE_def
-   wp: crunch_wps getObject_inv loadObject_default_inv)
-
-lemma deleteASID_cte_wp_at'[wp]:
-  "\<lbrace>cte_wp_at' P p\<rbrace> deleteASID param_a param_b \<lbrace>\<lambda>_. cte_wp_at' P p\<rbrace>"
-  apply (simp add: deleteASID_def
-              cong: option.case_cong)
-  apply (wp setObject_cte_wp_at'[where Q="\<top>"] getObject_inv
-            loadObject_default_inv setVMRoot_cte_wp_at'
-          | clarsimp simp: updateObject_default_def in_monad
-          | rule equals0I
-          | wpc)+
-  done
-
-crunch unmapPageTable, unmapPage, unbindNotification, finaliseCapTrue_standin
-  for cte_wp_at'[wp]: "cte_wp_at' P p"
-  (simp: crunch_simps wp: crunch_wps getObject_inv loadObject_default_inv)
-
-crunch vcpuFinalise
-  for cte_wp_at'[wp]: "cte_wp_at' P p"
-  (wp: crunch_wps getObject_inv loadObject_default_inv)
-
-lemma arch_finaliseCap_cte_wp_at[wp]:
-  "\<lbrace>cte_wp_at' P p\<rbrace> Arch.finaliseCap cap fin \<lbrace>\<lambda>rv. cte_wp_at' P p\<rbrace>"
-  apply (simp add: AARCH64_H.finaliseCap_def)
-  apply (wpsimp wp: unmapPage_cte_wp_at')
-  done
-
-lemma deletingIRQHandler_cte_preserved:
-  assumes x: "\<And>cap final. P cap \<Longrightarrow> finaliseCap cap final True = fail"
-  shows "\<lbrace>cte_wp_at' (\<lambda>cte. P (cteCap cte)) p\<rbrace>
-           deletingIRQHandler irq
-         \<lbrace>\<lambda>rv. cte_wp_at' (\<lambda>cte. P (cteCap cte)) p\<rbrace>"
-  apply (simp add: deletingIRQHandler_def getSlotCap_def
-                   getIRQSlot_def locateSlot_conv getInterruptState_def)
-  apply (wpsimp wp: cteDeleteOne_cte_wp_at_preserved getCTE_wp' simp: x)
-  done
-
-lemma finaliseCap_equal_cap[wp]:
-  "\<lbrace>cte_wp_at' (\<lambda>cte. cteCap cte = cap) sl\<rbrace>
-     finaliseCap cap fin flag
-   \<lbrace>\<lambda>rv. cte_wp_at' (\<lambda>cte. cteCap cte = cap) sl\<rbrace>"
-  apply (simp add: finaliseCap_def Let_def
+lemma finaliseCap_cte_refs:
+  "\<lbrace>\<lambda>s. s \<turnstile>' cap\<rbrace>
+     finaliseCap cap final flag
+   \<lbrace>\<lambda>rv s. fst rv \<noteq> NullCap \<longrightarrow> cte_refs' (fst rv) = cte_refs' cap\<rbrace>"
+  apply (simp add: global.finaliseCap_def Let_def getThreadCSpaceRoot finaliseCap_def
              cong: if_cong split del: if_split)
   apply (rule hoare_pre)
-   apply (wp suspend_cte_wp_at' deletingIRQHandler_cte_preserved
-        | clarsimp simp: finaliseCap_def | wpc)+
-  apply (case_tac cap)
-  apply auto
-  done
-
-lemma setThreadState_st_tcb_at_simplish':
-  "simple' st \<Longrightarrow>
-   \<lbrace>st_tcb_at' (P or simple') t\<rbrace>
-     setThreadState st t'
-   \<lbrace>\<lambda>rv. st_tcb_at' (P or simple') t\<rbrace>"
-  apply (wp sts_st_tcb_at'_cases)
+   apply (wp | wpc | simp only: o_def)+
+  apply (frule valid_capAligned)
+  apply (cases cap, simp_all add: gen_isCap_simps)
+   apply (clarsimp simp: tcb_cte_cases_def word_count_from_top gen_objBits_simps)
   apply clarsimp
+  apply (rule ext, simp)
+  apply (rule image_cong [OF _ refl])
+  apply (fastforce simp: mask_def capAligned_def gen_objBits_simps shiftL_nat)
   done
 
-lemmas setThreadState_st_tcb_at_simplish
-    = setThreadState_st_tcb_at_simplish'[unfolded pred_disj_def]
+lemma emptySlot_invs'[wp]:
+  "\<lbrace>\<lambda>s. invs' s \<and> cte_wp_at' (\<lambda>cte. removeable' sl s (cteCap cte)) sl s
+            \<and> (info \<noteq> NullCap \<longrightarrow> post_cap_delete_pre' info sl (cteCaps_of s) )\<rbrace>
+     emptySlot sl info
+   \<lbrace>\<lambda>rv. invs'\<rbrace>"
+  apply (simp add: invs'_def valid_state'_def valid_pspace'_def)
+  apply (wp valid_irq_node_lift cur_tcb_lift valid_dom_schedule'_lift)
+  apply (clarsimp simp: cte_wp_at_ctes_of post_cap_delete_pre'_def cteCaps_of_def
+                 split: capability.split_asm)
+  by auto
 
-crunch cteDeleteOne
-  for st_tcb_at_simplish: "st_tcb_at' (\<lambda>st. P st \<or> simple' st) t"
-  (wp: crunch_wps getObject_inv loadObject_default_inv threadSet_pred_tcb_no_state
-   simp: crunch_simps unless_def ignore: threadSet)
-
-lemma cteDeleteOne_st_tcb_at[wp]:
-  assumes x[simp]: "\<And>st. simple' st \<longrightarrow> P st" shows
-  "\<lbrace>st_tcb_at' P t\<rbrace> cteDeleteOne slot \<lbrace>\<lambda>rv. st_tcb_at' P t\<rbrace>"
-  apply (subgoal_tac "\<exists>Q. P = (Q or simple')")
-   apply (clarsimp simp: pred_disj_def)
-   apply (rule cteDeleteOne_st_tcb_at_simplish)
-  apply (rule_tac x=P in exI)
-  apply auto
-  done
-
-lemma cteDeleteOne_reply_pred_tcb_at:
-  "\<lbrace>\<lambda>s. pred_tcb_at' proj P t s \<and> (\<exists>t' r. cte_wp_at' (\<lambda>cte. cteCap cte = ReplyCap t' False r) slot s)\<rbrace>
-    cteDeleteOne slot
-   \<lbrace>\<lambda>rv. pred_tcb_at' proj P t\<rbrace>"
-  apply (simp add: cteDeleteOne_def unless_def isFinalCapability_def)
-  apply (rule bind_wp [OF _ getCTE_sp])
-  apply (rule hoare_assume_pre)
-  apply (clarsimp simp: cte_wp_at_ctes_of when_def isCap_simps
-                        Let_def finaliseCapTrue_standin_def)
-  apply (intro impI conjI, (wp | simp)+)
-  done
-
-lemmas setNotification_typ_at'[wp] = typ_at_lifts[OF setNotification_typ_at']
-
-crunch setBoundNotification, setNotification
-  for sch_act_simple[wp]: sch_act_simple
-  (wp: sch_act_simple_lift)
-
-crunch cteDeleteOne, unbindNotification
-  for sch_act_simple[wp]: sch_act_simple
-  (wp: crunch_wps ssa_sch_act_simple sts_sch_act_simple getObject_inv
-       loadObject_default_inv
-   simp: crunch_simps
-   rule: sch_act_simple_lift)
-
-lemma rescheduleRequired_sch_act_not[wp]:
-  "\<lbrace>\<top>\<rbrace> rescheduleRequired \<lbrace>\<lambda>rv. sch_act_not t\<rbrace>"
-  apply (simp add: rescheduleRequired_def setSchedulerAction_def)
-  apply (wp hoare_TrueI | simp)+
-  done
-
-crunch cteDeleteOne
-  for sch_act_not[wp]: "sch_act_not t"
-  (simp: crunch_simps case_Null_If unless_def
-   wp: crunch_wps getObject_inv loadObject_default_inv)
-
-lemma cancelAllIPC_mapM_x_weak_sch_act:
-  "\<lbrace>\<lambda>s. weak_sch_act_wf (ksSchedulerAction s) s\<rbrace>
-   mapM_x (\<lambda>t. do
-                 y \<leftarrow> setThreadState Structures_H.thread_state.Restart t;
-                 tcbSchedEnqueue t
-               od) q
-   \<lbrace>\<lambda>rv s. weak_sch_act_wf (ksSchedulerAction s) s\<rbrace>"
-  apply (rule mapM_x_wp_inv)
-  apply (wp)
-  apply (clarsimp)
-  done
-
-lemma cancelAllIPC_mapM_x_valid_objs':
-  "\<lbrace>valid_objs' and pspace_aligned' and pspace_distinct'\<rbrace>
-   mapM_x (\<lambda>t. do
-                 y \<leftarrow> setThreadState Structures_H.thread_state.Restart t;
-                 tcbSchedEnqueue t
-               od) q
-   \<lbrace>\<lambda>_. valid_objs'\<rbrace>"
-  apply (rule hoare_strengthen_post)
-   apply (rule mapM_x_wp')
-  apply (wpsimp wp: sts_valid_objs')
-   apply (clarsimp simp: valid_tcb_state'_def)+
-  done
-
-lemma cancelAllIPC_mapM_x_tcbDomain_obj_at':
-  "\<lbrace>obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>
-   mapM_x (\<lambda>t. do
-                 y \<leftarrow> setThreadState Structures_H.thread_state.Restart t;
-                 tcbSchedEnqueue t
-               od) q
-  \<lbrace>\<lambda>_. obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>"
-  by (wp mapM_x_wp' | simp)+
-
-lemma rescheduleRequired_oa_queued':
-  "rescheduleRequired \<lbrace>obj_at' (\<lambda>tcb. Q (tcbDomain tcb) (tcbPriority tcb)) t\<rbrace>"
-  unfolding rescheduleRequired_def tcbSchedEnqueue_def tcbQueuePrepend_def
-  by wpsimp
-
-lemma cancelAllIPC_tcbDomain_obj_at':
-  "\<lbrace>obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>
-     cancelAllIPC epptr
-   \<lbrace>\<lambda>_. obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>"
-  apply (simp add: cancelAllIPC_def)
-  apply (wp hoare_vcg_conj_lift hoare_vcg_const_Ball_lift
-            rescheduleRequired_oa_queued' cancelAllIPC_mapM_x_tcbDomain_obj_at'
-            getEndpoint_wp
-       | wpc
-       | simp)+
-  done
-
-lemma cancelAllSignals_tcbDomain_obj_at':
-  "\<lbrace>obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>
-     cancelAllSignals epptr
-   \<lbrace>\<lambda>_. obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>"
-apply (simp add: cancelAllSignals_def)
-apply (wp hoare_vcg_conj_lift hoare_vcg_const_Ball_lift
-          rescheduleRequired_oa_queued' cancelAllIPC_mapM_x_tcbDomain_obj_at'
-          getNotification_wp
-     | wpc
-     | simp)+
-done
-
-lemma unbindMaybeNotification_tcbDomain_obj_at':
-  "\<lbrace>obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>
-     unbindMaybeNotification r
-   \<lbrace>\<lambda>_. obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>"
-  unfolding unbindMaybeNotification_def
-  by (wpsimp wp: getNotification_wp gbn_wp' simp: setBoundNotification_def)+
-
-crunch isFinalCapability
-  for sch_act[wp]: "\<lambda>s. sch_act_wf (ksSchedulerAction s) s"
-  (simp: crunch_simps)
-
-crunch
-  isFinalCapability
-  for weak_sch_act[wp]: "\<lambda>s. weak_sch_act_wf (ksSchedulerAction s) s"
-  (simp: crunch_simps)
-
-crunch cteDeleteOne
-  for ksCurDomain[wp]: "\<lambda>s. P (ksCurDomain s)"
-  (wp: crunch_wps simp: crunch_simps unless_def)
-
-lemma cteDeleteOne_tcbDomain_obj_at':
-  "\<lbrace>obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace> cteDeleteOne slot \<lbrace>\<lambda>_. obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>"
-  apply (simp add: cteDeleteOne_def unless_def split_def)
-  apply (wp emptySlot_tcbDomain cancelAllIPC_tcbDomain_obj_at' cancelAllSignals_tcbDomain_obj_at'
-          isFinalCapability_inv getCTE_wp
-          unbindMaybeNotification_tcbDomain_obj_at'
-     | rule hoare_drop_imp
-     | simp add: finaliseCapTrue_standin_def Let_def
-            split del: if_split
-     | wpc)+
-  apply (clarsimp simp: cte_wp_at'_def)
-  done
-
-end
-
-global_interpretation delete_one_conc_pre
-  by (unfold_locales, wp)
-     (wp cteDeleteOne_tcbDomain_obj_at' cteDeleteOne_typ_at' cteDeleteOne_reply_pred_tcb_at | simp)+
-
-context begin interpretation Arch . (*FIXME: arch-split*)
-
-lemma cteDeleteOne_invs[wp]:
-  "\<lbrace>invs'\<rbrace> cteDeleteOne ptr \<lbrace>\<lambda>rv. invs'\<rbrace>"
+lemma cteDeleteOne_invs[Finalise_R_3_assms, wp]:
+  "cteDeleteOne ptr \<lbrace>invs'\<rbrace>"
   apply (simp add: cteDeleteOne_def unless_def
                    split_def finaliseCapTrue_standin_simple_def)
   apply wp
     apply (rule hoare_strengthen_post)
-     apply (rule hoare_vcg_conj_lift)
-      apply (rule finaliseCap_True_invs)
-     apply (rule hoare_vcg_conj_lift)
-      apply (rule finaliseCap_replaceable[where slot=ptr])
-     apply (rule hoare_vcg_conj_lift)
-      apply (rule finaliseCap_cte_refs)
+     apply (rule hoare_vcg_conj_lift[OF finaliseCap_True_invs])
+     apply (rule hoare_vcg_conj_lift[OF finaliseCap_replaceable[where slot=ptr]])
+     apply (rule hoare_vcg_conj_lift[OF finaliseCap_cte_refs])
      apply (rule finaliseCap_equal_cap[where sl=ptr])
     apply (clarsimp simp: cte_wp_at_ctes_of)
-    apply (erule disjE)
-     apply simp
+    apply (erule disjE, solves simp)
     apply (clarsimp dest!: isCapDs simp: capRemovable_def)
     apply (clarsimp simp: removeable'_def fun_eq_iff[where f="cte_refs' cap" for cap]
                      del: disjCI)
-    apply (rule disjI2)
-    apply (rule conjI)
-     subgoal by auto
-    subgoal by (auto dest!: isCapDs simp: pred_tcb_at'_def obj_at'_def
-                                     live'_def hyp_live'_def ko_wp_at'_def)
+    subgoal by (auto dest!: isCapDs simp: pred_tcb_at'_def obj_at'_def live'_def ko_wp_at'_def)
    apply (wp isFinalCapability_inv getCTE_wp' hoare_weak_lift_imp
-        | wp (once) isFinal[where x=ptr])+
+          | wp (once) isFinal[where x=ptr])+
   apply (fastforce simp: cte_wp_at_ctes_of)
   done
 
-end
-
-global_interpretation delete_one_conc_fr: delete_one_conc
-  by unfold_locales wp
-
-declare cteDeleteOne_invs[wp]
-
-lemma deletingIRQHandler_invs' [wp]:
-  "\<lbrace>invs'\<rbrace> deletingIRQHandler i \<lbrace>\<lambda>_. invs'\<rbrace>"
-  apply (simp add: deletingIRQHandler_def getSlotCap_def
-                   getIRQSlot_def locateSlot_conv getInterruptState_def)
-  apply (wp getCTE_wp')
-  apply simp
-  done
-
-lemma finaliseCap_invs:
-  "\<lbrace>invs' and sch_act_simple and valid_cap' cap
-         and cte_wp_at' (\<lambda>cte. cteCap cte = cap) sl\<rbrace>
-     finaliseCap cap fin flag
-   \<lbrace>\<lambda>rv. invs'\<rbrace>"
-  apply (simp add: finaliseCap_def Let_def
-             cong: if_cong split del: if_split)
-  apply (rule hoare_pre)
-   apply (wp hoare_drop_imps hoare_vcg_all_lift | simp only: o_def | wpc)+
+lemma isFinalCapability_corres'[Finalise_R_3_assms]:
+  "final_matters' (cteCap cte) \<Longrightarrow>
+   corres (=) (invs and cte_wp_at ((=) cap) ptr)
+               (invs' and cte_wp_at' ((=) cte) (cte_map ptr))
+       (is_final_cap cap) (isFinalCapability cte)"
+  apply (rule corres_gets_lift)
+      apply (rule isFinalCapability_inv)
+     apply (rule isFinal[where x="cte_map ptr"])
+    apply clarsimp
+    apply (rule conjI, clarsimp)
+    apply (rule refl)
+   apply (rule no_fail_pre, wp, fastforce)
+  apply (simp add: is_final_cap_def)
+  apply (clarsimp simp: cte_wp_at_ctes_of cteCaps_of_def state_relation_def)
+  apply (frule (1) pspace_relation_ctes_ofI)
+    apply fastforce
+   apply fastforce
   apply clarsimp
-  apply (intro conjI impI)
-    apply (clarsimp dest!: isCapDs simp: valid_cap'_def)
-   apply (drule invs_valid_global', drule(1) valid_globals_cte_wpD')
-   apply (drule valid_capAligned, drule capAligned_capUntypedPtr)
-    apply (clarsimp dest!: isCapDs)
-   apply (clarsimp dest!: isCapDs)
-  apply (clarsimp dest!: isCapDs)
-  done
-
-lemma finaliseCap_zombie_cap[wp]:
-  "\<lbrace>cte_wp_at' (\<lambda>cte. (P and isZombie) (cteCap cte)) sl\<rbrace>
-     finaliseCap cap fin flag
-   \<lbrace>\<lambda>rv. cte_wp_at' (\<lambda>cte. (P and isZombie) (cteCap cte)) sl\<rbrace>"
-  apply (simp add: finaliseCap_def Let_def
-             cong: if_cong split del: if_split)
-  apply (rule hoare_pre)
-   apply (wp suspend_cte_wp_at' deletingIRQHandler_cte_preserved
-          | clarsimp simp: finaliseCap_def gen_isCap_simps | wpc)+
-  done
-
-lemma finaliseCap_zombie_cap':
-  "\<lbrace>cte_wp_at' (\<lambda>cte. (P and isZombie) (cteCap cte)) sl\<rbrace>
-     finaliseCap cap fin flag
-   \<lbrace>\<lambda>rv. cte_wp_at' (\<lambda>cte. P (cteCap cte)) sl\<rbrace>"
-  apply (rule hoare_strengthen_post)
-   apply (rule finaliseCap_zombie_cap)
-  apply (clarsimp simp: cte_wp_at_ctes_of)
-  done
-
-lemma finaliseCap_cte_cap_wp_to[wp]:
-  "\<lbrace>ex_cte_cap_wp_to' P sl\<rbrace> finaliseCap cap fin flag \<lbrace>\<lambda>rv. ex_cte_cap_wp_to' P sl\<rbrace>"
-  apply (simp add: ex_cte_cap_to'_def)
-  apply (rule hoare_pre, rule hoare_use_eq_irq_node' [OF finaliseCap_irq_node'])
-   apply (simp add: finaliseCap_def Let_def
-              cong: if_cong split del: if_split)
-   apply (wp suspend_cte_wp_at'
-             deletingIRQHandler_cte_preserved
-             hoare_vcg_ex_lift
-                 | clarsimp simp: finaliseCap_def gen_isCap_simps
-                 | rule conjI
-                 | wpc)+
-  apply fastforce
-  done
-
-crunch unbindNotification
-  for valid_cap'[wp]: "valid_cap' cap"
-
-lemma finaliseCap_valid_cap[wp]:
-  "\<lbrace>valid_cap' cap\<rbrace> finaliseCap cap final flag \<lbrace>\<lambda>rv. valid_cap' (fst rv)\<rbrace>"
-  apply (simp add: finaliseCap_def Let_def
-                   getThreadCSpaceRoot
-                   AARCH64_H.finaliseCap_def
-             cong: if_cong split del: if_split)
-  apply (rule hoare_pre)
-   apply (wp | simp only: valid_NullCap o_def fst_conv | wpc)+
+  apply (rule iffI)
+   apply (simp add: is_final_cap'_def2 isFinal_def)
+   apply clarsimp
+   apply (subgoal_tac "obj_refs cap \<noteq> {} \<or> cap_irqs cap \<noteq> {} \<or> arch_gen_refs cap \<noteq> {}")
+    prefer 2
+    apply (erule_tac x=a in allE)
+    apply (erule_tac x=b in allE)
+    apply (clarsimp simp: cte_wp_at_def gen_obj_refs_Int)
+   apply (subgoal_tac "ptr = (a,b)")
+    prefer 2
+    apply (erule_tac x="fst ptr" in allE)
+    apply (erule_tac x="snd ptr" in allE)
+    apply (clarsimp simp: cte_wp_at_def gen_obj_refs_Int)
+   apply clarsimp
+   apply (rule context_conjI)
+    apply (clarsimp simp: isCap_simps)
+    apply (cases cap, auto)[1]
+   apply clarsimp
+   apply (drule_tac x=p' in pspace_relation_cte_wp_atI, assumption)
+    apply fastforce
+   apply clarsimp
+   apply (erule_tac x=aa in allE)
+   apply (erule_tac x=ba in allE)
+   apply (clarsimp simp: cte_wp_at_caps_of_state)
+   apply (clarsimp simp: sameObjectAs_def3 obj_refs_relation_Master cap_irqs_relation_Master
+                         arch_gen_refs_relation_Master gen_obj_refs_Int
+                   cong: if_cong
+                  split: capability.split_asm)
+  apply (clarsimp simp: isFinal_def is_final_cap'_def3)
+  apply (rule_tac x="fst ptr" in exI)
+  apply (rule_tac x="snd ptr" in exI)
+  apply (rule conjI)
+   apply (clarsimp simp: cte_wp_at_def final_matters'_def arch_final_matters'_def
+                         gen_obj_refs_Int
+                  split: cap_relation_split_asm arch_cap.split_asm)
+  apply clarsimp
+  apply (drule_tac p="(a,b)" in cte_wp_at_norm)
+  apply clarsimp
+  apply (frule_tac slot="(a,b)" in pspace_relation_ctes_ofI, assumption)
+    apply fastforce
+   apply fastforce
+  apply clarsimp
+  apply (frule_tac p="(a,b)" in cte_wp_valid_cap, fastforce)
+  apply (erule_tac x="cte_map (a,b)" in allE)
   apply simp
-  apply (intro conjI impI)
-   apply (clarsimp simp: valid_cap'_def gen_isCap_simps capAligned_def
-                         AARCH64.objBits_simps shiftL_nat)+
+  apply (erule impCE, simp, drule cte_map_inj_eq)
+        apply (erule cte_wp_at_weakenE, rule TrueI)
+       apply (erule cte_wp_at_weakenE, rule TrueI)
+      apply fastforce
+     apply fastforce
+    apply (erule invs_distinct)
+   apply simp
+  apply (frule_tac p=ptr in cte_wp_valid_cap, fastforce)
+  apply (clarsimp simp: cte_wp_at_def gen_obj_refs_Int)
+  apply (rule conjI)
+   apply (rule classical)
+   apply (frule(1) zombies_finalD2[OF _ _ _ invs_zombies],
+          simp?, clarsimp, assumption+)
+   subgoal by (clarsimp simp: sameObjectAs_def3 isCap_simps valid_cap_def valid_arch_cap_def
+                              valid_arch_cap_ref_def obj_at_def is_obj_defs a_type_def
+                              final_matters'_def arch_final_matters'_def
+                        split: cap.split_asm arch_cap.split_asm option.split_asm if_split_asm,
+               simp_all add: is_cap_defs)
+  apply (rule classical)
+  apply (clarsimp simp: cap_irqs_def cap_irq_opt_def sameObjectAs_def3 isCap_simps
+                 split: cap.split_asm)
   done
-
-lemma no_idle_thread_cap:
-  "\<lbrakk> cte_wp_at ((=) (cap.ThreadCap (idle_thread s))) sl s; valid_global_refs s \<rbrakk> \<Longrightarrow> False"
-  apply (cases sl)
-  apply (clarsimp simp: valid_global_refs_def valid_refs_def cte_wp_at_caps_of_state)
-  apply ((erule allE)+, erule (1) impE)
-  apply (clarsimp simp: cap_range_def)
-  done
-
-lemmas getCTE_no_0_obj'_helper
-  = getCTE_inv
-    hoare_strengthen_post[where Q'="\<lambda>_. no_0_obj'" and P=no_0_obj' and f="getCTE slot" for slot]
-
-context begin interpretation Arch . (*FIXME: arch-split*)
 
 crunch invalidateTLBByASID
   for nosch[wp]: "\<lambda>s. P (ksSchedulerAction s)"
@@ -3839,67 +1383,20 @@ crunch dissociateVCPUTCB, unmapPageTable
   (wp: crunch_wps getVCPU_wp getObject_inv hoare_vcg_all_lift hoare_vcg_if_lift3
    simp: loadObject_default_def updateObject_default_def)
 
-crunch "Arch.finaliseCap"
-  for nosch[wp]: "\<lambda>s. P (ksSchedulerAction s)"
-  (wp: crunch_wps getObject_inv simp: loadObject_default_def updateObject_default_def)
+context notes if_cong[cong] begin
 
-crunch finaliseCap
+crunch Arch_finaliseCap
+  for nosch[wp]: "\<lambda>s. P (ksSchedulerAction s)"
+  (wp: crunch_wps getObject_inv simp: loadObject_default_def updateObject_default_def
+   rule: AARCH64_H.finaliseCap_def)
+
+end
+
+crunch vcpuFinalise, deletingIRQHandler, finaliseCap
   for sch_act_simple[wp]: sch_act_simple
   (simp: crunch_simps
    rule: sch_act_simple_lift
    wp: getObject_inv loadObject_default_inv crunch_wps)
-
-end
-
-
-lemma interrupt_cap_null_or_ntfn:
-  "invs s
-    \<Longrightarrow> cte_wp_at (\<lambda>cp. is_ntfn_cap cp \<or> cp = cap.NullCap) (interrupt_irq_node s irq, []) s"
-  apply (frule invs_valid_irq_node)
-  apply (clarsimp simp: valid_irq_node_def)
-  apply (drule_tac x=irq in spec)
-  apply (drule cte_at_0)
-  apply (clarsimp simp: cte_wp_at_caps_of_state)
-  apply (drule caps_of_state_cteD)
-  apply (frule if_unsafe_then_capD, clarsimp+)
-  apply (clarsimp simp: ex_cte_cap_wp_to_def cte_wp_at_caps_of_state)
-  apply (frule cte_refs_obj_refs_elem, erule disjE)
-   apply (clarsimp | drule caps_of_state_cteD valid_global_refsD[rotated]
-     | rule irq_node_global_refs[where irq=irq])+
-   apply (simp add: cap_range_def)
-  apply (clarsimp simp: appropriate_cte_cap_def
-                 split: cap.split_asm)
-  done
-
-lemma (in delete_one) deletingIRQHandler_corres:
-  "corres dc (einvs) (invs')
-          (deleting_irq_handler irq) (deletingIRQHandler irq)"
-  apply (simp add: deleting_irq_handler_def deletingIRQHandler_def)
-  apply (rule corres_guard_imp)
-    apply (rule corres_split[OF getIRQSlot_corres])
-      apply simp
-      apply (rule_tac P'="cte_at' (cte_map slot)" in corres_symb_exec_r_conj)
-         apply (rule_tac F="isNotificationCap rv \<or> rv = capability.NullCap"
-             and P="cte_wp_at (\<lambda>cp. is_ntfn_cap cp \<or> cp = cap.NullCap) slot
-                 and einvs"
-             and P'="invs' and cte_wp_at' (\<lambda>cte. cteCap cte = rv)
-                 (cte_map slot)" in corres_req)
-          apply (clarsimp simp: cte_wp_at_caps_of_state state_relation_def)
-          apply (drule caps_of_state_cteD)
-          apply (drule(1) pspace_relation_cte_wp_at, clarsimp+)
-          apply (auto simp: cte_wp_at_ctes_of is_cap_simps gen_isCap_simps)[1]
-         apply simp
-         apply (rule corres_guard_imp, rule delete_one_corres[unfolded dc_def])
-          apply (auto simp: cte_wp_at_caps_of_state is_cap_simps can_fast_finalise_def)[1]
-         apply (clarsimp simp: cte_wp_at_ctes_of)
-        apply (wp getCTE_wp' | simp add: getSlotCap_def)+
-     apply (wp | simp add: get_irq_slot_def getIRQSlot_def
-                           locateSlot_conv getInterruptState_def)+
-   apply (clarsimp simp: ex_cte_cap_wp_to_def interrupt_cap_null_or_ntfn)
-  apply (clarsimp simp: cte_wp_at_ctes_of)
-  done
-
-context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma sym_refs_vcpu_tcb: (* FIXME: move to AInvs *)
   "\<lbrakk> vcpus_of s v = Some vcpu; vcpu_tcb vcpu = Some t; sym_refs (state_hyp_refs_of s) \<rbrakk> \<Longrightarrow>
@@ -3925,13 +1422,7 @@ lemma vcpuFinalise_corres[corres]:
   apply (fastforce elim: vcpu_at_cross)
   done
 
-lemma return_NullCap_pair_corres[corres]:
-  "corres (\<lambda>r r'. cap_relation (fst r) (fst r') \<and> cap_relation (snd r) (snd r'))
-          \<top> \<top>
-          (return (cap.NullCap, cap.NullCap)) (return (NullCap, NullCap))"
-  by (corres corres: corres_returnTT)
-
-lemma arch_finaliseCap_corres:
+lemma arch_finaliseCap_corres[Finalise_R_3_assms]:
   "\<lbrakk> final_matters' (ArchObjectCap cap') \<Longrightarrow> final = final'; acap_relation cap cap' \<rbrakk>
      \<Longrightarrow> corres (\<lambda>r r'. cap_relation (fst r) (fst r') \<and> cap_relation (snd r) (snd r'))
            (\<lambda>s. invs s \<and> s \<turnstile> cap.ArchObjectCap cap
@@ -3943,8 +1434,9 @@ lemma arch_finaliseCap_corres:
                       final' = isFinal (ArchObjectCap cap') (cte_map sl) (cteCaps_of s)))
            (arch_finalise_cap cap final) (Arch.finaliseCap cap' final')"
   apply (simp add: arch_finalise_cap_def AARCH64_H.finaliseCap_def)
-  apply (corres_cases_both simp: final_matters'_def acap_relation_def mdata_map_def |
-         corres corres: deleteASIDPool_corres[@lift_corres_args] unmapPageTable_corres)+
+  apply (corres_cases_both simp: final_matters'_def arch_final_matters'_def acap_relation_def
+                                 mdata_map_def
+         | corres corres: deleteASIDPool_corres[@lift_corres_args] unmapPageTable_corres)+
    apply (clarsimp simp: valid_cap_def)
    apply (rule conjI, clarsimp simp: wellformed_mapdata_def valid_unmap_def vmsz_aligned_def)+
     apply (fastforce dest: vspace_for_asid_not_normal_pt simp: wellformed_mapdata_def)
@@ -3952,314 +1444,14 @@ lemma arch_finaliseCap_corres:
   apply fastforce
   done
 
-lemma unbindNotification_corres:
-  "corres dc
-      (invs and tcb_at t)
-      invs'
-      (unbind_notification t)
-      (unbindNotification t)"
-  apply (simp add: unbind_notification_def unbindNotification_def)
-  apply (rule corres_guard_imp)
-    apply (rule corres_split[OF getBoundNotification_corres])
-      apply (rule corres_option_split)
-        apply simp
-       apply (rule corres_return_trivial)
-      apply (rule corres_split[OF getNotification_corres])
-        apply clarsimp
-        apply (rule corres_split[OF setNotification_corres])
-           apply (clarsimp simp: ntfn_relation_def split:Structures_A.ntfn.splits)
-          apply (rule setBoundNotification_corres)
-         apply (wp gbn_wp' gbn_wp)+
-   apply (clarsimp elim!: obj_at_valid_objsE
-                   dest!: bound_tcb_at_state_refs_ofD invs_valid_objs
-                    simp: valid_obj_def is_tcb tcb_ntfn_is_bound_def obj_at_def
-                          valid_tcb_def valid_bound_ntfn_def invs_psp_aligned invs_distinct
-                   split: option.splits)
-  apply (clarsimp dest!: obj_at_valid_objs' bound_tcb_at_state_refs_ofD' invs_valid_objs'
-                   simp: valid_obj'_def valid_tcb'_def valid_bound_ntfn'_def tcb_ntfn_is_bound'_def
-                  split: option.splits)
-  done
+lemmas deleteCallerCap_typ_ats[wp] = typ_at_lifts[OF deleteCallerCap_typ_at']
 
-lemma unbindMaybeNotification_corres:
-  "corres dc
-      (invs and ntfn_at ntfnptr) (invs' and ntfn_at' ntfnptr)
-      (unbind_maybe_notification ntfnptr)
-      (unbindMaybeNotification ntfnptr)"
-  apply (simp add: unbind_maybe_notification_def unbindMaybeNotification_def)
-  apply (rule corres_guard_imp)
-    apply (rule corres_split[OF getNotification_corres])
-      apply (rule corres_option_split)
-        apply (clarsimp simp: ntfn_relation_def split: Structures_A.ntfn.splits)
-       apply (rule corres_return_trivial)
-      apply simp
-      apply (rule corres_split[OF setNotification_corres])
-         apply (clarsimp simp: ntfn_relation_def split: Structures_A.ntfn.splits)
-        apply (rule setBoundNotification_corres)
-       apply (wp get_simple_ko_wp getNotification_wp)+
-   apply (clarsimp elim!: obj_at_valid_objsE
-                   dest!: bound_tcb_at_state_refs_ofD invs_valid_objs
-                    simp: valid_obj_def is_tcb tcb_ntfn_is_bound_def invs_psp_aligned invs_distinct
-                          valid_tcb_def valid_bound_ntfn_def valid_ntfn_def
-                   split: option.splits)
-  apply (clarsimp dest!: obj_at_valid_objs' bound_tcb_at_state_refs_ofD' invs_valid_objs'
-                   simp: valid_obj'_def valid_tcb'_def valid_bound_ntfn'_def
-                         tcb_ntfn_is_bound'_def valid_ntfn'_def
-                  split: option.splits)
-  done
+end (* Arch *)
 
-lemma fast_finaliseCap_corres:
-  "\<lbrakk> final_matters' cap' \<longrightarrow> final = final'; cap_relation cap cap';
-     can_fast_finalise cap \<rbrakk>
-   \<Longrightarrow> corres dc
-           (\<lambda>s. invs s \<and> valid_sched s \<and> s \<turnstile> cap
-                       \<and> cte_wp_at ((=) cap) sl s)
-           (\<lambda>s. invs' s \<and> s \<turnstile>' cap')
-           (fast_finalise cap final)
-           (do
-               p \<leftarrow> finaliseCap cap' final' True;
-               assert (capRemovable (fst p) (cte_map ptr) \<and> snd p = NullCap)
-            od)"
-  apply (cases cap, simp_all add: finaliseCap_def isCap_simps
-                                  corres_liftM2_simp[unfolded liftM_def]
-                                  o_def dc_def[symmetric] when_def
-                                  can_fast_finalise_def capRemovable_def
-                       split del: if_split cong: if_cong)
-   apply (clarsimp simp: final_matters'_def)
-   apply (rule corres_guard_imp)
-     apply (rule corres_rel_imp)
-      apply (rule ep_cancel_corres)
-     apply simp
-    apply (simp add: valid_cap_def)
-   apply (simp add: valid_cap'_def)
-  apply (clarsimp simp: final_matters'_def)
-  apply (rule corres_guard_imp)
-    apply (rule corres_split[OF unbindMaybeNotification_corres])
-         apply (rule cancelAllSignals_corres)
-       apply (wp abs_typ_at_lifts unbind_maybe_notification_invs typ_at_lifts hoare_drop_imps getNotification_wp
-            | wpc)+
-   apply (clarsimp simp: valid_cap_def)
-  apply (clarsimp simp: valid_cap'_def valid_obj'_def
-                 dest!: invs_valid_objs' obj_at_valid_objs' )
-  done
-
-lemma cap_delete_one_corres:
-  "corres dc (einvs and cte_wp_at can_fast_finalise ptr)
-        (invs' and cte_at' (cte_map ptr))
-        (cap_delete_one ptr) (cteDeleteOne (cte_map ptr))"
-  apply (simp add: cap_delete_one_def cteDeleteOne_def'
-                   unless_def when_def)
-  apply (rule corres_guard_imp)
-    apply (rule corres_split[OF get_cap_corres])
-      apply (rule_tac F="can_fast_finalise cap" in corres_gen_asm)
-      apply (rule corres_if)
-        apply fastforce
-       apply (rule corres_split[OF isFinalCapability_corres[where ptr=ptr]])
-         apply (simp add: split_def bind_assoc [THEN sym])
-         apply (rule corres_split[OF fast_finaliseCap_corres[where sl=ptr]])
-              apply simp+
-           apply (rule emptySlot_corres, simp)
-          apply (wp hoare_drop_imps)+
-       apply (wp isFinalCapability_inv | wp (once) isFinal[where x="cte_map ptr"])+
-      apply (rule corres_trivial, simp)
-     apply (wp get_cap_wp getCTE_wp)+
-   apply (clarsimp simp: cte_wp_at_caps_of_state can_fast_finalise_Null
-                  elim!: caps_of_state_valid_cap)
-  apply (clarsimp simp: cte_wp_at_ctes_of)
-  apply fastforce
-  done
-
-context
-notes option.case_cong_weak[cong]
-begin
-crunch ThreadDecls_H.suspend, unbindNotification
-  for no_0_obj'[wp]: no_0_obj'
-  (simp: crunch_simps wp: crunch_wps getCTE_no_0_obj'_helper)
-end
-
-end
-(* FIXME: strengthen locale instead *)
-
-global_interpretation delete_one
-  apply unfold_locales
-  apply (rule corres_guard_imp)
-    apply (rule cap_delete_one_corres)
-   apply auto
-  done
-
-lemma finaliseCap_corres:
-  "\<lbrakk> final_matters' cap' \<Longrightarrow> final = final'; cap_relation cap cap';
-          flag \<longrightarrow> can_fast_finalise cap \<rbrakk>
-     \<Longrightarrow> corres (\<lambda>x y. cap_relation (fst x) (fst y) \<and> cap_relation (snd x) (snd y))
-           (\<lambda>s. einvs s \<and> s \<turnstile> cap \<and> (final_matters cap \<longrightarrow> final = is_final_cap' cap s)
-                       \<and> cte_wp_at ((=) cap) sl s)
-           (\<lambda>s. invs' s \<and> s \<turnstile>' cap' \<and> sch_act_simple s \<and>
-                 (final_matters' cap' \<longrightarrow>
-                      final' = isFinal cap' (cte_map sl) (cteCaps_of s)))
-           (finalise_cap cap final) (finaliseCap cap' final' flag)"
-  supply invs_no_0_obj'[simp]
-  apply (cases cap, simp_all add: finaliseCap_def gen_isCap_simps
-                                  corres_liftM2_simp[unfolded liftM_def]
-                                  o_def dc_def[symmetric] when_def
-                                  can_fast_finalise_def
-                       split del: if_split cong: if_cong)
-        apply (clarsimp simp: final_matters'_def)
-        apply (rule corres_guard_imp)
-          apply (rule ep_cancel_corres)
-         apply (simp add: valid_cap_def)
-        apply (simp add: valid_cap'_def)
-       apply (clarsimp simp add: final_matters'_def)
-       apply (rule corres_guard_imp)
-         apply (rule corres_split[OF unbindMaybeNotification_corres])
-           apply (rule cancelAllSignals_corres)
-          apply (wp abs_typ_at_lifts unbind_maybe_notification_invs AARCH64.typ_at_lifts hoare_drop_imps hoare_vcg_all_lift | wpc)+
-        apply (clarsimp simp: valid_cap_def)
-       apply (clarsimp simp: valid_cap'_def)
-      apply (fastforce simp: final_matters'_def shiftL_nat zbits_map_def)
-     apply (clarsimp simp add: final_matters'_def getThreadCSpaceRoot
-                               liftM_def[symmetric] o_def zbits_map_def
-                               dc_def[symmetric])
-     apply (rename_tac t)
-     apply (rule_tac P="\<lambda>s. t \<noteq> idle_thread s" and P'="\<lambda>s. t \<noteq> ksIdleThread s" in corres_add_guard)
-      apply clarsimp
-      apply (rule context_conjI)
-       apply (clarsimp dest!: no_idle_thread_cap)
-      apply (clarsimp simp: state_relation_def)
-     apply (rule corres_guard_imp)
-       apply (rule corres_split[OF unbindNotification_corres])
-         apply (rule corres_split[OF suspend_corres])
-           apply (clarsimp simp: liftM_def[symmetric] o_def dc_def[symmetric] zbits_map_def)
-           apply (rule AARCH64.prepareThreadDelete_corres, simp) (* FIXME arch-split: interface *)
-          apply (wp unbind_notification_invs unbind_notification_simple_sched_action
-                    delete_one_conc_fr.suspend_objs')+
-      apply (clarsimp simp add: valid_cap_def)
-     apply (clarsimp simp add: valid_cap'_def)
-    apply (simp add: final_matters'_def liftM_def[symmetric]
-                     o_def dc_def[symmetric])
-    apply (intro impI, rule corres_guard_imp)
-      apply (rule deletingIRQHandler_corres)
-     apply simp
-    apply simp
-   apply (clarsimp simp: final_matters'_def)
-   apply (rule_tac F="False" in corres_req)
-    apply clarsimp
-    apply (frule zombies_finalD, (clarsimp simp: is_cap_simps)+)
-    apply (clarsimp simp: cte_wp_at_caps_of_state)
-   apply simp
-  apply (clarsimp split del: if_split simp: o_def)
-  apply (rule corres_guard_imp [OF arch_finaliseCap_corres], (fastforce simp: valid_sched_def)+)
-  done
-
-context begin interpretation Arch . (*FIXME: arch-split*)
-
-lemma threadSet_ct_idle_or_in_cur_domain':
-  "\<lbrace>ct_idle_or_in_cur_domain' and (\<lambda>s. \<forall>tcb. tcbDomain tcb = ksCurDomain s \<longrightarrow> tcbDomain (F tcb) = ksCurDomain s)\<rbrace>
-    threadSet F t
-   \<lbrace>\<lambda>_. ct_idle_or_in_cur_domain'\<rbrace>"
-  apply (simp add: ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def)
-  apply (wp hoare_vcg_disj_lift hoare_vcg_imp_lift)
-    apply wps
-    apply wp
-   apply wps
-   apply wp
-  apply (auto simp: obj_at'_def)
-  done
-
-lemma cte_wp_at_norm_eq':
-  "cte_wp_at' P p s = (\<exists>cte. cte_wp_at' ((=) cte) p s \<and> P cte)"
-  by (simp add: cte_wp_at_ctes_of)
-
-lemma isFinal_cte_wp_def:
-  "isFinal cap p (cteCaps_of s) =
-  (\<not>isUntypedCap cap \<and>
-   (\<forall>p'. p \<noteq> p' \<longrightarrow>
-         cte_at' p' s \<longrightarrow>
-         cte_wp_at' (\<lambda>cte'. \<not> isUntypedCap (cteCap cte') \<longrightarrow>
-                            \<not> sameObjectAs cap (cteCap cte')) p' s))"
-  apply (simp add: isFinal_def cte_wp_at_ctes_of cteCaps_of_def)
-  apply (rule iffI)
-   apply clarsimp
-   apply (case_tac cte)
-   apply fastforce
-  apply fastforce
-  done
-
-lemma valid_cte_at_neg_typ':
-  assumes T: "\<And>P T p. \<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace> f \<lbrace>\<lambda>_ s. P (typ_at' T p s)\<rbrace>"
-  shows "\<lbrace>\<lambda>s. \<not> cte_at' p' s\<rbrace> f \<lbrace>\<lambda>rv s. \<not> cte_at' p' s\<rbrace>"
-  apply (simp add: cte_at_typ')
-  apply (rule hoare_vcg_conj_lift [OF T])
-  apply (simp only: imp_conv_disj)
-  apply (rule hoare_vcg_all_lift)
-  apply (rule hoare_vcg_disj_lift [OF T])
-  apply (rule hoare_vcg_prop)
-  done
-
-lemma isFinal_lift:
-  assumes x: "\<And>P p. \<lbrace>cte_wp_at' P p\<rbrace> f \<lbrace>\<lambda>_. cte_wp_at' P p\<rbrace>"
-  assumes y: "\<And>P T p. \<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace> f \<lbrace>\<lambda>_ s. P (typ_at' T p s)\<rbrace>"
-  shows "\<lbrace>\<lambda>s. cte_wp_at' (\<lambda>cte. isFinal (cteCap cte) sl (cteCaps_of s)) sl s\<rbrace>
-         f
-         \<lbrace>\<lambda>r s. cte_wp_at' (\<lambda>cte. isFinal (cteCap cte) sl (cteCaps_of s)) sl s\<rbrace>"
-  apply (subst cte_wp_at_norm_eq')
-  apply (subst cte_wp_at_norm_eq' [where P="\<lambda>cte. isFinal (cteCap cte) sl m" for sl m])
-  apply (simp only: isFinal_cte_wp_def imp_conv_disj de_Morgan_conj)
-  apply (wp hoare_vcg_ex_lift hoare_vcg_all_lift x hoare_vcg_disj_lift
-            valid_cte_at_neg_typ' [OF y])
-  done
-
-lemmas final_matters'_simps = final_matters'_def [split_simps capability.split arch_capability.split]
-
-crunch deleteCallerCap
-  for idle_thread[wp]: "\<lambda>s. P (ksIdleThread s)"
-  (wp: crunch_wps)
-crunch deleteCallerCap
-  for sch_act_simple: sch_act_simple
-  (wp: crunch_wps)
-crunch deleteCallerCap
-  for sch_act_not[wp]: "sch_act_not t"
-  (wp: crunch_wps)
-crunch deleteCallerCap
-  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  (wp: crunch_wps)
-lemmas deleteCallerCap_typ_ats[wp] = typ_at_lifts [OF deleteCallerCap_typ_at']
-
-lemma setEndpoint_sch_act_not_ct[wp]:
-  "\<lbrace>\<lambda>s. sch_act_not (ksCurThread s) s\<rbrace>
-   setEndpoint ptr val \<lbrace>\<lambda>_ s. sch_act_not (ksCurThread s) s\<rbrace>"
-  by (rule hoare_weaken_pre, wps, wp, simp)
-
-lemma sbn_ct_in_state'[wp]:
-  "\<lbrace>ct_in_state' P\<rbrace> setBoundNotification ntfn t \<lbrace>\<lambda>_. ct_in_state' P\<rbrace>"
-  apply (simp add: ct_in_state'_def)
-  apply (rule hoare_pre)
-   apply (wps setBoundNotification_ct')
-  apply (wp sbn_st_tcb', clarsimp)
-  done
-
-lemma set_ntfn_ct_in_state'[wp]:
-  "\<lbrace>ct_in_state' P\<rbrace> setNotification a ntfn \<lbrace>\<lambda>_. ct_in_state' P\<rbrace>"
-  apply (simp add: ct_in_state'_def)
-  apply (rule hoare_pre)
-   apply (wps setNotification_ksCurThread, wp, clarsimp)
-  done
-
-lemma unbindMaybeNotification_ct_in_state'[wp]:
-  "\<lbrace>ct_in_state' P\<rbrace> unbindMaybeNotification t \<lbrace>\<lambda>_. ct_in_state' P\<rbrace>"
-  apply (simp add: unbindMaybeNotification_def)
-  apply (wp | wpc | simp)+
-  done
-
-lemma setNotification_sch_act_sane:
-  "\<lbrace>sch_act_sane\<rbrace> setNotification a ntfn \<lbrace>\<lambda>_. sch_act_sane\<rbrace>"
-  by (wp sch_act_sane_lift)
-
-
-lemma unbindMaybeNotification_sch_act_sane[wp]:
-  "\<lbrace>sch_act_sane\<rbrace> unbindMaybeNotification t \<lbrace>\<lambda>_. sch_act_sane\<rbrace>"
-  apply (simp add: unbindMaybeNotification_def)
-  apply (wp setNotification_sch_act_sane sbn_sch_act_sane | wpc | clarsimp)+
-  done
-
-end
+interpretation Finalise_R_3?: Finalise_R_3 arch_final_matters' arch_cap_has_cleanup'
+proof goal_cases
+  interpret Arch  .
+  case 1 show ?case by (intro_locales; (unfold_locales; (fact Finalise_R_3_assms)?)?)
+qed
 
 end

--- a/proof/refine/AARCH64/ArchIpcCancel_R.thy
+++ b/proof/refine/AARCH64/ArchIpcCancel_R.thy
@@ -138,7 +138,7 @@ lemma fpuRelease_corres[corres]:
    corres dc (pspace_aligned and pspace_distinct and valid_cur_fpu) \<top> (fpu_release t) (fpuRelease t')"
   by (corres simp: fpu_release_def fpuRelease_def)
 
-lemma prepareThreadDelete_corres[corres]:
+lemma prepareThreadDelete_corres[IpcCancel_R_assms, corres]:
   "t' = t \<Longrightarrow>
    corres dc (invs and tcb_at t) no_0_obj'
           (prepare_thread_delete t) (prepareThreadDelete t')"

--- a/proof/refine/AARCH64/ArchMachine_R.thy
+++ b/proof/refine/AARCH64/ArchMachine_R.thy
@@ -51,10 +51,8 @@ lemma dmo_maskInterrupt_True:
                    ct_not_inQ_def ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def)
   done
 
-lemma setIRQState_irq_states':
-  "\<lbrace>valid_irq_states'\<rbrace>
-      setIRQState state irq
-   \<lbrace>\<lambda>rv. valid_irq_states'\<rbrace>"
+lemma setIRQState_irq_states'[Machine_R_assms, wp]:
+  "setIRQState state irq \<lbrace>valid_irq_states'\<rbrace>"
   apply (simp add: setIRQState_def setInterruptState_def getInterruptState_def)
   apply (wp dmo_maskInterrupt)
   apply (simp add: valid_irq_masks'_def)

--- a/proof/refine/AARCH64/ArchTcbAcc_R.thy
+++ b/proof/refine/AARCH64/ArchTcbAcc_R.thy
@@ -1010,15 +1010,7 @@ lemma setThreadState_state_hyp_refs_of'[TcbAcc_R_2_assms, wp]:
         | wp threadSet_state_hyp_refs_of' hoare_drop_imps)+
   done
 
-lemma setBoundNotification_state_refs_of'[wp]:
-  "\<lbrace>\<lambda>s. P ((state_refs_of' s) (t := tcb_bound_refs' ntfn
-                                 \<union> {r \<in> state_refs_of' s t. snd r \<noteq> TCBBound}))\<rbrace>
-     setBoundNotification ntfn t
-   \<lbrace>\<lambda>rv s. P (state_refs_of' s)\<rbrace>"
-  by (simp add: setBoundNotification_def Un_commute fun_upd_def
-        | wp threadSet_state_refs_of' )+
-
-lemma setBoundNotification_state_hyp_refs_of'[wp]:
+lemma setBoundNotification_state_hyp_refs_of'[TcbAcc_R_2_assms, wp]:
   "\<lbrace>\<lambda>s. P (state_hyp_refs_of' s)\<rbrace>
      setBoundNotification ntfn t
    \<lbrace>\<lambda>rv s. P (state_hyp_refs_of' s)\<rbrace>"
@@ -1043,7 +1035,7 @@ lemma tcbQueued_update_iflive'[TcbAcc_R_2_assms, wp]:
    \<lbrace>\<lambda>_. if_live_then_nonz_cap'\<rbrace>"
   by (wpsimp wp: threadSet_iflive'T simp: update_tcb_cte_cases)
 
-lemma sbn_iflive'[wp]:
+lemma sbn_iflive'[TcbAcc_R_2_assms, wp]:
   "\<lbrace>\<lambda>s. if_live_then_nonz_cap' s
       \<and> (bound ntfn \<longrightarrow> ex_nonz_cap_to' t s)\<rbrace>
    setBoundNotification ntfn t

--- a/proof/refine/AARCH64/Arch_R.thy
+++ b/proof/refine/AARCH64/Arch_R.thy
@@ -757,7 +757,7 @@ lemma decodeARMPageTableInvocation_corres:
                                  in corres_gen_asm2)
         apply (rule corres_split[OF isFinalCapability_corres[where ptr=slot]])
           apply (drule mp)
-           apply (clarsimp simp: isCap_simps final_matters'_def)
+           apply (clarsimp simp: isCap_simps final_matters'_def arch_final_matters'_def)
           apply (rule whenE_throwError_corres; simp)
           apply (rule option_corres)
             apply (cases opt; simp add: mdata_map_def)
@@ -1876,10 +1876,6 @@ lemma performASIDControlInvocation_st_tcb_at':
        apply simp
   apply auto
   done
-
-lemmas arch_finalise_cap_aligned' = ArchRetypeDecls_H_AARCH64_H_finaliseCap_aligned'
-
-lemmas arch_finalise_cap_distinct' = ArchRetypeDecls_H_AARCH64_H_finaliseCap_distinct'
 
 crunch "Arch.finaliseCap"
   for st_tcb_at'[wp]: "st_tcb_at' P t"

--- a/proof/refine/AARCH64/Arch_R.thy
+++ b/proof/refine/AARCH64/Arch_R.thy
@@ -10,7 +10,7 @@
 *)
 
 theory Arch_R
-imports Untyped_R Finalise_R
+imports Untyped_R ArchFinalise_R
 begin
 
 unbundle l4v_word_context

--- a/proof/refine/AARCH64/CNodeInv_R.thy
+++ b/proof/refine/AARCH64/CNodeInv_R.thy
@@ -329,7 +329,7 @@ lemma decodeCNodeInvocation_corres:
                  apply (intro conjI)
                   apply (erule cap_map_update_data)+
                 apply (wp hoare_drop_imps)+
-          apply simp
+          apply (simp cong: if_cong)
           apply (wp lsfco_cte_at' lookup_cap_valid lookup_cap_valid')
          apply (simp add: if_apply_def2)
          apply (wp hoare_drop_imps)
@@ -6322,6 +6322,7 @@ proof (induct arbitrary: P p rule: finalise_spec_induct2)
     by (simp add: no_cte_prop_def finalise_prop_stuff_def)
   note stuff'[unfolded finalise_prop_stuff_def, simp]
   show ?case
+    supply arch_cap_has_cleanup'_def[simp]
     apply (subst finaliseSlot'.simps)
     apply (fold reduceZombie_def[unfolded cteDelete_def finaliseSlot_def])
     apply (unfold split_def)

--- a/proof/refine/AARCH64/EmptyFail_H.thy
+++ b/proof/refine/AARCH64/EmptyFail_H.thy
@@ -103,7 +103,7 @@ lemma constOnFailure_empty_fail[intro!, wp, simp]:
 lemma ArchRetypeDecls_H_deriveCap_empty_fail[intro!, wp, simp]:
   "empty_fail (Arch.deriveCap x y)"
   unfolding AARCH64_H.deriveCap_def
-  by (cases y, auto simp: isCap_simps)
+  by (cases y, auto simp: isCap_simps cong: if_cong)
 
 crunch ensureNoChildren
   for (empty_fail) empty_fail[intro!, wp, simp]
@@ -292,6 +292,7 @@ crunch
 
 lemma ThreadDecls_H_schedule_empty_fail[intro!, wp, simp]:
   "empty_fail schedule"
+  supply if_cong[cong]
   apply (simp add: schedule_def)
   apply (clarsimp simp: scheduleChooseNewThread_def split: if_split | wp | wpc)+
   done

--- a/proof/refine/AARCH64/Interrupt_R.thy
+++ b/proof/refine/AARCH64/Interrupt_R.thy
@@ -671,6 +671,7 @@ lemma timerTick_corres:
   "corres dc
      (cur_tcb and valid_sched and pspace_aligned and pspace_distinct) invs'
      timer_tick timerTick"
+  supply if_cong[cong]
   apply (simp add: timerTick_def timer_tick_def)
   apply (simp add: thread_state_case_if threadState_case_if)
   apply (rule_tac Q="cur_tcb and valid_sched and pspace_aligned and pspace_distinct"

--- a/proof/refine/AARCH64/Ipc_R.thy
+++ b/proof/refine/AARCH64/Ipc_R.thy
@@ -637,6 +637,7 @@ lemma cteInsert_weak_cte_wp_at2:
     "\<lbrace>\<lambda>s. if p = dest then P cap else cte_wp_at' (\<lambda>c. P (cteCap c)) p s\<rbrace>
      cteInsert cap src dest
      \<lbrace>\<lambda>uu. cte_wp_at' (\<lambda>c. P (cteCap c)) p\<rbrace>"
+  supply if_cong[cong]
   apply (rule hoare_pre)
    apply (rule hoare_use_eq_irq_node' [OF cteInsert_ksInterruptState])
    apply (clarsimp simp:cteInsert_def)
@@ -1443,6 +1444,7 @@ lemma doNormalTransfer_corres:
    and case_option \<top> valid_ipc_buffer_ptr' recv_buf)
   (do_normal_transfer sender send_buf ep badge can_grant receiver recv_buf)
   (doNormalTransfer sender send_buf ep badge can_grant receiver recv_buf)"
+  supply if_cong[cong]
   apply (simp add: do_normal_transfer_def doNormalTransfer_def)
   apply (rule corres_guard_imp)
     apply (rule corres_split_mapr[OF getMessageInfo_corres])
@@ -2629,6 +2631,7 @@ lemma valid_sched_weak_strg:
 lemma sendSignal_corres:
   "corres dc (einvs and ntfn_at ep) (invs' and ntfn_at' ep)
              (send_signal ep bg) (sendSignal ep bg)"
+  supply if_cong[cong]
   apply (simp add: send_signal_def sendSignal_def Let_def)
   apply (rule corres_guard_imp)
     apply (rule corres_split[OF getNotification_corres,
@@ -3595,6 +3598,7 @@ lemma cteInsert_cap_to':
   "\<lbrace>ex_nonz_cap_to' p and cte_wp_at' (\<lambda>c. cteCap c = NullCap) dest\<rbrace>
      cteInsert cap src dest
    \<lbrace>\<lambda>rv. ex_nonz_cap_to' p\<rbrace>"
+  supply if_cong[cong]
   apply (simp add: cteInsert_def ex_nonz_cap_to'_def updateCap_def setUntypedCapAsFull_def)
   apply (wpsimp wp: updateMDB_weak_cte_wp_at setCTE_weak_cte_wp_at hoare_vcg_ex_lift
          | rule hoare_drop_imps
@@ -4029,6 +4033,7 @@ lemma si_invs'[wp]:
   sendIPC bl call ba cg cgr t ep
   \<lbrace>\<lambda>rv. invs'\<rbrace>"
   supply if_split[split del]
+  supply if_cong[cong]
   apply (simp add: sendIPC_def)
   apply (rule bind_wp [OF _ get_ep_sp'])
   apply (case_tac epa)

--- a/proof/refine/AARCH64/Ipc_R.thy
+++ b/proof/refine/AARCH64/Ipc_R.thy
@@ -6,7 +6,7 @@
  *)
 
 theory Ipc_R
-imports Finalise_R
+imports ArchFinalise_R
 begin
 
 context begin interpretation Arch . (*FIXME: arch-split*)

--- a/proof/refine/AARCH64/Syscall_R.thy
+++ b/proof/refine/AARCH64/Syscall_R.thy
@@ -684,6 +684,7 @@ lemma pinv_tcb'[wp]:
 
 lemma sts_cte_at[wp]:
   "\<lbrace>cte_at' p\<rbrace> setThreadState st t \<lbrace>\<lambda>rv. cte_at' p\<rbrace>"
+  supply if_cong[cong]
   apply (simp add: setThreadState_def)
   apply (wp|simp)+
   done
@@ -697,6 +698,7 @@ lemma sts_mcpriority_tcb_at'[wp]:
   "\<lbrace>mcpriority_tcb_at' P t\<rbrace>
     setThreadState st t'
    \<lbrace>\<lambda>_. mcpriority_tcb_at' P t\<rbrace>"
+  supply if_cong[cong]
   apply (cases "t = t'",
          simp_all add: setThreadState_def
                   split del: if_split)
@@ -769,6 +771,7 @@ lemma decodeDomainSetStart_inv_wf[wp]:
 lemma decodeDomainConfigure_inv_wf[wp]:
   "\<lbrace>\<top>\<rbrace> decodeDomainConfigure args excaps \<lbrace>valid_domain_inv'\<rbrace>, -"
   unfolding decodeDomainConfigure_def
+  supply if_cong[cong]
   apply (wpsimp simp: valid_domain_inv'_def split_del: if_split)
   apply (clarsimp simp: not_less not_le le_maxDomain_eq_less_numDomains unat_ucast)
   using numDomains_fits_domainBits

--- a/proof/refine/AARCH64/Tcb_R.thy
+++ b/proof/refine/AARCH64/Tcb_R.thy
@@ -936,6 +936,7 @@ lemma checked_insert_tcb_invs'[wp]:
       (checkCapAt (ThreadCap target) slot'
        (assertDerived src_slot new_cap (cteInsert new_cap src_slot slot))) \<lbrace>\<lambda>rv. invs'\<rbrace>"
   supply option.case_cong[cong]
+  supply if_cong[cong]
   apply (simp add: checkCapAt_def liftM_def assertDerived_def stateAssert_def)
   apply (wp getCTE_cteCap_wp cteInsert_invs)
   apply (clarsimp split: option.splits)

--- a/proof/refine/AARCH64/orphanage/Orphanage.thy
+++ b/proof/refine/AARCH64/orphanage/Orphanage.thy
@@ -478,7 +478,7 @@ lemma setThreadState_not_is_active_thread_state_no_orphans:
    apply (unfold no_orphans_disj almost_no_orphans_disj)
    apply (wp hoare_vcg_all_lift hoare_vcg_disj_lift threadSet_pred_tcb_at_state
              threadSet_all_queued_tcb_ptrs hoare_drop_imps
-          | fastforce)+
+          | fastforce cong: if_cong)+
   done
 
 lemma setThreadState_almost_no_orphans [wp]:
@@ -498,7 +498,7 @@ lemma setThreadState_not_active_no_orphans:
    apply (unfold no_orphans_disj)
    apply (wp hoare_vcg_all_lift hoare_vcg_disj_lift threadSet_pred_tcb_at_state
              threadSet_all_queued_tcb_ptrs hoare_drop_imps
-          | fastforce)+
+          | fastforce cong: if_cong)+
   done
 
 lemma setThreadState_not_active_almost_no_orphans:
@@ -508,7 +508,7 @@ lemma setThreadState_not_active_almost_no_orphans:
    apply (unfold almost_no_orphans_disj)
    apply (wp hoare_vcg_all_lift hoare_vcg_disj_lift threadSet_pred_tcb_at_state
              threadSet_all_queued_tcb_ptrs hoare_drop_imps
-          | fastforce)+
+          | fastforce cong: if_cong)+
   done
 
 lemma activateThread_no_orphans [wp]:
@@ -576,6 +576,7 @@ lemma tcbSchedDequeue_no_orphans[wp]:
    apply wpsimp
    apply (clarsimp simp: st_tcb_at'_def obj_at'_def is_active_tcb_ptr_def disj_not1)
   apply (wpsimp wp: tcbQueued_update_False_all_queued_tcb_ptrs hoare_vcg_disj_lift
+              cong: if_cong
               simp: tcbSchedDequeue_def)
   done
 
@@ -591,10 +592,14 @@ lemma switchToIdleThread_no_orphans' [wp]:
   apply (force simp: is_active_tcb_ptr_def st_tcb_at_neg' typ_at_tcb')
   done
 
+context notes if_cong[cong] begin
+
 crunch getVMID, Arch.switchToThread
   for ksCurThread[wp]: "\<lambda> s. P (ksCurThread s)"
   (wp: crunch_wps getObject_inv loadObject_default_inv findVSpaceForASID_vs_at_wp
    simp: getThreadVSpaceRoot_def if_distribR)
+
+end
 
 crunch lazyFpuRestore
   for tcbQueued[wp]: "\<lambda>s. Q (obj_at' (\<lambda>tcb. P (tcbQueued tcb)) tcb_ptr s)"
@@ -718,7 +723,7 @@ lemma chooseThread_no_orphans [wp]:
    \<lbrace>\<lambda>_. no_orphans\<rbrace>"
   (is "\<lbrace>?PRE\<rbrace> _ \<lbrace>_\<rbrace>")
   unfolding chooseThread_def Let_def
-  supply if_split[split del]
+  supply if_split[split del] if_cong[cong]
   apply (simp only: return_bind, simp)
   apply (intro bind_wp[OF _ stateAssert_sp])
   apply (rule bind_wp[where Q'="\<lambda>rv s. ?PRE s \<and> ksReadyQueues_asrt s \<and> ready_qs_runnable s
@@ -1216,7 +1221,8 @@ lemma deleteObjects_no_orphans [wp]:
   apply wpsimp
   apply (clarsimp simp: no_orphans_def all_active_tcb_ptrs_def
                         all_queued_tcb_ptrs_def is_active_tcb_ptr_def
-                        ksMachineState_ksPSpace_upd_comm)
+                        ksMachineState_ksPSpace_upd_comm
+                   cong: if_cong)
   apply (drule_tac x=tcb_ptr in spec)
   apply (clarsimp simp: pred_tcb_at'_def obj_at_delete')
   done

--- a/proof/refine/AARCH64/orphanage/Orphanage.thy
+++ b/proof/refine/AARCH64/orphanage/Orphanage.thy
@@ -592,14 +592,11 @@ lemma switchToIdleThread_no_orphans' [wp]:
   apply (force simp: is_active_tcb_ptr_def st_tcb_at_neg' typ_at_tcb')
   done
 
-context notes if_cong[cong] begin
-
 crunch getVMID, Arch.switchToThread
   for ksCurThread[wp]: "\<lambda> s. P (ksCurThread s)"
   (wp: crunch_wps getObject_inv loadObject_default_inv findVSpaceForASID_vs_at_wp
-   simp: getThreadVSpaceRoot_def if_distribR)
-
-end
+   simp: getThreadVSpaceRoot_def if_distribR
+   cong: if_cong)
 
 crunch lazyFpuRestore
   for tcbQueued[wp]: "\<lambda>s. Q (obj_at' (\<lambda>tcb. P (tcbQueued tcb)) tcb_ptr s)"

--- a/proof/refine/ARM/ArchFinalise_R.thy
+++ b/proof/refine/ARM/ArchFinalise_R.thy
@@ -1,5 +1,6 @@
 (*
  * Copyright 2014, General Dynamics C4 Systems
+ * Copyright 2023, Proofcraft Pty Ltd
  *
  * SPDX-License-Identifier: GPL-2.0-only
  *)
@@ -9,475 +10,80 @@ imports
   Finalise_R
 begin
 
-context begin interpretation Arch . (*FIXME: arch-split*)
+context Arch begin arch_global_naming
 
-declare doUnbindNotification_def[simp]
+named_theorems Finalise_R_assms
 
 lemma isArchSGISignalCap_NullCap[simp]:
   "\<not>isArchSGISignalCap NullCap"
   by (simp add: isCap_simps)
 
-text \<open>Properties about empty_slot/emptySlot\<close>
+lemma arch_postCapDeletion_ksArchState_lift[Finalise_R_assms]:
+  "\<lbrakk>\<And>s as. P (s\<lparr>ksArchState := as\<rparr>) = P s\<rbrakk> \<Longrightarrow> Arch.postCapDeletion ac \<lbrace>P\<rbrace>"
+  unfolding postCapDeletion_def
+  by wpsimp
 
-lemma case_Null_If:
-  "(case c of NullCap \<Rightarrow> a | _ \<Rightarrow> b) = (if c = NullCap then a else b)"
-  by (case_tac c, simp_all)
+lemmas clearUntypedFreeIndex_typ_ats[wp] = typ_at_lifts[OF clearUntypedFreeIndex_typ_at']
 
-crunch emptySlot
-  for aligned'[wp]: pspace_aligned' (simp: case_Null_If)
-crunch emptySlot
-  for distinct'[wp]: pspace_distinct' (simp: case_Null_If)
+crunch setIRQState
+  for umm[Finalise_R_assms, wp]: "\<lambda>s. P (underlying_memory (ksMachineState s))"
+  (wp: dmo_lift' simp: maskInterrupt_def)
 
-lemma updateCap_cte_wp_at_cases:
-  "\<lbrace>\<lambda>s. (ptr = ptr' \<longrightarrow> cte_wp_at' (P \<circ> cteCap_update (K cap)) ptr' s) \<and> (ptr \<noteq> ptr' \<longrightarrow> cte_wp_at' P ptr' s)\<rbrace>
-     updateCap ptr cap
-   \<lbrace>\<lambda>rv. cte_wp_at' P ptr'\<rbrace>"
-  apply (clarsimp simp: valid_def)
-  apply (drule updateCap_stuff)
-  apply (clarsimp simp: cte_wp_at_ctes_of modify_map_def)
-  done
+(* better crunch names for Arch.postCapDeletion *)
+abbreviation (input)
+  "Arch_postCapDeletion \<equiv> Arch.postCapDeletion"
 
-crunch postCapDeletion, updateTrackedFreeIndex
-  for cte_wp_at'[wp]: "cte_wp_at' P p"
+crunch Arch_postCapDeletion
+  for valid_global_refs[wp]: valid_global_refs'
+  and valid_arch_state'[wp]: valid_arch_state'
+  (rule: ARM_H.postCapDeletion_def)
 
-lemma updateFreeIndex_cte_wp_at:
-  "\<lbrace>\<lambda>s. cte_at' p s \<and> P (cte_wp_at' (if p = p' then P'
-      o (cteCap_update (capFreeIndex_update (K idx))) else P') p' s)\<rbrace>
-    updateFreeIndex p idx
-  \<lbrace>\<lambda>rv s. P (cte_wp_at' P' p' s)\<rbrace>"
-  apply (simp add: updateFreeIndex_def updateTrackedFreeIndex_def
-        split del: if_split)
-  apply (rule hoare_pre)
-   apply (wp updateCap_cte_wp_at' getSlotCap_wp)
-  apply (clarsimp simp: cte_wp_at_ctes_of)
-  apply (cases "p' = p", simp_all)
-  apply (case_tac cte, simp)
-  done
+lemma arch_postCapDeletion_corres[Finalise_R_assms]:
+  "acap_relation cap cap' \<Longrightarrow> corres dc \<top> \<top> (arch_post_cap_deletion cap) (ARM_H.postCapDeletion cap')"
+  by (clarsimp simp: arch_post_cap_deletion_def ARM_H.postCapDeletion_def)
 
-lemma emptySlot_cte_wp_cap_other:
-  "\<lbrace>(\<lambda>s. cte_wp_at' (\<lambda>c. P (cteCap c)) p s) and K (p \<noteq> p')\<rbrace>
-  emptySlot p' opt
-  \<lbrace>\<lambda>rv s. cte_wp_at' (\<lambda>c. P (cteCap c)) p s\<rbrace>"
-  apply (rule hoare_gen_asm)
-  apply (simp add: emptySlot_def clearUntypedFreeIndex_def getSlotCap_def)
-  apply (rule hoare_pre)
-   apply (wp updateMDB_weak_cte_wp_at updateCap_cte_wp_at_cases
-             updateFreeIndex_cte_wp_at getCTE_wp' hoare_vcg_all_lift
-              | simp add:  | wpc
-              | wp (once) hoare_drop_imps)+
-  done
+(* better crunch names for Arch.finaliseCap *)
+abbreviation (input)
+  "Arch_finaliseCap \<equiv> Arch.finaliseCap"
 
-lemmas clearUntypedFreeIndex_typ_ats[wp]
-    = typ_at_lifts[OF clearUntypedFreeIndex_typ_at']
+crunch Arch_finaliseCap, prepareThreadDelete, archThreadSet
+  for typ_at'[Finalise_R_assms, wp]: "\<lambda>s. P (typ_at' T p s)"
+  and aligned'[Finalise_R_assms, wp]: "pspace_aligned'"
+  and distinct'[Finalise_R_assms, wp]: "pspace_distinct'"
+  (wp: crunch_wps getObject_inv loadObject_default_inv
+   simp: crunch_simps unless_def o_def
+   ignore_del: setObject
+   rule: ARM_H.finaliseCap_def)
 
-crunch postCapDeletion
-  for tcb_at'[wp]: "tcb_at' t"
-crunch emptySlot
-  for ct[wp]: "\<lambda>s. P (ksCurThread s)"
-crunch clearUntypedFreeIndex
-  for cur_tcb'[wp]: "cur_tcb'"
-  (wp: cur_tcb_lift)
+crunch prepareThreadDelete, Arch_finaliseCap
+  for it'[Finalise_R_assms, wp]: "\<lambda>s. P (ksIdleThread s)"
+  (wp: hoare_drop_imps mapM_wp
+   simp: crunch_simps updateObject_default_def
+   rule: ARM_H.finaliseCap_def)
 
-crunch emptySlot
-  for ksRQ[wp]: "\<lambda>s. P (ksReadyQueues s)"
-crunch emptySlot
-  for ksRQL1[wp]: "\<lambda>s. P (ksReadyQueuesL1Bitmap s)"
-crunch emptySlot
-  for ksRQL2[wp]: "\<lambda>s. P (ksReadyQueuesL2Bitmap s)"
-crunch postCapDeletion
-  for obj_at'[wp]: "obj_at' P p"
+definition
+  arch_final_matters' :: "arch_capability \<Rightarrow> bool" where
+ "arch_final_matters' acap \<equiv> case acap of
+    PageCap ref rghts sz d mapdata \<Rightarrow> False
+  | ASIDControlCap \<Rightarrow> False
+  | SGISignalCap _ _ \<Rightarrow> False
+  | _ \<Rightarrow> True"
 
-crunch clearUntypedFreeIndex
-  for inQ[wp]: "\<lambda>s. P (obj_at' (inQ d p) t s)"
-crunch clearUntypedFreeIndex
-  for tcbDomain[wp]: "obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t"
-crunch clearUntypedFreeIndex
-  for tcbPriority[wp]: "obj_at' (\<lambda>tcb. P (tcbPriority tcb)) t"
+definition arch_cap_has_cleanup' :: "arch_capability \<Rightarrow> bool" where
+  "arch_cap_has_cleanup' _ \<equiv> False"
 
-crunch emptySlot
-  for nosch[wp]: "\<lambda>s. P (ksSchedulerAction s)"
-crunch emptySlot
-  for ksCurDomain[wp]: "\<lambda>s. P (ksCurDomain s)"
+definition
+  "post_cap_delete_pre' cap sl cs \<equiv> case cap of
+     IRQHandlerCap irq \<Rightarrow> irq \<le> maxIRQ \<and> (\<forall>sl'. sl \<noteq> sl' \<longrightarrow> cs sl' \<noteq> Some cap)
+   | _ \<Rightarrow> False"
 
-lemma emptySlot_sch_act_wf [wp]:
-  "\<lbrace>\<lambda>s. sch_act_wf (ksSchedulerAction s) s\<rbrace>
-  emptySlot sl opt
-  \<lbrace>\<lambda>rv s. sch_act_wf (ksSchedulerAction s) s\<rbrace>"
-  apply (simp add: emptySlot_def case_Null_If)
-  apply (wp sch_act_wf_lift tcb_in_cur_domain'_lift | wpcw | simp)+
-  done
+end (* Arch *)
 
-lemma updateCap_valid_objs' [wp]:
-  "\<lbrace>valid_objs' and valid_cap' cap\<rbrace>
-  updateCap ptr cap \<lbrace>\<lambda>r. valid_objs'\<rbrace>"
-  unfolding updateCap_def
-  by (wp setCTE_valid_objs getCTE_wp) (clarsimp dest!: cte_at_cte_wp_atD)
+arch_requalify_consts
+  arch_final_matters'
+  arch_cap_has_cleanup'
 
-lemma updateFreeIndex_valid_objs' [wp]:
-  "\<lbrace>valid_objs'\<rbrace> clearUntypedFreeIndex ptr \<lbrace>\<lambda>r. valid_objs'\<rbrace>"
-  apply (simp add: clearUntypedFreeIndex_def getSlotCap_def)
-  apply (wp getCTE_wp' | wpc | simp add: updateTrackedFreeIndex_def)+
-  done
-
-crunch emptySlot
-  for valid_objs'[wp]: "valid_objs'"
-
-crunch setInterruptState
-  for state_refs_of'[wp]: "\<lambda>s. P (state_refs_of' s)"
-  (simp: state_refs_of'_pspaceI)
-crunch emptySlot
-  for state_refs_of'[wp]: "\<lambda>s. P (state_refs_of' s)"
-  (wp: crunch_wps)
-
-lemma mdb_chunked2D:
-  "\<lbrakk> mdb_chunked m; m \<turnstile> p \<leadsto> p'; m \<turnstile> p' \<leadsto> p'';
-     m p = Some (CTE cap nd); m p'' = Some (CTE cap'' nd'');
-     sameRegionAs cap cap''; p \<noteq> p''; mdb_chunked_arch_assms cap \<rbrakk>
-     \<Longrightarrow> \<exists>cap' nd'. m p' = Some (CTE cap' nd') \<and> sameRegionAs cap cap'"
-  apply (subgoal_tac "\<exists>cap' nd'. m p' = Some (CTE cap' nd')")
-   apply (clarsimp simp add: mdb_chunked_def)
-   apply (drule spec[where x=p])
-   apply (drule spec[where x=p''])
-   apply clarsimp
-   apply (drule mp, erule trancl_into_trancl2)
-    apply (erule trancl.intros(1))
-   apply (simp add: is_chunk_def)
-   apply (drule spec, drule mp, erule trancl.intros(1))
-   apply (drule mp, rule trancl_into_rtrancl)
-    apply (erule trancl.intros(1))
-   apply clarsimp
-  apply (clarsimp simp: mdb_next_unfold)
-  apply (case_tac z, simp)
-  done
-
-lemma nullPointer_eq_0_simp[simp]: (* FIXME: move to nullPointer_0_simp in Retype_R *)
-  "(0 = nullPointer) = True"
-  by (simp add: nullPointer_def)+
-
-lemma no_0_no_0_lhs_trancl [simp]:
-  "no_0 m \<Longrightarrow> \<not> m \<turnstile> 0 \<leadsto>\<^sup>+ x"
-  by (rule, drule tranclD, clarsimp simp: next_unfold')
-
-lemma no_0_no_0_lhs_rtrancl [simp]:
-  "\<lbrakk> no_0 m; x \<noteq> 0 \<rbrakk> \<Longrightarrow> \<not> m \<turnstile> 0 \<leadsto>\<^sup>* x"
-  by (clarsimp dest!: rtranclD)
-
-end
-locale mdb_empty =
-  mdb_ptr?: mdb_ptr m _ _ slot s_cap s_node
-    for m slot s_cap s_node +
-
-  fixes n
-  defines "n \<equiv>
-           modify_map
-             (modify_map
-               (modify_map
-                 (modify_map m (mdbPrev s_node)
-                   (cteMDBNode_update (mdbNext_update (%_. (mdbNext s_node)))))
-                 (mdbNext s_node)
-                 (cteMDBNode_update
-                   (\<lambda>mdb. mdbFirstBadged_update (%_. (mdbFirstBadged mdb \<or> mdbFirstBadged s_node))
-                           (mdbPrev_update (%_. (mdbPrev s_node)) mdb))))
-               slot (cteCap_update (%_. capability.NullCap)))
-              slot (cteMDBNode_update (const nullMDBNode))"
-begin
-interpretation Arch . (*FIXME: arch-split*)
-
-lemmas m_slot_prev = m_p_prev
-lemmas m_slot_next = m_p_next
-lemmas prev_slot_next = prev_p_next
-lemmas next_slot_prev = next_p_prev
-
-lemma n_revokable:
-  "n p = Some (CTE cap node) \<Longrightarrow>
-  (\<exists>cap' node'. m p = Some (CTE cap' node') \<and>
-              (if p = slot
-               then \<not> mdbRevocable node
-               else mdbRevocable node = mdbRevocable node'))"
-  by (auto simp add: n_def modify_map_if nullMDBNode_def split: if_split_asm)
-
-lemma m_revokable:
-  "m p = Some (CTE cap node) \<Longrightarrow>
-  (\<exists>cap' node'. n p = Some (CTE cap' node') \<and>
-              (if p = slot
-               then \<not> mdbRevocable node'
-               else mdbRevocable node' = mdbRevocable node))"
-  apply (clarsimp simp add: n_def modify_map_if nullMDBNode_def split: if_split_asm)
-  apply (cases "p=slot", simp)
-  apply (cases "p=mdbNext s_node", simp)
-   apply (cases "p=mdbPrev s_node", simp)
-   apply clarsimp
-  apply simp
-  apply (cases "p=mdbPrev s_node", simp)
-  apply simp
-  done
-
-lemma no_0_n:
-  "no_0 n"
-  using no_0 by (simp add: n_def)
-
-lemma n_next:
-  "n p = Some (CTE cap node) \<Longrightarrow>
-  (\<exists>cap' node'. m p = Some (CTE cap' node') \<and>
-              (if p = slot
-               then mdbNext node = 0
-               else if p = mdbPrev s_node
-               then mdbNext node = mdbNext s_node
-               else mdbNext node = mdbNext node'))"
-  apply (subgoal_tac "p \<noteq> 0")
-   prefer 2
-   apply (insert no_0_n)[1]
-   apply clarsimp
-  apply (cases "p = slot")
-   apply (clarsimp simp: n_def modify_map_if initMDBNode_def split: if_split_asm)
-  apply (cases "p = mdbPrev s_node")
-   apply (auto simp: n_def modify_map_if initMDBNode_def split: if_split_asm)
-  done
-
-lemma n_prev:
-  "n p = Some (CTE cap node) \<Longrightarrow>
-  (\<exists>cap' node'. m p = Some (CTE cap' node') \<and>
-              (if p = slot
-               then mdbPrev node = 0
-               else if p = mdbNext s_node
-               then mdbPrev node = mdbPrev s_node
-               else mdbPrev node = mdbPrev node'))"
-  apply (subgoal_tac "p \<noteq> 0")
-   prefer 2
-   apply (insert no_0_n)[1]
-   apply clarsimp
-  apply (cases "p = slot")
-   apply (clarsimp simp: n_def modify_map_if initMDBNode_def split: if_split_asm)
-  apply (cases "p = mdbNext s_node")
-   apply (auto simp: n_def modify_map_if initMDBNode_def split: if_split_asm)
-  done
-
-lemma n_cap:
-  "n p = Some (CTE cap node) \<Longrightarrow>
-  \<exists>cap' node'. m p = Some (CTE cap' node') \<and>
-              (if p = slot
-               then cap = NullCap
-               else cap' = cap)"
-  apply (clarsimp simp: n_def modify_map_if initMDBNode_def split: if_split_asm)
-   apply (cases node)
-   apply auto
-  done
-
-lemma m_cap:
-  "m p = Some (CTE cap node) \<Longrightarrow>
-  \<exists>cap' node'. n p = Some (CTE cap' node') \<and>
-              (if p = slot
-               then cap' = NullCap
-               else cap' = cap)"
-  apply (clarsimp simp: n_def modify_map_cases initMDBNode_def)
-  apply (cases node)
-  apply clarsimp
-  apply (cases "p=slot", simp)
-  apply clarsimp
-  apply (cases "mdbNext s_node = p", simp)
-   apply fastforce
-  apply simp
-  apply (cases "mdbPrev s_node = p", simp)
-  apply fastforce
-  done
-
-lemma n_badged:
-  "n p = Some (CTE cap node) \<Longrightarrow>
-  \<exists>cap' node'. m p = Some (CTE cap' node') \<and>
-              (if p = slot
-               then \<not> mdbFirstBadged node
-               else if p = mdbNext s_node
-               then mdbFirstBadged node = (mdbFirstBadged node' \<or> mdbFirstBadged s_node)
-               else mdbFirstBadged node = mdbFirstBadged node')"
-  apply (subgoal_tac "p \<noteq> 0")
-   prefer 2
-   apply (insert no_0_n)[1]
-   apply clarsimp
-  apply (cases "p = slot")
-   apply (clarsimp simp: n_def modify_map_if initMDBNode_def split: if_split_asm)
-  apply (cases "p = mdbNext s_node")
-   apply (auto simp: n_def modify_map_if nullMDBNode_def split: if_split_asm)
-  done
-
-lemma m_badged:
-  "m p = Some (CTE cap node) \<Longrightarrow>
-  \<exists>cap' node'. n p = Some (CTE cap' node') \<and>
-              (if p = slot
-               then \<not> mdbFirstBadged node'
-               else if p = mdbNext s_node
-               then mdbFirstBadged node' = (mdbFirstBadged node \<or> mdbFirstBadged s_node)
-               else mdbFirstBadged node' = mdbFirstBadged node)"
-  apply (subgoal_tac "p \<noteq> 0")
-   prefer 2
-   apply (insert no_0_n)[1]
-   apply clarsimp
-  apply (cases "p = slot")
-   apply (clarsimp simp: n_def modify_map_if nullMDBNode_def split: if_split_asm)
-  apply (cases "p = mdbNext s_node")
-   apply (clarsimp simp: n_def modify_map_if nullMDBNode_def split: if_split_asm)
-  apply clarsimp
-  apply (cases "p = mdbPrev s_node")
-   apply (auto simp: n_def modify_map_if initMDBNode_def  split: if_split_asm)
-  done
-
-lemmas slot = m_p
-
-lemma m_next:
-  "m p = Some (CTE cap node) \<Longrightarrow>
-  \<exists>cap' node'. n p = Some (CTE cap' node') \<and>
-              (if p = slot
-               then mdbNext node' = 0
-               else if p = mdbPrev s_node
-               then mdbNext node' = mdbNext s_node
-               else mdbNext node' = mdbNext node)"
-  apply (subgoal_tac "p \<noteq> 0")
-   prefer 2
-   apply clarsimp
-  apply (cases "p = slot")
-   apply (clarsimp simp: n_def modify_map_if)
-  apply (cases "p = mdbPrev s_node")
-   apply (simp add: n_def modify_map_if)
-  apply simp
-  apply (simp add: n_def modify_map_if)
-  apply (cases "mdbNext s_node = p")
-   apply fastforce
-  apply fastforce
-  done
-
-lemma m_prev:
-  "m p = Some (CTE cap node) \<Longrightarrow>
-  \<exists>cap' node'. n p = Some (CTE cap' node') \<and>
-              (if p = slot
-               then mdbPrev node' = 0
-               else if p = mdbNext s_node
-               then mdbPrev node' = mdbPrev s_node
-               else mdbPrev node' = mdbPrev node)"
-  apply (subgoal_tac "p \<noteq> 0")
-   prefer 2
-   apply clarsimp
-  apply (cases "p = slot")
-   apply (clarsimp simp: n_def modify_map_if)
-  apply (cases "p = mdbPrev s_node")
-   apply (simp add: n_def modify_map_if)
-  apply simp
-  apply (simp add: n_def modify_map_if)
-  apply (cases "mdbNext s_node = p")
-   apply fastforce
-  apply fastforce
-  done
-
-lemma n_nextD:
-  "n \<turnstile> p \<leadsto> p' \<Longrightarrow>
-  if p = slot then p' = 0
-  else if p = mdbPrev s_node
-  then m \<turnstile> p \<leadsto> slot \<and> p' = mdbNext s_node
-  else m \<turnstile> p \<leadsto> p'"
-  apply (clarsimp simp: mdb_next_unfold split del: if_split cong: if_cong)
-  apply (case_tac z)
-  apply (clarsimp split del: if_split)
-  apply (drule n_next)
-  apply (elim exE conjE)
-  apply (simp split: if_split_asm)
-  apply (frule dlist_prevD [OF m_slot_prev])
-  apply (clarsimp simp: mdb_next_unfold)
-  done
-
-lemma n_next_eq:
-  "n \<turnstile> p \<leadsto> p' =
-  (if p = slot then p' = 0
-  else if p = mdbPrev s_node
-  then m \<turnstile> p \<leadsto> slot \<and> p' = mdbNext s_node
-  else m \<turnstile> p \<leadsto> p')"
-  apply (rule iffI)
-   apply (erule n_nextD)
-  apply (clarsimp simp: mdb_next_unfold split: if_split_asm)
-    apply (simp add: n_def modify_map_if slot)
-   apply hypsubst_thin
-   apply (case_tac z)
-   apply simp
-   apply (drule m_next)
-   apply clarsimp
-  apply (case_tac z)
-  apply simp
-  apply (drule m_next)
-  apply clarsimp
-  done
-
-lemma n_prev_eq:
-  "n \<turnstile> p \<leftarrow> p' =
-  (if p' = slot then p = 0
-  else if p' = mdbNext s_node
-  then m \<turnstile> slot \<leftarrow> p' \<and> p = mdbPrev s_node
-  else m \<turnstile> p \<leftarrow> p')"
-  apply (rule iffI)
-   apply (clarsimp simp: mdb_prev_def split del: if_split cong: if_cong)
-   apply (case_tac z)
-   apply (clarsimp split del: if_split)
-   apply (drule n_prev)
-   apply (elim exE conjE)
-   apply (simp split: if_split_asm)
-   apply (frule dlist_nextD [OF m_slot_next])
-   apply (clarsimp simp: mdb_prev_def)
-  apply (clarsimp simp: mdb_prev_def split: if_split_asm)
-    apply (simp add: n_def modify_map_if slot)
-   apply hypsubst_thin
-   apply (case_tac z)
-   apply clarsimp
-   apply (drule m_prev)
-   apply clarsimp
-  apply (case_tac z)
-  apply simp
-  apply (drule m_prev)
-  apply clarsimp
-  done
-
-lemma valid_dlist_n:
-  "valid_dlist n" using dlist
-  apply (clarsimp simp: valid_dlist_def2 [OF no_0_n])
-  apply (simp add: n_next_eq n_prev_eq m_slot_next m_slot_prev cong: if_cong)
-  apply (rule conjI, clarsimp)
-   apply (rule conjI, clarsimp simp: next_slot_prev prev_slot_next)
-   apply (fastforce dest!: dlist_prev_src_unique)
-  apply clarsimp
-  apply (rule conjI, clarsimp)
-   apply (clarsimp simp: valid_dlist_def2 [OF no_0])
-   apply (case_tac "mdbNext s_node = 0")
-    apply simp
-    apply (subgoal_tac "m \<turnstile> slot \<leadsto> c'")
-     prefer 2
-     apply fastforce
-    apply (clarsimp simp: mdb_next_unfold slot)
-   apply (frule next_slot_prev)
-   apply (drule (1) dlist_prev_src_unique, simp)
-   apply simp
-  apply clarsimp
-  apply (rule conjI, clarsimp)
-   apply (fastforce dest: dlist_next_src_unique)
-  apply clarsimp
-  apply (rule conjI, clarsimp)
-   apply (clarsimp simp: valid_dlist_def2 [OF no_0])
-   apply (clarsimp simp: mdb_prev_def slot)
-  apply (clarsimp simp: valid_dlist_def2 [OF no_0])
-  done
-
-lemma caps_contained_n:
-  "caps_contained' n"
-  using valid
-  apply (clarsimp simp: valid_mdb_ctes_def caps_contained'_def)
-  apply (drule n_cap)+
-  apply (clarsimp split: if_split_asm)
-  apply (erule disjE, clarsimp)
-  apply clarsimp
-  apply fastforce
-  done
-
-lemma chunked:
-  "mdb_chunked m"
-  using valid ..
-
-lemma valid_badges:
-  "valid_badges m"
-  using valid ..
+context Arch_mdb_empty begin
 
 lemma valid_badges_n:
   "valid_badges n"
@@ -485,6 +91,7 @@ proof -
   from valid_badges
   show ?thesis
     supply if_cong[cong]
+    supply to_slot_eq[simp del]
     apply (simp add: valid_badges_def2)
     apply clarsimp
     apply (rule conjI)
@@ -552,14 +159,6 @@ proof -
     done
 qed
 
-lemma to_slot_eq [simp]:
-  "m \<turnstile> p \<leadsto> slot = (p = mdbPrev s_node \<and> p \<noteq> 0)"
-  apply (rule iffI)
-   apply (frule dlist_nextD0, simp)
-   apply (clarsimp simp: mdb_prev_def slot mdb_next_unfold)
-  apply (clarsimp intro!: prev_slot_next)
-  done
-
 lemma n_parent_of:
   "\<lbrakk> n \<turnstile> p parentOf p'; p \<noteq> slot; p' \<noteq> slot \<rbrakk> \<Longrightarrow> m \<turnstile> p parentOf p'"
   supply if_cong[cong]
@@ -590,11 +189,8 @@ lemma m_parent_of:
   apply (frule_tac p=p' in m_badged)
   apply (drule_tac p=p' in m_revokable)
   apply clarsimp
-  apply (simp split: if_split_asm;
-         clarsimp simp: isMDBParentOf_def isArchMDBParentOf_def2 isCap_simps
-                  split: if_split_asm
-                  cong: if_cong)
-  done
+  by (fastforce simp: isMDBParentOf_def isArchMDBParentOf_def2 isCap_simps
+                split: if_split_asm)
 
 lemma m_parent_of_next:
   "\<lbrakk> m \<turnstile> p parentOf mdbNext s_node; m \<turnstile> p parentOf slot; p \<noteq> slot; p\<noteq>mdbNext s_node \<rbrakk>
@@ -614,30 +210,6 @@ lemma m_parent_of_next:
   apply (drule_tac p="slot" in m_revokable)
   by (auto simp: isMDBParentOf_def isArchMDBParentOf_def2 isCap_simps
            split: if_split_asm cong: if_cong)
-
-lemma n_mdbNext:
-  "\<lbrakk> n (mdbNext s_node) = Some (CTE cap node); mdbPrev s_node \<noteq> 0 \<rbrakk> \<Longrightarrow>
-  \<exists>node'. m (mdbNext s_node) = Some (CTE cap node') \<and>
-          mdbNext node = mdbNext node' \<and>
-          mdbPrev node = mdbPrev s_node \<and>
-          mdbRevocable node = mdbRevocable node' \<and>
-          (mdbFirstBadged node = mdbFirstBadged node' \<or> mdbFirstBadged s_node)"
-  apply (clarsimp simp: n_def modify_map_def)
-  apply (case_tac z)
-  apply clarsimp
-  done
-
-lemma n_mdbPrev:
-  "\<lbrakk> n (mdbPrev s_node) = Some (CTE cap node); mdbNext s_node \<noteq> 0 \<rbrakk> \<Longrightarrow>
-    \<exists>node'. m (mdbPrev s_node) = Some (CTE cap node') \<and>
-          mdbNext node = mdbNext s_node \<and>
-          mdbPrev node = mdbPrev node' \<and>
-          mdbRevocable node = mdbRevocable node' \<and>
-          (mdbFirstBadged node = mdbFirstBadged node')"
-  apply (clarsimp simp: n_def modify_map_def)
-  apply (case_tac z)
-  apply clarsimp
-  done
 
 lemma parency_n:
   assumes "n \<turnstile> p \<rightarrow> p'"
@@ -698,13 +270,16 @@ proof induct
      apply (case_tac cap'', simp_all add: isCap_simps)[1]
       apply (clarsimp simp: sameRegionAs_def3 isCap_simps)
      apply (clarsimp simp: sameRegionAs_def3 isCap_simps)
+     apply (rename_tac acap'')
+     apply (case_tac acap''; clarsimp simp: sameRegionAs_def3 isCap_simps)
     (* SGISignalCap *)
-    apply (clarsimp simp: parentOf_def isCap_simps isMDBParentOf_CTE arch_capBadge_def)
+    apply (clarsimp simp: parentOf_def isCap_simps isMDBParentOf_CTE)
     apply (rename_tac next_node)
     apply (rule subtree.trans_parent[OF _ m_slot_next], simp_all)
      apply (rule subtree.direct_parent)
        apply (erule prev_slot_next)
       apply simp
+     prefer 2
      apply (clarsimp simp: parentOf_def slot isMDBParentOf_CTE)
     apply (clarsimp simp: parentOf_def slot isMDBParentOf_CTE isCap_simps)
     apply (cases "mdbFirstBadged s_node", simp)
@@ -796,9 +371,11 @@ next
         apply (case_tac cap'', simp_all add: isCap_simps)[1]
          apply (clarsimp simp: sameRegionAs_def3 isCap_simps)
         apply (clarsimp simp: sameRegionAs_def3 isCap_simps)
+        apply (rename_tac acap'')
+        apply (case_tac acap''; clarsimp simp: sameRegionAs_def3 isCap_simps)
        (* SGISignalCap *)
        apply (rename_tac next_cap next_node)
-       apply (clarsimp simp: isCap_simps arch_capBadge_def)
+       apply (clarsimp simp: isCap_simps)
        apply (case_tac cte, case_tac cte')
        apply (rename_tac cap'' node'')
        apply (clarsimp simp: isMDBParentOf_CTE)
@@ -816,1106 +393,115 @@ next
     done
 qed
 
-lemma parency_m:
-  assumes "m \<turnstile> p \<rightarrow> p'"
-  shows "p \<noteq> slot \<longrightarrow> (if p' \<noteq> slot then n \<turnstile> p \<rightarrow> p' else m \<turnstile> p \<rightarrow> mdbNext s_node \<longrightarrow> n \<turnstile> p \<rightarrow> mdbNext s_node)"
-using assms
-proof induct
-  case (direct_parent c)
-  thus ?case
-    apply clarsimp
-    apply (rule conjI)
-     apply clarsimp
-     apply (rule subtree.direct_parent)
-       apply (simp add: n_next_eq)
-       apply clarsimp
-       apply (subgoal_tac "mdbPrev s_node \<noteq> 0")
-        prefer 2
-        apply (clarsimp simp: mdb_next_unfold)
-       apply (drule prev_slot_next)
-       apply (clarsimp simp: mdb_next_unfold)
-      apply assumption
-     apply (erule m_parent_of, simp, simp)
-      apply clarsimp
-     apply clarsimp
-     apply (drule dlist_next_src_unique)
-       apply fastforce
-      apply clarsimp
-     apply simp
-    apply clarsimp
-    apply (rule subtree.direct_parent)
-      apply (simp add: n_next_eq)
-     apply (drule subtree_parent)
-     apply (clarsimp simp: parentOf_def)
-    apply (drule subtree_parent)
-    apply (erule (1) m_parent_of_next)
-     apply clarsimp
-    apply clarsimp
-    done
-next
-  case (trans_parent c c')
-  thus ?case
-    apply clarsimp
-    apply (rule conjI)
-     apply clarsimp
-     apply (cases "c=slot")
-      apply simp
-      apply (erule impE)
-       apply (erule subtree.trans_parent)
-         apply fastforce
-        apply (clarsimp simp: slot mdb_next_unfold)
-       apply (clarsimp simp: slot mdb_next_unfold)
-      apply (clarsimp simp: slot mdb_next_unfold)
-     apply clarsimp
-     apply (erule subtree.trans_parent)
-       apply (simp add: n_next_eq)
-       apply clarsimp
-       apply (subgoal_tac "mdbPrev s_node \<noteq> 0")
-        prefer 2
-        apply (clarsimp simp: mdb_next_unfold)
-       apply (drule prev_slot_next)
-       apply (clarsimp simp: mdb_next_unfold)
-      apply assumption
-     apply (erule m_parent_of, simp, simp)
-      apply clarsimp
-      apply (drule subtree_mdb_next)
-      apply (drule trancl_trans)
-       apply (erule r_into_trancl)
-      apply simp
-     apply clarsimp
-     apply (drule dlist_next_src_unique)
-       apply fastforce
-      apply clarsimp
-     apply simp
-    apply clarsimp
-    apply (erule subtree.trans_parent)
-      apply (simp add: n_next_eq)
-     apply clarsimp
-    apply (rule m_parent_of_next, erule subtree_parent, assumption, assumption)
-    apply clarsimp
-    done
+end (* Arch_mdb_empty *)
+
+context mdb_empty begin
+
+lemmas gen_arch_assms =
+  Arch_mdb_empty.valid_badges_n
+  Arch_mdb_empty.parency_n
+  Arch_mdb_empty.m_parent_of
+  Arch_mdb_empty.m_parent_of_next
+
+(* extract arch-dependent assumptions of mdb_empty_gen proved in Arch_mdb_empty
+   (faster than interpreting Arch) *)
+lemmas gen_assms = gen_arch_assms[unfolded Arch_mdb_empty_def, OF mdb_empty_axioms]
+
+sublocale mdb_empty_gen
+  by (unfold_locales)
+     (blast intro!: gen_assms)+
+
+(* re-bind names *)
+lemmas vmdb_n = vmdb_n
+lemmas descendants = descendants
+
+end (* mdb_empty *)
+
+interpretation Finalise_R?: Finalise_R arch_final_matters' arch_cap_has_cleanup'
+proof goal_cases
+  interpret Arch  .
+  case 1 show ?case by (intro_locales; (unfold_locales; (fact Finalise_R_assms)?)?)
 qed
 
-lemma parency:
-  "n \<turnstile> p \<rightarrow> p' = (p \<noteq> slot \<and> p' \<noteq> slot \<and> m \<turnstile> p \<rightarrow> p')"
-  by (auto dest!: parency_n parency_m)
+context Arch begin arch_global_naming
 
-lemma descendants:
-  "descendants_of' p n =
-  (if p = slot then {} else descendants_of' p m - {slot})"
-  by (auto simp add: parency descendants_of'_def)
+named_theorems Finalise_R_2_assms
 
-lemma n_tranclD:
-  "n \<turnstile> p \<leadsto>\<^sup>+ p' \<Longrightarrow> m \<turnstile> p \<leadsto>\<^sup>+ p' \<and> p' \<noteq> slot"
-  apply (erule trancl_induct)
-   apply (clarsimp simp add: n_next_eq split: if_split_asm)
-     apply (rule mdb_chain_0D)
-      apply (rule chain)
-     apply (clarsimp simp: slot)
-    apply (blast intro: trancl_trans prev_slot_next)
-   apply fastforce
-  apply (clarsimp simp: n_next_eq split: if_split_asm)
-   apply (erule trancl_trans)
-   apply (blast intro: trancl_trans prev_slot_next)
-  apply (fastforce intro: trancl_trans)
-  done
-
-lemma m_tranclD:
-  "m \<turnstile> p \<leadsto>\<^sup>+ p' \<Longrightarrow>
-  if p = slot then n \<turnstile> mdbNext s_node \<leadsto>\<^sup>* p'
-  else if p' = slot then n \<turnstile> p \<leadsto>\<^sup>+ mdbNext s_node
-  else n \<turnstile> p \<leadsto>\<^sup>+ p'"
-  using no_0_n
-  apply -
-  apply (erule trancl_induct)
-   apply clarsimp
-   apply (rule conjI)
-    apply clarsimp
-    apply (rule r_into_trancl)
-    apply (clarsimp simp: n_next_eq)
-   apply clarsimp
-   apply (rule conjI)
-    apply (insert m_slot_next)[1]
-    apply (clarsimp simp: mdb_next_unfold)
-   apply clarsimp
-   apply (rule r_into_trancl)
-   apply (clarsimp simp: n_next_eq)
-   apply (rule context_conjI)
-    apply (clarsimp simp: mdb_next_unfold)
-   apply (drule prev_slot_next)
-   apply (clarsimp simp: mdb_next_unfold)
-  apply clarsimp
-  apply (rule conjI)
-   apply clarsimp
-   apply (rule conjI)
-    apply clarsimp
-    apply (drule prev_slot_next)
-    apply (drule trancl_trans, erule r_into_trancl)
-    apply simp
-   apply clarsimp
-   apply (erule trancl_trans)
-   apply (rule r_into_trancl)
-   apply (simp add: n_next_eq)
-  apply clarsimp
-  apply (rule conjI)
-   apply clarsimp
-   apply (erule rtrancl_trans)
-   apply (rule r_into_rtrancl)
-   apply (simp add: n_next_eq)
-   apply (rule conjI)
-    apply clarsimp
-    apply (rule context_conjI)
-     apply (clarsimp simp: mdb_next_unfold)
-    apply (drule prev_slot_next)
-    apply (clarsimp simp: mdb_next_unfold)
-   apply clarsimp
-  apply clarsimp
-  apply (simp split: if_split_asm)
-   apply (clarsimp simp: mdb_next_unfold slot)
-  apply (erule trancl_trans)
-  apply (rule r_into_trancl)
-  apply (clarsimp simp add: n_next_eq)
-  apply (rule context_conjI)
-   apply (clarsimp simp: mdb_next_unfold)
-  apply (drule prev_slot_next)
-  apply (clarsimp simp: mdb_next_unfold)
-  done
-
-lemma n_trancl_eq:
-  "n \<turnstile> p \<leadsto>\<^sup>+ p' = (m \<turnstile> p \<leadsto>\<^sup>+ p' \<and> (p = slot \<longrightarrow> p' = 0) \<and> p' \<noteq> slot)"
-  using no_0_n
-  apply -
-  apply (rule iffI)
-   apply (frule n_tranclD)
-   apply clarsimp
-   apply (drule tranclD)
-   apply (clarsimp simp: n_next_eq)
-   apply (simp add: rtrancl_eq_or_trancl)
-  apply clarsimp
-  apply (drule m_tranclD)
-  apply (simp split: if_split_asm)
-  apply (rule r_into_trancl)
-  apply (simp add: n_next_eq)
-  done
-
-lemma n_rtrancl_eq:
-  "n \<turnstile> p \<leadsto>\<^sup>* p' =
-  (m \<turnstile> p \<leadsto>\<^sup>* p' \<and>
-   (p = slot \<longrightarrow> p' = 0 \<or> p' = slot) \<and>
-   (p' = slot \<longrightarrow> p = slot))"
-  by (auto simp: rtrancl_eq_or_trancl n_trancl_eq)
-
-lemma mdb_chain_0_n:
-  "mdb_chain_0 n"
-  using chain
-  apply (clarsimp simp: mdb_chain_0_def)
-  apply (drule bspec)
-   apply (fastforce simp: n_def modify_map_if split: if_split_asm)
-  apply (simp add: n_trancl_eq)
-  done
-
-lemma mdb_chunked_n:
-  "mdb_chunked n"
-  using chunked
-  apply (clarsimp simp: mdb_chunked_def)
-  apply (drule n_cap)+
-  apply (clarsimp split: if_split_asm)
-  apply (case_tac "p=slot", clarsimp)
-  apply clarsimp
-  apply (erule_tac x=p in allE)
-  apply (erule_tac x=p' in allE)
-  apply (clarsimp simp: is_chunk_def)
-  apply (simp add: n_trancl_eq n_rtrancl_eq)
-  apply (rule conjI)
-   apply clarsimp
-   apply (erule_tac x=p'' in allE)
-   apply clarsimp
-   apply (drule_tac p=p'' in m_cap)
-   apply clarsimp
-  apply clarsimp
-  apply (erule_tac x=p'' in allE)
-  apply clarsimp
-  apply (drule_tac p=p'' in m_cap)
-  apply clarsimp
-  done
-
-lemma untyped_mdb_n:
-  "untyped_mdb' n"
-  using untyped_mdb
-  apply (simp add: untyped_mdb'_def descendants_of'_def parency)
-  apply clarsimp
-  apply (drule n_cap)+
-  apply (clarsimp split: if_split_asm)
-  apply (case_tac "p=slot", simp)
-  apply clarsimp
-  done
-
-lemma untyped_inc_n:
-  "untyped_inc' n"
-  using untyped_inc
-  apply (simp add: untyped_inc'_def descendants_of'_def parency)
-  apply clarsimp
-  apply (drule n_cap)+
-  apply (clarsimp split: if_split_asm)
-  apply (case_tac "p=slot", simp)
-  apply clarsimp
-  apply (erule_tac x=p in allE)
-  apply (erule_tac x=p' in allE)
-  apply simp
-  done
-
-lemmas vn_prev [dest!] = valid_nullcaps_prev [OF _ slot no_0 dlist nullcaps]
-lemmas vn_next [dest!] = valid_nullcaps_next [OF _ slot no_0 dlist nullcaps]
-
-lemma nullcaps_n: "valid_nullcaps n"
-proof -
-  from valid have "valid_nullcaps m" ..
-  thus ?thesis
-    apply (clarsimp simp: valid_nullcaps_def nullMDBNode_def nullPointer_def)
-    apply (frule n_cap)
-    apply (frule n_next)
-    apply (frule n_badged)
-    apply (frule n_revokable)
-    apply (drule n_prev)
-    apply (case_tac n)
-    apply (insert slot)
-    apply (fastforce split: if_split_asm)
-    done
-qed
-
-lemma ut_rev_n: "ut_revocable' n"
-  apply(insert valid)
-  apply(clarsimp simp: ut_revocable'_def)
-  apply(frule n_cap)
-  apply(drule n_revokable)
-  apply(clarsimp simp: isCap_simps split: if_split_asm)
-  apply(simp add: valid_mdb_ctes_def ut_revocable'_def)
-  done
-
-lemma class_links_n: "class_links n"
-  using valid slot
-  apply (clarsimp simp: valid_mdb_ctes_def class_links_def)
-  apply (case_tac cte, case_tac cte')
-  apply (drule n_nextD)
-  apply (clarsimp simp: split: if_split_asm)
-    apply (simp add: no_0_n)
-   apply (drule n_cap)+
-   apply clarsimp
-   apply (frule spec[where x=slot],
-          drule spec[where x="mdbNext s_node"],
-          simp, simp add: m_slot_next)
-   apply (drule spec[where x="mdbPrev s_node"],
-          drule spec[where x=slot], simp)
-  apply (drule n_cap)+
-  apply clarsimp
-  apply (fastforce split: if_split_asm)
-  done
-
-lemma distinct_zombies_m: "distinct_zombies m"
-  using valid by (simp add: valid_mdb_ctes_def)
-
-lemma distinct_zombies_n[simp]:
-  "distinct_zombies n"
-  using distinct_zombies_m
-  apply (simp add: n_def distinct_zombies_nonCTE_modify_map)
-  apply (subst modify_map_apply[where p=slot])
-   apply (simp add: modify_map_def slot)
-  apply simp
-  apply (rule distinct_zombies_sameMasterE)
-    apply (simp add: distinct_zombies_nonCTE_modify_map)
-   apply (simp add: modify_map_def slot)
-  apply simp
-  done
-
-lemma irq_control_n [simp]: "irq_control n"
-  using slot
-  apply (clarsimp simp: irq_control_def)
-  apply (frule n_revokable)
-  apply (drule n_cap)
-  apply (clarsimp split: if_split_asm)
-  apply (frule irq_revocable, rule irq_control)
-  apply clarsimp
-  apply (drule n_cap)
-  apply (clarsimp simp: if_split_asm)
-  apply (erule (1) irq_controlD, rule irq_control)
-  done
-
-lemma reply_masters_rvk_fb_m: "reply_masters_rvk_fb m"
-  using valid by auto
-
-lemma reply_masters_rvk_fb_n [simp]: "reply_masters_rvk_fb n"
-  using reply_masters_rvk_fb_m
-  apply (simp add: reply_masters_rvk_fb_def n_def
-                   ball_ran_modify_map_eq
-                   modify_map_comp[symmetric])
-  apply (subst ball_ran_modify_map_eq)
-   apply (frule bspec, rule ranI, rule slot)
-   apply (simp add: nullMDBNode_def isCap_simps modify_map_def
-                    slot)
-  apply (subst ball_ran_modify_map_eq)
-   apply (clarsimp simp add: modify_map_def)
-   apply fastforce
-  apply (simp add: ball_ran_modify_map_eq)
-  done
-
-lemma vmdb_n: "valid_mdb_ctes n"
-  by (simp add: valid_mdb_ctes_def valid_dlist_n
-                no_0_n mdb_chain_0_n valid_badges_n
-                caps_contained_n mdb_chunked_n
-                untyped_mdb_n untyped_inc_n
-                nullcaps_n ut_rev_n class_links_n)
-
-end
-
-context begin interpretation Arch .
-crunch postCapDeletion, clearUntypedFreeIndex
-  for ctes_of[wp]: "\<lambda>s. P (ctes_of s)"
-
-lemma emptySlot_mdb [wp]:
-  "\<lbrace>valid_mdb'\<rbrace>
-  emptySlot sl opt
-  \<lbrace>\<lambda>_. valid_mdb'\<rbrace>"
-  unfolding emptySlot_def
-  apply (simp only: case_Null_If valid_mdb'_def)
-  apply (wp updateCap_ctes_of_wp getCTE_wp'
-            opt_return_pres_lift | simp add: cte_wp_at_ctes_of)+
-  apply (clarsimp)
-  apply (case_tac cte)
-  apply (rename_tac cap node)
-  apply (simp)
-  apply (subgoal_tac "mdb_empty (ctes_of s) sl cap node")
-   prefer 2
-   apply (rule mdb_empty.intro)
-   apply (rule mdb_ptr.intro)
-    apply (rule vmdb.intro)
-    apply (simp add: valid_mdb_ctes_def)
-   apply (rule mdb_ptr_axioms.intro)
-   apply (simp add: cte_wp_at_ctes_of)
-  apply (rule conjI, clarsimp simp: valid_mdb_ctes_def)
-  apply (erule mdb_empty.vmdb_n[unfolded const_def])
-  done
-end
-
-lemma if_live_then_nonz_cap'_def2:
-  "if_live_then_nonz_cap' = (\<lambda>s. \<forall>ptr. ko_wp_at' live' ptr s
-                               \<longrightarrow> (\<exists>p zr. (option_map zobj_refs' o cteCaps_of s) p = Some zr \<and> ptr \<in> zr))"
-  by (fastforce intro!: ext
-                 simp: if_live_then_nonz_cap'_def ex_nonz_cap_to'_def
-                       cte_wp_at_ctes_of cteCaps_of_def)
-
-lemma updateMDB_ko_wp_at_live[wp]:
-  "\<lbrace>\<lambda>s. P (ko_wp_at' live' p' s)\<rbrace>
-      updateMDB p m
-   \<lbrace>\<lambda>rv s. P (ko_wp_at' live' p' s)\<rbrace>"
-  unfolding updateMDB_def Let_def
-  apply (rule hoare_pre, wp)
-  apply simp
-  done
-
-lemma updateCap_ko_wp_at_live[wp]:
-  "\<lbrace>\<lambda>s. P (ko_wp_at' live' p' s)\<rbrace>
-      updateCap p cap
-   \<lbrace>\<lambda>rv s. P (ko_wp_at' live' p' s)\<rbrace>"
-  unfolding updateCap_def
-  by wp
-
-primrec
-  threadCapRefs :: "capability \<Rightarrow> word32 set"
-where
-  "threadCapRefs (ThreadCap r)                  = {r}"
-| "threadCapRefs (ReplyCap t m x)               = {}"
-| "threadCapRefs NullCap                        = {}"
-| "threadCapRefs (UntypedCap d r n i)           = {}"
-| "threadCapRefs (EndpointCap r badge x y z t)  = {}"
-| "threadCapRefs (NotificationCap r badge x y)  = {}"
-| "threadCapRefs (CNodeCap r b g gsz)           = {}"
-| "threadCapRefs (Zombie r b n)                 = {}"
-| "threadCapRefs (ArchObjectCap ac)             = {}"
-| "threadCapRefs (IRQHandlerCap irq)            = {}"
-| "threadCapRefs (IRQControlCap)                = {}"
-| "threadCapRefs (DomainCap)                    = {}"
-
-definition
-  "isFinal cap p m \<equiv>
-  \<not>isUntypedCap cap \<and>
-  (\<forall>p' c. m p' = Some c \<longrightarrow>
-          p \<noteq> p' \<longrightarrow> \<not>isUntypedCap c \<longrightarrow>
-          \<not> sameObjectAs cap c)"
-
-lemma not_FinalE:
-  "\<lbrakk> \<not> isFinal cap sl cps; isUntypedCap cap \<Longrightarrow> P;
-     \<And>p c. \<lbrakk> cps p = Some c; p \<noteq> sl; \<not> isUntypedCap c; sameObjectAs cap c \<rbrakk> \<Longrightarrow> P
-    \<rbrakk> \<Longrightarrow> P"
-  by (fastforce simp: isFinal_def)
-
-definition
- "removeable' sl \<equiv> \<lambda>s cap.
-    (\<exists>p. p \<noteq> sl \<and> cte_wp_at' (\<lambda>cte. capMasterCap (cteCap cte) = capMasterCap cap) p s)
-    \<or> ((\<forall>p \<in> cte_refs' cap (irq_node' s). p \<noteq> sl \<longrightarrow> cte_wp_at' (\<lambda>cte. cteCap cte = NullCap) p s)
-         \<and> (\<forall>p \<in> zobj_refs' cap. ko_wp_at' (Not \<circ> live') p s))"
-
-lemma not_Final_removeable:
-  "\<not> isFinal cap sl (cteCaps_of s)
-    \<Longrightarrow> removeable' sl s cap"
+lemma not_Final_removeable[Finalise_R_2_assms]:
+  "\<not> isFinal cap sl (cteCaps_of s) \<Longrightarrow> removeable' sl s cap"
   apply (erule not_FinalE)
    apply (clarsimp simp: removeable'_def gen_isCap_simps)
   apply (clarsimp simp: cteCaps_of_def ARM.sameObjectAs_def2 removeable'_def
-                        cte_wp_at_ctes_of) (* FIXME arch-split *)
+                        cte_wp_at_ctes_of)
   apply fastforce
   done
 
-context begin interpretation Arch .
-crunch postCapDeletion
-  for ko_wp_at'[wp]: "\<lambda>s. P (ko_wp_at' P' p s)"
-crunch postCapDeletion
-  for cteCaps_of[wp]: "\<lambda>s. P (cteCaps_of s)"
-  (simp: cteCaps_of_def o_def)
-end
-
-crunch clearUntypedFreeIndex
-  for ko_at_live[wp]: "\<lambda>s. P (ko_wp_at' live' ptr s)"
-
-lemma clearUntypedFreeIndex_cteCaps_of[wp]:
-  "\<lbrace>\<lambda>s. P (cteCaps_of s)\<rbrace>
-       clearUntypedFreeIndex sl \<lbrace>\<lambda>y s. P (cteCaps_of s)\<rbrace>"
-  by (simp add: cteCaps_of_def, wp)
-
-lemma emptySlot_iflive'[wp]:
-  "\<lbrace>\<lambda>s. if_live_then_nonz_cap' s \<and> cte_wp_at' (\<lambda>cte. removeable' sl s (cteCap cte)) sl s\<rbrace>
-     emptySlot sl opt
-   \<lbrace>\<lambda>rv. if_live_then_nonz_cap'\<rbrace>"
-  apply (simp add: emptySlot_def case_Null_If if_live_then_nonz_cap'_def2
-              del: comp_apply)
+lemma deletedIRQHandler_valid_global_refs[Finalise_R_2_assms, wp]:
+  "\<lbrace>valid_global_refs'\<rbrace> deletedIRQHandler irq \<lbrace>\<lambda>rv. valid_global_refs'\<rbrace>"
+  apply (clarsimp simp: valid_global_refs'_def global_refs'_def)
   apply (rule hoare_pre)
-   apply (wp hoare_vcg_all_lift hoare_vcg_disj_lift
-             getCTE_wp opt_return_pres_lift
-             clearUntypedFreeIndex_ctes_of
-             clearUntypedFreeIndex_cteCaps_of
-             hoare_vcg_ex_lift
-             | wp (once) hoare_vcg_imp_lift
-             | simp add: cte_wp_at_ctes_of del: comp_apply)+
-  apply (clarsimp simp: modify_map_same
-    imp_conjR[symmetric])
-  apply (drule spec, drule(1) mp)
-  apply (clarsimp simp: cte_wp_at_ctes_of modify_map_def split: if_split_asm)
-  apply (case_tac "p \<noteq> sl")
-   apply blast
-  apply (simp add: removeable'_def cteCaps_of_def)
-  apply (erule disjE)
-   apply (clarsimp simp: cte_wp_at_ctes_of modify_map_def
-                  dest!: capMaster_same_refs)
-   apply fastforce
-  apply clarsimp
-  apply (drule(1) bspec)
-  apply (clarsimp simp: ko_wp_at'_def)
-  done
-
-lemma setIRQState_irq_node'[wp]:
-  "\<lbrace>\<lambda>s. P (irq_node' s)\<rbrace> setIRQState state irq \<lbrace>\<lambda>_ s. P (irq_node' s)\<rbrace>"
-  apply (simp add: setIRQState_def setInterruptState_def getInterruptState_def)
-  apply wp
-  apply simp
-  done
-
-context begin interpretation Arch .
-crunch emptySlot
-  for irq_node'[wp]: "\<lambda>s. P (irq_node' s)"
-end
-
-lemma emptySlot_ifunsafe'[wp]:
-  "\<lbrace>\<lambda>s. if_unsafe_then_cap' s \<and> cte_wp_at' (\<lambda>cte. removeable' sl s (cteCap cte)) sl s\<rbrace>
-     emptySlot sl opt
-   \<lbrace>\<lambda>rv. if_unsafe_then_cap'\<rbrace>"
-  apply (simp add: ifunsafe'_def3)
-  apply (rule hoare_pre, rule hoare_use_eq_irq_node'[OF emptySlot_irq_node'])
-   apply (simp add: emptySlot_def case_Null_If)
-   apply (wp opt_return_pres_lift | simp add: o_def)+
-   apply (wp getCTE_cteCap_wp clearUntypedFreeIndex_cteCaps_of)+
-  apply (clarsimp simp: tree_cte_cteCap_eq[unfolded o_def]
-                        modify_map_same
-                        modify_map_comp[symmetric]
-                 split: option.split_asm if_split_asm
-                 dest!: modify_map_K_D)
-  apply (clarsimp simp: modify_map_def)
-  apply (drule_tac x=cref in spec, clarsimp)
-  apply (case_tac "cref' \<noteq> sl")
-   apply (rule_tac x=cref' in exI)
-   apply (clarsimp simp: modify_map_def)
-  apply (simp add: removeable'_def)
-  apply (erule disjE)
-   apply (clarsimp simp: modify_map_def)
-   apply (subst(asm) tree_cte_cteCap_eq[unfolded o_def])
-   apply (clarsimp split: option.split_asm dest!: capMaster_same_refs)
-   apply fastforce
-  apply clarsimp
-  apply (drule(1) bspec)
-  apply (clarsimp simp: cte_wp_at_ctes_of cteCaps_of_def)
-  done
-
-lemma ctes_of_valid'[elim]:
-  "\<lbrakk>ctes_of s p = Some cte; valid_objs' s\<rbrakk> \<Longrightarrow> s \<turnstile>' cteCap cte"
-  by (cases cte, simp) (rule ctes_of_valid_cap')
-
-crunch setInterruptState
-  for valid_idle'[wp]: "valid_idle'"
-  (simp: valid_idle'_def)
-
-context begin interpretation Arch .
-crunch emptySlot
-  for valid_idle'[wp]: "valid_idle'"
-
-crunch emptySlot
-  for ksArch[wp]: "\<lambda>s. P (ksArchState s)"
-crunch emptySlot
-  for ksIdle[wp]: "\<lambda>s. P (ksIdleThread s)"
-crunch emptySlot
-  for gsMaxObjectSize[wp]: "\<lambda>s. P (gsMaxObjectSize s)"
-end
-
-lemma emptySlot_cteCaps_of:
-  "\<lbrace>\<lambda>s. P ((cteCaps_of s)(p \<mapsto> NullCap))\<rbrace>
-     emptySlot p opt
-   \<lbrace>\<lambda>rv s. P (cteCaps_of s)\<rbrace>"
-  apply (simp add: emptySlot_def case_Null_If)
-  apply (wp opt_return_pres_lift getCTE_cteCap_wp
-            clearUntypedFreeIndex_cteCaps_of)
-  apply (clarsimp simp: cteCaps_of_def cte_wp_at_ctes_of)
-  apply (auto elim!: rsubst[where P=P]
-               simp: modify_map_def fun_upd_def[symmetric] o_def
-                     fun_upd_idem cteCaps_of_def
-              split: option.splits)
-  done
-
-lemma emptySlot_valid_global_refs[wp]:
-  "\<lbrace>valid_global_refs' and cte_at' sl\<rbrace> emptySlot sl opt \<lbrace>\<lambda>rv. valid_global_refs'\<rbrace>"
-  apply (simp add: valid_global_refs'_def ARM.global_refs'_def)
-  apply (rule hoare_pre)
-   apply (rule hoare_use_eq_irq_node' [OF emptySlot_irq_node'])
-   apply (rule hoare_use_eq [where f=ksArchState, OF emptySlot_ksArch])
-   apply (rule hoare_use_eq [where f=ksIdleThread, OF emptySlot_ksIdle])
-   apply (rule hoare_use_eq [where f=gsMaxObjectSize], wp)
+   apply (rule hoare_use_eq_irq_node' [OF deletedIRQHandler_irq_node'])
+   apply (rule hoare_use_eq [where f=ksIdleThread, OF deletedIRQHandler_ksIdle])
+   apply (rule hoare_use_eq [where f=ksArchState, OF deletedIRQHandler_ksArch])
+   apply (rule hoare_use_eq[where f="gsMaxObjectSize"], wp)
    apply (simp add: valid_refs'_cteCaps valid_cap_sizes_cteCaps)
-   apply (rule emptySlot_cteCaps_of)
+   apply (rule deletedIRQHandler_cteCaps_of)
   apply (clarsimp simp: cte_wp_at_ctes_of)
-  apply (frule(1) cte_at_valid_cap_sizes_0)
   apply (clarsimp simp: valid_refs'_cteCaps valid_cap_sizes_cteCaps ball_ran_eq)
   done
 
-lemmas doMachineOp_irq_handlers[wp]
-    = valid_irq_handlers_lift'' [OF doMachineOp_ctes doMachineOp_ksInterruptState]
-
-lemma deletedIRQHandler_irq_handlers'[wp]:
-  "\<lbrace>\<lambda>s. valid_irq_handlers' s \<and> (IRQHandlerCap irq \<notin> ran (cteCaps_of s))\<rbrace>
-       deletedIRQHandler irq
-   \<lbrace>\<lambda>rv. valid_irq_handlers'\<rbrace>"
-  apply (simp add: deletedIRQHandler_def setIRQState_def setInterruptState_def getInterruptState_def)
-  apply wp
-  apply (clarsimp simp: valid_irq_handlers'_def irq_issued'_def ran_def cteCaps_of_def)
-  done
-
-context begin interpretation Arch .
-
-lemma postCapDeletion_irq_handlers'[wp]:
-  "\<lbrace>\<lambda>s. valid_irq_handlers' s \<and> (cap \<noteq> NullCap \<longrightarrow> cap \<notin> ran (cteCaps_of s))\<rbrace>
-       postCapDeletion cap
-   \<lbrace>\<lambda>rv. valid_irq_handlers'\<rbrace>"
-  by (wpsimp simp: Retype_H.postCapDeletion_def ARM_H.postCapDeletion_def)
-
-end
-
-crunch clearUntypedFreeIndex
-  for ksInterruptState[wp]: "\<lambda>s. P (ksInterruptState s)"
-
-lemma emptySlot_valid_irq_handlers'[wp]:
-  "\<lbrace>\<lambda>s. valid_irq_handlers' s
-          \<and> (\<forall>sl'. info \<noteq> NullCap \<longrightarrow> sl' \<noteq> sl \<longrightarrow> cteCaps_of s sl' \<noteq> Some info)\<rbrace>
-     emptySlot sl info
-   \<lbrace>\<lambda>rv. valid_irq_handlers'\<rbrace>"
-  apply (simp add: emptySlot_def case_Null_If)
-  apply (wp | wpc)+
-        apply (unfold valid_irq_handlers'_def irq_issued'_def)
-        apply (wp getCTE_cteCap_wp clearUntypedFreeIndex_cteCaps_of
-          | wps clearUntypedFreeIndex_ksInterruptState)+
-  apply (clarsimp simp: cteCaps_of_def cte_wp_at_ctes_of ran_def modify_map_def
-                 split: option.split)
-  apply auto
-  done
-
-context begin interpretation Arch .
-crunch emptySlot
-  for irq_states'[wp]: valid_irq_states'
-
-crunch emptySlot
-  for no_0_obj'[wp]: no_0_obj'
- (wp: crunch_wps)
-
-crunch emptySlot
-  for pde_mappings'[wp]: "valid_pde_mappings'"
-
-lemma deletedIRQHandler_irqs_masked'[wp]:
-  "\<lbrace>irqs_masked'\<rbrace> deletedIRQHandler irq \<lbrace>\<lambda>_. irqs_masked'\<rbrace>"
-  apply (simp add: deletedIRQHandler_def setIRQState_def getInterruptState_def setInterruptState_def)
-  apply (wp dmo_maskInterrupt)
-  apply (simp add: irqs_masked'_def)
-  done
-
-crunch emptySlot
-  for irqs_masked'[wp]: "irqs_masked'"
-
-lemma setIRQState_umm:
- "\<lbrace>\<lambda>s. P (underlying_memory (ksMachineState s))\<rbrace>
-   setIRQState irqState irq
-  \<lbrace>\<lambda>_ s. P (underlying_memory (ksMachineState s))\<rbrace>"
-  by (simp add: setIRQState_def maskInterrupt_def
-                setInterruptState_def getInterruptState_def
-      | wp dmo_lift')+
-
-crunch emptySlot
-  for umm[wp]: "\<lambda>s. P (underlying_memory (ksMachineState s))"
-  (wp: setIRQState_umm)
-
-lemma emptySlot_vms'[wp]:
-  "\<lbrace>valid_machine_state'\<rbrace> emptySlot slot irq \<lbrace>\<lambda>_. valid_machine_state'\<rbrace>"
-  by (simp add: valid_machine_state'_def pointerInUserData_def pointerInDeviceData_def)
-     (wp hoare_vcg_all_lift hoare_vcg_disj_lift)
-
-crunch emptySlot
-  for pspace_domain_valid[wp]: "pspace_domain_valid"
-
-crunch emptySlot
-  for ksDomSchedule[wp]: "\<lambda>s. P (ksDomSchedule s)"
-  and ksDomScheduleIdx[wp]: "\<lambda>s. P (ksDomScheduleIdx s)"
-
-lemma deletedIRQHandler_ct_not_inQ[wp]:
-  "\<lbrace>ct_not_inQ\<rbrace> deletedIRQHandler irq \<lbrace>\<lambda>_. ct_not_inQ\<rbrace>"
-  apply (rule ct_not_inQ_lift [OF deletedIRQHandler_nosch])
-  apply (rule hoare_weaken_pre)
-   apply (wps deletedIRQHandler_ct)
-   apply (simp add: deletedIRQHandler_def setIRQState_def)
-   apply (wp)
-  apply (simp add: comp_def)
-  done
-
-crunch emptySlot
-  for ct_not_inQ[wp]: "ct_not_inQ"
-
-crunch emptySlot
-  for tcbDomain[wp]: "obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t"
-
-lemma emptySlot_ct_idle_or_in_cur_domain'[wp]:
-  "\<lbrace>ct_idle_or_in_cur_domain'\<rbrace> emptySlot sl opt \<lbrace>\<lambda>_. ct_idle_or_in_cur_domain'\<rbrace>"
-apply (wp ct_idle_or_in_cur_domain'_lift2 tcb_in_cur_domain'_lift | simp)+
-done
-
-crunch postCapDeletion
-  for gsUntypedZeroRanges[wp]: "\<lambda>s. P (gsUntypedZeroRanges s)"
-  (wp: crunch_wps simp: crunch_simps)
-
-lemma untypedZeroRange_modify_map_isUntypedCap:
-  "m sl = Some v \<Longrightarrow> \<not> isUntypedCap v \<Longrightarrow> \<not> isUntypedCap (f v)
-    \<Longrightarrow> (untypedZeroRange \<circ>\<^sub>m modify_map m sl f) = (untypedZeroRange \<circ>\<^sub>m m)"
-  by (simp add: modify_map_def map_comp_def fun_eq_iff untypedZeroRange_def)
-
-lemma emptySlot_untyped_ranges[wp]:
-  "\<lbrace>untyped_ranges_zero' and valid_objs' and valid_mdb'\<rbrace>
-     emptySlot sl opt \<lbrace>\<lambda>rv. untyped_ranges_zero'\<rbrace>"
-  apply (simp add: emptySlot_def case_Null_If)
+lemma clearUntypedFreeIndex_valid_global_refs[Finalise_R_2_assms, wp]:
+  "\<lbrace>valid_global_refs'\<rbrace> clearUntypedFreeIndex irq \<lbrace>\<lambda>rv. valid_global_refs'\<rbrace>"
+  apply (clarsimp simp: valid_global_refs'_def global_refs'_def)
   apply (rule hoare_pre)
-   apply (rule bind_wp)
-    apply (rule untyped_ranges_zero_lift)
-     apply (wp getCTE_cteCap_wp clearUntypedFreeIndex_cteCaps_of
-       | wpc | simp add: clearUntypedFreeIndex_def updateTrackedFreeIndex_def
-                         getSlotCap_def
-                  split: option.split)+
-  apply (clarsimp simp: modify_map_comp[symmetric] modify_map_same)
-  apply (case_tac "\<not> isUntypedCap (the (cteCaps_of s sl))")
-   apply (case_tac "the (cteCaps_of s sl)",
-     simp_all add: untyped_ranges_zero_inv_def
-                   untypedZeroRange_modify_map_isUntypedCap isCap_simps)[1]
-  apply (clarsimp simp: isCap_simps untypedZeroRange_def modify_map_def)
-  apply (strengthen untyped_ranges_zero_fun_upd[mk_strg I E])
-  apply simp
-  apply (simp add: untypedZeroRange_def isCap_simps)
-  done
-
-crunch emptySlot
-  for valid_bitmaps[wp]: valid_bitmaps
-  and tcbQueued_opt_pred[wp]: "\<lambda>s. P (tcbQueued |< tcbs_of' s)"
-  and valid_sched_pointers[wp]: valid_sched_pointers
-  and sched_projs[wp]: "\<lambda>s. P (tcbSchedNexts_of s) (tcbSchedPrevs_of s)"
-  and valid_arch_state'[wp]: valid_arch_state'
-  and ksDomScheduleStart[wp]: "\<lambda>s. P (ksDomScheduleStart s)"
-  (wp: valid_bitmaps_lift)
-
-lemma emptySlot_invs'[wp]:
-  "\<lbrace>\<lambda>s. invs' s \<and> cte_wp_at' (\<lambda>cte. removeable' sl s (cteCap cte)) sl s
-            \<and> (\<forall>sl'. info \<noteq> NullCap \<longrightarrow> sl' \<noteq> sl \<longrightarrow> cteCaps_of s sl' \<noteq> Some info)\<rbrace>
-     emptySlot sl info
-   \<lbrace>\<lambda>rv. invs'\<rbrace>"
-  apply (simp add: invs'_def valid_state'_def valid_pspace'_def)
-  apply (wp valid_irq_node_lift cur_tcb_lift valid_dom_schedule'_lift)
+   apply (rule hoare_use_eq_irq_node' [OF clearUntypedFreeIndex_irq_node'])
+   apply (rule hoare_use_eq [where f=ksIdleThread, OF clearUntypedFreeIndex_ksIdle])
+   apply (rule hoare_use_eq [where f=ksArchState, OF clearUntypedFreeIndex_ksArch])
+   apply (rule hoare_use_eq[where f="gsMaxObjectSize"], wp)
+   apply (simp add: valid_refs'_cteCaps valid_cap_sizes_cteCaps)
+   apply (rule clearUntypedFreeIndex_cteCaps_of)
   apply (clarsimp simp: cte_wp_at_ctes_of)
+  apply (clarsimp simp: valid_refs'_cteCaps valid_cap_sizes_cteCaps ball_ran_eq)
   done
-
-lemma deletedIRQHandler_corres:
-  "corres dc \<top> \<top>
-    (deleted_irq_handler irq)
-    (deletedIRQHandler irq)"
-  apply (simp add: deleted_irq_handler_def deletedIRQHandler_def)
-  apply (rule setIRQState_corres)
-  apply (simp add: irq_state_relation_def)
-  done
-
-lemma arch_postCapDeletion_corres:
-  "acap_relation cap cap' \<Longrightarrow> corres dc \<top> \<top> (arch_post_cap_deletion cap) (ARM_H.postCapDeletion cap')"
-  by (corresKsimp simp: arch_post_cap_deletion_def ARM_H.postCapDeletion_def)
-
-lemma postCapDeletion_corres:
-  "cap_relation cap cap' \<Longrightarrow> corres dc \<top> \<top> (post_cap_deletion cap) (postCapDeletion cap')"
-  apply (cases cap; clarsimp simp: post_cap_deletion_def Retype_H.postCapDeletion_def)
-   apply (corresKsimp corres: deletedIRQHandler_corres)
-  by (corresKsimp corres: arch_postCapDeletion_corres)
-
-lemma set_cap_trans_state:
-  "((),s') \<in> fst (set_cap c p s) \<Longrightarrow> ((),trans_state f s') \<in> fst (set_cap c p (trans_state f s))"
-  apply (cases p)
-  apply (clarsimp simp add: set_cap_def in_monad set_object_def get_object_def)
-  apply (case_tac y)
-  apply (auto simp add: in_monad set_object_def split: if_split_asm)
-  done
-
-lemma clearUntypedFreeIndex_noop_corres:
-  "corres dc \<top> (cte_at' (cte_map slot))
-    (return ()) (clearUntypedFreeIndex (cte_map slot))"
-  apply (simp add: clearUntypedFreeIndex_def)
-  apply (rule corres_guard_imp)
-    apply (rule corres_bind_return2)
-    apply (rule corres_symb_exec_r_conj[where P'="cte_at' (cte_map slot)"])
-       apply (rule corres_trivial, simp)
-      apply (wp getCTE_wp' | wpc
-        | simp add: updateTrackedFreeIndex_def getSlotCap_def)+
-     apply (clarsimp simp: state_relation_def)
-    apply (rule no_fail_pre)
-     apply (wp no_fail_getSlotCap getCTE_wp'
-       | wpc | simp add: updateTrackedFreeIndex_def getSlotCap_def)+
-  done
-
-lemma clearUntypedFreeIndex_valid_pspace'[wp]:
-  "\<lbrace>valid_pspace'\<rbrace> clearUntypedFreeIndex slot \<lbrace>\<lambda>rv. valid_pspace'\<rbrace>"
-  apply (simp add: valid_pspace'_def)
-  apply (rule hoare_pre)
-   apply (wp | simp add: valid_mdb'_def)+
-  done
-
-lemma emptySlot_corres:
-  "cap_relation info info' \<Longrightarrow> corres dc (einvs and cte_at slot) (invs' and cte_at' (cte_map slot))
-             (empty_slot slot info) (emptySlot (cte_map slot) info')"
-  unfolding emptySlot_def empty_slot_def
-  apply (simp add: case_Null_If)
-  apply (rule corres_guard_imp)
-    apply (rule corres_split_noop_rhs[OF clearUntypedFreeIndex_noop_corres])
-     apply (rule_tac R="\<lambda>cap. einvs and cte_wp_at ((=) cap) slot" and
-                     R'="\<lambda>cte. valid_pspace' and cte_wp_at' ((=) cte) (cte_map slot)" in
-                     corres_split[OF get_cap_corres])
-       defer
-       apply (wp get_cap_wp getCTE_wp')+
-     apply (simp add: cte_wp_at_ctes_of)
-     apply (wp hoare_vcg_imp_lift clearUntypedFreeIndex_valid_pspace')
-    apply fastforce
-   apply (fastforce simp: cte_wp_at_ctes_of)
-  apply simp
-  apply (rule conjI, clarsimp)
-   defer
-  apply clarsimp
-  apply (rule conjI, clarsimp)
-  apply clarsimp
-  apply (simp only: bind_assoc[symmetric])
-  apply (rule corres_underlying_split[where r'=dc, OF _ postCapDeletion_corres])
-    defer
-    apply wpsimp+
-  apply (rule corres_no_failI)
-   apply (rule no_fail_pre, wp hoare_weak_lift_imp)
-   apply (clarsimp simp: cte_wp_at_ctes_of valid_pspace'_def)
-   apply (clarsimp simp: valid_mdb'_def valid_mdb_ctes_def)
-   apply (rule conjI, clarsimp)
-    apply (erule (2) valid_dlistEp)
-    apply simp
-   apply clarsimp
-   apply (erule (2) valid_dlistEn)
-   apply simp
-  apply (clarsimp simp: in_monad bind_assoc exec_gets)
-  apply (subgoal_tac "mdb_empty_abs a")
-   prefer 2
-   apply (rule mdb_empty_abs.intro)
-   apply (rule vmdb_abs.intro)
-   apply fastforce
-  apply (frule mdb_empty_abs'.intro)
-  apply (simp add: mdb_empty_abs'.empty_slot_ext_det_def2 update_cdt_list_def set_cdt_list_def exec_gets set_cdt_def bind_assoc exec_get exec_put set_original_def modify_def del: fun_upd_apply | subst bind_def, simp, simp add: mdb_empty_abs'.empty_slot_ext_det_def2)+
-  apply (simp add: put_def)
-  apply (simp add: exec_gets exec_get exec_put del: fun_upd_apply | subst bind_def)+
-  apply (clarsimp simp: state_relation_def)
-  apply (drule updateMDB_the_lot, fastforce simp: pspace_relation_def, fastforce, fastforce)
-   apply (clarsimp simp: invs'_def valid_state'_def valid_pspace'_def
-                         valid_mdb'_def valid_mdb_ctes_def)
-  apply (elim conjE)
-  apply (drule (4) updateMDB_the_lot, elim conjE)
-  apply clarsimp
-  apply (drule_tac s'=s''a and c=cap.NullCap in set_cap_not_quite_corres)
-                      subgoal by simp
-                     subgoal by simp
-                    subgoal by simp
-                   subgoal by simp
-                  subgoal by fastforce
-                 subgoal by fastforce
-                subgoal by fastforce
-               subgoal by fastforce
-              subgoal by fastforce
-             apply fastforce
-            subgoal by fastforce
-           subgoal by fastforce
-          subgoal by fastforce
-         apply (erule cte_wp_at_weakenE, rule TrueI)
-        apply assumption
-       subgoal by simp
-      subgoal by simp
-     subgoal by simp
-    subgoal by simp
-   apply (rule refl)
-  apply clarsimp
-  apply (drule updateCap_stuff, elim conjE, erule (1) impE)
-  apply clarsimp
-  apply (drule updateMDB_the_lot, force simp: pspace_relation_def, assumption+, simp)
-  apply (rule bexI)
-   prefer 2
-   apply (simp only: trans_state_update[symmetric])
-   apply (rule set_cap_trans_state)
-   apply (rule set_cap_revokable_update)
-   apply (erule set_cap_cdt_update)
-  apply clarsimp
-  apply (thin_tac "ctes_of t = s" for t s)+
-  apply (thin_tac "ksMachineState t = p" for t p)+
-  apply (thin_tac "ksCurThread t = p" for t p)+
-  apply (thin_tac "ksReadyQueues t = p" for t p)+
-  apply (thin_tac "ksSchedulerAction t = p" for t p)+
-  apply (clarsimp simp: cte_wp_at_ctes_of)
-  apply (case_tac rv')
-  apply (rename_tac s_cap s_node)
-  apply (subgoal_tac "cte_at slot a")
-   prefer 2
-   apply (fastforce elim: cte_wp_at_weakenE)
-  apply (subgoal_tac "mdb_empty (ctes_of b) (cte_map slot) s_cap s_node")
-   prefer 2
-   apply (rule mdb_empty.intro)
-   apply (rule mdb_ptr.intro)
-    apply (rule vmdb.intro)
-    subgoal by (simp add: invs'_def valid_state'_def valid_pspace'_def valid_mdb'_def)
-   apply (rule mdb_ptr_axioms.intro)
-   subgoal by simp
-  apply (clarsimp simp: ghost_relation_typ_at set_cap_a_type_inv)
-  apply (simp add: pspace_relation_def)
-  apply (rule conjI)
-   apply (clarsimp simp: data_at_def ghost_relation_typ_at set_cap_a_type_inv)
-  apply (rule conjI)
-   prefer 2
-   apply (rule conjI)
-    apply (clarsimp simp: cdt_list_relation_def)
-    apply(frule invs_valid_pspace, frule invs_mdb)
-    apply(subgoal_tac "no_mloop (cdt a) \<and> finite_depth (cdt a)")
-     prefer 2
-     subgoal by(simp add: finite_depth valid_mdb_def)
-    apply(subgoal_tac "valid_mdb_ctes (ctes_of b)")
-     prefer 2
-     subgoal by(simp add: mdb_empty_def mdb_ptr_def vmdb_def)
-    apply(clarsimp simp: valid_pspace_def)
-
-    apply(case_tac "cdt a slot")
-     apply(simp add: next_slot_eq[OF mdb_empty_abs'.next_slot_no_parent])
-     apply(case_tac "next_slot (aa, bb) (cdt_list a) (cdt a)")
-      subgoal by (simp)
-     apply(clarsimp)
-     apply(frule(1) mdb_empty.n_next)
-     apply(clarsimp)
-     apply(erule_tac x=aa in allE, erule_tac x=bb in allE)
-     apply(simp split: if_split_asm)
-      apply(drule cte_map_inj_eq)
-           apply(drule cte_at_next_slot)
-             apply(assumption)+
-      apply(simp)
-     apply(subgoal_tac "(ab, bc) = slot")
-      prefer 2
-      apply(drule_tac cte="CTE s_cap s_node" in valid_mdbD2')
-        subgoal by (clarsimp simp: valid_mdb_ctes_def no_0_def)
-       subgoal by (clarsimp simp: invs'_def valid_state'_def valid_pspace'_def)
-      apply(clarsimp)
-      apply(rule cte_map_inj_eq)
-           apply(assumption)
-          apply(drule(3) cte_at_next_slot', assumption)
-         apply(assumption)+
-     apply(simp)
-     apply(drule_tac p="(aa, bb)" in no_parent_not_next_slot)
-        apply(assumption)+
-     apply(clarsimp)
-
-    apply(simp add: next_slot_eq[OF mdb_empty_abs'.next_slot] split del: if_split)
-    apply(case_tac "next_slot (aa, bb) (cdt_list a) (cdt a)")
-     subgoal by (simp)
-    apply(case_tac "(aa, bb) = slot", simp)
-    apply(case_tac "next_slot (aa, bb) (cdt_list a) (cdt a) = Some slot")
-     apply(simp)
-     apply(case_tac "next_slot ac (cdt_list a) (cdt a)", simp)
-     apply(simp)
-     apply(frule(1) mdb_empty.n_next)
-     apply(clarsimp)
-     apply(erule_tac x=aa in allE', erule_tac x=bb in allE)
-     apply(erule_tac x=ac in allE, erule_tac x=bd in allE)
-     apply(clarsimp split: if_split_asm)
-      apply(drule(1) no_self_loop_next)
-      apply(simp)
-     apply(drule_tac cte="CTE cap' node'" in valid_mdbD1')
-       apply(fastforce simp: valid_mdb_ctes_def no_0_def)
-      subgoal by (simp add: valid_mdb'_def)
-     apply(clarsimp)
-    apply(simp)
-    apply(frule(1) mdb_empty.n_next)
-    apply(erule_tac x=aa in allE, erule_tac x=bb in allE)
-    apply(clarsimp split: if_split_asm)
-     apply(drule(1) no_self_loop_prev)
-     apply(clarsimp)
-     apply(drule_tac cte="CTE s_cap s_node" in valid_mdbD2')
-       apply(clarsimp simp: valid_mdb_ctes_def no_0_def)
-      apply clarify
-     apply(clarsimp)
-     apply(drule cte_map_inj_eq)
-          apply(drule(3) cte_at_next_slot')
-          apply(assumption)+
-     apply(simp)
-    apply(erule disjE)
-     apply(drule cte_map_inj_eq)
-          apply(drule(3) cte_at_next_slot)
-          apply(assumption)+
-     apply(simp)
-    subgoal by (simp)
-   apply (simp add: revokable_relation_def)
-   apply (clarsimp simp: in_set_cap_cte_at)
-   apply (rule conjI)
-    apply clarsimp
-    apply (drule(1) mdb_empty.n_revokable)
-    subgoal by clarsimp
-   apply clarsimp
-   apply (drule (1) mdb_empty.n_revokable)
-   apply (subgoal_tac "null_filter (caps_of_state a) (aa,bb) \<noteq> None")
-    prefer 2
-    apply (drule set_cap_caps_of_state_monad)
-    subgoal by (force simp: null_filter_def)
-   apply clarsimp
-   apply (subgoal_tac "cte_at (aa, bb) a")
-    prefer 2
-    apply (drule null_filter_caps_of_stateD, erule cte_wp_cte_at)
-   apply (drule (2) cte_map_inj_ps, fastforce)
-   subgoal by simp
-  apply (clarsimp simp add: cdt_relation_def)
-  apply (subst mdb_empty_abs.descendants, assumption)
-  apply (subst mdb_empty.descendants, assumption)
-  apply clarsimp
-  apply (frule_tac p="(aa, bb)" in in_set_cap_cte_at)
-  apply clarsimp
-  apply (frule (2) cte_map_inj_ps, fastforce)
-  apply simp
-  apply (case_tac "slot \<in> descendants_of (aa,bb) (cdt a)")
-   apply (subst inj_on_image_set_diff)
-      apply (rule inj_on_descendants_cte_map)
-         apply fastforce
-        apply fastforce
-       apply fastforce
-      apply fastforce
-     apply fastforce
-    subgoal by simp
-   subgoal by simp
-  apply simp
-  apply (subgoal_tac "cte_map slot \<notin> descendants_of' (cte_map (aa,bb)) (ctes_of b)")
-   subgoal by simp
-  apply (erule_tac x=aa in allE, erule allE, erule (1) impE)
-  apply (drule_tac s="cte_map ` u" for u in sym)
-  apply clarsimp
-  apply (drule cte_map_inj_eq, assumption)
-      apply (erule descendants_of_cte_at, fastforce)
-     apply fastforce
-    apply fastforce
-   apply fastforce
-  apply simp
-  done
-
-
-
-text \<open>Some facts about is_final_cap/isFinalCapability\<close>
-
-lemma isFinalCapability_inv:
-  "\<lbrace>P\<rbrace> isFinalCapability cap \<lbrace>\<lambda>_. P\<rbrace>"
-  apply (simp add: isFinalCapability_def Let_def
-              split del: if_split cong: if_cong)
-  apply (rule hoare_pre, wp)
-   apply (rule hoare_post_imp[where Q'="\<lambda>s. P"], simp)
-   apply wp
-  apply simp
-  done
-
-definition
-  final_matters' :: "capability \<Rightarrow> bool"
-where
- "final_matters' cap \<equiv> case cap of
-    EndpointCap ref bdg s r g gr \<Rightarrow> True
-  | NotificationCap ref bdg s r \<Rightarrow> True
-  | ThreadCap ref \<Rightarrow> True
-  | CNodeCap ref bits gd gs \<Rightarrow> True
-  | Zombie ptr zb n \<Rightarrow> True
-  | IRQHandlerCap irq \<Rightarrow> True
-  | ArchObjectCap acap \<Rightarrow> (case acap of
-    PageCap d ref rghts sz mapdata \<Rightarrow> False
-  | ASIDControlCap \<Rightarrow> False
-  | SGISignalCap _ _ \<Rightarrow> False
-  | _ \<Rightarrow> True)
-  | _ \<Rightarrow> False"
 
 lemma final_matters_Master:
   "final_matters' (capMasterCap cap) = final_matters' cap"
   by (simp add: capMasterCap_def arch_capMasterCap_def split: capability.split arch_capability.split,
-      simp add: final_matters'_def)
+      simp add: final_matters'_def arch_final_matters'_def)
 
 lemma final_matters_sameRegion_sameObject:
   "final_matters' cap \<Longrightarrow> sameRegionAs cap cap' = sameObjectAs cap cap'"
   apply (rule iffI)
    apply (erule sameRegionAsE)
       apply (simp add: sameObjectAs_def3)
-      apply (clarsimp simp: isCap_simps sameObjectAs_sameRegionAs final_matters'_def
-        split:capability.splits arch_capability.splits)+
+      apply (clarsimp simp: isCap_simps sameObjectAs_sameRegionAs
+                            final_matters'_def arch_final_matters'_def
+                      split: capability.splits arch_capability.splits)+
   done
 
 lemma final_matters_sameRegion_sameObject2:
   "\<lbrakk> final_matters' cap'; \<not> isUntypedCap cap; \<not> isIRQHandlerCap cap' \<rbrakk>
-     \<Longrightarrow> sameRegionAs cap cap' = sameObjectAs cap cap'"
+   \<Longrightarrow> sameRegionAs cap cap' = sameObjectAs cap cap'"
   apply (rule iffI)
    apply (erule sameRegionAsE)
        apply (simp add: sameObjectAs_def3)
-       apply (fastforce simp: isCap_simps final_matters'_def)
+       apply (fastforce simp: isCap_simps final_matters'_def arch_final_matters'_def)
       apply simp
-     apply (clarsimp simp: final_matters'_def isCap_simps)
-    apply (clarsimp simp: final_matters'_def isCap_simps)
-   apply (clarsimp simp: final_matters'_def isCap_simps)
+     apply (clarsimp simp: final_matters'_def arch_final_matters'_def isCap_simps)+
   apply (erule sameObjectAs_sameRegionAs)
   done
 
 lemma final_matters_mdb_chunked_arch_assms:
   "final_matters' cap \<Longrightarrow> mdb_chunked_arch_assms cap"
-  by (clarsimp simp: mdb_chunked_arch_assms_def isCap_simps final_matters'_def)
+  by (clarsimp simp: mdb_chunked_arch_assms_def isCap_simps
+                     final_matters'_def arch_final_matters'_def)
 
-lemma notFinal_prev_or_next:
+lemma notFinal_prev_or_next[Finalise_R_2_assms]:
   "\<lbrakk> \<not> isFinal cap x (cteCaps_of s); mdb_chunked (ctes_of s);
-      valid_dlist (ctes_of s); no_0 (ctes_of s);
-      ctes_of s x = Some (CTE cap node); final_matters' cap \<rbrakk>
-     \<Longrightarrow> (\<exists>cap' node'. ctes_of s (mdbPrev node) = Some (CTE cap' node')
-              \<and> sameObjectAs cap cap')
-      \<or> (\<exists>cap' node'. ctes_of s (mdbNext node) = Some (CTE cap' node')
-              \<and> sameObjectAs cap cap')"
+     valid_dlist (ctes_of s); no_0 (ctes_of s);
+     ctes_of s x = Some (CTE cap node); final_matters' cap \<rbrakk>
+   \<Longrightarrow> (\<exists>cap' node'. ctes_of s (mdbPrev node) = Some (CTE cap' node') \<and> sameObjectAs cap cap')
+      \<or> (\<exists>cap' node'. ctes_of s (mdbNext node) = Some (CTE cap' node') \<and> sameObjectAs cap cap')"
   apply (erule not_FinalE)
    apply (clarsimp simp: isCap_simps final_matters'_def)
   apply (frule final_matters_mdb_chunked_arch_assms)
@@ -1957,91 +543,20 @@ lemma notFinal_prev_or_next:
   apply (clarsimp simp: sameObjectAs_def3 simp del: isArchFrameCap_capMasterCap)
   done
 
-lemma isFinal:
-  "\<lbrace>\<lambda>s. valid_mdb' s \<and> cte_wp_at' ((=) cte) x s
-          \<and> final_matters' (cteCap cte)
-          \<and> Q (isFinal (cteCap cte) x (cteCaps_of s)) s\<rbrace>
-    isFinalCapability cte
-   \<lbrace>Q\<rbrace>"
-  unfolding isFinalCapability_def
-  apply (cases cte)
-  apply (rename_tac cap node)
-  apply (unfold Let_def)
-  apply (simp only: if_False)
-  apply (wp getCTE_wp')
-  apply (cases "mdbPrev (cteMDBNode cte) = nullPointer")
-   apply simp
-   apply (clarsimp simp: valid_mdb_ctes_def valid_mdb'_def
-                         cte_wp_at_ctes_of)
-   apply (rule conjI, clarsimp simp: nullPointer_def)
-    apply (erule rsubst[where P="\<lambda>x. Q x s" for s], simp)
-    apply (rule classical)
-    apply (drule(5) notFinal_prev_or_next)
-    apply clarsimp
-   apply (clarsimp simp: nullPointer_def)
-   apply (erule rsubst[where P="\<lambda>x. Q x s" for s])
-   apply (rule sym, rule iffI)
-    apply (rule classical)
-    apply (drule(5) notFinal_prev_or_next)
-    apply clarsimp
-   apply clarsimp
-   apply (clarsimp simp: cte_wp_at_ctes_of cteCaps_of_def)
-   apply (case_tac cte)
-   apply clarsimp
-   apply (clarsimp simp add: isFinal_def)
-   apply (erule_tac x="mdbNext node" in allE)
-   apply simp
-   apply (erule impE)
-    apply (clarsimp simp: valid_mdb'_def valid_mdb_ctes_def)
-    apply (drule (1) mdb_chain_0_no_loops)
-    apply simp
-   apply (clarsimp simp: sameObjectAs_def3 isCap_simps)
-  apply simp
-  apply (clarsimp simp: cte_wp_at_ctes_of
-                        valid_mdb_ctes_def valid_mdb'_def)
-  apply (case_tac cte)
-  apply clarsimp
-  apply (rule conjI)
-   apply clarsimp
-   apply (erule rsubst[where P="\<lambda>x. Q x s" for s])
-   apply clarsimp
-   apply (clarsimp simp: isFinal_def cteCaps_of_def)
-   apply (erule_tac x="mdbPrev node" in allE)
-   apply simp
-   apply (erule impE)
-    apply clarsimp
-    apply (drule (1) mdb_chain_0_no_loops)
-    apply (subgoal_tac "ctes_of s (mdbNext node) = Some (CTE cap node)")
-     apply clarsimp
-    apply (erule (1) valid_dlistEp)
-     apply clarsimp
-    apply (case_tac cte')
-    apply clarsimp
-   apply (fastforce simp add: sameObjectAs_def3 isCap_simps)
-  apply clarsimp
-  apply (rule conjI)
-   apply clarsimp
-   apply (erule rsubst[where P="\<lambda>x. Q x s" for s], simp)
-   apply (rule classical, drule(5) notFinal_prev_or_next)
-   apply (clarsimp simp: sameObjectAs_sym nullPointer_def)
-  apply (clarsimp simp: nullPointer_def)
-  apply (erule rsubst[where P="\<lambda>x. Q x s" for s])
-  apply (rule sym, rule iffI)
-   apply (rule classical, drule(5) notFinal_prev_or_next)
-   apply (clarsimp simp: sameObjectAs_sym)
-   apply auto[1]
-  apply (clarsimp simp: isFinal_def cteCaps_of_def)
-  apply (case_tac cte)
-  apply (erule_tac x="mdbNext node" in allE)
-  apply simp
-  apply (erule impE)
-   apply clarsimp
-   apply (drule (1) mdb_chain_0_no_loops)
-   apply simp
-  apply clarsimp
-  apply (clarsimp simp: isCap_simps sameObjectAs_def3)
-  done
-end
+lemma sameObjectAs_not_Untyped[Finalise_R_2_assms]:
+  "\<lbrakk> global.sameObjectAs cap cap'; \<not> isUntypedCap cap \<rbrakk>
+   \<Longrightarrow> \<not> isUntypedCap cap'"
+  by (clarsimp simp: gen_isCap_simps sameObjectAs_def3)
+
+lemma sameObjectAs_not_Untyped'[Finalise_R_2_assms]:
+  "\<lbrakk> global.sameObjectAs cap cap'; \<not> isUntypedCap cap' \<rbrakk>
+   \<Longrightarrow> global.sameObjectAs cap' cap"
+  by (clarsimp simp: isCap_simps sameObjectAs_def3)
+
+end (* Arch *)
+
+(* only two arch-specific lemmas in vmdb;
+   save processing time by not creating an extra Arch_vmdb locale, directly requalify instead *)
 
 lemma (in vmdb) isFinal_no_subtree:
   "\<lbrakk> m \<turnstile> sl \<rightarrow> p; isFinal cap sl (option_map cteCap o m);
@@ -2051,20 +566,9 @@ lemma (in vmdb) isFinal_no_subtree:
    apply (clarsimp simp: isFinal_def parentOf_def mdb_next_unfold cteCaps_of_def)
    apply (erule_tac x="mdbNext n" in allE)
    apply simp
-   (* FIXME arch-split *)
-   apply (clarsimp simp: ARM.isMDBParentOf_CTE final_matters_sameRegion_sameObject)
-   apply (clarsimp simp: gen_isCap_simps ARM.sameObjectAs_def3) (* FIXME arch-split *)
+   apply (clarsimp simp: ARM.isMDBParentOf_CTE ARM.final_matters_sameRegion_sameObject)
+   apply (clarsimp simp: gen_isCap_simps ARM.sameObjectAs_def3)
   apply clarsimp
-  done
-
-lemma isFinal_no_descendants:
-  "\<lbrakk> isFinal cap sl (cteCaps_of s); ctes_of s sl = Some (CTE cap n);
-      valid_mdb' s; final_matters' cap \<rbrakk>
-  \<Longrightarrow> descendants_of' sl (ctes_of s) = {}"
-  apply (clarsimp simp add: descendants_of'_def cteCaps_of_def)
-  apply (erule(3) vmdb.isFinal_no_subtree[rotated])
-  apply unfold_locales[1]
-  apply (simp add: valid_mdb'_def)
   done
 
 lemma (in vmdb) isFinal_untypedParent:
@@ -2089,67 +593,535 @@ lemma (in vmdb) isFinal_untypedParent:
   apply clarsimp
   apply (drule isMDBParent_sameRegion)
   apply simp
-  apply (frule final_matters_mdb_chunked_arch_assms)
+  apply (frule ARM.final_matters_mdb_chunked_arch_assms)
   apply (rule classical, simp)
-  apply (simp add: final_matters_sameRegion_sameObject2
+  apply (simp add: ARM.final_matters_sameRegion_sameObject2
                    sameObjectAs_sym)
   done
 
-context begin interpretation Arch . (*FIXME: arch-split*)
+context Arch begin arch_global_naming
 
-lemma no_fail_isFinalCapability [wp]:
-  "no_fail (valid_mdb' and cte_wp_at' ((=) cte) p) (isFinalCapability cte)"
-  apply (simp add: isFinalCapability_def)
-  apply (clarsimp simp: Let_def split del: if_split)
-  apply (rule no_fail_pre, wp getCTE_wp')
-  apply (clarsimp simp: valid_mdb'_def valid_mdb_ctes_def cte_wp_at_ctes_of nullPointer_def)
-  apply (rule conjI)
-   apply clarsimp
-   apply (erule (2) valid_dlistEp)
-   apply simp
-  apply clarsimp
-  apply (rule conjI)
-   apply (erule (2) valid_dlistEn)
-   apply simp
-  apply clarsimp
-  apply (rule valid_dlistEn, assumption+)
-  apply (erule (2) valid_dlistEp)
-  apply simp
+lemma isFinal_no_descendants:
+  "\<lbrakk> isFinal cap sl (cteCaps_of s); ctes_of s sl = Some (CTE cap n);
+      valid_mdb' s; final_matters' cap \<rbrakk>
+  \<Longrightarrow> descendants_of' sl (ctes_of s) = {}"
+  apply (clarsimp simp add: descendants_of'_def cteCaps_of_def)
+  apply (erule(3) vmdb.isFinal_no_subtree[rotated])
+  apply unfold_locales[1]
+  apply (simp add: valid_mdb'_def)
   done
 
-lemma corres_gets_lift:
-  assumes inv: "\<And>P. \<lbrace>P\<rbrace> g \<lbrace>\<lambda>_. P\<rbrace>"
-  assumes res: "\<lbrace>Q'\<rbrace> g \<lbrace>\<lambda>r s. r = g' s\<rbrace>"
-  assumes Q: "\<And>s. Q s \<Longrightarrow> Q' s"
-  assumes nf: "no_fail Q g"
-  shows "corres r P Q f (gets g') \<Longrightarrow> corres r P Q f g"
-  apply (clarsimp simp add: corres_underlying_def simpler_gets_def)
-  apply (drule (1) bspec)
+lemmas cancelAllIPC_typs[wp] = typ_at_lifts[OF cancelAllIPC_typ_at']
+lemmas cancelAllSignals_typs[wp] = typ_at_lifts[OF cancelAllSignals_typ_at']
+lemmas suspend_typs[wp] = typ_at_lifts[OF suspend_typ_at']
+
+lemmas finaliseCap_typ_ats[wp] = typ_at_lifts[OF finaliseCap_typ_at']
+
+crunch flushSpace
+  for invs'[wp]: "invs'"
+  (ignore: doMachineOp)
+
+lemma invalidateASIDEntry_invs'[wp]:
+  "invalidateASIDEntry asid \<lbrace>invs'\<rbrace>"
+  apply (simp add: invalidateASIDEntry_def invalidateASID_def
+                   invalidateHWASIDEntry_def bind_assoc)
+  apply (wp loadHWASID_wp | simp)+
+  apply (clarsimp simp: fun_upd_def[symmetric])
   apply (rule conjI)
-   apply clarsimp
-   apply (rule bexI)
-    prefer 2
-    apply assumption
-   apply simp
-   apply (frule in_inv_by_hoareD [OF inv])
-   apply simp
-   apply (drule use_valid, rule res)
-    apply (erule Q)
-   apply simp
-  apply (insert nf)
-  apply (clarsimp simp: no_fail_def)
+   apply (clarsimp simp: invs'_def valid_state'_def)
+   apply (rule conjI)
+    apply (simp add: valid_global_refs'_def
+                     global_refs'_def)
+   apply (simp add: valid_arch_state'_def ran_def
+                    valid_asid_table'_def is_inv_None_upd
+                    valid_machine_state'_def
+                    comp_upd_simp fun_upd_def[symmetric]
+                    inj_on_fun_upd_elsewhere
+                    valid_asid_map'_def
+                    ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def
+             cong: option.case_cong)
+   subgoal by (auto elim!: subset_inj_on)
+  apply (clarsimp simp: invs'_def valid_state'_def)
+  apply (rule conjI)
+   apply (simp add: valid_global_refs'_def global_refs'_def)
+  apply (rule conjI)
+   apply (simp add: valid_arch_state'_def ran_def
+                    valid_asid_table'_def comp_upd_simp
+              cong: option.case_cong)
+  apply (simp add: valid_machine_state'_def ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def)
   done
 
-lemma obj_refs_Master:
-  "\<lbrakk> cap_relation cap cap'; P cap \<rbrakk>
-      \<Longrightarrow> obj_refs cap =
-           (if capClass (capMasterCap cap') = PhysicalClass
-                  \<and> \<not> isUntypedCap (capMasterCap cap')
-            then {capUntypedPtr (capMasterCap cap')} else {})"
-  by (clarsimp simp: isCap_simps
-              split: cap_relation_split_asm arch_cap.split_asm)
+lemma invs_asid_update_strg':
+  "invs' s \<and> tab = armKSASIDTable (ksArchState s) \<longrightarrow>
+   invs' (s\<lparr>ksArchState := armKSASIDTable_update
+            (\<lambda>_. tab (asid := None)) (ksArchState s)\<rparr>)"
+  apply (simp add: invs'_def)
+  apply (simp add: valid_state'_def)
+  apply (simp add: valid_global_refs'_def global_refs'_def valid_arch_state'_def
+                   valid_asid_table'_def valid_machine_state'_def ct_idle_or_in_cur_domain'_def
+                   tcb_in_cur_domain'_def
+             cong: option.case_cong)
+  apply (auto simp add: ran_def split: if_split_asm)
+  done
 
-lemma isFinalCapability_corres':
+crunch invalidateTLBByASID
+  for asidTable[wp]: "\<lambda>s. P (armKSASIDTable (ksArchState s))"
+
+crunch copyGlobalMappings
+  for pred_tcb_at'[wp]: "pred_tcb_at' proj P t"
+  (wp: crunch_wps ignore: storePDE)
+
+lemma deleteASIDPool_invs[wp]:
+  "\<lbrace>invs'\<rbrace> deleteASIDPool asid pool \<lbrace>\<lambda>rv. invs'\<rbrace>"
+  apply (simp add: deleteASIDPool_def)
+  apply wp
+      apply (simp del: fun_upd_apply)
+      apply (strengthen invs_asid_update_strg')
+      apply (wpsimp wp: mapM_wp' getObject_inv loadObject_default_inv)+
+  done
+
+lemma deleteASID_invs'[wp]:
+  "deleteASID asid pd \<lbrace>invs'\<rbrace>"
+  apply (simp add: deleteASID_def cong: option.case_cong)
+  apply (rule hoare_pre)
+   apply (wp | wpc)+
+    apply (rule_tac Q'="\<lambda>rv. valid_obj' (injectKO rv) and invs'"
+              in hoare_post_imp)
+     apply (rename_tac rv s)
+     apply (clarsimp split: if_split_asm del: subsetI)
+     apply (simp add: fun_upd_def[symmetric] valid_obj'_def)
+     apply (case_tac rv, simp)
+     apply (subst inv_f_f, rule inj_onI, simp)+
+     apply (rule conjI)
+      apply clarsimp
+      apply (drule subsetD, blast)
+      apply clarsimp
+     apply (auto dest!: ran_del_subset)[1]
+    apply (wp getObject_valid_obj getObject_inv loadObject_default_inv
+             | simp add: objBits_simps pageBits_def)+
+  apply clarsimp
+  done
+
+lemmas archThreadSet_typ_ats[wp] = typ_at_lifts[OF archThreadSet_typ_at']
+
+lemma archThreadSet_valid_objs'[wp]:
+  "\<lbrace>valid_objs' and (\<lambda>s. \<forall>tcb. ko_at' tcb t s \<longrightarrow> valid_arch_tcb' (f (tcbArch tcb)) s)\<rbrace>
+   archThreadSet f t \<lbrace>\<lambda>_. valid_objs'\<rbrace>"
+  unfolding archThreadSet_def
+  apply (wp setObject_tcb_valid_objs getObject_tcb_wp)
+  apply clarsimp
+  apply normalise_obj_at'
+  apply (drule (1) tcb_ko_at_valid_objs_valid_tcb')
+  apply (clarsimp simp: valid_obj'_def valid_tcb'_def tcb_cte_cases_def cteSizeBits_def)
+  done
+
+crunch archThreadSet
+  for no_0_obj'[wp]: no_0_obj'
+
+lemma archThreadSet_ctes_of[wp]:
+  "archThreadSet f t \<lbrace>\<lambda>s. P (ctes_of s)\<rbrace>"
+  unfolding archThreadSet_def
+  apply (wpsimp wp: getObject_tcb_wp)
+  apply normalise_obj_at'
+  apply (auto simp: tcb_cte_cases_def cteSizeBits_def)
+  done
+
+crunch archThreadSet
+  for ksCurDomain[wp]: "\<lambda>s. P (ksCurDomain s)"
+  (wp: setObject_cd_inv)
+
+lemma archThreadSet_obj_at':
+  "(\<And>tcb. P tcb \<Longrightarrow> P (tcb \<lparr> tcbArch:= f (tcbArch tcb)\<rparr>)) \<Longrightarrow> archThreadSet f t \<lbrace>obj_at' P t'\<rbrace>"
+  unfolding archThreadSet_def
+  apply (wpsimp wp: getObject_tcb_wp setObject_tcb_strongest)
+  apply normalise_obj_at'
+  apply auto
+  done
+
+lemma archThreadSet_tcbDomain[wp]:
+  "archThreadSet f t \<lbrace>obj_at' (\<lambda>tcb. x = tcbDomain tcb) t'\<rbrace>"
+  by (wpsimp wp: archThreadSet_obj_at')
+
+lemma archThreadSet_inQ[wp]:
+  "archThreadSet f t' \<lbrace>\<lambda>s. P (obj_at' (inQ d p) t s)\<rbrace>"
+  unfolding obj_at'_real_def archThreadSet_def
+  apply (wpsimp wp: setObject_ko_wp_at getObject_tcb_wp
+              simp: objBits_simps' archObjSize_def pageBits_def
+         | simp)+
+  apply (auto simp: obj_at'_def ko_wp_at'_def)
+  done
+
+crunch archThreadSet
+  for ct[wp]: "\<lambda>s. P (ksCurThread s)"
+  and sched[wp]: "\<lambda>s. P (ksSchedulerAction s)"
+  and L1[wp]: "\<lambda>s. P (ksReadyQueuesL1Bitmap s)"
+  and L2[wp]: "\<lambda>s. P (ksReadyQueuesL2Bitmap s)"
+  and ksArch[wp]: "\<lambda>s. P (ksArchState s)"
+  and ksDomSchedule[wp]: "\<lambda>s. P (ksDomSchedule s)"
+  and pspace_canonical'[wp]: pspace_canonical'
+  and gsMaxObjectSize[wp]: "\<lambda>s. P (gsMaxObjectSize s)"
+  and ksInterruptState[wp]: "\<lambda>s. P (ksInterruptState s)"
+  (wp: setObject_ct_inv setObject_sa_unchanged setObject_ksDomSchedule_inv)
+
+crunch archThreadSet
+  for ksDomScheduleIdx[wp]: "\<lambda>s. P (ksDomScheduleIdx s)"
+  and ksDomScheduleStart[wp]: "\<lambda>s. P (ksDomScheduleStart s)"
+  (simp: setObject_def wp: updateObject_default_inv)
+
+crunch archThreadSet
+  for ksMachineState[wp]: "\<lambda>s. P (ksMachineState s)"
+  (wp: setObject_ksMachine updateObject_default_inv)
+
+lemma archThreadSet_state_refs_of'[wp]:
+  "archThreadSet f t \<lbrace>\<lambda>s. P (state_refs_of' s)\<rbrace>"
+  unfolding archThreadSet_def
+  apply (wpsimp wp: setObject_tcb_state_refs_of' getObject_tcb_wp)
+  apply normalise_obj_at'
+  apply (erule rsubst[where P=P])
+  apply (rule ext)
+  apply (auto simp: state_refs_of'_def obj_at'_def)
+  done
+
+lemma archThreadSet_state_hyp_refs_of'[wp]:
+  "\<lbrace>\<lambda>s. \<forall>tcb. ko_at' tcb t s \<longrightarrow> P ((state_hyp_refs_of' s)(t := tcb_hyp_refs' (f (tcbArch tcb))))\<rbrace>
+  archThreadSet f t \<lbrace>\<lambda>_ s. P (state_hyp_refs_of' s)\<rbrace>"
+  unfolding archThreadSet_def
+  apply (wpsimp wp: setObject_state_hyp_refs_of' getObject_tcb_wp simp: objBits_simps')
+  apply normalise_obj_at'
+  apply (erule rsubst[where P=P])
+  apply auto
+  done
+
+crunch archThreadSet
+  for ko_at'_pde[wp]: "\<lambda>s. P (ko_at' (pde::pde) p' s)"
+  and valid_pde_mappings'[wp]: valid_pde_mappings'
+
+lemma archThreadSet_ifunsafe'[wp]:
+  "archThreadSet f t \<lbrace>if_unsafe_then_cap'\<rbrace>"
+  unfolding archThreadSet_def
+  apply (wpsimp wp: setObject_tcb_ifunsafe' getObject_tcb_wp)
+  apply normalise_obj_at'
+  apply (auto simp: tcb_cte_cases_def if_live_then_nonz_cap'_def cteSizeBits_def)
+  done
+
+lemma archThreadSet_valid_idle'[wp]:
+  "archThreadSet f t \<lbrace>valid_idle'\<rbrace>"
+  unfolding archThreadSet_def
+  apply (wpsimp wp: setObject_tcb_idle' getObject_tcb_wp)
+  apply (clarsimp simp: valid_idle'_def pred_tcb_at'_def obj_at'_def idle_tcb'_def)
+  done
+
+lemma archThreadSet_ct_not_inQ[wp]:
+  "archThreadSet f t \<lbrace>ct_not_inQ\<rbrace>"
+  unfolding ct_not_inQ_def
+  apply (rule hoare_lift_Pf[where f=ksCurThread]; wp?)
+  apply (wpsimp wp: hoare_vcg_imp_lift simp: o_def)
+  done
+
+lemma archThreadSet_obj_at'_pte[wp]:
+  "archThreadSet f t \<lbrace>obj_at' (P::pte \<Rightarrow> bool) p\<rbrace>"
+  unfolding archThreadSet_def
+  by (wpsimp wp: obj_at_setObject2 simp: updateObject_default_def in_monad)
+
+crunch archThreadSet
+  for pspace_domain_valid[wp]: pspace_domain_valid
+
+crunch archThreadSet
+  for gsUntypedZeroRanges[wp]: "\<lambda>s. P (gsUntypedZeroRanges s)"
+
+lemma archThreadSet_untyped_ranges_zero'[wp]:
+  "archThreadSet f t \<lbrace>untyped_ranges_zero'\<rbrace>"
+  by (rule hoare_lift_Pf[where f=cteCaps_of]; wp cteCaps_of_ctes_of_lift)
+
+lemma archThreadSet_tcb_at'[wp]:
+  "\<lbrace>\<top>\<rbrace> archThreadSet f t \<lbrace>\<lambda>_. tcb_at' t\<rbrace>"
+  unfolding archThreadSet_def
+  by (wpsimp wp: getObject_tcb_wp simp: obj_at'_def)
+
+lemma archThreadSet_tcbSchedPrevs_of[wp]:
+  "archThreadSet f t \<lbrace>\<lambda>s. P (tcbSchedPrevs_of s)\<rbrace>"
+  unfolding archThreadSet_def
+  apply (wp getObject_tcb_wp)
+  apply normalise_obj_at'
+  apply (erule rsubst[where P=P])
+  apply (rule ext)
+  apply (clarsimp simp: opt_map_def obj_at'_def split: option.splits)
+  done
+
+lemma archThreadSet_tcbSchedNexts_of[wp]:
+  "archThreadSet f t \<lbrace>\<lambda>s. P (tcbSchedNexts_of s)\<rbrace>"
+  unfolding archThreadSet_def
+  apply (wp getObject_tcb_wp)
+  apply normalise_obj_at'
+  apply (erule rsubst[where P=P])
+  apply (rule ext)
+  apply (clarsimp simp: opt_map_def obj_at'_def split: option.splits)
+  done
+
+lemma archThreadSet_tcbQueued[wp]:
+  "archThreadSet f t \<lbrace>\<lambda>s. P (tcbQueued |< tcbs_of' s)\<rbrace>"
+  unfolding archThreadSet_def
+  apply (wp getObject_tcb_wp)
+  apply normalise_obj_at'
+  apply (erule rsubst[where P=P])
+  apply (rule ext)
+  apply (clarsimp simp: opt_pred_def opt_map_def obj_at'_def split: option.splits)
+  done
+
+lemma archThreadSet_valid_sched_pointers[wp]:
+  "archThreadSet f t \<lbrace>valid_sched_pointers\<rbrace>"
+  by (wp_pre, wps, wp, assumption)
+
+lemma arch_finaliseCap_invs[Finalise_R_2_assms, wp]:
+  "\<lbrace>invs' and valid_cap' (ArchObjectCap cap)\<rbrace> Arch.finaliseCap cap fin \<lbrace>\<lambda>rv. invs'\<rbrace>"
+  unfolding ARM_H.finaliseCap_def Let_def by wpsimp
+
+crunch setVMRoot, deleteASIDPool, invalidateTLBByASID, invalidateASIDEntry
+  for ctes_of[wp]: "\<lambda>s. P (ctes_of s)"
+  (wp: crunch_wps getObject_inv loadObject_default_inv getASID_wp simp: crunch_simps)
+
+lemma deleteASID_ctes_of[wp]:
+  "deleteASID a ptr \<lbrace>\<lambda>s. P (ctes_of s)\<rbrace>"
+  unfolding deleteASID_def by (wpsimp wp: getASID_wp hoare_drop_imps hoare_vcg_all_lift)
+
+lemma arch_finaliseCap_removeable[wp]:
+  "\<lbrace>\<lambda>s. s \<turnstile>' ArchObjectCap cap \<and> invs' s
+       \<and> (final_matters' (ArchObjectCap cap)
+               \<longrightarrow> (final = isFinal (ArchObjectCap cap) slot (cteCaps_of s))) \<rbrace>
+     Arch.finaliseCap cap final
+   \<lbrace>\<lambda>rv s. isNullCap (fst rv) \<and> removeable' slot s (ArchObjectCap cap) \<and> isNullCap (snd rv)\<rbrace>"
+  apply (simp add: ARM_H.finaliseCap_def
+                   removeable'_def)
+  apply (safe ; wpsimp)
+  done
+
+crunch archThreadSet
+  for isFinal: "\<lambda>s. isFinal cap slot (cteCaps_of s)"
+  (wp: cteCaps_of_ctes_of_lift)
+
+crunch prepareThreadDelete
+  for isFinal: "\<lambda>s. isFinal cap slot (cteCaps_of s)"
+
+lemma archThreadSet_bound_tcb_at'[wp]:
+  "archThreadSet f t \<lbrace>bound_tcb_at' P t'\<rbrace>"
+  unfolding archThreadSet_def
+  apply (wpsimp wp: setObject_tcb_strongest getObject_tcb_wp simp: pred_tcb_at'_def)
+  by (auto simp: obj_at'_def objBits_simps)
+
+crunch prepareThreadDelete
+  for bound_tcb_at'[wp]: "bound_tcb_at' P t"
+  (wp: sts_bound_tcb_at' crunch_wps hoare_vcg_all_lift hoare_vcg_if_lift3
+   ignore: archThreadSet)
+
+crunch Arch.finaliseCap, prepareThreadDelete
+  for irq_node'[Finalise_R_2_assms, wp]: "\<lambda>s. P (irq_node' s)"
+  (wp: crunch_wps getObject_inv loadObject_default_inv
+       updateObject_default_inv setObject_ksInterrupt
+   simp: crunch_simps o_def)
+
+lemmas Arch_finaliseCap_irq_node'[Finalise_R_2_assms] = ArchRetypeDecls_H_ARM_H_finaliseCap_irq_node'
+
+crunch prepareThreadDelete
+  for cte_wp_at'[Finalise_R_2_assms, wp]: "cte_wp_at' P p"
+  and valid_cap'[Finalise_R_2_assms, wp]: "valid_cap' cap"
+
+crunch prepareThreadDelete
+  for invs[Finalise_R_2_assms, wp]: "invs'"
+  (ignore: doMachineOp simp: crunch_simps)
+
+lemma archThreadSet_tcbSchedPrevNext[wp]:
+  "archThreadSet f t' \<lbrace>obj_at' (\<lambda>tcb. P (tcbSchedNext tcb) (tcbSchedPrev tcb)) t\<rbrace>"
+  unfolding archThreadSet_def
+  apply (wpsimp wp: setObject_tcb_strongest getObject_tcb_wp)
+  apply normalise_obj_at'
+  apply auto
+  done
+
+context notes if_cong[cong] begin
+
+crunch asUser
+  for tcbSchedPrevNext[wp]: "obj_at' (\<lambda>tcb. P (tcbSchedNext tcb) (tcbSchedPrev tcb)) t"
+  (wp: threadGet_wp)
+
+end
+
+crunch prepareThreadDelete
+  for tcbSchedPrevNext[wp]: "obj_at' (\<lambda>tcb. P (tcbSchedNext tcb) (tcbSchedPrev tcb)) t"
+  (wp: threadGet_wp archThreadGet_wp crunch_wps simp: crunch_simps)
+
+crunch deleteASIDPool
+  for cte_wp_at'[wp]: "cte_wp_at' P p"
+  (simp: crunch_simps assertE_def
+   wp: crunch_wps getObject_inv loadObject_default_inv)
+
+lemma deleteASID_cte_wp_at'[wp]:
+  "\<lbrace>cte_wp_at' P p\<rbrace> deleteASID param_a param_b \<lbrace>\<lambda>_. cte_wp_at' P p\<rbrace>"
+  apply (simp add: deleteASID_def
+              cong: option.case_cong)
+  apply (wp setObject_cte_wp_at'[where Q="\<top>"] getObject_inv
+            loadObject_default_inv setVMRoot_cte_wp_at'
+          | clarsimp simp: updateObject_default_def in_monad cong: if_cong
+          | rule equals0I
+          | wpc)+
+  done
+
+lemma arch_finaliseCap_cte_wp_at[Finalise_R_2_assms, wp]:
+  "\<lbrace>cte_wp_at' P p\<rbrace> Arch.finaliseCap cap fin \<lbrace>\<lambda>rv. cte_wp_at' P p\<rbrace>"
+  unfolding ARM_H.finaliseCap_def
+  by (wpsimp wp: unmapPage_cte_wp_at'|rule conjI)+
+
+lemma finaliseCap_valid_cap[Finalise_R_2_assms, wp]:
+  "\<lbrace>\<top>\<rbrace> Arch.finaliseCap cap final \<lbrace>\<lambda>rv. valid_cap' (fst rv)\<rbrace>"
+  by (wpsimp simp: ARM_H.finaliseCap_def split_del: if_split)
+
+lemma finaliseCap_cases[wp]:
+  "\<lbrace>\<top>\<rbrace>
+   finaliseCap cap final flag
+   \<lbrace>\<lambda>rv s. fst rv = NullCap \<and> (snd rv \<noteq> NullCap \<longrightarrow> final \<and> cap_has_cleanup' cap \<and> snd rv = cap)
+           \<or> isZombie (fst rv) \<and> final \<and> \<not> flag \<and> snd rv = NullCap
+             \<and> capUntypedPtr (fst rv) = capUntypedPtr cap
+             \<and> (isThreadCap cap \<or> isCNodeCap cap \<or> isZombie cap)\<rbrace>"
+  apply (simp add: finaliseCap_def ARM_H.finaliseCap_def Let_def
+                   getThreadCSpaceRoot
+             cong: if_cong split del: if_split)
+  apply (rule hoare_pre)
+   apply ((wp | simp add: gen_isCap_simps split del: if_split
+              | wpc
+              | simp only: valid_NullCap fst_conv snd_conv)+)[1]
+  apply (simp only: simp_thms fst_conv snd_conv option.simps if_cancel
+                    o_def)
+  apply (intro allI impI conjI TrueI)
+  apply (auto simp add: gen_isCap_simps cap_has_cleanup'_def)
+  done
+
+lemmas [Finalise_R_2_assms] =
+  cancelAllIPC_cte_wp_at' cancelAllSignals_cte_wp_at' unbindMaybeNotification_cte_wp_at'
+  prepareThreadDelete_cte_wp_at' unbindNotification_cte_wp_at'
+  Arch_postCapDeletion_valid_global_refs Arch_postCapDeletion_valid_arch_state'
+  mdb_empty.vmdb_n mdb_empty.descendants not_Final_removeable
+
+end (* Arch *)
+
+interpretation Finalise_R_2?: Finalise_R_2 arch_final_matters' arch_cap_has_cleanup'
+proof goal_cases
+  interpret Arch  .
+  case 1 show ?case by (intro_locales; (unfold_locales; (fact Finalise_R_2_assms)?)?)
+qed
+
+(* this is the only arch-specific lemma in delete_one_conc_pre so far;
+   save processing time by not creating an extra Arch_delete_one_conc_pre locale
+   by directly requalifying instead *)
+lemma (in delete_one_conc_pre) finaliseCap_replaceable:
+  "\<lbrace>\<lambda>s. invs' s \<and> cte_wp_at' (\<lambda>cte. cteCap cte = cap) slot s
+       \<and> (final_matters' cap \<longrightarrow> (final = isFinal cap slot (cteCaps_of s)))
+       \<and> weak_sch_act_wf (ksSchedulerAction s) s\<rbrace>
+     finaliseCap cap final flag
+   \<lbrace>\<lambda>rv s. (isNullCap (fst rv) \<and> removeable' slot s cap
+                \<and> (snd rv \<noteq> NullCap \<longrightarrow> snd rv = cap \<and> cap_has_cleanup' cap
+                                      \<and> isFinal cap slot (cteCaps_of s)))
+        \<or>
+          (isZombie (fst rv) \<and> snd rv = NullCap
+            \<and> isFinal cap slot (cteCaps_of s)
+            \<and> capClass cap = capClass (fst rv)
+            \<and> capUntypedPtr (fst rv) = capUntypedPtr cap
+            \<and> capBits (fst rv) = capBits cap
+            \<and> capRange (fst rv) = capRange cap
+            \<and> (isThreadCap cap \<or> isCNodeCap cap \<or> isZombie cap)
+            \<and> (\<forall>p \<in> threadCapRefs cap. st_tcb_at' ((=) Inactive) p s
+                     \<and> obj_at' (Not \<circ> tcbQueued) p s
+                     \<and> bound_tcb_at' ((=) None) p s
+                     \<and> obj_at' (\<lambda>tcb. tcbSchedNext tcb = None \<and> tcbSchedPrev tcb = None) p s))\<rbrace>"
+  supply [wp] = ARM.prepareThreadDelete_bound_tcb_at'
+                ARM.prepareThreadDelete_tcbSchedPrevNext
+  apply (simp add: finaliseCap_def Let_def getThreadCSpaceRoot
+             cong: if_cong split del: if_split)
+  apply (rule hoare_pre)
+   apply (wp prepares_delete_helper'' [OF cancelAllIPC_unlive]
+             prepares_delete_helper'' [OF cancelAllSignals_unlive]
+             suspend_isFinal ARM.prepareThreadDelete_unqueued
+             ARM.prepareThreadDelete_inactive ARM.prepareThreadDelete_isFinal
+             suspend_makes_inactive
+             deletingIRQHandler_removeable'
+             deletingIRQHandler_final[where slot=slot ]
+             unbindMaybeNotification_obj_at'_bound
+             getNotification_wp
+             suspend_bound_tcb_at'
+             unbindNotification_bound_tcb_at'
+             suspend_tcbSchedNext_tcbSchedPrev_None
+           | simp add: isZombie_Null isThreadCap_threadCapRefs_tcbptr
+                       isArchObjectCap_Cap_capCap
+           | (rule hoare_strengthen_post[OF ARM.arch_finaliseCap_removeable[where slot=slot]],
+              clarsimp simp: gen_isCap_simps)
+           | wpc)+
+  apply clarsimp
+  apply (frule cte_wp_at_valid_objs_valid_cap', clarsimp+)
+  apply (case_tac "cteCap cte",
+         simp_all add: gen_isCap_simps capRange_def cap_has_cleanup'_def
+                       final_matters'_def gen_objBits_simps
+                       not_Final_removeable finaliseCap_def,
+         simp_all add: removeable'_def)
+     (* thread *)
+     apply (frule capAligned_capUntypedPtr [OF valid_capAligned], simp)
+     apply (clarsimp simp: valid_cap'_def)
+     apply (drule valid_globals_cte_wpD'[rotated], clarsimp)
+     apply (clarsimp simp: invs'_def valid_state'_def valid_pspace'_def)
+    apply (clarsimp simp: obj_at'_def | rule conjI)+
+  done
+
+context Arch begin arch_global_naming
+
+named_theorems Finalise_R_3_assms
+
+lemma finaliseCap_cte_refs:
+  "\<lbrace>\<lambda>s. s \<turnstile>' cap\<rbrace>
+     finaliseCap cap final flag
+   \<lbrace>\<lambda>rv s. fst rv \<noteq> NullCap \<longrightarrow> cte_refs' (fst rv) = cte_refs' cap\<rbrace>"
+  apply (simp add: global.finaliseCap_def Let_def getThreadCSpaceRoot finaliseCap_def
+             cong: if_cong split del: if_split)
+  apply (rule hoare_pre)
+   apply (wp | wpc | simp only: o_def)+
+  apply (frule valid_capAligned)
+  apply (cases cap, simp_all add: gen_isCap_simps)
+   apply (clarsimp simp: tcb_cte_cases_def word_count_from_top gen_objBits_simps)
+  apply clarsimp
+  apply (rule ext, simp)
+  apply (rule image_cong [OF _ refl])
+  apply (fastforce simp: mask_def capAligned_def gen_objBits_simps shiftL_nat)
+  done
+
+lemma emptySlot_invs'[wp]:
+  "\<lbrace>\<lambda>s. invs' s \<and> cte_wp_at' (\<lambda>cte. removeable' sl s (cteCap cte)) sl s
+            \<and> (\<forall>sl'. info \<noteq> NullCap \<longrightarrow> sl' \<noteq> sl \<longrightarrow> cteCaps_of s sl' \<noteq> Some info)\<rbrace>
+     emptySlot sl info
+   \<lbrace>\<lambda>rv. invs'\<rbrace>"
+  apply (simp add: invs'_def valid_state'_def valid_pspace'_def)
+  apply (wp valid_irq_node_lift cur_tcb_lift valid_dom_schedule'_lift)
+  apply (clarsimp simp: cte_wp_at_ctes_of)
+  done
+
+lemma cteDeleteOne_invs[Finalise_R_3_assms, wp]:
+  "cteDeleteOne ptr \<lbrace>invs'\<rbrace>"
+  apply (simp add: cteDeleteOne_def unless_def
+                   split_def finaliseCapTrue_standin_simple_def)
+  apply wp
+    apply (rule hoare_strengthen_post)
+     apply (rule hoare_vcg_conj_lift[OF finaliseCap_True_invs])
+     apply (rule hoare_vcg_conj_lift[OF finaliseCap_replaceable[where slot=ptr]])
+     apply (rule hoare_vcg_conj_lift[OF finaliseCap_cte_refs])
+     apply (rule finaliseCap_equal_cap[where sl=ptr])
+    apply (clarsimp simp: cte_wp_at_ctes_of)
+    apply (erule disjE, solves simp)
+    apply (clarsimp dest!: isCapDs simp: capRemovable_def)
+    apply (clarsimp simp: removeable'_def fun_eq_iff[where f="cte_refs' cap" for cap]
+                     del: disjCI)
+    subgoal by (auto dest!: isCapDs simp: pred_tcb_at'_def obj_at'_def
+                                          live'_def hyp_live'_def ko_wp_at'_def)
+   apply (wp isFinalCapability_inv getCTE_wp' hoare_weak_lift_imp
+          | wp (once) isFinal[where x=ptr])+
+  apply (fastforce simp: cte_wp_at_ctes_of)
+  done
+
+lemma isFinalCapability_corres'[Finalise_R_3_assms]:
   "final_matters' (cteCap cte) \<Longrightarrow>
    corres (=) (invs and cte_wp_at ((=) cap) ptr)
                (invs' and cte_wp_at' ((=) cte) (cte_map ptr))
@@ -2191,7 +1163,7 @@ lemma isFinalCapability_corres':
    apply (erule_tac x=aa in allE)
    apply (erule_tac x=ba in allE)
    apply (clarsimp simp: cte_wp_at_caps_of_state)
-   apply (clarsimp simp: sameObjectAs_def3 obj_refs_Master cap_irqs_relation_Master
+   apply (clarsimp simp: sameObjectAs_def3 obj_refs_relation_Master cap_irqs_relation_Master
                          arch_gen_refs_relation_Master gen_obj_refs_Int
                    cong: if_cong
                   split: capability.split_asm)
@@ -2199,7 +1171,7 @@ lemma isFinalCapability_corres':
   apply (rule_tac x="fst ptr" in exI)
   apply (rule_tac x="snd ptr" in exI)
   apply (rule conjI)
-   apply (clarsimp simp: cte_wp_at_def final_matters'_def
+   apply (clarsimp simp: cte_wp_at_def final_matters'_def arch_final_matters'_def
                          gen_obj_refs_Int
                   split: cap_relation_split_asm arch_cap.split_asm)
   apply clarsimp
@@ -2225,1176 +1197,45 @@ lemma isFinalCapability_corres':
    apply (rule classical)
    apply (frule(1) zombies_finalD2[OF _ _ _ invs_zombies],
           simp?, clarsimp, assumption+)
-   subgoal by (clarsimp simp: sameObjectAs_def3 isCap_simps valid_cap_def
-                         obj_at_def is_obj_defs a_type_def final_matters'_def
-                  split: cap.split_asm arch_cap.split_asm
-                         option.split_asm if_split_asm,
-          simp_all add: is_cap_defs)
+   subgoal by (clarsimp simp: sameObjectAs_def3 isCap_simps valid_cap_def valid_arch_cap_def
+                              valid_arch_cap_ref_def obj_at_def is_obj_defs a_type_def
+                              final_matters'_def arch_final_matters'_def
+                        split: cap.split_asm arch_cap.split_asm option.split_asm if_split_asm,
+               simp_all add: is_cap_defs)
   apply (rule classical)
   by (clarsimp simp: cap_irqs_def cap_irq_opt_def sameObjectAs_def3 isCap_simps arch_gen_obj_refs_def
                  split: cap.split_asm)
 
-lemma isFinalCapability_corres:
-  "corres (\<lambda>rv rv'. final_matters' (cteCap cte) \<longrightarrow> rv = rv')
-          (invs and cte_wp_at ((=) cap) ptr)
-          (invs' and cte_wp_at' ((=) cte) (cte_map ptr))
-       (is_final_cap cap) (isFinalCapability cte)"
-  apply (cases "final_matters' (cteCap cte)")
-   apply simp
-   apply (erule isFinalCapability_corres')
-  apply (subst bind_return[symmetric],
-         rule corres_symb_exec_r)
-     apply (rule corres_no_failI)
-      apply wp
-     apply (clarsimp simp: in_monad is_final_cap_def simpler_gets_def)
-    apply (wp isFinalCapability_inv)+
-  apply fastforce
-  done
-
-text \<open>Facts about finalise_cap/finaliseCap and
-        cap_delete_one/cteDelete in no particular order\<close>
-
-
-definition
-  finaliseCapTrue_standin_simple_def:
-  "finaliseCapTrue_standin cap fin \<equiv> finaliseCap cap fin True"
-
-context
-begin
-
-declare if_cong [cong]
-
-lemmas finaliseCapTrue_standin_def
-    = finaliseCapTrue_standin_simple_def
-        [unfolded finaliseCap_def, simplified]
-
-lemmas cteDeleteOne_def'
-    = eq_reflection [OF cteDeleteOne_def]
-lemmas cteDeleteOne_def
-    = cteDeleteOne_def'[folded finaliseCapTrue_standin_simple_def]
-
-crunch cteDeleteOne, suspend, prepareThreadDelete
-  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  (wp: crunch_wps getObject_inv loadObject_default_inv
-   simp: crunch_simps unless_def o_def)
-
-end
-
-lemmas cancelAllIPC_typs[wp] = typ_at_lifts [OF cancelAllIPC_typ_at']
-lemmas cancelAllSignals_typs[wp] = typ_at_lifts [OF cancelAllSignals_typ_at']
-lemmas suspend_typs[wp] = typ_at_lifts [OF suspend_typ_at']
-
-definition
-  arch_cap_has_cleanup' :: "arch_capability \<Rightarrow> bool"
-where
-  "arch_cap_has_cleanup' acap \<equiv> False"
-
-definition
-  cap_has_cleanup' :: "capability \<Rightarrow> bool"
-where
-  "cap_has_cleanup' cap \<equiv> case cap of
-     IRQHandlerCap _ \<Rightarrow> True
-   | ArchObjectCap acap \<Rightarrow> arch_cap_has_cleanup' acap
-   | _ \<Rightarrow> False"
-
-lemmas cap_has_cleanup'_simps[simp] = cap_has_cleanup'_def[split_simps capability.split]
-
-lemma finaliseCap_cases[wp]:
-  "\<lbrace>\<top>\<rbrace>
-     finaliseCap cap final flag
-   \<lbrace>\<lambda>rv s. fst rv = NullCap \<and> (snd rv \<noteq> NullCap \<longrightarrow> final \<and> cap_has_cleanup' cap \<and> snd rv = cap)
-     \<or>
-       isZombie (fst rv) \<and> final \<and> \<not> flag \<and> snd rv = NullCap
-        \<and> capUntypedPtr (fst rv) = capUntypedPtr cap
-        \<and> (isThreadCap cap \<or> isCNodeCap cap \<or> isZombie cap)\<rbrace>"
-  apply (simp add: finaliseCap_def ARM_H.finaliseCap_def Let_def
-                   getThreadCSpaceRoot
-             cong: if_cong split del: if_split)
-  apply (rule hoare_pre)
-   apply ((wp | simp add: isCap_simps split del: if_split
-              | wpc
-              | simp only: valid_NullCap fst_conv snd_conv)+)[1]
-  apply (simp only: simp_thms fst_conv snd_conv option.simps if_cancel
-                    o_def)
-  apply (intro allI impI conjI TrueI)
-  apply (auto simp add: isCap_simps cap_has_cleanup'_def)
-  done
-
-crunch finaliseCap
-  for aligned'[wp]: "pspace_aligned'"
-  (simp: crunch_simps assertE_def unless_def o_def
-     wp: getObject_inv loadObject_default_inv crunch_wps)
-
-crunch finaliseCap
-  for distinct'[wp]: "pspace_distinct'"
-  (simp: crunch_simps assertE_def unless_def o_def
-     wp: getObject_inv loadObject_default_inv crunch_wps)
-
-crunch finaliseCap
-  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  (simp: crunch_simps assertE_def
-     wp: getObject_inv loadObject_default_inv crunch_wps)
-lemmas finaliseCap_typ_ats[wp] = typ_at_lifts[OF finaliseCap_typ_at']
-
-crunch finaliseCap
-  for it'[wp]: "\<lambda>s. P (ksIdleThread s)"
-  (wp: mapM_x_wp_inv mapM_wp' hoare_drop_imps getObject_inv loadObject_default_inv
-   simp: crunch_simps o_def)
-
-lemma ntfn_q_refs_of'_mult:
-  "ntfn_q_refs_of' ntfn = (case ntfn of Structures_H.WaitingNtfn q \<Rightarrow> set q | _ \<Rightarrow> {}) \<times> {NTFNSignal}"
-  by (cases ntfn, simp_all)
-
-lemma tcb_st_not_Bound:
-  "(p, NTFNBound) \<notin> tcb_st_refs_of' ts"
-  "(p, TCBBound) \<notin> tcb_st_refs_of' ts"
-  by (auto simp: tcb_st_refs_of'_def split: Structures_H.thread_state.split)
-
-crunch setBoundNotification
-  for valid_bitmaps[wp]: valid_bitmaps
-  and tcbSchedNexts_of[wp]: "\<lambda>s. P (tcbSchedNexts_of s)"
-  and tcbSchedPrevs_of[wp]: "\<lambda>s. P (tcbSchedPrevs_of s)"
-  and tcbQueued[wp]: "\<lambda>s. P (tcbQueued |< tcbs_of' s)"
-  and valid_sched_pointers[wp]: valid_sched_pointers
-  (wp: valid_bitmaps_lift)
-
-lemma unbindNotification_invs[wp]:
-  "\<lbrace>invs'\<rbrace> unbindNotification tcb \<lbrace>\<lambda>rv. invs'\<rbrace>"
-  apply (simp add: unbindNotification_def invs'_def valid_state'_def)
-  apply (rule bind_wp[OF _ gbn_sp'])
-  apply (case_tac ntfnPtr, clarsimp, wp, clarsimp)
-  apply clarsimp
-  apply (rule bind_wp[OF _ get_ntfn_sp'])
-  apply (rule hoare_pre)
-  apply (wp sbn'_valid_pspace'_inv sbn_sch_act' valid_irq_node_lift valid_dom_schedule'_lift
-            irqs_masked_lift setBoundNotification_ct_not_inQ sym_heap_sched_pointers_lift
-            untyped_ranges_zero_lift | clarsimp simp: cteCaps_of_def o_def)+
-  apply (rule conjI)
-   apply (clarsimp elim!: obj_atE'
-                    simp: projectKOs
-                   dest!: pred_tcb_at')
-  apply (clarsimp simp: pred_tcb_at' conj_comms)
-  apply (frule bound_tcb_ex_cap'', clarsimp+)
-  apply (frule(1) sym_refs_bound_tcb_atD')
-  apply (frule(1) sym_refs_obj_atD')
-  apply (clarsimp simp: refs_of_rev')
-  apply normalise_obj_at'
-  apply (subst delta_sym_refs, assumption)
-    apply (auto split: if_split_asm)[1]
-   apply (auto simp: tcb_st_not_Bound ntfn_q_refs_of'_mult split: if_split_asm)[1]
-  apply (frule obj_at_valid_objs', clarsimp+)
-  apply (simp add: valid_ntfn'_def valid_obj'_def projectKOs live'_def
-            split: ntfn.splits)
-  apply (erule if_live_then_nonz_capE')
-  apply (clarsimp simp: obj_at'_def ko_wp_at'_def projectKOs live'_def)
-  done
-
-lemma ntfn_bound_tcb_at':
-  "\<lbrakk>sym_refs (state_refs_of' s); valid_objs' s; ko_at' ntfn ntfnptr s;
-    ntfnBoundTCB ntfn = Some tcbptr; P (Some ntfnptr)\<rbrakk>
-  \<Longrightarrow> bound_tcb_at' P tcbptr s"
-  apply (drule_tac x=ntfnptr in sym_refsD[rotated])
-   apply (clarsimp simp: obj_at'_def projectKOs)
-   apply (fastforce simp: state_refs_of'_def)
-  apply (auto simp: pred_tcb_at'_def obj_at'_def valid_obj'_def valid_ntfn'_def
-                    state_refs_of'_def refs_of_rev' projectKOs
-          simp del: refs_of_simps
-             elim!: valid_objsE
-             split: option.splits if_split_asm)
-  done
-
-
-lemma unbindMaybeNotification_invs[wp]:
-  "\<lbrace>invs'\<rbrace> unbindMaybeNotification ntfnptr \<lbrace>\<lambda>rv. invs'\<rbrace>"
-  apply (simp add: unbindMaybeNotification_def invs'_def valid_state'_def)
-  apply (rule bind_wp[OF _ get_ntfn_sp'])
-  apply (rule hoare_pre)
-   apply (wp sbn'_valid_pspace'_inv sbn_sch_act' sym_heap_sched_pointers_lift valid_irq_node_lift
-             irqs_masked_lift valid_dom_schedule'_lift setBoundNotification_ct_not_inQ
-             untyped_ranges_zero_lift
-             | wpc | clarsimp simp: cteCaps_of_def o_def)+
-  apply safe[1]
-           defer 3
-           defer 7
-           apply (fold_subgoals (prefix))[8]
-           subgoal premises prems using prems by (auto simp: pred_tcb_at' valid_pspace'_def projectKOs valid_obj'_def valid_ntfn'_def
-                             ko_wp_at'_def live'_def
-                      elim!: obj_atE' valid_objsE' if_live_then_nonz_capE'
-                      split: option.splits ntfn.splits)
-   apply (rule delta_sym_refs, assumption)
-    apply (fold_subgoals (prefix))[2]
-    subgoal premises prems using prems by (fastforce simp: symreftype_inverse' ntfn_q_refs_of'_def
-                    split: ntfn.splits if_split_asm
-                     dest!: ko_at_state_refs_ofD')+
-  apply (rule delta_sym_refs, assumption)
-   apply (clarsimp split: if_split_asm)
-   apply (frule ko_at_state_refs_ofD', simp)
-  apply (clarsimp split: if_split_asm)
-   apply (frule_tac P="(=) (Some ntfnptr)" in ntfn_bound_tcb_at', simp_all add: valid_pspace'_def)[1]
-   subgoal by (fastforce simp: ntfn_q_refs_of'_def state_refs_of'_def tcb_ntfn_is_bound'_def
-                          tcb_st_refs_of'_def
-                   dest!: bound_tcb_at_state_refs_ofD'
-                   split: ntfn.splits thread_state.splits)
-  apply (frule ko_at_state_refs_ofD', simp)
-  done
-
-(* Ugh, required to be able to split out the abstract invs *)
-lemma finaliseCap_True_invs[wp]:
-  "\<lbrace>invs'\<rbrace> finaliseCap cap final True \<lbrace>\<lambda>rv. invs'\<rbrace>"
-  apply (simp add: finaliseCap_def Let_def)
-  apply safe
-    apply (wp irqs_masked_lift| simp | wpc)+
-  done
-
-crunch flushSpace
-  for invs'[wp]: "invs'"
-  (ignore: doMachineOp)
-
-lemma invs_asid_update_strg':
-  "invs' s \<and> tab = armKSASIDTable (ksArchState s) \<longrightarrow>
-   invs' (s\<lparr>ksArchState := armKSASIDTable_update
-            (\<lambda>_. tab (asid := None)) (ksArchState s)\<rparr>)"
-  apply (simp add: invs'_def)
-  apply (simp add: valid_state'_def)
-  apply (simp add: valid_global_refs'_def global_refs'_def valid_arch_state'_def valid_asid_table'_def valid_machine_state'_def ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def)
-  apply (auto simp add: ran_def split: if_split_asm)
-  done
-
-lemma invalidateASIDEntry_invs' [wp]:
-  "\<lbrace>invs'\<rbrace> invalidateASIDEntry asid \<lbrace>\<lambda>r. invs'\<rbrace>"
-  apply (simp add: invalidateASIDEntry_def invalidateASID_def
-                   invalidateHWASIDEntry_def bind_assoc)
-  apply (wp loadHWASID_wp | simp)+
-  apply (clarsimp simp: fun_upd_def[symmetric])
-  apply (rule conjI)
-   apply (clarsimp simp: invs'_def valid_state'_def)
-   apply (rule conjI)
-    apply (simp add: valid_global_refs'_def
-                     global_refs'_def)
-   apply (simp add: valid_arch_state'_def ran_def
-                    valid_asid_table'_def is_inv_None_upd
-                    valid_machine_state'_def
-                    comp_upd_simp fun_upd_def[symmetric]
-                    inj_on_fun_upd_elsewhere
-                    valid_asid_map'_def
-                    ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def)
-   subgoal by (auto elim!: subset_inj_on)
-  apply (clarsimp simp: invs'_def valid_state'_def)
-  apply (rule conjI)
-   apply (simp add: valid_global_refs'_def
-                    global_refs'_def)
-  apply (rule conjI)
-   apply (simp add: valid_arch_state'_def ran_def
-                    valid_asid_table'_def None_upd_eq
-                    fun_upd_def[symmetric] comp_upd_simp)
-  apply (simp add: valid_machine_state'_def ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def)
-  done
-
-lemma deleteASIDPool_invs[wp]:
-  "\<lbrace>invs'\<rbrace> deleteASIDPool asid pool \<lbrace>\<lambda>rv. invs'\<rbrace>"
-  apply (simp add: deleteASIDPool_def)
-  apply wp
-    apply (simp del: fun_upd_apply)
-    apply (strengthen invs_asid_update_strg')
-  apply (wp mapM_wp' getObject_inv loadObject_default_inv
-              | simp)+
-  done
-
-lemmas flushSpace_typ_ats' [wp] = typ_at_lifts [OF flushSpace_typ_at']
-
-lemma deleteASID_invs'[wp]:
-  "\<lbrace>invs'\<rbrace> deleteASID asid pd \<lbrace>\<lambda>rv. invs'\<rbrace>"
-  apply (simp add: deleteASID_def cong: option.case_cong)
-  apply (rule hoare_pre)
-   apply (wp | wpc)+
-    apply (rule_tac Q'="\<lambda>rv. valid_obj' (injectKO rv) and invs'"
-              in hoare_post_imp)
-     apply (rename_tac rv s)
-     apply (clarsimp split: if_split_asm del: subsetI)
-     apply (simp add: fun_upd_def[symmetric] valid_obj'_def)
-     apply (case_tac rv, simp)
-     apply (subst inv_f_f, rule inj_onI, simp)+
-     apply (rule conjI)
-      apply clarsimp
-      apply (drule subsetD, blast)
-      apply clarsimp
-     apply (auto dest!: ran_del_subset)[1]
-    apply (wp getObject_valid_obj getObject_inv loadObject_default_inv
-             | simp add: objBits_simps archObjSize_def pageBits_def)+
-  apply clarsimp
-  done
-
-lemma arch_finaliseCap_invs[wp]:
-  "\<lbrace>invs' and valid_cap' (ArchObjectCap cap)\<rbrace>
-     Arch.finaliseCap cap fin
-   \<lbrace>\<lambda>rv. invs'\<rbrace>"
-  unfolding ARM_H.finaliseCap_def
-  apply clarsimp
-  apply (safe ; wpsimp)
-  done
-
-lemma arch_finaliseCap_removeable[wp]:
-  "\<lbrace>\<lambda>s. s \<turnstile>' ArchObjectCap cap \<and> invs' s
-       \<and> (final \<and> final_matters' (ArchObjectCap cap)
-            \<longrightarrow> isFinal (ArchObjectCap cap) slot (cteCaps_of s))\<rbrace>
-     Arch.finaliseCap cap final
-   \<lbrace>\<lambda>rv s. isNullCap (fst rv) \<and> removeable' slot s (ArchObjectCap cap) \<and> isNullCap (snd rv)\<rbrace>"
-  apply (simp add: ARM_H.finaliseCap_def
-                   removeable'_def)
-  apply (safe ; wpsimp)
-  done
-
-lemma isZombie_Null:
-  "\<not> isZombie NullCap"
-  by (simp add: isCap_simps)
-
-lemma prepares_delete_helper'':
-  assumes x: "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv. ko_wp_at' (Not \<circ> live') p\<rbrace>"
-  shows      "\<lbrace>P and K ((\<forall>x. cte_refs' cap x = {})
-                          \<and> zobj_refs' cap = {p}
-                          \<and> threadCapRefs cap = {})\<rbrace>
-                 f \<lbrace>\<lambda>rv s. removeable' sl s cap\<rbrace>"
-  apply (rule hoare_gen_asm)
-  apply (rule hoare_strengthen_post [OF x])
-  apply (clarsimp simp: removeable'_def)
-  done
-
-lemmas ctes_of_cteCaps_of_lift = cteCaps_of_ctes_of_lift
-
-crunch finaliseCapTrue_standin, unbindNotification
-  for ctes_of[wp]: "\<lambda>s. P (ctes_of s)"
-  (wp: crunch_wps getObject_inv loadObject_default_inv simp: crunch_simps)
-
-lemma cteDeleteOne_cteCaps_of:
-  "\<lbrace>\<lambda>s. (cte_wp_at' (\<lambda>cte. \<exists>final. finaliseCap (cteCap cte) final True \<noteq> fail) p s \<longrightarrow>
-          P ((cteCaps_of s)(p \<mapsto> NullCap)))\<rbrace>
-     cteDeleteOne p
-   \<lbrace>\<lambda>rv s. P (cteCaps_of s)\<rbrace>"
-  apply (simp add: cteDeleteOne_def unless_def split_def)
-  apply (rule bind_wp [OF _ getCTE_sp])
-  apply (case_tac "\<forall>final. finaliseCap (cteCap cte) final True = fail")
-   apply (simp add: finaliseCapTrue_standin_simple_def)
-   apply wp
-   apply (clarsimp simp: cte_wp_at_ctes_of cteCaps_of_def
-                         finaliseCap_def isCap_simps)
-   apply (drule_tac x=s in fun_cong)
-   apply (simp add: return_def fail_def)
-  apply (wp emptySlot_cteCaps_of)
-    apply (simp add: cteCaps_of_def)
-    apply (wp (once) hoare_drop_imps)
-    apply (wp isFinalCapability_inv getCTE_wp')+
-  apply (clarsimp simp: cteCaps_of_def cte_wp_at_ctes_of)
-  apply (auto simp: fun_upd_idem fun_upd_def[symmetric] o_def)
-  done
-
-lemma cteDeleteOne_isFinal:
-  "\<lbrace>\<lambda>s. isFinal cap slot (cteCaps_of s)\<rbrace>
-     cteDeleteOne p
-   \<lbrace>\<lambda>rv s. isFinal cap slot (cteCaps_of s)\<rbrace>"
-  apply (wp cteDeleteOne_cteCaps_of)
-  apply (clarsimp simp: isFinal_def sameObjectAs_def2)
-  done
-
-lemmas setEndpoint_cteCaps_of[wp] = ctes_of_cteCaps_of_lift [OF set_ep_ctes_of]
-lemmas setNotification_cteCaps_of[wp] = ctes_of_cteCaps_of_lift [OF set_ntfn_ctes_of]
-lemmas threadSet_cteCaps_of = ctes_of_cteCaps_of_lift [OF threadSet_ctes_of]
-
-crunch suspend, prepareThreadDelete
-  for isFinal: "\<lambda>s. isFinal cap slot (cteCaps_of s)"
-  (ignore: threadSet
-       wp: threadSet_cteCaps_of crunch_wps
-     simp: crunch_simps unless_def o_def)
-
-lemma isThreadCap_threadCapRefs_tcbptr:
-  "isThreadCap cap \<Longrightarrow> threadCapRefs cap = {capTCBPtr cap}"
-  by (clarsimp simp: isCap_simps)
-
-lemma isArchObjectCap_Cap_capCap:
-  "isArchObjectCap cap \<Longrightarrow> ArchObjectCap (capCap cap) = cap"
-  by (clarsimp simp: isCap_simps)
-
-lemma cteDeleteOne_deletes[wp]:
-  "\<lbrace>\<top>\<rbrace> cteDeleteOne p \<lbrace>\<lambda>rv s. cte_wp_at' (\<lambda>c. cteCap c = NullCap) p s\<rbrace>"
-  apply (subst tree_cte_cteCap_eq[unfolded o_def])
-  apply (wp cteDeleteOne_cteCaps_of)
-  apply clarsimp
-  done
-
-crunch finaliseCap
-  for irq_node'[wp]: "\<lambda>s. P (irq_node' s)"
-  (wp: mapM_x_wp crunch_wps getObject_inv loadObject_default_inv
-       updateObject_default_inv setObject_ksInterrupt
-   simp: crunch_simps unless_def o_def)
-
-lemma deletingIRQHandler_removeable':
-  "\<lbrace>invs' and (\<lambda>s. isFinal (IRQHandlerCap irq) slot (cteCaps_of s))
-          and K (cap = IRQHandlerCap irq)\<rbrace>
-     deletingIRQHandler irq
-   \<lbrace>\<lambda>rv s. removeable' slot s cap\<rbrace>"
-  apply (rule hoare_gen_asm)
-  apply (simp add: deletingIRQHandler_def getIRQSlot_def locateSlot_conv
-                   getInterruptState_def getSlotCap_def)
-  apply (simp add: removeable'_def tree_cte_cteCap_eq[unfolded o_def])
-  apply (subst tree_cte_cteCap_eq[unfolded o_def])+
-  apply (wp hoare_use_eq_irq_node' [OF cteDeleteOne_irq_node' cteDeleteOne_cteCaps_of]
-            getCTE_wp')
-  apply (clarsimp simp: cte_level_bits_def ucast_nat_def shiftl_t2n mult_ac cteSizeBits_def
-                  split: option.split_asm)
-  done
-
-lemma finaliseCap_cte_refs:
-  "\<lbrace>\<lambda>s. s \<turnstile>' cap\<rbrace>
-     finaliseCap cap final flag
-   \<lbrace>\<lambda>rv s. fst rv \<noteq> NullCap \<longrightarrow> cte_refs' (fst rv) = cte_refs' cap\<rbrace>"
-  apply (simp  add: finaliseCap_def Let_def getThreadCSpaceRoot
-                    ARM_H.finaliseCap_def
-             cong: if_cong split del: if_split)
-  apply (rule hoare_pre)
-   apply (wp | wpc | simp only: o_def)+
-  apply (frule valid_capAligned)
-  apply (cases cap, simp_all add: isCap_simps)
-   apply (clarsimp simp: tcb_cte_cases_def word_count_from_top objBits_defs)
-  apply clarsimp
-  apply (rule ext, simp)
-  apply (rule image_cong [OF _ refl])
-  apply (fastforce simp: capAligned_def objBits_simps shiftL_nat mask_def)
-  done
-
-lemma deletingIRQHandler_final:
-  "\<lbrace>\<lambda>s. isFinal cap slot (cteCaps_of s)
-             \<and> (\<forall>final. finaliseCap cap final True = fail)\<rbrace>
-     deletingIRQHandler irq
-   \<lbrace>\<lambda>rv s. isFinal cap slot (cteCaps_of s)\<rbrace>"
-  apply (simp add: deletingIRQHandler_def isFinal_def getIRQSlot_def
-                   getInterruptState_def locateSlot_conv getSlotCap_def)
-  apply (wp cteDeleteOne_cteCaps_of getCTE_wp')
-  apply (auto simp: sameObjectAs_def3)
-  done
-
-declare suspend_unqueued [wp]
-
-lemma unbindNotification_valid_objs'_helper:
-  "valid_tcb' tcb s \<longrightarrow> valid_tcb' (tcbBoundNotification_update (\<lambda>_. None) tcb) s "
-  by (clarsimp simp: valid_bound_ntfn'_def valid_tcb'_def tcb_cte_cases_def tcb_cte_cases_neqs
-                  split: option.splits ntfn.splits)
-
-lemma unbindNotification_valid_objs'_helper':
-  "valid_ntfn' tcb s \<longrightarrow> valid_ntfn' (ntfnBoundTCB_update (\<lambda>_. None) tcb) s "
-  by (clarsimp simp: valid_bound_tcb'_def valid_ntfn'_def
-                  split: option.splits ntfn.splits)
-
-lemmas setNotification_valid_tcb' = typ_at'_valid_tcb'_lift [OF setNotification_typ_at']
-
-lemma unbindNotification_valid_objs'[wp]:
-  "\<lbrace>valid_objs'\<rbrace>
-     unbindNotification t
-   \<lbrace>\<lambda>rv. valid_objs'\<rbrace>"
-  apply (simp add: unbindNotification_def)
-  apply (rule hoare_pre)
-  apply (wp threadSet_valid_objs' gbn_wp' set_ntfn_valid_objs' hoare_vcg_all_lift
-            setNotification_valid_tcb' getNotification_wp
-        | wpc | clarsimp simp: setBoundNotification_def unbindNotification_valid_objs'_helper)+
-  apply (clarsimp elim!: obj_atE' simp: projectKOs)
-  apply (rule valid_objsE', assumption+)
-  apply (clarsimp simp: valid_obj'_def unbindNotification_valid_objs'_helper')
-  done
-
-lemma unbindMaybeNotification_valid_objs'[wp]:
-  "\<lbrace>valid_objs'\<rbrace>
-     unbindMaybeNotification t
-   \<lbrace>\<lambda>rv. valid_objs'\<rbrace>"
-  apply (simp add: unbindMaybeNotification_def)
-  apply (rule bind_wp[OF _ get_ntfn_sp'])
-  apply (rule hoare_pre)
-  apply (wp threadSet_valid_objs' gbn_wp' set_ntfn_valid_objs' hoare_vcg_all_lift
-            setNotification_valid_tcb' getNotification_wp
-        | wpc | clarsimp simp: setBoundNotification_def unbindNotification_valid_objs'_helper)+
-  apply (clarsimp elim!: obj_atE' simp: projectKOs)
-  apply (rule valid_objsE', assumption+)
-  apply (clarsimp simp: valid_obj'_def unbindNotification_valid_objs'_helper')
-  done
-
-lemma unbindMaybeNotification_sch_act_wf[wp]:
-  "\<lbrace>\<lambda>s. sch_act_wf (ksSchedulerAction s) s\<rbrace> unbindMaybeNotification t
-  \<lbrace>\<lambda>rv s. sch_act_wf (ksSchedulerAction s) s\<rbrace>"
-  apply (simp add: unbindMaybeNotification_def)
-  apply (rule hoare_pre)
-  apply (wp sbn_sch_act' | wpc | simp)+
-  done
-
-lemma valid_cong:
-  "\<lbrakk> \<And>s. P s = P' s; \<And>s. P' s \<Longrightarrow> f s = f' s;
-        \<And>rv s' s. \<lbrakk> (rv, s') \<in> fst (f' s); P' s \<rbrakk> \<Longrightarrow> Q rv s' = Q' rv s' \<rbrakk>
-    \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace> = \<lbrace>P'\<rbrace> f' \<lbrace>Q'\<rbrace>"
-  by (clarsimp simp add: valid_def, blast)
-
-lemma unbindMaybeNotification_obj_at'_bound:
-  "\<lbrace>\<top>\<rbrace>
-     unbindMaybeNotification r
-   \<lbrace>\<lambda>_ s. obj_at' (\<lambda>ntfn. ntfnBoundTCB ntfn = None) r s\<rbrace>"
-  apply (simp add: unbindMaybeNotification_def)
-  apply (rule bind_wp[OF _ get_ntfn_sp'])
-  apply (rule hoare_pre)
-   apply (wp obj_at_setObject2
-        | wpc
-        | simp add: setBoundNotification_def threadSet_def updateObject_default_def in_monad projectKOs)+
-  apply (simp add: setNotification_def obj_at'_real_def cong: valid_cong)
-   apply (wp setObject_ko_wp_at, (simp add: objBits_simps')+)
-  apply (clarsimp simp: obj_at'_def ko_wp_at'_def projectKOs)
-  done
-
-context
-notes option.case_cong_weak[cong]
-begin
-crunch unbindNotification, unbindMaybeNotification
-  for isFinal[wp]: "\<lambda>s. isFinal cap slot (cteCaps_of s)"
-  (wp: sts_bound_tcb_at' threadSet_cteCaps_of crunch_wps getObject_inv loadObject_default_inv
-   ignore: threadSet)
-end
-
-crunch cancelSignal, cancelAllIPC
-  for bound_tcb_at'[wp]: "bound_tcb_at' P t"
-  (wp: sts_bound_tcb_at' threadSet_cteCaps_of crunch_wps getObject_inv
-       loadObject_default_inv)
-
-lemma finaliseCapTrue_standin_bound_tcb_at':
-  "\<lbrace>\<lambda>s. bound_tcb_at' P t s \<and> (\<exists>tt b r. cap = ReplyCap tt b r) \<rbrace>
-     finaliseCapTrue_standin cap final
-   \<lbrace>\<lambda>_. bound_tcb_at' P t\<rbrace>"
-  apply (case_tac cap, simp_all add:finaliseCapTrue_standin_def)
-  apply (clarsimp simp: isNotificationCap_def)
-  apply (wp, clarsimp)
-  done
-
-lemma capDeleteOne_bound_tcb_at':
-  "\<lbrace>bound_tcb_at' P tptr and cte_wp_at' (isReplyCap \<circ> cteCap) callerCap\<rbrace>
-      cteDeleteOne callerCap \<lbrace>\<lambda>rv. bound_tcb_at' P tptr\<rbrace>"
-  apply (simp add: cteDeleteOne_def unless_def)
-  apply (rule hoare_pre)
-   apply (wp finaliseCapTrue_standin_bound_tcb_at' hoare_vcg_all_lift
-            hoare_vcg_if_lift2 getCTE_cteCap_wp
-        | wpc | simp | wp (once) hoare_drop_imp)+
-  apply (clarsimp simp:  cteCaps_of_def projectKOs isReplyCap_def cte_wp_at_ctes_of
-                 split: option.splits)
-  apply (case_tac "cteCap cte", simp_all)
-  done
-
-lemma cancelIPC_bound_tcb_at'[wp]:
-  "\<lbrace>bound_tcb_at' P tptr\<rbrace> cancelIPC t \<lbrace>\<lambda>rv. bound_tcb_at' P tptr\<rbrace>"
-  apply (simp add: cancelIPC_def Let_def)
-  apply (rule bind_wp[OF _ gts_sp'])
-  apply (case_tac "state", simp_all)
-         defer 2
-         apply (rule hoare_pre)
-          apply ((wp sts_bound_tcb_at' getEndpoint_wp | wpc | simp)+)[8]
-  apply (simp add: getThreadReplySlot_def locateSlot_conv liftM_def)
-  apply (rule hoare_pre)
-   apply (wp capDeleteOne_bound_tcb_at' getCTE_ctes_of)
-   apply (rule_tac Q'="\<lambda>_. bound_tcb_at' P tptr" in hoare_post_imp)
-   apply (clarsimp simp: capHasProperty_def cte_wp_at_ctes_of)
-   apply (wp threadSet_pred_tcb_no_state | simp)+
-  done
-
-crunch suspend, prepareThreadDelete
-  for bound_tcb_at'[wp]: "bound_tcb_at' P t"
-  (wp: sts_bound_tcb_at' cancelIPC_bound_tcb_at')
-
-lemma unbindNotification_bound_tcb_at':
-  "\<lbrace>\<lambda>_. True\<rbrace> unbindNotification t \<lbrace>\<lambda>rv. bound_tcb_at' ((=) None) t\<rbrace>"
-  apply (simp add: unbindNotification_def)
-  apply (wp setBoundNotification_bound_tcb gbn_wp' | wpc | simp)+
-  done
-
-crunch unbindNotification, unbindMaybeNotification
-  for weak_sch_act_wf[wp]: "\<lambda>s. weak_sch_act_wf (ksSchedulerAction s) s"
-
-lemma unbindNotification_tcb_at'[wp]:
-  "\<lbrace>tcb_at' t'\<rbrace> unbindNotification t \<lbrace>\<lambda>rv. tcb_at' t'\<rbrace>"
-  apply (simp add: unbindNotification_def)
-  apply (wp gbn_wp' | wpc | simp)+
-  done
-
-lemma unbindMaybeNotification_tcb_at'[wp]:
-  "\<lbrace>tcb_at' t'\<rbrace> unbindMaybeNotification t \<lbrace>\<lambda>rv. tcb_at' t'\<rbrace>"
-  apply (simp add: unbindMaybeNotification_def)
-  apply (wp gbn_wp' | wpc | simp)+
-  done
-
-crunch prepareThreadDelete
-  for cte_wp_at'[wp]: "cte_wp_at' P p"
-crunch prepareThreadDelete
-  for valid_cap'[wp]: "valid_cap' cap"
-crunch prepareThreadDelete
-  for invs[wp]: "invs'"
-
-crunch prepareThreadDelete
-  for sched_projs_obj_at'[wp]:
-    "\<lambda>s. obj_at' (\<lambda>tcb. tcbSchedNext tcb = None \<and> tcbSchedPrev tcb = None) t s"
-
-end
-
-lemma tcbQueueRemove_tcbSchedNext_tcbSchedPrev_None_obj_at':
-  "\<lbrace>\<lambda>s. \<exists>ts. list_queue_relation ts q (tcbSchedNexts_of s) (tcbSchedPrevs_of s)\<rbrace>
-   tcbQueueRemove q t
-   \<lbrace>\<lambda>_ s. obj_at' (\<lambda>tcb. tcbSchedNext tcb = None \<and> tcbSchedPrev tcb = None) t s\<rbrace>"
-  apply (clarsimp simp: tcbQueueRemove_def)
-  apply (wpsimp wp: threadSet_wp getTCB_wp)
-  by (fastforce dest!: heap_ls_last_None
-                 simp: list_queue_relation_def prev_queue_head_def queue_end_valid_def
-                       obj_at'_def projectKOs opt_map_def ps_clear_def gen_objBits_simps
-                split: if_splits)
-
-lemma tcbSchedDequeue_tcbSchedNext_tcbSchedPrev_None_obj_at':
-  "\<lbrace>valid_sched_pointers\<rbrace>
-   tcbSchedDequeue t
-   \<lbrace>\<lambda>_ s. obj_at' (\<lambda>tcb. tcbSchedNext tcb = None \<and> tcbSchedPrev tcb = None) t s\<rbrace>"
-  unfolding tcbSchedDequeue_def
-  by (wpsimp wp: tcbQueueRemove_tcbSchedNext_tcbSchedPrev_None_obj_at' threadGet_wp)
-     (fastforce simp: ready_queue_relation_def ksReadyQueues_asrt_def obj_at'_def
-                      valid_sched_pointers_def opt_pred_def opt_map_def projectKOs
-               split: option.splits)
-
-crunch updateRestartPC, cancelIPC
-  for valid_sched_pointers[wp]: valid_sched_pointers
-  (simp: crunch_simps wp: crunch_wps)
-
-lemma setThreadState_tcbSchedNext_tcbSchedPrev_None_obj_at'[wp]:
-  "setThreadState ref ts \<lbrace>\<lambda>s. obj_at' (\<lambda>tcb. tcbSchedNext tcb = None \<and> tcbSchedPrev tcb = None) t s\<rbrace>"
-  unfolding setThreadState_def
-  apply (wpsimp wp: threadSet_wp getTCB_wp)
-  apply (fastforce simp: obj_at'_def gen_objBits_simps)
-  done
-
-lemma suspend_tcbSchedNext_tcbSchedPrev_None:
-  "\<lbrace>invs'\<rbrace> suspend t \<lbrace>\<lambda>_ s. obj_at' (\<lambda>tcb. tcbSchedNext tcb = None \<and> tcbSchedPrev tcb = None) t s\<rbrace>"
-  unfolding suspend_def
-  by (wpsimp wp: hoare_drop_imps tcbSchedDequeue_tcbSchedNext_tcbSchedPrev_None_obj_at')
-
-lemma (in delete_one_conc_pre) finaliseCap_replaceable:
-  "\<lbrace>\<lambda>s. invs' s \<and> cte_wp_at' (\<lambda>cte. cteCap cte = cap) slot s
-       \<and> (final_matters' cap \<longrightarrow> (final = isFinal cap slot (cteCaps_of s)))
-       \<and> weak_sch_act_wf (ksSchedulerAction s) s\<rbrace>
-     finaliseCap cap final flag
-   \<lbrace>\<lambda>rv s. (isNullCap (fst rv) \<and> removeable' slot s cap
-                \<and> (snd rv \<noteq> NullCap \<longrightarrow> snd rv = cap \<and> cap_has_cleanup' cap
-                                      \<and> isFinal cap slot (cteCaps_of s)))
-        \<or>
-          (isZombie (fst rv) \<and> snd rv = NullCap
-            \<and> isFinal cap slot (cteCaps_of s)
-            \<and> capClass cap = capClass (fst rv)
-            \<and> capUntypedPtr (fst rv) = capUntypedPtr cap
-            \<and> capBits (fst rv) = capBits cap
-            \<and> capRange (fst rv) = capRange cap
-            \<and> (isThreadCap cap \<or> isCNodeCap cap \<or> isZombie cap)
-            \<and> (\<forall>p \<in> threadCapRefs cap. st_tcb_at' ((=) Inactive) p s
-                     \<and> obj_at' (Not \<circ> tcbQueued) p s
-                     \<and> bound_tcb_at' ((=) None) p s
-                     \<and> obj_at' (\<lambda>tcb. tcbSchedNext tcb = None \<and> tcbSchedPrev tcb = None) p s))\<rbrace>"
-  apply (simp add: finaliseCap_def Let_def getThreadCSpaceRoot
-             cong: if_cong split del: if_split)
-  apply (rule hoare_pre)
-   apply (wp prepares_delete_helper'' [OF cancelAllIPC_unlive]
-             prepares_delete_helper'' [OF cancelAllSignals_unlive]
-             suspend_isFinal ARM.prepareThreadDelete_unqueued (* FIXME arch-split: interface *)
-             ARM.prepareThreadDelete_inactive prepareThreadDelete_isFinal
-             suspend_makes_inactive
-             deletingIRQHandler_removeable'
-             deletingIRQHandler_final[where slot=slot ]
-             unbindMaybeNotification_obj_at'_bound
-             getNotification_wp
-             suspend_bound_tcb_at'
-             unbindNotification_bound_tcb_at'
-             suspend_tcbSchedNext_tcbSchedPrev_None
-           | simp add: isZombie_Null isThreadCap_threadCapRefs_tcbptr
-                       isArchObjectCap_Cap_capCap
-           | (rule hoare_strengthen_post [OF arch_finaliseCap_removeable[where slot=slot]],
-              clarsimp simp: gen_isCap_simps)
-           | wpc)+
-
-  apply clarsimp
-  apply (frule cte_wp_at_valid_objs_valid_cap', clarsimp+)
-  apply (case_tac "cteCap cte",
-         simp_all add: gen_isCap_simps capRange_def cap_has_cleanup'_def
-                       final_matters'_def gen_objBits_simps
-                       not_Final_removeable finaliseCap_def,
-         simp_all add: removeable'_def)
-     (* thread *)
-     apply (frule capAligned_capUntypedPtr [OF valid_capAligned], simp)
-     apply (clarsimp simp: valid_cap'_def)
-     apply (drule valid_globals_cte_wpD'[rotated], clarsimp)
-     apply (clarsimp simp: invs'_def valid_state'_def valid_pspace'_def)
-    apply (clarsimp simp: obj_at'_def | rule conjI)+
-  done
-
-lemma cteDeleteOne_cte_wp_at_preserved:
-  assumes x: "\<And>cap final. P cap \<Longrightarrow> finaliseCap cap final True = fail"
-  shows "\<lbrace>\<lambda>s. cte_wp_at' (\<lambda>cte. P (cteCap cte)) p s\<rbrace>
-           cteDeleteOne ptr
-         \<lbrace>\<lambda>rv s. cte_wp_at' (\<lambda>cte. P (cteCap cte)) p s\<rbrace>"
-  apply (simp add: tree_cte_cteCap_eq[unfolded o_def])
-  apply (rule hoare_pre, wp cteDeleteOne_cteCaps_of)
-  apply (clarsimp simp: cteCaps_of_def cte_wp_at_ctes_of x)
-  done
-
-crunch cancelSignal
-  for ctes_of[wp]: "\<lambda>s. P (ctes_of s)"
-  (simp: crunch_simps wp: crunch_wps)
-
-lemma cancelIPC_cteCaps_of:
-  "\<lbrace>\<lambda>s. (\<forall>p. cte_wp_at' (\<lambda>cte. \<exists>final. finaliseCap (cteCap cte) final True \<noteq> fail) p s \<longrightarrow>
-          P ((cteCaps_of s)(p \<mapsto> NullCap))) \<and>
-     P (cteCaps_of s)\<rbrace>
-     cancelIPC t
-   \<lbrace>\<lambda>rv s. P (cteCaps_of s)\<rbrace>"
-  apply (simp add: cancelIPC_def Let_def capHasProperty_def
-                   getThreadReplySlot_def locateSlot_conv)
-  apply (rule hoare_pre)
-   apply (wp cteDeleteOne_cteCaps_of getCTE_wp' | wpcw
-        | simp add: cte_wp_at_ctes_of
-        | wp (once) hoare_drop_imps ctes_of_cteCaps_of_lift)+
-          apply (wp hoare_convert_imp hoare_vcg_all_lift
-                    threadSet_ctes_of threadSet_cteCaps_of
-               | clarsimp)+
-    apply (wp cteDeleteOne_cteCaps_of getCTE_wp' | wpcw | simp
-       | wp (once) hoare_drop_imps ctes_of_cteCaps_of_lift)+
-  apply (clarsimp simp: cte_wp_at_ctes_of cteCaps_of_def)
-  apply (drule_tac x="mdbNext (cteMDBNode x)" in spec)
-  apply clarsimp
-  apply (auto simp: o_def map_option_case fun_upd_def[symmetric])
-  done
-
-lemma cancelIPC_cte_wp_at':
-  assumes x: "\<And>cap final. P cap \<Longrightarrow> finaliseCap cap final True = fail"
-  shows "\<lbrace>\<lambda>s. cte_wp_at' (\<lambda>cte. P (cteCap cte)) p s\<rbrace>
-           cancelIPC t
-         \<lbrace>\<lambda>rv s. cte_wp_at' (\<lambda>cte. P (cteCap cte)) p s\<rbrace>"
-  apply (simp add: tree_cte_cteCap_eq[unfolded o_def])
-  apply (rule hoare_pre, wp cancelIPC_cteCaps_of)
-  apply (clarsimp simp: cteCaps_of_def cte_wp_at_ctes_of x)
-  done
-
-crunch tcbSchedDequeue
-  for cte_wp_at'[wp]: "cte_wp_at' P p"
-  (wp: crunch_wps)
-
-lemma suspend_cte_wp_at':
-  assumes x: "\<And>cap final. P cap \<Longrightarrow> finaliseCap cap final True = fail"
-  shows "\<lbrace>cte_wp_at' (\<lambda>cte. P (cteCap cte)) p\<rbrace>
-           suspend t
-         \<lbrace>\<lambda>rv. cte_wp_at' (\<lambda>cte. P (cteCap cte)) p\<rbrace>"
-  apply (simp add: suspend_def)
-  unfolding updateRestartPC_def
-  apply (rule hoare_pre)
-   apply (wp threadSet_cte_wp_at' cancelIPC_cte_wp_at'
-            | simp add: x)+
-  done
-
-context begin interpretation Arch . (*FIXME: arch-split*)
-
-crunch deleteASIDPool
-  for cte_wp_at'[wp]: "cte_wp_at' P p"
-  (simp: crunch_simps assertE_def
-   wp: crunch_wps getObject_inv loadObject_default_inv)
-
-lemma deleteASID_cte_wp_at'[wp]:
-  "\<lbrace>cte_wp_at' P p\<rbrace> deleteASID param_a param_b \<lbrace>\<lambda>_. cte_wp_at' P p\<rbrace>"
-  apply (simp add: deleteASID_def invalidateHWASIDEntry_def invalidateASID_def
-              cong: option.case_cong)
-  apply (wp setObject_cte_wp_at'[where Q="\<top>"] getObject_inv
-            loadObject_default_inv setVMRoot_cte_wp_at'
-          | clarsimp simp: updateObject_default_def in_monad
-                           projectKOs
-          | rule equals0I
-          | wpc)+
-  done
-
-crunch unmapPageTable, unmapPage, unbindNotification, finaliseCapTrue_standin
-  for cte_wp_at'[wp]: "cte_wp_at' P p"
-  (simp: crunch_simps wp: crunch_wps getObject_inv loadObject_default_inv)
-
-lemma arch_finaliseCap_cte_wp_at[wp]:
-  "\<lbrace>cte_wp_at' P p\<rbrace> Arch.finaliseCap cap fin \<lbrace>\<lambda>rv. cte_wp_at' P p\<rbrace>"
-  apply (simp add: ARM_H.finaliseCap_def)
-  apply (safe ; wpsimp wp: unmapPage_cte_wp_at')
-  done
-
-lemma deletingIRQHandler_cte_preserved:
-  assumes x: "\<And>cap final. P cap \<Longrightarrow> finaliseCap cap final True = fail"
-  shows "\<lbrace>cte_wp_at' (\<lambda>cte. P (cteCap cte)) p\<rbrace>
-           deletingIRQHandler irq
-         \<lbrace>\<lambda>rv. cte_wp_at' (\<lambda>cte. P (cteCap cte)) p\<rbrace>"
-  apply (simp add: deletingIRQHandler_def getSlotCap_def
-                   getIRQSlot_def locateSlot_conv getInterruptState_def)
-  apply (wp cteDeleteOne_cte_wp_at_preserved getCTE_wp'
-              | simp add: x)+
-  done
-
-lemma finaliseCap_equal_cap[wp]:
-  "\<lbrace>cte_wp_at' (\<lambda>cte. cteCap cte = cap) sl\<rbrace>
-     finaliseCap cap fin flag
-   \<lbrace>\<lambda>rv. cte_wp_at' (\<lambda>cte. cteCap cte = cap) sl\<rbrace>"
-  apply (simp add: finaliseCap_def Let_def
-             cong: if_cong split del: if_split)
-  apply (rule hoare_pre)
-   apply (wp suspend_cte_wp_at' deletingIRQHandler_cte_preserved
-        | clarsimp simp: finaliseCap_def | wpc)+
-  apply (case_tac cap)
-  apply auto
-  done
-
-lemma setThreadState_st_tcb_at_simplish':
-  "simple' st \<Longrightarrow>
-   \<lbrace>st_tcb_at' (P or simple') t\<rbrace>
-     setThreadState st t'
-   \<lbrace>\<lambda>rv. st_tcb_at' (P or simple') t\<rbrace>"
-  apply (wp sts_st_tcb_at'_cases)
-  apply clarsimp
-  done
-
-lemmas setThreadState_st_tcb_at_simplish
-    = setThreadState_st_tcb_at_simplish'[unfolded pred_disj_def]
-
-crunch cteDeleteOne
-  for st_tcb_at_simplish: "st_tcb_at' (\<lambda>st. P st \<or> simple' st) t"
-  (wp: crunch_wps getObject_inv loadObject_default_inv threadSet_pred_tcb_no_state
-   simp: crunch_simps unless_def)
-
-lemma cteDeleteOne_st_tcb_at[wp]:
-  assumes x[simp]: "\<And>st. simple' st \<longrightarrow> P st" shows
-  "\<lbrace>st_tcb_at' P t\<rbrace> cteDeleteOne slot \<lbrace>\<lambda>rv. st_tcb_at' P t\<rbrace>"
-  apply (subgoal_tac "\<exists>Q. P = (Q or simple')")
-   apply (clarsimp simp: pred_disj_def)
-   apply (rule cteDeleteOne_st_tcb_at_simplish)
-  apply (rule_tac x=P in exI)
-  apply (auto intro!: ext)
-  done
-
-lemma cteDeleteOne_reply_pred_tcb_at:
-  "\<lbrace>\<lambda>s. pred_tcb_at' proj P t s \<and> (\<exists>t' r. cte_wp_at' (\<lambda>cte. cteCap cte = ReplyCap t' False r) slot s)\<rbrace>
-    cteDeleteOne slot
-   \<lbrace>\<lambda>rv. pred_tcb_at' proj P t\<rbrace>"
-  apply (simp add: cteDeleteOne_def unless_def isFinalCapability_def)
-  apply (rule bind_wp [OF _ getCTE_sp])
-  apply (rule hoare_assume_pre)
-  apply (clarsimp simp: cte_wp_at_ctes_of when_def isCap_simps
-                        Let_def finaliseCapTrue_standin_def)
-  apply (intro impI conjI, (wp | simp)+)
-  done
-
-context
-notes option.case_cong_weak[cong]
-begin
-crunch cteDeleteOne, unbindNotification
-  for sch_act_simple[wp]: sch_act_simple
-  (wp: crunch_wps ssa_sch_act_simple sts_sch_act_simple getObject_inv
-       loadObject_default_inv
-   simp: crunch_simps unless_def
-   rule: sch_act_simple_lift)
-end
-
-lemma rescheduleRequired_sch_act_not[wp]:
-  "\<lbrace>\<top>\<rbrace> rescheduleRequired \<lbrace>\<lambda>rv. sch_act_not t\<rbrace>"
-  apply (simp add: rescheduleRequired_def setSchedulerAction_def)
-  apply (wp hoare_TrueI | simp)+
-  done
-
-crunch cteDeleteOne
-  for sch_act_not[wp]: "sch_act_not t"
-  (simp: crunch_simps case_Null_If unless_def
-   wp: crunch_wps getObject_inv loadObject_default_inv)
-
-lemma cancelAllIPC_mapM_x_weak_sch_act:
-  "\<lbrace>\<lambda>s. weak_sch_act_wf (ksSchedulerAction s) s\<rbrace>
-   mapM_x (\<lambda>t. do
-                 y \<leftarrow> setThreadState Structures_H.thread_state.Restart t;
-                 tcbSchedEnqueue t
-               od) q
-   \<lbrace>\<lambda>rv s. weak_sch_act_wf (ksSchedulerAction s) s\<rbrace>"
-  apply (rule mapM_x_wp_inv)
-  apply (wp)
-  apply (clarsimp)
-  done
-
-lemma cancelAllIPC_mapM_x_valid_objs':
-  "\<lbrace>valid_objs' and pspace_aligned' and pspace_distinct'\<rbrace>
-   mapM_x (\<lambda>t. do
-                 y \<leftarrow> setThreadState Structures_H.thread_state.Restart t;
-                 tcbSchedEnqueue t
-               od) q
-   \<lbrace>\<lambda>_. valid_objs'\<rbrace>"
-  apply (rule hoare_strengthen_post)
-   apply (rule mapM_x_wp')
-  apply (wpsimp wp: sts_valid_objs')
-   apply (clarsimp simp: valid_tcb_state'_def)+
-  done
-
-lemma cancelAllIPC_mapM_x_tcbDomain_obj_at':
-  "\<lbrace>obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>
-   mapM_x (\<lambda>t. do
-                 y \<leftarrow> setThreadState Structures_H.thread_state.Restart t;
-                 tcbSchedEnqueue t
-               od) q
-  \<lbrace>\<lambda>_. obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>"
-  by (wpsimp wp: mapM_x_wp')
-
-lemma rescheduleRequired_oa_queued':
-  "rescheduleRequired \<lbrace>obj_at' (\<lambda>tcb. Q (tcbDomain tcb) (tcbPriority tcb)) t\<rbrace>"
-  unfolding rescheduleRequired_def tcbSchedEnqueue_def tcbQueuePrepend_def
-  by wpsimp
-
-lemma cancelAllIPC_tcbDomain_obj_at':
-  "\<lbrace>obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>
-     cancelAllIPC epptr
-   \<lbrace>\<lambda>_. obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>"
-apply (simp add: cancelAllIPC_def)
-apply (wp hoare_vcg_conj_lift hoare_vcg_const_Ball_lift
-          rescheduleRequired_oa_queued' cancelAllIPC_mapM_x_tcbDomain_obj_at'
-          getEndpoint_wp
-     | wpc
-     | simp)+
-done
-
-lemma cancelAllSignals_tcbDomain_obj_at':
-  "\<lbrace>obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>
-     cancelAllSignals epptr
-   \<lbrace>\<lambda>_. obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>"
-apply (simp add: cancelAllSignals_def)
-apply (wp hoare_vcg_conj_lift hoare_vcg_const_Ball_lift
-          rescheduleRequired_oa_queued' cancelAllIPC_mapM_x_tcbDomain_obj_at'
-          getNotification_wp
-     | wpc
-     | simp)+
-done
-
-lemma unbindMaybeNotification_tcbDomain_obj_at':
-  "\<lbrace>obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>
-     unbindMaybeNotification r
-   \<lbrace>\<lambda>_. obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>"
-  unfolding unbindMaybeNotification_def
-  by (wpsimp wp: getNotification_wp gbn_wp' simp: setBoundNotification_def)+
-
-crunch isFinalCapability
-  for sch_act[wp]: "\<lambda>s. sch_act_wf (ksSchedulerAction s) s"
-  (simp: crunch_simps)
-
-crunch
-  isFinalCapability
-  for weak_sch_act[wp]: "\<lambda>s. weak_sch_act_wf (ksSchedulerAction s) s"
-  (simp: crunch_simps)
-
-crunch cteDeleteOne
-  for ksCurDomain[wp]: "\<lambda>s. P (ksCurDomain s)"
-  (wp: crunch_wps simp: crunch_simps unless_def)
-
-lemma cteDeleteOne_tcbDomain_obj_at':
-  "\<lbrace>obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace> cteDeleteOne slot \<lbrace>\<lambda>_. obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>"
-  apply (simp add: cteDeleteOne_def unless_def split_def)
-  apply (wp emptySlot_tcbDomain cancelAllIPC_tcbDomain_obj_at' cancelAllSignals_tcbDomain_obj_at'
-          isFinalCapability_inv getCTE_wp
-          unbindMaybeNotification_tcbDomain_obj_at'
-     | rule hoare_drop_imp
-     | simp add: finaliseCapTrue_standin_def Let_def
-            split del: if_split
-     | wpc)+
-  apply (clarsimp simp: cte_wp_at'_def)
-  done
-
-end
-
-global_interpretation delete_one_conc_pre
-  by (unfold_locales, wp) (wp cteDeleteOne_tcbDomain_obj_at' cteDeleteOne_typ_at' cteDeleteOne_reply_pred_tcb_at | simp)+
-
-context begin interpretation Arch . (*FIXME: arch-split*)
-
-lemma cteDeleteOne_invs[wp]:
-  "\<lbrace>invs'\<rbrace> cteDeleteOne ptr \<lbrace>\<lambda>rv. invs'\<rbrace>"
-  apply (simp add: cteDeleteOne_def unless_def
-                   split_def finaliseCapTrue_standin_simple_def)
-  apply wp
-    apply (rule hoare_strengthen_post)
-     apply (rule hoare_vcg_conj_lift)
-      apply (rule finaliseCap_True_invs)
-     apply (rule hoare_vcg_conj_lift)
-      apply (rule finaliseCap_replaceable[where slot=ptr])
-     apply (rule hoare_vcg_conj_lift)
-      apply (rule finaliseCap_cte_refs)
-     apply (rule finaliseCap_equal_cap[where sl=ptr])
-    apply (clarsimp simp: cte_wp_at_ctes_of)
-    apply (erule disjE)
-     apply simp
-    apply (clarsimp dest!: isCapDs simp: capRemovable_def)
-    apply (clarsimp simp: removeable'_def fun_eq_iff[where f="cte_refs' cap" for cap]
-                     del: disjCI)
-    apply (rule disjI2)
-    apply (rule conjI)
-     subgoal by auto
-    subgoal by (auto dest!: isCapDs simp: pred_tcb_at'_def obj_at'_def projectKOs
-                                          live'_def hyp_live'_def ko_wp_at'_def)
-   apply (wp isFinalCapability_inv getCTE_wp' hoare_weak_lift_imp
-        | wp (once) isFinal[where x=ptr])+
-  apply (fastforce simp: cte_wp_at_ctes_of)
-  done
-
-end
-
-global_interpretation delete_one_conc_fr: delete_one_conc
-  by unfold_locales wp
-
-declare cteDeleteOne_invs[wp]
-
-lemma deletingIRQHandler_invs' [wp]:
-  "\<lbrace>invs'\<rbrace> deletingIRQHandler i \<lbrace>\<lambda>_. invs'\<rbrace>"
-  apply (simp add: deletingIRQHandler_def getSlotCap_def
-                   getIRQSlot_def locateSlot_conv getInterruptState_def)
-  apply (wp getCTE_wp')
-  apply simp
-  done
-
-crunch unbindNotification, unbindMaybeNotification
-  for tcb_at'[wp]: "tcb_at' t"
-
-lemma finaliseCap_invs:
-  "\<lbrace>invs' and sch_act_simple and valid_cap' cap
-         and cte_wp_at' (\<lambda>cte. cteCap cte = cap) sl\<rbrace>
-     finaliseCap cap fin flag
-   \<lbrace>\<lambda>rv. invs'\<rbrace>"
-  apply (simp add: finaliseCap_def Let_def
-             cong: if_cong split del: if_split)
-  apply (rule hoare_pre)
-   apply (wp hoare_drop_imps hoare_vcg_all_lift | simp only: o_def | wpc)+
-
-  apply clarsimp
-  apply (intro conjI impI)
-    apply (clarsimp dest!: isCapDs simp: valid_cap'_def)
-   apply (drule invs_valid_global', drule(1) valid_globals_cte_wpD')
-   apply (drule valid_capAligned, drule capAligned_capUntypedPtr)
-    apply (clarsimp dest!: isCapDs)
-   apply (clarsimp dest!: isCapDs)
-  apply (clarsimp dest!: isCapDs)
-  done
-
-lemma finaliseCap_zombie_cap[wp]:
-  "\<lbrace>cte_wp_at' (\<lambda>cte. (P and isZombie) (cteCap cte)) sl\<rbrace>
-     finaliseCap cap fin flag
-   \<lbrace>\<lambda>rv. cte_wp_at' (\<lambda>cte. (P and isZombie) (cteCap cte)) sl\<rbrace>"
-  apply (simp add: finaliseCap_def Let_def
-             cong: if_cong split del: if_split)
-  apply (rule hoare_pre)
-   apply (wp suspend_cte_wp_at' deletingIRQHandler_cte_preserved
-          | clarsimp simp: finaliseCap_def gen_isCap_simps | wpc)+
-  done
-
-lemma finaliseCap_zombie_cap':
-  "\<lbrace>cte_wp_at' (\<lambda>cte. (P and isZombie) (cteCap cte)) sl\<rbrace>
-     finaliseCap cap fin flag
-   \<lbrace>\<lambda>rv. cte_wp_at' (\<lambda>cte. P (cteCap cte)) sl\<rbrace>"
-  apply (rule hoare_strengthen_post)
-   apply (rule finaliseCap_zombie_cap)
-  apply (clarsimp simp: cte_wp_at_ctes_of)
-  done
-
-lemma finaliseCap_cte_cap_wp_to[wp]:
-  "\<lbrace>ex_cte_cap_wp_to' P sl\<rbrace> finaliseCap cap fin flag \<lbrace>\<lambda>rv. ex_cte_cap_wp_to' P sl\<rbrace>"
-  apply (simp add: ex_cte_cap_to'_def)
-  apply (rule hoare_pre, rule hoare_use_eq_irq_node' [OF finaliseCap_irq_node'])
-   apply (simp add: finaliseCap_def Let_def
-              cong: if_cong split del: if_split)
-   apply (wp suspend_cte_wp_at'
-             deletingIRQHandler_cte_preserved
-             hoare_vcg_ex_lift
-                 | clarsimp simp: finaliseCap_def gen_isCap_simps
-                 | rule conjI
-                 | wpc)+
-  apply fastforce
-  done
-
-context
-notes option.case_cong_weak[cong]
-begin
-crunch unbindNotification
-  for valid_cap'[wp]: "valid_cap' cap"
-end
-
-lemma finaliseCap_valid_cap[wp]:
-  "\<lbrace>valid_cap' cap\<rbrace> finaliseCap cap final flag \<lbrace>\<lambda>rv. valid_cap' (fst rv)\<rbrace>"
-  apply (simp add: finaliseCap_def Let_def
-                   getThreadCSpaceRoot
-                   ARM_H.finaliseCap_def
-             cong: if_cong split del: if_split)
-  apply (rule hoare_pre)
-   apply (wp | simp only: valid_NullCap o_def fst_conv | wpc)+
-  apply simp
-  apply (intro conjI impI)
-   apply (clarsimp simp: valid_cap'_def gen_isCap_simps capAligned_def
-                         ARM.objBits_simps shiftL_nat)+
-  done
-
-
-context begin interpretation Arch . (*FIXME: arch-split*)
-
-crunch "Arch.finaliseCap"
+lemma arch_recycleCap_improve_cases:
+  "\<lbrakk>\<not> isPageCap cap; \<not> isPageTableCap cap; \<not> isPageDirectoryCap cap;\<not> isVCPUCap cap;
+    \<not> isASIDControlCap cap; \<not>isSGISignalCap cap \<rbrakk> \<Longrightarrow>
+   (if isASIDPoolCap cap then v else undefined) = v"
+  by (cases cap, simp_all add: isCap_simps)
+
+crunch invalidateTLBByASID
   for nosch[wp]: "\<lambda>s. P (ksSchedulerAction s)"
-  (wp: crunch_wps getObject_inv simp: loadObject_default_def updateObject_default_def)
 
-crunch finaliseCap
+crunch unmapPageTable
+  for nosch[wp]: "\<lambda>s. P (ksSchedulerAction s)"
+  (wp: crunch_wps getObject_inv hoare_vcg_all_lift hoare_vcg_if_lift3
+   simp: loadObject_default_def updateObject_default_def)
+
+context notes if_cong[cong] begin
+
+crunch Arch_finaliseCap
+  for nosch[wp]: "\<lambda>s. P (ksSchedulerAction s)"
+  (wp: crunch_wps getObject_inv simp: loadObject_default_def updateObject_default_def
+   rule: ARM_H.finaliseCap_def)
+
+end
+
+crunch deletingIRQHandler, finaliseCap
   for sch_act_simple[wp]: sch_act_simple
   (simp: crunch_simps
    rule: sch_act_simple_lift
    wp: getObject_inv loadObject_default_inv crunch_wps)
 
-end
-
-
-lemma interrupt_cap_null_or_ntfn:
-  "invs s
-    \<Longrightarrow> cte_wp_at (\<lambda>cp. is_ntfn_cap cp \<or> cp = cap.NullCap) (interrupt_irq_node s irq, []) s"
-  apply (frule invs_valid_irq_node)
-  apply (clarsimp simp: valid_irq_node_def)
-  apply (drule_tac x=irq in spec)
-  apply (drule cte_at_0)
-  apply (clarsimp simp: cte_wp_at_caps_of_state)
-  apply (drule caps_of_state_cteD)
-  apply (frule if_unsafe_then_capD, clarsimp+)
-  apply (clarsimp simp: ex_cte_cap_wp_to_def cte_wp_at_caps_of_state)
-  apply (frule cte_refs_obj_refs_elem, erule disjE)
-   apply (clarsimp | drule caps_of_state_cteD valid_global_refsD[rotated]
-     | rule irq_node_global_refs[where irq=irq])+
-   apply (simp add: cap_range_def)
-  apply (clarsimp simp: appropriate_cte_cap_def
-                 split: cap.split_asm)
-  done
-
-lemma (in delete_one) deletingIRQHandler_corres:
-  "corres dc (einvs) (invs')
-          (deleting_irq_handler irq) (deletingIRQHandler irq)"
-  apply (simp add: deleting_irq_handler_def deletingIRQHandler_def)
-  apply (rule corres_guard_imp)
-    apply (rule corres_split[OF getIRQSlot_corres])
-      apply simp
-      apply (rule_tac P'="cte_at' (cte_map slot)" in corres_symb_exec_r_conj)
-         apply (rule_tac F="isNotificationCap rv \<or> rv = capability.NullCap"
-             and P="cte_wp_at (\<lambda>cp. is_ntfn_cap cp \<or> cp = cap.NullCap) slot
-                 and einvs"
-             and P'="invs' and cte_wp_at' (\<lambda>cte. cteCap cte = rv)
-                 (cte_map slot)" in corres_req)
-          apply (clarsimp simp: cte_wp_at_caps_of_state state_relation_def)
-          apply (drule caps_of_state_cteD)
-          apply (drule(1) pspace_relation_cte_wp_at, clarsimp+)
-          apply (auto simp: cte_wp_at_ctes_of is_cap_simps gen_isCap_simps)[1]
-         apply simp
-         apply (rule corres_guard_imp, rule delete_one_corres[unfolded dc_def])
-          apply (auto simp: cte_wp_at_caps_of_state is_cap_simps can_fast_finalise_def)[1]
-         apply (clarsimp simp: cte_wp_at_ctes_of)
-        apply (wp getCTE_wp' | simp add: getSlotCap_def)+
-     apply (wp | simp add: get_irq_slot_def getIRQSlot_def
-                           locateSlot_conv getInterruptState_def)+
-   apply (clarsimp simp: ex_cte_cap_wp_to_def interrupt_cap_null_or_ntfn)
-  apply (clarsimp simp: cte_wp_at_ctes_of)
-  done
-
-context begin interpretation Arch . (*FIXME: arch-split*)
-
-lemma arch_finaliseCap_corres:
+lemma arch_finaliseCap_corres[Finalise_R_3_assms]:
   "\<lbrakk> final_matters' (ArchObjectCap cap') \<Longrightarrow> final = final'; acap_relation cap cap' \<rbrakk>
      \<Longrightarrow> corres (\<lambda>r r'. cap_relation (fst r) (fst r') \<and> cap_relation (snd r) (snd r'))
            (\<lambda>s. invs s \<and> s \<turnstile> cap.ArchObjectCap cap
@@ -3405,13 +1246,11 @@ lemma arch_finaliseCap_corres:
                  (final_matters' (ArchObjectCap cap') \<longrightarrow>
                       final' = isFinal (ArchObjectCap cap') (cte_map sl) (cteCaps_of s)))
            (arch_finalise_cap cap final) (Arch.finaliseCap cap' final')"
-  apply (cases cap;
-        clarsimp simp: arch_finalise_cap_def ARM_H.finaliseCap_def
-                       final_matters'_def case_bool_If liftM_def[symmetric]
-                       isASIDPoolCap_def isPageCap_def isPageDirectoryCap_def
-                       isPageTableCap_def
+  apply (cases cap,
+         simp_all add: arch_finalise_cap_def ARM_H.finaliseCap_def isCap_simps
+                       final_matters'_def arch_final_matters'_def case_bool_If liftM_def[symmetric]
                        o_def dc_def[symmetric]
-                split: option.split)
+                split: option.split, safe)
      apply (rule corres_guard_imp, rule deleteASIDPool_corres)
       apply (clarsimp simp: valid_cap_def mask_def)
      apply (clarsimp simp: valid_cap'_def)
@@ -3420,336 +1259,22 @@ lemma arch_finaliseCap_corres:
       apply simp
      apply (clarsimp simp: valid_cap_def valid_unmap_def)
      apply (auto simp: vmsz_aligned_def pbfs_atleast_pageBits mask_def
-                 elim: is_aligned_weaken invs_valid_asid_map)[2]
+                 elim: is_aligned_weaken)[2]
    apply (rule corres_guard_imp, rule unmapPageTable_corres)
     apply (auto simp: valid_cap_def valid_cap'_def mask_def
-               elim!: is_aligned_weaken invs_valid_asid_map)[2]
+               elim!: is_aligned_weaken)[2]
   apply (rule corres_guard_imp, rule deleteASID_corres)
-   apply (auto elim!: invs_valid_asid_map simp: mask_def valid_cap_def)[2]
+   apply (auto simp: mask_def valid_cap_def)[2]
   done
 
-lemma unbindNotification_corres:
-  "corres dc
-      (invs and tcb_at t)
-      invs'
-      (unbind_notification t)
-      (unbindNotification t)"
-  apply (simp add: unbind_notification_def unbindNotification_def)
-  apply (rule corres_guard_imp)
-    apply (rule corres_split[OF getBoundNotification_corres])
-      apply (rule corres_option_split)
-        apply simp
-       apply (rule corres_return_trivial)
-      apply (rule corres_split[OF getNotification_corres])
-        apply clarsimp
-        apply (rule corres_split[OF setNotification_corres])
-           apply (clarsimp simp: ntfn_relation_def split:Structures_A.ntfn.splits)
-          apply (rule setBoundNotification_corres)
-         apply (wp gbn_wp' gbn_wp)+
-   apply (clarsimp elim!: obj_at_valid_objsE
-                   dest!: bound_tcb_at_state_refs_ofD invs_valid_objs
-                    simp: valid_obj_def is_tcb tcb_ntfn_is_bound_def obj_at_def
-                          valid_tcb_def valid_bound_ntfn_def invs_psp_aligned invs_distinct
-                   split: option.splits)
-  apply (clarsimp dest!: obj_at_valid_objs' bound_tcb_at_state_refs_ofD' invs_valid_objs'
-                   simp: valid_obj'_def valid_tcb'_def valid_bound_ntfn'_def tcb_ntfn_is_bound'_def
-                         projectKOs
-                  split: option.splits)
-  done
+lemmas deleteCallerCap_typ_ats[wp] = typ_at_lifts[OF deleteCallerCap_typ_at']
 
-lemma unbindMaybeNotification_corres:
-  "corres dc
-      (invs and ntfn_at ntfnptr) (invs' and ntfn_at' ntfnptr)
-      (unbind_maybe_notification ntfnptr)
-      (unbindMaybeNotification ntfnptr)"
-  apply (simp add: unbind_maybe_notification_def unbindMaybeNotification_def
-              cong: option.case_cong)
-  apply (rule corres_guard_imp)
-    apply (rule corres_split[OF getNotification_corres])
-      apply (rule corres_option_split)
-        apply (clarsimp simp: ntfn_relation_def split: Structures_A.ntfn.splits)
-       apply (rule corres_return_trivial)
-      apply (rule corres_split[OF setNotification_corres])
-         apply (clarsimp simp: ntfn_relation_def split: Structures_A.ntfn.splits)
-        apply (rule setBoundNotification_corres)
-       apply (wp get_simple_ko_wp getNotification_wp)+
-   apply (clarsimp elim!: obj_at_valid_objsE
-                   dest!: bound_tcb_at_state_refs_ofD invs_valid_objs
-                    simp: valid_obj_def is_tcb tcb_ntfn_is_bound_def invs_psp_aligned invs_distinct
-                          valid_tcb_def valid_bound_ntfn_def valid_ntfn_def
-                   split: option.splits)
-  apply (clarsimp dest!: obj_at_valid_objs' bound_tcb_at_state_refs_ofD' invs_valid_objs'
-                   simp: valid_obj'_def valid_tcb'_def valid_bound_ntfn'_def
-                         tcb_ntfn_is_bound'_def valid_ntfn'_def
-                  split: option.splits)
-  done
+end (* Arch *)
 
-lemma fast_finaliseCap_corres:
-  "\<lbrakk> final_matters' cap' \<longrightarrow> final = final'; cap_relation cap cap';
-     can_fast_finalise cap \<rbrakk>
-   \<Longrightarrow> corres dc
-           (\<lambda>s. invs s \<and> valid_sched s \<and> s \<turnstile> cap
-                       \<and> cte_wp_at ((=) cap) sl s)
-           (\<lambda>s. invs' s \<and> s \<turnstile>' cap')
-           (fast_finalise cap final)
-           (do
-               p \<leftarrow> finaliseCap cap' final' True;
-               assert (capRemovable (fst p) (cte_map ptr) \<and> snd p = NullCap)
-            od)"
-  apply (cases cap, simp_all add: finaliseCap_def isCap_simps
-                                  corres_liftM2_simp[unfolded liftM_def]
-                                  o_def dc_def[symmetric] when_def
-                                  can_fast_finalise_def capRemovable_def
-                       split del: if_split cong: if_cong)
-   apply (clarsimp simp: final_matters'_def)
-   apply (rule corres_guard_imp)
-     apply (rule corres_rel_imp)
-      apply (rule ep_cancel_corres)
-     apply simp
-    apply (simp add: valid_cap_def)
-   apply (simp add: valid_cap'_def)
-  apply (clarsimp simp: final_matters'_def)
-  apply (rule corres_guard_imp)
-    apply (rule corres_split[OF unbindMaybeNotification_corres])
-         apply (rule cancelAllSignals_corres)
-       apply (wp abs_typ_at_lifts unbind_maybe_notification_invs typ_at_lifts hoare_drop_imps getNotification_wp
-            | wpc)+
-   apply (clarsimp simp: valid_cap_def)
-  apply (clarsimp simp: valid_cap'_def projectKOs valid_obj'_def
-                 dest!: invs_valid_objs' obj_at_valid_objs' )
-  done
-
-lemma cap_delete_one_corres:
-  "corres dc (einvs and cte_wp_at can_fast_finalise ptr)
-        (invs' and cte_at' (cte_map ptr))
-        (cap_delete_one ptr) (cteDeleteOne (cte_map ptr))"
-  apply (simp add: cap_delete_one_def cteDeleteOne_def'
-                   unless_def when_def)
-  apply (rule corres_guard_imp)
-    apply (rule corres_split[OF get_cap_corres])
-      apply (rule_tac F="can_fast_finalise cap" in corres_gen_asm)
-      apply (rule corres_if)
-        apply fastforce
-       apply (rule corres_split[OF isFinalCapability_corres[where ptr=ptr]])
-         apply (simp add: split_def bind_assoc [THEN sym])
-         apply (rule corres_split[OF fast_finaliseCap_corres[where sl=ptr]])
-              apply simp+
-           apply (rule emptySlot_corres, simp)
-          apply (wp hoare_drop_imps)+
-       apply (wp isFinalCapability_inv | wp (once) isFinal[where x="cte_map ptr"])+
-      apply (rule corres_trivial, simp)
-     apply (wp get_cap_wp getCTE_wp)+
-   apply (clarsimp simp: cte_wp_at_caps_of_state can_fast_finalise_Null
-                  elim!: caps_of_state_valid_cap)
-  apply (clarsimp simp: cte_wp_at_ctes_of)
-  apply fastforce
-  done
-end
-(* FIXME: strengthen locale instead *)
-
-global_interpretation delete_one
-  apply unfold_locales
-  apply (rule corres_guard_imp)
-    apply (rule cap_delete_one_corres)
-   apply auto
-  done
-
-lemma no_idle_thread_cap:
-  "\<lbrakk> cte_wp_at ((=) (cap.ThreadCap (idle_thread s))) sl s; valid_global_refs s \<rbrakk> \<Longrightarrow> False"
-  apply (cases sl)
-  apply (clarsimp simp: valid_global_refs_def valid_refs_def cte_wp_at_caps_of_state)
-  apply ((erule allE)+, erule (1) impE)
-  apply (clarsimp simp: cap_range_def)
-  done
-
-lemmas getCTE_no_0_obj'_helper
-  = getCTE_inv
-    hoare_strengthen_post[where Q'="\<lambda>_. no_0_obj'" and P=no_0_obj' and f="getCTE slot" for slot]
-
-context begin interpretation Arch . (*FIXME: arch-split*)
-context
-notes option.case_cong_weak[cong]
-begin
-crunch ThreadDecls_H.suspend, unbindNotification
-  for no_0_obj'[wp]: no_0_obj'
-  (simp: crunch_simps wp: crunch_wps getCTE_no_0_obj'_helper)
-end
-end
-
-lemma finaliseCap_corres:
-  "\<lbrakk> final_matters' cap' \<Longrightarrow> final = final'; cap_relation cap cap';
-          flag \<longrightarrow> can_fast_finalise cap \<rbrakk>
-     \<Longrightarrow> corres (\<lambda>x y. cap_relation (fst x) (fst y) \<and> cap_relation (snd x) (snd y))
-           (\<lambda>s. einvs s \<and> s \<turnstile> cap \<and> (final_matters cap \<longrightarrow> final = is_final_cap' cap s)
-                       \<and> cte_wp_at ((=) cap) sl s)
-           (\<lambda>s. invs' s \<and> s \<turnstile>' cap' \<and>
-                 (final_matters' cap' \<longrightarrow>
-                      final' = isFinal cap' (cte_map sl) (cteCaps_of s)))
-           (finalise_cap cap final) (finaliseCap cap' final' flag)"
-  supply invs_no_0_obj'[simp]
-  apply (cases cap, simp_all add: finaliseCap_def gen_isCap_simps
-                                  corres_liftM2_simp[unfolded liftM_def]
-                                  o_def dc_def[symmetric] when_def
-                                  can_fast_finalise_def
-                       split del: if_split cong: if_cong)
-        apply (clarsimp simp: final_matters'_def)
-        apply (rule corres_guard_imp)
-          apply (rule ep_cancel_corres)
-         apply (simp add: valid_cap_def)
-        apply (simp add: valid_cap'_def)
-       apply (clarsimp simp add: final_matters'_def)
-       apply (rule corres_guard_imp)
-         apply (rule corres_split[OF unbindMaybeNotification_corres])
-           apply (rule cancelAllSignals_corres)
-          apply (wp abs_typ_at_lifts unbind_maybe_notification_invs gen_typ_at_lifts hoare_drop_imps hoare_vcg_all_lift | wpc)+
-        apply (clarsimp simp: valid_cap_def)
-       apply (clarsimp simp: valid_cap'_def)
-      apply (fastforce simp: final_matters'_def shiftL_nat zbits_map_def)
-     apply (clarsimp simp add: final_matters'_def getThreadCSpaceRoot
-                               liftM_def[symmetric] o_def zbits_map_def
-                               dc_def[symmetric])
-     apply (rename_tac t)
-     apply (rule_tac P="\<lambda>s. t \<noteq> idle_thread s" and P'="\<lambda>s. t \<noteq> ksIdleThread s" in corres_add_guard)
-      apply clarsimp
-      apply (rule context_conjI)
-       apply (clarsimp dest!: no_idle_thread_cap)
-      apply (clarsimp simp: state_relation_def)
-     apply (rule corres_guard_imp)
-       apply (rule corres_split[OF unbindNotification_corres])
-         apply (rule corres_split[OF suspend_corres])
-            apply (clarsimp simp: liftM_def[symmetric] o_def dc_def[symmetric] zbits_map_def)
-          apply (rule ARM.prepareThreadDelete_corres, rule refl) (* FIXME arch-split: interface *)
-        apply (wp unbind_notification_invs unbind_notification_simple_sched_action)+
-      apply (simp add: valid_cap_def)
-     apply (simp add: valid_cap'_def)
-    apply (simp add: final_matters'_def liftM_def[symmetric]
-                     o_def dc_def[symmetric])
-    apply (intro impI, rule corres_guard_imp)
-      apply (rule deletingIRQHandler_corres)
-     apply simp
-    apply simp
-   apply (clarsimp simp: final_matters'_def)
-   apply (rule_tac F="False" in corres_req)
-    apply clarsimp
-    apply (frule zombies_finalD, (clarsimp simp: is_cap_simps)+)
-    apply (clarsimp simp: cte_wp_at_caps_of_state)
-   apply simp
-  apply (clarsimp split del: if_split simp: o_def)
-  apply (rule corres_guard_imp [OF arch_finaliseCap_corres], (fastforce simp: valid_sched_def)+)
-  done
-
-context begin interpretation Arch . (*FIXME: arch-split*)
-
-crunch copyGlobalMappings
-  for ifunsafe'[wp]: "if_unsafe_then_cap'"
-  (wp: crunch_wps ignore: storePDE)
-
-crunch copyGlobalMappings
-  for pred_tcb_at'[wp]: "pred_tcb_at' proj P t"
-  (wp: crunch_wps ignore: storePDE)
-
-crunch copyGlobalMappings
-  for vms'[wp]: "valid_machine_state'"
-  (wp: crunch_wps ignore: storePDE)
-
-crunch copyGlobalMappings
-  for ct_not_inQ[wp]: "ct_not_inQ"
-  (wp: crunch_wps ignore: storePDE)
-
-crunch copyGlobalMappings
-  for tcb_in_cur_domain'[wp]: "tcb_in_cur_domain' t"
-  (wp: crunch_wps)
-
-crunch copyGlobalMappings
-  for ct__in_cur_domain'[wp]: ct_idle_or_in_cur_domain'
-  (wp: crunch_wps)
-
-crunch copyGlobalMappings
-  for gsUntypedZeroRanges[wp]: "\<lambda>s. P (gsUntypedZeroRanges s)"
-  (wp: crunch_wps)
-
-lemma threadSet_ct_idle_or_in_cur_domain':
-  "\<lbrace>ct_idle_or_in_cur_domain' and (\<lambda>s. \<forall>tcb. tcbDomain tcb = ksCurDomain s \<longrightarrow> tcbDomain (F tcb) = ksCurDomain s)\<rbrace>
-    threadSet F t
-   \<lbrace>\<lambda>_. ct_idle_or_in_cur_domain'\<rbrace>"
-apply (simp add: ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def)
-apply (wp hoare_vcg_disj_lift hoare_vcg_imp_lift)
-  apply wps
-  apply wp
- apply wps
- apply wp
-apply (auto simp: obj_at'_def)
-done
-
-crunch invalidateTLBByASID
-  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-crunch invalidateTLBByASID
-  for valid_arch_state'[wp]: "valid_arch_state'"
-lemmas invalidateTLBByASID_typ_ats[wp] = typ_at_lifts [OF invalidateTLBByASID_typ_at']
-
-crunch invalidateTLBByASID
-  for cteCaps_of: "\<lambda>s. P (cteCaps_of s)"
-
-lemma cteCaps_of_ctes_of_lift:
-  "(\<And>P. \<lbrace>\<lambda>s. P (ctes_of s)\<rbrace> f \<lbrace>\<lambda>_ s. P (ctes_of s)\<rbrace>) \<Longrightarrow> \<lbrace>\<lambda>s. P (cteCaps_of s) \<rbrace> f \<lbrace>\<lambda>_ s. P (cteCaps_of s)\<rbrace>"
-  unfolding cteCaps_of_def .
-
-lemmas final_matters'_simps = final_matters'_def [split_simps capability.split arch_capability.split]
-
-crunch deleteCallerCap
-  for idle_thread[wp]: "\<lambda>s. P (ksIdleThread s)"
-  (wp: crunch_wps)
-crunch deleteCallerCap
-  for sch_act_simple: sch_act_simple
-  (wp: crunch_wps)
-crunch deleteCallerCap
-  for sch_act_not[wp]: "sch_act_not t"
-  (wp: crunch_wps)
-crunch deleteCallerCap
-  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  (wp: crunch_wps)
-lemmas deleteCallerCap_typ_ats[wp] = typ_at_lifts [OF deleteCallerCap_typ_at']
-
-crunch emptySlot
-  for ksQ[wp]: "\<lambda>s. P (ksReadyQueues s p)"
-
-lemma setEndpoint_sch_act_not_ct[wp]:
-  "\<lbrace>\<lambda>s. sch_act_not (ksCurThread s) s\<rbrace>
-   setEndpoint ptr val \<lbrace>\<lambda>_ s. sch_act_not (ksCurThread s) s\<rbrace>"
-  by (rule hoare_weaken_pre, wps, wp, simp)
-
-lemma sbn_ct_in_state'[wp]:
-  "\<lbrace>ct_in_state' P\<rbrace> setBoundNotification ntfn t \<lbrace>\<lambda>_. ct_in_state' P\<rbrace>"
-  apply (simp add: ct_in_state'_def)
-  apply (rule hoare_pre)
-   apply (wps setBoundNotification_ct')
-  apply (wp sbn_st_tcb', clarsimp)
-  done
-
-lemma set_ntfn_ct_in_state'[wp]:
-  "\<lbrace>ct_in_state' P\<rbrace> setNotification a ntfn \<lbrace>\<lambda>_. ct_in_state' P\<rbrace>"
-  apply (simp add: ct_in_state'_def)
-  apply (rule hoare_pre)
-   apply (wps setNotification_ksCurThread, wp, clarsimp)
-  done
-
-lemma unbindMaybeNotification_ct_in_state'[wp]:
-  "\<lbrace>ct_in_state' P\<rbrace> unbindMaybeNotification t \<lbrace>\<lambda>_. ct_in_state' P\<rbrace>"
-  apply (simp add: unbindMaybeNotification_def)
-  apply (wp | wpc | simp)+
-  done
-
-lemma setNotification_sch_act_sane:
-  "\<lbrace>sch_act_sane\<rbrace> setNotification a ntfn \<lbrace>\<lambda>_. sch_act_sane\<rbrace>"
-  by (wp sch_act_sane_lift)
-
-context
-notes option.case_cong_weak[cong]
-begin
-crunch unbindNotification, unbindMaybeNotification
-  for sch_act_sane[wp]: "sch_act_sane"
-end
-
-end
+interpretation Finalise_R_3?: Finalise_R_3 arch_final_matters' arch_cap_has_cleanup'
+proof goal_cases
+  interpret Arch  .
+  case 1 show ?case by (intro_locales; (unfold_locales; (fact Finalise_R_3_assms)?)?)
+qed
 
 end

--- a/proof/refine/ARM/ArchFinalise_R.thy
+++ b/proof/refine/ARM/ArchFinalise_R.thy
@@ -937,13 +937,9 @@ lemma archThreadSet_tcbSchedPrevNext[wp]:
   apply auto
   done
 
-context notes if_cong[cong] begin
-
 crunch asUser
   for tcbSchedPrevNext[wp]: "obj_at' (\<lambda>tcb. P (tcbSchedNext tcb) (tcbSchedPrev tcb)) t"
-  (wp: threadGet_wp)
-
-end
+  (wp: threadGet_wp cong: if_cong)
 
 crunch prepareThreadDelete
   for tcbSchedPrevNext[wp]: "obj_at' (\<lambda>tcb. P (tcbSchedNext tcb) (tcbSchedPrev tcb)) t"
@@ -1220,14 +1216,11 @@ crunch unmapPageTable
   (wp: crunch_wps getObject_inv hoare_vcg_all_lift hoare_vcg_if_lift3
    simp: loadObject_default_def updateObject_default_def)
 
-context notes if_cong[cong] begin
-
 crunch Arch_finaliseCap
   for nosch[wp]: "\<lambda>s. P (ksSchedulerAction s)"
   (wp: crunch_wps getObject_inv simp: loadObject_default_def updateObject_default_def
-   rule: ARM_H.finaliseCap_def)
-
-end
+   rule: ARM_H.finaliseCap_def
+   cong: if_cong)
 
 crunch deletingIRQHandler, finaliseCap
   for sch_act_simple[wp]: sch_act_simple

--- a/proof/refine/ARM/ArchFinalise_R.thy
+++ b/proof/refine/ARM/ArchFinalise_R.thy
@@ -4,12 +4,11 @@
  * SPDX-License-Identifier: GPL-2.0-only
  *)
 
-theory Finalise_R
+theory ArchFinalise_R
 imports
-  ArchIpcCancel_R
-  InterruptAcc_R
-  ArchRetype_R
+  Finalise_R
 begin
+
 context begin interpretation Arch . (*FIXME: arch-split*)
 
 declare doUnbindNotification_def[simp]

--- a/proof/refine/ARM/ArchIpcCancel_R.thy
+++ b/proof/refine/ARM/ArchIpcCancel_R.thy
@@ -71,7 +71,7 @@ proof -
               corres: getObject_TCB_corres setObject_update_TCB_corres')
 qed
 
-lemma prepareThreadDelete_corres[corres]:
+lemma prepareThreadDelete_corres[IpcCancel_R_assms, corres]:
   "t' = t \<Longrightarrow>
    corres dc (invs and tcb_at t) no_0_obj'
           (prepare_thread_delete t) (prepareThreadDelete t')"

--- a/proof/refine/ARM/ArchMachine_R.thy
+++ b/proof/refine/ARM/ArchMachine_R.thy
@@ -51,10 +51,8 @@ lemma dmo_maskInterrupt_True:
                    ct_not_inQ_def ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def)
   done
 
-lemma setIRQState_irq_states':
-  "\<lbrace>valid_irq_states'\<rbrace>
-      setIRQState state irq
-   \<lbrace>\<lambda>rv. valid_irq_states'\<rbrace>"
+lemma setIRQState_irq_states'[Machine_R_assms, wp]:
+  "setIRQState state irq \<lbrace>valid_irq_states'\<rbrace>"
   apply (simp add: setIRQState_def setInterruptState_def getInterruptState_def)
   apply (wp dmo_maskInterrupt)
   apply (simp add: valid_irq_masks'_def)

--- a/proof/refine/ARM/ArchTcbAcc_R.thy
+++ b/proof/refine/ARM/ArchTcbAcc_R.thy
@@ -982,15 +982,7 @@ lemma setThreadState_state_hyp_refs_of'[TcbAcc_R_2_assms, wp]:
         | wp threadSet_state_hyp_refs_of')+
   done
 
-lemma setBoundNotification_state_refs_of'[wp]:
-  "\<lbrace>\<lambda>s. P ((state_refs_of' s) (t := tcb_bound_refs' ntfn
-                                 \<union> {r \<in> state_refs_of' s t. snd r \<noteq> TCBBound}))\<rbrace>
-     setBoundNotification ntfn t
-   \<lbrace>\<lambda>rv s. P (state_refs_of' s)\<rbrace>"
-  by (simp add: setBoundNotification_def Un_commute fun_upd_def
-        | wp threadSet_state_refs_of' )+
-
-lemma setBoundNotification_state_hyp_refs_of'[wp]:
+lemma setBoundNotification_state_hyp_refs_of'[TcbAcc_R_2_assms, wp]:
   "\<lbrace>\<lambda>s. P (state_hyp_refs_of' s)\<rbrace>
      setBoundNotification ntfn t
    \<lbrace>\<lambda>rv s. P (state_hyp_refs_of' s)\<rbrace>"
@@ -1015,7 +1007,7 @@ lemma tcbQueued_update_iflive'[TcbAcc_R_2_assms, wp]:
    \<lbrace>\<lambda>_. if_live_then_nonz_cap'\<rbrace>"
   by (wpsimp wp: threadSet_iflive'T simp: update_tcb_cte_cases)
 
-lemma sbn_iflive'[wp]:
+lemma sbn_iflive'[TcbAcc_R_2_assms, wp]:
   "\<lbrace>\<lambda>s. if_live_then_nonz_cap' s
       \<and> (bound ntfn \<longrightarrow> ex_nonz_cap_to' t s)\<rbrace>
    setBoundNotification ntfn t

--- a/proof/refine/ARM/Arch_R.thy
+++ b/proof/refine/ARM/Arch_R.thy
@@ -10,7 +10,7 @@
 *)
 
 theory Arch_R
-imports Untyped_R Finalise_R
+imports Untyped_R ArchFinalise_R
 begin
 
 unbundle l4v_word_context

--- a/proof/refine/ARM/Arch_R.thy
+++ b/proof/refine/ARM/Arch_R.thy
@@ -1032,7 +1032,7 @@ shows
                in corres_gen_asm2)
         apply (rule corres_split[OF isFinalCapability_corres[where ptr=slot]])
           apply (drule mp)
-           apply (clarsimp simp: isCap_simps final_matters'_def)
+           apply (clarsimp simp: isCap_simps final_matters'_def arch_final_matters'_def)
           apply (rule whenE_throwError_corres)
             apply simp
            apply simp
@@ -1769,10 +1769,6 @@ crunch performPageDirectoryInvocation, performPageTableInvocation, performPageIn
             performASIDPoolInvocation
   for st_tcb_at': "st_tcb_at' P t"
   (wp: crunch_wps getASID_wp getObject_cte_inv simp: crunch_simps)
-
-lemmas arch_finalise_cap_aligned' = finaliseCap_aligned'
-
-lemmas arch_finalise_cap_distinct' = finaliseCap_distinct'
 
 crunch "Arch.finaliseCap"
   for st_tcb_at'[wp]: "st_tcb_at' P t"

--- a/proof/refine/ARM/CNodeInv_R.thy
+++ b/proof/refine/ARM/CNodeInv_R.thy
@@ -321,7 +321,7 @@ lemma decodeCNodeInvocation_corres:
                  apply (intro conjI)
                   apply (erule cap_map_update_data)+
                 apply (wp hoare_drop_imps)+
-          apply simp
+          apply (simp cong: if_cong)
           apply (wp lsfco_cte_at' lookup_cap_valid lookup_cap_valid')
          apply (simp add: if_apply_def2)
          apply (wp hoare_drop_imps)
@@ -5663,6 +5663,7 @@ lemma make_zombie_invs':
                                               \<and> tcbSchedPrev tcb = None) p s)) sl s\<rbrace>
     updateCap sl cap
   \<lbrace>\<lambda>rv. invs'\<rbrace>"
+  supply if_cong[cong]
   apply (simp add: invs'_def valid_state'_def valid_pspace'_def valid_mdb'_def
                    valid_irq_handlers'_def irq_issued'_def)
   apply (wp updateCap_ctes_of_wp sch_act_wf_lift valid_queues_lift cur_tcb_lift
@@ -6726,6 +6727,8 @@ lemma capSwap_rvk_prog:
   apply simp
   apply arith
   done
+
+lemmas ctes_of_cteCaps_of_lift = cteCaps_of_ctes_of_lift (* FIXME *)
 
 lemmas cancelAllIPC_cteCaps_of[wp] = ctes_of_cteCaps_of_lift [OF cancelAllIPC_ctes_of]
 lemmas cancelAllSignals_cteCaps_of[wp] = ctes_of_cteCaps_of_lift [OF cancelAllSignals_ctes_of]

--- a/proof/refine/ARM/EmptyFail_H.thy
+++ b/proof/refine/ARM/EmptyFail_H.thy
@@ -105,8 +105,7 @@ lemma ArchRetypeDecls_H_deriveCap_empty_fail[intro!, wp, simp]:
   "isPageTableCap y \<or> isPageDirectoryCap y \<or> isPageCap y
    \<or> isASIDControlCap y \<or> isASIDPoolCap y \<or> isSGISignalCap y
    \<Longrightarrow> empty_fail (Arch.deriveCap x y)"
-  apply (simp add: ARM_H.deriveCap_def)
-  by auto
+  by (auto simp: ARM_H.deriveCap_def cong: if_cong)
 
 crunch ensureNoChildren
   for (empty_fail) empty_fail[intro!, wp, simp]
@@ -265,6 +264,7 @@ crunch
 
 lemma ThreadDecls_H_schedule_empty_fail[intro!, wp, simp]:
   "empty_fail schedule"
+  supply if_cong[cong]
   apply (simp add: schedule_def)
   apply (clarsimp simp: scheduleChooseNewThread_def split: if_split | wp | wpc)+
   done

--- a/proof/refine/ARM/Interrupt_R.thy
+++ b/proof/refine/ARM/Interrupt_R.thy
@@ -706,6 +706,7 @@ lemma timerTick_corres:
   "corres dc
      (cur_tcb and valid_sched and pspace_aligned and pspace_distinct) invs'
      timer_tick timerTick"
+  supply if_cong[cong]
   apply (simp add: timerTick_def timer_tick_def)
   apply (simp add: thread_state_case_if threadState_case_if)
   apply (rule_tac Q="cur_tcb and valid_sched and pspace_aligned and pspace_distinct"

--- a/proof/refine/ARM/Ipc_R.thy
+++ b/proof/refine/ARM/Ipc_R.thy
@@ -621,6 +621,7 @@ lemma cteInsert_weak_cte_wp_at2:
     "\<lbrace>\<lambda>s. if p = dest then P cap else cte_wp_at' (\<lambda>c. P (cteCap c)) p s\<rbrace>
      cteInsert cap src dest
      \<lbrace>\<lambda>uu. cte_wp_at' (\<lambda>c. P (cteCap c)) p\<rbrace>"
+  supply if_cong[cong]
   apply (rule hoare_pre)
    apply (rule hoare_use_eq_irq_node' [OF cteInsert_ksInterruptState])
    apply (clarsimp simp:cteInsert_def)
@@ -1412,6 +1413,7 @@ lemma doNormalTransfer_corres:
    and case_option \<top> valid_ipc_buffer_ptr' recv_buf)
   (do_normal_transfer sender send_buf ep badge can_grant receiver recv_buf)
   (doNormalTransfer sender send_buf ep badge can_grant receiver recv_buf)"
+  supply if_cong[cong]
   apply (simp add: do_normal_transfer_def doNormalTransfer_def)
   apply (rule corres_guard_imp)
     apply (rule corres_split_mapr[OF getMessageInfo_corres])
@@ -2591,6 +2593,7 @@ crunch as_user
 lemma sendSignal_corres:
   "corres dc (einvs and ntfn_at ep) (invs' and ntfn_at' ep)
              (send_signal ep bg) (sendSignal ep bg)"
+  supply if_cong[cong]
   apply (simp add: send_signal_def sendSignal_def Let_def)
   apply (rule corres_guard_imp)
     apply (rule corres_split[OF getNotification_corres,
@@ -3558,6 +3561,7 @@ lemma cteInsert_cap_to':
   "\<lbrace>ex_nonz_cap_to' p and cte_wp_at' (\<lambda>c. cteCap c = NullCap) dest\<rbrace>
      cteInsert cap src dest
    \<lbrace>\<lambda>rv. ex_nonz_cap_to' p\<rbrace>"
+  supply if_cong[cong]
   apply (simp add: cteInsert_def ex_nonz_cap_to'_def updateCap_def setUntypedCapAsFull_def)
   apply (wpsimp wp: updateMDB_weak_cte_wp_at setCTE_weak_cte_wp_at hoare_vcg_ex_lift
          | rule hoare_drop_imps
@@ -3612,9 +3616,13 @@ crunch setupCallerCap
   for irq_states'[wp]: valid_irq_states'
   (wp: crunch_wps)
 
+context notes if_cong[cong] begin
+
 crunch setupCallerCap
   for pde_mappings'[wp]: valid_pde_mappings'
   (wp: crunch_wps)
+
+end
 
 crunch receiveIPC
   for irqs_masked'[wp]: "irqs_masked'"
@@ -4023,6 +4031,7 @@ lemma si_invs'[wp]:
   sendIPC bl call ba cg cgr t ep
   \<lbrace>\<lambda>rv. invs'\<rbrace>"
   supply if_split[split del]
+  supply if_cong[cong]
   apply (simp add: sendIPC_def split del: if_split)
   apply (rule bind_wp [OF _ get_ep_sp'])
   apply (case_tac epa)

--- a/proof/refine/ARM/Ipc_R.thy
+++ b/proof/refine/ARM/Ipc_R.thy
@@ -3616,13 +3616,9 @@ crunch setupCallerCap
   for irq_states'[wp]: valid_irq_states'
   (wp: crunch_wps)
 
-context notes if_cong[cong] begin
-
 crunch setupCallerCap
   for pde_mappings'[wp]: valid_pde_mappings'
-  (wp: crunch_wps)
-
-end
+  (wp: crunch_wps cong: if_cong)
 
 crunch receiveIPC
   for irqs_masked'[wp]: "irqs_masked'"

--- a/proof/refine/ARM/Ipc_R.thy
+++ b/proof/refine/ARM/Ipc_R.thy
@@ -5,7 +5,7 @@
  *)
 
 theory Ipc_R
-imports Finalise_R
+imports ArchFinalise_R
 begin
 
 context begin interpretation Arch . (*FIXME: arch-split*)

--- a/proof/refine/ARM/PageTableDuplicates.thy
+++ b/proof/refine/ARM/PageTableDuplicates.thy
@@ -85,6 +85,7 @@ lemma mapM_x_storePTE_updates:
      \<and> Q (\<lambda>x. if (x \<in> set xs) then Some (KOArch (KOPTE pte)) else (ksPSpace s) x) \<rbrace>
      mapM_x (swp storePTE pte) xs
    \<lbrace>\<lambda>r s. Q (ksPSpace s)\<rbrace>"
+  supply if_cong[cong]
   apply (induct xs)
    apply (simp add: mapM_x_Nil)
   apply (simp add: mapM_x_Cons)
@@ -381,6 +382,7 @@ lemma mapM_x_storePDE_updates:
      \<and> Q (\<lambda>x. if (x \<in> set xs) then Some (KOArch (KOPDE pte)) else (ksPSpace s) x) \<rbrace>
      mapM_x (swp storePDE pte) xs
    \<lbrace>\<lambda>r s. Q (ksPSpace s)\<rbrace>"
+  supply if_cong[cong]
   apply (induct xs)
    apply (simp add: mapM_x_Nil)
   apply (simp add: mapM_x_Cons)
@@ -1104,6 +1106,7 @@ lemma createObject_valid_duplicates'[wp]:
    apply (rule none_in_new_cap_addrs[where us =12,simplified]
      ,(simp add: objBits_simps pageBits_def word_bits_conv archObjSize_def pdeBits_def)+)[1]
   supply APIType_capBits_generic[simp del]
+  supply if_cong[cong]
   apply (intro conjI impI allI)
       apply simp
      apply clarsimp

--- a/proof/refine/ARM/Syscall_R.thy
+++ b/proof/refine/ARM/Syscall_R.thy
@@ -1354,12 +1354,9 @@ crunch rescheduleRequired
   for valid_duplicates'[wp]: "\<lambda>s. vs_valid_duplicates' (ksPSpace s)"
   (wp: setObject_ksInterrupt updateObject_default_inv)
 
-context notes if_cong[cong] begin
-
 crunch setThreadState
   for valid_duplicates'[wp]: "\<lambda>s. vs_valid_duplicates' (ksPSpace s)"
-
-end
+  (cong: if_cong)
 
 crunch reply_from_kernel
   for pspace_aligned[wp]: pspace_aligned

--- a/proof/refine/ARM/Syscall_R.thy
+++ b/proof/refine/ARM/Syscall_R.thy
@@ -662,6 +662,7 @@ lemma pinv_tcb'[wp]:
 
 lemma sts_cte_at[wp]:
   "\<lbrace>cte_at' p\<rbrace> setThreadState st t \<lbrace>\<lambda>rv. cte_at' p\<rbrace>"
+  supply if_cong[cong]
   apply (simp add: setThreadState_def)
   apply (wp|simp)+
   done
@@ -675,6 +676,7 @@ lemma sts_mcpriority_tcb_at'[wp]:
   "\<lbrace>mcpriority_tcb_at' P t\<rbrace>
     setThreadState st t'
    \<lbrace>\<lambda>_. mcpriority_tcb_at' P t\<rbrace>"
+  supply if_cong[cong]
   apply (cases "t = t'",
          simp_all add: setThreadState_def
                   split del: if_split)
@@ -748,6 +750,7 @@ lemma decodeDomainSetStart_inv_wf[wp]:
 lemma decodeDomainConfigure_inv_wf[wp]:
   "\<lbrace>\<top>\<rbrace> decodeDomainConfigure args excaps \<lbrace>valid_domain_inv'\<rbrace>, -"
   unfolding decodeDomainConfigure_def
+  supply if_cong[cong]
   apply (wpsimp simp: valid_domain_inv'_def split_del: if_split)
   apply (clarsimp simp: not_less not_le le_maxDomain_eq_less_numDomains unat_ucast)
   using numDomains_fits_domainBits
@@ -1351,8 +1354,12 @@ crunch rescheduleRequired
   for valid_duplicates'[wp]: "\<lambda>s. vs_valid_duplicates' (ksPSpace s)"
   (wp: setObject_ksInterrupt updateObject_default_inv)
 
+context notes if_cong[cong] begin
+
 crunch setThreadState
   for valid_duplicates'[wp]: "\<lambda>s. vs_valid_duplicates' (ksPSpace s)"
+
+end
 
 crunch reply_from_kernel
   for pspace_aligned[wp]: pspace_aligned

--- a/proof/refine/ARM/orphanage/Orphanage.thy
+++ b/proof/refine/ARM/orphanage/Orphanage.thy
@@ -478,6 +478,7 @@ lemma setThreadState_not_is_active_thread_state_no_orphans:
    setThreadState state tcb_ptr
    \<lbrace>\<lambda>_ . no_orphans\<rbrace>"
   unfolding setThreadState_def
+  supply if_cong[cong]
   apply (wpsimp wp: ssa_no_orphans)
    apply (unfold no_orphans_disj almost_no_orphans_disj)
    apply (wp hoare_vcg_all_lift hoare_vcg_disj_lift threadSet_pred_tcb_at_state
@@ -498,6 +499,7 @@ lemma setThreadState_almost_no_orphans [wp]:
 lemma setThreadState_not_active_no_orphans:
   "\<not> is_active_thread_state state \<Longrightarrow> setThreadState state tcb_ptr \<lbrace>no_orphans\<rbrace>"
   unfolding setThreadState_def
+  supply if_cong[cong]
   apply (wpsimp wp: ssa_no_orphans)
    apply (unfold no_orphans_disj)
    apply (wp hoare_vcg_all_lift hoare_vcg_disj_lift threadSet_pred_tcb_at_state
@@ -508,6 +510,7 @@ lemma setThreadState_not_active_no_orphans:
 lemma setThreadState_not_active_almost_no_orphans:
   "\<not> is_active_thread_state state \<Longrightarrow> setThreadState state tcb_ptr \<lbrace>almost_no_orphans thread\<rbrace>"
   unfolding setThreadState_def
+  supply if_cong[cong]
   apply (wpsimp wp: ssa_no_orphans)
    apply (unfold almost_no_orphans_disj)
    apply (wp hoare_vcg_all_lift hoare_vcg_disj_lift threadSet_pred_tcb_at_state
@@ -570,6 +573,7 @@ lemma tcbSchedDequeue_no_orphans[wp]:
    tcbSchedDequeue tcbPtr
    \<lbrace>\<lambda>_. no_orphans\<rbrace>"
   supply disj_not1[simp del]
+  supply if_cong[cong]
   unfolding no_orphans_disj almost_no_orphans_disj
   apply (rule hoare_allI)
   apply (rename_tac tcb_ptr)
@@ -712,6 +716,7 @@ lemma chooseThread_no_orphans [wp]:
   (is "\<lbrace>?PRE\<rbrace> _ \<lbrace>_\<rbrace>")
   unfolding chooseThread_def Let_def
   supply if_split[split del]
+  supply if_cong[cong]
   apply (simp only: return_bind, simp)
   apply (intro bind_wp[OF _ stateAssert_sp])
   apply (rule bind_wp[where Q'="\<lambda>rv s. ?PRE s \<and> ksReadyQueues_asrt s \<and> ready_qs_runnable s
@@ -1313,7 +1318,7 @@ lemma unbindNotification_no_orphans[wp]:
   "\<lbrace>\<lambda>s. no_orphans s\<rbrace>
     unbindNotification t
    \<lbrace> \<lambda>rv s. no_orphans s\<rbrace>"
-  unfolding unbindNotification_def
+  unfolding unbindNotification_def doUnbindNotification_def
   apply (rule bind_wp[OF _ gbn_sp'])
   apply (case_tac ntfnPtr, simp_all, wp, simp)
   apply (rule bind_wp[OF _ get_ntfn_sp'])
@@ -1324,7 +1329,7 @@ lemma unbindMaybeNotification_no_orphans[wp]:
   "\<lbrace>\<lambda>s. no_orphans s\<rbrace>
     unbindMaybeNotification a
    \<lbrace> \<lambda>rv s. no_orphans s\<rbrace>"
-  unfolding unbindMaybeNotification_def
+  unfolding unbindMaybeNotification_def doUnbindNotification_def
   by (wp getNotification_wp | simp | wpc)+
 
 lemma finaliseCapTrue_standin_no_orphans[wp]:

--- a/proof/refine/ARM_HYP/ArchFinalise_R.thy
+++ b/proof/refine/ARM_HYP/ArchFinalise_R.thy
@@ -1,33 +1,21 @@
 (*
- * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ * Copyright 2014, General Dynamics C4 Systems
  *
  * SPDX-License-Identifier: GPL-2.0-only
  *)
 
-theory Finalise_R
+theory ArchFinalise_R
 imports
-  ArchIpcCancel_R
-  InterruptAcc_R
-  ArchRetype_R
+  Finalise_R
 begin
 
 context begin interpretation Arch . (*FIXME: arch-split*)
 
 declare doUnbindNotification_def[simp]
 
-crunch copyGlobalMappings
-  for ifunsafe'[wp]: "if_unsafe_then_cap'"
-  and pred_tcb_at'[wp]: "pred_tcb_at' proj P t"
-  and vms'[wp]: "valid_machine_state'"
-  and ct_not_inQ[wp]: "ct_not_inQ"
-  and tcb_in_cur_domain'[wp]: "tcb_in_cur_domain' t"
-  and ct__in_cur_domain'[wp]: ct_idle_or_in_cur_domain'
-  and gsUntypedZeroRanges[wp]: "\<lambda>s. P (gsUntypedZeroRanges s)"
-  and gsMaxObjectSize[wp]: "\<lambda>s. P (gsMaxObjectSize s)"
-  and it'[wp]: "\<lambda>s. P (ksIdleThread s)"
-  and valid_irq_states'[wp]: "valid_irq_states'"
-  and ksDomScheduleIdx[wp]: "\<lambda>s. P (ksDomScheduleIdx s)"
-  (wp: crunch_wps ignore: storePTE)
+lemma isArchSGISignalCap_NullCap[simp]:
+  "\<not>isArchSGISignalCap NullCap"
+  by (simp add: isCap_simps)
 
 text \<open>Properties about empty_slot/emptySlot\<close>
 
@@ -36,11 +24,9 @@ lemma case_Null_If:
   by (case_tac c, simp_all)
 
 crunch emptySlot
-  for aligned'[wp]: pspace_aligned'
-  and pspace_canonical'[wp]: pspace_canonical'
-  and pspace_in_kernel_mappings'[wp]: pspace_in_kernel_mappings'
-  and distinct'[wp]: pspace_distinct'
-  (simp: case_Null_If)
+  for aligned'[wp]: pspace_aligned' (simp: case_Null_If)
+crunch emptySlot
+  for distinct'[wp]: pspace_distinct' (simp: case_Null_If)
 
 lemma updateCap_cte_wp_at_cases:
   "\<lbrace>\<lambda>s. (ptr = ptr' \<longrightarrow> cte_wp_at' (P \<circ> cteCap_update (K cap)) ptr' s) \<and> (ptr \<noteq> ptr' \<longrightarrow> cte_wp_at' P ptr' s)\<rbrace>
@@ -81,7 +67,10 @@ lemma emptySlot_cte_wp_cap_other:
               | wp (once) hoare_drop_imps)+
   done
 
-lemmas clearUntypedFreeIndex_typ_ats[wp] = typ_at_lifts[OF clearUntypedFreeIndex_typ_at']
+crunch emptySlot
+  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
+lemmas clearUntypedFreeIndex_typ_ats[wp]
+    = typ_at_lifts[OF clearUntypedFreeIndex_typ_at']
 
 crunch postCapDeletion
   for tcb_at'[wp]: "tcb_at' t"
@@ -141,14 +130,20 @@ crunch setInterruptState
 crunch emptySlot
   for state_refs_of'[wp]: "\<lambda>s. P (state_refs_of' s)"
   (wp: crunch_wps)
+crunch setInterruptState
+  for state_hyp_refs_of'[wp]: "\<lambda>s. P (state_hyp_refs_of' s)"
+  (simp: state_hyp_refs_of'_pspaceI)
+crunch emptySlot
+  for state_hyp_refs_of'[wp]: "\<lambda>s. P (state_hyp_refs_of' s)"
+  (wp: crunch_wps)
 
 lemma mdb_chunked2D:
   "\<lbrakk> mdb_chunked m; m \<turnstile> p \<leadsto> p'; m \<turnstile> p' \<leadsto> p'';
      m p = Some (CTE cap nd); m p'' = Some (CTE cap'' nd'');
-     sameRegionAs cap cap''; p \<noteq> p'' \<rbrakk>
+     sameRegionAs cap cap''; p \<noteq> p''; mdb_chunked_arch_assms cap \<rbrakk>
      \<Longrightarrow> \<exists>cap' nd'. m p' = Some (CTE cap' nd') \<and> sameRegionAs cap cap'"
   apply (subgoal_tac "\<exists>cap' nd'. m p' = Some (CTE cap' nd')")
-   apply (clarsimp simp add: mdb_chunked_def mdb_chunked_arch_assms_def) (* FIXME arch-split; take AARCH64 version *)
+   apply (clarsimp simp add: mdb_chunked_def)
    apply (drule spec[where x=p])
    apply (drule spec[where x=p''])
    apply clarsimp
@@ -163,8 +158,7 @@ lemma mdb_chunked2D:
   apply (case_tac z, simp)
   done
 
-lemma nullPointer_eq_0_simp[simp]:
-  "(nullPointer = 0) = True"
+lemma nullPointer_eq_0_simp[simp]: (* FIXME: move to nullPointer_0_simp in Retype_R *)
   "(0 = nullPointer) = True"
   by (simp add: nullPointer_def)+
 
@@ -487,7 +481,7 @@ lemma caps_contained_n:
 
 lemma chunked:
   "mdb_chunked m"
-  using valid by (simp add: valid_mdb_ctes_def)
+  using valid ..
 
 lemma valid_badges:
   "valid_badges m"
@@ -499,8 +493,22 @@ proof -
   from valid_badges
   show ?thesis
     supply if_cong[cong]
-    apply (simp add: valid_badges_def2 valid_arch_badges_def) (* FIXME arch-split; take AARCH64 version *)
+    apply (simp add: valid_badges_def2)
     apply clarsimp
+    apply (rule conjI)
+     prefer 2
+     apply (drule_tac p=p in n_cap)
+     apply (frule n_cap)
+     apply (drule n_badged)
+     apply (clarsimp simp: n_next_eq)
+     apply (case_tac "p=slot", simp)
+     apply clarsimp
+     apply (case_tac "p'=slot", simp add: isCap_simps)
+     apply clarsimp
+     apply (case_tac "p = mdbPrev s_node")
+      apply (clarsimp simp: valid_arch_badges_def)
+      apply blast
+     apply (fastforce simp: valid_arch_badges_def)
     apply (drule_tac p=p in n_cap)
     apply (frule n_cap)
     apply (drule n_badged)
@@ -508,21 +516,22 @@ proof -
     apply (case_tac "p=slot", simp)
     apply clarsimp
     apply (case_tac "p'=slot", simp)
-    apply clarsimp
+     apply clarsimp
     apply (case_tac "p = mdbPrev s_node")
      apply clarsimp
      apply (insert slot)[1]
-     (* using mdb_chunked to show cap in between is same as on either side *)
+      (* using mdb_chunked to show cap in between is same as on either side *)
      apply (subgoal_tac "capMasterCap s_cap = capMasterCap cap'")
       prefer 2
       apply (thin_tac "\<forall>p. P p" for P)
       apply (drule mdb_chunked2D[OF chunked])
-           apply (fastforce simp: mdb_next_unfold)
-          apply assumption+
-        apply (simp add: sameRegionAs_def3)
-        apply (intro disjI1)
-        apply (fastforce simp:isCap_simps capMasterCap_def arch_capBadge_def split:capability.splits)
-       apply clarsimp
+            apply (fastforce simp: mdb_next_unfold)
+           apply assumption+
+         apply (simp add: sameRegionAs_def3)
+         apply (intro disjI1)
+         apply (fastforce simp:isCap_simps capMasterCap_def arch_capBadge_def split:capability.splits)
+        apply clarsimp
+       apply (clarsimp simp: isCap_simps mdb_chunked_arch_assms_def)
       apply clarsimp
       apply (erule sameRegionAsE, auto simp: isCap_simps capMasterCap_def split:capability.splits)[1]
      (* instantiating known valid_badges on both sides to transitively
@@ -572,9 +581,8 @@ lemma n_parent_of:
   apply (frule_tac p=p' in n_cap)
   apply (frule_tac p=p' in n_badged)
   apply (drule_tac p=p' in n_revokable)
-  apply (clarsimp split: if_split_asm;
-         clarsimp simp: isMDBParentOf_def isCap_simps split: if_split_asm cong: if_cong)
-  done
+  apply (clarsimp split: if_split_asm)
+  by (auto simp: isMDBParentOf_def isArchMDBParentOf_def2 isCap_simps split: if_split_asm)
 
 lemma m_parent_of:
   "\<lbrakk> m \<turnstile> p parentOf p'; p \<noteq> slot; p' \<noteq> slot; p\<noteq>p'; p'\<noteq>mdbNext s_node \<rbrakk> \<Longrightarrow> n \<turnstile> p parentOf p'"
@@ -591,7 +599,9 @@ lemma m_parent_of:
   apply (drule_tac p=p' in m_revokable)
   apply clarsimp
   apply (simp split: if_split_asm;
-         clarsimp simp: isMDBParentOf_def isCap_simps split: if_split_asm cong: if_cong)
+         clarsimp simp: isMDBParentOf_def isArchMDBParentOf_def2 isCap_simps
+                  split: if_split_asm
+                  cong: if_cong)
   done
 
 lemma m_parent_of_next:
@@ -610,13 +620,37 @@ lemma m_parent_of_next:
   apply (frule_tac p="slot" in m_cap)
   apply (frule_tac p="slot" in m_badged)
   apply (drule_tac p="slot" in m_revokable)
-  apply (clarsimp simp: isMDBParentOf_def isCap_simps split: if_split_asm cong: if_cong)
+  by (auto simp: isMDBParentOf_def isArchMDBParentOf_def2 isCap_simps
+           split: if_split_asm cong: if_cong)
+
+lemma n_mdbNext:
+  "\<lbrakk> n (mdbNext s_node) = Some (CTE cap node); mdbPrev s_node \<noteq> 0 \<rbrakk> \<Longrightarrow>
+  \<exists>node'. m (mdbNext s_node) = Some (CTE cap node') \<and>
+          mdbNext node = mdbNext node' \<and>
+          mdbPrev node = mdbPrev s_node \<and>
+          mdbRevocable node = mdbRevocable node' \<and>
+          (mdbFirstBadged node = mdbFirstBadged node' \<or> mdbFirstBadged s_node)"
+  apply (clarsimp simp: n_def modify_map_def)
+  apply (case_tac z)
+  apply clarsimp
+  done
+
+lemma n_mdbPrev:
+  "\<lbrakk> n (mdbPrev s_node) = Some (CTE cap node); mdbNext s_node \<noteq> 0 \<rbrakk> \<Longrightarrow>
+    \<exists>node'. m (mdbPrev s_node) = Some (CTE cap node') \<and>
+          mdbNext node = mdbNext s_node \<and>
+          mdbPrev node = mdbPrev node' \<and>
+          mdbRevocable node = mdbRevocable node' \<and>
+          (mdbFirstBadged node = mdbFirstBadged node')"
+  apply (clarsimp simp: n_def modify_map_def)
+  apply (case_tac z)
+  apply clarsimp
   done
 
 lemma parency_n:
   assumes "n \<turnstile> p \<rightarrow> p'"
   shows "m \<turnstile> p \<rightarrow> p' \<and> p \<noteq> slot \<and> p' \<noteq> slot"
-using assms
+  using assms
 proof induct
   case (direct_parent c')
   moreover
@@ -635,38 +669,65 @@ proof induct
      apply (erule (2) n_parent_of)
     apply clarsimp
     apply (frule n_parent_of, simp, simp)
-    apply (rule subtree.trans_parent[OF _ m_slot_next], simp_all)
-    apply (rule subtree.direct_parent)
-      apply (erule prev_slot_next)
-     apply simp
-    apply (clarsimp simp: parentOf_def slot)
-    apply (case_tac cte'a)
-    apply (case_tac ctea)
+    apply (prop_tac "\<exists>prev_cap prev_node. m (mdbPrev s_node) = Some (CTE prev_cap prev_node)")
+     apply (clarsimp simp: parentOf_def, case_tac cte'a, clarsimp)
     apply clarsimp
-    apply (frule(2) mdb_chunked2D [OF chunked prev_slot_next m_slot_next])
-      apply (clarsimp simp: isMDBParentOf_CTE)
-     apply simp
-    apply (simp add: slot)
-    apply (clarsimp simp add: isMDBParentOf_CTE)
-    apply (insert valid_badges)
-    apply (simp add: valid_badges_def2)
-    apply (drule spec[where x=slot])
-    apply (drule spec[where x="mdbNext s_node"])
-    apply (simp add: slot m_slot_next)
-    apply (insert valid_badges)
-    apply (simp add: valid_badges_def2)
-    apply (drule spec[where x="mdbPrev s_node"])
-    apply (drule spec[where x=slot])
-    apply (simp add: slot prev_slot_next)
-    apply (case_tac cte, case_tac cte')
-    apply (rename_tac cap'' node'')
-    apply (clarsimp simp: isMDBParentOf_CTE)
-    apply (frule n_cap, drule n_badged)
-    apply (frule n_cap, drule n_badged)
-    apply clarsimp
-    apply (case_tac cap'', simp_all add: isCap_simps arch_capBadge_def)[1]
+    apply (case_tac "isArchSGISignalCap prev_cap")
+     prefer 2
+     apply (rule subtree.trans_parent[OF _ m_slot_next], simp_all)
+     apply (rule subtree.direct_parent)
+       apply (erule prev_slot_next)
+      apply simp
+     apply (clarsimp simp: parentOf_def slot)
+     apply (case_tac cte, rename_tac next_cap next_node)
+     apply clarsimp
+     apply (frule(2) mdb_chunked2D [OF chunked prev_slot_next m_slot_next])
+        apply (clarsimp simp: isMDBParentOf_CTE)
+       apply simp
+      apply (simp add: mdb_chunked_arch_assms_def)
+     apply (simp add: slot)
+     apply (clarsimp simp add: isMDBParentOf_CTE)
+     apply (insert valid_badges)[1]
+     apply (simp add: valid_badges_def2)
+     apply (drule spec[where x=slot])
+     apply (drule spec[where x="mdbNext s_node"])
+     apply (simp add: slot m_slot_next)
+     apply (insert valid_badges)[1]
+     apply (simp add: valid_badges_def2)
+     apply (drule spec[where x="mdbPrev s_node"])
+     apply (drule spec[where x=slot])
+     apply (simp add: slot prev_slot_next)
+     apply (case_tac ctea, case_tac cte')
+     apply (rename_tac cap'' node'')
+     apply (clarsimp simp: isMDBParentOf_CTE)
+     apply (frule n_cap, drule n_badged)
+     apply (frule n_cap, drule n_badged)
+     apply clarsimp
+     apply (case_tac cap'', simp_all add: isCap_simps)[1]
+      apply (clarsimp simp: sameRegionAs_def3 isCap_simps)
      apply (clarsimp simp: sameRegionAs_def3 isCap_simps)
-    apply (clarsimp simp: sameRegionAs_def3 isCap_simps)
+    (* SGISignalCap *)
+    apply (clarsimp simp: parentOf_def isCap_simps isMDBParentOf_CTE arch_capBadge_def)
+    apply (rename_tac next_node)
+    apply (rule subtree.trans_parent[OF _ m_slot_next], simp_all)
+     apply (rule subtree.direct_parent)
+       apply (erule prev_slot_next)
+      apply simp
+     apply (clarsimp simp: parentOf_def slot isMDBParentOf_CTE)
+    apply (clarsimp simp: parentOf_def slot isMDBParentOf_CTE isCap_simps)
+    apply (cases "mdbFirstBadged s_node", simp)
+     apply (case_tac ctea, case_tac cte', clarsimp)
+     apply (frule n_cap, drule n_badged)
+     apply (frule n_cap, drule n_badged)
+     apply clarsimp
+     apply (rename_tac prev_node' next_node')
+     apply (clarsimp simp: isMDBParentOf_CTE isCap_simps)
+    apply simp
+    apply (insert valid_badges)[1]
+    apply (clarsimp simp: valid_badges_def)
+    apply (erule_tac x="slot" in allE)
+    apply (erule_tac x="mdbNext s_node" in allE)
+    apply (simp add: slot m_p_next isCap_simps valid_arch_badges_def)
     done
 next
   case (trans_parent c c')
@@ -696,55 +757,67 @@ next
        apply (rename_tac cap node)
        apply (case_tac ctea)
        apply clarsimp
-       apply (subgoal_tac "sameRegionAs cap s_cap")
-        prefer 2
-        apply (insert chunked)[1]
-        apply (simp add: mdb_chunked_def)
-        apply (erule_tac x="p" in allE)
-        apply (erule_tac x="mdbNext s_node" in allE)
-        apply simp
-        apply (drule isMDBParent_sameRegion)+
-        apply clarsimp
-        apply (subgoal_tac "m \<turnstile> p \<leadsto>\<^sup>+ slot")
-         prefer 2
-         apply (rule trancl_trans)
-          apply (erule subtree_mdb_next)
-         apply (rule r_into_trancl)
-         apply (rule prev_slot_next)
+       apply (case_tac "\<not>isArchSGISignalCap cap")
+        apply (prop_tac "sameRegionAs cap s_cap")
+         apply (insert chunked)[1]
+         apply (simp add: mdb_chunked_def)
+         apply (erule_tac x="p" in allE)
+         apply (erule_tac x="mdbNext s_node" in allE)
+         apply simp
+         apply (drule isMDBParent_sameRegion)+
          apply clarsimp
-        apply (subgoal_tac "m \<turnstile> p \<leadsto>\<^sup>+ mdbNext s_node")
-         prefer 2
-         apply (erule trancl_trans)
-         apply fastforce
-        apply (simp add: mdb_chunked_arch_assms_def)
-        apply (erule impE)
+         apply (prop_tac "m \<turnstile> p \<leadsto>\<^sup>+ slot")
+          apply (rule trancl_trans)
+           apply (erule subtree_mdb_next)
+          apply (rule r_into_trancl)
+          apply (rule prev_slot_next)
+          apply clarsimp
+         apply (prop_tac "m \<turnstile> p \<leadsto>\<^sup>+ mdbNext s_node")
+          apply (erule trancl_trans)
+          apply fastforce
+         apply (simp add: mdb_chunked_arch_assms_def)
+         apply (erule impE)
+          apply clarsimp
          apply clarsimp
-        apply clarsimp
-        apply (thin_tac "s \<longrightarrow> t" for s t)
-        apply (simp add: is_chunk_def)
-        apply (erule_tac x=slot in allE)
-        apply (erule impE, fastforce)
-        apply (erule impE, fastforce)
-        apply (clarsimp simp: slot)
-       apply (clarsimp simp: isMDBParentOf_CTE)
-       apply (insert valid_badges, simp add: valid_badges_def2)
-       apply (drule spec[where x=slot], drule spec[where x="mdbNext s_node"])
-       apply (simp add: slot m_slot_next)
+         apply (thin_tac "s \<longrightarrow> t" for s t)
+         apply (simp add: is_chunk_def)
+         apply (erule_tac x=slot in allE)
+         apply (erule impE, fastforce)
+         apply (erule impE, fastforce)
+         apply (clarsimp simp: slot)
+        apply (clarsimp simp: isMDBParentOf_CTE)
+        apply (insert valid_badges, simp add: valid_badges_def2)[1]
+        apply (drule spec[where x=slot], drule spec[where x="mdbNext s_node"])
+        apply (simp add: slot m_slot_next)
+        apply (case_tac cte, case_tac cte')
+        apply (rename_tac cap'' node'')
+        apply (clarsimp simp: isMDBParentOf_CTE)
+        apply (frule n_cap, drule n_badged)
+        apply (frule n_cap, drule n_badged)
+        apply (clarsimp split: if_split_asm)
+         apply (drule subtree_mdb_next)
+         apply (drule no_loops_tranclE[OF no_loops])
+         apply (erule notE, rule trancl_into_rtrancl)
+         apply (rule trancl.intros(2)[OF _ m_slot_next])
+         apply (rule trancl.intros(1), rule prev_slot_next)
+         apply simp
+        apply (case_tac cap'', simp_all add: isCap_simps)[1]
+         apply (clarsimp simp: sameRegionAs_def3 isCap_simps)
+        apply (clarsimp simp: sameRegionAs_def3 isCap_simps)
+       (* SGISignalCap *)
+       apply (rename_tac next_cap next_node)
+       apply (clarsimp simp: isCap_simps arch_capBadge_def)
        apply (case_tac cte, case_tac cte')
        apply (rename_tac cap'' node'')
        apply (clarsimp simp: isMDBParentOf_CTE)
        apply (frule n_cap, drule n_badged)
        apply (frule n_cap, drule n_badged)
-       apply (clarsimp split: if_split_asm)
-        apply (drule subtree_mdb_next)
-        apply (drule no_loops_tranclE[OF no_loops])
-        apply (erule notE, rule trancl_into_rtrancl)
-        apply (rule trancl.intros(2)[OF _ m_slot_next])
-        apply (rule trancl.intros(1), rule prev_slot_next)
-        apply simp
-       apply (case_tac cap'', simp_all add: isCap_simps arch_capBadge_def)[1]
-        apply (clarsimp simp: sameRegionAs_def3 isCap_simps)
-       apply (clarsimp simp: sameRegionAs_def3 isCap_simps)
+       apply (clarsimp simp: isCap_simps)
+       apply (insert valid_badges)[1]
+       apply (clarsimp simp: valid_badges_def)
+       apply (erule_tac x="slot" in allE)
+       apply (erule_tac x="mdbNext s_node" in allE)
+       apply (simp add: slot m_p_next isCap_simps valid_arch_badges_def)
       apply (rule m_slot_next)
      apply simp
     apply (erule n_parent_of, simp, simp)
@@ -1132,11 +1205,11 @@ lemma emptySlot_mdb [wp]:
 end
 
 lemma if_live_then_nonz_cap'_def2:
-  "if_live_then_nonz_cap' =
-   (\<lambda>s. \<forall>ptr. ko_wp_at' live' ptr s \<longrightarrow>
-              (\<exists>p zr. (option_map zobj_refs' o cteCaps_of s) p = Some zr \<and> ptr \<in> zr))"
-  by (fastforce simp: if_live_then_nonz_cap'_def ex_nonz_cap_to'_def cte_wp_at_ctes_of
-                      cteCaps_of_def)
+  "if_live_then_nonz_cap' = (\<lambda>s. \<forall>ptr. ko_wp_at' live' ptr s
+                               \<longrightarrow> (\<exists>p zr. (option_map zobj_refs' o cteCaps_of s) p = Some zr \<and> ptr \<in> zr))"
+  by (fastforce intro!: ext
+                 simp: if_live_then_nonz_cap'_def ex_nonz_cap_to'_def
+                       cte_wp_at_ctes_of cteCaps_of_def)
 
 lemma updateMDB_ko_wp_at_live[wp]:
   "\<lbrace>\<lambda>s. P (ko_wp_at' live' p' s)\<rbrace>
@@ -1155,7 +1228,7 @@ lemma updateCap_ko_wp_at_live[wp]:
   by wp
 
 primrec
-  threadCapRefs :: "capability \<Rightarrow> machine_word set"
+  threadCapRefs :: "capability \<Rightarrow> word32 set"
 where
   "threadCapRefs (ThreadCap r)                  = {r}"
 | "threadCapRefs (ReplyCap t m x)               = {}"
@@ -1194,7 +1267,7 @@ lemma not_Final_removeable:
     \<Longrightarrow> removeable' sl s cap"
   apply (erule not_FinalE)
    apply (clarsimp simp: removeable'_def gen_isCap_simps)
-  apply (clarsimp simp: cteCaps_of_def RISCV64.sameObjectAs_def2 removeable'_def
+  apply (clarsimp simp: cteCaps_of_def ARM_HYP.sameObjectAs_def2 removeable'_def
                         cte_wp_at_ctes_of) (* FIXME arch-split *)
   apply fastforce
   done
@@ -1229,7 +1302,8 @@ lemma emptySlot_iflive'[wp]:
              hoare_vcg_ex_lift
              | wp (once) hoare_vcg_imp_lift
              | simp add: cte_wp_at_ctes_of del: comp_apply)+
-  apply (clarsimp simp: modify_map_same imp_conjR[symmetric])
+  apply (clarsimp simp: modify_map_same
+    imp_conjR[symmetric])
   apply (drule spec, drule(1) mp)
   apply (clarsimp simp: cte_wp_at_ctes_of modify_map_def split: if_split_asm)
   apply (case_tac "p \<noteq> sl")
@@ -1243,6 +1317,9 @@ lemma emptySlot_iflive'[wp]:
   apply (drule(1) bspec)
   apply (clarsimp simp: ko_wp_at'_def)
   done
+
+crunch doMachineOp
+  for irq_node'[wp]: "\<lambda>s. P (irq_node' s)"
 
 lemma setIRQState_irq_node'[wp]:
   "\<lbrace>\<lambda>s. P (irq_node' s)\<rbrace> setIRQState state irq \<lbrace>\<lambda>_ s. P (irq_node' s)\<rbrace>"
@@ -1286,7 +1363,12 @@ lemma emptySlot_ifunsafe'[wp]:
   apply (clarsimp simp: cte_wp_at_ctes_of cteCaps_of_def)
   done
 
-lemmas ctes_of_valid'[elim] = ctes_of_valid_cap''[where r=cte for cte]
+lemma ctes_of_valid'[elim]:
+  "\<lbrakk>ctes_of s p = Some cte; valid_objs' s\<rbrakk> \<Longrightarrow> s \<turnstile>' cteCap cte"
+  by (cases cte, simp) (rule ctes_of_valid_cap')
+
+crunch postCapDeletion
+  for ksrq[wp]: "\<lambda>s. P (ksReadyQueues s)"
 
 crunch setInterruptState
   for valid_idle'[wp]: "valid_idle'"
@@ -1295,7 +1377,8 @@ crunch setInterruptState
 context begin interpretation Arch .
 crunch emptySlot
   for valid_idle'[wp]: "valid_idle'"
-crunch deletedIRQHandler, getSlotCap, clearUntypedFreeIndex, updateMDB, getCTE, updateCap
+
+crunch emptySlot
   for ksArch[wp]: "\<lambda>s. P (ksArchState s)"
 crunch emptySlot
   for ksIdle[wp]: "\<lambda>s. P (ksIdleThread s)"
@@ -1317,51 +1400,20 @@ lemma emptySlot_cteCaps_of:
               split: option.splits)
   done
 
-context begin interpretation Arch .
-
-crunch deletedIRQHandler
-  for cteCaps_of[wp]: "\<lambda>s. P (cteCaps_of s)"
-
-lemma deletedIRQHandler_valid_global_refs[wp]:
-  "\<lbrace>valid_global_refs'\<rbrace> deletedIRQHandler irq \<lbrace>\<lambda>rv. valid_global_refs'\<rbrace>"
-  apply (clarsimp simp: valid_global_refs'_def global_refs'_def)
-  apply (rule hoare_pre)
-   apply (rule hoare_use_eq_irq_node' [OF deletedIRQHandler_irq_node'])
-   apply (rule hoare_use_eq [where f=ksIdleThread, OF deletedIRQHandler_ksIdle])
-   apply (rule hoare_use_eq [where f=ksArchState, OF deletedIRQHandler_ksArch])
-   apply (rule hoare_use_eq[where f="gsMaxObjectSize"], wp)
-   apply (simp add: valid_refs'_cteCaps valid_cap_sizes_cteCaps)
-   apply (rule deletedIRQHandler_cteCaps_of)
-  apply (clarsimp simp: cte_wp_at_ctes_of)
-  apply (clarsimp simp: valid_refs'_cteCaps valid_cap_sizes_cteCaps ball_ran_eq)
-  done
-
-lemma clearUntypedFreeIndex_valid_global_refs[wp]:
-  "\<lbrace>valid_global_refs'\<rbrace> clearUntypedFreeIndex irq \<lbrace>\<lambda>rv. valid_global_refs'\<rbrace>"
-  apply (clarsimp simp: valid_global_refs'_def global_refs'_def)
-  apply (rule hoare_pre)
-   apply (rule hoare_use_eq_irq_node' [OF clearUntypedFreeIndex_irq_node'])
-   apply (rule hoare_use_eq [where f=ksIdleThread, OF clearUntypedFreeIndex_ksIdle])
-   apply (rule hoare_use_eq [where f=ksArchState, OF clearUntypedFreeIndex_ksArch])
-   apply (rule hoare_use_eq[where f="gsMaxObjectSize"], wp)
-   apply (simp add: valid_refs'_cteCaps valid_cap_sizes_cteCaps)
-   apply (rule clearUntypedFreeIndex_cteCaps_of)
-  apply (clarsimp simp: cte_wp_at_ctes_of)
-  apply (clarsimp simp: valid_refs'_cteCaps valid_cap_sizes_cteCaps ball_ran_eq)
-  done
-
-crunch global.postCapDeletion
-  for valid_global_refs[wp]: "valid_global_refs'"
-
 lemma emptySlot_valid_global_refs[wp]:
   "\<lbrace>valid_global_refs' and cte_at' sl\<rbrace> emptySlot sl opt \<lbrace>\<lambda>rv. valid_global_refs'\<rbrace>"
-  apply (clarsimp simp: emptySlot_def)
-  apply (wpsimp wp: getCTE_wp hoare_drop_imps hoare_vcg_ex_lift simp: cte_wp_at_ctes_of)
-  apply (clarsimp simp: valid_global_refs'_def global_refs'_def)
+  apply (simp add: valid_global_refs'_def ARM_HYP.global_refs'_def)
+  apply (rule hoare_pre)
+   apply (rule hoare_use_eq_irq_node' [OF emptySlot_irq_node'])
+   apply (rule hoare_use_eq [where f=ksArchState, OF emptySlot_ksArch])
+   apply (rule hoare_use_eq [where f=ksIdleThread, OF emptySlot_ksIdle])
+   apply (rule hoare_use_eq [where f=gsMaxObjectSize], wp)
+   apply (simp add: valid_refs'_cteCaps valid_cap_sizes_cteCaps)
+   apply (rule emptySlot_cteCaps_of)
+  apply (clarsimp simp: cte_wp_at_ctes_of)
   apply (frule(1) cte_at_valid_cap_sizes_0)
   apply (clarsimp simp: valid_refs'_cteCaps valid_cap_sizes_cteCaps ball_ran_eq)
   done
-end
 
 lemmas doMachineOp_irq_handlers[wp]
     = valid_irq_handlers_lift'' [OF doMachineOp_ctes doMachineOp_ksInterruptState]
@@ -1381,12 +1433,7 @@ lemma postCapDeletion_irq_handlers'[wp]:
   "\<lbrace>\<lambda>s. valid_irq_handlers' s \<and> (cap \<noteq> NullCap \<longrightarrow> cap \<notin> ran (cteCaps_of s))\<rbrace>
        postCapDeletion cap
    \<lbrace>\<lambda>rv. valid_irq_handlers'\<rbrace>"
-  by (wpsimp simp: Retype_H.postCapDeletion_def RISCV64_H.postCapDeletion_def)
-
-definition
-  "post_cap_delete_pre' cap sl cs \<equiv> case cap of
-     IRQHandlerCap irq \<Rightarrow> irq \<le> maxIRQ \<and> (\<forall>sl'. sl \<noteq> sl' \<longrightarrow> cs sl' \<noteq> Some cap)
-   | _ \<Rightarrow> False"
+  by (wpsimp simp: Retype_H.postCapDeletion_def ARM_HYP_H.postCapDeletion_def)
 
 end
 
@@ -1415,6 +1462,9 @@ crunch emptySlot
 crunch emptySlot
   for no_0_obj'[wp]: no_0_obj'
  (wp: crunch_wps)
+
+crunch emptySlot
+  for pde_mappings'[wp]: "valid_pde_mappings'"
 
 lemma deletedIRQHandler_irqs_masked'[wp]:
   "\<lbrace>irqs_masked'\<rbrace> deletedIRQHandler irq \<lbrace>\<lambda>_. irqs_masked'\<rbrace>"
@@ -1447,6 +1497,12 @@ crunch emptySlot
   for pspace_domain_valid[wp]: "pspace_domain_valid"
 
 crunch emptySlot
+  for nosch[wp]: "\<lambda>s. P (ksSchedulerAction s)"
+crunch emptySlot
+  for ct[wp]: "\<lambda>s. P (ksCurThread s)"
+crunch emptySlot
+  for ksCurDomain[wp]: "\<lambda>s. P (ksCurDomain s)"
+crunch emptySlot
   for ksDomSchedule[wp]: "\<lambda>s. P (ksDomSchedule s)"
 crunch emptySlot
   for ksDomScheduleIdx[wp]: "\<lambda>s. P (ksDomScheduleIdx s)"
@@ -1469,7 +1525,8 @@ crunch emptySlot
 
 lemma emptySlot_ct_idle_or_in_cur_domain'[wp]:
   "\<lbrace>ct_idle_or_in_cur_domain'\<rbrace> emptySlot sl opt \<lbrace>\<lambda>_. ct_idle_or_in_cur_domain'\<rbrace>"
-  by (wp ct_idle_or_in_cur_domain'_lift2 tcb_in_cur_domain'_lift | simp)+
+apply (wp ct_idle_or_in_cur_domain'_lift2 tcb_in_cur_domain'_lift | simp)+
+done
 
 crunch postCapDeletion
   for gsUntypedZeroRanges[wp]: "\<lambda>s. P (gsUntypedZeroRanges s)"
@@ -1502,37 +1559,28 @@ lemma emptySlot_untyped_ranges[wp]:
   apply (simp add: untypedZeroRange_def isCap_simps)
   done
 
-crunch deletedIRQHandler, updateMDB, updateCap, clearUntypedFreeIndex
+crunch emptySlot
   for valid_arch'[wp]: valid_arch_state'
-  (wp: valid_arch_state_lift')
-
-crunch global.postCapDeletion
-  for valid_arch'[wp]: valid_arch_state'
-
-lemma emptySlot_valid_arch'[wp]:
-  "\<lbrace>valid_arch_state' and cte_at' sl\<rbrace> emptySlot sl info \<lbrace>\<lambda>rv. valid_arch_state'\<rbrace>"
-  by (wpsimp simp: emptySlot_def cte_wp_at_ctes_of
-               wp: getCTE_wp hoare_drop_imps hoare_vcg_ex_lift)
+  (wp: crunch_wps)
 
 crunch emptySlot
   for valid_bitmaps[wp]: valid_bitmaps
   and tcbQueued_opt_pred[wp]: "\<lambda>s. P (tcbQueued |< tcbs_of' s)"
   and valid_sched_pointers[wp]: valid_sched_pointers
   and sched_projs[wp]: "\<lambda>s. P (tcbSchedNexts_of s) (tcbSchedPrevs_of s)"
-  and ksDomScheduleIdx[wp]: "\<lambda>s. P (ksDomScheduleIdx s)"
+  and valid_arch_state'[wp]: valid_arch_state'
   and ksDomScheduleStart[wp]: "\<lambda>s. P (ksDomScheduleStart s)"
   (wp: valid_bitmaps_lift)
 
 lemma emptySlot_invs'[wp]:
   "\<lbrace>\<lambda>s. invs' s \<and> cte_wp_at' (\<lambda>cte. removeable' sl s (cteCap cte)) sl s
-            \<and> (info \<noteq> NullCap \<longrightarrow> post_cap_delete_pre' info sl (cteCaps_of s) )\<rbrace>
+            \<and> (\<forall>sl'. info \<noteq> NullCap \<longrightarrow> sl' \<noteq> sl \<longrightarrow> cteCaps_of s sl' \<noteq> Some info)\<rbrace>
      emptySlot sl info
    \<lbrace>\<lambda>rv. invs'\<rbrace>"
   apply (simp add: invs'_def valid_state'_def valid_pspace'_def)
   apply (wp valid_irq_node_lift cur_tcb_lift valid_dom_schedule'_lift)
-  apply (clarsimp simp: cte_wp_at_ctes_of post_cap_delete_pre'_def cteCaps_of_def
-                 split: capability.split_asm arch_capability.split_asm)
-  by auto
+  apply (clarsimp simp: cte_wp_at_ctes_of)
+  done
 
 lemma deletedIRQHandler_corres:
   "corres dc \<top> \<top>
@@ -1544,8 +1592,8 @@ lemma deletedIRQHandler_corres:
   done
 
 lemma arch_postCapDeletion_corres:
-  "acap_relation cap cap' \<Longrightarrow> corres dc \<top> \<top> (arch_post_cap_deletion cap) (RISCV64_H.postCapDeletion cap')"
-  by (clarsimp simp: arch_post_cap_deletion_def RISCV64_H.postCapDeletion_def)
+  "acap_relation cap cap' \<Longrightarrow> corres dc \<top> \<top> (arch_post_cap_deletion cap) (ARM_HYP_H.postCapDeletion cap')"
+  by (corresKsimp simp: arch_post_cap_deletion_def ARM_HYP_H.postCapDeletion_def)
 
 lemma postCapDeletion_corres:
   "cap_relation cap cap' \<Longrightarrow> corres dc \<top> \<top> (post_cap_deletion cap) (postCapDeletion cap')"
@@ -1556,9 +1604,9 @@ lemma postCapDeletion_corres:
 lemma set_cap_trans_state:
   "((),s') \<in> fst (set_cap c p s) \<Longrightarrow> ((),trans_state f s') \<in> fst (set_cap c p (trans_state f s))"
   apply (cases p)
-  apply (clarsimp simp add: set_cap_def in_monad set_object_def get_object_def)
+  apply (clarsimp simp add: set_cap_def in_monad get_object_def)
   apply (case_tac y)
-      apply (auto simp add: in_monad set_object_def well_formed_cnode_n_def split: if_split_asm)
+      apply (auto simp: in_monad set_object_def get_object_def split: if_split_asm)
   done
 
 lemma clearUntypedFreeIndex_noop_corres:
@@ -1569,7 +1617,7 @@ lemma clearUntypedFreeIndex_noop_corres:
     apply (rule corres_bind_return2)
     apply (rule corres_symb_exec_r_conj[where P'="cte_at' (cte_map slot)"])
        apply (rule corres_trivial, simp)
-      apply (wp getCTE_wp' | wpc
+      apply (wp wp_post_taut getCTE_wp' | wpc
         | simp add: updateTrackedFreeIndex_def getSlotCap_def)+
      apply (clarsimp simp: state_relation_def)
     apply (rule no_fail_pre)
@@ -1597,7 +1645,7 @@ lemma emptySlot_corres:
        defer
        apply (wp get_cap_wp getCTE_wp')+
      apply (simp add: cte_wp_at_ctes_of)
-     apply (wp hoare_vcg_imp_lift' clearUntypedFreeIndex_valid_pspace')
+     apply (wp hoare_vcg_imp_lift clearUntypedFreeIndex_valid_pspace')
     apply fastforce
    apply (fastforce simp: cte_wp_at_ctes_of)
   apply simp
@@ -1847,9 +1895,10 @@ where
   | Zombie ptr zb n \<Rightarrow> True
   | IRQHandlerCap irq \<Rightarrow> True
   | ArchObjectCap acap \<Rightarrow> (case acap of
-      FrameCap ref rghts sz d mapdata \<Rightarrow> False
-    | ASIDControlCap \<Rightarrow> False
-    | _ \<Rightarrow> True)
+    PageCap d ref rghts sz mapdata \<Rightarrow> False
+  | ASIDControlCap \<Rightarrow> False
+  | SGISignalCap _ _ \<Rightarrow> False
+  | _ \<Rightarrow> True)
   | _ \<Rightarrow> False"
 
 lemma final_matters_Master:
@@ -1882,7 +1931,7 @@ lemma final_matters_sameRegion_sameObject2:
 
 lemma final_matters_mdb_chunked_arch_assms:
   "final_matters' cap \<Longrightarrow> mdb_chunked_arch_assms cap"
-  by (clarsimp simp: mdb_chunked_arch_assms_def)
+  by (clarsimp simp: mdb_chunked_arch_assms_def isCap_simps final_matters'_def)
 
 lemma notFinal_prev_or_next:
   "\<lbrakk> \<not> isFinal cap x (cteCaps_of s); mdb_chunked (ctes_of s);
@@ -1993,7 +2042,7 @@ lemma isFinal:
      apply clarsimp
     apply (case_tac cte')
     apply clarsimp
-   apply (clarsimp simp add: sameObjectAs_def3 isCap_simps)
+   apply (fastforce simp add: sameObjectAs_def3 isCap_simps)
   apply clarsimp
   apply (rule conjI)
    apply clarsimp
@@ -2028,8 +2077,8 @@ lemma (in vmdb) isFinal_no_subtree:
    apply (erule_tac x="mdbNext n" in allE)
    apply simp
    (* FIXME arch-split *)
-   apply (clarsimp simp: RISCV64.isMDBParentOf_CTE final_matters_sameRegion_sameObject)
-   apply (clarsimp simp: gen_isCap_simps RISCV64.sameObjectAs_def3) (* FIXME arch-split *)
+   apply (clarsimp simp: ARM_HYP.isMDBParentOf_CTE final_matters_sameRegion_sameObject)
+   apply (clarsimp simp: gen_isCap_simps ARM_HYP.sameObjectAs_def3) (* FIXME arch-split *)
   apply clarsimp
   done
 
@@ -2065,6 +2114,7 @@ lemma (in vmdb) isFinal_untypedParent:
   apply clarsimp
   apply (drule isMDBParent_sameRegion)
   apply simp
+  apply (frule final_matters_mdb_chunked_arch_assms)
   apply (rule classical, simp)
   apply (simp add: final_matters_sameRegion_sameObject2
                    sameObjectAs_sym)
@@ -2200,16 +2250,14 @@ lemma isFinalCapability_corres':
    apply (rule classical)
    apply (frule(1) zombies_finalD2[OF _ _ _ invs_zombies],
           simp?, clarsimp, assumption+)
-   subgoal by (clarsimp simp: sameObjectAs_def3 isCap_simps valid_cap_def valid_arch_cap_def
-                              valid_arch_cap_ref_def obj_at_def is_obj_defs a_type_def
-                              final_matters'_def
-                        split: cap.split_asm arch_cap.split_asm option.split_asm if_split_asm,
-               simp_all add: is_cap_defs)
+   subgoal by (clarsimp simp: sameObjectAs_def3 isCap_simps valid_cap_def
+                         obj_at_def is_obj_defs a_type_def final_matters'_def
+                  split: cap.split_asm arch_cap.split_asm
+                         option.split_asm if_split_asm,
+          simp_all add: is_cap_defs)
   apply (rule classical)
-  apply (clarsimp simp: cap_irqs_def cap_irq_opt_def sameObjectAs_def3 isCap_simps
-                        acap_relation_def
-                 split: cap.split_asm arch_cap.split_asm)
-  done
+  by (clarsimp simp: cap_irqs_def cap_irq_opt_def sameObjectAs_def3 isCap_simps arch_gen_obj_refs_def
+                 split: cap.split_asm)
 
 lemma isFinalCapability_corres:
   "corres (\<lambda>rv rv'. final_matters' (cteCap cte) \<longrightarrow> rv = rv')
@@ -2252,8 +2300,9 @@ lemmas cteDeleteOne_def
 
 crunch cteDeleteOne, suspend, prepareThreadDelete
   for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  (wp: crunch_wps getObject_inv loadObject_default_inv
-   simp: crunch_simps unless_def o_def)
+  (ignore_del: setObject
+         simp: crunch_simps unless_def o_def
+           wp: crunch_wps getObject_inv loadObject_default_inv)
 
 end
 
@@ -2262,11 +2311,16 @@ lemmas cancelAllSignals_typs[wp] = typ_at_lifts [OF cancelAllSignals_typ_at']
 lemmas suspend_typs[wp] = typ_at_lifts [OF suspend_typ_at']
 
 definition
+  arch_cap_has_cleanup' :: "arch_capability \<Rightarrow> bool"
+where
+  "arch_cap_has_cleanup' acap \<equiv> False"
+
+definition
   cap_has_cleanup' :: "capability \<Rightarrow> bool"
 where
   "cap_has_cleanup' cap \<equiv> case cap of
      IRQHandlerCap _ \<Rightarrow> True
-   | ArchObjectCap acap \<Rightarrow> False
+   | ArchObjectCap acap \<Rightarrow> arch_cap_has_cleanup' acap
    | _ \<Rightarrow> False"
 
 lemmas cap_has_cleanup'_simps[simp] = cap_has_cleanup'_def[split_simps capability.split]
@@ -2279,7 +2333,7 @@ lemma finaliseCap_cases[wp]:
        isZombie (fst rv) \<and> final \<and> \<not> flag \<and> snd rv = NullCap
         \<and> capUntypedPtr (fst rv) = capUntypedPtr cap
         \<and> (isThreadCap cap \<or> isCNodeCap cap \<or> isZombie cap)\<rbrace>"
-  apply (simp add: finaliseCap_def RISCV64_H.finaliseCap_def Let_def
+  apply (simp add: finaliseCap_def ARM_HYP_H.finaliseCap_def Let_def
                    getThreadCSpaceRoot
              cong: if_cong split del: if_split)
   apply (rule hoare_pre)
@@ -2308,14 +2362,16 @@ crunch finaliseCap
      wp: getObject_inv loadObject_default_inv crunch_wps)
 lemmas finaliseCap_typ_ats[wp] = typ_at_lifts[OF finaliseCap_typ_at']
 
-lemma unmapPageTable_it'[wp]:
-  "unmapPageTable asid vaddr pt \<lbrace>\<lambda>s. P (ksIdleThread s)\<rbrace>"
-  unfolding unmapPageTable_def by wpsimp
-
 crunch finaliseCap
   for it'[wp]: "\<lambda>s. P (ksIdleThread s)"
-  (simp: crunch_simps assertE_def o_def
-     wp: crunch_wps)
+  (wp: mapM_x_wp_inv mapM_wp' hoare_drop_imps getObject_inv loadObject_default_inv
+   simp: crunch_simps updateObject_default_def o_def)
+
+crunch flush_space
+  for vs_lookup[wp]: "\<lambda>s. P (vs_lookup s)"
+  (wp: crunch_wps)
+
+declare doUnbindNotification_def[simp]
 
 lemma ntfn_q_refs_of'_mult:
   "ntfn_q_refs_of' ntfn = (case ntfn of Structures_H.WaitingNtfn q \<Rightarrow> set q | _ \<Rightarrow> {}) \<times> {NTFNSignal}"
@@ -2347,6 +2403,7 @@ lemma unbindNotification_invs[wp]:
             untyped_ranges_zero_lift | clarsimp simp: cteCaps_of_def o_def)+
   apply (rule conjI)
    apply (clarsimp elim!: obj_atE'
+                    simp: projectKOs
                    dest!: pred_tcb_at')
   apply (clarsimp simp: pred_tcb_at' conj_comms)
   apply (frule bound_tcb_ex_cap'', clarsimp+)
@@ -2358,10 +2415,10 @@ lemma unbindNotification_invs[wp]:
     apply (auto split: if_split_asm)[1]
    apply (auto simp: tcb_st_not_Bound ntfn_q_refs_of'_mult split: if_split_asm)[1]
   apply (frule obj_at_valid_objs', clarsimp+)
-  apply (simp add: valid_ntfn'_def valid_obj'_def live'_def
+  apply (simp add: valid_ntfn'_def valid_obj'_def projectKOs live'_def
             split: ntfn.splits)
   apply (erule if_live_then_nonz_capE')
-  apply (clarsimp simp: obj_at'_def ko_wp_at'_def live'_def)
+  apply (clarsimp simp: obj_at'_def ko_wp_at'_def projectKOs live'_def)
   done
 
 lemma ntfn_bound_tcb_at':
@@ -2369,11 +2426,12 @@ lemma ntfn_bound_tcb_at':
     ntfnBoundTCB ntfn = Some tcbptr; P (Some ntfnptr)\<rbrakk>
   \<Longrightarrow> bound_tcb_at' P tcbptr s"
   apply (drule_tac x=ntfnptr in sym_refsD[rotated])
-   apply (clarsimp simp: obj_at'_def)
+   apply (clarsimp simp: obj_at'_def projectKOs)
    apply (fastforce simp: state_refs_of'_def)
   apply (auto simp: pred_tcb_at'_def obj_at'_def valid_obj'_def valid_ntfn'_def
-                    state_refs_of'_def refs_of_rev'
+                    state_refs_of'_def refs_of_rev' projectKOs
           simp del: refs_of_simps
+             elim!: valid_objsE
              split: option.splits if_split_asm)
   done
 
@@ -2391,10 +2449,9 @@ lemma unbindMaybeNotification_invs[wp]:
            defer 3
            defer 7
            apply (fold_subgoals (prefix))[8]
-           subgoal premises prems using prems
-              by (auto simp: pred_tcb_at' valid_pspace'_def valid_obj'_def valid_ntfn'_def
+           subgoal premises prems using prems by (auto simp: pred_tcb_at' valid_pspace'_def projectKOs valid_obj'_def valid_ntfn'_def
                              ko_wp_at'_def live'_def
-                      elim!: obj_atE' if_live_then_nonz_capE'
+                      elim!: obj_atE' valid_objsE' if_live_then_nonz_capE'
                       split: option.splits ntfn.splits)
    apply (rule delta_sym_refs, assumption)
     apply (fold_subgoals (prefix))[2]
@@ -2421,16 +2478,50 @@ lemma finaliseCap_True_invs[wp]:
     apply (wp irqs_masked_lift| simp | wpc)+
   done
 
+crunch flushSpace
+  for invs'[wp]: "invs'"
+  (ignore: doMachineOp)
+
 lemma invs_asid_update_strg':
-  "invs' s \<and> tab = riscvKSASIDTable (ksArchState s) \<longrightarrow>
-   invs' (s\<lparr>ksArchState := riscvKSASIDTable_update
+  "invs' s \<and> tab = armKSASIDTable (ksArchState s) \<longrightarrow>
+   invs' (s\<lparr>ksArchState := armKSASIDTable_update
             (\<lambda>_. tab (asid := None)) (ksArchState s)\<rparr>)"
   apply (simp add: invs'_def)
   apply (simp add: valid_state'_def)
-  apply (simp add: valid_global_refs'_def global_refs'_def valid_arch_state'_def
-                   valid_asid_table'_def valid_machine_state'_def ct_idle_or_in_cur_domain'_def
-                   tcb_in_cur_domain'_def)
-  apply (auto simp add: ran_def split: if_split_asm)
+  apply (simp add: valid_global_refs'_def global_refs'_def valid_arch_state'_def valid_asid_table'_def
+                   valid_machine_state'_def ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def
+             cong: option.case_cong)
+  by (auto simp add: ran_def split: if_split_asm)
+
+lemma invalidateASIDEntry_invs' [wp]:
+  "\<lbrace>invs'\<rbrace> invalidateASIDEntry asid \<lbrace>\<lambda>r. invs'\<rbrace>"
+  apply (simp add: invalidateASIDEntry_def invalidateASID_def
+                   invalidateHWASIDEntry_def bind_assoc)
+  apply (wp loadHWASID_wp | simp)+
+  apply (clarsimp simp: fun_upd_def[symmetric])
+  apply (rule conjI)
+   apply (clarsimp simp: invs'_def valid_state'_def)
+   apply (rule conjI)
+    apply (simp add: valid_global_refs'_def
+                     global_refs'_def)
+   apply (simp add: valid_arch_state'_def ran_def
+                    valid_asid_table'_def is_inv_None_upd
+                    valid_machine_state'_def
+                    comp_upd_simp fun_upd_def[symmetric]
+                    inj_on_fun_upd_elsewhere
+                    valid_asid_map'_def
+                    ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def
+             cong: option.case_cong)
+   subgoal by (auto elim!: subset_inj_on)
+  apply (clarsimp simp: invs'_def valid_state'_def)
+  apply (rule conjI)
+   apply (simp add: valid_global_refs'_def global_refs'_def)
+  apply (rule conjI)
+   apply (simp add: valid_arch_state'_def ran_def
+                    valid_asid_table'_def None_upd_eq
+                    fun_upd_def[symmetric] comp_upd_simp
+              cong: option.case_cong)
+  apply (simp add: valid_machine_state'_def ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def)
   done
 
 lemma deleteASIDPool_invs[wp]:
@@ -2443,47 +2534,424 @@ lemma deleteASIDPool_invs[wp]:
               | simp)+
   done
 
-crunch hwASIDFlush
-  for irq_masks[wp]: "\<lambda>s. P (irq_masks s)"
-
-lemma dmo_hwASIDFlush_invs[wp]:
-  "doMachineOp (hwASIDFlush asid) \<lbrace>invs'\<rbrace>"
-  apply (wp dmo_invs')
-  apply (clarsimp simp: hwASIDFlush_def machine_op_lift_def machine_rest_lift_def in_monad select_f_def)
-  done
+lemmas flushSpace_typ_ats' [wp] = typ_at_lifts [OF flushSpace_typ_at']
 
 lemma deleteASID_invs'[wp]:
-  "deleteASID asid pd \<lbrace>invs'\<rbrace>"
-  unfolding deleteASID_def by (wpsimp wp: getASID_wp)
+  "\<lbrace>invs'\<rbrace> deleteASID asid pd \<lbrace>\<lambda>rv. invs'\<rbrace>"
+  apply (simp add: deleteASID_def cong: option.case_cong)
+  apply (rule hoare_pre)
+   apply (wp | wpc)+
+    apply (rule_tac Q'="\<lambda>rv. valid_obj' (injectKO rv) and invs'"
+              in hoare_post_imp)
+     apply (rename_tac rv s)
+     apply (clarsimp split: if_split_asm del: subsetI)
+     apply (simp add: fun_upd_def[symmetric] valid_obj'_def)
+     apply (case_tac rv, simp)
+     apply (subst inv_f_f, rule inj_onI, simp)+
+     apply (rule conjI)
+      apply clarsimp
+      apply (drule subsetD, blast)
+      apply clarsimp
+     apply (auto dest!: ran_del_subset)[1]
+    apply (wp getObject_valid_obj getObject_inv loadObject_default_inv
+             | simp add: objBits_simps archObjSize_def pageBits_def)+
+  apply clarsimp
+  done
+
+(* FIMXME: move up *)
+lemmas archThreadSet_typ_ats[wp] = typ_at_lifts [OF archThreadSet_typ_at']
+
+lemma archThreadSet_valid_objs'[wp]:
+  "\<lbrace>valid_objs' and (\<lambda>s. \<forall>tcb. ko_at' tcb t s \<longrightarrow> valid_arch_tcb' (f (tcbArch tcb)) s)\<rbrace>
+   archThreadSet f t \<lbrace>\<lambda>_. valid_objs'\<rbrace>"
+  unfolding archThreadSet_def
+  apply (wp setObject_tcb_valid_objs getObject_tcb_wp)
+  apply clarsimp
+  apply normalise_obj_at'
+  apply (drule (1) tcb_ko_at_valid_objs_valid_tcb')
+  apply (clarsimp simp: valid_obj'_def valid_tcb'_def tcb_cte_cases_def tcb_cte_cases_neqs)
+  done
+
+crunch archThreadSet
+  for no_0_obj'[wp]: no_0_obj'
+
+lemma archThreadSet_ctes_of[wp]:
+  "archThreadSet f t \<lbrace>\<lambda>s. P (ctes_of s)\<rbrace>"
+  unfolding archThreadSet_def
+  apply (wpsimp wp: getObject_tcb_wp)
+  apply normalise_obj_at'
+  apply (auto simp: tcb_cte_cases_def tcb_cte_cases_neqs)
+  done
+
+crunch archThreadSet
+  for ksCurDomain[wp]: "\<lambda>s. P (ksCurDomain s)"
+  (wp: setObject_cd_inv)
+
+lemma archThreadSet_obj_at':
+  "(\<And>tcb. P tcb \<Longrightarrow> P (tcb \<lparr> tcbArch:= f (tcbArch tcb)\<rparr>)) \<Longrightarrow> archThreadSet f t \<lbrace>obj_at' P t'\<rbrace>"
+  unfolding archThreadSet_def
+  apply (wpsimp wp: getObject_tcb_wp setObject_tcb_strongest)
+  apply normalise_obj_at'
+  apply auto
+  done
+
+lemma archThreadSet_tcbDomain[wp]:
+  "archThreadSet f t \<lbrace>obj_at' (\<lambda>tcb. x = tcbDomain tcb) t'\<rbrace>"
+  by (wpsimp wp: archThreadSet_obj_at')
+
+lemma archThreadSet_inQ[wp]:
+  "archThreadSet f t' \<lbrace>\<lambda>s. P (obj_at' (inQ d p) t s)\<rbrace>"
+  unfolding obj_at'_real_def archThreadSet_def
+  apply (wpsimp wp: setObject_ko_wp_at getObject_tcb_wp
+              simp: objBits_simps' archObjSize_def vcpu_bits_def pageBits_def
+         | simp)+
+  apply (auto simp: obj_at'_def ko_wp_at'_def projectKOs)
+  done
+
+crunch archThreadSet
+  for ct[wp]: "\<lambda>s. P (ksCurThread s)"
+  (wp: setObject_ct_inv)
+
+crunch archThreadSet
+  for sched[wp]: "\<lambda>s. P (ksSchedulerAction s)"
+  (wp: setObject_sa_inv)
+
+crunch archThreadSet
+  for L1[wp]: "\<lambda>s. P (ksReadyQueuesL1Bitmap s)"
+  (wp: setObject_sa_inv)
+
+crunch archThreadSet
+  for L2[wp]: "\<lambda>s. P (ksReadyQueuesL2Bitmap s)"
+  (wp: setObject_sa_inv)
+
+crunch archThreadSet
+  for ksArch[wp]: "\<lambda>s. P (ksArchState s)"
+
+crunch archThreadSet
+  for ksDomSchedule[wp]: "\<lambda>s. P (ksDomSchedule s)"
+  (wp: setObject_ksDomSchedule_inv)
+
+crunch archThreadSet
+  for ksDomScheduleIdx[wp]: "\<lambda>s. P (ksDomScheduleIdx s)"
+  and ksDomScheduleStart[wp]: "\<lambda>s. P (ksDomScheduleStart s)"
+  (simp: setObject_def wp: updateObject_default_inv)
+
+lemma setObject_tcb_ksInterruptState[wp]:
+  "setObject t (v :: tcb) \<lbrace>\<lambda>s. P (ksInterruptState s)\<rbrace>"
+  by (wpsimp simp: setObject_def wp: updateObject_default_inv)
+
+lemma setObject_tcb_gsMaxObjectSize[wp]:
+  "setObject t (v :: tcb) \<lbrace>\<lambda>s. P (gsMaxObjectSize s)\<rbrace>"
+  by (wpsimp simp: setObject_def wp: updateObject_default_inv)
+
+crunch archThreadSet
+  for ksInterruptState[wp]: "\<lambda>s. P (ksInterruptState s)"
+
+crunch archThreadSet
+  for gsMaxObjectSize[wp]: "\<lambda>s. P (gsMaxObjectSize s)"
+
+crunch archThreadSet
+  for ksMachineState[wp]: "\<lambda>s. P (ksMachineState s)"
+  (wp: setObject_ksMachine updateObject_default_inv)
+
+lemma archThreadSet_state_refs_of'[wp]:
+  "archThreadSet f t \<lbrace>\<lambda>s. P (state_refs_of' s)\<rbrace>"
+  unfolding archThreadSet_def
+  apply (wpsimp wp: setObject_tcb_state_refs_of' getObject_tcb_wp)
+  apply normalise_obj_at'
+  apply (erule rsubst[where P=P])
+  apply (rule ext)
+  apply (auto simp: state_refs_of'_def obj_at'_def projectKOs)
+  done
+
+lemma archThreadSet_state_hyp_refs_of'[wp]:
+  "\<lbrace>\<lambda>s. \<forall>tcb. ko_at' tcb t s \<longrightarrow> P ((state_hyp_refs_of' s)(t := tcb_hyp_refs' (f (tcbArch tcb))))\<rbrace>
+  archThreadSet f t \<lbrace>\<lambda>_ s. P (state_hyp_refs_of' s)\<rbrace>"
+  unfolding archThreadSet_def
+  apply (wpsimp wp: setObject_state_hyp_refs_of' getObject_tcb_wp simp: objBits_simps')
+  apply normalise_obj_at'
+  apply (erule rsubst[where P=P])
+  apply auto
+  done
+
+crunch archThreadSet
+  for ko_at'_pde[wp]: "\<lambda>s. P (ko_at' (pde::pde) p' s)"
+  and valid_pde_mappings'[wp]: valid_pde_mappings'
+
+lemma archThreadSet_if_live'[wp]:
+  "\<lbrace>\<lambda>s. if_live_then_nonz_cap' s \<and>
+        (\<forall>tcb. ko_at' tcb t s \<longrightarrow> atcbVCPUPtr (f (tcbArch tcb)) \<noteq> None \<longrightarrow> ex_nonz_cap_to' t s)\<rbrace>
+  archThreadSet f t \<lbrace>\<lambda>_. if_live_then_nonz_cap'\<rbrace>"
+  unfolding archThreadSet_def
+  apply (wpsimp wp: setObject_tcb_iflive' getObject_tcb_wp)
+  apply normalise_obj_at'
+  apply (clarsimp simp: tcb_cte_cases_def tcb_cte_cases_neqs if_live_then_nonz_cap'_def)
+  apply (erule_tac x=t in allE)
+  apply (erule impE)
+   apply (clarsimp simp: obj_at'_real_def ko_wp_at'_def projectKOs live'_def hyp_live'_def)
+  apply simp
+  done
+
+lemma archThreadSet_ifunsafe'[wp]:
+  "archThreadSet f t \<lbrace>if_unsafe_then_cap'\<rbrace>"
+  unfolding archThreadSet_def
+  apply (wpsimp wp: setObject_tcb_ifunsafe' getObject_tcb_wp)
+  apply normalise_obj_at'
+  apply (auto simp: tcb_cte_cases_def tcb_cte_cases_neqs if_live_then_nonz_cap'_def)
+  done
+
+lemma archThreadSet_valid_idle'[wp]:
+  "archThreadSet f t \<lbrace>valid_idle'\<rbrace>"
+  unfolding archThreadSet_def
+  apply (wpsimp wp: setObject_tcb_idle' getObject_tcb_wp)
+  apply (clarsimp simp: valid_idle'_def pred_tcb_at'_def obj_at'_def idle_tcb'_def)
+  done
+
+lemma archThreadSet_ko_wp_at_no_vcpu[wp]:
+  "archThreadSet f t \<lbrace>ko_wp_at' (is_vcpu' and hyp_live') p\<rbrace>"
+  unfolding archThreadSet_def
+  apply (wpsimp wp: getObject_tcb_wp setObject_ko_wp_at simp: objBits_simps' | rule refl)+
+  apply normalise_obj_at'
+  apply (auto simp: ko_wp_at'_def obj_at'_real_def projectKOs is_vcpu'_def)
+  done
+
+lemma archThreadSet_valid_arch_state'[wp]:
+  "archThreadSet f t \<lbrace>valid_arch_state'\<rbrace>"
+  unfolding valid_arch_state'_def valid_asid_table'_def option_case_all_conv split_def
+  apply (rule hoare_lift_Pf[where f=ksArchState]; wpsimp wp: hoare_vcg_all_lift hoare_vcg_imp_lift)
+  apply (clarsimp simp: pred_conj_def)
+  done
+
+lemma archThreadSet_ct_not_inQ[wp]:
+  "archThreadSet f t \<lbrace>ct_not_inQ\<rbrace>"
+  unfolding ct_not_inQ_def
+  apply (rule hoare_lift_Pf[where f=ksCurThread]; wp?)
+  apply (wpsimp wp: hoare_vcg_imp_lift simp: o_def)
+  done
+
+lemma archThreadSet_obj_at'_pde[wp]:
+  "archThreadSet f t \<lbrace>obj_at' (P::pde \<Rightarrow> bool) p\<rbrace>"
+  unfolding archThreadSet_def
+  by (wpsimp wp: obj_at_setObject2 simp: updateObject_default_def in_monad)
+
+crunch archThreadSet
+  for pspace_domain_valid[wp]: pspace_domain_valid
+
+lemma setObject_tcb_gsUntypedZeroRanges[wp]:
+  "setObject ptr (tcb::tcb) \<lbrace>\<lambda>s. P (gsUntypedZeroRanges s)\<rbrace>"
+  by (wpsimp wp: updateObject_default_inv simp: setObject_def)
+
+crunch archThreadSet
+  for gsUntypedZeroRanges[wp]: "\<lambda>s. P (gsUntypedZeroRanges s)"
+
+lemma archThreadSet_untyped_ranges_zero'[wp]:
+  "archThreadSet f t \<lbrace>untyped_ranges_zero'\<rbrace>"
+  by (rule hoare_lift_Pf[where f=cteCaps_of]; wp cteCaps_of_ctes_of_lift)
+
+lemma archThreadSet_tcb_at'[wp]:
+  "\<lbrace>\<top>\<rbrace> archThreadSet f t \<lbrace>\<lambda>_. tcb_at' t\<rbrace>"
+  unfolding archThreadSet_def
+  by (wpsimp wp: getObject_tcb_wp simp: obj_at'_def)
+
+lemma setObject_tcb_tcbs_of'[wp]:
+  "\<lbrace>\<lambda>s. P ((tcbs_of' s) (t \<mapsto> tcb))\<rbrace>
+   setObject t tcb
+   \<lbrace>\<lambda>_ s. P (tcbs_of' s)\<rbrace>"
+  unfolding setObject_def
+  apply (wpsimp simp: updateObject_default_def)
+  apply (erule rsubst[where P=P])
+  apply (rule ext)
+  apply (clarsimp simp: opt_map_def split: option.splits)
+  done
+
+lemma archThreadSet_tcbSchedPrevs_of[wp]:
+  "archThreadSet f t \<lbrace>\<lambda>s. P (tcbSchedPrevs_of s)\<rbrace>"
+  supply projectKOs[simp]
+  unfolding archThreadSet_def
+  apply (wp getObject_tcb_wp)
+  apply normalise_obj_at'
+  apply (erule rsubst[where P=P])
+  apply (rule ext)
+  apply (clarsimp simp: opt_map_def obj_at'_def split: option.splits)
+  done
+
+lemma archThreadSet_tcbSchedNexts_of[wp]:
+  "archThreadSet f t \<lbrace>\<lambda>s. P (tcbSchedNexts_of s)\<rbrace>"
+  supply projectKOs[simp]
+  unfolding archThreadSet_def
+  apply (wp getObject_tcb_wp)
+  apply normalise_obj_at'
+  apply (erule rsubst[where P=P])
+  apply (rule ext)
+  apply (clarsimp simp: opt_map_def obj_at'_def split: option.splits)
+  done
+
+lemma archThreadSet_tcbQueued[wp]:
+  "archThreadSet f t \<lbrace>\<lambda>s. P (tcbQueued |< tcbs_of' s)\<rbrace>"
+  supply projectKOs[simp]
+  unfolding archThreadSet_def
+  apply (wp getObject_tcb_wp)
+  apply normalise_obj_at'
+  apply (erule rsubst[where P=P])
+  apply (rule ext)
+  apply (clarsimp simp: opt_pred_def opt_map_def obj_at'_def split: option.splits)
+  done
+
+lemma archThreadSet_valid_sched_pointers[wp]:
+  "archThreadSet f t \<lbrace>valid_sched_pointers\<rbrace>"
+  by (wp_pre, wps, wp, assumption)
+
+lemma dissoc_invs':
+  "\<lbrace>invs' and (\<lambda>s. \<forall>p. (\<exists>a. armHSCurVCPU (ksArchState s) = Some (p, a)) \<longrightarrow> p \<noteq> v) and
+    ko_at' vcpu v and K (vcpuTCBPtr vcpu = Some t) and
+    obj_at' (\<lambda>tcb. atcbVCPUPtr (tcbArch tcb) = Some v) t\<rbrace>
+   do
+    archThreadSet (atcbVCPUPtr_update (\<lambda>_. Nothing)) t;
+    setObject v $ vcpuTCBPtr_update (\<lambda>_. Nothing) vcpu
+   od \<lbrace>\<lambda>_. invs' and tcb_at' t\<rbrace>"
+  unfolding invs'_def valid_state'_def valid_pspace'_def valid_mdb'_def
+            valid_machine_state'_def pointerInUserData_def pointerInDeviceData_def
+  supply fun_upd_apply[simp del]
+  apply (wpsimp wp: sch_act_wf_lift tcb_in_cur_domain'_lift valid_queues_lift
+                    setObject_tcb_valid_objs setObject_vcpu_valid_objs'
+                    setObject_state_refs_of' setObject_state_hyp_refs_of' valid_global_refs_lift'
+                    valid_irq_node_lift_asm [where Q=\<top>] valid_irq_handlers_lift'
+                    cteCaps_of_ctes_of_lift irqs_masked_lift ct_idle_or_in_cur_domain'_lift
+                    valid_irq_states_lift' hoare_vcg_all_lift hoare_vcg_disj_lift
+                    valid_pde_mappings_lift' setObject_typ_at' cur_tcb_lift
+                    setVCPU_valid_arch' archThreadSet_if_live' valid_bitmaps_lift
+                    sym_heap_sched_pointers_lift valid_dom_schedule'_lift
+              simp: objBits_simps archObjSize_def vcpu_bits_def pageBits_def
+                    state_refs_of'_vcpu_empty state_hyp_refs_of'_vcpu_absorb valid_arch_tcb'_def
+        | clarsimp simp: live'_def hyp_live'_def arch_live'_def)+
+  apply (drule (1) valid_objs_valid_vcpu')
+  apply (clarsimp simp: valid_vcpu'_def)
+  supply fun_upd_apply[simp]
+  apply (clarsimp simp: state_hyp_refs_of'_def obj_at'_def projectKOs tcb_vcpu_refs'_def
+                  split: option.splits if_split_asm)
+  apply safe
+  apply (rule_tac rfs'="state_hyp_refs_of' s" in delta_sym_refs)
+   apply (clarsimp simp: state_hyp_refs_of'_def obj_at'_def projectKOs tcb_vcpu_refs'_def
+                   split: option.splits if_split_asm)+
+  done
+
+lemma setVCPU_archThreadSet_None_eq:
+  "do
+    archThreadSet (atcbVCPUPtr_update (\<lambda>_. Nothing)) t;
+    setObject v $ vcpuTCBPtr_update (\<lambda>_. Nothing) vcpu;
+    f
+   od = do
+    do
+      archThreadSet (atcbVCPUPtr_update (\<lambda>_. Nothing)) t;
+      setObject v $ vcpuTCBPtr_update (\<lambda>_. Nothing) vcpu
+    od;
+    f
+  od" by (simp add: bind_assoc)
+
+lemma vcpuInvalidateActive_inactive[wp]:
+  "\<lbrace>\<top>\<rbrace> vcpuInvalidateActive \<lbrace>\<lambda>rv s. \<forall>p. (\<exists>a. armHSCurVCPU (ksArchState s) = Some (p, a)) \<longrightarrow> P p rv s\<rbrace>"
+  unfolding vcpuInvalidateActive_def modifyArchState_def by wpsimp
+
+lemma vcpuDisableNone_obj_at'[wp]:
+  "vcpuDisable None \<lbrace>\<lambda>s. P (obj_at' P' p s)\<rbrace>"
+  unfolding vcpuDisable_def by wpsimp
+
+lemma vcpuInvalidateActive_obj_at'[wp]:
+  "vcpuInvalidateActive \<lbrace>\<lambda>s. P (obj_at' P' p s)\<rbrace>"
+  unfolding vcpuInvalidateActive_def modifyArchState_def by wpsimp
+
+lemma when_assert_eq:
+  "(when P $ haskell_fail xs) = assert (\<not>P)"
+  by (simp add: assert_def when_def)
+
+lemma dissociateVCPUTCB_invs'[wp]:
+  "dissociateVCPUTCB vcpu tcb \<lbrace>invs'\<rbrace>"
+  unfolding dissociateVCPUTCB_def setVCPU_archThreadSet_None_eq when_assert_eq
+  apply (wpsimp wp: dissoc_invs' getVCPU_wp | wpsimp wp: getObject_tcb_wp simp: archThreadGet_def)+
+  apply (drule tcb_ko_at')
+  apply clarsimp
+  apply (rule exI, rule conjI, assumption)
+  apply clarsimp
+  apply (rule conjI)
+   apply normalise_obj_at'
+  apply (rule conjI)
+   apply normalise_obj_at'
+  apply (clarsimp simp: obj_at'_def)
+  done
+
+lemma vcpuFinalise_invs'[wp]: "vcpuFinalise vcpu \<lbrace>invs'\<rbrace>"
+  unfolding vcpuFinalise_def by wpsimp
 
 lemma arch_finaliseCap_invs[wp]:
-  "\<lbrace>invs' and valid_cap' (ArchObjectCap cap)\<rbrace>
-     Arch.finaliseCap cap fin
-   \<lbrace>\<lambda>rv. invs'\<rbrace>"
-  unfolding RISCV64_H.finaliseCap_def by wpsimp
+  "\<lbrace>invs' and valid_cap' (ArchObjectCap cap)\<rbrace> Arch.finaliseCap cap fin \<lbrace>\<lambda>rv. invs'\<rbrace>"
+  unfolding ARM_HYP_H.finaliseCap_def Let_def by wpsimp
 
-crunch setVMRoot, deleteASIDPool
-  for ctes_of[wp]: "\<lambda>s. P (ctes_of s)"
-  (wp: crunch_wps getObject_inv loadObject_default_inv getASID_wp simp: crunch_simps)
+lemma setObject_tcb_unlive[wp]:
+   "\<lbrace>\<lambda>s. vr \<noteq> t \<and> ko_wp_at' (Not \<circ> live') vr s\<rbrace>
+        setObject t (tcbArch_update (\<lambda>_. atcbVCPUPtr_update Map.empty (tcbArch tcb)) tcb)
+           \<lbrace>\<lambda>_. ko_wp_at' (Not \<circ> live') vr\<rbrace>"
+  apply (rule wp_pre)
+  apply (wpsimp wp: setObject_ko_wp_at simp: objBits_simps', simp+)
+  apply (clarsimp simp: tcb_at_typ_at' typ_at'_def ko_wp_at'_def )
+  done
 
-lemma deleteASID_ctes_of[wp]:
-  "deleteASID a ptr \<lbrace>\<lambda>s. P (ctes_of s)\<rbrace>"
-  unfolding deleteASID_def by (wpsimp wp: getASID_wp)
+lemma setVCPU_unlive[wp]:
+  "\<lbrace>\<top>\<rbrace> setObject vr (vcpuTCBPtr_update Map.empty vcpu) \<lbrace>\<lambda>_. ko_wp_at' (Not \<circ> live') vr\<rbrace>"
+  apply (rule wp_pre)
+  apply (wpsimp wp: setObject_ko_wp_at
+           simp: objBits_def objBitsKO_def archObjSize_def vcpu_bits_def pageBits_def)
+    apply simp+
+  apply (clarsimp simp: live'_def hyp_live'_def arch_live'_def ko_wp_at'_def obj_at'_def)
+  done
 
-lemma unmapPageTable_ctes_of[wp]:
-  "unmapPageTable asid vptr pt \<lbrace>\<lambda>s. P (ctes_of s)\<rbrace>"
-  unfolding unmapPageTable_def by wpsimp
+lemma asUser_unlive[wp]:
+  "\<lbrace>ko_wp_at' (Not \<circ> live') vr\<rbrace> asUser t f \<lbrace>\<lambda>_. ko_wp_at' (Not \<circ> live') vr\<rbrace>"
+  unfolding asUser_def
+  apply (wpsimp simp: threadSet_def atcbContextSet_def objBits_simps' split_def
+                  wp: setObject_ko_wp_at)
+  apply (rule refl, simp)
+  apply (wpsimp simp: atcbContextGet_def wp: getObject_tcb_wp threadGet_wp)+
+  apply (clarsimp simp: tcb_at_typ_at' typ_at'_def ko_wp_at'_def[where p=t])
+  apply (case_tac ko; simp)
+  apply (rename_tac tcb)
+  apply (rule_tac x=tcb in exI)
+  apply (clarsimp simp: obj_at'_def projectKOs)
+  apply (clarsimp simp: ko_wp_at'_def live'_def hyp_live'_def)
+  done
+
+lemma dissociateVCPUTCB_unlive:
+  "\<lbrace> \<top> \<rbrace> dissociateVCPUTCB vcpu tcb \<lbrace> \<lambda>_. ko_wp_at' (Not o live') vcpu \<rbrace>"
+  unfolding dissociateVCPUTCB_def setVCPU_archThreadSet_None_eq when_assert_eq
+  by (wpsimp wp: getVCPU_wp[where p=vcpu] |
+      wpsimp wp: getObject_tcb_wp hoare_vcg_conj_lift hoare_vcg_ex_lift
+                 getVCPU_wp[where p=vcpu] setVCPU_unlive[simplified o_def]
+                 setObject_tcb_unlive hoare_drop_imp setObject_tcb_strongest
+             simp: archThreadGet_def archThreadSet_def)+
+
+lemma vcpuFinalise_unlive[wp]:
+  "\<lbrace> \<top> \<rbrace> vcpuFinalise v \<lbrace> \<lambda>_. ko_wp_at' (Not o live') v \<rbrace>"
+  apply (wpsimp simp: vcpuFinalise_def wp: dissociateVCPUTCB_unlive getVCPU_wp)
+  apply (frule state_hyp_refs_of'_vcpu_absorb)
+  apply (auto simp: ko_wp_at'_def)
+  apply (rule_tac x="KOArch (KOVCPU ko)" in exI)
+  apply (clarsimp simp: live'_def hyp_live'_def arch_live'_def obj_at'_def projectKOs)
+  done
 
 lemma arch_finaliseCap_removeable[wp]:
   "\<lbrace>\<lambda>s. s \<turnstile>' ArchObjectCap cap \<and> invs' s
-       \<and> (final \<and> final_matters' (ArchObjectCap cap)
-            \<longrightarrow> isFinal (ArchObjectCap cap) slot (cteCaps_of s))\<rbrace>
+       \<and> (final_matters' (ArchObjectCap cap)
+               \<longrightarrow> (final = isFinal (ArchObjectCap cap) slot (cteCaps_of s))) \<rbrace>
      Arch.finaliseCap cap final
-   \<lbrace>\<lambda>rv s. isNullCap (fst rv) \<and> removeable' slot s (ArchObjectCap cap)
-          \<and> (snd rv \<noteq> NullCap \<longrightarrow> snd rv = (ArchObjectCap cap) \<and> cap_has_cleanup' (ArchObjectCap cap)
-                                      \<and> isFinal (ArchObjectCap cap) slot (cteCaps_of s))\<rbrace>"
-  apply (simp add: RISCV64_H.finaliseCap_def removeable'_def)
-  apply (wpsimp wp: cteCaps_of_ctes_of_lift)
+   \<lbrace>\<lambda>rv s. isNullCap (fst rv) \<and> removeable' slot s (ArchObjectCap cap) \<and> isNullCap (snd rv)\<rbrace>"
+  unfolding ARM_HYP_H.finaliseCap_def
+  including classic_wp_pre
+  apply (case_tac cap; clarsimp)
+        apply ((wpsimp simp: removeable'_def isCap_simps
+                 | rule conjI)+)[5]
+   apply (clarsimp simp: isCap_simps, rule conjI)
+    apply (wpsimp simp: isCap_simps removeable'_def wp: hoare_disjI2)
+   apply  (wpsimp simp: not_Final_removeable final_matters'_def)
+  apply  (wpsimp simp: isCap_simps removeable'_def)
   done
 
 lemma isZombie_Null:
@@ -2500,6 +2968,8 @@ lemma prepares_delete_helper'':
   apply (rule hoare_strengthen_post [OF x])
   apply (clarsimp simp: removeable'_def)
   done
+
+lemmas ctes_of_cteCaps_of_lift = cteCaps_of_ctes_of_lift
 
 crunch finaliseCapTrue_standin, unbindNotification
   for ctes_of[wp]: "\<lambda>s. P (ctes_of s)"
@@ -2535,9 +3005,15 @@ lemma cteDeleteOne_isFinal:
   apply (clarsimp simp: isFinal_def sameObjectAs_def2)
   done
 
-lemmas setEndpoint_cteCaps_of[wp] = cteCaps_of_ctes_of_lift [OF set_ep_ctes_of]
-lemmas setNotification_cteCaps_of[wp] = cteCaps_of_ctes_of_lift [OF set_ntfn_ctes_of]
-lemmas threadSet_cteCaps_of = cteCaps_of_ctes_of_lift [OF threadSet_ctes_of]
+lemmas setEndpoint_cteCaps_of[wp] = ctes_of_cteCaps_of_lift [OF set_ep_ctes_of]
+lemmas setNotification_cteCaps_of[wp] = ctes_of_cteCaps_of_lift [OF set_ntfn_ctes_of]
+lemmas threadSet_cteCaps_of = ctes_of_cteCaps_of_lift [OF threadSet_ctes_of]
+
+crunch dissociateVCPUTCB
+  for ctes_of[wp]: "\<lambda>s. P (ctes_of s)"
+  (wp: crunch_wps simp: crunch_simps)
+
+lemmas dissociateVCPUTCB_isFinal =  ctes_of_cteCaps_of_lift [OF dissociateVCPUTCB_ctes_of]
 
 crunch suspend, prepareThreadDelete
   for isFinal: "\<lambda>s. isFinal cap slot (cteCaps_of s)"
@@ -2560,15 +3036,17 @@ lemma cteDeleteOne_deletes[wp]:
   apply clarsimp
   done
 
-lemma unmapPageTable_irq_node'[wp]:
-  "unmapPageTable asid vaddr pt \<lbrace>\<lambda>s. P (irq_node' s)\<rbrace>"
-  unfolding unmapPageTable_def by wpsimp
+crunch vcpuSwitch
+  for irq_node'[wp]: "\<lambda>s. P (irq_node' s)"
+  (wp: FalseI crunch_wps getObject_inv loadObject_default_inv
+       updateObject_default_inv setObject_ksInterrupt
+   simp: crunch_simps unless_def)
 
 crunch finaliseCap
   for irq_node'[wp]: "\<lambda>s. P (irq_node' s)"
-  (wp: crunch_wps getObject_inv loadObject_default_inv
+  (wp: mapM_x_wp crunch_wps getObject_inv loadObject_default_inv
        updateObject_default_inv setObject_ksInterrupt
-   simp: crunch_simps o_def)
+   simp: crunch_simps unless_def o_def)
 
 lemma deletingIRQHandler_removeable':
   "\<lbrace>invs' and (\<lambda>s. isFinal (IRQHandlerCap irq) slot (cteCaps_of s))
@@ -2591,7 +3069,7 @@ lemma finaliseCap_cte_refs:
      finaliseCap cap final flag
    \<lbrace>\<lambda>rv s. fst rv \<noteq> NullCap \<longrightarrow> cte_refs' (fst rv) = cte_refs' cap\<rbrace>"
   apply (simp  add: finaliseCap_def Let_def getThreadCSpaceRoot
-                    RISCV64_H.finaliseCap_def
+                    ARM_HYP_H.finaliseCap_def
              cong: if_cong split del: if_split)
   apply (rule hoare_pre)
    apply (wp | wpc | simp only: o_def)+
@@ -2601,7 +3079,7 @@ lemma finaliseCap_cte_refs:
   apply clarsimp
   apply (rule ext, simp)
   apply (rule image_cong [OF _ refl])
-  apply (fastforce simp: mask_def capAligned_def objBits_simps shiftL_nat)
+  apply (fastforce simp: capAligned_def objBits_simps shiftL_nat mask_def)
   done
 
 lemma deletingIRQHandler_final:
@@ -2619,7 +3097,7 @@ declare suspend_unqueued [wp]
 
 lemma unbindNotification_valid_objs'_helper:
   "valid_tcb' tcb s \<longrightarrow> valid_tcb' (tcbBoundNotification_update (\<lambda>_. None) tcb) s "
-  by (clarsimp simp: valid_bound_ntfn'_def valid_tcb'_def tcb_cte_cases_def cteSizeBits_def
+  by (clarsimp simp: valid_bound_ntfn'_def valid_tcb'_def tcb_cte_cases_def tcb_cte_cases_neqs
                   split: option.splits ntfn.splits)
 
 lemma unbindNotification_valid_objs'_helper':
@@ -2638,7 +3116,7 @@ lemma unbindNotification_valid_objs'[wp]:
   apply (wp threadSet_valid_objs' gbn_wp' set_ntfn_valid_objs' hoare_vcg_all_lift
             setNotification_valid_tcb' getNotification_wp
         | wpc | clarsimp simp: setBoundNotification_def unbindNotification_valid_objs'_helper)+
-  apply (clarsimp elim!: obj_atE')
+  apply (clarsimp elim!: obj_atE' simp: projectKOs)
   apply (rule valid_objsE', assumption+)
   apply (clarsimp simp: valid_obj'_def unbindNotification_valid_objs'_helper')
   done
@@ -2653,7 +3131,7 @@ lemma unbindMaybeNotification_valid_objs'[wp]:
   apply (wp threadSet_valid_objs' gbn_wp' set_ntfn_valid_objs' hoare_vcg_all_lift
             setNotification_valid_tcb' getNotification_wp
         | wpc | clarsimp simp: setBoundNotification_def unbindNotification_valid_objs'_helper)+
-  apply (clarsimp elim!: obj_atE')
+  apply (clarsimp elim!: obj_atE' simp: projectKOs)
   apply (rule valid_objsE', assumption+)
   apply (clarsimp simp: valid_obj'_def unbindNotification_valid_objs'_helper')
   done
@@ -2677,9 +3155,10 @@ lemma sym_refs_ntfn_bound_eq: "sym_refs (state_refs_of' s)
     = bound_tcb_at' (\<lambda>st. st = Some x) t s"
   apply (rule iffI)
    apply (drule (1) sym_refs_obj_atD')
-   apply (clarsimp simp: pred_tcb_at'_def obj_at'_def ko_wp_at'_def refs_of_rev')
+   apply (clarsimp simp: pred_tcb_at'_def obj_at'_def ko_wp_at'_def projectKOs
+                         refs_of_rev')
   apply (drule(1) sym_refs_bound_tcb_atD')
-  apply (clarsimp simp: obj_at'_def ko_wp_at'_def refs_of_rev')
+  apply (clarsimp simp: obj_at'_def projectKOs ko_wp_at'_def refs_of_rev')
   done
 
 lemma unbindMaybeNotification_obj_at'_bound:
@@ -2691,18 +3170,21 @@ lemma unbindMaybeNotification_obj_at'_bound:
   apply (rule hoare_pre)
    apply (wp obj_at_setObject2
         | wpc
-        | simp add: setBoundNotification_def threadSet_def updateObject_default_def in_monad)+
+        | simp add: setBoundNotification_def threadSet_def updateObject_default_def in_monad projectKOs)+
   apply (simp add: setNotification_def obj_at'_real_def cong: valid_cong)
    apply (wp setObject_ko_wp_at, (simp add: objBits_simps')+)
-  apply (clarsimp simp: obj_at'_def ko_wp_at'_def)
+  apply (clarsimp simp: obj_at'_def ko_wp_at'_def projectKOs)
   done
 
+context
+notes option.case_cong_weak[cong]
+begin
 crunch unbindNotification, unbindMaybeNotification
   for isFinal[wp]: "\<lambda>s. isFinal cap slot (cteCaps_of s)"
   (wp: sts_bound_tcb_at' threadSet_cteCaps_of crunch_wps getObject_inv
        loadObject_default_inv
-   ignore: threadSet
-   simp: setBoundNotification_def)
+   ignore: threadSet)
+end
 
 crunch cancelSignal, cancelAllIPC
   for bound_tcb_at'[wp]: "bound_tcb_at' P t"
@@ -2727,7 +3209,7 @@ lemma capDeleteOne_bound_tcb_at':
    apply (wp finaliseCapTrue_standin_bound_tcb_at' hoare_vcg_all_lift
             hoare_vcg_if_lift2 getCTE_cteCap_wp
         | wpc | simp | wp (once) hoare_drop_imp)+
-  apply (clarsimp simp:  cteCaps_of_def isReplyCap_def cte_wp_at_ctes_of
+  apply (clarsimp simp:  cteCaps_of_def projectKOs isReplyCap_def cte_wp_at_ctes_of
                  split: option.splits)
   apply (case_tac "cteCap cte", simp_all)
   done
@@ -2747,6 +3229,22 @@ lemma cancelIPC_bound_tcb_at'[wp]:
    apply (clarsimp simp: capHasProperty_def cte_wp_at_ctes_of)
    apply (wp threadSet_pred_tcb_no_state | simp)+
   done
+
+lemma archThreadSet_bound_tcb_at'[wp]:
+  "archThreadSet f t \<lbrace>bound_tcb_at' P t'\<rbrace>"
+  unfolding archThreadSet_def
+  apply (wpsimp wp: setObject_tcb_strongest getObject_tcb_wp simp: pred_tcb_at'_def)
+  by (auto simp: obj_at'_def projectKOs objBits_simps)
+
+lemmas asUser_bound_obj_at'[wp] = asUser_pred_tcb_at' [of itcbBoundNotification]
+
+lemmas setObject_vcpu_pred_tcb_at'[wp] =
+  setObject_vcpu_obj_at'_no_vcpu [of _ "\<lambda>ko. tst (pr (tcb_to_itcb' ko))" for tst pr, folded pred_tcb_at'_def]
+
+crunch dissociateVCPUTCB, vgicUpdateLR
+  for bound_tcb_at'[wp]: "bound_tcb_at' P t"
+  (wp: sts_bound_tcb_at' getVCPU_wp crunch_wps hoare_vcg_all_lift hoare_vcg_if_lift3
+   ignore: archThreadSet)
 
 crunch suspend, prepareThreadDelete
   for bound_tcb_at'[wp]: "bound_tcb_at' P t"
@@ -2774,15 +3272,64 @@ lemma unbindMaybeNotification_tcb_at'[wp]:
   apply (wp gbn_wp' | wpc | simp)+
   done
 
+lemma dissociateVCPUTCB_cte_wp_at'[wp]:
+  "dissociateVCPUTCB v t \<lbrace>cte_wp_at' P p\<rbrace>"
+  unfolding cte_wp_at_ctes_of by wp
+
+lemmas dissociateVCPUTCB_typ_ats'[wp] = typ_at_lifts[OF dissociateVCPUTCB_typ_at']
+
 crunch prepareThreadDelete
   for cte_wp_at'[wp]: "cte_wp_at' P p"
 crunch prepareThreadDelete
   for valid_cap'[wp]: "valid_cap' cap"
 crunch prepareThreadDelete
-  for invs[wp]: "invs'" (ignore: doMachineOp)
-crunch prepareThreadDelete
-  for obj_at'[wp]: "\<lambda>s. P' (obj_at' P p s)"
-  (wp: whenE_wp simp: crunch_simps)
+  for invs[wp]: "invs'"
+
+lemma unset_vcpu_hyp_unlive[wp]:
+  "\<lbrace>\<top>\<rbrace> archThreadSet (atcbVCPUPtr_update Map.empty) t \<lbrace>\<lambda>_. ko_wp_at' (Not \<circ> hyp_live') t\<rbrace>"
+  unfolding archThreadSet_def
+  apply (wpsimp wp: setObject_ko_wp_at' getObject_tcb_wp; (simp add: objBits_simps')?)+
+  apply (clarsimp simp: obj_at'_def ko_wp_at'_def projectKOs hyp_live'_def)
+  done
+
+ lemma unset_tcb_hyp_unlive[wp]:
+  "\<lbrace>\<top>\<rbrace> setObject vr (vcpuTCBPtr_update Map.empty vcpu) \<lbrace>\<lambda>_. ko_wp_at' (Not \<circ> hyp_live') vr\<rbrace>"
+  apply (wpsimp wp: setObject_ko_wp_at' getObject_tcb_wp
+                simp: objBits_simps archObjSize_def vcpu_bits_def pageBits_def
+        | simp)+
+  apply (clarsimp simp: obj_at'_def ko_wp_at'_def projectKOs hyp_live'_def arch_live'_def)
+  done
+
+lemma setObject_vcpu_hyp_unlive[wp]:
+   "\<lbrace>\<lambda>s. t \<noteq> vr \<and> ko_wp_at' (Not \<circ> hyp_live') t s\<rbrace>
+         setObject vr (vcpuTCBPtr_update Map.empty vcpu)
+    \<lbrace>\<lambda>_. ko_wp_at' (Not \<circ> hyp_live') t\<rbrace>"
+  apply (rule wp_pre)
+  apply (wpsimp wp: setObject_ko_wp_at
+                simp: objBits_def objBitsKO_def archObjSize_def vcpu_bits_def pageBits_def
+        | simp)+
+  apply (clarsimp simp: tcb_at_typ_at' typ_at'_def ko_wp_at'_def )
+  done
+
+
+lemma asUser_hyp_unlive[wp]:
+  "asUser f t \<lbrace>ko_wp_at' (Not \<circ> hyp_live') t'\<rbrace>"
+  unfolding asUser_def
+  apply (wpsimp wp: threadSet_ko_wp_at2' threadGet_wp)
+  apply (clarsimp simp: ko_wp_at'_def obj_at'_def projectKOs hyp_live'_def atcbContextSet_def)
+  done
+
+lemma dissociateVCPUTCB_hyp_unlive[wp]:
+  "\<lbrace>\<top>\<rbrace> dissociateVCPUTCB v t \<lbrace>\<lambda>_. ko_wp_at' (Not \<circ> hyp_live') t\<rbrace>"
+  unfolding dissociateVCPUTCB_def
+  by (cases "v = t"; wpsimp wp: unset_tcb_hyp_unlive unset_vcpu_hyp_unlive[simplified comp_def])
+
+lemma prepareThreadDelete_hyp_unlive[wp]:
+  "\<lbrace>\<top>\<rbrace> prepareThreadDelete t \<lbrace>\<lambda>_. ko_wp_at' (Not \<circ> hyp_live') t\<rbrace>"
+  unfolding prepareThreadDelete_def archThreadGet_def
+  apply (wpsimp wp: getObject_tcb_wp)
+  apply (clarsimp simp: ko_wp_at'_def obj_at'_def projectKOs hyp_live'_def)
+  done
 
 end
 
@@ -2790,6 +3337,7 @@ lemma tcbQueueRemove_tcbSchedNext_tcbSchedPrev_None_obj_at':
   "\<lbrace>\<lambda>s. \<exists>ts. list_queue_relation ts q (tcbSchedNexts_of s) (tcbSchedPrevs_of s)\<rbrace>
    tcbQueueRemove q t
    \<lbrace>\<lambda>_ s. obj_at' (\<lambda>tcb. tcbSchedNext tcb = None \<and> tcbSchedPrev tcb = None) t s\<rbrace>"
+  supply projectKOs[simp]
   apply (clarsimp simp: tcbQueueRemove_def)
   apply (wpsimp wp: threadSet_wp getTCB_wp)
   by (fastforce dest!: heap_ls_last_None
@@ -2801,6 +3349,7 @@ lemma tcbSchedDequeue_tcbSchedNext_tcbSchedPrev_None_obj_at':
   "\<lbrace>valid_sched_pointers\<rbrace>
    tcbSchedDequeue t
    \<lbrace>\<lambda>_ s. obj_at' (\<lambda>tcb. tcbSchedNext tcb = None \<and> tcbSchedPrev tcb = None) t s\<rbrace>"
+  supply projectKOs[simp]
   unfolding tcbSchedDequeue_def
   by (wpsimp wp: tcbQueueRemove_tcbSchedNext_tcbSchedPrev_None_obj_at' threadGet_wp)
      (fastforce simp: ready_queue_relation_def ksReadyQueues_asrt_def obj_at'_def
@@ -2823,6 +3372,22 @@ lemma suspend_tcbSchedNext_tcbSchedPrev_None:
   unfolding suspend_def
   by (wpsimp wp: hoare_drop_imps tcbSchedDequeue_tcbSchedNext_tcbSchedPrev_None_obj_at')
 
+context begin interpretation Arch . (*FIXME: arch-split*)
+
+lemma archThreadSet_tcbSchedPrevNext[wp]:
+  "archThreadSet f t' \<lbrace>obj_at' (\<lambda>tcb. P (tcbSchedNext tcb) (tcbSchedPrev tcb)) t\<rbrace>"
+  unfolding archThreadSet_def
+  apply (wpsimp wp: setObject_tcb_strongest getObject_tcb_wp)
+  apply normalise_obj_at'
+  apply auto
+  done
+
+crunch prepareThreadDelete
+  for tcbSchedPrevNext[wp]: "obj_at' (\<lambda>tcb. P (tcbSchedNext tcb) (tcbSchedPrev tcb)) t"
+  (wp: threadGet_wp getVCPU_wp archThreadGet_wp crunch_wps simp: crunch_simps)
+
+end
+
 lemma (in delete_one_conc_pre) finaliseCap_replaceable:
   "\<lbrace>\<lambda>s. invs' s \<and> cte_wp_at' (\<lambda>cte. cteCap cte = cap) slot s
        \<and> (final_matters' cap \<longrightarrow> (final = isFinal cap slot (cteCaps_of s)))
@@ -2842,14 +3407,15 @@ lemma (in delete_one_conc_pre) finaliseCap_replaceable:
             \<and> (\<forall>p \<in> threadCapRefs cap. st_tcb_at' ((=) Inactive) p s
                      \<and> obj_at' (Not \<circ> tcbQueued) p s
                      \<and> bound_tcb_at' ((=) None) p s
+                     \<and> ko_wp_at' (Not \<circ> hyp_live') p s
                      \<and> obj_at' (\<lambda>tcb. tcbSchedNext tcb = None \<and> tcbSchedPrev tcb = None) p s))\<rbrace>"
   apply (simp add: finaliseCap_def Let_def getThreadCSpaceRoot
              cong: if_cong split del: if_split)
   apply (rule hoare_pre)
    apply (wp prepares_delete_helper'' [OF cancelAllIPC_unlive]
              prepares_delete_helper'' [OF cancelAllSignals_unlive]
-             suspend_isFinal RISCV64.prepareThreadDelete_unqueued (* FIXME arch-split: interface *)
-             RISCV64.prepareThreadDelete_inactive prepareThreadDelete_isFinal
+             suspend_isFinal ARM_HYP.prepareThreadDelete_unqueued (* FIXME arch-split: interface *)
+             ARM_HYP.prepareThreadDelete_inactive prepareThreadDelete_isFinal
              suspend_makes_inactive
              deletingIRQHandler_removeable'
              deletingIRQHandler_final[where slot=slot ]
@@ -2866,16 +3432,11 @@ lemma (in delete_one_conc_pre) finaliseCap_replaceable:
   apply clarsimp
   apply (frule cte_wp_at_valid_objs_valid_cap', clarsimp+)
   apply (case_tac "cteCap cte",
-         simp_all add: gen_isCap_simps capRange_def cap_has_cleanup'_def
+         simp_all add: gen_isCap_simps capRange_def
                        final_matters'_def gen_objBits_simps
                        not_Final_removeable finaliseCap_def,
-         simp_all add: removeable'_def)
-     (* thread *)
-     apply (frule capAligned_capUntypedPtr [OF valid_capAligned], simp)
-     apply (clarsimp simp: valid_cap'_def)
-     apply (drule valid_globals_cte_wpD'[rotated], clarsimp)
-     apply (clarsimp simp: invs'_def valid_state'_def valid_pspace'_def)
-    apply (clarsimp simp: obj_at'_def | rule conjI)+
+         simp_all add: removeable'_def)[1]
+   apply fastforce+
   done
 
 lemma cteDeleteOne_cte_wp_at_preserved:
@@ -2902,13 +3463,13 @@ lemma cancelIPC_cteCaps_of:
                    getThreadReplySlot_def locateSlot_conv)
   apply (rule hoare_pre)
    apply (wp cteDeleteOne_cteCaps_of getCTE_wp' | wpcw
-          | simp add: cte_wp_at_ctes_of
-          | wp (once) hoare_drop_imps cteCaps_of_ctes_of_lift)+
+        | simp add: cte_wp_at_ctes_of
+        | wp (once) hoare_drop_imps ctes_of_cteCaps_of_lift)+
           apply (wp hoare_convert_imp hoare_vcg_all_lift
                     threadSet_ctes_of threadSet_cteCaps_of
-                 | clarsimp)+
-         apply (wp cteDeleteOne_cteCaps_of getCTE_wp' | wpcw | simp
-                | wp (once) hoare_drop_imps cteCaps_of_ctes_of_lift)+
+               | clarsimp)+
+    apply (wp cteDeleteOne_cteCaps_of getCTE_wp' | wpcw | simp
+       | wp (once) hoare_drop_imps ctes_of_cteCaps_of_lift)+
   apply (clarsimp simp: cte_wp_at_ctes_of cteCaps_of_def)
   apply (drule_tac x="mdbNext (cteMDBNode x)" in spec)
   apply clarsimp
@@ -2934,7 +3495,8 @@ lemma suspend_cte_wp_at':
   shows "\<lbrace>cte_wp_at' (\<lambda>cte. P (cteCap cte)) p\<rbrace>
            suspend t
          \<lbrace>\<lambda>rv. cte_wp_at' (\<lambda>cte. P (cteCap cte)) p\<rbrace>"
-  apply (simp add: suspend_def updateRestartPC_def)
+  apply (simp add: suspend_def)
+  unfolding updateRestartPC_def
   apply (rule hoare_pre)
    apply (wp threadSet_cte_wp_at' cancelIPC_cte_wp_at'
              | simp add: x)+
@@ -2949,11 +3511,12 @@ crunch deleteASIDPool
 
 lemma deleteASID_cte_wp_at'[wp]:
   "\<lbrace>cte_wp_at' P p\<rbrace> deleteASID param_a param_b \<lbrace>\<lambda>_. cte_wp_at' P p\<rbrace>"
-  apply (simp add: deleteASID_def
+  apply (simp add: deleteASID_def invalidateHWASIDEntry_def invalidateASID_def
               cong: option.case_cong)
   apply (wp setObject_cte_wp_at'[where Q="\<top>"] getObject_inv
             loadObject_default_inv setVMRoot_cte_wp_at'
           | clarsimp simp: updateObject_default_def in_monad
+                           projectKOs
           | rule equals0I
           | wpc)+
   done
@@ -2962,11 +3525,14 @@ crunch unmapPageTable, unmapPage, unbindNotification, finaliseCapTrue_standin
   for cte_wp_at'[wp]: "cte_wp_at' P p"
   (simp: crunch_simps wp: crunch_wps getObject_inv loadObject_default_inv)
 
+crunch vcpuFinalise
+  for cte_wp_at'[wp]: "cte_wp_at' P p"
+  (wp: crunch_wps getObject_inv loadObject_default_inv)
+
 lemma arch_finaliseCap_cte_wp_at[wp]:
   "\<lbrace>cte_wp_at' P p\<rbrace> Arch.finaliseCap cap fin \<lbrace>\<lambda>rv. cte_wp_at' P p\<rbrace>"
-  apply (simp add: RISCV64_H.finaliseCap_def)
-  apply (wpsimp wp: unmapPage_cte_wp_at')
-  done
+  unfolding ARM_HYP_H.finaliseCap_def
+  by (wpsimp wp: unmapPage_cte_wp_at'|rule conjI)+
 
 lemma deletingIRQHandler_cte_preserved:
   assumes x: "\<And>cap final. P cap \<Longrightarrow> finaliseCap cap final True = fail"
@@ -2975,7 +3541,8 @@ lemma deletingIRQHandler_cte_preserved:
          \<lbrace>\<lambda>rv. cte_wp_at' (\<lambda>cte. P (cteCap cte)) p\<rbrace>"
   apply (simp add: deletingIRQHandler_def getSlotCap_def
                    getIRQSlot_def locateSlot_conv getInterruptState_def)
-  apply (wpsimp wp: cteDeleteOne_cte_wp_at_preserved getCTE_wp' simp: x)
+  apply (wp cteDeleteOne_cte_wp_at_preserved getCTE_wp'
+              | simp add: x)+
   done
 
 lemma finaliseCap_equal_cap[wp]:
@@ -3015,7 +3582,7 @@ lemma cteDeleteOne_st_tcb_at[wp]:
    apply (clarsimp simp: pred_disj_def)
    apply (rule cteDeleteOne_st_tcb_at_simplish)
   apply (rule_tac x=P in exI)
-  apply auto
+  apply (auto intro!: ext)
   done
 
 lemma cteDeleteOne_reply_pred_tcb_at:
@@ -3030,18 +3597,16 @@ lemma cteDeleteOne_reply_pred_tcb_at:
   apply (intro impI conjI, (wp | simp)+)
   done
 
-lemmas setNotification_typ_at'[wp] = typ_at_lifts[OF setNotification_typ_at']
-
-crunch setBoundNotification, setNotification
-  for sch_act_simple[wp]: sch_act_simple
-  (wp: sch_act_simple_lift)
-
+context
+notes option.case_cong_weak[cong]
+begin
 crunch cteDeleteOne, unbindNotification
   for sch_act_simple[wp]: sch_act_simple
   (wp: crunch_wps ssa_sch_act_simple sts_sch_act_simple getObject_inv
        loadObject_default_inv
-   simp: crunch_simps
+   simp: crunch_simps unless_def
    rule: sch_act_simple_lift)
+end
 
 lemma rescheduleRequired_sch_act_not[wp]:
   "\<lbrace>\<top>\<rbrace> rescheduleRequired \<lbrace>\<lambda>rv. sch_act_not t\<rbrace>"
@@ -3086,7 +3651,7 @@ lemma cancelAllIPC_mapM_x_tcbDomain_obj_at':
                  tcbSchedEnqueue t
                od) q
   \<lbrace>\<lambda>_. obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>"
-  by (wp mapM_x_wp' | simp)+
+  by (wpsimp wp: mapM_x_wp')
 
 lemma rescheduleRequired_oa_queued':
   "rescheduleRequired \<lbrace>obj_at' (\<lambda>tcb. Q (tcbDomain tcb) (tcbPriority tcb)) t\<rbrace>"
@@ -3097,13 +3662,13 @@ lemma cancelAllIPC_tcbDomain_obj_at':
   "\<lbrace>obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>
      cancelAllIPC epptr
    \<lbrace>\<lambda>_. obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>"
-  apply (simp add: cancelAllIPC_def)
-  apply (wp hoare_vcg_conj_lift hoare_vcg_const_Ball_lift
-            rescheduleRequired_oa_queued' cancelAllIPC_mapM_x_tcbDomain_obj_at'
-            getEndpoint_wp
-       | wpc
-       | simp)+
-  done
+apply (simp add: cancelAllIPC_def)
+apply (wp hoare_vcg_conj_lift hoare_vcg_const_Ball_lift
+          rescheduleRequired_oa_queued' cancelAllIPC_mapM_x_tcbDomain_obj_at'
+          getEndpoint_wp
+     | wpc
+     | simp)+
+done
 
 lemma cancelAllSignals_tcbDomain_obj_at':
   "\<lbrace>obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>
@@ -3118,9 +3683,7 @@ apply (wp hoare_vcg_conj_lift hoare_vcg_const_Ball_lift
 done
 
 lemma unbindMaybeNotification_tcbDomain_obj_at':
-  "\<lbrace>obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>
-     unbindMaybeNotification r
-   \<lbrace>\<lambda>_. obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>"
+  "unbindMaybeNotification r \<lbrace>obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>"
   unfolding unbindMaybeNotification_def
   by (wpsimp wp: getNotification_wp gbn_wp' simp: setBoundNotification_def)+
 
@@ -3153,8 +3716,7 @@ lemma cteDeleteOne_tcbDomain_obj_at':
 end
 
 global_interpretation delete_one_conc_pre
-  by (unfold_locales, wp)
-     (wp cteDeleteOne_tcbDomain_obj_at' cteDeleteOne_typ_at' cteDeleteOne_reply_pred_tcb_at | simp)+
+  by (unfold_locales, wp) (wp cteDeleteOne_tcbDomain_obj_at' cteDeleteOne_typ_at' cteDeleteOne_reply_pred_tcb_at | simp)+
 
 context begin interpretation Arch . (*FIXME: arch-split*)
 
@@ -3181,7 +3743,7 @@ lemma cteDeleteOne_invs[wp]:
     apply (rule conjI)
      subgoal by auto
     subgoal by (auto dest!: isCapDs simp: pred_tcb_at'_def obj_at'_def projectKOs
-                                           live'_def hyp_live'_def ko_wp_at'_def)
+                                      live'_def hyp_live'_def ko_wp_at'_def)
    apply (wp isFinalCapability_inv getCTE_wp' hoare_weak_lift_imp
         | wp (once) isFinal[where x=ptr])+
   apply (fastforce simp: cte_wp_at_ctes_of)
@@ -3201,6 +3763,9 @@ lemma deletingIRQHandler_invs' [wp]:
   apply (wp getCTE_wp')
   apply simp
   done
+
+crunch unbindNotification, unbindMaybeNotification
+  for tcb_at'[wp]: "tcb_at' t"
 
 lemma finaliseCap_invs:
   "\<lbrace>invs' and sch_act_simple and valid_cap' cap
@@ -3256,14 +3821,18 @@ lemma finaliseCap_cte_cap_wp_to[wp]:
   apply fastforce
   done
 
+context
+notes option.case_cong_weak[cong]
+begin
 crunch unbindNotification
   for valid_cap'[wp]: "valid_cap' cap"
+end
 
 lemma finaliseCap_valid_cap[wp]:
   "\<lbrace>valid_cap' cap\<rbrace> finaliseCap cap final flag \<lbrace>\<lambda>rv. valid_cap' (fst rv)\<rbrace>"
   apply (simp add: finaliseCap_def Let_def
                    getThreadCSpaceRoot
-                   RISCV64_H.finaliseCap_def
+                   ARM_HYP_H.finaliseCap_def
              cong: if_cong split del: if_split)
   apply (rule hoare_pre)
    apply (wp | simp only: valid_NullCap o_def fst_conv | wpc)+
@@ -3276,9 +3845,10 @@ lemma finaliseCap_valid_cap[wp]:
 
 context begin interpretation Arch . (*FIXME: arch-split*)
 
-lemma unmapPageTable_nosch[wp]:
-  "unmapPageTable asid vaddr pt \<lbrace>\<lambda>s. P (ksSchedulerAction s)\<rbrace>"
-  unfolding unmapPageTable_def by wpsimp
+crunch dissociateVCPUTCB
+  for nosch[wp]: "\<lambda>s. P (ksSchedulerAction s)"
+  (wp: crunch_wps getVCPU_wp getObject_inv hoare_vcg_all_lift hoare_vcg_if_lift3
+   simp: loadObject_default_def updateObject_default_def)
 
 crunch "Arch.finaliseCap"
   for nosch[wp]: "\<lambda>s. P (ksSchedulerAction s)"
@@ -3342,6 +3912,31 @@ lemma (in delete_one) deletingIRQHandler_corres:
 
 context begin interpretation Arch . (*FIXME: arch-split*)
 
+lemma sym_refs_vcpu_tcb:
+  "\<lbrakk> ko_at (ArchObj (VCPU vcpu)) v s; vcpu_tcb vcpu = Some t; sym_refs (state_hyp_refs_of s) \<rbrakk> \<Longrightarrow>
+  \<exists>tcb. ko_at (TCB tcb) t s \<and> tcb_vcpu (tcb_arch tcb) = Some v"
+  apply (drule (1) hyp_sym_refs_obj_atD)
+  apply (clarsimp simp: obj_at_def hyp_refs_of_def)
+  apply (rename_tac ko)
+  apply (case_tac ko; simp add: tcb_vcpu_refs_def split: option.splits)
+  apply (rename_tac koa)
+  apply (case_tac koa; simp add: refs_of_a_def vcpu_tcb_refs_def split: option.splits)
+  done
+
+lemma vcpuFinalise_corres [corres]:
+  "corres dc (invs and vcpu_at vcpu) (invs' and vcpu_at' vcpu) (vcpu_finalise vcpu) (vcpuFinalise vcpu)"
+  unfolding vcpuFinalise_def vcpu_finalise_def
+  apply (corresKsimp corres: getObject_vcpu_corres simp: vcpu_relation_def)
+     apply (wpsimp wp: get_vcpu_wp getVCPU_wp)+
+  apply (rule conjI)
+   apply clarsimp
+   apply (frule sym_refs_vcpu_tcb)
+     apply (simp add: vcpu_relation_def)
+    apply fastforce
+   apply (fastforce simp: obj_at_def vcpu_relation_def)
+  apply clarsimp
+  done
+
 lemma arch_finaliseCap_corres:
   "\<lbrakk> final_matters' (ArchObjectCap cap') \<Longrightarrow> final = final'; acap_relation cap cap' \<rbrakk>
      \<Longrightarrow> corres (\<lambda>r r'. cap_relation (fst r) (fst r') \<and> cap_relation (snd r) (snd r'))
@@ -3354,47 +3949,35 @@ lemma arch_finaliseCap_corres:
                       final' = isFinal (ArchObjectCap cap') (cte_map sl) (cteCaps_of s)))
            (arch_finalise_cap cap final) (Arch.finaliseCap cap' final')"
   apply (cases cap,
-         simp_all add: arch_finalise_cap_def RISCV64_H.finaliseCap_def
+         simp_all add: arch_finalise_cap_def ARM_HYP_H.finaliseCap_def isCap_simps
                        final_matters'_def case_bool_If liftM_def[symmetric]
                        o_def dc_def[symmetric]
-                split: option.split,
-         safe)
-    apply (rule corres_guard_imp, rule deleteASIDPool_corres[OF refl refl])
-     apply (clarsimp simp: valid_cap_def mask_def)
-    apply (clarsimp simp: valid_cap'_def)
-   apply auto[1]
-   apply (rule corres_guard_imp, rule unmapPage_corres[OF refl refl refl refl])
-    apply simp
-    apply (clarsimp simp: valid_cap_def valid_unmap_def)
-    apply (auto simp: vmsz_aligned_def pbfs_atleast_pageBits mask_def wellformed_mapdata_def
-                elim: is_aligned_weaken)[2]
-  apply (rule corres_guard_imp)
-    apply (rule corres_split_catch[where f=dc])
-       apply (rule corres_splitEE)
-          apply (rule corres_rel_imp[where r="dc \<oplus> (=)"], rule findVSpaceForASID_corres; simp)
-          apply (case_tac x; simp)
-         apply (simp only: whenE_def)
-         apply (rule corres_if[where Q=\<top> and Q'=\<top>], simp)
-          apply simp
-          apply (rule deleteASID_corres; rule refl)
-         apply simp
-        apply (wpsimp wp: hoare_vcg_if_lift_ER hoare_drop_imps)+
-      apply (rule unmapPageTable_corres; simp)
-     apply (wpsimp wp: hoare_drop_imps)+
-   apply (clarsimp simp: invs_psp_aligned invs_distinct invs_vspace_objs invs_valid_asid_table)
-   apply (clarsimp simp: cte_wp_at_caps_of_state)
-   apply (drule (1) caps_of_state_valid)
-   apply (simp add: valid_cap_def wellformed_mapdata_def)
-  apply (simp add: invs_no_0_obj')
+                split: option.split, safe)
+     apply (rule corres_guard_imp, rule deleteASIDPool_corres)
+      apply (clarsimp simp: valid_cap_def mask_def)
+     apply (clarsimp simp: valid_cap'_def)
+     apply auto[1]
+    apply (rule corres_guard_imp, rule unmapPage_corres)
+      apply simp
+     apply (clarsimp simp: valid_cap_def valid_unmap_def)
+     apply (auto simp: vmsz_aligned_def pbfs_atleast_pageBits mask_def
+                 elim: is_aligned_weaken invs_valid_asid_map)[2]
+   apply (rule corres_guard_imp, rule unmapPageTable_corres)
+    apply (auto simp: valid_cap_def valid_cap'_def mask_def
+               elim!: is_aligned_weaken invs_valid_asid_map)[2]
+  apply (rule corres_guard_imp, rule deleteASID_corres)
+   apply (auto elim!: invs_valid_asid_map simp: mask_def valid_cap_def)[2]
+  apply corresK
+  apply (clarsimp simp: valid_cap_def valid_cap'_def)
   done
-
 
 lemma unbindNotification_corres:
   "corres dc
       (invs and tcb_at t)
-      invs'
+      (invs' and tcb_at' t)
       (unbind_notification t)
       (unbindNotification t)"
+  supply option.case_cong_weak[cong]
   apply (simp add: unbind_notification_def unbindNotification_def)
   apply (rule corres_guard_imp)
     apply (rule corres_split[OF getBoundNotification_corres])
@@ -3407,13 +3990,17 @@ lemma unbindNotification_corres:
            apply (clarsimp simp: ntfn_relation_def split:Structures_A.ntfn.splits)
           apply (rule setBoundNotification_corres)
          apply (wp gbn_wp' gbn_wp)+
+   apply clarsimp
+   apply (frule invs_psp_aligned)
+   apply (frule invs_distinct)
    apply (clarsimp elim!: obj_at_valid_objsE
                    dest!: bound_tcb_at_state_refs_ofD invs_valid_objs
-                    simp: valid_obj_def is_tcb tcb_ntfn_is_bound_def obj_at_def
-                          valid_tcb_def valid_bound_ntfn_def invs_psp_aligned invs_distinct
+                    simp: valid_obj_def is_tcb tcb_ntfn_is_bound_def
+                          valid_tcb_def valid_bound_ntfn_def
                    split: option.splits)
   apply (clarsimp dest!: obj_at_valid_objs' bound_tcb_at_state_refs_ofD' invs_valid_objs'
-                   simp: valid_obj'_def valid_tcb'_def valid_bound_ntfn'_def tcb_ntfn_is_bound'_def
+                   simp: projectKOs valid_obj'_def valid_tcb'_def valid_bound_ntfn'_def
+                         tcb_ntfn_is_bound'_def
                   split: option.splits)
   done
 
@@ -3422,24 +4009,27 @@ lemma unbindMaybeNotification_corres:
       (invs and ntfn_at ntfnptr) (invs' and ntfn_at' ntfnptr)
       (unbind_maybe_notification ntfnptr)
       (unbindMaybeNotification ntfnptr)"
-  apply (simp add: unbind_maybe_notification_def unbindMaybeNotification_def)
+  apply (simp add: unbind_maybe_notification_def unbindMaybeNotification_def
+              cong: option.case_cong)
   apply (rule corres_guard_imp)
     apply (rule corres_split[OF getNotification_corres])
       apply (rule corres_option_split)
         apply (clarsimp simp: ntfn_relation_def split: Structures_A.ntfn.splits)
        apply (rule corres_return_trivial)
-      apply simp
       apply (rule corres_split[OF setNotification_corres])
          apply (clarsimp simp: ntfn_relation_def split: Structures_A.ntfn.splits)
         apply (rule setBoundNotification_corres)
        apply (wp get_simple_ko_wp getNotification_wp)+
+   apply clarsimp
+   apply (frule invs_psp_aligned)
+   apply (frule invs_distinct)
    apply (clarsimp elim!: obj_at_valid_objsE
                    dest!: bound_tcb_at_state_refs_ofD invs_valid_objs
-                    simp: valid_obj_def is_tcb tcb_ntfn_is_bound_def invs_psp_aligned invs_distinct
+                    simp: valid_obj_def is_tcb tcb_ntfn_is_bound_def
                           valid_tcb_def valid_bound_ntfn_def valid_ntfn_def
                    split: option.splits)
   apply (clarsimp dest!: obj_at_valid_objs' bound_tcb_at_state_refs_ofD' invs_valid_objs'
-                   simp: valid_obj'_def valid_tcb'_def valid_bound_ntfn'_def
+                   simp: projectKOs valid_obj'_def valid_tcb'_def valid_bound_ntfn'_def
                          tcb_ntfn_is_bound'_def valid_ntfn'_def
                   split: option.splits)
   done
@@ -3475,7 +4065,7 @@ lemma fast_finaliseCap_corres:
        apply (wp abs_typ_at_lifts unbind_maybe_notification_invs typ_at_lifts hoare_drop_imps getNotification_wp
             | wpc)+
    apply (clarsimp simp: valid_cap_def)
-  apply (clarsimp simp: valid_cap'_def valid_obj'_def
+  apply (clarsimp simp: valid_cap'_def projectKOs valid_obj'_def
                  dest!: invs_valid_objs' obj_at_valid_objs' )
   done
 
@@ -3542,7 +4132,7 @@ lemma finaliseCap_corres:
      \<Longrightarrow> corres (\<lambda>x y. cap_relation (fst x) (fst y) \<and> cap_relation (snd x) (snd y))
            (\<lambda>s. einvs s \<and> s \<turnstile> cap \<and> (final_matters cap \<longrightarrow> final = is_final_cap' cap s)
                        \<and> cte_wp_at ((=) cap) sl s)
-           (\<lambda>s. invs' s \<and> s \<turnstile>' cap' \<and>
+           (\<lambda>s. invs' s \<and> s \<turnstile>' cap' \<and> sch_act_simple s \<and>
                  (final_matters' cap' \<longrightarrow>
                       final' = isFinal cap' (cte_map sl) (cteCaps_of s)))
            (finalise_cap cap final) (finaliseCap cap' final' flag)"
@@ -3578,12 +4168,12 @@ lemma finaliseCap_corres:
        apply (rule corres_split[OF unbindNotification_corres])
          apply (rule corres_split[OF suspend_corres])
             apply (clarsimp simp: liftM_def[symmetric] o_def dc_def[symmetric] zbits_map_def)
-          apply (rule RISCV64.prepareThreadDelete_corres, rule refl) (* FIXME arch-split: interface *)
-        apply (wp unbind_notification_invs unbind_notification_simple_sched_action)+
+          apply (rule ARM_HYP.prepareThreadDelete_corres, rule refl) (* FIXME arch-split: interface *)
+        apply (wp unbind_notification_invs unbind_notification_simple_sched_action
+                  delete_one_conc_fr.suspend_objs')+
       apply (simp add: valid_cap_def)
      apply (simp add: valid_cap'_def)
-    apply (simp add: final_matters'_def liftM_def[symmetric]
-                     o_def dc_def[symmetric])
+    apply (simp add: final_matters'_def liftM_def[symmetric] o_def dc_def[symmetric])
     apply (intro impI, rule corres_guard_imp)
       apply (rule deletingIRQHandler_corres)
      apply simp
@@ -3599,19 +4189,66 @@ lemma finaliseCap_corres:
   done
 
 context begin interpretation Arch . (*FIXME: arch-split*)
+lemma arch_recycleCap_improve_cases:
+   "\<lbrakk> \<not> isPageCap cap; \<not> isPageTableCap cap; \<not> isPageDirectoryCap cap;\<not> isVCPUCap cap;
+         \<not> isASIDControlCap cap; \<not>isSGISignalCap cap \<rbrakk> \<Longrightarrow>
+  (if isASIDPoolCap cap then v else undefined) = v"
+  by (cases cap, simp_all add: isCap_simps)
+
+crunch copyGlobalMappings
+  for ifunsafe'[wp]: "if_unsafe_then_cap'"
+  (wp: crunch_wps ignore: storePDE)
+
+lemma copyGlobalMappings_pde_mappings2':
+  "\<lbrace>valid_pde_mappings' and valid_arch_state'
+            and K (is_aligned pd pdBits)\<rbrace>
+      copyGlobalMappings pd \<lbrace>\<lambda>rv. valid_pde_mappings'\<rbrace>"
+  apply (wp copyGlobalMappings_pde_mappings')
+  apply (clarsimp simp: valid_arch_state'_def page_directory_at'_def)
+  done
+
+crunch copyGlobalMappings
+  for pred_tcb_at'[wp]: "pred_tcb_at' proj P t"
+  (wp: crunch_wps ignore: storePDE)
+
+crunch copyGlobalMappings
+  for vms'[wp]: "valid_machine_state'"
+  (wp: crunch_wps ignore: storePDE)
+
+crunch copyGlobalMappings
+  for ct_not_inQ[wp]: "ct_not_inQ"
+  (wp: crunch_wps ignore: storePDE)
+
+crunch copyGlobalMappings
+  for tcb_in_cur_domain'[wp]: "tcb_in_cur_domain' t"
+  (wp: crunch_wps)
+
+crunch copyGlobalMappings
+  for ct__in_cur_domain'[wp]: ct_idle_or_in_cur_domain'
+  (wp: crunch_wps)
+
+crunch copyGlobalMappings
+  for gsUntypedZeroRanges[wp]: "\<lambda>s. P (gsUntypedZeroRanges s)"
+  (wp: crunch_wps)
 
 lemma threadSet_ct_idle_or_in_cur_domain':
   "\<lbrace>ct_idle_or_in_cur_domain' and (\<lambda>s. \<forall>tcb. tcbDomain tcb = ksCurDomain s \<longrightarrow> tcbDomain (F tcb) = ksCurDomain s)\<rbrace>
     threadSet F t
    \<lbrace>\<lambda>_. ct_idle_or_in_cur_domain'\<rbrace>"
-  apply (simp add: ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def)
-  apply (wp hoare_vcg_disj_lift hoare_vcg_imp_lift)
-    apply wps
-    apply wp
-   apply wps
-   apply wp
-  apply (auto simp: obj_at'_def)
-  done
+apply (simp add: ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def)
+apply (wp hoare_vcg_disj_lift hoare_vcg_imp_lift)
+  apply wps
+  apply wp
+ apply wps
+ apply wp
+apply (auto simp: obj_at'_def)
+done
+
+crunch invalidateTLBByASID
+  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
+crunch invalidateTLBByASID
+  for valid_arch_state'[wp]: "valid_arch_state'"
+lemmas invalidateTLBByASID_typ_ats[wp] = typ_at_lifts [OF invalidateTLBByASID_typ_at']
 
 lemma cte_wp_at_norm_eq':
   "cte_wp_at' P p s = (\<exists>cte. cte_wp_at' ((=) cte) p s \<and> P cte)"
@@ -3656,6 +4293,13 @@ lemma isFinal_lift:
             valid_cte_at_neg_typ' [OF y])
   done
 
+crunch invalidateTLBByASID
+  for cteCaps_of: "\<lambda>s. P (cteCaps_of s)"
+
+lemma cteCaps_of_ctes_of_lift:
+  "(\<And>P. \<lbrace>\<lambda>s. P (ctes_of s)\<rbrace> f \<lbrace>\<lambda>_ s. P (ctes_of s)\<rbrace>) \<Longrightarrow> \<lbrace>\<lambda>s. P (cteCaps_of s) \<rbrace> f \<lbrace>\<lambda>_ s. P (cteCaps_of s)\<rbrace>"
+  unfolding cteCaps_of_def .
+
 lemmas final_matters'_simps = final_matters'_def [split_simps capability.split arch_capability.split]
 
 crunch deleteCallerCap
@@ -3671,6 +4315,9 @@ crunch deleteCallerCap
   for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
   (wp: crunch_wps)
 lemmas deleteCallerCap_typ_ats[wp] = typ_at_lifts [OF deleteCallerCap_typ_at']
+
+crunch emptySlot
+  for ksQ[wp]: "\<lambda>s. P (ksReadyQueues s p)"
 
 lemma setEndpoint_sch_act_not_ct[wp]:
   "\<lbrace>\<lambda>s. sch_act_not (ksCurThread s) s\<rbrace>

--- a/proof/refine/ARM_HYP/ArchFinalise_R.thy
+++ b/proof/refine/ARM_HYP/ArchFinalise_R.thy
@@ -1146,13 +1146,9 @@ lemma archThreadSet_tcbSchedPrevNext[wp]:
   apply auto
   done
 
-context notes if_cong[cong] begin
-
 crunch asUser
   for tcbSchedPrevNext[wp]: "obj_at' (\<lambda>tcb. P (tcbSchedNext tcb) (tcbSchedPrev tcb)) t"
-  (wp: threadGet_wp)
-
-end
+  (wp: threadGet_wp cong: if_cong)
 
 crunch prepareThreadDelete
   for tcbSchedPrevNext[wp]: "obj_at' (\<lambda>tcb. P (tcbSchedNext tcb) (tcbSchedPrev tcb)) t"
@@ -1433,14 +1429,11 @@ crunch dissociateVCPUTCB, unmapPageTable
   (wp: crunch_wps getVCPU_wp getObject_inv hoare_vcg_all_lift hoare_vcg_if_lift3
    simp: loadObject_default_def updateObject_default_def)
 
-context notes if_cong[cong] begin
-
 crunch Arch_finaliseCap
   for nosch[wp]: "\<lambda>s. P (ksSchedulerAction s)"
   (wp: crunch_wps getObject_inv simp: loadObject_default_def updateObject_default_def
-   rule: ARM_HYP_H.finaliseCap_def)
-
-end
+   rule: ARM_HYP_H.finaliseCap_def
+   cong: if_cong)
 
 crunch vcpuFinalise, deletingIRQHandler, finaliseCap
   for sch_act_simple[wp]: sch_act_simple

--- a/proof/refine/ARM_HYP/ArchFinalise_R.thy
+++ b/proof/refine/ARM_HYP/ArchFinalise_R.thy
@@ -1,5 +1,6 @@
 (*
  * Copyright 2014, General Dynamics C4 Systems
+ * Copyright 2023, Proofcraft Pty Ltd
  *
  * SPDX-License-Identifier: GPL-2.0-only
  *)
@@ -9,483 +10,80 @@ imports
   Finalise_R
 begin
 
-context begin interpretation Arch . (*FIXME: arch-split*)
+context Arch begin arch_global_naming
 
-declare doUnbindNotification_def[simp]
+named_theorems Finalise_R_assms
 
 lemma isArchSGISignalCap_NullCap[simp]:
   "\<not>isArchSGISignalCap NullCap"
   by (simp add: isCap_simps)
 
-text \<open>Properties about empty_slot/emptySlot\<close>
+lemma arch_postCapDeletion_ksArchState_lift[Finalise_R_assms]:
+  "\<lbrakk>\<And>s as. P (s\<lparr>ksArchState := as\<rparr>) = P s\<rbrakk> \<Longrightarrow> Arch.postCapDeletion ac \<lbrace>P\<rbrace>"
+  unfolding postCapDeletion_def
+  by wpsimp
 
-lemma case_Null_If:
-  "(case c of NullCap \<Rightarrow> a | _ \<Rightarrow> b) = (if c = NullCap then a else b)"
-  by (case_tac c, simp_all)
+lemmas clearUntypedFreeIndex_typ_ats[wp] = typ_at_lifts[OF clearUntypedFreeIndex_typ_at']
 
-crunch emptySlot
-  for aligned'[wp]: pspace_aligned' (simp: case_Null_If)
-crunch emptySlot
-  for distinct'[wp]: pspace_distinct' (simp: case_Null_If)
+crunch setIRQState
+  for umm[Finalise_R_assms, wp]: "\<lambda>s. P (underlying_memory (ksMachineState s))"
+  (wp: dmo_lift' simp: maskInterrupt_def)
 
-lemma updateCap_cte_wp_at_cases:
-  "\<lbrace>\<lambda>s. (ptr = ptr' \<longrightarrow> cte_wp_at' (P \<circ> cteCap_update (K cap)) ptr' s) \<and> (ptr \<noteq> ptr' \<longrightarrow> cte_wp_at' P ptr' s)\<rbrace>
-     updateCap ptr cap
-   \<lbrace>\<lambda>rv. cte_wp_at' P ptr'\<rbrace>"
-  apply (clarsimp simp: valid_def)
-  apply (drule updateCap_stuff)
-  apply (clarsimp simp: cte_wp_at_ctes_of modify_map_def)
-  done
+(* better crunch names for Arch.postCapDeletion *)
+abbreviation (input)
+  "Arch_postCapDeletion \<equiv> Arch.postCapDeletion"
 
-crunch postCapDeletion, updateTrackedFreeIndex
-  for cte_wp_at'[wp]: "cte_wp_at' P p"
+crunch Arch_postCapDeletion
+  for valid_global_refs[wp]: valid_global_refs'
+  and valid_arch_state'[wp]: valid_arch_state'
+  (rule: ARM_HYP_H.postCapDeletion_def)
 
-lemma updateFreeIndex_cte_wp_at:
-  "\<lbrace>\<lambda>s. cte_at' p s \<and> P (cte_wp_at' (if p = p' then P'
-      o (cteCap_update (capFreeIndex_update (K idx))) else P') p' s)\<rbrace>
-    updateFreeIndex p idx
-  \<lbrace>\<lambda>rv s. P (cte_wp_at' P' p' s)\<rbrace>"
-  apply (simp add: updateFreeIndex_def updateTrackedFreeIndex_def
-        split del: if_split)
-  apply (rule hoare_pre)
-   apply (wp updateCap_cte_wp_at' getSlotCap_wp)
-  apply (clarsimp simp: cte_wp_at_ctes_of)
-  apply (cases "p' = p", simp_all)
-  apply (case_tac cte, simp)
-  done
+lemma arch_postCapDeletion_corres[Finalise_R_assms]:
+  "acap_relation cap cap' \<Longrightarrow> corres dc \<top> \<top> (arch_post_cap_deletion cap) (ARM_HYP_H.postCapDeletion cap')"
+  by (clarsimp simp: arch_post_cap_deletion_def ARM_HYP_H.postCapDeletion_def)
 
-lemma emptySlot_cte_wp_cap_other:
-  "\<lbrace>(\<lambda>s. cte_wp_at' (\<lambda>c. P (cteCap c)) p s) and K (p \<noteq> p')\<rbrace>
-  emptySlot p' opt
-  \<lbrace>\<lambda>rv s. cte_wp_at' (\<lambda>c. P (cteCap c)) p s\<rbrace>"
-  apply (rule hoare_gen_asm)
-  apply (simp add: emptySlot_def clearUntypedFreeIndex_def getSlotCap_def)
-  apply (rule hoare_pre)
-   apply (wp updateMDB_weak_cte_wp_at updateCap_cte_wp_at_cases
-             updateFreeIndex_cte_wp_at getCTE_wp' hoare_vcg_all_lift
-              | simp add:  | wpc
-              | wp (once) hoare_drop_imps)+
-  done
+(* better crunch names for Arch.finaliseCap *)
+abbreviation (input)
+  "Arch_finaliseCap \<equiv> Arch.finaliseCap"
 
-crunch emptySlot
-  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-lemmas clearUntypedFreeIndex_typ_ats[wp]
-    = typ_at_lifts[OF clearUntypedFreeIndex_typ_at']
+crunch Arch_finaliseCap, prepareThreadDelete
+  for typ_at'[Finalise_R_assms, wp]: "\<lambda>s. P (typ_at' T p s)"
+  and aligned'[Finalise_R_assms, wp]: "pspace_aligned'"
+  and distinct'[Finalise_R_assms, wp]: "pspace_distinct'"
+  (wp: crunch_wps getObject_inv loadObject_default_inv
+   simp: crunch_simps unless_def o_def
+   ignore_del: setObject
+   rule: ARM_HYP_H.finaliseCap_def)
 
-crunch postCapDeletion
-  for tcb_at'[wp]: "tcb_at' t"
-crunch emptySlot
-  for ct[wp]: "\<lambda>s. P (ksCurThread s)"
-crunch clearUntypedFreeIndex
-  for cur_tcb'[wp]: "cur_tcb'"
-  (wp: cur_tcb_lift)
+crunch prepareThreadDelete, Arch_finaliseCap
+  for it'[Finalise_R_assms, wp]: "\<lambda>s. P (ksIdleThread s)"
+  (wp: hoare_drop_imps mapM_wp
+   simp: crunch_simps updateObject_default_def
+   rule: ARM_HYP_H.finaliseCap_def)
 
-crunch emptySlot
-  for ksRQ[wp]: "\<lambda>s. P (ksReadyQueues s)"
-crunch emptySlot
-  for ksRQL1[wp]: "\<lambda>s. P (ksReadyQueuesL1Bitmap s)"
-crunch emptySlot
-  for ksRQL2[wp]: "\<lambda>s. P (ksReadyQueuesL2Bitmap s)"
-crunch postCapDeletion
-  for obj_at'[wp]: "obj_at' P p"
+definition
+  arch_final_matters' :: "arch_capability \<Rightarrow> bool" where
+ "arch_final_matters' acap \<equiv> case acap of
+    PageCap ref rghts sz d mapdata \<Rightarrow> False
+  | ASIDControlCap \<Rightarrow> False
+  | SGISignalCap _ _ \<Rightarrow> False
+  | _ \<Rightarrow> True"
 
-crunch clearUntypedFreeIndex
-  for inQ[wp]: "\<lambda>s. P (obj_at' (inQ d p) t s)"
-crunch clearUntypedFreeIndex
-  for tcbDomain[wp]: "obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t"
-crunch clearUntypedFreeIndex
-  for tcbPriority[wp]: "obj_at' (\<lambda>tcb. P (tcbPriority tcb)) t"
+definition arch_cap_has_cleanup' :: "arch_capability \<Rightarrow> bool" where
+  "arch_cap_has_cleanup' _ \<equiv> False"
 
-crunch emptySlot
-  for nosch[wp]: "\<lambda>s. P (ksSchedulerAction s)"
-crunch emptySlot
-  for ksCurDomain[wp]: "\<lambda>s. P (ksCurDomain s)"
+definition
+  "post_cap_delete_pre' cap sl cs \<equiv> case cap of
+     IRQHandlerCap irq \<Rightarrow> irq \<le> maxIRQ \<and> (\<forall>sl'. sl \<noteq> sl' \<longrightarrow> cs sl' \<noteq> Some cap)
+   | _ \<Rightarrow> False"
 
-lemma emptySlot_sch_act_wf [wp]:
-  "\<lbrace>\<lambda>s. sch_act_wf (ksSchedulerAction s) s\<rbrace>
-  emptySlot sl opt
-  \<lbrace>\<lambda>rv s. sch_act_wf (ksSchedulerAction s) s\<rbrace>"
-  apply (simp add: emptySlot_def case_Null_If)
-  apply (wp sch_act_wf_lift tcb_in_cur_domain'_lift | wpcw | simp)+
-  done
+end (* Arch *)
 
-lemma updateCap_valid_objs' [wp]:
-  "\<lbrace>valid_objs' and valid_cap' cap\<rbrace>
-  updateCap ptr cap \<lbrace>\<lambda>r. valid_objs'\<rbrace>"
-  unfolding updateCap_def
-  by (wp setCTE_valid_objs getCTE_wp) (clarsimp dest!: cte_at_cte_wp_atD)
+arch_requalify_consts
+  arch_final_matters'
+  arch_cap_has_cleanup'
 
-lemma updateFreeIndex_valid_objs' [wp]:
-  "\<lbrace>valid_objs'\<rbrace> clearUntypedFreeIndex ptr \<lbrace>\<lambda>r. valid_objs'\<rbrace>"
-  apply (simp add: clearUntypedFreeIndex_def getSlotCap_def)
-  apply (wp getCTE_wp' | wpc | simp add: updateTrackedFreeIndex_def)+
-  done
-
-crunch emptySlot
-  for valid_objs'[wp]: "valid_objs'"
-
-crunch setInterruptState
-  for state_refs_of'[wp]: "\<lambda>s. P (state_refs_of' s)"
-  (simp: state_refs_of'_pspaceI)
-crunch emptySlot
-  for state_refs_of'[wp]: "\<lambda>s. P (state_refs_of' s)"
-  (wp: crunch_wps)
-crunch setInterruptState
-  for state_hyp_refs_of'[wp]: "\<lambda>s. P (state_hyp_refs_of' s)"
-  (simp: state_hyp_refs_of'_pspaceI)
-crunch emptySlot
-  for state_hyp_refs_of'[wp]: "\<lambda>s. P (state_hyp_refs_of' s)"
-  (wp: crunch_wps)
-
-lemma mdb_chunked2D:
-  "\<lbrakk> mdb_chunked m; m \<turnstile> p \<leadsto> p'; m \<turnstile> p' \<leadsto> p'';
-     m p = Some (CTE cap nd); m p'' = Some (CTE cap'' nd'');
-     sameRegionAs cap cap''; p \<noteq> p''; mdb_chunked_arch_assms cap \<rbrakk>
-     \<Longrightarrow> \<exists>cap' nd'. m p' = Some (CTE cap' nd') \<and> sameRegionAs cap cap'"
-  apply (subgoal_tac "\<exists>cap' nd'. m p' = Some (CTE cap' nd')")
-   apply (clarsimp simp add: mdb_chunked_def)
-   apply (drule spec[where x=p])
-   apply (drule spec[where x=p''])
-   apply clarsimp
-   apply (drule mp, erule trancl_into_trancl2)
-    apply (erule trancl.intros(1))
-   apply (simp add: is_chunk_def)
-   apply (drule spec, drule mp, erule trancl.intros(1))
-   apply (drule mp, rule trancl_into_rtrancl)
-    apply (erule trancl.intros(1))
-   apply clarsimp
-  apply (clarsimp simp: mdb_next_unfold)
-  apply (case_tac z, simp)
-  done
-
-lemma nullPointer_eq_0_simp[simp]: (* FIXME: move to nullPointer_0_simp in Retype_R *)
-  "(0 = nullPointer) = True"
-  by (simp add: nullPointer_def)+
-
-lemma no_0_no_0_lhs_trancl [simp]:
-  "no_0 m \<Longrightarrow> \<not> m \<turnstile> 0 \<leadsto>\<^sup>+ x"
-  by (rule, drule tranclD, clarsimp simp: next_unfold')
-
-lemma no_0_no_0_lhs_rtrancl [simp]:
-  "\<lbrakk> no_0 m; x \<noteq> 0 \<rbrakk> \<Longrightarrow> \<not> m \<turnstile> 0 \<leadsto>\<^sup>* x"
-  by (clarsimp dest!: rtranclD)
-
-end
-locale mdb_empty =
-  mdb_ptr?: mdb_ptr m _ _ slot s_cap s_node
-    for m slot s_cap s_node +
-
-  fixes n
-  defines "n \<equiv>
-           modify_map
-             (modify_map
-               (modify_map
-                 (modify_map m (mdbPrev s_node)
-                   (cteMDBNode_update (mdbNext_update (%_. (mdbNext s_node)))))
-                 (mdbNext s_node)
-                 (cteMDBNode_update
-                   (\<lambda>mdb. mdbFirstBadged_update (%_. (mdbFirstBadged mdb \<or> mdbFirstBadged s_node))
-                           (mdbPrev_update (%_. (mdbPrev s_node)) mdb))))
-               slot (cteCap_update (%_. capability.NullCap)))
-              slot (cteMDBNode_update (const nullMDBNode))"
-begin
-interpretation Arch . (*FIXME: arch-split*)
-
-lemmas m_slot_prev = m_p_prev
-lemmas m_slot_next = m_p_next
-lemmas prev_slot_next = prev_p_next
-lemmas next_slot_prev = next_p_prev
-
-lemma n_revokable:
-  "n p = Some (CTE cap node) \<Longrightarrow>
-  (\<exists>cap' node'. m p = Some (CTE cap' node') \<and>
-              (if p = slot
-               then \<not> mdbRevocable node
-               else mdbRevocable node = mdbRevocable node'))"
-  by (auto simp add: n_def modify_map_if nullMDBNode_def split: if_split_asm)
-
-lemma m_revokable:
-  "m p = Some (CTE cap node) \<Longrightarrow>
-  (\<exists>cap' node'. n p = Some (CTE cap' node') \<and>
-              (if p = slot
-               then \<not> mdbRevocable node'
-               else mdbRevocable node' = mdbRevocable node))"
-  apply (clarsimp simp add: n_def modify_map_if nullMDBNode_def split: if_split_asm)
-  apply (cases "p=slot", simp)
-  apply (cases "p=mdbNext s_node", simp)
-   apply (cases "p=mdbPrev s_node", simp)
-   apply clarsimp
-  apply simp
-  apply (cases "p=mdbPrev s_node", simp)
-  apply simp
-  done
-
-lemma no_0_n:
-  "no_0 n"
-  using no_0 by (simp add: n_def)
-
-lemma n_next:
-  "n p = Some (CTE cap node) \<Longrightarrow>
-  (\<exists>cap' node'. m p = Some (CTE cap' node') \<and>
-              (if p = slot
-               then mdbNext node = 0
-               else if p = mdbPrev s_node
-               then mdbNext node = mdbNext s_node
-               else mdbNext node = mdbNext node'))"
-  apply (subgoal_tac "p \<noteq> 0")
-   prefer 2
-   apply (insert no_0_n)[1]
-   apply clarsimp
-  apply (cases "p = slot")
-   apply (clarsimp simp: n_def modify_map_if initMDBNode_def split: if_split_asm)
-  apply (cases "p = mdbPrev s_node")
-   apply (auto simp: n_def modify_map_if initMDBNode_def split: if_split_asm)
-  done
-
-lemma n_prev:
-  "n p = Some (CTE cap node) \<Longrightarrow>
-  (\<exists>cap' node'. m p = Some (CTE cap' node') \<and>
-              (if p = slot
-               then mdbPrev node = 0
-               else if p = mdbNext s_node
-               then mdbPrev node = mdbPrev s_node
-               else mdbPrev node = mdbPrev node'))"
-  apply (subgoal_tac "p \<noteq> 0")
-   prefer 2
-   apply (insert no_0_n)[1]
-   apply clarsimp
-  apply (cases "p = slot")
-   apply (clarsimp simp: n_def modify_map_if initMDBNode_def split: if_split_asm)
-  apply (cases "p = mdbNext s_node")
-   apply (auto simp: n_def modify_map_if initMDBNode_def split: if_split_asm)
-  done
-
-lemma n_cap:
-  "n p = Some (CTE cap node) \<Longrightarrow>
-  \<exists>cap' node'. m p = Some (CTE cap' node') \<and>
-              (if p = slot
-               then cap = NullCap
-               else cap' = cap)"
-  apply (clarsimp simp: n_def modify_map_if initMDBNode_def split: if_split_asm)
-   apply (cases node)
-   apply auto
-  done
-
-lemma m_cap:
-  "m p = Some (CTE cap node) \<Longrightarrow>
-  \<exists>cap' node'. n p = Some (CTE cap' node') \<and>
-              (if p = slot
-               then cap' = NullCap
-               else cap' = cap)"
-  apply (clarsimp simp: n_def modify_map_cases initMDBNode_def)
-  apply (cases node)
-  apply clarsimp
-  apply (cases "p=slot", simp)
-  apply clarsimp
-  apply (cases "mdbNext s_node = p", simp)
-   apply fastforce
-  apply simp
-  apply (cases "mdbPrev s_node = p", simp)
-  apply fastforce
-  done
-
-lemma n_badged:
-  "n p = Some (CTE cap node) \<Longrightarrow>
-  \<exists>cap' node'. m p = Some (CTE cap' node') \<and>
-              (if p = slot
-               then \<not> mdbFirstBadged node
-               else if p = mdbNext s_node
-               then mdbFirstBadged node = (mdbFirstBadged node' \<or> mdbFirstBadged s_node)
-               else mdbFirstBadged node = mdbFirstBadged node')"
-  apply (subgoal_tac "p \<noteq> 0")
-   prefer 2
-   apply (insert no_0_n)[1]
-   apply clarsimp
-  apply (cases "p = slot")
-   apply (clarsimp simp: n_def modify_map_if initMDBNode_def split: if_split_asm)
-  apply (cases "p = mdbNext s_node")
-   apply (auto simp: n_def modify_map_if nullMDBNode_def split: if_split_asm)
-  done
-
-lemma m_badged:
-  "m p = Some (CTE cap node) \<Longrightarrow>
-  \<exists>cap' node'. n p = Some (CTE cap' node') \<and>
-              (if p = slot
-               then \<not> mdbFirstBadged node'
-               else if p = mdbNext s_node
-               then mdbFirstBadged node' = (mdbFirstBadged node \<or> mdbFirstBadged s_node)
-               else mdbFirstBadged node' = mdbFirstBadged node)"
-  apply (subgoal_tac "p \<noteq> 0")
-   prefer 2
-   apply (insert no_0_n)[1]
-   apply clarsimp
-  apply (cases "p = slot")
-   apply (clarsimp simp: n_def modify_map_if nullMDBNode_def split: if_split_asm)
-  apply (cases "p = mdbNext s_node")
-   apply (clarsimp simp: n_def modify_map_if nullMDBNode_def split: if_split_asm)
-  apply clarsimp
-  apply (cases "p = mdbPrev s_node")
-   apply (auto simp: n_def modify_map_if initMDBNode_def  split: if_split_asm)
-  done
-
-lemmas slot = m_p
-
-lemma m_next:
-  "m p = Some (CTE cap node) \<Longrightarrow>
-  \<exists>cap' node'. n p = Some (CTE cap' node') \<and>
-              (if p = slot
-               then mdbNext node' = 0
-               else if p = mdbPrev s_node
-               then mdbNext node' = mdbNext s_node
-               else mdbNext node' = mdbNext node)"
-  apply (subgoal_tac "p \<noteq> 0")
-   prefer 2
-   apply clarsimp
-  apply (cases "p = slot")
-   apply (clarsimp simp: n_def modify_map_if)
-  apply (cases "p = mdbPrev s_node")
-   apply (simp add: n_def modify_map_if)
-  apply simp
-  apply (simp add: n_def modify_map_if)
-  apply (cases "mdbNext s_node = p")
-   apply fastforce
-  apply fastforce
-  done
-
-lemma m_prev:
-  "m p = Some (CTE cap node) \<Longrightarrow>
-  \<exists>cap' node'. n p = Some (CTE cap' node') \<and>
-              (if p = slot
-               then mdbPrev node' = 0
-               else if p = mdbNext s_node
-               then mdbPrev node' = mdbPrev s_node
-               else mdbPrev node' = mdbPrev node)"
-  apply (subgoal_tac "p \<noteq> 0")
-   prefer 2
-   apply clarsimp
-  apply (cases "p = slot")
-   apply (clarsimp simp: n_def modify_map_if)
-  apply (cases "p = mdbPrev s_node")
-   apply (simp add: n_def modify_map_if)
-  apply simp
-  apply (simp add: n_def modify_map_if)
-  apply (cases "mdbNext s_node = p")
-   apply fastforce
-  apply fastforce
-  done
-
-lemma n_nextD:
-  "n \<turnstile> p \<leadsto> p' \<Longrightarrow>
-  if p = slot then p' = 0
-  else if p = mdbPrev s_node
-  then m \<turnstile> p \<leadsto> slot \<and> p' = mdbNext s_node
-  else m \<turnstile> p \<leadsto> p'"
-  apply (clarsimp simp: mdb_next_unfold split del: if_split cong: if_cong)
-  apply (case_tac z)
-  apply (clarsimp split del: if_split)
-  apply (drule n_next)
-  apply (elim exE conjE)
-  apply (simp split: if_split_asm)
-  apply (frule dlist_prevD [OF m_slot_prev])
-  apply (clarsimp simp: mdb_next_unfold)
-  done
-
-lemma n_next_eq:
-  "n \<turnstile> p \<leadsto> p' =
-  (if p = slot then p' = 0
-  else if p = mdbPrev s_node
-  then m \<turnstile> p \<leadsto> slot \<and> p' = mdbNext s_node
-  else m \<turnstile> p \<leadsto> p')"
-  apply (rule iffI)
-   apply (erule n_nextD)
-  apply (clarsimp simp: mdb_next_unfold split: if_split_asm)
-    apply (simp add: n_def modify_map_if slot)
-   apply hypsubst_thin
-   apply (case_tac z)
-   apply simp
-   apply (drule m_next)
-   apply clarsimp
-  apply (case_tac z)
-  apply simp
-  apply (drule m_next)
-  apply clarsimp
-  done
-
-lemma n_prev_eq:
-  "n \<turnstile> p \<leftarrow> p' =
-  (if p' = slot then p = 0
-  else if p' = mdbNext s_node
-  then m \<turnstile> slot \<leftarrow> p' \<and> p = mdbPrev s_node
-  else m \<turnstile> p \<leftarrow> p')"
-  apply (rule iffI)
-   apply (clarsimp simp: mdb_prev_def split del: if_split cong: if_cong)
-   apply (case_tac z)
-   apply (clarsimp split del: if_split)
-   apply (drule n_prev)
-   apply (elim exE conjE)
-   apply (simp split: if_split_asm)
-   apply (frule dlist_nextD [OF m_slot_next])
-   apply (clarsimp simp: mdb_prev_def)
-  apply (clarsimp simp: mdb_prev_def split: if_split_asm)
-    apply (simp add: n_def modify_map_if slot)
-   apply hypsubst_thin
-   apply (case_tac z)
-   apply clarsimp
-   apply (drule m_prev)
-   apply clarsimp
-  apply (case_tac z)
-  apply simp
-  apply (drule m_prev)
-  apply clarsimp
-  done
-
-lemma valid_dlist_n:
-  "valid_dlist n" using dlist
-  apply (clarsimp simp: valid_dlist_def2 [OF no_0_n])
-  apply (simp add: n_next_eq n_prev_eq m_slot_next m_slot_prev cong: if_cong)
-  apply (rule conjI, clarsimp)
-   apply (rule conjI, clarsimp simp: next_slot_prev prev_slot_next)
-   apply (fastforce dest!: dlist_prev_src_unique)
-  apply clarsimp
-  apply (rule conjI, clarsimp)
-   apply (clarsimp simp: valid_dlist_def2 [OF no_0])
-   apply (case_tac "mdbNext s_node = 0")
-    apply simp
-    apply (subgoal_tac "m \<turnstile> slot \<leadsto> c'")
-     prefer 2
-     apply fastforce
-    apply (clarsimp simp: mdb_next_unfold slot)
-   apply (frule next_slot_prev)
-   apply (drule (1) dlist_prev_src_unique, simp)
-   apply simp
-  apply clarsimp
-  apply (rule conjI, clarsimp)
-   apply (fastforce dest: dlist_next_src_unique)
-  apply clarsimp
-  apply (rule conjI, clarsimp)
-   apply (clarsimp simp: valid_dlist_def2 [OF no_0])
-   apply (clarsimp simp: mdb_prev_def slot)
-  apply (clarsimp simp: valid_dlist_def2 [OF no_0])
-  done
-
-lemma caps_contained_n:
-  "caps_contained' n"
-  using valid
-  apply (clarsimp simp: valid_mdb_ctes_def caps_contained'_def)
-  apply (drule n_cap)+
-  apply (clarsimp split: if_split_asm)
-  apply (erule disjE, clarsimp)
-  apply clarsimp
-  apply fastforce
-  done
-
-lemma chunked:
-  "mdb_chunked m"
-  using valid ..
-
-lemma valid_badges:
-  "valid_badges m"
-  using valid ..
+context Arch_mdb_empty begin
 
 lemma valid_badges_n:
   "valid_badges n"
@@ -493,6 +91,7 @@ proof -
   from valid_badges
   show ?thesis
     supply if_cong[cong]
+    supply to_slot_eq[simp del]
     apply (simp add: valid_badges_def2)
     apply clarsimp
     apply (rule conjI)
@@ -560,14 +159,6 @@ proof -
     done
 qed
 
-lemma to_slot_eq [simp]:
-  "m \<turnstile> p \<leadsto> slot = (p = mdbPrev s_node \<and> p \<noteq> 0)"
-  apply (rule iffI)
-   apply (frule dlist_nextD0, simp)
-   apply (clarsimp simp: mdb_prev_def slot mdb_next_unfold)
-  apply (clarsimp intro!: prev_slot_next)
-  done
-
 lemma n_parent_of:
   "\<lbrakk> n \<turnstile> p parentOf p'; p \<noteq> slot; p' \<noteq> slot \<rbrakk> \<Longrightarrow> m \<turnstile> p parentOf p'"
   supply if_cong[cong]
@@ -598,11 +189,8 @@ lemma m_parent_of:
   apply (frule_tac p=p' in m_badged)
   apply (drule_tac p=p' in m_revokable)
   apply clarsimp
-  apply (simp split: if_split_asm;
-         clarsimp simp: isMDBParentOf_def isArchMDBParentOf_def2 isCap_simps
-                  split: if_split_asm
-                  cong: if_cong)
-  done
+  by (fastforce simp: isMDBParentOf_def isArchMDBParentOf_def2 isCap_simps
+                split: if_split_asm)
 
 lemma m_parent_of_next:
   "\<lbrakk> m \<turnstile> p parentOf mdbNext s_node; m \<turnstile> p parentOf slot; p \<noteq> slot; p\<noteq>mdbNext s_node \<rbrakk>
@@ -622,30 +210,6 @@ lemma m_parent_of_next:
   apply (drule_tac p="slot" in m_revokable)
   by (auto simp: isMDBParentOf_def isArchMDBParentOf_def2 isCap_simps
            split: if_split_asm cong: if_cong)
-
-lemma n_mdbNext:
-  "\<lbrakk> n (mdbNext s_node) = Some (CTE cap node); mdbPrev s_node \<noteq> 0 \<rbrakk> \<Longrightarrow>
-  \<exists>node'. m (mdbNext s_node) = Some (CTE cap node') \<and>
-          mdbNext node = mdbNext node' \<and>
-          mdbPrev node = mdbPrev s_node \<and>
-          mdbRevocable node = mdbRevocable node' \<and>
-          (mdbFirstBadged node = mdbFirstBadged node' \<or> mdbFirstBadged s_node)"
-  apply (clarsimp simp: n_def modify_map_def)
-  apply (case_tac z)
-  apply clarsimp
-  done
-
-lemma n_mdbPrev:
-  "\<lbrakk> n (mdbPrev s_node) = Some (CTE cap node); mdbNext s_node \<noteq> 0 \<rbrakk> \<Longrightarrow>
-    \<exists>node'. m (mdbPrev s_node) = Some (CTE cap node') \<and>
-          mdbNext node = mdbNext s_node \<and>
-          mdbPrev node = mdbPrev node' \<and>
-          mdbRevocable node = mdbRevocable node' \<and>
-          (mdbFirstBadged node = mdbFirstBadged node')"
-  apply (clarsimp simp: n_def modify_map_def)
-  apply (case_tac z)
-  apply clarsimp
-  done
 
 lemma parency_n:
   assumes "n \<turnstile> p \<rightarrow> p'"
@@ -706,13 +270,16 @@ proof induct
      apply (case_tac cap'', simp_all add: isCap_simps)[1]
       apply (clarsimp simp: sameRegionAs_def3 isCap_simps)
      apply (clarsimp simp: sameRegionAs_def3 isCap_simps)
+     apply (rename_tac acap'')
+     apply (case_tac acap''; clarsimp simp: sameRegionAs_def3 isCap_simps)
     (* SGISignalCap *)
-    apply (clarsimp simp: parentOf_def isCap_simps isMDBParentOf_CTE arch_capBadge_def)
+    apply (clarsimp simp: parentOf_def isCap_simps isMDBParentOf_CTE)
     apply (rename_tac next_node)
     apply (rule subtree.trans_parent[OF _ m_slot_next], simp_all)
      apply (rule subtree.direct_parent)
        apply (erule prev_slot_next)
       apply simp
+     prefer 2
      apply (clarsimp simp: parentOf_def slot isMDBParentOf_CTE)
     apply (clarsimp simp: parentOf_def slot isMDBParentOf_CTE isCap_simps)
     apply (cases "mdbFirstBadged s_node", simp)
@@ -804,9 +371,11 @@ next
         apply (case_tac cap'', simp_all add: isCap_simps)[1]
          apply (clarsimp simp: sameRegionAs_def3 isCap_simps)
         apply (clarsimp simp: sameRegionAs_def3 isCap_simps)
+        apply (rename_tac acap'')
+        apply (case_tac acap''; clarsimp simp: sameRegionAs_def3 isCap_simps)
        (* SGISignalCap *)
        apply (rename_tac next_cap next_node)
-       apply (clarsimp simp: isCap_simps arch_capBadge_def)
+       apply (clarsimp simp: isCap_simps)
        apply (case_tac cte, case_tac cte')
        apply (rename_tac cap'' node'')
        apply (clarsimp simp: isMDBParentOf_CTE)
@@ -824,1123 +393,115 @@ next
     done
 qed
 
-lemma parency_m:
-  assumes "m \<turnstile> p \<rightarrow> p'"
-  shows "p \<noteq> slot \<longrightarrow> (if p' \<noteq> slot then n \<turnstile> p \<rightarrow> p' else m \<turnstile> p \<rightarrow> mdbNext s_node \<longrightarrow> n \<turnstile> p \<rightarrow> mdbNext s_node)"
-using assms
-proof induct
-  case (direct_parent c)
-  thus ?case
-    apply clarsimp
-    apply (rule conjI)
-     apply clarsimp
-     apply (rule subtree.direct_parent)
-       apply (simp add: n_next_eq)
-       apply clarsimp
-       apply (subgoal_tac "mdbPrev s_node \<noteq> 0")
-        prefer 2
-        apply (clarsimp simp: mdb_next_unfold)
-       apply (drule prev_slot_next)
-       apply (clarsimp simp: mdb_next_unfold)
-      apply assumption
-     apply (erule m_parent_of, simp, simp)
-      apply clarsimp
-     apply clarsimp
-     apply (drule dlist_next_src_unique)
-       apply fastforce
-      apply clarsimp
-     apply simp
-    apply clarsimp
-    apply (rule subtree.direct_parent)
-      apply (simp add: n_next_eq)
-     apply (drule subtree_parent)
-     apply (clarsimp simp: parentOf_def)
-    apply (drule subtree_parent)
-    apply (erule (1) m_parent_of_next)
-     apply clarsimp
-    apply clarsimp
-    done
-next
-  case (trans_parent c c')
-  thus ?case
-    apply clarsimp
-    apply (rule conjI)
-     apply clarsimp
-     apply (cases "c=slot")
-      apply simp
-      apply (erule impE)
-       apply (erule subtree.trans_parent)
-         apply fastforce
-        apply (clarsimp simp: slot mdb_next_unfold)
-       apply (clarsimp simp: slot mdb_next_unfold)
-      apply (clarsimp simp: slot mdb_next_unfold)
-     apply clarsimp
-     apply (erule subtree.trans_parent)
-       apply (simp add: n_next_eq)
-       apply clarsimp
-       apply (subgoal_tac "mdbPrev s_node \<noteq> 0")
-        prefer 2
-        apply (clarsimp simp: mdb_next_unfold)
-       apply (drule prev_slot_next)
-       apply (clarsimp simp: mdb_next_unfold)
-      apply assumption
-     apply (erule m_parent_of, simp, simp)
-      apply clarsimp
-      apply (drule subtree_mdb_next)
-      apply (drule trancl_trans)
-       apply (erule r_into_trancl)
-      apply simp
-     apply clarsimp
-     apply (drule dlist_next_src_unique)
-       apply fastforce
-      apply clarsimp
-     apply simp
-    apply clarsimp
-    apply (erule subtree.trans_parent)
-      apply (simp add: n_next_eq)
-     apply clarsimp
-    apply (rule m_parent_of_next, erule subtree_parent, assumption, assumption)
-    apply clarsimp
-    done
+end (* Arch_mdb_empty *)
+
+context mdb_empty begin
+
+lemmas gen_arch_assms =
+  Arch_mdb_empty.valid_badges_n
+  Arch_mdb_empty.parency_n
+  Arch_mdb_empty.m_parent_of
+  Arch_mdb_empty.m_parent_of_next
+
+(* extract arch-dependent assumptions of mdb_empty_gen proved in Arch_mdb_empty
+   (faster than interpreting Arch) *)
+lemmas gen_assms = gen_arch_assms[unfolded Arch_mdb_empty_def, OF mdb_empty_axioms]
+
+sublocale mdb_empty_gen
+  by (unfold_locales)
+     (blast intro!: gen_assms)+
+
+(* re-bind names *)
+lemmas vmdb_n = vmdb_n
+lemmas descendants = descendants
+
+end (* mdb_empty *)
+
+interpretation Finalise_R?: Finalise_R arch_final_matters' arch_cap_has_cleanup'
+proof goal_cases
+  interpret Arch  .
+  case 1 show ?case by (intro_locales; (unfold_locales; (fact Finalise_R_assms)?)?)
 qed
 
-lemma parency:
-  "n \<turnstile> p \<rightarrow> p' = (p \<noteq> slot \<and> p' \<noteq> slot \<and> m \<turnstile> p \<rightarrow> p')"
-  by (auto dest!: parency_n parency_m)
+context Arch begin arch_global_naming
 
-lemma descendants:
-  "descendants_of' p n =
-  (if p = slot then {} else descendants_of' p m - {slot})"
-  by (auto simp add: parency descendants_of'_def)
+named_theorems Finalise_R_2_assms
 
-lemma n_tranclD:
-  "n \<turnstile> p \<leadsto>\<^sup>+ p' \<Longrightarrow> m \<turnstile> p \<leadsto>\<^sup>+ p' \<and> p' \<noteq> slot"
-  apply (erule trancl_induct)
-   apply (clarsimp simp add: n_next_eq split: if_split_asm)
-     apply (rule mdb_chain_0D)
-      apply (rule chain)
-     apply (clarsimp simp: slot)
-    apply (blast intro: trancl_trans prev_slot_next)
-   apply fastforce
-  apply (clarsimp simp: n_next_eq split: if_split_asm)
-   apply (erule trancl_trans)
-   apply (blast intro: trancl_trans prev_slot_next)
-  apply (fastforce intro: trancl_trans)
-  done
-
-lemma m_tranclD:
-  "m \<turnstile> p \<leadsto>\<^sup>+ p' \<Longrightarrow>
-  if p = slot then n \<turnstile> mdbNext s_node \<leadsto>\<^sup>* p'
-  else if p' = slot then n \<turnstile> p \<leadsto>\<^sup>+ mdbNext s_node
-  else n \<turnstile> p \<leadsto>\<^sup>+ p'"
-  using no_0_n
-  apply -
-  apply (erule trancl_induct)
-   apply clarsimp
-   apply (rule conjI)
-    apply clarsimp
-    apply (rule r_into_trancl)
-    apply (clarsimp simp: n_next_eq)
-   apply clarsimp
-   apply (rule conjI)
-    apply (insert m_slot_next)[1]
-    apply (clarsimp simp: mdb_next_unfold)
-   apply clarsimp
-   apply (rule r_into_trancl)
-   apply (clarsimp simp: n_next_eq)
-   apply (rule context_conjI)
-    apply (clarsimp simp: mdb_next_unfold)
-   apply (drule prev_slot_next)
-   apply (clarsimp simp: mdb_next_unfold)
-  apply clarsimp
-  apply (rule conjI)
-   apply clarsimp
-   apply (rule conjI)
-    apply clarsimp
-    apply (drule prev_slot_next)
-    apply (drule trancl_trans, erule r_into_trancl)
-    apply simp
-   apply clarsimp
-   apply (erule trancl_trans)
-   apply (rule r_into_trancl)
-   apply (simp add: n_next_eq)
-  apply clarsimp
-  apply (rule conjI)
-   apply clarsimp
-   apply (erule rtrancl_trans)
-   apply (rule r_into_rtrancl)
-   apply (simp add: n_next_eq)
-   apply (rule conjI)
-    apply clarsimp
-    apply (rule context_conjI)
-     apply (clarsimp simp: mdb_next_unfold)
-    apply (drule prev_slot_next)
-    apply (clarsimp simp: mdb_next_unfold)
-   apply clarsimp
-  apply clarsimp
-  apply (simp split: if_split_asm)
-   apply (clarsimp simp: mdb_next_unfold slot)
-  apply (erule trancl_trans)
-  apply (rule r_into_trancl)
-  apply (clarsimp simp add: n_next_eq)
-  apply (rule context_conjI)
-   apply (clarsimp simp: mdb_next_unfold)
-  apply (drule prev_slot_next)
-  apply (clarsimp simp: mdb_next_unfold)
-  done
-
-lemma n_trancl_eq:
-  "n \<turnstile> p \<leadsto>\<^sup>+ p' = (m \<turnstile> p \<leadsto>\<^sup>+ p' \<and> (p = slot \<longrightarrow> p' = 0) \<and> p' \<noteq> slot)"
-  using no_0_n
-  apply -
-  apply (rule iffI)
-   apply (frule n_tranclD)
-   apply clarsimp
-   apply (drule tranclD)
-   apply (clarsimp simp: n_next_eq)
-   apply (simp add: rtrancl_eq_or_trancl)
-  apply clarsimp
-  apply (drule m_tranclD)
-  apply (simp split: if_split_asm)
-  apply (rule r_into_trancl)
-  apply (simp add: n_next_eq)
-  done
-
-lemma n_rtrancl_eq:
-  "n \<turnstile> p \<leadsto>\<^sup>* p' =
-  (m \<turnstile> p \<leadsto>\<^sup>* p' \<and>
-   (p = slot \<longrightarrow> p' = 0 \<or> p' = slot) \<and>
-   (p' = slot \<longrightarrow> p = slot))"
-  by (auto simp: rtrancl_eq_or_trancl n_trancl_eq)
-
-lemma mdb_chain_0_n:
-  "mdb_chain_0 n"
-  using chain
-  apply (clarsimp simp: mdb_chain_0_def)
-  apply (drule bspec)
-   apply (fastforce simp: n_def modify_map_if split: if_split_asm)
-  apply (simp add: n_trancl_eq)
-  done
-
-lemma mdb_chunked_n:
-  "mdb_chunked n"
-  using chunked
-  apply (clarsimp simp: mdb_chunked_def)
-  apply (drule n_cap)+
-  apply (clarsimp split: if_split_asm)
-  apply (case_tac "p=slot", clarsimp)
-  apply clarsimp
-  apply (erule_tac x=p in allE)
-  apply (erule_tac x=p' in allE)
-  apply (clarsimp simp: is_chunk_def)
-  apply (simp add: n_trancl_eq n_rtrancl_eq)
-  apply (rule conjI)
-   apply clarsimp
-   apply (erule_tac x=p'' in allE)
-   apply clarsimp
-   apply (drule_tac p=p'' in m_cap)
-   apply clarsimp
-  apply clarsimp
-  apply (erule_tac x=p'' in allE)
-  apply clarsimp
-  apply (drule_tac p=p'' in m_cap)
-  apply clarsimp
-  done
-
-lemma untyped_mdb_n:
-  "untyped_mdb' n"
-  using untyped_mdb
-  apply (simp add: untyped_mdb'_def descendants_of'_def parency)
-  apply clarsimp
-  apply (drule n_cap)+
-  apply (clarsimp split: if_split_asm)
-  apply (case_tac "p=slot", simp)
-  apply clarsimp
-  done
-
-lemma untyped_inc_n:
-  "untyped_inc' n"
-  using untyped_inc
-  apply (simp add: untyped_inc'_def descendants_of'_def parency)
-  apply clarsimp
-  apply (drule n_cap)+
-  apply (clarsimp split: if_split_asm)
-  apply (case_tac "p=slot", simp)
-  apply clarsimp
-  apply (erule_tac x=p in allE)
-  apply (erule_tac x=p' in allE)
-  apply simp
-  done
-
-lemmas vn_prev [dest!] = valid_nullcaps_prev [OF _ slot no_0 dlist nullcaps]
-lemmas vn_next [dest!] = valid_nullcaps_next [OF _ slot no_0 dlist nullcaps]
-
-lemma nullcaps_n: "valid_nullcaps n"
-proof -
-  from valid have "valid_nullcaps m" ..
-  thus ?thesis
-    apply (clarsimp simp: valid_nullcaps_def nullMDBNode_def nullPointer_def)
-    apply (frule n_cap)
-    apply (frule n_next)
-    apply (frule n_badged)
-    apply (frule n_revokable)
-    apply (drule n_prev)
-    apply (case_tac n)
-    apply (insert slot)
-    apply (fastforce split: if_split_asm)
-    done
-qed
-
-lemma ut_rev_n: "ut_revocable' n"
-  apply(insert valid)
-  apply(clarsimp simp: ut_revocable'_def)
-  apply(frule n_cap)
-  apply(drule n_revokable)
-  apply(clarsimp simp: isCap_simps split: if_split_asm)
-  apply(simp add: valid_mdb_ctes_def ut_revocable'_def)
-  done
-
-lemma class_links_n: "class_links n"
-  using valid slot
-  apply (clarsimp simp: valid_mdb_ctes_def class_links_def)
-  apply (case_tac cte, case_tac cte')
-  apply (drule n_nextD)
-  apply (clarsimp simp: split: if_split_asm)
-    apply (simp add: no_0_n)
-   apply (drule n_cap)+
-   apply clarsimp
-   apply (frule spec[where x=slot],
-          drule spec[where x="mdbNext s_node"],
-          simp, simp add: m_slot_next)
-   apply (drule spec[where x="mdbPrev s_node"],
-          drule spec[where x=slot], simp)
-  apply (drule n_cap)+
-  apply clarsimp
-  apply (fastforce split: if_split_asm)
-  done
-
-lemma distinct_zombies_m: "distinct_zombies m"
-  using valid by (simp add: valid_mdb_ctes_def)
-
-lemma distinct_zombies_n[simp]:
-  "distinct_zombies n"
-  using distinct_zombies_m
-  apply (simp add: n_def distinct_zombies_nonCTE_modify_map)
-  apply (subst modify_map_apply[where p=slot])
-   apply (simp add: modify_map_def slot)
-  apply simp
-  apply (rule distinct_zombies_sameMasterE)
-    apply (simp add: distinct_zombies_nonCTE_modify_map)
-   apply (simp add: modify_map_def slot)
-  apply simp
-  done
-
-lemma irq_control_n [simp]: "irq_control n"
-  using slot
-  apply (clarsimp simp: irq_control_def)
-  apply (frule n_revokable)
-  apply (drule n_cap)
-  apply (clarsimp split: if_split_asm)
-  apply (frule irq_revocable, rule irq_control)
-  apply clarsimp
-  apply (drule n_cap)
-  apply (clarsimp simp: if_split_asm)
-  apply (erule (1) irq_controlD, rule irq_control)
-  done
-
-lemma reply_masters_rvk_fb_m: "reply_masters_rvk_fb m"
-  using valid by auto
-
-lemma reply_masters_rvk_fb_n [simp]: "reply_masters_rvk_fb n"
-  using reply_masters_rvk_fb_m
-  apply (simp add: reply_masters_rvk_fb_def n_def
-                   ball_ran_modify_map_eq
-                   modify_map_comp[symmetric])
-  apply (subst ball_ran_modify_map_eq)
-   apply (frule bspec, rule ranI, rule slot)
-   apply (simp add: nullMDBNode_def isCap_simps modify_map_def
-                    slot)
-  apply (subst ball_ran_modify_map_eq)
-   apply (clarsimp simp add: modify_map_def)
-   apply fastforce
-  apply (simp add: ball_ran_modify_map_eq)
-  done
-
-lemma vmdb_n: "valid_mdb_ctes n"
-  by (simp add: valid_mdb_ctes_def valid_dlist_n
-                no_0_n mdb_chain_0_n valid_badges_n
-                caps_contained_n mdb_chunked_n
-                untyped_mdb_n untyped_inc_n
-                nullcaps_n ut_rev_n class_links_n)
-
-end
-
-context begin interpretation Arch .
-crunch postCapDeletion, clearUntypedFreeIndex
-  for ctes_of[wp]: "\<lambda>s. P (ctes_of s)"
-
-lemma emptySlot_mdb [wp]:
-  "\<lbrace>valid_mdb'\<rbrace>
-  emptySlot sl opt
-  \<lbrace>\<lambda>_. valid_mdb'\<rbrace>"
-  unfolding emptySlot_def
-  apply (simp only: case_Null_If valid_mdb'_def)
-  apply (wp updateCap_ctes_of_wp getCTE_wp'
-            opt_return_pres_lift | simp add: cte_wp_at_ctes_of)+
-  apply (clarsimp)
-  apply (case_tac cte)
-  apply (rename_tac cap node)
-  apply (simp)
-  apply (subgoal_tac "mdb_empty (ctes_of s) sl cap node")
-   prefer 2
-   apply (rule mdb_empty.intro)
-   apply (rule mdb_ptr.intro)
-    apply (rule vmdb.intro)
-    apply (simp add: valid_mdb_ctes_def)
-   apply (rule mdb_ptr_axioms.intro)
-   apply (simp add: cte_wp_at_ctes_of)
-  apply (rule conjI, clarsimp simp: valid_mdb_ctes_def)
-  apply (erule mdb_empty.vmdb_n[unfolded const_def])
-  done
-end
-
-lemma if_live_then_nonz_cap'_def2:
-  "if_live_then_nonz_cap' = (\<lambda>s. \<forall>ptr. ko_wp_at' live' ptr s
-                               \<longrightarrow> (\<exists>p zr. (option_map zobj_refs' o cteCaps_of s) p = Some zr \<and> ptr \<in> zr))"
-  by (fastforce intro!: ext
-                 simp: if_live_then_nonz_cap'_def ex_nonz_cap_to'_def
-                       cte_wp_at_ctes_of cteCaps_of_def)
-
-lemma updateMDB_ko_wp_at_live[wp]:
-  "\<lbrace>\<lambda>s. P (ko_wp_at' live' p' s)\<rbrace>
-      updateMDB p m
-   \<lbrace>\<lambda>rv s. P (ko_wp_at' live' p' s)\<rbrace>"
-  unfolding updateMDB_def Let_def
-  apply (rule hoare_pre, wp)
-  apply simp
-  done
-
-lemma updateCap_ko_wp_at_live[wp]:
-  "\<lbrace>\<lambda>s. P (ko_wp_at' live' p' s)\<rbrace>
-      updateCap p cap
-   \<lbrace>\<lambda>rv s. P (ko_wp_at' live' p' s)\<rbrace>"
-  unfolding updateCap_def
-  by wp
-
-primrec
-  threadCapRefs :: "capability \<Rightarrow> word32 set"
-where
-  "threadCapRefs (ThreadCap r)                  = {r}"
-| "threadCapRefs (ReplyCap t m x)               = {}"
-| "threadCapRefs NullCap                        = {}"
-| "threadCapRefs (UntypedCap d r n i)           = {}"
-| "threadCapRefs (EndpointCap r badge x y z t)  = {}"
-| "threadCapRefs (NotificationCap r badge x y)  = {}"
-| "threadCapRefs (CNodeCap r b g gsz)           = {}"
-| "threadCapRefs (Zombie r b n)                 = {}"
-| "threadCapRefs (ArchObjectCap ac)             = {}"
-| "threadCapRefs (IRQHandlerCap irq)            = {}"
-| "threadCapRefs (IRQControlCap)                = {}"
-| "threadCapRefs (DomainCap)                    = {}"
-
-definition
-  "isFinal cap p m \<equiv>
-  \<not>isUntypedCap cap \<and>
-  (\<forall>p' c. m p' = Some c \<longrightarrow>
-          p \<noteq> p' \<longrightarrow> \<not>isUntypedCap c \<longrightarrow>
-          \<not> sameObjectAs cap c)"
-
-lemma not_FinalE:
-  "\<lbrakk> \<not> isFinal cap sl cps; isUntypedCap cap \<Longrightarrow> P;
-     \<And>p c. \<lbrakk> cps p = Some c; p \<noteq> sl; \<not> isUntypedCap c; sameObjectAs cap c \<rbrakk> \<Longrightarrow> P
-    \<rbrakk> \<Longrightarrow> P"
-  by (fastforce simp: isFinal_def)
-
-definition
- "removeable' sl \<equiv> \<lambda>s cap.
-    (\<exists>p. p \<noteq> sl \<and> cte_wp_at' (\<lambda>cte. capMasterCap (cteCap cte) = capMasterCap cap) p s)
-    \<or> ((\<forall>p \<in> cte_refs' cap (irq_node' s). p \<noteq> sl \<longrightarrow> cte_wp_at' (\<lambda>cte. cteCap cte = NullCap) p s)
-         \<and> (\<forall>p \<in> zobj_refs' cap. ko_wp_at' (Not \<circ> live') p s))"
-
-lemma not_Final_removeable:
-  "\<not> isFinal cap sl (cteCaps_of s)
-    \<Longrightarrow> removeable' sl s cap"
+lemma not_Final_removeable[Finalise_R_2_assms]:
+  "\<not> isFinal cap sl (cteCaps_of s) \<Longrightarrow> removeable' sl s cap"
   apply (erule not_FinalE)
    apply (clarsimp simp: removeable'_def gen_isCap_simps)
   apply (clarsimp simp: cteCaps_of_def ARM_HYP.sameObjectAs_def2 removeable'_def
-                        cte_wp_at_ctes_of) (* FIXME arch-split *)
+                        cte_wp_at_ctes_of)
   apply fastforce
   done
 
-context begin interpretation Arch .
-crunch postCapDeletion
-  for ko_wp_at'[wp]: "\<lambda>s. P (ko_wp_at' P' p s)"
-crunch postCapDeletion
-  for cteCaps_of[wp]: "\<lambda>s. P (cteCaps_of s)"
-  (simp: cteCaps_of_def o_def)
-end
-
-crunch clearUntypedFreeIndex
-  for ko_at_live[wp]: "\<lambda>s. P (ko_wp_at' live' ptr s)"
-
-lemma clearUntypedFreeIndex_cteCaps_of[wp]:
-  "\<lbrace>\<lambda>s. P (cteCaps_of s)\<rbrace>
-       clearUntypedFreeIndex sl \<lbrace>\<lambda>y s. P (cteCaps_of s)\<rbrace>"
-  by (simp add: cteCaps_of_def, wp)
-
-lemma emptySlot_iflive'[wp]:
-  "\<lbrace>\<lambda>s. if_live_then_nonz_cap' s \<and> cte_wp_at' (\<lambda>cte. removeable' sl s (cteCap cte)) sl s\<rbrace>
-     emptySlot sl opt
-   \<lbrace>\<lambda>rv. if_live_then_nonz_cap'\<rbrace>"
-  apply (simp add: emptySlot_def case_Null_If if_live_then_nonz_cap'_def2
-              del: comp_apply)
+lemma deletedIRQHandler_valid_global_refs[Finalise_R_2_assms, wp]:
+  "\<lbrace>valid_global_refs'\<rbrace> deletedIRQHandler irq \<lbrace>\<lambda>rv. valid_global_refs'\<rbrace>"
+  apply (clarsimp simp: valid_global_refs'_def global_refs'_def)
   apply (rule hoare_pre)
-   apply (wp hoare_vcg_all_lift hoare_vcg_disj_lift
-             getCTE_wp opt_return_pres_lift
-             clearUntypedFreeIndex_ctes_of
-             clearUntypedFreeIndex_cteCaps_of
-             hoare_vcg_ex_lift
-             | wp (once) hoare_vcg_imp_lift
-             | simp add: cte_wp_at_ctes_of del: comp_apply)+
-  apply (clarsimp simp: modify_map_same
-    imp_conjR[symmetric])
-  apply (drule spec, drule(1) mp)
-  apply (clarsimp simp: cte_wp_at_ctes_of modify_map_def split: if_split_asm)
-  apply (case_tac "p \<noteq> sl")
-   apply blast
-  apply (simp add: removeable'_def cteCaps_of_def)
-  apply (erule disjE)
-   apply (clarsimp simp: cte_wp_at_ctes_of modify_map_def
-                  dest!: capMaster_same_refs)
-   apply fastforce
-  apply clarsimp
-  apply (drule(1) bspec)
-  apply (clarsimp simp: ko_wp_at'_def)
-  done
-
-crunch doMachineOp
-  for irq_node'[wp]: "\<lambda>s. P (irq_node' s)"
-
-lemma setIRQState_irq_node'[wp]:
-  "\<lbrace>\<lambda>s. P (irq_node' s)\<rbrace> setIRQState state irq \<lbrace>\<lambda>_ s. P (irq_node' s)\<rbrace>"
-  apply (simp add: setIRQState_def setInterruptState_def getInterruptState_def)
-  apply wp
-  apply simp
-  done
-
-context begin interpretation Arch .
-crunch emptySlot
-  for irq_node'[wp]: "\<lambda>s. P (irq_node' s)"
-end
-
-lemma emptySlot_ifunsafe'[wp]:
-  "\<lbrace>\<lambda>s. if_unsafe_then_cap' s \<and> cte_wp_at' (\<lambda>cte. removeable' sl s (cteCap cte)) sl s\<rbrace>
-     emptySlot sl opt
-   \<lbrace>\<lambda>rv. if_unsafe_then_cap'\<rbrace>"
-  apply (simp add: ifunsafe'_def3)
-  apply (rule hoare_pre, rule hoare_use_eq_irq_node'[OF emptySlot_irq_node'])
-   apply (simp add: emptySlot_def case_Null_If)
-   apply (wp opt_return_pres_lift | simp add: o_def)+
-   apply (wp getCTE_cteCap_wp clearUntypedFreeIndex_cteCaps_of)+
-  apply (clarsimp simp: tree_cte_cteCap_eq[unfolded o_def]
-                        modify_map_same
-                        modify_map_comp[symmetric]
-                 split: option.split_asm if_split_asm
-                 dest!: modify_map_K_D)
-  apply (clarsimp simp: modify_map_def)
-  apply (drule_tac x=cref in spec, clarsimp)
-  apply (case_tac "cref' \<noteq> sl")
-   apply (rule_tac x=cref' in exI)
-   apply (clarsimp simp: modify_map_def)
-  apply (simp add: removeable'_def)
-  apply (erule disjE)
-   apply (clarsimp simp: modify_map_def)
-   apply (subst(asm) tree_cte_cteCap_eq[unfolded o_def])
-   apply (clarsimp split: option.split_asm dest!: capMaster_same_refs)
-   apply fastforce
-  apply clarsimp
-  apply (drule(1) bspec)
-  apply (clarsimp simp: cte_wp_at_ctes_of cteCaps_of_def)
-  done
-
-lemma ctes_of_valid'[elim]:
-  "\<lbrakk>ctes_of s p = Some cte; valid_objs' s\<rbrakk> \<Longrightarrow> s \<turnstile>' cteCap cte"
-  by (cases cte, simp) (rule ctes_of_valid_cap')
-
-crunch postCapDeletion
-  for ksrq[wp]: "\<lambda>s. P (ksReadyQueues s)"
-
-crunch setInterruptState
-  for valid_idle'[wp]: "valid_idle'"
-  (simp: valid_idle'_def)
-
-context begin interpretation Arch .
-crunch emptySlot
-  for valid_idle'[wp]: "valid_idle'"
-
-crunch emptySlot
-  for ksArch[wp]: "\<lambda>s. P (ksArchState s)"
-crunch emptySlot
-  for ksIdle[wp]: "\<lambda>s. P (ksIdleThread s)"
-crunch emptySlot
-  for gsMaxObjectSize[wp]: "\<lambda>s. P (gsMaxObjectSize s)"
-end
-
-lemma emptySlot_cteCaps_of:
-  "\<lbrace>\<lambda>s. P ((cteCaps_of s)(p \<mapsto> NullCap))\<rbrace>
-     emptySlot p opt
-   \<lbrace>\<lambda>rv s. P (cteCaps_of s)\<rbrace>"
-  apply (simp add: emptySlot_def case_Null_If)
-  apply (wp opt_return_pres_lift getCTE_cteCap_wp
-            clearUntypedFreeIndex_cteCaps_of)
-  apply (clarsimp simp: cteCaps_of_def cte_wp_at_ctes_of)
-  apply (auto elim!: rsubst[where P=P]
-               simp: modify_map_def fun_upd_def[symmetric] o_def
-                     fun_upd_idem cteCaps_of_def
-              split: option.splits)
-  done
-
-lemma emptySlot_valid_global_refs[wp]:
-  "\<lbrace>valid_global_refs' and cte_at' sl\<rbrace> emptySlot sl opt \<lbrace>\<lambda>rv. valid_global_refs'\<rbrace>"
-  apply (simp add: valid_global_refs'_def ARM_HYP.global_refs'_def)
-  apply (rule hoare_pre)
-   apply (rule hoare_use_eq_irq_node' [OF emptySlot_irq_node'])
-   apply (rule hoare_use_eq [where f=ksArchState, OF emptySlot_ksArch])
-   apply (rule hoare_use_eq [where f=ksIdleThread, OF emptySlot_ksIdle])
-   apply (rule hoare_use_eq [where f=gsMaxObjectSize], wp)
+   apply (rule hoare_use_eq_irq_node' [OF deletedIRQHandler_irq_node'])
+   apply (rule hoare_use_eq [where f=ksIdleThread, OF deletedIRQHandler_ksIdle])
+   apply (rule hoare_use_eq [where f=ksArchState, OF deletedIRQHandler_ksArch])
+   apply (rule hoare_use_eq[where f="gsMaxObjectSize"], wp)
    apply (simp add: valid_refs'_cteCaps valid_cap_sizes_cteCaps)
-   apply (rule emptySlot_cteCaps_of)
+   apply (rule deletedIRQHandler_cteCaps_of)
   apply (clarsimp simp: cte_wp_at_ctes_of)
-  apply (frule(1) cte_at_valid_cap_sizes_0)
   apply (clarsimp simp: valid_refs'_cteCaps valid_cap_sizes_cteCaps ball_ran_eq)
   done
 
-lemmas doMachineOp_irq_handlers[wp]
-    = valid_irq_handlers_lift'' [OF doMachineOp_ctes doMachineOp_ksInterruptState]
-
-lemma deletedIRQHandler_irq_handlers'[wp]:
-  "\<lbrace>\<lambda>s. valid_irq_handlers' s \<and> (IRQHandlerCap irq \<notin> ran (cteCaps_of s))\<rbrace>
-       deletedIRQHandler irq
-   \<lbrace>\<lambda>rv. valid_irq_handlers'\<rbrace>"
-  apply (simp add: deletedIRQHandler_def setIRQState_def setInterruptState_def getInterruptState_def)
-  apply wp
-  apply (clarsimp simp: valid_irq_handlers'_def irq_issued'_def ran_def cteCaps_of_def)
-  done
-
-context begin interpretation Arch .
-
-lemma postCapDeletion_irq_handlers'[wp]:
-  "\<lbrace>\<lambda>s. valid_irq_handlers' s \<and> (cap \<noteq> NullCap \<longrightarrow> cap \<notin> ran (cteCaps_of s))\<rbrace>
-       postCapDeletion cap
-   \<lbrace>\<lambda>rv. valid_irq_handlers'\<rbrace>"
-  by (wpsimp simp: Retype_H.postCapDeletion_def ARM_HYP_H.postCapDeletion_def)
-
-end
-
-crunch clearUntypedFreeIndex
-  for ksInterruptState[wp]: "\<lambda>s. P (ksInterruptState s)"
-
-lemma emptySlot_valid_irq_handlers'[wp]:
-  "\<lbrace>\<lambda>s. valid_irq_handlers' s
-          \<and> (\<forall>sl'. info \<noteq> NullCap \<longrightarrow> sl' \<noteq> sl \<longrightarrow> cteCaps_of s sl' \<noteq> Some info)\<rbrace>
-     emptySlot sl info
-   \<lbrace>\<lambda>rv. valid_irq_handlers'\<rbrace>"
-  apply (simp add: emptySlot_def case_Null_If)
-  apply (wp | wpc)+
-        apply (unfold valid_irq_handlers'_def irq_issued'_def)
-        apply (wp getCTE_cteCap_wp clearUntypedFreeIndex_cteCaps_of
-          | wps clearUntypedFreeIndex_ksInterruptState)+
-  apply (clarsimp simp: cteCaps_of_def cte_wp_at_ctes_of ran_def modify_map_def
-                 split: option.split)
-  apply auto
-  done
-
-context begin interpretation Arch .
-crunch emptySlot
-  for irq_states'[wp]: valid_irq_states'
-
-crunch emptySlot
-  for no_0_obj'[wp]: no_0_obj'
- (wp: crunch_wps)
-
-crunch emptySlot
-  for pde_mappings'[wp]: "valid_pde_mappings'"
-
-lemma deletedIRQHandler_irqs_masked'[wp]:
-  "\<lbrace>irqs_masked'\<rbrace> deletedIRQHandler irq \<lbrace>\<lambda>_. irqs_masked'\<rbrace>"
-  apply (simp add: deletedIRQHandler_def setIRQState_def getInterruptState_def setInterruptState_def)
-  apply (wp dmo_maskInterrupt)
-  apply (simp add: irqs_masked'_def)
-  done
-
-crunch emptySlot
-  for irqs_masked'[wp]: "irqs_masked'"
-
-lemma setIRQState_umm:
- "\<lbrace>\<lambda>s. P (underlying_memory (ksMachineState s))\<rbrace>
-   setIRQState irqState irq
-  \<lbrace>\<lambda>_ s. P (underlying_memory (ksMachineState s))\<rbrace>"
-  by (simp add: setIRQState_def maskInterrupt_def
-                setInterruptState_def getInterruptState_def
-      | wp dmo_lift')+
-
-crunch emptySlot
-  for umm[wp]: "\<lambda>s. P (underlying_memory (ksMachineState s))"
-  (wp: setIRQState_umm)
-
-lemma emptySlot_vms'[wp]:
-  "\<lbrace>valid_machine_state'\<rbrace> emptySlot slot irq \<lbrace>\<lambda>_. valid_machine_state'\<rbrace>"
-  by (simp add: valid_machine_state'_def pointerInUserData_def pointerInDeviceData_def)
-     (wp hoare_vcg_all_lift hoare_vcg_disj_lift)
-
-crunch emptySlot
-  for pspace_domain_valid[wp]: "pspace_domain_valid"
-
-crunch emptySlot
-  for nosch[wp]: "\<lambda>s. P (ksSchedulerAction s)"
-crunch emptySlot
-  for ct[wp]: "\<lambda>s. P (ksCurThread s)"
-crunch emptySlot
-  for ksCurDomain[wp]: "\<lambda>s. P (ksCurDomain s)"
-crunch emptySlot
-  for ksDomSchedule[wp]: "\<lambda>s. P (ksDomSchedule s)"
-crunch emptySlot
-  for ksDomScheduleIdx[wp]: "\<lambda>s. P (ksDomScheduleIdx s)"
-
-lemma deletedIRQHandler_ct_not_inQ[wp]:
-  "\<lbrace>ct_not_inQ\<rbrace> deletedIRQHandler irq \<lbrace>\<lambda>_. ct_not_inQ\<rbrace>"
-  apply (rule ct_not_inQ_lift [OF deletedIRQHandler_nosch])
-  apply (rule hoare_weaken_pre)
-   apply (wps deletedIRQHandler_ct)
-   apply (simp add: deletedIRQHandler_def setIRQState_def)
-   apply (wp)
-  apply (simp add: comp_def)
-  done
-
-crunch emptySlot
-  for ct_not_inQ[wp]: "ct_not_inQ"
-
-crunch emptySlot
-  for tcbDomain[wp]: "obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t"
-
-lemma emptySlot_ct_idle_or_in_cur_domain'[wp]:
-  "\<lbrace>ct_idle_or_in_cur_domain'\<rbrace> emptySlot sl opt \<lbrace>\<lambda>_. ct_idle_or_in_cur_domain'\<rbrace>"
-apply (wp ct_idle_or_in_cur_domain'_lift2 tcb_in_cur_domain'_lift | simp)+
-done
-
-crunch postCapDeletion
-  for gsUntypedZeroRanges[wp]: "\<lambda>s. P (gsUntypedZeroRanges s)"
-  (wp: crunch_wps simp: crunch_simps)
-
-lemma untypedZeroRange_modify_map_isUntypedCap:
-  "m sl = Some v \<Longrightarrow> \<not> isUntypedCap v \<Longrightarrow> \<not> isUntypedCap (f v)
-    \<Longrightarrow> (untypedZeroRange \<circ>\<^sub>m modify_map m sl f) = (untypedZeroRange \<circ>\<^sub>m m)"
-  by (simp add: modify_map_def map_comp_def fun_eq_iff untypedZeroRange_def)
-
-lemma emptySlot_untyped_ranges[wp]:
-  "\<lbrace>untyped_ranges_zero' and valid_objs' and valid_mdb'\<rbrace>
-     emptySlot sl opt \<lbrace>\<lambda>rv. untyped_ranges_zero'\<rbrace>"
-  apply (simp add: emptySlot_def case_Null_If)
+lemma clearUntypedFreeIndex_valid_global_refs[Finalise_R_2_assms, wp]:
+  "\<lbrace>valid_global_refs'\<rbrace> clearUntypedFreeIndex irq \<lbrace>\<lambda>rv. valid_global_refs'\<rbrace>"
+  apply (clarsimp simp: valid_global_refs'_def global_refs'_def)
   apply (rule hoare_pre)
-   apply (rule bind_wp)
-    apply (rule untyped_ranges_zero_lift)
-     apply (wp getCTE_cteCap_wp clearUntypedFreeIndex_cteCaps_of
-       | wpc | simp add: clearUntypedFreeIndex_def updateTrackedFreeIndex_def
-                         getSlotCap_def
-                  split: option.split)+
-  apply (clarsimp simp: modify_map_comp[symmetric] modify_map_same)
-  apply (case_tac "\<not> isUntypedCap (the (cteCaps_of s sl))")
-   apply (case_tac "the (cteCaps_of s sl)",
-     simp_all add: untyped_ranges_zero_inv_def
-                   untypedZeroRange_modify_map_isUntypedCap isCap_simps)[1]
-  apply (clarsimp simp: isCap_simps untypedZeroRange_def modify_map_def)
-  apply (strengthen untyped_ranges_zero_fun_upd[mk_strg I E])
-  apply simp
-  apply (simp add: untypedZeroRange_def isCap_simps)
-  done
-
-crunch emptySlot
-  for valid_arch'[wp]: valid_arch_state'
-  (wp: crunch_wps)
-
-crunch emptySlot
-  for valid_bitmaps[wp]: valid_bitmaps
-  and tcbQueued_opt_pred[wp]: "\<lambda>s. P (tcbQueued |< tcbs_of' s)"
-  and valid_sched_pointers[wp]: valid_sched_pointers
-  and sched_projs[wp]: "\<lambda>s. P (tcbSchedNexts_of s) (tcbSchedPrevs_of s)"
-  and valid_arch_state'[wp]: valid_arch_state'
-  and ksDomScheduleStart[wp]: "\<lambda>s. P (ksDomScheduleStart s)"
-  (wp: valid_bitmaps_lift)
-
-lemma emptySlot_invs'[wp]:
-  "\<lbrace>\<lambda>s. invs' s \<and> cte_wp_at' (\<lambda>cte. removeable' sl s (cteCap cte)) sl s
-            \<and> (\<forall>sl'. info \<noteq> NullCap \<longrightarrow> sl' \<noteq> sl \<longrightarrow> cteCaps_of s sl' \<noteq> Some info)\<rbrace>
-     emptySlot sl info
-   \<lbrace>\<lambda>rv. invs'\<rbrace>"
-  apply (simp add: invs'_def valid_state'_def valid_pspace'_def)
-  apply (wp valid_irq_node_lift cur_tcb_lift valid_dom_schedule'_lift)
+   apply (rule hoare_use_eq_irq_node' [OF clearUntypedFreeIndex_irq_node'])
+   apply (rule hoare_use_eq [where f=ksIdleThread, OF clearUntypedFreeIndex_ksIdle])
+   apply (rule hoare_use_eq [where f=ksArchState, OF clearUntypedFreeIndex_ksArch])
+   apply (rule hoare_use_eq[where f="gsMaxObjectSize"], wp)
+   apply (simp add: valid_refs'_cteCaps valid_cap_sizes_cteCaps)
+   apply (rule clearUntypedFreeIndex_cteCaps_of)
   apply (clarsimp simp: cte_wp_at_ctes_of)
+  apply (clarsimp simp: valid_refs'_cteCaps valid_cap_sizes_cteCaps ball_ran_eq)
   done
-
-lemma deletedIRQHandler_corres:
-  "corres dc \<top> \<top>
-    (deleted_irq_handler irq)
-    (deletedIRQHandler irq)"
-  apply (simp add: deleted_irq_handler_def deletedIRQHandler_def)
-  apply (rule setIRQState_corres)
-  apply (simp add: irq_state_relation_def)
-  done
-
-lemma arch_postCapDeletion_corres:
-  "acap_relation cap cap' \<Longrightarrow> corres dc \<top> \<top> (arch_post_cap_deletion cap) (ARM_HYP_H.postCapDeletion cap')"
-  by (corresKsimp simp: arch_post_cap_deletion_def ARM_HYP_H.postCapDeletion_def)
-
-lemma postCapDeletion_corres:
-  "cap_relation cap cap' \<Longrightarrow> corres dc \<top> \<top> (post_cap_deletion cap) (postCapDeletion cap')"
-  apply (cases cap; clarsimp simp: post_cap_deletion_def Retype_H.postCapDeletion_def)
-   apply (corresKsimp corres: deletedIRQHandler_corres)
-  by (corresKsimp corres: arch_postCapDeletion_corres)
-
-lemma set_cap_trans_state:
-  "((),s') \<in> fst (set_cap c p s) \<Longrightarrow> ((),trans_state f s') \<in> fst (set_cap c p (trans_state f s))"
-  apply (cases p)
-  apply (clarsimp simp add: set_cap_def in_monad get_object_def)
-  apply (case_tac y)
-      apply (auto simp: in_monad set_object_def get_object_def split: if_split_asm)
-  done
-
-lemma clearUntypedFreeIndex_noop_corres:
-  "corres dc \<top> (cte_at' (cte_map slot))
-    (return ()) (clearUntypedFreeIndex (cte_map slot))"
-  apply (simp add: clearUntypedFreeIndex_def)
-  apply (rule corres_guard_imp)
-    apply (rule corres_bind_return2)
-    apply (rule corres_symb_exec_r_conj[where P'="cte_at' (cte_map slot)"])
-       apply (rule corres_trivial, simp)
-      apply (wp wp_post_taut getCTE_wp' | wpc
-        | simp add: updateTrackedFreeIndex_def getSlotCap_def)+
-     apply (clarsimp simp: state_relation_def)
-    apply (rule no_fail_pre)
-     apply (wp no_fail_getSlotCap getCTE_wp'
-       | wpc | simp add: updateTrackedFreeIndex_def getSlotCap_def)+
-  done
-
-lemma clearUntypedFreeIndex_valid_pspace'[wp]:
-  "\<lbrace>valid_pspace'\<rbrace> clearUntypedFreeIndex slot \<lbrace>\<lambda>rv. valid_pspace'\<rbrace>"
-  apply (simp add: valid_pspace'_def)
-  apply (rule hoare_pre)
-   apply (wp | simp add: valid_mdb'_def)+
-  done
-
-lemma emptySlot_corres:
-  "cap_relation info info' \<Longrightarrow> corres dc (einvs and cte_at slot) (invs' and cte_at' (cte_map slot))
-             (empty_slot slot info) (emptySlot (cte_map slot) info')"
-  unfolding emptySlot_def empty_slot_def
-  apply (simp add: case_Null_If)
-  apply (rule corres_guard_imp)
-    apply (rule corres_split_noop_rhs[OF clearUntypedFreeIndex_noop_corres])
-     apply (rule_tac R="\<lambda>cap. einvs and cte_wp_at ((=) cap) slot" and
-                     R'="\<lambda>cte. valid_pspace' and cte_wp_at' ((=) cte) (cte_map slot)" in
-                     corres_split[OF get_cap_corres])
-       defer
-       apply (wp get_cap_wp getCTE_wp')+
-     apply (simp add: cte_wp_at_ctes_of)
-     apply (wp hoare_vcg_imp_lift clearUntypedFreeIndex_valid_pspace')
-    apply fastforce
-   apply (fastforce simp: cte_wp_at_ctes_of)
-  apply simp
-  apply (rule conjI, clarsimp)
-   defer
-  apply clarsimp
-  apply (rule conjI, clarsimp)
-  apply clarsimp
-  apply (simp only: bind_assoc[symmetric])
-  apply (rule corres_underlying_split[where r'=dc, OF _ postCapDeletion_corres])
-    defer
-    apply wpsimp+
-  apply (rule corres_no_failI)
-   apply (rule no_fail_pre, wp hoare_weak_lift_imp)
-   apply (clarsimp simp: cte_wp_at_ctes_of valid_pspace'_def)
-   apply (clarsimp simp: valid_mdb'_def valid_mdb_ctes_def)
-   apply (rule conjI, clarsimp)
-    apply (erule (2) valid_dlistEp)
-    apply simp
-   apply clarsimp
-   apply (erule (2) valid_dlistEn)
-   apply simp
-  apply (clarsimp simp: in_monad bind_assoc exec_gets)
-  apply (subgoal_tac "mdb_empty_abs a")
-   prefer 2
-   apply (rule mdb_empty_abs.intro)
-   apply (rule vmdb_abs.intro)
-   apply fastforce
-  apply (frule mdb_empty_abs'.intro)
-  apply (simp add: mdb_empty_abs'.empty_slot_ext_det_def2 update_cdt_list_def set_cdt_list_def exec_gets set_cdt_def bind_assoc exec_get exec_put set_original_def modify_def del: fun_upd_apply | subst bind_def, simp, simp add: mdb_empty_abs'.empty_slot_ext_det_def2)+
-  apply (simp add: put_def)
-  apply (simp add: exec_gets exec_get exec_put del: fun_upd_apply | subst bind_def)+
-  apply (clarsimp simp: state_relation_def)
-  apply (drule updateMDB_the_lot, fastforce simp: pspace_relation_def, fastforce, fastforce)
-   apply (clarsimp simp: invs'_def valid_state'_def valid_pspace'_def
-                         valid_mdb'_def valid_mdb_ctes_def)
-  apply (elim conjE)
-  apply (drule (4) updateMDB_the_lot, elim conjE)
-  apply clarsimp
-  apply (drule_tac s'=s''a and c=cap.NullCap in set_cap_not_quite_corres)
-                      subgoal by simp
-                     subgoal by simp
-                    subgoal by simp
-                   subgoal by simp
-                  subgoal by fastforce
-                 subgoal by fastforce
-                subgoal by fastforce
-               subgoal by fastforce
-              subgoal by fastforce
-             apply fastforce
-            subgoal by fastforce
-           subgoal by fastforce
-          subgoal by fastforce
-         apply (erule cte_wp_at_weakenE, rule TrueI)
-        apply assumption
-       subgoal by simp
-      subgoal by simp
-     subgoal by simp
-    subgoal by simp
-   apply (rule refl)
-  apply clarsimp
-  apply (drule updateCap_stuff, elim conjE, erule (1) impE)
-  apply clarsimp
-  apply (drule updateMDB_the_lot, force simp: pspace_relation_def, assumption+, simp)
-  apply (rule bexI)
-   prefer 2
-   apply (simp only: trans_state_update[symmetric])
-   apply (rule set_cap_trans_state)
-   apply (rule set_cap_revokable_update)
-   apply (erule set_cap_cdt_update)
-  apply clarsimp
-  apply (thin_tac "ctes_of t = s" for t s)+
-  apply (thin_tac "ksMachineState t = p" for t p)+
-  apply (thin_tac "ksCurThread t = p" for t p)+
-  apply (thin_tac "ksReadyQueues t = p" for t p)+
-  apply (thin_tac "ksSchedulerAction t = p" for t p)+
-  apply (clarsimp simp: cte_wp_at_ctes_of)
-  apply (case_tac rv')
-  apply (rename_tac s_cap s_node)
-  apply (subgoal_tac "cte_at slot a")
-   prefer 2
-   apply (fastforce elim: cte_wp_at_weakenE)
-  apply (subgoal_tac "mdb_empty (ctes_of b) (cte_map slot) s_cap s_node")
-   prefer 2
-   apply (rule mdb_empty.intro)
-   apply (rule mdb_ptr.intro)
-    apply (rule vmdb.intro)
-    subgoal by (simp add: invs'_def valid_state'_def valid_pspace'_def valid_mdb'_def)
-   apply (rule mdb_ptr_axioms.intro)
-   subgoal by simp
-  apply (clarsimp simp: ghost_relation_typ_at set_cap_a_type_inv)
-  apply (simp add: pspace_relation_def)
-  apply (rule conjI)
-   apply (clarsimp simp: data_at_def ghost_relation_typ_at set_cap_a_type_inv)
-  apply (rule conjI)
-   prefer 2
-   apply (rule conjI)
-    apply (clarsimp simp: cdt_list_relation_def)
-    apply(frule invs_valid_pspace, frule invs_mdb)
-    apply(subgoal_tac "no_mloop (cdt a) \<and> finite_depth (cdt a)")
-     prefer 2
-     subgoal by(simp add: finite_depth valid_mdb_def)
-    apply(subgoal_tac "valid_mdb_ctes (ctes_of b)")
-     prefer 2
-     subgoal by(simp add: mdb_empty_def mdb_ptr_def vmdb_def)
-    apply(clarsimp simp: valid_pspace_def)
-
-    apply(case_tac "cdt a slot")
-     apply(simp add: next_slot_eq[OF mdb_empty_abs'.next_slot_no_parent])
-     apply(case_tac "next_slot (aa, bb) (cdt_list a) (cdt a)")
-      subgoal by (simp)
-     apply(clarsimp)
-     apply(frule(1) mdb_empty.n_next)
-     apply(clarsimp)
-     apply(erule_tac x=aa in allE, erule_tac x=bb in allE)
-     apply(simp split: if_split_asm)
-      apply(drule cte_map_inj_eq)
-           apply(drule cte_at_next_slot)
-             apply(assumption)+
-      apply(simp)
-     apply(subgoal_tac "(ab, bc) = slot")
-      prefer 2
-      apply(drule_tac cte="CTE s_cap s_node" in valid_mdbD2')
-        subgoal by (clarsimp simp: valid_mdb_ctes_def no_0_def)
-       subgoal by (clarsimp simp: invs'_def valid_state'_def valid_pspace'_def)
-      apply(clarsimp)
-      apply(rule cte_map_inj_eq)
-           apply(assumption)
-          apply(drule(3) cte_at_next_slot', assumption)
-         apply(assumption)+
-     apply(simp)
-     apply(drule_tac p="(aa, bb)" in no_parent_not_next_slot)
-        apply(assumption)+
-     apply(clarsimp)
-
-    apply(simp add: next_slot_eq[OF mdb_empty_abs'.next_slot] split del: if_split)
-    apply(case_tac "next_slot (aa, bb) (cdt_list a) (cdt a)")
-     subgoal by (simp)
-    apply(case_tac "(aa, bb) = slot", simp)
-    apply(case_tac "next_slot (aa, bb) (cdt_list a) (cdt a) = Some slot")
-     apply(simp)
-     apply(case_tac "next_slot ac (cdt_list a) (cdt a)", simp)
-     apply(simp)
-     apply(frule(1) mdb_empty.n_next)
-     apply(clarsimp)
-     apply(erule_tac x=aa in allE', erule_tac x=bb in allE)
-     apply(erule_tac x=ac in allE, erule_tac x=bd in allE)
-     apply(clarsimp split: if_split_asm)
-      apply(drule(1) no_self_loop_next)
-      apply(simp)
-     apply(drule_tac cte="CTE cap' node'" in valid_mdbD1')
-       apply(fastforce simp: valid_mdb_ctes_def no_0_def)
-      subgoal by (simp add: valid_mdb'_def)
-     apply(clarsimp)
-    apply(simp)
-    apply(frule(1) mdb_empty.n_next)
-    apply(erule_tac x=aa in allE, erule_tac x=bb in allE)
-    apply(clarsimp split: if_split_asm)
-     apply(drule(1) no_self_loop_prev)
-     apply(clarsimp)
-     apply(drule_tac cte="CTE s_cap s_node" in valid_mdbD2')
-       apply(clarsimp simp: valid_mdb_ctes_def no_0_def)
-      apply clarify
-     apply(clarsimp)
-     apply(drule cte_map_inj_eq)
-          apply(drule(3) cte_at_next_slot')
-          apply(assumption)+
-     apply(simp)
-    apply(erule disjE)
-     apply(drule cte_map_inj_eq)
-          apply(drule(3) cte_at_next_slot)
-          apply(assumption)+
-     apply(simp)
-    subgoal by (simp)
-   apply (simp add: revokable_relation_def)
-   apply (clarsimp simp: in_set_cap_cte_at)
-   apply (rule conjI)
-    apply clarsimp
-    apply (drule(1) mdb_empty.n_revokable)
-    subgoal by clarsimp
-   apply clarsimp
-   apply (drule (1) mdb_empty.n_revokable)
-   apply (subgoal_tac "null_filter (caps_of_state a) (aa,bb) \<noteq> None")
-    prefer 2
-    apply (drule set_cap_caps_of_state_monad)
-    subgoal by (force simp: null_filter_def)
-   apply clarsimp
-   apply (subgoal_tac "cte_at (aa, bb) a")
-    prefer 2
-    apply (drule null_filter_caps_of_stateD, erule cte_wp_cte_at)
-   apply (drule (2) cte_map_inj_ps, fastforce)
-   subgoal by simp
-  apply (clarsimp simp add: cdt_relation_def)
-  apply (subst mdb_empty_abs.descendants, assumption)
-  apply (subst mdb_empty.descendants, assumption)
-  apply clarsimp
-  apply (frule_tac p="(aa, bb)" in in_set_cap_cte_at)
-  apply clarsimp
-  apply (frule (2) cte_map_inj_ps, fastforce)
-  apply simp
-  apply (case_tac "slot \<in> descendants_of (aa,bb) (cdt a)")
-   apply (subst inj_on_image_set_diff)
-      apply (rule inj_on_descendants_cte_map)
-         apply fastforce
-        apply fastforce
-       apply fastforce
-      apply fastforce
-     apply fastforce
-    subgoal by simp
-   subgoal by simp
-  apply simp
-  apply (subgoal_tac "cte_map slot \<notin> descendants_of' (cte_map (aa,bb)) (ctes_of b)")
-   subgoal by simp
-  apply (erule_tac x=aa in allE, erule allE, erule (1) impE)
-  apply (drule_tac s="cte_map ` u" for u in sym)
-  apply clarsimp
-  apply (drule cte_map_inj_eq, assumption)
-      apply (erule descendants_of_cte_at, fastforce)
-     apply fastforce
-    apply fastforce
-   apply fastforce
-  apply simp
-  done
-
-
-
-text \<open>Some facts about is_final_cap/isFinalCapability\<close>
-
-lemma isFinalCapability_inv:
-  "\<lbrace>P\<rbrace> isFinalCapability cap \<lbrace>\<lambda>_. P\<rbrace>"
-  apply (simp add: isFinalCapability_def Let_def
-              split del: if_split cong: if_cong)
-  apply (rule hoare_pre, wp)
-   apply (rule hoare_post_imp[where Q'="\<lambda>s. P"], simp)
-   apply wp
-  apply simp
-  done
-
-definition
-  final_matters' :: "capability \<Rightarrow> bool"
-where
- "final_matters' cap \<equiv> case cap of
-    EndpointCap ref bdg s r g gr \<Rightarrow> True
-  | NotificationCap ref bdg s r \<Rightarrow> True
-  | ThreadCap ref \<Rightarrow> True
-  | CNodeCap ref bits gd gs \<Rightarrow> True
-  | Zombie ptr zb n \<Rightarrow> True
-  | IRQHandlerCap irq \<Rightarrow> True
-  | ArchObjectCap acap \<Rightarrow> (case acap of
-    PageCap d ref rghts sz mapdata \<Rightarrow> False
-  | ASIDControlCap \<Rightarrow> False
-  | SGISignalCap _ _ \<Rightarrow> False
-  | _ \<Rightarrow> True)
-  | _ \<Rightarrow> False"
 
 lemma final_matters_Master:
   "final_matters' (capMasterCap cap) = final_matters' cap"
   by (simp add: capMasterCap_def arch_capMasterCap_def split: capability.split arch_capability.split,
-      simp add: final_matters'_def)
+      simp add: final_matters'_def arch_final_matters'_def)
 
 lemma final_matters_sameRegion_sameObject:
   "final_matters' cap \<Longrightarrow> sameRegionAs cap cap' = sameObjectAs cap cap'"
   apply (rule iffI)
    apply (erule sameRegionAsE)
       apply (simp add: sameObjectAs_def3)
-      apply (clarsimp simp: isCap_simps sameObjectAs_sameRegionAs final_matters'_def
-        split:capability.splits arch_capability.splits)+
+      apply (clarsimp simp: isCap_simps sameObjectAs_sameRegionAs
+                            final_matters'_def arch_final_matters'_def
+                      split: capability.splits arch_capability.splits)+
   done
 
 lemma final_matters_sameRegion_sameObject2:
   "\<lbrakk> final_matters' cap'; \<not> isUntypedCap cap; \<not> isIRQHandlerCap cap' \<rbrakk>
-     \<Longrightarrow> sameRegionAs cap cap' = sameObjectAs cap cap'"
+   \<Longrightarrow> sameRegionAs cap cap' = sameObjectAs cap cap'"
   apply (rule iffI)
    apply (erule sameRegionAsE)
        apply (simp add: sameObjectAs_def3)
-       apply (fastforce simp: isCap_simps final_matters'_def)
+       apply (fastforce simp: isCap_simps final_matters'_def arch_final_matters'_def)
       apply simp
-     apply (clarsimp simp: final_matters'_def isCap_simps)
-    apply (clarsimp simp: final_matters'_def isCap_simps)
-   apply (clarsimp simp: final_matters'_def isCap_simps)
+     apply (clarsimp simp: final_matters'_def arch_final_matters'_def isCap_simps)+
   apply (erule sameObjectAs_sameRegionAs)
   done
 
 lemma final_matters_mdb_chunked_arch_assms:
   "final_matters' cap \<Longrightarrow> mdb_chunked_arch_assms cap"
-  by (clarsimp simp: mdb_chunked_arch_assms_def isCap_simps final_matters'_def)
+  by (clarsimp simp: mdb_chunked_arch_assms_def isCap_simps
+                     final_matters'_def arch_final_matters'_def)
 
-lemma notFinal_prev_or_next:
+lemma notFinal_prev_or_next[Finalise_R_2_assms]:
   "\<lbrakk> \<not> isFinal cap x (cteCaps_of s); mdb_chunked (ctes_of s);
-      valid_dlist (ctes_of s); no_0 (ctes_of s);
-      ctes_of s x = Some (CTE cap node); final_matters' cap \<rbrakk>
-     \<Longrightarrow> (\<exists>cap' node'. ctes_of s (mdbPrev node) = Some (CTE cap' node')
-              \<and> sameObjectAs cap cap')
-      \<or> (\<exists>cap' node'. ctes_of s (mdbNext node) = Some (CTE cap' node')
-              \<and> sameObjectAs cap cap')"
+     valid_dlist (ctes_of s); no_0 (ctes_of s);
+     ctes_of s x = Some (CTE cap node); final_matters' cap \<rbrakk>
+   \<Longrightarrow> (\<exists>cap' node'. ctes_of s (mdbPrev node) = Some (CTE cap' node') \<and> sameObjectAs cap cap')
+      \<or> (\<exists>cap' node'. ctes_of s (mdbNext node) = Some (CTE cap' node') \<and> sameObjectAs cap cap')"
   apply (erule not_FinalE)
    apply (clarsimp simp: isCap_simps final_matters'_def)
   apply (frule final_matters_mdb_chunked_arch_assms)
@@ -1982,91 +543,20 @@ lemma notFinal_prev_or_next:
   apply (clarsimp simp: sameObjectAs_def3 simp del: isArchFrameCap_capMasterCap)
   done
 
-lemma isFinal:
-  "\<lbrace>\<lambda>s. valid_mdb' s \<and> cte_wp_at' ((=) cte) x s
-          \<and> final_matters' (cteCap cte)
-          \<and> Q (isFinal (cteCap cte) x (cteCaps_of s)) s\<rbrace>
-    isFinalCapability cte
-   \<lbrace>Q\<rbrace>"
-  unfolding isFinalCapability_def
-  apply (cases cte)
-  apply (rename_tac cap node)
-  apply (unfold Let_def)
-  apply (simp only: if_False)
-  apply (wp getCTE_wp')
-  apply (cases "mdbPrev (cteMDBNode cte) = nullPointer")
-   apply simp
-   apply (clarsimp simp: valid_mdb_ctes_def valid_mdb'_def
-                         cte_wp_at_ctes_of)
-   apply (rule conjI, clarsimp simp: nullPointer_def)
-    apply (erule rsubst[where P="\<lambda>x. Q x s" for s], simp)
-    apply (rule classical)
-    apply (drule(5) notFinal_prev_or_next)
-    apply clarsimp
-   apply (clarsimp simp: nullPointer_def)
-   apply (erule rsubst[where P="\<lambda>x. Q x s" for s])
-   apply (rule sym, rule iffI)
-    apply (rule classical)
-    apply (drule(5) notFinal_prev_or_next)
-    apply clarsimp
-   apply clarsimp
-   apply (clarsimp simp: cte_wp_at_ctes_of cteCaps_of_def)
-   apply (case_tac cte)
-   apply clarsimp
-   apply (clarsimp simp add: isFinal_def)
-   apply (erule_tac x="mdbNext node" in allE)
-   apply simp
-   apply (erule impE)
-    apply (clarsimp simp: valid_mdb'_def valid_mdb_ctes_def)
-    apply (drule (1) mdb_chain_0_no_loops)
-    apply simp
-   apply (clarsimp simp: sameObjectAs_def3 isCap_simps)
-  apply simp
-  apply (clarsimp simp: cte_wp_at_ctes_of
-                        valid_mdb_ctes_def valid_mdb'_def)
-  apply (case_tac cte)
-  apply clarsimp
-  apply (rule conjI)
-   apply clarsimp
-   apply (erule rsubst[where P="\<lambda>x. Q x s" for s])
-   apply clarsimp
-   apply (clarsimp simp: isFinal_def cteCaps_of_def)
-   apply (erule_tac x="mdbPrev node" in allE)
-   apply simp
-   apply (erule impE)
-    apply clarsimp
-    apply (drule (1) mdb_chain_0_no_loops)
-    apply (subgoal_tac "ctes_of s (mdbNext node) = Some (CTE cap node)")
-     apply clarsimp
-    apply (erule (1) valid_dlistEp)
-     apply clarsimp
-    apply (case_tac cte')
-    apply clarsimp
-   apply (fastforce simp add: sameObjectAs_def3 isCap_simps)
-  apply clarsimp
-  apply (rule conjI)
-   apply clarsimp
-   apply (erule rsubst[where P="\<lambda>x. Q x s" for s], simp)
-   apply (rule classical, drule(5) notFinal_prev_or_next)
-   apply (clarsimp simp: sameObjectAs_sym nullPointer_def)
-  apply (clarsimp simp: nullPointer_def)
-  apply (erule rsubst[where P="\<lambda>x. Q x s" for s])
-  apply (rule sym, rule iffI)
-   apply (rule classical, drule(5) notFinal_prev_or_next)
-   apply (clarsimp simp: sameObjectAs_sym)
-   apply auto[1]
-  apply (clarsimp simp: isFinal_def cteCaps_of_def)
-  apply (case_tac cte)
-  apply (erule_tac x="mdbNext node" in allE)
-  apply simp
-  apply (erule impE)
-   apply clarsimp
-   apply (drule (1) mdb_chain_0_no_loops)
-   apply simp
-  apply clarsimp
-  apply (clarsimp simp: isCap_simps sameObjectAs_def3)
-  done
-end
+lemma sameObjectAs_not_Untyped[Finalise_R_2_assms]:
+  "\<lbrakk> global.sameObjectAs cap cap'; \<not> isUntypedCap cap \<rbrakk>
+   \<Longrightarrow> \<not> isUntypedCap cap'"
+  by (clarsimp simp: gen_isCap_simps sameObjectAs_def3)
+
+lemma sameObjectAs_not_Untyped'[Finalise_R_2_assms]:
+  "\<lbrakk> global.sameObjectAs cap cap'; \<not> isUntypedCap cap' \<rbrakk>
+   \<Longrightarrow> global.sameObjectAs cap' cap"
+  by (clarsimp simp: isCap_simps sameObjectAs_def3)
+
+end (* Arch *)
+
+(* only two arch-specific lemmas in vmdb;
+   save processing time by not creating an extra Arch_vmdb locale, directly requalify instead *)
 
 lemma (in vmdb) isFinal_no_subtree:
   "\<lbrakk> m \<turnstile> sl \<rightarrow> p; isFinal cap sl (option_map cteCap o m);
@@ -2076,20 +566,9 @@ lemma (in vmdb) isFinal_no_subtree:
    apply (clarsimp simp: isFinal_def parentOf_def mdb_next_unfold cteCaps_of_def)
    apply (erule_tac x="mdbNext n" in allE)
    apply simp
-   (* FIXME arch-split *)
-   apply (clarsimp simp: ARM_HYP.isMDBParentOf_CTE final_matters_sameRegion_sameObject)
-   apply (clarsimp simp: gen_isCap_simps ARM_HYP.sameObjectAs_def3) (* FIXME arch-split *)
+   apply (clarsimp simp: ARM_HYP.isMDBParentOf_CTE ARM_HYP.final_matters_sameRegion_sameObject)
+   apply (clarsimp simp: gen_isCap_simps ARM_HYP.sameObjectAs_def3)
   apply clarsimp
-  done
-
-lemma isFinal_no_descendants:
-  "\<lbrakk> isFinal cap sl (cteCaps_of s); ctes_of s sl = Some (CTE cap n);
-      valid_mdb' s; final_matters' cap \<rbrakk>
-  \<Longrightarrow> descendants_of' sl (ctes_of s) = {}"
-  apply (clarsimp simp add: descendants_of'_def cteCaps_of_def)
-  apply (erule(3) vmdb.isFinal_no_subtree[rotated])
-  apply unfold_locales[1]
-  apply (simp add: valid_mdb'_def)
   done
 
 lemma (in vmdb) isFinal_untypedParent:
@@ -2114,67 +593,748 @@ lemma (in vmdb) isFinal_untypedParent:
   apply clarsimp
   apply (drule isMDBParent_sameRegion)
   apply simp
-  apply (frule final_matters_mdb_chunked_arch_assms)
+  apply (frule ARM_HYP.final_matters_mdb_chunked_arch_assms)
   apply (rule classical, simp)
-  apply (simp add: final_matters_sameRegion_sameObject2
+  apply (simp add: ARM_HYP.final_matters_sameRegion_sameObject2
                    sameObjectAs_sym)
   done
 
-context begin interpretation Arch . (*FIXME: arch-split*)
+context Arch begin arch_global_naming
 
-lemma no_fail_isFinalCapability [wp]:
-  "no_fail (valid_mdb' and cte_wp_at' ((=) cte) p) (isFinalCapability cte)"
-  apply (simp add: isFinalCapability_def)
-  apply (clarsimp simp: Let_def split del: if_split)
-  apply (rule no_fail_pre, wp getCTE_wp')
-  apply (clarsimp simp: valid_mdb'_def valid_mdb_ctes_def cte_wp_at_ctes_of nullPointer_def)
+lemma isFinal_no_descendants:
+  "\<lbrakk> isFinal cap sl (cteCaps_of s); ctes_of s sl = Some (CTE cap n);
+      valid_mdb' s; final_matters' cap \<rbrakk>
+  \<Longrightarrow> descendants_of' sl (ctes_of s) = {}"
+  apply (clarsimp simp add: descendants_of'_def cteCaps_of_def)
+  apply (erule(3) vmdb.isFinal_no_subtree[rotated])
+  apply unfold_locales[1]
+  apply (simp add: valid_mdb'_def)
+  done
+
+lemmas cancelAllIPC_typs[wp] = typ_at_lifts[OF cancelAllIPC_typ_at']
+lemmas cancelAllSignals_typs[wp] = typ_at_lifts[OF cancelAllSignals_typ_at']
+lemmas suspend_typs[wp] = typ_at_lifts[OF suspend_typ_at']
+
+lemmas finaliseCap_typ_ats[wp] = typ_at_lifts[OF finaliseCap_typ_at']
+
+crunch flushSpace
+  for invs'[wp]: "invs'"
+  (ignore: doMachineOp)
+
+lemma invalidateASIDEntry_invs'[wp]:
+  "invalidateASIDEntry asid \<lbrace>invs'\<rbrace>"
+  apply (simp add: invalidateASIDEntry_def invalidateASID_def
+                   invalidateHWASIDEntry_def bind_assoc)
+  apply (wp loadHWASID_wp | simp)+
+  apply (clarsimp simp: fun_upd_def[symmetric])
   apply (rule conjI)
-   apply clarsimp
-   apply (erule (2) valid_dlistEp)
-   apply simp
-  apply clarsimp
+   apply (clarsimp simp: invs'_def valid_state'_def)
+   apply (rule conjI)
+    apply (simp add: valid_global_refs'_def
+                     global_refs'_def)
+   apply (simp add: valid_arch_state'_def ran_def
+                    valid_asid_table'_def is_inv_None_upd
+                    valid_machine_state'_def
+                    comp_upd_simp fun_upd_def[symmetric]
+                    inj_on_fun_upd_elsewhere
+                    valid_asid_map'_def
+                    ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def
+             cong: option.case_cong)
+   subgoal by (auto elim!: subset_inj_on)
+  apply (clarsimp simp: invs'_def valid_state'_def)
   apply (rule conjI)
-   apply (erule (2) valid_dlistEn)
-   apply simp
+   apply (simp add: valid_global_refs'_def global_refs'_def)
+  apply (rule conjI)
+   apply (simp add: valid_arch_state'_def ran_def
+                    valid_asid_table'_def comp_upd_simp
+              cong: option.case_cong)
+  apply (simp add: valid_machine_state'_def ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def)
+  done
+
+lemma invs_asid_update_strg':
+  "invs' s \<and> tab = armKSASIDTable (ksArchState s) \<longrightarrow>
+   invs' (s\<lparr>ksArchState := armKSASIDTable_update
+            (\<lambda>_. tab (asid := None)) (ksArchState s)\<rparr>)"
+  apply (simp add: invs'_def)
+  apply (simp add: valid_state'_def)
+  apply (simp add: valid_global_refs'_def global_refs'_def valid_arch_state'_def
+                   valid_asid_table'_def valid_machine_state'_def ct_idle_or_in_cur_domain'_def
+                   tcb_in_cur_domain'_def
+             cong: option.case_cong)
+  apply (auto simp add: ran_def split: if_split_asm)
+  done
+
+crunch invalidateTLBByASID
+  for asidTable[wp]: "\<lambda>s. P (armKSASIDTable (ksArchState s))"
+
+lemma deleteASIDPool_invs[wp]:
+  "\<lbrace>invs'\<rbrace> deleteASIDPool asid pool \<lbrace>\<lambda>rv. invs'\<rbrace>"
+  apply (simp add: deleteASIDPool_def)
+  apply wp
+      apply (simp del: fun_upd_apply)
+      apply (strengthen invs_asid_update_strg')
+      apply (wpsimp wp: mapM_wp' getObject_inv loadObject_default_inv)+
+  done
+
+lemma deleteASID_invs'[wp]:
+  "deleteASID asid pd \<lbrace>invs'\<rbrace>"
+  apply (simp add: deleteASID_def cong: option.case_cong)
+  apply (rule hoare_pre)
+   apply (wp | wpc)+
+    apply (rule_tac Q'="\<lambda>rv. valid_obj' (injectKO rv) and invs'"
+              in hoare_post_imp)
+     apply (rename_tac rv s)
+     apply (clarsimp split: if_split_asm del: subsetI)
+     apply (simp add: fun_upd_def[symmetric] valid_obj'_def)
+     apply (case_tac rv, simp)
+     apply (subst inv_f_f, rule inj_onI, simp)+
+     apply (rule conjI)
+      apply clarsimp
+      apply (drule subsetD, blast)
+      apply clarsimp
+     apply (auto dest!: ran_del_subset)[1]
+    apply (wp getObject_valid_obj getObject_inv loadObject_default_inv
+             | simp add: objBits_simps pageBits_def)+
   apply clarsimp
-  apply (rule valid_dlistEn, assumption+)
-  apply (erule (2) valid_dlistEp)
+  done
+
+lemmas archThreadSet_typ_ats[wp] = typ_at_lifts[OF archThreadSet_typ_at']
+
+lemma archThreadSet_valid_objs'[wp]:
+  "\<lbrace>valid_objs' and (\<lambda>s. \<forall>tcb. ko_at' tcb t s \<longrightarrow> valid_arch_tcb' (f (tcbArch tcb)) s)\<rbrace>
+   archThreadSet f t \<lbrace>\<lambda>_. valid_objs'\<rbrace>"
+  unfolding archThreadSet_def
+  apply (wp setObject_tcb_valid_objs getObject_tcb_wp)
+  apply clarsimp
+  apply normalise_obj_at'
+  apply (drule (1) tcb_ko_at_valid_objs_valid_tcb')
+  apply (clarsimp simp: valid_obj'_def valid_tcb'_def tcb_cte_cases_def cteSizeBits_def)
+  done
+
+crunch archThreadSet
+  for no_0_obj'[wp]: no_0_obj'
+
+lemma archThreadSet_ctes_of[wp]:
+  "archThreadSet f t \<lbrace>\<lambda>s. P (ctes_of s)\<rbrace>"
+  unfolding archThreadSet_def
+  apply (wpsimp wp: getObject_tcb_wp)
+  apply normalise_obj_at'
+  apply (auto simp: tcb_cte_cases_def cteSizeBits_def)
+  done
+
+crunch archThreadSet
+  for ksCurDomain[wp]: "\<lambda>s. P (ksCurDomain s)"
+  (wp: setObject_cd_inv)
+
+lemma archThreadSet_obj_at':
+  "(\<And>tcb. P tcb \<Longrightarrow> P (tcb \<lparr> tcbArch:= f (tcbArch tcb)\<rparr>)) \<Longrightarrow> archThreadSet f t \<lbrace>obj_at' P t'\<rbrace>"
+  unfolding archThreadSet_def
+  apply (wpsimp wp: getObject_tcb_wp setObject_tcb_strongest)
+  apply normalise_obj_at'
+  apply auto
+  done
+
+lemma archThreadSet_tcbDomain[wp]:
+  "archThreadSet f t \<lbrace>obj_at' (\<lambda>tcb. x = tcbDomain tcb) t'\<rbrace>"
+  by (wpsimp wp: archThreadSet_obj_at')
+
+lemma archThreadSet_inQ[wp]:
+  "archThreadSet f t' \<lbrace>\<lambda>s. P (obj_at' (inQ d p) t s)\<rbrace>"
+  unfolding obj_at'_real_def archThreadSet_def
+  apply (wpsimp wp: setObject_ko_wp_at getObject_tcb_wp
+              simp: objBits_simps' archObjSize_def vcpuBits_def pageBits_def
+         | simp)+
+  apply (auto simp: obj_at'_def ko_wp_at'_def)
+  done
+
+crunch archThreadSet
+  for ct[wp]: "\<lambda>s. P (ksCurThread s)"
+  and sched[wp]: "\<lambda>s. P (ksSchedulerAction s)"
+  and L1[wp]: "\<lambda>s. P (ksReadyQueuesL1Bitmap s)"
+  and L2[wp]: "\<lambda>s. P (ksReadyQueuesL2Bitmap s)"
+  and ksArch[wp]: "\<lambda>s. P (ksArchState s)"
+  and ksDomSchedule[wp]: "\<lambda>s. P (ksDomSchedule s)"
+  and pspace_canonical'[wp]: pspace_canonical'
+  and gsMaxObjectSize[wp]: "\<lambda>s. P (gsMaxObjectSize s)"
+  and ksInterruptState[wp]: "\<lambda>s. P (ksInterruptState s)"
+  (wp: setObject_ct_inv setObject_sa_unchanged setObject_ksDomSchedule_inv)
+
+crunch archThreadSet
+  for ksDomScheduleIdx[wp]: "\<lambda>s. P (ksDomScheduleIdx s)"
+  and ksDomScheduleStart[wp]: "\<lambda>s. P (ksDomScheduleStart s)"
+  (simp: setObject_def wp: updateObject_default_inv)
+
+crunch archThreadSet
+  for ksMachineState[wp]: "\<lambda>s. P (ksMachineState s)"
+  (wp: setObject_ksMachine updateObject_default_inv)
+
+lemma archThreadSet_state_refs_of'[wp]:
+  "archThreadSet f t \<lbrace>\<lambda>s. P (state_refs_of' s)\<rbrace>"
+  unfolding archThreadSet_def
+  apply (wpsimp wp: setObject_tcb_state_refs_of' getObject_tcb_wp)
+  apply normalise_obj_at'
+  apply (erule rsubst[where P=P])
+  apply (rule ext)
+  apply (auto simp: state_refs_of'_def obj_at'_def)
+  done
+
+lemma archThreadSet_state_hyp_refs_of'[wp]:
+  "\<lbrace>\<lambda>s. \<forall>tcb. ko_at' tcb t s \<longrightarrow> P ((state_hyp_refs_of' s)(t := tcb_hyp_refs' (f (tcbArch tcb))))\<rbrace>
+  archThreadSet f t \<lbrace>\<lambda>_ s. P (state_hyp_refs_of' s)\<rbrace>"
+  unfolding archThreadSet_def
+  apply (wpsimp wp: setObject_state_hyp_refs_of' getObject_tcb_wp simp: objBits_simps')
+  apply normalise_obj_at'
+  apply (erule rsubst[where P=P])
+  apply auto
+  done
+
+crunch archThreadSet
+  for ko_at'_pde[wp]: "\<lambda>s. P (ko_at' (pde::pde) p' s)"
+  and valid_pde_mappings'[wp]: valid_pde_mappings'
+
+lemma archThreadSet_if_live'[wp]:
+  "\<lbrace>\<lambda>s. if_live_then_nonz_cap' s \<and>
+        (\<forall>tcb. ko_at' tcb t s \<longrightarrow> atcbVCPUPtr (f (tcbArch tcb)) \<noteq> None \<longrightarrow> ex_nonz_cap_to' t s)\<rbrace>
+  archThreadSet f t \<lbrace>\<lambda>_. if_live_then_nonz_cap'\<rbrace>"
+  unfolding archThreadSet_def
+  apply (wpsimp wp: setObject_tcb_iflive' getObject_tcb_wp)
+  apply normalise_obj_at'
+  apply (clarsimp simp: tcb_cte_cases_def if_live_then_nonz_cap'_def cteSizeBits_def)
+  apply (erule_tac x=t in allE)
+  apply (erule impE)
+   apply (clarsimp simp: obj_at'_real_def ko_wp_at'_def live'_def hyp_live'_def)
   apply simp
   done
 
-lemma corres_gets_lift:
-  assumes inv: "\<And>P. \<lbrace>P\<rbrace> g \<lbrace>\<lambda>_. P\<rbrace>"
-  assumes res: "\<lbrace>Q'\<rbrace> g \<lbrace>\<lambda>r s. r = g' s\<rbrace>"
-  assumes Q: "\<And>s. Q s \<Longrightarrow> Q' s"
-  assumes nf: "no_fail Q g"
-  shows "corres r P Q f (gets g') \<Longrightarrow> corres r P Q f g"
-  apply (clarsimp simp add: corres_underlying_def simpler_gets_def)
-  apply (drule (1) bspec)
-  apply (rule conjI)
-   apply clarsimp
-   apply (rule bexI)
-    prefer 2
-    apply assumption
-   apply simp
-   apply (frule in_inv_by_hoareD [OF inv])
-   apply simp
-   apply (drule use_valid, rule res)
-    apply (erule Q)
-   apply simp
-  apply (insert nf)
-  apply (clarsimp simp: no_fail_def)
+lemma archThreadSet_ifunsafe'[wp]:
+  "archThreadSet f t \<lbrace>if_unsafe_then_cap'\<rbrace>"
+  unfolding archThreadSet_def
+  apply (wpsimp wp: setObject_tcb_ifunsafe' getObject_tcb_wp)
+  apply normalise_obj_at'
+  apply (auto simp: tcb_cte_cases_def if_live_then_nonz_cap'_def cteSizeBits_def)
   done
 
-lemma obj_refs_Master:
-  "\<lbrakk> cap_relation cap cap'; P cap \<rbrakk>
-      \<Longrightarrow> obj_refs cap =
-           (if capClass (capMasterCap cap') = PhysicalClass
-                  \<and> \<not> isUntypedCap (capMasterCap cap')
-            then {capUntypedPtr (capMasterCap cap')} else {})"
-  by (clarsimp simp: isCap_simps
-              split: cap_relation_split_asm arch_cap.split_asm)
+lemma archThreadSet_valid_idle'[wp]:
+  "archThreadSet f t \<lbrace>valid_idle'\<rbrace>"
+  unfolding archThreadSet_def
+  apply (wpsimp wp: setObject_tcb_idle' getObject_tcb_wp)
+  apply (clarsimp simp: valid_idle'_def pred_tcb_at'_def obj_at'_def idle_tcb'_def)
+  done
 
-lemma isFinalCapability_corres':
+lemma archThreadSet_ko_wp_at_no_vcpu[wp]:
+  "archThreadSet f t \<lbrace>ko_wp_at' (is_vcpu' and hyp_live') p\<rbrace>"
+  unfolding archThreadSet_def
+  apply (wpsimp wp: getObject_tcb_wp setObject_ko_wp_at simp: objBits_simps' | rule refl)+
+  apply normalise_obj_at'
+  apply (auto simp: ko_wp_at'_def obj_at'_real_def is_vcpu'_def)
+  done
+
+lemma archThreadSet_valid_arch_state'[wp]:
+  "archThreadSet f t \<lbrace>valid_arch_state'\<rbrace>"
+  unfolding valid_arch_state'_def valid_asid_table'_def option_case_all_conv split_def
+  apply (rule hoare_lift_Pf[where f=ksArchState]; wpsimp wp: hoare_vcg_all_lift hoare_vcg_imp_lift)
+  apply (clarsimp simp: pred_conj_def)
+  done
+
+lemma archThreadSet_ct_not_inQ[wp]:
+  "archThreadSet f t \<lbrace>ct_not_inQ\<rbrace>"
+  unfolding ct_not_inQ_def
+  apply (rule hoare_lift_Pf[where f=ksCurThread]; wp?)
+  apply (wpsimp wp: hoare_vcg_imp_lift simp: o_def)
+  done
+
+lemma archThreadSet_obj_at'_pte[wp]:
+  "archThreadSet f t \<lbrace>obj_at' (P::pte \<Rightarrow> bool) p\<rbrace>"
+  unfolding archThreadSet_def
+  by (wpsimp wp: obj_at_setObject2 simp: updateObject_default_def in_monad)
+
+crunch archThreadSet
+  for pspace_domain_valid[wp]: pspace_domain_valid
+
+crunch archThreadSet
+  for gsUntypedZeroRanges[wp]: "\<lambda>s. P (gsUntypedZeroRanges s)"
+
+lemma archThreadSet_untyped_ranges_zero'[wp]:
+  "archThreadSet f t \<lbrace>untyped_ranges_zero'\<rbrace>"
+  by (rule hoare_lift_Pf[where f=cteCaps_of]; wp cteCaps_of_ctes_of_lift)
+
+lemma archThreadSet_tcb_at'[wp]:
+  "\<lbrace>\<top>\<rbrace> archThreadSet f t \<lbrace>\<lambda>_. tcb_at' t\<rbrace>"
+  unfolding archThreadSet_def
+  by (wpsimp wp: getObject_tcb_wp simp: obj_at'_def)
+
+lemma archThreadSet_tcbSchedPrevs_of[wp]:
+  "archThreadSet f t \<lbrace>\<lambda>s. P (tcbSchedPrevs_of s)\<rbrace>"
+  unfolding archThreadSet_def
+  apply (wp getObject_tcb_wp)
+  apply normalise_obj_at'
+  apply (erule rsubst[where P=P])
+  apply (rule ext)
+  apply (clarsimp simp: opt_map_def obj_at'_def split: option.splits)
+  done
+
+lemma archThreadSet_tcbSchedNexts_of[wp]:
+  "archThreadSet f t \<lbrace>\<lambda>s. P (tcbSchedNexts_of s)\<rbrace>"
+  unfolding archThreadSet_def
+  apply (wp getObject_tcb_wp)
+  apply normalise_obj_at'
+  apply (erule rsubst[where P=P])
+  apply (rule ext)
+  apply (clarsimp simp: opt_map_def obj_at'_def split: option.splits)
+  done
+
+lemma archThreadSet_tcbQueued[wp]:
+  "archThreadSet f t \<lbrace>\<lambda>s. P (tcbQueued |< tcbs_of' s)\<rbrace>"
+  unfolding archThreadSet_def
+  apply (wp getObject_tcb_wp)
+  apply normalise_obj_at'
+  apply (erule rsubst[where P=P])
+  apply (rule ext)
+  apply (clarsimp simp: opt_pred_def opt_map_def obj_at'_def split: option.splits)
+  done
+
+lemma archThreadSet_valid_sched_pointers[wp]:
+  "archThreadSet f t \<lbrace>valid_sched_pointers\<rbrace>"
+  by (wp_pre, wps, wp, assumption)
+
+lemma dissoc_invs':
+  "\<lbrace>invs' and (\<lambda>s. \<forall>p. (\<exists>a. armHSCurVCPU (ksArchState s) = Some (p, a)) \<longrightarrow> p \<noteq> v) and
+    ko_at' vcpu v and K (vcpuTCBPtr vcpu = Some t) and
+    obj_at' (\<lambda>tcb. atcbVCPUPtr (tcbArch tcb) = Some v) t\<rbrace>
+   do
+    archThreadSet (atcbVCPUPtr_update (\<lambda>_. Nothing)) t;
+    setObject v $ vcpuTCBPtr_update (\<lambda>_. Nothing) vcpu
+   od \<lbrace>\<lambda>_. invs' and tcb_at' t\<rbrace>"
+  unfolding invs'_def valid_state'_def valid_pspace'_def valid_mdb'_def
+            valid_machine_state'_def pointerInUserData_def pointerInDeviceData_def
+  supply fun_upd_apply[simp del]
+  apply (wpsimp wp: sch_act_wf_lift tcb_in_cur_domain'_lift valid_queues_lift
+                    setObject_tcb_valid_objs setObject_vcpu_valid_objs'
+                    setObject_state_refs_of' setObject_state_hyp_refs_of' valid_global_refs_lift'
+                    valid_irq_node_lift_asm [where Q=\<top>] valid_irq_handlers_lift'
+                    cteCaps_of_ctes_of_lift irqs_masked_lift ct_idle_or_in_cur_domain'_lift
+                    valid_irq_states_lift' hoare_vcg_all_lift hoare_vcg_disj_lift
+                    setObject_typ_at' cur_tcb_lift valid_bitmaps_lift valid_dom_schedule'_lift
+                    setVCPU_valid_arch' archThreadSet_if_live' sym_heap_sched_pointers_lift
+              simp: objBits_simps archObjSize_def vcpu_bits_def pageBits_def
+                    state_refs_of'_vcpu_empty state_hyp_refs_of'_vcpu_absorb valid_arch_tcb'_def
+        | clarsimp simp: live'_def hyp_live'_def arch_live'_def)+
+  supply fun_upd_apply[simp]
+  apply (clarsimp simp: state_hyp_refs_of'_def obj_at'_def tcb_vcpu_refs'_def valid_vcpu'_def
+                  split: option.splits if_split_asm)
+  apply safe
+   apply (rule_tac rfs'="state_hyp_refs_of' s" in delta_sym_refs)
+     apply (clarsimp simp: state_hyp_refs_of'_def obj_at'_def tcb_vcpu_refs'_def
+                     split: option.splits if_split_asm)+
+  done
+
+lemma setVCPU_archThreadSet_None_eq:
+  "do
+    archThreadSet (atcbVCPUPtr_update (\<lambda>_. Nothing)) t;
+    setObject v $ vcpuTCBPtr_update (\<lambda>_. Nothing) vcpu;
+    f
+   od = do
+    do
+      archThreadSet (atcbVCPUPtr_update (\<lambda>_. Nothing)) t;
+      setObject v $ vcpuTCBPtr_update (\<lambda>_. Nothing) vcpu
+    od;
+    f
+  od" by (simp add: bind_assoc)
+
+lemma vcpuInvalidateActive_inactive[wp]:
+  "\<lbrace>\<top>\<rbrace> vcpuInvalidateActive \<lbrace>\<lambda>rv s. \<forall>p. (\<exists>a. armHSCurVCPU (ksArchState s) = Some (p, a)) \<longrightarrow> P p rv s\<rbrace>"
+  unfolding vcpuInvalidateActive_def modifyArchState_def by wpsimp
+
+lemma vcpuDisableNone_obj_at'[wp]:
+  "vcpuDisable None \<lbrace>\<lambda>s. P (obj_at' P' p s)\<rbrace>"
+  unfolding vcpuDisable_def by wpsimp
+
+lemma vcpuInvalidateActive_obj_at'[wp]:
+  "vcpuInvalidateActive \<lbrace>\<lambda>s. P (obj_at' P' p s)\<rbrace>"
+  unfolding vcpuInvalidateActive_def modifyArchState_def by wpsimp
+
+lemma dissociateVCPUTCB_invs'[wp]:
+  "dissociateVCPUTCB vcpu tcb \<lbrace>invs'\<rbrace>"
+  unfolding dissociateVCPUTCB_def setVCPU_archThreadSet_None_eq when_assert_eq
+  apply (wpsimp wp: dissoc_invs' getVCPU_wp | wpsimp wp: getObject_tcb_wp simp: archThreadGet_def)+
+  apply (drule tcb_ko_at')
+  apply clarsimp
+  apply (rule exI, rule conjI, assumption)
+  apply clarsimp
+  apply (rule conjI)
+   apply normalise_obj_at'
+  apply (rule conjI)
+   apply normalise_obj_at'
+  apply (clarsimp simp: obj_at'_def)
+  done
+
+lemma vcpuFinalise_invs'[wp]: "vcpuFinalise vcpu \<lbrace>invs'\<rbrace>"
+  unfolding vcpuFinalise_def by wpsimp
+
+lemma arch_finaliseCap_invs[Finalise_R_2_assms, wp]:
+  "\<lbrace>invs' and valid_cap' (ArchObjectCap cap)\<rbrace> Arch.finaliseCap cap fin \<lbrace>\<lambda>rv. invs'\<rbrace>"
+  unfolding ARM_HYP_H.finaliseCap_def Let_def by wpsimp
+
+lemma setObject_tcb_unlive[wp]:
+   "\<lbrace>\<lambda>s. vr \<noteq> t \<and> ko_wp_at' (Not \<circ> live') vr s\<rbrace>
+        setObject t (tcbArch_update (\<lambda>_. atcbVCPUPtr_update Map.empty (tcbArch tcb)) tcb)
+           \<lbrace>\<lambda>_. ko_wp_at' (Not \<circ> live') vr\<rbrace>"
+  apply (rule wp_pre)
+  apply (wpsimp wp: setObject_ko_wp_at simp: objBits_simps', simp+)
+  apply (clarsimp simp: tcb_at_typ_at' typ_at'_def ko_wp_at'_def )
+  done
+
+lemma setVCPU_unlive[wp]:
+  "\<lbrace>\<top>\<rbrace> setObject vr (vcpuTCBPtr_update Map.empty vcpu) \<lbrace>\<lambda>_. ko_wp_at' (Not \<circ> live') vr\<rbrace>"
+  apply (rule wp_pre)
+  apply (wpsimp wp: setObject_ko_wp_at
+           simp: objBits_def objBitsKO_def archObjSize_def vcpu_bits_def pageBits_def)
+    apply simp+
+  apply (clarsimp simp: live'_def hyp_live'_def arch_live'_def ko_wp_at'_def obj_at'_def)
+  done
+
+lemma asUser_unlive[wp]:
+  "\<lbrace>ko_wp_at' (Not \<circ> live') vr\<rbrace> asUser t f \<lbrace>\<lambda>_. ko_wp_at' (Not \<circ> live') vr\<rbrace>"
+  unfolding asUser_def
+  apply (wpsimp simp: threadSet_def atcbContextSet_def objBits_simps' split_def
+                  wp: setObject_ko_wp_at)
+  apply (rule refl, simp)
+  apply (wpsimp simp: atcbContextGet_def wp: getObject_tcb_wp threadGet_wp)+
+  apply (clarsimp simp: tcb_at_typ_at' typ_at'_def ko_wp_at'_def[where p=t])
+  apply (case_tac ko; simp)
+  apply (rename_tac tcb)
+  apply (rule_tac x=tcb in exI)
+  apply (clarsimp simp: obj_at'_def ko_wp_at'_def live'_def hyp_live'_def)
+  done
+
+lemma dissociateVCPUTCB_unlive:
+  "\<lbrace> \<top> \<rbrace> dissociateVCPUTCB vcpu tcb \<lbrace> \<lambda>_. ko_wp_at' (Not o live') vcpu \<rbrace>"
+  unfolding dissociateVCPUTCB_def setVCPU_archThreadSet_None_eq when_assert_eq
+  by (wpsimp wp: getVCPU_wp[where p=vcpu] |
+      wpsimp wp: getObject_tcb_wp hoare_vcg_conj_lift hoare_vcg_ex_lift
+                 getVCPU_wp[where p=vcpu] setVCPU_unlive[simplified o_def]
+                 setObject_tcb_unlive hoare_drop_imp setObject_tcb_strongest
+             simp: archThreadGet_def archThreadSet_def)+
+
+lemma vcpuFinalise_unlive[wp]:
+  "\<lbrace> \<top> \<rbrace> vcpuFinalise v \<lbrace> \<lambda>_. ko_wp_at' (Not o live') v \<rbrace>"
+  apply (wpsimp simp: vcpuFinalise_def wp: dissociateVCPUTCB_unlive getVCPU_wp)
+  apply (frule state_hyp_refs_of'_vcpu_absorb)
+  apply (auto simp: ko_wp_at'_def)
+  apply (rule_tac x="KOArch (KOVCPU ko)" in exI)
+  apply (clarsimp simp: live'_def hyp_live'_def arch_live'_def obj_at'_def)
+  done
+
+crunch setVMRoot, deleteASIDPool, invalidateTLBByASID, invalidateASIDEntry, vcpuFinalise
+  for ctes_of[wp]: "\<lambda>s. P (ctes_of s)"
+  (wp: crunch_wps getObject_inv loadObject_default_inv getASID_wp simp: crunch_simps)
+
+lemma deleteASID_ctes_of[wp]:
+  "deleteASID a ptr \<lbrace>\<lambda>s. P (ctes_of s)\<rbrace>"
+  unfolding deleteASID_def by (wpsimp wp: getASID_wp hoare_drop_imps hoare_vcg_all_lift)
+
+lemma arch_finaliseCap_removeable[wp]:
+  "\<lbrace>\<lambda>s. s \<turnstile>' ArchObjectCap cap \<and> invs' s
+       \<and> (final_matters' (ArchObjectCap cap)
+               \<longrightarrow> (final = isFinal (ArchObjectCap cap) slot (cteCaps_of s))) \<rbrace>
+     Arch.finaliseCap cap final
+   \<lbrace>\<lambda>rv s. isNullCap (fst rv) \<and> removeable' slot s (ArchObjectCap cap) \<and> isNullCap (snd rv)\<rbrace>"
+  unfolding ARM_HYP_H.finaliseCap_def
+  including classic_wp_pre
+  apply (case_tac cap; clarsimp)
+        apply ((wpsimp simp: removeable'_def isCap_simps
+                 | rule conjI)+)[5]
+   apply (clarsimp simp: isCap_simps, rule conjI)
+    apply (wpsimp simp: isCap_simps removeable'_def wp: hoare_disjI2)
+   apply (wpsimp simp: not_Final_removeable final_matters'_def arch_final_matters'_def)
+  apply (wpsimp simp: isCap_simps removeable'_def)
+  done
+
+crunch archThreadSet, vcpuUpdate, dissociateVCPUTCB
+  for isFinal: "\<lambda>s. isFinal cap slot (cteCaps_of s)"
+  (wp: cteCaps_of_ctes_of_lift)
+
+crunch prepareThreadDelete
+  for isFinal: "\<lambda>s. isFinal cap slot (cteCaps_of s)"
+
+lemma archThreadSet_bound_tcb_at'[wp]:
+  "archThreadSet f t \<lbrace>bound_tcb_at' P t'\<rbrace>"
+  unfolding archThreadSet_def
+  apply (wpsimp wp: setObject_tcb_strongest getObject_tcb_wp simp: pred_tcb_at'_def)
+  by (auto simp: obj_at'_def objBits_simps)
+
+lemmas setObject_vcpu_pred_tcb_at'[wp] =
+  setObject_vcpu_obj_at'_no_vcpu [of _ "\<lambda>ko. tst (pr (tcb_to_itcb' ko))" for tst pr, folded pred_tcb_at'_def]
+
+crunch dissociateVCPUTCB, vgicUpdateLR, prepareThreadDelete
+  for bound_tcb_at'[wp]: "bound_tcb_at' P t"
+  (wp: sts_bound_tcb_at' getVCPU_wp crunch_wps hoare_vcg_all_lift hoare_vcg_if_lift3
+   ignore: archThreadSet)
+
+lemma dissociateVCPUTCB_cte_wp_at'[wp]:
+  "dissociateVCPUTCB v t \<lbrace>cte_wp_at' P p\<rbrace>"
+  unfolding cte_wp_at_ctes_of by wp
+
+lemmas dissociateVCPUTCB_typ_ats'[wp] = typ_at_lifts[OF dissociateVCPUTCB_typ_at']
+
+crunch Arch.finaliseCap, prepareThreadDelete
+  for irq_node'[Finalise_R_2_assms, wp]: "\<lambda>s. P (irq_node' s)"
+  (wp: crunch_wps getObject_inv loadObject_default_inv
+       updateObject_default_inv setObject_ksInterrupt
+   simp: crunch_simps o_def)
+
+lemmas Arch_finaliseCap_irq_node'[Finalise_R_2_assms] = ArchRetypeDecls_H_ARM_HYP_H_finaliseCap_irq_node'
+
+crunch prepareThreadDelete
+  for cte_wp_at'[Finalise_R_2_assms, wp]: "cte_wp_at' P p"
+  and valid_cap'[Finalise_R_2_assms, wp]: "valid_cap' cap"
+
+lemma unset_vcpu_hyp_unlive[wp]:
+  "\<lbrace>\<top>\<rbrace> archThreadSet (atcbVCPUPtr_update Map.empty) t \<lbrace>\<lambda>_. ko_wp_at' (Not \<circ> hyp_live') t\<rbrace>"
+  unfolding archThreadSet_def
+  apply (wpsimp wp: setObject_ko_wp_at' getObject_tcb_wp; (simp add: objBits_simps')?)+
+  apply (clarsimp simp: obj_at'_def ko_wp_at'_def hyp_live'_def)
+  done
+
+ lemma unset_tcb_hyp_unlive[wp]:
+  "\<lbrace>\<top>\<rbrace> setObject vr (vcpuTCBPtr_update Map.empty vcpu) \<lbrace>\<lambda>_. ko_wp_at' (Not \<circ> hyp_live') vr\<rbrace>"
+  apply (wpsimp wp: setObject_ko_wp_at' getObject_tcb_wp
+                simp: objBits_simps archObjSize_def vcpu_bits_def pageBits_def
+        | simp)+
+  apply (clarsimp simp: obj_at'_def ko_wp_at'_def hyp_live'_def arch_live'_def)
+  done
+
+lemma setObject_vcpu_hyp_unlive[wp]:
+   "\<lbrace>\<lambda>s. t \<noteq> vr \<and> ko_wp_at' (Not \<circ> hyp_live') t s\<rbrace>
+         setObject vr (vcpuTCBPtr_update Map.empty vcpu)
+    \<lbrace>\<lambda>_. ko_wp_at' (Not \<circ> hyp_live') t\<rbrace>"
+  apply (rule wp_pre)
+  apply (wpsimp wp: setObject_ko_wp_at
+                simp: objBits_def objBitsKO_def archObjSize_def vcpu_bits_def pageBits_def
+        | simp)+
+  apply (clarsimp simp: tcb_at_typ_at' typ_at'_def ko_wp_at'_def )
+  done
+
+lemma asUser_hyp_unlive[wp]:
+  "asUser f t \<lbrace>ko_wp_at' (Not \<circ> hyp_live') t'\<rbrace>"
+  unfolding asUser_def
+  apply (wpsimp wp: threadSet_ko_wp_at2' threadGet_wp)
+  apply (clarsimp simp: ko_wp_at'_def obj_at'_def hyp_live'_def atcbContextSet_def)
+  done
+
+lemma dissociateVCPUTCB_hyp_unlive[wp]:
+  "\<lbrace>\<top>\<rbrace> dissociateVCPUTCB v t \<lbrace>\<lambda>_. ko_wp_at' (Not \<circ> hyp_live') t\<rbrace>"
+  unfolding dissociateVCPUTCB_def
+  by (cases "v = t"; wpsimp wp: unset_tcb_hyp_unlive unset_vcpu_hyp_unlive[simplified comp_def])
+
+lemma prepareThreadDelete_hyp_unlive[wp]:
+  "\<lbrace>\<top>\<rbrace> prepareThreadDelete t \<lbrace>\<lambda>_. ko_wp_at' (Not \<circ> hyp_live') t\<rbrace>"
+  unfolding prepareThreadDelete_def archThreadGet_def
+  apply (wpsimp wp: getObject_tcb_wp hoare_vcg_imp_lift' hoare_vcg_ex_lift)
+  apply (auto simp: ko_wp_at'_def obj_at'_def hyp_live'_def)
+  done
+
+crunch prepareThreadDelete
+  for invs[Finalise_R_2_assms, wp]: "invs'"
+  (ignore: doMachineOp simp: crunch_simps)
+
+lemma archThreadSet_tcbSchedPrevNext[wp]:
+  "archThreadSet f t' \<lbrace>obj_at' (\<lambda>tcb. P (tcbSchedNext tcb) (tcbSchedPrev tcb)) t\<rbrace>"
+  unfolding archThreadSet_def
+  apply (wpsimp wp: setObject_tcb_strongest getObject_tcb_wp)
+  apply normalise_obj_at'
+  apply auto
+  done
+
+context notes if_cong[cong] begin
+
+crunch asUser
+  for tcbSchedPrevNext[wp]: "obj_at' (\<lambda>tcb. P (tcbSchedNext tcb) (tcbSchedPrev tcb)) t"
+  (wp: threadGet_wp)
+
+end
+
+crunch prepareThreadDelete
+  for tcbSchedPrevNext[wp]: "obj_at' (\<lambda>tcb. P (tcbSchedNext tcb) (tcbSchedPrev tcb)) t"
+  (wp: threadGet_wp getVCPU_wp archThreadGet_wp crunch_wps simp: crunch_simps)
+
+crunch deleteASIDPool
+  for cte_wp_at'[wp]: "cte_wp_at' P p"
+  (simp: crunch_simps assertE_def
+   wp: crunch_wps getObject_inv loadObject_default_inv)
+
+lemma deleteASID_cte_wp_at'[wp]:
+  "\<lbrace>cte_wp_at' P p\<rbrace> deleteASID param_a param_b \<lbrace>\<lambda>_. cte_wp_at' P p\<rbrace>"
+  apply (simp add: deleteASID_def
+              cong: option.case_cong)
+  apply (wp setObject_cte_wp_at'[where Q="\<top>"] getObject_inv
+            loadObject_default_inv setVMRoot_cte_wp_at'
+          | clarsimp simp: updateObject_default_def in_monad cong: if_cong
+          | rule equals0I
+          | wpc)+
+  done
+
+crunch vcpuFinalise
+  for cte_wp_at'[wp]: "cte_wp_at' P p"
+  (wp: crunch_wps getObject_inv loadObject_default_inv)
+
+lemma arch_finaliseCap_cte_wp_at[Finalise_R_2_assms, wp]:
+  "\<lbrace>cte_wp_at' P p\<rbrace> Arch.finaliseCap cap fin \<lbrace>\<lambda>rv. cte_wp_at' P p\<rbrace>"
+  unfolding ARM_HYP_H.finaliseCap_def
+  by (wpsimp wp: unmapPage_cte_wp_at'|rule conjI)+
+
+lemma finaliseCap_valid_cap[Finalise_R_2_assms, wp]:
+  "\<lbrace>\<top>\<rbrace> Arch.finaliseCap cap final \<lbrace>\<lambda>rv. valid_cap' (fst rv)\<rbrace>"
+  by (wpsimp simp: ARM_HYP_H.finaliseCap_def split_del: if_split)
+
+lemma finaliseCap_cases[wp]:
+  "\<lbrace>\<top>\<rbrace>
+   finaliseCap cap final flag
+   \<lbrace>\<lambda>rv s. fst rv = NullCap \<and> (snd rv \<noteq> NullCap \<longrightarrow> final \<and> cap_has_cleanup' cap \<and> snd rv = cap)
+           \<or> isZombie (fst rv) \<and> final \<and> \<not> flag \<and> snd rv = NullCap
+             \<and> capUntypedPtr (fst rv) = capUntypedPtr cap
+             \<and> (isThreadCap cap \<or> isCNodeCap cap \<or> isZombie cap)\<rbrace>"
+  apply (simp add: finaliseCap_def ARM_HYP_H.finaliseCap_def Let_def
+                   getThreadCSpaceRoot
+             cong: if_cong split del: if_split)
+  apply (rule hoare_pre)
+   apply ((wp | simp add: gen_isCap_simps split del: if_split
+              | wpc
+              | simp only: valid_NullCap fst_conv snd_conv)+)[1]
+  apply (simp only: simp_thms fst_conv snd_conv option.simps if_cancel
+                    o_def)
+  apply (intro allI impI conjI TrueI)
+  apply (auto simp add: gen_isCap_simps cap_has_cleanup'_def)
+  done
+
+lemmas [Finalise_R_2_assms] =
+  cancelAllIPC_cte_wp_at' cancelAllSignals_cte_wp_at' unbindMaybeNotification_cte_wp_at'
+  prepareThreadDelete_cte_wp_at' unbindNotification_cte_wp_at'
+  Arch_postCapDeletion_valid_global_refs Arch_postCapDeletion_valid_arch_state'
+  mdb_empty.vmdb_n mdb_empty.descendants not_Final_removeable
+
+end (* Arch *)
+
+interpretation Finalise_R_2?: Finalise_R_2 arch_final_matters' arch_cap_has_cleanup'
+proof goal_cases
+  interpret Arch  .
+  case 1 show ?case by (intro_locales; (unfold_locales; (fact Finalise_R_2_assms)?)?)
+qed
+
+(* this is the only arch-specific lemma in delete_one_conc_pre so far;
+   save processing time by not creating an extra Arch_delete_one_conc_pre locale
+   by directly requalifying instead *)
+lemma (in delete_one_conc_pre) finaliseCap_replaceable:
+  "\<lbrace>\<lambda>s. invs' s \<and> cte_wp_at' (\<lambda>cte. cteCap cte = cap) slot s
+       \<and> (final_matters' cap \<longrightarrow> (final = isFinal cap slot (cteCaps_of s)))
+       \<and> weak_sch_act_wf (ksSchedulerAction s) s\<rbrace>
+     finaliseCap cap final flag
+   \<lbrace>\<lambda>rv s. (isNullCap (fst rv) \<and> removeable' slot s cap
+                \<and> (snd rv \<noteq> NullCap \<longrightarrow> snd rv = cap \<and> cap_has_cleanup' cap
+                                      \<and> isFinal cap slot (cteCaps_of s)))
+        \<or>
+          (isZombie (fst rv) \<and> snd rv = NullCap
+            \<and> isFinal cap slot (cteCaps_of s)
+            \<and> capClass cap = capClass (fst rv)
+            \<and> capUntypedPtr (fst rv) = capUntypedPtr cap
+            \<and> capBits (fst rv) = capBits cap
+            \<and> capRange (fst rv) = capRange cap
+            \<and> (isThreadCap cap \<or> isCNodeCap cap \<or> isZombie cap)
+            \<and> (\<forall>p \<in> threadCapRefs cap. st_tcb_at' ((=) Inactive) p s
+                     \<and> obj_at' (Not \<circ> tcbQueued) p s
+                     \<and> bound_tcb_at' ((=) None) p s
+                     \<and> ko_wp_at' (Not \<circ> hyp_live') p s
+                     \<and> obj_at' (\<lambda>tcb. tcbSchedNext tcb = None \<and> tcbSchedPrev tcb = None) p s))\<rbrace>"
+  supply [wp] = ARM_HYP.prepareThreadDelete_bound_tcb_at' ARM_HYP.prepareThreadDelete_hyp_unlive
+                ARM_HYP.prepareThreadDelete_tcbSchedPrevNext
+  apply (simp add: finaliseCap_def Let_def getThreadCSpaceRoot
+             cong: if_cong split del: if_split)
+  apply (rule hoare_pre)
+   apply (wp prepares_delete_helper'' [OF cancelAllIPC_unlive]
+             prepares_delete_helper'' [OF cancelAllSignals_unlive]
+             suspend_isFinal ARM_HYP.prepareThreadDelete_unqueued
+             ARM_HYP.prepareThreadDelete_inactive ARM_HYP.prepareThreadDelete_isFinal
+             suspend_makes_inactive
+             deletingIRQHandler_removeable'
+             deletingIRQHandler_final[where slot=slot ]
+             unbindMaybeNotification_obj_at'_bound
+             getNotification_wp
+             suspend_bound_tcb_at'
+             unbindNotification_bound_tcb_at'
+             suspend_tcbSchedNext_tcbSchedPrev_None
+           | simp add: isZombie_Null isThreadCap_threadCapRefs_tcbptr
+                       isArchObjectCap_Cap_capCap
+           | (rule hoare_strengthen_post[OF ARM_HYP.arch_finaliseCap_removeable[where slot=slot]],
+                  clarsimp simp: gen_isCap_simps)
+           | wpc)+
+  apply clarsimp
+  apply (frule cte_wp_at_valid_objs_valid_cap', clarsimp+)
+  apply (case_tac "cteCap cte",
+         simp_all add: gen_isCap_simps capRange_def cap_has_cleanup'_def
+                       final_matters'_def gen_objBits_simps
+                       not_Final_removeable finaliseCap_def,
+         simp_all add: removeable'_def)
+     (* thread *)
+     apply (frule capAligned_capUntypedPtr [OF valid_capAligned], simp)
+     apply (clarsimp simp: valid_cap'_def)
+     apply (drule valid_globals_cte_wpD'[rotated], clarsimp)
+     apply (clarsimp simp: invs'_def valid_state'_def valid_pspace'_def)
+    apply (clarsimp simp: obj_at'_def | rule conjI)+
+  done
+
+context Arch begin arch_global_naming
+
+named_theorems Finalise_R_3_assms
+
+lemma finaliseCap_cte_refs:
+  "\<lbrace>\<lambda>s. s \<turnstile>' cap\<rbrace>
+     finaliseCap cap final flag
+   \<lbrace>\<lambda>rv s. fst rv \<noteq> NullCap \<longrightarrow> cte_refs' (fst rv) = cte_refs' cap\<rbrace>"
+  apply (simp add: global.finaliseCap_def Let_def getThreadCSpaceRoot finaliseCap_def
+             cong: if_cong split del: if_split)
+  apply (rule hoare_pre)
+   apply (wp | wpc | simp only: o_def)+
+  apply (frule valid_capAligned)
+  apply (cases cap, simp_all add: gen_isCap_simps)
+   apply (clarsimp simp: tcb_cte_cases_def word_count_from_top gen_objBits_simps)
+  apply clarsimp
+  apply (rule ext, simp)
+  apply (rule image_cong [OF _ refl])
+  apply (fastforce simp: mask_def capAligned_def gen_objBits_simps shiftL_nat)
+  done
+
+lemma emptySlot_invs'[wp]:
+  "\<lbrace>\<lambda>s. invs' s \<and> cte_wp_at' (\<lambda>cte. removeable' sl s (cteCap cte)) sl s
+            \<and> (\<forall>sl'. info \<noteq> NullCap \<longrightarrow> sl' \<noteq> sl \<longrightarrow> cteCaps_of s sl' \<noteq> Some info)\<rbrace>
+     emptySlot sl info
+   \<lbrace>\<lambda>rv. invs'\<rbrace>"
+  apply (simp add: invs'_def valid_state'_def valid_pspace'_def)
+  apply (wp valid_irq_node_lift cur_tcb_lift valid_dom_schedule'_lift)
+  apply (clarsimp simp: cte_wp_at_ctes_of)
+  done
+
+lemma cteDeleteOne_invs[Finalise_R_3_assms, wp]:
+  "cteDeleteOne ptr \<lbrace>invs'\<rbrace>"
+  apply (simp add: cteDeleteOne_def unless_def
+                   split_def finaliseCapTrue_standin_simple_def)
+  apply wp
+    apply (rule hoare_strengthen_post)
+     apply (rule hoare_vcg_conj_lift[OF finaliseCap_True_invs])
+     apply (rule hoare_vcg_conj_lift[OF finaliseCap_replaceable[where slot=ptr]])
+     apply (rule hoare_vcg_conj_lift[OF finaliseCap_cte_refs])
+     apply (rule finaliseCap_equal_cap[where sl=ptr])
+    apply (clarsimp simp: cte_wp_at_ctes_of)
+    apply (erule disjE, solves simp)
+    apply (clarsimp dest!: isCapDs simp: capRemovable_def)
+    apply (clarsimp simp: removeable'_def fun_eq_iff[where f="cte_refs' cap" for cap]
+                     del: disjCI)
+    subgoal by (auto dest!: isCapDs simp: pred_tcb_at'_def obj_at'_def live'_def ko_wp_at'_def)
+   apply (wp isFinalCapability_inv getCTE_wp' hoare_weak_lift_imp
+          | wp (once) isFinal[where x=ptr])+
+  apply (fastforce simp: cte_wp_at_ctes_of)
+  done
+
+lemma isFinalCapability_corres'[Finalise_R_3_assms]:
   "final_matters' (cteCap cte) \<Longrightarrow>
    corres (=) (invs and cte_wp_at ((=) cap) ptr)
                (invs' and cte_wp_at' ((=) cte) (cte_map ptr))
@@ -2216,7 +1376,7 @@ lemma isFinalCapability_corres':
    apply (erule_tac x=aa in allE)
    apply (erule_tac x=ba in allE)
    apply (clarsimp simp: cte_wp_at_caps_of_state)
-   apply (clarsimp simp: sameObjectAs_def3 obj_refs_Master cap_irqs_relation_Master
+   apply (clarsimp simp: sameObjectAs_def3 obj_refs_relation_Master cap_irqs_relation_Master
                          arch_gen_refs_relation_Master gen_obj_refs_Int
                    cong: if_cong
                   split: capability.split_asm)
@@ -2224,7 +1384,7 @@ lemma isFinalCapability_corres':
   apply (rule_tac x="fst ptr" in exI)
   apply (rule_tac x="snd ptr" in exI)
   apply (rule conjI)
-   apply (clarsimp simp: cte_wp_at_def final_matters'_def
+   apply (clarsimp simp: cte_wp_at_def final_matters'_def arch_final_matters'_def
                          gen_obj_refs_Int
                   split: cap_relation_split_asm arch_cap.split_asm)
   apply clarsimp
@@ -2250,1671 +1410,47 @@ lemma isFinalCapability_corres':
    apply (rule classical)
    apply (frule(1) zombies_finalD2[OF _ _ _ invs_zombies],
           simp?, clarsimp, assumption+)
-   subgoal by (clarsimp simp: sameObjectAs_def3 isCap_simps valid_cap_def
-                         obj_at_def is_obj_defs a_type_def final_matters'_def
-                  split: cap.split_asm arch_cap.split_asm
-                         option.split_asm if_split_asm,
-          simp_all add: is_cap_defs)
+   subgoal by (clarsimp simp: sameObjectAs_def3 isCap_simps valid_cap_def valid_arch_cap_def
+                              valid_arch_cap_ref_def obj_at_def is_obj_defs a_type_def
+                              final_matters'_def arch_final_matters'_def
+                        split: cap.split_asm arch_cap.split_asm option.split_asm if_split_asm,
+               simp_all add: is_cap_defs)
   apply (rule classical)
   by (clarsimp simp: cap_irqs_def cap_irq_opt_def sameObjectAs_def3 isCap_simps arch_gen_obj_refs_def
                  split: cap.split_asm)
 
-lemma isFinalCapability_corres:
-  "corres (\<lambda>rv rv'. final_matters' (cteCap cte) \<longrightarrow> rv = rv')
-          (invs and cte_wp_at ((=) cap) ptr)
-          (invs' and cte_wp_at' ((=) cte) (cte_map ptr))
-       (is_final_cap cap) (isFinalCapability cte)"
-  apply (cases "final_matters' (cteCap cte)")
-   apply simp
-   apply (erule isFinalCapability_corres')
-  apply (subst bind_return[symmetric],
-         rule corres_symb_exec_r)
-     apply (rule corres_no_failI)
-      apply wp
-     apply (clarsimp simp: in_monad is_final_cap_def simpler_gets_def)
-    apply (wp isFinalCapability_inv)+
-  apply fastforce
-  done
-
-text \<open>Facts about finalise_cap/finaliseCap and
-        cap_delete_one/cteDelete in no particular order\<close>
-
-
-definition
-  finaliseCapTrue_standin_simple_def:
-  "finaliseCapTrue_standin cap fin \<equiv> finaliseCap cap fin True"
-
-context
-begin
-
-declare if_cong [cong]
-
-lemmas finaliseCapTrue_standin_def
-    = finaliseCapTrue_standin_simple_def
-        [unfolded finaliseCap_def, simplified]
-
-lemmas cteDeleteOne_def'
-    = eq_reflection [OF cteDeleteOne_def]
-lemmas cteDeleteOne_def
-    = cteDeleteOne_def'[folded finaliseCapTrue_standin_simple_def]
-
-crunch cteDeleteOne, suspend, prepareThreadDelete
-  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  (ignore_del: setObject
-         simp: crunch_simps unless_def o_def
-           wp: crunch_wps getObject_inv loadObject_default_inv)
-
-end
-
-lemmas cancelAllIPC_typs[wp] = typ_at_lifts [OF cancelAllIPC_typ_at']
-lemmas cancelAllSignals_typs[wp] = typ_at_lifts [OF cancelAllSignals_typ_at']
-lemmas suspend_typs[wp] = typ_at_lifts [OF suspend_typ_at']
-
-definition
-  arch_cap_has_cleanup' :: "arch_capability \<Rightarrow> bool"
-where
-  "arch_cap_has_cleanup' acap \<equiv> False"
-
-definition
-  cap_has_cleanup' :: "capability \<Rightarrow> bool"
-where
-  "cap_has_cleanup' cap \<equiv> case cap of
-     IRQHandlerCap _ \<Rightarrow> True
-   | ArchObjectCap acap \<Rightarrow> arch_cap_has_cleanup' acap
-   | _ \<Rightarrow> False"
-
-lemmas cap_has_cleanup'_simps[simp] = cap_has_cleanup'_def[split_simps capability.split]
-
-lemma finaliseCap_cases[wp]:
-  "\<lbrace>\<top>\<rbrace>
-     finaliseCap cap final flag
-   \<lbrace>\<lambda>rv s. fst rv = NullCap \<and> (snd rv \<noteq> NullCap \<longrightarrow> final \<and> cap_has_cleanup' cap \<and> snd rv = cap)
-     \<or>
-       isZombie (fst rv) \<and> final \<and> \<not> flag \<and> snd rv = NullCap
-        \<and> capUntypedPtr (fst rv) = capUntypedPtr cap
-        \<and> (isThreadCap cap \<or> isCNodeCap cap \<or> isZombie cap)\<rbrace>"
-  apply (simp add: finaliseCap_def ARM_HYP_H.finaliseCap_def Let_def
-                   getThreadCSpaceRoot
-             cong: if_cong split del: if_split)
-  apply (rule hoare_pre)
-   apply ((wp | simp add: isCap_simps split del: if_split
-              | wpc
-              | simp only: valid_NullCap fst_conv snd_conv)+)[1]
-  apply (simp only: simp_thms fst_conv snd_conv option.simps if_cancel
-                    o_def)
-  apply (intro allI impI conjI TrueI)
-  apply (auto simp add: isCap_simps cap_has_cleanup'_def)
-  done
-
-crunch finaliseCap
-  for aligned'[wp]: "pspace_aligned'"
-  (simp: crunch_simps assertE_def unless_def o_def
-     wp: getObject_inv loadObject_default_inv crunch_wps)
-
-crunch finaliseCap
-  for distinct'[wp]: "pspace_distinct'"
-  (simp: crunch_simps assertE_def unless_def o_def
-     wp: getObject_inv loadObject_default_inv crunch_wps)
-
-crunch finaliseCap
-  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  (simp: crunch_simps assertE_def
-     wp: getObject_inv loadObject_default_inv crunch_wps)
-lemmas finaliseCap_typ_ats[wp] = typ_at_lifts[OF finaliseCap_typ_at']
-
-crunch finaliseCap
-  for it'[wp]: "\<lambda>s. P (ksIdleThread s)"
-  (wp: mapM_x_wp_inv mapM_wp' hoare_drop_imps getObject_inv loadObject_default_inv
-   simp: crunch_simps updateObject_default_def o_def)
-
-crunch flush_space
-  for vs_lookup[wp]: "\<lambda>s. P (vs_lookup s)"
-  (wp: crunch_wps)
-
-declare doUnbindNotification_def[simp]
-
-lemma ntfn_q_refs_of'_mult:
-  "ntfn_q_refs_of' ntfn = (case ntfn of Structures_H.WaitingNtfn q \<Rightarrow> set q | _ \<Rightarrow> {}) \<times> {NTFNSignal}"
-  by (cases ntfn, simp_all)
-
-lemma tcb_st_not_Bound:
-  "(p, NTFNBound) \<notin> tcb_st_refs_of' ts"
-  "(p, TCBBound) \<notin> tcb_st_refs_of' ts"
-  by (auto simp: tcb_st_refs_of'_def split: Structures_H.thread_state.split)
-
-crunch setBoundNotification
-  for valid_bitmaps[wp]: valid_bitmaps
-  and tcbSchedNexts_of[wp]: "\<lambda>s. P (tcbSchedNexts_of s)"
-  and tcbSchedPrevs_of[wp]: "\<lambda>s. P (tcbSchedPrevs_of s)"
-  and tcbQueued[wp]: "\<lambda>s. P (tcbQueued |< tcbs_of' s)"
-  and valid_sched_pointers[wp]: valid_sched_pointers
-  (wp: valid_bitmaps_lift)
-
-lemma unbindNotification_invs[wp]:
-  "\<lbrace>invs'\<rbrace> unbindNotification tcb \<lbrace>\<lambda>rv. invs'\<rbrace>"
-  apply (simp add: unbindNotification_def invs'_def valid_state'_def)
-  apply (rule bind_wp[OF _ gbn_sp'])
-  apply (case_tac ntfnPtr, clarsimp, wp, clarsimp)
-  apply clarsimp
-  apply (rule bind_wp[OF _ get_ntfn_sp'])
-  apply (rule hoare_pre)
-  apply (wp sbn'_valid_pspace'_inv sbn_sch_act' valid_irq_node_lift valid_dom_schedule'_lift
-            irqs_masked_lift setBoundNotification_ct_not_inQ sym_heap_sched_pointers_lift
-            untyped_ranges_zero_lift | clarsimp simp: cteCaps_of_def o_def)+
-  apply (rule conjI)
-   apply (clarsimp elim!: obj_atE'
-                    simp: projectKOs
-                   dest!: pred_tcb_at')
-  apply (clarsimp simp: pred_tcb_at' conj_comms)
-  apply (frule bound_tcb_ex_cap'', clarsimp+)
-  apply (frule(1) sym_refs_bound_tcb_atD')
-  apply (frule(1) sym_refs_obj_atD')
-  apply (clarsimp simp: refs_of_rev')
-  apply normalise_obj_at'
-  apply (subst delta_sym_refs, assumption)
-    apply (auto split: if_split_asm)[1]
-   apply (auto simp: tcb_st_not_Bound ntfn_q_refs_of'_mult split: if_split_asm)[1]
-  apply (frule obj_at_valid_objs', clarsimp+)
-  apply (simp add: valid_ntfn'_def valid_obj'_def projectKOs live'_def
-            split: ntfn.splits)
-  apply (erule if_live_then_nonz_capE')
-  apply (clarsimp simp: obj_at'_def ko_wp_at'_def projectKOs live'_def)
-  done
-
-lemma ntfn_bound_tcb_at':
-  "\<lbrakk>sym_refs (state_refs_of' s); valid_objs' s; ko_at' ntfn ntfnptr s;
-    ntfnBoundTCB ntfn = Some tcbptr; P (Some ntfnptr)\<rbrakk>
-  \<Longrightarrow> bound_tcb_at' P tcbptr s"
-  apply (drule_tac x=ntfnptr in sym_refsD[rotated])
-   apply (clarsimp simp: obj_at'_def projectKOs)
-   apply (fastforce simp: state_refs_of'_def)
-  apply (auto simp: pred_tcb_at'_def obj_at'_def valid_obj'_def valid_ntfn'_def
-                    state_refs_of'_def refs_of_rev' projectKOs
-          simp del: refs_of_simps
-             elim!: valid_objsE
-             split: option.splits if_split_asm)
-  done
-
-
-lemma unbindMaybeNotification_invs[wp]:
-  "\<lbrace>invs'\<rbrace> unbindMaybeNotification ntfnptr \<lbrace>\<lambda>rv. invs'\<rbrace>"
-  apply (simp add: unbindMaybeNotification_def invs'_def valid_state'_def)
-  apply (rule bind_wp[OF _ get_ntfn_sp'])
-  apply (rule hoare_pre)
-   apply (wp sbn'_valid_pspace'_inv sbn_sch_act' sym_heap_sched_pointers_lift valid_irq_node_lift
-             irqs_masked_lift valid_dom_schedule'_lift setBoundNotification_ct_not_inQ
-             untyped_ranges_zero_lift
-             | wpc | clarsimp simp: cteCaps_of_def o_def)+
-  apply safe[1]
-           defer 3
-           defer 7
-           apply (fold_subgoals (prefix))[8]
-           subgoal premises prems using prems by (auto simp: pred_tcb_at' valid_pspace'_def projectKOs valid_obj'_def valid_ntfn'_def
-                             ko_wp_at'_def live'_def
-                      elim!: obj_atE' valid_objsE' if_live_then_nonz_capE'
-                      split: option.splits ntfn.splits)
-   apply (rule delta_sym_refs, assumption)
-    apply (fold_subgoals (prefix))[2]
-    subgoal premises prems using prems by (fastforce simp: symreftype_inverse' ntfn_q_refs_of'_def
-                    split: ntfn.splits if_split_asm
-                     dest!: ko_at_state_refs_ofD')+
-  apply (rule delta_sym_refs, assumption)
-   apply (clarsimp split: if_split_asm)
-   apply (frule ko_at_state_refs_ofD', simp)
-  apply (clarsimp split: if_split_asm)
-   apply (frule_tac P="(=) (Some ntfnptr)" in ntfn_bound_tcb_at', simp_all add: valid_pspace'_def)[1]
-   subgoal by (fastforce simp: ntfn_q_refs_of'_def state_refs_of'_def tcb_ntfn_is_bound'_def
-                          tcb_st_refs_of'_def
-                   dest!: bound_tcb_at_state_refs_ofD'
-                   split: ntfn.splits thread_state.splits)
-  apply (frule ko_at_state_refs_ofD', simp)
-  done
-
-(* Ugh, required to be able to split out the abstract invs *)
-lemma finaliseCap_True_invs[wp]:
-  "\<lbrace>invs'\<rbrace> finaliseCap cap final True \<lbrace>\<lambda>rv. invs'\<rbrace>"
-  apply (simp add: finaliseCap_def Let_def)
-  apply safe
-    apply (wp irqs_masked_lift| simp | wpc)+
-  done
-
-crunch flushSpace
-  for invs'[wp]: "invs'"
-  (ignore: doMachineOp)
-
-lemma invs_asid_update_strg':
-  "invs' s \<and> tab = armKSASIDTable (ksArchState s) \<longrightarrow>
-   invs' (s\<lparr>ksArchState := armKSASIDTable_update
-            (\<lambda>_. tab (asid := None)) (ksArchState s)\<rparr>)"
-  apply (simp add: invs'_def)
-  apply (simp add: valid_state'_def)
-  apply (simp add: valid_global_refs'_def global_refs'_def valid_arch_state'_def valid_asid_table'_def
-                   valid_machine_state'_def ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def
-             cong: option.case_cong)
-  by (auto simp add: ran_def split: if_split_asm)
-
-lemma invalidateASIDEntry_invs' [wp]:
-  "\<lbrace>invs'\<rbrace> invalidateASIDEntry asid \<lbrace>\<lambda>r. invs'\<rbrace>"
-  apply (simp add: invalidateASIDEntry_def invalidateASID_def
-                   invalidateHWASIDEntry_def bind_assoc)
-  apply (wp loadHWASID_wp | simp)+
-  apply (clarsimp simp: fun_upd_def[symmetric])
-  apply (rule conjI)
-   apply (clarsimp simp: invs'_def valid_state'_def)
-   apply (rule conjI)
-    apply (simp add: valid_global_refs'_def
-                     global_refs'_def)
-   apply (simp add: valid_arch_state'_def ran_def
-                    valid_asid_table'_def is_inv_None_upd
-                    valid_machine_state'_def
-                    comp_upd_simp fun_upd_def[symmetric]
-                    inj_on_fun_upd_elsewhere
-                    valid_asid_map'_def
-                    ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def
-             cong: option.case_cong)
-   subgoal by (auto elim!: subset_inj_on)
-  apply (clarsimp simp: invs'_def valid_state'_def)
-  apply (rule conjI)
-   apply (simp add: valid_global_refs'_def global_refs'_def)
-  apply (rule conjI)
-   apply (simp add: valid_arch_state'_def ran_def
-                    valid_asid_table'_def None_upd_eq
-                    fun_upd_def[symmetric] comp_upd_simp
-              cong: option.case_cong)
-  apply (simp add: valid_machine_state'_def ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def)
-  done
-
-lemma deleteASIDPool_invs[wp]:
-  "\<lbrace>invs'\<rbrace> deleteASIDPool asid pool \<lbrace>\<lambda>rv. invs'\<rbrace>"
-  apply (simp add: deleteASIDPool_def)
-  apply wp
-    apply (simp del: fun_upd_apply)
-    apply (strengthen invs_asid_update_strg')
-  apply (wp mapM_wp' getObject_inv loadObject_default_inv
-              | simp)+
-  done
-
-lemmas flushSpace_typ_ats' [wp] = typ_at_lifts [OF flushSpace_typ_at']
-
-lemma deleteASID_invs'[wp]:
-  "\<lbrace>invs'\<rbrace> deleteASID asid pd \<lbrace>\<lambda>rv. invs'\<rbrace>"
-  apply (simp add: deleteASID_def cong: option.case_cong)
-  apply (rule hoare_pre)
-   apply (wp | wpc)+
-    apply (rule_tac Q'="\<lambda>rv. valid_obj' (injectKO rv) and invs'"
-              in hoare_post_imp)
-     apply (rename_tac rv s)
-     apply (clarsimp split: if_split_asm del: subsetI)
-     apply (simp add: fun_upd_def[symmetric] valid_obj'_def)
-     apply (case_tac rv, simp)
-     apply (subst inv_f_f, rule inj_onI, simp)+
-     apply (rule conjI)
-      apply clarsimp
-      apply (drule subsetD, blast)
-      apply clarsimp
-     apply (auto dest!: ran_del_subset)[1]
-    apply (wp getObject_valid_obj getObject_inv loadObject_default_inv
-             | simp add: objBits_simps archObjSize_def pageBits_def)+
-  apply clarsimp
-  done
-
-(* FIMXME: move up *)
-lemmas archThreadSet_typ_ats[wp] = typ_at_lifts [OF archThreadSet_typ_at']
-
-lemma archThreadSet_valid_objs'[wp]:
-  "\<lbrace>valid_objs' and (\<lambda>s. \<forall>tcb. ko_at' tcb t s \<longrightarrow> valid_arch_tcb' (f (tcbArch tcb)) s)\<rbrace>
-   archThreadSet f t \<lbrace>\<lambda>_. valid_objs'\<rbrace>"
-  unfolding archThreadSet_def
-  apply (wp setObject_tcb_valid_objs getObject_tcb_wp)
-  apply clarsimp
-  apply normalise_obj_at'
-  apply (drule (1) tcb_ko_at_valid_objs_valid_tcb')
-  apply (clarsimp simp: valid_obj'_def valid_tcb'_def tcb_cte_cases_def tcb_cte_cases_neqs)
-  done
-
-crunch archThreadSet
-  for no_0_obj'[wp]: no_0_obj'
-
-lemma archThreadSet_ctes_of[wp]:
-  "archThreadSet f t \<lbrace>\<lambda>s. P (ctes_of s)\<rbrace>"
-  unfolding archThreadSet_def
-  apply (wpsimp wp: getObject_tcb_wp)
-  apply normalise_obj_at'
-  apply (auto simp: tcb_cte_cases_def tcb_cte_cases_neqs)
-  done
-
-crunch archThreadSet
-  for ksCurDomain[wp]: "\<lambda>s. P (ksCurDomain s)"
-  (wp: setObject_cd_inv)
-
-lemma archThreadSet_obj_at':
-  "(\<And>tcb. P tcb \<Longrightarrow> P (tcb \<lparr> tcbArch:= f (tcbArch tcb)\<rparr>)) \<Longrightarrow> archThreadSet f t \<lbrace>obj_at' P t'\<rbrace>"
-  unfolding archThreadSet_def
-  apply (wpsimp wp: getObject_tcb_wp setObject_tcb_strongest)
-  apply normalise_obj_at'
-  apply auto
-  done
-
-lemma archThreadSet_tcbDomain[wp]:
-  "archThreadSet f t \<lbrace>obj_at' (\<lambda>tcb. x = tcbDomain tcb) t'\<rbrace>"
-  by (wpsimp wp: archThreadSet_obj_at')
-
-lemma archThreadSet_inQ[wp]:
-  "archThreadSet f t' \<lbrace>\<lambda>s. P (obj_at' (inQ d p) t s)\<rbrace>"
-  unfolding obj_at'_real_def archThreadSet_def
-  apply (wpsimp wp: setObject_ko_wp_at getObject_tcb_wp
-              simp: objBits_simps' archObjSize_def vcpu_bits_def pageBits_def
-         | simp)+
-  apply (auto simp: obj_at'_def ko_wp_at'_def projectKOs)
-  done
-
-crunch archThreadSet
-  for ct[wp]: "\<lambda>s. P (ksCurThread s)"
-  (wp: setObject_ct_inv)
-
-crunch archThreadSet
-  for sched[wp]: "\<lambda>s. P (ksSchedulerAction s)"
-  (wp: setObject_sa_inv)
-
-crunch archThreadSet
-  for L1[wp]: "\<lambda>s. P (ksReadyQueuesL1Bitmap s)"
-  (wp: setObject_sa_inv)
-
-crunch archThreadSet
-  for L2[wp]: "\<lambda>s. P (ksReadyQueuesL2Bitmap s)"
-  (wp: setObject_sa_inv)
-
-crunch archThreadSet
-  for ksArch[wp]: "\<lambda>s. P (ksArchState s)"
-
-crunch archThreadSet
-  for ksDomSchedule[wp]: "\<lambda>s. P (ksDomSchedule s)"
-  (wp: setObject_ksDomSchedule_inv)
-
-crunch archThreadSet
-  for ksDomScheduleIdx[wp]: "\<lambda>s. P (ksDomScheduleIdx s)"
-  and ksDomScheduleStart[wp]: "\<lambda>s. P (ksDomScheduleStart s)"
-  (simp: setObject_def wp: updateObject_default_inv)
-
-lemma setObject_tcb_ksInterruptState[wp]:
-  "setObject t (v :: tcb) \<lbrace>\<lambda>s. P (ksInterruptState s)\<rbrace>"
-  by (wpsimp simp: setObject_def wp: updateObject_default_inv)
-
-lemma setObject_tcb_gsMaxObjectSize[wp]:
-  "setObject t (v :: tcb) \<lbrace>\<lambda>s. P (gsMaxObjectSize s)\<rbrace>"
-  by (wpsimp simp: setObject_def wp: updateObject_default_inv)
-
-crunch archThreadSet
-  for ksInterruptState[wp]: "\<lambda>s. P (ksInterruptState s)"
-
-crunch archThreadSet
-  for gsMaxObjectSize[wp]: "\<lambda>s. P (gsMaxObjectSize s)"
-
-crunch archThreadSet
-  for ksMachineState[wp]: "\<lambda>s. P (ksMachineState s)"
-  (wp: setObject_ksMachine updateObject_default_inv)
-
-lemma archThreadSet_state_refs_of'[wp]:
-  "archThreadSet f t \<lbrace>\<lambda>s. P (state_refs_of' s)\<rbrace>"
-  unfolding archThreadSet_def
-  apply (wpsimp wp: setObject_tcb_state_refs_of' getObject_tcb_wp)
-  apply normalise_obj_at'
-  apply (erule rsubst[where P=P])
-  apply (rule ext)
-  apply (auto simp: state_refs_of'_def obj_at'_def projectKOs)
-  done
-
-lemma archThreadSet_state_hyp_refs_of'[wp]:
-  "\<lbrace>\<lambda>s. \<forall>tcb. ko_at' tcb t s \<longrightarrow> P ((state_hyp_refs_of' s)(t := tcb_hyp_refs' (f (tcbArch tcb))))\<rbrace>
-  archThreadSet f t \<lbrace>\<lambda>_ s. P (state_hyp_refs_of' s)\<rbrace>"
-  unfolding archThreadSet_def
-  apply (wpsimp wp: setObject_state_hyp_refs_of' getObject_tcb_wp simp: objBits_simps')
-  apply normalise_obj_at'
-  apply (erule rsubst[where P=P])
-  apply auto
-  done
-
-crunch archThreadSet
-  for ko_at'_pde[wp]: "\<lambda>s. P (ko_at' (pde::pde) p' s)"
-  and valid_pde_mappings'[wp]: valid_pde_mappings'
-
-lemma archThreadSet_if_live'[wp]:
-  "\<lbrace>\<lambda>s. if_live_then_nonz_cap' s \<and>
-        (\<forall>tcb. ko_at' tcb t s \<longrightarrow> atcbVCPUPtr (f (tcbArch tcb)) \<noteq> None \<longrightarrow> ex_nonz_cap_to' t s)\<rbrace>
-  archThreadSet f t \<lbrace>\<lambda>_. if_live_then_nonz_cap'\<rbrace>"
-  unfolding archThreadSet_def
-  apply (wpsimp wp: setObject_tcb_iflive' getObject_tcb_wp)
-  apply normalise_obj_at'
-  apply (clarsimp simp: tcb_cte_cases_def tcb_cte_cases_neqs if_live_then_nonz_cap'_def)
-  apply (erule_tac x=t in allE)
-  apply (erule impE)
-   apply (clarsimp simp: obj_at'_real_def ko_wp_at'_def projectKOs live'_def hyp_live'_def)
-  apply simp
-  done
-
-lemma archThreadSet_ifunsafe'[wp]:
-  "archThreadSet f t \<lbrace>if_unsafe_then_cap'\<rbrace>"
-  unfolding archThreadSet_def
-  apply (wpsimp wp: setObject_tcb_ifunsafe' getObject_tcb_wp)
-  apply normalise_obj_at'
-  apply (auto simp: tcb_cte_cases_def tcb_cte_cases_neqs if_live_then_nonz_cap'_def)
-  done
-
-lemma archThreadSet_valid_idle'[wp]:
-  "archThreadSet f t \<lbrace>valid_idle'\<rbrace>"
-  unfolding archThreadSet_def
-  apply (wpsimp wp: setObject_tcb_idle' getObject_tcb_wp)
-  apply (clarsimp simp: valid_idle'_def pred_tcb_at'_def obj_at'_def idle_tcb'_def)
-  done
-
-lemma archThreadSet_ko_wp_at_no_vcpu[wp]:
-  "archThreadSet f t \<lbrace>ko_wp_at' (is_vcpu' and hyp_live') p\<rbrace>"
-  unfolding archThreadSet_def
-  apply (wpsimp wp: getObject_tcb_wp setObject_ko_wp_at simp: objBits_simps' | rule refl)+
-  apply normalise_obj_at'
-  apply (auto simp: ko_wp_at'_def obj_at'_real_def projectKOs is_vcpu'_def)
-  done
-
-lemma archThreadSet_valid_arch_state'[wp]:
-  "archThreadSet f t \<lbrace>valid_arch_state'\<rbrace>"
-  unfolding valid_arch_state'_def valid_asid_table'_def option_case_all_conv split_def
-  apply (rule hoare_lift_Pf[where f=ksArchState]; wpsimp wp: hoare_vcg_all_lift hoare_vcg_imp_lift)
-  apply (clarsimp simp: pred_conj_def)
-  done
-
-lemma archThreadSet_ct_not_inQ[wp]:
-  "archThreadSet f t \<lbrace>ct_not_inQ\<rbrace>"
-  unfolding ct_not_inQ_def
-  apply (rule hoare_lift_Pf[where f=ksCurThread]; wp?)
-  apply (wpsimp wp: hoare_vcg_imp_lift simp: o_def)
-  done
-
-lemma archThreadSet_obj_at'_pde[wp]:
-  "archThreadSet f t \<lbrace>obj_at' (P::pde \<Rightarrow> bool) p\<rbrace>"
-  unfolding archThreadSet_def
-  by (wpsimp wp: obj_at_setObject2 simp: updateObject_default_def in_monad)
-
-crunch archThreadSet
-  for pspace_domain_valid[wp]: pspace_domain_valid
-
-lemma setObject_tcb_gsUntypedZeroRanges[wp]:
-  "setObject ptr (tcb::tcb) \<lbrace>\<lambda>s. P (gsUntypedZeroRanges s)\<rbrace>"
-  by (wpsimp wp: updateObject_default_inv simp: setObject_def)
-
-crunch archThreadSet
-  for gsUntypedZeroRanges[wp]: "\<lambda>s. P (gsUntypedZeroRanges s)"
-
-lemma archThreadSet_untyped_ranges_zero'[wp]:
-  "archThreadSet f t \<lbrace>untyped_ranges_zero'\<rbrace>"
-  by (rule hoare_lift_Pf[where f=cteCaps_of]; wp cteCaps_of_ctes_of_lift)
-
-lemma archThreadSet_tcb_at'[wp]:
-  "\<lbrace>\<top>\<rbrace> archThreadSet f t \<lbrace>\<lambda>_. tcb_at' t\<rbrace>"
-  unfolding archThreadSet_def
-  by (wpsimp wp: getObject_tcb_wp simp: obj_at'_def)
-
-lemma setObject_tcb_tcbs_of'[wp]:
-  "\<lbrace>\<lambda>s. P ((tcbs_of' s) (t \<mapsto> tcb))\<rbrace>
-   setObject t tcb
-   \<lbrace>\<lambda>_ s. P (tcbs_of' s)\<rbrace>"
-  unfolding setObject_def
-  apply (wpsimp simp: updateObject_default_def)
-  apply (erule rsubst[where P=P])
-  apply (rule ext)
-  apply (clarsimp simp: opt_map_def split: option.splits)
-  done
-
-lemma archThreadSet_tcbSchedPrevs_of[wp]:
-  "archThreadSet f t \<lbrace>\<lambda>s. P (tcbSchedPrevs_of s)\<rbrace>"
-  supply projectKOs[simp]
-  unfolding archThreadSet_def
-  apply (wp getObject_tcb_wp)
-  apply normalise_obj_at'
-  apply (erule rsubst[where P=P])
-  apply (rule ext)
-  apply (clarsimp simp: opt_map_def obj_at'_def split: option.splits)
-  done
-
-lemma archThreadSet_tcbSchedNexts_of[wp]:
-  "archThreadSet f t \<lbrace>\<lambda>s. P (tcbSchedNexts_of s)\<rbrace>"
-  supply projectKOs[simp]
-  unfolding archThreadSet_def
-  apply (wp getObject_tcb_wp)
-  apply normalise_obj_at'
-  apply (erule rsubst[where P=P])
-  apply (rule ext)
-  apply (clarsimp simp: opt_map_def obj_at'_def split: option.splits)
-  done
-
-lemma archThreadSet_tcbQueued[wp]:
-  "archThreadSet f t \<lbrace>\<lambda>s. P (tcbQueued |< tcbs_of' s)\<rbrace>"
-  supply projectKOs[simp]
-  unfolding archThreadSet_def
-  apply (wp getObject_tcb_wp)
-  apply normalise_obj_at'
-  apply (erule rsubst[where P=P])
-  apply (rule ext)
-  apply (clarsimp simp: opt_pred_def opt_map_def obj_at'_def split: option.splits)
-  done
-
-lemma archThreadSet_valid_sched_pointers[wp]:
-  "archThreadSet f t \<lbrace>valid_sched_pointers\<rbrace>"
-  by (wp_pre, wps, wp, assumption)
-
-lemma dissoc_invs':
-  "\<lbrace>invs' and (\<lambda>s. \<forall>p. (\<exists>a. armHSCurVCPU (ksArchState s) = Some (p, a)) \<longrightarrow> p \<noteq> v) and
-    ko_at' vcpu v and K (vcpuTCBPtr vcpu = Some t) and
-    obj_at' (\<lambda>tcb. atcbVCPUPtr (tcbArch tcb) = Some v) t\<rbrace>
-   do
-    archThreadSet (atcbVCPUPtr_update (\<lambda>_. Nothing)) t;
-    setObject v $ vcpuTCBPtr_update (\<lambda>_. Nothing) vcpu
-   od \<lbrace>\<lambda>_. invs' and tcb_at' t\<rbrace>"
-  unfolding invs'_def valid_state'_def valid_pspace'_def valid_mdb'_def
-            valid_machine_state'_def pointerInUserData_def pointerInDeviceData_def
-  supply fun_upd_apply[simp del]
-  apply (wpsimp wp: sch_act_wf_lift tcb_in_cur_domain'_lift valid_queues_lift
-                    setObject_tcb_valid_objs setObject_vcpu_valid_objs'
-                    setObject_state_refs_of' setObject_state_hyp_refs_of' valid_global_refs_lift'
-                    valid_irq_node_lift_asm [where Q=\<top>] valid_irq_handlers_lift'
-                    cteCaps_of_ctes_of_lift irqs_masked_lift ct_idle_or_in_cur_domain'_lift
-                    valid_irq_states_lift' hoare_vcg_all_lift hoare_vcg_disj_lift
-                    valid_pde_mappings_lift' setObject_typ_at' cur_tcb_lift
-                    setVCPU_valid_arch' archThreadSet_if_live' valid_bitmaps_lift
-                    sym_heap_sched_pointers_lift valid_dom_schedule'_lift
-              simp: objBits_simps archObjSize_def vcpu_bits_def pageBits_def
-                    state_refs_of'_vcpu_empty state_hyp_refs_of'_vcpu_absorb valid_arch_tcb'_def
-        | clarsimp simp: live'_def hyp_live'_def arch_live'_def)+
-  apply (drule (1) valid_objs_valid_vcpu')
-  apply (clarsimp simp: valid_vcpu'_def)
-  supply fun_upd_apply[simp]
-  apply (clarsimp simp: state_hyp_refs_of'_def obj_at'_def projectKOs tcb_vcpu_refs'_def
-                  split: option.splits if_split_asm)
-  apply safe
-  apply (rule_tac rfs'="state_hyp_refs_of' s" in delta_sym_refs)
-   apply (clarsimp simp: state_hyp_refs_of'_def obj_at'_def projectKOs tcb_vcpu_refs'_def
-                   split: option.splits if_split_asm)+
-  done
-
-lemma setVCPU_archThreadSet_None_eq:
-  "do
-    archThreadSet (atcbVCPUPtr_update (\<lambda>_. Nothing)) t;
-    setObject v $ vcpuTCBPtr_update (\<lambda>_. Nothing) vcpu;
-    f
-   od = do
-    do
-      archThreadSet (atcbVCPUPtr_update (\<lambda>_. Nothing)) t;
-      setObject v $ vcpuTCBPtr_update (\<lambda>_. Nothing) vcpu
-    od;
-    f
-  od" by (simp add: bind_assoc)
-
-lemma vcpuInvalidateActive_inactive[wp]:
-  "\<lbrace>\<top>\<rbrace> vcpuInvalidateActive \<lbrace>\<lambda>rv s. \<forall>p. (\<exists>a. armHSCurVCPU (ksArchState s) = Some (p, a)) \<longrightarrow> P p rv s\<rbrace>"
-  unfolding vcpuInvalidateActive_def modifyArchState_def by wpsimp
-
-lemma vcpuDisableNone_obj_at'[wp]:
-  "vcpuDisable None \<lbrace>\<lambda>s. P (obj_at' P' p s)\<rbrace>"
-  unfolding vcpuDisable_def by wpsimp
-
-lemma vcpuInvalidateActive_obj_at'[wp]:
-  "vcpuInvalidateActive \<lbrace>\<lambda>s. P (obj_at' P' p s)\<rbrace>"
-  unfolding vcpuInvalidateActive_def modifyArchState_def by wpsimp
-
-lemma when_assert_eq:
-  "(when P $ haskell_fail xs) = assert (\<not>P)"
-  by (simp add: assert_def when_def)
-
-lemma dissociateVCPUTCB_invs'[wp]:
-  "dissociateVCPUTCB vcpu tcb \<lbrace>invs'\<rbrace>"
-  unfolding dissociateVCPUTCB_def setVCPU_archThreadSet_None_eq when_assert_eq
-  apply (wpsimp wp: dissoc_invs' getVCPU_wp | wpsimp wp: getObject_tcb_wp simp: archThreadGet_def)+
-  apply (drule tcb_ko_at')
-  apply clarsimp
-  apply (rule exI, rule conjI, assumption)
-  apply clarsimp
-  apply (rule conjI)
-   apply normalise_obj_at'
-  apply (rule conjI)
-   apply normalise_obj_at'
-  apply (clarsimp simp: obj_at'_def)
-  done
-
-lemma vcpuFinalise_invs'[wp]: "vcpuFinalise vcpu \<lbrace>invs'\<rbrace>"
-  unfolding vcpuFinalise_def by wpsimp
-
-lemma arch_finaliseCap_invs[wp]:
-  "\<lbrace>invs' and valid_cap' (ArchObjectCap cap)\<rbrace> Arch.finaliseCap cap fin \<lbrace>\<lambda>rv. invs'\<rbrace>"
-  unfolding ARM_HYP_H.finaliseCap_def Let_def by wpsimp
-
-lemma setObject_tcb_unlive[wp]:
-   "\<lbrace>\<lambda>s. vr \<noteq> t \<and> ko_wp_at' (Not \<circ> live') vr s\<rbrace>
-        setObject t (tcbArch_update (\<lambda>_. atcbVCPUPtr_update Map.empty (tcbArch tcb)) tcb)
-           \<lbrace>\<lambda>_. ko_wp_at' (Not \<circ> live') vr\<rbrace>"
-  apply (rule wp_pre)
-  apply (wpsimp wp: setObject_ko_wp_at simp: objBits_simps', simp+)
-  apply (clarsimp simp: tcb_at_typ_at' typ_at'_def ko_wp_at'_def )
-  done
-
-lemma setVCPU_unlive[wp]:
-  "\<lbrace>\<top>\<rbrace> setObject vr (vcpuTCBPtr_update Map.empty vcpu) \<lbrace>\<lambda>_. ko_wp_at' (Not \<circ> live') vr\<rbrace>"
-  apply (rule wp_pre)
-  apply (wpsimp wp: setObject_ko_wp_at
-           simp: objBits_def objBitsKO_def archObjSize_def vcpu_bits_def pageBits_def)
-    apply simp+
-  apply (clarsimp simp: live'_def hyp_live'_def arch_live'_def ko_wp_at'_def obj_at'_def)
-  done
-
-lemma asUser_unlive[wp]:
-  "\<lbrace>ko_wp_at' (Not \<circ> live') vr\<rbrace> asUser t f \<lbrace>\<lambda>_. ko_wp_at' (Not \<circ> live') vr\<rbrace>"
-  unfolding asUser_def
-  apply (wpsimp simp: threadSet_def atcbContextSet_def objBits_simps' split_def
-                  wp: setObject_ko_wp_at)
-  apply (rule refl, simp)
-  apply (wpsimp simp: atcbContextGet_def wp: getObject_tcb_wp threadGet_wp)+
-  apply (clarsimp simp: tcb_at_typ_at' typ_at'_def ko_wp_at'_def[where p=t])
-  apply (case_tac ko; simp)
-  apply (rename_tac tcb)
-  apply (rule_tac x=tcb in exI)
-  apply (clarsimp simp: obj_at'_def projectKOs)
-  apply (clarsimp simp: ko_wp_at'_def live'_def hyp_live'_def)
-  done
-
-lemma dissociateVCPUTCB_unlive:
-  "\<lbrace> \<top> \<rbrace> dissociateVCPUTCB vcpu tcb \<lbrace> \<lambda>_. ko_wp_at' (Not o live') vcpu \<rbrace>"
-  unfolding dissociateVCPUTCB_def setVCPU_archThreadSet_None_eq when_assert_eq
-  by (wpsimp wp: getVCPU_wp[where p=vcpu] |
-      wpsimp wp: getObject_tcb_wp hoare_vcg_conj_lift hoare_vcg_ex_lift
-                 getVCPU_wp[where p=vcpu] setVCPU_unlive[simplified o_def]
-                 setObject_tcb_unlive hoare_drop_imp setObject_tcb_strongest
-             simp: archThreadGet_def archThreadSet_def)+
-
-lemma vcpuFinalise_unlive[wp]:
-  "\<lbrace> \<top> \<rbrace> vcpuFinalise v \<lbrace> \<lambda>_. ko_wp_at' (Not o live') v \<rbrace>"
-  apply (wpsimp simp: vcpuFinalise_def wp: dissociateVCPUTCB_unlive getVCPU_wp)
-  apply (frule state_hyp_refs_of'_vcpu_absorb)
-  apply (auto simp: ko_wp_at'_def)
-  apply (rule_tac x="KOArch (KOVCPU ko)" in exI)
-  apply (clarsimp simp: live'_def hyp_live'_def arch_live'_def obj_at'_def projectKOs)
-  done
-
-lemma arch_finaliseCap_removeable[wp]:
-  "\<lbrace>\<lambda>s. s \<turnstile>' ArchObjectCap cap \<and> invs' s
-       \<and> (final_matters' (ArchObjectCap cap)
-               \<longrightarrow> (final = isFinal (ArchObjectCap cap) slot (cteCaps_of s))) \<rbrace>
-     Arch.finaliseCap cap final
-   \<lbrace>\<lambda>rv s. isNullCap (fst rv) \<and> removeable' slot s (ArchObjectCap cap) \<and> isNullCap (snd rv)\<rbrace>"
-  unfolding ARM_HYP_H.finaliseCap_def
-  including classic_wp_pre
-  apply (case_tac cap; clarsimp)
-        apply ((wpsimp simp: removeable'_def isCap_simps
-                 | rule conjI)+)[5]
-   apply (clarsimp simp: isCap_simps, rule conjI)
-    apply (wpsimp simp: isCap_simps removeable'_def wp: hoare_disjI2)
-   apply  (wpsimp simp: not_Final_removeable final_matters'_def)
-  apply  (wpsimp simp: isCap_simps removeable'_def)
-  done
-
-lemma isZombie_Null:
-  "\<not> isZombie NullCap"
-  by (simp add: isCap_simps)
-
-lemma prepares_delete_helper'':
-  assumes x: "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv. ko_wp_at' (Not \<circ> live') p\<rbrace>"
-  shows      "\<lbrace>P and K ((\<forall>x. cte_refs' cap x = {})
-                          \<and> zobj_refs' cap = {p}
-                          \<and> threadCapRefs cap = {})\<rbrace>
-                 f \<lbrace>\<lambda>rv s. removeable' sl s cap\<rbrace>"
-  apply (rule hoare_gen_asm)
-  apply (rule hoare_strengthen_post [OF x])
-  apply (clarsimp simp: removeable'_def)
-  done
-
-lemmas ctes_of_cteCaps_of_lift = cteCaps_of_ctes_of_lift
-
-crunch finaliseCapTrue_standin, unbindNotification
-  for ctes_of[wp]: "\<lambda>s. P (ctes_of s)"
-  (wp: crunch_wps getObject_inv loadObject_default_inv simp: crunch_simps)
-
-lemma cteDeleteOne_cteCaps_of:
-  "\<lbrace>\<lambda>s. (cte_wp_at' (\<lambda>cte. \<exists>final. finaliseCap (cteCap cte) final True \<noteq> fail) p s \<longrightarrow>
-          P ((cteCaps_of s)(p \<mapsto> NullCap)))\<rbrace>
-     cteDeleteOne p
-   \<lbrace>\<lambda>rv s. P (cteCaps_of s)\<rbrace>"
-  apply (simp add: cteDeleteOne_def unless_def split_def)
-  apply (rule bind_wp [OF _ getCTE_sp])
-  apply (case_tac "\<forall>final. finaliseCap (cteCap cte) final True = fail")
-   apply (simp add: finaliseCapTrue_standin_simple_def)
-   apply wp
-   apply (clarsimp simp: cte_wp_at_ctes_of cteCaps_of_def
-                         finaliseCap_def isCap_simps)
-   apply (drule_tac x=s in fun_cong)
-   apply (simp add: return_def fail_def)
-  apply (wp emptySlot_cteCaps_of)
-    apply (simp add: cteCaps_of_def)
-    apply (wp (once) hoare_drop_imps)
-    apply (wp isFinalCapability_inv getCTE_wp')+
-  apply (clarsimp simp: cteCaps_of_def cte_wp_at_ctes_of)
-  apply (auto simp: fun_upd_idem fun_upd_def[symmetric] o_def)
-  done
-
-lemma cteDeleteOne_isFinal:
-  "\<lbrace>\<lambda>s. isFinal cap slot (cteCaps_of s)\<rbrace>
-     cteDeleteOne p
-   \<lbrace>\<lambda>rv s. isFinal cap slot (cteCaps_of s)\<rbrace>"
-  apply (wp cteDeleteOne_cteCaps_of)
-  apply (clarsimp simp: isFinal_def sameObjectAs_def2)
-  done
-
-lemmas setEndpoint_cteCaps_of[wp] = ctes_of_cteCaps_of_lift [OF set_ep_ctes_of]
-lemmas setNotification_cteCaps_of[wp] = ctes_of_cteCaps_of_lift [OF set_ntfn_ctes_of]
-lemmas threadSet_cteCaps_of = ctes_of_cteCaps_of_lift [OF threadSet_ctes_of]
-
-crunch dissociateVCPUTCB
-  for ctes_of[wp]: "\<lambda>s. P (ctes_of s)"
-  (wp: crunch_wps simp: crunch_simps)
-
-lemmas dissociateVCPUTCB_isFinal =  ctes_of_cteCaps_of_lift [OF dissociateVCPUTCB_ctes_of]
-
-crunch suspend, prepareThreadDelete
-  for isFinal: "\<lambda>s. isFinal cap slot (cteCaps_of s)"
-  (ignore: threadSet
-       wp: threadSet_cteCaps_of crunch_wps
-     simp: crunch_simps unless_def o_def)
-
-lemma isThreadCap_threadCapRefs_tcbptr:
-  "isThreadCap cap \<Longrightarrow> threadCapRefs cap = {capTCBPtr cap}"
-  by (clarsimp simp: isCap_simps)
-
-lemma isArchObjectCap_Cap_capCap:
-  "isArchObjectCap cap \<Longrightarrow> ArchObjectCap (capCap cap) = cap"
-  by (clarsimp simp: isCap_simps)
-
-lemma cteDeleteOne_deletes[wp]:
-  "\<lbrace>\<top>\<rbrace> cteDeleteOne p \<lbrace>\<lambda>rv s. cte_wp_at' (\<lambda>c. cteCap c = NullCap) p s\<rbrace>"
-  apply (subst tree_cte_cteCap_eq[unfolded o_def])
-  apply (wp cteDeleteOne_cteCaps_of)
-  apply clarsimp
-  done
-
-crunch vcpuSwitch
-  for irq_node'[wp]: "\<lambda>s. P (irq_node' s)"
-  (wp: FalseI crunch_wps getObject_inv loadObject_default_inv
-       updateObject_default_inv setObject_ksInterrupt
-   simp: crunch_simps unless_def)
-
-crunch finaliseCap
-  for irq_node'[wp]: "\<lambda>s. P (irq_node' s)"
-  (wp: mapM_x_wp crunch_wps getObject_inv loadObject_default_inv
-       updateObject_default_inv setObject_ksInterrupt
-   simp: crunch_simps unless_def o_def)
-
-lemma deletingIRQHandler_removeable':
-  "\<lbrace>invs' and (\<lambda>s. isFinal (IRQHandlerCap irq) slot (cteCaps_of s))
-          and K (cap = IRQHandlerCap irq)\<rbrace>
-     deletingIRQHandler irq
-   \<lbrace>\<lambda>rv s. removeable' slot s cap\<rbrace>"
-  apply (rule hoare_gen_asm)
-  apply (simp add: deletingIRQHandler_def getIRQSlot_def locateSlot_conv
-                   getInterruptState_def getSlotCap_def)
-  apply (simp add: removeable'_def tree_cte_cteCap_eq[unfolded o_def])
-  apply (subst tree_cte_cteCap_eq[unfolded o_def])+
-  apply (wp hoare_use_eq_irq_node' [OF cteDeleteOne_irq_node' cteDeleteOne_cteCaps_of]
-            getCTE_wp')
-  apply (clarsimp simp: cte_level_bits_def ucast_nat_def shiftl_t2n mult_ac cteSizeBits_def
-                  split: option.split_asm)
-  done
-
-lemma finaliseCap_cte_refs:
-  "\<lbrace>\<lambda>s. s \<turnstile>' cap\<rbrace>
-     finaliseCap cap final flag
-   \<lbrace>\<lambda>rv s. fst rv \<noteq> NullCap \<longrightarrow> cte_refs' (fst rv) = cte_refs' cap\<rbrace>"
-  apply (simp  add: finaliseCap_def Let_def getThreadCSpaceRoot
-                    ARM_HYP_H.finaliseCap_def
-             cong: if_cong split del: if_split)
-  apply (rule hoare_pre)
-   apply (wp | wpc | simp only: o_def)+
-  apply (frule valid_capAligned)
-  apply (cases cap, simp_all add: isCap_simps)
-   apply (clarsimp simp: tcb_cte_cases_def word_count_from_top objBits_defs)
-  apply clarsimp
-  apply (rule ext, simp)
-  apply (rule image_cong [OF _ refl])
-  apply (fastforce simp: capAligned_def objBits_simps shiftL_nat mask_def)
-  done
-
-lemma deletingIRQHandler_final:
-  "\<lbrace>\<lambda>s. isFinal cap slot (cteCaps_of s)
-             \<and> (\<forall>final. finaliseCap cap final True = fail)\<rbrace>
-     deletingIRQHandler irq
-   \<lbrace>\<lambda>rv s. isFinal cap slot (cteCaps_of s)\<rbrace>"
-  apply (simp add: deletingIRQHandler_def isFinal_def getIRQSlot_def
-                   getInterruptState_def locateSlot_conv getSlotCap_def)
-  apply (wp cteDeleteOne_cteCaps_of getCTE_wp')
-  apply (auto simp: sameObjectAs_def3)
-  done
-
-declare suspend_unqueued [wp]
-
-lemma unbindNotification_valid_objs'_helper:
-  "valid_tcb' tcb s \<longrightarrow> valid_tcb' (tcbBoundNotification_update (\<lambda>_. None) tcb) s "
-  by (clarsimp simp: valid_bound_ntfn'_def valid_tcb'_def tcb_cte_cases_def tcb_cte_cases_neqs
-                  split: option.splits ntfn.splits)
-
-lemma unbindNotification_valid_objs'_helper':
-  "valid_ntfn' tcb s \<longrightarrow> valid_ntfn' (ntfnBoundTCB_update (\<lambda>_. None) tcb) s "
-  by (clarsimp simp: valid_bound_tcb'_def valid_ntfn'_def
-                  split: option.splits ntfn.splits)
-
-lemmas setNotification_valid_tcb' = typ_at'_valid_tcb'_lift [OF setNotification_typ_at']
-
-lemma unbindNotification_valid_objs'[wp]:
-  "\<lbrace>valid_objs'\<rbrace>
-     unbindNotification t
-   \<lbrace>\<lambda>rv. valid_objs'\<rbrace>"
-  apply (simp add: unbindNotification_def)
-  apply (rule hoare_pre)
-  apply (wp threadSet_valid_objs' gbn_wp' set_ntfn_valid_objs' hoare_vcg_all_lift
-            setNotification_valid_tcb' getNotification_wp
-        | wpc | clarsimp simp: setBoundNotification_def unbindNotification_valid_objs'_helper)+
-  apply (clarsimp elim!: obj_atE' simp: projectKOs)
-  apply (rule valid_objsE', assumption+)
-  apply (clarsimp simp: valid_obj'_def unbindNotification_valid_objs'_helper')
-  done
-
-lemma unbindMaybeNotification_valid_objs'[wp]:
-  "\<lbrace>valid_objs'\<rbrace>
-     unbindMaybeNotification t
-   \<lbrace>\<lambda>rv. valid_objs'\<rbrace>"
-  apply (simp add: unbindMaybeNotification_def)
-  apply (rule bind_wp[OF _ get_ntfn_sp'])
-  apply (rule hoare_pre)
-  apply (wp threadSet_valid_objs' gbn_wp' set_ntfn_valid_objs' hoare_vcg_all_lift
-            setNotification_valid_tcb' getNotification_wp
-        | wpc | clarsimp simp: setBoundNotification_def unbindNotification_valid_objs'_helper)+
-  apply (clarsimp elim!: obj_atE' simp: projectKOs)
-  apply (rule valid_objsE', assumption+)
-  apply (clarsimp simp: valid_obj'_def unbindNotification_valid_objs'_helper')
-  done
-
-lemma unbindMaybeNotification_sch_act_wf[wp]:
-  "\<lbrace>\<lambda>s. sch_act_wf (ksSchedulerAction s) s\<rbrace> unbindMaybeNotification t
-  \<lbrace>\<lambda>rv s. sch_act_wf (ksSchedulerAction s) s\<rbrace>"
-  apply (simp add: unbindMaybeNotification_def)
-  apply (rule hoare_pre)
-  apply (wp sbn_sch_act' | wpc | simp)+
-  done
-
-lemma valid_cong:
-  "\<lbrakk> \<And>s. P s = P' s; \<And>s. P' s \<Longrightarrow> f s = f' s;
-        \<And>rv s' s. \<lbrakk> (rv, s') \<in> fst (f' s); P' s \<rbrakk> \<Longrightarrow> Q rv s' = Q' rv s' \<rbrakk>
-    \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace> = \<lbrace>P'\<rbrace> f' \<lbrace>Q'\<rbrace>"
-  by (clarsimp simp add: valid_def, blast)
-
-lemma sym_refs_ntfn_bound_eq: "sym_refs (state_refs_of' s)
-    \<Longrightarrow> obj_at' (\<lambda>ntfn. ntfnBoundTCB ntfn = Some t) x s
-    = bound_tcb_at' (\<lambda>st. st = Some x) t s"
-  apply (rule iffI)
-   apply (drule (1) sym_refs_obj_atD')
-   apply (clarsimp simp: pred_tcb_at'_def obj_at'_def ko_wp_at'_def projectKOs
-                         refs_of_rev')
-  apply (drule(1) sym_refs_bound_tcb_atD')
-  apply (clarsimp simp: obj_at'_def projectKOs ko_wp_at'_def refs_of_rev')
-  done
-
-lemma unbindMaybeNotification_obj_at'_bound:
-  "\<lbrace>\<top>\<rbrace>
-     unbindMaybeNotification r
-   \<lbrace>\<lambda>_ s. obj_at' (\<lambda>ntfn. ntfnBoundTCB ntfn = None) r s\<rbrace>"
-  apply (simp add: unbindMaybeNotification_def)
-  apply (rule bind_wp[OF _ get_ntfn_sp'])
-  apply (rule hoare_pre)
-   apply (wp obj_at_setObject2
-        | wpc
-        | simp add: setBoundNotification_def threadSet_def updateObject_default_def in_monad projectKOs)+
-  apply (simp add: setNotification_def obj_at'_real_def cong: valid_cong)
-   apply (wp setObject_ko_wp_at, (simp add: objBits_simps')+)
-  apply (clarsimp simp: obj_at'_def ko_wp_at'_def projectKOs)
-  done
-
-context
-notes option.case_cong_weak[cong]
-begin
-crunch unbindNotification, unbindMaybeNotification
-  for isFinal[wp]: "\<lambda>s. isFinal cap slot (cteCaps_of s)"
-  (wp: sts_bound_tcb_at' threadSet_cteCaps_of crunch_wps getObject_inv
-       loadObject_default_inv
-   ignore: threadSet)
-end
-
-crunch cancelSignal, cancelAllIPC
-  for bound_tcb_at'[wp]: "bound_tcb_at' P t"
-  (wp: sts_bound_tcb_at' threadSet_cteCaps_of crunch_wps getObject_inv
-       loadObject_default_inv
-   ignore: threadSet)
-
-lemma finaliseCapTrue_standin_bound_tcb_at':
-  "\<lbrace>\<lambda>s. bound_tcb_at' P t s \<and> (\<exists>tt b r. cap = ReplyCap tt b r) \<rbrace>
-     finaliseCapTrue_standin cap final
-   \<lbrace>\<lambda>_. bound_tcb_at' P t\<rbrace>"
-  apply (case_tac cap, simp_all add:finaliseCapTrue_standin_def)
-  apply (clarsimp simp: isNotificationCap_def)
-  apply (wp, clarsimp)
-  done
-
-lemma capDeleteOne_bound_tcb_at':
-  "\<lbrace>bound_tcb_at' P tptr and cte_wp_at' (isReplyCap \<circ> cteCap) callerCap\<rbrace>
-      cteDeleteOne callerCap \<lbrace>\<lambda>rv. bound_tcb_at' P tptr\<rbrace>"
-  apply (simp add: cteDeleteOne_def unless_def)
-  apply (rule hoare_pre)
-   apply (wp finaliseCapTrue_standin_bound_tcb_at' hoare_vcg_all_lift
-            hoare_vcg_if_lift2 getCTE_cteCap_wp
-        | wpc | simp | wp (once) hoare_drop_imp)+
-  apply (clarsimp simp:  cteCaps_of_def projectKOs isReplyCap_def cte_wp_at_ctes_of
-                 split: option.splits)
-  apply (case_tac "cteCap cte", simp_all)
-  done
-
-lemma cancelIPC_bound_tcb_at'[wp]:
-  "\<lbrace>bound_tcb_at' P tptr\<rbrace> cancelIPC t \<lbrace>\<lambda>rv. bound_tcb_at' P tptr\<rbrace>"
-  apply (simp add: cancelIPC_def Let_def)
-  apply (rule bind_wp[OF _ gts_sp'])
-  apply (case_tac "state", simp_all)
-         defer 2
-         apply (rule hoare_pre)
-          apply ((wp sts_bound_tcb_at' getEndpoint_wp | wpc | simp)+)[8]
-  apply (simp add: getThreadReplySlot_def locateSlot_conv liftM_def)
-  apply (rule hoare_pre)
-   apply (wp capDeleteOne_bound_tcb_at' getCTE_ctes_of)
-   apply (rule_tac Q'="\<lambda>_. bound_tcb_at' P tptr" in hoare_post_imp)
-   apply (clarsimp simp: capHasProperty_def cte_wp_at_ctes_of)
-   apply (wp threadSet_pred_tcb_no_state | simp)+
-  done
-
-lemma archThreadSet_bound_tcb_at'[wp]:
-  "archThreadSet f t \<lbrace>bound_tcb_at' P t'\<rbrace>"
-  unfolding archThreadSet_def
-  apply (wpsimp wp: setObject_tcb_strongest getObject_tcb_wp simp: pred_tcb_at'_def)
-  by (auto simp: obj_at'_def projectKOs objBits_simps)
-
-lemmas asUser_bound_obj_at'[wp] = asUser_pred_tcb_at' [of itcbBoundNotification]
-
-lemmas setObject_vcpu_pred_tcb_at'[wp] =
-  setObject_vcpu_obj_at'_no_vcpu [of _ "\<lambda>ko. tst (pr (tcb_to_itcb' ko))" for tst pr, folded pred_tcb_at'_def]
-
-crunch dissociateVCPUTCB, vgicUpdateLR
-  for bound_tcb_at'[wp]: "bound_tcb_at' P t"
-  (wp: sts_bound_tcb_at' getVCPU_wp crunch_wps hoare_vcg_all_lift hoare_vcg_if_lift3
-   ignore: archThreadSet)
-
-crunch suspend, prepareThreadDelete
-  for bound_tcb_at'[wp]: "bound_tcb_at' P t"
-  (wp: sts_bound_tcb_at' cancelIPC_bound_tcb_at'
-   ignore: threadSet)
-
-lemma unbindNotification_bound_tcb_at':
-  "\<lbrace>\<lambda>_. True\<rbrace> unbindNotification t \<lbrace>\<lambda>rv. bound_tcb_at' ((=) None) t\<rbrace>"
-  apply (simp add: unbindNotification_def)
-  apply (wp setBoundNotification_bound_tcb gbn_wp' | wpc | simp)+
-  done
-
-crunch unbindNotification, unbindMaybeNotification
-  for weak_sch_act_wf[wp]: "\<lambda>s. weak_sch_act_wf (ksSchedulerAction s) s"
-
-lemma unbindNotification_tcb_at'[wp]:
-  "\<lbrace>tcb_at' t'\<rbrace> unbindNotification t \<lbrace>\<lambda>rv. tcb_at' t'\<rbrace>"
-  apply (simp add: unbindNotification_def)
-  apply (wp gbn_wp' | wpc | simp)+
-  done
-
-lemma unbindMaybeNotification_tcb_at'[wp]:
-  "\<lbrace>tcb_at' t'\<rbrace> unbindMaybeNotification t \<lbrace>\<lambda>rv. tcb_at' t'\<rbrace>"
-  apply (simp add: unbindMaybeNotification_def)
-  apply (wp gbn_wp' | wpc | simp)+
-  done
-
-lemma dissociateVCPUTCB_cte_wp_at'[wp]:
-  "dissociateVCPUTCB v t \<lbrace>cte_wp_at' P p\<rbrace>"
-  unfolding cte_wp_at_ctes_of by wp
-
-lemmas dissociateVCPUTCB_typ_ats'[wp] = typ_at_lifts[OF dissociateVCPUTCB_typ_at']
-
-crunch prepareThreadDelete
-  for cte_wp_at'[wp]: "cte_wp_at' P p"
-crunch prepareThreadDelete
-  for valid_cap'[wp]: "valid_cap' cap"
-crunch prepareThreadDelete
-  for invs[wp]: "invs'"
-
-lemma unset_vcpu_hyp_unlive[wp]:
-  "\<lbrace>\<top>\<rbrace> archThreadSet (atcbVCPUPtr_update Map.empty) t \<lbrace>\<lambda>_. ko_wp_at' (Not \<circ> hyp_live') t\<rbrace>"
-  unfolding archThreadSet_def
-  apply (wpsimp wp: setObject_ko_wp_at' getObject_tcb_wp; (simp add: objBits_simps')?)+
-  apply (clarsimp simp: obj_at'_def ko_wp_at'_def projectKOs hyp_live'_def)
-  done
-
- lemma unset_tcb_hyp_unlive[wp]:
-  "\<lbrace>\<top>\<rbrace> setObject vr (vcpuTCBPtr_update Map.empty vcpu) \<lbrace>\<lambda>_. ko_wp_at' (Not \<circ> hyp_live') vr\<rbrace>"
-  apply (wpsimp wp: setObject_ko_wp_at' getObject_tcb_wp
-                simp: objBits_simps archObjSize_def vcpu_bits_def pageBits_def
-        | simp)+
-  apply (clarsimp simp: obj_at'_def ko_wp_at'_def projectKOs hyp_live'_def arch_live'_def)
-  done
-
-lemma setObject_vcpu_hyp_unlive[wp]:
-   "\<lbrace>\<lambda>s. t \<noteq> vr \<and> ko_wp_at' (Not \<circ> hyp_live') t s\<rbrace>
-         setObject vr (vcpuTCBPtr_update Map.empty vcpu)
-    \<lbrace>\<lambda>_. ko_wp_at' (Not \<circ> hyp_live') t\<rbrace>"
-  apply (rule wp_pre)
-  apply (wpsimp wp: setObject_ko_wp_at
-                simp: objBits_def objBitsKO_def archObjSize_def vcpu_bits_def pageBits_def
-        | simp)+
-  apply (clarsimp simp: tcb_at_typ_at' typ_at'_def ko_wp_at'_def )
-  done
-
-
-lemma asUser_hyp_unlive[wp]:
-  "asUser f t \<lbrace>ko_wp_at' (Not \<circ> hyp_live') t'\<rbrace>"
-  unfolding asUser_def
-  apply (wpsimp wp: threadSet_ko_wp_at2' threadGet_wp)
-  apply (clarsimp simp: ko_wp_at'_def obj_at'_def projectKOs hyp_live'_def atcbContextSet_def)
-  done
-
-lemma dissociateVCPUTCB_hyp_unlive[wp]:
-  "\<lbrace>\<top>\<rbrace> dissociateVCPUTCB v t \<lbrace>\<lambda>_. ko_wp_at' (Not \<circ> hyp_live') t\<rbrace>"
-  unfolding dissociateVCPUTCB_def
-  by (cases "v = t"; wpsimp wp: unset_tcb_hyp_unlive unset_vcpu_hyp_unlive[simplified comp_def])
-
-lemma prepareThreadDelete_hyp_unlive[wp]:
-  "\<lbrace>\<top>\<rbrace> prepareThreadDelete t \<lbrace>\<lambda>_. ko_wp_at' (Not \<circ> hyp_live') t\<rbrace>"
-  unfolding prepareThreadDelete_def archThreadGet_def
-  apply (wpsimp wp: getObject_tcb_wp)
-  apply (clarsimp simp: ko_wp_at'_def obj_at'_def projectKOs hyp_live'_def)
-  done
-
-end
-
-lemma tcbQueueRemove_tcbSchedNext_tcbSchedPrev_None_obj_at':
-  "\<lbrace>\<lambda>s. \<exists>ts. list_queue_relation ts q (tcbSchedNexts_of s) (tcbSchedPrevs_of s)\<rbrace>
-   tcbQueueRemove q t
-   \<lbrace>\<lambda>_ s. obj_at' (\<lambda>tcb. tcbSchedNext tcb = None \<and> tcbSchedPrev tcb = None) t s\<rbrace>"
-  supply projectKOs[simp]
-  apply (clarsimp simp: tcbQueueRemove_def)
-  apply (wpsimp wp: threadSet_wp getTCB_wp)
-  by (fastforce dest!: heap_ls_last_None
-                 simp: list_queue_relation_def prev_queue_head_def queue_end_valid_def
-                       obj_at'_def opt_map_def ps_clear_def gen_objBits_simps
-                split: if_splits)
-
-lemma tcbSchedDequeue_tcbSchedNext_tcbSchedPrev_None_obj_at':
-  "\<lbrace>valid_sched_pointers\<rbrace>
-   tcbSchedDequeue t
-   \<lbrace>\<lambda>_ s. obj_at' (\<lambda>tcb. tcbSchedNext tcb = None \<and> tcbSchedPrev tcb = None) t s\<rbrace>"
-  supply projectKOs[simp]
-  unfolding tcbSchedDequeue_def
-  by (wpsimp wp: tcbQueueRemove_tcbSchedNext_tcbSchedPrev_None_obj_at' threadGet_wp)
-     (fastforce simp: ready_queue_relation_def ksReadyQueues_asrt_def obj_at'_def
-                      valid_sched_pointers_def opt_pred_def opt_map_def
-               split: option.splits)
-
-crunch updateRestartPC, cancelIPC
-  for valid_sched_pointers[wp]: valid_sched_pointers
-  (simp: crunch_simps wp: crunch_wps)
-
-lemma setThreadState_tcbSchedNext_tcbSchedPrev_None_obj_at'[wp]:
-  "setThreadState ref ts \<lbrace>\<lambda>s. obj_at' (\<lambda>tcb. tcbSchedNext tcb = None \<and> tcbSchedPrev tcb = None) t s\<rbrace>"
-  unfolding setThreadState_def
-  apply (wpsimp wp: threadSet_wp getTCB_wp)
-  apply (fastforce simp: obj_at'_def gen_objBits_simps)
-  done
-
-lemma suspend_tcbSchedNext_tcbSchedPrev_None:
-  "\<lbrace>invs'\<rbrace> suspend t \<lbrace>\<lambda>_ s. obj_at' (\<lambda>tcb. tcbSchedNext tcb = None \<and> tcbSchedPrev tcb = None) t s\<rbrace>"
-  unfolding suspend_def
-  by (wpsimp wp: hoare_drop_imps tcbSchedDequeue_tcbSchedNext_tcbSchedPrev_None_obj_at')
-
-context begin interpretation Arch . (*FIXME: arch-split*)
-
-lemma archThreadSet_tcbSchedPrevNext[wp]:
-  "archThreadSet f t' \<lbrace>obj_at' (\<lambda>tcb. P (tcbSchedNext tcb) (tcbSchedPrev tcb)) t\<rbrace>"
-  unfolding archThreadSet_def
-  apply (wpsimp wp: setObject_tcb_strongest getObject_tcb_wp)
-  apply normalise_obj_at'
-  apply auto
-  done
-
-crunch prepareThreadDelete
-  for tcbSchedPrevNext[wp]: "obj_at' (\<lambda>tcb. P (tcbSchedNext tcb) (tcbSchedPrev tcb)) t"
-  (wp: threadGet_wp getVCPU_wp archThreadGet_wp crunch_wps simp: crunch_simps)
-
-end
-
-lemma (in delete_one_conc_pre) finaliseCap_replaceable:
-  "\<lbrace>\<lambda>s. invs' s \<and> cte_wp_at' (\<lambda>cte. cteCap cte = cap) slot s
-       \<and> (final_matters' cap \<longrightarrow> (final = isFinal cap slot (cteCaps_of s)))
-       \<and> weak_sch_act_wf (ksSchedulerAction s) s\<rbrace>
-     finaliseCap cap final flag
-   \<lbrace>\<lambda>rv s. (isNullCap (fst rv) \<and> removeable' slot s cap
-                \<and> (snd rv \<noteq> NullCap \<longrightarrow> snd rv = cap \<and> cap_has_cleanup' cap
-                                      \<and> isFinal cap slot (cteCaps_of s)))
-        \<or>
-          (isZombie (fst rv) \<and> snd rv = NullCap
-            \<and> isFinal cap slot (cteCaps_of s)
-            \<and> capClass cap = capClass (fst rv)
-            \<and> capUntypedPtr (fst rv) = capUntypedPtr cap
-            \<and> capBits (fst rv) = capBits cap
-            \<and> capRange (fst rv) = capRange cap
-            \<and> (isThreadCap cap \<or> isCNodeCap cap \<or> isZombie cap)
-            \<and> (\<forall>p \<in> threadCapRefs cap. st_tcb_at' ((=) Inactive) p s
-                     \<and> obj_at' (Not \<circ> tcbQueued) p s
-                     \<and> bound_tcb_at' ((=) None) p s
-                     \<and> ko_wp_at' (Not \<circ> hyp_live') p s
-                     \<and> obj_at' (\<lambda>tcb. tcbSchedNext tcb = None \<and> tcbSchedPrev tcb = None) p s))\<rbrace>"
-  apply (simp add: finaliseCap_def Let_def getThreadCSpaceRoot
-             cong: if_cong split del: if_split)
-  apply (rule hoare_pre)
-   apply (wp prepares_delete_helper'' [OF cancelAllIPC_unlive]
-             prepares_delete_helper'' [OF cancelAllSignals_unlive]
-             suspend_isFinal ARM_HYP.prepareThreadDelete_unqueued (* FIXME arch-split: interface *)
-             ARM_HYP.prepareThreadDelete_inactive prepareThreadDelete_isFinal
-             suspend_makes_inactive
-             deletingIRQHandler_removeable'
-             deletingIRQHandler_final[where slot=slot ]
-             unbindMaybeNotification_obj_at'_bound
-             getNotification_wp
-             suspend_bound_tcb_at'
-             unbindNotification_bound_tcb_at'
-             suspend_tcbSchedNext_tcbSchedPrev_None
-           | simp add: isZombie_Null isThreadCap_threadCapRefs_tcbptr
-                       isArchObjectCap_Cap_capCap
-           | (rule hoare_strengthen_post [OF arch_finaliseCap_removeable[where slot=slot]],
-              clarsimp simp: gen_isCap_simps)
-           | wpc)+
-  apply clarsimp
-  apply (frule cte_wp_at_valid_objs_valid_cap', clarsimp+)
-  apply (case_tac "cteCap cte",
-         simp_all add: gen_isCap_simps capRange_def
-                       final_matters'_def gen_objBits_simps
-                       not_Final_removeable finaliseCap_def,
-         simp_all add: removeable'_def)[1]
-   apply fastforce+
-  done
-
-lemma cteDeleteOne_cte_wp_at_preserved:
-  assumes x: "\<And>cap final. P cap \<Longrightarrow> finaliseCap cap final True = fail"
-  shows "\<lbrace>\<lambda>s. cte_wp_at' (\<lambda>cte. P (cteCap cte)) p s\<rbrace>
-           cteDeleteOne ptr
-         \<lbrace>\<lambda>rv s. cte_wp_at' (\<lambda>cte. P (cteCap cte)) p s\<rbrace>"
-  apply (simp add: tree_cte_cteCap_eq[unfolded o_def])
-  apply (rule hoare_pre, wp cteDeleteOne_cteCaps_of)
-  apply (clarsimp simp: cteCaps_of_def cte_wp_at_ctes_of x)
-  done
-
-crunch cancelSignal
-  for ctes_of[wp]: "\<lambda>s. P (ctes_of s)"
-  (simp: crunch_simps wp: crunch_wps)
-
-lemma cancelIPC_cteCaps_of:
-  "\<lbrace>\<lambda>s. (\<forall>p. cte_wp_at' (\<lambda>cte. \<exists>final. finaliseCap (cteCap cte) final True \<noteq> fail) p s \<longrightarrow>
-          P ((cteCaps_of s)(p \<mapsto> NullCap))) \<and>
-     P (cteCaps_of s)\<rbrace>
-     cancelIPC t
-   \<lbrace>\<lambda>rv s. P (cteCaps_of s)\<rbrace>"
-  apply (simp add: cancelIPC_def Let_def capHasProperty_def
-                   getThreadReplySlot_def locateSlot_conv)
-  apply (rule hoare_pre)
-   apply (wp cteDeleteOne_cteCaps_of getCTE_wp' | wpcw
-        | simp add: cte_wp_at_ctes_of
-        | wp (once) hoare_drop_imps ctes_of_cteCaps_of_lift)+
-          apply (wp hoare_convert_imp hoare_vcg_all_lift
-                    threadSet_ctes_of threadSet_cteCaps_of
-               | clarsimp)+
-    apply (wp cteDeleteOne_cteCaps_of getCTE_wp' | wpcw | simp
-       | wp (once) hoare_drop_imps ctes_of_cteCaps_of_lift)+
-  apply (clarsimp simp: cte_wp_at_ctes_of cteCaps_of_def)
-  apply (drule_tac x="mdbNext (cteMDBNode x)" in spec)
-  apply clarsimp
-  apply (auto simp: o_def map_option_case fun_upd_def[symmetric])
-  done
-
-lemma cancelIPC_cte_wp_at':
-  assumes x: "\<And>cap final. P cap \<Longrightarrow> finaliseCap cap final True = fail"
-  shows "\<lbrace>\<lambda>s. cte_wp_at' (\<lambda>cte. P (cteCap cte)) p s\<rbrace>
-           cancelIPC t
-         \<lbrace>\<lambda>rv s. cte_wp_at' (\<lambda>cte. P (cteCap cte)) p s\<rbrace>"
-  apply (simp add: tree_cte_cteCap_eq[unfolded o_def])
-  apply (rule hoare_pre, wp cancelIPC_cteCaps_of)
-  apply (clarsimp simp: cteCaps_of_def cte_wp_at_ctes_of x)
-  done
-
-crunch tcbSchedDequeue
-  for cte_wp_at'[wp]: "cte_wp_at' P p"
-  (wp: crunch_wps)
-
-lemma suspend_cte_wp_at':
-  assumes x: "\<And>cap final. P cap \<Longrightarrow> finaliseCap cap final True = fail"
-  shows "\<lbrace>cte_wp_at' (\<lambda>cte. P (cteCap cte)) p\<rbrace>
-           suspend t
-         \<lbrace>\<lambda>rv. cte_wp_at' (\<lambda>cte. P (cteCap cte)) p\<rbrace>"
-  apply (simp add: suspend_def)
-  unfolding updateRestartPC_def
-  apply (rule hoare_pre)
-   apply (wp threadSet_cte_wp_at' cancelIPC_cte_wp_at'
-             | simp add: x)+
-  done
-
-context begin interpretation Arch . (*FIXME: arch-split*)
-
-crunch deleteASIDPool
-  for cte_wp_at'[wp]: "cte_wp_at' P p"
-  (simp: crunch_simps assertE_def
-   wp: crunch_wps getObject_inv loadObject_default_inv)
-
-lemma deleteASID_cte_wp_at'[wp]:
-  "\<lbrace>cte_wp_at' P p\<rbrace> deleteASID param_a param_b \<lbrace>\<lambda>_. cte_wp_at' P p\<rbrace>"
-  apply (simp add: deleteASID_def invalidateHWASIDEntry_def invalidateASID_def
-              cong: option.case_cong)
-  apply (wp setObject_cte_wp_at'[where Q="\<top>"] getObject_inv
-            loadObject_default_inv setVMRoot_cte_wp_at'
-          | clarsimp simp: updateObject_default_def in_monad
-                           projectKOs
-          | rule equals0I
-          | wpc)+
-  done
-
-crunch unmapPageTable, unmapPage, unbindNotification, finaliseCapTrue_standin
-  for cte_wp_at'[wp]: "cte_wp_at' P p"
-  (simp: crunch_simps wp: crunch_wps getObject_inv loadObject_default_inv)
-
-crunch vcpuFinalise
-  for cte_wp_at'[wp]: "cte_wp_at' P p"
-  (wp: crunch_wps getObject_inv loadObject_default_inv)
-
-lemma arch_finaliseCap_cte_wp_at[wp]:
-  "\<lbrace>cte_wp_at' P p\<rbrace> Arch.finaliseCap cap fin \<lbrace>\<lambda>rv. cte_wp_at' P p\<rbrace>"
-  unfolding ARM_HYP_H.finaliseCap_def
-  by (wpsimp wp: unmapPage_cte_wp_at'|rule conjI)+
-
-lemma deletingIRQHandler_cte_preserved:
-  assumes x: "\<And>cap final. P cap \<Longrightarrow> finaliseCap cap final True = fail"
-  shows "\<lbrace>cte_wp_at' (\<lambda>cte. P (cteCap cte)) p\<rbrace>
-           deletingIRQHandler irq
-         \<lbrace>\<lambda>rv. cte_wp_at' (\<lambda>cte. P (cteCap cte)) p\<rbrace>"
-  apply (simp add: deletingIRQHandler_def getSlotCap_def
-                   getIRQSlot_def locateSlot_conv getInterruptState_def)
-  apply (wp cteDeleteOne_cte_wp_at_preserved getCTE_wp'
-              | simp add: x)+
-  done
-
-lemma finaliseCap_equal_cap[wp]:
-  "\<lbrace>cte_wp_at' (\<lambda>cte. cteCap cte = cap) sl\<rbrace>
-     finaliseCap cap fin flag
-   \<lbrace>\<lambda>rv. cte_wp_at' (\<lambda>cte. cteCap cte = cap) sl\<rbrace>"
-  apply (simp add: finaliseCap_def Let_def
-             cong: if_cong split del: if_split)
-  apply (rule hoare_pre)
-   apply (wp suspend_cte_wp_at' deletingIRQHandler_cte_preserved
-        | clarsimp simp: finaliseCap_def | wpc)+
-  apply (case_tac cap)
-  apply auto
-  done
-
-lemma setThreadState_st_tcb_at_simplish':
-  "simple' st \<Longrightarrow>
-   \<lbrace>st_tcb_at' (P or simple') t\<rbrace>
-     setThreadState st t'
-   \<lbrace>\<lambda>rv. st_tcb_at' (P or simple') t\<rbrace>"
-  apply (wp sts_st_tcb_at'_cases)
-  apply clarsimp
-  done
-
-lemmas setThreadState_st_tcb_at_simplish
-    = setThreadState_st_tcb_at_simplish'[unfolded pred_disj_def]
-
-crunch cteDeleteOne
-  for st_tcb_at_simplish: "st_tcb_at' (\<lambda>st. P st \<or> simple' st) t"
-  (wp: crunch_wps getObject_inv loadObject_default_inv threadSet_pred_tcb_no_state
-   simp: crunch_simps unless_def ignore: threadSet)
-
-lemma cteDeleteOne_st_tcb_at[wp]:
-  assumes x[simp]: "\<And>st. simple' st \<longrightarrow> P st" shows
-  "\<lbrace>st_tcb_at' P t\<rbrace> cteDeleteOne slot \<lbrace>\<lambda>rv. st_tcb_at' P t\<rbrace>"
-  apply (subgoal_tac "\<exists>Q. P = (Q or simple')")
-   apply (clarsimp simp: pred_disj_def)
-   apply (rule cteDeleteOne_st_tcb_at_simplish)
-  apply (rule_tac x=P in exI)
-  apply (auto intro!: ext)
-  done
-
-lemma cteDeleteOne_reply_pred_tcb_at:
-  "\<lbrace>\<lambda>s. pred_tcb_at' proj P t s \<and> (\<exists>t' r. cte_wp_at' (\<lambda>cte. cteCap cte = ReplyCap t' False r) slot s)\<rbrace>
-    cteDeleteOne slot
-   \<lbrace>\<lambda>rv. pred_tcb_at' proj P t\<rbrace>"
-  apply (simp add: cteDeleteOne_def unless_def isFinalCapability_def)
-  apply (rule bind_wp [OF _ getCTE_sp])
-  apply (rule hoare_assume_pre)
-  apply (clarsimp simp: cte_wp_at_ctes_of when_def isCap_simps
-                        Let_def finaliseCapTrue_standin_def)
-  apply (intro impI conjI, (wp | simp)+)
-  done
-
-context
-notes option.case_cong_weak[cong]
-begin
-crunch cteDeleteOne, unbindNotification
-  for sch_act_simple[wp]: sch_act_simple
-  (wp: crunch_wps ssa_sch_act_simple sts_sch_act_simple getObject_inv
-       loadObject_default_inv
-   simp: crunch_simps unless_def
-   rule: sch_act_simple_lift)
-end
-
-lemma rescheduleRequired_sch_act_not[wp]:
-  "\<lbrace>\<top>\<rbrace> rescheduleRequired \<lbrace>\<lambda>rv. sch_act_not t\<rbrace>"
-  apply (simp add: rescheduleRequired_def setSchedulerAction_def)
-  apply (wp hoare_TrueI | simp)+
-  done
-
-crunch cteDeleteOne
-  for sch_act_not[wp]: "sch_act_not t"
-  (simp: crunch_simps case_Null_If unless_def
-   wp: crunch_wps getObject_inv loadObject_default_inv)
-
-lemma cancelAllIPC_mapM_x_weak_sch_act:
-  "\<lbrace>\<lambda>s. weak_sch_act_wf (ksSchedulerAction s) s\<rbrace>
-   mapM_x (\<lambda>t. do
-                 y \<leftarrow> setThreadState Structures_H.thread_state.Restart t;
-                 tcbSchedEnqueue t
-               od) q
-   \<lbrace>\<lambda>rv s. weak_sch_act_wf (ksSchedulerAction s) s\<rbrace>"
-  apply (rule mapM_x_wp_inv)
-  apply (wp)
-  apply (clarsimp)
-  done
-
-lemma cancelAllIPC_mapM_x_valid_objs':
-  "\<lbrace>valid_objs' and pspace_aligned' and pspace_distinct'\<rbrace>
-   mapM_x (\<lambda>t. do
-                 y \<leftarrow> setThreadState Structures_H.thread_state.Restart t;
-                 tcbSchedEnqueue t
-               od) q
-   \<lbrace>\<lambda>_. valid_objs'\<rbrace>"
-  apply (rule hoare_strengthen_post)
-   apply (rule mapM_x_wp')
-  apply (wpsimp wp: sts_valid_objs')
-   apply (clarsimp simp: valid_tcb_state'_def)+
-  done
-
-lemma cancelAllIPC_mapM_x_tcbDomain_obj_at':
-  "\<lbrace>obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>
-   mapM_x (\<lambda>t. do
-                 y \<leftarrow> setThreadState Structures_H.thread_state.Restart t;
-                 tcbSchedEnqueue t
-               od) q
-  \<lbrace>\<lambda>_. obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>"
-  by (wpsimp wp: mapM_x_wp')
-
-lemma rescheduleRequired_oa_queued':
-  "rescheduleRequired \<lbrace>obj_at' (\<lambda>tcb. Q (tcbDomain tcb) (tcbPriority tcb)) t\<rbrace>"
-  unfolding rescheduleRequired_def tcbSchedEnqueue_def tcbQueuePrepend_def
-  by wpsimp
-
-lemma cancelAllIPC_tcbDomain_obj_at':
-  "\<lbrace>obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>
-     cancelAllIPC epptr
-   \<lbrace>\<lambda>_. obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>"
-apply (simp add: cancelAllIPC_def)
-apply (wp hoare_vcg_conj_lift hoare_vcg_const_Ball_lift
-          rescheduleRequired_oa_queued' cancelAllIPC_mapM_x_tcbDomain_obj_at'
-          getEndpoint_wp
-     | wpc
-     | simp)+
-done
-
-lemma cancelAllSignals_tcbDomain_obj_at':
-  "\<lbrace>obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>
-     cancelAllSignals epptr
-   \<lbrace>\<lambda>_. obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>"
-apply (simp add: cancelAllSignals_def)
-apply (wp hoare_vcg_conj_lift hoare_vcg_const_Ball_lift
-          rescheduleRequired_oa_queued' cancelAllIPC_mapM_x_tcbDomain_obj_at'
-          getNotification_wp
-     | wpc
-     | simp)+
-done
-
-lemma unbindMaybeNotification_tcbDomain_obj_at':
-  "unbindMaybeNotification r \<lbrace>obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>"
-  unfolding unbindMaybeNotification_def
-  by (wpsimp wp: getNotification_wp gbn_wp' simp: setBoundNotification_def)+
-
-crunch isFinalCapability
-  for sch_act[wp]: "\<lambda>s. sch_act_wf (ksSchedulerAction s) s"
-  (simp: crunch_simps)
-
-crunch
-  isFinalCapability
-  for weak_sch_act[wp]: "\<lambda>s. weak_sch_act_wf (ksSchedulerAction s) s"
-  (simp: crunch_simps)
-
-crunch cteDeleteOne
-  for ksCurDomain[wp]: "\<lambda>s. P (ksCurDomain s)"
-  (wp: crunch_wps simp: crunch_simps unless_def)
-
-lemma cteDeleteOne_tcbDomain_obj_at':
-  "\<lbrace>obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace> cteDeleteOne slot \<lbrace>\<lambda>_. obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>"
-  apply (simp add: cteDeleteOne_def unless_def split_def)
-  apply (wp emptySlot_tcbDomain cancelAllIPC_tcbDomain_obj_at' cancelAllSignals_tcbDomain_obj_at'
-          isFinalCapability_inv getCTE_wp
-          unbindMaybeNotification_tcbDomain_obj_at'
-     | rule hoare_drop_imp
-     | simp add: finaliseCapTrue_standin_def Let_def
-            split del: if_split
-     | wpc)+
-  apply (clarsimp simp: cte_wp_at'_def)
-  done
-
-end
-
-global_interpretation delete_one_conc_pre
-  by (unfold_locales, wp) (wp cteDeleteOne_tcbDomain_obj_at' cteDeleteOne_typ_at' cteDeleteOne_reply_pred_tcb_at | simp)+
-
-context begin interpretation Arch . (*FIXME: arch-split*)
-
-lemma cteDeleteOne_invs[wp]:
-  "\<lbrace>invs'\<rbrace> cteDeleteOne ptr \<lbrace>\<lambda>rv. invs'\<rbrace>"
-  apply (simp add: cteDeleteOne_def unless_def
-                   split_def finaliseCapTrue_standin_simple_def)
-  apply wp
-    apply (rule hoare_strengthen_post)
-     apply (rule hoare_vcg_conj_lift)
-      apply (rule finaliseCap_True_invs)
-     apply (rule hoare_vcg_conj_lift)
-      apply (rule finaliseCap_replaceable[where slot=ptr])
-     apply (rule hoare_vcg_conj_lift)
-      apply (rule finaliseCap_cte_refs)
-     apply (rule finaliseCap_equal_cap[where sl=ptr])
-    apply (clarsimp simp: cte_wp_at_ctes_of)
-    apply (erule disjE)
-     apply simp
-    apply (clarsimp dest!: isCapDs simp: capRemovable_def)
-    apply (clarsimp simp: removeable'_def fun_eq_iff[where f="cte_refs' cap" for cap]
-                     del: disjCI)
-    apply (rule disjI2)
-    apply (rule conjI)
-     subgoal by auto
-    subgoal by (auto dest!: isCapDs simp: pred_tcb_at'_def obj_at'_def projectKOs
-                                      live'_def hyp_live'_def ko_wp_at'_def)
-   apply (wp isFinalCapability_inv getCTE_wp' hoare_weak_lift_imp
-        | wp (once) isFinal[where x=ptr])+
-  apply (fastforce simp: cte_wp_at_ctes_of)
-  done
-
-end
-
-global_interpretation delete_one_conc_fr: delete_one_conc
-  by unfold_locales wp
-
-declare cteDeleteOne_invs[wp]
-
-lemma deletingIRQHandler_invs' [wp]:
-  "\<lbrace>invs'\<rbrace> deletingIRQHandler i \<lbrace>\<lambda>_. invs'\<rbrace>"
-  apply (simp add: deletingIRQHandler_def getSlotCap_def
-                   getIRQSlot_def locateSlot_conv getInterruptState_def)
-  apply (wp getCTE_wp')
-  apply simp
-  done
-
-crunch unbindNotification, unbindMaybeNotification
-  for tcb_at'[wp]: "tcb_at' t"
-
-lemma finaliseCap_invs:
-  "\<lbrace>invs' and sch_act_simple and valid_cap' cap
-         and cte_wp_at' (\<lambda>cte. cteCap cte = cap) sl\<rbrace>
-     finaliseCap cap fin flag
-   \<lbrace>\<lambda>rv. invs'\<rbrace>"
-  apply (simp add: finaliseCap_def Let_def
-             cong: if_cong split del: if_split)
-  apply (rule hoare_pre)
-   apply (wp hoare_drop_imps hoare_vcg_all_lift | simp only: o_def | wpc)+
-  apply clarsimp
-  apply (intro conjI impI)
-    apply (clarsimp dest!: isCapDs simp: valid_cap'_def)
-   apply (drule invs_valid_global', drule(1) valid_globals_cte_wpD')
-   apply (drule valid_capAligned, drule capAligned_capUntypedPtr)
-    apply (clarsimp dest!: isCapDs)
-   apply (clarsimp dest!: isCapDs)
-  apply (clarsimp dest!: isCapDs)
-  done
-
-lemma finaliseCap_zombie_cap[wp]:
-  "\<lbrace>cte_wp_at' (\<lambda>cte. (P and isZombie) (cteCap cte)) sl\<rbrace>
-     finaliseCap cap fin flag
-   \<lbrace>\<lambda>rv. cte_wp_at' (\<lambda>cte. (P and isZombie) (cteCap cte)) sl\<rbrace>"
-  apply (simp add: finaliseCap_def Let_def
-             cong: if_cong split del: if_split)
-  apply (rule hoare_pre)
-   apply (wp suspend_cte_wp_at' deletingIRQHandler_cte_preserved
-          | clarsimp simp: finaliseCap_def gen_isCap_simps | wpc)+
-  done
-
-lemma finaliseCap_zombie_cap':
-  "\<lbrace>cte_wp_at' (\<lambda>cte. (P and isZombie) (cteCap cte)) sl\<rbrace>
-     finaliseCap cap fin flag
-   \<lbrace>\<lambda>rv. cte_wp_at' (\<lambda>cte. P (cteCap cte)) sl\<rbrace>"
-  apply (rule hoare_strengthen_post)
-   apply (rule finaliseCap_zombie_cap)
-  apply (clarsimp simp: cte_wp_at_ctes_of)
-  done
-
-lemma finaliseCap_cte_cap_wp_to[wp]:
-  "\<lbrace>ex_cte_cap_wp_to' P sl\<rbrace> finaliseCap cap fin flag \<lbrace>\<lambda>rv. ex_cte_cap_wp_to' P sl\<rbrace>"
-  apply (simp add: ex_cte_cap_to'_def)
-  apply (rule hoare_pre, rule hoare_use_eq_irq_node' [OF finaliseCap_irq_node'])
-   apply (simp add: finaliseCap_def Let_def
-              cong: if_cong split del: if_split)
-   apply (wp suspend_cte_wp_at'
-             deletingIRQHandler_cte_preserved
-             hoare_vcg_ex_lift
-                 | clarsimp simp: finaliseCap_def gen_isCap_simps
-                 | rule conjI
-                 | wpc)+
-  apply fastforce
-  done
-
-context
-notes option.case_cong_weak[cong]
-begin
-crunch unbindNotification
-  for valid_cap'[wp]: "valid_cap' cap"
-end
-
-lemma finaliseCap_valid_cap[wp]:
-  "\<lbrace>valid_cap' cap\<rbrace> finaliseCap cap final flag \<lbrace>\<lambda>rv. valid_cap' (fst rv)\<rbrace>"
-  apply (simp add: finaliseCap_def Let_def
-                   getThreadCSpaceRoot
-                   ARM_HYP_H.finaliseCap_def
-             cong: if_cong split del: if_split)
-  apply (rule hoare_pre)
-   apply (wp | simp only: valid_NullCap o_def fst_conv | wpc)+
-  apply simp
-  apply (intro conjI impI)
-   apply (clarsimp simp: valid_cap'_def gen_isCap_simps capAligned_def
-                         gen_objBits_simps shiftL_nat)+
-  done
-
-
-context begin interpretation Arch . (*FIXME: arch-split*)
-
-crunch dissociateVCPUTCB
+lemma arch_recycleCap_improve_cases:
+  "\<lbrakk>\<not> isPageCap cap; \<not> isPageTableCap cap; \<not> isPageDirectoryCap cap;\<not> isVCPUCap cap;
+    \<not> isASIDControlCap cap; \<not>isSGISignalCap cap \<rbrakk> \<Longrightarrow>
+   (if isASIDPoolCap cap then v else undefined) = v"
+  by (cases cap, simp_all add: isCap_simps)
+
+crunch invalidateTLBByASID
+  for nosch[wp]: "\<lambda>s. P (ksSchedulerAction s)"
+
+crunch dissociateVCPUTCB, unmapPageTable
   for nosch[wp]: "\<lambda>s. P (ksSchedulerAction s)"
   (wp: crunch_wps getVCPU_wp getObject_inv hoare_vcg_all_lift hoare_vcg_if_lift3
    simp: loadObject_default_def updateObject_default_def)
 
-crunch "Arch.finaliseCap"
-  for nosch[wp]: "\<lambda>s. P (ksSchedulerAction s)"
-  (wp: crunch_wps getObject_inv simp: loadObject_default_def updateObject_default_def)
+context notes if_cong[cong] begin
 
-crunch finaliseCap
+crunch Arch_finaliseCap
+  for nosch[wp]: "\<lambda>s. P (ksSchedulerAction s)"
+  (wp: crunch_wps getObject_inv simp: loadObject_default_def updateObject_default_def
+   rule: ARM_HYP_H.finaliseCap_def)
+
+end
+
+crunch vcpuFinalise, deletingIRQHandler, finaliseCap
   for sch_act_simple[wp]: sch_act_simple
   (simp: crunch_simps
    rule: sch_act_simple_lift
    wp: getObject_inv loadObject_default_inv crunch_wps)
 
-end
-
-
-lemma interrupt_cap_null_or_ntfn:
-  "invs s
-    \<Longrightarrow> cte_wp_at (\<lambda>cp. is_ntfn_cap cp \<or> cp = cap.NullCap) (interrupt_irq_node s irq, []) s"
-  apply (frule invs_valid_irq_node)
-  apply (clarsimp simp: valid_irq_node_def)
-  apply (drule_tac x=irq in spec)
-  apply (drule cte_at_0)
-  apply (clarsimp simp: cte_wp_at_caps_of_state)
-  apply (drule caps_of_state_cteD)
-  apply (frule if_unsafe_then_capD, clarsimp+)
-  apply (clarsimp simp: ex_cte_cap_wp_to_def cte_wp_at_caps_of_state)
-  apply (frule cte_refs_obj_refs_elem, erule disjE)
-   apply (clarsimp | drule caps_of_state_cteD valid_global_refsD[rotated]
-     | rule irq_node_global_refs[where irq=irq])+
-   apply (simp add: cap_range_def)
-  apply (clarsimp simp: appropriate_cte_cap_def
-                 split: cap.split_asm)
-  done
-
-lemma (in delete_one) deletingIRQHandler_corres:
-  "corres dc (einvs) (invs')
-          (deleting_irq_handler irq) (deletingIRQHandler irq)"
-  apply (simp add: deleting_irq_handler_def deletingIRQHandler_def)
-  apply (rule corres_guard_imp)
-    apply (rule corres_split[OF getIRQSlot_corres])
-      apply simp
-      apply (rule_tac P'="cte_at' (cte_map slot)" in corres_symb_exec_r_conj)
-         apply (rule_tac F="isNotificationCap rv \<or> rv = capability.NullCap"
-             and P="cte_wp_at (\<lambda>cp. is_ntfn_cap cp \<or> cp = cap.NullCap) slot
-                 and einvs"
-             and P'="invs' and cte_wp_at' (\<lambda>cte. cteCap cte = rv)
-                 (cte_map slot)" in corres_req)
-          apply (clarsimp simp: cte_wp_at_caps_of_state state_relation_def)
-          apply (drule caps_of_state_cteD)
-          apply (drule(1) pspace_relation_cte_wp_at, clarsimp+)
-          apply (auto simp: cte_wp_at_ctes_of is_cap_simps gen_isCap_simps)[1]
-         apply simp
-         apply (rule corres_guard_imp, rule delete_one_corres[unfolded dc_def])
-          apply (auto simp: cte_wp_at_caps_of_state is_cap_simps can_fast_finalise_def)[1]
-         apply (clarsimp simp: cte_wp_at_ctes_of)
-        apply (wp getCTE_wp' | simp add: getSlotCap_def)+
-     apply (wp | simp add: get_irq_slot_def getIRQSlot_def
-                           locateSlot_conv getInterruptState_def)+
-   apply (clarsimp simp: ex_cte_cap_wp_to_def interrupt_cap_null_or_ntfn)
-  apply (clarsimp simp: cte_wp_at_ctes_of)
-  done
-
-context begin interpretation Arch . (*FIXME: arch-split*)
-
 lemma sym_refs_vcpu_tcb:
   "\<lbrakk> ko_at (ArchObj (VCPU vcpu)) v s; vcpu_tcb vcpu = Some t; sym_refs (state_hyp_refs_of s) \<rbrakk> \<Longrightarrow>
-  \<exists>tcb. ko_at (TCB tcb) t s \<and> tcb_vcpu (tcb_arch tcb) = Some v"
+   \<exists>tcb. ko_at (TCB tcb) t s \<and> tcb_vcpu (tcb_arch tcb) = Some v"
   apply (drule (1) hyp_sym_refs_obj_atD)
   apply (clarsimp simp: obj_at_def hyp_refs_of_def)
   apply (rename_tac ko)
@@ -3923,21 +1459,19 @@ lemma sym_refs_vcpu_tcb:
   apply (case_tac koa; simp add: refs_of_a_def vcpu_tcb_refs_def split: option.splits)
   done
 
-lemma vcpuFinalise_corres [corres]:
-  "corres dc (invs and vcpu_at vcpu) (invs' and vcpu_at' vcpu) (vcpu_finalise vcpu) (vcpuFinalise vcpu)"
-  unfolding vcpuFinalise_def vcpu_finalise_def
-  apply (corresKsimp corres: getObject_vcpu_corres simp: vcpu_relation_def)
-     apply (wpsimp wp: get_vcpu_wp getVCPU_wp)+
-  apply (rule conjI)
-   apply clarsimp
-   apply (frule sym_refs_vcpu_tcb)
-     apply (simp add: vcpu_relation_def)
-    apply fastforce
-   apply (fastforce simp: obj_at_def vcpu_relation_def)
-  apply clarsimp
+lemma vcpuFinalise_corres[corres]:
+  "vcpu' = vcpu \<Longrightarrow>
+   corres dc (invs and vcpu_at vcpu) no_0_obj' (vcpu_finalise vcpu) (vcpuFinalise vcpu')"
+  apply (simp add: vcpuFinalise_def vcpu_finalise_def)
+  apply (corres corres: getObject_vcpu_corres
+                simp: vcpu_relation_def
+                wp: get_vcpu_wp getVCPU_wp
+         | corres_cases_both)+
+   apply (fastforce simp: obj_at_def in_omonad dest: sym_refs_vcpu_tcb)
+  apply (fastforce elim: vcpu_at_cross)
   done
 
-lemma arch_finaliseCap_corres:
+lemma arch_finaliseCap_corres[Finalise_R_3_assms]:
   "\<lbrakk> final_matters' (ArchObjectCap cap') \<Longrightarrow> final = final'; acap_relation cap cap' \<rbrakk>
      \<Longrightarrow> corres (\<lambda>r r'. cap_relation (fst r) (fst r') \<and> cap_relation (snd r) (snd r'))
            (\<lambda>s. invs s \<and> s \<turnstile> cap.ArchObjectCap cap
@@ -3950,7 +1484,7 @@ lemma arch_finaliseCap_corres:
            (arch_finalise_cap cap final) (Arch.finaliseCap cap' final')"
   apply (cases cap,
          simp_all add: arch_finalise_cap_def ARM_HYP_H.finaliseCap_def isCap_simps
-                       final_matters'_def case_bool_If liftM_def[symmetric]
+                       final_matters'_def arch_final_matters'_def case_bool_If liftM_def[symmetric]
                        o_def dc_def[symmetric]
                 split: option.split, safe)
      apply (rule corres_guard_imp, rule deleteASIDPool_corres)
@@ -3961,401 +1495,24 @@ lemma arch_finaliseCap_corres:
       apply simp
      apply (clarsimp simp: valid_cap_def valid_unmap_def)
      apply (auto simp: vmsz_aligned_def pbfs_atleast_pageBits mask_def
-                 elim: is_aligned_weaken invs_valid_asid_map)[2]
+                 elim: is_aligned_weaken)[2]
    apply (rule corres_guard_imp, rule unmapPageTable_corres)
     apply (auto simp: valid_cap_def valid_cap'_def mask_def
-               elim!: is_aligned_weaken invs_valid_asid_map)[2]
+               elim!: is_aligned_weaken)[2]
   apply (rule corres_guard_imp, rule deleteASID_corres)
-   apply (auto elim!: invs_valid_asid_map simp: mask_def valid_cap_def)[2]
+   apply (auto simp: mask_def valid_cap_def)[2]
   apply corresK
   apply (clarsimp simp: valid_cap_def valid_cap'_def)
   done
 
-lemma unbindNotification_corres:
-  "corres dc
-      (invs and tcb_at t)
-      (invs' and tcb_at' t)
-      (unbind_notification t)
-      (unbindNotification t)"
-  supply option.case_cong_weak[cong]
-  apply (simp add: unbind_notification_def unbindNotification_def)
-  apply (rule corres_guard_imp)
-    apply (rule corres_split[OF getBoundNotification_corres])
-      apply (rule corres_option_split)
-        apply simp
-       apply (rule corres_return_trivial)
-      apply (rule corres_split[OF getNotification_corres])
-        apply clarsimp
-        apply (rule corres_split[OF setNotification_corres])
-           apply (clarsimp simp: ntfn_relation_def split:Structures_A.ntfn.splits)
-          apply (rule setBoundNotification_corres)
-         apply (wp gbn_wp' gbn_wp)+
-   apply clarsimp
-   apply (frule invs_psp_aligned)
-   apply (frule invs_distinct)
-   apply (clarsimp elim!: obj_at_valid_objsE
-                   dest!: bound_tcb_at_state_refs_ofD invs_valid_objs
-                    simp: valid_obj_def is_tcb tcb_ntfn_is_bound_def
-                          valid_tcb_def valid_bound_ntfn_def
-                   split: option.splits)
-  apply (clarsimp dest!: obj_at_valid_objs' bound_tcb_at_state_refs_ofD' invs_valid_objs'
-                   simp: projectKOs valid_obj'_def valid_tcb'_def valid_bound_ntfn'_def
-                         tcb_ntfn_is_bound'_def
-                  split: option.splits)
-  done
+lemmas deleteCallerCap_typ_ats[wp] = typ_at_lifts[OF deleteCallerCap_typ_at']
 
-lemma unbindMaybeNotification_corres:
-  "corres dc
-      (invs and ntfn_at ntfnptr) (invs' and ntfn_at' ntfnptr)
-      (unbind_maybe_notification ntfnptr)
-      (unbindMaybeNotification ntfnptr)"
-  apply (simp add: unbind_maybe_notification_def unbindMaybeNotification_def
-              cong: option.case_cong)
-  apply (rule corres_guard_imp)
-    apply (rule corres_split[OF getNotification_corres])
-      apply (rule corres_option_split)
-        apply (clarsimp simp: ntfn_relation_def split: Structures_A.ntfn.splits)
-       apply (rule corres_return_trivial)
-      apply (rule corres_split[OF setNotification_corres])
-         apply (clarsimp simp: ntfn_relation_def split: Structures_A.ntfn.splits)
-        apply (rule setBoundNotification_corres)
-       apply (wp get_simple_ko_wp getNotification_wp)+
-   apply clarsimp
-   apply (frule invs_psp_aligned)
-   apply (frule invs_distinct)
-   apply (clarsimp elim!: obj_at_valid_objsE
-                   dest!: bound_tcb_at_state_refs_ofD invs_valid_objs
-                    simp: valid_obj_def is_tcb tcb_ntfn_is_bound_def
-                          valid_tcb_def valid_bound_ntfn_def valid_ntfn_def
-                   split: option.splits)
-  apply (clarsimp dest!: obj_at_valid_objs' bound_tcb_at_state_refs_ofD' invs_valid_objs'
-                   simp: projectKOs valid_obj'_def valid_tcb'_def valid_bound_ntfn'_def
-                         tcb_ntfn_is_bound'_def valid_ntfn'_def
-                  split: option.splits)
-  done
+end (* Arch *)
 
-lemma fast_finaliseCap_corres:
-  "\<lbrakk> final_matters' cap' \<longrightarrow> final = final'; cap_relation cap cap';
-     can_fast_finalise cap \<rbrakk>
-   \<Longrightarrow> corres dc
-           (\<lambda>s. invs s \<and> valid_sched s \<and> s \<turnstile> cap
-                       \<and> cte_wp_at ((=) cap) sl s)
-           (\<lambda>s. invs' s \<and> s \<turnstile>' cap')
-           (fast_finalise cap final)
-           (do
-               p \<leftarrow> finaliseCap cap' final' True;
-               assert (capRemovable (fst p) (cte_map ptr) \<and> snd p = NullCap)
-            od)"
-  apply (cases cap, simp_all add: finaliseCap_def isCap_simps
-                                  corres_liftM2_simp[unfolded liftM_def]
-                                  o_def dc_def[symmetric] when_def
-                                  can_fast_finalise_def capRemovable_def
-                       split del: if_split cong: if_cong)
-   apply (clarsimp simp: final_matters'_def)
-   apply (rule corres_guard_imp)
-     apply (rule corres_rel_imp)
-      apply (rule ep_cancel_corres)
-     apply simp
-    apply (simp add: valid_cap_def)
-   apply (simp add: valid_cap'_def)
-  apply (clarsimp simp: final_matters'_def)
-  apply (rule corres_guard_imp)
-    apply (rule corres_split[OF unbindMaybeNotification_corres])
-         apply (rule cancelAllSignals_corres)
-       apply (wp abs_typ_at_lifts unbind_maybe_notification_invs typ_at_lifts hoare_drop_imps getNotification_wp
-            | wpc)+
-   apply (clarsimp simp: valid_cap_def)
-  apply (clarsimp simp: valid_cap'_def projectKOs valid_obj'_def
-                 dest!: invs_valid_objs' obj_at_valid_objs' )
-  done
-
-lemma cap_delete_one_corres:
-  "corres dc (einvs and cte_wp_at can_fast_finalise ptr)
-        (invs' and cte_at' (cte_map ptr))
-        (cap_delete_one ptr) (cteDeleteOne (cte_map ptr))"
-  apply (simp add: cap_delete_one_def cteDeleteOne_def'
-                   unless_def when_def)
-  apply (rule corres_guard_imp)
-    apply (rule corres_split[OF get_cap_corres])
-      apply (rule_tac F="can_fast_finalise cap" in corres_gen_asm)
-      apply (rule corres_if)
-        apply fastforce
-       apply (rule corres_split[OF isFinalCapability_corres[where ptr=ptr]])
-         apply (simp add: split_def bind_assoc [THEN sym])
-         apply (rule corres_split[OF fast_finaliseCap_corres[where sl=ptr]])
-              apply simp+
-           apply (rule emptySlot_corres, simp)
-          apply (wp hoare_drop_imps)+
-       apply (wp isFinalCapability_inv | wp (once) isFinal[where x="cte_map ptr"])+
-      apply (rule corres_trivial, simp)
-     apply (wp get_cap_wp getCTE_wp)+
-   apply (clarsimp simp: cte_wp_at_caps_of_state can_fast_finalise_Null
-                  elim!: caps_of_state_valid_cap)
-  apply (clarsimp simp: cte_wp_at_ctes_of)
-  apply fastforce
-  done
-end
-(* FIXME: strengthen locale instead *)
-
-global_interpretation delete_one
-  apply unfold_locales
-  apply (rule corres_guard_imp)
-    apply (rule cap_delete_one_corres)
-   apply auto
-  done
-
-lemma no_idle_thread_cap:
-  "\<lbrakk> cte_wp_at ((=) (cap.ThreadCap (idle_thread s))) sl s; valid_global_refs s \<rbrakk> \<Longrightarrow> False"
-  apply (cases sl)
-  apply (clarsimp simp: valid_global_refs_def valid_refs_def cte_wp_at_caps_of_state)
-  apply ((erule allE)+, erule (1) impE)
-  apply (clarsimp simp: cap_range_def)
-  done
-
-lemmas getCTE_no_0_obj'_helper
-  = getCTE_inv
-    hoare_strengthen_post[where Q'="\<lambda>_. no_0_obj'" and P=no_0_obj' and f="getCTE slot" for slot]
-
-context begin interpretation Arch . (*FIXME: arch-split*)
-context
-notes option.case_cong_weak[cong]
-begin
-crunch ThreadDecls_H.suspend, unbindNotification
-  for no_0_obj'[wp]: no_0_obj'
-  (simp: crunch_simps wp: crunch_wps getCTE_no_0_obj'_helper)
-end
-end
-
-lemma finaliseCap_corres:
-  "\<lbrakk> final_matters' cap' \<Longrightarrow> final = final'; cap_relation cap cap';
-          flag \<longrightarrow> can_fast_finalise cap \<rbrakk>
-     \<Longrightarrow> corres (\<lambda>x y. cap_relation (fst x) (fst y) \<and> cap_relation (snd x) (snd y))
-           (\<lambda>s. einvs s \<and> s \<turnstile> cap \<and> (final_matters cap \<longrightarrow> final = is_final_cap' cap s)
-                       \<and> cte_wp_at ((=) cap) sl s)
-           (\<lambda>s. invs' s \<and> s \<turnstile>' cap' \<and> sch_act_simple s \<and>
-                 (final_matters' cap' \<longrightarrow>
-                      final' = isFinal cap' (cte_map sl) (cteCaps_of s)))
-           (finalise_cap cap final) (finaliseCap cap' final' flag)"
-  supply invs_no_0_obj'[simp]
-  apply (cases cap, simp_all add: finaliseCap_def gen_isCap_simps
-                                  corres_liftM2_simp[unfolded liftM_def]
-                                  o_def dc_def[symmetric] when_def
-                                  can_fast_finalise_def
-                       split del: if_split cong: if_cong)
-        apply (clarsimp simp: final_matters'_def)
-        apply (rule corres_guard_imp)
-          apply (rule ep_cancel_corres)
-         apply (simp add: valid_cap_def)
-        apply (simp add: valid_cap'_def)
-       apply (clarsimp simp add: final_matters'_def)
-       apply (rule corres_guard_imp)
-         apply (rule corres_split[OF unbindMaybeNotification_corres])
-           apply (rule cancelAllSignals_corres)
-          apply (wp abs_typ_at_lifts unbind_maybe_notification_invs gen_typ_at_lifts hoare_drop_imps hoare_vcg_all_lift | wpc)+
-        apply (clarsimp simp: valid_cap_def)
-       apply (clarsimp simp: valid_cap'_def)
-      apply (fastforce simp: final_matters'_def shiftL_nat zbits_map_def)
-     apply (clarsimp simp add: final_matters'_def getThreadCSpaceRoot
-                               liftM_def[symmetric] o_def zbits_map_def
-                               dc_def[symmetric])
-     apply (rename_tac t)
-     apply (rule_tac P="\<lambda>s. t \<noteq> idle_thread s" and P'="\<lambda>s. t \<noteq> ksIdleThread s" in corres_add_guard)
-      apply clarsimp
-      apply (rule context_conjI)
-       apply (clarsimp dest!: no_idle_thread_cap)
-      apply (clarsimp simp: state_relation_def)
-     apply (rule corres_guard_imp)
-       apply (rule corres_split[OF unbindNotification_corres])
-         apply (rule corres_split[OF suspend_corres])
-            apply (clarsimp simp: liftM_def[symmetric] o_def dc_def[symmetric] zbits_map_def)
-          apply (rule ARM_HYP.prepareThreadDelete_corres, rule refl) (* FIXME arch-split: interface *)
-        apply (wp unbind_notification_invs unbind_notification_simple_sched_action
-                  delete_one_conc_fr.suspend_objs')+
-      apply (simp add: valid_cap_def)
-     apply (simp add: valid_cap'_def)
-    apply (simp add: final_matters'_def liftM_def[symmetric] o_def dc_def[symmetric])
-    apply (intro impI, rule corres_guard_imp)
-      apply (rule deletingIRQHandler_corres)
-     apply simp
-    apply simp
-   apply (clarsimp simp: final_matters'_def)
-   apply (rule_tac F="False" in corres_req)
-    apply clarsimp
-    apply (frule zombies_finalD, (clarsimp simp: is_cap_simps)+)
-    apply (clarsimp simp: cte_wp_at_caps_of_state)
-   apply simp
-  apply (clarsimp split del: if_split simp: o_def)
-  apply (rule corres_guard_imp [OF arch_finaliseCap_corres], (fastforce simp: valid_sched_def)+)
-  done
-
-context begin interpretation Arch . (*FIXME: arch-split*)
-lemma arch_recycleCap_improve_cases:
-   "\<lbrakk> \<not> isPageCap cap; \<not> isPageTableCap cap; \<not> isPageDirectoryCap cap;\<not> isVCPUCap cap;
-         \<not> isASIDControlCap cap; \<not>isSGISignalCap cap \<rbrakk> \<Longrightarrow>
-  (if isASIDPoolCap cap then v else undefined) = v"
-  by (cases cap, simp_all add: isCap_simps)
-
-crunch copyGlobalMappings
-  for ifunsafe'[wp]: "if_unsafe_then_cap'"
-  (wp: crunch_wps ignore: storePDE)
-
-lemma copyGlobalMappings_pde_mappings2':
-  "\<lbrace>valid_pde_mappings' and valid_arch_state'
-            and K (is_aligned pd pdBits)\<rbrace>
-      copyGlobalMappings pd \<lbrace>\<lambda>rv. valid_pde_mappings'\<rbrace>"
-  apply (wp copyGlobalMappings_pde_mappings')
-  apply (clarsimp simp: valid_arch_state'_def page_directory_at'_def)
-  done
-
-crunch copyGlobalMappings
-  for pred_tcb_at'[wp]: "pred_tcb_at' proj P t"
-  (wp: crunch_wps ignore: storePDE)
-
-crunch copyGlobalMappings
-  for vms'[wp]: "valid_machine_state'"
-  (wp: crunch_wps ignore: storePDE)
-
-crunch copyGlobalMappings
-  for ct_not_inQ[wp]: "ct_not_inQ"
-  (wp: crunch_wps ignore: storePDE)
-
-crunch copyGlobalMappings
-  for tcb_in_cur_domain'[wp]: "tcb_in_cur_domain' t"
-  (wp: crunch_wps)
-
-crunch copyGlobalMappings
-  for ct__in_cur_domain'[wp]: ct_idle_or_in_cur_domain'
-  (wp: crunch_wps)
-
-crunch copyGlobalMappings
-  for gsUntypedZeroRanges[wp]: "\<lambda>s. P (gsUntypedZeroRanges s)"
-  (wp: crunch_wps)
-
-lemma threadSet_ct_idle_or_in_cur_domain':
-  "\<lbrace>ct_idle_or_in_cur_domain' and (\<lambda>s. \<forall>tcb. tcbDomain tcb = ksCurDomain s \<longrightarrow> tcbDomain (F tcb) = ksCurDomain s)\<rbrace>
-    threadSet F t
-   \<lbrace>\<lambda>_. ct_idle_or_in_cur_domain'\<rbrace>"
-apply (simp add: ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def)
-apply (wp hoare_vcg_disj_lift hoare_vcg_imp_lift)
-  apply wps
-  apply wp
- apply wps
- apply wp
-apply (auto simp: obj_at'_def)
-done
-
-crunch invalidateTLBByASID
-  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-crunch invalidateTLBByASID
-  for valid_arch_state'[wp]: "valid_arch_state'"
-lemmas invalidateTLBByASID_typ_ats[wp] = typ_at_lifts [OF invalidateTLBByASID_typ_at']
-
-lemma cte_wp_at_norm_eq':
-  "cte_wp_at' P p s = (\<exists>cte. cte_wp_at' ((=) cte) p s \<and> P cte)"
-  by (simp add: cte_wp_at_ctes_of)
-
-lemma isFinal_cte_wp_def:
-  "isFinal cap p (cteCaps_of s) =
-  (\<not>isUntypedCap cap \<and>
-   (\<forall>p'. p \<noteq> p' \<longrightarrow>
-         cte_at' p' s \<longrightarrow>
-         cte_wp_at' (\<lambda>cte'. \<not> isUntypedCap (cteCap cte') \<longrightarrow>
-                            \<not> sameObjectAs cap (cteCap cte')) p' s))"
-  apply (simp add: isFinal_def cte_wp_at_ctes_of cteCaps_of_def)
-  apply (rule iffI)
-   apply clarsimp
-   apply (case_tac cte)
-   apply fastforce
-  apply fastforce
-  done
-
-lemma valid_cte_at_neg_typ':
-  assumes T: "\<And>P T p. \<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace> f \<lbrace>\<lambda>_ s. P (typ_at' T p s)\<rbrace>"
-  shows "\<lbrace>\<lambda>s. \<not> cte_at' p' s\<rbrace> f \<lbrace>\<lambda>rv s. \<not> cte_at' p' s\<rbrace>"
-  apply (simp add: cte_at_typ')
-  apply (rule hoare_vcg_conj_lift [OF T])
-  apply (simp only: imp_conv_disj)
-  apply (rule hoare_vcg_all_lift)
-  apply (rule hoare_vcg_disj_lift [OF T])
-  apply (rule hoare_vcg_prop)
-  done
-
-lemma isFinal_lift:
-  assumes x: "\<And>P p. \<lbrace>cte_wp_at' P p\<rbrace> f \<lbrace>\<lambda>_. cte_wp_at' P p\<rbrace>"
-  assumes y: "\<And>P T p. \<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace> f \<lbrace>\<lambda>_ s. P (typ_at' T p s)\<rbrace>"
-  shows "\<lbrace>\<lambda>s. cte_wp_at' (\<lambda>cte. isFinal (cteCap cte) sl (cteCaps_of s)) sl s\<rbrace>
-         f
-         \<lbrace>\<lambda>r s. cte_wp_at' (\<lambda>cte. isFinal (cteCap cte) sl (cteCaps_of s)) sl s\<rbrace>"
-  apply (subst cte_wp_at_norm_eq')
-  apply (subst cte_wp_at_norm_eq' [where P="\<lambda>cte. isFinal (cteCap cte) sl m" for sl m])
-  apply (simp only: isFinal_cte_wp_def imp_conv_disj de_Morgan_conj)
-  apply (wp hoare_vcg_ex_lift hoare_vcg_all_lift x hoare_vcg_disj_lift
-            valid_cte_at_neg_typ' [OF y])
-  done
-
-crunch invalidateTLBByASID
-  for cteCaps_of: "\<lambda>s. P (cteCaps_of s)"
-
-lemma cteCaps_of_ctes_of_lift:
-  "(\<And>P. \<lbrace>\<lambda>s. P (ctes_of s)\<rbrace> f \<lbrace>\<lambda>_ s. P (ctes_of s)\<rbrace>) \<Longrightarrow> \<lbrace>\<lambda>s. P (cteCaps_of s) \<rbrace> f \<lbrace>\<lambda>_ s. P (cteCaps_of s)\<rbrace>"
-  unfolding cteCaps_of_def .
-
-lemmas final_matters'_simps = final_matters'_def [split_simps capability.split arch_capability.split]
-
-crunch deleteCallerCap
-  for idle_thread[wp]: "\<lambda>s. P (ksIdleThread s)"
-  (wp: crunch_wps)
-crunch deleteCallerCap
-  for sch_act_simple: sch_act_simple
-  (wp: crunch_wps)
-crunch deleteCallerCap
-  for sch_act_not[wp]: "sch_act_not t"
-  (wp: crunch_wps)
-crunch deleteCallerCap
-  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  (wp: crunch_wps)
-lemmas deleteCallerCap_typ_ats[wp] = typ_at_lifts [OF deleteCallerCap_typ_at']
-
-crunch emptySlot
-  for ksQ[wp]: "\<lambda>s. P (ksReadyQueues s p)"
-
-lemma setEndpoint_sch_act_not_ct[wp]:
-  "\<lbrace>\<lambda>s. sch_act_not (ksCurThread s) s\<rbrace>
-   setEndpoint ptr val \<lbrace>\<lambda>_ s. sch_act_not (ksCurThread s) s\<rbrace>"
-  by (rule hoare_weaken_pre, wps, wp, simp)
-
-lemma sbn_ct_in_state'[wp]:
-  "\<lbrace>ct_in_state' P\<rbrace> setBoundNotification ntfn t \<lbrace>\<lambda>_. ct_in_state' P\<rbrace>"
-  apply (simp add: ct_in_state'_def)
-  apply (rule hoare_pre)
-   apply (wps setBoundNotification_ct')
-  apply (wp sbn_st_tcb', clarsimp)
-  done
-
-lemma set_ntfn_ct_in_state'[wp]:
-  "\<lbrace>ct_in_state' P\<rbrace> setNotification a ntfn \<lbrace>\<lambda>_. ct_in_state' P\<rbrace>"
-  apply (simp add: ct_in_state'_def)
-  apply (rule hoare_pre)
-   apply (wps setNotification_ksCurThread, wp, clarsimp)
-  done
-
-lemma unbindMaybeNotification_ct_in_state'[wp]:
-  "\<lbrace>ct_in_state' P\<rbrace> unbindMaybeNotification t \<lbrace>\<lambda>_. ct_in_state' P\<rbrace>"
-  apply (simp add: unbindMaybeNotification_def)
-  apply (wp | wpc | simp)+
-  done
-
-lemma setNotification_sch_act_sane:
-  "\<lbrace>sch_act_sane\<rbrace> setNotification a ntfn \<lbrace>\<lambda>_. sch_act_sane\<rbrace>"
-  by (wp sch_act_sane_lift)
-
-
-lemma unbindMaybeNotification_sch_act_sane[wp]:
-  "\<lbrace>sch_act_sane\<rbrace> unbindMaybeNotification t \<lbrace>\<lambda>_. sch_act_sane\<rbrace>"
-  apply (simp add: unbindMaybeNotification_def)
-  apply (wp setNotification_sch_act_sane sbn_sch_act_sane | wpc | clarsimp)+
-  done
-
-end
+interpretation Finalise_R_3?: Finalise_R_3 arch_final_matters' arch_cap_has_cleanup'
+proof goal_cases
+  interpret Arch  .
+  case 1 show ?case by (intro_locales; (unfold_locales; (fact Finalise_R_3_assms)?)?)
+qed
 
 end

--- a/proof/refine/ARM_HYP/ArchIpcCancel_R.thy
+++ b/proof/refine/ARM_HYP/ArchIpcCancel_R.thy
@@ -137,7 +137,7 @@ lemma sym_refs_tcb_vcpu:
   apply (case_tac koa; simp add: vcpu_tcb_refs_def split: option.splits)
   done
 
-lemma prepareThreadDelete_corres[corres]:
+lemma prepareThreadDelete_corres[IpcCancel_R_assms, corres]:
   "t' = t \<Longrightarrow>
    corres dc (invs and tcb_at t) no_0_obj'
           (prepare_thread_delete t) (prepareThreadDelete t')"

--- a/proof/refine/ARM_HYP/ArchMachine_R.thy
+++ b/proof/refine/ARM_HYP/ArchMachine_R.thy
@@ -51,10 +51,8 @@ lemma dmo_maskInterrupt_True:
                    ct_not_inQ_def ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def)
   done
 
-lemma setIRQState_irq_states':
-  "\<lbrace>valid_irq_states'\<rbrace>
-      setIRQState state irq
-   \<lbrace>\<lambda>rv. valid_irq_states'\<rbrace>"
+lemma setIRQState_irq_states'[Machine_R_assms, wp]:
+  "setIRQState state irq \<lbrace>valid_irq_states'\<rbrace>"
   apply (simp add: setIRQState_def setInterruptState_def getInterruptState_def)
   apply (wp dmo_maskInterrupt)
   apply (simp add: valid_irq_masks'_def)

--- a/proof/refine/ARM_HYP/ArchTcbAcc_R.thy
+++ b/proof/refine/ARM_HYP/ArchTcbAcc_R.thy
@@ -1020,15 +1020,7 @@ lemma setThreadState_state_hyp_refs_of'[TcbAcc_R_2_assms, wp]:
         | wp threadSet_state_hyp_refs_of' hoare_drop_imps)+
   done
 
-lemma setBoundNotification_state_refs_of'[wp]:
-  "\<lbrace>\<lambda>s. P ((state_refs_of' s) (t := tcb_bound_refs' ntfn
-                                 \<union> {r \<in> state_refs_of' s t. snd r \<noteq> TCBBound}))\<rbrace>
-     setBoundNotification ntfn t
-   \<lbrace>\<lambda>rv s. P (state_refs_of' s)\<rbrace>"
-  by (simp add: setBoundNotification_def Un_commute fun_upd_def
-        | wp threadSet_state_refs_of' )+
-
-lemma setBoundNotification_state_hyp_refs_of'[wp]:
+lemma setBoundNotification_state_hyp_refs_of'[TcbAcc_R_2_assms, wp]:
   "\<lbrace>\<lambda>s. P (state_hyp_refs_of' s)\<rbrace>
      setBoundNotification ntfn t
    \<lbrace>\<lambda>rv s. P (state_hyp_refs_of' s)\<rbrace>"
@@ -1053,7 +1045,7 @@ lemma tcbQueued_update_iflive'[TcbAcc_R_2_assms, wp]:
    \<lbrace>\<lambda>_. if_live_then_nonz_cap'\<rbrace>"
   by (wpsimp wp: threadSet_iflive'T simp: update_tcb_cte_cases)
 
-lemma sbn_iflive'[wp]:
+lemma sbn_iflive'[TcbAcc_R_2_assms, wp]:
   "\<lbrace>\<lambda>s. if_live_then_nonz_cap' s
       \<and> (bound ntfn \<longrightarrow> ex_nonz_cap_to' t s)\<rbrace>
    setBoundNotification ntfn t

--- a/proof/refine/ARM_HYP/Arch_R.thy
+++ b/proof/refine/ARM_HYP/Arch_R.thy
@@ -10,7 +10,7 @@
 *)
 
 theory Arch_R
-imports Untyped_R Finalise_R
+imports Untyped_R ArchFinalise_R
 begin
 
 unbundle l4v_word_context

--- a/proof/refine/ARM_HYP/Arch_R.thy
+++ b/proof/refine/ARM_HYP/Arch_R.thy
@@ -1169,7 +1169,7 @@ shows
                   in corres_gen_asm2)
          apply (rule corres_split[OF isFinalCapability_corres[where ptr=slot]])
            apply (drule mp)
-            apply (clarsimp simp: isCap_simps final_matters'_def)
+            apply (clarsimp simp: isCap_simps final_matters'_def arch_final_matters'_def)
            apply (rule whenE_throwError_corres)
              apply simp
             apply simp
@@ -2098,13 +2098,9 @@ crunch "Arch.finaliseCap"
   for aligned': pspace_aligned'
   (wp: crunch_wps getASID_wp simp: crunch_simps)
 
-lemmas arch_finalise_cap_aligned' = finaliseCap_aligned'
-
 crunch "Arch.finaliseCap"
   for distinct': pspace_distinct'
   (wp: crunch_wps getASID_wp simp: crunch_simps)
-
-lemmas arch_finalise_cap_distinct' = finaliseCap_distinct'
 
 crunch "Arch.finaliseCap"
   for nosch[wp]: "\<lambda>s. P (ksSchedulerAction s)"

--- a/proof/refine/ARM_HYP/CNodeInv_R.thy
+++ b/proof/refine/ARM_HYP/CNodeInv_R.thy
@@ -321,7 +321,7 @@ lemma decodeCNodeInvocation_corres:
                  apply (intro conjI)
                   apply (erule cap_map_update_data)+
                 apply (wp hoare_drop_imps)+
-          apply simp
+          apply (simp cong: if_cong)
           apply (wp lsfco_cte_at' lookup_cap_valid lookup_cap_valid')
          apply (simp add: if_apply_def2)
          apply (wp hoare_drop_imps)
@@ -5691,6 +5691,7 @@ lemma make_zombie_invs':
                                               \<and> tcbSchedPrev tcb = None) p s)) sl s\<rbrace>
     updateCap sl cap
   \<lbrace>\<lambda>rv. invs'\<rbrace>"
+  supply if_cong[cong]
   apply (simp add: invs'_def valid_state'_def valid_pspace'_def valid_mdb'_def
                    valid_irq_handlers'_def irq_issued'_def)
   apply (wp updateCap_ctes_of_wp sch_act_wf_lift valid_queues_lift cur_tcb_lift
@@ -6799,6 +6800,8 @@ lemma capSwap_rvk_prog:
   apply arith
   done
 
+lemmas ctes_of_cteCaps_of_lift = cteCaps_of_ctes_of_lift (* FIXME *)
+
 lemmas cancelAllIPC_cteCaps_of[wp] = ctes_of_cteCaps_of_lift [OF cancelAllIPC_ctes_of]
 lemmas cancelAllSignals_cteCaps_of[wp] = ctes_of_cteCaps_of_lift [OF cancelAllSignals_ctes_of]
 lemmas setEndpoint_cteCaps_of[wp] = ctes_of_cteCaps_of_lift [OF set_ep_ctes_of]
@@ -6824,16 +6827,12 @@ lemma vcpuFinalise_rvk_prog':
   "vcpuFinalise v \<lbrace>\<lambda>s. revoke_progress_ord m (\<lambda>x. map_option capToRPO (cteCaps_of s x))\<rbrace>"
   by (wpsimp simp: cteCaps_of_def)
 
-context
-notes option.case_cong_weak[cong]
-begin
 crunch finaliseCap
   for rvk_prog': "\<lambda>s. revoke_progress_ord m (\<lambda>x. option_map capToRPO (cteCaps_of s x))"
   (wp: crunch_wps threadSet_ctesCaps_of getObject_inv
-       loadObject_default_inv dissociateVCPUTCB_isFinal
+       loadObject_default_inv ctes_of_cteCaps_of_lift[OF dissociateVCPUTCB_ctes_of]
    simp: crunch_simps o_def
    ignore: threadSet)
-end
 
 lemmas finalise_induct3 = finaliseSlot'.induct[where P=
     "\<lambda>sl exp s. P sl (finaliseSlot' sl exp) s" for P]

--- a/proof/refine/ARM_HYP/EmptyFail_H.thy
+++ b/proof/refine/ARM_HYP/EmptyFail_H.thy
@@ -105,8 +105,7 @@ lemma ArchRetypeDecls_H_deriveCap_empty_fail[intro!, wp, simp]:
   "isPageTableCap y \<or> isPageDirectoryCap y \<or> isPageCap y
    \<or> isASIDControlCap y \<or> isASIDPoolCap y \<or> isVCPUCap y \<or> isSGISignalCap y
    \<Longrightarrow> empty_fail (Arch.deriveCap x y)"
-  apply (simp add: ARM_HYP_H.deriveCap_def)
-  by auto
+  by (auto simp: ARM_HYP_H.deriveCap_def cong: if_cong)
 
 crunch ensureNoChildren
   for (empty_fail) empty_fail[intro!, wp, simp]
@@ -274,6 +273,7 @@ crunch
 
 lemma ThreadDecls_H_schedule_empty_fail[intro!, wp, simp]:
   "empty_fail schedule"
+  supply if_cong[cong]
   apply (simp add: schedule_def)
   apply (clarsimp simp: scheduleChooseNewThread_def split: if_split | wp | wpc)+
   done

--- a/proof/refine/ARM_HYP/Interrupt_R.thy
+++ b/proof/refine/ARM_HYP/Interrupt_R.thy
@@ -415,6 +415,7 @@ lemma invokeIRQHandler_corres:
              (invs' and irq_handler_inv_valid' i')
      (invoke_irq_handler i)
      (InterruptDecls_H.invokeIRQHandler i')"
+  supply if_cong[cong]
   apply (cases i; simp add: Interrupt_H.invokeIRQHandler_def invokeIRQHandler_def theIRQ_def
                        split del: if_split)
     apply (corres corres: corres_machine_op)
@@ -695,6 +696,7 @@ lemma timerTick_corres:
   "corres dc
      (cur_tcb and valid_sched and pspace_aligned and pspace_distinct) invs'
      timer_tick timerTick"
+  supply if_cong[cong]
   apply (simp add: timerTick_def timer_tick_def)
   apply (simp add: thread_state_case_if threadState_case_if)
   apply (rule_tac Q="cur_tcb and valid_sched and pspace_aligned and pspace_distinct"

--- a/proof/refine/ARM_HYP/Ipc_R.thy
+++ b/proof/refine/ARM_HYP/Ipc_R.thy
@@ -3764,13 +3764,9 @@ crunch setupCallerCap
   for irq_states'[wp]: valid_irq_states'
   (wp: crunch_wps)
 
-context notes if_cong[cong] begin
-
 crunch setupCallerCap
   for pde_mappings'[wp]: valid_pde_mappings'
-  (wp: crunch_wps)
-
-end
+  (wp: crunch_wps cong: if_cong)
 
 crunch receiveIPC
   for irqs_masked'[wp]: "irqs_masked'"

--- a/proof/refine/ARM_HYP/Ipc_R.thy
+++ b/proof/refine/ARM_HYP/Ipc_R.thy
@@ -5,7 +5,7 @@
  *)
 
 theory Ipc_R
-imports Finalise_R
+imports ArchFinalise_R
 begin
 
 context begin interpretation Arch . (*FIXME: arch-split*)

--- a/proof/refine/ARM_HYP/Ipc_R.thy
+++ b/proof/refine/ARM_HYP/Ipc_R.thy
@@ -633,6 +633,7 @@ lemma cteInsert_weak_cte_wp_at2:
     "\<lbrace>\<lambda>s. if p = dest then P cap else cte_wp_at' (\<lambda>c. P (cteCap c)) p s\<rbrace>
      cteInsert cap src dest
      \<lbrace>\<lambda>uu. cte_wp_at' (\<lambda>c. P (cteCap c)) p\<rbrace>"
+  supply if_cong[cong]
   apply (rule hoare_pre)
    apply (rule hoare_use_eq_irq_node' [OF cteInsert_ksInterruptState])
    apply (clarsimp simp:cteInsert_def)
@@ -1476,6 +1477,7 @@ lemma doNormalTransfer_corres:
    and case_option \<top> valid_ipc_buffer_ptr' recv_buf)
   (do_normal_transfer sender send_buf ep badge can_grant receiver recv_buf)
   (doNormalTransfer sender send_buf ep badge can_grant receiver recv_buf)"
+  supply if_cong[cong]
   apply (simp add: do_normal_transfer_def doNormalTransfer_def)
   apply (rule corres_guard_imp)
     apply (rule corres_split_mapr[OF getMessageInfo_corres])
@@ -2723,6 +2725,7 @@ crunch as_user
 lemma sendSignal_corres:
   "corres dc (einvs and ntfn_at ep) (invs' and ntfn_at' ep)
              (send_signal ep bg) (sendSignal ep bg)"
+  supply if_cong[cong]
   apply (simp add: send_signal_def sendSignal_def Let_def)
   apply (rule corres_guard_imp)
     apply (rule corres_split[OF getNotification_corres,
@@ -3706,6 +3709,7 @@ lemma cteInsert_cap_to':
   "\<lbrace>ex_nonz_cap_to' p and cte_wp_at' (\<lambda>c. cteCap c = NullCap) dest\<rbrace>
      cteInsert cap src dest
    \<lbrace>\<lambda>rv. ex_nonz_cap_to' p\<rbrace>"
+  supply if_cong[cong]
   apply (simp add: cteInsert_def ex_nonz_cap_to'_def updateCap_def setUntypedCapAsFull_def)
   apply (wpsimp wp: updateMDB_weak_cte_wp_at setCTE_weak_cte_wp_at hoare_vcg_ex_lift
          | rule hoare_drop_imps
@@ -3760,9 +3764,13 @@ crunch setupCallerCap
   for irq_states'[wp]: valid_irq_states'
   (wp: crunch_wps)
 
+context notes if_cong[cong] begin
+
 crunch setupCallerCap
   for pde_mappings'[wp]: valid_pde_mappings'
   (wp: crunch_wps)
+
+end
 
 crunch receiveIPC
   for irqs_masked'[wp]: "irqs_masked'"
@@ -4188,6 +4196,7 @@ lemma si_invs'[wp]:
   sendIPC bl call ba cg cgr t ep
   \<lbrace>\<lambda>rv. invs'\<rbrace>"
   supply if_split[split del]
+  supply if_cong[cong]
   apply (simp add: sendIPC_def split del: if_split)
   apply (rule bind_wp [OF _ get_ep_sp'])
   apply (case_tac epa)

--- a/proof/refine/ARM_HYP/Syscall_R.thy
+++ b/proof/refine/ARM_HYP/Syscall_R.thy
@@ -1386,12 +1386,9 @@ crunch rescheduleRequired
   for valid_duplicates'[wp]: "\<lambda>s. vs_valid_duplicates' (ksPSpace s)"
   (wp: setObject_ksInterrupt updateObject_default_inv)
 
-context notes if_cong[cong] begin
-
 crunch setThreadState
   for valid_duplicates'[wp]: "\<lambda>s. vs_valid_duplicates' (ksPSpace s)"
-
-end
+  (cong: if_cong)
 
 crunch reply_from_kernel
   for pspace_aligned[wp]: pspace_aligned

--- a/proof/refine/ARM_HYP/Syscall_R.thy
+++ b/proof/refine/ARM_HYP/Syscall_R.thy
@@ -682,6 +682,7 @@ lemma pinv_tcb'[wp]:
 
 lemma sts_cte_at[wp]:
   "\<lbrace>cte_at' p\<rbrace> setThreadState st t \<lbrace>\<lambda>rv. cte_at' p\<rbrace>"
+  supply if_cong[cong]
   apply (simp add: setThreadState_def)
   apply (wp|simp)+
   done
@@ -695,6 +696,7 @@ lemma sts_mcpriority_tcb_at'[wp]:
   "\<lbrace>mcpriority_tcb_at' P t\<rbrace>
     setThreadState st t'
    \<lbrace>\<lambda>_. mcpriority_tcb_at' P t\<rbrace>"
+  supply if_cong[cong]
   apply (cases "t = t'",
          simp_all add: setThreadState_def
                   split del: if_split)
@@ -768,6 +770,7 @@ lemma decodeDomainSetStart_inv_wf[wp]:
 lemma decodeDomainConfigure_inv_wf[wp]:
   "\<lbrace>\<top>\<rbrace> decodeDomainConfigure args excaps \<lbrace>valid_domain_inv'\<rbrace>, -"
   unfolding decodeDomainConfigure_def
+  supply if_cong[cong]
   apply (wpsimp simp: valid_domain_inv'_def split_del: if_split)
   apply (clarsimp simp: not_less not_le le_maxDomain_eq_less_numDomains unat_ucast)
   using numDomains_fits_domainBits
@@ -1383,8 +1386,12 @@ crunch rescheduleRequired
   for valid_duplicates'[wp]: "\<lambda>s. vs_valid_duplicates' (ksPSpace s)"
   (wp: setObject_ksInterrupt updateObject_default_inv)
 
+context notes if_cong[cong] begin
+
 crunch setThreadState
   for valid_duplicates'[wp]: "\<lambda>s. vs_valid_duplicates' (ksPSpace s)"
+
+end
 
 crunch reply_from_kernel
   for pspace_aligned[wp]: pspace_aligned

--- a/proof/refine/Finalise_R.thy
+++ b/proof/refine/Finalise_R.thy
@@ -1,0 +1,16 @@
+(*
+ * Copyright 2014, General Dynamics C4 Systems
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ * Copyright 2023, Proofcraft Pty Ltd
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory Finalise_R
+imports
+  ArchIpcCancel_R
+  InterruptAcc_R
+  ArchRetype_R
+begin
+
+end

--- a/proof/refine/Finalise_R.thy
+++ b/proof/refine/Finalise_R.thy
@@ -13,4 +13,3011 @@ imports
   ArchRetype_R
 begin
 
+arch_requalify_facts
+  emptySlot_pred_tcb_at' (* can't be in locale assumptions due to free type variable *)
+
+lemmas [wp] = emptySlot_pred_tcb_at'
+
+lemma nullPointer_eq_0_simp[simp]: (* FIXME: move to nullPointer_0_simp in Retype_R *)
+  "(0 = nullPointer) = True"
+  by (simp add: nullPointer_def)+
+
+lemma no_0_no_0_lhs_trancl [simp]:
+  "no_0 m \<Longrightarrow> \<not> m \<turnstile> 0 \<leadsto>\<^sup>+ x"
+  by (rule, drule tranclD, clarsimp simp: next_unfold')
+
+lemma no_0_no_0_lhs_rtrancl [simp]:
+  "\<lbrakk> no_0 m; x \<noteq> 0 \<rbrakk> \<Longrightarrow> \<not> m \<turnstile> 0 \<leadsto>\<^sup>* x"
+  by (clarsimp dest!: rtranclD)
+
+locale mdb_empty =
+  mdb_ptr?: mdb_ptr m _ _ slot s_cap s_node
+    for m slot s_cap s_node +
+
+  fixes n
+  defines "n \<equiv>
+           modify_map
+             (modify_map
+               (modify_map
+                 (modify_map m (mdbPrev s_node)
+                   (cteMDBNode_update (mdbNext_update (%_. (mdbNext s_node)))))
+                 (mdbNext s_node)
+                 (cteMDBNode_update
+                   (\<lambda>mdb. mdbFirstBadged_update (%_. (mdbFirstBadged mdb \<or> mdbFirstBadged s_node))
+                           (mdbPrev_update (%_. (mdbPrev s_node)) mdb))))
+               slot (cteCap_update (%_. capability.NullCap)))
+              slot (cteMDBNode_update (const nullMDBNode))"
+begin
+
+lemmas m_slot_prev = m_p_prev
+lemmas m_slot_next = m_p_next
+lemmas prev_slot_next = prev_p_next
+lemmas next_slot_prev = next_p_prev
+
+lemma n_revokable:
+  "n p = Some (CTE cap node) \<Longrightarrow>
+  (\<exists>cap' node'. m p = Some (CTE cap' node') \<and>
+              (if p = slot
+               then \<not> mdbRevocable node
+               else mdbRevocable node = mdbRevocable node'))"
+  by (auto simp add: n_def modify_map_if nullMDBNode_def split: if_split_asm)
+
+lemma m_revokable:
+  "m p = Some (CTE cap node) \<Longrightarrow>
+  (\<exists>cap' node'. n p = Some (CTE cap' node') \<and>
+              (if p = slot
+               then \<not> mdbRevocable node'
+               else mdbRevocable node' = mdbRevocable node))"
+  apply (clarsimp simp add: n_def modify_map_if nullMDBNode_def split: if_split_asm)
+  apply (cases "p=slot", simp)
+  apply (cases "p=mdbNext s_node", simp)
+   apply (cases "p=mdbPrev s_node", simp)
+   apply clarsimp
+  apply simp
+  apply (cases "p=mdbPrev s_node", simp)
+  apply simp
+  done
+
+lemma no_0_n:
+  "no_0 n"
+  using no_0 by (simp add: n_def)
+
+lemma n_next:
+  "n p = Some (CTE cap node) \<Longrightarrow>
+  (\<exists>cap' node'. m p = Some (CTE cap' node') \<and>
+              (if p = slot
+               then mdbNext node = 0
+               else if p = mdbPrev s_node
+               then mdbNext node = mdbNext s_node
+               else mdbNext node = mdbNext node'))"
+  apply (subgoal_tac "p \<noteq> 0")
+   prefer 2
+   apply (insert no_0_n)[1]
+   apply clarsimp
+  apply (cases "p = slot")
+   apply (clarsimp simp: n_def modify_map_if initMDBNode_def split: if_split_asm)
+  apply (cases "p = mdbPrev s_node")
+   apply (auto simp: n_def modify_map_if initMDBNode_def split: if_split_asm)
+  done
+
+lemma n_prev:
+  "n p = Some (CTE cap node) \<Longrightarrow>
+  (\<exists>cap' node'. m p = Some (CTE cap' node') \<and>
+              (if p = slot
+               then mdbPrev node = 0
+               else if p = mdbNext s_node
+               then mdbPrev node = mdbPrev s_node
+               else mdbPrev node = mdbPrev node'))"
+  apply (subgoal_tac "p \<noteq> 0")
+   prefer 2
+   apply (insert no_0_n)[1]
+   apply clarsimp
+  apply (cases "p = slot")
+   apply (clarsimp simp: n_def modify_map_if initMDBNode_def split: if_split_asm)
+  apply (cases "p = mdbNext s_node")
+   apply (auto simp: n_def modify_map_if initMDBNode_def split: if_split_asm)
+  done
+
+lemma n_cap:
+  "n p = Some (CTE cap node) \<Longrightarrow>
+  \<exists>cap' node'. m p = Some (CTE cap' node') \<and>
+              (if p = slot
+               then cap = NullCap
+               else cap' = cap)"
+  apply (clarsimp simp: n_def modify_map_if initMDBNode_def split: if_split_asm)
+   apply (cases node)
+   apply auto
+  done
+
+lemma m_cap:
+  "m p = Some (CTE cap node) \<Longrightarrow>
+  \<exists>cap' node'. n p = Some (CTE cap' node') \<and>
+              (if p = slot
+               then cap' = NullCap
+               else cap' = cap)"
+  apply (clarsimp simp: n_def modify_map_cases initMDBNode_def)
+  apply (cases node)
+  apply clarsimp
+  apply (cases "p=slot", simp)
+  apply clarsimp
+  apply (cases "mdbNext s_node = p", simp)
+   apply fastforce
+  apply simp
+  apply (cases "mdbPrev s_node = p", simp)
+  apply fastforce
+  done
+
+lemma n_badged:
+  "n p = Some (CTE cap node) \<Longrightarrow>
+  \<exists>cap' node'. m p = Some (CTE cap' node') \<and>
+              (if p = slot
+               then \<not> mdbFirstBadged node
+               else if p = mdbNext s_node
+               then mdbFirstBadged node = (mdbFirstBadged node' \<or> mdbFirstBadged s_node)
+               else mdbFirstBadged node = mdbFirstBadged node')"
+  apply (subgoal_tac "p \<noteq> 0")
+   prefer 2
+   apply (insert no_0_n)[1]
+   apply clarsimp
+  apply (cases "p = slot")
+   apply (clarsimp simp: n_def modify_map_if initMDBNode_def split: if_split_asm)
+  apply (cases "p = mdbNext s_node")
+   apply (auto simp: n_def modify_map_if nullMDBNode_def split: if_split_asm)
+  done
+
+lemma m_badged:
+  "m p = Some (CTE cap node) \<Longrightarrow>
+  \<exists>cap' node'. n p = Some (CTE cap' node') \<and>
+              (if p = slot
+               then \<not> mdbFirstBadged node'
+               else if p = mdbNext s_node
+               then mdbFirstBadged node' = (mdbFirstBadged node \<or> mdbFirstBadged s_node)
+               else mdbFirstBadged node' = mdbFirstBadged node)"
+  apply (subgoal_tac "p \<noteq> 0")
+   prefer 2
+   apply (insert no_0_n)[1]
+   apply clarsimp
+  apply (cases "p = slot")
+   apply (clarsimp simp: n_def modify_map_if nullMDBNode_def split: if_split_asm)
+  apply (cases "p = mdbNext s_node")
+   apply (clarsimp simp: n_def modify_map_if nullMDBNode_def split: if_split_asm)
+  apply clarsimp
+  apply (cases "p = mdbPrev s_node")
+   apply (auto simp: n_def modify_map_if initMDBNode_def split: if_split_asm)
+  done
+
+lemmas slot = m_p
+
+lemma m_next:
+  "m p = Some (CTE cap node) \<Longrightarrow>
+  \<exists>cap' node'. n p = Some (CTE cap' node') \<and>
+              (if p = slot
+               then mdbNext node' = 0
+               else if p = mdbPrev s_node
+               then mdbNext node' = mdbNext s_node
+               else mdbNext node' = mdbNext node)"
+  apply (subgoal_tac "p \<noteq> 0")
+   prefer 2
+   apply clarsimp
+  apply (cases "p = slot")
+   apply (clarsimp simp: n_def modify_map_if)
+  apply (cases "p = mdbPrev s_node")
+   apply (simp add: n_def modify_map_if)
+  apply simp
+  apply (simp add: n_def modify_map_if)
+  apply (cases "mdbNext s_node = p")
+   apply fastforce
+  apply fastforce
+  done
+
+lemma m_prev:
+  "m p = Some (CTE cap node) \<Longrightarrow>
+  \<exists>cap' node'. n p = Some (CTE cap' node') \<and>
+              (if p = slot
+               then mdbPrev node' = 0
+               else if p = mdbNext s_node
+               then mdbPrev node' = mdbPrev s_node
+               else mdbPrev node' = mdbPrev node)"
+  apply (subgoal_tac "p \<noteq> 0")
+   prefer 2
+   apply clarsimp
+  apply (cases "p = slot")
+   apply (clarsimp simp: n_def modify_map_if)
+  apply (cases "p = mdbPrev s_node")
+   apply (simp add: n_def modify_map_if)
+  apply simp
+  apply (simp add: n_def modify_map_if)
+  apply (cases "mdbNext s_node = p")
+   apply fastforce
+  apply fastforce
+  done
+
+lemma n_nextD:
+  "n \<turnstile> p \<leadsto> p' \<Longrightarrow>
+  if p = slot then p' = 0
+  else if p = mdbPrev s_node
+  then m \<turnstile> p \<leadsto> slot \<and> p' = mdbNext s_node
+  else m \<turnstile> p \<leadsto> p'"
+  apply (clarsimp simp: mdb_next_unfold split del: if_split cong: if_cong)
+  apply (case_tac z)
+  apply (clarsimp split del: if_split)
+  apply (drule n_next)
+  apply (elim exE conjE)
+  apply (simp split: if_split_asm)
+  apply (frule dlist_prevD [OF m_slot_prev])
+  apply (clarsimp simp: mdb_next_unfold)
+  done
+
+lemma n_next_eq:
+  "n \<turnstile> p \<leadsto> p' =
+  (if p = slot then p' = 0
+  else if p = mdbPrev s_node
+  then m \<turnstile> p \<leadsto> slot \<and> p' = mdbNext s_node
+  else m \<turnstile> p \<leadsto> p')"
+  apply (rule iffI)
+   apply (erule n_nextD)
+  apply (clarsimp simp: mdb_next_unfold split: if_split_asm)
+    apply (simp add: n_def modify_map_if slot)
+   apply hypsubst_thin
+   apply (case_tac z)
+   apply simp
+   apply (drule m_next)
+   apply clarsimp
+  apply (case_tac z)
+  apply simp
+  apply (drule m_next)
+  apply clarsimp
+  done
+
+lemma n_prev_eq:
+  "n \<turnstile> p \<leftarrow> p' =
+  (if p' = slot then p = 0
+  else if p' = mdbNext s_node
+  then m \<turnstile> slot \<leftarrow> p' \<and> p = mdbPrev s_node
+  else m \<turnstile> p \<leftarrow> p')"
+  apply (rule iffI)
+   apply (clarsimp simp: mdb_prev_def split del: if_split cong: if_cong)
+   apply (case_tac z)
+   apply (clarsimp split del: if_split)
+   apply (drule n_prev)
+   apply (elim exE conjE)
+   apply (simp split: if_split_asm)
+   apply (frule dlist_nextD [OF m_slot_next])
+   apply (clarsimp simp: mdb_prev_def)
+  apply (clarsimp simp: mdb_prev_def split: if_split_asm)
+    apply (simp add: n_def modify_map_if slot)
+   apply hypsubst_thin
+   apply (case_tac z)
+   apply clarsimp
+   apply (drule m_prev)
+   apply clarsimp
+  apply (case_tac z)
+  apply simp
+  apply (drule m_prev)
+  apply clarsimp
+  done
+
+lemma valid_dlist_n:
+  "valid_dlist n" using dlist
+  apply (clarsimp simp: valid_dlist_def2 [OF no_0_n])
+  apply (simp add: n_next_eq n_prev_eq m_slot_next m_slot_prev cong: if_cong)
+  apply (rule conjI, clarsimp)
+   apply (rule conjI, clarsimp simp: next_slot_prev prev_slot_next)
+   apply (fastforce dest!: dlist_prev_src_unique)
+  apply clarsimp
+  apply (rule conjI, clarsimp)
+   apply (clarsimp simp: valid_dlist_def2 [OF no_0])
+   apply (case_tac "mdbNext s_node = 0")
+    apply simp
+    apply (subgoal_tac "m \<turnstile> slot \<leadsto> c'")
+     prefer 2
+     apply fastforce
+    apply (clarsimp simp: mdb_next_unfold slot)
+   apply (frule next_slot_prev)
+   apply (drule (1) dlist_prev_src_unique, simp)
+   apply simp
+  apply clarsimp
+  apply (rule conjI, clarsimp)
+   apply (fastforce dest: dlist_next_src_unique)
+  apply clarsimp
+  apply (rule conjI, clarsimp)
+   apply (clarsimp simp: valid_dlist_def2 [OF no_0])
+   apply (clarsimp simp: mdb_prev_def slot)
+  apply (clarsimp simp: valid_dlist_def2 [OF no_0])
+  done
+
+lemma caps_contained_n:
+  "caps_contained' n"
+  using valid
+  apply (clarsimp simp: valid_mdb_ctes_def caps_contained'_def)
+  apply (drule n_cap)+
+  apply (clarsimp split: if_split_asm)
+  apply (erule disjE, clarsimp)
+  apply clarsimp
+  apply fastforce
+  done
+
+lemma chunked:
+  "mdb_chunked m"
+  using valid ..
+
+lemma valid_badges:
+  "valid_badges m"
+  using valid ..
+
+lemma to_slot_eq [simp]:
+  "m \<turnstile> p \<leadsto> slot = (p = mdbPrev s_node \<and> p \<noteq> 0)"
+  apply (rule iffI)
+   apply (frule dlist_nextD0, simp)
+   apply (clarsimp simp: mdb_prev_def slot mdb_next_unfold)
+  apply (clarsimp intro!: prev_slot_next)
+  done
+
+lemma n_mdbNext:
+  "\<lbrakk> n (mdbNext s_node) = Some (CTE cap node); mdbPrev s_node \<noteq> 0 \<rbrakk> \<Longrightarrow>
+  \<exists>node'. m (mdbNext s_node) = Some (CTE cap node') \<and>
+          mdbNext node = mdbNext node' \<and>
+          mdbPrev node = mdbPrev s_node \<and>
+          mdbRevocable node = mdbRevocable node' \<and>
+          (mdbFirstBadged node = mdbFirstBadged node' \<or> mdbFirstBadged s_node)"
+  apply (clarsimp simp: n_def modify_map_def)
+  apply (case_tac z)
+  apply clarsimp
+  done
+
+lemma n_mdbPrev:
+  "\<lbrakk> n (mdbPrev s_node) = Some (CTE cap node); mdbNext s_node \<noteq> 0 \<rbrakk> \<Longrightarrow>
+    \<exists>node'. m (mdbPrev s_node) = Some (CTE cap node') \<and>
+          mdbNext node = mdbNext s_node \<and>
+          mdbPrev node = mdbPrev node' \<and>
+          mdbRevocable node = mdbRevocable node' \<and>
+          (mdbFirstBadged node = mdbFirstBadged node')"
+  apply (clarsimp simp: n_def modify_map_def)
+  apply (case_tac z)
+  apply clarsimp
+  done
+
+lemma n_tranclD:
+  "n \<turnstile> p \<leadsto>\<^sup>+ p' \<Longrightarrow> m \<turnstile> p \<leadsto>\<^sup>+ p' \<and> p' \<noteq> slot"
+  apply (erule trancl_induct)
+   apply (clarsimp simp add: n_next_eq split: if_split_asm)
+     apply (rule mdb_chain_0D)
+      apply (rule chain)
+     apply (clarsimp simp: slot)
+    apply (blast intro: trancl_trans prev_slot_next)
+   apply fastforce
+  apply (clarsimp simp: n_next_eq split: if_split_asm)
+   apply (erule trancl_trans)
+   apply (blast intro: trancl_trans prev_slot_next)
+  apply (fastforce intro: trancl_trans)
+  done
+
+lemma m_tranclD:
+  "m \<turnstile> p \<leadsto>\<^sup>+ p' \<Longrightarrow>
+  if p = slot then n \<turnstile> mdbNext s_node \<leadsto>\<^sup>* p'
+  else if p' = slot then n \<turnstile> p \<leadsto>\<^sup>+ mdbNext s_node
+  else n \<turnstile> p \<leadsto>\<^sup>+ p'"
+  using no_0_n
+  apply -
+  apply (erule trancl_induct)
+   apply clarsimp
+   apply (rule conjI)
+    apply clarsimp
+    apply (rule r_into_trancl)
+    apply (clarsimp simp: n_next_eq)
+   apply clarsimp
+   apply (rule conjI)
+    apply (insert m_slot_next)[1]
+    apply (clarsimp simp: mdb_next_unfold)
+   apply clarsimp
+   apply (rule r_into_trancl)
+   apply (clarsimp simp: n_next_eq)
+   apply (rule context_conjI)
+    apply (clarsimp simp: mdb_next_unfold)
+   apply (drule prev_slot_next)
+   apply (clarsimp simp: mdb_next_unfold)
+  apply clarsimp
+  apply (rule conjI)
+   apply clarsimp
+   apply (rule conjI)
+    apply clarsimp
+    apply (drule prev_slot_next)
+    apply (drule trancl_trans, erule r_into_trancl)
+    apply simp
+   apply clarsimp
+   apply (erule trancl_trans)
+   apply (rule r_into_trancl)
+   apply (simp add: n_next_eq)
+  apply clarsimp
+  apply (rule conjI)
+   apply clarsimp
+   apply (erule rtrancl_trans)
+   apply (rule r_into_rtrancl)
+   apply (simp add: n_next_eq)
+   apply (rule conjI)
+    apply clarsimp
+    apply (rule context_conjI)
+     apply (clarsimp simp: mdb_next_unfold)
+    apply (drule prev_slot_next)
+    apply (clarsimp simp: mdb_next_unfold)
+   apply clarsimp
+  apply clarsimp
+  apply (simp split: if_split_asm)
+   apply (clarsimp simp: mdb_next_unfold slot)
+  apply (erule trancl_trans)
+  apply (rule r_into_trancl)
+  apply (clarsimp simp add: n_next_eq)
+  apply (rule context_conjI)
+   apply (clarsimp simp: mdb_next_unfold)
+  apply (drule prev_slot_next)
+  apply (clarsimp simp: mdb_next_unfold)
+  done
+
+lemma n_trancl_eq:
+  "n \<turnstile> p \<leadsto>\<^sup>+ p' = (m \<turnstile> p \<leadsto>\<^sup>+ p' \<and> (p = slot \<longrightarrow> p' = 0) \<and> p' \<noteq> slot)"
+  using no_0_n
+  apply -
+  apply (rule iffI)
+   apply (frule n_tranclD)
+   apply clarsimp
+   apply (drule tranclD)
+   apply (clarsimp simp: n_next_eq)
+   apply (simp add: rtrancl_eq_or_trancl)
+  apply clarsimp
+  apply (drule m_tranclD)
+  apply (simp split: if_split_asm)
+  apply (rule r_into_trancl)
+  apply (simp add: n_next_eq)
+  done
+
+lemma n_rtrancl_eq:
+  "n \<turnstile> p \<leadsto>\<^sup>* p' =
+  (m \<turnstile> p \<leadsto>\<^sup>* p' \<and>
+   (p = slot \<longrightarrow> p' = 0 \<or> p' = slot) \<and>
+   (p' = slot \<longrightarrow> p = slot))"
+  by (auto simp: rtrancl_eq_or_trancl n_trancl_eq)
+
+lemma mdb_chain_0_n:
+  "mdb_chain_0 n"
+  using chain
+  apply (clarsimp simp: mdb_chain_0_def)
+  apply (drule bspec)
+   apply (fastforce simp: n_def modify_map_if split: if_split_asm)
+  apply (simp add: n_trancl_eq)
+  done
+
+lemma mdb_chunked_n:
+  "mdb_chunked n"
+  using chunked
+  apply (clarsimp simp: mdb_chunked_def)
+  apply (drule n_cap)+
+  apply (clarsimp split: if_split_asm)
+  apply (case_tac "p=slot", clarsimp)
+  apply clarsimp
+  apply (erule_tac x=p in allE)
+  apply (erule_tac x=p' in allE)
+  apply (clarsimp simp: is_chunk_def)
+  apply (simp add: n_trancl_eq n_rtrancl_eq)
+  apply (rule conjI)
+   apply clarsimp
+   apply (erule_tac x=p'' in allE)
+   apply clarsimp
+   apply (drule_tac p=p'' in m_cap)
+   apply clarsimp
+  apply clarsimp
+  apply (erule_tac x=p'' in allE)
+  apply clarsimp
+  apply (drule_tac p=p'' in m_cap)
+  apply clarsimp
+  done
+
+lemmas vn_prev [dest!] = valid_nullcaps_prev [OF _ slot no_0 dlist nullcaps]
+lemmas vn_next [dest!] = valid_nullcaps_next [OF _ slot no_0 dlist nullcaps]
+
+lemma nullcaps_n: "valid_nullcaps n"
+proof -
+  from valid have "valid_nullcaps m" ..
+  thus ?thesis
+    apply (clarsimp simp: valid_nullcaps_def nullMDBNode_def nullPointer_def)
+    apply (frule n_cap)
+    apply (frule n_next)
+    apply (frule n_badged)
+    apply (frule n_revokable)
+    apply (drule n_prev)
+    apply (case_tac n)
+    apply (insert slot)
+    apply (fastforce split: if_split_asm)
+    done
+qed
+
+lemma ut_rev_n: "ut_revocable' n"
+  apply(insert valid)
+  apply(clarsimp simp: ut_revocable'_def)
+  apply(frule n_cap)
+  apply(drule n_revokable)
+  apply(clarsimp simp: gen_isCap_simps split: if_split_asm)
+  apply(simp add: valid_mdb_ctes_def ut_revocable'_def)
+  done
+
+lemma class_links_n: "class_links n"
+  using valid slot
+  apply (clarsimp simp: valid_mdb_ctes_def class_links_def)
+  apply (case_tac cte, case_tac cte')
+  apply (drule n_nextD)
+  apply (clarsimp simp: split: if_split_asm)
+    apply (simp add: no_0_n)
+   apply (drule n_cap)+
+   apply clarsimp
+   apply (frule spec[where x=slot],
+          drule spec[where x="mdbNext s_node"],
+          simp, simp add: m_slot_next)
+   apply (drule spec[where x="mdbPrev s_node"],
+          drule spec[where x=slot], simp)
+  apply (drule n_cap)+
+  apply clarsimp
+  apply (fastforce split: if_split_asm)
+  done
+
+lemma distinct_zombies_m: "distinct_zombies m"
+  using valid by (simp add: valid_mdb_ctes_def)
+
+lemma distinct_zombies_n[simp]:
+  "distinct_zombies n"
+  using distinct_zombies_m
+  apply (simp add: n_def distinct_zombies_nonCTE_modify_map)
+  apply (subst modify_map_apply[where p=slot])
+   apply (simp add: modify_map_def slot)
+  apply simp
+  apply (rule distinct_zombies_sameMasterE)
+    apply (simp add: distinct_zombies_nonCTE_modify_map)
+   apply (simp add: modify_map_def slot)
+  apply simp
+  done
+
+lemma irq_control_n [simp]: "irq_control n"
+  using slot
+  apply (clarsimp simp: irq_control_def)
+  apply (frule n_revokable)
+  apply (drule n_cap)
+  apply (clarsimp split: if_split_asm)
+  apply (frule irq_revocable, rule irq_control)
+  apply clarsimp
+  apply (drule n_cap)
+  apply (clarsimp simp: if_split_asm)
+  apply (erule (1) irq_controlD, rule irq_control)
+  done
+
+lemma reply_masters_rvk_fb_m: "reply_masters_rvk_fb m"
+  using valid by auto
+
+lemma reply_masters_rvk_fb_n [simp]: "reply_masters_rvk_fb n"
+  using reply_masters_rvk_fb_m
+  apply (simp add: reply_masters_rvk_fb_def n_def
+                   ball_ran_modify_map_eq
+                   modify_map_comp[symmetric])
+  apply (subst ball_ran_modify_map_eq)
+   apply (frule bspec, rule ranI, rule slot)
+   apply (simp add: nullMDBNode_def gen_isCap_simps modify_map_def
+                    slot)
+  apply (subst ball_ran_modify_map_eq)
+   apply (clarsimp simp add: modify_map_def)
+   apply fastforce
+  apply (simp add: ball_ran_modify_map_eq)
+  done
+
+end (* mdb_empty *)
+
+text \<open>Properties about empty_slot/emptySlot\<close>
+
+lemmas clearUntypedFreeIndex_gen_typ_ats[wp] = gen_typ_at_lifts[OF clearUntypedFreeIndex_typ_at']
+
+lemma case_Null_If:
+  "(case c of NullCap \<Rightarrow> a | _ \<Rightarrow> b) = (if c = NullCap then a else b)"
+  by (case_tac c, simp_all)
+
+lemma updateCap_cte_wp_at_cases:
+  "\<lbrace>\<lambda>s. (ptr = ptr' \<longrightarrow> cte_wp_at' (P \<circ> cteCap_update (K cap)) ptr' s) \<and> (ptr \<noteq> ptr' \<longrightarrow> cte_wp_at' P ptr' s)\<rbrace>
+     updateCap ptr cap
+   \<lbrace>\<lambda>rv. cte_wp_at' P ptr'\<rbrace>"
+  apply (clarsimp simp: valid_def)
+  apply (drule updateCap_stuff)
+  apply (clarsimp simp: cte_wp_at_ctes_of modify_map_def)
+  done
+
+lemma updateFreeIndex_cte_wp_at:
+  "\<lbrace>\<lambda>s. cte_at' p s
+        \<and> P (cte_wp_at' (if p = p' then P' \<circ> (cteCap_update (capFreeIndex_update (K idx))) else P')
+                        p' s)\<rbrace>
+   updateFreeIndex p idx
+   \<lbrace>\<lambda>rv s. P (cte_wp_at' P' p' s)\<rbrace>"
+  apply (simp add: updateFreeIndex_def updateTrackedFreeIndex_def split del: if_split)
+  apply (wpsimp wp: updateCap_cte_wp_at' getSlotCap_wp simp: cte_wp_at_ctes_of)
+  apply (cases "p' = p"; simp)
+  apply (case_tac cte, simp)
+  done
+
+lemma updateCap_valid_objs' [wp]:
+  "\<lbrace>valid_objs' and valid_cap' cap\<rbrace>
+  updateCap ptr cap \<lbrace>\<lambda>r. valid_objs'\<rbrace>"
+  unfolding updateCap_def
+  by (wp setCTE_valid_objs getCTE_wp) (clarsimp dest!: cte_at_cte_wp_atD)
+
+lemma updateFreeIndex_valid_objs' [wp]:
+  "\<lbrace>valid_objs'\<rbrace> clearUntypedFreeIndex ptr \<lbrace>\<lambda>r. valid_objs'\<rbrace>"
+  apply (simp add: clearUntypedFreeIndex_def getSlotCap_def)
+  apply (wp getCTE_wp' | wpc | simp add: updateTrackedFreeIndex_def)+
+  done
+
+crunch setInterruptState
+  for state_refs_of'[wp]: "\<lambda>s. P (state_refs_of' s)"
+  (simp: state_refs_of'_pspaceI)
+crunch setInterruptState
+  for state_hyp_refs_of'[wp]: "\<lambda>s. P (state_hyp_refs_of' s)"
+  (simp: state_hyp_refs_of'_pspaceI)
+
+definition
+  "isFinal cap p m \<equiv>
+  \<not>isUntypedCap cap \<and>
+  (\<forall>p' c. m p' = Some c \<longrightarrow>
+          p \<noteq> p' \<longrightarrow> \<not>isUntypedCap c \<longrightarrow>
+          \<not> sameObjectAs cap c)"
+
+locale Finalise_R =
+  fixes arch_final_matters' :: "arch_capability \<Rightarrow> bool"
+  fixes arch_cap_has_cleanup' :: "arch_capability \<Rightarrow> bool"
+  assumes arch_postCapDeletion_ksArchState_lift:
+    "\<And>P ac. \<lbrakk>\<And>s as. P (s\<lparr>ksArchState := as\<rparr>) = P s\<rbrakk> \<Longrightarrow> Arch.postCapDeletion ac \<lbrace>P\<rbrace>"
+  assumes setIRQState_umm[wp]:
+    "\<And>st irq P. setIRQState st irq \<lbrace>\<lambda>s. P (underlying_memory (ksMachineState s))\<rbrace>"
+  assumes arch_postCapDeletion_corres:
+    "\<And>cap cap'.
+     acap_relation cap cap'
+     \<Longrightarrow> corres dc \<top> \<top> (arch_post_cap_deletion cap) (Arch.postCapDeletion cap')"
+  assumes Arch_finaliseCap_typ_at'[wp]:
+    "\<And>acap final P T p. Arch.finaliseCap acap final \<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace>"
+  assumes Arch_finaliseCap_aligned'[wp]:
+    "\<And>acap final. Arch.finaliseCap acap final \<lbrace>pspace_aligned'\<rbrace>"
+  assumes Arch_finaliseCap_distinct'[wp]:
+    "\<And>acap final. Arch.finaliseCap acap final \<lbrace>pspace_distinct'\<rbrace>"
+  assumes Arch_finaliseCap_it'[wp]:
+    "\<And>acap final P. Arch.finaliseCap acap final \<lbrace>\<lambda>s. P (ksIdleThread s)\<rbrace>"
+  assumes prepareThreadDelete_typ_at'[wp]:
+    "\<And>t P T p. Arch.prepareThreadDelete t \<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace>"
+  assumes prepareThreadDelete_aligned'[wp]:
+    "\<And>t. Arch.prepareThreadDelete t \<lbrace>pspace_aligned'\<rbrace>"
+  assumes prepareThreadDelete_distinct'[wp]:
+    "\<And>t. Arch.prepareThreadDelete t \<lbrace>pspace_distinct'\<rbrace>"
+  assumes prepareThreadDelete_it'[wp]:
+    "\<And>t P. Arch.prepareThreadDelete t \<lbrace>\<lambda>s. P (ksIdleThread s)\<rbrace>"
+begin
+
+definition final_matters' :: "capability \<Rightarrow> bool" where
+ "final_matters' cap \<equiv> case cap of
+    EndpointCap ref bdg s r g gr \<Rightarrow> True
+  | NotificationCap ref bdg s r \<Rightarrow> True
+  | ThreadCap ref \<Rightarrow> True
+  | CNodeCap ref bits gd gs \<Rightarrow> True
+  | Zombie ptr zb n \<Rightarrow> True
+  | IRQHandlerCap irq \<Rightarrow> True
+  | ArchObjectCap acap \<Rightarrow> arch_final_matters' acap
+  | _ \<Rightarrow> False"
+
+crunch Arch.postCapDeletion
+  for aligned'[wp]: pspace_aligned'
+  and distinct'[wp]: pspace_distinct'
+  and pspace_canonical'[wp]: pspace_canonical'
+  and cte_wp_at'[wp]: "cte_wp_at' P p"
+  and obj_at'[wp]: "obj_at' P p"
+  and ct[wp]: "\<lambda>s. P (ksCurThread s)"
+  and ksRQ[wp]: "\<lambda>s. P (ksReadyQueues s)"
+  and ksRQL1[wp]: "\<lambda>s. P (ksReadyQueuesL1Bitmap s)"
+  and ksRQL2[wp]: "\<lambda>s. P (ksReadyQueuesL2Bitmap s)"
+  and nosch[wp]: "\<lambda>s. P (ksSchedulerAction s)"
+  and ksCurDomain[wp]: "\<lambda>s. P (ksCurDomain s)"
+  and valid_objs'[wp]: "valid_objs'"
+  and state_refs_of'[wp]: "\<lambda>s. P (state_refs_of' s)"
+  and state_hyp_refs_of'[wp]: "\<lambda>s. P (state_hyp_refs_of' s)"
+  and ctes_of[wp]: "\<lambda>s. P (ctes_of s)"
+  (rule: arch_postCapDeletion_ksArchState_lift)
+
+crunch emptySlot
+  for aligned'[wp]: pspace_aligned'
+  and distinct'[wp]: pspace_distinct'
+  and pspace_canonical'[wp]: pspace_canonical'
+  (simp: case_Null_If)
+
+crunch postCapDeletion, updateTrackedFreeIndex
+  for cte_wp_at'[wp]: "cte_wp_at' P p"
+
+lemma emptySlot_cte_wp_cap_other:
+  "\<lbrace>(\<lambda>s. cte_wp_at' (\<lambda>c. P (cteCap c)) p s) and K (p \<noteq> p')\<rbrace>
+  emptySlot p' opt
+  \<lbrace>\<lambda>rv s. cte_wp_at' (\<lambda>c. P (cteCap c)) p s\<rbrace>"
+  apply (rule hoare_gen_asm)
+  apply (simp add: emptySlot_def clearUntypedFreeIndex_def getSlotCap_def)
+  apply (rule hoare_pre)
+   apply (wp updateMDB_weak_cte_wp_at updateCap_cte_wp_at_cases
+             updateFreeIndex_cte_wp_at getCTE_wp' hoare_vcg_all_lift
+              | simp add:  | wpc
+              | wp (once) hoare_drop_imps)+
+  done
+
+crunch postCapDeletion
+  for obj_at'[wp]: "obj_at' P p"
+
+crunch emptySlot
+  for ct[wp]: "\<lambda>s. P (ksCurThread s)"
+  and ksRQ[wp]: "\<lambda>s. P (ksReadyQueues s)"
+  and ksRQL1[wp]: "\<lambda>s. P (ksReadyQueuesL1Bitmap s)"
+  and ksRQL2[wp]: "\<lambda>s. P (ksReadyQueuesL2Bitmap s)"
+  and nosch[wp]: "\<lambda>s. P (ksSchedulerAction s)"
+  and ksCurDomain[wp]: "\<lambda>s. P (ksCurDomain s)"
+
+crunch clearUntypedFreeIndex
+  for cur_tcb'[wp]: "cur_tcb'"
+  and inQ[wp]: "\<lambda>s. P (obj_at' (inQ d p) t s)"
+  and tcbDomain[wp]: "obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t"
+  and tcbPriority[wp]: "obj_at' (\<lambda>tcb. P (tcbPriority tcb)) t"
+  (wp: cur_tcb_lift)
+
+lemma emptySlot_sch_act_wf [wp]:
+  "\<lbrace>\<lambda>s. sch_act_wf (ksSchedulerAction s) s\<rbrace>
+  emptySlot sl opt
+  \<lbrace>\<lambda>rv s. sch_act_wf (ksSchedulerAction s) s\<rbrace>"
+  by (simp add: emptySlot_def case_Null_If)
+     (wp sch_act_wf_lift tcb_in_cur_domain'_lift | wpcw | simp)+
+
+crunch emptySlot
+  for state_refs_of'[wp]: "\<lambda>s. P (state_refs_of' s)"
+  (wp: crunch_wps)
+crunch emptySlot
+  for state_hyp_refs_of'[wp]: "\<lambda>s. P (state_hyp_refs_of' s)"
+  (wp: crunch_wps)
+
+crunch postCapDeletion, clearUntypedFreeIndex
+  for ctes_of[wp]: "\<lambda>s. P (ctes_of s)"
+
+crunch postCapDeletion
+  for ko_wp_at'[wp]: "\<lambda>s. P (ko_wp_at' P' p s)"
+  (rule: arch_postCapDeletion_ksArchState_lift)
+
+crunch postCapDeletion
+  for cteCaps_of[wp]: "\<lambda>s. P (cteCaps_of s)"
+  (simp: cteCaps_of_def o_def)
+
+
+end (* Finalise_R *)
+
+lemma mdb_chunked2D:
+  "\<lbrakk> mdb_chunked m; m \<turnstile> p \<leadsto> p'; m \<turnstile> p' \<leadsto> p'';
+     m p = Some (CTE cap nd); m p'' = Some (CTE cap'' nd'');
+     sameRegionAs cap cap''; p \<noteq> p''; mdb_chunked_arch_assms cap \<rbrakk>
+     \<Longrightarrow> \<exists>cap' nd'. m p' = Some (CTE cap' nd') \<and> sameRegionAs cap cap'"
+  apply (subgoal_tac "\<exists>cap' nd'. m p' = Some (CTE cap' nd')")
+   apply (clarsimp simp add: mdb_chunked_def)
+   apply (drule spec[where x=p])
+   apply (drule spec[where x=p''])
+   apply clarsimp
+   apply (drule mp, erule trancl_into_trancl2)
+    apply (erule trancl.intros(1))
+   apply (simp add: is_chunk_def)
+   apply (drule spec, drule mp, erule trancl.intros(1))
+   apply (drule mp, rule trancl_into_rtrancl)
+    apply (erule trancl.intros(1))
+   apply clarsimp
+  apply (clarsimp simp: mdb_next_unfold)
+  apply (case_tac z, simp)
+  done
+
+(* assume mdb_empty lemmas which require Arch to prove *)
+locale mdb_empty_gen = mdb_empty +
+  assumes valid_badges_n:
+    "valid_badges n"
+  assumes parency_n:
+    "\<And>p p'. n \<turnstile> p \<rightarrow> p' \<Longrightarrow> m \<turnstile> p \<rightarrow> p' \<and> p \<noteq> slot \<and> p' \<noteq> slot"
+  assumes m_parent_of:
+    "\<And>p p'. \<lbrakk> m \<turnstile> p parentOf p'; p \<noteq> slot; p' \<noteq> slot; p\<noteq>p'; p'\<noteq>mdbNext s_node \<rbrakk> \<Longrightarrow> n \<turnstile> p parentOf p'"
+  assumes m_parent_of_next:
+    "\<And>p. \<lbrakk> m \<turnstile> p parentOf mdbNext s_node; m \<turnstile> p parentOf slot; p \<noteq> slot; p\<noteq>mdbNext s_node \<rbrakk>
+         \<Longrightarrow> n \<turnstile> p parentOf mdbNext s_node"
+begin
+
+lemma parency_m:
+  assumes "m \<turnstile> p \<rightarrow> p'"
+  shows "p \<noteq> slot \<longrightarrow> (if p' \<noteq> slot then n \<turnstile> p \<rightarrow> p' else m \<turnstile> p \<rightarrow> mdbNext s_node \<longrightarrow> n \<turnstile> p \<rightarrow> mdbNext s_node)"
+using assms
+proof induct
+  case (direct_parent c)
+  thus ?case
+    apply clarsimp
+    apply (rule conjI)
+     apply clarsimp
+     apply (rule subtree.direct_parent)
+       apply (simp add: n_next_eq)
+       apply clarsimp
+       apply (subgoal_tac "mdbPrev s_node \<noteq> 0")
+        prefer 2
+        apply (clarsimp simp: mdb_next_unfold)
+       apply (drule prev_slot_next)
+       apply (clarsimp simp: mdb_next_unfold)
+      apply assumption
+     apply (erule m_parent_of, simp, simp)
+      apply clarsimp
+     apply clarsimp
+     apply (drule dlist_next_src_unique)
+       apply fastforce
+      apply clarsimp
+     apply simp
+    apply clarsimp
+    apply (rule subtree.direct_parent)
+      apply (simp add: n_next_eq)
+     apply (drule subtree_parent)
+     apply (clarsimp simp: parentOf_def)
+    apply (drule subtree_parent)
+    apply (erule (1) m_parent_of_next)
+     apply clarsimp
+    apply clarsimp
+    done
+next
+  case (trans_parent c c')
+  thus ?case
+    apply clarsimp
+    apply (rule conjI)
+     apply clarsimp
+     apply (cases "c=slot")
+      apply simp
+      apply (erule impE)
+       apply (erule subtree.trans_parent)
+         apply fastforce
+        apply (clarsimp simp: slot mdb_next_unfold)
+       apply (clarsimp simp: slot mdb_next_unfold)
+      apply (clarsimp simp: slot mdb_next_unfold)
+     apply clarsimp
+     apply (erule subtree.trans_parent)
+       apply (simp add: n_next_eq)
+       apply clarsimp
+       apply (subgoal_tac "mdbPrev s_node \<noteq> 0")
+        prefer 2
+        apply (clarsimp simp: mdb_next_unfold)
+       apply (drule prev_slot_next)
+       apply (clarsimp simp: mdb_next_unfold)
+      apply assumption
+     apply (erule m_parent_of, simp, simp)
+      apply clarsimp
+      apply (drule subtree_mdb_next)
+      apply (drule trancl_trans)
+       apply (erule r_into_trancl)
+      apply simp
+     apply clarsimp
+     apply (drule dlist_next_src_unique)
+       apply fastforce
+      apply clarsimp
+     apply simp
+    apply clarsimp
+    apply (erule subtree.trans_parent)
+      apply (simp add: n_next_eq)
+     apply clarsimp
+    apply (rule m_parent_of_next, erule subtree_parent, assumption, assumption)
+    apply clarsimp
+    done
+qed
+
+lemma parency:
+  "n \<turnstile> p \<rightarrow> p' = (p \<noteq> slot \<and> p' \<noteq> slot \<and> m \<turnstile> p \<rightarrow> p')"
+  by (auto dest!: parency_n parency_m)
+
+lemma descendants:
+  "descendants_of' p n =
+  (if p = slot then {} else descendants_of' p m - {slot})"
+  by (auto simp add: parency descendants_of'_def)
+
+lemma untyped_mdb_n:
+  "untyped_mdb' n"
+  using untyped_mdb
+  apply (simp add: untyped_mdb'_def descendants_of'_def parency)
+  apply clarsimp
+  apply (drule n_cap)+
+  apply (clarsimp split: if_split_asm)
+  apply (case_tac "p=slot", simp)
+  apply clarsimp
+  done
+
+lemma untyped_inc_n:
+  "untyped_inc' n"
+  using untyped_inc
+  apply (simp add: untyped_inc'_def descendants_of'_def parency)
+  apply clarsimp
+  apply (drule n_cap)+
+  apply (clarsimp split: if_split_asm)
+  apply (case_tac "p=slot", simp)
+  apply clarsimp
+  apply (erule_tac x=p in allE)
+  apply (erule_tac x=p' in allE)
+  apply simp
+  done
+
+lemma vmdb_n: "valid_mdb_ctes n"
+  by (simp add: valid_mdb_ctes_def valid_dlist_n
+                no_0_n mdb_chain_0_n valid_badges_n
+                caps_contained_n mdb_chunked_n
+                untyped_mdb_n untyped_inc_n
+                nullcaps_n ut_rev_n class_links_n)
+
+end (* mdb_empty_gen *)
+
+locale Arch_mdb_empty = mdb_empty + Arch
+
+lemma if_live_then_nonz_cap'_def2:
+  "if_live_then_nonz_cap' =
+   (\<lambda>s. \<forall>ptr. ko_wp_at' live' ptr s \<longrightarrow>
+              (\<exists>p zr. (option_map zobj_refs' o cteCaps_of s) p = Some zr \<and> ptr \<in> zr))"
+  by (fastforce simp: if_live_then_nonz_cap'_def ex_nonz_cap_to'_def cte_wp_at_ctes_of
+                      cteCaps_of_def)
+
+lemma updateMDB_ko_wp_at_live[wp]:
+  "\<lbrace>\<lambda>s. P (ko_wp_at' live' p' s)\<rbrace>
+      updateMDB p m
+   \<lbrace>\<lambda>rv s. P (ko_wp_at' live' p' s)\<rbrace>"
+  unfolding updateMDB_def Let_def
+  apply (rule hoare_pre, wp)
+  apply simp
+  done
+
+lemma updateCap_ko_wp_at_live[wp]:
+  "\<lbrace>\<lambda>s. P (ko_wp_at' live' p' s)\<rbrace>
+      updateCap p cap
+   \<lbrace>\<lambda>rv s. P (ko_wp_at' live' p' s)\<rbrace>"
+  unfolding updateCap_def
+  by wp
+
+primrec
+  threadCapRefs :: "capability \<Rightarrow> machine_word set"
+where
+  "threadCapRefs (ThreadCap r)                  = {r}"
+| "threadCapRefs (ReplyCap t m x)               = {}"
+| "threadCapRefs NullCap                        = {}"
+| "threadCapRefs (UntypedCap d r n i)           = {}"
+| "threadCapRefs (EndpointCap r badge x y z t)  = {}"
+| "threadCapRefs (NotificationCap r badge x y)  = {}"
+| "threadCapRefs (CNodeCap r b g gsz)           = {}"
+| "threadCapRefs (Zombie r b n)                 = {}"
+| "threadCapRefs (ArchObjectCap ac)             = {}"
+| "threadCapRefs (IRQHandlerCap irq)            = {}"
+| "threadCapRefs (IRQControlCap)                = {}"
+| "threadCapRefs (DomainCap)                    = {}"
+
+lemma not_FinalE:
+  "\<lbrakk> \<not> isFinal cap sl cps; isUntypedCap cap \<Longrightarrow> P;
+     \<And>p c. \<lbrakk> cps p = Some c; p \<noteq> sl; \<not> isUntypedCap c; sameObjectAs cap c \<rbrakk> \<Longrightarrow> P\<rbrakk>
+   \<Longrightarrow> P"
+  by (fastforce simp: isFinal_def)
+
+definition
+ "removeable' sl \<equiv> \<lambda>s cap.
+    (\<exists>p. p \<noteq> sl \<and> cte_wp_at' (\<lambda>cte. capMasterCap (cteCap cte) = capMasterCap cap) p s)
+    \<or> ((\<forall>p \<in> cte_refs' cap (irq_node' s). p \<noteq> sl \<longrightarrow> cte_wp_at' (\<lambda>cte. cteCap cte = NullCap) p s)
+         \<and> (\<forall>p \<in> zobj_refs' cap. ko_wp_at' (Not \<circ> live') p s))"
+
+crunch clearUntypedFreeIndex
+  for ko_at_live[wp]: "\<lambda>s. P (ko_wp_at' live' ptr s)"
+
+lemma setIRQState_irq_node'[wp]:
+  "\<lbrace>\<lambda>s. P (irq_node' s)\<rbrace> setIRQState state irq \<lbrace>\<lambda>_ s. P (irq_node' s)\<rbrace>"
+  apply (simp add: setIRQState_def setInterruptState_def getInterruptState_def)
+  apply wp
+  apply simp
+  done
+
+lemmas ctes_of_valid'[elim] = ctes_of_valid_cap''[where r=cte for cte]
+
+crunch setInterruptState
+  for valid_idle'[wp]: "valid_idle'"
+  (simp: valid_idle'_def)
+
+crunch deletedIRQHandler, getSlotCap, clearUntypedFreeIndex, updateMDB, getCTE, updateCap
+  for ksArch[wp]: "\<lambda>s. P (ksArchState s)"
+
+context Finalise_R begin
+
+lemma clearUntypedFreeIndex_cteCaps_of[wp]:
+  "\<lbrace>\<lambda>s. P (cteCaps_of s)\<rbrace>
+       clearUntypedFreeIndex sl \<lbrace>\<lambda>y s. P (cteCaps_of s)\<rbrace>"
+  by (simp add: cteCaps_of_def, wp)
+
+lemma emptySlot_iflive'[wp]:
+  "\<lbrace>\<lambda>s. if_live_then_nonz_cap' s \<and> cte_wp_at' (\<lambda>cte. removeable' sl s (cteCap cte)) sl s\<rbrace>
+     emptySlot sl opt
+   \<lbrace>\<lambda>rv. if_live_then_nonz_cap'\<rbrace>"
+  apply (simp add: emptySlot_def case_Null_If if_live_then_nonz_cap'_def2
+              del: comp_apply)
+  apply (rule hoare_pre)
+   apply (wp hoare_vcg_all_lift hoare_vcg_disj_lift
+             getCTE_wp opt_return_pres_lift
+             clearUntypedFreeIndex_ctes_of
+             clearUntypedFreeIndex_cteCaps_of
+             hoare_vcg_ex_lift
+             | wp (once) hoare_vcg_imp_lift
+             | simp add: cte_wp_at_ctes_of del: comp_apply)+
+  apply (clarsimp simp: modify_map_same imp_conjR[symmetric])
+  apply (drule spec, drule(1) mp)
+  apply (clarsimp simp: cte_wp_at_ctes_of modify_map_def split: if_split_asm)
+  apply (case_tac "p \<noteq> sl")
+   apply blast
+  apply (simp add: removeable'_def cteCaps_of_def)
+  apply (erule disjE)
+   apply (clarsimp simp: cte_wp_at_ctes_of modify_map_def
+                  dest!: capMaster_same_refs)
+   apply fastforce
+  apply clarsimp
+  apply (drule(1) bspec)
+  apply (clarsimp simp: ko_wp_at'_def)
+  done
+
+crunch emptySlot
+  for irq_node'[wp]: "\<lambda>s. P (irq_node' s)"
+  (rule: arch_postCapDeletion_ksArchState_lift)
+
+lemma emptySlot_ifunsafe'[wp]:
+  "\<lbrace>\<lambda>s. if_unsafe_then_cap' s \<and> cte_wp_at' (\<lambda>cte. removeable' sl s (cteCap cte)) sl s\<rbrace>
+     emptySlot sl opt
+   \<lbrace>\<lambda>rv. if_unsafe_then_cap'\<rbrace>"
+  apply (simp add: ifunsafe'_def3)
+  apply (rule hoare_pre, rule hoare_use_eq_irq_node'[OF emptySlot_irq_node'])
+   apply (simp add: emptySlot_def case_Null_If)
+   apply (wp opt_return_pres_lift | simp add: o_def)+
+   apply (wp getCTE_cteCap_wp clearUntypedFreeIndex_cteCaps_of)+
+  apply (clarsimp simp: tree_cte_cteCap_eq[unfolded o_def]
+                        modify_map_same
+                        modify_map_comp[symmetric]
+                 split: option.split_asm if_split_asm
+                 dest!: modify_map_K_D)
+  apply (clarsimp simp: modify_map_def)
+  apply (drule_tac x=cref in spec, clarsimp)
+  apply (case_tac "cref' \<noteq> sl")
+   apply (rule_tac x=cref' in exI)
+   apply (clarsimp simp: modify_map_def)
+  apply (simp add: removeable'_def)
+  apply (erule disjE)
+   apply (clarsimp simp: modify_map_def)
+   apply (subst(asm) tree_cte_cteCap_eq[unfolded o_def])
+   apply (clarsimp split: option.split_asm dest!: capMaster_same_refs)
+   apply fastforce
+  apply clarsimp
+  apply (drule(1) bspec)
+  apply (clarsimp simp: cte_wp_at_ctes_of cteCaps_of_def)
+  done
+
+crunch emptySlot
+  for valid_idle'[wp]: "valid_idle'"
+  and ksIdle[wp]: "\<lambda>s. P (ksIdleThread s)"
+  and gsMaxObjectSize[wp]: "\<lambda>s. P (gsMaxObjectSize s)"
+  (rule: arch_postCapDeletion_ksArchState_lift)
+
+lemma emptySlot_cteCaps_of:
+  "\<lbrace>\<lambda>s. P ((cteCaps_of s)(p \<mapsto> NullCap))\<rbrace>
+     emptySlot p opt
+   \<lbrace>\<lambda>rv s. P (cteCaps_of s)\<rbrace>"
+  apply (simp add: emptySlot_def case_Null_If)
+  apply (wp opt_return_pres_lift getCTE_cteCap_wp
+            clearUntypedFreeIndex_cteCaps_of)
+  apply (clarsimp simp: cteCaps_of_def cte_wp_at_ctes_of)
+  apply (auto elim!: rsubst[where P=P]
+               simp: modify_map_def fun_upd_def[symmetric] o_def
+                     fun_upd_idem cteCaps_of_def
+              split: option.splits)
+  done
+
+crunch deletedIRQHandler
+  for cteCaps_of[wp]: "\<lambda>s. P (cteCaps_of s)"
+
+end (* Finalise_R *)
+
+locale Finalise_R_2 = Finalise_R +
+  assumes Arch_postCapDeletion_valid_global_refs[wp]:
+    "\<And>t. Arch.postCapDeletion t \<lbrace>valid_global_refs'\<rbrace>"
+  assumes Arch_postCapDeletion_valid_arch_state'[wp]:
+    "\<And>t. Arch.postCapDeletion t \<lbrace>valid_arch_state'\<rbrace>"
+  assumes clearUntypedFreeIndex_valid_global_refs[wp]:
+    "\<And>irq. clearUntypedFreeIndex irq \<lbrace>valid_global_refs'\<rbrace>"
+  assumes deletedIRQHandler_valid_global_refs[wp]:
+    "\<And>irq. deletedIRQHandler irq \<lbrace>valid_global_refs'\<rbrace>"
+  assumes Arch_finaliseCap_irq_node'[wp]:
+    "\<And>acap final P. Arch.finaliseCap acap final \<lbrace>\<lambda>s. P (Invariants_H.irq_node' s)\<rbrace>"
+  assumes prepareThreadDelete_irq_node'[wp]:
+    "\<And>t P. prepareThreadDelete t \<lbrace>\<lambda>s. P (Invariants_H.irq_node' s)\<rbrace>"
+  assumes prepareThreadDelete_cte_wp_at'[wp]:
+    "\<And>t P p. prepareThreadDelete t \<lbrace>cte_wp_at' P p\<rbrace>"
+  assumes arch_finaliseCap_cte_wp_at[wp]:
+    "\<And>cap fin P p. Arch.finaliseCap cap fin \<lbrace>cte_wp_at' P p\<rbrace>"
+  assumes notFinal_prev_or_next:
+    "\<And>cap s x node.
+     \<lbrakk> \<not> isFinal cap x (cteCaps_of s); mdb_chunked (ctes_of s); valid_dlist (ctes_of s);
+       no_0 (ctes_of s); ctes_of s x = Some (CTE cap node); final_matters' cap \<rbrakk>
+     \<Longrightarrow> (\<exists>cap' node'. ctes_of s (mdbPrev node) = Some (CTE cap' node') \<and> sameObjectAs cap cap')
+        \<or> (\<exists>cap' node'. ctes_of s (mdbNext node) = Some (CTE cap' node') \<and> sameObjectAs cap cap')"
+  assumes sameObjectAs_not_Untyped:
+    "\<And>cap cap'. \<lbrakk> global.sameObjectAs cap cap'; \<not> isUntypedCap cap \<rbrakk> \<Longrightarrow> \<not> isUntypedCap cap'"
+  assumes sameObjectAs_not_Untyped':
+    "\<And>cap cap'.
+     \<lbrakk> global.sameObjectAs cap cap'; \<not> isUntypedCap cap' \<rbrakk> \<Longrightarrow> global.sameObjectAs cap' cap"
+  assumes arch_finaliseCap_invs[wp]:
+    "\<And>cap fin.
+     \<lbrace>invs' and valid_cap' (ArchObjectCap cap)\<rbrace> Arch.finaliseCap cap fin \<lbrace>\<lambda>rv. invs'\<rbrace>"
+  assumes prepareThreadDelete_invs[wp]:
+    "prepareThreadDelete t \<lbrace>invs'\<rbrace>"
+  assumes prepareThreadDelete_valid_cap'[wp]:
+    "\<And>cap. prepareThreadDelete t \<lbrace>valid_cap' cap\<rbrace>"
+  assumes finaliseCap_valid_cap[wp]:
+    "\<And>cap final. \<lbrace>\<lambda>_. True\<rbrace> Arch.finaliseCap cap final \<lbrace>\<lambda>rv. valid_cap' (fst rv)\<rbrace>"
+  assumes not_Final_removeable:
+    "\<And>cap sl s. \<not> isFinal cap sl (cteCaps_of s) \<Longrightarrow> removeable' sl s cap"
+  (* This is the expanded form of mdb_insert.vmdb_n which needs Arch to prove (via mdb_insert_gen).
+     The original form contracts this significantly via internal locale variables from mdb_empty. *)
+  assumes mdb_empty_vmdb_n:
+    "\<And>m slot s_cap s_node.
+     mdb_empty m slot s_cap s_node \<Longrightarrow>
+     valid_mdb_ctes
+      (modify_map
+        (modify_map
+          (modify_map
+            (modify_map m (mdbPrev s_node) (cteMDBNode_update (mdbNext_update (\<lambda>_. mdbNext s_node))))
+            (mdbNext s_node)
+            (cteMDBNode_update
+              (\<lambda>mdb. mdbFirstBadged_update (\<lambda>_. mdbFirstBadged mdb \<or> mdbFirstBadged s_node)
+                      (mdbPrev_update (\<lambda>_. mdbPrev s_node) mdb))))
+          slot (cteCap_update (\<lambda>_. capability.NullCap)))
+        slot (cteMDBNode_update (const nullMDBNode)))"
+  assumes mdb_empty_descendants:
+    "\<And>m slot s_cap s_node p.
+     mdb_empty m slot s_cap s_node \<Longrightarrow>
+     descendants_of' p
+      (modify_map
+        (modify_map
+          (modify_map
+            (modify_map m (mdbPrev s_node) (cteMDBNode_update (mdbNext_update (\<lambda>_. mdbNext s_node))))
+            (mdbNext s_node)
+            (cteMDBNode_update
+              (\<lambda>mdb. mdbFirstBadged_update (\<lambda>_. mdbFirstBadged mdb \<or> mdbFirstBadged s_node)
+                      (mdbPrev_update (\<lambda>_. mdbPrev s_node) mdb))))
+          slot (cteCap_update (\<lambda>_. capability.NullCap)))
+        slot (cteMDBNode_update (const nullMDBNode))) =
+     (if p = slot then {} else descendants_of' p m - {slot})"
+begin
+
+crunch global.postCapDeletion
+  for valid_global_refs[wp]: "valid_global_refs'"
+
+lemma emptySlot_valid_global_refs[wp]:
+  "\<lbrace>valid_global_refs' and cte_at' sl\<rbrace> emptySlot sl opt \<lbrace>\<lambda>rv. valid_global_refs'\<rbrace>"
+  apply (clarsimp simp: emptySlot_def)
+  apply (wpsimp wp: getCTE_wp hoare_drop_imps hoare_vcg_ex_lift simp: cte_wp_at_ctes_of)
+  apply (clarsimp simp: valid_global_refs'_def)
+  apply (frule(1) cte_at_valid_cap_sizes_0)
+  apply (clarsimp simp: valid_refs'_cteCaps valid_cap_sizes_cteCaps ball_ran_eq)
+  done
+
+end (* Finalise_R_2 *)
+
+lemmas doMachineOp_irq_handlers[wp]
+    = valid_irq_handlers_lift'' [OF doMachineOp_ctes doMachineOp_ksInterruptState]
+
+lemma deletedIRQHandler_irq_handlers'[wp]:
+  "\<lbrace>\<lambda>s. valid_irq_handlers' s \<and> (IRQHandlerCap irq \<notin> ran (cteCaps_of s))\<rbrace>
+       deletedIRQHandler irq
+   \<lbrace>\<lambda>rv. valid_irq_handlers'\<rbrace>"
+  apply (simp add: deletedIRQHandler_def setIRQState_def setInterruptState_def getInterruptState_def)
+  apply wp
+  apply (clarsimp simp: valid_irq_handlers'_def irq_issued'_def ran_def cteCaps_of_def)
+  done
+
+crunch clearUntypedFreeIndex
+  for ksInterruptState[wp]: "\<lambda>s. P (ksInterruptState s)"
+
+lemma deletedIRQHandler_irqs_masked'[wp]:
+  "\<lbrace>irqs_masked'\<rbrace> deletedIRQHandler irq \<lbrace>\<lambda>_. irqs_masked'\<rbrace>"
+  apply (simp add: deletedIRQHandler_def setIRQState_def getInterruptState_def setInterruptState_def)
+  apply (wp dmo_maskInterrupt)
+  apply (simp add: irqs_masked'_def)
+  done
+
+lemma untypedZeroRange_modify_map_isUntypedCap:
+  "m sl = Some v \<Longrightarrow> \<not> isUntypedCap v \<Longrightarrow> \<not> isUntypedCap (f v)
+   \<Longrightarrow> (untypedZeroRange \<circ>\<^sub>m modify_map m sl f) = (untypedZeroRange \<circ>\<^sub>m m)"
+  by (simp add: modify_map_def map_comp_def fun_eq_iff untypedZeroRange_def)
+
+context Finalise_R begin
+
+lemma postCapDeletion_irq_handlers'[wp]:
+  "\<lbrace>\<lambda>s. valid_irq_handlers' s \<and> (cap \<noteq> NullCap \<longrightarrow> cap \<notin> ran (cteCaps_of s))\<rbrace>
+   postCapDeletion cap
+   \<lbrace>\<lambda>rv. valid_irq_handlers'\<rbrace>"
+  by (wpsimp simp: Retype_H.postCapDeletion_def | rule arch_postCapDeletion_ksArchState_lift)+
+
+lemma emptySlot_valid_irq_handlers'[wp]:
+  "\<lbrace>\<lambda>s. valid_irq_handlers' s
+          \<and> (\<forall>sl'. info \<noteq> NullCap \<longrightarrow> sl' \<noteq> sl \<longrightarrow> cteCaps_of s sl' \<noteq> Some info)\<rbrace>
+     emptySlot sl info
+   \<lbrace>\<lambda>rv. valid_irq_handlers'\<rbrace>"
+  apply (simp add: emptySlot_def case_Null_If)
+  apply (wp | wpc)+
+        apply (unfold valid_irq_handlers'_def irq_issued'_def)
+        apply (wp getCTE_cteCap_wp clearUntypedFreeIndex_cteCaps_of
+          | wps clearUntypedFreeIndex_ksInterruptState)+
+  apply (clarsimp simp: cteCaps_of_def cte_wp_at_ctes_of ran_def modify_map_def
+                 split: option.split)
+  apply auto
+  done
+
+crunch emptySlot
+  for irq_states'[wp]: valid_irq_states'
+  and no_0_obj'[wp]: no_0_obj'
+  and irqs_masked'[wp]: "irqs_masked'"
+  (wp: crunch_wps rule: arch_postCapDeletion_ksArchState_lift)
+
+lemma deletedIRQHandler_ct_not_inQ[wp]:
+  "\<lbrace>ct_not_inQ\<rbrace> deletedIRQHandler irq \<lbrace>\<lambda>_. ct_not_inQ\<rbrace>"
+  apply (rule ct_not_inQ_lift [OF deletedIRQHandler_nosch])
+  apply (rule hoare_weaken_pre)
+   apply (wps deletedIRQHandler_ct)
+   apply (simp add: deletedIRQHandler_def setIRQState_def)
+   apply (wp)
+  apply (simp add: comp_def)
+  done
+
+crunch emptySlot
+  for umm[wp]: "\<lambda>s. P (underlying_memory (ksMachineState s))"
+  and pspace_domain_valid[wp]: "pspace_domain_valid"
+  and ksDomSchedule[wp]: "\<lambda>s. P (ksDomSchedule s)"
+  and ksDomScheduleIdx[wp]: "\<lambda>s. P (ksDomScheduleIdx s)"
+  and ct_not_inQ[wp]: "ct_not_inQ"
+  and tcbDomain[wp]: "obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t"
+  (wp: setIRQState_umm rule: arch_postCapDeletion_ksArchState_lift)
+
+lemma emptySlot_vms'[wp]:
+  "\<lbrace>valid_machine_state'\<rbrace> emptySlot slot irq \<lbrace>\<lambda>_. valid_machine_state'\<rbrace>"
+  by (simp add: valid_machine_state'_def pointerInUserData_def pointerInDeviceData_def)
+     (wp hoare_vcg_all_lift hoare_vcg_disj_lift)
+
+lemma emptySlot_ct_idle_or_in_cur_domain'[wp]:
+  "\<lbrace>ct_idle_or_in_cur_domain'\<rbrace> emptySlot sl opt \<lbrace>\<lambda>_. ct_idle_or_in_cur_domain'\<rbrace>"
+  by (wp ct_idle_or_in_cur_domain'_lift2 tcb_in_cur_domain'_lift | simp)+
+
+crunch postCapDeletion
+  for gsUntypedZeroRanges[wp]: "\<lambda>s. P (gsUntypedZeroRanges s)"
+  (wp: crunch_wps simp: crunch_simps rule: arch_postCapDeletion_ksArchState_lift)
+
+lemma emptySlot_untyped_ranges[wp]:
+  "\<lbrace>untyped_ranges_zero' and valid_objs' and valid_mdb'\<rbrace>
+     emptySlot sl opt \<lbrace>\<lambda>rv. untyped_ranges_zero'\<rbrace>"
+  apply (simp add: emptySlot_def case_Null_If)
+  apply (rule hoare_pre)
+   apply (rule bind_wp)
+    apply (rule untyped_ranges_zero_lift)
+     apply (wp getCTE_cteCap_wp clearUntypedFreeIndex_cteCaps_of
+       | wpc | simp add: clearUntypedFreeIndex_def updateTrackedFreeIndex_def
+                         getSlotCap_def
+                  split: option.split)+
+  apply (clarsimp simp: modify_map_comp[symmetric] modify_map_same)
+  apply (case_tac "\<not> isUntypedCap (the (cteCaps_of s sl))")
+   apply (case_tac "the (cteCaps_of s sl)",
+     simp_all add: untyped_ranges_zero_inv_def
+                   untypedZeroRange_modify_map_isUntypedCap gen_isCap_simps)[1]
+  apply (clarsimp simp: gen_isCap_simps untypedZeroRange_def modify_map_def)
+  apply (strengthen untyped_ranges_zero_fun_upd[mk_strg I E])
+  apply simp
+  apply (simp add: untypedZeroRange_def gen_isCap_simps)
+  done
+
+crunch emptySlot
+  for valid_bitmaps[wp]: valid_bitmaps
+  and tcbQueued_opt_pred[wp]: "\<lambda>s. P (tcbQueued |< tcbs_of' s)"
+  and valid_sched_pointers[wp]: valid_sched_pointers
+  and sched_projs[wp]: "\<lambda>s. P (tcbSchedNexts_of s) (tcbSchedPrevs_of s)"
+  and ksDomScheduleStart[wp]: "\<lambda>s. P (ksDomScheduleStart s)"
+  and pspace_in_kernel_mappings'[wp]: pspace_in_kernel_mappings'
+  and valid_objs'[wp]: "valid_objs'"
+  (wp: valid_bitmaps_lift rule: arch_postCapDeletion_ksArchState_lift)
+
+end (* Finalise_R *)
+
+context Finalise_R_2 begin
+
+crunch emptySlot
+  for valid_arch'[wp]: valid_arch_state'
+  (wp: crunch_wps)
+
+lemma emptySlot_mdb[wp]:
+  "\<lbrace>valid_mdb'\<rbrace>
+  emptySlot sl opt
+  \<lbrace>\<lambda>_. valid_mdb'\<rbrace>"
+  unfolding emptySlot_def
+  apply (simp only: case_Null_If valid_mdb'_def)
+  apply (wp updateCap_ctes_of_wp getCTE_wp'
+            opt_return_pres_lift | simp add: cte_wp_at_ctes_of)+
+  apply (clarsimp)
+  apply (case_tac cte)
+  apply (rename_tac cap node)
+  apply (simp)
+  apply (subgoal_tac "mdb_empty (ctes_of s) sl cap node")
+   prefer 2
+   apply (rule mdb_empty.intro)
+   apply (rule mdb_ptr.intro)
+    apply (rule vmdb.intro)
+    apply (simp add: valid_mdb_ctes_def)
+   apply (rule mdb_ptr_axioms.intro)
+   apply (simp add: cte_wp_at_ctes_of)
+  apply (rule conjI, clarsimp simp: valid_mdb_ctes_def)
+  apply (erule mdb_empty_vmdb_n[unfolded const_def])
+  done
+
+end (* Finalise_R_2 *)
+
+lemma deletedIRQHandler_corres:
+  "corres dc \<top> \<top>
+    (deleted_irq_handler irq)
+    (deletedIRQHandler irq)"
+  apply (simp add: deleted_irq_handler_def deletedIRQHandler_def)
+  apply (rule setIRQState_corres)
+  apply (simp add: irq_state_relation_def)
+  done
+
+lemma set_cap_trans_state:
+  "((),s') \<in> fst (set_cap c p s) \<Longrightarrow> ((),trans_state f s') \<in> fst (set_cap c p (trans_state f s))"
+  apply (cases p)
+  apply (clarsimp simp add: set_cap_def in_monad set_object_def get_object_def)
+  apply (case_tac y)
+      apply (auto simp add: in_monad set_object_def well_formed_cnode_n_def split: if_split_asm)
+  done
+
+lemma clearUntypedFreeIndex_noop_corres:
+  "corres dc \<top> (cte_at' (cte_map slot))
+    (return ()) (clearUntypedFreeIndex (cte_map slot))"
+  apply (simp add: clearUntypedFreeIndex_def)
+  apply (rule corres_guard_imp)
+    apply (rule corres_bind_return2)
+    apply (rule corres_symb_exec_r_conj[where P'="cte_at' (cte_map slot)"])
+       apply (rule corres_trivial, simp)
+      apply (wp getCTE_wp' | wpc
+        | simp add: updateTrackedFreeIndex_def getSlotCap_def)+
+     apply (clarsimp simp: state_relation_def)
+    apply (rule no_fail_pre)
+     apply (wp no_fail_getSlotCap getCTE_wp'
+       | wpc | simp add: updateTrackedFreeIndex_def getSlotCap_def)+
+  done
+
+context Finalise_R begin
+
+lemma postCapDeletion_corres:
+  "cap_relation cap cap' \<Longrightarrow> corres dc \<top> \<top> (post_cap_deletion cap) (postCapDeletion cap')"
+  apply (cases cap; clarsimp simp: post_cap_deletion_def Retype_H.postCapDeletion_def)
+   apply (corresKsimp corres: deletedIRQHandler_corres)
+  by (corresKsimp corres: arch_postCapDeletion_corres)
+
+lemma clearUntypedFreeIndex_valid_pspace'[wp]:
+  "\<lbrace>valid_pspace'\<rbrace> clearUntypedFreeIndex slot \<lbrace>\<lambda>rv. valid_pspace'\<rbrace>"
+  apply (simp add: valid_pspace'_def)
+  apply (rule hoare_pre)
+   apply (wp | simp add: valid_mdb'_def)+
+  done
+
+end (* Finalise_R *)
+
+lemma (in Finalise_R_2) emptySlot_corres:
+  "cap_relation info info' \<Longrightarrow> corres dc (einvs and cte_at slot) (invs' and cte_at' (cte_map slot))
+             (empty_slot slot info) (emptySlot (cte_map slot) info')"
+  unfolding emptySlot_def empty_slot_def
+  apply (simp add: case_Null_If)
+  apply (rule corres_guard_imp)
+    apply (rule corres_split_noop_rhs[OF clearUntypedFreeIndex_noop_corres])
+     apply (rule_tac R="\<lambda>cap. einvs and cte_wp_at ((=) cap) slot" and
+                     R'="\<lambda>cte. valid_pspace' and cte_wp_at' ((=) cte) (cte_map slot)" in
+                     corres_split[OF get_cap_corres])
+       defer
+       apply (wp get_cap_wp getCTE_wp')+
+     apply (simp add: cte_wp_at_ctes_of)
+     apply (wp hoare_vcg_imp_lift' clearUntypedFreeIndex_valid_pspace')
+    apply fastforce
+   apply (fastforce simp: cte_wp_at_ctes_of)
+  apply simp
+  apply (rule conjI, clarsimp)
+   defer
+  apply clarsimp
+  apply (rule conjI, clarsimp)
+  apply clarsimp
+  apply (simp only: bind_assoc[symmetric])
+  apply (rule corres_underlying_split[where r'=dc, OF _ postCapDeletion_corres])
+    defer
+    apply wpsimp+
+  apply (rule corres_no_failI)
+   apply (rule no_fail_pre, wp hoare_weak_lift_imp)
+   apply (clarsimp simp: cte_wp_at_ctes_of valid_pspace'_def)
+   apply (clarsimp simp: valid_mdb'_def valid_mdb_ctes_def)
+   apply (rule conjI, clarsimp)
+    apply (erule (2) valid_dlistEp)
+    apply simp
+   apply clarsimp
+   apply (erule (2) valid_dlistEn)
+   apply simp
+  apply (clarsimp simp: in_monad bind_assoc exec_gets)
+  apply (subgoal_tac "mdb_empty_abs a")
+   prefer 2
+   apply (rule mdb_empty_abs.intro)
+   apply (rule vmdb_abs.intro)
+   apply fastforce
+  apply (frule mdb_empty_abs'.intro)
+  apply (simp add: mdb_empty_abs'.empty_slot_ext_det_def2 update_cdt_list_def set_cdt_list_def exec_gets set_cdt_def bind_assoc exec_get exec_put set_original_def modify_def del: fun_upd_apply | subst bind_def, simp, simp add: mdb_empty_abs'.empty_slot_ext_det_def2)+
+  apply (simp add: put_def)
+  apply (simp add: exec_gets exec_get exec_put del: fun_upd_apply | subst bind_def)+
+  apply (clarsimp simp: state_relation_def)
+  apply (drule updateMDB_the_lot, fastforce simp: pspace_relation_def, fastforce, fastforce)
+   apply (clarsimp simp: invs'_def valid_state'_def valid_pspace'_def
+                         valid_mdb'_def valid_mdb_ctes_def)
+  apply (elim conjE)
+  apply (drule (4) updateMDB_the_lot, elim conjE)
+  apply clarsimp
+  apply (drule_tac s'=s''a and c=cap.NullCap in set_cap_not_quite_corres)
+                      subgoal by simp
+                     subgoal by simp
+                    subgoal by simp
+                   subgoal by simp
+                  subgoal by fastforce
+                 subgoal by fastforce
+                subgoal by fastforce
+               subgoal by fastforce
+              subgoal by fastforce
+             apply fastforce
+            subgoal by fastforce
+           subgoal by fastforce
+          subgoal by fastforce
+         apply (erule cte_wp_at_weakenE, rule TrueI)
+        apply assumption
+       subgoal by simp
+      subgoal by simp
+     subgoal by simp
+    subgoal by simp
+   apply (rule refl)
+  apply clarsimp
+  apply (drule updateCap_stuff, elim conjE, erule (1) impE)
+  apply clarsimp
+  apply (drule updateMDB_the_lot, force simp: pspace_relation_def, assumption+, simp)
+  apply (rule bexI)
+   prefer 2
+   apply (simp only: trans_state_update[symmetric])
+   apply (rule set_cap_trans_state)
+   apply (rule set_cap_revokable_update)
+   apply (erule set_cap_cdt_update)
+  apply clarsimp
+  apply (thin_tac "ctes_of t = s" for t s)+
+  apply (thin_tac "ksMachineState t = p" for t p)+
+  apply (thin_tac "ksCurThread t = p" for t p)+
+  apply (thin_tac "ksReadyQueues t = p" for t p)+
+  apply (thin_tac "ksSchedulerAction t = p" for t p)+
+  apply (clarsimp simp: cte_wp_at_ctes_of)
+  apply (case_tac rv')
+  apply (rename_tac s_cap s_node)
+  apply (subgoal_tac "cte_at slot a")
+   prefer 2
+   apply (fastforce elim: cte_wp_at_weakenE)
+  apply (subgoal_tac "mdb_empty (ctes_of b) (cte_map slot) s_cap s_node")
+   prefer 2
+   apply (rule mdb_empty.intro)
+   apply (rule mdb_ptr.intro)
+    apply (rule vmdb.intro)
+    subgoal by (simp add: invs'_def valid_state'_def valid_pspace'_def valid_mdb'_def)
+   apply (rule mdb_ptr_axioms.intro)
+   subgoal by simp
+  apply (prop_tac "ghost_relation_wrapper t b")
+   apply (erule (1) ghost_relation_wrapper_same_abs_set_cap; rule refl)
+  apply (clarsimp simp: set_cap_a_type_inv)
+  apply (simp add: pspace_relation_def)
+  apply (rule conjI)
+   prefer 2
+   apply (rule conjI)
+    apply (clarsimp simp: cdt_list_relation_def)
+    apply(frule invs_valid_pspace, frule invs_mdb)
+    apply(subgoal_tac "no_mloop (cdt a) \<and> finite_depth (cdt a)")
+     prefer 2
+     subgoal by(simp add: finite_depth valid_mdb_def)
+    apply(subgoal_tac "valid_mdb_ctes (ctes_of b)")
+     prefer 2
+     subgoal by(simp add: mdb_empty_def mdb_ptr_def vmdb_def)
+    apply(clarsimp simp: valid_pspace_def)
+
+    apply(case_tac "cdt a slot")
+     apply(simp add: next_slot_eq[OF mdb_empty_abs'.next_slot_no_parent])
+     apply(case_tac "next_slot (aa, bb) (cdt_list a) (cdt a)")
+      subgoal by (simp)
+     apply(clarsimp)
+     apply(frule(1) mdb_empty.n_next)
+     apply(clarsimp)
+     apply(erule_tac x=aa in allE, erule_tac x=bb in allE)
+     apply(simp split: if_split_asm)
+      apply(drule cte_map_inj_eq)
+           apply(drule cte_at_next_slot)
+             apply(assumption)+
+      apply(simp)
+     apply(subgoal_tac "(ab, bc) = slot")
+      prefer 2
+      apply(drule_tac cte="CTE s_cap s_node" in valid_mdbD2')
+        subgoal by (clarsimp simp: valid_mdb_ctes_def no_0_def)
+       subgoal by (clarsimp simp: invs'_def valid_state'_def valid_pspace'_def)
+      apply(clarsimp)
+      apply(rule cte_map_inj_eq)
+           apply(assumption)
+          apply(drule(3) cte_at_next_slot', assumption)
+         apply(assumption)+
+     apply(simp)
+     apply(drule_tac p="(aa, bb)" in no_parent_not_next_slot)
+        apply(assumption)+
+     apply(clarsimp)
+
+    apply(simp add: next_slot_eq[OF mdb_empty_abs'.next_slot] split del: if_split)
+    apply(case_tac "next_slot (aa, bb) (cdt_list a) (cdt a)")
+     subgoal by (simp)
+    apply(case_tac "(aa, bb) = slot", simp)
+    apply(case_tac "next_slot (aa, bb) (cdt_list a) (cdt a) = Some slot")
+     apply(simp)
+     apply(case_tac "next_slot ac (cdt_list a) (cdt a)", simp)
+     apply(simp)
+     apply(frule(1) mdb_empty.n_next)
+     apply(clarsimp)
+     apply(erule_tac x=aa in allE', erule_tac x=bb in allE)
+     apply(erule_tac x=ac in allE, erule_tac x=bd in allE)
+     apply(clarsimp split: if_split_asm)
+      apply(drule(1) no_self_loop_next)
+      apply(simp)
+     apply(drule_tac cte="CTE cap' node'" in valid_mdbD1')
+       apply(fastforce simp: valid_mdb_ctes_def no_0_def)
+      subgoal by (simp add: valid_mdb'_def)
+     apply(clarsimp)
+    apply(simp)
+    apply(frule(1) mdb_empty.n_next)
+    apply(erule_tac x=aa in allE, erule_tac x=bb in allE)
+    apply(clarsimp split: if_split_asm)
+     apply(drule(1) no_self_loop_prev)
+     apply(clarsimp)
+     apply(drule_tac cte="CTE s_cap s_node" in valid_mdbD2')
+       apply(clarsimp simp: valid_mdb_ctes_def no_0_def)
+      apply clarify
+     apply(clarsimp)
+     apply(drule cte_map_inj_eq)
+          apply(drule(3) cte_at_next_slot')
+          apply(assumption)+
+     apply(simp)
+    apply(erule disjE)
+     apply(drule cte_map_inj_eq)
+          apply(drule(3) cte_at_next_slot)
+          apply(assumption)+
+     apply(simp)
+    subgoal by (simp)
+   apply (simp add: revokable_relation_def)
+   apply (clarsimp simp: in_set_cap_cte_at)
+   apply (rule conjI)
+    apply clarsimp
+    apply (drule(1) mdb_empty.n_revokable)
+    subgoal by clarsimp
+   apply clarsimp
+   apply (drule (1) mdb_empty.n_revokable)
+   apply (subgoal_tac "null_filter (caps_of_state a) (aa,bb) \<noteq> None")
+    prefer 2
+    apply (drule set_cap_caps_of_state_monad)
+    subgoal by (force simp: null_filter_def)
+   apply clarsimp
+   apply (subgoal_tac "cte_at (aa, bb) a")
+    prefer 2
+    apply (drule null_filter_caps_of_stateD, erule cte_wp_cte_at)
+   apply (drule (2) cte_map_inj_ps, fastforce)
+   subgoal by simp
+  apply (clarsimp simp add: cdt_relation_def)
+  apply (subst mdb_empty_abs.descendants, assumption)
+  apply (subst mdb_empty_descendants, assumption)
+  apply clarsimp
+  apply (frule_tac p="(aa, bb)" in in_set_cap_cte_at)
+  apply clarsimp
+  apply (frule (2) cte_map_inj_ps, fastforce)
+  apply simp
+  apply (case_tac "slot \<in> descendants_of (aa,bb) (cdt a)")
+   apply (subst inj_on_image_set_diff)
+      apply (rule inj_on_descendants_cte_map)
+         apply fastforce
+        apply fastforce
+       apply fastforce
+      apply fastforce
+     apply fastforce
+    subgoal by simp
+   subgoal by simp
+  apply simp
+  apply (subgoal_tac "cte_map slot \<notin> descendants_of' (cte_map (aa,bb)) (ctes_of b)")
+   subgoal by simp
+  apply (erule_tac x=aa in allE, erule allE, erule (1) impE)
+  apply (drule_tac s="cte_map ` u" for u in sym)
+  apply clarsimp
+  apply (drule cte_map_inj_eq, assumption)
+      apply (erule descendants_of_cte_at, fastforce)
+     apply fastforce
+    apply fastforce
+   apply fastforce
+  apply simp
+  done
+
+text \<open>Some facts about is_final_cap/isFinalCapability\<close>
+
+lemma isFinalCapability_inv:
+  "\<lbrace>P\<rbrace> isFinalCapability cap \<lbrace>\<lambda>_. P\<rbrace>"
+  apply (simp add: isFinalCapability_def Let_def
+              split del: if_split cong: if_cong)
+  apply (rule hoare_pre, wp)
+   apply (rule hoare_post_imp[where Q'="\<lambda>s. P"], simp)
+   apply wp
+  apply simp
+  done
+
+lemma no_fail_isFinalCapability [wp]:
+  "no_fail (valid_mdb' and cte_wp_at' ((=) cte) p) (isFinalCapability cte)"
+  apply (simp add: isFinalCapability_def)
+  apply (clarsimp simp: Let_def split del: if_split)
+  apply (rule no_fail_pre, wp getCTE_wp')
+  apply (clarsimp simp: valid_mdb'_def valid_mdb_ctes_def cte_wp_at_ctes_of nullPointer_def)
+  apply (rule conjI)
+   apply clarsimp
+   apply (erule (2) valid_dlistEp)
+   apply simp
+  apply clarsimp
+  apply (rule conjI)
+   apply (erule (2) valid_dlistEn)
+   apply simp
+  apply clarsimp
+  apply (rule valid_dlistEn, assumption+)
+  apply (erule (2) valid_dlistEp)
+  apply simp
+  done
+
+lemma corres_gets_lift:
+  assumes inv: "\<And>P. \<lbrace>P\<rbrace> g \<lbrace>\<lambda>_. P\<rbrace>"
+  assumes res: "\<lbrace>Q'\<rbrace> g \<lbrace>\<lambda>r s. r = g' s\<rbrace>"
+  assumes Q: "\<And>s. Q s \<Longrightarrow> Q' s"
+  assumes nf: "no_fail Q g"
+  shows "corres r P Q f (gets g') \<Longrightarrow> corres r P Q f g"
+  apply (clarsimp simp add: corres_underlying_def simpler_gets_def)
+  apply (drule (1) bspec)
+  apply (rule conjI)
+   apply clarsimp
+   apply (rule bexI)
+    prefer 2
+    apply assumption
+   apply simp
+   apply (frule in_inv_by_hoareD [OF inv])
+   apply simp
+   apply (drule use_valid, rule res)
+    apply (erule Q)
+   apply simp
+  apply (insert nf)
+  apply (clarsimp simp: no_fail_def)
+  done
+
+text \<open>Facts about finalise_cap/finaliseCap and
+        cap_delete_one/cteDelete in no particular order\<close>
+
+definition
+  finaliseCapTrue_standin_simple_def:
+  "finaliseCapTrue_standin cap fin \<equiv> finaliseCap cap fin True"
+
+lemmas finaliseCapTrue_standin_def
+    = finaliseCapTrue_standin_simple_def[unfolded finaliseCap_def, @\<open>simp cong: if_cong\<close>]
+
+lemmas cteDeleteOne_def' = eq_reflection[OF cteDeleteOne_def]
+lemmas cteDeleteOne_def = cteDeleteOne_def'[folded finaliseCapTrue_standin_simple_def]
+
+crunch unbindNotification, finaliseCapTrue_standin
+  for cte_wp_at'[wp]: "cte_wp_at' P p"
+  (simp: crunch_simps wp: crunch_wps getObject_inv loadObject_default_inv)
+
+crunch cteDeleteOne, suspend
+  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
+  (wp: crunch_wps getObject_inv loadObject_default_inv
+   simp: crunch_simps unless_def o_def
+   ignore_del: setObject)
+
+lemmas cancelAllIPC_typs[wp] = gen_typ_at_lifts[OF cancelAllIPC_typ_at']
+lemmas cancelAllSignals_typs[wp] = gen_typ_at_lifts[OF cancelAllSignals_typ_at']
+lemmas suspend_typs[wp] = gen_typ_at_lifts[OF suspend_typ_at']
+
+context Finalise_R begin
+
+definition cap_has_cleanup' :: "capability \<Rightarrow> bool" where
+  "cap_has_cleanup' cap \<equiv> case cap of
+     IRQHandlerCap _ \<Rightarrow> True
+   | ArchObjectCap acap \<Rightarrow> arch_cap_has_cleanup' acap
+   | _ \<Rightarrow> False"
+
+lemmas cap_has_cleanup'_simps[simp] = cap_has_cleanup'_def[split_simps capability.split]
+
+crunch finaliseCap
+  for aligned'[wp]: "pspace_aligned'"
+  (simp: crunch_simps assertE_def unless_def o_def
+     wp: getObject_inv loadObject_default_inv crunch_wps)
+
+crunch finaliseCap
+  for distinct'[wp]: "pspace_distinct'"
+  (simp: crunch_simps assertE_def unless_def o_def
+     wp: getObject_inv loadObject_default_inv crunch_wps)
+
+crunch finaliseCap
+  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
+  (simp: crunch_simps assertE_def
+     wp: getObject_inv loadObject_default_inv crunch_wps)
+
+lemmas finaliseCap_typ_ats[wp] = gen_typ_at_lifts[OF finaliseCap_typ_at']
+
+crunch finaliseCap
+  for it'[wp]: "\<lambda>s. P (ksIdleThread s)"
+  (wp: mapM_x_wp_inv mapM_wp' hoare_drop_imps getObject_inv loadObject_default_inv
+   simp: crunch_simps updateObject_default_def o_def)
+
+end (* Finalise_R *)
+
+lemma ntfn_q_refs_of'_mult:
+  "ntfn_q_refs_of' ntfn = (case ntfn of Structures_H.WaitingNtfn q \<Rightarrow> set q | _ \<Rightarrow> {}) \<times> {NTFNSignal}"
+  by (cases ntfn, simp_all)
+
+lemma tcb_st_not_Bound:
+  "(p, NTFNBound) \<notin> tcb_st_refs_of' ts"
+  "(p, TCBBound) \<notin> tcb_st_refs_of' ts"
+  by (auto simp: tcb_st_refs_of'_def split: Structures_H.thread_state.split)
+
+crunch setBoundNotification
+  for valid_bitmaps[wp]: valid_bitmaps
+  and tcbSchedNexts_of[wp]: "\<lambda>s. P (tcbSchedNexts_of s)"
+  and tcbSchedPrevs_of[wp]: "\<lambda>s. P (tcbSchedPrevs_of s)"
+  and tcbQueued[wp]: "\<lambda>s. P (tcbQueued |< tcbs_of' s)"
+  and valid_sched_pointers[wp]: valid_sched_pointers
+  (wp: valid_bitmaps_lift)
+
+lemma unbindNotification_invs[wp]:
+  "\<lbrace>invs'\<rbrace> unbindNotification tcb \<lbrace>\<lambda>rv. invs'\<rbrace>"
+  apply (simp add: unbindNotification_def invs'_def valid_state'_def)
+  apply (rule bind_wp[OF _ gbn_sp'])
+  apply (case_tac ntfnPtr, clarsimp, wp, clarsimp)
+  apply clarsimp
+  apply (rule bind_wp[OF _ get_ntfn_sp'])
+  apply (wpsimp wp: sbn'_valid_pspace'_inv sbn_sch_act' valid_irq_node_lift valid_dom_schedule'_lift
+                    irqs_masked_lift setBoundNotification_ct_not_inQ sym_heap_sched_pointers_lift
+                    untyped_ranges_zero_lift
+                simp: cteCaps_of_def o_def  doUnbindNotification_def)
+  apply (frule obj_at_valid_objs', clarsimp+)
+  apply (clarsimp simp: pred_tcb_at' conj_comms)
+  apply (frule bound_tcb_ex_cap'', clarsimp+)
+  apply (frule(1) sym_refs_bound_tcb_atD')
+  apply (frule(1) sym_refs_obj_atD')
+  apply (clarsimp simp: refs_of_rev')
+  apply normalise_obj_at'
+  apply (subst delta_sym_refs, assumption)
+    apply (auto split: if_split_asm)[1]
+   (* FIXME: weak elimination rule warning for no_0_obj_at' despite supply *)
+   supply no_0_obj_at'[rule del] (* avoid weak elim rule warning *)
+   apply (auto simp: tcb_st_not_Bound ntfn_q_refs_of'_mult split: if_split_asm)[1]
+  apply (frule obj_at_valid_objs', clarsimp+)
+  apply (simp add: valid_ntfn'_def valid_obj'_def live'_def
+            split: ntfn.splits)
+  apply (erule if_live_then_nonz_capE')
+  apply (clarsimp simp: obj_at'_def ko_wp_at'_def live'_def)
+  done
+
+lemma ntfn_bound_tcb_at':
+  "\<lbrakk>sym_refs (state_refs_of' s); valid_objs' s; ko_at' ntfn ntfnptr s;
+    ntfnBoundTCB ntfn = Some tcbptr; P (Some ntfnptr)\<rbrakk>
+  \<Longrightarrow> bound_tcb_at' P tcbptr s"
+  apply (drule_tac x=ntfnptr in sym_refsD[rotated])
+   apply (clarsimp simp: obj_at'_def)
+   apply (fastforce simp: state_refs_of'_def)
+  apply (auto simp: pred_tcb_at'_def obj_at'_def valid_obj'_def valid_ntfn'_def
+                    state_refs_of'_def refs_of_rev'
+          simp del: refs_of_simps
+             split: option.splits if_split_asm)
+  done
+
+lemma unbindMaybeNotification_invs[wp]:
+  "\<lbrace>invs'\<rbrace> unbindMaybeNotification ntfnptr \<lbrace>\<lambda>rv. invs'\<rbrace>"
+  supply if_cong[cong]
+  apply (simp add: unbindMaybeNotification_def invs'_def valid_state'_def)
+  apply (rule bind_wp[OF _ get_ntfn_sp'])
+  apply (rule hoare_pre)
+   apply (wp sbn'_valid_pspace'_inv sbn_sch_act' sym_heap_sched_pointers_lift valid_irq_node_lift
+             irqs_masked_lift valid_dom_schedule'_lift setBoundNotification_ct_not_inQ
+             untyped_ranges_zero_lift
+             | wpc | clarsimp simp: cteCaps_of_def o_def doUnbindNotification_def)+
+  apply safe[1]
+           defer 3
+           defer 7
+           apply (fold_subgoals (prefix))[8]
+           subgoal premises prems using prems
+              by (auto simp: pred_tcb_at' valid_pspace'_def valid_obj'_def valid_ntfn'_def
+                             ko_wp_at'_def live'_def
+                      elim!: obj_atE' if_live_then_nonz_capE'
+                      split: option.splits ntfn.splits)
+   apply (rule delta_sym_refs, assumption)
+    apply (fold_subgoals (prefix))[2]
+    subgoal premises prems using prems by (fastforce simp: symreftype_inverse' ntfn_q_refs_of'_def
+                    split: ntfn.splits if_split_asm
+                     dest!: ko_at_state_refs_ofD')+
+  apply (rule delta_sym_refs, assumption)
+   apply (clarsimp split: if_split_asm)
+   apply (frule ko_at_state_refs_ofD', simp)
+  apply (clarsimp split: if_split_asm)
+   apply (frule_tac P="(=) (Some ntfnptr)" in ntfn_bound_tcb_at', simp_all add: valid_pspace'_def)[1]
+   subgoal by (fastforce simp: ntfn_q_refs_of'_def state_refs_of'_def tcb_ntfn_is_bound'_def
+                          tcb_st_refs_of'_def
+                   dest!: bound_tcb_at_state_refs_ofD'
+                   split: ntfn.splits thread_state.splits)
+  apply (frule ko_at_state_refs_ofD', simp)
+  done
+
+(* Ugh, required to be able to split out the abstract invs *)
+lemma finaliseCap_True_invs[wp]:
+  "\<lbrace>invs'\<rbrace> finaliseCap cap final True \<lbrace>\<lambda>rv. invs'\<rbrace>"
+  apply (simp add: finaliseCap_def Let_def)
+  apply safe
+    apply (wp irqs_masked_lift| simp | wpc)+
+  done
+
+lemma setObject_tcb_ksInterruptState[wp]:
+  "setObject t (v :: tcb) \<lbrace>\<lambda>s. P (ksInterruptState s)\<rbrace>"
+  by (wpsimp simp: setObject_def wp: updateObject_default_inv)
+
+lemma setObject_tcb_gsMaxObjectSize[wp]:
+  "setObject t (v :: tcb) \<lbrace>\<lambda>s. P (gsMaxObjectSize s)\<rbrace>"
+  by (wpsimp simp: setObject_def wp: updateObject_default_inv)
+
+lemma setObject_tcb_gsUntypedZeroRanges[wp]:
+  "setObject ptr (tcb::tcb) \<lbrace>\<lambda>s. P (gsUntypedZeroRanges s)\<rbrace>"
+  by (wpsimp wp: updateObject_default_inv simp: setObject_def)
+
+lemma setObject_tcb_tcbs_of'[wp]:
+  "\<lbrace>\<lambda>s. P ((tcbs_of' s) (t \<mapsto> tcb))\<rbrace>
+   setObject t tcb
+   \<lbrace>\<lambda>_ s. P (tcbs_of' s)\<rbrace>"
+  unfolding setObject_def
+  apply (wpsimp simp: updateObject_default_def)
+  apply (erule rsubst[where P=P])
+  apply (rule ext)
+  apply (clarsimp simp: opt_map_def split: option.splits)
+  done
+
+lemma when_assert_eq:
+  "(when P $ haskell_fail xs) = assert (\<not>P)"
+  by (simp add: assert_def when_def)
+
+lemma isZombie_Null:
+  "\<not> isZombie NullCap"
+  by (simp add: gen_isCap_simps)
+
+lemma prepares_delete_helper'':
+  assumes x: "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv. ko_wp_at' (Not \<circ> live') p\<rbrace>"
+  shows      "\<lbrace>P and K ((\<forall>x. cte_refs' cap x = {})
+                          \<and> zobj_refs' cap = {p}
+                          \<and> threadCapRefs cap = {})\<rbrace>
+                 f \<lbrace>\<lambda>rv s. removeable' sl s cap\<rbrace>"
+  apply (rule hoare_gen_asm)
+  apply (rule hoare_strengthen_post [OF x])
+  apply (clarsimp simp: removeable'_def)
+  done
+
+crunch finaliseCapTrue_standin, unbindNotification
+  for ctes_of[wp]: "\<lambda>s. P (ctes_of s)"
+  (wp: crunch_wps getObject_inv loadObject_default_inv simp: crunch_simps)
+
+lemma sameObjectAs_Null[simp]:
+  "global.sameObjectAs c capability.NullCap = False"
+  "global.sameObjectAs capability.NullCap c = False"
+  by (clarsimp simp add: sameObjectAs_def split: capability.splits)+
+
+context Finalise_R begin
+
+lemma cteDeleteOne_cteCaps_of:
+  "\<lbrace>\<lambda>s. (cte_wp_at' (\<lambda>cte. \<exists>final. finaliseCap (cteCap cte) final True \<noteq> fail) p s \<longrightarrow>
+          P ((cteCaps_of s)(p \<mapsto> NullCap)))\<rbrace>
+     cteDeleteOne p
+   \<lbrace>\<lambda>rv s. P (cteCaps_of s)\<rbrace>"
+  apply (simp add: cteDeleteOne_def unless_def split_def)
+  apply (rule bind_wp [OF _ getCTE_sp])
+  apply (case_tac "\<forall>final. finaliseCap (cteCap cte) final True = fail")
+   apply (simp add: finaliseCapTrue_standin_simple_def)
+   apply wp
+   apply (clarsimp simp: cte_wp_at_ctes_of cteCaps_of_def
+                         finaliseCap_def gen_isCap_simps)
+   apply (drule_tac x=s in fun_cong)
+   apply (simp add: return_def fail_def)
+  apply (wp emptySlot_cteCaps_of)
+    apply (simp add: cteCaps_of_def)
+    apply (wp (once) hoare_drop_imps)
+    apply (wp isFinalCapability_inv getCTE_wp')+
+  apply (clarsimp simp: cteCaps_of_def cte_wp_at_ctes_of)
+  apply (auto simp: fun_upd_idem fun_upd_def[symmetric] o_def)
+  done
+
+lemma cteDeleteOne_isFinal:
+  "cteDeleteOne p \<lbrace>\<lambda>s. isFinal cap slot (cteCaps_of s)\<rbrace>"
+  by (wpsimp wp: cteDeleteOne_cteCaps_of simp: isFinal_def)
+
+end (* Finalise_R *)
+
+lemmas setEndpoint_cteCaps_of[wp] = cteCaps_of_ctes_of_lift [OF set_ep_ctes_of]
+lemmas setNotification_cteCaps_of[wp] = cteCaps_of_ctes_of_lift [OF set_ntfn_ctes_of]
+lemmas threadSet_cteCaps_of = cteCaps_of_ctes_of_lift [OF threadSet_ctes_of]
+
+lemma isThreadCap_threadCapRefs_tcbptr:
+  "isThreadCap cap \<Longrightarrow> threadCapRefs cap = {capTCBPtr cap}"
+  by (clarsimp simp: gen_isCap_simps)
+
+lemma isArchObjectCap_Cap_capCap:
+  "isArchObjectCap cap \<Longrightarrow> ArchObjectCap (capCap cap) = cap"
+  by (clarsimp simp: gen_isCap_simps)
+
+context Finalise_R_2 begin
+
+crunch suspend
+  for isFinal: "\<lambda>s. isFinal cap slot (cteCaps_of s)"
+  (ignore: threadSet
+       wp: threadSet_cteCaps_of crunch_wps
+     simp: crunch_simps unless_def o_def)
+
+crunch finaliseCap
+  for irq_node'[wp]: "\<lambda>s. P (irq_node' s)"
+  (wp: crunch_wps
+   simp: crunch_simps)
+
+lemma cteDeleteOne_deletes[wp]:
+  "\<lbrace>\<top>\<rbrace> cteDeleteOne p \<lbrace>\<lambda>rv s. cte_wp_at' (\<lambda>c. cteCap c = NullCap) p s\<rbrace>"
+  apply (subst tree_cte_cteCap_eq[unfolded o_def])
+  apply (wp cteDeleteOne_cteCaps_of)
+  apply clarsimp
+  done
+
+lemma deletingIRQHandler_removeable':
+  "\<lbrace>invs' and (\<lambda>s. isFinal (IRQHandlerCap irq) slot (cteCaps_of s))
+          and K (cap = IRQHandlerCap irq)\<rbrace>
+     deletingIRQHandler irq
+   \<lbrace>\<lambda>rv s. removeable' slot s cap\<rbrace>"
+  apply (rule hoare_gen_asm)
+  apply (simp add: deletingIRQHandler_def getIRQSlot_def locateSlot_conv
+                   getInterruptState_def getSlotCap_def)
+  apply (simp add: removeable'_def tree_cte_cteCap_eq[unfolded o_def])
+  apply (subst tree_cte_cteCap_eq[unfolded o_def])+
+  apply (wp hoare_use_eq_irq_node' [OF cteDeleteOne_irq_node' cteDeleteOne_cteCaps_of]
+            getCTE_wp')
+  apply (clarsimp simp: cteSizeBits_cte_level_bits shiftl_t2n
+                  split: option.split_asm)
+  done
+
+lemma deletingIRQHandler_final:
+  "\<lbrace>\<lambda>s. isFinal cap slot (cteCaps_of s)
+             \<and> (\<forall>final. finaliseCap cap final True = fail)\<rbrace>
+     deletingIRQHandler irq
+   \<lbrace>\<lambda>rv s. isFinal cap slot (cteCaps_of s)\<rbrace>"
+  apply (simp add: deletingIRQHandler_def isFinal_def getIRQSlot_def
+                   getInterruptState_def locateSlot_conv getSlotCap_def)
+  apply (wpsimp wp: cteDeleteOne_cteCaps_of getCTE_wp')
+  done
+
+crunch updateRestartPC, cancelIPC
+  for valid_sched_pointers[wp]: valid_sched_pointers
+  (simp: crunch_simps wp: crunch_wps)
+
+end (* Finalise_R_2 *)
+
+lemma unbindNotification_valid_objs'_helper:
+  "valid_tcb' tcb s \<longrightarrow> valid_tcb' (tcbBoundNotification_update (\<lambda>_. None) tcb) s "
+  by (clarsimp simp: valid_bound_ntfn'_def valid_tcb'_def tcb_cte_cases_def tcb_cte_cases_neqs
+                  split: option.splits ntfn.splits)
+
+lemma unbindNotification_valid_objs'_helper':
+  "valid_ntfn' tcb s \<longrightarrow> valid_ntfn' (ntfnBoundTCB_update (\<lambda>_. None) tcb) s "
+  by (clarsimp simp: valid_bound_tcb'_def valid_ntfn'_def
+                  split: option.splits ntfn.splits)
+
+lemmas setNotification_valid_tcb' = typ_at'_valid_tcb'_lift [OF setNotification_typ_at']
+
+lemma unbindNotification_valid_objs'[wp]:
+  "\<lbrace>valid_objs'\<rbrace>
+     unbindNotification t
+   \<lbrace>\<lambda>rv. valid_objs'\<rbrace>"
+  apply (simp add: unbindNotification_def)
+  apply (rule hoare_pre)
+  apply (wpsimp wp: threadSet_valid_objs' gbn_wp' set_ntfn_valid_objs' hoare_vcg_all_lift
+                    setNotification_valid_tcb' getNotification_wp
+                simp: setBoundNotification_def unbindNotification_valid_objs'_helper
+                      doUnbindNotification_def)
+  apply (clarsimp elim!: obj_atE')
+  apply (rule valid_objsE', assumption+)
+  apply (clarsimp simp: valid_obj'_def unbindNotification_valid_objs'_helper')
+  done
+
+lemma unbindMaybeNotification_valid_objs'[wp]:
+  "\<lbrace>valid_objs'\<rbrace>
+     unbindMaybeNotification t
+   \<lbrace>\<lambda>rv. valid_objs'\<rbrace>"
+  apply (simp add: unbindMaybeNotification_def)
+  apply (rule bind_wp[OF _ get_ntfn_sp'])
+  apply (rule hoare_pre)
+  apply (wpsimp wp: threadSet_valid_objs' gbn_wp' set_ntfn_valid_objs' hoare_vcg_all_lift
+                    setNotification_valid_tcb' getNotification_wp
+                simp: setBoundNotification_def unbindNotification_valid_objs'_helper
+                      doUnbindNotification_def)+
+  apply (clarsimp elim!: obj_atE')
+  apply (rule valid_objsE', assumption+)
+  apply (clarsimp simp: valid_obj'_def unbindNotification_valid_objs'_helper')
+  done
+
+lemma unbindMaybeNotification_sch_act_wf[wp]:
+  "\<lbrace>\<lambda>s. sch_act_wf (ksSchedulerAction s) s\<rbrace> unbindMaybeNotification t
+  \<lbrace>\<lambda>rv s. sch_act_wf (ksSchedulerAction s) s\<rbrace>"
+  apply (simp add: unbindMaybeNotification_def)
+  apply (rule hoare_pre)
+  apply (wpsimp wp: sbn_sch_act' simp: doUnbindNotification_def)+
+  done
+
+lemma valid_cong:
+  "\<lbrakk> \<And>s. P s = P' s; \<And>s. P' s \<Longrightarrow> f s = f' s;
+        \<And>rv s' s. \<lbrakk> (rv, s') \<in> fst (f' s); P' s \<rbrakk> \<Longrightarrow> Q rv s' = Q' rv s' \<rbrakk>
+    \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace> = \<lbrace>P'\<rbrace> f' \<lbrace>Q'\<rbrace>"
+  by (clarsimp simp add: valid_def, blast)
+
+lemma sym_refs_ntfn_bound_eq: "sym_refs (state_refs_of' s)
+    \<Longrightarrow> obj_at' (\<lambda>ntfn. ntfnBoundTCB ntfn = Some t) x s
+    = bound_tcb_at' (\<lambda>st. st = Some x) t s"
+  apply (rule iffI)
+   apply (drule (1) sym_refs_obj_atD')
+   apply (clarsimp simp: pred_tcb_at'_def obj_at'_def ko_wp_at'_def refs_of_rev')
+  apply (drule(1) sym_refs_bound_tcb_atD')
+  apply (clarsimp simp: obj_at'_def ko_wp_at'_def refs_of_rev')
+  done
+
+lemma unbindMaybeNotification_obj_at'_bound:
+  "\<lbrace>\<top>\<rbrace>
+   unbindMaybeNotification r
+   \<lbrace>\<lambda>_ s. obj_at' (\<lambda>ntfn. ntfnBoundTCB ntfn = None) r s\<rbrace>"
+  apply (simp add: unbindMaybeNotification_def)
+  apply (rule bind_wp[OF _ get_ntfn_sp'])
+  apply (rule hoare_pre)
+   apply (wpsimp wp: obj_at_setObject2
+                 simp: setBoundNotification_def threadSet_def updateObject_default_def in_monad
+                       doUnbindNotification_def)
+  apply (simp add: setNotification_def obj_at'_real_def)
+   apply (wp setObject_ko_wp_at, (simp add: gen_objBits_simps)+)
+  apply (clarsimp simp: obj_at'_def ko_wp_at'_def)
+  done
+
+crunch unbindNotification, unbindMaybeNotification
+  for isFinal[wp]: "\<lambda>s. isFinal cap slot (cteCaps_of s)"
+  (wp: sts_bound_tcb_at' threadSet_cteCaps_of crunch_wps getObject_inv
+       loadObject_default_inv
+   ignore: threadSet
+   simp: setBoundNotification_def)
+
+crunch cancelSignal, cancelAllIPC
+  for bound_tcb_at'[wp]: "bound_tcb_at' P t"
+  (wp: sts_bound_tcb_at' threadSet_cteCaps_of crunch_wps getObject_inv
+       loadObject_default_inv
+   ignore: threadSet)
+
+lemma finaliseCapTrue_standin_bound_tcb_at':
+  "\<lbrace>\<lambda>s. bound_tcb_at' P t s \<and> (\<exists>tt b r. cap = ReplyCap tt b r) \<rbrace>
+     finaliseCapTrue_standin cap final
+   \<lbrace>\<lambda>_. bound_tcb_at' P t\<rbrace>"
+  apply (case_tac cap, simp_all add:finaliseCapTrue_standin_def)
+  apply (clarsimp simp: isNotificationCap_def)
+  apply (wp, clarsimp)
+  done
+
+lemma capDeleteOne_bound_tcb_at':
+  "\<lbrace>bound_tcb_at' P tptr and cte_wp_at' (isReplyCap \<circ> cteCap) callerCap\<rbrace>
+      cteDeleteOne callerCap \<lbrace>\<lambda>rv. bound_tcb_at' P tptr\<rbrace>"
+  apply (simp add: cteDeleteOne_def unless_def)
+  apply (rule hoare_pre)
+   apply (wp finaliseCapTrue_standin_bound_tcb_at' hoare_vcg_all_lift
+            hoare_vcg_if_lift2 getCTE_cteCap_wp emptySlot_pred_tcb_at'
+        | wpc | simp | wp (once) hoare_drop_imp)+
+  apply (clarsimp simp:  cteCaps_of_def isReplyCap_def cte_wp_at_ctes_of
+                 split: option.splits)
+  apply (case_tac "cteCap cte", simp_all)
+  done
+
+lemma cancelIPC_bound_tcb_at'[wp]:
+  "\<lbrace>bound_tcb_at' P tptr\<rbrace> cancelIPC t \<lbrace>\<lambda>rv. bound_tcb_at' P tptr\<rbrace>"
+  apply (simp add: cancelIPC_def Let_def)
+  apply (rule bind_wp[OF _ gts_sp'])
+  apply (case_tac "state", simp_all)
+         defer 2
+         apply (rule hoare_pre)
+          apply ((wp sts_bound_tcb_at' getEndpoint_wp | wpc | simp)+)[8]
+  apply (simp add: getThreadReplySlot_def locateSlot_conv liftM_def)
+  apply (rule hoare_pre)
+   apply (wp capDeleteOne_bound_tcb_at' getCTE_ctes_of)
+   apply (rule_tac Q'="\<lambda>_. bound_tcb_at' P tptr" in hoare_post_imp)
+   apply (clarsimp simp: capHasProperty_def cte_wp_at_ctes_of)
+   apply (wp threadSet_pred_tcb_no_state | simp)+
+  done
+
+lemmas asUser_bound_obj_at'[wp] = asUser_pred_tcb_at' [of itcbBoundNotification]
+
+crunch suspend
+  for bound_tcb_at'[wp]: "bound_tcb_at' P t"
+  (wp: sts_bound_tcb_at' cancelIPC_bound_tcb_at'
+   ignore: threadSet)
+
+lemma unbindNotification_bound_tcb_at':
+  "\<lbrace>\<lambda>_. True\<rbrace> unbindNotification t \<lbrace>\<lambda>rv. bound_tcb_at' ((=) None) t\<rbrace>"
+  unfolding unbindNotification_def
+  by (wpsimp wp: setBoundNotification_bound_tcb gbn_wp' simp: doUnbindNotification_def)
+
+crunch unbindNotification, unbindMaybeNotification
+  for weak_sch_act_wf[wp]: "\<lambda>s. weak_sch_act_wf (ksSchedulerAction s) s"
+
+lemma unbindNotification_tcb_at'[wp]:
+  "\<lbrace>tcb_at' t'\<rbrace> unbindNotification t \<lbrace>\<lambda>rv. tcb_at' t'\<rbrace>"
+  unfolding unbindNotification_def
+  by (wpsimp wp: setBoundNotification_bound_tcb gbn_wp' simp: doUnbindNotification_def)
+
+lemma unbindMaybeNotification_tcb_at'[wp]:
+  "\<lbrace>tcb_at' t'\<rbrace> unbindMaybeNotification t \<lbrace>\<lambda>rv. tcb_at' t'\<rbrace>"
+  by (simp add: unbindMaybeNotification_def)
+     (wpsimp wp: setBoundNotification_bound_tcb gbn_wp' simp: doUnbindNotification_def)
+
+lemma tcbQueueRemove_tcbSchedNext_tcbSchedPrev_None_obj_at':
+  "\<lbrace>\<lambda>s. \<exists>ts. list_queue_relation ts q (tcbSchedNexts_of s) (tcbSchedPrevs_of s)\<rbrace>
+   tcbQueueRemove q t
+   \<lbrace>\<lambda>_ s. obj_at' (\<lambda>tcb. tcbSchedNext tcb = None \<and> tcbSchedPrev tcb = None) t s\<rbrace>"
+  apply (clarsimp simp: tcbQueueRemove_def)
+  apply (wpsimp wp: threadSet_wp getTCB_wp)
+  by (fastforce dest!: heap_ls_last_None
+                 simp: list_queue_relation_def prev_queue_head_def queue_end_valid_def
+                       obj_at'_def opt_map_def ps_clear_def gen_objBits_simps
+                split: if_splits)
+
+lemma tcbSchedDequeue_tcbSchedNext_tcbSchedPrev_None_obj_at':
+  "\<lbrace>valid_sched_pointers\<rbrace>
+   tcbSchedDequeue t
+   \<lbrace>\<lambda>_ s. obj_at' (\<lambda>tcb. tcbSchedNext tcb = None \<and> tcbSchedPrev tcb = None) t s\<rbrace>"
+  unfolding tcbSchedDequeue_def
+  by (wpsimp wp: tcbQueueRemove_tcbSchedNext_tcbSchedPrev_None_obj_at' threadGet_wp)
+     (fastforce simp: ready_queue_relation_def ksReadyQueues_asrt_def obj_at'_def
+                      valid_sched_pointers_def opt_pred_def opt_map_def
+               split: option.splits)
+
+lemma setThreadState_tcbSchedNext_tcbSchedPrev_None_obj_at'[wp]:
+  "setThreadState ref ts \<lbrace>\<lambda>s. obj_at' (\<lambda>tcb. tcbSchedNext tcb = None \<and> tcbSchedPrev tcb = None) t s\<rbrace>"
+  unfolding setThreadState_def
+  apply (wpsimp wp: threadSet_wp getTCB_wp)
+  apply (fastforce simp: obj_at'_def gen_objBits_simps)
+  done
+
+lemma (in Finalise_R_2) suspend_tcbSchedNext_tcbSchedPrev_None:
+  "\<lbrace>invs'\<rbrace> suspend t \<lbrace>\<lambda>_ s. obj_at' (\<lambda>tcb. tcbSchedNext tcb = None \<and> tcbSchedPrev tcb = None) t s\<rbrace>"
+  unfolding suspend_def
+  by (wpsimp wp: hoare_drop_imps tcbSchedDequeue_tcbSchedNext_tcbSchedPrev_None_obj_at')
+
+crunch cancelSignal
+  for ctes_of[wp]: "\<lambda>s. P (ctes_of s)"
+  (simp: crunch_simps wp: crunch_wps)
+
+crunch tcbSchedDequeue
+  for cte_wp_at'[wp]: "cte_wp_at' P p"
+  (wp: crunch_wps)
+
+context Finalise_R begin
+
+lemma cteDeleteOne_cte_wp_at_preserved:
+  assumes x: "\<And>cap final. P cap \<Longrightarrow> finaliseCap cap final True = fail"
+  shows "\<lbrace>\<lambda>s. cte_wp_at' (\<lambda>cte. P (cteCap cte)) p s\<rbrace>
+           cteDeleteOne ptr
+         \<lbrace>\<lambda>rv s. cte_wp_at' (\<lambda>cte. P (cteCap cte)) p s\<rbrace>"
+  apply (simp add: tree_cte_cteCap_eq[unfolded o_def])
+  apply (rule hoare_pre, wp cteDeleteOne_cteCaps_of)
+  apply (clarsimp simp: cteCaps_of_def cte_wp_at_ctes_of x)
+  done
+
+lemma cancelIPC_cteCaps_of:
+  "\<lbrace>\<lambda>s. (\<forall>p. cte_wp_at' (\<lambda>cte. \<exists>final. finaliseCap (cteCap cte) final True \<noteq> fail) p s \<longrightarrow>
+          P ((cteCaps_of s)(p \<mapsto> NullCap))) \<and>
+     P (cteCaps_of s)\<rbrace>
+     cancelIPC t
+   \<lbrace>\<lambda>rv s. P (cteCaps_of s)\<rbrace>"
+  supply if_cong[cong]
+  apply (simp add: cancelIPC_def Let_def capHasProperty_def
+                   getThreadReplySlot_def locateSlot_conv)
+  apply (rule hoare_pre)
+   apply (wp cteDeleteOne_cteCaps_of getCTE_wp' | wpcw
+          | simp add: cte_wp_at_ctes_of
+          | wp (once) hoare_drop_imps cteCaps_of_ctes_of_lift)+
+          apply (wp hoare_convert_imp hoare_vcg_all_lift
+                    threadSet_ctes_of threadSet_cteCaps_of
+                 | clarsimp)+
+         apply (wp cteDeleteOne_cteCaps_of getCTE_wp' | wpcw | simp
+                | wp (once) hoare_drop_imps cteCaps_of_ctes_of_lift)+
+  apply (clarsimp simp: cte_wp_at_ctes_of cteCaps_of_def)
+  apply (drule_tac x="mdbNext (cteMDBNode x)" in spec)
+  apply clarsimp
+  apply (auto simp: o_def map_option_case fun_upd_def[symmetric])
+  done
+
+lemma cancelIPC_cte_wp_at':
+  assumes x: "\<And>cap final. P cap \<Longrightarrow> finaliseCap cap final True = fail"
+  shows "\<lbrace>\<lambda>s. cte_wp_at' (\<lambda>cte. P (cteCap cte)) p s\<rbrace>
+           cancelIPC t
+         \<lbrace>\<lambda>rv s. cte_wp_at' (\<lambda>cte. P (cteCap cte)) p s\<rbrace>"
+  apply (simp add: tree_cte_cteCap_eq[unfolded o_def])
+  apply (rule hoare_pre, wp cancelIPC_cteCaps_of)
+  apply (clarsimp simp: cteCaps_of_def cte_wp_at_ctes_of x)
+  done
+
+lemma suspend_cte_wp_at':
+  assumes x: "\<And>cap final. P cap \<Longrightarrow> finaliseCap cap final True = fail"
+  shows "\<lbrace>cte_wp_at' (\<lambda>cte. P (cteCap cte)) p\<rbrace>
+           suspend t
+         \<lbrace>\<lambda>rv. cte_wp_at' (\<lambda>cte. P (cteCap cte)) p\<rbrace>"
+  apply (simp add: suspend_def updateRestartPC_def cong: if_cong)
+  apply (rule hoare_pre)
+   apply (wp threadSet_cte_wp_at' cancelIPC_cte_wp_at'
+             | simp add: x)+
+  done
+
+end (* Finalise_R *)
+
+context Finalise_R_2 begin
+
+lemma deletingIRQHandler_cte_preserved:
+  assumes x: "\<And>cap final. P cap \<Longrightarrow> finaliseCap cap final True = fail"
+  shows "\<lbrace>cte_wp_at' (\<lambda>cte. P (cteCap cte)) p\<rbrace>
+           deletingIRQHandler irq
+         \<lbrace>\<lambda>rv. cte_wp_at' (\<lambda>cte. P (cteCap cte)) p\<rbrace>"
+  apply (simp add: deletingIRQHandler_def getSlotCap_def
+                   getIRQSlot_def locateSlot_conv getInterruptState_def)
+  apply (wpsimp wp: cteDeleteOne_cte_wp_at_preserved getCTE_wp' simp: x)
+  done
+
+lemma finaliseCap_equal_cap[wp]:
+  "\<lbrace>cte_wp_at' (\<lambda>cte. cteCap cte = cap) sl\<rbrace>
+     finaliseCap cap fin flag
+   \<lbrace>\<lambda>rv. cte_wp_at' (\<lambda>cte. cteCap cte = cap) sl\<rbrace>"
+  apply (simp add: finaliseCap_def Let_def
+             cong: if_cong split del: if_split)
+   apply (wpsimp wp: suspend_cte_wp_at' deletingIRQHandler_cte_preserved  simp: finaliseCap_def)
+  apply (case_tac cap; auto)
+  done
+
+end (* Finalise_R_2 *)
+
+lemma setThreadState_st_tcb_at_simplish':
+  "simple' st \<Longrightarrow>
+   \<lbrace>st_tcb_at' (P or simple') t\<rbrace>
+     setThreadState st t'
+   \<lbrace>\<lambda>rv. st_tcb_at' (P or simple') t\<rbrace>"
+  apply (wp sts_st_tcb_at'_cases)
+  apply clarsimp
+  done
+
+lemmas setThreadState_st_tcb_at_simplish
+    = setThreadState_st_tcb_at_simplish'[unfolded pred_disj_def]
+
+crunch cteDeleteOne
+  for st_tcb_at_simplish: "st_tcb_at' (\<lambda>st. P st \<or> simple' st) t"
+  (wp: crunch_wps getObject_inv loadObject_default_inv threadSet_pred_tcb_no_state
+   simp: crunch_simps unless_def ignore: threadSet)
+
+lemma cteDeleteOne_st_tcb_at[wp]:
+  assumes x[simp]: "\<And>st. simple' st \<longrightarrow> P st" shows
+  "\<lbrace>st_tcb_at' P t\<rbrace> cteDeleteOne slot \<lbrace>\<lambda>rv. st_tcb_at' P t\<rbrace>"
+  apply (subgoal_tac "\<exists>Q. P = (Q or simple')")
+   apply (clarsimp simp: pred_disj_def)
+   apply (rule cteDeleteOne_st_tcb_at_simplish)
+  apply (rule_tac x=P in exI)
+  apply auto
+  done
+
+lemma cteDeleteOne_reply_pred_tcb_at:
+  "\<lbrace>\<lambda>s. pred_tcb_at' proj P t s \<and> (\<exists>t' r. cte_wp_at' (\<lambda>cte. cteCap cte = ReplyCap t' False r) slot s)\<rbrace>
+    cteDeleteOne slot
+   \<lbrace>\<lambda>rv. pred_tcb_at' proj P t\<rbrace>"
+  apply (simp add: cteDeleteOne_def unless_def isFinalCapability_def)
+  apply (rule bind_wp [OF _ getCTE_sp])
+  apply (rule hoare_assume_pre)
+  apply (clarsimp simp: cte_wp_at_ctes_of when_def gen_isCap_simps
+                        Let_def finaliseCapTrue_standin_def)
+  apply (intro impI conjI, (wp | simp)+)
+  done
+
+lemmas setNotification_typ_at'[wp] = gen_typ_at_lifts[OF setNotification_typ_at']
+
+crunch setBoundNotification, setNotification
+  for sch_act_simple[wp]: sch_act_simple
+  (wp: sch_act_simple_lift)
+
+lemma rescheduleRequired_sch_act_not[wp]:
+  "\<lbrace>\<top>\<rbrace> rescheduleRequired \<lbrace>\<lambda>rv. sch_act_not t\<rbrace>"
+  apply (simp add: rescheduleRequired_def setSchedulerAction_def)
+  apply (wp hoare_TrueI | simp)+
+  done
+
+lemma cancelAllIPC_mapM_x_weak_sch_act:
+  "\<lbrace>\<lambda>s. weak_sch_act_wf (ksSchedulerAction s) s\<rbrace>
+   mapM_x (\<lambda>t. do
+                 y \<leftarrow> setThreadState Structures_H.thread_state.Restart t;
+                 tcbSchedEnqueue t
+               od) q
+   \<lbrace>\<lambda>rv s. weak_sch_act_wf (ksSchedulerAction s) s\<rbrace>"
+  apply (rule mapM_x_wp_inv)
+  apply (wp)
+  apply (clarsimp)
+  done
+
+lemma cancelAllIPC_mapM_x_valid_objs':
+  "\<lbrace>valid_objs' and pspace_aligned' and pspace_distinct'\<rbrace>
+   mapM_x (\<lambda>t. do
+                 y \<leftarrow> setThreadState Structures_H.thread_state.Restart t;
+                 tcbSchedEnqueue t
+               od) q
+   \<lbrace>\<lambda>_. valid_objs'\<rbrace>"
+  apply (rule hoare_strengthen_post)
+   apply (rule mapM_x_wp')
+  apply (wpsimp wp: sts_valid_objs')
+   apply (clarsimp simp: valid_tcb_state'_def)+
+  done
+
+lemma cancelAllIPC_mapM_x_tcbDomain_obj_at':
+  "\<lbrace>obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>
+   mapM_x (\<lambda>t. do
+                 y \<leftarrow> setThreadState Structures_H.thread_state.Restart t;
+                 tcbSchedEnqueue t
+               od) q
+  \<lbrace>\<lambda>_. obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>"
+  by (wp mapM_x_wp' | simp)+
+
+lemma rescheduleRequired_oa_queued':
+  "rescheduleRequired \<lbrace>obj_at' (\<lambda>tcb. Q (tcbDomain tcb) (tcbPriority tcb)) t\<rbrace>"
+  unfolding rescheduleRequired_def tcbSchedEnqueue_def tcbQueuePrepend_def
+  by (wpsimp wp: threadGet_wp)
+
+lemma cancelAllIPC_tcbDomain_obj_at':
+  "\<lbrace>obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>
+     cancelAllIPC epptr
+   \<lbrace>\<lambda>_. obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>"
+  apply (simp add: cancelAllIPC_def)
+  apply (wp hoare_vcg_conj_lift hoare_vcg_const_Ball_lift
+            rescheduleRequired_oa_queued' cancelAllIPC_mapM_x_tcbDomain_obj_at'
+            getEndpoint_wp
+       | wpc
+       | simp)+
+  done
+
+lemma cancelAllSignals_tcbDomain_obj_at':
+  "\<lbrace>obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>
+     cancelAllSignals epptr
+   \<lbrace>\<lambda>_. obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>"
+apply (simp add: cancelAllSignals_def)
+apply (wp hoare_vcg_conj_lift hoare_vcg_const_Ball_lift
+          rescheduleRequired_oa_queued' cancelAllIPC_mapM_x_tcbDomain_obj_at'
+          getNotification_wp
+     | wpc
+     | simp)+
+done
+
+lemma unbindMaybeNotification_tcbDomain_obj_at':
+  "\<lbrace>obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>
+     unbindMaybeNotification r
+   \<lbrace>\<lambda>_. obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>"
+  unfolding unbindMaybeNotification_def
+  by (wpsimp wp: getNotification_wp gbn_wp' simp: setBoundNotification_def doUnbindNotification_def)
+
+crunch isFinalCapability
+  for sch_act[wp]: "\<lambda>s. sch_act_wf (ksSchedulerAction s) s"
+  (simp: crunch_simps)
+
+crunch
+  isFinalCapability
+  for weak_sch_act[wp]: "\<lambda>s. weak_sch_act_wf (ksSchedulerAction s) s"
+  (simp: crunch_simps)
+
+crunch unbindNotification
+  for valid_cap'[wp]: "valid_cap' cap"
+
+lemma no_idle_thread_cap:
+  "\<lbrakk> cte_wp_at ((=) (cap.ThreadCap (idle_thread s))) sl s; valid_global_refs s \<rbrakk> \<Longrightarrow> False"
+  apply (cases sl)
+  apply (clarsimp simp: valid_global_refs_def valid_refs_def cte_wp_at_caps_of_state)
+  apply ((erule allE)+, erule (1) impE)
+  apply (clarsimp simp: cap_range_def)
+  done
+
+lemmas getCTE_no_0_obj'_helper
+  = getCTE_inv
+    hoare_strengthen_post[where Q'="\<lambda>_. no_0_obj'" and P=no_0_obj' and f="getCTE slot" for slot]
+
+lemma interrupt_cap_null_or_ntfn:
+  "invs s
+    \<Longrightarrow> cte_wp_at (\<lambda>cp. is_ntfn_cap cp \<or> cp = cap.NullCap) (interrupt_irq_node s irq, []) s"
+  apply (frule invs_valid_irq_node)
+  apply (clarsimp simp: valid_irq_node_def)
+  apply (drule_tac x=irq in spec)
+  apply (drule cte_at_0)
+  apply (clarsimp simp: cte_wp_at_caps_of_state)
+  apply (drule caps_of_state_cteD)
+  apply (frule if_unsafe_then_capD, clarsimp+)
+  apply (clarsimp simp: ex_cte_cap_wp_to_def cte_wp_at_caps_of_state)
+  apply (frule cte_refs_obj_refs_elem, erule disjE)
+   apply (clarsimp | drule caps_of_state_cteD valid_global_refsD[rotated]
+     | rule irq_node_global_refs[where irq=irq])+
+   apply (simp add: cap_range_def)
+  apply (clarsimp simp: appropriate_cte_cap_def
+                 split: cap.split_asm)
+  done
+
+lemma (in delete_one) deletingIRQHandler_corres:
+  "corres dc (einvs) (invs')
+          (deleting_irq_handler irq) (deletingIRQHandler irq)"
+  apply (simp add: deleting_irq_handler_def deletingIRQHandler_def)
+  apply (rule corres_guard_imp)
+    apply (rule corres_split[OF getIRQSlot_corres])
+      apply simp
+      apply (rule_tac P'="cte_at' (cte_map slot)" in corres_symb_exec_r_conj)
+         apply (rule_tac F="isNotificationCap rv \<or> rv = capability.NullCap"
+             and P="cte_wp_at (\<lambda>cp. is_ntfn_cap cp \<or> cp = cap.NullCap) slot
+                 and einvs"
+             and P'="invs' and cte_wp_at' (\<lambda>cte. cteCap cte = rv)
+                 (cte_map slot)" in corres_req)
+          apply (clarsimp simp: cte_wp_at_caps_of_state state_relation_def)
+          apply (drule caps_of_state_cteD)
+          apply (drule(1) pspace_relation_cte_wp_at, clarsimp+)
+          apply (auto simp: cte_wp_at_ctes_of is_cap_simps gen_isCap_simps)[1]
+         apply simp
+         apply (rule corres_guard_imp, rule delete_one_corres[unfolded dc_def])
+          apply (auto simp: cte_wp_at_caps_of_state is_cap_simps can_fast_finalise_def)[1]
+         apply (clarsimp simp: cte_wp_at_ctes_of)
+        apply (wp getCTE_wp' | simp add: getSlotCap_def)+
+     apply (wp | simp add: get_irq_slot_def getIRQSlot_def
+                           locateSlot_conv getInterruptState_def)+
+   apply (clarsimp simp: ex_cte_cap_wp_to_def interrupt_cap_null_or_ntfn)
+  apply (clarsimp simp: cte_wp_at_ctes_of)
+  done
+
+lemma return_NullCap_pair_corres[corres]:
+  "corres (\<lambda>r r'. cap_relation (fst r) (fst r') \<and> cap_relation (snd r) (snd r'))
+          \<top> \<top>
+          (return (cap.NullCap, cap.NullCap)) (return (NullCap, NullCap))"
+  by (corres corres: corres_returnTT)
+
+lemma unbindNotification_corres:
+  "corres dc
+      (invs and tcb_at t)
+      invs'
+      (unbind_notification t)
+      (unbindNotification t)"
+  apply (simp add: unbind_notification_def unbindNotification_def)
+  apply (rule corres_guard_imp)
+    apply (rule corres_split[OF getBoundNotification_corres])
+      apply (rule corres_option_split)
+        apply simp
+       apply (rule corres_return_trivial)
+      apply (rule corres_split[OF getNotification_corres])
+        apply (clarsimp simp: doUnbindNotification_def)
+        apply (rule corres_split[OF setNotification_corres])
+           apply (clarsimp simp: ntfn_relation_def split:Structures_A.ntfn.splits)
+          apply (rule setBoundNotification_corres)
+         apply (wp gbn_wp' gbn_wp)+
+   apply (clarsimp elim!: obj_at_valid_objsE
+                   dest!: bound_tcb_at_state_refs_ofD invs_valid_objs
+                    simp: valid_obj_def is_tcb tcb_ntfn_is_bound_def obj_at_def
+                          valid_tcb_def valid_bound_ntfn_def invs_psp_aligned invs_distinct
+                   split: option.splits)
+  apply (clarsimp dest!: obj_at_valid_objs' bound_tcb_at_state_refs_ofD' invs_valid_objs'
+                   simp: valid_obj'_def valid_tcb'_def valid_bound_ntfn'_def tcb_ntfn_is_bound'_def
+                  split: option.splits)
+  done
+
+lemma unbindMaybeNotification_corres:
+  "corres dc
+      (invs and ntfn_at ntfnptr) (invs' and ntfn_at' ntfnptr)
+      (unbind_maybe_notification ntfnptr)
+      (unbindMaybeNotification ntfnptr)"
+  apply (simp add: unbind_maybe_notification_def unbindMaybeNotification_def)
+  apply (rule corres_guard_imp)
+    apply (rule corres_split[OF getNotification_corres])
+      apply (rule corres_option_split)
+        apply (clarsimp simp: ntfn_relation_def split: Structures_A.ntfn.splits)
+       apply (rule corres_return_trivial)
+      apply (simp add: doUnbindNotification_def)
+      apply (rule corres_split[OF setNotification_corres])
+         apply (clarsimp simp: ntfn_relation_def split: Structures_A.ntfn.splits)
+        apply (rule setBoundNotification_corres)
+       apply (wp get_simple_ko_wp getNotification_wp)+
+   apply (clarsimp elim!: obj_at_valid_objsE
+                   dest!: bound_tcb_at_state_refs_ofD invs_valid_objs
+                    simp: valid_obj_def is_tcb tcb_ntfn_is_bound_def invs_psp_aligned invs_distinct
+                          valid_tcb_def valid_bound_ntfn_def valid_ntfn_def
+                   split: option.splits)
+  apply (clarsimp dest!: obj_at_valid_objs' bound_tcb_at_state_refs_ofD' invs_valid_objs'
+                   simp: valid_obj'_def valid_tcb'_def valid_bound_ntfn'_def
+                         tcb_ntfn_is_bound'_def valid_ntfn'_def
+                  split: option.splits)
+  done
+
+lemma threadSet_ct_idle_or_in_cur_domain':
+  "\<lbrace>ct_idle_or_in_cur_domain' and (\<lambda>s. \<forall>tcb. tcbDomain tcb = ksCurDomain s \<longrightarrow> tcbDomain (F tcb) = ksCurDomain s)\<rbrace>
+    threadSet F t
+   \<lbrace>\<lambda>_. ct_idle_or_in_cur_domain'\<rbrace>"
+  apply (simp add: ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def)
+  apply (wp hoare_vcg_disj_lift hoare_vcg_imp_lift)
+    apply wps
+    apply wp
+   apply wps
+   apply wp
+  apply (auto simp: obj_at'_def)
+  done
+
+lemma cte_wp_at_norm_eq':
+  "cte_wp_at' P p s = (\<exists>cte. cte_wp_at' ((=) cte) p s \<and> P cte)"
+  by (simp add: cte_wp_at_ctes_of)
+
+lemma isFinal_cte_wp_def:
+  "isFinal cap p (cteCaps_of s) =
+  (\<not>isUntypedCap cap \<and>
+   (\<forall>p'. p \<noteq> p' \<longrightarrow>
+         cte_at' p' s \<longrightarrow>
+         cte_wp_at' (\<lambda>cte'. \<not> isUntypedCap (cteCap cte') \<longrightarrow>
+                            \<not> sameObjectAs cap (cteCap cte')) p' s))"
+  apply (simp add: isFinal_def cte_wp_at_ctes_of cteCaps_of_def)
+  apply (rule iffI)
+   apply clarsimp
+   apply (case_tac cte)
+   apply fastforce
+  apply fastforce
+  done
+
+lemma valid_cte_at_neg_typ':
+  assumes T: "\<And>P T p. \<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace> f \<lbrace>\<lambda>_ s. P (typ_at' T p s)\<rbrace>"
+  shows "\<lbrace>\<lambda>s. \<not> cte_at' p' s\<rbrace> f \<lbrace>\<lambda>rv s. \<not> cte_at' p' s\<rbrace>"
+  apply (simp add: cte_at_typ')
+  apply (rule hoare_vcg_conj_lift [OF T])
+  apply (simp only: imp_conv_disj)
+  apply (rule hoare_vcg_all_lift)
+  apply (rule hoare_vcg_disj_lift [OF T])
+  apply (rule hoare_vcg_prop)
+  done
+
+lemma isFinal_lift:
+  assumes x: "\<And>P p. \<lbrace>cte_wp_at' P p\<rbrace> f \<lbrace>\<lambda>_. cte_wp_at' P p\<rbrace>"
+  assumes y: "\<And>P T p. \<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace> f \<lbrace>\<lambda>_ s. P (typ_at' T p s)\<rbrace>"
+  shows "\<lbrace>\<lambda>s. cte_wp_at' (\<lambda>cte. isFinal (cteCap cte) sl (cteCaps_of s)) sl s\<rbrace>
+         f
+         \<lbrace>\<lambda>r s. cte_wp_at' (\<lambda>cte. isFinal (cteCap cte) sl (cteCaps_of s)) sl s\<rbrace>"
+  apply (subst cte_wp_at_norm_eq')
+  apply (subst cte_wp_at_norm_eq' [where P="\<lambda>cte. isFinal (cteCap cte) sl m" for sl m])
+  apply (simp only: isFinal_cte_wp_def imp_conv_disj de_Morgan_conj)
+  apply (wp hoare_vcg_ex_lift hoare_vcg_all_lift x hoare_vcg_disj_lift
+            valid_cte_at_neg_typ' [OF y])
+  done
+
+lemma setEndpoint_sch_act_not_ct[wp]:
+  "\<lbrace>\<lambda>s. sch_act_not (ksCurThread s) s\<rbrace>
+   setEndpoint ptr val \<lbrace>\<lambda>_ s. sch_act_not (ksCurThread s) s\<rbrace>"
+  by (rule hoare_weaken_pre, wps, wp, simp)
+
+lemma sbn_ct_in_state'[wp]:
+  "\<lbrace>ct_in_state' P\<rbrace> setBoundNotification ntfn t \<lbrace>\<lambda>_. ct_in_state' P\<rbrace>"
+  apply (simp add: ct_in_state'_def)
+  apply (rule hoare_pre)
+   apply (wps setBoundNotification_ct')
+  apply (wp sbn_st_tcb', clarsimp)
+  done
+
+lemma set_ntfn_ct_in_state'[wp]:
+  "\<lbrace>ct_in_state' P\<rbrace> setNotification a ntfn \<lbrace>\<lambda>_. ct_in_state' P\<rbrace>"
+  apply (simp add: ct_in_state'_def)
+  apply (rule hoare_pre)
+   apply (wps setNotification_ksCurThread, wp, clarsimp)
+  done
+
+lemma unbindMaybeNotification_ct_in_state'[wp]:
+  "\<lbrace>ct_in_state' P\<rbrace> unbindMaybeNotification t \<lbrace>\<lambda>_. ct_in_state' P\<rbrace>"
+  unfolding unbindMaybeNotification_def
+  by (wpsimp simp: doUnbindNotification_def)
+
+lemma setNotification_sch_act_sane:
+  "\<lbrace>sch_act_sane\<rbrace> setNotification a ntfn \<lbrace>\<lambda>_. sch_act_sane\<rbrace>"
+  by (wp sch_act_sane_lift)
+
+lemma unbindMaybeNotification_sch_act_sane[wp]:
+  "\<lbrace>sch_act_sane\<rbrace> unbindMaybeNotification t \<lbrace>\<lambda>_. sch_act_sane\<rbrace>"
+  unfolding unbindMaybeNotification_def
+  by (wpsimp wp: setNotification_sch_act_sane sbn_sch_act_sane simp: doUnbindNotification_def)
+
+context Finalise_R_2 begin
+
+lemma isFinal:
+  "\<lbrace>\<lambda>s. valid_mdb' s \<and> cte_wp_at' ((=) cte) x s
+          \<and> final_matters' (cteCap cte)
+          \<and> Q (isFinal (cteCap cte) x (cteCaps_of s)) s\<rbrace>
+    isFinalCapability cte
+   \<lbrace>Q\<rbrace>"
+  unfolding isFinalCapability_def
+  apply (cases cte)
+  apply (rename_tac cap node)
+  apply (unfold Let_def)
+  apply (simp only: if_False)
+  apply (wp getCTE_wp')
+  apply (cases "mdbPrev (cteMDBNode cte) = nullPointer")
+   apply simp
+   apply (clarsimp simp: valid_mdb_ctes_def valid_mdb'_def
+                         cte_wp_at_ctes_of)
+   apply (rule conjI, clarsimp simp: nullPointer_def)
+    apply (erule rsubst[where P="\<lambda>x. Q x s" for s], simp)
+    apply (rule classical)
+    apply (drule(5) notFinal_prev_or_next)
+    apply clarsimp
+   apply (clarsimp simp: nullPointer_def)
+   apply (erule rsubst[where P="\<lambda>x. Q x s" for s])
+   apply (rule sym, rule iffI)
+    apply (rule classical)
+    apply (drule(5) notFinal_prev_or_next)
+    apply clarsimp
+   apply clarsimp
+   apply (clarsimp simp: cte_wp_at_ctes_of cteCaps_of_def)
+   apply (case_tac cte)
+   apply clarsimp
+   apply (clarsimp simp add: isFinal_def)
+   apply (erule_tac x="mdbNext node" in allE)
+   apply simp
+   apply (erule impE)
+    apply (clarsimp simp: valid_mdb'_def valid_mdb_ctes_def)
+    apply (drule (1) mdb_chain_0_no_loops)
+    apply simp
+   apply (clarsimp simp: sameObjectAs_not_Untyped)
+  apply simp
+  apply (clarsimp simp: cte_wp_at_ctes_of
+                        valid_mdb_ctes_def valid_mdb'_def)
+  apply (case_tac cte)
+  apply clarsimp
+  apply (rule conjI)
+   apply clarsimp
+   apply (erule rsubst[where P="\<lambda>x. Q x s" for s])
+   apply clarsimp
+   apply (clarsimp simp: isFinal_def cteCaps_of_def)
+   apply (erule_tac x="mdbPrev node" in allE)
+   apply simp
+   apply (erule impE)
+    apply clarsimp
+    apply (drule (1) mdb_chain_0_no_loops)
+    apply (subgoal_tac "ctes_of s (mdbNext node) = Some (CTE cap node)")
+     apply clarsimp
+    apply (erule (1) valid_dlistEp)
+     apply clarsimp
+    apply (case_tac cte')
+    apply clarsimp
+   subgoal by (simp add: verit_implies_simplify(1) sameObjectAs_not_Untyped)
+              (simp add: sameObjectAs_not_Untyped') (* simps do not combine *)
+  apply clarsimp
+  apply (rule conjI)
+   apply clarsimp
+   apply (erule rsubst[where P="\<lambda>x. Q x s" for s], simp)
+   apply (rule classical, drule(5) notFinal_prev_or_next)
+   apply (clarsimp simp: sameObjectAs_sym nullPointer_def)
+  apply (clarsimp simp: nullPointer_def)
+  apply (erule rsubst[where P="\<lambda>x. Q x s" for s])
+  apply (rule sym, rule iffI)
+   apply (rule classical, drule(5) notFinal_prev_or_next)
+   apply (clarsimp simp: sameObjectAs_sym)
+   apply auto[1]
+  apply (clarsimp simp: isFinal_def cteCaps_of_def)
+  apply (case_tac cte)
+  apply (erule_tac x="mdbNext node" in allE)
+  apply simp
+  apply (erule impE)
+   apply clarsimp
+   apply (drule (1) mdb_chain_0_no_loops)
+   apply simp
+  apply (clarsimp simp: sameObjectAs_not_Untyped)
+  done
+
+crunch cteDeleteOne, unbindNotification
+  for sch_act_simple[wp]: sch_act_simple
+  (wp: crunch_wps ssa_sch_act_simple sts_sch_act_simple getObject_inv
+       loadObject_default_inv
+   simp: crunch_simps
+   rule: sch_act_simple_lift)
+
+crunch cteDeleteOne
+  for sch_act_not[wp]: "sch_act_not t"
+  (simp: crunch_simps case_Null_If unless_def
+   wp: crunch_wps getObject_inv loadObject_default_inv)
+
+crunch cteDeleteOne
+  for ksCurDomain[wp]: "\<lambda>s. P (ksCurDomain s)"
+  (wp: crunch_wps simp: crunch_simps unless_def)
+
+lemma cteDeleteOne_tcbDomain_obj_at':
+  "\<lbrace>obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace> cteDeleteOne slot \<lbrace>\<lambda>_. obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>"
+  apply (simp add: cteDeleteOne_def unless_def split_def)
+  apply (wp emptySlot_tcbDomain cancelAllIPC_tcbDomain_obj_at' cancelAllSignals_tcbDomain_obj_at'
+          isFinalCapability_inv getCTE_wp
+          unbindMaybeNotification_tcbDomain_obj_at'
+     | rule hoare_drop_imp
+     | simp add: finaliseCapTrue_standin_def Let_def
+            split del: if_split
+     | wpc)+
+  apply (clarsimp simp: cte_wp_at'_def)
+  done
+
+lemma fast_finaliseCap_corres:
+  "\<lbrakk> final_matters' cap' \<longrightarrow> final = final'; cap_relation cap cap';
+     can_fast_finalise cap \<rbrakk>
+   \<Longrightarrow> corres dc
+           (\<lambda>s. invs s \<and> valid_sched s \<and> s \<turnstile> cap
+                       \<and> cte_wp_at ((=) cap) sl s)
+           (\<lambda>s. invs' s \<and> s \<turnstile>' cap')
+           (fast_finalise cap final)
+           (do
+               p \<leftarrow> finaliseCap cap' final' True;
+               assert (capRemovable (fst p) (cte_map ptr) \<and> snd p = NullCap)
+            od)"
+  apply (cases cap, simp_all add: finaliseCap_def gen_isCap_simps
+                                  corres_liftM2_simp[unfolded liftM_def]
+                                  o_def dc_def[symmetric] when_def
+                                  can_fast_finalise_def capRemovable_def
+                       split del: if_split cong: if_cong)
+   apply (clarsimp simp: final_matters'_def)
+   apply (rule corres_guard_imp)
+     apply (rule corres_rel_imp)
+      apply (rule ep_cancel_corres)
+     apply simp
+    apply (simp add: valid_cap_def)
+   apply (simp add: valid_cap'_def)
+  apply (clarsimp simp: final_matters'_def)
+  apply (rule corres_guard_imp)
+    apply (rule corres_split[OF unbindMaybeNotification_corres])
+         apply (rule cancelAllSignals_corres)
+       apply (wp abs_typ_at_lifts unbind_maybe_notification_invs gen_typ_at_lifts hoare_drop_imps getNotification_wp
+            | wpc)+
+   apply (clarsimp simp: valid_cap_def)
+  apply (clarsimp simp: valid_cap'_def valid_obj'_def
+                 dest!: invs_valid_objs' obj_at_valid_objs' )
+  done
+
+crunch ThreadDecls_H.suspend, unbindNotification
+  for no_0_obj'[wp]: no_0_obj'
+  (simp: crunch_simps wp: crunch_wps getCTE_no_0_obj'_helper cong: option.case_cong_weak)
+
+crunch deleteCallerCap
+  for idle_thread[wp]: "\<lambda>s. P (ksIdleThread s)"
+  (wp: crunch_wps)
+crunch deleteCallerCap
+  for sch_act_simple: sch_act_simple
+  (wp: crunch_wps)
+crunch deleteCallerCap
+  for sch_act_not[wp]: "sch_act_not t"
+  (wp: crunch_wps)
+crunch deleteCallerCap
+  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
+  (wp: crunch_wps)
+
+lemmas deleteCallerCap_gen_typ_ats[wp] = gen_typ_at_lifts[OF deleteCallerCap_typ_at']
+
+sublocale delete_one_conc_pre
+  by (unfold_locales, wp)
+     (wp cteDeleteOne_tcbDomain_obj_at' cteDeleteOne_typ_at' cteDeleteOne_reply_pred_tcb_at | simp)+
+
+end (* Finalise_R_2 *)
+
+locale Finalise_R_3 = Finalise_R_2 +
+  assumes isFinalCapability_corres':
+    "\<And>cap ptr cte.
+     final_matters' (cteCap cte) \<Longrightarrow>
+     corres (=) (invs and cte_wp_at ((=) cap) ptr)
+                 (invs' and cte_wp_at' ((=) cte) (cte_map ptr))
+         (is_final_cap cap) (isFinalCapability cte)"
+  assumes cteDeleteOne_invs[wp]:
+    "\<And>ptr. cteDeleteOne ptr \<lbrace>invs'\<rbrace>"
+  assumes arch_finaliseCap_corres:
+    "\<And>cap cap' final final'.
+     \<lbrakk>final_matters' (ArchObjectCap cap') \<Longrightarrow> final = final'; acap_relation cap cap'\<rbrakk>
+     \<Longrightarrow> corres (\<lambda>r r'. cap_relation (fst r) (fst r') \<and> cap_relation (snd r) (snd r'))
+               (\<lambda>s. invs s \<and> s \<turnstile> cap.ArchObjectCap cap
+                    \<and> (final_matters (cap.ArchObjectCap cap)
+                    \<longrightarrow> final = is_final_cap' (cap.ArchObjectCap cap) s)
+                       \<and> cte_wp_at ((=) (cap.ArchObjectCap cap)) sl s)
+               (\<lambda>s. invs' s \<and> s \<turnstile>' ArchObjectCap cap' \<and>
+                    (final_matters' (ArchObjectCap cap') \<longrightarrow>
+                     final' = isFinal (ArchObjectCap cap') (cte_map sl) (cteCaps_of s)))
+               (arch_finalise_cap cap final) (Arch.finaliseCap cap' final')"
+begin
+
+sublocale delete_one_conc_fr: delete_one_conc
+  by unfold_locales (wp cteDeleteOne_invs)
+
+lemma finaliseCap_valid_cap[wp]:
+  "\<lbrace>valid_cap' cap\<rbrace> finaliseCap cap final flag \<lbrace>\<lambda>rv. valid_cap' (fst rv)\<rbrace>"
+  apply (simp add: finaliseCap_def Let_def
+                   getThreadCSpaceRoot
+             cong: if_cong split del: if_split)
+  apply (rule hoare_pre)
+   apply (wp | simp only: valid_NullCap o_def fst_conv | wpc)+
+  apply simp
+  apply (intro conjI impI)
+   apply (clarsimp simp: valid_cap'_def gen_isCap_simps capAligned_def
+                         gen_objBits_simps shiftL_nat)+
+  done
+
+lemma deletingIRQHandler_invs' [wp]:
+  "\<lbrace>invs'\<rbrace> deletingIRQHandler i \<lbrace>\<lambda>_. invs'\<rbrace>"
+  apply (simp add: deletingIRQHandler_def getSlotCap_def
+                   getIRQSlot_def locateSlot_conv getInterruptState_def)
+  apply (wp getCTE_wp')
+  apply simp
+  done
+
+lemma finaliseCap_invs:
+  "\<lbrace>invs' and sch_act_simple and valid_cap' cap
+         and cte_wp_at' (\<lambda>cte. cteCap cte = cap) sl\<rbrace>
+     finaliseCap cap fin flag
+   \<lbrace>\<lambda>rv. invs'\<rbrace>"
+  apply (simp add: finaliseCap_def Let_def
+             cong: if_cong split del: if_split)
+  apply (rule hoare_pre)
+   apply (wp hoare_drop_imps hoare_vcg_all_lift | simp only: o_def | wpc)+
+  apply clarsimp
+  apply (intro conjI impI)
+    apply (clarsimp dest!: isCapDs simp: valid_cap'_def)
+   apply (drule invs_valid_global', drule(1) valid_globals_cte_wpD')
+   apply (drule valid_capAligned, drule capAligned_capUntypedPtr)
+    apply (clarsimp dest!: isCapDs)
+   apply (clarsimp dest!: isCapDs)
+  apply (clarsimp dest!: isCapDs)
+  done
+
+lemma finaliseCap_zombie_cap[wp]:
+  "\<lbrace>cte_wp_at' (\<lambda>cte. (P and isZombie) (cteCap cte)) sl\<rbrace>
+     finaliseCap cap fin flag
+   \<lbrace>\<lambda>rv. cte_wp_at' (\<lambda>cte. (P and isZombie) (cteCap cte)) sl\<rbrace>"
+  apply (simp add: finaliseCap_def Let_def
+             cong: if_cong split del: if_split)
+  apply (rule hoare_pre)
+   apply (wp suspend_cte_wp_at' deletingIRQHandler_cte_preserved
+          | clarsimp simp: finaliseCap_def gen_isCap_simps | wpc)+
+  done
+
+lemma finaliseCap_zombie_cap':
+  "\<lbrace>cte_wp_at' (\<lambda>cte. (P and isZombie) (cteCap cte)) sl\<rbrace>
+     finaliseCap cap fin flag
+   \<lbrace>\<lambda>rv. cte_wp_at' (\<lambda>cte. P (cteCap cte)) sl\<rbrace>"
+  apply (rule hoare_strengthen_post)
+   apply (rule finaliseCap_zombie_cap)
+  apply (clarsimp simp: cte_wp_at_ctes_of)
+  done
+
+lemma finaliseCap_cte_cap_wp_to[wp]:
+  "\<lbrace>ex_cte_cap_wp_to' P sl\<rbrace> finaliseCap cap fin flag \<lbrace>\<lambda>rv. ex_cte_cap_wp_to' P sl\<rbrace>"
+  apply (simp add: ex_cte_cap_to'_def)
+  apply (rule hoare_pre, rule hoare_use_eq_irq_node' [OF finaliseCap_irq_node'])
+   apply (simp add: finaliseCap_def Let_def
+              cong: if_cong split del: if_split)
+   apply (wp suspend_cte_wp_at'
+             deletingIRQHandler_cte_preserved
+             hoare_vcg_ex_lift
+                 | clarsimp simp: finaliseCap_def gen_isCap_simps
+                 | rule conjI
+                 | wpc)+
+  apply fastforce
+  done
+
+lemma isFinalCapability_corres:
+  "corres (\<lambda>rv rv'. final_matters' (cteCap cte) \<longrightarrow> rv = rv')
+          (invs and cte_wp_at ((=) cap) ptr)
+          (invs' and cte_wp_at' ((=) cte) (cte_map ptr))
+       (is_final_cap cap) (isFinalCapability cte)"
+  apply (cases "final_matters' (cteCap cte)")
+   apply simp
+   apply (erule isFinalCapability_corres')
+  apply (subst bind_return[symmetric],
+         rule corres_symb_exec_r)
+     apply (rule corres_no_failI)
+      apply wp
+     apply (clarsimp simp: in_monad is_final_cap_def simpler_gets_def)
+    apply (wp isFinalCapability_inv)+
+  apply fastforce
+  done
+
+lemma cap_delete_one_corres:
+  "corres dc (einvs and cte_wp_at can_fast_finalise ptr)
+        (invs' and cte_at' (cte_map ptr))
+        (cap_delete_one ptr) (cteDeleteOne (cte_map ptr))"
+  apply (simp add: cap_delete_one_def cteDeleteOne_def'
+                   unless_def when_def)
+  apply (rule corres_guard_imp)
+    apply (rule corres_split[OF get_cap_corres])
+      apply (rule_tac F="can_fast_finalise cap" in corres_gen_asm)
+      apply (rule corres_if)
+        apply fastforce
+       apply (rule corres_split[OF isFinalCapability_corres[where ptr=ptr]])
+         apply (simp add: split_def bind_assoc [THEN sym])
+         apply (rule corres_split[OF fast_finaliseCap_corres[where sl=ptr]])
+              apply simp+
+           apply (rule emptySlot_corres, simp)
+          apply (repeat 3 \<open>wp hoare_drop_imps\<close>)
+       apply (wp isFinalCapability_inv | wp (once) isFinal[where x="cte_map ptr"])+
+      apply (rule corres_trivial, simp)
+     apply (wp get_cap_wp getCTE_wp)+
+   apply (clarsimp simp: cte_wp_at_caps_of_state can_fast_finalise_Null
+                  elim!: caps_of_state_valid_cap)
+  apply (clarsimp simp: cte_wp_at_ctes_of)
+  apply fastforce
+  done
+
+sublocale delete_one
+  by (unfold_locales)
+     (corres corres: cap_delete_one_corres)
+
+lemma finaliseCap_corres:
+  "\<lbrakk> final_matters' cap' \<Longrightarrow> final = final'; cap_relation cap cap';
+          flag \<longrightarrow> can_fast_finalise cap \<rbrakk>
+     \<Longrightarrow> corres (\<lambda>x y. cap_relation (fst x) (fst y) \<and> cap_relation (snd x) (snd y))
+           (\<lambda>s. einvs s \<and> s \<turnstile> cap \<and> (final_matters cap \<longrightarrow> final = is_final_cap' cap s)
+                       \<and> cte_wp_at ((=) cap) sl s)
+           (\<lambda>s. invs' s \<and> s \<turnstile>' cap' \<and> sch_act_simple s \<and>
+                 (final_matters' cap' \<longrightarrow>
+                      final' = isFinal cap' (cte_map sl) (cteCaps_of s)))
+           (finalise_cap cap final) (finaliseCap cap' final' flag)"
+  supply invs_no_0_obj'[simp]
+  apply (cases cap, simp_all add: finaliseCap_def gen_isCap_simps
+                                  corres_liftM2_simp[unfolded liftM_def]
+                                  o_def dc_def[symmetric] when_def
+                                  can_fast_finalise_def
+                       split del: if_split cong: if_cong)
+        apply (clarsimp simp: final_matters'_def)
+        apply (rule corres_guard_imp)
+          apply (rule ep_cancel_corres)
+         apply (simp add: valid_cap_def)
+        apply (simp add: valid_cap'_def)
+       apply (clarsimp simp add: final_matters'_def)
+       apply (rule corres_guard_imp)
+         apply (rule corres_split[OF unbindMaybeNotification_corres])
+           apply (rule cancelAllSignals_corres)
+          apply (wpsimp wp: abs_typ_at_lifts unbind_maybe_notification_invs gen_typ_at_lifts hoare_drop_imps
+                            hoare_vcg_all_lift)+
+        apply (clarsimp simp: valid_cap_def)
+       apply (clarsimp simp: valid_cap'_def)
+      apply (fastforce simp: final_matters'_def shiftL_nat zbits_map_def)
+     apply (clarsimp simp add: final_matters'_def getThreadCSpaceRoot
+                               liftM_def[symmetric] o_def zbits_map_def
+                               dc_def[symmetric])
+     apply (rename_tac t)
+     apply (rule_tac P="\<lambda>s. t \<noteq> idle_thread s" and P'="\<lambda>s. t \<noteq> ksIdleThread s" in corres_add_guard)
+      apply clarsimp
+      apply (rule context_conjI)
+       apply (clarsimp dest!: no_idle_thread_cap)
+      apply (clarsimp simp: state_relation_def)
+     apply (rule corres_guard_imp)
+       apply (rule corres_split[OF unbindNotification_corres])
+         apply (rule corres_split[OF suspend_corres])
+           apply (clarsimp simp: liftM_def[symmetric] o_def dc_def[symmetric] zbits_map_def)
+           apply (rule prepareThreadDelete_corres, simp)
+          apply (wp unbind_notification_invs unbind_notification_simple_sched_action
+                    delete_one_conc_fr.suspend_objs')+
+      apply (clarsimp simp add: valid_cap_def)
+     apply (clarsimp simp add: valid_cap'_def)
+    apply (simp add: final_matters'_def liftM_def[symmetric]
+                     o_def dc_def[symmetric])
+    apply (intro impI, rule corres_guard_imp)
+      apply (rule deletingIRQHandler_corres)
+     apply simp
+    apply simp
+   apply (clarsimp simp: final_matters'_def)
+   apply (rule_tac F="False" in corres_req)
+    apply clarsimp
+    apply (frule zombies_finalD, (clarsimp simp: is_cap_simps)+)
+    apply (clarsimp simp: cte_wp_at_caps_of_state)
+   apply simp
+  apply (clarsimp split del: if_split simp: o_def)
+  apply (rule corres_guard_imp [OF arch_finaliseCap_corres], (fastforce simp: valid_sched_def)+)
+  done
+
+end (* Finalise_R_3 *)
+
 end

--- a/proof/refine/IpcCancel_R.thy
+++ b/proof/refine/IpcCancel_R.thy
@@ -11,6 +11,8 @@ imports
   ArchSchedule_R
 begin
 
+arch_requalify_consts (H) prepareThreadDelete
+
 arch_requalify_facts
   asUser_sym_heap_sched_pointers (* free type variable *)
 
@@ -396,6 +398,10 @@ locale IpcCancel_R =
     "\<And>acap. arch_post_cap_deletion acap \<lbrace>\<lambda>s::det_state. pspace_distinct s\<rbrace>"
   assumes arch_post_cap_deletion_pspace_aligned[wp]:
     "\<And>acap. arch_post_cap_deletion acap \<lbrace>\<lambda>s::det_state. pspace_aligned s\<rbrace>"
+  assumes prepareThreadDelete_corres[corres]:
+    "\<And>t t'. t' = t \<Longrightarrow>
+            corres dc (invs and tcb_at t) no_0_obj'
+                   (prepare_thread_delete t) (prepareThreadDelete t')"
 
 context IpcCancel_R begin
 
@@ -2182,7 +2188,7 @@ crunch setThreadState
   for obj_at'_tcbQueued[wp]: "\<lambda>s. Q (obj_at' (\<lambda>tcb. P (tcbQueued tcb)) t s)"
   (wp: threadSet_obj_at'_no_state crunch_wps simp: crunch_simps)
 
-lemma suspend_unqueued:
+lemma suspend_unqueued[wp]:
   "\<lbrace>\<top>\<rbrace> suspend t \<lbrace>\<lambda>rv. obj_at' (Not \<circ> tcbQueued) t\<rbrace>"
   unfolding suspend_def
   by (wpsimp simp: comp_def wp: tcbSchedDequeue_not_tcbQueued)

--- a/proof/refine/Machine_R.thy
+++ b/proof/refine/Machine_R.thy
@@ -37,5 +37,7 @@ locale Machine_R =
   assumes dmo_getirq_inv[wp]:
     "\<And>P in_kernel.
      irq_state_independent_H P \<Longrightarrow> \<lbrace>P\<rbrace> doMachineOp (getActiveIRQ in_kernel) \<lbrace>\<lambda>rv. P\<rbrace>"
+  assumes setIRQState_irq_states'[wp]:
+    "\<And>state irq. setIRQState state irq \<lbrace>valid_irq_states'\<rbrace>"
 
 end

--- a/proof/refine/RISCV64/ArchFinalise_R.thy
+++ b/proof/refine/RISCV64/ArchFinalise_R.thy
@@ -1,5 +1,6 @@
 (*
  * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ * Copyright 2023, Proofcraft Pty Ltd
  *
  * SPDX-License-Identifier: GPL-2.0-only
  *)
@@ -9,9 +10,54 @@ imports
   Finalise_R
 begin
 
-context begin interpretation Arch . (*FIXME: arch-split*)
+context Arch begin arch_global_naming
 
-declare doUnbindNotification_def[simp]
+named_theorems Finalise_R_assms
+
+lemma arch_postCapDeletion_ksArchState_lift[Finalise_R_assms]:
+  "\<lbrakk>\<And>s as. P (s\<lparr>ksArchState := as\<rparr>) = P s\<rbrakk> \<Longrightarrow> Arch.postCapDeletion ac \<lbrace>P\<rbrace>"
+  unfolding postCapDeletion_def
+  by wpsimp
+
+lemmas clearUntypedFreeIndex_typ_ats[wp] = typ_at_lifts[OF clearUntypedFreeIndex_typ_at']
+
+lemma setIRQState_umm[Finalise_R_assms]:
+  "setIRQState irqState irq \<lbrace>\<lambda>s. P (underlying_memory (ksMachineState s))\<rbrace> "
+  by (simp add: setIRQState_def maskInterrupt_def
+                setInterruptState_def getInterruptState_def
+      | wp dmo_lift')+
+
+(* better crunch names for Arch.postCapDeletion *)
+abbreviation (input)
+  "Arch_postCapDeletion \<equiv> Arch.postCapDeletion"
+
+crunch Arch_postCapDeletion
+  for valid_global_refs[wp]: valid_global_refs'
+  and valid_arch_state'[wp]: valid_arch_state'
+  (rule: RISCV64_H.postCapDeletion_def)
+
+lemma arch_postCapDeletion_corres[Finalise_R_assms]:
+  "acap_relation cap cap' \<Longrightarrow> corres dc \<top> \<top> (arch_post_cap_deletion cap) (RISCV64_H.postCapDeletion cap')"
+  by (clarsimp simp: arch_post_cap_deletion_def RISCV64_H.postCapDeletion_def)
+
+(* better crunch names for Arch.finaliseCap *)
+abbreviation (input)
+  "Arch_finaliseCap \<equiv> Arch.finaliseCap"
+
+crunch Arch_finaliseCap, prepareThreadDelete, archThreadSet
+  for typ_at'[Finalise_R_assms, wp]: "\<lambda>s. P (typ_at' T p s)"
+  and aligned'[Finalise_R_assms, wp]: "pspace_aligned'"
+  and distinct'[Finalise_R_assms, wp]: "pspace_distinct'"
+  (wp: crunch_wps getObject_inv loadObject_default_inv
+   simp: crunch_simps unless_def o_def
+   ignore_del: setObject
+   rule: RISCV64_H.finaliseCap_def)
+
+crunch prepareThreadDelete, Arch_finaliseCap
+  for it'[Finalise_R_assms, wp]: "\<lambda>s. P (ksIdleThread s)"
+  (wp: hoare_drop_imps
+   simp: crunch_simps updateObject_default_def
+   rule: RISCV64_H.finaliseCap_def)
 
 crunch copyGlobalMappings
   for ifunsafe'[wp]: "if_unsafe_then_cap'"
@@ -22,474 +68,32 @@ crunch copyGlobalMappings
   and ct__in_cur_domain'[wp]: ct_idle_or_in_cur_domain'
   and gsUntypedZeroRanges[wp]: "\<lambda>s. P (gsUntypedZeroRanges s)"
   and gsMaxObjectSize[wp]: "\<lambda>s. P (gsMaxObjectSize s)"
-  and it'[wp]: "\<lambda>s. P (ksIdleThread s)"
   and valid_irq_states'[wp]: "valid_irq_states'"
   and ksDomScheduleIdx[wp]: "\<lambda>s. P (ksDomScheduleIdx s)"
   (wp: crunch_wps ignore: storePTE)
 
-text \<open>Properties about empty_slot/emptySlot\<close>
+definition
+  arch_final_matters' :: "arch_capability \<Rightarrow> bool" where
+ "arch_final_matters' acap \<equiv> case acap of
+    FrameCap ref rghts sz d mapdata \<Rightarrow> False
+  | ASIDControlCap \<Rightarrow> False
+  | _ \<Rightarrow> True"
 
-lemma case_Null_If:
-  "(case c of NullCap \<Rightarrow> a | _ \<Rightarrow> b) = (if c = NullCap then a else b)"
-  by (case_tac c, simp_all)
+definition arch_cap_has_cleanup' :: "arch_capability \<Rightarrow> bool" where
+  "arch_cap_has_cleanup' _ \<equiv> False"
 
-crunch emptySlot
-  for aligned'[wp]: pspace_aligned'
-  and pspace_canonical'[wp]: pspace_canonical'
-  and pspace_in_kernel_mappings'[wp]: pspace_in_kernel_mappings'
-  and distinct'[wp]: pspace_distinct'
-  (simp: case_Null_If)
+definition
+  "post_cap_delete_pre' cap sl cs \<equiv> case cap of
+     IRQHandlerCap irq \<Rightarrow> irq \<le> maxIRQ \<and> (\<forall>sl'. sl \<noteq> sl' \<longrightarrow> cs sl' \<noteq> Some cap)
+   | _ \<Rightarrow> False"
 
-lemma updateCap_cte_wp_at_cases:
-  "\<lbrace>\<lambda>s. (ptr = ptr' \<longrightarrow> cte_wp_at' (P \<circ> cteCap_update (K cap)) ptr' s) \<and> (ptr \<noteq> ptr' \<longrightarrow> cte_wp_at' P ptr' s)\<rbrace>
-     updateCap ptr cap
-   \<lbrace>\<lambda>rv. cte_wp_at' P ptr'\<rbrace>"
-  apply (clarsimp simp: valid_def)
-  apply (drule updateCap_stuff)
-  apply (clarsimp simp: cte_wp_at_ctes_of modify_map_def)
-  done
+end (* Arch *)
 
-crunch postCapDeletion, updateTrackedFreeIndex
-  for cte_wp_at'[wp]: "cte_wp_at' P p"
+arch_requalify_consts
+  arch_final_matters'
+  arch_cap_has_cleanup'
 
-lemma updateFreeIndex_cte_wp_at:
-  "\<lbrace>\<lambda>s. cte_at' p s \<and> P (cte_wp_at' (if p = p' then P'
-      o (cteCap_update (capFreeIndex_update (K idx))) else P') p' s)\<rbrace>
-    updateFreeIndex p idx
-  \<lbrace>\<lambda>rv s. P (cte_wp_at' P' p' s)\<rbrace>"
-  apply (simp add: updateFreeIndex_def updateTrackedFreeIndex_def
-        split del: if_split)
-  apply (rule hoare_pre)
-   apply (wp updateCap_cte_wp_at' getSlotCap_wp)
-  apply (clarsimp simp: cte_wp_at_ctes_of)
-  apply (cases "p' = p", simp_all)
-  apply (case_tac cte, simp)
-  done
-
-lemma emptySlot_cte_wp_cap_other:
-  "\<lbrace>(\<lambda>s. cte_wp_at' (\<lambda>c. P (cteCap c)) p s) and K (p \<noteq> p')\<rbrace>
-  emptySlot p' opt
-  \<lbrace>\<lambda>rv s. cte_wp_at' (\<lambda>c. P (cteCap c)) p s\<rbrace>"
-  apply (rule hoare_gen_asm)
-  apply (simp add: emptySlot_def clearUntypedFreeIndex_def getSlotCap_def)
-  apply (rule hoare_pre)
-   apply (wp updateMDB_weak_cte_wp_at updateCap_cte_wp_at_cases
-             updateFreeIndex_cte_wp_at getCTE_wp' hoare_vcg_all_lift
-              | simp add:  | wpc
-              | wp (once) hoare_drop_imps)+
-  done
-
-lemmas clearUntypedFreeIndex_typ_ats[wp] = typ_at_lifts[OF clearUntypedFreeIndex_typ_at']
-
-crunch postCapDeletion
-  for tcb_at'[wp]: "tcb_at' t"
-crunch emptySlot
-  for ct[wp]: "\<lambda>s. P (ksCurThread s)"
-crunch clearUntypedFreeIndex
-  for cur_tcb'[wp]: "cur_tcb'"
-  (wp: cur_tcb_lift)
-
-crunch emptySlot
-  for ksRQ[wp]: "\<lambda>s. P (ksReadyQueues s)"
-crunch emptySlot
-  for ksRQL1[wp]: "\<lambda>s. P (ksReadyQueuesL1Bitmap s)"
-crunch emptySlot
-  for ksRQL2[wp]: "\<lambda>s. P (ksReadyQueuesL2Bitmap s)"
-crunch postCapDeletion
-  for obj_at'[wp]: "obj_at' P p"
-
-crunch clearUntypedFreeIndex
-  for inQ[wp]: "\<lambda>s. P (obj_at' (inQ d p) t s)"
-crunch clearUntypedFreeIndex
-  for tcbDomain[wp]: "obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t"
-crunch clearUntypedFreeIndex
-  for tcbPriority[wp]: "obj_at' (\<lambda>tcb. P (tcbPriority tcb)) t"
-
-crunch emptySlot
-  for nosch[wp]: "\<lambda>s. P (ksSchedulerAction s)"
-crunch emptySlot
-  for ksCurDomain[wp]: "\<lambda>s. P (ksCurDomain s)"
-
-lemma emptySlot_sch_act_wf [wp]:
-  "\<lbrace>\<lambda>s. sch_act_wf (ksSchedulerAction s) s\<rbrace>
-  emptySlot sl opt
-  \<lbrace>\<lambda>rv s. sch_act_wf (ksSchedulerAction s) s\<rbrace>"
-  apply (simp add: emptySlot_def case_Null_If)
-  apply (wp sch_act_wf_lift tcb_in_cur_domain'_lift | wpcw | simp)+
-  done
-
-lemma updateCap_valid_objs' [wp]:
-  "\<lbrace>valid_objs' and valid_cap' cap\<rbrace>
-  updateCap ptr cap \<lbrace>\<lambda>r. valid_objs'\<rbrace>"
-  unfolding updateCap_def
-  by (wp setCTE_valid_objs getCTE_wp) (clarsimp dest!: cte_at_cte_wp_atD)
-
-lemma updateFreeIndex_valid_objs' [wp]:
-  "\<lbrace>valid_objs'\<rbrace> clearUntypedFreeIndex ptr \<lbrace>\<lambda>r. valid_objs'\<rbrace>"
-  apply (simp add: clearUntypedFreeIndex_def getSlotCap_def)
-  apply (wp getCTE_wp' | wpc | simp add: updateTrackedFreeIndex_def)+
-  done
-
-crunch emptySlot
-  for valid_objs'[wp]: "valid_objs'"
-
-crunch setInterruptState
-  for state_refs_of'[wp]: "\<lambda>s. P (state_refs_of' s)"
-  (simp: state_refs_of'_pspaceI)
-crunch emptySlot
-  for state_refs_of'[wp]: "\<lambda>s. P (state_refs_of' s)"
-  (wp: crunch_wps)
-
-lemma mdb_chunked2D:
-  "\<lbrakk> mdb_chunked m; m \<turnstile> p \<leadsto> p'; m \<turnstile> p' \<leadsto> p'';
-     m p = Some (CTE cap nd); m p'' = Some (CTE cap'' nd'');
-     sameRegionAs cap cap''; p \<noteq> p'' \<rbrakk>
-     \<Longrightarrow> \<exists>cap' nd'. m p' = Some (CTE cap' nd') \<and> sameRegionAs cap cap'"
-  apply (subgoal_tac "\<exists>cap' nd'. m p' = Some (CTE cap' nd')")
-   apply (clarsimp simp add: mdb_chunked_def mdb_chunked_arch_assms_def) (* FIXME arch-split; take AARCH64 version *)
-   apply (drule spec[where x=p])
-   apply (drule spec[where x=p''])
-   apply clarsimp
-   apply (drule mp, erule trancl_into_trancl2)
-    apply (erule trancl.intros(1))
-   apply (simp add: is_chunk_def)
-   apply (drule spec, drule mp, erule trancl.intros(1))
-   apply (drule mp, rule trancl_into_rtrancl)
-    apply (erule trancl.intros(1))
-   apply clarsimp
-  apply (clarsimp simp: mdb_next_unfold)
-  apply (case_tac z, simp)
-  done
-
-lemma nullPointer_eq_0_simp[simp]:
-  "(nullPointer = 0) = True"
-  "(0 = nullPointer) = True"
-  by (simp add: nullPointer_def)+
-
-lemma no_0_no_0_lhs_trancl [simp]:
-  "no_0 m \<Longrightarrow> \<not> m \<turnstile> 0 \<leadsto>\<^sup>+ x"
-  by (rule, drule tranclD, clarsimp simp: next_unfold')
-
-lemma no_0_no_0_lhs_rtrancl [simp]:
-  "\<lbrakk> no_0 m; x \<noteq> 0 \<rbrakk> \<Longrightarrow> \<not> m \<turnstile> 0 \<leadsto>\<^sup>* x"
-  by (clarsimp dest!: rtranclD)
-
-end
-locale mdb_empty =
-  mdb_ptr?: mdb_ptr m _ _ slot s_cap s_node
-    for m slot s_cap s_node +
-
-  fixes n
-  defines "n \<equiv>
-           modify_map
-             (modify_map
-               (modify_map
-                 (modify_map m (mdbPrev s_node)
-                   (cteMDBNode_update (mdbNext_update (%_. (mdbNext s_node)))))
-                 (mdbNext s_node)
-                 (cteMDBNode_update
-                   (\<lambda>mdb. mdbFirstBadged_update (%_. (mdbFirstBadged mdb \<or> mdbFirstBadged s_node))
-                           (mdbPrev_update (%_. (mdbPrev s_node)) mdb))))
-               slot (cteCap_update (%_. capability.NullCap)))
-              slot (cteMDBNode_update (const nullMDBNode))"
-begin
-interpretation Arch . (*FIXME: arch-split*)
-
-lemmas m_slot_prev = m_p_prev
-lemmas m_slot_next = m_p_next
-lemmas prev_slot_next = prev_p_next
-lemmas next_slot_prev = next_p_prev
-
-lemma n_revokable:
-  "n p = Some (CTE cap node) \<Longrightarrow>
-  (\<exists>cap' node'. m p = Some (CTE cap' node') \<and>
-              (if p = slot
-               then \<not> mdbRevocable node
-               else mdbRevocable node = mdbRevocable node'))"
-  by (auto simp add: n_def modify_map_if nullMDBNode_def split: if_split_asm)
-
-lemma m_revokable:
-  "m p = Some (CTE cap node) \<Longrightarrow>
-  (\<exists>cap' node'. n p = Some (CTE cap' node') \<and>
-              (if p = slot
-               then \<not> mdbRevocable node'
-               else mdbRevocable node' = mdbRevocable node))"
-  apply (clarsimp simp add: n_def modify_map_if nullMDBNode_def split: if_split_asm)
-  apply (cases "p=slot", simp)
-  apply (cases "p=mdbNext s_node", simp)
-   apply (cases "p=mdbPrev s_node", simp)
-   apply clarsimp
-  apply simp
-  apply (cases "p=mdbPrev s_node", simp)
-  apply simp
-  done
-
-lemma no_0_n:
-  "no_0 n"
-  using no_0 by (simp add: n_def)
-
-lemma n_next:
-  "n p = Some (CTE cap node) \<Longrightarrow>
-  (\<exists>cap' node'. m p = Some (CTE cap' node') \<and>
-              (if p = slot
-               then mdbNext node = 0
-               else if p = mdbPrev s_node
-               then mdbNext node = mdbNext s_node
-               else mdbNext node = mdbNext node'))"
-  apply (subgoal_tac "p \<noteq> 0")
-   prefer 2
-   apply (insert no_0_n)[1]
-   apply clarsimp
-  apply (cases "p = slot")
-   apply (clarsimp simp: n_def modify_map_if initMDBNode_def split: if_split_asm)
-  apply (cases "p = mdbPrev s_node")
-   apply (auto simp: n_def modify_map_if initMDBNode_def split: if_split_asm)
-  done
-
-lemma n_prev:
-  "n p = Some (CTE cap node) \<Longrightarrow>
-  (\<exists>cap' node'. m p = Some (CTE cap' node') \<and>
-              (if p = slot
-               then mdbPrev node = 0
-               else if p = mdbNext s_node
-               then mdbPrev node = mdbPrev s_node
-               else mdbPrev node = mdbPrev node'))"
-  apply (subgoal_tac "p \<noteq> 0")
-   prefer 2
-   apply (insert no_0_n)[1]
-   apply clarsimp
-  apply (cases "p = slot")
-   apply (clarsimp simp: n_def modify_map_if initMDBNode_def split: if_split_asm)
-  apply (cases "p = mdbNext s_node")
-   apply (auto simp: n_def modify_map_if initMDBNode_def split: if_split_asm)
-  done
-
-lemma n_cap:
-  "n p = Some (CTE cap node) \<Longrightarrow>
-  \<exists>cap' node'. m p = Some (CTE cap' node') \<and>
-              (if p = slot
-               then cap = NullCap
-               else cap' = cap)"
-  apply (clarsimp simp: n_def modify_map_if initMDBNode_def split: if_split_asm)
-   apply (cases node)
-   apply auto
-  done
-
-lemma m_cap:
-  "m p = Some (CTE cap node) \<Longrightarrow>
-  \<exists>cap' node'. n p = Some (CTE cap' node') \<and>
-              (if p = slot
-               then cap' = NullCap
-               else cap' = cap)"
-  apply (clarsimp simp: n_def modify_map_cases initMDBNode_def)
-  apply (cases node)
-  apply clarsimp
-  apply (cases "p=slot", simp)
-  apply clarsimp
-  apply (cases "mdbNext s_node = p", simp)
-   apply fastforce
-  apply simp
-  apply (cases "mdbPrev s_node = p", simp)
-  apply fastforce
-  done
-
-lemma n_badged:
-  "n p = Some (CTE cap node) \<Longrightarrow>
-  \<exists>cap' node'. m p = Some (CTE cap' node') \<and>
-              (if p = slot
-               then \<not> mdbFirstBadged node
-               else if p = mdbNext s_node
-               then mdbFirstBadged node = (mdbFirstBadged node' \<or> mdbFirstBadged s_node)
-               else mdbFirstBadged node = mdbFirstBadged node')"
-  apply (subgoal_tac "p \<noteq> 0")
-   prefer 2
-   apply (insert no_0_n)[1]
-   apply clarsimp
-  apply (cases "p = slot")
-   apply (clarsimp simp: n_def modify_map_if initMDBNode_def split: if_split_asm)
-  apply (cases "p = mdbNext s_node")
-   apply (auto simp: n_def modify_map_if nullMDBNode_def split: if_split_asm)
-  done
-
-lemma m_badged:
-  "m p = Some (CTE cap node) \<Longrightarrow>
-  \<exists>cap' node'. n p = Some (CTE cap' node') \<and>
-              (if p = slot
-               then \<not> mdbFirstBadged node'
-               else if p = mdbNext s_node
-               then mdbFirstBadged node' = (mdbFirstBadged node \<or> mdbFirstBadged s_node)
-               else mdbFirstBadged node' = mdbFirstBadged node)"
-  apply (subgoal_tac "p \<noteq> 0")
-   prefer 2
-   apply (insert no_0_n)[1]
-   apply clarsimp
-  apply (cases "p = slot")
-   apply (clarsimp simp: n_def modify_map_if nullMDBNode_def split: if_split_asm)
-  apply (cases "p = mdbNext s_node")
-   apply (clarsimp simp: n_def modify_map_if nullMDBNode_def split: if_split_asm)
-  apply clarsimp
-  apply (cases "p = mdbPrev s_node")
-   apply (auto simp: n_def modify_map_if initMDBNode_def  split: if_split_asm)
-  done
-
-lemmas slot = m_p
-
-lemma m_next:
-  "m p = Some (CTE cap node) \<Longrightarrow>
-  \<exists>cap' node'. n p = Some (CTE cap' node') \<and>
-              (if p = slot
-               then mdbNext node' = 0
-               else if p = mdbPrev s_node
-               then mdbNext node' = mdbNext s_node
-               else mdbNext node' = mdbNext node)"
-  apply (subgoal_tac "p \<noteq> 0")
-   prefer 2
-   apply clarsimp
-  apply (cases "p = slot")
-   apply (clarsimp simp: n_def modify_map_if)
-  apply (cases "p = mdbPrev s_node")
-   apply (simp add: n_def modify_map_if)
-  apply simp
-  apply (simp add: n_def modify_map_if)
-  apply (cases "mdbNext s_node = p")
-   apply fastforce
-  apply fastforce
-  done
-
-lemma m_prev:
-  "m p = Some (CTE cap node) \<Longrightarrow>
-  \<exists>cap' node'. n p = Some (CTE cap' node') \<and>
-              (if p = slot
-               then mdbPrev node' = 0
-               else if p = mdbNext s_node
-               then mdbPrev node' = mdbPrev s_node
-               else mdbPrev node' = mdbPrev node)"
-  apply (subgoal_tac "p \<noteq> 0")
-   prefer 2
-   apply clarsimp
-  apply (cases "p = slot")
-   apply (clarsimp simp: n_def modify_map_if)
-  apply (cases "p = mdbPrev s_node")
-   apply (simp add: n_def modify_map_if)
-  apply simp
-  apply (simp add: n_def modify_map_if)
-  apply (cases "mdbNext s_node = p")
-   apply fastforce
-  apply fastforce
-  done
-
-lemma n_nextD:
-  "n \<turnstile> p \<leadsto> p' \<Longrightarrow>
-  if p = slot then p' = 0
-  else if p = mdbPrev s_node
-  then m \<turnstile> p \<leadsto> slot \<and> p' = mdbNext s_node
-  else m \<turnstile> p \<leadsto> p'"
-  apply (clarsimp simp: mdb_next_unfold split del: if_split cong: if_cong)
-  apply (case_tac z)
-  apply (clarsimp split del: if_split)
-  apply (drule n_next)
-  apply (elim exE conjE)
-  apply (simp split: if_split_asm)
-  apply (frule dlist_prevD [OF m_slot_prev])
-  apply (clarsimp simp: mdb_next_unfold)
-  done
-
-lemma n_next_eq:
-  "n \<turnstile> p \<leadsto> p' =
-  (if p = slot then p' = 0
-  else if p = mdbPrev s_node
-  then m \<turnstile> p \<leadsto> slot \<and> p' = mdbNext s_node
-  else m \<turnstile> p \<leadsto> p')"
-  apply (rule iffI)
-   apply (erule n_nextD)
-  apply (clarsimp simp: mdb_next_unfold split: if_split_asm)
-    apply (simp add: n_def modify_map_if slot)
-   apply hypsubst_thin
-   apply (case_tac z)
-   apply simp
-   apply (drule m_next)
-   apply clarsimp
-  apply (case_tac z)
-  apply simp
-  apply (drule m_next)
-  apply clarsimp
-  done
-
-lemma n_prev_eq:
-  "n \<turnstile> p \<leftarrow> p' =
-  (if p' = slot then p = 0
-  else if p' = mdbNext s_node
-  then m \<turnstile> slot \<leftarrow> p' \<and> p = mdbPrev s_node
-  else m \<turnstile> p \<leftarrow> p')"
-  apply (rule iffI)
-   apply (clarsimp simp: mdb_prev_def split del: if_split cong: if_cong)
-   apply (case_tac z)
-   apply (clarsimp split del: if_split)
-   apply (drule n_prev)
-   apply (elim exE conjE)
-   apply (simp split: if_split_asm)
-   apply (frule dlist_nextD [OF m_slot_next])
-   apply (clarsimp simp: mdb_prev_def)
-  apply (clarsimp simp: mdb_prev_def split: if_split_asm)
-    apply (simp add: n_def modify_map_if slot)
-   apply hypsubst_thin
-   apply (case_tac z)
-   apply clarsimp
-   apply (drule m_prev)
-   apply clarsimp
-  apply (case_tac z)
-  apply simp
-  apply (drule m_prev)
-  apply clarsimp
-  done
-
-lemma valid_dlist_n:
-  "valid_dlist n" using dlist
-  apply (clarsimp simp: valid_dlist_def2 [OF no_0_n])
-  apply (simp add: n_next_eq n_prev_eq m_slot_next m_slot_prev cong: if_cong)
-  apply (rule conjI, clarsimp)
-   apply (rule conjI, clarsimp simp: next_slot_prev prev_slot_next)
-   apply (fastforce dest!: dlist_prev_src_unique)
-  apply clarsimp
-  apply (rule conjI, clarsimp)
-   apply (clarsimp simp: valid_dlist_def2 [OF no_0])
-   apply (case_tac "mdbNext s_node = 0")
-    apply simp
-    apply (subgoal_tac "m \<turnstile> slot \<leadsto> c'")
-     prefer 2
-     apply fastforce
-    apply (clarsimp simp: mdb_next_unfold slot)
-   apply (frule next_slot_prev)
-   apply (drule (1) dlist_prev_src_unique, simp)
-   apply simp
-  apply clarsimp
-  apply (rule conjI, clarsimp)
-   apply (fastforce dest: dlist_next_src_unique)
-  apply clarsimp
-  apply (rule conjI, clarsimp)
-   apply (clarsimp simp: valid_dlist_def2 [OF no_0])
-   apply (clarsimp simp: mdb_prev_def slot)
-  apply (clarsimp simp: valid_dlist_def2 [OF no_0])
-  done
-
-lemma caps_contained_n:
-  "caps_contained' n"
-  using valid
-  apply (clarsimp simp: valid_mdb_ctes_def caps_contained'_def)
-  apply (drule n_cap)+
-  apply (clarsimp split: if_split_asm)
-  apply (erule disjE, clarsimp)
-  apply clarsimp
-  apply fastforce
-  done
-
-lemma chunked:
-  "mdb_chunked m"
-  using valid by (simp add: valid_mdb_ctes_def)
-
-lemma valid_badges:
-  "valid_badges m"
-  using valid ..
+context Arch_mdb_empty begin
 
 lemma valid_badges_n:
   "valid_badges n"
@@ -497,7 +101,8 @@ proof -
   from valid_badges
   show ?thesis
     supply if_cong[cong]
-    apply (simp add: valid_badges_def2 valid_arch_badges_def) (* FIXME arch-split; take AARCH64 version *)
+    supply to_slot_eq[simp del]
+    apply (simp add: valid_badges_def2 valid_arch_badges_def)
     apply clarsimp
     apply (drule_tac p=p in n_cap)
     apply (frule n_cap)
@@ -514,7 +119,7 @@ proof -
      apply (subgoal_tac "capMasterCap s_cap = capMasterCap cap'")
       prefer 2
       apply (thin_tac "\<forall>p. P p" for P)
-      apply (drule mdb_chunked2D[OF chunked])
+      apply (drule mdb_chunked2D[simplified mdb_chunked_arch_assms_def, simplified, OF chunked])
            apply (fastforce simp: mdb_next_unfold)
           apply assumption+
         apply (simp add: sameRegionAs_def3)
@@ -548,14 +153,6 @@ proof -
     apply fastforce
     done
 qed
-
-lemma to_slot_eq [simp]:
-  "m \<turnstile> p \<leadsto> slot = (p = mdbPrev s_node \<and> p \<noteq> 0)"
-  apply (rule iffI)
-   apply (frule dlist_nextD0, simp)
-   apply (clarsimp simp: mdb_prev_def slot mdb_next_unfold)
-  apply (clarsimp intro!: prev_slot_next)
-  done
 
 lemma n_parent_of:
   "\<lbrakk> n \<turnstile> p parentOf p'; p \<noteq> slot; p' \<noteq> slot \<rbrakk> \<Longrightarrow> m \<turnstile> p parentOf p'"
@@ -614,7 +211,7 @@ lemma m_parent_of_next:
 lemma parency_n:
   assumes "n \<turnstile> p \<rightarrow> p'"
   shows "m \<turnstile> p \<rightarrow> p' \<and> p \<noteq> slot \<and> p' \<noteq> slot"
-using assms
+  using assms
 proof induct
   case (direct_parent c')
   moreover
@@ -633,38 +230,43 @@ proof induct
      apply (erule (2) n_parent_of)
     apply clarsimp
     apply (frule n_parent_of, simp, simp)
+    apply (prop_tac "\<exists>prev_cap prev_node. m (mdbPrev s_node) = Some (CTE prev_cap prev_node)")
+     apply (clarsimp simp: parentOf_def, case_tac cte'a, clarsimp)
+    apply clarsimp
     apply (rule subtree.trans_parent[OF _ m_slot_next], simp_all)
     apply (rule subtree.direct_parent)
       apply (erule prev_slot_next)
      apply simp
     apply (clarsimp simp: parentOf_def slot)
-    apply (case_tac cte'a)
-    apply (case_tac ctea)
+    apply (case_tac cte, rename_tac next_cap next_node)
     apply clarsimp
     apply (frule(2) mdb_chunked2D [OF chunked prev_slot_next m_slot_next])
-      apply (clarsimp simp: isMDBParentOf_CTE)
-     apply simp
+       apply (clarsimp simp: isMDBParentOf_CTE)
+      apply simp
+     apply (simp add: mdb_chunked_arch_assms_def)
     apply (simp add: slot)
     apply (clarsimp simp add: isMDBParentOf_CTE)
-    apply (insert valid_badges)
+    apply (insert valid_badges)[1]
     apply (simp add: valid_badges_def2)
     apply (drule spec[where x=slot])
     apply (drule spec[where x="mdbNext s_node"])
     apply (simp add: slot m_slot_next)
-    apply (insert valid_badges)
+    apply (insert valid_badges)[1]
     apply (simp add: valid_badges_def2)
     apply (drule spec[where x="mdbPrev s_node"])
     apply (drule spec[where x=slot])
     apply (simp add: slot prev_slot_next)
-    apply (case_tac cte, case_tac cte')
+    apply (case_tac ctea, case_tac cte')
     apply (rename_tac cap'' node'')
     apply (clarsimp simp: isMDBParentOf_CTE)
     apply (frule n_cap, drule n_badged)
     apply (frule n_cap, drule n_badged)
     apply clarsimp
-    apply (case_tac cap'', simp_all add: isCap_simps arch_capBadge_def)[1]
+    apply (case_tac cap'', simp_all add: isCap_simps)[1]
+      apply (clarsimp simp: sameRegionAs_def3 isCap_simps)
      apply (clarsimp simp: sameRegionAs_def3 isCap_simps)
-    apply (clarsimp simp: sameRegionAs_def3 isCap_simps)
+    apply (rename_tac acap'')
+    apply (case_tac acap''; clarsimp simp: sameRegionAs_def3 isCap_simps)
     done
 next
   case (trans_parent c c')
@@ -694,8 +296,7 @@ next
        apply (rename_tac cap node)
        apply (case_tac ctea)
        apply clarsimp
-       apply (subgoal_tac "sameRegionAs cap s_cap")
-        prefer 2
+       apply (prop_tac "sameRegionAs cap s_cap")
         apply (insert chunked)[1]
         apply (simp add: mdb_chunked_def)
         apply (erule_tac x="p" in allE)
@@ -703,15 +304,13 @@ next
         apply simp
         apply (drule isMDBParent_sameRegion)+
         apply clarsimp
-        apply (subgoal_tac "m \<turnstile> p \<leadsto>\<^sup>+ slot")
-         prefer 2
+        apply (prop_tac "m \<turnstile> p \<leadsto>\<^sup>+ slot")
          apply (rule trancl_trans)
           apply (erule subtree_mdb_next)
          apply (rule r_into_trancl)
          apply (rule prev_slot_next)
          apply clarsimp
-        apply (subgoal_tac "m \<turnstile> p \<leadsto>\<^sup>+ mdbNext s_node")
-         prefer 2
+        apply (prop_tac "m \<turnstile> p \<leadsto>\<^sup>+ mdbNext s_node")
          apply (erule trancl_trans)
          apply fastforce
         apply (simp add: mdb_chunked_arch_assms_def)
@@ -725,7 +324,7 @@ next
         apply (erule impE, fastforce)
         apply (clarsimp simp: slot)
        apply (clarsimp simp: isMDBParentOf_CTE)
-       apply (insert valid_badges, simp add: valid_badges_def2)
+       apply (insert valid_badges, simp add: valid_badges_def2)[1]
        apply (drule spec[where x=slot], drule spec[where x="mdbNext s_node"])
        apply (simp add: slot m_slot_next)
        apply (case_tac cte, case_tac cte')
@@ -740,587 +339,61 @@ next
         apply (rule trancl.intros(2)[OF _ m_slot_next])
         apply (rule trancl.intros(1), rule prev_slot_next)
         apply simp
-       apply (case_tac cap'', simp_all add: isCap_simps arch_capBadge_def)[1]
+       apply (case_tac cap'', simp_all add: isCap_simps)[1]
+         apply (clarsimp simp: sameRegionAs_def3 isCap_simps)
         apply (clarsimp simp: sameRegionAs_def3 isCap_simps)
-       apply (clarsimp simp: sameRegionAs_def3 isCap_simps)
+       apply (rename_tac acap'')
+       apply (case_tac acap''; clarsimp simp: sameRegionAs_def3 isCap_simps)
       apply (rule m_slot_next)
      apply simp
     apply (erule n_parent_of, simp, simp)
     done
 qed
 
-lemma parency_m:
-  assumes "m \<turnstile> p \<rightarrow> p'"
-  shows "p \<noteq> slot \<longrightarrow> (if p' \<noteq> slot then n \<turnstile> p \<rightarrow> p' else m \<turnstile> p \<rightarrow> mdbNext s_node \<longrightarrow> n \<turnstile> p \<rightarrow> mdbNext s_node)"
-using assms
-proof induct
-  case (direct_parent c)
-  thus ?case
-    apply clarsimp
-    apply (rule conjI)
-     apply clarsimp
-     apply (rule subtree.direct_parent)
-       apply (simp add: n_next_eq)
-       apply clarsimp
-       apply (subgoal_tac "mdbPrev s_node \<noteq> 0")
-        prefer 2
-        apply (clarsimp simp: mdb_next_unfold)
-       apply (drule prev_slot_next)
-       apply (clarsimp simp: mdb_next_unfold)
-      apply assumption
-     apply (erule m_parent_of, simp, simp)
-      apply clarsimp
-     apply clarsimp
-     apply (drule dlist_next_src_unique)
-       apply fastforce
-      apply clarsimp
-     apply simp
-    apply clarsimp
-    apply (rule subtree.direct_parent)
-      apply (simp add: n_next_eq)
-     apply (drule subtree_parent)
-     apply (clarsimp simp: parentOf_def)
-    apply (drule subtree_parent)
-    apply (erule (1) m_parent_of_next)
-     apply clarsimp
-    apply clarsimp
-    done
-next
-  case (trans_parent c c')
-  thus ?case
-    apply clarsimp
-    apply (rule conjI)
-     apply clarsimp
-     apply (cases "c=slot")
-      apply simp
-      apply (erule impE)
-       apply (erule subtree.trans_parent)
-         apply fastforce
-        apply (clarsimp simp: slot mdb_next_unfold)
-       apply (clarsimp simp: slot mdb_next_unfold)
-      apply (clarsimp simp: slot mdb_next_unfold)
-     apply clarsimp
-     apply (erule subtree.trans_parent)
-       apply (simp add: n_next_eq)
-       apply clarsimp
-       apply (subgoal_tac "mdbPrev s_node \<noteq> 0")
-        prefer 2
-        apply (clarsimp simp: mdb_next_unfold)
-       apply (drule prev_slot_next)
-       apply (clarsimp simp: mdb_next_unfold)
-      apply assumption
-     apply (erule m_parent_of, simp, simp)
-      apply clarsimp
-      apply (drule subtree_mdb_next)
-      apply (drule trancl_trans)
-       apply (erule r_into_trancl)
-      apply simp
-     apply clarsimp
-     apply (drule dlist_next_src_unique)
-       apply fastforce
-      apply clarsimp
-     apply simp
-    apply clarsimp
-    apply (erule subtree.trans_parent)
-      apply (simp add: n_next_eq)
-     apply clarsimp
-    apply (rule m_parent_of_next, erule subtree_parent, assumption, assumption)
-    apply clarsimp
-    done
+end (* Arch_mdb_empty *)
+
+context mdb_empty begin
+
+lemmas gen_arch_assms =
+  Arch_mdb_empty.valid_badges_n
+  Arch_mdb_empty.parency_n
+  Arch_mdb_empty.m_parent_of
+  Arch_mdb_empty.m_parent_of_next
+
+(* extract arch-dependent assumptions of mdb_empty_gen proved in Arch_mdb_empty
+   (faster than interpreting Arch) *)
+lemmas gen_assms = gen_arch_assms[unfolded Arch_mdb_empty_def, OF mdb_empty_axioms]
+
+sublocale mdb_empty_gen
+  by (unfold_locales)
+     (blast intro!: gen_assms)+
+
+(* re-bind names *)
+lemmas vmdb_n = vmdb_n
+lemmas descendants = descendants
+
+end (* mdb_empty *)
+
+interpretation Finalise_R?: Finalise_R arch_final_matters' arch_cap_has_cleanup'
+proof goal_cases
+  interpret Arch  .
+  case 1 show ?case by (intro_locales; (unfold_locales; (fact Finalise_R_assms)?)?)
 qed
 
-lemma parency:
-  "n \<turnstile> p \<rightarrow> p' = (p \<noteq> slot \<and> p' \<noteq> slot \<and> m \<turnstile> p \<rightarrow> p')"
-  by (auto dest!: parency_n parency_m)
+context Arch begin arch_global_naming
 
-lemma descendants:
-  "descendants_of' p n =
-  (if p = slot then {} else descendants_of' p m - {slot})"
-  by (auto simp add: parency descendants_of'_def)
+named_theorems Finalise_R_2_assms
 
-lemma n_tranclD:
-  "n \<turnstile> p \<leadsto>\<^sup>+ p' \<Longrightarrow> m \<turnstile> p \<leadsto>\<^sup>+ p' \<and> p' \<noteq> slot"
-  apply (erule trancl_induct)
-   apply (clarsimp simp add: n_next_eq split: if_split_asm)
-     apply (rule mdb_chain_0D)
-      apply (rule chain)
-     apply (clarsimp simp: slot)
-    apply (blast intro: trancl_trans prev_slot_next)
-   apply fastforce
-  apply (clarsimp simp: n_next_eq split: if_split_asm)
-   apply (erule trancl_trans)
-   apply (blast intro: trancl_trans prev_slot_next)
-  apply (fastforce intro: trancl_trans)
-  done
-
-lemma m_tranclD:
-  "m \<turnstile> p \<leadsto>\<^sup>+ p' \<Longrightarrow>
-  if p = slot then n \<turnstile> mdbNext s_node \<leadsto>\<^sup>* p'
-  else if p' = slot then n \<turnstile> p \<leadsto>\<^sup>+ mdbNext s_node
-  else n \<turnstile> p \<leadsto>\<^sup>+ p'"
-  using no_0_n
-  apply -
-  apply (erule trancl_induct)
-   apply clarsimp
-   apply (rule conjI)
-    apply clarsimp
-    apply (rule r_into_trancl)
-    apply (clarsimp simp: n_next_eq)
-   apply clarsimp
-   apply (rule conjI)
-    apply (insert m_slot_next)[1]
-    apply (clarsimp simp: mdb_next_unfold)
-   apply clarsimp
-   apply (rule r_into_trancl)
-   apply (clarsimp simp: n_next_eq)
-   apply (rule context_conjI)
-    apply (clarsimp simp: mdb_next_unfold)
-   apply (drule prev_slot_next)
-   apply (clarsimp simp: mdb_next_unfold)
-  apply clarsimp
-  apply (rule conjI)
-   apply clarsimp
-   apply (rule conjI)
-    apply clarsimp
-    apply (drule prev_slot_next)
-    apply (drule trancl_trans, erule r_into_trancl)
-    apply simp
-   apply clarsimp
-   apply (erule trancl_trans)
-   apply (rule r_into_trancl)
-   apply (simp add: n_next_eq)
-  apply clarsimp
-  apply (rule conjI)
-   apply clarsimp
-   apply (erule rtrancl_trans)
-   apply (rule r_into_rtrancl)
-   apply (simp add: n_next_eq)
-   apply (rule conjI)
-    apply clarsimp
-    apply (rule context_conjI)
-     apply (clarsimp simp: mdb_next_unfold)
-    apply (drule prev_slot_next)
-    apply (clarsimp simp: mdb_next_unfold)
-   apply clarsimp
-  apply clarsimp
-  apply (simp split: if_split_asm)
-   apply (clarsimp simp: mdb_next_unfold slot)
-  apply (erule trancl_trans)
-  apply (rule r_into_trancl)
-  apply (clarsimp simp add: n_next_eq)
-  apply (rule context_conjI)
-   apply (clarsimp simp: mdb_next_unfold)
-  apply (drule prev_slot_next)
-  apply (clarsimp simp: mdb_next_unfold)
-  done
-
-lemma n_trancl_eq:
-  "n \<turnstile> p \<leadsto>\<^sup>+ p' = (m \<turnstile> p \<leadsto>\<^sup>+ p' \<and> (p = slot \<longrightarrow> p' = 0) \<and> p' \<noteq> slot)"
-  using no_0_n
-  apply -
-  apply (rule iffI)
-   apply (frule n_tranclD)
-   apply clarsimp
-   apply (drule tranclD)
-   apply (clarsimp simp: n_next_eq)
-   apply (simp add: rtrancl_eq_or_trancl)
-  apply clarsimp
-  apply (drule m_tranclD)
-  apply (simp split: if_split_asm)
-  apply (rule r_into_trancl)
-  apply (simp add: n_next_eq)
-  done
-
-lemma n_rtrancl_eq:
-  "n \<turnstile> p \<leadsto>\<^sup>* p' =
-  (m \<turnstile> p \<leadsto>\<^sup>* p' \<and>
-   (p = slot \<longrightarrow> p' = 0 \<or> p' = slot) \<and>
-   (p' = slot \<longrightarrow> p = slot))"
-  by (auto simp: rtrancl_eq_or_trancl n_trancl_eq)
-
-lemma mdb_chain_0_n:
-  "mdb_chain_0 n"
-  using chain
-  apply (clarsimp simp: mdb_chain_0_def)
-  apply (drule bspec)
-   apply (fastforce simp: n_def modify_map_if split: if_split_asm)
-  apply (simp add: n_trancl_eq)
-  done
-
-lemma mdb_chunked_n:
-  "mdb_chunked n"
-  using chunked
-  apply (clarsimp simp: mdb_chunked_def)
-  apply (drule n_cap)+
-  apply (clarsimp split: if_split_asm)
-  apply (case_tac "p=slot", clarsimp)
-  apply clarsimp
-  apply (erule_tac x=p in allE)
-  apply (erule_tac x=p' in allE)
-  apply (clarsimp simp: is_chunk_def)
-  apply (simp add: n_trancl_eq n_rtrancl_eq)
-  apply (rule conjI)
-   apply clarsimp
-   apply (erule_tac x=p'' in allE)
-   apply clarsimp
-   apply (drule_tac p=p'' in m_cap)
-   apply clarsimp
-  apply clarsimp
-  apply (erule_tac x=p'' in allE)
-  apply clarsimp
-  apply (drule_tac p=p'' in m_cap)
-  apply clarsimp
-  done
-
-lemma untyped_mdb_n:
-  "untyped_mdb' n"
-  using untyped_mdb
-  apply (simp add: untyped_mdb'_def descendants_of'_def parency)
-  apply clarsimp
-  apply (drule n_cap)+
-  apply (clarsimp split: if_split_asm)
-  apply (case_tac "p=slot", simp)
-  apply clarsimp
-  done
-
-lemma untyped_inc_n:
-  "untyped_inc' n"
-  using untyped_inc
-  apply (simp add: untyped_inc'_def descendants_of'_def parency)
-  apply clarsimp
-  apply (drule n_cap)+
-  apply (clarsimp split: if_split_asm)
-  apply (case_tac "p=slot", simp)
-  apply clarsimp
-  apply (erule_tac x=p in allE)
-  apply (erule_tac x=p' in allE)
-  apply simp
-  done
-
-lemmas vn_prev [dest!] = valid_nullcaps_prev [OF _ slot no_0 dlist nullcaps]
-lemmas vn_next [dest!] = valid_nullcaps_next [OF _ slot no_0 dlist nullcaps]
-
-lemma nullcaps_n: "valid_nullcaps n"
-proof -
-  from valid have "valid_nullcaps m" ..
-  thus ?thesis
-    apply (clarsimp simp: valid_nullcaps_def nullMDBNode_def nullPointer_def)
-    apply (frule n_cap)
-    apply (frule n_next)
-    apply (frule n_badged)
-    apply (frule n_revokable)
-    apply (drule n_prev)
-    apply (case_tac n)
-    apply (insert slot)
-    apply (fastforce split: if_split_asm)
-    done
-qed
-
-lemma ut_rev_n: "ut_revocable' n"
-  apply(insert valid)
-  apply(clarsimp simp: ut_revocable'_def)
-  apply(frule n_cap)
-  apply(drule n_revokable)
-  apply(clarsimp simp: isCap_simps split: if_split_asm)
-  apply(simp add: valid_mdb_ctes_def ut_revocable'_def)
-  done
-
-lemma class_links_n: "class_links n"
-  using valid slot
-  apply (clarsimp simp: valid_mdb_ctes_def class_links_def)
-  apply (case_tac cte, case_tac cte')
-  apply (drule n_nextD)
-  apply (clarsimp simp: split: if_split_asm)
-    apply (simp add: no_0_n)
-   apply (drule n_cap)+
-   apply clarsimp
-   apply (frule spec[where x=slot],
-          drule spec[where x="mdbNext s_node"],
-          simp, simp add: m_slot_next)
-   apply (drule spec[where x="mdbPrev s_node"],
-          drule spec[where x=slot], simp)
-  apply (drule n_cap)+
-  apply clarsimp
-  apply (fastforce split: if_split_asm)
-  done
-
-lemma distinct_zombies_m: "distinct_zombies m"
-  using valid by (simp add: valid_mdb_ctes_def)
-
-lemma distinct_zombies_n[simp]:
-  "distinct_zombies n"
-  using distinct_zombies_m
-  apply (simp add: n_def distinct_zombies_nonCTE_modify_map)
-  apply (subst modify_map_apply[where p=slot])
-   apply (simp add: modify_map_def slot)
-  apply simp
-  apply (rule distinct_zombies_sameMasterE)
-    apply (simp add: distinct_zombies_nonCTE_modify_map)
-   apply (simp add: modify_map_def slot)
-  apply simp
-  done
-
-lemma irq_control_n [simp]: "irq_control n"
-  using slot
-  apply (clarsimp simp: irq_control_def)
-  apply (frule n_revokable)
-  apply (drule n_cap)
-  apply (clarsimp split: if_split_asm)
-  apply (frule irq_revocable, rule irq_control)
-  apply clarsimp
-  apply (drule n_cap)
-  apply (clarsimp simp: if_split_asm)
-  apply (erule (1) irq_controlD, rule irq_control)
-  done
-
-lemma reply_masters_rvk_fb_m: "reply_masters_rvk_fb m"
-  using valid by auto
-
-lemma reply_masters_rvk_fb_n [simp]: "reply_masters_rvk_fb n"
-  using reply_masters_rvk_fb_m
-  apply (simp add: reply_masters_rvk_fb_def n_def
-                   ball_ran_modify_map_eq
-                   modify_map_comp[symmetric])
-  apply (subst ball_ran_modify_map_eq)
-   apply (frule bspec, rule ranI, rule slot)
-   apply (simp add: nullMDBNode_def isCap_simps modify_map_def
-                    slot)
-  apply (subst ball_ran_modify_map_eq)
-   apply (clarsimp simp add: modify_map_def)
-   apply fastforce
-  apply (simp add: ball_ran_modify_map_eq)
-  done
-
-lemma vmdb_n: "valid_mdb_ctes n"
-  by (simp add: valid_mdb_ctes_def valid_dlist_n
-                no_0_n mdb_chain_0_n valid_badges_n
-                caps_contained_n mdb_chunked_n
-                untyped_mdb_n untyped_inc_n
-                nullcaps_n ut_rev_n class_links_n)
-
-end
-
-context begin interpretation Arch .
-crunch postCapDeletion, clearUntypedFreeIndex
-  for ctes_of[wp]: "\<lambda>s. P (ctes_of s)"
-
-lemma emptySlot_mdb [wp]:
-  "\<lbrace>valid_mdb'\<rbrace>
-  emptySlot sl opt
-  \<lbrace>\<lambda>_. valid_mdb'\<rbrace>"
-  unfolding emptySlot_def
-  apply (simp only: case_Null_If valid_mdb'_def)
-  apply (wp updateCap_ctes_of_wp getCTE_wp'
-            opt_return_pres_lift | simp add: cte_wp_at_ctes_of)+
-  apply (clarsimp)
-  apply (case_tac cte)
-  apply (rename_tac cap node)
-  apply (simp)
-  apply (subgoal_tac "mdb_empty (ctes_of s) sl cap node")
-   prefer 2
-   apply (rule mdb_empty.intro)
-   apply (rule mdb_ptr.intro)
-    apply (rule vmdb.intro)
-    apply (simp add: valid_mdb_ctes_def)
-   apply (rule mdb_ptr_axioms.intro)
-   apply (simp add: cte_wp_at_ctes_of)
-  apply (rule conjI, clarsimp simp: valid_mdb_ctes_def)
-  apply (erule mdb_empty.vmdb_n[unfolded const_def])
-  done
-end
-
-lemma if_live_then_nonz_cap'_def2:
-  "if_live_then_nonz_cap' =
-   (\<lambda>s. \<forall>ptr. ko_wp_at' live' ptr s \<longrightarrow>
-              (\<exists>p zr. (option_map zobj_refs' o cteCaps_of s) p = Some zr \<and> ptr \<in> zr))"
-  by (fastforce simp: if_live_then_nonz_cap'_def ex_nonz_cap_to'_def cte_wp_at_ctes_of
-                      cteCaps_of_def)
-
-lemma updateMDB_ko_wp_at_live[wp]:
-  "\<lbrace>\<lambda>s. P (ko_wp_at' live' p' s)\<rbrace>
-      updateMDB p m
-   \<lbrace>\<lambda>rv s. P (ko_wp_at' live' p' s)\<rbrace>"
-  unfolding updateMDB_def Let_def
-  apply (rule hoare_pre, wp)
-  apply simp
-  done
-
-lemma updateCap_ko_wp_at_live[wp]:
-  "\<lbrace>\<lambda>s. P (ko_wp_at' live' p' s)\<rbrace>
-      updateCap p cap
-   \<lbrace>\<lambda>rv s. P (ko_wp_at' live' p' s)\<rbrace>"
-  unfolding updateCap_def
-  by wp
-
-primrec
-  threadCapRefs :: "capability \<Rightarrow> machine_word set"
-where
-  "threadCapRefs (ThreadCap r)                  = {r}"
-| "threadCapRefs (ReplyCap t m x)               = {}"
-| "threadCapRefs NullCap                        = {}"
-| "threadCapRefs (UntypedCap d r n i)           = {}"
-| "threadCapRefs (EndpointCap r badge x y z t)  = {}"
-| "threadCapRefs (NotificationCap r badge x y)  = {}"
-| "threadCapRefs (CNodeCap r b g gsz)           = {}"
-| "threadCapRefs (Zombie r b n)                 = {}"
-| "threadCapRefs (ArchObjectCap ac)             = {}"
-| "threadCapRefs (IRQHandlerCap irq)            = {}"
-| "threadCapRefs (IRQControlCap)                = {}"
-| "threadCapRefs (DomainCap)                    = {}"
-
-definition
-  "isFinal cap p m \<equiv>
-  \<not>isUntypedCap cap \<and>
-  (\<forall>p' c. m p' = Some c \<longrightarrow>
-          p \<noteq> p' \<longrightarrow> \<not>isUntypedCap c \<longrightarrow>
-          \<not> sameObjectAs cap c)"
-
-lemma not_FinalE:
-  "\<lbrakk> \<not> isFinal cap sl cps; isUntypedCap cap \<Longrightarrow> P;
-     \<And>p c. \<lbrakk> cps p = Some c; p \<noteq> sl; \<not> isUntypedCap c; sameObjectAs cap c \<rbrakk> \<Longrightarrow> P
-    \<rbrakk> \<Longrightarrow> P"
-  by (fastforce simp: isFinal_def)
-
-definition
- "removeable' sl \<equiv> \<lambda>s cap.
-    (\<exists>p. p \<noteq> sl \<and> cte_wp_at' (\<lambda>cte. capMasterCap (cteCap cte) = capMasterCap cap) p s)
-    \<or> ((\<forall>p \<in> cte_refs' cap (irq_node' s). p \<noteq> sl \<longrightarrow> cte_wp_at' (\<lambda>cte. cteCap cte = NullCap) p s)
-         \<and> (\<forall>p \<in> zobj_refs' cap. ko_wp_at' (Not \<circ> live') p s))"
-
-lemma not_Final_removeable:
-  "\<not> isFinal cap sl (cteCaps_of s)
-    \<Longrightarrow> removeable' sl s cap"
+lemma not_Final_removeable[Finalise_R_2_assms]:
+  "\<not> isFinal cap sl (cteCaps_of s) \<Longrightarrow> removeable' sl s cap"
   apply (erule not_FinalE)
    apply (clarsimp simp: removeable'_def gen_isCap_simps)
   apply (clarsimp simp: cteCaps_of_def RISCV64.sameObjectAs_def2 removeable'_def
-                        cte_wp_at_ctes_of) (* FIXME arch-split *)
+                        cte_wp_at_ctes_of)
   apply fastforce
   done
 
-context begin interpretation Arch .
-crunch postCapDeletion
-  for ko_wp_at'[wp]: "\<lambda>s. P (ko_wp_at' P' p s)"
-crunch postCapDeletion
-  for cteCaps_of[wp]: "\<lambda>s. P (cteCaps_of s)"
-  (simp: cteCaps_of_def o_def)
-end
-
-crunch clearUntypedFreeIndex
-  for ko_at_live[wp]: "\<lambda>s. P (ko_wp_at' live' ptr s)"
-
-lemma clearUntypedFreeIndex_cteCaps_of[wp]:
-  "\<lbrace>\<lambda>s. P (cteCaps_of s)\<rbrace>
-       clearUntypedFreeIndex sl \<lbrace>\<lambda>y s. P (cteCaps_of s)\<rbrace>"
-  by (simp add: cteCaps_of_def, wp)
-
-lemma emptySlot_iflive'[wp]:
-  "\<lbrace>\<lambda>s. if_live_then_nonz_cap' s \<and> cte_wp_at' (\<lambda>cte. removeable' sl s (cteCap cte)) sl s\<rbrace>
-     emptySlot sl opt
-   \<lbrace>\<lambda>rv. if_live_then_nonz_cap'\<rbrace>"
-  apply (simp add: emptySlot_def case_Null_If if_live_then_nonz_cap'_def2
-              del: comp_apply)
-  apply (rule hoare_pre)
-   apply (wp hoare_vcg_all_lift hoare_vcg_disj_lift
-             getCTE_wp opt_return_pres_lift
-             clearUntypedFreeIndex_ctes_of
-             clearUntypedFreeIndex_cteCaps_of
-             hoare_vcg_ex_lift
-             | wp (once) hoare_vcg_imp_lift
-             | simp add: cte_wp_at_ctes_of del: comp_apply)+
-  apply (clarsimp simp: modify_map_same imp_conjR[symmetric])
-  apply (drule spec, drule(1) mp)
-  apply (clarsimp simp: cte_wp_at_ctes_of modify_map_def split: if_split_asm)
-  apply (case_tac "p \<noteq> sl")
-   apply blast
-  apply (simp add: removeable'_def cteCaps_of_def)
-  apply (erule disjE)
-   apply (clarsimp simp: cte_wp_at_ctes_of modify_map_def
-                  dest!: capMaster_same_refs)
-   apply fastforce
-  apply clarsimp
-  apply (drule(1) bspec)
-  apply (clarsimp simp: ko_wp_at'_def)
-  done
-
-lemma setIRQState_irq_node'[wp]:
-  "\<lbrace>\<lambda>s. P (irq_node' s)\<rbrace> setIRQState state irq \<lbrace>\<lambda>_ s. P (irq_node' s)\<rbrace>"
-  apply (simp add: setIRQState_def setInterruptState_def getInterruptState_def)
-  apply wp
-  apply simp
-  done
-
-context begin interpretation Arch .
-crunch emptySlot
-  for irq_node'[wp]: "\<lambda>s. P (irq_node' s)"
-end
-
-lemma emptySlot_ifunsafe'[wp]:
-  "\<lbrace>\<lambda>s. if_unsafe_then_cap' s \<and> cte_wp_at' (\<lambda>cte. removeable' sl s (cteCap cte)) sl s\<rbrace>
-     emptySlot sl opt
-   \<lbrace>\<lambda>rv. if_unsafe_then_cap'\<rbrace>"
-  apply (simp add: ifunsafe'_def3)
-  apply (rule hoare_pre, rule hoare_use_eq_irq_node'[OF emptySlot_irq_node'])
-   apply (simp add: emptySlot_def case_Null_If)
-   apply (wp opt_return_pres_lift | simp add: o_def)+
-   apply (wp getCTE_cteCap_wp clearUntypedFreeIndex_cteCaps_of)+
-  apply (clarsimp simp: tree_cte_cteCap_eq[unfolded o_def]
-                        modify_map_same
-                        modify_map_comp[symmetric]
-                 split: option.split_asm if_split_asm
-                 dest!: modify_map_K_D)
-  apply (clarsimp simp: modify_map_def)
-  apply (drule_tac x=cref in spec, clarsimp)
-  apply (case_tac "cref' \<noteq> sl")
-   apply (rule_tac x=cref' in exI)
-   apply (clarsimp simp: modify_map_def)
-  apply (simp add: removeable'_def)
-  apply (erule disjE)
-   apply (clarsimp simp: modify_map_def)
-   apply (subst(asm) tree_cte_cteCap_eq[unfolded o_def])
-   apply (clarsimp split: option.split_asm dest!: capMaster_same_refs)
-   apply fastforce
-  apply clarsimp
-  apply (drule(1) bspec)
-  apply (clarsimp simp: cte_wp_at_ctes_of cteCaps_of_def)
-  done
-
-lemmas ctes_of_valid'[elim] = ctes_of_valid_cap''[where r=cte for cte]
-
-crunch setInterruptState
-  for valid_idle'[wp]: "valid_idle'"
-  (simp: valid_idle'_def)
-
-context begin interpretation Arch .
-crunch emptySlot
-  for valid_idle'[wp]: "valid_idle'"
-crunch deletedIRQHandler, getSlotCap, clearUntypedFreeIndex, updateMDB, getCTE, updateCap
-  for ksArch[wp]: "\<lambda>s. P (ksArchState s)"
-crunch emptySlot
-  for ksIdle[wp]: "\<lambda>s. P (ksIdleThread s)"
-crunch emptySlot
-  for gsMaxObjectSize[wp]: "\<lambda>s. P (gsMaxObjectSize s)"
-end
-
-lemma emptySlot_cteCaps_of:
-  "\<lbrace>\<lambda>s. P ((cteCaps_of s)(p \<mapsto> NullCap))\<rbrace>
-     emptySlot p opt
-   \<lbrace>\<lambda>rv s. P (cteCaps_of s)\<rbrace>"
-  apply (simp add: emptySlot_def case_Null_If)
-  apply (wp opt_return_pres_lift getCTE_cteCap_wp
-            clearUntypedFreeIndex_cteCaps_of)
-  apply (clarsimp simp: cteCaps_of_def cte_wp_at_ctes_of)
-  apply (auto elim!: rsubst[where P=P]
-               simp: modify_map_def fun_upd_def[symmetric] o_def
-                     fun_upd_idem cteCaps_of_def
-              split: option.splits)
-  done
-
-context begin interpretation Arch .
-
-crunch deletedIRQHandler
-  for cteCaps_of[wp]: "\<lambda>s. P (cteCaps_of s)"
-
-lemma deletedIRQHandler_valid_global_refs[wp]:
+lemma deletedIRQHandler_valid_global_refs[Finalise_R_2_assms, wp]:
   "\<lbrace>valid_global_refs'\<rbrace> deletedIRQHandler irq \<lbrace>\<lambda>rv. valid_global_refs'\<rbrace>"
   apply (clarsimp simp: valid_global_refs'_def global_refs'_def)
   apply (rule hoare_pre)
@@ -1334,7 +407,7 @@ lemma deletedIRQHandler_valid_global_refs[wp]:
   apply (clarsimp simp: valid_refs'_cteCaps valid_cap_sizes_cteCaps ball_ran_eq)
   done
 
-lemma clearUntypedFreeIndex_valid_global_refs[wp]:
+lemma clearUntypedFreeIndex_valid_global_refs[Finalise_R_2_assms, wp]:
   "\<lbrace>valid_global_refs'\<rbrace> clearUntypedFreeIndex irq \<lbrace>\<lambda>rv. valid_global_refs'\<rbrace>"
   apply (clarsimp simp: valid_global_refs'_def global_refs'_def)
   apply (rule hoare_pre)
@@ -1348,548 +421,44 @@ lemma clearUntypedFreeIndex_valid_global_refs[wp]:
   apply (clarsimp simp: valid_refs'_cteCaps valid_cap_sizes_cteCaps ball_ran_eq)
   done
 
-crunch global.postCapDeletion
-  for valid_global_refs[wp]: "valid_global_refs'"
-
-lemma emptySlot_valid_global_refs[wp]:
-  "\<lbrace>valid_global_refs' and cte_at' sl\<rbrace> emptySlot sl opt \<lbrace>\<lambda>rv. valid_global_refs'\<rbrace>"
-  apply (clarsimp simp: emptySlot_def)
-  apply (wpsimp wp: getCTE_wp hoare_drop_imps hoare_vcg_ex_lift simp: cte_wp_at_ctes_of)
-  apply (clarsimp simp: valid_global_refs'_def global_refs'_def)
-  apply (frule(1) cte_at_valid_cap_sizes_0)
-  apply (clarsimp simp: valid_refs'_cteCaps valid_cap_sizes_cteCaps ball_ran_eq)
-  done
-end
-
-lemmas doMachineOp_irq_handlers[wp]
-    = valid_irq_handlers_lift'' [OF doMachineOp_ctes doMachineOp_ksInterruptState]
-
-lemma deletedIRQHandler_irq_handlers'[wp]:
-  "\<lbrace>\<lambda>s. valid_irq_handlers' s \<and> (IRQHandlerCap irq \<notin> ran (cteCaps_of s))\<rbrace>
-       deletedIRQHandler irq
-   \<lbrace>\<lambda>rv. valid_irq_handlers'\<rbrace>"
-  apply (simp add: deletedIRQHandler_def setIRQState_def setInterruptState_def getInterruptState_def)
-  apply wp
-  apply (clarsimp simp: valid_irq_handlers'_def irq_issued'_def ran_def cteCaps_of_def)
-  done
-
-context begin interpretation Arch .
-
-lemma postCapDeletion_irq_handlers'[wp]:
-  "\<lbrace>\<lambda>s. valid_irq_handlers' s \<and> (cap \<noteq> NullCap \<longrightarrow> cap \<notin> ran (cteCaps_of s))\<rbrace>
-       postCapDeletion cap
-   \<lbrace>\<lambda>rv. valid_irq_handlers'\<rbrace>"
-  by (wpsimp simp: Retype_H.postCapDeletion_def RISCV64_H.postCapDeletion_def)
-
-definition
-  "post_cap_delete_pre' cap sl cs \<equiv> case cap of
-     IRQHandlerCap irq \<Rightarrow> irq \<le> maxIRQ \<and> (\<forall>sl'. sl \<noteq> sl' \<longrightarrow> cs sl' \<noteq> Some cap)
-   | _ \<Rightarrow> False"
-
-end
-
-crunch clearUntypedFreeIndex
-  for ksInterruptState[wp]: "\<lambda>s. P (ksInterruptState s)"
-
-lemma emptySlot_valid_irq_handlers'[wp]:
-  "\<lbrace>\<lambda>s. valid_irq_handlers' s
-          \<and> (\<forall>sl'. info \<noteq> NullCap \<longrightarrow> sl' \<noteq> sl \<longrightarrow> cteCaps_of s sl' \<noteq> Some info)\<rbrace>
-     emptySlot sl info
-   \<lbrace>\<lambda>rv. valid_irq_handlers'\<rbrace>"
-  apply (simp add: emptySlot_def case_Null_If)
-  apply (wp | wpc)+
-        apply (unfold valid_irq_handlers'_def irq_issued'_def)
-        apply (wp getCTE_cteCap_wp clearUntypedFreeIndex_cteCaps_of
-          | wps clearUntypedFreeIndex_ksInterruptState)+
-  apply (clarsimp simp: cteCaps_of_def cte_wp_at_ctes_of ran_def modify_map_def
-                 split: option.split)
-  apply auto
-  done
-
-context begin interpretation Arch .
-crunch emptySlot
-  for irq_states'[wp]: valid_irq_states'
-
-crunch emptySlot
-  for no_0_obj'[wp]: no_0_obj'
- (wp: crunch_wps)
-
-lemma deletedIRQHandler_irqs_masked'[wp]:
-  "\<lbrace>irqs_masked'\<rbrace> deletedIRQHandler irq \<lbrace>\<lambda>_. irqs_masked'\<rbrace>"
-  apply (simp add: deletedIRQHandler_def setIRQState_def getInterruptState_def setInterruptState_def)
-  apply (wp dmo_maskInterrupt)
-  apply (simp add: irqs_masked'_def)
-  done
-
-crunch emptySlot
-  for irqs_masked'[wp]: "irqs_masked'"
-
-lemma setIRQState_umm:
- "\<lbrace>\<lambda>s. P (underlying_memory (ksMachineState s))\<rbrace>
-   setIRQState irqState irq
-  \<lbrace>\<lambda>_ s. P (underlying_memory (ksMachineState s))\<rbrace>"
-  by (simp add: setIRQState_def maskInterrupt_def
-                setInterruptState_def getInterruptState_def
-      | wp dmo_lift')+
-
-crunch emptySlot
-  for umm[wp]: "\<lambda>s. P (underlying_memory (ksMachineState s))"
-  (wp: setIRQState_umm)
-
-lemma emptySlot_vms'[wp]:
-  "\<lbrace>valid_machine_state'\<rbrace> emptySlot slot irq \<lbrace>\<lambda>_. valid_machine_state'\<rbrace>"
-  by (simp add: valid_machine_state'_def pointerInUserData_def pointerInDeviceData_def)
-     (wp hoare_vcg_all_lift hoare_vcg_disj_lift)
-
-crunch emptySlot
-  for pspace_domain_valid[wp]: "pspace_domain_valid"
-
-crunch emptySlot
-  for ksDomSchedule[wp]: "\<lambda>s. P (ksDomSchedule s)"
-crunch emptySlot
-  for ksDomScheduleIdx[wp]: "\<lambda>s. P (ksDomScheduleIdx s)"
-
-lemma deletedIRQHandler_ct_not_inQ[wp]:
-  "\<lbrace>ct_not_inQ\<rbrace> deletedIRQHandler irq \<lbrace>\<lambda>_. ct_not_inQ\<rbrace>"
-  apply (rule ct_not_inQ_lift [OF deletedIRQHandler_nosch])
-  apply (rule hoare_weaken_pre)
-   apply (wps deletedIRQHandler_ct)
-   apply (simp add: deletedIRQHandler_def setIRQState_def)
-   apply (wp)
-  apply (simp add: comp_def)
-  done
-
-crunch emptySlot
-  for ct_not_inQ[wp]: "ct_not_inQ"
-
-crunch emptySlot
-  for tcbDomain[wp]: "obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t"
-
-lemma emptySlot_ct_idle_or_in_cur_domain'[wp]:
-  "\<lbrace>ct_idle_or_in_cur_domain'\<rbrace> emptySlot sl opt \<lbrace>\<lambda>_. ct_idle_or_in_cur_domain'\<rbrace>"
-  by (wp ct_idle_or_in_cur_domain'_lift2 tcb_in_cur_domain'_lift | simp)+
-
-crunch postCapDeletion
-  for gsUntypedZeroRanges[wp]: "\<lambda>s. P (gsUntypedZeroRanges s)"
-  (wp: crunch_wps simp: crunch_simps)
-
-lemma untypedZeroRange_modify_map_isUntypedCap:
-  "m sl = Some v \<Longrightarrow> \<not> isUntypedCap v \<Longrightarrow> \<not> isUntypedCap (f v)
-    \<Longrightarrow> (untypedZeroRange \<circ>\<^sub>m modify_map m sl f) = (untypedZeroRange \<circ>\<^sub>m m)"
-  by (simp add: modify_map_def map_comp_def fun_eq_iff untypedZeroRange_def)
-
-lemma emptySlot_untyped_ranges[wp]:
-  "\<lbrace>untyped_ranges_zero' and valid_objs' and valid_mdb'\<rbrace>
-     emptySlot sl opt \<lbrace>\<lambda>rv. untyped_ranges_zero'\<rbrace>"
-  apply (simp add: emptySlot_def case_Null_If)
-  apply (rule hoare_pre)
-   apply (rule bind_wp)
-    apply (rule untyped_ranges_zero_lift)
-     apply (wp getCTE_cteCap_wp clearUntypedFreeIndex_cteCaps_of
-       | wpc | simp add: clearUntypedFreeIndex_def updateTrackedFreeIndex_def
-                         getSlotCap_def
-                  split: option.split)+
-  apply (clarsimp simp: modify_map_comp[symmetric] modify_map_same)
-  apply (case_tac "\<not> isUntypedCap (the (cteCaps_of s sl))")
-   apply (case_tac "the (cteCaps_of s sl)",
-     simp_all add: untyped_ranges_zero_inv_def
-                   untypedZeroRange_modify_map_isUntypedCap isCap_simps)[1]
-  apply (clarsimp simp: isCap_simps untypedZeroRange_def modify_map_def)
-  apply (strengthen untyped_ranges_zero_fun_upd[mk_strg I E])
-  apply simp
-  apply (simp add: untypedZeroRange_def isCap_simps)
-  done
-
-crunch deletedIRQHandler, updateMDB, updateCap, clearUntypedFreeIndex
-  for valid_arch'[wp]: valid_arch_state'
-  (wp: valid_arch_state_lift')
-
-crunch global.postCapDeletion
-  for valid_arch'[wp]: valid_arch_state'
-
-lemma emptySlot_valid_arch'[wp]:
-  "\<lbrace>valid_arch_state' and cte_at' sl\<rbrace> emptySlot sl info \<lbrace>\<lambda>rv. valid_arch_state'\<rbrace>"
-  by (wpsimp simp: emptySlot_def cte_wp_at_ctes_of
-               wp: getCTE_wp hoare_drop_imps hoare_vcg_ex_lift)
-
-crunch emptySlot
-  for valid_bitmaps[wp]: valid_bitmaps
-  and tcbQueued_opt_pred[wp]: "\<lambda>s. P (tcbQueued |< tcbs_of' s)"
-  and valid_sched_pointers[wp]: valid_sched_pointers
-  and sched_projs[wp]: "\<lambda>s. P (tcbSchedNexts_of s) (tcbSchedPrevs_of s)"
-  and ksDomScheduleIdx[wp]: "\<lambda>s. P (ksDomScheduleIdx s)"
-  and ksDomScheduleStart[wp]: "\<lambda>s. P (ksDomScheduleStart s)"
-  (wp: valid_bitmaps_lift)
-
-lemma emptySlot_invs'[wp]:
-  "\<lbrace>\<lambda>s. invs' s \<and> cte_wp_at' (\<lambda>cte. removeable' sl s (cteCap cte)) sl s
-            \<and> (info \<noteq> NullCap \<longrightarrow> post_cap_delete_pre' info sl (cteCaps_of s) )\<rbrace>
-     emptySlot sl info
-   \<lbrace>\<lambda>rv. invs'\<rbrace>"
-  apply (simp add: invs'_def valid_state'_def valid_pspace'_def)
-  apply (wp valid_irq_node_lift cur_tcb_lift valid_dom_schedule'_lift)
-  apply (clarsimp simp: cte_wp_at_ctes_of post_cap_delete_pre'_def cteCaps_of_def
-                 split: capability.split_asm arch_capability.split_asm)
-  by auto
-
-lemma deletedIRQHandler_corres:
-  "corres dc \<top> \<top>
-    (deleted_irq_handler irq)
-    (deletedIRQHandler irq)"
-  apply (simp add: deleted_irq_handler_def deletedIRQHandler_def)
-  apply (rule setIRQState_corres)
-  apply (simp add: irq_state_relation_def)
-  done
-
-lemma arch_postCapDeletion_corres:
-  "acap_relation cap cap' \<Longrightarrow> corres dc \<top> \<top> (arch_post_cap_deletion cap) (RISCV64_H.postCapDeletion cap')"
-  by (clarsimp simp: arch_post_cap_deletion_def RISCV64_H.postCapDeletion_def)
-
-lemma postCapDeletion_corres:
-  "cap_relation cap cap' \<Longrightarrow> corres dc \<top> \<top> (post_cap_deletion cap) (postCapDeletion cap')"
-  apply (cases cap; clarsimp simp: post_cap_deletion_def Retype_H.postCapDeletion_def)
-   apply (corresKsimp corres: deletedIRQHandler_corres)
-  by (corresKsimp corres: arch_postCapDeletion_corres)
-
-lemma set_cap_trans_state:
-  "((),s') \<in> fst (set_cap c p s) \<Longrightarrow> ((),trans_state f s') \<in> fst (set_cap c p (trans_state f s))"
-  apply (cases p)
-  apply (clarsimp simp add: set_cap_def in_monad set_object_def get_object_def)
-  apply (case_tac y)
-      apply (auto simp add: in_monad set_object_def well_formed_cnode_n_def split: if_split_asm)
-  done
-
-lemma clearUntypedFreeIndex_noop_corres:
-  "corres dc \<top> (cte_at' (cte_map slot))
-    (return ()) (clearUntypedFreeIndex (cte_map slot))"
-  apply (simp add: clearUntypedFreeIndex_def)
-  apply (rule corres_guard_imp)
-    apply (rule corres_bind_return2)
-    apply (rule corres_symb_exec_r_conj[where P'="cte_at' (cte_map slot)"])
-       apply (rule corres_trivial, simp)
-      apply (wp getCTE_wp' | wpc
-        | simp add: updateTrackedFreeIndex_def getSlotCap_def)+
-     apply (clarsimp simp: state_relation_def)
-    apply (rule no_fail_pre)
-     apply (wp no_fail_getSlotCap getCTE_wp'
-       | wpc | simp add: updateTrackedFreeIndex_def getSlotCap_def)+
-  done
-
-lemma clearUntypedFreeIndex_valid_pspace'[wp]:
-  "\<lbrace>valid_pspace'\<rbrace> clearUntypedFreeIndex slot \<lbrace>\<lambda>rv. valid_pspace'\<rbrace>"
-  apply (simp add: valid_pspace'_def)
-  apply (rule hoare_pre)
-   apply (wp | simp add: valid_mdb'_def)+
-  done
-
-lemma emptySlot_corres:
-  "cap_relation info info' \<Longrightarrow> corres dc (einvs and cte_at slot) (invs' and cte_at' (cte_map slot))
-             (empty_slot slot info) (emptySlot (cte_map slot) info')"
-  unfolding emptySlot_def empty_slot_def
-  apply (simp add: case_Null_If)
-  apply (rule corres_guard_imp)
-    apply (rule corres_split_noop_rhs[OF clearUntypedFreeIndex_noop_corres])
-     apply (rule_tac R="\<lambda>cap. einvs and cte_wp_at ((=) cap) slot" and
-                     R'="\<lambda>cte. valid_pspace' and cte_wp_at' ((=) cte) (cte_map slot)" in
-                     corres_split[OF get_cap_corres])
-       defer
-       apply (wp get_cap_wp getCTE_wp')+
-     apply (simp add: cte_wp_at_ctes_of)
-     apply (wp hoare_vcg_imp_lift' clearUntypedFreeIndex_valid_pspace')
-    apply fastforce
-   apply (fastforce simp: cte_wp_at_ctes_of)
-  apply simp
-  apply (rule conjI, clarsimp)
-   defer
-  apply clarsimp
-  apply (rule conjI, clarsimp)
-  apply clarsimp
-  apply (simp only: bind_assoc[symmetric])
-  apply (rule corres_underlying_split[where r'=dc, OF _ postCapDeletion_corres])
-    defer
-    apply wpsimp+
-  apply (rule corres_no_failI)
-   apply (rule no_fail_pre, wp hoare_weak_lift_imp)
-   apply (clarsimp simp: cte_wp_at_ctes_of valid_pspace'_def)
-   apply (clarsimp simp: valid_mdb'_def valid_mdb_ctes_def)
-   apply (rule conjI, clarsimp)
-    apply (erule (2) valid_dlistEp)
-    apply simp
-   apply clarsimp
-   apply (erule (2) valid_dlistEn)
-   apply simp
-  apply (clarsimp simp: in_monad bind_assoc exec_gets)
-  apply (subgoal_tac "mdb_empty_abs a")
-   prefer 2
-   apply (rule mdb_empty_abs.intro)
-   apply (rule vmdb_abs.intro)
-   apply fastforce
-  apply (frule mdb_empty_abs'.intro)
-  apply (simp add: mdb_empty_abs'.empty_slot_ext_det_def2 update_cdt_list_def set_cdt_list_def exec_gets set_cdt_def bind_assoc exec_get exec_put set_original_def modify_def del: fun_upd_apply | subst bind_def, simp, simp add: mdb_empty_abs'.empty_slot_ext_det_def2)+
-  apply (simp add: put_def)
-  apply (simp add: exec_gets exec_get exec_put del: fun_upd_apply | subst bind_def)+
-  apply (clarsimp simp: state_relation_def)
-  apply (drule updateMDB_the_lot, fastforce simp: pspace_relation_def, fastforce, fastforce)
-   apply (clarsimp simp: invs'_def valid_state'_def valid_pspace'_def
-                         valid_mdb'_def valid_mdb_ctes_def)
-  apply (elim conjE)
-  apply (drule (4) updateMDB_the_lot, elim conjE)
-  apply clarsimp
-  apply (drule_tac s'=s''a and c=cap.NullCap in set_cap_not_quite_corres)
-                      subgoal by simp
-                     subgoal by simp
-                    subgoal by simp
-                   subgoal by simp
-                  subgoal by fastforce
-                 subgoal by fastforce
-                subgoal by fastforce
-               subgoal by fastforce
-              subgoal by fastforce
-             apply fastforce
-            subgoal by fastforce
-           subgoal by fastforce
-          subgoal by fastforce
-         apply (erule cte_wp_at_weakenE, rule TrueI)
-        apply assumption
-       subgoal by simp
-      subgoal by simp
-     subgoal by simp
-    subgoal by simp
-   apply (rule refl)
-  apply clarsimp
-  apply (drule updateCap_stuff, elim conjE, erule (1) impE)
-  apply clarsimp
-  apply (drule updateMDB_the_lot, force simp: pspace_relation_def, assumption+, simp)
-  apply (rule bexI)
-   prefer 2
-   apply (simp only: trans_state_update[symmetric])
-   apply (rule set_cap_trans_state)
-   apply (rule set_cap_revokable_update)
-   apply (erule set_cap_cdt_update)
-  apply clarsimp
-  apply (thin_tac "ctes_of t = s" for t s)+
-  apply (thin_tac "ksMachineState t = p" for t p)+
-  apply (thin_tac "ksCurThread t = p" for t p)+
-  apply (thin_tac "ksReadyQueues t = p" for t p)+
-  apply (thin_tac "ksSchedulerAction t = p" for t p)+
-  apply (clarsimp simp: cte_wp_at_ctes_of)
-  apply (case_tac rv')
-  apply (rename_tac s_cap s_node)
-  apply (subgoal_tac "cte_at slot a")
-   prefer 2
-   apply (fastforce elim: cte_wp_at_weakenE)
-  apply (subgoal_tac "mdb_empty (ctes_of b) (cte_map slot) s_cap s_node")
-   prefer 2
-   apply (rule mdb_empty.intro)
-   apply (rule mdb_ptr.intro)
-    apply (rule vmdb.intro)
-    subgoal by (simp add: invs'_def valid_state'_def valid_pspace'_def valid_mdb'_def)
-   apply (rule mdb_ptr_axioms.intro)
-   subgoal by simp
-  apply (clarsimp simp: ghost_relation_typ_at set_cap_a_type_inv)
-  apply (simp add: pspace_relation_def)
-  apply (rule conjI)
-   apply (clarsimp simp: data_at_def ghost_relation_typ_at set_cap_a_type_inv)
-  apply (rule conjI)
-   prefer 2
-   apply (rule conjI)
-    apply (clarsimp simp: cdt_list_relation_def)
-    apply(frule invs_valid_pspace, frule invs_mdb)
-    apply(subgoal_tac "no_mloop (cdt a) \<and> finite_depth (cdt a)")
-     prefer 2
-     subgoal by(simp add: finite_depth valid_mdb_def)
-    apply(subgoal_tac "valid_mdb_ctes (ctes_of b)")
-     prefer 2
-     subgoal by(simp add: mdb_empty_def mdb_ptr_def vmdb_def)
-    apply(clarsimp simp: valid_pspace_def)
-
-    apply(case_tac "cdt a slot")
-     apply(simp add: next_slot_eq[OF mdb_empty_abs'.next_slot_no_parent])
-     apply(case_tac "next_slot (aa, bb) (cdt_list a) (cdt a)")
-      subgoal by (simp)
-     apply(clarsimp)
-     apply(frule(1) mdb_empty.n_next)
-     apply(clarsimp)
-     apply(erule_tac x=aa in allE, erule_tac x=bb in allE)
-     apply(simp split: if_split_asm)
-      apply(drule cte_map_inj_eq)
-           apply(drule cte_at_next_slot)
-             apply(assumption)+
-      apply(simp)
-     apply(subgoal_tac "(ab, bc) = slot")
-      prefer 2
-      apply(drule_tac cte="CTE s_cap s_node" in valid_mdbD2')
-        subgoal by (clarsimp simp: valid_mdb_ctes_def no_0_def)
-       subgoal by (clarsimp simp: invs'_def valid_state'_def valid_pspace'_def)
-      apply(clarsimp)
-      apply(rule cte_map_inj_eq)
-           apply(assumption)
-          apply(drule(3) cte_at_next_slot', assumption)
-         apply(assumption)+
-     apply(simp)
-     apply(drule_tac p="(aa, bb)" in no_parent_not_next_slot)
-        apply(assumption)+
-     apply(clarsimp)
-
-    apply(simp add: next_slot_eq[OF mdb_empty_abs'.next_slot] split del: if_split)
-    apply(case_tac "next_slot (aa, bb) (cdt_list a) (cdt a)")
-     subgoal by (simp)
-    apply(case_tac "(aa, bb) = slot", simp)
-    apply(case_tac "next_slot (aa, bb) (cdt_list a) (cdt a) = Some slot")
-     apply(simp)
-     apply(case_tac "next_slot ac (cdt_list a) (cdt a)", simp)
-     apply(simp)
-     apply(frule(1) mdb_empty.n_next)
-     apply(clarsimp)
-     apply(erule_tac x=aa in allE', erule_tac x=bb in allE)
-     apply(erule_tac x=ac in allE, erule_tac x=bd in allE)
-     apply(clarsimp split: if_split_asm)
-      apply(drule(1) no_self_loop_next)
-      apply(simp)
-     apply(drule_tac cte="CTE cap' node'" in valid_mdbD1')
-       apply(fastforce simp: valid_mdb_ctes_def no_0_def)
-      subgoal by (simp add: valid_mdb'_def)
-     apply(clarsimp)
-    apply(simp)
-    apply(frule(1) mdb_empty.n_next)
-    apply(erule_tac x=aa in allE, erule_tac x=bb in allE)
-    apply(clarsimp split: if_split_asm)
-     apply(drule(1) no_self_loop_prev)
-     apply(clarsimp)
-     apply(drule_tac cte="CTE s_cap s_node" in valid_mdbD2')
-       apply(clarsimp simp: valid_mdb_ctes_def no_0_def)
-      apply clarify
-     apply(clarsimp)
-     apply(drule cte_map_inj_eq)
-          apply(drule(3) cte_at_next_slot')
-          apply(assumption)+
-     apply(simp)
-    apply(erule disjE)
-     apply(drule cte_map_inj_eq)
-          apply(drule(3) cte_at_next_slot)
-          apply(assumption)+
-     apply(simp)
-    subgoal by (simp)
-   apply (simp add: revokable_relation_def)
-   apply (clarsimp simp: in_set_cap_cte_at)
-   apply (rule conjI)
-    apply clarsimp
-    apply (drule(1) mdb_empty.n_revokable)
-    subgoal by clarsimp
-   apply clarsimp
-   apply (drule (1) mdb_empty.n_revokable)
-   apply (subgoal_tac "null_filter (caps_of_state a) (aa,bb) \<noteq> None")
-    prefer 2
-    apply (drule set_cap_caps_of_state_monad)
-    subgoal by (force simp: null_filter_def)
-   apply clarsimp
-   apply (subgoal_tac "cte_at (aa, bb) a")
-    prefer 2
-    apply (drule null_filter_caps_of_stateD, erule cte_wp_cte_at)
-   apply (drule (2) cte_map_inj_ps, fastforce)
-   subgoal by simp
-  apply (clarsimp simp add: cdt_relation_def)
-  apply (subst mdb_empty_abs.descendants, assumption)
-  apply (subst mdb_empty.descendants, assumption)
-  apply clarsimp
-  apply (frule_tac p="(aa, bb)" in in_set_cap_cte_at)
-  apply clarsimp
-  apply (frule (2) cte_map_inj_ps, fastforce)
-  apply simp
-  apply (case_tac "slot \<in> descendants_of (aa,bb) (cdt a)")
-   apply (subst inj_on_image_set_diff)
-      apply (rule inj_on_descendants_cte_map)
-         apply fastforce
-        apply fastforce
-       apply fastforce
-      apply fastforce
-     apply fastforce
-    subgoal by simp
-   subgoal by simp
-  apply simp
-  apply (subgoal_tac "cte_map slot \<notin> descendants_of' (cte_map (aa,bb)) (ctes_of b)")
-   subgoal by simp
-  apply (erule_tac x=aa in allE, erule allE, erule (1) impE)
-  apply (drule_tac s="cte_map ` u" for u in sym)
-  apply clarsimp
-  apply (drule cte_map_inj_eq, assumption)
-      apply (erule descendants_of_cte_at, fastforce)
-     apply fastforce
-    apply fastforce
-   apply fastforce
-  apply simp
-  done
-
-
-
-text \<open>Some facts about is_final_cap/isFinalCapability\<close>
-
-lemma isFinalCapability_inv:
-  "\<lbrace>P\<rbrace> isFinalCapability cap \<lbrace>\<lambda>_. P\<rbrace>"
-  apply (simp add: isFinalCapability_def Let_def
-              split del: if_split cong: if_cong)
-  apply (rule hoare_pre, wp)
-   apply (rule hoare_post_imp[where Q'="\<lambda>s. P"], simp)
-   apply wp
-  apply simp
-  done
-
-definition
-  final_matters' :: "capability \<Rightarrow> bool"
-where
- "final_matters' cap \<equiv> case cap of
-    EndpointCap ref bdg s r g gr \<Rightarrow> True
-  | NotificationCap ref bdg s r \<Rightarrow> True
-  | ThreadCap ref \<Rightarrow> True
-  | CNodeCap ref bits gd gs \<Rightarrow> True
-  | Zombie ptr zb n \<Rightarrow> True
-  | IRQHandlerCap irq \<Rightarrow> True
-  | ArchObjectCap acap \<Rightarrow> (case acap of
-      FrameCap ref rghts sz d mapdata \<Rightarrow> False
-    | ASIDControlCap \<Rightarrow> False
-    | _ \<Rightarrow> True)
-  | _ \<Rightarrow> False"
-
 lemma final_matters_Master:
   "final_matters' (capMasterCap cap) = final_matters' cap"
   by (simp add: capMasterCap_def arch_capMasterCap_def split: capability.split arch_capability.split,
-      simp add: final_matters'_def)
+      simp add: final_matters'_def arch_final_matters'_def)
 
 lemma final_matters_sameRegion_sameObject:
   "final_matters' cap \<Longrightarrow> sameRegionAs cap cap' = sameObjectAs cap cap'"
   apply (rule iffI)
    apply (erule sameRegionAsE)
       apply (simp add: sameObjectAs_def3)
-      apply (clarsimp simp: isCap_simps sameObjectAs_sameRegionAs final_matters'_def
-        split:capability.splits arch_capability.splits)+
+      apply (clarsimp simp: isCap_simps sameObjectAs_sameRegionAs
+                            final_matters'_def arch_final_matters'_def
+                      split: capability.splits arch_capability.splits)+
   done
 
 lemma final_matters_sameRegion_sameObject2:
   "\<lbrakk> final_matters' cap'; \<not> isUntypedCap cap; \<not> isIRQHandlerCap cap' \<rbrakk>
-     \<Longrightarrow> sameRegionAs cap cap' = sameObjectAs cap cap'"
+   \<Longrightarrow> sameRegionAs cap cap' = sameObjectAs cap cap'"
   apply (rule iffI)
    apply (erule sameRegionAsE)
        apply (simp add: sameObjectAs_def3)
-       apply (fastforce simp: isCap_simps final_matters'_def)
+       apply (fastforce simp: isCap_simps final_matters'_def arch_final_matters'_def)
       apply simp
-     apply (clarsimp simp: final_matters'_def isCap_simps)
-    apply (clarsimp simp: final_matters'_def isCap_simps)
-   apply (clarsimp simp: final_matters'_def isCap_simps)
+     apply (clarsimp simp: final_matters'_def arch_final_matters'_def isCap_simps)+
   apply (erule sameObjectAs_sameRegionAs)
   done
 
 lemma final_matters_mdb_chunked_arch_assms:
   "final_matters' cap \<Longrightarrow> mdb_chunked_arch_assms cap"
-  by (clarsimp simp: mdb_chunked_arch_assms_def)
+  by (clarsimp simp: mdb_chunked_arch_assms_def isCap_simps
+                     final_matters'_def arch_final_matters'_def)
 
-lemma notFinal_prev_or_next:
+lemma notFinal_prev_or_next[Finalise_R_2_assms]:
   "\<lbrakk> \<not> isFinal cap x (cteCaps_of s); mdb_chunked (ctes_of s);
-      valid_dlist (ctes_of s); no_0 (ctes_of s);
-      ctes_of s x = Some (CTE cap node); final_matters' cap \<rbrakk>
-     \<Longrightarrow> (\<exists>cap' node'. ctes_of s (mdbPrev node) = Some (CTE cap' node')
-              \<and> sameObjectAs cap cap')
-      \<or> (\<exists>cap' node'. ctes_of s (mdbNext node) = Some (CTE cap' node')
-              \<and> sameObjectAs cap cap')"
+     valid_dlist (ctes_of s); no_0 (ctes_of s);
+     ctes_of s x = Some (CTE cap node); final_matters' cap \<rbrakk>
+   \<Longrightarrow> (\<exists>cap' node'. ctes_of s (mdbPrev node) = Some (CTE cap' node') \<and> sameObjectAs cap cap')
+      \<or> (\<exists>cap' node'. ctes_of s (mdbNext node) = Some (CTE cap' node') \<and> sameObjectAs cap cap')"
   apply (erule not_FinalE)
    apply (clarsimp simp: isCap_simps final_matters'_def)
   apply (frule final_matters_mdb_chunked_arch_assms)
@@ -1931,91 +500,20 @@ lemma notFinal_prev_or_next:
   apply (clarsimp simp: sameObjectAs_def3 simp del: isArchFrameCap_capMasterCap)
   done
 
-lemma isFinal:
-  "\<lbrace>\<lambda>s. valid_mdb' s \<and> cte_wp_at' ((=) cte) x s
-          \<and> final_matters' (cteCap cte)
-          \<and> Q (isFinal (cteCap cte) x (cteCaps_of s)) s\<rbrace>
-    isFinalCapability cte
-   \<lbrace>Q\<rbrace>"
-  unfolding isFinalCapability_def
-  apply (cases cte)
-  apply (rename_tac cap node)
-  apply (unfold Let_def)
-  apply (simp only: if_False)
-  apply (wp getCTE_wp')
-  apply (cases "mdbPrev (cteMDBNode cte) = nullPointer")
-   apply simp
-   apply (clarsimp simp: valid_mdb_ctes_def valid_mdb'_def
-                         cte_wp_at_ctes_of)
-   apply (rule conjI, clarsimp simp: nullPointer_def)
-    apply (erule rsubst[where P="\<lambda>x. Q x s" for s], simp)
-    apply (rule classical)
-    apply (drule(5) notFinal_prev_or_next)
-    apply clarsimp
-   apply (clarsimp simp: nullPointer_def)
-   apply (erule rsubst[where P="\<lambda>x. Q x s" for s])
-   apply (rule sym, rule iffI)
-    apply (rule classical)
-    apply (drule(5) notFinal_prev_or_next)
-    apply clarsimp
-   apply clarsimp
-   apply (clarsimp simp: cte_wp_at_ctes_of cteCaps_of_def)
-   apply (case_tac cte)
-   apply clarsimp
-   apply (clarsimp simp add: isFinal_def)
-   apply (erule_tac x="mdbNext node" in allE)
-   apply simp
-   apply (erule impE)
-    apply (clarsimp simp: valid_mdb'_def valid_mdb_ctes_def)
-    apply (drule (1) mdb_chain_0_no_loops)
-    apply simp
-   apply (clarsimp simp: sameObjectAs_def3 isCap_simps)
-  apply simp
-  apply (clarsimp simp: cte_wp_at_ctes_of
-                        valid_mdb_ctes_def valid_mdb'_def)
-  apply (case_tac cte)
-  apply clarsimp
-  apply (rule conjI)
-   apply clarsimp
-   apply (erule rsubst[where P="\<lambda>x. Q x s" for s])
-   apply clarsimp
-   apply (clarsimp simp: isFinal_def cteCaps_of_def)
-   apply (erule_tac x="mdbPrev node" in allE)
-   apply simp
-   apply (erule impE)
-    apply clarsimp
-    apply (drule (1) mdb_chain_0_no_loops)
-    apply (subgoal_tac "ctes_of s (mdbNext node) = Some (CTE cap node)")
-     apply clarsimp
-    apply (erule (1) valid_dlistEp)
-     apply clarsimp
-    apply (case_tac cte')
-    apply clarsimp
-   apply (clarsimp simp add: sameObjectAs_def3 isCap_simps)
-  apply clarsimp
-  apply (rule conjI)
-   apply clarsimp
-   apply (erule rsubst[where P="\<lambda>x. Q x s" for s], simp)
-   apply (rule classical, drule(5) notFinal_prev_or_next)
-   apply (clarsimp simp: sameObjectAs_sym nullPointer_def)
-  apply (clarsimp simp: nullPointer_def)
-  apply (erule rsubst[where P="\<lambda>x. Q x s" for s])
-  apply (rule sym, rule iffI)
-   apply (rule classical, drule(5) notFinal_prev_or_next)
-   apply (clarsimp simp: sameObjectAs_sym)
-   apply auto[1]
-  apply (clarsimp simp: isFinal_def cteCaps_of_def)
-  apply (case_tac cte)
-  apply (erule_tac x="mdbNext node" in allE)
-  apply simp
-  apply (erule impE)
-   apply clarsimp
-   apply (drule (1) mdb_chain_0_no_loops)
-   apply simp
-  apply clarsimp
-  apply (clarsimp simp: isCap_simps sameObjectAs_def3)
-  done
-end
+lemma sameObjectAs_not_Untyped[Finalise_R_2_assms]:
+  "\<lbrakk> global.sameObjectAs cap cap'; \<not> isUntypedCap cap \<rbrakk>
+   \<Longrightarrow> \<not> isUntypedCap cap'"
+  by (clarsimp simp: gen_isCap_simps sameObjectAs_def3)
+
+lemma sameObjectAs_not_Untyped'[Finalise_R_2_assms]:
+  "\<lbrakk> global.sameObjectAs cap cap'; \<not> isUntypedCap cap' \<rbrakk>
+   \<Longrightarrow> global.sameObjectAs cap' cap"
+  by (clarsimp simp: isCap_simps sameObjectAs_def3)
+
+end (* Arch *)
+
+(* only two arch-specific lemmas in vmdb;
+   save processing time by not creating an extra Arch_vmdb locale, directly requalify instead *)
 
 lemma (in vmdb) isFinal_no_subtree:
   "\<lbrakk> m \<turnstile> sl \<rightarrow> p; isFinal cap sl (option_map cteCap o m);
@@ -2025,20 +523,9 @@ lemma (in vmdb) isFinal_no_subtree:
    apply (clarsimp simp: isFinal_def parentOf_def mdb_next_unfold cteCaps_of_def)
    apply (erule_tac x="mdbNext n" in allE)
    apply simp
-   (* FIXME arch-split *)
-   apply (clarsimp simp: RISCV64.isMDBParentOf_CTE final_matters_sameRegion_sameObject)
-   apply (clarsimp simp: gen_isCap_simps RISCV64.sameObjectAs_def3) (* FIXME arch-split *)
+   apply (clarsimp simp: RISCV64.isMDBParentOf_CTE RISCV64.final_matters_sameRegion_sameObject)
+   apply (clarsimp simp: gen_isCap_simps RISCV64.sameObjectAs_def3)
   apply clarsimp
-  done
-
-lemma isFinal_no_descendants:
-  "\<lbrakk> isFinal cap sl (cteCaps_of s); ctes_of s sl = Some (CTE cap n);
-      valid_mdb' s; final_matters' cap \<rbrakk>
-  \<Longrightarrow> descendants_of' sl (ctes_of s) = {}"
-  apply (clarsimp simp add: descendants_of'_def cteCaps_of_def)
-  apply (erule(3) vmdb.isFinal_no_subtree[rotated])
-  apply unfold_locales[1]
-  apply (simp add: valid_mdb'_def)
   done
 
 lemma (in vmdb) isFinal_untypedParent:
@@ -2063,66 +550,504 @@ lemma (in vmdb) isFinal_untypedParent:
   apply clarsimp
   apply (drule isMDBParent_sameRegion)
   apply simp
+  apply (frule RISCV64.final_matters_mdb_chunked_arch_assms)
   apply (rule classical, simp)
-  apply (simp add: final_matters_sameRegion_sameObject2
+  apply (simp add: RISCV64.final_matters_sameRegion_sameObject2
                    sameObjectAs_sym)
   done
 
-context begin interpretation Arch . (*FIXME: arch-split*)
+context Arch begin arch_global_naming
 
-lemma no_fail_isFinalCapability [wp]:
-  "no_fail (valid_mdb' and cte_wp_at' ((=) cte) p) (isFinalCapability cte)"
-  apply (simp add: isFinalCapability_def)
-  apply (clarsimp simp: Let_def split del: if_split)
-  apply (rule no_fail_pre, wp getCTE_wp')
-  apply (clarsimp simp: valid_mdb'_def valid_mdb_ctes_def cte_wp_at_ctes_of nullPointer_def)
-  apply (rule conjI)
-   apply clarsimp
-   apply (erule (2) valid_dlistEp)
-   apply simp
+lemma isFinal_no_descendants:
+  "\<lbrakk> isFinal cap sl (cteCaps_of s); ctes_of s sl = Some (CTE cap n);
+      valid_mdb' s; final_matters' cap \<rbrakk>
+  \<Longrightarrow> descendants_of' sl (ctes_of s) = {}"
+  apply (clarsimp simp add: descendants_of'_def cteCaps_of_def)
+  apply (erule(3) vmdb.isFinal_no_subtree[rotated])
+  apply unfold_locales[1]
+  apply (simp add: valid_mdb'_def)
+  done
+
+lemmas cancelAllIPC_typs[wp] = typ_at_lifts[OF cancelAllIPC_typ_at']
+lemmas cancelAllSignals_typs[wp] = typ_at_lifts[OF cancelAllSignals_typ_at']
+lemmas suspend_typs[wp] = typ_at_lifts[OF suspend_typ_at']
+
+lemmas finaliseCap_typ_ats[wp] = typ_at_lifts[OF finaliseCap_typ_at']
+
+lemma invs_asid_update_strg':
+  "invs' s \<and> tab = riscvKSASIDTable (ksArchState s) \<longrightarrow>
+   invs' (s\<lparr>ksArchState := riscvKSASIDTable_update
+            (\<lambda>_. tab (asid := None)) (ksArchState s)\<rparr>)"
+  apply (simp add: invs'_def)
+  apply (simp add: valid_state'_def)
+  apply (simp add: valid_global_refs'_def global_refs'_def valid_arch_state'_def
+                   valid_asid_table'_def valid_machine_state'_def ct_idle_or_in_cur_domain'_def
+                   tcb_in_cur_domain'_def)
+  apply (auto simp add: ran_def split: if_split_asm)
+  done
+
+lemma deleteASIDPool_invs[wp]:
+  "\<lbrace>invs'\<rbrace> deleteASIDPool asid pool \<lbrace>\<lambda>rv. invs'\<rbrace>"
+  apply (simp add: deleteASIDPool_def)
+  apply wp
+    apply (simp del: fun_upd_apply)
+    apply (strengthen invs_asid_update_strg')
+  apply (wp mapM_wp' getObject_inv loadObject_default_inv
+              | simp)+
+  done
+
+crunch hwASIDFlush
+  for irq_masks[wp]: "\<lambda>s. P (irq_masks s)"
+
+lemma dmo_hwASIDFlush_invs[wp]:
+  "doMachineOp (hwASIDFlush asid) \<lbrace>invs'\<rbrace>"
+  apply (wp dmo_invs')
+  apply (clarsimp simp: hwASIDFlush_def machine_op_lift_def machine_rest_lift_def in_monad select_f_def)
+  done
+
+lemma deleteASID_invs'[wp]:
+  "deleteASID asid pd \<lbrace>invs'\<rbrace>"
+  unfolding deleteASID_def
+  by (wpsimp wp: getASID_wp)
+
+lemmas archThreadSet_typ_ats[wp] = typ_at_lifts[OF archThreadSet_typ_at']
+
+lemma archThreadSet_valid_objs'[wp]:
+  "\<lbrace>valid_objs' and (\<lambda>s. \<forall>tcb. ko_at' tcb t s \<longrightarrow> valid_arch_tcb' (f (tcbArch tcb)) s)\<rbrace>
+   archThreadSet f t \<lbrace>\<lambda>_. valid_objs'\<rbrace>"
+  unfolding archThreadSet_def
+  apply (wp setObject_tcb_valid_objs getObject_tcb_wp)
   apply clarsimp
-  apply (rule conjI)
-   apply (erule (2) valid_dlistEn)
-   apply simp
-  apply clarsimp
-  apply (rule valid_dlistEn, assumption+)
-  apply (erule (2) valid_dlistEp)
+  apply normalise_obj_at'
+  apply (drule (1) tcb_ko_at_valid_objs_valid_tcb')
+  apply (clarsimp simp: valid_obj'_def valid_tcb'_def tcb_cte_cases_def cteSizeBits_def)
+  done
+
+crunch archThreadSet
+  for no_0_obj'[wp]: no_0_obj'
+
+lemma archThreadSet_ctes_of[wp]:
+  "archThreadSet f t \<lbrace>\<lambda>s. P (ctes_of s)\<rbrace>"
+  unfolding archThreadSet_def
+  apply (wpsimp wp: getObject_tcb_wp)
+  apply normalise_obj_at'
+  apply (auto simp: tcb_cte_cases_def cteSizeBits_def)
+  done
+
+crunch archThreadSet
+  for ksCurDomain[wp]: "\<lambda>s. P (ksCurDomain s)"
+  (wp: setObject_cd_inv)
+
+lemma archThreadSet_obj_at':
+  "(\<And>tcb. P tcb \<Longrightarrow> P (tcb \<lparr> tcbArch:= f (tcbArch tcb)\<rparr>)) \<Longrightarrow> archThreadSet f t \<lbrace>obj_at' P t'\<rbrace>"
+  unfolding archThreadSet_def
+  apply (wpsimp wp: getObject_tcb_wp setObject_tcb_strongest)
+  apply normalise_obj_at'
+  apply auto
+  done
+
+lemma archThreadSet_tcbDomain[wp]:
+  "archThreadSet f t \<lbrace>obj_at' (\<lambda>tcb. x = tcbDomain tcb) t'\<rbrace>"
+  by (wpsimp wp: archThreadSet_obj_at')
+
+lemma archThreadSet_inQ[wp]:
+  "archThreadSet f t' \<lbrace>\<lambda>s. P (obj_at' (inQ d p) t s)\<rbrace>"
+  unfolding obj_at'_real_def archThreadSet_def
+  apply (wpsimp wp: setObject_ko_wp_at getObject_tcb_wp
+              simp: objBits_simps' archObjSize_def pageBits_def
+         | simp)+
+  apply (auto simp: obj_at'_def ko_wp_at'_def)
+  done
+
+crunch archThreadSet
+  for ct[wp]: "\<lambda>s. P (ksCurThread s)"
+  and sched[wp]: "\<lambda>s. P (ksSchedulerAction s)"
+  and L1[wp]: "\<lambda>s. P (ksReadyQueuesL1Bitmap s)"
+  and L2[wp]: "\<lambda>s. P (ksReadyQueuesL2Bitmap s)"
+  and ksArch[wp]: "\<lambda>s. P (ksArchState s)"
+  and ksDomSchedule[wp]: "\<lambda>s. P (ksDomSchedule s)"
+  and pspace_canonical'[wp]: pspace_canonical'
+  and gsMaxObjectSize[wp]: "\<lambda>s. P (gsMaxObjectSize s)"
+  and ksInterruptState[wp]: "\<lambda>s. P (ksInterruptState s)"
+  (wp: setObject_ct_inv setObject_sa_unchanged setObject_ksDomSchedule_inv)
+
+crunch archThreadSet
+  for ksDomScheduleIdx[wp]: "\<lambda>s. P (ksDomScheduleIdx s)"
+  and ksDomScheduleStart[wp]: "\<lambda>s. P (ksDomScheduleStart s)"
+  (simp: setObject_def wp: updateObject_default_inv)
+
+crunch archThreadSet
+  for ksMachineState[wp]: "\<lambda>s. P (ksMachineState s)"
+  (wp: setObject_ksMachine updateObject_default_inv)
+
+lemma archThreadSet_state_refs_of'[wp]:
+  "archThreadSet f t \<lbrace>\<lambda>s. P (state_refs_of' s)\<rbrace>"
+  unfolding archThreadSet_def
+  apply (wpsimp wp: setObject_tcb_state_refs_of' getObject_tcb_wp)
+  apply normalise_obj_at'
+  apply (erule rsubst[where P=P])
+  apply (rule ext)
+  apply (auto simp: state_refs_of'_def obj_at'_def)
+  done
+
+lemma archThreadSet_state_hyp_refs_of'[wp]:
+  "\<lbrace>\<lambda>s. \<forall>tcb. ko_at' tcb t s \<longrightarrow> P ((state_hyp_refs_of' s)(t := tcb_hyp_refs' (f (tcbArch tcb))))\<rbrace>
+  archThreadSet f t \<lbrace>\<lambda>_ s. P (state_hyp_refs_of' s)\<rbrace>"
+  unfolding archThreadSet_def
+  apply (wpsimp wp: setObject_state_hyp_refs_of' getObject_tcb_wp simp: objBits_simps')
+  apply normalise_obj_at'
+  apply (erule rsubst[where P=P])
+  apply auto
+  done
+
+lemma archThreadSet_if_live'[wp]:
+  "\<lbrace>\<lambda>s. if_live_then_nonz_cap' s \<and>
+        (\<forall>tcb. ko_at' tcb t s \<longrightarrow> atcbVCPUPtr (f (tcbArch tcb)) \<noteq> None \<longrightarrow> ex_nonz_cap_to' t s)\<rbrace>
+  archThreadSet f t \<lbrace>\<lambda>_. if_live_then_nonz_cap'\<rbrace>"
+  unfolding archThreadSet_def
+  apply (wpsimp wp: setObject_tcb_iflive' getObject_tcb_wp)
+  apply normalise_obj_at'
+  apply (clarsimp simp: tcb_cte_cases_def if_live_then_nonz_cap'_def cteSizeBits_def)
+  apply (erule_tac x=t in allE)
+  apply (erule impE)
+   apply (clarsimp simp: obj_at'_real_def ko_wp_at'_def live'_def hyp_live'_def)
   apply simp
   done
 
-lemma corres_gets_lift:
-  assumes inv: "\<And>P. \<lbrace>P\<rbrace> g \<lbrace>\<lambda>_. P\<rbrace>"
-  assumes res: "\<lbrace>Q'\<rbrace> g \<lbrace>\<lambda>r s. r = g' s\<rbrace>"
-  assumes Q: "\<And>s. Q s \<Longrightarrow> Q' s"
-  assumes nf: "no_fail Q g"
-  shows "corres r P Q f (gets g') \<Longrightarrow> corres r P Q f g"
-  apply (clarsimp simp add: corres_underlying_def simpler_gets_def)
-  apply (drule (1) bspec)
-  apply (rule conjI)
-   apply clarsimp
-   apply (rule bexI)
-    prefer 2
-    apply assumption
-   apply simp
-   apply (frule in_inv_by_hoareD [OF inv])
-   apply simp
-   apply (drule use_valid, rule res)
-    apply (erule Q)
-   apply simp
-  apply (insert nf)
-  apply (clarsimp simp: no_fail_def)
+lemma archThreadSet_ifunsafe'[wp]:
+  "archThreadSet f t \<lbrace>if_unsafe_then_cap'\<rbrace>"
+  unfolding archThreadSet_def
+  apply (wpsimp wp: setObject_tcb_ifunsafe' getObject_tcb_wp)
+  apply normalise_obj_at'
+  apply (auto simp: tcb_cte_cases_def if_live_then_nonz_cap'_def cteSizeBits_def)
   done
 
-lemma obj_refs_Master:
-  "\<lbrakk> cap_relation cap cap'; P cap \<rbrakk>
-      \<Longrightarrow> obj_refs cap =
-           (if capClass (capMasterCap cap') = PhysicalClass
-                  \<and> \<not> isUntypedCap (capMasterCap cap')
-            then {capUntypedPtr (capMasterCap cap')} else {})"
-  by (clarsimp simp: isCap_simps
-              split: cap_relation_split_asm arch_cap.split_asm)
+lemma archThreadSet_valid_idle'[wp]:
+  "archThreadSet f t \<lbrace>valid_idle'\<rbrace>"
+  unfolding archThreadSet_def
+  apply (wpsimp wp: setObject_tcb_idle' getObject_tcb_wp)
+  apply (clarsimp simp: valid_idle'_def pred_tcb_at'_def obj_at'_def idle_tcb'_def)
+  done
 
-lemma isFinalCapability_corres':
+lemma archThreadSet_ct_not_inQ[wp]:
+  "archThreadSet f t \<lbrace>ct_not_inQ\<rbrace>"
+  unfolding ct_not_inQ_def
+  apply (rule hoare_lift_Pf[where f=ksCurThread]; wp?)
+  apply (wpsimp wp: hoare_vcg_imp_lift simp: o_def)
+  done
+
+lemma archThreadSet_obj_at'_pte[wp]:
+  "archThreadSet f t \<lbrace>obj_at' (P::pte \<Rightarrow> bool) p\<rbrace>"
+  unfolding archThreadSet_def
+  by (wpsimp wp: obj_at_setObject2 simp: updateObject_default_def in_monad)
+
+crunch archThreadSet
+  for pspace_domain_valid[wp]: pspace_domain_valid
+
+crunch archThreadSet
+  for gsUntypedZeroRanges[wp]: "\<lambda>s. P (gsUntypedZeroRanges s)"
+
+lemma archThreadSet_untyped_ranges_zero'[wp]:
+  "archThreadSet f t \<lbrace>untyped_ranges_zero'\<rbrace>"
+  by (rule hoare_lift_Pf[where f=cteCaps_of]; wp cteCaps_of_ctes_of_lift)
+
+lemma archThreadSet_tcb_at'[wp]:
+  "\<lbrace>\<top>\<rbrace> archThreadSet f t \<lbrace>\<lambda>_. tcb_at' t\<rbrace>"
+  unfolding archThreadSet_def
+  by (wpsimp wp: getObject_tcb_wp simp: obj_at'_def)
+
+lemma archThreadSet_tcbSchedPrevs_of[wp]:
+  "archThreadSet f t \<lbrace>\<lambda>s. P (tcbSchedPrevs_of s)\<rbrace>"
+  unfolding archThreadSet_def
+  apply (wp getObject_tcb_wp)
+  apply normalise_obj_at'
+  apply (erule rsubst[where P=P])
+  apply (rule ext)
+  apply (clarsimp simp: opt_map_def obj_at'_def split: option.splits)
+  done
+
+lemma archThreadSet_tcbSchedNexts_of[wp]:
+  "archThreadSet f t \<lbrace>\<lambda>s. P (tcbSchedNexts_of s)\<rbrace>"
+  unfolding archThreadSet_def
+  apply (wp getObject_tcb_wp)
+  apply normalise_obj_at'
+  apply (erule rsubst[where P=P])
+  apply (rule ext)
+  apply (clarsimp simp: opt_map_def obj_at'_def split: option.splits)
+  done
+
+lemma archThreadSet_tcbQueued[wp]:
+  "archThreadSet f t \<lbrace>\<lambda>s. P (tcbQueued |< tcbs_of' s)\<rbrace>"
+  unfolding archThreadSet_def
+  apply (wp getObject_tcb_wp)
+  apply normalise_obj_at'
+  apply (erule rsubst[where P=P])
+  apply (rule ext)
+  apply (clarsimp simp: opt_pred_def opt_map_def obj_at'_def split: option.splits)
+  done
+
+lemma archThreadSet_valid_sched_pointers[wp]:
+  "archThreadSet f t \<lbrace>valid_sched_pointers\<rbrace>"
+  by (wp_pre, wps, wp, assumption)
+
+lemma arch_finaliseCap_invs[Finalise_R_2_assms, wp]:
+  "\<lbrace>invs' and valid_cap' (ArchObjectCap cap)\<rbrace> Arch.finaliseCap cap fin \<lbrace>\<lambda>rv. invs'\<rbrace>"
+  unfolding RISCV64_H.finaliseCap_def Let_def by wpsimp
+
+crunch setVMRoot, deleteASIDPool
+  for ctes_of[wp]: "\<lambda>s. P (ctes_of s)"
+  (wp: crunch_wps getObject_inv loadObject_default_inv getASID_wp simp: crunch_simps)
+
+lemma deleteASID_ctes_of[wp]:
+  "deleteASID a ptr \<lbrace>\<lambda>s. P (ctes_of s)\<rbrace>"
+  unfolding deleteASID_def by (wpsimp wp: getASID_wp hoare_drop_imps hoare_vcg_all_lift)
+
+lemma arch_finaliseCap_removeable[wp]:
+  "\<lbrace>\<lambda>s. s \<turnstile>' ArchObjectCap cap \<and> invs' s
+       \<and> (final_matters' (ArchObjectCap cap)
+               \<longrightarrow> (final = isFinal (ArchObjectCap cap) slot (cteCaps_of s))) \<rbrace>
+     Arch.finaliseCap cap final
+   \<lbrace>\<lambda>rv s. isNullCap (fst rv) \<and> removeable' slot s (ArchObjectCap cap) \<and> isNullCap (snd rv)\<rbrace>"
+  unfolding RISCV64_H.finaliseCap_def
+  by (wpsimp wp: hoare_vcg_op_lift simp: removeable'_def isCap_simps cte_wp_at_ctes_of)
+
+crunch archThreadSet
+  for isFinal: "\<lambda>s. isFinal cap slot (cteCaps_of s)"
+  (wp: cteCaps_of_ctes_of_lift)
+
+crunch prepareThreadDelete
+  for isFinal: "\<lambda>s. isFinal cap slot (cteCaps_of s)"
+
+lemma archThreadSet_bound_tcb_at'[wp]:
+  "archThreadSet f t \<lbrace>bound_tcb_at' P t'\<rbrace>"
+  unfolding archThreadSet_def
+  apply (wpsimp wp: setObject_tcb_strongest getObject_tcb_wp simp: pred_tcb_at'_def)
+  by (auto simp: obj_at'_def objBits_simps)
+
+crunch prepareThreadDelete
+  for bound_tcb_at'[wp]: "bound_tcb_at' P t"
+  (wp: sts_bound_tcb_at' crunch_wps hoare_vcg_all_lift hoare_vcg_if_lift3
+   ignore: archThreadSet)
+
+crunch Arch.finaliseCap, prepareThreadDelete
+  for irq_node'[Finalise_R_2_assms, wp]: "\<lambda>s. P (irq_node' s)"
+  (wp: crunch_wps getObject_inv loadObject_default_inv
+       updateObject_default_inv setObject_ksInterrupt
+   simp: crunch_simps o_def)
+
+lemmas Arch_finaliseCap_irq_node'[Finalise_R_2_assms] = ArchRetypeDecls_H_RISCV64_H_finaliseCap_irq_node'
+
+crunch prepareThreadDelete
+  for cte_wp_at'[Finalise_R_2_assms, wp]: "cte_wp_at' P p"
+  and valid_cap'[Finalise_R_2_assms, wp]: "valid_cap' cap"
+
+lemma asUser_hyp_unlive[wp]:
+  "asUser f t \<lbrace>ko_wp_at' (Not \<circ> hyp_live') t'\<rbrace>"
+  unfolding asUser_def
+  apply (wpsimp wp: threadSet_ko_wp_at2' threadGet_wp)
+  apply (clarsimp simp: ko_wp_at'_def obj_at'_def hyp_live'_def atcbContextSet_def)
+  done
+
+crunch prepareThreadDelete
+  for invs[Finalise_R_2_assms, wp]: "invs'"
+  (ignore: doMachineOp simp: crunch_simps)
+
+lemma archThreadSet_tcbSchedPrevNext[wp]:
+  "archThreadSet f t' \<lbrace>obj_at' (\<lambda>tcb. P (tcbSchedNext tcb) (tcbSchedPrev tcb)) t\<rbrace>"
+  unfolding archThreadSet_def
+  apply (wpsimp wp: setObject_tcb_strongest getObject_tcb_wp)
+  apply normalise_obj_at'
+  apply auto
+  done
+
+context notes if_cong[cong] begin
+
+crunch asUser
+  for tcbSchedPrevNext[wp]: "obj_at' (\<lambda>tcb. P (tcbSchedNext tcb) (tcbSchedPrev tcb)) t"
+  (wp: threadGet_wp)
+
+end
+
+crunch prepareThreadDelete
+  for tcbSchedPrevNext[wp]: "obj_at' (\<lambda>tcb. P (tcbSchedNext tcb) (tcbSchedPrev tcb)) t"
+  (wp: threadGet_wp archThreadGet_wp crunch_wps simp: crunch_simps)
+
+crunch deleteASIDPool
+  for cte_wp_at'[wp]: "cte_wp_at' P p"
+  (simp: crunch_simps assertE_def
+   wp: crunch_wps getObject_inv loadObject_default_inv)
+
+lemma deleteASID_cte_wp_at'[wp]:
+  "\<lbrace>cte_wp_at' P p\<rbrace> deleteASID param_a param_b \<lbrace>\<lambda>_. cte_wp_at' P p\<rbrace>"
+  supply if_cong[cong]
+  apply (simp add: deleteASID_def
+              cong: option.case_cong)
+  apply (wp setObject_cte_wp_at'[where Q="\<top>"] getObject_inv
+            loadObject_default_inv setVMRoot_cte_wp_at'
+          | clarsimp simp: updateObject_default_def in_monad
+          | rule equals0I
+          | wpc)+
+  done
+
+lemma arch_finaliseCap_cte_wp_at[Finalise_R_2_assms, wp]:
+  "\<lbrace>cte_wp_at' P p\<rbrace> Arch.finaliseCap cap fin \<lbrace>\<lambda>rv. cte_wp_at' P p\<rbrace>"
+  apply (simp add: RISCV64_H.finaliseCap_def)
+  apply (wpsimp wp: unmapPage_cte_wp_at')
+  done
+
+lemma finaliseCap_valid_cap[Finalise_R_2_assms, wp]:
+  "\<lbrace>\<top>\<rbrace> Arch.finaliseCap cap final \<lbrace>\<lambda>rv. valid_cap' (fst rv)\<rbrace>"
+  by (wpsimp simp: RISCV64_H.finaliseCap_def)
+
+lemma finaliseCap_cases[wp]:
+  "\<lbrace>\<top>\<rbrace>
+   finaliseCap cap final flag
+   \<lbrace>\<lambda>rv s. fst rv = NullCap \<and> (snd rv \<noteq> NullCap \<longrightarrow> final \<and> cap_has_cleanup' cap \<and> snd rv = cap)
+           \<or> isZombie (fst rv) \<and> final \<and> \<not> flag \<and> snd rv = NullCap
+             \<and> capUntypedPtr (fst rv) = capUntypedPtr cap
+             \<and> (isThreadCap cap \<or> isCNodeCap cap \<or> isZombie cap)\<rbrace>"
+  apply (simp add: finaliseCap_def RISCV64_H.finaliseCap_def Let_def
+                   getThreadCSpaceRoot
+             cong: if_cong split del: if_split)
+  apply (rule hoare_pre)
+   apply ((wp | simp add: gen_isCap_simps split del: if_split
+              | wpc
+              | simp only: valid_NullCap fst_conv snd_conv)+)[1]
+  apply (simp only: simp_thms fst_conv snd_conv option.simps if_cancel
+                    o_def)
+  apply (intro allI impI conjI TrueI)
+  apply (auto simp add: gen_isCap_simps cap_has_cleanup'_def)
+  done
+
+lemmas [Finalise_R_2_assms] =
+  cancelAllIPC_cte_wp_at' cancelAllSignals_cte_wp_at' unbindMaybeNotification_cte_wp_at'
+  prepareThreadDelete_cte_wp_at' unbindNotification_cte_wp_at'
+  Arch_postCapDeletion_valid_global_refs Arch_postCapDeletion_valid_arch_state'
+  mdb_empty.vmdb_n mdb_empty.descendants not_Final_removeable
+
+end (* Arch *)
+
+interpretation Finalise_R_2?: Finalise_R_2 arch_final_matters' arch_cap_has_cleanup'
+proof goal_cases
+  interpret Arch  .
+  case 1 show ?case by (intro_locales; (unfold_locales; (fact Finalise_R_2_assms)?)?)
+qed
+
+(* this is the only arch-specific lemma in delete_one_conc_pre so far;
+   save processing time by not creating an extra Arch_delete_one_conc_pre locale
+   by directly requalifying instead *)
+lemma (in delete_one_conc_pre) finaliseCap_replaceable:
+  "\<lbrace>\<lambda>s. invs' s \<and> cte_wp_at' (\<lambda>cte. cteCap cte = cap) slot s
+       \<and> (final_matters' cap \<longrightarrow> (final = isFinal cap slot (cteCaps_of s)))
+       \<and> weak_sch_act_wf (ksSchedulerAction s) s\<rbrace>
+     finaliseCap cap final flag
+   \<lbrace>\<lambda>rv s. (isNullCap (fst rv) \<and> removeable' slot s cap
+                \<and> (snd rv \<noteq> NullCap \<longrightarrow> snd rv = cap \<and> cap_has_cleanup' cap
+                                      \<and> isFinal cap slot (cteCaps_of s)))
+        \<or>
+          (isZombie (fst rv) \<and> snd rv = NullCap
+            \<and> isFinal cap slot (cteCaps_of s)
+            \<and> capClass cap = capClass (fst rv)
+            \<and> capUntypedPtr (fst rv) = capUntypedPtr cap
+            \<and> capBits (fst rv) = capBits cap
+            \<and> capRange (fst rv) = capRange cap
+            \<and> (isThreadCap cap \<or> isCNodeCap cap \<or> isZombie cap)
+            \<and> (\<forall>p \<in> threadCapRefs cap. st_tcb_at' ((=) Inactive) p s
+                     \<and> obj_at' (Not \<circ> tcbQueued) p s
+                     \<and> bound_tcb_at' ((=) None) p s
+                     \<and> obj_at' (\<lambda>tcb. tcbSchedNext tcb = None \<and> tcbSchedPrev tcb = None) p s))\<rbrace>"
+  supply [wp] = RISCV64.prepareThreadDelete_bound_tcb_at'
+                RISCV64.prepareThreadDelete_tcbSchedPrevNext
+  apply (simp add: finaliseCap_def Let_def getThreadCSpaceRoot
+             cong: if_cong split del: if_split)
+  apply (rule hoare_pre)
+   apply (wp prepares_delete_helper'' [OF cancelAllIPC_unlive]
+             prepares_delete_helper'' [OF cancelAllSignals_unlive]
+             suspend_isFinal RISCV64.prepareThreadDelete_unqueued
+             RISCV64.prepareThreadDelete_inactive RISCV64.prepareThreadDelete_isFinal
+             suspend_makes_inactive
+             deletingIRQHandler_removeable'
+             deletingIRQHandler_final[where slot=slot ]
+             unbindMaybeNotification_obj_at'_bound
+             getNotification_wp
+             suspend_bound_tcb_at'
+             unbindNotification_bound_tcb_at'
+             suspend_tcbSchedNext_tcbSchedPrev_None
+           | simp add: isZombie_Null isThreadCap_threadCapRefs_tcbptr
+                       isArchObjectCap_Cap_capCap
+           | (rule hoare_strengthen_post[OF RISCV64.arch_finaliseCap_removeable[where slot=slot]],
+                  clarsimp simp: gen_isCap_simps)
+           | wpc)+
+  apply clarsimp
+  apply (frule cte_wp_at_valid_objs_valid_cap', clarsimp+)
+  apply (case_tac "cteCap cte",
+         simp_all add: gen_isCap_simps capRange_def cap_has_cleanup'_def
+                       final_matters'_def gen_objBits_simps
+                       not_Final_removeable finaliseCap_def,
+         simp_all add: removeable'_def)
+     (* thread *)
+     apply (frule capAligned_capUntypedPtr [OF valid_capAligned], simp)
+     apply (clarsimp simp: valid_cap'_def)
+     apply (drule valid_globals_cte_wpD'[rotated], clarsimp)
+     apply (clarsimp simp: invs'_def valid_state'_def valid_pspace'_def)
+    apply (clarsimp simp: obj_at'_def | rule conjI)+
+  done
+
+context Arch begin arch_global_naming
+
+named_theorems Finalise_R_3_assms
+
+lemma finaliseCap_cte_refs:
+  "\<lbrace>\<lambda>s. s \<turnstile>' cap\<rbrace>
+     finaliseCap cap final flag
+   \<lbrace>\<lambda>rv s. fst rv \<noteq> NullCap \<longrightarrow> cte_refs' (fst rv) = cte_refs' cap\<rbrace>"
+  apply (simp add: global.finaliseCap_def Let_def getThreadCSpaceRoot finaliseCap_def
+             cong: if_cong split del: if_split)
+  apply (rule hoare_pre)
+   apply (wp | wpc | simp only: o_def)+
+  apply (frule valid_capAligned)
+  apply (cases cap, simp_all add: gen_isCap_simps)
+   apply (clarsimp simp: tcb_cte_cases_def word_count_from_top gen_objBits_simps)
+  apply clarsimp
+  apply (rule ext, simp)
+  apply (rule image_cong [OF _ refl])
+  apply (fastforce simp: mask_def capAligned_def gen_objBits_simps shiftL_nat)
+  done
+
+lemma emptySlot_invs'[wp]:
+  "\<lbrace>\<lambda>s. invs' s \<and> cte_wp_at' (\<lambda>cte. removeable' sl s (cteCap cte)) sl s
+            \<and> (info \<noteq> NullCap \<longrightarrow> post_cap_delete_pre' info sl (cteCaps_of s) )\<rbrace>
+     emptySlot sl info
+   \<lbrace>\<lambda>rv. invs'\<rbrace>"
+  apply (simp add: invs'_def valid_state'_def valid_pspace'_def)
+  apply (wp valid_irq_node_lift cur_tcb_lift valid_dom_schedule'_lift)
+  apply (clarsimp simp: cte_wp_at_ctes_of post_cap_delete_pre'_def cteCaps_of_def
+                 split: capability.split_asm)
+  by auto
+
+lemma cteDeleteOne_invs[Finalise_R_3_assms, wp]:
+  "cteDeleteOne ptr \<lbrace>invs'\<rbrace>"
+  apply (simp add: cteDeleteOne_def unless_def
+                   split_def finaliseCapTrue_standin_simple_def)
+  apply wp
+    apply (rule hoare_strengthen_post)
+     apply (rule hoare_vcg_conj_lift[OF finaliseCap_True_invs])
+     apply (rule hoare_vcg_conj_lift[OF finaliseCap_replaceable[where slot=ptr]])
+     apply (rule hoare_vcg_conj_lift[OF finaliseCap_cte_refs])
+     apply (rule finaliseCap_equal_cap[where sl=ptr])
+    apply (clarsimp simp: cte_wp_at_ctes_of)
+    apply (erule disjE, solves simp)
+    apply (clarsimp dest!: isCapDs simp: capRemovable_def)
+    apply (clarsimp simp: removeable'_def fun_eq_iff[where f="cte_refs' cap" for cap]
+                     del: disjCI)
+    subgoal by (auto dest!: isCapDs simp: pred_tcb_at'_def obj_at'_def live'_def hyp_live'_def
+                                          ko_wp_at'_def)
+   apply (wp isFinalCapability_inv getCTE_wp' hoare_weak_lift_imp
+          | wp (once) isFinal[where x=ptr])+
+  apply (fastforce simp: cte_wp_at_ctes_of)
+  done
+
+lemma isFinalCapability_corres'[Finalise_R_3_assms]:
   "final_matters' (cteCap cte) \<Longrightarrow>
    corres (=) (invs and cte_wp_at ((=) cap) ptr)
                (invs' and cte_wp_at' ((=) cte) (cte_map ptr))
@@ -2164,7 +1089,7 @@ lemma isFinalCapability_corres':
    apply (erule_tac x=aa in allE)
    apply (erule_tac x=ba in allE)
    apply (clarsimp simp: cte_wp_at_caps_of_state)
-   apply (clarsimp simp: sameObjectAs_def3 obj_refs_Master cap_irqs_relation_Master
+   apply (clarsimp simp: sameObjectAs_def3 obj_refs_relation_Master cap_irqs_relation_Master
                          arch_gen_refs_relation_Master gen_obj_refs_Int
                    cong: if_cong
                   split: capability.split_asm)
@@ -2172,7 +1097,7 @@ lemma isFinalCapability_corres':
   apply (rule_tac x="fst ptr" in exI)
   apply (rule_tac x="snd ptr" in exI)
   apply (rule conjI)
-   apply (clarsimp simp: cte_wp_at_def final_matters'_def
+   apply (clarsimp simp: cte_wp_at_def final_matters'_def arch_final_matters'_def
                          gen_obj_refs_Int
                   split: cap_relation_split_asm arch_cap.split_asm)
   apply clarsimp
@@ -2200,1147 +1125,35 @@ lemma isFinalCapability_corres':
           simp?, clarsimp, assumption+)
    subgoal by (clarsimp simp: sameObjectAs_def3 isCap_simps valid_cap_def valid_arch_cap_def
                               valid_arch_cap_ref_def obj_at_def is_obj_defs a_type_def
-                              final_matters'_def
+                              final_matters'_def arch_final_matters'_def
                         split: cap.split_asm arch_cap.split_asm option.split_asm if_split_asm,
                simp_all add: is_cap_defs)
   apply (rule classical)
   apply (clarsimp simp: cap_irqs_def cap_irq_opt_def sameObjectAs_def3 isCap_simps
-                        acap_relation_def
-                 split: cap.split_asm arch_cap.split_asm)
+                 split: cap.split_asm)
   done
 
-lemma isFinalCapability_corres:
-  "corres (\<lambda>rv rv'. final_matters' (cteCap cte) \<longrightarrow> rv = rv')
-          (invs and cte_wp_at ((=) cap) ptr)
-          (invs' and cte_wp_at' ((=) cte) (cte_map ptr))
-       (is_final_cap cap) (isFinalCapability cte)"
-  apply (cases "final_matters' (cteCap cte)")
-   apply simp
-   apply (erule isFinalCapability_corres')
-  apply (subst bind_return[symmetric],
-         rule corres_symb_exec_r)
-     apply (rule corres_no_failI)
-      apply wp
-     apply (clarsimp simp: in_monad is_final_cap_def simpler_gets_def)
-    apply (wp isFinalCapability_inv)+
-  apply fastforce
-  done
-
-text \<open>Facts about finalise_cap/finaliseCap and
-        cap_delete_one/cteDelete in no particular order\<close>
-
-
-definition
-  finaliseCapTrue_standin_simple_def:
-  "finaliseCapTrue_standin cap fin \<equiv> finaliseCap cap fin True"
-
-context
-begin
-
-declare if_cong [cong]
-
-lemmas finaliseCapTrue_standin_def
-    = finaliseCapTrue_standin_simple_def
-        [unfolded finaliseCap_def, simplified]
-
-lemmas cteDeleteOne_def'
-    = eq_reflection [OF cteDeleteOne_def]
-lemmas cteDeleteOne_def
-    = cteDeleteOne_def'[folded finaliseCapTrue_standin_simple_def]
-
-crunch cteDeleteOne, suspend, prepareThreadDelete
-  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  (wp: crunch_wps getObject_inv loadObject_default_inv
-   simp: crunch_simps unless_def o_def)
-
-end
-
-lemmas cancelAllIPC_typs[wp] = typ_at_lifts [OF cancelAllIPC_typ_at']
-lemmas cancelAllSignals_typs[wp] = typ_at_lifts [OF cancelAllSignals_typ_at']
-lemmas suspend_typs[wp] = typ_at_lifts [OF suspend_typ_at']
-
-definition
-  cap_has_cleanup' :: "capability \<Rightarrow> bool"
-where
-  "cap_has_cleanup' cap \<equiv> case cap of
-     IRQHandlerCap _ \<Rightarrow> True
-   | ArchObjectCap acap \<Rightarrow> False
-   | _ \<Rightarrow> False"
-
-lemmas cap_has_cleanup'_simps[simp] = cap_has_cleanup'_def[split_simps capability.split]
-
-lemma finaliseCap_cases[wp]:
-  "\<lbrace>\<top>\<rbrace>
-     finaliseCap cap final flag
-   \<lbrace>\<lambda>rv s. fst rv = NullCap \<and> (snd rv \<noteq> NullCap \<longrightarrow> final \<and> cap_has_cleanup' cap \<and> snd rv = cap)
-     \<or>
-       isZombie (fst rv) \<and> final \<and> \<not> flag \<and> snd rv = NullCap
-        \<and> capUntypedPtr (fst rv) = capUntypedPtr cap
-        \<and> (isThreadCap cap \<or> isCNodeCap cap \<or> isZombie cap)\<rbrace>"
-  apply (simp add: finaliseCap_def RISCV64_H.finaliseCap_def Let_def
-                   getThreadCSpaceRoot
-             cong: if_cong split del: if_split)
-  apply (rule hoare_pre)
-   apply ((wp | simp add: isCap_simps split del: if_split
-              | wpc
-              | simp only: valid_NullCap fst_conv snd_conv)+)[1]
-  apply (simp only: simp_thms fst_conv snd_conv option.simps if_cancel
-                    o_def)
-  apply (intro allI impI conjI TrueI)
-  apply (auto simp add: isCap_simps cap_has_cleanup'_def)
-  done
-
-crunch finaliseCap
-  for aligned'[wp]: "pspace_aligned'"
-  (simp: crunch_simps assertE_def unless_def o_def
-     wp: getObject_inv loadObject_default_inv crunch_wps)
-
-crunch finaliseCap
-  for distinct'[wp]: "pspace_distinct'"
-  (simp: crunch_simps assertE_def unless_def o_def
-     wp: getObject_inv loadObject_default_inv crunch_wps)
-
-crunch finaliseCap
-  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  (simp: crunch_simps assertE_def
-     wp: getObject_inv loadObject_default_inv crunch_wps)
-lemmas finaliseCap_typ_ats[wp] = typ_at_lifts[OF finaliseCap_typ_at']
-
-lemma unmapPageTable_it'[wp]:
-  "unmapPageTable asid vaddr pt \<lbrace>\<lambda>s. P (ksIdleThread s)\<rbrace>"
-  unfolding unmapPageTable_def by wpsimp
-
-crunch finaliseCap
-  for it'[wp]: "\<lambda>s. P (ksIdleThread s)"
-  (simp: crunch_simps assertE_def o_def
-     wp: crunch_wps)
-
-lemma ntfn_q_refs_of'_mult:
-  "ntfn_q_refs_of' ntfn = (case ntfn of Structures_H.WaitingNtfn q \<Rightarrow> set q | _ \<Rightarrow> {}) \<times> {NTFNSignal}"
-  by (cases ntfn, simp_all)
-
-lemma tcb_st_not_Bound:
-  "(p, NTFNBound) \<notin> tcb_st_refs_of' ts"
-  "(p, TCBBound) \<notin> tcb_st_refs_of' ts"
-  by (auto simp: tcb_st_refs_of'_def split: Structures_H.thread_state.split)
-
-crunch setBoundNotification
-  for valid_bitmaps[wp]: valid_bitmaps
-  and tcbSchedNexts_of[wp]: "\<lambda>s. P (tcbSchedNexts_of s)"
-  and tcbSchedPrevs_of[wp]: "\<lambda>s. P (tcbSchedPrevs_of s)"
-  and tcbQueued[wp]: "\<lambda>s. P (tcbQueued |< tcbs_of' s)"
-  and valid_sched_pointers[wp]: valid_sched_pointers
-  (wp: valid_bitmaps_lift)
-
-lemma unbindNotification_invs[wp]:
-  "\<lbrace>invs'\<rbrace> unbindNotification tcb \<lbrace>\<lambda>rv. invs'\<rbrace>"
-  apply (simp add: unbindNotification_def invs'_def valid_state'_def)
-  apply (rule bind_wp[OF _ gbn_sp'])
-  apply (case_tac ntfnPtr, clarsimp, wp, clarsimp)
-  apply clarsimp
-  apply (rule bind_wp[OF _ get_ntfn_sp'])
-  apply (rule hoare_pre)
-  apply (wp sbn'_valid_pspace'_inv sbn_sch_act' valid_irq_node_lift valid_dom_schedule'_lift
-            irqs_masked_lift setBoundNotification_ct_not_inQ sym_heap_sched_pointers_lift
-            untyped_ranges_zero_lift | clarsimp simp: cteCaps_of_def o_def)+
-  apply (rule conjI)
-   apply (clarsimp elim!: obj_atE'
-                   dest!: pred_tcb_at')
-  apply (clarsimp simp: pred_tcb_at' conj_comms)
-  apply (frule bound_tcb_ex_cap'', clarsimp+)
-  apply (frule(1) sym_refs_bound_tcb_atD')
-  apply (frule(1) sym_refs_obj_atD')
-  apply (clarsimp simp: refs_of_rev')
-  apply normalise_obj_at'
-  apply (subst delta_sym_refs, assumption)
-    apply (auto split: if_split_asm)[1]
-   apply (auto simp: tcb_st_not_Bound ntfn_q_refs_of'_mult split: if_split_asm)[1]
-  apply (frule obj_at_valid_objs', clarsimp+)
-  apply (simp add: valid_ntfn'_def valid_obj'_def live'_def
-            split: ntfn.splits)
-  apply (erule if_live_then_nonz_capE')
-  apply (clarsimp simp: obj_at'_def ko_wp_at'_def live'_def)
-  done
-
-lemma ntfn_bound_tcb_at':
-  "\<lbrakk>sym_refs (state_refs_of' s); valid_objs' s; ko_at' ntfn ntfnptr s;
-    ntfnBoundTCB ntfn = Some tcbptr; P (Some ntfnptr)\<rbrakk>
-  \<Longrightarrow> bound_tcb_at' P tcbptr s"
-  apply (drule_tac x=ntfnptr in sym_refsD[rotated])
-   apply (clarsimp simp: obj_at'_def)
-   apply (fastforce simp: state_refs_of'_def)
-  apply (auto simp: pred_tcb_at'_def obj_at'_def valid_obj'_def valid_ntfn'_def
-                    state_refs_of'_def refs_of_rev'
-          simp del: refs_of_simps
-             split: option.splits if_split_asm)
-  done
-
-
-lemma unbindMaybeNotification_invs[wp]:
-  "\<lbrace>invs'\<rbrace> unbindMaybeNotification ntfnptr \<lbrace>\<lambda>rv. invs'\<rbrace>"
-  apply (simp add: unbindMaybeNotification_def invs'_def valid_state'_def)
-  apply (rule bind_wp[OF _ get_ntfn_sp'])
-  apply (rule hoare_pre)
-   apply (wp sbn'_valid_pspace'_inv sbn_sch_act' sym_heap_sched_pointers_lift valid_irq_node_lift
-             irqs_masked_lift valid_dom_schedule'_lift setBoundNotification_ct_not_inQ
-             untyped_ranges_zero_lift
-             | wpc | clarsimp simp: cteCaps_of_def o_def)+
-  apply safe[1]
-           defer 3
-           defer 7
-           apply (fold_subgoals (prefix))[8]
-           subgoal premises prems using prems
-              by (auto simp: pred_tcb_at' valid_pspace'_def valid_obj'_def valid_ntfn'_def
-                             ko_wp_at'_def live'_def
-                      elim!: obj_atE' if_live_then_nonz_capE'
-                      split: option.splits ntfn.splits)
-   apply (rule delta_sym_refs, assumption)
-    apply (fold_subgoals (prefix))[2]
-    subgoal premises prems using prems by (fastforce simp: symreftype_inverse' ntfn_q_refs_of'_def
-                    split: ntfn.splits if_split_asm
-                     dest!: ko_at_state_refs_ofD')+
-  apply (rule delta_sym_refs, assumption)
-   apply (clarsimp split: if_split_asm)
-   apply (frule ko_at_state_refs_ofD', simp)
-  apply (clarsimp split: if_split_asm)
-   apply (frule_tac P="(=) (Some ntfnptr)" in ntfn_bound_tcb_at', simp_all add: valid_pspace'_def)[1]
-   subgoal by (fastforce simp: ntfn_q_refs_of'_def state_refs_of'_def tcb_ntfn_is_bound'_def
-                          tcb_st_refs_of'_def
-                   dest!: bound_tcb_at_state_refs_ofD'
-                   split: ntfn.splits thread_state.splits)
-  apply (frule ko_at_state_refs_ofD', simp)
-  done
-
-(* Ugh, required to be able to split out the abstract invs *)
-lemma finaliseCap_True_invs[wp]:
-  "\<lbrace>invs'\<rbrace> finaliseCap cap final True \<lbrace>\<lambda>rv. invs'\<rbrace>"
-  apply (simp add: finaliseCap_def Let_def)
-  apply safe
-    apply (wp irqs_masked_lift| simp | wpc)+
-  done
-
-lemma invs_asid_update_strg':
-  "invs' s \<and> tab = riscvKSASIDTable (ksArchState s) \<longrightarrow>
-   invs' (s\<lparr>ksArchState := riscvKSASIDTable_update
-            (\<lambda>_. tab (asid := None)) (ksArchState s)\<rparr>)"
-  apply (simp add: invs'_def)
-  apply (simp add: valid_state'_def)
-  apply (simp add: valid_global_refs'_def global_refs'_def valid_arch_state'_def
-                   valid_asid_table'_def valid_machine_state'_def ct_idle_or_in_cur_domain'_def
-                   tcb_in_cur_domain'_def)
-  apply (auto simp add: ran_def split: if_split_asm)
-  done
-
-lemma deleteASIDPool_invs[wp]:
-  "\<lbrace>invs'\<rbrace> deleteASIDPool asid pool \<lbrace>\<lambda>rv. invs'\<rbrace>"
-  apply (simp add: deleteASIDPool_def)
-  apply wp
-    apply (simp del: fun_upd_apply)
-    apply (strengthen invs_asid_update_strg')
-  apply (wp mapM_wp' getObject_inv loadObject_default_inv
-              | simp)+
-  done
-
-crunch hwASIDFlush
-  for irq_masks[wp]: "\<lambda>s. P (irq_masks s)"
-
-lemma dmo_hwASIDFlush_invs[wp]:
-  "doMachineOp (hwASIDFlush asid) \<lbrace>invs'\<rbrace>"
-  apply (wp dmo_invs')
-  apply (clarsimp simp: hwASIDFlush_def machine_op_lift_def machine_rest_lift_def in_monad select_f_def)
-  done
-
-lemma deleteASID_invs'[wp]:
-  "deleteASID asid pd \<lbrace>invs'\<rbrace>"
-  unfolding deleteASID_def by (wpsimp wp: getASID_wp)
-
-lemma arch_finaliseCap_invs[wp]:
-  "\<lbrace>invs' and valid_cap' (ArchObjectCap cap)\<rbrace>
-     Arch.finaliseCap cap fin
-   \<lbrace>\<lambda>rv. invs'\<rbrace>"
-  unfolding RISCV64_H.finaliseCap_def by wpsimp
-
-crunch setVMRoot, deleteASIDPool
-  for ctes_of[wp]: "\<lambda>s. P (ctes_of s)"
-  (wp: crunch_wps getObject_inv loadObject_default_inv getASID_wp simp: crunch_simps)
-
-lemma deleteASID_ctes_of[wp]:
-  "deleteASID a ptr \<lbrace>\<lambda>s. P (ctes_of s)\<rbrace>"
-  unfolding deleteASID_def by (wpsimp wp: getASID_wp)
-
-lemma unmapPageTable_ctes_of[wp]:
-  "unmapPageTable asid vptr pt \<lbrace>\<lambda>s. P (ctes_of s)\<rbrace>"
-  unfolding unmapPageTable_def by wpsimp
-
-lemma arch_finaliseCap_removeable[wp]:
-  "\<lbrace>\<lambda>s. s \<turnstile>' ArchObjectCap cap \<and> invs' s
-       \<and> (final \<and> final_matters' (ArchObjectCap cap)
-            \<longrightarrow> isFinal (ArchObjectCap cap) slot (cteCaps_of s))\<rbrace>
-     Arch.finaliseCap cap final
-   \<lbrace>\<lambda>rv s. isNullCap (fst rv) \<and> removeable' slot s (ArchObjectCap cap)
-          \<and> (snd rv \<noteq> NullCap \<longrightarrow> snd rv = (ArchObjectCap cap) \<and> cap_has_cleanup' (ArchObjectCap cap)
-                                      \<and> isFinal (ArchObjectCap cap) slot (cteCaps_of s))\<rbrace>"
-  apply (simp add: RISCV64_H.finaliseCap_def removeable'_def)
-  apply (wpsimp wp: cteCaps_of_ctes_of_lift)
-  done
-
-lemma isZombie_Null:
-  "\<not> isZombie NullCap"
-  by (simp add: isCap_simps)
-
-lemma prepares_delete_helper'':
-  assumes x: "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv. ko_wp_at' (Not \<circ> live') p\<rbrace>"
-  shows      "\<lbrace>P and K ((\<forall>x. cte_refs' cap x = {})
-                          \<and> zobj_refs' cap = {p}
-                          \<and> threadCapRefs cap = {})\<rbrace>
-                 f \<lbrace>\<lambda>rv s. removeable' sl s cap\<rbrace>"
-  apply (rule hoare_gen_asm)
-  apply (rule hoare_strengthen_post [OF x])
-  apply (clarsimp simp: removeable'_def)
-  done
-
-crunch finaliseCapTrue_standin, unbindNotification
-  for ctes_of[wp]: "\<lambda>s. P (ctes_of s)"
-  (wp: crunch_wps getObject_inv loadObject_default_inv simp: crunch_simps)
-
-lemma cteDeleteOne_cteCaps_of:
-  "\<lbrace>\<lambda>s. (cte_wp_at' (\<lambda>cte. \<exists>final. finaliseCap (cteCap cte) final True \<noteq> fail) p s \<longrightarrow>
-          P ((cteCaps_of s)(p \<mapsto> NullCap)))\<rbrace>
-     cteDeleteOne p
-   \<lbrace>\<lambda>rv s. P (cteCaps_of s)\<rbrace>"
-  apply (simp add: cteDeleteOne_def unless_def split_def)
-  apply (rule bind_wp [OF _ getCTE_sp])
-  apply (case_tac "\<forall>final. finaliseCap (cteCap cte) final True = fail")
-   apply (simp add: finaliseCapTrue_standin_simple_def)
-   apply wp
-   apply (clarsimp simp: cte_wp_at_ctes_of cteCaps_of_def
-                         finaliseCap_def isCap_simps)
-   apply (drule_tac x=s in fun_cong)
-   apply (simp add: return_def fail_def)
-  apply (wp emptySlot_cteCaps_of)
-    apply (simp add: cteCaps_of_def)
-    apply (wp (once) hoare_drop_imps)
-    apply (wp isFinalCapability_inv getCTE_wp')+
-  apply (clarsimp simp: cteCaps_of_def cte_wp_at_ctes_of)
-  apply (auto simp: fun_upd_idem fun_upd_def[symmetric] o_def)
-  done
-
-lemma cteDeleteOne_isFinal:
-  "\<lbrace>\<lambda>s. isFinal cap slot (cteCaps_of s)\<rbrace>
-     cteDeleteOne p
-   \<lbrace>\<lambda>rv s. isFinal cap slot (cteCaps_of s)\<rbrace>"
-  apply (wp cteDeleteOne_cteCaps_of)
-  apply (clarsimp simp: isFinal_def sameObjectAs_def2)
-  done
-
-lemmas setEndpoint_cteCaps_of[wp] = cteCaps_of_ctes_of_lift [OF set_ep_ctes_of]
-lemmas setNotification_cteCaps_of[wp] = cteCaps_of_ctes_of_lift [OF set_ntfn_ctes_of]
-lemmas threadSet_cteCaps_of = cteCaps_of_ctes_of_lift [OF threadSet_ctes_of]
-
-crunch suspend, prepareThreadDelete
-  for isFinal: "\<lambda>s. isFinal cap slot (cteCaps_of s)"
-  (ignore: threadSet
-       wp: threadSet_cteCaps_of crunch_wps
-     simp: crunch_simps unless_def o_def)
-
-lemma isThreadCap_threadCapRefs_tcbptr:
-  "isThreadCap cap \<Longrightarrow> threadCapRefs cap = {capTCBPtr cap}"
-  by (clarsimp simp: isCap_simps)
-
-lemma isArchObjectCap_Cap_capCap:
-  "isArchObjectCap cap \<Longrightarrow> ArchObjectCap (capCap cap) = cap"
-  by (clarsimp simp: isCap_simps)
-
-lemma cteDeleteOne_deletes[wp]:
-  "\<lbrace>\<top>\<rbrace> cteDeleteOne p \<lbrace>\<lambda>rv s. cte_wp_at' (\<lambda>c. cteCap c = NullCap) p s\<rbrace>"
-  apply (subst tree_cte_cteCap_eq[unfolded o_def])
-  apply (wp cteDeleteOne_cteCaps_of)
-  apply clarsimp
-  done
-
-lemma unmapPageTable_irq_node'[wp]:
-  "unmapPageTable asid vaddr pt \<lbrace>\<lambda>s. P (irq_node' s)\<rbrace>"
-  unfolding unmapPageTable_def by wpsimp
-
-crunch finaliseCap
-  for irq_node'[wp]: "\<lambda>s. P (irq_node' s)"
-  (wp: crunch_wps getObject_inv loadObject_default_inv
-       updateObject_default_inv setObject_ksInterrupt
-   simp: crunch_simps o_def)
-
-lemma deletingIRQHandler_removeable':
-  "\<lbrace>invs' and (\<lambda>s. isFinal (IRQHandlerCap irq) slot (cteCaps_of s))
-          and K (cap = IRQHandlerCap irq)\<rbrace>
-     deletingIRQHandler irq
-   \<lbrace>\<lambda>rv s. removeable' slot s cap\<rbrace>"
-  apply (rule hoare_gen_asm)
-  apply (simp add: deletingIRQHandler_def getIRQSlot_def locateSlot_conv
-                   getInterruptState_def getSlotCap_def)
-  apply (simp add: removeable'_def tree_cte_cteCap_eq[unfolded o_def])
-  apply (subst tree_cte_cteCap_eq[unfolded o_def])+
-  apply (wp hoare_use_eq_irq_node' [OF cteDeleteOne_irq_node' cteDeleteOne_cteCaps_of]
-            getCTE_wp')
-  apply (clarsimp simp: cte_level_bits_def ucast_nat_def shiftl_t2n mult_ac cteSizeBits_def
-                  split: option.split_asm)
-  done
-
-lemma finaliseCap_cte_refs:
-  "\<lbrace>\<lambda>s. s \<turnstile>' cap\<rbrace>
-     finaliseCap cap final flag
-   \<lbrace>\<lambda>rv s. fst rv \<noteq> NullCap \<longrightarrow> cte_refs' (fst rv) = cte_refs' cap\<rbrace>"
-  apply (simp  add: finaliseCap_def Let_def getThreadCSpaceRoot
-                    RISCV64_H.finaliseCap_def
-             cong: if_cong split del: if_split)
-  apply (rule hoare_pre)
-   apply (wp | wpc | simp only: o_def)+
-  apply (frule valid_capAligned)
-  apply (cases cap, simp_all add: isCap_simps)
-   apply (clarsimp simp: tcb_cte_cases_def word_count_from_top objBits_defs)
-  apply clarsimp
-  apply (rule ext, simp)
-  apply (rule image_cong [OF _ refl])
-  apply (fastforce simp: mask_def capAligned_def objBits_simps shiftL_nat)
-  done
-
-lemma deletingIRQHandler_final:
-  "\<lbrace>\<lambda>s. isFinal cap slot (cteCaps_of s)
-             \<and> (\<forall>final. finaliseCap cap final True = fail)\<rbrace>
-     deletingIRQHandler irq
-   \<lbrace>\<lambda>rv s. isFinal cap slot (cteCaps_of s)\<rbrace>"
-  apply (simp add: deletingIRQHandler_def isFinal_def getIRQSlot_def
-                   getInterruptState_def locateSlot_conv getSlotCap_def)
-  apply (wp cteDeleteOne_cteCaps_of getCTE_wp')
-  apply (auto simp: sameObjectAs_def3)
-  done
-
-declare suspend_unqueued [wp]
-
-lemma unbindNotification_valid_objs'_helper:
-  "valid_tcb' tcb s \<longrightarrow> valid_tcb' (tcbBoundNotification_update (\<lambda>_. None) tcb) s "
-  by (clarsimp simp: valid_bound_ntfn'_def valid_tcb'_def tcb_cte_cases_def cteSizeBits_def
-                  split: option.splits ntfn.splits)
-
-lemma unbindNotification_valid_objs'_helper':
-  "valid_ntfn' tcb s \<longrightarrow> valid_ntfn' (ntfnBoundTCB_update (\<lambda>_. None) tcb) s "
-  by (clarsimp simp: valid_bound_tcb'_def valid_ntfn'_def
-                  split: option.splits ntfn.splits)
-
-lemmas setNotification_valid_tcb' = typ_at'_valid_tcb'_lift [OF setNotification_typ_at']
-
-lemma unbindNotification_valid_objs'[wp]:
-  "\<lbrace>valid_objs'\<rbrace>
-     unbindNotification t
-   \<lbrace>\<lambda>rv. valid_objs'\<rbrace>"
-  apply (simp add: unbindNotification_def)
-  apply (rule hoare_pre)
-  apply (wp threadSet_valid_objs' gbn_wp' set_ntfn_valid_objs' hoare_vcg_all_lift
-            setNotification_valid_tcb' getNotification_wp
-        | wpc | clarsimp simp: setBoundNotification_def unbindNotification_valid_objs'_helper)+
-  apply (clarsimp elim!: obj_atE')
-  apply (rule valid_objsE', assumption+)
-  apply (clarsimp simp: valid_obj'_def unbindNotification_valid_objs'_helper')
-  done
-
-lemma unbindMaybeNotification_valid_objs'[wp]:
-  "\<lbrace>valid_objs'\<rbrace>
-     unbindMaybeNotification t
-   \<lbrace>\<lambda>rv. valid_objs'\<rbrace>"
-  apply (simp add: unbindMaybeNotification_def)
-  apply (rule bind_wp[OF _ get_ntfn_sp'])
-  apply (rule hoare_pre)
-  apply (wp threadSet_valid_objs' gbn_wp' set_ntfn_valid_objs' hoare_vcg_all_lift
-            setNotification_valid_tcb' getNotification_wp
-        | wpc | clarsimp simp: setBoundNotification_def unbindNotification_valid_objs'_helper)+
-  apply (clarsimp elim!: obj_atE')
-  apply (rule valid_objsE', assumption+)
-  apply (clarsimp simp: valid_obj'_def unbindNotification_valid_objs'_helper')
-  done
-
-lemma unbindMaybeNotification_sch_act_wf[wp]:
-  "\<lbrace>\<lambda>s. sch_act_wf (ksSchedulerAction s) s\<rbrace> unbindMaybeNotification t
-  \<lbrace>\<lambda>rv s. sch_act_wf (ksSchedulerAction s) s\<rbrace>"
-  apply (simp add: unbindMaybeNotification_def)
-  apply (rule hoare_pre)
-  apply (wp sbn_sch_act' | wpc | simp)+
-  done
-
-lemma valid_cong:
-  "\<lbrakk> \<And>s. P s = P' s; \<And>s. P' s \<Longrightarrow> f s = f' s;
-        \<And>rv s' s. \<lbrakk> (rv, s') \<in> fst (f' s); P' s \<rbrakk> \<Longrightarrow> Q rv s' = Q' rv s' \<rbrakk>
-    \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace> = \<lbrace>P'\<rbrace> f' \<lbrace>Q'\<rbrace>"
-  by (clarsimp simp add: valid_def, blast)
-
-lemma sym_refs_ntfn_bound_eq: "sym_refs (state_refs_of' s)
-    \<Longrightarrow> obj_at' (\<lambda>ntfn. ntfnBoundTCB ntfn = Some t) x s
-    = bound_tcb_at' (\<lambda>st. st = Some x) t s"
-  apply (rule iffI)
-   apply (drule (1) sym_refs_obj_atD')
-   apply (clarsimp simp: pred_tcb_at'_def obj_at'_def ko_wp_at'_def refs_of_rev')
-  apply (drule(1) sym_refs_bound_tcb_atD')
-  apply (clarsimp simp: obj_at'_def ko_wp_at'_def refs_of_rev')
-  done
-
-lemma unbindMaybeNotification_obj_at'_bound:
-  "\<lbrace>\<top>\<rbrace>
-     unbindMaybeNotification r
-   \<lbrace>\<lambda>_ s. obj_at' (\<lambda>ntfn. ntfnBoundTCB ntfn = None) r s\<rbrace>"
-  apply (simp add: unbindMaybeNotification_def)
-  apply (rule bind_wp[OF _ get_ntfn_sp'])
-  apply (rule hoare_pre)
-   apply (wp obj_at_setObject2
-        | wpc
-        | simp add: setBoundNotification_def threadSet_def updateObject_default_def in_monad)+
-  apply (simp add: setNotification_def obj_at'_real_def cong: valid_cong)
-   apply (wp setObject_ko_wp_at, (simp add: objBits_simps')+)
-  apply (clarsimp simp: obj_at'_def ko_wp_at'_def)
-  done
-
-crunch unbindNotification, unbindMaybeNotification
-  for isFinal[wp]: "\<lambda>s. isFinal cap slot (cteCaps_of s)"
-  (wp: sts_bound_tcb_at' threadSet_cteCaps_of crunch_wps getObject_inv
-       loadObject_default_inv
-   ignore: threadSet
-   simp: setBoundNotification_def)
-
-crunch cancelSignal, cancelAllIPC
-  for bound_tcb_at'[wp]: "bound_tcb_at' P t"
-  (wp: sts_bound_tcb_at' threadSet_cteCaps_of crunch_wps getObject_inv
-       loadObject_default_inv
-   ignore: threadSet)
-
-lemma finaliseCapTrue_standin_bound_tcb_at':
-  "\<lbrace>\<lambda>s. bound_tcb_at' P t s \<and> (\<exists>tt b r. cap = ReplyCap tt b r) \<rbrace>
-     finaliseCapTrue_standin cap final
-   \<lbrace>\<lambda>_. bound_tcb_at' P t\<rbrace>"
-  apply (case_tac cap, simp_all add:finaliseCapTrue_standin_def)
-  apply (clarsimp simp: isNotificationCap_def)
-  apply (wp, clarsimp)
-  done
-
-lemma capDeleteOne_bound_tcb_at':
-  "\<lbrace>bound_tcb_at' P tptr and cte_wp_at' (isReplyCap \<circ> cteCap) callerCap\<rbrace>
-      cteDeleteOne callerCap \<lbrace>\<lambda>rv. bound_tcb_at' P tptr\<rbrace>"
-  apply (simp add: cteDeleteOne_def unless_def)
-  apply (rule hoare_pre)
-   apply (wp finaliseCapTrue_standin_bound_tcb_at' hoare_vcg_all_lift
-            hoare_vcg_if_lift2 getCTE_cteCap_wp
-        | wpc | simp | wp (once) hoare_drop_imp)+
-  apply (clarsimp simp:  cteCaps_of_def isReplyCap_def cte_wp_at_ctes_of
-                 split: option.splits)
-  apply (case_tac "cteCap cte", simp_all)
-  done
-
-lemma cancelIPC_bound_tcb_at'[wp]:
-  "\<lbrace>bound_tcb_at' P tptr\<rbrace> cancelIPC t \<lbrace>\<lambda>rv. bound_tcb_at' P tptr\<rbrace>"
-  apply (simp add: cancelIPC_def Let_def)
-  apply (rule bind_wp[OF _ gts_sp'])
-  apply (case_tac "state", simp_all)
-         defer 2
-         apply (rule hoare_pre)
-          apply ((wp sts_bound_tcb_at' getEndpoint_wp | wpc | simp)+)[8]
-  apply (simp add: getThreadReplySlot_def locateSlot_conv liftM_def)
-  apply (rule hoare_pre)
-   apply (wp capDeleteOne_bound_tcb_at' getCTE_ctes_of)
-   apply (rule_tac Q'="\<lambda>_. bound_tcb_at' P tptr" in hoare_post_imp)
-   apply (clarsimp simp: capHasProperty_def cte_wp_at_ctes_of)
-   apply (wp threadSet_pred_tcb_no_state | simp)+
-  done
-
-crunch suspend, prepareThreadDelete
-  for bound_tcb_at'[wp]: "bound_tcb_at' P t"
-  (wp: sts_bound_tcb_at' cancelIPC_bound_tcb_at'
-   ignore: threadSet)
-
-lemma unbindNotification_bound_tcb_at':
-  "\<lbrace>\<lambda>_. True\<rbrace> unbindNotification t \<lbrace>\<lambda>rv. bound_tcb_at' ((=) None) t\<rbrace>"
-  apply (simp add: unbindNotification_def)
-  apply (wp setBoundNotification_bound_tcb gbn_wp' | wpc | simp)+
-  done
-
-crunch unbindNotification, unbindMaybeNotification
-  for weak_sch_act_wf[wp]: "\<lambda>s. weak_sch_act_wf (ksSchedulerAction s) s"
-
-lemma unbindNotification_tcb_at'[wp]:
-  "\<lbrace>tcb_at' t'\<rbrace> unbindNotification t \<lbrace>\<lambda>rv. tcb_at' t'\<rbrace>"
-  apply (simp add: unbindNotification_def)
-  apply (wp gbn_wp' | wpc | simp)+
-  done
-
-lemma unbindMaybeNotification_tcb_at'[wp]:
-  "\<lbrace>tcb_at' t'\<rbrace> unbindMaybeNotification t \<lbrace>\<lambda>rv. tcb_at' t'\<rbrace>"
-  apply (simp add: unbindMaybeNotification_def)
-  apply (wp gbn_wp' | wpc | simp)+
-  done
-
-crunch prepareThreadDelete
-  for cte_wp_at'[wp]: "cte_wp_at' P p"
-crunch prepareThreadDelete
-  for valid_cap'[wp]: "valid_cap' cap"
-crunch prepareThreadDelete
-  for invs[wp]: "invs'" (ignore: doMachineOp)
-crunch prepareThreadDelete
-  for obj_at'[wp]: "\<lambda>s. P' (obj_at' P p s)"
-  (wp: whenE_wp simp: crunch_simps)
-
-end
-
-lemma tcbQueueRemove_tcbSchedNext_tcbSchedPrev_None_obj_at':
-  "\<lbrace>\<lambda>s. \<exists>ts. list_queue_relation ts q (tcbSchedNexts_of s) (tcbSchedPrevs_of s)\<rbrace>
-   tcbQueueRemove q t
-   \<lbrace>\<lambda>_ s. obj_at' (\<lambda>tcb. tcbSchedNext tcb = None \<and> tcbSchedPrev tcb = None) t s\<rbrace>"
-  apply (clarsimp simp: tcbQueueRemove_def)
-  apply (wpsimp wp: threadSet_wp getTCB_wp)
-  by (fastforce dest!: heap_ls_last_None
-                 simp: list_queue_relation_def prev_queue_head_def queue_end_valid_def
-                       obj_at'_def opt_map_def ps_clear_def gen_objBits_simps
-                split: if_splits)
-
-lemma tcbSchedDequeue_tcbSchedNext_tcbSchedPrev_None_obj_at':
-  "\<lbrace>valid_sched_pointers\<rbrace>
-   tcbSchedDequeue t
-   \<lbrace>\<lambda>_ s. obj_at' (\<lambda>tcb. tcbSchedNext tcb = None \<and> tcbSchedPrev tcb = None) t s\<rbrace>"
-  unfolding tcbSchedDequeue_def
-  by (wpsimp wp: tcbQueueRemove_tcbSchedNext_tcbSchedPrev_None_obj_at' threadGet_wp)
-     (fastforce simp: ready_queue_relation_def ksReadyQueues_asrt_def obj_at'_def
-                      valid_sched_pointers_def opt_pred_def opt_map_def
-               split: option.splits)
-
-crunch updateRestartPC, cancelIPC
-  for valid_sched_pointers[wp]: valid_sched_pointers
-  (simp: crunch_simps wp: crunch_wps)
-
-lemma setThreadState_tcbSchedNext_tcbSchedPrev_None_obj_at'[wp]:
-  "setThreadState ref ts \<lbrace>\<lambda>s. obj_at' (\<lambda>tcb. tcbSchedNext tcb = None \<and> tcbSchedPrev tcb = None) t s\<rbrace>"
-  unfolding setThreadState_def
-  apply (wpsimp wp: threadSet_wp getTCB_wp)
-  apply (fastforce simp: obj_at'_def gen_objBits_simps)
-  done
-
-lemma suspend_tcbSchedNext_tcbSchedPrev_None:
-  "\<lbrace>invs'\<rbrace> suspend t \<lbrace>\<lambda>_ s. obj_at' (\<lambda>tcb. tcbSchedNext tcb = None \<and> tcbSchedPrev tcb = None) t s\<rbrace>"
-  unfolding suspend_def
-  by (wpsimp wp: hoare_drop_imps tcbSchedDequeue_tcbSchedNext_tcbSchedPrev_None_obj_at')
-
-lemma (in delete_one_conc_pre) finaliseCap_replaceable:
-  "\<lbrace>\<lambda>s. invs' s \<and> cte_wp_at' (\<lambda>cte. cteCap cte = cap) slot s
-       \<and> (final_matters' cap \<longrightarrow> (final = isFinal cap slot (cteCaps_of s)))
-       \<and> weak_sch_act_wf (ksSchedulerAction s) s\<rbrace>
-     finaliseCap cap final flag
-   \<lbrace>\<lambda>rv s. (isNullCap (fst rv) \<and> removeable' slot s cap
-                \<and> (snd rv \<noteq> NullCap \<longrightarrow> snd rv = cap \<and> cap_has_cleanup' cap
-                                      \<and> isFinal cap slot (cteCaps_of s)))
-        \<or>
-          (isZombie (fst rv) \<and> snd rv = NullCap
-            \<and> isFinal cap slot (cteCaps_of s)
-            \<and> capClass cap = capClass (fst rv)
-            \<and> capUntypedPtr (fst rv) = capUntypedPtr cap
-            \<and> capBits (fst rv) = capBits cap
-            \<and> capRange (fst rv) = capRange cap
-            \<and> (isThreadCap cap \<or> isCNodeCap cap \<or> isZombie cap)
-            \<and> (\<forall>p \<in> threadCapRefs cap. st_tcb_at' ((=) Inactive) p s
-                     \<and> obj_at' (Not \<circ> tcbQueued) p s
-                     \<and> bound_tcb_at' ((=) None) p s
-                     \<and> obj_at' (\<lambda>tcb. tcbSchedNext tcb = None \<and> tcbSchedPrev tcb = None) p s))\<rbrace>"
-  apply (simp add: finaliseCap_def Let_def getThreadCSpaceRoot
-             cong: if_cong split del: if_split)
-  apply (rule hoare_pre)
-   apply (wp prepares_delete_helper'' [OF cancelAllIPC_unlive]
-             prepares_delete_helper'' [OF cancelAllSignals_unlive]
-             suspend_isFinal RISCV64.prepareThreadDelete_unqueued (* FIXME arch-split: interface *)
-             RISCV64.prepareThreadDelete_inactive prepareThreadDelete_isFinal
-             suspend_makes_inactive
-             deletingIRQHandler_removeable'
-             deletingIRQHandler_final[where slot=slot ]
-             unbindMaybeNotification_obj_at'_bound
-             getNotification_wp
-             suspend_bound_tcb_at'
-             unbindNotification_bound_tcb_at'
-             suspend_tcbSchedNext_tcbSchedPrev_None
-           | simp add: isZombie_Null isThreadCap_threadCapRefs_tcbptr
-                       isArchObjectCap_Cap_capCap
-           | (rule hoare_strengthen_post [OF arch_finaliseCap_removeable[where slot=slot]],
-              clarsimp simp: gen_isCap_simps)
-           | wpc)+
-  apply clarsimp
-  apply (frule cte_wp_at_valid_objs_valid_cap', clarsimp+)
-  apply (case_tac "cteCap cte",
-         simp_all add: gen_isCap_simps capRange_def cap_has_cleanup'_def
-                       final_matters'_def gen_objBits_simps
-                       not_Final_removeable finaliseCap_def,
-         simp_all add: removeable'_def)
-     (* thread *)
-     apply (frule capAligned_capUntypedPtr [OF valid_capAligned], simp)
-     apply (clarsimp simp: valid_cap'_def)
-     apply (drule valid_globals_cte_wpD'[rotated], clarsimp)
-     apply (clarsimp simp: invs'_def valid_state'_def valid_pspace'_def)
-    apply (clarsimp simp: obj_at'_def | rule conjI)+
-  done
-
-lemma cteDeleteOne_cte_wp_at_preserved:
-  assumes x: "\<And>cap final. P cap \<Longrightarrow> finaliseCap cap final True = fail"
-  shows "\<lbrace>\<lambda>s. cte_wp_at' (\<lambda>cte. P (cteCap cte)) p s\<rbrace>
-           cteDeleteOne ptr
-         \<lbrace>\<lambda>rv s. cte_wp_at' (\<lambda>cte. P (cteCap cte)) p s\<rbrace>"
-  apply (simp add: tree_cte_cteCap_eq[unfolded o_def])
-  apply (rule hoare_pre, wp cteDeleteOne_cteCaps_of)
-  apply (clarsimp simp: cteCaps_of_def cte_wp_at_ctes_of x)
-  done
-
-crunch cancelSignal
-  for ctes_of[wp]: "\<lambda>s. P (ctes_of s)"
-  (simp: crunch_simps wp: crunch_wps)
-
-lemma cancelIPC_cteCaps_of:
-  "\<lbrace>\<lambda>s. (\<forall>p. cte_wp_at' (\<lambda>cte. \<exists>final. finaliseCap (cteCap cte) final True \<noteq> fail) p s \<longrightarrow>
-          P ((cteCaps_of s)(p \<mapsto> NullCap))) \<and>
-     P (cteCaps_of s)\<rbrace>
-     cancelIPC t
-   \<lbrace>\<lambda>rv s. P (cteCaps_of s)\<rbrace>"
-  apply (simp add: cancelIPC_def Let_def capHasProperty_def
-                   getThreadReplySlot_def locateSlot_conv)
-  apply (rule hoare_pre)
-   apply (wp cteDeleteOne_cteCaps_of getCTE_wp' | wpcw
-          | simp add: cte_wp_at_ctes_of
-          | wp (once) hoare_drop_imps cteCaps_of_ctes_of_lift)+
-          apply (wp hoare_convert_imp hoare_vcg_all_lift
-                    threadSet_ctes_of threadSet_cteCaps_of
-                 | clarsimp)+
-         apply (wp cteDeleteOne_cteCaps_of getCTE_wp' | wpcw | simp
-                | wp (once) hoare_drop_imps cteCaps_of_ctes_of_lift)+
-  apply (clarsimp simp: cte_wp_at_ctes_of cteCaps_of_def)
-  apply (drule_tac x="mdbNext (cteMDBNode x)" in spec)
-  apply clarsimp
-  apply (auto simp: o_def map_option_case fun_upd_def[symmetric])
-  done
-
-lemma cancelIPC_cte_wp_at':
-  assumes x: "\<And>cap final. P cap \<Longrightarrow> finaliseCap cap final True = fail"
-  shows "\<lbrace>\<lambda>s. cte_wp_at' (\<lambda>cte. P (cteCap cte)) p s\<rbrace>
-           cancelIPC t
-         \<lbrace>\<lambda>rv s. cte_wp_at' (\<lambda>cte. P (cteCap cte)) p s\<rbrace>"
-  apply (simp add: tree_cte_cteCap_eq[unfolded o_def])
-  apply (rule hoare_pre, wp cancelIPC_cteCaps_of)
-  apply (clarsimp simp: cteCaps_of_def cte_wp_at_ctes_of x)
-  done
-
-crunch tcbSchedDequeue
-  for cte_wp_at'[wp]: "cte_wp_at' P p"
-  (wp: crunch_wps)
-
-lemma suspend_cte_wp_at':
-  assumes x: "\<And>cap final. P cap \<Longrightarrow> finaliseCap cap final True = fail"
-  shows "\<lbrace>cte_wp_at' (\<lambda>cte. P (cteCap cte)) p\<rbrace>
-           suspend t
-         \<lbrace>\<lambda>rv. cte_wp_at' (\<lambda>cte. P (cteCap cte)) p\<rbrace>"
-  apply (simp add: suspend_def updateRestartPC_def)
-  apply (rule hoare_pre)
-   apply (wp threadSet_cte_wp_at' cancelIPC_cte_wp_at'
-             | simp add: x)+
-  done
-
-context begin interpretation Arch . (*FIXME: arch-split*)
-
-crunch deleteASIDPool
-  for cte_wp_at'[wp]: "cte_wp_at' P p"
-  (simp: crunch_simps assertE_def
-   wp: crunch_wps getObject_inv loadObject_default_inv)
-
-lemma deleteASID_cte_wp_at'[wp]:
-  "\<lbrace>cte_wp_at' P p\<rbrace> deleteASID param_a param_b \<lbrace>\<lambda>_. cte_wp_at' P p\<rbrace>"
-  apply (simp add: deleteASID_def
-              cong: option.case_cong)
-  apply (wp setObject_cte_wp_at'[where Q="\<top>"] getObject_inv
-            loadObject_default_inv setVMRoot_cte_wp_at'
-          | clarsimp simp: updateObject_default_def in_monad
-          | rule equals0I
-          | wpc)+
-  done
-
-crunch unmapPageTable, unmapPage, unbindNotification, finaliseCapTrue_standin
-  for cte_wp_at'[wp]: "cte_wp_at' P p"
-  (simp: crunch_simps wp: crunch_wps getObject_inv loadObject_default_inv)
-
-lemma arch_finaliseCap_cte_wp_at[wp]:
-  "\<lbrace>cte_wp_at' P p\<rbrace> Arch.finaliseCap cap fin \<lbrace>\<lambda>rv. cte_wp_at' P p\<rbrace>"
-  apply (simp add: RISCV64_H.finaliseCap_def)
-  apply (wpsimp wp: unmapPage_cte_wp_at')
-  done
-
-lemma deletingIRQHandler_cte_preserved:
-  assumes x: "\<And>cap final. P cap \<Longrightarrow> finaliseCap cap final True = fail"
-  shows "\<lbrace>cte_wp_at' (\<lambda>cte. P (cteCap cte)) p\<rbrace>
-           deletingIRQHandler irq
-         \<lbrace>\<lambda>rv. cte_wp_at' (\<lambda>cte. P (cteCap cte)) p\<rbrace>"
-  apply (simp add: deletingIRQHandler_def getSlotCap_def
-                   getIRQSlot_def locateSlot_conv getInterruptState_def)
-  apply (wpsimp wp: cteDeleteOne_cte_wp_at_preserved getCTE_wp' simp: x)
-  done
-
-lemma finaliseCap_equal_cap[wp]:
-  "\<lbrace>cte_wp_at' (\<lambda>cte. cteCap cte = cap) sl\<rbrace>
-     finaliseCap cap fin flag
-   \<lbrace>\<lambda>rv. cte_wp_at' (\<lambda>cte. cteCap cte = cap) sl\<rbrace>"
-  apply (simp add: finaliseCap_def Let_def
-             cong: if_cong split del: if_split)
-  apply (rule hoare_pre)
-   apply (wp suspend_cte_wp_at' deletingIRQHandler_cte_preserved
-        | clarsimp simp: finaliseCap_def | wpc)+
-  apply (case_tac cap)
-  apply auto
-  done
-
-lemma setThreadState_st_tcb_at_simplish':
-  "simple' st \<Longrightarrow>
-   \<lbrace>st_tcb_at' (P or simple') t\<rbrace>
-     setThreadState st t'
-   \<lbrace>\<lambda>rv. st_tcb_at' (P or simple') t\<rbrace>"
-  apply (wp sts_st_tcb_at'_cases)
-  apply clarsimp
-  done
-
-lemmas setThreadState_st_tcb_at_simplish
-    = setThreadState_st_tcb_at_simplish'[unfolded pred_disj_def]
-
-crunch cteDeleteOne
-  for st_tcb_at_simplish: "st_tcb_at' (\<lambda>st. P st \<or> simple' st) t"
-  (wp: crunch_wps getObject_inv loadObject_default_inv threadSet_pred_tcb_no_state
-   simp: crunch_simps unless_def ignore: threadSet)
-
-lemma cteDeleteOne_st_tcb_at[wp]:
-  assumes x[simp]: "\<And>st. simple' st \<longrightarrow> P st" shows
-  "\<lbrace>st_tcb_at' P t\<rbrace> cteDeleteOne slot \<lbrace>\<lambda>rv. st_tcb_at' P t\<rbrace>"
-  apply (subgoal_tac "\<exists>Q. P = (Q or simple')")
-   apply (clarsimp simp: pred_disj_def)
-   apply (rule cteDeleteOne_st_tcb_at_simplish)
-  apply (rule_tac x=P in exI)
-  apply auto
-  done
-
-lemma cteDeleteOne_reply_pred_tcb_at:
-  "\<lbrace>\<lambda>s. pred_tcb_at' proj P t s \<and> (\<exists>t' r. cte_wp_at' (\<lambda>cte. cteCap cte = ReplyCap t' False r) slot s)\<rbrace>
-    cteDeleteOne slot
-   \<lbrace>\<lambda>rv. pred_tcb_at' proj P t\<rbrace>"
-  apply (simp add: cteDeleteOne_def unless_def isFinalCapability_def)
-  apply (rule bind_wp [OF _ getCTE_sp])
-  apply (rule hoare_assume_pre)
-  apply (clarsimp simp: cte_wp_at_ctes_of when_def isCap_simps
-                        Let_def finaliseCapTrue_standin_def)
-  apply (intro impI conjI, (wp | simp)+)
-  done
-
-lemmas setNotification_typ_at'[wp] = typ_at_lifts[OF setNotification_typ_at']
-
-crunch setBoundNotification, setNotification
-  for sch_act_simple[wp]: sch_act_simple
-  (wp: sch_act_simple_lift)
-
-crunch cteDeleteOne, unbindNotification
-  for sch_act_simple[wp]: sch_act_simple
-  (wp: crunch_wps ssa_sch_act_simple sts_sch_act_simple getObject_inv
-       loadObject_default_inv
-   simp: crunch_simps
-   rule: sch_act_simple_lift)
-
-lemma rescheduleRequired_sch_act_not[wp]:
-  "\<lbrace>\<top>\<rbrace> rescheduleRequired \<lbrace>\<lambda>rv. sch_act_not t\<rbrace>"
-  apply (simp add: rescheduleRequired_def setSchedulerAction_def)
-  apply (wp hoare_TrueI | simp)+
-  done
-
-crunch cteDeleteOne
-  for sch_act_not[wp]: "sch_act_not t"
-  (simp: crunch_simps case_Null_If unless_def
-   wp: crunch_wps getObject_inv loadObject_default_inv)
-
-lemma cancelAllIPC_mapM_x_weak_sch_act:
-  "\<lbrace>\<lambda>s. weak_sch_act_wf (ksSchedulerAction s) s\<rbrace>
-   mapM_x (\<lambda>t. do
-                 y \<leftarrow> setThreadState Structures_H.thread_state.Restart t;
-                 tcbSchedEnqueue t
-               od) q
-   \<lbrace>\<lambda>rv s. weak_sch_act_wf (ksSchedulerAction s) s\<rbrace>"
-  apply (rule mapM_x_wp_inv)
-  apply (wp)
-  apply (clarsimp)
-  done
-
-lemma cancelAllIPC_mapM_x_valid_objs':
-  "\<lbrace>valid_objs' and pspace_aligned' and pspace_distinct'\<rbrace>
-   mapM_x (\<lambda>t. do
-                 y \<leftarrow> setThreadState Structures_H.thread_state.Restart t;
-                 tcbSchedEnqueue t
-               od) q
-   \<lbrace>\<lambda>_. valid_objs'\<rbrace>"
-  apply (rule hoare_strengthen_post)
-   apply (rule mapM_x_wp')
-  apply (wpsimp wp: sts_valid_objs')
-   apply (clarsimp simp: valid_tcb_state'_def)+
-  done
-
-lemma cancelAllIPC_mapM_x_tcbDomain_obj_at':
-  "\<lbrace>obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>
-   mapM_x (\<lambda>t. do
-                 y \<leftarrow> setThreadState Structures_H.thread_state.Restart t;
-                 tcbSchedEnqueue t
-               od) q
-  \<lbrace>\<lambda>_. obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>"
-  by (wp mapM_x_wp' | simp)+
-
-lemma rescheduleRequired_oa_queued':
-  "rescheduleRequired \<lbrace>obj_at' (\<lambda>tcb. Q (tcbDomain tcb) (tcbPriority tcb)) t\<rbrace>"
-  unfolding rescheduleRequired_def tcbSchedEnqueue_def tcbQueuePrepend_def
-  by wpsimp
-
-lemma cancelAllIPC_tcbDomain_obj_at':
-  "\<lbrace>obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>
-     cancelAllIPC epptr
-   \<lbrace>\<lambda>_. obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>"
-  apply (simp add: cancelAllIPC_def)
-  apply (wp hoare_vcg_conj_lift hoare_vcg_const_Ball_lift
-            rescheduleRequired_oa_queued' cancelAllIPC_mapM_x_tcbDomain_obj_at'
-            getEndpoint_wp
-       | wpc
-       | simp)+
-  done
-
-lemma cancelAllSignals_tcbDomain_obj_at':
-  "\<lbrace>obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>
-     cancelAllSignals epptr
-   \<lbrace>\<lambda>_. obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>"
-apply (simp add: cancelAllSignals_def)
-apply (wp hoare_vcg_conj_lift hoare_vcg_const_Ball_lift
-          rescheduleRequired_oa_queued' cancelAllIPC_mapM_x_tcbDomain_obj_at'
-          getNotification_wp
-     | wpc
-     | simp)+
-done
-
-lemma unbindMaybeNotification_tcbDomain_obj_at':
-  "\<lbrace>obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>
-     unbindMaybeNotification r
-   \<lbrace>\<lambda>_. obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>"
-  unfolding unbindMaybeNotification_def
-  by (wpsimp wp: getNotification_wp gbn_wp' simp: setBoundNotification_def)+
-
-crunch isFinalCapability
-  for sch_act[wp]: "\<lambda>s. sch_act_wf (ksSchedulerAction s) s"
-  (simp: crunch_simps)
-
-crunch
-  isFinalCapability
-  for weak_sch_act[wp]: "\<lambda>s. weak_sch_act_wf (ksSchedulerAction s) s"
-  (simp: crunch_simps)
-
-crunch cteDeleteOne
-  for ksCurDomain[wp]: "\<lambda>s. P (ksCurDomain s)"
-  (wp: crunch_wps simp: crunch_simps unless_def)
-
-lemma cteDeleteOne_tcbDomain_obj_at':
-  "\<lbrace>obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace> cteDeleteOne slot \<lbrace>\<lambda>_. obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>"
-  apply (simp add: cteDeleteOne_def unless_def split_def)
-  apply (wp emptySlot_tcbDomain cancelAllIPC_tcbDomain_obj_at' cancelAllSignals_tcbDomain_obj_at'
-          isFinalCapability_inv getCTE_wp
-          unbindMaybeNotification_tcbDomain_obj_at'
-     | rule hoare_drop_imp
-     | simp add: finaliseCapTrue_standin_def Let_def
-            split del: if_split
-     | wpc)+
-  apply (clarsimp simp: cte_wp_at'_def)
-  done
-
-end
-
-global_interpretation delete_one_conc_pre
-  by (unfold_locales, wp)
-     (wp cteDeleteOne_tcbDomain_obj_at' cteDeleteOne_typ_at' cteDeleteOne_reply_pred_tcb_at | simp)+
-
-context begin interpretation Arch . (*FIXME: arch-split*)
-
-lemma cteDeleteOne_invs[wp]:
-  "\<lbrace>invs'\<rbrace> cteDeleteOne ptr \<lbrace>\<lambda>rv. invs'\<rbrace>"
-  apply (simp add: cteDeleteOne_def unless_def
-                   split_def finaliseCapTrue_standin_simple_def)
-  apply wp
-    apply (rule hoare_strengthen_post)
-     apply (rule hoare_vcg_conj_lift)
-      apply (rule finaliseCap_True_invs)
-     apply (rule hoare_vcg_conj_lift)
-      apply (rule finaliseCap_replaceable[where slot=ptr])
-     apply (rule hoare_vcg_conj_lift)
-      apply (rule finaliseCap_cte_refs)
-     apply (rule finaliseCap_equal_cap[where sl=ptr])
-    apply (clarsimp simp: cte_wp_at_ctes_of)
-    apply (erule disjE)
-     apply simp
-    apply (clarsimp dest!: isCapDs simp: capRemovable_def)
-    apply (clarsimp simp: removeable'_def fun_eq_iff[where f="cte_refs' cap" for cap]
-                     del: disjCI)
-    apply (rule disjI2)
-    apply (rule conjI)
-     subgoal by auto
-    subgoal by (auto dest!: isCapDs simp: pred_tcb_at'_def obj_at'_def projectKOs
-                                           live'_def hyp_live'_def ko_wp_at'_def)
-   apply (wp isFinalCapability_inv getCTE_wp' hoare_weak_lift_imp
-        | wp (once) isFinal[where x=ptr])+
-  apply (fastforce simp: cte_wp_at_ctes_of)
-  done
-
-end
-
-global_interpretation delete_one_conc_fr: delete_one_conc
-  by unfold_locales wp
-
-declare cteDeleteOne_invs[wp]
-
-lemma deletingIRQHandler_invs' [wp]:
-  "\<lbrace>invs'\<rbrace> deletingIRQHandler i \<lbrace>\<lambda>_. invs'\<rbrace>"
-  apply (simp add: deletingIRQHandler_def getSlotCap_def
-                   getIRQSlot_def locateSlot_conv getInterruptState_def)
-  apply (wp getCTE_wp')
-  apply simp
-  done
-
-lemma finaliseCap_invs:
-  "\<lbrace>invs' and sch_act_simple and valid_cap' cap
-         and cte_wp_at' (\<lambda>cte. cteCap cte = cap) sl\<rbrace>
-     finaliseCap cap fin flag
-   \<lbrace>\<lambda>rv. invs'\<rbrace>"
-  apply (simp add: finaliseCap_def Let_def
-             cong: if_cong split del: if_split)
-  apply (rule hoare_pre)
-   apply (wp hoare_drop_imps hoare_vcg_all_lift | simp only: o_def | wpc)+
-  apply clarsimp
-  apply (intro conjI impI)
-    apply (clarsimp dest!: isCapDs simp: valid_cap'_def)
-   apply (drule invs_valid_global', drule(1) valid_globals_cte_wpD')
-   apply (drule valid_capAligned, drule capAligned_capUntypedPtr)
-    apply (clarsimp dest!: isCapDs)
-   apply (clarsimp dest!: isCapDs)
-  apply (clarsimp dest!: isCapDs)
-  done
-
-lemma finaliseCap_zombie_cap[wp]:
-  "\<lbrace>cte_wp_at' (\<lambda>cte. (P and isZombie) (cteCap cte)) sl\<rbrace>
-     finaliseCap cap fin flag
-   \<lbrace>\<lambda>rv. cte_wp_at' (\<lambda>cte. (P and isZombie) (cteCap cte)) sl\<rbrace>"
-  apply (simp add: finaliseCap_def Let_def
-             cong: if_cong split del: if_split)
-  apply (rule hoare_pre)
-   apply (wp suspend_cte_wp_at' deletingIRQHandler_cte_preserved
-          | clarsimp simp: finaliseCap_def gen_isCap_simps | wpc)+
-  done
-
-lemma finaliseCap_zombie_cap':
-  "\<lbrace>cte_wp_at' (\<lambda>cte. (P and isZombie) (cteCap cte)) sl\<rbrace>
-     finaliseCap cap fin flag
-   \<lbrace>\<lambda>rv. cte_wp_at' (\<lambda>cte. P (cteCap cte)) sl\<rbrace>"
-  apply (rule hoare_strengthen_post)
-   apply (rule finaliseCap_zombie_cap)
-  apply (clarsimp simp: cte_wp_at_ctes_of)
-  done
-
-lemma finaliseCap_cte_cap_wp_to[wp]:
-  "\<lbrace>ex_cte_cap_wp_to' P sl\<rbrace> finaliseCap cap fin flag \<lbrace>\<lambda>rv. ex_cte_cap_wp_to' P sl\<rbrace>"
-  apply (simp add: ex_cte_cap_to'_def)
-  apply (rule hoare_pre, rule hoare_use_eq_irq_node' [OF finaliseCap_irq_node'])
-   apply (simp add: finaliseCap_def Let_def
-              cong: if_cong split del: if_split)
-   apply (wp suspend_cte_wp_at'
-             deletingIRQHandler_cte_preserved
-             hoare_vcg_ex_lift
-                 | clarsimp simp: finaliseCap_def gen_isCap_simps
-                 | rule conjI
-                 | wpc)+
-  apply fastforce
-  done
-
-crunch unbindNotification
-  for valid_cap'[wp]: "valid_cap' cap"
-
-lemma finaliseCap_valid_cap[wp]:
-  "\<lbrace>valid_cap' cap\<rbrace> finaliseCap cap final flag \<lbrace>\<lambda>rv. valid_cap' (fst rv)\<rbrace>"
-  apply (simp add: finaliseCap_def Let_def
-                   getThreadCSpaceRoot
-                   RISCV64_H.finaliseCap_def
-             cong: if_cong split del: if_split)
-  apply (rule hoare_pre)
-   apply (wp | simp only: valid_NullCap o_def fst_conv | wpc)+
-  apply simp
-  apply (intro conjI impI)
-   apply (clarsimp simp: valid_cap'_def gen_isCap_simps capAligned_def
-                         gen_objBits_simps shiftL_nat)+
-  done
-
-
-context begin interpretation Arch . (*FIXME: arch-split*)
-
-lemma unmapPageTable_nosch[wp]:
-  "unmapPageTable asid vaddr pt \<lbrace>\<lambda>s. P (ksSchedulerAction s)\<rbrace>"
-  unfolding unmapPageTable_def by wpsimp
-
-crunch "Arch.finaliseCap"
+crunch unmapPageTable
   for nosch[wp]: "\<lambda>s. P (ksSchedulerAction s)"
-  (wp: crunch_wps getObject_inv simp: loadObject_default_def updateObject_default_def)
+  (wp: crunch_wps getObject_inv hoare_vcg_all_lift hoare_vcg_if_lift3
+   simp: loadObject_default_def updateObject_default_def)
 
-crunch finaliseCap
+context notes if_cong[cong] begin
+
+crunch Arch_finaliseCap
+  for nosch[wp]: "\<lambda>s. P (ksSchedulerAction s)"
+  (wp: crunch_wps getObject_inv simp: loadObject_default_def updateObject_default_def
+   rule: RISCV64_H.finaliseCap_def)
+
+end
+
+crunch deletingIRQHandler, finaliseCap
   for sch_act_simple[wp]: sch_act_simple
   (simp: crunch_simps
    rule: sch_act_simple_lift
    wp: getObject_inv loadObject_default_inv crunch_wps)
 
-end
-
-
-lemma interrupt_cap_null_or_ntfn:
-  "invs s
-    \<Longrightarrow> cte_wp_at (\<lambda>cp. is_ntfn_cap cp \<or> cp = cap.NullCap) (interrupt_irq_node s irq, []) s"
-  apply (frule invs_valid_irq_node)
-  apply (clarsimp simp: valid_irq_node_def)
-  apply (drule_tac x=irq in spec)
-  apply (drule cte_at_0)
-  apply (clarsimp simp: cte_wp_at_caps_of_state)
-  apply (drule caps_of_state_cteD)
-  apply (frule if_unsafe_then_capD, clarsimp+)
-  apply (clarsimp simp: ex_cte_cap_wp_to_def cte_wp_at_caps_of_state)
-  apply (frule cte_refs_obj_refs_elem, erule disjE)
-   apply (clarsimp | drule caps_of_state_cteD valid_global_refsD[rotated]
-     | rule irq_node_global_refs[where irq=irq])+
-   apply (simp add: cap_range_def)
-  apply (clarsimp simp: appropriate_cte_cap_def
-                 split: cap.split_asm)
-  done
-
-lemma (in delete_one) deletingIRQHandler_corres:
-  "corres dc (einvs) (invs')
-          (deleting_irq_handler irq) (deletingIRQHandler irq)"
-  apply (simp add: deleting_irq_handler_def deletingIRQHandler_def)
-  apply (rule corres_guard_imp)
-    apply (rule corres_split[OF getIRQSlot_corres])
-      apply simp
-      apply (rule_tac P'="cte_at' (cte_map slot)" in corres_symb_exec_r_conj)
-         apply (rule_tac F="isNotificationCap rv \<or> rv = capability.NullCap"
-             and P="cte_wp_at (\<lambda>cp. is_ntfn_cap cp \<or> cp = cap.NullCap) slot
-                 and einvs"
-             and P'="invs' and cte_wp_at' (\<lambda>cte. cteCap cte = rv)
-                 (cte_map slot)" in corres_req)
-          apply (clarsimp simp: cte_wp_at_caps_of_state state_relation_def)
-          apply (drule caps_of_state_cteD)
-          apply (drule(1) pspace_relation_cte_wp_at, clarsimp+)
-          apply (auto simp: cte_wp_at_ctes_of is_cap_simps gen_isCap_simps)[1]
-         apply simp
-         apply (rule corres_guard_imp, rule delete_one_corres[unfolded dc_def])
-          apply (auto simp: cte_wp_at_caps_of_state is_cap_simps can_fast_finalise_def)[1]
-         apply (clarsimp simp: cte_wp_at_ctes_of)
-        apply (wp getCTE_wp' | simp add: getSlotCap_def)+
-     apply (wp | simp add: get_irq_slot_def getIRQSlot_def
-                           locateSlot_conv getInterruptState_def)+
-   apply (clarsimp simp: ex_cte_cap_wp_to_def interrupt_cap_null_or_ntfn)
-  apply (clarsimp simp: cte_wp_at_ctes_of)
-  done
-
-context begin interpretation Arch . (*FIXME: arch-split*)
-
-lemma arch_finaliseCap_corres:
+lemma arch_finaliseCap_corres[Finalise_R_3_assms]:
   "\<lbrakk> final_matters' (ArchObjectCap cap') \<Longrightarrow> final = final'; acap_relation cap cap' \<rbrakk>
      \<Longrightarrow> corres (\<lambda>r r'. cap_relation (fst r) (fst r') \<and> cap_relation (snd r) (snd r'))
            (\<lambda>s. invs s \<and> s \<turnstile> cap.ArchObjectCap cap
@@ -3353,7 +1166,7 @@ lemma arch_finaliseCap_corres:
            (arch_finalise_cap cap final) (Arch.finaliseCap cap' final')"
   apply (cases cap,
          simp_all add: arch_finalise_cap_def RISCV64_H.finaliseCap_def
-                       final_matters'_def case_bool_If liftM_def[symmetric]
+                       final_matters'_def arch_final_matters'_def case_bool_If liftM_def[symmetric]
                        o_def dc_def[symmetric]
                 split: option.split,
          safe)
@@ -3386,327 +1199,14 @@ lemma arch_finaliseCap_corres:
   apply (simp add: invs_no_0_obj')
   done
 
+lemmas deleteCallerCap_typ_ats[wp] = typ_at_lifts[OF deleteCallerCap_typ_at']
 
-lemma unbindNotification_corres:
-  "corres dc
-      (invs and tcb_at t)
-      invs'
-      (unbind_notification t)
-      (unbindNotification t)"
-  apply (simp add: unbind_notification_def unbindNotification_def)
-  apply (rule corres_guard_imp)
-    apply (rule corres_split[OF getBoundNotification_corres])
-      apply (rule corres_option_split)
-        apply simp
-       apply (rule corres_return_trivial)
-      apply (rule corres_split[OF getNotification_corres])
-        apply clarsimp
-        apply (rule corres_split[OF setNotification_corres])
-           apply (clarsimp simp: ntfn_relation_def split:Structures_A.ntfn.splits)
-          apply (rule setBoundNotification_corres)
-         apply (wp gbn_wp' gbn_wp)+
-   apply (clarsimp elim!: obj_at_valid_objsE
-                   dest!: bound_tcb_at_state_refs_ofD invs_valid_objs
-                    simp: valid_obj_def is_tcb tcb_ntfn_is_bound_def obj_at_def
-                          valid_tcb_def valid_bound_ntfn_def invs_psp_aligned invs_distinct
-                   split: option.splits)
-  apply (clarsimp dest!: obj_at_valid_objs' bound_tcb_at_state_refs_ofD' invs_valid_objs'
-                   simp: valid_obj'_def valid_tcb'_def valid_bound_ntfn'_def tcb_ntfn_is_bound'_def
-                  split: option.splits)
-  done
+end (* Arch *)
 
-lemma unbindMaybeNotification_corres:
-  "corres dc
-      (invs and ntfn_at ntfnptr) (invs' and ntfn_at' ntfnptr)
-      (unbind_maybe_notification ntfnptr)
-      (unbindMaybeNotification ntfnptr)"
-  apply (simp add: unbind_maybe_notification_def unbindMaybeNotification_def)
-  apply (rule corres_guard_imp)
-    apply (rule corres_split[OF getNotification_corres])
-      apply (rule corres_option_split)
-        apply (clarsimp simp: ntfn_relation_def split: Structures_A.ntfn.splits)
-       apply (rule corres_return_trivial)
-      apply simp
-      apply (rule corres_split[OF setNotification_corres])
-         apply (clarsimp simp: ntfn_relation_def split: Structures_A.ntfn.splits)
-        apply (rule setBoundNotification_corres)
-       apply (wp get_simple_ko_wp getNotification_wp)+
-   apply (clarsimp elim!: obj_at_valid_objsE
-                   dest!: bound_tcb_at_state_refs_ofD invs_valid_objs
-                    simp: valid_obj_def is_tcb tcb_ntfn_is_bound_def invs_psp_aligned invs_distinct
-                          valid_tcb_def valid_bound_ntfn_def valid_ntfn_def
-                   split: option.splits)
-  apply (clarsimp dest!: obj_at_valid_objs' bound_tcb_at_state_refs_ofD' invs_valid_objs'
-                   simp: valid_obj'_def valid_tcb'_def valid_bound_ntfn'_def
-                         tcb_ntfn_is_bound'_def valid_ntfn'_def
-                  split: option.splits)
-  done
-
-lemma fast_finaliseCap_corres:
-  "\<lbrakk> final_matters' cap' \<longrightarrow> final = final'; cap_relation cap cap';
-     can_fast_finalise cap \<rbrakk>
-   \<Longrightarrow> corres dc
-           (\<lambda>s. invs s \<and> valid_sched s \<and> s \<turnstile> cap
-                       \<and> cte_wp_at ((=) cap) sl s)
-           (\<lambda>s. invs' s \<and> s \<turnstile>' cap')
-           (fast_finalise cap final)
-           (do
-               p \<leftarrow> finaliseCap cap' final' True;
-               assert (capRemovable (fst p) (cte_map ptr) \<and> snd p = NullCap)
-            od)"
-  apply (cases cap, simp_all add: finaliseCap_def isCap_simps
-                                  corres_liftM2_simp[unfolded liftM_def]
-                                  o_def dc_def[symmetric] when_def
-                                  can_fast_finalise_def capRemovable_def
-                       split del: if_split cong: if_cong)
-   apply (clarsimp simp: final_matters'_def)
-   apply (rule corres_guard_imp)
-     apply (rule corres_rel_imp)
-      apply (rule ep_cancel_corres)
-     apply simp
-    apply (simp add: valid_cap_def)
-   apply (simp add: valid_cap'_def)
-  apply (clarsimp simp: final_matters'_def)
-  apply (rule corres_guard_imp)
-    apply (rule corres_split[OF unbindMaybeNotification_corres])
-         apply (rule cancelAllSignals_corres)
-       apply (wp abs_typ_at_lifts unbind_maybe_notification_invs typ_at_lifts hoare_drop_imps getNotification_wp
-            | wpc)+
-   apply (clarsimp simp: valid_cap_def)
-  apply (clarsimp simp: valid_cap'_def valid_obj'_def
-                 dest!: invs_valid_objs' obj_at_valid_objs' )
-  done
-
-lemma cap_delete_one_corres:
-  "corres dc (einvs and cte_wp_at can_fast_finalise ptr)
-        (invs' and cte_at' (cte_map ptr))
-        (cap_delete_one ptr) (cteDeleteOne (cte_map ptr))"
-  apply (simp add: cap_delete_one_def cteDeleteOne_def'
-                   unless_def when_def)
-  apply (rule corres_guard_imp)
-    apply (rule corres_split[OF get_cap_corres])
-      apply (rule_tac F="can_fast_finalise cap" in corres_gen_asm)
-      apply (rule corres_if)
-        apply fastforce
-       apply (rule corres_split[OF isFinalCapability_corres[where ptr=ptr]])
-         apply (simp add: split_def bind_assoc [THEN sym])
-         apply (rule corres_split[OF fast_finaliseCap_corres[where sl=ptr]])
-              apply simp+
-           apply (rule emptySlot_corres, simp)
-          apply (wp hoare_drop_imps)+
-       apply (wp isFinalCapability_inv | wp (once) isFinal[where x="cte_map ptr"])+
-      apply (rule corres_trivial, simp)
-     apply (wp get_cap_wp getCTE_wp)+
-   apply (clarsimp simp: cte_wp_at_caps_of_state can_fast_finalise_Null
-                  elim!: caps_of_state_valid_cap)
-  apply (clarsimp simp: cte_wp_at_ctes_of)
-  apply fastforce
-  done
-end
-(* FIXME: strengthen locale instead *)
-
-global_interpretation delete_one
-  apply unfold_locales
-  apply (rule corres_guard_imp)
-    apply (rule cap_delete_one_corres)
-   apply auto
-  done
-
-lemma no_idle_thread_cap:
-  "\<lbrakk> cte_wp_at ((=) (cap.ThreadCap (idle_thread s))) sl s; valid_global_refs s \<rbrakk> \<Longrightarrow> False"
-  apply (cases sl)
-  apply (clarsimp simp: valid_global_refs_def valid_refs_def cte_wp_at_caps_of_state)
-  apply ((erule allE)+, erule (1) impE)
-  apply (clarsimp simp: cap_range_def)
-  done
-
-lemmas getCTE_no_0_obj'_helper
-  = getCTE_inv
-    hoare_strengthen_post[where Q'="\<lambda>_. no_0_obj'" and P=no_0_obj' and f="getCTE slot" for slot]
-
-context begin interpretation Arch . (*FIXME: arch-split*)
-context
-notes option.case_cong_weak[cong]
-begin
-crunch ThreadDecls_H.suspend, unbindNotification
-  for no_0_obj'[wp]: no_0_obj'
-  (simp: crunch_simps wp: crunch_wps getCTE_no_0_obj'_helper)
-end
-end
-
-lemma finaliseCap_corres:
-  "\<lbrakk> final_matters' cap' \<Longrightarrow> final = final'; cap_relation cap cap';
-          flag \<longrightarrow> can_fast_finalise cap \<rbrakk>
-     \<Longrightarrow> corres (\<lambda>x y. cap_relation (fst x) (fst y) \<and> cap_relation (snd x) (snd y))
-           (\<lambda>s. einvs s \<and> s \<turnstile> cap \<and> (final_matters cap \<longrightarrow> final = is_final_cap' cap s)
-                       \<and> cte_wp_at ((=) cap) sl s)
-           (\<lambda>s. invs' s \<and> s \<turnstile>' cap' \<and>
-                 (final_matters' cap' \<longrightarrow>
-                      final' = isFinal cap' (cte_map sl) (cteCaps_of s)))
-           (finalise_cap cap final) (finaliseCap cap' final' flag)"
-  supply invs_no_0_obj'[simp]
-  apply (cases cap, simp_all add: finaliseCap_def gen_isCap_simps
-                                  corres_liftM2_simp[unfolded liftM_def]
-                                  o_def dc_def[symmetric] when_def
-                                  can_fast_finalise_def
-                       split del: if_split cong: if_cong)
-        apply (clarsimp simp: final_matters'_def)
-        apply (rule corres_guard_imp)
-          apply (rule ep_cancel_corres)
-         apply (simp add: valid_cap_def)
-        apply (simp add: valid_cap'_def)
-       apply (clarsimp simp add: final_matters'_def)
-       apply (rule corres_guard_imp)
-         apply (rule corres_split[OF unbindMaybeNotification_corres])
-           apply (rule cancelAllSignals_corres)
-          apply (wp abs_typ_at_lifts unbind_maybe_notification_invs gen_typ_at_lifts hoare_drop_imps hoare_vcg_all_lift | wpc)+
-        apply (clarsimp simp: valid_cap_def)
-       apply (clarsimp simp: valid_cap'_def)
-      apply (fastforce simp: final_matters'_def shiftL_nat zbits_map_def)
-     apply (clarsimp simp add: final_matters'_def getThreadCSpaceRoot
-                               liftM_def[symmetric] o_def zbits_map_def
-                               dc_def[symmetric])
-     apply (rename_tac t)
-     apply (rule_tac P="\<lambda>s. t \<noteq> idle_thread s" and P'="\<lambda>s. t \<noteq> ksIdleThread s" in corres_add_guard)
-      apply clarsimp
-      apply (rule context_conjI)
-       apply (clarsimp dest!: no_idle_thread_cap)
-      apply (clarsimp simp: state_relation_def)
-     apply (rule corres_guard_imp)
-       apply (rule corres_split[OF unbindNotification_corres])
-         apply (rule corres_split[OF suspend_corres])
-            apply (clarsimp simp: liftM_def[symmetric] o_def dc_def[symmetric] zbits_map_def)
-          apply (rule RISCV64.prepareThreadDelete_corres, rule refl) (* FIXME arch-split: interface *)
-        apply (wp unbind_notification_invs unbind_notification_simple_sched_action)+
-      apply (simp add: valid_cap_def)
-     apply (simp add: valid_cap'_def)
-    apply (simp add: final_matters'_def liftM_def[symmetric]
-                     o_def dc_def[symmetric])
-    apply (intro impI, rule corres_guard_imp)
-      apply (rule deletingIRQHandler_corres)
-     apply simp
-    apply simp
-   apply (clarsimp simp: final_matters'_def)
-   apply (rule_tac F="False" in corres_req)
-    apply clarsimp
-    apply (frule zombies_finalD, (clarsimp simp: is_cap_simps)+)
-    apply (clarsimp simp: cte_wp_at_caps_of_state)
-   apply simp
-  apply (clarsimp split del: if_split simp: o_def)
-  apply (rule corres_guard_imp [OF arch_finaliseCap_corres], (fastforce simp: valid_sched_def)+)
-  done
-
-context begin interpretation Arch . (*FIXME: arch-split*)
-
-lemma threadSet_ct_idle_or_in_cur_domain':
-  "\<lbrace>ct_idle_or_in_cur_domain' and (\<lambda>s. \<forall>tcb. tcbDomain tcb = ksCurDomain s \<longrightarrow> tcbDomain (F tcb) = ksCurDomain s)\<rbrace>
-    threadSet F t
-   \<lbrace>\<lambda>_. ct_idle_or_in_cur_domain'\<rbrace>"
-  apply (simp add: ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def)
-  apply (wp hoare_vcg_disj_lift hoare_vcg_imp_lift)
-    apply wps
-    apply wp
-   apply wps
-   apply wp
-  apply (auto simp: obj_at'_def)
-  done
-
-lemma cte_wp_at_norm_eq':
-  "cte_wp_at' P p s = (\<exists>cte. cte_wp_at' ((=) cte) p s \<and> P cte)"
-  by (simp add: cte_wp_at_ctes_of)
-
-lemma isFinal_cte_wp_def:
-  "isFinal cap p (cteCaps_of s) =
-  (\<not>isUntypedCap cap \<and>
-   (\<forall>p'. p \<noteq> p' \<longrightarrow>
-         cte_at' p' s \<longrightarrow>
-         cte_wp_at' (\<lambda>cte'. \<not> isUntypedCap (cteCap cte') \<longrightarrow>
-                            \<not> sameObjectAs cap (cteCap cte')) p' s))"
-  apply (simp add: isFinal_def cte_wp_at_ctes_of cteCaps_of_def)
-  apply (rule iffI)
-   apply clarsimp
-   apply (case_tac cte)
-   apply fastforce
-  apply fastforce
-  done
-
-lemma valid_cte_at_neg_typ':
-  assumes T: "\<And>P T p. \<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace> f \<lbrace>\<lambda>_ s. P (typ_at' T p s)\<rbrace>"
-  shows "\<lbrace>\<lambda>s. \<not> cte_at' p' s\<rbrace> f \<lbrace>\<lambda>rv s. \<not> cte_at' p' s\<rbrace>"
-  apply (simp add: cte_at_typ')
-  apply (rule hoare_vcg_conj_lift [OF T])
-  apply (simp only: imp_conv_disj)
-  apply (rule hoare_vcg_all_lift)
-  apply (rule hoare_vcg_disj_lift [OF T])
-  apply (rule hoare_vcg_prop)
-  done
-
-lemma isFinal_lift:
-  assumes x: "\<And>P p. \<lbrace>cte_wp_at' P p\<rbrace> f \<lbrace>\<lambda>_. cte_wp_at' P p\<rbrace>"
-  assumes y: "\<And>P T p. \<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace> f \<lbrace>\<lambda>_ s. P (typ_at' T p s)\<rbrace>"
-  shows "\<lbrace>\<lambda>s. cte_wp_at' (\<lambda>cte. isFinal (cteCap cte) sl (cteCaps_of s)) sl s\<rbrace>
-         f
-         \<lbrace>\<lambda>r s. cte_wp_at' (\<lambda>cte. isFinal (cteCap cte) sl (cteCaps_of s)) sl s\<rbrace>"
-  apply (subst cte_wp_at_norm_eq')
-  apply (subst cte_wp_at_norm_eq' [where P="\<lambda>cte. isFinal (cteCap cte) sl m" for sl m])
-  apply (simp only: isFinal_cte_wp_def imp_conv_disj de_Morgan_conj)
-  apply (wp hoare_vcg_ex_lift hoare_vcg_all_lift x hoare_vcg_disj_lift
-            valid_cte_at_neg_typ' [OF y])
-  done
-
-lemmas final_matters'_simps = final_matters'_def [split_simps capability.split arch_capability.split]
-
-crunch deleteCallerCap
-  for idle_thread[wp]: "\<lambda>s. P (ksIdleThread s)"
-  (wp: crunch_wps)
-crunch deleteCallerCap
-  for sch_act_simple: sch_act_simple
-  (wp: crunch_wps)
-crunch deleteCallerCap
-  for sch_act_not[wp]: "sch_act_not t"
-  (wp: crunch_wps)
-crunch deleteCallerCap
-  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  (wp: crunch_wps)
-lemmas deleteCallerCap_typ_ats[wp] = typ_at_lifts [OF deleteCallerCap_typ_at']
-
-lemma setEndpoint_sch_act_not_ct[wp]:
-  "\<lbrace>\<lambda>s. sch_act_not (ksCurThread s) s\<rbrace>
-   setEndpoint ptr val \<lbrace>\<lambda>_ s. sch_act_not (ksCurThread s) s\<rbrace>"
-  by (rule hoare_weaken_pre, wps, wp, simp)
-
-lemma sbn_ct_in_state'[wp]:
-  "\<lbrace>ct_in_state' P\<rbrace> setBoundNotification ntfn t \<lbrace>\<lambda>_. ct_in_state' P\<rbrace>"
-  apply (simp add: ct_in_state'_def)
-  apply (rule hoare_pre)
-   apply (wps setBoundNotification_ct')
-  apply (wp sbn_st_tcb', clarsimp)
-  done
-
-lemma set_ntfn_ct_in_state'[wp]:
-  "\<lbrace>ct_in_state' P\<rbrace> setNotification a ntfn \<lbrace>\<lambda>_. ct_in_state' P\<rbrace>"
-  apply (simp add: ct_in_state'_def)
-  apply (rule hoare_pre)
-   apply (wps setNotification_ksCurThread, wp, clarsimp)
-  done
-
-lemma unbindMaybeNotification_ct_in_state'[wp]:
-  "\<lbrace>ct_in_state' P\<rbrace> unbindMaybeNotification t \<lbrace>\<lambda>_. ct_in_state' P\<rbrace>"
-  apply (simp add: unbindMaybeNotification_def)
-  apply (wp | wpc | simp)+
-  done
-
-lemma setNotification_sch_act_sane:
-  "\<lbrace>sch_act_sane\<rbrace> setNotification a ntfn \<lbrace>\<lambda>_. sch_act_sane\<rbrace>"
-  by (wp sch_act_sane_lift)
-
-
-lemma unbindMaybeNotification_sch_act_sane[wp]:
-  "\<lbrace>sch_act_sane\<rbrace> unbindMaybeNotification t \<lbrace>\<lambda>_. sch_act_sane\<rbrace>"
-  apply (simp add: unbindMaybeNotification_def)
-  apply (wp setNotification_sch_act_sane sbn_sch_act_sane | wpc | clarsimp)+
-  done
-
-end
+interpretation Finalise_R_3?: Finalise_R_3 arch_final_matters' arch_cap_has_cleanup'
+proof goal_cases
+  interpret Arch  .
+  case 1 show ?case by (intro_locales; (unfold_locales; (fact Finalise_R_3_assms)?)?)
+qed
 
 end

--- a/proof/refine/RISCV64/ArchFinalise_R.thy
+++ b/proof/refine/RISCV64/ArchFinalise_R.thy
@@ -1,22 +1,31 @@
 (*
- * Copyright 2014, General Dynamics C4 Systems
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
  *
  * SPDX-License-Identifier: GPL-2.0-only
  *)
 
-theory Finalise_R
+theory ArchFinalise_R
 imports
-  ArchIpcCancel_R
-  InterruptAcc_R
-  ArchRetype_R
+  Finalise_R
 begin
+
 context begin interpretation Arch . (*FIXME: arch-split*)
 
 declare doUnbindNotification_def[simp]
 
-lemma isArchSGISignalCap_NullCap[simp]:
-  "\<not>isArchSGISignalCap NullCap"
-  by (simp add: isCap_simps)
+crunch copyGlobalMappings
+  for ifunsafe'[wp]: "if_unsafe_then_cap'"
+  and pred_tcb_at'[wp]: "pred_tcb_at' proj P t"
+  and vms'[wp]: "valid_machine_state'"
+  and ct_not_inQ[wp]: "ct_not_inQ"
+  and tcb_in_cur_domain'[wp]: "tcb_in_cur_domain' t"
+  and ct__in_cur_domain'[wp]: ct_idle_or_in_cur_domain'
+  and gsUntypedZeroRanges[wp]: "\<lambda>s. P (gsUntypedZeroRanges s)"
+  and gsMaxObjectSize[wp]: "\<lambda>s. P (gsMaxObjectSize s)"
+  and it'[wp]: "\<lambda>s. P (ksIdleThread s)"
+  and valid_irq_states'[wp]: "valid_irq_states'"
+  and ksDomScheduleIdx[wp]: "\<lambda>s. P (ksDomScheduleIdx s)"
+  (wp: crunch_wps ignore: storePTE)
 
 text \<open>Properties about empty_slot/emptySlot\<close>
 
@@ -25,9 +34,11 @@ lemma case_Null_If:
   by (case_tac c, simp_all)
 
 crunch emptySlot
-  for aligned'[wp]: pspace_aligned' (simp: case_Null_If)
-crunch emptySlot
-  for distinct'[wp]: pspace_distinct' (simp: case_Null_If)
+  for aligned'[wp]: pspace_aligned'
+  and pspace_canonical'[wp]: pspace_canonical'
+  and pspace_in_kernel_mappings'[wp]: pspace_in_kernel_mappings'
+  and distinct'[wp]: pspace_distinct'
+  (simp: case_Null_If)
 
 lemma updateCap_cte_wp_at_cases:
   "\<lbrace>\<lambda>s. (ptr = ptr' \<longrightarrow> cte_wp_at' (P \<circ> cteCap_update (K cap)) ptr' s) \<and> (ptr \<noteq> ptr' \<longrightarrow> cte_wp_at' P ptr' s)\<rbrace>
@@ -68,10 +79,7 @@ lemma emptySlot_cte_wp_cap_other:
               | wp (once) hoare_drop_imps)+
   done
 
-crunch emptySlot
-  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-lemmas clearUntypedFreeIndex_typ_ats[wp]
-    = typ_at_lifts[OF clearUntypedFreeIndex_typ_at']
+lemmas clearUntypedFreeIndex_typ_ats[wp] = typ_at_lifts[OF clearUntypedFreeIndex_typ_at']
 
 crunch postCapDeletion
   for tcb_at'[wp]: "tcb_at' t"
@@ -131,20 +139,14 @@ crunch setInterruptState
 crunch emptySlot
   for state_refs_of'[wp]: "\<lambda>s. P (state_refs_of' s)"
   (wp: crunch_wps)
-crunch setInterruptState
-  for state_hyp_refs_of'[wp]: "\<lambda>s. P (state_hyp_refs_of' s)"
-  (simp: state_hyp_refs_of'_pspaceI)
-crunch emptySlot
-  for state_hyp_refs_of'[wp]: "\<lambda>s. P (state_hyp_refs_of' s)"
-  (wp: crunch_wps)
 
 lemma mdb_chunked2D:
   "\<lbrakk> mdb_chunked m; m \<turnstile> p \<leadsto> p'; m \<turnstile> p' \<leadsto> p'';
      m p = Some (CTE cap nd); m p'' = Some (CTE cap'' nd'');
-     sameRegionAs cap cap''; p \<noteq> p''; mdb_chunked_arch_assms cap \<rbrakk>
+     sameRegionAs cap cap''; p \<noteq> p'' \<rbrakk>
      \<Longrightarrow> \<exists>cap' nd'. m p' = Some (CTE cap' nd') \<and> sameRegionAs cap cap'"
   apply (subgoal_tac "\<exists>cap' nd'. m p' = Some (CTE cap' nd')")
-   apply (clarsimp simp add: mdb_chunked_def)
+   apply (clarsimp simp add: mdb_chunked_def mdb_chunked_arch_assms_def) (* FIXME arch-split; take AARCH64 version *)
    apply (drule spec[where x=p])
    apply (drule spec[where x=p''])
    apply clarsimp
@@ -159,7 +161,8 @@ lemma mdb_chunked2D:
   apply (case_tac z, simp)
   done
 
-lemma nullPointer_eq_0_simp[simp]: (* FIXME: move to nullPointer_0_simp in Retype_R *)
+lemma nullPointer_eq_0_simp[simp]:
+  "(nullPointer = 0) = True"
   "(0 = nullPointer) = True"
   by (simp add: nullPointer_def)+
 
@@ -482,7 +485,7 @@ lemma caps_contained_n:
 
 lemma chunked:
   "mdb_chunked m"
-  using valid ..
+  using valid by (simp add: valid_mdb_ctes_def)
 
 lemma valid_badges:
   "valid_badges m"
@@ -494,22 +497,8 @@ proof -
   from valid_badges
   show ?thesis
     supply if_cong[cong]
-    apply (simp add: valid_badges_def2)
+    apply (simp add: valid_badges_def2 valid_arch_badges_def) (* FIXME arch-split; take AARCH64 version *)
     apply clarsimp
-    apply (rule conjI)
-     prefer 2
-     apply (drule_tac p=p in n_cap)
-     apply (frule n_cap)
-     apply (drule n_badged)
-     apply (clarsimp simp: n_next_eq)
-     apply (case_tac "p=slot", simp)
-     apply clarsimp
-     apply (case_tac "p'=slot", simp add: isCap_simps)
-     apply clarsimp
-     apply (case_tac "p = mdbPrev s_node")
-      apply (clarsimp simp: valid_arch_badges_def)
-      apply blast
-     apply (fastforce simp: valid_arch_badges_def)
     apply (drule_tac p=p in n_cap)
     apply (frule n_cap)
     apply (drule n_badged)
@@ -517,22 +506,21 @@ proof -
     apply (case_tac "p=slot", simp)
     apply clarsimp
     apply (case_tac "p'=slot", simp)
-     apply clarsimp
+    apply clarsimp
     apply (case_tac "p = mdbPrev s_node")
      apply clarsimp
      apply (insert slot)[1]
-      (* using mdb_chunked to show cap in between is same as on either side *)
+     (* using mdb_chunked to show cap in between is same as on either side *)
      apply (subgoal_tac "capMasterCap s_cap = capMasterCap cap'")
       prefer 2
       apply (thin_tac "\<forall>p. P p" for P)
       apply (drule mdb_chunked2D[OF chunked])
-            apply (fastforce simp: mdb_next_unfold)
-           apply assumption+
-         apply (simp add: sameRegionAs_def3)
-         apply (intro disjI1)
-         apply (fastforce simp:isCap_simps capMasterCap_def arch_capBadge_def split:capability.splits)
-        apply clarsimp
-       apply (clarsimp simp: isCap_simps mdb_chunked_arch_assms_def)
+           apply (fastforce simp: mdb_next_unfold)
+          apply assumption+
+        apply (simp add: sameRegionAs_def3)
+        apply (intro disjI1)
+        apply (fastforce simp:isCap_simps capMasterCap_def arch_capBadge_def split:capability.splits)
+       apply clarsimp
       apply clarsimp
       apply (erule sameRegionAsE, auto simp: isCap_simps capMasterCap_def split:capability.splits)[1]
      (* instantiating known valid_badges on both sides to transitively
@@ -582,8 +570,9 @@ lemma n_parent_of:
   apply (frule_tac p=p' in n_cap)
   apply (frule_tac p=p' in n_badged)
   apply (drule_tac p=p' in n_revokable)
-  apply (clarsimp split: if_split_asm)
-  by (auto simp: isMDBParentOf_def isArchMDBParentOf_def2 isCap_simps split: if_split_asm)
+  apply (clarsimp split: if_split_asm;
+         clarsimp simp: isMDBParentOf_def isCap_simps split: if_split_asm cong: if_cong)
+  done
 
 lemma m_parent_of:
   "\<lbrakk> m \<turnstile> p parentOf p'; p \<noteq> slot; p' \<noteq> slot; p\<noteq>p'; p'\<noteq>mdbNext s_node \<rbrakk> \<Longrightarrow> n \<turnstile> p parentOf p'"
@@ -600,9 +589,7 @@ lemma m_parent_of:
   apply (drule_tac p=p' in m_revokable)
   apply clarsimp
   apply (simp split: if_split_asm;
-         clarsimp simp: isMDBParentOf_def isArchMDBParentOf_def2 isCap_simps
-                  split: if_split_asm
-                  cong: if_cong)
+         clarsimp simp: isMDBParentOf_def isCap_simps split: if_split_asm cong: if_cong)
   done
 
 lemma m_parent_of_next:
@@ -621,37 +608,13 @@ lemma m_parent_of_next:
   apply (frule_tac p="slot" in m_cap)
   apply (frule_tac p="slot" in m_badged)
   apply (drule_tac p="slot" in m_revokable)
-  by (auto simp: isMDBParentOf_def isArchMDBParentOf_def2 isCap_simps
-           split: if_split_asm cong: if_cong)
-
-lemma n_mdbNext:
-  "\<lbrakk> n (mdbNext s_node) = Some (CTE cap node); mdbPrev s_node \<noteq> 0 \<rbrakk> \<Longrightarrow>
-  \<exists>node'. m (mdbNext s_node) = Some (CTE cap node') \<and>
-          mdbNext node = mdbNext node' \<and>
-          mdbPrev node = mdbPrev s_node \<and>
-          mdbRevocable node = mdbRevocable node' \<and>
-          (mdbFirstBadged node = mdbFirstBadged node' \<or> mdbFirstBadged s_node)"
-  apply (clarsimp simp: n_def modify_map_def)
-  apply (case_tac z)
-  apply clarsimp
-  done
-
-lemma n_mdbPrev:
-  "\<lbrakk> n (mdbPrev s_node) = Some (CTE cap node); mdbNext s_node \<noteq> 0 \<rbrakk> \<Longrightarrow>
-    \<exists>node'. m (mdbPrev s_node) = Some (CTE cap node') \<and>
-          mdbNext node = mdbNext s_node \<and>
-          mdbPrev node = mdbPrev node' \<and>
-          mdbRevocable node = mdbRevocable node' \<and>
-          (mdbFirstBadged node = mdbFirstBadged node')"
-  apply (clarsimp simp: n_def modify_map_def)
-  apply (case_tac z)
-  apply clarsimp
+  apply (clarsimp simp: isMDBParentOf_def isCap_simps split: if_split_asm cong: if_cong)
   done
 
 lemma parency_n:
   assumes "n \<turnstile> p \<rightarrow> p'"
   shows "m \<turnstile> p \<rightarrow> p' \<and> p \<noteq> slot \<and> p' \<noteq> slot"
-  using assms
+using assms
 proof induct
   case (direct_parent c')
   moreover
@@ -670,65 +633,38 @@ proof induct
      apply (erule (2) n_parent_of)
     apply clarsimp
     apply (frule n_parent_of, simp, simp)
-    apply (prop_tac "\<exists>prev_cap prev_node. m (mdbPrev s_node) = Some (CTE prev_cap prev_node)")
-     apply (clarsimp simp: parentOf_def, case_tac cte'a, clarsimp)
-    apply clarsimp
-    apply (case_tac "isArchSGISignalCap prev_cap")
-     prefer 2
-     apply (rule subtree.trans_parent[OF _ m_slot_next], simp_all)
-     apply (rule subtree.direct_parent)
-       apply (erule prev_slot_next)
-      apply simp
-     apply (clarsimp simp: parentOf_def slot)
-     apply (case_tac cte, rename_tac next_cap next_node)
-     apply clarsimp
-     apply (frule(2) mdb_chunked2D [OF chunked prev_slot_next m_slot_next])
-        apply (clarsimp simp: isMDBParentOf_CTE)
-       apply simp
-      apply (simp add: mdb_chunked_arch_assms_def)
-     apply (simp add: slot)
-     apply (clarsimp simp add: isMDBParentOf_CTE)
-     apply (insert valid_badges)[1]
-     apply (simp add: valid_badges_def2)
-     apply (drule spec[where x=slot])
-     apply (drule spec[where x="mdbNext s_node"])
-     apply (simp add: slot m_slot_next)
-     apply (insert valid_badges)[1]
-     apply (simp add: valid_badges_def2)
-     apply (drule spec[where x="mdbPrev s_node"])
-     apply (drule spec[where x=slot])
-     apply (simp add: slot prev_slot_next)
-     apply (case_tac ctea, case_tac cte')
-     apply (rename_tac cap'' node'')
-     apply (clarsimp simp: isMDBParentOf_CTE)
-     apply (frule n_cap, drule n_badged)
-     apply (frule n_cap, drule n_badged)
-     apply clarsimp
-     apply (case_tac cap'', simp_all add: isCap_simps)[1]
-      apply (clarsimp simp: sameRegionAs_def3 isCap_simps)
-     apply (clarsimp simp: sameRegionAs_def3 isCap_simps)
-    (* SGISignalCap *)
-    apply (clarsimp simp: parentOf_def isCap_simps isMDBParentOf_CTE arch_capBadge_def)
-    apply (rename_tac next_node)
     apply (rule subtree.trans_parent[OF _ m_slot_next], simp_all)
-     apply (rule subtree.direct_parent)
-       apply (erule prev_slot_next)
-      apply simp
-     apply (clarsimp simp: parentOf_def slot isMDBParentOf_CTE)
-    apply (clarsimp simp: parentOf_def slot isMDBParentOf_CTE isCap_simps)
-    apply (cases "mdbFirstBadged s_node", simp)
-     apply (case_tac ctea, case_tac cte', clarsimp)
-     apply (frule n_cap, drule n_badged)
-     apply (frule n_cap, drule n_badged)
-     apply clarsimp
-     apply (rename_tac prev_node' next_node')
-     apply (clarsimp simp: isMDBParentOf_CTE isCap_simps)
-    apply simp
-    apply (insert valid_badges)[1]
-    apply (clarsimp simp: valid_badges_def)
-    apply (erule_tac x="slot" in allE)
-    apply (erule_tac x="mdbNext s_node" in allE)
-    apply (simp add: slot m_p_next isCap_simps valid_arch_badges_def)
+    apply (rule subtree.direct_parent)
+      apply (erule prev_slot_next)
+     apply simp
+    apply (clarsimp simp: parentOf_def slot)
+    apply (case_tac cte'a)
+    apply (case_tac ctea)
+    apply clarsimp
+    apply (frule(2) mdb_chunked2D [OF chunked prev_slot_next m_slot_next])
+      apply (clarsimp simp: isMDBParentOf_CTE)
+     apply simp
+    apply (simp add: slot)
+    apply (clarsimp simp add: isMDBParentOf_CTE)
+    apply (insert valid_badges)
+    apply (simp add: valid_badges_def2)
+    apply (drule spec[where x=slot])
+    apply (drule spec[where x="mdbNext s_node"])
+    apply (simp add: slot m_slot_next)
+    apply (insert valid_badges)
+    apply (simp add: valid_badges_def2)
+    apply (drule spec[where x="mdbPrev s_node"])
+    apply (drule spec[where x=slot])
+    apply (simp add: slot prev_slot_next)
+    apply (case_tac cte, case_tac cte')
+    apply (rename_tac cap'' node'')
+    apply (clarsimp simp: isMDBParentOf_CTE)
+    apply (frule n_cap, drule n_badged)
+    apply (frule n_cap, drule n_badged)
+    apply clarsimp
+    apply (case_tac cap'', simp_all add: isCap_simps arch_capBadge_def)[1]
+     apply (clarsimp simp: sameRegionAs_def3 isCap_simps)
+    apply (clarsimp simp: sameRegionAs_def3 isCap_simps)
     done
 next
   case (trans_parent c c')
@@ -758,67 +694,55 @@ next
        apply (rename_tac cap node)
        apply (case_tac ctea)
        apply clarsimp
-       apply (case_tac "\<not>isArchSGISignalCap cap")
-        apply (prop_tac "sameRegionAs cap s_cap")
-         apply (insert chunked)[1]
-         apply (simp add: mdb_chunked_def)
-         apply (erule_tac x="p" in allE)
-         apply (erule_tac x="mdbNext s_node" in allE)
-         apply simp
-         apply (drule isMDBParent_sameRegion)+
+       apply (subgoal_tac "sameRegionAs cap s_cap")
+        prefer 2
+        apply (insert chunked)[1]
+        apply (simp add: mdb_chunked_def)
+        apply (erule_tac x="p" in allE)
+        apply (erule_tac x="mdbNext s_node" in allE)
+        apply simp
+        apply (drule isMDBParent_sameRegion)+
+        apply clarsimp
+        apply (subgoal_tac "m \<turnstile> p \<leadsto>\<^sup>+ slot")
+         prefer 2
+         apply (rule trancl_trans)
+          apply (erule subtree_mdb_next)
+         apply (rule r_into_trancl)
+         apply (rule prev_slot_next)
          apply clarsimp
-         apply (prop_tac "m \<turnstile> p \<leadsto>\<^sup>+ slot")
-          apply (rule trancl_trans)
-           apply (erule subtree_mdb_next)
-          apply (rule r_into_trancl)
-          apply (rule prev_slot_next)
-          apply clarsimp
-         apply (prop_tac "m \<turnstile> p \<leadsto>\<^sup>+ mdbNext s_node")
-          apply (erule trancl_trans)
-          apply fastforce
-         apply (simp add: mdb_chunked_arch_assms_def)
-         apply (erule impE)
-          apply clarsimp
+        apply (subgoal_tac "m \<turnstile> p \<leadsto>\<^sup>+ mdbNext s_node")
+         prefer 2
+         apply (erule trancl_trans)
+         apply fastforce
+        apply (simp add: mdb_chunked_arch_assms_def)
+        apply (erule impE)
          apply clarsimp
-         apply (thin_tac "s \<longrightarrow> t" for s t)
-         apply (simp add: is_chunk_def)
-         apply (erule_tac x=slot in allE)
-         apply (erule impE, fastforce)
-         apply (erule impE, fastforce)
-         apply (clarsimp simp: slot)
-        apply (clarsimp simp: isMDBParentOf_CTE)
-        apply (insert valid_badges, simp add: valid_badges_def2)[1]
-        apply (drule spec[where x=slot], drule spec[where x="mdbNext s_node"])
-        apply (simp add: slot m_slot_next)
-        apply (case_tac cte, case_tac cte')
-        apply (rename_tac cap'' node'')
-        apply (clarsimp simp: isMDBParentOf_CTE)
-        apply (frule n_cap, drule n_badged)
-        apply (frule n_cap, drule n_badged)
-        apply (clarsimp split: if_split_asm)
-         apply (drule subtree_mdb_next)
-         apply (drule no_loops_tranclE[OF no_loops])
-         apply (erule notE, rule trancl_into_rtrancl)
-         apply (rule trancl.intros(2)[OF _ m_slot_next])
-         apply (rule trancl.intros(1), rule prev_slot_next)
-         apply simp
-        apply (case_tac cap'', simp_all add: isCap_simps)[1]
-         apply (clarsimp simp: sameRegionAs_def3 isCap_simps)
-        apply (clarsimp simp: sameRegionAs_def3 isCap_simps)
-       (* SGISignalCap *)
-       apply (rename_tac next_cap next_node)
-       apply (clarsimp simp: isCap_simps arch_capBadge_def)
+        apply clarsimp
+        apply (thin_tac "s \<longrightarrow> t" for s t)
+        apply (simp add: is_chunk_def)
+        apply (erule_tac x=slot in allE)
+        apply (erule impE, fastforce)
+        apply (erule impE, fastforce)
+        apply (clarsimp simp: slot)
+       apply (clarsimp simp: isMDBParentOf_CTE)
+       apply (insert valid_badges, simp add: valid_badges_def2)
+       apply (drule spec[where x=slot], drule spec[where x="mdbNext s_node"])
+       apply (simp add: slot m_slot_next)
        apply (case_tac cte, case_tac cte')
        apply (rename_tac cap'' node'')
        apply (clarsimp simp: isMDBParentOf_CTE)
        apply (frule n_cap, drule n_badged)
        apply (frule n_cap, drule n_badged)
-       apply (clarsimp simp: isCap_simps)
-       apply (insert valid_badges)[1]
-       apply (clarsimp simp: valid_badges_def)
-       apply (erule_tac x="slot" in allE)
-       apply (erule_tac x="mdbNext s_node" in allE)
-       apply (simp add: slot m_p_next isCap_simps valid_arch_badges_def)
+       apply (clarsimp split: if_split_asm)
+        apply (drule subtree_mdb_next)
+        apply (drule no_loops_tranclE[OF no_loops])
+        apply (erule notE, rule trancl_into_rtrancl)
+        apply (rule trancl.intros(2)[OF _ m_slot_next])
+        apply (rule trancl.intros(1), rule prev_slot_next)
+        apply simp
+       apply (case_tac cap'', simp_all add: isCap_simps arch_capBadge_def)[1]
+        apply (clarsimp simp: sameRegionAs_def3 isCap_simps)
+       apply (clarsimp simp: sameRegionAs_def3 isCap_simps)
       apply (rule m_slot_next)
      apply simp
     apply (erule n_parent_of, simp, simp)
@@ -1206,11 +1130,11 @@ lemma emptySlot_mdb [wp]:
 end
 
 lemma if_live_then_nonz_cap'_def2:
-  "if_live_then_nonz_cap' = (\<lambda>s. \<forall>ptr. ko_wp_at' live' ptr s
-                               \<longrightarrow> (\<exists>p zr. (option_map zobj_refs' o cteCaps_of s) p = Some zr \<and> ptr \<in> zr))"
-  by (fastforce intro!: ext
-                 simp: if_live_then_nonz_cap'_def ex_nonz_cap_to'_def
-                       cte_wp_at_ctes_of cteCaps_of_def)
+  "if_live_then_nonz_cap' =
+   (\<lambda>s. \<forall>ptr. ko_wp_at' live' ptr s \<longrightarrow>
+              (\<exists>p zr. (option_map zobj_refs' o cteCaps_of s) p = Some zr \<and> ptr \<in> zr))"
+  by (fastforce simp: if_live_then_nonz_cap'_def ex_nonz_cap_to'_def cte_wp_at_ctes_of
+                      cteCaps_of_def)
 
 lemma updateMDB_ko_wp_at_live[wp]:
   "\<lbrace>\<lambda>s. P (ko_wp_at' live' p' s)\<rbrace>
@@ -1229,7 +1153,7 @@ lemma updateCap_ko_wp_at_live[wp]:
   by wp
 
 primrec
-  threadCapRefs :: "capability \<Rightarrow> word32 set"
+  threadCapRefs :: "capability \<Rightarrow> machine_word set"
 where
   "threadCapRefs (ThreadCap r)                  = {r}"
 | "threadCapRefs (ReplyCap t m x)               = {}"
@@ -1268,7 +1192,7 @@ lemma not_Final_removeable:
     \<Longrightarrow> removeable' sl s cap"
   apply (erule not_FinalE)
    apply (clarsimp simp: removeable'_def gen_isCap_simps)
-  apply (clarsimp simp: cteCaps_of_def ARM_HYP.sameObjectAs_def2 removeable'_def
+  apply (clarsimp simp: cteCaps_of_def RISCV64.sameObjectAs_def2 removeable'_def
                         cte_wp_at_ctes_of) (* FIXME arch-split *)
   apply fastforce
   done
@@ -1303,8 +1227,7 @@ lemma emptySlot_iflive'[wp]:
              hoare_vcg_ex_lift
              | wp (once) hoare_vcg_imp_lift
              | simp add: cte_wp_at_ctes_of del: comp_apply)+
-  apply (clarsimp simp: modify_map_same
-    imp_conjR[symmetric])
+  apply (clarsimp simp: modify_map_same imp_conjR[symmetric])
   apply (drule spec, drule(1) mp)
   apply (clarsimp simp: cte_wp_at_ctes_of modify_map_def split: if_split_asm)
   apply (case_tac "p \<noteq> sl")
@@ -1318,9 +1241,6 @@ lemma emptySlot_iflive'[wp]:
   apply (drule(1) bspec)
   apply (clarsimp simp: ko_wp_at'_def)
   done
-
-crunch doMachineOp
-  for irq_node'[wp]: "\<lambda>s. P (irq_node' s)"
 
 lemma setIRQState_irq_node'[wp]:
   "\<lbrace>\<lambda>s. P (irq_node' s)\<rbrace> setIRQState state irq \<lbrace>\<lambda>_ s. P (irq_node' s)\<rbrace>"
@@ -1364,12 +1284,7 @@ lemma emptySlot_ifunsafe'[wp]:
   apply (clarsimp simp: cte_wp_at_ctes_of cteCaps_of_def)
   done
 
-lemma ctes_of_valid'[elim]:
-  "\<lbrakk>ctes_of s p = Some cte; valid_objs' s\<rbrakk> \<Longrightarrow> s \<turnstile>' cteCap cte"
-  by (cases cte, simp) (rule ctes_of_valid_cap')
-
-crunch postCapDeletion
-  for ksrq[wp]: "\<lambda>s. P (ksReadyQueues s)"
+lemmas ctes_of_valid'[elim] = ctes_of_valid_cap''[where r=cte for cte]
 
 crunch setInterruptState
   for valid_idle'[wp]: "valid_idle'"
@@ -1378,8 +1293,7 @@ crunch setInterruptState
 context begin interpretation Arch .
 crunch emptySlot
   for valid_idle'[wp]: "valid_idle'"
-
-crunch emptySlot
+crunch deletedIRQHandler, getSlotCap, clearUntypedFreeIndex, updateMDB, getCTE, updateCap
   for ksArch[wp]: "\<lambda>s. P (ksArchState s)"
 crunch emptySlot
   for ksIdle[wp]: "\<lambda>s. P (ksIdleThread s)"
@@ -1401,20 +1315,51 @@ lemma emptySlot_cteCaps_of:
               split: option.splits)
   done
 
+context begin interpretation Arch .
+
+crunch deletedIRQHandler
+  for cteCaps_of[wp]: "\<lambda>s. P (cteCaps_of s)"
+
+lemma deletedIRQHandler_valid_global_refs[wp]:
+  "\<lbrace>valid_global_refs'\<rbrace> deletedIRQHandler irq \<lbrace>\<lambda>rv. valid_global_refs'\<rbrace>"
+  apply (clarsimp simp: valid_global_refs'_def global_refs'_def)
+  apply (rule hoare_pre)
+   apply (rule hoare_use_eq_irq_node' [OF deletedIRQHandler_irq_node'])
+   apply (rule hoare_use_eq [where f=ksIdleThread, OF deletedIRQHandler_ksIdle])
+   apply (rule hoare_use_eq [where f=ksArchState, OF deletedIRQHandler_ksArch])
+   apply (rule hoare_use_eq[where f="gsMaxObjectSize"], wp)
+   apply (simp add: valid_refs'_cteCaps valid_cap_sizes_cteCaps)
+   apply (rule deletedIRQHandler_cteCaps_of)
+  apply (clarsimp simp: cte_wp_at_ctes_of)
+  apply (clarsimp simp: valid_refs'_cteCaps valid_cap_sizes_cteCaps ball_ran_eq)
+  done
+
+lemma clearUntypedFreeIndex_valid_global_refs[wp]:
+  "\<lbrace>valid_global_refs'\<rbrace> clearUntypedFreeIndex irq \<lbrace>\<lambda>rv. valid_global_refs'\<rbrace>"
+  apply (clarsimp simp: valid_global_refs'_def global_refs'_def)
+  apply (rule hoare_pre)
+   apply (rule hoare_use_eq_irq_node' [OF clearUntypedFreeIndex_irq_node'])
+   apply (rule hoare_use_eq [where f=ksIdleThread, OF clearUntypedFreeIndex_ksIdle])
+   apply (rule hoare_use_eq [where f=ksArchState, OF clearUntypedFreeIndex_ksArch])
+   apply (rule hoare_use_eq[where f="gsMaxObjectSize"], wp)
+   apply (simp add: valid_refs'_cteCaps valid_cap_sizes_cteCaps)
+   apply (rule clearUntypedFreeIndex_cteCaps_of)
+  apply (clarsimp simp: cte_wp_at_ctes_of)
+  apply (clarsimp simp: valid_refs'_cteCaps valid_cap_sizes_cteCaps ball_ran_eq)
+  done
+
+crunch global.postCapDeletion
+  for valid_global_refs[wp]: "valid_global_refs'"
+
 lemma emptySlot_valid_global_refs[wp]:
   "\<lbrace>valid_global_refs' and cte_at' sl\<rbrace> emptySlot sl opt \<lbrace>\<lambda>rv. valid_global_refs'\<rbrace>"
-  apply (simp add: valid_global_refs'_def ARM_HYP.global_refs'_def)
-  apply (rule hoare_pre)
-   apply (rule hoare_use_eq_irq_node' [OF emptySlot_irq_node'])
-   apply (rule hoare_use_eq [where f=ksArchState, OF emptySlot_ksArch])
-   apply (rule hoare_use_eq [where f=ksIdleThread, OF emptySlot_ksIdle])
-   apply (rule hoare_use_eq [where f=gsMaxObjectSize], wp)
-   apply (simp add: valid_refs'_cteCaps valid_cap_sizes_cteCaps)
-   apply (rule emptySlot_cteCaps_of)
-  apply (clarsimp simp: cte_wp_at_ctes_of)
+  apply (clarsimp simp: emptySlot_def)
+  apply (wpsimp wp: getCTE_wp hoare_drop_imps hoare_vcg_ex_lift simp: cte_wp_at_ctes_of)
+  apply (clarsimp simp: valid_global_refs'_def global_refs'_def)
   apply (frule(1) cte_at_valid_cap_sizes_0)
   apply (clarsimp simp: valid_refs'_cteCaps valid_cap_sizes_cteCaps ball_ran_eq)
   done
+end
 
 lemmas doMachineOp_irq_handlers[wp]
     = valid_irq_handlers_lift'' [OF doMachineOp_ctes doMachineOp_ksInterruptState]
@@ -1434,7 +1379,12 @@ lemma postCapDeletion_irq_handlers'[wp]:
   "\<lbrace>\<lambda>s. valid_irq_handlers' s \<and> (cap \<noteq> NullCap \<longrightarrow> cap \<notin> ran (cteCaps_of s))\<rbrace>
        postCapDeletion cap
    \<lbrace>\<lambda>rv. valid_irq_handlers'\<rbrace>"
-  by (wpsimp simp: Retype_H.postCapDeletion_def ARM_HYP_H.postCapDeletion_def)
+  by (wpsimp simp: Retype_H.postCapDeletion_def RISCV64_H.postCapDeletion_def)
+
+definition
+  "post_cap_delete_pre' cap sl cs \<equiv> case cap of
+     IRQHandlerCap irq \<Rightarrow> irq \<le> maxIRQ \<and> (\<forall>sl'. sl \<noteq> sl' \<longrightarrow> cs sl' \<noteq> Some cap)
+   | _ \<Rightarrow> False"
 
 end
 
@@ -1463,9 +1413,6 @@ crunch emptySlot
 crunch emptySlot
   for no_0_obj'[wp]: no_0_obj'
  (wp: crunch_wps)
-
-crunch emptySlot
-  for pde_mappings'[wp]: "valid_pde_mappings'"
 
 lemma deletedIRQHandler_irqs_masked'[wp]:
   "\<lbrace>irqs_masked'\<rbrace> deletedIRQHandler irq \<lbrace>\<lambda>_. irqs_masked'\<rbrace>"
@@ -1498,12 +1445,6 @@ crunch emptySlot
   for pspace_domain_valid[wp]: "pspace_domain_valid"
 
 crunch emptySlot
-  for nosch[wp]: "\<lambda>s. P (ksSchedulerAction s)"
-crunch emptySlot
-  for ct[wp]: "\<lambda>s. P (ksCurThread s)"
-crunch emptySlot
-  for ksCurDomain[wp]: "\<lambda>s. P (ksCurDomain s)"
-crunch emptySlot
   for ksDomSchedule[wp]: "\<lambda>s. P (ksDomSchedule s)"
 crunch emptySlot
   for ksDomScheduleIdx[wp]: "\<lambda>s. P (ksDomScheduleIdx s)"
@@ -1526,8 +1467,7 @@ crunch emptySlot
 
 lemma emptySlot_ct_idle_or_in_cur_domain'[wp]:
   "\<lbrace>ct_idle_or_in_cur_domain'\<rbrace> emptySlot sl opt \<lbrace>\<lambda>_. ct_idle_or_in_cur_domain'\<rbrace>"
-apply (wp ct_idle_or_in_cur_domain'_lift2 tcb_in_cur_domain'_lift | simp)+
-done
+  by (wp ct_idle_or_in_cur_domain'_lift2 tcb_in_cur_domain'_lift | simp)+
 
 crunch postCapDeletion
   for gsUntypedZeroRanges[wp]: "\<lambda>s. P (gsUntypedZeroRanges s)"
@@ -1560,28 +1500,37 @@ lemma emptySlot_untyped_ranges[wp]:
   apply (simp add: untypedZeroRange_def isCap_simps)
   done
 
-crunch emptySlot
+crunch deletedIRQHandler, updateMDB, updateCap, clearUntypedFreeIndex
   for valid_arch'[wp]: valid_arch_state'
-  (wp: crunch_wps)
+  (wp: valid_arch_state_lift')
+
+crunch global.postCapDeletion
+  for valid_arch'[wp]: valid_arch_state'
+
+lemma emptySlot_valid_arch'[wp]:
+  "\<lbrace>valid_arch_state' and cte_at' sl\<rbrace> emptySlot sl info \<lbrace>\<lambda>rv. valid_arch_state'\<rbrace>"
+  by (wpsimp simp: emptySlot_def cte_wp_at_ctes_of
+               wp: getCTE_wp hoare_drop_imps hoare_vcg_ex_lift)
 
 crunch emptySlot
   for valid_bitmaps[wp]: valid_bitmaps
   and tcbQueued_opt_pred[wp]: "\<lambda>s. P (tcbQueued |< tcbs_of' s)"
   and valid_sched_pointers[wp]: valid_sched_pointers
   and sched_projs[wp]: "\<lambda>s. P (tcbSchedNexts_of s) (tcbSchedPrevs_of s)"
-  and valid_arch_state'[wp]: valid_arch_state'
+  and ksDomScheduleIdx[wp]: "\<lambda>s. P (ksDomScheduleIdx s)"
   and ksDomScheduleStart[wp]: "\<lambda>s. P (ksDomScheduleStart s)"
   (wp: valid_bitmaps_lift)
 
 lemma emptySlot_invs'[wp]:
   "\<lbrace>\<lambda>s. invs' s \<and> cte_wp_at' (\<lambda>cte. removeable' sl s (cteCap cte)) sl s
-            \<and> (\<forall>sl'. info \<noteq> NullCap \<longrightarrow> sl' \<noteq> sl \<longrightarrow> cteCaps_of s sl' \<noteq> Some info)\<rbrace>
+            \<and> (info \<noteq> NullCap \<longrightarrow> post_cap_delete_pre' info sl (cteCaps_of s) )\<rbrace>
      emptySlot sl info
    \<lbrace>\<lambda>rv. invs'\<rbrace>"
   apply (simp add: invs'_def valid_state'_def valid_pspace'_def)
   apply (wp valid_irq_node_lift cur_tcb_lift valid_dom_schedule'_lift)
-  apply (clarsimp simp: cte_wp_at_ctes_of)
-  done
+  apply (clarsimp simp: cte_wp_at_ctes_of post_cap_delete_pre'_def cteCaps_of_def
+                 split: capability.split_asm arch_capability.split_asm)
+  by auto
 
 lemma deletedIRQHandler_corres:
   "corres dc \<top> \<top>
@@ -1593,8 +1542,8 @@ lemma deletedIRQHandler_corres:
   done
 
 lemma arch_postCapDeletion_corres:
-  "acap_relation cap cap' \<Longrightarrow> corres dc \<top> \<top> (arch_post_cap_deletion cap) (ARM_HYP_H.postCapDeletion cap')"
-  by (corresKsimp simp: arch_post_cap_deletion_def ARM_HYP_H.postCapDeletion_def)
+  "acap_relation cap cap' \<Longrightarrow> corres dc \<top> \<top> (arch_post_cap_deletion cap) (RISCV64_H.postCapDeletion cap')"
+  by (clarsimp simp: arch_post_cap_deletion_def RISCV64_H.postCapDeletion_def)
 
 lemma postCapDeletion_corres:
   "cap_relation cap cap' \<Longrightarrow> corres dc \<top> \<top> (post_cap_deletion cap) (postCapDeletion cap')"
@@ -1605,9 +1554,9 @@ lemma postCapDeletion_corres:
 lemma set_cap_trans_state:
   "((),s') \<in> fst (set_cap c p s) \<Longrightarrow> ((),trans_state f s') \<in> fst (set_cap c p (trans_state f s))"
   apply (cases p)
-  apply (clarsimp simp add: set_cap_def in_monad get_object_def)
+  apply (clarsimp simp add: set_cap_def in_monad set_object_def get_object_def)
   apply (case_tac y)
-      apply (auto simp: in_monad set_object_def get_object_def split: if_split_asm)
+      apply (auto simp add: in_monad set_object_def well_formed_cnode_n_def split: if_split_asm)
   done
 
 lemma clearUntypedFreeIndex_noop_corres:
@@ -1618,7 +1567,7 @@ lemma clearUntypedFreeIndex_noop_corres:
     apply (rule corres_bind_return2)
     apply (rule corres_symb_exec_r_conj[where P'="cte_at' (cte_map slot)"])
        apply (rule corres_trivial, simp)
-      apply (wp wp_post_taut getCTE_wp' | wpc
+      apply (wp getCTE_wp' | wpc
         | simp add: updateTrackedFreeIndex_def getSlotCap_def)+
      apply (clarsimp simp: state_relation_def)
     apply (rule no_fail_pre)
@@ -1646,7 +1595,7 @@ lemma emptySlot_corres:
        defer
        apply (wp get_cap_wp getCTE_wp')+
      apply (simp add: cte_wp_at_ctes_of)
-     apply (wp hoare_vcg_imp_lift clearUntypedFreeIndex_valid_pspace')
+     apply (wp hoare_vcg_imp_lift' clearUntypedFreeIndex_valid_pspace')
     apply fastforce
    apply (fastforce simp: cte_wp_at_ctes_of)
   apply simp
@@ -1896,10 +1845,9 @@ where
   | Zombie ptr zb n \<Rightarrow> True
   | IRQHandlerCap irq \<Rightarrow> True
   | ArchObjectCap acap \<Rightarrow> (case acap of
-    PageCap d ref rghts sz mapdata \<Rightarrow> False
-  | ASIDControlCap \<Rightarrow> False
-  | SGISignalCap _ _ \<Rightarrow> False
-  | _ \<Rightarrow> True)
+      FrameCap ref rghts sz d mapdata \<Rightarrow> False
+    | ASIDControlCap \<Rightarrow> False
+    | _ \<Rightarrow> True)
   | _ \<Rightarrow> False"
 
 lemma final_matters_Master:
@@ -1932,7 +1880,7 @@ lemma final_matters_sameRegion_sameObject2:
 
 lemma final_matters_mdb_chunked_arch_assms:
   "final_matters' cap \<Longrightarrow> mdb_chunked_arch_assms cap"
-  by (clarsimp simp: mdb_chunked_arch_assms_def isCap_simps final_matters'_def)
+  by (clarsimp simp: mdb_chunked_arch_assms_def)
 
 lemma notFinal_prev_or_next:
   "\<lbrakk> \<not> isFinal cap x (cteCaps_of s); mdb_chunked (ctes_of s);
@@ -2043,7 +1991,7 @@ lemma isFinal:
      apply clarsimp
     apply (case_tac cte')
     apply clarsimp
-   apply (fastforce simp add: sameObjectAs_def3 isCap_simps)
+   apply (clarsimp simp add: sameObjectAs_def3 isCap_simps)
   apply clarsimp
   apply (rule conjI)
    apply clarsimp
@@ -2078,8 +2026,8 @@ lemma (in vmdb) isFinal_no_subtree:
    apply (erule_tac x="mdbNext n" in allE)
    apply simp
    (* FIXME arch-split *)
-   apply (clarsimp simp: ARM_HYP.isMDBParentOf_CTE final_matters_sameRegion_sameObject)
-   apply (clarsimp simp: gen_isCap_simps ARM_HYP.sameObjectAs_def3) (* FIXME arch-split *)
+   apply (clarsimp simp: RISCV64.isMDBParentOf_CTE final_matters_sameRegion_sameObject)
+   apply (clarsimp simp: gen_isCap_simps RISCV64.sameObjectAs_def3) (* FIXME arch-split *)
   apply clarsimp
   done
 
@@ -2115,7 +2063,6 @@ lemma (in vmdb) isFinal_untypedParent:
   apply clarsimp
   apply (drule isMDBParent_sameRegion)
   apply simp
-  apply (frule final_matters_mdb_chunked_arch_assms)
   apply (rule classical, simp)
   apply (simp add: final_matters_sameRegion_sameObject2
                    sameObjectAs_sym)
@@ -2251,14 +2198,16 @@ lemma isFinalCapability_corres':
    apply (rule classical)
    apply (frule(1) zombies_finalD2[OF _ _ _ invs_zombies],
           simp?, clarsimp, assumption+)
-   subgoal by (clarsimp simp: sameObjectAs_def3 isCap_simps valid_cap_def
-                         obj_at_def is_obj_defs a_type_def final_matters'_def
-                  split: cap.split_asm arch_cap.split_asm
-                         option.split_asm if_split_asm,
-          simp_all add: is_cap_defs)
+   subgoal by (clarsimp simp: sameObjectAs_def3 isCap_simps valid_cap_def valid_arch_cap_def
+                              valid_arch_cap_ref_def obj_at_def is_obj_defs a_type_def
+                              final_matters'_def
+                        split: cap.split_asm arch_cap.split_asm option.split_asm if_split_asm,
+               simp_all add: is_cap_defs)
   apply (rule classical)
-  by (clarsimp simp: cap_irqs_def cap_irq_opt_def sameObjectAs_def3 isCap_simps arch_gen_obj_refs_def
-                 split: cap.split_asm)
+  apply (clarsimp simp: cap_irqs_def cap_irq_opt_def sameObjectAs_def3 isCap_simps
+                        acap_relation_def
+                 split: cap.split_asm arch_cap.split_asm)
+  done
 
 lemma isFinalCapability_corres:
   "corres (\<lambda>rv rv'. final_matters' (cteCap cte) \<longrightarrow> rv = rv')
@@ -2301,9 +2250,8 @@ lemmas cteDeleteOne_def
 
 crunch cteDeleteOne, suspend, prepareThreadDelete
   for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  (ignore_del: setObject
-         simp: crunch_simps unless_def o_def
-           wp: crunch_wps getObject_inv loadObject_default_inv)
+  (wp: crunch_wps getObject_inv loadObject_default_inv
+   simp: crunch_simps unless_def o_def)
 
 end
 
@@ -2312,16 +2260,11 @@ lemmas cancelAllSignals_typs[wp] = typ_at_lifts [OF cancelAllSignals_typ_at']
 lemmas suspend_typs[wp] = typ_at_lifts [OF suspend_typ_at']
 
 definition
-  arch_cap_has_cleanup' :: "arch_capability \<Rightarrow> bool"
-where
-  "arch_cap_has_cleanup' acap \<equiv> False"
-
-definition
   cap_has_cleanup' :: "capability \<Rightarrow> bool"
 where
   "cap_has_cleanup' cap \<equiv> case cap of
      IRQHandlerCap _ \<Rightarrow> True
-   | ArchObjectCap acap \<Rightarrow> arch_cap_has_cleanup' acap
+   | ArchObjectCap acap \<Rightarrow> False
    | _ \<Rightarrow> False"
 
 lemmas cap_has_cleanup'_simps[simp] = cap_has_cleanup'_def[split_simps capability.split]
@@ -2334,7 +2277,7 @@ lemma finaliseCap_cases[wp]:
        isZombie (fst rv) \<and> final \<and> \<not> flag \<and> snd rv = NullCap
         \<and> capUntypedPtr (fst rv) = capUntypedPtr cap
         \<and> (isThreadCap cap \<or> isCNodeCap cap \<or> isZombie cap)\<rbrace>"
-  apply (simp add: finaliseCap_def ARM_HYP_H.finaliseCap_def Let_def
+  apply (simp add: finaliseCap_def RISCV64_H.finaliseCap_def Let_def
                    getThreadCSpaceRoot
              cong: if_cong split del: if_split)
   apply (rule hoare_pre)
@@ -2363,16 +2306,14 @@ crunch finaliseCap
      wp: getObject_inv loadObject_default_inv crunch_wps)
 lemmas finaliseCap_typ_ats[wp] = typ_at_lifts[OF finaliseCap_typ_at']
 
+lemma unmapPageTable_it'[wp]:
+  "unmapPageTable asid vaddr pt \<lbrace>\<lambda>s. P (ksIdleThread s)\<rbrace>"
+  unfolding unmapPageTable_def by wpsimp
+
 crunch finaliseCap
   for it'[wp]: "\<lambda>s. P (ksIdleThread s)"
-  (wp: mapM_x_wp_inv mapM_wp' hoare_drop_imps getObject_inv loadObject_default_inv
-   simp: crunch_simps updateObject_default_def o_def)
-
-crunch flush_space
-  for vs_lookup[wp]: "\<lambda>s. P (vs_lookup s)"
-  (wp: crunch_wps)
-
-declare doUnbindNotification_def[simp]
+  (simp: crunch_simps assertE_def o_def
+     wp: crunch_wps)
 
 lemma ntfn_q_refs_of'_mult:
   "ntfn_q_refs_of' ntfn = (case ntfn of Structures_H.WaitingNtfn q \<Rightarrow> set q | _ \<Rightarrow> {}) \<times> {NTFNSignal}"
@@ -2404,7 +2345,6 @@ lemma unbindNotification_invs[wp]:
             untyped_ranges_zero_lift | clarsimp simp: cteCaps_of_def o_def)+
   apply (rule conjI)
    apply (clarsimp elim!: obj_atE'
-                    simp: projectKOs
                    dest!: pred_tcb_at')
   apply (clarsimp simp: pred_tcb_at' conj_comms)
   apply (frule bound_tcb_ex_cap'', clarsimp+)
@@ -2416,10 +2356,10 @@ lemma unbindNotification_invs[wp]:
     apply (auto split: if_split_asm)[1]
    apply (auto simp: tcb_st_not_Bound ntfn_q_refs_of'_mult split: if_split_asm)[1]
   apply (frule obj_at_valid_objs', clarsimp+)
-  apply (simp add: valid_ntfn'_def valid_obj'_def projectKOs live'_def
+  apply (simp add: valid_ntfn'_def valid_obj'_def live'_def
             split: ntfn.splits)
   apply (erule if_live_then_nonz_capE')
-  apply (clarsimp simp: obj_at'_def ko_wp_at'_def projectKOs live'_def)
+  apply (clarsimp simp: obj_at'_def ko_wp_at'_def live'_def)
   done
 
 lemma ntfn_bound_tcb_at':
@@ -2427,12 +2367,11 @@ lemma ntfn_bound_tcb_at':
     ntfnBoundTCB ntfn = Some tcbptr; P (Some ntfnptr)\<rbrakk>
   \<Longrightarrow> bound_tcb_at' P tcbptr s"
   apply (drule_tac x=ntfnptr in sym_refsD[rotated])
-   apply (clarsimp simp: obj_at'_def projectKOs)
+   apply (clarsimp simp: obj_at'_def)
    apply (fastforce simp: state_refs_of'_def)
   apply (auto simp: pred_tcb_at'_def obj_at'_def valid_obj'_def valid_ntfn'_def
-                    state_refs_of'_def refs_of_rev' projectKOs
+                    state_refs_of'_def refs_of_rev'
           simp del: refs_of_simps
-             elim!: valid_objsE
              split: option.splits if_split_asm)
   done
 
@@ -2450,9 +2389,10 @@ lemma unbindMaybeNotification_invs[wp]:
            defer 3
            defer 7
            apply (fold_subgoals (prefix))[8]
-           subgoal premises prems using prems by (auto simp: pred_tcb_at' valid_pspace'_def projectKOs valid_obj'_def valid_ntfn'_def
+           subgoal premises prems using prems
+              by (auto simp: pred_tcb_at' valid_pspace'_def valid_obj'_def valid_ntfn'_def
                              ko_wp_at'_def live'_def
-                      elim!: obj_atE' valid_objsE' if_live_then_nonz_capE'
+                      elim!: obj_atE' if_live_then_nonz_capE'
                       split: option.splits ntfn.splits)
    apply (rule delta_sym_refs, assumption)
     apply (fold_subgoals (prefix))[2]
@@ -2479,50 +2419,16 @@ lemma finaliseCap_True_invs[wp]:
     apply (wp irqs_masked_lift| simp | wpc)+
   done
 
-crunch flushSpace
-  for invs'[wp]: "invs'"
-  (ignore: doMachineOp)
-
 lemma invs_asid_update_strg':
-  "invs' s \<and> tab = armKSASIDTable (ksArchState s) \<longrightarrow>
-   invs' (s\<lparr>ksArchState := armKSASIDTable_update
+  "invs' s \<and> tab = riscvKSASIDTable (ksArchState s) \<longrightarrow>
+   invs' (s\<lparr>ksArchState := riscvKSASIDTable_update
             (\<lambda>_. tab (asid := None)) (ksArchState s)\<rparr>)"
   apply (simp add: invs'_def)
   apply (simp add: valid_state'_def)
-  apply (simp add: valid_global_refs'_def global_refs'_def valid_arch_state'_def valid_asid_table'_def
-                   valid_machine_state'_def ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def
-             cong: option.case_cong)
-  by (auto simp add: ran_def split: if_split_asm)
-
-lemma invalidateASIDEntry_invs' [wp]:
-  "\<lbrace>invs'\<rbrace> invalidateASIDEntry asid \<lbrace>\<lambda>r. invs'\<rbrace>"
-  apply (simp add: invalidateASIDEntry_def invalidateASID_def
-                   invalidateHWASIDEntry_def bind_assoc)
-  apply (wp loadHWASID_wp | simp)+
-  apply (clarsimp simp: fun_upd_def[symmetric])
-  apply (rule conjI)
-   apply (clarsimp simp: invs'_def valid_state'_def)
-   apply (rule conjI)
-    apply (simp add: valid_global_refs'_def
-                     global_refs'_def)
-   apply (simp add: valid_arch_state'_def ran_def
-                    valid_asid_table'_def is_inv_None_upd
-                    valid_machine_state'_def
-                    comp_upd_simp fun_upd_def[symmetric]
-                    inj_on_fun_upd_elsewhere
-                    valid_asid_map'_def
-                    ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def
-             cong: option.case_cong)
-   subgoal by (auto elim!: subset_inj_on)
-  apply (clarsimp simp: invs'_def valid_state'_def)
-  apply (rule conjI)
-   apply (simp add: valid_global_refs'_def global_refs'_def)
-  apply (rule conjI)
-   apply (simp add: valid_arch_state'_def ran_def
-                    valid_asid_table'_def None_upd_eq
-                    fun_upd_def[symmetric] comp_upd_simp
-              cong: option.case_cong)
-  apply (simp add: valid_machine_state'_def ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def)
+  apply (simp add: valid_global_refs'_def global_refs'_def valid_arch_state'_def
+                   valid_asid_table'_def valid_machine_state'_def ct_idle_or_in_cur_domain'_def
+                   tcb_in_cur_domain'_def)
+  apply (auto simp add: ran_def split: if_split_asm)
   done
 
 lemma deleteASIDPool_invs[wp]:
@@ -2535,424 +2441,47 @@ lemma deleteASIDPool_invs[wp]:
               | simp)+
   done
 
-lemmas flushSpace_typ_ats' [wp] = typ_at_lifts [OF flushSpace_typ_at']
+crunch hwASIDFlush
+  for irq_masks[wp]: "\<lambda>s. P (irq_masks s)"
+
+lemma dmo_hwASIDFlush_invs[wp]:
+  "doMachineOp (hwASIDFlush asid) \<lbrace>invs'\<rbrace>"
+  apply (wp dmo_invs')
+  apply (clarsimp simp: hwASIDFlush_def machine_op_lift_def machine_rest_lift_def in_monad select_f_def)
+  done
 
 lemma deleteASID_invs'[wp]:
-  "\<lbrace>invs'\<rbrace> deleteASID asid pd \<lbrace>\<lambda>rv. invs'\<rbrace>"
-  apply (simp add: deleteASID_def cong: option.case_cong)
-  apply (rule hoare_pre)
-   apply (wp | wpc)+
-    apply (rule_tac Q'="\<lambda>rv. valid_obj' (injectKO rv) and invs'"
-              in hoare_post_imp)
-     apply (rename_tac rv s)
-     apply (clarsimp split: if_split_asm del: subsetI)
-     apply (simp add: fun_upd_def[symmetric] valid_obj'_def)
-     apply (case_tac rv, simp)
-     apply (subst inv_f_f, rule inj_onI, simp)+
-     apply (rule conjI)
-      apply clarsimp
-      apply (drule subsetD, blast)
-      apply clarsimp
-     apply (auto dest!: ran_del_subset)[1]
-    apply (wp getObject_valid_obj getObject_inv loadObject_default_inv
-             | simp add: objBits_simps archObjSize_def pageBits_def)+
-  apply clarsimp
-  done
-
-(* FIMXME: move up *)
-lemmas archThreadSet_typ_ats[wp] = typ_at_lifts [OF archThreadSet_typ_at']
-
-lemma archThreadSet_valid_objs'[wp]:
-  "\<lbrace>valid_objs' and (\<lambda>s. \<forall>tcb. ko_at' tcb t s \<longrightarrow> valid_arch_tcb' (f (tcbArch tcb)) s)\<rbrace>
-   archThreadSet f t \<lbrace>\<lambda>_. valid_objs'\<rbrace>"
-  unfolding archThreadSet_def
-  apply (wp setObject_tcb_valid_objs getObject_tcb_wp)
-  apply clarsimp
-  apply normalise_obj_at'
-  apply (drule (1) tcb_ko_at_valid_objs_valid_tcb')
-  apply (clarsimp simp: valid_obj'_def valid_tcb'_def tcb_cte_cases_def tcb_cte_cases_neqs)
-  done
-
-crunch archThreadSet
-  for no_0_obj'[wp]: no_0_obj'
-
-lemma archThreadSet_ctes_of[wp]:
-  "archThreadSet f t \<lbrace>\<lambda>s. P (ctes_of s)\<rbrace>"
-  unfolding archThreadSet_def
-  apply (wpsimp wp: getObject_tcb_wp)
-  apply normalise_obj_at'
-  apply (auto simp: tcb_cte_cases_def tcb_cte_cases_neqs)
-  done
-
-crunch archThreadSet
-  for ksCurDomain[wp]: "\<lambda>s. P (ksCurDomain s)"
-  (wp: setObject_cd_inv)
-
-lemma archThreadSet_obj_at':
-  "(\<And>tcb. P tcb \<Longrightarrow> P (tcb \<lparr> tcbArch:= f (tcbArch tcb)\<rparr>)) \<Longrightarrow> archThreadSet f t \<lbrace>obj_at' P t'\<rbrace>"
-  unfolding archThreadSet_def
-  apply (wpsimp wp: getObject_tcb_wp setObject_tcb_strongest)
-  apply normalise_obj_at'
-  apply auto
-  done
-
-lemma archThreadSet_tcbDomain[wp]:
-  "archThreadSet f t \<lbrace>obj_at' (\<lambda>tcb. x = tcbDomain tcb) t'\<rbrace>"
-  by (wpsimp wp: archThreadSet_obj_at')
-
-lemma archThreadSet_inQ[wp]:
-  "archThreadSet f t' \<lbrace>\<lambda>s. P (obj_at' (inQ d p) t s)\<rbrace>"
-  unfolding obj_at'_real_def archThreadSet_def
-  apply (wpsimp wp: setObject_ko_wp_at getObject_tcb_wp
-              simp: objBits_simps' archObjSize_def vcpu_bits_def pageBits_def
-         | simp)+
-  apply (auto simp: obj_at'_def ko_wp_at'_def projectKOs)
-  done
-
-crunch archThreadSet
-  for ct[wp]: "\<lambda>s. P (ksCurThread s)"
-  (wp: setObject_ct_inv)
-
-crunch archThreadSet
-  for sched[wp]: "\<lambda>s. P (ksSchedulerAction s)"
-  (wp: setObject_sa_inv)
-
-crunch archThreadSet
-  for L1[wp]: "\<lambda>s. P (ksReadyQueuesL1Bitmap s)"
-  (wp: setObject_sa_inv)
-
-crunch archThreadSet
-  for L2[wp]: "\<lambda>s. P (ksReadyQueuesL2Bitmap s)"
-  (wp: setObject_sa_inv)
-
-crunch archThreadSet
-  for ksArch[wp]: "\<lambda>s. P (ksArchState s)"
-
-crunch archThreadSet
-  for ksDomSchedule[wp]: "\<lambda>s. P (ksDomSchedule s)"
-  (wp: setObject_ksDomSchedule_inv)
-
-crunch archThreadSet
-  for ksDomScheduleIdx[wp]: "\<lambda>s. P (ksDomScheduleIdx s)"
-  and ksDomScheduleStart[wp]: "\<lambda>s. P (ksDomScheduleStart s)"
-  (simp: setObject_def wp: updateObject_default_inv)
-
-lemma setObject_tcb_ksInterruptState[wp]:
-  "setObject t (v :: tcb) \<lbrace>\<lambda>s. P (ksInterruptState s)\<rbrace>"
-  by (wpsimp simp: setObject_def wp: updateObject_default_inv)
-
-lemma setObject_tcb_gsMaxObjectSize[wp]:
-  "setObject t (v :: tcb) \<lbrace>\<lambda>s. P (gsMaxObjectSize s)\<rbrace>"
-  by (wpsimp simp: setObject_def wp: updateObject_default_inv)
-
-crunch archThreadSet
-  for ksInterruptState[wp]: "\<lambda>s. P (ksInterruptState s)"
-
-crunch archThreadSet
-  for gsMaxObjectSize[wp]: "\<lambda>s. P (gsMaxObjectSize s)"
-
-crunch archThreadSet
-  for ksMachineState[wp]: "\<lambda>s. P (ksMachineState s)"
-  (wp: setObject_ksMachine updateObject_default_inv)
-
-lemma archThreadSet_state_refs_of'[wp]:
-  "archThreadSet f t \<lbrace>\<lambda>s. P (state_refs_of' s)\<rbrace>"
-  unfolding archThreadSet_def
-  apply (wpsimp wp: setObject_tcb_state_refs_of' getObject_tcb_wp)
-  apply normalise_obj_at'
-  apply (erule rsubst[where P=P])
-  apply (rule ext)
-  apply (auto simp: state_refs_of'_def obj_at'_def projectKOs)
-  done
-
-lemma archThreadSet_state_hyp_refs_of'[wp]:
-  "\<lbrace>\<lambda>s. \<forall>tcb. ko_at' tcb t s \<longrightarrow> P ((state_hyp_refs_of' s)(t := tcb_hyp_refs' (f (tcbArch tcb))))\<rbrace>
-  archThreadSet f t \<lbrace>\<lambda>_ s. P (state_hyp_refs_of' s)\<rbrace>"
-  unfolding archThreadSet_def
-  apply (wpsimp wp: setObject_state_hyp_refs_of' getObject_tcb_wp simp: objBits_simps')
-  apply normalise_obj_at'
-  apply (erule rsubst[where P=P])
-  apply auto
-  done
-
-crunch archThreadSet
-  for ko_at'_pde[wp]: "\<lambda>s. P (ko_at' (pde::pde) p' s)"
-  and valid_pde_mappings'[wp]: valid_pde_mappings'
-
-lemma archThreadSet_if_live'[wp]:
-  "\<lbrace>\<lambda>s. if_live_then_nonz_cap' s \<and>
-        (\<forall>tcb. ko_at' tcb t s \<longrightarrow> atcbVCPUPtr (f (tcbArch tcb)) \<noteq> None \<longrightarrow> ex_nonz_cap_to' t s)\<rbrace>
-  archThreadSet f t \<lbrace>\<lambda>_. if_live_then_nonz_cap'\<rbrace>"
-  unfolding archThreadSet_def
-  apply (wpsimp wp: setObject_tcb_iflive' getObject_tcb_wp)
-  apply normalise_obj_at'
-  apply (clarsimp simp: tcb_cte_cases_def tcb_cte_cases_neqs if_live_then_nonz_cap'_def)
-  apply (erule_tac x=t in allE)
-  apply (erule impE)
-   apply (clarsimp simp: obj_at'_real_def ko_wp_at'_def projectKOs live'_def hyp_live'_def)
-  apply simp
-  done
-
-lemma archThreadSet_ifunsafe'[wp]:
-  "archThreadSet f t \<lbrace>if_unsafe_then_cap'\<rbrace>"
-  unfolding archThreadSet_def
-  apply (wpsimp wp: setObject_tcb_ifunsafe' getObject_tcb_wp)
-  apply normalise_obj_at'
-  apply (auto simp: tcb_cte_cases_def tcb_cte_cases_neqs if_live_then_nonz_cap'_def)
-  done
-
-lemma archThreadSet_valid_idle'[wp]:
-  "archThreadSet f t \<lbrace>valid_idle'\<rbrace>"
-  unfolding archThreadSet_def
-  apply (wpsimp wp: setObject_tcb_idle' getObject_tcb_wp)
-  apply (clarsimp simp: valid_idle'_def pred_tcb_at'_def obj_at'_def idle_tcb'_def)
-  done
-
-lemma archThreadSet_ko_wp_at_no_vcpu[wp]:
-  "archThreadSet f t \<lbrace>ko_wp_at' (is_vcpu' and hyp_live') p\<rbrace>"
-  unfolding archThreadSet_def
-  apply (wpsimp wp: getObject_tcb_wp setObject_ko_wp_at simp: objBits_simps' | rule refl)+
-  apply normalise_obj_at'
-  apply (auto simp: ko_wp_at'_def obj_at'_real_def projectKOs is_vcpu'_def)
-  done
-
-lemma archThreadSet_valid_arch_state'[wp]:
-  "archThreadSet f t \<lbrace>valid_arch_state'\<rbrace>"
-  unfolding valid_arch_state'_def valid_asid_table'_def option_case_all_conv split_def
-  apply (rule hoare_lift_Pf[where f=ksArchState]; wpsimp wp: hoare_vcg_all_lift hoare_vcg_imp_lift)
-  apply (clarsimp simp: pred_conj_def)
-  done
-
-lemma archThreadSet_ct_not_inQ[wp]:
-  "archThreadSet f t \<lbrace>ct_not_inQ\<rbrace>"
-  unfolding ct_not_inQ_def
-  apply (rule hoare_lift_Pf[where f=ksCurThread]; wp?)
-  apply (wpsimp wp: hoare_vcg_imp_lift simp: o_def)
-  done
-
-lemma archThreadSet_obj_at'_pde[wp]:
-  "archThreadSet f t \<lbrace>obj_at' (P::pde \<Rightarrow> bool) p\<rbrace>"
-  unfolding archThreadSet_def
-  by (wpsimp wp: obj_at_setObject2 simp: updateObject_default_def in_monad)
-
-crunch archThreadSet
-  for pspace_domain_valid[wp]: pspace_domain_valid
-
-lemma setObject_tcb_gsUntypedZeroRanges[wp]:
-  "setObject ptr (tcb::tcb) \<lbrace>\<lambda>s. P (gsUntypedZeroRanges s)\<rbrace>"
-  by (wpsimp wp: updateObject_default_inv simp: setObject_def)
-
-crunch archThreadSet
-  for gsUntypedZeroRanges[wp]: "\<lambda>s. P (gsUntypedZeroRanges s)"
-
-lemma archThreadSet_untyped_ranges_zero'[wp]:
-  "archThreadSet f t \<lbrace>untyped_ranges_zero'\<rbrace>"
-  by (rule hoare_lift_Pf[where f=cteCaps_of]; wp cteCaps_of_ctes_of_lift)
-
-lemma archThreadSet_tcb_at'[wp]:
-  "\<lbrace>\<top>\<rbrace> archThreadSet f t \<lbrace>\<lambda>_. tcb_at' t\<rbrace>"
-  unfolding archThreadSet_def
-  by (wpsimp wp: getObject_tcb_wp simp: obj_at'_def)
-
-lemma setObject_tcb_tcbs_of'[wp]:
-  "\<lbrace>\<lambda>s. P ((tcbs_of' s) (t \<mapsto> tcb))\<rbrace>
-   setObject t tcb
-   \<lbrace>\<lambda>_ s. P (tcbs_of' s)\<rbrace>"
-  unfolding setObject_def
-  apply (wpsimp simp: updateObject_default_def)
-  apply (erule rsubst[where P=P])
-  apply (rule ext)
-  apply (clarsimp simp: opt_map_def split: option.splits)
-  done
-
-lemma archThreadSet_tcbSchedPrevs_of[wp]:
-  "archThreadSet f t \<lbrace>\<lambda>s. P (tcbSchedPrevs_of s)\<rbrace>"
-  supply projectKOs[simp]
-  unfolding archThreadSet_def
-  apply (wp getObject_tcb_wp)
-  apply normalise_obj_at'
-  apply (erule rsubst[where P=P])
-  apply (rule ext)
-  apply (clarsimp simp: opt_map_def obj_at'_def split: option.splits)
-  done
-
-lemma archThreadSet_tcbSchedNexts_of[wp]:
-  "archThreadSet f t \<lbrace>\<lambda>s. P (tcbSchedNexts_of s)\<rbrace>"
-  supply projectKOs[simp]
-  unfolding archThreadSet_def
-  apply (wp getObject_tcb_wp)
-  apply normalise_obj_at'
-  apply (erule rsubst[where P=P])
-  apply (rule ext)
-  apply (clarsimp simp: opt_map_def obj_at'_def split: option.splits)
-  done
-
-lemma archThreadSet_tcbQueued[wp]:
-  "archThreadSet f t \<lbrace>\<lambda>s. P (tcbQueued |< tcbs_of' s)\<rbrace>"
-  supply projectKOs[simp]
-  unfolding archThreadSet_def
-  apply (wp getObject_tcb_wp)
-  apply normalise_obj_at'
-  apply (erule rsubst[where P=P])
-  apply (rule ext)
-  apply (clarsimp simp: opt_pred_def opt_map_def obj_at'_def split: option.splits)
-  done
-
-lemma archThreadSet_valid_sched_pointers[wp]:
-  "archThreadSet f t \<lbrace>valid_sched_pointers\<rbrace>"
-  by (wp_pre, wps, wp, assumption)
-
-lemma dissoc_invs':
-  "\<lbrace>invs' and (\<lambda>s. \<forall>p. (\<exists>a. armHSCurVCPU (ksArchState s) = Some (p, a)) \<longrightarrow> p \<noteq> v) and
-    ko_at' vcpu v and K (vcpuTCBPtr vcpu = Some t) and
-    obj_at' (\<lambda>tcb. atcbVCPUPtr (tcbArch tcb) = Some v) t\<rbrace>
-   do
-    archThreadSet (atcbVCPUPtr_update (\<lambda>_. Nothing)) t;
-    setObject v $ vcpuTCBPtr_update (\<lambda>_. Nothing) vcpu
-   od \<lbrace>\<lambda>_. invs' and tcb_at' t\<rbrace>"
-  unfolding invs'_def valid_state'_def valid_pspace'_def valid_mdb'_def
-            valid_machine_state'_def pointerInUserData_def pointerInDeviceData_def
-  supply fun_upd_apply[simp del]
-  apply (wpsimp wp: sch_act_wf_lift tcb_in_cur_domain'_lift valid_queues_lift
-                    setObject_tcb_valid_objs setObject_vcpu_valid_objs'
-                    setObject_state_refs_of' setObject_state_hyp_refs_of' valid_global_refs_lift'
-                    valid_irq_node_lift_asm [where Q=\<top>] valid_irq_handlers_lift'
-                    cteCaps_of_ctes_of_lift irqs_masked_lift ct_idle_or_in_cur_domain'_lift
-                    valid_irq_states_lift' hoare_vcg_all_lift hoare_vcg_disj_lift
-                    valid_pde_mappings_lift' setObject_typ_at' cur_tcb_lift
-                    setVCPU_valid_arch' archThreadSet_if_live' valid_bitmaps_lift
-                    sym_heap_sched_pointers_lift valid_dom_schedule'_lift
-              simp: objBits_simps archObjSize_def vcpu_bits_def pageBits_def
-                    state_refs_of'_vcpu_empty state_hyp_refs_of'_vcpu_absorb valid_arch_tcb'_def
-        | clarsimp simp: live'_def hyp_live'_def arch_live'_def)+
-  apply (drule (1) valid_objs_valid_vcpu')
-  apply (clarsimp simp: valid_vcpu'_def)
-  supply fun_upd_apply[simp]
-  apply (clarsimp simp: state_hyp_refs_of'_def obj_at'_def projectKOs tcb_vcpu_refs'_def
-                  split: option.splits if_split_asm)
-  apply safe
-  apply (rule_tac rfs'="state_hyp_refs_of' s" in delta_sym_refs)
-   apply (clarsimp simp: state_hyp_refs_of'_def obj_at'_def projectKOs tcb_vcpu_refs'_def
-                   split: option.splits if_split_asm)+
-  done
-
-lemma setVCPU_archThreadSet_None_eq:
-  "do
-    archThreadSet (atcbVCPUPtr_update (\<lambda>_. Nothing)) t;
-    setObject v $ vcpuTCBPtr_update (\<lambda>_. Nothing) vcpu;
-    f
-   od = do
-    do
-      archThreadSet (atcbVCPUPtr_update (\<lambda>_. Nothing)) t;
-      setObject v $ vcpuTCBPtr_update (\<lambda>_. Nothing) vcpu
-    od;
-    f
-  od" by (simp add: bind_assoc)
-
-lemma vcpuInvalidateActive_inactive[wp]:
-  "\<lbrace>\<top>\<rbrace> vcpuInvalidateActive \<lbrace>\<lambda>rv s. \<forall>p. (\<exists>a. armHSCurVCPU (ksArchState s) = Some (p, a)) \<longrightarrow> P p rv s\<rbrace>"
-  unfolding vcpuInvalidateActive_def modifyArchState_def by wpsimp
-
-lemma vcpuDisableNone_obj_at'[wp]:
-  "vcpuDisable None \<lbrace>\<lambda>s. P (obj_at' P' p s)\<rbrace>"
-  unfolding vcpuDisable_def by wpsimp
-
-lemma vcpuInvalidateActive_obj_at'[wp]:
-  "vcpuInvalidateActive \<lbrace>\<lambda>s. P (obj_at' P' p s)\<rbrace>"
-  unfolding vcpuInvalidateActive_def modifyArchState_def by wpsimp
-
-lemma when_assert_eq:
-  "(when P $ haskell_fail xs) = assert (\<not>P)"
-  by (simp add: assert_def when_def)
-
-lemma dissociateVCPUTCB_invs'[wp]:
-  "dissociateVCPUTCB vcpu tcb \<lbrace>invs'\<rbrace>"
-  unfolding dissociateVCPUTCB_def setVCPU_archThreadSet_None_eq when_assert_eq
-  apply (wpsimp wp: dissoc_invs' getVCPU_wp | wpsimp wp: getObject_tcb_wp simp: archThreadGet_def)+
-  apply (drule tcb_ko_at')
-  apply clarsimp
-  apply (rule exI, rule conjI, assumption)
-  apply clarsimp
-  apply (rule conjI)
-   apply normalise_obj_at'
-  apply (rule conjI)
-   apply normalise_obj_at'
-  apply (clarsimp simp: obj_at'_def)
-  done
-
-lemma vcpuFinalise_invs'[wp]: "vcpuFinalise vcpu \<lbrace>invs'\<rbrace>"
-  unfolding vcpuFinalise_def by wpsimp
+  "deleteASID asid pd \<lbrace>invs'\<rbrace>"
+  unfolding deleteASID_def by (wpsimp wp: getASID_wp)
 
 lemma arch_finaliseCap_invs[wp]:
-  "\<lbrace>invs' and valid_cap' (ArchObjectCap cap)\<rbrace> Arch.finaliseCap cap fin \<lbrace>\<lambda>rv. invs'\<rbrace>"
-  unfolding ARM_HYP_H.finaliseCap_def Let_def by wpsimp
+  "\<lbrace>invs' and valid_cap' (ArchObjectCap cap)\<rbrace>
+     Arch.finaliseCap cap fin
+   \<lbrace>\<lambda>rv. invs'\<rbrace>"
+  unfolding RISCV64_H.finaliseCap_def by wpsimp
 
-lemma setObject_tcb_unlive[wp]:
-   "\<lbrace>\<lambda>s. vr \<noteq> t \<and> ko_wp_at' (Not \<circ> live') vr s\<rbrace>
-        setObject t (tcbArch_update (\<lambda>_. atcbVCPUPtr_update Map.empty (tcbArch tcb)) tcb)
-           \<lbrace>\<lambda>_. ko_wp_at' (Not \<circ> live') vr\<rbrace>"
-  apply (rule wp_pre)
-  apply (wpsimp wp: setObject_ko_wp_at simp: objBits_simps', simp+)
-  apply (clarsimp simp: tcb_at_typ_at' typ_at'_def ko_wp_at'_def )
-  done
+crunch setVMRoot, deleteASIDPool
+  for ctes_of[wp]: "\<lambda>s. P (ctes_of s)"
+  (wp: crunch_wps getObject_inv loadObject_default_inv getASID_wp simp: crunch_simps)
 
-lemma setVCPU_unlive[wp]:
-  "\<lbrace>\<top>\<rbrace> setObject vr (vcpuTCBPtr_update Map.empty vcpu) \<lbrace>\<lambda>_. ko_wp_at' (Not \<circ> live') vr\<rbrace>"
-  apply (rule wp_pre)
-  apply (wpsimp wp: setObject_ko_wp_at
-           simp: objBits_def objBitsKO_def archObjSize_def vcpu_bits_def pageBits_def)
-    apply simp+
-  apply (clarsimp simp: live'_def hyp_live'_def arch_live'_def ko_wp_at'_def obj_at'_def)
-  done
+lemma deleteASID_ctes_of[wp]:
+  "deleteASID a ptr \<lbrace>\<lambda>s. P (ctes_of s)\<rbrace>"
+  unfolding deleteASID_def by (wpsimp wp: getASID_wp)
 
-lemma asUser_unlive[wp]:
-  "\<lbrace>ko_wp_at' (Not \<circ> live') vr\<rbrace> asUser t f \<lbrace>\<lambda>_. ko_wp_at' (Not \<circ> live') vr\<rbrace>"
-  unfolding asUser_def
-  apply (wpsimp simp: threadSet_def atcbContextSet_def objBits_simps' split_def
-                  wp: setObject_ko_wp_at)
-  apply (rule refl, simp)
-  apply (wpsimp simp: atcbContextGet_def wp: getObject_tcb_wp threadGet_wp)+
-  apply (clarsimp simp: tcb_at_typ_at' typ_at'_def ko_wp_at'_def[where p=t])
-  apply (case_tac ko; simp)
-  apply (rename_tac tcb)
-  apply (rule_tac x=tcb in exI)
-  apply (clarsimp simp: obj_at'_def projectKOs)
-  apply (clarsimp simp: ko_wp_at'_def live'_def hyp_live'_def)
-  done
-
-lemma dissociateVCPUTCB_unlive:
-  "\<lbrace> \<top> \<rbrace> dissociateVCPUTCB vcpu tcb \<lbrace> \<lambda>_. ko_wp_at' (Not o live') vcpu \<rbrace>"
-  unfolding dissociateVCPUTCB_def setVCPU_archThreadSet_None_eq when_assert_eq
-  by (wpsimp wp: getVCPU_wp[where p=vcpu] |
-      wpsimp wp: getObject_tcb_wp hoare_vcg_conj_lift hoare_vcg_ex_lift
-                 getVCPU_wp[where p=vcpu] setVCPU_unlive[simplified o_def]
-                 setObject_tcb_unlive hoare_drop_imp setObject_tcb_strongest
-             simp: archThreadGet_def archThreadSet_def)+
-
-lemma vcpuFinalise_unlive[wp]:
-  "\<lbrace> \<top> \<rbrace> vcpuFinalise v \<lbrace> \<lambda>_. ko_wp_at' (Not o live') v \<rbrace>"
-  apply (wpsimp simp: vcpuFinalise_def wp: dissociateVCPUTCB_unlive getVCPU_wp)
-  apply (frule state_hyp_refs_of'_vcpu_absorb)
-  apply (auto simp: ko_wp_at'_def)
-  apply (rule_tac x="KOArch (KOVCPU ko)" in exI)
-  apply (clarsimp simp: live'_def hyp_live'_def arch_live'_def obj_at'_def projectKOs)
-  done
+lemma unmapPageTable_ctes_of[wp]:
+  "unmapPageTable asid vptr pt \<lbrace>\<lambda>s. P (ctes_of s)\<rbrace>"
+  unfolding unmapPageTable_def by wpsimp
 
 lemma arch_finaliseCap_removeable[wp]:
   "\<lbrace>\<lambda>s. s \<turnstile>' ArchObjectCap cap \<and> invs' s
-       \<and> (final_matters' (ArchObjectCap cap)
-               \<longrightarrow> (final = isFinal (ArchObjectCap cap) slot (cteCaps_of s))) \<rbrace>
+       \<and> (final \<and> final_matters' (ArchObjectCap cap)
+            \<longrightarrow> isFinal (ArchObjectCap cap) slot (cteCaps_of s))\<rbrace>
      Arch.finaliseCap cap final
-   \<lbrace>\<lambda>rv s. isNullCap (fst rv) \<and> removeable' slot s (ArchObjectCap cap) \<and> isNullCap (snd rv)\<rbrace>"
-  unfolding ARM_HYP_H.finaliseCap_def
-  including classic_wp_pre
-  apply (case_tac cap; clarsimp)
-        apply ((wpsimp simp: removeable'_def isCap_simps
-                 | rule conjI)+)[5]
-   apply (clarsimp simp: isCap_simps, rule conjI)
-    apply (wpsimp simp: isCap_simps removeable'_def wp: hoare_disjI2)
-   apply  (wpsimp simp: not_Final_removeable final_matters'_def)
-  apply  (wpsimp simp: isCap_simps removeable'_def)
+   \<lbrace>\<lambda>rv s. isNullCap (fst rv) \<and> removeable' slot s (ArchObjectCap cap)
+          \<and> (snd rv \<noteq> NullCap \<longrightarrow> snd rv = (ArchObjectCap cap) \<and> cap_has_cleanup' (ArchObjectCap cap)
+                                      \<and> isFinal (ArchObjectCap cap) slot (cteCaps_of s))\<rbrace>"
+  apply (simp add: RISCV64_H.finaliseCap_def removeable'_def)
+  apply (wpsimp wp: cteCaps_of_ctes_of_lift)
   done
 
 lemma isZombie_Null:
@@ -2969,8 +2498,6 @@ lemma prepares_delete_helper'':
   apply (rule hoare_strengthen_post [OF x])
   apply (clarsimp simp: removeable'_def)
   done
-
-lemmas ctes_of_cteCaps_of_lift = cteCaps_of_ctes_of_lift
 
 crunch finaliseCapTrue_standin, unbindNotification
   for ctes_of[wp]: "\<lambda>s. P (ctes_of s)"
@@ -3006,15 +2533,9 @@ lemma cteDeleteOne_isFinal:
   apply (clarsimp simp: isFinal_def sameObjectAs_def2)
   done
 
-lemmas setEndpoint_cteCaps_of[wp] = ctes_of_cteCaps_of_lift [OF set_ep_ctes_of]
-lemmas setNotification_cteCaps_of[wp] = ctes_of_cteCaps_of_lift [OF set_ntfn_ctes_of]
-lemmas threadSet_cteCaps_of = ctes_of_cteCaps_of_lift [OF threadSet_ctes_of]
-
-crunch dissociateVCPUTCB
-  for ctes_of[wp]: "\<lambda>s. P (ctes_of s)"
-  (wp: crunch_wps simp: crunch_simps)
-
-lemmas dissociateVCPUTCB_isFinal =  ctes_of_cteCaps_of_lift [OF dissociateVCPUTCB_ctes_of]
+lemmas setEndpoint_cteCaps_of[wp] = cteCaps_of_ctes_of_lift [OF set_ep_ctes_of]
+lemmas setNotification_cteCaps_of[wp] = cteCaps_of_ctes_of_lift [OF set_ntfn_ctes_of]
+lemmas threadSet_cteCaps_of = cteCaps_of_ctes_of_lift [OF threadSet_ctes_of]
 
 crunch suspend, prepareThreadDelete
   for isFinal: "\<lambda>s. isFinal cap slot (cteCaps_of s)"
@@ -3037,17 +2558,15 @@ lemma cteDeleteOne_deletes[wp]:
   apply clarsimp
   done
 
-crunch vcpuSwitch
-  for irq_node'[wp]: "\<lambda>s. P (irq_node' s)"
-  (wp: FalseI crunch_wps getObject_inv loadObject_default_inv
-       updateObject_default_inv setObject_ksInterrupt
-   simp: crunch_simps unless_def)
+lemma unmapPageTable_irq_node'[wp]:
+  "unmapPageTable asid vaddr pt \<lbrace>\<lambda>s. P (irq_node' s)\<rbrace>"
+  unfolding unmapPageTable_def by wpsimp
 
 crunch finaliseCap
   for irq_node'[wp]: "\<lambda>s. P (irq_node' s)"
-  (wp: mapM_x_wp crunch_wps getObject_inv loadObject_default_inv
+  (wp: crunch_wps getObject_inv loadObject_default_inv
        updateObject_default_inv setObject_ksInterrupt
-   simp: crunch_simps unless_def o_def)
+   simp: crunch_simps o_def)
 
 lemma deletingIRQHandler_removeable':
   "\<lbrace>invs' and (\<lambda>s. isFinal (IRQHandlerCap irq) slot (cteCaps_of s))
@@ -3070,7 +2589,7 @@ lemma finaliseCap_cte_refs:
      finaliseCap cap final flag
    \<lbrace>\<lambda>rv s. fst rv \<noteq> NullCap \<longrightarrow> cte_refs' (fst rv) = cte_refs' cap\<rbrace>"
   apply (simp  add: finaliseCap_def Let_def getThreadCSpaceRoot
-                    ARM_HYP_H.finaliseCap_def
+                    RISCV64_H.finaliseCap_def
              cong: if_cong split del: if_split)
   apply (rule hoare_pre)
    apply (wp | wpc | simp only: o_def)+
@@ -3080,7 +2599,7 @@ lemma finaliseCap_cte_refs:
   apply clarsimp
   apply (rule ext, simp)
   apply (rule image_cong [OF _ refl])
-  apply (fastforce simp: capAligned_def objBits_simps shiftL_nat mask_def)
+  apply (fastforce simp: mask_def capAligned_def objBits_simps shiftL_nat)
   done
 
 lemma deletingIRQHandler_final:
@@ -3098,7 +2617,7 @@ declare suspend_unqueued [wp]
 
 lemma unbindNotification_valid_objs'_helper:
   "valid_tcb' tcb s \<longrightarrow> valid_tcb' (tcbBoundNotification_update (\<lambda>_. None) tcb) s "
-  by (clarsimp simp: valid_bound_ntfn'_def valid_tcb'_def tcb_cte_cases_def tcb_cte_cases_neqs
+  by (clarsimp simp: valid_bound_ntfn'_def valid_tcb'_def tcb_cte_cases_def cteSizeBits_def
                   split: option.splits ntfn.splits)
 
 lemma unbindNotification_valid_objs'_helper':
@@ -3117,7 +2636,7 @@ lemma unbindNotification_valid_objs'[wp]:
   apply (wp threadSet_valid_objs' gbn_wp' set_ntfn_valid_objs' hoare_vcg_all_lift
             setNotification_valid_tcb' getNotification_wp
         | wpc | clarsimp simp: setBoundNotification_def unbindNotification_valid_objs'_helper)+
-  apply (clarsimp elim!: obj_atE' simp: projectKOs)
+  apply (clarsimp elim!: obj_atE')
   apply (rule valid_objsE', assumption+)
   apply (clarsimp simp: valid_obj'_def unbindNotification_valid_objs'_helper')
   done
@@ -3132,7 +2651,7 @@ lemma unbindMaybeNotification_valid_objs'[wp]:
   apply (wp threadSet_valid_objs' gbn_wp' set_ntfn_valid_objs' hoare_vcg_all_lift
             setNotification_valid_tcb' getNotification_wp
         | wpc | clarsimp simp: setBoundNotification_def unbindNotification_valid_objs'_helper)+
-  apply (clarsimp elim!: obj_atE' simp: projectKOs)
+  apply (clarsimp elim!: obj_atE')
   apply (rule valid_objsE', assumption+)
   apply (clarsimp simp: valid_obj'_def unbindNotification_valid_objs'_helper')
   done
@@ -3156,10 +2675,9 @@ lemma sym_refs_ntfn_bound_eq: "sym_refs (state_refs_of' s)
     = bound_tcb_at' (\<lambda>st. st = Some x) t s"
   apply (rule iffI)
    apply (drule (1) sym_refs_obj_atD')
-   apply (clarsimp simp: pred_tcb_at'_def obj_at'_def ko_wp_at'_def projectKOs
-                         refs_of_rev')
+   apply (clarsimp simp: pred_tcb_at'_def obj_at'_def ko_wp_at'_def refs_of_rev')
   apply (drule(1) sym_refs_bound_tcb_atD')
-  apply (clarsimp simp: obj_at'_def projectKOs ko_wp_at'_def refs_of_rev')
+  apply (clarsimp simp: obj_at'_def ko_wp_at'_def refs_of_rev')
   done
 
 lemma unbindMaybeNotification_obj_at'_bound:
@@ -3171,21 +2689,18 @@ lemma unbindMaybeNotification_obj_at'_bound:
   apply (rule hoare_pre)
    apply (wp obj_at_setObject2
         | wpc
-        | simp add: setBoundNotification_def threadSet_def updateObject_default_def in_monad projectKOs)+
+        | simp add: setBoundNotification_def threadSet_def updateObject_default_def in_monad)+
   apply (simp add: setNotification_def obj_at'_real_def cong: valid_cong)
    apply (wp setObject_ko_wp_at, (simp add: objBits_simps')+)
-  apply (clarsimp simp: obj_at'_def ko_wp_at'_def projectKOs)
+  apply (clarsimp simp: obj_at'_def ko_wp_at'_def)
   done
 
-context
-notes option.case_cong_weak[cong]
-begin
 crunch unbindNotification, unbindMaybeNotification
   for isFinal[wp]: "\<lambda>s. isFinal cap slot (cteCaps_of s)"
   (wp: sts_bound_tcb_at' threadSet_cteCaps_of crunch_wps getObject_inv
        loadObject_default_inv
-   ignore: threadSet)
-end
+   ignore: threadSet
+   simp: setBoundNotification_def)
 
 crunch cancelSignal, cancelAllIPC
   for bound_tcb_at'[wp]: "bound_tcb_at' P t"
@@ -3210,7 +2725,7 @@ lemma capDeleteOne_bound_tcb_at':
    apply (wp finaliseCapTrue_standin_bound_tcb_at' hoare_vcg_all_lift
             hoare_vcg_if_lift2 getCTE_cteCap_wp
         | wpc | simp | wp (once) hoare_drop_imp)+
-  apply (clarsimp simp:  cteCaps_of_def projectKOs isReplyCap_def cte_wp_at_ctes_of
+  apply (clarsimp simp:  cteCaps_of_def isReplyCap_def cte_wp_at_ctes_of
                  split: option.splits)
   apply (case_tac "cteCap cte", simp_all)
   done
@@ -3230,22 +2745,6 @@ lemma cancelIPC_bound_tcb_at'[wp]:
    apply (clarsimp simp: capHasProperty_def cte_wp_at_ctes_of)
    apply (wp threadSet_pred_tcb_no_state | simp)+
   done
-
-lemma archThreadSet_bound_tcb_at'[wp]:
-  "archThreadSet f t \<lbrace>bound_tcb_at' P t'\<rbrace>"
-  unfolding archThreadSet_def
-  apply (wpsimp wp: setObject_tcb_strongest getObject_tcb_wp simp: pred_tcb_at'_def)
-  by (auto simp: obj_at'_def projectKOs objBits_simps)
-
-lemmas asUser_bound_obj_at'[wp] = asUser_pred_tcb_at' [of itcbBoundNotification]
-
-lemmas setObject_vcpu_pred_tcb_at'[wp] =
-  setObject_vcpu_obj_at'_no_vcpu [of _ "\<lambda>ko. tst (pr (tcb_to_itcb' ko))" for tst pr, folded pred_tcb_at'_def]
-
-crunch dissociateVCPUTCB, vgicUpdateLR
-  for bound_tcb_at'[wp]: "bound_tcb_at' P t"
-  (wp: sts_bound_tcb_at' getVCPU_wp crunch_wps hoare_vcg_all_lift hoare_vcg_if_lift3
-   ignore: archThreadSet)
 
 crunch suspend, prepareThreadDelete
   for bound_tcb_at'[wp]: "bound_tcb_at' P t"
@@ -3273,64 +2772,15 @@ lemma unbindMaybeNotification_tcb_at'[wp]:
   apply (wp gbn_wp' | wpc | simp)+
   done
 
-lemma dissociateVCPUTCB_cte_wp_at'[wp]:
-  "dissociateVCPUTCB v t \<lbrace>cte_wp_at' P p\<rbrace>"
-  unfolding cte_wp_at_ctes_of by wp
-
-lemmas dissociateVCPUTCB_typ_ats'[wp] = typ_at_lifts[OF dissociateVCPUTCB_typ_at']
-
 crunch prepareThreadDelete
   for cte_wp_at'[wp]: "cte_wp_at' P p"
 crunch prepareThreadDelete
   for valid_cap'[wp]: "valid_cap' cap"
 crunch prepareThreadDelete
-  for invs[wp]: "invs'"
-
-lemma unset_vcpu_hyp_unlive[wp]:
-  "\<lbrace>\<top>\<rbrace> archThreadSet (atcbVCPUPtr_update Map.empty) t \<lbrace>\<lambda>_. ko_wp_at' (Not \<circ> hyp_live') t\<rbrace>"
-  unfolding archThreadSet_def
-  apply (wpsimp wp: setObject_ko_wp_at' getObject_tcb_wp; (simp add: objBits_simps')?)+
-  apply (clarsimp simp: obj_at'_def ko_wp_at'_def projectKOs hyp_live'_def)
-  done
-
- lemma unset_tcb_hyp_unlive[wp]:
-  "\<lbrace>\<top>\<rbrace> setObject vr (vcpuTCBPtr_update Map.empty vcpu) \<lbrace>\<lambda>_. ko_wp_at' (Not \<circ> hyp_live') vr\<rbrace>"
-  apply (wpsimp wp: setObject_ko_wp_at' getObject_tcb_wp
-                simp: objBits_simps archObjSize_def vcpu_bits_def pageBits_def
-        | simp)+
-  apply (clarsimp simp: obj_at'_def ko_wp_at'_def projectKOs hyp_live'_def arch_live'_def)
-  done
-
-lemma setObject_vcpu_hyp_unlive[wp]:
-   "\<lbrace>\<lambda>s. t \<noteq> vr \<and> ko_wp_at' (Not \<circ> hyp_live') t s\<rbrace>
-         setObject vr (vcpuTCBPtr_update Map.empty vcpu)
-    \<lbrace>\<lambda>_. ko_wp_at' (Not \<circ> hyp_live') t\<rbrace>"
-  apply (rule wp_pre)
-  apply (wpsimp wp: setObject_ko_wp_at
-                simp: objBits_def objBitsKO_def archObjSize_def vcpu_bits_def pageBits_def
-        | simp)+
-  apply (clarsimp simp: tcb_at_typ_at' typ_at'_def ko_wp_at'_def )
-  done
-
-
-lemma asUser_hyp_unlive[wp]:
-  "asUser f t \<lbrace>ko_wp_at' (Not \<circ> hyp_live') t'\<rbrace>"
-  unfolding asUser_def
-  apply (wpsimp wp: threadSet_ko_wp_at2' threadGet_wp)
-  apply (clarsimp simp: ko_wp_at'_def obj_at'_def projectKOs hyp_live'_def atcbContextSet_def)
-  done
-
-lemma dissociateVCPUTCB_hyp_unlive[wp]:
-  "\<lbrace>\<top>\<rbrace> dissociateVCPUTCB v t \<lbrace>\<lambda>_. ko_wp_at' (Not \<circ> hyp_live') t\<rbrace>"
-  unfolding dissociateVCPUTCB_def
-  by (cases "v = t"; wpsimp wp: unset_tcb_hyp_unlive unset_vcpu_hyp_unlive[simplified comp_def])
-
-lemma prepareThreadDelete_hyp_unlive[wp]:
-  "\<lbrace>\<top>\<rbrace> prepareThreadDelete t \<lbrace>\<lambda>_. ko_wp_at' (Not \<circ> hyp_live') t\<rbrace>"
-  unfolding prepareThreadDelete_def archThreadGet_def
-  apply (wpsimp wp: getObject_tcb_wp)
-  apply (clarsimp simp: ko_wp_at'_def obj_at'_def projectKOs hyp_live'_def)
-  done
+  for invs[wp]: "invs'" (ignore: doMachineOp)
+crunch prepareThreadDelete
+  for obj_at'[wp]: "\<lambda>s. P' (obj_at' P p s)"
+  (wp: whenE_wp simp: crunch_simps)
 
 end
 
@@ -3338,7 +2788,6 @@ lemma tcbQueueRemove_tcbSchedNext_tcbSchedPrev_None_obj_at':
   "\<lbrace>\<lambda>s. \<exists>ts. list_queue_relation ts q (tcbSchedNexts_of s) (tcbSchedPrevs_of s)\<rbrace>
    tcbQueueRemove q t
    \<lbrace>\<lambda>_ s. obj_at' (\<lambda>tcb. tcbSchedNext tcb = None \<and> tcbSchedPrev tcb = None) t s\<rbrace>"
-  supply projectKOs[simp]
   apply (clarsimp simp: tcbQueueRemove_def)
   apply (wpsimp wp: threadSet_wp getTCB_wp)
   by (fastforce dest!: heap_ls_last_None
@@ -3350,7 +2799,6 @@ lemma tcbSchedDequeue_tcbSchedNext_tcbSchedPrev_None_obj_at':
   "\<lbrace>valid_sched_pointers\<rbrace>
    tcbSchedDequeue t
    \<lbrace>\<lambda>_ s. obj_at' (\<lambda>tcb. tcbSchedNext tcb = None \<and> tcbSchedPrev tcb = None) t s\<rbrace>"
-  supply projectKOs[simp]
   unfolding tcbSchedDequeue_def
   by (wpsimp wp: tcbQueueRemove_tcbSchedNext_tcbSchedPrev_None_obj_at' threadGet_wp)
      (fastforce simp: ready_queue_relation_def ksReadyQueues_asrt_def obj_at'_def
@@ -3373,22 +2821,6 @@ lemma suspend_tcbSchedNext_tcbSchedPrev_None:
   unfolding suspend_def
   by (wpsimp wp: hoare_drop_imps tcbSchedDequeue_tcbSchedNext_tcbSchedPrev_None_obj_at')
 
-context begin interpretation Arch . (*FIXME: arch-split*)
-
-lemma archThreadSet_tcbSchedPrevNext[wp]:
-  "archThreadSet f t' \<lbrace>obj_at' (\<lambda>tcb. P (tcbSchedNext tcb) (tcbSchedPrev tcb)) t\<rbrace>"
-  unfolding archThreadSet_def
-  apply (wpsimp wp: setObject_tcb_strongest getObject_tcb_wp)
-  apply normalise_obj_at'
-  apply auto
-  done
-
-crunch prepareThreadDelete
-  for tcbSchedPrevNext[wp]: "obj_at' (\<lambda>tcb. P (tcbSchedNext tcb) (tcbSchedPrev tcb)) t"
-  (wp: threadGet_wp getVCPU_wp archThreadGet_wp crunch_wps simp: crunch_simps)
-
-end
-
 lemma (in delete_one_conc_pre) finaliseCap_replaceable:
   "\<lbrace>\<lambda>s. invs' s \<and> cte_wp_at' (\<lambda>cte. cteCap cte = cap) slot s
        \<and> (final_matters' cap \<longrightarrow> (final = isFinal cap slot (cteCaps_of s)))
@@ -3408,15 +2840,14 @@ lemma (in delete_one_conc_pre) finaliseCap_replaceable:
             \<and> (\<forall>p \<in> threadCapRefs cap. st_tcb_at' ((=) Inactive) p s
                      \<and> obj_at' (Not \<circ> tcbQueued) p s
                      \<and> bound_tcb_at' ((=) None) p s
-                     \<and> ko_wp_at' (Not \<circ> hyp_live') p s
                      \<and> obj_at' (\<lambda>tcb. tcbSchedNext tcb = None \<and> tcbSchedPrev tcb = None) p s))\<rbrace>"
   apply (simp add: finaliseCap_def Let_def getThreadCSpaceRoot
              cong: if_cong split del: if_split)
   apply (rule hoare_pre)
    apply (wp prepares_delete_helper'' [OF cancelAllIPC_unlive]
              prepares_delete_helper'' [OF cancelAllSignals_unlive]
-             suspend_isFinal ARM_HYP.prepareThreadDelete_unqueued (* FIXME arch-split: interface *)
-             ARM_HYP.prepareThreadDelete_inactive prepareThreadDelete_isFinal
+             suspend_isFinal RISCV64.prepareThreadDelete_unqueued (* FIXME arch-split: interface *)
+             RISCV64.prepareThreadDelete_inactive prepareThreadDelete_isFinal
              suspend_makes_inactive
              deletingIRQHandler_removeable'
              deletingIRQHandler_final[where slot=slot ]
@@ -3433,11 +2864,16 @@ lemma (in delete_one_conc_pre) finaliseCap_replaceable:
   apply clarsimp
   apply (frule cte_wp_at_valid_objs_valid_cap', clarsimp+)
   apply (case_tac "cteCap cte",
-         simp_all add: gen_isCap_simps capRange_def
+         simp_all add: gen_isCap_simps capRange_def cap_has_cleanup'_def
                        final_matters'_def gen_objBits_simps
                        not_Final_removeable finaliseCap_def,
-         simp_all add: removeable'_def)[1]
-   apply fastforce+
+         simp_all add: removeable'_def)
+     (* thread *)
+     apply (frule capAligned_capUntypedPtr [OF valid_capAligned], simp)
+     apply (clarsimp simp: valid_cap'_def)
+     apply (drule valid_globals_cte_wpD'[rotated], clarsimp)
+     apply (clarsimp simp: invs'_def valid_state'_def valid_pspace'_def)
+    apply (clarsimp simp: obj_at'_def | rule conjI)+
   done
 
 lemma cteDeleteOne_cte_wp_at_preserved:
@@ -3464,13 +2900,13 @@ lemma cancelIPC_cteCaps_of:
                    getThreadReplySlot_def locateSlot_conv)
   apply (rule hoare_pre)
    apply (wp cteDeleteOne_cteCaps_of getCTE_wp' | wpcw
-        | simp add: cte_wp_at_ctes_of
-        | wp (once) hoare_drop_imps ctes_of_cteCaps_of_lift)+
+          | simp add: cte_wp_at_ctes_of
+          | wp (once) hoare_drop_imps cteCaps_of_ctes_of_lift)+
           apply (wp hoare_convert_imp hoare_vcg_all_lift
                     threadSet_ctes_of threadSet_cteCaps_of
-               | clarsimp)+
-    apply (wp cteDeleteOne_cteCaps_of getCTE_wp' | wpcw | simp
-       | wp (once) hoare_drop_imps ctes_of_cteCaps_of_lift)+
+                 | clarsimp)+
+         apply (wp cteDeleteOne_cteCaps_of getCTE_wp' | wpcw | simp
+                | wp (once) hoare_drop_imps cteCaps_of_ctes_of_lift)+
   apply (clarsimp simp: cte_wp_at_ctes_of cteCaps_of_def)
   apply (drule_tac x="mdbNext (cteMDBNode x)" in spec)
   apply clarsimp
@@ -3496,8 +2932,7 @@ lemma suspend_cte_wp_at':
   shows "\<lbrace>cte_wp_at' (\<lambda>cte. P (cteCap cte)) p\<rbrace>
            suspend t
          \<lbrace>\<lambda>rv. cte_wp_at' (\<lambda>cte. P (cteCap cte)) p\<rbrace>"
-  apply (simp add: suspend_def)
-  unfolding updateRestartPC_def
+  apply (simp add: suspend_def updateRestartPC_def)
   apply (rule hoare_pre)
    apply (wp threadSet_cte_wp_at' cancelIPC_cte_wp_at'
              | simp add: x)+
@@ -3512,12 +2947,11 @@ crunch deleteASIDPool
 
 lemma deleteASID_cte_wp_at'[wp]:
   "\<lbrace>cte_wp_at' P p\<rbrace> deleteASID param_a param_b \<lbrace>\<lambda>_. cte_wp_at' P p\<rbrace>"
-  apply (simp add: deleteASID_def invalidateHWASIDEntry_def invalidateASID_def
+  apply (simp add: deleteASID_def
               cong: option.case_cong)
   apply (wp setObject_cte_wp_at'[where Q="\<top>"] getObject_inv
             loadObject_default_inv setVMRoot_cte_wp_at'
           | clarsimp simp: updateObject_default_def in_monad
-                           projectKOs
           | rule equals0I
           | wpc)+
   done
@@ -3526,14 +2960,11 @@ crunch unmapPageTable, unmapPage, unbindNotification, finaliseCapTrue_standin
   for cte_wp_at'[wp]: "cte_wp_at' P p"
   (simp: crunch_simps wp: crunch_wps getObject_inv loadObject_default_inv)
 
-crunch vcpuFinalise
-  for cte_wp_at'[wp]: "cte_wp_at' P p"
-  (wp: crunch_wps getObject_inv loadObject_default_inv)
-
 lemma arch_finaliseCap_cte_wp_at[wp]:
   "\<lbrace>cte_wp_at' P p\<rbrace> Arch.finaliseCap cap fin \<lbrace>\<lambda>rv. cte_wp_at' P p\<rbrace>"
-  unfolding ARM_HYP_H.finaliseCap_def
-  by (wpsimp wp: unmapPage_cte_wp_at'|rule conjI)+
+  apply (simp add: RISCV64_H.finaliseCap_def)
+  apply (wpsimp wp: unmapPage_cte_wp_at')
+  done
 
 lemma deletingIRQHandler_cte_preserved:
   assumes x: "\<And>cap final. P cap \<Longrightarrow> finaliseCap cap final True = fail"
@@ -3542,8 +2973,7 @@ lemma deletingIRQHandler_cte_preserved:
          \<lbrace>\<lambda>rv. cte_wp_at' (\<lambda>cte. P (cteCap cte)) p\<rbrace>"
   apply (simp add: deletingIRQHandler_def getSlotCap_def
                    getIRQSlot_def locateSlot_conv getInterruptState_def)
-  apply (wp cteDeleteOne_cte_wp_at_preserved getCTE_wp'
-              | simp add: x)+
+  apply (wpsimp wp: cteDeleteOne_cte_wp_at_preserved getCTE_wp' simp: x)
   done
 
 lemma finaliseCap_equal_cap[wp]:
@@ -3583,7 +3013,7 @@ lemma cteDeleteOne_st_tcb_at[wp]:
    apply (clarsimp simp: pred_disj_def)
    apply (rule cteDeleteOne_st_tcb_at_simplish)
   apply (rule_tac x=P in exI)
-  apply (auto intro!: ext)
+  apply auto
   done
 
 lemma cteDeleteOne_reply_pred_tcb_at:
@@ -3598,16 +3028,18 @@ lemma cteDeleteOne_reply_pred_tcb_at:
   apply (intro impI conjI, (wp | simp)+)
   done
 
-context
-notes option.case_cong_weak[cong]
-begin
+lemmas setNotification_typ_at'[wp] = typ_at_lifts[OF setNotification_typ_at']
+
+crunch setBoundNotification, setNotification
+  for sch_act_simple[wp]: sch_act_simple
+  (wp: sch_act_simple_lift)
+
 crunch cteDeleteOne, unbindNotification
   for sch_act_simple[wp]: sch_act_simple
   (wp: crunch_wps ssa_sch_act_simple sts_sch_act_simple getObject_inv
        loadObject_default_inv
-   simp: crunch_simps unless_def
+   simp: crunch_simps
    rule: sch_act_simple_lift)
-end
 
 lemma rescheduleRequired_sch_act_not[wp]:
   "\<lbrace>\<top>\<rbrace> rescheduleRequired \<lbrace>\<lambda>rv. sch_act_not t\<rbrace>"
@@ -3652,7 +3084,7 @@ lemma cancelAllIPC_mapM_x_tcbDomain_obj_at':
                  tcbSchedEnqueue t
                od) q
   \<lbrace>\<lambda>_. obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>"
-  by (wpsimp wp: mapM_x_wp')
+  by (wp mapM_x_wp' | simp)+
 
 lemma rescheduleRequired_oa_queued':
   "rescheduleRequired \<lbrace>obj_at' (\<lambda>tcb. Q (tcbDomain tcb) (tcbPriority tcb)) t\<rbrace>"
@@ -3663,13 +3095,13 @@ lemma cancelAllIPC_tcbDomain_obj_at':
   "\<lbrace>obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>
      cancelAllIPC epptr
    \<lbrace>\<lambda>_. obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>"
-apply (simp add: cancelAllIPC_def)
-apply (wp hoare_vcg_conj_lift hoare_vcg_const_Ball_lift
-          rescheduleRequired_oa_queued' cancelAllIPC_mapM_x_tcbDomain_obj_at'
-          getEndpoint_wp
-     | wpc
-     | simp)+
-done
+  apply (simp add: cancelAllIPC_def)
+  apply (wp hoare_vcg_conj_lift hoare_vcg_const_Ball_lift
+            rescheduleRequired_oa_queued' cancelAllIPC_mapM_x_tcbDomain_obj_at'
+            getEndpoint_wp
+       | wpc
+       | simp)+
+  done
 
 lemma cancelAllSignals_tcbDomain_obj_at':
   "\<lbrace>obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>
@@ -3684,7 +3116,9 @@ apply (wp hoare_vcg_conj_lift hoare_vcg_const_Ball_lift
 done
 
 lemma unbindMaybeNotification_tcbDomain_obj_at':
-  "unbindMaybeNotification r \<lbrace>obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>"
+  "\<lbrace>obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>
+     unbindMaybeNotification r
+   \<lbrace>\<lambda>_. obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>"
   unfolding unbindMaybeNotification_def
   by (wpsimp wp: getNotification_wp gbn_wp' simp: setBoundNotification_def)+
 
@@ -3717,7 +3151,8 @@ lemma cteDeleteOne_tcbDomain_obj_at':
 end
 
 global_interpretation delete_one_conc_pre
-  by (unfold_locales, wp) (wp cteDeleteOne_tcbDomain_obj_at' cteDeleteOne_typ_at' cteDeleteOne_reply_pred_tcb_at | simp)+
+  by (unfold_locales, wp)
+     (wp cteDeleteOne_tcbDomain_obj_at' cteDeleteOne_typ_at' cteDeleteOne_reply_pred_tcb_at | simp)+
 
 context begin interpretation Arch . (*FIXME: arch-split*)
 
@@ -3744,7 +3179,7 @@ lemma cteDeleteOne_invs[wp]:
     apply (rule conjI)
      subgoal by auto
     subgoal by (auto dest!: isCapDs simp: pred_tcb_at'_def obj_at'_def projectKOs
-                                      live'_def hyp_live'_def ko_wp_at'_def)
+                                           live'_def hyp_live'_def ko_wp_at'_def)
    apply (wp isFinalCapability_inv getCTE_wp' hoare_weak_lift_imp
         | wp (once) isFinal[where x=ptr])+
   apply (fastforce simp: cte_wp_at_ctes_of)
@@ -3764,9 +3199,6 @@ lemma deletingIRQHandler_invs' [wp]:
   apply (wp getCTE_wp')
   apply simp
   done
-
-crunch unbindNotification, unbindMaybeNotification
-  for tcb_at'[wp]: "tcb_at' t"
 
 lemma finaliseCap_invs:
   "\<lbrace>invs' and sch_act_simple and valid_cap' cap
@@ -3822,18 +3254,14 @@ lemma finaliseCap_cte_cap_wp_to[wp]:
   apply fastforce
   done
 
-context
-notes option.case_cong_weak[cong]
-begin
 crunch unbindNotification
   for valid_cap'[wp]: "valid_cap' cap"
-end
 
 lemma finaliseCap_valid_cap[wp]:
   "\<lbrace>valid_cap' cap\<rbrace> finaliseCap cap final flag \<lbrace>\<lambda>rv. valid_cap' (fst rv)\<rbrace>"
   apply (simp add: finaliseCap_def Let_def
                    getThreadCSpaceRoot
-                   ARM_HYP_H.finaliseCap_def
+                   RISCV64_H.finaliseCap_def
              cong: if_cong split del: if_split)
   apply (rule hoare_pre)
    apply (wp | simp only: valid_NullCap o_def fst_conv | wpc)+
@@ -3846,10 +3274,9 @@ lemma finaliseCap_valid_cap[wp]:
 
 context begin interpretation Arch . (*FIXME: arch-split*)
 
-crunch dissociateVCPUTCB
-  for nosch[wp]: "\<lambda>s. P (ksSchedulerAction s)"
-  (wp: crunch_wps getVCPU_wp getObject_inv hoare_vcg_all_lift hoare_vcg_if_lift3
-   simp: loadObject_default_def updateObject_default_def)
+lemma unmapPageTable_nosch[wp]:
+  "unmapPageTable asid vaddr pt \<lbrace>\<lambda>s. P (ksSchedulerAction s)\<rbrace>"
+  unfolding unmapPageTable_def by wpsimp
 
 crunch "Arch.finaliseCap"
   for nosch[wp]: "\<lambda>s. P (ksSchedulerAction s)"
@@ -3913,31 +3340,6 @@ lemma (in delete_one) deletingIRQHandler_corres:
 
 context begin interpretation Arch . (*FIXME: arch-split*)
 
-lemma sym_refs_vcpu_tcb:
-  "\<lbrakk> ko_at (ArchObj (VCPU vcpu)) v s; vcpu_tcb vcpu = Some t; sym_refs (state_hyp_refs_of s) \<rbrakk> \<Longrightarrow>
-  \<exists>tcb. ko_at (TCB tcb) t s \<and> tcb_vcpu (tcb_arch tcb) = Some v"
-  apply (drule (1) hyp_sym_refs_obj_atD)
-  apply (clarsimp simp: obj_at_def hyp_refs_of_def)
-  apply (rename_tac ko)
-  apply (case_tac ko; simp add: tcb_vcpu_refs_def split: option.splits)
-  apply (rename_tac koa)
-  apply (case_tac koa; simp add: refs_of_a_def vcpu_tcb_refs_def split: option.splits)
-  done
-
-lemma vcpuFinalise_corres [corres]:
-  "corres dc (invs and vcpu_at vcpu) (invs' and vcpu_at' vcpu) (vcpu_finalise vcpu) (vcpuFinalise vcpu)"
-  unfolding vcpuFinalise_def vcpu_finalise_def
-  apply (corresKsimp corres: getObject_vcpu_corres simp: vcpu_relation_def)
-     apply (wpsimp wp: get_vcpu_wp getVCPU_wp)+
-  apply (rule conjI)
-   apply clarsimp
-   apply (frule sym_refs_vcpu_tcb)
-     apply (simp add: vcpu_relation_def)
-    apply fastforce
-   apply (fastforce simp: obj_at_def vcpu_relation_def)
-  apply clarsimp
-  done
-
 lemma arch_finaliseCap_corres:
   "\<lbrakk> final_matters' (ArchObjectCap cap') \<Longrightarrow> final = final'; acap_relation cap cap' \<rbrakk>
      \<Longrightarrow> corres (\<lambda>r r'. cap_relation (fst r) (fst r') \<and> cap_relation (snd r) (snd r'))
@@ -3950,35 +3352,47 @@ lemma arch_finaliseCap_corres:
                       final' = isFinal (ArchObjectCap cap') (cte_map sl) (cteCaps_of s)))
            (arch_finalise_cap cap final) (Arch.finaliseCap cap' final')"
   apply (cases cap,
-         simp_all add: arch_finalise_cap_def ARM_HYP_H.finaliseCap_def isCap_simps
+         simp_all add: arch_finalise_cap_def RISCV64_H.finaliseCap_def
                        final_matters'_def case_bool_If liftM_def[symmetric]
                        o_def dc_def[symmetric]
-                split: option.split, safe)
-     apply (rule corres_guard_imp, rule deleteASIDPool_corres)
-      apply (clarsimp simp: valid_cap_def mask_def)
-     apply (clarsimp simp: valid_cap'_def)
-     apply auto[1]
-    apply (rule corres_guard_imp, rule unmapPage_corres)
-      apply simp
-     apply (clarsimp simp: valid_cap_def valid_unmap_def)
-     apply (auto simp: vmsz_aligned_def pbfs_atleast_pageBits mask_def
-                 elim: is_aligned_weaken invs_valid_asid_map)[2]
-   apply (rule corres_guard_imp, rule unmapPageTable_corres)
-    apply (auto simp: valid_cap_def valid_cap'_def mask_def
-               elim!: is_aligned_weaken invs_valid_asid_map)[2]
-  apply (rule corres_guard_imp, rule deleteASID_corres)
-   apply (auto elim!: invs_valid_asid_map simp: mask_def valid_cap_def)[2]
-  apply corresK
-  apply (clarsimp simp: valid_cap_def valid_cap'_def)
+                split: option.split,
+         safe)
+    apply (rule corres_guard_imp, rule deleteASIDPool_corres[OF refl refl])
+     apply (clarsimp simp: valid_cap_def mask_def)
+    apply (clarsimp simp: valid_cap'_def)
+   apply auto[1]
+   apply (rule corres_guard_imp, rule unmapPage_corres[OF refl refl refl refl])
+    apply simp
+    apply (clarsimp simp: valid_cap_def valid_unmap_def)
+    apply (auto simp: vmsz_aligned_def pbfs_atleast_pageBits mask_def wellformed_mapdata_def
+                elim: is_aligned_weaken)[2]
+  apply (rule corres_guard_imp)
+    apply (rule corres_split_catch[where f=dc])
+       apply (rule corres_splitEE)
+          apply (rule corres_rel_imp[where r="dc \<oplus> (=)"], rule findVSpaceForASID_corres; simp)
+          apply (case_tac x; simp)
+         apply (simp only: whenE_def)
+         apply (rule corres_if[where Q=\<top> and Q'=\<top>], simp)
+          apply simp
+          apply (rule deleteASID_corres; rule refl)
+         apply simp
+        apply (wpsimp wp: hoare_vcg_if_lift_ER hoare_drop_imps)+
+      apply (rule unmapPageTable_corres; simp)
+     apply (wpsimp wp: hoare_drop_imps)+
+   apply (clarsimp simp: invs_psp_aligned invs_distinct invs_vspace_objs invs_valid_asid_table)
+   apply (clarsimp simp: cte_wp_at_caps_of_state)
+   apply (drule (1) caps_of_state_valid)
+   apply (simp add: valid_cap_def wellformed_mapdata_def)
+  apply (simp add: invs_no_0_obj')
   done
+
 
 lemma unbindNotification_corres:
   "corres dc
       (invs and tcb_at t)
-      (invs' and tcb_at' t)
+      invs'
       (unbind_notification t)
       (unbindNotification t)"
-  supply option.case_cong_weak[cong]
   apply (simp add: unbind_notification_def unbindNotification_def)
   apply (rule corres_guard_imp)
     apply (rule corres_split[OF getBoundNotification_corres])
@@ -3991,17 +3405,13 @@ lemma unbindNotification_corres:
            apply (clarsimp simp: ntfn_relation_def split:Structures_A.ntfn.splits)
           apply (rule setBoundNotification_corres)
          apply (wp gbn_wp' gbn_wp)+
-   apply clarsimp
-   apply (frule invs_psp_aligned)
-   apply (frule invs_distinct)
    apply (clarsimp elim!: obj_at_valid_objsE
                    dest!: bound_tcb_at_state_refs_ofD invs_valid_objs
-                    simp: valid_obj_def is_tcb tcb_ntfn_is_bound_def
-                          valid_tcb_def valid_bound_ntfn_def
+                    simp: valid_obj_def is_tcb tcb_ntfn_is_bound_def obj_at_def
+                          valid_tcb_def valid_bound_ntfn_def invs_psp_aligned invs_distinct
                    split: option.splits)
   apply (clarsimp dest!: obj_at_valid_objs' bound_tcb_at_state_refs_ofD' invs_valid_objs'
-                   simp: projectKOs valid_obj'_def valid_tcb'_def valid_bound_ntfn'_def
-                         tcb_ntfn_is_bound'_def
+                   simp: valid_obj'_def valid_tcb'_def valid_bound_ntfn'_def tcb_ntfn_is_bound'_def
                   split: option.splits)
   done
 
@@ -4010,27 +3420,24 @@ lemma unbindMaybeNotification_corres:
       (invs and ntfn_at ntfnptr) (invs' and ntfn_at' ntfnptr)
       (unbind_maybe_notification ntfnptr)
       (unbindMaybeNotification ntfnptr)"
-  apply (simp add: unbind_maybe_notification_def unbindMaybeNotification_def
-              cong: option.case_cong)
+  apply (simp add: unbind_maybe_notification_def unbindMaybeNotification_def)
   apply (rule corres_guard_imp)
     apply (rule corres_split[OF getNotification_corres])
       apply (rule corres_option_split)
         apply (clarsimp simp: ntfn_relation_def split: Structures_A.ntfn.splits)
        apply (rule corres_return_trivial)
+      apply simp
       apply (rule corres_split[OF setNotification_corres])
          apply (clarsimp simp: ntfn_relation_def split: Structures_A.ntfn.splits)
         apply (rule setBoundNotification_corres)
        apply (wp get_simple_ko_wp getNotification_wp)+
-   apply clarsimp
-   apply (frule invs_psp_aligned)
-   apply (frule invs_distinct)
    apply (clarsimp elim!: obj_at_valid_objsE
                    dest!: bound_tcb_at_state_refs_ofD invs_valid_objs
-                    simp: valid_obj_def is_tcb tcb_ntfn_is_bound_def
+                    simp: valid_obj_def is_tcb tcb_ntfn_is_bound_def invs_psp_aligned invs_distinct
                           valid_tcb_def valid_bound_ntfn_def valid_ntfn_def
                    split: option.splits)
   apply (clarsimp dest!: obj_at_valid_objs' bound_tcb_at_state_refs_ofD' invs_valid_objs'
-                   simp: projectKOs valid_obj'_def valid_tcb'_def valid_bound_ntfn'_def
+                   simp: valid_obj'_def valid_tcb'_def valid_bound_ntfn'_def
                          tcb_ntfn_is_bound'_def valid_ntfn'_def
                   split: option.splits)
   done
@@ -4066,7 +3473,7 @@ lemma fast_finaliseCap_corres:
        apply (wp abs_typ_at_lifts unbind_maybe_notification_invs typ_at_lifts hoare_drop_imps getNotification_wp
             | wpc)+
    apply (clarsimp simp: valid_cap_def)
-  apply (clarsimp simp: valid_cap'_def projectKOs valid_obj'_def
+  apply (clarsimp simp: valid_cap'_def valid_obj'_def
                  dest!: invs_valid_objs' obj_at_valid_objs' )
   done
 
@@ -4133,7 +3540,7 @@ lemma finaliseCap_corres:
      \<Longrightarrow> corres (\<lambda>x y. cap_relation (fst x) (fst y) \<and> cap_relation (snd x) (snd y))
            (\<lambda>s. einvs s \<and> s \<turnstile> cap \<and> (final_matters cap \<longrightarrow> final = is_final_cap' cap s)
                        \<and> cte_wp_at ((=) cap) sl s)
-           (\<lambda>s. invs' s \<and> s \<turnstile>' cap' \<and> sch_act_simple s \<and>
+           (\<lambda>s. invs' s \<and> s \<turnstile>' cap' \<and>
                  (final_matters' cap' \<longrightarrow>
                       final' = isFinal cap' (cte_map sl) (cteCaps_of s)))
            (finalise_cap cap final) (finaliseCap cap' final' flag)"
@@ -4169,12 +3576,12 @@ lemma finaliseCap_corres:
        apply (rule corres_split[OF unbindNotification_corres])
          apply (rule corres_split[OF suspend_corres])
             apply (clarsimp simp: liftM_def[symmetric] o_def dc_def[symmetric] zbits_map_def)
-          apply (rule ARM_HYP.prepareThreadDelete_corres, rule refl) (* FIXME arch-split: interface *)
-        apply (wp unbind_notification_invs unbind_notification_simple_sched_action
-                  delete_one_conc_fr.suspend_objs')+
+          apply (rule RISCV64.prepareThreadDelete_corres, rule refl) (* FIXME arch-split: interface *)
+        apply (wp unbind_notification_invs unbind_notification_simple_sched_action)+
       apply (simp add: valid_cap_def)
      apply (simp add: valid_cap'_def)
-    apply (simp add: final_matters'_def liftM_def[symmetric] o_def dc_def[symmetric])
+    apply (simp add: final_matters'_def liftM_def[symmetric]
+                     o_def dc_def[symmetric])
     apply (intro impI, rule corres_guard_imp)
       apply (rule deletingIRQHandler_corres)
      apply simp
@@ -4190,66 +3597,19 @@ lemma finaliseCap_corres:
   done
 
 context begin interpretation Arch . (*FIXME: arch-split*)
-lemma arch_recycleCap_improve_cases:
-   "\<lbrakk> \<not> isPageCap cap; \<not> isPageTableCap cap; \<not> isPageDirectoryCap cap;\<not> isVCPUCap cap;
-         \<not> isASIDControlCap cap; \<not>isSGISignalCap cap \<rbrakk> \<Longrightarrow>
-  (if isASIDPoolCap cap then v else undefined) = v"
-  by (cases cap, simp_all add: isCap_simps)
-
-crunch copyGlobalMappings
-  for ifunsafe'[wp]: "if_unsafe_then_cap'"
-  (wp: crunch_wps ignore: storePDE)
-
-lemma copyGlobalMappings_pde_mappings2':
-  "\<lbrace>valid_pde_mappings' and valid_arch_state'
-            and K (is_aligned pd pdBits)\<rbrace>
-      copyGlobalMappings pd \<lbrace>\<lambda>rv. valid_pde_mappings'\<rbrace>"
-  apply (wp copyGlobalMappings_pde_mappings')
-  apply (clarsimp simp: valid_arch_state'_def page_directory_at'_def)
-  done
-
-crunch copyGlobalMappings
-  for pred_tcb_at'[wp]: "pred_tcb_at' proj P t"
-  (wp: crunch_wps ignore: storePDE)
-
-crunch copyGlobalMappings
-  for vms'[wp]: "valid_machine_state'"
-  (wp: crunch_wps ignore: storePDE)
-
-crunch copyGlobalMappings
-  for ct_not_inQ[wp]: "ct_not_inQ"
-  (wp: crunch_wps ignore: storePDE)
-
-crunch copyGlobalMappings
-  for tcb_in_cur_domain'[wp]: "tcb_in_cur_domain' t"
-  (wp: crunch_wps)
-
-crunch copyGlobalMappings
-  for ct__in_cur_domain'[wp]: ct_idle_or_in_cur_domain'
-  (wp: crunch_wps)
-
-crunch copyGlobalMappings
-  for gsUntypedZeroRanges[wp]: "\<lambda>s. P (gsUntypedZeroRanges s)"
-  (wp: crunch_wps)
 
 lemma threadSet_ct_idle_or_in_cur_domain':
   "\<lbrace>ct_idle_or_in_cur_domain' and (\<lambda>s. \<forall>tcb. tcbDomain tcb = ksCurDomain s \<longrightarrow> tcbDomain (F tcb) = ksCurDomain s)\<rbrace>
     threadSet F t
    \<lbrace>\<lambda>_. ct_idle_or_in_cur_domain'\<rbrace>"
-apply (simp add: ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def)
-apply (wp hoare_vcg_disj_lift hoare_vcg_imp_lift)
-  apply wps
-  apply wp
- apply wps
- apply wp
-apply (auto simp: obj_at'_def)
-done
-
-crunch invalidateTLBByASID
-  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-crunch invalidateTLBByASID
-  for valid_arch_state'[wp]: "valid_arch_state'"
-lemmas invalidateTLBByASID_typ_ats[wp] = typ_at_lifts [OF invalidateTLBByASID_typ_at']
+  apply (simp add: ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def)
+  apply (wp hoare_vcg_disj_lift hoare_vcg_imp_lift)
+    apply wps
+    apply wp
+   apply wps
+   apply wp
+  apply (auto simp: obj_at'_def)
+  done
 
 lemma cte_wp_at_norm_eq':
   "cte_wp_at' P p s = (\<exists>cte. cte_wp_at' ((=) cte) p s \<and> P cte)"
@@ -4294,13 +3654,6 @@ lemma isFinal_lift:
             valid_cte_at_neg_typ' [OF y])
   done
 
-crunch invalidateTLBByASID
-  for cteCaps_of: "\<lambda>s. P (cteCaps_of s)"
-
-lemma cteCaps_of_ctes_of_lift:
-  "(\<And>P. \<lbrace>\<lambda>s. P (ctes_of s)\<rbrace> f \<lbrace>\<lambda>_ s. P (ctes_of s)\<rbrace>) \<Longrightarrow> \<lbrace>\<lambda>s. P (cteCaps_of s) \<rbrace> f \<lbrace>\<lambda>_ s. P (cteCaps_of s)\<rbrace>"
-  unfolding cteCaps_of_def .
-
 lemmas final_matters'_simps = final_matters'_def [split_simps capability.split arch_capability.split]
 
 crunch deleteCallerCap
@@ -4316,9 +3669,6 @@ crunch deleteCallerCap
   for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
   (wp: crunch_wps)
 lemmas deleteCallerCap_typ_ats[wp] = typ_at_lifts [OF deleteCallerCap_typ_at']
-
-crunch emptySlot
-  for ksQ[wp]: "\<lambda>s. P (ksReadyQueues s p)"
 
 lemma setEndpoint_sch_act_not_ct[wp]:
   "\<lbrace>\<lambda>s. sch_act_not (ksCurThread s) s\<rbrace>

--- a/proof/refine/RISCV64/ArchFinalise_R.thy
+++ b/proof/refine/RISCV64/ArchFinalise_R.thy
@@ -860,13 +860,9 @@ lemma archThreadSet_tcbSchedPrevNext[wp]:
   apply auto
   done
 
-context notes if_cong[cong] begin
-
 crunch asUser
   for tcbSchedPrevNext[wp]: "obj_at' (\<lambda>tcb. P (tcbSchedNext tcb) (tcbSchedPrev tcb)) t"
-  (wp: threadGet_wp)
-
-end
+  (wp: threadGet_wp cong: if_cong)
 
 crunch prepareThreadDelete
   for tcbSchedPrevNext[wp]: "obj_at' (\<lambda>tcb. P (tcbSchedNext tcb) (tcbSchedPrev tcb)) t"
@@ -1138,14 +1134,11 @@ crunch unmapPageTable
   (wp: crunch_wps getObject_inv hoare_vcg_all_lift hoare_vcg_if_lift3
    simp: loadObject_default_def updateObject_default_def)
 
-context notes if_cong[cong] begin
-
 crunch Arch_finaliseCap
   for nosch[wp]: "\<lambda>s. P (ksSchedulerAction s)"
   (wp: crunch_wps getObject_inv simp: loadObject_default_def updateObject_default_def
-   rule: RISCV64_H.finaliseCap_def)
-
-end
+   rule: RISCV64_H.finaliseCap_def
+   cong: if_cong)
 
 crunch deletingIRQHandler, finaliseCap
   for sch_act_simple[wp]: sch_act_simple

--- a/proof/refine/RISCV64/ArchIpcCancel_R.thy
+++ b/proof/refine/RISCV64/ArchIpcCancel_R.thy
@@ -71,7 +71,7 @@ proof -
               corres: getObject_TCB_corres setObject_update_TCB_corres')
 qed
 
-lemma prepareThreadDelete_corres[corres]:
+lemma prepareThreadDelete_corres[IpcCancel_R_assms, corres]:
   "t' = t \<Longrightarrow>
    corres dc (invs and tcb_at t) no_0_obj'
           (prepare_thread_delete t) (prepareThreadDelete t')"

--- a/proof/refine/RISCV64/ArchMachine_R.thy
+++ b/proof/refine/RISCV64/ArchMachine_R.thy
@@ -51,10 +51,8 @@ lemma dmo_maskInterrupt_True:
                    ct_not_inQ_def ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def)
   done
 
-lemma setIRQState_irq_states':
-  "\<lbrace>valid_irq_states'\<rbrace>
-      setIRQState state irq
-   \<lbrace>\<lambda>rv. valid_irq_states'\<rbrace>"
+lemma setIRQState_irq_states'[Machine_R_assms, wp]:
+  "setIRQState state irq \<lbrace>valid_irq_states'\<rbrace>"
   apply (simp add: setIRQState_def setInterruptState_def getInterruptState_def)
   apply (wp dmo_maskInterrupt)
   apply (simp add: valid_irq_masks'_def)

--- a/proof/refine/RISCV64/ArchTcbAcc_R.thy
+++ b/proof/refine/RISCV64/ArchTcbAcc_R.thy
@@ -971,15 +971,7 @@ lemma setThreadState_state_hyp_refs_of'[TcbAcc_R_2_assms, wp]:
         | wp threadSet_state_hyp_refs_of')+
   done
 
-lemma setBoundNotification_state_refs_of'[wp]:
-  "\<lbrace>\<lambda>s. P ((state_refs_of' s) (t := tcb_bound_refs' ntfn
-                                 \<union> {r \<in> state_refs_of' s t. snd r \<noteq> TCBBound}))\<rbrace>
-     setBoundNotification ntfn t
-   \<lbrace>\<lambda>rv s. P (state_refs_of' s)\<rbrace>"
-  by (simp add: setBoundNotification_def Un_commute fun_upd_def
-        | wp threadSet_state_refs_of' )+
-
-lemma setBoundNotification_state_hyp_refs_of'[wp]:
+lemma setBoundNotification_state_hyp_refs_of'[TcbAcc_R_2_assms, wp]:
   "\<lbrace>\<lambda>s. P (state_hyp_refs_of' s)\<rbrace>
      setBoundNotification ntfn t
    \<lbrace>\<lambda>rv s. P (state_hyp_refs_of' s)\<rbrace>"
@@ -1004,7 +996,7 @@ lemma tcbQueued_update_iflive'[TcbAcc_R_2_assms, wp]:
    \<lbrace>\<lambda>_. if_live_then_nonz_cap'\<rbrace>"
   by (wpsimp wp: threadSet_iflive'T simp: update_tcb_cte_cases)
 
-lemma sbn_iflive'[wp]:
+lemma sbn_iflive'[TcbAcc_R_2_assms, wp]:
   "\<lbrace>\<lambda>s. if_live_then_nonz_cap' s
       \<and> (bound ntfn \<longrightarrow> ex_nonz_cap_to' t s)\<rbrace>
    setBoundNotification ntfn t

--- a/proof/refine/RISCV64/Arch_R.thy
+++ b/proof/refine/RISCV64/Arch_R.thy
@@ -686,7 +686,7 @@ lemma decodeX64PageTableInvocation_corres:
                                  in corres_gen_asm2)
         apply (rule corres_split[OF isFinalCapability_corres[where ptr=slot]])
           apply (drule mp)
-           apply (clarsimp simp: isCap_simps final_matters'_def)
+           apply (clarsimp simp: isCap_simps final_matters'_def arch_final_matters'_def)
           apply (rule whenE_throwError_corres; simp)
           apply (rule option_corres)
             apply (cases opt; simp add: mdata_map_def)
@@ -1233,10 +1233,6 @@ lemma performASIDControlInvocation_st_tcb_at':
        apply simp
   apply auto
   done
-
-lemmas arch_finalise_cap_aligned' = ArchRetypeDecls_H_RISCV64_H_finaliseCap_aligned'
-
-lemmas arch_finalise_cap_distinct' = ArchRetypeDecls_H_RISCV64_H_finaliseCap_distinct'
 
 crunch "Arch.finaliseCap"
   for st_tcb_at'[wp]: "st_tcb_at' P t"

--- a/proof/refine/RISCV64/Arch_R.thy
+++ b/proof/refine/RISCV64/Arch_R.thy
@@ -9,7 +9,7 @@
 *)
 
 theory Arch_R
-imports Untyped_R Finalise_R
+imports Untyped_R ArchFinalise_R
 begin
 
 unbundle l4v_word_context

--- a/proof/refine/RISCV64/CNodeInv_R.thy
+++ b/proof/refine/RISCV64/CNodeInv_R.thy
@@ -322,7 +322,7 @@ lemma decodeCNodeInvocation_corres:
                  apply (intro conjI)
                   apply (erule cap_map_update_data)+
                 apply (wp hoare_drop_imps)+
-          apply simp
+          apply (simp cong: if_cong)
           apply (wp lsfco_cte_at' lookup_cap_valid lookup_cap_valid')
          apply (simp add: if_apply_def2)
          apply (wp hoare_drop_imps)
@@ -6244,7 +6244,7 @@ proof (induct arbitrary: P p rule: finalise_spec_induct2)
        apply (erule disjE[where P="F \<and> G" for F G])
         apply (clarsimp simp: capRemovable_def cte_wp_at_ctes_of)
         apply (rule conjI, clarsimp)
-        apply (case_tac b; case_tac "cteCap rv"; simp add: post_cap_delete_pre'_def)
+        apply (case_tac b; case_tac "cteCap rv"; simp add: arch_cap_has_cleanup'_def post_cap_delete_pre'_def)
          apply (clarsimp simp: final_IRQHandler_no_copy)
          apply (drule (1) ctes_of_valid'[OF _ invs_valid_objs'])
          apply (clarsimp simp: valid_cap'_def)

--- a/proof/refine/RISCV64/EmptyFail_H.thy
+++ b/proof/refine/RISCV64/EmptyFail_H.thy
@@ -98,8 +98,7 @@ lemma constOnFailure_empty_fail[intro!, wp, simp]:
 lemma ArchRetypeDecls_H_deriveCap_empty_fail[intro!, wp, simp]:
   "isPageTableCap y \<or> isFrameCap y \<or> isASIDControlCap y \<or> isASIDPoolCap y
    \<Longrightarrow> empty_fail (Arch.deriveCap x y)"
-  apply (simp add: RISCV64_H.deriveCap_def)
-  by (auto simp: isCap_simps)
+  by (auto simp: isCap_simps RISCV64_H.deriveCap_def cong: if_cong)
 
 crunch ensureNoChildren
   for (empty_fail) empty_fail[intro!, wp, simp]
@@ -270,6 +269,7 @@ crunch
 
 lemma ThreadDecls_H_schedule_empty_fail[intro!, wp, simp]:
   "empty_fail schedule"
+  supply if_cong[cong]
   apply (simp add: schedule_def)
   apply (clarsimp simp: scheduleChooseNewThread_def split: if_split | wp | wpc)+
   done

--- a/proof/refine/RISCV64/Interrupt_R.thy
+++ b/proof/refine/RISCV64/Interrupt_R.thy
@@ -635,6 +635,7 @@ lemma timerTick_corres:
   "corres dc
      (cur_tcb and valid_sched and pspace_aligned and pspace_distinct) invs'
      timer_tick timerTick"
+  supply if_cong[cong]
   apply (simp add: timerTick_def timer_tick_def)
   apply (simp add: thread_state_case_if threadState_case_if)
   apply (rule_tac Q="cur_tcb and valid_sched and pspace_aligned and pspace_distinct"

--- a/proof/refine/RISCV64/Ipc_R.thy
+++ b/proof/refine/RISCV64/Ipc_R.thy
@@ -5,7 +5,7 @@
  *)
 
 theory Ipc_R
-imports Finalise_R
+imports ArchFinalise_R
 begin
 
 context begin interpretation Arch . (*FIXME: arch-split*)

--- a/proof/refine/RISCV64/Ipc_R.thy
+++ b/proof/refine/RISCV64/Ipc_R.thy
@@ -635,6 +635,7 @@ lemma cteInsert_weak_cte_wp_at2:
     "\<lbrace>\<lambda>s. if p = dest then P cap else cte_wp_at' (\<lambda>c. P (cteCap c)) p s\<rbrace>
      cteInsert cap src dest
      \<lbrace>\<lambda>uu. cte_wp_at' (\<lambda>c. P (cteCap c)) p\<rbrace>"
+  supply if_cong[cong]
   apply (rule hoare_pre)
    apply (rule hoare_use_eq_irq_node' [OF cteInsert_ksInterruptState])
    apply (clarsimp simp:cteInsert_def)
@@ -1463,6 +1464,7 @@ lemma doNormalTransfer_corres:
    and case_option \<top> valid_ipc_buffer_ptr' recv_buf)
   (do_normal_transfer sender send_buf ep badge can_grant receiver recv_buf)
   (doNormalTransfer sender send_buf ep badge can_grant receiver recv_buf)"
+  supply if_cong[cong]
   apply (simp add: do_normal_transfer_def doNormalTransfer_def)
   apply (rule corres_guard_imp)
     apply (rule corres_split_mapr[OF getMessageInfo_corres])
@@ -2640,6 +2642,7 @@ lemma valid_sched_weak_strg:
 lemma sendSignal_corres:
   "corres dc (einvs and ntfn_at ep) (invs' and ntfn_at' ep)
              (send_signal ep bg) (sendSignal ep bg)"
+  supply if_cong[cong]
   apply (simp add: send_signal_def sendSignal_def Let_def)
   apply (rule corres_guard_imp)
     apply (rule corres_split[OF getNotification_corres,
@@ -3606,6 +3609,7 @@ lemma cteInsert_cap_to':
   "\<lbrace>ex_nonz_cap_to' p and cte_wp_at' (\<lambda>c. cteCap c = NullCap) dest\<rbrace>
      cteInsert cap src dest
    \<lbrace>\<lambda>rv. ex_nonz_cap_to' p\<rbrace>"
+  supply if_cong[cong]
   apply (simp add: cteInsert_def ex_nonz_cap_to'_def updateCap_def setUntypedCapAsFull_def)
   apply (wpsimp wp: updateMDB_weak_cte_wp_at setCTE_weak_cte_wp_at hoare_vcg_ex_lift
          | rule hoare_drop_imps
@@ -4054,6 +4058,7 @@ lemma si_invs'[wp]:
   sendIPC bl call ba cg cgr t ep
   \<lbrace>\<lambda>rv. invs'\<rbrace>"
   supply if_split[split del]
+  supply if_cong[cong]
   apply (simp add: sendIPC_def)
   apply (rule bind_wp [OF _ get_ep_sp'])
   apply (case_tac epa)

--- a/proof/refine/RISCV64/Syscall_R.thy
+++ b/proof/refine/RISCV64/Syscall_R.thy
@@ -670,6 +670,7 @@ lemma pinv_tcb'[wp]:
 
 lemma sts_cte_at[wp]:
   "\<lbrace>cte_at' p\<rbrace> setThreadState st t \<lbrace>\<lambda>rv. cte_at' p\<rbrace>"
+  supply if_cong[cong]
   apply (simp add: setThreadState_def)
   apply (wp|simp)+
   done
@@ -683,6 +684,7 @@ lemma sts_mcpriority_tcb_at'[wp]:
   "\<lbrace>mcpriority_tcb_at' P t\<rbrace>
     setThreadState st t'
    \<lbrace>\<lambda>_. mcpriority_tcb_at' P t\<rbrace>"
+  supply if_cong[cong]
   apply (cases "t = t'",
          simp_all add: setThreadState_def
                   split del: if_split)
@@ -754,6 +756,7 @@ lemma decodeDomainSetStart_inv_wf[wp]:
 lemma decodeDomainConfigure_inv_wf[wp]:
   "\<lbrace>\<top>\<rbrace> decodeDomainConfigure args excaps \<lbrace>valid_domain_inv'\<rbrace>, -"
   unfolding decodeDomainConfigure_def
+  supply if_cong[cong]
   apply (wpsimp simp: valid_domain_inv'_def split_del: if_split)
   apply (clarsimp simp: not_less not_le le_maxDomain_eq_less_numDomains unat_ucast)
   using numDomains_fits_domainBits

--- a/proof/refine/RISCV64/Tcb_R.thy
+++ b/proof/refine/RISCV64/Tcb_R.thy
@@ -927,6 +927,7 @@ lemma checked_insert_tcb_invs'[wp]:
       (checkCapAt (ThreadCap target) slot'
        (assertDerived src_slot new_cap (cteInsert new_cap src_slot slot))) \<lbrace>\<lambda>rv. invs'\<rbrace>"
   supply option.case_cong[cong]
+  supply if_cong[cong]
   apply (simp add: checkCapAt_def liftM_def assertDerived_def stateAssert_def)
   apply (wp getCTE_cteCap_wp cteInsert_invs)
   apply (clarsimp split: option.splits)

--- a/proof/refine/RISCV64/orphanage/Orphanage.thy
+++ b/proof/refine/RISCV64/orphanage/Orphanage.thy
@@ -478,6 +478,7 @@ lemma setThreadState_not_is_active_thread_state_no_orphans:
    setThreadState state tcb_ptr
    \<lbrace>\<lambda>_ . no_orphans\<rbrace>"
   unfolding setThreadState_def
+  supply if_cong[cong]
   apply (wpsimp wp: ssa_no_orphans)
    apply (unfold no_orphans_disj almost_no_orphans_disj)
    apply (wp hoare_vcg_all_lift hoare_vcg_disj_lift threadSet_pred_tcb_at_state
@@ -498,6 +499,7 @@ lemma setThreadState_almost_no_orphans [wp]:
 lemma setThreadState_not_active_no_orphans:
   "\<not> is_active_thread_state state \<Longrightarrow> setThreadState state tcb_ptr \<lbrace>no_orphans\<rbrace>"
   unfolding setThreadState_def
+  supply if_cong[cong]
   apply (wpsimp wp: ssa_no_orphans)
    apply (unfold no_orphans_disj)
    apply (wp hoare_vcg_all_lift hoare_vcg_disj_lift threadSet_pred_tcb_at_state
@@ -508,6 +510,7 @@ lemma setThreadState_not_active_no_orphans:
 lemma setThreadState_not_active_almost_no_orphans:
   "\<not> is_active_thread_state state \<Longrightarrow> setThreadState state tcb_ptr \<lbrace>almost_no_orphans thread\<rbrace>"
   unfolding setThreadState_def
+  supply if_cong[cong]
   apply (wpsimp wp: ssa_no_orphans)
    apply (unfold almost_no_orphans_disj)
    apply (wp hoare_vcg_all_lift hoare_vcg_disj_lift threadSet_pred_tcb_at_state
@@ -571,6 +574,7 @@ lemma tcbSchedDequeue_no_orphans[wp]:
    \<lbrace>\<lambda>_. no_orphans\<rbrace>"
   supply disj_not1[simp del]
   unfolding no_orphans_disj almost_no_orphans_disj
+  supply if_cong[cong]
   apply (rule hoare_allI)
   apply (rename_tac tcb_ptr)
   apply (case_tac "tcb_ptr = tcbPtr")
@@ -705,6 +709,7 @@ lemma chooseThread_no_orphans [wp]:
   (is "\<lbrace>?PRE\<rbrace> _ \<lbrace>_\<rbrace>")
   unfolding chooseThread_def Let_def
   supply if_split[split del]
+  supply if_cong[cong]
   apply (simp only: return_bind, simp)
   apply (intro bind_wp[OF _ stateAssert_sp])
   apply (rule bind_wp[where Q'="\<lambda>rv s. ?PRE s \<and> ksReadyQueues_asrt s \<and> ready_qs_runnable s
@@ -1321,7 +1326,7 @@ lemma unbindNotification_no_orphans[wp]:
   "\<lbrace>\<lambda>s. no_orphans s\<rbrace>
     unbindNotification t
    \<lbrace> \<lambda>rv s. no_orphans s\<rbrace>"
-  unfolding unbindNotification_def
+  unfolding unbindNotification_def doUnbindNotification_def
   apply (rule bind_wp[OF _ gbn_sp'])
   apply (case_tac ntfnPtr, simp_all, wp, simp)
   apply (rule bind_wp[OF _ get_ntfn_sp'])
@@ -1332,7 +1337,7 @@ lemma unbindMaybeNotification_no_orphans[wp]:
   "\<lbrace>\<lambda>s. no_orphans s\<rbrace>
     unbindMaybeNotification a
    \<lbrace> \<lambda>rv s. no_orphans s\<rbrace>"
-  unfolding unbindMaybeNotification_def
+  unfolding unbindMaybeNotification_def doUnbindNotification_def
   by (wp getNotification_wp | simp | wpc)+
 
 lemma finaliseCapTrue_standin_no_orphans[wp]:

--- a/proof/refine/TcbAcc_R.thy
+++ b/proof/refine/TcbAcc_R.thy
@@ -2114,7 +2114,24 @@ locale TcbAcc_R_2 = TcbAcc_R +
     "\<And>F tcb s.
      tcb_hyp_refs' (tcbArch (F tcb)) = tcb_hyp_refs' (tcbArch tcb)
      \<Longrightarrow> valid_arch_tcb' (tcbArch (F tcb)) s = valid_arch_tcb' (tcbArch tcb) s"
+  assumes setBoundNotification_state_hyp_refs_of'[wp]:
+    "\<And>ntfn t P. setBoundNotification ntfn t \<lbrace>\<lambda>s. P (state_hyp_refs_of' s)\<rbrace>"
+  assumes sbn_iflive'[wp]:
+    "\<And>ntfn t.
+     \<lbrace>\<lambda>s. if_live_then_nonz_cap' s
+          \<and> (bound ntfn \<longrightarrow> ex_nonz_cap_to' t s)\<rbrace>
+     setBoundNotification ntfn t
+     \<lbrace>\<lambda>_. if_live_then_nonz_cap'\<rbrace>"
 begin
+
+lemma setBoundNotification_state_refs_of'[wp]:
+  "\<lbrace>\<lambda>s. P ((state_refs_of' s) (t := tcb_bound_refs' ntfn
+                               \<union> {r \<in> state_refs_of' s t. snd r \<noteq> TCBBound}))\<rbrace>
+   setBoundNotification ntfn t
+   \<lbrace>\<lambda>rv s. P (state_refs_of' s)\<rbrace>"
+  unfolding setBoundNotification_def
+  by (simp add: Un_commute
+      | wpsimp simp: fun_upd_def wp: threadSet_state_refs_of')+
 
 crunch setQueue, tcbQueuePrepend, tcbQueueRemove, removeFromBitmap
   for ghost_relation_wrapper[wp]: "ghost_relation_wrapper t"

--- a/proof/refine/X64/ArchFinalise_R.thy
+++ b/proof/refine/X64/ArchFinalise_R.thy
@@ -4,12 +4,11 @@
  * SPDX-License-Identifier: GPL-2.0-only
  *)
 
-theory Finalise_R
+theory ArchFinalise_R
 imports
-  ArchIpcCancel_R
-  InterruptAcc_R
-  ArchRetype_R
+  Finalise_R
 begin
+
 context begin interpretation Arch . (*FIXME: arch-split*)
 
 declare doUnbindNotification_def[simp]

--- a/proof/refine/X64/ArchFinalise_R.thy
+++ b/proof/refine/X64/ArchFinalise_R.thy
@@ -1,5 +1,6 @@
 (*
  * Copyright 2014, General Dynamics C4 Systems
+ * Copyright 2023, Proofcraft Pty Ltd
  *
  * SPDX-License-Identifier: GPL-2.0-only
  *)
@@ -9,476 +10,120 @@ imports
   Finalise_R
 begin
 
-context begin interpretation Arch . (*FIXME: arch-split*)
+context Arch begin arch_global_naming
 
-declare doUnbindNotification_def[simp]
+named_theorems Finalise_R_assms
 
-text \<open>Properties about empty_slot/emptySlot\<close>
+lemma arch_postCapDeletion_ksArchState_lift[Finalise_R_assms]:
+  "\<lbrakk>\<And>s as. P (s\<lparr>ksArchState := as\<rparr>) = P s\<rbrakk> \<Longrightarrow> Arch.postCapDeletion ac \<lbrace>P\<rbrace>"
+  unfolding postCapDeletion_def freeIOPortRange_def setIOPortMask_def
+  by wpsimp
 
-lemma case_Null_If:
-  "(case c of NullCap \<Rightarrow> a | _ \<Rightarrow> b) = (if c = NullCap then a else b)"
-  by (case_tac c, simp_all)
+lemmas clearUntypedFreeIndex_typ_ats[wp] = typ_at_lifts[OF clearUntypedFreeIndex_typ_at']
 
-crunch emptySlot
+crunch setIRQState
+  for umm[Finalise_R_assms, wp]: "\<lambda>s. P (underlying_memory (ksMachineState s))"
+  (wp: dmo_lift')
+
+lemma setIOPortMask_valid_arch'[wp]:
+  "\<lbrace>valid_arch_state'\<rbrace> setIOPortMask f l b \<lbrace>\<lambda>rv. valid_arch_state'\<rbrace>"
+  by (wpsimp simp: valid_arch_state'_def setIOPortMask_def)
+
+lemma freeIOPortRange_valid_global_refs[wp]:
+  "\<lbrace>valid_global_refs'\<rbrace> freeIOPortRange f l \<lbrace>\<lambda>rv. valid_global_refs'\<rbrace>"
+  unfolding freeIOPortRange_def setIOPortMask_def
+  by wpsimp
+     (clarsimp simp: valid_global_refs'_def global_refs'_def table_refs'_def bit_simps)
+
+(* better crunch names for Arch.postCapDeletion *)
+abbreviation (input)
+  "Arch_postCapDeletion \<equiv> Arch.postCapDeletion"
+
+crunch Arch_postCapDeletion
+  for valid_global_refs[wp]: valid_global_refs'
+  and valid_arch_state'[wp]: valid_arch_state'
+  (rule: X64_H.postCapDeletion_def)
+
+crunch freeIOPortRange, setIOPortMask
   for aligned'[wp]: pspace_aligned'
   and pspace_canonical'[wp]: pspace_canonical'
   and pspace_in_kernel_mappings'[wp]: pspace_in_kernel_mappings'
   and distinct'[wp]: pspace_distinct'
-  (simp: case_Null_If)
 
-lemma updateCap_cte_wp_at_cases:
-  "\<lbrace>\<lambda>s. (ptr = ptr' \<longrightarrow> cte_wp_at' (P \<circ> cteCap_update (K cap)) ptr' s) \<and> (ptr \<noteq> ptr' \<longrightarrow> cte_wp_at' P ptr' s)\<rbrace>
-     updateCap ptr cap
-   \<lbrace>\<lambda>rv. cte_wp_at' P ptr'\<rbrace>"
-  apply (clarsimp simp: valid_def)
-  apply (drule updateCap_stuff)
-  apply (clarsimp simp: cte_wp_at_ctes_of modify_map_def)
+lemma corres_gets_allocated_io_ports [corres]:
+  "corres (=) \<top> \<top>
+        (gets (x64_allocated_io_ports \<circ> arch_state))
+        (gets (x64KSAllocatedIOPorts \<circ> ksArchState))"
+  by (simp add: state_relation_def arch_state_relation_def)
+
+lemma set_ioport_mask_corres[corres]:
+  "corres dc \<top> \<top>
+     (set_ioport_mask f l b)
+     (setIOPortMask f l b)"
+  apply (clarsimp simp: set_ioport_mask_def setIOPortMask_def)
+  apply (rule corres_guard_imp)
+    apply (rule corres_split_eqr[OF corres_gets_allocated_io_ports])
+      apply (rule corres_modify)
+      apply (clarsimp simp: state_relation_def arch_state_relation_def foldl_map
+                            foldl_fun_upd)
+     apply wpsimp+
   done
 
-crunch postCapDeletion, updateTrackedFreeIndex
-  for cte_wp_at'[wp]: "cte_wp_at' P p"
-
-lemma updateFreeIndex_cte_wp_at:
-  "\<lbrace>\<lambda>s. cte_at' p s \<and> P (cte_wp_at' (if p = p' then P'
-      o (cteCap_update (capFreeIndex_update (K idx))) else P') p' s)\<rbrace>
-    updateFreeIndex p idx
-  \<lbrace>\<lambda>rv s. P (cte_wp_at' P' p' s)\<rbrace>"
-  apply (simp add: updateFreeIndex_def updateTrackedFreeIndex_def
-        split del: if_split)
-  apply (rule hoare_pre)
-   apply (wp updateCap_cte_wp_at' getSlotCap_wp)
-  apply (clarsimp simp: cte_wp_at_ctes_of)
-  apply (cases "p' = p", simp_all)
-  apply (case_tac cte, simp)
+lemma arch_postCapDeletion_corres[Finalise_R_assms]:
+  "acap_relation cap cap' \<Longrightarrow> corres dc \<top> \<top> (arch_post_cap_deletion cap) (X64_H.postCapDeletion cap')"
+  apply (clarsimp simp: arch_post_cap_deletion_def X64_H.postCapDeletion_def)
+  apply (rule corres_guard_imp)
+    apply (case_tac cap; clarsimp simp: acap_relation_def)
+    apply (clarsimp simp: free_ioport_range_def freeIOPortRange_def)
+    apply (rule set_ioport_mask_corres)
+   apply clarsimp+
   done
 
-lemma emptySlot_cte_wp_cap_other:
-  "\<lbrace>(\<lambda>s. cte_wp_at' (\<lambda>c. P (cteCap c)) p s) and K (p \<noteq> p')\<rbrace>
-  emptySlot p' opt
-  \<lbrace>\<lambda>rv s. cte_wp_at' (\<lambda>c. P (cteCap c)) p s\<rbrace>"
-  apply (rule hoare_gen_asm)
-  apply (simp add: emptySlot_def clearUntypedFreeIndex_def getSlotCap_def)
-  apply (rule hoare_pre)
-   apply (wp updateMDB_weak_cte_wp_at updateCap_cte_wp_at_cases
-             updateFreeIndex_cte_wp_at getCTE_wp' hoare_vcg_all_lift
-              | simp add:  | wpc
-              | wp (once) hoare_drop_imps)+
-  done
+(* better crunch names for Arch.finaliseCap *)
+abbreviation (input)
+  "Arch_finaliseCap \<equiv> Arch.finaliseCap"
 
-crunch emptySlot
-  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-lemmas clearUntypedFreeIndex_typ_ats[wp]
-    = typ_at_lifts[OF clearUntypedFreeIndex_typ_at']
+crunch Arch_finaliseCap, prepareThreadDelete
+  for typ_at'[Finalise_R_assms, wp]: "\<lambda>s. P (typ_at' T p s)"
+  and aligned'[Finalise_R_assms, wp]: "pspace_aligned'"
+  and distinct'[Finalise_R_assms, wp]: "pspace_distinct'"
+  (wp: crunch_wps getObject_inv loadObject_default_inv
+   simp: crunch_simps unless_def o_def
+   ignore_del: setObject
+   rule: X64_H.finaliseCap_def)
 
-crunch postCapDeletion
-  for tcb_at'[wp]: "tcb_at' t"
-crunch emptySlot
-  for ct[wp]: "\<lambda>s. P (ksCurThread s)"
-crunch clearUntypedFreeIndex
-  for cur_tcb'[wp]: "cur_tcb'"
-  (wp: cur_tcb_lift)
+crunch prepareThreadDelete, Arch_finaliseCap
+  for it'[Finalise_R_assms, wp]: "\<lambda>s. P (ksIdleThread s)"
+  (wp: hoare_drop_imps
+   simp: crunch_simps updateObject_default_def
+   rule: X64_H.finaliseCap_def)
 
-crunch emptySlot
-  for ksRQ[wp]: "\<lambda>s. P (ksReadyQueues s)"
-crunch emptySlot
-  for ksRQL1[wp]: "\<lambda>s. P (ksReadyQueuesL1Bitmap s)"
-crunch emptySlot
-  for ksRQL2[wp]: "\<lambda>s. P (ksReadyQueuesL2Bitmap s)"
-crunch postCapDeletion
-  for obj_at'[wp]: "obj_at' P p"
+definition
+  arch_final_matters' :: "arch_capability \<Rightarrow> bool" where
+ "arch_final_matters' acap \<equiv> case acap of
+    PageCap ref rghts mt sz d mapdata \<Rightarrow> False
+  | ASIDControlCap \<Rightarrow> False
+  | IOPortControlCap \<Rightarrow> False
+  | _ \<Rightarrow> True"
 
-crunch clearUntypedFreeIndex
-  for inQ[wp]: "\<lambda>s. P (obj_at' (inQ d p) t s)"
-crunch clearUntypedFreeIndex
-  for tcbDomain[wp]: "obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t"
-crunch clearUntypedFreeIndex
-  for tcbPriority[wp]: "obj_at' (\<lambda>tcb. P (tcbPriority tcb)) t"
+definition arch_cap_has_cleanup' :: "arch_capability \<Rightarrow> bool" where
+  "arch_cap_has_cleanup' acap \<equiv> isIOPortCap acap"
 
-crunch emptySlot
-  for nosch[wp]: "\<lambda>s. P (ksSchedulerAction s)"
-crunch emptySlot
-  for ksCurDomain[wp]: "\<lambda>s. P (ksCurDomain s)"
+(* extra constraints on IO ports are not needed since there is no valid_ioports to preserve in
+   Refine *)
+definition
+  "post_cap_delete_pre' cap sl cs \<equiv> case cap
+     of IRQHandlerCap irq \<Rightarrow> irq \<le> maxIRQ \<and> (\<forall>sl'. sl \<noteq> sl' \<longrightarrow> cs sl' \<noteq> Some cap)
+     | ArchObjectCap (IOPortCap f l) \<Rightarrow> f \<le> l \<and> (\<forall>sl'. sl \<noteq> sl' \<longrightarrow> cs sl' \<noteq> Some cap)
+     | _ \<Rightarrow> False"
 
-lemma emptySlot_sch_act_wf [wp]:
-  "\<lbrace>\<lambda>s. sch_act_wf (ksSchedulerAction s) s\<rbrace>
-  emptySlot sl opt
-  \<lbrace>\<lambda>rv s. sch_act_wf (ksSchedulerAction s) s\<rbrace>"
-  apply (simp add: emptySlot_def case_Null_If)
-  apply (wp sch_act_wf_lift tcb_in_cur_domain'_lift | wpcw | simp)+
-  done
+end (* Arch *)
 
-lemma updateCap_valid_objs' [wp]:
-  "\<lbrace>valid_objs' and valid_cap' cap\<rbrace>
-  updateCap ptr cap \<lbrace>\<lambda>r. valid_objs'\<rbrace>"
-  unfolding updateCap_def
-  by (wp setCTE_valid_objs getCTE_wp) (clarsimp dest!: cte_at_cte_wp_atD)
+arch_requalify_consts
+  arch_final_matters'
+  arch_cap_has_cleanup'
 
-lemma updateFreeIndex_valid_objs' [wp]:
-  "\<lbrace>valid_objs'\<rbrace> clearUntypedFreeIndex ptr \<lbrace>\<lambda>r. valid_objs'\<rbrace>"
-  apply (simp add: clearUntypedFreeIndex_def getSlotCap_def)
-  apply (wp getCTE_wp' | wpc | simp add: updateTrackedFreeIndex_def)+
-  done
-
-crunch emptySlot
-  for valid_objs'[wp]: "valid_objs'"
-
-crunch setInterruptState
-  for state_refs_of'[wp]: "\<lambda>s. P (state_refs_of' s)"
-  (simp: state_refs_of'_pspaceI)
-crunch emptySlot
-  for state_refs_of'[wp]: "\<lambda>s. P (state_refs_of' s)"
-  (wp: crunch_wps)
-
-lemma mdb_chunked2D:
-  "\<lbrakk> mdb_chunked m; m \<turnstile> p \<leadsto> p'; m \<turnstile> p' \<leadsto> p'';
-     m p = Some (CTE cap nd); m p'' = Some (CTE cap'' nd'');
-     sameRegionAs cap cap''; p \<noteq> p'' \<rbrakk>
-     \<Longrightarrow> \<exists>cap' nd'. m p' = Some (CTE cap' nd') \<and> sameRegionAs cap cap'"
-  apply (subgoal_tac "\<exists>cap' nd'. m p' = Some (CTE cap' nd')")
-   apply (clarsimp simp add: mdb_chunked_def mdb_chunked_arch_assms_def) (* FIXME arch-split; take AARCH64 version *)
-   apply (drule spec[where x=p])
-   apply (drule spec[where x=p''])
-   apply clarsimp
-   apply (drule mp, erule trancl_into_trancl2)
-    apply (erule trancl.intros(1))
-   apply (simp add: is_chunk_def)
-   apply (drule spec, drule mp, erule trancl.intros(1))
-   apply (drule mp, rule trancl_into_rtrancl)
-    apply (erule trancl.intros(1))
-   apply clarsimp
-  apply (clarsimp simp: mdb_next_unfold)
-  apply (case_tac z, simp)
-  done
-
-lemma nullPointer_eq_0_simp[simp]:
-  "(nullPointer = 0) = True"
-  "(0 = nullPointer) = True"
-  by (simp add: nullPointer_def)+
-
-lemma no_0_no_0_lhs_trancl [simp]:
-  "no_0 m \<Longrightarrow> \<not> m \<turnstile> 0 \<leadsto>\<^sup>+ x"
-  by (rule, drule tranclD, clarsimp simp: next_unfold')
-
-lemma no_0_no_0_lhs_rtrancl [simp]:
-  "\<lbrakk> no_0 m; x \<noteq> 0 \<rbrakk> \<Longrightarrow> \<not> m \<turnstile> 0 \<leadsto>\<^sup>* x"
-  by (clarsimp dest!: rtranclD)
-
-end
-locale mdb_empty =
-  mdb_ptr?: mdb_ptr m _ _ slot s_cap s_node
-    for m slot s_cap s_node +
-
-  fixes n
-  defines "n \<equiv>
-           modify_map
-             (modify_map
-               (modify_map
-                 (modify_map m (mdbPrev s_node)
-                   (cteMDBNode_update (mdbNext_update (%_. (mdbNext s_node)))))
-                 (mdbNext s_node)
-                 (cteMDBNode_update
-                   (\<lambda>mdb. mdbFirstBadged_update (%_. (mdbFirstBadged mdb \<or> mdbFirstBadged s_node))
-                           (mdbPrev_update (%_. (mdbPrev s_node)) mdb))))
-               slot (cteCap_update (%_. capability.NullCap)))
-              slot (cteMDBNode_update (const nullMDBNode))"
-begin
-interpretation Arch . (*FIXME: arch-split*)
-
-lemmas m_slot_prev = m_p_prev
-lemmas m_slot_next = m_p_next
-lemmas prev_slot_next = prev_p_next
-lemmas next_slot_prev = next_p_prev
-
-lemma n_revokable:
-  "n p = Some (CTE cap node) \<Longrightarrow>
-  (\<exists>cap' node'. m p = Some (CTE cap' node') \<and>
-              (if p = slot
-               then \<not> mdbRevocable node
-               else mdbRevocable node = mdbRevocable node'))"
-  by (auto simp add: n_def modify_map_if nullMDBNode_def split: if_split_asm)
-
-lemma m_revokable:
-  "m p = Some (CTE cap node) \<Longrightarrow>
-  (\<exists>cap' node'. n p = Some (CTE cap' node') \<and>
-              (if p = slot
-               then \<not> mdbRevocable node'
-               else mdbRevocable node' = mdbRevocable node))"
-  apply (clarsimp simp add: n_def modify_map_if nullMDBNode_def split: if_split_asm)
-  apply (cases "p=slot", simp)
-  apply (cases "p=mdbNext s_node", simp)
-   apply (cases "p=mdbPrev s_node", simp)
-   apply clarsimp
-  apply simp
-  apply (cases "p=mdbPrev s_node", simp)
-  apply simp
-  done
-
-lemma no_0_n:
-  "no_0 n"
-  using no_0 by (simp add: n_def)
-
-lemma n_next:
-  "n p = Some (CTE cap node) \<Longrightarrow>
-  (\<exists>cap' node'. m p = Some (CTE cap' node') \<and>
-              (if p = slot
-               then mdbNext node = 0
-               else if p = mdbPrev s_node
-               then mdbNext node = mdbNext s_node
-               else mdbNext node = mdbNext node'))"
-  apply (subgoal_tac "p \<noteq> 0")
-   prefer 2
-   apply (insert no_0_n)[1]
-   apply clarsimp
-  apply (cases "p = slot")
-   apply (clarsimp simp: n_def modify_map_if initMDBNode_def split: if_split_asm)
-  apply (cases "p = mdbPrev s_node")
-   apply (auto simp: n_def modify_map_if initMDBNode_def split: if_split_asm)
-  done
-
-lemma n_prev:
-  "n p = Some (CTE cap node) \<Longrightarrow>
-  (\<exists>cap' node'. m p = Some (CTE cap' node') \<and>
-              (if p = slot
-               then mdbPrev node = 0
-               else if p = mdbNext s_node
-               then mdbPrev node = mdbPrev s_node
-               else mdbPrev node = mdbPrev node'))"
-  apply (subgoal_tac "p \<noteq> 0")
-   prefer 2
-   apply (insert no_0_n)[1]
-   apply clarsimp
-  apply (cases "p = slot")
-   apply (clarsimp simp: n_def modify_map_if initMDBNode_def split: if_split_asm)
-  apply (cases "p = mdbNext s_node")
-   apply (auto simp: n_def modify_map_if initMDBNode_def split: if_split_asm)
-  done
-
-lemma n_cap:
-  "n p = Some (CTE cap node) \<Longrightarrow>
-  \<exists>cap' node'. m p = Some (CTE cap' node') \<and>
-              (if p = slot
-               then cap = NullCap
-               else cap' = cap)"
-  apply (clarsimp simp: n_def modify_map_if initMDBNode_def split: if_split_asm)
-   apply (cases node)
-   apply auto
-  done
-
-lemma m_cap:
-  "m p = Some (CTE cap node) \<Longrightarrow>
-  \<exists>cap' node'. n p = Some (CTE cap' node') \<and>
-              (if p = slot
-               then cap' = NullCap
-               else cap' = cap)"
-  apply (clarsimp simp: n_def modify_map_cases initMDBNode_def)
-  apply (cases node)
-  apply clarsimp
-  apply (cases "p=slot", simp)
-  apply clarsimp
-  apply (cases "mdbNext s_node = p", simp)
-   apply fastforce
-  apply simp
-  apply (cases "mdbPrev s_node = p", simp)
-  apply fastforce
-  done
-
-lemma n_badged:
-  "n p = Some (CTE cap node) \<Longrightarrow>
-  \<exists>cap' node'. m p = Some (CTE cap' node') \<and>
-              (if p = slot
-               then \<not> mdbFirstBadged node
-               else if p = mdbNext s_node
-               then mdbFirstBadged node = (mdbFirstBadged node' \<or> mdbFirstBadged s_node)
-               else mdbFirstBadged node = mdbFirstBadged node')"
-  apply (subgoal_tac "p \<noteq> 0")
-   prefer 2
-   apply (insert no_0_n)[1]
-   apply clarsimp
-  apply (cases "p = slot")
-   apply (clarsimp simp: n_def modify_map_if initMDBNode_def split: if_split_asm)
-  apply (cases "p = mdbNext s_node")
-   apply (auto simp: n_def modify_map_if nullMDBNode_def split: if_split_asm)
-  done
-
-lemma m_badged:
-  "m p = Some (CTE cap node) \<Longrightarrow>
-  \<exists>cap' node'. n p = Some (CTE cap' node') \<and>
-              (if p = slot
-               then \<not> mdbFirstBadged node'
-               else if p = mdbNext s_node
-               then mdbFirstBadged node' = (mdbFirstBadged node \<or> mdbFirstBadged s_node)
-               else mdbFirstBadged node' = mdbFirstBadged node)"
-  apply (subgoal_tac "p \<noteq> 0")
-   prefer 2
-   apply (insert no_0_n)[1]
-   apply clarsimp
-  apply (cases "p = slot")
-   apply (clarsimp simp: n_def modify_map_if nullMDBNode_def split: if_split_asm)
-  apply (cases "p = mdbNext s_node")
-   apply (clarsimp simp: n_def modify_map_if nullMDBNode_def split: if_split_asm)
-  apply clarsimp
-  apply (cases "p = mdbPrev s_node")
-   apply (auto simp: n_def modify_map_if initMDBNode_def  split: if_split_asm)
-  done
-
-lemmas slot = m_p
-
-lemma m_next:
-  "m p = Some (CTE cap node) \<Longrightarrow>
-  \<exists>cap' node'. n p = Some (CTE cap' node') \<and>
-              (if p = slot
-               then mdbNext node' = 0
-               else if p = mdbPrev s_node
-               then mdbNext node' = mdbNext s_node
-               else mdbNext node' = mdbNext node)"
-  apply (subgoal_tac "p \<noteq> 0")
-   prefer 2
-   apply clarsimp
-  apply (cases "p = slot")
-   apply (clarsimp simp: n_def modify_map_if)
-  apply (cases "p = mdbPrev s_node")
-   apply (simp add: n_def modify_map_if)
-  apply simp
-  apply (simp add: n_def modify_map_if)
-  apply (cases "mdbNext s_node = p")
-   apply fastforce
-  apply fastforce
-  done
-
-lemma m_prev:
-  "m p = Some (CTE cap node) \<Longrightarrow>
-  \<exists>cap' node'. n p = Some (CTE cap' node') \<and>
-              (if p = slot
-               then mdbPrev node' = 0
-               else if p = mdbNext s_node
-               then mdbPrev node' = mdbPrev s_node
-               else mdbPrev node' = mdbPrev node)"
-  apply (subgoal_tac "p \<noteq> 0")
-   prefer 2
-   apply clarsimp
-  apply (cases "p = slot")
-   apply (clarsimp simp: n_def modify_map_if)
-  apply (cases "p = mdbPrev s_node")
-   apply (simp add: n_def modify_map_if)
-  apply simp
-  apply (simp add: n_def modify_map_if)
-  apply (cases "mdbNext s_node = p")
-   apply fastforce
-  apply fastforce
-  done
-
-lemma n_nextD:
-  "n \<turnstile> p \<leadsto> p' \<Longrightarrow>
-  if p = slot then p' = 0
-  else if p = mdbPrev s_node
-  then m \<turnstile> p \<leadsto> slot \<and> p' = mdbNext s_node
-  else m \<turnstile> p \<leadsto> p'"
-  apply (clarsimp simp: mdb_next_unfold split del: if_split cong: if_cong)
-  apply (case_tac z)
-  apply (clarsimp split del: if_split)
-  apply (drule n_next)
-  apply (elim exE conjE)
-  apply (simp split: if_split_asm)
-  apply (frule dlist_prevD [OF m_slot_prev])
-  apply (clarsimp simp: mdb_next_unfold)
-  done
-
-lemma n_next_eq:
-  "n \<turnstile> p \<leadsto> p' =
-  (if p = slot then p' = 0
-  else if p = mdbPrev s_node
-  then m \<turnstile> p \<leadsto> slot \<and> p' = mdbNext s_node
-  else m \<turnstile> p \<leadsto> p')"
-  apply (rule iffI)
-   apply (erule n_nextD)
-  apply (clarsimp simp: mdb_next_unfold split: if_split_asm)
-    apply (simp add: n_def modify_map_if slot)
-   apply hypsubst_thin
-   apply (case_tac z)
-   apply simp
-   apply (drule m_next)
-   apply clarsimp
-  apply (case_tac z)
-  apply simp
-  apply (drule m_next)
-  apply clarsimp
-  done
-
-lemma n_prev_eq:
-  "n \<turnstile> p \<leftarrow> p' =
-  (if p' = slot then p = 0
-  else if p' = mdbNext s_node
-  then m \<turnstile> slot \<leftarrow> p' \<and> p = mdbPrev s_node
-  else m \<turnstile> p \<leftarrow> p')"
-  apply (rule iffI)
-   apply (clarsimp simp: mdb_prev_def split del: if_split cong: if_cong)
-   apply (case_tac z)
-   apply (clarsimp split del: if_split)
-   apply (drule n_prev)
-   apply (elim exE conjE)
-   apply (simp split: if_split_asm)
-   apply (frule dlist_nextD [OF m_slot_next])
-   apply (clarsimp simp: mdb_prev_def)
-  apply (clarsimp simp: mdb_prev_def split: if_split_asm)
-    apply (simp add: n_def modify_map_if slot)
-   apply hypsubst_thin
-   apply (case_tac z)
-   apply clarsimp
-   apply (drule m_prev)
-   apply clarsimp
-  apply (case_tac z)
-  apply simp
-  apply (drule m_prev)
-  apply clarsimp
-  done
-
-lemma valid_dlist_n:
-  "valid_dlist n" using dlist
-  apply (clarsimp simp: valid_dlist_def2 [OF no_0_n])
-  apply (simp add: n_next_eq n_prev_eq m_slot_next m_slot_prev cong: if_cong)
-  apply (rule conjI, clarsimp)
-   apply (rule conjI, clarsimp simp: next_slot_prev prev_slot_next)
-   apply (fastforce dest!: dlist_prev_src_unique)
-  apply clarsimp
-  apply (rule conjI, clarsimp)
-   apply (clarsimp simp: valid_dlist_def2 [OF no_0])
-   apply (case_tac "mdbNext s_node = 0")
-    apply simp
-    apply (subgoal_tac "m \<turnstile> slot \<leadsto> c'")
-     prefer 2
-     apply fastforce
-    apply (clarsimp simp: mdb_next_unfold slot)
-   apply (frule next_slot_prev)
-   apply (drule (1) dlist_prev_src_unique, simp)
-   apply simp
-  apply clarsimp
-  apply (rule conjI, clarsimp)
-   apply (fastforce dest: dlist_next_src_unique)
-  apply clarsimp
-  apply (rule conjI, clarsimp)
-   apply (clarsimp simp: valid_dlist_def2 [OF no_0])
-   apply (clarsimp simp: mdb_prev_def slot)
-  apply (clarsimp simp: valid_dlist_def2 [OF no_0])
-  done
-
-lemma caps_contained_n:
-  "caps_contained' n"
-  using valid
-  apply (clarsimp simp: valid_mdb_ctes_def caps_contained'_def)
-  apply (drule n_cap)+
-  apply (clarsimp split: if_split_asm)
-  apply (erule disjE, clarsimp)
-  apply clarsimp
-  apply fastforce
-  done
-
-lemma chunked:
-  "mdb_chunked m"
-  using valid by (simp add: valid_mdb_ctes_def)
-
-lemma valid_badges:
-  "valid_badges m"
-  using valid ..
+context Arch_mdb_empty begin
 
 lemma valid_badges_n:
   "valid_badges n"
@@ -486,7 +131,8 @@ proof -
   from valid_badges
   show ?thesis
     supply if_cong[cong]
-    apply (simp add: valid_badges_def2 valid_arch_badges_def) (* FIXME arch-split; take AARCH64 version *)
+    supply to_slot_eq[simp del]
+    apply (simp add: valid_badges_def2 valid_arch_badges_def)
     apply clarsimp
     apply (drule_tac p=p in n_cap)
     apply (frule n_cap)
@@ -503,7 +149,7 @@ proof -
      apply (subgoal_tac "capMasterCap s_cap = capMasterCap cap'")
       prefer 2
       apply (thin_tac "\<forall>p. P p" for P)
-      apply (drule mdb_chunked2D[OF chunked])
+      apply (drule mdb_chunked2D[simplified mdb_chunked_arch_assms_def, simplified, OF chunked])
            apply (fastforce simp: mdb_next_unfold)
           apply assumption+
         apply (simp add: sameRegionAs_def3)
@@ -537,14 +183,6 @@ proof -
     apply fastforce
     done
 qed
-
-lemma to_slot_eq [simp]:
-  "m \<turnstile> p \<leadsto> slot = (p = mdbPrev s_node \<and> p \<noteq> 0)"
-  apply (rule iffI)
-   apply (frule dlist_nextD0, simp)
-   apply (clarsimp simp: mdb_prev_def slot mdb_next_unfold)
-  apply (clarsimp intro!: prev_slot_next)
-  done
 
 lemma n_parent_of:
   "\<lbrakk> n \<turnstile> p parentOf p'; p \<noteq> slot; p' \<noteq> slot \<rbrakk> \<Longrightarrow> m \<turnstile> p parentOf p'"
@@ -630,7 +268,8 @@ proof induct
     apply (case_tac cte'a)
     apply (case_tac ctea)
     apply clarsimp
-    apply (frule(2) mdb_chunked2D [OF chunked prev_slot_next m_slot_next])
+    apply (frule(2) mdb_chunked2D[simplified mdb_chunked_arch_assms_def, simplified,
+                                  OF chunked prev_slot_next m_slot_next])
       apply (clarsimp simp: isMDBParentOf_CTE)
      apply simp
     apply (simp add: slot)
@@ -738,586 +377,50 @@ next
     done
 qed
 
-lemma parency_m:
-  assumes "m \<turnstile> p \<rightarrow> p'"
-  shows "p \<noteq> slot \<longrightarrow> (if p' \<noteq> slot then n \<turnstile> p \<rightarrow> p' else m \<turnstile> p \<rightarrow> mdbNext s_node \<longrightarrow> n \<turnstile> p \<rightarrow> mdbNext s_node)"
-using assms
-proof induct
-  case (direct_parent c)
-  thus ?case
-    apply clarsimp
-    apply (rule conjI)
-     apply clarsimp
-     apply (rule subtree.direct_parent)
-       apply (simp add: n_next_eq)
-       apply clarsimp
-       apply (subgoal_tac "mdbPrev s_node \<noteq> 0")
-        prefer 2
-        apply (clarsimp simp: mdb_next_unfold)
-       apply (drule prev_slot_next)
-       apply (clarsimp simp: mdb_next_unfold)
-      apply assumption
-     apply (erule m_parent_of, simp, simp)
-      apply clarsimp
-     apply clarsimp
-     apply (drule dlist_next_src_unique)
-       apply fastforce
-      apply clarsimp
-     apply simp
-    apply clarsimp
-    apply (rule subtree.direct_parent)
-      apply (simp add: n_next_eq)
-     apply (drule subtree_parent)
-     apply (clarsimp simp: parentOf_def)
-    apply (drule subtree_parent)
-    apply (erule (1) m_parent_of_next)
-     apply clarsimp
-    apply clarsimp
-    done
-next
-  case (trans_parent c c')
-  thus ?case
-    apply clarsimp
-    apply (rule conjI)
-     apply clarsimp
-     apply (cases "c=slot")
-      apply simp
-      apply (erule impE)
-       apply (erule subtree.trans_parent)
-         apply fastforce
-        apply (clarsimp simp: slot mdb_next_unfold)
-       apply (clarsimp simp: slot mdb_next_unfold)
-      apply (clarsimp simp: slot mdb_next_unfold)
-     apply clarsimp
-     apply (erule subtree.trans_parent)
-       apply (simp add: n_next_eq)
-       apply clarsimp
-       apply (subgoal_tac "mdbPrev s_node \<noteq> 0")
-        prefer 2
-        apply (clarsimp simp: mdb_next_unfold)
-       apply (drule prev_slot_next)
-       apply (clarsimp simp: mdb_next_unfold)
-      apply assumption
-     apply (erule m_parent_of, simp, simp)
-      apply clarsimp
-      apply (drule subtree_mdb_next)
-      apply (drule trancl_trans)
-       apply (erule r_into_trancl)
-      apply simp
-     apply clarsimp
-     apply (drule dlist_next_src_unique)
-       apply fastforce
-      apply clarsimp
-     apply simp
-    apply clarsimp
-    apply (erule subtree.trans_parent)
-      apply (simp add: n_next_eq)
-     apply clarsimp
-    apply (rule m_parent_of_next, erule subtree_parent, assumption, assumption)
-    apply clarsimp
-    done
+end (* Arch_mdb_empty *)
+
+context mdb_empty begin
+
+lemmas gen_arch_assms =
+  Arch_mdb_empty.valid_badges_n
+  Arch_mdb_empty.parency_n
+  Arch_mdb_empty.m_parent_of
+  Arch_mdb_empty.m_parent_of_next
+
+(* extract arch-dependent assumptions of mdb_empty_gen proved in Arch_mdb_empty
+   (faster than interpreting Arch) *)
+lemmas gen_assms = gen_arch_assms[unfolded Arch_mdb_empty_def, OF mdb_empty_axioms]
+
+sublocale mdb_empty_gen
+  by (unfold_locales)
+     (blast intro!: gen_assms)+
+
+(* re-bind names *)
+lemmas vmdb_n = vmdb_n
+lemmas descendants = descendants
+
+end (* mdb_empty *)
+
+interpretation Finalise_R?: Finalise_R arch_final_matters' arch_cap_has_cleanup'
+proof goal_cases
+  interpret Arch  .
+  case 1 show ?case by (intro_locales; (unfold_locales; (fact Finalise_R_assms)?)?)
 qed
 
-lemma parency:
-  "n \<turnstile> p \<rightarrow> p' = (p \<noteq> slot \<and> p' \<noteq> slot \<and> m \<turnstile> p \<rightarrow> p')"
-  by (auto dest!: parency_n parency_m)
+context Arch begin arch_global_naming
 
-lemma descendants:
-  "descendants_of' p n =
-  (if p = slot then {} else descendants_of' p m - {slot})"
-  by (auto simp add: parency descendants_of'_def)
+named_theorems Finalise_R_2_assms
 
-lemma n_tranclD:
-  "n \<turnstile> p \<leadsto>\<^sup>+ p' \<Longrightarrow> m \<turnstile> p \<leadsto>\<^sup>+ p' \<and> p' \<noteq> slot"
-  apply (erule trancl_induct)
-   apply (clarsimp simp add: n_next_eq split: if_split_asm)
-     apply (rule mdb_chain_0D)
-      apply (rule chain)
-     apply (clarsimp simp: slot)
-    apply (blast intro: trancl_trans prev_slot_next)
-   apply fastforce
-  apply (clarsimp simp: n_next_eq split: if_split_asm)
-   apply (erule trancl_trans)
-   apply (blast intro: trancl_trans prev_slot_next)
-  apply (fastforce intro: trancl_trans)
-  done
-
-lemma m_tranclD:
-  "m \<turnstile> p \<leadsto>\<^sup>+ p' \<Longrightarrow>
-  if p = slot then n \<turnstile> mdbNext s_node \<leadsto>\<^sup>* p'
-  else if p' = slot then n \<turnstile> p \<leadsto>\<^sup>+ mdbNext s_node
-  else n \<turnstile> p \<leadsto>\<^sup>+ p'"
-  using no_0_n
-  apply -
-  apply (erule trancl_induct)
-   apply clarsimp
-   apply (rule conjI)
-    apply clarsimp
-    apply (rule r_into_trancl)
-    apply (clarsimp simp: n_next_eq)
-   apply clarsimp
-   apply (rule conjI)
-    apply (insert m_slot_next)[1]
-    apply (clarsimp simp: mdb_next_unfold)
-   apply clarsimp
-   apply (rule r_into_trancl)
-   apply (clarsimp simp: n_next_eq)
-   apply (rule context_conjI)
-    apply (clarsimp simp: mdb_next_unfold)
-   apply (drule prev_slot_next)
-   apply (clarsimp simp: mdb_next_unfold)
-  apply clarsimp
-  apply (rule conjI)
-   apply clarsimp
-   apply (rule conjI)
-    apply clarsimp
-    apply (drule prev_slot_next)
-    apply (drule trancl_trans, erule r_into_trancl)
-    apply simp
-   apply clarsimp
-   apply (erule trancl_trans)
-   apply (rule r_into_trancl)
-   apply (simp add: n_next_eq)
-  apply clarsimp
-  apply (rule conjI)
-   apply clarsimp
-   apply (erule rtrancl_trans)
-   apply (rule r_into_rtrancl)
-   apply (simp add: n_next_eq)
-   apply (rule conjI)
-    apply clarsimp
-    apply (rule context_conjI)
-     apply (clarsimp simp: mdb_next_unfold)
-    apply (drule prev_slot_next)
-    apply (clarsimp simp: mdb_next_unfold)
-   apply clarsimp
-  apply clarsimp
-  apply (simp split: if_split_asm)
-   apply (clarsimp simp: mdb_next_unfold slot)
-  apply (erule trancl_trans)
-  apply (rule r_into_trancl)
-  apply (clarsimp simp add: n_next_eq)
-  apply (rule context_conjI)
-   apply (clarsimp simp: mdb_next_unfold)
-  apply (drule prev_slot_next)
-  apply (clarsimp simp: mdb_next_unfold)
-  done
-
-lemma n_trancl_eq:
-  "n \<turnstile> p \<leadsto>\<^sup>+ p' = (m \<turnstile> p \<leadsto>\<^sup>+ p' \<and> (p = slot \<longrightarrow> p' = 0) \<and> p' \<noteq> slot)"
-  using no_0_n
-  apply -
-  apply (rule iffI)
-   apply (frule n_tranclD)
-   apply clarsimp
-   apply (drule tranclD)
-   apply (clarsimp simp: n_next_eq)
-   apply (simp add: rtrancl_eq_or_trancl)
-  apply clarsimp
-  apply (drule m_tranclD)
-  apply (simp split: if_split_asm)
-  apply (rule r_into_trancl)
-  apply (simp add: n_next_eq)
-  done
-
-lemma n_rtrancl_eq:
-  "n \<turnstile> p \<leadsto>\<^sup>* p' =
-  (m \<turnstile> p \<leadsto>\<^sup>* p' \<and>
-   (p = slot \<longrightarrow> p' = 0 \<or> p' = slot) \<and>
-   (p' = slot \<longrightarrow> p = slot))"
-  by (auto simp: rtrancl_eq_or_trancl n_trancl_eq)
-
-lemma mdb_chain_0_n:
-  "mdb_chain_0 n"
-  using chain
-  apply (clarsimp simp: mdb_chain_0_def)
-  apply (drule bspec)
-   apply (fastforce simp: n_def modify_map_if split: if_split_asm)
-  apply (simp add: n_trancl_eq)
-  done
-
-lemma mdb_chunked_n:
-  "mdb_chunked n"
-  using chunked
-  apply (clarsimp simp: mdb_chunked_def)
-  apply (drule n_cap)+
-  apply (clarsimp split: if_split_asm)
-  apply (case_tac "p=slot", clarsimp)
-  apply clarsimp
-  apply (erule_tac x=p in allE)
-  apply (erule_tac x=p' in allE)
-  apply (clarsimp simp: is_chunk_def)
-  apply (simp add: n_trancl_eq n_rtrancl_eq)
-  apply (rule conjI)
-   apply clarsimp
-   apply (erule_tac x=p'' in allE)
-   apply clarsimp
-   apply (drule_tac p=p'' in m_cap)
-   apply clarsimp
-  apply clarsimp
-  apply (erule_tac x=p'' in allE)
-  apply clarsimp
-  apply (drule_tac p=p'' in m_cap)
-  apply clarsimp
-  done
-
-lemma untyped_mdb_n:
-  "untyped_mdb' n"
-  using untyped_mdb
-  apply (simp add: untyped_mdb'_def descendants_of'_def parency)
-  apply clarsimp
-  apply (drule n_cap)+
-  apply (clarsimp split: if_split_asm)
-  apply (case_tac "p=slot", simp)
-  apply clarsimp
-  done
-
-lemma untyped_inc_n:
-  "untyped_inc' n"
-  using untyped_inc
-  apply (simp add: untyped_inc'_def descendants_of'_def parency)
-  apply clarsimp
-  apply (drule n_cap)+
-  apply (clarsimp split: if_split_asm)
-  apply (case_tac "p=slot", simp)
-  apply clarsimp
-  apply (erule_tac x=p in allE)
-  apply (erule_tac x=p' in allE)
-  apply simp
-  done
-
-lemmas vn_prev [dest!] = valid_nullcaps_prev [OF _ slot no_0 dlist nullcaps]
-lemmas vn_next [dest!] = valid_nullcaps_next [OF _ slot no_0 dlist nullcaps]
-
-lemma nullcaps_n: "valid_nullcaps n"
-proof -
-  from valid have "valid_nullcaps m" ..
-  thus ?thesis
-    apply (clarsimp simp: valid_nullcaps_def nullMDBNode_def nullPointer_def)
-    apply (frule n_cap)
-    apply (frule n_next)
-    apply (frule n_badged)
-    apply (frule n_revokable)
-    apply (drule n_prev)
-    apply (case_tac n)
-    apply (insert slot)
-    apply (fastforce split: if_split_asm)
-    done
-qed
-
-lemma ut_rev_n: "ut_revocable' n"
-  apply(insert valid)
-  apply(clarsimp simp: ut_revocable'_def)
-  apply(frule n_cap)
-  apply(drule n_revokable)
-  apply(clarsimp simp: isCap_simps split: if_split_asm)
-  apply(simp add: valid_mdb_ctes_def ut_revocable'_def)
-  done
-
-lemma class_links_n: "class_links n"
-  using valid slot
-  apply (clarsimp simp: valid_mdb_ctes_def class_links_def)
-  apply (case_tac cte, case_tac cte')
-  apply (drule n_nextD)
-  apply (clarsimp simp: split: if_split_asm)
-    apply (simp add: no_0_n)
-   apply (drule n_cap)+
-   apply clarsimp
-   apply (frule spec[where x=slot],
-          drule spec[where x="mdbNext s_node"],
-          simp, simp add: m_slot_next)
-   apply (drule spec[where x="mdbPrev s_node"],
-          drule spec[where x=slot], simp)
-  apply (drule n_cap)+
-  apply clarsimp
-  apply (fastforce split: if_split_asm)
-  done
-
-lemma distinct_zombies_m: "distinct_zombies m"
-  using valid by (simp add: valid_mdb_ctes_def)
-
-lemma distinct_zombies_n[simp]:
-  "distinct_zombies n"
-  using distinct_zombies_m
-  apply (simp add: n_def distinct_zombies_nonCTE_modify_map)
-  apply (subst modify_map_apply[where p=slot])
-   apply (simp add: modify_map_def slot)
-  apply simp
-  apply (rule distinct_zombies_sameMasterE)
-    apply (simp add: distinct_zombies_nonCTE_modify_map)
-   apply (simp add: modify_map_def slot)
-  apply simp
-  done
-
-lemma irq_control_n [simp]: "irq_control n"
-  using slot
-  apply (clarsimp simp: irq_control_def)
-  apply (frule n_revokable)
-  apply (drule n_cap)
-  apply (clarsimp split: if_split_asm)
-  apply (frule irq_revocable, rule irq_control)
-  apply clarsimp
-  apply (drule n_cap)
-  apply (clarsimp simp: if_split_asm)
-  apply (erule (1) irq_controlD, rule irq_control)
-  done
-
-lemma reply_masters_rvk_fb_m: "reply_masters_rvk_fb m"
-  using valid by auto
-
-lemma reply_masters_rvk_fb_n [simp]: "reply_masters_rvk_fb n"
-  using reply_masters_rvk_fb_m
-  apply (simp add: reply_masters_rvk_fb_def n_def
-                   ball_ran_modify_map_eq
-                   modify_map_comp[symmetric])
-  apply (subst ball_ran_modify_map_eq)
-   apply (frule bspec, rule ranI, rule slot)
-   apply (simp add: nullMDBNode_def isCap_simps modify_map_def
-                    slot)
-  apply (subst ball_ran_modify_map_eq)
-   apply (clarsimp simp add: modify_map_def)
-   apply fastforce
-  apply (simp add: ball_ran_modify_map_eq)
-  done
-
-lemma vmdb_n: "valid_mdb_ctes n"
-  by (simp add: valid_mdb_ctes_def valid_dlist_n
-                no_0_n mdb_chain_0_n valid_badges_n
-                caps_contained_n mdb_chunked_n
-                untyped_mdb_n untyped_inc_n
-                nullcaps_n ut_rev_n class_links_n)
-
-end
-
-context begin interpretation Arch .
-crunch postCapDeletion, clearUntypedFreeIndex
-  for ctes_of[wp]: "\<lambda>s. P (ctes_of s)"
-
-lemma emptySlot_mdb [wp]:
-  "\<lbrace>valid_mdb'\<rbrace>
-  emptySlot sl opt
-  \<lbrace>\<lambda>_. valid_mdb'\<rbrace>"
-  unfolding emptySlot_def
-  apply (simp only: case_Null_If valid_mdb'_def)
-  apply (wp updateCap_ctes_of_wp getCTE_wp'
-            opt_return_pres_lift | simp add: cte_wp_at_ctes_of)+
-  apply (clarsimp)
-  apply (case_tac cte)
-  apply (rename_tac cap node)
-  apply (simp)
-  apply (subgoal_tac "mdb_empty (ctes_of s) sl cap node")
-   prefer 2
-   apply (rule mdb_empty.intro)
-   apply (rule mdb_ptr.intro)
-    apply (rule vmdb.intro)
-    apply (simp add: valid_mdb_ctes_def)
-   apply (rule mdb_ptr_axioms.intro)
-   apply (simp add: cte_wp_at_ctes_of)
-  apply (rule conjI, clarsimp simp: valid_mdb_ctes_def)
-  apply (erule mdb_empty.vmdb_n[unfolded const_def])
-  done
-end
-
-lemma if_live_then_nonz_cap'_def2:
-  "if_live_then_nonz_cap' = (\<lambda>s. \<forall>ptr. ko_wp_at' live' ptr s
-                               \<longrightarrow> (\<exists>p zr. (option_map zobj_refs' o cteCaps_of s) p = Some zr \<and> ptr \<in> zr))"
-  by (fastforce intro!: ext
-                 simp: if_live_then_nonz_cap'_def ex_nonz_cap_to'_def
-                       cte_wp_at_ctes_of cteCaps_of_def)
-
-lemma updateMDB_ko_wp_at_live[wp]:
-  "\<lbrace>\<lambda>s. P (ko_wp_at' live' p' s)\<rbrace>
-      updateMDB p m
-   \<lbrace>\<lambda>rv s. P (ko_wp_at' live' p' s)\<rbrace>"
-  unfolding updateMDB_def Let_def
-  apply (rule hoare_pre, wp)
-  apply simp
-  done
-
-lemma updateCap_ko_wp_at_live[wp]:
-  "\<lbrace>\<lambda>s. P (ko_wp_at' live' p' s)\<rbrace>
-      updateCap p cap
-   \<lbrace>\<lambda>rv s. P (ko_wp_at' live' p' s)\<rbrace>"
-  unfolding updateCap_def
-  by wp
-
-primrec
-  threadCapRefs :: "capability \<Rightarrow> machine_word set"
-where
-  "threadCapRefs (ThreadCap r)                  = {r}"
-| "threadCapRefs (ReplyCap t m x)               = {}"
-| "threadCapRefs NullCap                        = {}"
-| "threadCapRefs (UntypedCap d r n i)           = {}"
-| "threadCapRefs (EndpointCap r badge x y z t)  = {}"
-| "threadCapRefs (NotificationCap r badge x y)  = {}"
-| "threadCapRefs (CNodeCap r b g gsz)           = {}"
-| "threadCapRefs (Zombie r b n)                 = {}"
-| "threadCapRefs (ArchObjectCap ac)             = {}"
-| "threadCapRefs (IRQHandlerCap irq)            = {}"
-| "threadCapRefs (IRQControlCap)                = {}"
-| "threadCapRefs (DomainCap)                    = {}"
-
-definition
-  "isFinal cap p m \<equiv>
-  \<not>isUntypedCap cap \<and>
-  (\<forall>p' c. m p' = Some c \<longrightarrow>
-          p \<noteq> p' \<longrightarrow> \<not>isUntypedCap c \<longrightarrow>
-          \<not> sameObjectAs cap c)"
-
-lemma not_FinalE:
-  "\<lbrakk> \<not> isFinal cap sl cps; isUntypedCap cap \<Longrightarrow> P;
-     \<And>p c. \<lbrakk> cps p = Some c; p \<noteq> sl; \<not> isUntypedCap c; sameObjectAs cap c \<rbrakk> \<Longrightarrow> P
-    \<rbrakk> \<Longrightarrow> P"
-  by (fastforce simp: isFinal_def)
-
-definition
- "removeable' sl \<equiv> \<lambda>s cap.
-    (\<exists>p. p \<noteq> sl \<and> cte_wp_at' (\<lambda>cte. capMasterCap (cteCap cte) = capMasterCap cap) p s)
-    \<or> ((\<forall>p \<in> cte_refs' cap (irq_node' s). p \<noteq> sl \<longrightarrow> cte_wp_at' (\<lambda>cte. cteCap cte = NullCap) p s)
-         \<and> (\<forall>p \<in> zobj_refs' cap. ko_wp_at' (Not \<circ> live') p s))"
-
-lemma not_Final_removeable:
-  "\<not> isFinal cap sl (cteCaps_of s)
-    \<Longrightarrow> removeable' sl s cap"
+lemma not_Final_removeable[Finalise_R_2_assms]:
+  "\<not> isFinal cap sl (cteCaps_of s) \<Longrightarrow> removeable' sl s cap"
   apply (erule not_FinalE)
    apply (clarsimp simp: removeable'_def gen_isCap_simps)
   apply (clarsimp simp: cteCaps_of_def X64.sameObjectAs_def2 removeable'_def
-                        cte_wp_at_ctes_of) (* FIXME arch-split *)
+                        cte_wp_at_ctes_of)
   apply fastforce
   done
 
-context begin interpretation Arch .
-crunch postCapDeletion
-  for ko_wp_at'[wp]: "\<lambda>s. P (ko_wp_at' P' p s)"
-crunch postCapDeletion
-  for cteCaps_of[wp]: "\<lambda>s. P (cteCaps_of s)"
-end
-
-crunch clearUntypedFreeIndex
-  for ko_at_live[wp]: "\<lambda>s. P (ko_wp_at' live' ptr s)"
-
-lemma clearUntypedFreeIndex_cteCaps_of[wp]:
-  "\<lbrace>\<lambda>s. P (cteCaps_of s)\<rbrace>
-       clearUntypedFreeIndex sl \<lbrace>\<lambda>y s. P (cteCaps_of s)\<rbrace>"
-  by (simp add: cteCaps_of_def, wp)
-
-lemma emptySlot_iflive'[wp]:
-  "\<lbrace>\<lambda>s. if_live_then_nonz_cap' s \<and> cte_wp_at' (\<lambda>cte. removeable' sl s (cteCap cte)) sl s\<rbrace>
-     emptySlot sl opt
-   \<lbrace>\<lambda>rv. if_live_then_nonz_cap'\<rbrace>"
-  apply (simp add: emptySlot_def case_Null_If if_live_then_nonz_cap'_def2
-              del: comp_apply)
-  apply (rule hoare_pre)
-   apply (wp hoare_vcg_all_lift hoare_vcg_disj_lift
-             getCTE_wp opt_return_pres_lift
-             clearUntypedFreeIndex_ctes_of
-             clearUntypedFreeIndex_cteCaps_of
-             hoare_vcg_ex_lift
-             | wp (once) hoare_vcg_imp_lift
-             | simp add: cte_wp_at_ctes_of del: comp_apply)+
-  apply (clarsimp simp: modify_map_same
-    imp_conjR[symmetric])
-  apply (drule spec, drule(1) mp)
-  apply (clarsimp simp: cte_wp_at_ctes_of modify_map_def split: if_split_asm)
-  apply (case_tac "p \<noteq> sl")
-   apply blast
-  apply (simp add: removeable'_def cteCaps_of_def)
-  apply (erule disjE)
-   apply (clarsimp simp: cte_wp_at_ctes_of modify_map_def
-                  dest!: capMaster_same_refs)
-   apply fastforce
-  apply clarsimp
-  apply (drule(1) bspec)
-  apply (clarsimp simp: ko_wp_at'_def)
-  done
-
-crunch doMachineOp
-  for irq_node'[wp]: "\<lambda>s. P (irq_node' s)"
-
-lemma setIRQState_irq_node'[wp]:
-  "\<lbrace>\<lambda>s. P (irq_node' s)\<rbrace> setIRQState state irq \<lbrace>\<lambda>_ s. P (irq_node' s)\<rbrace>"
-  apply (simp add: setIRQState_def setInterruptState_def getInterruptState_def)
-  apply wp
-  apply simp
-  done
-
-context begin interpretation Arch .
-crunch emptySlot
-  for irq_node'[wp]: "\<lambda>s. P (irq_node' s)"
-end
-
-lemma emptySlot_ifunsafe'[wp]:
-  "\<lbrace>\<lambda>s. if_unsafe_then_cap' s \<and> cte_wp_at' (\<lambda>cte. removeable' sl s (cteCap cte)) sl s\<rbrace>
-     emptySlot sl opt
-   \<lbrace>\<lambda>rv. if_unsafe_then_cap'\<rbrace>"
-  apply (simp add: ifunsafe'_def3)
-  apply (rule hoare_pre, rule hoare_use_eq_irq_node'[OF emptySlot_irq_node'])
-   apply (simp add: emptySlot_def case_Null_If)
-   apply (wp opt_return_pres_lift | simp add: o_def)+
-   apply (wp getCTE_cteCap_wp clearUntypedFreeIndex_cteCaps_of)+
-  apply (clarsimp simp: tree_cte_cteCap_eq[unfolded o_def]
-                        modify_map_same
-                        modify_map_comp[symmetric]
-                 split: option.split_asm if_split_asm
-                 dest!: modify_map_K_D)
-  apply (clarsimp simp: modify_map_def)
-  apply (drule_tac x=cref in spec, clarsimp)
-  apply (case_tac "cref' \<noteq> sl")
-   apply (rule_tac x=cref' in exI)
-   apply (clarsimp simp: modify_map_def)
-  apply (simp add: removeable'_def)
-  apply (erule disjE)
-   apply (clarsimp simp: modify_map_def)
-   apply (subst(asm) tree_cte_cteCap_eq[unfolded o_def])
-   apply (clarsimp split: option.split_asm dest!: capMaster_same_refs)
-   apply fastforce
-  apply clarsimp
-  apply (drule(1) bspec)
-  apply (clarsimp simp: cte_wp_at_ctes_of cteCaps_of_def)
-  done
-
-lemma ctes_of_valid'[elim]:
-  "\<lbrakk>ctes_of s p = Some cte; valid_objs' s\<rbrakk> \<Longrightarrow> s \<turnstile>' cteCap cte"
-  by (cases cte, simp) (rule ctes_of_valid_cap')
-
-crunch postCapDeletion
-  for ksrq[wp]: "\<lambda>s. P (ksReadyQueues s)"
-
-crunch setInterruptState
-  for valid_idle'[wp]: "valid_idle'"
-  (simp: valid_idle'_def)
-
-context begin interpretation Arch .
-crunch emptySlot
-  for valid_idle'[wp]: "valid_idle'"
-  and ksIdle[wp]: "\<lambda>s. P (ksIdleThread s)"
-  and gsMaxObjectSize[wp]: "\<lambda>s. P (gsMaxObjectSize s)"
-crunch deletedIRQHandler, getSlotCap, clearUntypedFreeIndex, updateMDB, getCTE, updateCap
-  for ksArch[wp]: "\<lambda>s. P (ksArchState s)"
-end
-
-lemma emptySlot_cteCaps_of:
-  "\<lbrace>\<lambda>s. P ((cteCaps_of s)(p \<mapsto> NullCap))\<rbrace>
-     emptySlot p opt
-   \<lbrace>\<lambda>rv s. P (cteCaps_of s)\<rbrace>"
-  apply (simp add: emptySlot_def case_Null_If)
-  apply (wp opt_return_pres_lift getCTE_cteCap_wp
-            clearUntypedFreeIndex_cteCaps_of)
-  apply (clarsimp simp: cteCaps_of_def cte_wp_at_ctes_of)
-  apply (auto elim!: rsubst[where P=P]
-               simp: modify_map_def fun_upd_def[symmetric] o_def
-                     fun_upd_idem cteCaps_of_def
-              split: option.splits)
-  done
-
-context begin interpretation Arch .
-lemma freeIOPortRange_valid_global_refs[wp]:
-  "\<lbrace>valid_global_refs'\<rbrace> freeIOPortRange f l \<lbrace>\<lambda>rv. valid_global_refs'\<rbrace>"
-  apply (clarsimp simp: freeIOPortRange_def setIOPortMask_def)
-  apply wpsimp
-  by (clarsimp simp: valid_global_refs'_def global_refs'_def table_refs'_def bit_simps)
-
-lemma deletedIRQHandler_valid_global_refs[wp]:
+lemma deletedIRQHandler_valid_global_refs[Finalise_R_2_assms, wp]:
   "\<lbrace>valid_global_refs'\<rbrace> deletedIRQHandler irq \<lbrace>\<lambda>rv. valid_global_refs'\<rbrace>"
   apply (clarsimp simp: valid_global_refs'_def global_refs'_def)
   apply (rule hoare_pre)
@@ -1331,7 +434,7 @@ lemma deletedIRQHandler_valid_global_refs[wp]:
   apply (clarsimp simp: valid_refs'_cteCaps valid_cap_sizes_cteCaps ball_ran_eq)
   done
 
-lemma clearUntypedFreeIndex_valid_global_refs[wp]:
+lemma clearUntypedFreeIndex_valid_global_refs[Finalise_R_2_assms, wp]:
   "\<lbrace>valid_global_refs'\<rbrace> clearUntypedFreeIndex irq \<lbrace>\<lambda>rv. valid_global_refs'\<rbrace>"
   apply (clarsimp simp: valid_global_refs'_def global_refs'_def)
   apply (rule hoare_pre)
@@ -1345,576 +448,30 @@ lemma clearUntypedFreeIndex_valid_global_refs[wp]:
   apply (clarsimp simp: valid_refs'_cteCaps valid_cap_sizes_cteCaps ball_ran_eq)
   done
 
-crunch global.postCapDeletion
-  for valid_global_refs[wp]: "valid_global_refs'"
-
-lemma emptySlot_valid_global_refs[wp]:
-  "\<lbrace>valid_global_refs' and cte_at' sl\<rbrace> emptySlot sl opt \<lbrace>\<lambda>rv. valid_global_refs'\<rbrace>"
-  apply (clarsimp simp: emptySlot_def)
-  apply (wpsimp wp: getCTE_wp hoare_drop_imps hoare_vcg_ex_lift simp: cte_wp_at_ctes_of)
-  apply (clarsimp simp: valid_global_refs'_def global_refs'_def)
-  apply (frule(1) cte_at_valid_cap_sizes_0)
-  apply (clarsimp simp: valid_refs'_cteCaps valid_cap_sizes_cteCaps ball_ran_eq)
-  done
-end
-
-lemmas doMachineOp_irq_handlers[wp]
-    = valid_irq_handlers_lift'' [OF doMachineOp_ctes doMachineOp_ksInterruptState]
-
-lemma deletedIRQHandler_irq_handlers'[wp]:
-  "\<lbrace>\<lambda>s. valid_irq_handlers' s \<and> (IRQHandlerCap irq \<notin> ran (cteCaps_of s))\<rbrace>
-       deletedIRQHandler irq
-   \<lbrace>\<lambda>rv. valid_irq_handlers'\<rbrace>"
-  apply (simp add: deletedIRQHandler_def setIRQState_def setInterruptState_def getInterruptState_def)
-  apply wp
-  apply (clarsimp simp: valid_irq_handlers'_def irq_issued'_def ran_def cteCaps_of_def)
-  done
-
-context begin interpretation Arch .
-
-crunch freeIOPortRange
-  for valid_irq_handlers'[wp]: "valid_irq_handlers'"
-
-lemma postCapDeletion_irq_handlers'[wp]:
-  "\<lbrace>\<lambda>s. valid_irq_handlers' s \<and> (cap \<noteq> NullCap \<longrightarrow> cap \<notin> ran (cteCaps_of s))\<rbrace>
-       postCapDeletion cap
-   \<lbrace>\<lambda>rv. valid_irq_handlers'\<rbrace>"
-  by (wpsimp simp: Retype_H.postCapDeletion_def X64_H.postCapDeletion_def)
-
-(* extra constraints on IO ports are not needed since there is no valid_ioports to preserve in
-   Refine *)
-definition
-  "post_cap_delete_pre' cap sl cs \<equiv> case cap
-     of IRQHandlerCap irq \<Rightarrow> irq \<le> maxIRQ \<and> (\<forall>sl'. sl \<noteq> sl' \<longrightarrow> cs sl' \<noteq> Some cap)
-     | ArchObjectCap (IOPortCap f l) \<Rightarrow> f \<le> l \<and> (\<forall>sl'. sl \<noteq> sl' \<longrightarrow> cs sl' \<noteq> Some cap)
-     | _ \<Rightarrow> False"
-
-end
-
-crunch clearUntypedFreeIndex
-  for ksInterruptState[wp]: "\<lambda>s. P (ksInterruptState s)"
-
-lemma emptySlot_valid_irq_handlers'[wp]:
-  "\<lbrace>\<lambda>s. valid_irq_handlers' s
-          \<and> (\<forall>sl'. info \<noteq> NullCap \<longrightarrow> sl' \<noteq> sl \<longrightarrow> cteCaps_of s sl' \<noteq> Some info)\<rbrace>
-     emptySlot sl info
-   \<lbrace>\<lambda>rv. valid_irq_handlers'\<rbrace>"
-  apply (simp add: emptySlot_def case_Null_If)
-  apply (wp | wpc)+
-        apply (unfold valid_irq_handlers'_def irq_issued'_def)
-        apply (wp getCTE_cteCap_wp clearUntypedFreeIndex_cteCaps_of
-          | wps clearUntypedFreeIndex_ksInterruptState)+
-  apply (clarsimp simp: cteCaps_of_def cte_wp_at_ctes_of ran_def modify_map_def
-                 split: option.split)
-  apply auto
-  done
-
-context begin interpretation Arch .
-crunch emptySlot
-  for irq_states'[wp]: valid_irq_states'
-
-crunch emptySlot
-  for no_0_obj'[wp]: no_0_obj'
- (wp: crunch_wps)
-
-lemma deletedIRQHandler_irqs_masked'[wp]:
-  "\<lbrace>irqs_masked'\<rbrace> deletedIRQHandler irq \<lbrace>\<lambda>_. irqs_masked'\<rbrace>"
-  apply (simp add: deletedIRQHandler_def setIRQState_def getInterruptState_def setInterruptState_def)
-  apply (wp dmo_maskInterrupt)
-  apply (simp add: irqs_masked'_def)
-  done
-
-crunch emptySlot
-  for irqs_masked'[wp]: "irqs_masked'"
-
-lemma setIRQState_umm:
- "\<lbrace>\<lambda>s. P (underlying_memory (ksMachineState s))\<rbrace>
-   setIRQState irqState irq
-  \<lbrace>\<lambda>_ s. P (underlying_memory (ksMachineState s))\<rbrace>"
-  by (simp add: setIRQState_def maskInterrupt_def
-                setInterruptState_def getInterruptState_def
-      | wp dmo_lift')+
-
-crunch emptySlot
-  for umm[wp]: "\<lambda>s. P (underlying_memory (ksMachineState s))"
-  (wp: setIRQState_umm)
-
-lemma emptySlot_vms'[wp]:
-  "\<lbrace>valid_machine_state'\<rbrace> emptySlot slot irq \<lbrace>\<lambda>_. valid_machine_state'\<rbrace>"
-  by (simp add: valid_machine_state'_def pointerInUserData_def pointerInDeviceData_def)
-     (wp hoare_vcg_all_lift hoare_vcg_disj_lift)
-
-crunch emptySlot
-  for pspace_domain_valid[wp]: "pspace_domain_valid"
-
-crunch emptySlot
-  for nosch[wp]: "\<lambda>s. P (ksSchedulerAction s)"
-crunch emptySlot
-  for ct[wp]: "\<lambda>s. P (ksCurThread s)"
-crunch emptySlot
-  for ksCurDomain[wp]: "\<lambda>s. P (ksCurDomain s)"
-crunch emptySlot
-  for ksDomSchedule[wp]: "\<lambda>s. P (ksDomSchedule s)"
-crunch emptySlot
-  for ksDomScheduleIdx[wp]: "\<lambda>s. P (ksDomScheduleIdx s)"
-
-lemma deletedIRQHandler_ct_not_inQ[wp]:
-  "\<lbrace>ct_not_inQ\<rbrace> deletedIRQHandler irq \<lbrace>\<lambda>_. ct_not_inQ\<rbrace>"
-  apply (rule ct_not_inQ_lift [OF deletedIRQHandler_nosch])
-  apply (rule hoare_weaken_pre)
-   apply (wps deletedIRQHandler_ct)
-   apply (simp add: deletedIRQHandler_def setIRQState_def)
-   apply (wp)
-  apply (simp add: comp_def)
-  done
-
-lemma setIOPortMask_ct_not_inQ[wp]:
-  "\<lbrace>ct_not_inQ\<rbrace> setIOPortMask f l b \<lbrace>\<lambda>rv. ct_not_inQ\<rbrace>"
-  by (wpsimp simp: ct_not_inQ_def setIOPortMask_def)
-
-crunch emptySlot
-  for ct_not_inQ[wp]: "ct_not_inQ"
-
-crunch emptySlot
-  for tcbDomain[wp]: "obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t"
-
-lemma emptySlot_ct_idle_or_in_cur_domain'[wp]:
-  "\<lbrace>ct_idle_or_in_cur_domain'\<rbrace> emptySlot sl opt \<lbrace>\<lambda>_. ct_idle_or_in_cur_domain'\<rbrace>"
-apply (wp ct_idle_or_in_cur_domain'_lift2 tcb_in_cur_domain'_lift | simp)+
-done
-
-crunch postCapDeletion
-  for gsUntypedZeroRanges[wp]: "\<lambda>s. P (gsUntypedZeroRanges s)"
-  (wp: crunch_wps simp: crunch_simps)
-
-lemma untypedZeroRange_modify_map_isUntypedCap:
-  "m sl = Some v \<Longrightarrow> \<not> isUntypedCap v \<Longrightarrow> \<not> isUntypedCap (f v)
-    \<Longrightarrow> (untypedZeroRange \<circ>\<^sub>m modify_map m sl f) = (untypedZeroRange \<circ>\<^sub>m m)"
-  by (simp add: modify_map_def map_comp_def fun_eq_iff untypedZeroRange_def)
-
-lemma emptySlot_untyped_ranges[wp]:
-  "\<lbrace>untyped_ranges_zero' and valid_objs' and valid_mdb'\<rbrace>
-     emptySlot sl opt \<lbrace>\<lambda>rv. untyped_ranges_zero'\<rbrace>"
-  apply (simp add: emptySlot_def case_Null_If)
-  apply (rule hoare_pre)
-   apply (rule bind_wp)
-    apply (rule untyped_ranges_zero_lift)
-     apply (wp getCTE_cteCap_wp clearUntypedFreeIndex_cteCaps_of
-       | wpc | simp add: clearUntypedFreeIndex_def updateTrackedFreeIndex_def
-                         getSlotCap_def
-                  split: option.split)+
-  apply (clarsimp simp: modify_map_comp[symmetric] modify_map_same)
-  apply (case_tac "\<not> isUntypedCap (the (cteCaps_of s sl))")
-   apply (case_tac "the (cteCaps_of s sl)",
-     simp_all add: untyped_ranges_zero_inv_def
-                   untypedZeroRange_modify_map_isUntypedCap isCap_simps)[1]
-  apply (clarsimp simp: isCap_simps untypedZeroRange_def modify_map_def)
-  apply (strengthen untyped_ranges_zero_fun_upd[mk_strg I E])
-  apply simp
-  apply (simp add: untypedZeroRange_def isCap_simps)
-  done
-
-lemma setIOPortMask_valid_arch'[wp]:
-  "\<lbrace>valid_arch_state'\<rbrace> setIOPortMask f l b \<lbrace>\<lambda>rv. valid_arch_state'\<rbrace>"
-  by (wpsimp simp: valid_arch_state'_def setIOPortMask_def)
-
-crunch deletedIRQHandler, updateMDB, updateCap, clearUntypedFreeIndex
-  for valid_arch'[wp]: valid_arch_state'
-  (wp: valid_arch_state_lift')
-
-crunch global.postCapDeletion
-  for valid_arch'[wp]: valid_arch_state'
-
-lemma emptySlot_valid_arch'[wp]:
-  "\<lbrace>valid_arch_state' and cte_at' sl\<rbrace> emptySlot sl info \<lbrace>\<lambda>rv. valid_arch_state'\<rbrace>"
-  by (wpsimp simp: emptySlot_def cte_wp_at_ctes_of
-               wp: getCTE_wp hoare_drop_imps hoare_vcg_ex_lift)
-
-crunch emptySlot
-  for valid_bitmaps[wp]: valid_bitmaps
-  and tcbQueued_opt_pred[wp]: "\<lambda>s. P (tcbQueued |< tcbs_of' s)"
-  and valid_sched_pointers[wp]: valid_sched_pointers
-  and sched_projs[wp]: "\<lambda>s. P (tcbSchedNexts_of s) (tcbSchedPrevs_of s)"
-  and ksDomScheduleIdx[wp]: "\<lambda>s. P (ksDomScheduleIdx s)"
-  and ksDomScheduleStart[wp]: "\<lambda>s. P (ksDomScheduleStart s)"
-  (wp: valid_bitmaps_lift)
-
-lemma emptySlot_invs'[wp]:
-  "\<lbrace>\<lambda>s. invs' s \<and> cte_wp_at' (\<lambda>cte. removeable' sl s (cteCap cte)) sl s
-            \<and> (info \<noteq> NullCap \<longrightarrow> post_cap_delete_pre' info sl (cteCaps_of s) )\<rbrace>
-     emptySlot sl info
-   \<lbrace>\<lambda>rv. invs'\<rbrace>"
-  apply (simp add: invs'_def valid_state'_def valid_pspace'_def)
-  apply (wpsimp wp: valid_irq_node_lift cur_tcb_lift valid_dom_schedule'_lift)
-  apply (clarsimp simp: post_cap_delete_pre'_def cteCaps_of_def cte_wp_at_ctes_of
-                 split: capability.split_asm arch_capability.split_asm)
-  by auto
-
-lemma deletedIRQHandler_corres:
-  "corres dc \<top> \<top>
-    (deleted_irq_handler irq)
-    (deletedIRQHandler irq)"
-  apply (simp add: deleted_irq_handler_def deletedIRQHandler_def)
-  apply (rule setIRQState_corres)
-  apply (simp add: irq_state_relation_def)
-  done
-
-lemma corres_gets_allocated_io_ports [corres]:
-  "corres (=) \<top> \<top>
-        (gets (x64_allocated_io_ports \<circ> arch_state))
-        (gets (x64KSAllocatedIOPorts \<circ> ksArchState))"
-  by (simp add: state_relation_def arch_state_relation_def)
-
-lemma set_ioport_mask_corres[corres]:
-  "corres dc \<top> \<top>
-     (set_ioport_mask f l b)
-     (setIOPortMask f l b)"
-  apply (clarsimp simp: set_ioport_mask_def setIOPortMask_def)
-  apply (rule corres_guard_imp)
-    apply (rule corres_split_eqr[OF corres_gets_allocated_io_ports])
-      apply (rule corres_modify)
-      apply (clarsimp simp: state_relation_def arch_state_relation_def foldl_map
-                            foldl_fun_upd)
-     by wpsimp+
-
-lemma arch_postCapDeletion_corres:
-  "acap_relation cap cap' \<Longrightarrow> corres dc \<top> \<top> (arch_post_cap_deletion cap) (X64_H.postCapDeletion cap')"
-  apply (clarsimp simp: arch_post_cap_deletion_def X64_H.postCapDeletion_def)
-  apply (rule corres_guard_imp)
-    apply (case_tac cap; clarsimp simp: acap_relation_def)
-    apply (clarsimp simp: free_ioport_range_def freeIOPortRange_def)
-    apply (rule set_ioport_mask_corres)
-   by clarsimp+
-
-lemma postCapDeletion_corres:
-  "cap_relation cap cap' \<Longrightarrow> corres dc \<top> \<top> (post_cap_deletion cap) (postCapDeletion cap')"
-  apply (cases cap; clarsimp simp: post_cap_deletion_def Retype_H.postCapDeletion_def)
-   apply (corresKsimp corres: deletedIRQHandler_corres)
-  by (corresKsimp corres: arch_postCapDeletion_corres)
-
-lemma set_cap_trans_state:
-  "((),s') \<in> fst (set_cap c p s) \<Longrightarrow> ((),trans_state f s') \<in> fst (set_cap c p (trans_state f s))"
-  apply (cases p)
-  apply (clarsimp simp add: set_cap_def in_monad set_object_def get_object_def)
-  apply (case_tac y)
-      apply (auto simp add: in_monad set_object_def split: if_split_asm)
-  done
-
-lemma clearUntypedFreeIndex_noop_corres:
-  "corres dc \<top> (cte_at' (cte_map slot))
-    (return ()) (clearUntypedFreeIndex (cte_map slot))"
-  apply (simp add: clearUntypedFreeIndex_def)
-  apply (rule corres_guard_imp)
-    apply (rule corres_bind_return2)
-    apply (rule corres_symb_exec_r_conj[where P'="cte_at' (cte_map slot)"])
-       apply (rule corres_trivial, simp)
-      apply (wp getCTE_wp' | wpc
-        | simp add: updateTrackedFreeIndex_def getSlotCap_def)+
-     apply (clarsimp simp: state_relation_def)
-    apply (rule no_fail_pre)
-     apply (wp no_fail_getSlotCap getCTE_wp'
-       | wpc | simp add: updateTrackedFreeIndex_def getSlotCap_def)+
-  done
-
-lemma clearUntypedFreeIndex_valid_pspace'[wp]:
-  "\<lbrace>valid_pspace'\<rbrace> clearUntypedFreeIndex slot \<lbrace>\<lambda>rv. valid_pspace'\<rbrace>"
-  apply (simp add: valid_pspace'_def)
-  apply (rule hoare_pre)
-   apply (wp | simp add: valid_mdb'_def)+
-  done
-
-lemma emptySlot_corres:
-  "cap_relation info info' \<Longrightarrow> corres dc (einvs and cte_at slot) (invs' and cte_at' (cte_map slot))
-             (empty_slot slot info) (emptySlot (cte_map slot) info')"
-  unfolding emptySlot_def empty_slot_def
-  apply (simp add: case_Null_If)
-  apply (rule corres_guard_imp)
-    apply (rule corres_split_noop_rhs[OF clearUntypedFreeIndex_noop_corres])
-     apply (rule_tac R="\<lambda>cap. einvs and cte_wp_at ((=) cap) slot" and
-                     R'="\<lambda>cte. valid_pspace' and cte_wp_at' ((=) cte) (cte_map slot)" in
-                     corres_split[OF get_cap_corres])
-       defer
-       apply (wp get_cap_wp getCTE_wp')+
-     apply (simp add: cte_wp_at_ctes_of)
-     apply (wp hoare_vcg_imp_lift' clearUntypedFreeIndex_valid_pspace')
-    apply fastforce
-   apply (fastforce simp: cte_wp_at_ctes_of)
-  apply simp
-  apply (rule conjI, clarsimp)
-   defer
-  apply clarsimp
-  apply (rule conjI, clarsimp)
-  apply clarsimp
-  apply (simp only: bind_assoc[symmetric])
-  apply (rule corres_underlying_split[where r'=dc, OF _ postCapDeletion_corres])
-    defer
-    apply wpsimp+
-  apply (rule corres_no_failI)
-   apply (rule no_fail_pre, wp hoare_weak_lift_imp)
-   apply (clarsimp simp: cte_wp_at_ctes_of valid_pspace'_def)
-   apply (clarsimp simp: valid_mdb'_def valid_mdb_ctes_def)
-   apply (rule conjI, clarsimp)
-    apply (erule (2) valid_dlistEp)
-    apply simp
-   apply clarsimp
-   apply (erule (2) valid_dlistEn)
-   apply simp
-  apply (clarsimp simp: in_monad bind_assoc exec_gets)
-  apply (subgoal_tac "mdb_empty_abs a")
-   prefer 2
-   apply (rule mdb_empty_abs.intro)
-   apply (rule vmdb_abs.intro)
-   apply fastforce
-  apply (frule mdb_empty_abs'.intro)
-  apply (simp add: mdb_empty_abs'.empty_slot_ext_det_def2 update_cdt_list_def set_cdt_list_def exec_gets set_cdt_def bind_assoc exec_get exec_put set_original_def modify_def del: fun_upd_apply | subst bind_def, simp, simp add: mdb_empty_abs'.empty_slot_ext_det_def2)+
-  apply (simp add: put_def)
-  apply (simp add: exec_gets exec_get exec_put del: fun_upd_apply | subst bind_def)+
-  apply (clarsimp simp: state_relation_def)
-  apply (drule updateMDB_the_lot, fastforce simp: pspace_relation_def, fastforce, fastforce)
-   apply (clarsimp simp: invs'_def valid_state'_def valid_pspace'_def
-                         valid_mdb'_def valid_mdb_ctes_def)
-  apply (elim conjE)
-  apply (drule (4) updateMDB_the_lot, elim conjE)
-  apply clarsimp
-  apply (drule_tac s'=s''a and c=cap.NullCap in set_cap_not_quite_corres)
-                      subgoal by simp
-                     subgoal by simp
-                    subgoal by simp
-                   subgoal by simp
-                  subgoal by fastforce
-                 subgoal by fastforce
-                subgoal by fastforce
-               subgoal by fastforce
-              subgoal by fastforce
-             apply fastforce
-            subgoal by fastforce
-           subgoal by fastforce
-          subgoal by fastforce
-         apply (erule cte_wp_at_weakenE, rule TrueI)
-        apply assumption
-       subgoal by simp
-      subgoal by simp
-     subgoal by simp
-    subgoal by simp
-   apply (rule refl)
-  apply clarsimp
-  apply (drule updateCap_stuff, elim conjE, erule (1) impE)
-  apply clarsimp
-  apply (drule updateMDB_the_lot, force simp: pspace_relation_def, assumption+, simp)
-  apply (rule bexI)
-   prefer 2
-   apply (simp only: trans_state_update[symmetric])
-   apply (rule set_cap_trans_state)
-   apply (rule set_cap_revokable_update)
-   apply (erule set_cap_cdt_update)
-  apply clarsimp
-  apply (thin_tac "ctes_of t = s" for t s)+
-  apply (thin_tac "ksMachineState t = p" for t p)+
-  apply (thin_tac "ksCurThread t = p" for t p)+
-  apply (thin_tac "ksReadyQueues t = p" for t p)+
-  apply (thin_tac "ksSchedulerAction t = p" for t p)+
-  apply (clarsimp simp: cte_wp_at_ctes_of)
-  apply (case_tac rv')
-  apply (rename_tac s_cap s_node)
-  apply (subgoal_tac "cte_at slot a")
-   prefer 2
-   apply (fastforce elim: cte_wp_at_weakenE)
-  apply (subgoal_tac "mdb_empty (ctes_of b) (cte_map slot) s_cap s_node")
-   prefer 2
-   apply (rule mdb_empty.intro)
-   apply (rule mdb_ptr.intro)
-    apply (rule vmdb.intro)
-    subgoal by (simp add: invs'_def valid_state'_def valid_pspace'_def valid_mdb'_def)
-   apply (rule mdb_ptr_axioms.intro)
-   subgoal by simp
-  apply (clarsimp simp: ghost_relation_typ_at set_cap_a_type_inv)
-  apply (simp add: pspace_relation_def)
-  apply (rule conjI)
-   apply (clarsimp simp: data_at_def ghost_relation_typ_at set_cap_a_type_inv)
-  apply (rule conjI)
-   prefer 2
-   apply (rule conjI)
-    apply (clarsimp simp: cdt_list_relation_def)
-    apply(frule invs_valid_pspace, frule invs_mdb)
-    apply(subgoal_tac "no_mloop (cdt a) \<and> finite_depth (cdt a)")
-     prefer 2
-     subgoal by(simp add: finite_depth valid_mdb_def)
-    apply(subgoal_tac "valid_mdb_ctes (ctes_of b)")
-     prefer 2
-     subgoal by(simp add: mdb_empty_def mdb_ptr_def vmdb_def)
-    apply(clarsimp simp: valid_pspace_def)
-
-    apply(case_tac "cdt a slot")
-     apply(simp add: next_slot_eq[OF mdb_empty_abs'.next_slot_no_parent])
-     apply(case_tac "next_slot (aa, bb) (cdt_list a) (cdt a)")
-      subgoal by (simp)
-     apply(clarsimp)
-     apply(frule(1) mdb_empty.n_next)
-     apply(clarsimp)
-     apply(erule_tac x=aa in allE, erule_tac x=bb in allE)
-     apply(simp split: if_split_asm)
-      apply(drule cte_map_inj_eq)
-           apply(drule cte_at_next_slot)
-             apply(assumption)+
-      apply(simp)
-     apply(subgoal_tac "(ab, bc) = slot")
-      prefer 2
-      apply(drule_tac cte="CTE s_cap s_node" in valid_mdbD2')
-        subgoal by (clarsimp simp: valid_mdb_ctes_def no_0_def)
-       subgoal by (clarsimp simp: invs'_def valid_state'_def valid_pspace'_def)
-      apply(clarsimp)
-      apply(rule cte_map_inj_eq)
-           apply(assumption)
-          apply(drule(3) cte_at_next_slot', assumption)
-         apply(assumption)+
-     apply(simp)
-     apply(drule_tac p="(aa, bb)" in no_parent_not_next_slot)
-        apply(assumption)+
-     apply(clarsimp)
-
-    apply(simp add: next_slot_eq[OF mdb_empty_abs'.next_slot] split del: if_split)
-    apply(case_tac "next_slot (aa, bb) (cdt_list a) (cdt a)")
-     subgoal by (simp)
-    apply(case_tac "(aa, bb) = slot", simp)
-    apply(case_tac "next_slot (aa, bb) (cdt_list a) (cdt a) = Some slot")
-     apply(simp)
-     apply(case_tac "next_slot ac (cdt_list a) (cdt a)", simp)
-     apply(simp)
-     apply(frule(1) mdb_empty.n_next)
-     apply(clarsimp)
-     apply(erule_tac x=aa in allE', erule_tac x=bb in allE)
-     apply(erule_tac x=ac in allE, erule_tac x=bd in allE)
-     apply(clarsimp split: if_split_asm)
-      apply(drule(1) no_self_loop_next)
-      apply(simp)
-     apply(drule_tac cte="CTE cap' node'" in valid_mdbD1')
-       apply(fastforce simp: valid_mdb_ctes_def no_0_def)
-      subgoal by (simp add: valid_mdb'_def)
-     apply(clarsimp)
-    apply(simp)
-    apply(frule(1) mdb_empty.n_next)
-    apply(erule_tac x=aa in allE, erule_tac x=bb in allE)
-    apply(clarsimp split: if_split_asm)
-     apply(drule(1) no_self_loop_prev)
-     apply(clarsimp)
-     apply(drule_tac cte="CTE s_cap s_node" in valid_mdbD2')
-       apply(clarsimp simp: valid_mdb_ctes_def no_0_def)
-      apply clarify
-     apply(clarsimp)
-     apply(drule cte_map_inj_eq)
-          apply(drule(3) cte_at_next_slot')
-          apply(assumption)+
-     apply(simp)
-    apply(erule disjE)
-     apply(drule cte_map_inj_eq)
-          apply(drule(3) cte_at_next_slot)
-          apply(assumption)+
-     apply(simp)
-    subgoal by (simp)
-   apply (simp add: revokable_relation_def)
-   apply (clarsimp simp: in_set_cap_cte_at)
-   apply (rule conjI)
-    apply clarsimp
-    apply (drule(1) mdb_empty.n_revokable)
-    subgoal by clarsimp
-   apply clarsimp
-   apply (drule (1) mdb_empty.n_revokable)
-   apply (subgoal_tac "null_filter (caps_of_state a) (aa,bb) \<noteq> None")
-    prefer 2
-    apply (drule set_cap_caps_of_state_monad)
-    subgoal by (force simp: null_filter_def)
-   apply clarsimp
-   apply (subgoal_tac "cte_at (aa, bb) a")
-    prefer 2
-    apply (drule null_filter_caps_of_stateD, erule cte_wp_cte_at)
-   apply (drule (2) cte_map_inj_ps, fastforce)
-   subgoal by simp
-  apply (clarsimp simp add: cdt_relation_def)
-  apply (subst mdb_empty_abs.descendants, assumption)
-  apply (subst mdb_empty.descendants, assumption)
-  apply clarsimp
-  apply (frule_tac p="(aa, bb)" in in_set_cap_cte_at)
-  apply clarsimp
-  apply (frule (2) cte_map_inj_ps, fastforce)
-  apply simp
-  apply (case_tac "slot \<in> descendants_of (aa,bb) (cdt a)")
-   apply (subst inj_on_image_set_diff)
-      apply (rule inj_on_descendants_cte_map)
-         apply fastforce
-        apply fastforce
-       apply fastforce
-      apply fastforce
-     apply fastforce
-    subgoal by simp
-   subgoal by simp
-  apply simp
-  apply (subgoal_tac "cte_map slot \<notin> descendants_of' (cte_map (aa,bb)) (ctes_of b)")
-   subgoal by simp
-  apply (erule_tac x=aa in allE, erule allE, erule (1) impE)
-  apply (drule_tac s="cte_map ` u" for u in sym)
-  apply clarsimp
-  apply (drule cte_map_inj_eq, assumption)
-      apply (erule descendants_of_cte_at, fastforce)
-     apply fastforce
-    apply fastforce
-   apply fastforce
-  apply simp
-  done
-
-
-
-text \<open>Some facts about is_final_cap/isFinalCapability\<close>
-
-lemma isFinalCapability_inv:
-  "\<lbrace>P\<rbrace> isFinalCapability cap \<lbrace>\<lambda>_. P\<rbrace>"
-  apply (simp add: isFinalCapability_def Let_def
-              split del: if_split cong: if_cong)
-  apply (rule hoare_pre, wp)
-   apply (rule hoare_post_imp[where Q'="\<lambda>s. P"], simp)
-   apply wp
-  apply simp
-  done
-
-definition
-  final_matters' :: "capability \<Rightarrow> bool"
-where
- "final_matters' cap \<equiv> case cap of
-    EndpointCap ref bdg s r g gr \<Rightarrow> True
-  | NotificationCap ref bdg s r \<Rightarrow> True
-  | ThreadCap ref \<Rightarrow> True
-  | CNodeCap ref bits gd gs \<Rightarrow> True
-  | Zombie ptr zb n \<Rightarrow> True
-  | IRQHandlerCap irq \<Rightarrow> True
-  | ArchObjectCap acap \<Rightarrow> (case acap of
-    PageCap ref rghts mt sz d mapdata \<Rightarrow> False
-  | ASIDControlCap \<Rightarrow> False
-  | IOPortControlCap \<Rightarrow> False
-  | _ \<Rightarrow> True)
-  | _ \<Rightarrow> False"
-
 lemma final_matters_Master:
   "final_matters' (capMasterCap cap) = final_matters' cap"
   by (simp add: capMasterCap_def arch_capMasterCap_def split: capability.split arch_capability.split,
-      simp add: final_matters'_def)
+      simp add: final_matters'_def arch_final_matters'_def)
 
 lemma final_matters_sameRegion_sameObject:
   "final_matters' cap \<Longrightarrow> sameRegionAs cap cap' = sameObjectAs cap cap'"
   apply (rule iffI)
    apply (erule sameRegionAsE)
       apply (simp add: sameObjectAs_def3)
-      apply (clarsimp simp: isCap_simps sameObjectAs_sameRegionAs final_matters'_def
-        split:capability.splits arch_capability.splits)+
+      apply (clarsimp simp: isCap_simps sameObjectAs_sameRegionAs
+                            final_matters'_def arch_final_matters'_def
+                      split: capability.splits arch_capability.splits)+
   done
 
 lemma final_matters_sameRegion_sameObject2:
   "\<lbrakk> final_matters' cap'; \<not> isUntypedCap cap; \<not> isIRQHandlerCap cap'; \<not> isArchIOPortCap cap' \<rbrakk>
-     \<Longrightarrow> sameRegionAs cap cap' = sameObjectAs cap cap'"
+   \<Longrightarrow> sameRegionAs cap cap' = sameObjectAs cap cap'"
   apply (rule iffI)
    apply (erule sameRegionAsE)
        apply (simp add: sameObjectAs_def3)
-       apply (fastforce simp: isCap_simps final_matters'_def)
+       apply (fastforce simp: isCap_simps final_matters'_def arch_final_matters'_def)
       apply simp
-     apply (clarsimp simp: final_matters'_def isCap_simps)
+     apply (clarsimp simp: final_matters'_def arch_final_matters'_def isCap_simps)
     apply (clarsimp simp: final_matters'_def isCap_simps)
    apply (clarsimp simp: final_matters'_def isCap_simps)
   apply (erule sameObjectAs_sameRegionAs)
@@ -1922,16 +479,15 @@ lemma final_matters_sameRegion_sameObject2:
 
 lemma final_matters_mdb_chunked_arch_assms:
   "final_matters' cap \<Longrightarrow> mdb_chunked_arch_assms cap"
-  by (clarsimp simp: mdb_chunked_arch_assms_def)
+  by (clarsimp simp: mdb_chunked_arch_assms_def isCap_simps
+                     final_matters'_def arch_final_matters'_def)
 
-lemma notFinal_prev_or_next:
+lemma notFinal_prev_or_next[Finalise_R_2_assms]:
   "\<lbrakk> \<not> isFinal cap x (cteCaps_of s); mdb_chunked (ctes_of s);
-      valid_dlist (ctes_of s); no_0 (ctes_of s);
-      ctes_of s x = Some (CTE cap node); final_matters' cap \<rbrakk>
-     \<Longrightarrow> (\<exists>cap' node'. ctes_of s (mdbPrev node) = Some (CTE cap' node')
-              \<and> sameObjectAs cap cap')
-      \<or> (\<exists>cap' node'. ctes_of s (mdbNext node) = Some (CTE cap' node')
-              \<and> sameObjectAs cap cap')"
+     valid_dlist (ctes_of s); no_0 (ctes_of s);
+     ctes_of s x = Some (CTE cap node); final_matters' cap \<rbrakk>
+   \<Longrightarrow> (\<exists>cap' node'. ctes_of s (mdbPrev node) = Some (CTE cap' node') \<and> sameObjectAs cap cap')
+      \<or> (\<exists>cap' node'. ctes_of s (mdbNext node) = Some (CTE cap' node') \<and> sameObjectAs cap cap')"
   apply (erule not_FinalE)
    apply (clarsimp simp: isCap_simps final_matters'_def)
   apply (frule final_matters_mdb_chunked_arch_assms)
@@ -1973,91 +529,20 @@ lemma notFinal_prev_or_next:
   apply (clarsimp simp: sameObjectAs_def3 simp del: isArchFrameCap_capMasterCap)
   done
 
-lemma isFinal:
-  "\<lbrace>\<lambda>s. valid_mdb' s \<and> cte_wp_at' ((=) cte) x s
-          \<and> final_matters' (cteCap cte)
-          \<and> Q (isFinal (cteCap cte) x (cteCaps_of s)) s\<rbrace>
-    isFinalCapability cte
-   \<lbrace>Q\<rbrace>"
-  unfolding isFinalCapability_def
-  apply (cases cte)
-  apply (rename_tac cap node)
-  apply (unfold Let_def)
-  apply (simp only: if_False)
-  apply (wp getCTE_wp')
-  apply (cases "mdbPrev (cteMDBNode cte) = nullPointer")
-   apply simp
-   apply (clarsimp simp: valid_mdb_ctes_def valid_mdb'_def
-                         cte_wp_at_ctes_of)
-   apply (rule conjI, clarsimp simp: nullPointer_def)
-    apply (erule rsubst[where P="\<lambda>x. Q x s" for s], simp)
-    apply (rule classical)
-    apply (drule(5) notFinal_prev_or_next)
-    apply clarsimp
-   apply (clarsimp simp: nullPointer_def)
-   apply (erule rsubst[where P="\<lambda>x. Q x s" for s])
-   apply (rule sym, rule iffI)
-    apply (rule classical)
-    apply (drule(5) notFinal_prev_or_next)
-    apply clarsimp
-   apply clarsimp
-   apply (clarsimp simp: cte_wp_at_ctes_of cteCaps_of_def)
-   apply (case_tac cte)
-   apply clarsimp
-   apply (clarsimp simp add: isFinal_def)
-   apply (erule_tac x="mdbNext node" in allE)
-   apply simp
-   apply (erule impE)
-    apply (clarsimp simp: valid_mdb'_def valid_mdb_ctes_def)
-    apply (drule (1) mdb_chain_0_no_loops)
-    apply simp
-   apply (clarsimp simp: sameObjectAs_def3 isCap_simps)
-  apply simp
-  apply (clarsimp simp: cte_wp_at_ctes_of
-                        valid_mdb_ctes_def valid_mdb'_def)
-  apply (case_tac cte)
-  apply clarsimp
-  apply (rule conjI)
-   apply clarsimp
-   apply (erule rsubst[where P="\<lambda>x. Q x s" for s])
-   apply clarsimp
-   apply (clarsimp simp: isFinal_def cteCaps_of_def)
-   apply (erule_tac x="mdbPrev node" in allE)
-   apply simp
-   apply (erule impE)
-    apply clarsimp
-    apply (drule (1) mdb_chain_0_no_loops)
-    apply (subgoal_tac "ctes_of s (mdbNext node) = Some (CTE cap node)")
-     apply clarsimp
-    apply (erule (1) valid_dlistEp)
-     apply clarsimp
-    apply (case_tac cte')
-    apply clarsimp
-   apply (clarsimp simp add: sameObjectAs_def3 isCap_simps)
-  apply clarsimp
-  apply (rule conjI)
-   apply clarsimp
-   apply (erule rsubst[where P="\<lambda>x. Q x s" for s], simp)
-   apply (rule classical, drule(5) notFinal_prev_or_next)
-   apply (clarsimp simp: sameObjectAs_sym nullPointer_def)
-  apply (clarsimp simp: nullPointer_def)
-  apply (erule rsubst[where P="\<lambda>x. Q x s" for s])
-  apply (rule sym, rule iffI)
-   apply (rule classical, drule(5) notFinal_prev_or_next)
-   apply (clarsimp simp: sameObjectAs_sym)
-   apply auto[1]
-  apply (clarsimp simp: isFinal_def cteCaps_of_def)
-  apply (case_tac cte)
-  apply (erule_tac x="mdbNext node" in allE)
-  apply simp
-  apply (erule impE)
-   apply clarsimp
-   apply (drule (1) mdb_chain_0_no_loops)
-   apply simp
-  apply clarsimp
-  apply (clarsimp simp: isCap_simps sameObjectAs_def3)
-  done
-end
+lemma sameObjectAs_not_Untyped[Finalise_R_2_assms]:
+  "\<lbrakk> global.sameObjectAs cap cap'; \<not> isUntypedCap cap \<rbrakk>
+   \<Longrightarrow> \<not> isUntypedCap cap'"
+  by (clarsimp simp: gen_isCap_simps sameObjectAs_def3)
+
+lemma sameObjectAs_not_Untyped'[Finalise_R_2_assms]:
+  "\<lbrakk> global.sameObjectAs cap cap'; \<not> isUntypedCap cap' \<rbrakk>
+   \<Longrightarrow> global.sameObjectAs cap' cap"
+  by (clarsimp simp: isCap_simps sameObjectAs_def3)
+
+end (* Arch *)
+
+(* only two arch-specific lemmas in vmdb;
+   save processing time by not creating an extra Arch_vmdb locale, directly requalify instead *)
 
 lemma (in vmdb) isFinal_no_subtree:
   "\<lbrakk> m \<turnstile> sl \<rightarrow> p; isFinal cap sl (option_map cteCap o m);
@@ -2067,22 +552,11 @@ lemma (in vmdb) isFinal_no_subtree:
    apply (clarsimp simp: isFinal_def parentOf_def mdb_next_unfold cteCaps_of_def)
    apply (erule_tac x="mdbNext n" in allE)
    apply simp
-   apply (clarsimp simp: X64.isMDBParentOf_CTE final_matters_sameRegion_sameObject) (* FIXME arch-split *)
+   apply (clarsimp simp: X64.isMDBParentOf_CTE X64.final_matters_sameRegion_sameObject)
    apply (clarsimp simp: gen_isCap_simps X64.sameObjectAs_def3)
   apply clarsimp
   done
 
-lemma isFinal_no_descendants:
-  "\<lbrakk> isFinal cap sl (cteCaps_of s); ctes_of s sl = Some (CTE cap n);
-      valid_mdb' s; final_matters' cap \<rbrakk>
-  \<Longrightarrow> descendants_of' sl (ctes_of s) = {}"
-  apply (clarsimp simp add: descendants_of'_def cteCaps_of_def)
-  apply (erule(3) vmdb.isFinal_no_subtree[rotated])
-  apply unfold_locales[1]
-  apply (simp add: valid_mdb'_def)
-  done
-
-(* FIXME arch-split: locale+Arch combination *)
 lemma (in vmdb) isFinal_untypedParent:
   assumes x: "m slot = Some cte" "isFinal (cteCap cte) slot (option_map cteCap o m)"
              "final_matters' (cteCap cte) \<and> \<not> isIRQHandlerCap (cteCap cte) \<and> \<not> X64.isArchIOPortCap (cteCap cte)"
@@ -2106,65 +580,543 @@ lemma (in vmdb) isFinal_untypedParent:
   apply (drule isMDBParent_sameRegion)
   apply simp
   apply (rule classical, simp)
-  apply (simp add: final_matters_sameRegion_sameObject2
+  apply (simp add: X64.final_matters_sameRegion_sameObject2
                    sameObjectAs_sym)
   done
 
-context begin interpretation Arch . (*FIXME: arch-split*)
+context Arch begin arch_global_naming
 
-lemma no_fail_isFinalCapability [wp]:
-  "no_fail (valid_mdb' and cte_wp_at' ((=) cte) p) (isFinalCapability cte)"
-  apply (simp add: isFinalCapability_def)
-  apply (clarsimp simp: Let_def split del: if_split)
-  apply (rule no_fail_pre, wp getCTE_wp')
-  apply (clarsimp simp: valid_mdb'_def valid_mdb_ctes_def cte_wp_at_ctes_of nullPointer_def)
-  apply (rule conjI)
-   apply clarsimp
-   apply (erule (2) valid_dlistEp)
-   apply simp
+lemma isFinal_no_descendants:
+  "\<lbrakk> isFinal cap sl (cteCaps_of s); ctes_of s sl = Some (CTE cap n);
+      valid_mdb' s; final_matters' cap \<rbrakk>
+  \<Longrightarrow> descendants_of' sl (ctes_of s) = {}"
+  apply (clarsimp simp add: descendants_of'_def cteCaps_of_def)
+  apply (erule(3) vmdb.isFinal_no_subtree[rotated])
+  apply unfold_locales[1]
+  apply (simp add: valid_mdb'_def)
+  done
+
+lemmas cancelAllIPC_typs[wp] = typ_at_lifts[OF cancelAllIPC_typ_at']
+lemmas cancelAllSignals_typs[wp] = typ_at_lifts[OF cancelAllSignals_typ_at']
+lemmas suspend_typs[wp] = typ_at_lifts[OF suspend_typ_at']
+
+lemmas finaliseCap_typ_ats[wp] = typ_at_lifts[OF finaliseCap_typ_at']
+
+lemma invs_asid_update_strg':
+  "invs' s \<and> tab = x64KSASIDTable (ksArchState s) \<longrightarrow>
+   invs' (s\<lparr>ksArchState := x64KSASIDTable_update
+            (\<lambda>_. tab (asid := None)) (ksArchState s)\<rparr>)"
+  apply (simp add: invs'_def)
+  apply (simp add: valid_state'_def)
+  apply (simp add: valid_global_refs'_def global_refs'_def valid_arch_state'_def
+                   valid_asid_table'_def valid_machine_state'_def ct_idle_or_in_cur_domain'_def
+                   tcb_in_cur_domain'_def)
+  apply (auto simp add: ran_def split: if_split_asm)
+  done
+
+lemma hwASIDInvalidate_invs'[wp]:
+  "\<lbrace>invs'\<rbrace> hwASIDInvalidate asid vs \<lbrace>\<lambda>r. invs'\<rbrace>"
+  by (wpsimp simp: hwASIDInvalidate_def)
+
+lemma deleteASIDPool_invs[wp]:
+  "\<lbrace>invs'\<rbrace> deleteASIDPool asid pool \<lbrace>\<lambda>rv. invs'\<rbrace>"
+  apply (simp add: deleteASIDPool_def)
+  apply wp
+    apply (simp del: fun_upd_apply)
+    apply (strengthen invs_asid_update_strg')
+  apply (wp mapM_wp' getObject_inv loadObject_default_inv
+              | simp)+
+  done
+
+lemma deleteASID_invs'[wp]:
+  "\<lbrace>invs'\<rbrace> deleteASID asid pd \<lbrace>\<lambda>rv. invs'\<rbrace>"
+  supply inj_ASIDPool[simp del]
+  apply (simp add: deleteASID_def cong: option.case_cong)
+  apply (rule hoare_pre)
+   apply (wp | wpc)+
+    apply (rule_tac Q'="\<lambda>rv. valid_obj' (injectKO rv) and invs'"
+              in hoare_post_imp)
+     apply (rename_tac rv s)
+     apply (clarsimp split: if_split_asm del: subsetI)
+     apply (simp add: fun_upd_def[symmetric] valid_obj'_def)
+     apply (case_tac rv, simp)
+     apply (subst inv_f_f, rule inj_onI, simp)+
+     apply (rule conjI)
+      apply clarsimp
+      apply (drule subsetD, blast)
+      apply clarsimp
+     apply (auto dest!: ran_del_subset)[1]
+    apply (wp getObject_valid_obj getObject_inv loadObject_default_inv
+           | simp add: X64.objBits_simps pageBits_def)+
   apply clarsimp
-  apply (rule conjI)
-   apply (erule (2) valid_dlistEn)
-   apply simp
+  done
+
+lemma archThreadSet_valid_objs'[wp]:
+  "\<lbrace>valid_objs' and (\<lambda>s. \<forall>tcb. ko_at' tcb t s \<longrightarrow> valid_arch_tcb' (f (tcbArch tcb)) s)\<rbrace>
+   archThreadSet f t \<lbrace>\<lambda>_. valid_objs'\<rbrace>"
+  unfolding archThreadSet_def
+  apply (wp setObject_tcb_valid_objs getObject_tcb_wp)
   apply clarsimp
-  apply (rule valid_dlistEn, assumption+)
-  apply (erule (2) valid_dlistEp)
+  apply normalise_obj_at'
+  apply (drule (1) tcb_ko_at_valid_objs_valid_tcb')
+  apply (clarsimp simp: valid_obj'_def valid_tcb'_def tcb_cte_cases_def cteSizeBits_def)
+  done
+
+crunch archThreadSet
+  for no_0_obj'[wp]: no_0_obj'
+
+lemma archThreadSet_ctes_of[wp]:
+  "archThreadSet f t \<lbrace>\<lambda>s. P (ctes_of s)\<rbrace>"
+  unfolding archThreadSet_def
+  apply (wpsimp wp: getObject_tcb_wp)
+  apply normalise_obj_at'
+  apply (auto simp: tcb_cte_cases_def cteSizeBits_def)
+  done
+
+crunch archThreadSet
+  for ksCurDomain[wp]: "\<lambda>s. P (ksCurDomain s)"
+  (wp: setObject_cd_inv)
+
+lemma archThreadSet_obj_at':
+  "(\<And>tcb. P tcb \<Longrightarrow> P (tcb \<lparr> tcbArch:= f (tcbArch tcb)\<rparr>)) \<Longrightarrow> archThreadSet f t \<lbrace>obj_at' P t'\<rbrace>"
+  unfolding archThreadSet_def
+  apply (wpsimp wp: getObject_tcb_wp setObject_tcb_strongest)
+  apply normalise_obj_at'
+  apply auto
+  done
+
+lemma archThreadSet_tcbDomain[wp]:
+  "archThreadSet f t \<lbrace>obj_at' (\<lambda>tcb. x = tcbDomain tcb) t'\<rbrace>"
+  by (wpsimp wp: archThreadSet_obj_at')
+
+lemma archThreadSet_inQ[wp]:
+  "archThreadSet f t' \<lbrace>\<lambda>s. P (obj_at' (inQ d p) t s)\<rbrace>"
+  unfolding obj_at'_real_def archThreadSet_def
+  apply (wpsimp wp: setObject_ko_wp_at getObject_tcb_wp
+              simp: objBits_simps' archObjSize_def pageBits_def
+         | simp)+
+  apply (auto simp: obj_at'_def ko_wp_at'_def)
+  done
+
+crunch archThreadSet
+  for ct[wp]: "\<lambda>s. P (ksCurThread s)"
+  and sched[wp]: "\<lambda>s. P (ksSchedulerAction s)"
+  and L1[wp]: "\<lambda>s. P (ksReadyQueuesL1Bitmap s)"
+  and L2[wp]: "\<lambda>s. P (ksReadyQueuesL2Bitmap s)"
+  and ksArch[wp]: "\<lambda>s. P (ksArchState s)"
+  and ksDomSchedule[wp]: "\<lambda>s. P (ksDomSchedule s)"
+  and pspace_canonical'[wp]: pspace_canonical'
+  and gsMaxObjectSize[wp]: "\<lambda>s. P (gsMaxObjectSize s)"
+  and ksInterruptState[wp]: "\<lambda>s. P (ksInterruptState s)"
+  (wp: setObject_ct_inv setObject_sa_unchanged setObject_ksDomSchedule_inv)
+
+crunch archThreadSet
+  for ksDomScheduleIdx[wp]: "\<lambda>s. P (ksDomScheduleIdx s)"
+  and ksDomScheduleStart[wp]: "\<lambda>s. P (ksDomScheduleStart s)"
+  (simp: setObject_def wp: updateObject_default_inv)
+
+crunch archThreadSet
+  for ksMachineState[wp]: "\<lambda>s. P (ksMachineState s)"
+  (wp: setObject_ksMachine updateObject_default_inv)
+
+lemma archThreadSet_state_refs_of'[wp]:
+  "archThreadSet f t \<lbrace>\<lambda>s. P (state_refs_of' s)\<rbrace>"
+  unfolding archThreadSet_def
+  apply (wpsimp wp: setObject_tcb_state_refs_of' getObject_tcb_wp)
+  apply normalise_obj_at'
+  apply (erule rsubst[where P=P])
+  apply (rule ext)
+  apply (auto simp: state_refs_of'_def obj_at'_def)
+  done
+
+lemma archThreadSet_state_hyp_refs_of'[wp]:
+  "\<lbrace>\<lambda>s. \<forall>tcb. ko_at' tcb t s \<longrightarrow> P ((state_hyp_refs_of' s)(t := tcb_hyp_refs' (f (tcbArch tcb))))\<rbrace>
+  archThreadSet f t \<lbrace>\<lambda>_ s. P (state_hyp_refs_of' s)\<rbrace>"
+  unfolding archThreadSet_def
+  apply (wpsimp wp: setObject_state_hyp_refs_of' getObject_tcb_wp simp: objBits_simps')
+  apply normalise_obj_at'
+  apply (erule rsubst[where P=P])
+  apply auto
+  done
+
+lemma archThreadSet_if_live'[wp]:
+  "\<lbrace>\<lambda>s. if_live_then_nonz_cap' s \<and>
+        (\<forall>tcb. ko_at' tcb t s \<longrightarrow> atcbVCPUPtr (f (tcbArch tcb)) \<noteq> None \<longrightarrow> ex_nonz_cap_to' t s)\<rbrace>
+  archThreadSet f t \<lbrace>\<lambda>_. if_live_then_nonz_cap'\<rbrace>"
+  unfolding archThreadSet_def
+  apply (wpsimp wp: setObject_tcb_iflive' getObject_tcb_wp)
+  apply normalise_obj_at'
+  apply (clarsimp simp: tcb_cte_cases_def if_live_then_nonz_cap'_def cteSizeBits_def)
+  apply (erule_tac x=t in allE)
+  apply (erule impE)
+   apply (clarsimp simp: obj_at'_real_def ko_wp_at'_def live'_def hyp_live'_def)
   apply simp
   done
 
-lemma corres_gets_lift:
-  assumes inv: "\<And>P. \<lbrace>P\<rbrace> g \<lbrace>\<lambda>_. P\<rbrace>"
-  assumes res: "\<lbrace>Q'\<rbrace> g \<lbrace>\<lambda>r s. r = g' s\<rbrace>"
-  assumes Q: "\<And>s. Q s \<Longrightarrow> Q' s"
-  assumes nf: "no_fail Q g"
-  shows "corres r P Q f (gets g') \<Longrightarrow> corres r P Q f g"
-  apply (clarsimp simp add: corres_underlying_def simpler_gets_def)
-  apply (drule (1) bspec)
-  apply (rule conjI)
-   apply clarsimp
-   apply (rule bexI)
-    prefer 2
-    apply assumption
-   apply simp
-   apply (frule in_inv_by_hoareD [OF inv])
-   apply simp
-   apply (drule use_valid, rule res)
-    apply (erule Q)
-   apply simp
-  apply (insert nf)
-  apply (clarsimp simp: no_fail_def)
+lemma archThreadSet_ifunsafe'[wp]:
+  "archThreadSet f t \<lbrace>if_unsafe_then_cap'\<rbrace>"
+  unfolding archThreadSet_def
+  apply (wpsimp wp: setObject_tcb_ifunsafe' getObject_tcb_wp)
+  apply normalise_obj_at'
+  apply (auto simp: tcb_cte_cases_def if_live_then_nonz_cap'_def cteSizeBits_def)
   done
 
-lemma obj_refs_Master:
-  "\<lbrakk> cap_relation cap cap'; P cap \<rbrakk>
-      \<Longrightarrow> obj_refs cap =
-           (if capClass (capMasterCap cap') = PhysicalClass
-                  \<and> \<not> isUntypedCap (capMasterCap cap')
-            then {capUntypedPtr (capMasterCap cap')} else {})"
-  by (clarsimp simp: isCap_simps
-              split: cap_relation_split_asm arch_cap.split_asm)
+lemma archThreadSet_valid_idle'[wp]:
+  "archThreadSet f t \<lbrace>valid_idle'\<rbrace>"
+  unfolding archThreadSet_def
+  apply (wpsimp wp: setObject_tcb_idle' getObject_tcb_wp)
+  apply (clarsimp simp: valid_idle'_def pred_tcb_at'_def obj_at'_def idle_tcb'_def)
+  done
 
-lemma isFinalCapability_corres':
+lemma archThreadSet_ct_not_inQ[wp]:
+  "archThreadSet f t \<lbrace>ct_not_inQ\<rbrace>"
+  unfolding ct_not_inQ_def
+  apply (rule hoare_lift_Pf[where f=ksCurThread]; wp?)
+  apply (wpsimp wp: hoare_vcg_imp_lift simp: o_def)
+  done
+
+lemma archThreadSet_obj_at'_pte[wp]:
+  "archThreadSet f t \<lbrace>obj_at' (P::pte \<Rightarrow> bool) p\<rbrace>"
+  unfolding archThreadSet_def
+  by (wpsimp wp: obj_at_setObject2 simp: updateObject_default_def in_monad)
+
+crunch archThreadSet
+  for pspace_domain_valid[wp]: pspace_domain_valid
+
+crunch archThreadSet
+  for gsUntypedZeroRanges[wp]: "\<lambda>s. P (gsUntypedZeroRanges s)"
+
+lemma archThreadSet_untyped_ranges_zero'[wp]:
+  "archThreadSet f t \<lbrace>untyped_ranges_zero'\<rbrace>"
+  by (rule hoare_lift_Pf[where f=cteCaps_of]; wp cteCaps_of_ctes_of_lift)
+
+lemma archThreadSet_tcb_at'[wp]:
+  "\<lbrace>\<top>\<rbrace> archThreadSet f t \<lbrace>\<lambda>_. tcb_at' t\<rbrace>"
+  unfolding archThreadSet_def
+  by (wpsimp wp: getObject_tcb_wp simp: obj_at'_def)
+
+lemma archThreadSet_tcbSchedPrevs_of[wp]:
+  "archThreadSet f t \<lbrace>\<lambda>s. P (tcbSchedPrevs_of s)\<rbrace>"
+  unfolding archThreadSet_def
+  apply (wp getObject_tcb_wp)
+  apply normalise_obj_at'
+  apply (erule rsubst[where P=P])
+  apply (rule ext)
+  apply (clarsimp simp: opt_map_def obj_at'_def split: option.splits)
+  done
+
+lemma archThreadSet_tcbSchedNexts_of[wp]:
+  "archThreadSet f t \<lbrace>\<lambda>s. P (tcbSchedNexts_of s)\<rbrace>"
+  unfolding archThreadSet_def
+  apply (wp getObject_tcb_wp)
+  apply normalise_obj_at'
+  apply (erule rsubst[where P=P])
+  apply (rule ext)
+  apply (clarsimp simp: opt_map_def obj_at'_def split: option.splits)
+  done
+
+lemma archThreadSet_tcbQueued[wp]:
+  "archThreadSet f t \<lbrace>\<lambda>s. P (tcbQueued |< tcbs_of' s)\<rbrace>"
+  unfolding archThreadSet_def
+  apply (wp getObject_tcb_wp)
+  apply normalise_obj_at'
+  apply (erule rsubst[where P=P])
+  apply (rule ext)
+  apply (clarsimp simp: opt_pred_def opt_map_def obj_at'_def split: option.splits)
+  done
+
+lemma archThreadSet_valid_sched_pointers[wp]:
+  "archThreadSet f t \<lbrace>valid_sched_pointers\<rbrace>"
+  by (wp_pre, wps, wp, assumption)
+
+lemma arch_finaliseCap_invs[Finalise_R_2_assms, wp]:
+  "\<lbrace>invs' and valid_cap' (ArchObjectCap cap)\<rbrace> Arch.finaliseCap cap fin \<lbrace>\<lambda>rv. invs'\<rbrace>"
+  unfolding X64_H.finaliseCap_def Let_def by wpsimp
+
+lemma asUser_unlive[wp]:
+  "\<lbrace>ko_wp_at' (Not \<circ> live') vr\<rbrace> asUser t f \<lbrace>\<lambda>_. ko_wp_at' (Not \<circ> live') vr\<rbrace>"
+  unfolding asUser_def
+  apply (wpsimp simp: threadSet_def atcbContextSet_def objBits_simps' split_def
+                  wp: setObject_ko_wp_at)
+  apply (rule refl, simp)
+  apply (wpsimp simp: atcbContextGet_def wp: getObject_tcb_wp threadGet_wp)+
+  apply (clarsimp simp: tcb_at_typ_at' typ_at'_def ko_wp_at'_def[where p=t])
+  apply (case_tac ko; simp)
+  apply (rename_tac tcb)
+  apply (rule_tac x=tcb in exI)
+  apply (clarsimp simp: obj_at'_def ko_wp_at'_def live'_def hyp_live'_def)
+  done
+
+crunch setVMRoot, deleteASIDPool, unmapPageTable, unmapPageDirectory, unmapPDPT
+  for ctes_of[wp]: "\<lambda>s. P (ctes_of s)"
+  (wp: crunch_wps getObject_inv loadObject_default_inv getASID_wp simp: crunch_simps)
+
+lemma deleteASID_ctes_of[wp]:
+  "deleteASID a ptr \<lbrace>\<lambda>s. P (ctes_of s)\<rbrace>"
+  unfolding deleteASID_def by (wpsimp wp: getASID_wp hoare_drop_imps hoare_vcg_all_lift)
+
+lemma arch_finaliseCap_removeable[wp]:
+  "\<lbrace>\<lambda>s. s \<turnstile>' ArchObjectCap cap \<and> invs' s
+       \<and> (final \<and> final_matters' (ArchObjectCap cap)
+            \<longrightarrow> isFinal (ArchObjectCap cap) slot (cteCaps_of s))\<rbrace>
+     Arch.finaliseCap cap final
+   \<lbrace>\<lambda>rv s. isNullCap (fst rv) \<and> removeable' slot s (ArchObjectCap cap)
+          \<and> (snd rv \<noteq> NullCap \<longrightarrow> snd rv = (ArchObjectCap cap) \<and> cap_has_cleanup' (ArchObjectCap cap)
+                                      \<and> isFinal (ArchObjectCap cap) slot (cteCaps_of s))\<rbrace>"
+  apply (simp add: X64_H.finaliseCap_def
+                   removeable'_def)
+  apply (rule hoare_pre)
+   apply (wp cteCaps_of_ctes_of_lift | wpc | wp (once) hoare_drop_imps)+
+  apply (clarsimp simp: arch_cap_has_cleanup'_def isCap_simps
+                        final_matters'_def arch_final_matters'_def)
+  done
+
+crunch archThreadSet
+  for isFinal: "\<lambda>s. isFinal cap slot (cteCaps_of s)"
+  (wp: cteCaps_of_ctes_of_lift)
+
+crunch prepareThreadDelete
+  for isFinal: "\<lambda>s. isFinal cap slot (cteCaps_of s)"
+
+lemma archThreadSet_bound_tcb_at'[wp]:
+  "archThreadSet f t \<lbrace>bound_tcb_at' P t'\<rbrace>"
+  unfolding archThreadSet_def
+  apply (wpsimp wp: setObject_tcb_strongest getObject_tcb_wp simp: pred_tcb_at'_def)
+  by (auto simp: obj_at'_def objBits_simps)
+
+crunch prepareThreadDelete
+  for bound_tcb_at'[wp]: "bound_tcb_at' P t"
+  (wp: sts_bound_tcb_at' crunch_wps hoare_vcg_all_lift hoare_vcg_if_lift3
+   ignore: archThreadSet)
+
+crunch Arch.finaliseCap, prepareThreadDelete
+  for irq_node'[Finalise_R_2_assms, wp]: "\<lambda>s. P (irq_node' s)"
+  (wp: crunch_wps getObject_inv loadObject_default_inv
+       updateObject_default_inv setObject_ksInterrupt
+   simp: crunch_simps o_def)
+
+lemmas Arch_finaliseCap_irq_node'[Finalise_R_2_assms] = ArchRetypeDecls_H_X64_H_finaliseCap_irq_node'
+
+crunch prepareThreadDelete, postCapDeletion, setIOPortMask
+  for cte_wp_at'[Finalise_R_2_assms, wp]: "cte_wp_at' P p"
+  and valid_cap'[Finalise_R_2_assms, wp]: "valid_cap' cap"
+
+crunch setIOPortMask
+  for ctes_of[wp]: "\<lambda>s. P (ctes_of s)"
+  and irq_node'[wp]: "\<lambda>s. P (irq_node' s)"
+  and valid_objs'[wp]: "valid_objs'"
+
+lemma asUser_hyp_unlive[wp]:
+  "asUser f t \<lbrace>ko_wp_at' (Not \<circ> hyp_live') t'\<rbrace>"
+  unfolding asUser_def
+  apply (wpsimp wp: threadSet_ko_wp_at2' threadGet_wp)
+  apply (clarsimp simp: ko_wp_at'_def obj_at'_def hyp_live'_def atcbContextSet_def)
+  done
+
+crunch fpuRelease
+  for hyp_unlive[wp]: "ko_wp_at' (Not \<circ> hyp_live') ptr"
+  (simp: ko_wp_at'_not_comp_fold)
+
+crunch prepareThreadDelete
+  for invs[Finalise_R_2_assms, wp]: "invs'"
+  (ignore: doMachineOp simp: crunch_simps)
+
+lemma archThreadSet_tcbSchedPrevNext[wp]:
+  "archThreadSet f t' \<lbrace>obj_at' (\<lambda>tcb. P (tcbSchedNext tcb) (tcbSchedPrev tcb)) t\<rbrace>"
+  unfolding archThreadSet_def
+  apply (wpsimp wp: setObject_tcb_strongest getObject_tcb_wp)
+  apply normalise_obj_at'
+  apply auto
+  done
+
+context notes if_cong[cong] begin
+
+crunch asUser
+  for tcbSchedPrevNext[wp]: "obj_at' (\<lambda>tcb. P (tcbSchedNext tcb) (tcbSchedPrev tcb)) t"
+  (wp: threadGet_wp)
+
+end
+
+crunch prepareThreadDelete
+  for tcbSchedPrevNext[wp]: "obj_at' (\<lambda>tcb. P (tcbSchedNext tcb) (tcbSchedPrev tcb)) t"
+  (wp: threadGet_wp crunch_wps simp: crunch_simps)
+
+crunch deleteASIDPool
+  for cte_wp_at'[wp]: "cte_wp_at' P p"
+  (simp: crunch_simps assertE_def
+   wp: crunch_wps getObject_inv loadObject_default_inv)
+
+lemma deleteASID_cte_wp_at'[wp]:
+  "\<lbrace>cte_wp_at' P p\<rbrace> deleteASID param_a param_b \<lbrace>\<lambda>_. cte_wp_at' P p\<rbrace>"
+  supply if_cong[cong]
+  apply (simp add: deleteASID_def
+              cong: option.case_cong)
+  apply (wp setObject_cte_wp_at'[where Q="\<top>"] getObject_inv
+            loadObject_default_inv setVMRoot_cte_wp_at'
+          | clarsimp simp: updateObject_default_def in_monad
+          | rule equals0I
+          | wpc)+
+  done
+
+lemma arch_finaliseCap_cte_wp_at[Finalise_R_2_assms, wp]:
+  "\<lbrace>cte_wp_at' P p\<rbrace> Arch.finaliseCap cap fin \<lbrace>\<lambda>rv. cte_wp_at' P p\<rbrace>"
+  apply (simp add: X64_H.finaliseCap_def)
+  apply (wpsimp wp: unmapPage_cte_wp_at')
+  done
+
+lemma finaliseCap_valid_cap[Finalise_R_2_assms, wp]:
+  "\<lbrace>\<top>\<rbrace> Arch.finaliseCap cap final \<lbrace>\<lambda>rv. valid_cap' (fst rv)\<rbrace>"
+  by (wpsimp simp: X64_H.finaliseCap_def)
+
+lemma finaliseCap_cases[wp]:
+  "\<lbrace>\<top>\<rbrace>
+   finaliseCap cap final flag
+   \<lbrace>\<lambda>rv s. fst rv = NullCap \<and> (snd rv \<noteq> NullCap \<longrightarrow> final \<and> cap_has_cleanup' cap \<and> snd rv = cap)
+           \<or> isZombie (fst rv) \<and> final \<and> \<not> flag \<and> snd rv = NullCap
+             \<and> capUntypedPtr (fst rv) = capUntypedPtr cap
+             \<and> (isThreadCap cap \<or> isCNodeCap cap \<or> isZombie cap)\<rbrace>"
+  apply (simp add: finaliseCap_def X64_H.finaliseCap_def Let_def
+                   getThreadCSpaceRoot
+             cong: if_cong split del: if_split)
+  apply (rule hoare_pre)
+   apply ((wp | simp add: gen_isCap_simps split del: if_split
+              | wpc
+              | simp only: valid_NullCap fst_conv snd_conv)+)[1]
+  apply (simp only: simp_thms fst_conv snd_conv option.simps if_cancel
+                    o_def)
+  apply (intro allI impI conjI TrueI)
+  apply (auto simp add: isCap_simps cap_has_cleanup'_def arch_cap_has_cleanup'_def)
+  done
+
+lemmas [Finalise_R_2_assms] =
+  cancelAllIPC_cte_wp_at' cancelAllSignals_cte_wp_at' unbindMaybeNotification_cte_wp_at'
+  prepareThreadDelete_cte_wp_at' unbindNotification_cte_wp_at'
+  Arch_postCapDeletion_valid_global_refs Arch_postCapDeletion_valid_arch_state'
+  mdb_empty.vmdb_n mdb_empty.descendants not_Final_removeable
+
+end (* Arch *)
+
+interpretation Finalise_R_2?: Finalise_R_2 arch_final_matters' arch_cap_has_cleanup'
+proof goal_cases
+  interpret Arch  .
+  case 1 show ?case by (intro_locales; (unfold_locales; (fact Finalise_R_2_assms)?)?)
+qed
+
+(* this is the only arch-specific lemma in delete_one_conc_pre so far;
+   save processing time by not creating an extra Arch_delete_one_conc_pre locale
+   by directly requalifying instead *)
+lemma (in delete_one_conc_pre) finaliseCap_replaceable:
+  "\<lbrace>\<lambda>s. invs' s \<and> cte_wp_at' (\<lambda>cte. cteCap cte = cap) slot s
+       \<and> (final_matters' cap \<longrightarrow> (final = isFinal cap slot (cteCaps_of s)))
+       \<and> weak_sch_act_wf (ksSchedulerAction s) s\<rbrace>
+     finaliseCap cap final flag
+   \<lbrace>\<lambda>rv s. (isNullCap (fst rv) \<and> removeable' slot s cap
+                \<and> (snd rv \<noteq> NullCap \<longrightarrow> snd rv = cap \<and> cap_has_cleanup' cap
+                                      \<and> isFinal cap slot (cteCaps_of s)))
+        \<or>
+          (isZombie (fst rv) \<and> snd rv = NullCap
+            \<and> isFinal cap slot (cteCaps_of s)
+            \<and> capClass cap = capClass (fst rv)
+            \<and> capUntypedPtr (fst rv) = capUntypedPtr cap
+            \<and> capBits (fst rv) = capBits cap
+            \<and> capRange (fst rv) = capRange cap
+            \<and> (isThreadCap cap \<or> isCNodeCap cap \<or> isZombie cap)
+            \<and> (\<forall>p \<in> threadCapRefs cap. st_tcb_at' ((=) Inactive) p s
+                     \<and> obj_at' (Not \<circ> tcbQueued) p s
+                     \<and> bound_tcb_at' ((=) None) p s
+                     \<and> obj_at' (\<lambda>tcb. tcbSchedNext tcb = None \<and> tcbSchedPrev tcb = None) p s))\<rbrace>"
+  supply [wp] = X64.prepareThreadDelete_bound_tcb_at'
+                X64.prepareThreadDelete_tcbSchedPrevNext
+  apply (simp add: finaliseCap_def Let_def getThreadCSpaceRoot
+             cong: if_cong split del: if_split)
+  apply (rule hoare_pre)
+   apply (wp prepares_delete_helper'' [OF cancelAllIPC_unlive]
+             prepares_delete_helper'' [OF cancelAllSignals_unlive]
+             suspend_isFinal X64.prepareThreadDelete_unqueued
+             X64.prepareThreadDelete_inactive X64.prepareThreadDelete_isFinal
+             suspend_makes_inactive
+             deletingIRQHandler_removeable'
+             deletingIRQHandler_final[where slot=slot ]
+             unbindMaybeNotification_obj_at'_bound
+             getNotification_wp
+             suspend_bound_tcb_at'
+             unbindNotification_bound_tcb_at'
+             suspend_tcbSchedNext_tcbSchedPrev_None
+           | simp add: isZombie_Null isThreadCap_threadCapRefs_tcbptr
+                       isArchObjectCap_Cap_capCap
+           | (rule hoare_strengthen_post[OF X64.arch_finaliseCap_removeable[where slot=slot]],
+                  clarsimp simp: gen_isCap_simps)
+           | wpc)+
+  apply clarsimp
+  apply (frule cte_wp_at_valid_objs_valid_cap', clarsimp+)
+  apply (case_tac "cteCap cte",
+         simp_all add: gen_isCap_simps capRange_def cap_has_cleanup'_def
+                       final_matters'_def gen_objBits_simps
+                       not_Final_removeable finaliseCap_def,
+         simp_all add: removeable'_def)
+     (* thread *)
+     apply (frule capAligned_capUntypedPtr [OF valid_capAligned], simp)
+     apply (clarsimp simp: valid_cap'_def)
+     apply (drule valid_globals_cte_wpD'[rotated], clarsimp)
+     apply (clarsimp simp: invs'_def valid_state'_def valid_pspace'_def)
+    apply (clarsimp simp: obj_at'_def | rule conjI)+
+  done
+
+context Arch begin arch_global_naming
+
+named_theorems Finalise_R_3_assms
+
+lemma finaliseCap_cte_refs:
+  "\<lbrace>\<lambda>s. s \<turnstile>' cap\<rbrace>
+     finaliseCap cap final flag
+   \<lbrace>\<lambda>rv s. fst rv \<noteq> NullCap \<longrightarrow> cte_refs' (fst rv) = cte_refs' cap\<rbrace>"
+  apply (simp add: global.finaliseCap_def Let_def getThreadCSpaceRoot finaliseCap_def
+             cong: if_cong split del: if_split)
+  apply (rule hoare_pre)
+   apply (wp | wpc | simp only: o_def)+
+  apply (frule valid_capAligned)
+  apply (cases cap, simp_all add: gen_isCap_simps)
+   apply (clarsimp simp: tcb_cte_cases_def word_count_from_top gen_objBits_simps)
+  apply clarsimp
+  apply (rule ext, simp)
+  apply (rule image_cong [OF _ refl])
+  apply (fastforce simp: mask_def capAligned_def gen_objBits_simps shiftL_nat)
+  done
+
+lemma emptySlot_invs'[wp]:
+  "\<lbrace>\<lambda>s. invs' s \<and> cte_wp_at' (\<lambda>cte. removeable' sl s (cteCap cte)) sl s
+            \<and> (info \<noteq> NullCap \<longrightarrow> post_cap_delete_pre' info sl (cteCaps_of s) )\<rbrace>
+     emptySlot sl info
+   \<lbrace>\<lambda>rv. invs'\<rbrace>"
+  apply (simp add: invs'_def valid_state'_def valid_pspace'_def)
+  apply (wpsimp wp: valid_irq_node_lift cur_tcb_lift valid_dom_schedule'_lift)
+  apply (auto simp: post_cap_delete_pre'_def cteCaps_of_def cte_wp_at_ctes_of
+                 split: capability.split_asm arch_capability.split_asm)
+  done
+
+lemma cteDeleteOne_invs[Finalise_R_3_assms, wp]:
+  "cteDeleteOne ptr \<lbrace>invs'\<rbrace>"
+  apply (simp add: cteDeleteOne_def unless_def
+                   split_def finaliseCapTrue_standin_simple_def)
+  apply wp
+    apply (rule hoare_strengthen_post)
+     apply (rule hoare_vcg_conj_lift[OF finaliseCap_True_invs])
+     apply (rule hoare_vcg_conj_lift[OF finaliseCap_replaceable[where slot=ptr]])
+     apply (rule hoare_vcg_conj_lift[OF finaliseCap_cte_refs])
+     apply (rule finaliseCap_equal_cap[where sl=ptr])
+    apply (clarsimp simp: cte_wp_at_ctes_of)
+    apply (erule disjE, solves simp)
+    apply (clarsimp dest!: isCapDs simp: capRemovable_def)
+    apply (clarsimp simp: removeable'_def fun_eq_iff[where f="cte_refs' cap" for cap]
+                     del: disjCI)
+    subgoal by (auto dest!: isCapDs simp: pred_tcb_at'_def obj_at'_def live'_def X64.hyp_live'_def
+                                          ko_wp_at'_def)
+   apply (wp isFinalCapability_inv getCTE_wp' hoare_weak_lift_imp
+          | wp (once) isFinal[where x=ptr])+
+  apply (fastforce simp: cte_wp_at_ctes_of)
+  done
+
+lemma isFinalCapability_corres'[Finalise_R_3_assms]:
   "final_matters' (cteCap cte) \<Longrightarrow>
    corres (=) (invs and cte_wp_at ((=) cap) ptr)
                (invs' and cte_wp_at' ((=) cte) (cte_map ptr))
@@ -2206,7 +1158,7 @@ lemma isFinalCapability_corres':
    apply (erule_tac x=aa in allE)
    apply (erule_tac x=ba in allE)
    apply (clarsimp simp: cte_wp_at_caps_of_state)
-   apply (clarsimp simp: sameObjectAs_def3 obj_refs_Master cap_irqs_relation_Master
+   apply (clarsimp simp: sameObjectAs_def3 obj_refs_relation_Master cap_irqs_relation_Master
                          arch_gen_refs_relation_Master gen_obj_refs_Int
                    cong: if_cong
                   split: capability.split_asm)
@@ -2214,7 +1166,7 @@ lemma isFinalCapability_corres':
   apply (rule_tac x="fst ptr" in exI)
   apply (rule_tac x="snd ptr" in exI)
   apply (rule conjI)
-   apply (clarsimp simp: cte_wp_at_def final_matters'_def
+   apply (clarsimp simp: cte_wp_at_def final_matters'_def arch_final_matters'_def
                          gen_obj_refs_Int
                   split: cap_relation_split_asm arch_cap.split_asm)
   apply clarsimp
@@ -2240,1189 +1192,45 @@ lemma isFinalCapability_corres':
    apply (rule classical)
    apply (frule(1) zombies_finalD2[OF _ _ _ invs_zombies],
           simp?, clarsimp, assumption+)
-   subgoal by (clarsimp simp: sameObjectAs_def3 isCap_simps valid_cap_def
-                         obj_at_def is_obj_defs a_type_def final_matters'_def
-                  split: cap.split_asm arch_cap.split_asm
-                         option.split_asm if_split_asm,
-          simp_all add: is_cap_defs)
+   subgoal by (clarsimp simp: sameObjectAs_def3 isCap_simps valid_cap_def valid_arch_cap_def
+                              valid_arch_cap_ref_def obj_at_def is_obj_defs a_type_def
+                              final_matters'_def arch_final_matters'_def
+                        split: cap.split_asm arch_cap.split_asm option.split_asm if_split_asm,
+               simp_all add: is_cap_defs)
   apply (rule classical)
   apply (clarsimp simp: cap_irqs_def cap_irq_opt_def sameObjectAs_def3 isCap_simps arch_gen_obj_refs_def
                         acap_relation_def
                  split: cap.split_asm arch_cap.split_asm)
   apply (case_tac cap; clarsimp simp: arch_gen_obj_refs_def)
   apply (case_tac x12; clarsimp simp: get_cap_caps_of_state)
+  apply (rename_tac last first' last')
   apply (drule invs_valid_ioports, clarsimp simp: valid_ioports_def ioports_no_overlap_def)
-  apply (drule_tac x="cap.ArchObjectCap (arch_cap.IOPortCap x31a x32)" in bspec, fastforce)
-  apply (drule_tac x="cap.ArchObjectCap (arch_cap.IOPortCap x31a x32a)" in bspec, fastforce)
-  by (clarsimp simp: cap_ioports_def valid_cap_def)
-
-lemma isFinalCapability_corres:
-  "corres (\<lambda>rv rv'. final_matters' (cteCap cte) \<longrightarrow> rv = rv')
-          (invs and cte_wp_at ((=) cap) ptr)
-          (invs' and cte_wp_at' ((=) cte) (cte_map ptr))
-       (is_final_cap cap) (isFinalCapability cte)"
-  apply (cases "final_matters' (cteCap cte)")
-   apply simp
-   apply (erule isFinalCapability_corres')
-  apply (subst bind_return[symmetric],
-         rule corres_symb_exec_r)
-     apply (rule corres_no_failI)
-      apply wp
-     apply (clarsimp simp: in_monad is_final_cap_def simpler_gets_def)
-    apply (wp isFinalCapability_inv)+
-  apply fastforce
+  apply (drule_tac x="cap.ArchObjectCap (arch_cap.IOPortCap first' last)" in bspec, fastforce)
+  apply (drule_tac x="cap.ArchObjectCap (arch_cap.IOPortCap first' last')" in bspec, fastforce)
+  apply (clarsimp simp: cap_ioports_def valid_cap_def)
   done
 
-text \<open>Facts about finalise_cap/finaliseCap and
-        cap_delete_one/cteDelete in no particular order\<close>
-
-
-definition
-  finaliseCapTrue_standin_simple_def:
-  "finaliseCapTrue_standin cap fin \<equiv> finaliseCap cap fin True"
-
-context
-begin
-
-declare if_cong [cong]
-
-lemmas finaliseCapTrue_standin_def
-    = finaliseCapTrue_standin_simple_def
-        [unfolded finaliseCap_def, simplified]
-
-lemmas cteDeleteOne_def'
-    = eq_reflection [OF cteDeleteOne_def]
-lemmas cteDeleteOne_def
-    = cteDeleteOne_def'[folded finaliseCapTrue_standin_simple_def]
-
-crunch cteDeleteOne, suspend, prepareThreadDelete
-  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  (wp: crunch_wps getObject_inv loadObject_default_inv
-   simp: crunch_simps unless_def o_def)
-
-end
-
-lemmas cancelAllIPC_typs[wp] = typ_at_lifts [OF cancelAllIPC_typ_at']
-lemmas cancelAllSignals_typs[wp] = typ_at_lifts [OF cancelAllSignals_typ_at']
-lemmas suspend_typs[wp] = typ_at_lifts [OF suspend_typ_at']
-
-definition
-  arch_cap_has_cleanup' :: "arch_capability \<Rightarrow> bool"
-where
-  "arch_cap_has_cleanup' acap \<equiv> isIOPortCap acap"
-
-definition
-  cap_has_cleanup' :: "capability \<Rightarrow> bool"
-where
-  "cap_has_cleanup' cap \<equiv> case cap of
-     IRQHandlerCap _ \<Rightarrow> True
-   | ArchObjectCap acap \<Rightarrow> arch_cap_has_cleanup' acap
-   | _ \<Rightarrow> False"
-
-lemmas cap_has_cleanup'_simps[simp] = cap_has_cleanup'_def[split_simps capability.split]
-
-lemma finaliseCap_cases[wp]:
-  "\<lbrace>\<top>\<rbrace>
-     finaliseCap cap final flag
-   \<lbrace>\<lambda>rv s. fst rv = NullCap \<and> (snd rv \<noteq> NullCap \<longrightarrow> final \<and> cap_has_cleanup' cap \<and> snd rv = cap)
-     \<or>
-       isZombie (fst rv) \<and> final \<and> \<not> flag \<and> snd rv = NullCap
-        \<and> capUntypedPtr (fst rv) = capUntypedPtr cap
-        \<and> (isThreadCap cap \<or> isCNodeCap cap \<or> isZombie cap)\<rbrace>"
-  apply (simp add: finaliseCap_def X64_H.finaliseCap_def Let_def
-                   getThreadCSpaceRoot
-             cong: if_cong split del: if_split)
-  apply (rule hoare_pre)
-   apply ((wp | simp add: isCap_simps split del: if_split
-              | wpc
-              | simp only: valid_NullCap fst_conv snd_conv)+)[1]
-  apply (simp only: simp_thms fst_conv snd_conv option.simps if_cancel
-                    o_def)
-  apply (intro allI impI conjI TrueI)
-  apply (auto simp add: isCap_simps cap_has_cleanup'_def arch_cap_has_cleanup'_def)
-  done
-
-crunch finaliseCap
-  for aligned'[wp]: "pspace_aligned'"
-  (simp: crunch_simps assertE_def unless_def o_def
-     wp: getObject_inv loadObject_default_inv crunch_wps)
-
-crunch finaliseCap
-  for distinct'[wp]: "pspace_distinct'"
-  (simp: crunch_simps assertE_def unless_def o_def
-     wp: getObject_inv loadObject_default_inv crunch_wps)
-
-crunch finaliseCap
-  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  (simp: crunch_simps assertE_def
-     wp: getObject_inv loadObject_default_inv crunch_wps)
-lemmas finaliseCap_typ_ats[wp] = typ_at_lifts[OF finaliseCap_typ_at']
-
-crunch finaliseCap
-  for it'[wp]: "\<lambda>s. P (ksIdleThread s)"
-  (wp: mapM_x_wp_inv mapM_wp' hoare_drop_imps getObject_inv loadObject_default_inv
-   simp: crunch_simps o_def)
-
-declare doUnbindNotification_def[simp]
-
-lemma ntfn_q_refs_of'_mult:
-  "ntfn_q_refs_of' ntfn = (case ntfn of Structures_H.WaitingNtfn q \<Rightarrow> set q | _ \<Rightarrow> {}) \<times> {NTFNSignal}"
-  by (cases ntfn, simp_all)
-
-lemma tcb_st_not_Bound:
-  "(p, NTFNBound) \<notin> tcb_st_refs_of' ts"
-  "(p, TCBBound) \<notin> tcb_st_refs_of' ts"
-  by (auto simp: tcb_st_refs_of'_def split: Structures_H.thread_state.split)
-
-crunch setBoundNotification
-  for valid_bitmaps[wp]: valid_bitmaps
-  and tcbSchedNexts_of[wp]: "\<lambda>s. P (tcbSchedNexts_of s)"
-  and tcbSchedPrevs_of[wp]: "\<lambda>s. P (tcbSchedPrevs_of s)"
-  and tcbQueued[wp]: "\<lambda>s. P (tcbQueued |< tcbs_of' s)"
-  and valid_sched_pointers[wp]: valid_sched_pointers
-  (wp: valid_bitmaps_lift)
-
-lemma unbindNotification_invs[wp]:
-  "\<lbrace>invs'\<rbrace> unbindNotification tcb \<lbrace>\<lambda>rv. invs'\<rbrace>"
-  apply (simp add: unbindNotification_def invs'_def valid_state'_def)
-  apply (rule bind_wp[OF _ gbn_sp'])
-  apply (case_tac ntfnPtr, clarsimp, wp, clarsimp)
-  apply clarsimp
-  apply (rule bind_wp[OF _ get_ntfn_sp'])
-  apply (rule hoare_pre)
-  apply (wp sbn'_valid_pspace'_inv sbn_sch_act' valid_irq_node_lift valid_dom_schedule'_lift
-            irqs_masked_lift setBoundNotification_ct_not_inQ sym_heap_sched_pointers_lift
-            untyped_ranges_zero_lift | clarsimp simp: cteCaps_of_def o_def)+
-  apply (rule conjI)
-   apply (clarsimp elim!: obj_atE'
-                    simp: projectKOs
-                   dest!: pred_tcb_at')
-  apply (clarsimp simp: pred_tcb_at' conj_comms)
-  apply (frule bound_tcb_ex_cap'', clarsimp+)
-  apply (frule(1) sym_refs_bound_tcb_atD')
-  apply (frule(1) sym_refs_obj_atD')
-  apply (clarsimp simp: refs_of_rev')
-  apply normalise_obj_at'
-  apply (subst delta_sym_refs, assumption)
-    apply (auto split: if_split_asm)[1]
-   apply (auto simp: tcb_st_not_Bound ntfn_q_refs_of'_mult split: if_split_asm)[1]
-  apply (frule obj_at_valid_objs', clarsimp+)
-  apply (simp add: valid_ntfn'_def valid_obj'_def projectKOs live'_def
-            split: ntfn.splits)
-  apply (erule if_live_then_nonz_capE')
-  apply (clarsimp simp: obj_at'_def ko_wp_at'_def projectKOs live'_def)
-  done
-
-lemma ntfn_bound_tcb_at':
-  "\<lbrakk>sym_refs (state_refs_of' s); valid_objs' s; ko_at' ntfn ntfnptr s;
-    ntfnBoundTCB ntfn = Some tcbptr; P (Some ntfnptr)\<rbrakk>
-  \<Longrightarrow> bound_tcb_at' P tcbptr s"
-  apply (drule_tac x=ntfnptr in sym_refsD[rotated])
-   apply (clarsimp simp: obj_at'_def projectKOs)
-   apply (fastforce simp: state_refs_of'_def)
-  apply (auto simp: pred_tcb_at'_def obj_at'_def valid_obj'_def valid_ntfn'_def
-                    state_refs_of'_def refs_of_rev' projectKOs
-          simp del: refs_of_simps
-             elim!: valid_objsE
-             split: option.splits if_split_asm)
-  done
-
-
-lemma unbindMaybeNotification_invs[wp]:
-  "\<lbrace>invs'\<rbrace> unbindMaybeNotification ntfnptr \<lbrace>\<lambda>rv. invs'\<rbrace>"
-  apply (simp add: unbindMaybeNotification_def invs'_def valid_state'_def)
-  apply (rule bind_wp[OF _ get_ntfn_sp'])
-  apply (rule hoare_pre)
-   apply (wp sbn'_valid_pspace'_inv sbn_sch_act' sym_heap_sched_pointers_lift valid_irq_node_lift
-             irqs_masked_lift valid_dom_schedule'_lift setBoundNotification_ct_not_inQ
-             untyped_ranges_zero_lift
-             | wpc | clarsimp simp: cteCaps_of_def o_def)+
-  apply safe[1]
-           defer 3
-           defer 7
-           apply (fold_subgoals (prefix))[8]
-           subgoal premises prems using prems by (auto simp: pred_tcb_at' valid_pspace'_def projectKOs valid_obj'_def valid_ntfn'_def
-                             ko_wp_at'_def live'_def
-                      elim!: obj_atE' valid_objsE' if_live_then_nonz_capE'
-                      split: option.splits ntfn.splits)
-   apply (rule delta_sym_refs, assumption)
-    apply (fold_subgoals (prefix))[2]
-    subgoal premises prems using prems by (fastforce simp: symreftype_inverse' ntfn_q_refs_of'_def
-                    split: ntfn.splits if_split_asm
-                     dest!: ko_at_state_refs_ofD')+
-  apply (rule delta_sym_refs, assumption)
-   apply (clarsimp split: if_split_asm)
-   apply (frule ko_at_state_refs_ofD', simp)
-  apply (clarsimp split: if_split_asm)
-   apply (frule_tac P="(=) (Some ntfnptr)" in ntfn_bound_tcb_at', simp_all add: valid_pspace'_def)[1]
-   subgoal by (fastforce simp: ntfn_q_refs_of'_def state_refs_of'_def tcb_ntfn_is_bound'_def
-                          tcb_st_refs_of'_def
-                   dest!: bound_tcb_at_state_refs_ofD'
-                   split: ntfn.splits thread_state.splits)
-  apply (frule ko_at_state_refs_ofD', simp)
-  done
-
-(* Ugh, required to be able to split out the abstract invs *)
-lemma finaliseCap_True_invs[wp]:
-  "\<lbrace>invs'\<rbrace> finaliseCap cap final True \<lbrace>\<lambda>rv. invs'\<rbrace>"
-  apply (simp add: finaliseCap_def Let_def)
-  apply safe
-    apply (wp irqs_masked_lift| simp | wpc)+
-  done
-
-lemma invs_asid_update_strg':
-  "invs' s \<and> tab = x64KSASIDTable (ksArchState s) \<longrightarrow>
-   invs' (s\<lparr>ksArchState := x64KSASIDTable_update
-            (\<lambda>_. tab (asid := None)) (ksArchState s)\<rparr>)"
-  apply (simp add: invs'_def)
-  apply (simp add: valid_state'_def)
-  apply (simp add: valid_global_refs'_def global_refs'_def valid_arch_state'_def
-                   valid_asid_table'_def valid_machine_state'_def ct_idle_or_in_cur_domain'_def
-                   tcb_in_cur_domain'_def)
-  apply (auto simp add: ran_def split: if_split_asm)
-  done
-
-lemma hwASIDInvalidate_invs'[wp]:
-  "\<lbrace>invs'\<rbrace> hwASIDInvalidate asid vs \<lbrace>\<lambda>r. invs'\<rbrace>"
-  apply (simp add: hwASIDInvalidate_def)
-  by wpsimp
-
-lemma deleteASIDPool_invs[wp]:
-  "\<lbrace>invs'\<rbrace> deleteASIDPool asid pool \<lbrace>\<lambda>rv. invs'\<rbrace>"
-  apply (simp add: deleteASIDPool_def)
-  apply wp
-    apply (simp del: fun_upd_apply)
-    apply (strengthen invs_asid_update_strg')
-  apply (wp mapM_wp' getObject_inv loadObject_default_inv
-              | simp)+
-  done
-
-lemma deleteASID_invs'[wp]:
-  "\<lbrace>invs'\<rbrace> deleteASID asid pd \<lbrace>\<lambda>rv. invs'\<rbrace>"
-  supply inj_ASIDPool[simp del]
-  apply (simp add: deleteASID_def cong: option.case_cong)
-  apply (rule hoare_pre)
-   apply (wp | wpc)+
-    apply (rule_tac Q'="\<lambda>rv. valid_obj' (injectKO rv) and invs'"
-              in hoare_post_imp)
-     apply (rename_tac rv s)
-     apply (clarsimp split: if_split_asm del: subsetI)
-     apply (simp add: fun_upd_def[symmetric] valid_obj'_def)
-     apply (case_tac rv, simp)
-     apply (subst inv_f_f, rule inj_onI, simp)+
-     apply (rule conjI)
-      apply clarsimp
-      apply (drule subsetD, blast)
-      apply clarsimp
-     apply (auto dest!: ran_del_subset)[1]
-    apply (wp getObject_valid_obj getObject_inv loadObject_default_inv
-             | simp add: X64.objBits_simps archObjSize_def pageBits_def)+
-  apply clarsimp
-  done
-
-lemma arch_finaliseCap_invs[wp]:
-  "\<lbrace>invs' and valid_cap' (ArchObjectCap cap)\<rbrace>
-     Arch.finaliseCap cap fin
-   \<lbrace>\<lambda>rv. invs'\<rbrace>"
-  apply (simp add: X64_H.finaliseCap_def)
-  apply (rule hoare_pre)
-   apply (wp | wpc)+
-  apply clarsimp
-  done
-
-lemma ctes_of_cteCaps_of_lift:
-  "\<lbrakk> \<And>P. \<lbrace>\<lambda>s. P (ctes_of s)\<rbrace> f \<lbrace>\<lambda>rv s. P (ctes_of s)\<rbrace> \<rbrakk>
-     \<Longrightarrow> \<lbrace>\<lambda>s. P (cteCaps_of s)\<rbrace> f \<lbrace>\<lambda>rv s. P (cteCaps_of s)\<rbrace>"
-  by (wp | simp add: cteCaps_of_def)+
-
-crunch deleteASIDPool, unmapPageTable, unmapPageDirectory, unmapPDPT
-  for ctes_of[wp]: "\<lambda>s. P (ctes_of s)"
-  (wp: crunch_wps getObject_inv loadObject_default_inv getASID_wp simp: crunch_simps)
-
-lemma deleteASID_ctes_of[wp]:
-  "\<lbrace>\<lambda>s. P (ctes_of s)\<rbrace> deleteASID a ptr \<lbrace>\<lambda>rv s. P (ctes_of s)\<rbrace>"
-  apply (clarsimp simp: deleteASID_def)
-  by (wpsimp wp: getASID_wp)
-
-lemma arch_finaliseCap_removeable[wp]:
-  "\<lbrace>\<lambda>s. s \<turnstile>' ArchObjectCap cap \<and> invs' s
-       \<and> (final \<and> final_matters' (ArchObjectCap cap)
-            \<longrightarrow> isFinal (ArchObjectCap cap) slot (cteCaps_of s))\<rbrace>
-     Arch.finaliseCap cap final
-   \<lbrace>\<lambda>rv s. isNullCap (fst rv) \<and> removeable' slot s (ArchObjectCap cap)
-          \<and> (snd rv \<noteq> NullCap \<longrightarrow> snd rv = (ArchObjectCap cap) \<and> cap_has_cleanup' (ArchObjectCap cap)
-                                      \<and> isFinal (ArchObjectCap cap) slot (cteCaps_of s))\<rbrace>"
-  apply (simp add: X64_H.finaliseCap_def
-                   removeable'_def)
-  apply (rule hoare_pre)
-   apply (wp ctes_of_cteCaps_of_lift | wpc | wp (once) hoare_drop_imps)+
-  apply (clarsimp simp: arch_cap_has_cleanup'_def isCap_simps final_matters'_def)
-  done
-
-lemma isZombie_Null:
-  "\<not> isZombie NullCap"
-  by (simp add: isCap_simps)
-
-lemma prepares_delete_helper'':
-  assumes x: "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv. ko_wp_at' (Not \<circ> live') p\<rbrace>"
-  shows      "\<lbrace>P and K ((\<forall>x. cte_refs' cap x = {})
-                          \<and> zobj_refs' cap = {p}
-                          \<and> threadCapRefs cap = {})\<rbrace>
-                 f \<lbrace>\<lambda>rv s. removeable' sl s cap\<rbrace>"
-  apply (rule hoare_gen_asm)
-  apply (rule hoare_strengthen_post [OF x])
-  apply (clarsimp simp: removeable'_def)
-  done
-
-crunch finaliseCapTrue_standin, unbindNotification
-  for ctes_of[wp]: "\<lambda>s. P (ctes_of s)"
-  (wp: crunch_wps getObject_inv loadObject_default_inv simp: crunch_simps)
-
-lemma cteDeleteOne_cteCaps_of:
-  "\<lbrace>\<lambda>s. (cte_wp_at' (\<lambda>cte. \<exists>final. finaliseCap (cteCap cte) final True \<noteq> fail) p s \<longrightarrow>
-          P ((cteCaps_of s)(p \<mapsto> NullCap)))\<rbrace>
-     cteDeleteOne p
-   \<lbrace>\<lambda>rv s. P (cteCaps_of s)\<rbrace>"
-  apply (simp add: cteDeleteOne_def unless_def split_def)
-  apply (rule bind_wp [OF _ getCTE_sp])
-  apply (case_tac "\<forall>final. finaliseCap (cteCap cte) final True = fail")
-   apply (simp add: finaliseCapTrue_standin_simple_def)
-   apply wp
-   apply (clarsimp simp: cte_wp_at_ctes_of cteCaps_of_def
-                         finaliseCap_def isCap_simps)
-   apply (drule_tac x=s in fun_cong)
-   apply (simp add: return_def fail_def)
-  apply (wp emptySlot_cteCaps_of)
-    apply (simp add: cteCaps_of_def)
-    apply (wp (once) hoare_drop_imps)
-    apply (wp isFinalCapability_inv getCTE_wp')+
-  apply (clarsimp simp: cteCaps_of_def cte_wp_at_ctes_of)
-  apply (auto simp: fun_upd_idem fun_upd_def[symmetric] o_def)
-  done
-
-lemma cteDeleteOne_isFinal:
-  "\<lbrace>\<lambda>s. isFinal cap slot (cteCaps_of s)\<rbrace>
-     cteDeleteOne p
-   \<lbrace>\<lambda>rv s. isFinal cap slot (cteCaps_of s)\<rbrace>"
-  apply (wp cteDeleteOne_cteCaps_of)
-  apply (clarsimp simp: isFinal_def sameObjectAs_def2)
-  done
-
-lemmas setEndpoint_cteCaps_of[wp] = ctes_of_cteCaps_of_lift [OF set_ep_ctes_of]
-lemmas setNotification_cteCaps_of[wp] = ctes_of_cteCaps_of_lift [OF set_ntfn_ctes_of]
-lemmas threadSet_cteCaps_of = ctes_of_cteCaps_of_lift [OF threadSet_ctes_of]
-
-crunch suspend, prepareThreadDelete
-  for isFinal: "\<lambda>s. isFinal cap slot (cteCaps_of s)"
-  (ignore: threadSet
-       wp: threadSet_cteCaps_of crunch_wps
-     simp: crunch_simps unless_def o_def)
-
-lemma isThreadCap_threadCapRefs_tcbptr:
-  "isThreadCap cap \<Longrightarrow> threadCapRefs cap = {capTCBPtr cap}"
-  by (clarsimp simp: isCap_simps)
-
-lemma isArchObjectCap_Cap_capCap:
-  "isArchObjectCap cap \<Longrightarrow> ArchObjectCap (capCap cap) = cap"
-  by (clarsimp simp: isCap_simps)
-
-lemma cteDeleteOne_deletes[wp]:
-  "\<lbrace>\<top>\<rbrace> cteDeleteOne p \<lbrace>\<lambda>rv s. cte_wp_at' (\<lambda>c. cteCap c = NullCap) p s\<rbrace>"
-  apply (subst tree_cte_cteCap_eq[unfolded o_def])
-  apply (wp cteDeleteOne_cteCaps_of)
-  apply clarsimp
-  done
-
-crunch finaliseCap
-  for irq_node'[wp]: "\<lambda>s. P (irq_node' s)"
-  (wp: crunch_wps getObject_inv loadObject_default_inv
-       updateObject_default_inv setObject_ksInterrupt
-   simp: crunch_simps o_def)
-
-lemma deletingIRQHandler_removeable':
-  "\<lbrace>invs' and (\<lambda>s. isFinal (IRQHandlerCap irq) slot (cteCaps_of s))
-          and K (cap = IRQHandlerCap irq)\<rbrace>
-     deletingIRQHandler irq
-   \<lbrace>\<lambda>rv s. removeable' slot s cap\<rbrace>"
-  apply (rule hoare_gen_asm)
-  apply (simp add: deletingIRQHandler_def getIRQSlot_def locateSlot_conv
-                   getInterruptState_def getSlotCap_def)
-  apply (simp add: removeable'_def tree_cte_cteCap_eq[unfolded o_def])
-  apply (subst tree_cte_cteCap_eq[unfolded o_def])+
-  apply (wp hoare_use_eq_irq_node' [OF cteDeleteOne_irq_node' cteDeleteOne_cteCaps_of]
-            getCTE_wp')
-  apply (clarsimp simp: cte_level_bits_def ucast_nat_def shiftl_t2n mult_ac cteSizeBits_def
-                  split: option.split_asm)
-  done
-
-lemma finaliseCap_cte_refs:
-  "\<lbrace>\<lambda>s. s \<turnstile>' cap\<rbrace>
-     finaliseCap cap final flag
-   \<lbrace>\<lambda>rv s. fst rv \<noteq> NullCap \<longrightarrow> cte_refs' (fst rv) = cte_refs' cap\<rbrace>"
-  apply (simp  add: finaliseCap_def Let_def getThreadCSpaceRoot
-                    X64_H.finaliseCap_def
-             cong: if_cong split del: if_split)
-  apply (rule hoare_pre)
-   apply (wp | wpc | simp only: o_def)+
-  apply (frule valid_capAligned)
-  apply (cases cap, simp_all add: isCap_simps)
-   apply (clarsimp simp: tcb_cte_cases_def word_count_from_top objBits_defs)
-  apply clarsimp
-  apply (rule ext, simp)
-  apply (rule image_cong [OF _ refl])
-  apply (fastforce simp: capAligned_def objBits_simps shiftL_nat mask_def)
-  done
-
-lemma deletingIRQHandler_final:
-  "\<lbrace>\<lambda>s. isFinal cap slot (cteCaps_of s)
-             \<and> (\<forall>final. finaliseCap cap final True = fail)\<rbrace>
-     deletingIRQHandler irq
-   \<lbrace>\<lambda>rv s. isFinal cap slot (cteCaps_of s)\<rbrace>"
-  apply (simp add: deletingIRQHandler_def isFinal_def getIRQSlot_def
-                   getInterruptState_def locateSlot_conv getSlotCap_def)
-  apply (wp cteDeleteOne_cteCaps_of getCTE_wp')
-  apply (auto simp: sameObjectAs_def3)
-  done
-
-declare suspend_unqueued [wp]
-
-lemma unbindNotification_valid_objs'_helper:
-  "valid_tcb' tcb s \<longrightarrow> valid_tcb' (tcbBoundNotification_update (\<lambda>_. None) tcb) s "
-  by (clarsimp simp: valid_bound_ntfn'_def valid_tcb'_def tcb_cte_cases_def tcb_cte_cases_neqs
-                  split: option.splits ntfn.splits)
-
-lemma unbindNotification_valid_objs'_helper':
-  "valid_ntfn' tcb s \<longrightarrow> valid_ntfn' (ntfnBoundTCB_update (\<lambda>_. None) tcb) s "
-  by (clarsimp simp: valid_bound_tcb'_def valid_ntfn'_def
-                  split: option.splits ntfn.splits)
-
-lemmas setNotification_valid_tcb' = typ_at'_valid_tcb'_lift [OF setNotification_typ_at']
-
-lemma unbindNotification_valid_objs'[wp]:
-  "\<lbrace>valid_objs'\<rbrace>
-     unbindNotification t
-   \<lbrace>\<lambda>rv. valid_objs'\<rbrace>"
-  apply (simp add: unbindNotification_def)
-  apply (rule hoare_pre)
-  apply (wp threadSet_valid_objs' gbn_wp' set_ntfn_valid_objs' hoare_vcg_all_lift
-            setNotification_valid_tcb' getNotification_wp
-        | wpc | clarsimp simp: setBoundNotification_def unbindNotification_valid_objs'_helper)+
-  apply (clarsimp elim!: obj_atE' simp: projectKOs)
-  apply (rule valid_objsE', assumption+)
-  apply (clarsimp simp: valid_obj'_def unbindNotification_valid_objs'_helper')
-  done
-
-lemma unbindMaybeNotification_valid_objs'[wp]:
-  "\<lbrace>valid_objs'\<rbrace>
-     unbindMaybeNotification t
-   \<lbrace>\<lambda>rv. valid_objs'\<rbrace>"
-  apply (simp add: unbindMaybeNotification_def)
-  apply (rule bind_wp[OF _ get_ntfn_sp'])
-  apply (rule hoare_pre)
-  apply (wp threadSet_valid_objs' gbn_wp' set_ntfn_valid_objs' hoare_vcg_all_lift
-            setNotification_valid_tcb' getNotification_wp
-        | wpc | clarsimp simp: setBoundNotification_def unbindNotification_valid_objs'_helper)+
-  apply (clarsimp elim!: obj_atE' simp: projectKOs)
-  apply (rule valid_objsE', assumption+)
-  apply (clarsimp simp: valid_obj'_def unbindNotification_valid_objs'_helper')
-  done
-
-lemma unbindMaybeNotification_sch_act_wf[wp]:
-  "\<lbrace>\<lambda>s. sch_act_wf (ksSchedulerAction s) s\<rbrace> unbindMaybeNotification t
-  \<lbrace>\<lambda>rv s. sch_act_wf (ksSchedulerAction s) s\<rbrace>"
-  apply (simp add: unbindMaybeNotification_def)
-  apply (rule hoare_pre)
-  apply (wp sbn_sch_act' | wpc | simp)+
-  done
-
-lemma valid_cong:
-  "\<lbrakk> \<And>s. P s = P' s; \<And>s. P' s \<Longrightarrow> f s = f' s;
-        \<And>rv s' s. \<lbrakk> (rv, s') \<in> fst (f' s); P' s \<rbrakk> \<Longrightarrow> Q rv s' = Q' rv s' \<rbrakk>
-    \<Longrightarrow> \<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace> = \<lbrace>P'\<rbrace> f' \<lbrace>Q'\<rbrace>"
-  by (clarsimp simp add: valid_def, blast)
-
-lemma sym_refs_ntfn_bound_eq: "sym_refs (state_refs_of' s)
-    \<Longrightarrow> obj_at' (\<lambda>ntfn. ntfnBoundTCB ntfn = Some t) x s
-    = bound_tcb_at' (\<lambda>st. st = Some x) t s"
-  apply (rule iffI)
-   apply (drule (1) sym_refs_obj_atD')
-   apply (clarsimp simp: pred_tcb_at'_def obj_at'_def ko_wp_at'_def projectKOs
-                         refs_of_rev')
-  apply (drule(1) sym_refs_bound_tcb_atD')
-  apply (clarsimp simp: obj_at'_def projectKOs ko_wp_at'_def refs_of_rev')
-  done
-
-lemma unbindMaybeNotification_obj_at'_bound:
-  "\<lbrace>\<top>\<rbrace>
-     unbindMaybeNotification r
-   \<lbrace>\<lambda>_ s. obj_at' (\<lambda>ntfn. ntfnBoundTCB ntfn = None) r s\<rbrace>"
-  apply (simp add: unbindMaybeNotification_def)
-  apply (rule bind_wp[OF _ get_ntfn_sp'])
-  apply (rule hoare_pre)
-   apply (wp obj_at_setObject2
-        | wpc
-        | simp add: setBoundNotification_def threadSet_def updateObject_default_def in_monad projectKOs)+
-  apply (simp add: setNotification_def obj_at'_real_def cong: valid_cong)
-   apply (wp setObject_ko_wp_at, (simp add: objBits_simps')+)
-  apply (clarsimp simp: obj_at'_def ko_wp_at'_def projectKOs)
-  done
-
-crunch unbindNotification, unbindMaybeNotification
-  for isFinal[wp]: "\<lambda>s. isFinal cap slot (cteCaps_of s)"
-  (wp: sts_bound_tcb_at' threadSet_cteCaps_of crunch_wps getObject_inv
-       loadObject_default_inv
-   simp: setBoundNotification_def
-   ignore: threadSet)
-
-crunch cancelSignal, cancelAllIPC
-  for bound_tcb_at'[wp]: "bound_tcb_at' P t"
-  (wp: sts_bound_tcb_at' threadSet_cteCaps_of crunch_wps getObject_inv
-       loadObject_default_inv
-   ignore: threadSet)
-
-lemma finaliseCapTrue_standin_bound_tcb_at':
-  "\<lbrace>\<lambda>s. bound_tcb_at' P t s \<and> (\<exists>tt b r. cap = ReplyCap tt b r) \<rbrace>
-     finaliseCapTrue_standin cap final
-   \<lbrace>\<lambda>_. bound_tcb_at' P t\<rbrace>"
-  apply (case_tac cap, simp_all add:finaliseCapTrue_standin_def)
-  apply (clarsimp simp: isNotificationCap_def)
-  apply (wp, clarsimp)
-  done
-
-lemma capDeleteOne_bound_tcb_at':
-  "\<lbrace>bound_tcb_at' P tptr and cte_wp_at' (isReplyCap \<circ> cteCap) callerCap\<rbrace>
-      cteDeleteOne callerCap \<lbrace>\<lambda>rv. bound_tcb_at' P tptr\<rbrace>"
-  apply (simp add: cteDeleteOne_def unless_def)
-  apply (rule hoare_pre)
-   apply (wp finaliseCapTrue_standin_bound_tcb_at' hoare_vcg_all_lift
-            hoare_vcg_if_lift2 getCTE_cteCap_wp
-        | wpc | simp | wp (once) hoare_drop_imp)+
-  apply (clarsimp simp:  cteCaps_of_def projectKOs isReplyCap_def cte_wp_at_ctes_of
-                 split: option.splits)
-  apply (case_tac "cteCap cte", simp_all)
-  done
-
-lemma cancelIPC_bound_tcb_at'[wp]:
-  "\<lbrace>bound_tcb_at' P tptr\<rbrace> cancelIPC t \<lbrace>\<lambda>rv. bound_tcb_at' P tptr\<rbrace>"
-  apply (simp add: cancelIPC_def Let_def)
-  apply (rule bind_wp[OF _ gts_sp'])
-  apply (case_tac "state", simp_all)
-         defer 2
-         apply (rule hoare_pre)
-          apply ((wp sts_bound_tcb_at' getEndpoint_wp | wpc | simp)+)[8]
-  apply (simp add: getThreadReplySlot_def locateSlot_conv liftM_def)
-  apply (rule hoare_pre)
-   apply (wp capDeleteOne_bound_tcb_at' getCTE_ctes_of)
-   apply (rule_tac Q'="\<lambda>_. bound_tcb_at' P tptr" in hoare_post_imp)
-   apply (clarsimp simp: capHasProperty_def cte_wp_at_ctes_of)
-   apply (wp threadSet_pred_tcb_no_state | simp)+
-  done
-
-crunch suspend, prepareThreadDelete
-  for bound_tcb_at'[wp]: "bound_tcb_at' P t"
-  (wp: sts_bound_tcb_at' cancelIPC_bound_tcb_at'
-   ignore: threadSet)
-
-lemma unbindNotification_bound_tcb_at':
-  "\<lbrace>\<lambda>_. True\<rbrace> unbindNotification t \<lbrace>\<lambda>rv. bound_tcb_at' ((=) None) t\<rbrace>"
-  apply (simp add: unbindNotification_def)
-  apply (wp setBoundNotification_bound_tcb gbn_wp' | wpc | simp)+
-  done
-
-crunch unbindNotification, unbindMaybeNotification
-  for weak_sch_act_wf[wp]: "\<lambda>s. weak_sch_act_wf (ksSchedulerAction s) s"
-
-lemma unbindNotification_tcb_at'[wp]:
-  "\<lbrace>tcb_at' t'\<rbrace> unbindNotification t \<lbrace>\<lambda>rv. tcb_at' t'\<rbrace>"
-  apply (simp add: unbindNotification_def)
-  apply (wp gbn_wp' | wpc | simp)+
-  done
-
-lemma unbindMaybeNotification_tcb_at'[wp]:
-  "\<lbrace>tcb_at' t'\<rbrace> unbindMaybeNotification t \<lbrace>\<lambda>rv. tcb_at' t'\<rbrace>"
-  apply (simp add: unbindMaybeNotification_def)
-  apply (wp gbn_wp' | wpc | simp)+
-  done
-
-crunch prepareThreadDelete
-  for cte_wp_at'[wp]: "cte_wp_at' P p"
-crunch prepareThreadDelete
-  for valid_cap'[wp]: "valid_cap' cap"
-crunch prepareThreadDelete
-  for invs[wp]: "invs'"
-  (ignore: doMachineOp)
-
-crunch prepareThreadDelete
-  for tcbSchedPrevNext[wp]: "obj_at' (\<lambda>tcb. P (tcbSchedNext tcb) (tcbSchedPrev tcb)) t"
-  (wp: crunch_wps simp: crunch_simps)
-
-end
-
-lemma tcbQueueRemove_tcbSchedNext_tcbSchedPrev_None_obj_at':
-  "\<lbrace>\<lambda>s. \<exists>ts. list_queue_relation ts q (tcbSchedNexts_of s) (tcbSchedPrevs_of s)\<rbrace>
-   tcbQueueRemove q t
-   \<lbrace>\<lambda>_ s. obj_at' (\<lambda>tcb. tcbSchedNext tcb = None \<and> tcbSchedPrev tcb = None) t s\<rbrace>"
-  supply projectKOs[simp]
-  apply (clarsimp simp: tcbQueueRemove_def)
-  apply (wpsimp wp: threadSet_wp getTCB_wp)
-  by (fastforce dest!: heap_ls_last_None
-                 simp: list_queue_relation_def prev_queue_head_def queue_end_valid_def
-                       obj_at'_def opt_map_def ps_clear_def X64.objBits_simps
-                split: if_splits)
-
-lemma tcbSchedDequeue_tcbSchedNext_tcbSchedPrev_None_obj_at':
-  "\<lbrace>valid_sched_pointers\<rbrace>
-   tcbSchedDequeue t
-   \<lbrace>\<lambda>_ s. obj_at' (\<lambda>tcb. tcbSchedNext tcb = None \<and> tcbSchedPrev tcb = None) t s\<rbrace>"
-  unfolding tcbSchedDequeue_def
-  supply projectKOs[simp]
-  by (wpsimp wp: tcbQueueRemove_tcbSchedNext_tcbSchedPrev_None_obj_at' threadGet_wp)
-     (fastforce simp: ready_queue_relation_def ksReadyQueues_asrt_def obj_at'_def
-                      valid_sched_pointers_def opt_pred_def opt_map_def
-               split: option.splits)
-
-crunch updateRestartPC, cancelIPC
-  for valid_sched_pointers[wp]: valid_sched_pointers
-  (simp: crunch_simps wp: crunch_wps)
-
-lemma setThreadState_tcbSchedNext_tcbSchedPrev_None_obj_at'[wp]:
-  "setThreadState ref ts \<lbrace>\<lambda>s. obj_at' (\<lambda>tcb. tcbSchedNext tcb = None \<and> tcbSchedPrev tcb = None) t s\<rbrace>"
-  unfolding setThreadState_def
-  apply (wpsimp wp: threadSet_wp getTCB_wp)
-  apply (fastforce simp: obj_at'_def gen_objBits_simps)
-  done
-
-lemma suspend_tcbSchedNext_tcbSchedPrev_None:
-  "\<lbrace>invs'\<rbrace> suspend t \<lbrace>\<lambda>_ s. obj_at' (\<lambda>tcb. tcbSchedNext tcb = None \<and> tcbSchedPrev tcb = None) t s\<rbrace>"
-  unfolding suspend_def
-  by (wpsimp wp: hoare_drop_imps tcbSchedDequeue_tcbSchedNext_tcbSchedPrev_None_obj_at')
-
-lemma (in delete_one_conc_pre) finaliseCap_replaceable:
-  "\<lbrace>\<lambda>s. invs' s \<and> cte_wp_at' (\<lambda>cte. cteCap cte = cap) slot s
-       \<and> (final_matters' cap \<longrightarrow> (final = isFinal cap slot (cteCaps_of s)))
-       \<and> weak_sch_act_wf (ksSchedulerAction s) s\<rbrace>
-     finaliseCap cap final flag
-   \<lbrace>\<lambda>rv s. (isNullCap (fst rv) \<and> removeable' slot s cap
-                \<and> (snd rv \<noteq> NullCap \<longrightarrow> snd rv = cap \<and> cap_has_cleanup' cap
-                                      \<and> isFinal cap slot (cteCaps_of s)))
-        \<or>
-          (isZombie (fst rv) \<and> snd rv = NullCap
-            \<and> isFinal cap slot (cteCaps_of s)
-            \<and> capClass cap = capClass (fst rv)
-            \<and> capUntypedPtr (fst rv) = capUntypedPtr cap
-            \<and> capBits (fst rv) = capBits cap
-            \<and> capRange (fst rv) = capRange cap
-            \<and> (isThreadCap cap \<or> isCNodeCap cap \<or> isZombie cap)
-            \<and> (\<forall>p \<in> threadCapRefs cap. st_tcb_at' ((=) Inactive) p s
-                     \<and> obj_at' (Not \<circ> tcbQueued) p s
-                     \<and> bound_tcb_at' ((=) None) p s
-                     \<and> obj_at' (\<lambda>tcb. tcbSchedNext tcb = None \<and> tcbSchedPrev tcb = None) p s))\<rbrace>"
-  apply (simp add: finaliseCap_def Let_def getThreadCSpaceRoot
-             cong: if_cong split del: if_split)
-  apply (rule hoare_pre)
-   apply (wp prepares_delete_helper'' [OF cancelAllIPC_unlive]
-             prepares_delete_helper'' [OF cancelAllSignals_unlive]
-             suspend_isFinal X64.prepareThreadDelete_unqueued (* FIXME arch-split: interface *)
-             X64.prepareThreadDelete_inactive prepareThreadDelete_isFinal
-             suspend_makes_inactive
-             deletingIRQHandler_removeable'
-             deletingIRQHandler_final[where slot=slot ]
-             unbindMaybeNotification_obj_at'_bound
-             getNotification_wp
-             suspend_bound_tcb_at'
-             unbindNotification_bound_tcb_at'
-             suspend_tcbSchedNext_tcbSchedPrev_None
-           | simp add: isZombie_Null isThreadCap_threadCapRefs_tcbptr
-                       isArchObjectCap_Cap_capCap
-           | (rule hoare_strengthen_post [OF arch_finaliseCap_removeable[where slot=slot]],
-              clarsimp simp: gen_isCap_simps)
-           | wpc)+
-  apply clarsimp
-  apply (frule cte_wp_at_valid_objs_valid_cap', clarsimp+)
-  apply (case_tac "cteCap cte",
-         simp_all add: gen_isCap_simps capRange_def cap_has_cleanup'_def
-                       final_matters'_def X64.objBits_simps
-                       not_Final_removeable finaliseCap_def,
-         simp_all add: removeable'_def)
-     (* thread *)
-     apply (frule capAligned_capUntypedPtr [OF valid_capAligned], simp)
-     apply (clarsimp simp: valid_cap'_def)
-     apply (drule valid_globals_cte_wpD'[rotated], clarsimp)
-     apply (clarsimp simp: invs'_def valid_state'_def valid_pspace'_def)
-    apply (clarsimp simp: obj_at'_def | rule conjI)+
-  done
-
-lemma cteDeleteOne_cte_wp_at_preserved:
-  assumes x: "\<And>cap final. P cap \<Longrightarrow> finaliseCap cap final True = fail"
-  shows "\<lbrace>\<lambda>s. cte_wp_at' (\<lambda>cte. P (cteCap cte)) p s\<rbrace>
-           cteDeleteOne ptr
-         \<lbrace>\<lambda>rv s. cte_wp_at' (\<lambda>cte. P (cteCap cte)) p s\<rbrace>"
-  apply (simp add: tree_cte_cteCap_eq[unfolded o_def])
-  apply (rule hoare_pre, wp cteDeleteOne_cteCaps_of)
-  apply (clarsimp simp: cteCaps_of_def cte_wp_at_ctes_of x)
-  done
-
-crunch cancelSignal
-  for ctes_of[wp]: "\<lambda>s. P (ctes_of s)"
-  (simp: crunch_simps wp: crunch_wps)
-
-lemma cancelIPC_cteCaps_of:
-  "\<lbrace>\<lambda>s. (\<forall>p. cte_wp_at' (\<lambda>cte. \<exists>final. finaliseCap (cteCap cte) final True \<noteq> fail) p s \<longrightarrow>
-          P ((cteCaps_of s)(p \<mapsto> NullCap))) \<and>
-     P (cteCaps_of s)\<rbrace>
-     cancelIPC t
-   \<lbrace>\<lambda>rv s. P (cteCaps_of s)\<rbrace>"
-  apply (simp add: cancelIPC_def Let_def capHasProperty_def
-                   getThreadReplySlot_def locateSlot_conv)
-  apply (rule hoare_pre)
-   apply (wp cteDeleteOne_cteCaps_of getCTE_wp' | wpcw
-        | simp add: cte_wp_at_ctes_of
-        | wp (once) hoare_drop_imps ctes_of_cteCaps_of_lift)+
-          apply (wp hoare_convert_imp hoare_vcg_all_lift
-                    threadSet_ctes_of threadSet_cteCaps_of
-               | clarsimp)+
-    apply (wp cteDeleteOne_cteCaps_of getCTE_wp' | wpcw | simp
-       | wp (once) hoare_drop_imps ctes_of_cteCaps_of_lift)+
-  apply (clarsimp simp: cte_wp_at_ctes_of cteCaps_of_def)
-  apply (drule_tac x="mdbNext (cteMDBNode x)" in spec)
-  apply clarsimp
-  apply (auto simp: o_def map_option_case fun_upd_def[symmetric])
-  done
-
-lemma cancelIPC_cte_wp_at':
-  assumes x: "\<And>cap final. P cap \<Longrightarrow> finaliseCap cap final True = fail"
-  shows "\<lbrace>\<lambda>s. cte_wp_at' (\<lambda>cte. P (cteCap cte)) p s\<rbrace>
-           cancelIPC t
-         \<lbrace>\<lambda>rv s. cte_wp_at' (\<lambda>cte. P (cteCap cte)) p s\<rbrace>"
-  apply (simp add: tree_cte_cteCap_eq[unfolded o_def])
-  apply (rule hoare_pre, wp cancelIPC_cteCaps_of)
-  apply (clarsimp simp: cteCaps_of_def cte_wp_at_ctes_of x)
-  done
-
-crunch tcbSchedDequeue
-  for cte_wp_at'[wp]: "cte_wp_at' P p"
-  (wp: crunch_wps)
-
-lemma suspend_cte_wp_at':
-  assumes x: "\<And>cap final. P cap \<Longrightarrow> finaliseCap cap final True = fail"
-  shows "\<lbrace>cte_wp_at' (\<lambda>cte. P (cteCap cte)) p\<rbrace>
-           suspend t
-         \<lbrace>\<lambda>rv. cte_wp_at' (\<lambda>cte. P (cteCap cte)) p\<rbrace>"
-  apply (simp add: suspend_def updateRestartPC_def)
-  apply (rule hoare_pre)
-   apply (wp threadSet_cte_wp_at' cancelIPC_cte_wp_at'
-             | simp add: x)+
-  done
-
-context begin interpretation Arch . (*FIXME: arch-split*)
-
-crunch deleteASIDPool
-  for cte_wp_at'[wp]: "cte_wp_at' P p"
-  (simp: crunch_simps assertE_def
-   wp: crunch_wps getObject_inv loadObject_default_inv)
-
-lemma deleteASID_cte_wp_at'[wp]:
-  "\<lbrace>cte_wp_at' P p\<rbrace> deleteASID param_a param_b \<lbrace>\<lambda>_. cte_wp_at' P p\<rbrace>"
-  apply (simp add: deleteASID_def
-              cong: option.case_cong)
-  apply (wp setObject_cte_wp_at'[where Q="\<top>"] getObject_inv
-            loadObject_default_inv setVMRoot_cte_wp_at'
-          | clarsimp simp: updateObject_default_def in_monad
-                           projectKOs
-          | rule equals0I
-          | wpc)+
-  done
-
-crunch unmapPageTable, unmapPage, unbindNotification, finaliseCapTrue_standin
-  for cte_wp_at'[wp]: "cte_wp_at' P p"
-  (simp: crunch_simps wp: crunch_wps getObject_inv loadObject_default_inv)
-
-lemma arch_finaliseCap_cte_wp_at[wp]:
-  "\<lbrace>cte_wp_at' P p\<rbrace> Arch.finaliseCap cap fin \<lbrace>\<lambda>rv. cte_wp_at' P p\<rbrace>"
-  apply (simp add: X64_H.finaliseCap_def)
-  apply (rule hoare_pre)
-   apply (wp unmapPage_cte_wp_at'| simp | wpc)+
-  done
-
-lemma deletingIRQHandler_cte_preserved:
-  assumes x: "\<And>cap final. P cap \<Longrightarrow> finaliseCap cap final True = fail"
-  shows "\<lbrace>cte_wp_at' (\<lambda>cte. P (cteCap cte)) p\<rbrace>
-           deletingIRQHandler irq
-         \<lbrace>\<lambda>rv. cte_wp_at' (\<lambda>cte. P (cteCap cte)) p\<rbrace>"
-  apply (simp add: deletingIRQHandler_def getSlotCap_def
-                   getIRQSlot_def locateSlot_conv getInterruptState_def)
-  apply (wp cteDeleteOne_cte_wp_at_preserved getCTE_wp'
-              | simp add: x)+
-  done
-
-lemma finaliseCap_equal_cap[wp]:
-  "\<lbrace>cte_wp_at' (\<lambda>cte. cteCap cte = cap) sl\<rbrace>
-     finaliseCap cap fin flag
-   \<lbrace>\<lambda>rv. cte_wp_at' (\<lambda>cte. cteCap cte = cap) sl\<rbrace>"
-  apply (simp add: finaliseCap_def Let_def
-             cong: if_cong split del: if_split)
-  apply (rule hoare_pre)
-   apply (wp suspend_cte_wp_at' deletingIRQHandler_cte_preserved
-        | clarsimp simp: finaliseCap_def | wpc)+
-  apply (case_tac cap)
-  apply auto
-  done
-
-lemma setThreadState_st_tcb_at_simplish':
-  "simple' st \<Longrightarrow>
-   \<lbrace>st_tcb_at' (P or simple') t\<rbrace>
-     setThreadState st t'
-   \<lbrace>\<lambda>rv. st_tcb_at' (P or simple') t\<rbrace>"
-  apply (wp sts_st_tcb_at'_cases)
-  apply clarsimp
-  done
-
-lemmas setThreadState_st_tcb_at_simplish
-    = setThreadState_st_tcb_at_simplish'[unfolded pred_disj_def]
-
-crunch cteDeleteOne
-  for st_tcb_at_simplish: "st_tcb_at' (\<lambda>st. P st \<or> simple' st) t"
-  (wp: crunch_wps getObject_inv loadObject_default_inv threadSet_pred_tcb_no_state
-   simp: crunch_simps unless_def ignore: threadSet)
-
-lemma cteDeleteOne_st_tcb_at[wp]:
-  assumes x[simp]: "\<And>st. simple' st \<longrightarrow> P st" shows
-  "\<lbrace>st_tcb_at' P t\<rbrace> cteDeleteOne slot \<lbrace>\<lambda>rv. st_tcb_at' P t\<rbrace>"
-  apply (subgoal_tac "\<exists>Q. P = (Q or simple')")
-   apply (clarsimp simp: pred_disj_def)
-   apply (rule cteDeleteOne_st_tcb_at_simplish)
-  apply (rule_tac x=P in exI)
-  apply (auto intro!: ext)
-  done
-
-lemma cteDeleteOne_reply_pred_tcb_at:
-  "\<lbrace>\<lambda>s. pred_tcb_at' proj P t s \<and> (\<exists>t' r. cte_wp_at' (\<lambda>cte. cteCap cte = ReplyCap t' False r) slot s)\<rbrace>
-    cteDeleteOne slot
-   \<lbrace>\<lambda>rv. pred_tcb_at' proj P t\<rbrace>"
-  apply (simp add: cteDeleteOne_def unless_def isFinalCapability_def)
-  apply (rule bind_wp [OF _ getCTE_sp])
-  apply (rule hoare_assume_pre)
-  apply (clarsimp simp: cte_wp_at_ctes_of when_def isCap_simps
-                        Let_def finaliseCapTrue_standin_def)
-  apply (intro impI conjI, (wp | simp)+)
-  done
-
-context
-notes option.case_cong_weak[cong]
-begin
-crunch cteDeleteOne, unbindNotification
-  for sch_act_simple[wp]: sch_act_simple
-  (wp: crunch_wps ssa_sch_act_simple sts_sch_act_simple getObject_inv
-       loadObject_default_inv
-   simp: crunch_simps unless_def
-   rule: sch_act_simple_lift)
-end
-
-lemma rescheduleRequired_sch_act_not[wp]:
-  "\<lbrace>\<top>\<rbrace> rescheduleRequired \<lbrace>\<lambda>rv. sch_act_not t\<rbrace>"
-  apply (simp add: rescheduleRequired_def setSchedulerAction_def)
-  apply (wp hoare_TrueI | simp)+
-  done
-
-crunch cteDeleteOne
-  for sch_act_not[wp]: "sch_act_not t"
-  (simp: crunch_simps case_Null_If unless_def
-   wp: crunch_wps getObject_inv loadObject_default_inv)
-
-lemma cancelAllIPC_mapM_x_weak_sch_act:
-  "\<lbrace>\<lambda>s. weak_sch_act_wf (ksSchedulerAction s) s\<rbrace>
-   mapM_x (\<lambda>t. do
-                 y \<leftarrow> setThreadState Structures_H.thread_state.Restart t;
-                 tcbSchedEnqueue t
-               od) q
-   \<lbrace>\<lambda>rv s. weak_sch_act_wf (ksSchedulerAction s) s\<rbrace>"
-  apply (rule mapM_x_wp_inv)
-  apply (wp)
-  apply (clarsimp)
-  done
-
-lemma cancelAllIPC_mapM_x_valid_objs':
-  "\<lbrace>valid_objs' and pspace_aligned' and pspace_distinct'\<rbrace>
-   mapM_x (\<lambda>t. do
-                 y \<leftarrow> setThreadState Structures_H.thread_state.Restart t;
-                 tcbSchedEnqueue t
-               od) q
-   \<lbrace>\<lambda>_. valid_objs'\<rbrace>"
-  apply (rule hoare_strengthen_post)
-   apply (rule mapM_x_wp')
-  apply (wpsimp wp: sts_valid_objs')
-   apply (clarsimp simp: valid_tcb_state'_def)+
-  done
-
-lemma cancelAllIPC_mapM_x_tcbDomain_obj_at':
-  "\<lbrace>obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>
-   mapM_x (\<lambda>t. do
-                 y \<leftarrow> setThreadState Structures_H.thread_state.Restart t;
-                 tcbSchedEnqueue t
-               od) q
-  \<lbrace>\<lambda>_. obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>"
-  by (wpsimp wp: mapM_x_wp' X64.setThreadState_oa_queued) (* FIXME arch-split: X64 only lemma *)
-
-lemma rescheduleRequired_oa_queued':
-  "\<lbrace>obj_at' (\<lambda>tcb. Q (tcbDomain tcb) (tcbPriority tcb)) t'\<rbrace>
-    rescheduleRequired
-   \<lbrace>\<lambda>_. obj_at' (\<lambda>tcb. Q (tcbDomain tcb) (tcbPriority tcb)) t'\<rbrace>"
-  by (wpsimp simp: rescheduleRequired_def tcbSchedEnqueue_def tcbQueuePrepend_def)
-
-lemma cancelAllIPC_tcbDomain_obj_at':
-  "\<lbrace>obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>
-     cancelAllIPC epptr
-   \<lbrace>\<lambda>_. obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>"
-  unfolding cancelAllIPC_def
-  by (wpsimp wp: hoare_vcg_conj_lift hoare_vcg_const_Ball_lift getEndpoint_wp
-                 rescheduleRequired_oa_queued' cancelAllIPC_mapM_x_tcbDomain_obj_at')
-
-lemma cancelAllSignals_tcbDomain_obj_at':
-  "\<lbrace>obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>
-     cancelAllSignals epptr
-   \<lbrace>\<lambda>_. obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>"
-  unfolding cancelAllSignals_def
-  by (wpsimp wp: hoare_vcg_conj_lift hoare_vcg_const_Ball_lift getNotification_wp
-                 rescheduleRequired_oa_queued' cancelAllIPC_mapM_x_tcbDomain_obj_at')
-
-lemma unbindMaybeNotification_tcbDomain_obj_at':
-  "\<lbrace>obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>
-     unbindMaybeNotification r
-   \<lbrace>\<lambda>_. obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>"
-  apply (simp add: unbindMaybeNotification_def)
-  apply (wp setBoundNotification_oa_queued getNotification_wp gbn_wp' | wpc | simp)+
-  done
-
-crunch isFinalCapability
-  for sch_act[wp]: "\<lambda>s. sch_act_wf (ksSchedulerAction s) s"
-  (simp: crunch_simps)
-
-crunch
-  isFinalCapability
-  for weak_sch_act[wp]: "\<lambda>s. weak_sch_act_wf (ksSchedulerAction s) s"
-  (simp: crunch_simps)
-
-crunch cteDeleteOne
-  for ksCurDomain[wp]: "\<lambda>s. P (ksCurDomain s)"
-  (wp: crunch_wps simp: crunch_simps unless_def)
-
-lemma cteDeleteOne_tcbDomain_obj_at':
-  "\<lbrace>obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace> cteDeleteOne slot \<lbrace>\<lambda>_. obj_at' (\<lambda>tcb. P (tcbDomain tcb)) t'\<rbrace>"
-  apply (simp add: cteDeleteOne_def unless_def split_def)
-  apply (wp emptySlot_tcbDomain cancelAllIPC_tcbDomain_obj_at' cancelAllSignals_tcbDomain_obj_at'
-          isFinalCapability_inv getCTE_wp
-          unbindMaybeNotification_tcbDomain_obj_at'
-     | rule hoare_drop_imp
-     | simp add: finaliseCapTrue_standin_def Let_def
-            split del: if_split
-     | wpc)+
-  apply (clarsimp simp: cte_wp_at'_def)
-  done
-
-end
-
-global_interpretation delete_one_conc_pre
-  by (unfold_locales, wp) (wp cteDeleteOne_tcbDomain_obj_at' cteDeleteOne_typ_at' cteDeleteOne_reply_pred_tcb_at | simp)+
-
-context begin interpretation Arch . (*FIXME: arch-split*)
-
-lemma cteDeleteOne_invs[wp]:
-  "\<lbrace>invs'\<rbrace> cteDeleteOne ptr \<lbrace>\<lambda>rv. invs'\<rbrace>"
-  apply (simp add: cteDeleteOne_def unless_def
-                   split_def finaliseCapTrue_standin_simple_def)
-  apply wp
-    apply (rule hoare_strengthen_post)
-     apply (rule hoare_vcg_conj_lift)
-      apply (rule finaliseCap_True_invs)
-     apply (rule hoare_vcg_conj_lift)
-      apply (rule finaliseCap_replaceable[where slot=ptr])
-     apply (rule hoare_vcg_conj_lift)
-      apply (rule finaliseCap_cte_refs)
-     apply (rule finaliseCap_equal_cap[where sl=ptr])
-    apply (clarsimp simp: cte_wp_at_ctes_of)
-    apply (erule disjE)
-     apply simp
-    apply (clarsimp dest!: isCapDs simp: capRemovable_def)
-    apply (clarsimp simp: removeable'_def fun_eq_iff[where f="cte_refs' cap" for cap]
-                     del: disjCI)
-    apply (rule disjI2)
-    apply (rule conjI)
-     subgoal by auto
-    subgoal by (auto dest!: isCapDs simp: pred_tcb_at'_def obj_at'_def projectKOs
-                                     live'_def hyp_live'_def ko_wp_at'_def)
-   apply (wp isFinalCapability_inv getCTE_wp' hoare_weak_lift_imp
-        | wp (once) isFinal[where x=ptr])+
-  apply (fastforce simp: cte_wp_at_ctes_of)
-  done
-
-end
-
-global_interpretation delete_one_conc_fr: delete_one_conc
-  by unfold_locales wp
-
-declare cteDeleteOne_invs[wp]
-
-lemma deletingIRQHandler_invs' [wp]:
-  "\<lbrace>invs'\<rbrace> deletingIRQHandler i \<lbrace>\<lambda>_. invs'\<rbrace>"
-  apply (simp add: deletingIRQHandler_def getSlotCap_def
-                   getIRQSlot_def locateSlot_conv getInterruptState_def)
-  apply (wp getCTE_wp')
-  apply simp
-  done
-
-lemma finaliseCap_invs:
-  "\<lbrace>invs' and sch_act_simple and valid_cap' cap
-         and cte_wp_at' (\<lambda>cte. cteCap cte = cap) sl\<rbrace>
-     finaliseCap cap fin flag
-   \<lbrace>\<lambda>rv. invs'\<rbrace>"
-  apply (simp add: finaliseCap_def Let_def
-             cong: if_cong split del: if_split)
-  apply (rule hoare_pre)
-   apply (wp hoare_drop_imps hoare_vcg_all_lift | simp only: o_def | wpc)+
-
-  apply clarsimp
-  apply (intro conjI impI)
-    apply (clarsimp dest!: isCapDs simp: valid_cap'_def)
-   apply (drule invs_valid_global', drule(1) valid_globals_cte_wpD')
-   apply (drule valid_capAligned, drule capAligned_capUntypedPtr)
-    apply (clarsimp dest!: isCapDs)
-   apply (clarsimp dest!: isCapDs)
-  apply (clarsimp dest!: isCapDs)
-  done
-
-lemma finaliseCap_zombie_cap[wp]:
-  "\<lbrace>cte_wp_at' (\<lambda>cte. (P and isZombie) (cteCap cte)) sl\<rbrace>
-     finaliseCap cap fin flag
-   \<lbrace>\<lambda>rv. cte_wp_at' (\<lambda>cte. (P and isZombie) (cteCap cte)) sl\<rbrace>"
-  apply (simp add: finaliseCap_def Let_def
-             cong: if_cong split del: if_split)
-  apply (rule hoare_pre)
-   apply (wp suspend_cte_wp_at' deletingIRQHandler_cte_preserved
-          | clarsimp simp: finaliseCap_def gen_isCap_simps | wpc)+
-  done
-
-lemma finaliseCap_zombie_cap':
-  "\<lbrace>cte_wp_at' (\<lambda>cte. (P and isZombie) (cteCap cte)) sl\<rbrace>
-     finaliseCap cap fin flag
-   \<lbrace>\<lambda>rv. cte_wp_at' (\<lambda>cte. P (cteCap cte)) sl\<rbrace>"
-  apply (rule hoare_strengthen_post)
-   apply (rule finaliseCap_zombie_cap)
-  apply (clarsimp simp: cte_wp_at_ctes_of)
-  done
-
-lemma finaliseCap_cte_cap_wp_to[wp]:
-  "\<lbrace>ex_cte_cap_wp_to' P sl\<rbrace> finaliseCap cap fin flag \<lbrace>\<lambda>rv. ex_cte_cap_wp_to' P sl\<rbrace>"
-  apply (simp add: ex_cte_cap_to'_def)
-  apply (rule hoare_pre, rule hoare_use_eq_irq_node' [OF finaliseCap_irq_node'])
-   apply (simp add: finaliseCap_def Let_def
-              cong: if_cong split del: if_split)
-   apply (wp suspend_cte_wp_at'
-             deletingIRQHandler_cte_preserved
-             hoare_vcg_ex_lift
-                 | clarsimp simp: finaliseCap_def gen_isCap_simps
-                 | rule conjI
-                 | wpc)+
-  apply fastforce
-  done
-
-context
-notes option.case_cong_weak[cong]
-begin
-crunch unbindNotification
-  for valid_cap'[wp]: "valid_cap' cap"
-end
-
-lemma finaliseCap_valid_cap[wp]:
-  "\<lbrace>valid_cap' cap\<rbrace> finaliseCap cap final flag \<lbrace>\<lambda>rv. valid_cap' (fst rv)\<rbrace>"
-  apply (simp add: finaliseCap_def Let_def
-                   getThreadCSpaceRoot
-                   X64_H.finaliseCap_def
-             cong: if_cong split del: if_split)
-  apply (rule hoare_pre)
-   apply (wp | simp only: valid_NullCap o_def fst_conv | wpc)+
-  apply simp
-  apply (intro conjI impI)
-   apply (clarsimp simp: valid_cap'_def gen_isCap_simps capAligned_def
-                         X64.objBits_simps shiftL_nat)+
-  done
-
-lemma no_idle_thread_cap:
-  "\<lbrakk> cte_wp_at ((=) (cap.ThreadCap (idle_thread s))) sl s; valid_global_refs s \<rbrakk> \<Longrightarrow> False"
-  apply (cases sl)
-  apply (clarsimp simp: valid_global_refs_def valid_refs_def cte_wp_at_caps_of_state)
-  apply ((erule allE)+, erule (1) impE)
-  apply (clarsimp simp: cap_range_def)
-  done
-
-lemmas getCTE_no_0_obj'_helper
-  = getCTE_inv
-    hoare_strengthen_post[where Q'="\<lambda>_. no_0_obj'" and P=no_0_obj' and f="getCTE slot" for slot]
-
-context begin interpretation Arch . (*FIXME: arch-split*)
-
-crunch "Arch.finaliseCap"
+crunch unmapPageTable
   for nosch[wp]: "\<lambda>s. P (ksSchedulerAction s)"
-  (wp: crunch_wps getObject_inv simp: loadObject_default_def updateObject_default_def)
+  (wp: crunch_wps getObject_inv hoare_vcg_all_lift hoare_vcg_if_lift3
+   simp: loadObject_default_def updateObject_default_def)
 
-crunch finaliseCap
+context notes if_cong[cong] begin
+
+crunch Arch_finaliseCap
+  for nosch[wp]: "\<lambda>s. P (ksSchedulerAction s)"
+  (wp: crunch_wps getObject_inv simp: loadObject_default_def updateObject_default_def
+   rule: X64_H.finaliseCap_def)
+
+end
+
+crunch deletingIRQHandler, finaliseCap
   for sch_act_simple[wp]: sch_act_simple
   (simp: crunch_simps
    rule: sch_act_simple_lift
    wp: getObject_inv loadObject_default_inv crunch_wps)
 
-end
-
-
-lemma interrupt_cap_null_or_ntfn:
-  "invs s
-    \<Longrightarrow> cte_wp_at (\<lambda>cp. is_ntfn_cap cp \<or> cp = cap.NullCap) (interrupt_irq_node s irq, []) s"
-  apply (frule invs_valid_irq_node)
-  apply (clarsimp simp: valid_irq_node_def)
-  apply (drule_tac x=irq in spec)
-  apply (drule cte_at_0)
-  apply (clarsimp simp: cte_wp_at_caps_of_state)
-  apply (drule caps_of_state_cteD)
-  apply (frule if_unsafe_then_capD, clarsimp+)
-  apply (clarsimp simp: ex_cte_cap_wp_to_def cte_wp_at_caps_of_state)
-  apply (frule cte_refs_obj_refs_elem, erule disjE)
-   apply (clarsimp | drule caps_of_state_cteD valid_global_refsD[rotated]
-     | rule irq_node_global_refs[where irq=irq])+
-   apply (simp add: cap_range_def)
-  apply (clarsimp simp: appropriate_cte_cap_def
-                 split: cap.split_asm)
-  done
-
-lemma (in delete_one) deletingIRQHandler_corres:
-  "corres dc (einvs) (invs')
-          (deleting_irq_handler irq) (deletingIRQHandler irq)"
-  apply (simp add: deleting_irq_handler_def deletingIRQHandler_def)
-  apply (rule corres_guard_imp)
-    apply (rule corres_split[OF getIRQSlot_corres])
-      apply simp
-      apply (rule_tac P'="cte_at' (cte_map slot)" in corres_symb_exec_r_conj)
-         apply (rule_tac F="isNotificationCap rv \<or> rv = capability.NullCap"
-             and P="cte_wp_at (\<lambda>cp. is_ntfn_cap cp \<or> cp = cap.NullCap) slot
-                 and einvs"
-             and P'="invs' and cte_wp_at' (\<lambda>cte. cteCap cte = rv)
-                 (cte_map slot)" in corres_req)
-          apply (clarsimp simp: cte_wp_at_caps_of_state state_relation_def)
-          apply (drule caps_of_state_cteD)
-          apply (drule(1) pspace_relation_cte_wp_at, clarsimp+)
-          apply (auto simp: cte_wp_at_ctes_of is_cap_simps gen_isCap_simps)[1]
-         apply simp
-         apply (rule corres_guard_imp, rule delete_one_corres[unfolded dc_def])
-          apply (auto simp: cte_wp_at_caps_of_state is_cap_simps can_fast_finalise_def)[1]
-         apply (clarsimp simp: cte_wp_at_ctes_of)
-        apply (wp getCTE_wp' | simp add: getSlotCap_def)+
-     apply (wp | simp add: get_irq_slot_def getIRQSlot_def
-                           locateSlot_conv getInterruptState_def)+
-   apply (clarsimp simp: ex_cte_cap_wp_to_def interrupt_cap_null_or_ntfn)
-  apply (clarsimp simp: cte_wp_at_ctes_of)
-  done
-
-context begin interpretation Arch . (*FIXME: arch-split*)
-
-lemma arch_finaliseCap_corres:
+lemma arch_finaliseCap_corres[Finalise_R_3_assms]:
   "\<lbrakk> final_matters' (ArchObjectCap cap') \<Longrightarrow> final = final'; acap_relation cap cap' \<rbrakk>
      \<Longrightarrow> corres (\<lambda>r r'. cap_relation (fst r) (fst r') \<and> cap_relation (snd r) (snd r'))
            (\<lambda>s. invs s \<and> s \<turnstile> cap.ArchObjectCap cap
@@ -3435,7 +1243,7 @@ lemma arch_finaliseCap_corres:
            (arch_finalise_cap cap final) (Arch.finaliseCap cap' final')"
   apply (cases cap,
          simp_all add: arch_finalise_cap_def X64_H.finaliseCap_def
-                       final_matters'_def case_bool_If liftM_def[symmetric]
+                       final_matters'_def arch_final_matters'_def case_bool_If liftM_def[symmetric]
                        o_def dc_def[symmetric]
                 split: option.split,
          safe)
@@ -3463,328 +1271,14 @@ lemma arch_finaliseCap_corres:
    apply (auto simp: mask_def valid_cap_def)[2]
   done
 
+lemmas deleteCallerCap_typ_ats[wp] = typ_at_lifts[OF deleteCallerCap_typ_at']
 
-lemma unbindNotification_corres:
-  "corres dc
-      (invs and tcb_at t)
-      (invs' and tcb_at' t)
-      (unbind_notification t)
-      (unbindNotification t)"
-  supply option.case_cong_weak[cong]
-  apply (simp add: unbind_notification_def unbindNotification_def)
-  apply (rule corres_guard_imp)
-    apply (rule corres_split[OF getBoundNotification_corres])
-      apply (rule corres_option_split)
-        apply simp
-       apply (rule corres_return_trivial)
-      apply (rule corres_split[OF getNotification_corres])
-        apply clarsimp
-        apply (rule corres_split[OF setNotification_corres])
-           apply (clarsimp simp: ntfn_relation_def split:Structures_A.ntfn.splits)
-          apply (rule setBoundNotification_corres)
-         apply (wp gbn_wp' gbn_wp)+
-   apply (clarsimp elim!: obj_at_valid_objsE
-                   dest!: bound_tcb_at_state_refs_ofD invs_valid_objs
-                    simp: valid_obj_def is_tcb tcb_ntfn_is_bound_def
-                          valid_tcb_def valid_bound_ntfn_def invs_distinct invs_psp_aligned
-                   split: option.splits)
-  apply (clarsimp dest!: obj_at_valid_objs' bound_tcb_at_state_refs_ofD' invs_valid_objs'
-                   simp: projectKOs valid_obj'_def valid_tcb'_def valid_bound_ntfn'_def
-                         tcb_ntfn_is_bound'_def
-                  split: option.splits)
-  done
+end (* Arch *)
 
-lemma unbindMaybeNotification_corres:
-  "corres dc
-      (invs and ntfn_at ntfnptr) (invs' and ntfn_at' ntfnptr)
-      (unbind_maybe_notification ntfnptr)
-      (unbindMaybeNotification ntfnptr)"
-  apply (simp add: unbind_maybe_notification_def unbindMaybeNotification_def)
-  apply (rule corres_guard_imp)
-    apply (rule corres_split[OF getNotification_corres])
-      apply (rule corres_option_split)
-        apply (clarsimp simp: ntfn_relation_def split: Structures_A.ntfn.splits)
-       apply (rule corres_return_trivial)
-      apply simp
-      apply (rule corres_split[OF setNotification_corres])
-         apply (clarsimp simp: ntfn_relation_def split: Structures_A.ntfn.splits)
-        apply (rule setBoundNotification_corres)
-       apply (wp get_simple_ko_wp getNotification_wp)+
-   apply (clarsimp elim!: obj_at_valid_objsE
-                   dest!: bound_tcb_at_state_refs_ofD invs_valid_objs
-                    simp: valid_obj_def is_tcb tcb_ntfn_is_bound_def invs_psp_aligned
-                          valid_tcb_def valid_bound_ntfn_def valid_ntfn_def invs_distinct
-                   split: option.splits)
-  apply (clarsimp dest!: obj_at_valid_objs' bound_tcb_at_state_refs_ofD' invs_valid_objs'
-                   simp: projectKOs valid_obj'_def valid_tcb'_def valid_bound_ntfn'_def
-                         tcb_ntfn_is_bound'_def valid_ntfn'_def
-                  split: option.splits)
-  done
-
-lemma fast_finaliseCap_corres:
-  "\<lbrakk> final_matters' cap' \<longrightarrow> final = final'; cap_relation cap cap';
-     can_fast_finalise cap \<rbrakk>
-   \<Longrightarrow> corres dc
-           (\<lambda>s. invs s \<and> valid_sched s \<and> s \<turnstile> cap
-                       \<and> cte_wp_at ((=) cap) sl s)
-           (\<lambda>s. invs' s \<and> s \<turnstile>' cap')
-           (fast_finalise cap final)
-           (do
-               p \<leftarrow> finaliseCap cap' final' True;
-               assert (capRemovable (fst p) (cte_map ptr) \<and> snd p = NullCap)
-            od)"
-  apply (cases cap, simp_all add: finaliseCap_def isCap_simps
-                                  corres_liftM2_simp[unfolded liftM_def]
-                                  o_def dc_def[symmetric] when_def
-                                  can_fast_finalise_def capRemovable_def
-                       split del: if_split cong: if_cong)
-   apply (clarsimp simp: final_matters'_def)
-   apply (rule corres_guard_imp)
-     apply (rule corres_rel_imp)
-      apply (rule ep_cancel_corres)
-     apply simp
-    apply (simp add: valid_cap_def)
-   apply (simp add: valid_cap'_def)
-  apply (clarsimp simp: final_matters'_def)
-  apply (rule corres_guard_imp)
-    apply (rule corres_split[OF unbindMaybeNotification_corres])
-         apply (rule cancelAllSignals_corres)
-       apply (wp abs_typ_at_lifts unbind_maybe_notification_invs typ_at_lifts hoare_drop_imps getNotification_wp
-            | wpc)+
-   apply (clarsimp simp: valid_cap_def)
-  apply (clarsimp simp: valid_cap'_def projectKOs valid_obj'_def
-                 dest!: invs_valid_objs' obj_at_valid_objs' )
-  done
-
-lemma cap_delete_one_corres:
-  "corres dc (einvs and cte_wp_at can_fast_finalise ptr)
-        (invs' and cte_at' (cte_map ptr))
-        (cap_delete_one ptr) (cteDeleteOne (cte_map ptr))"
-  apply (simp add: cap_delete_one_def cteDeleteOne_def'
-                   unless_def when_def)
-  apply (rule corres_guard_imp)
-    apply (rule corres_split[OF get_cap_corres])
-      apply (rule_tac F="can_fast_finalise cap" in corres_gen_asm)
-      apply (rule corres_if)
-        apply fastforce
-       apply (rule corres_split[OF isFinalCapability_corres[where ptr=ptr]])
-         apply (simp add: split_def bind_assoc [THEN sym])
-         apply (rule corres_split[OF fast_finaliseCap_corres[where sl=ptr]])
-              apply simp+
-           apply (rule emptySlot_corres, simp)
-          apply (wp hoare_drop_imps)+
-       apply (wp isFinalCapability_inv | wp (once) isFinal[where x="cte_map ptr"])+
-      apply (rule corres_trivial, simp)
-     apply (wp get_cap_wp getCTE_wp)+
-   apply (clarsimp simp: cte_wp_at_caps_of_state can_fast_finalise_Null
-                  elim!: caps_of_state_valid_cap)
-  apply (clarsimp simp: cte_wp_at_ctes_of)
-  apply fastforce
-  done
-
-context
-notes option.case_cong_weak[cong]
-begin
-crunch ThreadDecls_H.suspend, unbindNotification
-  for no_0_obj'[wp]: no_0_obj'
-  (simp: crunch_simps wp: crunch_wps getCTE_no_0_obj'_helper)
-end
-
-end
-(* FIXME: strengthen locale instead *)
-
-global_interpretation delete_one
-  apply unfold_locales
-  apply (rule corres_guard_imp)
-    apply (rule cap_delete_one_corres)
-   apply auto
-  done
-
-lemma finaliseCap_corres:
-  "\<lbrakk> final_matters' cap' \<Longrightarrow> final = final'; cap_relation cap cap';
-          flag \<longrightarrow> can_fast_finalise cap \<rbrakk>
-     \<Longrightarrow> corres (\<lambda>x y. cap_relation (fst x) (fst y) \<and> cap_relation (snd x) (snd y))
-           (\<lambda>s. einvs s \<and> s \<turnstile> cap \<and> (final_matters cap \<longrightarrow> final = is_final_cap' cap s)
-                       \<and> cte_wp_at ((=) cap) sl s)
-           (\<lambda>s. invs' s \<and> s \<turnstile>' cap' \<and>
-                 (final_matters' cap' \<longrightarrow>
-                      final' = isFinal cap' (cte_map sl) (cteCaps_of s)))
-           (finalise_cap cap final) (finaliseCap cap' final' flag)"
-  supply invs_no_0_obj'[simp]
-  apply (cases cap, simp_all add: finaliseCap_def gen_isCap_simps
-                                  corres_liftM2_simp[unfolded liftM_def]
-                                  o_def dc_def[symmetric] when_def
-                                  can_fast_finalise_def
-                       split del: if_split cong: if_cong)
-        apply (clarsimp simp: final_matters'_def)
-        apply (rule corres_guard_imp)
-          apply (rule ep_cancel_corres)
-         apply (simp add: valid_cap_def)
-        apply (simp add: valid_cap'_def)
-       apply (clarsimp simp add: final_matters'_def)
-       apply (rule corres_guard_imp)
-         apply (rule corres_split[OF unbindMaybeNotification_corres])
-           apply (rule cancelAllSignals_corres)
-          apply (wp abs_typ_at_lifts unbind_maybe_notification_invs gen_typ_at_lifts hoare_drop_imps hoare_vcg_all_lift | wpc)+
-        apply (clarsimp simp: valid_cap_def)
-       apply (clarsimp simp: valid_cap'_def)
-      apply (fastforce simp: final_matters'_def shiftL_nat zbits_map_def)
-     apply (clarsimp simp add: final_matters'_def getThreadCSpaceRoot
-                               liftM_def[symmetric] o_def zbits_map_def
-                               dc_def[symmetric])
-     apply (rename_tac t)
-     apply (rule_tac P="\<lambda>s. t \<noteq> idle_thread s" and P'="\<lambda>s. t \<noteq> ksIdleThread s" in corres_add_guard)
-      apply clarsimp
-      apply (rule context_conjI)
-       apply (clarsimp dest!: no_idle_thread_cap)
-      apply (clarsimp simp: state_relation_def)
-     apply (rule corres_guard_imp)
-       apply (rule corres_split[OF unbindNotification_corres])
-         apply (rule corres_split[OF suspend_corres])
-           apply (clarsimp simp: liftM_def[symmetric] o_def dc_def[symmetric] zbits_map_def)
-           apply (rule X64.prepareThreadDelete_corres, simp) (* FIXME arch-split: interface *)
-          apply (wp unbind_notification_invs unbind_notification_simple_sched_action
-                    delete_one_conc_fr.suspend_objs')+
-      apply (simp add: valid_cap_def)
-     apply (simp add: valid_cap'_def)
-    apply (simp add: final_matters'_def liftM_def[symmetric]
-                     o_def dc_def[symmetric])
-    apply (intro impI, rule corres_guard_imp)
-      apply (rule deletingIRQHandler_corres)
-     apply simp
-    apply simp
-   apply (clarsimp simp: final_matters'_def)
-   apply (rule_tac F="False" in corres_req)
-    apply clarsimp
-    apply (frule zombies_finalD, (clarsimp simp: is_cap_simps)+)
-    apply (clarsimp simp: cte_wp_at_caps_of_state)
-   apply simp
-  apply (clarsimp split del: if_split simp: o_def)
-  apply (rule corres_guard_imp [OF arch_finaliseCap_corres], (fastforce simp: valid_sched_def)+)
-  done
-
-context begin interpretation Arch . (*FIXME: arch-split*)
-
-crunch copyGlobalMappings
-  for ifunsafe'[wp]: "if_unsafe_then_cap'"
-  and pred_tcb_at'[wp]: "pred_tcb_at' proj P t"
-  and vms'[wp]: "valid_machine_state'"
-  and ct_not_inQ[wp]: "ct_not_inQ"
-  and tcb_in_cur_domain'[wp]: "tcb_in_cur_domain' t"
-  and ct__in_cur_domain'[wp]: ct_idle_or_in_cur_domain'
-  (wp: crunch_wps ignore: storePDE)
-
-lemma threadSet_ct_idle_or_in_cur_domain':
-  "\<lbrace>ct_idle_or_in_cur_domain' and (\<lambda>s. \<forall>tcb. tcbDomain tcb = ksCurDomain s \<longrightarrow> tcbDomain (F tcb) = ksCurDomain s)\<rbrace>
-    threadSet F t
-   \<lbrace>\<lambda>_. ct_idle_or_in_cur_domain'\<rbrace>"
-apply (simp add: ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def)
-apply (wp hoare_vcg_disj_lift hoare_vcg_imp_lift)
-  apply wps
-  apply wp
- apply wps
- apply wp
-apply (auto simp: obj_at'_def)
-done
-
-lemma cte_wp_at_norm_eq':
-  "cte_wp_at' P p s = (\<exists>cte. cte_wp_at' ((=) cte) p s \<and> P cte)"
-  by (simp add: cte_wp_at_ctes_of)
-
-lemma isFinal_cte_wp_def:
-  "isFinal cap p (cteCaps_of s) =
-  (\<not>isUntypedCap cap \<and>
-   (\<forall>p'. p \<noteq> p' \<longrightarrow>
-         cte_at' p' s \<longrightarrow>
-         cte_wp_at' (\<lambda>cte'. \<not> isUntypedCap (cteCap cte') \<longrightarrow>
-                            \<not> sameObjectAs cap (cteCap cte')) p' s))"
-  apply (simp add: isFinal_def cte_wp_at_ctes_of cteCaps_of_def)
-  apply (rule iffI)
-   apply clarsimp
-   apply (case_tac cte)
-   apply fastforce
-  apply fastforce
-  done
-
-lemma valid_cte_at_neg_typ':
-  assumes T: "\<And>P T p. \<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace> f \<lbrace>\<lambda>_ s. P (typ_at' T p s)\<rbrace>"
-  shows "\<lbrace>\<lambda>s. \<not> cte_at' p' s\<rbrace> f \<lbrace>\<lambda>rv s. \<not> cte_at' p' s\<rbrace>"
-  apply (simp add: cte_at_typ')
-  apply (rule hoare_vcg_conj_lift [OF T])
-  apply (simp only: imp_conv_disj)
-  apply (rule hoare_vcg_all_lift)
-  apply (rule hoare_vcg_disj_lift [OF T])
-  apply (rule hoare_vcg_prop)
-  done
-
-lemma isFinal_lift:
-  assumes x: "\<And>P p. \<lbrace>cte_wp_at' P p\<rbrace> f \<lbrace>\<lambda>_. cte_wp_at' P p\<rbrace>"
-  assumes y: "\<And>P T p. \<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace> f \<lbrace>\<lambda>_ s. P (typ_at' T p s)\<rbrace>"
-  shows "\<lbrace>\<lambda>s. cte_wp_at' (\<lambda>cte. isFinal (cteCap cte) sl (cteCaps_of s)) sl s\<rbrace>
-         f
-         \<lbrace>\<lambda>r s. cte_wp_at' (\<lambda>cte. isFinal (cteCap cte) sl (cteCaps_of s)) sl s\<rbrace>"
-  apply (subst cte_wp_at_norm_eq')
-  apply (subst cte_wp_at_norm_eq' [where P="\<lambda>cte. isFinal (cteCap cte) sl m" for sl m])
-  apply (simp only: isFinal_cte_wp_def imp_conv_disj de_Morgan_conj)
-  apply (wp hoare_vcg_ex_lift hoare_vcg_all_lift x hoare_vcg_disj_lift
-            valid_cte_at_neg_typ' [OF y])
-  done
-
-lemmas cteCaps_of_ctes_of_lift = ctes_of_cteCaps_of_lift
-
-lemmas final_matters'_simps = final_matters'_def [split_simps capability.split arch_capability.split]
-
-crunch deleteCallerCap
-  for idle_thread[wp]: "\<lambda>s. P (ksIdleThread s)"
-  (wp: crunch_wps)
-crunch deleteCallerCap
-  for sch_act_simple: sch_act_simple
-  (wp: crunch_wps)
-crunch deleteCallerCap
-  for sch_act_not[wp]: "sch_act_not t"
-  (wp: crunch_wps)
-crunch deleteCallerCap
-  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  (wp: crunch_wps)
-lemmas deleteCallerCap_typ_ats[wp] = typ_at_lifts [OF deleteCallerCap_typ_at']
-
-lemma setEndpoint_sch_act_not_ct[wp]:
-  "\<lbrace>\<lambda>s. sch_act_not (ksCurThread s) s\<rbrace>
-   setEndpoint ptr val \<lbrace>\<lambda>_ s. sch_act_not (ksCurThread s) s\<rbrace>"
-  by (rule hoare_weaken_pre, wps, wp, simp)
-
-lemma sbn_ct_in_state'[wp]:
-  "\<lbrace>ct_in_state' P\<rbrace> setBoundNotification ntfn t \<lbrace>\<lambda>_. ct_in_state' P\<rbrace>"
-  apply (simp add: ct_in_state'_def)
-  apply (rule hoare_pre)
-   apply (wps setBoundNotification_ct')
-  apply (wp sbn_st_tcb', clarsimp)
-  done
-
-lemma set_ntfn_ct_in_state'[wp]:
-  "\<lbrace>ct_in_state' P\<rbrace> setNotification a ntfn \<lbrace>\<lambda>_. ct_in_state' P\<rbrace>"
-  apply (simp add: ct_in_state'_def)
-  apply (rule hoare_pre)
-   apply (wps setNotification_ksCurThread, wp, clarsimp)
-  done
-
-lemma unbindMaybeNotification_ct_in_state'[wp]:
-  "\<lbrace>ct_in_state' P\<rbrace> unbindMaybeNotification t \<lbrace>\<lambda>_. ct_in_state' P\<rbrace>"
-  apply (simp add: unbindMaybeNotification_def)
-  apply (wp | wpc | simp)+
-  done
-
-lemma setNotification_sch_act_sane:
-  "\<lbrace>sch_act_sane\<rbrace> setNotification a ntfn \<lbrace>\<lambda>_. sch_act_sane\<rbrace>"
-  by (wp sch_act_sane_lift)
-
-
-lemma unbindMaybeNotification_sch_act_sane[wp]:
-  "\<lbrace>sch_act_sane\<rbrace> unbindMaybeNotification t \<lbrace>\<lambda>_. sch_act_sane\<rbrace>"
-  apply (simp add: unbindMaybeNotification_def)
-  apply (wp setNotification_sch_act_sane sbn_sch_act_sane | wpc | clarsimp)+
-  done
-
-end
+interpretation Finalise_R_3?: Finalise_R_3 arch_final_matters' arch_cap_has_cleanup'
+proof goal_cases
+  interpret Arch  .
+  case 1 show ?case by (intro_locales; (unfold_locales; (fact Finalise_R_3_assms)?)?)
+qed
 
 end

--- a/proof/refine/X64/ArchFinalise_R.thy
+++ b/proof/refine/X64/ArchFinalise_R.thy
@@ -929,13 +929,9 @@ lemma archThreadSet_tcbSchedPrevNext[wp]:
   apply auto
   done
 
-context notes if_cong[cong] begin
-
 crunch asUser
   for tcbSchedPrevNext[wp]: "obj_at' (\<lambda>tcb. P (tcbSchedNext tcb) (tcbSchedPrev tcb)) t"
-  (wp: threadGet_wp)
-
-end
+  (wp: threadGet_wp cong: if_cong)
 
 crunch prepareThreadDelete
   for tcbSchedPrevNext[wp]: "obj_at' (\<lambda>tcb. P (tcbSchedNext tcb) (tcbSchedPrev tcb)) t"
@@ -1215,14 +1211,11 @@ crunch unmapPageTable
   (wp: crunch_wps getObject_inv hoare_vcg_all_lift hoare_vcg_if_lift3
    simp: loadObject_default_def updateObject_default_def)
 
-context notes if_cong[cong] begin
-
 crunch Arch_finaliseCap
   for nosch[wp]: "\<lambda>s. P (ksSchedulerAction s)"
   (wp: crunch_wps getObject_inv simp: loadObject_default_def updateObject_default_def
-   rule: X64_H.finaliseCap_def)
-
-end
+   rule: X64_H.finaliseCap_def
+   cong: if_cong)
 
 crunch deletingIRQHandler, finaliseCap
   for sch_act_simple[wp]: sch_act_simple

--- a/proof/refine/X64/ArchIpcCancel_R.thy
+++ b/proof/refine/X64/ArchIpcCancel_R.thy
@@ -72,7 +72,7 @@ lemma fpuRelease_corres[corres]:
    corres dc (pspace_aligned and pspace_distinct and valid_cur_fpu) \<top> (fpu_release t) (fpuRelease t')"
   by (corres simp: fpu_release_def fpuRelease_def)
 
-lemma prepareThreadDelete_corres[corres]:
+lemma prepareThreadDelete_corres[IpcCancel_R_assms, corres]:
   "t' = t \<Longrightarrow>
    corres dc (invs and tcb_at t) no_0_obj'
           (prepare_thread_delete t) (prepareThreadDelete t')"

--- a/proof/refine/X64/ArchMachine_R.thy
+++ b/proof/refine/X64/ArchMachine_R.thy
@@ -51,10 +51,8 @@ lemma dmo_maskInterrupt_True:
                    ct_not_inQ_def ct_idle_or_in_cur_domain'_def tcb_in_cur_domain'_def)
   done
 
-lemma setIRQState_irq_states':
-  "\<lbrace>valid_irq_states'\<rbrace>
-      setIRQState state irq
-   \<lbrace>\<lambda>rv. valid_irq_states'\<rbrace>"
+lemma setIRQState_irq_states'[Machine_R_assms, wp]:
+  "setIRQState state irq \<lbrace>valid_irq_states'\<rbrace>"
   apply (simp add: setIRQState_def setInterruptState_def getInterruptState_def)
   apply (wp dmo_maskInterrupt)
   apply (simp add: valid_irq_masks'_def)

--- a/proof/refine/X64/ArchTcbAcc_R.thy
+++ b/proof/refine/X64/ArchTcbAcc_R.thy
@@ -956,15 +956,7 @@ lemma setThreadState_state_hyp_refs_of'[TcbAcc_R_2_assms, wp]:
         | wp threadSet_state_hyp_refs_of')+
   done
 
-lemma setBoundNotification_state_refs_of'[wp]:
-  "\<lbrace>\<lambda>s. P ((state_refs_of' s) (t := tcb_bound_refs' ntfn
-                                 \<union> {r \<in> state_refs_of' s t. snd r \<noteq> TCBBound}))\<rbrace>
-     setBoundNotification ntfn t
-   \<lbrace>\<lambda>rv s. P (state_refs_of' s)\<rbrace>"
-  by (simp add: setBoundNotification_def Un_commute fun_upd_def
-        | wp threadSet_state_refs_of' )+
-
-lemma setBoundNotification_state_hyp_refs_of'[wp]:
+lemma setBoundNotification_state_hyp_refs_of'[TcbAcc_R_2_assms, wp]:
   "\<lbrace>\<lambda>s. P (state_hyp_refs_of' s)\<rbrace>
      setBoundNotification ntfn t
    \<lbrace>\<lambda>rv s. P (state_hyp_refs_of' s)\<rbrace>"
@@ -989,7 +981,7 @@ lemma tcbQueued_update_iflive'[TcbAcc_R_2_assms, wp]:
    \<lbrace>\<lambda>_. if_live_then_nonz_cap'\<rbrace>"
   by (wpsimp wp: threadSet_iflive'T simp: update_tcb_cte_cases)
 
-lemma sbn_iflive'[wp]:
+lemma sbn_iflive'[TcbAcc_R_2_assms, wp]:
   "\<lbrace>\<lambda>s. if_live_then_nonz_cap' s
       \<and> (bound ntfn \<longrightarrow> ex_nonz_cap_to' t s)\<rbrace>
    setBoundNotification ntfn t

--- a/proof/refine/X64/Arch_R.thy
+++ b/proof/refine/X64/Arch_R.thy
@@ -9,7 +9,7 @@
 *)
 
 theory Arch_R
-imports Untyped_R Finalise_R
+imports Untyped_R ArchFinalise_R
 begin
 
 unbundle l4v_word_context

--- a/proof/refine/X64/Arch_R.thy
+++ b/proof/refine/X64/Arch_R.thy
@@ -712,7 +712,7 @@ lemma decodeX64PageTableInvocation_corres:
                                  in corres_gen_asm2)
         apply (rule corres_split[OF isFinalCapability_corres[where ptr=slot]])
           apply (drule mp)
-           apply (clarsimp simp: isCap_simps final_matters'_def)
+           apply (clarsimp simp: isCap_simps final_matters'_def arch_final_matters'_def)
           apply (rule whenE_throwError_corres)
             apply simp
            apply simp
@@ -803,7 +803,7 @@ lemma decodeX64PageDirectoryInvocation_corres:
       in corres_gen_asm2)
         apply (rule corres_split[OF isFinalCapability_corres[where ptr=slot]])
           apply (drule mp)
-           apply (clarsimp simp: isCap_simps final_matters'_def)
+           apply (clarsimp simp: isCap_simps final_matters'_def arch_final_matters'_def)
           apply (rule whenE_throwError_corres)
             apply simp
            apply simp
@@ -883,7 +883,7 @@ lemma decodeX64PDPointerTableInvocation_corres:
                      in corres_gen_asm2)
         apply (rule corres_split[OF isFinalCapability_corres[where ptr=slot]])
           apply (drule mp)
-           apply (clarsimp simp: isCap_simps final_matters'_def)
+           apply (clarsimp simp: isCap_simps final_matters'_def arch_final_matters'_def)
           apply (rule whenE_throwError_corres)
             apply simp
            apply simp
@@ -1943,13 +1943,9 @@ crunch "Arch.finaliseCap"
   for aligned': pspace_aligned'
   (wp: crunch_wps getASID_wp simp: crunch_simps)
 
-lemmas arch_finalise_cap_aligned' = finaliseCap_aligned'
-
 crunch "Arch.finaliseCap"
   for distinct': pspace_distinct'
   (wp: crunch_wps getASID_wp simp: crunch_simps)
-
-lemmas arch_finalise_cap_distinct' = finaliseCap_distinct'
 
 crunch "Arch.finaliseCap"
   for nosch[wp]: "\<lambda>s. P (ksSchedulerAction s)"

--- a/proof/refine/X64/CNodeInv_R.thy
+++ b/proof/refine/X64/CNodeInv_R.thy
@@ -322,7 +322,7 @@ lemma decodeCNodeInvocation_corres:
                  apply (intro conjI)
                   apply (erule cap_map_update_data)+
                 apply (wp hoare_drop_imps)+
-          apply simp
+          apply (simp cong: if_cong)
           apply (wp lsfco_cte_at' lookup_cap_valid lookup_cap_valid')
          apply (simp add: if_apply_def2)
          apply (wp hoare_drop_imps)
@@ -6707,6 +6707,8 @@ lemma capSwap_rvk_prog:
   apply simp
   apply arith
   done
+
+lemmas ctes_of_cteCaps_of_lift = cteCaps_of_ctes_of_lift (* FIXME *)
 
 lemmas cancelAllIPC_cteCaps_of[wp] = ctes_of_cteCaps_of_lift [OF cancelAllIPC_ctes_of]
 lemmas cancelAllSignals_cteCaps_of[wp] = ctes_of_cteCaps_of_lift [OF cancelAllSignals_ctes_of]

--- a/proof/refine/X64/EmptyFail_H.thy
+++ b/proof/refine/X64/EmptyFail_H.thy
@@ -105,8 +105,7 @@ lemma ArchRetypeDecls_H_deriveCap_empty_fail[intro!, wp, simp]:
   "isPageTableCap y \<or> isPageDirectoryCap y \<or> isPageCap y \<or> isIOPortControlCap y
    \<or> isASIDControlCap y \<or> isASIDPoolCap y \<or> isPDPointerTableCap y \<or> isPML4Cap y \<or> isIOPortCap y
    \<Longrightarrow> empty_fail (Arch.deriveCap x y)"
-  apply (simp add: X64_H.deriveCap_def)
-  by auto
+  by (auto simp: X64_H.deriveCap_def cong: if_cong)
 
 crunch ensureNoChildren
   for (empty_fail) empty_fail[intro!, wp, simp]
@@ -270,6 +269,7 @@ crunch
 
 lemma ThreadDecls_H_schedule_empty_fail[intro!, wp, simp]:
   "empty_fail schedule"
+  supply if_cong[cong]
   apply (simp add: schedule_def)
   apply (clarsimp simp: scheduleChooseNewThread_def split: if_split | wp | wpc)+
   done

--- a/proof/refine/X64/Ipc_R.thy
+++ b/proof/refine/X64/Ipc_R.thy
@@ -636,6 +636,7 @@ lemma cteInsert_weak_cte_wp_at2:
     "\<lbrace>\<lambda>s. if p = dest then P cap else cte_wp_at' (\<lambda>c. P (cteCap c)) p s\<rbrace>
      cteInsert cap src dest
      \<lbrace>\<lambda>uu. cte_wp_at' (\<lambda>c. P (cteCap c)) p\<rbrace>"
+  supply if_cong[cong]
   apply (rule hoare_pre)
    apply (rule hoare_use_eq_irq_node' [OF cteInsert_ksInterruptState])
    apply (clarsimp simp:cteInsert_def)
@@ -1476,6 +1477,7 @@ lemma doNormalTransfer_corres:
    and case_option \<top> valid_ipc_buffer_ptr' recv_buf)
   (do_normal_transfer sender send_buf ep badge can_grant receiver recv_buf)
   (doNormalTransfer sender send_buf ep badge can_grant receiver recv_buf)"
+  supply if_cong[cong]
   apply (simp add: do_normal_transfer_def doNormalTransfer_def)
   apply (rule corres_guard_imp)
     apply (rule corres_split_mapr[OF getMessageInfo_corres])
@@ -2658,6 +2660,7 @@ lemma valid_sched_weak_strg:
 lemma sendSignal_corres:
   "corres dc (einvs and ntfn_at ep) (invs' and ntfn_at' ep)
              (send_signal ep bg) (sendSignal ep bg)"
+  supply if_cong[cong]
   apply (simp add: send_signal_def sendSignal_def Let_def)
   apply (rule corres_guard_imp)
     apply (rule corres_split[OF getNotification_corres,
@@ -3602,6 +3605,7 @@ lemma cteInsert_cap_to':
   "\<lbrace>ex_nonz_cap_to' p and cte_wp_at' (\<lambda>c. cteCap c = NullCap) dest\<rbrace>
      cteInsert cap src dest
    \<lbrace>\<lambda>rv. ex_nonz_cap_to' p\<rbrace>"
+  supply if_cong[cong]
   apply (simp add: cteInsert_def ex_nonz_cap_to'_def updateCap_def setUntypedCapAsFull_def)
   apply (wpsimp wp: updateMDB_weak_cte_wp_at setCTE_weak_cte_wp_at hoare_vcg_ex_lift
          | rule hoare_drop_imps
@@ -4068,6 +4072,7 @@ lemma si_invs'[wp]:
   sendIPC bl call ba cg cgr t ep
   \<lbrace>\<lambda>rv. invs'\<rbrace>"
   supply if_split[split del]
+  supply if_cong[cong]
   apply (simp add: sendIPC_def split del: if_split)
   apply (rule bind_wp [OF _ get_ep_sp'])
   apply (case_tac epa)

--- a/proof/refine/X64/Ipc_R.thy
+++ b/proof/refine/X64/Ipc_R.thy
@@ -5,7 +5,7 @@
  *)
 
 theory Ipc_R
-imports Finalise_R
+imports ArchFinalise_R
 begin
 
 context begin interpretation Arch . (*FIXME: arch-split*)

--- a/proof/refine/X64/Syscall_R.thy
+++ b/proof/refine/X64/Syscall_R.thy
@@ -671,6 +671,7 @@ lemma pinv_tcb'[wp]:
 
 lemma sts_cte_at[wp]:
   "\<lbrace>cte_at' p\<rbrace> setThreadState st t \<lbrace>\<lambda>rv. cte_at' p\<rbrace>"
+  supply if_cong[cong]
   apply (simp add: setThreadState_def)
   apply (wp|simp)+
   done
@@ -684,6 +685,7 @@ lemma sts_mcpriority_tcb_at'[wp]:
   "\<lbrace>mcpriority_tcb_at' P t\<rbrace>
     setThreadState st t'
    \<lbrace>\<lambda>_. mcpriority_tcb_at' P t\<rbrace>"
+  supply if_cong[cong]
   apply (cases "t = t'",
          simp_all add: setThreadState_def
                   split del: if_split)
@@ -757,6 +759,7 @@ lemma decodeDomainSetStart_inv_wf[wp]:
 lemma decodeDomainConfigure_inv_wf[wp]:
   "\<lbrace>\<top>\<rbrace> decodeDomainConfigure args excaps \<lbrace>valid_domain_inv'\<rbrace>, -"
   unfolding decodeDomainConfigure_def
+  supply if_cong[cong]
   apply (wpsimp simp: valid_domain_inv'_def split_del: if_split)
   apply (clarsimp simp: not_less not_le le_maxDomain_eq_less_numDomains unat_ucast)
   using numDomains_fits_domainBits

--- a/proof/refine/X64/Tcb_R.thy
+++ b/proof/refine/X64/Tcb_R.thy
@@ -199,13 +199,10 @@ lemma setupReplyMaster_weak_sch_act_wf[wp]:
   apply assumption
   done
 
-context notes if_cong[cong] begin
-
 crunch setup_reply_master
   for pspace_aligned[wp]: pspace_aligned
   and pspace_distinct[wp]: pspace_distinct
-
-end
+  (cong: if_cong)
 
 lemma restart_corres:
   "corres dc (einvs  and tcb_at t) (invs' and tcb_at' t and ex_nonz_cap_to' t)

--- a/proof/refine/X64/Tcb_R.thy
+++ b/proof/refine/X64/Tcb_R.thy
@@ -199,9 +199,13 @@ lemma setupReplyMaster_weak_sch_act_wf[wp]:
   apply assumption
   done
 
+context notes if_cong[cong] begin
+
 crunch setup_reply_master
   for pspace_aligned[wp]: pspace_aligned
   and pspace_distinct[wp]: pspace_distinct
+
+end
 
 lemma restart_corres:
   "corres dc (einvs  and tcb_at t) (invs' and tcb_at' t and ex_nonz_cap_to' t)
@@ -943,6 +947,7 @@ lemma checked_insert_tcb_invs'[wp]:
       (checkCapAt (ThreadCap target) slot'
        (assertDerived src_slot new_cap (cteInsert new_cap src_slot slot))) \<lbrace>\<lambda>rv. invs'\<rbrace>"
   supply o_apply[simp del]
+  supply if_cong[cong]
   apply (simp add: checkCapAt_def liftM_def assertDerived_def stateAssert_def)
   apply (wp getCTE_cteCap_wp cteInsert_invs)
   apply (clarsimp split: option.splits)


### PR DESCRIPTION
🦆🦆🦆 Apart from some locale fails/optimisations (for which I left comments), and an increasing tendency to try avoid interpreting Arch since it's so slow, nothing really novel. Instructions below to remind people of the flow of this.
Extra commit added for cleanup now possible thanks to `crunch cong:`

**Instructions:**

In real life, I did the usual addition of Finalise_R, hierarchy update, arch-split and then update. However, since the arch-split part first splits AARCH64, then takes the AARCH64 version of Finalise_R and only fixes what broke, we ended up with a small(er) diff there (again).

Please review commit-by commit with the following notes (some inconsistency with squash/wip/fake comments on the PR-only commits):
- `[squash] PR: copy AARCH64 version into ..._R` - same as last time: stop `..._R` looking like a wall of green (no need to review)
- `aarch64 refine: arch-split `..._R` - this is the main bulk of the arch-split, dealing with AARCH64, as well as updates
- `[squash] copy AARCH64 Arch..._R to other arches` - wipes the *body* (not the header!) of other arches' Arch..._R with a copy of the AARCH64 version with `AARCH64` appropriately substituted - (mostly pointless to review)
- `[squash][fake] refine: arch-split ..._R (other arches) - result of fixing up the ArchSchedule_R of other architectures - shows diff to AARCH64

Reminder: DO NOT MERGE squashed version if it still says `aarch64 refine: arch-split` or `AARCH64`

Stats: 86 files changed, 8107 insertions(+), 18227 deletions(-)
Total: 10120 lines removed