### PR TITLE
refine: improve typ_at_lifts and add typ_at_props' locale

### DIFF
--- a/lib/Lib.thy
+++ b/lib/Lib.thy
@@ -2673,4 +2673,12 @@ lemma wf_fst_size:
 (* FIXME: use the name wf_fst_size instead of list_length_wf_helper *)
 lemmas list_length_wf_helper = wf_fst_size
 
+lemma bool_to_bool_cases:
+  assumes "f = (\<lambda>x. True) \<Longrightarrow> P"
+  assumes "f = (\<lambda>x. False) \<Longrightarrow> P"
+  assumes "f = (\<lambda>x. x) \<Longrightarrow> P"
+  assumes "f = (\<lambda>x. \<not>x) \<Longrightarrow> P"
+  shows P
+  by (cases "f True"; cases "f False"; rule assms; rule ext; case_tac x; simp)
+
 end

--- a/proof/crefine/AARCH64/Arch_C.thy
+++ b/proof/crefine/AARCH64/Arch_C.thy
@@ -4543,6 +4543,7 @@ lemma invokeSMCCall_ccorres:
                    apply (rule allI, rule conseqPre, vcg)
                    apply (simp add: return_def)
                   apply wp
+                 apply clarsimp
                  apply wpsimp
                 apply clarsimp
                apply (wpsimp simp: setMR_def length_of_msgRegisters)

--- a/proof/crefine/AARCH64/Fastpath_C.thy
+++ b/proof/crefine/AARCH64/Fastpath_C.thy
@@ -2671,13 +2671,6 @@ lemma ccap_relation_reply_helper:
                      cap_reply_cap_lift_def
               elim!: ccap_relationE)
 
