### PR TITLE
docs+README: fix google repo links

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ Setup
 -----
 
 This repository is meant to be used as part of a Google [repo][5] setup. Instead
-of cloning it directly, please follow the directions for software dependencies
-and Isabelle installation in the [setup.md](docs/setup.md) file in the `docs`
-directory.
+of cloning the l4v repository directly, please follow the directions for
+software dependencies and Isabelle installation in the [setup.md](docs/setup.md)
+file in the `docs` directory.
 
-[5]: https://gerrit.googlesource.com/git-repo/+/HEAD/README.md
+[5]: https://gerrit.googlesource.com/git-repo/
 
 Contributing
 ------------

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -161,7 +161,7 @@ If you are looking to use the proofs for a specific release version of seL4, use
 the `-m` option to select the corresponding manifest file in the
 [verification-manifest] repository.
 
-[repo]: https://gerrit.googlesource.com/git-repo/+/HEAD/README.md
+[repo]: https://gerrit.googlesource.com/git-repo/
 [verification-manifest]: https://github.com/seL4/verification-manifest
 
 ## Isabelle Setup


### PR DESCRIPTION
The direct link to the README no longer works for the link checker. The main site is showing mostly the repo README and should be sufficient.