### PR TITLE
Add `ccorres_exec_l_pre` method

### DIFF
--- a/lib/Monads/nondet/Nondet_Lemmas.thy
+++ b/lib/Monads/nondet/Nondet_Lemmas.thy
@@ -182,6 +182,10 @@ lemma liftE_alternative:
   "liftE (a \<sqinter> b) = (liftE a \<sqinter> liftE b)"
   by (simp add: liftE_def alternative_bind)
 
+lemma K_bind_apply:
+  "K_bind a b = a"
+  by simp
+
 
 subsection \<open>Lifting and Alternative Basic Definitions\<close>
 

--- a/lib/clib/Corres_UL_C.thy
+++ b/lib/clib/Corres_UL_C.thy
@@ -1241,6 +1241,24 @@ lemma ccorres_symb_exec_l2:
   apply (fastforce simp: in_monad')
   done
 
+text \<open>
+  The following method is intended to be used on ccorres goals that have non-schematic guards,
+  consuming a line of the abstract function via a strongest postcondition rule, and adding
+  information directly to the abstract guard. The user may add their own strongest postcondition
+  rules to the ccorres_exec_l_pre argument of the method, and may add their own unfolding rules to
+  the unfold argument.\<close>
+
+named_theorems ccorres_exec_l_pre
+
+lemmas [ccorres_exec_l_pre] = assert_sp
+lemmas [ccorres_exec_l_pre] = stateAssert_sp
+lemmas [ccorres_exec_l_pre] = stateAssert_sp[unfolded HaskellLib_H.stateAssert_def]
+
+method ccorres_exec_l_pre uses unfold wp simp declares ccorres_exec_l_pre =
+  (simp only: unfold haskell_assert_def K_bind_apply fun_app_def)?,
+  (rule ccorres_exec_l_pre[THEN ccorres_symb_exec_l'[rotated 2]];
+   (solves \<open>wpsimp wp: wp simp: simp\<close>)?)
+
 lemma exec_handlers_SkipD:
   "\<Gamma>\<turnstile>\<^sub>h \<langle>SKIP # hs, s\<rangle> \<Rightarrow> (n, s') \<Longrightarrow> s' = Normal s \<and> n = length hs"
   apply (erule exec_handlers.cases)

--- a/proof/crefine/RISCV64/Finalise_C.thy
+++ b/proof/crefine/RISCV64/Finalise_C.thy
@@ -80,9 +80,7 @@ lemma refill_ready_ccorres:
   supply sched_context_C_size[simp del] refill_C_size[simp del]
   unfolding refillReady_def readRefillReady_def gets_the_obind ohaskell_state_assert_def
             gets_the_ostate_assert
-  apply (rule ccorres_symb_exec_l'
-               [OF _ _ stateAssert_sp[simplified HaskellLib_H.stateAssert_def]];
-         (solves wpsimp)?)+
+  apply ccorres_exec_l_pre+
   apply (cinit' lift: sc_'
                 simp: readCurTime_def gets_the_ogets getRefillHead_def[symmetric]
                       getCurTime_def[symmetric])
@@ -121,9 +119,7 @@ lemma refill_next_ccorres:
   supply len_bit0[simp del]
   unfolding getRefillNext_def readRefillNext_def gets_the_obind ohaskell_state_assert_def
             gets_the_ostate_assert
-  apply (rule ccorres_symb_exec_l'
-               [OF _ _ stateAssert_sp[simplified HaskellLib_H.stateAssert_def]];
-         (solves wpsimp)?)+
+  apply ccorres_exec_l_pre+
   apply (cinit' lift: sc_' index_'
                 simp: refillNext_def readSchedContext_def getObject_def[symmetric]
                       getSchedContext_def[symmetric])
@@ -157,8 +153,8 @@ lemma refill_pop_head_ccorres:
      no_0_obj' \<lbrace>\<acute>sc = Ptr scPtr\<rbrace> []
      (refillPopHead scPtr) (Call refill_pop_head_'proc)"
   supply sched_context_C_size[simp del] refill_C_size[simp del]
-  unfolding refillPopHead_def K_bind_apply
-  apply (rule ccorres_symb_exec_l'[OF _ _ stateAssert_sp]; (solves wpsimp)?)+
+  unfolding refillPopHead_def
+  apply ccorres_exec_l_pre+
   apply (cinit' lift: sc_')
    apply (rule ccorres_symb_exec_r)
      apply (rule_tac xf'="\<lambda>s. h_val (hrs_mem (t_hrs_' (globals s))) (ret__ptr_to_struct_refill_C_' s)"
@@ -790,8 +786,7 @@ lemma cancelAllIPC_ccorres:
   "ccorres dc xfdc invs' \<lbrace>\<acute>epptr = ep_Ptr epptr\<rbrace> hs
      (cancelAllIPC epptr) (Call cancelAllIPC_'proc)"
   unfolding cancelAllIPC_def K_bind_apply haskell_assert_def
-  apply (rule ccorres_symb_exec_l'[OF _ _ stateAssert_sp]; (solves wpsimp)?)+
-  apply (rule ccorres_symb_exec_l'[OF _ _ get_ep_sp']; (solves wpsimp)?)
+  apply (ccorres_exec_l_pre ccorres_exec_l_pre: get_ep_sp')+
   apply (rename_tac ep)
   apply (subst endpoint_IdleEPState_split)
   apply (cinit' lift: epptr_')
@@ -864,7 +859,7 @@ lemma cancelAllIPC_ccorres:
                             and P'="\<lbrace>thread = tcb_ptr_to_ctcb_ptr t\<rbrace>"
                              in ccorres_split_nothrow)
                     apply (rule ccorres_add_return2)
-                    apply (rule ccorres_symb_exec_l'[OF _ _ threadGet_sp]; (solves wpsimp)?)
+                    apply (ccorres_exec_l_pre ccorres_exec_l_pre: threadGet_sp)
                     apply (rule ccorres_from_vcg)
                     apply (rule allI, rule conseqPre, vcg)
                     apply (clarsimp simp: return_def)
@@ -1023,9 +1018,8 @@ lemma cancelAllSignals_ccorres:
   "ccorres dc xfdc
      invs' \<lbrace>\<acute>ntfnPtr = ntfn_Ptr ntfnPtr\<rbrace> hs
      (cancelAllSignals ntfnPtr) (Call cancelAllSignals_'proc)"
-  unfolding cancelAllSignals_def K_bind_apply haskell_assert_def
-  apply (rule ccorres_symb_exec_l'[OF _ _ stateAssert_sp]; (solves wpsimp)?)+
-  apply (rule ccorres_symb_exec_l'[OF _ _ get_ntfn_sp']; (solves wpsimp)?)
+  unfolding cancelAllSignals_def
+  apply (ccorres_exec_l_pre ccorres_exec_l_pre: get_ntfn_sp')+
   apply (rename_tac ntfn)
   apply (subst ntfn_Waiting_split)
   apply (cinit' lift: ntfnPtr_')
@@ -1099,7 +1093,7 @@ lemma cancelAllSignals_ccorres:
                              and P'="{s'. thread = tcb_ptr_to_ctcb_ptr t}"
                               in ccorres_split_nothrow)
                      apply (rule ccorres_add_return2)
-                     apply (rule ccorres_symb_exec_l'[OF _ _ threadGet_sp]; (solves wpsimp)?)
+                     apply (ccorres_exec_l_pre ccorres_exec_l_pre: threadGet_sp)
                      apply (rule ccorres_from_vcg)
                      apply (rule allI, rule conseqPre, vcg)
                      apply (clarsimp simp: return_def)
@@ -1251,8 +1245,8 @@ lemma schedContext_cancelYieldTo_ccorres:
      (tcb_at' tptr and no_0_obj')
      \<lbrace>\<acute>tcb = tcb_ptr_to_ctcb_ptr tptr\<rbrace> []
      (schedContextCancelYieldTo tptr) (Call schedContext_cancelYieldTo_'proc)"
-  unfolding schedContextCancelYieldTo_def K_bind_apply
-  apply (rule ccorres_symb_exec_l'[OF _ _ stateAssert_sp]; (solves wpsimp)?)
+  unfolding schedContextCancelYieldTo_def
+  apply ccorres_exec_l_pre
   apply (cinit' lift: tcb_')
    apply csymbr
    apply simp
@@ -1448,7 +1442,7 @@ lemma unbindNotification_ccorres:
     invs' \<lbrace>\<acute>tcb = tcb_ptr_to_ctcb_ptr tcbPtr\<rbrace> hs
     (unbindNotification tcbPtr) (Call unbindNotification_'proc)"
   unfolding unbindNotification_def getBoundNotification_def
-  apply (rule ccorres_symb_exec_l'[OF _ _ threadGet_sp]; (solves wpsimp)?)
+  apply (ccorres_exec_l_pre ccorres_exec_l_pre: threadGet_sp)
   apply (rename_tac ntfnPtrOpt)
   apply (subst case_option_If2)
   apply (cinit' lift: tcb_')
@@ -2489,8 +2483,7 @@ lemma cteDeleteOne_ccorres:
     \<inter> {s. slot_' s = Ptr slot}) []
    (cteDeleteOne slot) (Call cteDeleteOne_'proc)"
   unfolding cteDeleteOne_def
-  apply (rule ccorres_symb_exec_l'
-                [OF _ getCTE_inv getCTE_sp empty_fail_getCTE])
+  apply (ccorres_exec_l_pre ccorres_exec_l_pre: getCTE_sp)
   apply (cinit' lift: slot_' cong: call_ignore_cong)
    apply (rule ccorres_move_c_guard_cte)
    apply csymbr

--- a/proof/crefine/RISCV64/IpcCancel_C.thy
+++ b/proof/crefine/RISCV64/IpcCancel_C.thy
@@ -522,7 +522,7 @@ lemma tcb_queue_prepend_ccorres:
      (tcbQueuePrepend queue tcbPtr) (Call tcb_queue_prepend_'proc)"
   supply if_split[split del]
   unfolding tcbQueuePrepend_def
-  apply (rule ccorres_symb_exec_l'[OF _ _ stateAssert_sp]; (solves wpsimp)?)
+  apply ccorres_exec_l_pre
   apply (cinit lift: tcb_')
    \<comment> \<open>cinit is not able to lift queue_' because queue_' is later modified in the C program\<close>
    apply (rule_tac xf'=queue_' in ccorres_abstract, ceqv, rename_tac cqueue)
@@ -607,7 +607,7 @@ lemma tcb_queue_append_ccorres:
      (tcbQueueAppend queue tcbPtr) (Call tcb_queue_append_'proc)"
   supply if_split[split del]
   unfolding tcbQueueAppend_def
-  apply (rule ccorres_symb_exec_l'[OF _ _ stateAssert_sp]; (solves wpsimp)?)
+  apply ccorres_exec_l_pre
   apply (cinit lift: tcb_')
    \<comment> \<open>cinit is not able to lift queue_' because queue_' is later modified in the C program\<close>
    apply (rule_tac xf'=queue_' in ccorres_abstract, ceqv, rename_tac cqueue)
@@ -740,8 +740,8 @@ proof -
   note word_less_1[simp del]
 
   show ?thesis
-    unfolding tcbSchedEnqueue_def K_bind_apply
-    apply (rule ccorres_symb_exec_l'[OF _ _ stateAssert_sp]; (solves wpsimp)?)+
+    unfolding tcbSchedEnqueue_def
+    apply ccorres_exec_l_pre+
     apply (cinit' lift: tcb_')
      apply (rule ccorres_symb_exec_l)
         apply (rule ccorres_assert)
@@ -877,7 +877,7 @@ proof -
 
   show ?thesis
     unfolding tcbSchedAppend_def K_bind_apply
-    apply (rule ccorres_symb_exec_l'[OF _ _ stateAssert_sp]; (solves wpsimp)?)+
+    apply ccorres_exec_l_pre+
     apply (cinit' lift: tcb_')
      apply (rule ccorres_symb_exec_l)
         apply (rule ccorres_assert)
@@ -1114,8 +1114,8 @@ lemma tcb_queue_remove_ccorres:
      (tcbQueueRemove queue tcbPtr) (Call tcb_queue_remove_'proc)"
   (is "ccorres _ _ ?abs _ _ _ _")
   supply if_split[split del] return_bind[simp del]
-  unfolding tcbQueueRemove_def K_bind_apply
-  apply (rule ccorres_symb_exec_l'[OF _ _ stateAssert_sp]; (solves wpsimp)?)+
+  unfolding tcbQueueRemove_def
+  apply ccorres_exec_l_pre+
   apply (cinit' lift: tcb_')
    apply (rename_tac tcb')
     \<comment> \<open>cinit is not able to lift queue_' because queue_' is later modified in the C program\<close>
@@ -1436,8 +1436,8 @@ proof -
   note word_less_1[simp del]
 
   show ?thesis
-    unfolding tcbSchedDequeue_def K_bind_apply
-    apply (rule ccorres_symb_exec_l'[OF _ _ stateAssert_sp]; (solves wpsimp)?)+
+    unfolding tcbSchedDequeue_def
+    apply ccorres_exec_l_pre+
     apply (cinit' lift: tcb_')
      apply (rule_tac r'="\<lambda>rv rv'. rv = to_bool rv'" and xf'="ret__unsigned_longlong_'"
                   in ccorres_split_nothrow)
@@ -2351,8 +2351,8 @@ lemma tcbNTFNDequeue_ccorres[corres]:
      (\<lbrace>\<acute>thread = tcb_ptr_to_ctcb_ptr thread\<rbrace> \<inter> \<lbrace>\<acute>ntfnPtr = ntfn_Ptr ntfnPtr\<rbrace>) hs
      (tcbNTFNDequeue thread ntfnPtr) (Call tcbNTFNDequeue_'proc)"
   supply if_split[split del]
-  unfolding tcbNTFNDequeue_def haskell_assert_def K_bind_apply fun_app_def
-  apply (rule ccorres_symb_exec_l'[OF _ _ get_ntfn_sp']; (solves wpsimp)?)
+  unfolding tcbNTFNDequeue_def
+  apply (ccorres_exec_l_pre ccorres_exec_l_pre: get_ntfn_sp')
   apply (rename_tac notification)
   apply (cinit' lift: thread_' ntfnPtr_')
    apply (rule_tac xf'=queue_'
@@ -3407,8 +3407,9 @@ lemma tcbEPDequeue_ccorres[corres]:
      (\<lbrace>\<acute>thread = tcb_ptr_to_ctcb_ptr thread\<rbrace> \<inter> \<lbrace>\<acute>epptr = ep_Ptr epPtr\<rbrace>) hs
      (tcbEPDequeue thread epPtr) (Call tcbEPDequeue_'proc)"
   supply if_split[split del]
-  unfolding tcbEPDequeue_def haskell_assert_def K_bind_apply fun_app_def
-  apply (rule ccorres_symb_exec_l'[OF _ _ get_ep_sp']; (solves \<open>wpsimp wp: empty_fail_getEndpoint\<close>)?)
+  unfolding tcbEPDequeue_def
+  apply (ccorres_exec_l_pre ccorres_exec_l_pre: get_ep_sp'
+                                            wp: empty_fail_getEndpoint)
   apply (rename_tac endpoint)
   apply (cinit' lift: thread_' epptr_')
    apply (rule_tac xf'=queue_'

--- a/proof/crefine/RISCV64/Ipc_C.thy
+++ b/proof/crefine/RISCV64/Ipc_C.thy
@@ -4654,11 +4654,8 @@ lemma tcbReadyTime_ccorres:
   unfolding readTCBReadyTime_def readReadyTime_def gets_the_ohaskell_assert
             gets_the_obind threadGet_def[symmetric]
             getRefillHead_def[symmetric]
-  apply (rule ccorres_symb_exec_l'[OF _ _ threadGet_sp]; (solves wpsimp)?)
-  apply (rule ccorres_symb_exec_l'[OF _ _ assert_sp]; (solves wpsimp)?)
-  unfolding  Nondet_Reader_Option.gets_the_return return_bind fun_app_def scActive_def[symmetric]
-  apply (rule ccorres_symb_exec_l'[OF _ _ scActive_sp]; (solves wpsimp)?)
-  apply (rule ccorres_symb_exec_l'[OF _ _ assert_sp]; (solves wpsimp)?)
+            Nondet_Reader_Option.gets_the_return return_bind fun_app_def scActive_def[symmetric]
+  apply (ccorres_exec_l_pre ccorres_exec_l_pre: threadGet_sp scActive_sp)+
   apply (cinit' lift: tcb_')
    apply (rule ccorres_move_c_guard_tcb)
    apply (rule_tac xf'="\<lambda>s. h_val (hrs_mem (t_hrs_' (globals s))) (ret__ptr_to_struct_refill_C_' s)"
@@ -4963,13 +4960,8 @@ lemma tcbReleaseEnqueue_ccorres:
      (no_0_obj' and pspace_aligned' and pspace_distinct' and pspace_bounded')
      \<lbrace>\<acute>tcb = tcb_ptr_to_ctcb_ptr tcbPtr\<rbrace> hs
      (tcbReleaseEnqueue tcbPtr) (Call tcbReleaseEnqueue_'proc)"
-  unfolding tcbReleaseEnqueue_def K_bind_apply haskell_assert_def
-  apply (rule ccorres_symb_exec_l'[OF _ _ stateAssert_sp]; (solves wpsimp)?)+
-  apply (rule ccorres_symb_exec_l'[OF _ _ isRunnable_sp]; (solves wpsimp)?)
-  apply (rule ccorres_symb_exec_l'[OF _ _ assert_sp]; (solves wpsimp)?)
-  apply (rule ccorres_symb_exec_l'[OF _ _ get_tcb_sp']; (solves wpsimp)?)
-  apply (rule ccorres_symb_exec_l'[OF _ _ assert_sp]; (solves wpsimp)?)
-  apply (rule ccorres_symb_exec_l'[OF _ _ getReleaseQueue_sp]; (solves wpsimp)?)
+  unfolding tcbReleaseEnqueue_def
+  apply (ccorres_exec_l_pre ccorres_exec_l_pre: isRunnable_sp get_tcb_sp' getReleaseQueue_sp)+
   apply (rename_tac queue)
   apply (cinit' lift: tcb_' simp: orderedInsert_def)
    apply (rule_tac xf'=queue_'
@@ -5678,12 +5670,10 @@ lemma tcbAppend_ccorres[corres]:
      (valid_objs' and pspace_canonical' and tcb_at' tcbPtr)
      (\<lbrace>\<acute>tcb = tcb_ptr_to_ctcb_ptr tcbPtr\<rbrace> \<inter> \<lbrace>ctcb_queue_relation q \<acute>queue\<rbrace>) hs
      (tcbAppend tcbPtr q) (Call tcbAppend_'proc)"
+  unfolding tcbAppend_def orderedInsert_def
   supply Collect_const[simp del]
-  unfolding tcbAppend_def orderedInsert_def K_bind_apply
-  apply (rule ccorres_symb_exec_l'[OF _ _ stateAssert_sp]; (solves wpsimp)?)+
-  apply (rule ccorres_symb_exec_l'[OF _ _ gets_the_sp]; (solves wpsimp)?)
+  apply (ccorres_exec_l_pre ccorres_exec_l_pre: gets_the_sp)+
   apply (rename_tac val)
-  apply (subst bind_dummy_ret_val)+
   apply (cinit' lift: tcb_' queue_')
    apply (rule ccorres_move_c_guard_tcb)
    apply (rule_tac xf'=priority_'
@@ -5844,12 +5834,11 @@ lemma tcbEPAppend_ccorres[corres]:
      (\<lbrace>\<acute>thread = tcb_ptr_to_ctcb_ptr thread\<rbrace> \<inter> \<lbrace>\<acute>epptr = ep_Ptr epPtr\<rbrace>
       \<inter> \<lbrace>cendpoint_state_relation state \<acute>ep_state\<rbrace>) hs
      (tcbEPAppend thread epPtr state) (Call tcbEPAppend_'proc)"
-  unfolding tcbEPAppend_def haskell_assert_def K_bind_apply fun_app_def
-  apply (rule ccorres_symb_exec_l'[OF _ _ stateAssert_sp]; (solves wpsimp)?)
-  apply (rule ccorres_symb_exec_l'[OF _ _ get_ep_sp']; (solves wpsimp)?)
-  apply (rename_tac endpoint)
+  unfolding tcbEPAppend_def
+  apply (ccorres_exec_l_pre ccorres_exec_l_pre: get_ep_sp')+
   apply (cinit' lift: thread_' epptr_' ep_state_')
    apply clarsimp
+   apply (rename_tac endpoint ep_state)
    apply (rule_tac xf'=queue_'
                and val="tcb_queue_to_tcb_queue_C (epQueue endpoint)"
                and R="ko_at' endpoint epPtr and valid_objs'"
@@ -5861,7 +5850,6 @@ lemma tcbEPAppend_ccorres[corres]:
                         simp: cendpoint_relation_def ctcb_queue_relation_def
                               tcb_queue_to_tcb_queue_C_def typ_heap_simps)
      apply ceqv
-    apply (rule ccorres_stateAssert)
     apply (ctac add: tcbAppend_ccorres)
       apply (rename_tac q' new_queue)
       apply (rule ccorres_split_nothrow[where r'=dc and xf'=xfdc])
@@ -6832,11 +6820,10 @@ lemma maybeReturnSchedContext_ccorres:
      (\<lbrace>\<acute>ntfnPtr = Ptr ntfnPtr\<rbrace> \<inter> \<lbrace>\<acute>tcb = tcb_ptr_to_ctcb_ptr tcbPtr\<rbrace>) hs
      (maybeReturnSc ntfnPtr tcbPtr) (Call maybeReturnSchedContext_'proc)"
   supply Collect_const[simp del]
-  unfolding maybeReturnSc_def K_bind_apply liftM_def nested_bind fun_app_def
-  apply (rule ccorres_symb_exec_l'[rotated, OF _ stateAssert_sp]; (solves wpsimp)?)
-  apply (rule ccorres_symb_exec_l'[rotated, OF _ get_ntfn_sp']; (solves wpsimp)?)
-  apply (rename_tac ntfn)
-  apply (rule ccorres_symb_exec_l'[rotated, OF _ threadGet_sp]; (solves wpsimp)?)
+  unfolding maybeReturnSc_def
+  apply (ccorres_exec_l_pre unfold: liftM_def nested_bind
+                            ccorres_exec_l_pre: get_ntfn_sp' threadGet_sp)+
+  apply (rename_tac ntfn tscOpt)
   apply (cinit' lift: ntfnPtr_' tcb_')
    apply (rule ccorres_rhs_assoc2)
    apply (rule_tac xf'=sc_'
@@ -7628,9 +7615,8 @@ lemma sendSignal_ccorres[corres]:
      (\<lbrace>\<acute>ntfnPtr = Ptr ntfnPtr\<rbrace> \<inter> \<lbrace>\<acute>badge___unsigned_long = badge\<rbrace>) hs
      (sendSignal ntfnPtr badge) (Call sendSignal_'proc)"
   supply Collect_const[simp del]
-  unfolding sendSignal_def K_bind_apply haskell_assert_def
-  apply (rule ccorres_symb_exec_l'[OF _ _ stateAssert_sp]; (solves wpsimp)?)
-  apply (rule ccorres_symb_exec_l'[OF _ _ get_ntfn_sp']; (solves wpsimp)?)
+  unfolding sendSignal_def
+  apply (ccorres_exec_l_pre ccorres_exec_l_pre: get_ntfn_sp')+
   apply (rename_tac ntfn)
   apply (cinit' lift: ntfnPtr_' badge___unsigned_long_')
    apply (rule_tac xf'=ret__unsigned_longlong_'
@@ -7976,11 +7962,11 @@ lemma tcbNTFNAppend_ccorres[corres]:
      (valid_objs' and pspace_canonical' and tcb_at' thread)
      (\<lbrace>\<acute>thread = tcb_ptr_to_ctcb_ptr thread\<rbrace> \<inter> \<lbrace>\<acute>ntfnPtr = ntfn_Ptr ntfnPtr\<rbrace>) hs
      (tcbNTFNAppend thread ntfnPtr) (Call tcbNTFNAppend_'proc)"
-  unfolding tcbNTFNAppend_def haskell_assert_def K_bind_apply fun_app_def
-  apply (rule ccorres_symb_exec_l'[OF _ _ get_ntfn_sp']; (solves wpsimp)?)
-  apply (rename_tac ntfn)
+  unfolding tcbNTFNAppend_def
+  apply (ccorres_exec_l_pre ccorres_exec_l_pre: get_ntfn_sp')+
   apply (cinit' lift: thread_' ntfnPtr_')
    apply clarsimp
+   apply (rename_tac ntfn)
    apply (rule_tac xf'=queue_'
                and val="tcb_queue_to_tcb_queue_C (ntfnQueue ntfn)"
                and R="ko_at' ntfn ntfnPtr and valid_objs'"
@@ -7992,7 +7978,6 @@ lemma tcbNTFNAppend_ccorres[corres]:
                         simp: cnotification_relation_def Let_def ctcb_queue_relation_def
                               tcb_queue_to_tcb_queue_C_def typ_heap_simps)
      apply ceqv
-    apply (rule ccorres_stateAssert)
     apply (ctac add: tcbAppend_ccorres)
       apply (rename_tac q' new_queue)
             apply (rule_tac P'="\<lambda>s. ntfn_at' ntfnPtr s \<and> pspace_canonical' s
@@ -8046,11 +8031,7 @@ lemma receiveSignal_ccorres[corres]:
   unfolding receiveSignal_def K_bind_def haskell_assert_def return_bind
   supply Collect_const[simp del]
   apply (rule ccorres_grab_asm)
-  apply (rule ccorres_symb_exec_l'[OF _ _ stateAssert_sp]; (solves wpsimp)?)+
-  apply (rule ccorres_symb_exec_l'[OF _ _ isRunnable_sp]; (solves wpsimp)?)
-  apply (rule ccorres_symb_exec_l'[OF _ _ assert_sp]; (solves wpsimp)?)
-  apply (rule ccorres_symb_exec_l'[OF _ _ stateAssert_sp]; (solves wpsimp)?)+
-  apply (rule ccorres_symb_exec_l'[OF _ _ get_ntfn_sp']; (solves wpsimp)?)
+  apply (ccorres_exec_l_pre ccorres_exec_l_pre: isRunnable_sp get_ntfn_sp')+
   apply (cinit' lift: thread_' cap_' isBlocking_')
    apply (subst ntfn_Active_split)
    apply (subst if_swap)

--- a/proof/crefine/RISCV64/Recycle_C.thy
+++ b/proof/crefine/RISCV64/Recycle_C.thy
@@ -788,9 +788,8 @@ lemma cancelBadgedSends_ccorres:
   "ccorres dc xfdc
      invs' (\<lbrace>\<acute>epptr = ep_Ptr epptr\<rbrace> \<inter> \<lbrace>\<acute>badge___unsigned_long = badge\<rbrace>) hs
      (cancelBadgedSends epptr badge) (Call cancelBadgedSends_'proc)"
-  unfolding cancelBadgedSends_def K_bind_apply haskell_assert_def
-  apply (rule ccorres_symb_exec_l'[OF _ _ stateAssert_sp]; (solves wpsimp)?)+
-  apply (rule ccorres_symb_exec_l'[OF _ _ get_ep_sp']; (solves wpsimp)?)
+  unfolding cancelBadgedSends_def
+  apply (ccorres_exec_l_pre ccorres_exec_l_pre: get_ep_sp')+
   apply (rename_tac ep)
   apply (cinit' lift: epptr_' badge___unsigned_long_')
    apply (rule_tac xf'=ret__unsigned_longlong_'
@@ -862,7 +861,7 @@ lemma cancelBadgedSends_ccorres:
                              and P'="{s'. thread = tcb_ptr_to_ctcb_ptr t}"
                               in ccorres_split_nothrow)
                      apply (rule ccorres_add_return2)
-                     apply (rule ccorres_symb_exec_l'[OF _ _ threadGet_sp]; (solves wpsimp)?)
+                     apply (ccorres_exec_l_pre ccorres_exec_l_pre: threadGet_sp)
                      apply (rule ccorres_from_vcg)
                      apply (rule allI, rule conseqPre, vcg)
                      apply (clarsimp simp: return_def)

--- a/proof/crefine/RISCV64/Schedule_C.thy
+++ b/proof/crefine/RISCV64/Schedule_C.thy
@@ -108,8 +108,8 @@ lemma switchToThread_ccorres:
            hs
            (switchToThread t)
            (Call switchToThread_'proc)"
-  apply (clarsimp simp: switchToThread_def)
-  apply (rule ccorres_symb_exec_l'[OF _ _ isRunnable_sp]; wpsimp)
+  unfolding switchToThread_def
+  apply (ccorres_exec_l_pre ccorres_exec_l_pre: isRunnable_sp)
   apply (cinit' lift: thread_')
    apply (rule ccorres_assert2)
    apply (rule ccorres_stateAssert)+
@@ -130,10 +130,8 @@ lemma activateThread_ccorres:
   "ccorres dc xfdc
      (invs' and (\<lambda>s. weak_sch_act_wf (ksSchedulerAction s) s)) UNIV hs
      activateThread (Call activateThread_'proc)"
-  unfolding activateThread_def K_bind_apply
-  apply (rule ccorres_symb_exec_l'[OF _ _ stateAssert_sp]; (solves wpsimp)?)
-  apply (rule ccorres_symb_exec_l'[OF _ _ getCurThread_sp]; (solves wpsimp)?)
-  apply (rule ccorres_symb_exec_l'[OF _ _ threadGet_sp]; (solves wpsimp)?)
+  unfolding activateThread_def
+  apply (ccorres_exec_l_pre ccorres_exec_l_pre: getCurThread_sp threadGet_sp)+
   apply cinit'
    apply (rule_tac P="\<lambda>s. ksCurThread s = thread" in ccorres_cross_over_guard)
    apply (rule ccorres_abstract_ksCurThread, ceqv)
@@ -714,11 +712,8 @@ lemma refill_add_tail_ccorres:
      (refillAddTail scPtr new) (Call refill_add_tail_'proc)"
   supply sched_context_C_size[simp del] refill_C_size[simp del] len_bit0[simp del]
 
-  unfolding refillAddTail_def K_bind_apply haskell_assert_def
-  apply (rule ccorres_symb_exec_l'[rotated, OF _ stateAssert_sp]; (solves wpsimp)?)
-  apply (rule ccorres_symb_exec_l'[rotated, OF _ getRefillSize_sp]; (solves wpsimp)?)
-  apply (rule ccorres_symb_exec_l'[rotated, OF _ get_sc_sp']; (solves wpsimp)?)
-  apply (rule ccorres_symb_exec_l'[rotated, OF _ assert_sp]; (solves wpsimp)?)
+  unfolding refillAddTail_def
+  apply (ccorres_exec_l_pre ccorres_exec_l_pre: getRefillSize_sp get_sc_sp')+
 
   apply (cinit' lift: sc_' refill_' simp: updateRefillIndex_def)
    apply (rule ccorres_move_c_guard_sc)
@@ -792,9 +787,8 @@ lemma schedule_used_ccorres:
      (scheduleUsed scPtr new) (Call schedule_used_'proc)"
   (is "ccorres _ _ ?abs _ _ _ _")
   supply sched_context_C_size[simp del] refill_C_size[simp del]
-  unfolding scheduleUsed_def haskell_assert_def
-  apply (rule ccorres_symb_exec_l'[OF _ _ scActive_sp]; (solves wpsimp)?)
-  apply (rule ccorres_symb_exec_l'[OF _ _ assert_sp]; (solves wpsimp)?)
+  unfolding scheduleUsed_def
+  apply (ccorres_exec_l_pre ccorres_exec_l_pre: scActive_sp)+
   apply (cinit' lift: sc_' new_')
    apply (rule_tac xf'="\<lambda>s. h_val (hrs_mem (t_hrs_' (globals s))) (ret__ptr_to_struct_refill_C_' s)"
                 in ccorres_split_nothrow_call)
@@ -1335,12 +1329,8 @@ lemma refill_budget_check_ccorres:
      (refillBudgetCheck usage) (Call refill_budget_check_'proc)"
   supply sched_context_C_size[simp del] refill_C_size[simp del]
          Collect_const [simp del]
-  unfolding refillBudgetCheck_def haskell_assert_def K_bind_def
-  apply (rule ccorres_symb_exec_l'[rotated, OF _ getCurSc_sp]; (solves wpsimp)?)
-  apply (rule ccorres_symb_exec_l'[rotated, OF _ scActive_sp]; (solves wpsimp)?)
-  apply (rule ccorres_symb_exec_l'[rotated, OF _ assert_sp]; (solves wpsimp)?)
-  apply (rule ccorres_symb_exec_l'[rotated, OF _ isRoundRobin_sp]; (solves wpsimp)?)
-  apply (rule ccorres_symb_exec_l'[rotated, OF _ assert_sp]; (solves wpsimp)?)
+  unfolding refillBudgetCheck_def
+  apply (ccorres_exec_l_pre ccorres_exec_l_pre: getCurSc_sp scActive_sp isRoundRobin_sp)+
   apply (cinit' simp: max_minus_one_word64 runReaderT_def whileAnno_def)
    apply (rule_tac xf'=sc_'
                and val="Ptr scPtr"
@@ -1939,7 +1929,7 @@ lemma release_q_non_empty_and_ready_ccorres:
             releaseQNonEmptyAndReady_def gets_the_if_distrib readReleaseQueue_def
             gets_the_ogets ohaskell_state_assert_def gets_the_ostate_assert
             getReleaseQueue_def[symmetric]
-  apply (rule ccorres_symb_exec_l'[OF _ _ getReleaseQueue_sp]; (solves wpsimp)?)
+  apply (ccorres_exec_l_pre ccorres_exec_l_pre: getReleaseQueue_sp)
   apply cinit'
    apply (simp add: releaseQNonEmptyAndReady_def gets_the_if_distrib readReleaseQueue_def
                     gets_the_ogets ohaskell_state_assert_def gets_the_ostate_assert

--- a/proof/crefine/RISCV64/StoreWord_C.thy
+++ b/proof/crefine/RISCV64/StoreWord_C.thy
@@ -1151,7 +1151,7 @@ lemma storeWordUser_ccorres:
           (Basic (\<lambda>s. globals_update (t_hrs_'_update
            (hrs_mem_update (heap_update (ptr' s) (w' s)))) s)))"
   apply (simp add: storeWordUser_def)
-  apply (rule ccorres_symb_exec_l'[OF _ stateAssert_inv stateAssert_sp empty_fail_stateAssert])
+  apply ccorres_exec_l_pre
   apply (rule ccorres_guard_imp2)
    apply (rule ccorres_Guard)
    apply (rule storeWord_ccorres[unfolded fun_app_def])

--- a/proof/crefine/RISCV64/SyscallArgs_C.thy
+++ b/proof/crefine/RISCV64/SyscallArgs_C.thy
@@ -434,9 +434,8 @@ lemma refill_capacity_ccorres:
      no_0_obj' (\<lbrace>\<acute>sc = Ptr scPtr\<rbrace> \<inter> \<lbrace>\<acute>usage = usage\<rbrace>) hs
      (getRefillCapacity scPtr usage) (Call refill_capacity_'proc)"
   unfolding getRefillCapacity_def readRefillCapacity_def gets_the_obind ohaskell_state_assert_def
-            gets_the_ostate_assert K_bind_apply
-  apply (rule ccorres_symb_exec_l'[OF _ _ stateAssert_sp[unfolded HaskellLib_H.stateAssert_def]];
-         (solves wpsimp)?)+
+            gets_the_ostate_assert
+  apply ccorres_exec_l_pre+
   apply (cinit' lift: usage_')
    apply (clarsimp simp: getRefillHead_def[symmetric] refillCapacity_def)
    apply (clarsimp simp: if_distrib)

--- a/proof/crefine/RISCV64/Syscall_C.thy
+++ b/proof/crefine/RISCV64/Syscall_C.thy
@@ -172,10 +172,8 @@ lemma handleTimeout_ccorres:
                       (Ptr &(tcb_ptr_to_ctcb_ptr tptr\<rightarrow>[''tcbLookupFailure_C'']))))\<rbrace>
       \<inter> \<lbrace>\<acute>tptr = tcb_ptr_to_ctcb_ptr tptr\<rbrace>) hs
      (handleTimeout tptr fault) (Call handleTimeout_'proc)"
-  unfolding handleTimeout_def K_bind_apply haskell_assert_def
-  apply (rule ccorres_symb_exec_l'[OF _ _ stateAssert_sp]; (solves wpsimp)?)+
-  apply (rule ccorres_symb_exec_l'[OF _ _ isValidTimeoutHandler_sp]; (solves \<open>wpsimp\<close>)?)
-  apply (rule ccorres_symb_exec_l'[OF _ _ assert_sp]; (solves wpsimp)?)
+  unfolding handleTimeout_def
+  apply (ccorres_exec_l_pre ccorres_exec_l_pre: isValidTimeoutHandler_sp)+
   apply (cinit' lift: tptr_')
    apply (simp add: getThreadTimeoutHandlerSlot_def locateSlot_conv cte_C_size)
    apply ccorres_remove_UNIV_guard
@@ -306,8 +304,8 @@ lemma doReplyTransfer_ccorres:
     (doReplyTransfer sender replyPtr grant)
     (Call doReplyTransfer_'proc)"
   supply Collect_const[simp del]
-  unfolding doReplyTransfer_def K_bind_apply
-  apply (rule ccorres_symb_exec_l'[OF _ _ stateAssert_sp]; (solves wpsimp)?)+
+  unfolding doReplyTransfer_def
+  apply ccorres_exec_l_pre+
   apply (cinit' lift: sender_' reply_' grant_' simp: liftM_def)
    apply (rule ccorres_pre_getObject_reply, rename_tac reply)
    apply (simp add: option.case_eq_if)
@@ -368,6 +366,7 @@ lemma doReplyTransfer_ccorres:
         apply (clarsimp simp: creply_relation_def typ_heap_simps)
        apply ceqv
       apply (ctac add: reply_remove_ccorres, rename_tac xfdc')
+        apply simp
         apply (rule ccorres_pre_threadGet)
         apply (rule ccorres_move_c_guard_tcb)
         apply (rule ccorres_rhs_assoc2)
@@ -1812,11 +1811,8 @@ lemma chargeBudget_ccorres:
      (chargeBudget consumed canTimeoutFault) (Call chargeBudget_'proc)"
   supply sched_context_C_size[simp del] refill_C_size[simp del]
   supply Collect_const[simp del]
-  unfolding chargeBudget_def K_bind_apply
-  apply (rule ccorres_symb_exec_l'[OF _ _ stateAssert_sp]; (solves wpsimp)?)+
-  apply (rule ccorres_symb_exec_l'[OF _ _ getCurSc_sp]; (solves wpsimp)?)+
-  apply (rule ccorres_symb_exec_l'[OF _ _ stateAssert_sp]; (solves wpsimp)?)
-  apply (rule ccorres_symb_exec_l'[OF _ _ getIdleSC_sp]; (solves wpsimp)?)
+  unfolding chargeBudget_def
+  apply (ccorres_exec_l_pre ccorres_exec_l_pre: getCurSc_sp getIdleSC_sp)+
   apply (cinit' lift: consumed_' canTimeoutFault_')
    apply (rule ccorres_split_nothrow)
        apply (clarsimp simp: when_def)
@@ -2148,14 +2144,9 @@ lemma handleYield_ccorres:
      (handleYield) (Call handleYield_'proc)"
   supply sched_context_C_size[simp del] refill_C_size[simp del]
   supply Collect_const[simp del]
-  unfolding handleYield_def K_bind_apply
-  apply (rule ccorres_symb_exec_l'[OF _ _ getCurSc_sp]; (solves wpsimp)?)
-  apply (rename_tac scPtr)
-  apply (rule ccorres_symb_exec_l'[OF _ _ stateAssert_sp]; (solves wpsimp)?)
-  apply (rule ccorres_symb_exec_l'[OF _ _ get_sc_sp']; (solves wpsimp)?)
-  apply (rename_tac sc)
-  apply (rule ccorres_symb_exec_l'[OF _ _ getConsumedTime_sp]; (solves wpsimp)?)
-  apply (rename_tac consumed)
+  unfolding handleYield_def
+  apply (ccorres_exec_l_pre ccorres_exec_l_pre: getCurSc_sp get_sc_sp' getConsumedTime_sp)+
+  apply (rename_tac scPtr rv sc consumed)
   apply cinit'
    apply (rule ccorres_Guard_Seq)
    apply (rule_tac val="scConsumed sc + consumed"

--- a/proof/crefine/RISCV64/Tcb_C.thy
+++ b/proof/crefine/RISCV64/Tcb_C.thy
@@ -707,7 +707,7 @@ lemma checkCapAt_ccorres:
                 h_val (hrs_mem \<acute>t_hrs) (cap_Ptr &(slot'\<rightarrow>[''cap_C'']))));;c)"
   apply (rule ccorres_gen_asm2)+
   apply (simp add: checkCapAt_def liftM_def bind_assoc del: Collect_const)
-  apply (rule ccorres_symb_exec_l' [OF _ getCTE_inv getCTE_sp empty_fail_getCTE])
+  apply (ccorres_exec_l_pre ccorres_exec_l_pre: getCTE_sp)
   apply (rule ccorres_guard_imp2)
    apply (rule ccorres_move_c_guard_cte)
    apply (rule_tac xf'=ret__unsigned_long_' and val="from_bool (sameObjectAs cap (cteCap x))"
@@ -719,7 +719,7 @@ lemma checkCapAt_ccorres:
       apply (rule exI, rule conjI, assumption)
       apply (clarsimp simp: typ_heap_simps dest!: ccte_relation_ccap_relation)
       apply (rule exI, rule conjI, assumption)
-      apply (auto intro: valid_capAligned dest: ctes_of_valid')[1]
+      subgoal by (auto intro: valid_capAligned dest: ctes_of_valid')
      apply assumption
     apply (simp only: when_def if_to_top_of_bind)
     apply (rule ccorres_if_lhs)

--- a/proof/crefine/RISCV64/VSpace_C.thy
+++ b/proof/crefine/RISCV64/VSpace_C.thy
@@ -881,7 +881,7 @@ lemma setVMRoot_ccorres:
   "ccorres dc xfdc invs' \<lbrace>\<acute>tcb = tcb_ptr_to_ctcb_ptr thread\<rbrace> hs
      (setVMRoot thread) (Call setVMRoot_'proc)"
   unfolding setVMRoot_def
-  apply (rule ccorres_symb_exec_l'[OF _ _ stateAssert_sp]; (solves wpsimp)?)
+  apply ccorres_exec_l_pre
   supply Collect_const[simp del]
   apply (cinit lift: tcb_')
    apply (rule ccorres_move_array_assertion_tcb_ctes)

--- a/tools/autocorres/Polish.thy
+++ b/tools/autocorres/Polish.thy
@@ -147,9 +147,7 @@ lemma bind_K_bind [polish]: "A >>= (\<lambda>x :: unit. B) = (A >>= K_bind B)"
 lemma obind_K_bind [polish]: "A |>> (\<lambda>x :: unit. B) = (A  |>> K_bind B)"
   by clarsimp
 
-lemma K_bind_apply [polish]:
-    "K_bind a b = a"
-  by simp
+declare K_bind_apply[polish]
 
 lemma condition_to_if [polish]:
   "condition (\<lambda>s. C) (return a) (return b) = return (if C then a else b)"


### PR DESCRIPTION
I'd be happy to squash commits however people would like. I did not add a body to the commit message of the commit containing the new method, since there is already a comment where the method is defined. I could add the comment to the body of the commit message if that's preferable.

I could do this for `master`, too, if everyone is happy with this method. There are only a few uses of this pattern there, but it may be good to consolidate the tech between `master` and `rt`.

Test with seL4/seL4@michaelm/ipc_queues_mcs_testing