### PR TITLE
github: bump GH action versions

### DIFF
--- a/.github/workflows/external.yml
+++ b/.github/workflows/external.yml
@@ -32,13 +32,13 @@ jobs:
         AWS_SSH: ${{ secrets.AWS_SSH }}
         GH_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
     - name: Upload kernel builds
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: kernel-builds-${{ matrix.arch }}
         path: artifacts/kernel-builds
         if-no-files-found: ignore
     - name: Upload logs
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: logs-${{ matrix.arch }}
         path: logs.tar.xz

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
       with:
         token: ${{ secrets.READ_TOKEN }}
         pr_num: ${{ github.event.pull_request.number }}
-    - uses: yuzutech/annotations-action@v0.5.0
+    - uses: yuzutech/annotations-action@v0.6.0
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         title: 'File annotations for theory linter'

--- a/.github/workflows/proof-deploy.yml
+++ b/.github/workflows/proof-deploy.yml
@@ -86,13 +86,13 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         AWS_SSH: ${{ secrets.AWS_SSH }}
     - name: Upload kernel builds
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: kernel-builds-${{ matrix.num_domains }}-${{ matrix.arch }}-${{ matrix.plat }}
         path: artifacts/kernel-builds
         if-no-files-found: ignore
     - name: Upload logs
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: logs-${{ matrix.num_domains }}-${{ matrix.arch }}-${{ matrix.plat }}
         path: logs.tar.xz
@@ -125,13 +125,13 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         AWS_SSH: ${{ secrets.AWS_SSH }}
     - name: Upload kernel builds
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: mcs-kernel-builds-${{ matrix.num_domains }}-${{ matrix.arch }}-${{ matrix.plat }}
         path: artifacts/kernel-builds
         if-no-files-found: ignore
     - name: Upload logs
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: mcs-logs-${{ matrix.num_domains }}-${{ matrix.arch }}-${{ matrix.plat }}
         path: logs.tar.xz
@@ -166,6 +166,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Trigger rebase
-      uses: peter-evans/repository-dispatch@v3
+      uses: peter-evans/repository-dispatch@v4
       with:
         event-type: rebase

--- a/.github/workflows/proof.yml
+++ b/.github/workflows/proof.yml
@@ -48,13 +48,13 @@ jobs:
         AWS_SSH: ${{ secrets.AWS_SSH }}
         GH_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
     - name: Upload kernel builds
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: kernel-builds-${{ matrix.arch }}
         path: artifacts/kernel-builds
         if-no-files-found: ignore
     - name: Upload logs
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: logs-${{ matrix.arch }}
         path: logs.tar.xz

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -29,7 +29,7 @@ jobs:
         branch: [imx8-fpu-ver]
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         ref: ${{ matrix.branch }}
         path: l4v-${{ matrix.branch }}

--- a/.github/workflows/rt-proof.yml
+++ b/.github/workflows/rt-proof.yml
@@ -50,13 +50,13 @@ jobs:
         AWS_SSH: ${{ secrets.AWS_SSH }}
         GH_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
     - name: Upload kernel builds
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: kernel-builds-${{ matrix.arch }}
         path: artifacts/kernel-builds
         if-no-files-found: ignore
     - name: Upload logs
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: logs-${{ matrix.arch }}
         path: logs.tar.xz

--- a/.github/workflows/trigger.yml
+++ b/.github/workflows/trigger.yml
@@ -20,7 +20,7 @@ jobs:
     name: CParser Deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: peter-evans/repository-dispatch@v3
+      - uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ secrets.PRIV_REPO_TOKEN }}
           repository: seL4/ci-actions

--- a/.github/workflows/weekly-clean.yml
+++ b/.github/workflows/weekly-clean.yml
@@ -88,13 +88,13 @@ jobs:
         AWS_SSH: ${{ secrets.AWS_SSH }}
         GH_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
     - name: Upload kernel builds
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: kernel-builds-${{ matrix.num_domains }}-${{ matrix.arch }}-${{ matrix.plat }}
         path: artifacts/kernel-builds
         if-no-files-found: ignore
     - name: Upload logs
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: logs-${{ matrix.num_domains }}-${{ matrix.arch }}-${{ matrix.plat }}
         path: logs.tar.xz


### PR DESCRIPTION
Node 20 is deprecated. Bump GitHub action dependencies to versions that run on more recent node.