-lemma valid_ep_typ_at_lift':
-  "\<lbrakk> \<And>p. \<lbrace>typ_at' TCBT p\<rbrace> f \<lbrace>\<lambda>rv. typ_at' TCBT p\<rbrace> \<rbrakk>
-      \<Longrightarrow> \<lbrace>\<lambda>s. valid_ep' ep s\<rbrace> f \<lbrace>\<lambda>rv s. valid_ep' ep s\<rbrace>"
-  apply (cases ep, simp_all add: valid_ep'_def)
-   apply (wp hoare_vcg_const_Ball_lift typ_at_lifts | assumption)+
-  done
-
 lemma threadSet_tcbState_valid_objs:
   "\<lbrace>valid_tcb_state' st and valid_objs'\<rbrace>
      threadSet (tcbState_update (\<lambda>_. st)) t
@@ -3305,7 +3298,7 @@ proof -
                                                 valid_mdb'_def)
                                apply (wp threadSet_cur threadSet_tcbState_valid_objs
                                          threadSet_state_refs_of' threadSet_ctes_of
-                                         valid_ep_typ_at_lift' threadSet_cte_wp_at' asid_has_vmid_lift
+                                         threadSet_cte_wp_at' asid_has_vmid_lift
                                       | simp)+
                               apply (vcg exspec=thread_state_ptr_mset_blockingObject_tsType_modifies)
                              apply simp

--- a/proof/crefine/AARCH64/Fastpath_Equiv.thy
+++ b/proof/crefine/AARCH64/Fastpath_Equiv.thy
@@ -286,13 +286,6 @@ lemma recv_ep_queued_st_tcb_at':
   apply (clarsimp simp: isBlockedOnReceive_def )
   done
 
-lemma valid_ep_typ_at_lift':
-  "\<lbrakk> \<And>p. \<lbrace>typ_at' TCBT p\<rbrace> f \<lbrace>\<lambda>rv. typ_at' TCBT p\<rbrace> \<rbrakk>
-      \<Longrightarrow> \<lbrace>\<lambda>s. valid_ep' ep s\<rbrace> f \<lbrace>\<lambda>rv s. valid_ep' ep s\<rbrace>"
-  apply (cases ep, simp_all add: valid_ep'_def)
-   apply (wp hoare_vcg_const_Ball_lift typ_at_lifts | assumption)+
-  done
-
 lemma threadSet_tcbState_valid_objs:
   "\<lbrace>valid_tcb_state' st and valid_objs'\<rbrace>
      threadSet (tcbState_update (\<lambda>_. st)) t
@@ -1726,7 +1719,7 @@ lemma fastpath_callKernel_SysReplyRecv_corres:
                                       emptySlot_tcbContext[simplified comp_apply]
                                       emptySlot_cte_wp_at_cteCap
                                       emptySlot_cnode_caps
-                                      user_getreg_inv asUser_typ_ats
+                                      user_getreg_inv
                                       asUser_obj_at_not_queued asUser_obj_at' mapM_x_wp'
                                       hoare_weak_lift_imp hoare_vcg_all_lift hoare_vcg_imp_lift
                                       cnode_caps_gsCNodes_lift
@@ -1738,7 +1731,7 @@ lemma fastpath_callKernel_SysReplyRecv_corres:
 
                             apply (wpsimp wp: fastpathBestSwitchCandidate_lift[where f="asUser a b" for a b])+
                            apply (clarsimp cong: conj_cong)
-                           apply ((wp user_getreg_inv asUser_typ_ats
+                           apply ((wp user_getreg_inv asUser.typ_ats
                                       asUser_obj_at_not_queued asUser_obj_at' mapM_x_wp'
                                       hoare_weak_lift_imp hoare_vcg_all_lift hoare_vcg_imp_lift
                                       cnode_caps_gsCNodes_lift
@@ -1909,8 +1902,7 @@ lemma fastpath_callKernel_SysReplyRecv_corres:
   apply (frule(1) st_tcb_at_is_Reply_imp_not_tcbQueued)
   apply (frule invs_pspace_aligned')
   apply (frule invs_pspace_distinct')
-  apply (auto simp: obj_at_tcbs_of tcbSlots projectKOs
-                        cte_level_bits_def)
+  apply (auto simp: obj_at_tcbs_of tcbSlots cte_level_bits_def)
   done
 
 end

--- a/proof/crefine/AARCH64/Finalise_C.thy
+++ b/proof/crefine/AARCH64/Finalise_C.thy
@@ -2270,7 +2270,7 @@ lemma associateVCPUTCB_ccorres:
          apply vcg
         apply wpsimp
        apply (vcg exspec=dissociateVCPUTCB_modifies)
-      apply ((wpsimp wp: hoare_vcg_all_lift hoare_drop_imps valid_arch_tcb_lift'
+      apply ((wpsimp wp: hoare_vcg_all_lift hoare_drop_imps
               | strengthen invs_valid_objs' invs_arch_state')+)[1]
      apply (vcg exspec=dissociateVCPUTCB_modifies)
     apply (rule_tac Q'="\<lambda>_. invs' and vcpu_at' vcpuptr and tcb_at' tptr" in hoare_post_imp)

--- a/proof/crefine/AARCH64/Ipc_C.thy
+++ b/proof/crefine/AARCH64/Ipc_C.thy
@@ -568,7 +568,7 @@ lemma handleFaultReply':
                                    asUser_return submonad_asUser.fn_stateAssert
                   | rule monadic_rewrite_bind_tail monadic_rewrite_refl
                          monadic_rewrite_symb_exec_l[OF _ stateAssert_inv]
-                  | wp asUser_typ_ats)+)+
+                  | wp)+)+
        apply (case_tac "msgLength tag < scast n_msgRegisters")
         apply (erule disjE[OF word_less_cases],
                   ( clarsimp simp: n_msgRegisters_def asUser_bind_distrib
@@ -583,7 +583,7 @@ lemma handleFaultReply':
                          monadic_rewrite_symb_exec_l[OF _ stateAssert_inv]
                          monadic_rewrite_threadGet_return
                          monadic_rewrite_getSanitiseRegisterInfo_return
-                  | wp asUser_typ_ats mapM_wp')+)+
+                  | wp mapM_wp')+)+
        apply (simp add: n_msgRegisters_def word_le_nat_alt n_syscallMessage_def
                         linorder_not_less syscallMessage_unfold)
        apply (clarsimp | frule neq0_conv[THEN iffD2, THEN not0_implies_Suc,
@@ -626,7 +626,7 @@ lemma handleFaultReply':
                                monadic_rewrite_threadGet_return
                                monadic_rewrite_getSanitiseRegisterInfo_return
                                monadic_rewrite_getSanitiseRegisterInfo_drop
-                        | wp asUser_typ_ats empty_fail_loadWordUser)+)+
+                        | wp empty_fail_loadWordUser)+)+
        apply (clarsimp simp: upto_enum_word word_le_nat_alt simp del: upt.simps cong: if_weak_cong)
        apply (cut_tac i="unat n" and j="Suc (unat (scast n_syscallMessage :: machine_word))"
                                  and k="Suc msgMaxLength" in upt_add_eq_append')
@@ -4167,8 +4167,7 @@ lemma doNormalTransfer_local_slots:
     doNormalTransfer sender sendBuffer ep badge grant receiver receiveBuffer
    \<lbrace>\<lambda>rv. cte_wp_at' (\<lambda>cte. P (cteCap cte)) slot\<rbrace>"
   apply (simp add: doNormalTransfer_def)
-  apply (wp transferCaps_local_slots weak copyMRs_typ_at'[where T=CTET, unfolded typ_at_cte']
-    | simp)+
+  apply (wpsimp wp: transferCaps_local_slots weak)
   done
 
 lemma doIPCTransfer_local_slots:

--- a/proof/crefine/AARCH64/Ipc_C.thy
+++ b/proof/crefine/AARCH64/Ipc_C.thy
@@ -4167,7 +4167,7 @@ lemma doNormalTransfer_local_slots:
     doNormalTransfer sender sendBuffer ep badge grant receiver receiveBuffer
    \<lbrace>\<lambda>rv. cte_wp_at' (\<lambda>cte. P (cteCap cte)) slot\<rbrace>"
   apply (simp add: doNormalTransfer_def)
-  apply (wp transferCaps_local_slots weak copyMRs_typ_at'[where T=CTET, unfolded typ_at_cte]
+  apply (wp transferCaps_local_slots weak copyMRs_typ_at'[where T=CTET, unfolded typ_at_cte']
     | simp)+
   done
 

--- a/proof/crefine/AARCH64/Syscall_C.thy
+++ b/proof/crefine/AARCH64/Syscall_C.thy
@@ -647,8 +647,7 @@ lemma sendFaultIPC_ccorres:
               apply (ctac (no_vcg) add: sendIPC_ccorres)
                apply (ctac (no_vcg) add: ccorres_return_CE [unfolded returnOk_def comp_def])
               apply wp
-             apply (wpsimp wp: threadSet_invs_trivial)
-             apply (wpsimp wp: threadSet_pred_tcb_no_state threadSet_typ_at_lifts)
+             apply (wpsimp wp: threadSet_invs_trivial threadSet_pred_tcb_no_state)
 
             apply (clarsimp simp: guard_is_UNIV_def)
             apply (subgoal_tac "capEPBadge epcap && mask 64 = capEPBadge epcap")
@@ -1151,20 +1150,6 @@ lemma option_to_ctcb_ptr_valid_ntfn:
   apply (cases "ntfnBoundTCB ntfn", simp_all add: option_to_ctcb_ptr_def)
   apply (clarsimp simp: valid_ntfn'_def tcb_at_not_NULL)
   done
-
-
-lemma deleteCallerCap_valid_ntfn'[wp]:
-  "\<lbrace>\<lambda>s. valid_ntfn' x s\<rbrace> deleteCallerCap c \<lbrace>\<lambda>rv s. valid_ntfn' x s\<rbrace>"
-  apply (wp hoare_vcg_ex_lift hoare_vcg_all_lift hoare_vcg_ball_lift hoare_vcg_imp_lift
-            | simp add: valid_ntfn'_def split: ntfn.splits)+
-   apply auto
-  done
-
-lemma hoare_vcg_imp_liftE:
-  "\<lbrakk>\<lbrace>P'\<rbrace> f \<lbrace>\<lambda>rv s. \<not> P rv s\<rbrace>, \<lbrace>E\<rbrace>; \<lbrace>Q'\<rbrace> f \<lbrace>Q\<rbrace>, \<lbrace>E\<rbrace>\<rbrakk> \<Longrightarrow>  \<lbrace>\<lambda>s. P' s \<or> Q' s\<rbrace> f \<lbrace>\<lambda>rv s. P rv s \<longrightarrow> Q rv s\<rbrace>, \<lbrace>E\<rbrace>"
-  apply (simp add: validE_def valid_def split_def split: sum.splits)
-  done
-
 
 lemma not_obj_at'_ntfn:
   "(\<not>obj_at' (P::Structures_H.notification \<Rightarrow> bool) t s) = (\<not> typ_at' NotificationT t s \<or> obj_at' (Not \<circ> P) t s)"

--- a/proof/crefine/AARCH64/Tcb_C.thy
+++ b/proof/crefine/AARCH64/Tcb_C.thy
@@ -429,7 +429,7 @@ lemma setPriority_ccorres:
     apply (simp add: guard_is_UNIV_def)
    apply (rule hoare_strengthen_post[
                  where Q'="\<lambda>rv s.
-                          obj_at' (\<lambda>_. True) t s \<and>
+                          tcb_at' t s \<and>
                           priority \<le> maxPriority \<and>
                           ksCurDomain s \<le> maxDomain \<and>
                           valid_objs' s \<and>

--- a/proof/crefine/ARM/Fastpath_C.thy
+++ b/proof/crefine/ARM/Fastpath_C.thy
@@ -2461,13 +2461,6 @@ lemma ccap_relation_reply_helper:
                      cap_reply_cap_lift_def
               elim!: ccap_relationE)
 
-lemma valid_ep_typ_at_lift':
-  "\<lbrakk> \<And>p. \<lbrace>typ_at' TCBT p\<rbrace> f \<lbrace>\<lambda>rv. typ_at' TCBT p\<rbrace> \<rbrakk>
-      \<Longrightarrow> \<lbrace>\<lambda>s. valid_ep' ep s\<rbrace> f \<lbrace>\<lambda>rv s. valid_ep' ep s\<rbrace>"
-  apply (cases ep, simp_all add: valid_ep'_def)
-   apply (wp hoare_vcg_const_Ball_lift typ_at_lifts | assumption)+
-  done
-
 lemma threadSet_tcbState_valid_objs:
   "\<lbrace>valid_tcb_state' st and valid_objs'\<rbrace>
      threadSet (tcbState_update (\<lambda>_. st)) t
@@ -3000,9 +2993,8 @@ lemma fastpath_reply_recv_ccorres:
                      apply (simp add: valid_pspace'_def pred_conj_def conj_comms
                                       valid_mdb'_def)
                      apply (wp threadSet_cur threadSet_tcbState_valid_objs
-                               threadSet_state_refs_of' threadSet_ctes_of
-                               valid_ep_typ_at_lift' threadSet_cte_wp_at'
-                                  | simp)+
+                               threadSet_state_refs_of' threadSet_ctes_of threadSet_cte_wp_at'
+                            | simp)+
                     apply (vcg exspec=thread_state_ptr_mset_blockingObject_tsType_modifies)
 
                      apply simp

--- a/proof/crefine/ARM/Fastpath_Equiv.thy
+++ b/proof/crefine/ARM/Fastpath_Equiv.thy
@@ -293,13 +293,6 @@ lemma recv_ep_queued_st_tcb_at':
   apply (clarsimp simp: isBlockedOnReceive_def projectKOs)
   done
 
-lemma valid_ep_typ_at_lift':
-  "\<lbrakk> \<And>p. \<lbrace>typ_at' TCBT p\<rbrace> f \<lbrace>\<lambda>rv. typ_at' TCBT p\<rbrace> \<rbrakk>
-      \<Longrightarrow> \<lbrace>\<lambda>s. valid_ep' ep s\<rbrace> f \<lbrace>\<lambda>rv s. valid_ep' ep s\<rbrace>"
-  apply (cases ep, simp_all add: valid_ep'_def)
-   apply (wp hoare_vcg_const_Ball_lift typ_at_lifts | assumption)+
-  done
-
 lemma threadSet_tcbState_valid_objs:
   "\<lbrace>valid_tcb_state' st and valid_objs'\<rbrace>
      threadSet (tcbState_update (\<lambda>_. st)) t
@@ -1385,16 +1378,6 @@ crunch emptySlot
 crunch getBoundNotification
   for (no_fail) no_fail[intro!, wp, simp]
 
-lemma threadSet_tcb_at'[wp]:
-  "threadSet f t' \<lbrace>\<lambda>s. P (tcb_at' addr s)\<rbrace>"
-  apply (wpsimp wp: threadSet_wp)
-  apply (erule rsubst[where P=P])
-  by (clarsimp simp: obj_at'_def projectKOs ps_clear_upd objBits_simps)
-
-crunch rescheduleRequired, tcbSchedDequeue, setThreadState, setBoundNotification
-  for tcb''[wp]: "\<lambda>s. P (tcb_at' addr s)"
-  (wp: crunch_wps)
-
 lemma fastpath_callKernel_SysReplyRecv_corres:
   "monadic_rewrite True False
      (invs' and ct_in_state' ((=) Running) and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread)
@@ -1609,7 +1592,7 @@ lemma fastpath_callKernel_SysReplyRecv_corres:
                                       emptySlot_tcbContext[simplified comp_apply]
                                       emptySlot_cte_wp_at_cteCap
                                       emptySlot_cnode_caps
-                                      user_getreg_inv asUser_typ_ats
+                                      user_getreg_inv
                                       asUser_obj_at_not_queued asUser_obj_at' mapM_x_wp'
                                       hoare_weak_lift_imp hoare_vcg_all_lift hoare_vcg_imp_lift
                                       hoare_weak_lift_imp cnode_caps_gsCNodes_lift
@@ -1621,7 +1604,7 @@ lemma fastpath_callKernel_SysReplyRecv_corres:
 
                             apply (wpsimp wp: fastpathBestSwitchCandidate_lift[where f="asUser a b" for a b])+
                            apply (clarsimp cong: conj_cong)
-                           apply ((wp user_getreg_inv asUser_typ_ats
+                           apply ((wp user_getreg_inv asUser.typ_ats
                                       asUser_obj_at_not_queued asUser_obj_at' mapM_x_wp'
                                       hoare_weak_lift_imp hoare_vcg_all_lift hoare_vcg_imp_lift
                                       hoare_weak_lift_imp cnode_caps_gsCNodes_lift
@@ -1779,8 +1762,7 @@ lemma fastpath_callKernel_SysReplyRecv_corres:
   apply (frule(1) st_tcb_at_is_Reply_imp_not_tcbQueued)
   apply (frule invs_pspace_aligned')
   apply (frule invs_pspace_distinct')
-  apply (auto simp: obj_at_tcbs_of tcbSlots projectKOs
-                        cte_level_bits_def)
+  apply (auto simp: obj_at_tcbs_of tcbSlots cte_level_bits_def)
   done
 
 end

--- a/proof/crefine/ARM/Ipc_C.thy
+++ b/proof/crefine/ARM/Ipc_C.thy
@@ -3876,7 +3876,7 @@ lemma doNormalTransfer_local_slots:
     doNormalTransfer sender sendBuffer ep badge grant receiver receiveBuffer
    \<lbrace>\<lambda>rv. cte_wp_at' (\<lambda>cte. P (cteCap cte)) slot\<rbrace>"
   apply (simp add: doNormalTransfer_def)
-  apply (wp transferCaps_local_slots weak copyMRs_typ_at'[where T=CTET, unfolded typ_at_cte]
+  apply (wp transferCaps_local_slots weak copyMRs_typ_at'[where T=CTET, unfolded typ_at_cte']
     | simp)+
   done
 

--- a/proof/crefine/ARM/Ipc_C.thy
+++ b/proof/crefine/ARM/Ipc_C.thy
@@ -3876,8 +3876,7 @@ lemma doNormalTransfer_local_slots:
     doNormalTransfer sender sendBuffer ep badge grant receiver receiveBuffer
    \<lbrace>\<lambda>rv. cte_wp_at' (\<lambda>cte. P (cteCap cte)) slot\<rbrace>"
   apply (simp add: doNormalTransfer_def)
-  apply (wp transferCaps_local_slots weak copyMRs_typ_at'[where T=CTET, unfolded typ_at_cte']
-    | simp)+
+  apply (wpsimp wp: transferCaps_local_slots weak)
   done
 
 lemma doIPCTransfer_local_slots:

--- a/proof/crefine/ARM/Syscall_C.thy
+++ b/proof/crefine/ARM/Syscall_C.thy
@@ -589,8 +589,7 @@ lemma sendFaultIPC_ccorres:
               apply (ctac (no_vcg) add: sendIPC_ccorres)
                apply (ctac (no_vcg) add: ccorres_return_CE [unfolded returnOk_def comp_def])
               apply wp
-             apply (wpsimp wp: threadSet_invs_trivial)
-             apply (wpsimp wp: threadSet_pred_tcb_no_state threadSet_typ_at_lifts)
+             apply (wpsimp wp: threadSet_invs_trivial threadSet_pred_tcb_no_state)
 
             apply (clarsimp simp: guard_is_UNIV_def)
             apply (subgoal_tac "capEPBadge epcap && mask 28 = capEPBadge epcap")

--- a/proof/crefine/ARM/Tcb_C.thy
+++ b/proof/crefine/ARM/Tcb_C.thy
@@ -391,7 +391,7 @@ lemma setPriority_ccorres:
     apply (simp add: guard_is_UNIV_def)
    apply (rule hoare_strengthen_post[
                  where Q'="\<lambda>rv s.
-                          obj_at' (\<lambda>_. True) t s \<and>
+                          tcb_at' t s \<and>
                           priority \<le> maxPriority \<and>
                           ksCurDomain s \<le> maxDomain \<and>
                           valid_objs' s \<and>

--- a/proof/crefine/ARM_HYP/Fastpath_C.thy
+++ b/proof/crefine/ARM_HYP/Fastpath_C.thy
@@ -2506,13 +2506,6 @@ lemma ccap_relation_reply_helper:
                      cap_reply_cap_lift_def
               elim!: ccap_relationE)
 
-lemma valid_ep_typ_at_lift':
-  "\<lbrakk> \<And>p. \<lbrace>typ_at' TCBT p\<rbrace> f \<lbrace>\<lambda>rv. typ_at' TCBT p\<rbrace> \<rbrakk>
-      \<Longrightarrow> \<lbrace>\<lambda>s. valid_ep' ep s\<rbrace> f \<lbrace>\<lambda>rv s. valid_ep' ep s\<rbrace>"
-  apply (cases ep, simp_all add: valid_ep'_def)
-   apply (wp hoare_vcg_const_Ball_lift typ_at_lifts | assumption)+
-  done
-
 lemma threadSet_tcbState_valid_objs:
   "\<lbrace>valid_tcb_state' st and valid_objs'\<rbrace>
      threadSet (tcbState_update (\<lambda>_. st)) t
@@ -3045,9 +3038,8 @@ lemma fastpath_reply_recv_ccorres:
                      apply (simp add: valid_pspace'_def pred_conj_def conj_comms
                                       valid_mdb'_def)
                      apply (wp threadSet_cur threadSet_tcbState_valid_objs
-                               threadSet_state_refs_of' threadSet_ctes_of
-                               valid_ep_typ_at_lift' threadSet_cte_wp_at'
-                                  | simp)+
+                               threadSet_state_refs_of' threadSet_ctes_of threadSet_cte_wp_at'
+                            | simp)+
                     apply (vcg exspec=thread_state_ptr_mset_blockingObject_tsType_modifies)
 
                      apply simp

--- a/proof/crefine/ARM_HYP/Fastpath_Equiv.thy
+++ b/proof/crefine/ARM_HYP/Fastpath_Equiv.thy
@@ -293,13 +293,6 @@ lemma recv_ep_queued_st_tcb_at':
   apply (clarsimp simp: isBlockedOnReceive_def projectKOs)
   done
 
-lemma valid_ep_typ_at_lift':
-  "\<lbrakk> \<And>p. \<lbrace>typ_at' TCBT p\<rbrace> f \<lbrace>\<lambda>rv. typ_at' TCBT p\<rbrace> \<rbrakk>
-      \<Longrightarrow> \<lbrace>\<lambda>s. valid_ep' ep s\<rbrace> f \<lbrace>\<lambda>rv s. valid_ep' ep s\<rbrace>"
-  apply (cases ep, simp_all add: valid_ep'_def)
-   apply (wp hoare_vcg_const_Ball_lift typ_at_lifts | assumption)+
-  done
-
 lemma threadSet_tcbState_valid_objs:
   "\<lbrace>valid_tcb_state' st and valid_objs'\<rbrace>
      threadSet (tcbState_update (\<lambda>_. st)) t
@@ -1388,16 +1381,6 @@ crunch emptySlot
 crunch getBoundNotification
   for (no_fail) no_fail[intro!, wp, simp]
 
-lemma threadSet_tcb_at'[wp]:
-  "threadSet f t' \<lbrace>\<lambda>s. P (tcb_at' addr s)\<rbrace>"
-  apply (wpsimp wp: threadSet_wp)
-  apply (erule rsubst[where P=P])
-  by (clarsimp simp: obj_at'_def projectKOs ps_clear_upd objBits_simps)
-
-crunch rescheduleRequired, tcbSchedDequeue, setThreadState, setBoundNotification
-  for tcb''[wp]: "\<lambda>s. P (tcb_at' addr s)"
-  (wp: crunch_wps)
-
 lemma fastpath_callKernel_SysReplyRecv_corres:
   "monadic_rewrite True False
      (invs' and ct_in_state' ((=) Running) and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread)
@@ -1612,7 +1595,7 @@ lemma fastpath_callKernel_SysReplyRecv_corres:
                                       emptySlot_tcbContext[simplified comp_apply]
                                       emptySlot_cte_wp_at_cteCap
                                       emptySlot_cnode_caps
-                                      user_getreg_inv asUser_typ_ats
+                                      user_getreg_inv
                                       asUser_obj_at_not_queued asUser_obj_at' mapM_x_wp'
                                       hoare_weak_lift_imp hoare_vcg_all_lift hoare_vcg_imp_lift
                                       hoare_weak_lift_imp cnode_caps_gsCNodes_lift
@@ -1624,7 +1607,7 @@ lemma fastpath_callKernel_SysReplyRecv_corres:
 
                             apply (wpsimp wp: fastpathBestSwitchCandidate_lift[where f="asUser a b" for a b])+
                            apply (clarsimp cong: conj_cong)
-                           apply ((wp user_getreg_inv asUser_typ_ats
+                           apply ((wp user_getreg_inv asUser.typ_ats
                                       asUser_obj_at_not_queued asUser_obj_at' mapM_x_wp'
                                       hoare_weak_lift_imp hoare_vcg_all_lift hoare_vcg_imp_lift
                                       hoare_weak_lift_imp cnode_caps_gsCNodes_lift
@@ -1785,8 +1768,7 @@ lemma fastpath_callKernel_SysReplyRecv_corres:
   apply (frule(1) st_tcb_at_is_Reply_imp_not_tcbQueued)
   apply (frule invs_pspace_aligned')
   apply (frule invs_pspace_distinct')
-  apply (auto simp: obj_at_tcbs_of tcbSlots projectKOs
-                        cte_level_bits_def)
+  apply (auto simp: obj_at_tcbs_of tcbSlots cte_level_bits_def)
   done
 
 end

--- a/proof/crefine/ARM_HYP/Ipc_C.thy
+++ b/proof/crefine/ARM_HYP/Ipc_C.thy
@@ -767,7 +767,7 @@ lemma handleFaultReply':
                                monadic_rewrite_threadGet_return
                                monadic_rewrite_getSanitiseRegisterInfo_return
                                monadic_rewrite_getSanitiseRegisterInfo_drop
-                        | wp asUser_typ_ats empty_fail_loadWordUser)+)+
+                        | wp empty_fail_loadWordUser)+)+
        apply (clarsimp simp: upto_enum_word word_le_nat_alt simp del: upt.simps cong: if_weak_cong)
        apply (cut_tac i="unat n" and j="Suc (unat (scast n_syscallMessage :: word32))"
                                  and k="Suc msgMaxLength" in upt_add_eq_append')
@@ -4404,8 +4404,7 @@ lemma doNormalTransfer_local_slots:
     doNormalTransfer sender sendBuffer ep badge grant receiver receiveBuffer
    \<lbrace>\<lambda>rv. cte_wp_at' (\<lambda>cte. P (cteCap cte)) slot\<rbrace>"
   apply (simp add: doNormalTransfer_def)
-  apply (wp transferCaps_local_slots weak copyMRs_typ_at'[where T=CTET, unfolded typ_at_cte']
-    | simp)+
+  apply (wpsimp wp: transferCaps_local_slots weak)
   done
 
 lemma doIPCTransfer_local_slots:

--- a/proof/crefine/ARM_HYP/Ipc_C.thy
+++ b/proof/crefine/ARM_HYP/Ipc_C.thy
@@ -4404,7 +4404,7 @@ lemma doNormalTransfer_local_slots:
     doNormalTransfer sender sendBuffer ep badge grant receiver receiveBuffer
    \<lbrace>\<lambda>rv. cte_wp_at' (\<lambda>cte. P (cteCap cte)) slot\<rbrace>"
   apply (simp add: doNormalTransfer_def)
-  apply (wp transferCaps_local_slots weak copyMRs_typ_at'[where T=CTET, unfolded typ_at_cte]
+  apply (wp transferCaps_local_slots weak copyMRs_typ_at'[where T=CTET, unfolded typ_at_cte']
     | simp)+
   done
 

--- a/proof/crefine/ARM_HYP/Syscall_C.thy
+++ b/proof/crefine/ARM_HYP/Syscall_C.thy
@@ -674,8 +674,7 @@ lemma sendFaultIPC_ccorres:
               apply (ctac (no_vcg) add: sendIPC_ccorres)
                apply (ctac (no_vcg) add: ccorres_return_CE [unfolded returnOk_def comp_def])
               apply wp
-             apply (wpsimp wp: threadSet_invs_trivial)
-             apply (wpsimp wp: threadSet_pred_tcb_no_state threadSet_typ_at_lifts)
+             apply (wpsimp wp: threadSet_invs_trivial threadSet_pred_tcb_no_state)
 
             apply (clarsimp simp: guard_is_UNIV_def)
             apply (subgoal_tac "capEPBadge epcap && mask 28 = capEPBadge epcap")
@@ -1213,20 +1212,6 @@ lemma option_to_ctcb_ptr_valid_ntfn:
   apply (cases "ntfnBoundTCB ntfn", simp_all add: option_to_ctcb_ptr_def)
   apply (clarsimp simp: valid_ntfn'_def tcb_at_not_NULL)
   done
-
-
-lemma deleteCallerCap_valid_ntfn'[wp]:
-  "\<lbrace>\<lambda>s. valid_ntfn' x s\<rbrace> deleteCallerCap c \<lbrace>\<lambda>rv s. valid_ntfn' x s\<rbrace>"
-  apply (wp hoare_vcg_ex_lift hoare_vcg_all_lift hoare_vcg_ball_lift hoare_vcg_imp_lift
-            | simp add: valid_ntfn'_def split: ntfn.splits)+
-   apply auto
-  done
-
-lemma hoare_vcg_imp_liftE:
-  "\<lbrakk>\<lbrace>P'\<rbrace> f \<lbrace>\<lambda>rv s. \<not> P rv s\<rbrace>, \<lbrace>E\<rbrace>; \<lbrace>Q'\<rbrace> f \<lbrace>Q\<rbrace>, \<lbrace>E\<rbrace>\<rbrakk> \<Longrightarrow>  \<lbrace>\<lambda>s. P' s \<or> Q' s\<rbrace> f \<lbrace>\<lambda>rv s. P rv s \<longrightarrow> Q rv s\<rbrace>, \<lbrace>E\<rbrace>"
-  apply (simp add: validE_def valid_def split_def split: sum.splits)
-  done
-
 
 lemma not_obj_at'_ntfn:
   "(\<not>obj_at' (P::Structures_H.notification \<Rightarrow> bool) t s) = (\<not> typ_at' NotificationT t s \<or> obj_at' (Not \<circ> P) t s)"

--- a/proof/crefine/ARM_HYP/Tcb_C.thy
+++ b/proof/crefine/ARM_HYP/Tcb_C.thy
@@ -429,7 +429,7 @@ lemma setPriority_ccorres:
     apply (simp add: guard_is_UNIV_def)
    apply (rule hoare_strengthen_post[
                  where Q'="\<lambda>rv s.
-                          obj_at' (\<lambda>_. True) t s \<and>
+                          tcb_at' t s \<and>
                           priority \<le> maxPriority \<and>
                           ksCurDomain s \<le> maxDomain \<and>
                           valid_objs' s \<and>

--- a/proof/crefine/Move_C.thy
+++ b/proof/crefine/Move_C.thy
@@ -528,7 +528,7 @@ lemma asUser_mapM_x:
   apply (rule ext)
   apply (rule bind_apply_cong [OF refl])+
   apply (clarsimp simp: in_monad dest!: fst_stateAssertD)
-  apply (drule use_valid, rule mapM_wp', rule asUser_typ_ats, assumption)
+  apply (drule use_valid, rule mapM_wp', rule asUser.gen_typ_ats, assumption)
   apply (simp add: stateAssert_def get_def Nondet_Monad.bind_def)
   done
 

--- a/proof/crefine/RISCV64/Ipc_C.thy
+++ b/proof/crefine/RISCV64/Ipc_C.thy
@@ -634,7 +634,7 @@ lemma handleFaultReply':
                                    asUser_return submonad_asUser.fn_stateAssert
                   | rule monadic_rewrite_bind_tail monadic_rewrite_refl
                          monadic_rewrite_symb_exec_l[OF _ stateAssert_inv]
-                  | wp asUser_typ_ats)+)+
+                  | wp)+)+
        apply (case_tac "msgLength tag < scast n_msgRegisters")
         apply (erule disjE[OF word_less_cases],
                   ( clarsimp simp: n_msgRegisters_def asUser_bind_distrib
@@ -649,7 +649,7 @@ lemma handleFaultReply':
                          monadic_rewrite_symb_exec_l[OF _ stateAssert_inv]
                          monadic_rewrite_threadGet_return
                          monadic_rewrite_getSanitiseRegisterInfo_return
-                  | wp asUser_typ_ats mapM_wp')+)+
+                  | wp mapM_wp')+)+
        apply (simp add: n_msgRegisters_def word_le_nat_alt n_syscallMessage_def
                         linorder_not_less syscallMessage_unfold)
        apply (clarsimp | frule neq0_conv[THEN iffD2, THEN not0_implies_Suc,
@@ -692,7 +692,7 @@ lemma handleFaultReply':
                                monadic_rewrite_threadGet_return
                                monadic_rewrite_getSanitiseRegisterInfo_return
                                monadic_rewrite_getSanitiseRegisterInfo_drop
-                        | wp asUser_typ_ats empty_fail_loadWordUser)+)+
+                        | wp empty_fail_loadWordUser)+)+
        apply (clarsimp simp: upto_enum_word word_le_nat_alt simp del: upt.simps cong: if_weak_cong)
        apply (cut_tac i="unat n" and j="Suc (unat (scast n_syscallMessage :: machine_word))"
                                  and k="Suc msgMaxLength" in upt_add_eq_append')
@@ -4115,8 +4115,7 @@ lemma doNormalTransfer_local_slots:
     doNormalTransfer sender sendBuffer ep badge grant receiver receiveBuffer
    \<lbrace>\<lambda>rv. cte_wp_at' (\<lambda>cte. P (cteCap cte)) slot\<rbrace>"
   apply (simp add: doNormalTransfer_def)
-  apply (wp transferCaps_local_slots weak copyMRs_typ_at'[where T=CTET, unfolded typ_at_cte']
-    | simp)+
+  apply (wpsimp wp: transferCaps_local_slots weak)
   done
 
 lemma doIPCTransfer_local_slots:

--- a/proof/crefine/RISCV64/Ipc_C.thy
+++ b/proof/crefine/RISCV64/Ipc_C.thy
@@ -4115,7 +4115,7 @@ lemma doNormalTransfer_local_slots:
     doNormalTransfer sender sendBuffer ep badge grant receiver receiveBuffer
    \<lbrace>\<lambda>rv. cte_wp_at' (\<lambda>cte. P (cteCap cte)) slot\<rbrace>"
   apply (simp add: doNormalTransfer_def)
-  apply (wp transferCaps_local_slots weak copyMRs_typ_at'[where T=CTET, unfolded typ_at_cte]
+  apply (wp transferCaps_local_slots weak copyMRs_typ_at'[where T=CTET, unfolded typ_at_cte']
     | simp)+
   done
 

--- a/proof/crefine/RISCV64/Syscall_C.thy
+++ b/proof/crefine/RISCV64/Syscall_C.thy
@@ -647,8 +647,7 @@ lemma sendFaultIPC_ccorres:
               apply (ctac (no_vcg) add: sendIPC_ccorres)
                apply (ctac (no_vcg) add: ccorres_return_CE [unfolded returnOk_def comp_def])
               apply wp
-             apply (wpsimp wp: threadSet_invs_trivial)
-             apply (wpsimp wp: threadSet_pred_tcb_no_state threadSet_typ_at_lifts)
+             apply (wpsimp wp: threadSet_invs_trivial threadSet_pred_tcb_no_state)
 
             apply (clarsimp simp: guard_is_UNIV_def)
             apply (subgoal_tac "capEPBadge epcap && mask 64 = capEPBadge epcap")
@@ -1151,20 +1150,6 @@ lemma option_to_ctcb_ptr_valid_ntfn:
   apply (cases "ntfnBoundTCB ntfn", simp_all add: option_to_ctcb_ptr_def)
   apply (clarsimp simp: valid_ntfn'_def tcb_at_not_NULL)
   done
-
-
-lemma deleteCallerCap_valid_ntfn'[wp]:
-  "\<lbrace>\<lambda>s. valid_ntfn' x s\<rbrace> deleteCallerCap c \<lbrace>\<lambda>rv s. valid_ntfn' x s\<rbrace>"
-  apply (wp hoare_vcg_ex_lift hoare_vcg_all_lift hoare_vcg_ball_lift hoare_vcg_imp_lift
-            | simp add: valid_ntfn'_def split: ntfn.splits)+
-   apply auto
-  done
-
-lemma hoare_vcg_imp_liftE:
-  "\<lbrakk>\<lbrace>P'\<rbrace> f \<lbrace>\<lambda>rv s. \<not> P rv s\<rbrace>, \<lbrace>E\<rbrace>; \<lbrace>Q'\<rbrace> f \<lbrace>Q\<rbrace>, \<lbrace>E\<rbrace>\<rbrakk> \<Longrightarrow>  \<lbrace>\<lambda>s. P' s \<or> Q' s\<rbrace> f \<lbrace>\<lambda>rv s. P rv s \<longrightarrow> Q rv s\<rbrace>, \<lbrace>E\<rbrace>"
-  apply (simp add: validE_def valid_def split_def split: sum.splits)
-  done
-
 
 lemma not_obj_at'_ntfn:
   "(\<not>obj_at' (P::Structures_H.notification \<Rightarrow> bool) t s) = (\<not> typ_at' NotificationT t s \<or> obj_at' (Not \<circ> P) t s)"

--- a/proof/crefine/RISCV64/Tcb_C.thy
+++ b/proof/crefine/RISCV64/Tcb_C.thy
@@ -430,7 +430,7 @@ lemma setPriority_ccorres:
     apply (simp add: guard_is_UNIV_def)
    apply (rule hoare_strengthen_post[
                  where Q'="\<lambda>rv s.
-                          obj_at' (\<lambda>_. True) t s \<and>
+                          tcb_at' t s \<and>
                           priority \<le> maxPriority \<and>
                           ksCurDomain s \<le> maxDomain \<and>
                           valid_objs' s \<and>

--- a/proof/crefine/X64/Ipc_C.thy
+++ b/proof/crefine/X64/Ipc_C.thy
@@ -634,7 +634,7 @@ lemma handleFaultReply':
                                    asUser_return submonad_asUser.fn_stateAssert
                   | rule monadic_rewrite_bind_tail monadic_rewrite_refl
                          monadic_rewrite_symb_exec_l[OF _ stateAssert_inv]
-                  | wp asUser_typ_ats)+)+
+                  | wp)+)+
        apply (case_tac "msgLength tag < scast n_msgRegisters")
         apply (erule disjE[OF word_less_cases],
                   ( clarsimp simp: n_msgRegisters_def asUser_bind_distrib
@@ -649,7 +649,7 @@ lemma handleFaultReply':
                          monadic_rewrite_symb_exec_l[OF _ stateAssert_inv]
                          monadic_rewrite_threadGet_return
                          monadic_rewrite_getSanitiseRegisterInfo_return
-                  | wp asUser_typ_ats mapM_wp')+)+
+                  | wp mapM_wp')+)+
        apply (simp add: n_msgRegisters_def word_le_nat_alt n_syscallMessage_def
                         linorder_not_less syscallMessage_unfold)
        apply (clarsimp | frule neq0_conv[THEN iffD2, THEN not0_implies_Suc,
@@ -692,7 +692,7 @@ lemma handleFaultReply':
                                monadic_rewrite_threadGet_return
                                monadic_rewrite_getSanitiseRegisterInfo_return
                                monadic_rewrite_getSanitiseRegisterInfo_drop
-                        | wp asUser_typ_ats empty_fail_loadWordUser)+)+
+                        | wp empty_fail_loadWordUser)+)+
        apply (clarsimp simp: upto_enum_word word_le_nat_alt simp del: upt.simps cong: if_weak_cong)
        apply (cut_tac i="unat n" and j="Suc (unat (scast n_syscallMessage :: machine_word))"
                                  and k="Suc msgMaxLength" in upt_add_eq_append')
@@ -4123,8 +4123,7 @@ lemma doNormalTransfer_local_slots:
     doNormalTransfer sender sendBuffer ep badge grant receiver receiveBuffer
    \<lbrace>\<lambda>rv. cte_wp_at' (\<lambda>cte. P (cteCap cte)) slot\<rbrace>"
   apply (simp add: doNormalTransfer_def)
-  apply (wp transferCaps_local_slots weak copyMRs_typ_at'[where T=CTET, unfolded typ_at_cte']
-    | simp)+
+  apply (wpsimp wp: transferCaps_local_slots weak)
   done
 
 lemma doIPCTransfer_local_slots:

--- a/proof/crefine/X64/Ipc_C.thy
+++ b/proof/crefine/X64/Ipc_C.thy
@@ -4123,7 +4123,7 @@ lemma doNormalTransfer_local_slots:
     doNormalTransfer sender sendBuffer ep badge grant receiver receiveBuffer
    \<lbrace>\<lambda>rv. cte_wp_at' (\<lambda>cte. P (cteCap cte)) slot\<rbrace>"
   apply (simp add: doNormalTransfer_def)
-  apply (wp transferCaps_local_slots weak copyMRs_typ_at'[where T=CTET, unfolded typ_at_cte]
+  apply (wp transferCaps_local_slots weak copyMRs_typ_at'[where T=CTET, unfolded typ_at_cte']
     | simp)+
   done
 

--- a/proof/crefine/X64/Syscall_C.thy
+++ b/proof/crefine/X64/Syscall_C.thy
@@ -644,8 +644,7 @@ lemma sendFaultIPC_ccorres:
               apply (ctac (no_vcg) add: sendIPC_ccorres)
                apply (ctac (no_vcg) add: ccorres_return_CE [unfolded returnOk_def comp_def])
               apply wp
-             apply (wpsimp wp: threadSet_invs_trivial)
-             apply (wpsimp wp: threadSet_pred_tcb_no_state threadSet_typ_at_lifts)
+             apply (wpsimp wp: threadSet_invs_trivial threadSet_pred_tcb_no_state)
 
             apply (clarsimp simp: guard_is_UNIV_def)
             apply (subgoal_tac "capEPBadge epcap && mask 64 = capEPBadge epcap")
@@ -1149,20 +1148,6 @@ lemma option_to_ctcb_ptr_valid_ntfn:
   apply (cases "ntfnBoundTCB ntfn", simp_all add: option_to_ctcb_ptr_def)
   apply (clarsimp simp: valid_ntfn'_def tcb_at_not_NULL)
   done
-
-
-lemma deleteCallerCap_valid_ntfn'[wp]:
-  "\<lbrace>\<lambda>s. valid_ntfn' x s\<rbrace> deleteCallerCap c \<lbrace>\<lambda>rv s. valid_ntfn' x s\<rbrace>"
-  apply (wp hoare_vcg_ex_lift hoare_vcg_all_lift hoare_vcg_ball_lift hoare_vcg_imp_lift
-            | simp add: valid_ntfn'_def split: ntfn.splits)+
-   apply auto
-  done
-
-lemma hoare_vcg_imp_liftE:
-  "\<lbrakk>\<lbrace>P'\<rbrace> f \<lbrace>\<lambda>rv s. \<not> P rv s\<rbrace>, \<lbrace>E\<rbrace>; \<lbrace>Q'\<rbrace> f \<lbrace>Q\<rbrace>, \<lbrace>E\<rbrace>\<rbrakk> \<Longrightarrow>  \<lbrace>\<lambda>s. P' s \<or> Q' s\<rbrace> f \<lbrace>\<lambda>rv s. P rv s \<longrightarrow> Q rv s\<rbrace>, \<lbrace>E\<rbrace>"
-  apply (simp add: validE_def valid_def split_def split: sum.splits)
-  done
-
 
 lemma not_obj_at'_ntfn:
   "(\<not>obj_at' (P::Structures_H.notification \<Rightarrow> bool) t s) = (\<not> typ_at' NotificationT t s \<or> obj_at' (Not \<circ> P) t s)"

--- a/proof/crefine/X64/Tcb_C.thy
+++ b/proof/crefine/X64/Tcb_C.thy
@@ -429,7 +429,7 @@ lemma setPriority_ccorres:
     apply (simp add: guard_is_UNIV_def)
    apply (rule hoare_strengthen_post[
                  where Q'="\<lambda>rv s.
-                          obj_at' (\<lambda>_. True) t s \<and>
+                          tcb_at' t s \<and>
                           priority \<le> maxPriority \<and>
                           ksCurDomain s \<le> maxDomain \<and>
                           valid_objs' s \<and>

--- a/proof/refine/AARCH64/ArchArchAcc_R.thy
+++ b/proof/refine/AARCH64/ArchArchAcc_R.thy
@@ -888,15 +888,9 @@ qed
 
 crunch storePTE
   for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  (wp: crunch_wps mapM_x_wp' simp: crunch_simps ignore_del: setObject)
 
-lemmas storePTE_typ_ats[wp] = typ_at_lifts [OF storePTE_typ_at']
-
-lemma setObject_asid_typ_at' [wp]:
-  "\<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace> setObject p' (v::asidpool) \<lbrace>\<lambda>_ s. P (typ_at' T p s)\<rbrace>"
-  by (rule setObject_typ_at')
-
-lemmas setObject_asid_typ_ats'[wp] = typ_at_lifts [OF setObject_asid_typ_at']
+sublocale storePTE: typ_at_props' "storePTE slot pte"
+  by typ_at_props'
 
 lemma getObject_pte_inv[wp]:
   "\<lbrace>P\<rbrace> getObject p \<lbrace>\<lambda>rv :: pte. P\<rbrace>"

--- a/proof/refine/AARCH64/ArchCNodeInv_R.thy
+++ b/proof/refine/AARCH64/ArchCNodeInv_R.thy
@@ -532,4 +532,23 @@ proof goal_cases
   case 1 show ?case by (intro_locales; (unfold_locales; (fact CNodeInv_R_assms)?)?)
 qed
 
+context Arch begin arch_global_naming
+
+sublocale cteDelete: typ_at_props' "cteDelete slot exposed"
+  by typ_at_props'
+
+sublocale reduceZombie: typ_at_props' "reduceZombie cap slot x"
+  by typ_at_props'
+
+sublocale finaliseSlot: typ_at_props' "finaliseSlot ptr exposed"
+  by typ_at_props'
+
+sublocale invokeCNode: typ_at_props' "invokeCNode i"
+  by typ_at_props'
+
+sublocale cteMove: typ_at_props' "cteMove cap src dest"
+  by typ_at_props'
+
+end  (* Arch *)
+
 end

--- a/proof/refine/AARCH64/ArchCSpace1_R.thy
+++ b/proof/refine/AARCH64/ArchCSpace1_R.thy
@@ -246,7 +246,8 @@ proof -
   done
 qed
 
-lemmas setCTE_typ_ats[wp] = typ_at_lifts[OF setCTE_typ_at']
+sublocale setCTE: typ_at_props' "setCTE c cte"
+  by typ_at_props'
 
 lemma arch_updateCapData_Master[CSpace1_R_assms]:
   "Arch.updateCapData P d acap \<noteq> NullCap \<Longrightarrow>

--- a/proof/refine/AARCH64/ArchCSpace_R.thy
+++ b/proof/refine/AARCH64/ArchCSpace_R.thy
@@ -33,9 +33,14 @@ lemma capAligned_master[CSpace_R_assms]:
    apply (clarsimp simp: capAligned_def)+
   done
 
-lemmas updateMDB_typ_ats[wp] = typ_at_lifts[OF updateMDB_typ_at']
-lemmas updateCap_typ_ats[wp] = typ_at_lifts[OF updateCap_typ_at']
-lemmas cteInsert_typ_ats[wp] = typ_at_lifts[OF cteInsert_typ_at']
+sublocale updateMDB: typ_at_props' "updateMDB slot f"
+  by typ_at_props'
+
+sublocale updateCap: typ_at_props' "updateCap slot newCap"
+  by typ_at_props'
+
+sublocale cteInsert: typ_at_props' "cteInsert newCap srcSlot destSlot"
+  by typ_at_props'
 
 lemma maskedAsFull_derived'[CSpace_R_assms]:
   "\<lbrakk>m src = Some (CTE s_cap s_node); is_derived' m ptr b c\<rbrakk>

--- a/proof/refine/AARCH64/ArchFinalise_R.thy
+++ b/proof/refine/AARCH64/ArchFinalise_R.thy
@@ -23,7 +23,8 @@ lemma arch_postCapDeletion_ksArchState_lift[Finalise_R_assms]:
   unfolding postCapDeletion_def
   by wpsimp
 
-lemmas clearUntypedFreeIndex_typ_ats[wp] = typ_at_lifts[OF clearUntypedFreeIndex_typ_at']
+sublocale clearUntypedFreeIndex: typ_at_props' "clearUntypedFreeIndex slot"
+  by typ_at_props'
 
 crunch setIRQState
   for umm[Finalise_R_assms, wp]: "\<lambda>s. P (underlying_memory (ksMachineState s))"
@@ -613,11 +614,23 @@ lemma isFinal_no_descendants[Finalise_R_2_assms]:
   apply (simp add: valid_mdb'_def)
   done
 
-lemmas cancelAllIPC_typs[wp] = typ_at_lifts[OF cancelAllIPC_typ_at']
-lemmas cancelAllSignals_typs[wp] = typ_at_lifts[OF cancelAllSignals_typ_at']
-lemmas suspend_typs[wp] = typ_at_lifts[OF suspend_typ_at']
+sublocale cancelIPC: typ_at_props' "cancelIPC tptr"
+  by typ_at_props'
 
-lemmas finaliseCap_typ_ats[wp] = typ_at_lifts[OF finaliseCap_typ_at']
+sublocale cancelAllIPC: typ_at_props' "cancelAllIPC epptr"
+  by typ_at_props'
+
+sublocale cancelAllSignals: typ_at_props' "cancelAllSignals ntfnPtr"
+  by typ_at_props'
+
+sublocale suspend: typ_at_props' "suspend target"
+  by typ_at_props'
+
+sublocale finaliseCap: typ_at_props' "finaliseCap cap final x"
+  by typ_at_props'
+
+sublocale unbindNotification: typ_at_props' "unbindNotification tcb"
+  by typ_at_props'
 
 lemma invalidateASIDEntry_invs'[wp]:
   "invalidateASIDEntry asid \<lbrace>invs'\<rbrace>"
@@ -655,7 +668,8 @@ lemma deleteASID_invs'[wp]:
   unfolding deleteASID_def
   by (wpsimp wp: getASID_wp hoare_drop_imps simp: getPoolPtr_def)
 
-lemmas archThreadSet_typ_ats[wp] = typ_at_lifts[OF archThreadSet_typ_at']
+sublocale archThreadSet: typ_at_props' "archThreadSet f tptr"
+  by typ_at_props'
 
 lemma archThreadSet_valid_objs'[wp]:
   "\<lbrace>valid_objs' and (\<lambda>s. \<forall>tcb. ko_at' tcb t s \<longrightarrow> valid_arch_tcb' (f (tcbArch tcb)) s)\<rbrace>
@@ -1023,7 +1037,8 @@ lemma dissociateVCPUTCB_cte_wp_at'[wp]:
   "dissociateVCPUTCB v t \<lbrace>cte_wp_at' P p\<rbrace>"
   unfolding cte_wp_at_ctes_of by wp
 
-lemmas dissociateVCPUTCB_typ_ats'[wp] = typ_at_lifts[OF dissociateVCPUTCB_typ_at']
+sublocale dissociateVCPUTCB: typ_at_props' "dissociateVCPUTCB v t"
+  by typ_at_props'
 
 crunch Arch.finaliseCap, prepareThreadDelete
   for irq_node'[Finalise_R_2_assms, wp]: "\<lambda>s. P (irq_node' s)"
@@ -1425,7 +1440,8 @@ lemma arch_finaliseCap_corres[Finalise_R_3_assms]:
   apply fastforce
   done
 
-lemmas deleteCallerCap_typ_ats[wp] = typ_at_lifts[OF deleteCallerCap_typ_at']
+sublocale deleteCallerCap: typ_at_props' "deleteCallerCap receiver"
+  by typ_at_props'
 
 end (* Arch *)
 

--- a/proof/refine/AARCH64/ArchInvsLemmas_H.thy
+++ b/proof/refine/AARCH64/ArchInvsLemmas_H.thy
@@ -479,6 +479,25 @@ lemmas typ_at_lifts = gen_typ_at_lifts typ_at_lifts_strong_internal
 
 end
 
+end (* Arch *)
+
+locale typ_at_props' = Arch +
+  fixes f :: "_ kernel"
+  assumes typ': "f \<lbrace>\<lambda>s. P (typ_at' T p' s)\<rbrace>"
+begin
+
+lemmas typ_ats[wp] = typ_at_lifts[REPEAT [OF typ']]
+
+context begin
+(* We want to enforce that typ_ats only contains lemmas that have no
+   assumptions. The following thm statement should fail if this is not true. *)
+private lemmas check_valid_internal = iffD1[OF refl, where P="valid p g q" for p g q]
+thm typ_ats[atomized, THEN check_valid_internal]
+end
+
+end (* typ_at_props' *)
+
+context Arch begin arch_global_naming
 
 lemma valid_arch_state_armKSGlobalUserVSpace:
   "valid_arch_state' s \<Longrightarrow> canonical_address (addrFromKPPtr (armKSGlobalUserVSpace (ksArchState s)))"

--- a/proof/refine/AARCH64/ArchInvsLemmas_H.thy
+++ b/proof/refine/AARCH64/ArchInvsLemmas_H.thy
@@ -395,62 +395,90 @@ lemma is_physical_cases:
              | _                                \<Rightarrow> True)"
   by (simp split: capability.splits arch_capability.splits zombie_type.splits)
 
-lemma typ_at_lift_page_table_at':
-  assumes x: "\<And>T p. f \<lbrace>typ_at' T p\<rbrace>"
-  shows "f \<lbrace>page_table_at' pt_t p\<rbrace>"
+named_theorems Invariants_H_typ_at_lifts_assms
+
+lemma page_table_at'_typ_at_lift_strong:
+  "(\<And>p. f \<lbrace>\<lambda>s. P (typ_at' (ArchT PTET) p s)\<rbrace>) \<Longrightarrow> f \<lbrace>\<lambda>s. P (page_table_at' pt_t p s)\<rbrace>"
   unfolding page_table_at'_def
-  by (wpsimp wp: hoare_vcg_all_lift hoare_vcg_imp_lift' x)
+  apply (rule bool_to_bool_cases[where f=P]; clarsimp)
+  apply (wpsimp wp: hoare_vcg_const_Ball_lift hoare_vcg_imp_lift
+                    hoare_vcg_all_lift hoare_vcg_ex_lift
+         | assumption)+
+  done
 
-lemma typ_at_lift_asid_at':
-  "(\<And>T p. \<lbrace>typ_at' T p\<rbrace> f \<lbrace>\<lambda>_. typ_at' T p\<rbrace>) \<Longrightarrow> \<lbrace>asid_pool_at' p\<rbrace> f \<lbrace>\<lambda>_. asid_pool_at' p\<rbrace>"
-  by assumption
-
-lemma typ_at_lift_vcpu_at':
-  "(\<And>T p. \<lbrace>typ_at' T p\<rbrace> f \<lbrace>\<lambda>_. typ_at' T p\<rbrace>) \<Longrightarrow> \<lbrace>vcpu_at' p\<rbrace> f \<lbrace>\<lambda>_. vcpu_at' p\<rbrace>"
-  by assumption
-
-lemma typ_at_lift_frame_at':
-  assumes "\<And>T p. f \<lbrace>typ_at' T p\<rbrace>"
-  shows "f \<lbrace>frame_at' p sz d\<rbrace>"
+lemma frame_at'_typ_at_lift_strong:
+  "\<lbrakk>\<And>T p. f \<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace>\<rbrakk> \<Longrightarrow> f \<lbrace>\<lambda>s. P (frame_at' p sz d s)\<rbrace>"
+  supply if_split[split del]
   unfolding frame_at'_def
-  by (wpsimp wp: hoare_vcg_all_lift hoare_vcg_const_imp_lift assms split_del: if_split)
-
-lemma typ_at_lift_valid_cap':
-  assumes P: "\<And>P T p. \<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace> f \<lbrace>\<lambda>rv s. P (typ_at' T p s)\<rbrace>"
-  shows      "\<lbrace>\<lambda>s. valid_cap' cap s\<rbrace> f \<lbrace>\<lambda>rv s. valid_cap' cap s\<rbrace>"
-  including no_pre
-  apply (simp add: valid_cap'_def)
-  apply wp
-  apply (case_tac cap;
-         simp add: valid_cap'_def P[of id, simplified] typ_at_lift_tcb'
-                   hoare_vcg_prop typ_at_lift_ep'
-                   typ_at_lift_ntfn' typ_at_lift_cte_at'
-                   hoare_vcg_conj_lift [OF typ_at_lift_cte_at'])
-     apply (rename_tac zombie_type nat)
-     apply (case_tac zombie_type; simp)
-      apply (wp typ_at_lift_tcb' P hoare_vcg_all_lift typ_at_lift_cte')+
-    apply (rename_tac arch_capability)
-    apply (case_tac arch_capability,
-           simp_all add: P[of id, simplified] vspace_table_at'_defs
-                         hoare_vcg_prop All_less_Ball
-                    split del: if_split)
-       apply (wp hoare_vcg_const_Ball_lift P typ_at_lift_valid_untyped'
-                 hoare_vcg_all_lift typ_at_lift_cte' typ_at_lift_frame_at')+
+  apply (rule bool_to_bool_cases[where f=P]; clarsimp)
+   apply (wpsimp wp: hoare_vcg_all_lift hoare_vcg_const_imp_lift hoare_vcg_ex_lift
+          | assumption)+
   done
 
-(* interface lemma *)
-lemma valid_arch_tcb_lift':
-  assumes x: "\<And>T p. \<lbrace>typ_at' T p\<rbrace> f \<lbrace>\<lambda>rv. typ_at' T p\<rbrace>"
-  shows "\<lbrace>\<lambda>s. valid_arch_tcb' tcb s\<rbrace> f \<lbrace>\<lambda>rv s. valid_arch_tcb' tcb s\<rbrace>"
-  apply (clarsimp simp add: valid_arch_tcb'_def)
-  apply (cases "atcbVCPUPtr tcb"; simp)
-   apply (wp x)+
+lemma asid_pool_at'_typ_at_lift_strong:
+  "(\<And>T p. f \<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace>) \<Longrightarrow> f \<lbrace>\<lambda>s. P (asid_pool_at' p s)\<rbrace>"
+  by assumption
+
+lemma vcpu_at'_typ_at_lift_strong:
+  "(\<And>T p. f \<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace>) \<Longrightarrow> f \<lbrace>\<lambda>s. P (vcpu_at' p s)\<rbrace>"
+  by assumption
+
+lemma valid_arch_tcb'_typ_at_lift_strong[Invariants_H_typ_at_lifts_assms]:
+  "(\<And>T p. f \<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace>) \<Longrightarrow> f \<lbrace>\<lambda>s. P (valid_arch_tcb' tcb s)\<rbrace>"
+  unfolding valid_arch_tcb'_def
+  apply (rule bool_to_bool_cases[where f=P]; clarsimp)
+  apply (wpsimp wp: hoare_vcg_imp_lift hoare_vcg_all_lift hoare_vcg_ex_lift
+         | assumption)+
   done
 
-lemmas typ_at_lifts =
-           typ_at_lift_tcb' typ_at_lift_ep' typ_at_lift_ntfn' typ_at_lift_cte' typ_at_lift_cte_at'
-           typ_at_lift_valid_untyped' typ_at_lift_valid_cap' valid_bound_tcb_lift
-           typ_at_lift_page_table_at' typ_at_lift_asid_at' typ_at_lift_vcpu_at'
+lemma valid_arch_cap'_typ_at_lift[Invariants_H_typ_at_lifts_assms]:
+  assumes P: "\<And>P T p. f \<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace>"
+  shows      "f \<lbrace>\<lambda>s. valid_arch_cap' cap s\<rbrace>"
+  apply (case_tac cap,
+         simp_all add: P[where P=id, simplified] All_less_Ball
+            split del: if_split)
+    apply (wp hoare_vcg_const_Ball_lift P
+              page_table_at'_typ_at_lift_strong frame_at'_typ_at_lift_strong)+
+  done
+
+end (* Arch *)
+
+global_interpretation Invariants_H_typ_at_lifts?: Invariants_H_typ_at_lifts
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case by (intro_locales; unfold_locales; (fact Invariants_H_typ_at_lifts_assms)?)
+qed
+
+context Arch begin arch_global_naming
+
+lemmas typ_at_lifts_strong =
+  gen_typ_at_lifts_strong
+  page_table_at'_typ_at_lift_strong
+  frame_at'_typ_at_lift_strong
+  asid_pool_at'_typ_at_lift_strong
+  vcpu_at'_typ_at_lift_strong
+
+context begin
+
+\<comment>\<open> See the comment above @{ML weaken_typ_at_lifts_thms} for an explanation of what
+    this @{command ML_goal} is for. Here we are constructing the combined list of
+    both generic and arch-specific typ_at_lifts lemmas.\<close>
+ML \<open>
+local
+  val strong_thms = subtract Thm.eq_thm gen_strong_thms @{thms typ_at_lifts_strong[no_vars]};
+in
+  val typ_at_lifts_internal_goals = weaken_typ_at_lifts_thms strong_thms
+end
+\<close>
+
+private ML_goal typ_at_lifts_strong_internal:
+  \<open>typ_at_lifts_internal_goals\<close>
+  by (auto simp: typ_at_lifts_strong)
+
+lemmas typ_at_lifts = gen_typ_at_lifts typ_at_lifts_strong_internal
+
+end
+
 
 lemma valid_arch_state_armKSGlobalUserVSpace:
   "valid_arch_state' s \<Longrightarrow> canonical_address (addrFromKPPtr (armKSGlobalUserVSpace (ksArchState s)))"

--- a/proof/refine/AARCH64/ArchIpc_R.thy
+++ b/proof/refine/AARCH64/ArchIpc_R.thy
@@ -260,6 +260,33 @@ lemma is_derived_mask'[simp]:
   "is_derived' m p (maskCapRights R c) = is_derived' m p c"
   by (rule ext, simp add: is_derived'_def badge_derived'_def)
 
+sublocale setExtraBadge: typ_at_props' "setExtraBadge buffer badge n"
+  by typ_at_props'
+
+sublocale transferCaps: typ_at_props' "transferCaps info caps endpoint receiver receiveBuffer"
+  by typ_at_props'
+
+sublocale copyMRs: typ_at_props' "copyMRs s sb r rb n"
+  by typ_at_props'
+
+sublocale doNormalTransfer: typ_at_props' "doNormalTransfer s sb e b g r rb"
+  by typ_at_props'
+
+sublocale doIPCTransfer: typ_at_props' "doIPCTransfer s e b g r"
+  by typ_at_props'
+
+sublocale handleFaultReply: typ_at_props' "handleFaultReply x t l m"
+  by typ_at_props'
+
+sublocale sendFaultIPC: typ_at_props' "sendFaultIPC tptr fault"
+  by typ_at_props'
+
+sublocale receiveIPC: typ_at_props' "receiveIPC t cap b"
+  by typ_at_props'
+
+sublocale receiveSignal: typ_at_props' "receiveSignal t cap b"
+  by typ_at_props'
+
 end (* Arch *)
 
 end

--- a/proof/refine/AARCH64/ArchKHeap_R.thy
+++ b/proof/refine/AARCH64/ArchKHeap_R.thy
@@ -464,11 +464,14 @@ lemma setObject_ko_wp_at':
 
 lemmas [KHeap_R_assms_2] = setEndpoint_valid_arch' setNotification_valid_arch'
 
-lemmas setObject_typ_ats[wp] = typ_at_lifts[OF setObject_typ_at']
+sublocale setObject: typ_at_props' "setObject p v"
+  by typ_at_props'
 
-lemmas doMachineOp_typ_ats[wp] = typ_at_lifts[OF doMachineOp_typ_at']
+sublocale doMachineOp: typ_at_props' "doMachineOp mop"
+  by typ_at_props'
 
-lemmas setEndpoint_typ_ats[wp] = typ_at_lifts[OF setEndpoint_typ_at']
+sublocale setEndpoint: typ_at_props' "setEndpoint ptr val"
+  by typ_at_props'
 
 end
 

--- a/proof/refine/AARCH64/ArchRetype_R.thy
+++ b/proof/refine/AARCH64/ArchRetype_R.thy
@@ -320,7 +320,7 @@ proof -
 
            apply (in_case "HugePageObject")
            apply (subst doMachineOp_mapM_x[unfolded o_def, simplified, symmetric], simp)
-           apply (wp hoare_vcg_op_lift doMachineOp_typ_ats)
+           apply (wp hoare_vcg_op_lift)
             apply (simp add: valid_cap'_def capAligned_def n_less_word_bits ball_conj_distrib)
             apply (wp createObjects_aligned2 createObjects_nonzero'
                       cwo_ret'[where bs="2 * ptTranslationBits NormalPT_T", simplified]
@@ -329,7 +329,7 @@ proof -
 
           apply (in_case "VSpaceObject")
           apply (subst doMachineOp_mapM_x[unfolded o_def, simplified, symmetric], simp)
-          apply (wp hoare_vcg_op_lift doMachineOp_typ_ats)
+          apply (wp hoare_vcg_op_lift)
            apply (simp add: valid_cap'_def capAligned_def n_less_word_bits)
            apply (rule hoare_chain)
              apply (rule hoare_vcg_conj_lift)
@@ -351,7 +351,7 @@ proof -
 
          apply (in_case "SmallPageObject")
          apply (subst doMachineOp_mapM_x[unfolded o_def, simplified, symmetric], simp)
-         apply (wp hoare_vcg_op_lift doMachineOp_typ_ats)
+         apply (wp hoare_vcg_op_lift)
           apply (simp add: valid_cap'_def capAligned_def n_less_word_bits ball_conj_distrib)
           apply (wp createObjects_aligned2 createObjects_nonzero'
                     cwo_ret'[where bs=0, simplified]
@@ -360,7 +360,7 @@ proof -
 
         apply (in_case \<open>LargePageObject\<close>)
         apply (subst doMachineOp_mapM_x[unfolded o_def, simplified, symmetric], simp)
-        apply (wp hoare_vcg_op_lift doMachineOp_typ_ats)
+        apply (wp hoare_vcg_op_lift)
          apply (simp add: valid_cap'_def capAligned_def n_less_word_bits ball_conj_distrib)
          apply (wp createObjects_aligned2 createObjects_nonzero'
                    cwo_ret'[where bs="ptTranslationBits NormalPT_T", simplified]
@@ -369,7 +369,7 @@ proof -
 
        apply (in_case \<open>PageTableObject\<close>)
        apply (subst doMachineOp_mapM_x[unfolded o_def, simplified, symmetric], simp)
-       apply (wp hoare_vcg_op_lift doMachineOp_typ_ats)
+       apply (wp hoare_vcg_op_lift)
         apply (simp add: valid_cap'_def capAligned_def n_less_word_bits)
         apply (rule hoare_chain)
           apply (rule hoare_vcg_conj_lift)

--- a/proof/refine/AARCH64/ArchSchedule_R.thy
+++ b/proof/refine/AARCH64/ArchSchedule_R.thy
@@ -205,13 +205,15 @@ crunch vcpuEnable, vcpuDisable, vcpuSave, vcpuRestore, lazyFpuRestore
   (simp: crunch_simps
      wp: crunch_wps getObject_inv loadObject_default_inv)
 
+lemmas lazyFpuRestore_typ_ats[wp] = typ_at_lifts[OF lazyFpuRestore_typ_at']
+
 lemma vcpuSwitch_typ_at'[wp]:
   "\<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace> vcpuSwitch param_a \<lbrace>\<lambda>_ s. P (typ_at' T p s) \<rbrace>"
   by (wpsimp simp: vcpuSwitch_def modifyArchState_def | assumption)+
 
 lemma arch_switch_thread_tcb_at'[wp]:
   "\<lbrace>tcb_at' t\<rbrace> Arch.switchToThread t \<lbrace>\<lambda>_. tcb_at' t\<rbrace>"
-  by (unfold AARCH64_H.switchToThread_def, wp typ_at_lift_tcb')
+  by (unfold AARCH64_H.switchToThread_def, wp)
 
 lemma updateASIDPoolEntry_pred_tcb_at'[wp]:
   "updateASIDPoolEntry f asid \<lbrace>pred_tcb_at' proj P t'\<rbrace>"
@@ -228,6 +230,8 @@ crunch setVMRoot, vcpuSwitch, lazyFpuRestore
 
 crunch Arch.switchToThread
   for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
+
+lemmas saveFpuState_typ_ats[wp] = typ_at_lifts[OF saveFpuState_typ_at']
 
 lemma Arch_switchToThread_pred_tcb'[wp]:
   "Arch.switchToThread t \<lbrace>\<lambda>s. P (pred_tcb_at' proj P' t' s)\<rbrace>"
@@ -346,7 +350,7 @@ crunch loadFpuState, saveFpuState
 lemma switchLocalFpuOwner_invs[wp]:
   "\<lbrace>invs' and opt_tcb_at' newOwner\<rbrace> switchLocalFpuOwner newOwner \<lbrace>\<lambda>_. invs'\<rbrace>"
   unfolding switchLocalFpuOwner_def
-  by (wpsimp wp: hoare_vcg_all_lift hoare_vcg_imp_lift' typ_at_lifts simp: fpuOwner_asrt_def)
+  by (wpsimp wp: hoare_vcg_all_lift hoare_vcg_imp_lift' simp: fpuOwner_asrt_def)
 
 lemma lazyFpuRestore_invs[wp]:
   "\<lbrace>invs' and tcb_at' t\<rbrace> lazyFpuRestore t \<lbrace>\<lambda>_. invs'\<rbrace>"

--- a/proof/refine/AARCH64/ArchSchedule_R.thy
+++ b/proof/refine/AARCH64/ArchSchedule_R.thy
@@ -200,12 +200,16 @@ crunch tcbSchedAppend, tcbSchedDequeue, tcbSchedEnqueue
   for state_hyp_refs_of'[Schedule_R_assms, wp]: "\<lambda>s. P (state_hyp_refs_of' s)"
   (simp: unless_def crunch_simps obj_at'_def wp: getObject_tcb_wp)
 
-crunch vcpuEnable, vcpuDisable, vcpuSave, vcpuRestore, lazyFpuRestore
+crunch vcpuEnable, vcpuDisable, vcpuSave, vcpuRestore, lazyFpuRestore, saveFpuState
   for typ_at' [wp]: "\<lambda>s. P (typ_at' T p s)"
   (simp: crunch_simps
      wp: crunch_wps getObject_inv loadObject_default_inv)
 
-lemmas lazyFpuRestore_typ_ats[wp] = typ_at_lifts[OF lazyFpuRestore_typ_at']
+sublocale lazyFpuRestore: typ_at_props' "lazyFpuRestore t"
+  by typ_at_props'
+
+sublocale saveFpuState: typ_at_props' "saveFpuState t"
+  by typ_at_props'
 
 lemma vcpuSwitch_typ_at'[wp]:
   "\<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace> vcpuSwitch param_a \<lbrace>\<lambda>_ s. P (typ_at' T p s) \<rbrace>"
@@ -230,8 +234,6 @@ crunch setVMRoot, vcpuSwitch, lazyFpuRestore
 
 crunch Arch.switchToThread
   for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-
-lemmas saveFpuState_typ_ats[wp] = typ_at_lifts[OF saveFpuState_typ_at']
 
 lemma Arch_switchToThread_pred_tcb'[wp]:
   "Arch.switchToThread t \<lbrace>\<lambda>s. P (pred_tcb_at' proj P' t' s)\<rbrace>"

--- a/proof/refine/AARCH64/ArchTcbAcc_R.thy
+++ b/proof/refine/AARCH64/ArchTcbAcc_R.thy
@@ -197,7 +197,8 @@ lemma threadSet_iflive'T[TcbAcc_R_assms]:
   apply (clarsimp simp: bspec_split [OF spec [OF x]])
   done
 
-lemmas threadSet_typ_at_lifts[wp] = typ_at_lifts[OF threadSet_typ_at']
+sublocale threadSet: typ_at_props' "threadSet tptr f"
+  by typ_at_props'
 
 lemma zobj_refs'_capRange[TcbAcc_R_assms]:
   "s \<turnstile>' cap \<Longrightarrow> zobj_refs' cap \<subseteq> capRange cap"
@@ -228,8 +229,11 @@ lemma asUser_valid_tcbs'[wp]:
               simp: valid_tcb'_def valid_arch_tcb'_def tcb_cte_cases_def objBits_simps')
   done
 
-lemmas addToBitmap_typ_ats[wp] = typ_at_lifts[OF addToBitmap_typ_at']
-lemmas removeFromBitmap_typ_ats[wp] = typ_at_lifts[OF removeFromBitmap_typ_at']
+sublocale addToBitmap: typ_at_props' "addToBitmap tdom prio"
+  by typ_at_props'
+
+sublocale removeFromBitmap: typ_at_props' "removeFromBitmap tdom prio"
+  by typ_at_props'
 
 crunch tcbQueueRemove, tcbQueuePrepend, tcbQueueAppend, tcbQueueInsert,
          setQueue, removeFromBitmap
@@ -347,7 +351,8 @@ context Arch begin arch_global_naming
 
 named_theorems TcbAcc_R_2_assms
 
-lemmas asUser_typ_ats[wp] = typ_at_lifts[OF asUser_typ_at']
+sublocale asUser: typ_at_props' "asUser tptr f"
+  by typ_at_props'
 
 lemma tcb_hyp_refs'_valid_arch_tcb'_eq[TcbAcc_R_2_assms]:
   "tcb_hyp_refs' (tcbArch (F tcb)) = tcb_hyp_refs' (tcbArch tcb)
@@ -877,8 +882,17 @@ lemma set_mrs_invs'[TcbAcc_R_3_assms, wp]:
          simp add: zipWithM_x_mapM split_def)+
   done
 
-lemmas setThreadState_typ_ats[wp] = typ_at_lifts [OF setThreadState_typ_at']
-lemmas setBoundNotification_typ_ats[wp] = typ_at_lifts [OF setBoundNotification_typ_at']
+sublocale rescheduleRequired: typ_at_props' "rescheduleRequired"
+  by typ_at_props'
+
+sublocale tcbSchedDequeue: typ_at_props' "tcbSchedDequeue thread"
+  by typ_at_props'
+
+sublocale setThreadState: typ_at_props' "setThreadState st p"
+  by typ_at_props'
+
+sublocale setBoundNotification: typ_at_props' "setBoundNotification v p"
+  by typ_at_props'
 
 end (* Arch *)
 

--- a/proof/refine/AARCH64/ArchTcb_R.thy
+++ b/proof/refine/AARCH64/ArchTcb_R.thy
@@ -39,6 +39,12 @@ lemma asUser_postModifyRegisters_corres[Tcb_R_assms]:
    use this as interface, but keep original lemma name for use outside of Arch *)
 lemmas threadSet_state_hyp_refs_of'_interface[Tcb_R_assms] = threadSet_state_hyp_refs_of'
 
+sublocale setPriority: typ_at_props' "setPriority t prio"
+  by typ_at_props'
+
+sublocale setMCPriority: typ_at_props' "setMCPriority t prio"
+  by typ_at_props'
+
 lemma sameObject_corres2[Tcb_R_assms]:
   "\<lbrakk> cap_relation c c'; cap_relation d d' \<rbrakk>
    \<Longrightarrow> same_object_as c d = sameObjectAs c' d'"

--- a/proof/refine/AARCH64/ArchVSpace_R.thy
+++ b/proof/refine/AARCH64/ArchVSpace_R.thy
@@ -872,8 +872,7 @@ lemma vcpuEnable_invs_no_cicd'[wp]:
 lemma vcpuDisable_invs_no_cicd'[wp]:
   "\<lbrace>invs_no_cicd'\<rbrace> vcpuDisable v \<lbrace>\<lambda>_. invs_no_cicd'\<rbrace>"
   unfolding vcpuDisable_def
-  by (wpsimp wp: doMachineOp_typ_ats
-             simp: vcpuDisable_def doMachineOp_typ_at' split: option.splits
+  by (wpsimp simp: vcpuDisable_def doMachineOp_typ_at' split: option.splits
       | subst doMachineOp_bind | rule empty_fail_bind conjI)+
 
 lemma vcpuRestore_invs_no_cicd'[wp]:
@@ -1933,11 +1932,34 @@ lemma deleteASIDPool_corres:
   apply (fastforce simp: is_aligned_asid_low_bits_of_zero valid_asid_table'_def ran_def dom_def)
   done
 
-crunch setVMRoot
-  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  (simp: crunch_simps loadObject_default_def wp: crunch_wps getObject_inv)
+crunch unmapPageTable, unmapPage, setVMRoot, setMessageInfo, setMRs, performPageTableInvocation,
+       performASIDPoolInvocation, performPageInvocation
+  for typ_at' [wp]: "\<lambda>s. P (typ_at' T p s)"
+  (wp: crunch_wps getASID_wp simp: crunch_simps)
 
-lemmas setVMRoot_typ_ats [wp] = typ_at_lifts [OF setVMRoot_typ_at']
+sublocale unmapPageTable: typ_at_props' "unmapPageTable asid vaddr pt"
+  by typ_at_props'
+
+sublocale unmapPage: typ_at_props' "unmapPage magnitude asid vptr ptr"
+  by typ_at_props'
+
+sublocale setVMRoot: typ_at_props' "setVMRoot tcb"
+  by typ_at_props'
+
+sublocale setMessageInfo: typ_at_props' "setMessageInfo thread info"
+  by typ_at_props'
+
+sublocale setMRs: typ_at_props' "setMRs thread buffer messageData"
+  by typ_at_props'
+
+sublocale performPageTableInvocation: typ_at_props' "performPageTableInvocation iv"
+  by typ_at_props'
+
+sublocale performPageInvocation: typ_at_props' "performPageInvocation iv"
+  by typ_at_props'
+
+sublocale performASIDPoolInvocation: typ_at_props' "performASIDPoolInvocation iv"
+  by typ_at_props'
 
 lemma getObject_PTE_corres'':
   assumes "p' = p"
@@ -1949,7 +1971,6 @@ crunch unmapPageTable, unmapPage
   for aligned'[wp]: "pspace_aligned'"
   and distinct'[wp]: "pspace_distinct'"
   and ctes [wp]: "\<lambda>s. P (ctes_of s)"
-  and typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
   (simp: crunch_simps
    wp: crunch_wps getObject_inv loadObject_default_inv)
 
@@ -2052,12 +2073,6 @@ definition
       cte_wp_at' (is_arch_update' (ArchObjectCap cap)) ptr and valid_cap' (ArchObjectCap cap)
   | PageGetAddr ptr \<Rightarrow> \<top>
   | PageFlush ty start end pstart space asid \<Rightarrow> \<top>"
-
-lemmas setMRs_typ_at_lifts[wp] = typ_at_lifts[OF setMRs_typ_at']
-
-crunch unmapPage
-  for cte_at'[wp]: "cte_at' p"
-  (wp: crunch_wps simp: crunch_simps)
 
 lemma vs_lookup_slot_vspace_for_asidD:
   "\<lbrakk> vs_lookup_slot level asid vref s = Some (level, slot); level \<le> max_pt_level;
@@ -2185,8 +2200,6 @@ lemma clear_page_table_corres:
    apply (simp add: bit_simps word_less_nat_alt word_le_nat_alt unat_of_nat)
   apply simp
   done
-
-lemmas unmapPageTable_typ_ats[wp] = typ_at_lifts[OF unmapPageTable_typ_at']
 
 lemma performPageTableInvocation_corres:
   "page_table_invocation_map pti pti' \<Longrightarrow>
@@ -2666,28 +2679,6 @@ crunch deleteASID
   (simp: crunch_simps loadObject_default_def updateObject_default_def
    wp: getObject_inv)
 
-crunch performPageTableInvocation
-  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  (wp: crunch_wps)
-
-crunch performPageInvocation
-  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  (wp: crunch_wps simp: crunch_simps)
-
-lemma performASIDPoolInvocation_typ_at' [wp]:
-  "\<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace> performASIDPoolInvocation api \<lbrace>\<lambda>_ s. P (typ_at' T p s)\<rbrace>"
-  by (wpsimp simp: performASIDPoolInvocation_def
-               wp: getASID_wp hoare_vcg_imp_lift[where P'=\<bottom>, simplified])
-
-lemmas performPageTableInvocation_typ_ats' [wp] =
-  typ_at_lifts [OF performPageTableInvocation_typ_at']
-
-lemmas performPageInvocation_typ_ats' [wp] =
-  typ_at_lifts [OF performPageInvocation_typ_at']
-
-lemmas performASIDPoolInvocation_typ_ats' [wp] =
-  typ_at_lifts [OF performASIDPoolInvocation_typ_at']
-
 lemma storePTE_pred_tcb_at' [wp]:
   "storePTE p pte \<lbrace>pred_tcb_at' proj P t\<rbrace>"
   apply (simp add: storePTE_def pred_tcb_at'_def)
@@ -2892,8 +2883,6 @@ lemma perform_pti_invs [wp]:
 crunch unmapPage
   for cte_wp_at': "\<lambda>s. P (cte_wp_at' P' p s)"
   (wp: crunch_wps lookupPTSlotFromLevel_inv simp: crunch_simps)
-
-lemmas unmapPage_typ_ats [wp] = typ_at_lifts [OF unmapPage_typ_at']
 
 lemma unmapPage_invs' [wp]:
   "unmapPage sz asid vptr pptr \<lbrace>invs'\<rbrace>"

--- a/proof/refine/AARCH64/orphanage/Orphanage.thy
+++ b/proof/refine/AARCH64/orphanage/Orphanage.thy
@@ -1679,7 +1679,6 @@ lemma tc_no_orphans:
   apply (rule hoare_walk_assmsE)
     apply (cases mcp; clarsimp simp: pred_conj_def option.splits[where P="\<lambda>x. x s" for s])
      apply ((wp case_option_wp threadSet_no_orphans threadSet_invs_trivial setMCPriority_invs'
-                typ_at_lifts[OF setMCPriority_typ_at']
                 threadSet_cap_to' hoare_vcg_all_lift hoare_weak_lift_imp | clarsimp simp: inQ_def)+)[3]
   apply ((simp only: simp_thms cong: conj_cong
           | wp cteDelete_deletes cteDelete_invs' cteDelete_sch_act_simple

--- a/proof/refine/ARM/ArchArchAcc_R.thy
+++ b/proof/refine/ARM/ArchArchAcc_R.thy
@@ -981,22 +981,15 @@ lemma lookupPTSlot_corres [@lift_corres_args, corres]:
                       wp: get_pde_wp_valid getPDE_wp)
   by (auto simp: lookup_failure_map_def obj_at_def)
 
-crunch storePDE
+crunch storePDE, storePTE
   for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
   (wp: crunch_wps mapM_x_wp' simp: crunch_simps ignore_del: setObject)
 
-crunch storePTE
-  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  (wp: crunch_wps mapM_x_wp' simp: crunch_simps ignore_del: setObject)
+sublocale storePDE: typ_at_props' "storePDE slot pde"
+  by typ_at_props'
 
-lemmas storePDE_typ_ats[wp] = typ_at_lifts [OF storePDE_typ_at']
-lemmas storePTE_typ_ats[wp] = typ_at_lifts [OF storePTE_typ_at']
-
-lemma setObject_asid_typ_at' [wp]:
-  "\<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace> setObject p' (v::asidpool) \<lbrace>\<lambda>_ s. P (typ_at' T p s)\<rbrace>"
-  by (rule setObject_typ_at')
-
-lemmas setObject_asid_typ_ats'[wp] = typ_at_lifts [OF setObject_asid_typ_at']
+sublocale storePTE: typ_at_props' "storePTE slot pte"
+  by typ_at_props'
 
 lemma getObject_pte_inv[wp]:
   "\<lbrace>P\<rbrace> getObject p \<lbrace>\<lambda>rv :: pte. P\<rbrace>"
@@ -1010,7 +1003,8 @@ crunch copyGlobalMappings
   for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
   (wp: mapM_x_wp')
 
-lemmas copyGlobalMappings_typ_ats[wp] = typ_at_lifts [OF copyGlobalMappings_typ_at']
+sublocale copyGlobalMappings: typ_at_props' "copyGlobalMappings newPT"
+  by typ_at_props'
 
 lemma arch_cap_rights_update[ArchAcc_R_assms]:
   "acap_relation c c' \<Longrightarrow>

--- a/proof/refine/ARM/ArchCNodeInv_R.thy
+++ b/proof/refine/ARM/ArchCNodeInv_R.thy
@@ -453,4 +453,23 @@ proof goal_cases
   case 1 show ?case by (intro_locales; (unfold_locales; (fact CNodeInv_R_assms)?)?)
 qed
 
+context Arch begin arch_global_naming
+
+sublocale cteDelete: typ_at_props' "cteDelete slot exposed"
+  by typ_at_props'
+
+sublocale reduceZombie: typ_at_props' "reduceZombie cap slot x"
+  by typ_at_props'
+
+sublocale finaliseSlot: typ_at_props' "finaliseSlot ptr exposed"
+  by typ_at_props'
+
+sublocale invokeCNode: typ_at_props' "invokeCNode i"
+  by typ_at_props'
+
+sublocale cteMove: typ_at_props' "cteMove cap src dest"
+  by typ_at_props'
+
+end  (* Arch *)
+
 end

--- a/proof/refine/ARM/ArchCSpace1_R.thy
+++ b/proof/refine/ARM/ArchCSpace1_R.thy
@@ -231,7 +231,8 @@ proof -
   done
 qed
 
-lemmas setCTE_typ_ats[wp] = typ_at_lifts[OF setCTE_typ_at']
+sublocale setCTE: typ_at_props' "setCTE c cte"
+  by typ_at_props'
 
 lemma arch_updateCapData_Master[CSpace1_R_assms]:
   "Arch.updateCapData P d acap \<noteq> NullCap \<Longrightarrow>

--- a/proof/refine/ARM/ArchCSpace_R.thy
+++ b/proof/refine/ARM/ArchCSpace_R.thy
@@ -33,9 +33,14 @@ lemma capAligned_master[CSpace_R_assms]:
    apply (clarsimp simp: capAligned_def)+
   done
 
-lemmas updateMDB_typ_ats[wp] = typ_at_lifts[OF updateMDB_typ_at']
-lemmas updateCap_typ_ats[wp] = typ_at_lifts[OF updateCap_typ_at']
-lemmas cteInsert_typ_ats[wp] = typ_at_lifts[OF cteInsert_typ_at']
+sublocale updateMDB: typ_at_props' "updateMDB slot f"
+  by typ_at_props'
+
+sublocale updateCap: typ_at_props' "updateCap slot newCap"
+  by typ_at_props'
+
+sublocale cteInsert: typ_at_props' "cteInsert newCap srcSlot destSlot"
+  by typ_at_props'
 
 lemma maskedAsFull_derived'[CSpace_R_assms]:
   "\<lbrakk>m src = Some (CTE s_cap s_node); is_derived' m ptr b c\<rbrakk>

--- a/proof/refine/ARM/ArchFinalise_R.thy
+++ b/proof/refine/ARM/ArchFinalise_R.thy
@@ -23,7 +23,8 @@ lemma arch_postCapDeletion_ksArchState_lift[Finalise_R_assms]:
   unfolding postCapDeletion_def
   by wpsimp
 
-lemmas clearUntypedFreeIndex_typ_ats[wp] = typ_at_lifts[OF clearUntypedFreeIndex_typ_at']
+sublocale clearUntypedFreeIndex: typ_at_props' "clearUntypedFreeIndex slot"
+  by typ_at_props'
 
 crunch setIRQState
   for umm[Finalise_R_assms, wp]: "\<lambda>s. P (underlying_memory (ksMachineState s))"
@@ -610,11 +611,23 @@ lemma isFinal_no_descendants[Finalise_R_2_assms]:
   apply (simp add: valid_mdb'_def)
   done
 
-lemmas cancelAllIPC_typs[wp] = typ_at_lifts[OF cancelAllIPC_typ_at']
-lemmas cancelAllSignals_typs[wp] = typ_at_lifts[OF cancelAllSignals_typ_at']
-lemmas suspend_typs[wp] = typ_at_lifts[OF suspend_typ_at']
+sublocale cancelIPC: typ_at_props' "cancelIPC tptr"
+  by typ_at_props'
 
-lemmas finaliseCap_typ_ats[wp] = typ_at_lifts[OF finaliseCap_typ_at']
+sublocale cancelAllIPC: typ_at_props' "cancelAllIPC epptr"
+  by typ_at_props'
+
+sublocale cancelAllSignals: typ_at_props' "cancelAllSignals ntfnPtr"
+  by typ_at_props'
+
+sublocale suspend: typ_at_props' "suspend target"
+  by typ_at_props'
+
+sublocale finaliseCap: typ_at_props' "finaliseCap cap final x"
+  by typ_at_props'
+
+sublocale unbindNotification: typ_at_props' "unbindNotification tcb"
+  by typ_at_props'
 
 crunch flushSpace
   for invs'[wp]: "invs'"
@@ -701,7 +714,8 @@ lemma deleteASID_invs'[wp]:
   apply clarsimp
   done
 
-lemmas archThreadSet_typ_ats[wp] = typ_at_lifts[OF archThreadSet_typ_at']
+sublocale archThreadSet: typ_at_props' "archThreadSet f tptr"
+  by typ_at_props'
 
 lemma archThreadSet_valid_objs'[wp]:
   "\<lbrace>valid_objs' and (\<lambda>s. \<forall>tcb. ko_at' tcb t s \<longrightarrow> valid_arch_tcb' (f (tcbArch tcb)) s)\<rbrace>
@@ -1257,7 +1271,8 @@ lemma arch_finaliseCap_corres[Finalise_R_3_assms]:
    apply (auto simp: mask_def valid_cap_def)[2]
   done
 
-lemmas deleteCallerCap_typ_ats[wp] = typ_at_lifts[OF deleteCallerCap_typ_at']
+sublocale deleteCallerCap: typ_at_props' "deleteCallerCap receiver"
+  by typ_at_props'
 
 end (* Arch *)
 

--- a/proof/refine/ARM/ArchInvsLemmas_H.thy
+++ b/proof/refine/ARM/ArchInvsLemmas_H.thy
@@ -405,6 +405,25 @@ lemmas typ_at_lifts = gen_typ_at_lifts typ_at_lifts_strong_internal
 
 end
 
+end (* Arch *)
+
+locale typ_at_props' = Arch +
+  fixes f :: "_ kernel"
+  assumes typ': "f \<lbrace>\<lambda>s. P (typ_at' T p' s)\<rbrace>"
+begin
+
+lemmas typ_ats[wp] = typ_at_lifts[REPEAT [OF typ']]
+
+context begin
+(* We want to enforce that typ_ats only contains lemmas that have no
+   assumptions. The following thm statement should fail if this is not true. *)
+private lemmas check_valid_internal = iffD1[OF refl, where P="valid p g q" for p g q]
+thm typ_ats[atomized, THEN check_valid_internal]
+end
+
+end (* typ_at_props' *)
+
+context Arch begin arch_global_naming
 
 lemmas bit_simps' = pteBits_def pdeBits_def asidHighBits_def asid_low_bits_def word_size_bits_def
                     asid_high_bits_def bit_simps

--- a/proof/refine/ARM/ArchInvsLemmas_H.thy
+++ b/proof/refine/ARM/ArchInvsLemmas_H.thy
@@ -329,58 +329,82 @@ lemma is_physical_cases:
              | _                                \<Rightarrow> True)"
   by (simp split: capability.splits arch_capability.splits zombie_type.splits)
 
-lemma typ_at_lift_page_directory_at':
-  assumes x: "\<And>T p. \<lbrace>typ_at' T p\<rbrace> f \<lbrace>\<lambda>rv. typ_at' T p\<rbrace>"
-  shows      "\<lbrace>page_directory_at' p\<rbrace> f \<lbrace>\<lambda>rv. page_directory_at' p\<rbrace>"
-  unfolding page_directory_at'_def All_less_Ball
-  by (wp hoare_vcg_const_Ball_lift x)
+named_theorems Invariants_H_typ_at_lifts_assms
 
-lemma typ_at_lift_page_table_at':
-  assumes x: "\<And>T p. \<lbrace>typ_at' T p\<rbrace> f \<lbrace>\<lambda>rv. typ_at' T p\<rbrace>"
-  shows      "\<lbrace>page_table_at' p\<rbrace> f \<lbrace>\<lambda>rv. page_table_at' p\<rbrace>"
-  unfolding page_table_at'_def All_less_Ball
-  by (wp hoare_vcg_const_Ball_lift x)
-
-lemma typ_at_lift_asid_at':
-  "(\<And>T p. \<lbrace>typ_at' T p\<rbrace> f \<lbrace>\<lambda>_. typ_at' T p\<rbrace>) \<Longrightarrow> \<lbrace>asid_pool_at' p\<rbrace> f \<lbrace>\<lambda>_. asid_pool_at' p\<rbrace>"
-  by assumption
-
-lemma typ_at_lift_valid_cap':
-  assumes P: "\<And>P T p. \<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace> f \<lbrace>\<lambda>rv s. P (typ_at' T p s)\<rbrace>"
-  shows      "\<lbrace>\<lambda>s. valid_cap' cap s\<rbrace> f \<lbrace>\<lambda>rv s. valid_cap' cap s\<rbrace>"
-  including no_pre
-  apply (simp add: valid_cap'_def)
-  apply wp
-  apply (case_tac cap;
-         simp add: valid_cap'_def P[of id, simplified] typ_at_lift_tcb'
-                   hoare_vcg_prop typ_at_lift_ep'
-                   typ_at_lift_ntfn' typ_at_lift_cte_at'
-                   hoare_vcg_conj_lift [OF typ_at_lift_cte_at'])
-     apply (rename_tac zombie_type nat)
-     apply (case_tac zombie_type; simp)
-      apply (wp typ_at_lift_tcb' P hoare_vcg_all_lift typ_at_lift_cte')+
-    apply (rename_tac arch_capability)
-    apply (case_tac arch_capability,
-           simp_all add: P[of id, simplified] vspace_table_at'_defs
-                         hoare_vcg_prop All_less_Ball
-                    split del: if_split)
-       apply (wp hoare_vcg_const_Ball_lift P typ_at_lift_valid_untyped'
-                 hoare_vcg_all_lift typ_at_lift_cte')+
+lemma page_directory_at'_typ_at_lift_strong:
+  "(\<And>p. f \<lbrace>\<lambda>s. P (typ_at' (ArchT PDET) p s)\<rbrace>) \<Longrightarrow> f \<lbrace>\<lambda>s. P (page_directory_at' p s)\<rbrace>"
+  unfolding page_directory_at'_def
+  apply (rule bool_to_bool_cases[where f=P]; clarsimp)
+  apply (wpsimp wp: hoare_vcg_const_Ball_lift hoare_vcg_imp_lift
+                    hoare_vcg_all_lift hoare_vcg_ex_lift
+         | assumption)+
   done
 
-(* interface lemma *)
-lemma valid_arch_tcb_lift':
-  assumes x: "\<And>T p. \<lbrace>typ_at' T p\<rbrace> f \<lbrace>\<lambda>rv. typ_at' T p\<rbrace>"
-  shows "\<lbrace>\<lambda>s. valid_arch_tcb' tcb s\<rbrace> f \<lbrace>\<lambda>rv s. valid_arch_tcb' tcb s\<rbrace>"
-  by (clarsimp simp add: valid_arch_tcb'_def, wp)
+lemma page_table_at'_typ_at_lift_strong:
+  "(\<And>p. f \<lbrace>\<lambda>s. P (typ_at' (ArchT PTET) p s)\<rbrace>) \<Longrightarrow> f \<lbrace>\<lambda>s. P (page_table_at' p s)\<rbrace>"
+  unfolding page_table_at'_def
+  apply (rule bool_to_bool_cases[where f=P]; clarsimp)
+  apply (wpsimp wp: hoare_vcg_const_Ball_lift hoare_vcg_imp_lift
+                    hoare_vcg_all_lift hoare_vcg_ex_lift
+         | assumption)+
+  done
 
-lemmas typ_at_lifts =
-           typ_at_lift_tcb' typ_at_lift_ep' typ_at_lift_ntfn' typ_at_lift_cte' typ_at_lift_cte_at'
-           typ_at_lift_valid_untyped' typ_at_lift_valid_cap' valid_bound_tcb_lift
-           typ_at_lift_page_table_at'
-           typ_at_lift_page_directory_at'
-           typ_at_lift_asid_at'
-           valid_arch_tcb_lift'
+lemma asid_at'_typ_at_lift_strong:
+  "(\<And>T p. f \<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace>) \<Longrightarrow> f \<lbrace>\<lambda>s. P (asid_pool_at' p s)\<rbrace>"
+  by assumption
+
+lemma valid_arch_tcb'_typ_at_lift_strong[Invariants_H_typ_at_lifts_assms]:
+  assumes "\<And>T p. f \<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace>"
+  shows "f \<lbrace>\<lambda>s. P (valid_arch_tcb' tcb s)\<rbrace>"
+  by (clarsimp simp: valid_arch_tcb'_def, wp)
+
+lemma valid_arch_cap'_typ_at_lift[Invariants_H_typ_at_lifts_assms]:
+  assumes P: "\<And>P T p. f \<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace>"
+  shows      "f \<lbrace>\<lambda>s. valid_arch_cap' cap s\<rbrace>"
+  apply (case_tac cap,
+         simp_all add: P[where P=id, simplified] All_less_Ball
+            split del: if_split)
+    apply (wp hoare_vcg_const_Ball_lift P
+              page_directory_at'_typ_at_lift_strong page_table_at'_typ_at_lift_strong)+
+  done
+
+end (* Arch *)
+
+global_interpretation Invariants_H_typ_at_lifts?: Invariants_H_typ_at_lifts
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case by (intro_locales; unfold_locales; (fact Invariants_H_typ_at_lifts_assms)?)
+qed
+
+context Arch begin arch_global_naming
+
+lemmas typ_at_lifts_strong =
+  gen_typ_at_lifts_strong
+  page_directory_at'_typ_at_lift_strong
+  page_table_at'_typ_at_lift_strong
+  asid_at'_typ_at_lift_strong
+
+context begin
+
+\<comment>\<open> See the comment above @{ML weaken_typ_at_lifts_thms} for an explanation of what
+    this @{command ML_goal} is for. Here we are constructing the combined list of
+    both generic and arch-specific typ_at_lifts lemmas.\<close>
+ML \<open>
+local
+  val strong_thms = subtract Thm.eq_thm gen_strong_thms @{thms typ_at_lifts_strong[no_vars]};
+in
+  val typ_at_lifts_internal_goals = weaken_typ_at_lifts_thms strong_thms
+end
+\<close>
+
+private ML_goal typ_at_lifts_strong_internal:
+  \<open>typ_at_lifts_internal_goals\<close>
+  by (auto simp: typ_at_lifts_strong)
+
+lemmas typ_at_lifts = gen_typ_at_lifts typ_at_lifts_strong_internal
+
+end
+
 
 lemmas bit_simps' = pteBits_def pdeBits_def asidHighBits_def asid_low_bits_def word_size_bits_def
                     asid_high_bits_def bit_simps

--- a/proof/refine/ARM/ArchIpc_R.thy
+++ b/proof/refine/ARM/ArchIpc_R.thy
@@ -269,6 +269,33 @@ lemma is_derived_mask'[simp]:
   "is_derived' m p (maskCapRights R c) = is_derived' m p c"
   by (rule ext, simp add: is_derived'_def badge_derived'_def)
 
+sublocale setExtraBadge: typ_at_props' "setExtraBadge buffer badge n"
+  by typ_at_props'
+
+sublocale transferCaps: typ_at_props' "transferCaps info caps endpoint receiver receiveBuffer"
+  by typ_at_props'
+
+sublocale copyMRs: typ_at_props' "copyMRs s sb r rb n"
+  by typ_at_props'
+
+sublocale doNormalTransfer: typ_at_props' "doNormalTransfer s sb e b g r rb"
+  by typ_at_props'
+
+sublocale doIPCTransfer: typ_at_props' "doIPCTransfer s e b g r"
+  by typ_at_props'
+
+sublocale handleFaultReply: typ_at_props' "handleFaultReply x t l m"
+  by typ_at_props'
+
+sublocale sendFaultIPC: typ_at_props' "sendFaultIPC tptr fault"
+  by typ_at_props'
+
+sublocale receiveIPC: typ_at_props' "receiveIPC t cap b"
+  by typ_at_props'
+
+sublocale receiveSignal: typ_at_props' "receiveSignal t cap b"
+  by typ_at_props'
+
 end (* Arch *)
 
 end

--- a/proof/refine/ARM/ArchKHeap_R.thy
+++ b/proof/refine/ARM/ArchKHeap_R.thy
@@ -325,7 +325,7 @@ lemma valid_arch_state_lift':
                    page_table_at'_def
                    All_less_Ball)
   apply (rule hoare_lift_Pf [where f="ksArchState"])
-   apply (wp typs pds valid_pde_mappings'_lift' hoare_vcg_const_Ball_lift arch typ_at_lifts)+
+   apply (wp typs pds valid_pde_mappings'_lift' hoare_vcg_const_Ball_lift arch)+
   done
 
 lemma valid_arch_state_lift'_valid_pde_mappings':
@@ -385,8 +385,6 @@ crunch setEndpoint, setNotification
   for valid_arch'[wp]: valid_arch_state'
   (wp: valid_arch_state_lift')
 
-lemmas setObject_typ_ats[wp] = typ_at_lifts[OF setObject_typ_at']
-
 lemma setObject_ko_wp_at':
   fixes v :: "'a :: pspace_storable"
   assumes x: "\<And>v :: 'a. updateObject v = updateObject_default v"
@@ -402,9 +400,14 @@ lemma setObject_ko_wp_at':
 
 lemmas [KHeap_R_assms_2] = setEndpoint_valid_arch' setNotification_valid_arch'
 
-lemmas doMachineOp_typ_ats[wp] = typ_at_lifts[OF doMachineOp_typ_at']
+sublocale setObject: typ_at_props' "setObject p v"
+  by typ_at_props'
 
-lemmas setEndpoint_typ_ats[wp] = typ_at_lifts[OF setEndpoint_typ_at']
+sublocale doMachineOp: typ_at_props' "doMachineOp mop"
+  by typ_at_props'
+
+sublocale setEndpoint: typ_at_props' "setEndpoint ptr val"
+  by typ_at_props'
 
 end
 

--- a/proof/refine/ARM/ArchSchedule_R.thy
+++ b/proof/refine/ARM/ArchSchedule_R.thy
@@ -19,7 +19,7 @@ crunch tcbSchedAppend, tcbSchedDequeue, tcbSchedEnqueue
 
 lemma arch_switch_thread_tcb_at'[wp]:
   "\<lbrace>tcb_at' t\<rbrace> Arch.switchToThread t \<lbrace>\<lambda>_. tcb_at' t\<rbrace>"
-  by (unfold ARM_H.switchToThread_def, wp typ_at_lift_tcb')
+  by (unfold ARM_H.switchToThread_def, wp)
 
 crunch setVMRoot
   for pred_tcb_at'[wp]: "pred_tcb_at' proj P t'"

--- a/proof/refine/ARM/ArchTcbAcc_R.thy
+++ b/proof/refine/ARM/ArchTcbAcc_R.thy
@@ -189,7 +189,8 @@ lemma threadSet_iflive'T[TcbAcc_R_assms]:
   apply (clarsimp simp: bspec_split [OF spec [OF x]])
   done
 
-lemmas threadSet_typ_at_lifts[wp] = typ_at_lifts[OF threadSet_typ_at']
+sublocale threadSet: typ_at_props' "threadSet tptr f"
+  by typ_at_props'
 
 lemma setObject_tcb_pde_mappings'[wp]:
   "\<lbrace>valid_pde_mappings'\<rbrace> setObject p (tcb :: tcb) \<lbrace>\<lambda>rv. valid_pde_mappings'\<rbrace>"
@@ -214,8 +215,11 @@ lemma asUser_valid_tcbs'[wp]:
               simp: valid_tcb'_def valid_arch_tcb'_def tcb_cte_cases_def objBits_simps')
   done
 
-lemmas addToBitmap_typ_ats[wp] = typ_at_lifts[OF addToBitmap_typ_at']
-lemmas removeFromBitmap_typ_ats[wp] = typ_at_lifts[OF removeFromBitmap_typ_at']
+sublocale addToBitmap: typ_at_props' "addToBitmap tdom prio"
+  by typ_at_props'
+
+sublocale removeFromBitmap: typ_at_props' "removeFromBitmap tdom prio"
+  by typ_at_props'
 
 crunch tcbQueueRemove, tcbQueuePrepend, tcbQueueAppend, tcbQueueInsert,
          setQueue, removeFromBitmap
@@ -333,7 +337,8 @@ context Arch begin arch_global_naming
 
 named_theorems TcbAcc_R_2_assms
 
-lemmas asUser_typ_ats[wp] = typ_at_lifts[OF asUser_typ_at']
+sublocale asUser: typ_at_props' "asUser tptr f"
+  by typ_at_props'
 
 lemma tcb_hyp_refs'_valid_arch_tcb'_eq[TcbAcc_R_2_assms]:
   "tcb_hyp_refs' (tcbArch (F tcb)) = tcb_hyp_refs' (tcbArch tcb)
@@ -860,8 +865,17 @@ lemma set_mrs_invs'[TcbAcc_R_3_assms, wp]:
          simp add: zipWithM_x_mapM split_def)+
   done
 
-lemmas setThreadState_typ_ats[wp] = typ_at_lifts [OF setThreadState_typ_at']
-lemmas setBoundNotification_typ_ats[wp] = typ_at_lifts [OF setBoundNotification_typ_at']
+sublocale rescheduleRequired: typ_at_props' "rescheduleRequired"
+  by typ_at_props'
+
+sublocale tcbSchedDequeue: typ_at_props' "tcbSchedDequeue thread"
+  by typ_at_props'
+
+sublocale setThreadState: typ_at_props' "setThreadState st p"
+  by typ_at_props'
+
+sublocale setBoundNotification: typ_at_props' "setBoundNotification v p"
+  by typ_at_props'
 
 end (* Arch *)
 

--- a/proof/refine/ARM/ArchTcb_R.thy
+++ b/proof/refine/ARM/ArchTcb_R.thy
@@ -42,6 +42,12 @@ lemma threadSet_state_hyp_refs_of'_interface[Tcb_R_assms]:
    \<Longrightarrow> threadSet F t \<lbrace>\<lambda>s. P (state_hyp_refs_of' s)\<rbrace> "
   by (wpsimp simp: threadSet_state_hyp_refs_of')
 
+sublocale setPriority: typ_at_props' "setPriority t prio"
+  by typ_at_props'
+
+sublocale setMCPriority: typ_at_props' "setMCPriority t prio"
+  by typ_at_props'
+
 lemma sameObject_corres2[Tcb_R_assms]:
   "\<lbrakk> cap_relation c c'; cap_relation d d' \<rbrakk>
    \<Longrightarrow> same_object_as c d = sameObjectAs c' d'"

--- a/proof/refine/ARM/ArchVSpace_R.thy
+++ b/proof/refine/ARM/ArchVSpace_R.thy
@@ -1094,23 +1094,52 @@ proof -
     done
 qed
 
-crunch armv_contextSwitch
-  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  (simp: crunch_simps)
+crunch unmapPageTable, unmapPage, setVMRoot, setMessageInfo, setMRs, performPageTableInvocation,
+       performPageDirectoryInvocation, performASIDPoolInvocation, performPageInvocation
+  for typ_at' [wp]: "\<lambda>s. P (typ_at' T p s)"
+  (wp: crunch_wps getASID_wp simp: crunch_simps)
 
-crunch setVMRoot
-  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  (simp: crunch_simps)
+sublocale unmapPageTable: typ_at_props' "unmapPageTable asid vaddr pt"
+  by typ_at_props'
 
-lemmas setVMRoot_typ_ats [wp] = typ_at_lifts [OF setVMRoot_typ_at']
+sublocale unmapPage: typ_at_props' "unmapPage magnitude asid vptr ptr"
+  by typ_at_props'
 
-lemmas loadHWASID_typ_ats [wp] = typ_at_lifts [OF loadHWASID_inv]
+sublocale setVMRoot: typ_at_props' "setVMRoot tcb"
+  by typ_at_props'
 
-crunch setVMRootForFlush
-  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  (wp: hoare_drop_imps)
+sublocale loadHWASID: typ_at_props' "loadHWASID asid"
+  by typ_at_props'
 
-lemmas setVMRootForFlush_typ_ats' [wp] = typ_at_lifts [OF setVMRootForFlush_typ_at']
+sublocale setVMRootForFlush: typ_at_props' "setVMRootForFlush pd asid"
+  by typ_at_props'
+
+sublocale setMessageInfo: typ_at_props' "setMessageInfo thread info"
+  by typ_at_props'
+
+sublocale setMRs: typ_at_props' "setMRs thread buffer messageData"
+  by typ_at_props'
+
+sublocale performPageTableInvocation: typ_at_props' "performPageTableInvocation iv"
+  by typ_at_props'
+
+sublocale performPageDirectoryInvocation: typ_at_props' "performPageDirectoryInvocation iv"
+  by typ_at_props'
+
+sublocale performPageInvocation: typ_at_props' "performPageInvocation iv"
+  by typ_at_props'
+
+sublocale performASIDPoolInvocation: typ_at_props' "performASIDPoolInvocation iv"
+  by typ_at_props'
+
+sublocale flushTable: typ_at_props' "flushTable pd asid vptr"
+  by typ_at_props'
+
+sublocale findPDForASID: typ_at_props' "findPDForASID asid"
+  by typ_at_props'
+
+sublocale flushPage: typ_at_props' "flushPage m pd asid vptr"
+  by typ_at_props'
 
 crunch setVMRootForFlush
   for aligned'[wp]: pspace_aligned'
@@ -1324,14 +1353,6 @@ lemma flushPage_corres:
               | clarsimp simp: cur_tcb_def [symmetric] cur_tcb'_def [symmetric])+
   done
 
-crunch flushTable
-  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  (wp: crunch_wps)
-
-lemmas flushTable_typ_ats' [wp] = typ_at_lifts [OF flushTable_typ_at']
-
-lemmas findPDForASID_typ_ats' [wp] = typ_at_lifts [OF findPDForASID_inv]
-
 crunch unmapPageTable
   for aligned'[wp]: "pspace_aligned'"
   (simp: crunch_simps
@@ -1432,12 +1453,6 @@ lemma unmapPageTable_corres:
    apply (auto elim: simp: empty_table_def valid_pde_mappings_def pde_ref_def obj_at_def
                      vs_refs_pages_def graph_of_def split: if_splits)
   done
-
-crunch flushPage
-  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  (wp: crunch_wps hoare_drop_imps)
-
-lemmas flushPage_typ_ats' [wp] = typ_at_lifts [OF flushPage_typ_at']
 
 crunch flushPage
   for valid_objs'[wp]: "valid_objs'"
@@ -2044,8 +2059,6 @@ crunch updateCap
   for valid_duplicates'[wp]: "\<lambda>s. vs_valid_duplicates' (ksPSpace s)"
   (wp: crunch_wps simp: crunch_simps unless_def)
 
-lemmas setMRs_typ_at_lifts[wp] = typ_at_lifts [OF setMRs_typ_at']
-
 lemma same_refs_vs_cap_ref_eq:
   assumes "valid_slots entries s"
   assumes "same_refs entries cap s"
@@ -2332,10 +2345,6 @@ lemma clear_page_table_corres:
                     pteBits_def)
   apply simp
   done
-
-crunch unmapPageTable
-  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-lemmas unmapPageTable_typ_ats[wp] = typ_at_lifts[OF unmapPageTable_typ_at']
 
 lemma performPageTableInvocation_corres:
   "page_table_invocation_map pti pti' \<Longrightarrow>
@@ -2638,34 +2647,6 @@ lemma valid_slots_lift':
   apply safe
    apply (rule hoare_pre, wp hoare_vcg_const_Ball_lift t, simp)+
   done
-
-crunch performPageTableInvocation
-  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  (wp: crunch_wps)
-
-crunch performPageDirectoryInvocation
-  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  (wp: crunch_wps)
-
-crunch performPageInvocation
-  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  (wp: crunch_wps)
-
-crunch performASIDPoolInvocation
-  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  (wp: getObject_cte_inv getASID_wp)
-
-lemmas performPageTableInvocation_typ_ats' [wp] =
-  typ_at_lifts [OF performPageTableInvocation_typ_at']
-
-lemmas performPageDirectoryInvocation_typ_ats' [wp] =
-  typ_at_lifts [OF performPageDirectoryInvocation_typ_at']
-
-lemmas performPageInvocation_typ_ats' [wp] =
-  typ_at_lifts [OF performPageInvocation_typ_at']
-
-lemmas performASIDPoolInvocation_typ_ats' [wp] =
-  typ_at_lifts [OF performASIDPoolInvocation_typ_at']
 
 lemma storePDE_pred_tcb_at' [wp]:
   "\<lbrace>pred_tcb_at' proj P t\<rbrace> storePDE p pde \<lbrace>\<lambda>_. pred_tcb_at' proj P t\<rbrace>"
@@ -3331,8 +3312,6 @@ lemma mapM_storePDE_invs:
 crunch unmapPage
   for cte_wp_at': "\<lambda>s. P (cte_wp_at' P' p s)"
   (wp: crunch_wps simp: crunch_simps)
-
-lemmas unmapPage_typ_ats [wp] = typ_at_lifts [OF unmapPage_typ_at']
 
 lemma flushPage_invs' [wp]:
   "\<lbrace>invs'\<rbrace> flushPage sz pd asid vptr \<lbrace>\<lambda>_. invs'\<rbrace>"

--- a/proof/refine/ARM/PageTableDuplicates.thy
+++ b/proof/refine/ARM/PageTableDuplicates.thy
@@ -2078,7 +2078,6 @@ lemma tc_valid_duplicates':
   apply (rule hoare_walk_assmsE)
     apply (clarsimp simp: pred_conj_def option.splits [where P="\<lambda>x. x s" for s])
     apply ((wp case_option_wp threadSet_invs_trivial hoare_weak_lift_imp setMCPriority_invs'
-               typ_at_lifts[OF setMCPriority_typ_at']
                hoare_vcg_all_lift threadSet_cap_to' | clarsimp simp: inQ_def)+)[2]
   apply ((simp only: simp_thms cases_simp cong: conj_cong
           | (wp cteDelete_deletes cteDelete_invs' cteDelete_sch_act_simple
@@ -2090,7 +2089,7 @@ lemma tc_valid_duplicates':
               checkCap_inv[where P="\<lambda>s. P (ksReadyQueues s)" for P]
               checkCap_inv[where P="\<lambda>s. vs_valid_duplicates' (ksPSpace s)"]
               checkCap_inv[where P=sch_act_simple] cteDelete_valid_duplicates' hoare_vcg_const_imp_liftE_R
-              typ_at_lifts[OF setPriority_typ_at'] assertDerived_wp threadSet_cte_wp_at'
+              assertDerived_wp threadSet_cte_wp_at'
               hoare_vcg_all_liftE_R hoare_vcg_all_lift hoare_weak_lift_imp)[1]
           | wpc
           | simp add: inQ_def

--- a/proof/refine/ARM/orphanage/Orphanage.thy
+++ b/proof/refine/ARM/orphanage/Orphanage.thy
@@ -1722,7 +1722,6 @@ lemma tc_no_orphans:
   apply (rule hoare_walk_assmsE)
     apply (cases mcp; clarsimp simp: pred_conj_def option.splits[where P="\<lambda>x. x s" for s])
      apply ((wp case_option_wp threadSet_no_orphans threadSet_invs_trivial setMCPriority_invs'
-                typ_at_lifts[OF setMCPriority_typ_at']
                 threadSet_cap_to' hoare_vcg_all_lift hoare_weak_lift_imp | clarsimp simp: inQ_def)+)[3]
   apply ((simp only: simp_thms cong: conj_cong
           | wp cteDelete_deletes cteDelete_invs' cteDelete_sch_act_simple

--- a/proof/refine/ARM_HYP/ArchArchAcc_R.thy
+++ b/proof/refine/ARM_HYP/ArchArchAcc_R.thy
@@ -1162,22 +1162,15 @@ lemma lookupPTSlot_corres [corres]:
                       wp: get_pde_wp_valid getPDE_wp)
   by (auto simp: lookup_failure_map_def obj_at_def)
 
-crunch storePDE
+crunch storePDE, storePTE
   for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
   (wp: crunch_wps mapM_x_wp' simp: crunch_simps ignore_del: setObject)
 
-crunch storePTE
-  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  (wp: crunch_wps mapM_x_wp' simp: crunch_simps ignore_del: setObject)
+sublocale storePDE: typ_at_props' "storePDE slot pde"
+  by typ_at_props'
 
-lemmas storePDE_typ_ats[wp] = typ_at_lifts [OF storePDE_typ_at']
-lemmas storePTE_typ_ats[wp] = typ_at_lifts [OF storePTE_typ_at']
-
-lemma setObject_asid_typ_at' [wp]:
-  "\<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace> setObject p' (v::asidpool) \<lbrace>\<lambda>_ s. P (typ_at' T p s)\<rbrace>"
-  by (rule setObject_typ_at')
-
-lemmas setObject_asid_typ_ats'[wp] = typ_at_lifts [OF setObject_asid_typ_at']
+sublocale storePTE: typ_at_props' "storePTE slot pte"
+  by typ_at_props'
 
 lemma getObject_pte_inv[wp]:
   "\<lbrace>P\<rbrace> getObject p \<lbrace>\<lambda>rv :: pte. P\<rbrace>"
@@ -1191,7 +1184,8 @@ crunch copyGlobalMappings
   for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
   (wp: mapM_x_wp')
 
-lemmas copyGlobalMappings_typ_ats[wp] = typ_at_lifts [OF copyGlobalMappings_typ_at']
+sublocale copyGlobalMappings: typ_at_props' "copyGlobalMappings newPT"
+  by typ_at_props'
 
 lemma copy_global_mappings_corres [corres]:
   "corres dc (page_directory_at pd and pspace_aligned and valid_arch_state)

--- a/proof/refine/ARM_HYP/ArchCNodeInv_R.thy
+++ b/proof/refine/ARM_HYP/ArchCNodeInv_R.thy
@@ -508,4 +508,23 @@ proof goal_cases
   case 1 show ?case by (intro_locales; (unfold_locales; (fact CNodeInv_R_assms)?)?)
 qed
 
+context Arch begin arch_global_naming
+
+sublocale cteDelete: typ_at_props' "cteDelete slot exposed"
+  by typ_at_props'
+
+sublocale reduceZombie: typ_at_props' "reduceZombie cap slot x"
+  by typ_at_props'
+
+sublocale finaliseSlot: typ_at_props' "finaliseSlot ptr exposed"
+  by typ_at_props'
+
+sublocale invokeCNode: typ_at_props' "invokeCNode i"
+  by typ_at_props'
+
+sublocale cteMove: typ_at_props' "cteMove cap src dest"
+  by typ_at_props'
+
+end  (* Arch *)
+
 end

--- a/proof/refine/ARM_HYP/ArchCSpace1_R.thy
+++ b/proof/refine/ARM_HYP/ArchCSpace1_R.thy
@@ -231,7 +231,8 @@ proof -
   done
 qed
 
-lemmas setCTE_typ_ats[wp] = typ_at_lifts[OF setCTE_typ_at']
+sublocale setCTE: typ_at_props' "setCTE c cte"
+  by typ_at_props'
 
 lemma arch_updateCapData_Master[CSpace1_R_assms]:
   "Arch.updateCapData P d acap \<noteq> NullCap \<Longrightarrow>

--- a/proof/refine/ARM_HYP/ArchCSpace_R.thy
+++ b/proof/refine/ARM_HYP/ArchCSpace_R.thy
@@ -33,9 +33,14 @@ lemma capAligned_master[CSpace_R_assms]:
    apply (clarsimp simp: capAligned_def)+
   done
 
-lemmas updateMDB_typ_ats[wp] = typ_at_lifts[OF updateMDB_typ_at']
-lemmas updateCap_typ_ats[wp] = typ_at_lifts[OF updateCap_typ_at']
-lemmas cteInsert_typ_ats[wp] = typ_at_lifts[OF cteInsert_typ_at']
+sublocale updateMDB: typ_at_props' "updateMDB slot f"
+  by typ_at_props'
+
+sublocale updateCap: typ_at_props' "updateCap slot newCap"
+  by typ_at_props'
+
+sublocale cteInsert: typ_at_props' "cteInsert newCap srcSlot destSlot"
+  by typ_at_props'
 
 lemma maskedAsFull_derived'[CSpace_R_assms]:
   "\<lbrakk>m src = Some (CTE s_cap s_node); is_derived' m ptr b c\<rbrakk>

--- a/proof/refine/ARM_HYP/ArchFinalise_R.thy
+++ b/proof/refine/ARM_HYP/ArchFinalise_R.thy
@@ -23,7 +23,8 @@ lemma arch_postCapDeletion_ksArchState_lift[Finalise_R_assms]:
   unfolding postCapDeletion_def
   by wpsimp
 
-lemmas clearUntypedFreeIndex_typ_ats[wp] = typ_at_lifts[OF clearUntypedFreeIndex_typ_at']
+sublocale clearUntypedFreeIndex: typ_at_props' "clearUntypedFreeIndex slot"
+  by typ_at_props'
 
 crunch setIRQState
   for umm[Finalise_R_assms, wp]: "\<lambda>s. P (underlying_memory (ksMachineState s))"
@@ -610,11 +611,23 @@ lemma isFinal_no_descendants[Finalise_R_2_assms]:
   apply (simp add: valid_mdb'_def)
   done
 
-lemmas cancelAllIPC_typs[wp] = typ_at_lifts[OF cancelAllIPC_typ_at']
-lemmas cancelAllSignals_typs[wp] = typ_at_lifts[OF cancelAllSignals_typ_at']
-lemmas suspend_typs[wp] = typ_at_lifts[OF suspend_typ_at']
+sublocale cancelIPC: typ_at_props' "cancelIPC tptr"
+  by typ_at_props'
 
-lemmas finaliseCap_typ_ats[wp] = typ_at_lifts[OF finaliseCap_typ_at']
+sublocale cancelAllIPC: typ_at_props' "cancelAllIPC epptr"
+  by typ_at_props'
+
+sublocale cancelAllSignals: typ_at_props' "cancelAllSignals ntfnPtr"
+  by typ_at_props'
+
+sublocale suspend: typ_at_props' "suspend target"
+  by typ_at_props'
+
+sublocale finaliseCap: typ_at_props' "finaliseCap cap final x"
+  by typ_at_props'
+
+sublocale unbindNotification: typ_at_props' "unbindNotification tcb"
+  by typ_at_props'
 
 crunch flushSpace
   for invs'[wp]: "invs'"
@@ -697,7 +710,8 @@ lemma deleteASID_invs'[wp]:
   apply clarsimp
   done
 
-lemmas archThreadSet_typ_ats[wp] = typ_at_lifts[OF archThreadSet_typ_at']
+sublocale archThreadSet: typ_at_props' "archThreadSet f tptr"
+  by typ_at_props'
 
 lemma archThreadSet_valid_objs'[wp]:
   "\<lbrace>valid_objs' and (\<lambda>s. \<forall>tcb. ko_at' tcb t s \<longrightarrow> valid_arch_tcb' (f (tcbArch tcb)) s)\<rbrace>
@@ -1074,7 +1088,8 @@ lemma dissociateVCPUTCB_cte_wp_at'[wp]:
   "dissociateVCPUTCB v t \<lbrace>cte_wp_at' P p\<rbrace>"
   unfolding cte_wp_at_ctes_of by wp
 
-lemmas dissociateVCPUTCB_typ_ats'[wp] = typ_at_lifts[OF dissociateVCPUTCB_typ_at']
+sublocale dissociateVCPUTCB: typ_at_props' "dissociateVCPUTCB vcpu tcb"
+  by typ_at_props'
 
 crunch Arch.finaliseCap, prepareThreadDelete
   for irq_node'[Finalise_R_2_assms, wp]: "\<lambda>s. P (irq_node' s)"
@@ -1487,7 +1502,8 @@ lemma arch_finaliseCap_corres[Finalise_R_3_assms]:
   apply (clarsimp simp: valid_cap_def valid_cap'_def)
   done
 
-lemmas deleteCallerCap_typ_ats[wp] = typ_at_lifts[OF deleteCallerCap_typ_at']
+sublocale deleteCallerCap: typ_at_props' "deleteCallerCap receiver"
+  by typ_at_props'
 
 end (* Arch *)
 

--- a/proof/refine/ARM_HYP/ArchInvsLemmas_H.thy
+++ b/proof/refine/ARM_HYP/ArchInvsLemmas_H.thy
@@ -446,6 +446,25 @@ lemmas typ_at_lifts = gen_typ_at_lifts typ_at_lifts_strong_internal
 
 end
 
+end (* Arch *)
+
+locale typ_at_props' = Arch +
+  fixes f :: "_ kernel"
+  assumes typ': "f \<lbrace>\<lambda>s. P (typ_at' T p' s)\<rbrace>"
+begin
+
+lemmas typ_ats[wp] = typ_at_lifts[REPEAT [OF typ']]
+
+context begin
+(* We want to enforce that typ_ats only contains lemmas that have no
+   assumptions. The following thm statement should fail if this is not true. *)
+private lemmas check_valid_internal = iffD1[OF refl, where P="valid p g q" for p g q]
+thm typ_ats[atomized, THEN check_valid_internal]
+end
+
+end (* typ_at_props' *)
+
+context Arch begin arch_global_naming
 
 lemmas bit_simps' = pteBits_def pdeBits_def asidHighBits_def asid_low_bits_def word_size_bits_def
                     asid_high_bits_def bit_simps

--- a/proof/refine/ARM_HYP/ArchInvsLemmas_H.thy
+++ b/proof/refine/ARM_HYP/ArchInvsLemmas_H.thy
@@ -362,66 +362,90 @@ lemma is_physical_cases:
              | _                                \<Rightarrow> True)"
   by (simp split: capability.splits arch_capability.splits zombie_type.splits)
 
-lemma typ_at_lift_page_directory_at':
-  assumes x: "\<And>T p. \<lbrace>typ_at' T p\<rbrace> f \<lbrace>\<lambda>rv. typ_at' T p\<rbrace>"
-  shows      "\<lbrace>page_directory_at' p\<rbrace> f \<lbrace>\<lambda>rv. page_directory_at' p\<rbrace>"
-  unfolding page_directory_at'_def All_less_Ball
-  by (wp hoare_vcg_const_Ball_lift x)
+named_theorems Invariants_H_typ_at_lifts_assms
 
-lemma typ_at_lift_page_table_at':
-  assumes x: "\<And>T p. \<lbrace>typ_at' T p\<rbrace> f \<lbrace>\<lambda>rv. typ_at' T p\<rbrace>"
-  shows      "\<lbrace>page_table_at' p\<rbrace> f \<lbrace>\<lambda>rv. page_table_at' p\<rbrace>"
-  unfolding page_table_at'_def All_less_Ball
-  by (wp hoare_vcg_const_Ball_lift x)
-
-lemma typ_at_lift_asid_at':
-  "(\<And>T p. \<lbrace>typ_at' T p\<rbrace> f \<lbrace>\<lambda>_. typ_at' T p\<rbrace>) \<Longrightarrow> \<lbrace>asid_pool_at' p\<rbrace> f \<lbrace>\<lambda>_. asid_pool_at' p\<rbrace>"
-  by assumption
-
-lemma typ_at_lift_vcpu_at':
-  "(\<And>T p. \<lbrace>typ_at' T p\<rbrace> f \<lbrace>\<lambda>_. typ_at' T p\<rbrace>) \<Longrightarrow> \<lbrace>vcpu_at' p\<rbrace> f \<lbrace>\<lambda>_. vcpu_at' p\<rbrace>"
-  by assumption
-
-lemma typ_at_lift_valid_cap':
-  assumes P: "\<And>P T p. \<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace> f \<lbrace>\<lambda>rv s. P (typ_at' T p s)\<rbrace>"
-  shows      "\<lbrace>\<lambda>s. valid_cap' cap s\<rbrace> f \<lbrace>\<lambda>rv s. valid_cap' cap s\<rbrace>"
-  including no_pre
-  apply (simp add: valid_cap'_def)
-  apply wp
-  apply (case_tac cap;
-         simp add: valid_cap'_def P[of id, simplified] typ_at_lift_tcb'
-                   hoare_vcg_prop typ_at_lift_ep'
-                   typ_at_lift_ntfn' typ_at_lift_cte_at'
-                   hoare_vcg_conj_lift [OF typ_at_lift_cte_at'])
-     apply (rename_tac zombie_type nat)
-     apply (case_tac zombie_type; simp)
-      apply (wp typ_at_lift_tcb' P hoare_vcg_all_lift typ_at_lift_cte')+
-    apply (rename_tac arch_capability)
-    apply (case_tac arch_capability,
-           simp_all add: P[of id, simplified] vspace_table_at'_defs
-                         hoare_vcg_prop All_less_Ball
-                    split del: if_split)
-       apply (wp hoare_vcg_const_Ball_lift P typ_at_lift_valid_untyped'
-                 hoare_vcg_all_lift typ_at_lift_cte')+
+lemma page_directory_at'_typ_at_lift_strong:
+  "(\<And>p. f \<lbrace>\<lambda>s. P (typ_at' (ArchT PDET) p s)\<rbrace>) \<Longrightarrow> f \<lbrace>\<lambda>s. P (page_directory_at' p s)\<rbrace>"
+  unfolding page_directory_at'_def
+  apply (rule bool_to_bool_cases[where f=P]; clarsimp)
+  apply (wpsimp wp: hoare_vcg_const_Ball_lift hoare_vcg_imp_lift
+                    hoare_vcg_all_lift hoare_vcg_ex_lift
+         | assumption)+
   done
 
-(* interface lemma *)
-lemma valid_arch_tcb_lift':
-  assumes x: "\<And>T p. \<lbrace>typ_at' T p\<rbrace> f \<lbrace>\<lambda>rv. typ_at' T p\<rbrace>"
-  shows "\<lbrace>\<lambda>s. valid_arch_tcb' tcb s\<rbrace> f \<lbrace>\<lambda>rv s. valid_arch_tcb' tcb s\<rbrace>"
-  apply (clarsimp simp add: valid_arch_tcb'_def)
-  apply (cases "atcbVCPUPtr tcb"; simp)
-   apply (wp x)+
+lemma page_table_at'_typ_at_lift_strong:
+  "(\<And>p. f \<lbrace>\<lambda>s. P (typ_at' (ArchT PTET) p s)\<rbrace>) \<Longrightarrow> f \<lbrace>\<lambda>s. P (page_table_at' p s)\<rbrace>"
+  unfolding page_table_at'_def
+  apply (rule bool_to_bool_cases[where f=P]; clarsimp)
+  apply (wpsimp wp: hoare_vcg_const_Ball_lift hoare_vcg_imp_lift
+                    hoare_vcg_all_lift hoare_vcg_ex_lift
+         | assumption)+
   done
 
-lemmas typ_at_lifts =
-           typ_at_lift_tcb' typ_at_lift_ep' typ_at_lift_ntfn' typ_at_lift_cte' typ_at_lift_cte_at'
-           typ_at_lift_valid_untyped' typ_at_lift_valid_cap' valid_bound_tcb_lift
-           typ_at_lift_vcpu_at'
-           typ_at_lift_page_table_at'
-           typ_at_lift_page_directory_at'
-           typ_at_lift_asid_at'
-           valid_arch_tcb_lift'
+lemma asid_pool_at'_typ_at_lift_strong:
+  "(\<And>T p. f \<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace>) \<Longrightarrow> f \<lbrace>\<lambda>s. P (asid_pool_at' p s)\<rbrace>"
+  by assumption
+
+lemma vcpu_at'_typ_at_lift_strong:
+  "(\<And>T p. f \<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace>) \<Longrightarrow> f \<lbrace>\<lambda>s. P (vcpu_at' p s)\<rbrace>"
+  by assumption
+
+lemma valid_arch_tcb'_typ_at_lift_strong[Invariants_H_typ_at_lifts_assms]:
+  "(\<And>T p. f \<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace>) \<Longrightarrow> f \<lbrace>\<lambda>s. P (valid_arch_tcb' tcb s)\<rbrace>"
+  unfolding valid_arch_tcb'_def
+  apply (rule bool_to_bool_cases[where f=P]; clarsimp)
+  apply (wpsimp wp: hoare_vcg_imp_lift hoare_vcg_all_lift hoare_vcg_ex_lift
+         | assumption)+
+  done
+
+lemma valid_arch_cap'_typ_at_lift[Invariants_H_typ_at_lifts_assms]:
+  assumes P: "\<And>P T p. f \<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace>"
+  shows      "f \<lbrace>\<lambda>s. valid_arch_cap' cap s\<rbrace>"
+  apply (case_tac cap,
+         simp_all add: P[where P=id, simplified] All_less_Ball
+            split del: if_split)
+    apply (wp hoare_vcg_const_Ball_lift P
+              page_directory_at'_typ_at_lift_strong page_table_at'_typ_at_lift_strong)+
+  done
+
+end (* Arch *)
+
+global_interpretation Invariants_H_typ_at_lifts?: Invariants_H_typ_at_lifts
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case by (intro_locales; unfold_locales; (fact Invariants_H_typ_at_lifts_assms)?)
+qed
+
+context Arch begin arch_global_naming
+
+lemmas typ_at_lifts_strong =
+  gen_typ_at_lifts_strong
+  page_directory_at'_typ_at_lift_strong
+  page_table_at'_typ_at_lift_strong
+  asid_pool_at'_typ_at_lift_strong
+  vcpu_at'_typ_at_lift_strong
+
+context begin
+
+\<comment>\<open> See the comment above @{ML weaken_typ_at_lifts_thms} for an explanation of what
+    this @{command ML_goal} is for. Here we are constructing the combined list of
+    both generic and arch-specific typ_at_lifts lemmas.\<close>
+ML \<open>
+local
+  val strong_thms = subtract Thm.eq_thm gen_strong_thms @{thms typ_at_lifts_strong[no_vars]};
+in
+  val typ_at_lifts_internal_goals = weaken_typ_at_lifts_thms strong_thms
+end
+\<close>
+
+private ML_goal typ_at_lifts_strong_internal:
+  \<open>typ_at_lifts_internal_goals\<close>
+  by (auto simp: typ_at_lifts_strong)
+
+lemmas typ_at_lifts = gen_typ_at_lifts typ_at_lifts_strong_internal
+
+end
+
 
 lemmas bit_simps' = pteBits_def pdeBits_def asidHighBits_def asid_low_bits_def word_size_bits_def
                     asid_high_bits_def bit_simps

--- a/proof/refine/ARM_HYP/ArchIpc_R.thy
+++ b/proof/refine/ARM_HYP/ArchIpc_R.thy
@@ -278,6 +278,33 @@ lemma dmo_addressTranslateS1_valid_machine_state'[wp]:
                     addressTranslateS1_underlying_memory
                     hoare_vcg_disj_lift)
 
+sublocale setExtraBadge: typ_at_props' "setExtraBadge buffer badge n"
+  by typ_at_props'
+
+sublocale transferCaps: typ_at_props' "transferCaps info caps endpoint receiver receiveBuffer"
+  by typ_at_props'
+
+sublocale copyMRs: typ_at_props' "copyMRs s sb r rb n"
+  by typ_at_props'
+
+sublocale doNormalTransfer: typ_at_props' "doNormalTransfer s sb e b g r rb"
+  by typ_at_props'
+
+sublocale doIPCTransfer: typ_at_props' "doIPCTransfer s e b g r"
+  by typ_at_props'
+
+sublocale handleFaultReply: typ_at_props' "handleFaultReply x t l m"
+  by typ_at_props'
+
+sublocale sendFaultIPC: typ_at_props' "sendFaultIPC tptr fault"
+  by typ_at_props'
+
+sublocale receiveIPC: typ_at_props' "receiveIPC t cap b"
+  by typ_at_props'
+
+sublocale receiveSignal: typ_at_props' "receiveSignal t cap b"
+  by typ_at_props'
+
 end (* Arch *)
 
 end

--- a/proof/refine/ARM_HYP/ArchKHeap_R.thy
+++ b/proof/refine/ARM_HYP/ArchKHeap_R.thy
@@ -385,7 +385,7 @@ lemma valid_arch_state_lift':
   including no_pre
   apply (wp hoare_vcg_const_Ball_lift)
   apply (case_tac "armHSCurVCPU x"; simp add: split_def; wp?)
-  apply (wpsimp wp: vcpu typ_at_lifts typs pds valid_pde_mappings'_lift')+
+  apply (wpsimp wp: vcpu typs pds valid_pde_mappings'_lift')+
   done
 
 lemma valid_arch_state_lift'_valid_pde_mappings':
@@ -461,8 +461,6 @@ crunch setEndpoint, setNotification
   for valid_arch'[wp]: valid_arch_state'
   (wp: valid_arch_state_lift')
 
-lemmas setObject_typ_ats[wp] = typ_at_lifts[OF setObject_typ_at']
-
 lemma setObject_ko_wp_at':
   fixes v :: "'a :: pspace_storable"
   assumes x: "\<And>v :: 'a. updateObject v = updateObject_default v"
@@ -478,9 +476,14 @@ lemma setObject_ko_wp_at':
 
 lemmas [KHeap_R_assms_2] = setEndpoint_valid_arch' setNotification_valid_arch'
 
-lemmas doMachineOp_typ_ats[wp] = typ_at_lifts[OF doMachineOp_typ_at']
+sublocale setObject: typ_at_props' "setObject p v"
+  by typ_at_props'
 
-lemmas setEndpoint_typ_ats[wp] = typ_at_lifts[OF setEndpoint_typ_at']
+sublocale doMachineOp: typ_at_props' "doMachineOp mop"
+  by typ_at_props'
+
+sublocale setEndpoint: typ_at_props' "setEndpoint ptr val"
+  by typ_at_props'
 
 end
 

--- a/proof/refine/ARM_HYP/ArchSchedule_R.thy
+++ b/proof/refine/ARM_HYP/ArchSchedule_R.thy
@@ -104,7 +104,7 @@ lemma vcpuSwitch_typ_at'[wp]:
 
 lemma arch_switch_thread_tcb_at'[wp]:
   "\<lbrace>tcb_at' t\<rbrace> Arch.switchToThread t \<lbrace>\<lambda>_. tcb_at' t\<rbrace>"
-  by (unfold ARM_HYP_H.switchToThread_def, wp typ_at_lift_tcb')
+  by (unfold ARM_HYP_H.switchToThread_def, wp)
 
 crunch setVMRoot, vcpuSwitch
   for pred_tcb_at'[wp]: "pred_tcb_at' proj P t'"

--- a/proof/refine/ARM_HYP/ArchTcbAcc_R.thy
+++ b/proof/refine/ARM_HYP/ArchTcbAcc_R.thy
@@ -201,7 +201,8 @@ lemma threadSet_iflive'T[TcbAcc_R_assms]:
   apply (clarsimp simp: bspec_split [OF spec [OF x]])
   done
 
-lemmas threadSet_typ_at_lifts[wp] = typ_at_lifts[OF threadSet_typ_at']
+sublocale threadSet: typ_at_props' "threadSet tptr f"
+  by typ_at_props'
 
 lemma setObject_tcb_pde_mappings'[wp]:
   "\<lbrace>valid_pde_mappings'\<rbrace> setObject p (tcb :: tcb) \<lbrace>\<lambda>rv. valid_pde_mappings'\<rbrace>"
@@ -239,8 +240,11 @@ lemma asUser_valid_tcbs'[wp]:
               simp: valid_tcb'_def valid_arch_tcb'_def tcb_cte_cases_def objBits_simps')
   done
 
-lemmas addToBitmap_typ_ats[wp] = typ_at_lifts[OF addToBitmap_typ_at']
-lemmas removeFromBitmap_typ_ats[wp] = typ_at_lifts[OF removeFromBitmap_typ_at']
+sublocale addToBitmap: typ_at_props' "addToBitmap tdom prio"
+  by typ_at_props'
+
+sublocale removeFromBitmap: typ_at_props' "removeFromBitmap tdom prio"
+  by typ_at_props'
 
 crunch tcbQueueRemove, tcbQueuePrepend, tcbQueueAppend, tcbQueueInsert,
          setQueue, removeFromBitmap
@@ -358,7 +362,8 @@ context Arch begin arch_global_naming
 
 named_theorems TcbAcc_R_2_assms
 
-lemmas asUser_typ_ats[wp] = typ_at_lifts[OF asUser_typ_at']
+sublocale asUser: typ_at_props' "asUser tptr f"
+  by typ_at_props'
 
 lemma tcb_hyp_refs'_valid_arch_tcb'_eq[TcbAcc_R_2_assms]:
   "tcb_hyp_refs' (tcbArch (F tcb)) = tcb_hyp_refs' (tcbArch tcb)
@@ -891,8 +896,17 @@ lemma set_mrs_invs'[TcbAcc_R_3_assms, wp]:
          simp add: zipWithM_x_mapM split_def)+
   done
 
-lemmas setThreadState_typ_ats[wp] = typ_at_lifts [OF setThreadState_typ_at']
-lemmas setBoundNotification_typ_ats[wp] = typ_at_lifts [OF setBoundNotification_typ_at']
+sublocale rescheduleRequired: typ_at_props' "rescheduleRequired"
+  by typ_at_props'
+
+sublocale tcbSchedDequeue: typ_at_props' "tcbSchedDequeue thread"
+  by typ_at_props'
+
+sublocale setThreadState: typ_at_props' "setThreadState st p"
+  by typ_at_props'
+
+sublocale setBoundNotification: typ_at_props' "setBoundNotification v p"
+  by typ_at_props'
 
 end (* Arch *)
 

--- a/proof/refine/ARM_HYP/ArchTcb_R.thy
+++ b/proof/refine/ARM_HYP/ArchTcb_R.thy
@@ -39,6 +39,12 @@ lemma asUser_postModifyRegisters_corres[Tcb_R_assms]:
    use this as interface, but keep original lemma name for use outside of Arch *)
 lemmas threadSet_state_hyp_refs_of'_interface[Tcb_R_assms] = threadSet_state_hyp_refs_of'
 
+sublocale setPriority: typ_at_props' "setPriority t prio"
+  by typ_at_props'
+
+sublocale setMCPriority: typ_at_props' "setMCPriority t prio"
+  by typ_at_props'
+
 lemma sameObject_corres2[Tcb_R_assms]:
   "\<lbrakk> cap_relation c c'; cap_relation d d' \<rbrakk>
    \<Longrightarrow> same_object_as c d = sameObjectAs c' d'"

--- a/proof/refine/ARM_HYP/ArchVSpace_R.thy
+++ b/proof/refine/ARM_HYP/ArchVSpace_R.thy
@@ -1608,33 +1608,57 @@ proof -
   done
 qed
 
-crunch armv_contextSwitch
-  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  (simp: crunch_simps)
+crunch unmapPageTable, unmapPage, setVMRoot, setMessageInfo, setMRs, performPageTableInvocation,
+       performPageDirectoryInvocation, performASIDPoolInvocation, performPageInvocation
+  for typ_at' [wp]: "\<lambda>s. P (typ_at' T p s)"
+  (wp: crunch_wps getASID_wp simp: crunch_simps)
 
-crunch vcpuEnable, vcpuDisable, vcpuSave, vcpuRestore
+sublocale unmapPageTable: typ_at_props' "unmapPageTable asid vaddr pt"
+  by typ_at_props'
+
+sublocale unmapPage: typ_at_props' "unmapPage magnitude asid vptr ptr"
+  by typ_at_props'
+
+sublocale setVMRoot: typ_at_props' "setVMRoot tcb"
+  by typ_at_props'
+
+sublocale loadHWASID: typ_at_props' "loadHWASID asid"
+  by typ_at_props'
+
+sublocale setVMRootForFlush: typ_at_props' "setVMRootForFlush pd asid"
+  by typ_at_props'
+
+sublocale setMessageInfo: typ_at_props' "setMessageInfo thread info"
+  by typ_at_props'
+
+sublocale setMRs: typ_at_props' "setMRs thread buffer messageData"
+  by typ_at_props'
+
+sublocale performPageTableInvocation: typ_at_props' "performPageTableInvocation iv"
+  by typ_at_props'
+
+sublocale performPageDirectoryInvocation: typ_at_props' "performPageDirectoryInvocation iv"
+  by typ_at_props'
+
+sublocale performPageInvocation: typ_at_props' "performPageInvocation iv"
+  by typ_at_props'
+
+sublocale performASIDPoolInvocation: typ_at_props' "performASIDPoolInvocation iv"
+  by typ_at_props'
+
+sublocale flushTable: typ_at_props' "flushTable pd asid vptr"
+  by typ_at_props'
+
+sublocale findPDForASID: typ_at_props' "findPDForASID asid"
+  by typ_at_props'
+
+sublocale flushPage: typ_at_props' "flushPage m pd asid vptr"
+  by typ_at_props'
+
+crunch vcpuEnable, vcpuDisable, vcpuSave, vcpuRestore, vcpuSwitch
   for typ_at' [wp]: "\<lambda>s. P (typ_at' T p s)"
   (simp: crunch_simps
      wp: crunch_wps getObject_inv loadObject_default_inv)
-
-lemma vcpuSwitch_typ_at'[wp]:
-  "\<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace> vcpuSwitch param_a \<lbrace>\<lambda>_ s. P (typ_at' T p s) \<rbrace>"
-  by (wpsimp simp: vcpuSwitch_def modifyArchState_def | assumption)+
-
-crunch setVMRoot
-  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  (simp: crunch_simps
-     wp: crunch_wps getObject_inv loadObject_default_inv)
-
-lemmas setVMRoot_typ_ats [wp] = typ_at_lifts [OF setVMRoot_typ_at']
-
-lemmas loadHWASID_typ_ats [wp] = typ_at_lifts [OF loadHWASID_inv]
-
-crunch setVMRootForFlush
-  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  (wp: hoare_drop_imps)
-
-lemmas setVMRootForFlush_typ_ats' [wp] = typ_at_lifts [OF setVMRootForFlush_typ_at']
 
 crunch setVMRootForFlush
   for aligned'[wp]: pspace_aligned'
@@ -1850,14 +1874,6 @@ lemma flushPage_corres:
                | fold cur_tcb_def cur_tcb'_def)+
   done
 
-crunch flushTable
-  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  (simp: assertE_def when_def wp: crunch_wps)
-
-lemmas flushTable_typ_ats' [wp] = typ_at_lifts [OF flushTable_typ_at']
-
-lemmas findPDForASID_typ_ats' [wp] = typ_at_lifts [OF findPDForASID_inv]
-
 crunch vcpuEnable, vcpuSave, vcpuDisable, vcpuRestore
   for pspace_aligned'[wp]: pspace_aligned'
   (simp: crunch_simps wp: crunch_wps getObject_inv_vcpu loadObject_default_inv)
@@ -2000,12 +2016,6 @@ lemma unmapPageTable_corres:
    apply (auto elim: simp: empty_table_def valid_pde_mappings_def pde_ref_def obj_at_def
                      vs_refs_pages_def graph_of_def split: if_splits)
   done
-
-crunch flushPage
-  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  (wp: crunch_wps hoare_drop_imps)
-
-lemmas flushPage_typ_ats' [wp] = typ_at_lifts [OF flushPage_typ_at']
 
 lemma valid_objs_valid_vcpu': "\<lbrakk> valid_objs' s ; ko_at' (t :: vcpu) p s \<rbrakk> \<Longrightarrow> valid_vcpu' t"
   by (fastforce simp add: obj_at'_def ran_def valid_obj'_def valid_objs'_def)
@@ -2671,8 +2681,6 @@ crunch updateCap
   (wp: crunch_wps
    simp: crunch_simps unless_def)
 
-lemmas setMRs_typ_at_lifts[wp] = typ_at_lifts [OF setMRs_typ_at']
-
 lemma same_refs_vs_cap_ref_eq:
   assumes "valid_slots entries s"
   assumes "same_refs entries cap s"
@@ -3002,10 +3010,6 @@ lemma clear_page_table_corres:
    apply (simp add: ptBits_def pageBits_def pt_bits_def word_less_nat_alt word_le_nat_alt unat_of_nat)
   apply simp
   done
-
-crunch unmapPageTable
-  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-lemmas unmapPageTable_typ_ats[wp] = typ_at_lifts[OF unmapPageTable_typ_at']
 
 lemma performPageTableInvocation_corres:
   "page_table_invocation_map pti pti' \<Longrightarrow>
@@ -3729,8 +3733,7 @@ lemma dmo_maskInterrupt_True_invs_no_cicd'[wp]:
 
 lemma vcpuDisable_invs_no_cicd'[wp]:
   "\<lbrace>invs_no_cicd'\<rbrace> vcpuDisable v \<lbrace>\<lambda>_. invs_no_cicd'\<rbrace>"
-  by (wpsimp wp: doMachineOp_typ_ats
-             simp: vcpuDisable_def valid_vcpu'_def doMachineOp_typ_at' split: option.splits
+  by (wpsimp simp: vcpuDisable_def valid_vcpu'_def doMachineOp_typ_at' split: option.splits
       | subst doMachineOp_bind | rule empty_fail_bind conjI)+
 
 lemma vcpuRestore_invs_no_cicd'[wp]:
@@ -4213,34 +4216,6 @@ lemma valid_slots_lift':
   apply safe
    apply (rule hoare_pre, wp hoare_vcg_const_Ball_lift t, simp)+
   done
-
-crunch performPageTableInvocation
-  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  (wp: crunch_wps)
-
-crunch performPageDirectoryInvocation
-  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  (wp: crunch_wps)
-
-crunch performPageInvocation
-  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  (wp: crunch_wps)
-
-crunch performASIDPoolInvocation
-  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  (wp: getObject_cte_inv getASID_wp)
-
-lemmas performPageTableInvocation_typ_ats' [wp] =
-  typ_at_lifts [OF performPageTableInvocation_typ_at']
-
-lemmas performPageDirectoryInvocation_typ_ats' [wp] =
-  typ_at_lifts [OF performPageDirectoryInvocation_typ_at']
-
-lemmas performPageInvocation_typ_ats' [wp] =
-  typ_at_lifts [OF performPageInvocation_typ_at']
-
-lemmas performASIDPoolInvocation_typ_ats' [wp] =
-  typ_at_lifts [OF performASIDPoolInvocation_typ_at']
 
 lemma storePDE_pred_tcb_at' [wp]:
   "\<lbrace>pred_tcb_at' proj P t\<rbrace> storePDE p pde \<lbrace>\<lambda>_. pred_tcb_at' proj P t\<rbrace>"
@@ -4997,8 +4972,6 @@ lemma mapM_storePDE_invs:
 crunch unmapPage
   for cte_wp_at': "\<lambda>s. P (cte_wp_at' P' p s)"
   (wp: crunch_wps simp: crunch_simps)
-
-lemmas unmapPage_typ_ats [wp] = typ_at_lifts [OF unmapPage_typ_at']
 
 lemma flushPage_invs' [wp]:
   "\<lbrace>invs'\<rbrace> flushPage sz pd asid vptr \<lbrace>\<lambda>_. invs'\<rbrace>"

--- a/proof/refine/CNodeInv_R.thy
+++ b/proof/refine/CNodeInv_R.thy
@@ -6369,11 +6369,12 @@ lemma cteDelete_invs':
   apply simp
   done
 
-lemma cteDelete_typ_at' [wp]:
-  "\<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace> cteDelete slot exposed \<lbrace>\<lambda>_ s. P (typ_at' T p s)\<rbrace>"
-  by (wp cteDelete_preservation | simp | fastforce)+
+crunch cteDelete
+  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
+  (rule: cteDelete_preservation)
 
-lemmas cteDelete_typ_at'_lifts [wp] = gen_typ_at_lifts [OF cteDelete_typ_at']
+sublocale cteDelete: gen_typ_at_props' "cteDelete slot exposed"
+  by typ_at_props'
 
 lemma cteDelete_cte_at:
   "\<lbrace>\<top>\<rbrace> cteDelete slot bool \<lbrace>\<lambda>rv. cte_at' slot\<rbrace>"
@@ -6381,7 +6382,7 @@ lemma cteDelete_cte_at:
                in hoare_weaken_pre)
    apply (rule hoare_strengthen_post)
     apply (rule hoare_vcg_disj_lift)
-     apply (rule gen_typ_at_lifts, rule cteDelete_typ_at')
+     apply (rule cteDelete.gen_typ_ats)
     apply (simp add: cteDelete_def finaliseSlot_def split_def)
     apply (rule validE_valid, rule bindE_wp_fwd)
      apply (subst finaliseSlot'_simps_ext)
@@ -6835,13 +6836,15 @@ crunch reduceZombie
   for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
   (simp: crunch_simps wp: crunch_wps)
 
-lemmas reduceZombie_typ_ats[wp] = gen_typ_at_lifts[OF reduceZombie_typ_at']
+sublocale reduceZombie: gen_typ_at_props' "reduceZombie cap slot x"
+  by typ_at_props'
 
-lemma finaliseSlot_typ_at'[wp]:
-  "\<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace> finaliseSlot ptr exposed \<lbrace>\<lambda>_ s. P (typ_at' T p s)\<rbrace>"
-  by (rule finaliseSlot_preservation, (wp | simp)+)
+crunch finaliseSlot
+  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
+  (rule: finaliseSlot_preservation)
 
-lemmas finaliseSlot_typ_ats[wp] = gen_typ_at_lifts[OF finaliseSlot_typ_at']
+sublocale finaliseSlot: gen_typ_at_props' "finaliseSlot ptr exposed"
+  by typ_at_props'
 
 lemma rec_del_corres:
   "\<forall>C \<in> rec_del_concrete args.
@@ -7645,7 +7648,8 @@ crunch invokeCNode
      simp: crunch_simps filterM_mapM unless_def
        wp: crunch_wps undefined_valid finaliseSlot_preservation)
 
-lemmas invokeCNode_typ_ats[wp] = gen_typ_at_lifts[OF invokeCNode_typ_at']
+sublocale invokeCNode: gen_typ_at_props' "invokeCNode i"
+  by typ_at_props'
 
 end (* CNodeInv_R *)
 
@@ -8399,10 +8403,11 @@ lemma cteMove_irq_handlers' [wp]:
 
 context CNodeInv_R begin
 
+sublocale cteMove: gen_typ_at_props' "cteMove cap src dest"
+  by typ_at_props'
+
 lemmas cteMove_valid_irq_node'[wp]
     = valid_irq_node_lift[OF cteMove_ksInterrupt cteMove_typ_at']
-
-lemmas cteMove_typ_at_lifts[wp] = gen_typ_at_lifts[OF cteMove_typ_at']
 
 lemmas finalise_slot_corres'
     = rec_del_corres[where args="FinaliseSlotCall slot exp",

--- a/proof/refine/CSpace1_R.thy
+++ b/proof/refine/CSpace1_R.thy
@@ -906,17 +906,11 @@ lemma setObject_cte_obj_at_tcb':
                         Structures_H.kernel_object.split_asm)
   done
 
-lemma setCTE_typ_at':
-  "\<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace> setCTE c cte \<lbrace>\<lambda>_ s. P (typ_at' T p s)\<rbrace>"
-  by (clarsimp simp add: setCTE_def) (wp setObject_typ_at')
+crunch setCTE
+  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
 
-lemmas setObject_typ_at [wp] = setObject_typ_at' [where P=id, simplified]
-
-lemma setCTE_typ_at [wp]:
-  "\<lbrace>typ_at' T p\<rbrace> setCTE c cte \<lbrace>\<lambda>_. typ_at' T p\<rbrace>"
-  by (clarsimp simp add: setCTE_def) wp
-
-lemmas gen_setCTE_typ_ats[wp] = gen_typ_at_lifts[OF setCTE_typ_at']
+global_interpretation setCTE: gen_typ_at_props' "setCTE c cte"
+  by typ_at_props'
 
 lemma setObject_cte_ksCurDomain[wp]:
   "\<lbrace>\<lambda>s. P (ksCurDomain s)\<rbrace> setObject ptr (cte::cte) \<lbrace>\<lambda>_ s. P (ksCurDomain s)\<rbrace>"

--- a/proof/refine/CSpace_R.thy
+++ b/proof/refine/CSpace_R.thy
@@ -1345,9 +1345,14 @@ crunch cteInsert
   for ct[wp]: "\<lambda>s. P (ksCurThread s)"
   (wp: setObject_cte_ct hoare_drop_imps)
 
-lemmas updateMDB_typ_ats[wp] = gen_typ_at_lifts[OF updateMDB_typ_at']
-lemmas updateCap_typ_ats[wp] = gen_typ_at_lifts[OF updateCap_typ_at']
-lemmas cteInsert_typ_ats[wp] = gen_typ_at_lifts[OF cteInsert_typ_at']
+global_interpretation updateMDB: gen_typ_at_props' "updateMDB slot f"
+  by typ_at_props'
+
+global_interpretation updateCap: gen_typ_at_props' "updateCap slot newCap"
+  by typ_at_props'
+
+global_interpretation cteInsert: gen_typ_at_props' "cteInsert newCap srcSlot destSlot"
+  by typ_at_props'
 
 context mdb_insert begin
 

--- a/proof/refine/Finalise_R.thy
+++ b/proof/refine/Finalise_R.thy
@@ -609,7 +609,8 @@ end (* mdb_empty *)
 
 text \<open>Properties about empty_slot/emptySlot\<close>
 
-lemmas clearUntypedFreeIndex_gen_typ_ats[wp] = gen_typ_at_lifts[OF clearUntypedFreeIndex_typ_at']
+global_interpretation clearUntypedFreeIndex: gen_typ_at_props' "clearUntypedFreeIndex slot"
+  by typ_at_props'
 
 lemma case_Null_If:
   "(case c of NullCap \<Rightarrow> a | _ \<Rightarrow> b) = (if c = NullCap then a else b)"
@@ -1751,33 +1752,32 @@ crunch cteDeleteOne, suspend
    simp: crunch_simps unless_def o_def
    ignore_del: setObject)
 
-lemmas cancelAllIPC_typs[wp] = gen_typ_at_lifts[OF cancelAllIPC_typ_at']
-lemmas cancelAllSignals_typs[wp] = gen_typ_at_lifts[OF cancelAllSignals_typ_at']
-lemmas suspend_typs[wp] = gen_typ_at_lifts[OF suspend_typ_at']
+global_interpretation cancelIPC: gen_typ_at_props' "cancelIPC tptr"
+  by typ_at_props'
+
+global_interpretation cancelAllIPC: gen_typ_at_props' "cancelAllIPC epptr"
+  by typ_at_props'
+
+global_interpretation cancelAllSignals: gen_typ_at_props' "cancelAllSignals ntfnPtr"
+  by typ_at_props'
+
+global_interpretation suspend: gen_typ_at_props' "suspend target"
+  by typ_at_props'
 
 context Finalise_R begin
 
 crunch finaliseCap
-  for aligned'[wp]: "pspace_aligned'"
-  (simp: crunch_simps assertE_def unless_def o_def
-     wp: getObject_inv loadObject_default_inv crunch_wps)
+  for aligned'[wp]: pspace_aligned'
+  and distinct'[wp]: pspace_distinct'
+  and typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
+  and it'[wp]: "\<lambda>s. P (ksIdleThread s)"
+  (wp: crunch_wps hoare_vcg_all_lift simp: crunch_simps)
 
-crunch finaliseCap
-  for distinct'[wp]: "pspace_distinct'"
-  (simp: crunch_simps assertE_def unless_def o_def
-     wp: getObject_inv loadObject_default_inv crunch_wps)
+sublocale finaliseCap: gen_typ_at_props' "finaliseCap cap final x"
+  by typ_at_props'
 
-crunch finaliseCap
-  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  (simp: crunch_simps assertE_def
-     wp: getObject_inv loadObject_default_inv crunch_wps)
-
-lemmas finaliseCap_typ_ats[wp] = gen_typ_at_lifts[OF finaliseCap_typ_at']
-
-crunch finaliseCap
-  for it'[wp]: "\<lambda>s. P (ksIdleThread s)"
-  (wp: mapM_x_wp_inv mapM_wp' hoare_drop_imps getObject_inv loadObject_default_inv
-   simp: crunch_simps updateObject_default_def o_def)
+sublocale unbindNotification: gen_typ_at_props' "unbindNotification tcb"
+  by typ_at_props'
 
 end (* Finalise_R *)
 
@@ -2349,7 +2349,8 @@ lemma cteDeleteOne_reply_pred_tcb_at:
   apply (intro impI conjI, (wp | simp)+)
   done
 
-lemmas setNotification_typ_at'[wp] = gen_typ_at_lifts[OF setNotification_typ_at']
+global_interpretation setNotification: gen_typ_at_props' "setNotification p ko"
+  by typ_at_props'
 
 crunch setBoundNotification, setNotification
   for sch_act_simple[wp]: sch_act_simple
@@ -2821,7 +2822,8 @@ crunch deleteCallerCap
   for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
   (wp: crunch_wps)
 
-lemmas deleteCallerCap_gen_typ_ats[wp] = gen_typ_at_lifts[OF deleteCallerCap_typ_at']
+sublocale deleteCallerCap: gen_typ_at_props' "deleteCallerCap receiver"
+  by typ_at_props'
 
 sublocale delete_one_conc_pre
   by (unfold_locales, wp)

--- a/proof/refine/Finalise_R.thy
+++ b/proof/refine/Finalise_R.thy
@@ -2040,8 +2040,6 @@ lemma unbindNotification_valid_objs'_helper':
   by (clarsimp simp: valid_bound_tcb'_def valid_ntfn'_def
                   split: option.splits ntfn.splits)
 
-lemmas setNotification_valid_tcb' = typ_at'_valid_tcb'_lift [OF setNotification_typ_at']
-
 lemma unbindNotification_valid_objs'[wp]:
   "\<lbrace>valid_objs'\<rbrace>
      unbindNotification t
@@ -2049,7 +2047,7 @@ lemma unbindNotification_valid_objs'[wp]:
   apply (simp add: unbindNotification_def)
   apply (rule hoare_pre)
   apply (wpsimp wp: threadSet_valid_objs' gbn_wp' set_ntfn_valid_objs' hoare_vcg_all_lift
-                    setNotification_valid_tcb' getNotification_wp
+                    getNotification_wp
                 simp: setBoundNotification_def unbindNotification_valid_objs'_helper
                       doUnbindNotification_def)
   apply (clarsimp elim!: obj_atE')
@@ -2065,7 +2063,7 @@ lemma unbindMaybeNotification_valid_objs'[wp]:
   apply (rule bind_wp[OF _ get_ntfn_sp'])
   apply (rule hoare_pre)
   apply (wpsimp wp: threadSet_valid_objs' gbn_wp' set_ntfn_valid_objs' hoare_vcg_all_lift
-                    setNotification_valid_tcb' getNotification_wp
+                    getNotification_wp
                 simp: setBoundNotification_def unbindNotification_valid_objs'_helper
                       doUnbindNotification_def)+
   apply (clarsimp elim!: obj_atE')

--- a/proof/refine/Interrupt_R.thy
+++ b/proof/refine/Interrupt_R.thy
@@ -666,7 +666,7 @@ lemma invoke_irq_control_invs'[wp]:
   "\<lbrace>invs' and irq_control_inv_valid' i\<rbrace> performIRQControl i \<lbrace>\<lambda>rv. invs'\<rbrace>"
   apply (cases i, simp_all add: performIRQControl_def)
   apply (rule hoare_pre)
-   apply_trace (wp cteInsert_simple_invs | simp add: cte_wp_at_ctes_of)+
+   apply (wp cteInsert_simple_invs | simp add: cte_wp_at_ctes_of)+
   apply (clarsimp simp: cte_wp_at_ctes_of arch_valid_irq_le_maxIRQ
                         gen_isCap_simps is_simple_cap'_IRQHandlerCap
                         safe_parent_for'_def arch_valid_irq_valid_IRQHandlerCap)

--- a/proof/refine/InvariantUpdates_H.thy
+++ b/proof/refine/InvariantUpdates_H.thy
@@ -13,18 +13,10 @@ arch_requalify_facts
   cte_wp_atE'
   cte_wp_at_cteI'
   tcb_at_cte_at'
-  typ_at_lift_valid_cap'
-  valid_arch_tcb_lift'
   tcb_at_cte_at'
   gen_objBitsT_simps
   objBitsT_koTypeOf (* FIXME arch-split: consider declaring [simp] here rather than Schedule_R *)
   hyp_refs_of_live'
-
-(* arch-specific typ_at_lifts in Arch *)
-lemmas gen_typ_at_lifts =
-         typ_at_lift_tcb' typ_at_lift_ep' typ_at_lift_ntfn' typ_at_lift_cte' typ_at_lift_cte_at'
-         typ_at_lift_valid_untyped' typ_at_lift_valid_cap' valid_bound_tcb_lift
-         valid_arch_tcb_lift'
 
 (* these depend on interpretations in ArchInvLemmas_H *)
 context pspace_update_eq'

--- a/proof/refine/InvariantUpdates_H.thy
+++ b/proof/refine/InvariantUpdates_H.thy
@@ -18,6 +18,13 @@ arch_requalify_facts
   objBitsT_koTypeOf (* FIXME arch-split: consider declaring [simp] here rather than Schedule_R *)
   hyp_refs_of_live'
 
+(* Transfer facts from partial locale (with extra assumptions) into complete locale.
+   Done this way because Invariants_H_typ_at_lifts has a fixes that gen_typ_at_props'_interface had
+   to inherit. Now that Invariants_H_typ_at_lifts has been instantiated, we can drop that fixes
+   assumption by moving everything into gen_typ_at_props'. *)
+sublocale gen_typ_at_props' < gen_typ_at_props'_interface \<open>TYPE('f_rvt)\<close> f
+  by unfold_locales (fact typ')
+
 (* these depend on interpretations in ArchInvLemmas_H *)
 context pspace_update_eq'
 begin

--- a/proof/refine/Invariants_H.thy
+++ b/proof/refine/Invariants_H.thy
@@ -1939,81 +1939,66 @@ lemma locateSlot_conv:
                          split: zombie_type.split cong: option.case_cong)
   done
 
+context
+begin
+
+private method typ_at_proof =
+  unfold obj_at'_real_def typ_at'_def ko_wp_at'_def,
+  (rule ext)+,
+  (rule iffI; clarsimp, case_tac ko; clarsimp simp: projectKO_opts_defs)
+
 lemma typ_at_tcb':
   "typ_at' TCBT = tcb_at'"
-  apply (rule ext)+
-  apply (simp add: obj_at'_real_def typ_at'_def)
-  apply (simp add: ko_wp_at'_def)
-  apply (rule iffI)
-   apply clarsimp
-   apply (case_tac ko)
-   apply (auto simp: projectKO_opt_tcb)[9]
-  apply (case_tac ko)
-  apply (auto simp: projectKO_opt_tcb)
-  done
+  by typ_at_proof
 
-lemma typ_at_ep:
+lemma typ_at_ep':
   "typ_at' EndpointT = ep_at'"
-  apply (rule ext)+
-  apply (simp add: obj_at'_real_def typ_at'_def)
-  apply (simp add: ko_wp_at'_def)
-  apply (rule iffI)
-   apply clarsimp
-   apply (case_tac ko)
-   apply (auto simp: projectKO_opt_ep)[9]
-  apply (case_tac ko)
-  apply (auto simp: projectKO_opt_ep)
-  done
+  by typ_at_proof
 
-lemma typ_at_ntfn:
+lemma typ_at_ntfn':
   "typ_at' NotificationT = ntfn_at'"
-  apply (rule ext)+
-  apply (simp add: obj_at'_real_def typ_at'_def)
-  apply (simp add: ko_wp_at'_def)
-  apply (rule iffI)
-   apply clarsimp
-   apply (case_tac ko)
-   apply (auto simp: projectKO_opt_ntfn)[8]
-  apply clarsimp
-  apply (case_tac ko)
-  apply (auto simp: projectKO_opt_ntfn)
-  done
+  by typ_at_proof
 
-lemma typ_at_cte:
+lemma typ_at_cte':
   "typ_at' CTET = real_cte_at'"
-  apply (rule ext)+
-  apply (simp add: obj_at'_real_def typ_at'_def)
-  apply (simp add: ko_wp_at'_def)
-  apply (rule iffI)
-   apply clarsimp
-   apply (case_tac ko)
-   apply (auto simp: projectKO_opt_cte)[8]
-  apply clarsimp
-  apply (case_tac ko)
-  apply (auto simp: projectKO_opt_cte)
-  done
+  by typ_at_proof
 
-lemma typ_at_lift_tcb':
-  "\<lbrace>typ_at' TCBT p\<rbrace> f \<lbrace>\<lambda>_. typ_at' TCBT p\<rbrace> \<Longrightarrow> \<lbrace>tcb_at' p\<rbrace> f \<lbrace>\<lambda>_. tcb_at' p\<rbrace>"
+lemmas typ_ats' = typ_at_cte' typ_at_ntfn' typ_at_ep' typ_at_tcb'
+
+end
+
+lemma tcb_at'_typ_at_lift_strong:
+  "f \<lbrace>\<lambda>s. P (typ_at' TCBT p s)\<rbrace> \<Longrightarrow> f \<lbrace>\<lambda>s. P (tcb_at' p s)\<rbrace>"
   by (simp add: typ_at_tcb')
 
-lemma typ_at_lift_ep':
-  "\<lbrace>typ_at' EndpointT p\<rbrace> f \<lbrace>\<lambda>_. typ_at' EndpointT p\<rbrace> \<Longrightarrow> \<lbrace>ep_at' p\<rbrace> f \<lbrace>\<lambda>_. ep_at' p\<rbrace>"
-  by (simp add: typ_at_ep)
+lemma ep_at'_typ_at_lift_strong:
+  "f \<lbrace>\<lambda>s. P (typ_at' EndpointT p s)\<rbrace> \<Longrightarrow> f \<lbrace>\<lambda>s. P (ep_at' p s)\<rbrace>"
+  by (simp add: typ_at_ep')
 
-lemma typ_at_lift_ntfn':
-  "\<lbrace>typ_at' NotificationT p\<rbrace> f \<lbrace>\<lambda>_. typ_at' NotificationT p\<rbrace> \<Longrightarrow> \<lbrace>ntfn_at' p\<rbrace> f \<lbrace>\<lambda>_. ntfn_at' p\<rbrace>"
-  by (simp add: typ_at_ntfn)
+lemma ntfn_at'_typ_at_lift_strong:
+  "f \<lbrace>\<lambda>s. P (typ_at' NotificationT p s)\<rbrace> \<Longrightarrow> f \<lbrace>\<lambda>s. P (ntfn_at' p s)\<rbrace>"
+  by (simp add: typ_at_ntfn')
 
-lemma typ_at_lift_cte':
-  "\<lbrace>typ_at' CTET p\<rbrace> f \<lbrace>\<lambda>_. typ_at' CTET p\<rbrace> \<Longrightarrow> \<lbrace>real_cte_at' p\<rbrace> f \<lbrace>\<lambda>_. real_cte_at' p\<rbrace>"
-  by (simp add: typ_at_cte)
+lemma real_cte_at'_typ_at_lift_strong:
+  "f \<lbrace>\<lambda>s. P (typ_at' CTET p s)\<rbrace> \<Longrightarrow> f \<lbrace>\<lambda>s. P (real_cte_at' p s)\<rbrace>"
+  by (simp add: typ_at_cte')
 
-lemma (in Invariants_H_cte_ats) typ_at_lift_cte_at':
-  assumes x: "\<And>T p. \<lbrace>typ_at' T p\<rbrace> f \<lbrace>\<lambda>rv. typ_at' T p\<rbrace>"
-  shows      "\<lbrace>cte_at' c\<rbrace> f \<lbrace>\<lambda>rv. cte_at' c\<rbrace>"
+lemma (in Invariants_H_cte_ats) cte_at'_typ_at_lift':
+  assumes x: "\<And>P T p. f \<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace>"
+  shows      "f \<lbrace>\<lambda>s. P (cte_at' c s)\<rbrace>"
   apply (simp only: cte_at_typ')
-  apply (wp hoare_vcg_disj_lift hoare_vcg_ex_lift x)
+  apply (rule P_bool_lift[where P=P])
+   apply (wpsimp wp: hoare_vcg_disj_lift hoare_vcg_ex_lift hoare_vcg_all_lift x)+
+  done
+
+lemma valid_tcb_state'_typ_at_lift_strong:
+  assumes ep: "\<And>p. f \<lbrace>\<lambda>s. P (typ_at' EndpointT p s)\<rbrace>"
+      and ntfn: "\<And>p. f \<lbrace>\<lambda>s. P (typ_at' NotificationT p s)\<rbrace>"
+  shows "f \<lbrace>\<lambda>s. P (valid_tcb_state' st s)\<rbrace>"
+  unfolding valid_tcb_state'_def
+  apply (case_tac st ; clarsimp split: option.splits,
+         wpsimp wp: hoare_vcg_imp_lift' hoare_vcg_all_lift ep_at'_typ_at_lift_strong[OF ep]
+                    ntfn_at'_typ_at_lift_strong[OF ntfn])
   done
 
 (* proof is identical for all architectures *)
@@ -2030,9 +2015,9 @@ lemma ko_wp_typ_at':
   "ko_wp_at' P p s \<Longrightarrow> \<exists>T. typ_at' T p s"
   by (clarsimp simp: typ_at'_def ko_wp_at'_def)
 
-lemma typ_at_lift_valid_untyped':
-  assumes P: "\<And>T p. \<lbrace>\<lambda>s. \<not>typ_at' T p s\<rbrace> f \<lbrace>\<lambda>rv s. \<not>typ_at' T p s\<rbrace>"
-  shows "\<lbrace>\<lambda>s. valid_untyped' d p n idx s\<rbrace> f \<lbrace>\<lambda>rv s. valid_untyped' d p n idx s\<rbrace>"
+lemma valid_untyped'_typ_at_lift:
+  assumes P: "\<And>T p. f \<lbrace>\<lambda>s. \<not>typ_at' T p s\<rbrace>"
+  shows "f \<lbrace>\<lambda>s. valid_untyped' d p n idx s\<rbrace>"
   apply (clarsimp simp: valid_untyped'_def split del:if_split)
   apply (rule hoare_vcg_all_lift)
   apply (clarsimp simp: valid_def split del:if_split)
@@ -2056,17 +2041,152 @@ lemma typ_at_lift_valid_untyped':
   apply (clarsimp split:if_splits)
   done
 
-lemma typ_at_lift_valid_irq_node':
-  assumes P: "\<And>P T p. \<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace> f \<lbrace>\<lambda>rv s. P (typ_at' T p s)\<rbrace>"
-  shows      "\<lbrace>valid_irq_node' p\<rbrace> f \<lbrace>\<lambda>_. valid_irq_node' p\<rbrace>"
-  apply (simp add: valid_irq_node'_def)
-  apply (wp hoare_vcg_all_lift P typ_at_lift_cte')
+lemma valid_bound_tcb'_typ_at_lift:
+  "(\<And>T p. f \<lbrace>typ_at' T p\<rbrace>) \<Longrightarrow> f \<lbrace>valid_bound_tcb' tcb\<rbrace>"
+  by (auto simp: valid_bound_tcb'_def valid_def typ_ats'[symmetric] split: option.splits)
+
+lemma valid_bound_ntfn'_typ_at_lift:
+  "(\<And>T p. f \<lbrace>typ_at' T p\<rbrace>) \<Longrightarrow> f \<lbrace>valid_bound_ntfn' ntfn\<rbrace>"
+  by (auto simp: valid_bound_ntfn'_def valid_def typ_ats'[symmetric] split: option.splits)
+
+lemma valid_ntfn'_typ_at_lift':
+  "(\<And>T p. f \<lbrace>typ_at' T p\<rbrace>) \<Longrightarrow> f \<lbrace>valid_ntfn' ntfn\<rbrace>"
+  unfolding valid_ntfn'_def
+  apply (cases "ntfnObj ntfn"; clarsimp)
+    apply (wpsimp wp: valid_bound_tcb'_typ_at_lift)
+   apply (wpsimp wp: valid_bound_tcb'_typ_at_lift)
+  apply (wpsimp wp: hoare_vcg_ball_lift tcb_at'_typ_at_lift_strong[where P=id, simplified])
+   apply (wpsimp wp: valid_bound_tcb'_typ_at_lift)
+  apply simp
   done
 
-lemma valid_bound_tcb_lift:
-  "(\<And>T p. \<lbrace>typ_at' T p\<rbrace> f \<lbrace>\<lambda>_. typ_at' T p\<rbrace>) \<Longrightarrow>
-  \<lbrace>valid_bound_tcb' tcb\<rbrace> f \<lbrace>\<lambda>_. valid_bound_tcb' tcb\<rbrace>"
-  by (auto simp: valid_bound_tcb'_def valid_def typ_at_tcb'[symmetric] split: option.splits)
+lemma valid_irq_node'_typ_at_lift:
+  assumes P: "\<And>P T p. f \<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace>"
+  shows      "f \<lbrace>valid_irq_node' p\<rbrace>"
+  apply (simp add: valid_irq_node'_def)
+  apply (wp hoare_vcg_all_lift P real_cte_at'_typ_at_lift_strong)
+  done
+
+(* arch-interface locale for typ_at lifting lemmas *)
+locale Invariants_H_typ_at_lifts = Invariants_H_cte_ats +
+  (* Use f_rvt_itself parameter to fix free type variable for the return value of f in the interface
+     lemmas. This is the loosest constraint that we have come up with to make this locale work, and
+     is able to be used here because nothing within the locale looks at f. *)
+  fixes f_rvt_itself :: "'f_rvt itself"
+  assumes valid_arch_tcb'_typ_at_lift_strong:
+    "\<And>(f :: 'f_rvt kernel) P tcb. (\<And>T p. f \<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace>) \<Longrightarrow> f \<lbrace>\<lambda>s. P (valid_arch_tcb' tcb s)\<rbrace>"
+  assumes valid_arch_cap'_typ_at_lift:
+    "\<And>(f :: 'f_rvt kernel) cap. (\<And>P T p. f \<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace>) \<Longrightarrow> f \<lbrace>valid_arch_cap' cap\<rbrace>"
+begin
+
+lemmas gen_typ_at_lifts_strong =
+  tcb_at'_typ_at_lift_strong[where 'a='f_rvt] ep_at'_typ_at_lift_strong[where 'a='f_rvt]
+  ntfn_at'_typ_at_lift_strong[where 'a='f_rvt] real_cte_at'_typ_at_lift_strong[where 'a='f_rvt]
+  valid_tcb_state'_typ_at_lift_strong[where 'a='f_rvt]
+  valid_arch_tcb'_typ_at_lift_strong
+
+(* anonymous context to keep gen_typ_at_lifts_strong_internal private *)
+context begin
+\<comment>\<open> We're using @{command ML_goal} here because there are two useful formulations
+    of typ_at lifting lemmas and we do not want to write all of the possibilities
+    out by hand. If we use typ_at_lift_tcb' as an example, then the first is
+    @{term "\<lbrace>\<lambda>s. P (typ_at' TCBT p s)\<rbrace> f \<lbrace>\<lambda>_ s. P (typ_at' TCBT p s)\<rbrace>
+            \<Longrightarrow> \<lbrace>\<lambda>s. P (tcb_at' p s)\<rbrace> f \<lbrace>\<lambda>_ s. P (tcb_at' p s)\<rbrace>"} and the second is
+    @{term "(\<And>P. \<lbrace>\<lambda>s. P (typ_at' TCBT p s)\<rbrace> f \<lbrace>\<lambda>_ s. P (typ_at' TCBT p s)\<rbrace>)
+            \<Longrightarrow> \<lbrace>\<lambda>s. P (tcb_at' p s)\<rbrace> f \<lbrace>\<lambda>_ s. P (tcb_at' p s)\<rbrace>"}.
+    The first form is stronger, and therefore preferred for backward reasoning
+    using rule. However, since the P in the premise is free in the first form,
+    forward unification using the OF attribute produces flex-flex pairs which
+    causes problems. The second form avoids the unification issue by demanding
+    that there is a P that is free in the lemma supplied to the OF attribute.
+    However, it can only be applied if @{term f} preserves both
+    @{term "typ_at' TCBT p s"} and @{term "\<not> typ_at' TCBT p s"}.
+    The following @{command ML_goal} generates lemmas of the second form based on
+    the previously proven stronger lemmas of the first form. \<close>
+ML \<open>
+fun weaken_typ_at_lifts_thms strong_thms =
+  let
+    fun abstract_P term = Logic.all (Free ("P", @{typ "bool \<Rightarrow> bool"})) term
+    fun abstract thm =
+      let
+        val prems = List.map abstract_P (Thm.prems_of thm);
+        fun imp [] = Thm.concl_of thm
+          | imp (p :: pms) = @{const Pure.imp} $ p $ imp pms
+      in
+        imp prems
+      end
+  in
+    List.map abstract strong_thms
+  end
+
+val gen_strong_thms = @{thms gen_typ_at_lifts_strong[no_vars]}
+val gen_typ_at_lifts_internal_goals = weaken_typ_at_lifts_thms gen_strong_thms
+\<close>
+
+private ML_goal gen_typ_at_lifts_strong_internal:
+  \<open>gen_typ_at_lifts_internal_goals\<close>
+  by (auto simp: gen_typ_at_lifts_strong)
+
+lemma valid_cap'_typ_at_lift:
+  assumes P: "\<And>P T p. (f :: 'f_rvt kernel) \<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace>"
+  shows      "f \<lbrace>\<lambda>s. valid_cap' cap s\<rbrace>"
+  including no_pre
+  apply (simp add: valid_cap'_def)
+  apply wp
+  apply (case_tac cap;
+         wpsimp wp: valid_cap'_def P gen_typ_at_lifts_strong
+                    valid_arch_cap'_typ_at_lift)
+     apply (rename_tac zombie_type nat)
+     apply (case_tac zombie_type; simp)
+      apply (wp gen_typ_at_lifts_strong[where P=id, simplified] P)
+    apply (wp hoare_vcg_all_lift P valid_untyped'_typ_at_lift gen_typ_at_lifts_strong)+
+  done
+
+lemma valid_obj'_typ_at_lift:
+  assumes P: "\<And>P T p. (f :: 'f_rvt kernel) \<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace>"
+  notes [wp] = hoare_vcg_all_lift hoare_vcg_imp_lift hoare_vcg_const_Ball_lift
+               gen_typ_at_lifts_strong[OF P] valid_cap'_typ_at_lift[OF P]
+               valid_bound_tcb'_typ_at_lift[OF P] valid_bound_ntfn'_typ_at_lift[OF P]
+  shows      "f \<lbrace>\<lambda>s. valid_obj' obj s\<rbrace>"
+  apply (cases obj; simp add: valid_obj'_def hoare_TrueI)
+      apply (rename_tac endpoint)
+      apply (case_tac endpoint; simp add: valid_ep'_def, wp)
+     apply (rename_tac notification)
+     apply (case_tac "ntfnObj notification";
+            simp add: valid_ntfn'_def split: option.splits,
+            (wpsimp|rule conjI)+)
+    apply (rename_tac tcb)
+    apply (case_tac "tcbState tcb";
+           simp add: valid_tcb'_def valid_tcb_state'_def split_def opt_tcb_at'_def;
+           wpsimp wp: hoare_case_option_wp)
+   apply (wpsimp simp: valid_cte'_def)+
+  done
+
+lemmas valid_ep'_typ_at_lift =
+  valid_obj'_typ_at_lift[where obj="KOEndpoint ko" for ko, simplified valid_obj'_def kernel_object.case]
+
+lemmas valid_ntfn'_typ_at_lift =
+  valid_obj'_typ_at_lift[where obj="KONotification ko" for ko, simplified valid_obj'_def kernel_object.case]
+
+lemmas valid_tcb'_typ_at_lift =
+  valid_obj'_typ_at_lift[where obj="KOTCB ko" for ko, simplified valid_obj'_def kernel_object.case]
+
+lemmas valid_cte'_typ_at_lift =
+  valid_obj'_typ_at_lift[where obj="KOCTE ko" for ko, simplified valid_obj'_def kernel_object.case]
+
+lemmas valid_arch_obj'_typ_at_lift =
+  valid_obj'_typ_at_lift[where obj="KOArch ko" for ko, simplified valid_obj'_def kernel_object.case]
+
+lemmas gen_typ_at_lifts =
+  gen_typ_at_lifts_strong_internal cte_at'_typ_at_lift' valid_untyped'_typ_at_lift
+  valid_bound_tcb'_typ_at_lift valid_bound_ntfn'_typ_at_lift valid_ntfn'_typ_at_lift'
+  valid_irq_node'_typ_at_lift valid_cap'_typ_at_lift valid_obj'_typ_at_lift valid_arch_cap'_typ_at_lift
+  valid_ep'_typ_at_lift valid_ntfn'_typ_at_lift valid_tcb'_typ_at_lift valid_cte'_typ_at_lift
+  valid_arch_obj'_typ_at_lift
+
+end
+
+end (* typ_at_gen *)
 
 lemma mdb_next_unfold:
   "s \<turnstile> c \<leadsto> c' = (\<exists>z. s c = Some z \<and> c' = mdbNext (cteMDBNode z))"

--- a/proof/refine/Invariants_H.thy
+++ b/proof/refine/Invariants_H.thy
@@ -2188,6 +2188,35 @@ end
 
 end (* typ_at_gen *)
 
+(* Will be a sublocale of gen_typ_at_props' once Invariants_H_typ_at_lifts is interpreted.
+   Done this way to avoid f_rvt_itself parameter in final gen_typ_at_props' locale.*)
+locale gen_typ_at_props'_interface = Invariants_H_typ_at_lifts "f_rvt_itself :: 'f_rvt itself" for f_rvt_itself +
+  fixes f :: "'f_rvt kernel"
+  assumes typ'_interface: "f \<lbrace>\<lambda>s. P (typ_at' T p' s)\<rbrace>"
+begin
+
+lemmas gen_typ_ats[wp] = gen_typ_at_lifts[REPEAT [OF typ'_interface]]
+
+context begin
+(* We want to enforce that gen_typ_ats only contains lemmas that have no
+   assumptions. The following thm statement should fail if this is not true. *)
+private lemmas check_valid_internal = iffD1[OF refl, where P="valid p g q" for p g q]
+thm gen_typ_ats[atomized, THEN check_valid_internal]
+end
+
+end (* gen_typ_at_props'_interface *)
+
+(* Main typ_at_props' locale used for function instantiation.
+   Requires Invariants_H_typ_at_lifts to be interpreted first before gen_typ_at_props'_interface
+   can become a sublocale. *)
+locale gen_typ_at_props' =
+  fixes f :: "'f_rvt kernel"
+  assumes typ': "f \<lbrace>\<lambda>s. P (typ_at' T p' s)\<rbrace>"
+
+(* we expect typ_at' lemmas to be [wp], so this should be easy *)
+method typ_at_props' "for instantiating typ_at_props' locale"
+  = unfold_locales; wp?
+
 lemma mdb_next_unfold:
   "s \<turnstile> c \<leadsto> c' = (\<exists>z. s c = Some z \<and> c' = mdbNext (cteMDBNode z))"
   by (auto simp add: mdb_next_rel_def mdb_next_def)

--- a/proof/refine/IpcCancel_R.thy
+++ b/proof/refine/IpcCancel_R.thy
@@ -88,7 +88,7 @@ locale delete_one_conc_pre =
   assumes delete_one_st_tcb_at:
     "\<And>P. (\<And>st. simple' st \<longrightarrow> P st) \<Longrightarrow>
      \<lbrace>st_tcb_at' P t\<rbrace> cteDeleteOne slot \<lbrace>\<lambda>rv. st_tcb_at' P t\<rbrace>"
-  assumes delete_one_typ_at:
+  assumes delete_one_typ_at[wp]:
     "\<And>P. \<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace> cteDeleteOne slot \<lbrace>\<lambda>rv s. P (typ_at' T p s)\<rbrace>"
   assumes delete_one_aligned:
     "\<lbrace>pspace_aligned'\<rbrace> cteDeleteOne slot \<lbrace>\<lambda>rv. pspace_aligned'\<rbrace>"
@@ -145,13 +145,15 @@ lemma (in delete_one_conc_pre) cancelIPC_st_tcb_at':
 
 context delete_one_conc_pre begin
 
-lemmas delete_one_typ_ats[wp] = gen_typ_at_lifts[OF delete_one_typ_at]
+(* FIXME arch-split: not clear where arch version of this should go *)
+sublocale delete_one: gen_typ_at_props' "cteDeleteOne slot"
+  by typ_at_props'
 
 lemma cancelIPC_tcb_at'[wp]:
   "\<lbrace>tcb_at' t\<rbrace> cancelIPC t' \<lbrace>\<lambda>_. tcb_at' t\<rbrace>"
   apply (simp add: cancelIPC_def Let_def getThreadReplySlot_def)
-  apply (wp delete_one_typ_ats hoare_drop_imps
-       | simp add: o_def if_apply_def2 | wpc | assumption)+
+  apply (wpsimp wp: hoare_drop_imps
+              simp: o_def if_apply_def2)
   done
 
 end (* delete_one_conc_pre *)

--- a/proof/refine/Ipc_R.thy
+++ b/proof/refine/Ipc_R.thy
@@ -3801,13 +3801,12 @@ lemma ri_invs' [wp]:
    apply (case_tac ep)
      \<comment> \<open>endpoint = RecvEP\<close>
      apply (simp add: invs'_def valid_state'_def)
-     apply (rule hoare_pre, wpc, wp valid_irq_node_lift valid_dom_schedule'_lift)
-      apply (simp add: valid_ep'_def)
-      apply (wp sts_sch_act' hoare_vcg_const_Ball_lift valid_irq_node_lift valid_dom_schedule'_lift
-                setThreadState_ct_not_inQ
-                asUser_urz
+     apply (rule hoare_pre, wpc, wp sts_sch_act' valid_irq_node_lift valid_dom_schedule'_lift)
+      apply simp
+      apply (wp hoare_vcg_const_Ball_lift valid_irq_node_lift valid_dom_schedule'_lift
+                setThreadState_ct_not_inQ asUser_urz
            | simp add: doNBRecvFailedTransfer_def cteCaps_of_def)+
-     apply (clarsimp simp: valid_tcb_state'_def pred_tcb_at' o_def)
+     apply (clarsimp simp: valid_ep'_def valid_tcb_state'_def pred_tcb_at' o_def)
      apply (rule conjI, clarsimp elim!: obj_at'_weakenE)
      apply (frule obj_at_valid_objs')
       apply (clarsimp simp: valid_pspace'_def)
@@ -3828,13 +3827,12 @@ lemma ri_invs' [wp]:
      apply (fastforce simp: valid_pspace'_def global'_no_ex_cap idle'_not_queued)
    \<comment> \<open>endpoint = IdleEP\<close>
     apply (simp add: invs'_def valid_state'_def)
-    apply (rule hoare_pre, wpc, wp valid_irq_node_lift valid_dom_schedule'_lift)
-     apply (simp add: valid_ep'_def)
-     apply (wp sts_sch_act' valid_irq_node_lift valid_dom_schedule'_lift
-               setThreadState_ct_not_inQ
-               asUser_urz
+    apply (rule hoare_pre, wpc, wp sts_sch_act' valid_irq_node_lift valid_dom_schedule'_lift)
+     apply simp
+     apply (wp valid_irq_node_lift valid_dom_schedule'_lift
+               setThreadState_ct_not_inQ asUser_urz
           | simp add: doNBRecvFailedTransfer_def cteCaps_of_def)+
-    apply (clarsimp simp: pred_tcb_at' valid_tcb_state'_def o_def)
+    apply (clarsimp simp: valid_ep'_def pred_tcb_at' valid_tcb_state'_def o_def)
     apply (rule conjI, clarsimp elim!: obj_at'_weakenE)
     apply (subgoal_tac "t \<noteq> capEPPtr cap")
      apply (drule simple_st_tcb_at_state_refs_ofD')
@@ -3854,16 +3852,16 @@ lemma ri_invs' [wp]:
    apply (case_tac list, simp_all split del: if_split)
    apply (rename_tac sender queue)
    apply (rule hoare_pre)
-    apply (wp valid_irq_node_lift hoare_drop_imps setEndpoint_valid_mdb'
+    apply (wp valid_irq_node_lift setEndpoint_valid_mdb'
               set_ep_valid_objs' sts_st_tcb' sts_sch_act' valid_dom_schedule'_lift
               setThreadState_ct_not_inQ
               possibleSwitchTo_ct_not_inQ hoare_vcg_all_lift
               setEndpoint_ksQ
-         | simp add: valid_tcb_state'_def case_bool_If
-                     case_option_If
-              split del: if_split cong: if_cong
-        | wp (once) sch_act_sane_lift hoare_vcg_conj_lift hoare_vcg_all_lift
-                  untyped_ranges_zero_lift)+
+           | simp add: valid_tcb_state'_def case_bool_If
+                       case_option_If
+                  split del: if_split cong: if_cong
+           | wp (once) hoare_drop_imps sch_act_sane_lift hoare_vcg_conj_lift hoare_vcg_all_lift
+                       untyped_ranges_zero_lift)+
    apply (clarsimp split del: if_split simp: pred_tcb_at')
    apply (frule obj_at_valid_objs')
     apply (clarsimp simp: valid_pspace'_def)
@@ -4090,10 +4088,10 @@ lemma si_invs'[wp]:
    \<comment> \<open>epa = IdleEP\<close>
    apply (cases bl)
     apply (simp add: invs'_def valid_state'_def)
-    apply (rule hoare_pre, wp valid_irq_node_lift valid_dom_schedule'_lift)
-     apply (simp add: valid_ep'_def)
-     apply (wp valid_irq_node_lift valid_dom_schedule'_lift sts_sch_act' setThreadState_ct_not_inQ)
-    apply (clarsimp simp: valid_tcb_state'_def pred_tcb_at')
+    apply (rule hoare_pre, wp sts_sch_act' valid_irq_node_lift valid_dom_schedule'_lift)
+     apply simp
+     apply (wp valid_irq_node_lift valid_dom_schedule'_lift setThreadState_ct_not_inQ)
+    apply (clarsimp simp: valid_ep'_def valid_tcb_state'_def pred_tcb_at')
     apply (rule conjI, clarsimp elim!: obj_at'_weakenE)
     apply (subgoal_tac "ep \<noteq> t")
      apply (drule simple_st_tcb_at_state_refs_ofD' ko_at_state_refs_ofD'
@@ -4109,11 +4107,11 @@ lemma si_invs'[wp]:
   \<comment> \<open>epa = SendEP\<close>
   apply (cases bl)
    apply (simp add: invs'_def valid_state'_def)
-   apply (rule hoare_pre, wp valid_irq_node_lift valid_dom_schedule'_lift)
-    apply (simp add: valid_ep'_def)
-    apply (wp hoare_vcg_const_Ball_lift valid_irq_node_lift sts_sch_act' setThreadState_ct_not_inQ
+   apply (rule hoare_pre, wp sts_sch_act' valid_irq_node_lift valid_dom_schedule'_lift)
+    apply simp
+    apply (wp hoare_vcg_const_Ball_lift valid_irq_node_lift setThreadState_ct_not_inQ
               valid_dom_schedule'_lift)
-   apply (clarsimp simp: valid_tcb_state'_def pred_tcb_at')
+   apply (clarsimp simp: valid_ep'_def valid_tcb_state'_def pred_tcb_at')
    apply (rule conjI, clarsimp elim!: obj_at'_weakenE)
    apply (frule obj_at_valid_objs', clarsimp)
    apply (frule(1) sym_refs_ko_atD')

--- a/proof/refine/Ipc_R.thy
+++ b/proof/refine/Ipc_R.thy
@@ -447,16 +447,13 @@ lemma corres_set_extra_badge:
   done
 
 crunch setExtraBadge
-  for typ_at': "\<lambda>s. P (typ_at' T p s)"
+  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
+  and valid_pspace'[wp]: valid_pspace'
+  and cte_wp_at'[wp]: "cte_wp_at' P p"
+  and ipc_buffer'[wp]: "valid_ipc_buffer_ptr' buffer"
 
-lemmas setExtraBadge_gen_typ_ats' [wp] = gen_typ_at_lifts[OF setExtraBadge_typ_at']
-
-crunch setExtraBadge
-  for valid_pspace'[wp]: valid_pspace'
-crunch setExtraBadge
-  for cte_wp_at'[wp]: "cte_wp_at' P p"
-crunch setExtraBadge
-  for ipc_buffer'[wp]: "valid_ipc_buffer_ptr' buffer"
+global_interpretation setExtraBadge: gen_typ_at_props' "setExtraBadge buffer badge n"
+  by typ_at_props'
 
 crunch getExtraCPtr
   for inv'[wp]: P (wp: dmo_inv' loadWord_inv)
@@ -1323,7 +1320,8 @@ end (* Ipc_R *)
 crunch transferCaps
   for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
 
-lemmas transferCaps_gen_typ_ats[wp] = gen_typ_at_lifts [OF transferCaps_typ_at']
+global_interpretation transferCaps: gen_typ_at_props' "transferCaps info caps endpoint receiver receiveBuffer"
+  by typ_at_props'
 
 lemma capReplyMaster_mask[simp]:
   "isReplyCap c \<Longrightarrow> capReplyMaster (maskCapRights R c) = capReplyMaster c"
@@ -1361,11 +1359,12 @@ lemma get_mrs_inv'[wp]:
   by (wpsimp wp: dmo_inv' loadWord_inv mapM_wp' asUser_inv det_mapM[where S=UNIV]
              simp: getMRs_def load_word_offs_def getRegister_inv)
 
-lemma copyMRs_typ_at':
-  "\<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace> copyMRs s sb r rb n \<lbrace>\<lambda>rv s. P (typ_at' T p s)\<rbrace>"
-  by (simp add: copyMRs_def | wp mapM_wp [where S=UNIV, simplified] | wpc)+
+crunch copyMRs
+  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
+  (wp: crunch_wps)
 
-lemmas copyMRs_gen_typ_at_lifts[wp] = gen_typ_at_lifts[OF copyMRs_typ_at']
+global_interpretation copyMRs: gen_typ_at_props' "copyMRs s sb r rb n"
+  by typ_at_props'
 
 lemma copy_mrs_invs'[wp]:
   "\<lbrace> invs' and tcb_at' s and tcb_at' r \<rbrace> copyMRs s sb r rb n \<lbrace>\<lambda>rv. invs' \<rbrace>"
@@ -1581,7 +1580,8 @@ lemmas corres_ipc_thread_helper =
 crunch doNormalTransfer
   for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
 
-lemmas doNormal_gen_typ_at_lifts[wp] = gen_typ_at_lifts[OF doNormalTransfer_typ_at']
+global_interpretation doNormalTransfer: gen_typ_at_props' "doNormalTransfer s sb e b g r rb"
+  by typ_at_props'
 
 crunch doNormalTransfer
   for aligned'[wp]: pspace_aligned'
@@ -1846,22 +1846,18 @@ lemma doIPCTransfer_corres:
 
 crunch doIPCTransfer
   for ifunsafe[wp]: "if_unsafe_then_cap'"
-  (wp: crunch_wps hoare_vcg_const_Ball_lift get_rs_cte_at' ignore: transferCapsToSlots
-    simp: zipWithM_x_mapM ball_conj_distrib )
-crunch doIPCTransfer
-  for iflive[wp]: "if_live_then_nonz_cap'"
-  (wp: crunch_wps hoare_vcg_const_Ball_lift get_rs_cte_at' ignore: transferCapsToSlots
-    simp: zipWithM_x_mapM ball_conj_distrib )
+  and iflive[wp]: "if_live_then_nonz_cap'"
+  and sch_act_wf[wp]: "\<lambda>s. sch_act_wf (ksSchedulerAction s) s"
+  and state_refs_of[wp]: "\<lambda>s. P (state_refs_of' s)"
+  and typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
+  and irq_node'[wp]: "\<lambda>s. P (irq_node' s)"
+  and valid_arch_state'[wp]: "valid_arch_state'"
+  (wp: crunch_wps
+   simp: zipWithM_x_mapM ball_conj_distrib)
 
 crunch doIPCTransfer
   for vp[wp]: "valid_pspace'"
   (wp: crunch_wps hoare_vcg_const_Ball_lift get_rs_cte_at' wp: transferCapsToSlots_vp simp:ball_conj_distrib )
-crunch doIPCTransfer
-  for sch_act_wf[wp]: "\<lambda>s. sch_act_wf (ksSchedulerAction s) s"
-  (wp: crunch_wps get_rs_cte_at' ignore: transferCapsToSlots  simp: zipWithM_x_mapM)
-crunch doIPCTransfer
-  for state_refs_of[wp]: "\<lambda>s. P (state_refs_of' s)"
-  (wp: crunch_wps get_rs_cte_at' ignore: transferCapsToSlots  simp: zipWithM_x_mapM)
 crunch doIPCTransfer
   for state_hyp_refs_of[wp]: "\<lambda>s. P (state_hyp_refs_of' s)"
   (wp: crunch_wps get_rs_cte_at' ignore: transferCapsToSlots  simp: zipWithM_x_mapM)
@@ -1872,22 +1868,8 @@ crunch doIPCTransfer
   for idle'[wp]: "valid_idle'"
   (wp: crunch_wps get_rs_cte_at' ignore: transferCapsToSlots  simp: zipWithM_x_mapM)
 
-crunch doIPCTransfer
-  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  (wp: crunch_wps  simp: zipWithM_x_mapM)
-
-lemmas dit'_gen_typ_at_lifts[wp] = gen_typ_at_lifts[OF doIPCTransfer_typ_at']
-
-crunch doIPCTransfer
-  for irq_node'[wp]: "\<lambda>s. P (irq_node' s)"
-  (wp: crunch_wps simp: crunch_simps)
-
-lemmas dit_irq_node'[wp]
-    = valid_irq_node_lift [OF doIPCTransfer_irq_node' doIPCTransfer_typ_at']
-
-crunch doIPCTransfer
-  for valid_arch_state'[wp]: "valid_arch_state'"
-  (wp: crunch_wps simp: crunch_simps)
+sublocale doIPCTransfer: gen_typ_at_props' "doIPCTransfer s e b g r"
+  by typ_at_props'
 
 crunch doIPCTransfer
   for objs'[wp]: "valid_objs'"
@@ -1968,7 +1950,8 @@ lemma handleFaultReply_corres:
                           handle_fault_reply_registers_corres)
      (corres corres: handleArchFaultReply_corres)
 
-lemmas hfr_gen_typ_at_lifts[wp] = gen_typ_at_lifts[OF handleFaultReply_typ_at']
+sublocale handleFaultReply: gen_typ_at_props' "handleFaultReply x t l m"
+  by typ_at_props'
 
 lemma doIPCTransfer_sch_act_simple [wp]:
   "\<lbrace>sch_act_simple\<rbrace> doIPCTransfer sender endpoint badge grant receiver \<lbrace>\<lambda>_. sch_act_simple\<rbrace>"
@@ -2544,7 +2527,7 @@ proof -
                 apply (wp | simp)+
                 apply (wp sts_cur_tcb set_thread_state_runnable_weak_valid_sched_action sts_st_tcb_at_cases)
                apply (wp sts_weak_sch_act_wf sts_valid_objs'
-                         sts_cur_tcb' setThreadState_tcb' sts_st_tcb_at'_cases)[1]
+                         sts_cur_tcb' sts_st_tcb_at'_cases)[1]
               apply (simp add: valid_tcb_state_def pred_conj_def)
               apply (strengthen reply_cap_doesnt_exist_strg disjI2_strg
                                 valid_queues_in_correct_ready_q valid_queues_ready_qs_distinct
@@ -2615,7 +2598,7 @@ proof -
                apply ((wp sts_cur_tcb set_thread_state_runnable_weak_valid_sched_action sts_st_tcb_at_cases |
                           simp add: if_apply_def2 split del: if_split)+)[1]
               apply (wp sts_weak_sch_act_wf sts_valid_objs'
-                        sts_cur_tcb' setThreadState_tcb' sts_st_tcb_at'_cases)
+                        sts_cur_tcb' sts_st_tcb_at'_cases)
              apply (simp add: valid_tcb_state_def pred_conj_def)
              apply ((wp hoare_drop_imps do_ipc_transfer_tcb_caps  weak_valid_sched_action_lift
                      | clarsimp simp: is_cap_simps
@@ -2646,8 +2629,6 @@ proof -
    apply (clarsimp simp: ep_at_def2)+
   done
 qed
-
-lemmas setMessageInfo_gen_typ_at_lifts[wp] = gen_typ_at_lifts[OF setMessageInfo_typ_at']
 
 crunch cancel_ipc
   for cur[wp]: "cur_tcb"
@@ -3468,20 +3449,18 @@ lemma handleDoubleFault_corres:
        apply (wpsimp wp: asUser_inv getRestartPC_inv dmo_inv' no_fail_getRestartPC)+
   done
 
-crunch sendFaultIPC
-  for tcb'[wp]: "tcb_at' t" (wp: crunch_wps)
-
-crunch receiveIPC
+crunch sendFaultIPC, receiveIPC, receiveSignal
   for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
   (wp: crunch_wps)
 
-crunch receiveSignal
-  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  (wp: crunch_wps)
+sublocale sendFaultIPC: gen_typ_at_props' "sendFaultIPC tptr fault"
+  by typ_at_props'
 
-lemmas receiveIPC_gen_typ_at_lifts[wp] = gen_typ_at_lifts[OF receiveIPC_typ_at']
+sublocale receiveIPC: gen_typ_at_props' "receiveIPC t cap b"
+  by typ_at_props'
 
-lemmas receiveAIPC_gen_typ_at_lifts[wp] = gen_typ_at_lifts[OF receiveSignal_typ_at']
+sublocale receiveSignal: gen_typ_at_props' "receiveSignal t cap b"
+  by typ_at_props'
 
 crunch setupCallerCap
   for aligned'[wp]: "pspace_aligned'"
@@ -3801,8 +3780,7 @@ lemma ri_invs' [wp]:
    apply (case_tac ep)
      \<comment> \<open>endpoint = RecvEP\<close>
      apply (simp add: invs'_def valid_state'_def)
-     apply (rule hoare_pre, wpc, wp sts_sch_act' valid_irq_node_lift valid_dom_schedule'_lift)
-      apply simp
+     apply (wpsimp wp: sts_sch_act' valid_irq_node_lift valid_dom_schedule'_lift)
       apply (wp hoare_vcg_const_Ball_lift valid_irq_node_lift valid_dom_schedule'_lift
                 setThreadState_ct_not_inQ asUser_urz
            | simp add: doNBRecvFailedTransfer_def cteCaps_of_def)+
@@ -3827,8 +3805,7 @@ lemma ri_invs' [wp]:
      apply (fastforce simp: valid_pspace'_def global'_no_ex_cap idle'_not_queued)
    \<comment> \<open>endpoint = IdleEP\<close>
     apply (simp add: invs'_def valid_state'_def)
-    apply (rule hoare_pre, wpc, wp sts_sch_act' valid_irq_node_lift valid_dom_schedule'_lift)
-     apply simp
+    apply (wpsimp wp: sts_sch_act' valid_irq_node_lift valid_dom_schedule'_lift)
      apply (wp valid_irq_node_lift valid_dom_schedule'_lift
                setThreadState_ct_not_inQ asUser_urz
           | simp add: doNBRecvFailedTransfer_def cteCaps_of_def)+
@@ -3919,9 +3896,8 @@ lemma rai_invs'[wp]:
     \<comment> \<open>ep = IdleNtfn\<close>
     apply (simp add: invs'_def valid_state'_def)
     apply (rule hoare_pre)
-     apply (wp valid_irq_node_lift sts_sch_act' gen_typ_at_lifts valid_dom_schedule'_lift
-               setThreadState_ct_not_inQ
-               asUser_urz
+     apply (wp valid_irq_node_lift sts_sch_act' valid_dom_schedule'_lift
+               setThreadState_ct_not_inQ asUser_urz
             | simp add: valid_ntfn'_def doNBRecvFailedTransfer_def live'_def | wpc)+
     apply (clarsimp simp: pred_tcb_at' valid_tcb_state'_def)
     apply (rule conjI, clarsimp elim!: obj_at'_weakenE)
@@ -3943,7 +3919,7 @@ lemma rai_invs'[wp]:
    \<comment> \<open>ep = ActiveNtfn\<close>
    apply (simp add: invs'_def valid_state'_def)
    apply (rule hoare_pre)
-    apply (wp valid_irq_node_lift sts_valid_objs' gen_typ_at_lifts hoare_weak_lift_imp
+    apply (wp valid_irq_node_lift sts_valid_objs' hoare_weak_lift_imp
               asUser_urz valid_dom_schedule'_lift
          | simp add: valid_ntfn'_def)+
    apply (clarsimp simp: pred_tcb_at' valid_pspace'_def)
@@ -3958,8 +3934,7 @@ lemma rai_invs'[wp]:
   apply (simp add: invs'_def valid_state'_def)
   apply (rule hoare_pre)
    apply (wp hoare_vcg_const_Ball_lift valid_irq_node_lift sts_sch_act'
-             setThreadState_ct_not_inQ gen_typ_at_lifts valid_dom_schedule'_lift
-             asUser_urz
+             setThreadState_ct_not_inQ valid_dom_schedule'_lift asUser_urz
         | simp add: valid_ntfn'_def doNBRecvFailedTransfer_def live'_def | wpc)+
   apply (clarsimp simp: valid_tcb_state'_def)
   apply (frule_tac t=t in not_in_ntfnQueue)
@@ -4088,8 +4063,7 @@ lemma si_invs'[wp]:
    \<comment> \<open>epa = IdleEP\<close>
    apply (cases bl)
     apply (simp add: invs'_def valid_state'_def)
-    apply (rule hoare_pre, wp sts_sch_act' valid_irq_node_lift valid_dom_schedule'_lift)
-     apply simp
+    apply (wpsimp wp: sts_sch_act' valid_irq_node_lift valid_dom_schedule'_lift)
      apply (wp valid_irq_node_lift valid_dom_schedule'_lift setThreadState_ct_not_inQ)
     apply (clarsimp simp: valid_ep'_def valid_tcb_state'_def pred_tcb_at')
     apply (rule conjI, clarsimp elim!: obj_at'_weakenE)
@@ -4107,8 +4081,7 @@ lemma si_invs'[wp]:
   \<comment> \<open>epa = SendEP\<close>
   apply (cases bl)
    apply (simp add: invs'_def valid_state'_def)
-   apply (rule hoare_pre, wp sts_sch_act' valid_irq_node_lift valid_dom_schedule'_lift)
-    apply simp
+   apply (wpsimp wp: sts_sch_act' valid_irq_node_lift valid_dom_schedule'_lift)
     apply (wp hoare_vcg_const_Ball_lift valid_irq_node_lift setThreadState_ct_not_inQ
               valid_dom_schedule'_lift)
    apply (clarsimp simp: valid_ep'_def valid_tcb_state'_def pred_tcb_at')

--- a/proof/refine/KHeap_R.thy
+++ b/proof/refine/KHeap_R.thy
@@ -1313,7 +1313,7 @@ lemma set_ntfn_maxObj [wp]:
   by (simp add: setNotification_def | wp setObject_ksPSpace_only updateObject_default_inv)+
 
 lemmas valid_irq_node_lift =
-    hoare_use_eq_irq_node' [OF _ typ_at_lift_valid_irq_node']
+    hoare_use_eq_irq_node' [OF _ valid_irq_node'_typ_at_lift]
 
 lemmas untyped_ranges_zero_lift
     = hoare_use_eq[where f="gsUntypedZeroRanges"
@@ -1754,8 +1754,6 @@ lemma setNotification_corres:
   apply (corresKsimp wp: get_object_ret get_object_wp)+
   by (fastforce simp: is_ntfn gen_obj_at_simps partial_inv_def)
 
-lemmas setObject_valid_obj = typ_at'_valid_obj'_lift [OF setObject_typ_at']
-
 lemma setObject_valid_objs':
   assumes x: "\<And>x n ko s ko' s'.
        \<lbrakk> (ko', s') \<in> fst (updateObject val ko ptr x n s); P s;
@@ -1766,7 +1764,7 @@ lemma setObject_valid_objs':
   apply (subgoal_tac "\<forall>ko. valid_obj' ko s \<longrightarrow> valid_obj' ko b")
    defer
    apply clarsimp
-   apply (erule(1) use_valid [OF _ setObject_valid_obj])
+   apply (erule(1) use_valid [OF _ valid_obj'_typ_at_lift[OF setObject_typ_at']])
   apply (clarsimp simp: setObject_def split_def in_monad
                         lookupAround2_char1)
   apply (simp add: valid_objs'_def)

--- a/proof/refine/KHeap_R.thy
+++ b/proof/refine/KHeap_R.thy
@@ -1476,7 +1476,8 @@ crunch doMachineOp
 crunch doMachineOp
   for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
 
-lemmas doMachineOp_gen_typ_ats[wp] = gen_typ_at_lifts[OF doMachineOp_typ_at']
+global_interpretation doMachineOp: gen_typ_at_props' "doMachineOp mop"
+  by typ_at_props'
 
 lemma doMachineOp_invs_bits[wp]:
   "doMachineOp m \<lbrace>valid_pspace'\<rbrace>"
@@ -1600,11 +1601,12 @@ lemma setObject_typ_at_not:
   apply fastforce
   done
 
-lemma setObject_typ_at':
-  "\<lbrace>\<lambda>s. P (typ_at' T p' s)\<rbrace> setObject p v \<lbrace>\<lambda>r s. P (typ_at' T p' s)\<rbrace>"
+lemma setObject_typ_at'[wp]:
+  "setObject p v \<lbrace>\<lambda>s. P (typ_at' T p' s)\<rbrace>"
   by (blast intro: P_bool_lift setObject_typ_at_inv setObject_typ_at_not)
 
-lemmas setObject_gen_typ_ats[wp] = gen_typ_at_lifts[OF setObject_typ_at']
+sublocale setObject: gen_typ_at_props' "setObject p v"
+  by typ_at_props'
 
 lemma setObject_cte_wp_at':
   assumes x: "\<And>x n tcb s t. \<lbrakk> t \<in> fst (updateObject v (KOTCB tcb) ptr x n s); Q s;
@@ -1680,17 +1682,9 @@ lemma setNotification_cte_wp_at':
                      intro!: set_eqI)+
   done
 
-lemma setObject_ep_tcb':
-  "\<lbrace>tcb_at' t\<rbrace> setObject p (e::endpoint) \<lbrace>\<lambda>_. tcb_at' t\<rbrace>"
-  by (rule setObject_gen_typ_ats)
-
-lemma setObject_ntfn_tcb':
-  "\<lbrace>tcb_at' t\<rbrace> setObject p (e::Structures_H.notification) \<lbrace>\<lambda>_. tcb_at' t\<rbrace>"
-  by (rule setObject_gen_typ_ats)
-
-lemma set_ntfn_tcb' [wp]:
+lemma set_ntfn_tcb'[wp]:
   "\<lbrace> tcb_at' t \<rbrace> setNotification ntfn v \<lbrace> \<lambda>rv. tcb_at' t \<rbrace>"
-  by (simp add: setNotification_def setObject_ntfn_tcb')
+  by (wpsimp simp: setNotification_def)
 
 lemma ctes_of_from_cte_wp_at:
   assumes x: "\<And>P P' p. \<lbrace>\<lambda>s. P (cte_wp_at' P' p s) \<and> Q s\<rbrace> f \<lbrace>\<lambda>r s. P (cte_wp_at' P' p s)\<rbrace>"
@@ -1944,7 +1938,8 @@ lemma setEndpoint_typ_at'[wp]:
   unfolding setEndpoint_def
   by (rule setObject_typ_at')
 
-lemmas setEndpoint_gen_typ_ats[wp] = gen_typ_at_lifts[OF setEndpoint_typ_at']
+sublocale setEndpoint: gen_typ_at_props' "setEndpoint ptr val"
+  by typ_at_props'
 
 lemma setEndpoint_iflive'[wp]:
   "\<lbrace>\<lambda>s. if_live_then_nonz_cap' s

--- a/proof/refine/KHeap_R.thy
+++ b/proof/refine/KHeap_R.thy
@@ -1754,26 +1754,6 @@ lemma setNotification_corres:
   apply (corresKsimp wp: get_object_ret get_object_wp)+
   by (fastforce simp: is_ntfn gen_obj_at_simps partial_inv_def)
 
-lemma typ_at'_valid_obj'_lift:
-  assumes P: "\<And>P T p. \<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace> f \<lbrace>\<lambda>rv s. P (typ_at' T p s)\<rbrace>"
-  notes [wp] = hoare_vcg_all_lift hoare_vcg_imp_lift hoare_vcg_const_Ball_lift gen_typ_at_lifts[OF P]
-  shows      "\<lbrace>\<lambda>s. valid_obj' obj s\<rbrace> f \<lbrace>\<lambda>rv s. valid_obj' obj s\<rbrace>"
-  apply (cases obj; simp add: valid_obj'_def hoare_TrueI)
-      apply (rename_tac endpoint)
-      apply (case_tac endpoint; simp add: valid_ep'_def, wp)
-     apply (rename_tac notification)
-     apply (case_tac "ntfnObj notification";
-            simp add: valid_ntfn'_def split: option.splits,
-            (wpsimp|rule conjI)+)
-    apply (rename_tac tcb)
-    apply (case_tac "tcbState tcb";
-           simp add: valid_tcb'_def valid_tcb_state'_def split_def opt_tcb_at'_def
-                     valid_bound_ntfn'_def;
-           wpsimp wp: hoare_case_option_wp hoare_case_option_wp2 valid_arch_tcb_lift' P;
-           (clarsimp split: option.splits)?)
-   apply (wpsimp simp: valid_cte'_def)+
-  done
-
 lemmas setObject_valid_obj = typ_at'_valid_obj'_lift [OF setObject_typ_at']
 
 lemma setObject_valid_objs':

--- a/proof/refine/RISCV64/ArchArchAcc_R.thy
+++ b/proof/refine/RISCV64/ArchArchAcc_R.thy
@@ -806,15 +806,9 @@ qed
 
 crunch storePTE
   for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  (wp: crunch_wps mapM_x_wp' simp: crunch_simps ignore_del: setObject)
 
-lemmas storePTE_typ_ats[wp] = typ_at_lifts [OF storePTE_typ_at']
-
-lemma setObject_asid_typ_at'[wp]:
-  "\<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace> setObject p' (v::asidpool) \<lbrace>\<lambda>_ s. P (typ_at' T p s)\<rbrace>"
-  by (wp setObject_typ_at')
-
-lemmas setObject_asid_typ_ats'[wp] = typ_at_lifts[OF setObject_asid_typ_at']
+sublocale storePTE: typ_at_props' "storePTE slot pte"
+  by typ_at_props'
 
 lemma getObject_pte_inv[wp]:
   "\<lbrace>P\<rbrace> getObject p \<lbrace>\<lambda>rv :: pte. P\<rbrace>"
@@ -824,7 +818,8 @@ crunch copyGlobalMappings
   for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
   (wp: mapM_x_wp')
 
-lemmas copyGlobalMappings_typ_ats[wp] = typ_at_lifts [OF copyGlobalMappings_typ_at']
+sublocale copyGlobalMappings: typ_at_props' "copyGlobalMappings newPT"
+  by typ_at_props'
 
 lemma corres_gets_global_pt [corres]:
   "corres (=) valid_global_arch_objs \<top>

--- a/proof/refine/RISCV64/ArchCNodeInv_R.thy
+++ b/proof/refine/RISCV64/ArchCNodeInv_R.thy
@@ -421,4 +421,23 @@ proof goal_cases
   case 1 show ?case by (intro_locales; (unfold_locales; (fact CNodeInv_R_assms)?)?)
 qed
 
+context Arch begin arch_global_naming
+
+sublocale cteDelete: typ_at_props' "cteDelete slot exposed"
+  by typ_at_props'
+
+sublocale reduceZombie: typ_at_props' "reduceZombie cap slot x"
+  by typ_at_props'
+
+sublocale finaliseSlot: typ_at_props' "finaliseSlot ptr exposed"
+  by typ_at_props'
+
+sublocale invokeCNode: typ_at_props' "invokeCNode i"
+  by typ_at_props'
+
+sublocale cteMove: typ_at_props' "cteMove cap src dest"
+  by typ_at_props'
+
+end  (* Arch *)
+
 end

--- a/proof/refine/RISCV64/ArchCSpace1_R.thy
+++ b/proof/refine/RISCV64/ArchCSpace1_R.thy
@@ -197,7 +197,8 @@ proof -
   done
 qed
 
-lemmas setCTE_typ_ats[wp] = typ_at_lifts[OF setCTE_typ_at']
+sublocale setCTE: typ_at_props' "setCTE c cte"
+  by typ_at_props'
 
 lemma arch_updateCapData_Master[CSpace1_R_assms]:
   "Arch.updateCapData P d acap \<noteq> NullCap \<Longrightarrow>

--- a/proof/refine/RISCV64/ArchCSpace_R.thy
+++ b/proof/refine/RISCV64/ArchCSpace_R.thy
@@ -27,9 +27,14 @@ lemma capAligned_master[CSpace_R_assms]:
    apply (clarsimp simp: capAligned_def)+
   done
 
-lemmas updateMDB_typ_ats[wp] = typ_at_lifts[OF updateMDB_typ_at']
-lemmas updateCap_typ_ats[wp] = typ_at_lifts[OF updateCap_typ_at']
-lemmas cteInsert_typ_ats[wp] = typ_at_lifts[OF cteInsert_typ_at']
+sublocale updateMDB: typ_at_props' "updateMDB slot f"
+  by typ_at_props'
+
+sublocale updateCap: typ_at_props' "updateCap slot newCap"
+  by typ_at_props'
+
+sublocale cteInsert: typ_at_props' "cteInsert newCap srcSlot destSlot"
+  by typ_at_props'
 
 lemma maskedAsFull_derived'[CSpace_R_assms]:
   "\<lbrakk>m src = Some (CTE s_cap s_node); is_derived' m ptr b c\<rbrakk>

--- a/proof/refine/RISCV64/ArchFinalise_R.thy
+++ b/proof/refine/RISCV64/ArchFinalise_R.thy
@@ -19,7 +19,8 @@ lemma arch_postCapDeletion_ksArchState_lift[Finalise_R_assms]:
   unfolding postCapDeletion_def
   by wpsimp
 
-lemmas clearUntypedFreeIndex_typ_ats[wp] = typ_at_lifts[OF clearUntypedFreeIndex_typ_at']
+sublocale clearUntypedFreeIndex: typ_at_props' "clearUntypedFreeIndex slot"
+  by typ_at_props'
 
 lemma setIRQState_umm[Finalise_R_assms]:
   "setIRQState irqState irq \<lbrace>\<lambda>s. P (underlying_memory (ksMachineState s))\<rbrace> "
@@ -567,11 +568,23 @@ lemma isFinal_no_descendants[Finalise_R_2_assms]:
   apply (simp add: valid_mdb'_def)
   done
 
-lemmas cancelAllIPC_typs[wp] = typ_at_lifts[OF cancelAllIPC_typ_at']
-lemmas cancelAllSignals_typs[wp] = typ_at_lifts[OF cancelAllSignals_typ_at']
-lemmas suspend_typs[wp] = typ_at_lifts[OF suspend_typ_at']
+sublocale cancelIPC: typ_at_props' "cancelIPC tptr"
+  by typ_at_props'
 
-lemmas finaliseCap_typ_ats[wp] = typ_at_lifts[OF finaliseCap_typ_at']
+sublocale cancelAllIPC: typ_at_props' "cancelAllIPC epptr"
+  by typ_at_props'
+
+sublocale cancelAllSignals: typ_at_props' "cancelAllSignals ntfnPtr"
+  by typ_at_props'
+
+sublocale suspend: typ_at_props' "suspend target"
+  by typ_at_props'
+
+sublocale finaliseCap: typ_at_props' "finaliseCap cap final x"
+  by typ_at_props'
+
+sublocale unbindNotification: typ_at_props' "unbindNotification tcb"
+  by typ_at_props'
 
 lemma invs_asid_update_strg':
   "invs' s \<and> tab = riscvKSASIDTable (ksArchState s) \<longrightarrow>
@@ -609,7 +622,8 @@ lemma deleteASID_invs'[wp]:
   unfolding deleteASID_def
   by (wpsimp wp: getASID_wp)
 
-lemmas archThreadSet_typ_ats[wp] = typ_at_lifts[OF archThreadSet_typ_at']
+sublocale archThreadSet: typ_at_props' "archThreadSet f tptr"
+  by typ_at_props'
 
 lemma archThreadSet_valid_objs'[wp]:
   "\<lbrace>valid_objs' and (\<lambda>s. \<forall>tcb. ko_at' tcb t s \<longrightarrow> valid_arch_tcb' (f (tcbArch tcb)) s)\<rbrace>
@@ -1174,7 +1188,8 @@ lemma arch_finaliseCap_corres[Finalise_R_3_assms]:
   apply (simp add: invs_no_0_obj')
   done
 
-lemmas deleteCallerCap_typ_ats[wp] = typ_at_lifts[OF deleteCallerCap_typ_at']
+sublocale deleteCallerCap: typ_at_props' "deleteCallerCap receiver"
+  by typ_at_props'
 
 end (* Arch *)
 

--- a/proof/refine/RISCV64/ArchInvsLemmas_H.thy
+++ b/proof/refine/RISCV64/ArchInvsLemmas_H.thy
@@ -442,6 +442,25 @@ lemmas typ_at_lifts = gen_typ_at_lifts typ_at_lifts_strong_internal
 
 end
 
+end (* Arch *)
+
+locale typ_at_props' = Arch +
+  fixes f :: "_ kernel"
+  assumes typ': "f \<lbrace>\<lambda>s. P (typ_at' T p' s)\<rbrace>"
+begin
+
+lemmas typ_ats[wp] = typ_at_lifts[REPEAT [OF typ']]
+
+context begin
+(* We want to enforce that typ_ats only contains lemmas that have no
+   assumptions. The following thm statement should fail if this is not true. *)
+private lemmas check_valid_internal = iffD1[OF refl, where P="valid p g q" for p g q]
+thm typ_ats[atomized, THEN check_valid_internal]
+end
+
+end (* typ_at_props' *)
+
+context Arch begin arch_global_naming
 
 lemma page_table_pte_atI':
   "page_table_at' p s \<Longrightarrow> pte_at' (p + (ucast (x::pt_index) << pte_bits)) s"

--- a/proof/refine/RISCV64/ArchInvsLemmas_H.thy
+++ b/proof/refine/RISCV64/ArchInvsLemmas_H.thy
@@ -366,55 +366,82 @@ lemma is_physical_cases:
              | _                               \<Rightarrow> True)"
   by (simp split: capability.splits arch_capability.splits zombie_type.splits)
 
-lemma typ_at_lift_page_table_at':
-  assumes x: "\<And>T p. f \<lbrace>typ_at' T p\<rbrace>"
-  shows "f \<lbrace>page_table_at' p\<rbrace>"
+named_theorems Invariants_H_typ_at_lifts_assms
+
+lemma page_table_at'_typ_at_lift_strong:
+  "(\<And>p. f \<lbrace>\<lambda>s. P (typ_at' (ArchT PTET) p s)\<rbrace>) \<Longrightarrow> f \<lbrace>\<lambda>s. P (page_table_at' p s)\<rbrace>"
   unfolding page_table_at'_def
-  by (wpsimp wp: hoare_vcg_all_lift hoare_vcg_imp_lift' x)
-
-lemma typ_at_lift_asid_at':
-  "(\<And>T p. \<lbrace>typ_at' T p\<rbrace> f \<lbrace>\<lambda>_. typ_at' T p\<rbrace>) \<Longrightarrow> \<lbrace>asid_pool_at' p\<rbrace> f \<lbrace>\<lambda>_. asid_pool_at' p\<rbrace>"
-  by assumption
-
-lemma typ_at_lift_frame_at':
-  assumes "\<And>T p. f \<lbrace>typ_at' T p\<rbrace>"
-  shows "f \<lbrace>frame_at' p sz d\<rbrace>"
-  unfolding frame_at'_def
-  by (wpsimp wp: hoare_vcg_all_lift hoare_vcg_const_imp_lift assms split_del: if_split)
-
-lemma typ_at_lift_valid_cap':
-  assumes P: "\<And>P T p. \<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace> f \<lbrace>\<lambda>rv s. P (typ_at' T p s)\<rbrace>"
-  shows      "\<lbrace>\<lambda>s. valid_cap' cap s\<rbrace> f \<lbrace>\<lambda>rv s. valid_cap' cap s\<rbrace>"
-  including no_pre
-  apply (simp add: valid_cap'_def)
-  apply wp
-  apply (case_tac cap;
-         simp add: valid_cap'_def P[of id, simplified] typ_at_lift_tcb'
-                   hoare_vcg_prop typ_at_lift_ep'
-                   typ_at_lift_ntfn' typ_at_lift_cte_at'
-                   hoare_vcg_conj_lift [OF typ_at_lift_cte_at'])
-     apply (rename_tac zombie_type nat)
-     apply (case_tac zombie_type; simp)
-      apply (wp typ_at_lift_tcb' P hoare_vcg_all_lift typ_at_lift_cte')+
-    apply (rename_tac arch_capability)
-    apply (case_tac arch_capability,
-           simp_all add: P[of id, simplified] vspace_table_at'_defs
-                         hoare_vcg_prop All_less_Ball
-                    split del: if_split)
-       apply (wp hoare_vcg_const_Ball_lift P typ_at_lift_valid_untyped'
-                 hoare_vcg_all_lift typ_at_lift_cte' typ_at_lift_frame_at')+
+  apply (rule bool_to_bool_cases[where f=P]; clarsimp)
+  apply (wpsimp wp: hoare_vcg_const_Ball_lift hoare_vcg_imp_lift
+                    hoare_vcg_all_lift hoare_vcg_ex_lift
+         | assumption)+
   done
 
-(* interface lemma *)
-lemma valid_arch_tcb_lift':
-  assumes x: "\<And>T p. \<lbrace>typ_at' T p\<rbrace> f \<lbrace>\<lambda>rv. typ_at' T p\<rbrace>"
-  shows "\<lbrace>\<lambda>s. valid_arch_tcb' tcb s\<rbrace> f \<lbrace>\<lambda>rv s. valid_arch_tcb' tcb s\<rbrace>"
-  by (clarsimp simp add: valid_arch_tcb'_def, wp)
+lemma frame_at'_typ_at_lift_strong:
+  "\<lbrakk>\<And>T p. f \<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace>\<rbrakk> \<Longrightarrow> f \<lbrace>\<lambda>s. P (frame_at' p sz d s)\<rbrace>"
+  supply if_split[split del]
+  unfolding frame_at'_def
+  apply (rule bool_to_bool_cases[where f=P]; clarsimp)
+   apply (wpsimp wp: hoare_vcg_all_lift hoare_vcg_const_imp_lift hoare_vcg_ex_lift
+          | assumption)+
+  done
 
-lemmas typ_at_lifts =
-           typ_at_lift_tcb' typ_at_lift_ep' typ_at_lift_ntfn' typ_at_lift_cte' typ_at_lift_cte_at'
-           typ_at_lift_valid_untyped' typ_at_lift_valid_cap' valid_bound_tcb_lift
-           typ_at_lift_page_table_at' typ_at_lift_asid_at'
+lemma asid_pool_at'_typ_at_lift_strong:
+  "(\<And>T p. f \<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace>) \<Longrightarrow> f \<lbrace>\<lambda>s. P (asid_pool_at' p s)\<rbrace>"
+  by assumption
+
+lemma valid_arch_tcb'_typ_at_lift_strong[Invariants_H_typ_at_lifts_assms]:
+  assumes "\<And>T p. f \<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace>"
+  shows "f \<lbrace>\<lambda>s. P (valid_arch_tcb' tcb s)\<rbrace>"
+  by (clarsimp simp: valid_arch_tcb'_def, wp)
+
+lemma valid_arch_cap'_typ_at_lift[Invariants_H_typ_at_lifts_assms]:
+  assumes P: "\<And>P T p. f \<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace>"
+  shows      "f \<lbrace>\<lambda>s. valid_arch_cap' cap s\<rbrace>"
+  apply (case_tac cap,
+         simp_all add: P[where P=id, simplified] All_less_Ball
+            split del: if_split)
+    apply (wp hoare_vcg_const_Ball_lift P
+              page_table_at'_typ_at_lift_strong frame_at'_typ_at_lift_strong)+
+  done
+
+end (* Arch *)
+
+global_interpretation Invariants_H_typ_at_lifts?: Invariants_H_typ_at_lifts
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case by (intro_locales; unfold_locales; (fact Invariants_H_typ_at_lifts_assms)?)
+qed
+
+context Arch begin arch_global_naming
+
+lemmas typ_at_lifts_strong =
+  gen_typ_at_lifts_strong
+  page_table_at'_typ_at_lift_strong
+  frame_at'_typ_at_lift_strong
+  asid_pool_at'_typ_at_lift_strong
+
+context begin
+
+\<comment>\<open> See the comment above @{ML weaken_typ_at_lifts_thms} for an explanation of what
+    this @{command ML_goal} is for. Here we are constructing the combined list of
+    both generic and arch-specific typ_at_lifts lemmas.\<close>
+ML \<open>
+local
+  val strong_thms = subtract Thm.eq_thm gen_strong_thms @{thms typ_at_lifts_strong[no_vars]};
+in
+  val typ_at_lifts_internal_goals = weaken_typ_at_lifts_thms strong_thms
+end
+\<close>
+
+private ML_goal typ_at_lifts_strong_internal:
+  \<open>typ_at_lifts_internal_goals\<close>
+  by (auto simp: typ_at_lifts_strong)
+
+lemmas typ_at_lifts = gen_typ_at_lifts typ_at_lifts_strong_internal
+
+end
+
 
 lemma page_table_pte_atI':
   "page_table_at' p s \<Longrightarrow> pte_at' (p + (ucast (x::pt_index) << pte_bits)) s"

--- a/proof/refine/RISCV64/ArchIpc_R.thy
+++ b/proof/refine/RISCV64/ArchIpc_R.thy
@@ -260,6 +260,33 @@ lemma is_derived_mask'[simp]:
   "is_derived' m p (maskCapRights R c) = is_derived' m p c"
   by (rule ext, simp add: is_derived'_def badge_derived'_def)
 
+sublocale setExtraBadge: typ_at_props' "setExtraBadge buffer badge n"
+  by typ_at_props'
+
+sublocale transferCaps: typ_at_props' "transferCaps info caps endpoint receiver receiveBuffer"
+  by typ_at_props'
+
+sublocale copyMRs: typ_at_props' "copyMRs s sb r rb n"
+  by typ_at_props'
+
+sublocale doNormalTransfer: typ_at_props' "doNormalTransfer s sb e b g r rb"
+  by typ_at_props'
+
+sublocale doIPCTransfer: typ_at_props' "doIPCTransfer s e b g r"
+  by typ_at_props'
+
+sublocale handleFaultReply: typ_at_props' "handleFaultReply x t l m"
+  by typ_at_props'
+
+sublocale sendFaultIPC: typ_at_props' "sendFaultIPC tptr fault"
+  by typ_at_props'
+
+sublocale receiveIPC: typ_at_props' "receiveIPC t cap b"
+  by typ_at_props'
+
+sublocale receiveSignal: typ_at_props' "receiveSignal t cap b"
+  by typ_at_props'
+
 end (* Arch *)
 
 end

--- a/proof/refine/RISCV64/ArchKHeap_R.thy
+++ b/proof/refine/RISCV64/ArchKHeap_R.thy
@@ -302,7 +302,7 @@ lemma valid_arch_state_lift':
   apply (simp add: valid_arch_state'_def valid_asid_table'_def valid_global_pts'_def
                    vspace_table_at'_defs)
   apply (rule hoare_lift_Pf [where f="ksArchState"])
-   apply (wp typs hoare_vcg_all_lift hoare_vcg_ball_lift arch typ_at_lifts)+
+   apply (wp typs hoare_vcg_all_lift hoare_vcg_ball_lift arch)+
   done
 
 lemma idle_is_global[KHeap_R_assms, intro!]:
@@ -348,11 +348,14 @@ lemma setObject_ko_wp_at':
 
 lemmas [KHeap_R_assms_2] = setEndpoint_valid_arch' setNotification_valid_arch'
 
-lemmas setObject_typ_ats[wp] = typ_at_lifts[OF setObject_typ_at']
+sublocale setObject: typ_at_props' "setObject p v"
+  by typ_at_props'
 
-lemmas doMachineOp_typ_ats[wp] = typ_at_lifts[OF doMachineOp_typ_at']
+sublocale doMachineOp: typ_at_props' "doMachineOp mop"
+  by typ_at_props'
 
-lemmas setEndpoint_typ_ats[wp] = typ_at_lifts[OF setEndpoint_typ_at']
+sublocale setEndpoint: typ_at_props' "setEndpoint ptr val"
+  by typ_at_props'
 
 end
 

--- a/proof/refine/RISCV64/ArchSchedule_R.thy
+++ b/proof/refine/RISCV64/ArchSchedule_R.thy
@@ -23,7 +23,7 @@ crunch tcbSchedAppend, tcbSchedDequeue, tcbSchedEnqueue
 
 lemma arch_switch_thread_tcb_at'[wp]:
   "\<lbrace>tcb_at' t\<rbrace> Arch.switchToThread t \<lbrace>\<lambda>_. tcb_at' t\<rbrace>"
-  by (unfold RISCV64_H.switchToThread_def, wp typ_at_lift_tcb')
+  by (unfold RISCV64_H.switchToThread_def, wp)
 
 crunch setVMRoot
   for pred_tcb_at'[wp]: "pred_tcb_at' proj P t'"

--- a/proof/refine/RISCV64/ArchTcbAcc_R.thy
+++ b/proof/refine/RISCV64/ArchTcbAcc_R.thy
@@ -185,7 +185,8 @@ lemma threadSet_iflive'T[TcbAcc_R_assms]:
   apply (clarsimp simp: bspec_split [OF spec [OF x]])
   done
 
-lemmas threadSet_typ_at_lifts[wp] = typ_at_lifts[OF threadSet_typ_at']
+sublocale threadSet: typ_at_props' "threadSet tptr f"
+  by typ_at_props'
 
 lemma zobj_refs'_capRange[TcbAcc_R_assms]:
   "s \<turnstile>' cap \<Longrightarrow> zobj_refs' cap \<subseteq> capRange cap"
@@ -203,8 +204,11 @@ lemma asUser_valid_tcbs'[wp]:
               simp: valid_tcb'_def valid_arch_tcb'_def tcb_cte_cases_def objBits_simps')
   done
 
-lemmas addToBitmap_typ_ats[wp] = typ_at_lifts[OF addToBitmap_typ_at']
-lemmas removeFromBitmap_typ_ats[wp] = typ_at_lifts[OF removeFromBitmap_typ_at']
+sublocale addToBitmap: typ_at_props' "addToBitmap tdom prio"
+  by typ_at_props'
+
+sublocale removeFromBitmap: typ_at_props' "removeFromBitmap tdom prio"
+  by typ_at_props'
 
 crunch tcbQueueRemove, tcbQueuePrepend, tcbQueueAppend, tcbQueueInsert,
          setQueue, removeFromBitmap
@@ -322,7 +326,8 @@ context Arch begin arch_global_naming
 
 named_theorems TcbAcc_R_2_assms
 
-lemmas asUser_typ_ats[wp] = typ_at_lifts[OF asUser_typ_at']
+sublocale asUser: typ_at_props' "asUser tptr f"
+  by typ_at_props'
 
 lemma tcb_hyp_refs'_valid_arch_tcb'_eq[TcbAcc_R_2_assms]:
   "tcb_hyp_refs' (tcbArch (F tcb)) = tcb_hyp_refs' (tcbArch tcb)
@@ -846,8 +851,17 @@ lemma set_mrs_invs'[TcbAcc_R_3_assms, wp]:
          simp add: zipWithM_x_mapM split_def)+
   done
 
-lemmas setThreadState_typ_ats[wp] = typ_at_lifts [OF setThreadState_typ_at']
-lemmas setBoundNotification_typ_ats[wp] = typ_at_lifts [OF setBoundNotification_typ_at']
+sublocale rescheduleRequired: typ_at_props' "rescheduleRequired"
+  by typ_at_props'
+
+sublocale tcbSchedDequeue: typ_at_props' "tcbSchedDequeue thread"
+  by typ_at_props'
+
+sublocale setThreadState: typ_at_props' "setThreadState st p"
+  by typ_at_props'
+
+sublocale setBoundNotification: typ_at_props' "setBoundNotification v p"
+  by typ_at_props'
 
 end (* Arch *)
 

--- a/proof/refine/RISCV64/ArchTcb_R.thy
+++ b/proof/refine/RISCV64/ArchTcb_R.thy
@@ -42,6 +42,12 @@ lemma threadSet_state_hyp_refs_of'_interface[Tcb_R_assms]:
    \<Longrightarrow> threadSet F t \<lbrace>\<lambda>s. P (state_hyp_refs_of' s)\<rbrace> "
   by (wpsimp simp: threadSet_state_hyp_refs_of')
 
+sublocale setPriority: typ_at_props' "setPriority t prio"
+  by typ_at_props'
+
+sublocale setMCPriority: typ_at_props' "setMCPriority t prio"
+  by typ_at_props'
+
 lemma sameObject_corres2[Tcb_R_assms]:
   "\<lbrakk> cap_relation c c'; cap_relation d d' \<rbrakk>
    \<Longrightarrow> same_object_as c d = sameObjectAs c' d'"

--- a/proof/refine/RISCV64/ArchVSpace_R.thy
+++ b/proof/refine/RISCV64/ArchVSpace_R.thy
@@ -248,11 +248,34 @@ lemma deleteASIDPool_corres:
   apply clarsimp
   done
 
-crunch setVMRoot
-  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  (simp: crunch_simps wp: crunch_wps)
+crunch unmapPageTable, unmapPage, setVMRoot, setMessageInfo, setMRs, performPageTableInvocation,
+       performASIDPoolInvocation, performPageInvocation
+  for typ_at' [wp]: "\<lambda>s. P (typ_at' T p s)"
+  (wp: crunch_wps getASID_wp simp: crunch_simps)
 
-lemmas setVMRoot_typ_ats [wp] = typ_at_lifts [OF setVMRoot_typ_at']
+sublocale unmapPageTable: typ_at_props' "unmapPageTable asid vaddr pt"
+  by typ_at_props'
+
+sublocale unmapPage: typ_at_props' "unmapPage magnitude asid vptr ptr"
+  by typ_at_props'
+
+sublocale setVMRoot: typ_at_props' "setVMRoot tcb"
+  by typ_at_props'
+
+sublocale setMessageInfo: typ_at_props' "setMessageInfo thread info"
+  by typ_at_props'
+
+sublocale setMRs: typ_at_props' "setMRs thread buffer messageData"
+  by typ_at_props'
+
+sublocale performPageTableInvocation: typ_at_props' "performPageTableInvocation iv"
+  by typ_at_props'
+
+sublocale performPageInvocation: typ_at_props' "performPageInvocation iv"
+  by typ_at_props'
+
+sublocale performASIDPoolInvocation: typ_at_props' "performASIDPoolInvocation iv"
+  by typ_at_props'
 
 lemma getObject_PTE_corres'':
   assumes "p' = p"
@@ -264,7 +287,6 @@ crunch unmapPageTable, unmapPage
   for aligned'[wp]: "pspace_aligned'"
   and distinct'[wp]: "pspace_distinct'"
   and ctes [wp]: "\<lambda>s. P (ctes_of s)"
-  and typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
   (simp: crunch_simps
    wp: crunch_wps getObject_inv loadObject_default_inv)
 
@@ -374,12 +396,6 @@ definition
       cte_wp_at' (is_arch_update' (ArchObjectCap cap)) ptr and valid_cap' (ArchObjectCap cap)
   | PageGetAddr ptr \<Rightarrow> \<top>"
 
-lemmas setMRs_typ_at_lifts[wp] = typ_at_lifts [OF setMRs_typ_at']
-
-crunch unmapPage
-  for cte_at'[wp]: "cte_at' p"
-  (wp: crunch_wps simp: crunch_simps)
-
 lemma performPageInvocation_corres:
   assumes "page_invocation_map pgi pgi'"
   shows "corres (=) (invs and valid_page_inv pgi) (no_0_obj' and valid_page_inv' pgi')
@@ -486,8 +502,6 @@ lemma clear_page_table_corres:
    apply (simp add: bit_simps word_less_nat_alt word_le_nat_alt unat_of_nat)
   apply simp
   done
-
-lemmas unmapPageTable_typ_ats[wp] = typ_at_lifts[OF unmapPageTable_typ_at']
 
 lemma performPageTableInvocation_corres:
   "page_table_invocation_map pti pti' \<Longrightarrow>
@@ -660,28 +674,6 @@ crunch deleteASID
   for it'[wp]: "\<lambda>s. P (ksIdleThread s)"
   (simp: crunch_simps loadObject_default_def updateObject_default_def
    wp: getObject_inv)
-
-crunch performPageTableInvocation
-  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  (wp: crunch_wps)
-
-crunch performPageInvocation
-  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  (wp: crunch_wps simp: crunch_simps)
-
-lemma performASIDPoolInvocation_typ_at' [wp]:
-  "\<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace> performASIDPoolInvocation api \<lbrace>\<lambda>_ s. P (typ_at' T p s)\<rbrace>"
-  by (wpsimp simp: performASIDPoolInvocation_def
-               wp: getASID_wp hoare_vcg_imp_lift[where P'=\<bottom>, simplified])
-
-lemmas performPageTableInvocation_typ_ats' [wp] =
-  typ_at_lifts [OF performPageTableInvocation_typ_at']
-
-lemmas performPageInvocation_typ_ats' [wp] =
-  typ_at_lifts [OF performPageInvocation_typ_at']
-
-lemmas performASIDPoolInvocation_typ_ats' [wp] =
-  typ_at_lifts [OF performASIDPoolInvocation_typ_at']
 
 lemma storePTE_pred_tcb_at' [wp]:
   "storePTE p pte \<lbrace>pred_tcb_at' proj P t\<rbrace>"
@@ -1052,8 +1044,6 @@ lemma perform_pti_invs [wp]:
 crunch unmapPage
   for cte_wp_at': "\<lambda>s. P (cte_wp_at' P' p s)"
   (wp: crunch_wps lookupPTSlotFromLevel_inv simp: crunch_simps)
-
-lemmas unmapPage_typ_ats [wp] = typ_at_lifts [OF unmapPage_typ_at']
 
 lemma unmapPage_invs' [wp]:
   "unmapPage sz asid vptr pptr \<lbrace>invs'\<rbrace>"

--- a/proof/refine/RISCV64/orphanage/Orphanage.thy
+++ b/proof/refine/RISCV64/orphanage/Orphanage.thy
@@ -1679,7 +1679,6 @@ lemma tc_no_orphans:
   apply (rule hoare_walk_assmsE)
     apply (cases mcp; clarsimp simp: pred_conj_def option.splits[where P="\<lambda>x. x s" for s])
      apply ((wp case_option_wp threadSet_no_orphans threadSet_invs_trivial setMCPriority_invs'
-                typ_at_lifts[OF setMCPriority_typ_at']
                 threadSet_cap_to' hoare_vcg_all_lift hoare_weak_lift_imp | clarsimp simp: inQ_def)+)[3]
   apply ((simp only: simp_thms cong: conj_cong
           | wp cteDelete_deletes cteDelete_invs' cteDelete_sch_act_simple

--- a/proof/refine/Syscall_R.thy
+++ b/proof/refine/Syscall_R.thy
@@ -810,17 +810,33 @@ lemma invokeTCB_typ_at'[wp]:
           | wpcw)+
   done
 
-lemmas invokeTCB_typ_ats[wp] = gen_typ_at_lifts[OF invokeTCB_typ_at']
-
-crunch doReplyTransfer, invokeIRQHandler, performIRQControl
+crunch restart, bindNotification, performTransfer, setFlags, postSetFlags, invokeTCB, doReplyTransfer,
+       performIRQControl, invokeIRQHandler, sendIPC, handleFault
   for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  (wp: hoare_drop_imps)
+  (simp: crunch_simps
+   wp: crunch_wps checkCap_inv hoare_vcg_all_lift
+   ignore: checkCapAt)
 
-lemmas doReplyTransfer_typ_ats[wp] = gen_typ_at_lifts[OF doReplyTransfer_typ_at']
+sublocale invokeTCB: gen_typ_at_props' "invokeTCB i"
+  by typ_at_props'
 
-lemmas invokeIRQControl_typ_ats[wp] = gen_typ_at_lifts[OF performIRQControl_typ_at']
+sublocale doReplyTransfer: gen_typ_at_props' "doReplyTransfer s r sl g"
+  by typ_at_props'
 
-lemmas invokeIRQHandler_typ_ats[wp] = gen_typ_at_lifts[OF invokeIRQHandler_typ_at']
+sublocale performIRQControl: gen_typ_at_props' "performIRQControl i"
+  by typ_at_props'
+
+sublocale arch_invokeIRQHandler: gen_typ_at_props' "Arch.invokeIRQHandler i"
+  by typ_at_props'
+
+sublocale invokeIRQHandler: gen_typ_at_props' "invokeIRQHandler i"
+  by typ_at_props'
+
+sublocale sendIPC: gen_typ_at_props' "sendIPC bl call bdg cg cgr t' ep"
+  by typ_at_props'
+
+sublocale handleFault: gen_typ_at_props' "handleFault t ex"
+  by typ_at_props'
 
 crunch invokeDomain
   for tcb_at'[wp]: "tcb_at' tptr"
@@ -872,12 +888,10 @@ lemma sts_valid_inv'[wp]:
      apply (wp hoare_vcg_ex_lift ex_cte_cap_to'_pres | simp)+
   apply (rename_tac tcbinvocation)
   apply (case_tac tcbinvocation,
-         simp_all add: setThreadState_tcb',
+         simp_all,
          auto  intro!: hoare_vcg_conj_lift hoare_vcg_disj_lift
             simp only: imp_conv_disj simp_thms pred_conj_def,
-         auto  intro!: hoare_vcg_prop
-                       sts_cap_to' sts_cte_cap_to'
-                       setThreadState_typ_ats
+         auto  intro!: hoare_vcg_prop sts_cap_to' sts_cte_cap_to'
                 split: option.splits)[1]
     apply (wp sts_bound_tcb_at' hoare_vcg_all_lift hoare_vcg_const_imp_lift)+
   done
@@ -1502,12 +1516,6 @@ lemma rfk_ksQ[wp]:
   apply (simp add: replyFromKernel_def)
   apply (wp)
   done
-
-crunch handleFault
-  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  (wp: crunch_wps)
-
-lemmas handleFault_typ_ats[wp] = gen_typ_at_lifts[OF handleFault_typ_at']
 
 context Syscall_R begin
 

--- a/proof/refine/TcbAcc_R.thy
+++ b/proof/refine/TcbAcc_R.thy
@@ -1078,11 +1078,8 @@ lemma threadSet_obj_at'_no_state:
   assumes "\<And>tcb. P' (f tcb) = P' tcb"
   shows   "threadSet f t \<lbrace>\<lambda>s. P (obj_at' P' t' s)\<rbrace>"
 proof -
-  have pos: "\<And>t' t.
-            \<lbrace>obj_at' P' t'\<rbrace> threadSet f t \<lbrace>\<lambda>rv. obj_at' P' t'\<rbrace>"
-    apply (wp threadSet_obj_at'_strongish)
-    apply clarsimp
-    apply (erule obj_at'_weakenE)
+  have pos: "\<And>t' t. threadSet f t \<lbrace>obj_at' P' t'\<rbrace>"
+    apply (wpsimp wp: threadSet_obj_at'_strongish)
     apply (insert assms)
     apply clarsimp
     done
@@ -1090,15 +1087,10 @@ proof -
     apply (rule_tac P=P in P_bool_lift)
      apply (rule pos)
     apply (rule_tac Q'="\<lambda>_ s. \<not> tcb_at' t' s \<or> obj_at' (\<lambda>tcb. \<not> P' tcb) t' s"
-             in hoare_post_imp)
-     apply (erule disjE)
-      apply (clarsimp simp: obj_at'_def)
-     apply (clarsimp)
-     apply (frule_tac P=P' and Q="\<lambda>tcb. \<not> P' tcb" in obj_at_conj')
-      apply (clarsimp)+
-    apply (wp hoare_convert_imp)
-      apply (simp add: typ_at_tcb' [symmetric])
-      apply (wp pos)+
+                 in hoare_post_imp)
+     apply (clarsimp simp: obj_at'_def)
+    apply (simp add: typ_at_tcb'[symmetric])
+    apply (wpsimp wp: hoare_convert_imp)
     apply (clarsimp simp: not_obj_at' assms elim!: obj_at'_weakenE)
     done
 qed
@@ -1306,11 +1298,6 @@ lemma threadSet_valid_objs':
   apply (clarsimp elim!: obj_at'_weakenE)
   done
 
-lemmas typ_at'_valid_tcb'_lift =
-  typ_at'_valid_obj'_lift[where obj="KOTCB tcb" for tcb, unfolded valid_obj'_def, simplified]
-
-lemmas setObject_valid_tcb' = typ_at'_valid_tcb'_lift[OF setObject_typ_at']
-
 lemma setObject_valid_tcbs':
   assumes preserve_valid_tcb': "\<And>s s' ko ko' x n tcb tcb'.
             \<lbrakk> (ko', s') \<in> fst (updateObject val ko ptr x n s); P s;
@@ -1323,7 +1310,7 @@ lemma setObject_valid_tcbs':
   apply (rename_tac s s' ptr' tcb)
   apply (prop_tac "\<forall>tcb'. valid_tcb' tcb s \<longrightarrow> valid_tcb' tcb s'")
    apply clarsimp
-   apply (erule (1) use_valid[OF _ setObject_valid_tcb'])
+   apply (erule (1) use_valid[OF _ valid_tcb'_typ_at_lift[OF setObject_typ_at']])
   apply (drule spec, erule mp)
   apply (clarsimp simp: setObject_def in_monad split_def lookupAround2_char1)
   apply (rename_tac s ptr' new_tcb' ptr'' old_tcb_ko' s' f)
@@ -1349,9 +1336,7 @@ lemma threadSet_valid_tcb':
   "\<lbrace>valid_tcb' tcb and (\<lambda>s. \<forall>tcb. valid_tcb' tcb s \<longrightarrow> valid_tcb' (f tcb) s)\<rbrace>
    threadSet f t
    \<lbrace>\<lambda>_. valid_tcb' tcb\<rbrace>"
-  apply (simp add: threadSet_def)
-  apply (wpsimp wp: setObject_valid_tcb')
-  done
+  by (wpsimp simp: threadSet_def)
 
 lemma threadSet_valid_tcbs':
   "\<lbrace>valid_tcbs' and (\<lambda>s. \<forall>tcb. valid_tcb' tcb s \<longrightarrow> valid_tcb' (f tcb) s)\<rbrace>

--- a/proof/refine/TcbAcc_R.thy
+++ b/proof/refine/TcbAcc_R.thy
@@ -986,11 +986,11 @@ crunch threadSet
 crunch threadSet
   for ksArchState[wp]: "\<lambda>s. P (ksArchState s)"
 
-lemma threadSet_typ_at'[wp]:
-  "\<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace> threadSet t F \<lbrace>\<lambda>rv s. P (typ_at' T p s)\<rbrace>"
-  by (simp add: threadSet_def, wp setObject_typ_at')
+crunch threadSet
+  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
 
-lemmas threadSet_typ_at_lifts[wp] = gen_typ_at_lifts[OF threadSet_typ_at']
+global_interpretation threadSet: gen_typ_at_props' "threadSet tptr f"
+  by typ_at_props'
 
 crunch threadSet
   for irq_states'[wp]: valid_irq_states'
@@ -1368,11 +1368,12 @@ proof -
     done
 qed
 
-lemma asUser_typ_at' [wp]:
-  "\<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace> asUser t' f \<lbrace>\<lambda>rv s. P (typ_at' T p s)\<rbrace>"
-  by (simp add: asUser_def bind_assoc split_def, wp select_f_inv)
+crunch asUser
+  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
+  (wp: crunch_wps)
 
-lemmas asUser_typ_ats[wp] = gen_typ_at_lifts[OF asUser_typ_at']
+global_interpretation asUser: gen_typ_at_props' "asUser tptr f"
+  by typ_at_props'
 
 lemma asUser_nosch[wp]:
   "\<lbrace>\<lambda>s. P (ksSchedulerAction s)\<rbrace> asUser t m \<lbrace>\<lambda>rv s. P (ksSchedulerAction s)\<rbrace>"
@@ -1662,16 +1663,14 @@ lemma removeFromBitmap_corres_noop:
 
 end (* TcbAcc_R *)
 
-crunch addToBitmap
+crunch addToBitmap, removeFromBitmap
   for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  (wp: hoare_drop_imps setCTE_typ_at')
 
-crunch removeFromBitmap
-  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  (wp: hoare_drop_imps setCTE_typ_at')
+global_interpretation addToBitmap: gen_typ_at_props' "addToBitmap tdom prio"
+  by typ_at_props'
 
-lemmas addToBitmap_typ_ats [wp] = gen_typ_at_lifts[OF addToBitmap_typ_at']
-lemmas removeFromBitmap_typ_ats [wp] = gen_typ_at_lifts[OF removeFromBitmap_typ_at']
+global_interpretation removeFromBitmap: gen_typ_at_props' "removeFromBitmap tdom prio"
+  by typ_at_props'
 
 lemma pspace_relation_tcb_domain_priority:
   "\<lbrakk>pspace_relation (kheap s) (ksPSpace s'); kheap s t = Some (TCB tcb);
@@ -2963,7 +2962,21 @@ lemma setBoundNotification_corres:
 end (* TcbAcc_R_2 *)
 
 crunch rescheduleRequired, tcbSchedDequeue, setThreadState, setBoundNotification
-  for tcb'[wp]: "tcb_at' addr"
+  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
+  and ctes_of[wp]: "\<lambda>s. P (ctes_of s)"
+  (wp: crunch_wps)
+
+global_interpretation rescheduleRequired: gen_typ_at_props' "rescheduleRequired"
+  by typ_at_props'
+
+global_interpretation tcbSchedDequeue: gen_typ_at_props' "tcbSchedDequeue thread"
+  by typ_at_props'
+
+global_interpretation setThreadState: gen_typ_at_props' "setThreadState st p"
+  by typ_at_props'
+
+global_interpretation setBoundNotification: gen_typ_at_props' "setBoundNotification v p"
+  by typ_at_props'
 
 lemma tcbSchedNext_update_valid_objs'[wp]:
   "\<lbrace>valid_objs' and valid_bound_tcb' ptrOpt\<rbrace>
@@ -3877,13 +3890,6 @@ lemma sbn_bound_tcb_at':
    apply (wp threadSet_obj_at'_really_strongest
                | simp add: pred_tcb_at'_def)+
   done
-
-context TcbAcc_R_2 begin
-
-lemmas setThreadState_typ_ats[wp] = gen_typ_at_lifts[OF setThreadState_typ_at']
-lemmas setBoundNotification_typ_ats[wp] = gen_typ_at_lifts[OF setBoundNotification_typ_at']
-
-end (* TcbAcc_R_2 *)
 
 crunch setThreadState, setBoundNotification
   for aligned'[wp]: pspace_aligned'

--- a/proof/refine/Tcb_R.thy
+++ b/proof/refine/Tcb_R.thy
@@ -1779,8 +1779,7 @@ lemma bindNotification_invs':
   apply (rule bind_wp[OF _ get_ntfn_sp'])
   apply (rule hoare_pre)
    apply (wp set_ntfn_valid_pspace' sbn_sch_act' valid_irq_node_lift
-             setBoundNotification_ct_not_inQ valid_bound_ntfn_lift
-             untyped_ranges_zero_lift valid_dom_schedule'_lift
+             setBoundNotification_ct_not_inQ untyped_ranges_zero_lift valid_dom_schedule'_lift
           | clarsimp dest!: global'_no_ex_cap simp: cteCaps_of_def)+
   apply (clarsimp simp: valid_pspace'_def)
   apply (cases "tcbptr = ntfnptr")

--- a/proof/refine/Tcb_R.thy
+++ b/proof/refine/Tcb_R.thy
@@ -817,11 +817,11 @@ crunch setPriority, setMCPriority
   for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
   (simp: crunch_simps)
 
-lemmas setPriority_gen_typ_ats[wp] = gen_typ_at_lifts[OF setPriority_typ_at']
+global_interpretation setPriority: gen_typ_at_props' "setPriority t prio"
+  by typ_at_props'
 
-crunch setPriority, setMCPriority
-  for valid_cap[wp]: "valid_cap' c"
-  (wp: getObject_tcb_inv)
+global_interpretation setMCPriority: gen_typ_at_props' "setMCPriority t prio"
+  by typ_at_props'
 
 definition newroot_rel ::
   "(cap \<times> cslot_ptr) option \<Rightarrow> (capability \<times> machine_word) option \<Rightarrow> bool"
@@ -1457,8 +1457,6 @@ proof -
             apply (wp add: stuff hoare_vcg_all_liftE_R hoare_vcg_all_lift
                                  hoare_vcg_const_imp_liftE_R hoare_vcg_const_imp_lift setMCPriority_invs'
                                  threadSet_valid_objs' thread_set_not_state_valid_sched setP_invs'
-                                 gen_typ_at_lifts[OF setPriority_typ_at']
-                                 gen_typ_at_lifts[OF setMCPriority_typ_at']
                                  threadSet_cap_to' assertDerived_wp checked_insert_tcb_invs_gen
                       del: cteInsert_invs
                    | simp add: ran_tcb_cap_cases split_def U V
@@ -1548,7 +1546,6 @@ lemma (in Tcb_R) tc_invs':
   apply (rule hoare_walk_assmsE)
     apply (clarsimp simp: pred_conj_def option.splits [where P="\<lambda>x. x s" for s])
     apply ((wp case_option_wp threadSet_invs_trivial hoare_weak_lift_imp setMCPriority_invs'
-               gen_typ_at_lifts[OF setMCPriority_typ_at']
                hoare_vcg_all_lift threadSet_cap_to' | clarsimp simp: inQ_def)+)[2]
   apply (wp add: setP_invs' hoare_weak_lift_imp hoare_vcg_all_lift)+
       apply (rule case_option_wp_None_return[OF setP_invs'[simplified pred_conj_assoc]])
@@ -1561,15 +1558,15 @@ lemma (in Tcb_R) tc_invs':
                         threadSet_invs_trivial2 threadSet_tcb'  hoare_vcg_all_lift threadSet_cte_wp_at')
        apply (wpsimp wp: hoare_weak_lift_impE_R cteDelete_deletes
                          hoare_vcg_all_liftE_R hoare_vcg_conj_liftE1 hoare_vcg_const_imp_liftE_R hoare_vcg_propE_R
-                         cteDelete_invs' cteDelete_invs' cteDelete_typ_at'_lifts)+
+                         cteDelete_invs' cteDelete_invs')+
      apply (assumption | clarsimp cong: conj_cong imp_cong | (rule case_option_wp_None_returnOk)
             | wpsimp wp: hoare_weak_lift_imp hoare_vcg_all_lift checkCap_inv[where P="tcb_at' t" for t] assertDerived_wp_weak
                          hoare_vcg_imp_lift' hoare_vcg_all_lift checkCap_inv[where P="tcb_at' t" for t]
                          checkCap_inv[where P="valid_cap' c" for c] checkCap_inv[where P=sch_act_simple]
                          hoare_vcg_const_imp_liftE_R assertDerived_wp_weak hoare_weak_lift_impE_R cteDelete_deletes
                          hoare_vcg_all_liftE_R hoare_vcg_conj_liftE1 hoare_vcg_const_imp_liftE_R hoare_vcg_propE_R
-                         cteDelete_invs' cteDelete_typ_at'_lifts cteDelete_sch_act_simple)+
-  apply (clarsimp simp: tcb_cte_cases_def  tcb_cte_cases_neqs tcbIPCBufferSlot_def
+                         cteDelete_invs' cteDelete_sch_act_simple)+
+  apply (clarsimp simp: tcb_cte_cases_def tcb_cte_cases_neqs tcbIPCBufferSlot_def
                         cteSizeBits_cte_level_bits[symmetric] shiftl_t2n)
   apply (auto dest!: isCapDs isReplyCapD isValidVTableRootD_gen simp: gen_isCap_simps)
   done
@@ -1758,13 +1755,6 @@ lemma tcbBoundNotification_caps_safe[simp]:
   "\<forall>(getF, setF)\<in>ran tcb_cte_cases.
      getF (tcbBoundNotification_update (\<lambda>_. Some ntfnptr) tcb) = getF tcb"
   by (case_tac tcb, simp add: tcb_cte_cases_def tcb_cte_cases_neqs)
-
-lemma valid_bound_ntfn_lift:
-  assumes P: "\<And>P T p. \<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace> f \<lbrace>\<lambda>rv s. P (typ_at' T p s)\<rbrace>"
-  shows      "\<lbrace>\<lambda>s. valid_bound_ntfn' a s\<rbrace> f \<lbrace>\<lambda>rv s. valid_bound_ntfn' a s\<rbrace>"
-  apply (simp add: valid_bound_ntfn'_def, case_tac a, simp_all)
-  apply (wp gen_typ_at_lifts[OF P])+
-  done
 
 lemma bindNotification_invs':
   "\<lbrace>bound_tcb_at' ((=) None) tcbptr

--- a/proof/refine/Untyped_R.thy
+++ b/proof/refine/Untyped_R.thy
@@ -2236,7 +2236,8 @@ lemma caps_overlap_reserved'_D:
   apply fastforce
   done
 
-lemmas updateNewFreeIndex_typ_ats[wp] = gen_typ_at_lifts[OF updateNewFreeIndex_typ_at']
+global_interpretation updateNewFreeIndex: gen_typ_at_props' "updateNewFreeIndex slot"
+  by typ_at_props'
 
 lemma updateNewFreeIndex_valid_objs[wp]:
   "\<lbrace>valid_objs'\<rbrace> updateNewFreeIndex slot \<lbrace>\<lambda>_. valid_objs'\<rbrace>"

--- a/proof/refine/VSpace_R.thy
+++ b/proof/refine/VSpace_R.thy
@@ -183,15 +183,15 @@ lemma setMessageInfo_corres:
   apply (simp add: message_info_to_data_eqv)
   done
 
-lemma set_mi_tcb' [wp]:
-  "\<lbrace> tcb_at' t \<rbrace> setMessageInfo receiver msg \<lbrace>\<lambda>rv. tcb_at' t\<rbrace>"
-  by (simp add: setMessageInfo_def) wp
+crunch setMessageInfo, setMRs
+  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
+  (wp: crunch_wps simp: crunch_simps)
 
-lemma setMRs_typ_at':
-  "\<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace> setMRs receiver recv_buf mrs \<lbrace>\<lambda>rv s. P (typ_at' T p s)\<rbrace>"
-  by (simp add: setMRs_def zipWithM_x_mapM split_def, wp crunch_wps)
+global_interpretation setMessageInfo: gen_typ_at_props' "setMessageInfo thread info"
+  by typ_at_props'
 
-lemmas setMRs_typ_at_lifts[wp] = gen_typ_at_lifts[OF setMRs_typ_at']
+global_interpretation setMRs: gen_typ_at_props' "setMRs receiver recv_buf mrs"
+  by typ_at_props'
 
 crunch doMachineOp
   for arch[wp]: "\<lambda>s. P (ksArchState s)"

--- a/proof/refine/X64/ArchArchAcc_R.thy
+++ b/proof/refine/X64/ArchArchAcc_R.thy
@@ -1477,32 +1477,21 @@ lemma lookupPTSlot_corres:
        apply (wpsimp wp: getPDE_wp | wp (once) hoare_drop_imps)+
   done
 
-crunch storePML4E
+crunch storePML4E, storePDPTE, storePDE, storePTE
   for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
   (wp: crunch_wps mapM_x_wp' simp: crunch_simps ignore_del: setObject)
 
-crunch storePDPTE
-  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  (wp: crunch_wps mapM_x_wp' simp: crunch_simps ignore_del: setObject)
+sublocale storePML4E: typ_at_props' "storePML4E slot pml4e"
+  by typ_at_props'
 
-crunch storePDE
-  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  (wp: crunch_wps mapM_x_wp' simp: crunch_simps ignore_del: setObject)
+sublocale storePDPTE: typ_at_props' "storePDPTE slot pdpte"
+  by typ_at_props'
 
-crunch storePTE
-  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  (wp: crunch_wps mapM_x_wp' simp: crunch_simps ignore_del: setObject)
+sublocale storePDE: typ_at_props' "storePDE slot pde"
+  by typ_at_props'
 
-lemmas storePML4E_typ_ats[wp] = typ_at_lifts [OF storePML4E_typ_at']
-lemmas storePDPTE_typ_ats[wp] = typ_at_lifts [OF storePDPTE_typ_at']
-lemmas storePDE_typ_ats[wp] = typ_at_lifts [OF storePDE_typ_at']
-lemmas storePTE_typ_ats[wp] = typ_at_lifts [OF storePTE_typ_at']
-
-lemma setObject_asid_typ_at' [wp]:
-  "\<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace> setObject p' (v::asidpool) \<lbrace>\<lambda>_ s. P (typ_at' T p s)\<rbrace>"
-  by (wp setObject_typ_at')
-
-lemmas setObject_asid_typ_ats' [wp] = typ_at_lifts [OF setObject_asid_typ_at']
+sublocale storePTE: typ_at_props' "storePTE slot pte"
+  by typ_at_props'
 
 lemma getObject_pte_inv[wp]:
   "\<lbrace>P\<rbrace> getObject p \<lbrace>\<lambda>rv :: pte. P\<rbrace>"
@@ -1524,7 +1513,8 @@ crunch copyGlobalMappings
   for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
   (wp: mapM_x_wp')
 
-lemmas copyGlobalMappings_typ_ats[wp] = typ_at_lifts [OF copyGlobalMappings_typ_at']
+sublocale copyGlobalMappings: typ_at_props' "copyGlobalMappings newPT"
+  by typ_at_props'
 
 lemma corres_gets_global_pml4 [corres]:
   "corres (=) \<top> \<top> (gets (x64_global_pml4 \<circ> arch_state)) (gets (x64KSSKIMPML4 \<circ> ksArchState))"

--- a/proof/refine/X64/ArchCNodeInv_R.thy
+++ b/proof/refine/X64/ArchCNodeInv_R.thy
@@ -448,4 +448,23 @@ proof goal_cases
   case 1 show ?case by (intro_locales; (unfold_locales; (fact CNodeInv_R_assms)?)?)
 qed
 
+context Arch begin arch_global_naming
+
+sublocale cteDelete: typ_at_props' "cteDelete slot exposed"
+  by typ_at_props'
+
+sublocale reduceZombie: typ_at_props' "reduceZombie cap slot x"
+  by typ_at_props'
+
+sublocale finaliseSlot: typ_at_props' "finaliseSlot ptr exposed"
+  by typ_at_props'
+
+sublocale invokeCNode: typ_at_props' "invokeCNode i"
+  by typ_at_props'
+
+sublocale cteMove: typ_at_props' "cteMove cap src dest"
+  by typ_at_props'
+
+end  (* Arch *)
+
 end

--- a/proof/refine/X64/ArchCSpace1_R.thy
+++ b/proof/refine/X64/ArchCSpace1_R.thy
@@ -292,7 +292,8 @@ proof -
   done
 qed
 
-lemmas setCTE_typ_ats[wp] = typ_at_lifts[OF setCTE_typ_at']
+sublocale setCTE: typ_at_props' "setCTE c cte"
+  by typ_at_props'
 
 lemma arch_updateCapData_Master[CSpace1_R_assms]:
   "Arch.updateCapData P d acap \<noteq> NullCap \<Longrightarrow>

--- a/proof/refine/X64/ArchCSpace_R.thy
+++ b/proof/refine/X64/ArchCSpace_R.thy
@@ -27,9 +27,14 @@ lemma capAligned_master[CSpace_R_assms]:
    apply (clarsimp simp: capAligned_def)+
   done
 
-lemmas updateMDB_typ_ats[wp] = typ_at_lifts[OF updateMDB_typ_at']
-lemmas updateCap_typ_ats[wp] = typ_at_lifts[OF updateCap_typ_at']
-lemmas cteInsert_typ_ats[wp] = typ_at_lifts[OF cteInsert_typ_at']
+sublocale updateMDB: typ_at_props' "updateMDB slot f"
+  by typ_at_props'
+
+sublocale updateCap: typ_at_props' "updateCap slot newCap"
+  by typ_at_props'
+
+sublocale cteInsert: typ_at_props' "cteInsert newCap srcSlot destSlot"
+  by typ_at_props'
 
 lemma maskedAsFull_derived'[CSpace_R_assms]:
   "\<lbrakk>m src = Some (CTE s_cap s_node); is_derived' m ptr b c\<rbrakk>

--- a/proof/refine/X64/ArchFinalise_R.thy
+++ b/proof/refine/X64/ArchFinalise_R.thy
@@ -19,7 +19,8 @@ lemma arch_postCapDeletion_ksArchState_lift[Finalise_R_assms]:
   unfolding postCapDeletion_def freeIOPortRange_def setIOPortMask_def
   by wpsimp
 
-lemmas clearUntypedFreeIndex_typ_ats[wp] = typ_at_lifts[OF clearUntypedFreeIndex_typ_at']
+sublocale clearUntypedFreeIndex: typ_at_props' "clearUntypedFreeIndex slot"
+  by typ_at_props'
 
 crunch setIRQState
   for umm[Finalise_R_assms, wp]: "\<lambda>s. P (underlying_memory (ksMachineState s))"
@@ -83,7 +84,7 @@ lemma arch_postCapDeletion_corres[Finalise_R_assms]:
 abbreviation (input)
   "Arch_finaliseCap \<equiv> Arch.finaliseCap"
 
-crunch Arch_finaliseCap, prepareThreadDelete
+crunch Arch_finaliseCap, prepareThreadDelete, archThreadSet
   for typ_at'[Finalise_R_assms, wp]: "\<lambda>s. P (typ_at' T p s)"
   and aligned'[Finalise_R_assms, wp]: "pspace_aligned'"
   and distinct'[Finalise_R_assms, wp]: "pspace_distinct'"
@@ -595,11 +596,23 @@ lemma isFinal_no_descendants[Finalise_R_2_assms]:
   apply (simp add: valid_mdb'_def)
   done
 
-lemmas cancelAllIPC_typs[wp] = typ_at_lifts[OF cancelAllIPC_typ_at']
-lemmas cancelAllSignals_typs[wp] = typ_at_lifts[OF cancelAllSignals_typ_at']
-lemmas suspend_typs[wp] = typ_at_lifts[OF suspend_typ_at']
+sublocale cancelIPC: typ_at_props' "cancelIPC tptr"
+  by typ_at_props'
 
-lemmas finaliseCap_typ_ats[wp] = typ_at_lifts[OF finaliseCap_typ_at']
+sublocale cancelAllIPC: typ_at_props' "cancelAllIPC epptr"
+  by typ_at_props'
+
+sublocale cancelAllSignals: typ_at_props' "cancelAllSignals ntfnPtr"
+  by typ_at_props'
+
+sublocale suspend: typ_at_props' "suspend target"
+  by typ_at_props'
+
+sublocale finaliseCap: typ_at_props' "finaliseCap cap final x"
+  by typ_at_props'
+
+sublocale unbindNotification: typ_at_props' "unbindNotification tcb"
+  by typ_at_props'
 
 lemma invs_asid_update_strg':
   "invs' s \<and> tab = x64KSASIDTable (ksArchState s) \<longrightarrow>
@@ -649,6 +662,9 @@ lemma deleteASID_invs'[wp]:
            | simp add: X64.objBits_simps pageBits_def)+
   apply clarsimp
   done
+
+sublocale archThreadSet: typ_at_props' "archThreadSet f tptr"
+  by typ_at_props'
 
 lemma archThreadSet_valid_objs'[wp]:
   "\<lbrace>valid_objs' and (\<lambda>s. \<forall>tcb. ko_at' tcb t s \<longrightarrow> valid_arch_tcb' (f (tcbArch tcb)) s)\<rbrace>
@@ -1246,7 +1262,8 @@ lemma arch_finaliseCap_corres[Finalise_R_3_assms]:
    apply (auto simp: mask_def valid_cap_def)[2]
   done
 
-lemmas deleteCallerCap_typ_ats[wp] = typ_at_lifts[OF deleteCallerCap_typ_at']
+sublocale deleteCallerCap: typ_at_props' "deleteCallerCap receiver"
+  by typ_at_props'
 
 end (* Arch *)
 

--- a/proof/refine/X64/ArchInvsLemmas_H.thy
+++ b/proof/refine/X64/ArchInvsLemmas_H.thy
@@ -400,72 +400,106 @@ lemma is_physical_cases:
              | _                               \<Rightarrow> True)"
   by (simp split: capability.splits arch_capability.splits zombie_type.splits)
 
-lemma typ_at_lift_page_directory_at':
-  assumes x: "\<And>T p. \<lbrace>typ_at' T p\<rbrace> f \<lbrace>\<lambda>rv. typ_at' T p\<rbrace>"
-  shows      "\<lbrace>page_directory_at' p\<rbrace> f \<lbrace>\<lambda>rv. page_directory_at' p\<rbrace>"
-  unfolding page_directory_at'_def All_less_Ball
-  by (wp hoare_vcg_const_Ball_lift x)
+named_theorems Invariants_H_typ_at_lifts_assms
 
-lemma typ_at_lift_page_table_at':
-  assumes x: "\<And>T p. \<lbrace>typ_at' T p\<rbrace> f \<lbrace>\<lambda>rv. typ_at' T p\<rbrace>"
-  shows      "\<lbrace>page_table_at' p\<rbrace> f \<lbrace>\<lambda>rv. page_table_at' p\<rbrace>"
-  unfolding page_table_at'_def All_less_Ball
-  by (wp hoare_vcg_const_Ball_lift x)
-
-lemma typ_at_lift_pd_pointer_table_at':
-  assumes x: "\<And>T p. \<lbrace>typ_at' T p\<rbrace> f \<lbrace>\<lambda>rv. typ_at' T p\<rbrace>"
-  shows      "\<lbrace>pd_pointer_table_at' p\<rbrace> f \<lbrace>\<lambda>rv. pd_pointer_table_at' p\<rbrace>"
-  unfolding pd_pointer_table_at'_def All_less_Ball
-  by (wp hoare_vcg_const_Ball_lift x)
-
-lemma typ_at_lift_page_map_l4_at':
-  assumes x: "\<And>T p. \<lbrace>typ_at' T p\<rbrace> f \<lbrace>\<lambda>rv. typ_at' T p\<rbrace>"
-  shows      "\<lbrace>page_map_l4_at' p\<rbrace> f \<lbrace>\<lambda>rv. page_map_l4_at' p\<rbrace>"
-  unfolding page_map_l4_at'_def All_less_Ball
-  by (wp hoare_vcg_const_Ball_lift x)
-
-lemma typ_at_lift_asid_at':
-  "(\<And>T p. \<lbrace>typ_at' T p\<rbrace> f \<lbrace>\<lambda>_. typ_at' T p\<rbrace>) \<Longrightarrow> \<lbrace>asid_pool_at' p\<rbrace> f \<lbrace>\<lambda>_. asid_pool_at' p\<rbrace>"
-  by assumption
-
-lemma typ_at_lift_valid_cap':
-  assumes P: "\<And>P T p. \<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace> f \<lbrace>\<lambda>rv s. P (typ_at' T p s)\<rbrace>"
-  shows      "\<lbrace>\<lambda>s. valid_cap' cap s\<rbrace> f \<lbrace>\<lambda>rv s. valid_cap' cap s\<rbrace>"
-  including no_pre
-  apply (simp add: valid_cap'_def)
-  apply wp
-  apply (case_tac cap;
-         simp add: valid_cap'_def P[where P=id, simplified] typ_at_lift_tcb'
-                   hoare_vcg_prop typ_at_lift_ep'
-                   typ_at_lift_ntfn' typ_at_lift_cte_at'
-                   hoare_vcg_conj_lift [OF typ_at_lift_cte_at'])
-     apply (rename_tac zombie_type nat)
-     apply (case_tac zombie_type; simp)
-      apply (wp typ_at_lift_tcb' P hoare_vcg_all_lift typ_at_lift_cte')+
-    apply (rename_tac arch_capability)
-    apply (case_tac arch_capability,
-           simp_all add: P[where P=id, simplified] vspace_table_at'_defs
-                         hoare_vcg_prop All_less_Ball
-                    split del: if_split)
-       apply (wp hoare_vcg_const_Ball_lift P typ_at_lift_valid_untyped'
-                 hoare_vcg_all_lift typ_at_lift_cte')+
+lemma page_directory_at'_typ_at_lift_strong:
+  "(\<And>p. f \<lbrace>\<lambda>s. P (typ_at' (ArchT PDET) p s)\<rbrace>) \<Longrightarrow> f \<lbrace>\<lambda>s. P (page_directory_at' p s)\<rbrace>"
+  unfolding page_directory_at'_def
+  apply (rule bool_to_bool_cases[where f=P]; clarsimp)
+  apply (wpsimp wp: hoare_vcg_const_Ball_lift hoare_vcg_imp_lift
+                    hoare_vcg_all_lift hoare_vcg_ex_lift
+         | assumption)+
   done
 
-(* interface lemma *)
-lemma valid_arch_tcb_lift':
-  assumes x: "\<And>T p. \<lbrace>typ_at' T p\<rbrace> f \<lbrace>\<lambda>rv. typ_at' T p\<rbrace>"
-  shows "\<lbrace>\<lambda>s. valid_arch_tcb' tcb s\<rbrace> f \<lbrace>\<lambda>rv s. valid_arch_tcb' tcb s\<rbrace>"
-  by (clarsimp simp add: valid_arch_tcb'_def, wp)
+lemma page_table_at'_typ_at_lift_strong:
+  "(\<And>p. f \<lbrace>\<lambda>s. P (typ_at' (ArchT PTET) p s)\<rbrace>) \<Longrightarrow> f \<lbrace>\<lambda>s. P (page_table_at' p s)\<rbrace>"
+  unfolding page_table_at'_def
+  apply (rule bool_to_bool_cases[where f=P]; clarsimp)
+  apply (wpsimp wp: hoare_vcg_const_Ball_lift hoare_vcg_imp_lift
+                    hoare_vcg_all_lift hoare_vcg_ex_lift
+         | assumption)+
+  done
 
-lemmas typ_at_lifts =
-         typ_at_lift_tcb' typ_at_lift_ep' typ_at_lift_ntfn' typ_at_lift_cte' typ_at_lift_cte_at'
-         typ_at_lift_valid_untyped' typ_at_lift_valid_cap' valid_bound_tcb_lift
-         typ_at_lift_page_table_at'
-         typ_at_lift_page_directory_at'
-         typ_at_lift_page_map_l4_at'
-         typ_at_lift_pd_pointer_table_at'
-         typ_at_lift_asid_at'
-         valid_arch_tcb_lift'
+lemma pd_pointer_table_at'_typ_at_lift_strong:
+  "(\<And>p. f \<lbrace>\<lambda>s. P (typ_at' (ArchT PDPTET) p s)\<rbrace>) \<Longrightarrow> f \<lbrace>\<lambda>s. P (pd_pointer_table_at' p s)\<rbrace>"
+  unfolding pd_pointer_table_at'_def
+  apply (rule bool_to_bool_cases[where f=P]; clarsimp)
+  apply (wpsimp wp: hoare_vcg_const_Ball_lift hoare_vcg_imp_lift
+                    hoare_vcg_all_lift hoare_vcg_ex_lift
+         | assumption)+
+  done
+
+lemma page_map_l4_at'_typ_at_lift_strong:
+  "(\<And>p. f \<lbrace>\<lambda>s. P (typ_at' (ArchT PML4ET) p s)\<rbrace>) \<Longrightarrow> f \<lbrace>\<lambda>s. P (page_map_l4_at' p s)\<rbrace>"
+  unfolding page_map_l4_at'_def
+  apply (rule bool_to_bool_cases[where f=P]; clarsimp)
+  apply (wpsimp wp: hoare_vcg_const_Ball_lift hoare_vcg_imp_lift
+                    hoare_vcg_all_lift hoare_vcg_ex_lift
+         | assumption)+
+  done
+
+lemma asid_pool_at'_typ_at_lift_strong:
+  "(\<And>T p. f \<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace>) \<Longrightarrow> f \<lbrace>\<lambda>s. P (asid_pool_at' p s)\<rbrace>"
+  by assumption
+
+lemma valid_arch_tcb'_typ_at_lift_strong[Invariants_H_typ_at_lifts_assms]:
+  "(\<And>T p. f \<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace>) \<Longrightarrow> f \<lbrace>\<lambda>s. P (valid_arch_tcb' tcb s)\<rbrace>"
+  unfolding valid_arch_tcb'_def
+  apply (rule bool_to_bool_cases[where f=P]; clarsimp)
+  apply (wpsimp wp: hoare_vcg_imp_lift hoare_vcg_all_lift hoare_vcg_ex_lift
+         | assumption)+
+  done
+
+lemma valid_arch_cap'_typ_at_lift[Invariants_H_typ_at_lifts_assms]:
+  assumes P: "\<And>P T p. f \<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace>"
+  shows      "f \<lbrace>\<lambda>s. valid_arch_cap' cap s\<rbrace>"
+  apply (case_tac cap,
+         simp_all add: P[where P=id, simplified] All_less_Ball
+            split del: if_split)
+    apply (wp hoare_vcg_const_Ball_lift P
+              page_directory_at'_typ_at_lift_strong page_table_at'_typ_at_lift_strong
+              pd_pointer_table_at'_typ_at_lift_strong page_map_l4_at'_typ_at_lift_strong)+
+  done
+
+end (* Arch *)
+
+global_interpretation Invariants_H_typ_at_lifts?: Invariants_H_typ_at_lifts
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case by (intro_locales; unfold_locales; (fact Invariants_H_typ_at_lifts_assms)?)
+qed
+
+context Arch begin arch_global_naming
+
+lemmas typ_at_lifts_strong =
+  gen_typ_at_lifts_strong
+  page_directory_at'_typ_at_lift_strong
+  page_table_at'_typ_at_lift_strong
+  pd_pointer_table_at'_typ_at_lift_strong
+  page_map_l4_at'_typ_at_lift_strong
+  asid_pool_at'_typ_at_lift_strong
+
+context begin
+
+\<comment>\<open> See the comment above @{ML weaken_typ_at_lifts_thms} for an explanation of what
+    this @{command ML_goal} is for. Here we are constructing the combined list of
+    both generic and arch-specific typ_at_lifts lemmas.\<close>
+ML \<open>
+local
+  val strong_thms = subtract Thm.eq_thm gen_strong_thms @{thms typ_at_lifts_strong[no_vars]};
+in
+  val typ_at_lifts_internal_goals = weaken_typ_at_lifts_thms strong_thms
+end
+\<close>
+
+private ML_goal typ_at_lifts_strong_internal:
+  \<open>typ_at_lifts_internal_goals\<close>
+  by (auto simp: typ_at_lifts_strong)
+
+lemmas typ_at_lifts = gen_typ_at_lifts typ_at_lifts_strong_internal
+
+end
+
 
 (* FIXME arch-split: X64: this probably needs more to be useful *)
 lemmas bit_simps' = asidHighBits_def asid_low_bits_def

--- a/proof/refine/X64/ArchInvsLemmas_H.thy
+++ b/proof/refine/X64/ArchInvsLemmas_H.thy
@@ -500,6 +500,25 @@ lemmas typ_at_lifts = gen_typ_at_lifts typ_at_lifts_strong_internal
 
 end
 
+end (* Arch *)
+
+locale typ_at_props' = Arch +
+  fixes f :: "_ kernel"
+  assumes typ': "f \<lbrace>\<lambda>s. P (typ_at' T p' s)\<rbrace>"
+begin
+
+lemmas typ_ats[wp] = typ_at_lifts[REPEAT [OF typ']]
+
+context begin
+(* We want to enforce that typ_ats only contains lemmas that have no
+   assumptions. The following thm statement should fail if this is not true. *)
+private lemmas check_valid_internal = iffD1[OF refl, where P="valid p g q" for p g q]
+thm typ_ats[atomized, THEN check_valid_internal]
+end
+
+end (* typ_at_props' *)
+
+context Arch begin arch_global_naming
 
 (* FIXME arch-split: X64: this probably needs more to be useful *)
 lemmas bit_simps' = asidHighBits_def asid_low_bits_def

--- a/proof/refine/X64/ArchIpc_R.thy
+++ b/proof/refine/X64/ArchIpc_R.thy
@@ -273,6 +273,33 @@ lemma is_derived_mask'[simp]:
   "is_derived' m p (maskCapRights R c) = is_derived' m p c"
   by (rule ext, simp add: is_derived'_def badge_derived'_def)
 
+sublocale setExtraBadge: typ_at_props' "setExtraBadge buffer badge n"
+  by typ_at_props'
+
+sublocale transferCaps: typ_at_props' "transferCaps info caps endpoint receiver receiveBuffer"
+  by typ_at_props'
+
+sublocale copyMRs: typ_at_props' "copyMRs s sb r rb n"
+  by typ_at_props'
+
+sublocale doNormalTransfer: typ_at_props' "doNormalTransfer s sb e b g r rb"
+  by typ_at_props'
+
+sublocale doIPCTransfer: typ_at_props' "doIPCTransfer s e b g r"
+  by typ_at_props'
+
+sublocale handleFaultReply: typ_at_props' "handleFaultReply x t l m"
+  by typ_at_props'
+
+sublocale sendFaultIPC: typ_at_props' "sendFaultIPC tptr fault"
+  by typ_at_props'
+
+sublocale receiveIPC: typ_at_props' "receiveIPC t cap b"
+  by typ_at_props'
+
+sublocale receiveSignal: typ_at_props' "receiveSignal t cap b"
+  by typ_at_props'
+
 end (* Arch *)
 
 end

--- a/proof/refine/X64/ArchKHeap_R.thy
+++ b/proof/refine/X64/ArchKHeap_R.thy
@@ -350,7 +350,7 @@ lemma valid_arch_state_lift':
                    vspace_table_at'_defs
                    All_less_Ball)
   apply (rule hoare_lift_Pf [where f="ksArchState"])
-   apply (wp typs hoare_vcg_const_Ball_lift arch typ_at_lifts)+
+   apply (wp typs hoare_vcg_const_Ball_lift arch)+
   done
 
 lemma idle_is_global[KHeap_R_assms, intro!]:
@@ -396,11 +396,14 @@ lemma setObject_ko_wp_at':
 
 lemmas [KHeap_R_assms_2] = setEndpoint_valid_arch' setNotification_valid_arch'
 
-lemmas setObject_typ_ats[wp] = typ_at_lifts[OF setObject_typ_at']
+sublocale setObject: typ_at_props' "setObject p v"
+  by typ_at_props'
 
-lemmas doMachineOp_typ_ats[wp] = typ_at_lifts[OF doMachineOp_typ_at']
+sublocale doMachineOp: typ_at_props' "doMachineOp mop"
+  by typ_at_props'
 
-lemmas setEndpoint_typ_ats[wp] = typ_at_lifts[OF setEndpoint_typ_at']
+sublocale setEndpoint: typ_at_props' "setEndpoint ptr val"
+  by typ_at_props'
 
 end
 

--- a/proof/refine/X64/ArchSchedule_R.thy
+++ b/proof/refine/X64/ArchSchedule_R.thy
@@ -128,9 +128,11 @@ crunch setVMRoot, lazyFpuRestore
 crunch Arch.switchToThread
   for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
 
-lemmas lazyFpuRestore_typ_ats[wp] = typ_at_lifts[OF lazyFpuRestore_typ_at']
+sublocale lazyFpuRestore: typ_at_props' "lazyFpuRestore t"
+  by typ_at_props'
 
-lemmas saveFpuState_typ_ats[wp] = typ_at_lifts[OF saveFpuState_typ_at']
+sublocale saveFpuState: typ_at_props' "saveFpuState t"
+  by typ_at_props'
 
 lemma Arch_switchToThread_pred_tcb'[wp]:
   "Arch.switchToThread t \<lbrace>\<lambda>s. P (pred_tcb_at' proj P' t' s)\<rbrace>"

--- a/proof/refine/X64/ArchSchedule_R.thy
+++ b/proof/refine/X64/ArchSchedule_R.thy
@@ -128,6 +128,10 @@ crunch setVMRoot, lazyFpuRestore
 crunch Arch.switchToThread
   for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
 
+lemmas lazyFpuRestore_typ_ats[wp] = typ_at_lifts[OF lazyFpuRestore_typ_at']
+
+lemmas saveFpuState_typ_ats[wp] = typ_at_lifts[OF saveFpuState_typ_at']
+
 lemma Arch_switchToThread_pred_tcb'[wp]:
   "Arch.switchToThread t \<lbrace>\<lambda>s. P (pred_tcb_at' proj P' t' s)\<rbrace>"
 proof -
@@ -213,7 +217,7 @@ crunch loadFpuState, saveFpuState
 lemma switchLocalFpuOwner_invs[wp]:
   "\<lbrace>invs' and opt_tcb_at' newOwner\<rbrace> switchLocalFpuOwner newOwner \<lbrace>\<lambda>_. invs'\<rbrace>"
   unfolding switchLocalFpuOwner_def
-  by (wpsimp wp: hoare_vcg_all_lift hoare_vcg_imp_lift' typ_at_lifts simp: fpuOwner_asrt_def)
+  by (wpsimp wp: hoare_vcg_all_lift hoare_vcg_imp_lift' simp: fpuOwner_asrt_def)
 
 lemma lazyFpuRestore_invs[wp]:
   "\<lbrace>invs' and tcb_at' t\<rbrace> lazyFpuRestore t \<lbrace>\<lambda>_. invs'\<rbrace>"

--- a/proof/refine/X64/ArchTcbAcc_R.thy
+++ b/proof/refine/X64/ArchTcbAcc_R.thy
@@ -174,7 +174,8 @@ lemma threadSet_iflive'T[TcbAcc_R_assms]:
   apply (clarsimp simp: bspec_split [OF spec [OF x]])
   done
 
-lemmas threadSet_typ_at_lifts[wp] = typ_at_lifts[OF threadSet_typ_at']
+sublocale threadSet: typ_at_props' "threadSet tptr f"
+  by typ_at_props'
 
 lemma zobj_refs'_capRange[TcbAcc_R_assms]:
   "s \<turnstile>' cap \<Longrightarrow> zobj_refs' cap \<subseteq> capRange cap"
@@ -192,8 +193,11 @@ lemma asUser_valid_tcbs'[wp]:
               simp: valid_tcb'_def valid_arch_tcb'_def tcb_cte_cases_def objBits_simps')
   done
 
-lemmas addToBitmap_typ_ats[wp] = typ_at_lifts[OF addToBitmap_typ_at']
-lemmas removeFromBitmap_typ_ats[wp] = typ_at_lifts[OF removeFromBitmap_typ_at']
+sublocale addToBitmap: typ_at_props' "addToBitmap tdom prio"
+  by typ_at_props'
+
+sublocale removeFromBitmap: typ_at_props' "removeFromBitmap tdom prio"
+  by typ_at_props'
 
 crunch tcbQueueRemove, tcbQueuePrepend, tcbQueueAppend, tcbQueueInsert,
          setQueue, removeFromBitmap
@@ -312,7 +316,8 @@ context Arch begin arch_global_naming
 
 named_theorems TcbAcc_R_2_assms
 
-lemmas asUser_typ_ats[wp] = typ_at_lifts[OF asUser_typ_at']
+sublocale asUser: typ_at_props' "asUser tptr f"
+  by typ_at_props'
 
 lemma tcb_hyp_refs'_valid_arch_tcb'_eq[TcbAcc_R_2_assms]:
   "tcb_hyp_refs' (tcbArch (F tcb)) = tcb_hyp_refs' (tcbArch tcb)
@@ -831,8 +836,17 @@ lemma set_mrs_invs'[TcbAcc_R_3_assms, wp]:
          simp add: zipWithM_x_mapM split_def)+
   done
 
-lemmas setThreadState_typ_ats[wp] = typ_at_lifts [OF setThreadState_typ_at']
-lemmas setBoundNotification_typ_ats[wp] = typ_at_lifts [OF setBoundNotification_typ_at']
+sublocale rescheduleRequired: typ_at_props' "rescheduleRequired"
+  by typ_at_props'
+
+sublocale tcbSchedDequeue: typ_at_props' "tcbSchedDequeue thread"
+  by typ_at_props'
+
+sublocale setThreadState: typ_at_props' "setThreadState st p"
+  by typ_at_props'
+
+sublocale setBoundNotification: typ_at_props' "setBoundNotification v p"
+  by typ_at_props'
 
 end (* Arch *)
 

--- a/proof/refine/X64/ArchTcb_R.thy
+++ b/proof/refine/X64/ArchTcb_R.thy
@@ -42,6 +42,12 @@ lemma threadSet_state_hyp_refs_of'_interface[Tcb_R_assms]:
    \<Longrightarrow> threadSet F t \<lbrace>\<lambda>s. P (state_hyp_refs_of' s)\<rbrace> "
   by (wpsimp simp: threadSet_state_hyp_refs_of')
 
+sublocale setPriority: typ_at_props' "setPriority t prio"
+  by typ_at_props'
+
+sublocale setMCPriority: typ_at_props' "setMCPriority t prio"
+  by typ_at_props'
+
 lemma sameObject_corres2[Tcb_R_assms]:
   "\<lbrakk> cap_relation c c'; cap_relation d d' \<rbrakk>
    \<Longrightarrow> same_object_as c d = sameObjectAs c' d'"

--- a/proof/refine/X64/ArchVSpace_R.thy
+++ b/proof/refine/X64/ArchVSpace_R.thy
@@ -167,8 +167,7 @@ lemma handleVMFault_corres':
          apply (rule asUser_getRegister_corres)
         apply (cases fault; simp)
        apply (simp, wp as_user_typ_at)
-      apply (simp, wp asUser_typ_ats)
-     apply wpsimp+
+      apply wpsimp+
   done
 
 (* interface lemma, superset of all architecture preconditions *)
@@ -478,11 +477,52 @@ lemma deleteASIDPool_corres:
   apply clarsimp
   done
 
-crunch setVMRoot
-  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  (simp: crunch_simps)
+crunch unmapPageTable, unmapPage, unmapPDPT, setVMRoot, setMessageInfo, setMRs, performPageTableInvocation,
+       performPageDirectoryInvocation, performASIDPoolInvocation, performPageInvocation, performPDPTInvocation
+  for typ_at' [wp]: "\<lambda>s. P (typ_at' T p s)"
+  (wp: crunch_wps getASID_wp simp: crunch_simps)
 
-lemmas setVMRoot_typ_ats [wp] = typ_at_lifts [OF setVMRoot_typ_at']
+sublocale unmapPageTable: typ_at_props' "unmapPageTable asid vaddr pt"
+  by typ_at_props'
+
+sublocale unmapPageDirectory: typ_at_props' "unmapPageDirectory asid vaddr pt"
+  by typ_at_props'
+
+sublocale unmapPDPT: typ_at_props' "unmapPDPT asid vaddr pt"
+  by typ_at_props'
+
+sublocale unmapPage: typ_at_props' "unmapPage magnitude asid vptr ptr"
+  by typ_at_props'
+
+sublocale setVMRoot: typ_at_props' "setVMRoot tcb"
+  by typ_at_props'
+
+sublocale setMessageInfo: typ_at_props' "setMessageInfo thread info"
+  by typ_at_props'
+
+sublocale setMRs: typ_at_props' "setMRs thread buffer messageData"
+  by typ_at_props'
+
+sublocale performPageTableInvocation: typ_at_props' "performPageTableInvocation iv"
+  by typ_at_props'
+
+sublocale performPageDirectoryInvocation: typ_at_props' "performPageDirectoryInvocation iv"
+  by typ_at_props'
+
+sublocale performPDPTInvocation: typ_at_props' "performPDPTInvocation iv"
+  by typ_at_props'
+
+sublocale performPageInvocation: typ_at_props' "performPageInvocation iv"
+  by typ_at_props'
+
+sublocale performASIDPoolInvocation: typ_at_props' "performASIDPoolInvocation iv"
+  by typ_at_props'
+
+sublocale flushTable: typ_at_props' "flushTable vspace vptr pt asid"
+  by typ_at_props'
+
+sublocale findVSpaceForASID: typ_at_props' "findVSpaceForASID asid"
+  by typ_at_props'
 
 crunch flushTable
   for no_0_obj'[wp]: "no_0_obj'"
@@ -539,14 +579,6 @@ lemma flushTable_corres:
       apply (simp add: bit_simps)
       done
   qed
-
-crunch flushTable
-  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  (simp: assertE_def when_def wp: crunch_wps)
-
-lemmas flushTable_typ_ats' [wp] = typ_at_lifts [OF flushTable_typ_at']
-
-lemmas findVSpaceForASID_typ_ats' [wp] = typ_at_lifts [OF findVSpaceForASID_inv]
 
 crunch unmapPageTable, unmapPageDirectory, unmapPDPT
   for aligned'[wp]: "pspace_aligned'"
@@ -803,8 +835,6 @@ lemma set_cap_valid_page_map_inv:
   apply (clarsimp simp: cte_wp_at_def parent_for_refs_def)
   apply (auto simp: is_pt_cap_def is_pg_cap_def is_pd_cap_def is_pdpt_cap_def split: vm_page_entry.splits)
   done
-
-lemmas setMRs_typ_at_lifts[wp] = typ_at_lifts [OF setMRs_typ_at']
 
 lemma same_refs_vs_cap_ref_eq:
   assumes "valid_slots entries s"
@@ -1067,14 +1097,6 @@ lemma clear_pdpt_corres:
    apply (simp add: bit_simps word_less_nat_alt word_le_nat_alt unat_of_nat)
   apply simp
   done
-
-crunch invalidatePageStructureCacheASID, unmapPageTable, unmapPageDirectory, unmapPDPT
-  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  (wp: crunch_wps hoare_vcg_all_liftE_R)
-
-lemmas unmapPageTable_typ_ats[wp] = typ_at_lifts[OF unmapPageTable_typ_at']
-lemmas unmapPageDirectory_typ_ats[wp] = typ_at_lifts[OF unmapPageDirectory_typ_at']
-lemmas unmapPDPT_typ_ats[wp] = typ_at_lifts[OF unmapPDPT_typ_at']
 
 lemma performPageTableInvocation_corres:
   "page_table_invocation_map pti pti' \<Longrightarrow>
@@ -1529,31 +1551,6 @@ crunch deleteASIDPool, flushTable, deleteASID, storePTE, storePDE, storePDPTE, s
   for it'[wp]: "\<lambda>s. P (ksIdleThread s)"
   (simp: crunch_simps loadObject_default_def updateObject_default_def
    wp: getObject_inv mapM_wp' setObject_idle' hoare_drop_imps mapM_x_wp')
-
-crunch performPageTableInvocation, performPageDirectoryInvocation, performPDPTInvocation,
-       performPageInvocation
-  for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  (wp: crunch_wps simp: crunch_simps)
-
-lemma performASIDPoolInvocation_typ_at' [wp]:
-  "\<lbrace>\<lambda>s. P (typ_at' T p s)\<rbrace> performASIDPoolInvocation api \<lbrace>\<lambda>_ s. P (typ_at' T p s)\<rbrace>"
-  by (wpsimp simp: performASIDPoolInvocation_def
-               wp: getASID_wp hoare_vcg_imp_lift[where P'=\<bottom>, simplified])
-
-lemmas performPageTableInvocation_typ_ats' [wp] =
-  typ_at_lifts [OF performPageTableInvocation_typ_at']
-
-lemmas performPageDirectoryInvocation_typ_ats' [wp] =
-  typ_at_lifts [OF performPageDirectoryInvocation_typ_at']
-
-lemmas performPDPTInvocation_typ_ats' [wp] =
-  typ_at_lifts [OF performPDPTInvocation_typ_at']
-
-lemmas performPageInvocation_typ_ats' [wp] =
-  typ_at_lifts [OF performPageInvocation_typ_at']
-
-lemmas performASIDPoolInvocation_typ_ats' [wp] =
-  typ_at_lifts [OF performASIDPoolInvocation_typ_at']
 
 lemma storePDE_pred_tcb_at' [wp]:
   "\<lbrace>pred_tcb_at' proj P t\<rbrace> storePDE p pde \<lbrace>\<lambda>_. pred_tcb_at' proj P t\<rbrace>"
@@ -2449,8 +2446,6 @@ lemma perform_pdpti_invs [wp]:
 crunch unmapPage
   for cte_wp_at': "\<lambda>s. P (cte_wp_at' P' p s)"
   (wp: crunch_wps simp: crunch_simps)
-
-lemmas unmapPage_typ_ats [wp] = typ_at_lifts [OF unmapPage_typ_at']
 
 lemma unmapPage_invs' [wp]:
   "\<lbrace>invs'\<rbrace> unmapPage sz asid vptr pptr \<lbrace>\<lambda>_. invs'\<rbrace>"


### PR DESCRIPTION
These changes are based on ones that were previously made in the `rt` branch. Some additional cleanup was done along the way and the `typ_at_props'` locale was arch-split and applied to all architectures.

The main benefit for master is the improved `typ_at_lifts` lemmas; the `typ_at_props'` locales themselves are not as immediately useful as in `rt`. However, backporting them does make the two branches more similar and should ease future merges.

See the following commits for where some of these changes originally happened in the `rt` branch:
6710b9a271a327aee25d8a1c2e95042524a3ba5a
64b6edf5143056cc1dc8a526370019b1e1d4752c
79e2e2b714017d91f202d5c918440fd8d110c08a
91a2023934bc549b9abd3e5dd35bab15e984f752
78bb847ddd78386d22d9eda29ade6807a767af71
8a01dd4b4edc2e7ae219e7dfc4aa146776d3177d
336bd0b1d63b3165f28cfef73dc4c70067fb35f3